### PR TITLE
fix: qualify devis conversion SQL ids

### DIFF
--- a/src/__tests__/devis.routes.test.ts
+++ b/src/__tests__/devis.routes.test.ts
@@ -376,6 +376,77 @@ describe("/api/v1/devis", () => {
     });
 
     expect(mocks.clientRelease).toHaveBeenCalled();
+
+    const headerSql = String(
+      mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("FROM devis d"))?.[0] ?? ""
+    );
+    expect(headerSql).toContain("d.id::text AS id");
+    expect(headerSql).toContain("WHERE d.id = $1");
+
+    const linesSql = String(
+      mocks.clientQuery.mock.calls.find(
+        (c) => String(c[0]).includes("FROM devis_ligne dl") && String(c[0]).includes("source_article_devis_id")
+      )?.[0] ?? ""
+    );
+    expect(linesSql).toContain("dl.id::text AS id");
+    expect(linesSql).not.toMatch(/^\s*id::text AS id/m);
+  });
+
+  it("POST /api/v1/devis/:id/convert-to-commande creates commande and lines from accepted devis", async () => {
+    mocks.clientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "7",
+            numero: "DV-7",
+            client_id: "001",
+            contact_id: null,
+            adresse_facturation_id: null,
+            adresse_livraison_id: "33333333-3333-3333-3333-333333333333",
+            mode_reglement_id: null,
+            conditions_paiement_id: 15,
+            biller_id: null,
+            compte_vente_id: null,
+            commentaires: "Depuis devis",
+            remise_globale: 0,
+            total_ht: 100,
+            total_ttc: 120,
+            statut: "ACCEPTE",
+            updated_at: "2026-03-24T10:00:00.000Z",
+            created_at: "2026-03-23T10:00:00.000Z",
+          },
+        ],
+      }) // load devis FOR UPDATE
+      .mockResolvedValueOnce({ rows: [] }) // existing commande
+      .mockResolvedValueOnce({ rows: [{ id: "55" }] }) // commande id sequence
+      .mockResolvedValueOnce({ rows: [] }) // INSERT commande_client
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // INSERT commande_ligne from devis_ligne
+      .mockResolvedValueOnce({ rows: [] }) // UPDATE articles EN_DEVIS -> VALIDE
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await request(app).post("/api/v1/devis/7/convert-to-commande");
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ id: 55, numero: "CC-55" });
+
+    const existingSql = String(
+      mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("FROM commande_client cc"))?.[0] ?? ""
+    );
+    expect(existingSql).toContain("cc.id::text AS id");
+    expect(existingSql).toContain("WHERE cc.devis_id = $1");
+
+    const insertCommandeSql = String(
+      mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("INSERT INTO commande_client"))?.[0] ?? ""
+    );
+    expect(insertCommandeSql).toContain("source_devis_version_id");
+
+    const insertLinesSql = String(
+      mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("INSERT INTO commande_ligne"))?.[0] ?? ""
+    );
+    expect(insertLinesSql).toContain("ad.id");
+    expect(insertLinesSql).toContain("dd.id");
+    expect(insertLinesSql).not.toMatch(/^\s*id\b/m);
   });
 
   it("GET /api/v1/devis/by-article/:articleId returns related devis with versions", async () => {

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,5 +1,5 @@
 import type { Request, Response, NextFunction } from "express";
-import { HttpError } from "../utils/httpError.js";
+import { HttpError } from "../utils/httpError";
 import { ApiError } from "../utils/apiError";
  
 export function errorHandler(err: any, req: Request, res: Response, _next: NextFunction) {

--- a/src/module/devis/repository/devis.repository.ts
+++ b/src/module/devis/repository/devis.repository.ts
@@ -197,25 +197,25 @@ async function loadDevisCommandeHeader(
   const res = await client.query<DevisCommandeHeaderRow>(
     `
       SELECT
-        id::text AS id,
-        numero,
-        client_id,
-        contact_id::text AS contact_id,
-        adresse_facturation_id::text AS adresse_facturation_id,
-        adresse_livraison_id::text AS adresse_livraison_id,
-        mode_reglement_id::text AS mode_reglement_id,
-        conditions_paiement_id,
-        biller_id::text AS biller_id,
-        compte_vente_id::text AS compte_vente_id,
-        commentaires,
-        remise_globale::float8 AS remise_globale,
-        total_ht::float8 AS total_ht,
-        total_ttc::float8 AS total_ttc,
-        statut,
+        d.id::text AS id,
+        d.numero,
+        d.client_id,
+        d.contact_id::text AS contact_id,
+        d.adresse_facturation_id::text AS adresse_facturation_id,
+        d.adresse_livraison_id::text AS adresse_livraison_id,
+        d.mode_reglement_id::text AS mode_reglement_id,
+        d.conditions_paiement_id,
+        d.biller_id::text AS biller_id,
+        d.compte_vente_id::text AS compte_vente_id,
+        d.commentaires,
+        d.remise_globale::float8 AS remise_globale,
+        d.total_ht::float8 AS total_ht,
+        d.total_ttc::float8 AS total_ttc,
+        d.statut,
         to_jsonb(d)->>'updated_at' AS updated_at,
         COALESCE(to_jsonb(d)->>'created_at', d.date_creation::text) AS created_at
       FROM devis d
-      WHERE id = $1
+      WHERE d.id = $1
       ${lockClause}
     `,
     [devisId]
@@ -232,18 +232,18 @@ async function loadDevisCommandeLines(
   const res = await client.query<DevisCommandeLineRow>(
     `
         SELECT
-          id::text AS id,
-          description,
-          article_id::text AS article_id,
-          piece_technique_id::text AS piece_technique_id,
+          dl.id::text AS id,
+          dl.description,
+          dl.article_id::text AS article_id,
+          dl.piece_technique_id::text AS piece_technique_id,
           ad.id::text AS source_article_devis_id,
           dd.id::text AS source_dossier_devis_id,
           ${codePieceSelect},
-          quantite::float8 AS quantite,
-          unite,
-          prix_unitaire_ht::float8 AS prix_unitaire_ht,
-          remise_ligne::float8 AS remise_ligne,
-          taux_tva::float8 AS taux_tva
+          dl.quantite::float8 AS quantite,
+          dl.unite,
+          dl.prix_unitaire_ht::float8 AS prix_unitaire_ht,
+          dl.remise_ligne::float8 AS remise_ligne,
+          dl.taux_tva::float8 AS taux_tva
       FROM devis_ligne dl
       LEFT JOIN public.article_devis ad ON ad.devis_ligne_id = dl.id
       LEFT JOIN public.dossier_technique_piece_devis dd ON dd.article_devis_id = ad.id
@@ -1148,13 +1148,13 @@ async function cloneDevisPreparatoryEntities(client: PoolClient, sourceDevisId: 
   const lineMapRes = await client.query<{ source_line_id: string; target_line_id: string }>(
     `
       WITH src AS (
-        SELECT id, row_number() OVER (ORDER BY id ASC) AS rn
-        FROM public.devis_ligne
-        WHERE devis_id = $1::bigint
+        SELECT dl.id, row_number() OVER (ORDER BY dl.id ASC) AS rn
+        FROM public.devis_ligne dl
+        WHERE dl.devis_id = $1::bigint
       ), tgt AS (
-        SELECT id, row_number() OVER (ORDER BY id ASC) AS rn
-        FROM public.devis_ligne
-        WHERE devis_id = $2::bigint
+        SELECT dl.id, row_number() OVER (ORDER BY dl.id ASC) AS rn
+        FROM public.devis_ligne dl
+        WHERE dl.devis_id = $2::bigint
       )
       SELECT src.id::text AS source_line_id, tgt.id::text AS target_line_id
       FROM src
@@ -1663,18 +1663,18 @@ export async function repoReviseDevis(
           )
           SELECT
             $1,
-            description,
-            article_id,
-            piece_technique_id,
-            code_piece,
-            quantite,
-            unite,
-            prix_unitaire_ht,
-            remise_ligne,
-            taux_tva
-          FROM devis_ligne
-          WHERE devis_id = $2
-          ORDER BY id ASC
+            dl.description,
+            dl.article_id,
+            dl.piece_technique_id,
+            dl.code_piece,
+            dl.quantite,
+            dl.unite,
+            dl.prix_unitaire_ht,
+            dl.remise_ligne,
+            dl.taux_tva
+          FROM devis_ligne dl
+          WHERE dl.devis_id = $2
+          ORDER BY dl.id ASC
         `,
         [newDevisId, id]
       );
@@ -1863,9 +1863,9 @@ export async function repoConvertDevisToCommande(devisId: number) {
 
     const existing = await client.query<{ id: string; numero: string }>(
       `
-      SELECT id::text AS id, numero
-      FROM commande_client
-      WHERE devis_id = $1
+      SELECT cc.id::text AS id, cc.numero
+      FROM commande_client cc
+      WHERE cc.devis_id = $1
       LIMIT 1
       `,
       [devisId]


### PR DESCRIPTION
## Summary

Fixes the Devis to customer order conversion SQL ambiguity by explicitly qualifying `id` columns in the Devis backend repository queries.

## Root Cause

The command draft query selected `id::text AS id` from `devis_ligne` while joining `article_devis`, `dossier_technique_piece_devis`, `articles`, and `pieces_techniques`. PostgreSQL could not resolve which joined table owned `id`, causing `column reference "id" is ambiguous` during Devis to Commande preparation.

## Changes

- Qualifies Devis conversion and draft SQL identifiers with table aliases (`d.id`, `dl.id`, `cc.id`, `ad.id`, `dd.id`).
- Adds backend coverage for `/api/v1/devis/:id/commande-draft` SQL qualification.
- Adds backend coverage for successful `/api/v1/devis/:id/convert-to-commande` conversion.
- Fixes local dev backend startup import for `HttpError`.

## Validation

- `pnpm test -- src/modules/devis` in `crp-systems-web`: 29 files, 82 tests passed.
- `pnpm typecheck` in `crp-systems-web`: passed.
- `pnpm build:web` in `crp-systems-web`: passed, with existing Vite chunk-size warning.
- `npm run test:run -- src/__tests__/devis.routes.test.ts` in `erp-crp-backend`: 11 tests passed.
- `npm run build` in `erp-crp-backend`: passed.

## Notes

No SQL migration is required. The real DB-backed UI conversion could not be executed locally because the backend environment did not provide `DATABASE_URL` / `JWT_SECRET`.

## Summary by Sourcery

Qualify SQL identifiers in Devis-to-commande conversion queries to remove ambiguous id references and add regression coverage around these endpoints.

Bug Fixes:
- Resolve PostgreSQL 'column reference "id" is ambiguous' errors by fully qualifying id and related columns in Devis header, line, cloning, and conversion queries.

Enhancements:
- Add backend tests asserting correct SQL qualification for Devis commande draft and successful convert-to-commande flows.

Tests:
- Extend Devis routes integration tests to cover commande draft SQL structure and successful Devis-to-commande conversion including inserted commande and line SQL.

Chores:
- Fix local backend error handler import to reference HttpError without the .js extension.