### PR TITLE
[codex] Prepare CERP local-first storage

### DIFF
--- a/.env_exemple
+++ b/.env_exemple
@@ -1,16 +1,25 @@
-DATABASE_URL= "Votre base de données
-BACKEND_URL= addresse IP de votre serveur
-JWT_SECRET= "ton secret jwt
-JWT_EXPIRES_IN= 
-PORT= "le port souhaitée"
+APP_NAME=CERP
+CERP_ROOT=/srv/cerp
+CERP_STORAGE_ROOT=/srv/cerp/data
+CERP_DOCUMENTS_ROOT=/srv/cerp/data/documents
+CERP_GENERATED_ROOT=/srv/cerp/data/generated
+CERP_INBOUND_ROOT=/srv/cerp/data/inbound
+CERP_EXPORTS_ROOT=/srv/cerp/data/exports
+CERP_TMP_ROOT=/srv/cerp/data/tmp
+CERP_IMAGES_ROOT=/srv/cerp/data/generated/images
+DATABASE_URL=postgresql://cerp_app:SECRET@127.0.0.1:5432/cerp_prod
+BACKEND_URL=http://10.90.0.2:8080
+JWT_SECRET=un_secret_jwt_fort
+JWT_EXPIRES_IN=8h
+PORT=8080
 
 # Password reset (frontend link base)
-FRONTEND_URL=http://localhost:5173
+FRONTEND_URL=https://cerp.croix-rousse-precision.fr
 
 # Resend (password reset emails)
 RESEND_API_KEY=re_your_api_key
-RESEND_FROM="CRP Systems <noreply@yourdomain.tld>"
+RESEND_FROM="CERP <noreply@yourdomain.tld>"
 RESEND_API_BASE_URL=https://api.resend.com
 
 # Optional: explicit email logo URL (fallback uses BACKEND_URL + /images/...)
-EMAIL_LOGO_URL=https://erp-backend.croix-rousse-precision.fr/images/images_logiciel/CRP-Ops.png
+EMAIL_LOGO_URL=

--- a/INSTRUCTIONS_BACKEND.md
+++ b/INSTRUCTIONS_BACKEND.md
@@ -1,6 +1,6 @@
 # INSTRUCTIONS_BACKEND.md
 
-Repo-specific instructions for automated coding agents working on the **erp-crp-backend** (CRP SYSTEMS backend).
+Repo-specific instructions for automated coding agents working on the **cerp-api** backend.
 
 ## 1) Audience, Language, Non-Goals
 

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -1,0 +1,48 @@
+# Database Patches
+
+CERP stores SQL patch files in `db/patches/`. The local-first production
+database is PostgreSQL on HYPERBOX2, database `cerp_prod`.
+
+Do not make schema changes directly on the VPS. The VPS must not become a
+second writable database.
+
+## Commands
+
+Show patch status:
+
+```bash
+npm run db:patches:status
+```
+
+Preview pending patches without changing the database:
+
+```bash
+npm run db:patches:up -- --dry-run
+```
+
+Apply pending patches to the local database:
+
+```bash
+npm run db:patches:up
+```
+
+Record the current patch set as already applied without executing SQL:
+
+```bash
+npm run db:patches:baseline -- --dry-run
+npm run db:patches:baseline
+```
+
+Use `baseline` only after confirming the restored database already contains the
+schema represented by the current patch files.
+
+## Rules
+
+- Before any database change, download or retrieve the latest SQL backup from
+  the VPS/Coolify backup system first.
+- Keep a local PostgreSQL backup as an additional safety net, but do not treat
+  it as a replacement for the VPS/Coolify backup requested for CERP DB work.
+- Prefer additive SQL changes.
+- Do not edit a patch file after it has been applied; add a new patch instead.
+- Review `checksum-mismatch` results before continuing.
+- Keep passwords and `DATABASE_URL` out of Git, logs, and tickets.

--- a/docs/frontend_repo_map.md
+++ b/docs/frontend_repo_map.md
@@ -1,8 +1,8 @@
-# Backend Project Map (erp-crp-backend)
+# Backend Project Map (cerp-api)
 
 Generated from repository inspection on 2026-03-05.
 
-This file lives in `docs/frontend_repo_map.md` by request, but it documents the backend repository `erp-crp-backend`.
+This file lives in `docs/frontend_repo_map.md` by request, but it documents the CERP backend repository.
 
 ## A) Repo Structure Summary
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "erp-crp-backend",
+  "name": "cerp-api",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "erp-crp-backend",
+      "name": "cerp-api",
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "erp-crp-backend",
+  "name": "cerp-api",
   "version": "1.0.0",
   "description": "",
   "author": "",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc -p tsconfig.json",
     "start": "node dist/index.js",
+    "db:patches:status": "node scripts/db-patches.js status",
+    "db:patches:up": "node scripts/db-patches.js up",
+    "db:patches:baseline": "node scripts/db-patches.js baseline",
     "test": "vitest",
     "test:run": "vitest run",
     "test:ui": "vitest --ui"

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -1,0 +1,274 @@
+#!/usr/bin/env node
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const { Client } = require("pg");
+const dotenv = require("dotenv");
+
+const ROOT_DIR = path.resolve(__dirname, "..");
+const DEFAULT_PATCH_DIR = path.join(ROOT_DIR, "db", "patches");
+const MIGRATION_TABLE = "public.cerp_schema_migrations";
+const LOCK_NAME = "cerp_schema_migrations";
+
+dotenv.config({ path: path.join(ROOT_DIR, ".env") });
+
+function parseArgs(argv) {
+  const args = [...argv];
+  const command = args[0] && !args[0].startsWith("--") ? args.shift() : "status";
+  const options = {
+    command,
+    dryRun: false,
+    check: false,
+    patchDir: DEFAULT_PATCH_DIR,
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg === "--check") {
+      options.check = true;
+    } else if (arg === "--patch-dir") {
+      options.patchDir = path.resolve(args[++i]);
+    } else if (arg.startsWith("--patch-dir=")) {
+      options.patchDir = path.resolve(arg.slice("--patch-dir=".length));
+    } else if (arg === "--help" || arg === "-h") {
+      printHelp();
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/db-patches.js status [--check] [--patch-dir DIR]
+  node scripts/db-patches.js up [--dry-run] [--patch-dir DIR]
+  node scripts/db-patches.js baseline [--dry-run] [--patch-dir DIR]
+
+Commands:
+  status    Show applied, pending, and checksum mismatch status.
+  up        Apply pending SQL patches from db/patches in filename order.
+  baseline  Record current patch files as already applied without executing SQL.
+
+Notes:
+  - Requires DATABASE_URL.
+  - Stores patch metadata in ${MIGRATION_TABLE}.
+  - Does not print connection strings or secrets.
+`);
+}
+
+function listPatches(patchDir) {
+  if (!fs.existsSync(patchDir)) {
+    throw new Error(`Patch directory not found: ${patchDir}`);
+  }
+
+  return fs.readdirSync(patchDir)
+    .filter((name) => name.endsWith(".sql"))
+    .sort((a, b) => a.localeCompare(b))
+    .map((filename) => {
+      const fullPath = path.join(patchDir, filename);
+      const sql = fs.readFileSync(fullPath, "utf8");
+      const sha256 = crypto.createHash("sha256").update(sql).digest("hex");
+      return { filename, fullPath, sql, sha256 };
+    });
+}
+
+async function tableExists(client) {
+  const result = await client.query(`
+    SELECT to_regclass($1) IS NOT NULL AS exists
+  `, [MIGRATION_TABLE]);
+  return result.rows[0]?.exists === true;
+}
+
+async function ensureMigrationTable(client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS ${MIGRATION_TABLE} (
+      filename text PRIMARY KEY,
+      sha256 text NOT NULL,
+      applied_at timestamptz NOT NULL DEFAULT now()
+    )
+  `);
+}
+
+async function getApplied(client) {
+  if (!(await tableExists(client))) {
+    return new Map();
+  }
+
+  const result = await client.query(`
+    SELECT filename, sha256, applied_at
+    FROM ${MIGRATION_TABLE}
+    ORDER BY filename
+  `);
+
+  return new Map(result.rows.map((row) => [row.filename, row]));
+}
+
+function buildStatuses(patches, applied) {
+  return patches.map((patch) => {
+    const row = applied.get(patch.filename);
+    if (!row) {
+      return { ...patch, status: "pending" };
+    }
+    if (row.sha256 !== patch.sha256) {
+      return {
+        ...patch,
+        status: "checksum-mismatch",
+        appliedAt: row.applied_at,
+        appliedSha256: row.sha256,
+      };
+    }
+    return { ...patch, status: "applied", appliedAt: row.applied_at };
+  });
+}
+
+function printStatuses(statuses) {
+  const counts = statuses.reduce((acc, item) => {
+    acc[item.status] = (acc[item.status] || 0) + 1;
+    return acc;
+  }, {});
+
+  for (const item of statuses) {
+    console.log(`${item.status.padEnd(18)} ${item.filename}`);
+  }
+
+  console.log("");
+  console.log(`Summary: applied=${counts.applied || 0} pending=${counts.pending || 0} checksum-mismatch=${counts["checksum-mismatch"] || 0}`);
+}
+
+async function withClient(fn) {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is required");
+  }
+
+  const client = new Client({ connectionString });
+  await client.connect();
+  try {
+    return await fn(client);
+  } finally {
+    await client.end();
+  }
+}
+
+async function withMigrationLock(client, fn) {
+  await client.query("SELECT pg_advisory_lock(hashtext($1))", [LOCK_NAME]);
+  try {
+    return await fn();
+  } finally {
+    await client.query("SELECT pg_advisory_unlock(hashtext($1))", [LOCK_NAME]);
+  }
+}
+
+async function runStatus(client, patches, { check }) {
+  const applied = await getApplied(client);
+  const statuses = buildStatuses(patches, applied);
+  printStatuses(statuses);
+
+  const mismatches = statuses.filter((item) => item.status === "checksum-mismatch");
+  const pending = statuses.filter((item) => item.status === "pending");
+  if (mismatches.length > 0 || (check && pending.length > 0)) {
+    process.exitCode = 1;
+  }
+}
+
+async function runUp(client, patches, { dryRun }) {
+  if (dryRun) {
+    const applied = await getApplied(client);
+    const statuses = buildStatuses(patches, applied);
+    const pending = statuses.filter((item) => item.status === "pending");
+    printStatuses(statuses);
+    console.log("");
+    console.log(`Dry-run: ${pending.length} patch(es) would be applied.`);
+    return;
+  }
+
+  await withMigrationLock(client, async () => {
+    await ensureMigrationTable(client);
+    const applied = await getApplied(client);
+    const statuses = buildStatuses(patches, applied);
+    const mismatches = statuses.filter((item) => item.status === "checksum-mismatch");
+    if (mismatches.length > 0) {
+      printStatuses(statuses);
+      throw new Error("Refusing to apply patches because one or more applied files changed checksum.");
+    }
+
+    const pending = statuses.filter((item) => item.status === "pending");
+    for (const patch of pending) {
+      console.log(`Applying ${patch.filename}`);
+      try {
+        await client.query(patch.sql);
+        await client.query(`
+          INSERT INTO ${MIGRATION_TABLE} (filename, sha256)
+          VALUES ($1, $2)
+        `, [patch.filename, patch.sha256]);
+      } catch (error) {
+        try {
+          await client.query("ROLLBACK");
+        } catch (_) {
+          // Ignore rollback errors; the patch may not have opened a transaction.
+        }
+        throw error;
+      }
+    }
+    console.log(`Applied ${pending.length} patch(es).`);
+  });
+}
+
+async function runBaseline(client, patches, { dryRun }) {
+  if (dryRun) {
+    const applied = await getApplied(client);
+    const statuses = buildStatuses(patches, applied);
+    printStatuses(statuses);
+    console.log("");
+    console.log("Dry-run: patch metadata would be recorded without executing SQL.");
+    return;
+  }
+
+  await withMigrationLock(client, async () => {
+    await ensureMigrationTable(client);
+    const applied = await getApplied(client);
+    const statuses = buildStatuses(patches, applied);
+    const mismatches = statuses.filter((item) => item.status === "checksum-mismatch");
+    if (mismatches.length > 0) {
+      printStatuses(statuses);
+      throw new Error("Refusing to baseline because one or more applied files changed checksum.");
+    }
+
+    const pending = statuses.filter((item) => item.status === "pending");
+    for (const patch of pending) {
+      await client.query(`
+        INSERT INTO ${MIGRATION_TABLE} (filename, sha256)
+        VALUES ($1, $2)
+      `, [patch.filename, patch.sha256]);
+    }
+    console.log(`Baselined ${pending.length} patch(es) without executing SQL.`);
+  });
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const patches = listPatches(options.patchDir);
+
+  await withClient(async (client) => {
+    if (options.command === "status") {
+      await runStatus(client, patches, options);
+    } else if (options.command === "up") {
+      await runUp(client, patches, options);
+    } else if (options.command === "baseline") {
+      await runBaseline(client, patches, options);
+    } else {
+      throw new Error(`Unknown command: ${options.command}`);
+    }
+  });
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/src/__tests__/app.test.ts
+++ b/src/__tests__/app.test.ts
@@ -8,17 +8,17 @@ vi.mock('../utils/checkNetworkDrive', () => ({
     checkNetworkDrive: vi.fn(() => Promise.resolve())
 }))
 
-describe('Test de l\'application Express ERP', () => {
+describe('Test de l\'application Express CERP', () => {
     it('✅ GET / doit renvoyer un message de confirmation', async () => {
         const res = await request(app).get('/')
         expect(res.status).toBe(200)
-        expect(res.text).toContain('Backend ERP en ligne')
+        expect(res.text).toContain('Backend CERP en ligne')
     })
 
     it('✅ GET /api/v1 doit répondre correctement', async () => {
         const res = await request(app).get('/api/v1')
         expect(res.status).toBe(200)
-        expect(res.text).toContain('Backend ERP en ligne en V1')
+        expect(res.text).toContain('Backend CERP en ligne en V1')
     })
 
     it('🌐 Test CORS headers', async () => {

--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -5,6 +5,9 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import jwt from "jsonwebtoken";
+import { getDocumentStoragePath } from "../utils/cerpStorage";
+
+process.env.CERP_DOCUMENTS_ROOT = path.resolve("uploads", "docs");
 
 const mocks = vi.hoisted(() => ({
   poolQuery: vi.fn(),
@@ -238,7 +241,7 @@ describe("/api/v1/commandes", () => {
 
   it("GET /api/v1/commandes/:id/documents/:docId/file serves linked document", async () => {
     const docId = "22222222-2222-2222-2222-222222222222";
-    const uploadsDir = path.resolve("uploads/docs");
+    const uploadsDir = getDocumentStoragePath();
     fs.mkdirSync(uploadsDir, { recursive: true });
     const filePath = path.join(uploadsDir, `${docId}.pdf`);
     fs.writeFileSync(filePath, "hello");
@@ -268,7 +271,7 @@ describe("/api/v1/commandes", () => {
   it("POST /api/v1/commandes handles multipart data + documents[]", async () => {
     const ARTICLE_ID = "11111111-1111-1111-1111-111111111111";
     const PIECE_ID = "22222222-2222-2222-2222-222222222222";
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "erp-crp-docs-"));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cerp-docs-"));
     const tmpFile = path.join(tmpDir, "doc.txt");
     fs.writeFileSync(tmpFile, "hello");
 

--- a/src/__tests__/devis.routes.test.ts
+++ b/src/__tests__/devis.routes.test.ts
@@ -4,6 +4,9 @@ import { EventEmitter } from "events";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { getDocumentStoragePath } from "../utils/cerpStorage";
+
+process.env.CERP_DOCUMENTS_ROOT = path.resolve("uploads", "docs");
 
 const mocks = vi.hoisted(() => ({
   poolQuery: vi.fn(),
@@ -529,7 +532,7 @@ describe("/api/v1/devis", () => {
 
   it("GET /api/v1/devis/:id/documents/:docId/file serves linked document", async () => {
     const docId = "33333333-3333-3333-3333-333333333333";
-    const uploadsDir = path.resolve("uploads/docs");
+    const uploadsDir = getDocumentStoragePath();
     fs.mkdirSync(uploadsDir, { recursive: true });
     const filePath = path.join(uploadsDir, `${docId}.pdf`);
     fs.writeFileSync(filePath, "hello");
@@ -555,7 +558,7 @@ describe("/api/v1/devis", () => {
   });
 
   it("POST /api/v1/devis supports multipart data + optional documents[]", async () => {
-    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "erp-crp-devis-"));
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "cerp-devis-"));
     const tmpFile = path.join(tmpDir, "doc.txt");
     fs.writeFileSync(tmpFile, "hello");
 

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -26,8 +26,8 @@ app.use(requestIdMiddleware);
 app.use(helmet());
 
 const staticAllowedOrigins = new Set<string>([
-  "https://crp-systems.croix-rousse-precision.fr",
-  "http://crp-systems.croix-rousse-precision.fr",
+  "https://cerp.croix-rousse-precision.fr",
+  "http://cerp.croix-rousse-precision.fr",
   "http://localhost:5173",
   "http://localhost:5137",
   "http://localhost:4173",
@@ -134,11 +134,11 @@ app.use(
 /* ------------------ 4) Routes ------------------ */
 
 app.get("/", (_req, res) => {
-  res.send("✅ Backend ERP en ligne !");
+  res.send("✅ Backend CERP en ligne !");
 });
 
 app.get("/api/v1", (_req, res) => {
-  res.send("✅ Backend ERP en ligne en V1 !");
+  res.send("✅ Backend CERP en ligne en V1 !");
 });
 
 // Routes API v1

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,6 @@ startAuditNotifyListener().catch((err) => {
 
 // 🚀 Lancement du serveur
 httpServer.listen(PORT, '0.0.0.0', () => {
-  console.log(`🚀 Serveur ERP lancé sur http://0.0.0.0:${PORT}`);
-  console.log(`🌐 Accès depuis le réseau : http://erp-backend.croix-rousse-precision.fr:8080`);
+  console.log(`🚀 Serveur CERP lancé sur http://0.0.0.0:${PORT}`);
+  console.log(`🌐 Accès local prévu : http://10.90.0.2:${PORT}`);
 });

--- a/src/module/asbuilt/repository/asbuilt.repository.ts
+++ b/src/module/asbuilt/repository/asbuilt.repository.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 import type { PoolClient } from "pg"
 
 import pool from "../../../config/database"
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 
 import type {
@@ -353,7 +354,7 @@ export async function repoInsertAsbuiltPackVersionTx(
 }
 
 async function ensureDocsDir(): Promise<string> {
-  const baseDir = path.resolve("uploads/docs/asbuilt")
+  const baseDir = ensureDocumentStoragePath("asbuilt")
   await fs.mkdir(baseDir, { recursive: true })
   return baseDir
 }

--- a/src/module/asbuilt/services/asbuilt.service.ts
+++ b/src/module/asbuilt/services/asbuilt.service.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises"
 import path from "node:path"
 
 import pool from "../../../config/database"
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
@@ -40,7 +41,7 @@ function getPgErrorInfo(err: unknown) {
 }
 
 async function ensureDocsDir(): Promise<string> {
-  const baseDir = path.resolve("uploads/docs/asbuilt")
+  const baseDir = ensureDocumentStoragePath("asbuilt")
   await fs.mkdir(baseDir, { recursive: true })
   return baseDir
 }

--- a/src/module/auth/services/password-reset-email.service.ts
+++ b/src/module/auth/services/password-reset-email.service.ts
@@ -37,21 +37,21 @@ function buildPasswordResetEmail(params: {
   const safeUsername = escapeHtml(params.username);
   const safeUrl = escapeHtml(params.resetUrl);
 
-  const subject = "Réinitialisation de mot de passe — CRP Systems";
+  const subject = "Réinitialisation de mot de passe — CERP";
 
   const text =
     `Bonjour ${params.username},\n\n` +
-    `Une demande de réinitialisation de mot de passe a été effectuée pour votre compte CRP Systems.\n\n` +
+    `Une demande de réinitialisation de mot de passe a été effectuée pour votre compte CERP.\n\n` +
     `Lien (valide ${params.expiresMinutes} minutes) :\n${params.resetUrl}\n\n` +
     `Si vous n'êtes pas à l'origine de cette demande, vous pouvez ignorer cet email.\n\n` +
-    `— CRP Systems`;
+    `— CERP`;
 
   // ✅ No logo here
   const html = `
   <div style="background:#f6f7fb;padding:24px 12px;font-family:Arial,Helvetica,sans-serif;color:#0f172a;">
-    <div style="max-width:560px;margin:0 auto;background:#ffffff;border:1px solid #e2e8f0;border-radius:14px;overflow:hidden;">
-      <div style="padding:18px 18px 8px 18px;border-bottom:1px solid #e2e8f0;">
-        <div style="font-size:14px;font-weight:700;letter-spacing:0.2px;">CRP Systems</div>
+      <div style="max-width:560px;margin:0 auto;background:#ffffff;border:1px solid #e2e8f0;border-radius:14px;overflow:hidden;">
+        <div style="padding:18px 18px 8px 18px;border-bottom:1px solid #e2e8f0;">
+        <div style="font-size:14px;font-weight:700;letter-spacing:0.2px;">CERP</div>
         <div style="margin-top:10px;font-size:18px;font-weight:800;">Réinitialisation de mot de passe</div>
         <div style="margin-top:4px;font-size:12px;color:#475569;">Demande pour l'utilisateur : <b>${safeUsername}</b></div>
       </div>

--- a/src/module/commande-client/controllers/commande-client.controller.ts
+++ b/src/module/commande-client/controllers/commande-client.controller.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
 import { HttpError } from "../../../utils/httpError";
+import { getDocumentStoragePath, isPathInsideDirectory } from "../../../utils/cerpStorage";
 import {
   createCommandeSVC,
   createCadreReleaseSVC,
@@ -613,10 +614,9 @@ export const getCommandeDocumentFile: RequestHandler = async (req, res, next) =>
       return;
     }
 
-    const baseDir = path.resolve("uploads/docs");
+    const baseDir = getDocumentStoragePath();
     const absPath = path.resolve(baseDir, `${doc.id}${safeExtFromName(doc.document_name)}`);
-    const basePrefix = baseDir.endsWith(path.sep) ? baseDir : `${baseDir}${path.sep}`;
-    if (!absPath.startsWith(basePrefix)) {
+    if (!isPathInsideDirectory(baseDir, absPath)) {
       throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path");
     }
 

--- a/src/module/commande-client/repository/commande-ar.repository.ts
+++ b/src/module/commande-client/repository/commande-ar.repository.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
+import { getDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoEnsureCommandeWorkflowStatus } from "./commande-client.repository";
 import type { AppNotification } from "../../notifications/types/notifications.types";
@@ -283,7 +284,7 @@ export async function repoCreateCommandeArDraft(params: {
   const client = await pool.connect();
   const documentId = crypto.randomUUID();
   const arId = crypto.randomUUID();
-  const filePath = path.resolve("uploads/docs", `${documentId}.pdf`);
+  const filePath = path.resolve(getDocumentStoragePath(), `${documentId}.pdf`);
 
   try {
     await client.query("BEGIN");

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { generateAffaireCode, requireClientCode } from "../../../shared/codes/code-generator.service";
 import { emitAppNotificationCreated, emitEntityChanged } from "../../../shared/realtime/realtime.service";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -2453,7 +2454,7 @@ async function insertCommandeDocuments(client: PoolClient, commandeId: string, d
     const extCandidate = path.extname(doc.originalname).toLowerCase();
     const safeExt = /^\.[a-z0-9]+$/.test(extCandidate) && extCandidate.length <= 10 ? extCandidate : "";
 
-    const uploadDir = path.resolve("uploads/docs");
+    const uploadDir = ensureDocumentStoragePath();
     const finalPath = path.join(uploadDir, `${documentId}${safeExt}`);
 
     try {

--- a/src/module/commande-client/routes/commande-client.routes.ts
+++ b/src/module/commande-client/routes/commande-client.routes.ts
@@ -1,11 +1,10 @@
 import type { RequestHandler } from "express"
 import { Router } from "express"
 import multer from "multer"
-import path from "path"
-import fs from "fs"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
 import { HttpError } from "../../../utils/httpError"
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import {
   addCadreReleaseLine,
   analyzeCommandeStock,
@@ -51,10 +50,7 @@ import {
   validate,
 } from "../validators/commande-client.validators"
 
-// Storage vers /uploads/docs (ou ton NAS si prod)
-const ensureDir = (dir: string) => { if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true }) }
-const uploadDir = path.resolve("uploads/docs")
-ensureDir(uploadDir)
+const uploadDir = ensureDocumentStoragePath()
 const upload = multer({ dest: uploadDir })
 
 // middleware pour parser `data` JSON depuis multipart

--- a/src/module/commande-client/services/commande-ar.service.ts
+++ b/src/module/commande-client/services/commande-ar.service.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { HttpError } from "../../../utils/httpError";
+import { getDocumentStoragePath } from "../../../utils/cerpStorage";
 import { emitAppNotificationCreated, emitEntityChanged } from "../../../shared/realtime/realtime.service";
 import { sendTransactionalEmail, type ResendSendResult } from "../../../shared/email/resend.service";
 import type {
@@ -291,7 +292,7 @@ export async function svcSendCommandeAr(params: {
     throw new HttpError(404, "COMMANDE_AR_NOT_FOUND", "Accusé de réception introuvable");
   }
 
-  const filePath = path.resolve("uploads/docs", `${draft.document_id}.pdf`);
+  const filePath = path.resolve(getDocumentStoragePath(), `${draft.document_id}.pdf`);
   const pdfBuffer = await fs.readFile(filePath);
 
   const baseText = draft.body_text?.trim() || `Veuillez trouver ci-joint l'accuse de reception de la commande.`;

--- a/src/module/devis/controllers/devis.controller.ts
+++ b/src/module/devis/controllers/devis.controller.ts
@@ -1,6 +1,7 @@
 import type { Request, RequestHandler } from "express";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { getDocumentStoragePath, isPathInsideDirectory } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import {
   devisArticleParamsSchema,
@@ -212,10 +213,9 @@ export const getDevisDocumentFile: RequestHandler = async (req, res, next) => {
       return;
     }
 
-    const baseDir = path.resolve("uploads/docs");
+    const baseDir = getDocumentStoragePath();
     const absPath = path.resolve(baseDir, `${doc.id}${safeExtFromName(doc.document_name)}`);
-    const basePrefix = baseDir.endsWith(path.sep) ? baseDir : `${baseDir}${path.sep}`;
-    if (!absPath.startsWith(basePrefix)) {
+    if (!isPathInsideDirectory(baseDir, absPath)) {
       throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path");
     }
 

--- a/src/module/devis/repository/devis.repository.ts
+++ b/src/module/devis/repository/devis.repository.ts
@@ -3,6 +3,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 import type { PoolClient } from "pg";
 import pool from "../../../config/database";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import type {
   CreateDevisBodyDTO,
@@ -829,7 +830,7 @@ async function insertDevisDocuments(client: PoolClient, devisId: number, documen
 
     const extCandidate = path.extname(doc.originalname).toLowerCase();
     const safeExt = /^\.[a-z0-9]+$/.test(extCandidate) && extCandidate.length <= 10 ? extCandidate : "";
-    const uploadDir = path.resolve("uploads/docs");
+    const uploadDir = ensureDocumentStoragePath();
     const finalPath = path.join(uploadDir, `${documentId}${safeExt}`);
 
     try {

--- a/src/module/devis/routes/devis.routes.ts
+++ b/src/module/devis/routes/devis.routes.ts
@@ -1,10 +1,9 @@
 import type { RequestHandler } from "express";
 import { Router } from "express";
-import fs from "node:fs";
-import path from "node:path";
 import multer from "multer";
 import { z } from "zod";
 import { HttpError } from "../../../utils/httpError";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import {
   createDevis,
   convertDevisToCommande,
@@ -28,11 +27,7 @@ declare global {
   }
 }
 
-const ensureDir = (dir: string) => {
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-};
-const uploadDir = path.resolve("uploads/docs");
-ensureDir(uploadDir);
+const uploadDir = ensureDocumentStoragePath();
 const upload = multer({ dest: uploadDir });
 
 const parseMultipartData = (schema: z.ZodTypeAny): RequestHandler => {

--- a/src/module/facturation/services/pdf.service.ts
+++ b/src/module/facturation/services/pdf.service.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 import PDFDocument from "pdfkit";
 import pool from "../../../config/database";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoGetAvoir } from "../repository/avoirs.repository";
 import { repoGetFacture } from "../repository/factures.repository";
@@ -27,7 +28,7 @@ function formatDateFR(iso: string | null | undefined): string {
 }
 
 async function ensureDocsDir(): Promise<string> {
-  const uploadDir = path.resolve("uploads/docs");
+  const uploadDir = ensureDocumentStoragePath();
   await fs.mkdir(uploadDir, { recursive: true });
   return uploadDir;
 }

--- a/src/module/fournisseurs/controllers/fournisseurs.controller.ts
+++ b/src/module/fournisseurs/controllers/fournisseurs.controller.ts
@@ -1,7 +1,7 @@
 import type { Request, RequestHandler, Response } from "express"
 import fs from "node:fs/promises"
-import path from "node:path"
 
+import { getDocumentStoragePath, isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import type { AuditContext } from "../repository/fournisseurs.repository"
 import {
@@ -88,10 +88,9 @@ async function sendDocumentFile(
   res: Response,
   doc: { storage_path: string; mime_type: string; original_name: string }
 ) {
-  const baseDir = path.resolve(path.posix.join("uploads", "docs", "fournisseurs"))
-  const absPath = path.resolve(doc.storage_path)
-  const basePrefix = baseDir.endsWith(path.sep) ? baseDir : `${baseDir}${path.sep}`
-  if (!absPath.startsWith(basePrefix)) {
+  const baseDir = getDocumentStoragePath("fournisseurs")
+  const absPath = resolveCerpStoragePath(doc.storage_path, baseDir)
+  if (!isPathInsideDirectory(baseDir, absPath)) {
     throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path")
   }
 

--- a/src/module/fournisseurs/repository/fournisseurs.repository.ts
+++ b/src/module/fournisseurs/repository/fournisseurs.repository.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises"
 import path from "node:path"
 
 import db from "../../../config/database"
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators"
@@ -1282,7 +1283,7 @@ export async function repoAttachFournisseurDocuments(
   audit: AuditContext
 ): Promise<FournisseurDocument[] | null> {
   const client = await db.connect()
-  const docsDirRel = path.posix.join("uploads", "docs", "fournisseurs")
+  const docsDirRel = ensureDocumentStoragePath("fournisseurs")
   const docsDirAbs = path.resolve(docsDirRel)
   const movedFiles: string[] = []
   try {

--- a/src/module/fournisseurs/routes/fournisseurs.routes.ts
+++ b/src/module/fournisseurs/routes/fournisseurs.routes.ts
@@ -1,9 +1,8 @@
 import { Router } from "express"
-import fs from "fs"
 import multer from "multer"
-import path from "path"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import {
   attachFournisseurDocuments,
   createFournisseur,
@@ -27,12 +26,7 @@ import {
   updateFournisseurContact,
 } from "../controllers/fournisseurs.controller"
 
-const ensureDir = (dir: string) => {
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
-}
-
-const docsBaseDir = path.resolve("uploads/docs/fournisseurs")
-ensureDir(docsBaseDir)
+const docsBaseDir = ensureDocumentStoragePath("fournisseurs")
 
 const upload = multer({
   dest: docsBaseDir,

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -4,6 +4,7 @@ import crypto from "node:crypto"
 import type { PoolClient } from "pg"
 
 import pool from "../../../config/database"
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
@@ -2025,7 +2026,7 @@ export async function repoCreateLivraisonFromCommande(commandeId: number, userId
 }
 
 async function ensureDocsDir(): Promise<string> {
-  const baseDir = path.resolve("uploads/docs/livraisons")
+  const baseDir = ensureDocumentStoragePath("livraisons")
   await fs.mkdir(baseDir, { recursive: true })
   return baseDir
 }

--- a/src/module/livraisons/routes/livraisons.routes.ts
+++ b/src/module/livraisons/routes/livraisons.routes.ts
@@ -1,9 +1,8 @@
 import { Router } from "express"
 import multer from "multer"
-import fs from "node:fs"
-import path from "node:path"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
+import { ensureTmpStoragePath } from "../../../utils/cerpStorage"
 import {
   addLivraisonLine,
   addLivraisonLineAllocation,
@@ -31,12 +30,7 @@ import {
   revokeLivraisonPackVersion,
 } from "../controllers/pack.controller"
 
-const ensureDir = (dir: string) => {
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
-}
-
-const uploadTmpDir = path.resolve("uploads/tmp")
-ensureDir(uploadTmpDir)
+const uploadTmpDir = ensureTmpStoragePath("livraisons")
 const upload = multer({ dest: uploadTmpDir })
 
 const router = Router()

--- a/src/module/livraisons/services/pack.service.ts
+++ b/src/module/livraisons/services/pack.service.ts
@@ -3,6 +3,7 @@ import path from "node:path"
 import crypto from "node:crypto"
 
 import pool from "../../../config/database"
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
@@ -30,7 +31,7 @@ function safeFileToken(input: string): string {
 }
 
 async function ensureDocsDir(): Promise<string> {
-  const baseDir = path.resolve("uploads/docs/livraisons")
+  const baseDir = ensureDocumentStoragePath("livraisons")
   await fs.mkdir(baseDir, { recursive: true })
   return baseDir
 }

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -5,6 +5,7 @@ import crypto from "node:crypto"
 import PDFDocument from "pdfkit"
 
 import pool from "../../../config/database"
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { repoGetLivraisonDetail, repoGetDocumentName } from "../repository/livraisons.repository"
 
@@ -23,7 +24,7 @@ function formatDateFR(iso: string | null | undefined): string {
 }
 
 async function ensureDocsDir(): Promise<string> {
-  const uploadDir = path.resolve("uploads/docs/livraisons")
+  const uploadDir = ensureDocumentStoragePath("livraisons")
   await fs.mkdir(uploadDir, { recursive: true })
   return uploadDir
 }

--- a/src/module/metrologie/controllers/metrologie.controller.ts
+++ b/src/module/metrologie/controllers/metrologie.controller.ts
@@ -1,8 +1,8 @@
 import type { Request, RequestHandler } from "express";
 import fs from "node:fs/promises";
-import path from "node:path";
 
 import { asyncHandler } from "../../../utils/asyncHandler";
+import { isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 import { emitEntityChanged } from "../../../shared/realtime/realtime.service";
@@ -230,9 +230,8 @@ export const downloadCertificatFile: RequestHandler = asyncHandler(async (req, r
   }
 
   const baseDir = svcMetrologieDocsBaseDir();
-  const absPath = path.resolve(doc.storage_path);
-  const basePrefix = baseDir.endsWith(path.sep) ? baseDir : `${baseDir}${path.sep}`;
-  if (!absPath.startsWith(basePrefix)) {
+  const absPath = resolveCerpStoragePath(doc.storage_path, baseDir);
+  if (!isPathInsideDirectory(baseDir, absPath)) {
     throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path");
   }
 

--- a/src/module/metrologie/repository/metrologie.repository.ts
+++ b/src/module/metrologie/repository/metrologie.repository.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import pool from "../../../config/database";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 
@@ -140,7 +141,7 @@ async function insertMetrologieEvent(
 }
 
 export function repoMetrologieDocsBaseDir(): string {
-  return path.resolve(path.posix.join("uploads", "docs", "metrologie"));
+  return ensureDocumentStoragePath("metrologie");
 }
 
 function normalizeLikeQuery(q: string): string {
@@ -1232,7 +1233,7 @@ export async function repoAttachCertificats(params: {
 }): Promise<MetrologieCertificat[] | null> {
   const { equipement_id, body, documents, audit } = params;
   const client = await pool.connect();
-  const docsDirRel = path.posix.join("uploads", "docs", "metrologie");
+  const docsDirRel = ensureDocumentStoragePath("metrologie");
   const docsDirAbs = path.resolve(docsDirRel);
 
   try {

--- a/src/module/metrologie/routes/metrologie.routes.ts
+++ b/src/module/metrologie/routes/metrologie.routes.ts
@@ -1,9 +1,8 @@
 import { Router } from "express";
-import fs from "node:fs";
 import multer from "multer";
-import path from "node:path";
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import { ensureTmpStoragePath } from "../../../utils/cerpStorage";
 import {
   attachCertificats,
   createEquipement,
@@ -20,12 +19,7 @@ import {
   upsertPlan,
 } from "../controllers/metrologie.controller";
 
-const ensureDir = (dir: string) => {
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-};
-
-const tmpBaseDir = path.resolve("uploads/tmp/metrologie");
-ensureDir(tmpBaseDir);
+const tmpBaseDir = ensureTmpStoragePath("metrologie");
 
 const upload = multer({
   dest: tmpBaseDir,

--- a/src/module/operation-dossiers/repository/operation-dossiers.repository.ts
+++ b/src/module/operation-dossiers/repository/operation-dossiers.repository.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 import type { PoolClient } from "pg"
 
 import pool from "../../../config/database"
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators"
@@ -112,7 +113,7 @@ function resolveMimeType(value: string | null | undefined): string {
 }
 
 async function ensureDocsDir(): Promise<string> {
-  const baseDir = path.resolve("uploads/docs/operation-dossiers")
+  const baseDir = ensureDocumentStoragePath("operation-dossiers")
   await fs.mkdir(baseDir, { recursive: true })
   return baseDir
 }

--- a/src/module/operation-dossiers/routes/operation-dossiers.routes.ts
+++ b/src/module/operation-dossiers/routes/operation-dossiers.routes.ts
@@ -1,21 +1,15 @@
 import { Router } from "express"
 import multer from "multer"
-import fs from "node:fs"
-import path from "node:path"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
+import { ensureTmpStoragePath } from "../../../utils/cerpStorage"
 import {
   createOperationDossierVersion,
   downloadOperationDossierDocument,
   getOperationDossierByOperation,
 } from "../controllers/operation-dossiers.controller"
 
-const ensureDir = (dir: string) => {
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
-}
-
-const uploadTmpDir = path.resolve("uploads/tmp")
-ensureDir(uploadTmpDir)
+const uploadTmpDir = ensureTmpStoragePath("operation-dossiers")
 const upload = multer({ dest: uploadTmpDir, limits: { files: 10 } })
 
 const router = Router()

--- a/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
+++ b/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
@@ -1,7 +1,7 @@
 // src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
 import type { Request, RequestHandler } from "express"
 import fs from "node:fs/promises"
-import path from "node:path"
+import { getDocumentStoragePath, isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import {
   achatIdParamSchema,
@@ -281,10 +281,9 @@ export const downloadPieceTechniqueDocument: RequestHandler = async (req, res, n
       return
     }
 
-    const baseDir = path.resolve("uploads/docs/pieces-techniques")
-    const absPath = path.resolve(doc.storage_path)
-    const basePrefix = baseDir.endsWith(path.sep) ? baseDir : `${baseDir}${path.sep}`
-    if (!absPath.startsWith(basePrefix)) {
+    const baseDir = getDocumentStoragePath("pieces-techniques")
+    const absPath = resolveCerpStoragePath(doc.storage_path, baseDir)
+    if (!isPathInsideDirectory(baseDir, absPath)) {
       throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path")
     }
     await fs.access(absPath)

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -5,6 +5,7 @@ import { createReadStream } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import db from "../../../config/database";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
@@ -686,7 +687,7 @@ export async function repoAttachPieceTechniqueDocuments(
   audit: AuditContext
 ): Promise<PieceTechniqueDocument[] | null> {
   const client = await db.connect();
-  const docsDirRel = path.posix.join("uploads", "docs", "pieces-techniques");
+  const docsDirRel = ensureDocumentStoragePath("pieces-techniques");
   const docsDirAbs = path.resolve(docsDirRel);
 
   try {

--- a/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
+++ b/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
@@ -1,10 +1,9 @@
 // src/module/pieces-techniques/routes/pieces-techniques.routes.ts
 import { Router, type RequestHandler } from "express"
-import fs from "fs"
 import multer from "multer"
-import path from "path"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import {
   addAchat,
@@ -74,12 +73,7 @@ const requireAdmin: RequestHandler = (req, _res, next) => {
   next()
 }
 
-const ensureDir = (dir: string) => {
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
-}
-
-const docsBaseDir = path.resolve("uploads/docs/pieces-techniques")
-ensureDir(docsBaseDir)
+const docsBaseDir = ensureDocumentStoragePath("pieces-techniques")
 
 const upload = multer({
   dest: docsBaseDir,

--- a/src/module/planning/controllers/planning.controller.ts
+++ b/src/module/planning/controllers/planning.controller.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import { asyncHandler } from "../../../utils/asyncHandler";
+import { getDocumentStoragePath, isPathInsideDirectory } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import type { AuditContext } from "../repository/planning.repository";
 import {
@@ -219,10 +220,9 @@ export const getPlanningEventDocumentFile: RequestHandler = async (req, res, nex
       return;
     }
 
-    const baseDir = path.resolve("uploads/docs");
+    const baseDir = getDocumentStoragePath();
     const absPath = path.resolve(baseDir, `${doc.id}${safeExtFromName(doc.document_name)}`);
-    const basePrefix = baseDir.endsWith(path.sep) ? baseDir : `${baseDir}${path.sep}`;
-    if (!absPath.startsWith(basePrefix)) {
+    if (!isPathInsideDirectory(baseDir, absPath)) {
       throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path");
     }
 

--- a/src/module/planning/repository/planning.repository.ts
+++ b/src/module/planning/repository/planning.repository.ts
@@ -5,6 +5,7 @@ import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
 import { emitAppNotificationCreated, emitEntityChanged } from "../../../shared/realtime/realtime.service";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
@@ -2185,7 +2186,7 @@ async function insertPlanningEventDocuments(tx: PoolClient, params: {
     const extCandidate = path.extname(doc.originalname).toLowerCase();
     const safeExt = /^\.[a-z0-9]+$/.test(extCandidate) && extCandidate.length <= 10 ? extCandidate : "";
 
-    const uploadDir = path.resolve("uploads/docs");
+    const uploadDir = ensureDocumentStoragePath();
     const finalPath = path.join(uploadDir, `${documentId}${safeExt}`);
 
     try {

--- a/src/module/planning/routes/planning.routes.ts
+++ b/src/module/planning/routes/planning.routes.ts
@@ -1,6 +1,7 @@
 import { Router, type RequestHandler } from "express";
 import multer from "multer";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import {
   archivePlanningEvent,
@@ -38,7 +39,7 @@ const requireProductionOrAdmin: RequestHandler = (req, _res, next) => {
   next();
 };
 
-const uploadDocs = multer({ dest: "uploads/docs" });
+const uploadDocs = multer({ dest: ensureDocumentStoragePath() });
 
 const router = Router();
 

--- a/src/module/qualite/controllers/qualite.controller.ts
+++ b/src/module/qualite/controllers/qualite.controller.ts
@@ -1,8 +1,8 @@
 import type { Request, RequestHandler } from "express";
 import fs from "node:fs/promises";
-import path from "node:path";
 
 import { asyncHandler } from "../../../utils/asyncHandler";
+import { isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 import { emitEntityChanged } from "../../../shared/realtime/realtime.service";
@@ -321,9 +321,8 @@ async function downloadDocHandler(req: Request, res: Parameters<RequestHandler>[
   }
 
   const baseDir = svcQualityDocumentBaseDir();
-  const absPath = path.resolve(doc.storage_path);
-  const basePrefix = baseDir.endsWith(path.sep) ? baseDir : `${baseDir}${path.sep}`;
-  if (!absPath.startsWith(basePrefix)) {
+  const absPath = resolveCerpStoragePath(doc.storage_path, baseDir);
+  if (!isPathInsideDirectory(baseDir, absPath)) {
     throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path");
   }
   await fs.access(absPath);

--- a/src/module/qualite/repository/qualite.repository.ts
+++ b/src/module/qualite/repository/qualite.repository.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import pool from "../../../config/database";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import { repoGetMetrologieBlockState } from "../../metrologie/repository/metrologie.repository";
@@ -1413,7 +1414,7 @@ export async function repoAttachDocuments(params: {
   const { entity_type, entity_id, document_type, documents, audit } = params;
 
   const client = await pool.connect();
-  const docsDirRel = path.posix.join("uploads", "docs", "qualite");
+  const docsDirRel = ensureDocumentStoragePath("qualite");
   const docsDirAbs = path.resolve(docsDirRel);
 
   try {
@@ -1739,7 +1740,7 @@ export async function repoGetDocumentForDownload(params: {
 }
 
 export function qualityDocumentBaseDir(): string {
-  return path.resolve("uploads/docs/qualite");
+  return ensureDocumentStoragePath("qualite");
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/module/qualite/routes/qualite.routes.ts
+++ b/src/module/qualite/routes/qualite.routes.ts
@@ -1,9 +1,8 @@
 import { Router, type RequestHandler } from "express";
-import fs from "node:fs";
 import multer from "multer";
-import path from "node:path";
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 
 import {
@@ -93,12 +92,7 @@ router.post("/actions", createAction);
 router.patch("/actions/:id", patchAction);
 
 // Documents (multer)
-const ensureDir = (dir: string) => {
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-};
-
-const docsBaseDir = path.resolve("uploads/docs/qualite");
-ensureDir(docsBaseDir);
+const docsBaseDir = ensureDocumentStoragePath("qualite");
 
 const upload = multer({
   dest: docsBaseDir,

--- a/src/module/receptions/controllers/receptions.controller.ts
+++ b/src/module/receptions/controllers/receptions.controller.ts
@@ -1,7 +1,7 @@
 import type { Request, RequestHandler, Response } from "express"
 import fs from "node:fs/promises"
-import path from "node:path"
 
+import { getDocumentStoragePath, isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { emitEntityChanged } from "../../../shared/realtime/realtime.service"
 import type { AuditContext } from "../repository/receptions.repository"
@@ -104,10 +104,9 @@ async function sendDocumentFile(
   res: Response,
   doc: { storage_path: string; mime_type: string; original_name: string }
 ) {
-  const baseDir = path.resolve(path.posix.join("uploads", "docs", "receptions"))
-  const absPath = path.resolve(doc.storage_path)
-  const basePrefix = baseDir.endsWith(path.sep) ? baseDir : `${baseDir}${path.sep}`
-  if (!absPath.startsWith(basePrefix)) {
+  const baseDir = getDocumentStoragePath("receptions")
+  const absPath = resolveCerpStoragePath(doc.storage_path, baseDir)
+  if (!isPathInsideDirectory(baseDir, absPath)) {
     throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path")
   }
 

--- a/src/module/receptions/repository/receptions.repository.ts
+++ b/src/module/receptions/repository/receptions.repository.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises"
 import path from "node:path"
 
 import db from "../../../config/database"
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators"
@@ -974,7 +975,7 @@ export async function repoAttachDocuments(
   audit: AuditContext
 ): Promise<ReceptionFournisseurDocument[] | null> {
   const client = await db.connect()
-  const docsDirRel = path.posix.join("uploads", "docs", "receptions")
+  const docsDirRel = ensureDocumentStoragePath("receptions")
   const docsDirAbs = path.resolve(docsDirRel)
   const movedFiles: string[] = []
   try {

--- a/src/module/receptions/routes/receptions.routes.ts
+++ b/src/module/receptions/routes/receptions.routes.ts
@@ -1,9 +1,8 @@
 import { Router } from "express"
-import fs from "node:fs"
 import multer from "multer"
-import path from "node:path"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
+import { ensureTmpStoragePath } from "../../../utils/cerpStorage"
 import {
   addIncomingMeasurement,
   attachReceptionDocuments,
@@ -21,12 +20,7 @@ import {
   startIncomingInspection,
 } from "../controllers/receptions.controller"
 
-const ensureDir = (dir: string) => {
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
-}
-
-const tmpBaseDir = path.resolve("uploads/tmp/receptions")
-ensureDir(tmpBaseDir)
+const tmpBaseDir = ensureTmpStoragePath("receptions")
 
 const upload = multer({
   dest: tmpBaseDir,

--- a/src/module/stock/controllers/stock.controller.ts
+++ b/src/module/stock/controllers/stock.controller.ts
@@ -1,7 +1,7 @@
 import type { Request, RequestHandler, Response } from "express";
 import fs from "node:fs/promises";
-import path from "node:path";
 
+import { getDocumentStoragePath, isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import {
   createInventorySessionSchema,
@@ -238,10 +238,9 @@ async function sendDocumentFile(
   res: Response,
   doc: { storage_path: string; mime_type: string; original_name: string }
 ) {
-  const baseDir = path.resolve(path.posix.join("uploads", "docs", "stock"));
-  const absPath = path.resolve(doc.storage_path);
-  const basePrefix = baseDir.endsWith(path.sep) ? baseDir : `${baseDir}${path.sep}`;
-  if (!absPath.startsWith(basePrefix)) {
+  const baseDir = getDocumentStoragePath("stock");
+  const absPath = resolveCerpStoragePath(doc.storage_path, baseDir);
+  if (!isPathInsideDirectory(baseDir, absPath)) {
     throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path");
   }
 

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import db from "../../../config/database";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
@@ -4233,7 +4234,7 @@ export async function repoAttachArticleDocuments(
   audit: AuditContext
 ): Promise<StockDocument[] | null> {
   const client = await db.connect();
-  const docsDirRel = path.posix.join("uploads", "docs", "stock", "articles");
+  const docsDirRel = ensureDocumentStoragePath("stock", "articles");
   try {
     await client.query("BEGIN");
 
@@ -4396,7 +4397,7 @@ export async function repoAttachMovementDocuments(
   audit: AuditContext
 ): Promise<StockDocument[] | null> {
   const client = await db.connect();
-  const docsDirRel = path.posix.join("uploads", "docs", "stock", "movements");
+  const docsDirRel = ensureDocumentStoragePath("stock", "movements");
   try {
     await client.query("BEGIN");
 

--- a/src/module/stock/routes/stock.routes.ts
+++ b/src/module/stock/routes/stock.routes.ts
@@ -1,9 +1,8 @@
 import { Router } from "express";
-import fs from "fs";
 import multer from "multer";
-import path from "path";
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import { ensureTmpStoragePath } from "../../../utils/cerpStorage";
 import {
   attachStockArticleDocuments,
   attachStockMovementDocuments,
@@ -58,12 +57,7 @@ import {
 
 const router = Router();
 
-const ensureDir = (dir: string) => {
-  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-};
-
-const tmpBaseDir = path.resolve("uploads/tmp/stock");
-ensureDir(tmpBaseDir);
+const tmpBaseDir = ensureTmpStoragePath("stock");
 
 const upload = multer({
   dest: tmpBaseDir,

--- a/src/sockets/sockeServer.ts
+++ b/src/sockets/sockeServer.ts
@@ -29,8 +29,8 @@ function listOnlineUserIds(): number[] {
 }
 
 const staticAllowedOrigins = new Set<string>([
-  "https://crp-systems.croix-rousse-precision.fr",
-  "http://crp-systems.croix-rousse-precision.fr",
+  "https://cerp.croix-rousse-precision.fr",
+  "http://cerp.croix-rousse-precision.fr",
   "http://localhost:5173",
   "http://localhost:5137",
   "http://localhost:4173",

--- a/src/swagger/swagger.ts
+++ b/src/swagger/swagger.ts
@@ -3,14 +3,14 @@ import { OpenAPIV3_1 } from 'openapi-types';
 export const swaggerSpec: OpenAPIV3_1.Document = {
   openapi: '3.0.3',
   info: {
-    title: 'ERP CRP API',
+    title: 'CERP API',
     version: '1.0.0',
     description:
-      'Documentation des endpoints ERP CRP pour la gestion des clients. Authentification par JWT (Bearer).',
+      'Documentation des endpoints CERP. Authentification par JWT (Bearer).',
   },
   servers: [
     { url: '/api/v1', description: 'API v1 (même host)' },
-    // { url: 'https://api.crp-systems.croix-rousse-precision.fr/api/v1', description: 'Prod' },
+    // { url: 'https://cerp.croix-rousse-precision.fr/api/v1', description: 'Prod' },
   ],
   components: {
     securitySchemes: {

--- a/src/utils/cerpStorage.ts
+++ b/src/utils/cerpStorage.ts
@@ -1,0 +1,109 @@
+import fs from "fs";
+import path from "path";
+
+function clean(value: string | undefined) {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+function fallbackRoot() {
+  return fs.existsSync("/srv/cerp") ? "/srv/cerp" : process.cwd();
+}
+
+export function getCerpRootPath(...segments: string[]) {
+  const root = clean(process.env.CERP_ROOT) ?? fallbackRoot();
+  return path.resolve(root, ...segments.filter(Boolean));
+}
+
+export function getStorageRootPath(...segments: string[]) {
+  const root = clean(process.env.CERP_STORAGE_ROOT) ?? getCerpRootPath("data");
+  return path.resolve(root, ...segments.filter(Boolean));
+}
+
+export function getDocumentsRootPath(...segments: string[]) {
+  const root = clean(process.env.CERP_DOCUMENTS_ROOT) ?? getStorageRootPath("documents");
+  return path.resolve(root, ...segments.filter(Boolean));
+}
+
+export function getGeneratedRootPath(...segments: string[]) {
+  const root = clean(process.env.CERP_GENERATED_ROOT) ?? getStorageRootPath("generated");
+  return path.resolve(root, ...segments.filter(Boolean));
+}
+
+export function getInboundRootPath(...segments: string[]) {
+  const root = clean(process.env.CERP_INBOUND_ROOT) ?? getStorageRootPath("inbound");
+  return path.resolve(root, ...segments.filter(Boolean));
+}
+
+export function getExportsRootPath(...segments: string[]) {
+  const root = clean(process.env.CERP_EXPORTS_ROOT) ?? getStorageRootPath("exports");
+  return path.resolve(root, ...segments.filter(Boolean));
+}
+
+export function getTmpRootPath(...segments: string[]) {
+  const root = clean(process.env.CERP_TMP_ROOT) ?? getStorageRootPath("tmp");
+  return path.resolve(root, ...segments.filter(Boolean));
+}
+
+export function getDocumentStoragePath(...segments: string[]) {
+  return getDocumentsRootPath(...segments);
+}
+
+export function getTmpStoragePath(...segments: string[]) {
+  return getTmpRootPath(...segments);
+}
+
+export function resolveCerpStoragePath(storagePath: string, fallbackBase?: string) {
+  const trimmed = storagePath.trim();
+  if (!trimmed) return path.resolve(fallbackBase ?? getCerpRootPath());
+
+  if (path.isAbsolute(trimmed)) return path.resolve(trimmed);
+
+  const normalized = trimmed.replace(/\\/g, "/").replace(/^\.\//, "");
+  const legacyMappings: Array<[string, string]> = [
+    ["uploads/docs", getDocumentsRootPath()],
+    ["uploads/tmp", getTmpRootPath()],
+    ["uploads/images", getGeneratedRootPath("images")],
+  ];
+
+  for (const [legacyPrefix, targetRoot] of legacyMappings) {
+    if (normalized === legacyPrefix) return targetRoot;
+    if (normalized.startsWith(`${legacyPrefix}/`)) {
+      return path.resolve(targetRoot, normalized.slice(legacyPrefix.length + 1));
+    }
+  }
+
+  return path.resolve(fallbackBase ?? getCerpRootPath(), normalized);
+}
+
+export function isPathInsideDirectory(baseDir: string, candidatePath: string) {
+  const base = path.resolve(baseDir);
+  const candidate = path.resolve(candidatePath);
+  const relative = path.relative(base, candidate);
+  return relative === "" || (!!relative && !relative.startsWith("..") && !path.isAbsolute(relative));
+}
+
+export function ensureDirectory(dir: string) {
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export function ensureDocumentsPath(...segments: string[]) {
+  return ensureDirectory(getDocumentsRootPath(...segments));
+}
+
+export function ensureGeneratedPath(...segments: string[]) {
+  return ensureDirectory(getGeneratedRootPath(...segments));
+}
+
+export function ensureTmpPath(...segments: string[]) {
+  return ensureDirectory(getTmpRootPath(...segments));
+}
+
+export function ensureDocumentStoragePath(...segments: string[]) {
+  return ensureDirectory(getDocumentStoragePath(...segments));
+}
+
+export function ensureTmpStoragePath(...segments: string[]) {
+  return ensureDirectory(getTmpStoragePath(...segments));
+}

--- a/src/utils/imageStorage.ts
+++ b/src/utils/imageStorage.ts
@@ -1,14 +1,15 @@
 import fs from "fs"
 import path from "path"
+import { getGeneratedRootPath } from "./cerpStorage"
 
-const DEFAULT_IMAGES_DIR = path.resolve("uploads/images")
+const DEFAULT_IMAGES_DIR = getGeneratedRootPath("images")
 
 function trimSlashes(value: string) {
   return value.replace(/^\/+|\/+$/g, "")
 }
 
 export function getImagesRootPath() {
-  const configured = process.env.IMAGES_UPLOAD_DIR?.trim()
+  const configured = (process.env.CERP_IMAGES_ROOT ?? process.env.IMAGES_UPLOAD_DIR)?.trim()
   return path.resolve(configured && configured.length ? configured : DEFAULT_IMAGES_DIR)
 }
 


### PR DESCRIPTION
## Summary

- Rename backend-facing application labels to CERP.
- Centralize local-first storage paths through CERP environment variables.
- Move document/tmp/image storage resolution toward `/srv/cerp/data/...` while preserving compatibility for legacy stored paths.
- Update tests and example env values for the CERP local-first setup.

## Validation

- `npm run build`
- `npm run test:run` - 25 files, 110 tests passed
- Local API service verified on HYPERBOX2 at `http://127.0.0.1:8080/`
- VPS-to-local WireGuard route verified through `10.90.0.2:8080`

## Notes

No `.env`, secrets, build output, or `node_modules` are included.

## Summary by Sourcery

Introduce centralized CERP storage helpers and migrate document/image/tmp paths to them while rebranding backend identifiers from ERP/CRP Systems to CERP.

New Features:
- Add cerpStorage utilities to resolve and ensure CERP root, storage, documents, generated, inbound, exports, and tmp paths with environment-based configuration and legacy path compatibility.

Enhancements:
- Replace hardcoded upload and tmp directory handling across modules with cerpStorage helpers for consistent local-first storage management and directory safety checks.
- Update application, socket, Swagger, and console messaging to use the CERP naming and production host URLs instead of ERP/CRP Systems branding.
- Align image storage configuration with new CERP-generated storage roots and environment variables.
- Adjust tests and repository helpers to use centralized document storage paths and new temporary directory naming.
- Rename the backend package and internal documentation references from erp-crp-backend to cerp-api.

Tests:
- Update HTTP and document-serving tests to account for CERP naming and new document storage resolution.