### PR TITLE
fix: accept login database selector

### DIFF
--- a/src/__tests__/auth.validator.test.ts
+++ b/src/__tests__/auth.validator.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { loginSchema } from "../module/auth/validators/auth.validator";
+
+describe("auth login validator", () => {
+  it("accepts the frontend database selector", () => {
+    const parsed = loginSchema.parse({
+      username: " admin ",
+      password: "secret",
+      database: "cerp_prod",
+    });
+
+    expect(parsed).toEqual({
+      username: "ADMIN",
+      password: "secret",
+      database: "cerp_prod",
+    });
+  });
+
+  it("keeps database optional for legacy callers", () => {
+    const parsed = loginSchema.parse({
+      username: "admin",
+      password: "secret",
+    });
+
+    expect(parsed).toEqual({
+      username: "ADMIN",
+      password: "secret",
+    });
+  });
+
+  it("rejects unknown database ids", () => {
+    expect(() =>
+      loginSchema.parse({
+        username: "admin",
+        password: "secret",
+        database: "other",
+      })
+    ).toThrow();
+  });
+});

--- a/src/__tests__/cors.config.test.ts
+++ b/src/__tests__/cors.config.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import request from "supertest";
+
+import app from "../config/app";
+
+describe("CORS configuration", () => {
+  it("allows the frontend database header during login preflight", async () => {
+    const res = await request(app)
+      .options("/api/v1/auth/login")
+      .set("Origin", "http://localhost:5173")
+      .set("Access-Control-Request-Method", "POST")
+      .set("Access-Control-Request-Headers", "content-type,x-cerp-database");
+
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-allow-origin"]).toBe("http://localhost:5173");
+    expect(res.headers["access-control-allow-headers"]).toContain("X-CERP-Database");
+  });
+
+  it("allows the packaged desktop origin when requests bypass the Electron proxy", async () => {
+    const res = await request(app)
+      .options("/api/v1/auth/login")
+      .set("Origin", "app://cerp")
+      .set("Access-Control-Request-Method", "POST")
+      .set("Access-Control-Request-Headers", "content-type,x-cerp-database");
+
+    expect(res.status).toBe(204);
+    expect(res.headers["access-control-allow-origin"]).toBe("app://cerp");
+  });
+});

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -34,6 +34,7 @@ const staticAllowedOrigins = new Set<string>([
   "http://127.0.0.1:5173",
   "http://127.0.0.1:5137",
   "http://127.0.0.1:4173",
+  "app://cerp",
 ]);
 
 const envOrigins = (process.env.CORS_ORIGINS ?? "")
@@ -82,6 +83,7 @@ const corsOptionsDelegate: cors.CorsOptionsDelegate = (req, cb) => {
     allowedHeaders: [
       "Content-Type",
       "Authorization",
+      "X-CERP-Database",
       "X-Request-Id",
       "X-Page-Key",
       "X-Client-Session-Id",

--- a/src/module/auth/validators/auth.validator.ts
+++ b/src/module/auth/validators/auth.validator.ts
@@ -8,6 +8,7 @@ export const loginSchema = z.object({
   password: z
     .string({ required_error: "Mot de passe requis" })
     .min(1, "Mot de passe requis"),
+  database: z.enum(["cerp_prod", "cerp_test"]).optional(),
 }).strict();
 
 export type LoginDTO = z.infer<typeof loginSchema>;


### PR DESCRIPTION
## Summary
- allow `/auth/login` to accept the frontend database selector (`cerp_prod` / `cerp_test`)
- allow the `X-CERP-Database` CORS header used by the login request
- allow `app://cerp` defensively for packaged desktop requests that bypass the Electron proxy
- add validator and CORS regression tests

## Root cause
The frontend login payload sends `database` and `X-CERP-Database`, but the backend login schema was strict and CORS preflight did not list the custom header. The browser blocked login before authentication could complete.

## Validation
- `npm run test:run -- auth.validator.test.ts cors.config.test.ts`
- `npm run build`

Closes #17

## Summary by Sourcery

Allow the authentication flow to support a frontend-selected database and ensure related headers and desktop origins are accepted by CORS.

Bug Fixes:
- Accept an optional database selector in the login payload to align backend validation with the frontend request format.
- Allow the X-CERP-Database header in CORS to prevent login requests from being blocked by preflight checks.

Enhancements:
- Add app://cerp as an allowed CORS origin for packaged desktop clients.

Tests:
- Add validator tests for the login schema and regression tests for the CORS configuration.