### PR TITLE
[codex] align Docker storage permissions on dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,14 +20,21 @@ RUN npm ci --omit=dev
 
 # ...
 COPY --from=builder /app/dist ./dist
-RUN mkdir -p /app/uploads && chown -R node:node /app/uploads
+RUN mkdir -p \
+    /app/data/documents \
+    /app/data/generated \
+    /app/data/inbound \
+    /app/data/exports \
+    /app/data/tmp \
+    /app/uploads \
+  && chown -R node:node /app/data /app/uploads
 USER node
 ENV PORT=5000
 EXPOSE 5000
 # ...
 
 
-VOLUME ["/app/uploads"]
+VOLUME ["/app/data", "/app/uploads"]
 
 HEALTHCHECK --interval=30s --timeout=3s --start-period=20s --retries=3 \
   CMD node -e "require('http').get('http://127.0.0.1:'+(process.env.PORT||5000)+'/',r=>{if(r.statusCode<400)process.exit(0);process.exit(1)}).on('error',()=>process.exit(1))"

--- a/src/__tests__/dockerfile.storage.test.ts
+++ b/src/__tests__/dockerfile.storage.test.ts
@@ -1,0 +1,24 @@
+import fs from "fs";
+import path from "path";
+
+import { describe, expect, it } from "vitest";
+
+const dockerfile = fs.readFileSync(path.resolve(process.cwd(), "Dockerfile"), "utf8");
+
+describe("Dockerfile storage permissions", () => {
+  it("creates the active CERP storage root before switching to the node user", () => {
+    const mkdirIndex = dockerfile.indexOf("RUN mkdir -p");
+    const dataIndex = dockerfile.indexOf("/app/data/documents");
+    const chownIndex = dockerfile.indexOf("chown -R node:node /app/data /app/uploads");
+    const userIndex = dockerfile.indexOf("USER node");
+
+    expect(mkdirIndex).toBeGreaterThanOrEqual(0);
+    expect(dataIndex).toBeGreaterThan(mkdirIndex);
+    expect(chownIndex).toBeGreaterThan(dataIndex);
+    expect(userIndex).toBeGreaterThan(chownIndex);
+  });
+
+  it("declares the active storage root as a runtime volume", () => {
+    expect(dockerfile).toContain('VOLUME ["/app/data", "/app/uploads"]');
+  });
+});


### PR DESCRIPTION
Refs #20

## What changed
- Create `/app/data` storage directories in the runtime Docker image.
- Chown `/app/data` and `/app/uploads` before switching to the non-root `node` user.
- Declare `/app/data` as a runtime volume alongside the legacy `/app/uploads` path.
- Add a Vitest regression test for the Dockerfile storage contract.

## Root cause
Coolify deployed `main` successfully up to image startup, but the app rolled back because route imports call `ensureDocumentStoragePath()`. The backend defaulted to `/app/data/documents`, while the image only prepared `/app/uploads`, so `node` hit `EACCES` creating `/app/data/documents`.

## Validation
- `npm run test:run -- dockerfile.storage.test.ts auth.validator.test.ts cors.config.test.ts`
- `npm run build`

Docker image execution could not be run locally because Docker Desktop is not currently running on this workstation.

## Summary by Sourcery

Align Docker image storage layout and permissions with the application’s active storage paths to prevent runtime access issues.

Bug Fixes:
- Ensure all active storage directories under /app/data and legacy /app/uploads are created and owned by the node user before dropping root in the runtime image.

Enhancements:
- Declare /app/data as a runtime volume alongside the existing /app/uploads volume to persist application data across container restarts.

Tests:
- Add a Vitest regression test that validates the Dockerfile creates/chowns the active storage root before switching users and declares it as a runtime volume.