### PR TITLE
[release] Promote dev to main

### DIFF
--- a/db/patches/20260624_recursive_fabrication_tree_of_hierarchy.sql
+++ b/db/patches/20260624_recursive_fabrication_tree_of_hierarchy.sql
@@ -1,0 +1,303 @@
+-- Issue #55 - Arborescence de fabrication recursive et OF parent/enfant
+-- Migration additive uniquement : conserve les tables historiques et ajoute
+-- la trace d'execution necessaire aux generations recursives d'OF.
+
+DO $$
+BEGIN
+  EXECUTE 'CREATE EXTENSION IF NOT EXISTS pgcrypto';
+EXCEPTION
+  WHEN insufficient_privilege THEN
+    RAISE NOTICE 'Skipping CREATE EXTENSION pgcrypto (insufficient privileges)';
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pieces_techniques_nomenclature_no_self_parent_ck'
+      AND conrelid = 'public.pieces_techniques_nomenclature'::regclass
+  ) THEN
+    ALTER TABLE public.pieces_techniques_nomenclature
+      ADD CONSTRAINT pieces_techniques_nomenclature_no_self_parent_ck
+      CHECK (parent_piece_technique_id <> child_piece_technique_id);
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.of_generation_batches
+(
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  source_type text NOT NULL DEFAULT 'COMMANDE_CLIENT',
+  commande_id bigint NULL,
+  commande_ligne_id bigint NULL,
+  root_of_id bigint NULL,
+  root_piece_technique_id uuid NOT NULL,
+  requested_qty numeric(12, 3) NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  created_by integer NULL,
+  CONSTRAINT of_generation_batches_pkey PRIMARY KEY (id),
+  CONSTRAINT of_generation_batches_requested_qty_ck CHECK (requested_qty > 0)
+);
+
+ALTER TABLE public.ordres_fabrication
+  ADD COLUMN IF NOT EXISTS parent_of_id bigint NULL,
+  ADD COLUMN IF NOT EXISTS root_of_id bigint NULL,
+  ADD COLUMN IF NOT EXISTS generation_batch_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS generation_level integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS source_bom_line_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS structure_path text NULL,
+  ADD COLUMN IF NOT EXISTS quantity_per_parent numeric(12, 3) NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS quantity_cumulative numeric(12, 3) NOT NULL DEFAULT 1;
+
+UPDATE public.ordres_fabrication
+SET root_of_id = id
+WHERE root_of_id IS NULL;
+
+UPDATE public.ordres_fabrication
+SET structure_path = id::text
+WHERE structure_path IS NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ordres_fabrication_parent_of_id_fkey'
+      AND conrelid = 'public.ordres_fabrication'::regclass
+  ) THEN
+    ALTER TABLE public.ordres_fabrication
+      ADD CONSTRAINT ordres_fabrication_parent_of_id_fkey
+      FOREIGN KEY (parent_of_id) REFERENCES public.ordres_fabrication(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ordres_fabrication_root_of_id_fkey'
+      AND conrelid = 'public.ordres_fabrication'::regclass
+  ) THEN
+    ALTER TABLE public.ordres_fabrication
+      ADD CONSTRAINT ordres_fabrication_root_of_id_fkey
+      FOREIGN KEY (root_of_id) REFERENCES public.ordres_fabrication(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ordres_fabrication_generation_batch_id_fkey'
+      AND conrelid = 'public.ordres_fabrication'::regclass
+  ) THEN
+    ALTER TABLE public.ordres_fabrication
+      ADD CONSTRAINT ordres_fabrication_generation_batch_id_fkey
+      FOREIGN KEY (generation_batch_id) REFERENCES public.of_generation_batches(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ordres_fabrication_source_bom_line_id_fkey'
+      AND conrelid = 'public.ordres_fabrication'::regclass
+  ) THEN
+    ALTER TABLE public.ordres_fabrication
+      ADD CONSTRAINT ordres_fabrication_source_bom_line_id_fkey
+      FOREIGN KEY (source_bom_line_id) REFERENCES public.pieces_techniques_nomenclature(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ordres_fabrication_generation_level_ck'
+      AND conrelid = 'public.ordres_fabrication'::regclass
+  ) THEN
+    ALTER TABLE public.ordres_fabrication
+      ADD CONSTRAINT ordres_fabrication_generation_level_ck
+      CHECK (generation_level >= 0);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ordres_fabrication_generation_quantities_ck'
+      AND conrelid = 'public.ordres_fabrication'::regclass
+  ) THEN
+    ALTER TABLE public.ordres_fabrication
+      ADD CONSTRAINT ordres_fabrication_generation_quantities_ck
+      CHECK (quantity_per_parent > 0 AND quantity_cumulative > 0);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS ordres_fabrication_parent_of_idx
+  ON public.ordres_fabrication(parent_of_id)
+  WHERE parent_of_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS ordres_fabrication_root_of_idx
+  ON public.ordres_fabrication(root_of_id)
+  WHERE root_of_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS ordres_fabrication_generation_batch_idx
+  ON public.ordres_fabrication(generation_batch_id)
+  WHERE generation_batch_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS ordres_fabrication_source_bom_line_idx
+  ON public.ordres_fabrication(source_bom_line_id)
+  WHERE source_bom_line_id IS NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_generation_batches_commande_id_fkey'
+      AND conrelid = 'public.of_generation_batches'::regclass
+  ) THEN
+    ALTER TABLE public.of_generation_batches
+      ADD CONSTRAINT of_generation_batches_commande_id_fkey
+      FOREIGN KEY (commande_id) REFERENCES public.commande_client(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_generation_batches_commande_ligne_id_fkey'
+      AND conrelid = 'public.of_generation_batches'::regclass
+  ) THEN
+    ALTER TABLE public.of_generation_batches
+      ADD CONSTRAINT of_generation_batches_commande_ligne_id_fkey
+      FOREIGN KEY (commande_ligne_id) REFERENCES public.commande_ligne(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_generation_batches_root_of_id_fkey'
+      AND conrelid = 'public.of_generation_batches'::regclass
+  ) THEN
+    ALTER TABLE public.of_generation_batches
+      ADD CONSTRAINT of_generation_batches_root_of_id_fkey
+      FOREIGN KEY (root_of_id) REFERENCES public.ordres_fabrication(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_generation_batches_root_piece_technique_id_fkey'
+      AND conrelid = 'public.of_generation_batches'::regclass
+  ) THEN
+    ALTER TABLE public.of_generation_batches
+      ADD CONSTRAINT of_generation_batches_root_piece_technique_id_fkey
+      FOREIGN KEY (root_piece_technique_id) REFERENCES public.pieces_techniques(id) ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS of_generation_batches_commande_idx
+  ON public.of_generation_batches(commande_id, commande_ligne_id)
+  WHERE commande_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.of_structure_snapshot
+(
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  generation_batch_id uuid NULL,
+  root_of_id bigint NOT NULL,
+  parent_of_id bigint NULL,
+  of_id bigint NOT NULL,
+  level integer NOT NULL,
+  structure_path text NOT NULL,
+  source_bom_line_id uuid NULL,
+  parent_piece_technique_id uuid NULL,
+  piece_technique_id uuid NOT NULL,
+  piece_code text NOT NULL,
+  piece_designation text NOT NULL,
+  piece_version_number integer NOT NULL DEFAULT 1,
+  quantite_par_parent numeric(12, 3) NOT NULL DEFAULT 1,
+  quantite_cumulee numeric(12, 3) NOT NULL DEFAULT 1,
+  quantite_lancee numeric(12, 3) NOT NULL,
+  created_at timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT of_structure_snapshot_pkey PRIMARY KEY (id),
+  CONSTRAINT of_structure_snapshot_of_id_key UNIQUE (of_id),
+  CONSTRAINT of_structure_snapshot_level_ck CHECK (level >= 0),
+  CONSTRAINT of_structure_snapshot_quantities_ck CHECK (
+    quantite_par_parent > 0
+    AND quantite_cumulee > 0
+    AND quantite_lancee > 0
+  )
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_structure_snapshot_generation_batch_id_fkey'
+      AND conrelid = 'public.of_structure_snapshot'::regclass
+  ) THEN
+    ALTER TABLE public.of_structure_snapshot
+      ADD CONSTRAINT of_structure_snapshot_generation_batch_id_fkey
+      FOREIGN KEY (generation_batch_id) REFERENCES public.of_generation_batches(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_structure_snapshot_root_of_id_fkey'
+      AND conrelid = 'public.of_structure_snapshot'::regclass
+  ) THEN
+    ALTER TABLE public.of_structure_snapshot
+      ADD CONSTRAINT of_structure_snapshot_root_of_id_fkey
+      FOREIGN KEY (root_of_id) REFERENCES public.ordres_fabrication(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_structure_snapshot_parent_of_id_fkey'
+      AND conrelid = 'public.of_structure_snapshot'::regclass
+  ) THEN
+    ALTER TABLE public.of_structure_snapshot
+      ADD CONSTRAINT of_structure_snapshot_parent_of_id_fkey
+      FOREIGN KEY (parent_of_id) REFERENCES public.ordres_fabrication(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_structure_snapshot_of_id_fkey'
+      AND conrelid = 'public.of_structure_snapshot'::regclass
+  ) THEN
+    ALTER TABLE public.of_structure_snapshot
+      ADD CONSTRAINT of_structure_snapshot_of_id_fkey
+      FOREIGN KEY (of_id) REFERENCES public.ordres_fabrication(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_structure_snapshot_source_bom_line_id_fkey'
+      AND conrelid = 'public.of_structure_snapshot'::regclass
+  ) THEN
+    ALTER TABLE public.of_structure_snapshot
+      ADD CONSTRAINT of_structure_snapshot_source_bom_line_id_fkey
+      FOREIGN KEY (source_bom_line_id) REFERENCES public.pieces_techniques_nomenclature(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_structure_snapshot_piece_technique_id_fkey'
+      AND conrelid = 'public.of_structure_snapshot'::regclass
+  ) THEN
+    ALTER TABLE public.of_structure_snapshot
+      ADD CONSTRAINT of_structure_snapshot_piece_technique_id_fkey
+      FOREIGN KEY (piece_technique_id) REFERENCES public.pieces_techniques(id) ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS of_structure_snapshot_root_of_idx
+  ON public.of_structure_snapshot(root_of_id, level, structure_path);
+
+CREATE INDEX IF NOT EXISTS of_structure_snapshot_generation_batch_idx
+  ON public.of_structure_snapshot(generation_batch_id)
+  WHERE generation_batch_id IS NOT NULL;
+
+ALTER TABLE public.of_operations
+  ADD COLUMN IF NOT EXISTS source_piece_operation_id uuid NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_operations_source_piece_operation_id_fkey'
+      AND conrelid = 'public.of_operations'::regclass
+  ) THEN
+    ALTER TABLE public.of_operations
+      ADD CONSTRAINT of_operations_source_piece_operation_id_fkey
+      FOREIGN KEY (source_piece_operation_id) REFERENCES public.pieces_techniques_operations(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS of_operations_source_piece_operation_idx
+  ON public.of_operations(source_piece_operation_id)
+  WHERE source_piece_operation_id IS NOT NULL;

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -46,3 +46,21 @@ schema represented by the current patch files.
 - Do not edit a patch file after it has been applied; add a new patch instead.
 - Review `checksum-mismatch` results before continuing.
 - Keep passwords and `DATABASE_URL` out of Git, logs, and tickets.
+
+## Issue #55 - Recursive Fabrication Tree
+
+Patch `20260624_recursive_fabrication_tree_of_hierarchy.sql` adds only new
+structures for recursive OF generation:
+
+- `of_generation_batches` tracks one recursive generation batch from a command
+  line.
+- `ordres_fabrication` gains parent/root/generation metadata for OF trees.
+- `of_structure_snapshot` freezes the fabrication tree context at generation
+  time.
+- `of_operations.source_piece_operation_id` links copied OF operations back to
+  the source routing operation.
+
+This patch does not rename or remove historical tables. The technical table
+`pieces_techniques_nomenclature` remains the manufactured parent/child
+structure, while `pieces_techniques_achats` remains the purchase/procurement
+structure.

--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -1147,9 +1147,35 @@ describe("/api/v1/commandes", () => {
         return { rows: [{ v: "1" }] };
       }
 
+      if (q.includes("WITH RECURSIVE tree") && q.includes("public.pieces_techniques_nomenclature")) {
+        return {
+          rows: [
+            {
+              key: PIECE_ID,
+              parent_key: null,
+              bom_line_id: null,
+              parent_piece_technique_id: null,
+              piece_technique_id: PIECE_ID,
+              article_id: ARTICLE_ID,
+              code_piece: "PT-001",
+              designation: "Piece test",
+              version_number: 1,
+              level: 0,
+              ordre_affichage: 0,
+              quantite_par_parent: 1,
+              quantite_cumulee: 1,
+            },
+          ],
+        };
+      }
+
       if (q.includes("INSERT INTO affaire")) return { rows: [] };
       if (q.includes("INSERT INTO commande_to_affaire")) return { rows: [] };
+      if (q.includes("INSERT INTO public.of_generation_batches")) return { rows: [] };
+      if (q.includes("INSERT INTO public.ordres_fabrication")) return { rows: [] };
       if (q.includes("INSERT INTO public.of_operations")) return { rows: [], rowCount: 1 };
+      if (q.includes("INSERT INTO public.of_structure_snapshot")) return { rows: [] };
+      if (q.includes("UPDATE public.of_generation_batches")) return { rows: [] };
       if (q.includes("INSERT INTO public.commande_client_event_log")) return { rows: [] };
       if (q.includes("INSERT INTO erp_audit_logs")) return { rows: [{ id: "1", created_at: "2026-01-01T00:00:00.000Z" }] };
       if (q.includes("UPDATE commande_client SET updated_at")) return { rows: [] };
@@ -1172,5 +1198,174 @@ describe("/api/v1/commandes", () => {
       affaire_ids: [7],
       livraison_affaire_id: 7,
     });
+  });
+
+  it("POST /api/v1/commandes/:id/generate-affaires creates recursive OF tree for manufactured sub-pieces", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    const token = jwt.sign(
+      { id: 1, username: "test", email: "test@example.com", role: "admin" },
+      process.env.JWT_SECRET,
+      { expiresIn: "1h" }
+    );
+
+    const MAGASIN_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const LOCATION_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    const ARTICLE_ID = "11111111-1111-1111-1111-111111111111";
+    const ROOT_PIECE_ID = "22222222-2222-2222-2222-222222222222";
+    const CHILD_PIECE_ID = "33333333-3333-3333-3333-333333333333";
+    const BOM_LINE_ID = "44444444-4444-4444-4444-444444444444";
+
+    let ofSeq = 8;
+    const ofInsertCalls: unknown[][] = [];
+
+    mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
+      const q = String(sql);
+      const p0 = Array.isArray(params) ? params[0] : undefined;
+
+      if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
+
+      if (q.includes("FROM commande_client") && q.includes("FOR UPDATE") && q.includes("order_type")) {
+        return {
+          rows: [
+            {
+              client_id: "001",
+              type_affaire: "livraison",
+              order_type: "FERME",
+              devis_id: null,
+              numero: "CC-123",
+              dest_stock_magasin_id: null,
+              dest_stock_emplacement_id: null,
+            },
+          ],
+        };
+      }
+
+      if (q.includes("FROM pg_attribute") && q.includes("commande_to_affaire") && q.includes("attname = 'role'")) {
+        return { rows: [{ ok: 1 }] };
+      }
+
+      if (q.includes("FROM commande_to_affaire") && q.includes("WHERE commande_id")) {
+        return { rows: [] };
+      }
+
+      if (q.includes("FROM public.erp_settings") && String(p0) === "stock.default_shipping_location") {
+        return { rows: [{ value_json: { magasin_id: MAGASIN_ID, emplacement_id: 1 } }] };
+      }
+
+      if (q.includes("FROM public.emplacements") && q.includes("SELECT location_id")) {
+        return { rows: [{ location_id: LOCATION_ID }] };
+      }
+
+      if (q.includes("FROM commande_ligne") && q.includes("LEFT JOIN LATERAL")) {
+        return {
+          rows: [
+            {
+              commande_ligne_id: 1,
+              code_piece: "P1",
+              qty_ordered: 2,
+              article_id: ARTICLE_ID,
+              piece_technique_id: ROOT_PIECE_ID,
+            },
+          ],
+        };
+      }
+
+      if (q.includes("FROM public.stock_levels") && q.includes("GROUP BY sl.article_id")) {
+        return { rows: [{ article_id: ARTICLE_ID, qty_available: 0 }] };
+      }
+
+      if (q.includes("nextval('public.affaire_id_seq')")) {
+        return { rows: [{ id: "7" }] };
+      }
+
+      if (q.includes("SELECT client_code FROM public.clients")) {
+        return { rows: [{ client_code: "CLI-001" }] };
+      }
+
+      if (q.includes("public.fn_next_code_value")) {
+        return { rows: [{ v: "1" }] };
+      }
+
+      if (q.includes("WITH RECURSIVE tree") && q.includes("public.pieces_techniques_nomenclature")) {
+        return {
+          rows: [
+            {
+              key: ROOT_PIECE_ID,
+              parent_key: null,
+              bom_line_id: null,
+              parent_piece_technique_id: null,
+              piece_technique_id: ROOT_PIECE_ID,
+              article_id: ARTICLE_ID,
+              code_piece: "ROOT",
+              designation: "Piece mere",
+              version_number: 1,
+              level: 0,
+              ordre_affichage: 0,
+              quantite_par_parent: 1,
+              quantite_cumulee: 1,
+            },
+            {
+              key: `${ROOT_PIECE_ID}/${CHILD_PIECE_ID}`,
+              parent_key: ROOT_PIECE_ID,
+              bom_line_id: BOM_LINE_ID,
+              parent_piece_technique_id: ROOT_PIECE_ID,
+              piece_technique_id: CHILD_PIECE_ID,
+              article_id: null,
+              code_piece: "CHILD",
+              designation: "Sous-piece",
+              version_number: 1,
+              level: 1,
+              ordre_affichage: 10,
+              quantite_par_parent: 3,
+              quantite_cumulee: 3,
+            },
+          ],
+        };
+      }
+
+      if (q.includes("pg_get_serial_sequence") && q.includes("ordres_fabrication")) {
+        ofSeq += 1;
+        return { rows: [{ of_id: String(ofSeq) }] };
+      }
+
+      if (q.includes("INSERT INTO affaire")) return { rows: [] };
+      if (q.includes("INSERT INTO commande_to_affaire")) return { rows: [] };
+      if (q.includes("INSERT INTO public.commande_ligne_affaire_allocation")) return { rows: [] };
+      if (q.includes("INSERT INTO public.of_generation_batches")) return { rows: [] };
+      if (q.includes("INSERT INTO public.ordres_fabrication")) {
+        ofInsertCalls.push(Array.isArray(params) ? params : []);
+        return { rows: [] };
+      }
+      if (q.includes("INSERT INTO public.of_operations")) return { rows: [], rowCount: 1 };
+      if (q.includes("INSERT INTO public.of_structure_snapshot")) return { rows: [] };
+      if (q.includes("UPDATE public.of_generation_batches")) return { rows: [] };
+      if (q.includes("INSERT INTO public.commande_client_event_log")) return { rows: [] };
+      if (q.includes("INSERT INTO erp_audit_logs")) return { rows: [{ id: "1", created_at: "2026-01-01T00:00:00.000Z" }] };
+      if (q.includes("UPDATE commande_client SET updated_at")) return { rows: [] };
+
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post("/api/v1/commandes/123/generate-affaires")
+      .set("Authorization", `Bearer ${token}`)
+      .send({});
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ of_ids: [9, 10] });
+    expect(ofInsertCalls).toHaveLength(2);
+
+    const rootParams = ofInsertCalls[0];
+    const childParams = ofInsertCalls[1];
+    expect(rootParams[0]).toBe(9);
+    expect(rootParams[11]).toBe(0);
+    expect(rootParams[16]).toBe(2);
+    expect(childParams[0]).toBe(10);
+    expect(childParams[8]).toBe(9);
+    expect(childParams[9]).toBe(9);
+    expect(childParams[11]).toBe(1);
+    expect(childParams[14]).toBe(3);
+    expect(childParams[15]).toBe(3);
+    expect(childParams[16]).toBe(6);
   });
 });

--- a/src/__tests__/pieces-techniques.routes.test.ts
+++ b/src/__tests__/pieces-techniques.routes.test.ts
@@ -1,0 +1,92 @@
+import request from "supertest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+
+  const pool = {
+    on: emitter.on.bind(emitter),
+    query: mocks.poolQuery,
+    connect: mocks.poolConnect,
+  };
+
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+
+  return {
+    Pool: vi.fn(() => pool),
+    __emitter__: emitter,
+  };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (req: { user?: { id: number; role: string } }, _res: unknown, next: () => void) => {
+    req.user = { id: 1, role: "Administrateur Systeme et Reseau" };
+    next();
+  },
+  authorizeRole:
+    (...roles: string[]) =>
+    (req: { user?: { role: string } }, res: { status: (n: number) => { json: (b: unknown) => unknown } }, next: () => void) => {
+      if (req.user && roles.includes(req.user.role)) {
+        next();
+        return;
+      }
+      res.status(403).json({ error: "Acces interdit" });
+    },
+}));
+
+import app from "../config/app";
+
+beforeEach(() => {
+  mocks.poolQuery.mockReset();
+  mocks.poolConnect.mockReset();
+  mocks.clientQuery.mockReset();
+  mocks.clientRelease.mockReset();
+
+  mocks.poolQuery.mockResolvedValue({ rows: [] });
+  mocks.clientQuery.mockResolvedValue({ rows: [] });
+
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+});
+
+describe("/api/v1/pieces-techniques", () => {
+  it("rejects a manufactured child relation that would create a fabrication cycle", async () => {
+    const parentId = "11111111-1111-4111-8111-111111111111";
+    const childId = "22222222-2222-4222-8222-222222222222";
+
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("SELECT 1::int AS ok FROM pieces_techniques")) return { rows: [{ ok: 1 }] };
+      if (q.includes("WITH RECURSIVE descendants")) return { rows: [{ found: 1 }] };
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/pieces-techniques/${parentId}/nomenclature`)
+      .send({ child_piece_id: childId, quantite: 1 });
+
+    expect(res.status).toBe(409);
+    expect(mocks.clientQuery).toHaveBeenCalledWith("ROLLBACK");
+    expect(
+      mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO pieces_techniques_nomenclature"))
+    ).toBe(false);
+  });
+});

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -142,6 +142,355 @@ async function insertAuditLog(tx: Queryable, audit: AuditContext, entry: {
   });
 }
 
+type FabricationGenerationNode = {
+  key: string;
+  parent_key: string | null;
+  bom_line_id: string | null;
+  parent_piece_technique_id: string | null;
+  piece_technique_id: string;
+  article_id: string | null;
+  code_piece: string;
+  designation: string;
+  version_number: number;
+  level: number;
+  ordre_affichage: number;
+  quantite_par_parent: number;
+  quantite_cumulee: number;
+};
+
+async function loadFabricationGenerationTree(
+  tx: Queryable,
+  pieceTechniqueId: string,
+  maxDepth = 50
+): Promise<FabricationGenerationNode[]> {
+  const depth = Math.max(1, Math.min(50, Math.trunc(maxDepth)));
+  const res = await tx.query<FabricationGenerationNode>(
+    `
+      WITH RECURSIVE tree AS (
+        SELECT
+          NULL::uuid AS bom_line_id,
+          NULL::uuid AS parent_piece_technique_id,
+          p.id AS piece_technique_id,
+          p.article_id,
+          p.code_piece,
+          p.designation,
+          p.version_number,
+          0::int AS level,
+          ARRAY[p.id]::uuid[] AS path_ids,
+          ARRAY[0]::int[] AS order_path,
+          0::int AS ordre_affichage,
+          1::numeric AS quantite_par_parent,
+          1::numeric AS quantite_cumulee
+        FROM public.pieces_techniques p
+        WHERE p.id = $1::uuid
+          AND p.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT
+          n.id AS bom_line_id,
+          n.parent_piece_technique_id,
+          child.id AS piece_technique_id,
+          child.article_id,
+          child.code_piece,
+          child.designation,
+          child.version_number,
+          tree.level + 1 AS level,
+          tree.path_ids || child.id AS path_ids,
+          tree.order_path || n.rang AS order_path,
+          n.rang::int AS ordre_affichage,
+          n.quantite AS quantite_par_parent,
+          tree.quantite_cumulee * n.quantite AS quantite_cumulee
+        FROM tree
+        JOIN public.pieces_techniques_nomenclature n
+          ON n.parent_piece_technique_id = tree.piece_technique_id
+        JOIN public.pieces_techniques child
+          ON child.id = n.child_piece_technique_id
+         AND child.deleted_at IS NULL
+        WHERE tree.level < $2::int
+          AND NOT child.id = ANY(tree.path_ids)
+      )
+      SELECT
+        array_to_string(path_ids::text[], '/') AS key,
+        CASE
+          WHEN array_length(path_ids, 1) > 1
+            THEN array_to_string(path_ids[1:(array_length(path_ids, 1) - 1)]::text[], '/')
+          ELSE NULL
+        END AS parent_key,
+        bom_line_id::text AS bom_line_id,
+        parent_piece_technique_id::text AS parent_piece_technique_id,
+        piece_technique_id::text AS piece_technique_id,
+        article_id::text AS article_id,
+        code_piece,
+        designation,
+        version_number::int AS version_number,
+        level,
+        ordre_affichage,
+        quantite_par_parent::float8 AS quantite_par_parent,
+        quantite_cumulee::float8 AS quantite_cumulee
+      FROM tree
+      ORDER BY order_path ASC, piece_technique_id ASC
+    `,
+    [pieceTechniqueId, depth]
+  );
+
+  return res.rows.map((row) => ({
+    ...row,
+    version_number: Number(row.version_number),
+    level: Number(row.level),
+    ordre_affichage: Number(row.ordre_affichage),
+    quantite_par_parent: Number(row.quantite_par_parent),
+    quantite_cumulee: Number(row.quantite_cumulee),
+  }));
+}
+
+async function allocateOrdreFabricationId(tx: Queryable): Promise<number> {
+  const idRes = await tx.query<{ of_id: string }>(
+    `SELECT nextval(pg_get_serial_sequence('public.ordres_fabrication','id'))::text AS of_id`
+  );
+  return toInt(idRes.rows[0]?.of_id, "ordres_fabrication.id");
+}
+
+async function copyPieceOperationsToOf(tx: Queryable, params: {
+  of_id: number;
+  piece_technique_id: string;
+}): Promise<number> {
+  const operationsInsert = await tx.query(
+    `
+      INSERT INTO public.of_operations (
+        of_id,
+        phase,
+        designation,
+        cf_id,
+        poste_id,
+        machine_id,
+        hourly_rate_applied,
+        tp,
+        tf_unit,
+        qte,
+        coef,
+        temps_total_planned,
+        status,
+        notes,
+        source_piece_operation_id
+      )
+      SELECT
+        $1::bigint AS of_id,
+        pto.phase,
+        pto.designation,
+        pto.cf_id,
+        NULL::uuid AS poste_id,
+        NULL::uuid AS machine_id,
+        COALESCE(pto.taux_horaire, 0)::numeric(12,2) AS hourly_rate_applied,
+        COALESCE(pto.tp, 0)::numeric(12,3) AS tp,
+        COALESCE(pto.tf_unit, 0)::numeric(12,3) AS tf_unit,
+        COALESCE(pto.qte, 1)::numeric(12,3) AS qte,
+        COALESCE(pto.coef, 1)::numeric(10,3) AS coef,
+        ROUND((COALESCE(pto.tp,0) + COALESCE(pto.tf_unit,0) * COALESCE(pto.qte,1)) * COALESCE(pto.coef,1), 3)::numeric(12,3) AS temps_total_planned,
+        'TODO'::of_operation_status AS status,
+        pto.designation_2 AS notes,
+        pto.id AS source_piece_operation_id
+      FROM public.pieces_techniques_operations pto
+      WHERE pto.piece_technique_id = $2::uuid
+      ORDER BY pto.phase ASC, pto.id ASC
+    `,
+    [params.of_id, params.piece_technique_id]
+  );
+
+  return operationsInsert.rowCount ?? 0;
+}
+
+async function createRecursiveOrdresFabrication(tx: Queryable, params: {
+  commande_id: number;
+  commande_numero: string;
+  commande_ligne_id: number;
+  livraison_affaire_id: number;
+  client_id: string;
+  root_article_id: string | null;
+  root_piece_technique_id: string;
+  qty_to_produce: number;
+  user_id: number;
+}): Promise<number[]> {
+  const tree = await loadFabricationGenerationTree(tx, params.root_piece_technique_id);
+  if (!tree.length) {
+    throw new HttpError(
+      422,
+      "PIECE_TECHNIQUE_NOT_FOUND",
+      `Cannot create OF: piece technique ${params.root_piece_technique_id} was not found`
+    );
+  }
+
+  const ofIdByKey = new Map<string, number>();
+  for (const node of tree) {
+    ofIdByKey.set(node.key, await allocateOrdreFabricationId(tx));
+  }
+
+  const rootOfId = ofIdByKey.get(tree[0].key);
+  if (!rootOfId) throw new Error("Failed to allocate root OF id");
+
+  const batchId = crypto.randomUUID();
+  await tx.query(
+    `
+      INSERT INTO public.of_generation_batches (
+        id,
+        source_type,
+        commande_id,
+        commande_ligne_id,
+        root_of_id,
+        root_piece_technique_id,
+        requested_qty,
+        metadata,
+        created_by
+      )
+      VALUES ($1::uuid,'COMMANDE_CLIENT',$2::bigint,$3::bigint,NULL,$4::uuid,$5,$6::jsonb,$7)
+    `,
+    [
+      batchId,
+      params.commande_id,
+      params.commande_ligne_id,
+      params.root_piece_technique_id,
+      params.qty_to_produce,
+      JSON.stringify({ commande_numero: params.commande_numero }),
+      params.user_id,
+    ]
+  );
+
+  const ofIds: number[] = [];
+
+  for (const node of tree) {
+    const ofId = ofIdByKey.get(node.key);
+    if (!ofId) throw new Error(`Missing OF id for fabrication node ${node.key}`);
+
+    const parentOfId = node.parent_key ? ofIdByKey.get(node.parent_key) ?? null : null;
+    if (node.parent_key && !parentOfId) {
+      throw new Error(`Missing parent OF id for fabrication node ${node.key}`);
+    }
+
+    const numero = `OF-${ofId}`;
+    const qtyLancee = Number((params.qty_to_produce * node.quantite_cumulee).toFixed(3));
+    const articleId = node.article_id ?? (node.level === 0 ? params.root_article_id : null);
+    const notePrefix = node.level === 0 ? "piece mere" : "sous-piece";
+
+    await tx.query(
+      `
+        INSERT INTO public.ordres_fabrication (
+          id,
+          numero,
+          affaire_id,
+          commande_id,
+          commande_ligne_id,
+          article_id,
+          client_id,
+          piece_technique_id,
+          parent_of_id,
+          root_of_id,
+          generation_batch_id,
+          generation_level,
+          source_bom_line_id,
+          structure_path,
+          quantity_per_parent,
+          quantity_cumulative,
+          quantite_lancee,
+          statut,
+          priority,
+          notes,
+          created_by,
+          updated_by
+        ) VALUES (
+          $1,$2,$3::bigint,$4::bigint,$5::bigint,$6::uuid,$7,$8::uuid,
+          $9::bigint,$10::bigint,$11::uuid,$12,$13::uuid,$14,$15,$16,
+          $17,'BROUILLON'::of_status,'NORMAL'::of_priority,$18,$19,$19
+        )
+      `,
+      [
+        ofId,
+        numero,
+        params.livraison_affaire_id,
+        params.commande_id,
+        params.commande_ligne_id,
+        articleId,
+        params.client_id,
+        node.piece_technique_id,
+        parentOfId,
+        rootOfId,
+        batchId,
+        node.level,
+        node.bom_line_id,
+        node.key,
+        node.quantite_par_parent,
+        node.quantite_cumulee,
+        qtyLancee,
+        `Generated from commande ${params.commande_numero} line ${params.commande_ligne_id} (${notePrefix} ${node.code_piece})`,
+        params.user_id,
+      ]
+    );
+
+    const operationsCount = await copyPieceOperationsToOf(tx, {
+      of_id: ofId,
+      piece_technique_id: node.piece_technique_id,
+    });
+    if (operationsCount === 0) {
+      throw new HttpError(
+        409,
+        "PIECE_TECHNIQUE_OPERATION_REQUIRED",
+        `Cannot create complete OF: piece technique ${node.code_piece} has no operation for line ${params.commande_ligne_id}`
+      );
+    }
+
+    await tx.query(
+      `
+        INSERT INTO public.of_structure_snapshot (
+          generation_batch_id,
+          root_of_id,
+          parent_of_id,
+          of_id,
+          level,
+          structure_path,
+          source_bom_line_id,
+          parent_piece_technique_id,
+          piece_technique_id,
+          piece_code,
+          piece_designation,
+          piece_version_number,
+          quantite_par_parent,
+          quantite_cumulee,
+          quantite_lancee
+        )
+        VALUES (
+          $1::uuid,$2::bigint,$3::bigint,$4::bigint,$5,$6,$7::uuid,$8::uuid,
+          $9::uuid,$10,$11,$12,$13,$14,$15
+        )
+      `,
+      [
+        batchId,
+        rootOfId,
+        parentOfId,
+        ofId,
+        node.level,
+        node.key,
+        node.bom_line_id,
+        node.parent_piece_technique_id,
+        node.piece_technique_id,
+        node.code_piece,
+        node.designation,
+        node.version_number,
+        node.quantite_par_parent,
+        node.quantite_cumulee,
+        qtyLancee,
+      ]
+    );
+
+    ofIds.push(ofId);
+  }
+
+  await tx.query(
+    `UPDATE public.of_generation_batches SET root_of_id = $2::bigint WHERE id = $1::uuid`,
+    [batchId, rootOfId]
+  );
+
+  return ofIds;
+}
+
 async function insertCommandeEvent(db: Queryable, params: {
   commande_id: number;
   event_type: string;
@@ -3386,95 +3735,18 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           );
         }
 
-        const idRes = await client.query<{ of_id: string }>(
-          `SELECT nextval(pg_get_serial_sequence('public.ordres_fabrication','id'))::text AS of_id`
-        );
-        const rawId = idRes.rows[0]?.of_id;
-        const ofId = toInt(rawId, "ordres_fabrication.id");
-        const numero = `OF-${ofId}`;
-
-        await client.query(
-          `
-            INSERT INTO public.ordres_fabrication (
-              id,
-              numero,
-              affaire_id,
-              commande_id,
-              commande_ligne_id,
-              article_id,
-              client_id,
-              piece_technique_id,
-              quantite_lancee,
-              statut,
-              priority,
-              notes,
-              created_by,
-              updated_by
-            ) VALUES ($1,$2,$3::bigint,$4::bigint,$5::bigint,$6::uuid,$7,$8::uuid,$9,'BROUILLON'::of_status,'NORMAL'::of_priority,$10,$11,$11)
-          `,
-          [
-            ofId,
-            numero,
-            livraisonAffaireId,
-            commandeId,
-            l.commande_ligne_id,
-            l.article_id,
-            clientId,
-            pieceTechniqueId,
-            qtyToProduce,
-            `Generated from commande ${commande.numero} line ${l.commande_ligne_id}`,
-            audit.user_id,
-          ]
-        );
-
-        const operationsInsert = await client.query(
-          `
-            INSERT INTO public.of_operations (
-              of_id,
-              phase,
-              designation,
-              cf_id,
-              poste_id,
-              machine_id,
-              hourly_rate_applied,
-              tp,
-              tf_unit,
-              qte,
-              coef,
-              temps_total_planned,
-              status,
-              notes
-            )
-            SELECT
-              $1::bigint AS of_id,
-              pto.phase,
-              pto.designation,
-              pto.cf_id,
-              NULL::uuid AS poste_id,
-              NULL::uuid AS machine_id,
-              COALESCE(pto.taux_horaire, 0)::numeric(12,2) AS hourly_rate_applied,
-              COALESCE(pto.tp, 0)::numeric(12,3) AS tp,
-              COALESCE(pto.tf_unit, 0)::numeric(12,3) AS tf_unit,
-              COALESCE(pto.qte, 1)::numeric(12,3) AS qte,
-              COALESCE(pto.coef, 1)::numeric(10,3) AS coef,
-              ROUND((COALESCE(pto.tp,0) + COALESCE(pto.tf_unit,0) * COALESCE(pto.qte,1)) * COALESCE(pto.coef,1), 3)::numeric(12,3) AS temps_total_planned,
-              'TODO'::of_operation_status AS status,
-              pto.designation_2 AS notes
-            FROM public.pieces_techniques_operations pto
-            WHERE pto.piece_technique_id = $2::uuid
-            ORDER BY pto.phase ASC, pto.id ASC
-          `,
-          [ofId, pieceTechniqueId]
-        );
-        if ((operationsInsert.rowCount ?? 0) === 0) {
-          throw new HttpError(
-            409,
-            "PIECE_TECHNIQUE_OPERATION_REQUIRED",
-            `Cannot create complete OF: piece technique ${pieceTechniqueId} has no operation for line ${l.commande_ligne_id}`
-          );
-        }
-
-        ofIds.push(ofId);
+        const generatedIds = await createRecursiveOrdresFabrication(client, {
+          commande_id: commandeId,
+          commande_numero: commande.numero,
+          commande_ligne_id: l.commande_ligne_id,
+          livraison_affaire_id: livraisonAffaireId,
+          client_id: clientId,
+          root_article_id: l.article_id,
+          root_piece_technique_id: pieceTechniqueId,
+          qty_to_produce: qtyToProduce,
+          user_id: audit.user_id,
+        });
+        ofIds.push(...generatedIds);
       }
     }
 

--- a/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
+++ b/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
@@ -45,6 +45,7 @@ import {
   deleteOperationSVC,
   deletePieceTechniqueSVC,
   duplicatePieceTechniqueSVC,
+  getPieceTechniqueFabricationTreeSVC,
   getPieceTechniqueSVC,
   listPieceTechniquesSVC,
   reorderAchatsSVC,
@@ -138,6 +139,20 @@ export const getPieceTechnique: RequestHandler = async (req, res, next) => {
     const { id } = idParamSchema.parse({ params: req.params }).params
     const includes = parseIncludeSet(req)
     const out = await getPieceTechniqueSVC(id, includes)
+    if (!out) {
+      res.status(404).json({ error: "Not found" })
+      return
+    }
+    res.json(out)
+  } catch (err) {
+    next(err)
+  }
+}
+
+export const getPieceTechniqueFabricationTree: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = idParamSchema.parse({ params: req.params }).params
+    const out = await getPieceTechniqueFabricationTreeSVC(id)
     if (!out) {
       res.status(404).json({ error: "Not found" })
       return

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -13,6 +13,8 @@ import type {
   Achat,
   AffairePieceTechniqueLink,
   BomLine,
+  FabricationTreeNode,
+  FabricationTreeResponse,
   Operation,
   Paginated,
   PieceTechnique,
@@ -960,6 +962,211 @@ async function repoListBomLines(pieceTechniqueId: string): Promise<BomLine[]> {
   }));
 }
 
+type FabricationTreeRow = {
+  key: string;
+  parent_key: string | null;
+  bom_line_id: string | null;
+  parent_piece_technique_id: string | null;
+  piece_technique_id: string;
+  article_id: string | null;
+  code_piece: string;
+  designation: string;
+  designation_2: string | null;
+  statut: PieceTechniqueStatut;
+  en_fabrication: number;
+  ensemble: boolean;
+  version_number: number;
+  level: number;
+  path_text: string;
+  ordre_affichage: number;
+  quantite_par_parent: number;
+  quantite_cumulee: number;
+  repere: string | null;
+  line_designation: string | null;
+  operations_count: number;
+  operations_temps_total: number;
+  operations_cout_mo: number;
+  achats_count: number;
+  achats_total_ht: number;
+  achats_total_ttc: number;
+};
+
+function mapFabricationTreeRow(row: FabricationTreeRow): FabricationTreeNode {
+  return {
+    key: row.key,
+    bom_line_id: row.bom_line_id,
+    parent_piece_technique_id: row.parent_piece_technique_id,
+    piece_technique_id: row.piece_technique_id,
+    article_id: row.article_id,
+    code_piece: row.code_piece,
+    designation: row.designation,
+    designation_2: row.designation_2,
+    statut: row.statut,
+    en_fabrication: (row.en_fabrication ?? 0) === 1,
+    ensemble: row.ensemble,
+    version_number: row.version_number,
+    level: Number(row.level),
+    path: row.path_text.split("/").filter((part) => part.length > 0),
+    ordre_affichage: Number(row.ordre_affichage),
+    quantite_par_parent: Number(row.quantite_par_parent),
+    quantite_cumulee: Number(row.quantite_cumulee),
+    repere: row.repere,
+    line_designation: row.line_designation,
+    operations_count: Number(row.operations_count),
+    operations_temps_total: Number(row.operations_temps_total),
+    operations_cout_mo: Number(row.operations_cout_mo),
+    achats_count: Number(row.achats_count),
+    achats_total_ht: Number(row.achats_total_ht),
+    achats_total_ttc: Number(row.achats_total_ttc),
+    children: [],
+  };
+}
+
+export async function repoGetFabricationTree(pieceTechniqueId: string, maxDepth = 50): Promise<FabricationTreeResponse | null> {
+  const depth = Math.max(1, Math.min(50, Math.trunc(maxDepth)));
+  const res = await db.query<FabricationTreeRow>(
+    `
+      WITH RECURSIVE tree AS (
+        SELECT
+          NULL::uuid AS bom_line_id,
+          NULL::uuid AS parent_piece_technique_id,
+          p.id AS piece_technique_id,
+          p.article_id,
+          p.code_piece,
+          p.designation,
+          p.designation_2,
+          p.statut,
+          p.en_fabrication,
+          p.ensemble,
+          p.version_number,
+          0::int AS level,
+          ARRAY[p.id]::uuid[] AS path_ids,
+          ARRAY[0]::int[] AS order_path,
+          0::int AS ordre_affichage,
+          1::numeric AS quantite_par_parent,
+          1::numeric AS quantite_cumulee,
+          NULL::text AS repere,
+          NULL::text AS line_designation
+        FROM pieces_techniques p
+        WHERE p.id = $1::uuid
+          AND p.deleted_at IS NULL
+
+        UNION ALL
+
+        SELECT
+          n.id AS bom_line_id,
+          n.parent_piece_technique_id,
+          child.id AS piece_technique_id,
+          child.article_id,
+          child.code_piece,
+          child.designation,
+          child.designation_2,
+          child.statut,
+          child.en_fabrication,
+          child.ensemble,
+          child.version_number,
+          tree.level + 1 AS level,
+          tree.path_ids || child.id AS path_ids,
+          tree.order_path || n.rang AS order_path,
+          n.rang::int AS ordre_affichage,
+          n.quantite AS quantite_par_parent,
+          tree.quantite_cumulee * n.quantite AS quantite_cumulee,
+          n.repere,
+          n.designation AS line_designation
+        FROM tree
+        JOIN pieces_techniques_nomenclature n
+          ON n.parent_piece_technique_id = tree.piece_technique_id
+        JOIN pieces_techniques child
+          ON child.id = n.child_piece_technique_id
+         AND child.deleted_at IS NULL
+        WHERE tree.level < $2::int
+          AND NOT child.id = ANY(tree.path_ids)
+      ),
+      enriched AS (
+        SELECT
+          array_to_string(path_ids::text[], '/') AS key,
+          CASE
+            WHEN array_length(path_ids, 1) > 1
+              THEN array_to_string(path_ids[1:(array_length(path_ids, 1) - 1)]::text[], '/')
+            ELSE NULL
+          END AS parent_key,
+          bom_line_id::text AS bom_line_id,
+          parent_piece_technique_id::text AS parent_piece_technique_id,
+          piece_technique_id::text AS piece_technique_id,
+          article_id::text AS article_id,
+          code_piece,
+          designation,
+          designation_2,
+          statut::text AS statut,
+          en_fabrication::int AS en_fabrication,
+          ensemble,
+          version_number::int AS version_number,
+          level,
+          array_to_string(path_ids::text[], '/') AS path_text,
+          ordre_affichage,
+          quantite_par_parent::float8 AS quantite_par_parent,
+          quantite_cumulee::float8 AS quantite_cumulee,
+          repere,
+          line_designation,
+          order_path
+        FROM tree
+      )
+      SELECT
+        e.*,
+        COALESCE(ops.operations_count, 0)::int AS operations_count,
+        COALESCE(ops.operations_temps_total, 0)::float8 AS operations_temps_total,
+        COALESCE(ops.operations_cout_mo, 0)::float8 AS operations_cout_mo,
+        COALESCE(achats.achats_count, 0)::int AS achats_count,
+        COALESCE(achats.achats_total_ht, 0)::float8 AS achats_total_ht,
+        COALESCE(achats.achats_total_ttc, 0)::float8 AS achats_total_ttc
+      FROM enriched e
+      LEFT JOIN LATERAL (
+        SELECT
+          COUNT(*)::int AS operations_count,
+          COALESCE(SUM(temps_total), 0)::float8 AS operations_temps_total,
+          COALESCE(SUM(cout_mo), 0)::float8 AS operations_cout_mo
+        FROM pieces_techniques_operations op
+        WHERE op.piece_technique_id = e.piece_technique_id::uuid
+      ) ops ON TRUE
+      LEFT JOIN LATERAL (
+        SELECT
+          COUNT(*)::int AS achats_count,
+          COALESCE(SUM(total_achat_ht), 0)::float8 AS achats_total_ht,
+          COALESCE(SUM(total_achat_ttc), 0)::float8 AS achats_total_ttc
+        FROM pieces_techniques_achats achat
+        WHERE achat.piece_technique_id = e.piece_technique_id::uuid
+      ) achats ON TRUE
+      ORDER BY e.order_path ASC, e.piece_technique_id ASC
+    `,
+    [pieceTechniqueId, depth]
+  );
+
+  if (!res.rows.length) return null;
+
+  const nodes = res.rows.map(mapFabricationTreeRow);
+  const byKey = new Map(nodes.map((node) => [node.key, node] as const));
+  let root: FabricationTreeNode | null = null;
+
+  for (const row of res.rows) {
+    const node = byKey.get(row.key);
+    if (!node) continue;
+    if (!row.parent_key) {
+      root = node;
+      continue;
+    }
+    byKey.get(row.parent_key)?.children.push(node);
+  }
+
+  if (!root) return null;
+
+  return {
+    root,
+    nodes,
+    total_nodes: nodes.length,
+    max_depth: nodes.reduce((max, node) => Math.max(max, node.level), 0),
+  };
+}
+
 type OperationRow = {
   id: string;
   phase: number;
@@ -1290,6 +1497,7 @@ async function insertBomLines(client: PoolClient, pieceTechniqueId: string, bom:
   const out: BomLine[] = [];
   for (let i = 0; i < bom.length; i++) {
     const l = bom[i];
+    await ensureBomLinkAllowed(client, pieceTechniqueId, l.child_piece_id);
     const rang = typeof l.rang === "number" ? l.rang : nextRang;
     nextRang = rang + 10;
 
@@ -2082,13 +2290,21 @@ async function wouldCreateBomCycle(client: PoolClient, parentId: string, childId
   const res = await client.query<{ found: number }>(
     `
       WITH RECURSIVE descendants AS (
-        SELECT child_piece_technique_id
+        SELECT
+          child_piece_technique_id,
+          ARRAY[parent_piece_technique_id, child_piece_technique_id]::uuid[] AS path_ids,
+          1::int AS depth
         FROM pieces_techniques_nomenclature
         WHERE parent_piece_technique_id = $1::uuid
         UNION ALL
-        SELECT n.child_piece_technique_id
+        SELECT
+          n.child_piece_technique_id,
+          d.path_ids || n.child_piece_technique_id,
+          d.depth + 1
         FROM pieces_techniques_nomenclature n
         JOIN descendants d ON n.parent_piece_technique_id = d.child_piece_technique_id
+        WHERE d.depth < 50
+          AND NOT n.child_piece_technique_id = ANY(d.path_ids)
       )
       SELECT 1::int AS found
       FROM descendants
@@ -2098,6 +2314,16 @@ async function wouldCreateBomCycle(client: PoolClient, parentId: string, childId
     [childId, parentId]
   );
   return Boolean(res.rows[0]?.found);
+}
+
+async function ensureBomLinkAllowed(client: PoolClient, parentId: string, childId: string): Promise<void> {
+  const childExists = await ensurePieceTechniqueExists(client, childId);
+  if (!childExists) {
+    throw new HttpError(422, "CHILD_PIECE_TECHNIQUE_NOT_FOUND", "Child piece technique not found");
+  }
+
+  const cycle = await wouldCreateBomCycle(client, parentId, childId);
+  if (cycle) throw new HttpError(409, "BOM_CYCLE", "This line would create a fabrication tree cycle");
 }
 
 export async function repoAddBomLine(pieceTechniqueId: string, body: AddBomLineBodyDTO): Promise<BomLine | null> {
@@ -2110,8 +2336,7 @@ export async function repoAddBomLine(pieceTechniqueId: string, body: AddBomLineB
       return null;
     }
 
-    const cycle = await wouldCreateBomCycle(client, pieceTechniqueId, body.child_piece_id);
-    if (cycle) throw new HttpError(409, "BOM_CYCLE", "This line would create a nomenclature cycle");
+    await ensureBomLinkAllowed(client, pieceTechniqueId, body.child_piece_id);
 
     let rang = body.rang;
     if (rang === undefined) {
@@ -2172,8 +2397,7 @@ export async function repoUpdateBomLine(
     await client.query("BEGIN");
 
     if (body.child_piece_id !== undefined) {
-      const cycle = await wouldCreateBomCycle(client, pieceTechniqueId, body.child_piece_id);
-      if (cycle) throw new HttpError(409, "BOM_CYCLE", "This line would create a nomenclature cycle");
+      await ensureBomLinkAllowed(client, pieceTechniqueId, body.child_piece_id);
     }
 
     const sets: string[] = [];

--- a/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
+++ b/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
@@ -16,6 +16,7 @@ import {
   deleteOperation,
   duplicatePieceTechnique,
   downloadPieceTechniqueDocument,
+  getPieceTechniqueFabricationTree,
   getPieceTechnique,
   linkPieceTechniqueAffaire,
   listAffairePieceTechniques,
@@ -87,6 +88,7 @@ router.use(authenticateToken)
 router.post("/", validate(createPieceTechniqueSchema), createPieceTechnique)
 router.get("/", listPieceTechniques)
 router.get("/by-affaire/:affaireId", validate(affaireOnlyParamSchema), listAffairePieceTechniques)
+router.get("/:id/arborescence", validate(idParamSchema), getPieceTechniqueFabricationTree)
 router.get("/:id", validate(idParamSchema), getPieceTechnique)
 router.patch("/:id", validate(idParamSchema), validate(updatePieceTechniqueSchema), updatePieceTechnique)
 router.delete("/:id", requireAdmin, validate(idParamSchema), deletePieceTechnique)

--- a/src/module/pieces-techniques/services/pieces-techniques.service.ts
+++ b/src/module/pieces-techniques/services/pieces-techniques.service.ts
@@ -22,6 +22,7 @@ import {
   repoDeleteOperation,
   repoDeletePieceTechnique,
   repoDuplicatePieceTechnique,
+  repoGetFabricationTree,
   repoListAffairePieceTechniques,
   repoGetPieceTechniqueDocumentForDownload,
   repoGetPieceTechnique,
@@ -88,6 +89,8 @@ function isValidTransition(from: PieceTechniqueStatut, to: PieceTechniqueStatut)
 export const listPieceTechniquesSVC = (filters: ListPiecesTechniquesQueryDTO) => repoListPieceTechniques(filters);
 
 export const getPieceTechniqueSVC = (id: string, includes: Set<string>) => repoGetPieceTechnique(id, includes);
+
+export const getPieceTechniqueFabricationTreeSVC = (id: string) => repoGetFabricationTree(id);
 
 export async function createPieceTechniqueSVC(body: CreatePieceTechniqueBodyDTO, audit: AuditContext) {
   const statut = body.statut ?? "DRAFT";

--- a/src/module/pieces-techniques/types/pieces-techniques.types.ts
+++ b/src/module/pieces-techniques/types/pieces-techniques.types.ts
@@ -11,6 +11,42 @@ export type BomLine = {
 
 export type PieceTechniqueStatut = "DRAFT" | "ACTIVE" | "IN_FABRICATION" | "OBSOLETE"
 
+export type FabricationTreeNode = {
+  key: string
+  bom_line_id: string | null
+  parent_piece_technique_id: string | null
+  piece_technique_id: string
+  article_id: string | null
+  code_piece: string
+  designation: string
+  designation_2: string | null
+  statut: PieceTechniqueStatut
+  en_fabrication: boolean
+  ensemble: boolean
+  version_number: number
+  level: number
+  path: string[]
+  ordre_affichage: number
+  quantite_par_parent: number
+  quantite_cumulee: number
+  repere: string | null
+  line_designation: string | null
+  operations_count: number
+  operations_temps_total: number
+  operations_cout_mo: number
+  achats_count: number
+  achats_total_ht: number
+  achats_total_ttc: number
+  children: FabricationTreeNode[]
+}
+
+export type FabricationTreeResponse = {
+  root: FabricationTreeNode
+  nodes: FabricationTreeNode[]
+  total_nodes: number
+  max_depth: number
+}
+
 export type PieceTechniqueHistoryEntry = {
   id: string
   date_action: string

--- a/src/module/production/controllers/production.controller.ts
+++ b/src/module/production/controllers/production.controller.ts
@@ -32,6 +32,7 @@ import {
   svcCreateOrdreFabrication,
   svcCreatePoste,
   svcGetOrdreFabrication,
+  svcGetOrdreFabricationTree,
   svcGetMachine,
   svcGetPoste,
   svcGetOfReceiptContext,
@@ -269,6 +270,16 @@ export const getOrdreFabrication = asyncHandler(async (req, res) => {
   const { id } = ofIdParamSchema.parse({ params: req.params }).params;
   const userId = typeof req.user?.id === "number" ? req.user.id : undefined;
   const out = await svcGetOrdreFabrication({ id, user_id: userId });
+  if (!out) {
+    res.status(404).json({ error: "Not found" });
+    return;
+  }
+  res.json(out);
+});
+
+export const getOrdreFabricationTree = asyncHandler(async (req, res) => {
+  const { id } = ofIdParamSchema.parse({ params: req.params }).params;
+  const out = await svcGetOrdreFabricationTree({ id });
   if (!out) {
     res.status(404).json({ error: "Not found" });
     return;

--- a/src/module/production/repository/production.repository.ts
+++ b/src/module/production/repository/production.repository.ts
@@ -12,6 +12,8 @@ import type {
   OfTimeLog,
   OrdreFabricationDetail,
   OrdreFabricationListItem,
+  OrdreFabricationTree,
+  OrdreFabricationTreeNode,
   Paginated,
   PosteDetail,
   PosteListItem,
@@ -2109,6 +2111,14 @@ async function selectOfHeader(q: DbQueryer, ofId: number): Promise<Omit<OrdreFab
     numero: string;
     affaire_id: string | null;
     commande_id: string | null;
+    parent_of_id: string | null;
+    root_of_id: string | null;
+    generation_batch_id: string | null;
+    generation_level: number;
+    source_bom_line_id: string | null;
+    structure_path: string | null;
+    quantity_per_parent: number;
+    quantity_cumulative: number;
     client_id: string | null;
     client_company_name: string | null;
     production_group_id: string | null;
@@ -2139,6 +2149,14 @@ async function selectOfHeader(q: DbQueryer, ofId: number): Promise<Omit<OrdreFab
         o.numero,
         o.affaire_id::text AS affaire_id,
         o.commande_id::text AS commande_id,
+        o.parent_of_id::text AS parent_of_id,
+        o.root_of_id::text AS root_of_id,
+        o.generation_batch_id::text AS generation_batch_id,
+        o.generation_level::int AS generation_level,
+        o.source_bom_line_id::text AS source_bom_line_id,
+        o.structure_path,
+        o.quantity_per_parent::float8 AS quantity_per_parent,
+        o.quantity_cumulative::float8 AS quantity_cumulative,
         o.client_id,
         c.company_name AS client_company_name,
         o.production_group_id::text AS production_group_id,
@@ -2178,6 +2196,14 @@ async function selectOfHeader(q: DbQueryer, ofId: number): Promise<Omit<OrdreFab
     numero: row.numero,
     affaire_id: toNullableInt(row.affaire_id, "ordres_fabrication.affaire_id"),
     commande_id: toNullableInt(row.commande_id, "ordres_fabrication.commande_id"),
+    parent_of_id: toNullableInt(row.parent_of_id, "ordres_fabrication.parent_of_id"),
+    root_of_id: toNullableInt(row.root_of_id, "ordres_fabrication.root_of_id"),
+    generation_batch_id: row.generation_batch_id,
+    generation_level: Number(row.generation_level),
+    source_bom_line_id: row.source_bom_line_id,
+    structure_path: row.structure_path,
+    quantity_per_parent: Number(row.quantity_per_parent),
+    quantity_cumulative: Number(row.quantity_cumulative),
     client_id: row.client_id,
     client_company_name: row.client_company_name,
     production_group_id: row.production_group_id,
@@ -2551,6 +2577,14 @@ export async function repoListOrdresFabrication(filters: ListOfQueryDTO): Promis
     numero: string;
     affaire_id: string | null;
     commande_id: string | null;
+    parent_of_id: string | null;
+    root_of_id: string | null;
+    generation_batch_id: string | null;
+    generation_level: number;
+    source_bom_line_id: string | null;
+    structure_path: string | null;
+    quantity_per_parent: number;
+    quantity_cumulative: number;
     client_id: string | null;
     client_company_name: string | null;
     production_group_id: string | null;
@@ -2577,6 +2611,14 @@ export async function repoListOrdresFabrication(filters: ListOfQueryDTO): Promis
         o.numero,
         o.affaire_id::text AS affaire_id,
         o.commande_id::text AS commande_id,
+        o.parent_of_id::text AS parent_of_id,
+        o.root_of_id::text AS root_of_id,
+        o.generation_batch_id::text AS generation_batch_id,
+        o.generation_level::int AS generation_level,
+        o.source_bom_line_id::text AS source_bom_line_id,
+        o.structure_path,
+        o.quantity_per_parent::float8 AS quantity_per_parent,
+        o.quantity_cumulative::float8 AS quantity_cumulative,
         o.client_id,
         c.company_name AS client_company_name,
         o.production_group_id::text AS production_group_id,
@@ -2618,6 +2660,14 @@ export async function repoListOrdresFabrication(filters: ListOfQueryDTO): Promis
     numero: r.numero,
     affaire_id: toNullableInt(r.affaire_id, "ordres_fabrication.affaire_id"),
     commande_id: toNullableInt(r.commande_id, "ordres_fabrication.commande_id"),
+    parent_of_id: toNullableInt(r.parent_of_id, "ordres_fabrication.parent_of_id"),
+    root_of_id: toNullableInt(r.root_of_id, "ordres_fabrication.root_of_id"),
+    generation_batch_id: r.generation_batch_id,
+    generation_level: Number(r.generation_level),
+    source_bom_line_id: r.source_bom_line_id,
+    structure_path: r.structure_path,
+    quantity_per_parent: Number(r.quantity_per_parent),
+    quantity_cumulative: Number(r.quantity_cumulative),
     client_id: r.client_id,
     client_company_name: r.client_company_name,
     production_group_id: r.production_group_id,
@@ -2650,6 +2700,188 @@ export async function repoGetOrdreFabrication(params: {
   const operations = await selectOfOperations(pool, { of_id: params.id, user_id: params.user_id });
 
   return { ...header, operations };
+}
+
+type OfTreeRow = {
+  key: string;
+  parent_key: string | null;
+  id: string;
+  numero: string;
+  affaire_id: string | null;
+  commande_id: string | null;
+  parent_of_id: string | null;
+  root_of_id: string | null;
+  generation_batch_id: string | null;
+  generation_level: number;
+  source_bom_line_id: string | null;
+  structure_path: string | null;
+  quantity_per_parent: number;
+  quantity_cumulative: number;
+  client_id: string | null;
+  client_company_name: string | null;
+  production_group_id: string | null;
+  production_group_code: string | null;
+  piece_technique_id: string;
+  piece_code: string;
+  piece_designation: string;
+  quantite_lancee: number;
+  quantite_bonne: number;
+  quantite_rebut: number;
+  statut: OrdreFabricationListItem["statut"];
+  priority: OrdreFabricationListItem["priority"];
+  date_lancement_prevue: string | null;
+  date_fin_prevue: string | null;
+  updated_at: string;
+  total_ops: number;
+  done_ops: number;
+};
+
+function mapOfTreeRow(row: OfTreeRow): OrdreFabricationTreeNode {
+  return {
+    id: toInt(row.id, "ordres_fabrication.id"),
+    numero: row.numero,
+    affaire_id: toNullableInt(row.affaire_id, "ordres_fabrication.affaire_id"),
+    commande_id: toNullableInt(row.commande_id, "ordres_fabrication.commande_id"),
+    parent_of_id: toNullableInt(row.parent_of_id, "ordres_fabrication.parent_of_id"),
+    root_of_id: toNullableInt(row.root_of_id, "ordres_fabrication.root_of_id"),
+    generation_batch_id: row.generation_batch_id,
+    generation_level: Number(row.generation_level),
+    source_bom_line_id: row.source_bom_line_id,
+    structure_path: row.structure_path,
+    quantity_per_parent: Number(row.quantity_per_parent),
+    quantity_cumulative: Number(row.quantity_cumulative),
+    client_id: row.client_id,
+    client_company_name: row.client_company_name,
+    production_group_id: row.production_group_id,
+    production_group_code: row.production_group_code,
+    piece_technique_id: row.piece_technique_id,
+    piece_code: row.piece_code,
+    piece_designation: row.piece_designation,
+    quantite_lancee: Number(row.quantite_lancee),
+    quantite_bonne: Number(row.quantite_bonne),
+    quantite_rebut: Number(row.quantite_rebut),
+    statut: row.statut,
+    priority: row.priority,
+    date_lancement_prevue: row.date_lancement_prevue,
+    date_fin_prevue: row.date_fin_prevue,
+    updated_at: row.updated_at,
+    total_ops: Number(row.total_ops),
+    done_ops: Number(row.done_ops),
+    children: [],
+  };
+}
+
+export async function repoGetOrdreFabricationTree(id: number): Promise<OrdreFabricationTree | null> {
+  const res = await pool.query<OfTreeRow>(
+    `
+      WITH RECURSIVE root AS (
+        SELECT COALESCE(root_of_id, id)::bigint AS root_id
+        FROM ordres_fabrication
+        WHERE id = $1::bigint
+        LIMIT 1
+      ),
+      tree AS (
+        SELECT
+          o.*,
+          ARRAY[o.id]::bigint[] AS path_ids,
+          0::int AS depth
+        FROM ordres_fabrication o
+        JOIN root r ON r.root_id = o.id
+
+        UNION ALL
+
+        SELECT
+          child.*,
+          tree.path_ids || child.id,
+          tree.depth + 1
+        FROM tree
+        JOIN ordres_fabrication child ON child.parent_of_id = tree.id
+        WHERE tree.depth < 50
+          AND NOT child.id = ANY(tree.path_ids)
+      ),
+      enriched AS (
+        SELECT
+          array_to_string(path_ids::text[], '/') AS key,
+          CASE
+            WHEN array_length(path_ids, 1) > 1
+              THEN array_to_string(path_ids[1:(array_length(path_ids, 1) - 1)]::text[], '/')
+            ELSE NULL
+          END AS parent_key,
+          t.*
+        FROM tree t
+      )
+      SELECT
+        e.key,
+        e.parent_key,
+        e.id::text AS id,
+        e.numero,
+        e.affaire_id::text AS affaire_id,
+        e.commande_id::text AS commande_id,
+        e.parent_of_id::text AS parent_of_id,
+        e.root_of_id::text AS root_of_id,
+        e.generation_batch_id::text AS generation_batch_id,
+        e.generation_level::int AS generation_level,
+        e.source_bom_line_id::text AS source_bom_line_id,
+        e.structure_path,
+        e.quantity_per_parent::float8 AS quantity_per_parent,
+        e.quantity_cumulative::float8 AS quantity_cumulative,
+        e.client_id,
+        c.company_name AS client_company_name,
+        e.production_group_id::text AS production_group_id,
+        pg.code AS production_group_code,
+        e.piece_technique_id::text AS piece_technique_id,
+        pt.code_piece AS piece_code,
+        pt.designation AS piece_designation,
+        e.quantite_lancee::float8 AS quantite_lancee,
+        e.quantite_bonne::float8 AS quantite_bonne,
+        e.quantite_rebut::float8 AS quantite_rebut,
+        e.statut::text AS statut,
+        e.priority::text AS priority,
+        e.date_lancement_prevue::text AS date_lancement_prevue,
+        e.date_fin_prevue::text AS date_fin_prevue,
+        e.updated_at::text AS updated_at,
+        COALESCE(ops.total_ops, 0)::int AS total_ops,
+        COALESCE(ops.done_ops, 0)::int AS done_ops
+      FROM enriched e
+      JOIN pieces_techniques pt ON pt.id = e.piece_technique_id
+      LEFT JOIN clients c ON c.client_id = e.client_id
+      LEFT JOIN production_group pg ON pg.id = e.production_group_id
+      LEFT JOIN LATERAL (
+        SELECT
+          COUNT(*) AS total_ops,
+          COUNT(*) FILTER (WHERE op.status = 'DONE') AS done_ops
+        FROM of_operations op
+        WHERE op.of_id = e.id
+      ) ops ON TRUE
+      ORDER BY e.path_ids ASC
+    `,
+    [id]
+  );
+
+  if (!res.rows.length) return null;
+
+  const nodes = res.rows.map(mapOfTreeRow);
+  const byKey = new Map(nodes.map((node, index) => [res.rows[index].key, node] as const));
+  let root: OrdreFabricationTreeNode | null = null;
+
+  for (const row of res.rows) {
+    const node = byKey.get(row.key);
+    if (!node) continue;
+    if (!row.parent_key) {
+      root = node;
+      continue;
+    }
+    byKey.get(row.parent_key)?.children.push(node);
+  }
+
+  if (!root) return null;
+
+  return {
+    root,
+    nodes,
+    total_nodes: nodes.length,
+    max_depth: nodes.reduce((max, node) => Math.max(max, node.generation_level), 0),
+  };
 }
 
 export async function repoCreateOrdreFabrication(params: {
@@ -2685,6 +2917,12 @@ export async function repoCreateOrdreFabrication(params: {
           numero,
           affaire_id,
           commande_id,
+          parent_of_id,
+          root_of_id,
+          generation_level,
+          structure_path,
+          quantity_per_parent,
+          quantity_cumulative,
           client_id,
           piece_technique_id,
           quantite_lancee,
@@ -2701,6 +2939,12 @@ export async function repoCreateOrdreFabrication(params: {
           $2,
           $3::bigint,
           $4::bigint,
+          NULL::bigint,
+          $1::bigint,
+          0,
+          $1::text,
+          1,
+          1,
           $5,
           $6::uuid,
           $7,
@@ -2750,7 +2994,8 @@ export async function repoCreateOrdreFabrication(params: {
           coef,
           temps_total_planned,
           status,
-          notes
+          notes,
+          source_piece_operation_id
         )
         SELECT
           $1::bigint AS of_id,
@@ -2766,7 +3011,8 @@ export async function repoCreateOrdreFabrication(params: {
           COALESCE(pto.coef, 1)::numeric(10,3) AS coef,
           ROUND((COALESCE(pto.tp,0) + COALESCE(pto.tf_unit,0) * COALESCE(pto.qte,1)) * COALESCE(pto.coef,1), 3)::numeric(12,3) AS temps_total_planned,
           'TODO'::of_operation_status AS status,
-          pto.designation_2 AS notes
+          pto.designation_2 AS notes,
+          pto.id AS source_piece_operation_id
         FROM pieces_techniques_operations pto
         WHERE pto.piece_technique_id = $2::uuid
         ORDER BY pto.phase ASC, pto.id ASC

--- a/src/module/production/routes/production.routes.ts
+++ b/src/module/production/routes/production.routes.ts
@@ -14,6 +14,7 @@ import {
   getOfReceiptContext,
   getOfTraceability,
   getOrdreFabrication,
+  getOrdreFabricationTree,
   getMachine,
   getPoste,
   listOrdresFabrication,
@@ -113,6 +114,7 @@ router.delete("/postes/:id", requireAdmin, archivePoste);
 
 // OF
 router.get("/ofs", listOrdresFabrication);
+router.get("/ofs/:id/tree", getOrdreFabricationTree);
 router.get("/ofs/:id", getOrdreFabrication);
 router.post("/ofs", createOrdreFabrication);
 router.patch("/ofs/:id", updateOrdreFabrication);

--- a/src/module/production/services/production.service.ts
+++ b/src/module/production/services/production.service.ts
@@ -68,6 +68,8 @@ export const svcListOrdresFabrication = (filters: ListOfQueryDTO) => repo.repoLi
 export const svcGetOrdreFabrication = (params: { id: number; user_id?: number }) =>
   repo.repoGetOrdreFabrication(params);
 
+export const svcGetOrdreFabricationTree = (params: { id: number }) => repo.repoGetOrdreFabricationTree(params.id);
+
 export const svcCreateOrdreFabrication = (params: { body: CreateOfBodyDTO; audit: repo.AuditContext }) =>
   repo.repoCreateOrdreFabrication(params);
 

--- a/src/module/production/types/production.types.ts
+++ b/src/module/production/types/production.types.ts
@@ -86,6 +86,14 @@ export type OrdreFabricationListItem = {
   numero: string;
   affaire_id: number | null;
   commande_id: number | null;
+  parent_of_id: number | null;
+  root_of_id: number | null;
+  generation_batch_id: string | null;
+  generation_level: number;
+  source_bom_line_id: string | null;
+  structure_path: string | null;
+  quantity_per_parent: number;
+  quantity_cumulative: number;
   client_id: string | null;
   client_company_name: string | null;
   production_group_id: string | null;
@@ -150,6 +158,14 @@ export type OrdreFabricationDetail = {
   numero: string;
   affaire_id: number | null;
   commande_id: number | null;
+  parent_of_id: number | null;
+  root_of_id: number | null;
+  generation_batch_id: string | null;
+  generation_level: number;
+  source_bom_line_id: string | null;
+  structure_path: string | null;
+  quantity_per_parent: number;
+  quantity_cumulative: number;
   client_id: string | null;
   client_company_name: string | null;
   production_group_id: string | null;
@@ -172,4 +188,18 @@ export type OrdreFabricationDetail = {
   created_by: number | null;
   updated_by: number | null;
   operations: OfOperation[];
+};
+
+export type OrdreFabricationTreeNode = Omit<OrdreFabricationListItem, "updated_at" | "total_ops" | "done_ops"> & {
+  updated_at: string;
+  total_ops: number;
+  done_ops: number;
+  children: OrdreFabricationTreeNode[];
+};
+
+export type OrdreFabricationTree = {
+  root: OrdreFabricationTreeNode;
+  nodes: OrdreFabricationTreeNode[];
+  total_nodes: number;
+  max_depth: number;
 };

--- a/src/swagger/swagger.ts
+++ b/src/swagger/swagger.ts
@@ -1,6 +1,4 @@
-import { OpenAPIV3_1 } from 'openapi-types';
-
-export const swaggerSpec: OpenAPIV3_1.Document = {
+export const swaggerSpec = {
   openapi: '3.0.3',
   info: {
     title: 'CERP API',


### PR DESCRIPTION
Promotes the current dev integration branch to main. Includes issue #55 recursive fabrication tree backend changes, database patch, OF hierarchy generation, and integration updates. Validate before merge because main may trigger production-facing workflows.

## Summary by Sourcery

Implement recursive fabrication tree and hierarchical ordre de fabrication generation with corresponding database structures and APIs.

New Features:
- Add recursive fabrication tree queries for pieces techniques and expose them via new API endpoints.
- Introduce recursive generation of hierarchical ordres de fabrication from client orders, including batch tracking and structure snapshots.
- Provide API to retrieve an ordre de fabrication tree with progress metrics per node.

Enhancements:
- Extend ordre de fabrication models, repositories, and services with parent/root metadata, BOM source references, and quantity propagation fields.
- Harden BOM maintenance by preventing self-links and cyclic fabrication trees and reusing shared validation logic.
- Link OF operations back to their source piece technique operations for traceability.

Documentation:
- Document the new recursive fabrication tree and OF hierarchy database structures in the database patches guide.

Tests:
- Extend commande generation tests to cover recursive OF tree creation and add route tests for fabrication tree behavior.