### PR TITLE
fix: bound postgres waits before proxy timeout

### DIFF
--- a/.env_exemple
+++ b/.env_exemple
@@ -8,6 +8,15 @@ CERP_EXPORTS_ROOT=/srv/cerp/data/exports
 CERP_TMP_ROOT=/srv/cerp/data/tmp
 CERP_IMAGES_ROOT=/srv/cerp/data/generated/images
 DATABASE_URL=postgresql://cerp_app:SECRET@127.0.0.1:5432/cerp_prod
+# PostgreSQL pool guardrails. Keep these below the reverse-proxy timeout.
+PG_POOL_MAX=10
+PG_CONNECTION_TIMEOUT_MS=5000
+PG_IDLE_TIMEOUT_MS=30000
+PG_MAX_LIFETIME_SECONDS=300
+PG_STATEMENT_TIMEOUT_MS=20000
+PG_QUERY_TIMEOUT_MS=25000
+PG_LOCK_TIMEOUT_MS=5000
+PG_IDLE_TX_TIMEOUT_MS=15000
 BACKEND_URL=http://10.90.0.2:8080
 JWT_SECRET=un_secret_jwt_fort
 JWT_EXPIRES_IN=8h

--- a/INSTRUCTIONS_BACKEND.md
+++ b/INSTRUCTIONS_BACKEND.md
@@ -82,6 +82,15 @@ Env var names observed in code (names only):
   - `src/middlewares/upload.ts` (upload destination selection)
   - `src/utils/checkNetworkDrive.ts` (network path checks)
 - `DATABASE_URL` (PostgreSQL connection string) in `src/config/database.ts`
+- PostgreSQL pool guardrails in `src/config/database.ts`:
+  - `PG_POOL_MAX`
+  - `PG_CONNECTION_TIMEOUT_MS`
+  - `PG_IDLE_TIMEOUT_MS`
+  - `PG_MAX_LIFETIME_SECONDS`
+  - `PG_STATEMENT_TIMEOUT_MS`
+  - `PG_QUERY_TIMEOUT_MS`
+  - `PG_LOCK_TIMEOUT_MS`
+  - `PG_IDLE_TX_TIMEOUT_MS`
 - `JWT_SECRET` (JWT signing/verifying secret) in:
   - `src/module/auth/middlewares/auth.middleware.ts`
   - `src/module/auth/services/auth.service.ts`
@@ -218,6 +227,7 @@ Security guard rails:
 Database:
 
 - Pool is created in `src/config/database.ts` using `process.env.DATABASE_URL`.
+- Pool waits and SQL execution are bounded by env-configurable defaults so database pressure fails before the reverse proxy returns a generic 504. Keep `PG_STATEMENT_TIMEOUT_MS` and `PG_QUERY_TIMEOUT_MS` below the VPS/reverse-proxy timeout.
 - Repositories/services use `pool.query(...)` or `pool.connect()` for transactions.
 - Transaction pattern: `BEGIN` / `COMMIT` / `ROLLBACK` with `finally { client.release() }` (example: `src/module/client/repository/client.repository.ts`).
 

--- a/src/__tests__/db.test.ts
+++ b/src/__tests__/db.test.ts
@@ -1,61 +1,126 @@
-import { describe, test, vi, expect, beforeEach, afterAll } from 'vitest'
+import { describe, test, vi, expect, beforeEach, afterEach, afterAll } from 'vitest'
 import { EventEmitter } from 'events'
 
-// Mock de pg.Pool avec un EventEmitter
 vi.mock('pg', () => {
     const emitter = new EventEmitter()
 
     return {
         Pool: vi.fn(() => emitter),
-        __emitter__: emitter, // Pour déclencher manuellement les événements
+        __emitter__: emitter,
     }
 })
 
-import dotenv from 'dotenv'
-dotenv.config()
+const ENV_KEYS = [
+    'DATABASE_URL',
+    'PG_POOL_MAX',
+    'PG_CONNECTION_TIMEOUT_MS',
+    'PG_IDLE_TIMEOUT_MS',
+    'PG_MAX_LIFETIME_SECONDS',
+    'PG_STATEMENT_TIMEOUT_MS',
+    'PG_QUERY_TIMEOUT_MS',
+    'PG_LOCK_TIMEOUT_MS',
+    'PG_IDLE_TX_TIMEOUT_MS',
+] as const
+
+const originalEnv = ENV_KEYS.reduce<Record<string, string | undefined>>((acc, key) => {
+    acc[key] = process.env[key]
+    return acc
+}, {})
+
+function restoreEnv() {
+    for (const key of ENV_KEYS) {
+        const original = originalEnv[key]
+        if (typeof original === 'undefined') {
+            delete process.env[key]
+        } else {
+            process.env[key] = original
+        }
+    }
+}
 
 describe('Connexion PostgreSQL', () => {
     beforeEach(() => {
+        vi.resetModules()
         vi.clearAllMocks()
+        restoreEnv()
     })
 
-    test('✅ Initialise correctement Pool avec DATABASE_URL', async () => {
+    afterEach(() => {
+        vi.restoreAllMocks()
+        restoreEnv()
+    })
+
+    test('initialise Pool avec DATABASE_URL et timeouts bornes', async () => {
         process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test'
         const { Pool } = await import('pg')
-        const poolModule = await import('../config/database') // adapte si besoin
+        const poolModule = await import('../config/database')
 
         expect(Pool).toHaveBeenCalledWith({
             connectionString: process.env.DATABASE_URL,
+            max: 10,
+            connectionTimeoutMillis: 5_000,
+            idleTimeoutMillis: 30_000,
+            maxLifetimeSeconds: 300,
+            statement_timeout: 20_000,
+            query_timeout: 25_000,
+            lock_timeout: 5_000,
+            idle_in_transaction_session_timeout: 15_000,
         })
 
         expect(poolModule.default).toBeDefined()
     })
 
-    test('🟢 Événement connect déclenche log', async () => {
+    test('utilise les overrides env valides et ignore les valeurs invalides', async () => {
+        process.env.DATABASE_URL = 'postgresql://user:pass@localhost:5432/test'
+        process.env.PG_POOL_MAX = '16'
+        process.env.PG_CONNECTION_TIMEOUT_MS = '7000'
+        process.env.PG_IDLE_TIMEOUT_MS = '45000'
+        process.env.PG_MAX_LIFETIME_SECONDS = '600'
+        process.env.PG_STATEMENT_TIMEOUT_MS = '30000'
+        process.env.PG_QUERY_TIMEOUT_MS = 'not-a-number'
+        process.env.PG_LOCK_TIMEOUT_MS = '-1'
+        process.env.PG_IDLE_TX_TIMEOUT_MS = '12000'
+
+        const { Pool } = await import('pg')
+        await import('../config/database')
+
+        expect(Pool).toHaveBeenCalledWith({
+            connectionString: process.env.DATABASE_URL,
+            max: 16,
+            connectionTimeoutMillis: 7_000,
+            idleTimeoutMillis: 45_000,
+            maxLifetimeSeconds: 600,
+            statement_timeout: 30_000,
+            query_timeout: 25_000,
+            lock_timeout: 5_000,
+            idle_in_transaction_session_timeout: 12_000,
+        })
+    })
+
+    test('evenement connect declenche log', async () => {
         const logSpy = vi.spyOn(console, 'log').mockImplementation(() => { })
 
         const pg = await import('pg')
         await import('../config/database')
 
-            ; (pg as any).__emitter__.emit('connect')
+        ; (pg as any).__emitter__.emit('connect')
 
         expect(logSpy).toHaveBeenCalledWith('🟢 Connecté à PostgreSQL avec succès')
     })
 
-    test('❌ Événement error déclenche erreur console', async () => {
+    test('evenement error declenche erreur console', async () => {
         const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => { })
 
         const pg = await import('pg')
         await import('../config/database')
 
         const fakeError = new Error('Connexion refusée')
-            ; (pg as any).__emitter__.emit('error', fakeError)
+        ; (pg as any).__emitter__.emit('error', fakeError)
 
         expect(errorSpy).toHaveBeenCalledWith('❌ Erreur de connexion PostgreSQL', fakeError)
     })
+
     afterAll(() => {
         console.log('\n✅ Connexion PostgreSQL : tous les tests sont OK 🟢\n')
     })
 })
-
-

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -3,8 +3,24 @@ import dotenv from 'dotenv';
 
 dotenv.config();
 
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
+  max: readPositiveIntEnv('PG_POOL_MAX', 10),
+  connectionTimeoutMillis: readPositiveIntEnv('PG_CONNECTION_TIMEOUT_MS', 5_000),
+  idleTimeoutMillis: readPositiveIntEnv('PG_IDLE_TIMEOUT_MS', 30_000),
+  maxLifetimeSeconds: readPositiveIntEnv('PG_MAX_LIFETIME_SECONDS', 300),
+  statement_timeout: readPositiveIntEnv('PG_STATEMENT_TIMEOUT_MS', 20_000),
+  query_timeout: readPositiveIntEnv('PG_QUERY_TIMEOUT_MS', 25_000),
+  lock_timeout: readPositiveIntEnv('PG_LOCK_TIMEOUT_MS', 5_000),
+  idle_in_transaction_session_timeout: readPositiveIntEnv('PG_IDLE_TX_TIMEOUT_MS', 15_000),
 });
 
 pool.on('connect', () => {


### PR DESCRIPTION
## What changed

- Added bounded PostgreSQL pool and query timeouts in `src/config/database.ts`.
- Documented the new runtime knobs in `.env_exemple` and `INSTRUCTIONS_BACKEND.md`.
- Updated DB config tests to cover defaults and environment overrides.

## Why

CERP Desktop intermittently received `504 Gateway Timeout` on proxied `/api/v1` calls. The Electron frontend only relays the upstream response, while the backend PostgreSQL pool previously had no explicit wait/query bounds. Under DB pressure or lock waits, requests could hang until the VPS reverse proxy returned a generic 504.

## Validation

- `npm run test:run -- src/__tests__/db.test.ts`
- `npm run test:run`
- `npm run build`
- Read-only public smoke: `/api/v1` and `/api/v1/clients?limit=1` returned 200 after the local fix was prepared.

Closes #25

## Summary by Sourcery

Bound PostgreSQL pool waits and query timeouts via new env-configurable defaults to reduce backend requests hanging until reverse proxy timeouts.

New Features:
- Introduce configurable PostgreSQL pool and query timeout guardrails via new environment variables.

Enhancements:
- Add helper for reading positive integer environment variables with sane fallbacks in database configuration.
- Document new PostgreSQL pool-related environment variables and timeout guidance in backend instructions and example env file.

Tests:
- Expand PostgreSQL connection tests to cover default timeout configuration, environment overrides, and logging behavior while ensuring env isolation between cases.