### PR TITLE
fix(security): bloque l'escalade de privilèges via /auth/register public

### DIFF
--- a/src/module/auth/controllers/auth.controller.ts
+++ b/src/module/auth/controllers/auth.controller.ts
@@ -8,7 +8,11 @@ import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 export const register = asyncHandler(async (req: Request, res: Response) => {
   const validated = registerSchema.parse(req.body);
 
-  const user = await registerUser(validated);
+  // Sécurité (ISO A.5.15 / A.8.2) : l'inscription publique ne doit JAMAIS permettre
+  // l'auto-attribution d'un rôle. Tout `role` fourni par le client est ignoré et forcé
+  // à "Employee". La création de comptes avec rôle privilégié passe exclusivement par
+  // le module admin (POST /admin/users, protégé par authenticateToken + authorizeRole).
+  const user = await registerUser({ ...validated, role: "Employee" });
 
   return res.status(201).json({
     message: "Utilisateur créé avec succès",


### PR DESCRIPTION
## 🔴 Sécurité — Escalade de privilèges (critique)

### Vulnérabilité
`POST /auth/register` est **public** (aucune auth) et le schéma acceptait un champ `role` parmi l'enum complet (`.default("Employee")`). Un appelant **anonyme** pouvait donc créer un compte `"Administrateur Systeme et Reseau"` ou `"Directeur"` → **escalade de privilèges** (CWE-269).

### Correctif
`role` est désormais **forcé à `"Employee"`** sur l'inscription publique (toute valeur client ignorée). La création de comptes avec rôle privilégié passe exclusivement par le module admin `POST /admin/users` (protégé `authenticateToken` + `authorizeRole`, schéma séparé `adminCreateUserSchema` — **non impacté**).

### Impact
- Aucun impact sur l'onboarding admin (chemin séparé et protégé).
- Aucun impact sur l'inscription légitime (les nouveaux comptes obtiennent `Employee`, comportement attendu).

### Tests
- `tsc --noEmit` ✅ · `vitest run` ✅ **121 tests** (aucune régression — aucun test ne dépendait du comportement vulnérable).

### Rollback
`git revert` du commit.

### Suivi (hors périmètre de cette PR — voir `/compliance/iso27001` actions correctives)
- 10 modules backend sans `authenticateToken` (banking-info, paiements, avoirs, devis…) + CRUD commande public → socle *default-deny* à ajouter (**CA-SEC-01**).
- Pas de rate-limit login / MFA (**CA-SEC-02**).
- Logs d'audit sans protection anti-altération (**CA-SEC-03**).

ISO/IEC 27001:2022 : **A.5.15**, **A.8.2**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Bug Fixes:
- Prevent privilege escalation by forcing newly registered public users to be created with the Employee role regardless of client input.