### PR TITLE
fix(security): socle default-deny d'authentification sur /api/v1 (CA-SEC-01)

### DIFF
--- a/src/__tests__/auth-baseline.routes.test.ts
+++ b/src/__tests__/auth-baseline.routes.test.ts
@@ -1,0 +1,42 @@
+import request from "supertest";
+import { describe, it, expect, vi } from "vitest";
+
+// NOTE: on ne mocke PAS auth.middleware ici — on veut le vrai comportement default-deny.
+vi.mock("pg", () => {
+  const pool = { on: vi.fn(), query: vi.fn(), connect: vi.fn() };
+  return { Pool: vi.fn(() => pool) };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+import app from "../config/app";
+
+describe("Socle default-deny d'authentification (ISO/IEC 27001 A.5.15 / A.8.3)", () => {
+  it("refuse les routes protégées sans token (401)", async () => {
+    const protectedGets = [
+      "/api/v1/clients",
+      "/api/v1/banking-info",
+      "/api/v1/devis",
+      "/api/v1/paiements",
+      "/api/v1/avoirs",
+      "/api/v1/commandes",
+    ];
+    for (const path of protectedGets) {
+      const res = await request(app).get(path);
+      expect(res.status, `GET ${path} doit exiger un token`).toBe(401);
+    }
+  });
+
+  it("refuse les mutations protégées sans token (401)", async () => {
+    const res = await request(app).post("/api/v1/commandes").send({});
+    expect(res.status).toBe(401);
+  });
+
+  it("laisse les routes /auth publiques (pas derrière le socle)", async () => {
+    // Corps vide => 400 de validation, PAS 401 : prouve que la route est atteignable sans token.
+    const res = await request(app).post("/api/v1/auth/login").send({});
+    expect(res.status).not.toBe(401);
+  });
+});

--- a/src/__tests__/devis.routes.test.ts
+++ b/src/__tests__/devis.routes.test.ts
@@ -39,6 +39,14 @@ vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
 }));
 
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (req: { user?: { id: number; username: string; email: string; role: string } }, _res: unknown, next: () => void) => {
+    req.user = { id: 1, username: "test-admin", email: "admin@example.test", role: "administrateur" };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app";
 
 beforeEach(() => {

--- a/src/__tests__/fournisseurs.routes.test.ts
+++ b/src/__tests__/fournisseurs.routes.test.ts
@@ -34,6 +34,14 @@ vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
 }))
 
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (req: { user?: { id: number; username: string; email: string; role: string } }, _res: unknown, next: () => void) => {
+    req.user = { id: 1, username: "test-admin", email: "admin@example.test", role: "administrateur" };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app"
 
 beforeEach(() => {

--- a/src/__tests__/metrologie.routes.test.ts
+++ b/src/__tests__/metrologie.routes.test.ts
@@ -34,6 +34,14 @@ vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
 }))
 
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (req: { user?: { id: number; username: string; email: string; role: string } }, _res: unknown, next: () => void) => {
+    req.user = { id: 1, username: "test-admin", email: "admin@example.test", role: "administrateur" };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app"
 
 beforeEach(() => {

--- a/src/__tests__/outils.routes.test.ts
+++ b/src/__tests__/outils.routes.test.ts
@@ -34,6 +34,14 @@ vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
 }))
 
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (req: { user?: { id: number; username: string; email: string; role: string } }, _res: unknown, next: () => void) => {
+    req.user = { id: 1, username: "test-admin", email: "admin@example.test", role: "administrateur" };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app"
 
 beforeEach(() => {

--- a/src/__tests__/qualite.routes.test.ts
+++ b/src/__tests__/qualite.routes.test.ts
@@ -34,6 +34,14 @@ vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
 }))
 
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (req: { user?: { id: number; username: string; email: string; role: string } }, _res: unknown, next: () => void) => {
+    req.user = { id: 1, username: "test-admin", email: "admin@example.test", role: "administrateur" };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app"
 
 beforeEach(() => {

--- a/src/__tests__/receptions.routes.test.ts
+++ b/src/__tests__/receptions.routes.test.ts
@@ -34,6 +34,14 @@ vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
 }))
 
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (req: { user?: { id: number; username: string; email: string; role: string } }, _res: unknown, next: () => void) => {
+    req.user = { id: 1, username: "test-admin", email: "admin@example.test", role: "administrateur" };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app"
 
 beforeEach(() => {

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -1,6 +1,7 @@
 // src/routes/v1.routes.ts
 import { Router } from "express"
 import authRoutes from "../module/auth/routes/auth.routes"
+import { authenticateToken } from "../module/auth/middlewares/auth.middleware"
 import outilRoutes from "../module/outils/routes/outil.routes"
 import bankingInfoRoutes from "../module/banking-info/routes/banking-info.routes"
 import commandeClientRoutes from "../module/commande-client/routes/commande-client.routes"
@@ -39,7 +40,14 @@ import asbuiltRoutes from "../module/asbuilt/routes/asbuilt.routes"
 import locksRoutes from "../module/locks/routes/locks.routes"
 const router = Router()
 
+// --- Routes publiques (avant authentification) ---
 router.use("/auth", authRoutes)
+
+// 🔒 Socle default-deny (ISO/IEC 27001 A.5.15 / A.8.3) : toute route sous /api/v1
+// définie APRÈS cette ligne exige un JWT valide. Les modules conservent en plus leurs
+// gardes authorizeRole plus fines. Tout nouveau module est protégé par défaut.
+router.use(authenticateToken)
+
 router.use("/outils", outilRoutes)
 router.use("/banking-info", bankingInfoRoutes)  
 router.use("/commandes", commandeClientRoutes) // ✅  


### PR DESCRIPTION
## 🔴 Sécurité — Modules exposés sans authentification (CA-SEC-01)

### Vulnérabilité
~10 modules (`banking-info` IBAN/RIB, `paiements`, `avoirs`, `tarification`, `reporting`, `devis`, `biller`, `payment-mode`, `pieces-families`, `centre-frais`) **et le CRUD commande core** étaient joignables **sans aucune authentification** (lecture/écriture de données financières par quiconque sur le réseau).

### Correctif
Socle **default-deny** dans `v1.routes.ts` : `router.use(authenticateToken)` monté **après** les routes publiques `/auth`, donc toute route `/api/v1` exige un JWT valide par défaut. Les modules conservent leurs gardes `authorizeRole` plus fines. Tout futur module est protégé automatiquement.

### Non-régression
Le front envoie déjà le JWT sur **toutes** les requêtes (`http.ts:119`) → les flux connectés ne sont pas impactés. `GET /` et `GET /api/v1` (health-poll) restent publics (hors v1Router).

### Tests
- 6 tests de routes (devis, fournisseurs, metrologie, outils, qualite, receptions) reçoivent le mock auth standard.
- **Nouveau test positif** `auth-baseline.routes.test.ts` : route protégée sans token → **401** ; `/auth/login` → 400 (public).
- `tsc --noEmit` ✅ · `vitest run` ✅ **124 tests** (30 fichiers).

### Rollback
`git revert`.

ISO/IEC 27001:2022 : **A.5.15**, **A.8.3**. Débloque partiellement A.8.2/A.8.5 (voir CA-SEC-02 rate-limit/MFA à suivre).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enforce default-deny JWT authentication on all /api/v1 routes while keeping /auth endpoints public.

Bug Fixes:
- Protect previously unauthenticated financial and core order modules under a global authentication middleware on the v1 router.

Enhancements:
- Add a baseline test suite verifying that protected /api/v1 routes return 401 without a token and that /auth remains publicly reachable.
- Update existing route tests to standardize mocking of the authentication middleware so they continue to run against secured endpoints.