### PR TITLE
ci(backend): portail qualité (typecheck + tests) + gate du déploiement prod (CA-DEV-01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: ✅ Backend CI (quality gate)
+
+# Portail qualité backend (ISO/IEC 27001 A.8.25 dev sécurisé, A.8.29 tests, A.8.32 changements).
+# Le backend se déployait jusqu'ici sans aucune vérification automatisée (deploy.yml = restart SSH seul).
+
+on:
+  pull_request:
+    branches: [dev, main]
+  push:
+    branches: [dev, main]
+
+jobs:
+  verify:
+    name: Typecheck + tests
+    runs-on: ubuntu-latest
+    env:
+      # Placeholders : les tests mockent `pg` ; ces valeurs évitent tout throw à l'import.
+      DATABASE_URL: postgres://ci:ci@localhost:5432/ci
+      JWT_SECRET: ci-test-secret-not-used-in-prod
+      NODE_ENV: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck (tsc --noEmit)
+        run: npx tsc -p tsconfig.json --noEmit
+
+      - name: Unit & integration tests (vitest)
+        run: npm run test:run

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,8 +6,32 @@ on:
       - main
 
 jobs:
+  # 🔒 Portail qualité : le déploiement prod est bloqué si typecheck/tests échouent (ISO A.8.25/A.8.32).
+  verify:
+    name: Verify (typecheck + tests) before deploy
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: postgres://ci:ci@localhost:5432/ci
+      JWT_SECRET: ci-test-secret-not-used-in-prod
+      NODE_ENV: test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Typecheck (tsc --noEmit)
+        run: npx tsc -p tsconfig.json --noEmit
+      - name: Unit & integration tests (vitest)
+        run: npm run test:run
+
   deploy:
     name: Deploy via SSH to VPS
+    needs: verify
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
## Gouvernance — Backend déployé sans vérification (CA-DEV-01)

### Problème
`erp-crp-backend/.github/workflows/deploy.yml` ne faisait qu'un **restart SSH** sur push→main : **aucun lint/typecheck/test** avant la prod, alors qu'un harness vitest (124 tests) existe. Plus fort levier de gouvernance.

### Correctif
- **Nouveau `ci.yml`** : `tsc --noEmit` + `vitest run` sur chaque **PR** et **push** vers `dev`/`main` (bloquant).
- **`deploy.yml`** : job `verify` (typecheck + tests) ajouté, et `deploy` en dépend (`needs: verify`) → **le déploiement prod est bloqué si les checks échouent**.
- Variables d'env placeholder pour la CI (les tests mockent `pg` ; aucun secret réel).

### Note
Le backend n'a pas d'ESLint configuré → lint non inclus (à ajouter ultérieurement). Secret-scan backend non inclus (le scan existe côté front) → suivi CA-DEV-04.

### Vérification
YAML validé (parse OK). Les tests tournent déjà verts en local (124).

ISO/IEC 27001:2022 : **A.8.25**, **A.8.29**, **A.8.32**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a backend CI quality gate and enforce automated verification before production deployment.

CI:
- Add a backend CI workflow that runs TypeScript typechecking and vitest tests on every pull request and pushes to dev/main branches.
- Update the deploy workflow to run a verify job (typecheck + tests) and require it to succeed before triggering the SSH-based production deployment.