### PR TITLE
fix(devis): recalcul serveur des totaux (source de vérité, CA-APP-01)

### DIFF
--- a/src/module/devis/lib/totals.test.ts
+++ b/src/module/devis/lib/totals.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { computeLineTotals, computeDevisTotals } from "./totals";
+
+describe("devis totals (recalcul serveur — ISO A.8.28)", () => {
+  it("calcule HT/TVA/TTC d'une ligne simple", () => {
+    expect(computeLineTotals({ quantite: 2, prix_unitaire_ht: 10, taux_tva: 20 })).toEqual({
+      total_ht: 20,
+      total_tva: 4,
+      total_ttc: 24,
+    });
+  });
+
+  it("arrondit à 2 décimales", () => {
+    const t = computeLineTotals({ quantite: 3, prix_unitaire_ht: 9.99, taux_tva: 20 });
+    expect(t.total_ht).toBe(29.97);
+    expect(t.total_ttc).toBe(35.96);
+  });
+
+  it("applique la remise de ligne (clampée 0..100)", () => {
+    expect(computeLineTotals({ quantite: 1, prix_unitaire_ht: 100, remise_ligne: 10, taux_tva: 0 }).total_ht).toBe(90);
+    // remise > 100 -> clamp à 100 -> HT 0
+    expect(computeLineTotals({ quantite: 1, prix_unitaire_ht: 100, remise_ligne: 150 }).total_ht).toBe(0);
+  });
+
+  it("interdit un HT négatif (prix négatif -> 0)", () => {
+    expect(computeLineTotals({ quantite: 1, prix_unitaire_ht: -50, taux_tva: 20 }).total_ht).toBe(0);
+  });
+
+  it("gère un devis vide", () => {
+    expect(computeDevisTotals([], 0)).toMatchObject({ total_ht: 0, total_ttc: 0, total_tva: 0 });
+  });
+
+  it("applique la remise globale sur le sous-total", () => {
+    const lines = [
+      { quantite: 1, prix_unitaire_ht: 100, taux_tva: 20 },
+      { quantite: 1, prix_unitaire_ht: 100, taux_tva: 20 },
+    ];
+    const t = computeDevisTotals(lines, 10);
+    expect(t.subtotal_ht).toBe(200);
+    expect(t.total_ht).toBe(180);
+    expect(t.total_ttc).toBe(216);
+    expect(t.remise_pct).toBe(10);
+  });
+
+  it("gère des taux de TVA mixtes", () => {
+    const t = computeDevisTotals(
+      [
+        { quantite: 1, prix_unitaire_ht: 100, taux_tva: 20 },
+        { quantite: 1, prix_unitaire_ht: 100, taux_tva: 5.5 },
+      ],
+      0
+    );
+    expect(t.total_ht).toBe(200);
+    expect(t.total_ttc).toBe(225.5);
+  });
+});

--- a/src/module/devis/lib/totals.ts
+++ b/src/module/devis/lib/totals.ts
@@ -1,0 +1,59 @@
+// Recalcul serveur des totaux devis — source de vérité (ISO/IEC 27001 A.8.28 codage sécurisé).
+// Miroir de la règle frontend `src/modules/devis/lib/totals.ts` : les totaux envoyés par le
+// client ne sont JAMAIS de confiance ; le backend recalcule à partir des lignes.
+
+type LineLike = {
+  quantite: number;
+  prix_unitaire_ht: number;
+  remise_ligne?: number | null;
+  taux_tva?: number | null;
+};
+
+export type DevisLineTotals = {
+  total_ht: number;
+  total_tva: number;
+  total_ttc: number;
+};
+
+export type DevisTotals = {
+  subtotal_ht: number;
+  subtotal_ttc: number;
+  remise_pct: number;
+  total_ht: number;
+  total_tva: number;
+  total_ttc: number;
+};
+
+function round2(n: number): number {
+  return Math.round((n + Number.EPSILON) * 100) / 100;
+}
+
+function clamp(n: number, min: number, max: number): number {
+  return Math.min(Math.max(n, min), max);
+}
+
+export function computeLineTotals(line: LineLike): DevisLineTotals {
+  const qte = Number.isFinite(line.quantite) ? Number(line.quantite) : 0;
+  const pu = Number.isFinite(line.prix_unitaire_ht) ? Number(line.prix_unitaire_ht) : 0;
+  const remise = clamp(Number(line.remise_ligne ?? 0), 0, 100);
+  const tva = clamp(Number(line.taux_tva ?? 0), 0, 100);
+
+  const baseHt = qte * pu * (1 - remise / 100);
+  const total_ht = round2(Math.max(0, baseHt));
+  const total_ttc = round2(total_ht * (1 + tva / 100));
+  const total_tva = round2(total_ttc - total_ht);
+  return { total_ht, total_tva, total_ttc };
+}
+
+export function computeDevisTotals(lines: readonly LineLike[], remise_globale_pct: number): DevisTotals {
+  const safeLines = Array.isArray(lines) ? lines : [];
+  const subtotal_ht = round2(safeLines.reduce((s, l) => s + computeLineTotals(l).total_ht, 0));
+  const subtotal_ttc = round2(safeLines.reduce((s, l) => s + computeLineTotals(l).total_ttc, 0));
+  const remise_pct = clamp(Number(remise_globale_pct || 0), 0, 100);
+
+  const total_ht = round2(subtotal_ht * (1 - remise_pct / 100));
+  const total_ttc = round2(subtotal_ttc * (1 - remise_pct / 100));
+  const total_tva = round2(total_ttc - total_ht);
+
+  return { subtotal_ht, subtotal_ttc, remise_pct, total_ht, total_tva, total_ttc };
+}

--- a/src/module/devis/repository/devis.repository.ts
+++ b/src/module/devis/repository/devis.repository.ts
@@ -5,6 +5,7 @@ import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
+import { computeDevisTotals } from "../lib/totals";
 import type {
   CreateDevisBodyDTO,
   ListDevisQueryDTO,
@@ -1339,6 +1340,9 @@ export async function repoCreateDevis(input: CreateDevisBodyDTO, userId: number,
     const numero = (input.numero ?? `DV-${devisId}`).slice(0, 30);
     const dateCreation = (input.date_creation ?? new Date().toISOString().slice(0, 10)).slice(0, 10);
 
+    // Totaux recalculés côté serveur — les totaux envoyés par le client sont ignorés (ISO A.8.28).
+    const totals = computeDevisTotals(input.lignes, input.remise_globale ?? 0);
+
     const ins = await client.query<{ id: string }>(
       `
       INSERT INTO devis (
@@ -1384,9 +1388,9 @@ export async function repoCreateDevis(input: CreateDevisBodyDTO, userId: number,
         dateCreation,
         input.date_validite ?? null,
         input.statut,
-        input.remise_globale,
-        input.total_ht,
-        input.total_ttc,
+        totals.remise_pct,
+        totals.total_ht,
+        totals.total_ttc,
         input.commentaires ?? null,
         input.conditions_paiement_id ?? null,
         input.biller_id ?? null,
@@ -1591,6 +1595,13 @@ export async function repoReviseDevis(
     const numero = (input.numero ?? computedNumero).slice(0, 30);
     const dateCreation = (input.date_creation ?? new Date().toISOString().slice(0, 10)).slice(0, 10);
 
+    // Totaux recalculés côté serveur. Si de nouvelles lignes sont fournies, on recalcule ;
+    // sinon les lignes sont clonées de la source et on conserve ses totaux (ISO A.8.28).
+    const revisedRemise = input.remise_globale ?? source.remise_globale ?? 0;
+    const revisedTotals = input.lignes
+      ? computeDevisTotals(input.lignes, revisedRemise)
+      : { remise_pct: revisedRemise, total_ht: source.total_ht, total_ttc: source.total_ttc };
+
     const inserted = await client.query<{ id: string }>(
       `
         INSERT INTO devis (
@@ -1636,9 +1647,9 @@ export async function repoReviseDevis(
         dateCreation,
         input.date_validite !== undefined ? input.date_validite : source.date_validite,
         input.statut ?? source.statut,
-        input.remise_globale ?? source.remise_globale,
-        input.total_ht ?? source.total_ht,
-        input.total_ttc ?? source.total_ttc,
+        revisedTotals.remise_pct,
+        revisedTotals.total_ht,
+        revisedTotals.total_ttc,
         input.commentaires !== undefined ? input.commentaires : source.commentaires,
         input.conditions_paiement_id !== undefined ? input.conditions_paiement_id : source.conditions_paiement_id,
         input.biller_id !== undefined ? input.biller_id : source.biller_id,


### PR DESCRIPTION
## Intégrité — Totaux devis non recalculés (CA-APP-01)

### Problème
`repoCreateDevis` et `repoReviseDevis` stockaient `total_ht`/`total_ttc` **tels qu'envoyés par le client** (`devis.validators.ts` acceptait `min(0)`). Un client pouvait persister des totaux **faux ou falsifiés**, et l'arrondi front/back pouvait diverger.

### Correctif
- Nouveau helper serveur `src/module/devis/lib/totals.ts` (`computeDevisTotals`), **miroir exact** de la règle front `src/modules/devis/lib/totals.ts` (round2 par ligne, HT/TVA/TTC, remise ligne + globale clampées 0..100).
- `repoCreateDevis` / `repoReviseDevis` **recalculent** `total_ht`/`total_ttc`/`remise` depuis les lignes validées ; les totaux client sont **ignorés**. En révision sans nouvelles lignes (clone), les totaux source (désormais fiables) sont conservés.

### Tests
- 7 tests unitaires : arrondis, TVA, devis vide, **prix négatif → HT 0**, remise ligne, remise globale, TVA mixtes.
- `tsc --noEmit` ✅ · `vitest run` ✅ **128 tests**.

### Note
`repoUpdateDevis` (PATCH) est mort côté UI (le front utilise `/revise`) → non modifié ici, à traiter dans le suivi CA-APP-01.

ISO/IEC 27001:2022 : **A.8.28** (codage sécurisé), A.8.26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Recalculate devis financial totals on the backend and establish the server as the single source of truth for quote amounts.

New Features:
- Introduce a backend helper to compute devis line and global totals mirroring the frontend pricing rules.

Bug Fixes:
- Prevent persistence of incorrect or tampered devis totals by ignoring client-provided totals and recomputing them from validated lines in creation and revision flows.
- Ensure negative prices and out‑of‑range discounts cannot produce negative HT totals or invalid global totals.

Enhancements:
- Align backend total calculations with frontend rounding, VAT handling, and discount clamping for consistent quote amounts across the system.

Tests:
- Add unit tests covering line total computation, rounding behavior, negative price handling, empty devis, global discounts, and mixed VAT rates.