### PR TITLE
release: devis statut enum canonique (CA-APP-02)

### DIFF
--- a/db/patches/20260707_devis_statut_enum.sql
+++ b/db/patches/20260707_devis_statut_enum.sql
@@ -1,0 +1,66 @@
+-- 20260707_devis_statut_enum.sql
+--
+-- Purpose
+-- - Enforce a canonical devis.statut enum: BROUILLON / ENVOYE / ACCEPTE / REFUSE / EXPIRE / ANNULE.
+-- - Normalize any legacy value (lowercase / accented / EN aliases) to the canonical form.
+--
+-- Safety
+-- - Idempotent (safe to run multiple times).
+-- - Non-destructive: only normalizes text values + swaps a CHECK constraint. No data loss.
+--   (devis table is currently empty on cerp_prod/cerp_test, so the UPDATEs are no-ops today.)
+--
+-- Target DB: PostgreSQL
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.devis') IS NULL THEN
+    RAISE NOTICE 'Skipping: public.devis missing';
+    RETURN;
+  END IF;
+
+  -- 1) Normalize known legacy values to the canonical enum.
+  UPDATE public.devis d SET statut = m.canon
+  FROM (VALUES
+    ('brouillon','BROUILLON'), ('draft','BROUILLON'),
+    ('envoye','ENVOYE'), ('envoyé','ENVOYE'), ('sent','ENVOYE'), ('a_relancer','ENVOYE'),
+    ('accepte','ACCEPTE'), ('accepté','ACCEPTE'), ('acceptee','ACCEPTE'), ('acceptée','ACCEPTE'), ('accepted','ACCEPTE'),
+    ('refuse','REFUSE'), ('refusé','REFUSE'), ('refusee','REFUSE'), ('refusée','REFUSE'), ('rejected','REFUSE'),
+    ('expire','EXPIRE'), ('expiré','EXPIRE'), ('expiree','EXPIRE'), ('expirée','EXPIRE'), ('expired','EXPIRE'),
+    ('annule','ANNULE'), ('annulé','ANNULE'), ('annulee','ANNULE'), ('annulée','ANNULE'), ('cancelled','ANNULE'), ('canceled','ANNULE')
+  ) AS m(src, canon)
+  WHERE lower(btrim(d.statut)) = m.src;
+
+  -- 2) Any remaining non-canonical value -> BROUILLON (safe default).
+  UPDATE public.devis
+  SET statut = 'BROUILLON'
+  WHERE statut IS NULL
+     OR statut NOT IN ('BROUILLON','ENVOYE','ACCEPTE','REFUSE','EXPIRE','ANNULE');
+
+  -- 3) Default + CHECK.
+  EXECUTE 'ALTER TABLE public.devis ALTER COLUMN statut SET DEFAULT ''BROUILLON''';
+
+  -- Drop any pre-existing statut CHECK constraint, then add the canonical one.
+  BEGIN
+    EXECUTE (
+      SELECT string_agg(format('ALTER TABLE public.devis DROP CONSTRAINT IF EXISTS %I;', conname), ' ')
+      FROM pg_constraint
+      WHERE conrelid = 'public.devis'::regclass
+        AND contype = 'c'
+        AND pg_get_constraintdef(oid) ILIKE '%statut%'
+    );
+  EXCEPTION WHEN others THEN NULL;
+  END;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'devis_statut_check' AND conrelid = 'public.devis'::regclass
+  ) THEN
+    ALTER TABLE public.devis
+      ADD CONSTRAINT devis_statut_check
+      CHECK (statut IN ('BROUILLON','ENVOYE','ACCEPTE','REFUSE','EXPIRE','ANNULE'));
+  END IF;
+END $$;
+
+COMMIT;

--- a/src/module/devis/lib/status.test.ts
+++ b/src/module/devis/lib/status.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { normalizeDevisStatut, canTransitionDevisStatut, DEVIS_STATUTS } from "./status";
+
+describe("devis statut enum (canonique partagé)", () => {
+  it("normalise les alias FR (casse + accents) vers le canonique", () => {
+    expect(normalizeDevisStatut("brouillon")).toBe("BROUILLON");
+    expect(normalizeDevisStatut("Envoyé")).toBe("ENVOYE");
+    expect(normalizeDevisStatut("accepté")).toBe("ACCEPTE");
+    expect(normalizeDevisStatut("ACCEPTÉE")).toBe("ACCEPTE");
+    expect(normalizeDevisStatut("refusé")).toBe("REFUSE");
+    expect(normalizeDevisStatut("expiré")).toBe("EXPIRE");
+    expect(normalizeDevisStatut("annulé")).toBe("ANNULE");
+  });
+
+  it("normalise les alias EN et les valeurs déjà canoniques", () => {
+    expect(normalizeDevisStatut("draft")).toBe("BROUILLON");
+    expect(normalizeDevisStatut("sent")).toBe("ENVOYE");
+    expect(normalizeDevisStatut("BROUILLON")).toBe("BROUILLON");
+    expect(normalizeDevisStatut("ENVOYE")).toBe("ENVOYE");
+  });
+
+  it("retombe sur BROUILLON pour vide/inconnu/null", () => {
+    expect(normalizeDevisStatut("")).toBe("BROUILLON");
+    expect(normalizeDevisStatut(null)).toBe("BROUILLON");
+    expect(normalizeDevisStatut(undefined)).toBe("BROUILLON");
+    expect(normalizeDevisStatut("xyz")).toBe("BROUILLON");
+  });
+
+  it("expose 6 statuts canoniques", () => {
+    expect(DEVIS_STATUTS).toEqual(["BROUILLON", "ENVOYE", "ACCEPTE", "REFUSE", "EXPIRE", "ANNULE"]);
+  });
+
+  it("applique les transitions autorisées", () => {
+    expect(canTransitionDevisStatut("BROUILLON", "ENVOYE")).toBe(true);
+    expect(canTransitionDevisStatut("ENVOYE", "ACCEPTE")).toBe(true);
+    expect(canTransitionDevisStatut("BROUILLON", "ACCEPTE")).toBe(false);
+    expect(canTransitionDevisStatut("ANNULE", "BROUILLON")).toBe(false);
+    expect(canTransitionDevisStatut("ACCEPTE", "ACCEPTE")).toBe(true);
+  });
+});

--- a/src/module/devis/lib/status.ts
+++ b/src/module/devis/lib/status.ts
@@ -1,0 +1,80 @@
+// Statuts devis — enum canonique partagé (source de vérité backend).
+// Le frontend (src/modules/devis/lib/devis-ui.ts) reflète les mêmes valeurs + libellés.
+// ISO/IEC 27001 A.8.28 (codage sécurisé) / A.5.12 (classification) : statut contrôlé, non texte libre.
+
+export const DEVIS_STATUTS = ["BROUILLON", "ENVOYE", "ACCEPTE", "REFUSE", "EXPIRE", "ANNULE"] as const;
+export type DevisStatut = (typeof DEVIS_STATUTS)[number];
+
+export const DEVIS_STATUT_DEFAULT: DevisStatut = "BROUILLON";
+
+export const DEVIS_STATUT_LABELS: Record<DevisStatut, string> = {
+  BROUILLON: "Brouillon",
+  ENVOYE: "Envoyé",
+  ACCEPTE: "Accepté",
+  REFUSE: "Refusé",
+  EXPIRE: "Expiré",
+  ANNULE: "Annulé",
+};
+
+function stripAccentsLower(value: string): string {
+  try {
+    return value.trim().toLowerCase().normalize("NFD").replace(/[̀-ͯ]/g, "");
+  } catch {
+    return value.trim().toLowerCase();
+  }
+}
+
+/**
+ * Normalise n'importe quelle entrée (casse, accents, alias FR/EN) vers un statut canonique.
+ * Valeur inconnue/vide -> BROUILLON (défaut sûr).
+ */
+export function normalizeDevisStatut(input: unknown): DevisStatut {
+  const raw = typeof input === "string" ? input : input == null ? "" : String(input);
+  const s = stripAccentsLower(raw);
+  switch (s) {
+    case "":
+    case "brouillon":
+    case "draft":
+      return "BROUILLON";
+    case "envoye":
+    case "sent":
+    case "a_relancer":
+      return "ENVOYE";
+    case "accepte":
+    case "acceptee":
+    case "accepted":
+      return "ACCEPTE";
+    case "refuse":
+    case "refusee":
+    case "rejected":
+      return "REFUSE";
+    case "expire":
+    case "expiree":
+    case "expired":
+      return "EXPIRE";
+    case "annule":
+    case "annulee":
+    case "cancelled":
+    case "canceled":
+      return "ANNULE";
+    default: {
+      const upper = raw.trim().toUpperCase();
+      return (DEVIS_STATUTS as readonly string[]).includes(upper) ? (upper as DevisStatut) : "BROUILLON";
+    }
+  }
+}
+
+// Transitions métier autorisées.
+export const DEVIS_STATUT_TRANSITIONS: Record<DevisStatut, readonly DevisStatut[]> = {
+  BROUILLON: ["ENVOYE", "ANNULE"],
+  ENVOYE: ["ACCEPTE", "REFUSE", "EXPIRE", "ANNULE"],
+  ACCEPTE: ["ANNULE"],
+  REFUSE: ["BROUILLON", "ANNULE"],
+  EXPIRE: ["BROUILLON", "ENVOYE", "ANNULE"],
+  ANNULE: [],
+};
+
+export function canTransitionDevisStatut(from: DevisStatut, to: DevisStatut): boolean {
+  if (from === to) return true;
+  return DEVIS_STATUT_TRANSITIONS[from].includes(to);
+}

--- a/src/module/devis/validators/devis.validators.ts
+++ b/src/module/devis/validators/devis.validators.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { DEVIS_STATUTS, normalizeDevisStatut } from "../lib/status";
 
 const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date (expected YYYY-MM-DD)");
 
@@ -134,7 +135,7 @@ export const createDevisBodySchema = z.object({
   compte_vente_id: z.string().uuid().optional().nullable(),
   date_creation: z.preprocess(emptyStringToNull, isoDate).optional().nullable(),
   date_validite: z.preprocess(emptyStringToNull, isoDate).optional().nullable(),
-  statut: z.preprocess(emptyStringToUndefined, z.string().trim().min(1).max(20)).optional().default("BROUILLON"),
+  statut: z.preprocess(normalizeDevisStatut, z.enum(DEVIS_STATUTS)),
   remise_globale: z.coerce.number().min(0).optional().default(0),
   total_ht: z.coerce.number().min(0).optional().default(0),
   total_ttc: z.coerce.number().min(0).optional().default(0),
@@ -157,7 +158,7 @@ export const updateDevisBodySchema = z.object({
   compte_vente_id: z.string().uuid().optional().nullable(),
   date_creation: z.preprocess(emptyStringToNull, isoDate).optional().nullable(),
   date_validite: z.preprocess(emptyStringToNull, isoDate).optional().nullable(),
-  statut: z.preprocess(emptyStringToUndefined, z.string().trim().min(1).max(20)).optional(),
+  statut: z.preprocess((v) => (v === undefined ? undefined : normalizeDevisStatut(v)), z.enum(DEVIS_STATUTS).optional()),
   remise_globale: z.coerce.number().min(0).optional(),
   total_ht: z.coerce.number().min(0).optional(),
   total_ttc: z.coerce.number().min(0).optional(),


### PR DESCRIPTION
Release dev→main: enum statut devis + normalisation backend + migration (déjà appliquée). Aligne le code prod avec le CHECK DB. 136 tests verts.

## Summary by Sourcery

Enforce a canonical, shared enum for devis status across backend validation and database, with normalization of legacy values and explicit transition rules.

New Features:
- Introduce a canonical devis status enum with labels, normalization logic, and allowed status transitions in backend code.

Bug Fixes:
- Normalize and constrain existing and future devis.statut values at the database level via an idempotent migration aligned with the backend enum.

Enhancements:
- Update devis creation and update validators to rely on the canonical status enum and normalization instead of free-form strings.

Tests:
- Add unit tests covering status normalization, canonical enum values, and allowed status transitions.