### PR TITLE
feat(clients): PATCH /clients/:id partiel réel (P1.3)

### DIFF
--- a/src/__tests__/client-patch.routes.test.ts
+++ b/src/__tests__/client-patch.routes.test.ts
@@ -1,0 +1,90 @@
+import request from "supertest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = { on: emitter.on.bind(emitter), query: mocks.poolQuery, connect: mocks.poolConnect };
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (req: { user?: unknown }, _res: unknown, next: () => void) => {
+    (req as { user?: unknown }).user = { id: 1, username: "t", email: "t@t.t", role: "administrateur" };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import app from "../config/app";
+
+const CLIENT_ROW = {
+  client_id: "001",
+  bill_address_id: "b1",
+  delivery_address_id: "d1",
+  bank_info_id: null,
+  primary_contact_id: null,
+};
+
+beforeEach(() => {
+  mocks.poolQuery.mockReset();
+  mocks.clientQuery.mockReset();
+  mocks.poolConnect.mockReset();
+  mocks.clientRelease.mockReset();
+
+  mocks.poolQuery.mockResolvedValue({ rows: [] });
+  mocks.poolConnect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease });
+  mocks.clientQuery.mockImplementation((sql: unknown) => {
+    if (typeof sql === "string" && sql.includes("FOR UPDATE")) return Promise.resolve({ rows: [CLIENT_ROW] });
+    return Promise.resolve({ rows: [{ id: 1, created_at: "2026-07-07T00:00:00.000Z" }] });
+  });
+});
+
+function sqls(): string[] {
+  return mocks.clientQuery.mock.calls.map((c) => String(c[0]));
+}
+
+describe("PATCH /api/v1/clients/:id — vrai partiel", () => {
+  it("PATCH téléphone seul: UPDATE clients ne touche que phone, ne supprime aucun contact", async () => {
+    const res = await request(app).patch("/api/v1/clients/001").send({ phone: "+33612345678" });
+    expect(res.status).toBe(204);
+    const update = sqls().find((s) => s.includes("UPDATE clients SET"));
+    expect(update).toBeTruthy();
+    expect(update).toContain("phone");
+    expect(update).not.toContain("company_name");
+    expect(sqls().some((s) => s.includes("DELETE FROM contacts"))).toBe(false);
+    expect(sqls().some((s) => s.includes("DELETE FROM client_payment_modes"))).toBe(false);
+  });
+
+  it("PATCH email invalide -> 400", async () => {
+    const res = await request(app).patch("/api/v1/clients/001").send({ email: "pas-un-email" });
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH vide -> 400 (aucun champ)", async () => {
+    const res = await request(app).patch("/api/v1/clients/001").send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH adresse de facturation seule: UPDATE adresse_facturation, PAS UPDATE clients", async () => {
+    const res = await request(app)
+      .patch("/api/v1/clients/001")
+      .send({
+        bill_address: { name: "Siège", street: "1 rue X", postal_code: "69001", city: "Lyon", country: "France" },
+      });
+    expect(res.status).toBe(204);
+    expect(sqls().some((s) => s.includes("UPDATE adresse_facturation"))).toBe(true);
+    expect(sqls().some((s) => s.includes("UPDATE clients SET"))).toBe(false);
+  });
+});

--- a/src/module/client/controllers/client.controller.ts
+++ b/src/module/client/controllers/client.controller.ts
@@ -5,8 +5,8 @@ import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 
 import * as clientService from "../services/client.service"; // ✅ namespace import
 import { svcGetClientById, svcListClientAddresses } from "../services/clients.read.service";
-import { createClientSchema, createClientContactBodySchema } from "../validators/client.validators";
-import { type AuditContext, repoArchiveClient, repoCreateClient, repoDeleteClient, repoUpdateClient } from "../repository/client.repository";
+import { createClientSchema, createClientContactBodySchema, clientPatchSchema } from "../validators/client.validators";
+import { type AuditContext, repoArchiveClient, repoCreateClient, repoDeleteClient, repoPatchClient } from "../repository/client.repository";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import path from "node:path";
 // import { LOGO_BASE_DIR } from "../upload/client-logo-upload";
@@ -200,12 +200,19 @@ export const patchClient: RequestHandler = async (req, res, next) => {
     const audit = buildAuditContext(req);
     const id = routeParam(req, "id");
 
-    // on réutilise le même schéma que pour la création
-    const dto = createClientSchema.parse(req.body);
+    // Vrai PATCH partiel : on valide avec un schéma partiel (validateurs par champ préservés),
+    // puis on ne conserve que les champs RÉELLEMENT présents dans le body (les .default() du
+    // schéma réinjectent des tableaux vides qu'il ne faut pas appliquer -> risque d'écrasement).
+    const provided = new Set(Object.keys((req.body ?? {}) as Record<string, unknown>));
+    const dto = clientPatchSchema.parse(req.body);
+    const fields = new Set([...provided].filter((k) => k in dto));
 
-    await repoUpdateClient(id, dto, audit);
+    if (fields.size === 0) {
+      throw new HttpError(400, "EMPTY_PATCH", "Aucun champ à mettre à jour");
+    }
 
-    // pas besoin de body, le frontend n'en attend pas
+    await repoPatchClient(id, dto, fields, audit);
+
     res.status(204).end();
   } catch (e) {
     next(e);

--- a/src/module/client/repository/client.repository.ts
+++ b/src/module/client/repository/client.repository.ts
@@ -3,7 +3,7 @@ import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
-import type { CreateClientDTO } from "../validators/client.validators";
+import type { CreateClientDTO, ClientPatchDTO } from "../validators/client.validators";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import { generateClientCode } from "../../../shared/codes/code-generator.service";
@@ -412,6 +412,159 @@ export async function repoCreateClient(
 }
 
 // EDIT CLIENT 
+
+// PATCH partiel : ne met à jour QUE les champs réellement fournis. Un champ absent n'est
+// jamais écrasé ni supprimé (contrairement à repoUpdateClient qui fait un remplacement complet).
+// La liste des champs fournis (`fields`) vient du contrôleur (clés réellement présentes dans le body).
+export async function repoPatchClient(
+  id: string,
+  patch: ClientPatchDTO,
+  fields: ReadonlySet<string>,
+  audit: AuditContext
+): Promise<void> {
+  const has = (k: string) => fields.has(k);
+  const db = await pool.connect();
+  try {
+    await db.query("BEGIN");
+
+    const current = await db.query(
+      `SELECT client_id, bill_address_id, delivery_address_id, bank_info_id, contact_id AS primary_contact_id
+         FROM clients WHERE client_id = $1 FOR UPDATE`,
+      [id]
+    );
+    if (current.rows.length === 0) {
+      const err = new Error("Client not found");
+      (err as any).status = 404;
+      throw err;
+    }
+    const { bill_address_id, delivery_address_id, bank_info_id, primary_contact_id } = current.rows[0] as {
+      bill_address_id: string | null;
+      delivery_address_id: string | null;
+      bank_info_id: string | null;
+      primary_contact_id: string | null;
+    };
+
+    // 1) Champs scalaires — SET dynamique, uniquement ceux fournis.
+    const sets: string[] = [];
+    const vals: unknown[] = [];
+    const put = (sql: (ph: string) => string, value: unknown) => {
+      vals.push(value);
+      sets.push(sql(`$${vals.length}`));
+    };
+    if (has("company_name")) put((p) => `company_name = ${p}`, patch.company_name);
+    if (has("email")) put((p) => `email = NULLIF(${p}, '')`, patch.email ?? "");
+    if (has("phone")) put((p) => `phone = NULLIF(${p}, '')`, patch.phone ?? "");
+    if (has("website_url")) put((p) => `website_url = NULLIF(${p}, '')`, patch.website_url ?? "");
+    if (has("siret")) put((p) => `siret = NULLIF(${p}, '')`, patch.siret ?? "");
+    if (has("vat_number")) put((p) => `vat_number = NULLIF(${p}, '')`, patch.vat_number ?? "");
+    if (has("naf_code")) put((p) => `naf_code = NULLIF(${p}, '')`, patch.naf_code ?? "");
+    if (has("status")) put((p) => `status = ${p}`, patch.status);
+    if (has("blocked")) put((p) => `blocked = ${p}`, patch.blocked);
+    if (has("reason")) put((p) => `reason = NULLIF(${p}, '')`, patch.reason ?? "");
+    if (has("observations")) put((p) => `observations = NULLIF(${p}, '')`, patch.observations ?? "");
+    if (has("biller_id")) {
+      const biller = typeof patch.biller_id === "string" && patch.biller_id.trim() !== "" ? patch.biller_id : null;
+      put((p) => `biller_id = ${p}`, biller);
+    }
+    if (has("provided_documents_id")) {
+      const docs =
+        typeof patch.provided_documents_id === "string" && patch.provided_documents_id.trim() !== ""
+          ? patch.provided_documents_id
+          : null;
+      put((p) => `provided_documents_id = ${p}`, docs);
+    }
+    if (has("quality_levels")) put((p) => `quality_levels = ${p}::text[]`, patch.quality_levels ?? []);
+    if (has("client_code")) {
+      const provided = (patch.client_code ?? "").trim();
+      if (!provided) throw new HttpError(400, "CLIENT_CODE_REQUIRED", clientCodeRequiredMessage);
+      if (!isValidCode("client", provided)) throw new HttpError(400, "CLIENT_CODE_INVALID", clientCodeInvalidMessage);
+      await ensureClientCodeAvailable(db, provided, id);
+      put((p) => `client_code = ${p}`, provided);
+    }
+
+    if (sets.length > 0) {
+      vals.push(id);
+      try {
+        await db.query(`UPDATE clients SET ${sets.join(", ")} WHERE client_id = $${vals.length}`, vals);
+      } catch (err) {
+        const { code, constraint } = getPgErrorInfo(err);
+        if (code === "23505" && constraint === "clients_client_code_key") {
+          throw new HttpError(409, "CLIENT_CODE_EXISTS", clientCodeExistsMessage);
+        }
+        throw err;
+      }
+    }
+
+    // 2) Adresses — uniquement si fournies.
+    if (has("bill_address") && patch.bill_address && bill_address_id) {
+      const a = patch.bill_address;
+      await db.query(
+        `UPDATE adresse_facturation SET street=$1, house_number=$2, address_complement=$3, postal_code=$4, city=$5, country=$6, name=$7 WHERE bill_address_id=$8`,
+        [a.street, a.house_number ?? null, a.address_complement ?? null, a.postal_code, a.city, a.country, a.name, bill_address_id]
+      );
+    }
+    if (has("delivery_address") && patch.delivery_address && delivery_address_id) {
+      const a = patch.delivery_address;
+      await db.query(
+        `UPDATE adresse_livraison SET street=$1, house_number=$2, address_complement=$3, postal_code=$4, city=$5, country=$6, name=$7 WHERE delivery_address_id=$8`,
+        [a.street, a.house_number ?? null, a.address_complement ?? null, a.postal_code, a.city, a.country, a.name, delivery_address_id]
+      );
+    }
+
+    // 3) Banque — uniquement si fournie.
+    if (has("bank") && patch.bank) {
+      const newBankInfoId = await upsertBank(db, patch.bank);
+      if (!bank_info_id || bank_info_id !== newBankInfoId) {
+        await db.query(`UPDATE clients SET bank_info_id = $1 WHERE client_id = $2`, [newBankInfoId, id]);
+      }
+    }
+
+    // 4) Modes de règlement — uniquement si fournis (remplacement contrôlé).
+    if (has("payment_mode_ids")) {
+      await db.query(`DELETE FROM client_payment_modes WHERE client_id = $1`, [id]);
+      for (const pid of patch.payment_mode_ids ?? []) {
+        await db.query(
+          `INSERT INTO client_payment_modes (client_id, payment_id) VALUES ($1,$2) ON CONFLICT (client_id,payment_id) DO NOTHING`,
+          [id, pid]
+        );
+      }
+    }
+
+    // 5) Contacts — uniquement si fournis : upsert SANS supprimer les absents.
+    if (has("contacts") && Array.isArray(patch.contacts) && patch.contacts.length > 0) {
+      const existing = await fetchExistingContacts(db, id);
+      for (const c of patch.contacts) {
+        const cid = (c as { contact_id?: string }).contact_id;
+        if (cid && existing.includes(cid)) await updateContact(db, cid, c);
+        else await insertContact(db, c, id);
+      }
+    }
+
+    // 6) Contact principal — uniquement si fourni.
+    if (has("primary_contact") && patch.primary_contact) {
+      if (primary_contact_id) {
+        await updateContact(db, primary_contact_id, patch.primary_contact);
+      } else {
+        const newId = await insertPrimaryContact(db, patch.primary_contact, id);
+        await db.query(`UPDATE clients SET contact_id = $1 WHERE client_id = $2`, [newId, id]);
+      }
+    }
+
+    await insertAuditLog(db, audit, {
+      action: "CLIENT_PATCH",
+      entity_type: "client",
+      entity_id: id,
+      details: { fields: Array.from(fields) },
+    });
+
+    await db.query("COMMIT");
+  } catch (e) {
+    await db.query("ROLLBACK");
+    throw e;
+  } finally {
+    db.release();
+  }
+}
 
 export async function repoUpdateClient(id: string, dto: CreateClientDTO, audit: AuditContext): Promise<void> {
   const db = await pool.connect();

--- a/src/module/client/validators/client.validators.ts
+++ b/src/module/client/validators/client.validators.ts
@@ -253,3 +253,9 @@ export const createClientSchema = z.object({
 });
 
 export type CreateClientDTO = z.infer<typeof createClientSchema>;
+
+// PATCH partiel : tous les champs optionnels, mais les validateurs par champ (email, téléphone,
+// SIRET, TVA, NAF, adresses via addressSchema, etc.) restent appliqués quand le champ est fourni.
+// L'identité `client_id` n'est pas dans le body (route param) -> non patchable.
+export const clientPatchSchema = createClientSchema.partial();
+export type ClientPatchDTO = z.infer<typeof clientPatchSchema>;


### PR DESCRIPTION
## Intégrité — PATCH client partiel (P1.3)

### Problème
`patchClient` reparsait le **schéma de création complet** (tous champs requis) et reconstruisait tout le client via `repoUpdateClient` — qui **supprimait même les contacts absents** du payload. Un vrai PATCH partiel était impossible.

### Correctif
- **`clientPatchSchema = createClientSchema.partial()`** — validateurs par champ (email, téléphone, SIRET, TVA, NAF, adresses) **préservés** quand le champ est fourni.
- **Contrôleur** : ne conserve que les champs **réellement présents dans `req.body`** (`partial()` réinjecte des `[]` par défaut qui écraseraient modes de règlement/contacts) ; **PATCH vide → 400** (`EMPTY_PATCH`).
- **`repoPatchClient`** : `SET` dynamique des scalaires fournis uniquement ; adresses / banque / modes de règlement / contacts / contact principal touchés **seulement si fournis** ; un champ **absent n'est jamais écrasé ni supprimé**.

### ⚠️ Changement de comportement
Les contacts fournis sont désormais **upsertés** (plus de suppression des contacts non listés). La suppression d'un contact passe par les endpoints contact dédiés (`POST /clients/:id/contacts`, `PATCH /clients/:id/contact`). Cela respecte « ne pas supprimer les champs absents ».

### Tests
4 tests : téléphone seul (pas d'écrasement, pas de `DELETE`), adresse seule, email invalide → 400, vide → 400. `tsc` ✅ · `vitest` ✅ **140 tests**.

ISO/IEC 27001:2022 : **A.8.28**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement partial PATCH support for clients that only updates provided fields and preserves untouched data.

Bug Fixes:
- Fix client PATCH behavior to avoid overwriting or deleting fields and contacts that are absent from the request payload.

Enhancements:
- Add repository-level partial update logic for scalar fields, addresses, bank info, payment modes, contacts, and primary contact, driven by the actually provided fields.
- Introduce a dedicated Zod schema and DTO for client partial PATCH validation with field-level validators preserved.

Tests:
- Add integration tests for client PATCH to cover single-field updates, invalid email handling, empty payload errors, and address-only updates.