### PR TITLE
fix(security): rate-limit login anti-bruteforce (CA-SEC-02)

### DIFF
--- a/src/__tests__/login-ratelimit.routes.test.ts
+++ b/src/__tests__/login-ratelimit.routes.test.ts
@@ -1,0 +1,28 @@
+import request from "supertest";
+import { describe, it, expect, vi } from "vitest";
+
+// Fichier isolé : les maps de rate-limit (module-level) sont fraîches dans ce worker vitest.
+vi.mock("pg", () => {
+  const pool = { on: vi.fn(), query: vi.fn().mockResolvedValue({ rows: [] }), connect: vi.fn() };
+  return { Pool: vi.fn(() => pool) };
+});
+vi.mock("../utils/checkNetworkDrive", () => ({ checkNetworkDrive: vi.fn(() => Promise.resolve()) }));
+
+import app from "../config/app";
+
+describe("Login rate-limit anti-bruteforce (ISO/IEC 27001 A.8.5)", () => {
+  it("renvoie 429 après trop de tentatives (limite = 10)", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    let got429 = false;
+    let lastStatus = 0;
+    for (let i = 0; i < 12; i++) {
+      const res = await request(app)
+        .post("/api/v1/auth/login")
+        .send({ username: "brute-force-user", password: "wrong-password-123" });
+      lastStatus = res.status;
+      if (res.status === 429) got429 = true;
+    }
+    expect(got429).toBe(true);
+    expect(lastStatus).toBe(429);
+  });
+});

--- a/src/module/auth/controllers/auth.controller.ts
+++ b/src/module/auth/controllers/auth.controller.ts
@@ -27,6 +27,18 @@ export const login = asyncHandler(async (req: Request, res: Response) => {
   const user_agent = req.headers["user-agent"]?.toString() ?? null;
   const device = parseDevice(user_agent);
 
+  // Rate-limit anti-bruteforce (A.8.5) : par IP + identifiant, avant toute vérification.
+  const rateKey = normalizeIdentifier(username);
+  const rateLimited =
+    trackAndCheckRateLimit(loginRateByIp, ip, LOGIN_RATE_LIMIT, LOGIN_RATE_WINDOW_MS) ||
+    trackAndCheckRateLimit(loginRateByUsername, rateKey, LOGIN_RATE_LIMIT, LOGIN_RATE_WINDOW_MS);
+  if (rateLimited) {
+    return res.status(429).json({
+      error: "TOO_MANY_ATTEMPTS",
+      message: "Trop de tentatives de connexion. Réessayez dans quelques minutes.",
+    });
+  }
+
   const data = await loginUser(username, password, {
     ip,
     user_agent,
@@ -54,18 +66,24 @@ const resetRateByIdentifier = new Map<string, RateEntry>();
 const RESET_RATE_LIMIT = 5;
 const RESET_RATE_WINDOW_MS = 60 * 60 * 1000;
 
-function trackAndCheckRateLimit(map: Map<string, RateEntry>, key: string | null): boolean {
+// Anti-bruteforce login (ISO/IEC 27001 A.8.5) : limite les tentatives par IP et par identifiant.
+const loginRateByIp = new Map<string, RateEntry>();
+const loginRateByUsername = new Map<string, RateEntry>();
+const LOGIN_RATE_LIMIT = 10;
+const LOGIN_RATE_WINDOW_MS = 15 * 60 * 1000;
+
+function trackAndCheckRateLimit(map: Map<string, RateEntry>, key: string | null, limit: number, windowMs: number): boolean {
   if (!key) return false;
   const now = Date.now();
   const existing = map.get(key);
   if (!existing || now >= existing.resetAt) {
-    map.set(key, { count: 1, resetAt: now + RESET_RATE_WINDOW_MS });
+    map.set(key, { count: 1, resetAt: now + windowMs });
     return false;
   }
 
   const nextCount = existing.count + 1;
   map.set(key, { count: nextCount, resetAt: existing.resetAt });
-  return nextCount > RESET_RATE_LIMIT;
+  return nextCount > limit;
 }
 
 function normalizeIdentifier(value: string): string {
@@ -82,7 +100,9 @@ export const forgotPassword = asyncHandler(async (req: Request, res: Response) =
   const parsed = forgotPasswordSchema.safeParse(req.body);
   const identifier = parsed.success ? normalizeIdentifier(parsed.data.usernameOrEmail) : null;
 
-  const limited = trackAndCheckRateLimit(resetRateByIp, ip) || trackAndCheckRateLimit(resetRateByIdentifier, identifier);
+  const limited =
+    trackAndCheckRateLimit(resetRateByIp, ip, RESET_RATE_LIMIT, RESET_RATE_WINDOW_MS) ||
+    trackAndCheckRateLimit(resetRateByIdentifier, identifier, RESET_RATE_LIMIT, RESET_RATE_WINDOW_MS);
 
   if (!limited && parsed.success) {
     // Fire-and-forget: we don't want email delivery or DB latency to become an enumeration side-channel.


### PR DESCRIPTION
## CA-SEC-02 — Rate-limit login

### Problème
Le login n'avait **aucun throttling** (seul forgot-password en avait) → bruteforce / credential-stuffing possible.

### Correctif
Limiteur en mémoire **par IP + par identifiant** (10 tentatives / 15 min) renvoyant **429 avant toute vérification** d'identifiants. `trackAndCheckRateLimit` généralisé (limit + window en paramètres).

### Limites (suivi documenté)
- Limiteur **en mémoire par process** (reset au redémarrage, non partagé multi-instances) → store partagé (Redis) = suivi durable.
- **MFA** pour rôles privilégiés = ticket séparé (CA-SEC-02 partie 2).

### Tests
1 test dédié (11e tentative → 429). `tsc` ✅ · `vitest` ✅ **141 tests**.

ISO/IEC 27001:2022 : **A.8.5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce in-memory rate limiting for login attempts to mitigate brute-force attacks and generalize the rate-limit helper for configurable limits and windows.

New Features:
- Add login rate limiting per IP and per normalized identifier with a 10-attempt window over 15 minutes, returning HTTP 429 on excess attempts.

Enhancements:
- Generalize the trackAndCheckRateLimit helper to accept configurable limit and window parameters and reuse it for both login and forgot-password flows.

Tests:
- Add an integration test to verify that excessive login attempts are blocked with HTTP 429 after the configured threshold.