### PR TITLE
release: login rate-limit (CA-SEC-02)

### DIFF
--- a/src/__tests__/login-ratelimit.routes.test.ts
+++ b/src/__tests__/login-ratelimit.routes.test.ts
@@ -1,0 +1,28 @@
+import request from "supertest";
+import { describe, it, expect, vi } from "vitest";
+
+// Fichier isolé : les maps de rate-limit (module-level) sont fraîches dans ce worker vitest.
+vi.mock("pg", () => {
+  const pool = { on: vi.fn(), query: vi.fn().mockResolvedValue({ rows: [] }), connect: vi.fn() };
+  return { Pool: vi.fn(() => pool) };
+});
+vi.mock("../utils/checkNetworkDrive", () => ({ checkNetworkDrive: vi.fn(() => Promise.resolve()) }));
+
+import app from "../config/app";
+
+describe("Login rate-limit anti-bruteforce (ISO/IEC 27001 A.8.5)", () => {
+  it("renvoie 429 après trop de tentatives (limite = 10)", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    let got429 = false;
+    let lastStatus = 0;
+    for (let i = 0; i < 12; i++) {
+      const res = await request(app)
+        .post("/api/v1/auth/login")
+        .send({ username: "brute-force-user", password: "wrong-password-123" });
+      lastStatus = res.status;
+      if (res.status === 429) got429 = true;
+    }
+    expect(got429).toBe(true);
+    expect(lastStatus).toBe(429);
+  });
+});

--- a/src/module/auth/controllers/auth.controller.ts
+++ b/src/module/auth/controllers/auth.controller.ts
@@ -27,6 +27,18 @@ export const login = asyncHandler(async (req: Request, res: Response) => {
   const user_agent = req.headers["user-agent"]?.toString() ?? null;
   const device = parseDevice(user_agent);
 
+  // Rate-limit anti-bruteforce (A.8.5) : par IP + identifiant, avant toute vérification.
+  const rateKey = normalizeIdentifier(username);
+  const rateLimited =
+    trackAndCheckRateLimit(loginRateByIp, ip, LOGIN_RATE_LIMIT, LOGIN_RATE_WINDOW_MS) ||
+    trackAndCheckRateLimit(loginRateByUsername, rateKey, LOGIN_RATE_LIMIT, LOGIN_RATE_WINDOW_MS);
+  if (rateLimited) {
+    return res.status(429).json({
+      error: "TOO_MANY_ATTEMPTS",
+      message: "Trop de tentatives de connexion. Réessayez dans quelques minutes.",
+    });
+  }
+
   const data = await loginUser(username, password, {
     ip,
     user_agent,
@@ -54,18 +66,24 @@ const resetRateByIdentifier = new Map<string, RateEntry>();
 const RESET_RATE_LIMIT = 5;
 const RESET_RATE_WINDOW_MS = 60 * 60 * 1000;
 
-function trackAndCheckRateLimit(map: Map<string, RateEntry>, key: string | null): boolean {
+// Anti-bruteforce login (ISO/IEC 27001 A.8.5) : limite les tentatives par IP et par identifiant.
+const loginRateByIp = new Map<string, RateEntry>();
+const loginRateByUsername = new Map<string, RateEntry>();
+const LOGIN_RATE_LIMIT = 10;
+const LOGIN_RATE_WINDOW_MS = 15 * 60 * 1000;
+
+function trackAndCheckRateLimit(map: Map<string, RateEntry>, key: string | null, limit: number, windowMs: number): boolean {
   if (!key) return false;
   const now = Date.now();
   const existing = map.get(key);
   if (!existing || now >= existing.resetAt) {
-    map.set(key, { count: 1, resetAt: now + RESET_RATE_WINDOW_MS });
+    map.set(key, { count: 1, resetAt: now + windowMs });
     return false;
   }
 
   const nextCount = existing.count + 1;
   map.set(key, { count: nextCount, resetAt: existing.resetAt });
-  return nextCount > RESET_RATE_LIMIT;
+  return nextCount > limit;
 }
 
 function normalizeIdentifier(value: string): string {
@@ -82,7 +100,9 @@ export const forgotPassword = asyncHandler(async (req: Request, res: Response) =
   const parsed = forgotPasswordSchema.safeParse(req.body);
   const identifier = parsed.success ? normalizeIdentifier(parsed.data.usernameOrEmail) : null;
 
-  const limited = trackAndCheckRateLimit(resetRateByIp, ip) || trackAndCheckRateLimit(resetRateByIdentifier, identifier);
+  const limited =
+    trackAndCheckRateLimit(resetRateByIp, ip, RESET_RATE_LIMIT, RESET_RATE_WINDOW_MS) ||
+    trackAndCheckRateLimit(resetRateByIdentifier, identifier, RESET_RATE_LIMIT, RESET_RATE_WINDOW_MS);
 
   if (!limited && parsed.success) {
     // Fire-and-forget: we don't want email delivery or DB latency to become an enumeration side-channel.


### PR DESCRIPTION
CA-SEC-02.

## Summary by Sourcery

Add configurable rate limiting to the login and password reset flows to mitigate brute-force attacks and validate it with a dedicated test.

New Features:
- Introduce per-IP and per-identifier rate limiting on login attempts with a 429 response after too many failures.

Enhancements:
- Generalize the rate-limiting helper to accept custom limits and time windows for different flows.

Tests:
- Add an integration test verifying that excessive login attempts trigger the 429 rate-limit response.