### PR TITLE
release: erp_audit_logs append-only (CA-SEC-03)

### DIFF
--- a/db/privileged/20260707_erp_audit_logs_append_only.rollback.sql
+++ b/db/privileged/20260707_erp_audit_logs_append_only.rollback.sql
@@ -1,0 +1,41 @@
+-- ROLLBACK for 20260707_erp_audit_logs_append_only.sql   (SUPERUSER ONLY)
+--
+-- Restores the pre-CA-SEC-03 state: cerp_app owns erp_audit_logs (+ its sequence)
+-- with full privileges, and the append-only trigger/function are removed.
+--
+--   sudo -u postgres psql -d <db> -f db/privileged/20260707_erp_audit_logs_append_only.rollback.sql
+--
+-- Non-destructive: no audit row is modified or deleted.
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS trg_erp_audit_logs_no_update ON public.erp_audit_logs;
+DROP TRIGGER IF EXISTS trg_erp_audit_logs_no_delete ON public.erp_audit_logs;
+DROP TRIGGER IF EXISTS trg_erp_audit_logs_no_truncate ON public.erp_audit_logs;
+DROP FUNCTION IF EXISTS public.erp_audit_logs_prevent_mutation();
+
+-- Restore ownership + privileges to the app role (prior state).
+DO $rb$
+DECLARE
+  v_seq text;
+BEGIN
+  IF to_regclass('public.erp_audit_logs') IS NULL THEN
+    RAISE NOTICE 'rollback: public.erp_audit_logs missing — nothing to do';
+    RETURN;
+  END IF;
+
+  EXECUTE 'ALTER TABLE public.erp_audit_logs OWNER TO cerp_app';
+
+  v_seq := pg_get_serial_sequence('public.erp_audit_logs', 'id');
+  IF v_seq IS NOT NULL THEN
+    EXECUTE format('ALTER SEQUENCE %s OWNER TO cerp_app', v_seq);
+  END IF;
+
+  EXECUTE 'GRANT ALL ON public.erp_audit_logs TO cerp_app';
+  IF v_seq IS NOT NULL THEN
+    EXECUTE format('GRANT ALL ON SEQUENCE %s TO cerp_app', v_seq);
+  END IF;
+END
+$rb$;
+
+COMMIT;

--- a/db/privileged/20260707_erp_audit_logs_append_only.sql
+++ b/db/privileged/20260707_erp_audit_logs_append_only.sql
@@ -1,0 +1,107 @@
+-- 20260707_erp_audit_logs_append_only.sql   (PRIVILEGED — SUPERUSER ONLY)
+--
+-- ISO/IEC 27001:2022 A.8.15 (Logging) — corrective action CA-SEC-03.
+-- Make public.erp_audit_logs APPEND-ONLY for the application role (cerp_app).
+--
+-- WHY THIS IS NOT A NORMAL db/patches PATCH
+--   The `db:patches` runner connects as the app role (cerp_app, via DATABASE_URL).
+--   cerp_app currently OWNS erp_audit_logs, and a table owner bypasses GRANT/REVOKE
+--   and can even `ALTER TABLE ... DISABLE TRIGGER`. Real immutability therefore
+--   requires moving ownership OFF the app role, which only a SUPERUSER can do.
+--   This file lives in db/privileged/ and MUST be applied by a DBA/superuser:
+--       sudo -u postgres psql -d cerp_test -f db/privileged/20260707_erp_audit_logs_append_only.sql
+--       sudo -u postgres psql -d cerp_prod -f db/privileged/20260707_erp_audit_logs_append_only.sql
+--   It is NOT picked up by `npm run db:patches:up` (which only reads db/patches/).
+--
+-- WHAT IT DOES
+--   1. Reassigns the table + its id sequence to `postgres` (owner off the app role).
+--   2. Restricts cerp_app to INSERT + SELECT (+ sequence USAGE) — no UPDATE/DELETE/TRUNCATE.
+--   3. Adds an append-only trigger (blocks UPDATE/DELETE/TRUNCATE for everyone, incl. the
+--      owner) as a hard backstop.
+--
+-- CONTROLLED MAINTENANCE (DBA / superuser only)
+--   Retention / anonymisation (CA-RGPD-02) is performed by a superuser by temporarily
+--   bypassing the append-only triggers:
+--       SET session_replication_role = 'replica';
+--       DELETE FROM public.erp_audit_logs WHERE created_at < now() - interval '<retention>';
+--       SET session_replication_role = 'origin';
+--   Only a superuser may set session_replication_role, so cerp_app cannot use this path.
+--
+-- SAFETY
+--   Idempotent (safe to re-run). Non-destructive: no row is modified or deleted.
+--   Rollback: db/privileged/20260707_erp_audit_logs_append_only.rollback.sql
+--   Verify:   db/privileged/20260707_erp_audit_logs_append_only.verify.sql
+--
+-- Target: PostgreSQL 17. Run as SUPERUSER (postgres).
+
+BEGIN;
+
+-- Guard: refuse to run as a non-superuser (e.g. the app role) — would fail half-way.
+DO $guard$
+BEGIN
+  IF NOT COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false) THEN
+    RAISE EXCEPTION
+      'CA-SEC-03: must be applied by a superuser; current_user=% is not a superuser', current_user;
+  END IF;
+END
+$guard$;
+
+DO $mig$
+DECLARE
+  v_seq text;
+BEGIN
+  IF to_regclass('public.erp_audit_logs') IS NULL THEN
+    RAISE NOTICE 'CA-SEC-03: public.erp_audit_logs is missing — nothing to do';
+    RETURN;
+  END IF;
+
+  -- 1) Ownership OFF the app role (so REVOKE/triggers cannot be bypassed by the owner).
+  EXECUTE 'ALTER TABLE public.erp_audit_logs OWNER TO postgres';
+
+  v_seq := pg_get_serial_sequence('public.erp_audit_logs', 'id');
+  IF v_seq IS NOT NULL THEN
+    EXECUTE format('ALTER SEQUENCE %s OWNER TO postgres', v_seq);
+  END IF;
+
+  -- 2) Least-privilege for the app role: INSERT + SELECT only.
+  EXECUTE 'REVOKE ALL ON public.erp_audit_logs FROM cerp_app';
+  EXECUTE 'REVOKE UPDATE, DELETE, TRUNCATE ON public.erp_audit_logs FROM PUBLIC';
+  EXECUTE 'GRANT SELECT, INSERT ON public.erp_audit_logs TO cerp_app';
+
+  -- 2b) The app still needs the id sequence to INSERT (nextval on the id default).
+  IF v_seq IS NOT NULL THEN
+    EXECUTE format('GRANT USAGE, SELECT ON SEQUENCE %s TO cerp_app', v_seq);
+  END IF;
+END
+$mig$;
+
+-- 3) Append-only backstop. Fires for EVERY role (including the owner). A superuser can
+--    bypass it for controlled maintenance via `SET session_replication_role = 'replica'`.
+CREATE OR REPLACE FUNCTION public.erp_audit_logs_prevent_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+  RAISE EXCEPTION
+    'erp_audit_logs is append-only: % is not permitted (ISO/IEC 27001 A.8.15 / CA-SEC-03)', TG_OP
+    USING ERRCODE = 'insufficient_privilege';
+  RETURN NULL;
+END
+$fn$;
+
+DROP TRIGGER IF EXISTS trg_erp_audit_logs_no_update ON public.erp_audit_logs;
+CREATE TRIGGER trg_erp_audit_logs_no_update
+  BEFORE UPDATE ON public.erp_audit_logs
+  FOR EACH ROW EXECUTE FUNCTION public.erp_audit_logs_prevent_mutation();
+
+DROP TRIGGER IF EXISTS trg_erp_audit_logs_no_delete ON public.erp_audit_logs;
+CREATE TRIGGER trg_erp_audit_logs_no_delete
+  BEFORE DELETE ON public.erp_audit_logs
+  FOR EACH ROW EXECUTE FUNCTION public.erp_audit_logs_prevent_mutation();
+
+DROP TRIGGER IF EXISTS trg_erp_audit_logs_no_truncate ON public.erp_audit_logs;
+CREATE TRIGGER trg_erp_audit_logs_no_truncate
+  BEFORE TRUNCATE ON public.erp_audit_logs
+  FOR EACH STATEMENT EXECUTE FUNCTION public.erp_audit_logs_prevent_mutation();
+
+COMMIT;

--- a/db/privileged/20260707_erp_audit_logs_append_only.verify.sql
+++ b/db/privileged/20260707_erp_audit_logs_append_only.verify.sql
@@ -1,0 +1,51 @@
+-- VERIFY CA-SEC-03 — erp_audit_logs append-only.   (SUPERUSER, on cerp_test)
+--
+--   sudo -u postgres psql -d cerp_test -f db/privileged/20260707_erp_audit_logs_append_only.verify.sql
+--
+-- Expected result:
+--   owner       = postgres
+--   cerp_app    = INSERT,SELECT
+--   [1] INSERT  -> SUCCESS (INSERT 0 1)
+--   [2] UPDATE  -> ERROR: permission denied for table erp_audit_logs  (privilege layer)
+--   [3] DELETE  -> ERROR: permission denied for table erp_audit_logs  (privilege layer)
+--   [4] UPDATE  -> ERROR: erp_audit_logs is append-only ...           (trigger backstop, owner)
+--   leftover    = 0
+
+\pset pager off
+\set ON_ERROR_STOP off
+
+\echo '### owner (expect: postgres)'
+SELECT tableowner FROM pg_tables WHERE schemaname = 'public' AND tablename = 'erp_audit_logs';
+
+\echo '### cerp_app table grants (expect: INSERT,SELECT)'
+SELECT COALESCE(string_agg(privilege_type, ',' ORDER BY privilege_type), '(none)') AS cerp_app_privs
+FROM information_schema.role_table_grants
+WHERE table_schema = 'public' AND table_name = 'erp_audit_logs' AND grantee = 'cerp_app';
+
+\echo '### existing append-only triggers (expect 3)'
+SELECT tgname FROM pg_trigger
+WHERE tgrelid = 'public.erp_audit_logs'::regclass AND NOT tgisinternal
+ORDER BY tgname;
+
+\echo '### [1] app role INSERT — EXPECT SUCCESS'
+SET ROLE cerp_app;
+INSERT INTO public.erp_audit_logs (user_id, event_type, action)
+VALUES (0, 'ACTION', 'ca_sec_03_verify');
+
+\echo '### [2] app role UPDATE — EXPECT: permission denied'
+UPDATE public.erp_audit_logs SET action = 'tampered' WHERE action = 'ca_sec_03_verify';
+
+\echo '### [3] app role DELETE — EXPECT: permission denied'
+DELETE FROM public.erp_audit_logs WHERE action = 'ca_sec_03_verify';
+RESET ROLE;
+
+\echo '### [4] trigger backstop: privileged UPDATE on the real row — EXPECT append-only exception'
+UPDATE public.erp_audit_logs SET action = 'tampered' WHERE action = 'ca_sec_03_verify';
+
+\echo '### [5] controlled maintenance cleanup (superuser + replica) — removes the marker row'
+SET session_replication_role = 'replica';
+DELETE FROM public.erp_audit_logs WHERE action = 'ca_sec_03_verify';
+SET session_replication_role = 'origin';
+
+\echo '### leftover marker rows (expect 0)'
+SELECT count(*) AS leftover FROM public.erp_audit_logs WHERE action = 'ca_sec_03_verify';

--- a/db/privileged/README.md
+++ b/db/privileged/README.md
@@ -1,0 +1,29 @@
+# db/privileged — superuser-only database migrations
+
+These SQL files are **NOT** part of the normal `db/patches` pipeline.
+
+`npm run db:patches:up` connects as the **application role** (`cerp_app`, via `DATABASE_URL`)
+and only reads `db/patches/*.sql`. The migrations here require a **PostgreSQL superuser**
+(`postgres`) because they change table ownership, grants, or other privileged objects that
+the app role cannot (and must not) perform.
+
+## How to apply
+
+```bash
+# On the atelier host (HYPERBOX2), via peer auth as the postgres superuser:
+sudo -u postgres psql -d cerp_test -f db/privileged/<file>.sql   # validate first
+sudo -u postgres psql -d cerp_prod -f db/privileged/<file>.sql   # prod, after validation
+```
+
+Each migration:
+- refuses to run if `current_user` is not a superuser (guard at the top);
+- is idempotent and non-destructive (no row changed/deleted);
+- ships with a `*.rollback.sql` and a `*.verify.sql` next to it.
+
+Always take a backup first: `sudo /usr/local/sbin/cerp-pg-backup.sh`.
+
+## Inventory
+
+| File | Purpose | ISO / CAPA |
+|---|---|---|
+| `20260707_erp_audit_logs_append_only.sql` | Make `erp_audit_logs` append-only for `cerp_app` (ownership off the app role + INSERT/SELECT-only grants + append-only trigger) | A.8.15 / CA-SEC-03 |

--- a/src/__tests__/audit-logs-append-only.guard.test.ts
+++ b/src/__tests__/audit-logs-append-only.guard.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+// CA-SEC-03 (ISO/IEC 27001:2022 A.8.15) — erp_audit_logs is APPEND-ONLY.
+//
+// The database enforces this: ownership is off the app role, cerp_app has INSERT/SELECT
+// only, and an append-only trigger blocks UPDATE/DELETE/TRUNCATE
+// (db/privileged/20260707_erp_audit_logs_append_only.sql).
+//
+// This test is the CODE-LEVEL regression guard: no application SQL may UPDATE, DELETE or
+// TRUNCATE erp_audit_logs — such a statement would fail at runtime against the hardened DB
+// and is therefore forbidden. If you must purge logs (retention), do it as a DBA/superuser,
+// never from the application.
+
+const SRC_DIR = path.resolve(__dirname, "..");
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "__tests__" || entry === "node_modules") continue;
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) out.push(...collectSourceFiles(full));
+    else if (/\.(ts|js)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+// UPDATE / DELETE / TRUNCATE targeting erp_audit_logs, within a single SQL statement
+// (the [^;] boundary keeps the match inside one statement / template literal).
+const FORBIDDEN: Array<{ label: string; re: RegExp }> = [
+  { label: "UPDATE erp_audit_logs", re: /update\s+[^;]*\berp_audit_logs\b/is },
+  { label: "DELETE FROM erp_audit_logs", re: /delete\s+from\s+[^;]*\berp_audit_logs\b/is },
+  { label: "TRUNCATE erp_audit_logs", re: /truncate\s+[^;]*\berp_audit_logs\b/is },
+];
+
+describe("CA-SEC-03 — erp_audit_logs is append-only at the code level", () => {
+  const files = collectSourceFiles(SRC_DIR);
+
+  it("has application source files to scan", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it("contains no UPDATE / DELETE / TRUNCATE against erp_audit_logs", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const sql = readFileSync(file, "utf8");
+      for (const { label, re } of FORBIDDEN) {
+        if (re.test(sql)) {
+          offenders.push(`${path.relative(SRC_DIR, file)} :: ${label}`);
+        }
+      }
+    }
+    expect(
+      offenders,
+      `erp_audit_logs is append-only (CA-SEC-03) — no app code may mutate it. Offenders:\n${offenders.join("\n")}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Promotion sur `main` de CA-SEC-03 (#53) : migration privilégiée `db/privileged/20260707_erp_audit_logs_append_only.sql` (append-only `erp_audit_logs`), rollback, verify, README, et guard-test code.

**Déjà appliqué + vérifié sur `cerp_test` ET `cerp_prod`** (owner=postgres, cerp_app=INSERT/SELECT, triggers append-only ; INSERT OK, UPDATE/DELETE refusés ; 5 lignes prod intactes). Backups pris.

Aucune application DB automatique au déploiement (migration superuser hors pipeline `db:patches`). CI : Typecheck + tests (143).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden erp_audit_logs as an append-only audit table via a privileged migration and add guardrails and verification around it.

Enhancements:
- Introduce a privileged PostgreSQL migration that moves erp_audit_logs ownership off the app role, restricts its privileges to INSERT/SELECT, and enforces append-only behaviour with triggers.
- Add a superuser-only rollback script to restore pre-change ownership and full privileges for erp_audit_logs, removing the append-only protections.
- Add a superuser-only verification script that validates ownership, grants, triggers, and expected behaviour of erp_audit_logs for the app and privileged roles.
- Document the new db/privileged migrations directory, its usage, and the inventory of privileged migrations.

Tests:
- Add a code-level guard test that scans the source tree to forbid any UPDATE/DELETE/TRUNCATE statements targeting erp_audit_logs, ensuring the application never attempts to mutate the append-only audit log.