### PR TITLE
release: users_view minimal exposure (CA-RGPD-07)

### DIFF
--- a/db/privileged/20260707_users_view_minimal.rollback.sql
+++ b/db/privileged/20260707_users_view_minimal.rollback.sql
@@ -1,0 +1,42 @@
+-- ROLLBACK for 20260707_users_view_minimal.sql   (SUPERUSER ONLY)
+--
+-- Restaure la vue users_view d'origine (colonnes complètes) et sa propriété cerp_app.
+--   sudo -u postgres psql -d <db> -f db/privileged/20260707_users_view_minimal.rollback.sql
+--
+-- Non destructif (aucune ligne `users` modifiée).
+
+BEGIN;
+
+DROP VIEW IF EXISTS public.users_view;
+
+CREATE VIEW public.users_view AS
+SELECT
+  id,
+  username,
+  password,
+  name,
+  surname,
+  email,
+  tel_no,
+  role,
+  gender,
+  address,
+  lane,
+  house_no,
+  postcode,
+  country,
+  salary,
+  date_of_birth,
+  employment_date,
+  employment_end_date,
+  national_id,
+  profile_picture,
+  last_login,
+  status,
+  created_at,
+  (date_of_birth > (CURRENT_DATE - INTERVAL '18 years')) AS is_minor
+FROM public.users;
+
+ALTER VIEW public.users_view OWNER TO cerp_app;
+
+COMMIT;

--- a/db/privileged/20260707_users_view_minimal.sql
+++ b/db/privileged/20260707_users_view_minimal.sql
@@ -1,0 +1,69 @@
+-- 20260707_users_view_minimal.sql   (PRIVILEGED — SUPERUSER ONLY)
+--
+-- ISO/IEC 27001:2022 A.8.24 / A.5.34 — minimisation, préparation avant CA-RGPD-01.
+-- Réduit l'exposition inutile de données sensibles dans la vue public.users_view.
+--
+-- CONTEXTE
+--   users_view exposait password, salary, national_id, date_of_birth, adresse (address/lane/
+--   house_no/postcode/country), gender, tel_no et les dates d'emploi — alors qu'AUCUN code
+--   applicatif ne l'utilise (vérifié : la table `users` est lue directement ; l'auth lit le
+--   mot de passe FROM users). La vue n'a aucun objet dépendant.
+--
+-- CE QUE FAIT LA MIGRATION
+--   Recrée users_view avec le strict nécessaire à l'administration standard, retire toutes
+--   les colonnes sensibles, conserve `is_minor` DÉRIVÉ (sans exposer la date de naissance),
+--   déplace la propriété au superuser et ne laisse que SELECT au rôle applicatif.
+--
+--   CONSERVÉ  : id, username, name, surname, email, role, status, profile_picture,
+--               last_login, created_at, is_minor (dérivé).
+--   RETIRÉ    : password, tel_no, gender, address, lane, house_no, postcode, country,
+--               salary, date_of_birth (brute), employment_date, employment_end_date,
+--               national_id.  (social_security_number n'y figurait déjà pas.)
+--
+-- POURQUOI SUPERUSER / db/privileged
+--   `CREATE OR REPLACE VIEW` ne peut pas retirer de colonnes → DROP + CREATE requis.
+--   La vue appartient au rôle applicatif ; on remet la propriété au superuser et on
+--   restreint à SELECT (cohérent avec CA-SEC-03). Hors pipeline `db:patches` (rôle app).
+--       sudo -u postgres psql -d cerp_test -f db/privileged/20260707_users_view_minimal.sql
+--       sudo -u postgres psql -d cerp_prod -f db/privileged/20260707_users_view_minimal.sql
+--
+-- SAFETY : non destructif (aucune ligne `users` modifiée). Idempotent.
+--   Rollback : db/privileged/20260707_users_view_minimal.rollback.sql
+--   Verify   : db/privileged/20260707_users_view_minimal.verify.sql
+--
+-- Cible : PostgreSQL. Run as SUPERUSER (postgres).
+
+BEGIN;
+
+-- Guard : refuse si non-superuser (ex. rôle applicatif).
+DO $guard$
+BEGIN
+  IF NOT COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false) THEN
+    RAISE EXCEPTION 'users_view minimal: must be applied by a superuser; current_user=% is not a superuser', current_user;
+  END IF;
+END
+$guard$;
+
+DROP VIEW IF EXISTS public.users_view;
+
+CREATE VIEW public.users_view AS
+SELECT
+  id,
+  username,
+  name,
+  surname,
+  email,
+  role,
+  status,
+  profile_picture,
+  last_login,
+  created_at,
+  (date_of_birth > (CURRENT_DATE - INTERVAL '18 years')) AS is_minor
+FROM public.users;
+
+-- Propriété au superuser + lecture seule pour le rôle applicatif.
+ALTER VIEW public.users_view OWNER TO postgres;
+REVOKE ALL ON public.users_view FROM PUBLIC;
+GRANT SELECT ON public.users_view TO cerp_app;
+
+COMMIT;

--- a/db/privileged/20260707_users_view_minimal.verify.sql
+++ b/db/privileged/20260707_users_view_minimal.verify.sql
@@ -1,0 +1,42 @@
+-- VERIFY users_view minimal exposure   (SUPERUSER, on cerp_test)
+--
+--   sudo -u postgres psql -d cerp_test -f db/privileged/20260707_users_view_minimal.verify.sql
+--
+-- Attendu :
+--   owner            = postgres
+--   columns          = id, username, name, surname, email, role, status,
+--                      profile_picture, last_login, created_at, is_minor
+--   sensitive_leaks  = 0
+--   cerp_app SELECT  = fonctionne (renvoie un count, aucune valeur sensible affichée)
+--   cerp_app grants  = SELECT
+
+\pset pager off
+\set ON_ERROR_STOP off
+
+\echo '### view owner (expect postgres)'
+SELECT viewowner FROM pg_views WHERE schemaname = 'public' AND viewname = 'users_view';
+
+\echo '### exposed columns'
+SELECT string_agg(column_name, ', ' ORDER BY ordinal_position) AS columns
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'users_view';
+
+\echo '### sensitive columns still exposed (expect 0)'
+SELECT count(*) AS sensitive_leaks
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'users_view'
+  AND column_name IN (
+    'password','salary','national_id','date_of_birth','social_security_number',
+    'address','tel_no','gender','lane','house_no','postcode','country',
+    'employment_date','employment_end_date'
+  );
+
+\echo '### cerp_app can still read the minimal view (count only, no values)'
+SET ROLE cerp_app;
+SELECT count(*) AS readable_rows FROM public.users_view;
+RESET ROLE;
+
+\echo '### cerp_app grants on the view (expect SELECT)'
+SELECT COALESCE(string_agg(privilege_type, ',' ORDER BY privilege_type), '(none)') AS cerp_app_privs
+FROM information_schema.role_table_grants
+WHERE table_schema = 'public' AND table_name = 'users_view' AND grantee = 'cerp_app';

--- a/db/privileged/README.md
+++ b/db/privileged/README.md
@@ -27,3 +27,4 @@ Always take a backup first: `sudo /usr/local/sbin/cerp-pg-backup.sh`.
 | File | Purpose | ISO / CAPA |
 |---|---|---|
 | `20260707_erp_audit_logs_append_only.sql` | Make `erp_audit_logs` append-only for `cerp_app` (ownership off the app role + INSERT/SELECT-only grants + append-only trigger) | A.8.15 / CA-SEC-03 |
+| `20260707_users_view_minimal.sql` | Recreate `users_view` without sensitive columns (drop `password`/`salary`/`national_id`/`date_of_birth`/address/…); keep standard-admin fields + derived `is_minor`; owner→`postgres`, `cerp_app` SELECT-only | A.8.24 / A.5.34 / CA-RGPD-07 |


### PR DESCRIPTION
Promotion sur main de #55 : migration privilégiée users_view minimale (retrait password/salary/national_id/DOB/adresse…), owner→postgres, cerp_app SELECT. Appliqué + vérifié sur cerp_test ET cerp_prod (sensitive_leaks=0, 4 lignes prod intactes). Hors pipeline db:patches. CI : Typecheck+tests 143.

## Summary by Sourcery

Restrict the public.users_view to a minimal, non-sensitive projection and align its ownership and grants with security requirements.

Enhancements:
- Recreate public.users_view to expose only non-sensitive administrative fields plus a derived is_minor flag while dropping password, salary, national_id, date_of_birth, address and other personal data.
- Transfer users_view ownership to the postgres superuser and restrict cerp_app permissions to SELECT-only for the view.
- Document the privileged migration in db/privileged/README.md along with dedicated rollback and verification scripts for the new minimal users_view.