### PR TITLE
release: GPAO pièces techniques versions/gammes (P2)

### DIFF
--- a/db/patches/20260707_pieces_techniques_gpao_versions_gammes.sql
+++ b/db/patches/20260707_pieces_techniques_gpao_versions_gammes.sql
@@ -1,0 +1,89 @@
+-- 20260707_pieces_techniques_gpao_versions_gammes.sql
+--
+-- GPAO — consolidation Pièces techniques (P2).
+-- ADR : crp-systems-web/docs/architecture/pieces-techniques-gpao-target-model.md
+--
+-- ADDITIF & NON DESTRUCTIF :
+--   - nouvelles tables : piece_technique_versions (indice/version/plan), gammes (gamme d'une version) ;
+--   - colonnes NULLABLES ajoutées à pieces_techniques_operations (+gamme_id, +machine_id)
+--     et pieces_techniques_nomenclature (+parent/child_version_id, +child_article_id) ;
+--   - dépréciation (COMMENT) du cluster legacy piece_technique/operation_technique/achat_technique.
+--   Aucune table/colonne existante n'est modifiée ou supprimée → le code actuel reste compatible.
+--   Tables cibles vides → aucune migration de données. Le legacy N'EST PAS supprimé (P4 ultérieure).
+--
+-- Pipeline normal db/patches (appliqué en tant que cerp_app, qui possède ces tables et a CREATE
+-- sur public). Idempotent (IF NOT EXISTS partout).
+--   Rollback : db/patches/support/20260707_pieces_techniques_gpao_versions_gammes.rollback.sql
+--   Verify   : db/patches/support/20260707_pieces_techniques_gpao_versions_gammes.verify.sql
+--
+-- Cible : PostgreSQL 17.
+
+BEGIN;
+
+-- 1) piece_technique_versions — indice / version / plan d'une pièce (identité = pieces_techniques).
+CREATE TABLE IF NOT EXISTS public.piece_technique_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  piece_technique_id uuid NOT NULL REFERENCES public.pieces_techniques(id) ON DELETE CASCADE,
+  indice text NOT NULL,
+  plan_reference text,
+  matiere_prevue text,
+  statut text NOT NULL DEFAULT 'brouillon',
+  is_current boolean NOT NULL DEFAULT false,
+  commentaire_revision text,
+  date_revision timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer,
+  updated_by integer,
+  CONSTRAINT piece_technique_versions_piece_indice_uq UNIQUE (piece_technique_id, indice)
+);
+CREATE INDEX IF NOT EXISTS piece_technique_versions_piece_idx
+  ON public.piece_technique_versions (piece_technique_id);
+
+-- 2) gammes — gamme d'une version (la gamme suit l'indice).
+CREATE TABLE IF NOT EXISTS public.gammes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  piece_technique_version_id uuid NOT NULL REFERENCES public.piece_technique_versions(id) ON DELETE CASCADE,
+  code text,
+  designation text,
+  statut text NOT NULL DEFAULT 'brouillon',
+  is_current boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer,
+  updated_by integer
+);
+CREATE INDEX IF NOT EXISTS gammes_version_idx
+  ON public.gammes (piece_technique_version_id);
+
+-- 3) pieces_techniques_operations : lien canonique vers la gamme + machine (additif, nullable).
+ALTER TABLE public.pieces_techniques_operations
+  ADD COLUMN IF NOT EXISTS gamme_id uuid REFERENCES public.gammes(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS machine_id uuid REFERENCES public.machines(id) ON DELETE SET NULL;
+CREATE INDEX IF NOT EXISTS pt_operations_gamme_idx
+  ON public.pieces_techniques_operations (gamme_id);
+
+-- 4) pieces_techniques_nomenclature : suivre l'indice (versions) + ligne article (acheté/standard/matière).
+ALTER TABLE public.pieces_techniques_nomenclature
+  ADD COLUMN IF NOT EXISTS parent_piece_technique_version_id uuid
+    REFERENCES public.piece_technique_versions(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS child_piece_technique_version_id uuid
+    REFERENCES public.piece_technique_versions(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS child_article_id uuid
+    REFERENCES public.articles(id) ON DELETE SET NULL;
+
+-- 5) Déprécier le cluster legacy (informatif, non destructif — suppression prévue en P4).
+DO $$
+BEGIN
+  IF to_regclass('public.piece_technique') IS NOT NULL THEN
+    EXECUTE 'COMMENT ON TABLE public.piece_technique IS ''DEPRECATED (2026-07-07) — utiliser pieces_techniques ; suppression prévue P4''';
+  END IF;
+  IF to_regclass('public.operation_technique') IS NOT NULL THEN
+    EXECUTE 'COMMENT ON TABLE public.operation_technique IS ''DEPRECATED (2026-07-07) — utiliser pieces_techniques_operations ; suppression prévue P4''';
+  END IF;
+  IF to_regclass('public.achat_technique') IS NOT NULL THEN
+    EXECUTE 'COMMENT ON TABLE public.achat_technique IS ''DEPRECATED (2026-07-07) — utiliser pieces_techniques_achats ; suppression prévue P4''';
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/support/20260707_pieces_techniques_gpao_versions_gammes.rollback.sql
+++ b/db/patches/support/20260707_pieces_techniques_gpao_versions_gammes.rollback.sql
@@ -1,0 +1,32 @@
+-- ROLLBACK for db/patches/20260707_pieces_techniques_gpao_versions_gammes.sql
+--
+-- Retire ce qui a été ajouté (additif) : colonnes, tables, commentaires de dépréciation.
+-- Non destructif pour les données existantes (les tables cibles étaient vides ; les colonnes
+-- ajoutées étaient nullables et neuves).
+--   psql -d <db> -f db/patches/support/20260707_pieces_techniques_gpao_versions_gammes.rollback.sql
+
+BEGIN;
+
+-- Colonnes additives (FK vers les nouvelles tables) — retirées AVANT les tables.
+ALTER TABLE public.pieces_techniques_nomenclature
+  DROP COLUMN IF EXISTS parent_piece_technique_version_id,
+  DROP COLUMN IF EXISTS child_piece_technique_version_id,
+  DROP COLUMN IF EXISTS child_article_id;
+
+ALTER TABLE public.pieces_techniques_operations
+  DROP COLUMN IF EXISTS gamme_id,
+  DROP COLUMN IF EXISTS machine_id;
+
+-- Nouvelles tables (gammes → versions : drop gammes d'abord).
+DROP TABLE IF EXISTS public.gammes;
+DROP TABLE IF EXISTS public.piece_technique_versions;
+
+-- Retirer les commentaires de dépréciation.
+DO $$
+BEGIN
+  IF to_regclass('public.piece_technique') IS NOT NULL THEN EXECUTE 'COMMENT ON TABLE public.piece_technique IS NULL'; END IF;
+  IF to_regclass('public.operation_technique') IS NOT NULL THEN EXECUTE 'COMMENT ON TABLE public.operation_technique IS NULL'; END IF;
+  IF to_regclass('public.achat_technique') IS NOT NULL THEN EXECUTE 'COMMENT ON TABLE public.achat_technique IS NULL'; END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/support/20260707_pieces_techniques_gpao_versions_gammes.verify.sql
+++ b/db/patches/support/20260707_pieces_techniques_gpao_versions_gammes.verify.sql
@@ -1,0 +1,56 @@
+-- VERIFY db/patches/20260707_pieces_techniques_gpao_versions_gammes.sql
+--
+-- À exécuter sur cerp_test après la migration. Prouve : nouvelles tables/colonnes présentes,
+-- possédées par cerp_app (l'app peut écrire), FK en place, ET compatibilité (les colonnes/FK
+-- existantes de pieces_techniques_operations / _nomenclature sont intactes).
+--   sudo -u postgres psql -d cerp_test -f db/patches/support/20260707_...verify.sql
+
+\pset pager off
+
+\echo '### nouvelles tables + owner (attendu: cerp_app)'
+SELECT tablename, tableowner FROM pg_tables
+WHERE schemaname='public' AND tablename IN ('piece_technique_versions','gammes')
+ORDER BY tablename;
+
+\echo '### colonnes ajoutées à pieces_techniques_operations (attendu: gamme_id, machine_id)'
+SELECT column_name FROM information_schema.columns
+WHERE table_schema='public' AND table_name='pieces_techniques_operations'
+  AND column_name IN ('gamme_id','machine_id') ORDER BY column_name;
+
+\echo '### colonnes ajoutées à pieces_techniques_nomenclature (attendu: 3)'
+SELECT column_name FROM information_schema.columns
+WHERE table_schema='public' AND table_name='pieces_techniques_nomenclature'
+  AND column_name IN ('parent_piece_technique_version_id','child_piece_technique_version_id','child_article_id')
+ORDER BY column_name;
+
+\echo '### COMPAT — colonnes existantes de pieces_techniques_operations toujours présentes (attendu: 1)'
+SELECT count(*) AS ops_existing_cols_ok FROM information_schema.columns
+WHERE table_schema='public' AND table_name='pieces_techniques_operations'
+  AND column_name IN ('phase','prix','coef','tp','tf_unit','qte','taux_horaire','temps_total','cout_mo')
+HAVING count(*) = 9;
+
+\echo '### COMPAT — les tables existantes restent lisibles (aucune erreur = compatible)'
+SELECT
+  (SELECT count(*) FROM public.pieces_techniques)              AS pieces,
+  (SELECT count(*) FROM public.pieces_techniques_operations)  AS operations,
+  (SELECT count(*) FROM public.pieces_techniques_nomenclature) AS nomenclature;
+
+\echo '### FK des nouvelles tables (attendu: versions→pieces_techniques, gammes→versions, ops.gamme_id→gammes, ops.machine_id→machines, nomenclature.*→versions/articles)'
+SELECT conrelid::regclass AS on_table, confrelid::regclass AS referenced_table, conname
+FROM pg_constraint
+WHERE contype='f' AND conrelid IN (
+  'public.piece_technique_versions'::regclass,
+  'public.gammes'::regclass,
+  'public.pieces_techniques_operations'::regclass,
+  'public.pieces_techniques_nomenclature'::regclass
+) AND confrelid IN (
+  'public.pieces_techniques'::regclass,'public.piece_technique_versions'::regclass,
+  'public.gammes'::regclass,'public.machines'::regclass,'public.articles'::regclass
+)
+ORDER BY on_table, referenced_table;
+
+\echo '### legacy déprécié (attendu: 3 commentaires DEPRECATED)'
+SELECT c.relname, obj_description(c.oid) AS comment
+FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+WHERE n.nspname='public' AND c.relname IN ('piece_technique','operation_technique','achat_technique')
+ORDER BY c.relname;

--- a/db/patches/support/README.md
+++ b/db/patches/support/README.md
@@ -1,0 +1,12 @@
+# db/patches/support
+
+Fichiers **auxiliaires** des migrations `db/patches/` : `*.rollback.sql` et `*.verify.sql`.
+
+Ils sont volontairement dans ce **sous-dossier** pour ne PAS être exécutés par le runner
+`db:patches:up`, qui ne lit que `db/patches/*.sql` au premier niveau (`readdirSync` +
+filtre `.sql`, sans récursion). Ils sont lancés **manuellement** :
+
+```bash
+sudo -u postgres psql -d cerp_test -f db/patches/support/<name>.verify.sql
+sudo -u postgres psql -d <db>      -f db/patches/support/<name>.rollback.sql
+```

--- a/src/__tests__/gpao-legacy-pieces.guard.test.ts
+++ b/src/__tests__/gpao-legacy-pieces.guard.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import path from "node:path";
+
+// GPAO — le cluster legacy `piece_technique` / `operation_technique` / `achat_technique`
+// est DÉPRÉCIÉ (ADR pieces-techniques-gpao-target-model). La source canonique est
+// `pieces_techniques` (pluriel) et son écosystème. Ce garde empêche tout NOUVEL usage de ces
+// tables legacy dans le code applicatif (SQL FROM/JOIN/INTO/UPDATE/DELETE), en attendant leur
+// suppression physique (P4). Aujourd'hui : 0 usage — ce test verrouille l'état.
+
+const SRC_DIR = path.resolve(__dirname, "..");
+
+function collectSourceFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (entry === "__tests__" || entry === "node_modules") continue;
+    const full = path.join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) out.push(...collectSourceFiles(full));
+    else if (/\.(ts|js)$/.test(entry)) out.push(full);
+  }
+  return out;
+}
+
+// Nom de table legacy en position SQL (FROM/JOIN/INTO/UPDATE/DELETE FROM), au singulier.
+// Le `\b` après le nom évite de matcher `piece_technique_id` (colonne, suivie de `_id`) et
+// le pluriel `pieces_techniques` (pas de "piece_technique" sans "s" devant le "_").
+const LEGACY = ["piece_technique", "operation_technique", "achat_technique"];
+const FORBIDDEN = LEGACY.map((t) => ({
+  table: t,
+  re: new RegExp(String.raw`\b(from|join|into|update|delete\s+from)\s+(public\.)?${t}\b(?!_)`, "is"),
+}));
+
+describe("GPAO — pas de nouvel usage des tables Pièces techniques legacy", () => {
+  const files = collectSourceFiles(SRC_DIR);
+
+  it("a des fichiers source à scanner", () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it("n'utilise aucune table legacy (piece_technique/operation_technique/achat_technique) en SQL", () => {
+    const offenders: string[] = [];
+    for (const file of files) {
+      const sql = readFileSync(file, "utf8");
+      for (const { table, re } of FORBIDDEN) {
+        if (re.test(sql)) offenders.push(`${path.relative(SRC_DIR, file)} :: ${table}`);
+      }
+    }
+    expect(
+      offenders,
+      `Tables legacy dépréciées — utilise pieces_techniques (pluriel). Offenders:\n${offenders.join("\n")}`
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Promotion sur main de #57 : migration additive GPAO (piece_technique_versions, gammes, +gamme_id/machine_id sur operations, +versions/article sur nomenclature ; legacy déprécié + garde). Appliqué + vérifié sur cerp_test ET cerp_prod (13 FK, compat). Non destructif. CI Typecheck+tests 145.

## Summary by Sourcery

Introduce additive, non-destructive GPAO database migration for technical parts versions and routings, with supporting rollback, verification scripts, and a guard test against legacy table usage.

New Features:
- Add piece_technique_versions and gammes tables to model technical part versions and their routings.
- Extend pieces_techniques_operations with optional links to gammes and machines.
- Extend pieces_techniques_nomenclature with optional links to technical part versions and articles.

Enhancements:
- Deprecate legacy GPAO technical part tables via schema comments while keeping them operational.
- Document the support directory for migration rollback and verification scripts.

Documentation:
- Add README documenting how to run migration support verify and rollback scripts manually.

Tests:
- Add a guard test ensuring no new SQL usage of deprecated legacy GPAO tables in application source code.