### PR TITLE
Release — GPAO/PDM V2 (backend)

### DIFF
--- a/db/patches/20260708_gpao_achats_type.sql
+++ b/db/patches/20260708_gpao_achats_type.sql
@@ -1,0 +1,37 @@
+-- 20260708_gpao_achats_type.sql
+--
+-- GPAO B3.5 — Nomenclature d'achat séparée : catégorie de ligne d'achat (type_achat).
+-- Catégorise chaque ligne de pieces_techniques_achats (matière, visserie, composant catalogue,
+-- traitement, sous-traitance, certificat, divers) afin d'afficher une nomenclature d'achat
+-- STRUCTURÉE et DISTINCTE de l'arborescence de fabrication. Les achats ne sont jamais des
+-- nœuds fabriqués (cf. 20260708_gpao_nomenclature_versioned.sql).
+--
+-- ADDITIF & NON DESTRUCTIF : nouvelle colonne NOT NULL DEFAULT 'DIVERS' — les lignes existantes
+-- et les INSERT qui n'indiquent pas type_achat prennent le défaut 'DIVERS' (aucune rupture du
+-- flux de création). Idempotent. Pipeline db/patches (cerp_app). PostgreSQL 17. Rollback dans support/.
+
+BEGIN;
+
+ALTER TABLE public.pieces_techniques_achats
+  ADD COLUMN IF NOT EXISTS type_achat text NOT NULL DEFAULT 'DIVERS';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pt_achats_type_achat_check'
+      AND conrelid = 'public.pieces_techniques_achats'::regclass
+  ) THEN
+    ALTER TABLE public.pieces_techniques_achats
+      ADD CONSTRAINT pt_achats_type_achat_check
+      CHECK ( type_achat IN (
+        'MATIERE','VISSERIE','COMPOSANT_CATALOGUE','TRAITEMENT',
+        'SOUS_TRAITANCE','CERTIFICAT','DIVERS'
+      ) );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS pt_achats_type_achat_idx
+  ON public.pieces_techniques_achats (piece_technique_id, type_achat);
+
+COMMIT;

--- a/db/patches/20260708_gpao_gammes_operations_types.sql
+++ b/db/patches/20260708_gpao_gammes_operations_types.sql
@@ -1,0 +1,40 @@
+-- 20260708_gpao_gammes_operations_types.sql
+--
+-- GPAO B2.2 — gammes (nom/commentaire, statut aligné sur la version) + types d'opérations.
+-- ADDITIF & NON DESTRUCTIF : nouvelles colonnes nullables + élargissement d'un CHECK sur table
+-- vide. Les opérations existantes (sans gamme_id) restent lisibles et inchangées. Idempotent.
+-- Pipeline db/patches (cerp_app). Cible : PostgreSQL 17. Rollback dans support/.
+
+BEGIN;
+
+-- 1) gammes : nom + commentaire ; statut aligné sur le cycle de vie des versions.
+ALTER TABLE public.gammes
+  ADD COLUMN IF NOT EXISTS nom text,
+  ADD COLUMN IF NOT EXISTS commentaire text;
+
+ALTER TABLE public.gammes DROP CONSTRAINT IF EXISTS gammes_statut_check;
+ALTER TABLE public.gammes
+  ADD CONSTRAINT gammes_statut_check
+  CHECK (statut IN ('BROUILLON','EN_VALIDATION','APPLICABLE','OBSOLETE'));
+
+-- 2) opérations : type d'opération (découpage usinage), poste de charge, consignes.
+ALTER TABLE public.pieces_techniques_operations
+  ADD COLUMN IF NOT EXISTS type_operation text,
+  ADD COLUMN IF NOT EXISTS poste_id uuid,
+  ADD COLUMN IF NOT EXISTS consignes text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pieces_techniques_operations_type_operation_check'
+      AND conrelid = 'public.pieces_techniques_operations'::regclass
+  ) THEN
+    ALTER TABLE public.pieces_techniques_operations
+      ADD CONSTRAINT pieces_techniques_operations_type_operation_check
+      CHECK (type_operation IS NULL OR type_operation IN
+        ('TOURNAGE','FRAISAGE','REPRISE','CONTROLE','LAVAGE','SOUS_TRAITANCE','EMBALLAGE','AUTRE'));
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/20260708_gpao_nomenclature_versioned.sql
+++ b/db/patches/20260708_gpao_nomenclature_versioned.sql
@@ -1,0 +1,36 @@
+-- 20260708_gpao_nomenclature_versioned.sql
+--
+-- GPAO B2.3 — nomenclature/arborescence versionnée + séparation fabrication ⟂ achats.
+-- Une ligne de nomenclature de FABRICATION est SOIT une sous-pièce fabriquée
+-- (child_piece_technique_id, avec sa version child_piece_technique_version_id) SOIT un
+-- composant article non fabriqué (child_article_id) — jamais les deux. Les achats "purs"
+-- (matière, visserie, traitements, sous-traitance) restent dans pieces_techniques_achats et
+-- N'APPARAISSENT PAS dans l'arborescence de fabrication.
+--
+-- ADDITIF & NON DESTRUCTIF : les colonnes parent/child_piece_technique_version_id et
+-- child_article_id existent déjà (P2, nullables). On relâche seulement le NOT NULL de
+-- child_piece_technique_id (table vide → sûr) et on ajoute un CHECK XOR. Les insertions
+-- existantes (qui fournissent toujours child_piece_technique_id) restent valides (1+0=1).
+-- Idempotent. Pipeline db/patches (cerp_app). Cible : PostgreSQL 17. Rollback dans support/.
+
+BEGIN;
+
+ALTER TABLE public.pieces_techniques_nomenclature ALTER COLUMN child_piece_technique_id DROP NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pt_nomenclature_child_xor_article'
+      AND conrelid = 'public.pieces_techniques_nomenclature'::regclass
+  ) THEN
+    ALTER TABLE public.pieces_techniques_nomenclature
+      ADD CONSTRAINT pt_nomenclature_child_xor_article
+      CHECK ( (child_piece_technique_id IS NOT NULL)::int + (child_article_id IS NOT NULL)::int = 1 );
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS pt_nomenclature_child_article_idx
+  ON public.pieces_techniques_nomenclature (child_article_id) WHERE child_article_id IS NOT NULL;
+
+COMMIT;

--- a/db/patches/20260708_gpao_piece_article_unique.sql
+++ b/db/patches/20260708_gpao_piece_article_unique.sql
@@ -1,0 +1,19 @@
+-- 20260708_gpao_piece_article_unique.sql
+--
+-- GPAO B5 — unicité inverse du lien pièce↔article : au plus UN article principal par pièce côté
+-- pieces_techniques.article_id (miroir des index côté articles : articles_piece_technique_id_uniq
+-- + articles_fabrique_piece_uniq). Rend la relation strictement 1:1 : toute dérive (deux pièces
+-- pointant le même article) devient une erreur DB au lieu d'une corruption silencieuse.
+--
+-- ADDITIF & NON DESTRUCTIF : ajoute un index partiel unique (l'index non-unique préexistant
+-- pieces_techniques_article_id_idx est laissé en place, redondant mais inoffensif). cerp_test = 0
+-- ligne concernée → sûr. Idempotent. Pipeline db/patches (cerp_app). Rollback dans support/.
+-- cerp_prod : appliqué UNIQUEMENT au gate B7 (backup + verify).
+
+BEGIN;
+
+CREATE UNIQUE INDEX IF NOT EXISTS pieces_techniques_article_id_uniq
+  ON public.pieces_techniques (article_id)
+  WHERE article_id IS NOT NULL;
+
+COMMIT;

--- a/db/patches/20260708_gpao_versions_lifecycle.sql
+++ b/db/patches/20260708_gpao_versions_lifecycle.sql
@@ -1,0 +1,86 @@
+-- 20260708_gpao_versions_lifecycle.sql
+--
+-- GPAO B2 — cycle de vie des versions/indices + ordre des opérations.
+-- ADR : crp-systems-web/docs/architecture/pieces-techniques-gpao-target-model.md + B1 audit.
+--
+-- ADDITIF & NON DESTRUCTIF : ne modifie/supprime aucune colonne existante. Tables cibles
+-- (piece_technique_versions, gammes, pieces_techniques_operations) — les deux premières sont
+-- vides → aucune migration de données. Idempotent (IF NOT EXISTS / gardes).
+--
+-- Pipeline normal db/patches (appliqué en tant que cerp_app). Rollback + verify dans support/.
+-- Cible : PostgreSQL 17.
+
+BEGIN;
+
+-- 1) piece_technique_versions — statut canonique + champs évolution/modification.
+ALTER TABLE public.piece_technique_versions ALTER COLUMN statut SET DEFAULT 'BROUILLON';
+
+DO $$
+BEGIN
+  -- normalisation (no-op : table vide) puis CHECK statut
+  UPDATE public.piece_technique_versions SET statut = upper(statut) WHERE statut IS NOT NULL AND statut <> upper(statut);
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'piece_technique_versions_statut_check'
+      AND conrelid = 'public.piece_technique_versions'::regclass
+  ) THEN
+    ALTER TABLE public.piece_technique_versions
+      ADD CONSTRAINT piece_technique_versions_statut_check
+      CHECK (statut IN ('BROUILLON','EN_VALIDATION','APPLICABLE','OBSOLETE'));
+  END IF;
+END $$;
+
+ALTER TABLE public.piece_technique_versions
+  ADD COLUMN IF NOT EXISTS type_changement text,
+  ADD COLUMN IF NOT EXISTS raison_changement text,
+  ADD COLUMN IF NOT EXISTS impact_interchangeabilite boolean,
+  ADD COLUMN IF NOT EXISTS impact_parents text,
+  ADD COLUMN IF NOT EXISTS valide_par integer,
+  ADD COLUMN IF NOT EXISTS date_validation timestamptz,
+  ADD COLUMN IF NOT EXISTS date_application date,
+  ADD COLUMN IF NOT EXISTS commentaire_validation text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'piece_technique_versions_type_changement_check'
+      AND conrelid = 'public.piece_technique_versions'::regclass
+  ) THEN
+    ALTER TABLE public.piece_technique_versions
+      ADD CONSTRAINT piece_technique_versions_type_changement_check
+      CHECK (type_changement IS NULL OR type_changement IN ('EVOLUTION','MODIFICATION'));
+  END IF;
+END $$;
+
+-- Règle métier : une seule version APPLICABLE par pièce technique.
+CREATE UNIQUE INDEX IF NOT EXISTS piece_technique_versions_one_applicable_uq
+  ON public.piece_technique_versions (piece_technique_id)
+  WHERE statut = 'APPLICABLE';
+
+-- 2) gammes — statut canonique + une seule gamme courante par version.
+ALTER TABLE public.gammes ALTER COLUMN statut SET DEFAULT 'BROUILLON';
+
+DO $$
+BEGIN
+  UPDATE public.gammes SET statut = upper(statut) WHERE statut IS NOT NULL AND statut <> upper(statut);
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'gammes_statut_check' AND conrelid = 'public.gammes'::regclass
+  ) THEN
+    ALTER TABLE public.gammes
+      ADD CONSTRAINT gammes_statut_check
+      CHECK (statut IN ('BROUILLON','APPLICABLE','OBSOLETE'));
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS gammes_one_current_per_version_uq
+  ON public.gammes (piece_technique_version_id)
+  WHERE is_current = true;
+
+-- 3) pieces_techniques_operations — ordre d'affichage distinct de `phase`
+--    (le reorder ne doit plus écraser le numéro de phase).
+ALTER TABLE public.pieces_techniques_operations
+  ADD COLUMN IF NOT EXISTS ordre integer;
+
+COMMIT;

--- a/db/patches/support/20260708_gpao_achats_type.rollback.sql
+++ b/db/patches/support/20260708_gpao_achats_type.rollback.sql
@@ -1,0 +1,15 @@
+-- Rollback de 20260708_gpao_achats_type.sql (GPAO B3.5).
+-- Retire la catégorie d'achat (type_achat) + son CHECK + son index. Non destructif pour les
+-- autres colonnes. À exécuter par un DBA hors du runner db:patches (le runner ne parcourt pas support/).
+
+BEGIN;
+
+DROP INDEX IF EXISTS public.pt_achats_type_achat_idx;
+
+ALTER TABLE public.pieces_techniques_achats
+  DROP CONSTRAINT IF EXISTS pt_achats_type_achat_check;
+
+ALTER TABLE public.pieces_techniques_achats
+  DROP COLUMN IF EXISTS type_achat;
+
+COMMIT;

--- a/db/patches/support/20260708_gpao_gammes_operations_types.rollback.sql
+++ b/db/patches/support/20260708_gpao_gammes_operations_types.rollback.sql
@@ -1,0 +1,12 @@
+-- ROLLBACK for db/patches/20260708_gpao_gammes_operations_types.sql
+BEGIN;
+ALTER TABLE public.pieces_techniques_operations
+  DROP CONSTRAINT IF EXISTS pieces_techniques_operations_type_operation_check,
+  DROP COLUMN IF EXISTS type_operation,
+  DROP COLUMN IF EXISTS poste_id,
+  DROP COLUMN IF EXISTS consignes;
+ALTER TABLE public.gammes DROP CONSTRAINT IF EXISTS gammes_statut_check;
+ALTER TABLE public.gammes
+  ADD CONSTRAINT gammes_statut_check CHECK (statut IN ('BROUILLON','APPLICABLE','OBSOLETE'));
+ALTER TABLE public.gammes DROP COLUMN IF EXISTS nom, DROP COLUMN IF EXISTS commentaire;
+COMMIT;

--- a/db/patches/support/20260708_gpao_nomenclature_versioned.rollback.sql
+++ b/db/patches/support/20260708_gpao_nomenclature_versioned.rollback.sql
@@ -1,0 +1,13 @@
+-- ROLLBACK for db/patches/20260708_gpao_nomenclature_versioned.sql
+-- NB : re-mettre NOT NULL n'est sûr que si aucune ligne article-seule n'existe.
+BEGIN;
+DROP INDEX IF EXISTS public.pt_nomenclature_child_article_idx;
+ALTER TABLE public.pieces_techniques_nomenclature DROP CONSTRAINT IF EXISTS pt_nomenclature_child_xor_article;
+-- Restaure NOT NULL uniquement si plus aucune ligne sans child_piece_technique_id.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.pieces_techniques_nomenclature WHERE child_piece_technique_id IS NULL) THEN
+    ALTER TABLE public.pieces_techniques_nomenclature ALTER COLUMN child_piece_technique_id SET NOT NULL;
+  END IF;
+END $$;
+COMMIT;

--- a/db/patches/support/20260708_gpao_piece_article_unique.rollback.sql
+++ b/db/patches/support/20260708_gpao_piece_article_unique.rollback.sql
@@ -1,0 +1,5 @@
+-- Rollback de 20260708_gpao_piece_article_unique.sql (GPAO B5).
+-- Retire l'index partiel unique inverse. L'index non-unique pieces_techniques_article_id_idx reste.
+BEGIN;
+DROP INDEX IF EXISTS public.pieces_techniques_article_id_uniq;
+COMMIT;

--- a/db/patches/support/20260708_gpao_versions_lifecycle.rollback.sql
+++ b/db/patches/support/20260708_gpao_versions_lifecycle.rollback.sql
@@ -1,0 +1,18 @@
+-- ROLLBACK for db/patches/20260708_gpao_versions_lifecycle.sql (additif → on retire les ajouts).
+BEGIN;
+DROP INDEX IF EXISTS public.piece_technique_versions_one_applicable_uq;
+DROP INDEX IF EXISTS public.gammes_one_current_per_version_uq;
+ALTER TABLE public.piece_technique_versions
+  DROP CONSTRAINT IF EXISTS piece_technique_versions_statut_check,
+  DROP CONSTRAINT IF EXISTS piece_technique_versions_type_changement_check,
+  DROP COLUMN IF EXISTS type_changement,
+  DROP COLUMN IF EXISTS raison_changement,
+  DROP COLUMN IF EXISTS impact_interchangeabilite,
+  DROP COLUMN IF EXISTS impact_parents,
+  DROP COLUMN IF EXISTS valide_par,
+  DROP COLUMN IF EXISTS date_validation,
+  DROP COLUMN IF EXISTS date_application,
+  DROP COLUMN IF EXISTS commentaire_validation;
+ALTER TABLE public.gammes DROP CONSTRAINT IF EXISTS gammes_statut_check;
+ALTER TABLE public.pieces_techniques_operations DROP COLUMN IF EXISTS ordre;
+COMMIT;

--- a/src/__tests__/article-piece-link.test.ts
+++ b/src/__tests__/article-piece-link.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import { createArticleSchema } from "../module/stock/validators/stock.validators"
+
+// GPAO B5 — invariant fondamental : un article fabriqué exige une pièce technique (et réciproquement,
+// un article non-fabriqué ne peut pas en porter). Les scénarios link/doublon/create-from-piece/
+// transaction bidirectionnelle/audit sont validés en E2E API sur cerp_test (B5.5).
+const UUID = "11111111-1111-4111-8111-111111111111"
+
+describe("B5 — cohérence article fabriqué ↔ pièce technique (schéma de création)", () => {
+  it("rejette un article 'fabrique' SANS piece_technique_id", () => {
+    expect(() =>
+      createArticleSchema.parse({
+        body: { code: "PT-X", designation: "Test", family_code: "FAB", article_category: "fabrique" },
+      })
+    ).toThrow()
+  })
+
+  it("accepte un article 'fabrique' AVEC piece_technique_id", () => {
+    const r = createArticleSchema.parse({
+      body: {
+        code: "PT-X",
+        designation: "Test",
+        family_code: "FAB",
+        article_category: "fabrique",
+        piece_technique_id: UUID,
+      },
+    })
+    expect(r.body.piece_technique_id).toBe(UUID)
+    expect(r.body.article_category).toBe("fabrique")
+  })
+
+  it("rejette un piece_technique_id sur un article NON fabriqué ('achat')", () => {
+    expect(() =>
+      createArticleSchema.parse({
+        body: {
+          code: "ACH-X",
+          designation: "Test",
+          family_code: "ACH",
+          article_category: "achat",
+          piece_technique_id: UUID,
+        },
+      })
+    ).toThrow()
+  })
+})

--- a/src/__tests__/gammes.test.ts
+++ b/src/__tests__/gammes.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest"
+import {
+  addGammeOperationSchema,
+  createGammeSchema,
+  gammeStatutSchema,
+  operationTypeSchema,
+  reorderOperationsSchema,
+  updateGammeSchema,
+} from "../module/gammes/validators/gammes.validators"
+
+// GPAO B2.2 — validators gammes + opérations. (Le flux DB réel — création gamme, opérations,
+// reorder sans écraser phase, lisibilité des opérations legacy — est prouvé par le script
+// verify SQL sur cerp_test.)
+
+describe("Gammes — validators", () => {
+  it("exige un nom de gamme", () => {
+    expect(createGammeSchema.safeParse({ body: { nom: "Gamme principale" } }).success).toBe(true)
+    expect(createGammeSchema.safeParse({ body: {} }).success).toBe(false)
+  })
+
+  it("statut par défaut BROUILLON + enum aligné sur la version", () => {
+    const parsed = createGammeSchema.safeParse({ body: { nom: "G" } })
+    expect(parsed.success && parsed.data.body.statut).toBe("BROUILLON")
+    expect(gammeStatutSchema.options).toEqual(["BROUILLON", "EN_VALIDATION", "APPLICABLE", "OBSOLETE"])
+    expect(createGammeSchema.safeParse({ body: { nom: "G", statut: "WRONG" } }).success).toBe(false)
+  })
+
+  it("update partiel + expected_updated_at", () => {
+    expect(updateGammeSchema.safeParse({ body: { is_current: true, expected_updated_at: "2026-07-08" } }).success).toBe(true)
+    expect(updateGammeSchema.safeParse({ body: {} }).success).toBe(true)
+  })
+})
+
+describe("Gammes — opérations", () => {
+  it("exige une désignation ; défauts temps/coef ; type_operation optionnel", () => {
+    const ok = addGammeOperationSchema.safeParse({ body: { designation: "Tournage ébauche", type_operation: "TOURNAGE" } })
+    expect(ok.success).toBe(true)
+    if (ok.success) {
+      expect(ok.data.body.qte).toBe(1)
+      expect(ok.data.body.coef).toBe(1)
+      expect(ok.data.body.numero_operation).toBe(10)
+    }
+    expect(addGammeOperationSchema.safeParse({ body: {} }).success).toBe(false)
+  })
+
+  it("découpage usinage — types d'opération attendus", () => {
+    expect(operationTypeSchema.options).toEqual([
+      "TOURNAGE",
+      "FRAISAGE",
+      "REPRISE",
+      "CONTROLE",
+      "LAVAGE",
+      "SOUS_TRAITANCE",
+      "EMBALLAGE",
+      "AUTRE",
+    ])
+    expect(addGammeOperationSchema.safeParse({ body: { designation: "x", type_operation: "USINAGE" } }).success).toBe(false)
+  })
+
+  it("reorder exige une liste d'uuid", () => {
+    expect(reorderOperationsSchema.safeParse({ body: { order: ["11111111-1111-1111-1111-111111111111"] } }).success).toBe(true)
+    expect(reorderOperationsSchema.safeParse({ body: { order: [] } }).success).toBe(false)
+    expect(reorderOperationsSchema.safeParse({ body: { order: ["not-a-uuid"] } }).success).toBe(false)
+  })
+})

--- a/src/__tests__/pieces-techniques-achat-type.test.ts
+++ b/src/__tests__/pieces-techniques-achat-type.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest"
+
+import { addAchatSchema } from "../module/pieces-techniques/validators/pieces-techniques.validators"
+
+// GPAO B4 — le write-path des achats accepte la catégorie type_achat (défaut DIVERS).
+describe("addAchatSchema — type_achat (B4)", () => {
+  it("défaut à DIVERS quand type_achat est absent (rétro-compatible)", () => {
+    const r = addAchatSchema.parse({ body: { quantite: 1 } })
+    expect(r.body.type_achat).toBe("DIVERS")
+  })
+
+  it("accepte les 7 catégories", () => {
+    const cats = [
+      "MATIERE",
+      "VISSERIE",
+      "COMPOSANT_CATALOGUE",
+      "TRAITEMENT",
+      "SOUS_TRAITANCE",
+      "CERTIFICAT",
+      "DIVERS",
+    ] as const
+    for (const t of cats) {
+      const r = addAchatSchema.parse({ body: { quantite: 1, type_achat: t } })
+      expect(r.body.type_achat).toBe(t)
+    }
+  })
+
+  it("rejette une catégorie inconnue", () => {
+    expect(() => addAchatSchema.parse({ body: { quantite: 1, type_achat: "BOGUS" } })).toThrow()
+  })
+})

--- a/src/__tests__/pieces-techniques-versions.test.ts
+++ b/src/__tests__/pieces-techniques-versions.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest"
+import { isValidVersionTransition } from "../module/pieces-techniques/services/versions.service"
+import {
+  createNextVersionSchema,
+  createVersionSchema,
+  versionStatusSchema,
+} from "../module/pieces-techniques/validators/versions.validators"
+
+// GPAO B2.1 — règles de cycle de vie des versions.
+// (La règle "une seule APPLICABLE" est en plus garantie par l'index unique partiel DB
+//  piece_technique_versions_one_applicable_uq — prouvé sur cerp_test.)
+
+describe("Versions — transitions de statut", () => {
+  it("autorise le parcours nominal BROUILLON → EN_VALIDATION → APPLICABLE → OBSOLETE", () => {
+    expect(isValidVersionTransition("BROUILLON", "EN_VALIDATION")).toBe(true)
+    expect(isValidVersionTransition("EN_VALIDATION", "APPLICABLE")).toBe(true)
+    expect(isValidVersionTransition("APPLICABLE", "OBSOLETE")).toBe(true)
+  })
+
+  it("autorise le retour EN_VALIDATION → BROUILLON et same→same", () => {
+    expect(isValidVersionTransition("EN_VALIDATION", "BROUILLON")).toBe(true)
+    expect(isValidVersionTransition("BROUILLON", "BROUILLON")).toBe(true)
+    expect(isValidVersionTransition("APPLICABLE", "APPLICABLE")).toBe(true)
+  })
+
+  it("interdit les sauts et sorties non permises", () => {
+    expect(isValidVersionTransition("BROUILLON", "APPLICABLE")).toBe(false) // pas de saut de validation
+    expect(isValidVersionTransition("APPLICABLE", "BROUILLON")).toBe(false) // une applicable ne redevient pas brouillon
+    expect(isValidVersionTransition("APPLICABLE", "EN_VALIDATION")).toBe(false)
+    expect(isValidVersionTransition("OBSOLETE", "BROUILLON")).toBe(false) // terminal
+    expect(isValidVersionTransition("OBSOLETE", "APPLICABLE")).toBe(false)
+  })
+})
+
+describe("Versions — validators", () => {
+  it("exige un indice à la création", () => {
+    expect(createVersionSchema.safeParse({ body: { indice: "A" } }).success).toBe(true)
+    expect(createVersionSchema.safeParse({ body: {} }).success).toBe(false)
+    expect(createVersionSchema.safeParse({ body: { indice: "" } }).success).toBe(false)
+  })
+
+  it("accepte les champs évolution/modification", () => {
+    const parsed = createVersionSchema.safeParse({
+      body: {
+        indice: "B",
+        plan_reference: "PL-4567",
+        matiere_prevue: "Alu 7075",
+        type_changement: "MODIFICATION",
+        raison_changement: "Cote critique changée",
+        impact_interchangeabilite: true,
+        impact_parents: "Revoir l'ensemble X",
+      },
+    })
+    expect(parsed.success).toBe(true)
+    if (parsed.success) expect(parsed.data.body.type_changement).toBe("MODIFICATION")
+  })
+
+  it("rejette un type_changement inconnu et un statut inconnu", () => {
+    expect(createVersionSchema.safeParse({ body: { indice: "C", type_changement: "AUTRE" } }).success).toBe(false)
+    expect(versionStatusSchema.safeParse({ body: { next_statut: "APPLICABLE" } }).success).toBe(true)
+    expect(versionStatusSchema.safeParse({ body: { next_statut: "WRONG" } }).success).toBe(false)
+  })
+
+  it("create-next exige aussi un indice", () => {
+    expect(createNextVersionSchema.safeParse({ body: { indice: "B", type_changement: "EVOLUTION" } }).success).toBe(true)
+    expect(createNextVersionSchema.safeParse({ body: {} }).success).toBe(false)
+  })
+})

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -13,6 +13,7 @@ import { validationErrorMiddleware } from "../module/auth/middlewares/validation
 import { requestIdMiddleware } from "../middlewares/requestId";
 import { requestLogger } from "../middlewares/requestLogger";
 import { getImagesRootPath } from "../utils/imageStorage";
+import pool from "./database";
 
 const app = express();
 
@@ -141,6 +142,34 @@ app.get("/", (_req, res) => {
 
 app.get("/api/v1", (_req, res) => {
   res.send("✅ Backend CERP en ligne en V1 !");
+});
+
+// Environnement runtime (public) — source de vérité pour le badge front.
+// Renvoie la base RÉELLEMENT connectée (SELECT current_database()), impossible à mentir :
+// permet à l'UI d'afficher "cerp_test" quand l'API sert la base de test, et non la sélection front.
+app.get("/api/v1/environment", async (_req, res) => {
+  try {
+    const { rows } = await pool.query<{ database: string }>(
+      "SELECT current_database() AS database"
+    );
+    const database = rows[0]?.database ?? null;
+    const environment =
+      database === "cerp_prod"
+        ? "production"
+        : database === "cerp_test"
+        ? "test"
+        : database
+        ? "other"
+        : "unknown";
+    res.json({
+      database,
+      environment,
+      appEnv: process.env.NODE_ENV ?? null,
+    });
+  } catch {
+    // Base injoignable : on ne ment pas, on répond "unknown" (le badge se masquera).
+    res.status(503).json({ database: null, environment: "unknown", appEnv: process.env.NODE_ENV ?? null });
+  }
 });
 
 // Routes API v1

--- a/src/module/gammes/controllers/gammes.controller.ts
+++ b/src/module/gammes/controllers/gammes.controller.ts
@@ -1,0 +1,108 @@
+// src/module/gammes/controllers/gammes.controller.ts
+// GPAO B2.2 — HTTP handlers gammes + opérations de gamme.
+import type { Request, RequestHandler } from "express"
+import { HttpError } from "../../../utils/httpError"
+import type { AuditContext } from "../../pieces-techniques/repository/pieces-techniques.repository"
+import {
+  addGammeOperationSchema,
+  createGammeSchema,
+  reorderOperationsSchema,
+  updateGammeSchema,
+} from "../validators/gammes.validators"
+import {
+  addGammeOperationSVC,
+  createGammeSVC,
+  listGammeOperationsSVC,
+  listGammesByVersionSVC,
+  reorderGammeOperationsSVC,
+  updateGammeSVC,
+} from "../services/gammes.service"
+
+function buildAuditContext(req: Request): AuditContext {
+  const user = req.user
+  if (!user) throw new HttpError(401, "UNAUTHORIZED", "Authentication required")
+  const forwardedFor = req.headers["x-forwarded-for"]
+  const ipFromHeader = typeof forwardedFor === "string" ? forwardedFor.split(",")[0]?.trim() : null
+  const ua = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null
+  const pageKey = typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null
+  const clientSessionId =
+    typeof req.headers["x-client-session-id"] === "string"
+      ? req.headers["x-client-session-id"]
+      : typeof req.headers["x-session-id"] === "string"
+        ? req.headers["x-session-id"]
+        : null
+  return {
+    user_id: user.id,
+    ip: ipFromHeader ?? req.ip ?? null,
+    user_agent: ua,
+    device_type: null,
+    os: null,
+    browser: null,
+    path: req.originalUrl ?? null,
+    page_key: pageKey,
+    client_session_id: clientSessionId,
+  }
+}
+
+export const listGammesByVersion: RequestHandler = async (req, res, next) => {
+  try {
+    const items = await listGammesByVersionSVC(req.params.versionId)
+    res.json(items)
+  } catch (err) {
+    next(err)
+  }
+}
+
+export const createGamme: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req)
+    const body = createGammeSchema.parse({ body: req.body }).body
+    const out = await createGammeSVC(req.params.versionId, body, audit)
+    res.status(201).json(out)
+  } catch (err) {
+    next(err)
+  }
+}
+
+export const updateGamme: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req)
+    const body = updateGammeSchema.parse({ body: req.body }).body
+    const out = await updateGammeSVC(req.params.gammeId, body, audit)
+    if (!out) throw new HttpError(404, "NOT_FOUND", "Gamme introuvable")
+    res.json(out)
+  } catch (err) {
+    next(err)
+  }
+}
+
+export const listGammeOperations: RequestHandler = async (req, res, next) => {
+  try {
+    const items = await listGammeOperationsSVC(req.params.gammeId)
+    res.json(items)
+  } catch (err) {
+    next(err)
+  }
+}
+
+export const addGammeOperation: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req)
+    const body = addGammeOperationSchema.parse({ body: req.body }).body
+    const out = await addGammeOperationSVC(req.params.gammeId, body, audit)
+    res.status(201).json(out)
+  } catch (err) {
+    next(err)
+  }
+}
+
+export const reorderGammeOperations: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req)
+    const body = reorderOperationsSchema.parse({ body: req.body }).body
+    const out = await reorderGammeOperationsSVC(req.params.gammeId, body.order, audit)
+    res.json(out)
+  } catch (err) {
+    next(err)
+  }
+}

--- a/src/module/gammes/repository/gammes.repository.ts
+++ b/src/module/gammes/repository/gammes.repository.ts
@@ -1,0 +1,333 @@
+// src/module/gammes/repository/gammes.repository.ts
+// GPAO B2.2 — repository des gammes + opérations de gamme.
+import type { PoolClient } from "pg"
+import db from "../../../config/database"
+import { HttpError } from "../../../utils/httpError"
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
+import type { AuditContext } from "../../pieces-techniques/repository/pieces-techniques.repository"
+import type {
+  AddGammeOperationBodyDTO,
+  CreateGammeBodyDTO,
+  GammeStatutDTO,
+  OperationTypeDTO,
+  UpdateGammeBodyDTO,
+} from "../validators/gammes.validators"
+
+export type GammeRow = {
+  id: string
+  piece_technique_version_id: string
+  nom: string | null
+  code: string | null
+  designation: string | null
+  commentaire: string | null
+  statut: GammeStatutDTO
+  is_current: boolean
+  created_at: string
+  updated_at: string
+  created_by: number | null
+  updated_by: number | null
+}
+
+export type GammeOperationRow = {
+  id: string
+  piece_technique_id: string
+  gamme_id: string | null
+  ordre: number | null
+  phase: number | null
+  designation: string
+  designation_2: string | null
+  type_operation: OperationTypeDTO | null
+  machine_id: string | null
+  poste_id: string | null
+  cf_id: string | null
+  tp: number | null
+  tf_unit: number | null
+  qte: number | null
+  coef: number | null
+  taux_horaire: number | null
+  prix: number | null
+  temps_total: number | null
+  cout_mo: number | null
+  consignes: string | null
+}
+
+const GAMME_COLS = `
+  id::text AS id, piece_technique_version_id::text AS piece_technique_version_id, nom, code, designation,
+  commentaire, statut, is_current, created_at::text AS created_at, updated_at::text AS updated_at, created_by, updated_by
+`
+const OP_COLS = `
+  id::text AS id, piece_technique_id::text AS piece_technique_id, gamme_id::text AS gamme_id, ordre, phase,
+  designation, designation_2, type_operation, machine_id::text AS machine_id, poste_id::text AS poste_id,
+  cf_id::text AS cf_id, tp, tf_unit, qte, coef, taux_horaire, prix, temps_total, cout_mo, consignes
+`
+
+function computeOperation(input: { tp: number; tf_unit: number; qte: number; coef: number; taux_horaire: number }) {
+  const round = (v: number, d: number) => (Number.isFinite(v) ? Math.round(v * 10 ** d) / 10 ** d : 0)
+  const tempsTotal = round((input.tp + input.tf_unit * input.qte) * input.coef, 3)
+  const coutMo = round(tempsTotal * input.taux_horaire, 2)
+  return { temps_total: tempsTotal, cout_mo: coutMo }
+}
+
+async function insertAudit(
+  tx: Pick<PoolClient, "query">,
+  audit: AuditContext,
+  action: string,
+  entityType: string,
+  entityId: string,
+  details: Record<string, unknown> | null
+) {
+  await repoInsertAuditLog({
+    user_id: audit.user_id,
+    body: {
+      event_type: "ACTION",
+      action,
+      page_key: audit.page_key,
+      entity_type: entityType,
+      entity_id: entityId,
+      path: audit.path,
+      client_session_id: audit.client_session_id,
+      details,
+    },
+    ip: audit.ip,
+    user_agent: audit.user_agent,
+    device_type: audit.device_type,
+    os: audit.os,
+    browser: audit.browser,
+    tx,
+  })
+}
+
+async function assertVersionExists(tx: Pick<PoolClient, "query">, versionId: string): Promise<void> {
+  const res = await tx.query(`SELECT 1 FROM public.piece_technique_versions WHERE id = $1`, [versionId])
+  if (res.rowCount === 0) throw new HttpError(404, "NOT_FOUND", "Version introuvable")
+}
+
+export async function repoListGammesByVersion(versionId: string): Promise<GammeRow[]> {
+  await assertVersionExists(db, versionId)
+  const res = await db.query<GammeRow>(
+    `SELECT ${GAMME_COLS} FROM public.gammes WHERE piece_technique_version_id = $1 ORDER BY is_current DESC, created_at ASC`,
+    [versionId]
+  )
+  return res.rows
+}
+
+export async function repoCreateGamme(versionId: string, body: CreateGammeBodyDTO, audit: AuditContext): Promise<GammeRow> {
+  const client = await db.connect()
+  try {
+    await client.query("BEGIN")
+    await assertVersionExists(client, versionId)
+    // une seule gamme courante par version
+    if (body.is_current) {
+      await client.query(
+        `UPDATE public.gammes SET is_current = false, updated_at = now(), updated_by = $2
+         WHERE piece_technique_version_id = $1 AND is_current = true`,
+        [versionId, audit.user_id]
+      )
+    }
+    const res = await client.query<GammeRow>(
+      `INSERT INTO public.gammes
+        (piece_technique_version_id, nom, code, designation, commentaire, statut, is_current, created_by, updated_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$8)
+       RETURNING ${GAMME_COLS}`,
+      [
+        versionId,
+        body.nom,
+        body.code ?? null,
+        body.designation ?? null,
+        body.commentaire ?? null,
+        body.statut ?? "BROUILLON",
+        body.is_current ?? false,
+        audit.user_id,
+      ]
+    )
+    const row = res.rows[0]
+    await insertAudit(client, audit, "gammes.create", "gamme", row.id, {
+      piece_technique_version_id: versionId,
+      nom: row.nom,
+    })
+    await client.query("COMMIT")
+    return row
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {})
+    throw e
+  } finally {
+    client.release()
+  }
+}
+
+export async function repoUpdateGamme(gammeId: string, body: UpdateGammeBodyDTO, audit: AuditContext): Promise<GammeRow | null> {
+  const client = await db.connect()
+  try {
+    await client.query("BEGIN")
+    const cur = await client.query<{ piece_technique_version_id: string; updated_at: string }>(
+      `SELECT piece_technique_version_id::text AS piece_technique_version_id, updated_at::text AS updated_at
+       FROM public.gammes WHERE id = $1 FOR UPDATE`,
+      [gammeId]
+    )
+    const current = cur.rows[0]
+    if (!current) {
+      await client.query("ROLLBACK").catch(() => {})
+      return null
+    }
+    if (body.expected_updated_at && body.expected_updated_at !== current.updated_at) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "La gamme a été modifiée entre-temps")
+    }
+    if (body.is_current === true) {
+      await client.query(
+        `UPDATE public.gammes SET is_current = false, updated_at = now(), updated_by = $3
+         WHERE piece_technique_version_id = $1 AND is_current = true AND id <> $2`,
+        [current.piece_technique_version_id, gammeId, audit.user_id]
+      )
+    }
+
+    const sets: string[] = []
+    const values: unknown[] = []
+    const push = (col: string, val: unknown) => {
+      values.push(val)
+      sets.push(`${col} = $${values.length}`)
+    }
+    if (body.nom !== undefined) push("nom", body.nom)
+    if (body.code !== undefined) push("code", body.code)
+    if (body.designation !== undefined) push("designation", body.designation)
+    if (body.commentaire !== undefined) push("commentaire", body.commentaire)
+    if (body.statut !== undefined) push("statut", body.statut)
+    if (body.is_current !== undefined) push("is_current", body.is_current)
+    values.push(audit.user_id)
+    sets.push(`updated_by = $${values.length}`)
+    sets.push(`updated_at = now()`)
+    values.push(gammeId)
+
+    const res = await client.query<GammeRow>(
+      `UPDATE public.gammes SET ${sets.join(", ")} WHERE id = $${values.length} RETURNING ${GAMME_COLS}`,
+      values
+    )
+    const row = res.rows[0]
+    await insertAudit(client, audit, "gammes.update", "gamme", gammeId, null)
+    await client.query("COMMIT")
+    return row
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {})
+    throw e
+  } finally {
+    client.release()
+  }
+}
+
+export async function repoListGammeOperations(gammeId: string): Promise<GammeOperationRow[]> {
+  const gamme = await db.query(`SELECT 1 FROM public.gammes WHERE id = $1`, [gammeId])
+  if (gamme.rowCount === 0) throw new HttpError(404, "NOT_FOUND", "Gamme introuvable")
+  const res = await db.query<GammeOperationRow>(
+    `SELECT ${OP_COLS} FROM public.pieces_techniques_operations
+     WHERE gamme_id = $1 ORDER BY ordre NULLS LAST, phase NULLS LAST, id`,
+    [gammeId]
+  )
+  return res.rows
+}
+
+export async function repoAddGammeOperation(
+  gammeId: string,
+  body: AddGammeOperationBodyDTO,
+  audit: AuditContext
+): Promise<GammeOperationRow> {
+  const client = await db.connect()
+  try {
+    await client.query("BEGIN")
+    // gamme -> version -> pièce (piece_technique_id NOT NULL sur la table opérations)
+    const link = await client.query<{ piece_technique_id: string }>(
+      `SELECT ptv.piece_technique_id::text AS piece_technique_id
+       FROM public.gammes g JOIN public.piece_technique_versions ptv ON ptv.id = g.piece_technique_version_id
+       WHERE g.id = $1`,
+      [gammeId]
+    )
+    if (link.rowCount === 0) {
+      await client.query("ROLLBACK").catch(() => {})
+      throw new HttpError(404, "NOT_FOUND", "Gamme introuvable")
+    }
+    const pieceTechniqueId = link.rows[0].piece_technique_id
+
+    const nextOrdre = await client.query<{ next_ordre: number }>(
+      `SELECT COALESCE(MAX(ordre), 0) + 10 AS next_ordre FROM public.pieces_techniques_operations WHERE gamme_id = $1`,
+      [gammeId]
+    )
+    const ordre = nextOrdre.rows[0]?.next_ordre ?? 10
+
+    const tp = body.temps_preparation ?? 0
+    const tfUnit = body.temps_cycle ?? 0
+    const qte = body.qte ?? 1
+    const coef = body.coef ?? 1
+    const tauxHoraire = body.taux_horaire ?? 0
+    const { temps_total, cout_mo } = computeOperation({ tp, tf_unit: tfUnit, qte, coef, taux_horaire: tauxHoraire })
+
+    const res = await client.query<GammeOperationRow>(
+      `INSERT INTO public.pieces_techniques_operations
+        (piece_technique_id, gamme_id, ordre, phase, designation, designation_2, type_operation, machine_id,
+         poste_id, cf_id, tp, tf_unit, qte, coef, taux_horaire, prix, temps_total, cout_mo, consignes)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19)
+       RETURNING ${OP_COLS}`,
+      [
+        pieceTechniqueId,
+        gammeId,
+        ordre,
+        body.numero_operation ?? 10,
+        body.designation,
+        body.designation_2 ?? null,
+        body.type_operation ?? null,
+        body.machine_id ?? null,
+        body.poste_id ?? null,
+        body.cf_id ?? null,
+        tp,
+        tfUnit,
+        qte,
+        coef,
+        tauxHoraire,
+        body.prix ?? 0,
+        temps_total,
+        cout_mo,
+        body.consignes ?? null,
+      ]
+    )
+    const row = res.rows[0]
+    await insertAudit(client, audit, "gammes.operations.add", "gamme_operation", row.id, {
+      gamme_id: gammeId,
+      type_operation: row.type_operation,
+    })
+    await client.query("COMMIT")
+    return row
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {})
+    throw e
+  } finally {
+    client.release()
+  }
+}
+
+// Réordonne via `ordre` — NE TOUCHE PAS à `phase` (numéro d'opération métier).
+export async function repoReorderGammeOperations(gammeId: string, order: string[], audit: AuditContext): Promise<GammeOperationRow[]> {
+  const client = await db.connect()
+  try {
+    await client.query("BEGIN")
+    const gamme = await client.query(`SELECT 1 FROM public.gammes WHERE id = $1 FOR UPDATE`, [gammeId])
+    if (gamme.rowCount === 0) {
+      await client.query("ROLLBACK").catch(() => {})
+      throw new HttpError(404, "NOT_FOUND", "Gamme introuvable")
+    }
+    for (let i = 0; i < order.length; i += 1) {
+      await client.query(
+        `UPDATE public.pieces_techniques_operations SET ordre = $1, updated_at = now() WHERE id = $2 AND gamme_id = $3`,
+        [(i + 1) * 10, order[i], gammeId]
+      )
+    }
+    await insertAudit(client, audit, "gammes.operations.reorder", "gamme", gammeId, { count: order.length })
+    const res = await client.query<GammeOperationRow>(
+      `SELECT ${OP_COLS} FROM public.pieces_techniques_operations WHERE gamme_id = $1 ORDER BY ordre NULLS LAST, phase NULLS LAST, id`,
+      [gammeId]
+    )
+    await client.query("COMMIT")
+    return res.rows
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {})
+    throw e
+  } finally {
+    client.release()
+  }
+}

--- a/src/module/gammes/repository/gammes.repository.ts
+++ b/src/module/gammes/repository/gammes.repository.ts
@@ -58,7 +58,9 @@ const GAMME_COLS = `
 const OP_COLS = `
   id::text AS id, piece_technique_id::text AS piece_technique_id, gamme_id::text AS gamme_id, ordre, phase,
   designation, designation_2, type_operation, machine_id::text AS machine_id, poste_id::text AS poste_id,
-  cf_id::text AS cf_id, tp, tf_unit, qte, coef, taux_horaire, prix, temps_total, cout_mo, consignes
+  cf_id::text AS cf_id, tp::float8 AS tp, tf_unit::float8 AS tf_unit, qte::float8 AS qte, coef::float8 AS coef,
+  taux_horaire::float8 AS taux_horaire, prix::float8 AS prix, temps_total::float8 AS temps_total,
+  cout_mo::float8 AS cout_mo, consignes
 `
 
 function computeOperation(input: { tp: number; tf_unit: number; qte: number; coef: number; taux_horaire: number }) {

--- a/src/module/gammes/routes/gammes.routes.ts
+++ b/src/module/gammes/routes/gammes.routes.ts
@@ -1,0 +1,31 @@
+// src/module/gammes/routes/gammes.routes.ts — monté sur /gammes
+import { Router } from "express"
+import { authenticateToken } from "../../auth/middlewares/auth.middleware"
+import {
+  addGammeOperation,
+  listGammeOperations,
+  reorderGammeOperations,
+  updateGamme,
+} from "../controllers/gammes.controller"
+import {
+  addGammeOperationSchema,
+  gammeIdParamSchema,
+  reorderOperationsSchema,
+  updateGammeSchema,
+  validate,
+} from "../validators/gammes.validators"
+
+const router = Router()
+router.use(authenticateToken)
+
+router.patch("/:gammeId", validate(gammeIdParamSchema), validate(updateGammeSchema), updateGamme)
+router.get("/:gammeId/operations", validate(gammeIdParamSchema), listGammeOperations)
+router.post("/:gammeId/operations", validate(gammeIdParamSchema), validate(addGammeOperationSchema), addGammeOperation)
+router.patch(
+  "/:gammeId/operations/reorder",
+  validate(gammeIdParamSchema),
+  validate(reorderOperationsSchema),
+  reorderGammeOperations
+)
+
+export default router

--- a/src/module/gammes/routes/piece-technique-versions.routes.ts
+++ b/src/module/gammes/routes/piece-technique-versions.routes.ts
@@ -1,0 +1,13 @@
+// src/module/gammes/routes/piece-technique-versions.routes.ts — monté sur /piece-technique-versions
+import { Router } from "express"
+import { authenticateToken } from "../../auth/middlewares/auth.middleware"
+import { createGamme, listGammesByVersion } from "../controllers/gammes.controller"
+import { createGammeSchema, validate, versionIdParamSchema } from "../validators/gammes.validators"
+
+const router = Router()
+router.use(authenticateToken)
+
+router.get("/:versionId/gammes", validate(versionIdParamSchema), listGammesByVersion)
+router.post("/:versionId/gammes", validate(versionIdParamSchema), validate(createGammeSchema), createGamme)
+
+export default router

--- a/src/module/gammes/services/gammes.service.ts
+++ b/src/module/gammes/services/gammes.service.ts
@@ -1,0 +1,27 @@
+// src/module/gammes/services/gammes.service.ts
+// GPAO B2.2 — service gammes (logique fine dans le repository).
+import type { AuditContext } from "../../pieces-techniques/repository/pieces-techniques.repository"
+import {
+  repoAddGammeOperation,
+  repoCreateGamme,
+  repoListGammeOperations,
+  repoListGammesByVersion,
+  repoReorderGammeOperations,
+  repoUpdateGamme,
+} from "../repository/gammes.repository"
+import type {
+  AddGammeOperationBodyDTO,
+  CreateGammeBodyDTO,
+  UpdateGammeBodyDTO,
+} from "../validators/gammes.validators"
+
+export const listGammesByVersionSVC = (versionId: string) => repoListGammesByVersion(versionId)
+export const createGammeSVC = (versionId: string, body: CreateGammeBodyDTO, audit: AuditContext) =>
+  repoCreateGamme(versionId, body, audit)
+export const updateGammeSVC = (gammeId: string, body: UpdateGammeBodyDTO, audit: AuditContext) =>
+  repoUpdateGamme(gammeId, body, audit)
+export const listGammeOperationsSVC = (gammeId: string) => repoListGammeOperations(gammeId)
+export const addGammeOperationSVC = (gammeId: string, body: AddGammeOperationBodyDTO, audit: AuditContext) =>
+  repoAddGammeOperation(gammeId, body, audit)
+export const reorderGammeOperationsSVC = (gammeId: string, order: string[], audit: AuditContext) =>
+  repoReorderGammeOperations(gammeId, order, audit)

--- a/src/module/gammes/validators/gammes.validators.ts
+++ b/src/module/gammes/validators/gammes.validators.ts
@@ -1,0 +1,77 @@
+// src/module/gammes/validators/gammes.validators.ts
+// GPAO B2.2 — validators des gammes + opérations de gamme.
+import type { RequestHandler } from "express"
+import { z } from "zod"
+
+const uuid = z.string().uuid()
+
+export const gammeStatutSchema = z.enum(["BROUILLON", "EN_VALIDATION", "APPLICABLE", "OBSOLETE"])
+export type GammeStatutDTO = z.infer<typeof gammeStatutSchema>
+
+export const operationTypeSchema = z.enum([
+  "TOURNAGE",
+  "FRAISAGE",
+  "REPRISE",
+  "CONTROLE",
+  "LAVAGE",
+  "SOUS_TRAITANCE",
+  "EMBALLAGE",
+  "AUTRE",
+])
+export type OperationTypeDTO = z.infer<typeof operationTypeSchema>
+
+export const versionIdParamSchema = z.object({ params: z.object({ versionId: uuid }) })
+export const gammeIdParamSchema = z.object({ params: z.object({ gammeId: uuid }) })
+
+const gammeCore = z.object({
+  nom: z.string().trim().min(1, "Nom de gamme requis").max(200),
+  code: z.string().trim().max(80).optional().nullable(),
+  designation: z.string().trim().max(200).optional().nullable(),
+  commentaire: z.string().max(2000).optional().nullable(),
+  statut: gammeStatutSchema.optional().default("BROUILLON"),
+  is_current: z.boolean().optional().default(false),
+})
+
+export const createGammeSchema = z.object({ body: gammeCore })
+export type CreateGammeBodyDTO = z.infer<typeof createGammeSchema>["body"]
+
+export const updateGammeSchema = z.object({
+  body: gammeCore.partial().extend({ expected_updated_at: z.string().min(1).optional() }),
+})
+export type UpdateGammeBodyDTO = z.infer<typeof updateGammeSchema>["body"]
+
+// Opération de gamme. Noms métier mappés aux colonnes DB : numero_operation→phase,
+// temps_preparation→tp, temps_cycle→tf_unit.
+const operationCore = z.object({
+  numero_operation: z.coerce.number().int().min(0).optional().default(10),
+  designation: z.string().trim().min(1, "Désignation requise"),
+  designation_2: z.string().optional().nullable(),
+  type_operation: operationTypeSchema.optional().nullable(),
+  machine_id: uuid.optional().nullable(),
+  poste_id: uuid.optional().nullable(),
+  cf_id: uuid.optional().nullable(),
+  temps_preparation: z.coerce.number().min(0).optional().default(0),
+  temps_cycle: z.coerce.number().min(0).optional().default(0),
+  qte: z.coerce.number().min(0).optional().default(1),
+  coef: z.coerce.number().min(0).optional().default(1),
+  taux_horaire: z.coerce.number().min(0).optional().default(0),
+  prix: z.coerce.number().min(0).optional().default(0),
+  consignes: z.string().max(4000).optional().nullable(),
+})
+
+export const addGammeOperationSchema = z.object({ body: operationCore })
+export type AddGammeOperationBodyDTO = z.infer<typeof addGammeOperationSchema>["body"]
+
+export const reorderOperationsSchema = z.object({ body: z.object({ order: z.array(uuid).min(1) }) })
+export type ReorderOperationsBodyDTO = z.infer<typeof reorderOperationsSchema>["body"]
+
+export function validate(schema: z.ZodTypeAny): RequestHandler {
+  return (req, _res, next) => {
+    try {
+      schema.parse({ body: req.body, params: req.params, query: req.query })
+      next()
+    } catch (e) {
+      next(e)
+    }
+  }
+}

--- a/src/module/pieces-techniques/controllers/piece-article.controller.ts
+++ b/src/module/pieces-techniques/controllers/piece-article.controller.ts
@@ -1,0 +1,115 @@
+// src/module/pieces-techniques/controllers/piece-article.controller.ts
+// GPAO B5 — endpoints piece-side du lien Pièce technique ↔ Article fabriqué principal.
+// Lecture côté canonique (articles.piece_technique_id). La création passe par le chemin
+// transactionnel createStockArticleSVC (miroir articles + articles_fabrique + pieces_techniques.article_id).
+import type { Request, RequestHandler } from "express"
+import { z } from "zod"
+
+import db from "../../../config/database"
+import { HttpError } from "../../../utils/httpError"
+import { repoGetPieceArticlePrincipal } from "../../stock/repository/article-piece-link.repository"
+import type { AuditContext } from "../../stock/repository/stock.repository"
+import { createStockArticleSVC } from "../../stock/services/stock.service"
+import { createArticleSchema } from "../../stock/validators/stock.validators"
+
+const uuidSchema = z.string().uuid()
+const createOrLinkSchema = z.object({
+  code: z.string().trim().min(1).max(80).optional(),
+  designation: z.string().trim().min(1).max(400).optional(),
+  family_code: z.string().trim().min(1).max(40),
+  stock_managed: z.boolean().optional(),
+})
+
+function buildAuditContext(req: Request): AuditContext {
+  const user = req.user
+  if (!user) throw new HttpError(401, "UNAUTHORIZED", "Authentication required")
+  const forwardedFor = req.headers["x-forwarded-for"]
+  const ipFromHeader = typeof forwardedFor === "string" ? forwardedFor.split(",")[0]?.trim() : null
+  const ua = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null
+  const pageKey = typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null
+  const clientSessionId =
+    typeof req.headers["x-client-session-id"] === "string"
+      ? req.headers["x-client-session-id"]
+      : typeof req.headers["x-session-id"] === "string"
+        ? req.headers["x-session-id"]
+        : null
+  return {
+    user_id: user.id,
+    ip: ipFromHeader ?? req.ip ?? null,
+    user_agent: ua,
+    device_type: null,
+    os: null,
+    browser: null,
+    path: req.originalUrl ?? null,
+    page_key: pageKey,
+    client_session_id: clientSessionId,
+  }
+}
+
+function isUniqueViolation(e: unknown): boolean {
+  return typeof e === "object" && e !== null && (e as { code?: string }).code === "23505"
+}
+
+// GET /pieces-techniques/:id/article-principal
+export const getPieceArticlePrincipal: RequestHandler = async (req, res, next) => {
+  try {
+    const id = uuidSchema.parse(req.params.id)
+    const piece = await db.query("SELECT 1 FROM public.pieces_techniques WHERE id = $1::uuid", [id])
+    if (piece.rowCount === 0) {
+      res.status(404).json({ error: "Pièce technique introuvable" })
+      return
+    }
+    const article = await repoGetPieceArticlePrincipal(id)
+    res.json({ article })
+  } catch (err) {
+    next(err)
+  }
+}
+
+// POST /pieces-techniques/:id/create-or-link-article-fabrique { family_code, code?, designation?, stock_managed? }
+export const createOrLinkArticleFabrique: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req)
+    const id = uuidSchema.parse(req.params.id)
+    const input = createOrLinkSchema.parse(req.body)
+
+    const p = await db.query<{ code_piece: string; designation: string }>(
+      "SELECT code_piece, designation FROM public.pieces_techniques WHERE id = $1::uuid",
+      [id]
+    )
+    if (p.rowCount === 0) {
+      res.status(404).json({ error: "Pièce technique introuvable" })
+      return
+    }
+
+    // Déjà lié ? → on renvoie l'article existant (idempotent, pas de doublon).
+    const existing = await repoGetPieceArticlePrincipal(id)
+    if (existing) {
+      res.status(200).json({ created: false, article: existing })
+      return
+    }
+
+    const body = createArticleSchema.parse({
+      body: {
+        code: input.code ?? p.rows[0].code_piece,
+        designation: input.designation ?? p.rows[0].designation,
+        family_code: input.family_code,
+        article_category: "fabrique",
+        piece_technique_id: id,
+        stock_managed: input.stock_managed ?? true,
+      },
+    }).body
+
+    try {
+      const article = await createStockArticleSVC(body, audit)
+      res.status(201).json({ created: true, article })
+    } catch (e) {
+      if (isUniqueViolation(e)) {
+        throw new HttpError(409, "ALREADY_LINKED", "Un article fabriqué existe déjà pour cette pièce (ou ce code article).")
+      }
+      throw e
+    }
+  } catch (err) {
+    next(err)
+  }
+}

--- a/src/module/pieces-techniques/controllers/piece-article.controller.ts
+++ b/src/module/pieces-techniques/controllers/piece-article.controller.ts
@@ -89,9 +89,11 @@ export const createOrLinkArticleFabrique: RequestHandler = async (req, res, next
       return
     }
 
-    const body = createArticleSchema.parse({
+    const parsed = createArticleSchema.parse({
       body: {
-        code: input.code ?? p.rows[0].code_piece,
+        // Placeholder pour satisfaire min(1) ; remplacé par "" ci-dessous si l'utilisateur ne fournit
+        // pas de code → le backend génère alors le code fabriqué normalisé ({code_piece}-P{plan_index}).
+        code: input.code ?? "AUTO",
         designation: input.designation ?? p.rows[0].designation,
         family_code: input.family_code,
         article_category: "fabrique",
@@ -99,6 +101,7 @@ export const createOrLinkArticleFabrique: RequestHandler = async (req, res, next
         stock_managed: input.stock_managed ?? true,
       },
     }).body
+    const body = input.code ? parsed : { ...parsed, code: "" }
 
     try {
       const article = await createStockArticleSVC(body, audit)

--- a/src/module/pieces-techniques/controllers/versions.controller.ts
+++ b/src/module/pieces-techniques/controllers/versions.controller.ts
@@ -1,0 +1,99 @@
+// src/module/pieces-techniques/controllers/versions.controller.ts
+// GPAO B2.1 — HTTP handlers des versions/indices.
+import type { Request, RequestHandler } from "express"
+import { HttpError } from "../../../utils/httpError"
+import type { AuditContext } from "../repository/pieces-techniques.repository"
+import {
+  createNextVersionSchema,
+  createVersionSchema,
+  updateVersionSchema,
+  versionStatusSchema,
+} from "../validators/versions.validators"
+import {
+  createNextVersionSVC,
+  createVersionSVC,
+  listVersionsSVC,
+  updateVersionSVC,
+  updateVersionStatusSVC,
+} from "../services/versions.service"
+
+function buildAuditContext(req: Request): AuditContext {
+  const user = req.user
+  if (!user) throw new HttpError(401, "UNAUTHORIZED", "Authentication required")
+  const forwardedFor = req.headers["x-forwarded-for"]
+  const ipFromHeader = typeof forwardedFor === "string" ? forwardedFor.split(",")[0]?.trim() : null
+  const ua = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null
+  const pageKey = typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null
+  const clientSessionId =
+    typeof req.headers["x-client-session-id"] === "string"
+      ? req.headers["x-client-session-id"]
+      : typeof req.headers["x-session-id"] === "string"
+        ? req.headers["x-session-id"]
+        : null
+  return {
+    user_id: user.id,
+    ip: ipFromHeader ?? req.ip ?? null,
+    user_agent: ua,
+    device_type: null,
+    os: null,
+    browser: null,
+    path: req.originalUrl ?? null,
+    page_key: pageKey,
+    client_session_id: clientSessionId,
+  }
+}
+
+export const listVersions: RequestHandler = async (req, res, next) => {
+  try {
+    const items = await listVersionsSVC(req.params.id)
+    res.json(items)
+  } catch (err) {
+    next(err)
+  }
+}
+
+export const createVersion: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req)
+    const body = createVersionSchema.parse({ body: req.body }).body
+    const out = await createVersionSVC(req.params.id, body, audit)
+    res.status(201).json(out)
+  } catch (err) {
+    next(err)
+  }
+}
+
+export const updateVersion: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req)
+    const body = updateVersionSchema.parse({ body: req.body }).body
+    const out = await updateVersionSVC(req.params.id, req.params.versionId, body, audit)
+    if (!out) throw new HttpError(404, "NOT_FOUND", "Version introuvable")
+    res.json(out)
+  } catch (err) {
+    next(err)
+  }
+}
+
+export const updateVersionStatus: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req)
+    const body = versionStatusSchema.parse({ body: req.body }).body
+    const out = await updateVersionStatusSVC(req.params.id, req.params.versionId, body, audit)
+    if (!out) throw new HttpError(404, "NOT_FOUND", "Version introuvable")
+    res.json(out)
+  } catch (err) {
+    next(err)
+  }
+}
+
+export const createNextVersion: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req)
+    const body = createNextVersionSchema.parse({ body: req.body }).body
+    const out = await createNextVersionSVC(req.params.id, req.params.versionId, body, audit)
+    res.status(201).json(out)
+  } catch (err) {
+    next(err)
+  }
+}

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -2353,12 +2353,14 @@ export async function repoAddBomLine(pieceTechniqueId: string, body: AddBomLineB
         INSERT INTO pieces_techniques_nomenclature (
           parent_piece_technique_id,
           child_piece_technique_id,
+          parent_piece_technique_version_id,
+          child_piece_technique_version_id,
           rang,
           quantite,
           repere,
           designation
         )
-        VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6)
+        VALUES ($1::uuid, $2::uuid, $3::uuid, $4::uuid, $5, $6, $7, $8)
         RETURNING
           id::text AS id,
           child_piece_technique_id::text AS child_piece_id,
@@ -2367,7 +2369,16 @@ export async function repoAddBomLine(pieceTechniqueId: string, body: AddBomLineB
           repere,
           designation
       `,
-      [pieceTechniqueId, body.child_piece_id, rang, body.quantite, body.repere ?? null, body.designation ?? null]
+      [
+        pieceTechniqueId,
+        body.child_piece_id,
+        body.parent_piece_technique_version_id ?? null,
+        body.child_piece_technique_version_id ?? null,
+        rang,
+        body.quantite,
+        body.repere ?? null,
+        body.designation ?? null,
+      ]
     );
     await client.query("COMMIT");
     const r = ins.rows[0];
@@ -2408,6 +2419,10 @@ export async function repoUpdateBomLine(
     };
 
     if (body.child_piece_id !== undefined) sets.push(`child_piece_technique_id = ${push(body.child_piece_id)}::uuid`);
+    if (body.parent_piece_technique_version_id !== undefined)
+      sets.push(`parent_piece_technique_version_id = ${push(body.parent_piece_technique_version_id)}::uuid`);
+    if (body.child_piece_technique_version_id !== undefined)
+      sets.push(`child_piece_technique_version_id = ${push(body.child_piece_technique_version_id)}::uuid`);
     if (body.rang !== undefined) sets.push(`rang = ${push(body.rang)}`);
     if (body.quantite !== undefined) sets.push(`quantite = ${push(body.quantite)}`);
     if (body.repere !== undefined) sets.push(`repere = ${push(body.repere)}`);

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -2772,11 +2772,12 @@ export async function repoAddAchat(
         total_achat_ttc,
         designation,
         designation_2,
-        designation_3
+        designation_3,
+        type_achat
       )
       VALUES (
         $1::uuid,$2,$3::uuid,$4,$5::uuid,$6,$7,$8,
-        $9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23
+        $9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24
       )
       RETURNING
         id::text AS id,
@@ -2801,7 +2802,8 @@ export async function repoAddAchat(
         total_achat_ttc::float8 AS total_achat_ttc,
         designation,
         designation_2,
-        designation_3
+        designation_3,
+        type_achat
     `,
     [
       pieceTechniqueId,
@@ -2827,6 +2829,7 @@ export async function repoAddAchat(
       body.designation ?? null,
       body.designation_2 ?? null,
       body.designation_3 ?? null,
+      body.type_achat ?? "DIVERS",
     ]
   );
 
@@ -2834,6 +2837,7 @@ export async function repoAddAchat(
   return {
     id: r.id,
     phase: r.phase,
+    type_achat: (r.type_achat as TypeAchat) ?? "DIVERS",
     famille_piece_id: r.famille_piece_id,
     nom: r.nom,
     fournisseur_id: r.fournisseur_id,

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -11,6 +11,7 @@ import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repos
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import type {
   Achat,
+  TypeAchat,
   AffairePieceTechniqueLink,
   BomLine,
   FabricationTreeNode,
@@ -1224,6 +1225,7 @@ async function repoListOperations(pieceTechniqueId: string): Promise<Operation[]
 type AchatRow = {
   id: string;
   phase: number | null;
+  type_achat: string;
   famille_piece_id: string | null;
   nom: string | null;
   fournisseur_id: string | null;
@@ -1252,6 +1254,7 @@ async function repoListAchats(pieceTechniqueId: string): Promise<Achat[]> {
     SELECT
       id::text AS id,
       phase,
+      type_achat,
       famille_piece_id::text AS famille_piece_id,
       nom,
       fournisseur_id::text AS fournisseur_id,
@@ -1281,6 +1284,7 @@ async function repoListAchats(pieceTechniqueId: string): Promise<Achat[]> {
   return res.rows.map((r) => ({
     id: r.id,
     phase: r.phase,
+    type_achat: (r.type_achat as TypeAchat) ?? "DIVERS",
     famille_piece_id: r.famille_piece_id,
     nom: r.nom,
     fournisseur_id: r.fournisseur_id,

--- a/src/module/pieces-techniques/repository/versions.repository.ts
+++ b/src/module/pieces-techniques/repository/versions.repository.ts
@@ -1,0 +1,336 @@
+// src/module/pieces-techniques/repository/versions.repository.ts
+// GPAO B2.1 — repository des versions/indices d'une pièce technique.
+import type { PoolClient } from "pg"
+import db from "../../../config/database"
+import { HttpError } from "../../../utils/httpError"
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
+import type { AuditContext } from "./pieces-techniques.repository"
+import type {
+  CreateNextVersionBodyDTO,
+  CreateVersionBodyDTO,
+  UpdateVersionBodyDTO,
+  VersionStatutDTO,
+} from "../validators/versions.validators"
+
+export type PieceTechniqueVersionRow = {
+  id: string
+  piece_technique_id: string
+  indice: string
+  plan_reference: string | null
+  matiere_prevue: string | null
+  statut: VersionStatutDTO
+  is_current: boolean
+  commentaire_revision: string | null
+  type_changement: "EVOLUTION" | "MODIFICATION" | null
+  raison_changement: string | null
+  impact_interchangeabilite: boolean | null
+  impact_parents: string | null
+  valide_par: number | null
+  date_validation: string | null
+  date_application: string | null
+  commentaire_validation: string | null
+  date_revision: string | null
+  created_at: string
+  updated_at: string
+  created_by: number | null
+  updated_by: number | null
+}
+
+const VERSION_COLUMNS = `
+  id::text AS id, piece_technique_id::text AS piece_technique_id, indice, plan_reference, matiere_prevue,
+  statut, is_current, commentaire_revision, type_changement, raison_changement, impact_interchangeabilite,
+  impact_parents, valide_par, date_validation::text AS date_validation, date_application::text AS date_application,
+  commentaire_validation, date_revision::text AS date_revision, created_at::text AS created_at,
+  updated_at::text AS updated_at, created_by, updated_by
+`
+
+async function insertAudit(
+  tx: Pick<PoolClient, "query">,
+  audit: AuditContext,
+  action: string,
+  entityId: string,
+  details: Record<string, unknown> | null
+) {
+  await repoInsertAuditLog({
+    user_id: audit.user_id,
+    body: {
+      event_type: "ACTION",
+      action,
+      page_key: audit.page_key,
+      entity_type: "piece_technique_version",
+      entity_id: entityId,
+      path: audit.path,
+      client_session_id: audit.client_session_id,
+      details,
+    },
+    ip: audit.ip,
+    user_agent: audit.user_agent,
+    device_type: audit.device_type,
+    os: audit.os,
+    browser: audit.browser,
+    tx,
+  })
+}
+
+async function assertPieceExists(tx: Pick<PoolClient, "query">, pieceId: string): Promise<void> {
+  const res = await tx.query(`SELECT 1 FROM public.pieces_techniques WHERE id = $1 AND deleted_at IS NULL`, [pieceId])
+  if (res.rowCount === 0) throw new HttpError(404, "NOT_FOUND", "Pièce technique introuvable")
+}
+
+export async function repoListVersions(pieceTechniqueId: string): Promise<PieceTechniqueVersionRow[]> {
+  await assertPieceExists(db, pieceTechniqueId)
+  const res = await db.query<PieceTechniqueVersionRow>(
+    `SELECT ${VERSION_COLUMNS} FROM public.piece_technique_versions
+     WHERE piece_technique_id = $1
+     ORDER BY created_at ASC, indice ASC`,
+    [pieceTechniqueId]
+  )
+  return res.rows
+}
+
+export async function repoGetVersion(pieceTechniqueId: string, versionId: string): Promise<PieceTechniqueVersionRow | null> {
+  const res = await db.query<PieceTechniqueVersionRow>(
+    `SELECT ${VERSION_COLUMNS} FROM public.piece_technique_versions WHERE id = $1 AND piece_technique_id = $2`,
+    [versionId, pieceTechniqueId]
+  )
+  return res.rows[0] ?? null
+}
+
+export async function repoCreateVersion(
+  pieceTechniqueId: string,
+  body: CreateVersionBodyDTO,
+  audit: AuditContext
+): Promise<PieceTechniqueVersionRow> {
+  const client = await db.connect()
+  try {
+    await client.query("BEGIN")
+    await assertPieceExists(client, pieceTechniqueId)
+
+    const res = await client.query<PieceTechniqueVersionRow>(
+      `INSERT INTO public.piece_technique_versions
+        (piece_technique_id, indice, plan_reference, matiere_prevue, statut, is_current,
+         commentaire_revision, type_changement, raison_changement, impact_interchangeabilite, impact_parents,
+         date_revision, created_by, updated_by)
+       VALUES ($1,$2,$3,$4,'BROUILLON',false,$5,$6,$7,$8,$9, now(), $10,$10)
+       RETURNING ${VERSION_COLUMNS}`,
+      [
+        pieceTechniqueId,
+        body.indice,
+        body.plan_reference ?? null,
+        body.matiere_prevue ?? null,
+        body.commentaire_revision ?? null,
+        body.type_changement ?? null,
+        body.raison_changement ?? null,
+        body.impact_interchangeabilite ?? null,
+        body.impact_parents ?? null,
+        audit.user_id,
+      ]
+    )
+    const row = res.rows[0]
+    await insertAudit(client, audit, "pieces-techniques.version.create", row.id, {
+      piece_technique_id: pieceTechniqueId,
+      indice: row.indice,
+    })
+    await client.query("COMMIT")
+    return row
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {})
+    // unique (piece_technique_id, indice)
+    if ((e as { code?: string })?.code === "23505") {
+      throw new HttpError(409, "CONFLICT", "Cet indice existe déjà pour cette pièce")
+    }
+    throw e
+  } finally {
+    client.release()
+  }
+}
+
+// Édition autorisée uniquement en BROUILLON / EN_VALIDATION (une version APPLICABLE ne se
+// modifie pas directement — on crée une nouvelle version).
+export async function repoUpdateVersion(
+  pieceTechniqueId: string,
+  versionId: string,
+  body: UpdateVersionBodyDTO,
+  audit: AuditContext
+): Promise<PieceTechniqueVersionRow | null> {
+  const client = await db.connect()
+  try {
+    await client.query("BEGIN")
+    const cur = await client.query<{ statut: VersionStatutDTO; updated_at: string }>(
+      `SELECT statut, updated_at::text AS updated_at FROM public.piece_technique_versions
+       WHERE id = $1 AND piece_technique_id = $2 FOR UPDATE`,
+      [versionId, pieceTechniqueId]
+    )
+    const current = cur.rows[0]
+    if (!current) {
+      await client.query("ROLLBACK").catch(() => {})
+      return null
+    }
+    if (current.statut === "APPLICABLE" || current.statut === "OBSOLETE") {
+      throw new HttpError(409, "VERSION_LOCKED", "Une version applicable/obsolète ne se modifie pas — créez une nouvelle version")
+    }
+    if (body.expected_updated_at && body.expected_updated_at !== current.updated_at) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "La version a été modifiée entre-temps")
+    }
+
+    const sets: string[] = []
+    const values: unknown[] = []
+    const push = (col: string, val: unknown) => {
+      values.push(val)
+      sets.push(`${col} = $${values.length}`)
+    }
+    if (body.indice !== undefined) push("indice", body.indice)
+    if (body.plan_reference !== undefined) push("plan_reference", body.plan_reference)
+    if (body.matiere_prevue !== undefined) push("matiere_prevue", body.matiere_prevue)
+    if (body.commentaire_revision !== undefined) push("commentaire_revision", body.commentaire_revision)
+    if (body.type_changement !== undefined) push("type_changement", body.type_changement)
+    if (body.raison_changement !== undefined) push("raison_changement", body.raison_changement)
+    if (body.impact_interchangeabilite !== undefined) push("impact_interchangeabilite", body.impact_interchangeabilite)
+    if (body.impact_parents !== undefined) push("impact_parents", body.impact_parents)
+
+    values.push(audit.user_id)
+    sets.push(`updated_by = $${values.length}`)
+    sets.push(`updated_at = now()`)
+
+    values.push(versionId)
+    const res = await client.query<PieceTechniqueVersionRow>(
+      `UPDATE public.piece_technique_versions SET ${sets.join(", ")} WHERE id = $${values.length} RETURNING ${VERSION_COLUMNS}`,
+      values
+    )
+    const row = res.rows[0]
+    await insertAudit(client, audit, "pieces-techniques.version.update", versionId, { piece_technique_id: pieceTechniqueId })
+    await client.query("COMMIT")
+    return row
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {})
+    if ((e as { code?: string })?.code === "23505") throw new HttpError(409, "CONFLICT", "Cet indice existe déjà pour cette pièce")
+    throw e
+  } finally {
+    client.release()
+  }
+}
+
+// Transition de statut. Passe à APPLICABLE = déclasse l'APPLICABLE précédente en OBSOLETE
+// (règle : une seule version APPLICABLE par pièce) dans la même transaction.
+export async function repoUpdateVersionStatus(
+  pieceTechniqueId: string,
+  versionId: string,
+  toStatut: VersionStatutDTO,
+  extra: { valide_par: number | null; date_application: string | null; commentaire_validation: string | null; expected_updated_at?: string },
+  audit: AuditContext
+): Promise<PieceTechniqueVersionRow | null> {
+  const client = await db.connect()
+  try {
+    await client.query("BEGIN")
+    const cur = await client.query<{ statut: VersionStatutDTO; updated_at: string }>(
+      `SELECT statut, updated_at::text AS updated_at FROM public.piece_technique_versions
+       WHERE id = $1 AND piece_technique_id = $2 FOR UPDATE`,
+      [versionId, pieceTechniqueId]
+    )
+    const current = cur.rows[0]
+    if (!current) {
+      await client.query("ROLLBACK").catch(() => {})
+      return null
+    }
+    if (extra.expected_updated_at && extra.expected_updated_at !== current.updated_at) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "La version a été modifiée entre-temps")
+    }
+
+    // Passe APPLICABLE : déclasser l'ancienne APPLICABLE d'abord (respecte l'index unique partiel).
+    if (toStatut === "APPLICABLE") {
+      await client.query(
+        `UPDATE public.piece_technique_versions
+         SET statut = 'OBSOLETE', is_current = false, updated_at = now(), updated_by = $3
+         WHERE piece_technique_id = $1 AND statut = 'APPLICABLE' AND id <> $2`,
+        [pieceTechniqueId, versionId, audit.user_id]
+      )
+    }
+
+    const isCurrent = toStatut === "APPLICABLE"
+    const res = await client.query<PieceTechniqueVersionRow>(
+      `UPDATE public.piece_technique_versions SET
+         statut = $2,
+         is_current = $3,
+         valide_par = CASE WHEN $2 = 'APPLICABLE' THEN $4 ELSE valide_par END,
+         date_validation = CASE WHEN $2 = 'APPLICABLE' THEN now() ELSE date_validation END,
+         date_application = CASE WHEN $2 = 'APPLICABLE' THEN COALESCE($5::date, date_application, CURRENT_DATE) ELSE date_application END,
+         commentaire_validation = COALESCE($6, commentaire_validation),
+         updated_at = now(), updated_by = $7
+       WHERE id = $1
+       RETURNING ${VERSION_COLUMNS}`,
+      [versionId, toStatut, isCurrent, extra.valide_par ?? audit.user_id, extra.date_application ?? null, extra.commentaire_validation ?? null, audit.user_id]
+    )
+    const row = res.rows[0]
+    await insertAudit(client, audit, "pieces-techniques.version.status", versionId, {
+      piece_technique_id: pieceTechniqueId,
+      from: current.statut,
+      to: toStatut,
+    })
+    await client.query("COMMIT")
+    return row
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {})
+    throw e
+  } finally {
+    client.release()
+  }
+}
+
+// "Créer une nouvelle version depuis une version existante" (Nouvel indice / évolution / modification).
+export async function repoCreateNextVersion(
+  pieceTechniqueId: string,
+  sourceVersionId: string,
+  body: CreateNextVersionBodyDTO,
+  audit: AuditContext
+): Promise<PieceTechniqueVersionRow> {
+  const client = await db.connect()
+  try {
+    await client.query("BEGIN")
+    const src = await client.query<{ id: string; plan_reference: string | null; matiere_prevue: string | null }>(
+      `SELECT id::text AS id, plan_reference, matiere_prevue FROM public.piece_technique_versions
+       WHERE id = $1 AND piece_technique_id = $2`,
+      [sourceVersionId, pieceTechniqueId]
+    )
+    if (src.rowCount === 0) {
+      await client.query("ROLLBACK").catch(() => {})
+      throw new HttpError(404, "NOT_FOUND", "Version source introuvable")
+    }
+    const source = src.rows[0]
+
+    const res = await client.query<PieceTechniqueVersionRow>(
+      `INSERT INTO public.piece_technique_versions
+        (piece_technique_id, indice, plan_reference, matiere_prevue, statut, is_current,
+         commentaire_revision, type_changement, raison_changement, impact_interchangeabilite, impact_parents,
+         date_revision, created_by, updated_by)
+       VALUES ($1,$2,$3,$4,'BROUILLON',false,$5,$6,$7,$8,$9, now(), $10,$10)
+       RETURNING ${VERSION_COLUMNS}`,
+      [
+        pieceTechniqueId,
+        body.indice,
+        body.plan_reference ?? source.plan_reference,
+        body.matiere_prevue ?? source.matiere_prevue,
+        body.commentaire_revision ?? null,
+        body.type_changement ?? null,
+        body.raison_changement ?? null,
+        body.impact_interchangeabilite ?? null,
+        body.impact_parents ?? null,
+        audit.user_id,
+      ]
+    )
+    const row = res.rows[0]
+    await insertAudit(client, audit, "pieces-techniques.version.create-next", row.id, {
+      piece_technique_id: pieceTechniqueId,
+      source_version_id: sourceVersionId,
+      indice: row.indice,
+      type_changement: row.type_changement,
+    })
+    await client.query("COMMIT")
+    return row
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {})
+    if ((e as { code?: string })?.code === "23505") throw new HttpError(409, "CONFLICT", "Cet indice existe déjà pour cette pièce")
+    throw e
+  } finally {
+    client.release()
+  }
+}

--- a/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
+++ b/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
@@ -65,6 +65,7 @@ import {
   updateVersion,
   updateVersionStatus,
 } from "../controllers/versions.controller"
+import { createOrLinkArticleFabrique, getPieceArticlePrincipal } from "../controllers/piece-article.controller"
 import {
   createNextVersionSchema,
   createVersionSchema,
@@ -110,6 +111,10 @@ router.delete("/:id", requireAdmin, validate(idParamSchema), deletePieceTechniqu
 
 router.post("/:id/duplicate", validate(idParamSchema), duplicatePieceTechnique)
 router.post("/:id/status", validate(idParamSchema), validate(pieceTechniqueStatusSchema), updatePieceTechniqueStatus)
+
+// GPAO B5 — article fabriqué principal lié à la pièce
+router.get("/:id/article-principal", validate(idParamSchema), getPieceArticlePrincipal)
+router.post("/:id/create-or-link-article-fabrique", validate(idParamSchema), createOrLinkArticleFabrique)
 
 // Versions / indices (GPAO B2.1) — source de vérité indice/plan/statut.
 router.get("/:id/versions", validate(idParamSchema), listVersions)

--- a/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
+++ b/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
@@ -58,6 +58,21 @@ import {
   validate,
 } from "../validators/pieces-techniques.validators"
 
+import {
+  createNextVersion,
+  createVersion,
+  listVersions,
+  updateVersion,
+  updateVersionStatus,
+} from "../controllers/versions.controller"
+import {
+  createNextVersionSchema,
+  createVersionSchema,
+  updateVersionSchema,
+  versionIdParamSchema,
+  versionStatusSchema,
+} from "../validators/versions.validators"
+
 const router = Router()
 
 function isAdminRole(role: string | undefined): boolean {
@@ -95,6 +110,13 @@ router.delete("/:id", requireAdmin, validate(idParamSchema), deletePieceTechniqu
 
 router.post("/:id/duplicate", validate(idParamSchema), duplicatePieceTechnique)
 router.post("/:id/status", validate(idParamSchema), validate(pieceTechniqueStatusSchema), updatePieceTechniqueStatus)
+
+// Versions / indices (GPAO B2.1) — source de vérité indice/plan/statut.
+router.get("/:id/versions", validate(idParamSchema), listVersions)
+router.post("/:id/versions", validate(idParamSchema), validate(createVersionSchema), createVersion)
+router.patch("/:id/versions/:versionId", validate(versionIdParamSchema), validate(updateVersionSchema), updateVersion)
+router.patch("/:id/versions/:versionId/status", validate(versionIdParamSchema), validate(versionStatusSchema), updateVersionStatus)
+router.post("/:id/versions/:versionId/create-next", validate(versionIdParamSchema), validate(createNextVersionSchema), createNextVersion)
 
 router.post("/:id/nomenclature", validate(idParamSchema), validate(addBomLineSchema), addBomLine)
 router.patch("/:id/nomenclature/:lineId", validate(bomLineIdParamSchema), validate(updateBomLineSchema), updateBomLine)

--- a/src/module/pieces-techniques/services/versions.service.ts
+++ b/src/module/pieces-techniques/services/versions.service.ts
@@ -1,0 +1,72 @@
+// src/module/pieces-techniques/services/versions.service.ts
+// GPAO B2.1 — logique métier des versions (transitions + règle "une seule APPLICABLE").
+import { HttpError } from "../../../utils/httpError"
+import type { AuditContext } from "../repository/pieces-techniques.repository"
+import {
+  repoCreateNextVersion,
+  repoCreateVersion,
+  repoGetVersion,
+  repoListVersions,
+  repoUpdateVersion,
+  repoUpdateVersionStatus,
+} from "../repository/versions.repository"
+import type {
+  CreateNextVersionBodyDTO,
+  CreateVersionBodyDTO,
+  UpdateVersionBodyDTO,
+  VersionStatusBodyDTO,
+  VersionStatutDTO,
+} from "../validators/versions.validators"
+
+// BROUILLON → EN_VALIDATION → APPLICABLE → OBSOLETE (retour EN_VALIDATION→BROUILLON permis).
+const TRANSITIONS: Record<VersionStatutDTO, readonly VersionStatutDTO[]> = {
+  BROUILLON: ["EN_VALIDATION", "OBSOLETE"],
+  EN_VALIDATION: ["APPLICABLE", "BROUILLON", "OBSOLETE"],
+  APPLICABLE: ["OBSOLETE"],
+  OBSOLETE: [],
+}
+
+export function isValidVersionTransition(from: VersionStatutDTO, to: VersionStatutDTO): boolean {
+  if (from === to) return true
+  return TRANSITIONS[from].includes(to)
+}
+
+export const listVersionsSVC = (pieceTechniqueId: string) => repoListVersions(pieceTechniqueId)
+
+export const createVersionSVC = (pieceTechniqueId: string, body: CreateVersionBodyDTO, audit: AuditContext) =>
+  repoCreateVersion(pieceTechniqueId, body, audit)
+
+export const updateVersionSVC = (pieceTechniqueId: string, versionId: string, body: UpdateVersionBodyDTO, audit: AuditContext) =>
+  repoUpdateVersion(pieceTechniqueId, versionId, body, audit)
+
+export async function updateVersionStatusSVC(
+  pieceTechniqueId: string,
+  versionId: string,
+  body: VersionStatusBodyDTO,
+  audit: AuditContext
+) {
+  const current = await repoGetVersion(pieceTechniqueId, versionId)
+  if (!current) return null
+  if (!isValidVersionTransition(current.statut, body.next_statut)) {
+    throw new HttpError(409, "INVALID_TRANSITION", `Transition invalide ${current.statut} → ${body.next_statut}`)
+  }
+  return repoUpdateVersionStatus(
+    pieceTechniqueId,
+    versionId,
+    body.next_statut,
+    {
+      valide_par: body.valide_par ?? null,
+      date_application: body.date_application ?? null,
+      commentaire_validation: body.commentaire_validation ?? null,
+      expected_updated_at: body.expected_updated_at,
+    },
+    audit
+  )
+}
+
+export const createNextVersionSVC = (
+  pieceTechniqueId: string,
+  sourceVersionId: string,
+  body: CreateNextVersionBodyDTO,
+  audit: AuditContext
+) => repoCreateNextVersion(pieceTechniqueId, sourceVersionId, body, audit)

--- a/src/module/pieces-techniques/types/pieces-techniques.types.ts
+++ b/src/module/pieces-techniques/types/pieces-techniques.types.ts
@@ -114,9 +114,20 @@ export type Operation = {
   cout_mo: number
 }
 
+export type TypeAchat =
+  | "MATIERE"
+  | "VISSERIE"
+  | "COMPOSANT_CATALOGUE"
+  | "TRAITEMENT"
+  | "SOUS_TRAITANCE"
+  | "CERTIFICAT"
+  | "DIVERS"
+
 export type Achat = {
   id?: string
   phase?: number | null
+  // Catégorie de nomenclature d'achat (B3.5). Défaut 'DIVERS' côté base.
+  type_achat?: TypeAchat
   famille_piece_id?: string | null
   nom?: string | null
   fournisseur_id?: string | null

--- a/src/module/pieces-techniques/validators/pieces-techniques.validators.ts
+++ b/src/module/pieces-techniques/validators/pieces-techniques.validators.ts
@@ -108,6 +108,12 @@ const operationInputSchema = z.object({
 
 const achatInputSchema = z.object({
   phase: z.coerce.number().int().optional().nullable(),
+  // GPAO B3.5/B4 — catégorie de nomenclature d'achat (défaut DIVERS). Additif : les payloads
+  // existants sans type_achat restent valides.
+  type_achat: z
+    .enum(["MATIERE", "VISSERIE", "COMPOSANT_CATALOGUE", "TRAITEMENT", "SOUS_TRAITANCE", "CERTIFICAT", "DIVERS"])
+    .optional()
+    .default("DIVERS"),
   famille_piece_id: uuid.optional().nullable(),
   nom: z.string().optional().nullable(),
   article_id: uuid.optional().nullable(),

--- a/src/module/pieces-techniques/validators/pieces-techniques.validators.ts
+++ b/src/module/pieces-techniques/validators/pieces-techniques.validators.ts
@@ -84,6 +84,9 @@ export type GetPieceTechniqueQueryDTO = z.infer<typeof getPieceTechniqueQuerySch
 
 const bomLineInputSchema = z.object({
   child_piece_id: uuid,
+  // GPAO B2.3 — liens de version (arborescence de fabrication versionnée). Optionnels/additifs.
+  child_piece_technique_version_id: uuid.optional().nullable(),
+  parent_piece_technique_version_id: uuid.optional().nullable(),
   rang: z.coerce.number().int().min(1).optional(),
   quantite: z.coerce.number().positive().optional().default(1),
   repere: z.string().optional().nullable(),

--- a/src/module/pieces-techniques/validators/versions.validators.ts
+++ b/src/module/pieces-techniques/validators/versions.validators.ts
@@ -1,0 +1,51 @@
+// src/module/pieces-techniques/validators/versions.validators.ts
+// GPAO B2.1 — validators des versions/indices d'une pièce technique.
+import { z } from "zod"
+
+const uuid = z.string().uuid()
+
+export const versionStatutSchema = z.enum(["BROUILLON", "EN_VALIDATION", "APPLICABLE", "OBSOLETE"])
+export type VersionStatutDTO = z.infer<typeof versionStatutSchema>
+
+export const typeChangementSchema = z.enum(["EVOLUTION", "MODIFICATION"])
+export type TypeChangementDTO = z.infer<typeof typeChangementSchema>
+
+export const versionIdParamSchema = z.object({
+  params: z.object({ id: uuid, versionId: uuid }),
+})
+
+const versionCoreBody = z.object({
+  indice: z.string().trim().min(1, "Indice requis").max(20),
+  plan_reference: z.string().trim().max(160).optional().nullable(),
+  matiere_prevue: z.string().trim().max(200).optional().nullable(),
+  commentaire_revision: z.string().max(2000).optional().nullable(),
+  type_changement: typeChangementSchema.optional().nullable(),
+  raison_changement: z.string().max(2000).optional().nullable(),
+  impact_interchangeabilite: z.boolean().optional().nullable(),
+  impact_parents: z.string().max(2000).optional().nullable(),
+})
+
+export const createVersionSchema = z.object({ body: versionCoreBody })
+export type CreateVersionBodyDTO = z.infer<typeof createVersionSchema>["body"]
+
+export const updateVersionSchema = z.object({
+  body: versionCoreBody.partial().extend({
+    expected_updated_at: z.string().min(1).optional(),
+  }),
+})
+export type UpdateVersionBodyDTO = z.infer<typeof updateVersionSchema>["body"]
+
+export const versionStatusSchema = z.object({
+  body: z.object({
+    next_statut: versionStatutSchema,
+    valide_par: z.coerce.number().int().positive().optional().nullable(),
+    date_application: z.string().min(1).optional().nullable(),
+    commentaire_validation: z.string().max(2000).optional().nullable(),
+    expected_updated_at: z.string().min(1).optional(),
+  }),
+})
+export type VersionStatusBodyDTO = z.infer<typeof versionStatusSchema>["body"]
+
+// "Nouvel indice / nouvelle évolution / nouvelle modification" (remplace le duplicate cassé).
+export const createNextVersionSchema = z.object({ body: versionCoreBody })
+export type CreateNextVersionBodyDTO = z.infer<typeof createNextVersionSchema>["body"]

--- a/src/module/stock/controllers/article-piece-link.controller.ts
+++ b/src/module/stock/controllers/article-piece-link.controller.ts
@@ -1,0 +1,122 @@
+// src/module/stock/controllers/article-piece-link.controller.ts
+// GPAO B5 — endpoints article-side du lien Article fabriqué ↔ Pièce technique.
+// Le lien passe par le chemin transactionnel updateStockArticleSVC (miroir articles +
+// pieces_techniques.article_id + articles_fabrique). Aucune écriture directe hors transaction.
+import type { Request, RequestHandler } from "express"
+import { z } from "zod"
+
+import db from "../../../config/database"
+import { HttpError } from "../../../utils/httpError"
+import { repoGetArticleDefinitionTechnique } from "../repository/article-piece-link.repository"
+import type { AuditContext } from "../repository/stock.repository"
+import { getStockArticleSVC, updateStockArticleSVC } from "../services/stock.service"
+import { updateArticleSchema } from "../validators/stock.validators"
+
+const uuidSchema = z.string().uuid()
+const linkBodySchema = z.object({ piece_technique_id: uuidSchema })
+
+function buildAuditContext(req: Request): AuditContext {
+  const user = req.user
+  if (!user) throw new HttpError(401, "UNAUTHORIZED", "Authentication required")
+  const forwardedFor = req.headers["x-forwarded-for"]
+  const ipFromHeader = typeof forwardedFor === "string" ? forwardedFor.split(",")[0]?.trim() : null
+  const ua = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null
+  const pageKey = typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null
+  const clientSessionId =
+    typeof req.headers["x-client-session-id"] === "string"
+      ? req.headers["x-client-session-id"]
+      : typeof req.headers["x-session-id"] === "string"
+        ? req.headers["x-session-id"]
+        : null
+  return {
+    user_id: user.id,
+    ip: ipFromHeader ?? req.ip ?? null,
+    user_agent: ua,
+    device_type: null,
+    os: null,
+    browser: null,
+    path: req.originalUrl ?? null,
+    page_key: pageKey,
+    client_session_id: clientSessionId,
+  }
+}
+
+function isUniqueViolation(e: unknown): boolean {
+  return typeof e === "object" && e !== null && (e as { code?: string }).code === "23505"
+}
+
+// GET /stock/articles/:id/definition-technique
+export const getArticleDefinitionTechnique: RequestHandler = async (req, res, next) => {
+  try {
+    const id = uuidSchema.parse(req.params.id)
+    const out = await repoGetArticleDefinitionTechnique(id)
+    if (!out) {
+      res.status(404).json({ error: "Article introuvable" })
+      return
+    }
+    res.json(out)
+  } catch (err) {
+    next(err)
+  }
+}
+
+// POST /stock/articles/:id/link-piece-technique { piece_technique_id }
+export const linkArticlePieceTechnique: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req)
+    const id = uuidSchema.parse(req.params.id)
+    const { piece_technique_id } = linkBodySchema.parse(req.body)
+
+    const article = await getStockArticleSVC(id)
+    if (!article) {
+      res.status(404).json({ error: "Article introuvable" })
+      return
+    }
+    if (article.article_category !== "fabrique") {
+      throw new HttpError(409, "NOT_FABRIQUE", "Seul un article fabriqué peut être lié à une pièce technique")
+    }
+
+    const piece = await db.query("SELECT 1 FROM public.pieces_techniques WHERE id = $1::uuid", [piece_technique_id])
+    if (piece.rowCount === 0) {
+      throw new HttpError(404, "PIECE_NOT_FOUND", "Pièce technique introuvable")
+    }
+
+    // Chemin transactionnel : met à jour articles + miroir pieces_techniques.article_id + articles_fabrique.
+    const body = updateArticleSchema.parse({ body: { piece_technique_id } }).body
+    try {
+      const out = await updateStockArticleSVC(id, body, audit)
+      res.json(out)
+    } catch (e) {
+      if (isUniqueViolation(e)) {
+        throw new HttpError(409, "PIECE_ALREADY_LINKED", "Cette pièce est déjà liée à un autre article fabriqué")
+      }
+      throw e
+    }
+  } catch (err) {
+    next(err)
+  }
+}
+
+// DELETE /stock/articles/:id/link-piece-technique
+// Un article 'fabrique' NE PEUT PAS avoir piece_technique_id NULL (CHECK articles_piece_type_consistency).
+// On refuse donc proprement (recatégoriser d'abord). Pour un article non-fabriqué, il n'y a rien à délier.
+export const unlinkArticlePieceTechnique: RequestHandler = async (req, res, next) => {
+  try {
+    const id = uuidSchema.parse(req.params.id)
+    const article = await getStockArticleSVC(id)
+    if (!article) {
+      res.status(404).json({ error: "Article introuvable" })
+      return
+    }
+    if (article.article_category === "fabrique") {
+      throw new HttpError(
+        409,
+        "FABRIQUE_REQUIRES_PIECE",
+        "Un article fabriqué doit conserver une pièce technique. Recatégorisez l'article avant de délier."
+      )
+    }
+    res.json({ ok: true, message: "Aucune pièce technique liée à délier pour cet article." })
+  } catch (err) {
+    next(err)
+  }
+}

--- a/src/module/stock/repository/article-piece-link.repository.ts
+++ b/src/module/stock/repository/article-piece-link.repository.ts
@@ -1,0 +1,133 @@
+// src/module/stock/repository/article-piece-link.repository.ts
+// GPAO B5 — lectures agrégées du lien Article fabriqué ↔ Pièce technique ↔ Version.
+// L'indice n'est JAMAIS lu sur l'article : il vient de la version APPLICABLE de la pièce liée.
+import db from "../../../config/database"
+
+export type ArticleDefinitionTechnique = {
+  article: {
+    id: string
+    code: string
+    designation: string
+    article_category: string
+    piece_technique_id: string | null
+  }
+  linked: boolean
+  piece: { id: string; code_piece: string; designation: string; statut: string } | null
+  applicable_version: {
+    id: string
+    indice: string
+    statut: string
+    plan_reference: string | null
+    matiere_prevue: string | null
+    date_application: string | null
+  } | null
+  has_applicable_version: boolean
+  warning: string | null
+  counts: { operations: number; sous_pieces: number; achats: number }
+}
+
+export type PieceArticlePrincipal = {
+  id: string
+  code: string
+  designation: string
+  status: string
+  article_category: string
+  stock_managed: boolean
+} | null
+
+// Renvoie null si l'article n'existe pas (→ 404). Sinon un agrégat "définition technique".
+export async function repoGetArticleDefinitionTechnique(articleId: string): Promise<ArticleDefinitionTechnique | null> {
+  const a = await db.query<{
+    id: string
+    code: string
+    designation: string
+    article_category: string
+    piece_technique_id: string | null
+  }>(
+    `SELECT id::text AS id, code, designation, article_category, piece_technique_id::text AS piece_technique_id
+     FROM public.articles WHERE id = $1::uuid`,
+    [articleId]
+  )
+  const art = a.rows[0]
+  if (!art) return null
+
+  const base = {
+    article: {
+      id: art.id,
+      code: art.code,
+      designation: art.designation,
+      article_category: art.article_category,
+      piece_technique_id: art.piece_technique_id,
+    },
+  }
+
+  if (!art.piece_technique_id) {
+    return {
+      ...base,
+      linked: false,
+      piece: null,
+      applicable_version: null,
+      has_applicable_version: false,
+      warning: art.article_category === "fabrique" ? "Définition technique manquante" : null,
+      counts: { operations: 0, sous_pieces: 0, achats: 0 },
+    }
+  }
+
+  const pieceId = art.piece_technique_id
+  const [p, v, c] = await Promise.all([
+    db.query<{ id: string; code_piece: string; designation: string; statut: string }>(
+      `SELECT id::text AS id, code_piece, designation, statut FROM public.pieces_techniques WHERE id = $1::uuid`,
+      [pieceId]
+    ),
+    db.query<{
+      id: string
+      indice: string
+      statut: string
+      plan_reference: string | null
+      matiere_prevue: string | null
+      date_application: string | null
+    }>(
+      `SELECT id::text AS id, indice, statut, plan_reference, matiere_prevue, date_application::text AS date_application
+       FROM public.piece_technique_versions
+       WHERE piece_technique_id = $1::uuid AND statut = 'APPLICABLE'
+       ORDER BY date_application DESC NULLS LAST LIMIT 1`,
+      [pieceId]
+    ),
+    db.query<{ operations: string; sous_pieces: string; achats: string }>(
+      `SELECT
+         (SELECT count(*) FROM public.pieces_techniques_operations WHERE piece_technique_id = $1::uuid) AS operations,
+         (SELECT count(*) FROM public.pieces_techniques_nomenclature WHERE parent_piece_technique_id = $1::uuid) AS sous_pieces,
+         (SELECT count(*) FROM public.pieces_techniques_achats WHERE piece_technique_id = $1::uuid) AS achats`,
+      [pieceId]
+    ),
+  ])
+
+  const version = v.rows[0] ?? null
+  const counts = c.rows[0]
+  return {
+    ...base,
+    linked: true,
+    piece: p.rows[0] ?? null,
+    applicable_version: version,
+    has_applicable_version: !!version,
+    warning: version ? null : "Aucune version applicable pour cette pièce",
+    counts: {
+      operations: Number(counts?.operations ?? 0),
+      sous_pieces: Number(counts?.sous_pieces ?? 0),
+      achats: Number(counts?.achats ?? 0),
+    },
+  }
+}
+
+// Article fabriqué principal d'une pièce, lu CÔTÉ CANONIQUE (articles.piece_technique_id),
+// pas via pieces_techniques.article_id (sujet à dérive). Renvoie null si aucun.
+export async function repoGetPieceArticlePrincipal(pieceTechniqueId: string): Promise<PieceArticlePrincipal> {
+  const r = await db.query<NonNullable<PieceArticlePrincipal>>(
+    `SELECT id::text AS id, code, designation, status, article_category, stock_managed
+     FROM public.articles
+     WHERE piece_technique_id = $1::uuid AND article_category = 'fabrique'
+     LIMIT 1`,
+    [pieceTechniqueId]
+  )
+  return r.rows[0] ?? null
+}

--- a/src/module/stock/routes/stock.routes.ts
+++ b/src/module/stock/routes/stock.routes.ts
@@ -54,6 +54,11 @@ import {
   updateStockLot,
   updateStockMagasin,
 } from "../controllers/stock.controller";
+import {
+  getArticleDefinitionTechnique,
+  linkArticlePieceTechnique,
+  unlinkArticlePieceTechnique,
+} from "../controllers/article-piece-link.controller";
 
 const router = Router();
 
@@ -90,6 +95,11 @@ router.get("/inventory-sessions/:id", getStockInventorySession);
 router.get("/inventory-sessions/:id/lines", listStockInventorySessionLines);
 router.put("/inventory-sessions/:id/lines", upsertStockInventorySessionLine);
 router.post("/inventory-sessions/:id/close", closeStockInventorySession);
+
+// GPAO B5 — lien Article fabriqué ↔ Pièce technique
+router.get("/articles/:id/definition-technique", getArticleDefinitionTechnique);
+router.post("/articles/:id/link-piece-technique", linkArticlePieceTechnique);
+router.delete("/articles/:id/link-piece-technique", unlinkArticlePieceTechnique);
 
 router.get("/articles/:id/documents", listStockArticleDocuments);
 router.post("/articles/:id/documents", upload.array("documents[]"), attachStockArticleDocuments);

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -38,6 +38,8 @@ import usersRoutes from "../module/users/routes/users.routes";
 import traceabilityRoutes from "../module/traceability/routes/traceability.routes"
 import asbuiltRoutes from "../module/asbuilt/routes/asbuilt.routes"
 import locksRoutes from "../module/locks/routes/locks.routes"
+import gammesRoutes from "../module/gammes/routes/gammes.routes"
+import pieceTechniqueVersionsRoutes from "../module/gammes/routes/piece-technique-versions.routes"
 const router = Router()
 
 // --- Routes publiques (avant authentification) ---
@@ -57,6 +59,8 @@ router.use("/billers", billerRoutes);
 router.use("/pieces-families", piecesfamiliesRoutes) 
 router.use("/centre-frais", CFRoutes)     
 router.use("/pieces-techniques", piecesTechniquesRoutes)
+router.use("/piece-technique-versions", pieceTechniqueVersionsRoutes) // GPAO B2.2 — gammes par version
+router.use("/gammes", gammesRoutes)                                   // GPAO B2.2 — gammes + opérations
 router.use("/audit-logs", auditLogsRoutes)
 router.use("/admin", adminRoutes);
 router.use("/affaires", affaireRoutes);


### PR DESCRIPTION
Release GPAO/PDM V2 vers `main`. Reprend erp-crp-backend#59 (feat/gpao-v2 → dev, CI verte).
Migrations déjà appliquées + vérifiées sur **cerp_prod** (backup pris, pending=0). Legacy conservé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce GPAO/PDM V2 backend support for versioned technical parts, routings, and article links while exposing environment diagnostics.

New Features:
- Expose a public environment endpoint that reports the actual connected database and runtime environment.
- Add APIs and domain model for piece technique versions, including lifecycle management and audit logging.
- Add APIs and data model for routings (gammes) and their operations, tied to specific piece technique versions.
- Introduce APIs and services to link manufactured stock articles to technical parts from both article and piece perspectives.
- Extend purchase BOM lines with a typed category field to support structured purchasing nomenclature.

Enhancements:
- Version BOM lines and fabrication trees by referencing parent and child piece technique versions.
- Refine stock and GPAO invariants to enforce one principal manufactured article per technical piece and one applicable version or current routing per scope.
- Add validation schemas and tests around version lifecycle, routings, purchase types, and article-piece consistency to secure GPAO flows.

Deployment:
- Add additive, rollbackable database patches for version lifecycle, routings and operation types, purchase categories, versioned BOM, and piece↔article uniqueness, plus their rollback scripts in support.

Tests:
- Add unit tests for version status transitions and validators for piece technique versions.
- Add unit tests for routing (gammes) validators and operation schemas.
- Add unit tests verifying manufactured article vs piece technique schema invariants.
- Add unit tests for purchase line type_achat validation and defaults.