### PR TITLE
fix(security): CA-SEC-04 — erreurs 500 génériques (pas de fuite d'internes)

### DIFF
--- a/src/__tests__/errorHandler.test.ts
+++ b/src/__tests__/errorHandler.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import type { Request, Response } from "express";
+
+import { errorHandler } from "../middlewares/errorHandler";
+import { HttpError } from "../utils/httpError";
+import { ApiError } from "../utils/apiError";
+
+// CA-SEC-04 — le gestionnaire d'erreurs ne doit JAMAIS renvoyer d'internes (message
+// d'exception brut, nom de colonne/table, adresse, stack) au client sur une 5xx / erreur
+// inconnue. Les erreurs "connues" (HttpError/ApiError) < 500 conservent leur message
+// volontaire. Le message réel reste dans les logs serveur (console.error).
+
+function mockReqRes(originalUrl = "/api/v1/production/ofs") {
+  const req = { originalUrl, method: "GET", requestId: "req-test-123" } as unknown as Request;
+  const json = vi.fn();
+  const status = vi.fn().mockReturnValue({ json });
+  const res = { status } as unknown as Response;
+  return { req, res, status, json };
+}
+
+describe("CA-SEC-04 — errorHandler ne fuite pas d'internes sur 5xx", () => {
+  let errSpy: ReturnType<typeof vi.spyOn>;
+  beforeEach(() => {
+    errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    errSpy.mockRestore();
+  });
+
+  it("erreur inconnue (erreur SQL) → 500 + message générique + code INTERNAL_ERROR, pas de fuite", () => {
+    const { req, res, status, json } = mockReqRes();
+    const leak = "column o.parent_of_id does not exist";
+
+    errorHandler(new Error(leak), req, res, () => {});
+
+    expect(status).toHaveBeenCalledWith(500);
+    const payload = json.mock.calls[0][0];
+    expect(payload).toEqual({
+      success: false,
+      message: "Erreur serveur.",
+      code: "INTERNAL_ERROR",
+      path: "/api/v1/production/ofs",
+    });
+    // le message brut de la colonne ne doit PAS atteindre le client
+    expect(JSON.stringify(payload)).not.toContain("parent_of_id");
+  });
+
+  it("le message réel est bien journalisé côté serveur (pour le diagnostic)", () => {
+    const { req, res } = mockReqRes();
+    const leak = 'column "due_date" does not exist';
+
+    errorHandler(new Error(leak), req, res, () => {});
+
+    // présent dans les logs serveur (console.error), absent de la réponse client
+    expect(JSON.stringify(errSpy.mock.calls.flat())).toContain("due_date");
+  });
+
+  it("HttpError < 500 conserve son message volontaire (ex. 404)", () => {
+    const { req, res, status, json } = mockReqRes();
+
+    errorHandler(new HttpError(404, "PIECE_NOT_FOUND", "Pièce introuvable"), req, res, () => {});
+
+    expect(status).toHaveBeenCalledWith(404);
+    expect(json.mock.calls[0][0]).toEqual({
+      success: false,
+      message: "Pièce introuvable",
+      code: "PIECE_NOT_FOUND",
+      path: "/api/v1/production/ofs",
+    });
+  });
+
+  it("ApiError 409 conserve son message métier", () => {
+    const { req, res, status, json } = mockReqRes();
+
+    errorHandler(new ApiError(409, "ALREADY_LINKED", "Article déjà lié à une pièce"), req, res, () => {});
+
+    expect(status).toHaveBeenCalledWith(409);
+    const payload = json.mock.calls[0][0];
+    expect(payload.message).toBe("Article déjà lié à une pièce");
+    expect(payload.code).toBe("ALREADY_LINKED");
+  });
+
+  it("HttpError >= 500 est aussi masquée (message générique, mais code conservé)", () => {
+    const { req, res, status, json } = mockReqRes();
+
+    errorHandler(new HttpError(503, "DB_DOWN", "connection refused at 10.0.0.5:5432"), req, res, () => {});
+
+    expect(status).toHaveBeenCalledWith(503);
+    const payload = json.mock.calls[0][0];
+    expect(payload.message).toBe("Erreur serveur.");
+    expect(payload.code).toBe("DB_DOWN");
+    expect(JSON.stringify(payload)).not.toContain("10.0.0.5");
+  });
+});

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,22 +1,40 @@
 import type { Request, Response, NextFunction } from "express";
 import { HttpError } from "../utils/httpError";
 import { ApiError } from "../utils/apiError";
- 
+
+// Message générique renvoyé au client pour toute erreur serveur (5xx) ou inconnue.
+// CA-SEC-04 : ne jamais fuiter d'internes (message d'exception brut, nom de colonne/table,
+// stack) au client. Le message réel + la stack restent dans les logs serveur. Le client
+// peut corréler via l'en-tête X-Request-Id (posé par requestIdMiddleware sur chaque réponse).
+// Volontairement indépendant de NODE_ENV : en prod le backend tourne avec NODE_ENV=development
+// (cf. /environment.appEnv), donc un gate sur NODE_ENV ne se déclencherait pas. On masque
+// dans tous les environnements — le dev garde le détail complet dans les logs serveur.
+const GENERIC_SERVER_ERROR_MESSAGE = "Erreur serveur.";
+
 export function errorHandler(err: any, req: Request, res: Response, _next: NextFunction) {
-  const status = err instanceof HttpError ? err.status : err instanceof ApiError ? err.status : 500;
- 
+  const isKnown = err instanceof HttpError || err instanceof ApiError;
+  const status = isKnown ? err.status : 500;
+  const code = isKnown ? err.code : "INTERNAL_ERROR";
+
+  // Les erreurs "connues" (HttpError/ApiError) < 500 portent un message volontaire et sûr
+  // pour le client (ex. "Pièce introuvable", messages de validation). Toute 5xx ou erreur
+  // inconnue reçoit le message générique — jamais le message d'exception brut.
+  const message =
+    isKnown && status < 500 ? (err.message ?? GENERIC_SERVER_ERROR_MESSAGE) : GENERIC_SERVER_ERROR_MESSAGE;
+
   const payload = {
     success: false,
-    message: err?.message ?? "Erreur serveur.",
-    code: err instanceof HttpError ? err.code : err instanceof ApiError ? err.code : "INTERNAL_ERROR",
+    message,
+    code,
     path: req.originalUrl,
   };
 
-  // logs détaillés côté serveur
+  // logs détaillés côté serveur (JAMAIS renvoyés au client) — inclut le message réel + la stack.
   console.error("[ERROR]", {
     status,
-    code: payload.code,
-    message: payload.message,
+    code,
+    message: err?.message ?? null,
+    clientMessage: message,
     method: req.method,
     path: req.originalUrl,
     requestId: req.requestId ?? null,


### PR DESCRIPTION
## Objectif — CA-SEC-04
En production, les erreurs **500** ne doivent pas renvoyer `err.message` brut au client. Message générique côté client, détails uniquement dans les logs serveur.

## Preuve (vérification connectée prod, 2026-07-09)
Sur `cerp_prod`, deux endpoints (préexistants, hors GPAO) fuitaient des **noms de colonnes internes** :
- `GET /api/v1/production/ofs` → 500 `column o.parent_of_id does not exist`
- `GET /api/v1/qualite/dashboard` → 500 `column "due_date" does not exist`

## Changement
`src/middlewares/errorHandler.ts` :
- Erreur **inconnue / toute 5xx** → `{ message: "Erreur serveur.", code: "INTERNAL_ERROR" }`.
- `HttpError`/`ApiError` **< 500** → conservent leur message volontaire (validation, « Pièce introuvable », conflits métier 409…).
- Message réel + stack → **logs serveur uniquement** (`console.error`). Corrélation client via l'en-tête **`X-Request-Id`** (déjà posé sur chaque réponse).
- **Indépendant de `NODE_ENV`** : le backend prod tourne en `NODE_ENV=development` (cf. `/environment.appEnv`), un gate `NODE_ENV` ne se déclencherait pas. On masque dans tous les environnements ; le dev garde le détail complet dans les logs.

## Tests
`src/__tests__/errorHandler.test.ts` (5) : 500 générique + absence de fuite (`parent_of_id`, IP…), le log serveur conserve le détail, les 4xx (`HttpError` 404, `ApiError` 409) conservent leur message, une `HttpError` ≥ 500 est aussi masquée.
- **Suite complète : 41 fichiers / 169 tests verts. Typecheck (tsc) OK.**

## Périmètre
Correctif ciblé (1 fichier + 1 test), pas de refactor. Ne corrige pas la cause racine des 500 (migrations manquantes en prod — traité séparément).

## Summary by Sourcery

Mask server-side error details from HTTP 5xx responses to prevent leaking internal information while preserving diagnostic logs.

Bug Fixes:
- Ensure unknown errors and all 5xx responses return a generic server error message and INTERNAL_ERROR code instead of raw exception messages.
- Preserve intentional messages for 4xx HttpError/ApiError responses while still hiding messages for HttpError instances with status >= 500.

Tests:
- Add unit tests for the error handler to verify generic handling of 5xx and unknown errors, absence of internal data leaks, preservation of 4xx messages, and masking of 5xx HttpError messages.