### PR TITLE
chore(deps): CA-DEV-04 — picomatch 2.3.1→2.3.2 (audit backend = 0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3663,9 +3663,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## CA-DEV-04 (backend)

`npm audit fix` (patch, sans `--force`) : **picomatch 2.3.1 → 2.3.2**.
- Corrige ReDoS (GHSA-c2c7-rcm5-vvqj) + method injection (GHSA-3v7f-55p6-f55p).
- Transitif via `ts-node-dev > chokidar` — **dev/tooling only**, hors runtime prod (le runtime backend était déjà à 0 vuln).
- **Audit backend : 1 High → 0 vulnérabilité.**
- Lockfile uniquement (aucun changement de code).

Tests : `tsc --noEmit` OK + vitest **169** verts.

## Summary by Sourcery

Build:
- Update picomatch dependency in package-lock.json from 2.3.1 to 2.3.2 for backend tooling.