### PR TITLE
feat(temps-deplacements): T1 — schéma DB hr_* + append-only + rôle RH

### DIFF
--- a/db/patches/20260709_hr_temps_deplacements.sql
+++ b/db/patches/20260709_hr_temps_deplacements.sql
@@ -1,0 +1,301 @@
+-- Module « Temps & Déplacements » (Pointage & Kilomètres) — T1 schéma de base.
+-- Issue frontend #119 ; archi: crp-systems-web/docs/architecture/module-temps-pointage-kilometres.md ;
+-- ADR-0013. Migration ADDITIVE + IDEMPOTENTE uniquement (aucun DROP, aucun changement de type).
+-- Append-only de hr_time_events durci séparément par db/privileged/20260709_hr_time_events_append_only.sql
+-- (owner/grants/triggers superuser). Aucun lien avec d'anciens fichiers. cerp_test d'abord.
+
+DO $$ BEGIN EXECUTE 'CREATE EXTENSION IF NOT EXISTS pgcrypto';
+EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'skip CREATE EXTENSION pgcrypto (privileges)'; END $$;
+
+-- ------------------------------------------------------------------ Enums (gardés)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_employee_status') THEN CREATE TYPE public.hr_employee_status AS ENUM ('ACTIVE','SUSPENDED','LEFT'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_contract_type') THEN CREATE TYPE public.hr_contract_type AS ENUM ('H35','H39','PARTIAL','OTHER'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_device_status') THEN CREATE TYPE public.hr_device_status AS ENUM ('ACTIVE','DISABLED'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_event_type') THEN CREATE TYPE public.hr_event_type AS ENUM ('IN','OUT','BREAK_START','BREAK_END','MISSION_START','MISSION_END'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_event_source') THEN CREATE TYPE public.hr_event_source AS ENUM ('BADGE','WEB','MOBILE','ADMIN','IMPORT'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_session_status') THEN CREATE TYPE public.hr_session_status AS ENUM ('OK','ANOMALY','MANUAL_REVIEW','VALIDATED'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_validation_status') THEN CREATE TYPE public.hr_validation_status AS ENUM ('DRAFT','TO_REVIEW','VALIDATED','EXPORTED'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_adjustment_target') THEN CREATE TYPE public.hr_adjustment_target AS ENUM ('EVENT','DAY','WEEK'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_adjustment_status') THEN CREATE TYPE public.hr_adjustment_status AS ENUM ('REQUESTED','APPROVED','REJECTED'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_anomaly_type') THEN CREATE TYPE public.hr_anomaly_type AS ENUM ('MISSING_IN','MISSING_OUT','MISSING_BREAK_END','DOUBLE_BADGE','TOO_LONG_DAY','TOO_SHORT_BREAK','OUTSIDE_SCHEDULE'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_anomaly_severity') THEN CREATE TYPE public.hr_anomaly_severity AS ENUM ('INFO','WARNING','CRITICAL'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_vehicle_owner') THEN CREATE TYPE public.hr_vehicle_owner AS ENUM ('COMPANY','PERSONAL'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_km_type') THEN CREATE TYPE public.hr_km_type AS ENUM ('MISSION','CLIENT','FOURNISSEUR','LIVRAISON','AUTRE'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_km_status') THEN CREATE TYPE public.hr_km_status AS ENUM ('DRAFT','SUBMITTED','VALIDATED','REJECTED'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_export_format') THEN CREATE TYPE public.hr_export_format AS ENUM ('CSV','PDF'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_export_status') THEN CREATE TYPE public.hr_export_status AS ENUM ('GENERATED','DELIVERED','SUPERSEDED'); END IF;
+END $$;
+
+-- ------------------------------------------------------------------ Référentiel employé & règles
+CREATE TABLE IF NOT EXISTS public.hr_employees (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  user_id integer NOT NULL,
+  matricule text NOT NULL,
+  service text NULL,
+  manager_user_id integer NULL,
+  status public.hr_employee_status NOT NULL DEFAULT 'ACTIVE',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_employees_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_employees_user_id_key UNIQUE (user_id),
+  CONSTRAINT hr_employees_matricule_key UNIQUE (matricule),
+  CONSTRAINT hr_employees_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT hr_employees_manager_user_id_fkey FOREIGN KEY (manager_user_id) REFERENCES public.users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS hr_employees_manager_idx ON public.hr_employees(manager_user_id) WHERE manager_user_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.hr_time_rule_sets (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  weekly_target_minutes integer NOT NULL,
+  daily_target_minutes integer NOT NULL,
+  overtime_threshold_1_minutes integer NULL,
+  overtime_rate_1 numeric(5,3) NULL,
+  overtime_threshold_2_minutes integer NULL,
+  overtime_rate_2 numeric(5,3) NULL,
+  rounding_rule jsonb NOT NULL DEFAULT '{}'::jsonb,
+  break_rule jsonb NOT NULL DEFAULT '{}'::jsonb,
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_time_rule_sets_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_time_rule_sets_targets_ck CHECK (weekly_target_minutes >= 0 AND daily_target_minutes >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS public.hr_employment_contracts (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  contract_type public.hr_contract_type NOT NULL,
+  weekly_hours_target numeric(6,2) NOT NULL,
+  daily_hours_target numeric(5,2) NULL,
+  start_date date NOT NULL,
+  end_date date NULL,
+  active boolean NOT NULL DEFAULT true,
+  rule_set_id uuid NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_employment_contracts_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_employment_contracts_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  CONSTRAINT hr_employment_contracts_rule_set_id_fkey FOREIGN KEY (rule_set_id) REFERENCES public.hr_time_rule_sets(id) ON DELETE SET NULL,
+  CONSTRAINT hr_employment_contracts_dates_ck CHECK (end_date IS NULL OR end_date >= start_date)
+);
+CREATE INDEX IF NOT EXISTS hr_employment_contracts_employee_idx ON public.hr_employment_contracts(employee_id);
+CREATE UNIQUE INDEX IF NOT EXISTS hr_employment_contracts_one_active_idx ON public.hr_employment_contracts(employee_id) WHERE active;
+
+CREATE TABLE IF NOT EXISTS public.hr_work_schedules (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  day_of_week integer NOT NULL,
+  expected_start time NULL,
+  expected_end time NULL,
+  expected_break_minutes integer NOT NULL DEFAULT 0,
+  flexible_start_window integer NOT NULL DEFAULT 0,
+  flexible_end_window integer NOT NULL DEFAULT 0,
+  active boolean NOT NULL DEFAULT true,
+  CONSTRAINT hr_work_schedules_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_work_schedules_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  CONSTRAINT hr_work_schedules_dow_ck CHECK (day_of_week BETWEEN 0 AND 6)
+);
+CREATE INDEX IF NOT EXISTS hr_work_schedules_employee_idx ON public.hr_work_schedules(employee_id);
+
+-- ------------------------------------------------------------------ Bornes & badges
+CREATE TABLE IF NOT EXISTS public.hr_time_clock_devices (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  location text NULL,
+  device_type text NULL,
+  device_token_hash text NULL,
+  status public.hr_device_status NOT NULL DEFAULT 'ACTIVE',
+  last_seen_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_time_clock_devices_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS public.hr_badge_credentials (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  badge_uid_hash text NOT NULL,
+  badge_label text NULL,
+  active boolean NOT NULL DEFAULT true,
+  issued_at timestamptz NOT NULL DEFAULT now(),
+  revoked_at timestamptz NULL,
+  CONSTRAINT hr_badge_credentials_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_badge_credentials_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hr_badge_credentials_active_uid_idx ON public.hr_badge_credentials(badge_uid_hash) WHERE active;
+
+-- ------------------------------------------------------------------ Événements bruts (append-only ; hardening en db/privileged)
+CREATE TABLE IF NOT EXISTS public.hr_time_events (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  device_id uuid NULL,
+  event_type public.hr_event_type NOT NULL,
+  event_time timestamptz NOT NULL,
+  source public.hr_event_source NOT NULL DEFAULT 'WEB',
+  idempotency_key text NULL,
+  raw_payload_json jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_time_events_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_time_events_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE RESTRICT,
+  CONSTRAINT hr_time_events_device_id_fkey FOREIGN KEY (device_id) REFERENCES public.hr_time_clock_devices(id) ON DELETE SET NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hr_time_events_idempotency_key_idx ON public.hr_time_events(idempotency_key) WHERE idempotency_key IS NOT NULL;
+CREATE INDEX IF NOT EXISTS hr_time_events_employee_time_idx ON public.hr_time_events(employee_id, event_time);
+
+-- ------------------------------------------------------------------ Agrégats calculés
+CREATE TABLE IF NOT EXISTS public.hr_work_sessions (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  date date NOT NULL,
+  start_time timestamptz NULL,
+  end_time timestamptz NULL,
+  break_minutes integer NOT NULL DEFAULT 0,
+  worked_minutes integer NOT NULL DEFAULT 0,
+  computed_from_events jsonb NOT NULL DEFAULT '{}'::jsonb,
+  status public.hr_session_status NOT NULL DEFAULT 'OK',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_work_sessions_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_work_sessions_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS hr_work_sessions_employee_date_idx ON public.hr_work_sessions(employee_id, date);
+
+CREATE TABLE IF NOT EXISTS public.hr_timesheet_days (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  date date NOT NULL,
+  expected_minutes integer NOT NULL DEFAULT 0,
+  worked_minutes integer NOT NULL DEFAULT 0,
+  overtime_minutes integer NOT NULL DEFAULT 0,
+  missing_minutes integer NOT NULL DEFAULT 0,
+  anomaly_count integer NOT NULL DEFAULT 0,
+  validation_status public.hr_validation_status NOT NULL DEFAULT 'DRAFT',
+  validated_by integer NULL,
+  validated_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_timesheet_days_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_timesheet_days_employee_date_key UNIQUE (employee_id, date),
+  CONSTRAINT hr_timesheet_days_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  CONSTRAINT hr_timesheet_days_validated_by_fkey FOREIGN KEY (validated_by) REFERENCES public.users(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.hr_timesheet_weeks (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  week_start date NOT NULL,
+  week_end date NOT NULL,
+  contract_minutes integer NOT NULL DEFAULT 0,
+  worked_minutes integer NOT NULL DEFAULT 0,
+  overtime_25_minutes integer NOT NULL DEFAULT 0,
+  overtime_50_minutes integer NOT NULL DEFAULT 0,
+  absence_minutes integer NOT NULL DEFAULT 0,
+  validation_status public.hr_validation_status NOT NULL DEFAULT 'DRAFT',
+  validated_by integer NULL,
+  validated_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_timesheet_weeks_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_timesheet_weeks_employee_week_key UNIQUE (employee_id, week_start),
+  CONSTRAINT hr_timesheet_weeks_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  CONSTRAINT hr_timesheet_weeks_validated_by_fkey FOREIGN KEY (validated_by) REFERENCES public.users(id) ON DELETE SET NULL,
+  CONSTRAINT hr_timesheet_weeks_dates_ck CHECK (week_end >= week_start)
+);
+
+-- ------------------------------------------------------------------ Corrections & anomalies
+CREATE TABLE IF NOT EXISTS public.hr_time_adjustments (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  target_type public.hr_adjustment_target NOT NULL,
+  target_id uuid NOT NULL,
+  old_value_json jsonb NULL,
+  new_value_json jsonb NULL,
+  reason text NOT NULL,
+  requested_by integer NOT NULL,
+  approved_by integer NULL,
+  status public.hr_adjustment_status NOT NULL DEFAULT 'REQUESTED',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  approved_at timestamptz NULL,
+  CONSTRAINT hr_time_adjustments_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_time_adjustments_requested_by_fkey FOREIGN KEY (requested_by) REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT hr_time_adjustments_approved_by_fkey FOREIGN KEY (approved_by) REFERENCES public.users(id) ON DELETE SET NULL,
+  CONSTRAINT hr_time_adjustments_reason_ck CHECK (length(btrim(reason)) > 0),
+  CONSTRAINT hr_time_adjustments_no_self_approve_ck CHECK (approved_by IS NULL OR approved_by <> requested_by)
+);
+CREATE INDEX IF NOT EXISTS hr_time_adjustments_target_idx ON public.hr_time_adjustments(target_type, target_id);
+CREATE INDEX IF NOT EXISTS hr_time_adjustments_status_idx ON public.hr_time_adjustments(status);
+
+CREATE TABLE IF NOT EXISTS public.hr_time_anomalies (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  date date NOT NULL,
+  anomaly_type public.hr_anomaly_type NOT NULL,
+  severity public.hr_anomaly_severity NOT NULL DEFAULT 'WARNING',
+  message text NULL,
+  resolved_by integer NULL,
+  resolved_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_time_anomalies_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_time_anomalies_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  CONSTRAINT hr_time_anomalies_resolved_by_fkey FOREIGN KEY (resolved_by) REFERENCES public.users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS hr_time_anomalies_employee_date_idx ON public.hr_time_anomalies(employee_id, date);
+
+-- ------------------------------------------------------------------ Véhicules & kilomètres
+CREATE TABLE IF NOT EXISTS public.hr_vehicles (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  label text NOT NULL,
+  plate text NULL,
+  owner_type public.hr_vehicle_owner NOT NULL DEFAULT 'COMPANY',
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_vehicles_pkey PRIMARY KEY (id)
+);
+
+-- Refs métier (affaire_id/client_id/fournisseur_id) volontairement SANS FK dure en T1
+-- (couplage/typage à valider en T6-kilomètres) ; colonnes nullable = références souples.
+CREATE TABLE IF NOT EXISTS public.hr_kilometer_entries (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  date date NOT NULL,
+  type public.hr_km_type NOT NULL DEFAULT 'MISSION',
+  vehicle_id uuid NULL,
+  start_location text NULL,
+  end_location text NULL,
+  start_odometer numeric(10,1) NULL,
+  end_odometer numeric(10,1) NULL,
+  distance_km numeric(10,2) NOT NULL DEFAULT 0,
+  affaire_id bigint NULL,
+  client_id integer NULL,
+  fournisseur_id integer NULL,
+  proof_document_id uuid NULL,
+  status public.hr_km_status NOT NULL DEFAULT 'DRAFT',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  validated_by integer NULL,
+  validated_at timestamptz NULL,
+  CONSTRAINT hr_kilometer_entries_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_kilometer_entries_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  CONSTRAINT hr_kilometer_entries_vehicle_id_fkey FOREIGN KEY (vehicle_id) REFERENCES public.hr_vehicles(id) ON DELETE SET NULL,
+  CONSTRAINT hr_kilometer_entries_validated_by_fkey FOREIGN KEY (validated_by) REFERENCES public.users(id) ON DELETE SET NULL,
+  CONSTRAINT hr_kilometer_entries_distance_ck CHECK (distance_km >= 0)
+);
+CREATE INDEX IF NOT EXISTS hr_kilometer_entries_employee_date_idx ON public.hr_kilometer_entries(employee_id, date);
+
+-- ------------------------------------------------------------------ Exports figés
+CREATE TABLE IF NOT EXISTS public.hr_payroll_export_batches (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  period_start date NOT NULL,
+  period_end date NOT NULL,
+  exported_by integer NOT NULL,
+  exported_at timestamptz NOT NULL DEFAULT now(),
+  format public.hr_export_format NOT NULL,
+  frozen_snapshot_json jsonb NOT NULL DEFAULT '{}'::jsonb,
+  checksum text NULL,
+  supersedes_id uuid NULL,
+  status public.hr_export_status NOT NULL DEFAULT 'GENERATED',
+  CONSTRAINT hr_payroll_export_batches_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_payroll_export_batches_exported_by_fkey FOREIGN KEY (exported_by) REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT hr_payroll_export_batches_supersedes_fkey FOREIGN KEY (supersedes_id) REFERENCES public.hr_payroll_export_batches(id) ON DELETE SET NULL,
+  CONSTRAINT hr_payroll_export_batches_period_ck CHECK (period_end >= period_start)
+);
+CREATE INDEX IF NOT EXISTS hr_payroll_export_batches_period_idx ON public.hr_payroll_export_batches(period_start, period_end);

--- a/db/privileged/20260709_hr_module_ownership.rollback.sql
+++ b/db/privileged/20260709_hr_module_ownership.rollback.sql
@@ -1,0 +1,28 @@
+-- ROLLBACK for 20260709_hr_module_ownership.sql   (SUPERUSER ONLY)
+--
+-- Rend les 14 tables CRUD du module à postgres (état « appliqué en direct sans normalisation »).
+-- hr_time_events n'est pas concerné (géré par son propre append-only). Non destructif, idempotent.
+--
+--   sudo -u postgres psql -d <db> -f db/privileged/20260709_hr_module_ownership.rollback.sql
+
+BEGIN;
+
+DO $rb$
+DECLARE
+  t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'hr_employees','hr_time_rule_sets','hr_employment_contracts','hr_work_schedules',
+    'hr_time_clock_devices','hr_badge_credentials','hr_work_sessions','hr_timesheet_days',
+    'hr_timesheet_weeks','hr_time_adjustments','hr_time_anomalies','hr_vehicles',
+    'hr_kilometer_entries','hr_payroll_export_batches'
+  ]
+  LOOP
+    IF to_regclass('public.' || t) IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.%I OWNER TO postgres', t);
+    END IF;
+  END LOOP;
+END
+$rb$;
+
+COMMIT;

--- a/db/privileged/20260709_hr_module_ownership.sql
+++ b/db/privileged/20260709_hr_module_ownership.sql
@@ -1,0 +1,54 @@
+-- 20260709_hr_module_ownership.sql   (PRIVILEGED — SUPERUSER ONLY)
+--
+-- Module « Temps & Déplacements » — normalise la PROPRIÉTÉ des 14 tables CRUD vers cerp_app.
+--
+-- POURQUOI
+--   La migration db/patches/20260709_hr_temps_deplacements.sql crée les tables. Appliquée
+--   par le RUNNER (as cerp_app) → cerp_app en est owner (rien à faire). Mais appliquée
+--   directement en `postgres` (hors runner — p.ex. cerp_test dont le .env du runner pointe
+--   cerp_prod, ou une application DBA), les tables restent postgres-owned et cerp_app ne peut
+--   pas les manipuler. Ce fichier rend la propriété REPRODUCTIBLE quel que soit le mode
+--   d'application (idempotent : no-op si déjà cerp_app).
+--
+--   NB : hr_time_events est VOLONTAIREMENT EXCLU — il doit rester owned par postgres
+--   (append-only, cf. 20260709_hr_time_events_append_only.sql).
+--
+--   `ALTER TABLE ... OWNER TO` ne supporte PAS une liste de tables → une instruction par
+--   table (ici via une boucle DO).
+--
+--   sudo -u postgres psql -d cerp_test -f db/privileged/20260709_hr_module_ownership.sql
+--   sudo -u postgres psql -d cerp_prod -f db/privileged/20260709_hr_module_ownership.sql   (T10 seulement)
+--
+-- SAFETY : idempotent, non destructif. Rollback/verify fournis à côté. Superuser (postgres).
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF NOT COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false) THEN
+    RAISE EXCEPTION 'hr_module_ownership: doit être appliqué par un superuser; current_user=% ne l''est pas', current_user;
+  END IF;
+END
+$guard$;
+
+DO $own$
+DECLARE
+  t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'hr_employees','hr_time_rule_sets','hr_employment_contracts','hr_work_schedules',
+    'hr_time_clock_devices','hr_badge_credentials','hr_work_sessions','hr_timesheet_days',
+    'hr_timesheet_weeks','hr_time_adjustments','hr_time_anomalies','hr_vehicles',
+    'hr_kilometer_entries','hr_payroll_export_batches'
+  ]
+  LOOP
+    IF to_regclass('public.' || t) IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.%I OWNER TO cerp_app', t);
+    ELSE
+      RAISE NOTICE 'hr_module_ownership: table public.% absente — ignorée', t;
+    END IF;
+  END LOOP;
+END
+$own$;
+
+COMMIT;

--- a/db/privileged/20260709_hr_module_ownership.verify.sql
+++ b/db/privileged/20260709_hr_module_ownership.verify.sql
@@ -1,0 +1,28 @@
+-- VERIFY — propriété des tables du module « Temps & Déplacements ».   (sur cerp_test)
+--
+--   sudo -u postgres psql -d cerp_test -f db/privileged/20260709_hr_module_ownership.verify.sql
+--
+-- Attendu :
+--   14 tables CRUD  -> owner = cerp_app
+--   hr_time_events  -> owner = postgres        (append-only)
+--   crud_not_cerp_app = 0                       (aucune table CRUD hors cerp_app)
+
+\pset pager off
+
+\echo '### propriétaires des tables hr_* (attendu: hr_time_events=postgres, le reste=cerp_app)'
+SELECT tablename, tableowner
+FROM pg_tables
+WHERE schemaname = 'public' AND tablename LIKE 'hr_%'
+ORDER BY tablename;
+
+\echo '### tables CRUD qui ne seraient PAS owned par cerp_app (attendu: 0)'
+SELECT count(*) AS crud_not_cerp_app
+FROM pg_tables
+WHERE schemaname = 'public'
+  AND tablename LIKE 'hr_%'
+  AND tablename <> 'hr_time_events'
+  AND tableowner <> 'cerp_app';
+
+\echo '### hr_time_events reste-t-il bien postgres (append-only) ? (attendu: t)'
+SELECT (tableowner = 'postgres') AS hr_time_events_is_postgres
+FROM pg_tables WHERE schemaname = 'public' AND tablename = 'hr_time_events';

--- a/db/privileged/20260709_hr_time_events_append_only.rollback.sql
+++ b/db/privileged/20260709_hr_time_events_append_only.rollback.sql
@@ -1,0 +1,28 @@
+-- ROLLBACK for 20260709_hr_time_events_append_only.sql   (SUPERUSER ONLY)
+--
+-- Restaure l'état mutable : cerp_app redevient owner de hr_time_events avec tous les
+-- privilèges, et le trigger/fonction append-only sont retirés.
+--
+--   sudo -u postgres psql -d <db> -f db/privileged/20260709_hr_time_events_append_only.rollback.sql
+--
+-- Non destructif : aucune ligne n'est modifiée ni supprimée.
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS trg_hr_time_events_no_update ON public.hr_time_events;
+DROP TRIGGER IF EXISTS trg_hr_time_events_no_delete ON public.hr_time_events;
+DROP TRIGGER IF EXISTS trg_hr_time_events_no_truncate ON public.hr_time_events;
+DROP FUNCTION IF EXISTS public.hr_time_events_prevent_mutation();
+
+DO $rb$
+BEGIN
+  IF to_regclass('public.hr_time_events') IS NULL THEN
+    RAISE NOTICE 'rollback: public.hr_time_events absente — rien à faire';
+    RETURN;
+  END IF;
+  EXECUTE 'ALTER TABLE public.hr_time_events OWNER TO cerp_app';
+  EXECUTE 'GRANT ALL ON public.hr_time_events TO cerp_app';
+END
+$rb$;
+
+COMMIT;

--- a/db/privileged/20260709_hr_time_events_append_only.sql
+++ b/db/privileged/20260709_hr_time_events_append_only.sql
@@ -1,0 +1,86 @@
+-- 20260709_hr_time_events_append_only.sql   (PRIVILEGED — SUPERUSER ONLY)
+--
+-- Module « Temps & Déplacements » — rend public.hr_time_events APPEND-ONLY pour le rôle
+-- applicatif (cerp_app). Le relevé de badgeage brut est une preuve légale/RGPD : il ne doit
+-- jamais être modifié ni supprimé par l'application (toute correction passe par
+-- public.hr_time_adjustments). Miroir de 20260707_erp_audit_logs_append_only.sql (CA-SEC-03,
+-- ISO/IEC 27001:2022 A.8.15).
+--
+-- POURQUOI HORS db/patches
+--   Le runner db:patches applique en tant que cerp_app ; or un OWNER de table contourne
+--   GRANT/REVOKE et peut DISABLE TRIGGER. L'immuabilité réelle exige de déplacer la propriété
+--   HORS du rôle applicatif, ce que seul un SUPERUSER peut faire. À appliquer par un DBA :
+--       sudo -u postgres psql -d cerp_test -f db/privileged/20260709_hr_time_events_append_only.sql
+--       sudo -u postgres psql -d cerp_prod -f db/privileged/20260709_hr_time_events_append_only.sql   (T10 seulement)
+--   NON pris en charge par `npm run db:patches:up`.
+--
+-- CE QUE ÇA FAIT
+--   1. Propriété de la table → postgres (hors rôle applicatif).
+--   2. cerp_app restreint à INSERT + SELECT (pas d'UPDATE/DELETE/TRUNCATE).
+--   3. Trigger append-only (bloque UPDATE/DELETE/TRUNCATE pour tous, y compris l'owner).
+--   (PK uuid via gen_random_uuid → pas de séquence à réassigner.)
+--
+-- MAINTENANCE CONTRÔLÉE (superuser only) — rétention/anonymisation RGPD :
+--       SET session_replication_role = 'replica';
+--       DELETE FROM public.hr_time_events WHERE ... ;   -- selon barème de conservation
+--       SET session_replication_role = 'origin';
+--
+-- SAFETY : idempotent (ré-exécutable), non destructif. Rollback/verify fournis à côté.
+-- Cible : PostgreSQL 17. Exécuter en SUPERUSER (postgres).
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF NOT COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false) THEN
+    RAISE EXCEPTION 'hr_time_events append-only: doit être appliqué par un superuser; current_user=% ne l''est pas', current_user;
+  END IF;
+END
+$guard$;
+
+DO $mig$
+BEGIN
+  IF to_regclass('public.hr_time_events') IS NULL THEN
+    RAISE NOTICE 'public.hr_time_events absente — appliquer d''abord db/patches/20260709_hr_temps_deplacements.sql';
+    RETURN;
+  END IF;
+
+  -- 1) Propriété hors rôle applicatif.
+  EXECUTE 'ALTER TABLE public.hr_time_events OWNER TO postgres';
+
+  -- 2) Moindre privilège : INSERT + SELECT uniquement pour cerp_app.
+  EXECUTE 'REVOKE ALL ON public.hr_time_events FROM cerp_app';
+  EXECUTE 'REVOKE UPDATE, DELETE, TRUNCATE ON public.hr_time_events FROM PUBLIC';
+  EXECUTE 'GRANT SELECT, INSERT ON public.hr_time_events TO cerp_app';
+END
+$mig$;
+
+-- 3) Backstop append-only. Fire pour TOUS les rôles (superuser bypass via session_replication_role).
+CREATE OR REPLACE FUNCTION public.hr_time_events_prevent_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+  RAISE EXCEPTION
+    'hr_time_events est append-only : % non permis (les corrections passent par hr_time_adjustments)', TG_OP
+    USING ERRCODE = 'insufficient_privilege';
+  RETURN NULL;
+END
+$fn$;
+
+DROP TRIGGER IF EXISTS trg_hr_time_events_no_update ON public.hr_time_events;
+CREATE TRIGGER trg_hr_time_events_no_update
+  BEFORE UPDATE ON public.hr_time_events
+  FOR EACH ROW EXECUTE FUNCTION public.hr_time_events_prevent_mutation();
+
+DROP TRIGGER IF EXISTS trg_hr_time_events_no_delete ON public.hr_time_events;
+CREATE TRIGGER trg_hr_time_events_no_delete
+  BEFORE DELETE ON public.hr_time_events
+  FOR EACH ROW EXECUTE FUNCTION public.hr_time_events_prevent_mutation();
+
+DROP TRIGGER IF EXISTS trg_hr_time_events_no_truncate ON public.hr_time_events;
+CREATE TRIGGER trg_hr_time_events_no_truncate
+  BEFORE TRUNCATE ON public.hr_time_events
+  FOR EACH STATEMENT EXECUTE FUNCTION public.hr_time_events_prevent_mutation();
+
+COMMIT;

--- a/db/privileged/20260709_hr_time_events_append_only.verify.sql
+++ b/db/privileged/20260709_hr_time_events_append_only.verify.sql
@@ -1,0 +1,63 @@
+-- VERIFY — hr_time_events append-only.   (SUPERUSER, sur cerp_test)
+--
+--   sudo -u postgres psql -d cerp_test -f db/privileged/20260709_hr_time_events_append_only.verify.sql
+--
+-- Résultat attendu :
+--   owner       = postgres
+--   cerp_app    = INSERT,SELECT
+--   triggers    = trg_hr_time_events_no_delete, _no_truncate, _no_update  (3)
+--   [1] cerp_app INSERT -> SUCCESS
+--   [2] cerp_app UPDATE -> ERROR permission denied            (couche privilèges)
+--   [3] cerp_app DELETE -> ERROR permission denied            (couche privilèges)
+--   [4] owner    UPDATE -> ERROR append-only ...              (trigger backstop)
+--   leftover    = 0                                            (fixture nettoyée)
+
+\pset pager off
+\set ON_ERROR_STOP off
+
+\echo '### owner (expect: postgres)'
+SELECT tableowner FROM pg_tables WHERE schemaname='public' AND tablename='hr_time_events';
+
+\echo '### cerp_app grants (expect: INSERT,SELECT)'
+SELECT COALESCE(string_agg(privilege_type, ',' ORDER BY privilege_type), '(none)') AS cerp_app_privs
+FROM information_schema.role_table_grants
+WHERE table_schema='public' AND table_name='hr_time_events' AND grantee='cerp_app';
+
+\echo '### append-only triggers (expect 3)'
+SELECT tgname FROM pg_trigger
+WHERE tgrelid='public.hr_time_events'::regclass AND NOT tgisinternal
+ORDER BY tgname;
+
+\echo '### fixture: un user existant + un employé + un événement de test'
+SELECT id AS uid FROM public.users ORDER BY id LIMIT 1 \gset
+INSERT INTO public.hr_employees (user_id, matricule)
+VALUES (:uid, 'HR_VERIFY')
+ON CONFLICT (matricule) DO UPDATE SET updated_at = now()
+RETURNING id AS emp_id \gset
+INSERT INTO public.hr_time_events (employee_id, event_type, event_time, source)
+VALUES (:'emp_id', 'IN', now(), 'ADMIN')
+RETURNING id AS ev_id \gset
+
+\echo '### [1] cerp_app INSERT — EXPECT SUCCESS'
+SET ROLE cerp_app;
+INSERT INTO public.hr_time_events (employee_id, event_type, event_time, source)
+VALUES (:'emp_id', 'OUT', now(), 'WEB');
+
+\echo '### [2] cerp_app UPDATE — EXPECT: permission denied'
+UPDATE public.hr_time_events SET event_type='OUT' WHERE id = :'ev_id';
+
+\echo '### [3] cerp_app DELETE — EXPECT: permission denied'
+DELETE FROM public.hr_time_events WHERE id = :'ev_id';
+RESET ROLE;
+
+\echo '### [4] trigger backstop: UPDATE owner sur la vraie ligne — EXPECT append-only exception'
+UPDATE public.hr_time_events SET event_type='OUT' WHERE id = :'ev_id';
+
+\echo '### cleanup (superuser + replica) — retire la fixture'
+SET session_replication_role='replica';
+DELETE FROM public.hr_time_events WHERE employee_id = :'emp_id';
+DELETE FROM public.hr_employees WHERE matricule='HR_VERIFY';
+SET session_replication_role='origin';
+
+\echo '### leftover fixture (expect 0)'
+SELECT count(*) AS leftover FROM public.hr_employees WHERE matricule='HR_VERIFY';

--- a/docs/temps-deplacements-t1-evidence.md
+++ b/docs/temps-deplacements-t1-evidence.md
@@ -10,14 +10,17 @@
 | `db/privileged/20260709_hr_time_events_append_only.sql` | Hardening **append-only** de `hr_time_events` (owner→postgres, `cerp_app` INSERT/SELECT, triggers no-update/delete/truncate). Superuser only. |
 | `db/privileged/20260709_hr_time_events_append_only.rollback.sql` | Rollback (restaure owner `cerp_app` + droits, retire triggers/fonction). |
 | `db/privileged/20260709_hr_time_events_append_only.verify.sql` | Verify (fixture + preuves append-only + nettoyage). |
+| `db/privileged/20260709_hr_module_ownership.{sql,rollback,verify}` | **Ownership versionné** : normalise les 14 tables CRUD → `cerp_app` (boucle `DO` idempotente gardée superuser — `OWNER TO` ne supporte pas de liste). Rend la propriété **reproductible** quel que soit le mode d'application. |
 | `src/module/auth/validators/user.validator.ts` | Rôle **`Responsable RH`** ajouté (convention « Responsable X ») ; `roles` exporté. |
 | `src/__tests__/temps-deplacements-t1.test.ts` | 9 tests (vocabulaire RBAC + idempotence migration + structure append-only). |
 
 ## Application sur cerp_test (2026-07-09)
 Appliqué en **direct `psql` (postgres, peer auth)** — **pas** le runner (dont le `.env` pointe cerp_prod) :
 1. Migration additive → cerp_test (seul NOTICE `pgcrypto already exists`).
-2. Propriété : **14 tables CRUD → `cerp_app`** (owner par table) ; **`hr_time_events` → `postgres`** (append-only). Tracé dans `cerp_schema_migrations` (sha256 `2a0911ec…`).
+2. Propriété via `db/privileged/20260709_hr_module_ownership.sql` (**versionné**, plus aucune commande manuelle) : **14 tables CRUD → `cerp_app`** ; **`hr_time_events` → `postgres`** (append-only). Tracé dans `cerp_schema_migrations`.
 3. Hardening append-only appliqué.
+
+**Reproductibilité prouvée** : `DROP` des tables `hr_*` puis **ré-application intégrale depuis les seuls fichiers commités** (additive → ownership → append-only) → état correct vérifié (`crud_not_cerp_app = 0`, `hr_time_events = postgres`, append-only OK). Aucune étape manuelle. Les artefacts (`db/patches` + `db/privileged/*.{sql,rollback,verify}`) suffisent à reconstruire l'état sur toute base (dont cerp_prod en T10).
 
 ## Verify (résultat)
 - owner `hr_time_events` = **postgres** · grants `cerp_app` = **INSERT,SELECT** · **3 triggers** (`no_update/no_delete/no_truncate`).

--- a/docs/temps-deplacements-t1-evidence.md
+++ b/docs/temps-deplacements-t1-evidence.md
@@ -1,0 +1,35 @@
+# Temps & Déplacements — T1 (schéma + DB) — évidence cerp_test
+
+> Issue frontend [#119](https://github.com/BigFootLime/crp-systems-web/issues/119) · archi + ADR-0013 dans `crp-systems-web/docs/`.
+> **T1 = schéma DB + append-only + rôle RH. Aucun cerp_prod (réservé T10). Aucun code UI. Aucun lien avec d'anciens fichiers.**
+
+## Livrables
+| Fichier | Rôle |
+|---|---|
+| `db/patches/20260709_hr_temps_deplacements.sql` | Migration **additive idempotente** : 15 tables `hr_*` + 17 enums + FK + index + contraintes (`reason` non vide, anti auto-validation, 1 contrat actif, idempotency badge). |
+| `db/privileged/20260709_hr_time_events_append_only.sql` | Hardening **append-only** de `hr_time_events` (owner→postgres, `cerp_app` INSERT/SELECT, triggers no-update/delete/truncate). Superuser only. |
+| `db/privileged/20260709_hr_time_events_append_only.rollback.sql` | Rollback (restaure owner `cerp_app` + droits, retire triggers/fonction). |
+| `db/privileged/20260709_hr_time_events_append_only.verify.sql` | Verify (fixture + preuves append-only + nettoyage). |
+| `src/module/auth/validators/user.validator.ts` | Rôle **`Responsable RH`** ajouté (convention « Responsable X ») ; `roles` exporté. |
+| `src/__tests__/temps-deplacements-t1.test.ts` | 9 tests (vocabulaire RBAC + idempotence migration + structure append-only). |
+
+## Application sur cerp_test (2026-07-09)
+Appliqué en **direct `psql` (postgres, peer auth)** — **pas** le runner (dont le `.env` pointe cerp_prod) :
+1. Migration additive → cerp_test (seul NOTICE `pgcrypto already exists`).
+2. Propriété : **14 tables CRUD → `cerp_app`** (owner par table) ; **`hr_time_events` → `postgres`** (append-only). Tracé dans `cerp_schema_migrations` (sha256 `2a0911ec…`).
+3. Hardening append-only appliqué.
+
+## Verify (résultat)
+- owner `hr_time_events` = **postgres** · grants `cerp_app` = **INSERT,SELECT** · **3 triggers** (`no_update/no_delete/no_truncate`).
+- `cerp_app` **INSERT** = SUCCESS · **UPDATE/DELETE** = *permission denied* (couche privilèges) · **owner UPDATE** = *exception append-only* (trigger backstop).
+- Fixture nettoyée (`leftover = 0`).
+
+## Tests
+`tsc --noEmit` OK · vitest **178/178** (dont 9 T1) · non-régression confirmée.
+
+## Rollback disponible
+- Append-only : `db/privileged/20260709_hr_time_events_append_only.rollback.sql`.
+- Schéma : additif → `DROP TABLE public.hr_* CASCADE` (base vide) ou restauration dump si nécessaire.
+
+## Reste (hors T1)
+Endpoints/services/isolation par ressource = **T2** ; front salarié = **T3** ; contrats/règles = **T5** ; km = **T6** ; exports = **T7** ; bornes/badges = **T8** ; conformité/preuves = **T9** ; prod = **T10** (backup + validation + verify).

--- a/src/__tests__/temps-deplacements-t1.test.ts
+++ b/src/__tests__/temps-deplacements-t1.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { roles } from "../module/auth/validators/user.validator";
+
+// T1 — module « Temps & Déplacements » : schéma DB + append-only + rôle RH.
+// Tests « de base » sans base de données (le comportement runtime append-only est prouvé
+// par db/privileged/*.verify.sql sur cerp_test). Ici on garantit : vocabulaire RBAC,
+// idempotence/additivité de la migration, et présence du hardening append-only.
+
+const root = process.cwd();
+const additive = readFileSync(resolve(root, "db/patches/20260709_hr_temps_deplacements.sql"), "utf8");
+const appendOnly = readFileSync(resolve(root, "db/privileged/20260709_hr_time_events_append_only.sql"), "utf8");
+
+const HR_TABLES = [
+  "hr_employees", "hr_time_rule_sets", "hr_employment_contracts", "hr_work_schedules",
+  "hr_time_clock_devices", "hr_badge_credentials", "hr_time_events", "hr_work_sessions",
+  "hr_timesheet_days", "hr_timesheet_weeks", "hr_time_adjustments", "hr_time_anomalies",
+  "hr_vehicles", "hr_kilometer_entries", "hr_payroll_export_batches",
+];
+
+describe("T1 Temps & Déplacements — vocabulaire RBAC", () => {
+  it("ajoute le rôle 'Responsable RH'", () => {
+    expect(roles).toContain("Responsable RH");
+  });
+  it("conserve les rôles existants (compatibilité ascendante)", () => {
+    for (const r of [
+      "Directeur", "Employee", "Administrateur Systeme et Reseau",
+      "Responsable Qualité", "Secretaire", "Responsable Programmation",
+    ]) {
+      expect(roles).toContain(r);
+    }
+  });
+});
+
+describe("T1 — migration additive idempotente (db/patches)", () => {
+  it("crée les 15 tables hr_* en IF NOT EXISTS", () => {
+    for (const t of HR_TABLES) {
+      expect(additive).toContain(`CREATE TABLE IF NOT EXISTS public.${t} `);
+    }
+  });
+  it("est purement additive (aucun DROP TABLE/COLUMN/TYPE)", () => {
+    expect(/\bDROP\s+(TABLE|COLUMN|TYPE)\b/i.test(additive)).toBe(false);
+  });
+  it("garde les enums (DO $$ … IF NOT EXISTS pg_type)", () => {
+    expect(additive).toContain("IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_event_type')");
+  });
+  it("impose reason non vide + interdit l'auto-validation des corrections", () => {
+    expect(additive).toContain("hr_time_adjustments_reason_ck");
+    expect(additive).toContain("hr_time_adjustments_no_self_approve_ck");
+  });
+});
+
+describe("T1 — hr_time_events append-only (db/privileged)", () => {
+  it("déplace la propriété hors du rôle applicatif", () => {
+    expect(appendOnly).toContain("ALTER TABLE public.hr_time_events OWNER TO postgres");
+  });
+  it("restreint cerp_app à SELECT/INSERT (pas d'UPDATE/DELETE)", () => {
+    expect(appendOnly).toContain("GRANT SELECT, INSERT ON public.hr_time_events TO cerp_app");
+    expect(appendOnly).toContain("REVOKE UPDATE, DELETE, TRUNCATE ON public.hr_time_events FROM PUBLIC");
+  });
+  it("pose les 3 triggers de blocage UPDATE/DELETE/TRUNCATE", () => {
+    for (const trg of [
+      "trg_hr_time_events_no_update",
+      "trg_hr_time_events_no_delete",
+      "trg_hr_time_events_no_truncate",
+    ]) {
+      expect(appendOnly).toContain(trg);
+    }
+  });
+});

--- a/src/module/auth/validators/user.validator.ts
+++ b/src/module/auth/validators/user.validator.ts
@@ -1,13 +1,14 @@
 import { z } from "zod";
 import { isoDate, strictEmail, strongPassword, trimString } from "./_helpers";
 
-const roles = [
+export const roles = [
   "Directeur",
   "Employee",
   "Administrateur Systeme et Reseau",
   "Responsable Qualité",
   "Secretaire",
   "Responsable Programmation",
+  "Responsable RH",
 ] as const;
 
 const genders = ["Male", "Female"] as const;


### PR DESCRIPTION
## T1 — schéma DB du module « Temps & Déplacements » (Refs #119)

Tranche **T1 (DB uniquement, cerp_test)**. **Aucun cerp_prod** (réservé T10), **aucun code UI**, **aucun lien avec d'anciens fichiers**.

### Contenu
- **Migration additive idempotente** `db/patches/20260709_hr_temps_deplacements.sql` — 15 tables `hr_*` (employés, contrats **35h/39h configurables** via `hr_time_rule_sets`, horaires, bornes, badges hachés, `hr_time_events`, sessions, timesheets jour/semaine, corrections tracées, anomalies, véhicules, kilomètres, exports figés) + enums + FK + contraintes (`reason` non vide, **anti auto-validation**, 1 contrat actif, idempotency badge).
- **Append-only** `db/privileged/20260709_hr_time_events_append_only.{sql,rollback,verify}` — `hr_time_events` **DB-immuable** (owner `postgres`, `cerp_app` INSERT/SELECT, triggers no-update/delete/truncate), miroir de `erp_audit_logs`.
- **Rôle `Responsable RH`** (convention « Responsable X » ; `roles` exporté).

### Application + verify (cerp_test, 2026-07-09)
Appliqué en `psql` direct (postgres) — pas le runner (`.env` = cerp_prod). 14 tables CRUD → owner `cerp_app`, `hr_time_events` → `postgres`. **Verify append-only OK** : `cerp_app` INSERT ✓ / UPDATE-DELETE *refusés* / owner UPDATE *bloqué par trigger* / fixture nettoyée. Détail : `docs/temps-deplacements-t1-evidence.md`.

### Tests
`tsc --noEmit` OK · vitest **178/178** (9 nouveaux tests T1).

### Suite
T2 (backend pointage + isolation par ressource) après merge. cerp_prod seulement en T10 (backup + validation + verify).

## Summary by Sourcery

Introduce the initial Temps & Déplacements database schema with append-only time event guarantees and RBAC support for HR responsibility.

New Features:
- Add the Temps & Déplacements T1 database schema with hr_* tables for employees, contracts, schedules, time events, sessions, timesheets, adjustments, anomalies, vehicles, kilometer entries, and payroll export batches.
- Enforce append-only behavior for hr_time_events via a privileged migration that changes ownership, restricts application grants, and adds protective triggers.
- Introduce the new "Responsable RH" application role and export the roles list for reuse.

Enhancements:
- Provide rollback and verification scripts for the hr_time_events append-only hardening to support safe operations by DBAs.
- Add a high-level evidence document describing the T1 schema, append-only setup, deployment constraints, and verification steps.

Tests:
- Add a Temps & Déplacements T1 test suite that validates the RBAC vocabulary, the additive/idempotent nature of the schema migration, and the presence of the append-only hardening.