### PR TITLE
feat(temps-deplacements): T2 — backend pointage (events append-only, calcul, RBAC)

### DIFF
--- a/docs/temps-deplacements-t2-evidence.md
+++ b/docs/temps-deplacements-t2-evidence.md
@@ -1,0 +1,32 @@
+# Temps & Déplacements — T2 (backend pointage) — évidence cerp_test
+
+> Issue [#119](https://github.com/BigFootLime/crp-systems-web/issues/119) · s'appuie sur le schéma T1 (aucune nouvelle migration).
+> **cerp_test uniquement. Aucun front, aucune borne matérielle, aucun cerp_prod, aucun main.**
+
+## Module `src/module/temps-deplacements/` (quartet)
+`types/` · `validators/` (Zod, parse contrôleur) · `repository/` (SQL + transactions + audit) · `services/` (logique) · `controllers/` · `routes/`. Monté après le socle `authenticateToken` (`v1.routes.ts`) → **JWT d'office**.
+
+## Endpoints
+| Endpoint | Accès |
+|---|---|
+| `POST /time-clock/events` | salarié (employé dérivé de `req.user` — **aucun employee_id en entrée**) |
+| `GET /time-clock/me/today` · `/me/week` · `/me/anomalies` | salarié (ses données) |
+| `GET /time-clock/employees/:id/today` · `/:id/week` | **soi / manager / RH-Direction-Admin** (anti-IDOR) |
+| `POST /time-clock/device-events` · `/device-heartbeat` · `GET /device-config` | JWT socle **+ device_token haché** |
+
+## Règles implémentées
+- `hr_time_events` **append-only** (aucun UPDATE/DELETE ; corrections → `hr_time_adjustments`, T4).
+- **idempotency_key obligatoire** pour device-events (contrainte unique → dé-doublonnage).
+- **badge_uid & device_token hachés** (sha256), jamais stockés/loggés en clair.
+- **double badge** rapproché (même type < 90 s) détecté → anomalie `DOUBLE_BADGE`, pas de doublon.
+- **badge inconnu → 404**, **badge révoqué → 403** : traités comme **événements refusés + audités** (décision : pas de ligne `hr_time_anomalies`, un badge inconnu n'a pas d'employé). *(les enums `UNKNOWN_BADGE`/`REVOKED_BADGE` évoqués sont couverts par ce chemin refus+audit.)*
+- **Audit** sur toutes les écritures (`temps-deplacements.event.create_web/create_badge/double_badge_*/refused`, `.device.heartbeat`) — **jamais** de badge_uid/token/payload sensible dans les détails.
+- Réponse borne : aucune donnée RH sensible.
+- **Calcul journée** (moteur pur `summarizeDay`) : première IN, dernière OUT, pauses, temps travaillé ; attendu **depuis le contrat** (`repoGetDailyTargetMinutes` — jamais 35/39 en dur) ; heures sup / manquantes ; anomalies structurelles (`MISSING_IN/OUT/BREAK_END`, `TOO_LONG_DAY`, `TOO_SHORT_BREAK`). `MISSING_OUT`/`MISSING_BREAK_END` seulement sur jour passé (session en cours = normale aujourd'hui).
+
+## Tests
+- **17 tests unitaires** (`src/__tests__/temps-deplacements-t2.test.ts`) : `summarizeDay` (IN/OUT, pause complète/incomplète, entrée sans sortie), `detectTimeAnomalies`, hachage badge/token (jamais en clair), validateurs (anti-IDOR structurel, idempotency), RBAC (salarié↔autre = 403, manager, RH). **Suite : 43 fichiers / 195 verts. Typecheck OK.**
+- **Smoke SQL cerp_test** (couche repository) : insert `cerp_app` OK ; idempotency doublon → 23505 ; UPDATE `hr_time_events` → *permission denied* ; badge actif/révoqué/inconnu ; requête jour ; cleanup `leftover=0`.
+
+## Reste (hors T2)
+Front salarié = T3 · validation responsable + corrections = T4 · contrats/règles UI = T5 · km = T6 · exports = T7 · bornes/badges CRUD + kiosk = T8.

--- a/src/__tests__/temps-deplacements-t2.test.ts
+++ b/src/__tests__/temps-deplacements-t2.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  detectTimeAnomalies,
+  hashBadgeUid,
+  hashDeviceToken,
+  summarizeDay,
+} from "../module/temps-deplacements/services/temps-deplacements.service";
+import {
+  isHrPrivileged,
+  validateEmployeeAccess,
+  validateManagerScope,
+} from "../module/temps-deplacements/controllers/temps-deplacements.controller";
+import {
+  createTimeEventSchema,
+  deviceEventSchema,
+} from "../module/temps-deplacements/validators/temps-deplacements.validators";
+import type { HrEmployeeLite, HrEventType, HrTimeEvent } from "../module/temps-deplacements/types/temps-deplacements.types";
+
+function ev(type: HrEventType, time: string): HrTimeEvent {
+  return { id: "e", employee_id: "emp", device_id: null, event_type: type, event_time: time, source: "WEB", created_at: time };
+}
+const T = (h: number, m = 0) => `2026-07-06T${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:00+02:00`;
+const emp = (over: Partial<HrEmployeeLite> = {}): HrEmployeeLite => ({
+  id: "11111111-1111-4111-8111-111111111111",
+  user_id: 1,
+  matricule: "TD001",
+  service: null,
+  manager_user_id: null,
+  status: "ACTIVE",
+  ...over,
+});
+
+describe("T2 — summarizeDay (moteur journée, pur)", () => {
+  it("IN/OUT normal → temps travaillé", () => {
+    const r = summarizeDay([ev("IN", T(9)), ev("OUT", T(17))]);
+    expect(r.firstIn).toBe(T(9));
+    expect(r.lastOut).toBe(T(17));
+    expect(r.breakMinutes).toBe(0);
+    expect(r.workedMinutes).toBe(480);
+    expect(r.openBreak).toBe(false);
+  });
+  it("pause complète déduite du temps travaillé", () => {
+    const r = summarizeDay([ev("IN", T(9)), ev("BREAK_START", T(12)), ev("BREAK_END", T(13)), ev("OUT", T(17))]);
+    expect(r.breakMinutes).toBe(60);
+    expect(r.workedMinutes).toBe(420);
+    expect(r.openBreak).toBe(false);
+  });
+  it("pause incomplète → openBreak, pas de temps de pause compté", () => {
+    const r = summarizeDay([ev("IN", T(9)), ev("BREAK_START", T(12)), ev("OUT", T(17))]);
+    expect(r.openBreak).toBe(true);
+    expect(r.breakMinutes).toBe(0);
+    expect(r.workedMinutes).toBe(480);
+  });
+  it("entrée sans sortie → 0 minute travaillée (session ouverte)", () => {
+    const r = summarizeDay([ev("IN", T(9))]);
+    expect(r.lastOut).toBeNull();
+    expect(r.workedMinutes).toBe(0);
+  });
+});
+
+describe("T2 — detectTimeAnomalies", () => {
+  it("sortie sans entrée → MISSING_IN", () => {
+    const a = detectTimeAnomalies([ev("OUT", T(17))], { openBreak: false, workedMinutes: 0, totalBreak: 0, isPastDay: true });
+    expect(a.map((x) => x.anomaly_type)).toContain("MISSING_IN");
+  });
+  it("entrée sans sortie sur jour PASSÉ → MISSING_OUT", () => {
+    const a = detectTimeAnomalies([ev("IN", T(9))], { openBreak: false, workedMinutes: 0, totalBreak: 0, isPastDay: true });
+    expect(a.map((x) => x.anomaly_type)).toContain("MISSING_OUT");
+  });
+  it("entrée sans sortie AUJOURD'HUI → aucune anomalie (session en cours)", () => {
+    const a = detectTimeAnomalies([ev("IN", T(9))], { openBreak: false, workedMinutes: 0, totalBreak: 0, isPastDay: false });
+    expect(a.map((x) => x.anomaly_type)).not.toContain("MISSING_OUT");
+  });
+  it("pause non terminée jour passé → MISSING_BREAK_END", () => {
+    const a = detectTimeAnomalies([ev("IN", T(9)), ev("BREAK_START", T(12))], { openBreak: true, workedMinutes: 480, totalBreak: 0, isPastDay: true });
+    expect(a.map((x) => x.anomaly_type)).toContain("MISSING_BREAK_END");
+  });
+  it("journée > 12h → TOO_LONG_DAY", () => {
+    const a = detectTimeAnomalies([ev("IN", T(6)), ev("OUT", T(22))], { openBreak: false, workedMinutes: 13 * 60, totalBreak: 0, isPastDay: true });
+    expect(a.map((x) => x.anomaly_type)).toContain("TOO_LONG_DAY");
+  });
+});
+
+describe("T2 — hachage badge/token (jamais en clair)", () => {
+  it("badge UID haché en sha256 hex, ≠ clair, déterministe", () => {
+    const h = hashBadgeUid("04AABBCCDD");
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+    expect(h).not.toBe("04AABBCCDD");
+    expect(hashBadgeUid("04AABBCCDD")).toBe(h);
+    expect(hashBadgeUid("other")).not.toBe(h);
+  });
+  it("device token haché aussi", () => {
+    expect(hashDeviceToken("secret-token")).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashDeviceToken("secret-token")).not.toBe("secret-token");
+  });
+});
+
+describe("T2 — validateurs (anti-IDOR structurel + idempotency)", () => {
+  it("createTimeEventSchema accepte {event_type} et REFUSE tout employee_id", () => {
+    expect(createTimeEventSchema.parse({ event_type: "IN" }).event_type).toBe("IN");
+    expect(() => createTimeEventSchema.parse({ event_type: "IN", employee_id: "x" })).toThrow();
+    expect(() => createTimeEventSchema.parse({ event_type: "NOPE" })).toThrow();
+  });
+  it("deviceEventSchema EXIGE idempotency_key (min 8)", () => {
+    expect(() => deviceEventSchema.parse({ badge_uid: "abc", event_type: "IN" })).toThrow();
+    expect(() => deviceEventSchema.parse({ badge_uid: "abc", event_type: "IN", idempotency_key: "short" })).toThrow();
+    expect(deviceEventSchema.parse({ badge_uid: "abc", event_type: "IN", idempotency_key: "abcd1234" }).idempotency_key).toBe("abcd1234");
+  });
+});
+
+describe("T2 — RBAC / anti-IDOR", () => {
+  it("un salarié accède à SES données", () => {
+    expect(() => validateEmployeeAccess({ id: 1, role: "Employee" }, emp({ user_id: 1 }))).not.toThrow();
+  });
+  it("un salarié NE PEUT PAS lire un autre salarié (403)", () => {
+    expect(() => validateEmployeeAccess({ id: 2, role: "Employee" }, emp({ user_id: 1, manager_user_id: null }))).toThrow();
+  });
+  it("un manager accède à son subordonné", () => {
+    expect(() => validateEmployeeAccess({ id: 5, role: "Employee" }, emp({ user_id: 1, manager_user_id: 5 }))).not.toThrow();
+    expect(validateManagerScope({ id: 5, role: "Employee" }, emp({ manager_user_id: 5 }))).toBe(true);
+  });
+  it("Responsable RH / Direction / Admin accèdent globalement", () => {
+    expect(isHrPrivileged("Responsable RH")).toBe(true);
+    expect(isHrPrivileged("Directeur")).toBe(true);
+    expect(isHrPrivileged("Administrateur Systeme et Reseau")).toBe(true);
+    expect(isHrPrivileged("Employee")).toBe(false);
+    expect(() => validateEmployeeAccess({ id: 9, role: "Responsable RH" }, emp({ user_id: 1 }))).not.toThrow();
+  });
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements.controller.ts
@@ -1,0 +1,199 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { HttpError } from "../../../utils/httpError";
+import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import type { AuditContext } from "../repository/temps-deplacements.repository";
+import * as repo from "../repository/temps-deplacements.repository";
+import * as svc from "../services/temps-deplacements.service";
+import type { HrEmployeeLite } from "../types/temps-deplacements.types";
+import {
+  createTimeEventSchema,
+  deviceEventSchema,
+  deviceHeartbeatSchema,
+  employeeIdParamsSchema,
+  meAnomaliesQuerySchema,
+  meTodayQuerySchema,
+  meWeekQuerySchema,
+} from "../validators/temps-deplacements.validators";
+
+function buildAuditContext(req: Request): AuditContext {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
+  }
+  const userAgent = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null;
+  const ip = getClientIp(req);
+  const device = parseDevice(userAgent);
+  const pageKey = typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null;
+  const clientSessionId =
+    typeof req.headers["x-client-session-id"] === "string"
+      ? req.headers["x-client-session-id"]
+      : typeof req.headers["x-session-id"] === "string"
+        ? req.headers["x-session-id"]
+        : null;
+  return {
+    user_id: user.id,
+    ip,
+    user_agent: userAgent,
+    device_type: device.device_type,
+    os: device.os,
+    browser: device.browser,
+    path: req.originalUrl ?? null,
+    page_key: pageKey,
+    client_session_id: clientSessionId,
+  };
+}
+
+function requireUser(req: Request): { id: number; role: string } {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  return { id: user.id, role: typeof user.role === "string" ? user.role : "" };
+}
+
+// RBAC lecture d'un employé : soi-même, OU son manager, OU un rôle RH/Direction/Admin.
+export function isHrPrivileged(role: string): boolean {
+  const r = role.toLowerCase();
+  return r.includes("rh") || r.includes("directeur") || r.includes("direction") || r.includes("administrateur");
+}
+export function validateManagerScope(reqUser: { id: number; role: string }, target: HrEmployeeLite): boolean {
+  return target.manager_user_id !== null && target.manager_user_id === reqUser.id;
+}
+// Lève 403 si l'appelant n'a pas le droit de lire cet employé (anti-IDOR).
+export function validateEmployeeAccess(reqUser: { id: number; role: string }, target: HrEmployeeLite): void {
+  const self = target.user_id === reqUser.id;
+  if (self || validateManagerScope(reqUser, target) || isHrPrivileged(reqUser.role)) return;
+  throw new HttpError(403, "HR_FORBIDDEN", "Accès refusé aux données de cet employé.");
+}
+const assertCanReadEmployee = validateEmployeeAccess;
+
+function mondayOf(ymd: string): string {
+  const d = new Date(`${ymd}T12:00:00Z`);
+  const dow = d.getUTCDay(); // 0=dim..6=sam
+  const back = (dow + 6) % 7; // vers lundi
+  d.setUTCDate(d.getUTCDate() - back);
+  return d.toISOString().slice(0, 10);
+}
+
+// ------------------------------------------------------------------ Salarié (JWT socle)
+export const postEvent = asyncHandler(async (req: Request, res: Response) => {
+  const reqUser = requireUser(req);
+  const body = createTimeEventSchema.parse(req.body);
+  const emp = await svc.resolveEmployeeFromUser(reqUser.id);
+  const result = await svc.createTimeEvent(
+    { employee_id: emp.id, event_type: body.event_type, event_time: body.event_time, source: "WEB" },
+    buildAuditContext(req)
+  );
+  res.status(201).json(result);
+});
+
+export const getMeToday = asyncHandler(async (req: Request, res: Response) => {
+  const reqUser = requireUser(req);
+  const { date } = meTodayQuerySchema.parse(req.query);
+  const emp = await svc.resolveEmployeeFromUser(reqUser.id);
+  res.json(await svc.computeDailyTimesheet(emp.id, date ?? svc.todayParis()));
+});
+
+export const getMeWeek = asyncHandler(async (req: Request, res: Response) => {
+  const reqUser = requireUser(req);
+  const { week_start } = meWeekQuerySchema.parse(req.query);
+  const emp = await svc.resolveEmployeeFromUser(reqUser.id);
+  res.json(await svc.computeWeeklyTimesheet(emp.id, week_start ?? mondayOf(svc.todayParis())));
+});
+
+export const getMeAnomalies = asyncHandler(async (req: Request, res: Response) => {
+  const reqUser = requireUser(req);
+  const filters = meAnomaliesQuerySchema.parse(req.query);
+  const emp = await svc.resolveEmployeeFromUser(reqUser.id);
+  res.json(await svc.listMyAnomalies(emp.id, filters));
+});
+
+// Lecture périmètre (manager/RH) + garde ANTI-IDOR (un salarié ne peut pas lire un autre).
+export const getEmployeeToday = asyncHandler(async (req: Request, res: Response) => {
+  const reqUser = requireUser(req);
+  const { id } = employeeIdParamsSchema.parse(req.params);
+  const { date } = meTodayQuerySchema.parse(req.query);
+  const target = await repo.repoGetEmployeeById(id);
+  if (!target) throw new HttpError(404, "HR_EMPLOYEE_NOT_FOUND", "Employé introuvable.");
+  assertCanReadEmployee(reqUser, target);
+  res.json(await svc.computeDailyTimesheet(target.id, date ?? svc.todayParis()));
+});
+
+export const getEmployeeWeek = asyncHandler(async (req: Request, res: Response) => {
+  const reqUser = requireUser(req);
+  const { id } = employeeIdParamsSchema.parse(req.params);
+  const { week_start } = meWeekQuerySchema.parse(req.query);
+  const target = await repo.repoGetEmployeeById(id);
+  if (!target) throw new HttpError(404, "HR_EMPLOYEE_NOT_FOUND", "Employé introuvable.");
+  assertCanReadEmployee(reqUser, target);
+  res.json(await svc.computeWeeklyTimesheet(target.id, week_start ?? mondayOf(svc.todayParis())));
+});
+
+// ------------------------------------------------------------------ Borne / device (JWT socle + device_token)
+async function authenticateDevice(deviceToken: string | undefined): Promise<{ id: string }> {
+  if (!deviceToken) throw new HttpError(401, "HR_DEVICE_UNAUTHORIZED", "device_token requis.");
+  const device = await repo.repoGetActiveDeviceByTokenHash(svc.hashDeviceToken(deviceToken));
+  if (!device) throw new HttpError(401, "HR_DEVICE_UNAUTHORIZED", "Borne non autorisée.");
+  return device;
+}
+
+export const postDeviceEvent = asyncHandler(async (req: Request, res: Response) => {
+  requireUser(req);
+  const body = deviceEventSchema.parse(req.body);
+  const device = await authenticateDevice(body.device_token);
+  const audit = buildAuditContext(req);
+  let emp: HrEmployeeLite;
+  try {
+    emp = await svc.resolveEmployeeFromBadge(body.badge_uid); // badge_uid haché serveur ; jamais loggé
+  } catch (err) {
+    // Badge inconnu/révoqué : audité SANS le badge_uid brut.
+    await repo.withTransaction((client) =>
+      repo.insertAuditLog(client, audit, {
+        action: "temps-deplacements.event.refused",
+        entity_type: "hr_time_clock_devices",
+        entity_id: device.id,
+        details: { reason: err instanceof HttpError ? err.code : "UNKNOWN", event_type: body.event_type },
+      })
+    );
+    throw err;
+  }
+  const result = await svc.createTimeEvent(
+    {
+      employee_id: emp.id,
+      event_type: body.event_type,
+      event_time: body.event_time,
+      source: "BADGE",
+      device_id: device.id,
+      idempotency_key: body.idempotency_key,
+    },
+    audit
+  );
+  res.status(201).json(result);
+});
+
+export const postDeviceHeartbeat = asyncHandler(async (req: Request, res: Response) => {
+  requireUser(req);
+  const body = deviceHeartbeatSchema.parse(req.body);
+  const device = await authenticateDevice(body.device_token);
+  await repo.repoTouchDeviceHeartbeat(device.id);
+  await repo.withTransaction((client) =>
+    repo.insertAuditLog(client, buildAuditContext(req), {
+      action: "temps-deplacements.device.heartbeat",
+      entity_type: "hr_time_clock_devices",
+      entity_id: device.id,
+      details: null,
+    })
+  );
+  res.json({ ok: true, device_id: device.id });
+});
+
+// Config borne — AUCUNE donnée RH sensible (types d'événements + cadence heartbeat).
+export const getDeviceConfig = asyncHandler(async (req: Request, res: Response) => {
+  requireUser(req);
+  const token = typeof req.query.device_token === "string" ? req.query.device_token : undefined;
+  const device = await authenticateDevice(token);
+  res.json({
+    device_id: device.id,
+    event_types: ["IN", "OUT", "BREAK_START", "BREAK_END"],
+    heartbeat_interval_seconds: 60,
+  });
+});

--- a/src/module/temps-deplacements/repository/temps-deplacements.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements.repository.ts
@@ -1,0 +1,332 @@
+import type { PoolClient } from "pg";
+import pool from "../../../config/database";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
+import type {
+  CreateTimeEventInput,
+  HrEmployeeLite,
+  HrTimeAnomaly,
+  HrTimeEvent,
+} from "../types/temps-deplacements.types";
+
+export type DbQueryer = Pick<PoolClient, "query">;
+
+// Contexte d'audit (même forme que le reste de l'ERP). Jamais de secret/PII sensible dedans.
+export type AuditContext = {
+  user_id: number;
+  ip: string | null;
+  user_agent: string | null;
+  device_type: string | null;
+  os: string | null;
+  browser: string | null;
+  path: string | null;
+  page_key: string | null;
+  client_session_id: string | null;
+};
+
+export function isPgUniqueViolation(err: unknown): boolean {
+  return (err as { code?: unknown } | null)?.code === "23505";
+}
+
+export async function withTransaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      // ignore
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+const EMP_COLS = `id::text, user_id, matricule, service, manager_user_id, status::text`;
+
+function mapEmployee(r: Record<string, unknown>): HrEmployeeLite {
+  return {
+    id: String(r.id),
+    user_id: Number(r.user_id),
+    matricule: String(r.matricule),
+    service: (r.service as string | null) ?? null,
+    manager_user_id: r.manager_user_id === null || r.manager_user_id === undefined ? null : Number(r.manager_user_id),
+    status: r.status as HrEmployeeLite["status"],
+  };
+}
+
+function mapEvent(r: Record<string, unknown>): HrTimeEvent {
+  return {
+    id: String(r.id),
+    employee_id: String(r.employee_id),
+    device_id: (r.device_id as string | null) ?? null,
+    event_type: r.event_type as HrTimeEvent["event_type"],
+    event_time: String(r.event_time),
+    source: r.source as HrTimeEvent["source"],
+    created_at: String(r.created_at),
+  };
+}
+
+function mapAnomaly(r: Record<string, unknown>): HrTimeAnomaly {
+  return {
+    id: String(r.id),
+    employee_id: String(r.employee_id),
+    date: String(r.date),
+    anomaly_type: r.anomaly_type as HrTimeAnomaly["anomaly_type"],
+    severity: r.severity as HrTimeAnomaly["severity"],
+    message: (r.message as string | null) ?? null,
+    resolved_by: r.resolved_by === null || r.resolved_by === undefined ? null : Number(r.resolved_by),
+    resolved_at: (r.resolved_at as string | null) ?? null,
+    created_at: String(r.created_at),
+  };
+}
+
+// -------------------------------------------------------------- Employés
+export async function repoGetEmployeeByUserId(userId: number, q: DbQueryer = pool): Promise<HrEmployeeLite | null> {
+  const res = await q.query(
+    `SELECT ${EMP_COLS} FROM public.hr_employees WHERE user_id = $1 LIMIT 1`,
+    [userId]
+  );
+  return res.rows[0] ? mapEmployee(res.rows[0]) : null;
+}
+
+export async function repoGetEmployeeById(id: string, q: DbQueryer = pool): Promise<HrEmployeeLite | null> {
+  const res = await q.query(`SELECT ${EMP_COLS} FROM public.hr_employees WHERE id = $1::uuid LIMIT 1`, [id]);
+  return res.rows[0] ? mapEmployee(res.rows[0]) : null;
+}
+
+// Badge : renvoie l'employé + si le badge est actif (pour distinguer inconnu / révoqué / ok).
+export async function repoFindBadge(
+  badgeUidHash: string,
+  q: DbQueryer = pool
+): Promise<{ employee: HrEmployeeLite; active: boolean } | null> {
+  const res = await q.query(
+    `SELECT b.active, ${EMP_COLS.split(", ").map((c) => "e." + c).join(", ")}
+       FROM public.hr_badge_credentials b
+       JOIN public.hr_employees e ON e.id = b.employee_id
+      WHERE b.badge_uid_hash = $1
+      ORDER BY b.active DESC, b.issued_at DESC
+      LIMIT 1`,
+    [badgeUidHash]
+  );
+  if (!res.rows[0]) return null;
+  return { employee: mapEmployee(res.rows[0]), active: res.rows[0].active === true };
+}
+
+// -------------------------------------------------------------- Devices
+export async function repoGetActiveDeviceByTokenHash(tokenHash: string, q: DbQueryer = pool): Promise<{ id: string } | null> {
+  const res = await q.query(
+    `SELECT id::text FROM public.hr_time_clock_devices WHERE device_token_hash = $1 AND status = 'ACTIVE' LIMIT 1`,
+    [tokenHash]
+  );
+  return res.rows[0] ? { id: String(res.rows[0].id) } : null;
+}
+
+export async function repoTouchDeviceHeartbeat(deviceId: string, q: DbQueryer = pool): Promise<void> {
+  await q.query(`UPDATE public.hr_time_clock_devices SET last_seen_at = now() WHERE id = $1::uuid`, [deviceId]);
+}
+
+// -------------------------------------------------------------- Événements (append-only)
+export async function repoGetLastEvent(employeeId: string, q: DbQueryer = pool): Promise<HrTimeEvent | null> {
+  const res = await q.query(
+    `SELECT id::text, employee_id::text, device_id::text, event_type::text, event_time::text, source::text, created_at::text
+       FROM public.hr_time_events WHERE employee_id = $1::uuid ORDER BY event_time DESC, created_at DESC LIMIT 1`,
+    [employeeId]
+  );
+  return res.rows[0] ? mapEvent(res.rows[0]) : null;
+}
+
+export async function repoFindEventByIdempotencyKey(key: string, q: DbQueryer = pool): Promise<HrTimeEvent | null> {
+  const res = await q.query(
+    `SELECT id::text, employee_id::text, device_id::text, event_type::text, event_time::text, source::text, created_at::text
+       FROM public.hr_time_events WHERE idempotency_key = $1 LIMIT 1`,
+    [key]
+  );
+  return res.rows[0] ? mapEvent(res.rows[0]) : null;
+}
+
+// INSERT append-only. Idempotence : si idempotency_key déjà vu → renvoie l'existant (deduplicated).
+export async function repoInsertTimeEvent(
+  q: DbQueryer,
+  input: CreateTimeEventInput
+): Promise<{ event: HrTimeEvent; deduplicated: boolean }> {
+  if (input.idempotency_key) {
+    const existing = await repoFindEventByIdempotencyKey(input.idempotency_key, q);
+    if (existing) return { event: existing, deduplicated: true };
+  }
+  try {
+    const res = await q.query(
+      `INSERT INTO public.hr_time_events (employee_id, device_id, event_type, event_time, source, idempotency_key, raw_payload_json)
+       VALUES ($1::uuid, $2, $3::hr_event_type, COALESCE($4::timestamptz, now()), $5::hr_event_source, $6, $7::jsonb)
+       RETURNING id::text, employee_id::text, device_id::text, event_type::text, event_time::text, source::text, created_at::text`,
+      [
+        input.employee_id,
+        input.device_id ?? null,
+        input.event_type,
+        input.event_time ?? null,
+        input.source,
+        input.idempotency_key ?? null,
+        JSON.stringify(input.raw_payload ?? {}),
+      ]
+    );
+    return { event: mapEvent(res.rows[0]), deduplicated: false };
+  } catch (err) {
+    // Course sur idempotency_key : la contrainte unique a gagné → renvoyer l'existant.
+    if (isPgUniqueViolation(err) && input.idempotency_key) {
+      const existing = await repoFindEventByIdempotencyKey(input.idempotency_key, q);
+      if (existing) return { event: existing, deduplicated: true };
+    }
+    throw err;
+  }
+}
+
+export async function repoListEventsForDay(employeeId: string, date: string, q: DbQueryer = pool): Promise<HrTimeEvent[]> {
+  const res = await q.query(
+    `SELECT id::text, employee_id::text, device_id::text, event_type::text, event_time::text, source::text, created_at::text
+       FROM public.hr_time_events
+      WHERE employee_id = $1::uuid AND (event_time AT TIME ZONE 'Europe/Paris')::date = $2::date
+      ORDER BY event_time ASC, created_at ASC`,
+    [employeeId, date]
+  );
+  return res.rows.map(mapEvent);
+}
+
+// -------------------------------------------------------------- Anomalies
+export async function repoInsertAnomaly(
+  q: DbQueryer,
+  a: { employee_id: string; date: string; anomaly_type: HrTimeAnomaly["anomaly_type"]; severity: HrTimeAnomaly["severity"]; message?: string | null }
+): Promise<HrTimeAnomaly> {
+  const res = await q.query(
+    `INSERT INTO public.hr_time_anomalies (employee_id, date, anomaly_type, severity, message)
+     VALUES ($1::uuid, $2::date, $3::hr_anomaly_type, $4::hr_anomaly_severity, $5)
+     RETURNING id::text, employee_id::text, date::text, anomaly_type::text, severity::text, message, resolved_by, resolved_at::text, created_at::text`,
+    [a.employee_id, a.date, a.anomaly_type, a.severity, a.message ?? null]
+  );
+  return mapAnomaly(res.rows[0]);
+}
+
+export async function repoListAnomalies(
+  employeeId: string,
+  filters: { date?: string; from?: string; to?: string },
+  q: DbQueryer = pool
+): Promise<HrTimeAnomaly[]> {
+  const where: string[] = ["employee_id = $1::uuid"];
+  const vals: unknown[] = [employeeId];
+  if (filters.date) {
+    vals.push(filters.date);
+    where.push(`date = $${vals.length}::date`);
+  }
+  if (filters.from) {
+    vals.push(filters.from);
+    where.push(`date >= $${vals.length}::date`);
+  }
+  if (filters.to) {
+    vals.push(filters.to);
+    where.push(`date <= $${vals.length}::date`);
+  }
+  const res = await q.query(
+    `SELECT id::text, employee_id::text, date::text, anomaly_type::text, severity::text, message, resolved_by, resolved_at::text, created_at::text
+       FROM public.hr_time_anomalies WHERE ${where.join(" AND ")} ORDER BY date DESC, created_at DESC LIMIT 500`,
+    vals
+  );
+  return res.rows.map(mapAnomaly);
+}
+
+// Anomalies STRUCTURELLES (dérivées du jour) — DOUBLE_BADGE est event-spécifique et exclu.
+const STRUCTURAL_ANOMALY_TYPES = [
+  "MISSING_IN", "MISSING_OUT", "MISSING_BREAK_END", "TOO_LONG_DAY", "TOO_SHORT_BREAK", "OUTSIDE_SCHEDULE",
+];
+
+// Idempotent : retire les anomalies structurelles non résolues du jour puis réinsère l'ensemble courant.
+// Ne touche NI aux DOUBLE_BADGE (event-spécifiques) NI aux anomalies déjà résolues.
+export async function repoRefreshDayAnomalies(
+  q: DbQueryer,
+  employeeId: string,
+  date: string,
+  anomalies: Array<{ anomaly_type: HrTimeAnomaly["anomaly_type"]; severity: HrTimeAnomaly["severity"]; message?: string | null }>
+): Promise<void> {
+  await q.query(
+    `DELETE FROM public.hr_time_anomalies
+      WHERE employee_id = $1::uuid AND date = $2::date AND resolved_at IS NULL
+        AND anomaly_type::text = ANY($3::text[])`,
+    [employeeId, date, STRUCTURAL_ANOMALY_TYPES]
+  );
+  for (const a of anomalies) {
+    await q.query(
+      `INSERT INTO public.hr_time_anomalies (employee_id, date, anomaly_type, severity, message)
+       VALUES ($1::uuid, $2::date, $3::hr_anomaly_type, $4::hr_anomaly_severity, $5)`,
+      [employeeId, date, a.anomaly_type, a.severity, a.message ?? null]
+    );
+  }
+}
+
+// -------------------------------------------------------------- Contrat (attendu du jour)
+export async function repoGetDailyTargetMinutes(employeeId: string, date: string, q: DbQueryer = pool): Promise<number> {
+  const res = await q.query(
+    `SELECT c.daily_hours_target, rs.daily_target_minutes
+       FROM public.hr_employment_contracts c
+       LEFT JOIN public.hr_time_rule_sets rs ON rs.id = c.rule_set_id
+      WHERE c.employee_id = $1::uuid AND c.active
+        AND c.start_date <= $2::date AND (c.end_date IS NULL OR c.end_date >= $2::date)
+      ORDER BY c.start_date DESC LIMIT 1`,
+    [employeeId, date]
+  );
+  const row = res.rows[0];
+  if (!row) return 0;
+  if (row.daily_hours_target != null) return Math.round(Number(row.daily_hours_target) * 60);
+  if (row.daily_target_minutes != null) return Number(row.daily_target_minutes);
+  return 0;
+}
+
+// -------------------------------------------------------------- Timesheet day (persistance de l'agrégat)
+export async function repoUpsertTimesheetDay(
+  q: DbQueryer,
+  d: { employee_id: string; date: string; expected_minutes: number; worked_minutes: number; overtime_minutes: number; missing_minutes: number; anomaly_count: number }
+): Promise<void> {
+  await q.query(
+    `INSERT INTO public.hr_timesheet_days (employee_id, date, expected_minutes, worked_minutes, overtime_minutes, missing_minutes, anomaly_count)
+     VALUES ($1::uuid, $2::date, $3, $4, $5, $6, $7)
+     ON CONFLICT (employee_id, date) DO UPDATE SET
+       expected_minutes = EXCLUDED.expected_minutes,
+       worked_minutes = EXCLUDED.worked_minutes,
+       overtime_minutes = EXCLUDED.overtime_minutes,
+       missing_minutes = EXCLUDED.missing_minutes,
+       anomaly_count = EXCLUDED.anomaly_count,
+       updated_at = now()
+     WHERE public.hr_timesheet_days.validation_status = 'DRAFT'`,
+    [d.employee_id, d.date, d.expected_minutes, d.worked_minutes, d.overtime_minutes, d.missing_minutes, d.anomaly_count]
+  );
+}
+
+// -------------------------------------------------------------- Audit
+export async function insertAuditLog(
+  tx: DbQueryer,
+  audit: AuditContext,
+  entry: { action: string; entity_type: string | null; entity_id: string | null; details?: Record<string, unknown> | null }
+): Promise<void> {
+  const body: CreateAuditLogBodyDTO = {
+    event_type: "ACTION",
+    action: entry.action,
+    page_key: audit.page_key,
+    entity_type: entry.entity_type,
+    entity_id: entry.entity_id,
+    path: audit.path,
+    client_session_id: audit.client_session_id,
+    details: entry.details ?? null,
+  };
+  await repoInsertAuditLog({
+    user_id: audit.user_id,
+    body,
+    ip: audit.ip,
+    user_agent: audit.user_agent,
+    device_type: audit.device_type,
+    os: audit.os,
+    browser: audit.browser,
+    tx,
+  });
+}

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -1,0 +1,24 @@
+import { Router } from "express";
+import * as c from "../controllers/temps-deplacements.controller";
+
+// Monté après le socle authenticateToken (v1.routes.ts) → JWT requis d'office.
+// Anti-IDOR : les routes salarié dérivent l'employé de req.user ; /employees/:id/* est gardé
+// (soi-même / manager / RH-Direction-Admin). Device : JWT + device_token haché.
+const router = Router();
+
+// Salarié (self-service)
+router.post("/events", c.postEvent);
+router.get("/me/today", c.getMeToday);
+router.get("/me/week", c.getMeWeek);
+router.get("/me/anomalies", c.getMeAnomalies);
+
+// Lecture périmètre (manager / RH) + anti-IDOR
+router.get("/employees/:id/today", c.getEmployeeToday);
+router.get("/employees/:id/week", c.getEmployeeWeek);
+
+// Borne / device
+router.get("/device-config", c.getDeviceConfig);
+router.post("/device-events", c.postDeviceEvent);
+router.post("/device-heartbeat", c.postDeviceHeartbeat);
+
+export default router;

--- a/src/module/temps-deplacements/services/temps-deplacements.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements.service.ts
@@ -1,0 +1,232 @@
+import crypto from "node:crypto";
+import { HttpError } from "../../../utils/httpError";
+import * as repo from "../repository/temps-deplacements.repository";
+import type { AuditContext } from "../repository/temps-deplacements.repository";
+import type {
+  CreateTimeEventInput,
+  CreateTimeEventResult,
+  HrDailyTimesheet,
+  HrEmployeeLite,
+  HrTimeAnomaly,
+  HrTimeEvent,
+  HrWeeklyTimesheet,
+} from "../types/temps-deplacements.types";
+
+// Seuils d'anomalie = défauts MVP (déplaçables dans hr_time_rule_sets en T5).
+// L'attendu contractuel (35h/39h) vient DÉJÀ de la base (repoGetDailyTargetMinutes) — jamais en dur.
+const DOUBLE_BADGE_WINDOW_MS = 90_000;
+const TOO_LONG_DAY_MINUTES = 12 * 60;
+const LONG_DAY_MINUTES = 6 * 60;
+const MIN_BREAK_MINUTES = 20;
+const TZ = "Europe/Paris";
+
+export function hashBadgeUid(uid: string): string {
+  return crypto.createHash("sha256").update(uid.trim()).digest("hex");
+}
+export function hashDeviceToken(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+export function parisDay(iso: string | number | Date): string {
+  return new Date(iso).toLocaleDateString("en-CA", { timeZone: TZ }); // en-CA => YYYY-MM-DD
+}
+export function todayParis(): string {
+  return parisDay(Date.now());
+}
+function addDays(ymd: string, n: number): string {
+  const d = new Date(`${ymd}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+// -------------------------------------------------------------- Résolution employé
+export async function resolveEmployeeFromUser(userId: number): Promise<HrEmployeeLite> {
+  const emp = await repo.repoGetEmployeeByUserId(userId);
+  if (!emp) throw new HttpError(404, "HR_EMPLOYEE_NOT_FOUND", "Aucun employé n'est lié à ce compte.");
+  if (emp.status !== "ACTIVE") throw new HttpError(403, "HR_EMPLOYEE_INACTIVE", "Employé inactif.");
+  return emp;
+}
+
+export async function resolveEmployeeFromBadge(badgeUid: string): Promise<HrEmployeeLite> {
+  const found = await repo.repoFindBadge(hashBadgeUid(badgeUid));
+  if (!found) throw new HttpError(404, "HR_BADGE_UNKNOWN", "Badge inconnu.");
+  if (!found.active) throw new HttpError(403, "HR_BADGE_REVOKED", "Badge révoqué.");
+  if (found.employee.status !== "ACTIVE") throw new HttpError(403, "HR_EMPLOYEE_INACTIVE", "Employé inactif.");
+  return found.employee;
+}
+
+// -------------------------------------------------------------- Création d'événement (append-only)
+export async function createTimeEvent(input: CreateTimeEventInput, audit: AuditContext): Promise<CreateTimeEventResult> {
+  const result = await repo.withTransaction(async (client) => {
+    const evtTimeMs = input.event_time ? new Date(input.event_time).getTime() : Date.now();
+
+    // Double badge rapproché (même type, < fenêtre) — hors retry idempotent explicite.
+    if (!input.idempotency_key) {
+      const last = await repo.repoGetLastEvent(input.employee_id, client);
+      if (last && last.event_type === input.event_type) {
+        const delta = Math.abs(evtTimeMs - new Date(last.event_time).getTime());
+        if (delta < DOUBLE_BADGE_WINDOW_MS) {
+          await repo.repoInsertAnomaly(client, {
+            employee_id: input.employee_id,
+            date: parisDay(last.event_time),
+            anomaly_type: "DOUBLE_BADGE",
+            severity: "WARNING",
+            message: `Double badge ${input.event_type} rapproché ignoré`,
+          });
+          await repo.insertAuditLog(client, audit, {
+            action: input.source === "BADGE" ? "temps-deplacements.event.double_badge_badge" : "temps-deplacements.event.double_badge_web",
+            entity_type: "hr_time_events",
+            entity_id: last.id,
+            details: { event_type: input.event_type, source: input.source },
+          });
+          return { event: last, deduplicated: true, double_badge: true };
+        }
+      }
+    }
+
+    const inserted = await repo.repoInsertTimeEvent(client, input);
+    await repo.insertAuditLog(client, audit, {
+      action: input.source === "BADGE" ? "temps-deplacements.event.create_badge" : "temps-deplacements.event.create_web",
+      entity_type: "hr_time_events",
+      entity_id: inserted.event.id,
+      // JAMAIS de badge_uid/token/payload sensible dans l'audit.
+      details: { event_type: input.event_type, source: input.source, deduplicated: inserted.deduplicated },
+    });
+    return { event: inserted.event, deduplicated: inserted.deduplicated, double_badge: false };
+  });
+
+  // Recalcul du jour (best-effort ; ne doit jamais faire échouer l'enregistrement de l'événement).
+  try {
+    await computeDailyTimesheet(input.employee_id, parisDay(result.event.event_time));
+  } catch {
+    /* noop */
+  }
+  return result;
+}
+
+// -------------------------------------------------------------- Détection d'anomalies (pure)
+export function detectTimeAnomalies(
+  events: HrTimeEvent[],
+  ctx: { openBreak: boolean; workedMinutes: number; totalBreak: number; isPastDay: boolean }
+): Array<{ anomaly_type: HrTimeAnomaly["anomaly_type"]; severity: HrTimeAnomaly["severity"]; message: string }> {
+  const out: Array<{ anomaly_type: HrTimeAnomaly["anomaly_type"]; severity: HrTimeAnomaly["severity"]; message: string }> = [];
+  const hasIn = events.some((e) => e.event_type === "IN");
+  const hasOut = events.some((e) => e.event_type === "OUT");
+  if (hasOut && !hasIn) out.push({ anomaly_type: "MISSING_IN", severity: "WARNING", message: "Sortie sans entrée" });
+  // MISSING_OUT / MISSING_BREAK_END : uniquement sur un jour passé (aujourd'hui, une session ouverte est normale).
+  if (ctx.isPastDay && hasIn && !hasOut) out.push({ anomaly_type: "MISSING_OUT", severity: "WARNING", message: "Entrée sans sortie" });
+  if (ctx.isPastDay && ctx.openBreak) out.push({ anomaly_type: "MISSING_BREAK_END", severity: "WARNING", message: "Pause non terminée" });
+  if (ctx.workedMinutes > TOO_LONG_DAY_MINUTES) out.push({ anomaly_type: "TOO_LONG_DAY", severity: "WARNING", message: "Journée trop longue" });
+  if (ctx.workedMinutes >= LONG_DAY_MINUTES && ctx.totalBreak > 0 && ctx.totalBreak < MIN_BREAK_MINUTES) {
+    out.push({ anomaly_type: "TOO_SHORT_BREAK", severity: "INFO", message: "Pause trop courte" });
+  }
+  return out;
+}
+
+// Résumé PUR d'une journée à partir des événements bruts triés (testable sans DB).
+export function summarizeDay(events: HrTimeEvent[]): {
+  firstIn: string | null;
+  lastOut: string | null;
+  breakMinutes: number;
+  workedMinutes: number;
+  openBreak: boolean;
+} {
+  let firstIn: string | null = null;
+  let lastOut: string | null = null;
+  let totalBreak = 0;
+  let openBreakStart: number | null = null;
+  for (const e of events) {
+    const t = new Date(e.event_time).getTime();
+    switch (e.event_type) {
+      case "IN":
+        if (firstIn === null) firstIn = e.event_time;
+        break;
+      case "OUT":
+        lastOut = e.event_time;
+        break;
+      case "BREAK_START":
+        openBreakStart = t;
+        break;
+      case "BREAK_END":
+        if (openBreakStart !== null) {
+          totalBreak += Math.max(0, Math.round((t - openBreakStart) / 60000));
+          openBreakStart = null;
+        }
+        break;
+      default:
+        break; // MISSION_* : hors calcul de présence en T2 (traité en T6)
+    }
+  }
+  const openBreak = openBreakStart !== null;
+  const workedMinutes =
+    firstIn && lastOut
+      ? Math.max(0, Math.round((new Date(lastOut).getTime() - new Date(firstIn).getTime()) / 60000) - totalBreak)
+      : 0;
+  return { firstIn, lastOut, breakMinutes: totalBreak, workedMinutes, openBreak };
+}
+
+// -------------------------------------------------------------- Relevé journalier
+export async function computeDailyTimesheet(employeeId: string, date: string): Promise<HrDailyTimesheet> {
+  const events = await repo.repoListEventsForDay(employeeId, date);
+  const { firstIn, lastOut, breakMinutes: totalBreak, workedMinutes, openBreak } = summarizeDay(events);
+
+  const expected = await repo.repoGetDailyTargetMinutes(employeeId, date);
+  const overtime = Math.max(0, workedMinutes - expected);
+  const missing = Math.max(0, expected - workedMinutes);
+  const isPastDay = date < todayParis();
+
+  const descriptors = detectTimeAnomalies(events, { openBreak, workedMinutes, totalBreak, isPastDay });
+
+  await repo.withTransaction(async (client) => {
+    await repo.repoRefreshDayAnomalies(client, employeeId, date, descriptors);
+    await repo.repoUpsertTimesheetDay(client, {
+      employee_id: employeeId,
+      date,
+      expected_minutes: expected,
+      worked_minutes: workedMinutes,
+      overtime_minutes: overtime,
+      missing_minutes: missing,
+      anomaly_count: descriptors.length,
+    });
+  });
+
+  const anomalies = await repo.repoListAnomalies(employeeId, { date });
+  const status: HrDailyTimesheet["status"] = anomalies.some((a) => a.resolved_at === null) ? "ANOMALY" : "OK";
+  return {
+    employee_id: employeeId,
+    date,
+    first_in: firstIn,
+    last_out: lastOut,
+    break_minutes: totalBreak,
+    worked_minutes: workedMinutes,
+    expected_minutes: expected,
+    overtime_minutes: overtime,
+    missing_minutes: missing,
+    status,
+    anomalies,
+  };
+}
+
+// -------------------------------------------------------------- Relevé hebdomadaire
+export async function computeWeeklyTimesheet(employeeId: string, weekStart: string): Promise<HrWeeklyTimesheet> {
+  const days: HrDailyTimesheet[] = [];
+  for (let i = 0; i < 7; i++) {
+    days.push(await computeDailyTimesheet(employeeId, addDays(weekStart, i)));
+  }
+  const worked = days.reduce((s, d) => s + d.worked_minutes, 0);
+  const expected = days.reduce((s, d) => s + d.expected_minutes, 0);
+  return {
+    employee_id: employeeId,
+    week_start: weekStart,
+    week_end: addDays(weekStart, 6),
+    worked_minutes: worked,
+    contract_minutes: expected,
+    overtime_minutes: Math.max(0, worked - expected),
+    absence_minutes: Math.max(0, expected - worked),
+    days,
+  };
+}
+
+export async function listMyAnomalies(employeeId: string, filters: { date?: string; from?: string; to?: string }): Promise<HrTimeAnomaly[]> {
+  return repo.repoListAnomalies(employeeId, filters);
+}

--- a/src/module/temps-deplacements/types/temps-deplacements.types.ts
+++ b/src/module/temps-deplacements/types/temps-deplacements.types.ts
@@ -1,0 +1,88 @@
+// Module « Temps & Déplacements » — T2 backend pointage. Types du domaine.
+// hr_time_events est append-only : jamais d'UPDATE/DELETE (corrections via hr_time_adjustments, T4).
+
+export type HrEventType = "IN" | "OUT" | "BREAK_START" | "BREAK_END" | "MISSION_START" | "MISSION_END";
+export type HrEventSource = "BADGE" | "WEB" | "MOBILE" | "ADMIN" | "IMPORT";
+export type HrAnomalyType =
+  | "MISSING_IN"
+  | "MISSING_OUT"
+  | "MISSING_BREAK_END"
+  | "DOUBLE_BADGE"
+  | "TOO_LONG_DAY"
+  | "TOO_SHORT_BREAK"
+  | "OUTSIDE_SCHEDULE";
+export type HrAnomalySeverity = "INFO" | "WARNING" | "CRITICAL";
+
+export interface HrEmployeeLite {
+  id: string;
+  user_id: number;
+  matricule: string;
+  service: string | null;
+  manager_user_id: number | null;
+  status: "ACTIVE" | "SUSPENDED" | "LEFT";
+}
+
+export interface HrTimeEvent {
+  id: string;
+  employee_id: string;
+  device_id: string | null;
+  event_type: HrEventType;
+  event_time: string;
+  source: HrEventSource;
+  created_at: string;
+}
+
+export interface HrTimeAnomaly {
+  id: string;
+  employee_id: string;
+  date: string;
+  anomaly_type: HrAnomalyType;
+  severity: HrAnomalySeverity;
+  message: string | null;
+  resolved_by: number | null;
+  resolved_at: string | null;
+  created_at: string;
+}
+
+// Relevé journalier calculé à partir des événements bruts (jamais persisté comme source de vérité :
+// les événements le sont ; ceci est un agrégat recalculable — hr_work_sessions / hr_timesheet_days).
+export interface HrDailyTimesheet {
+  employee_id: string;
+  date: string;
+  first_in: string | null;
+  last_out: string | null;
+  break_minutes: number;
+  worked_minutes: number;
+  expected_minutes: number;
+  overtime_minutes: number;
+  missing_minutes: number;
+  status: "OK" | "ANOMALY" | "MANUAL_REVIEW" | "VALIDATED";
+  anomalies: HrTimeAnomaly[];
+}
+
+export interface HrWeeklyTimesheet {
+  employee_id: string;
+  week_start: string;
+  week_end: string;
+  worked_minutes: number;
+  contract_minutes: number;
+  overtime_minutes: number;
+  absence_minutes: number;
+  days: HrDailyTimesheet[];
+}
+
+export interface CreateTimeEventInput {
+  employee_id: string;
+  event_type: HrEventType;
+  event_time?: string;
+  source: HrEventSource;
+  device_id?: string | null;
+  idempotency_key?: string | null;
+  raw_payload?: Record<string, unknown>;
+}
+
+export interface CreateTimeEventResult {
+  event: HrTimeEvent;
+  deduplicated: boolean; // true si idempotency_key déjà vu (aucune nouvelle ligne)
+  double_badge: boolean; // true si double badge rapproché détecté (anomalie enregistrée)
+}

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+// Validateurs T2. Convention repo : parse contrôleur (schema.parse(req.body/query/params)),
+// DTOs via z.infer. ANTI-IDOR : les schémas salarié ne contiennent JAMAIS d'employee_id
+// (l'employé est dérivé de req.user côté serveur).
+
+export const HR_EVENT_TYPES = ["IN", "OUT", "BREAK_START", "BREAK_END", "MISSION_START", "MISSION_END"] as const;
+
+const eventTime = z.string().datetime({ offset: true }).optional(); // ISO 8601 ; défaut = now serveur
+const dateOnly = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date attendue au format YYYY-MM-DD");
+
+// POST /time-clock/events (salarié) — aucun employee_id.
+export const createTimeEventSchema = z
+  .object({
+    event_type: z.enum(HR_EVENT_TYPES, { errorMap: () => ({ message: "event_type invalide" }) }),
+    event_time: eventTime,
+  })
+  .strict();
+export type CreateTimeEventBody = z.infer<typeof createTimeEventSchema>;
+
+// POST /time-clock/device-events (borne) — idempotency_key OBLIGATOIRE ; badge_uid brut (haché serveur, jamais loggé).
+export const deviceEventSchema = z
+  .object({
+    badge_uid: z.string().min(1, "badge_uid requis").max(256),
+    event_type: z.enum(HR_EVENT_TYPES, { errorMap: () => ({ message: "event_type invalide" }) }),
+    event_time: eventTime,
+    idempotency_key: z.string().min(8, "idempotency_key requis (min 8 caractères)").max(200),
+    device_token: z.string().min(1).max(512).optional(),
+  })
+  .strict();
+export type DeviceEventBody = z.infer<typeof deviceEventSchema>;
+
+// POST /time-clock/device-heartbeat (borne).
+export const deviceHeartbeatSchema = z
+  .object({
+    device_token: z.string().min(1, "device_token requis").max(512),
+  })
+  .strict();
+export type DeviceHeartbeatBody = z.infer<typeof deviceHeartbeatSchema>;
+
+export const meTodayQuerySchema = z.object({ date: dateOnly.optional() });
+export const meWeekQuerySchema = z.object({ week_start: dateOnly.optional() });
+export const meAnomaliesQuerySchema = z.object({
+  date: dateOnly.optional(),
+  from: dateOnly.optional(),
+  to: dateOnly.optional(),
+});
+export const employeeIdParamsSchema = z.object({ id: z.string().uuid("employee id (uuid) attendu") });

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -38,6 +38,7 @@ import usersRoutes from "../module/users/routes/users.routes";
 import traceabilityRoutes from "../module/traceability/routes/traceability.routes"
 import asbuiltRoutes from "../module/asbuilt/routes/asbuilt.routes"
 import locksRoutes from "../module/locks/routes/locks.routes"
+import tempsDeplacementsRoutes from "../module/temps-deplacements/routes/temps-deplacements.routes"
 import gammesRoutes from "../module/gammes/routes/gammes.routes"
 import pieceTechniqueVersionsRoutes from "../module/gammes/routes/piece-technique-versions.routes"
 const router = Router()
@@ -87,4 +88,5 @@ router.use("/users", usersRoutes);
 router.use("/traceability", traceabilityRoutes)
 router.use("/asbuilt", asbuiltRoutes)
 router.use("/locks", locksRoutes)
+router.use("/time-clock", tempsDeplacementsRoutes) // Module « Temps & Déplacements » (RH pointage/kilomètres)
 export default router


### PR DESCRIPTION
## T2 — backend pointage (Refs #119)

Module `src/module/temps-deplacements/` (quartet) monté après le socle JWT. **cerp_test uniquement · aucun front · aucune borne matérielle · aucun cerp_prod · aucun main · aucune nouvelle migration** (s'appuie sur le schéma T1).

**Endpoints** : salarié (`/events`, `/me/today|week|anomalies` — employé dérivé de req.user), périmètre (`/employees/:id/today|week` — soi/manager/RH), device (`/device-events|heartbeat`, `/device-config` — JWT + device_token haché).

**Règles** : `hr_time_events` append-only · idempotency_key obligatoire (device) · badge_uid/token **hachés** · badge inconnu(404)/révoqué(403) = refus+audité · double badge détecté · audit sans secrets · calcul journée/semaine **via contrat** (jamais 35/39 en dur) · anti-IDOR structurel.

**Tests** : 17 unitaires + suite **195** verte + tsc OK. **Smoke SQL cerp_test** (idempotency 23505, append-only denied, badge actif/révoqué/inconnu, requête jour) OK. Évidence : `docs/temps-deplacements-t2-evidence.md`.

Suite : T3 (front salarié).

## Summary by Sourcery

Introduce the initial backend "Temps & Déplacements" time-clock module, exposing JWT-protected employee, perimeter, and device endpoints for time events and timesheet calculations on cerp_test only.

New Features:
- Add /time-clock REST API with employee self-service endpoints for creating time events and viewing daily/weekly timesheets and anomalies.
- Expose manager/RH perimeter endpoints to view daily and weekly timesheets for a given employee with RBAC-based access control.
- Provide device-facing endpoints for badge-based time event ingestion, heartbeat reporting, and device configuration using hashed device tokens and badge UIDs.

Enhancements:
- Implement append-only time event storage with idempotent event creation, anomaly detection, and contract-based daily/weekly timesheet computation.
- Add structured audit logging around time-clock device and event operations without persisting sensitive badge or token data.

Documentation:
- Add T2 backend evidence documentation describing the new time-clock module, endpoints, business rules, and test coverage.

Tests:
- Add unit tests covering day summarization, anomaly detection, hashing, validation schemas, and RBAC rules for the new time-clock module.