### PR TITLE
feat(temps-deplacements): T4 — validation responsable RH (corrections tracées + validation)

### DIFF
--- a/docs/temps-deplacements-t4-evidence.md
+++ b/docs/temps-deplacements-t4-evidence.md
@@ -1,0 +1,61 @@
+# T4 — Validation responsable RH : preuves
+
+Périmètre : corrections tracées (motif obligatoire, pas d'auto-validation), validation jour/semaine,
+lecture périmètre équipe (manager / RH-Direction-Admin). Issue #119. Append-only : les événements ne
+sont jamais mutés — une correction approuvée est la **preuve légale** de la décision ; l'application
+numérique d'un override dans le relevé relève de T5.
+
+## Endpoints (montés après le socle `authenticateToken`)
+
+| Méthode | Route | Rôle | Contrôle |
+|---|---|---|---|
+| POST | `/time-clock/adjustments` | salarié | motif obligatoire ; anti-IDOR (soi / manager / RH) |
+| PATCH | `/time-clock/adjustments/:id/approve` | responsable/RH | pas d'auto-validation ; périmètre ; idempotent |
+| PATCH | `/time-clock/adjustments/:id/reject` | responsable/RH | idem |
+| GET | `/time-clock/team/adjustments` | responsable/RH | demandes en attente du périmètre |
+| GET | `/time-clock/team/today` | responsable/RH | relevé du jour de l'équipe |
+| GET | `/time-clock/team/anomalies` | responsable/RH | anomalies du jour du périmètre |
+| PATCH | `/time-clock/days/:id/validate` | responsable/RH | DRAFT/TO_REVIEW → VALIDATED, non rejouable |
+| PATCH | `/time-clock/weeks/:id/validate` | responsable/RH | idem semaine |
+
+## Garanties
+
+- **Pas d'auto-validation** : refusée à deux niveaux — service (`requested_by === actor` → 403
+  `HR_SELF_APPROVAL_FORBIDDEN`) **et** DB (`CHECK approved_by <> requested_by`).
+- **Motif obligatoire** : Zod (`reason` min 3, `.strict()`) + DB (`CHECK length(btrim(reason)) > 0`).
+- **Anti-IDOR périmètre** : une décision/validation n'est permise qu'au manager de l'employé cible ou à
+  un rôle privilégié (`isHrPrivileged` = rh / direction / directeur / administrateur).
+- **Idempotence** : transition `WHERE status='REQUESTED'` (0 ligne si déjà décidée → 409) ; validation
+  `WHERE validation_status IN ('DRAFT','TO_REVIEW')` (409 si déjà VALIDATED/EXPORTED).
+- **Audit** : chaque écriture journalisée (`requested`/`approved`/`rejected`/`day.validated`/
+  `week.validated`) via `insertAuditLog` — jamais de secret, motif = donnée opérationnelle.
+
+## Tests unitaires — `src/__tests__/temps-deplacements-t4.test.ts` (15 verts)
+
+Validateurs (motif, strict, enum, uuid) ; `isHrPrivileged` ; `createAdjustment` (404 cible / 403
+anti-IDOR / créée+audit) ; `decideAdjustment` (404 / 409 déjà traitée / 403 auto-validation / 403 hors
+périmètre / APPROVED+audit / 409 course) ; `validateTimesheetDay` (404 / 409 déjà validée / VALIDATED+audit).
+
+Suite backend complète : **210 verts / 44 fichiers**, `tsc --noEmit` = 0.
+
+## Smoke SQL cerp_test (BEGIN…ROLLBACK, aucune persistance)
+
+```
+1 SELF_APPROVE_CHECK: bloqué par CHECK (OK)
+2 REASON_CHECK: motif vide refusé (OK)
+3 APPROVE_BY_OTHER: t (attendu t)
+4 NON_REPLAY: lignes_modifiees=0 reste_APPROVED=t (attendu 0 / t)
+5 DAY_VALIDATE: t (attendu t)
+6 TEAM_SCOPE_RESOLVE: matches=1 (attendu 1)
+residus_smoke = 0
+```
+
+## Écart ouvert (à traiter en T5)
+
+- **`users_role_check` ne contient pas `Responsable RH`** sur cerp_test (valeurs autorisées :
+  Directeur, Employee, Administrateur Systeme et Reseau, Responsable Qualité, Secretaire, Responsable
+  Programmation). Le validateur applicatif (`user.validator.ts`) l'autorise, mais la contrainte DB non :
+  on ne peut donc pas *créer* un utilisateur `Responsable RH` tant que la contrainte n'est pas étendue.
+  Mitigation actuelle : `isHrPrivileged` reconnaît `Directeur` et `Administrateur…` (rôles autorisés) →
+  les fonctions RH restent accessibles. **Correctif T5** : migration additive étendant `users_role_check`
+  (+ éventuel `Responsable RH`) ou décision d'utiliser les rôles existants. Preuve disponible ; écart ouvert.

--- a/src/__tests__/temps-deplacements-t4.test.ts
+++ b/src/__tests__/temps-deplacements-t4.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Repository corrections : entièrement mocké (pas de DB en test unitaire).
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-corrections.repository", () => ({
+  repoResolveTargetEmployeeId: vi.fn(),
+  repoCreateAdjustment: vi.fn(),
+  repoGetAdjustmentById: vi.fn(),
+  repoDecideAdjustment: vi.fn(),
+  repoGetTimesheetDayById: vi.fn(),
+  repoGetTimesheetWeekById: vi.fn(),
+  repoSetDayValidation: vi.fn(),
+  repoSetWeekValidation: vi.fn(),
+  repoListTeamAdjustments: vi.fn(),
+  repoListTeamAnomaliesForDate: vi.fn(),
+  repoListTeamEmployees: vi.fn(),
+}));
+
+// Repository T2 : on garde le réel SAUF transaction/audit/lecture employé (pour ne pas toucher la DB).
+vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../module/temps-deplacements/repository/temps-deplacements.repository")>();
+  return {
+    ...actual,
+    withTransaction: vi.fn(async (fn: (c: unknown) => unknown) => fn({ query: vi.fn() })),
+    insertAuditLog: vi.fn(async () => undefined),
+    repoGetEmployeeById: vi.fn(),
+  };
+});
+
+import * as corRepo from "../module/temps-deplacements/repository/temps-deplacements-corrections.repository";
+import * as baseRepo from "../module/temps-deplacements/repository/temps-deplacements.repository";
+import * as svc from "../module/temps-deplacements/services/temps-deplacements-corrections.service";
+import {
+  createAdjustmentSchema,
+  uuidParamsSchema,
+} from "../module/temps-deplacements/validators/temps-deplacements.validators";
+import type { HrEmployeeLite } from "../module/temps-deplacements/types/temps-deplacements.types";
+
+const cor = vi.mocked(corRepo);
+const base = vi.mocked(baseRepo);
+
+const UUID = "22222222-2222-4222-8222-222222222222";
+const AUDIT = {
+  user_id: 1, ip: null, user_agent: null, device_type: null, os: null, browser: null,
+  path: null, page_key: null, client_session_id: null,
+};
+const emp = (over: Partial<HrEmployeeLite> = {}): HrEmployeeLite => ({
+  id: "11111111-1111-4111-8111-111111111111",
+  user_id: 1, matricule: "TD001", service: null, manager_user_id: null, status: "ACTIVE", ...over,
+});
+const adj = (over: Partial<Awaited<ReturnType<typeof corRepo.repoGetAdjustmentById>>> = {}) => ({
+  id: UUID, target_type: "DAY" as const, target_id: UUID, reason: "oubli de badge",
+  status: "REQUESTED" as const, requested_by: 1, approved_by: null, created_at: "t", approved_at: null, ...over,
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("T4 — validateurs corrections", () => {
+  it("createAdjustmentSchema : motif obligatoire, strict, enum cible", () => {
+    expect(createAdjustmentSchema.parse({ target_type: "DAY", target_id: UUID, reason: "oubli" }).reason).toBe("oubli");
+    expect(() => createAdjustmentSchema.parse({ target_type: "DAY", target_id: UUID, reason: "x" })).toThrow(); // <3
+    expect(() => createAdjustmentSchema.parse({ target_type: "NOPE", target_id: UUID, reason: "oubli" })).toThrow();
+    expect(() => createAdjustmentSchema.parse({ target_type: "DAY", target_id: UUID, reason: "oubli", employee_id: 3 })).toThrow(); // strict
+  });
+  it("uuidParamsSchema : refuse un id non-uuid", () => {
+    expect(uuidParamsSchema.parse({ id: UUID }).id).toBe(UUID);
+    expect(() => uuidParamsSchema.parse({ id: "42" })).toThrow();
+  });
+});
+
+describe("T4 — isHrPrivileged", () => {
+  it("RH / Direction / Admin privilégiés ; salarié non", () => {
+    expect(svc.isHrPrivileged("Responsable RH")).toBe(true);
+    expect(svc.isHrPrivileged("Direction")).toBe(true);
+    expect(svc.isHrPrivileged("Administrateur")).toBe(true);
+    expect(svc.isHrPrivileged("Employee")).toBe(false);
+  });
+});
+
+describe("T4 — createAdjustment (anti-IDOR, motif tracé)", () => {
+  it("cible inexistante → 404", async () => {
+    cor.repoResolveTargetEmployeeId.mockResolvedValue(null);
+    await expect(svc.createAdjustment({ id: 1, role: "Employee" }, { target_type: "DAY", target_id: UUID, reason: "oubli" }, AUDIT))
+      .rejects.toMatchObject({ status: 404, code: "HR_TARGET_NOT_FOUND" });
+  });
+  it("un salarié ne peut PAS demander une correction sur autrui → 403", async () => {
+    cor.repoResolveTargetEmployeeId.mockResolvedValue("emp-x");
+    base.repoGetEmployeeById.mockResolvedValue(emp({ user_id: 1, manager_user_id: 9 }));
+    await expect(svc.createAdjustment({ id: 2, role: "Employee" }, { target_type: "DAY", target_id: UUID, reason: "oubli" }, AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+  });
+  it("sur SES données → créée en REQUESTED + audit 'requested'", async () => {
+    cor.repoResolveTargetEmployeeId.mockResolvedValue("emp-self");
+    base.repoGetEmployeeById.mockResolvedValue(emp({ user_id: 2 }));
+    cor.repoCreateAdjustment.mockResolvedValue(adj({ requested_by: 2 }));
+    const r = await svc.createAdjustment({ id: 2, role: "Employee" }, { target_type: "DAY", target_id: UUID, reason: "oubli de badge" }, AUDIT);
+    expect(r.status).toBe("REQUESTED");
+    expect(base.insertAuditLog).toHaveBeenCalledWith(expect.anything(), AUDIT, expect.objectContaining({ action: "temps-deplacements.adjustment.requested" }));
+  });
+});
+
+describe("T4 — decideAdjustment (pas d'auto-validation, RBAC, idempotence)", () => {
+  it("demande inexistante → 404", async () => {
+    cor.repoGetAdjustmentById.mockResolvedValue(null);
+    await expect(svc.decideAdjustment({ id: 5, role: "Responsable RH" }, UUID, "APPROVED", AUDIT))
+      .rejects.toMatchObject({ status: 404, code: "HR_ADJUSTMENT_NOT_FOUND" });
+  });
+  it("demande déjà traitée → 409", async () => {
+    cor.repoGetAdjustmentById.mockResolvedValue(adj({ status: "APPROVED" }));
+    await expect(svc.decideAdjustment({ id: 5, role: "Responsable RH" }, UUID, "APPROVED", AUDIT))
+      .rejects.toMatchObject({ status: 409, code: "HR_ADJUSTMENT_NOT_PENDING" });
+  });
+  it("AUTO-VALIDATION interdite : le demandeur ne peut approuver sa propre demande → 403", async () => {
+    cor.repoGetAdjustmentById.mockResolvedValue(adj({ requested_by: 7 }));
+    await expect(svc.decideAdjustment({ id: 7, role: "Responsable RH" }, UUID, "APPROVED", AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_SELF_APPROVAL_FORBIDDEN" });
+  });
+  it("hors périmètre (ni manager ni RH) → 403", async () => {
+    cor.repoGetAdjustmentById.mockResolvedValue(adj({ requested_by: 1 }));
+    cor.repoResolveTargetEmployeeId.mockResolvedValue("emp-x");
+    base.repoGetEmployeeById.mockResolvedValue(emp({ manager_user_id: 99 }));
+    await expect(svc.decideAdjustment({ id: 5, role: "Employee" }, UUID, "APPROVED", AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+  });
+  it("responsable RH approuve → APPROVED + audit 'approved'", async () => {
+    cor.repoGetAdjustmentById.mockResolvedValue(adj({ requested_by: 1 }));
+    cor.repoResolveTargetEmployeeId.mockResolvedValue("emp-x");
+    cor.repoDecideAdjustment.mockResolvedValue(adj({ status: "APPROVED", requested_by: 1, approved_by: 5 }));
+    const r = await svc.decideAdjustment({ id: 5, role: "Responsable RH" }, UUID, "APPROVED", AUDIT);
+    expect(r.status).toBe("APPROVED");
+    expect(base.insertAuditLog).toHaveBeenCalledWith(expect.anything(), AUDIT, expect.objectContaining({ action: "temps-deplacements.adjustment.approved" }));
+  });
+  it("course : la transition a déjà eu lieu (repo renvoie null) → 409", async () => {
+    cor.repoGetAdjustmentById.mockResolvedValue(adj({ requested_by: 1 }));
+    cor.repoResolveTargetEmployeeId.mockResolvedValue("emp-x");
+    cor.repoDecideAdjustment.mockResolvedValue(null);
+    await expect(svc.decideAdjustment({ id: 5, role: "Responsable RH" }, UUID, "APPROVED", AUDIT))
+      .rejects.toMatchObject({ status: 409, code: "HR_ADJUSTMENT_NOT_PENDING" });
+  });
+});
+
+describe("T4 — validateTimesheetDay", () => {
+  it("journée inexistante → 404", async () => {
+    cor.repoGetTimesheetDayById.mockResolvedValue(null);
+    await expect(svc.validateTimesheetDay({ id: 5, role: "Responsable RH" }, UUID, AUDIT))
+      .rejects.toMatchObject({ status: 404, code: "HR_TIMESHEET_NOT_FOUND" });
+  });
+  it("journée déjà validée → 409 (non rejouable)", async () => {
+    cor.repoGetTimesheetDayById.mockResolvedValue({ id: UUID, employee_id: "emp-x", validation_status: "VALIDATED" });
+    await expect(svc.validateTimesheetDay({ id: 5, role: "Responsable RH" }, UUID, AUDIT))
+      .rejects.toMatchObject({ status: 409, code: "HR_ALREADY_VALIDATED" });
+  });
+  it("DRAFT → VALIDATED + audit 'day.validated'", async () => {
+    cor.repoGetTimesheetDayById.mockResolvedValue({ id: UUID, employee_id: "emp-x", validation_status: "DRAFT" });
+    cor.repoSetDayValidation.mockResolvedValue({ id: UUID, employee_id: "emp-x", validation_status: "VALIDATED" });
+    const r = await svc.validateTimesheetDay({ id: 5, role: "Responsable RH" }, UUID, AUDIT);
+    expect(r.validation_status).toBe("VALIDATED");
+    expect(base.insertAuditLog).toHaveBeenCalledWith(expect.anything(), AUDIT, expect.objectContaining({ action: "temps-deplacements.day.validated" }));
+  });
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements-corrections.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements-corrections.controller.ts
@@ -1,0 +1,61 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import * as svc from "../services/temps-deplacements-corrections.service";
+import {
+  createAdjustmentSchema,
+  teamAnomaliesQuerySchema,
+  uuidParamsSchema,
+} from "../validators/temps-deplacements.validators";
+import { buildAuditContext, requireUser } from "./temps-deplacements.controller";
+
+// ------------------------------------------------------------------ Corrections (salarié + responsable)
+export const postAdjustment = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  const body = createAdjustmentSchema.parse(req.body);
+  const adj = await svc.createAdjustment(actor, body, buildAuditContext(req));
+  res.status(201).json(adj);
+});
+
+export const approveAdjustment = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  const { id } = uuidParamsSchema.parse(req.params);
+  const adj = await svc.decideAdjustment(actor, id, "APPROVED", buildAuditContext(req));
+  res.json(adj);
+});
+
+export const rejectAdjustment = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  const { id } = uuidParamsSchema.parse(req.params);
+  const adj = await svc.decideAdjustment(actor, id, "REJECTED", buildAuditContext(req));
+  res.json(adj);
+});
+
+export const getTeamAdjustments = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  res.json(await svc.listTeamAdjustments(actor));
+});
+
+// ------------------------------------------------------------------ Validation jour / semaine
+export const validateDay = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.validateTimesheetDay(actor, id, buildAuditContext(req)));
+});
+
+export const validateWeek = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.validateTimesheetWeek(actor, id, buildAuditContext(req)));
+});
+
+// ------------------------------------------------------------------ Périmètre équipe (lecture)
+export const getTeamToday = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  res.json(await svc.teamToday(actor));
+});
+
+export const getTeamAnomalies = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  const { date } = teamAnomaliesQuerySchema.parse(req.query);
+  res.json(await svc.teamAnomalies(actor, date));
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements.controller.ts
@@ -16,7 +16,7 @@ import {
   meWeekQuerySchema,
 } from "../validators/temps-deplacements.validators";
 
-function buildAuditContext(req: Request): AuditContext {
+export function buildAuditContext(req: Request): AuditContext {
   const user = req.user;
   if (!user || typeof user.id !== "number") {
     throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
@@ -44,7 +44,7 @@ function buildAuditContext(req: Request): AuditContext {
   };
 }
 
-function requireUser(req: Request): { id: number; role: string } {
+export function requireUser(req: Request): { id: number; role: string } {
   const user = req.user;
   if (!user || typeof user.id !== "number") throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
   return { id: user.id, role: typeof user.role === "string" ? user.role : "" };

--- a/src/module/temps-deplacements/repository/temps-deplacements-corrections.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements-corrections.repository.ts
@@ -1,0 +1,255 @@
+import pool from "../../../config/database";
+import type { HrEmployeeLite, HrTimeAnomaly } from "../types/temps-deplacements.types";
+import type { DbQueryer } from "./temps-deplacements.repository";
+
+// -------------------------------------------------------------- T4 : corrections + validation
+// Réutilise DbQueryer / withTransaction / insertAuditLog du repository T2.
+
+export type HrAdjustmentTarget = "EVENT" | "DAY" | "WEEK";
+export type HrAdjustmentStatus = "REQUESTED" | "APPROVED" | "REJECTED";
+export type HrValidationStatus = "DRAFT" | "TO_REVIEW" | "VALIDATED" | "EXPORTED";
+
+export type HrAdjustment = {
+  id: string;
+  target_type: HrAdjustmentTarget;
+  target_id: string;
+  reason: string;
+  status: HrAdjustmentStatus;
+  requested_by: number;
+  approved_by: number | null;
+  created_at: string;
+  approved_at: string | null;
+};
+export type HrAdjustmentWithEmployee = HrAdjustment & {
+  employee_id: string;
+  matricule: string;
+  service: string | null;
+};
+
+const ADJ_COLS =
+  `id::text, target_type::text, target_id::text, reason, status::text, requested_by, approved_by, created_at::text, approved_at::text`;
+const EMP_COLS = `id::text, user_id, matricule, service, manager_user_id, status::text`;
+
+function mapAdj(r: Record<string, unknown>): HrAdjustment {
+  return {
+    id: String(r.id),
+    target_type: r.target_type as HrAdjustmentTarget,
+    target_id: String(r.target_id),
+    reason: String(r.reason),
+    status: r.status as HrAdjustmentStatus,
+    requested_by: Number(r.requested_by),
+    approved_by: r.approved_by === null || r.approved_by === undefined ? null : Number(r.approved_by),
+    created_at: String(r.created_at),
+    approved_at: (r.approved_at as string | null) ?? null,
+  };
+}
+
+function mapEmployee(r: Record<string, unknown>): HrEmployeeLite {
+  return {
+    id: String(r.id),
+    user_id: Number(r.user_id),
+    matricule: String(r.matricule),
+    service: (r.service as string | null) ?? null,
+    manager_user_id: r.manager_user_id === null || r.manager_user_id === undefined ? null : Number(r.manager_user_id),
+    status: r.status as HrEmployeeLite["status"],
+  };
+}
+
+// Table propriétaire de la cible, par type (whitelist = enum hr_adjustment_target ⇒ pas d'injection).
+const TARGET_TABLE: Record<HrAdjustmentTarget, string> = {
+  EVENT: "hr_time_events",
+  DAY: "hr_timesheet_days",
+  WEEK: "hr_timesheet_weeks",
+};
+
+// Résout l'employé (uuid) propriétaire d'une cible de correction. null si la cible n'existe pas.
+export async function repoResolveTargetEmployeeId(
+  targetType: HrAdjustmentTarget,
+  targetId: string,
+  q: DbQueryer = pool
+): Promise<string | null> {
+  const res = await q.query(
+    `SELECT employee_id::text FROM public.${TARGET_TABLE[targetType]} WHERE id = $1::uuid LIMIT 1`,
+    [targetId]
+  );
+  return res.rows[0] ? String(res.rows[0].employee_id) : null;
+}
+
+export async function repoCreateAdjustment(
+  q: DbQueryer,
+  input: {
+    target_type: HrAdjustmentTarget;
+    target_id: string;
+    reason: string;
+    old_value?: Record<string, unknown> | null;
+    new_value?: Record<string, unknown> | null;
+    requested_by: number;
+  }
+): Promise<HrAdjustment> {
+  const res = await q.query(
+    `INSERT INTO public.hr_time_adjustments
+       (target_type, target_id, old_value_json, new_value_json, reason, requested_by, status)
+     VALUES ($1::hr_adjustment_target, $2::uuid, $3::jsonb, $4::jsonb, $5, $6, 'REQUESTED'::hr_adjustment_status)
+     RETURNING ${ADJ_COLS}`,
+    [
+      input.target_type,
+      input.target_id,
+      JSON.stringify(input.old_value ?? null),
+      JSON.stringify(input.new_value ?? null),
+      input.reason,
+      input.requested_by,
+    ]
+  );
+  return mapAdj(res.rows[0]);
+}
+
+export async function repoGetAdjustmentById(id: string, q: DbQueryer = pool): Promise<HrAdjustment | null> {
+  const res = await q.query(`SELECT ${ADJ_COLS} FROM public.hr_time_adjustments WHERE id = $1::uuid LIMIT 1`, [id]);
+  return res.rows[0] ? mapAdj(res.rows[0]) : null;
+}
+
+// Transition REQUESTED → APPROVED|REJECTED. Ne modifie QUE si encore en attente (retourne null sinon).
+// La contrainte DB hr_time_adjustments_no_self_approve_ck (approved_by <> requested_by) reste un garde-fou.
+export async function repoDecideAdjustment(
+  q: DbQueryer,
+  id: string,
+  status: Exclude<HrAdjustmentStatus, "REQUESTED">,
+  approvedBy: number
+): Promise<HrAdjustment | null> {
+  const res = await q.query(
+    `UPDATE public.hr_time_adjustments
+        SET status = $2::hr_adjustment_status, approved_by = $3, approved_at = now()
+      WHERE id = $1::uuid AND status = 'REQUESTED'::hr_adjustment_status
+      RETURNING ${ADJ_COLS}`,
+    [id, status, approvedBy]
+  );
+  return res.rows[0] ? mapAdj(res.rows[0]) : null;
+}
+
+// Demandes en attente : périmètre manager, OU toutes si privilégié (RH/Direction/Admin).
+export async function repoListTeamAdjustments(
+  filters: { managerUserId: number; isPrivileged: boolean; status?: HrAdjustmentStatus },
+  q: DbQueryer = pool
+): Promise<HrAdjustmentWithEmployee[]> {
+  const res = await q.query(
+    `SELECT a.id::text, a.target_type::text, a.target_id::text, a.reason, a.status::text,
+            a.requested_by, a.approved_by, a.created_at::text, a.approved_at::text,
+            emp.id::text AS employee_id, emp.matricule, emp.service
+       FROM public.hr_time_adjustments a
+       LEFT JOIN public.hr_time_events ev     ON a.target_type = 'EVENT' AND ev.id = a.target_id
+       LEFT JOIN public.hr_timesheet_days td  ON a.target_type = 'DAY'   AND td.id = a.target_id
+       LEFT JOIN public.hr_timesheet_weeks tw ON a.target_type = 'WEEK'  AND tw.id = a.target_id
+       JOIN public.hr_employees emp ON emp.id = COALESCE(ev.employee_id, td.employee_id, tw.employee_id)
+      WHERE a.status = $1::hr_adjustment_status
+        AND ($2::boolean OR emp.manager_user_id = $3::int)
+      ORDER BY a.created_at DESC
+      LIMIT 500`,
+    [filters.status ?? "REQUESTED", filters.isPrivileged, filters.managerUserId]
+  );
+  return res.rows.map((r) => ({
+    ...mapAdj(r),
+    employee_id: String(r.employee_id),
+    matricule: String(r.matricule),
+    service: (r.service as string | null) ?? null,
+  }));
+}
+
+// -------------------------------------------------------------- Validation jour / semaine
+export type TimesheetRef = { id: string; employee_id: string; validation_status: HrValidationStatus };
+
+export async function repoGetTimesheetDayById(id: string, q: DbQueryer = pool): Promise<TimesheetRef | null> {
+  const res = await q.query(
+    `SELECT id::text, employee_id::text, validation_status::text FROM public.hr_timesheet_days WHERE id = $1::uuid LIMIT 1`,
+    [id]
+  );
+  const r = res.rows[0];
+  return r ? { id: String(r.id), employee_id: String(r.employee_id), validation_status: r.validation_status as HrValidationStatus } : null;
+}
+
+export async function repoGetTimesheetWeekById(id: string, q: DbQueryer = pool): Promise<TimesheetRef | null> {
+  const res = await q.query(
+    `SELECT id::text, employee_id::text, validation_status::text FROM public.hr_timesheet_weeks WHERE id = $1::uuid LIMIT 1`,
+    [id]
+  );
+  const r = res.rows[0];
+  return r ? { id: String(r.id), employee_id: String(r.employee_id), validation_status: r.validation_status as HrValidationStatus } : null;
+}
+
+// VALIDATE : uniquement depuis DRAFT/TO_REVIEW (retourne null si déjà VALIDATED/EXPORTED — non rejouable).
+export async function repoSetDayValidation(
+  q: DbQueryer,
+  id: string,
+  status: "VALIDATED" | "TO_REVIEW",
+  validatedBy: number
+): Promise<TimesheetRef | null> {
+  const res = await q.query(
+    `UPDATE public.hr_timesheet_days
+        SET validation_status = $2::hr_validation_status,
+            validated_by = $3, validated_at = now(), updated_at = now()
+      WHERE id = $1::uuid AND validation_status IN ('DRAFT','TO_REVIEW')
+      RETURNING id::text, employee_id::text, validation_status::text`,
+    [id, status, validatedBy]
+  );
+  const r = res.rows[0];
+  return r ? { id: String(r.id), employee_id: String(r.employee_id), validation_status: r.validation_status as HrValidationStatus } : null;
+}
+
+export async function repoSetWeekValidation(
+  q: DbQueryer,
+  id: string,
+  status: "VALIDATED" | "TO_REVIEW",
+  validatedBy: number
+): Promise<TimesheetRef | null> {
+  const res = await q.query(
+    `UPDATE public.hr_timesheet_weeks
+        SET validation_status = $2::hr_validation_status,
+            validated_by = $3, validated_at = now(), updated_at = now()
+      WHERE id = $1::uuid AND validation_status IN ('DRAFT','TO_REVIEW')
+      RETURNING id::text, employee_id::text, validation_status::text`,
+    [id, status, validatedBy]
+  );
+  const r = res.rows[0];
+  return r ? { id: String(r.id), employee_id: String(r.employee_id), validation_status: r.validation_status as HrValidationStatus } : null;
+}
+
+// -------------------------------------------------------------- Périmètre équipe
+export async function repoListTeamEmployees(
+  filters: { managerUserId: number; isPrivileged: boolean },
+  q: DbQueryer = pool
+): Promise<HrEmployeeLite[]> {
+  const res = await q.query(
+    `SELECT ${EMP_COLS} FROM public.hr_employees
+      WHERE status = 'ACTIVE' AND ($1::boolean OR manager_user_id = $2::int)
+      ORDER BY matricule ASC LIMIT 500`,
+    [filters.isPrivileged, filters.managerUserId]
+  );
+  return res.rows.map(mapEmployee);
+}
+
+export async function repoListTeamAnomaliesForDate(
+  filters: { managerUserId: number; isPrivileged: boolean; date: string },
+  q: DbQueryer = pool
+): Promise<Array<HrTimeAnomaly & { matricule: string }>> {
+  const res = await q.query(
+    `SELECT an.id::text, an.employee_id::text, an.date::text, an.anomaly_type::text, an.severity::text,
+            an.message, an.resolved_by, an.resolved_at::text, an.created_at::text, emp.matricule
+       FROM public.hr_time_anomalies an
+       JOIN public.hr_employees emp ON emp.id = an.employee_id
+      WHERE an.date = $1::date AND ($2::boolean OR emp.manager_user_id = $3::int)
+      ORDER BY an.severity DESC, an.created_at DESC
+      LIMIT 500`,
+    [filters.date, filters.isPrivileged, filters.managerUserId]
+  );
+  return res.rows.map((r) => ({
+    id: String(r.id),
+    employee_id: String(r.employee_id),
+    date: String(r.date),
+    anomaly_type: r.anomaly_type as HrTimeAnomaly["anomaly_type"],
+    severity: r.severity as HrTimeAnomaly["severity"],
+    message: (r.message as string | null) ?? null,
+    resolved_by: r.resolved_by === null || r.resolved_by === undefined ? null : Number(r.resolved_by),
+    resolved_at: (r.resolved_at as string | null) ?? null,
+    created_at: String(r.created_at),
+    matricule: String(r.matricule),
+  }));
+}

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import * as cor from "../controllers/temps-deplacements-corrections.controller";
 import * as c from "../controllers/temps-deplacements.controller";
 
 // Monté après le socle authenticateToken (v1.routes.ts) → JWT requis d'office.
@@ -20,5 +21,15 @@ router.get("/employees/:id/week", c.getEmployeeWeek);
 router.get("/device-config", c.getDeviceConfig);
 router.post("/device-events", c.postDeviceEvent);
 router.post("/device-heartbeat", c.postDeviceHeartbeat);
+
+// T4 — corrections tracées (motif obligatoire, pas d'auto-validation) + validation responsable
+router.post("/adjustments", cor.postAdjustment); // salarié : demande sur ses données
+router.patch("/adjustments/:id/approve", cor.approveAdjustment); // responsable/RH
+router.patch("/adjustments/:id/reject", cor.rejectAdjustment); // responsable/RH
+router.get("/team/adjustments", cor.getTeamAdjustments); // demandes en attente (périmètre)
+router.get("/team/today", cor.getTeamToday); // relevé du jour de l'équipe
+router.get("/team/anomalies", cor.getTeamAnomalies); // anomalies équipe du jour
+router.patch("/days/:id/validate", cor.validateDay); // valide une journée
+router.patch("/weeks/:id/validate", cor.validateWeek); // valide une semaine
 
 export default router;

--- a/src/module/temps-deplacements/services/temps-deplacements-corrections.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-corrections.service.ts
@@ -1,0 +1,178 @@
+import { HttpError } from "../../../utils/httpError";
+import {
+  repoCreateAdjustment,
+  repoDecideAdjustment,
+  repoGetAdjustmentById,
+  repoGetTimesheetDayById,
+  repoGetTimesheetWeekById,
+  repoListTeamAdjustments,
+  repoListTeamAnomaliesForDate,
+  repoListTeamEmployees,
+  repoResolveTargetEmployeeId,
+  repoSetDayValidation,
+  repoSetWeekValidation,
+  type HrAdjustment,
+  type HrAdjustmentWithEmployee,
+  type TimesheetRef,
+} from "../repository/temps-deplacements-corrections.repository";
+import {
+  insertAuditLog,
+  repoGetEmployeeById,
+  withTransaction,
+  type AuditContext,
+} from "../repository/temps-deplacements.repository";
+import type { CreateAdjustmentBody } from "../validators/temps-deplacements.validators";
+import { computeDailyTimesheet, todayParis } from "./temps-deplacements.service";
+
+export type Actor = { id: number; role: string };
+
+// Miroir de isHrPrivileged du contrôleur T2 (rôle RH/Direction/Admin). Pur ⇒ testable directement.
+export function isHrPrivileged(role: string): boolean {
+  const r = role.toLowerCase();
+  return r.includes("rh") || r.includes("directeur") || r.includes("direction") || r.includes("administrateur");
+}
+
+// Lève 403 si l'appelant n'est ni le manager de l'employé ni un rôle privilégié (anti-IDOR périmètre).
+async function assertCanManageEmployee(actor: Actor, employeeId: string): Promise<void> {
+  if (isHrPrivileged(actor.role)) return;
+  const emp = await repoGetEmployeeById(employeeId);
+  if (emp && emp.manager_user_id !== null && emp.manager_user_id === actor.id) return;
+  throw new HttpError(403, "HR_FORBIDDEN", "Hors de votre périmètre de gestion.");
+}
+
+// -------------------------------------------------------------- Corrections (tracées, motif obligatoire)
+// Le salarié demande une correction sur SES données (ou son manager / RH sur le périmètre). L'application
+// numérique d'une correction approuvée (override dans le relevé) relève de T5 : ici on trace la DÉCISION
+// (append-only events ⇒ jamais mutés). L'enregistrement approuvé est la preuve légale de la correction.
+export async function createAdjustment(
+  actor: Actor,
+  body: CreateAdjustmentBody,
+  audit: AuditContext
+): Promise<HrAdjustment> {
+  const targetEmployeeId = await repoResolveTargetEmployeeId(body.target_type, body.target_id);
+  if (!targetEmployeeId) throw new HttpError(404, "HR_TARGET_NOT_FOUND", "Cible de correction introuvable.");
+
+  const emp = await repoGetEmployeeById(targetEmployeeId);
+  const isSelf = emp?.user_id === actor.id;
+  const isManager = emp?.manager_user_id !== null && emp?.manager_user_id === actor.id;
+  if (!isSelf && !isManager && !isHrPrivileged(actor.role)) {
+    throw new HttpError(403, "HR_FORBIDDEN", "Vous ne pouvez demander une correction que sur vos données.");
+  }
+
+  return withTransaction(async (client) => {
+    const adj = await repoCreateAdjustment(client, {
+      target_type: body.target_type,
+      target_id: body.target_id,
+      reason: body.reason,
+      old_value: body.old_value ?? null,
+      new_value: body.new_value ?? null,
+      requested_by: actor.id,
+    });
+    await insertAuditLog(client, audit, {
+      action: "temps-deplacements.adjustment.requested",
+      entity_type: "hr_time_adjustments",
+      entity_id: adj.id,
+      details: { target_type: body.target_type, target_id: body.target_id, reason: body.reason },
+    });
+    return adj;
+  });
+}
+
+// Approuve / rejette une demande. INTERDIT : auto-validation (requested_by === actor). RBAC périmètre.
+export async function decideAdjustment(
+  actor: Actor,
+  id: string,
+  decision: "APPROVED" | "REJECTED",
+  audit: AuditContext
+): Promise<HrAdjustment> {
+  const adj = await repoGetAdjustmentById(id);
+  if (!adj) throw new HttpError(404, "HR_ADJUSTMENT_NOT_FOUND", "Demande de correction introuvable.");
+  if (adj.status !== "REQUESTED") throw new HttpError(409, "HR_ADJUSTMENT_NOT_PENDING", "Demande déjà traitée.");
+  if (adj.requested_by === actor.id) {
+    throw new HttpError(403, "HR_SELF_APPROVAL_FORBIDDEN", "Auto-validation d'une correction interdite.");
+  }
+  const targetEmployeeId = await repoResolveTargetEmployeeId(adj.target_type, adj.target_id);
+  if (!targetEmployeeId) throw new HttpError(404, "HR_TARGET_NOT_FOUND", "Cible de correction introuvable.");
+  await assertCanManageEmployee(actor, targetEmployeeId);
+
+  return withTransaction(async (client) => {
+    const updated = await repoDecideAdjustment(client, id, decision, actor.id);
+    if (!updated) throw new HttpError(409, "HR_ADJUSTMENT_NOT_PENDING", "Demande déjà traitée.");
+    await insertAuditLog(client, audit, {
+      action: decision === "APPROVED" ? "temps-deplacements.adjustment.approved" : "temps-deplacements.adjustment.rejected",
+      entity_type: "hr_time_adjustments",
+      entity_id: id,
+      details: { decision, target_type: adj.target_type, target_id: adj.target_id },
+    });
+    return updated;
+  });
+}
+
+export async function listTeamAdjustments(actor: Actor): Promise<HrAdjustmentWithEmployee[]> {
+  return repoListTeamAdjustments({ managerUserId: actor.id, isPrivileged: isHrPrivileged(actor.role) });
+}
+
+// -------------------------------------------------------------- Validation jour / semaine
+export async function validateTimesheetDay(actor: Actor, dayId: string, audit: AuditContext): Promise<TimesheetRef> {
+  const day = await repoGetTimesheetDayById(dayId);
+  if (!day) throw new HttpError(404, "HR_TIMESHEET_NOT_FOUND", "Journée introuvable.");
+  await assertCanManageEmployee(actor, day.employee_id);
+  if (day.validation_status === "VALIDATED" || day.validation_status === "EXPORTED") {
+    throw new HttpError(409, "HR_ALREADY_VALIDATED", "Journée déjà validée ou exportée.");
+  }
+  return withTransaction(async (client) => {
+    const updated = await repoSetDayValidation(client, dayId, "VALIDATED", actor.id);
+    if (!updated) throw new HttpError(409, "HR_ALREADY_VALIDATED", "Journée déjà validée ou exportée.");
+    await insertAuditLog(client, audit, {
+      action: "temps-deplacements.day.validated",
+      entity_type: "hr_timesheet_days",
+      entity_id: dayId,
+      details: { validation_status: "VALIDATED" },
+    });
+    return updated;
+  });
+}
+
+export async function validateTimesheetWeek(actor: Actor, weekId: string, audit: AuditContext): Promise<TimesheetRef> {
+  const week = await repoGetTimesheetWeekById(weekId);
+  if (!week) throw new HttpError(404, "HR_TIMESHEET_NOT_FOUND", "Semaine introuvable.");
+  await assertCanManageEmployee(actor, week.employee_id);
+  if (week.validation_status === "VALIDATED" || week.validation_status === "EXPORTED") {
+    throw new HttpError(409, "HR_ALREADY_VALIDATED", "Semaine déjà validée ou exportée.");
+  }
+  return withTransaction(async (client) => {
+    const updated = await repoSetWeekValidation(client, weekId, "VALIDATED", actor.id);
+    if (!updated) throw new HttpError(409, "HR_ALREADY_VALIDATED", "Semaine déjà validée ou exportée.");
+    await insertAuditLog(client, audit, {
+      action: "temps-deplacements.week.validated",
+      entity_type: "hr_timesheet_weeks",
+      entity_id: weekId,
+      details: { validation_status: "VALIDATED" },
+    });
+    return updated;
+  });
+}
+
+// -------------------------------------------------------------- Périmètre équipe (lecture)
+export async function teamToday(actor: Actor): Promise<{
+  date: string;
+  employees: Array<{ employee: { id: string; matricule: string; service: string | null }; timesheet: Awaited<ReturnType<typeof computeDailyTimesheet>> }>;
+}> {
+  const isPriv = isHrPrivileged(actor.role);
+  const employees = await repoListTeamEmployees({ managerUserId: actor.id, isPrivileged: isPriv });
+  const date = todayParis();
+  const rows = await Promise.all(
+    employees.map(async (e) => ({
+      employee: { id: e.id, matricule: e.matricule, service: e.service },
+      timesheet: await computeDailyTimesheet(e.id, date),
+    }))
+  );
+  return { date, employees: rows };
+}
+
+export async function teamAnomalies(actor: Actor, date?: string) {
+  const isPriv = isHrPrivileged(actor.role);
+  const d = date ?? todayParis();
+  const anomalies = await repoListTeamAnomaliesForDate({ managerUserId: actor.id, isPrivileged: isPriv, date: d });
+  return { date: d, anomalies };
+}

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -46,3 +46,21 @@ export const meAnomaliesQuerySchema = z.object({
   to: dateOnly.optional(),
 });
 export const employeeIdParamsSchema = z.object({ id: z.string().uuid("employee id (uuid) attendu") });
+
+// --- T4 : corrections tracées + validation ---
+export const HR_ADJUSTMENT_TARGETS = ["EVENT", "DAY", "WEEK"] as const;
+
+// Le salarié demande une correction SUR SES PROPRES données (motif OBLIGATOIRE).
+export const createAdjustmentSchema = z
+  .object({
+    target_type: z.enum(HR_ADJUSTMENT_TARGETS),
+    target_id: z.string().uuid("target_id (uuid) attendu"),
+    reason: z.string().trim().min(3, "Motif obligatoire (min 3 caractères)").max(2000),
+    old_value: z.record(z.unknown()).optional(),
+    new_value: z.record(z.unknown()).optional(),
+  })
+  .strict();
+export type CreateAdjustmentBody = z.infer<typeof createAdjustmentSchema>;
+
+export const uuidParamsSchema = z.object({ id: z.string().uuid("id (uuid) attendu") });
+export const teamAnomaliesQuerySchema = z.object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional() });


### PR DESCRIPTION
## T4 — Validation responsable RH (Refs #119)

Corrections **tracées** (motif obligatoire, **pas d'auto-validation**) + **validation jour/semaine** + lecture **périmètre équipe**. Append-only préservé (les events ne sont jamais mutés) : une correction approuvée est la preuve légale ; l'override numérique dans le relevé relève de T5.

**8 endpoints** `/time-clock` : `POST /adjustments`, `PATCH /adjustments/:id/approve|reject`, `GET /team/adjustments|today|anomalies`, `PATCH /days|weeks/:id/validate`.

**Garanties** : anti auto-validation (service 403 **+** DB `CHECK approved_by<>requested_by`) · motif (Zod + `CHECK`) · anti-IDOR périmètre (`isHrPrivileged`/manager) · idempotence (`WHERE status='REQUESTED'`) · audit systématique (jamais de secret).

**Tests** : 15 unit (repo mocké) · suite **210** verte · `tsc` 0. **Smoke cerp_test** (BEGIN/ROLLBACK, **0 résidu**) : self-approve bloqué, motif vide refusé, approve-by-other, non-replay=0, day validate, team-scope=1.

**Écart ouvert** (doc + correctif T5) : `users_role_check` sans « Responsable RH » → mitigé, `Directeur`/`Admin` privilégiés. **Aucun cerp_prod, aucun main.** Voir `docs/temps-deplacements-t4-evidence.md`.

## Summary by Sourcery

Introduce HR-managed time corrections and timesheet validation endpoints for the time-clock module, with team-scoped access control and audit logging.

New Features:
- Add REST endpoints for employees to request time corrections and HR/managers to approve or reject them.
- Expose team-level endpoints to list pending adjustments, view today’s team timesheets, and see daily anomalies.
- Enable validation of timesheet days and weeks with non-replayable status transitions.

Enhancements:
- Add Zod schemas and UUID validators for correction payloads and team anomaly queries, enforcing mandatory reasons and strict input shapes.
- Implement role-based and manager-scoped access control helpers for HR privileges and team perimeter enforcement.
- Extend repository layer with correction, validation, and team-query operations, all integrated with audit logging and transactional behavior.

Documentation:
- Document T4 HR validation guarantees, endpoints, tests, and known DB role constraint gap in temps-deplacements-t4-evidence.md.

Tests:
- Add unit test suite for T4 corrections and validation covering schema validation, privilege checks, anti self-approval, idempotent decisions, and day validation flows.