### PR TITLE
feat(temps-deplacements): T5 — contrats/horaires/règles + calcul réel 35h/39h

### DIFF
--- a/db/patches/20260710_hr_users_role_responsable_rh.sql
+++ b/db/patches/20260710_hr_users_role_responsable_rh.sql
@@ -1,0 +1,25 @@
+-- 20260710_hr_users_role_responsable_rh.sql
+-- T5 (#119) — Élargit users_role_check pour autoriser le rôle « Responsable RH ».
+-- ADDITIF & SÛR : n'ajoute qu'une valeur permise (élargissement d'un CHECK ⇒ aucune ligne existante
+-- ne peut devenir invalide). Idempotent (DROP IF EXISTS + recréation). Ne supprime aucun rôle existant.
+-- Contexte : le validateur applicatif autorisait déjà « Responsable RH » mais la contrainte DB non,
+-- empêchant la création d'un tel utilisateur (écart ouvert en T4).
+
+BEGIN;
+
+ALTER TABLE public.users DROP CONSTRAINT IF EXISTS users_role_check;
+
+ALTER TABLE public.users
+  ADD CONSTRAINT users_role_check CHECK (
+    (role)::text = ANY (ARRAY[
+      'Directeur'::text,
+      'Employee'::text,
+      'Administrateur Systeme et Reseau'::text,
+      'Responsable Qualité'::text,
+      'Secretaire'::text,
+      'Responsable Programmation'::text,
+      'Responsable RH'::text
+    ])
+  );
+
+COMMIT;

--- a/docs/temps-deplacements-t5-evidence.md
+++ b/docs/temps-deplacements-t5-evidence.md
@@ -1,0 +1,54 @@
+# T5 — Contrats / horaires / règles : preuves
+
+Objectif : rendre les calculs réellement exploitables (35h, 39h, temps partiel, horaires types), **sans
+jamais coder 35/39 en dur**. Issue #119.
+
+## Ce qui est livré
+
+- **Migration** `db/patches/20260710_hr_users_role_responsable_rh.sql` — élargit `users_role_check` pour
+  autoriser `Responsable RH` (additif/sûr, idempotent). Appliquée sur cerp_test (écart T4 fermé).
+- **Moteur de règles PUR** `services/temps-deplacements-rules.ts` : `effectiveRuleSetFromRows` (rule_set
+  s'il existe, sinon dérivé du contrat — heures propres du salarié), `applyRounding`, `enforceMinimumBreak`,
+  `splitWeeklyOvertime`, `weeklyAggregate`, `effectiveDailyWorked`.
+- **Résolution effective** `repoGetEffectiveRuleSet(employeeId, date)` : contrat **couvrant la date**
+  (start ≤ date ≤ end), donc robuste au **changement de contrat** et au recalcul historique.
+- **Calcul câblé sur les règles réelles** : `computeDailyTimesheet` (cible jour + arrondi + pause mini) et
+  `computeWeeklyTimesheet` (cible hebdo + HS 25/50 + absence + persistance `hr_timesheet_weeks`).
+- **CRUD admin RH** (réservé rôles privilégiés) : `rule-sets`, `contracts` (1 seul actif/employé → 409),
+  `schedules`, + `GET /admin/employees` (pickers). Tout audité, jamais de secret.
+
+## Endpoints (`/time-clock/admin/*`, privilégiés)
+
+`GET employees` · `GET|POST rule-sets`, `PUT rule-sets/:id`, `PATCH rule-sets/:id/active` ·
+`GET|POST contracts`, `PUT contracts/:id`, `PATCH contracts/:id/active` ·
+`GET|POST schedules`, `PUT schedules/:id`, `DELETE schedules/:id`.
+
+## Modèle de calcul (configurable)
+
+- `weekly_target_minutes` / `daily_target_minutes` : cibles saisies (jamais 35/39 en dur).
+- HS : `[0..seuil1]` normal, `[seuil1..seuil2]` taux 1 (25 %), `[seuil2..]` taux 2 (50 %). Seuils/taux
+  dans `hr_time_rule_sets` ; à défaut, dérivés du contrat (HS au-delà de la cible contractuelle).
+- Arrondi (`rounding_rule`: `{unit_minutes, mode}`) et pause minimale (`break_rule`:
+  `{min_break_minutes, auto_deduct_after_minutes}`) appliqués au temps travaillé.
+
+## Tests unitaires (19 verts) — suite backend **229 / 46 fichiers**, `tsc` 0
+
+`temps-deplacements-t5-rules.test.ts` (13) : 35h normal, 39h normal, temps partiel, HS 25, HS 50, absence,
+absence de contrat (null → zéros), bornes split, contrat dérivé vs rule_set, changement 35→39 (cibles
+différentes), arrondis, pause mini. `temps-deplacements-t5-admin.test.ts` (6) : Responsable RH autorisé
+(create règle/contrat + audit), anti-IDOR (salarié 403 sur règle/contrats/horaire), 1 seul contrat actif (409).
+
+## Smoke SQL cerp_test (BEGIN…ROLLBACK, 0 résidu)
+
+```
+1 ONE_ACTIVE: 2e contrat actif refusé (OK)
+2 RESOLVE@2026-03-01: type=H35 weekly_h=35.00 rule_target=2100 (attendu H35/35/2100)
+3 RESOLVE@2026-08-01: type=H39 weekly_h=39.00 rule_target=NULL (attendu H39/39/NULL)
+4 RESOLVE@2025 (avant contrat): matches=0 (attendu 0)
+5 WEEK_UPSERT: worked=2400 ot25=300 (attendu 2400/300)
+residus = 0
+```
+
+Décision : approbation d'une correction (T4) trace la décision ; l'**override numérique** d'un relevé n'est
+pas implémenté ici (append-only) — laissé comme évolution documentée. HS « 25/50 » = libellés des taux
+configurables `overtime_rate_1/2`, pas des constantes.

--- a/src/__tests__/temps-deplacements-t5-admin.test.ts
+++ b/src/__tests__/temps-deplacements-t5-admin.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-rules.repository", () => ({
+  repoListRuleSets: vi.fn(),
+  repoInsertRuleSet: vi.fn(),
+  repoUpdateRuleSet: vi.fn(),
+  repoSetRuleSetActive: vi.fn(),
+  repoGetRuleSetById: vi.fn(),
+  repoListContracts: vi.fn(),
+  repoGetContractById: vi.fn(),
+  repoInsertContract: vi.fn(),
+  repoUpdateContract: vi.fn(),
+  repoSetContractActive: vi.fn(),
+  repoListSchedules: vi.fn(),
+  repoInsertSchedule: vi.fn(),
+  repoUpdateSchedule: vi.fn(),
+  repoDeleteSchedule: vi.fn(),
+}));
+vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", async (io) => {
+  const actual = await io<typeof import("../module/temps-deplacements/repository/temps-deplacements.repository")>();
+  return {
+    ...actual,
+    withTransaction: vi.fn(async (fn: (c: unknown) => unknown) => fn({ query: vi.fn() })),
+    insertAuditLog: vi.fn(async () => undefined),
+  };
+});
+
+import * as rulesRepo from "../module/temps-deplacements/repository/temps-deplacements-rules.repository";
+import * as baseRepo from "../module/temps-deplacements/repository/temps-deplacements.repository";
+import * as admin from "../module/temps-deplacements/services/temps-deplacements-admin.service";
+
+const rules = vi.mocked(rulesRepo);
+const base = vi.mocked(baseRepo);
+const AUDIT = { user_id: 9, ip: null, user_agent: null, device_type: null, os: null, browser: null, path: null, page_key: null, client_session_id: null };
+const RH = { id: 9, role: "Responsable RH" };
+const SALARIE = { id: 2, role: "Employee" };
+const RULE = {
+  name: "Cadre 35h", weekly_target_minutes: 2100, daily_target_minutes: 420,
+  overtime_threshold_1_minutes: 2100, overtime_rate_1: 1.25, overtime_threshold_2_minutes: 2580, overtime_rate_2: 1.5,
+  rounding_rule: {}, break_rule: {},
+};
+const CONTRACT = {
+  employee_id: "11111111-1111-4111-8111-111111111111", contract_type: "H35" as const,
+  weekly_hours_target: 35, daily_hours_target: null, start_date: "2026-01-01", end_date: null, rule_set_id: null, active: true,
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("T5 — admin RH : Responsable RH autorisé", () => {
+  it("crée une règle + audit", async () => {
+    rules.repoInsertRuleSet.mockResolvedValue({ id: "rs1", ...RULE });
+    const r = await admin.createRuleSet(RH, RULE, AUDIT);
+    expect(r.id).toBe("rs1");
+    expect(rules.repoInsertRuleSet).toHaveBeenCalledOnce();
+    expect(base.insertAuditLog).toHaveBeenCalledWith(expect.anything(), AUDIT, expect.objectContaining({ action: "temps-deplacements.rule_set.create" }));
+  });
+  it("crée un contrat", async () => {
+    rules.repoInsertContract.mockResolvedValue({ id: "c1", ...CONTRACT });
+    const r = await admin.createContract(RH, CONTRACT, AUDIT);
+    expect(r.id).toBe("c1");
+  });
+});
+
+describe("T5 — admin RH : anti-IDOR (salarié refusé)", () => {
+  it("un salarié ne peut PAS créer de règle → 403", async () => {
+    await expect(admin.createRuleSet(SALARIE, RULE, AUDIT)).rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+    expect(rules.repoInsertRuleSet).not.toHaveBeenCalled();
+  });
+  it("un salarié ne peut PAS lister les contrats → 403", async () => {
+    await expect(admin.listContracts(SALARIE)).rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+  });
+  it("un salarié ne peut PAS créer d'horaire → 403", async () => {
+    await expect(admin.createSchedule(SALARIE, { employee_id: CONTRACT.employee_id, day_of_week: 1, expected_start: null, expected_end: null, expected_break_minutes: 0, flexible_start_window: 0, flexible_end_window: 0, active: true }, AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+  });
+});
+
+describe("T5 — admin RH : un seul contrat actif par employé", () => {
+  it("créer un 2e contrat actif → 409", async () => {
+    rules.repoInsertContract.mockRejectedValue(Object.assign(new Error("dup"), { code: "23505" }));
+    await expect(admin.createContract(RH, CONTRACT, AUDIT)).rejects.toMatchObject({ status: 409, code: "HR_CONTRACT_ACTIVE_EXISTS" });
+  });
+});

--- a/src/__tests__/temps-deplacements-t5-rules.test.ts
+++ b/src/__tests__/temps-deplacements-t5-rules.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyRounding,
+  effectiveRuleSetFromRows,
+  enforceMinimumBreak,
+  splitWeeklyOvertime,
+  weeklyAggregate,
+  type ContractRow,
+  type HrRuleSet,
+} from "../module/temps-deplacements/services/temps-deplacements-rules";
+
+const rs = (over: Partial<HrRuleSet> = {}): HrRuleSet => ({
+  id: "r", name: "R", weekly_target_minutes: 2100, daily_target_minutes: 420,
+  overtime_threshold_1_minutes: 2100, overtime_rate_1: 1.25, overtime_threshold_2_minutes: 2580, overtime_rate_2: 1.5,
+  rounding_rule: {}, break_rule: {}, active: true, ...over,
+});
+
+// 35h = 2100 min, 39h = 2340 min, 43h = 2580 min. AUCUNE de ces valeurs n'est codée dans le moteur.
+describe("T5 — weeklyAggregate (35h/39h/HS/absence, règles configurables)", () => {
+  it("salarié 35h semaine normale → aucune HS, aucune absence", () => {
+    const a = weeklyAggregate(2100, rs({ weekly_target_minutes: 2100, overtime_threshold_1_minutes: 2100 }));
+    expect(a).toMatchObject({ contract_minutes: 2100, overtime_25_minutes: 0, overtime_50_minutes: 0, absence_minutes: 0 });
+  });
+  it("salarié 39h semaine normale → aucune HS (seuil = contrat)", () => {
+    const a = weeklyAggregate(2340, rs({ weekly_target_minutes: 2340, overtime_threshold_1_minutes: 2340 }));
+    expect(a).toMatchObject({ contract_minutes: 2340, overtime_25_minutes: 0, overtime_50_minutes: 0 });
+  });
+  it("temps partiel 20h → cible 1200, HS au-delà", () => {
+    expect(weeklyAggregate(1200, rs({ weekly_target_minutes: 1200, overtime_threshold_1_minutes: 1200, overtime_threshold_2_minutes: null })))
+      .toMatchObject({ overtime_25_minutes: 0, absence_minutes: 0 });
+    expect(weeklyAggregate(1320, rs({ weekly_target_minutes: 1200, overtime_threshold_1_minutes: 1200, overtime_threshold_2_minutes: null })).overtime_25_minutes).toBe(120);
+  });
+  it("heures sup 25 (base 35h) : 40h → 300 min à 25 %, 0 à 50 %", () => {
+    const a = weeklyAggregate(2400, rs());
+    expect(a.overtime_25_minutes).toBe(300);
+    expect(a.overtime_50_minutes).toBe(0);
+  });
+  it("heures sup 50 : 45h → 480 min à 25 % puis 120 min à 50 %", () => {
+    const a = weeklyAggregate(2700, rs());
+    expect(a.overtime_25_minutes).toBe(2580 - 2100);
+    expect(a.overtime_50_minutes).toBe(2700 - 2580);
+  });
+  it("absence : 30h sur contrat 35h → 300 min d'absence", () => {
+    expect(weeklyAggregate(1800, rs()).absence_minutes).toBe(300);
+  });
+  it("absence de contrat (règle nulle) → tout à zéro, pas de plantage", () => {
+    expect(weeklyAggregate(2000, null)).toEqual({ contract_minutes: 0, overtime_25_minutes: 0, overtime_50_minutes: 0, absence_minutes: 0, rule_set_name: null });
+  });
+});
+
+describe("T5 — splitWeeklyOvertime (bornes)", () => {
+  it("t2 non défini → tout le sup passe en taux 1", () => {
+    expect(splitWeeklyOvertime(2600, rs({ overtime_threshold_2_minutes: null }))).toEqual({ normal: 2100, overtime25: 500, overtime50: 0 });
+  });
+});
+
+describe("T5 — effectiveRuleSetFromRows (contrat vs rule_set, changement de contrat)", () => {
+  const ct = (over: Partial<ContractRow>): ContractRow => ({ id: "c", contract_type: "H35", weekly_hours_target: 35, daily_hours_target: null, rule_set_id: null, ...over });
+  it("sans rule_set : cible dérivée du CONTRAT (jamais 35/39 en dur)", () => {
+    const r = effectiveRuleSetFromRows(ct({ weekly_hours_target: 35 }), null);
+    expect(r.weekly_target_minutes).toBe(2100);
+    expect(r.daily_target_minutes).toBe(420); // 2100/5
+    expect(r.overtime_threshold_1_minutes).toBe(2100);
+  });
+  it("changement de contrat 35h → 39h : cibles différentes", () => {
+    const r35 = effectiveRuleSetFromRows(ct({ weekly_hours_target: 35 }), null);
+    const r39 = effectiveRuleSetFromRows(ct({ contract_type: "H39", weekly_hours_target: 39 }), null);
+    expect(r39.weekly_target_minutes).toBe(2340);
+    expect(r39.weekly_target_minutes).not.toBe(r35.weekly_target_minutes);
+  });
+  it("avec rule_set : les cibles du rule_set priment sur le contrat", () => {
+    const r = effectiveRuleSetFromRows(ct({ weekly_hours_target: 39, rule_set_id: "rs1" }), {
+      id: "rs1", name: "Cadre 35h", weekly_target_minutes: 2100, daily_target_minutes: 420,
+      overtime_threshold_1_minutes: 2100, overtime_rate_1: 1.25, overtime_threshold_2_minutes: 2580, overtime_rate_2: 1.5,
+      rounding_rule: { unit_minutes: 15, mode: "nearest" }, break_rule: { min_break_minutes: 20 }, active: true,
+    });
+    expect(r.weekly_target_minutes).toBe(2100); // rule_set, pas 2340
+    expect(r.rounding_rule.unit_minutes).toBe(15);
+    expect(r.break_rule.min_break_minutes).toBe(20);
+  });
+});
+
+describe("T5 — arrondis & pause minimale", () => {
+  it("arrondi au quart d'heure (nearest/up/down)", () => {
+    expect(applyRounding(127, { unit_minutes: 15, mode: "nearest" })).toBe(120);
+    expect(applyRounding(121, { unit_minutes: 15, mode: "up" })).toBe(135);
+    expect(applyRounding(134, { unit_minutes: 15, mode: "down" })).toBe(120);
+    expect(applyRounding(127, {})).toBe(127); // pas de règle → inchangé
+  });
+  it("pause minimale imposée au-delà d'un seuil", () => {
+    expect(enforceMinimumBreak(480, 10, { min_break_minutes: 30, auto_deduct_after_minutes: 360 })).toBe(460); // déduit 20
+    expect(enforceMinimumBreak(300, 0, { min_break_minutes: 30, auto_deduct_after_minutes: 360 })).toBe(300); // sous le seuil
+    expect(enforceMinimumBreak(480, 30, { min_break_minutes: 30, auto_deduct_after_minutes: 360 })).toBe(480); // pause suffisante
+  });
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements-admin.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements-admin.controller.ts
@@ -1,0 +1,76 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import * as svc from "../services/temps-deplacements-admin.service";
+import {
+  contractBodySchema,
+  listContractsQuerySchema,
+  listSchedulesQuerySchema,
+  ruleSetBodySchema,
+  scheduleBodySchema,
+  setActiveSchema,
+  uuidParamsSchema,
+} from "../validators/temps-deplacements.validators";
+import { buildAuditContext, requireUser } from "./temps-deplacements.controller";
+
+// -------------------------------------------------------------- Employés (pickers)
+export const getEmployees = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await svc.listEmployees(requireUser(req)));
+});
+
+// -------------------------------------------------------------- Rule sets
+export const getRuleSets = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await svc.listRuleSets(requireUser(req)));
+});
+export const postRuleSet = asyncHandler(async (req: Request, res: Response) => {
+  const body = ruleSetBodySchema.parse(req.body);
+  res.status(201).json(await svc.createRuleSet(requireUser(req), body, buildAuditContext(req)));
+});
+export const putRuleSet = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const body = ruleSetBodySchema.parse(req.body);
+  res.json(await svc.updateRuleSet(requireUser(req), id, body, buildAuditContext(req)));
+});
+export const patchRuleSetActive = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const { active } = setActiveSchema.parse(req.body);
+  res.json(await svc.setRuleSetActive(requireUser(req), id, active, buildAuditContext(req)));
+});
+
+// -------------------------------------------------------------- Contrats
+export const getContracts = asyncHandler(async (req: Request, res: Response) => {
+  const { employee_id } = listContractsQuerySchema.parse(req.query);
+  res.json(await svc.listContracts(requireUser(req), employee_id));
+});
+export const postContract = asyncHandler(async (req: Request, res: Response) => {
+  const body = contractBodySchema.parse(req.body);
+  res.status(201).json(await svc.createContract(requireUser(req), body, buildAuditContext(req)));
+});
+export const putContract = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const body = contractBodySchema.parse(req.body);
+  res.json(await svc.updateContract(requireUser(req), id, body, buildAuditContext(req)));
+});
+export const patchContractActive = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const { active } = setActiveSchema.parse(req.body);
+  res.json(await svc.setContractActive(requireUser(req), id, active, buildAuditContext(req)));
+});
+
+// -------------------------------------------------------------- Horaires types
+export const getSchedules = asyncHandler(async (req: Request, res: Response) => {
+  const { employee_id } = listSchedulesQuerySchema.parse(req.query);
+  res.json(await svc.listSchedules(requireUser(req), employee_id));
+});
+export const postSchedule = asyncHandler(async (req: Request, res: Response) => {
+  const body = scheduleBodySchema.parse(req.body);
+  res.status(201).json(await svc.createSchedule(requireUser(req), body, buildAuditContext(req)));
+});
+export const putSchedule = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const body = scheduleBodySchema.parse(req.body);
+  res.json(await svc.updateSchedule(requireUser(req), id, body, buildAuditContext(req)));
+});
+export const deleteScheduleHandler = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.deleteSchedule(requireUser(req), id, buildAuditContext(req)));
+});

--- a/src/module/temps-deplacements/repository/temps-deplacements-rules.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements-rules.repository.ts
@@ -1,0 +1,222 @@
+import pool from "../../../config/database";
+import { effectiveRuleSetFromRows, type ContractRow, type HrRuleSet, type RuleSetRow } from "../services/temps-deplacements-rules";
+import type { DbQueryer } from "./temps-deplacements.repository";
+
+// -------------------------------------------------------------- T5 : contrats / horaires / règles + résolution
+
+export interface RuleSetInput {
+  name: string;
+  weekly_target_minutes: number;
+  daily_target_minutes: number;
+  overtime_threshold_1_minutes: number | null;
+  overtime_rate_1: number | null;
+  overtime_threshold_2_minutes: number | null;
+  overtime_rate_2: number | null;
+  rounding_rule: Record<string, unknown>;
+  break_rule: Record<string, unknown>;
+}
+export interface ContractInput {
+  employee_id: string;
+  contract_type: "H35" | "H39" | "PARTIAL" | "OTHER";
+  weekly_hours_target: number;
+  daily_hours_target: number | null;
+  start_date: string;
+  end_date: string | null;
+  rule_set_id: string | null;
+  active: boolean;
+}
+export interface ScheduleInput {
+  employee_id: string;
+  day_of_week: number;
+  expected_start: string | null;
+  expected_end: string | null;
+  expected_break_minutes: number;
+  flexible_start_window: number;
+  flexible_end_window: number;
+  active: boolean;
+}
+
+const RS_COLS = `id::text, name, weekly_target_minutes, daily_target_minutes,
+  overtime_threshold_1_minutes, overtime_rate_1, overtime_threshold_2_minutes, overtime_rate_2,
+  rounding_rule, break_rule, active, created_at::text, updated_at::text`;
+const CT_COLS = `id::text, employee_id::text, contract_type::text, weekly_hours_target, daily_hours_target,
+  start_date::text, end_date::text, active, rule_set_id::text, created_at::text, updated_at::text`;
+const SC_COLS = `id::text, employee_id::text, day_of_week, expected_start::text, expected_end::text,
+  expected_break_minutes, flexible_start_window, flexible_end_window, active`;
+
+// ---- Résolution des règles effectives (contrat couvrant la date, puis son rule_set éventuel) ----
+export async function repoGetEffectiveRuleSet(employeeId: string, date: string, q: DbQueryer = pool): Promise<HrRuleSet | null> {
+  const res = await q.query(
+    `SELECT c.id::text, c.contract_type::text, c.weekly_hours_target, c.daily_hours_target, c.rule_set_id::text,
+            rs.id::text AS rs_id, rs.name AS rs_name, rs.weekly_target_minutes, rs.daily_target_minutes,
+            rs.overtime_threshold_1_minutes, rs.overtime_rate_1, rs.overtime_threshold_2_minutes, rs.overtime_rate_2,
+            rs.rounding_rule, rs.break_rule, rs.active AS rs_active
+       FROM public.hr_employment_contracts c
+       LEFT JOIN public.hr_time_rule_sets rs ON rs.id = c.rule_set_id
+      WHERE c.employee_id = $1::uuid
+        AND c.start_date <= $2::date AND (c.end_date IS NULL OR c.end_date >= $2::date)
+      ORDER BY c.active DESC, c.start_date DESC
+      LIMIT 1`,
+    [employeeId, date]
+  );
+  const r = res.rows[0];
+  if (!r) return null;
+  const contract: ContractRow = {
+    id: String(r.id),
+    contract_type: String(r.contract_type),
+    weekly_hours_target: r.weekly_hours_target,
+    daily_hours_target: r.daily_hours_target ?? null,
+    rule_set_id: r.rule_set_id ?? null,
+  };
+  const ruleSet: RuleSetRow | null = r.rs_id
+    ? {
+        id: String(r.rs_id),
+        name: String(r.rs_name),
+        weekly_target_minutes: Number(r.weekly_target_minutes),
+        daily_target_minutes: Number(r.daily_target_minutes),
+        overtime_threshold_1_minutes: r.overtime_threshold_1_minutes ?? null,
+        overtime_rate_1: r.overtime_rate_1 ?? null,
+        overtime_threshold_2_minutes: r.overtime_threshold_2_minutes ?? null,
+        overtime_rate_2: r.overtime_rate_2 ?? null,
+        rounding_rule: r.rounding_rule,
+        break_rule: r.break_rule,
+        active: r.rs_active === true,
+      }
+    : null;
+  return effectiveRuleSetFromRows(contract, ruleSet);
+}
+
+// -------------------------------------------------------------- Employés (lecture pour pickers admin)
+export async function repoListEmployees(q: DbQueryer = pool) {
+  const res = await q.query(
+    `SELECT e.id::text, e.matricule, e.service, e.status::text, e.user_id, e.manager_user_id,
+            u.name, u.surname
+       FROM public.hr_employees e
+       LEFT JOIN public.users u ON u.id = e.user_id
+      ORDER BY e.matricule ASC LIMIT 1000`
+  );
+  return res.rows;
+}
+
+// -------------------------------------------------------------- Rule sets (CRUD)
+export async function repoListRuleSets(q: DbQueryer = pool) {
+  const res = await q.query(`SELECT ${RS_COLS} FROM public.hr_time_rule_sets ORDER BY active DESC, name ASC LIMIT 500`);
+  return res.rows;
+}
+export async function repoGetRuleSetById(id: string, q: DbQueryer = pool) {
+  const res = await q.query(`SELECT ${RS_COLS} FROM public.hr_time_rule_sets WHERE id = $1::uuid LIMIT 1`, [id]);
+  return res.rows[0] ?? null;
+}
+export async function repoInsertRuleSet(q: DbQueryer, i: RuleSetInput) {
+  const res = await q.query(
+    `INSERT INTO public.hr_time_rule_sets
+       (name, weekly_target_minutes, daily_target_minutes, overtime_threshold_1_minutes, overtime_rate_1,
+        overtime_threshold_2_minutes, overtime_rate_2, rounding_rule, break_rule)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb) RETURNING ${RS_COLS}`,
+    [i.name, i.weekly_target_minutes, i.daily_target_minutes, i.overtime_threshold_1_minutes, i.overtime_rate_1,
+     i.overtime_threshold_2_minutes, i.overtime_rate_2, JSON.stringify(i.rounding_rule ?? {}), JSON.stringify(i.break_rule ?? {})]
+  );
+  return res.rows[0];
+}
+export async function repoUpdateRuleSet(q: DbQueryer, id: string, i: RuleSetInput) {
+  const res = await q.query(
+    `UPDATE public.hr_time_rule_sets SET
+       name=$2, weekly_target_minutes=$3, daily_target_minutes=$4, overtime_threshold_1_minutes=$5, overtime_rate_1=$6,
+       overtime_threshold_2_minutes=$7, overtime_rate_2=$8, rounding_rule=$9::jsonb, break_rule=$10::jsonb, updated_at=now()
+     WHERE id=$1::uuid RETURNING ${RS_COLS}`,
+    [id, i.name, i.weekly_target_minutes, i.daily_target_minutes, i.overtime_threshold_1_minutes, i.overtime_rate_1,
+     i.overtime_threshold_2_minutes, i.overtime_rate_2, JSON.stringify(i.rounding_rule ?? {}), JSON.stringify(i.break_rule ?? {})]
+  );
+  return res.rows[0] ?? null;
+}
+export async function repoSetRuleSetActive(q: DbQueryer, id: string, active: boolean) {
+  const res = await q.query(
+    `UPDATE public.hr_time_rule_sets SET active=$2, updated_at=now() WHERE id=$1::uuid RETURNING ${RS_COLS}`,
+    [id, active]
+  );
+  return res.rows[0] ?? null;
+}
+
+// -------------------------------------------------------------- Contrats (CRUD ; 1 seul actif/employé)
+export async function repoListContracts(q: DbQueryer, employeeId?: string) {
+  if (employeeId) {
+    const res = await q.query(`SELECT ${CT_COLS} FROM public.hr_employment_contracts WHERE employee_id=$1::uuid ORDER BY start_date DESC LIMIT 500`, [employeeId]);
+    return res.rows;
+  }
+  const res = await q.query(`SELECT ${CT_COLS} FROM public.hr_employment_contracts ORDER BY start_date DESC LIMIT 500`);
+  return res.rows;
+}
+export async function repoGetContractById(id: string, q: DbQueryer = pool) {
+  const res = await q.query(`SELECT ${CT_COLS} FROM public.hr_employment_contracts WHERE id=$1::uuid LIMIT 1`, [id]);
+  return res.rows[0] ?? null;
+}
+export async function repoInsertContract(q: DbQueryer, i: ContractInput) {
+  const res = await q.query(
+    `INSERT INTO public.hr_employment_contracts
+       (employee_id, contract_type, weekly_hours_target, daily_hours_target, start_date, end_date, rule_set_id, active)
+     VALUES ($1::uuid,$2::hr_contract_type,$3,$4,$5::date,$6::date,$7,$8) RETURNING ${CT_COLS}`,
+    [i.employee_id, i.contract_type, i.weekly_hours_target, i.daily_hours_target, i.start_date, i.end_date, i.rule_set_id, i.active]
+  );
+  return res.rows[0];
+}
+export async function repoUpdateContract(q: DbQueryer, id: string, i: ContractInput) {
+  const res = await q.query(
+    `UPDATE public.hr_employment_contracts SET
+       contract_type=$2::hr_contract_type, weekly_hours_target=$3, daily_hours_target=$4,
+       start_date=$5::date, end_date=$6::date, rule_set_id=$7, active=$8, updated_at=now()
+     WHERE id=$1::uuid RETURNING ${CT_COLS}`,
+    [id, i.contract_type, i.weekly_hours_target, i.daily_hours_target, i.start_date, i.end_date, i.rule_set_id, i.active]
+  );
+  return res.rows[0] ?? null;
+}
+export async function repoSetContractActive(q: DbQueryer, id: string, active: boolean) {
+  const res = await q.query(`UPDATE public.hr_employment_contracts SET active=$2, updated_at=now() WHERE id=$1::uuid RETURNING ${CT_COLS}`, [id, active]);
+  return res.rows[0] ?? null;
+}
+
+// -------------------------------------------------------------- Horaires types (CRUD)
+export async function repoListSchedules(q: DbQueryer, employeeId: string) {
+  const res = await q.query(`SELECT ${SC_COLS} FROM public.hr_work_schedules WHERE employee_id=$1::uuid ORDER BY day_of_week ASC LIMIT 500`, [employeeId]);
+  return res.rows;
+}
+export async function repoInsertSchedule(q: DbQueryer, i: ScheduleInput) {
+  const res = await q.query(
+    `INSERT INTO public.hr_work_schedules
+       (employee_id, day_of_week, expected_start, expected_end, expected_break_minutes, flexible_start_window, flexible_end_window, active)
+     VALUES ($1::uuid,$2,$3::time,$4::time,$5,$6,$7,$8) RETURNING ${SC_COLS}`,
+    [i.employee_id, i.day_of_week, i.expected_start, i.expected_end, i.expected_break_minutes, i.flexible_start_window, i.flexible_end_window, i.active]
+  );
+  return res.rows[0];
+}
+export async function repoUpdateSchedule(q: DbQueryer, id: string, i: ScheduleInput) {
+  const res = await q.query(
+    `UPDATE public.hr_work_schedules SET
+       day_of_week=$2, expected_start=$3::time, expected_end=$4::time, expected_break_minutes=$5,
+       flexible_start_window=$6, flexible_end_window=$7, active=$8
+     WHERE id=$1::uuid RETURNING ${SC_COLS}`,
+    [id, i.day_of_week, i.expected_start, i.expected_end, i.expected_break_minutes, i.flexible_start_window, i.flexible_end_window, i.active]
+  );
+  return res.rows[0] ?? null;
+}
+export async function repoDeleteSchedule(q: DbQueryer, id: string): Promise<boolean> {
+  const res = await q.query(`DELETE FROM public.hr_work_schedules WHERE id=$1::uuid`, [id]);
+  return (res.rowCount ?? 0) > 0;
+}
+
+// -------------------------------------------------------------- Persistance du relevé hebdo (agrégat)
+export async function repoUpsertTimesheetWeek(
+  q: DbQueryer,
+  w: { employee_id: string; week_start: string; week_end: string; contract_minutes: number; worked_minutes: number; overtime_25_minutes: number; overtime_50_minutes: number; absence_minutes: number }
+): Promise<void> {
+  await q.query(
+    `INSERT INTO public.hr_timesheet_weeks
+       (employee_id, week_start, week_end, contract_minutes, worked_minutes, overtime_25_minutes, overtime_50_minutes, absence_minutes)
+     VALUES ($1::uuid,$2::date,$3::date,$4,$5,$6,$7,$8)
+     ON CONFLICT (employee_id, week_start) DO UPDATE SET
+       week_end=EXCLUDED.week_end, contract_minutes=EXCLUDED.contract_minutes, worked_minutes=EXCLUDED.worked_minutes,
+       overtime_25_minutes=EXCLUDED.overtime_25_minutes, overtime_50_minutes=EXCLUDED.overtime_50_minutes,
+       absence_minutes=EXCLUDED.absence_minutes, updated_at=now()
+     WHERE public.hr_timesheet_weeks.validation_status = 'DRAFT'`,
+    [w.employee_id, w.week_start, w.week_end, w.contract_minutes, w.worked_minutes, w.overtime_25_minutes, w.overtime_50_minutes, w.absence_minutes]
+  );
+}

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import * as adm from "../controllers/temps-deplacements-admin.controller";
 import * as cor from "../controllers/temps-deplacements-corrections.controller";
 import * as c from "../controllers/temps-deplacements.controller";
 
@@ -31,5 +32,20 @@ router.get("/team/today", cor.getTeamToday); // relevé du jour de l'équipe
 router.get("/team/anomalies", cor.getTeamAnomalies); // anomalies équipe du jour
 router.patch("/days/:id/validate", cor.validateDay); // valide une journée
 router.patch("/weeks/:id/validate", cor.validateWeek); // valide une semaine
+
+// T5 — administration RH (règles / contrats / horaires). Réservé aux rôles privilégiés (service).
+router.get("/admin/employees", adm.getEmployees);
+router.get("/admin/rule-sets", adm.getRuleSets);
+router.post("/admin/rule-sets", adm.postRuleSet);
+router.put("/admin/rule-sets/:id", adm.putRuleSet);
+router.patch("/admin/rule-sets/:id/active", adm.patchRuleSetActive);
+router.get("/admin/contracts", adm.getContracts);
+router.post("/admin/contracts", adm.postContract);
+router.put("/admin/contracts/:id", adm.putContract);
+router.patch("/admin/contracts/:id/active", adm.patchContractActive);
+router.get("/admin/schedules", adm.getSchedules);
+router.post("/admin/schedules", adm.postSchedule);
+router.put("/admin/schedules/:id", adm.putSchedule);
+router.delete("/admin/schedules/:id", adm.deleteScheduleHandler);
 
 export default router;

--- a/src/module/temps-deplacements/services/temps-deplacements-admin.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-admin.service.ts
@@ -1,0 +1,137 @@
+import { HttpError } from "../../../utils/httpError";
+import {
+  repoDeleteSchedule,
+  repoGetContractById,
+  repoGetRuleSetById,
+  repoInsertContract,
+  repoInsertRuleSet,
+  repoInsertSchedule,
+  repoListContracts,
+  repoListEmployees,
+  repoListRuleSets,
+  repoListSchedules,
+  repoSetContractActive,
+  repoSetRuleSetActive,
+  repoUpdateContract,
+  repoUpdateRuleSet,
+  repoUpdateSchedule,
+  type ContractInput,
+  type RuleSetInput,
+  type ScheduleInput,
+} from "../repository/temps-deplacements-rules.repository";
+import { insertAuditLog, isPgUniqueViolation, withTransaction, type AuditContext } from "../repository/temps-deplacements.repository";
+import { isHrPrivileged, type Actor } from "./temps-deplacements-corrections.service";
+
+// Toute l'administration RH est réservée aux rôles privilégiés (RH/Direction/Admin) — anti-IDOR :
+// un salarié n'a AUCUN accès à ces endpoints (403), et ne peut pas cibler un autre employé.
+function assertPrivileged(actor: Actor): void {
+  if (!isHrPrivileged(actor.role)) throw new HttpError(403, "HR_FORBIDDEN", "Administration RH réservée.");
+}
+
+async function audit(actor: Actor, ctx: AuditContext, action: string, entityType: string, entityId: string | null, details: Record<string, unknown>) {
+  await withTransaction((client) =>
+    insertAuditLog(client, ctx, { action, entity_type: entityType, entity_id: entityId, details })
+  );
+}
+
+// -------------------------------------------------------------- Employés (lecture pickers)
+export async function listEmployees(actor: Actor) {
+  assertPrivileged(actor);
+  return repoListEmployees();
+}
+
+// -------------------------------------------------------------- Rule sets
+export async function listRuleSets(actor: Actor) {
+  assertPrivileged(actor);
+  return repoListRuleSets();
+}
+export async function createRuleSet(actor: Actor, input: RuleSetInput, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction((client) => repoInsertRuleSet(client, input));
+  await audit(actor, ctx, "temps-deplacements.rule_set.create", "hr_time_rule_sets", row.id, { name: input.name });
+  return row;
+}
+export async function updateRuleSet(actor: Actor, id: string, input: RuleSetInput, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction((client) => repoUpdateRuleSet(client, id, input));
+  if (!row) throw new HttpError(404, "HR_RULE_SET_NOT_FOUND", "Règle introuvable.");
+  await audit(actor, ctx, "temps-deplacements.rule_set.update", "hr_time_rule_sets", id, { name: input.name });
+  return row;
+}
+export async function setRuleSetActive(actor: Actor, id: string, active: boolean, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction((client) => repoSetRuleSetActive(client, id, active));
+  if (!row) throw new HttpError(404, "HR_RULE_SET_NOT_FOUND", "Règle introuvable.");
+  await audit(actor, ctx, "temps-deplacements.rule_set.set_active", "hr_time_rule_sets", id, { active });
+  return row;
+}
+
+// -------------------------------------------------------------- Contrats
+export async function listContracts(actor: Actor, employeeId?: string) {
+  assertPrivileged(actor);
+  return withTransaction((client) => repoListContracts(client, employeeId));
+}
+export async function createContract(actor: Actor, input: ContractInput, ctx: AuditContext) {
+  assertPrivileged(actor);
+  try {
+    const row = await withTransaction((client) => repoInsertContract(client, input));
+    await audit(actor, ctx, "temps-deplacements.contract.create", "hr_employment_contracts", row.id, {
+      employee_id: input.employee_id, contract_type: input.contract_type,
+    });
+    return row;
+  } catch (err) {
+    if (isPgUniqueViolation(err)) throw new HttpError(409, "HR_CONTRACT_ACTIVE_EXISTS", "Un contrat actif existe déjà pour cet employé.");
+    throw err;
+  }
+}
+export async function updateContract(actor: Actor, id: string, input: ContractInput, ctx: AuditContext) {
+  assertPrivileged(actor);
+  try {
+    const row = await withTransaction((client) => repoUpdateContract(client, id, input));
+    if (!row) throw new HttpError(404, "HR_CONTRACT_NOT_FOUND", "Contrat introuvable.");
+    await audit(actor, ctx, "temps-deplacements.contract.update", "hr_employment_contracts", id, { contract_type: input.contract_type });
+    return row;
+  } catch (err) {
+    if (isPgUniqueViolation(err)) throw new HttpError(409, "HR_CONTRACT_ACTIVE_EXISTS", "Un contrat actif existe déjà pour cet employé.");
+    throw err;
+  }
+}
+export async function setContractActive(actor: Actor, id: string, active: boolean, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const existing = await repoGetContractById(id);
+  if (!existing) throw new HttpError(404, "HR_CONTRACT_NOT_FOUND", "Contrat introuvable.");
+  try {
+    const row = await withTransaction((client) => repoSetContractActive(client, id, active));
+    await audit(actor, ctx, "temps-deplacements.contract.set_active", "hr_employment_contracts", id, { active });
+    return row;
+  } catch (err) {
+    if (isPgUniqueViolation(err)) throw new HttpError(409, "HR_CONTRACT_ACTIVE_EXISTS", "Un contrat actif existe déjà pour cet employé.");
+    throw err;
+  }
+}
+
+// -------------------------------------------------------------- Horaires types
+export async function listSchedules(actor: Actor, employeeId: string) {
+  assertPrivileged(actor);
+  return withTransaction((client) => repoListSchedules(client, employeeId));
+}
+export async function createSchedule(actor: Actor, input: ScheduleInput, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction((client) => repoInsertSchedule(client, input));
+  await audit(actor, ctx, "temps-deplacements.schedule.create", "hr_work_schedules", row.id, { employee_id: input.employee_id, day_of_week: input.day_of_week });
+  return row;
+}
+export async function updateSchedule(actor: Actor, id: string, input: ScheduleInput, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction((client) => repoUpdateSchedule(client, id, input));
+  if (!row) throw new HttpError(404, "HR_SCHEDULE_NOT_FOUND", "Horaire introuvable.");
+  await audit(actor, ctx, "temps-deplacements.schedule.update", "hr_work_schedules", id, { day_of_week: input.day_of_week });
+  return row;
+}
+export async function deleteSchedule(actor: Actor, id: string, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const ok = await withTransaction((client) => repoDeleteSchedule(client, id));
+  if (!ok) throw new HttpError(404, "HR_SCHEDULE_NOT_FOUND", "Horaire introuvable.");
+  await audit(actor, ctx, "temps-deplacements.schedule.delete", "hr_work_schedules", id, {});
+  return { ok: true };
+}

--- a/src/module/temps-deplacements/services/temps-deplacements-rules.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-rules.ts
@@ -1,0 +1,169 @@
+// T5 — Moteur de règles (PUR, testable sans DB). Aucune valeur 35/39 en dur : tout vient soit d'un
+// hr_time_rule_sets, soit — à défaut — dérivé du contrat de l'employé (ses propres heures).
+
+export interface RoundingRule {
+  unit_minutes?: number; // pas d'arrondi si absent/0
+  mode?: "nearest" | "up" | "down";
+}
+export interface BreakRule {
+  min_break_minutes?: number; // pause minimale imposée
+  auto_deduct_after_minutes?: number; // au-delà de ce temps travaillé, la pause minimale est déduite
+}
+
+export interface HrRuleSet {
+  id: string;
+  name: string;
+  weekly_target_minutes: number;
+  daily_target_minutes: number;
+  overtime_threshold_1_minutes: number | null; // début heures sup taux 1 (défaut = cible hebdo)
+  overtime_rate_1: number | null; // ex. 1.25
+  overtime_threshold_2_minutes: number | null; // début heures sup taux 2
+  overtime_rate_2: number | null; // ex. 1.50
+  rounding_rule: RoundingRule;
+  break_rule: BreakRule;
+  active: boolean;
+}
+
+// Lignes brutes DB (numeric ⇒ string via pg).
+export interface ContractRow {
+  id: string;
+  contract_type: string;
+  weekly_hours_target: string | number;
+  daily_hours_target: string | number | null;
+  rule_set_id: string | null;
+}
+export interface RuleSetRow {
+  id: string;
+  name: string;
+  weekly_target_minutes: number;
+  daily_target_minutes: number;
+  overtime_threshold_1_minutes: number | null;
+  overtime_rate_1: string | number | null;
+  overtime_threshold_2_minutes: number | null;
+  overtime_rate_2: string | number | null;
+  rounding_rule: unknown;
+  break_rule: unknown;
+  active: boolean;
+}
+
+function toNum(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function parseRoundingRule(raw: unknown): RoundingRule {
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  const unit = toNum(r.unit_minutes);
+  const mode = r.mode === "up" || r.mode === "down" || r.mode === "nearest" ? r.mode : undefined;
+  return { ...(unit && unit > 0 ? { unit_minutes: unit } : {}), ...(mode ? { mode } : {}) };
+}
+export function parseBreakRule(raw: unknown): BreakRule {
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  const minB = toNum(r.min_break_minutes);
+  const after = toNum(r.auto_deduct_after_minutes);
+  return {
+    ...(minB && minB > 0 ? { min_break_minutes: minB } : {}),
+    ...(after && after > 0 ? { auto_deduct_after_minutes: after } : {}),
+  };
+}
+
+// Combine contrat + (éventuel) rule_set → règles effectives. Sans rule_set : dérive du CONTRAT
+// (heures propres du salarié ⇒ jamais de 35/39 codé en dur).
+export function effectiveRuleSetFromRows(contract: ContractRow, ruleSet: RuleSetRow | null): HrRuleSet {
+  if (ruleSet) {
+    return {
+      id: ruleSet.id,
+      name: ruleSet.name,
+      weekly_target_minutes: ruleSet.weekly_target_minutes,
+      daily_target_minutes: ruleSet.daily_target_minutes,
+      overtime_threshold_1_minutes: ruleSet.overtime_threshold_1_minutes,
+      overtime_rate_1: toNum(ruleSet.overtime_rate_1),
+      overtime_threshold_2_minutes: ruleSet.overtime_threshold_2_minutes,
+      overtime_rate_2: toNum(ruleSet.overtime_rate_2),
+      rounding_rule: parseRoundingRule(ruleSet.rounding_rule),
+      break_rule: parseBreakRule(ruleSet.break_rule),
+      active: ruleSet.active,
+    };
+  }
+  const weekly = Math.round((toNum(contract.weekly_hours_target) ?? 0) * 60);
+  const dailyRaw = toNum(contract.daily_hours_target);
+  const daily = dailyRaw != null ? Math.round(dailyRaw * 60) : weekly > 0 ? Math.round(weekly / 5) : 0;
+  return {
+    id: `contract:${contract.id}`,
+    name: `Dérivé du contrat (${contract.contract_type})`,
+    weekly_target_minutes: weekly,
+    daily_target_minutes: daily,
+    overtime_threshold_1_minutes: weekly > 0 ? weekly : null, // HS au-delà de la cible contractuelle
+    overtime_rate_1: 1.25,
+    overtime_threshold_2_minutes: null,
+    overtime_rate_2: null,
+    rounding_rule: {},
+    break_rule: {},
+    active: true,
+  };
+}
+
+// Arrondi du temps travaillé selon la règle (aucun si unit absent/0).
+export function applyRounding(minutes: number, rule: RoundingRule): number {
+  const unit = rule.unit_minutes ?? 0;
+  if (!unit || unit <= 0) return Math.max(0, Math.round(minutes));
+  const q = minutes / unit;
+  const rounded = rule.mode === "up" ? Math.ceil(q) : rule.mode === "down" ? Math.floor(q) : Math.round(q);
+  return Math.max(0, rounded * unit);
+}
+
+// Impose une pause minimale : au-delà de `auto_deduct_after_minutes` de travail, si la pause réelle est
+// inférieure au minimum, le déficit est déduit du temps travaillé.
+export function enforceMinimumBreak(workedMinutes: number, actualBreakMinutes: number, rule: BreakRule): number {
+  const minB = rule.min_break_minutes ?? 0;
+  const after = rule.auto_deduct_after_minutes ?? Number.POSITIVE_INFINITY;
+  if (minB > 0 && workedMinutes >= after && actualBreakMinutes < minB) {
+    return Math.max(0, workedMinutes - (minB - actualBreakMinutes));
+  }
+  return workedMinutes;
+}
+
+// Découpe le temps travaillé hebdo en normal / HS taux 1 (25) / HS taux 2 (50).
+export function splitWeeklyOvertime(
+  workedWeeklyMinutes: number,
+  rule: Pick<HrRuleSet, "weekly_target_minutes" | "overtime_threshold_1_minutes" | "overtime_threshold_2_minutes">
+): { normal: number; overtime25: number; overtime50: number } {
+  const t1 = rule.overtime_threshold_1_minutes ?? rule.weekly_target_minutes;
+  const t2 = rule.overtime_threshold_2_minutes ?? Number.POSITIVE_INFINITY;
+  const w = Math.max(0, workedWeeklyMinutes);
+  const normal = Math.min(w, t1);
+  const overtime25 = Math.max(0, Math.min(w, t2) - t1);
+  const overtime50 = Math.max(0, w - t2);
+  return { normal, overtime25, overtime50 };
+}
+
+// Temps travaillé effectif d'une journée : pause minimale imposée puis arrondi.
+export function effectiveDailyWorked(workedRaw: number, actualBreak: number, rule: HrRuleSet): number {
+  return applyRounding(enforceMinimumBreak(workedRaw, actualBreak, rule.break_rule), rule.rounding_rule);
+}
+
+// Agrégat hebdomadaire selon la règle. Sans règle (aucun contrat) : tout à zéro (pas d'attendu à juger).
+export function weeklyAggregate(
+  workedWeekly: number,
+  ruleSet: HrRuleSet | null
+): {
+  contract_minutes: number;
+  overtime_25_minutes: number;
+  overtime_50_minutes: number;
+  absence_minutes: number;
+  rule_set_name: string | null;
+} {
+  if (!ruleSet) {
+    return { contract_minutes: 0, overtime_25_minutes: 0, overtime_50_minutes: 0, absence_minutes: 0, rule_set_name: null };
+  }
+  const split = splitWeeklyOvertime(workedWeekly, ruleSet);
+  const contract = ruleSet.weekly_target_minutes;
+  return {
+    contract_minutes: contract,
+    overtime_25_minutes: split.overtime25,
+    overtime_50_minutes: split.overtime50,
+    absence_minutes: contract > 0 ? Math.max(0, contract - workedWeekly) : 0,
+    rule_set_name: ruleSet.name,
+  };
+}

--- a/src/module/temps-deplacements/services/temps-deplacements.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements.service.ts
@@ -2,6 +2,8 @@ import crypto from "node:crypto";
 import { HttpError } from "../../../utils/httpError";
 import * as repo from "../repository/temps-deplacements.repository";
 import type { AuditContext } from "../repository/temps-deplacements.repository";
+import { repoGetEffectiveRuleSet, repoUpsertTimesheetWeek } from "../repository/temps-deplacements-rules.repository";
+import { effectiveDailyWorked, weeklyAggregate } from "./temps-deplacements-rules";
 import type {
   CreateTimeEventInput,
   CreateTimeEventResult,
@@ -168,11 +170,15 @@ export function summarizeDay(events: HrTimeEvent[]): {
 // -------------------------------------------------------------- Relevé journalier
 export async function computeDailyTimesheet(employeeId: string, date: string): Promise<HrDailyTimesheet> {
   const events = await repo.repoListEventsForDay(employeeId, date);
-  const { firstIn, lastOut, breakMinutes: totalBreak, workedMinutes, openBreak } = summarizeDay(events);
+  const { firstIn, lastOut, breakMinutes: totalBreak, workedMinutes: workedRaw, openBreak } = summarizeDay(events);
 
-  const expected = await repo.repoGetDailyTargetMinutes(employeeId, date);
-  const overtime = Math.max(0, workedMinutes - expected);
-  const missing = Math.max(0, expected - workedMinutes);
+  // Règles effectives (contrat couvrant la date + rule_set éventuel) — jamais 35/39 en dur.
+  const ruleSet = await repoGetEffectiveRuleSet(employeeId, date);
+  const expected = ruleSet ? ruleSet.daily_target_minutes : 0;
+  // Pause minimale imposée + arrondi selon la règle (sinon temps brut).
+  const workedMinutes = ruleSet ? effectiveDailyWorked(workedRaw, totalBreak, ruleSet) : workedRaw;
+  const overtime = expected > 0 ? Math.max(0, workedMinutes - expected) : 0;
+  const missing = expected > 0 ? Math.max(0, expected - workedMinutes) : 0;
   const isPastDay = date < todayParis();
 
   const descriptors = detectTimeAnomalies(events, { openBreak, workedMinutes, totalBreak, isPastDay });
@@ -214,15 +220,41 @@ export async function computeWeeklyTimesheet(employeeId: string, weekStart: stri
     days.push(await computeDailyTimesheet(employeeId, addDays(weekStart, i)));
   }
   const worked = days.reduce((s, d) => s + d.worked_minutes, 0);
-  const expected = days.reduce((s, d) => s + d.expected_minutes, 0);
+  const weekEnd = addDays(weekStart, 6);
+
+  // Règles effectives de la semaine (contrat au lundi) → cible hebdo + découpe HS 25/50 configurable.
+  const ruleSet = await repoGetEffectiveRuleSet(employeeId, weekStart);
+  const agg = weeklyAggregate(worked, ruleSet);
+
+  // Persistance de l'agrégat hebdo (nécessaire à la validation T4 ; DRAFT uniquement).
+  try {
+    await repo.withTransaction((client) =>
+      repoUpsertTimesheetWeek(client, {
+        employee_id: employeeId,
+        week_start: weekStart,
+        week_end: weekEnd,
+        contract_minutes: agg.contract_minutes,
+        worked_minutes: worked,
+        overtime_25_minutes: agg.overtime_25_minutes,
+        overtime_50_minutes: agg.overtime_50_minutes,
+        absence_minutes: agg.absence_minutes,
+      })
+    );
+  } catch {
+    /* best-effort : ne bloque jamais la lecture du relevé */
+  }
+
   return {
     employee_id: employeeId,
     week_start: weekStart,
-    week_end: addDays(weekStart, 6),
+    week_end: weekEnd,
     worked_minutes: worked,
-    contract_minutes: expected,
-    overtime_minutes: Math.max(0, worked - expected),
-    absence_minutes: Math.max(0, expected - worked),
+    contract_minutes: agg.contract_minutes,
+    overtime_minutes: agg.overtime_25_minutes + agg.overtime_50_minutes,
+    overtime_25_minutes: agg.overtime_25_minutes,
+    overtime_50_minutes: agg.overtime_50_minutes,
+    absence_minutes: agg.absence_minutes,
+    rule_set_name: agg.rule_set_name,
     days,
   };
 }

--- a/src/module/temps-deplacements/types/temps-deplacements.types.ts
+++ b/src/module/temps-deplacements/types/temps-deplacements.types.ts
@@ -66,8 +66,11 @@ export interface HrWeeklyTimesheet {
   week_end: string;
   worked_minutes: number;
   contract_minutes: number;
-  overtime_minutes: number;
+  overtime_minutes: number; // total HS (= 25 + 50), rétro-compat
+  overtime_25_minutes: number; // T5 — HS taux 1 (règle configurable)
+  overtime_50_minutes: number; // T5 — HS taux 2
   absence_minutes: number;
+  rule_set_name: string | null; // règle appliquée (traçabilité)
   days: HrDailyTimesheet[];
 }
 

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -64,3 +64,57 @@ export type CreateAdjustmentBody = z.infer<typeof createAdjustmentSchema>;
 
 export const uuidParamsSchema = z.object({ id: z.string().uuid("id (uuid) attendu") });
 export const teamAnomaliesQuerySchema = z.object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional() });
+
+// --- T5 : admin RH (règles / contrats / horaires) ---
+const nonNegInt = z.number().int().min(0);
+const timeOfDay = z.string().regex(/^\d{2}:\d{2}(:\d{2})?$/, "Heure attendue HH:MM").nullable();
+
+export const HR_CONTRACT_TYPES = ["H35", "H39", "PARTIAL", "OTHER"] as const;
+
+// Règle de calcul — JAMAIS de 35/39 en dur : les cibles sont saisies ici (minutes).
+export const ruleSetBodySchema = z
+  .object({
+    name: z.string().trim().min(2).max(200),
+    weekly_target_minutes: nonNegInt.max(10080), // ≤ 7j
+    daily_target_minutes: nonNegInt.max(1440),
+    overtime_threshold_1_minutes: nonNegInt.max(10080).nullable().default(null),
+    overtime_rate_1: z.number().min(1).max(5).nullable().default(null),
+    overtime_threshold_2_minutes: nonNegInt.max(10080).nullable().default(null),
+    overtime_rate_2: z.number().min(1).max(5).nullable().default(null),
+    rounding_rule: z.record(z.unknown()).default({}),
+    break_rule: z.record(z.unknown()).default({}),
+  })
+  .strict();
+export type RuleSetBody = z.infer<typeof ruleSetBodySchema>;
+
+export const contractBodySchema = z
+  .object({
+    employee_id: z.string().uuid(),
+    contract_type: z.enum(HR_CONTRACT_TYPES),
+    weekly_hours_target: z.number().min(0).max(168),
+    daily_hours_target: z.number().min(0).max(24).nullable().default(null),
+    start_date: dateOnly,
+    end_date: dateOnly.nullable().default(null),
+    rule_set_id: z.string().uuid().nullable().default(null),
+    active: z.boolean().default(true),
+  })
+  .strict();
+export type ContractBody = z.infer<typeof contractBodySchema>;
+
+export const scheduleBodySchema = z
+  .object({
+    employee_id: z.string().uuid(),
+    day_of_week: z.number().int().min(0).max(6),
+    expected_start: timeOfDay.default(null),
+    expected_end: timeOfDay.default(null),
+    expected_break_minutes: nonNegInt.max(1440).default(0),
+    flexible_start_window: nonNegInt.max(240).default(0),
+    flexible_end_window: nonNegInt.max(240).default(0),
+    active: z.boolean().default(true),
+  })
+  .strict();
+export type ScheduleBody = z.infer<typeof scheduleBodySchema>;
+
+export const setActiveSchema = z.object({ active: z.boolean() }).strict();
+export const listContractsQuerySchema = z.object({ employee_id: z.string().uuid().optional() });
+export const listSchedulesQuerySchema = z.object({ employee_id: z.string().uuid("employee_id (uuid) requis") });


### PR DESCRIPTION
## T5 — Contrats / horaires / règles (Refs #119)

Rend les calculs exploitables (35h/39h/partiel), **jamais 35/39 en dur** : cibles, seuils HS 25/50, taux, arrondis, pauses viennent de `hr_time_rule_sets` ou sont dérivés du contrat.

- **Migration** additive `users_role_check` → `Responsable RH` (écart T4 fermé, appliquée cerp_test).
- **Moteur PUR** `temps-deplacements-rules.ts` + résolution `repoGetEffectiveRuleSet(employeeId, date)` par contrat **couvrant la date** (changement de contrat OK).
- `computeDaily/WeeklyTimesheet` câblés sur les règles + persistance `hr_timesheet_weeks` (débloque validation semaine T4).
- **CRUD admin RH** (règles/contrats/horaires, privilégié + audit) ; 1 contrat actif/employé (409) ; `GET /admin/employees`.

**Tests** : 19 unit · suite **229** verte · tsc 0. **Smoke cerp_test** (BEGIN/ROLLBACK, 0 résidu) : one-active refusé, résolution H35@mars / H39@août, 0 avant contrat, upsert 2400/300.

**Aucun cerp_prod, aucun main.** Voir `docs/temps-deplacements-t5-evidence.md`.