### PR TITLE
feat(temps-deplacements): T7 — exports paie CSV/PDF figés + checksum

### DIFF
--- a/docs/temps-deplacements-t7-evidence.md
+++ b/docs/temps-deplacements-t7-evidence.md
@@ -1,0 +1,34 @@
+# T7 — Exports paie CSV/PDF : preuves
+
+Objectif : exports paie **figés** + **checksum**, CSV `;` UTF-8 BOM et PDF récap, **sans XLSX ni
+dépendance Excel**. Issue #119.
+
+## Livré
+
+- **Générateurs PURS** `services/temps-deplacements-exports.ts` : `toCsv` (séparateur `;`, BOM UTF-8,
+  CRLF, échappement `; " CR LF`), `buildPayrollCsv`, `minutesToDecimalHours`, `sha256Hex`, `buildPayrollPdf`
+  (pdfkit, police Helvetica intégrée — déjà en dépendance, **aucun ajout**).
+- **Lot figé** : `createExport` gèle les octets (base64) dans `hr_payroll_export_batches.frozen_snapshot_json`
+  + `checksum` SHA-256 en colonne. Re-téléchargement = octets **identiques**, intégrité **vérifiée**
+  (`getExportFile` recalcule le checksum → 409 si altération).
+- **Endpoints** (`/time-clock/admin/exports`, privilégiés) : `POST` (génère+fige), `GET` (liste, sans
+  octets), `GET /:id/download` (octets + en-têtes `Content-Disposition` + `X-Checksum-SHA256`).
+- **Frontend** : onglet « Exports paie » (période + format → générer ; liste + checksum + téléchargement
+  via `httpBlob` authentifié).
+
+## Tests (12 verts) — suite backend **241 / 48 fichiers**, `tsc` 0 ; frontend **103**, build OK
+
+`t7-exports.test.ts` (6, pur) : BOM + `;` + CRLF, échappement, minutes→heures, ligne paie complète,
+checksum SHA-256 connu (`sha256('abc')`), PDF `%PDF`. `t7-service.test.ts` (6) : CSV figé (base64 =
+octets, checksum exact) + audit, période invalide 400, salarié 403, intégrité (checksum OK → octets ;
+altéré → 409), 404/403.
+
+## Smoke SQL cerp_test (BEGIN…ROLLBACK, 0 résidu)
+
+```
+1 PERIOD_QUERY: matches=1 (attendu 1)
+2 BATCH_INSERT: format=CSV checksum=ba7816bf status=GENERATED row_count=1 (attendu CSV/ba7816bf/GENERATED/1)
+```
+
+Source des lignes = `hr_timesheet_weeks` (agrégats persistés par T5). Un export vide est possible tant que
+les semaines ne sont pas calculées/persistées (dépend des règles T5 + du pointage).

--- a/src/__tests__/temps-deplacements-t7-exports.test.ts
+++ b/src/__tests__/temps-deplacements-t7-exports.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPayrollCsv,
+  buildPayrollPdf,
+  minutesToDecimalHours,
+  payrollRowToCsvCells,
+  sha256Hex,
+  toCsv,
+  type PayrollWeekRow,
+} from "../module/temps-deplacements/services/temps-deplacements-exports";
+
+const row: PayrollWeekRow = {
+  matricule: "TD001", name: "Jean", surname: "Dupont", week_start: "2026-03-02", week_end: "2026-03-08",
+  worked_minutes: 2400, contract_minutes: 2100, overtime_25_minutes: 300, overtime_50_minutes: 0, absence_minutes: 0,
+};
+
+describe("T7 — CSV (séparateur ; + BOM UTF-8 + échappement)", () => {
+  it("préfixe le BOM UTF-8 et sépare par ;", () => {
+    const csv = toCsv(["A", "B"], [["1", "2"]]);
+    expect(csv.charCodeAt(0)).toBe(0xfeff); // BOM
+    expect(csv).toContain("A;B\r\n");
+    expect(csv.endsWith("\r\n")).toBe(true);
+  });
+  it("échappe les champs contenant ; \" ou saut de ligne", () => {
+    expect(toCsv(["X"], [["a;b"]])).toContain('"a;b"');
+    expect(toCsv(["X"], [['il a dit "oui"']])).toContain('"il a dit ""oui"""');
+  });
+  it("minutes → heures décimales", () => {
+    expect(minutesToDecimalHours(90)).toBe("1.50");
+    expect(minutesToDecimalHours(2100)).toBe("35.00");
+    expect(minutesToDecimalHours(0)).toBe("0.00");
+  });
+  it("ligne paie → cellules, CSV complet avec en-tête", () => {
+    expect(payrollRowToCsvCells(row)).toEqual(["TD001", "Dupont", "Jean", "2026-03-02", "2026-03-08", "40.00", "35.00", "5.00", "0.00", "0.00"]);
+    const csv = buildPayrollCsv([row]);
+    expect(csv).toContain("Matricule;Nom;Prénom");
+    expect(csv).toContain("TD001;Dupont;Jean;2026-03-02;2026-03-08;40.00;35.00;5.00;0.00;0.00");
+  });
+});
+
+describe("T7 — checksum SHA-256 déterministe", () => {
+  it("hache de façon stable et connue", () => {
+    expect(sha256Hex("abc")).toBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    const csv = buildPayrollCsv([row]);
+    expect(sha256Hex(csv)).toBe(sha256Hex(csv)); // reproductible
+  });
+});
+
+describe("T7 — PDF (pdfkit, sans dépendance Excel)", () => {
+  it("produit un buffer PDF valide (%PDF)", async () => {
+    const buf = await buildPayrollPdf({ periodStart: "2026-03-01", periodEnd: "2026-03-31" }, [row]);
+    expect(buf.length).toBeGreaterThan(100);
+    expect(buf.subarray(0, 4).toString("latin1")).toBe("%PDF");
+  });
+});

--- a/src/__tests__/temps-deplacements-t7-service.test.ts
+++ b/src/__tests__/temps-deplacements-t7-service.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-exports.repository", () => ({
+  repoListWeeksForPeriod: vi.fn(),
+  repoInsertExportBatch: vi.fn(),
+  repoListExportBatches: vi.fn(),
+  repoGetExportBatch: vi.fn(),
+}));
+vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", async (io) => {
+  const actual = await io<typeof import("../module/temps-deplacements/repository/temps-deplacements.repository")>();
+  return {
+    ...actual,
+    withTransaction: vi.fn(async (fn: (c: unknown) => unknown) => fn({ query: vi.fn() })),
+    insertAuditLog: vi.fn(async () => undefined),
+  };
+});
+
+import * as expRepo from "../module/temps-deplacements/repository/temps-deplacements-exports.repository";
+import * as baseRepo from "../module/temps-deplacements/repository/temps-deplacements.repository";
+import { buildPayrollCsv, sha256Hex, type PayrollWeekRow } from "../module/temps-deplacements/services/temps-deplacements-exports";
+import * as svc from "../module/temps-deplacements/services/temps-deplacements-exports.service";
+
+const repo = vi.mocked(expRepo);
+const base = vi.mocked(baseRepo);
+const AUDIT = { user_id: 9, ip: null, user_agent: null, device_type: null, os: null, browser: null, path: null, page_key: null, client_session_id: null };
+const RH = { id: 9, role: "Responsable RH" };
+const SALARIE = { id: 2, role: "Employee" };
+const WEEK: PayrollWeekRow = {
+  matricule: "TD001", name: "Jean", surname: "Dupont", week_start: "2026-03-02", week_end: "2026-03-08",
+  worked_minutes: 2400, contract_minutes: 2100, overtime_25_minutes: 300, overtime_50_minutes: 0, absence_minutes: 0,
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("T7 — createExport (figé + checksum, privilégié)", () => {
+  it("CSV : octets gelés (base64) + checksum SHA-256 exact + audit", async () => {
+    repo.repoListWeeksForPeriod.mockResolvedValue([WEEK]);
+    repo.repoInsertExportBatch.mockImplementation(async (_c, i) => ({ id: "b1", ...i, status: "GENERATED", exported_at: "t" }));
+    const r = await svc.createExport(RH, { period_start: "2026-03-01", period_end: "2026-03-31", format: "CSV" }, AUDIT);
+    expect(r.row_count).toBe(1);
+
+    const arg = repo.repoInsertExportBatch.mock.calls[0][1];
+    const expectedCsv = buildPayrollCsv([WEEK]);
+    const expectedChecksum = sha256Hex(Buffer.from(expectedCsv, "utf-8"));
+    expect(arg.checksum).toBe(expectedChecksum);
+    const frozen = arg.frozen_snapshot_json as { file_base64: string; row_count: number };
+    expect(Buffer.from(frozen.file_base64, "base64").toString("utf-8")).toBe(expectedCsv); // gelé identique
+    expect(base.insertAuditLog).toHaveBeenCalledWith(expect.anything(), AUDIT, expect.objectContaining({ action: "temps-deplacements.export.create" }));
+  });
+  it("période invalide (fin < début) → 400", async () => {
+    await expect(svc.createExport(RH, { period_start: "2026-03-31", period_end: "2026-03-01", format: "CSV" }, AUDIT))
+      .rejects.toMatchObject({ status: 400, code: "HR_EXPORT_BAD_PERIOD" });
+  });
+  it("un salarié ne peut PAS exporter → 403", async () => {
+    await expect(svc.createExport(SALARIE, { period_start: "2026-03-01", period_end: "2026-03-31", format: "CSV" }, AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+    expect(repo.repoInsertExportBatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("T7 — getExportFile (intégrité vérifiée)", () => {
+  const csv = buildPayrollCsv([WEEK]);
+  const good = { file_base64: Buffer.from(csv, "utf-8").toString("base64"), filename: "paie.csv", content_type: "text/csv; charset=utf-8" };
+
+  it("checksum correct → renvoie les octets figés", async () => {
+    repo.repoGetExportBatch.mockResolvedValue({ id: "b1", checksum: sha256Hex(Buffer.from(csv, "utf-8")), frozen_snapshot_json: good });
+    const f = await svc.getExportFile(RH, "11111111-1111-4111-8111-111111111111");
+    expect(f.buffer.toString("utf-8")).toBe(csv);
+  });
+  it("checksum incohérent (altération) → 409", async () => {
+    repo.repoGetExportBatch.mockResolvedValue({ id: "b1", checksum: "deadbeef", frozen_snapshot_json: good });
+    await expect(svc.getExportFile(RH, "11111111-1111-4111-8111-111111111111")).rejects.toMatchObject({ status: 409, code: "HR_EXPORT_CHECKSUM_MISMATCH" });
+  });
+  it("introuvable → 404 ; salarié → 403", async () => {
+    repo.repoGetExportBatch.mockResolvedValue(null);
+    await expect(svc.getExportFile(RH, "11111111-1111-4111-8111-111111111111")).rejects.toMatchObject({ status: 404 });
+    await expect(svc.getExportFile(SALARIE, "11111111-1111-4111-8111-111111111111")).rejects.toMatchObject({ status: 403 });
+  });
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements-exports.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements-exports.controller.ts
@@ -1,0 +1,25 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import * as svc from "../services/temps-deplacements-exports.service";
+import { exportBodySchema, uuidParamsSchema } from "../validators/temps-deplacements.validators";
+import { buildAuditContext, requireUser } from "./temps-deplacements.controller";
+
+export const postExport = asyncHandler(async (req: Request, res: Response) => {
+  const body = exportBodySchema.parse(req.body);
+  const batch = await svc.createExport(requireUser(req), body, buildAuditContext(req));
+  res.status(201).json(batch);
+});
+
+export const getExports = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await svc.listExports(requireUser(req)));
+});
+
+// Télécharge les octets FIGÉS + expose le checksum (intégrité vérifiée côté service).
+export const downloadExport = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const file = await svc.getExportFile(requireUser(req), id);
+  res.setHeader("Content-Type", file.contentType);
+  res.setHeader("Content-Disposition", `attachment; filename="${file.filename}"`);
+  res.setHeader("X-Checksum-SHA256", file.checksum);
+  res.send(file.buffer);
+});

--- a/src/module/temps-deplacements/repository/temps-deplacements-exports.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements-exports.repository.ts
@@ -1,0 +1,73 @@
+import pool from "../../../config/database";
+import type { PayrollWeekRow } from "../services/temps-deplacements-exports";
+import type { DbQueryer } from "./temps-deplacements.repository";
+
+// T7 — lecture des agrégats hebdo d'une période + persistance des lots d'export (figés + checksum).
+
+export async function repoListWeeksForPeriod(periodStart: string, periodEnd: string, q: DbQueryer = pool): Promise<PayrollWeekRow[]> {
+  const res = await q.query(
+    `SELECT e.matricule, u.name, u.surname,
+            w.week_start::text, w.week_end::text,
+            w.worked_minutes, w.contract_minutes, w.overtime_25_minutes, w.overtime_50_minutes, w.absence_minutes
+       FROM public.hr_timesheet_weeks w
+       JOIN public.hr_employees e ON e.id = w.employee_id
+       LEFT JOIN public.users u ON u.id = e.user_id
+      WHERE w.week_start >= $1::date AND w.week_start <= $2::date
+      ORDER BY e.matricule ASC, w.week_start ASC
+      LIMIT 5000`,
+    [periodStart, periodEnd]
+  );
+  return res.rows.map((r) => ({
+    matricule: String(r.matricule),
+    name: (r.name as string | null) ?? null,
+    surname: (r.surname as string | null) ?? null,
+    week_start: String(r.week_start),
+    week_end: String(r.week_end),
+    worked_minutes: Number(r.worked_minutes),
+    contract_minutes: Number(r.contract_minutes),
+    overtime_25_minutes: Number(r.overtime_25_minutes),
+    overtime_50_minutes: Number(r.overtime_50_minutes),
+    absence_minutes: Number(r.absence_minutes),
+  }));
+}
+
+export interface ExportBatchInsert {
+  period_start: string;
+  period_end: string;
+  exported_by: number;
+  format: "CSV" | "PDF";
+  frozen_snapshot_json: Record<string, unknown>;
+  checksum: string;
+}
+
+export async function repoInsertExportBatch(q: DbQueryer, i: ExportBatchInsert) {
+  const res = await q.query(
+    `INSERT INTO public.hr_payroll_export_batches
+       (period_start, period_end, exported_by, format, frozen_snapshot_json, checksum, status)
+     VALUES ($1::date,$2::date,$3,$4::hr_export_format,$5::jsonb,$6,'GENERATED'::hr_export_status)
+     RETURNING id::text, period_start::text, period_end::text, exported_by, format::text, checksum, status::text, exported_at::text`,
+    [i.period_start, i.period_end, i.exported_by, i.format, JSON.stringify(i.frozen_snapshot_json), i.checksum]
+  );
+  return res.rows[0];
+}
+
+// Métadonnées (sans le fichier base64 — on n'expose pas les octets dans la liste).
+export async function repoListExportBatches(q: DbQueryer = pool) {
+  const res = await q.query(
+    `SELECT id::text, period_start::text, period_end::text, exported_by, format::text, checksum, status::text,
+            exported_at::text, (frozen_snapshot_json->>'row_count')::int AS row_count
+       FROM public.hr_payroll_export_batches
+      ORDER BY exported_at DESC LIMIT 500`
+  );
+  return res.rows;
+}
+
+export async function repoGetExportBatch(id: string, q: DbQueryer = pool) {
+  const res = await q.query(
+    `SELECT id::text, period_start::text, period_end::text, exported_by, format::text, checksum, status::text,
+            exported_at::text, frozen_snapshot_json
+       FROM public.hr_payroll_export_batches WHERE id = $1::uuid LIMIT 1`,
+    [id]
+  );
+  return res.rows[0] ?? null;
+}

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import * as adm from "../controllers/temps-deplacements-admin.controller";
 import * as cor from "../controllers/temps-deplacements-corrections.controller";
+import * as exp from "../controllers/temps-deplacements-exports.controller";
 import * as c from "../controllers/temps-deplacements.controller";
 
 // Monté après le socle authenticateToken (v1.routes.ts) → JWT requis d'office.
@@ -47,5 +48,10 @@ router.get("/admin/schedules", adm.getSchedules);
 router.post("/admin/schedules", adm.postSchedule);
 router.put("/admin/schedules/:id", adm.putSchedule);
 router.delete("/admin/schedules/:id", adm.deleteScheduleHandler);
+
+// T7 — exports paie figés (CSV `;`+BOM / PDF) + checksum. Réservé aux rôles privilégiés (service).
+router.get("/admin/exports", exp.getExports);
+router.post("/admin/exports", exp.postExport);
+router.get("/admin/exports/:id/download", exp.downloadExport);
 
 export default router;

--- a/src/module/temps-deplacements/services/temps-deplacements-exports.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-exports.service.ts
@@ -1,0 +1,95 @@
+import { HttpError } from "../../../utils/httpError";
+import {
+  repoGetExportBatch,
+  repoInsertExportBatch,
+  repoListExportBatches,
+  repoListWeeksForPeriod,
+} from "../repository/temps-deplacements-exports.repository";
+import { insertAuditLog, withTransaction, type AuditContext } from "../repository/temps-deplacements.repository";
+import { isHrPrivileged, type Actor } from "./temps-deplacements-corrections.service";
+import { buildPayrollCsv, buildPayrollPdf, sha256Hex, type PayrollWeekRow } from "./temps-deplacements-exports";
+
+function assertPrivileged(actor: Actor): void {
+  if (!isHrPrivileged(actor.role)) throw new HttpError(403, "HR_FORBIDDEN", "Export réservé aux responsables RH / direction.");
+}
+
+export interface ExportFile {
+  filename: string;
+  contentType: string;
+  buffer: Buffer;
+  checksum: string;
+}
+
+async function renderFile(format: "CSV" | "PDF", periodStart: string, periodEnd: string, rows: PayrollWeekRow[]): Promise<ExportFile> {
+  if (format === "CSV") {
+    const buffer = Buffer.from(buildPayrollCsv(rows), "utf-8");
+    return { filename: `paie_${periodStart}_${periodEnd}.csv`, contentType: "text/csv; charset=utf-8", buffer, checksum: sha256Hex(buffer) };
+  }
+  const buffer = await buildPayrollPdf({ periodStart, periodEnd }, rows);
+  return { filename: `paie_${periodStart}_${periodEnd}.pdf`, contentType: "application/pdf", buffer, checksum: sha256Hex(buffer) };
+}
+
+// Crée un lot d'export FIGÉ : octets gelés (base64) + checksum SHA-256 en base → re-téléchargement identique.
+export async function createExport(
+  actor: Actor,
+  input: { period_start: string; period_end: string; format: "CSV" | "PDF" },
+  audit: AuditContext
+) {
+  assertPrivileged(actor);
+  if (input.period_end < input.period_start) throw new HttpError(400, "HR_EXPORT_BAD_PERIOD", "Période invalide (fin < début).");
+
+  const rows = await repoListWeeksForPeriod(input.period_start, input.period_end);
+  const file = await renderFile(input.format, input.period_start, input.period_end, rows);
+
+  const frozen = {
+    row_count: rows.length,
+    rows, // conservé pour transparence/audit (recalculable)
+    file_base64: file.buffer.toString("base64"),
+    filename: file.filename,
+    content_type: file.contentType,
+    generated_meta: { period_start: input.period_start, period_end: input.period_end, format: input.format },
+  };
+
+  const batch = await withTransaction(async (client) => {
+    const row = await repoInsertExportBatch(client, {
+      period_start: input.period_start,
+      period_end: input.period_end,
+      exported_by: actor.id,
+      format: input.format,
+      frozen_snapshot_json: frozen,
+      checksum: file.checksum,
+    });
+    await insertAuditLog(client, audit, {
+      action: "temps-deplacements.export.create",
+      entity_type: "hr_payroll_export_batches",
+      entity_id: row.id,
+      details: { format: input.format, period_start: input.period_start, period_end: input.period_end, row_count: rows.length, checksum: file.checksum },
+    });
+    return row;
+  });
+
+  return { ...batch, row_count: rows.length };
+}
+
+export async function listExports(actor: Actor) {
+  assertPrivileged(actor);
+  return repoListExportBatches();
+}
+
+// Renvoie les octets figés + VÉRIFIE l'intégrité (checksum stocké == checksum recalculé sur les octets).
+export async function getExportFile(actor: Actor, id: string): Promise<ExportFile> {
+  assertPrivileged(actor);
+  const batch = await repoGetExportBatch(id);
+  if (!batch) throw new HttpError(404, "HR_EXPORT_NOT_FOUND", "Lot d'export introuvable.");
+  const frozen = (batch.frozen_snapshot_json ?? {}) as { file_base64?: string; filename?: string; content_type?: string };
+  if (!frozen.file_base64) throw new HttpError(409, "HR_EXPORT_NO_FILE", "Lot sans fichier figé.");
+  const buffer = Buffer.from(frozen.file_base64, "base64");
+  const recomputed = sha256Hex(buffer);
+  if (recomputed !== batch.checksum) throw new HttpError(409, "HR_EXPORT_CHECKSUM_MISMATCH", "Intégrité de l'export compromise.");
+  return {
+    filename: frozen.filename ?? `export_${id}`,
+    contentType: frozen.content_type ?? "application/octet-stream",
+    buffer,
+    checksum: batch.checksum,
+  };
+}

--- a/src/module/temps-deplacements/services/temps-deplacements-exports.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-exports.ts
@@ -1,0 +1,113 @@
+import crypto from "node:crypto";
+import PDFDocument from "pdfkit";
+
+// T7 — Générateurs d'export PURS (CSV `;` + BOM UTF-8, PDF récap) + checksum. Aucune dépendance Excel/XLSX.
+
+export interface PayrollWeekRow {
+  matricule: string;
+  name: string | null;
+  surname: string | null;
+  week_start: string;
+  week_end: string;
+  worked_minutes: number;
+  contract_minutes: number;
+  overtime_25_minutes: number;
+  overtime_50_minutes: number;
+  absence_minutes: number;
+}
+
+export const CSV_HEADER = [
+  "Matricule", "Nom", "Prénom", "Début semaine", "Fin semaine",
+  "H. travaillées", "H. contractuelles", "HS 25%", "HS 50%", "H. absence",
+] as const;
+
+// Minutes → heures décimales (point), 2 décimales. 90 → "1.50".
+export function minutesToDecimalHours(min: number): string {
+  return (min / 60).toFixed(2);
+}
+
+export function payrollRowToCsvCells(r: PayrollWeekRow): string[] {
+  return [
+    r.matricule,
+    r.surname ?? "",
+    r.name ?? "",
+    r.week_start,
+    r.week_end,
+    minutesToDecimalHours(r.worked_minutes),
+    minutesToDecimalHours(r.contract_minutes),
+    minutesToDecimalHours(r.overtime_25_minutes),
+    minutesToDecimalHours(r.overtime_50_minutes),
+    minutesToDecimalHours(r.absence_minutes),
+  ];
+}
+
+// Échappement CSV : guillemets si le champ contient ; " CR ou LF.
+function escapeCsv(value: string): string {
+  const s = String(value ?? "");
+  return /[;"\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+// CSV français : séparateur `;`, BOM UTF-8, fins de ligne CRLF (compatible tableurs FR).
+export function toCsv(header: readonly string[], rows: string[][]): string {
+  const lines = [header as readonly string[], ...rows].map((r) => r.map((c) => escapeCsv(String(c))).join(";"));
+  return "﻿" + lines.join("\r\n") + "\r\n";
+}
+
+export function buildPayrollCsv(rows: PayrollWeekRow[]): string {
+  return toCsv(CSV_HEADER, rows.map(payrollRowToCsvCells));
+}
+
+export function sha256Hex(data: string | Buffer): string {
+  return crypto.createHash("sha256").update(data).digest("hex");
+}
+
+// PDF récapitulatif (pdfkit, police Helvetica intégrée — aucun fichier de police requis).
+export function buildPayrollPdf(meta: { periodStart: string; periodEnd: string }, rows: PayrollWeekRow[]): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    try {
+      const doc = new PDFDocument({ margin: 36, size: "A4" });
+      const chunks: Buffer[] = [];
+      doc.on("data", (c: Buffer) => chunks.push(c));
+      doc.on("end", () => resolve(Buffer.concat(chunks)));
+      doc.on("error", reject);
+
+      doc.fontSize(15).text("Récapitulatif temps — paie", { align: "left" });
+      doc.moveDown(0.3).fontSize(10).fillColor("#555").text(`Période : ${meta.periodStart} → ${meta.periodEnd}`);
+      doc.fillColor("#000").moveDown(0.8);
+
+      const cols = ["Matricule", "Salarié", "Semaine", "Trav.", "Contrat", "HS25", "HS50", "Abs."];
+      const widths = [70, 130, 90, 45, 50, 40, 40, 45];
+      const startX = doc.x;
+      let y = doc.y;
+      const drawRow = (cells: string[], bold: boolean) => {
+        doc.fontSize(8).font(bold ? "Helvetica-Bold" : "Helvetica");
+        let x = startX;
+        cells.forEach((c, i) => {
+          doc.text(c, x + 2, y + 2, { width: widths[i] - 4, ellipsis: true });
+          x += widths[i];
+        });
+        y += 16;
+        if (y > 780) { doc.addPage(); y = doc.y; }
+      };
+      drawRow([...cols], true);
+      for (const r of rows) {
+        drawRow(
+          [
+            r.matricule,
+            `${r.surname ?? ""} ${r.name ?? ""}`.trim(),
+            r.week_start,
+            minutesToDecimalHours(r.worked_minutes),
+            minutesToDecimalHours(r.contract_minutes),
+            minutesToDecimalHours(r.overtime_25_minutes),
+            minutesToDecimalHours(r.overtime_50_minutes),
+            minutesToDecimalHours(r.absence_minutes),
+          ],
+          false
+        );
+      }
+      doc.end();
+    } catch (err) {
+      reject(err);
+    }
+  });
+}

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -116,5 +116,12 @@ export const scheduleBodySchema = z
 export type ScheduleBody = z.infer<typeof scheduleBodySchema>;
 
 export const setActiveSchema = z.object({ active: z.boolean() }).strict();
+
+// --- T7 : exports paie ---
+export const HR_EXPORT_FORMATS = ["CSV", "PDF"] as const;
+export const exportBodySchema = z
+  .object({ period_start: dateOnly, period_end: dateOnly, format: z.enum(HR_EXPORT_FORMATS) })
+  .strict();
+export type ExportBody = z.infer<typeof exportBodySchema>;
 export const listContractsQuerySchema = z.object({ employee_id: z.string().uuid().optional() });
 export const listSchedulesQuerySchema = z.object({ employee_id: z.string().uuid("employee_id (uuid) requis") });


### PR DESCRIPTION
## T7 — Exports paie (Refs #119)

Exports paie **figés** (octets gelés + **SHA-256**), CSV `;` UTF-8 BOM et PDF récap. **Aucun XLSX ni dépendance Excel** (pdfkit déjà présent).

- **Générateurs purs** (`toCsv` ;+BOM+CRLF+échappement, `buildPayrollCsv`, `sha256Hex`, `buildPayrollPdf`).
- **`createExport`** gèle les octets (base64) dans `frozen_snapshot_json` + `checksum` en colonne ; **`getExportFile` vérifie l'intégrité** (409 si altération). Lot = batch.
- **Endpoints** `/admin/exports` (POST/GET/GET :id/download) privilégiés + audités.

**Tests** : 12 unit · suite **241** verte · tsc 0. **Smoke cerp_test** (BEGIN/ROLLBACK, 0 résidu) : requête période=1, insert lot CSV/checksum. **Aucun cerp_prod, aucun main.** Voir `docs/temps-deplacements-t7-evidence.md`.