### PR TITLE
feat(temps-deplacements): T6 — kilomètres (déclaration salarié + validation)

### DIFF
--- a/docs/temps-deplacements-t6-evidence.md
+++ b/docs/temps-deplacements-t6-evidence.md
@@ -1,0 +1,34 @@
+# T6 — Kilomètres : preuves
+
+Objectif : déclaration de kilomètres par le salarié + validation responsable, avec réfs métier
+(affaire/client/fournisseur) optionnelles, statut, audit, anti-IDOR. Issue #119.
+
+## Livré
+
+- **Cycle** : `DRAFT → SUBMITTED → VALIDATED | REJECTED` (transitions gardées côté SQL).
+- **Salarié (anti-IDOR)** : `POST /kilometers` (employé dérivé de `req.user`, JAMAIS du corps),
+  `GET /kilometers/me`, `PATCH /kilometers/:id/submit` (ne soumet que SES déclarations DRAFT).
+- **Responsable** : `GET /kilometers/team` (périmètre manager / RH), `PATCH /kilometers/:id/validate|reject`
+  (uniquement si SUBMITTED ; hors périmètre → 403). Audit sur chaque écriture.
+- **Distance** : l'écart d'odomètre prime (arrondi 2 déc., jamais négatif) ; sinon distance saisie.
+- **Réfs douces** : `affaire_id` (bigint), `client_id`/`fournisseur_id` (int) — sans FK dure (comme T1).
+- **Véhicules** : `GET /kilometers/vehicles` (picker) + `POST /admin/vehicles` (privilégié).
+- **Frontend** : « Mes kilomètres » (déclarer/soumettre) + « Kilomètres équipe » (valider/refuser, gate rôle).
+- **Pas de géolocalisation continue** : uniquement lieux texte + odomètre saisis.
+
+## Tests (7 verts) — suite backend **248 / 49 fichiers**, `tsc` 0
+
+`t6-km.test.ts` : createKmSchema refuse `employee_id` (anti-IDOR) + odomètre incohérent ;
+`computeDistanceKm` (odomètre prime / distance / jamais négatif) ; `createMyKmEntry` (employé = token,
+audit) ; soumission ownership 403 ; DRAFT→SUBMITTED puis 409 ; validation hors périmètre 403 / RH VALIDATED ;
+validation d'une non-soumise → 409.
+
+## Smoke SQL cerp_test (BEGIN…ROLLBACK, 0 résidu)
+
+```
+0 CREATE: km cree (distance 42.5, refs douces)
+1 SUBMIT: rows=1 (attendu 1)
+2 VALIDATE: rows=1 (attendu 1)
+3 NON_REPLAY: rows=0 status=VALIDATED (attendu 0 / VALIDATED)
+4 TEAM_SCOPE: matches=1 (attendu 1)
+```

--- a/src/__tests__/temps-deplacements-t6-km.test.ts
+++ b/src/__tests__/temps-deplacements-t6-km.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-km.repository", () => ({
+  repoCreateKmEntry: vi.fn(),
+  repoGetKmEntryById: vi.fn(),
+  repoSubmitKmEntry: vi.fn(),
+  repoDecideKmEntry: vi.fn(),
+  repoListKmForEmployee: vi.fn(),
+  repoListTeamKmEntries: vi.fn(),
+  repoListVehicles: vi.fn(),
+  repoCreateVehicle: vi.fn(),
+}));
+vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", async (io) => {
+  const actual = await io<typeof import("../module/temps-deplacements/repository/temps-deplacements.repository")>();
+  return {
+    ...actual,
+    withTransaction: vi.fn(async (fn: (c: unknown) => unknown) => fn({ query: vi.fn() })),
+    insertAuditLog: vi.fn(async () => undefined),
+    repoGetEmployeeById: vi.fn(),
+  };
+});
+vi.mock("../module/temps-deplacements/services/temps-deplacements.service", async (io) => {
+  const actual = await io<typeof import("../module/temps-deplacements/services/temps-deplacements.service")>();
+  return { ...actual, resolveEmployeeFromUser: vi.fn() };
+});
+
+import * as kmRepo from "../module/temps-deplacements/repository/temps-deplacements-km.repository";
+import * as baseRepo from "../module/temps-deplacements/repository/temps-deplacements.repository";
+import * as t2 from "../module/temps-deplacements/services/temps-deplacements.service";
+import * as svc from "../module/temps-deplacements/services/temps-deplacements-km.service";
+import { computeDistanceKm } from "../module/temps-deplacements/services/temps-deplacements-km.service";
+import { createKmSchema } from "../module/temps-deplacements/validators/temps-deplacements.validators";
+
+const km = vi.mocked(kmRepo);
+const t2m = vi.mocked(t2);
+const AUDIT = { user_id: 1, ip: null, user_agent: null, device_type: null, os: null, browser: null, path: null, page_key: null, client_session_id: null };
+const emp = (over = {}) => ({ id: "E", user_id: 1, matricule: "TD1", service: null, manager_user_id: null, status: "ACTIVE" as const, ...over });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("T6 — validateur & distance", () => {
+  it("createKmSchema REFUSE employee_id (anti-IDOR) et l'odomètre incohérent", () => {
+    expect(createKmSchema.parse({ date: "2026-03-02", distance_km: 12 }).distance_km).toBe(12);
+    expect(() => createKmSchema.parse({ date: "2026-03-02", employee_id: "x" })).toThrow();
+    expect(() => createKmSchema.parse({ date: "2026-03-02", start_odometer: 100, end_odometer: 50 })).toThrow();
+  });
+  it("computeDistanceKm : l'odomètre prime, sinon la distance, jamais négatif", () => {
+    expect(computeDistanceKm({ start_odometer: 1000, end_odometer: 1042, distance_km: 0 })).toBe(42);
+    expect(computeDistanceKm({ start_odometer: null, end_odometer: null, distance_km: 15.5 })).toBe(15.5);
+    expect(computeDistanceKm({ start_odometer: null, end_odometer: null, distance_km: -3 })).toBe(0);
+  });
+});
+
+describe("T6 — createMyKmEntry (anti-IDOR : employé dérivé de req.user)", () => {
+  it("emploie l'employé du token, pas du corps ; audit", async () => {
+    t2m.resolveEmployeeFromUser.mockResolvedValue(emp());
+    km.repoCreateKmEntry.mockImplementation(async (_c, i) => ({ id: "k1", ...i, created_at: "t", validated_by: null, validated_at: null }));
+    const r = await svc.createMyKmEntry({ id: 1, role: "Employee" }, { date: "2026-03-02", type: "MISSION", vehicle_id: null, start_location: null, end_location: null, start_odometer: null, end_odometer: null, distance_km: 12, affaire_id: null, client_id: null, fournisseur_id: null, submit: true }, AUDIT);
+    expect(km.repoCreateKmEntry.mock.calls[0][1].employee_id).toBe("E");
+    expect(r.status).toBe("SUBMITTED");
+    expect(baseRepo.insertAuditLog).toHaveBeenCalled();
+  });
+});
+
+describe("T6 — soumission & validation (ownership + périmètre + transitions)", () => {
+  it("un salarié ne peut soumettre QUE ses déclarations → 403", async () => {
+    km.repoGetKmEntryById.mockResolvedValue({ id: "k1", employee_id: "OTHER", status: "DRAFT" } as never);
+    t2m.resolveEmployeeFromUser.mockResolvedValue(emp());
+    await expect(svc.submitMyKmEntry({ id: 1, role: "Employee" }, "k1", AUDIT)).rejects.toMatchObject({ status: 403 });
+  });
+  it("soumission DRAFT→SUBMITTED ; déjà soumise → 409", async () => {
+    km.repoGetKmEntryById.mockResolvedValue({ id: "k1", employee_id: "E", status: "DRAFT" } as never);
+    t2m.resolveEmployeeFromUser.mockResolvedValue(emp());
+    km.repoSubmitKmEntry.mockResolvedValueOnce({ id: "k1", status: "SUBMITTED" } as never);
+    expect((await svc.submitMyKmEntry({ id: 1, role: "Employee" }, "k1", AUDIT)).status).toBe("SUBMITTED");
+    km.repoSubmitKmEntry.mockResolvedValueOnce(null);
+    await expect(svc.submitMyKmEntry({ id: 1, role: "Employee" }, "k1", AUDIT)).rejects.toMatchObject({ status: 409, code: "HR_KM_NOT_DRAFT" });
+  });
+  it("validation hors périmètre → 403 ; RH → VALIDATED", async () => {
+    km.repoGetKmEntryById.mockResolvedValue({ id: "k1", employee_id: "E", status: "SUBMITTED" } as never);
+    vi.mocked(baseRepo.repoGetEmployeeById).mockResolvedValue(emp({ manager_user_id: 99 }));
+    await expect(svc.decideKmEntry({ id: 5, role: "Employee" }, "k1", "VALIDATED", AUDIT)).rejects.toMatchObject({ status: 403 });
+    km.repoDecideKmEntry.mockResolvedValue({ id: "k1", status: "VALIDATED" } as never);
+    expect((await svc.decideKmEntry({ id: 5, role: "Responsable RH" }, "k1", "VALIDATED", AUDIT)).status).toBe("VALIDATED");
+  });
+  it("valider une déclaration non soumise → 409", async () => {
+    km.repoGetKmEntryById.mockResolvedValue({ id: "k1", employee_id: "E", status: "DRAFT" } as never);
+    km.repoDecideKmEntry.mockResolvedValue(null);
+    await expect(svc.decideKmEntry({ id: 5, role: "Responsable RH" }, "k1", "VALIDATED", AUDIT)).rejects.toMatchObject({ status: 409, code: "HR_KM_NOT_SUBMITTED" });
+  });
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements-km.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements-km.controller.ts
@@ -1,0 +1,50 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import * as svc from "../services/temps-deplacements-km.service";
+import {
+  createKmSchema,
+  myKmQuerySchema,
+  teamKmQuerySchema,
+  uuidParamsSchema,
+  vehicleBodySchema,
+} from "../validators/temps-deplacements.validators";
+import { buildAuditContext, requireUser } from "./temps-deplacements.controller";
+
+// ------------------------------------------------------------------ Salarié (self-service)
+export const postKm = asyncHandler(async (req: Request, res: Response) => {
+  const body = createKmSchema.parse(req.body);
+  const entry = await svc.createMyKmEntry(requireUser(req), body, buildAuditContext(req));
+  res.status(201).json(entry);
+});
+export const getMyKm = asyncHandler(async (req: Request, res: Response) => {
+  const filters = myKmQuerySchema.parse(req.query);
+  res.json(await svc.listMyKmEntries(requireUser(req), filters));
+});
+export const submitKm = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.submitMyKmEntry(requireUser(req), id, buildAuditContext(req)));
+});
+
+// ------------------------------------------------------------------ Responsable
+export const getTeamKm = asyncHandler(async (req: Request, res: Response) => {
+  const { status } = teamKmQuerySchema.parse(req.query);
+  res.json(await svc.listTeamKmEntries(requireUser(req), status));
+});
+export const validateKm = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.decideKmEntry(requireUser(req), id, "VALIDATED", buildAuditContext(req)));
+});
+export const rejectKm = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.decideKmEntry(requireUser(req), id, "REJECTED", buildAuditContext(req)));
+});
+
+// ------------------------------------------------------------------ Véhicules
+export const getVehicles = asyncHandler(async (req: Request, res: Response) => {
+  requireUser(req);
+  res.json(await svc.listVehicles());
+});
+export const postVehicle = asyncHandler(async (req: Request, res: Response) => {
+  const body = vehicleBodySchema.parse(req.body);
+  res.status(201).json(await svc.createVehicle(requireUser(req), body, buildAuditContext(req)));
+});

--- a/src/module/temps-deplacements/repository/temps-deplacements-km.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements-km.repository.ts
@@ -1,0 +1,158 @@
+import pool from "../../../config/database";
+import type { DbQueryer } from "./temps-deplacements.repository";
+
+// T6 — kilomètres. Statuts : DRAFT → SUBMITTED → VALIDATED | REJECTED.
+export type HrKmType = "MISSION" | "CLIENT" | "FOURNISSEUR" | "LIVRAISON" | "AUTRE";
+export type HrKmStatus = "DRAFT" | "SUBMITTED" | "VALIDATED" | "REJECTED";
+
+export interface KmEntry {
+  id: string;
+  employee_id: string;
+  date: string;
+  type: HrKmType;
+  vehicle_id: string | null;
+  start_location: string | null;
+  end_location: string | null;
+  start_odometer: number | null;
+  end_odometer: number | null;
+  distance_km: number;
+  affaire_id: number | null;
+  client_id: number | null;
+  fournisseur_id: number | null;
+  status: HrKmStatus;
+  created_at: string;
+  validated_by: number | null;
+  validated_at: string | null;
+}
+export type KmEntryWithEmployee = KmEntry & { matricule: string };
+
+export interface KmEntryInput {
+  employee_id: string;
+  date: string;
+  type: HrKmType;
+  vehicle_id: string | null;
+  start_location: string | null;
+  end_location: string | null;
+  start_odometer: number | null;
+  end_odometer: number | null;
+  distance_km: number;
+  affaire_id: number | null;
+  client_id: number | null;
+  fournisseur_id: number | null;
+  status: HrKmStatus;
+}
+
+const KM_COLS = `id::text, employee_id::text, date::text, type::text, vehicle_id::text,
+  start_location, end_location, start_odometer, end_odometer, distance_km,
+  affaire_id, client_id, fournisseur_id, status::text, created_at::text, validated_by, validated_at::text`;
+
+function num(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+function mapKm(r: Record<string, unknown>): KmEntry {
+  return {
+    id: String(r.id),
+    employee_id: String(r.employee_id),
+    date: String(r.date),
+    type: r.type as HrKmType,
+    vehicle_id: (r.vehicle_id as string | null) ?? null,
+    start_location: (r.start_location as string | null) ?? null,
+    end_location: (r.end_location as string | null) ?? null,
+    start_odometer: num(r.start_odometer),
+    end_odometer: num(r.end_odometer),
+    distance_km: num(r.distance_km) ?? 0,
+    affaire_id: num(r.affaire_id),
+    client_id: num(r.client_id),
+    fournisseur_id: num(r.fournisseur_id),
+    status: r.status as HrKmStatus,
+    created_at: String(r.created_at),
+    validated_by: num(r.validated_by),
+    validated_at: (r.validated_at as string | null) ?? null,
+  };
+}
+
+export async function repoCreateKmEntry(q: DbQueryer, i: KmEntryInput): Promise<KmEntry> {
+  const res = await q.query(
+    `INSERT INTO public.hr_kilometer_entries
+       (employee_id, date, type, vehicle_id, start_location, end_location, start_odometer, end_odometer,
+        distance_km, affaire_id, client_id, fournisseur_id, status)
+     VALUES ($1::uuid,$2::date,$3::hr_km_type,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13::hr_km_status)
+     RETURNING ${KM_COLS}`,
+    [i.employee_id, i.date, i.type, i.vehicle_id, i.start_location, i.end_location, i.start_odometer, i.end_odometer,
+     i.distance_km, i.affaire_id, i.client_id, i.fournisseur_id, i.status]
+  );
+  return mapKm(res.rows[0]);
+}
+
+export async function repoGetKmEntryById(id: string, q: DbQueryer = pool): Promise<KmEntry | null> {
+  const res = await q.query(`SELECT ${KM_COLS} FROM public.hr_kilometer_entries WHERE id = $1::uuid LIMIT 1`, [id]);
+  return res.rows[0] ? mapKm(res.rows[0]) : null;
+}
+
+export async function repoListKmForEmployee(
+  employeeId: string,
+  filters: { from?: string; to?: string; status?: HrKmStatus },
+  q: DbQueryer = pool
+): Promise<KmEntry[]> {
+  const where: string[] = ["employee_id = $1::uuid"];
+  const vals: unknown[] = [employeeId];
+  if (filters.from) { vals.push(filters.from); where.push(`date >= $${vals.length}::date`); }
+  if (filters.to) { vals.push(filters.to); where.push(`date <= $${vals.length}::date`); }
+  if (filters.status) { vals.push(filters.status); where.push(`status = $${vals.length}::hr_km_status`); }
+  const res = await q.query(`SELECT ${KM_COLS} FROM public.hr_kilometer_entries WHERE ${where.join(" AND ")} ORDER BY date DESC, created_at DESC LIMIT 500`, vals);
+  return res.rows.map(mapKm);
+}
+
+// DRAFT → SUBMITTED (par le salarié). Ne modifie que si DRAFT.
+export async function repoSubmitKmEntry(q: DbQueryer, id: string): Promise<KmEntry | null> {
+  const res = await q.query(
+    `UPDATE public.hr_kilometer_entries SET status='SUBMITTED'::hr_km_status
+      WHERE id=$1::uuid AND status='DRAFT'::hr_km_status RETURNING ${KM_COLS}`,
+    [id]
+  );
+  return res.rows[0] ? mapKm(res.rows[0]) : null;
+}
+
+// SUBMITTED → VALIDATED | REJECTED (par le responsable). Ne modifie que si SUBMITTED.
+export async function repoDecideKmEntry(q: DbQueryer, id: string, status: "VALIDATED" | "REJECTED", validatedBy: number): Promise<KmEntry | null> {
+  const res = await q.query(
+    `UPDATE public.hr_kilometer_entries SET status=$2::hr_km_status, validated_by=$3, validated_at=now()
+      WHERE id=$1::uuid AND status='SUBMITTED'::hr_km_status RETURNING ${KM_COLS}`,
+    [id, status, validatedBy]
+  );
+  return res.rows[0] ? mapKm(res.rows[0]) : null;
+}
+
+export async function repoListTeamKmEntries(
+  filters: { managerUserId: number; isPrivileged: boolean; status?: HrKmStatus },
+  q: DbQueryer = pool
+): Promise<KmEntryWithEmployee[]> {
+  const where: string[] = ["($1::boolean OR e.manager_user_id = $2::int)"];
+  const vals: unknown[] = [filters.isPrivileged, filters.managerUserId];
+  if (filters.status) { vals.push(filters.status); where.push(`k.status = $${vals.length}::hr_km_status`); }
+  const res = await q.query(
+    `SELECT ${KM_COLS.split(", ").map((c) => "k." + c).join(", ")}, e.matricule
+       FROM public.hr_kilometer_entries k
+       JOIN public.hr_employees e ON e.id = k.employee_id
+      WHERE ${where.join(" AND ")}
+      ORDER BY k.date DESC, k.created_at DESC LIMIT 500`,
+    vals
+  );
+  return res.rows.map((r) => ({ ...mapKm(r), matricule: String(r.matricule) }));
+}
+
+// -------------------------------------------------------------- Véhicules
+export async function repoListVehicles(q: DbQueryer = pool) {
+  const res = await q.query(`SELECT id::text, label, plate, owner_type::text, active FROM public.hr_vehicles WHERE active ORDER BY label ASC LIMIT 500`);
+  return res.rows;
+}
+export async function repoCreateVehicle(q: DbQueryer, i: { label: string; plate: string | null; owner_type: "COMPANY" | "PERSONAL" }) {
+  const res = await q.query(
+    `INSERT INTO public.hr_vehicles (label, plate, owner_type) VALUES ($1,$2,$3::hr_vehicle_owner)
+     RETURNING id::text, label, plate, owner_type::text, active`,
+    [i.label, i.plate, i.owner_type]
+  );
+  return res.rows[0];
+}

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import * as adm from "../controllers/temps-deplacements-admin.controller";
 import * as cor from "../controllers/temps-deplacements-corrections.controller";
 import * as exp from "../controllers/temps-deplacements-exports.controller";
+import * as km from "../controllers/temps-deplacements-km.controller";
 import * as c from "../controllers/temps-deplacements.controller";
 
 // Monté après le socle authenticateToken (v1.routes.ts) → JWT requis d'office.
@@ -53,5 +54,15 @@ router.delete("/admin/schedules/:id", adm.deleteScheduleHandler);
 router.get("/admin/exports", exp.getExports);
 router.post("/admin/exports", exp.postExport);
 router.get("/admin/exports/:id/download", exp.downloadExport);
+
+// T6 — kilomètres. Salarié : déclare/soumet SES km (anti-IDOR). Responsable : périmètre + validation.
+router.get("/kilometers/vehicles", km.getVehicles);
+router.post("/kilometers", km.postKm);
+router.get("/kilometers/me", km.getMyKm);
+router.patch("/kilometers/:id/submit", km.submitKm);
+router.get("/kilometers/team", km.getTeamKm);
+router.patch("/kilometers/:id/validate", km.validateKm);
+router.patch("/kilometers/:id/reject", km.rejectKm);
+router.post("/admin/vehicles", km.postVehicle);
 
 export default router;

--- a/src/module/temps-deplacements/services/temps-deplacements-km.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-km.service.ts
@@ -1,0 +1,128 @@
+import { HttpError } from "../../../utils/httpError";
+import {
+  repoCreateKmEntry,
+  repoCreateVehicle,
+  repoDecideKmEntry,
+  repoGetKmEntryById,
+  repoListKmForEmployee,
+  repoListTeamKmEntries,
+  repoListVehicles,
+  repoSubmitKmEntry,
+  type HrKmStatus,
+  type HrKmType,
+  type KmEntry,
+} from "../repository/temps-deplacements-km.repository";
+import { insertAuditLog, repoGetEmployeeById, withTransaction, type AuditContext } from "../repository/temps-deplacements.repository";
+import { isHrPrivileged, type Actor } from "./temps-deplacements-corrections.service";
+import { resolveEmployeeFromUser } from "./temps-deplacements.service";
+
+async function assertCanManageEmployee(actor: Actor, employeeId: string): Promise<void> {
+  if (isHrPrivileged(actor.role)) return;
+  const emp = await repoGetEmployeeById(employeeId);
+  if (emp && emp.manager_user_id !== null && emp.manager_user_id === actor.id) return;
+  throw new HttpError(403, "HR_FORBIDDEN", "Hors de votre périmètre de gestion.");
+}
+
+// Distance : privilégie l'écart de compteur (odomètre) s'il est fourni, sinon la distance saisie.
+export function computeDistanceKm(input: { start_odometer: number | null; end_odometer: number | null; distance_km: number }): number {
+  if (input.start_odometer != null && input.end_odometer != null) {
+    return Math.max(0, Number((input.end_odometer - input.start_odometer).toFixed(2)));
+  }
+  return Math.max(0, Number((input.distance_km ?? 0).toFixed(2)));
+}
+
+export interface CreateKmInput {
+  date: string;
+  type: HrKmType;
+  vehicle_id: string | null;
+  start_location: string | null;
+  end_location: string | null;
+  start_odometer: number | null;
+  end_odometer: number | null;
+  distance_km: number;
+  affaire_id: number | null;
+  client_id: number | null;
+  fournisseur_id: number | null;
+  submit: boolean;
+}
+
+// ANTI-IDOR : l'employé vient de req.user, JAMAIS du corps. Le salarié déclare SES kilomètres.
+export async function createMyKmEntry(actor: Actor, input: CreateKmInput, audit: AuditContext): Promise<KmEntry> {
+  const emp = await resolveEmployeeFromUser(actor.id);
+  const distance = computeDistanceKm(input);
+  return withTransaction(async (client) => {
+    const entry = await repoCreateKmEntry(client, {
+      employee_id: emp.id,
+      date: input.date,
+      type: input.type,
+      vehicle_id: input.vehicle_id,
+      start_location: input.start_location,
+      end_location: input.end_location,
+      start_odometer: input.start_odometer,
+      end_odometer: input.end_odometer,
+      distance_km: distance,
+      affaire_id: input.affaire_id,
+      client_id: input.client_id,
+      fournisseur_id: input.fournisseur_id,
+      status: input.submit ? "SUBMITTED" : "DRAFT",
+    });
+    await insertAuditLog(client, audit, {
+      action: "temps-deplacements.km.create",
+      entity_type: "hr_kilometer_entries",
+      entity_id: entry.id,
+      details: { type: input.type, distance_km: distance, status: entry.status },
+    });
+    return entry;
+  });
+}
+
+export async function listMyKmEntries(actor: Actor, filters: { from?: string; to?: string; status?: HrKmStatus }): Promise<KmEntry[]> {
+  const emp = await resolveEmployeeFromUser(actor.id);
+  return repoListKmForEmployee(emp.id, filters);
+}
+
+export async function submitMyKmEntry(actor: Actor, id: string, audit: AuditContext): Promise<KmEntry> {
+  const entry = await repoGetKmEntryById(id);
+  if (!entry) throw new HttpError(404, "HR_KM_NOT_FOUND", "Déclaration introuvable.");
+  const emp = await resolveEmployeeFromUser(actor.id);
+  if (entry.employee_id !== emp.id) throw new HttpError(403, "HR_FORBIDDEN", "Vous ne pouvez soumettre que vos déclarations.");
+  return withTransaction(async (client) => {
+    const updated = await repoSubmitKmEntry(client, id);
+    if (!updated) throw new HttpError(409, "HR_KM_NOT_DRAFT", "Déclaration déjà soumise ou traitée.");
+    await insertAuditLog(client, audit, { action: "temps-deplacements.km.submit", entity_type: "hr_kilometer_entries", entity_id: id, details: { status: "SUBMITTED" } });
+    return updated;
+  });
+}
+
+export async function decideKmEntry(actor: Actor, id: string, decision: "VALIDATED" | "REJECTED", audit: AuditContext): Promise<KmEntry> {
+  const entry = await repoGetKmEntryById(id);
+  if (!entry) throw new HttpError(404, "HR_KM_NOT_FOUND", "Déclaration introuvable.");
+  await assertCanManageEmployee(actor, entry.employee_id);
+  return withTransaction(async (client) => {
+    const updated = await repoDecideKmEntry(client, id, decision, actor.id);
+    if (!updated) throw new HttpError(409, "HR_KM_NOT_SUBMITTED", "La déclaration doit être soumise pour être traitée.");
+    await insertAuditLog(client, audit, {
+      action: decision === "VALIDATED" ? "temps-deplacements.km.validate" : "temps-deplacements.km.reject",
+      entity_type: "hr_kilometer_entries",
+      entity_id: id,
+      details: { decision },
+    });
+    return updated;
+  });
+}
+
+export async function listTeamKmEntries(actor: Actor, status?: HrKmStatus) {
+  return repoListTeamKmEntries({ managerUserId: actor.id, isPrivileged: isHrPrivileged(actor.role), status });
+}
+
+export async function listVehicles() {
+  return repoListVehicles();
+}
+export async function createVehicle(actor: Actor, input: { label: string; plate: string | null; owner_type: "COMPANY" | "PERSONAL" }, audit: AuditContext) {
+  if (!isHrPrivileged(actor.role)) throw new HttpError(403, "HR_FORBIDDEN", "Gestion des véhicules réservée.");
+  return withTransaction(async (client) => {
+    const v = await repoCreateVehicle(client, input);
+    await insertAuditLog(client, audit, { action: "temps-deplacements.vehicle.create", entity_type: "hr_vehicles", entity_id: v.id, details: { label: input.label } });
+    return v;
+  });
+}

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -117,6 +117,49 @@ export type ScheduleBody = z.infer<typeof scheduleBodySchema>;
 
 export const setActiveSchema = z.object({ active: z.boolean() }).strict();
 
+// --- T6 : kilomètres ---
+export const HR_KM_TYPES = ["MISSION", "CLIENT", "FOURNISSEUR", "LIVRAISON", "AUTRE"] as const;
+export const HR_KM_STATUSES = ["DRAFT", "SUBMITTED", "VALIDATED", "REJECTED"] as const;
+
+// ANTI-IDOR : aucun employee_id (l'employé vient de req.user).
+export const createKmSchema = z
+  .object({
+    date: dateOnly,
+    type: z.enum(HR_KM_TYPES).default("MISSION"),
+    vehicle_id: z.string().uuid().nullable().default(null),
+    start_location: z.string().trim().max(300).nullable().default(null),
+    end_location: z.string().trim().max(300).nullable().default(null),
+    start_odometer: z.number().min(0).max(9_999_999).nullable().default(null),
+    end_odometer: z.number().min(0).max(9_999_999).nullable().default(null),
+    distance_km: z.number().min(0).max(100_000).default(0),
+    affaire_id: z.number().int().positive().nullable().default(null),
+    client_id: z.number().int().positive().nullable().default(null),
+    fournisseur_id: z.number().int().positive().nullable().default(null),
+    submit: z.boolean().default(false),
+  })
+  .strict()
+  .refine((v) => v.start_odometer == null || v.end_odometer == null || v.end_odometer >= v.start_odometer, {
+    message: "Odomètre d'arrivée < départ.",
+    path: ["end_odometer"],
+  });
+export type CreateKmBody = z.infer<typeof createKmSchema>;
+
+export const myKmQuerySchema = z.object({
+  from: dateOnly.optional(),
+  to: dateOnly.optional(),
+  status: z.enum(HR_KM_STATUSES).optional(),
+});
+export const teamKmQuerySchema = z.object({ status: z.enum(HR_KM_STATUSES).optional() });
+
+export const vehicleBodySchema = z
+  .object({
+    label: z.string().trim().min(1).max(200),
+    plate: z.string().trim().max(20).nullable().default(null),
+    owner_type: z.enum(["COMPANY", "PERSONAL"]).default("COMPANY"),
+  })
+  .strict();
+export type VehicleBody = z.infer<typeof vehicleBodySchema>;
+
 // --- T7 : exports paie ---
 export const HR_EXPORT_FORMATS = ["CSV", "PDF"] as const;
 export const exportBodySchema = z


### PR DESCRIPTION
## T6 — Kilomètres (Refs #119)

Déclaration de km par le salarié + validation responsable. Cycle `DRAFT→SUBMITTED→VALIDATED|REJECTED`. **Anti-IDOR** : l'employé vient de `req.user`, jamais du corps.

- **Salarié** : `POST /kilometers`, `GET /kilometers/me`, `PATCH /:id/submit` (ses DRAFT).
- **Responsable** : `GET /kilometers/team` (périmètre), `PATCH /:id/validate|reject` (SUBMITTED ; hors périmètre 403).
- **Distance** : odomètre prime (≥0) sinon distance saisie ; réfs douces affaire/client/fournisseur ; audit ; **pas de géoloc continue**.
- Véhicules : picker + création privilégiée.

**Tests** : 7 unit · suite **248** verte · tsc 0. **Smoke cerp_test** (BEGIN/ROLLBACK, 0 résidu) : submit=1, validate=1, non-replay=0, team-scope=1. **Aucun cerp_prod, aucun main.** Voir `docs/temps-deplacements-t6-evidence.md`.