### PR TITLE
feat(temps-deplacements): T8 — provisioning bornes & badges

### DIFF
--- a/docs/temps-deplacements-t8-evidence.md
+++ b/docs/temps-deplacements-t8-evidence.md
@@ -1,0 +1,34 @@
+# T8 — Bornes & badges : preuves
+
+Objectif : provisioning des bornes/badges + page borne (kiosk). L'ingestion des événements borne
+(`/device-events`, `/device-heartbeat`, `/device-config`) existe depuis T2 ; T8 ajoute le CRUD admin.
+Issue #119.
+
+## Livré (backend)
+
+- **Bornes** (privilégié) : `POST /admin/devices` (génère un token opaque, stocke SON HASH, renvoie le
+  token en clair **une seule fois**), `GET /admin/devices` (sans hash), `PATCH /admin/devices/:id/status`
+  (ACTIVE/DISABLED), `POST /admin/devices/:id/rotate-token`.
+- **Badges** (privilégié) : `POST /admin/badges` (uid haché SHA-256, jamais stocké/loggé en clair),
+  `GET /admin/badges`, `PATCH /admin/badges/:id/revoke`.
+- **Sécurité** : token/uid **hachés** (`sha256` hex) — l'empreinte TS == `encode(digest(...),'hex')` PG
+  (interopérable avec la borne). Réponses/logs **sans secret ni PII sensible**.
+
+## Tests (7 verts) — suite backend **255 / 50 fichiers**, `tsc` 0
+
+`t8-devices.test.ts` : createDevice (token `^[0-9a-f]{48}$` renvoyé 1×, hash stocké = `hashDeviceToken(token)`,
+réponse sans hash, audit sans token), salarié 403, borne inconnue 404 ; createBadge (uid haché, audit sans
+uid), employé inexistant 404, salarié 403, révocation déjà faite 409.
+
+## Smoke SQL cerp_test (BEGIN…ROLLBACK, 0 résidu)
+
+```
+1 DEVICE_AUTH: matches=1 (attendu 1 ; sha256 TS == digest PG)
+2 BADGE_RESOLVE: matches=1 (attendu 1)
+3 DEVICE_DISABLED: active_matches=0 (attendu 0)
+4 BADGE_REVOKED: active_matches=0 (attendu 0)
+```
+
+Note : les endpoints borne sont derrière le socle `authenticateToken` (T2) ⇒ la borne s'exécute en
+session kiosk authentifiée **plus** son `device_token`. Front (page borne HID + feedback vert/orange/rouge
++ gestion bornes/badges) livré séparément (T8 front).

--- a/src/__tests__/temps-deplacements-t8-devices.test.ts
+++ b/src/__tests__/temps-deplacements-t8-devices.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-devices.repository", () => ({
+  repoCreateDevice: vi.fn(),
+  repoListDevices: vi.fn(),
+  repoSetDeviceStatus: vi.fn(),
+  repoRotateDeviceToken: vi.fn(),
+  repoCreateBadge: vi.fn(),
+  repoListBadges: vi.fn(),
+  repoRevokeBadge: vi.fn(),
+}));
+vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", async (io) => {
+  const actual = await io<typeof import("../module/temps-deplacements/repository/temps-deplacements.repository")>();
+  return {
+    ...actual,
+    withTransaction: vi.fn(async (fn: (c: unknown) => unknown) => fn({ query: vi.fn() })),
+    insertAuditLog: vi.fn(async () => undefined),
+    repoGetEmployeeById: vi.fn(),
+  };
+});
+
+import * as devRepo from "../module/temps-deplacements/repository/temps-deplacements-devices.repository";
+import * as baseRepo from "../module/temps-deplacements/repository/temps-deplacements.repository";
+import * as svc from "../module/temps-deplacements/services/temps-deplacements-devices.service";
+import { hashBadgeUid, hashDeviceToken } from "../module/temps-deplacements/services/temps-deplacements.service";
+
+const dev = vi.mocked(devRepo);
+const base = vi.mocked(baseRepo);
+const AUDIT = { user_id: 9, ip: null, user_agent: null, device_type: null, os: null, browser: null, path: null, page_key: null, client_session_id: null };
+const RH = { id: 9, role: "Responsable RH" };
+const SALARIE = { id: 2, role: "Employee" };
+const EMP_ID = "11111111-1111-4111-8111-111111111111";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("T8 — bornes : token généré, haché, jamais loggé", () => {
+  it("createDevice renvoie un token en clair 1×, stocke le HASH, audit sans secret", async () => {
+    dev.repoCreateDevice.mockImplementation(async (_c, i) => ({ id: "d1", name: i.name, location: i.location, device_type: i.device_type, status: "ACTIVE", last_seen_at: null, created_at: "t" }));
+    const r = await svc.createDevice(RH, { name: "Borne Atelier", location: "Hall", device_type: "KIOSK" }, AUDIT);
+    expect(r.token).toMatch(/^[0-9a-f]{48}$/);
+    // Le hash stocké correspond bien au token renvoyé.
+    expect(dev.repoCreateDevice.mock.calls[0][1].device_token_hash).toBe(hashDeviceToken(r.token));
+    // La réponse device n'expose PAS le hash.
+    expect(r.device).not.toHaveProperty("device_token_hash");
+    // L'audit ne contient JAMAIS le token.
+    const auditDetails = base.insertAuditLog.mock.calls[0][2].details as Record<string, unknown>;
+    expect(JSON.stringify(auditDetails)).not.toContain(r.token);
+    expect(auditDetails).toEqual({ name: "Borne Atelier" });
+  });
+  it("un salarié ne peut PAS créer de borne → 403", async () => {
+    await expect(svc.createDevice(SALARIE, { name: "X", location: null, device_type: null }, AUDIT)).rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+    expect(dev.repoCreateDevice).not.toHaveBeenCalled();
+  });
+  it("changer le statut d'une borne inexistante → 404", async () => {
+    dev.repoSetDeviceStatus.mockResolvedValue(null);
+    await expect(svc.setDeviceStatus(RH, EMP_ID, "DISABLED", AUDIT)).rejects.toMatchObject({ status: 404, code: "HR_DEVICE_NOT_FOUND" });
+  });
+});
+
+describe("T8 — badges : uid haché, jamais loggé", () => {
+  it("createBadge stocke le HASH de l'uid, audit sans uid", async () => {
+    base.repoGetEmployeeById.mockResolvedValue({ id: EMP_ID, user_id: 1, matricule: "TD1", service: null, manager_user_id: null, status: "ACTIVE" });
+    dev.repoCreateBadge.mockImplementation(async (_c, i) => ({ id: "b1", employee_id: i.employee_id, badge_label: i.badge_label, active: true, issued_at: "t", revoked_at: null }));
+    await svc.createBadge(RH, { employee_id: EMP_ID, badge_uid: "04AABBCCDD", badge_label: "Badge 1" }, AUDIT);
+    expect(dev.repoCreateBadge.mock.calls[0][1].badge_uid_hash).toBe(hashBadgeUid("04AABBCCDD"));
+    const auditDetails = base.insertAuditLog.mock.calls[0][2].details as Record<string, unknown>;
+    expect(JSON.stringify(auditDetails)).not.toContain("04AABBCCDD");
+  });
+  it("badge pour un employé inexistant → 404", async () => {
+    base.repoGetEmployeeById.mockResolvedValue(null);
+    await expect(svc.createBadge(RH, { employee_id: EMP_ID, badge_uid: "x", badge_label: null }, AUDIT)).rejects.toMatchObject({ status: 404 });
+  });
+  it("un salarié ne peut PAS créer de badge → 403", async () => {
+    await expect(svc.createBadge(SALARIE, { employee_id: EMP_ID, badge_uid: "x", badge_label: null }, AUDIT)).rejects.toMatchObject({ status: 403 });
+  });
+  it("révoquer un badge déjà révoqué → 409", async () => {
+    dev.repoRevokeBadge.mockResolvedValue(null);
+    await expect(svc.revokeBadge(RH, EMP_ID, AUDIT)).rejects.toMatchObject({ status: 409, code: "HR_BADGE_NOT_ACTIVE" });
+  });
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements-devices.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements-devices.controller.ts
@@ -1,0 +1,43 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import * as svc from "../services/temps-deplacements-devices.service";
+import {
+  badgeBodySchema,
+  deviceBodySchema,
+  deviceStatusSchema,
+  listBadgesQuerySchema,
+  uuidParamsSchema,
+} from "../validators/temps-deplacements.validators";
+import { buildAuditContext, requireUser } from "./temps-deplacements.controller";
+
+// ------------------------------------------------------------------ Bornes
+export const getDevices = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await svc.listDevices(requireUser(req)));
+});
+export const postDevice = asyncHandler(async (req: Request, res: Response) => {
+  const body = deviceBodySchema.parse(req.body);
+  res.status(201).json(await svc.createDevice(requireUser(req), body, buildAuditContext(req))); // { device, token } — token une seule fois
+});
+export const patchDeviceStatus = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const { status } = deviceStatusSchema.parse(req.body);
+  res.json(await svc.setDeviceStatus(requireUser(req), id, status, buildAuditContext(req)));
+});
+export const postDeviceRotate = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.rotateDeviceToken(requireUser(req), id, buildAuditContext(req)));
+});
+
+// ------------------------------------------------------------------ Badges
+export const getBadges = asyncHandler(async (req: Request, res: Response) => {
+  const { employee_id } = listBadgesQuerySchema.parse(req.query);
+  res.json(await svc.listBadges(requireUser(req), employee_id));
+});
+export const postBadge = asyncHandler(async (req: Request, res: Response) => {
+  const body = badgeBodySchema.parse(req.body);
+  res.status(201).json(await svc.createBadge(requireUser(req), body, buildAuditContext(req)));
+});
+export const revokeBadgeHandler = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.revokeBadge(requireUser(req), id, buildAuditContext(req)));
+});

--- a/src/module/temps-deplacements/repository/temps-deplacements-devices.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements-devices.repository.ts
@@ -1,0 +1,67 @@
+import pool from "../../../config/database";
+import type { DbQueryer } from "./temps-deplacements.repository";
+
+// T8 — bornes & badges. On ne stocke QUE les empreintes (token/uid hachés) ; jamais le secret en clair.
+export type HrDeviceStatus = "ACTIVE" | "DISABLED";
+
+// Colonnes exposées : JAMAIS device_token_hash / badge_uid_hash (pas de secret hors DB).
+const DEVICE_COLS = `id::text, name, location, device_type, status::text, last_seen_at::text, created_at::text`;
+const BADGE_COLS = `id::text, employee_id::text, badge_label, active, issued_at::text, revoked_at::text`;
+
+export async function repoCreateDevice(
+  q: DbQueryer,
+  i: { name: string; location: string | null; device_type: string | null; device_token_hash: string }
+) {
+  const res = await q.query(
+    `INSERT INTO public.hr_time_clock_devices (name, location, device_type, device_token_hash, status)
+     VALUES ($1,$2,$3,$4,'ACTIVE'::hr_device_status) RETURNING ${DEVICE_COLS}`,
+    [i.name, i.location, i.device_type, i.device_token_hash]
+  );
+  return res.rows[0];
+}
+export async function repoListDevices(q: DbQueryer = pool) {
+  const res = await q.query(`SELECT ${DEVICE_COLS} FROM public.hr_time_clock_devices ORDER BY created_at DESC LIMIT 500`);
+  return res.rows;
+}
+export async function repoSetDeviceStatus(q: DbQueryer, id: string, status: HrDeviceStatus) {
+  const res = await q.query(
+    `UPDATE public.hr_time_clock_devices SET status=$2::hr_device_status WHERE id=$1::uuid RETURNING ${DEVICE_COLS}`,
+    [id, status]
+  );
+  return res.rows[0] ?? null;
+}
+// Régénère le hash de token (rotation). Le token brut est renvoyé une seule fois par le service.
+export async function repoRotateDeviceToken(q: DbQueryer, id: string, tokenHash: string) {
+  const res = await q.query(
+    `UPDATE public.hr_time_clock_devices SET device_token_hash=$2 WHERE id=$1::uuid RETURNING ${DEVICE_COLS}`,
+    [id, tokenHash]
+  );
+  return res.rows[0] ?? null;
+}
+
+export async function repoCreateBadge(
+  q: DbQueryer,
+  i: { employee_id: string; badge_uid_hash: string; badge_label: string | null }
+) {
+  const res = await q.query(
+    `INSERT INTO public.hr_badge_credentials (employee_id, badge_uid_hash, badge_label, active)
+     VALUES ($1::uuid,$2,$3,true) RETURNING ${BADGE_COLS}`,
+    [i.employee_id, i.badge_uid_hash, i.badge_label]
+  );
+  return res.rows[0];
+}
+export async function repoListBadges(q: DbQueryer, employeeId?: string) {
+  if (employeeId) {
+    const res = await q.query(`SELECT ${BADGE_COLS} FROM public.hr_badge_credentials WHERE employee_id=$1::uuid ORDER BY issued_at DESC LIMIT 500`, [employeeId]);
+    return res.rows;
+  }
+  const res = await q.query(`SELECT ${BADGE_COLS} FROM public.hr_badge_credentials ORDER BY issued_at DESC LIMIT 500`);
+  return res.rows;
+}
+export async function repoRevokeBadge(q: DbQueryer, id: string) {
+  const res = await q.query(
+    `UPDATE public.hr_badge_credentials SET active=false, revoked_at=now() WHERE id=$1::uuid AND active=true RETURNING ${BADGE_COLS}`,
+    [id]
+  );
+  return res.rows[0] ?? null;
+}

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import * as adm from "../controllers/temps-deplacements-admin.controller";
 import * as cor from "../controllers/temps-deplacements-corrections.controller";
+import * as dev from "../controllers/temps-deplacements-devices.controller";
 import * as exp from "../controllers/temps-deplacements-exports.controller";
 import * as km from "../controllers/temps-deplacements-km.controller";
 import * as c from "../controllers/temps-deplacements.controller";
@@ -64,5 +65,14 @@ router.get("/kilometers/team", km.getTeamKm);
 router.patch("/kilometers/:id/validate", km.validateKm);
 router.patch("/kilometers/:id/reject", km.rejectKm);
 router.post("/admin/vehicles", km.postVehicle);
+
+// T8 — bornes & badges (provisioning). Réservé aux rôles privilégiés (service). Token borne renvoyé 1× à la création.
+router.get("/admin/devices", dev.getDevices);
+router.post("/admin/devices", dev.postDevice);
+router.patch("/admin/devices/:id/status", dev.patchDeviceStatus);
+router.post("/admin/devices/:id/rotate-token", dev.postDeviceRotate);
+router.get("/admin/badges", dev.getBadges);
+router.post("/admin/badges", dev.postBadge);
+router.patch("/admin/badges/:id/revoke", dev.revokeBadgeHandler);
 
 export default router;

--- a/src/module/temps-deplacements/services/temps-deplacements-devices.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-devices.service.ts
@@ -1,0 +1,96 @@
+import crypto from "node:crypto";
+import { HttpError } from "../../../utils/httpError";
+import {
+  repoCreateBadge,
+  repoCreateDevice,
+  repoListBadges,
+  repoListDevices,
+  repoRevokeBadge,
+  repoRotateDeviceToken,
+  repoSetDeviceStatus,
+  type HrDeviceStatus,
+} from "../repository/temps-deplacements-devices.repository";
+import { insertAuditLog, repoGetEmployeeById, withTransaction, type AuditContext } from "../repository/temps-deplacements.repository";
+import { isHrPrivileged, type Actor } from "./temps-deplacements-corrections.service";
+import { hashBadgeUid, hashDeviceToken } from "./temps-deplacements.service";
+
+function assertPrivileged(actor: Actor): void {
+  if (!isHrPrivileged(actor.role)) throw new HttpError(403, "HR_FORBIDDEN", "Gestion des bornes/badges réservée.");
+}
+
+// Token opaque, imprévisible. Stocké HACHÉ ; renvoyé en clair UNE seule fois (pour configurer la borne).
+function generateDeviceToken(): string {
+  return crypto.randomBytes(24).toString("hex");
+}
+
+// -------------------------------------------------------------- Bornes
+export async function createDevice(actor: Actor, input: { name: string; location: string | null; device_type: string | null }, audit: AuditContext) {
+  assertPrivileged(actor);
+  const token = generateDeviceToken();
+  const device = await withTransaction(async (client) => {
+    const row = await repoCreateDevice(client, { name: input.name, location: input.location, device_type: input.device_type, device_token_hash: hashDeviceToken(token) });
+    await insertAuditLog(client, audit, { action: "temps-deplacements.device.create", entity_type: "hr_time_clock_devices", entity_id: row.id, details: { name: input.name } });
+    return row;
+  });
+  return { device, token }; // token en clair : à copier maintenant, non re-consultable
+}
+
+export async function listDevices(actor: Actor) {
+  assertPrivileged(actor);
+  return repoListDevices();
+}
+
+export async function setDeviceStatus(actor: Actor, id: string, status: HrDeviceStatus, audit: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction(async (client) => {
+    const d = await repoSetDeviceStatus(client, id, status);
+    if (!d) return null;
+    await insertAuditLog(client, audit, { action: "temps-deplacements.device.set_status", entity_type: "hr_time_clock_devices", entity_id: id, details: { status } });
+    return d;
+  });
+  if (!row) throw new HttpError(404, "HR_DEVICE_NOT_FOUND", "Borne introuvable.");
+  return row;
+}
+
+export async function rotateDeviceToken(actor: Actor, id: string, audit: AuditContext) {
+  assertPrivileged(actor);
+  const token = generateDeviceToken();
+  const device = await withTransaction(async (client) => {
+    const d = await repoRotateDeviceToken(client, id, hashDeviceToken(token));
+    if (!d) return null;
+    await insertAuditLog(client, audit, { action: "temps-deplacements.device.rotate_token", entity_type: "hr_time_clock_devices", entity_id: id, details: {} });
+    return d;
+  });
+  if (!device) throw new HttpError(404, "HR_DEVICE_NOT_FOUND", "Borne introuvable.");
+  return { device, token };
+}
+
+// -------------------------------------------------------------- Badges
+export async function createBadge(actor: Actor, input: { employee_id: string; badge_uid: string; badge_label: string | null }, audit: AuditContext) {
+  assertPrivileged(actor);
+  const emp = await repoGetEmployeeById(input.employee_id);
+  if (!emp) throw new HttpError(404, "HR_EMPLOYEE_NOT_FOUND", "Employé introuvable.");
+  return withTransaction(async (client) => {
+    const row = await repoCreateBadge(client, { employee_id: input.employee_id, badge_uid_hash: hashBadgeUid(input.badge_uid), badge_label: input.badge_label });
+    // JAMAIS le badge_uid en clair dans l'audit.
+    await insertAuditLog(client, audit, { action: "temps-deplacements.badge.create", entity_type: "hr_badge_credentials", entity_id: row.id, details: { employee_id: input.employee_id } });
+    return row;
+  });
+}
+
+export async function listBadges(actor: Actor, employeeId?: string) {
+  assertPrivileged(actor);
+  return withTransaction((client) => repoListBadges(client, employeeId));
+}
+
+export async function revokeBadge(actor: Actor, id: string, audit: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction(async (client) => {
+    const b = await repoRevokeBadge(client, id);
+    if (!b) return null;
+    await insertAuditLog(client, audit, { action: "temps-deplacements.badge.revoke", entity_type: "hr_badge_credentials", entity_id: id, details: {} });
+    return b;
+  });
+  if (!row) throw new HttpError(409, "HR_BADGE_NOT_ACTIVE", "Badge déjà révoqué ou introuvable.");
+  return row;
+}

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -160,6 +160,29 @@ export const vehicleBodySchema = z
   .strict();
 export type VehicleBody = z.infer<typeof vehicleBodySchema>;
 
+// --- T8 : bornes & badges ---
+export const deviceBodySchema = z
+  .object({
+    name: z.string().trim().min(1).max(200),
+    location: z.string().trim().max(300).nullable().default(null),
+    device_type: z.string().trim().max(100).nullable().default(null),
+  })
+  .strict();
+export type DeviceBody = z.infer<typeof deviceBodySchema>;
+
+export const deviceStatusSchema = z.object({ status: z.enum(["ACTIVE", "DISABLED"]) }).strict();
+
+export const badgeBodySchema = z
+  .object({
+    employee_id: z.string().uuid(),
+    badge_uid: z.string().trim().min(1, "badge_uid requis").max(256),
+    badge_label: z.string().trim().max(200).nullable().default(null),
+  })
+  .strict();
+export type BadgeBody = z.infer<typeof badgeBodySchema>;
+
+export const listBadgesQuerySchema = z.object({ employee_id: z.string().uuid().optional() });
+
 // --- T7 : exports paie ---
 export const HR_EXPORT_FORMATS = ["CSV", "PDF"] as const;
 export const exportBodySchema = z


### PR DESCRIPTION
## T8 — Bornes & badges (Refs #119)

CRUD admin bornes/badges (l'ingestion `device-events` existe depuis T2). **Token borne généré opaque, stocké HACHÉ, renvoyé en clair une seule fois** ; badge uid haché SHA-256.

- **Bornes** : `POST/GET /admin/devices`, `PATCH /:id/status`, `POST /:id/rotate-token`.
- **Badges** : `POST/GET /admin/badges`, `PATCH /:id/revoke`. Privilégié + audit **sans secret**.
- Empreinte `sha256` TS **==** `encode(digest(...),'hex')` PG (interop borne prouvée).

**Tests** : 7 unit · suite **255** verte · tsc 0. **Smoke cerp_test** (BEGIN/ROLLBACK, 0 résidu) : device-auth=1, badge-resolve=1, désactivée=0, révoqué=0. **Aucun cerp_prod, aucun main.** Voir `docs/temps-deplacements-t8-evidence.md`.