### PR TITLE
docs(temps-deplacements): T10 E2E plan/seeds + T11 rapport final & gate prod

### DIFF
--- a/db/seeds/temps-deplacements-e2e-cleanup.sql
+++ b/db/seeds/temps-deplacements-e2e-cleanup.sql
@@ -1,0 +1,31 @@
+-- Nettoyage du seed E2E « Temps & Déplacements » — cerp_test UNIQUEMENT.
+-- hr_time_events est append-only (triggers) : la purge des événements de test nécessite un superuser
+-- via session_replication_role='replica' (comme la rétention CA-SEC-03). À exécuter en tant que postgres.
+\set ON_ERROR_STOP on
+BEGIN;
+DO $$
+DECLARE v_emp uuid;
+BEGIN
+  SELECT id INTO v_emp FROM public.hr_employees WHERE matricule='TEST_TD_EMP';
+  IF v_emp IS NOT NULL THEN
+    -- Dérivés (CRUD normaux)
+    DELETE FROM public.hr_time_adjustments a USING public.hr_timesheet_days d WHERE a.target_type='DAY' AND a.target_id=d.id AND d.employee_id=v_emp;
+    DELETE FROM public.hr_kilometer_entries WHERE employee_id=v_emp;
+    DELETE FROM public.hr_timesheet_days WHERE employee_id=v_emp;
+    DELETE FROM public.hr_timesheet_weeks WHERE employee_id=v_emp;
+    DELETE FROM public.hr_time_anomalies WHERE employee_id=v_emp;
+    DELETE FROM public.hr_badge_credentials WHERE employee_id=v_emp;
+    -- Événements append-only : purge contrôlée (superuser)
+    SET session_replication_role='replica';
+    DELETE FROM public.hr_time_events WHERE employee_id=v_emp;
+    SET session_replication_role='origin';
+    DELETE FROM public.hr_employment_contracts WHERE employee_id=v_emp;
+    DELETE FROM public.hr_employees WHERE id=v_emp;
+  END IF;
+  DELETE FROM public.hr_time_rule_sets WHERE name='TEST 35h';
+  DELETE FROM public.hr_time_clock_devices WHERE device_token_hash=encode(digest('TEST_TD_TOKEN','sha256'),'hex');
+  DELETE FROM public.hr_payroll_export_batches WHERE exported_by IN (SELECT id FROM public.users WHERE username IN ('test_td_mgr','test_td_emp'));
+  DELETE FROM public.users WHERE username IN ('test_td_mgr','test_td_emp');
+END $$;
+COMMIT;
+SELECT count(*) AS restes FROM public.hr_employees WHERE matricule='TEST_TD_EMP';

--- a/db/seeds/temps-deplacements-e2e-seed.sql
+++ b/db/seeds/temps-deplacements-e2e-seed.sql
@@ -1,0 +1,56 @@
+-- Seed E2E « Temps & Déplacements » — cerp_test UNIQUEMENT (jamais prod).
+-- Idempotent. À exécuter APRÈS déploiement du backend dev sur cerp_test, pour la validation navigateur.
+-- Nettoyage : db/seeds/temps-deplacements-e2e-cleanup.sql. Identifiants de TEST (non secrets) :
+--   token borne   = 'TEST_TD_TOKEN'      (à saisir dans la page borne)
+--   badge uid     = 'TEST_TD_BADGE'      (à « taper » sur la borne)
+--   employé user  = 'test_td_emp' / mot de passe applicatif à définir hors seed
+--   manager user  = 'test_td_mgr' (rôle Directeur ⇒ privilégié RH)
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- Utilisateurs de test (contraintes users : rôle/gender/tel/postcode/country valides).
+INSERT INTO public.users (username,password,name,surname,email,tel_no,role,gender,address,lane,house_no,postcode,date_of_birth,social_security_number)
+SELECT 'test_td_mgr','$2b$10$placeholderplaceholderplaceholderplaceholderphash','Test','Manager','test_td_mgr@example.invalid','+33612345678','Directeur','Male','Atelier','Rue','1','75001',DATE '1980-01-01','TEST-MGR'
+WHERE NOT EXISTS (SELECT 1 FROM public.users WHERE username='test_td_mgr');
+INSERT INTO public.users (username,password,name,surname,email,tel_no,role,gender,address,lane,house_no,postcode,date_of_birth,social_security_number)
+SELECT 'test_td_emp','$2b$10$placeholderplaceholderplaceholderplaceholderphash','Test','Salarié','test_td_emp@example.invalid','+33612345679','Employee','Female','Atelier','Rue','2','75001',DATE '1990-01-01','TEST-EMP'
+WHERE NOT EXISTS (SELECT 1 FROM public.users WHERE username='test_td_emp');
+
+DO $$
+DECLARE v_mgr int; v_emp_user int; v_emp uuid; v_rs uuid;
+BEGIN
+  SELECT id INTO v_mgr FROM public.users WHERE username='test_td_mgr';
+  SELECT id INTO v_emp_user FROM public.users WHERE username='test_td_emp';
+
+  -- Règle 35h de test
+  SELECT id INTO v_rs FROM public.hr_time_rule_sets WHERE name='TEST 35h';
+  IF v_rs IS NULL THEN
+    INSERT INTO public.hr_time_rule_sets (name, weekly_target_minutes, daily_target_minutes, overtime_threshold_1_minutes, overtime_rate_1, overtime_threshold_2_minutes, overtime_rate_2)
+      VALUES ('TEST 35h',2100,420,2100,1.25,2580,1.5) RETURNING id INTO v_rs;
+  END IF;
+
+  -- Employé de test (matricule TEST_TD_EMP), rattaché au manager de test
+  SELECT id INTO v_emp FROM public.hr_employees WHERE matricule='TEST_TD_EMP';
+  IF v_emp IS NULL THEN
+    INSERT INTO public.hr_employees (user_id, matricule, status, manager_user_id) VALUES (v_emp_user,'TEST_TD_EMP','ACTIVE', v_mgr) RETURNING id INTO v_emp;
+  END IF;
+
+  -- Contrat actif H35 lié à la règle
+  IF NOT EXISTS (SELECT 1 FROM public.hr_employment_contracts WHERE employee_id=v_emp AND active) THEN
+    INSERT INTO public.hr_employment_contracts (employee_id, contract_type, weekly_hours_target, daily_hours_target, start_date, rule_set_id, active)
+      VALUES (v_emp,'H35',35,7,'2026-01-01', v_rs, true);
+  END IF;
+
+  -- Badge de test (uid haché)
+  IF NOT EXISTS (SELECT 1 FROM public.hr_badge_credentials WHERE badge_uid_hash=encode(digest('TEST_TD_BADGE','sha256'),'hex') AND active) THEN
+    INSERT INTO public.hr_badge_credentials (employee_id, badge_uid_hash, badge_label, active) VALUES (v_emp, encode(digest('TEST_TD_BADGE','sha256'),'hex'),'Badge test', true);
+  END IF;
+
+  -- Borne de test (token haché)
+  IF NOT EXISTS (SELECT 1 FROM public.hr_time_clock_devices WHERE device_token_hash=encode(digest('TEST_TD_TOKEN','sha256'),'hex')) THEN
+    INSERT INTO public.hr_time_clock_devices (name, location, device_type, device_token_hash, status) VALUES ('Borne test','Atelier','KIOSK', encode(digest('TEST_TD_TOKEN','sha256'),'hex'),'ACTIVE');
+  END IF;
+END $$;
+
+COMMIT;
+SELECT 'seed OK — employé=' || (SELECT matricule FROM public.hr_employees WHERE matricule='TEST_TD_EMP') AS resultat;

--- a/docs/ai/temps-deplacements-final-report.md
+++ b/docs/ai/temps-deplacements-final-report.md
@@ -1,0 +1,74 @@
+# Temps & Déplacements — Rapport final (T1→T11)
+
+Issue #119. Mode max autonome. Cible **cerp_test**. **Aucun `cerp_prod`, aucun `main`, aucune release,
+aucune paie réelle** touchés. Module construit en tranches testées, chacune mergée vers `dev` avec CI verte.
+
+## 1. Statut global
+
+| Tranche | Livré | PRs |
+|---|---|---|
+| **T1** socle DB (15 tables `hr_*`, append-only, ownership) | ✅ | back #64 |
+| **T2** backend pointage (append-only, badge/borne, journée/semaine, anomalies) | ✅ | back (mergé) |
+| **T3** frontend salarié (pointer, relevé, anomalies) | ✅ | front #121 |
+| **T4** validation responsable (corrections tracées, validation, périmètre) | ✅ | back #66, front #122 |
+| **T5** contrats/horaires/règles 35h-39h configurables + admin RH | ✅ | back #68, front #123 |
+| **T6** kilomètres (déclaration + validation) | ✅ | back #70, front #125 |
+| **T7** exports CSV/PDF figés + checksum | ✅ | back #69, front #124 |
+| **T8** bornes/badges + page borne (kiosk HID) | ✅ | back #71, front #126 |
+| **T9** conformité/preuves + registre risques | ✅ | front #127 |
+| **T10** E2E : **chaîne service/DB validée** ; navigateur **gated** (déploiement) | 🟡 | ce dossier + seeds |
+| **T11** rapport final + gate prod | ✅ | ce document |
+
+## 2. Module utilisable ?
+
+- **Côté code (`dev`)** : **oui, complet** — un salarié pointe (web/borne), voit journée/semaine calculées
+  avec règles réelles (35/39/partiel, HS 25/50), déclare ses km ; un responsable valide corrections,
+  jours/semaines et km, administre règles/contrats/horaires/bornes/badges, génère des exports paie figés.
+- **Exécutable navigateur sur `cerp_test`** : **en attente** du déploiement backend (T10, gate humain).
+  Toute la chaîne est validée au niveau service/DB par smokes `BEGIN…ROLLBACK` (0 résidu).
+
+## 3. Tests
+
+- **Backend** : 255 tests / 50 fichiers, `tsc --noEmit` = 0.
+- **Frontend** : 105 tests / 36 fichiers, typecheck 0, lint 0 erreur, build OK.
+- **Smokes cerp_test** : T2, T4, T5, T6, T7, T8 + **chaîne complète T10** — tous verts, 0 donnée persistée.
+
+## 4. Conformité (audit interne, sans prétention ISO)
+
+Dossier `crp-systems-web/compliance/iso27001/evidence/time-clock-module.md` + `…-risk-register.md`.
+Contrôles implémentés (preuve disponible) : append-only, anti-IDOR, séparation des tâches (no self-approve),
+hachage secrets (badge/token SHA-256, jamais loggés), audit systématique, intégrité export (checksum),
+minimisation RGPD (pas de biométrie ni géoloc continue), règles configurables (aucun 35/39 en dur), socle
+default-deny. Écarts ouverts EC-01…EC-05 tracés.
+
+## 5. Gate prod (validation humaine requise — NON exécuté par l'agent)
+
+À dérouler, dans l'ordre, sous validation du propriétaire, avec backup préalable :
+
+1. **Migrations prod** (`db/patches/20260709_hr_temps_deplacements.sql`, `20260710_hr_users_role_responsable_rh.sql`)
+   appliquées sur `cerp_prod` **après backup**, en direct psql (pas le runner), avec verify.
+2. **Hardening append-only prod** : `db/privileged/20260709_hr_time_events_append_only.*` +
+   `20260709_hr_module_ownership.*` sur `cerp_prod` (superuser, backup préalable, verify).
+3. **Déploiement backend** (image `dev`→release) exposant `/time-clock/*` en prod.
+4. **Provisioning rôles** : créer les comptes `Responsable RH` / valider les managers (`manager_user_id`).
+5. **Données de référence** : règles de calcul réelles (35h/39h/partiel), contrats, horaires, véhicules,
+   bornes (jetons distribués), badges.
+6. **Recette navigateur** prod (20 scénarios T10) + revue des logs d'audit.
+7. **Purge/rétention** RGPD (EC-02) : planifier le job (aujourd'hui manuel DBA).
+
+## 6. Écarts ouverts (rappel)
+
+EC-01 E2E navigateur (déploiement) · EC-02 rétention automatisée · EC-03 append-only prod ·
+EC-04 application numérique d'une correction approuvée · EC-05 filtrage nav par rôle.
+
+## 7. Garde-fous respectés
+
+Aucune écriture `cerp_prod` ; aucun merge `main` ; aucune release ; aucun secret en clair (hachage
+SHA-256, jetons renvoyés 1×, jamais loggés) ; aucune donnée test persistée (smokes en `ROLLBACK`) ; pas de
+biométrie ni géolocalisation continue ; aucun lien/import Excel (exports maison CSV/PDF). Conformité
+formulée « contrôle implémenté / preuve disponible / écart ouvert ».
+
+## Prochaine action recommandée
+
+Exécuter le **gate prod** (§5) sous validation humaine, en commençant par le déploiement backend sur
+cerp_test pour lever EC-01 et dérouler la recette navigateur (T10).

--- a/docs/temps-deplacements-t10-e2e-plan.md
+++ b/docs/temps-deplacements-t10-e2e-plan.md
@@ -1,0 +1,73 @@
+# T10 — Validation E2E sur cerp_test
+
+## Ce qui est prouvé automatiquement (niveau service/DB)
+
+Chaîne complète exercée sur cerp_test en une transaction `BEGIN…ROLLBACK` (0 résidu) —
+`scratchpad/t10_e2e_chain.sql` :
+
+```
+A POINTAGE→MINUTES: worked=420 brk=60 (attendu 420 / 60)
+B CORRECTION: approuvée_par_tiers=t
+C VALIDATION: jour+semaine=t
+D KILOMETRES: validés=t
+E EXPORT: lot créé (matches=1)
+F BORNE_AUTH: matches=1
+G BADGE_RESOLVE: matches=1
+residus_emp = 0 ; residus_user = 0
+```
+
++ smokes par tranche (T2 idempotence/append-only, T4 self-approve, T5 résolution règles, T6 km, T7 export,
+T8 borne/badge). Le modèle événement→minutes, les transitions d'état, les contraintes (append-only,
+one-active, no-self-approve) et la résolution borne/badge sont donc validés côté données.
+
+## Blocage — validation NAVIGATEUR
+
+La validation navigateur complète nécessite le **backend T2+ exécuté contre cerp_test**. Il n'est
+aujourd'hui déployé nulle part (l'atelier sert le backend de prod). Deux options, toutes deux **hors
+périmètre « code sur dev »** ⇒ **validation humaine / infra** :
+
+1. Déploiement temporaire d'une instance backend (`origin/dev`) avec un `.env` pointant cerp_test
+   (nécessite le mot de passe `cerp_app` — non manipulé par l'agent).
+2. Exécution locale via tunnel SSH vers la base atelier (même prérequis d'identifiants).
+
+Tant que ce prérequis n'est pas levé, l'E2E navigateur reste **gated**. Le front (déployé) n'expose pas
+`/time-clock` côté prod : normal.
+
+## Procédure (une fois le backend déployé sur cerp_test)
+
+1. `psql -f db/seeds/temps-deplacements-e2e-seed.sql` (crée employé `TEST_TD_EMP`, manager, règle 35h,
+   contrat, badge `TEST_TD_BADGE`, borne token `TEST_TD_TOKEN`). Définir les mots de passe applicatifs
+   des comptes de test hors seed.
+2. Dérouler les 20 scénarios ci-dessous.
+3. `psql -f db/seeds/temps-deplacements-e2e-cleanup.sql` (purge, superuser — événements append-only).
+
+## 20 scénarios navigateur
+
+Salarié (`test_td_emp`) :
+1. Login → menu « Temps & Déplacements » visible.
+2. Mon pointage : pointer Entrée → toast succès, point vert.
+3. Pointer Pause puis Retour → temps de pause affiché.
+4. Pointer Sortie → journée calculée (temps travaillé cohérent).
+5. Double-clic Entrée < 90 s → « double badge » (orange), pas de doublon.
+6. Mon relevé : jour + semaine (cible 35h, HS/absence corrects).
+7. Mes anomalies : liste vide/pertinente selon le pointage.
+8. Mes kilomètres : déclarer un trajet (brouillon) → apparaît en DRAFT.
+9. Soumettre le trajet → statut SUBMITTED.
+10. Tentative d'accès « Administration RH » → « espace réservé » (gate rôle).
+
+Responsable (`test_td_mgr`, Directeur) :
+11. Équipe du jour : voir `TEST_TD_EMP` + KPIs.
+12. Corrections à valider : approuver une demande → disparaît de la liste.
+13. Refuser une autre demande → statut REJECTED.
+14. Kilomètres équipe : valider le trajet soumis (10→SUBMITTED) → VALIDATED.
+15. Administration RH · Règles : créer une règle 39h.
+16. Administration RH · Contrats : créer un 2ᵉ contrat actif → erreur « contrat actif existe déjà ».
+17. Administration RH · Horaires : ajouter/supprimer un horaire.
+18. Administration RH · Bornes : créer une borne → **jeton affiché une seule fois** ; désactiver.
+19. Administration RH · Exports : générer un CSV, télécharger → fichier `;`+BOM, checksum affiché.
+20. Borne de pointage : saisir `TEST_TD_TOKEN`, sélectionner Entrée, « taper » `TEST_TD_BADGE`+Entrée →
+    feedback **vert** ; badge inconnu → **rouge**.
+
+## Critère de succès
+
+20/20 verts, aucune fuite de secret (jeton/UID) à l'écran ou en console, `cleanup` → 0 reste.


### PR DESCRIPTION
## T10 + T11 (Refs #119)

**T10** — chaîne complète service/DB validée sur cerp_test (`BEGIN/ROLLBACK`, 0 résidu) : pointage→420min, correction par tiers, validation jour/semaine, km, export, borne/badge. Validation **navigateur = gated** (déploiement backend, validation humaine). Ajoute `db/seeds/temps-deplacements-e2e-seed.sql` + `…-cleanup.sql` (idempotents ; append-only purgé en superuser) + `docs/temps-deplacements-t10-e2e-plan.md` (20 scénarios).

**T11** — `docs/ai/temps-deplacements-final-report.md` : rapport final T1→T11 (statut, tests **255** back / **105** front, conformité, écarts) + **plan de gate prod** ordonné.

Docs/seeds-only. **Aucun cerp_prod, aucun main.**