### PR TITLE
release(temps-deplacements): module complet T1→T11 dev → main (prod pilote #119)

### DIFF
--- a/db/patches/20260709_hr_temps_deplacements.sql
+++ b/db/patches/20260709_hr_temps_deplacements.sql
@@ -1,0 +1,301 @@
+-- Module « Temps & Déplacements » (Pointage & Kilomètres) — T1 schéma de base.
+-- Issue frontend #119 ; archi: crp-systems-web/docs/architecture/module-temps-pointage-kilometres.md ;
+-- ADR-0013. Migration ADDITIVE + IDEMPOTENTE uniquement (aucun DROP, aucun changement de type).
+-- Append-only de hr_time_events durci séparément par db/privileged/20260709_hr_time_events_append_only.sql
+-- (owner/grants/triggers superuser). Aucun lien avec d'anciens fichiers. cerp_test d'abord.
+
+DO $$ BEGIN EXECUTE 'CREATE EXTENSION IF NOT EXISTS pgcrypto';
+EXCEPTION WHEN insufficient_privilege THEN RAISE NOTICE 'skip CREATE EXTENSION pgcrypto (privileges)'; END $$;
+
+-- ------------------------------------------------------------------ Enums (gardés)
+DO $$ BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_employee_status') THEN CREATE TYPE public.hr_employee_status AS ENUM ('ACTIVE','SUSPENDED','LEFT'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_contract_type') THEN CREATE TYPE public.hr_contract_type AS ENUM ('H35','H39','PARTIAL','OTHER'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_device_status') THEN CREATE TYPE public.hr_device_status AS ENUM ('ACTIVE','DISABLED'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_event_type') THEN CREATE TYPE public.hr_event_type AS ENUM ('IN','OUT','BREAK_START','BREAK_END','MISSION_START','MISSION_END'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_event_source') THEN CREATE TYPE public.hr_event_source AS ENUM ('BADGE','WEB','MOBILE','ADMIN','IMPORT'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_session_status') THEN CREATE TYPE public.hr_session_status AS ENUM ('OK','ANOMALY','MANUAL_REVIEW','VALIDATED'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_validation_status') THEN CREATE TYPE public.hr_validation_status AS ENUM ('DRAFT','TO_REVIEW','VALIDATED','EXPORTED'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_adjustment_target') THEN CREATE TYPE public.hr_adjustment_target AS ENUM ('EVENT','DAY','WEEK'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_adjustment_status') THEN CREATE TYPE public.hr_adjustment_status AS ENUM ('REQUESTED','APPROVED','REJECTED'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_anomaly_type') THEN CREATE TYPE public.hr_anomaly_type AS ENUM ('MISSING_IN','MISSING_OUT','MISSING_BREAK_END','DOUBLE_BADGE','TOO_LONG_DAY','TOO_SHORT_BREAK','OUTSIDE_SCHEDULE'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_anomaly_severity') THEN CREATE TYPE public.hr_anomaly_severity AS ENUM ('INFO','WARNING','CRITICAL'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_vehicle_owner') THEN CREATE TYPE public.hr_vehicle_owner AS ENUM ('COMPANY','PERSONAL'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_km_type') THEN CREATE TYPE public.hr_km_type AS ENUM ('MISSION','CLIENT','FOURNISSEUR','LIVRAISON','AUTRE'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_km_status') THEN CREATE TYPE public.hr_km_status AS ENUM ('DRAFT','SUBMITTED','VALIDATED','REJECTED'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_export_format') THEN CREATE TYPE public.hr_export_format AS ENUM ('CSV','PDF'); END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_export_status') THEN CREATE TYPE public.hr_export_status AS ENUM ('GENERATED','DELIVERED','SUPERSEDED'); END IF;
+END $$;
+
+-- ------------------------------------------------------------------ Référentiel employé & règles
+CREATE TABLE IF NOT EXISTS public.hr_employees (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  user_id integer NOT NULL,
+  matricule text NOT NULL,
+  service text NULL,
+  manager_user_id integer NULL,
+  status public.hr_employee_status NOT NULL DEFAULT 'ACTIVE',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_employees_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_employees_user_id_key UNIQUE (user_id),
+  CONSTRAINT hr_employees_matricule_key UNIQUE (matricule),
+  CONSTRAINT hr_employees_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT hr_employees_manager_user_id_fkey FOREIGN KEY (manager_user_id) REFERENCES public.users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS hr_employees_manager_idx ON public.hr_employees(manager_user_id) WHERE manager_user_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.hr_time_rule_sets (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  weekly_target_minutes integer NOT NULL,
+  daily_target_minutes integer NOT NULL,
+  overtime_threshold_1_minutes integer NULL,
+  overtime_rate_1 numeric(5,3) NULL,
+  overtime_threshold_2_minutes integer NULL,
+  overtime_rate_2 numeric(5,3) NULL,
+  rounding_rule jsonb NOT NULL DEFAULT '{}'::jsonb,
+  break_rule jsonb NOT NULL DEFAULT '{}'::jsonb,
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_time_rule_sets_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_time_rule_sets_targets_ck CHECK (weekly_target_minutes >= 0 AND daily_target_minutes >= 0)
+);
+
+CREATE TABLE IF NOT EXISTS public.hr_employment_contracts (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  contract_type public.hr_contract_type NOT NULL,
+  weekly_hours_target numeric(6,2) NOT NULL,
+  daily_hours_target numeric(5,2) NULL,
+  start_date date NOT NULL,
+  end_date date NULL,
+  active boolean NOT NULL DEFAULT true,
+  rule_set_id uuid NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_employment_contracts_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_employment_contracts_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  CONSTRAINT hr_employment_contracts_rule_set_id_fkey FOREIGN KEY (rule_set_id) REFERENCES public.hr_time_rule_sets(id) ON DELETE SET NULL,
+  CONSTRAINT hr_employment_contracts_dates_ck CHECK (end_date IS NULL OR end_date >= start_date)
+);
+CREATE INDEX IF NOT EXISTS hr_employment_contracts_employee_idx ON public.hr_employment_contracts(employee_id);
+CREATE UNIQUE INDEX IF NOT EXISTS hr_employment_contracts_one_active_idx ON public.hr_employment_contracts(employee_id) WHERE active;
+
+CREATE TABLE IF NOT EXISTS public.hr_work_schedules (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  day_of_week integer NOT NULL,
+  expected_start time NULL,
+  expected_end time NULL,
+  expected_break_minutes integer NOT NULL DEFAULT 0,
+  flexible_start_window integer NOT NULL DEFAULT 0,
+  flexible_end_window integer NOT NULL DEFAULT 0,
+  active boolean NOT NULL DEFAULT true,
+  CONSTRAINT hr_work_schedules_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_work_schedules_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  CONSTRAINT hr_work_schedules_dow_ck CHECK (day_of_week BETWEEN 0 AND 6)
+);
+CREATE INDEX IF NOT EXISTS hr_work_schedules_employee_idx ON public.hr_work_schedules(employee_id);
+
+-- ------------------------------------------------------------------ Bornes & badges
+CREATE TABLE IF NOT EXISTS public.hr_time_clock_devices (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  name text NOT NULL,
+  location text NULL,
+  device_type text NULL,
+  device_token_hash text NULL,
+  status public.hr_device_status NOT NULL DEFAULT 'ACTIVE',
+  last_seen_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_time_clock_devices_pkey PRIMARY KEY (id)
+);
+
+CREATE TABLE IF NOT EXISTS public.hr_badge_credentials (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  badge_uid_hash text NOT NULL,
+  badge_label text NULL,
+  active boolean NOT NULL DEFAULT true,
+  issued_at timestamptz NOT NULL DEFAULT now(),
+  revoked_at timestamptz NULL,
+  CONSTRAINT hr_badge_credentials_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_badge_credentials_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hr_badge_credentials_active_uid_idx ON public.hr_badge_credentials(badge_uid_hash) WHERE active;
+
+-- ------------------------------------------------------------------ Événements bruts (append-only ; hardening en db/privileged)
+CREATE TABLE IF NOT EXISTS public.hr_time_events (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  device_id uuid NULL,
+  event_type public.hr_event_type NOT NULL,
+  event_time timestamptz NOT NULL,
+  source public.hr_event_source NOT NULL DEFAULT 'WEB',
+  idempotency_key text NULL,
+  raw_payload_json jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_time_events_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_time_events_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE RESTRICT,
+  CONSTRAINT hr_time_events_device_id_fkey FOREIGN KEY (device_id) REFERENCES public.hr_time_clock_devices(id) ON DELETE SET NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS hr_time_events_idempotency_key_idx ON public.hr_time_events(idempotency_key) WHERE idempotency_key IS NOT NULL;
+CREATE INDEX IF NOT EXISTS hr_time_events_employee_time_idx ON public.hr_time_events(employee_id, event_time);
+
+-- ------------------------------------------------------------------ Agrégats calculés
+CREATE TABLE IF NOT EXISTS public.hr_work_sessions (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  date date NOT NULL,
+  start_time timestamptz NULL,
+  end_time timestamptz NULL,
+  break_minutes integer NOT NULL DEFAULT 0,
+  worked_minutes integer NOT NULL DEFAULT 0,
+  computed_from_events jsonb NOT NULL DEFAULT '{}'::jsonb,
+  status public.hr_session_status NOT NULL DEFAULT 'OK',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_work_sessions_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_work_sessions_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS hr_work_sessions_employee_date_idx ON public.hr_work_sessions(employee_id, date);
+
+CREATE TABLE IF NOT EXISTS public.hr_timesheet_days (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  date date NOT NULL,
+  expected_minutes integer NOT NULL DEFAULT 0,
+  worked_minutes integer NOT NULL DEFAULT 0,
+  overtime_minutes integer NOT NULL DEFAULT 0,
+  missing_minutes integer NOT NULL DEFAULT 0,
+  anomaly_count integer NOT NULL DEFAULT 0,
+  validation_status public.hr_validation_status NOT NULL DEFAULT 'DRAFT',
+  validated_by integer NULL,
+  validated_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_timesheet_days_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_timesheet_days_employee_date_key UNIQUE (employee_id, date),
+  CONSTRAINT hr_timesheet_days_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  CONSTRAINT hr_timesheet_days_validated_by_fkey FOREIGN KEY (validated_by) REFERENCES public.users(id) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.hr_timesheet_weeks (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  week_start date NOT NULL,
+  week_end date NOT NULL,
+  contract_minutes integer NOT NULL DEFAULT 0,
+  worked_minutes integer NOT NULL DEFAULT 0,
+  overtime_25_minutes integer NOT NULL DEFAULT 0,
+  overtime_50_minutes integer NOT NULL DEFAULT 0,
+  absence_minutes integer NOT NULL DEFAULT 0,
+  validation_status public.hr_validation_status NOT NULL DEFAULT 'DRAFT',
+  validated_by integer NULL,
+  validated_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_timesheet_weeks_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_timesheet_weeks_employee_week_key UNIQUE (employee_id, week_start),
+  CONSTRAINT hr_timesheet_weeks_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  CONSTRAINT hr_timesheet_weeks_validated_by_fkey FOREIGN KEY (validated_by) REFERENCES public.users(id) ON DELETE SET NULL,
+  CONSTRAINT hr_timesheet_weeks_dates_ck CHECK (week_end >= week_start)
+);
+
+-- ------------------------------------------------------------------ Corrections & anomalies
+CREATE TABLE IF NOT EXISTS public.hr_time_adjustments (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  target_type public.hr_adjustment_target NOT NULL,
+  target_id uuid NOT NULL,
+  old_value_json jsonb NULL,
+  new_value_json jsonb NULL,
+  reason text NOT NULL,
+  requested_by integer NOT NULL,
+  approved_by integer NULL,
+  status public.hr_adjustment_status NOT NULL DEFAULT 'REQUESTED',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  approved_at timestamptz NULL,
+  CONSTRAINT hr_time_adjustments_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_time_adjustments_requested_by_fkey FOREIGN KEY (requested_by) REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT hr_time_adjustments_approved_by_fkey FOREIGN KEY (approved_by) REFERENCES public.users(id) ON DELETE SET NULL,
+  CONSTRAINT hr_time_adjustments_reason_ck CHECK (length(btrim(reason)) > 0),
+  CONSTRAINT hr_time_adjustments_no_self_approve_ck CHECK (approved_by IS NULL OR approved_by <> requested_by)
+);
+CREATE INDEX IF NOT EXISTS hr_time_adjustments_target_idx ON public.hr_time_adjustments(target_type, target_id);
+CREATE INDEX IF NOT EXISTS hr_time_adjustments_status_idx ON public.hr_time_adjustments(status);
+
+CREATE TABLE IF NOT EXISTS public.hr_time_anomalies (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  date date NOT NULL,
+  anomaly_type public.hr_anomaly_type NOT NULL,
+  severity public.hr_anomaly_severity NOT NULL DEFAULT 'WARNING',
+  message text NULL,
+  resolved_by integer NULL,
+  resolved_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_time_anomalies_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_time_anomalies_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  CONSTRAINT hr_time_anomalies_resolved_by_fkey FOREIGN KEY (resolved_by) REFERENCES public.users(id) ON DELETE SET NULL
+);
+CREATE INDEX IF NOT EXISTS hr_time_anomalies_employee_date_idx ON public.hr_time_anomalies(employee_id, date);
+
+-- ------------------------------------------------------------------ Véhicules & kilomètres
+CREATE TABLE IF NOT EXISTS public.hr_vehicles (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  label text NOT NULL,
+  plate text NULL,
+  owner_type public.hr_vehicle_owner NOT NULL DEFAULT 'COMPANY',
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT hr_vehicles_pkey PRIMARY KEY (id)
+);
+
+-- Refs métier (affaire_id/client_id/fournisseur_id) volontairement SANS FK dure en T1
+-- (couplage/typage à valider en T6-kilomètres) ; colonnes nullable = références souples.
+CREATE TABLE IF NOT EXISTS public.hr_kilometer_entries (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  employee_id uuid NOT NULL,
+  date date NOT NULL,
+  type public.hr_km_type NOT NULL DEFAULT 'MISSION',
+  vehicle_id uuid NULL,
+  start_location text NULL,
+  end_location text NULL,
+  start_odometer numeric(10,1) NULL,
+  end_odometer numeric(10,1) NULL,
+  distance_km numeric(10,2) NOT NULL DEFAULT 0,
+  affaire_id bigint NULL,
+  client_id integer NULL,
+  fournisseur_id integer NULL,
+  proof_document_id uuid NULL,
+  status public.hr_km_status NOT NULL DEFAULT 'DRAFT',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  validated_by integer NULL,
+  validated_at timestamptz NULL,
+  CONSTRAINT hr_kilometer_entries_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_kilometer_entries_employee_id_fkey FOREIGN KEY (employee_id) REFERENCES public.hr_employees(id) ON DELETE CASCADE,
+  CONSTRAINT hr_kilometer_entries_vehicle_id_fkey FOREIGN KEY (vehicle_id) REFERENCES public.hr_vehicles(id) ON DELETE SET NULL,
+  CONSTRAINT hr_kilometer_entries_validated_by_fkey FOREIGN KEY (validated_by) REFERENCES public.users(id) ON DELETE SET NULL,
+  CONSTRAINT hr_kilometer_entries_distance_ck CHECK (distance_km >= 0)
+);
+CREATE INDEX IF NOT EXISTS hr_kilometer_entries_employee_date_idx ON public.hr_kilometer_entries(employee_id, date);
+
+-- ------------------------------------------------------------------ Exports figés
+CREATE TABLE IF NOT EXISTS public.hr_payroll_export_batches (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  period_start date NOT NULL,
+  period_end date NOT NULL,
+  exported_by integer NOT NULL,
+  exported_at timestamptz NOT NULL DEFAULT now(),
+  format public.hr_export_format NOT NULL,
+  frozen_snapshot_json jsonb NOT NULL DEFAULT '{}'::jsonb,
+  checksum text NULL,
+  supersedes_id uuid NULL,
+  status public.hr_export_status NOT NULL DEFAULT 'GENERATED',
+  CONSTRAINT hr_payroll_export_batches_pkey PRIMARY KEY (id),
+  CONSTRAINT hr_payroll_export_batches_exported_by_fkey FOREIGN KEY (exported_by) REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT hr_payroll_export_batches_supersedes_fkey FOREIGN KEY (supersedes_id) REFERENCES public.hr_payroll_export_batches(id) ON DELETE SET NULL,
+  CONSTRAINT hr_payroll_export_batches_period_ck CHECK (period_end >= period_start)
+);
+CREATE INDEX IF NOT EXISTS hr_payroll_export_batches_period_idx ON public.hr_payroll_export_batches(period_start, period_end);

--- a/db/patches/20260710_hr_users_role_responsable_rh.sql
+++ b/db/patches/20260710_hr_users_role_responsable_rh.sql
@@ -1,0 +1,25 @@
+-- 20260710_hr_users_role_responsable_rh.sql
+-- T5 (#119) — Élargit users_role_check pour autoriser le rôle « Responsable RH ».
+-- ADDITIF & SÛR : n'ajoute qu'une valeur permise (élargissement d'un CHECK ⇒ aucune ligne existante
+-- ne peut devenir invalide). Idempotent (DROP IF EXISTS + recréation). Ne supprime aucun rôle existant.
+-- Contexte : le validateur applicatif autorisait déjà « Responsable RH » mais la contrainte DB non,
+-- empêchant la création d'un tel utilisateur (écart ouvert en T4).
+
+BEGIN;
+
+ALTER TABLE public.users DROP CONSTRAINT IF EXISTS users_role_check;
+
+ALTER TABLE public.users
+  ADD CONSTRAINT users_role_check CHECK (
+    (role)::text = ANY (ARRAY[
+      'Directeur'::text,
+      'Employee'::text,
+      'Administrateur Systeme et Reseau'::text,
+      'Responsable Qualité'::text,
+      'Secretaire'::text,
+      'Responsable Programmation'::text,
+      'Responsable RH'::text
+    ])
+  );
+
+COMMIT;

--- a/db/privileged/20260709_hr_module_ownership.rollback.sql
+++ b/db/privileged/20260709_hr_module_ownership.rollback.sql
@@ -1,0 +1,28 @@
+-- ROLLBACK for 20260709_hr_module_ownership.sql   (SUPERUSER ONLY)
+--
+-- Rend les 14 tables CRUD du module à postgres (état « appliqué en direct sans normalisation »).
+-- hr_time_events n'est pas concerné (géré par son propre append-only). Non destructif, idempotent.
+--
+--   sudo -u postgres psql -d <db> -f db/privileged/20260709_hr_module_ownership.rollback.sql
+
+BEGIN;
+
+DO $rb$
+DECLARE
+  t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'hr_employees','hr_time_rule_sets','hr_employment_contracts','hr_work_schedules',
+    'hr_time_clock_devices','hr_badge_credentials','hr_work_sessions','hr_timesheet_days',
+    'hr_timesheet_weeks','hr_time_adjustments','hr_time_anomalies','hr_vehicles',
+    'hr_kilometer_entries','hr_payroll_export_batches'
+  ]
+  LOOP
+    IF to_regclass('public.' || t) IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.%I OWNER TO postgres', t);
+    END IF;
+  END LOOP;
+END
+$rb$;
+
+COMMIT;

--- a/db/privileged/20260709_hr_module_ownership.sql
+++ b/db/privileged/20260709_hr_module_ownership.sql
@@ -1,0 +1,54 @@
+-- 20260709_hr_module_ownership.sql   (PRIVILEGED — SUPERUSER ONLY)
+--
+-- Module « Temps & Déplacements » — normalise la PROPRIÉTÉ des 14 tables CRUD vers cerp_app.
+--
+-- POURQUOI
+--   La migration db/patches/20260709_hr_temps_deplacements.sql crée les tables. Appliquée
+--   par le RUNNER (as cerp_app) → cerp_app en est owner (rien à faire). Mais appliquée
+--   directement en `postgres` (hors runner — p.ex. cerp_test dont le .env du runner pointe
+--   cerp_prod, ou une application DBA), les tables restent postgres-owned et cerp_app ne peut
+--   pas les manipuler. Ce fichier rend la propriété REPRODUCTIBLE quel que soit le mode
+--   d'application (idempotent : no-op si déjà cerp_app).
+--
+--   NB : hr_time_events est VOLONTAIREMENT EXCLU — il doit rester owned par postgres
+--   (append-only, cf. 20260709_hr_time_events_append_only.sql).
+--
+--   `ALTER TABLE ... OWNER TO` ne supporte PAS une liste de tables → une instruction par
+--   table (ici via une boucle DO).
+--
+--   sudo -u postgres psql -d cerp_test -f db/privileged/20260709_hr_module_ownership.sql
+--   sudo -u postgres psql -d cerp_prod -f db/privileged/20260709_hr_module_ownership.sql   (T10 seulement)
+--
+-- SAFETY : idempotent, non destructif. Rollback/verify fournis à côté. Superuser (postgres).
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF NOT COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false) THEN
+    RAISE EXCEPTION 'hr_module_ownership: doit être appliqué par un superuser; current_user=% ne l''est pas', current_user;
+  END IF;
+END
+$guard$;
+
+DO $own$
+DECLARE
+  t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'hr_employees','hr_time_rule_sets','hr_employment_contracts','hr_work_schedules',
+    'hr_time_clock_devices','hr_badge_credentials','hr_work_sessions','hr_timesheet_days',
+    'hr_timesheet_weeks','hr_time_adjustments','hr_time_anomalies','hr_vehicles',
+    'hr_kilometer_entries','hr_payroll_export_batches'
+  ]
+  LOOP
+    IF to_regclass('public.' || t) IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.%I OWNER TO cerp_app', t);
+    ELSE
+      RAISE NOTICE 'hr_module_ownership: table public.% absente — ignorée', t;
+    END IF;
+  END LOOP;
+END
+$own$;
+
+COMMIT;

--- a/db/privileged/20260709_hr_module_ownership.verify.sql
+++ b/db/privileged/20260709_hr_module_ownership.verify.sql
@@ -1,0 +1,28 @@
+-- VERIFY — propriété des tables du module « Temps & Déplacements ».   (sur cerp_test)
+--
+--   sudo -u postgres psql -d cerp_test -f db/privileged/20260709_hr_module_ownership.verify.sql
+--
+-- Attendu :
+--   14 tables CRUD  -> owner = cerp_app
+--   hr_time_events  -> owner = postgres        (append-only)
+--   crud_not_cerp_app = 0                       (aucune table CRUD hors cerp_app)
+
+\pset pager off
+
+\echo '### propriétaires des tables hr_* (attendu: hr_time_events=postgres, le reste=cerp_app)'
+SELECT tablename, tableowner
+FROM pg_tables
+WHERE schemaname = 'public' AND tablename LIKE 'hr_%'
+ORDER BY tablename;
+
+\echo '### tables CRUD qui ne seraient PAS owned par cerp_app (attendu: 0)'
+SELECT count(*) AS crud_not_cerp_app
+FROM pg_tables
+WHERE schemaname = 'public'
+  AND tablename LIKE 'hr_%'
+  AND tablename <> 'hr_time_events'
+  AND tableowner <> 'cerp_app';
+
+\echo '### hr_time_events reste-t-il bien postgres (append-only) ? (attendu: t)'
+SELECT (tableowner = 'postgres') AS hr_time_events_is_postgres
+FROM pg_tables WHERE schemaname = 'public' AND tablename = 'hr_time_events';

--- a/db/privileged/20260709_hr_time_events_append_only.rollback.sql
+++ b/db/privileged/20260709_hr_time_events_append_only.rollback.sql
@@ -1,0 +1,28 @@
+-- ROLLBACK for 20260709_hr_time_events_append_only.sql   (SUPERUSER ONLY)
+--
+-- Restaure l'état mutable : cerp_app redevient owner de hr_time_events avec tous les
+-- privilèges, et le trigger/fonction append-only sont retirés.
+--
+--   sudo -u postgres psql -d <db> -f db/privileged/20260709_hr_time_events_append_only.rollback.sql
+--
+-- Non destructif : aucune ligne n'est modifiée ni supprimée.
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS trg_hr_time_events_no_update ON public.hr_time_events;
+DROP TRIGGER IF EXISTS trg_hr_time_events_no_delete ON public.hr_time_events;
+DROP TRIGGER IF EXISTS trg_hr_time_events_no_truncate ON public.hr_time_events;
+DROP FUNCTION IF EXISTS public.hr_time_events_prevent_mutation();
+
+DO $rb$
+BEGIN
+  IF to_regclass('public.hr_time_events') IS NULL THEN
+    RAISE NOTICE 'rollback: public.hr_time_events absente — rien à faire';
+    RETURN;
+  END IF;
+  EXECUTE 'ALTER TABLE public.hr_time_events OWNER TO cerp_app';
+  EXECUTE 'GRANT ALL ON public.hr_time_events TO cerp_app';
+END
+$rb$;
+
+COMMIT;

--- a/db/privileged/20260709_hr_time_events_append_only.sql
+++ b/db/privileged/20260709_hr_time_events_append_only.sql
@@ -1,0 +1,86 @@
+-- 20260709_hr_time_events_append_only.sql   (PRIVILEGED — SUPERUSER ONLY)
+--
+-- Module « Temps & Déplacements » — rend public.hr_time_events APPEND-ONLY pour le rôle
+-- applicatif (cerp_app). Le relevé de badgeage brut est une preuve légale/RGPD : il ne doit
+-- jamais être modifié ni supprimé par l'application (toute correction passe par
+-- public.hr_time_adjustments). Miroir de 20260707_erp_audit_logs_append_only.sql (CA-SEC-03,
+-- ISO/IEC 27001:2022 A.8.15).
+--
+-- POURQUOI HORS db/patches
+--   Le runner db:patches applique en tant que cerp_app ; or un OWNER de table contourne
+--   GRANT/REVOKE et peut DISABLE TRIGGER. L'immuabilité réelle exige de déplacer la propriété
+--   HORS du rôle applicatif, ce que seul un SUPERUSER peut faire. À appliquer par un DBA :
+--       sudo -u postgres psql -d cerp_test -f db/privileged/20260709_hr_time_events_append_only.sql
+--       sudo -u postgres psql -d cerp_prod -f db/privileged/20260709_hr_time_events_append_only.sql   (T10 seulement)
+--   NON pris en charge par `npm run db:patches:up`.
+--
+-- CE QUE ÇA FAIT
+--   1. Propriété de la table → postgres (hors rôle applicatif).
+--   2. cerp_app restreint à INSERT + SELECT (pas d'UPDATE/DELETE/TRUNCATE).
+--   3. Trigger append-only (bloque UPDATE/DELETE/TRUNCATE pour tous, y compris l'owner).
+--   (PK uuid via gen_random_uuid → pas de séquence à réassigner.)
+--
+-- MAINTENANCE CONTRÔLÉE (superuser only) — rétention/anonymisation RGPD :
+--       SET session_replication_role = 'replica';
+--       DELETE FROM public.hr_time_events WHERE ... ;   -- selon barème de conservation
+--       SET session_replication_role = 'origin';
+--
+-- SAFETY : idempotent (ré-exécutable), non destructif. Rollback/verify fournis à côté.
+-- Cible : PostgreSQL 17. Exécuter en SUPERUSER (postgres).
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF NOT COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false) THEN
+    RAISE EXCEPTION 'hr_time_events append-only: doit être appliqué par un superuser; current_user=% ne l''est pas', current_user;
+  END IF;
+END
+$guard$;
+
+DO $mig$
+BEGIN
+  IF to_regclass('public.hr_time_events') IS NULL THEN
+    RAISE NOTICE 'public.hr_time_events absente — appliquer d''abord db/patches/20260709_hr_temps_deplacements.sql';
+    RETURN;
+  END IF;
+
+  -- 1) Propriété hors rôle applicatif.
+  EXECUTE 'ALTER TABLE public.hr_time_events OWNER TO postgres';
+
+  -- 2) Moindre privilège : INSERT + SELECT uniquement pour cerp_app.
+  EXECUTE 'REVOKE ALL ON public.hr_time_events FROM cerp_app';
+  EXECUTE 'REVOKE UPDATE, DELETE, TRUNCATE ON public.hr_time_events FROM PUBLIC';
+  EXECUTE 'GRANT SELECT, INSERT ON public.hr_time_events TO cerp_app';
+END
+$mig$;
+
+-- 3) Backstop append-only. Fire pour TOUS les rôles (superuser bypass via session_replication_role).
+CREATE OR REPLACE FUNCTION public.hr_time_events_prevent_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $fn$
+BEGIN
+  RAISE EXCEPTION
+    'hr_time_events est append-only : % non permis (les corrections passent par hr_time_adjustments)', TG_OP
+    USING ERRCODE = 'insufficient_privilege';
+  RETURN NULL;
+END
+$fn$;
+
+DROP TRIGGER IF EXISTS trg_hr_time_events_no_update ON public.hr_time_events;
+CREATE TRIGGER trg_hr_time_events_no_update
+  BEFORE UPDATE ON public.hr_time_events
+  FOR EACH ROW EXECUTE FUNCTION public.hr_time_events_prevent_mutation();
+
+DROP TRIGGER IF EXISTS trg_hr_time_events_no_delete ON public.hr_time_events;
+CREATE TRIGGER trg_hr_time_events_no_delete
+  BEFORE DELETE ON public.hr_time_events
+  FOR EACH ROW EXECUTE FUNCTION public.hr_time_events_prevent_mutation();
+
+DROP TRIGGER IF EXISTS trg_hr_time_events_no_truncate ON public.hr_time_events;
+CREATE TRIGGER trg_hr_time_events_no_truncate
+  BEFORE TRUNCATE ON public.hr_time_events
+  FOR EACH STATEMENT EXECUTE FUNCTION public.hr_time_events_prevent_mutation();
+
+COMMIT;

--- a/db/privileged/20260709_hr_time_events_append_only.verify.sql
+++ b/db/privileged/20260709_hr_time_events_append_only.verify.sql
@@ -1,0 +1,63 @@
+-- VERIFY — hr_time_events append-only.   (SUPERUSER, sur cerp_test)
+--
+--   sudo -u postgres psql -d cerp_test -f db/privileged/20260709_hr_time_events_append_only.verify.sql
+--
+-- Résultat attendu :
+--   owner       = postgres
+--   cerp_app    = INSERT,SELECT
+--   triggers    = trg_hr_time_events_no_delete, _no_truncate, _no_update  (3)
+--   [1] cerp_app INSERT -> SUCCESS
+--   [2] cerp_app UPDATE -> ERROR permission denied            (couche privilèges)
+--   [3] cerp_app DELETE -> ERROR permission denied            (couche privilèges)
+--   [4] owner    UPDATE -> ERROR append-only ...              (trigger backstop)
+--   leftover    = 0                                            (fixture nettoyée)
+
+\pset pager off
+\set ON_ERROR_STOP off
+
+\echo '### owner (expect: postgres)'
+SELECT tableowner FROM pg_tables WHERE schemaname='public' AND tablename='hr_time_events';
+
+\echo '### cerp_app grants (expect: INSERT,SELECT)'
+SELECT COALESCE(string_agg(privilege_type, ',' ORDER BY privilege_type), '(none)') AS cerp_app_privs
+FROM information_schema.role_table_grants
+WHERE table_schema='public' AND table_name='hr_time_events' AND grantee='cerp_app';
+
+\echo '### append-only triggers (expect 3)'
+SELECT tgname FROM pg_trigger
+WHERE tgrelid='public.hr_time_events'::regclass AND NOT tgisinternal
+ORDER BY tgname;
+
+\echo '### fixture: un user existant + un employé + un événement de test'
+SELECT id AS uid FROM public.users ORDER BY id LIMIT 1 \gset
+INSERT INTO public.hr_employees (user_id, matricule)
+VALUES (:uid, 'HR_VERIFY')
+ON CONFLICT (matricule) DO UPDATE SET updated_at = now()
+RETURNING id AS emp_id \gset
+INSERT INTO public.hr_time_events (employee_id, event_type, event_time, source)
+VALUES (:'emp_id', 'IN', now(), 'ADMIN')
+RETURNING id AS ev_id \gset
+
+\echo '### [1] cerp_app INSERT — EXPECT SUCCESS'
+SET ROLE cerp_app;
+INSERT INTO public.hr_time_events (employee_id, event_type, event_time, source)
+VALUES (:'emp_id', 'OUT', now(), 'WEB');
+
+\echo '### [2] cerp_app UPDATE — EXPECT: permission denied'
+UPDATE public.hr_time_events SET event_type='OUT' WHERE id = :'ev_id';
+
+\echo '### [3] cerp_app DELETE — EXPECT: permission denied'
+DELETE FROM public.hr_time_events WHERE id = :'ev_id';
+RESET ROLE;
+
+\echo '### [4] trigger backstop: UPDATE owner sur la vraie ligne — EXPECT append-only exception'
+UPDATE public.hr_time_events SET event_type='OUT' WHERE id = :'ev_id';
+
+\echo '### cleanup (superuser + replica) — retire la fixture'
+SET session_replication_role='replica';
+DELETE FROM public.hr_time_events WHERE employee_id = :'emp_id';
+DELETE FROM public.hr_employees WHERE matricule='HR_VERIFY';
+SET session_replication_role='origin';
+
+\echo '### leftover fixture (expect 0)'
+SELECT count(*) AS leftover FROM public.hr_employees WHERE matricule='HR_VERIFY';

--- a/db/seeds/temps-deplacements-e2e-cleanup.sql
+++ b/db/seeds/temps-deplacements-e2e-cleanup.sql
@@ -1,0 +1,31 @@
+-- Nettoyage du seed E2E « Temps & Déplacements » — cerp_test UNIQUEMENT.
+-- hr_time_events est append-only (triggers) : la purge des événements de test nécessite un superuser
+-- via session_replication_role='replica' (comme la rétention CA-SEC-03). À exécuter en tant que postgres.
+\set ON_ERROR_STOP on
+BEGIN;
+DO $$
+DECLARE v_emp uuid;
+BEGIN
+  SELECT id INTO v_emp FROM public.hr_employees WHERE matricule='TEST_TD_EMP';
+  IF v_emp IS NOT NULL THEN
+    -- Dérivés (CRUD normaux)
+    DELETE FROM public.hr_time_adjustments a USING public.hr_timesheet_days d WHERE a.target_type='DAY' AND a.target_id=d.id AND d.employee_id=v_emp;
+    DELETE FROM public.hr_kilometer_entries WHERE employee_id=v_emp;
+    DELETE FROM public.hr_timesheet_days WHERE employee_id=v_emp;
+    DELETE FROM public.hr_timesheet_weeks WHERE employee_id=v_emp;
+    DELETE FROM public.hr_time_anomalies WHERE employee_id=v_emp;
+    DELETE FROM public.hr_badge_credentials WHERE employee_id=v_emp;
+    -- Événements append-only : purge contrôlée (superuser)
+    SET session_replication_role='replica';
+    DELETE FROM public.hr_time_events WHERE employee_id=v_emp;
+    SET session_replication_role='origin';
+    DELETE FROM public.hr_employment_contracts WHERE employee_id=v_emp;
+    DELETE FROM public.hr_employees WHERE id=v_emp;
+  END IF;
+  DELETE FROM public.hr_time_rule_sets WHERE name='TEST 35h';
+  DELETE FROM public.hr_time_clock_devices WHERE device_token_hash=encode(digest('TEST_TD_TOKEN','sha256'),'hex');
+  DELETE FROM public.hr_payroll_export_batches WHERE exported_by IN (SELECT id FROM public.users WHERE username IN ('test_td_mgr','test_td_emp'));
+  DELETE FROM public.users WHERE username IN ('test_td_mgr','test_td_emp');
+END $$;
+COMMIT;
+SELECT count(*) AS restes FROM public.hr_employees WHERE matricule='TEST_TD_EMP';

--- a/db/seeds/temps-deplacements-e2e-seed.sql
+++ b/db/seeds/temps-deplacements-e2e-seed.sql
@@ -1,0 +1,56 @@
+-- Seed E2E « Temps & Déplacements » — cerp_test UNIQUEMENT (jamais prod).
+-- Idempotent. À exécuter APRÈS déploiement du backend dev sur cerp_test, pour la validation navigateur.
+-- Nettoyage : db/seeds/temps-deplacements-e2e-cleanup.sql. Identifiants de TEST (non secrets) :
+--   token borne   = 'TEST_TD_TOKEN'      (à saisir dans la page borne)
+--   badge uid     = 'TEST_TD_BADGE'      (à « taper » sur la borne)
+--   employé user  = 'test_td_emp' / mot de passe applicatif à définir hors seed
+--   manager user  = 'test_td_mgr' (rôle Directeur ⇒ privilégié RH)
+\set ON_ERROR_STOP on
+BEGIN;
+
+-- Utilisateurs de test (contraintes users : rôle/gender/tel/postcode/country valides).
+INSERT INTO public.users (username,password,name,surname,email,tel_no,role,gender,address,lane,house_no,postcode,date_of_birth,social_security_number)
+SELECT 'test_td_mgr','$2b$10$placeholderplaceholderplaceholderplaceholderphash','Test','Manager','test_td_mgr@example.invalid','+33612345678','Directeur','Male','Atelier','Rue','1','75001',DATE '1980-01-01','TEST-MGR'
+WHERE NOT EXISTS (SELECT 1 FROM public.users WHERE username='test_td_mgr');
+INSERT INTO public.users (username,password,name,surname,email,tel_no,role,gender,address,lane,house_no,postcode,date_of_birth,social_security_number)
+SELECT 'test_td_emp','$2b$10$placeholderplaceholderplaceholderplaceholderphash','Test','Salarié','test_td_emp@example.invalid','+33612345679','Employee','Female','Atelier','Rue','2','75001',DATE '1990-01-01','TEST-EMP'
+WHERE NOT EXISTS (SELECT 1 FROM public.users WHERE username='test_td_emp');
+
+DO $$
+DECLARE v_mgr int; v_emp_user int; v_emp uuid; v_rs uuid;
+BEGIN
+  SELECT id INTO v_mgr FROM public.users WHERE username='test_td_mgr';
+  SELECT id INTO v_emp_user FROM public.users WHERE username='test_td_emp';
+
+  -- Règle 35h de test
+  SELECT id INTO v_rs FROM public.hr_time_rule_sets WHERE name='TEST 35h';
+  IF v_rs IS NULL THEN
+    INSERT INTO public.hr_time_rule_sets (name, weekly_target_minutes, daily_target_minutes, overtime_threshold_1_minutes, overtime_rate_1, overtime_threshold_2_minutes, overtime_rate_2)
+      VALUES ('TEST 35h',2100,420,2100,1.25,2580,1.5) RETURNING id INTO v_rs;
+  END IF;
+
+  -- Employé de test (matricule TEST_TD_EMP), rattaché au manager de test
+  SELECT id INTO v_emp FROM public.hr_employees WHERE matricule='TEST_TD_EMP';
+  IF v_emp IS NULL THEN
+    INSERT INTO public.hr_employees (user_id, matricule, status, manager_user_id) VALUES (v_emp_user,'TEST_TD_EMP','ACTIVE', v_mgr) RETURNING id INTO v_emp;
+  END IF;
+
+  -- Contrat actif H35 lié à la règle
+  IF NOT EXISTS (SELECT 1 FROM public.hr_employment_contracts WHERE employee_id=v_emp AND active) THEN
+    INSERT INTO public.hr_employment_contracts (employee_id, contract_type, weekly_hours_target, daily_hours_target, start_date, rule_set_id, active)
+      VALUES (v_emp,'H35',35,7,'2026-01-01', v_rs, true);
+  END IF;
+
+  -- Badge de test (uid haché)
+  IF NOT EXISTS (SELECT 1 FROM public.hr_badge_credentials WHERE badge_uid_hash=encode(digest('TEST_TD_BADGE','sha256'),'hex') AND active) THEN
+    INSERT INTO public.hr_badge_credentials (employee_id, badge_uid_hash, badge_label, active) VALUES (v_emp, encode(digest('TEST_TD_BADGE','sha256'),'hex'),'Badge test', true);
+  END IF;
+
+  -- Borne de test (token haché)
+  IF NOT EXISTS (SELECT 1 FROM public.hr_time_clock_devices WHERE device_token_hash=encode(digest('TEST_TD_TOKEN','sha256'),'hex')) THEN
+    INSERT INTO public.hr_time_clock_devices (name, location, device_type, device_token_hash, status) VALUES ('Borne test','Atelier','KIOSK', encode(digest('TEST_TD_TOKEN','sha256'),'hex'),'ACTIVE');
+  END IF;
+END $$;
+
+COMMIT;
+SELECT 'seed OK — employé=' || (SELECT matricule FROM public.hr_employees WHERE matricule='TEST_TD_EMP') AS resultat;

--- a/docs/ai/temps-deplacements-final-report.md
+++ b/docs/ai/temps-deplacements-final-report.md
@@ -1,0 +1,74 @@
+# Temps & Déplacements — Rapport final (T1→T11)
+
+Issue #119. Mode max autonome. Cible **cerp_test**. **Aucun `cerp_prod`, aucun `main`, aucune release,
+aucune paie réelle** touchés. Module construit en tranches testées, chacune mergée vers `dev` avec CI verte.
+
+## 1. Statut global
+
+| Tranche | Livré | PRs |
+|---|---|---|
+| **T1** socle DB (15 tables `hr_*`, append-only, ownership) | ✅ | back #64 |
+| **T2** backend pointage (append-only, badge/borne, journée/semaine, anomalies) | ✅ | back (mergé) |
+| **T3** frontend salarié (pointer, relevé, anomalies) | ✅ | front #121 |
+| **T4** validation responsable (corrections tracées, validation, périmètre) | ✅ | back #66, front #122 |
+| **T5** contrats/horaires/règles 35h-39h configurables + admin RH | ✅ | back #68, front #123 |
+| **T6** kilomètres (déclaration + validation) | ✅ | back #70, front #125 |
+| **T7** exports CSV/PDF figés + checksum | ✅ | back #69, front #124 |
+| **T8** bornes/badges + page borne (kiosk HID) | ✅ | back #71, front #126 |
+| **T9** conformité/preuves + registre risques | ✅ | front #127 |
+| **T10** E2E : **chaîne service/DB validée** ; navigateur **gated** (déploiement) | 🟡 | ce dossier + seeds |
+| **T11** rapport final + gate prod | ✅ | ce document |
+
+## 2. Module utilisable ?
+
+- **Côté code (`dev`)** : **oui, complet** — un salarié pointe (web/borne), voit journée/semaine calculées
+  avec règles réelles (35/39/partiel, HS 25/50), déclare ses km ; un responsable valide corrections,
+  jours/semaines et km, administre règles/contrats/horaires/bornes/badges, génère des exports paie figés.
+- **Exécutable navigateur sur `cerp_test`** : **en attente** du déploiement backend (T10, gate humain).
+  Toute la chaîne est validée au niveau service/DB par smokes `BEGIN…ROLLBACK` (0 résidu).
+
+## 3. Tests
+
+- **Backend** : 255 tests / 50 fichiers, `tsc --noEmit` = 0.
+- **Frontend** : 105 tests / 36 fichiers, typecheck 0, lint 0 erreur, build OK.
+- **Smokes cerp_test** : T2, T4, T5, T6, T7, T8 + **chaîne complète T10** — tous verts, 0 donnée persistée.
+
+## 4. Conformité (audit interne, sans prétention ISO)
+
+Dossier `crp-systems-web/compliance/iso27001/evidence/time-clock-module.md` + `…-risk-register.md`.
+Contrôles implémentés (preuve disponible) : append-only, anti-IDOR, séparation des tâches (no self-approve),
+hachage secrets (badge/token SHA-256, jamais loggés), audit systématique, intégrité export (checksum),
+minimisation RGPD (pas de biométrie ni géoloc continue), règles configurables (aucun 35/39 en dur), socle
+default-deny. Écarts ouverts EC-01…EC-05 tracés.
+
+## 5. Gate prod (validation humaine requise — NON exécuté par l'agent)
+
+À dérouler, dans l'ordre, sous validation du propriétaire, avec backup préalable :
+
+1. **Migrations prod** (`db/patches/20260709_hr_temps_deplacements.sql`, `20260710_hr_users_role_responsable_rh.sql`)
+   appliquées sur `cerp_prod` **après backup**, en direct psql (pas le runner), avec verify.
+2. **Hardening append-only prod** : `db/privileged/20260709_hr_time_events_append_only.*` +
+   `20260709_hr_module_ownership.*` sur `cerp_prod` (superuser, backup préalable, verify).
+3. **Déploiement backend** (image `dev`→release) exposant `/time-clock/*` en prod.
+4. **Provisioning rôles** : créer les comptes `Responsable RH` / valider les managers (`manager_user_id`).
+5. **Données de référence** : règles de calcul réelles (35h/39h/partiel), contrats, horaires, véhicules,
+   bornes (jetons distribués), badges.
+6. **Recette navigateur** prod (20 scénarios T10) + revue des logs d'audit.
+7. **Purge/rétention** RGPD (EC-02) : planifier le job (aujourd'hui manuel DBA).
+
+## 6. Écarts ouverts (rappel)
+
+EC-01 E2E navigateur (déploiement) · EC-02 rétention automatisée · EC-03 append-only prod ·
+EC-04 application numérique d'une correction approuvée · EC-05 filtrage nav par rôle.
+
+## 7. Garde-fous respectés
+
+Aucune écriture `cerp_prod` ; aucun merge `main` ; aucune release ; aucun secret en clair (hachage
+SHA-256, jetons renvoyés 1×, jamais loggés) ; aucune donnée test persistée (smokes en `ROLLBACK`) ; pas de
+biométrie ni géolocalisation continue ; aucun lien/import Excel (exports maison CSV/PDF). Conformité
+formulée « contrôle implémenté / preuve disponible / écart ouvert ».
+
+## Prochaine action recommandée
+
+Exécuter le **gate prod** (§5) sous validation humaine, en commençant par le déploiement backend sur
+cerp_test pour lever EC-01 et dérouler la recette navigateur (T10).

--- a/docs/ai/temps-deplacements-prod-release-report.md
+++ b/docs/ai/temps-deplacements-prod-release-report.md
@@ -1,0 +1,89 @@
+# Temps & Déplacements — Rapport de gate prod
+
+Issue #119. Date : 2026-07-10. Passage dev/cerp_test → main/cerp_prod, **en cours, ARRÊTÉ au gate merge/déploiement**.
+Aucun secret dans ce document. Le module DB est en prod ; l'application n'est **pas** encore déployée.
+
+## 1. Recette navigateur cerp_test
+
+**Non exécutée** (bloquée) : le backend T2+ n'est pas déployé sur cerp_test, et je ne peux ni déployer
+(secret DB `cerp_app`) ni me connecter (saisie de mot de passe interdite). **À la place**, la chaîne
+complète a été validée au niveau **service/DB** sur cerp_test (`BEGIN…ROLLBACK`, 0 résidu) :
+pointage→420 min, correction approuvée par un tiers, validation jour/semaine, km soumis→validés, export,
+auth borne + résolution badge — plus les smokes par tranche (T2/T4/T5/T6/T7/T8). Preuves : `docs/temps-deplacements-t*-evidence.md`.
+
+## 2. Backup cerp_prod
+
+- Fait **avant** toute migration. `pg_dump -Fc` → `/var/backups/cerp/cerp_prod_td_gate_20260710-083938.dump` (~848 Ko).
+- Vérifié : `pg_restore --list` = 1960 objets (archive valide/restaurable). Aucun secret affiché.
+
+## 3. Migrations appliquées sur cerp_prod (as postgres, `ON_ERROR_STOP=1`)
+
+Ordre strict, additif, idempotent :
+1. `db/patches/20260709_hr_temps_deplacements.sql` — 15 tables `hr_*`, 17 enums, contraintes, index.
+2. `db/privileged/20260709_hr_module_ownership.sql` — 14 tables CRUD → `cerp_app`.
+3. `db/privileged/20260709_hr_time_events_append_only.sql` — append-only (owner postgres, cerp_app INSERT/SELECT, 3 triggers).
+4. `db/patches/20260710_hr_users_role_responsable_rh.sql` — `users_role_check` + `Responsable RH`.
+
+Résultat : `PSQL_EXIT=0`. Aucune donnée existante modifiée (prod était vierge de `hr_*`).
+
+## 4. Verify SQL prod (prod-safe, sans insertion de ligne de test)
+
+```
+1. tables hr_ = 15
+2. propriété : cerp_app=14, postgres=1
+3. hr_time_events : owner=postgres ; cerp_app INSERT=t SELECT=t UPDATE=f DELETE=f
+4. triggers append-only = 3
+5. users_role_check ⊇ 'Responsable RH' = t
+6. contrainte no-self-approve = présente
+7. index unique idempotency_key = présent
+8. cerp_app écrit CRUD (hr_employees INSERT, hr_kilometer_entries UPDATE) = t,t
+9. index « 1 contrat actif / employé » = présent
+```
+
+## 5. PRs dev → main
+
+**Non ouvertes** (arrêt volontaire au gate). Backend dev **+19** commits d'avance sur main ; frontend **+16**.
+Le garde de visibilité pilote (front #128) est mergé sur dev, prêt à partir dans le merge main.
+
+## 6. CI / 7. Déploiement
+
+**N/A** — non déployé. Le backend/frontend de prod ne servent pas encore `/time-clock`.
+
+## 8. Vérification prod
+
+- **DB** : migrée + vérifiée (§4).
+- **Application** : non déployée → endpoints `/time-clock` pas encore exposés en prod (attendu).
+
+## 9. Rôles activés
+
+- **Garde front pilote** en place : menu visible seulement pour RH / Direction / Admin (front #128).
+- **Backend** : socle `authenticateToken` + RBAC (admin/responsable privilégiés ; salarié = ses données).
+- **Provisioning `Responsable RH`** : la contrainte DB l'autorise désormais ; **création des comptes = à faire** (gate).
+
+## 10. Données pilote / 11. Données test
+
+**Aucune** donnée pilote ni test créée en prod (0 ligne `hr_*` insérée). Verify 100 % introspection.
+Si un pilote est lancé, nommer les jeux `PILOT_TD` / `TEST_TD_PROD` et supprimer les tests.
+
+## 12. Risques restants
+
+EC-01 recette navigateur + déploiement (gate) · EC-02 rétention RGPD (manuelle) · EC-04 override numérique
+d'une correction approuvée · exposition prod tant que non déployé = nulle. `hr_time_events` immuable
+(append-only) dès maintenant.
+
+## 13. Rollback
+
+- **DB** : `db/privileged/*.rollback.sql` (append-only, ownership) + `DROP` des tables `hr_*` si besoin
+  (tables vides ⇒ aucune perte). Restauration complète possible depuis le dump du §2.
+- **users_role_check** : réversible (ré-appliquer l'ancienne définition sans `Responsable RH`).
+- **App** : non déployée ⇒ rien à annuler côté service.
+
+## 14. Verdict
+
+- **Module en prod** : **DB oui**, **application non** (pas déployée).
+- **Accès limité** : **oui** (garde front pilote + RBAC backend + socle).
+- **Prêt pilote** : **pas encore** — reste (gate humain) : (a) déployer backend sur cerp_test + recette
+  navigateur, (b) PR dev→main (back+front) + CI verte + déploiement, (c) créer les comptes `Responsable RH`
+  / valider les managers, (d) recette prod (20 scénarios), puis ouverture pilote restreinte.
+
+**Arrêt ici** conformément à la règle « ne touche pas main / pas de déploiement sans validation ».

--- a/docs/ai/temps-deplacements-status.md
+++ b/docs/ai/temps-deplacements-status.md
@@ -1,0 +1,75 @@
+# Temps & Déplacements — état d'avancement (checkpoint T1→T4)
+
+Issue #119. Mode max autonome. Cible : cerp_test. Aucun cerp_prod, aucun main, aucune paie réelle touchés.
+Ce document est un **checkpoint honnête**, pas un rapport de clôture : T5→T11 restent à faire.
+
+## Statut global
+
+| Tranche | Périmètre | État | Preuves |
+|---|---|---|---|
+| **T1** | Socle DB RH (15 tables `hr_*`, 17 enums, append-only, ownership) | ✅ mergé dev | migration + `db/privileged/*` (append-only + ownership), verify SQL, 9 tests |
+| **T2** | Backend pointage (events append-only, badge/borne, journée/semaine, anomalies) | ✅ mergé dev | 17 tests + smoke cerp_test (idempotence 23505, UPDATE refusé, badge) |
+| **T3** | Frontend salarié (pointer, relevé, anomalies) | ✅ mergé dev | typecheck/lint/build/tests verts |
+| **T4** | Backend validation responsable + front responsable | ✅ mergé dev | 15 tests + smoke cerp_test (self-approve bloqué, non-replay, validation) ; 2 tests gate rôle |
+| **T5** | Contrats / horaires / règles 35h–39h + admin RH | ⬜ à faire | — |
+| **T6** | Kilomètres (backend + front) | ⬜ à faire | placeholder front en place |
+| **T7** | Exports CSV (`;`, UTF-8 BOM) + PDF figé + checksum | ⬜ à faire | — |
+| **T8** | Bornes / badges / devices CRUD + page borne (kiosk) | ⬜ à faire | backend device-events déjà là (T2) |
+| **T9** | Conformité / preuves (ISO/RGPD/OWASP) | 🟡 partiel | preuves T1–T4 écrites ; registre risques à consolider |
+| **T10** | Validation E2E navigateur sur cerp_test | ⬜ **bloqué** | voir « Blocages » |
+| **T11** | Rapport final + gate prod | ⬜ à faire | ce checkpoint en tient lieu provisoire |
+
+## Module utilisable ? 
+
+- **Sur `dev` (code)** : oui pour le cœur — un salarié pointe (IN/PAUSE/RETOUR/SORTIE), voit sa journée
+  et sa semaine calculées + ses anomalies ; un responsable voit l'équipe du jour et approuve/refuse les
+  demandes de correction. Tout est typé, testé, mergé.
+- **Sur `cerp_test` (exécutable)** : **pas encore de bout en bout** — le schéma T1 est appliqué sur
+  cerp_test, mais le **backend T2+ n'y est pas déployé** (l'atelier sert le backend de prod). Il faut
+  déployer le backend `dev` pointant sur cerp_test pour un test navigateur réel (T10).
+
+## Tests verts ?
+
+- Backend : **210 tests / 44 fichiers**, `tsc --noEmit` = 0. Smokes cerp_test T2 & T4 OK (rollback, 0 résidu).
+- Frontend : **101 tests / 34 fichiers**, typecheck 0, lint 0 erreur, build OK.
+
+## PRs (toutes mergées vers `dev`, CI verte)
+
+- Backend : #64 (T1), T2 (mergé), #66 (T4). Frontend : #121 (T3), #122 (T4 front). Docs Phase 1 : #120.
+
+## Prochaines étapes (ordre recommandé)
+
+1. **T5 — règles 35h/39h configurables** (jamais en dur ; via `hr_time_rule_sets`) + contrats + admin RH.
+   Débloque le calcul heures sup 25/50 % et l'attendu jour/semaine réel.
+2. **T7 — exports** CSV (séparateur `;`, BOM UTF-8, pas de dépendance XLSX) + PDF figé (pdfkit) + checksum
+   SHA-256 + `hr_payroll_export_batches`. Valeur RH directe (remplacer l'Excel en sortie).
+3. **T6 — kilomètres** (barème configurable, pas de géoloc continue).
+4. **T8 — bornes/badges** CRUD + page borne (lecteur HID clavier). Le endpoint device-events existe déjà.
+5. **T10 — déploiement backend `dev`→cerp_test + E2E navigateur** (20 scénarios, seeds `TEST_TD`).
+6. **T9/T11 — consolidation preuves + rapport final + plan de gate prod.**
+
+## Petits suivis identifiés
+
+- **Validation directe jour/semaine (UI)** : exposer l'`id` de `hr_timesheet_days` dans `GET /team/today`
+  pour brancher les boutons « Valider la journée » (backend `PATCH /days/:id/validate` déjà prêt et testé).
+- **Application numérique d'une correction approuvée** : aujourd'hui la décision est tracée (preuve légale) ;
+  l'override du relevé (append-only ⇒ événement compensatoire ou champ override) est à définir en T5.
+
+## Blocages
+
+1. **T10 (E2E réel)** : nécessite de **déployer le backend `dev` sur cerp_test** (service + `.env` cerp_test).
+   C'est une action d'infrastructure sur l'atelier → **à faire en validation humaine** (hors périmètre
+   « code sur dev »). Sans cela, la validation navigateur reste impossible (le backend prod n'expose pas
+   `/time-clock`).
+2. **`users_role_check` sans `Responsable RH`** sur cerp_test (valeurs : Directeur, Employee, Administrateur
+   Systeme et Reseau, Responsable Qualité, Secretaire, Responsable Programmation). Le validateur applicatif
+   l'autorise mais pas la contrainte DB ⇒ on ne peut pas *créer* un `Responsable RH`. Mitigation : `Directeur`
+   et `Administrateur…` sont déjà privilégiés (`isHrPrivileged`). Correctif en T5 (migration additive de la
+   contrainte, ou décision d'utiliser les rôles existants). Contrôle implémenté ; preuve disponible ; écart ouvert.
+
+## Garde-fous respectés
+
+Aucune écriture cerp_prod ; aucun merge `main` ; aucune release ; aucun secret en clair (badge/token hachés
+SHA-256, jamais loggés) ; aucune donnée test persistée (smokes en `BEGIN…ROLLBACK`) ; pas de biométrie ni de
+géolocalisation continue ; aucun lien/import Excel. Formulation conformité : « contrôle implémenté / preuve
+disponible / écart ouvert », jamais « certifié/conforme ISO ».

--- a/docs/temps-deplacements-t1-evidence.md
+++ b/docs/temps-deplacements-t1-evidence.md
@@ -10,14 +10,17 @@
 | `db/privileged/20260709_hr_time_events_append_only.sql` | Hardening **append-only** de `hr_time_events` (owner→postgres, `cerp_app` INSERT/SELECT, triggers no-update/delete/truncate). Superuser only. |
 | `db/privileged/20260709_hr_time_events_append_only.rollback.sql` | Rollback (restaure owner `cerp_app` + droits, retire triggers/fonction). |
 | `db/privileged/20260709_hr_time_events_append_only.verify.sql` | Verify (fixture + preuves append-only + nettoyage). |
+| `db/privileged/20260709_hr_module_ownership.{sql,rollback,verify}` | **Ownership versionné** : normalise les 14 tables CRUD → `cerp_app` (boucle `DO` idempotente gardée superuser — `OWNER TO` ne supporte pas de liste). Rend la propriété **reproductible** quel que soit le mode d'application. |
 | `src/module/auth/validators/user.validator.ts` | Rôle **`Responsable RH`** ajouté (convention « Responsable X ») ; `roles` exporté. |
 | `src/__tests__/temps-deplacements-t1.test.ts` | 9 tests (vocabulaire RBAC + idempotence migration + structure append-only). |
 
 ## Application sur cerp_test (2026-07-09)
 Appliqué en **direct `psql` (postgres, peer auth)** — **pas** le runner (dont le `.env` pointe cerp_prod) :
 1. Migration additive → cerp_test (seul NOTICE `pgcrypto already exists`).
-2. Propriété : **14 tables CRUD → `cerp_app`** (owner par table) ; **`hr_time_events` → `postgres`** (append-only). Tracé dans `cerp_schema_migrations` (sha256 `2a0911ec…`).
+2. Propriété via `db/privileged/20260709_hr_module_ownership.sql` (**versionné**, plus aucune commande manuelle) : **14 tables CRUD → `cerp_app`** ; **`hr_time_events` → `postgres`** (append-only). Tracé dans `cerp_schema_migrations`.
 3. Hardening append-only appliqué.
+
+**Reproductibilité prouvée** : `DROP` des tables `hr_*` puis **ré-application intégrale depuis les seuls fichiers commités** (additive → ownership → append-only) → état correct vérifié (`crud_not_cerp_app = 0`, `hr_time_events = postgres`, append-only OK). Aucune étape manuelle. Les artefacts (`db/patches` + `db/privileged/*.{sql,rollback,verify}`) suffisent à reconstruire l'état sur toute base (dont cerp_prod en T10).
 
 ## Verify (résultat)
 - owner `hr_time_events` = **postgres** · grants `cerp_app` = **INSERT,SELECT** · **3 triggers** (`no_update/no_delete/no_truncate`).

--- a/docs/temps-deplacements-t1-evidence.md
+++ b/docs/temps-deplacements-t1-evidence.md
@@ -1,0 +1,35 @@
+# Temps & Déplacements — T1 (schéma + DB) — évidence cerp_test
+
+> Issue frontend [#119](https://github.com/BigFootLime/crp-systems-web/issues/119) · archi + ADR-0013 dans `crp-systems-web/docs/`.
+> **T1 = schéma DB + append-only + rôle RH. Aucun cerp_prod (réservé T10). Aucun code UI. Aucun lien avec d'anciens fichiers.**
+
+## Livrables
+| Fichier | Rôle |
+|---|---|
+| `db/patches/20260709_hr_temps_deplacements.sql` | Migration **additive idempotente** : 15 tables `hr_*` + 17 enums + FK + index + contraintes (`reason` non vide, anti auto-validation, 1 contrat actif, idempotency badge). |
+| `db/privileged/20260709_hr_time_events_append_only.sql` | Hardening **append-only** de `hr_time_events` (owner→postgres, `cerp_app` INSERT/SELECT, triggers no-update/delete/truncate). Superuser only. |
+| `db/privileged/20260709_hr_time_events_append_only.rollback.sql` | Rollback (restaure owner `cerp_app` + droits, retire triggers/fonction). |
+| `db/privileged/20260709_hr_time_events_append_only.verify.sql` | Verify (fixture + preuves append-only + nettoyage). |
+| `src/module/auth/validators/user.validator.ts` | Rôle **`Responsable RH`** ajouté (convention « Responsable X ») ; `roles` exporté. |
+| `src/__tests__/temps-deplacements-t1.test.ts` | 9 tests (vocabulaire RBAC + idempotence migration + structure append-only). |
+
+## Application sur cerp_test (2026-07-09)
+Appliqué en **direct `psql` (postgres, peer auth)** — **pas** le runner (dont le `.env` pointe cerp_prod) :
+1. Migration additive → cerp_test (seul NOTICE `pgcrypto already exists`).
+2. Propriété : **14 tables CRUD → `cerp_app`** (owner par table) ; **`hr_time_events` → `postgres`** (append-only). Tracé dans `cerp_schema_migrations` (sha256 `2a0911ec…`).
+3. Hardening append-only appliqué.
+
+## Verify (résultat)
+- owner `hr_time_events` = **postgres** · grants `cerp_app` = **INSERT,SELECT** · **3 triggers** (`no_update/no_delete/no_truncate`).
+- `cerp_app` **INSERT** = SUCCESS · **UPDATE/DELETE** = *permission denied* (couche privilèges) · **owner UPDATE** = *exception append-only* (trigger backstop).
+- Fixture nettoyée (`leftover = 0`).
+
+## Tests
+`tsc --noEmit` OK · vitest **178/178** (dont 9 T1) · non-régression confirmée.
+
+## Rollback disponible
+- Append-only : `db/privileged/20260709_hr_time_events_append_only.rollback.sql`.
+- Schéma : additif → `DROP TABLE public.hr_* CASCADE` (base vide) ou restauration dump si nécessaire.
+
+## Reste (hors T1)
+Endpoints/services/isolation par ressource = **T2** ; front salarié = **T3** ; contrats/règles = **T5** ; km = **T6** ; exports = **T7** ; bornes/badges = **T8** ; conformité/preuves = **T9** ; prod = **T10** (backup + validation + verify).

--- a/docs/temps-deplacements-t10-e2e-plan.md
+++ b/docs/temps-deplacements-t10-e2e-plan.md
@@ -1,0 +1,73 @@
+# T10 — Validation E2E sur cerp_test
+
+## Ce qui est prouvé automatiquement (niveau service/DB)
+
+Chaîne complète exercée sur cerp_test en une transaction `BEGIN…ROLLBACK` (0 résidu) —
+`scratchpad/t10_e2e_chain.sql` :
+
+```
+A POINTAGE→MINUTES: worked=420 brk=60 (attendu 420 / 60)
+B CORRECTION: approuvée_par_tiers=t
+C VALIDATION: jour+semaine=t
+D KILOMETRES: validés=t
+E EXPORT: lot créé (matches=1)
+F BORNE_AUTH: matches=1
+G BADGE_RESOLVE: matches=1
+residus_emp = 0 ; residus_user = 0
+```
+
++ smokes par tranche (T2 idempotence/append-only, T4 self-approve, T5 résolution règles, T6 km, T7 export,
+T8 borne/badge). Le modèle événement→minutes, les transitions d'état, les contraintes (append-only,
+one-active, no-self-approve) et la résolution borne/badge sont donc validés côté données.
+
+## Blocage — validation NAVIGATEUR
+
+La validation navigateur complète nécessite le **backend T2+ exécuté contre cerp_test**. Il n'est
+aujourd'hui déployé nulle part (l'atelier sert le backend de prod). Deux options, toutes deux **hors
+périmètre « code sur dev »** ⇒ **validation humaine / infra** :
+
+1. Déploiement temporaire d'une instance backend (`origin/dev`) avec un `.env` pointant cerp_test
+   (nécessite le mot de passe `cerp_app` — non manipulé par l'agent).
+2. Exécution locale via tunnel SSH vers la base atelier (même prérequis d'identifiants).
+
+Tant que ce prérequis n'est pas levé, l'E2E navigateur reste **gated**. Le front (déployé) n'expose pas
+`/time-clock` côté prod : normal.
+
+## Procédure (une fois le backend déployé sur cerp_test)
+
+1. `psql -f db/seeds/temps-deplacements-e2e-seed.sql` (crée employé `TEST_TD_EMP`, manager, règle 35h,
+   contrat, badge `TEST_TD_BADGE`, borne token `TEST_TD_TOKEN`). Définir les mots de passe applicatifs
+   des comptes de test hors seed.
+2. Dérouler les 20 scénarios ci-dessous.
+3. `psql -f db/seeds/temps-deplacements-e2e-cleanup.sql` (purge, superuser — événements append-only).
+
+## 20 scénarios navigateur
+
+Salarié (`test_td_emp`) :
+1. Login → menu « Temps & Déplacements » visible.
+2. Mon pointage : pointer Entrée → toast succès, point vert.
+3. Pointer Pause puis Retour → temps de pause affiché.
+4. Pointer Sortie → journée calculée (temps travaillé cohérent).
+5. Double-clic Entrée < 90 s → « double badge » (orange), pas de doublon.
+6. Mon relevé : jour + semaine (cible 35h, HS/absence corrects).
+7. Mes anomalies : liste vide/pertinente selon le pointage.
+8. Mes kilomètres : déclarer un trajet (brouillon) → apparaît en DRAFT.
+9. Soumettre le trajet → statut SUBMITTED.
+10. Tentative d'accès « Administration RH » → « espace réservé » (gate rôle).
+
+Responsable (`test_td_mgr`, Directeur) :
+11. Équipe du jour : voir `TEST_TD_EMP` + KPIs.
+12. Corrections à valider : approuver une demande → disparaît de la liste.
+13. Refuser une autre demande → statut REJECTED.
+14. Kilomètres équipe : valider le trajet soumis (10→SUBMITTED) → VALIDATED.
+15. Administration RH · Règles : créer une règle 39h.
+16. Administration RH · Contrats : créer un 2ᵉ contrat actif → erreur « contrat actif existe déjà ».
+17. Administration RH · Horaires : ajouter/supprimer un horaire.
+18. Administration RH · Bornes : créer une borne → **jeton affiché une seule fois** ; désactiver.
+19. Administration RH · Exports : générer un CSV, télécharger → fichier `;`+BOM, checksum affiché.
+20. Borne de pointage : saisir `TEST_TD_TOKEN`, sélectionner Entrée, « taper » `TEST_TD_BADGE`+Entrée →
+    feedback **vert** ; badge inconnu → **rouge**.
+
+## Critère de succès
+
+20/20 verts, aucune fuite de secret (jeton/UID) à l'écran ou en console, `cleanup` → 0 reste.

--- a/docs/temps-deplacements-t2-evidence.md
+++ b/docs/temps-deplacements-t2-evidence.md
@@ -1,0 +1,32 @@
+# Temps & Déplacements — T2 (backend pointage) — évidence cerp_test
+
+> Issue [#119](https://github.com/BigFootLime/crp-systems-web/issues/119) · s'appuie sur le schéma T1 (aucune nouvelle migration).
+> **cerp_test uniquement. Aucun front, aucune borne matérielle, aucun cerp_prod, aucun main.**
+
+## Module `src/module/temps-deplacements/` (quartet)
+`types/` · `validators/` (Zod, parse contrôleur) · `repository/` (SQL + transactions + audit) · `services/` (logique) · `controllers/` · `routes/`. Monté après le socle `authenticateToken` (`v1.routes.ts`) → **JWT d'office**.
+
+## Endpoints
+| Endpoint | Accès |
+|---|---|
+| `POST /time-clock/events` | salarié (employé dérivé de `req.user` — **aucun employee_id en entrée**) |
+| `GET /time-clock/me/today` · `/me/week` · `/me/anomalies` | salarié (ses données) |
+| `GET /time-clock/employees/:id/today` · `/:id/week` | **soi / manager / RH-Direction-Admin** (anti-IDOR) |
+| `POST /time-clock/device-events` · `/device-heartbeat` · `GET /device-config` | JWT socle **+ device_token haché** |
+
+## Règles implémentées
+- `hr_time_events` **append-only** (aucun UPDATE/DELETE ; corrections → `hr_time_adjustments`, T4).
+- **idempotency_key obligatoire** pour device-events (contrainte unique → dé-doublonnage).
+- **badge_uid & device_token hachés** (sha256), jamais stockés/loggés en clair.
+- **double badge** rapproché (même type < 90 s) détecté → anomalie `DOUBLE_BADGE`, pas de doublon.
+- **badge inconnu → 404**, **badge révoqué → 403** : traités comme **événements refusés + audités** (décision : pas de ligne `hr_time_anomalies`, un badge inconnu n'a pas d'employé). *(les enums `UNKNOWN_BADGE`/`REVOKED_BADGE` évoqués sont couverts par ce chemin refus+audit.)*
+- **Audit** sur toutes les écritures (`temps-deplacements.event.create_web/create_badge/double_badge_*/refused`, `.device.heartbeat`) — **jamais** de badge_uid/token/payload sensible dans les détails.
+- Réponse borne : aucune donnée RH sensible.
+- **Calcul journée** (moteur pur `summarizeDay`) : première IN, dernière OUT, pauses, temps travaillé ; attendu **depuis le contrat** (`repoGetDailyTargetMinutes` — jamais 35/39 en dur) ; heures sup / manquantes ; anomalies structurelles (`MISSING_IN/OUT/BREAK_END`, `TOO_LONG_DAY`, `TOO_SHORT_BREAK`). `MISSING_OUT`/`MISSING_BREAK_END` seulement sur jour passé (session en cours = normale aujourd'hui).
+
+## Tests
+- **17 tests unitaires** (`src/__tests__/temps-deplacements-t2.test.ts`) : `summarizeDay` (IN/OUT, pause complète/incomplète, entrée sans sortie), `detectTimeAnomalies`, hachage badge/token (jamais en clair), validateurs (anti-IDOR structurel, idempotency), RBAC (salarié↔autre = 403, manager, RH). **Suite : 43 fichiers / 195 verts. Typecheck OK.**
+- **Smoke SQL cerp_test** (couche repository) : insert `cerp_app` OK ; idempotency doublon → 23505 ; UPDATE `hr_time_events` → *permission denied* ; badge actif/révoqué/inconnu ; requête jour ; cleanup `leftover=0`.
+
+## Reste (hors T2)
+Front salarié = T3 · validation responsable + corrections = T4 · contrats/règles UI = T5 · km = T6 · exports = T7 · bornes/badges CRUD + kiosk = T8.

--- a/docs/temps-deplacements-t4-evidence.md
+++ b/docs/temps-deplacements-t4-evidence.md
@@ -1,0 +1,61 @@
+# T4 — Validation responsable RH : preuves
+
+Périmètre : corrections tracées (motif obligatoire, pas d'auto-validation), validation jour/semaine,
+lecture périmètre équipe (manager / RH-Direction-Admin). Issue #119. Append-only : les événements ne
+sont jamais mutés — une correction approuvée est la **preuve légale** de la décision ; l'application
+numérique d'un override dans le relevé relève de T5.
+
+## Endpoints (montés après le socle `authenticateToken`)
+
+| Méthode | Route | Rôle | Contrôle |
+|---|---|---|---|
+| POST | `/time-clock/adjustments` | salarié | motif obligatoire ; anti-IDOR (soi / manager / RH) |
+| PATCH | `/time-clock/adjustments/:id/approve` | responsable/RH | pas d'auto-validation ; périmètre ; idempotent |
+| PATCH | `/time-clock/adjustments/:id/reject` | responsable/RH | idem |
+| GET | `/time-clock/team/adjustments` | responsable/RH | demandes en attente du périmètre |
+| GET | `/time-clock/team/today` | responsable/RH | relevé du jour de l'équipe |
+| GET | `/time-clock/team/anomalies` | responsable/RH | anomalies du jour du périmètre |
+| PATCH | `/time-clock/days/:id/validate` | responsable/RH | DRAFT/TO_REVIEW → VALIDATED, non rejouable |
+| PATCH | `/time-clock/weeks/:id/validate` | responsable/RH | idem semaine |
+
+## Garanties
+
+- **Pas d'auto-validation** : refusée à deux niveaux — service (`requested_by === actor` → 403
+  `HR_SELF_APPROVAL_FORBIDDEN`) **et** DB (`CHECK approved_by <> requested_by`).
+- **Motif obligatoire** : Zod (`reason` min 3, `.strict()`) + DB (`CHECK length(btrim(reason)) > 0`).
+- **Anti-IDOR périmètre** : une décision/validation n'est permise qu'au manager de l'employé cible ou à
+  un rôle privilégié (`isHrPrivileged` = rh / direction / directeur / administrateur).
+- **Idempotence** : transition `WHERE status='REQUESTED'` (0 ligne si déjà décidée → 409) ; validation
+  `WHERE validation_status IN ('DRAFT','TO_REVIEW')` (409 si déjà VALIDATED/EXPORTED).
+- **Audit** : chaque écriture journalisée (`requested`/`approved`/`rejected`/`day.validated`/
+  `week.validated`) via `insertAuditLog` — jamais de secret, motif = donnée opérationnelle.
+
+## Tests unitaires — `src/__tests__/temps-deplacements-t4.test.ts` (15 verts)
+
+Validateurs (motif, strict, enum, uuid) ; `isHrPrivileged` ; `createAdjustment` (404 cible / 403
+anti-IDOR / créée+audit) ; `decideAdjustment` (404 / 409 déjà traitée / 403 auto-validation / 403 hors
+périmètre / APPROVED+audit / 409 course) ; `validateTimesheetDay` (404 / 409 déjà validée / VALIDATED+audit).
+
+Suite backend complète : **210 verts / 44 fichiers**, `tsc --noEmit` = 0.
+
+## Smoke SQL cerp_test (BEGIN…ROLLBACK, aucune persistance)
+
+```
+1 SELF_APPROVE_CHECK: bloqué par CHECK (OK)
+2 REASON_CHECK: motif vide refusé (OK)
+3 APPROVE_BY_OTHER: t (attendu t)
+4 NON_REPLAY: lignes_modifiees=0 reste_APPROVED=t (attendu 0 / t)
+5 DAY_VALIDATE: t (attendu t)
+6 TEAM_SCOPE_RESOLVE: matches=1 (attendu 1)
+residus_smoke = 0
+```
+
+## Écart ouvert (à traiter en T5)
+
+- **`users_role_check` ne contient pas `Responsable RH`** sur cerp_test (valeurs autorisées :
+  Directeur, Employee, Administrateur Systeme et Reseau, Responsable Qualité, Secretaire, Responsable
+  Programmation). Le validateur applicatif (`user.validator.ts`) l'autorise, mais la contrainte DB non :
+  on ne peut donc pas *créer* un utilisateur `Responsable RH` tant que la contrainte n'est pas étendue.
+  Mitigation actuelle : `isHrPrivileged` reconnaît `Directeur` et `Administrateur…` (rôles autorisés) →
+  les fonctions RH restent accessibles. **Correctif T5** : migration additive étendant `users_role_check`
+  (+ éventuel `Responsable RH`) ou décision d'utiliser les rôles existants. Preuve disponible ; écart ouvert.

--- a/docs/temps-deplacements-t5-evidence.md
+++ b/docs/temps-deplacements-t5-evidence.md
@@ -1,0 +1,54 @@
+# T5 — Contrats / horaires / règles : preuves
+
+Objectif : rendre les calculs réellement exploitables (35h, 39h, temps partiel, horaires types), **sans
+jamais coder 35/39 en dur**. Issue #119.
+
+## Ce qui est livré
+
+- **Migration** `db/patches/20260710_hr_users_role_responsable_rh.sql` — élargit `users_role_check` pour
+  autoriser `Responsable RH` (additif/sûr, idempotent). Appliquée sur cerp_test (écart T4 fermé).
+- **Moteur de règles PUR** `services/temps-deplacements-rules.ts` : `effectiveRuleSetFromRows` (rule_set
+  s'il existe, sinon dérivé du contrat — heures propres du salarié), `applyRounding`, `enforceMinimumBreak`,
+  `splitWeeklyOvertime`, `weeklyAggregate`, `effectiveDailyWorked`.
+- **Résolution effective** `repoGetEffectiveRuleSet(employeeId, date)` : contrat **couvrant la date**
+  (start ≤ date ≤ end), donc robuste au **changement de contrat** et au recalcul historique.
+- **Calcul câblé sur les règles réelles** : `computeDailyTimesheet` (cible jour + arrondi + pause mini) et
+  `computeWeeklyTimesheet` (cible hebdo + HS 25/50 + absence + persistance `hr_timesheet_weeks`).
+- **CRUD admin RH** (réservé rôles privilégiés) : `rule-sets`, `contracts` (1 seul actif/employé → 409),
+  `schedules`, + `GET /admin/employees` (pickers). Tout audité, jamais de secret.
+
+## Endpoints (`/time-clock/admin/*`, privilégiés)
+
+`GET employees` · `GET|POST rule-sets`, `PUT rule-sets/:id`, `PATCH rule-sets/:id/active` ·
+`GET|POST contracts`, `PUT contracts/:id`, `PATCH contracts/:id/active` ·
+`GET|POST schedules`, `PUT schedules/:id`, `DELETE schedules/:id`.
+
+## Modèle de calcul (configurable)
+
+- `weekly_target_minutes` / `daily_target_minutes` : cibles saisies (jamais 35/39 en dur).
+- HS : `[0..seuil1]` normal, `[seuil1..seuil2]` taux 1 (25 %), `[seuil2..]` taux 2 (50 %). Seuils/taux
+  dans `hr_time_rule_sets` ; à défaut, dérivés du contrat (HS au-delà de la cible contractuelle).
+- Arrondi (`rounding_rule`: `{unit_minutes, mode}`) et pause minimale (`break_rule`:
+  `{min_break_minutes, auto_deduct_after_minutes}`) appliqués au temps travaillé.
+
+## Tests unitaires (19 verts) — suite backend **229 / 46 fichiers**, `tsc` 0
+
+`temps-deplacements-t5-rules.test.ts` (13) : 35h normal, 39h normal, temps partiel, HS 25, HS 50, absence,
+absence de contrat (null → zéros), bornes split, contrat dérivé vs rule_set, changement 35→39 (cibles
+différentes), arrondis, pause mini. `temps-deplacements-t5-admin.test.ts` (6) : Responsable RH autorisé
+(create règle/contrat + audit), anti-IDOR (salarié 403 sur règle/contrats/horaire), 1 seul contrat actif (409).
+
+## Smoke SQL cerp_test (BEGIN…ROLLBACK, 0 résidu)
+
+```
+1 ONE_ACTIVE: 2e contrat actif refusé (OK)
+2 RESOLVE@2026-03-01: type=H35 weekly_h=35.00 rule_target=2100 (attendu H35/35/2100)
+3 RESOLVE@2026-08-01: type=H39 weekly_h=39.00 rule_target=NULL (attendu H39/39/NULL)
+4 RESOLVE@2025 (avant contrat): matches=0 (attendu 0)
+5 WEEK_UPSERT: worked=2400 ot25=300 (attendu 2400/300)
+residus = 0
+```
+
+Décision : approbation d'une correction (T4) trace la décision ; l'**override numérique** d'un relevé n'est
+pas implémenté ici (append-only) — laissé comme évolution documentée. HS « 25/50 » = libellés des taux
+configurables `overtime_rate_1/2`, pas des constantes.

--- a/docs/temps-deplacements-t6-evidence.md
+++ b/docs/temps-deplacements-t6-evidence.md
@@ -1,0 +1,34 @@
+# T6 — Kilomètres : preuves
+
+Objectif : déclaration de kilomètres par le salarié + validation responsable, avec réfs métier
+(affaire/client/fournisseur) optionnelles, statut, audit, anti-IDOR. Issue #119.
+
+## Livré
+
+- **Cycle** : `DRAFT → SUBMITTED → VALIDATED | REJECTED` (transitions gardées côté SQL).
+- **Salarié (anti-IDOR)** : `POST /kilometers` (employé dérivé de `req.user`, JAMAIS du corps),
+  `GET /kilometers/me`, `PATCH /kilometers/:id/submit` (ne soumet que SES déclarations DRAFT).
+- **Responsable** : `GET /kilometers/team` (périmètre manager / RH), `PATCH /kilometers/:id/validate|reject`
+  (uniquement si SUBMITTED ; hors périmètre → 403). Audit sur chaque écriture.
+- **Distance** : l'écart d'odomètre prime (arrondi 2 déc., jamais négatif) ; sinon distance saisie.
+- **Réfs douces** : `affaire_id` (bigint), `client_id`/`fournisseur_id` (int) — sans FK dure (comme T1).
+- **Véhicules** : `GET /kilometers/vehicles` (picker) + `POST /admin/vehicles` (privilégié).
+- **Frontend** : « Mes kilomètres » (déclarer/soumettre) + « Kilomètres équipe » (valider/refuser, gate rôle).
+- **Pas de géolocalisation continue** : uniquement lieux texte + odomètre saisis.
+
+## Tests (7 verts) — suite backend **248 / 49 fichiers**, `tsc` 0
+
+`t6-km.test.ts` : createKmSchema refuse `employee_id` (anti-IDOR) + odomètre incohérent ;
+`computeDistanceKm` (odomètre prime / distance / jamais négatif) ; `createMyKmEntry` (employé = token,
+audit) ; soumission ownership 403 ; DRAFT→SUBMITTED puis 409 ; validation hors périmètre 403 / RH VALIDATED ;
+validation d'une non-soumise → 409.
+
+## Smoke SQL cerp_test (BEGIN…ROLLBACK, 0 résidu)
+
+```
+0 CREATE: km cree (distance 42.5, refs douces)
+1 SUBMIT: rows=1 (attendu 1)
+2 VALIDATE: rows=1 (attendu 1)
+3 NON_REPLAY: rows=0 status=VALIDATED (attendu 0 / VALIDATED)
+4 TEAM_SCOPE: matches=1 (attendu 1)
+```

--- a/docs/temps-deplacements-t7-evidence.md
+++ b/docs/temps-deplacements-t7-evidence.md
@@ -1,0 +1,34 @@
+# T7 — Exports paie CSV/PDF : preuves
+
+Objectif : exports paie **figés** + **checksum**, CSV `;` UTF-8 BOM et PDF récap, **sans XLSX ni
+dépendance Excel**. Issue #119.
+
+## Livré
+
+- **Générateurs PURS** `services/temps-deplacements-exports.ts` : `toCsv` (séparateur `;`, BOM UTF-8,
+  CRLF, échappement `; " CR LF`), `buildPayrollCsv`, `minutesToDecimalHours`, `sha256Hex`, `buildPayrollPdf`
+  (pdfkit, police Helvetica intégrée — déjà en dépendance, **aucun ajout**).
+- **Lot figé** : `createExport` gèle les octets (base64) dans `hr_payroll_export_batches.frozen_snapshot_json`
+  + `checksum` SHA-256 en colonne. Re-téléchargement = octets **identiques**, intégrité **vérifiée**
+  (`getExportFile` recalcule le checksum → 409 si altération).
+- **Endpoints** (`/time-clock/admin/exports`, privilégiés) : `POST` (génère+fige), `GET` (liste, sans
+  octets), `GET /:id/download` (octets + en-têtes `Content-Disposition` + `X-Checksum-SHA256`).
+- **Frontend** : onglet « Exports paie » (période + format → générer ; liste + checksum + téléchargement
+  via `httpBlob` authentifié).
+
+## Tests (12 verts) — suite backend **241 / 48 fichiers**, `tsc` 0 ; frontend **103**, build OK
+
+`t7-exports.test.ts` (6, pur) : BOM + `;` + CRLF, échappement, minutes→heures, ligne paie complète,
+checksum SHA-256 connu (`sha256('abc')`), PDF `%PDF`. `t7-service.test.ts` (6) : CSV figé (base64 =
+octets, checksum exact) + audit, période invalide 400, salarié 403, intégrité (checksum OK → octets ;
+altéré → 409), 404/403.
+
+## Smoke SQL cerp_test (BEGIN…ROLLBACK, 0 résidu)
+
+```
+1 PERIOD_QUERY: matches=1 (attendu 1)
+2 BATCH_INSERT: format=CSV checksum=ba7816bf status=GENERATED row_count=1 (attendu CSV/ba7816bf/GENERATED/1)
+```
+
+Source des lignes = `hr_timesheet_weeks` (agrégats persistés par T5). Un export vide est possible tant que
+les semaines ne sont pas calculées/persistées (dépend des règles T5 + du pointage).

--- a/docs/temps-deplacements-t8-evidence.md
+++ b/docs/temps-deplacements-t8-evidence.md
@@ -1,0 +1,34 @@
+# T8 — Bornes & badges : preuves
+
+Objectif : provisioning des bornes/badges + page borne (kiosk). L'ingestion des événements borne
+(`/device-events`, `/device-heartbeat`, `/device-config`) existe depuis T2 ; T8 ajoute le CRUD admin.
+Issue #119.
+
+## Livré (backend)
+
+- **Bornes** (privilégié) : `POST /admin/devices` (génère un token opaque, stocke SON HASH, renvoie le
+  token en clair **une seule fois**), `GET /admin/devices` (sans hash), `PATCH /admin/devices/:id/status`
+  (ACTIVE/DISABLED), `POST /admin/devices/:id/rotate-token`.
+- **Badges** (privilégié) : `POST /admin/badges` (uid haché SHA-256, jamais stocké/loggé en clair),
+  `GET /admin/badges`, `PATCH /admin/badges/:id/revoke`.
+- **Sécurité** : token/uid **hachés** (`sha256` hex) — l'empreinte TS == `encode(digest(...),'hex')` PG
+  (interopérable avec la borne). Réponses/logs **sans secret ni PII sensible**.
+
+## Tests (7 verts) — suite backend **255 / 50 fichiers**, `tsc` 0
+
+`t8-devices.test.ts` : createDevice (token `^[0-9a-f]{48}$` renvoyé 1×, hash stocké = `hashDeviceToken(token)`,
+réponse sans hash, audit sans token), salarié 403, borne inconnue 404 ; createBadge (uid haché, audit sans
+uid), employé inexistant 404, salarié 403, révocation déjà faite 409.
+
+## Smoke SQL cerp_test (BEGIN…ROLLBACK, 0 résidu)
+
+```
+1 DEVICE_AUTH: matches=1 (attendu 1 ; sha256 TS == digest PG)
+2 BADGE_RESOLVE: matches=1 (attendu 1)
+3 DEVICE_DISABLED: active_matches=0 (attendu 0)
+4 BADGE_REVOKED: active_matches=0 (attendu 0)
+```
+
+Note : les endpoints borne sont derrière le socle `authenticateToken` (T2) ⇒ la borne s'exécute en
+session kiosk authentifiée **plus** son `device_token`. Front (page borne HID + feedback vert/orange/rouge
++ gestion bornes/badges) livré séparément (T8 front).

--- a/src/__tests__/temps-deplacements-t1.test.ts
+++ b/src/__tests__/temps-deplacements-t1.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { roles } from "../module/auth/validators/user.validator";
+
+// T1 — module « Temps & Déplacements » : schéma DB + append-only + rôle RH.
+// Tests « de base » sans base de données (le comportement runtime append-only est prouvé
+// par db/privileged/*.verify.sql sur cerp_test). Ici on garantit : vocabulaire RBAC,
+// idempotence/additivité de la migration, et présence du hardening append-only.
+
+const root = process.cwd();
+const additive = readFileSync(resolve(root, "db/patches/20260709_hr_temps_deplacements.sql"), "utf8");
+const appendOnly = readFileSync(resolve(root, "db/privileged/20260709_hr_time_events_append_only.sql"), "utf8");
+
+const HR_TABLES = [
+  "hr_employees", "hr_time_rule_sets", "hr_employment_contracts", "hr_work_schedules",
+  "hr_time_clock_devices", "hr_badge_credentials", "hr_time_events", "hr_work_sessions",
+  "hr_timesheet_days", "hr_timesheet_weeks", "hr_time_adjustments", "hr_time_anomalies",
+  "hr_vehicles", "hr_kilometer_entries", "hr_payroll_export_batches",
+];
+
+describe("T1 Temps & Déplacements — vocabulaire RBAC", () => {
+  it("ajoute le rôle 'Responsable RH'", () => {
+    expect(roles).toContain("Responsable RH");
+  });
+  it("conserve les rôles existants (compatibilité ascendante)", () => {
+    for (const r of [
+      "Directeur", "Employee", "Administrateur Systeme et Reseau",
+      "Responsable Qualité", "Secretaire", "Responsable Programmation",
+    ]) {
+      expect(roles).toContain(r);
+    }
+  });
+});
+
+describe("T1 — migration additive idempotente (db/patches)", () => {
+  it("crée les 15 tables hr_* en IF NOT EXISTS", () => {
+    for (const t of HR_TABLES) {
+      expect(additive).toContain(`CREATE TABLE IF NOT EXISTS public.${t} `);
+    }
+  });
+  it("est purement additive (aucun DROP TABLE/COLUMN/TYPE)", () => {
+    expect(/\bDROP\s+(TABLE|COLUMN|TYPE)\b/i.test(additive)).toBe(false);
+  });
+  it("garde les enums (DO $$ … IF NOT EXISTS pg_type)", () => {
+    expect(additive).toContain("IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname='hr_event_type')");
+  });
+  it("impose reason non vide + interdit l'auto-validation des corrections", () => {
+    expect(additive).toContain("hr_time_adjustments_reason_ck");
+    expect(additive).toContain("hr_time_adjustments_no_self_approve_ck");
+  });
+});
+
+describe("T1 — hr_time_events append-only (db/privileged)", () => {
+  it("déplace la propriété hors du rôle applicatif", () => {
+    expect(appendOnly).toContain("ALTER TABLE public.hr_time_events OWNER TO postgres");
+  });
+  it("restreint cerp_app à SELECT/INSERT (pas d'UPDATE/DELETE)", () => {
+    expect(appendOnly).toContain("GRANT SELECT, INSERT ON public.hr_time_events TO cerp_app");
+    expect(appendOnly).toContain("REVOKE UPDATE, DELETE, TRUNCATE ON public.hr_time_events FROM PUBLIC");
+  });
+  it("pose les 3 triggers de blocage UPDATE/DELETE/TRUNCATE", () => {
+    for (const trg of [
+      "trg_hr_time_events_no_update",
+      "trg_hr_time_events_no_delete",
+      "trg_hr_time_events_no_truncate",
+    ]) {
+      expect(appendOnly).toContain(trg);
+    }
+  });
+});

--- a/src/__tests__/temps-deplacements-t2.test.ts
+++ b/src/__tests__/temps-deplacements-t2.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  detectTimeAnomalies,
+  hashBadgeUid,
+  hashDeviceToken,
+  summarizeDay,
+} from "../module/temps-deplacements/services/temps-deplacements.service";
+import {
+  isHrPrivileged,
+  validateEmployeeAccess,
+  validateManagerScope,
+} from "../module/temps-deplacements/controllers/temps-deplacements.controller";
+import {
+  createTimeEventSchema,
+  deviceEventSchema,
+} from "../module/temps-deplacements/validators/temps-deplacements.validators";
+import type { HrEmployeeLite, HrEventType, HrTimeEvent } from "../module/temps-deplacements/types/temps-deplacements.types";
+
+function ev(type: HrEventType, time: string): HrTimeEvent {
+  return { id: "e", employee_id: "emp", device_id: null, event_type: type, event_time: time, source: "WEB", created_at: time };
+}
+const T = (h: number, m = 0) => `2026-07-06T${String(h).padStart(2, "0")}:${String(m).padStart(2, "0")}:00+02:00`;
+const emp = (over: Partial<HrEmployeeLite> = {}): HrEmployeeLite => ({
+  id: "11111111-1111-4111-8111-111111111111",
+  user_id: 1,
+  matricule: "TD001",
+  service: null,
+  manager_user_id: null,
+  status: "ACTIVE",
+  ...over,
+});
+
+describe("T2 — summarizeDay (moteur journée, pur)", () => {
+  it("IN/OUT normal → temps travaillé", () => {
+    const r = summarizeDay([ev("IN", T(9)), ev("OUT", T(17))]);
+    expect(r.firstIn).toBe(T(9));
+    expect(r.lastOut).toBe(T(17));
+    expect(r.breakMinutes).toBe(0);
+    expect(r.workedMinutes).toBe(480);
+    expect(r.openBreak).toBe(false);
+  });
+  it("pause complète déduite du temps travaillé", () => {
+    const r = summarizeDay([ev("IN", T(9)), ev("BREAK_START", T(12)), ev("BREAK_END", T(13)), ev("OUT", T(17))]);
+    expect(r.breakMinutes).toBe(60);
+    expect(r.workedMinutes).toBe(420);
+    expect(r.openBreak).toBe(false);
+  });
+  it("pause incomplète → openBreak, pas de temps de pause compté", () => {
+    const r = summarizeDay([ev("IN", T(9)), ev("BREAK_START", T(12)), ev("OUT", T(17))]);
+    expect(r.openBreak).toBe(true);
+    expect(r.breakMinutes).toBe(0);
+    expect(r.workedMinutes).toBe(480);
+  });
+  it("entrée sans sortie → 0 minute travaillée (session ouverte)", () => {
+    const r = summarizeDay([ev("IN", T(9))]);
+    expect(r.lastOut).toBeNull();
+    expect(r.workedMinutes).toBe(0);
+  });
+});
+
+describe("T2 — detectTimeAnomalies", () => {
+  it("sortie sans entrée → MISSING_IN", () => {
+    const a = detectTimeAnomalies([ev("OUT", T(17))], { openBreak: false, workedMinutes: 0, totalBreak: 0, isPastDay: true });
+    expect(a.map((x) => x.anomaly_type)).toContain("MISSING_IN");
+  });
+  it("entrée sans sortie sur jour PASSÉ → MISSING_OUT", () => {
+    const a = detectTimeAnomalies([ev("IN", T(9))], { openBreak: false, workedMinutes: 0, totalBreak: 0, isPastDay: true });
+    expect(a.map((x) => x.anomaly_type)).toContain("MISSING_OUT");
+  });
+  it("entrée sans sortie AUJOURD'HUI → aucune anomalie (session en cours)", () => {
+    const a = detectTimeAnomalies([ev("IN", T(9))], { openBreak: false, workedMinutes: 0, totalBreak: 0, isPastDay: false });
+    expect(a.map((x) => x.anomaly_type)).not.toContain("MISSING_OUT");
+  });
+  it("pause non terminée jour passé → MISSING_BREAK_END", () => {
+    const a = detectTimeAnomalies([ev("IN", T(9)), ev("BREAK_START", T(12))], { openBreak: true, workedMinutes: 480, totalBreak: 0, isPastDay: true });
+    expect(a.map((x) => x.anomaly_type)).toContain("MISSING_BREAK_END");
+  });
+  it("journée > 12h → TOO_LONG_DAY", () => {
+    const a = detectTimeAnomalies([ev("IN", T(6)), ev("OUT", T(22))], { openBreak: false, workedMinutes: 13 * 60, totalBreak: 0, isPastDay: true });
+    expect(a.map((x) => x.anomaly_type)).toContain("TOO_LONG_DAY");
+  });
+});
+
+describe("T2 — hachage badge/token (jamais en clair)", () => {
+  it("badge UID haché en sha256 hex, ≠ clair, déterministe", () => {
+    const h = hashBadgeUid("04AABBCCDD");
+    expect(h).toMatch(/^[0-9a-f]{64}$/);
+    expect(h).not.toBe("04AABBCCDD");
+    expect(hashBadgeUid("04AABBCCDD")).toBe(h);
+    expect(hashBadgeUid("other")).not.toBe(h);
+  });
+  it("device token haché aussi", () => {
+    expect(hashDeviceToken("secret-token")).toMatch(/^[0-9a-f]{64}$/);
+    expect(hashDeviceToken("secret-token")).not.toBe("secret-token");
+  });
+});
+
+describe("T2 — validateurs (anti-IDOR structurel + idempotency)", () => {
+  it("createTimeEventSchema accepte {event_type} et REFUSE tout employee_id", () => {
+    expect(createTimeEventSchema.parse({ event_type: "IN" }).event_type).toBe("IN");
+    expect(() => createTimeEventSchema.parse({ event_type: "IN", employee_id: "x" })).toThrow();
+    expect(() => createTimeEventSchema.parse({ event_type: "NOPE" })).toThrow();
+  });
+  it("deviceEventSchema EXIGE idempotency_key (min 8)", () => {
+    expect(() => deviceEventSchema.parse({ badge_uid: "abc", event_type: "IN" })).toThrow();
+    expect(() => deviceEventSchema.parse({ badge_uid: "abc", event_type: "IN", idempotency_key: "short" })).toThrow();
+    expect(deviceEventSchema.parse({ badge_uid: "abc", event_type: "IN", idempotency_key: "abcd1234" }).idempotency_key).toBe("abcd1234");
+  });
+});
+
+describe("T2 — RBAC / anti-IDOR", () => {
+  it("un salarié accède à SES données", () => {
+    expect(() => validateEmployeeAccess({ id: 1, role: "Employee" }, emp({ user_id: 1 }))).not.toThrow();
+  });
+  it("un salarié NE PEUT PAS lire un autre salarié (403)", () => {
+    expect(() => validateEmployeeAccess({ id: 2, role: "Employee" }, emp({ user_id: 1, manager_user_id: null }))).toThrow();
+  });
+  it("un manager accède à son subordonné", () => {
+    expect(() => validateEmployeeAccess({ id: 5, role: "Employee" }, emp({ user_id: 1, manager_user_id: 5 }))).not.toThrow();
+    expect(validateManagerScope({ id: 5, role: "Employee" }, emp({ manager_user_id: 5 }))).toBe(true);
+  });
+  it("Responsable RH / Direction / Admin accèdent globalement", () => {
+    expect(isHrPrivileged("Responsable RH")).toBe(true);
+    expect(isHrPrivileged("Directeur")).toBe(true);
+    expect(isHrPrivileged("Administrateur Systeme et Reseau")).toBe(true);
+    expect(isHrPrivileged("Employee")).toBe(false);
+    expect(() => validateEmployeeAccess({ id: 9, role: "Responsable RH" }, emp({ user_id: 1 }))).not.toThrow();
+  });
+});

--- a/src/__tests__/temps-deplacements-t4.test.ts
+++ b/src/__tests__/temps-deplacements-t4.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Repository corrections : entièrement mocké (pas de DB en test unitaire).
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-corrections.repository", () => ({
+  repoResolveTargetEmployeeId: vi.fn(),
+  repoCreateAdjustment: vi.fn(),
+  repoGetAdjustmentById: vi.fn(),
+  repoDecideAdjustment: vi.fn(),
+  repoGetTimesheetDayById: vi.fn(),
+  repoGetTimesheetWeekById: vi.fn(),
+  repoSetDayValidation: vi.fn(),
+  repoSetWeekValidation: vi.fn(),
+  repoListTeamAdjustments: vi.fn(),
+  repoListTeamAnomaliesForDate: vi.fn(),
+  repoListTeamEmployees: vi.fn(),
+}));
+
+// Repository T2 : on garde le réel SAUF transaction/audit/lecture employé (pour ne pas toucher la DB).
+vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../module/temps-deplacements/repository/temps-deplacements.repository")>();
+  return {
+    ...actual,
+    withTransaction: vi.fn(async (fn: (c: unknown) => unknown) => fn({ query: vi.fn() })),
+    insertAuditLog: vi.fn(async () => undefined),
+    repoGetEmployeeById: vi.fn(),
+  };
+});
+
+import * as corRepo from "../module/temps-deplacements/repository/temps-deplacements-corrections.repository";
+import * as baseRepo from "../module/temps-deplacements/repository/temps-deplacements.repository";
+import * as svc from "../module/temps-deplacements/services/temps-deplacements-corrections.service";
+import {
+  createAdjustmentSchema,
+  uuidParamsSchema,
+} from "../module/temps-deplacements/validators/temps-deplacements.validators";
+import type { HrEmployeeLite } from "../module/temps-deplacements/types/temps-deplacements.types";
+
+const cor = vi.mocked(corRepo);
+const base = vi.mocked(baseRepo);
+
+const UUID = "22222222-2222-4222-8222-222222222222";
+const AUDIT = {
+  user_id: 1, ip: null, user_agent: null, device_type: null, os: null, browser: null,
+  path: null, page_key: null, client_session_id: null,
+};
+const emp = (over: Partial<HrEmployeeLite> = {}): HrEmployeeLite => ({
+  id: "11111111-1111-4111-8111-111111111111",
+  user_id: 1, matricule: "TD001", service: null, manager_user_id: null, status: "ACTIVE", ...over,
+});
+const adj = (over: Partial<Awaited<ReturnType<typeof corRepo.repoGetAdjustmentById>>> = {}) => ({
+  id: UUID, target_type: "DAY" as const, target_id: UUID, reason: "oubli de badge",
+  status: "REQUESTED" as const, requested_by: 1, approved_by: null, created_at: "t", approved_at: null, ...over,
+});
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("T4 — validateurs corrections", () => {
+  it("createAdjustmentSchema : motif obligatoire, strict, enum cible", () => {
+    expect(createAdjustmentSchema.parse({ target_type: "DAY", target_id: UUID, reason: "oubli" }).reason).toBe("oubli");
+    expect(() => createAdjustmentSchema.parse({ target_type: "DAY", target_id: UUID, reason: "x" })).toThrow(); // <3
+    expect(() => createAdjustmentSchema.parse({ target_type: "NOPE", target_id: UUID, reason: "oubli" })).toThrow();
+    expect(() => createAdjustmentSchema.parse({ target_type: "DAY", target_id: UUID, reason: "oubli", employee_id: 3 })).toThrow(); // strict
+  });
+  it("uuidParamsSchema : refuse un id non-uuid", () => {
+    expect(uuidParamsSchema.parse({ id: UUID }).id).toBe(UUID);
+    expect(() => uuidParamsSchema.parse({ id: "42" })).toThrow();
+  });
+});
+
+describe("T4 — isHrPrivileged", () => {
+  it("RH / Direction / Admin privilégiés ; salarié non", () => {
+    expect(svc.isHrPrivileged("Responsable RH")).toBe(true);
+    expect(svc.isHrPrivileged("Direction")).toBe(true);
+    expect(svc.isHrPrivileged("Administrateur")).toBe(true);
+    expect(svc.isHrPrivileged("Employee")).toBe(false);
+  });
+});
+
+describe("T4 — createAdjustment (anti-IDOR, motif tracé)", () => {
+  it("cible inexistante → 404", async () => {
+    cor.repoResolveTargetEmployeeId.mockResolvedValue(null);
+    await expect(svc.createAdjustment({ id: 1, role: "Employee" }, { target_type: "DAY", target_id: UUID, reason: "oubli" }, AUDIT))
+      .rejects.toMatchObject({ status: 404, code: "HR_TARGET_NOT_FOUND" });
+  });
+  it("un salarié ne peut PAS demander une correction sur autrui → 403", async () => {
+    cor.repoResolveTargetEmployeeId.mockResolvedValue("emp-x");
+    base.repoGetEmployeeById.mockResolvedValue(emp({ user_id: 1, manager_user_id: 9 }));
+    await expect(svc.createAdjustment({ id: 2, role: "Employee" }, { target_type: "DAY", target_id: UUID, reason: "oubli" }, AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+  });
+  it("sur SES données → créée en REQUESTED + audit 'requested'", async () => {
+    cor.repoResolveTargetEmployeeId.mockResolvedValue("emp-self");
+    base.repoGetEmployeeById.mockResolvedValue(emp({ user_id: 2 }));
+    cor.repoCreateAdjustment.mockResolvedValue(adj({ requested_by: 2 }));
+    const r = await svc.createAdjustment({ id: 2, role: "Employee" }, { target_type: "DAY", target_id: UUID, reason: "oubli de badge" }, AUDIT);
+    expect(r.status).toBe("REQUESTED");
+    expect(base.insertAuditLog).toHaveBeenCalledWith(expect.anything(), AUDIT, expect.objectContaining({ action: "temps-deplacements.adjustment.requested" }));
+  });
+});
+
+describe("T4 — decideAdjustment (pas d'auto-validation, RBAC, idempotence)", () => {
+  it("demande inexistante → 404", async () => {
+    cor.repoGetAdjustmentById.mockResolvedValue(null);
+    await expect(svc.decideAdjustment({ id: 5, role: "Responsable RH" }, UUID, "APPROVED", AUDIT))
+      .rejects.toMatchObject({ status: 404, code: "HR_ADJUSTMENT_NOT_FOUND" });
+  });
+  it("demande déjà traitée → 409", async () => {
+    cor.repoGetAdjustmentById.mockResolvedValue(adj({ status: "APPROVED" }));
+    await expect(svc.decideAdjustment({ id: 5, role: "Responsable RH" }, UUID, "APPROVED", AUDIT))
+      .rejects.toMatchObject({ status: 409, code: "HR_ADJUSTMENT_NOT_PENDING" });
+  });
+  it("AUTO-VALIDATION interdite : le demandeur ne peut approuver sa propre demande → 403", async () => {
+    cor.repoGetAdjustmentById.mockResolvedValue(adj({ requested_by: 7 }));
+    await expect(svc.decideAdjustment({ id: 7, role: "Responsable RH" }, UUID, "APPROVED", AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_SELF_APPROVAL_FORBIDDEN" });
+  });
+  it("hors périmètre (ni manager ni RH) → 403", async () => {
+    cor.repoGetAdjustmentById.mockResolvedValue(adj({ requested_by: 1 }));
+    cor.repoResolveTargetEmployeeId.mockResolvedValue("emp-x");
+    base.repoGetEmployeeById.mockResolvedValue(emp({ manager_user_id: 99 }));
+    await expect(svc.decideAdjustment({ id: 5, role: "Employee" }, UUID, "APPROVED", AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+  });
+  it("responsable RH approuve → APPROVED + audit 'approved'", async () => {
+    cor.repoGetAdjustmentById.mockResolvedValue(adj({ requested_by: 1 }));
+    cor.repoResolveTargetEmployeeId.mockResolvedValue("emp-x");
+    cor.repoDecideAdjustment.mockResolvedValue(adj({ status: "APPROVED", requested_by: 1, approved_by: 5 }));
+    const r = await svc.decideAdjustment({ id: 5, role: "Responsable RH" }, UUID, "APPROVED", AUDIT);
+    expect(r.status).toBe("APPROVED");
+    expect(base.insertAuditLog).toHaveBeenCalledWith(expect.anything(), AUDIT, expect.objectContaining({ action: "temps-deplacements.adjustment.approved" }));
+  });
+  it("course : la transition a déjà eu lieu (repo renvoie null) → 409", async () => {
+    cor.repoGetAdjustmentById.mockResolvedValue(adj({ requested_by: 1 }));
+    cor.repoResolveTargetEmployeeId.mockResolvedValue("emp-x");
+    cor.repoDecideAdjustment.mockResolvedValue(null);
+    await expect(svc.decideAdjustment({ id: 5, role: "Responsable RH" }, UUID, "APPROVED", AUDIT))
+      .rejects.toMatchObject({ status: 409, code: "HR_ADJUSTMENT_NOT_PENDING" });
+  });
+});
+
+describe("T4 — validateTimesheetDay", () => {
+  it("journée inexistante → 404", async () => {
+    cor.repoGetTimesheetDayById.mockResolvedValue(null);
+    await expect(svc.validateTimesheetDay({ id: 5, role: "Responsable RH" }, UUID, AUDIT))
+      .rejects.toMatchObject({ status: 404, code: "HR_TIMESHEET_NOT_FOUND" });
+  });
+  it("journée déjà validée → 409 (non rejouable)", async () => {
+    cor.repoGetTimesheetDayById.mockResolvedValue({ id: UUID, employee_id: "emp-x", validation_status: "VALIDATED" });
+    await expect(svc.validateTimesheetDay({ id: 5, role: "Responsable RH" }, UUID, AUDIT))
+      .rejects.toMatchObject({ status: 409, code: "HR_ALREADY_VALIDATED" });
+  });
+  it("DRAFT → VALIDATED + audit 'day.validated'", async () => {
+    cor.repoGetTimesheetDayById.mockResolvedValue({ id: UUID, employee_id: "emp-x", validation_status: "DRAFT" });
+    cor.repoSetDayValidation.mockResolvedValue({ id: UUID, employee_id: "emp-x", validation_status: "VALIDATED" });
+    const r = await svc.validateTimesheetDay({ id: 5, role: "Responsable RH" }, UUID, AUDIT);
+    expect(r.validation_status).toBe("VALIDATED");
+    expect(base.insertAuditLog).toHaveBeenCalledWith(expect.anything(), AUDIT, expect.objectContaining({ action: "temps-deplacements.day.validated" }));
+  });
+});

--- a/src/__tests__/temps-deplacements-t5-admin.test.ts
+++ b/src/__tests__/temps-deplacements-t5-admin.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-rules.repository", () => ({
+  repoListRuleSets: vi.fn(),
+  repoInsertRuleSet: vi.fn(),
+  repoUpdateRuleSet: vi.fn(),
+  repoSetRuleSetActive: vi.fn(),
+  repoGetRuleSetById: vi.fn(),
+  repoListContracts: vi.fn(),
+  repoGetContractById: vi.fn(),
+  repoInsertContract: vi.fn(),
+  repoUpdateContract: vi.fn(),
+  repoSetContractActive: vi.fn(),
+  repoListSchedules: vi.fn(),
+  repoInsertSchedule: vi.fn(),
+  repoUpdateSchedule: vi.fn(),
+  repoDeleteSchedule: vi.fn(),
+}));
+vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", async (io) => {
+  const actual = await io<typeof import("../module/temps-deplacements/repository/temps-deplacements.repository")>();
+  return {
+    ...actual,
+    withTransaction: vi.fn(async (fn: (c: unknown) => unknown) => fn({ query: vi.fn() })),
+    insertAuditLog: vi.fn(async () => undefined),
+  };
+});
+
+import * as rulesRepo from "../module/temps-deplacements/repository/temps-deplacements-rules.repository";
+import * as baseRepo from "../module/temps-deplacements/repository/temps-deplacements.repository";
+import * as admin from "../module/temps-deplacements/services/temps-deplacements-admin.service";
+
+const rules = vi.mocked(rulesRepo);
+const base = vi.mocked(baseRepo);
+const AUDIT = { user_id: 9, ip: null, user_agent: null, device_type: null, os: null, browser: null, path: null, page_key: null, client_session_id: null };
+const RH = { id: 9, role: "Responsable RH" };
+const SALARIE = { id: 2, role: "Employee" };
+const RULE = {
+  name: "Cadre 35h", weekly_target_minutes: 2100, daily_target_minutes: 420,
+  overtime_threshold_1_minutes: 2100, overtime_rate_1: 1.25, overtime_threshold_2_minutes: 2580, overtime_rate_2: 1.5,
+  rounding_rule: {}, break_rule: {},
+};
+const CONTRACT = {
+  employee_id: "11111111-1111-4111-8111-111111111111", contract_type: "H35" as const,
+  weekly_hours_target: 35, daily_hours_target: null, start_date: "2026-01-01", end_date: null, rule_set_id: null, active: true,
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("T5 — admin RH : Responsable RH autorisé", () => {
+  it("crée une règle + audit", async () => {
+    rules.repoInsertRuleSet.mockResolvedValue({ id: "rs1", ...RULE });
+    const r = await admin.createRuleSet(RH, RULE, AUDIT);
+    expect(r.id).toBe("rs1");
+    expect(rules.repoInsertRuleSet).toHaveBeenCalledOnce();
+    expect(base.insertAuditLog).toHaveBeenCalledWith(expect.anything(), AUDIT, expect.objectContaining({ action: "temps-deplacements.rule_set.create" }));
+  });
+  it("crée un contrat", async () => {
+    rules.repoInsertContract.mockResolvedValue({ id: "c1", ...CONTRACT });
+    const r = await admin.createContract(RH, CONTRACT, AUDIT);
+    expect(r.id).toBe("c1");
+  });
+});
+
+describe("T5 — admin RH : anti-IDOR (salarié refusé)", () => {
+  it("un salarié ne peut PAS créer de règle → 403", async () => {
+    await expect(admin.createRuleSet(SALARIE, RULE, AUDIT)).rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+    expect(rules.repoInsertRuleSet).not.toHaveBeenCalled();
+  });
+  it("un salarié ne peut PAS lister les contrats → 403", async () => {
+    await expect(admin.listContracts(SALARIE)).rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+  });
+  it("un salarié ne peut PAS créer d'horaire → 403", async () => {
+    await expect(admin.createSchedule(SALARIE, { employee_id: CONTRACT.employee_id, day_of_week: 1, expected_start: null, expected_end: null, expected_break_minutes: 0, flexible_start_window: 0, flexible_end_window: 0, active: true }, AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+  });
+});
+
+describe("T5 — admin RH : un seul contrat actif par employé", () => {
+  it("créer un 2e contrat actif → 409", async () => {
+    rules.repoInsertContract.mockRejectedValue(Object.assign(new Error("dup"), { code: "23505" }));
+    await expect(admin.createContract(RH, CONTRACT, AUDIT)).rejects.toMatchObject({ status: 409, code: "HR_CONTRACT_ACTIVE_EXISTS" });
+  });
+});

--- a/src/__tests__/temps-deplacements-t5-rules.test.ts
+++ b/src/__tests__/temps-deplacements-t5-rules.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyRounding,
+  effectiveRuleSetFromRows,
+  enforceMinimumBreak,
+  splitWeeklyOvertime,
+  weeklyAggregate,
+  type ContractRow,
+  type HrRuleSet,
+} from "../module/temps-deplacements/services/temps-deplacements-rules";
+
+const rs = (over: Partial<HrRuleSet> = {}): HrRuleSet => ({
+  id: "r", name: "R", weekly_target_minutes: 2100, daily_target_minutes: 420,
+  overtime_threshold_1_minutes: 2100, overtime_rate_1: 1.25, overtime_threshold_2_minutes: 2580, overtime_rate_2: 1.5,
+  rounding_rule: {}, break_rule: {}, active: true, ...over,
+});
+
+// 35h = 2100 min, 39h = 2340 min, 43h = 2580 min. AUCUNE de ces valeurs n'est codée dans le moteur.
+describe("T5 — weeklyAggregate (35h/39h/HS/absence, règles configurables)", () => {
+  it("salarié 35h semaine normale → aucune HS, aucune absence", () => {
+    const a = weeklyAggregate(2100, rs({ weekly_target_minutes: 2100, overtime_threshold_1_minutes: 2100 }));
+    expect(a).toMatchObject({ contract_minutes: 2100, overtime_25_minutes: 0, overtime_50_minutes: 0, absence_minutes: 0 });
+  });
+  it("salarié 39h semaine normale → aucune HS (seuil = contrat)", () => {
+    const a = weeklyAggregate(2340, rs({ weekly_target_minutes: 2340, overtime_threshold_1_minutes: 2340 }));
+    expect(a).toMatchObject({ contract_minutes: 2340, overtime_25_minutes: 0, overtime_50_minutes: 0 });
+  });
+  it("temps partiel 20h → cible 1200, HS au-delà", () => {
+    expect(weeklyAggregate(1200, rs({ weekly_target_minutes: 1200, overtime_threshold_1_minutes: 1200, overtime_threshold_2_minutes: null })))
+      .toMatchObject({ overtime_25_minutes: 0, absence_minutes: 0 });
+    expect(weeklyAggregate(1320, rs({ weekly_target_minutes: 1200, overtime_threshold_1_minutes: 1200, overtime_threshold_2_minutes: null })).overtime_25_minutes).toBe(120);
+  });
+  it("heures sup 25 (base 35h) : 40h → 300 min à 25 %, 0 à 50 %", () => {
+    const a = weeklyAggregate(2400, rs());
+    expect(a.overtime_25_minutes).toBe(300);
+    expect(a.overtime_50_minutes).toBe(0);
+  });
+  it("heures sup 50 : 45h → 480 min à 25 % puis 120 min à 50 %", () => {
+    const a = weeklyAggregate(2700, rs());
+    expect(a.overtime_25_minutes).toBe(2580 - 2100);
+    expect(a.overtime_50_minutes).toBe(2700 - 2580);
+  });
+  it("absence : 30h sur contrat 35h → 300 min d'absence", () => {
+    expect(weeklyAggregate(1800, rs()).absence_minutes).toBe(300);
+  });
+  it("absence de contrat (règle nulle) → tout à zéro, pas de plantage", () => {
+    expect(weeklyAggregate(2000, null)).toEqual({ contract_minutes: 0, overtime_25_minutes: 0, overtime_50_minutes: 0, absence_minutes: 0, rule_set_name: null });
+  });
+});
+
+describe("T5 — splitWeeklyOvertime (bornes)", () => {
+  it("t2 non défini → tout le sup passe en taux 1", () => {
+    expect(splitWeeklyOvertime(2600, rs({ overtime_threshold_2_minutes: null }))).toEqual({ normal: 2100, overtime25: 500, overtime50: 0 });
+  });
+});
+
+describe("T5 — effectiveRuleSetFromRows (contrat vs rule_set, changement de contrat)", () => {
+  const ct = (over: Partial<ContractRow>): ContractRow => ({ id: "c", contract_type: "H35", weekly_hours_target: 35, daily_hours_target: null, rule_set_id: null, ...over });
+  it("sans rule_set : cible dérivée du CONTRAT (jamais 35/39 en dur)", () => {
+    const r = effectiveRuleSetFromRows(ct({ weekly_hours_target: 35 }), null);
+    expect(r.weekly_target_minutes).toBe(2100);
+    expect(r.daily_target_minutes).toBe(420); // 2100/5
+    expect(r.overtime_threshold_1_minutes).toBe(2100);
+  });
+  it("changement de contrat 35h → 39h : cibles différentes", () => {
+    const r35 = effectiveRuleSetFromRows(ct({ weekly_hours_target: 35 }), null);
+    const r39 = effectiveRuleSetFromRows(ct({ contract_type: "H39", weekly_hours_target: 39 }), null);
+    expect(r39.weekly_target_minutes).toBe(2340);
+    expect(r39.weekly_target_minutes).not.toBe(r35.weekly_target_minutes);
+  });
+  it("avec rule_set : les cibles du rule_set priment sur le contrat", () => {
+    const r = effectiveRuleSetFromRows(ct({ weekly_hours_target: 39, rule_set_id: "rs1" }), {
+      id: "rs1", name: "Cadre 35h", weekly_target_minutes: 2100, daily_target_minutes: 420,
+      overtime_threshold_1_minutes: 2100, overtime_rate_1: 1.25, overtime_threshold_2_minutes: 2580, overtime_rate_2: 1.5,
+      rounding_rule: { unit_minutes: 15, mode: "nearest" }, break_rule: { min_break_minutes: 20 }, active: true,
+    });
+    expect(r.weekly_target_minutes).toBe(2100); // rule_set, pas 2340
+    expect(r.rounding_rule.unit_minutes).toBe(15);
+    expect(r.break_rule.min_break_minutes).toBe(20);
+  });
+});
+
+describe("T5 — arrondis & pause minimale", () => {
+  it("arrondi au quart d'heure (nearest/up/down)", () => {
+    expect(applyRounding(127, { unit_minutes: 15, mode: "nearest" })).toBe(120);
+    expect(applyRounding(121, { unit_minutes: 15, mode: "up" })).toBe(135);
+    expect(applyRounding(134, { unit_minutes: 15, mode: "down" })).toBe(120);
+    expect(applyRounding(127, {})).toBe(127); // pas de règle → inchangé
+  });
+  it("pause minimale imposée au-delà d'un seuil", () => {
+    expect(enforceMinimumBreak(480, 10, { min_break_minutes: 30, auto_deduct_after_minutes: 360 })).toBe(460); // déduit 20
+    expect(enforceMinimumBreak(300, 0, { min_break_minutes: 30, auto_deduct_after_minutes: 360 })).toBe(300); // sous le seuil
+    expect(enforceMinimumBreak(480, 30, { min_break_minutes: 30, auto_deduct_after_minutes: 360 })).toBe(480); // pause suffisante
+  });
+});

--- a/src/__tests__/temps-deplacements-t6-km.test.ts
+++ b/src/__tests__/temps-deplacements-t6-km.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-km.repository", () => ({
+  repoCreateKmEntry: vi.fn(),
+  repoGetKmEntryById: vi.fn(),
+  repoSubmitKmEntry: vi.fn(),
+  repoDecideKmEntry: vi.fn(),
+  repoListKmForEmployee: vi.fn(),
+  repoListTeamKmEntries: vi.fn(),
+  repoListVehicles: vi.fn(),
+  repoCreateVehicle: vi.fn(),
+}));
+vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", async (io) => {
+  const actual = await io<typeof import("../module/temps-deplacements/repository/temps-deplacements.repository")>();
+  return {
+    ...actual,
+    withTransaction: vi.fn(async (fn: (c: unknown) => unknown) => fn({ query: vi.fn() })),
+    insertAuditLog: vi.fn(async () => undefined),
+    repoGetEmployeeById: vi.fn(),
+  };
+});
+vi.mock("../module/temps-deplacements/services/temps-deplacements.service", async (io) => {
+  const actual = await io<typeof import("../module/temps-deplacements/services/temps-deplacements.service")>();
+  return { ...actual, resolveEmployeeFromUser: vi.fn() };
+});
+
+import * as kmRepo from "../module/temps-deplacements/repository/temps-deplacements-km.repository";
+import * as baseRepo from "../module/temps-deplacements/repository/temps-deplacements.repository";
+import * as t2 from "../module/temps-deplacements/services/temps-deplacements.service";
+import * as svc from "../module/temps-deplacements/services/temps-deplacements-km.service";
+import { computeDistanceKm } from "../module/temps-deplacements/services/temps-deplacements-km.service";
+import { createKmSchema } from "../module/temps-deplacements/validators/temps-deplacements.validators";
+
+const km = vi.mocked(kmRepo);
+const t2m = vi.mocked(t2);
+const AUDIT = { user_id: 1, ip: null, user_agent: null, device_type: null, os: null, browser: null, path: null, page_key: null, client_session_id: null };
+const emp = (over = {}) => ({ id: "E", user_id: 1, matricule: "TD1", service: null, manager_user_id: null, status: "ACTIVE" as const, ...over });
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("T6 — validateur & distance", () => {
+  it("createKmSchema REFUSE employee_id (anti-IDOR) et l'odomètre incohérent", () => {
+    expect(createKmSchema.parse({ date: "2026-03-02", distance_km: 12 }).distance_km).toBe(12);
+    expect(() => createKmSchema.parse({ date: "2026-03-02", employee_id: "x" })).toThrow();
+    expect(() => createKmSchema.parse({ date: "2026-03-02", start_odometer: 100, end_odometer: 50 })).toThrow();
+  });
+  it("computeDistanceKm : l'odomètre prime, sinon la distance, jamais négatif", () => {
+    expect(computeDistanceKm({ start_odometer: 1000, end_odometer: 1042, distance_km: 0 })).toBe(42);
+    expect(computeDistanceKm({ start_odometer: null, end_odometer: null, distance_km: 15.5 })).toBe(15.5);
+    expect(computeDistanceKm({ start_odometer: null, end_odometer: null, distance_km: -3 })).toBe(0);
+  });
+});
+
+describe("T6 — createMyKmEntry (anti-IDOR : employé dérivé de req.user)", () => {
+  it("emploie l'employé du token, pas du corps ; audit", async () => {
+    t2m.resolveEmployeeFromUser.mockResolvedValue(emp());
+    km.repoCreateKmEntry.mockImplementation(async (_c, i) => ({ id: "k1", ...i, created_at: "t", validated_by: null, validated_at: null }));
+    const r = await svc.createMyKmEntry({ id: 1, role: "Employee" }, { date: "2026-03-02", type: "MISSION", vehicle_id: null, start_location: null, end_location: null, start_odometer: null, end_odometer: null, distance_km: 12, affaire_id: null, client_id: null, fournisseur_id: null, submit: true }, AUDIT);
+    expect(km.repoCreateKmEntry.mock.calls[0][1].employee_id).toBe("E");
+    expect(r.status).toBe("SUBMITTED");
+    expect(baseRepo.insertAuditLog).toHaveBeenCalled();
+  });
+});
+
+describe("T6 — soumission & validation (ownership + périmètre + transitions)", () => {
+  it("un salarié ne peut soumettre QUE ses déclarations → 403", async () => {
+    km.repoGetKmEntryById.mockResolvedValue({ id: "k1", employee_id: "OTHER", status: "DRAFT" } as never);
+    t2m.resolveEmployeeFromUser.mockResolvedValue(emp());
+    await expect(svc.submitMyKmEntry({ id: 1, role: "Employee" }, "k1", AUDIT)).rejects.toMatchObject({ status: 403 });
+  });
+  it("soumission DRAFT→SUBMITTED ; déjà soumise → 409", async () => {
+    km.repoGetKmEntryById.mockResolvedValue({ id: "k1", employee_id: "E", status: "DRAFT" } as never);
+    t2m.resolveEmployeeFromUser.mockResolvedValue(emp());
+    km.repoSubmitKmEntry.mockResolvedValueOnce({ id: "k1", status: "SUBMITTED" } as never);
+    expect((await svc.submitMyKmEntry({ id: 1, role: "Employee" }, "k1", AUDIT)).status).toBe("SUBMITTED");
+    km.repoSubmitKmEntry.mockResolvedValueOnce(null);
+    await expect(svc.submitMyKmEntry({ id: 1, role: "Employee" }, "k1", AUDIT)).rejects.toMatchObject({ status: 409, code: "HR_KM_NOT_DRAFT" });
+  });
+  it("validation hors périmètre → 403 ; RH → VALIDATED", async () => {
+    km.repoGetKmEntryById.mockResolvedValue({ id: "k1", employee_id: "E", status: "SUBMITTED" } as never);
+    vi.mocked(baseRepo.repoGetEmployeeById).mockResolvedValue(emp({ manager_user_id: 99 }));
+    await expect(svc.decideKmEntry({ id: 5, role: "Employee" }, "k1", "VALIDATED", AUDIT)).rejects.toMatchObject({ status: 403 });
+    km.repoDecideKmEntry.mockResolvedValue({ id: "k1", status: "VALIDATED" } as never);
+    expect((await svc.decideKmEntry({ id: 5, role: "Responsable RH" }, "k1", "VALIDATED", AUDIT)).status).toBe("VALIDATED");
+  });
+  it("valider une déclaration non soumise → 409", async () => {
+    km.repoGetKmEntryById.mockResolvedValue({ id: "k1", employee_id: "E", status: "DRAFT" } as never);
+    km.repoDecideKmEntry.mockResolvedValue(null);
+    await expect(svc.decideKmEntry({ id: 5, role: "Responsable RH" }, "k1", "VALIDATED", AUDIT)).rejects.toMatchObject({ status: 409, code: "HR_KM_NOT_SUBMITTED" });
+  });
+});

--- a/src/__tests__/temps-deplacements-t7-exports.test.ts
+++ b/src/__tests__/temps-deplacements-t7-exports.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPayrollCsv,
+  buildPayrollPdf,
+  minutesToDecimalHours,
+  payrollRowToCsvCells,
+  sha256Hex,
+  toCsv,
+  type PayrollWeekRow,
+} from "../module/temps-deplacements/services/temps-deplacements-exports";
+
+const row: PayrollWeekRow = {
+  matricule: "TD001", name: "Jean", surname: "Dupont", week_start: "2026-03-02", week_end: "2026-03-08",
+  worked_minutes: 2400, contract_minutes: 2100, overtime_25_minutes: 300, overtime_50_minutes: 0, absence_minutes: 0,
+};
+
+describe("T7 — CSV (séparateur ; + BOM UTF-8 + échappement)", () => {
+  it("préfixe le BOM UTF-8 et sépare par ;", () => {
+    const csv = toCsv(["A", "B"], [["1", "2"]]);
+    expect(csv.charCodeAt(0)).toBe(0xfeff); // BOM
+    expect(csv).toContain("A;B\r\n");
+    expect(csv.endsWith("\r\n")).toBe(true);
+  });
+  it("échappe les champs contenant ; \" ou saut de ligne", () => {
+    expect(toCsv(["X"], [["a;b"]])).toContain('"a;b"');
+    expect(toCsv(["X"], [['il a dit "oui"']])).toContain('"il a dit ""oui"""');
+  });
+  it("minutes → heures décimales", () => {
+    expect(minutesToDecimalHours(90)).toBe("1.50");
+    expect(minutesToDecimalHours(2100)).toBe("35.00");
+    expect(minutesToDecimalHours(0)).toBe("0.00");
+  });
+  it("ligne paie → cellules, CSV complet avec en-tête", () => {
+    expect(payrollRowToCsvCells(row)).toEqual(["TD001", "Dupont", "Jean", "2026-03-02", "2026-03-08", "40.00", "35.00", "5.00", "0.00", "0.00"]);
+    const csv = buildPayrollCsv([row]);
+    expect(csv).toContain("Matricule;Nom;Prénom");
+    expect(csv).toContain("TD001;Dupont;Jean;2026-03-02;2026-03-08;40.00;35.00;5.00;0.00;0.00");
+  });
+});
+
+describe("T7 — checksum SHA-256 déterministe", () => {
+  it("hache de façon stable et connue", () => {
+    expect(sha256Hex("abc")).toBe("ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad");
+    const csv = buildPayrollCsv([row]);
+    expect(sha256Hex(csv)).toBe(sha256Hex(csv)); // reproductible
+  });
+});
+
+describe("T7 — PDF (pdfkit, sans dépendance Excel)", () => {
+  it("produit un buffer PDF valide (%PDF)", async () => {
+    const buf = await buildPayrollPdf({ periodStart: "2026-03-01", periodEnd: "2026-03-31" }, [row]);
+    expect(buf.length).toBeGreaterThan(100);
+    expect(buf.subarray(0, 4).toString("latin1")).toBe("%PDF");
+  });
+});

--- a/src/__tests__/temps-deplacements-t7-service.test.ts
+++ b/src/__tests__/temps-deplacements-t7-service.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-exports.repository", () => ({
+  repoListWeeksForPeriod: vi.fn(),
+  repoInsertExportBatch: vi.fn(),
+  repoListExportBatches: vi.fn(),
+  repoGetExportBatch: vi.fn(),
+}));
+vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", async (io) => {
+  const actual = await io<typeof import("../module/temps-deplacements/repository/temps-deplacements.repository")>();
+  return {
+    ...actual,
+    withTransaction: vi.fn(async (fn: (c: unknown) => unknown) => fn({ query: vi.fn() })),
+    insertAuditLog: vi.fn(async () => undefined),
+  };
+});
+
+import * as expRepo from "../module/temps-deplacements/repository/temps-deplacements-exports.repository";
+import * as baseRepo from "../module/temps-deplacements/repository/temps-deplacements.repository";
+import { buildPayrollCsv, sha256Hex, type PayrollWeekRow } from "../module/temps-deplacements/services/temps-deplacements-exports";
+import * as svc from "../module/temps-deplacements/services/temps-deplacements-exports.service";
+
+const repo = vi.mocked(expRepo);
+const base = vi.mocked(baseRepo);
+const AUDIT = { user_id: 9, ip: null, user_agent: null, device_type: null, os: null, browser: null, path: null, page_key: null, client_session_id: null };
+const RH = { id: 9, role: "Responsable RH" };
+const SALARIE = { id: 2, role: "Employee" };
+const WEEK: PayrollWeekRow = {
+  matricule: "TD001", name: "Jean", surname: "Dupont", week_start: "2026-03-02", week_end: "2026-03-08",
+  worked_minutes: 2400, contract_minutes: 2100, overtime_25_minutes: 300, overtime_50_minutes: 0, absence_minutes: 0,
+};
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("T7 — createExport (figé + checksum, privilégié)", () => {
+  it("CSV : octets gelés (base64) + checksum SHA-256 exact + audit", async () => {
+    repo.repoListWeeksForPeriod.mockResolvedValue([WEEK]);
+    repo.repoInsertExportBatch.mockImplementation(async (_c, i) => ({ id: "b1", ...i, status: "GENERATED", exported_at: "t" }));
+    const r = await svc.createExport(RH, { period_start: "2026-03-01", period_end: "2026-03-31", format: "CSV" }, AUDIT);
+    expect(r.row_count).toBe(1);
+
+    const arg = repo.repoInsertExportBatch.mock.calls[0][1];
+    const expectedCsv = buildPayrollCsv([WEEK]);
+    const expectedChecksum = sha256Hex(Buffer.from(expectedCsv, "utf-8"));
+    expect(arg.checksum).toBe(expectedChecksum);
+    const frozen = arg.frozen_snapshot_json as { file_base64: string; row_count: number };
+    expect(Buffer.from(frozen.file_base64, "base64").toString("utf-8")).toBe(expectedCsv); // gelé identique
+    expect(base.insertAuditLog).toHaveBeenCalledWith(expect.anything(), AUDIT, expect.objectContaining({ action: "temps-deplacements.export.create" }));
+  });
+  it("période invalide (fin < début) → 400", async () => {
+    await expect(svc.createExport(RH, { period_start: "2026-03-31", period_end: "2026-03-01", format: "CSV" }, AUDIT))
+      .rejects.toMatchObject({ status: 400, code: "HR_EXPORT_BAD_PERIOD" });
+  });
+  it("un salarié ne peut PAS exporter → 403", async () => {
+    await expect(svc.createExport(SALARIE, { period_start: "2026-03-01", period_end: "2026-03-31", format: "CSV" }, AUDIT))
+      .rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+    expect(repo.repoInsertExportBatch).not.toHaveBeenCalled();
+  });
+});
+
+describe("T7 — getExportFile (intégrité vérifiée)", () => {
+  const csv = buildPayrollCsv([WEEK]);
+  const good = { file_base64: Buffer.from(csv, "utf-8").toString("base64"), filename: "paie.csv", content_type: "text/csv; charset=utf-8" };
+
+  it("checksum correct → renvoie les octets figés", async () => {
+    repo.repoGetExportBatch.mockResolvedValue({ id: "b1", checksum: sha256Hex(Buffer.from(csv, "utf-8")), frozen_snapshot_json: good });
+    const f = await svc.getExportFile(RH, "11111111-1111-4111-8111-111111111111");
+    expect(f.buffer.toString("utf-8")).toBe(csv);
+  });
+  it("checksum incohérent (altération) → 409", async () => {
+    repo.repoGetExportBatch.mockResolvedValue({ id: "b1", checksum: "deadbeef", frozen_snapshot_json: good });
+    await expect(svc.getExportFile(RH, "11111111-1111-4111-8111-111111111111")).rejects.toMatchObject({ status: 409, code: "HR_EXPORT_CHECKSUM_MISMATCH" });
+  });
+  it("introuvable → 404 ; salarié → 403", async () => {
+    repo.repoGetExportBatch.mockResolvedValue(null);
+    await expect(svc.getExportFile(RH, "11111111-1111-4111-8111-111111111111")).rejects.toMatchObject({ status: 404 });
+    await expect(svc.getExportFile(SALARIE, "11111111-1111-4111-8111-111111111111")).rejects.toMatchObject({ status: 403 });
+  });
+});

--- a/src/__tests__/temps-deplacements-t8-devices.test.ts
+++ b/src/__tests__/temps-deplacements-t8-devices.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../module/temps-deplacements/repository/temps-deplacements-devices.repository", () => ({
+  repoCreateDevice: vi.fn(),
+  repoListDevices: vi.fn(),
+  repoSetDeviceStatus: vi.fn(),
+  repoRotateDeviceToken: vi.fn(),
+  repoCreateBadge: vi.fn(),
+  repoListBadges: vi.fn(),
+  repoRevokeBadge: vi.fn(),
+}));
+vi.mock("../module/temps-deplacements/repository/temps-deplacements.repository", async (io) => {
+  const actual = await io<typeof import("../module/temps-deplacements/repository/temps-deplacements.repository")>();
+  return {
+    ...actual,
+    withTransaction: vi.fn(async (fn: (c: unknown) => unknown) => fn({ query: vi.fn() })),
+    insertAuditLog: vi.fn(async () => undefined),
+    repoGetEmployeeById: vi.fn(),
+  };
+});
+
+import * as devRepo from "../module/temps-deplacements/repository/temps-deplacements-devices.repository";
+import * as baseRepo from "../module/temps-deplacements/repository/temps-deplacements.repository";
+import * as svc from "../module/temps-deplacements/services/temps-deplacements-devices.service";
+import { hashBadgeUid, hashDeviceToken } from "../module/temps-deplacements/services/temps-deplacements.service";
+
+const dev = vi.mocked(devRepo);
+const base = vi.mocked(baseRepo);
+const AUDIT = { user_id: 9, ip: null, user_agent: null, device_type: null, os: null, browser: null, path: null, page_key: null, client_session_id: null };
+const RH = { id: 9, role: "Responsable RH" };
+const SALARIE = { id: 2, role: "Employee" };
+const EMP_ID = "11111111-1111-4111-8111-111111111111";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("T8 — bornes : token généré, haché, jamais loggé", () => {
+  it("createDevice renvoie un token en clair 1×, stocke le HASH, audit sans secret", async () => {
+    dev.repoCreateDevice.mockImplementation(async (_c, i) => ({ id: "d1", name: i.name, location: i.location, device_type: i.device_type, status: "ACTIVE", last_seen_at: null, created_at: "t" }));
+    const r = await svc.createDevice(RH, { name: "Borne Atelier", location: "Hall", device_type: "KIOSK" }, AUDIT);
+    expect(r.token).toMatch(/^[0-9a-f]{48}$/);
+    // Le hash stocké correspond bien au token renvoyé.
+    expect(dev.repoCreateDevice.mock.calls[0][1].device_token_hash).toBe(hashDeviceToken(r.token));
+    // La réponse device n'expose PAS le hash.
+    expect(r.device).not.toHaveProperty("device_token_hash");
+    // L'audit ne contient JAMAIS le token.
+    const auditDetails = base.insertAuditLog.mock.calls[0][2].details as Record<string, unknown>;
+    expect(JSON.stringify(auditDetails)).not.toContain(r.token);
+    expect(auditDetails).toEqual({ name: "Borne Atelier" });
+  });
+  it("un salarié ne peut PAS créer de borne → 403", async () => {
+    await expect(svc.createDevice(SALARIE, { name: "X", location: null, device_type: null }, AUDIT)).rejects.toMatchObject({ status: 403, code: "HR_FORBIDDEN" });
+    expect(dev.repoCreateDevice).not.toHaveBeenCalled();
+  });
+  it("changer le statut d'une borne inexistante → 404", async () => {
+    dev.repoSetDeviceStatus.mockResolvedValue(null);
+    await expect(svc.setDeviceStatus(RH, EMP_ID, "DISABLED", AUDIT)).rejects.toMatchObject({ status: 404, code: "HR_DEVICE_NOT_FOUND" });
+  });
+});
+
+describe("T8 — badges : uid haché, jamais loggé", () => {
+  it("createBadge stocke le HASH de l'uid, audit sans uid", async () => {
+    base.repoGetEmployeeById.mockResolvedValue({ id: EMP_ID, user_id: 1, matricule: "TD1", service: null, manager_user_id: null, status: "ACTIVE" });
+    dev.repoCreateBadge.mockImplementation(async (_c, i) => ({ id: "b1", employee_id: i.employee_id, badge_label: i.badge_label, active: true, issued_at: "t", revoked_at: null }));
+    await svc.createBadge(RH, { employee_id: EMP_ID, badge_uid: "04AABBCCDD", badge_label: "Badge 1" }, AUDIT);
+    expect(dev.repoCreateBadge.mock.calls[0][1].badge_uid_hash).toBe(hashBadgeUid("04AABBCCDD"));
+    const auditDetails = base.insertAuditLog.mock.calls[0][2].details as Record<string, unknown>;
+    expect(JSON.stringify(auditDetails)).not.toContain("04AABBCCDD");
+  });
+  it("badge pour un employé inexistant → 404", async () => {
+    base.repoGetEmployeeById.mockResolvedValue(null);
+    await expect(svc.createBadge(RH, { employee_id: EMP_ID, badge_uid: "x", badge_label: null }, AUDIT)).rejects.toMatchObject({ status: 404 });
+  });
+  it("un salarié ne peut PAS créer de badge → 403", async () => {
+    await expect(svc.createBadge(SALARIE, { employee_id: EMP_ID, badge_uid: "x", badge_label: null }, AUDIT)).rejects.toMatchObject({ status: 403 });
+  });
+  it("révoquer un badge déjà révoqué → 409", async () => {
+    dev.repoRevokeBadge.mockResolvedValue(null);
+    await expect(svc.revokeBadge(RH, EMP_ID, AUDIT)).rejects.toMatchObject({ status: 409, code: "HR_BADGE_NOT_ACTIVE" });
+  });
+});

--- a/src/module/auth/validators/user.validator.ts
+++ b/src/module/auth/validators/user.validator.ts
@@ -1,13 +1,14 @@
 import { z } from "zod";
 import { isoDate, strictEmail, strongPassword, trimString } from "./_helpers";
 
-const roles = [
+export const roles = [
   "Directeur",
   "Employee",
   "Administrateur Systeme et Reseau",
   "Responsable Qualité",
   "Secretaire",
   "Responsable Programmation",
+  "Responsable RH",
 ] as const;
 
 const genders = ["Male", "Female"] as const;

--- a/src/module/temps-deplacements/controllers/temps-deplacements-admin.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements-admin.controller.ts
@@ -1,0 +1,76 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import * as svc from "../services/temps-deplacements-admin.service";
+import {
+  contractBodySchema,
+  listContractsQuerySchema,
+  listSchedulesQuerySchema,
+  ruleSetBodySchema,
+  scheduleBodySchema,
+  setActiveSchema,
+  uuidParamsSchema,
+} from "../validators/temps-deplacements.validators";
+import { buildAuditContext, requireUser } from "./temps-deplacements.controller";
+
+// -------------------------------------------------------------- Employés (pickers)
+export const getEmployees = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await svc.listEmployees(requireUser(req)));
+});
+
+// -------------------------------------------------------------- Rule sets
+export const getRuleSets = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await svc.listRuleSets(requireUser(req)));
+});
+export const postRuleSet = asyncHandler(async (req: Request, res: Response) => {
+  const body = ruleSetBodySchema.parse(req.body);
+  res.status(201).json(await svc.createRuleSet(requireUser(req), body, buildAuditContext(req)));
+});
+export const putRuleSet = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const body = ruleSetBodySchema.parse(req.body);
+  res.json(await svc.updateRuleSet(requireUser(req), id, body, buildAuditContext(req)));
+});
+export const patchRuleSetActive = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const { active } = setActiveSchema.parse(req.body);
+  res.json(await svc.setRuleSetActive(requireUser(req), id, active, buildAuditContext(req)));
+});
+
+// -------------------------------------------------------------- Contrats
+export const getContracts = asyncHandler(async (req: Request, res: Response) => {
+  const { employee_id } = listContractsQuerySchema.parse(req.query);
+  res.json(await svc.listContracts(requireUser(req), employee_id));
+});
+export const postContract = asyncHandler(async (req: Request, res: Response) => {
+  const body = contractBodySchema.parse(req.body);
+  res.status(201).json(await svc.createContract(requireUser(req), body, buildAuditContext(req)));
+});
+export const putContract = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const body = contractBodySchema.parse(req.body);
+  res.json(await svc.updateContract(requireUser(req), id, body, buildAuditContext(req)));
+});
+export const patchContractActive = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const { active } = setActiveSchema.parse(req.body);
+  res.json(await svc.setContractActive(requireUser(req), id, active, buildAuditContext(req)));
+});
+
+// -------------------------------------------------------------- Horaires types
+export const getSchedules = asyncHandler(async (req: Request, res: Response) => {
+  const { employee_id } = listSchedulesQuerySchema.parse(req.query);
+  res.json(await svc.listSchedules(requireUser(req), employee_id));
+});
+export const postSchedule = asyncHandler(async (req: Request, res: Response) => {
+  const body = scheduleBodySchema.parse(req.body);
+  res.status(201).json(await svc.createSchedule(requireUser(req), body, buildAuditContext(req)));
+});
+export const putSchedule = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const body = scheduleBodySchema.parse(req.body);
+  res.json(await svc.updateSchedule(requireUser(req), id, body, buildAuditContext(req)));
+});
+export const deleteScheduleHandler = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.deleteSchedule(requireUser(req), id, buildAuditContext(req)));
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements-corrections.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements-corrections.controller.ts
@@ -1,0 +1,61 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import * as svc from "../services/temps-deplacements-corrections.service";
+import {
+  createAdjustmentSchema,
+  teamAnomaliesQuerySchema,
+  uuidParamsSchema,
+} from "../validators/temps-deplacements.validators";
+import { buildAuditContext, requireUser } from "./temps-deplacements.controller";
+
+// ------------------------------------------------------------------ Corrections (salarié + responsable)
+export const postAdjustment = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  const body = createAdjustmentSchema.parse(req.body);
+  const adj = await svc.createAdjustment(actor, body, buildAuditContext(req));
+  res.status(201).json(adj);
+});
+
+export const approveAdjustment = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  const { id } = uuidParamsSchema.parse(req.params);
+  const adj = await svc.decideAdjustment(actor, id, "APPROVED", buildAuditContext(req));
+  res.json(adj);
+});
+
+export const rejectAdjustment = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  const { id } = uuidParamsSchema.parse(req.params);
+  const adj = await svc.decideAdjustment(actor, id, "REJECTED", buildAuditContext(req));
+  res.json(adj);
+});
+
+export const getTeamAdjustments = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  res.json(await svc.listTeamAdjustments(actor));
+});
+
+// ------------------------------------------------------------------ Validation jour / semaine
+export const validateDay = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.validateTimesheetDay(actor, id, buildAuditContext(req)));
+});
+
+export const validateWeek = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.validateTimesheetWeek(actor, id, buildAuditContext(req)));
+});
+
+// ------------------------------------------------------------------ Périmètre équipe (lecture)
+export const getTeamToday = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  res.json(await svc.teamToday(actor));
+});
+
+export const getTeamAnomalies = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireUser(req);
+  const { date } = teamAnomaliesQuerySchema.parse(req.query);
+  res.json(await svc.teamAnomalies(actor, date));
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements-devices.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements-devices.controller.ts
@@ -1,0 +1,43 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import * as svc from "../services/temps-deplacements-devices.service";
+import {
+  badgeBodySchema,
+  deviceBodySchema,
+  deviceStatusSchema,
+  listBadgesQuerySchema,
+  uuidParamsSchema,
+} from "../validators/temps-deplacements.validators";
+import { buildAuditContext, requireUser } from "./temps-deplacements.controller";
+
+// ------------------------------------------------------------------ Bornes
+export const getDevices = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await svc.listDevices(requireUser(req)));
+});
+export const postDevice = asyncHandler(async (req: Request, res: Response) => {
+  const body = deviceBodySchema.parse(req.body);
+  res.status(201).json(await svc.createDevice(requireUser(req), body, buildAuditContext(req))); // { device, token } — token une seule fois
+});
+export const patchDeviceStatus = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const { status } = deviceStatusSchema.parse(req.body);
+  res.json(await svc.setDeviceStatus(requireUser(req), id, status, buildAuditContext(req)));
+});
+export const postDeviceRotate = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.rotateDeviceToken(requireUser(req), id, buildAuditContext(req)));
+});
+
+// ------------------------------------------------------------------ Badges
+export const getBadges = asyncHandler(async (req: Request, res: Response) => {
+  const { employee_id } = listBadgesQuerySchema.parse(req.query);
+  res.json(await svc.listBadges(requireUser(req), employee_id));
+});
+export const postBadge = asyncHandler(async (req: Request, res: Response) => {
+  const body = badgeBodySchema.parse(req.body);
+  res.status(201).json(await svc.createBadge(requireUser(req), body, buildAuditContext(req)));
+});
+export const revokeBadgeHandler = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.revokeBadge(requireUser(req), id, buildAuditContext(req)));
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements-exports.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements-exports.controller.ts
@@ -1,0 +1,25 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import * as svc from "../services/temps-deplacements-exports.service";
+import { exportBodySchema, uuidParamsSchema } from "../validators/temps-deplacements.validators";
+import { buildAuditContext, requireUser } from "./temps-deplacements.controller";
+
+export const postExport = asyncHandler(async (req: Request, res: Response) => {
+  const body = exportBodySchema.parse(req.body);
+  const batch = await svc.createExport(requireUser(req), body, buildAuditContext(req));
+  res.status(201).json(batch);
+});
+
+export const getExports = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await svc.listExports(requireUser(req)));
+});
+
+// Télécharge les octets FIGÉS + expose le checksum (intégrité vérifiée côté service).
+export const downloadExport = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  const file = await svc.getExportFile(requireUser(req), id);
+  res.setHeader("Content-Type", file.contentType);
+  res.setHeader("Content-Disposition", `attachment; filename="${file.filename}"`);
+  res.setHeader("X-Checksum-SHA256", file.checksum);
+  res.send(file.buffer);
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements-km.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements-km.controller.ts
@@ -1,0 +1,50 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import * as svc from "../services/temps-deplacements-km.service";
+import {
+  createKmSchema,
+  myKmQuerySchema,
+  teamKmQuerySchema,
+  uuidParamsSchema,
+  vehicleBodySchema,
+} from "../validators/temps-deplacements.validators";
+import { buildAuditContext, requireUser } from "./temps-deplacements.controller";
+
+// ------------------------------------------------------------------ Salarié (self-service)
+export const postKm = asyncHandler(async (req: Request, res: Response) => {
+  const body = createKmSchema.parse(req.body);
+  const entry = await svc.createMyKmEntry(requireUser(req), body, buildAuditContext(req));
+  res.status(201).json(entry);
+});
+export const getMyKm = asyncHandler(async (req: Request, res: Response) => {
+  const filters = myKmQuerySchema.parse(req.query);
+  res.json(await svc.listMyKmEntries(requireUser(req), filters));
+});
+export const submitKm = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.submitMyKmEntry(requireUser(req), id, buildAuditContext(req)));
+});
+
+// ------------------------------------------------------------------ Responsable
+export const getTeamKm = asyncHandler(async (req: Request, res: Response) => {
+  const { status } = teamKmQuerySchema.parse(req.query);
+  res.json(await svc.listTeamKmEntries(requireUser(req), status));
+});
+export const validateKm = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.decideKmEntry(requireUser(req), id, "VALIDATED", buildAuditContext(req)));
+});
+export const rejectKm = asyncHandler(async (req: Request, res: Response) => {
+  const { id } = uuidParamsSchema.parse(req.params);
+  res.json(await svc.decideKmEntry(requireUser(req), id, "REJECTED", buildAuditContext(req)));
+});
+
+// ------------------------------------------------------------------ Véhicules
+export const getVehicles = asyncHandler(async (req: Request, res: Response) => {
+  requireUser(req);
+  res.json(await svc.listVehicles());
+});
+export const postVehicle = asyncHandler(async (req: Request, res: Response) => {
+  const body = vehicleBodySchema.parse(req.body);
+  res.status(201).json(await svc.createVehicle(requireUser(req), body, buildAuditContext(req)));
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements.controller.ts
@@ -1,0 +1,199 @@
+import type { Request, Response } from "express";
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { HttpError } from "../../../utils/httpError";
+import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import type { AuditContext } from "../repository/temps-deplacements.repository";
+import * as repo from "../repository/temps-deplacements.repository";
+import * as svc from "../services/temps-deplacements.service";
+import type { HrEmployeeLite } from "../types/temps-deplacements.types";
+import {
+  createTimeEventSchema,
+  deviceEventSchema,
+  deviceHeartbeatSchema,
+  employeeIdParamsSchema,
+  meAnomaliesQuerySchema,
+  meTodayQuerySchema,
+  meWeekQuerySchema,
+} from "../validators/temps-deplacements.validators";
+
+function buildAuditContext(req: Request): AuditContext {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
+  }
+  const userAgent = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null;
+  const ip = getClientIp(req);
+  const device = parseDevice(userAgent);
+  const pageKey = typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null;
+  const clientSessionId =
+    typeof req.headers["x-client-session-id"] === "string"
+      ? req.headers["x-client-session-id"]
+      : typeof req.headers["x-session-id"] === "string"
+        ? req.headers["x-session-id"]
+        : null;
+  return {
+    user_id: user.id,
+    ip,
+    user_agent: userAgent,
+    device_type: device.device_type,
+    os: device.os,
+    browser: device.browser,
+    path: req.originalUrl ?? null,
+    page_key: pageKey,
+    client_session_id: clientSessionId,
+  };
+}
+
+function requireUser(req: Request): { id: number; role: string } {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  return { id: user.id, role: typeof user.role === "string" ? user.role : "" };
+}
+
+// RBAC lecture d'un employé : soi-même, OU son manager, OU un rôle RH/Direction/Admin.
+export function isHrPrivileged(role: string): boolean {
+  const r = role.toLowerCase();
+  return r.includes("rh") || r.includes("directeur") || r.includes("direction") || r.includes("administrateur");
+}
+export function validateManagerScope(reqUser: { id: number; role: string }, target: HrEmployeeLite): boolean {
+  return target.manager_user_id !== null && target.manager_user_id === reqUser.id;
+}
+// Lève 403 si l'appelant n'a pas le droit de lire cet employé (anti-IDOR).
+export function validateEmployeeAccess(reqUser: { id: number; role: string }, target: HrEmployeeLite): void {
+  const self = target.user_id === reqUser.id;
+  if (self || validateManagerScope(reqUser, target) || isHrPrivileged(reqUser.role)) return;
+  throw new HttpError(403, "HR_FORBIDDEN", "Accès refusé aux données de cet employé.");
+}
+const assertCanReadEmployee = validateEmployeeAccess;
+
+function mondayOf(ymd: string): string {
+  const d = new Date(`${ymd}T12:00:00Z`);
+  const dow = d.getUTCDay(); // 0=dim..6=sam
+  const back = (dow + 6) % 7; // vers lundi
+  d.setUTCDate(d.getUTCDate() - back);
+  return d.toISOString().slice(0, 10);
+}
+
+// ------------------------------------------------------------------ Salarié (JWT socle)
+export const postEvent = asyncHandler(async (req: Request, res: Response) => {
+  const reqUser = requireUser(req);
+  const body = createTimeEventSchema.parse(req.body);
+  const emp = await svc.resolveEmployeeFromUser(reqUser.id);
+  const result = await svc.createTimeEvent(
+    { employee_id: emp.id, event_type: body.event_type, event_time: body.event_time, source: "WEB" },
+    buildAuditContext(req)
+  );
+  res.status(201).json(result);
+});
+
+export const getMeToday = asyncHandler(async (req: Request, res: Response) => {
+  const reqUser = requireUser(req);
+  const { date } = meTodayQuerySchema.parse(req.query);
+  const emp = await svc.resolveEmployeeFromUser(reqUser.id);
+  res.json(await svc.computeDailyTimesheet(emp.id, date ?? svc.todayParis()));
+});
+
+export const getMeWeek = asyncHandler(async (req: Request, res: Response) => {
+  const reqUser = requireUser(req);
+  const { week_start } = meWeekQuerySchema.parse(req.query);
+  const emp = await svc.resolveEmployeeFromUser(reqUser.id);
+  res.json(await svc.computeWeeklyTimesheet(emp.id, week_start ?? mondayOf(svc.todayParis())));
+});
+
+export const getMeAnomalies = asyncHandler(async (req: Request, res: Response) => {
+  const reqUser = requireUser(req);
+  const filters = meAnomaliesQuerySchema.parse(req.query);
+  const emp = await svc.resolveEmployeeFromUser(reqUser.id);
+  res.json(await svc.listMyAnomalies(emp.id, filters));
+});
+
+// Lecture périmètre (manager/RH) + garde ANTI-IDOR (un salarié ne peut pas lire un autre).
+export const getEmployeeToday = asyncHandler(async (req: Request, res: Response) => {
+  const reqUser = requireUser(req);
+  const { id } = employeeIdParamsSchema.parse(req.params);
+  const { date } = meTodayQuerySchema.parse(req.query);
+  const target = await repo.repoGetEmployeeById(id);
+  if (!target) throw new HttpError(404, "HR_EMPLOYEE_NOT_FOUND", "Employé introuvable.");
+  assertCanReadEmployee(reqUser, target);
+  res.json(await svc.computeDailyTimesheet(target.id, date ?? svc.todayParis()));
+});
+
+export const getEmployeeWeek = asyncHandler(async (req: Request, res: Response) => {
+  const reqUser = requireUser(req);
+  const { id } = employeeIdParamsSchema.parse(req.params);
+  const { week_start } = meWeekQuerySchema.parse(req.query);
+  const target = await repo.repoGetEmployeeById(id);
+  if (!target) throw new HttpError(404, "HR_EMPLOYEE_NOT_FOUND", "Employé introuvable.");
+  assertCanReadEmployee(reqUser, target);
+  res.json(await svc.computeWeeklyTimesheet(target.id, week_start ?? mondayOf(svc.todayParis())));
+});
+
+// ------------------------------------------------------------------ Borne / device (JWT socle + device_token)
+async function authenticateDevice(deviceToken: string | undefined): Promise<{ id: string }> {
+  if (!deviceToken) throw new HttpError(401, "HR_DEVICE_UNAUTHORIZED", "device_token requis.");
+  const device = await repo.repoGetActiveDeviceByTokenHash(svc.hashDeviceToken(deviceToken));
+  if (!device) throw new HttpError(401, "HR_DEVICE_UNAUTHORIZED", "Borne non autorisée.");
+  return device;
+}
+
+export const postDeviceEvent = asyncHandler(async (req: Request, res: Response) => {
+  requireUser(req);
+  const body = deviceEventSchema.parse(req.body);
+  const device = await authenticateDevice(body.device_token);
+  const audit = buildAuditContext(req);
+  let emp: HrEmployeeLite;
+  try {
+    emp = await svc.resolveEmployeeFromBadge(body.badge_uid); // badge_uid haché serveur ; jamais loggé
+  } catch (err) {
+    // Badge inconnu/révoqué : audité SANS le badge_uid brut.
+    await repo.withTransaction((client) =>
+      repo.insertAuditLog(client, audit, {
+        action: "temps-deplacements.event.refused",
+        entity_type: "hr_time_clock_devices",
+        entity_id: device.id,
+        details: { reason: err instanceof HttpError ? err.code : "UNKNOWN", event_type: body.event_type },
+      })
+    );
+    throw err;
+  }
+  const result = await svc.createTimeEvent(
+    {
+      employee_id: emp.id,
+      event_type: body.event_type,
+      event_time: body.event_time,
+      source: "BADGE",
+      device_id: device.id,
+      idempotency_key: body.idempotency_key,
+    },
+    audit
+  );
+  res.status(201).json(result);
+});
+
+export const postDeviceHeartbeat = asyncHandler(async (req: Request, res: Response) => {
+  requireUser(req);
+  const body = deviceHeartbeatSchema.parse(req.body);
+  const device = await authenticateDevice(body.device_token);
+  await repo.repoTouchDeviceHeartbeat(device.id);
+  await repo.withTransaction((client) =>
+    repo.insertAuditLog(client, buildAuditContext(req), {
+      action: "temps-deplacements.device.heartbeat",
+      entity_type: "hr_time_clock_devices",
+      entity_id: device.id,
+      details: null,
+    })
+  );
+  res.json({ ok: true, device_id: device.id });
+});
+
+// Config borne — AUCUNE donnée RH sensible (types d'événements + cadence heartbeat).
+export const getDeviceConfig = asyncHandler(async (req: Request, res: Response) => {
+  requireUser(req);
+  const token = typeof req.query.device_token === "string" ? req.query.device_token : undefined;
+  const device = await authenticateDevice(token);
+  res.json({
+    device_id: device.id,
+    event_types: ["IN", "OUT", "BREAK_START", "BREAK_END"],
+    heartbeat_interval_seconds: 60,
+  });
+});

--- a/src/module/temps-deplacements/controllers/temps-deplacements.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements.controller.ts
@@ -16,7 +16,7 @@ import {
   meWeekQuerySchema,
 } from "../validators/temps-deplacements.validators";
 
-function buildAuditContext(req: Request): AuditContext {
+export function buildAuditContext(req: Request): AuditContext {
   const user = req.user;
   if (!user || typeof user.id !== "number") {
     throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
@@ -44,7 +44,7 @@ function buildAuditContext(req: Request): AuditContext {
   };
 }
 
-function requireUser(req: Request): { id: number; role: string } {
+export function requireUser(req: Request): { id: number; role: string } {
   const user = req.user;
   if (!user || typeof user.id !== "number") throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
   return { id: user.id, role: typeof user.role === "string" ? user.role : "" };

--- a/src/module/temps-deplacements/repository/temps-deplacements-corrections.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements-corrections.repository.ts
@@ -1,0 +1,255 @@
+import pool from "../../../config/database";
+import type { HrEmployeeLite, HrTimeAnomaly } from "../types/temps-deplacements.types";
+import type { DbQueryer } from "./temps-deplacements.repository";
+
+// -------------------------------------------------------------- T4 : corrections + validation
+// Réutilise DbQueryer / withTransaction / insertAuditLog du repository T2.
+
+export type HrAdjustmentTarget = "EVENT" | "DAY" | "WEEK";
+export type HrAdjustmentStatus = "REQUESTED" | "APPROVED" | "REJECTED";
+export type HrValidationStatus = "DRAFT" | "TO_REVIEW" | "VALIDATED" | "EXPORTED";
+
+export type HrAdjustment = {
+  id: string;
+  target_type: HrAdjustmentTarget;
+  target_id: string;
+  reason: string;
+  status: HrAdjustmentStatus;
+  requested_by: number;
+  approved_by: number | null;
+  created_at: string;
+  approved_at: string | null;
+};
+export type HrAdjustmentWithEmployee = HrAdjustment & {
+  employee_id: string;
+  matricule: string;
+  service: string | null;
+};
+
+const ADJ_COLS =
+  `id::text, target_type::text, target_id::text, reason, status::text, requested_by, approved_by, created_at::text, approved_at::text`;
+const EMP_COLS = `id::text, user_id, matricule, service, manager_user_id, status::text`;
+
+function mapAdj(r: Record<string, unknown>): HrAdjustment {
+  return {
+    id: String(r.id),
+    target_type: r.target_type as HrAdjustmentTarget,
+    target_id: String(r.target_id),
+    reason: String(r.reason),
+    status: r.status as HrAdjustmentStatus,
+    requested_by: Number(r.requested_by),
+    approved_by: r.approved_by === null || r.approved_by === undefined ? null : Number(r.approved_by),
+    created_at: String(r.created_at),
+    approved_at: (r.approved_at as string | null) ?? null,
+  };
+}
+
+function mapEmployee(r: Record<string, unknown>): HrEmployeeLite {
+  return {
+    id: String(r.id),
+    user_id: Number(r.user_id),
+    matricule: String(r.matricule),
+    service: (r.service as string | null) ?? null,
+    manager_user_id: r.manager_user_id === null || r.manager_user_id === undefined ? null : Number(r.manager_user_id),
+    status: r.status as HrEmployeeLite["status"],
+  };
+}
+
+// Table propriétaire de la cible, par type (whitelist = enum hr_adjustment_target ⇒ pas d'injection).
+const TARGET_TABLE: Record<HrAdjustmentTarget, string> = {
+  EVENT: "hr_time_events",
+  DAY: "hr_timesheet_days",
+  WEEK: "hr_timesheet_weeks",
+};
+
+// Résout l'employé (uuid) propriétaire d'une cible de correction. null si la cible n'existe pas.
+export async function repoResolveTargetEmployeeId(
+  targetType: HrAdjustmentTarget,
+  targetId: string,
+  q: DbQueryer = pool
+): Promise<string | null> {
+  const res = await q.query(
+    `SELECT employee_id::text FROM public.${TARGET_TABLE[targetType]} WHERE id = $1::uuid LIMIT 1`,
+    [targetId]
+  );
+  return res.rows[0] ? String(res.rows[0].employee_id) : null;
+}
+
+export async function repoCreateAdjustment(
+  q: DbQueryer,
+  input: {
+    target_type: HrAdjustmentTarget;
+    target_id: string;
+    reason: string;
+    old_value?: Record<string, unknown> | null;
+    new_value?: Record<string, unknown> | null;
+    requested_by: number;
+  }
+): Promise<HrAdjustment> {
+  const res = await q.query(
+    `INSERT INTO public.hr_time_adjustments
+       (target_type, target_id, old_value_json, new_value_json, reason, requested_by, status)
+     VALUES ($1::hr_adjustment_target, $2::uuid, $3::jsonb, $4::jsonb, $5, $6, 'REQUESTED'::hr_adjustment_status)
+     RETURNING ${ADJ_COLS}`,
+    [
+      input.target_type,
+      input.target_id,
+      JSON.stringify(input.old_value ?? null),
+      JSON.stringify(input.new_value ?? null),
+      input.reason,
+      input.requested_by,
+    ]
+  );
+  return mapAdj(res.rows[0]);
+}
+
+export async function repoGetAdjustmentById(id: string, q: DbQueryer = pool): Promise<HrAdjustment | null> {
+  const res = await q.query(`SELECT ${ADJ_COLS} FROM public.hr_time_adjustments WHERE id = $1::uuid LIMIT 1`, [id]);
+  return res.rows[0] ? mapAdj(res.rows[0]) : null;
+}
+
+// Transition REQUESTED → APPROVED|REJECTED. Ne modifie QUE si encore en attente (retourne null sinon).
+// La contrainte DB hr_time_adjustments_no_self_approve_ck (approved_by <> requested_by) reste un garde-fou.
+export async function repoDecideAdjustment(
+  q: DbQueryer,
+  id: string,
+  status: Exclude<HrAdjustmentStatus, "REQUESTED">,
+  approvedBy: number
+): Promise<HrAdjustment | null> {
+  const res = await q.query(
+    `UPDATE public.hr_time_adjustments
+        SET status = $2::hr_adjustment_status, approved_by = $3, approved_at = now()
+      WHERE id = $1::uuid AND status = 'REQUESTED'::hr_adjustment_status
+      RETURNING ${ADJ_COLS}`,
+    [id, status, approvedBy]
+  );
+  return res.rows[0] ? mapAdj(res.rows[0]) : null;
+}
+
+// Demandes en attente : périmètre manager, OU toutes si privilégié (RH/Direction/Admin).
+export async function repoListTeamAdjustments(
+  filters: { managerUserId: number; isPrivileged: boolean; status?: HrAdjustmentStatus },
+  q: DbQueryer = pool
+): Promise<HrAdjustmentWithEmployee[]> {
+  const res = await q.query(
+    `SELECT a.id::text, a.target_type::text, a.target_id::text, a.reason, a.status::text,
+            a.requested_by, a.approved_by, a.created_at::text, a.approved_at::text,
+            emp.id::text AS employee_id, emp.matricule, emp.service
+       FROM public.hr_time_adjustments a
+       LEFT JOIN public.hr_time_events ev     ON a.target_type = 'EVENT' AND ev.id = a.target_id
+       LEFT JOIN public.hr_timesheet_days td  ON a.target_type = 'DAY'   AND td.id = a.target_id
+       LEFT JOIN public.hr_timesheet_weeks tw ON a.target_type = 'WEEK'  AND tw.id = a.target_id
+       JOIN public.hr_employees emp ON emp.id = COALESCE(ev.employee_id, td.employee_id, tw.employee_id)
+      WHERE a.status = $1::hr_adjustment_status
+        AND ($2::boolean OR emp.manager_user_id = $3::int)
+      ORDER BY a.created_at DESC
+      LIMIT 500`,
+    [filters.status ?? "REQUESTED", filters.isPrivileged, filters.managerUserId]
+  );
+  return res.rows.map((r) => ({
+    ...mapAdj(r),
+    employee_id: String(r.employee_id),
+    matricule: String(r.matricule),
+    service: (r.service as string | null) ?? null,
+  }));
+}
+
+// -------------------------------------------------------------- Validation jour / semaine
+export type TimesheetRef = { id: string; employee_id: string; validation_status: HrValidationStatus };
+
+export async function repoGetTimesheetDayById(id: string, q: DbQueryer = pool): Promise<TimesheetRef | null> {
+  const res = await q.query(
+    `SELECT id::text, employee_id::text, validation_status::text FROM public.hr_timesheet_days WHERE id = $1::uuid LIMIT 1`,
+    [id]
+  );
+  const r = res.rows[0];
+  return r ? { id: String(r.id), employee_id: String(r.employee_id), validation_status: r.validation_status as HrValidationStatus } : null;
+}
+
+export async function repoGetTimesheetWeekById(id: string, q: DbQueryer = pool): Promise<TimesheetRef | null> {
+  const res = await q.query(
+    `SELECT id::text, employee_id::text, validation_status::text FROM public.hr_timesheet_weeks WHERE id = $1::uuid LIMIT 1`,
+    [id]
+  );
+  const r = res.rows[0];
+  return r ? { id: String(r.id), employee_id: String(r.employee_id), validation_status: r.validation_status as HrValidationStatus } : null;
+}
+
+// VALIDATE : uniquement depuis DRAFT/TO_REVIEW (retourne null si déjà VALIDATED/EXPORTED — non rejouable).
+export async function repoSetDayValidation(
+  q: DbQueryer,
+  id: string,
+  status: "VALIDATED" | "TO_REVIEW",
+  validatedBy: number
+): Promise<TimesheetRef | null> {
+  const res = await q.query(
+    `UPDATE public.hr_timesheet_days
+        SET validation_status = $2::hr_validation_status,
+            validated_by = $3, validated_at = now(), updated_at = now()
+      WHERE id = $1::uuid AND validation_status IN ('DRAFT','TO_REVIEW')
+      RETURNING id::text, employee_id::text, validation_status::text`,
+    [id, status, validatedBy]
+  );
+  const r = res.rows[0];
+  return r ? { id: String(r.id), employee_id: String(r.employee_id), validation_status: r.validation_status as HrValidationStatus } : null;
+}
+
+export async function repoSetWeekValidation(
+  q: DbQueryer,
+  id: string,
+  status: "VALIDATED" | "TO_REVIEW",
+  validatedBy: number
+): Promise<TimesheetRef | null> {
+  const res = await q.query(
+    `UPDATE public.hr_timesheet_weeks
+        SET validation_status = $2::hr_validation_status,
+            validated_by = $3, validated_at = now(), updated_at = now()
+      WHERE id = $1::uuid AND validation_status IN ('DRAFT','TO_REVIEW')
+      RETURNING id::text, employee_id::text, validation_status::text`,
+    [id, status, validatedBy]
+  );
+  const r = res.rows[0];
+  return r ? { id: String(r.id), employee_id: String(r.employee_id), validation_status: r.validation_status as HrValidationStatus } : null;
+}
+
+// -------------------------------------------------------------- Périmètre équipe
+export async function repoListTeamEmployees(
+  filters: { managerUserId: number; isPrivileged: boolean },
+  q: DbQueryer = pool
+): Promise<HrEmployeeLite[]> {
+  const res = await q.query(
+    `SELECT ${EMP_COLS} FROM public.hr_employees
+      WHERE status = 'ACTIVE' AND ($1::boolean OR manager_user_id = $2::int)
+      ORDER BY matricule ASC LIMIT 500`,
+    [filters.isPrivileged, filters.managerUserId]
+  );
+  return res.rows.map(mapEmployee);
+}
+
+export async function repoListTeamAnomaliesForDate(
+  filters: { managerUserId: number; isPrivileged: boolean; date: string },
+  q: DbQueryer = pool
+): Promise<Array<HrTimeAnomaly & { matricule: string }>> {
+  const res = await q.query(
+    `SELECT an.id::text, an.employee_id::text, an.date::text, an.anomaly_type::text, an.severity::text,
+            an.message, an.resolved_by, an.resolved_at::text, an.created_at::text, emp.matricule
+       FROM public.hr_time_anomalies an
+       JOIN public.hr_employees emp ON emp.id = an.employee_id
+      WHERE an.date = $1::date AND ($2::boolean OR emp.manager_user_id = $3::int)
+      ORDER BY an.severity DESC, an.created_at DESC
+      LIMIT 500`,
+    [filters.date, filters.isPrivileged, filters.managerUserId]
+  );
+  return res.rows.map((r) => ({
+    id: String(r.id),
+    employee_id: String(r.employee_id),
+    date: String(r.date),
+    anomaly_type: r.anomaly_type as HrTimeAnomaly["anomaly_type"],
+    severity: r.severity as HrTimeAnomaly["severity"],
+    message: (r.message as string | null) ?? null,
+    resolved_by: r.resolved_by === null || r.resolved_by === undefined ? null : Number(r.resolved_by),
+    resolved_at: (r.resolved_at as string | null) ?? null,
+    created_at: String(r.created_at),
+    matricule: String(r.matricule),
+  }));
+}

--- a/src/module/temps-deplacements/repository/temps-deplacements-devices.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements-devices.repository.ts
@@ -1,0 +1,67 @@
+import pool from "../../../config/database";
+import type { DbQueryer } from "./temps-deplacements.repository";
+
+// T8 — bornes & badges. On ne stocke QUE les empreintes (token/uid hachés) ; jamais le secret en clair.
+export type HrDeviceStatus = "ACTIVE" | "DISABLED";
+
+// Colonnes exposées : JAMAIS device_token_hash / badge_uid_hash (pas de secret hors DB).
+const DEVICE_COLS = `id::text, name, location, device_type, status::text, last_seen_at::text, created_at::text`;
+const BADGE_COLS = `id::text, employee_id::text, badge_label, active, issued_at::text, revoked_at::text`;
+
+export async function repoCreateDevice(
+  q: DbQueryer,
+  i: { name: string; location: string | null; device_type: string | null; device_token_hash: string }
+) {
+  const res = await q.query(
+    `INSERT INTO public.hr_time_clock_devices (name, location, device_type, device_token_hash, status)
+     VALUES ($1,$2,$3,$4,'ACTIVE'::hr_device_status) RETURNING ${DEVICE_COLS}`,
+    [i.name, i.location, i.device_type, i.device_token_hash]
+  );
+  return res.rows[0];
+}
+export async function repoListDevices(q: DbQueryer = pool) {
+  const res = await q.query(`SELECT ${DEVICE_COLS} FROM public.hr_time_clock_devices ORDER BY created_at DESC LIMIT 500`);
+  return res.rows;
+}
+export async function repoSetDeviceStatus(q: DbQueryer, id: string, status: HrDeviceStatus) {
+  const res = await q.query(
+    `UPDATE public.hr_time_clock_devices SET status=$2::hr_device_status WHERE id=$1::uuid RETURNING ${DEVICE_COLS}`,
+    [id, status]
+  );
+  return res.rows[0] ?? null;
+}
+// Régénère le hash de token (rotation). Le token brut est renvoyé une seule fois par le service.
+export async function repoRotateDeviceToken(q: DbQueryer, id: string, tokenHash: string) {
+  const res = await q.query(
+    `UPDATE public.hr_time_clock_devices SET device_token_hash=$2 WHERE id=$1::uuid RETURNING ${DEVICE_COLS}`,
+    [id, tokenHash]
+  );
+  return res.rows[0] ?? null;
+}
+
+export async function repoCreateBadge(
+  q: DbQueryer,
+  i: { employee_id: string; badge_uid_hash: string; badge_label: string | null }
+) {
+  const res = await q.query(
+    `INSERT INTO public.hr_badge_credentials (employee_id, badge_uid_hash, badge_label, active)
+     VALUES ($1::uuid,$2,$3,true) RETURNING ${BADGE_COLS}`,
+    [i.employee_id, i.badge_uid_hash, i.badge_label]
+  );
+  return res.rows[0];
+}
+export async function repoListBadges(q: DbQueryer, employeeId?: string) {
+  if (employeeId) {
+    const res = await q.query(`SELECT ${BADGE_COLS} FROM public.hr_badge_credentials WHERE employee_id=$1::uuid ORDER BY issued_at DESC LIMIT 500`, [employeeId]);
+    return res.rows;
+  }
+  const res = await q.query(`SELECT ${BADGE_COLS} FROM public.hr_badge_credentials ORDER BY issued_at DESC LIMIT 500`);
+  return res.rows;
+}
+export async function repoRevokeBadge(q: DbQueryer, id: string) {
+  const res = await q.query(
+    `UPDATE public.hr_badge_credentials SET active=false, revoked_at=now() WHERE id=$1::uuid AND active=true RETURNING ${BADGE_COLS}`,
+    [id]
+  );
+  return res.rows[0] ?? null;
+}

--- a/src/module/temps-deplacements/repository/temps-deplacements-exports.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements-exports.repository.ts
@@ -1,0 +1,73 @@
+import pool from "../../../config/database";
+import type { PayrollWeekRow } from "../services/temps-deplacements-exports";
+import type { DbQueryer } from "./temps-deplacements.repository";
+
+// T7 — lecture des agrégats hebdo d'une période + persistance des lots d'export (figés + checksum).
+
+export async function repoListWeeksForPeriod(periodStart: string, periodEnd: string, q: DbQueryer = pool): Promise<PayrollWeekRow[]> {
+  const res = await q.query(
+    `SELECT e.matricule, u.name, u.surname,
+            w.week_start::text, w.week_end::text,
+            w.worked_minutes, w.contract_minutes, w.overtime_25_minutes, w.overtime_50_minutes, w.absence_minutes
+       FROM public.hr_timesheet_weeks w
+       JOIN public.hr_employees e ON e.id = w.employee_id
+       LEFT JOIN public.users u ON u.id = e.user_id
+      WHERE w.week_start >= $1::date AND w.week_start <= $2::date
+      ORDER BY e.matricule ASC, w.week_start ASC
+      LIMIT 5000`,
+    [periodStart, periodEnd]
+  );
+  return res.rows.map((r) => ({
+    matricule: String(r.matricule),
+    name: (r.name as string | null) ?? null,
+    surname: (r.surname as string | null) ?? null,
+    week_start: String(r.week_start),
+    week_end: String(r.week_end),
+    worked_minutes: Number(r.worked_minutes),
+    contract_minutes: Number(r.contract_minutes),
+    overtime_25_minutes: Number(r.overtime_25_minutes),
+    overtime_50_minutes: Number(r.overtime_50_minutes),
+    absence_minutes: Number(r.absence_minutes),
+  }));
+}
+
+export interface ExportBatchInsert {
+  period_start: string;
+  period_end: string;
+  exported_by: number;
+  format: "CSV" | "PDF";
+  frozen_snapshot_json: Record<string, unknown>;
+  checksum: string;
+}
+
+export async function repoInsertExportBatch(q: DbQueryer, i: ExportBatchInsert) {
+  const res = await q.query(
+    `INSERT INTO public.hr_payroll_export_batches
+       (period_start, period_end, exported_by, format, frozen_snapshot_json, checksum, status)
+     VALUES ($1::date,$2::date,$3,$4::hr_export_format,$5::jsonb,$6,'GENERATED'::hr_export_status)
+     RETURNING id::text, period_start::text, period_end::text, exported_by, format::text, checksum, status::text, exported_at::text`,
+    [i.period_start, i.period_end, i.exported_by, i.format, JSON.stringify(i.frozen_snapshot_json), i.checksum]
+  );
+  return res.rows[0];
+}
+
+// Métadonnées (sans le fichier base64 — on n'expose pas les octets dans la liste).
+export async function repoListExportBatches(q: DbQueryer = pool) {
+  const res = await q.query(
+    `SELECT id::text, period_start::text, period_end::text, exported_by, format::text, checksum, status::text,
+            exported_at::text, (frozen_snapshot_json->>'row_count')::int AS row_count
+       FROM public.hr_payroll_export_batches
+      ORDER BY exported_at DESC LIMIT 500`
+  );
+  return res.rows;
+}
+
+export async function repoGetExportBatch(id: string, q: DbQueryer = pool) {
+  const res = await q.query(
+    `SELECT id::text, period_start::text, period_end::text, exported_by, format::text, checksum, status::text,
+            exported_at::text, frozen_snapshot_json
+       FROM public.hr_payroll_export_batches WHERE id = $1::uuid LIMIT 1`,
+    [id]
+  );
+  return res.rows[0] ?? null;
+}

--- a/src/module/temps-deplacements/repository/temps-deplacements-km.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements-km.repository.ts
@@ -1,0 +1,158 @@
+import pool from "../../../config/database";
+import type { DbQueryer } from "./temps-deplacements.repository";
+
+// T6 — kilomètres. Statuts : DRAFT → SUBMITTED → VALIDATED | REJECTED.
+export type HrKmType = "MISSION" | "CLIENT" | "FOURNISSEUR" | "LIVRAISON" | "AUTRE";
+export type HrKmStatus = "DRAFT" | "SUBMITTED" | "VALIDATED" | "REJECTED";
+
+export interface KmEntry {
+  id: string;
+  employee_id: string;
+  date: string;
+  type: HrKmType;
+  vehicle_id: string | null;
+  start_location: string | null;
+  end_location: string | null;
+  start_odometer: number | null;
+  end_odometer: number | null;
+  distance_km: number;
+  affaire_id: number | null;
+  client_id: number | null;
+  fournisseur_id: number | null;
+  status: HrKmStatus;
+  created_at: string;
+  validated_by: number | null;
+  validated_at: string | null;
+}
+export type KmEntryWithEmployee = KmEntry & { matricule: string };
+
+export interface KmEntryInput {
+  employee_id: string;
+  date: string;
+  type: HrKmType;
+  vehicle_id: string | null;
+  start_location: string | null;
+  end_location: string | null;
+  start_odometer: number | null;
+  end_odometer: number | null;
+  distance_km: number;
+  affaire_id: number | null;
+  client_id: number | null;
+  fournisseur_id: number | null;
+  status: HrKmStatus;
+}
+
+const KM_COLS = `id::text, employee_id::text, date::text, type::text, vehicle_id::text,
+  start_location, end_location, start_odometer, end_odometer, distance_km,
+  affaire_id, client_id, fournisseur_id, status::text, created_at::text, validated_by, validated_at::text`;
+
+function num(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+function mapKm(r: Record<string, unknown>): KmEntry {
+  return {
+    id: String(r.id),
+    employee_id: String(r.employee_id),
+    date: String(r.date),
+    type: r.type as HrKmType,
+    vehicle_id: (r.vehicle_id as string | null) ?? null,
+    start_location: (r.start_location as string | null) ?? null,
+    end_location: (r.end_location as string | null) ?? null,
+    start_odometer: num(r.start_odometer),
+    end_odometer: num(r.end_odometer),
+    distance_km: num(r.distance_km) ?? 0,
+    affaire_id: num(r.affaire_id),
+    client_id: num(r.client_id),
+    fournisseur_id: num(r.fournisseur_id),
+    status: r.status as HrKmStatus,
+    created_at: String(r.created_at),
+    validated_by: num(r.validated_by),
+    validated_at: (r.validated_at as string | null) ?? null,
+  };
+}
+
+export async function repoCreateKmEntry(q: DbQueryer, i: KmEntryInput): Promise<KmEntry> {
+  const res = await q.query(
+    `INSERT INTO public.hr_kilometer_entries
+       (employee_id, date, type, vehicle_id, start_location, end_location, start_odometer, end_odometer,
+        distance_km, affaire_id, client_id, fournisseur_id, status)
+     VALUES ($1::uuid,$2::date,$3::hr_km_type,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13::hr_km_status)
+     RETURNING ${KM_COLS}`,
+    [i.employee_id, i.date, i.type, i.vehicle_id, i.start_location, i.end_location, i.start_odometer, i.end_odometer,
+     i.distance_km, i.affaire_id, i.client_id, i.fournisseur_id, i.status]
+  );
+  return mapKm(res.rows[0]);
+}
+
+export async function repoGetKmEntryById(id: string, q: DbQueryer = pool): Promise<KmEntry | null> {
+  const res = await q.query(`SELECT ${KM_COLS} FROM public.hr_kilometer_entries WHERE id = $1::uuid LIMIT 1`, [id]);
+  return res.rows[0] ? mapKm(res.rows[0]) : null;
+}
+
+export async function repoListKmForEmployee(
+  employeeId: string,
+  filters: { from?: string; to?: string; status?: HrKmStatus },
+  q: DbQueryer = pool
+): Promise<KmEntry[]> {
+  const where: string[] = ["employee_id = $1::uuid"];
+  const vals: unknown[] = [employeeId];
+  if (filters.from) { vals.push(filters.from); where.push(`date >= $${vals.length}::date`); }
+  if (filters.to) { vals.push(filters.to); where.push(`date <= $${vals.length}::date`); }
+  if (filters.status) { vals.push(filters.status); where.push(`status = $${vals.length}::hr_km_status`); }
+  const res = await q.query(`SELECT ${KM_COLS} FROM public.hr_kilometer_entries WHERE ${where.join(" AND ")} ORDER BY date DESC, created_at DESC LIMIT 500`, vals);
+  return res.rows.map(mapKm);
+}
+
+// DRAFT → SUBMITTED (par le salarié). Ne modifie que si DRAFT.
+export async function repoSubmitKmEntry(q: DbQueryer, id: string): Promise<KmEntry | null> {
+  const res = await q.query(
+    `UPDATE public.hr_kilometer_entries SET status='SUBMITTED'::hr_km_status
+      WHERE id=$1::uuid AND status='DRAFT'::hr_km_status RETURNING ${KM_COLS}`,
+    [id]
+  );
+  return res.rows[0] ? mapKm(res.rows[0]) : null;
+}
+
+// SUBMITTED → VALIDATED | REJECTED (par le responsable). Ne modifie que si SUBMITTED.
+export async function repoDecideKmEntry(q: DbQueryer, id: string, status: "VALIDATED" | "REJECTED", validatedBy: number): Promise<KmEntry | null> {
+  const res = await q.query(
+    `UPDATE public.hr_kilometer_entries SET status=$2::hr_km_status, validated_by=$3, validated_at=now()
+      WHERE id=$1::uuid AND status='SUBMITTED'::hr_km_status RETURNING ${KM_COLS}`,
+    [id, status, validatedBy]
+  );
+  return res.rows[0] ? mapKm(res.rows[0]) : null;
+}
+
+export async function repoListTeamKmEntries(
+  filters: { managerUserId: number; isPrivileged: boolean; status?: HrKmStatus },
+  q: DbQueryer = pool
+): Promise<KmEntryWithEmployee[]> {
+  const where: string[] = ["($1::boolean OR e.manager_user_id = $2::int)"];
+  const vals: unknown[] = [filters.isPrivileged, filters.managerUserId];
+  if (filters.status) { vals.push(filters.status); where.push(`k.status = $${vals.length}::hr_km_status`); }
+  const res = await q.query(
+    `SELECT ${KM_COLS.split(", ").map((c) => "k." + c).join(", ")}, e.matricule
+       FROM public.hr_kilometer_entries k
+       JOIN public.hr_employees e ON e.id = k.employee_id
+      WHERE ${where.join(" AND ")}
+      ORDER BY k.date DESC, k.created_at DESC LIMIT 500`,
+    vals
+  );
+  return res.rows.map((r) => ({ ...mapKm(r), matricule: String(r.matricule) }));
+}
+
+// -------------------------------------------------------------- Véhicules
+export async function repoListVehicles(q: DbQueryer = pool) {
+  const res = await q.query(`SELECT id::text, label, plate, owner_type::text, active FROM public.hr_vehicles WHERE active ORDER BY label ASC LIMIT 500`);
+  return res.rows;
+}
+export async function repoCreateVehicle(q: DbQueryer, i: { label: string; plate: string | null; owner_type: "COMPANY" | "PERSONAL" }) {
+  const res = await q.query(
+    `INSERT INTO public.hr_vehicles (label, plate, owner_type) VALUES ($1,$2,$3::hr_vehicle_owner)
+     RETURNING id::text, label, plate, owner_type::text, active`,
+    [i.label, i.plate, i.owner_type]
+  );
+  return res.rows[0];
+}

--- a/src/module/temps-deplacements/repository/temps-deplacements-rules.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements-rules.repository.ts
@@ -1,0 +1,222 @@
+import pool from "../../../config/database";
+import { effectiveRuleSetFromRows, type ContractRow, type HrRuleSet, type RuleSetRow } from "../services/temps-deplacements-rules";
+import type { DbQueryer } from "./temps-deplacements.repository";
+
+// -------------------------------------------------------------- T5 : contrats / horaires / règles + résolution
+
+export interface RuleSetInput {
+  name: string;
+  weekly_target_minutes: number;
+  daily_target_minutes: number;
+  overtime_threshold_1_minutes: number | null;
+  overtime_rate_1: number | null;
+  overtime_threshold_2_minutes: number | null;
+  overtime_rate_2: number | null;
+  rounding_rule: Record<string, unknown>;
+  break_rule: Record<string, unknown>;
+}
+export interface ContractInput {
+  employee_id: string;
+  contract_type: "H35" | "H39" | "PARTIAL" | "OTHER";
+  weekly_hours_target: number;
+  daily_hours_target: number | null;
+  start_date: string;
+  end_date: string | null;
+  rule_set_id: string | null;
+  active: boolean;
+}
+export interface ScheduleInput {
+  employee_id: string;
+  day_of_week: number;
+  expected_start: string | null;
+  expected_end: string | null;
+  expected_break_minutes: number;
+  flexible_start_window: number;
+  flexible_end_window: number;
+  active: boolean;
+}
+
+const RS_COLS = `id::text, name, weekly_target_minutes, daily_target_minutes,
+  overtime_threshold_1_minutes, overtime_rate_1, overtime_threshold_2_minutes, overtime_rate_2,
+  rounding_rule, break_rule, active, created_at::text, updated_at::text`;
+const CT_COLS = `id::text, employee_id::text, contract_type::text, weekly_hours_target, daily_hours_target,
+  start_date::text, end_date::text, active, rule_set_id::text, created_at::text, updated_at::text`;
+const SC_COLS = `id::text, employee_id::text, day_of_week, expected_start::text, expected_end::text,
+  expected_break_minutes, flexible_start_window, flexible_end_window, active`;
+
+// ---- Résolution des règles effectives (contrat couvrant la date, puis son rule_set éventuel) ----
+export async function repoGetEffectiveRuleSet(employeeId: string, date: string, q: DbQueryer = pool): Promise<HrRuleSet | null> {
+  const res = await q.query(
+    `SELECT c.id::text, c.contract_type::text, c.weekly_hours_target, c.daily_hours_target, c.rule_set_id::text,
+            rs.id::text AS rs_id, rs.name AS rs_name, rs.weekly_target_minutes, rs.daily_target_minutes,
+            rs.overtime_threshold_1_minutes, rs.overtime_rate_1, rs.overtime_threshold_2_minutes, rs.overtime_rate_2,
+            rs.rounding_rule, rs.break_rule, rs.active AS rs_active
+       FROM public.hr_employment_contracts c
+       LEFT JOIN public.hr_time_rule_sets rs ON rs.id = c.rule_set_id
+      WHERE c.employee_id = $1::uuid
+        AND c.start_date <= $2::date AND (c.end_date IS NULL OR c.end_date >= $2::date)
+      ORDER BY c.active DESC, c.start_date DESC
+      LIMIT 1`,
+    [employeeId, date]
+  );
+  const r = res.rows[0];
+  if (!r) return null;
+  const contract: ContractRow = {
+    id: String(r.id),
+    contract_type: String(r.contract_type),
+    weekly_hours_target: r.weekly_hours_target,
+    daily_hours_target: r.daily_hours_target ?? null,
+    rule_set_id: r.rule_set_id ?? null,
+  };
+  const ruleSet: RuleSetRow | null = r.rs_id
+    ? {
+        id: String(r.rs_id),
+        name: String(r.rs_name),
+        weekly_target_minutes: Number(r.weekly_target_minutes),
+        daily_target_minutes: Number(r.daily_target_minutes),
+        overtime_threshold_1_minutes: r.overtime_threshold_1_minutes ?? null,
+        overtime_rate_1: r.overtime_rate_1 ?? null,
+        overtime_threshold_2_minutes: r.overtime_threshold_2_minutes ?? null,
+        overtime_rate_2: r.overtime_rate_2 ?? null,
+        rounding_rule: r.rounding_rule,
+        break_rule: r.break_rule,
+        active: r.rs_active === true,
+      }
+    : null;
+  return effectiveRuleSetFromRows(contract, ruleSet);
+}
+
+// -------------------------------------------------------------- Employés (lecture pour pickers admin)
+export async function repoListEmployees(q: DbQueryer = pool) {
+  const res = await q.query(
+    `SELECT e.id::text, e.matricule, e.service, e.status::text, e.user_id, e.manager_user_id,
+            u.name, u.surname
+       FROM public.hr_employees e
+       LEFT JOIN public.users u ON u.id = e.user_id
+      ORDER BY e.matricule ASC LIMIT 1000`
+  );
+  return res.rows;
+}
+
+// -------------------------------------------------------------- Rule sets (CRUD)
+export async function repoListRuleSets(q: DbQueryer = pool) {
+  const res = await q.query(`SELECT ${RS_COLS} FROM public.hr_time_rule_sets ORDER BY active DESC, name ASC LIMIT 500`);
+  return res.rows;
+}
+export async function repoGetRuleSetById(id: string, q: DbQueryer = pool) {
+  const res = await q.query(`SELECT ${RS_COLS} FROM public.hr_time_rule_sets WHERE id = $1::uuid LIMIT 1`, [id]);
+  return res.rows[0] ?? null;
+}
+export async function repoInsertRuleSet(q: DbQueryer, i: RuleSetInput) {
+  const res = await q.query(
+    `INSERT INTO public.hr_time_rule_sets
+       (name, weekly_target_minutes, daily_target_minutes, overtime_threshold_1_minutes, overtime_rate_1,
+        overtime_threshold_2_minutes, overtime_rate_2, rounding_rule, break_rule)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8::jsonb,$9::jsonb) RETURNING ${RS_COLS}`,
+    [i.name, i.weekly_target_minutes, i.daily_target_minutes, i.overtime_threshold_1_minutes, i.overtime_rate_1,
+     i.overtime_threshold_2_minutes, i.overtime_rate_2, JSON.stringify(i.rounding_rule ?? {}), JSON.stringify(i.break_rule ?? {})]
+  );
+  return res.rows[0];
+}
+export async function repoUpdateRuleSet(q: DbQueryer, id: string, i: RuleSetInput) {
+  const res = await q.query(
+    `UPDATE public.hr_time_rule_sets SET
+       name=$2, weekly_target_minutes=$3, daily_target_minutes=$4, overtime_threshold_1_minutes=$5, overtime_rate_1=$6,
+       overtime_threshold_2_minutes=$7, overtime_rate_2=$8, rounding_rule=$9::jsonb, break_rule=$10::jsonb, updated_at=now()
+     WHERE id=$1::uuid RETURNING ${RS_COLS}`,
+    [id, i.name, i.weekly_target_minutes, i.daily_target_minutes, i.overtime_threshold_1_minutes, i.overtime_rate_1,
+     i.overtime_threshold_2_minutes, i.overtime_rate_2, JSON.stringify(i.rounding_rule ?? {}), JSON.stringify(i.break_rule ?? {})]
+  );
+  return res.rows[0] ?? null;
+}
+export async function repoSetRuleSetActive(q: DbQueryer, id: string, active: boolean) {
+  const res = await q.query(
+    `UPDATE public.hr_time_rule_sets SET active=$2, updated_at=now() WHERE id=$1::uuid RETURNING ${RS_COLS}`,
+    [id, active]
+  );
+  return res.rows[0] ?? null;
+}
+
+// -------------------------------------------------------------- Contrats (CRUD ; 1 seul actif/employé)
+export async function repoListContracts(q: DbQueryer, employeeId?: string) {
+  if (employeeId) {
+    const res = await q.query(`SELECT ${CT_COLS} FROM public.hr_employment_contracts WHERE employee_id=$1::uuid ORDER BY start_date DESC LIMIT 500`, [employeeId]);
+    return res.rows;
+  }
+  const res = await q.query(`SELECT ${CT_COLS} FROM public.hr_employment_contracts ORDER BY start_date DESC LIMIT 500`);
+  return res.rows;
+}
+export async function repoGetContractById(id: string, q: DbQueryer = pool) {
+  const res = await q.query(`SELECT ${CT_COLS} FROM public.hr_employment_contracts WHERE id=$1::uuid LIMIT 1`, [id]);
+  return res.rows[0] ?? null;
+}
+export async function repoInsertContract(q: DbQueryer, i: ContractInput) {
+  const res = await q.query(
+    `INSERT INTO public.hr_employment_contracts
+       (employee_id, contract_type, weekly_hours_target, daily_hours_target, start_date, end_date, rule_set_id, active)
+     VALUES ($1::uuid,$2::hr_contract_type,$3,$4,$5::date,$6::date,$7,$8) RETURNING ${CT_COLS}`,
+    [i.employee_id, i.contract_type, i.weekly_hours_target, i.daily_hours_target, i.start_date, i.end_date, i.rule_set_id, i.active]
+  );
+  return res.rows[0];
+}
+export async function repoUpdateContract(q: DbQueryer, id: string, i: ContractInput) {
+  const res = await q.query(
+    `UPDATE public.hr_employment_contracts SET
+       contract_type=$2::hr_contract_type, weekly_hours_target=$3, daily_hours_target=$4,
+       start_date=$5::date, end_date=$6::date, rule_set_id=$7, active=$8, updated_at=now()
+     WHERE id=$1::uuid RETURNING ${CT_COLS}`,
+    [id, i.contract_type, i.weekly_hours_target, i.daily_hours_target, i.start_date, i.end_date, i.rule_set_id, i.active]
+  );
+  return res.rows[0] ?? null;
+}
+export async function repoSetContractActive(q: DbQueryer, id: string, active: boolean) {
+  const res = await q.query(`UPDATE public.hr_employment_contracts SET active=$2, updated_at=now() WHERE id=$1::uuid RETURNING ${CT_COLS}`, [id, active]);
+  return res.rows[0] ?? null;
+}
+
+// -------------------------------------------------------------- Horaires types (CRUD)
+export async function repoListSchedules(q: DbQueryer, employeeId: string) {
+  const res = await q.query(`SELECT ${SC_COLS} FROM public.hr_work_schedules WHERE employee_id=$1::uuid ORDER BY day_of_week ASC LIMIT 500`, [employeeId]);
+  return res.rows;
+}
+export async function repoInsertSchedule(q: DbQueryer, i: ScheduleInput) {
+  const res = await q.query(
+    `INSERT INTO public.hr_work_schedules
+       (employee_id, day_of_week, expected_start, expected_end, expected_break_minutes, flexible_start_window, flexible_end_window, active)
+     VALUES ($1::uuid,$2,$3::time,$4::time,$5,$6,$7,$8) RETURNING ${SC_COLS}`,
+    [i.employee_id, i.day_of_week, i.expected_start, i.expected_end, i.expected_break_minutes, i.flexible_start_window, i.flexible_end_window, i.active]
+  );
+  return res.rows[0];
+}
+export async function repoUpdateSchedule(q: DbQueryer, id: string, i: ScheduleInput) {
+  const res = await q.query(
+    `UPDATE public.hr_work_schedules SET
+       day_of_week=$2, expected_start=$3::time, expected_end=$4::time, expected_break_minutes=$5,
+       flexible_start_window=$6, flexible_end_window=$7, active=$8
+     WHERE id=$1::uuid RETURNING ${SC_COLS}`,
+    [id, i.day_of_week, i.expected_start, i.expected_end, i.expected_break_minutes, i.flexible_start_window, i.flexible_end_window, i.active]
+  );
+  return res.rows[0] ?? null;
+}
+export async function repoDeleteSchedule(q: DbQueryer, id: string): Promise<boolean> {
+  const res = await q.query(`DELETE FROM public.hr_work_schedules WHERE id=$1::uuid`, [id]);
+  return (res.rowCount ?? 0) > 0;
+}
+
+// -------------------------------------------------------------- Persistance du relevé hebdo (agrégat)
+export async function repoUpsertTimesheetWeek(
+  q: DbQueryer,
+  w: { employee_id: string; week_start: string; week_end: string; contract_minutes: number; worked_minutes: number; overtime_25_minutes: number; overtime_50_minutes: number; absence_minutes: number }
+): Promise<void> {
+  await q.query(
+    `INSERT INTO public.hr_timesheet_weeks
+       (employee_id, week_start, week_end, contract_minutes, worked_minutes, overtime_25_minutes, overtime_50_minutes, absence_minutes)
+     VALUES ($1::uuid,$2::date,$3::date,$4,$5,$6,$7,$8)
+     ON CONFLICT (employee_id, week_start) DO UPDATE SET
+       week_end=EXCLUDED.week_end, contract_minutes=EXCLUDED.contract_minutes, worked_minutes=EXCLUDED.worked_minutes,
+       overtime_25_minutes=EXCLUDED.overtime_25_minutes, overtime_50_minutes=EXCLUDED.overtime_50_minutes,
+       absence_minutes=EXCLUDED.absence_minutes, updated_at=now()
+     WHERE public.hr_timesheet_weeks.validation_status = 'DRAFT'`,
+    [w.employee_id, w.week_start, w.week_end, w.contract_minutes, w.worked_minutes, w.overtime_25_minutes, w.overtime_50_minutes, w.absence_minutes]
+  );
+}

--- a/src/module/temps-deplacements/repository/temps-deplacements.repository.ts
+++ b/src/module/temps-deplacements/repository/temps-deplacements.repository.ts
@@ -1,0 +1,332 @@
+import type { PoolClient } from "pg";
+import pool from "../../../config/database";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
+import type {
+  CreateTimeEventInput,
+  HrEmployeeLite,
+  HrTimeAnomaly,
+  HrTimeEvent,
+} from "../types/temps-deplacements.types";
+
+export type DbQueryer = Pick<PoolClient, "query">;
+
+// Contexte d'audit (même forme que le reste de l'ERP). Jamais de secret/PII sensible dedans.
+export type AuditContext = {
+  user_id: number;
+  ip: string | null;
+  user_agent: string | null;
+  device_type: string | null;
+  os: string | null;
+  browser: string | null;
+  path: string | null;
+  page_key: string | null;
+  client_session_id: string | null;
+};
+
+export function isPgUniqueViolation(err: unknown): boolean {
+  return (err as { code?: unknown } | null)?.code === "23505";
+}
+
+export async function withTransaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      // ignore
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+const EMP_COLS = `id::text, user_id, matricule, service, manager_user_id, status::text`;
+
+function mapEmployee(r: Record<string, unknown>): HrEmployeeLite {
+  return {
+    id: String(r.id),
+    user_id: Number(r.user_id),
+    matricule: String(r.matricule),
+    service: (r.service as string | null) ?? null,
+    manager_user_id: r.manager_user_id === null || r.manager_user_id === undefined ? null : Number(r.manager_user_id),
+    status: r.status as HrEmployeeLite["status"],
+  };
+}
+
+function mapEvent(r: Record<string, unknown>): HrTimeEvent {
+  return {
+    id: String(r.id),
+    employee_id: String(r.employee_id),
+    device_id: (r.device_id as string | null) ?? null,
+    event_type: r.event_type as HrTimeEvent["event_type"],
+    event_time: String(r.event_time),
+    source: r.source as HrTimeEvent["source"],
+    created_at: String(r.created_at),
+  };
+}
+
+function mapAnomaly(r: Record<string, unknown>): HrTimeAnomaly {
+  return {
+    id: String(r.id),
+    employee_id: String(r.employee_id),
+    date: String(r.date),
+    anomaly_type: r.anomaly_type as HrTimeAnomaly["anomaly_type"],
+    severity: r.severity as HrTimeAnomaly["severity"],
+    message: (r.message as string | null) ?? null,
+    resolved_by: r.resolved_by === null || r.resolved_by === undefined ? null : Number(r.resolved_by),
+    resolved_at: (r.resolved_at as string | null) ?? null,
+    created_at: String(r.created_at),
+  };
+}
+
+// -------------------------------------------------------------- Employés
+export async function repoGetEmployeeByUserId(userId: number, q: DbQueryer = pool): Promise<HrEmployeeLite | null> {
+  const res = await q.query(
+    `SELECT ${EMP_COLS} FROM public.hr_employees WHERE user_id = $1 LIMIT 1`,
+    [userId]
+  );
+  return res.rows[0] ? mapEmployee(res.rows[0]) : null;
+}
+
+export async function repoGetEmployeeById(id: string, q: DbQueryer = pool): Promise<HrEmployeeLite | null> {
+  const res = await q.query(`SELECT ${EMP_COLS} FROM public.hr_employees WHERE id = $1::uuid LIMIT 1`, [id]);
+  return res.rows[0] ? mapEmployee(res.rows[0]) : null;
+}
+
+// Badge : renvoie l'employé + si le badge est actif (pour distinguer inconnu / révoqué / ok).
+export async function repoFindBadge(
+  badgeUidHash: string,
+  q: DbQueryer = pool
+): Promise<{ employee: HrEmployeeLite; active: boolean } | null> {
+  const res = await q.query(
+    `SELECT b.active, ${EMP_COLS.split(", ").map((c) => "e." + c).join(", ")}
+       FROM public.hr_badge_credentials b
+       JOIN public.hr_employees e ON e.id = b.employee_id
+      WHERE b.badge_uid_hash = $1
+      ORDER BY b.active DESC, b.issued_at DESC
+      LIMIT 1`,
+    [badgeUidHash]
+  );
+  if (!res.rows[0]) return null;
+  return { employee: mapEmployee(res.rows[0]), active: res.rows[0].active === true };
+}
+
+// -------------------------------------------------------------- Devices
+export async function repoGetActiveDeviceByTokenHash(tokenHash: string, q: DbQueryer = pool): Promise<{ id: string } | null> {
+  const res = await q.query(
+    `SELECT id::text FROM public.hr_time_clock_devices WHERE device_token_hash = $1 AND status = 'ACTIVE' LIMIT 1`,
+    [tokenHash]
+  );
+  return res.rows[0] ? { id: String(res.rows[0].id) } : null;
+}
+
+export async function repoTouchDeviceHeartbeat(deviceId: string, q: DbQueryer = pool): Promise<void> {
+  await q.query(`UPDATE public.hr_time_clock_devices SET last_seen_at = now() WHERE id = $1::uuid`, [deviceId]);
+}
+
+// -------------------------------------------------------------- Événements (append-only)
+export async function repoGetLastEvent(employeeId: string, q: DbQueryer = pool): Promise<HrTimeEvent | null> {
+  const res = await q.query(
+    `SELECT id::text, employee_id::text, device_id::text, event_type::text, event_time::text, source::text, created_at::text
+       FROM public.hr_time_events WHERE employee_id = $1::uuid ORDER BY event_time DESC, created_at DESC LIMIT 1`,
+    [employeeId]
+  );
+  return res.rows[0] ? mapEvent(res.rows[0]) : null;
+}
+
+export async function repoFindEventByIdempotencyKey(key: string, q: DbQueryer = pool): Promise<HrTimeEvent | null> {
+  const res = await q.query(
+    `SELECT id::text, employee_id::text, device_id::text, event_type::text, event_time::text, source::text, created_at::text
+       FROM public.hr_time_events WHERE idempotency_key = $1 LIMIT 1`,
+    [key]
+  );
+  return res.rows[0] ? mapEvent(res.rows[0]) : null;
+}
+
+// INSERT append-only. Idempotence : si idempotency_key déjà vu → renvoie l'existant (deduplicated).
+export async function repoInsertTimeEvent(
+  q: DbQueryer,
+  input: CreateTimeEventInput
+): Promise<{ event: HrTimeEvent; deduplicated: boolean }> {
+  if (input.idempotency_key) {
+    const existing = await repoFindEventByIdempotencyKey(input.idempotency_key, q);
+    if (existing) return { event: existing, deduplicated: true };
+  }
+  try {
+    const res = await q.query(
+      `INSERT INTO public.hr_time_events (employee_id, device_id, event_type, event_time, source, idempotency_key, raw_payload_json)
+       VALUES ($1::uuid, $2, $3::hr_event_type, COALESCE($4::timestamptz, now()), $5::hr_event_source, $6, $7::jsonb)
+       RETURNING id::text, employee_id::text, device_id::text, event_type::text, event_time::text, source::text, created_at::text`,
+      [
+        input.employee_id,
+        input.device_id ?? null,
+        input.event_type,
+        input.event_time ?? null,
+        input.source,
+        input.idempotency_key ?? null,
+        JSON.stringify(input.raw_payload ?? {}),
+      ]
+    );
+    return { event: mapEvent(res.rows[0]), deduplicated: false };
+  } catch (err) {
+    // Course sur idempotency_key : la contrainte unique a gagné → renvoyer l'existant.
+    if (isPgUniqueViolation(err) && input.idempotency_key) {
+      const existing = await repoFindEventByIdempotencyKey(input.idempotency_key, q);
+      if (existing) return { event: existing, deduplicated: true };
+    }
+    throw err;
+  }
+}
+
+export async function repoListEventsForDay(employeeId: string, date: string, q: DbQueryer = pool): Promise<HrTimeEvent[]> {
+  const res = await q.query(
+    `SELECT id::text, employee_id::text, device_id::text, event_type::text, event_time::text, source::text, created_at::text
+       FROM public.hr_time_events
+      WHERE employee_id = $1::uuid AND (event_time AT TIME ZONE 'Europe/Paris')::date = $2::date
+      ORDER BY event_time ASC, created_at ASC`,
+    [employeeId, date]
+  );
+  return res.rows.map(mapEvent);
+}
+
+// -------------------------------------------------------------- Anomalies
+export async function repoInsertAnomaly(
+  q: DbQueryer,
+  a: { employee_id: string; date: string; anomaly_type: HrTimeAnomaly["anomaly_type"]; severity: HrTimeAnomaly["severity"]; message?: string | null }
+): Promise<HrTimeAnomaly> {
+  const res = await q.query(
+    `INSERT INTO public.hr_time_anomalies (employee_id, date, anomaly_type, severity, message)
+     VALUES ($1::uuid, $2::date, $3::hr_anomaly_type, $4::hr_anomaly_severity, $5)
+     RETURNING id::text, employee_id::text, date::text, anomaly_type::text, severity::text, message, resolved_by, resolved_at::text, created_at::text`,
+    [a.employee_id, a.date, a.anomaly_type, a.severity, a.message ?? null]
+  );
+  return mapAnomaly(res.rows[0]);
+}
+
+export async function repoListAnomalies(
+  employeeId: string,
+  filters: { date?: string; from?: string; to?: string },
+  q: DbQueryer = pool
+): Promise<HrTimeAnomaly[]> {
+  const where: string[] = ["employee_id = $1::uuid"];
+  const vals: unknown[] = [employeeId];
+  if (filters.date) {
+    vals.push(filters.date);
+    where.push(`date = $${vals.length}::date`);
+  }
+  if (filters.from) {
+    vals.push(filters.from);
+    where.push(`date >= $${vals.length}::date`);
+  }
+  if (filters.to) {
+    vals.push(filters.to);
+    where.push(`date <= $${vals.length}::date`);
+  }
+  const res = await q.query(
+    `SELECT id::text, employee_id::text, date::text, anomaly_type::text, severity::text, message, resolved_by, resolved_at::text, created_at::text
+       FROM public.hr_time_anomalies WHERE ${where.join(" AND ")} ORDER BY date DESC, created_at DESC LIMIT 500`,
+    vals
+  );
+  return res.rows.map(mapAnomaly);
+}
+
+// Anomalies STRUCTURELLES (dérivées du jour) — DOUBLE_BADGE est event-spécifique et exclu.
+const STRUCTURAL_ANOMALY_TYPES = [
+  "MISSING_IN", "MISSING_OUT", "MISSING_BREAK_END", "TOO_LONG_DAY", "TOO_SHORT_BREAK", "OUTSIDE_SCHEDULE",
+];
+
+// Idempotent : retire les anomalies structurelles non résolues du jour puis réinsère l'ensemble courant.
+// Ne touche NI aux DOUBLE_BADGE (event-spécifiques) NI aux anomalies déjà résolues.
+export async function repoRefreshDayAnomalies(
+  q: DbQueryer,
+  employeeId: string,
+  date: string,
+  anomalies: Array<{ anomaly_type: HrTimeAnomaly["anomaly_type"]; severity: HrTimeAnomaly["severity"]; message?: string | null }>
+): Promise<void> {
+  await q.query(
+    `DELETE FROM public.hr_time_anomalies
+      WHERE employee_id = $1::uuid AND date = $2::date AND resolved_at IS NULL
+        AND anomaly_type::text = ANY($3::text[])`,
+    [employeeId, date, STRUCTURAL_ANOMALY_TYPES]
+  );
+  for (const a of anomalies) {
+    await q.query(
+      `INSERT INTO public.hr_time_anomalies (employee_id, date, anomaly_type, severity, message)
+       VALUES ($1::uuid, $2::date, $3::hr_anomaly_type, $4::hr_anomaly_severity, $5)`,
+      [employeeId, date, a.anomaly_type, a.severity, a.message ?? null]
+    );
+  }
+}
+
+// -------------------------------------------------------------- Contrat (attendu du jour)
+export async function repoGetDailyTargetMinutes(employeeId: string, date: string, q: DbQueryer = pool): Promise<number> {
+  const res = await q.query(
+    `SELECT c.daily_hours_target, rs.daily_target_minutes
+       FROM public.hr_employment_contracts c
+       LEFT JOIN public.hr_time_rule_sets rs ON rs.id = c.rule_set_id
+      WHERE c.employee_id = $1::uuid AND c.active
+        AND c.start_date <= $2::date AND (c.end_date IS NULL OR c.end_date >= $2::date)
+      ORDER BY c.start_date DESC LIMIT 1`,
+    [employeeId, date]
+  );
+  const row = res.rows[0];
+  if (!row) return 0;
+  if (row.daily_hours_target != null) return Math.round(Number(row.daily_hours_target) * 60);
+  if (row.daily_target_minutes != null) return Number(row.daily_target_minutes);
+  return 0;
+}
+
+// -------------------------------------------------------------- Timesheet day (persistance de l'agrégat)
+export async function repoUpsertTimesheetDay(
+  q: DbQueryer,
+  d: { employee_id: string; date: string; expected_minutes: number; worked_minutes: number; overtime_minutes: number; missing_minutes: number; anomaly_count: number }
+): Promise<void> {
+  await q.query(
+    `INSERT INTO public.hr_timesheet_days (employee_id, date, expected_minutes, worked_minutes, overtime_minutes, missing_minutes, anomaly_count)
+     VALUES ($1::uuid, $2::date, $3, $4, $5, $6, $7)
+     ON CONFLICT (employee_id, date) DO UPDATE SET
+       expected_minutes = EXCLUDED.expected_minutes,
+       worked_minutes = EXCLUDED.worked_minutes,
+       overtime_minutes = EXCLUDED.overtime_minutes,
+       missing_minutes = EXCLUDED.missing_minutes,
+       anomaly_count = EXCLUDED.anomaly_count,
+       updated_at = now()
+     WHERE public.hr_timesheet_days.validation_status = 'DRAFT'`,
+    [d.employee_id, d.date, d.expected_minutes, d.worked_minutes, d.overtime_minutes, d.missing_minutes, d.anomaly_count]
+  );
+}
+
+// -------------------------------------------------------------- Audit
+export async function insertAuditLog(
+  tx: DbQueryer,
+  audit: AuditContext,
+  entry: { action: string; entity_type: string | null; entity_id: string | null; details?: Record<string, unknown> | null }
+): Promise<void> {
+  const body: CreateAuditLogBodyDTO = {
+    event_type: "ACTION",
+    action: entry.action,
+    page_key: audit.page_key,
+    entity_type: entry.entity_type,
+    entity_id: entry.entity_id,
+    path: audit.path,
+    client_session_id: audit.client_session_id,
+    details: entry.details ?? null,
+  };
+  await repoInsertAuditLog({
+    user_id: audit.user_id,
+    body,
+    ip: audit.ip,
+    user_agent: audit.user_agent,
+    device_type: audit.device_type,
+    os: audit.os,
+    browser: audit.browser,
+    tx,
+  });
+}

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -2,6 +2,7 @@ import { Router } from "express";
 import * as adm from "../controllers/temps-deplacements-admin.controller";
 import * as cor from "../controllers/temps-deplacements-corrections.controller";
 import * as exp from "../controllers/temps-deplacements-exports.controller";
+import * as km from "../controllers/temps-deplacements-km.controller";
 import * as c from "../controllers/temps-deplacements.controller";
 
 // Monté après le socle authenticateToken (v1.routes.ts) → JWT requis d'office.
@@ -53,5 +54,15 @@ router.delete("/admin/schedules/:id", adm.deleteScheduleHandler);
 router.get("/admin/exports", exp.getExports);
 router.post("/admin/exports", exp.postExport);
 router.get("/admin/exports/:id/download", exp.downloadExport);
+
+// T6 — kilomètres. Salarié : déclare/soumet SES km (anti-IDOR). Responsable : périmètre + validation.
+router.get("/kilometers/vehicles", km.getVehicles);
+router.post("/kilometers", km.postKm);
+router.get("/kilometers/me", km.getMyKm);
+router.patch("/kilometers/:id/submit", km.submitKm);
+router.get("/kilometers/team", km.getTeamKm);
+router.patch("/kilometers/:id/validate", km.validateKm);
+router.patch("/kilometers/:id/reject", km.rejectKm);
+router.post("/admin/vehicles", km.postVehicle);
 
 export default router;

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import * as cor from "../controllers/temps-deplacements-corrections.controller";
 import * as c from "../controllers/temps-deplacements.controller";
 
 // Monté après le socle authenticateToken (v1.routes.ts) → JWT requis d'office.
@@ -20,5 +21,15 @@ router.get("/employees/:id/week", c.getEmployeeWeek);
 router.get("/device-config", c.getDeviceConfig);
 router.post("/device-events", c.postDeviceEvent);
 router.post("/device-heartbeat", c.postDeviceHeartbeat);
+
+// T4 — corrections tracées (motif obligatoire, pas d'auto-validation) + validation responsable
+router.post("/adjustments", cor.postAdjustment); // salarié : demande sur ses données
+router.patch("/adjustments/:id/approve", cor.approveAdjustment); // responsable/RH
+router.patch("/adjustments/:id/reject", cor.rejectAdjustment); // responsable/RH
+router.get("/team/adjustments", cor.getTeamAdjustments); // demandes en attente (périmètre)
+router.get("/team/today", cor.getTeamToday); // relevé du jour de l'équipe
+router.get("/team/anomalies", cor.getTeamAnomalies); // anomalies équipe du jour
+router.patch("/days/:id/validate", cor.validateDay); // valide une journée
+router.patch("/weeks/:id/validate", cor.validateWeek); // valide une semaine
 
 export default router;

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -1,0 +1,24 @@
+import { Router } from "express";
+import * as c from "../controllers/temps-deplacements.controller";
+
+// Monté après le socle authenticateToken (v1.routes.ts) → JWT requis d'office.
+// Anti-IDOR : les routes salarié dérivent l'employé de req.user ; /employees/:id/* est gardé
+// (soi-même / manager / RH-Direction-Admin). Device : JWT + device_token haché.
+const router = Router();
+
+// Salarié (self-service)
+router.post("/events", c.postEvent);
+router.get("/me/today", c.getMeToday);
+router.get("/me/week", c.getMeWeek);
+router.get("/me/anomalies", c.getMeAnomalies);
+
+// Lecture périmètre (manager / RH) + anti-IDOR
+router.get("/employees/:id/today", c.getEmployeeToday);
+router.get("/employees/:id/week", c.getEmployeeWeek);
+
+// Borne / device
+router.get("/device-config", c.getDeviceConfig);
+router.post("/device-events", c.postDeviceEvent);
+router.post("/device-heartbeat", c.postDeviceHeartbeat);
+
+export default router;

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -1,4 +1,5 @@
 import { Router } from "express";
+import * as adm from "../controllers/temps-deplacements-admin.controller";
 import * as cor from "../controllers/temps-deplacements-corrections.controller";
 import * as c from "../controllers/temps-deplacements.controller";
 
@@ -31,5 +32,20 @@ router.get("/team/today", cor.getTeamToday); // relevé du jour de l'équipe
 router.get("/team/anomalies", cor.getTeamAnomalies); // anomalies équipe du jour
 router.patch("/days/:id/validate", cor.validateDay); // valide une journée
 router.patch("/weeks/:id/validate", cor.validateWeek); // valide une semaine
+
+// T5 — administration RH (règles / contrats / horaires). Réservé aux rôles privilégiés (service).
+router.get("/admin/employees", adm.getEmployees);
+router.get("/admin/rule-sets", adm.getRuleSets);
+router.post("/admin/rule-sets", adm.postRuleSet);
+router.put("/admin/rule-sets/:id", adm.putRuleSet);
+router.patch("/admin/rule-sets/:id/active", adm.patchRuleSetActive);
+router.get("/admin/contracts", adm.getContracts);
+router.post("/admin/contracts", adm.postContract);
+router.put("/admin/contracts/:id", adm.putContract);
+router.patch("/admin/contracts/:id/active", adm.patchContractActive);
+router.get("/admin/schedules", adm.getSchedules);
+router.post("/admin/schedules", adm.postSchedule);
+router.put("/admin/schedules/:id", adm.putSchedule);
+router.delete("/admin/schedules/:id", adm.deleteScheduleHandler);
 
 export default router;

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import * as adm from "../controllers/temps-deplacements-admin.controller";
 import * as cor from "../controllers/temps-deplacements-corrections.controller";
+import * as dev from "../controllers/temps-deplacements-devices.controller";
 import * as exp from "../controllers/temps-deplacements-exports.controller";
 import * as km from "../controllers/temps-deplacements-km.controller";
 import * as c from "../controllers/temps-deplacements.controller";
@@ -64,5 +65,14 @@ router.get("/kilometers/team", km.getTeamKm);
 router.patch("/kilometers/:id/validate", km.validateKm);
 router.patch("/kilometers/:id/reject", km.rejectKm);
 router.post("/admin/vehicles", km.postVehicle);
+
+// T8 — bornes & badges (provisioning). Réservé aux rôles privilégiés (service). Token borne renvoyé 1× à la création.
+router.get("/admin/devices", dev.getDevices);
+router.post("/admin/devices", dev.postDevice);
+router.patch("/admin/devices/:id/status", dev.patchDeviceStatus);
+router.post("/admin/devices/:id/rotate-token", dev.postDeviceRotate);
+router.get("/admin/badges", dev.getBadges);
+router.post("/admin/badges", dev.postBadge);
+router.patch("/admin/badges/:id/revoke", dev.revokeBadgeHandler);
 
 export default router;

--- a/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
+++ b/src/module/temps-deplacements/routes/temps-deplacements.routes.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import * as adm from "../controllers/temps-deplacements-admin.controller";
 import * as cor from "../controllers/temps-deplacements-corrections.controller";
+import * as exp from "../controllers/temps-deplacements-exports.controller";
 import * as c from "../controllers/temps-deplacements.controller";
 
 // Monté après le socle authenticateToken (v1.routes.ts) → JWT requis d'office.
@@ -47,5 +48,10 @@ router.get("/admin/schedules", adm.getSchedules);
 router.post("/admin/schedules", adm.postSchedule);
 router.put("/admin/schedules/:id", adm.putSchedule);
 router.delete("/admin/schedules/:id", adm.deleteScheduleHandler);
+
+// T7 — exports paie figés (CSV `;`+BOM / PDF) + checksum. Réservé aux rôles privilégiés (service).
+router.get("/admin/exports", exp.getExports);
+router.post("/admin/exports", exp.postExport);
+router.get("/admin/exports/:id/download", exp.downloadExport);
 
 export default router;

--- a/src/module/temps-deplacements/services/temps-deplacements-admin.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-admin.service.ts
@@ -1,0 +1,137 @@
+import { HttpError } from "../../../utils/httpError";
+import {
+  repoDeleteSchedule,
+  repoGetContractById,
+  repoGetRuleSetById,
+  repoInsertContract,
+  repoInsertRuleSet,
+  repoInsertSchedule,
+  repoListContracts,
+  repoListEmployees,
+  repoListRuleSets,
+  repoListSchedules,
+  repoSetContractActive,
+  repoSetRuleSetActive,
+  repoUpdateContract,
+  repoUpdateRuleSet,
+  repoUpdateSchedule,
+  type ContractInput,
+  type RuleSetInput,
+  type ScheduleInput,
+} from "../repository/temps-deplacements-rules.repository";
+import { insertAuditLog, isPgUniqueViolation, withTransaction, type AuditContext } from "../repository/temps-deplacements.repository";
+import { isHrPrivileged, type Actor } from "./temps-deplacements-corrections.service";
+
+// Toute l'administration RH est réservée aux rôles privilégiés (RH/Direction/Admin) — anti-IDOR :
+// un salarié n'a AUCUN accès à ces endpoints (403), et ne peut pas cibler un autre employé.
+function assertPrivileged(actor: Actor): void {
+  if (!isHrPrivileged(actor.role)) throw new HttpError(403, "HR_FORBIDDEN", "Administration RH réservée.");
+}
+
+async function audit(actor: Actor, ctx: AuditContext, action: string, entityType: string, entityId: string | null, details: Record<string, unknown>) {
+  await withTransaction((client) =>
+    insertAuditLog(client, ctx, { action, entity_type: entityType, entity_id: entityId, details })
+  );
+}
+
+// -------------------------------------------------------------- Employés (lecture pickers)
+export async function listEmployees(actor: Actor) {
+  assertPrivileged(actor);
+  return repoListEmployees();
+}
+
+// -------------------------------------------------------------- Rule sets
+export async function listRuleSets(actor: Actor) {
+  assertPrivileged(actor);
+  return repoListRuleSets();
+}
+export async function createRuleSet(actor: Actor, input: RuleSetInput, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction((client) => repoInsertRuleSet(client, input));
+  await audit(actor, ctx, "temps-deplacements.rule_set.create", "hr_time_rule_sets", row.id, { name: input.name });
+  return row;
+}
+export async function updateRuleSet(actor: Actor, id: string, input: RuleSetInput, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction((client) => repoUpdateRuleSet(client, id, input));
+  if (!row) throw new HttpError(404, "HR_RULE_SET_NOT_FOUND", "Règle introuvable.");
+  await audit(actor, ctx, "temps-deplacements.rule_set.update", "hr_time_rule_sets", id, { name: input.name });
+  return row;
+}
+export async function setRuleSetActive(actor: Actor, id: string, active: boolean, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction((client) => repoSetRuleSetActive(client, id, active));
+  if (!row) throw new HttpError(404, "HR_RULE_SET_NOT_FOUND", "Règle introuvable.");
+  await audit(actor, ctx, "temps-deplacements.rule_set.set_active", "hr_time_rule_sets", id, { active });
+  return row;
+}
+
+// -------------------------------------------------------------- Contrats
+export async function listContracts(actor: Actor, employeeId?: string) {
+  assertPrivileged(actor);
+  return withTransaction((client) => repoListContracts(client, employeeId));
+}
+export async function createContract(actor: Actor, input: ContractInput, ctx: AuditContext) {
+  assertPrivileged(actor);
+  try {
+    const row = await withTransaction((client) => repoInsertContract(client, input));
+    await audit(actor, ctx, "temps-deplacements.contract.create", "hr_employment_contracts", row.id, {
+      employee_id: input.employee_id, contract_type: input.contract_type,
+    });
+    return row;
+  } catch (err) {
+    if (isPgUniqueViolation(err)) throw new HttpError(409, "HR_CONTRACT_ACTIVE_EXISTS", "Un contrat actif existe déjà pour cet employé.");
+    throw err;
+  }
+}
+export async function updateContract(actor: Actor, id: string, input: ContractInput, ctx: AuditContext) {
+  assertPrivileged(actor);
+  try {
+    const row = await withTransaction((client) => repoUpdateContract(client, id, input));
+    if (!row) throw new HttpError(404, "HR_CONTRACT_NOT_FOUND", "Contrat introuvable.");
+    await audit(actor, ctx, "temps-deplacements.contract.update", "hr_employment_contracts", id, { contract_type: input.contract_type });
+    return row;
+  } catch (err) {
+    if (isPgUniqueViolation(err)) throw new HttpError(409, "HR_CONTRACT_ACTIVE_EXISTS", "Un contrat actif existe déjà pour cet employé.");
+    throw err;
+  }
+}
+export async function setContractActive(actor: Actor, id: string, active: boolean, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const existing = await repoGetContractById(id);
+  if (!existing) throw new HttpError(404, "HR_CONTRACT_NOT_FOUND", "Contrat introuvable.");
+  try {
+    const row = await withTransaction((client) => repoSetContractActive(client, id, active));
+    await audit(actor, ctx, "temps-deplacements.contract.set_active", "hr_employment_contracts", id, { active });
+    return row;
+  } catch (err) {
+    if (isPgUniqueViolation(err)) throw new HttpError(409, "HR_CONTRACT_ACTIVE_EXISTS", "Un contrat actif existe déjà pour cet employé.");
+    throw err;
+  }
+}
+
+// -------------------------------------------------------------- Horaires types
+export async function listSchedules(actor: Actor, employeeId: string) {
+  assertPrivileged(actor);
+  return withTransaction((client) => repoListSchedules(client, employeeId));
+}
+export async function createSchedule(actor: Actor, input: ScheduleInput, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction((client) => repoInsertSchedule(client, input));
+  await audit(actor, ctx, "temps-deplacements.schedule.create", "hr_work_schedules", row.id, { employee_id: input.employee_id, day_of_week: input.day_of_week });
+  return row;
+}
+export async function updateSchedule(actor: Actor, id: string, input: ScheduleInput, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction((client) => repoUpdateSchedule(client, id, input));
+  if (!row) throw new HttpError(404, "HR_SCHEDULE_NOT_FOUND", "Horaire introuvable.");
+  await audit(actor, ctx, "temps-deplacements.schedule.update", "hr_work_schedules", id, { day_of_week: input.day_of_week });
+  return row;
+}
+export async function deleteSchedule(actor: Actor, id: string, ctx: AuditContext) {
+  assertPrivileged(actor);
+  const ok = await withTransaction((client) => repoDeleteSchedule(client, id));
+  if (!ok) throw new HttpError(404, "HR_SCHEDULE_NOT_FOUND", "Horaire introuvable.");
+  await audit(actor, ctx, "temps-deplacements.schedule.delete", "hr_work_schedules", id, {});
+  return { ok: true };
+}

--- a/src/module/temps-deplacements/services/temps-deplacements-corrections.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-corrections.service.ts
@@ -1,0 +1,178 @@
+import { HttpError } from "../../../utils/httpError";
+import {
+  repoCreateAdjustment,
+  repoDecideAdjustment,
+  repoGetAdjustmentById,
+  repoGetTimesheetDayById,
+  repoGetTimesheetWeekById,
+  repoListTeamAdjustments,
+  repoListTeamAnomaliesForDate,
+  repoListTeamEmployees,
+  repoResolveTargetEmployeeId,
+  repoSetDayValidation,
+  repoSetWeekValidation,
+  type HrAdjustment,
+  type HrAdjustmentWithEmployee,
+  type TimesheetRef,
+} from "../repository/temps-deplacements-corrections.repository";
+import {
+  insertAuditLog,
+  repoGetEmployeeById,
+  withTransaction,
+  type AuditContext,
+} from "../repository/temps-deplacements.repository";
+import type { CreateAdjustmentBody } from "../validators/temps-deplacements.validators";
+import { computeDailyTimesheet, todayParis } from "./temps-deplacements.service";
+
+export type Actor = { id: number; role: string };
+
+// Miroir de isHrPrivileged du contrôleur T2 (rôle RH/Direction/Admin). Pur ⇒ testable directement.
+export function isHrPrivileged(role: string): boolean {
+  const r = role.toLowerCase();
+  return r.includes("rh") || r.includes("directeur") || r.includes("direction") || r.includes("administrateur");
+}
+
+// Lève 403 si l'appelant n'est ni le manager de l'employé ni un rôle privilégié (anti-IDOR périmètre).
+async function assertCanManageEmployee(actor: Actor, employeeId: string): Promise<void> {
+  if (isHrPrivileged(actor.role)) return;
+  const emp = await repoGetEmployeeById(employeeId);
+  if (emp && emp.manager_user_id !== null && emp.manager_user_id === actor.id) return;
+  throw new HttpError(403, "HR_FORBIDDEN", "Hors de votre périmètre de gestion.");
+}
+
+// -------------------------------------------------------------- Corrections (tracées, motif obligatoire)
+// Le salarié demande une correction sur SES données (ou son manager / RH sur le périmètre). L'application
+// numérique d'une correction approuvée (override dans le relevé) relève de T5 : ici on trace la DÉCISION
+// (append-only events ⇒ jamais mutés). L'enregistrement approuvé est la preuve légale de la correction.
+export async function createAdjustment(
+  actor: Actor,
+  body: CreateAdjustmentBody,
+  audit: AuditContext
+): Promise<HrAdjustment> {
+  const targetEmployeeId = await repoResolveTargetEmployeeId(body.target_type, body.target_id);
+  if (!targetEmployeeId) throw new HttpError(404, "HR_TARGET_NOT_FOUND", "Cible de correction introuvable.");
+
+  const emp = await repoGetEmployeeById(targetEmployeeId);
+  const isSelf = emp?.user_id === actor.id;
+  const isManager = emp?.manager_user_id !== null && emp?.manager_user_id === actor.id;
+  if (!isSelf && !isManager && !isHrPrivileged(actor.role)) {
+    throw new HttpError(403, "HR_FORBIDDEN", "Vous ne pouvez demander une correction que sur vos données.");
+  }
+
+  return withTransaction(async (client) => {
+    const adj = await repoCreateAdjustment(client, {
+      target_type: body.target_type,
+      target_id: body.target_id,
+      reason: body.reason,
+      old_value: body.old_value ?? null,
+      new_value: body.new_value ?? null,
+      requested_by: actor.id,
+    });
+    await insertAuditLog(client, audit, {
+      action: "temps-deplacements.adjustment.requested",
+      entity_type: "hr_time_adjustments",
+      entity_id: adj.id,
+      details: { target_type: body.target_type, target_id: body.target_id, reason: body.reason },
+    });
+    return adj;
+  });
+}
+
+// Approuve / rejette une demande. INTERDIT : auto-validation (requested_by === actor). RBAC périmètre.
+export async function decideAdjustment(
+  actor: Actor,
+  id: string,
+  decision: "APPROVED" | "REJECTED",
+  audit: AuditContext
+): Promise<HrAdjustment> {
+  const adj = await repoGetAdjustmentById(id);
+  if (!adj) throw new HttpError(404, "HR_ADJUSTMENT_NOT_FOUND", "Demande de correction introuvable.");
+  if (adj.status !== "REQUESTED") throw new HttpError(409, "HR_ADJUSTMENT_NOT_PENDING", "Demande déjà traitée.");
+  if (adj.requested_by === actor.id) {
+    throw new HttpError(403, "HR_SELF_APPROVAL_FORBIDDEN", "Auto-validation d'une correction interdite.");
+  }
+  const targetEmployeeId = await repoResolveTargetEmployeeId(adj.target_type, adj.target_id);
+  if (!targetEmployeeId) throw new HttpError(404, "HR_TARGET_NOT_FOUND", "Cible de correction introuvable.");
+  await assertCanManageEmployee(actor, targetEmployeeId);
+
+  return withTransaction(async (client) => {
+    const updated = await repoDecideAdjustment(client, id, decision, actor.id);
+    if (!updated) throw new HttpError(409, "HR_ADJUSTMENT_NOT_PENDING", "Demande déjà traitée.");
+    await insertAuditLog(client, audit, {
+      action: decision === "APPROVED" ? "temps-deplacements.adjustment.approved" : "temps-deplacements.adjustment.rejected",
+      entity_type: "hr_time_adjustments",
+      entity_id: id,
+      details: { decision, target_type: adj.target_type, target_id: adj.target_id },
+    });
+    return updated;
+  });
+}
+
+export async function listTeamAdjustments(actor: Actor): Promise<HrAdjustmentWithEmployee[]> {
+  return repoListTeamAdjustments({ managerUserId: actor.id, isPrivileged: isHrPrivileged(actor.role) });
+}
+
+// -------------------------------------------------------------- Validation jour / semaine
+export async function validateTimesheetDay(actor: Actor, dayId: string, audit: AuditContext): Promise<TimesheetRef> {
+  const day = await repoGetTimesheetDayById(dayId);
+  if (!day) throw new HttpError(404, "HR_TIMESHEET_NOT_FOUND", "Journée introuvable.");
+  await assertCanManageEmployee(actor, day.employee_id);
+  if (day.validation_status === "VALIDATED" || day.validation_status === "EXPORTED") {
+    throw new HttpError(409, "HR_ALREADY_VALIDATED", "Journée déjà validée ou exportée.");
+  }
+  return withTransaction(async (client) => {
+    const updated = await repoSetDayValidation(client, dayId, "VALIDATED", actor.id);
+    if (!updated) throw new HttpError(409, "HR_ALREADY_VALIDATED", "Journée déjà validée ou exportée.");
+    await insertAuditLog(client, audit, {
+      action: "temps-deplacements.day.validated",
+      entity_type: "hr_timesheet_days",
+      entity_id: dayId,
+      details: { validation_status: "VALIDATED" },
+    });
+    return updated;
+  });
+}
+
+export async function validateTimesheetWeek(actor: Actor, weekId: string, audit: AuditContext): Promise<TimesheetRef> {
+  const week = await repoGetTimesheetWeekById(weekId);
+  if (!week) throw new HttpError(404, "HR_TIMESHEET_NOT_FOUND", "Semaine introuvable.");
+  await assertCanManageEmployee(actor, week.employee_id);
+  if (week.validation_status === "VALIDATED" || week.validation_status === "EXPORTED") {
+    throw new HttpError(409, "HR_ALREADY_VALIDATED", "Semaine déjà validée ou exportée.");
+  }
+  return withTransaction(async (client) => {
+    const updated = await repoSetWeekValidation(client, weekId, "VALIDATED", actor.id);
+    if (!updated) throw new HttpError(409, "HR_ALREADY_VALIDATED", "Semaine déjà validée ou exportée.");
+    await insertAuditLog(client, audit, {
+      action: "temps-deplacements.week.validated",
+      entity_type: "hr_timesheet_weeks",
+      entity_id: weekId,
+      details: { validation_status: "VALIDATED" },
+    });
+    return updated;
+  });
+}
+
+// -------------------------------------------------------------- Périmètre équipe (lecture)
+export async function teamToday(actor: Actor): Promise<{
+  date: string;
+  employees: Array<{ employee: { id: string; matricule: string; service: string | null }; timesheet: Awaited<ReturnType<typeof computeDailyTimesheet>> }>;
+}> {
+  const isPriv = isHrPrivileged(actor.role);
+  const employees = await repoListTeamEmployees({ managerUserId: actor.id, isPrivileged: isPriv });
+  const date = todayParis();
+  const rows = await Promise.all(
+    employees.map(async (e) => ({
+      employee: { id: e.id, matricule: e.matricule, service: e.service },
+      timesheet: await computeDailyTimesheet(e.id, date),
+    }))
+  );
+  return { date, employees: rows };
+}
+
+export async function teamAnomalies(actor: Actor, date?: string) {
+  const isPriv = isHrPrivileged(actor.role);
+  const d = date ?? todayParis();
+  const anomalies = await repoListTeamAnomaliesForDate({ managerUserId: actor.id, isPrivileged: isPriv, date: d });
+  return { date: d, anomalies };
+}

--- a/src/module/temps-deplacements/services/temps-deplacements-devices.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-devices.service.ts
@@ -1,0 +1,96 @@
+import crypto from "node:crypto";
+import { HttpError } from "../../../utils/httpError";
+import {
+  repoCreateBadge,
+  repoCreateDevice,
+  repoListBadges,
+  repoListDevices,
+  repoRevokeBadge,
+  repoRotateDeviceToken,
+  repoSetDeviceStatus,
+  type HrDeviceStatus,
+} from "../repository/temps-deplacements-devices.repository";
+import { insertAuditLog, repoGetEmployeeById, withTransaction, type AuditContext } from "../repository/temps-deplacements.repository";
+import { isHrPrivileged, type Actor } from "./temps-deplacements-corrections.service";
+import { hashBadgeUid, hashDeviceToken } from "./temps-deplacements.service";
+
+function assertPrivileged(actor: Actor): void {
+  if (!isHrPrivileged(actor.role)) throw new HttpError(403, "HR_FORBIDDEN", "Gestion des bornes/badges réservée.");
+}
+
+// Token opaque, imprévisible. Stocké HACHÉ ; renvoyé en clair UNE seule fois (pour configurer la borne).
+function generateDeviceToken(): string {
+  return crypto.randomBytes(24).toString("hex");
+}
+
+// -------------------------------------------------------------- Bornes
+export async function createDevice(actor: Actor, input: { name: string; location: string | null; device_type: string | null }, audit: AuditContext) {
+  assertPrivileged(actor);
+  const token = generateDeviceToken();
+  const device = await withTransaction(async (client) => {
+    const row = await repoCreateDevice(client, { name: input.name, location: input.location, device_type: input.device_type, device_token_hash: hashDeviceToken(token) });
+    await insertAuditLog(client, audit, { action: "temps-deplacements.device.create", entity_type: "hr_time_clock_devices", entity_id: row.id, details: { name: input.name } });
+    return row;
+  });
+  return { device, token }; // token en clair : à copier maintenant, non re-consultable
+}
+
+export async function listDevices(actor: Actor) {
+  assertPrivileged(actor);
+  return repoListDevices();
+}
+
+export async function setDeviceStatus(actor: Actor, id: string, status: HrDeviceStatus, audit: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction(async (client) => {
+    const d = await repoSetDeviceStatus(client, id, status);
+    if (!d) return null;
+    await insertAuditLog(client, audit, { action: "temps-deplacements.device.set_status", entity_type: "hr_time_clock_devices", entity_id: id, details: { status } });
+    return d;
+  });
+  if (!row) throw new HttpError(404, "HR_DEVICE_NOT_FOUND", "Borne introuvable.");
+  return row;
+}
+
+export async function rotateDeviceToken(actor: Actor, id: string, audit: AuditContext) {
+  assertPrivileged(actor);
+  const token = generateDeviceToken();
+  const device = await withTransaction(async (client) => {
+    const d = await repoRotateDeviceToken(client, id, hashDeviceToken(token));
+    if (!d) return null;
+    await insertAuditLog(client, audit, { action: "temps-deplacements.device.rotate_token", entity_type: "hr_time_clock_devices", entity_id: id, details: {} });
+    return d;
+  });
+  if (!device) throw new HttpError(404, "HR_DEVICE_NOT_FOUND", "Borne introuvable.");
+  return { device, token };
+}
+
+// -------------------------------------------------------------- Badges
+export async function createBadge(actor: Actor, input: { employee_id: string; badge_uid: string; badge_label: string | null }, audit: AuditContext) {
+  assertPrivileged(actor);
+  const emp = await repoGetEmployeeById(input.employee_id);
+  if (!emp) throw new HttpError(404, "HR_EMPLOYEE_NOT_FOUND", "Employé introuvable.");
+  return withTransaction(async (client) => {
+    const row = await repoCreateBadge(client, { employee_id: input.employee_id, badge_uid_hash: hashBadgeUid(input.badge_uid), badge_label: input.badge_label });
+    // JAMAIS le badge_uid en clair dans l'audit.
+    await insertAuditLog(client, audit, { action: "temps-deplacements.badge.create", entity_type: "hr_badge_credentials", entity_id: row.id, details: { employee_id: input.employee_id } });
+    return row;
+  });
+}
+
+export async function listBadges(actor: Actor, employeeId?: string) {
+  assertPrivileged(actor);
+  return withTransaction((client) => repoListBadges(client, employeeId));
+}
+
+export async function revokeBadge(actor: Actor, id: string, audit: AuditContext) {
+  assertPrivileged(actor);
+  const row = await withTransaction(async (client) => {
+    const b = await repoRevokeBadge(client, id);
+    if (!b) return null;
+    await insertAuditLog(client, audit, { action: "temps-deplacements.badge.revoke", entity_type: "hr_badge_credentials", entity_id: id, details: {} });
+    return b;
+  });
+  if (!row) throw new HttpError(409, "HR_BADGE_NOT_ACTIVE", "Badge déjà révoqué ou introuvable.");
+  return row;
+}

--- a/src/module/temps-deplacements/services/temps-deplacements-exports.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-exports.service.ts
@@ -1,0 +1,95 @@
+import { HttpError } from "../../../utils/httpError";
+import {
+  repoGetExportBatch,
+  repoInsertExportBatch,
+  repoListExportBatches,
+  repoListWeeksForPeriod,
+} from "../repository/temps-deplacements-exports.repository";
+import { insertAuditLog, withTransaction, type AuditContext } from "../repository/temps-deplacements.repository";
+import { isHrPrivileged, type Actor } from "./temps-deplacements-corrections.service";
+import { buildPayrollCsv, buildPayrollPdf, sha256Hex, type PayrollWeekRow } from "./temps-deplacements-exports";
+
+function assertPrivileged(actor: Actor): void {
+  if (!isHrPrivileged(actor.role)) throw new HttpError(403, "HR_FORBIDDEN", "Export réservé aux responsables RH / direction.");
+}
+
+export interface ExportFile {
+  filename: string;
+  contentType: string;
+  buffer: Buffer;
+  checksum: string;
+}
+
+async function renderFile(format: "CSV" | "PDF", periodStart: string, periodEnd: string, rows: PayrollWeekRow[]): Promise<ExportFile> {
+  if (format === "CSV") {
+    const buffer = Buffer.from(buildPayrollCsv(rows), "utf-8");
+    return { filename: `paie_${periodStart}_${periodEnd}.csv`, contentType: "text/csv; charset=utf-8", buffer, checksum: sha256Hex(buffer) };
+  }
+  const buffer = await buildPayrollPdf({ periodStart, periodEnd }, rows);
+  return { filename: `paie_${periodStart}_${periodEnd}.pdf`, contentType: "application/pdf", buffer, checksum: sha256Hex(buffer) };
+}
+
+// Crée un lot d'export FIGÉ : octets gelés (base64) + checksum SHA-256 en base → re-téléchargement identique.
+export async function createExport(
+  actor: Actor,
+  input: { period_start: string; period_end: string; format: "CSV" | "PDF" },
+  audit: AuditContext
+) {
+  assertPrivileged(actor);
+  if (input.period_end < input.period_start) throw new HttpError(400, "HR_EXPORT_BAD_PERIOD", "Période invalide (fin < début).");
+
+  const rows = await repoListWeeksForPeriod(input.period_start, input.period_end);
+  const file = await renderFile(input.format, input.period_start, input.period_end, rows);
+
+  const frozen = {
+    row_count: rows.length,
+    rows, // conservé pour transparence/audit (recalculable)
+    file_base64: file.buffer.toString("base64"),
+    filename: file.filename,
+    content_type: file.contentType,
+    generated_meta: { period_start: input.period_start, period_end: input.period_end, format: input.format },
+  };
+
+  const batch = await withTransaction(async (client) => {
+    const row = await repoInsertExportBatch(client, {
+      period_start: input.period_start,
+      period_end: input.period_end,
+      exported_by: actor.id,
+      format: input.format,
+      frozen_snapshot_json: frozen,
+      checksum: file.checksum,
+    });
+    await insertAuditLog(client, audit, {
+      action: "temps-deplacements.export.create",
+      entity_type: "hr_payroll_export_batches",
+      entity_id: row.id,
+      details: { format: input.format, period_start: input.period_start, period_end: input.period_end, row_count: rows.length, checksum: file.checksum },
+    });
+    return row;
+  });
+
+  return { ...batch, row_count: rows.length };
+}
+
+export async function listExports(actor: Actor) {
+  assertPrivileged(actor);
+  return repoListExportBatches();
+}
+
+// Renvoie les octets figés + VÉRIFIE l'intégrité (checksum stocké == checksum recalculé sur les octets).
+export async function getExportFile(actor: Actor, id: string): Promise<ExportFile> {
+  assertPrivileged(actor);
+  const batch = await repoGetExportBatch(id);
+  if (!batch) throw new HttpError(404, "HR_EXPORT_NOT_FOUND", "Lot d'export introuvable.");
+  const frozen = (batch.frozen_snapshot_json ?? {}) as { file_base64?: string; filename?: string; content_type?: string };
+  if (!frozen.file_base64) throw new HttpError(409, "HR_EXPORT_NO_FILE", "Lot sans fichier figé.");
+  const buffer = Buffer.from(frozen.file_base64, "base64");
+  const recomputed = sha256Hex(buffer);
+  if (recomputed !== batch.checksum) throw new HttpError(409, "HR_EXPORT_CHECKSUM_MISMATCH", "Intégrité de l'export compromise.");
+  return {
+    filename: frozen.filename ?? `export_${id}`,
+    contentType: frozen.content_type ?? "application/octet-stream",
+    buffer,
+    checksum: batch.checksum,
+  };
+}

--- a/src/module/temps-deplacements/services/temps-deplacements-exports.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-exports.ts
@@ -1,0 +1,113 @@
+import crypto from "node:crypto";
+import PDFDocument from "pdfkit";
+
+// T7 — Générateurs d'export PURS (CSV `;` + BOM UTF-8, PDF récap) + checksum. Aucune dépendance Excel/XLSX.
+
+export interface PayrollWeekRow {
+  matricule: string;
+  name: string | null;
+  surname: string | null;
+  week_start: string;
+  week_end: string;
+  worked_minutes: number;
+  contract_minutes: number;
+  overtime_25_minutes: number;
+  overtime_50_minutes: number;
+  absence_minutes: number;
+}
+
+export const CSV_HEADER = [
+  "Matricule", "Nom", "Prénom", "Début semaine", "Fin semaine",
+  "H. travaillées", "H. contractuelles", "HS 25%", "HS 50%", "H. absence",
+] as const;
+
+// Minutes → heures décimales (point), 2 décimales. 90 → "1.50".
+export function minutesToDecimalHours(min: number): string {
+  return (min / 60).toFixed(2);
+}
+
+export function payrollRowToCsvCells(r: PayrollWeekRow): string[] {
+  return [
+    r.matricule,
+    r.surname ?? "",
+    r.name ?? "",
+    r.week_start,
+    r.week_end,
+    minutesToDecimalHours(r.worked_minutes),
+    minutesToDecimalHours(r.contract_minutes),
+    minutesToDecimalHours(r.overtime_25_minutes),
+    minutesToDecimalHours(r.overtime_50_minutes),
+    minutesToDecimalHours(r.absence_minutes),
+  ];
+}
+
+// Échappement CSV : guillemets si le champ contient ; " CR ou LF.
+function escapeCsv(value: string): string {
+  const s = String(value ?? "");
+  return /[;"\r\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
+}
+
+// CSV français : séparateur `;`, BOM UTF-8, fins de ligne CRLF (compatible tableurs FR).
+export function toCsv(header: readonly string[], rows: string[][]): string {
+  const lines = [header as readonly string[], ...rows].map((r) => r.map((c) => escapeCsv(String(c))).join(";"));
+  return "﻿" + lines.join("\r\n") + "\r\n";
+}
+
+export function buildPayrollCsv(rows: PayrollWeekRow[]): string {
+  return toCsv(CSV_HEADER, rows.map(payrollRowToCsvCells));
+}
+
+export function sha256Hex(data: string | Buffer): string {
+  return crypto.createHash("sha256").update(data).digest("hex");
+}
+
+// PDF récapitulatif (pdfkit, police Helvetica intégrée — aucun fichier de police requis).
+export function buildPayrollPdf(meta: { periodStart: string; periodEnd: string }, rows: PayrollWeekRow[]): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    try {
+      const doc = new PDFDocument({ margin: 36, size: "A4" });
+      const chunks: Buffer[] = [];
+      doc.on("data", (c: Buffer) => chunks.push(c));
+      doc.on("end", () => resolve(Buffer.concat(chunks)));
+      doc.on("error", reject);
+
+      doc.fontSize(15).text("Récapitulatif temps — paie", { align: "left" });
+      doc.moveDown(0.3).fontSize(10).fillColor("#555").text(`Période : ${meta.periodStart} → ${meta.periodEnd}`);
+      doc.fillColor("#000").moveDown(0.8);
+
+      const cols = ["Matricule", "Salarié", "Semaine", "Trav.", "Contrat", "HS25", "HS50", "Abs."];
+      const widths = [70, 130, 90, 45, 50, 40, 40, 45];
+      const startX = doc.x;
+      let y = doc.y;
+      const drawRow = (cells: string[], bold: boolean) => {
+        doc.fontSize(8).font(bold ? "Helvetica-Bold" : "Helvetica");
+        let x = startX;
+        cells.forEach((c, i) => {
+          doc.text(c, x + 2, y + 2, { width: widths[i] - 4, ellipsis: true });
+          x += widths[i];
+        });
+        y += 16;
+        if (y > 780) { doc.addPage(); y = doc.y; }
+      };
+      drawRow([...cols], true);
+      for (const r of rows) {
+        drawRow(
+          [
+            r.matricule,
+            `${r.surname ?? ""} ${r.name ?? ""}`.trim(),
+            r.week_start,
+            minutesToDecimalHours(r.worked_minutes),
+            minutesToDecimalHours(r.contract_minutes),
+            minutesToDecimalHours(r.overtime_25_minutes),
+            minutesToDecimalHours(r.overtime_50_minutes),
+            minutesToDecimalHours(r.absence_minutes),
+          ],
+          false
+        );
+      }
+      doc.end();
+    } catch (err) {
+      reject(err);
+    }
+  });
+}

--- a/src/module/temps-deplacements/services/temps-deplacements-km.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-km.service.ts
@@ -1,0 +1,128 @@
+import { HttpError } from "../../../utils/httpError";
+import {
+  repoCreateKmEntry,
+  repoCreateVehicle,
+  repoDecideKmEntry,
+  repoGetKmEntryById,
+  repoListKmForEmployee,
+  repoListTeamKmEntries,
+  repoListVehicles,
+  repoSubmitKmEntry,
+  type HrKmStatus,
+  type HrKmType,
+  type KmEntry,
+} from "../repository/temps-deplacements-km.repository";
+import { insertAuditLog, repoGetEmployeeById, withTransaction, type AuditContext } from "../repository/temps-deplacements.repository";
+import { isHrPrivileged, type Actor } from "./temps-deplacements-corrections.service";
+import { resolveEmployeeFromUser } from "./temps-deplacements.service";
+
+async function assertCanManageEmployee(actor: Actor, employeeId: string): Promise<void> {
+  if (isHrPrivileged(actor.role)) return;
+  const emp = await repoGetEmployeeById(employeeId);
+  if (emp && emp.manager_user_id !== null && emp.manager_user_id === actor.id) return;
+  throw new HttpError(403, "HR_FORBIDDEN", "Hors de votre périmètre de gestion.");
+}
+
+// Distance : privilégie l'écart de compteur (odomètre) s'il est fourni, sinon la distance saisie.
+export function computeDistanceKm(input: { start_odometer: number | null; end_odometer: number | null; distance_km: number }): number {
+  if (input.start_odometer != null && input.end_odometer != null) {
+    return Math.max(0, Number((input.end_odometer - input.start_odometer).toFixed(2)));
+  }
+  return Math.max(0, Number((input.distance_km ?? 0).toFixed(2)));
+}
+
+export interface CreateKmInput {
+  date: string;
+  type: HrKmType;
+  vehicle_id: string | null;
+  start_location: string | null;
+  end_location: string | null;
+  start_odometer: number | null;
+  end_odometer: number | null;
+  distance_km: number;
+  affaire_id: number | null;
+  client_id: number | null;
+  fournisseur_id: number | null;
+  submit: boolean;
+}
+
+// ANTI-IDOR : l'employé vient de req.user, JAMAIS du corps. Le salarié déclare SES kilomètres.
+export async function createMyKmEntry(actor: Actor, input: CreateKmInput, audit: AuditContext): Promise<KmEntry> {
+  const emp = await resolveEmployeeFromUser(actor.id);
+  const distance = computeDistanceKm(input);
+  return withTransaction(async (client) => {
+    const entry = await repoCreateKmEntry(client, {
+      employee_id: emp.id,
+      date: input.date,
+      type: input.type,
+      vehicle_id: input.vehicle_id,
+      start_location: input.start_location,
+      end_location: input.end_location,
+      start_odometer: input.start_odometer,
+      end_odometer: input.end_odometer,
+      distance_km: distance,
+      affaire_id: input.affaire_id,
+      client_id: input.client_id,
+      fournisseur_id: input.fournisseur_id,
+      status: input.submit ? "SUBMITTED" : "DRAFT",
+    });
+    await insertAuditLog(client, audit, {
+      action: "temps-deplacements.km.create",
+      entity_type: "hr_kilometer_entries",
+      entity_id: entry.id,
+      details: { type: input.type, distance_km: distance, status: entry.status },
+    });
+    return entry;
+  });
+}
+
+export async function listMyKmEntries(actor: Actor, filters: { from?: string; to?: string; status?: HrKmStatus }): Promise<KmEntry[]> {
+  const emp = await resolveEmployeeFromUser(actor.id);
+  return repoListKmForEmployee(emp.id, filters);
+}
+
+export async function submitMyKmEntry(actor: Actor, id: string, audit: AuditContext): Promise<KmEntry> {
+  const entry = await repoGetKmEntryById(id);
+  if (!entry) throw new HttpError(404, "HR_KM_NOT_FOUND", "Déclaration introuvable.");
+  const emp = await resolveEmployeeFromUser(actor.id);
+  if (entry.employee_id !== emp.id) throw new HttpError(403, "HR_FORBIDDEN", "Vous ne pouvez soumettre que vos déclarations.");
+  return withTransaction(async (client) => {
+    const updated = await repoSubmitKmEntry(client, id);
+    if (!updated) throw new HttpError(409, "HR_KM_NOT_DRAFT", "Déclaration déjà soumise ou traitée.");
+    await insertAuditLog(client, audit, { action: "temps-deplacements.km.submit", entity_type: "hr_kilometer_entries", entity_id: id, details: { status: "SUBMITTED" } });
+    return updated;
+  });
+}
+
+export async function decideKmEntry(actor: Actor, id: string, decision: "VALIDATED" | "REJECTED", audit: AuditContext): Promise<KmEntry> {
+  const entry = await repoGetKmEntryById(id);
+  if (!entry) throw new HttpError(404, "HR_KM_NOT_FOUND", "Déclaration introuvable.");
+  await assertCanManageEmployee(actor, entry.employee_id);
+  return withTransaction(async (client) => {
+    const updated = await repoDecideKmEntry(client, id, decision, actor.id);
+    if (!updated) throw new HttpError(409, "HR_KM_NOT_SUBMITTED", "La déclaration doit être soumise pour être traitée.");
+    await insertAuditLog(client, audit, {
+      action: decision === "VALIDATED" ? "temps-deplacements.km.validate" : "temps-deplacements.km.reject",
+      entity_type: "hr_kilometer_entries",
+      entity_id: id,
+      details: { decision },
+    });
+    return updated;
+  });
+}
+
+export async function listTeamKmEntries(actor: Actor, status?: HrKmStatus) {
+  return repoListTeamKmEntries({ managerUserId: actor.id, isPrivileged: isHrPrivileged(actor.role), status });
+}
+
+export async function listVehicles() {
+  return repoListVehicles();
+}
+export async function createVehicle(actor: Actor, input: { label: string; plate: string | null; owner_type: "COMPANY" | "PERSONAL" }, audit: AuditContext) {
+  if (!isHrPrivileged(actor.role)) throw new HttpError(403, "HR_FORBIDDEN", "Gestion des véhicules réservée.");
+  return withTransaction(async (client) => {
+    const v = await repoCreateVehicle(client, input);
+    await insertAuditLog(client, audit, { action: "temps-deplacements.vehicle.create", entity_type: "hr_vehicles", entity_id: v.id, details: { label: input.label } });
+    return v;
+  });
+}

--- a/src/module/temps-deplacements/services/temps-deplacements-rules.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-rules.ts
@@ -1,0 +1,169 @@
+// T5 — Moteur de règles (PUR, testable sans DB). Aucune valeur 35/39 en dur : tout vient soit d'un
+// hr_time_rule_sets, soit — à défaut — dérivé du contrat de l'employé (ses propres heures).
+
+export interface RoundingRule {
+  unit_minutes?: number; // pas d'arrondi si absent/0
+  mode?: "nearest" | "up" | "down";
+}
+export interface BreakRule {
+  min_break_minutes?: number; // pause minimale imposée
+  auto_deduct_after_minutes?: number; // au-delà de ce temps travaillé, la pause minimale est déduite
+}
+
+export interface HrRuleSet {
+  id: string;
+  name: string;
+  weekly_target_minutes: number;
+  daily_target_minutes: number;
+  overtime_threshold_1_minutes: number | null; // début heures sup taux 1 (défaut = cible hebdo)
+  overtime_rate_1: number | null; // ex. 1.25
+  overtime_threshold_2_minutes: number | null; // début heures sup taux 2
+  overtime_rate_2: number | null; // ex. 1.50
+  rounding_rule: RoundingRule;
+  break_rule: BreakRule;
+  active: boolean;
+}
+
+// Lignes brutes DB (numeric ⇒ string via pg).
+export interface ContractRow {
+  id: string;
+  contract_type: string;
+  weekly_hours_target: string | number;
+  daily_hours_target: string | number | null;
+  rule_set_id: string | null;
+}
+export interface RuleSetRow {
+  id: string;
+  name: string;
+  weekly_target_minutes: number;
+  daily_target_minutes: number;
+  overtime_threshold_1_minutes: number | null;
+  overtime_rate_1: string | number | null;
+  overtime_threshold_2_minutes: number | null;
+  overtime_rate_2: string | number | null;
+  rounding_rule: unknown;
+  break_rule: unknown;
+  active: boolean;
+}
+
+function toNum(v: unknown): number | null {
+  if (v === null || v === undefined) return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+export function parseRoundingRule(raw: unknown): RoundingRule {
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  const unit = toNum(r.unit_minutes);
+  const mode = r.mode === "up" || r.mode === "down" || r.mode === "nearest" ? r.mode : undefined;
+  return { ...(unit && unit > 0 ? { unit_minutes: unit } : {}), ...(mode ? { mode } : {}) };
+}
+export function parseBreakRule(raw: unknown): BreakRule {
+  const r = (raw && typeof raw === "object" ? raw : {}) as Record<string, unknown>;
+  const minB = toNum(r.min_break_minutes);
+  const after = toNum(r.auto_deduct_after_minutes);
+  return {
+    ...(minB && minB > 0 ? { min_break_minutes: minB } : {}),
+    ...(after && after > 0 ? { auto_deduct_after_minutes: after } : {}),
+  };
+}
+
+// Combine contrat + (éventuel) rule_set → règles effectives. Sans rule_set : dérive du CONTRAT
+// (heures propres du salarié ⇒ jamais de 35/39 codé en dur).
+export function effectiveRuleSetFromRows(contract: ContractRow, ruleSet: RuleSetRow | null): HrRuleSet {
+  if (ruleSet) {
+    return {
+      id: ruleSet.id,
+      name: ruleSet.name,
+      weekly_target_minutes: ruleSet.weekly_target_minutes,
+      daily_target_minutes: ruleSet.daily_target_minutes,
+      overtime_threshold_1_minutes: ruleSet.overtime_threshold_1_minutes,
+      overtime_rate_1: toNum(ruleSet.overtime_rate_1),
+      overtime_threshold_2_minutes: ruleSet.overtime_threshold_2_minutes,
+      overtime_rate_2: toNum(ruleSet.overtime_rate_2),
+      rounding_rule: parseRoundingRule(ruleSet.rounding_rule),
+      break_rule: parseBreakRule(ruleSet.break_rule),
+      active: ruleSet.active,
+    };
+  }
+  const weekly = Math.round((toNum(contract.weekly_hours_target) ?? 0) * 60);
+  const dailyRaw = toNum(contract.daily_hours_target);
+  const daily = dailyRaw != null ? Math.round(dailyRaw * 60) : weekly > 0 ? Math.round(weekly / 5) : 0;
+  return {
+    id: `contract:${contract.id}`,
+    name: `Dérivé du contrat (${contract.contract_type})`,
+    weekly_target_minutes: weekly,
+    daily_target_minutes: daily,
+    overtime_threshold_1_minutes: weekly > 0 ? weekly : null, // HS au-delà de la cible contractuelle
+    overtime_rate_1: 1.25,
+    overtime_threshold_2_minutes: null,
+    overtime_rate_2: null,
+    rounding_rule: {},
+    break_rule: {},
+    active: true,
+  };
+}
+
+// Arrondi du temps travaillé selon la règle (aucun si unit absent/0).
+export function applyRounding(minutes: number, rule: RoundingRule): number {
+  const unit = rule.unit_minutes ?? 0;
+  if (!unit || unit <= 0) return Math.max(0, Math.round(minutes));
+  const q = minutes / unit;
+  const rounded = rule.mode === "up" ? Math.ceil(q) : rule.mode === "down" ? Math.floor(q) : Math.round(q);
+  return Math.max(0, rounded * unit);
+}
+
+// Impose une pause minimale : au-delà de `auto_deduct_after_minutes` de travail, si la pause réelle est
+// inférieure au minimum, le déficit est déduit du temps travaillé.
+export function enforceMinimumBreak(workedMinutes: number, actualBreakMinutes: number, rule: BreakRule): number {
+  const minB = rule.min_break_minutes ?? 0;
+  const after = rule.auto_deduct_after_minutes ?? Number.POSITIVE_INFINITY;
+  if (minB > 0 && workedMinutes >= after && actualBreakMinutes < minB) {
+    return Math.max(0, workedMinutes - (minB - actualBreakMinutes));
+  }
+  return workedMinutes;
+}
+
+// Découpe le temps travaillé hebdo en normal / HS taux 1 (25) / HS taux 2 (50).
+export function splitWeeklyOvertime(
+  workedWeeklyMinutes: number,
+  rule: Pick<HrRuleSet, "weekly_target_minutes" | "overtime_threshold_1_minutes" | "overtime_threshold_2_minutes">
+): { normal: number; overtime25: number; overtime50: number } {
+  const t1 = rule.overtime_threshold_1_minutes ?? rule.weekly_target_minutes;
+  const t2 = rule.overtime_threshold_2_minutes ?? Number.POSITIVE_INFINITY;
+  const w = Math.max(0, workedWeeklyMinutes);
+  const normal = Math.min(w, t1);
+  const overtime25 = Math.max(0, Math.min(w, t2) - t1);
+  const overtime50 = Math.max(0, w - t2);
+  return { normal, overtime25, overtime50 };
+}
+
+// Temps travaillé effectif d'une journée : pause minimale imposée puis arrondi.
+export function effectiveDailyWorked(workedRaw: number, actualBreak: number, rule: HrRuleSet): number {
+  return applyRounding(enforceMinimumBreak(workedRaw, actualBreak, rule.break_rule), rule.rounding_rule);
+}
+
+// Agrégat hebdomadaire selon la règle. Sans règle (aucun contrat) : tout à zéro (pas d'attendu à juger).
+export function weeklyAggregate(
+  workedWeekly: number,
+  ruleSet: HrRuleSet | null
+): {
+  contract_minutes: number;
+  overtime_25_minutes: number;
+  overtime_50_minutes: number;
+  absence_minutes: number;
+  rule_set_name: string | null;
+} {
+  if (!ruleSet) {
+    return { contract_minutes: 0, overtime_25_minutes: 0, overtime_50_minutes: 0, absence_minutes: 0, rule_set_name: null };
+  }
+  const split = splitWeeklyOvertime(workedWeekly, ruleSet);
+  const contract = ruleSet.weekly_target_minutes;
+  return {
+    contract_minutes: contract,
+    overtime_25_minutes: split.overtime25,
+    overtime_50_minutes: split.overtime50,
+    absence_minutes: contract > 0 ? Math.max(0, contract - workedWeekly) : 0,
+    rule_set_name: ruleSet.name,
+  };
+}

--- a/src/module/temps-deplacements/services/temps-deplacements.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements.service.ts
@@ -1,0 +1,232 @@
+import crypto from "node:crypto";
+import { HttpError } from "../../../utils/httpError";
+import * as repo from "../repository/temps-deplacements.repository";
+import type { AuditContext } from "../repository/temps-deplacements.repository";
+import type {
+  CreateTimeEventInput,
+  CreateTimeEventResult,
+  HrDailyTimesheet,
+  HrEmployeeLite,
+  HrTimeAnomaly,
+  HrTimeEvent,
+  HrWeeklyTimesheet,
+} from "../types/temps-deplacements.types";
+
+// Seuils d'anomalie = défauts MVP (déplaçables dans hr_time_rule_sets en T5).
+// L'attendu contractuel (35h/39h) vient DÉJÀ de la base (repoGetDailyTargetMinutes) — jamais en dur.
+const DOUBLE_BADGE_WINDOW_MS = 90_000;
+const TOO_LONG_DAY_MINUTES = 12 * 60;
+const LONG_DAY_MINUTES = 6 * 60;
+const MIN_BREAK_MINUTES = 20;
+const TZ = "Europe/Paris";
+
+export function hashBadgeUid(uid: string): string {
+  return crypto.createHash("sha256").update(uid.trim()).digest("hex");
+}
+export function hashDeviceToken(token: string): string {
+  return crypto.createHash("sha256").update(token).digest("hex");
+}
+
+export function parisDay(iso: string | number | Date): string {
+  return new Date(iso).toLocaleDateString("en-CA", { timeZone: TZ }); // en-CA => YYYY-MM-DD
+}
+export function todayParis(): string {
+  return parisDay(Date.now());
+}
+function addDays(ymd: string, n: number): string {
+  const d = new Date(`${ymd}T12:00:00Z`);
+  d.setUTCDate(d.getUTCDate() + n);
+  return d.toISOString().slice(0, 10);
+}
+
+// -------------------------------------------------------------- Résolution employé
+export async function resolveEmployeeFromUser(userId: number): Promise<HrEmployeeLite> {
+  const emp = await repo.repoGetEmployeeByUserId(userId);
+  if (!emp) throw new HttpError(404, "HR_EMPLOYEE_NOT_FOUND", "Aucun employé n'est lié à ce compte.");
+  if (emp.status !== "ACTIVE") throw new HttpError(403, "HR_EMPLOYEE_INACTIVE", "Employé inactif.");
+  return emp;
+}
+
+export async function resolveEmployeeFromBadge(badgeUid: string): Promise<HrEmployeeLite> {
+  const found = await repo.repoFindBadge(hashBadgeUid(badgeUid));
+  if (!found) throw new HttpError(404, "HR_BADGE_UNKNOWN", "Badge inconnu.");
+  if (!found.active) throw new HttpError(403, "HR_BADGE_REVOKED", "Badge révoqué.");
+  if (found.employee.status !== "ACTIVE") throw new HttpError(403, "HR_EMPLOYEE_INACTIVE", "Employé inactif.");
+  return found.employee;
+}
+
+// -------------------------------------------------------------- Création d'événement (append-only)
+export async function createTimeEvent(input: CreateTimeEventInput, audit: AuditContext): Promise<CreateTimeEventResult> {
+  const result = await repo.withTransaction(async (client) => {
+    const evtTimeMs = input.event_time ? new Date(input.event_time).getTime() : Date.now();
+
+    // Double badge rapproché (même type, < fenêtre) — hors retry idempotent explicite.
+    if (!input.idempotency_key) {
+      const last = await repo.repoGetLastEvent(input.employee_id, client);
+      if (last && last.event_type === input.event_type) {
+        const delta = Math.abs(evtTimeMs - new Date(last.event_time).getTime());
+        if (delta < DOUBLE_BADGE_WINDOW_MS) {
+          await repo.repoInsertAnomaly(client, {
+            employee_id: input.employee_id,
+            date: parisDay(last.event_time),
+            anomaly_type: "DOUBLE_BADGE",
+            severity: "WARNING",
+            message: `Double badge ${input.event_type} rapproché ignoré`,
+          });
+          await repo.insertAuditLog(client, audit, {
+            action: input.source === "BADGE" ? "temps-deplacements.event.double_badge_badge" : "temps-deplacements.event.double_badge_web",
+            entity_type: "hr_time_events",
+            entity_id: last.id,
+            details: { event_type: input.event_type, source: input.source },
+          });
+          return { event: last, deduplicated: true, double_badge: true };
+        }
+      }
+    }
+
+    const inserted = await repo.repoInsertTimeEvent(client, input);
+    await repo.insertAuditLog(client, audit, {
+      action: input.source === "BADGE" ? "temps-deplacements.event.create_badge" : "temps-deplacements.event.create_web",
+      entity_type: "hr_time_events",
+      entity_id: inserted.event.id,
+      // JAMAIS de badge_uid/token/payload sensible dans l'audit.
+      details: { event_type: input.event_type, source: input.source, deduplicated: inserted.deduplicated },
+    });
+    return { event: inserted.event, deduplicated: inserted.deduplicated, double_badge: false };
+  });
+
+  // Recalcul du jour (best-effort ; ne doit jamais faire échouer l'enregistrement de l'événement).
+  try {
+    await computeDailyTimesheet(input.employee_id, parisDay(result.event.event_time));
+  } catch {
+    /* noop */
+  }
+  return result;
+}
+
+// -------------------------------------------------------------- Détection d'anomalies (pure)
+export function detectTimeAnomalies(
+  events: HrTimeEvent[],
+  ctx: { openBreak: boolean; workedMinutes: number; totalBreak: number; isPastDay: boolean }
+): Array<{ anomaly_type: HrTimeAnomaly["anomaly_type"]; severity: HrTimeAnomaly["severity"]; message: string }> {
+  const out: Array<{ anomaly_type: HrTimeAnomaly["anomaly_type"]; severity: HrTimeAnomaly["severity"]; message: string }> = [];
+  const hasIn = events.some((e) => e.event_type === "IN");
+  const hasOut = events.some((e) => e.event_type === "OUT");
+  if (hasOut && !hasIn) out.push({ anomaly_type: "MISSING_IN", severity: "WARNING", message: "Sortie sans entrée" });
+  // MISSING_OUT / MISSING_BREAK_END : uniquement sur un jour passé (aujourd'hui, une session ouverte est normale).
+  if (ctx.isPastDay && hasIn && !hasOut) out.push({ anomaly_type: "MISSING_OUT", severity: "WARNING", message: "Entrée sans sortie" });
+  if (ctx.isPastDay && ctx.openBreak) out.push({ anomaly_type: "MISSING_BREAK_END", severity: "WARNING", message: "Pause non terminée" });
+  if (ctx.workedMinutes > TOO_LONG_DAY_MINUTES) out.push({ anomaly_type: "TOO_LONG_DAY", severity: "WARNING", message: "Journée trop longue" });
+  if (ctx.workedMinutes >= LONG_DAY_MINUTES && ctx.totalBreak > 0 && ctx.totalBreak < MIN_BREAK_MINUTES) {
+    out.push({ anomaly_type: "TOO_SHORT_BREAK", severity: "INFO", message: "Pause trop courte" });
+  }
+  return out;
+}
+
+// Résumé PUR d'une journée à partir des événements bruts triés (testable sans DB).
+export function summarizeDay(events: HrTimeEvent[]): {
+  firstIn: string | null;
+  lastOut: string | null;
+  breakMinutes: number;
+  workedMinutes: number;
+  openBreak: boolean;
+} {
+  let firstIn: string | null = null;
+  let lastOut: string | null = null;
+  let totalBreak = 0;
+  let openBreakStart: number | null = null;
+  for (const e of events) {
+    const t = new Date(e.event_time).getTime();
+    switch (e.event_type) {
+      case "IN":
+        if (firstIn === null) firstIn = e.event_time;
+        break;
+      case "OUT":
+        lastOut = e.event_time;
+        break;
+      case "BREAK_START":
+        openBreakStart = t;
+        break;
+      case "BREAK_END":
+        if (openBreakStart !== null) {
+          totalBreak += Math.max(0, Math.round((t - openBreakStart) / 60000));
+          openBreakStart = null;
+        }
+        break;
+      default:
+        break; // MISSION_* : hors calcul de présence en T2 (traité en T6)
+    }
+  }
+  const openBreak = openBreakStart !== null;
+  const workedMinutes =
+    firstIn && lastOut
+      ? Math.max(0, Math.round((new Date(lastOut).getTime() - new Date(firstIn).getTime()) / 60000) - totalBreak)
+      : 0;
+  return { firstIn, lastOut, breakMinutes: totalBreak, workedMinutes, openBreak };
+}
+
+// -------------------------------------------------------------- Relevé journalier
+export async function computeDailyTimesheet(employeeId: string, date: string): Promise<HrDailyTimesheet> {
+  const events = await repo.repoListEventsForDay(employeeId, date);
+  const { firstIn, lastOut, breakMinutes: totalBreak, workedMinutes, openBreak } = summarizeDay(events);
+
+  const expected = await repo.repoGetDailyTargetMinutes(employeeId, date);
+  const overtime = Math.max(0, workedMinutes - expected);
+  const missing = Math.max(0, expected - workedMinutes);
+  const isPastDay = date < todayParis();
+
+  const descriptors = detectTimeAnomalies(events, { openBreak, workedMinutes, totalBreak, isPastDay });
+
+  await repo.withTransaction(async (client) => {
+    await repo.repoRefreshDayAnomalies(client, employeeId, date, descriptors);
+    await repo.repoUpsertTimesheetDay(client, {
+      employee_id: employeeId,
+      date,
+      expected_minutes: expected,
+      worked_minutes: workedMinutes,
+      overtime_minutes: overtime,
+      missing_minutes: missing,
+      anomaly_count: descriptors.length,
+    });
+  });
+
+  const anomalies = await repo.repoListAnomalies(employeeId, { date });
+  const status: HrDailyTimesheet["status"] = anomalies.some((a) => a.resolved_at === null) ? "ANOMALY" : "OK";
+  return {
+    employee_id: employeeId,
+    date,
+    first_in: firstIn,
+    last_out: lastOut,
+    break_minutes: totalBreak,
+    worked_minutes: workedMinutes,
+    expected_minutes: expected,
+    overtime_minutes: overtime,
+    missing_minutes: missing,
+    status,
+    anomalies,
+  };
+}
+
+// -------------------------------------------------------------- Relevé hebdomadaire
+export async function computeWeeklyTimesheet(employeeId: string, weekStart: string): Promise<HrWeeklyTimesheet> {
+  const days: HrDailyTimesheet[] = [];
+  for (let i = 0; i < 7; i++) {
+    days.push(await computeDailyTimesheet(employeeId, addDays(weekStart, i)));
+  }
+  const worked = days.reduce((s, d) => s + d.worked_minutes, 0);
+  const expected = days.reduce((s, d) => s + d.expected_minutes, 0);
+  return {
+    employee_id: employeeId,
+    week_start: weekStart,
+    week_end: addDays(weekStart, 6),
+    worked_minutes: worked,
+    contract_minutes: expected,
+    overtime_minutes: Math.max(0, worked - expected),
+    absence_minutes: Math.max(0, expected - worked),
+    days,
+  };
+}
+
+export async function listMyAnomalies(employeeId: string, filters: { date?: string; from?: string; to?: string }): Promise<HrTimeAnomaly[]> {
+  return repo.repoListAnomalies(employeeId, filters);
+}

--- a/src/module/temps-deplacements/services/temps-deplacements.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements.service.ts
@@ -2,6 +2,8 @@ import crypto from "node:crypto";
 import { HttpError } from "../../../utils/httpError";
 import * as repo from "../repository/temps-deplacements.repository";
 import type { AuditContext } from "../repository/temps-deplacements.repository";
+import { repoGetEffectiveRuleSet, repoUpsertTimesheetWeek } from "../repository/temps-deplacements-rules.repository";
+import { effectiveDailyWorked, weeklyAggregate } from "./temps-deplacements-rules";
 import type {
   CreateTimeEventInput,
   CreateTimeEventResult,
@@ -168,11 +170,15 @@ export function summarizeDay(events: HrTimeEvent[]): {
 // -------------------------------------------------------------- Relevé journalier
 export async function computeDailyTimesheet(employeeId: string, date: string): Promise<HrDailyTimesheet> {
   const events = await repo.repoListEventsForDay(employeeId, date);
-  const { firstIn, lastOut, breakMinutes: totalBreak, workedMinutes, openBreak } = summarizeDay(events);
+  const { firstIn, lastOut, breakMinutes: totalBreak, workedMinutes: workedRaw, openBreak } = summarizeDay(events);
 
-  const expected = await repo.repoGetDailyTargetMinutes(employeeId, date);
-  const overtime = Math.max(0, workedMinutes - expected);
-  const missing = Math.max(0, expected - workedMinutes);
+  // Règles effectives (contrat couvrant la date + rule_set éventuel) — jamais 35/39 en dur.
+  const ruleSet = await repoGetEffectiveRuleSet(employeeId, date);
+  const expected = ruleSet ? ruleSet.daily_target_minutes : 0;
+  // Pause minimale imposée + arrondi selon la règle (sinon temps brut).
+  const workedMinutes = ruleSet ? effectiveDailyWorked(workedRaw, totalBreak, ruleSet) : workedRaw;
+  const overtime = expected > 0 ? Math.max(0, workedMinutes - expected) : 0;
+  const missing = expected > 0 ? Math.max(0, expected - workedMinutes) : 0;
   const isPastDay = date < todayParis();
 
   const descriptors = detectTimeAnomalies(events, { openBreak, workedMinutes, totalBreak, isPastDay });
@@ -214,15 +220,41 @@ export async function computeWeeklyTimesheet(employeeId: string, weekStart: stri
     days.push(await computeDailyTimesheet(employeeId, addDays(weekStart, i)));
   }
   const worked = days.reduce((s, d) => s + d.worked_minutes, 0);
-  const expected = days.reduce((s, d) => s + d.expected_minutes, 0);
+  const weekEnd = addDays(weekStart, 6);
+
+  // Règles effectives de la semaine (contrat au lundi) → cible hebdo + découpe HS 25/50 configurable.
+  const ruleSet = await repoGetEffectiveRuleSet(employeeId, weekStart);
+  const agg = weeklyAggregate(worked, ruleSet);
+
+  // Persistance de l'agrégat hebdo (nécessaire à la validation T4 ; DRAFT uniquement).
+  try {
+    await repo.withTransaction((client) =>
+      repoUpsertTimesheetWeek(client, {
+        employee_id: employeeId,
+        week_start: weekStart,
+        week_end: weekEnd,
+        contract_minutes: agg.contract_minutes,
+        worked_minutes: worked,
+        overtime_25_minutes: agg.overtime_25_minutes,
+        overtime_50_minutes: agg.overtime_50_minutes,
+        absence_minutes: agg.absence_minutes,
+      })
+    );
+  } catch {
+    /* best-effort : ne bloque jamais la lecture du relevé */
+  }
+
   return {
     employee_id: employeeId,
     week_start: weekStart,
-    week_end: addDays(weekStart, 6),
+    week_end: weekEnd,
     worked_minutes: worked,
-    contract_minutes: expected,
-    overtime_minutes: Math.max(0, worked - expected),
-    absence_minutes: Math.max(0, expected - worked),
+    contract_minutes: agg.contract_minutes,
+    overtime_minutes: agg.overtime_25_minutes + agg.overtime_50_minutes,
+    overtime_25_minutes: agg.overtime_25_minutes,
+    overtime_50_minutes: agg.overtime_50_minutes,
+    absence_minutes: agg.absence_minutes,
+    rule_set_name: agg.rule_set_name,
     days,
   };
 }

--- a/src/module/temps-deplacements/types/temps-deplacements.types.ts
+++ b/src/module/temps-deplacements/types/temps-deplacements.types.ts
@@ -1,0 +1,88 @@
+// Module « Temps & Déplacements » — T2 backend pointage. Types du domaine.
+// hr_time_events est append-only : jamais d'UPDATE/DELETE (corrections via hr_time_adjustments, T4).
+
+export type HrEventType = "IN" | "OUT" | "BREAK_START" | "BREAK_END" | "MISSION_START" | "MISSION_END";
+export type HrEventSource = "BADGE" | "WEB" | "MOBILE" | "ADMIN" | "IMPORT";
+export type HrAnomalyType =
+  | "MISSING_IN"
+  | "MISSING_OUT"
+  | "MISSING_BREAK_END"
+  | "DOUBLE_BADGE"
+  | "TOO_LONG_DAY"
+  | "TOO_SHORT_BREAK"
+  | "OUTSIDE_SCHEDULE";
+export type HrAnomalySeverity = "INFO" | "WARNING" | "CRITICAL";
+
+export interface HrEmployeeLite {
+  id: string;
+  user_id: number;
+  matricule: string;
+  service: string | null;
+  manager_user_id: number | null;
+  status: "ACTIVE" | "SUSPENDED" | "LEFT";
+}
+
+export interface HrTimeEvent {
+  id: string;
+  employee_id: string;
+  device_id: string | null;
+  event_type: HrEventType;
+  event_time: string;
+  source: HrEventSource;
+  created_at: string;
+}
+
+export interface HrTimeAnomaly {
+  id: string;
+  employee_id: string;
+  date: string;
+  anomaly_type: HrAnomalyType;
+  severity: HrAnomalySeverity;
+  message: string | null;
+  resolved_by: number | null;
+  resolved_at: string | null;
+  created_at: string;
+}
+
+// Relevé journalier calculé à partir des événements bruts (jamais persisté comme source de vérité :
+// les événements le sont ; ceci est un agrégat recalculable — hr_work_sessions / hr_timesheet_days).
+export interface HrDailyTimesheet {
+  employee_id: string;
+  date: string;
+  first_in: string | null;
+  last_out: string | null;
+  break_minutes: number;
+  worked_minutes: number;
+  expected_minutes: number;
+  overtime_minutes: number;
+  missing_minutes: number;
+  status: "OK" | "ANOMALY" | "MANUAL_REVIEW" | "VALIDATED";
+  anomalies: HrTimeAnomaly[];
+}
+
+export interface HrWeeklyTimesheet {
+  employee_id: string;
+  week_start: string;
+  week_end: string;
+  worked_minutes: number;
+  contract_minutes: number;
+  overtime_minutes: number;
+  absence_minutes: number;
+  days: HrDailyTimesheet[];
+}
+
+export interface CreateTimeEventInput {
+  employee_id: string;
+  event_type: HrEventType;
+  event_time?: string;
+  source: HrEventSource;
+  device_id?: string | null;
+  idempotency_key?: string | null;
+  raw_payload?: Record<string, unknown>;
+}
+
+export interface CreateTimeEventResult {
+  event: HrTimeEvent;
+  deduplicated: boolean; // true si idempotency_key déjà vu (aucune nouvelle ligne)
+  double_badge: boolean; // true si double badge rapproché détecté (anomalie enregistrée)
+}

--- a/src/module/temps-deplacements/types/temps-deplacements.types.ts
+++ b/src/module/temps-deplacements/types/temps-deplacements.types.ts
@@ -66,8 +66,11 @@ export interface HrWeeklyTimesheet {
   week_end: string;
   worked_minutes: number;
   contract_minutes: number;
-  overtime_minutes: number;
+  overtime_minutes: number; // total HS (= 25 + 50), rétro-compat
+  overtime_25_minutes: number; // T5 — HS taux 1 (règle configurable)
+  overtime_50_minutes: number; // T5 — HS taux 2
   absence_minutes: number;
+  rule_set_name: string | null; // règle appliquée (traçabilité)
   days: HrDailyTimesheet[];
 }
 

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -116,5 +116,12 @@ export const scheduleBodySchema = z
 export type ScheduleBody = z.infer<typeof scheduleBodySchema>;
 
 export const setActiveSchema = z.object({ active: z.boolean() }).strict();
+
+// --- T7 : exports paie ---
+export const HR_EXPORT_FORMATS = ["CSV", "PDF"] as const;
+export const exportBodySchema = z
+  .object({ period_start: dateOnly, period_end: dateOnly, format: z.enum(HR_EXPORT_FORMATS) })
+  .strict();
+export type ExportBody = z.infer<typeof exportBodySchema>;
 export const listContractsQuerySchema = z.object({ employee_id: z.string().uuid().optional() });
 export const listSchedulesQuerySchema = z.object({ employee_id: z.string().uuid("employee_id (uuid) requis") });

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -64,3 +64,57 @@ export type CreateAdjustmentBody = z.infer<typeof createAdjustmentSchema>;
 
 export const uuidParamsSchema = z.object({ id: z.string().uuid("id (uuid) attendu") });
 export const teamAnomaliesQuerySchema = z.object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional() });
+
+// --- T5 : admin RH (règles / contrats / horaires) ---
+const nonNegInt = z.number().int().min(0);
+const timeOfDay = z.string().regex(/^\d{2}:\d{2}(:\d{2})?$/, "Heure attendue HH:MM").nullable();
+
+export const HR_CONTRACT_TYPES = ["H35", "H39", "PARTIAL", "OTHER"] as const;
+
+// Règle de calcul — JAMAIS de 35/39 en dur : les cibles sont saisies ici (minutes).
+export const ruleSetBodySchema = z
+  .object({
+    name: z.string().trim().min(2).max(200),
+    weekly_target_minutes: nonNegInt.max(10080), // ≤ 7j
+    daily_target_minutes: nonNegInt.max(1440),
+    overtime_threshold_1_minutes: nonNegInt.max(10080).nullable().default(null),
+    overtime_rate_1: z.number().min(1).max(5).nullable().default(null),
+    overtime_threshold_2_minutes: nonNegInt.max(10080).nullable().default(null),
+    overtime_rate_2: z.number().min(1).max(5).nullable().default(null),
+    rounding_rule: z.record(z.unknown()).default({}),
+    break_rule: z.record(z.unknown()).default({}),
+  })
+  .strict();
+export type RuleSetBody = z.infer<typeof ruleSetBodySchema>;
+
+export const contractBodySchema = z
+  .object({
+    employee_id: z.string().uuid(),
+    contract_type: z.enum(HR_CONTRACT_TYPES),
+    weekly_hours_target: z.number().min(0).max(168),
+    daily_hours_target: z.number().min(0).max(24).nullable().default(null),
+    start_date: dateOnly,
+    end_date: dateOnly.nullable().default(null),
+    rule_set_id: z.string().uuid().nullable().default(null),
+    active: z.boolean().default(true),
+  })
+  .strict();
+export type ContractBody = z.infer<typeof contractBodySchema>;
+
+export const scheduleBodySchema = z
+  .object({
+    employee_id: z.string().uuid(),
+    day_of_week: z.number().int().min(0).max(6),
+    expected_start: timeOfDay.default(null),
+    expected_end: timeOfDay.default(null),
+    expected_break_minutes: nonNegInt.max(1440).default(0),
+    flexible_start_window: nonNegInt.max(240).default(0),
+    flexible_end_window: nonNegInt.max(240).default(0),
+    active: z.boolean().default(true),
+  })
+  .strict();
+export type ScheduleBody = z.infer<typeof scheduleBodySchema>;
+
+export const setActiveSchema = z.object({ active: z.boolean() }).strict();
+export const listContractsQuerySchema = z.object({ employee_id: z.string().uuid().optional() });
+export const listSchedulesQuerySchema = z.object({ employee_id: z.string().uuid("employee_id (uuid) requis") });

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -46,3 +46,21 @@ export const meAnomaliesQuerySchema = z.object({
   to: dateOnly.optional(),
 });
 export const employeeIdParamsSchema = z.object({ id: z.string().uuid("employee id (uuid) attendu") });
+
+// --- T4 : corrections tracées + validation ---
+export const HR_ADJUSTMENT_TARGETS = ["EVENT", "DAY", "WEEK"] as const;
+
+// Le salarié demande une correction SUR SES PROPRES données (motif OBLIGATOIRE).
+export const createAdjustmentSchema = z
+  .object({
+    target_type: z.enum(HR_ADJUSTMENT_TARGETS),
+    target_id: z.string().uuid("target_id (uuid) attendu"),
+    reason: z.string().trim().min(3, "Motif obligatoire (min 3 caractères)").max(2000),
+    old_value: z.record(z.unknown()).optional(),
+    new_value: z.record(z.unknown()).optional(),
+  })
+  .strict();
+export type CreateAdjustmentBody = z.infer<typeof createAdjustmentSchema>;
+
+export const uuidParamsSchema = z.object({ id: z.string().uuid("id (uuid) attendu") });
+export const teamAnomaliesQuerySchema = z.object({ date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional() });

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -160,6 +160,29 @@ export const vehicleBodySchema = z
   .strict();
 export type VehicleBody = z.infer<typeof vehicleBodySchema>;
 
+// --- T8 : bornes & badges ---
+export const deviceBodySchema = z
+  .object({
+    name: z.string().trim().min(1).max(200),
+    location: z.string().trim().max(300).nullable().default(null),
+    device_type: z.string().trim().max(100).nullable().default(null),
+  })
+  .strict();
+export type DeviceBody = z.infer<typeof deviceBodySchema>;
+
+export const deviceStatusSchema = z.object({ status: z.enum(["ACTIVE", "DISABLED"]) }).strict();
+
+export const badgeBodySchema = z
+  .object({
+    employee_id: z.string().uuid(),
+    badge_uid: z.string().trim().min(1, "badge_uid requis").max(256),
+    badge_label: z.string().trim().max(200).nullable().default(null),
+  })
+  .strict();
+export type BadgeBody = z.infer<typeof badgeBodySchema>;
+
+export const listBadgesQuerySchema = z.object({ employee_id: z.string().uuid().optional() });
+
 // --- T7 : exports paie ---
 export const HR_EXPORT_FORMATS = ["CSV", "PDF"] as const;
 export const exportBodySchema = z

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -117,6 +117,49 @@ export type ScheduleBody = z.infer<typeof scheduleBodySchema>;
 
 export const setActiveSchema = z.object({ active: z.boolean() }).strict();
 
+// --- T6 : kilomètres ---
+export const HR_KM_TYPES = ["MISSION", "CLIENT", "FOURNISSEUR", "LIVRAISON", "AUTRE"] as const;
+export const HR_KM_STATUSES = ["DRAFT", "SUBMITTED", "VALIDATED", "REJECTED"] as const;
+
+// ANTI-IDOR : aucun employee_id (l'employé vient de req.user).
+export const createKmSchema = z
+  .object({
+    date: dateOnly,
+    type: z.enum(HR_KM_TYPES).default("MISSION"),
+    vehicle_id: z.string().uuid().nullable().default(null),
+    start_location: z.string().trim().max(300).nullable().default(null),
+    end_location: z.string().trim().max(300).nullable().default(null),
+    start_odometer: z.number().min(0).max(9_999_999).nullable().default(null),
+    end_odometer: z.number().min(0).max(9_999_999).nullable().default(null),
+    distance_km: z.number().min(0).max(100_000).default(0),
+    affaire_id: z.number().int().positive().nullable().default(null),
+    client_id: z.number().int().positive().nullable().default(null),
+    fournisseur_id: z.number().int().positive().nullable().default(null),
+    submit: z.boolean().default(false),
+  })
+  .strict()
+  .refine((v) => v.start_odometer == null || v.end_odometer == null || v.end_odometer >= v.start_odometer, {
+    message: "Odomètre d'arrivée < départ.",
+    path: ["end_odometer"],
+  });
+export type CreateKmBody = z.infer<typeof createKmSchema>;
+
+export const myKmQuerySchema = z.object({
+  from: dateOnly.optional(),
+  to: dateOnly.optional(),
+  status: z.enum(HR_KM_STATUSES).optional(),
+});
+export const teamKmQuerySchema = z.object({ status: z.enum(HR_KM_STATUSES).optional() });
+
+export const vehicleBodySchema = z
+  .object({
+    label: z.string().trim().min(1).max(200),
+    plate: z.string().trim().max(20).nullable().default(null),
+    owner_type: z.enum(["COMPANY", "PERSONAL"]).default("COMPANY"),
+  })
+  .strict();
+export type VehicleBody = z.infer<typeof vehicleBodySchema>;
+
 // --- T7 : exports paie ---
 export const HR_EXPORT_FORMATS = ["CSV", "PDF"] as const;
 export const exportBodySchema = z

--- a/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
+++ b/src/module/temps-deplacements/validators/temps-deplacements.validators.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+
+// Validateurs T2. Convention repo : parse contrôleur (schema.parse(req.body/query/params)),
+// DTOs via z.infer. ANTI-IDOR : les schémas salarié ne contiennent JAMAIS d'employee_id
+// (l'employé est dérivé de req.user côté serveur).
+
+export const HR_EVENT_TYPES = ["IN", "OUT", "BREAK_START", "BREAK_END", "MISSION_START", "MISSION_END"] as const;
+
+const eventTime = z.string().datetime({ offset: true }).optional(); // ISO 8601 ; défaut = now serveur
+const dateOnly = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date attendue au format YYYY-MM-DD");
+
+// POST /time-clock/events (salarié) — aucun employee_id.
+export const createTimeEventSchema = z
+  .object({
+    event_type: z.enum(HR_EVENT_TYPES, { errorMap: () => ({ message: "event_type invalide" }) }),
+    event_time: eventTime,
+  })
+  .strict();
+export type CreateTimeEventBody = z.infer<typeof createTimeEventSchema>;
+
+// POST /time-clock/device-events (borne) — idempotency_key OBLIGATOIRE ; badge_uid brut (haché serveur, jamais loggé).
+export const deviceEventSchema = z
+  .object({
+    badge_uid: z.string().min(1, "badge_uid requis").max(256),
+    event_type: z.enum(HR_EVENT_TYPES, { errorMap: () => ({ message: "event_type invalide" }) }),
+    event_time: eventTime,
+    idempotency_key: z.string().min(8, "idempotency_key requis (min 8 caractères)").max(200),
+    device_token: z.string().min(1).max(512).optional(),
+  })
+  .strict();
+export type DeviceEventBody = z.infer<typeof deviceEventSchema>;
+
+// POST /time-clock/device-heartbeat (borne).
+export const deviceHeartbeatSchema = z
+  .object({
+    device_token: z.string().min(1, "device_token requis").max(512),
+  })
+  .strict();
+export type DeviceHeartbeatBody = z.infer<typeof deviceHeartbeatSchema>;
+
+export const meTodayQuerySchema = z.object({ date: dateOnly.optional() });
+export const meWeekQuerySchema = z.object({ week_start: dateOnly.optional() });
+export const meAnomaliesQuerySchema = z.object({
+  date: dateOnly.optional(),
+  from: dateOnly.optional(),
+  to: dateOnly.optional(),
+});
+export const employeeIdParamsSchema = z.object({ id: z.string().uuid("employee id (uuid) attendu") });

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -38,6 +38,7 @@ import usersRoutes from "../module/users/routes/users.routes";
 import traceabilityRoutes from "../module/traceability/routes/traceability.routes"
 import asbuiltRoutes from "../module/asbuilt/routes/asbuilt.routes"
 import locksRoutes from "../module/locks/routes/locks.routes"
+import tempsDeplacementsRoutes from "../module/temps-deplacements/routes/temps-deplacements.routes"
 import gammesRoutes from "../module/gammes/routes/gammes.routes"
 import pieceTechniqueVersionsRoutes from "../module/gammes/routes/piece-technique-versions.routes"
 const router = Router()
@@ -87,4 +88,5 @@ router.use("/users", usersRoutes);
 router.use("/traceability", traceabilityRoutes)
 router.use("/asbuilt", asbuiltRoutes)
 router.use("/locks", locksRoutes)
+router.use("/time-clock", tempsDeplacementsRoutes) // Module « Temps & Déplacements » (RH pointage/kilomètres)
 export default router


### PR DESCRIPTION
## Release prod pilote — Module Temps & Déplacements (#119)

Décision projet : **déploiement validé sans recette navigateur UI complète**, risque résiduel accepté par le responsable projet. Validation retenue : tests unitaires (**255 back**), typecheck/lint/build, **smokes SQL cerp_test** (dont chaîne E2E complète 0 résidu) + validations service/DB.

**Contenu** : 19 commits, **100 % #119** (T1 DB → T11 rapport). Hors module : `user.validator.ts` (+rôle Responsable RH), `v1.routes.ts` (montage `/time-clock`) — points d'intégration requis.

**DB prod** : `cerp_prod` **déjà migrée + vérifiée** ce jour (15 tables, append-only 3 triggers + grants, Responsable RH, no-self-approve, idempotency). Backup frais : `cerp_prod_main_release_20260710-090525.dump`.

**Sécurité** : socle `authenticateToken` + RBAC (salarié = ses données, responsable = périmètre, admin privilégié) ; append-only ; secrets hachés. Garde front pilote (menu limité RH/Direction/Admin).

Merge = mise en prod pilote maîtrisée.