### PR TITLE
fix: preserve least-privilege VSM migration

### DIFF
--- a/db/patches/20260713_codification_versions_of_vsm.sql
+++ b/db/patches/20260713_codification_versions_of_vsm.sql
@@ -462,8 +462,6 @@ CREATE TRIGGER trg_prevent_quality_control_reference_mutation
   FOR EACH ROW EXECUTE FUNCTION public.fn_prevent_quality_control_reference_mutation();
 
 -- Project Office keeps evidence metadata in PostgreSQL and the binary in controlled storage.
-ALTER TYPE public.po_evidence_type ADD VALUE IF NOT EXISTS 'VSM';
-
 CREATE TABLE IF NOT EXISTS public.project_evidence_files (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   evidence_id uuid NOT NULL UNIQUE REFERENCES public.project_evidence(id) ON DELETE CASCADE,

--- a/db/patches/support/20260713_codification_versions_of_vsm.rollback.sql
+++ b/db/patches/support/20260713_codification_versions_of_vsm.rollback.sql
@@ -103,8 +103,4 @@ DROP TABLE IF EXISTS public.codification_141_sequence_baseline;
 DROP FUNCTION IF EXISTS public.fn_next_issued_code_value(text);
 DROP SEQUENCE IF EXISTS public.cerp_business_code_issue_seq;
 
--- PostgreSQL enum values cannot be safely removed in a transactional rollback.
--- `po_evidence_type.VSM` is additive and intentionally remains after a safe
--- structural rollback.
-
 COMMIT;

--- a/db/patches/support/20260713_codification_versions_of_vsm.verify.sql
+++ b/db/patches/support/20260713_codification_versions_of_vsm.verify.sql
@@ -64,7 +64,10 @@ WHERE schemaname = 'public'
   )
 ORDER BY indexname;
 
-SELECT unnest(enum_range(NULL::public.po_evidence_type))::text AS evidence_type;
+SELECT conname, pg_get_constraintdef(oid) AS definition
+FROM pg_constraint
+WHERE conrelid = 'public.project_evidence_files'::regclass
+  AND conname = 'project_evidence_files_category_check';
 
 SELECT last_value, is_called FROM public.cerp_business_code_issue_seq;
 

--- a/docs/codification-versions-vsm-api.md
+++ b/docs/codification-versions-vsm-api.md
@@ -49,6 +49,9 @@ Le formulaire multipart accepte `file`, `category` (`VSM` ou `DOCUMENT`), `versi
 La taille maximale est 25 MiB. Sont contrôlés : extension, MIME annoncé, signature réelle, structure
 des archives Bizagi BPM et OOXML, empreinte SHA-256 et doublon dans le projet. Les binaires vivent sous
 `CERP_DOCUMENTS_ROOT`; seuls métadonnées et chemin interne sont en base et ce chemin n'est jamais exposé.
+La catégorie `VSM|DOCUMENT` est contrainte sur `project_evidence_files` et ne modifie pas l'enum
+historique `po_evidence_type`, afin que le patch reste exécutable par le rôle runtime propriétaire
+des tables sans élévation permanente.
 
 ## Erreurs attendues
 

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -90,5 +90,7 @@ instance; the API refuses evidence storage when production lacks that setting.
 The companion rollback script is deliberately guarded and refuses to remove
 post-migration technical versions/metadata, code allocations, quality-control
 references, retained OF snapshots, or Project Office evidence. The additive
-`po_evidence_type.VSM` enum value remains because PostgreSQL cannot safely
-remove enum values in a transactional rollback.
+The VSM file category is enforced by the dedicated
+`project_evidence_files_category_check` table constraint. The patch deliberately
+does not alter the historical `po_evidence_type` enum, which can be owned by the
+administrative PostgreSQL role while runtime patches are executed by `cerp_app`.


### PR DESCRIPTION
Corrige le blocage détecté au préflight de l'issue #141 : l'enum historique appartient à postgres alors que la table de fichiers et son contrôle VSM|DOCUMENT sont autonomes.

- aucune modification de l'enum administratif
- contrainte dédiée vérifiée
- rollback et documentation alignés
- build et suite Vitest complète verts

## Summary by Sourcery

Preserve least-privilege execution of the VSM codification patch by relying on a dedicated table constraint instead of modifying the shared po_evidence_type enum, and align verification, rollback, and documentation with this behavior.

Enhancements:
- Replace verification of po_evidence_type enum contents with a check on the project_evidence_files_category_check constraint.
- Clarify database patch documentation to state that VSM/DOCUMENT categories are enforced via a table constraint without altering the historical po_evidence_type enum.
- Remove obsolete rollback comments about retaining the po_evidence_type.VSM enum value.

Documentation:
- Update API documentation to explain that VSM|DOCUMENT categories are enforced on project_evidence_files and do not require permanent privilege elevation on the enum owner.