### PR TITLE
release: activer l'orchestration des commandes internes

### DIFF
--- a/docs/frontend_repo_map.md
+++ b/docs/frontend_repo_map.md
@@ -362,7 +362,7 @@ POST	/api/v1/commandes/:id/affaires/preview	validate(idParamSchema)	validate(idP
 POST	/api/v1/commandes/:id/analyze-stock	authenticateToken, validate(idParamSchema)	validate(idParamSchema)
 GET	/api/v1/commandes/:id/documents/:docId/file	validate(documentIdParamSchema)	validate(documentIdParamSchema)
 POST	/api/v1/commandes/:id/duplicate	validate(idParamSchema)	validate(idParamSchema)
-POST	/api/v1/commandes/:id/generate-affaires	authenticateToken, validate(generateAffairesV3Schema)	validate(generateAffairesV3Schema)
+POST	/api/v1/commandes/:id/generate-affaires	authenticateToken, validate(generateAffairesV3Schema)	validate(generateAffairesV3Schema) + internal-order role/invariant checks in repository
 POST	/api/v1/commandes/:id/generate-affaires/confirm	validate(confirmGenerateAffairesSchema)	validate(confirmGenerateAffairesSchema)
 GET	/api/v1/commandes/:id/releases	validate(idParamSchema)	validate(idParamSchema)
 POST	/api/v1/commandes/:id/releases	validate(idParamSchema)	validate(idParamSchema)
@@ -714,6 +714,7 @@ Foreign keys are defined extensively in patches (hundreds). Examples of central 
   - `requireAdmin` in `src/module/production/routes/production.routes.ts` and `src/module/pieces-techniques/routes/pieces-techniques.routes.ts`
   - `requireProductionOrAdmin` in `src/module/production/routes/production.routes.ts`, `src/module/planning/routes/planning.routes.ts`, `src/module/programmation/routes/programmation.routes.ts`
   - `requireQualityOrAdmin` in `src/module/qualite/routes/qualite.routes.ts`
+  - internal-order launch authorization in `src/module/commande-client/repository/commande-client.repository.ts` after locking and identifying the order type
 
 ### Socket.IO
 

--- a/docs/http/commande-interne.md
+++ b/docs/http/commande-interne.md
@@ -1,0 +1,115 @@
+# Commande interne : validation et lancement
+
+Ce document décrit le contrat backend du flux cible de commande interne. Il complète la décision fonctionnelle portée par l'issue frontend `crp-systems-web#153` et l'issue backend `erp-crp-backend#85`.
+
+## Objectif
+
+Une commande dont `order_type = INTERNE` est le point d'entrée unique du besoin interne. Sa validation génère, dans une seule transaction :
+
+1. exactement une affaire de livraison ;
+2. les allocations de toutes les lignes ;
+3. un OF racine par ligne et les OF enfants issus de la nomenclature ;
+4. le passage du workflow à `ATTENTE_PLANNING` ;
+5. les événements et l'audit associés.
+
+Le flux ne génère ni AR client, ni facture, ni BL. Le BL reste un résultat ultérieur du processus logistique, après libération qualité.
+
+## Endpoint
+
+`POST /api/v1/commandes/:id/generate-affaires`
+
+La route exige une session authentifiée. Pour une commande interne, le lancement est réservé à un rôle d'administration, de direction ou de responsabilité production/atelier.
+
+Requête canonique :
+
+```json
+{
+  "decision": null,
+  "livraison_count": 1,
+  "lines": []
+}
+```
+
+Les choix de stock d'expédition et les découpages en plusieurs affaires restent disponibles pour les commandes client historiques, mais sont interdits pour les commandes internes.
+
+## Préconditions internes
+
+- la commande contient au moins une ligne ;
+- chaque ligne référence une `piece_technique_id` applicable ;
+- une seule destination interne est définie par `dest_stock_magasin_id` et `dest_stock_emplacement_id` ;
+- la destination correspond à un emplacement de stock existant ;
+- l'utilisateur possède un rôle autorisé ;
+- aucune génération précédente incohérente n'est déjà liée à la commande.
+
+L'absence de stock disponible ne réduit pas le besoin à fabriquer : la quantité complète demandée alimente les OF.
+
+## Réponse
+
+Exemple simplifié :
+
+```json
+{
+  "affaire_ids": [7],
+  "livraison_affaire_id": 7,
+  "livraison_affaire_ids": [7],
+  "generation_mode": "INTERNAL_ORDER",
+  "idempotent_replay": false,
+  "workflow_status": "ATTENTE_PLANNING",
+  "of_ids": [9, 10],
+  "root_of_ids": [9],
+  "child_of_ids": [10],
+  "ofs": [
+    {
+      "id": 9,
+      "root_of_id": 9,
+      "parent_of_id": null,
+      "generation_level": 0,
+      "commande_ligne_id": 1
+    },
+    {
+      "id": 10,
+      "root_of_id": 9,
+      "parent_of_id": 9,
+      "generation_level": 1,
+      "commande_ligne_id": 1
+    }
+  ],
+  "warnings": []
+}
+```
+
+`ofs` expose la topologie utile au frontend sans obliger celui-ci à reconstruire la hiérarchie.
+
+## Idempotence
+
+Une nouvelle demande après génération ne crée ni affaire ni OF supplémentaire. La réponse contient les identifiants et la topologie existants avec `idempotent_replay = true`.
+
+Une ancienne commande interne possédant plusieurs affaires de livraison peut être relue, mais renvoie l'avertissement `LEGACY_MULTIPLE_DELIVERY_AFFAIRS`. Cette tolérance ne permet pas de créer un nouveau découpage.
+
+## Erreurs métier principales
+
+| Statut | Code | Signification |
+| --- | --- | --- |
+| 403 | `INTERNAL_ORDER_LAUNCH_FORBIDDEN` | rôle insuffisant pour lancer la commande interne |
+| 400 | `INTERNAL_ORDER_SINGLE_AFFAIRE_REQUIRED` | `livraison_count` différent de 1 |
+| 400 | `INTERNAL_ORDER_STOCK_DECISION_FORBIDDEN` | décision ou surcharge de stock fournie |
+| 400 | `INTERNAL_ORDER_LINE_REQUIRED` | aucune ligne à fabriquer |
+| 400 | `PIECE_TECHNIQUE_REQUIRED` | pièce technique absente sur une ligne |
+| 400 | `DEST_STOCK_LOCATION_REQUIRED` | destination interne absente ou invalide |
+| 409 | `INTERNAL_ORDER_AFFAIRE_MAPPING_INVALID` | liaison historique d'affaire incompatible |
+
+## Traçabilité
+
+Le succès écrit notamment :
+
+- l'événement `AFFAIRES_GENERATED` commun au flux existant ;
+- l'événement `INTERNAL_ORDER_LAUNCHED` avec affaire, destination, OF racines/enfants et statut ;
+- le changement de statut dans `commande_historique` ;
+- les métadonnées `internal_order_flow` dans les checkpoints ;
+- l'audit applicatif de génération.
+
+## Compatibilité
+
+Le comportement des commandes client (`FERME`, `OUVERTE`, etc.) est conservé : analyse de stock d'expédition, confirmation éventuelle et livraisons fractionnées continuent d'utiliser le contrat historique.
+
+Cette évolution ne nécessite ni nouveau patch SQL ni migration de production.

--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -41,8 +41,16 @@ vi.mock("../utils/checkNetworkDrive", () => ({
 }));
 
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
-  authenticateToken: (req: { user?: { id: number; role: string } }, _res: unknown, next: () => void) => {
-    req.user = { id: 1, role: "Administrateur Systeme et Reseau" };
+  authenticateToken: (
+    req: { user?: { id: number; role: string }; headers?: Record<string, string | string[] | undefined> },
+    _res: unknown,
+    next: () => void
+  ) => {
+    const requestedRole = req.headers?.["x-test-role"];
+    req.user = {
+      id: 1,
+      role: typeof requestedRole === "string" ? requestedRole : "Administrateur Systeme et Reseau",
+    };
     next();
   },
   authorizeRole:
@@ -1399,5 +1407,305 @@ describe("/api/v1/commandes", () => {
     expect(childParams[17]).toBe(3);
     expect(childParams[18]).toBe(3);
     expect(childParams[19]).toBe(6);
+  });
+
+  it("POST /api/v1/commandes/:id/generate-affaires protects internal-order launch and single-affair invariant", async () => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM commande_client") && q.includes("FOR UPDATE") && q.includes("order_type")) {
+        return {
+          rows: [
+            {
+              client_id: "001",
+              type_affaire: "livraison",
+              order_type: "INTERNE",
+              devis_id: null,
+              numero: "CI-123",
+              dest_stock_magasin_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+              dest_stock_emplacement_id: "1",
+              ar_sent_at: null,
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const forbidden = await request(app)
+      .post("/api/v1/commandes/123/generate-affaires")
+      .set("x-test-role", "Employee")
+      .send({ decision: null, livraison_count: 1, lines: [] });
+
+    expect(forbidden.status).toBe(403);
+    expect(forbidden.body).toMatchObject({ code: "INTERNAL_ORDER_LAUNCH_FORBIDDEN" });
+
+    const split = await request(app)
+      .post("/api/v1/commandes/123/generate-affaires")
+      .set("x-test-role", "Directeur")
+      .send({ decision: null, livraison_count: 2, lines: [] });
+
+    expect(split.status).toBe(400);
+    expect(split.body).toMatchObject({ code: "INTERNAL_ORDER_SINGLE_AFFAIRE_REQUIRED" });
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(false);
+  });
+
+  it("POST /api/v1/commandes/:id/generate-affaires requires an internal stock destination", async () => {
+    const ARTICLE_ID = "11111111-1111-1111-1111-111111111111";
+    const PIECE_ID = "22222222-2222-2222-2222-222222222222";
+
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM commande_client") && q.includes("FOR UPDATE") && q.includes("order_type")) {
+        return {
+          rows: [
+            {
+              client_id: "001",
+              type_affaire: "livraison",
+              order_type: "INTERNE",
+              devis_id: null,
+              numero: "CI-123",
+              dest_stock_magasin_id: null,
+              dest_stock_emplacement_id: null,
+              ar_sent_at: null,
+            },
+          ],
+        };
+      }
+      if (q.includes("FROM public.erp_settings")) return { rows: [] };
+      if (q.includes("FROM pg_attribute") && q.includes("commande_to_affaire")) return { rows: [{ ok: 1 }] };
+      if (q.includes("FROM commande_to_affaire") && q.includes("WHERE commande_id")) return { rows: [] };
+      if (q.includes("FROM commande_ligne") && q.includes("LEFT JOIN LATERAL")) {
+        return {
+          rows: [
+            {
+              commande_ligne_id: 1,
+              code_piece: "P1",
+              qty_ordered: 2,
+              article_id: ARTICLE_ID,
+              piece_technique_id: PIECE_ID,
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post("/api/v1/commandes/123/generate-affaires")
+      .set("x-test-role", "Responsable Production")
+      .send({ decision: null, livraison_count: 1, lines: [] });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "DEST_STOCK_LOCATION_REQUIRED" });
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(false);
+  });
+
+  it("POST /api/v1/commandes/:id/generate-affaires launches one internal affair with complete OF topology", async () => {
+    const MAGASIN_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+    const LOCATION_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+    const ARTICLE_ID = "11111111-1111-1111-1111-111111111111";
+    const ROOT_PIECE_ID = "22222222-2222-2222-2222-222222222222";
+    const CHILD_PIECE_ID = "33333333-3333-3333-3333-333333333333";
+    const BOM_LINE_ID = "44444444-4444-4444-4444-444444444444";
+    let ofSeq = 8;
+
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM commande_client") && q.includes("FOR UPDATE") && q.includes("order_type")) {
+        return {
+          rows: [
+            {
+              client_id: "001",
+              type_affaire: "livraison",
+              order_type: "INTERNE",
+              devis_id: null,
+              numero: "CI-123",
+              dest_stock_magasin_id: MAGASIN_ID,
+              dest_stock_emplacement_id: "1",
+              ar_sent_at: null,
+            },
+          ],
+        };
+      }
+      if (q.includes("SELECT id::int AS id, numero, client_id") && q.includes("FROM commande_client")) {
+        return { rows: [{ id: 123, numero: "CI-123", client_id: "001" }] };
+      }
+      if (q.includes("SELECT nouveau_statut") && q.includes("FROM commande_historique")) return { rows: [] };
+      if (q.includes("INSERT INTO commande_historique") && q.includes("RETURNING id::text AS id")) {
+        return { rows: [{ id: "1" }] };
+      }
+      if (q.includes("FROM public.erp_settings")) return { rows: [] };
+      if (q.includes("FROM pg_attribute") && q.includes("commande_to_affaire")) return { rows: [{ ok: 1 }] };
+      if (q.includes("FROM commande_to_affaire") && q.includes("WHERE commande_id")) return { rows: [] };
+      if (q.includes("FROM commande_ligne") && q.includes("LEFT JOIN LATERAL")) {
+        return {
+          rows: [
+            {
+              commande_ligne_id: 1,
+              code_piece: "P1",
+              qty_ordered: 2,
+              article_id: ARTICLE_ID,
+              article_code: "ART-001",
+              article_designation: "Article test",
+              piece_technique_id: ROOT_PIECE_ID,
+              piece_code: "ROOT",
+              piece_designation: "Piece mere",
+            },
+          ],
+        };
+      }
+      if (q.includes("FROM public.emplacements") && q.includes("SELECT location_id")) {
+        return { rows: [{ location_id: LOCATION_ID }] };
+      }
+      if (q.includes("nextval('public.affaire_id_seq')")) return { rows: [{ id: "7" }] };
+      if (q.includes("SELECT client_code FROM public.clients")) return { rows: [{ client_code: "CRP" }] };
+      if (q.includes("public.fn_next_issued_code_value")) return { rows: [{ v: "1" }] };
+      if (q.includes("WITH RECURSIVE tree") && q.includes("public.pieces_techniques_nomenclature")) {
+        return {
+          rows: [
+            {
+              key: ROOT_PIECE_ID,
+              parent_key: null,
+              bom_line_id: null,
+              parent_piece_technique_id: null,
+              piece_technique_id: ROOT_PIECE_ID,
+              article_id: ARTICLE_ID,
+              code_piece: "ROOT",
+              designation: "Piece mere",
+              version_number: 1,
+              level: 0,
+              ordre_affichage: 0,
+              quantite_par_parent: 1,
+              quantite_cumulee: 1,
+            },
+            {
+              key: `${ROOT_PIECE_ID}/${CHILD_PIECE_ID}`,
+              parent_key: ROOT_PIECE_ID,
+              bom_line_id: BOM_LINE_ID,
+              parent_piece_technique_id: ROOT_PIECE_ID,
+              piece_technique_id: CHILD_PIECE_ID,
+              article_id: null,
+              code_piece: "CHILD",
+              designation: "Sous-piece",
+              version_number: 1,
+              level: 1,
+              ordre_affichage: 10,
+              quantite_par_parent: 3,
+              quantite_cumulee: 3,
+            },
+          ],
+        };
+      }
+      if (q.includes("FROM public.piece_technique_versions v") && q.includes("v.statut = 'APPLICABLE'")) {
+        return { rows: [{ version_id: "55555555-5555-5555-5555-555555555555", gamme_id: null, version_interne: 1 }] };
+      }
+      if (q.includes("jsonb_build_object") && q.includes("'piece'")) {
+        return { rows: [{ snapshot: { piece: { id: ROOT_PIECE_ID }, version: { version_interne: 1 } } }] };
+      }
+      if (q.includes("pg_get_serial_sequence") && q.includes("ordres_fabrication")) {
+        ofSeq += 1;
+        return { rows: [{ of_id: String(ofSeq) }] };
+      }
+      if (q.includes("INSERT INTO erp_audit_logs")) {
+        return { rows: [{ id: "1", created_at: "2026-01-01T00:00:00.000Z" }] };
+      }
+      if (q.includes("INSERT INTO public.of_operations")) return { rows: [], rowCount: 1 };
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post("/api/v1/commandes/123/generate-affaires")
+      .set("x-test-role", "Responsable Production")
+      .send({ decision: null, livraison_count: 1, lines: [] });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      affaire_ids: [7],
+      livraison_affaire_id: 7,
+      livraison_affaire_ids: [7],
+      generation_mode: "INTERNAL_ORDER",
+      idempotent_replay: false,
+      workflow_status: "ATTENTE_PLANNING",
+      of_ids: [9, 10],
+      root_of_ids: [9],
+      child_of_ids: [10],
+      warnings: [],
+    });
+    expect(res.body.ofs).toEqual([
+      expect.objectContaining({ id: 9, root_of_id: 9, parent_of_id: null, generation_level: 0 }),
+      expect.objectContaining({ id: 10, root_of_id: 9, parent_of_id: 9, generation_level: 1 }),
+    ]);
+    expect(mocks.clientQuery.mock.calls.filter((call) => String(call[0]).includes("INSERT INTO affaire"))).toHaveLength(1);
+    expect(
+      mocks.clientQuery.mock.calls.some(
+        (call) => String(call[0]).includes("UPDATE public.commande_client_workflow_checkpoint") && String(call[0]).includes("internal_order_flow")
+      )
+    ).toBe(true);
+    expect(
+      mocks.clientQuery.mock.calls.some(
+        (call) => String(call[0]).includes("INSERT INTO public.commande_client_event_log") && call[1]?.[1] === "INTERNAL_ORDER_LAUNCHED"
+      )
+    ).toBe(true);
+  });
+
+  it("POST /api/v1/commandes/:id/generate-affaires replays internal generation with existing OF topology", async () => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM commande_client") && q.includes("FOR UPDATE") && q.includes("order_type")) {
+        return {
+          rows: [
+            {
+              client_id: "001",
+              type_affaire: "livraison",
+              order_type: "INTERNE",
+              devis_id: null,
+              numero: "CI-123",
+              dest_stock_magasin_id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+              dest_stock_emplacement_id: "1",
+              ar_sent_at: null,
+            },
+          ],
+        };
+      }
+      if (q.includes("FROM public.erp_settings")) return { rows: [] };
+      if (q.includes("FROM pg_attribute") && q.includes("commande_to_affaire")) return { rows: [{ ok: 1 }] };
+      if (q.includes("FROM commande_to_affaire") && q.includes("WHERE commande_id")) {
+        return { rows: [{ affaire_id: 7, role: "LIVRAISON" }] };
+      }
+      if (q.includes("FROM public.ordres_fabrication") && q.includes("generation_batch_id IS NOT NULL")) {
+        return {
+          rows: [
+            { id: 9, root_of_id: 9, parent_of_id: null, generation_level: 0, commande_ligne_id: 1 },
+            { id: 10, root_of_id: 9, parent_of_id: 9, generation_level: 1, commande_ligne_id: 1 },
+          ],
+        };
+      }
+      if (q.includes("LEFT JOIN LATERAL") && q.includes("FROM commande_client cc")) {
+        return { rows: [{ id: "123", numero: "CI-123", client_id: "001", raw_statut: "ATTENTE_PLANNING" }] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post("/api/v1/commandes/123/generate-affaires")
+      .set("x-test-role", "Directeur")
+      .send({ decision: null, livraison_count: 1, lines: [] });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      affaire_ids: [7],
+      generation_mode: "INTERNAL_ORDER",
+      idempotent_replay: true,
+      workflow_status: "ATTENTE_PLANNING",
+      of_ids: [9, 10],
+      root_of_ids: [9],
+      child_of_ids: [10],
+    });
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO public.ordres_fabrication"))).toBe(false);
   });
 });

--- a/src/module/commande-client/controllers/commande-client.controller.ts
+++ b/src/module/commande-client/controllers/commande-client.controller.ts
@@ -105,6 +105,7 @@ function routeParam(req: Request, name: string): string {
 function buildAudit(req: Request) {
   return {
     user_id: getUserId(req),
+    user_role: typeof req.user?.role === "string" ? req.user.role : null,
     ip: null,
     user_agent: typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null,
     device_type: null,
@@ -232,7 +233,12 @@ export const runCommandeWorkflowAction: RequestHandler = async (req, res, next) 
       return;
     }
     const userId = typeof req.user?.id === "number" ? req.user.id : null;
-    const out = await runCommandeWorkflowActionSVC(routeParam(req, "id"), parsed.data, userId);
+    const out = await runCommandeWorkflowActionSVC(
+      routeParam(req, "id"),
+      parsed.data,
+      userId,
+      typeof req.user?.role === "string" ? req.user.role : null
+    );
     if (!out) {
       res.status(404).json({ error: "Not found" });
       return;

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -62,6 +62,18 @@ function coerceOrderType(value: unknown): CreateCommandeInput["order_type"] {
   return "FERME";
 }
 
+function canLaunchInternalOrder(role: string | null | undefined): boolean {
+  if (!role) return false;
+  const normalized = role.trim().toLowerCase();
+  if (normalized.includes("admin") || normalized.includes("administrateur") || normalized.includes("directeur")) {
+    return true;
+  }
+  const isManager = normalized.includes("responsable") || normalized.includes("chef");
+  const isProduction =
+    normalized.includes("production") || normalized.includes("atelier") || normalized.includes("programmation");
+  return isManager && isProduction;
+}
+
 function sortColumn(sortBy: ListCommandesQueryDTO["sortBy"]) {
   switch (sortBy) {
     case "numero":
@@ -103,6 +115,7 @@ type CommandeLineArticleResolution = {
 
 type AuditContext = {
   user_id: number;
+  user_role: string | null;
   ip: string | null;
   user_agent: string | null;
   device_type: string | null;
@@ -403,6 +416,20 @@ async function loadApplicableTechnicalSnapshot(
   };
 }
 
+type GeneratedOfRef = {
+  id: number;
+  root_of_id: number;
+  parent_of_id: number | null;
+  generation_level: number;
+  commande_ligne_id: number;
+};
+
+type RecursiveOfGenerationResult = {
+  batch_id: string;
+  root_of_id: number;
+  ofs: GeneratedOfRef[];
+};
+
 async function createRecursiveOrdresFabrication(tx: Queryable, params: {
   commande_id: number;
   commande_numero: string;
@@ -413,7 +440,7 @@ async function createRecursiveOrdresFabrication(tx: Queryable, params: {
   root_piece_technique_id: string;
   qty_to_produce: number;
   user_id: number;
-}): Promise<number[]> {
+}): Promise<RecursiveOfGenerationResult> {
   const tree = await loadFabricationGenerationTree(tx, params.root_piece_technique_id);
   if (!tree.length) {
     throw new HttpError(
@@ -458,7 +485,7 @@ async function createRecursiveOrdresFabrication(tx: Queryable, params: {
     ]
   );
 
-  const ofIds: number[] = [];
+  const generatedOfs: GeneratedOfRef[] = [];
 
   for (const node of tree) {
     const ofId = ofIdByKey.get(node.key);
@@ -602,7 +629,13 @@ async function createRecursiveOrdresFabrication(tx: Queryable, params: {
       ]
     );
 
-    ofIds.push(ofId);
+    generatedOfs.push({
+      id: ofId,
+      root_of_id: rootOfId,
+      parent_of_id: parentOfId,
+      generation_level: node.level,
+      commande_ligne_id: params.commande_ligne_id,
+    });
   }
 
   await tx.query(
@@ -610,7 +643,11 @@ async function createRecursiveOrdresFabrication(tx: Queryable, params: {
     [batchId, rootOfId]
   );
 
-  return ofIds;
+  return {
+    batch_id: batchId,
+    root_of_id: rootOfId,
+    ofs: generatedOfs,
+  };
 }
 
 async function insertCommandeEvent(db: Queryable, params: {
@@ -1196,6 +1233,38 @@ async function listCommandeToAffaireMappings(db: Queryable, commandeId: number):
   }));
 }
 
+async function listGeneratedOfRefs(db: Queryable, commandeId: number): Promise<GeneratedOfRef[]> {
+  const res = await db.query<{
+    id: number;
+    root_of_id: number;
+    parent_of_id: number | null;
+    generation_level: number;
+    commande_ligne_id: number;
+  }>(
+    `
+      SELECT
+        id::bigint::int AS id,
+        COALESCE(root_of_id, id)::bigint::int AS root_of_id,
+        parent_of_id::bigint::int AS parent_of_id,
+        generation_level::int AS generation_level,
+        commande_ligne_id::bigint::int AS commande_ligne_id
+      FROM public.ordres_fabrication
+      WHERE commande_id = $1
+        AND generation_batch_id IS NOT NULL
+      ORDER BY generation_level ASC, id ASC
+    `,
+    [commandeId]
+  );
+
+  return res.rows.map((row) => ({
+    id: Number(row.id),
+    root_of_id: Number(row.root_of_id),
+    parent_of_id: row.parent_of_id === null ? null : Number(row.parent_of_id),
+    generation_level: Number(row.generation_level),
+    commande_ligne_id: Number(row.commande_ligne_id),
+  }));
+}
+
 type StockOnHandSource = {
   table: string;
   alias: string;
@@ -1612,6 +1681,69 @@ export async function repoEnsureCommandeWorkflowStatus(params: {
     history_id: ins.rows[0]?.id ? toInt(ins.rows[0].id, "commande_historique.id") : null,
     notifications,
   };
+}
+
+async function advanceInternalOrderWorkflowAfterGeneration(params: {
+  tx: Queryable;
+  commande_id: number;
+  user_id: number;
+  livraison_affaire_id: number;
+  of_ids: number[];
+}) {
+  const transition = await repoEnsureCommandeWorkflowStatus({
+    tx: params.tx,
+    commande_id: params.commande_id,
+    nouveau_statut: "ATTENTE_PLANNING",
+    commentaire: "Commande interne validee et lancee",
+    user_id: params.user_id,
+  });
+
+  await ensureCommandeWorkflowCheckpoints(params.tx, params.commande_id, "ATTENTE_PLANNING");
+  await params.tx.query(
+    `
+      UPDATE public.commande_client_workflow_checkpoint
+      SET
+        status = CASE
+          WHEN checkpoint_code IN ('commercial_review','ar_preparation','ar_sent','invoicing') THEN 'skipped'
+          WHEN checkpoint_code IN ('order_intake','technical_analysis','of_generation') THEN 'done'
+          WHEN checkpoint_code = 'planning_validation' THEN 'active'
+          ELSE status
+        END,
+        completed_at = CASE
+          WHEN checkpoint_code IN (
+            'order_intake','commercial_review','technical_analysis','of_generation',
+            'ar_preparation','ar_sent','invoicing'
+          ) THEN COALESCE(completed_at, now())
+          ELSE completed_at
+        END,
+        completed_by = CASE
+          WHEN checkpoint_code IN (
+            'order_intake','commercial_review','technical_analysis','of_generation',
+            'ar_preparation','ar_sent','invoicing'
+          ) THEN COALESCE(completed_by, $2::int)
+          ELSE completed_by
+        END,
+        metadata = COALESCE(metadata, '{}'::jsonb) || CASE
+          WHEN checkpoint_code = 'of_generation' THEN $3::jsonb
+          WHEN checkpoint_code IN ('commercial_review','ar_preparation','ar_sent','invoicing')
+            THEN '{"skip_reason":"internal_order_flow"}'::jsonb
+          ELSE '{"internal_order_flow":true}'::jsonb
+        END,
+        updated_at = now()
+      WHERE commande_id = $1
+    `,
+    [
+      params.commande_id,
+      params.user_id,
+      JSON.stringify({
+        internal_order_flow: true,
+        livraison_affaire_id: params.livraison_affaire_id,
+        of_ids: params.of_ids,
+      }),
+    ]
+  );
+
+  return transition;
 }
 
 type CommandeWorkflowHeader = {
@@ -2118,7 +2250,8 @@ export async function repoUpdateCommandeWorkflowCheckpoint(
 export async function repoRunCommandeWorkflowAction(
   id: string,
   body: RunCommandeWorkflowActionBodyDTO,
-  userId: number | null
+  userId: number | null,
+  userRole: string | null
 ) {
   const commandeId = toInt(id, "commande_id");
   if (userId === null) throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
@@ -2127,6 +2260,7 @@ export async function repoRunCommandeWorkflowAction(
 
   const workflowAudit: AuditContext = {
     user_id: userId,
+    user_role: userRole,
     ip: null,
     user_agent: null,
     device_type: null,
@@ -3564,6 +3698,32 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
     }
 
     const orderType = coerceOrderType(commande.order_type);
+    const requestedLivraisonCountRaw = typeof body.livraison_count === "number" ? body.livraison_count : 1;
+    const requestedLivraisonCount = Math.max(1, Math.min(10, Math.trunc(requestedLivraisonCountRaw)));
+
+    if (orderType === "INTERNE") {
+      if (!canLaunchInternalOrder(audit.user_role)) {
+        throw new HttpError(
+          403,
+          "INTERNAL_ORDER_LAUNCH_FORBIDDEN",
+          "Production manager or administrator role required to launch an internal order"
+        );
+      }
+      if (requestedLivraisonCount !== 1) {
+        throw new HttpError(
+          400,
+          "INTERNAL_ORDER_SINGLE_AFFAIRE_REQUIRED",
+          "Internal orders generate exactly one delivery affair"
+        );
+      }
+      if (body.decision !== null || (body.lines?.length ?? 0) > 0) {
+        throw new HttpError(
+          400,
+          "INTERNAL_ORDER_STOCK_DECISION_FORBIDDEN",
+          "Internal orders always generate the full manufacturing requirement without a shipping-stock decision"
+        );
+      }
+    }
 
     const internalClientId = orderType === "INTERNE" ? await getInternalClientIdSetting(client) : null;
     const clientId = commande.client_id ?? internalClientId;
@@ -3577,22 +3737,41 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       );
     }
 
-    const requestedLivraisonCountRaw = typeof body.livraison_count === "number" ? body.livraison_count : 1;
-    const requestedLivraisonCount = Math.max(1, Math.min(10, Math.trunc(requestedLivraisonCountRaw)));
-
     // Idempotency + split delivery support: allow multiple LIVRAISON mappings per commande.
     const existingMappings = await listCommandeToAffaireMappings(client, commandeId);
     const existingLivraisons = existingMappings.filter((r) => r.role === "LIVRAISON");
 
     if (existingMappings.length > 0) {
+      if (orderType === "INTERNE" && existingLivraisons.length === 0) {
+        throw new HttpError(
+          409,
+          "INTERNAL_ORDER_AFFAIRE_MAPPING_INVALID",
+          "The existing affair mapping is not identified as a delivery affair"
+        );
+      }
+
       if (existingLivraisons.length >= requestedLivraisonCount) {
         const livraison = existingLivraisons[0]?.affaire_id ?? null;
+        const existingOfs = await listGeneratedOfRefs(client, commandeId);
+        const workflowHeader =
+          orderType === "INTERNE" ? await loadCommandeWorkflowHeaderWithStatus(client, commandeId) : null;
         await client.query("COMMIT");
         return {
           affaire_ids: existingLivraisons.map((r) => r.affaire_id),
           livraison_affaire_id: livraison,
           requires_confirmation: false,
           livraison_affaire_ids: existingLivraisons.map((l) => l.affaire_id),
+          generation_mode: orderType === "INTERNE" ? "INTERNAL_ORDER" : "CUSTOMER_ORDER",
+          idempotent_replay: true,
+          workflow_status: workflowHeader?.statut ?? null,
+          of_ids: existingOfs.map((of) => of.id),
+          root_of_ids: existingOfs.filter((of) => of.parent_of_id === null).map((of) => of.id),
+          child_of_ids: existingOfs.filter((of) => of.parent_of_id !== null).map((of) => of.id),
+          ofs: existingOfs,
+          warnings:
+            orderType === "INTERNE" && existingLivraisons.length > 1
+              ? ["LEGACY_MULTIPLE_DELIVERY_AFFAIRS"]
+              : [],
         };
       }
 
@@ -3632,19 +3811,37 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
     }
 
     const refs = await selectCommandeLineRefs(client, commandeId);
+    if (orderType === "INTERNE") {
+      if (refs.length === 0) {
+        throw new HttpError(400, "INTERNAL_ORDER_LINE_REQUIRED", "An internal order must contain at least one line");
+      }
+      const missingPiece = refs.find((line) => !line.piece_technique_id);
+      if (missingPiece) {
+        throw new HttpError(
+          400,
+          "PIECE_TECHNIQUE_REQUIRED",
+          `Cannot launch internal order: missing piece_technique_id for line ${missingPiece.commande_ligne_id}`
+        );
+      }
+    }
 
     let stockLocationId: string | null = null;
     if (orderType === "INTERNE") {
       const magasinId = commande.dest_stock_magasin_id;
       const emplacementIdRaw = commande.dest_stock_emplacement_id;
       const emplacementId = typeof emplacementIdRaw === "string" && /^\d+$/.test(emplacementIdRaw) ? Number(emplacementIdRaw) : null;
-      if (magasinId && typeof emplacementId === "number" && Number.isFinite(emplacementId)) {
-        stockLocationId = await resolveLocationIdForEmplacement(client, {
-          magasin_id: magasinId,
-          emplacement_id: emplacementId,
-          label: "dest_stock_location",
-        });
+      if (!magasinId || typeof emplacementId !== "number" || !Number.isFinite(emplacementId)) {
+        throw new HttpError(
+          400,
+          "DEST_STOCK_LOCATION_REQUIRED",
+          "dest_stock_magasin_id and dest_stock_emplacement_id are required for internal orders"
+        );
       }
+      stockLocationId = await resolveLocationIdForEmplacement(client, {
+        magasin_id: magasinId,
+        emplacement_id: emplacementId,
+        label: "dest_stock_location",
+      });
     } else {
       try {
         stockLocationId = (await getDefaultShippingLocation(client)).location_id;
@@ -3654,7 +3851,25 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
     }
 
     let analysis: CommandeStockAnalysis | null = null;
-    if (stockLocationId) {
+    if (orderType === "INTERNE") {
+      analysis = {
+        lines: refs.map((ref) => ({
+          commande_ligne_id: ref.commande_ligne_id,
+          code_piece: ref.code_piece,
+          article_id: ref.article_id,
+          article_code: ref.article_code,
+          article_designation: ref.article_designation,
+          piece_technique_id: ref.piece_technique_id,
+          piece_code: ref.piece_code,
+          piece_designation: ref.piece_designation,
+          requested_qty: Number(ref.qty_ordered),
+          available_qty: 0,
+          available_used_qty: 0,
+          shortage_qty: Number(ref.qty_ordered),
+          status: "NONE",
+        })),
+      };
+    } else if (stockLocationId) {
       try {
         analysis = await computeCommandeStockAnalysis(client, { commande_id: commandeId, location_id: stockLocationId });
       } catch {
@@ -3846,7 +4061,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       }
     }
 
-    const ofIds: number[] = [];
+    const generatedOfs: GeneratedOfRef[] = [];
     if (needsProduction) {
       const byLine = new Map<number, CommandeLineRef>(refs.map((r) => [r.commande_ligne_id, r] as const));
 
@@ -3865,7 +4080,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           );
         }
 
-        const generatedIds = await createRecursiveOrdresFabrication(client, {
+        const generated = await createRecursiveOrdresFabrication(client, {
           commande_id: commandeId,
           commande_numero: commande.numero,
           commande_ligne_id: l.commande_ligne_id,
@@ -3876,8 +4091,34 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           qty_to_produce: qtyToProduce,
           user_id: audit.user_id,
         });
-        ofIds.push(...generatedIds);
+        generatedOfs.push(...generated.ofs);
       }
+    }
+
+    const ofIds = generatedOfs.map((of) => of.id);
+    let workflowStatus: string | null = null;
+    if (orderType === "INTERNE") {
+      await advanceInternalOrderWorkflowAfterGeneration({
+        tx: client,
+        commande_id: commandeId,
+        user_id: audit.user_id,
+        livraison_affaire_id: livraisonAffaireId,
+        of_ids: ofIds,
+      });
+      workflowStatus = "ATTENTE_PLANNING";
+
+      await insertCommandeEvent(client, {
+        commande_id: commandeId,
+        event_type: "INTERNAL_ORDER_LAUNCHED",
+        new_values: {
+          livraison_affaire_id: livraisonAffaireId,
+          stock_location_id: stockLocationId,
+          root_of_ids: generatedOfs.filter((of) => of.parent_of_id === null).map((of) => of.id),
+          child_of_ids: generatedOfs.filter((of) => of.parent_of_id !== null).map((of) => of.id),
+          workflow_status: workflowStatus,
+        },
+        user_id: audit.user_id,
+      });
     }
 
     await insertCommandeEvent(client, {
@@ -3934,6 +4175,13 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       livraison_affaire_ids: livraisonAffaireIds,
       reservations_created: reservationsCreated,
       of_ids: ofIds,
+      root_of_ids: generatedOfs.filter((of) => of.parent_of_id === null).map((of) => of.id),
+      child_of_ids: generatedOfs.filter((of) => of.parent_of_id !== null).map((of) => of.id),
+      ofs: generatedOfs,
+      generation_mode: orderType === "INTERNE" ? "INTERNAL_ORDER" : "CUSTOMER_ORDER",
+      idempotent_replay: false,
+      workflow_status: workflowStatus,
+      warnings: [],
     };
   } catch (e) {
     await client.query("ROLLBACK");

--- a/src/module/commande-client/services/commande-client.service.ts
+++ b/src/module/commande-client/services/commande-client.service.ts
@@ -48,6 +48,7 @@ import type {
 
 export type CommandesAuditContext = {
   user_id: number;
+  user_role: string | null;
   ip: string | null;
   user_agent: string | null;
   device_type: string | null;
@@ -80,8 +81,9 @@ export const updateCommandeWorkflowCheckpointSVC = (
 export const runCommandeWorkflowActionSVC = (
   id: string,
   body: RunCommandeWorkflowActionBodyDTO,
-  userId: number | null
-) => repoRunCommandeWorkflowAction(id, body, userId);
+  userId: number | null,
+  userRole: string | null
+) => repoRunCommandeWorkflowAction(id, body, userId, userRole);
 
 export const getCommandeDocumentFileMetaSVC = (commandeId: string, docId: string) =>
   repoGetCommandeDocumentFileMeta(commandeId, docId);


### PR DESCRIPTION
## Release

Cette PR promeut vers `main` l'orchestration backend autoritaire des commandes internes.

### Garanties

- exactement une affaire de livraison ;
- quantité complète à fabriquer ;
- OF racines et enfants dans une transaction ;
- destination magasin/emplacement obligatoire ;
- contrôle des rôles de lancement ;
- rejeu idempotent sans doublon ;
- workflow vers `ATTENTE_PLANNING` ;
- événements et audit ;
- aucun AR, BL ou facture au lancement ;
- comportement historique des commandes client conservé.

### Validation

- PR d'intégration #86 fusionnée dans `dev` ;
- CI backend verte ;
- suite Vitest complète, tests Commandes, TypeScript et démarrage HTTP validés ;
- aucune migration PostgreSQL.

Refs #85

## Summary by Sourcery

Enforce backend orchestration for internal orders when generating affaires, adding role-based protections, workflow transitions, OF topology exposure, and documentation of the new internal-order contract.

New Features:
- Expose internal manufacturing order topology and generation mode in the response of /api/v1/commandes/:id/generate-affaires, including root/child OF identifiers and idempotent replay metadata.
- Add idempotent replay support for internal orders so repeated generation requests return existing affairs and OFs without duplications.

Enhancements:
- Restrict internal order launch to production-responsible or administrative roles and enforce single-affair, full-quantity generation invariants with specific business error codes.
- Require a valid internal stock destination and technical piece coverage for all lines before launching an internal order, failing fast with dedicated error codes when preconditions are not met.
- Advance the internal order workflow to ATTENTE_PLANNING after successful generation, updating checkpoints, emitting audit logs and internal-order-specific events.
- Propagate user role through the workflow action pipeline to support internal order authorization checks.
- Refactor OF generation to return structured OF references and batch metadata used both for fresh generation and idempotent replays.

Documentation:
- Add a dedicated HTTP contract document for internal orders describing preconditions, response shape, idempotence guarantees, business errors, and traceability.
- Update frontend repo map documentation to note internal-order role and invariant checks on the generate-affaires endpoint.

Tests:
- Extend commandes routes tests to cover internal-order role restrictions, destination requirements, OF topology generation, and idempotent replay behavior for /api/v1/commandes/:id/generate-affaires.