### PR TITLE
security+feat: Client 360 — durcissement P0 et extension (crp-systems-web#162)

### DIFF
--- a/db/patches/20260720_clients_360_hardening.sql
+++ b/db/patches/20260720_clients_360_hardening.sql
@@ -1,0 +1,143 @@
+-- 20260720_clients_360_hardening.sql
+-- #162 (BigFootLime/crp-systems-web#162) — Client 360 : évolutions ADDITIVES du référentiel clients.
+--
+-- STRICTEMENT ADDITIF : aucune colonne existante modifiée/supprimée, aucune ligne
+-- détruite, idempotent (IF NOT EXISTS partout). L'application actuelle fonctionne
+-- inchangée sans ce patch ; le code #162 « extension 360 » le requiert.
+-- Ordre de release : appliquer ce patch (cerp_test d'abord) AVANT de déployer le code.
+-- Verify   : db/patches/support/20260720_clients_360_hardening.verify.sql
+-- Rollback : db/patches/support/20260720_clients_360_hardening.rollback.sql
+--
+-- Contenu :
+--   1. clients.client_uuid       — identité technique cible (UUID stable) pour les
+--                                  futures relations, en coexistence avec la PK
+--                                  legacy client_id (varchar "001"). Aucune FK ne
+--                                  bascule ici (évolution documentée, pas de
+--                                  pseudo-migration).
+--   2. Archivage logique horodaté (archived_at/archived_by) en complément de la
+--      convention status='inactif'.
+--   3. Colonnes d'audit created_at/updated_at/created_by/updated_by (pattern
+--      fournisseurs), backfill created_at depuis creation_date.
+--   4. Finance/logistique structurés : devise, encours_max, incoterm, langue
+--      (fin de la concaténation de données métier dans observations).
+--   5. contacts.archived_at — désactivation logique des contacts (jamais de
+--      DELETE physique par les flux applicatifs).
+--   6. client_create_idempotency — rejeu sûr du POST /clients (double soumission).
+--   7. Index de recherche SIRET (non unique : des doublons legacy peuvent exister ;
+--      l'index UNIQUE est la cible une fois le verify sans doublons — voir script).
+
+BEGIN;
+
+-- 1) Identité technique cible ------------------------------------------------
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS client_uuid uuid NOT NULL DEFAULT gen_random_uuid();
+
+CREATE UNIQUE INDEX IF NOT EXISTS clients_client_uuid_uniq
+  ON public.clients (client_uuid);
+
+-- 2) Archivage logique horodaté ----------------------------------------------
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS archived_at timestamptz NULL;
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS archived_by integer NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'clients_archived_by_fkey'
+  ) THEN
+    ALTER TABLE public.clients
+      ADD CONSTRAINT clients_archived_by_fkey
+      FOREIGN KEY (archived_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- 3) Audit création/modification (pattern fournisseurs) -----------------------
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS created_at timestamptz NOT NULL DEFAULT now();
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS created_by integer NULL;
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS updated_by integer NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'clients_created_by_fkey'
+  ) THEN
+    ALTER TABLE public.clients
+      ADD CONSTRAINT clients_created_by_fkey
+      FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'clients_updated_by_fkey'
+  ) THEN
+    ALTER TABLE public.clients
+      ADD CONSTRAINT clients_updated_by_fkey
+      FOREIGN KEY (updated_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Backfill : les fiches legacy gardent leur date métier comme date de création
+-- technique (sinon DEFAULT now() mentirait sur l'ancienneté).
+UPDATE public.clients
+   SET created_at = creation_date
+ WHERE creation_date IS NOT NULL
+   AND created_at > creation_date;
+
+-- Trigger updated_at : réutilise public.tg_set_updated_at() si présent (même
+-- garde que le patch fournisseurs — on n'échoue pas si la fonction manque).
+DO $$
+BEGIN
+  IF to_regproc('public.tg_set_updated_at()') IS NULL THEN
+    RAISE NOTICE 'tg_set_updated_at() not found; skipping clients updated_at trigger.';
+  ELSE
+    EXECUTE 'DROP TRIGGER IF EXISTS clients_set_updated_at ON public.clients';
+    EXECUTE 'CREATE TRIGGER clients_set_updated_at
+             BEFORE UPDATE ON public.clients
+             FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
+  END IF;
+END $$;
+
+-- 4) Finance / logistique structurés ------------------------------------------
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS devise text NULL;
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS encours_max numeric(12,2) NULL;
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS incoterm text NULL;
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS langue text NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'clients_encours_max_non_negative'
+  ) THEN
+    ALTER TABLE public.clients
+      ADD CONSTRAINT clients_encours_max_non_negative
+      CHECK (encours_max IS NULL OR encours_max >= 0);
+  END IF;
+END $$;
+
+-- 5) Désactivation logique des contacts ---------------------------------------
+ALTER TABLE public.contacts
+  ADD COLUMN IF NOT EXISTS archived_at timestamptz NULL;
+
+-- 6) Idempotence de création ---------------------------------------------------
+-- Pas de FK vers clients(client_id) : table de bookkeeping éphémère (rejeu de
+-- POST), la PK legacy varchar(3) est amenée à évoluer vers client_uuid.
+CREATE TABLE IF NOT EXISTS public.client_create_idempotency (
+  idempotency_key uuid PRIMARY KEY,
+  client_id       text NOT NULL,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+-- 7) Index de recherche SIRET --------------------------------------------------
+CREATE INDEX IF NOT EXISTS clients_siret_idx
+  ON public.clients (siret)
+  WHERE siret IS NOT NULL;
+
+COMMIT;

--- a/db/patches/support/20260720_clients_360_hardening.rollback.sql
+++ b/db/patches/support/20260720_clients_360_hardening.rollback.sql
@@ -1,0 +1,39 @@
+-- 20260720_clients_360_hardening.rollback.sql
+-- Rollback du patch #162 — À N'EXÉCUTER QUE SUR DÉCISION HUMAINE EXPLICITE.
+-- Le patch étant strictement additif, ce rollback retire uniquement ce qu'il a
+-- ajouté. PERTE DE DONNÉES ASSUMÉE : les valeurs saisies dans les nouvelles
+-- colonnes (devise, encours_max, incoterm, langue, archived_*) et les clés
+-- d'idempotence sont supprimées. Aucune donnée préexistante n'est touchée.
+-- Après rollback, retirer aussi la ligne correspondante de
+-- public.cerp_schema_migrations si l'on veut ré-appliquer le patch :
+--   DELETE FROM public.cerp_schema_migrations WHERE filename = '20260720_clients_360_hardening.sql';
+
+BEGIN;
+
+DROP TRIGGER IF EXISTS clients_set_updated_at ON public.clients;
+
+DROP INDEX IF EXISTS public.clients_siret_idx;
+DROP INDEX IF EXISTS public.clients_client_uuid_uniq;
+
+DROP TABLE IF EXISTS public.client_create_idempotency;
+
+ALTER TABLE public.contacts DROP COLUMN IF EXISTS archived_at;
+
+ALTER TABLE public.clients DROP CONSTRAINT IF EXISTS clients_encours_max_non_negative;
+ALTER TABLE public.clients DROP CONSTRAINT IF EXISTS clients_archived_by_fkey;
+ALTER TABLE public.clients DROP CONSTRAINT IF EXISTS clients_created_by_fkey;
+ALTER TABLE public.clients DROP CONSTRAINT IF EXISTS clients_updated_by_fkey;
+
+ALTER TABLE public.clients DROP COLUMN IF EXISTS langue;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS incoterm;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS encours_max;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS devise;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS updated_by;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS created_by;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS updated_at;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS created_at;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS archived_by;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS archived_at;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS client_uuid;
+
+COMMIT;

--- a/db/patches/support/20260720_clients_360_hardening.verify.sql
+++ b/db/patches/support/20260720_clients_360_hardening.verify.sql
@@ -1,0 +1,66 @@
+-- 20260720_clients_360_hardening.verify.sql
+-- Vérification post-application du patch #162 (lecture seule, aucun effet de bord).
+-- Usage : psql "$DATABASE_URL" -f db/patches/support/20260720_clients_360_hardening.verify.sql
+-- Attendu : chaque bloc renvoie ok=true (ou un décompte explicite commenté).
+
+-- 1) Colonnes ajoutées sur clients
+SELECT
+  COUNT(*) FILTER (WHERE column_name = 'client_uuid')  = 1 AS has_client_uuid,
+  COUNT(*) FILTER (WHERE column_name = 'archived_at')  = 1 AS has_archived_at,
+  COUNT(*) FILTER (WHERE column_name = 'archived_by')  = 1 AS has_archived_by,
+  COUNT(*) FILTER (WHERE column_name = 'created_at')   = 1 AS has_created_at,
+  COUNT(*) FILTER (WHERE column_name = 'updated_at')   = 1 AS has_updated_at,
+  COUNT(*) FILTER (WHERE column_name = 'created_by')   = 1 AS has_created_by,
+  COUNT(*) FILTER (WHERE column_name = 'updated_by')   = 1 AS has_updated_by,
+  COUNT(*) FILTER (WHERE column_name = 'devise')       = 1 AS has_devise,
+  COUNT(*) FILTER (WHERE column_name = 'encours_max')  = 1 AS has_encours_max,
+  COUNT(*) FILTER (WHERE column_name = 'incoterm')     = 1 AS has_incoterm,
+  COUNT(*) FILTER (WHERE column_name = 'langue')       = 1 AS has_langue
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'clients';
+
+-- 2) Colonne contacts.archived_at
+SELECT COUNT(*) = 1 AS has_contacts_archived_at
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'contacts' AND column_name = 'archived_at';
+
+-- 3) Table d'idempotence
+SELECT to_regclass('public.client_create_idempotency') IS NOT NULL AS has_idempotency_table;
+
+-- 4) Index
+SELECT
+  COUNT(*) FILTER (WHERE indexname = 'clients_client_uuid_uniq') = 1 AS has_uuid_unique_index,
+  COUNT(*) FILTER (WHERE indexname = 'clients_siret_idx')        = 1 AS has_siret_index
+FROM pg_indexes
+WHERE schemaname = 'public' AND tablename = 'clients';
+
+-- 5) Unicité effective des UUID (attendu : 0 doublon)
+SELECT COUNT(*) AS duplicated_client_uuids
+FROM (
+  SELECT client_uuid FROM public.clients GROUP BY client_uuid HAVING COUNT(*) > 1
+) d;
+
+-- 6) Backfill created_at : aucune fiche legacy avec created_at postérieur à
+--    creation_date (attendu : 0)
+SELECT COUNT(*) AS created_at_after_creation_date
+FROM public.clients
+WHERE creation_date IS NOT NULL AND created_at > creation_date;
+
+-- 7) DOUBLONS SIRET LEGACY — décision différée documentée (#162) :
+--    tant que ce décompte est > 0, l'index UNIQUE sur siret ne peut pas être
+--    créé ; la garde applicative (409 CLIENT_SIRET_EXISTS) couvre les nouveaux
+--    flux. Attendu à terme : 0, puis créer :
+--    CREATE UNIQUE INDEX clients_siret_uniq ON public.clients (siret) WHERE siret IS NOT NULL;
+SELECT COALESCE(SUM(cnt - 1), 0) AS legacy_duplicate_siret_rows
+FROM (
+  SELECT siret, COUNT(*) AS cnt
+  FROM public.clients
+  WHERE siret IS NOT NULL AND btrim(siret) <> ''
+  GROUP BY siret
+  HAVING COUNT(*) > 1
+) d;
+
+-- 8) Contrainte encours
+SELECT COUNT(*) = 1 AS has_encours_check
+FROM pg_constraint
+WHERE conname = 'clients_encours_max_non_negative';

--- a/docs/clients-360-162.md
+++ b/docs/clients-360-162.md
@@ -1,0 +1,60 @@
+# Client 360 — durcissement et extension (#162)
+
+Référence : BigFootLime/crp-systems-web#162 (parent #161). ADR côté frontend :
+`docs/adr/ADR-0017-client-360-contract.md` (crp-systems-web). Deux commits :
+
+1. `security:` — durcissement P0 (aucune dépendance schéma, déployable seul).
+2. `feat:` — extension 360 (requiert le patch ci-dessous, à appliquer AVANT le code).
+
+## Contrat `/api/v1/clients` après #162
+
+| Route | Auth | Rôles écriture | Notes |
+|---|---|---|---|
+| GET `/`, `/analytics`, `/:id`, `/:clientId/contacts`, `/:clientId/addresses` | Bearer requis | — | Liste sans IBAN/BIC/téléphone personnel ; détail IBAN masqué (`iban_masked`) hors rôles finance |
+| POST `/` | Bearer | Directeur, Administrateur Systeme et Reseau, Secretaire | `client_code` fourni → 400 `CLIENT_CODE_READONLY` ; SIRET en conflit → 409 `CLIENT_SIRET_EXISTS` (+`details`) ; `Idempotency-Key` UUID → rejeu 200 |
+| POST `/duplicate-check` | Bearer | — (lecture) | Corps `{siret?, vat_number?, company_name?, exclude_client_id?}` → `{candidates[]}` minimisés |
+| PATCH `/:id` | Bearer | idem écriture | `client_code` → 400 `CLIENT_CODE_IMMUTABLE` ; statut actif efface `archived_at` |
+| DELETE `/:id` | Bearer | idem écriture | **Archivage logique** : `status='inactif'`, `blocked=true`, `archived_at/by` — aucune destruction |
+| POST `/:id/archive` | Bearer | idem écriture | Archivage horodaté |
+| PATCH `/:id/contact` | Bearer | idem écriture | Zod + appartenance au client sous transaction → 422 `CONTACT_NOT_OF_CLIENT` |
+
+Réponse d'erreur : `errorHandler` ajoute `details` pour les 4xx volontaires (ex. fiche en
+conflit SIRET). Les logs (requestLogger, morgan, auth middleware, contexte d'audit) ne
+portent plus de query string (PII des recherches).
+
+## Patch SQL additif
+
+`db/patches/20260720_clients_360_hardening.sql` — idempotent, strictement additif :
+`clients.client_uuid` (cible d'identité), `archived_at/archived_by`,
+`created_at/updated_at/created_by/updated_by` (+ backfill `creation_date`, trigger
+`tg_set_updated_at` si présent), `devise/encours_max/incoterm/langue`,
+`contacts.archived_at`, table `client_create_idempotency`, index `clients_siret_idx`.
+
+- Verify : `db/patches/support/20260720_clients_360_hardening.verify.sql` (contrôles + décompte
+  des doublons SIRET legacy : l'index UNIQUE n'est créé qu'à décompte zéro).
+- Rollback : `db/patches/support/20260720_clients_360_hardening.rollback.sql` (perte assumée
+  des seules données nouvelles).
+- **Jamais appliqué en production par la session IA.** Ordre de release : `cerp_test`,
+  verify, puis production par un humain, puis déploiement du code.
+
+## Code mort supprimé
+
+`nextClientId` (MAX+1), `client.service.createClient` (MAX+1 inline),
+`updateClientPrimaryContact` (sans contrôle d'appartenance), `repoUpdateClient`
+(remplacement complet + suppression physique de contacts) — tous non routés, vérifié.
+
+## Suivis documentés (non inclus volontairement)
+
+- Endpoint de désactivation de contact (`contacts.archived_at` prêt en base).
+- Index UNIQUE SIRET après nettoyage des doublons legacy (verify fourni).
+- Upload logo sécurisé (CA-APP-05) — route commentée conservée.
+- Chiffrement IBAN au repos après stabilisation du schéma.
+- `swagger.ts` non mis à jour pour les nouveaux champs/en-têtes.
+
+## Vérification
+
+`npm run build` ✅ · `npm run test:run` : 59 fichiers / 359 tests ✅ (dont
+`src/__tests__/clients-360-hardening.routes.test.ts` : 37 tests couvrant 401/403, DTO
+minimisés, masquage IBAN par rôle, code serveur sans MAX+1, 409 SIRET, duplicate-check,
+contact principal transactionnel, archivage logique, logs sans query, finance structurée,
+idempotence, horodatage d'archivage).

--- a/src/__tests__/client.validators.test.ts
+++ b/src/__tests__/client.validators.test.ts
@@ -72,28 +72,24 @@ describe("createClientSchema", () => {
       ],
     });
 
-    expect(parsed.client_code).toBeUndefined();
+    expect("client_code" in parsed).toBe(false);
     expect(parsed.primary_contact).toBeUndefined();
     expect(parsed.contacts).toEqual([]);
   });
 
-  it("rejects a client code that does not match CLI-001", () => {
+  it("strips client_code from the parsed payload (server-generated, immutable — #162)", () => {
+    // Le schéma ne connaît plus client_code : le code visible est généré côté
+    // serveur (ADR-0013). Le rejet explicite d'une valeur fournie est testé au
+    // niveau contrôleur (CLIENT_CODE_READONLY / CLIENT_CODE_IMMUTABLE).
     const parsed = createClientSchema.safeParse({
       ...makeValidPayload(),
-      client_code: "CLI-12",
+      client_code: "CLI-012",
     });
 
-    expect(parsed.success).toBe(false);
-    if (parsed.success) return;
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
 
-    expect(parsed.error.issues).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          path: ["client_code"],
-          message: "Le code client doit être au format CLI-001.",
-        }),
-      ])
-    );
+    expect("client_code" in parsed.data).toBe(false);
   });
 
   it("returns explicit French messages for missing required address fields", () => {

--- a/src/__tests__/clients-360-hardening.routes.test.ts
+++ b/src/__tests__/clients-360-hardening.routes.test.ts
@@ -84,6 +84,7 @@ beforeEach(() => {
     if (s.includes("INSERT INTO adresse_livraison")) return Promise.resolve({ rows: [{ delivery_address_id: "d1" }] });
     if (s.includes("INSERT INTO clients")) return Promise.resolve({ rows: [{ client_id: "007" }] });
     if (s.includes("WHERE siret = $1")) return Promise.resolve({ rows: [] });
+    if (s.includes("FROM client_create_idempotency")) return Promise.resolve({ rows: [] });
     if (s.includes("FOR UPDATE")) {
       return Promise.resolve({
         rows: [{ client_id: "001", bill_address_id: "b1", delivery_address_id: "d1", bank_info_id: null, primary_contact_id: null, contact_id: null, company_name: "X", status: "client" }],
@@ -351,6 +352,96 @@ describe("P0-7 — aucune query string dans les logs HTTP", () => {
     }
     const parsed = JSON.parse(httpLines[httpLines.length - 1]);
     expect(parsed.path).toBe("/api/v1/clients");
+  });
+});
+
+describe("Extension 360 — finance structurée, idempotence, archivage horodaté (patch 20260720 requis)", () => {
+  const IDEMPOTENCY_KEY = "b7e00000-1111-4222-8333-444455556666";
+
+  it("POST avec devise/encours/incoterm/langue -> colonnes structurées dans l'INSERT", async () => {
+    const res = await request(app)
+      .post("/api/v1/clients")
+      .set("x-test-role", "Secretaire")
+      .send({ ...VALID_CREATE_PAYLOAD, devise: "chf", encours_max: 25000.5, incoterm: "DAP", langue: "EN" });
+    expect(res.status).toBe(201);
+    const insert = sqls().find((s) => s.includes("INSERT INTO clients"));
+    expect(insert).toBeTruthy();
+    for (const col of ["devise", "encours_max", "incoterm", "langue", "created_by", "updated_by"]) {
+      expect(insert).toContain(col);
+    }
+    const insertCall = mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("INSERT INTO clients"));
+    const params = (insertCall?.[1] ?? []) as unknown[];
+    expect(params).toContain("CHF"); // devise normalisée majuscules
+    expect(params).toContain(25000.5);
+    expect(params).toContain("DAP");
+    expect(params).toContain("en"); // langue normalisée minuscules
+  });
+
+  it("devise invalide -> 400 de validation", async () => {
+    const res = await request(app)
+      .post("/api/v1/clients")
+      .set("x-test-role", "Secretaire")
+      .send({ ...VALID_CREATE_PAYLOAD, devise: "EURO" });
+    expect(res.status).toBe(400);
+  });
+
+  it("Idempotency-Key malformée -> 400 IDEMPOTENCY_KEY_INVALID", async () => {
+    const res = await request(app)
+      .post("/api/v1/clients")
+      .set("x-test-role", "Secretaire")
+      .set("Idempotency-Key", "pas-un-uuid")
+      .send(VALID_CREATE_PAYLOAD);
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("IDEMPOTENCY_KEY_INVALID");
+  });
+
+  it("première création avec Idempotency-Key -> 201 + clé enregistrée dans la transaction", async () => {
+    const res = await request(app)
+      .post("/api/v1/clients")
+      .set("x-test-role", "Secretaire")
+      .set("Idempotency-Key", IDEMPOTENCY_KEY)
+      .send(VALID_CREATE_PAYLOAD);
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ client_id: "007", client_code: "CLI-007" });
+    expect(sqls().some((s) => s.includes("INSERT INTO client_create_idempotency"))).toBe(true);
+  });
+
+  it("rejeu de la même Idempotency-Key -> 200, même fiche, AUCUNE nouvelle insertion", async () => {
+    mocks.clientQuery.mockImplementation((sql: unknown) => {
+      const s = String(sql);
+      if (s.includes("FROM client_create_idempotency")) {
+        return Promise.resolve({ rows: [{ client_id: "007", client_code: "CLI-007" }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    const res = await request(app)
+      .post("/api/v1/clients")
+      .set("x-test-role", "Secretaire")
+      .set("Idempotency-Key", IDEMPOTENCY_KEY)
+      .send(VALID_CREATE_PAYLOAD);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ client_id: "007", client_code: "CLI-007" });
+    expect(sqls().some((s) => s.includes("INSERT INTO clients"))).toBe(false);
+    expect(sqls().some((s) => s.includes("fn_next_issued_code_value"))).toBe(false);
+  });
+
+  it("DELETE (archivage logique) horodate archived_at avec l'auteur", async () => {
+    const res = await request(app).delete("/api/v1/clients/001").set("x-test-role", "Directeur");
+    expect(res.status).toBe(204);
+    const update = sqls().find((s) => s.includes("SET status = 'inactif'"));
+    expect(update).toContain("archived_at = now()");
+    expect(update).toContain("archived_by = $2");
+  });
+
+  it("PATCH status -> prospect/client efface l'horodatage d'archivage", async () => {
+    const res = await request(app)
+      .patch("/api/v1/clients/001")
+      .set("x-test-role", "Secretaire")
+      .send({ status: "client" });
+    expect(res.status).toBe(204);
+    const update = sqls().find((s) => s.includes("UPDATE clients SET"));
+    expect(update).toContain("archived_at = NULL");
+    expect(update).toContain("updated_by");
   });
 });
 

--- a/src/__tests__/clients-360-hardening.routes.test.ts
+++ b/src/__tests__/clients-360-hardening.routes.test.ts
@@ -1,0 +1,364 @@
+/**
+ * #162 — Non-régression des 7 constats P0 du module clients :
+ *  1. GET clients/analytics/contacts/adresses/détail : authentification requise,
+ *     IBAN/BIC/phone_personal absents de la liste, IBAN masqué en détail hors rôles finance.
+ *  2. Mutations : RBAC deny-by-default (rôles existants uniquement).
+ *  3. Contact principal : appartenance au client imposée, sous transaction.
+ *  4. DELETE : archivage logique, aucune destruction physique.
+ *  5. Aucun MAX+1 : le code visible vient de fn_next_issued_code_value (ADR-0013).
+ *  6. client_code : serveur et immuable (400 explicite si fourni) ; doublon SIRET -> 409.
+ *  7. Logs HTTP sans query string (PII des recherches).
+ */
+import request from "supertest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { EventEmitter } from "events";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = { on: emitter.on.bind(emitter), query: mocks.poolQuery, connect: mocks.poolConnect };
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+// authenticateToken simulé (401 sans en-tête de test, req.user sinon) ;
+// authorizeRole RÉEL — c'est précisément le RBAC qu'on veut tester.
+vi.mock("../module/auth/middlewares/auth.middleware", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../module/auth/middlewares/auth.middleware")>();
+  return {
+    ...actual,
+    authenticateToken: (
+      req: { user?: unknown; headers: Record<string, unknown> },
+      res: { status: (n: number) => { json: (b: unknown) => void } },
+      next: () => void
+    ) => {
+      const role = typeof req.headers["x-test-role"] === "string" ? (req.headers["x-test-role"] as string) : "";
+      if (!role) {
+        res.status(401).json({ error: "Token manquant ou invalide" });
+        return;
+      }
+      req.user = { id: 1, username: "t", email: "t@t.t", role };
+      next();
+    },
+  };
+});
+
+import app from "../config/app";
+import { stripQueryFromUrl } from "../utils/logPath";
+import { maskIban } from "../module/client/client.permissions";
+
+const VALID_CREATE_PAYLOAD = {
+  company_name: "Usinage Fictif SAS",
+  status: "prospect",
+  blocked: false,
+  creation_date: "2026-07-20T00:00:00Z",
+  bill_address: { name: "Facturation", street: "1 rue des Essais", postal_code: "69001", city: "Lyon", country: "France" },
+  delivery_address: { name: "Livraison", street: "1 rue des Essais", postal_code: "69001", city: "Lyon", country: "France" },
+};
+
+function sqls(): string[] {
+  return mocks.clientQuery.mock.calls.map((c) => String(c[0]));
+}
+
+beforeEach(() => {
+  mocks.poolQuery.mockReset();
+  mocks.clientQuery.mockReset();
+  mocks.poolConnect.mockReset();
+  mocks.clientRelease.mockReset();
+
+  mocks.poolQuery.mockResolvedValue({ rows: [] });
+  mocks.poolConnect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease });
+  mocks.clientQuery.mockImplementation((sql: unknown) => {
+    const s = String(sql);
+    if (s.includes("fn_next_issued_code_value")) return Promise.resolve({ rows: [{ v: "7" }] });
+    if (s.includes("INSERT INTO adresse_facturation")) return Promise.resolve({ rows: [{ bill_address_id: "b1" }] });
+    if (s.includes("INSERT INTO adresse_livraison")) return Promise.resolve({ rows: [{ delivery_address_id: "d1" }] });
+    if (s.includes("INSERT INTO clients")) return Promise.resolve({ rows: [{ client_id: "007" }] });
+    if (s.includes("WHERE siret = $1")) return Promise.resolve({ rows: [] });
+    if (s.includes("FOR UPDATE")) {
+      return Promise.resolve({
+        rows: [{ client_id: "001", bill_address_id: "b1", delivery_address_id: "d1", bank_info_id: null, primary_contact_id: null, contact_id: null, company_name: "X", status: "client" }],
+      });
+    }
+    return Promise.resolve({ rows: [{ id: 1, created_at: "2026-07-20T00:00:00.000Z" }] });
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("P0-1 — authentification obligatoire sur toutes les routes clients", () => {
+  it.each([
+    ["GET", "/api/v1/clients"],
+    ["GET", "/api/v1/clients/analytics"],
+    ["GET", "/api/v1/clients/001"],
+    ["GET", "/api/v1/clients/001/contacts"],
+    ["GET", "/api/v1/clients/001/addresses"],
+  ])("%s %s sans jeton -> 401", async (method, url) => {
+    const res = await (method === "GET" ? request(app).get(url) : request(app).post(url));
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/v1/clients authentifié (Employee) -> 200, lecture ouverte aux rôles non-gestionnaires", async () => {
+    const res = await request(app).get("/api/v1/clients").set("x-test-role", "Employee");
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("P0-1 — minimisation des DTO", () => {
+  it("la requête SQL de liste ne sélectionne ni IBAN, ni BIC, ni phone_personal", async () => {
+    await request(app).get("/api/v1/clients").set("x-test-role", "Employee");
+    const listSql = String(mocks.poolQuery.mock.calls[0]?.[0] ?? "");
+    expect(listSql.length).toBeGreaterThan(0);
+    expect(listSql).not.toMatch(/\biban\b/i);
+    expect(listSql).not.toMatch(/\bbic\b/i);
+    expect(listSql).not.toContain("phone_personal");
+  });
+
+  it("détail : IBAN masqué et BIC/phone_personal null pour un rôle non-finance (Employee)", async () => {
+    mocks.poolQuery.mockImplementation((sql: unknown) => {
+      const s = String(sql);
+      if (s.includes("FROM clients c")) {
+        return Promise.resolve({
+          rows: [{
+            client_id: "001", client_code: "CLI-001", company_name: "X", email: null, phone: null,
+            website_url: null, siret: null, vat_number: null, naf_code: null, status: "client",
+            blocked: false, reason: null, creation_date: "2026-01-01", observations: null,
+            provided_documents_id: null, biller_id: null, biller_name: null,
+            bill_address_id: "b1", bill_name: "F", bill_street: "r", bill_house_number: null,
+            bill_address_complement: null, bill_postal_code: "69001", bill_city: "Lyon", bill_country: "France",
+            delivery_address_id: "d1", deliv_name: "L", deliv_street: "r", deliv_house_number: null,
+            deliv_address_complement: null, deliv_postal_code: "69001", deliv_city: "Lyon", deliv_country: "France",
+            bank_info_id: "k1", bank_name: "Banque Fictive", iban: "FR7630001007941234567890185", bic: "BDFEFRPP",
+            contact_id: "c0ffee00-0000-4000-8000-000000000001", first_name: "Ana", last_name: "Bode",
+            civility: null, role: null, phone_direct: "+33400000000", phone_personal: "+33600000000",
+            contact_email: "ana@fictif.fr",
+          }],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const asEmployee = await request(app).get("/api/v1/clients/001").set("x-test-role", "Employee");
+    expect(asEmployee.status).toBe(200);
+    expect(asEmployee.body.bank.iban).toBe("••••0185");
+    expect(asEmployee.body.bank.bic).toBeNull();
+    expect(asEmployee.body.bank.iban_masked).toBe(true);
+    expect(asEmployee.body.primary_contact.phone_personal).toBeNull();
+
+    const asDirecteur = await request(app).get("/api/v1/clients/001").set("x-test-role", "Directeur");
+    expect(asDirecteur.status).toBe(200);
+    expect(asDirecteur.body.bank.iban).toBe("FR7630001007941234567890185");
+    expect(asDirecteur.body.bank.bic).toBe("BDFEFRPP");
+    expect(asDirecteur.body.bank.iban_masked).toBe(false);
+    expect(asDirecteur.body.primary_contact.phone_personal).toBe("+33600000000");
+  });
+});
+
+describe("P0-2 — RBAC deny-by-default sur les mutations", () => {
+  it.each(["Employee", "Responsable Programmation", "Responsable Qualité", "Responsable RH"])(
+    "POST /api/v1/clients en %s -> 403",
+    async (role) => {
+      const res = await request(app).post("/api/v1/clients").set("x-test-role", role).send(VALID_CREATE_PAYLOAD);
+      expect(res.status).toBe(403);
+    }
+  );
+
+  it.each(["Directeur", "Administrateur Systeme et Reseau", "Secretaire"])(
+    "POST /api/v1/clients en %s -> 201",
+    async (role) => {
+      const res = await request(app).post("/api/v1/clients").set("x-test-role", role).send(VALID_CREATE_PAYLOAD);
+      expect(res.status).toBe(201);
+    }
+  );
+
+  it("DELETE en Employee -> 403 ; PATCH en Employee -> 403", async () => {
+    const del = await request(app).delete("/api/v1/clients/001").set("x-test-role", "Employee");
+    expect(del.status).toBe(403);
+    const patch = await request(app).patch("/api/v1/clients/001").set("x-test-role", "Employee").send({ phone: "+33612345678" });
+    expect(patch.status).toBe(403);
+  });
+});
+
+describe("P0-5/P0-6 — code client serveur, immuable, sans MAX+1", () => {
+  it("POST minimal -> 201 avec code généré par fn_next_issued_code_value, jamais de MAX(client_id)", async () => {
+    const res = await request(app).post("/api/v1/clients").set("x-test-role", "Secretaire").send(VALID_CREATE_PAYLOAD);
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ client_id: "007", client_code: "CLI-007" });
+    expect(sqls().some((s) => s.includes("fn_next_issued_code_value"))).toBe(true);
+    expect(sqls().some((s) => s.includes("MAX(client_id"))).toBe(false);
+  });
+
+  it("POST avec client_code fourni -> 400 CLIENT_CODE_READONLY (aucune écriture)", async () => {
+    const res = await request(app)
+      .post("/api/v1/clients")
+      .set("x-test-role", "Secretaire")
+      .send({ ...VALID_CREATE_PAYLOAD, client_code: "CLI-042" });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("CLIENT_CODE_READONLY");
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
+  it("POST avec client_code vide (payloads legacy) -> toléré, code généré serveur", async () => {
+    const res = await request(app)
+      .post("/api/v1/clients")
+      .set("x-test-role", "Secretaire")
+      .send({ ...VALID_CREATE_PAYLOAD, client_code: "" });
+    expect(res.status).toBe(201);
+    expect(res.body.client_code).toBe("CLI-007");
+  });
+
+  it("PATCH avec client_code -> 400 CLIENT_CODE_IMMUTABLE", async () => {
+    const res = await request(app)
+      .patch("/api/v1/clients/001")
+      .set("x-test-role", "Secretaire")
+      .send({ client_code: "CLI-999" });
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("CLIENT_CODE_IMMUTABLE");
+  });
+
+  it("double soumission du même SIRET -> 409 CLIENT_SIRET_EXISTS avec la fiche existante", async () => {
+    mocks.clientQuery.mockImplementation((sql: unknown) => {
+      const s = String(sql);
+      if (s.includes("WHERE siret = $1")) {
+        return Promise.resolve({ rows: [{ client_id: "003", company_name: "Déjà Là SARL", client_code: "CLI-003" }] });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    const res = await request(app)
+      .post("/api/v1/clients")
+      .set("x-test-role", "Secretaire")
+      .send({ ...VALID_CREATE_PAYLOAD, siret: "12345678900011" });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("CLIENT_SIRET_EXISTS");
+    expect(res.body.details).toEqual({ client_id: "003", company_name: "Déjà Là SARL", client_code: "CLI-003" });
+    expect(sqls().some((s) => s.includes("INSERT INTO clients"))).toBe(false);
+  });
+});
+
+describe("P0-6 — duplicate-check (corps POST, jamais de query string)", () => {
+  it("POST /duplicate-check sans critère -> 400", async () => {
+    const res = await request(app).post("/api/v1/clients/duplicate-check").set("x-test-role", "Employee").send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /duplicate-check avec SIRET -> 200 { candidates } minimisés", async () => {
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{ client_id: "003", client_code: "CLI-003", company_name: "Déjà Là SARL", status: "client", siret: "12345678900011", vat_number: null }],
+    });
+    const res = await request(app)
+      .post("/api/v1/clients/duplicate-check")
+      .set("x-test-role", "Employee")
+      .send({ siret: "12345678900011" });
+    expect(res.status).toBe(200);
+    expect(res.body.candidates).toEqual([
+      { client_id: "003", client_code: "CLI-003", company_name: "Déjà Là SARL", status: "client", matched_on: ["siret"] },
+    ]);
+    expect(JSON.stringify(res.body)).not.toContain("iban");
+  });
+});
+
+describe("P0-3 — contact principal : appartenance + transaction", () => {
+  const CONTACT_ID = "c0ffee00-0000-4000-8000-000000000002";
+
+  it("contact d'un autre client -> 422 CONTACT_NOT_OF_CLIENT, aucun UPDATE clients", async () => {
+    mocks.clientQuery.mockImplementation((sql: unknown) => {
+      const s = String(sql);
+      if (s.includes("FOR UPDATE")) return Promise.resolve({ rows: [{ contact_id: null }] });
+      if (s.includes("FROM contacts WHERE contact_id")) return Promise.resolve({ rows: [] });
+      return Promise.resolve({ rows: [{ id: 1, created_at: "2026-07-20T00:00:00.000Z" }] });
+    });
+    const res = await request(app)
+      .patch("/api/v1/clients/001/contact")
+      .set("x-test-role", "Secretaire")
+      .send({ contact_id: CONTACT_ID });
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("CONTACT_NOT_OF_CLIENT");
+    expect(sqls().some((s) => s.includes("UPDATE clients SET contact_id"))).toBe(false);
+    expect(sqls()).toContain("ROLLBACK");
+  });
+
+  it("contact du client -> 204, bascule + audit dans la même transaction", async () => {
+    mocks.clientQuery.mockImplementation((sql: unknown) => {
+      const s = String(sql);
+      if (s.includes("FOR UPDATE")) return Promise.resolve({ rows: [{ contact_id: null }] });
+      if (s.includes("FROM contacts WHERE contact_id")) return Promise.resolve({ rows: [{ "?column?": 1 }] });
+      return Promise.resolve({ rows: [{ id: 1, created_at: "2026-07-20T00:00:00.000Z" }] });
+    });
+    const res = await request(app)
+      .patch("/api/v1/clients/001/contact")
+      .set("x-test-role", "Secretaire")
+      .send({ contact_id: CONTACT_ID });
+    expect(res.status).toBe(204);
+    const emitted = sqls();
+    expect(emitted).toContain("BEGIN");
+    expect(emitted.some((s) => s.includes("UPDATE clients SET contact_id"))).toBe(true);
+    expect(emitted.some((s) => s.includes("erp_audit_logs"))).toBe(true);
+    expect(emitted).toContain("COMMIT");
+  });
+
+  it("contact_id non uuid -> 400 de validation", async () => {
+    const res = await request(app)
+      .patch("/api/v1/clients/001/contact")
+      .set("x-test-role", "Secretaire")
+      .send({ contact_id: "pas-un-uuid" });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("P0-4 — DELETE = archivage logique, aucune destruction", () => {
+  it("DELETE -> 204 : status inactif + blocked, aucun DELETE physique, audit en mode logical_archive", async () => {
+    const res = await request(app).delete("/api/v1/clients/001").set("x-test-role", "Directeur");
+    expect(res.status).toBe(204);
+    const emitted = sqls();
+    expect(emitted.some((s) => s.includes("DELETE FROM clients"))).toBe(false);
+    expect(emitted.some((s) => s.includes("DELETE FROM contacts"))).toBe(false);
+    expect(emitted.some((s) => s.includes("DELETE FROM client_payment_modes"))).toBe(false);
+    expect(emitted.some((s) => s.includes("SET status = 'inactif', blocked = true"))).toBe(true);
+    expect(emitted.some((s) => s.includes("erp_audit_logs"))).toBe(true);
+  });
+});
+
+describe("P0-7 — aucune query string dans les logs HTTP", () => {
+  it("stripQueryFromUrl retire query et fragment, conserve le chemin", () => {
+    expect(stripQueryFromUrl("/api/v1/clients?q=jane%40doe.fr&limit=25")).toBe("/api/v1/clients");
+    expect(stripQueryFromUrl("/api/v1/clients#frag")).toBe("/api/v1/clients");
+    expect(stripQueryFromUrl("/api/v1/clients/001")).toBe("/api/v1/clients/001");
+    expect(stripQueryFromUrl(undefined)).toBeNull();
+    expect(stripQueryFromUrl("")).toBeNull();
+  });
+
+  it("le log http_request d'une recherche ne contient pas l'email cherché", async () => {
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await request(app).get("/api/v1/clients?q=jane%40doe.fr").set("x-test-role", "Employee");
+    const httpLines = logSpy.mock.calls
+      .map((c) => String(c[0]))
+      .filter((line) => line.includes("http_request"));
+    expect(httpLines.length).toBeGreaterThan(0);
+    for (const line of httpLines) {
+      expect(line).not.toContain("jane");
+      expect(line).not.toContain("q=");
+    }
+    const parsed = JSON.parse(httpLines[httpLines.length - 1]);
+    expect(parsed.path).toBe("/api/v1/clients");
+  });
+});
+
+describe("maskIban", () => {
+  it("garde uniquement les 4 derniers caractères", () => {
+    expect(maskIban("FR76 3000 1007 9412 3456 7890 185")).toBe("••••0185");
+    expect(maskIban(null)).toBeNull();
+    expect(maskIban("")).toBeNull();
+    expect(maskIban("AB12")).toBe("••••");
+  });
+});

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -13,6 +13,7 @@ import { validationErrorMiddleware } from "../module/auth/middlewares/validation
 import { requestIdMiddleware } from "../middlewares/requestId";
 import { requestLogger } from "../middlewares/requestLogger";
 import { getImagesRootPath } from "../utils/imageStorage";
+import { stripQueryFromUrl } from "../utils/logPath";
 import pool from "./database";
 
 const app = express();
@@ -58,12 +59,13 @@ const corsOptionsDelegate: cors.CorsOptionsDelegate = (req, cb) => {
     typeof (req as unknown as { requestId?: unknown }).requestId === "string"
       ? ((req as unknown as { requestId?: string }).requestId ?? null)
       : null;
-  const reqPath =
+  const reqPath = stripQueryFromUrl(
     typeof (req as unknown as { originalUrl?: unknown }).originalUrl === "string"
       ? (req as unknown as { originalUrl: string }).originalUrl
       : typeof (req as unknown as { url?: unknown }).url === "string"
         ? (req as unknown as { url: string }).url
-        : null;
+        : null
+  );
 
   if (origin && !allowed) {
     console.warn(
@@ -101,8 +103,13 @@ app.options("*", cors(corsOptionsDelegate));
 
 app.use(requestLogger);
 
-// Logger
-if (process.env.NODE_ENV === "development") app.use(morgan("dev"));
+// Logger — format "dev" mais avec l'URL débarrassée de sa query string :
+// morgan(":url") rejouerait les PII des recherches (?q=email, ?siret=...) dans
+// la console, y compris en prod où NODE_ENV vaut "development" (cf. errorHandler).
+morgan.token("pathname", (req) => stripQueryFromUrl((req as { originalUrl?: string }).originalUrl) ?? "-");
+if (process.env.NODE_ENV === "development") {
+  app.use(morgan(":method :pathname :status :res[content-length] - :response-time ms"));
+}
 
 /* --------- 2) Parsers: JSON + urlencoded (sans casser multipart) --------- */
 

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from "express";
 import { HttpError } from "../utils/httpError";
 import { ApiError } from "../utils/apiError";
+import { stripQueryFromUrl } from "../utils/logPath";
 
 // Message générique renvoyé au client pour toute erreur serveur (5xx) ou inconnue.
 // CA-SEC-04 : ne jamais fuiter d'internes (message d'exception brut, nom de colonne/table,
@@ -22,11 +23,21 @@ export function errorHandler(err: any, req: Request, res: Response, _next: NextF
   const message =
     isKnown && status < 500 ? (err.message ?? GENERIC_SERVER_ERROR_MESSAGE) : GENERIC_SERVER_ERROR_MESSAGE;
 
+  // Path sans query string : les recherches métier mettent des PII en query
+  // (?q=email, ?siret=...) ; ni la réponse ni les logs ne doivent les rejouer.
+  const safePath = stripQueryFromUrl(req.originalUrl);
+
+  // details : uniquement pour les erreurs 4xx construites volontairement (HttpError/ApiError
+  // avec details explicites, ex. 409 doublon SIRET -> { client_id, company_name }). Jamais pour
+  // les 5xx/erreurs inconnues (CA-SEC-04 : aucune fuite d'internes).
   const payload = {
     success: false,
     message,
     code,
-    path: req.originalUrl,
+    path: safePath,
+    ...(err instanceof HttpError && status < 500 && typeof err.details !== "undefined"
+      ? { details: err.details }
+      : {}),
   };
 
   // logs détaillés côté serveur (JAMAIS renvoyés au client) — inclut le message réel + la stack.
@@ -36,7 +47,7 @@ export function errorHandler(err: any, req: Request, res: Response, _next: NextF
     message: err?.message ?? null,
     clientMessage: message,
     method: req.method,
-    path: req.originalUrl,
+    path: safePath,
     requestId: req.requestId ?? null,
     details: err?.details,
     stack: err?.stack,

--- a/src/middlewares/requestLogger.ts
+++ b/src/middlewares/requestLogger.ts
@@ -1,4 +1,5 @@
 import type { RequestHandler } from "express";
+import { stripQueryFromUrl } from "../utils/logPath";
 
 export const requestLogger: RequestHandler = (req, res, next) => {
   const startedAt = Date.now();
@@ -9,7 +10,7 @@ export const requestLogger: RequestHandler = (req, res, next) => {
       type: "http_request",
       requestId: req.requestId ?? null,
       method: req.method,
-      path: req.originalUrl,
+      path: stripQueryFromUrl(req.originalUrl),
       status: res.statusCode,
       durationMs,
       origin: req.headers.origin ?? null,

--- a/src/module/auth/middlewares/auth.middleware.ts
+++ b/src/module/auth/middlewares/auth.middleware.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
 import jwt from 'jsonwebtoken';
+import { stripQueryFromUrl } from '../../../utils/logPath';
 
 interface JwtPayload {
   id: number;
@@ -24,7 +25,7 @@ export const authenticateToken: RequestHandler = (req, res, next) => {
     requestId: req.requestId ?? null,
     origin: req.headers.origin ?? null,
     method: req.method,
-    path: req.originalUrl,
+    path: stripQueryFromUrl(req.originalUrl),
   };
  
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -63,7 +64,7 @@ export const authorizeRole = (...roles: string[]) => {
             requestId: req.requestId ?? null,
             origin: req.headers.origin ?? null,
             method: req.method,
-            path: req.originalUrl,
+            path: stripQueryFromUrl(req.originalUrl),
           })
         );
         res.status(401).json({ error: 'Utilisateur non authentifié' });
@@ -77,7 +78,7 @@ export const authorizeRole = (...roles: string[]) => {
             requestId: req.requestId ?? null,
             origin: req.headers.origin ?? null,
             method: req.method,
-            path: req.originalUrl,
+            path: stripQueryFromUrl(req.originalUrl),
             userId: req.user.id,
             role: req.user.role,
             allowedRoles: roles,

--- a/src/module/client/client.permissions.ts
+++ b/src/module/client/client.permissions.ts
@@ -1,0 +1,32 @@
+/**
+ * RBAC clients — rôles existants uniquement (contrainte users_role_check,
+ * db/patches/20260710_hr_users_role_responsable_rh.sql). Deny by default :
+ * toute lecture exige un utilisateur authentifié ; les écritures et la
+ * consultation des données financières complètes (IBAN en clair) sont
+ * réservées aux rôles qui gèrent le référentiel clients.
+ */
+export const CLIENT_WRITE_ROLES = [
+  "Directeur",
+  "Administrateur Systeme et Reseau",
+  "Secretaire",
+] as const;
+
+/**
+ * Matrice données sensibles (docs frontend erp-core-completion-and-sensitive-data) :
+ * IBAN/BIC = critique, masqué par défaut, complet uniquement pour compta/admin.
+ * Faute de rôle comptabilité dédié, ce sont les rôles de gestion clients.
+ */
+export const CLIENT_FINANCE_ROLES = CLIENT_WRITE_ROLES;
+
+export function canViewClientFinance(role: string | undefined | null): boolean {
+  return typeof role === "string" && (CLIENT_FINANCE_ROLES as readonly string[]).includes(role);
+}
+
+/** Keep the last 4 characters visible: enough to recognise the account, useless to replay. */
+export function maskIban(iban: string | null | undefined): string | null {
+  if (typeof iban !== "string") return null;
+  const compact = iban.replace(/\s+/g, "");
+  if (compact.length === 0) return null;
+  if (compact.length <= 4) return "••••";
+  return `••••${compact.slice(-4)}`;
+}

--- a/src/module/client/controllers/client.controller.ts
+++ b/src/module/client/controllers/client.controller.ts
@@ -171,6 +171,8 @@ export const listClientAddresses: RequestHandler = async (req, res, next) => {
   }
 };
 
+const uuidHeaderRe = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 export const postClient: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req);
@@ -179,9 +181,17 @@ export const postClient: RequestHandler = async (req, res, next) => {
       "CLIENT_CODE_READONLY",
       "Le code client est généré automatiquement par le serveur."
     );
+
+    // Rejeu sûr (double clic / retry réseau) : même clé -> même fiche, 200.
+    const idempotencyHeader = req.headers["idempotency-key"];
+    const idempotencyKey = typeof idempotencyHeader === "string" ? idempotencyHeader.trim() : "";
+    if (idempotencyKey && !uuidHeaderRe.test(idempotencyKey)) {
+      throw new HttpError(400, "IDEMPOTENCY_KEY_INVALID", "Idempotency-Key doit être un UUID.");
+    }
+
     const dto = createClientSchema.parse(req.body);
-    const created = await repoCreateClient(dto, audit);
-    res.status(201).json(created); // { client_id, client_code }
+    const { replayed, ...created } = await repoCreateClient(dto, audit, idempotencyKey || null);
+    res.status(replayed ? 200 : 201).json(created); // { client_id, client_code }
   } catch (e) {
     next(e);
   }

--- a/src/module/client/controllers/client.controller.ts
+++ b/src/module/client/controllers/client.controller.ts
@@ -1,54 +1,53 @@
 // src/module/client/controllers/client.controller.ts
-import { Request, RequestHandler, Response } from "express";
+import { Request, RequestHandler } from "express";
 import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import { stripQueryFromUrl } from "../../../utils/logPath";
 
 import * as clientService from "../services/client.service"; // ✅ namespace import
 import { svcGetClientById, svcListClientAddresses } from "../services/clients.read.service";
-import { createClientSchema, createClientContactBodySchema, clientPatchSchema } from "../validators/client.validators";
-import { type AuditContext, repoArchiveClient, repoCreateClient, repoDeleteClient, repoPatchClient } from "../repository/client.repository";
-import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
-import path from "node:path";
-// import { LOGO_BASE_DIR } from "../upload/client-logo-upload";
-import { updateClientLogoPath } from "../services/client.service";
+import {
+  createClientSchema,
+  createClientContactBodySchema,
+  clientPatchSchema,
+  duplicateCheckSchema,
+  setPrimaryContactSchema,
+} from "../validators/client.validators";
+import {
+  type AuditContext,
+  repoArchiveClient,
+  repoCheckDuplicates,
+  repoCreateClient,
+  repoCreateClientContact,
+  repoDeleteClient,
+  repoPatchClient,
+  repoSetPrimaryContact,
+} from "../repository/client.repository";
+import { canViewClientFinance } from "../client.permissions";
 
-
+// Upload logo désactivé (CA-APP-05) : la route et ce handler restent commentés
+// tant qu'un upload sécurisé (auth + RBAC + sniffing MIME + taille max + nom
+// serveur) n'est pas spécifié. Réactiver imposera de réimporter node:path,
+// LOGO_BASE_DIR et updateClientLogoPath.
 // export const uploadClientLogo: RequestHandler = async (req, res, next) => {
 //   try {
 //     const clientId = req.params.id;
-
 //     if (!clientId) {
 //       return res.status(400).json({ message: "client_id manquant dans l'URL" });
 //     }
-
 //     const file = (req as any).file as Express.Multer.File | undefined;
-
 //     if (!file) {
 //       return res.status(400).json({ message: "Aucun fichier 'logo' reçu" });
 //     }
-
-//     // chemin absolu sur le VPS (ex: /mnt/crp/CLIENTS/005/LOGOS/005_111225_LOGO.png)
 //     const absolutePath = file.path;
-
-//     // ➜ chemin relatif par rapport à LOGO_BASE_DIR (CLIENTS)
-//     // Exemple: "005/LOGOS/005_111225_LOGO.png"
 //     let relativePath = path.relative(LOGO_BASE_DIR, absolutePath);
-
-//     // normalisation pour éviter les "\" en DB
 //     relativePath = relativePath.replace(/\\/g, "/");
-
-//     // update BDD
 //     await updateClientLogoPath(clientId, relativePath);
-
-//     return res.status(200).json({
-//       client_id: clientId,
-//       logo_path: relativePath, // ce qui est stocké en DB
-//     });
+//     return res.status(200).json({ client_id: clientId, logo_path: relativePath });
 //   } catch (e) {
 //     next(e);
 //   }
 // };
-
 
 function buildAuditContext(req: Request): AuditContext {
   const user = req.user;
@@ -75,7 +74,9 @@ function buildAuditContext(req: Request): AuditContext {
     device_type: device.device_type,
     os: device.os,
     browser: device.browser,
-    path: req.originalUrl ?? null,
+    // Sans query string : les recherches mettent des PII en query (?q=email),
+    // le contexte d'audit n'a besoin que du chemin + page_key.
+    path: stripQueryFromUrl(req.originalUrl),
     page_key: pageKey,
     client_session_id: clientSessionId,
   };
@@ -87,9 +88,24 @@ function routeParam(req: Request, name: string): string {
   throw new HttpError(400, "INVALID_ROUTE_PARAM", `${name} must be a string`);
 }
 
+/**
+ * Le code visible est généré côté serveur et immuable (ADR-0013). Toute valeur
+ * non vide fournie par le client est rejetée explicitement — aucune ambiguïté,
+ * pas d'écrasement silencieux. Les chaînes vides des anciens payloads restent
+ * tolérées (elles signifiaient déjà « laisse le serveur générer »).
+ */
+function rejectClientCodeInBody(body: unknown, code: string, message: string) {
+  if (!body || typeof body !== "object") return;
+  const value = (body as Record<string, unknown>).client_code;
+  if (typeof value === "string" && value.trim() === "") return;
+  if (value === undefined || value === null) return;
+  throw new HttpError(400, code, message);
+}
+
 export const getClientById: RequestHandler = async (req, res, next) => {
   try {
-    const row = await svcGetClientById(routeParam(req, "id"));
+    const includeSensitiveFinance = canViewClientFinance(req.user?.role);
+    const row = await svcGetClientById(routeParam(req, "id"), { includeSensitiveFinance });
     if (!row) {
       res.status(404).json({ message: "Client not found" });
       return;
@@ -124,7 +140,9 @@ export const listClients: RequestHandler = async (req, res, next) => {
 export const listClientContacts: RequestHandler = async (req, res, next) => {
   try {
     const clientId = routeParam(req, "clientId");
-    const rows = await clientService.listClientContacts(clientId);
+    const rows = await clientService.listClientContacts(clientId, {
+      includePersonalPhone: canViewClientFinance(req.user?.role),
+    });
     res.json(rows);
   } catch (e) {
     next(e);
@@ -133,9 +151,10 @@ export const listClientContacts: RequestHandler = async (req, res, next) => {
 
 export const postClientContact: RequestHandler = async (req, res, next) => {
   try {
+    const audit = buildAuditContext(req);
     const clientId = routeParam(req, "clientId");
     const dto = createClientContactBodySchema.parse(req.body);
-    const created = await clientService.createClientContact(clientId, dto);
+    const created = await repoCreateClientContact(clientId, dto, audit);
     res.status(201).json(created);
   } catch (e) {
     next(e);
@@ -155,9 +174,24 @@ export const listClientAddresses: RequestHandler = async (req, res, next) => {
 export const postClient: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req);
+    rejectClientCodeInBody(
+      req.body,
+      "CLIENT_CODE_READONLY",
+      "Le code client est généré automatiquement par le serveur."
+    );
     const dto = createClientSchema.parse(req.body);
     const created = await repoCreateClient(dto, audit);
-    res.status(201).json(created); // { client_id }
+    res.status(201).json(created); // { client_id, client_code }
+  } catch (e) {
+    next(e);
+  }
+};
+
+export const checkClientDuplicates: RequestHandler = async (req, res, next) => {
+  try {
+    const criteria = duplicateCheckSchema.parse(req.body);
+    const candidates = await repoCheckDuplicates(criteria);
+    res.json({ candidates });
   } catch (e) {
     next(e);
   }
@@ -167,28 +201,9 @@ export const patchClientPrimaryContact: RequestHandler = async (req, res, next) 
   try {
     const audit = buildAuditContext(req);
     const clientId = routeParam(req, "id");
-    const { contact_id } = req.body as { contact_id: string };
-    await clientService.updateClientPrimaryContact(clientId, contact_id);
-
-    await repoInsertAuditLog({
-      user_id: audit.user_id,
-      body: {
-        event_type: "ACTION",
-        action: "CLIENT_PRIMARY_CONTACT_SET",
-        page_key: audit.page_key,
-        entity_type: "client",
-        entity_id: clientId,
-        path: audit.path,
-        client_session_id: audit.client_session_id,
-        details: { contact_id },
-      },
-      ip: audit.ip,
-      user_agent: audit.user_agent,
-      device_type: audit.device_type,
-      os: audit.os,
-      browser: audit.browser,
-    });
-
+    const { contact_id } = setPrimaryContactSchema.parse(req.body);
+    // Appartenance au client + affectation + audit sous une même transaction.
+    await repoSetPrimaryContact(clientId, contact_id, audit);
     res.status(204).end();
   } catch (e) {
     next(e);
@@ -199,6 +214,12 @@ export const patchClient: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req);
     const id = routeParam(req, "id");
+
+    rejectClientCodeInBody(
+      req.body,
+      "CLIENT_CODE_IMMUTABLE",
+      "Le code client est immuable : il ne peut pas être modifié."
+    );
 
     // Vrai PATCH partiel : on valide avec un schéma partiel (validateurs par champ préservés),
     // puis on ne conserve que les champs RÉELLEMENT présents dans le body (les .default() du
@@ -224,6 +245,7 @@ export const deleteClient: RequestHandler = async (req, res, next) => {
     const audit = buildAuditContext(req);
     const id = routeParam(req, "id");
 
+    // Archivage logique — aucune suppression physique (voir repoDeleteClient).
     await repoDeleteClient(id, audit);
     res.status(204).end();
   } catch (e) {
@@ -242,4 +264,3 @@ export const archiveClient: RequestHandler = async (req, res, next) => {
     next(e);
   }
 };
-

--- a/src/module/client/repository/client.repository.ts
+++ b/src/module/client/repository/client.repository.ts
@@ -7,7 +7,8 @@ import type { CreateClientDTO, ClientPatchDTO } from "../validators/client.valid
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import { generateClientCode } from "../../../shared/codes/code-generator.service";
-import { codeFormatExample, isValidCode } from "../../../shared/codes/code-validator";
+import type { CreateClientContactInput, ClientContactRow } from "../services/client.service";
+import type { DuplicateCheckDTO } from "../validators/client.validators";
 
 export type AuditContext = {
   user_id: number;
@@ -23,13 +24,8 @@ export type AuditContext = {
 
 type DbQueryer = Pick<PoolClient, "query">;
 
-const clientCodeInvalidMessage = `Le code client doit être au format ${codeFormatExample("client")}.`;
 const clientCodeExistsMessage = "Un client avec ce code existe déjà.";
-const clientCodeRequiredMessage = "Le code client est obligatoire.";
-
-function isPgForeignKeyViolation(err: unknown): boolean {
-  return (err as { code?: unknown } | null)?.code === "23503";
-}
+const clientSiretExistsMessage = "Un client avec ce SIRET existe déjà.";
 
 function getPgErrorInfo(err: unknown): { code: string | null; constraint: string | null } {
   const e = err as { code?: unknown; constraint?: unknown } | null;
@@ -72,14 +68,6 @@ async function insertAuditLog(
   });
 }
 
-/** 001, 002, ... (3 chars) */
-async function nextClientId(client: any): Promise<string> {
-  const { rows } = await client.query(
-    `SELECT LPAD(CAST(COALESCE(MAX(client_id)::int,0)+1 AS text),3,'0') AS next_id FROM clients`
-  );
-  return rows[0].next_id as string;
-}
-
 async function insertAddressFacturation(client: any, a: CreateClientDTO["bill_address"]) {
   const { rows } = await client.query(
     `INSERT INTO adresse_facturation (street,house_number,address_complement,postal_code,city,country,name)
@@ -90,19 +78,32 @@ async function insertAddressFacturation(client: any, a: CreateClientDTO["bill_ad
   return rows[0].bill_address_id as string;
 }
 
-async function ensureClientCodeAvailable(db: any, clientCode: string, excludeClientId?: string) {
-  const result = await db.query(
-    `SELECT client_id::text AS client_id
-       FROM clients
-      WHERE client_code = $1
-      LIMIT 1`,
-    [clientCode]
-  );
+/**
+ * Duplicate guard on SIRET (14 digits = unique legal establishment id).
+ * Application-level check inside the same transaction : legacy rows may hold
+ * duplicates, so a DB unique index cannot be created yet (see patch verify
+ * script). The race window left open is closed operationally by this check +
+ * the audit trail; the unique index is the documented target once legacy data
+ * is confirmed clean.
+ */
+async function ensureSiretAvailable(db: DbQueryer, siret: string | null | undefined, excludeClientId?: string) {
+  const normalized = typeof siret === "string" ? siret.trim() : "";
+  if (!normalized) return;
 
-  const rows = result.rows as Array<{ client_id: string }>;
-  const existingClientId = rows[0]?.client_id ?? null;
-  if (existingClientId && existingClientId !== excludeClientId) {
-    throw new HttpError(409, "CLIENT_CODE_EXISTS", clientCodeExistsMessage);
+  const result = await db.query(
+    `SELECT client_id::text AS client_id, company_name, client_code
+       FROM clients
+      WHERE siret = $1
+      LIMIT 1`,
+    [normalized]
+  );
+  const existing = (result.rows as Array<{ client_id: string; company_name: string; client_code: string | null }>)[0];
+  if (existing && existing.client_id !== excludeClientId) {
+    throw new HttpError(409, "CLIENT_SIRET_EXISTS", clientSiretExistsMessage, {
+      client_id: existing.client_id,
+      company_name: existing.company_name,
+      client_code: existing.client_code,
+    });
   }
 }
 
@@ -335,17 +336,13 @@ export async function repoCreateClient(
   try {
     await db.query('BEGIN');
 
-    const clientCode = await (async (): Promise<string> => {
-      const provided = (dto.client_code ?? "").trim();
-      if (provided) {
-        if (!isValidCode("client", provided)) {
-          throw new HttpError(400, "CLIENT_CODE_INVALID", clientCodeInvalidMessage);
-        }
-        await ensureClientCodeAvailable(db, provided);
-        return provided;
-      }
-      return generateClientCode(db);
-    })();
+    // Doublon légal : un même établissement (SIRET) ne peut pas donner deux fiches.
+    await ensureSiretAvailable(db, dto.siret);
+
+    // Code visible : exclusivement généré côté serveur, dans la transaction,
+    // via la séquence non réutilisable de l'ADR-0013. Aucune valeur cliente
+    // n'est acceptée (le contrôleur rejette toute tentative en amont).
+    const clientCode = await generateClientCode(db);
 
     const billAddrId = await insertAddressFacturation(db, dto.bill_address);
     const delivAddrId = await insertAddressLivraison(db, dto.delivery_address);
@@ -414,7 +411,7 @@ export async function repoCreateClient(
 // EDIT CLIENT 
 
 // PATCH partiel : ne met à jour QUE les champs réellement fournis. Un champ absent n'est
-// jamais écrasé ni supprimé (contrairement à repoUpdateClient qui fait un remplacement complet).
+// jamais écrasé ni supprimé, et aucun contact existant n'est détruit par ce chemin.
 // La liste des champs fournis (`fields`) vient du contrôleur (clés réellement présentes dans le body).
 export async function repoPatchClient(
   id: string,
@@ -474,12 +471,11 @@ export async function repoPatchClient(
       put((p) => `provided_documents_id = ${p}`, docs);
     }
     if (has("quality_levels")) put((p) => `quality_levels = ${p}::text[]`, patch.quality_levels ?? []);
-    if (has("client_code")) {
-      const provided = (patch.client_code ?? "").trim();
-      if (!provided) throw new HttpError(400, "CLIENT_CODE_REQUIRED", clientCodeRequiredMessage);
-      if (!isValidCode("client", provided)) throw new HttpError(400, "CLIENT_CODE_INVALID", clientCodeInvalidMessage);
-      await ensureClientCodeAvailable(db, provided, id);
-      put((p) => `client_code = ${p}`, provided);
+    // client_code n'est jamais patchable : code visible immuable, généré serveur
+    // (ADR-0013). Toute tentative est rejetée en amont par le contrôleur.
+
+    if (has("siret")) {
+      await ensureSiretAvailable(db, patch.siret, id);
     }
 
     if (sets.length > 0) {
@@ -566,306 +562,23 @@ export async function repoPatchClient(
   }
 }
 
-export async function repoUpdateClient(id: string, dto: CreateClientDTO, audit: AuditContext): Promise<void> {
-  const db = await pool.connect();
-  try {
-    await db.query("BEGIN");
-
-    // 1) Verrouiller le client + récupérer IDs liés (+ contact_id existant)
-    const current = await db.query(
-      `SELECT client_id,
-              blocked,
-              bill_address_id,
-              delivery_address_id,
-              bank_info_id,
-              contact_id AS primary_contact_id
-         FROM clients
-        WHERE client_id = $1
-        FOR UPDATE`,
-      [id]
-    );
-
-    if (current.rows.length === 0) {
-      const err = new Error("Client not found");
-      (err as any).status = 404;
-      throw err;
-    }
-
-    const {
-      bill_address_id,
-      delivery_address_id,
-      bank_info_id,
-      primary_contact_id,
-      blocked: blocked_before,
-    } = current.rows[0] as {
-      bill_address_id: string | null;
-      delivery_address_id: string | null;
-      bank_info_id: string | null;
-      primary_contact_id: string | null;
-      blocked: boolean | null;
-    };
-
-    const wasBlocked = Boolean(blocked_before);
-
-    // 2) Mise à jour Adresse de facturation
-    if (bill_address_id) {
-      await db.query(
-        `UPDATE adresse_facturation
-            SET street       = $1,
-                house_number = $2,
-                address_complement = $3,
-                postal_code  = $4,
-                city         = $5,
-                country      = $6,
-                name         = $7
-          WHERE bill_address_id = $8`,
-        [
-          dto.bill_address.street,
-          dto.bill_address.house_number ?? null,
-          dto.bill_address.address_complement ?? null,
-          dto.bill_address.postal_code,
-          dto.bill_address.city,
-          dto.bill_address.country,
-          dto.bill_address.name,
-          bill_address_id,
-        ]
-      );
-    }
-
-    // 3) Mise à jour Adresse de livraison
-    if (delivery_address_id) {
-      await db.query(
-        `UPDATE adresse_livraison
-            SET street       = $1,
-                house_number = $2,
-                address_complement = $3,
-                postal_code  = $4,
-                city         = $5,
-                country      = $6,
-                name         = $7
-          WHERE delivery_address_id = $8`,
-        [
-          dto.delivery_address.street,
-          dto.delivery_address.house_number ?? null,
-          dto.delivery_address.address_complement ?? null,
-          dto.delivery_address.postal_code,
-          dto.delivery_address.city,
-          dto.delivery_address.country,
-          dto.delivery_address.name,
-          delivery_address_id,
-        ]
-      );
-    }
-
-    // 4) Banque : upsert + rattachement au client
-    if (dto.bank) {
-      const newBankInfoId = await upsertBank(db, dto.bank);
-      if (!bank_info_id || bank_info_id !== newBankInfoId) {
-        await db.query(
-          `UPDATE clients SET bank_info_id = $1 WHERE client_id = $2`,
-          [newBankInfoId, id]
-        );
-      }
-    }
-
-    // 5) Normalisation provided_documents_id
-    const normalizedProvidedDocsId =
-      dto.provided_documents_id && dto.provided_documents_id.trim() !== ""
-        ? dto.provided_documents_id
-        : null;
-
-    const normalizedBillerId =
-      typeof dto.biller_id === "string" && dto.biller_id.trim() !== "" ? dto.biller_id : null;
-
-    const clientCodeToSet = await (async (): Promise<string | null> => {
-      if (dto.client_code === undefined) return null;
-      const provided = (dto.client_code ?? "").trim();
-      if (!provided) {
-        throw new HttpError(400, "CLIENT_CODE_REQUIRED", clientCodeRequiredMessage);
-      }
-      if (!isValidCode("client", provided)) {
-        throw new HttpError(400, "CLIENT_CODE_INVALID", clientCodeInvalidMessage);
-      }
-
-      await ensureClientCodeAvailable(db, provided, id);
-      return provided;
-    })();
-
-    // 6) Mise à jour des champs principaux du client
-    try {
-      await db.query(
-      `
-      UPDATE clients
-         SET company_name          = $1,
-             client_code           = COALESCE($2, client_code),
-              email                 = NULLIF($3,''),
-              phone                 = NULLIF($4,''),
-              website_url           = NULLIF($5,''),
-              siret                 = NULLIF($6,''),
-              vat_number            = NULLIF($7,''),
-              naf_code              = NULLIF($8,''),
-              status                = $9,
-              blocked               = $10,
-              reason                = NULLIF($11,''),
-              creation_date         = COALESCE($12::timestamp, creation_date),
-              biller_id             = $13,
-              observations          = NULLIF($14,''),
-              provided_documents_id = $15,
-              quality_levels        = COALESCE($16::text[], '{}')
-       WHERE client_id = $17
-      `,
-      [
-        dto.company_name,
-        clientCodeToSet,
-        dto.email ?? "",
-        dto.phone ?? "",
-        dto.website_url ?? "",
-        dto.siret ?? "",
-        dto.vat_number ?? "",
-        dto.naf_code ?? "",
-        dto.status,
-        dto.blocked,
-        dto.reason ?? "",
-        dto.creation_date,
-        normalizedBillerId,
-        dto.observations ?? "",
-        normalizedProvidedDocsId,
-        dto.quality_levels ?? [],
-        id,
-      ]
-      );
-    } catch (err) {
-      const { code, constraint } = getPgErrorInfo(err);
-      if (code === "23505" && constraint === "clients_client_code_key") {
-        throw new HttpError(409, "CLIENT_CODE_EXISTS", clientCodeExistsMessage);
-      }
-      throw err;
-    }
-
-    // 7) Contacts : upsert en gardant les contact_id
-
-    // 7.1 Récupérer les contacts existants pour ce client
-    const existingContactIds = await fetchExistingContacts(db, id); // string[]
-
-    const payloadContacts = Array.isArray(dto.contacts) ? dto.contacts : [];
-
-    const usedContactIds = new Set<string>();
-    const newContactIds: string[] = [];
-
-    // 7.2 Upsert de chaque contact du payload
-    for (const c of payloadContacts) {
-      const cid = (c as any).contact_id as string | undefined;
-
-      if (cid && existingContactIds.includes(cid)) {
-        // 🔁 UPDATE contact existant
-        await updateContact(db, cid, c);
-        usedContactIds.add(cid);
-      } else {
-        // 🆕 INSERT nouveau contact
-        const newId = await insertContact(db, c, id);
-        newContactIds.push(newId);
-        usedContactIds.add(newId);
-        (c as any).contact_id = newId; // utile si on veut s’y référer pour le primary_contact
-      }
-    }
-
-    // 7.3 Supprimer les contacts qui ne sont plus dans le payload
-    const toDelete = existingContactIds.filter((cid: string) => !usedContactIds.has(cid));
-    if (toDelete.length) {
-      await db.query(
-        `DELETE FROM contacts WHERE client_id = $1 AND contact_id = ANY($2::uuid[])`,
-        [id, toDelete]
-      );
-    }
-
-    // 8) Primary contact
-
-    let finalPrimaryContactId: string | null = primary_contact_id;
-
-    if (dto.primary_contact) {
-      const pc = dto.primary_contact as any;
-      if (pc.contact_id && usedContactIds.has(pc.contact_id)) {
-        // 👉 Primary = un contact existant (ou nouvellement lié) du client
-        finalPrimaryContactId = pc.contact_id;
-      } else {
-        // pas d'id ou pas dans la liste → on crée/maj un contact dédié
-        if (primary_contact_id) {
-          // update l’existant
-          await updateContact(db, primary_contact_id, dto.primary_contact);
-          finalPrimaryContactId = primary_contact_id;
-        } else {
-          // create nouveau
-          const newPrimaryId = await insertPrimaryContact(db, dto.primary_contact, id);
-          finalPrimaryContactId = newPrimaryId;
-        }
-      }
-    } else {
-      // pas de primary_contact dans le payload :
-      // si on a déjà des contacts utilisés, on peut en prendre un
-      if (!finalPrimaryContactId && usedContactIds.size > 0) {
-        finalPrimaryContactId = Array.from(usedContactIds)[0];
-      }
-    }
-
-    await db.query(
-      `UPDATE clients SET contact_id = $1 WHERE client_id = $2`,
-      [finalPrimaryContactId, id]
-    );
-
-    // 9) Modes de règlement : reset + relink
-    await db.query(`DELETE FROM client_payment_modes WHERE client_id = $1`, [id]);
-    await linkPaymentModes(db, id, dto.payment_mode_ids);
-
-    const contactsAdded = newContactIds.length;
-    const contactsDeleted = toDelete.length;
-    const paymentModesCount = Array.isArray(dto.payment_mode_ids) ? dto.payment_mode_ids.length : 0;
-
-    await insertAuditLog(db, audit, {
-      action: "CLIENT_UPDATE",
-      entity_type: "client",
-      entity_id: id,
-      details: {
-        client_id: id,
-        company_name: dto.company_name,
-        status: dto.status,
-        blocked: dto.blocked,
-        payment_modes_count: paymentModesCount,
-        contacts_added: contactsAdded,
-        contacts_deleted: contactsDeleted,
-      },
-    });
-
-    if (wasBlocked !== dto.blocked) {
-      await insertAuditLog(db, audit, {
-        action: dto.blocked ? "CLIENT_BLOCK" : "CLIENT_UNBLOCK",
-        entity_type: "client",
-        entity_id: id,
-        details: {
-          from: wasBlocked,
-          to: dto.blocked,
-          reason: dto.reason ?? null,
-        },
-      });
-    }
-
-    await db.query("COMMIT");
-  } catch (e) {
-    await db.query("ROLLBACK");
-    throw e;
-  } finally {
-    db.release();
-  }
-}
-
+/**
+ * « Suppression » d'un client = archivage logique (#162).
+ * Aucune destruction physique : le client, ses contacts et ses modes de paiement
+ * sont conservés pour la traçabilité industrielle et les obligations RGPD de
+ * rétention contrôlée. Le client passe en status 'inactif' + blocked, et la
+ * demande de suppression est auditée comme telle.
+ */
 export async function repoDeleteClient(id: string, audit: AuditContext): Promise<void> {
   const db = await pool.connect();
   try {
     await db.query("BEGIN");
 
-    const currentRes = await db.query<{ client_id: string; company_name: string }>(
+    const currentRes = await db.query<{ client_id: string; company_name: string; status: string }>(
       `
         SELECT client_id::text AS client_id,
-               company_name
+               company_name,
+               status::text AS status
           FROM clients
          WHERE client_id = $1
          FOR UPDATE
@@ -878,13 +591,7 @@ export async function repoDeleteClient(id: string, audit: AuditContext): Promise
       throw new HttpError(404, "CLIENT_NOT_FOUND", "Client not found");
     }
 
-    // Break FK from clients.contact_id -> contacts.contact_id before deleting contacts.
-    await db.query(`UPDATE clients SET contact_id = NULL WHERE client_id = $1`, [id]);
-
-    await db.query(`DELETE FROM client_payment_modes WHERE client_id = $1`, [id]);
-    await db.query(`DELETE FROM contacts WHERE client_id = $1`, [id]);
-
-    await db.query(`DELETE FROM clients WHERE client_id = $1`, [id]);
+    await db.query(`UPDATE clients SET status = 'inactif', blocked = true WHERE client_id = $1`, [id]);
 
     await insertAuditLog(db, audit, {
       action: "CLIENT_DELETE",
@@ -893,15 +600,15 @@ export async function repoDeleteClient(id: string, audit: AuditContext): Promise
       details: {
         client_id: id,
         company_name: current.company_name,
+        mode: "logical_archive",
+        from_status: current.status,
+        to_status: "inactif",
       },
     });
 
     await db.query("COMMIT");
   } catch (err) {
     await db.query("ROLLBACK");
-    if (isPgForeignKeyViolation(err)) {
-      throw new HttpError(409, "CLIENT_IN_USE", "Client is referenced and cannot be deleted");
-    }
     throw err;
   } finally {
     db.release();
@@ -956,3 +663,204 @@ export async function repoArchiveClient(id: string, audit: AuditContext): Promis
 
 
 
+
+/**
+ * Contact principal : le contact doit appartenir au client ciblé, et la
+ * bascule (vérification + affectation + audit) se fait sous transaction avec
+ * verrou FOR UPDATE — un contact d'un autre client ne peut jamais devenir
+ * principal (#162, constat P0-3).
+ */
+export async function repoSetPrimaryContact(
+  clientId: string,
+  contactId: string,
+  audit: AuditContext
+): Promise<void> {
+  const db = await pool.connect();
+  try {
+    await db.query("BEGIN");
+
+    const clientRes = await db.query<{ contact_id: string | null }>(
+      `SELECT contact_id FROM clients WHERE client_id = $1 FOR UPDATE`,
+      [clientId]
+    );
+    if (clientRes.rows.length === 0) {
+      throw new HttpError(404, "CLIENT_NOT_FOUND", "Client not found");
+    }
+    const previousContactId = clientRes.rows[0]?.contact_id ?? null;
+
+    const ownership = await db.query(
+      `SELECT 1 FROM contacts WHERE contact_id = $1 AND client_id = $2 LIMIT 1`,
+      [contactId, clientId]
+    );
+    if (ownership.rows.length === 0) {
+      throw new HttpError(
+        422,
+        "CONTACT_NOT_OF_CLIENT",
+        "Ce contact n'appartient pas à ce client."
+      );
+    }
+
+    await db.query(`UPDATE clients SET contact_id = $1 WHERE client_id = $2`, [contactId, clientId]);
+
+    await insertAuditLog(db, audit, {
+      action: "CLIENT_PRIMARY_CONTACT_SET",
+      entity_type: "client",
+      entity_id: clientId,
+      details: { contact_id: contactId, previous_contact_id: previousContactId },
+    });
+
+    await db.query("COMMIT");
+  } catch (err) {
+    await db.query("ROLLBACK");
+    throw err;
+  } finally {
+    db.release();
+  }
+}
+
+/**
+ * Création d'un contact + éventuelle promotion en principal, sous une seule
+ * transaction (l'ancien chemin service faisait deux requêtes séparées hors
+ * transaction : un échec de la seconde laissait un état incohérent).
+ */
+export async function repoCreateClientContact(
+  clientId: string,
+  input: CreateClientContactInput,
+  audit: AuditContext
+): Promise<ClientContactRow> {
+  const db = await pool.connect();
+  try {
+    await db.query("BEGIN");
+
+    const clientRes = await db.query(
+      `SELECT 1 FROM clients WHERE client_id = $1 FOR UPDATE`,
+      [clientId]
+    );
+    if (clientRes.rows.length === 0) {
+      throw new HttpError(404, "CLIENT_NOT_FOUND", "Client not found");
+    }
+
+    const { rows } = await db.query(
+      `
+      INSERT INTO contacts (first_name,last_name,civility,role,phone_direct,phone_personal,email,client_id)
+      VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+      RETURNING
+        contact_id::text AS contact_id,
+        first_name,
+        last_name,
+        email,
+        phone_direct,
+        phone_personal,
+        role,
+        civility
+      `,
+      [
+        input.first_name,
+        input.last_name,
+        input.civility ?? null,
+        input.role ?? null,
+        input.phone_direct ?? null,
+        input.phone_personal ?? null,
+        input.email,
+        clientId,
+      ]
+    );
+    const row = rows[0] as Omit<ClientContactRow, "label">;
+
+    if (input.set_primary) {
+      await db.query(`UPDATE clients SET contact_id = $1 WHERE client_id = $2`, [row.contact_id, clientId]);
+    }
+
+    await insertAuditLog(db, audit, {
+      action: "CLIENT_CONTACT_CREATE",
+      entity_type: "client",
+      entity_id: clientId,
+      details: { contact_id: row.contact_id, set_primary: Boolean(input.set_primary) },
+    });
+
+    await db.query("COMMIT");
+    return { ...row, label: `${row.first_name} ${row.last_name} — ${row.email}` };
+  } catch (err) {
+    await db.query("ROLLBACK");
+    throw err;
+  } finally {
+    db.release();
+  }
+}
+
+/**
+ * Recherche de doublons candidats (SIRET exact, TVA exacte, raison sociale
+ * insensible à la casse). Lecture seule, réponse minimisée : identité et
+ * critères correspondants uniquement — jamais de coordonnées ni de PII.
+ */
+export async function repoCheckDuplicates(criteria: DuplicateCheckDTO): Promise<
+  Array<{
+    client_id: string;
+    client_code: string | null;
+    company_name: string;
+    status: string;
+    matched_on: string[];
+  }>
+> {
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  const push = (value: unknown) => {
+    params.push(value);
+    return `$${params.length}`;
+  };
+
+  if (criteria.siret) conditions.push(`c.siret = ${push(criteria.siret)}`);
+  if (criteria.vat_number) conditions.push(`UPPER(c.vat_number) = UPPER(${push(criteria.vat_number)})`);
+  if (criteria.company_name) conditions.push(`LOWER(c.company_name) = LOWER(${push(criteria.company_name)})`);
+  if (conditions.length === 0) return [];
+
+  let excludeSql = "";
+  if (criteria.exclude_client_id) {
+    excludeSql = ` AND c.client_id::text <> ${push(criteria.exclude_client_id)}`;
+  }
+
+  const { rows } = await pool.query(
+    `
+    SELECT
+      c.client_id::text AS client_id,
+      COALESCE(
+        NULLIF(btrim(to_jsonb(c)->>'client_code'), ''),
+        NULLIF(btrim(to_jsonb(c)->>'code_client'), '')
+      ) AS client_code,
+      c.company_name,
+      c.status::text AS status,
+      c.siret,
+      c.vat_number
+    FROM clients c
+    WHERE (${conditions.join(" OR ")})${excludeSql}
+    ORDER BY c.company_name ASC
+    LIMIT 10
+    `,
+    params
+  );
+
+  return (rows as Array<{
+    client_id: string;
+    client_code: string | null;
+    company_name: string;
+    status: string;
+    siret: string | null;
+    vat_number: string | null;
+  }>).map((r) => {
+    const matched: string[] = [];
+    if (criteria.siret && r.siret === criteria.siret) matched.push("siret");
+    if (criteria.vat_number && (r.vat_number ?? "").toUpperCase() === criteria.vat_number.toUpperCase()) {
+      matched.push("vat_number");
+    }
+    if (criteria.company_name && r.company_name.toLowerCase() === criteria.company_name.toLowerCase()) {
+      matched.push("company_name");
+    }
+    return {
+      client_id: r.client_id,
+      client_code: r.client_code,
+      company_name: r.company_name,
+      status: r.status,
+      matched_on: matched,
+    };
+  });
+}

--- a/src/module/client/repository/client.repository.ts
+++ b/src/module/client/repository/client.repository.ts
@@ -134,7 +134,8 @@ async function insertClient(
   billAddrId: string,
   delivAddrId: string,
   bankInfoId: string | null,
-  clientCode: string
+  clientCode: string,
+  createdBy: number
 ): Promise<string> {
   const normalizedProvidedDocsId =
     dto.provided_documents_id && dto.provided_documents_id.trim() !== ''
@@ -154,7 +155,9 @@ async function insertClient(
     biller_id,
      delivery_address_id, bill_address_id, bank_info_id,
     observations, provided_documents_id,
-    quality_levels               
+    quality_levels,
+    devise, encours_max, incoterm, langue,
+    created_by, updated_by
   ) VALUES (
     $1,$2,$3,
     NULLIF($4,''), NULLIF($5,''), NULLIF($6,''),
@@ -163,7 +166,9 @@ async function insertClient(
     $14,
     $15, $16, $17,
     NULLIF($18,''), $19,
-    COALESCE($20::text[], '{}')   
+    COALESCE($20::text[], '{}'),
+    NULLIF($21,''), $22, NULLIF($23,''), NULLIF($24,''),
+    $25, $25
   )
   RETURNING client_id
 `;
@@ -178,7 +183,9 @@ async function insertClient(
    normalizedBillerId,
    delivAddrId, billAddrId, bankInfoId,
    dto.observations ?? "", normalizedProvidedDocsId,
-   dto.quality_levels ?? []              // ⬅️ nouveau param
+   dto.quality_levels ?? [],
+   dto.devise ?? "", dto.encours_max ?? null, dto.incoterm ?? "", dto.langue ?? "",
+   createdBy
 ]);
 
   return rows[0].client_id as string;
@@ -328,13 +335,41 @@ async function resolvePaymentIds(db: any, ids: string[]): Promise<string[]> {
 
 
 
+async function findIdempotentReplay(
+  db: DbQueryer,
+  idempotencyKey: string
+): Promise<{ client_id: string; client_code: string } | null> {
+  const existing = await db.query(
+    `SELECT c.client_id::text AS client_id, c.client_code
+       FROM client_create_idempotency k
+       JOIN clients c ON c.client_id::text = k.client_id
+      WHERE k.idempotency_key = $1
+      LIMIT 1`,
+    [idempotencyKey]
+  );
+  const row = (existing.rows as Array<{ client_id: string; client_code: string | null }>)[0];
+  if (!row) return null;
+  return { client_id: row.client_id, client_code: row.client_code ?? "" };
+}
+
 export async function repoCreateClient(
   dto: CreateClientDTO,
-  audit: AuditContext
-): Promise<{ client_id: string; client_code: string }> {
+  audit: AuditContext,
+  idempotencyKey?: string | null
+): Promise<{ client_id: string; client_code: string; replayed: boolean }> {
   const db = await pool.connect();
   try {
     await db.query('BEGIN');
+
+    // Rejeu : la même Idempotency-Key renvoie la fiche déjà créée, sans double
+    // insertion (double clic, retry réseau). Table du patch 20260720.
+    if (idempotencyKey) {
+      const replay = await findIdempotentReplay(db, idempotencyKey);
+      if (replay) {
+        await db.query('ROLLBACK');
+        return { ...replay, replayed: true };
+      }
+    }
 
     // Doublon légal : un même établissement (SIRET) ne peut pas donner deux fiches.
     await ensureSiretAvailable(db, dto.siret);
@@ -351,7 +386,7 @@ export async function repoCreateClient(
     // ✅ récupère l'ID généré par le trigger
     let clientId = "";
     try {
-      clientId = await insertClient(db, dto, billAddrId, delivAddrId, bankInfoId, clientCode);
+      clientId = await insertClient(db, dto, billAddrId, delivAddrId, bankInfoId, clientCode, audit.user_id);
     } catch (err) {
       const { code, constraint } = getPgErrorInfo(err);
       if (code === "23505" && constraint === "clients_client_code_key") {
@@ -383,6 +418,13 @@ export async function repoCreateClient(
 
     await linkPaymentModes(db, clientId, dto.payment_mode_ids);
 
+    if (idempotencyKey) {
+      await db.query(
+        `INSERT INTO client_create_idempotency (idempotency_key, client_id) VALUES ($1, $2)`,
+        [idempotencyKey, clientId]
+      );
+    }
+
     await insertAuditLog(db, audit, {
       action: "CLIENT_CREATE",
       entity_type: "client",
@@ -399,9 +441,16 @@ export async function repoCreateClient(
     });
 
     await db.query('COMMIT');
-    return { client_id: clientId, client_code: clientCode };
+    return { client_id: clientId, client_code: clientCode, replayed: false };
   } catch (e) {
     await db.query('ROLLBACK');
+    // Course entre deux soumissions identiques : le perdant du conflit de clé
+    // renvoie la fiche créée par le gagnant.
+    const { code, constraint } = getPgErrorInfo(e);
+    if (idempotencyKey && code === "23505" && constraint === "client_create_idempotency_pkey") {
+      const replay = await findIdempotentReplay(db, idempotencyKey);
+      if (replay) return { ...replay, replayed: true };
+    }
     throw e;
   } finally {
     db.release();
@@ -471,6 +520,15 @@ export async function repoPatchClient(
       put((p) => `provided_documents_id = ${p}`, docs);
     }
     if (has("quality_levels")) put((p) => `quality_levels = ${p}::text[]`, patch.quality_levels ?? []);
+    if (has("devise")) put((p) => `devise = NULLIF(${p}, '')`, patch.devise ?? "");
+    if (has("encours_max")) put((p) => `encours_max = ${p}`, patch.encours_max ?? null);
+    if (has("incoterm")) put((p) => `incoterm = NULLIF(${p}, '')`, patch.incoterm ?? "");
+    if (has("langue")) put((p) => `langue = NULLIF(${p}, '')`, patch.langue ?? "");
+    // Réactivation : repasser en prospect/client efface l'horodatage d'archivage.
+    if (has("status") && patch.status && patch.status !== "inactif") {
+      sets.push("archived_at = NULL");
+      sets.push("archived_by = NULL");
+    }
     // client_code n'est jamais patchable : code visible immuable, généré serveur
     // (ADR-0013). Toute tentative est rejetée en amont par le contrôleur.
 
@@ -479,6 +537,7 @@ export async function repoPatchClient(
     }
 
     if (sets.length > 0) {
+      put((p) => `updated_by = ${p}`, audit.user_id);
       vals.push(id);
       try {
         await db.query(`UPDATE clients SET ${sets.join(", ")} WHERE client_id = $${vals.length}`, vals);
@@ -591,7 +650,12 @@ export async function repoDeleteClient(id: string, audit: AuditContext): Promise
       throw new HttpError(404, "CLIENT_NOT_FOUND", "Client not found");
     }
 
-    await db.query(`UPDATE clients SET status = 'inactif', blocked = true WHERE client_id = $1`, [id]);
+    await db.query(
+      `UPDATE clients
+          SET status = 'inactif', blocked = true, archived_at = now(), archived_by = $2, updated_by = $2
+        WHERE client_id = $1`,
+      [id, audit.user_id]
+    );
 
     await insertAuditLog(db, audit, {
       action: "CLIENT_DELETE",
@@ -637,7 +701,12 @@ export async function repoArchiveClient(id: string, audit: AuditContext): Promis
     }
 
     if (String(before.status).toLowerCase() !== "inactif") {
-      await db.query(`UPDATE clients SET status = 'inactif' WHERE client_id = $1`, [id]);
+      await db.query(
+        `UPDATE clients
+            SET status = 'inactif', archived_at = now(), archived_by = $2, updated_by = $2
+          WHERE client_id = $1`,
+        [id, audit.user_id]
+      );
     }
 
     await insertAuditLog(db, audit, {

--- a/src/module/client/repository/clients.read.repository.ts
+++ b/src/module/client/repository/clients.read.repository.ts
@@ -71,6 +71,10 @@ export async function repoGetClientById(clientId: string, options: ClientReadOpt
       c.siret, c.vat_number, c.naf_code,
       c.status, c.blocked, c.reason, c.creation_date,
       c.observations, c.provided_documents_id,
+      NULLIF(btrim(to_jsonb(c)->>'devise'), '') AS devise,
+      NULLIF(btrim(to_jsonb(c)->>'encours_max'), '')::numeric AS encours_max,
+      NULLIF(btrim(to_jsonb(c)->>'incoterm'), '') AS incoterm,
+      NULLIF(btrim(to_jsonb(c)->>'langue'), '') AS langue,
 
       -- biller
       f.biller_id, f.biller_name,
@@ -132,6 +136,10 @@ export async function repoGetClientById(clientId: string, options: ClientReadOpt
       creation_date: r.creation_date,
       observations: r.observations ?? null,
       provided_documents_id: r.provided_documents_id ?? null,
+      devise: r.devise ?? null,
+      encours_max: r.encours_max === null || typeof r.encours_max === "undefined" ? null : Number(r.encours_max),
+      incoterm: r.incoterm ?? null,
+      langue: r.langue ?? null,
     },
     biller: r.biller_id
       ? { id: r.biller_id, name: r.biller_name }

--- a/src/module/client/repository/clients.read.repository.ts
+++ b/src/module/client/repository/clients.read.repository.ts
@@ -1,5 +1,16 @@
 // src/module/clients/repository/clients.read.repository.ts
 import pool from "../../../config/database";
+import { maskIban } from "../client.permissions";
+
+export type ClientReadOptions = {
+  /**
+   * true uniquement pour les rôles finance/gestion clients (CLIENT_FINANCE_ROLES) :
+   * IBAN/BIC en clair et téléphone personnel du contact. Sinon IBAN masqué
+   * (4 derniers caractères), BIC et phone_personal à null — matrice données
+   * sensibles (#162).
+   */
+  includeSensitiveFinance?: boolean;
+};
 
 type ClientAddressKind = "billing" | "delivery";
 
@@ -47,7 +58,7 @@ function formatAddressInline(address: AddressValue): string {
  *   payment_modes: [{ id, code, type }]
  * }
  */
-export async function repoGetClientById(clientId: string) {
+export async function repoGetClientById(clientId: string, options: ClientReadOptions = {}) {
   const { rows } = await pool.query(
     `
     SELECT
@@ -148,8 +159,9 @@ export async function repoGetClientById(clientId: string) {
     bank: {
       id: r.bank_info_id ?? null,
       bank_name: r.bank_name ?? null,
-      iban: r.iban ?? null,
-      bic: r.bic ?? null,
+      iban: options.includeSensitiveFinance ? (r.iban ?? null) : maskIban(r.iban),
+      bic: options.includeSensitiveFinance ? (r.bic ?? null) : null,
+      iban_masked: !options.includeSensitiveFinance,
     },
     primary_contact: r.contact_id
       ? {
@@ -159,7 +171,7 @@ export async function repoGetClientById(clientId: string) {
           civility: r.civility,
           role: r.role,
           phone_direct: r.phone_direct ?? null,
-          phone_personal: r.phone_personal,
+          phone_personal: options.includeSensitiveFinance ? r.phone_personal : null,
           email: r.contact_email,
         }
       : null,
@@ -267,16 +279,13 @@ export async function repoListClients(q: string, limit = 25) {
       al.city  AS deliv_city,
       al.country AS deliv_country,
 
-      -- Banque
+      -- Banque : nom seul (IBAN/BIC jamais en liste — PII critique)
       ib.name AS bank_name,
-      ib.iban,
-      ib.bic,
 
-      -- Contact principal (aplaties)
+      -- Contact principal (aplaties) — sans phone_personal (PII élevée)
       ct.first_name AS contact_first_name,
       ct.last_name  AS contact_last_name,
       ct.email      AS contact_email,
-      ct.phone_personal AS contact_phone_personal,
       ct.role       AS contact_role,
       ct.civility   AS contact_civility,
 
@@ -335,10 +344,10 @@ export async function repoListClients(q: string, limit = 25) {
     deliv_name: string | null; deliv_street: string | null; deliv_house_number: string | null;
     deliv_postal_code: string | null; deliv_city: string | null; deliv_country: string | null;
 
-    bank_name: string | null; iban: string | null; bic: string | null;
+    bank_name: string | null;
 
     contact_first_name: string | null; contact_last_name: string | null; contact_email: string | null;
-    contact_phone_personal: string | null; contact_role: string | null; contact_civility: string | null;
+    contact_role: string | null; contact_civility: string | null;
 
     payment_mode_ids: string[];
      payment_mode_labels: string[]  

--- a/src/module/client/routes/client.routes.ts
+++ b/src/module/client/routes/client.routes.ts
@@ -1,8 +1,9 @@
 // src/module/clients/routes/clients.routes.ts
 import { Router } from "express";
-import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import { authenticateToken, authorizeRole } from "../../auth/middlewares/auth.middleware";
 import {
   archiveClient,
+  checkClientDuplicates,
   deleteClient,
   getClientById,
   listClientAddresses,
@@ -14,16 +15,25 @@ import {
   postClientContact,
 } from "../controllers/client.controller";
 import { listClientsAnalytics } from "../controllers/clients.analytics.controller"
+import { CLIENT_WRITE_ROLES } from "../client.permissions";
 // import { uploadClientLogoMulter } from "../upload/client-logo-upload";
 
 
 const router = Router();
 
-router.post("/", authenticateToken, postClient);
+// Les fiches clients portent des PII (emails, téléphones, SIRET) et des données
+// bancaires : aucune route n'est publique. Deny by default (#162).
+router.use(authenticateToken);
+
+const requireClientWriteRole = authorizeRole(...CLIENT_WRITE_ROLES);
+
+router.post("/", requireClientWriteRole, postClient);
 router.get("/", listClients);
 router.get("/analytics", listClientsAnalytics);
+// POST (et non GET) : SIRET/TVA/raison sociale ne doivent jamais transiter en query string.
+router.post("/duplicate-check", checkClientDuplicates);
 router.get("/:clientId/contacts", listClientContacts);
-router.post("/:clientId/contacts", authenticateToken, postClientContact);
+router.post("/:clientId/contacts", requireClientWriteRole, postClientContact);
 router.get("/:clientId/addresses", listClientAddresses);
 router.get("/:id", getClientById);
 
@@ -34,15 +44,17 @@ router.get("/:id", getClientById);
 //   uploadClientLogo
 // );
 
-// 🆕 update complet
-router.patch("/:id", authenticateToken, patchClient);
+// 🆕 update partiel
+router.patch("/:id", requireClientWriteRole, patchClient);
 
-router.delete("/:id", authenticateToken, deleteClient);
+// La « suppression » est un archivage logique : aucune destruction physique
+// de client/contacts/modes de paiement (traçabilité industrielle, #162).
+router.delete("/:id", requireClientWriteRole, deleteClient);
 
-router.post("/:id/archive", authenticateToken, archiveClient);
+router.post("/:id/archive", requireClientWriteRole, archiveClient);
 
 // deja existant
-router.patch("/:id/contact", authenticateToken, patchClientPrimaryContact);
+router.patch("/:id/contact", requireClientWriteRole, patchClientPrimaryContact);
 
 
 export default router;

--- a/src/module/client/services/client.service.ts
+++ b/src/module/client/services/client.service.ts
@@ -19,6 +19,10 @@ export type ClientRow = {
   provided_documents_id: string | null
   quality_level: string | null;
   quality_levels: string[] | null
+  devise: string | null
+  encours_max: number | null
+  incoterm: string | null
+  langue: string | null
 
    logo_path: string | null
 
@@ -105,6 +109,12 @@ export async function listClients(q = "", limit = 25): Promise<ClientRow[]> {
     c.observations, c.provided_documents_id,
     c.quality_level,
     c.quality_levels,
+    -- Finance structurée (#162) — lecture tolérante tant que le patch
+    -- 20260720_clients_360_hardening n'est pas appliqué partout.
+    NULLIF(btrim(to_jsonb(c)->>'devise'), '') AS devise,
+    NULLIF(btrim(to_jsonb(c)->>'encours_max'), '')::numeric AS encours_max,
+    NULLIF(btrim(to_jsonb(c)->>'incoterm'), '') AS incoterm,
+    NULLIF(btrim(to_jsonb(c)->>'langue'), '') AS langue,
     c.logo_path, 
 
     c.delivery_address_id::text AS delivery_address_id,

--- a/src/module/client/services/client.service.ts
+++ b/src/module/client/services/client.service.ts
@@ -44,17 +44,15 @@ export type ClientRow = {
   deliv_city: string | null
   deliv_country: string | null
 
-  // Bank
+  // Bank — volontairement sans IBAN/BIC : données critiques réservées à la
+  // fiche détail (masquées, RBAC finance). La liste n'en a aucun besoin métier.
   bank_name: string | null
-  iban: string | null
-  bic: string | null
 
-  // Primary contact
+  // Primary contact — phone_personal exclu (PII élevée, jamais en liste).
   contact_first_name: string | null
   contact_last_name: string | null
   contact_email: string | null
   contact_phone_direct: string | null
-  contact_phone_personal: string | null
   contact_role: string | null
   contact_civility: string | null
 
@@ -65,7 +63,6 @@ export type ClientRow = {
    email: string | null
    role: string | null
    phone_direct: string | null
-   phone_personal: string | null
  }>
 
 
@@ -124,15 +121,16 @@ export async function listClients(q = "", limit = 25): Promise<ClientRow[]> {
     al.address_complement AS deliv_address_complement,
     al.postal_code AS deliv_postal_code, al.city AS deliv_city, al.country AS deliv_country,
 
-    -- Banque
-    ib.name AS bank_name, ib.iban, ib.bic,
+    -- Banque : nom seul. Les coordonnées bancaires ne sortent JAMAIS par la
+    -- liste (PII critique, réservées au détail avec masquage + RBAC finance).
+    ib.name AS bank_name,
 
-    -- Contact principal (aplati)
+    -- Contact principal (aplati) — sans téléphone personnel (PII élevée).
     ct.first_name AS contact_first_name, ct.last_name AS contact_last_name,
-    ct.email AS contact_email, ct.phone_direct AS contact_phone_direct, ct.phone_personal AS contact_phone_personal,
+    ct.email AS contact_email, ct.phone_direct AS contact_phone_direct,
     ct.role AS contact_role, ct.civility AS contact_civility,
 
-    -- Tous les contacts du client (pour dropdown)
+    -- Tous les contacts du client (pour dropdown) — sans téléphone personnel.
     COALESCE(
       json_agg(
         DISTINCT jsonb_build_object(
@@ -140,8 +138,7 @@ export async function listClients(q = "", limit = 25): Promise<ClientRow[]> {
           'full_name',       trim(concat(ct2.civility,' ',ct2.first_name,' ',ct2.last_name)),
           'email',           ct2.email,
           'role',            ct2.role,
-          'phone_direct',    ct2.phone_direct,
-          'phone_personal',  ct2.phone_personal
+          'phone_direct',    ct2.phone_direct
         )
       ) FILTER (WHERE ct2.contact_id IS NOT NULL),
       '[]'
@@ -209,27 +206,10 @@ export async function listClients(q = "", limit = 25): Promise<ClientRow[]> {
   const { rows } = await pool.query<ClientRow>(sql, [q, limit]);
   return rows;
 }
-export async function createClient(data: {
-  company_name: string;
-  email?: string;
-  phone?: string;
-  // …the rest of your payload
-}): Promise<ClientRow> {
-  const { rows } = await pool.query<ClientRow>(
-    `INSERT INTO clients (client_id, company_name, email, phone)
-     VALUES (
-       lpad((SELECT COALESCE(MAX(client_id)::int,0)+1 FROM clients)::text, 3, '0'),
-       $1, $2, $3
-     )
-     RETURNING client_id, company_name, email, phone`,
-    [data.company_name, data.email ?? null, data.phone ?? null]
-  );
-  return rows[0];
-}
-
-export async function updateClientPrimaryContact(clientId: string, contactId: string) {
-  await pool.query(`UPDATE clients SET contact_id = $1 WHERE client_id = $2`, [contactId, clientId]);
-}
+// createClient (MAX+1 sur client_id) et updateClientPrimaryContact (sans
+// vérification d'appartenance) ont été supprimés (#162) : la création passe par
+// repoCreateClient (code serveur transactionnel) et la bascule de contact
+// principal par repoSetPrimaryContact (appartenance vérifiée sous transaction).
 
 export type ClientContactRow = {
   contact_id: string;
@@ -243,7 +223,14 @@ export type ClientContactRow = {
   label: string;
 };
 
-export async function listClientContacts(clientId: string): Promise<ClientContactRow[]> {
+/**
+ * Contacts d'un client. phone_personal (PII élevée, matrice données sensibles)
+ * n'est renvoyé qu'aux rôles finance/gestion clients ; masqué à null sinon.
+ */
+export async function listClientContacts(
+  clientId: string,
+  options: { includePersonalPhone?: boolean } = {}
+): Promise<ClientContactRow[]> {
   const { rows } = await pool.query<ClientContactRow>(
     `
     SELECT
@@ -263,6 +250,7 @@ export async function listClientContacts(clientId: string): Promise<ClientContac
   );
   return rows.map((r) => ({
     ...r,
+    phone_personal: options.includePersonalPhone ? r.phone_personal : null,
     label: `${r.first_name} ${r.last_name} — ${r.email}`,
   }));
 }
@@ -278,39 +266,6 @@ export type CreateClientContactInput = {
   set_primary?: boolean;
 };
 
-export async function createClientContact(
-  clientId: string,
-  input: CreateClientContactInput
-): Promise<ClientContactRow> {
-  const { rows } = await pool.query<ClientContactRow>(
-    `
-    INSERT INTO contacts (first_name,last_name,civility,role,phone_direct,phone_personal,email,client_id)
-    VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
-    RETURNING
-      contact_id::text AS contact_id,
-      first_name,
-      last_name,
-      email,
-      phone_direct,
-      phone_personal,
-      role,
-      civility
-    `,
-    [
-      input.first_name,
-      input.last_name,
-      input.civility ?? null,
-      input.role ?? null,
-      input.phone_direct ?? null,
-      input.phone_personal ?? null,
-      input.email,
-      clientId,
-    ]
-  );
-  const row = rows[0];
-  if (input.set_primary) {
-    await pool.query(`UPDATE clients SET contact_id = $1 WHERE client_id = $2`, [row.contact_id, clientId]);
-  }
-  return { ...row, label: `${row.first_name} ${row.last_name} — ${row.email}` };
-}
+// La création de contact (avec promotion set_primary éventuelle) est désormais
+// transactionnelle et auditée : voir repoCreateClientContact dans le repository.
 

--- a/src/module/client/services/clients.read.service.ts
+++ b/src/module/client/services/clients.read.service.ts
@@ -1,6 +1,12 @@
 // src/module/clients/services/clients.read.service.ts
-import { repoGetClientById, repoListClientAddresses, repoListClients } from "../repository/clients.read.repository";
+import {
+  repoGetClientById,
+  repoListClientAddresses,
+  repoListClients,
+  type ClientReadOptions,
+} from "../repository/clients.read.repository";
 
-export const svcGetClientById = (id: string) => repoGetClientById(id);
+export const svcGetClientById = (id: string, options: ClientReadOptions = {}) =>
+  repoGetClientById(id, options);
 export const svcListClients   = (q: string, limit: number) => repoListClients(q, limit);
 export const svcListClientAddresses = (clientId: string) => repoListClientAddresses(clientId);

--- a/src/module/client/validators/client.validators.ts
+++ b/src/module/client/validators/client.validators.ts
@@ -4,6 +4,10 @@ export const qualityLevels = z.enum(["Certificat MP", "Certificat TR", "Relevé 
 export const QUALITY_LEVELS = ["Certificat MP", "Certificat TR", "Relevé de valeurs"] as const;
 
 const siretRegex = /^\d{14}$/;
+const deviseRegex = /^[A-Za-z]{3}$/;
+const langueRegex = /^[A-Za-z]{2}$/;
+/** Incoterms 2020 — liste officielle ICC. */
+export const INCOTERMS = ["EXW", "FCA", "CPT", "CIP", "DAP", "DPU", "DDP", "FAS", "FOB", "CFR", "CIF"] as const;
 const nafRegex = /^\d{4}[A-Z]$/;
 const frVatRegex = /^FR[0-9A-Z]{2}\s?\d{9}$/i;
 const ibanRegex = /^[A-Z]{2}[0-9A-Z]{13,32}$/i;
@@ -241,6 +245,20 @@ export const createClientSchema = z.object({
     .optional()
     .default([])
     .transform((contacts) => contacts.filter(isDefined)),
+  // Finance / logistique structurés (#162) — patch 20260720_clients_360_hardening requis.
+  devise: z.preprocess(
+    emptyStringToUndefined,
+    z.string().trim().regex(deviseRegex, "Devise ISO 4217 à 3 lettres (ex. EUR)").transform((v) => v.toUpperCase()).optional()
+  ),
+  encours_max: z
+    .number({ invalid_type_error: "Encours maximum invalide" })
+    .nonnegative("L'encours maximum doit être positif")
+    .optional(),
+  incoterm: z.preprocess(emptyStringToUndefined, z.enum(INCOTERMS).optional()),
+  langue: z.preprocess(
+    emptyStringToUndefined,
+    z.string().trim().regex(langueRegex, "Code langue à 2 lettres (ex. fr)").transform((v) => v.toLowerCase()).optional()
+  ),
 });
 
 export type CreateClientDTO = z.infer<typeof createClientSchema>;

--- a/src/module/client/validators/client.validators.ts
+++ b/src/module/client/validators/client.validators.ts
@@ -1,7 +1,5 @@
 import { z } from "zod";
 
-import { codeFormatExample, isValidCode } from "../../../shared/codes/code-validator";
-
 export const qualityLevels = z.enum(["Certificat MP", "Certificat TR", "Relevé de valeurs"]);
 export const QUALITY_LEVELS = ["Certificat MP", "Certificat TR", "Relevé de valeurs"] as const;
 
@@ -11,7 +9,6 @@ const frVatRegex = /^FR[0-9A-Z]{2}\s?\d{9}$/i;
 const ibanRegex = /^[A-Z]{2}[0-9A-Z]{13,32}$/i;
 const bicRegex = /^[A-Z0-9]{8}([A-Z0-9]{3})?$/i;
 const CIVILITY_OPTIONS = ["Madame", "Monsieur"] as const;
-const clientCodeFormatMessage = `Le code client doit être au format ${codeFormatExample("client")}.`;
 
 function emptyStringToUndefined(value: unknown) {
   if (typeof value !== "string") return value;
@@ -209,15 +206,9 @@ export const createClientContactBodySchema = z.object({
 export type CreateClientContactBodyDTO = z.infer<typeof createClientContactBodySchema>;
 
 export const createClientSchema = z.object({
-  client_code: z.preprocess(
-    emptyStringToUndefined,
-    z
-      .string()
-      .trim()
-      .max(30, "Code client trop long")
-      .refine((value) => isValidCode("client", value), clientCodeFormatMessage)
-      .optional()
-  ),
+  // client_code volontairement absent : le code visible est généré côté serveur
+  // dans la transaction de création (ADR-0013) et reste immuable. Toute valeur
+  // fournie est rejetée explicitement par le contrôleur (CLIENT_CODE_READONLY).
   company_name: requiredText("Raison sociale requise"),
   email: z.preprocess(emptyStringToUndefined, z.string().trim().email("Email invalide").optional()),
   phone: z.preprocess(emptyStringToUndefined, z.string().trim().optional()),
@@ -259,3 +250,26 @@ export type CreateClientDTO = z.infer<typeof createClientSchema>;
 // L'identité `client_id` n'est pas dans le body (route param) -> non patchable.
 export const clientPatchSchema = createClientSchema.partial();
 export type ClientPatchDTO = z.infer<typeof clientPatchSchema>;
+
+/** PATCH /clients/:id/contact — le contact doit appartenir au client (vérifié en transaction). */
+export const setPrimaryContactSchema = z.object({
+  contact_id: z.string({ required_error: "Identifiant de contact requis" }).uuid("Identifiant de contact invalide"),
+});
+export type SetPrimaryContactDTO = z.infer<typeof setPrimaryContactSchema>;
+
+/**
+ * POST /clients/duplicate-check — corps (jamais de query string : SIRET/TVA/raison
+ * sociale sont des données à ne pas persister dans les logs d'URL).
+ */
+export const duplicateCheckSchema = z
+  .object({
+    siret: z.preprocess(emptyStringToUndefined, z.string().trim().regex(siretRegex, "SIRET invalide").optional()),
+    vat_number: z.preprocess(emptyStringToUndefined, z.string().trim().regex(frVatRegex, "TVA invalide").optional()),
+    company_name: z.preprocess(emptyStringToUndefined, z.string().trim().min(2, "Raison sociale trop courte").optional()),
+    exclude_client_id: z.preprocess(emptyStringToUndefined, z.string().trim().optional()),
+  })
+  .refine(
+    (value) => Boolean(value.siret || value.vat_number || value.company_name),
+    { message: "Au moins un critère (SIRET, TVA ou raison sociale) est requis." }
+  );
+export type DuplicateCheckDTO = z.infer<typeof duplicateCheckSchema>;

--- a/src/utils/logPath.ts
+++ b/src/utils/logPath.ts
@@ -1,0 +1,16 @@
+/**
+ * Strip the query string (and fragment) from a URL before it reaches any log sink.
+ * Business searches put PII in query params (?q=jane@doe.fr, ?siret=...) : logging
+ * originalUrl verbatim would persist that PII in server logs (GDPR minimisation,
+ * CA-SEC-04 family). Route params stay: they are internal ids, not free-text PII.
+ * NODE_ENV is "development" in prod (see errorHandler.ts), so this must not be
+ * gated on environment.
+ */
+export function stripQueryFromUrl(url: unknown): string | null {
+  if (typeof url !== "string" || url.length === 0) return null;
+  const qIndex = url.indexOf("?");
+  const hIndex = url.indexOf("#");
+  const end = url.length;
+  const cut = Math.min(qIndex === -1 ? end : qIndex, hIndex === -1 ? end : hIndex);
+  return url.slice(0, cut);
+}


### PR DESCRIPTION
## Client 360 — durcissement P0 + extension (module clients)

Référence : BigFootLime/crp-systems-web#162 (parent BigFootLime/crp-systems-web#161). PR frontend associée : BigFootLime/crp-systems-web#175.

### Commit 1 — `security:` durcissement P0 (déployable seul, aucune dépendance schéma)

Les 7 constats P0 confirmés sur `origin/dev` sont corrigés et testés :

1. **Toutes les routes clients authentifiées** (liste/analytics/détail/contacts/adresses étaient publiques et renvoyaient IBAN/BIC/téléphones personnels). Liste sans IBAN/BIC/`phone_personal` ; détail avec IBAN masqué `••••1234` + `iban_masked`, complet uniquement pour Directeur/Administrateur Systeme et Reseau/Secretaire.
2. **RBAC deny-by-default sur les écritures** : `authorizeRole("Directeur", "Administrateur Systeme et Reseau", "Secretaire")` — rôles existants de `users_role_check`, aucun rôle inventé.
3. **Contact principal sous transaction** : Zod + appartenance au client vérifiée (`422 CONTACT_NOT_OF_CLIENT`), verrou `FOR UPDATE`, audit dans la même transaction. Création de contact + `set_primary` désormais atomiques.
4. **DELETE = archivage logique** : plus aucune destruction physique de client/contacts/modes de paiement ; audit `CLIENT_DELETE` en mode `logical_archive`.
5. **MAX+1 éradiqué** : suppression du code mort dangereux (`nextClientId`, `createClient` service, `repoUpdateClient` non routés — vérifié). Le code visible vient exclusivement de `fn_next_issued_code_value` (ADR-0013).
6. **`client_code` serveur et immuable** : toute valeur fournie → `400 CLIENT_CODE_READONLY` (POST) / `400 CLIENT_CODE_IMMUTABLE` (PATCH). Doublon SIRET → `409 CLIENT_SIRET_EXISTS` avec la fiche existante en `details` ; `POST /clients/duplicate-check` (corps POST, pas de PII en query) pour l'avertissement inline.
7. **Logs sans query string** : `requestLogger`, `errorHandler`, morgan (format sanitisé), middleware auth, contexte d'audit — les recherches `?q=email`/SIRET ne fuient plus (rappel : la prod tourne en `NODE_ENV=development`, morgan y est actif).

### Commit 2 — `feat:` extension 360 (**requiert le patch, à appliquer AVANT le code**)

- Champs structurés `devise`/`encours_max`/`incoterm`/`langue` (fin de la concaténation dans `observations`), lectures tolérantes `to_jsonb` en défense.
- `Idempotency-Key` (UUID) sur `POST /clients` : rejeu → `200` avec la fiche déjà créée, course de clé gérée (23505).
- `archived_at`/`archived_by` horodatés sur DELETE/archive ; réactivation (statut actif) les efface ; `created_by`/`updated_by` renseignés.

### Patch SQL additif — jamais appliqué en production par cette session

`db/patches/20260720_clients_360_hardening.sql` (idempotent, strictement additif) + `support/*.verify.sql` (contrôles + décompte des doublons SIRET legacy avant tout index UNIQUE) + `support/*.rollback.sql`. Ordre de release : `cerp_test` → verify → production **par un humain** → déploiement du code.

### Vérification

- `npm run build` ✅ (TypeScript strict)
- `npm run test:run` : **59 fichiers / 359 tests ✅**, dont 37 nouveaux dans `src/__tests__/clients-360-hardening.routes.test.ts` (401/403 par rôle, DTO minimisés, masquage IBAN par rôle, code serveur sans MAX+1, 400 code fourni, 409 SIRET avec details, duplicate-check minimisé, contact principal transactionnel + 422, archivage logique sans DELETE physique, logs sans query PII, finance → INSERT, idempotence 201/200/rejeu sans insertion, horodatage d'archivage, désarchivage sur PATCH statut).

### Suivis documentés (`docs/clients-360-162.md`)

Endpoint de désactivation de contact (`contacts.archived_at` prêt), index UNIQUE SIRET après nettoyage legacy, upload logo sécurisé (CA-APP-05), chiffrement IBAN au repos après stabilisation du schéma, `swagger.ts` à rafraîchir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden the clients module security and extend the client 360 data model and APIs, including stricter RBAC, PII minimisation, transactional contact handling, logical archiving, structured finance fields, and idempotent client creation.

New Features:
- Add structured finance and logistics fields (devise, encours_max, incoterm, langue) to client entities and APIs.
- Introduce an idempotent client creation flow using an Idempotency-Key header and a bookkeeping table.
- Expose a duplicate-check endpoint for clients based on SIRET, VAT number, and company name with minimised responses.
- Add role-based controls for accessing full financial client details (unmasked IBAN/BIC and personal phone).

Enhancements:
- Require authentication for all client routes and enforce deny-by-default RBAC for write operations using existing roles.
- Ensure the visible client code is generated server-side and immutable, rejecting any client-supplied values and eliminating legacy MAX+1 code paths.
- Implement transactional handling and audit of primary contact changes and contact creation, including ownership checks.
- Convert client deletion into logical archiving with status changes, timestamps, and audit details while retaining related contacts and payment modes.
- Sanitise all logged request paths by stripping query strings to avoid persisting search PII in logs.
- Extend client read services and DTOs to minimise sensitive data exposure in listings and conditionally mask IBANs in details.

Deployment:
- Introduce an additive, idempotent SQL patch and accompanying verify/rollback scripts to evolve the clients schema for Client 360 without breaking existing data or code.
- Document the rollout order for applying the SQL patch in test and production before deploying the new code.

Documentation:
- Add documentation describing the hardened and extended Client 360 contract, the additive SQL patch, removed legacy code paths, and follow-up items.

Tests:
- Add an extensive routes test suite validating authentication, RBAC, DTO minimisation, IBAN masking, client code immutability, SIRET duplicate handling, idempotent creation, logical archiving, and query-string-free logging.