### PR TITLE
chore(backend): runbook hébergement + project-office WP codes + fallback domaines (#136)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,9 +5,11 @@ This repository is the backend implementation backup for Croix Rousse Precision 
 ## Required reading before edits
 
 1. `INSTRUCTIONS_BACKEND.md`
-2. `docs/frontend_repo_map.md`
-3. `db/patches/`
-4. impacted route, service, repository, and validator files
+2. Canonical Project Office workflow: `../crp-systems-web/docs/ai/AI_PROJECT_OFFICE_WORKFLOW.md`
+   ([GitHub fallback](https://github.com/BigFootLime/crp-systems-web/blob/dev/docs/ai/AI_PROJECT_OFFICE_WORKFLOW.md))
+3. `docs/frontend_repo_map.md`
+4. `db/patches/`
+5. impacted route, service, repository, and validator files
 
 ## Core rules
 

--- a/docs/hosting-and-database-access.md
+++ b/docs/hosting-and-database-access.md
@@ -1,0 +1,78 @@
+# CERP — Hosting & Database Access
+
+> How the CERP/CERP+ backend and database are hosted, how the two run modes connect, and how to access the database for modifications. Written 2026-07-06. Assumes this repo stays **private** (it references internal IPs; it contains **no secrets**).
+>
+> Deeper infra detail lives in the frontend/governance repo `crp-systems-web`: `docs/devops/cerp-wireguard-db-deployment.md`, `docs/devops/cerp-wireguard-over-tcp.md`, `docs/devops/hyperbox2-postgres-runbook.md`, `docs/devops/cerp-connectivity-incident-2026-07-06.md`.
+
+## 1. TL;DR
+
+- **Backend:** runs in **two** places at once (same codebase, two deployments).
+  - **Local** — on the atelier server **HYPERBOX2**, systemd service `cerp-api` (`node /srv/cerp/apps/api/dist/index.js`, port `:8080`), served to the LAN by Apache on `:8081`. Used by **on-site** users.
+  - **VPS** — a Coolify container on the Hostinger VPS (`82.25.112.61`), public at `https://erp-backend.croix-rousse-precision.fr` (container port `:5000`). Used by **off-site** users.
+- **Database:** lives **only on the atelier (HYPERBOX2)** — PostgreSQL 17, database `cerp_prod` (plus `cerp_test` for validation). It is the **single source of truth**. There is **no** database on the VPS.
+- **How each backend reaches the DB:**
+  - Local backend → `127.0.0.1:5432` (same machine).
+  - VPS backend → `10.90.0.2:5432` over the **WireGuard** tunnel (which now rides **TCP** — see the WG-over-TCP runbook — because the atelier's Bouygues 4G/5G uplink throttles raw UDP).
+
+## 2. Topology
+
+```
+ON-SITE (atelier LAN)                         OFF-SITE (internet)
+  browser                                       browser
+    │ http://cerp.local:8081                       │ https://cerp.croix-rousse-precision.fr
+    ▼                                               ▼
+  Apache :8081 (HYPERBOX2)                        VPS Traefik (Coolify, TLS)
+    │ prox/localhost                                │ Host(erp-backend.…)
+    ▼                                               ▼
+  cerp-api :8080 (HYPERBOX2)                      backend container :5000 (VPS)
+    │ 127.0.0.1:5432                                │ DATABASE_URL → 10.90.0.2:5432
+    ▼                                               ▼  (WireGuard, tunnelled over TCP)
+  ┌──────────────────────────── PostgreSQL 17 on HYPERBOX2 ────────────────────────────┐
+  │  db cerp_prod (source of truth) + cerp_test    listen_addresses = 127.0.0.1,10.90.0.2 │
+  └───────────────────────────────────────────────────────────────────────────────────┘
+```
+
+Both backends run the **same release**. The frontend is likewise deployed twice (Apache-served build on the atelier; Coolify-served build on the VPS). The login screen lets the user pick the database (`Production cerp_prod` / `Base test cerp_test`).
+
+## 3. Database facts
+
+| Item | Value |
+|---|---|
+| Engine | PostgreSQL 17 (pgdg, Ubuntu) on HYPERBOX2 |
+| Databases | `cerp_prod` (prod, ~190 tables), `cerp_test` (validation) |
+| App role | `cerp_app` — least-privilege (no superuser/createrole/createdb/replication) |
+| Admin role | `postgres` (superuser) — local socket / peer auth only |
+| `listen_addresses` | `127.0.0.1` (local backend) + `10.90.0.2` (WireGuard, for the VPS) |
+| `pg_hba` | `127.0.0.1`, `::1`, and WG peer `10.90.0.1/32` — all `scram-sha-256`; local socket `peer` |
+| Firewall | atelier `ufw` allows `5432` only from the WG peer; **not** exposed to LAN/WAN |
+| Backups | nightly `cerp-pg-backup.timer` → `/var/backups/cerp` (custom-format, restore-tested) |
+| Connection string shape | `postgresql://cerp_app:<password>@<host>:5432/cerp_prod` |
+
+## 4. Accessing the database for modifications
+
+**Recommended for admin / schema changes / migrations — no password needed** (peer auth as the OS `postgres` user, on the atelier):
+
+```bash
+# on HYPERBOX2 (SSH in, or the RustDesk terminal):
+sudo -u postgres psql -d cerp_prod        # prod   (careful!)
+sudo -u postgres psql -d cerp_test        # test / validation
+```
+
+**As the application user `cerp_app`** (needs the password):
+
+```bash
+psql "postgresql://cerp_app:<password>@127.0.0.1:5432/cerp_prod"   # on the atelier
+```
+
+- **Where the `cerp_app` password is stored** (it is deliberately **not** in this repo): the backend `.env` on the atelier (`/srv/cerp/apps/api/.env`), the VPS backend's **Coolify** `DATABASE_URL` env var, and the operator's password manager / the `pgAdmin-CERP-identifiants` desktop note. Keep those in sync — a drift between them is what broke on-site login on 2026-07-06.
+- **pgAdmin (GUI):** installed on the HYPERBOX2 desktop, connects via `127.0.0.1`.
+- **From off-site:** you don't connect to the DB directly; you go through the VPS backend API, which holds the WireGuard path.
+
+**Migrations / schema changes** follow the existing convention: idempotent SQL in [`db/patches/`](../db/patches), applied with `psql`. Always **back up first** (run `sudo /usr/local/sbin/cerp-pg-backup.sh` on the atelier) and prefer testing on `cerp_test`.
+
+## 5. Security notes
+
+- The DB is never exposed publicly; the VPS reaches it only via WireGuard, and PG binds to localhost + the WG IP only.
+- Never commit the DB password (or any secret) to this repo. Rotate `cerp_app`'s password if it is ever exposed, and update the backend `.env` + Coolify `DATABASE_URL` together.
+- The backend must never log `DATABASE_URL`/JWT/passwords.
+</content>

--- a/docs/project-office-explicit-work-package-codes.md
+++ b/docs/project-office-explicit-work-package-codes.md
@@ -1,0 +1,17 @@
+# Project Office — explicit work-package codes
+
+Issue frontend: `crp-systems-web#136` (`UI-GOV`).
+
+`POST /api/v1/project-office/work-packages` accepts an optional `code` field in addition to the
+historical auto-numbering behavior.
+
+- omitted code: the API keeps generating `WP-001`, `WP-002`, ... under the project lock;
+- explicit code: normalized to uppercase, limited to 64 characters, and validated with
+  `^[A-Z0-9][A-Z0-9_-]*$`;
+- duplicate explicit code in the same project: HTTP `409`, code `PO_WP_CODE_TAKEN`;
+- project-scoped database uniqueness remains authoritative;
+- no database migration is required.
+
+This additive contract lets the repository helper upsert stable governance codes such as
+`UI-GOV-03` without direct SQL. Authentication, Project Office feature access, project write access,
+activity log and global ERP audit remain unchanged.

--- a/src/__tests__/project-office-core.test.ts
+++ b/src/__tests__/project-office-core.test.ts
@@ -124,6 +124,28 @@ describe("Work packages", () => {
     expect(wp.reporter_id).toBe(42);
     expect(base.insertAuditLog).toHaveBeenCalled();
   });
+  it("createWorkPackage accepte un code métier explicite normalisé", async () => {
+    base.repoGetProjectAccess.mockResolvedValue(ownerAccess);
+    work.repoCreateWorkPackage.mockImplementation(async (_tx, i) => ({
+      id: WP1, project_id: i.project_id, parent_id: null, code: i.code, title: i.title, description: null,
+      type: i.type, status: i.status, priority: i.priority, assignee_id: null, assignee_username: null,
+      reporter_id: i.reporter_id, start_date: null, due_date: null, progress_percent: 0,
+      estimated_hours: null, spent_hours: null, created_at: "t", updated_at: "t",
+    }) as never);
+    const wp = await workSvc.createWorkPackage(OWNER, {
+      project_id: P, code: "ui-gov-01", title: "Audit UI", type: "AUDIT", status: "IN_PROGRESS", priority: "HIGH",
+    }, AUDIT);
+    expect(wp.code).toBe("UI-GOV-01");
+    expect(work.repoNextWorkPackageCode).not.toHaveBeenCalled();
+  });
+  it("retourne 409 quand un code métier explicite existe déjà", async () => {
+    base.repoGetProjectAccess.mockResolvedValue(ownerAccess);
+    work.repoCreateWorkPackage.mockRejectedValue(Object.assign(new Error("dup"), { code: "23505" }));
+    await expect(workSvc.createWorkPackage(OWNER, {
+      project_id: P, code: "UI-GOV", title: "Gouvernance", type: "EPIC", status: "IN_PROGRESS", priority: "HIGH",
+    }, AUDIT)).rejects.toMatchObject({ status: 409, code: "PO_WP_CODE_TAKEN" });
+    expect(work.repoNextWorkPackageCode).not.toHaveBeenCalled();
+  });
   it("dates incohérentes → 400", async () => {
     base.repoGetProjectAccess.mockResolvedValue(ownerAccess);
     await expect(workSvc.createWorkPackage(OWNER, {

--- a/src/module/fournisseurs/repository/fournisseurs.repository.ts
+++ b/src/module/fournisseurs/repository/fournisseurs.repository.ts
@@ -457,11 +457,19 @@ export async function repoGetFournisseur(id: string): Promise<Fournisseur | null
 }
 
 export async function repoListFournisseurDomaines(): Promise<FournisseurDomaine[]> {
-  const res = await db.query<FournisseurDomaine>(
-    `SELECT id::text AS id, code, label, description, icon, sort_order, is_active
-     FROM public.fournisseur_domaines WHERE is_active = true ORDER BY sort_order ASC, label ASC`
-  )
-  return res.rows.length ? res.rows : DEFAULT_FOURNISSEUR_DOMAINES
+  try {
+    const res = await db.query<FournisseurDomaine>(
+      `SELECT id::text AS id, code, label, description, icon, sort_order, is_active
+       FROM public.fournisseur_domaines WHERE is_active = true ORDER BY sort_order ASC, label ASC`
+    )
+    return res.rows.length ? res.rows : DEFAULT_FOURNISSEUR_DOMAINES
+  } catch (err) {
+    // Before the ecosystem patch (20260616) materializes public.fournisseur_domaines,
+    // fall back to the built-in defaults instead of surfacing a 500 (42P01 = undefined_table).
+    // Any other error is a genuine fault and must still propagate.
+    if ((err as { code?: string } | null)?.code === "42P01") return DEFAULT_FOURNISSEUR_DOMAINES
+    throw err
+  }
 }
 
 export async function repoReplaceFournisseurDomaines(

--- a/src/module/project-office/services/project-office-work.service.ts
+++ b/src/module/project-office/services/project-office-work.service.ts
@@ -54,10 +54,12 @@ export async function createWorkPackage(actor: Actor, input: CreateWorkPackageDT
     throw new HttpError(400, "PO_WP_BAD_DATES", "L'échéance précède le début.");
   }
   // Retry court sur collision de code (numérotation concourante).
-  for (let attempt = 0; attempt < 3; attempt++) {
+  const explicitCode = input.code?.trim().toUpperCase();
+  const attempts = explicitCode ? 1 : 3;
+  for (let attempt = 0; attempt < attempts; attempt++) {
     try {
       return await withTransaction(async (tx) => {
-        const code = await repoNextWorkPackageCode(tx, input.project_id);
+        const code = explicitCode ?? await repoNextWorkPackageCode(tx, input.project_id);
         const wp = await repoCreateWorkPackage(tx, {
           project_id: input.project_id,
           parent_id: input.parent_id ?? null,
@@ -84,7 +86,10 @@ export async function createWorkPackage(actor: Actor, input: CreateWorkPackageDT
         return wp;
       });
     } catch (err) {
-      if (!isPgUniqueViolation(err) || attempt === 2) throw err;
+      if (isPgUniqueViolation(err) && explicitCode) {
+        throw new HttpError(409, "PO_WP_CODE_TAKEN", "Ce code de tâche existe déjà dans le projet.");
+      }
+      if (!isPgUniqueViolation(err) || attempt === attempts - 1) throw err;
     }
   }
   throw new HttpError(500, "PO_WP_CODE_RACE", "Impossible d'attribuer un code de tâche.");

--- a/src/module/project-office/validators/project-office.validators.ts
+++ b/src/module/project-office/validators/project-office.validators.ts
@@ -78,6 +78,7 @@ export const memberParamsSchema = z.object({
 export const createWorkPackageSchema = z.object({
   project_id: z.string().uuid(),
   parent_id: z.string().uuid().nullish(),
+  code: trimmed(64).regex(/^[A-Z0-9][A-Z0-9_-]*$/i, "Code alphanumérique (tirets/underscores autorisés)").optional(),
   title: trimmed(300),
   description: z.string().trim().max(20_000).nullish(),
   type: z.enum(PO_WP_TYPES).default("TASK"),


### PR DESCRIPTION
Apporte sur dev :
- docs/hosting-and-database-access.md (référencé par la skill cerp-db-access, sans secret)
- feat(project-office): support explicit work package codes (4faec62, testé)
- fix(fournisseurs): fallback domaines sur table absente (42P01) au lieu d un 500

Build + 369/369 tests verts sur l arbre mergé (dev inclus).

Generated with Claude Code

## Summary by Sourcery

Add documentation and backend support for explicit Project Office work-package codes while improving fournisseur domaines fallback behavior and internal runbook references.

New Features:
- Allow Project Office work packages to be created with optional explicit, validated business codes alongside existing auto-numbering.
- Introduce backend handling for conflict errors when an explicit work-package code already exists in a project.

Bug Fixes:
- Return built-in default fournisseur domaines when the database table is missing instead of surfacing a server error.

Enhancements:
- Normalize explicit work-package codes to uppercase and limit them to a constrained character set and length.
- Adjust work-package code generation retry logic to account for explicit codes and conflict handling.
- Update internal agent instructions to reference the canonical Project Office workflow documentation.

Documentation:
- Add a hosting and database access runbook documenting CERP backend and PostgreSQL topology and access patterns.
- Document the Project Office API contract for explicit work-package codes including validation, error semantics, and governance use cases.

Tests:
- Add tests covering explicit work-package code normalization and duplicate-code conflict behavior in Project Office.