### PR TITLE
release: commande client #168 (refus lancement si apercu perime) -> main

### DIFF
--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -1450,6 +1450,42 @@ describe("/api/v1/commandes", () => {
     expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(false);
   });
 
+  it("POST /api/v1/commandes/:id/generate-affaires rejects a stale preview (expected_updated_at mismatch, #168)", async () => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM commande_client") && q.includes("FOR UPDATE") && q.includes("order_type")) {
+        return {
+          rows: [
+            {
+              client_id: "001",
+              type_affaire: "livraison",
+              order_type: "FERME",
+              devis_id: null,
+              numero: "CC-123",
+              dest_stock_magasin_id: null,
+              dest_stock_emplacement_id: null,
+              ar_sent_at: null,
+              updated_at: "2026-01-01T00:00:00.000Z",
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const stale = await request(app)
+      .post("/api/v1/commandes/123/generate-affaires")
+      .set("x-test-role", "Directeur")
+      .send({ decision: null, livraison_count: 1, lines: [], expected_updated_at: "2026-02-02T00:00:00.000Z" });
+
+    expect(stale.status).toBe(409);
+    expect(stale.body).toMatchObject({ code: "COMMANDE_PREVIEW_STALE" });
+    // Aucune affaire ni OF ne doit être créé quand l'aperçu est périmé.
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO ordres_fabrication"))).toBe(false);
+  });
+
   it("POST /api/v1/commandes/:id/generate-affaires requires an internal stock destination", async () => {
     const ARTICLE_ID = "11111111-1111-1111-1111-111111111111";
     const PIECE_ID = "22222222-2222-2222-2222-222222222222";

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -3679,12 +3679,14 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       dest_stock_magasin_id: string | null;
       dest_stock_emplacement_id: string | null;
       ar_sent_at: string | null;
+      updated_at: string | null;
     }>(
       `
       SELECT client_id, type_affaire, order_type, devis_id::text AS devis_id, numero,
              dest_stock_magasin_id::text AS dest_stock_magasin_id,
              dest_stock_emplacement_id::bigint::text AS dest_stock_emplacement_id,
-             ar_sent_at::text AS ar_sent_at
+             ar_sent_at::text AS ar_sent_at,
+             updated_at::text AS updated_at
       FROM commande_client
       WHERE id = $1
       FOR UPDATE
@@ -3695,6 +3697,21 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
     if (!commande) {
       await client.query("ROLLBACK");
       return null;
+    }
+
+    // #168 : verrou optimiste — refuse un lancement dont l'aperçu « Vérifier et lancer » est
+    // périmé (la commande a changé entre l'aperçu et la confirmation). Sans jeton, comportement
+    // inchangé.
+    if (
+      body.expected_updated_at &&
+      commande.updated_at &&
+      body.expected_updated_at !== commande.updated_at
+    ) {
+      throw new HttpError(
+        409,
+        "COMMANDE_PREVIEW_STALE",
+        "La commande a été modifiée depuis l'aperçu. Rechargez la commande avant de lancer."
+      );
     }
 
     const orderType = coerceOrderType(commande.order_type);

--- a/src/module/commande-client/validators/commande-client.validators.ts
+++ b/src/module/commande-client/validators/commande-client.validators.ts
@@ -466,6 +466,9 @@ export const generateAffairesV3Schema = z
     body: z
       .object({
         decision: commandesStockDecisionSchema.nullable().optional().default(null),
+        // #168 : jeton d'aperçu optionnel. Si fourni, doit égaler commande_client.updated_at,
+        // sinon 409 COMMANDE_PREVIEW_STALE (l'aperçu « Vérifier et lancer » est périmé).
+        expected_updated_at: z.string().min(1).optional(),
         livraison_count: z.coerce.number().int().min(1).max(10).optional().default(1),
         lines: z
           .array(


### PR DESCRIPTION
Release prod backend #168 : verrou optimiste additif sur le lancement (expected_updated_at -> 409). Aucune migration DB. 370/370 tests verts.

Generated with Claude Code

## Summary by Sourcery

Add optimistic locking to commande client affair generation to prevent launching from a stale preview.

New Features:
- Support an optional expected_updated_at token in the generate-affaires API to validate preview freshness before launching.

Enhancements:
- Return a 409 COMMANDE_PREVIEW_STALE error and avoid creating affaires or ordres de fabrication when the preview timestamp no longer matches the commande.

Tests:
- Add a test case covering rejection of generate-affaires when expected_updated_at mismatches the commande_client.updated_at.