### PR TITLE
feat(affaire): durcissement gouvernance 360 backend #169 (brouillon)

### DIFF
--- a/db/patches/20260721_affaire_360_hardening.sql
+++ b/db/patches/20260721_affaire_360_hardening.sql
@@ -1,0 +1,42 @@
+-- 20260721_affaire_360_hardening.sql
+-- #169 — Durcissement ADDITIF du dossier Affaire 360. NON destructif, idempotent, rejouable.
+--
+-- Ajoute :
+--   * affaire.is_principal (bool, def. false) : marque l'affaire PRINCIPALE d'une commande.
+--   * affaire.archived_at (timestamptz)       : horodatage d'archivage, distinct de l'annulation
+--     métier (statut ANNULEE). Prépare un archivage dédié (aujourd'hui l'archive passe ANNULEE).
+--   * index unique partiel affaire_principal_par_commande_uniq : AU PLUS une affaire principale
+--     par commande. Le split-livraison conserve plusieurs affaires non-principales.
+--
+-- Rappel schéma live (cerp_test, introspecté le 2026-07-21) : commande_to_affaire.role ne vaut
+-- plus que NULL | 'LIVRAISON' (le rôle PRODUCTION a été retiré) — il n'existait donc AUCUNE
+-- contrainte « une principale par commande ». Ce patch l'introduit de façon additive.
+--
+-- Aucun DROP/DELETE/UPDATE de données existantes. Toutes les affaires existantes gardent
+-- is_principal=false : l'index partiel n'indexe aucune ligne existante -> zéro conflit, aucune
+-- réécriture de table (ADD COLUMN ... DEFAULT constant est metadata-only en PG 11+).
+--
+-- NON inclus (suivi #169 volontaire, hors de ce patch) : le trigger d'invariant
+-- « somme des allocations actives d'une ligne <= quantité commandée ». Un trigger BLOQUANT sur
+-- commande_ligne_affaire_allocation doit d'abord être validé contre le moteur d'orchestration
+-- commande (upsertCommandeAllocations) pour ne pas rejeter des écritures légitimes ; il fera
+-- l'objet d'un patch dédié testé.
+
+BEGIN;
+
+ALTER TABLE public.affaire
+  ADD COLUMN IF NOT EXISTS is_principal boolean NOT NULL DEFAULT false;
+
+ALTER TABLE public.affaire
+  ADD COLUMN IF NOT EXISTS archived_at timestamptz;
+
+CREATE UNIQUE INDEX IF NOT EXISTS affaire_principal_par_commande_uniq
+  ON public.affaire (commande_id)
+  WHERE is_principal AND commande_id IS NOT NULL;
+
+COMMENT ON COLUMN public.affaire.is_principal IS
+  '#169 : affaire principale de la commande (au plus une par commande, cf. index partiel).';
+COMMENT ON COLUMN public.affaire.archived_at IS
+  '#169 : horodatage d''archivage (aucune suppression physique), distinct du statut ANNULEE.';
+
+COMMIT;

--- a/db/patches/support/20260721_affaire_360_hardening.preflight.sql
+++ b/db/patches/support/20260721_affaire_360_hardening.preflight.sql
@@ -1,0 +1,23 @@
+-- Preflight (LECTURE SEULE) pour 20260721_affaire_360_hardening.
+-- Ne modifie rien. À exécuter sur cerp_test AVANT l'application pour confirmer l'état de départ.
+\echo '== Colonnes affaire ciblées (avant apply : normalement absentes) =='
+SELECT column_name
+  FROM information_schema.columns
+ WHERE table_schema = 'public' AND table_name = 'affaire'
+   AND column_name IN ('is_principal', 'archived_at')
+ ORDER BY column_name;
+
+\echo '== Index principal déjà présent ? (avant apply : aucune ligne) =='
+SELECT indexname
+  FROM pg_indexes
+ WHERE schemaname = 'public' AND tablename = 'affaire'
+   AND indexname = 'affaire_principal_par_commande_uniq';
+
+\echo '== Contexte : nombre d''affaires + commandes portant >1 affaire (split-livraison) =='
+SELECT count(*) AS affaire_rows FROM public.affaire;
+SELECT count(*) AS commandes_multi_affaires
+  FROM (
+    SELECT commande_id FROM public.affaire
+     WHERE commande_id IS NOT NULL
+     GROUP BY commande_id HAVING count(*) > 1
+  ) m;

--- a/db/patches/support/20260721_affaire_360_hardening.rollback.sql
+++ b/db/patches/support/20260721_affaire_360_hardening.rollback.sql
@@ -1,0 +1,13 @@
+-- Rollback pour 20260721_affaire_360_hardening.
+-- À n'exécuter QUE pour annuler le patch (retire les objets additifs). Ne supprime aucune
+-- donnée métier autre que les deux colonnes introduites par ce patch.
+BEGIN;
+
+DROP INDEX IF EXISTS public.affaire_principal_par_commande_uniq;
+
+ALTER TABLE public.affaire DROP COLUMN IF EXISTS archived_at;
+ALTER TABLE public.affaire DROP COLUMN IF EXISTS is_principal;
+
+DELETE FROM public.cerp_schema_migrations WHERE filename = '20260721_affaire_360_hardening.sql';
+
+COMMIT;

--- a/db/patches/support/20260721_affaire_360_hardening.verify.sql
+++ b/db/patches/support/20260721_affaire_360_hardening.verify.sql
@@ -1,0 +1,24 @@
+-- Verify pour 20260721_affaire_360_hardening. À exécuter APRÈS l'application (cerp_test puis,
+-- sur autorisation, cerp_prod). Confirme la présence des objets et l'accès du rôle applicatif.
+\echo '== Colonnes ajoutées (attendu : is_principal bool NOT NULL def false ; archived_at timestamptz NULL) =='
+SELECT column_name, data_type, is_nullable, column_default
+  FROM information_schema.columns
+ WHERE table_schema = 'public' AND table_name = 'affaire'
+   AND column_name IN ('is_principal', 'archived_at')
+ ORDER BY column_name;
+
+\echo '== Index unique partiel (attendu : présent, WHERE is_principal AND commande_id IS NOT NULL) =='
+SELECT indexdef
+  FROM pg_indexes
+ WHERE schemaname = 'public' AND tablename = 'affaire'
+   AND indexname = 'affaire_principal_par_commande_uniq';
+
+\echo '== Le rôle applicatif cerp_app lit bien les nouvelles colonnes (pas de 42501) =='
+SET ROLE cerp_app;
+SELECT count(*) FILTER (WHERE is_principal) AS principals,
+       count(*) FILTER (WHERE archived_at IS NOT NULL) AS archived
+  FROM public.affaire;
+RESET ROLE;
+
+\echo '== Migration enregistrée =='
+SELECT filename FROM public.cerp_schema_migrations WHERE filename = '20260721_affaire_360_hardening.sql';

--- a/docs/http/affaires.md
+++ b/docs/http/affaires.md
@@ -1,0 +1,88 @@
+# Affaires — contrat HTTP (#169)
+
+Base : `/api/v1/affaires`. Toutes les routes exigent `authenticateToken` et une **capacité RBAC**
+distincte (refus par défaut). Le serveur est l'autorité : codes, statuts et dates sont attribués par
+le serveur ; le frontend ne calcule ni code, ni statut, ni agrégat.
+
+## Modèle
+
+L'affaire est le dossier opérationnel 360 de la commande à la clôture. Elle **n'invente ni ne recopie**
+de totaux métier modifiables : les agrégats (production, achats, planning, qualité, livraison, facture)
+proviennent de read-models calculés depuis les modules propriétaires (`/command-center`, `/:id/operations`).
+
+- `reference` : code métier **`AFF-AAAA-NNNN`**, attribué par le serveur via la séquence transactionnelle
+  centrale (`generateAffaireCode` → `fn_next_issued_code_value`). **Immuable**, jamais une clé étrangère,
+  jamais fourni par le client.
+- `statut` : `OUVERTE | EN_COURS | SUSPENDUE | CLOTUREE | ANNULEE`. N'évolue que par `/transition`.
+- Verrou optimiste : `updated_at` (jeton `expected_updated_at`).
+
+## Capacités RBAC
+
+`read` (lectures) · `write` (création / édition métadonnées / aperçu) · `transition` · `close` · `reopen`
+· `archive` · `allocate` · `finance`. Chaque capacité correspond à un ensemble de rôles ; le refus est
+renvoyé côté serveur indépendamment de la visibilité des boutons.
+
+## Endpoints
+
+### Lectures (`read`)
+- `GET /affaires` — liste paginée (filtres q / client / statut / type / dates, tri, `include=client`).
+- `GET /affaires/command-center` — command center avec rollups production / livraison / facturation /
+  contrôle, segments, `next_action`, `risk_flags`, traçabilité.
+- `GET /affaires/:id` — fiche (`include=client,commande,devis`).
+- `GET /affaires/:id/operations` — détail 360 : allocations par ligne, OF, livraisons, factures,
+  documents, timeline (event-logs + audit).
+
+### Aperçu de création (`write`) — aucun effet de bord
+`POST /affaires/preview`
+```json
+{ "client_id": "001", "commande_id": 123, "type_affaire": "livraison", "commentaire": null }
+```
+→ `200` `{ code_format: "AFF-YYYY-NNNN", type_affaire, client, commande, warnings[], blockers[], can_create }`.
+Ne consomme **pas** la séquence de code, ne crée rien. Avertissements : `COMMANDE_ALREADY_HAS_AFFAIRE`,
+`CLIENT_MISMATCH`. Bloqueurs : `CLIENT_NOT_FOUND`, `COMMANDE_NOT_FOUND`.
+
+### Création (`write`)
+`POST /affaires`
+```json
+{ "client_id": "001", "commande_id": 123, "type_affaire": "livraison", "date_ouverture": "2026-07-21", "commentaire": null }
+```
+→ `201` `{ id, reference, updated_at }`. Le `statut` initial est `OUVERTE` (serveur). Une `reference`
+fournie par le client est **ignorée**. `client_id` requis pour `livraison`, optionnel pour `projet`.
+
+### Édition métadonnées (`write`)
+`PATCH /affaires/:id`
+```json
+{ "commentaire": "note", "date_ouverture": "2026-07-21", "expected_updated_at": "<updated_at reçu au GET>" }
+```
+→ `200` `{ id, statut, updated_at }`. `statut` et `reference` **non modifiables** ici (ignorés). Corps sans
+champ modifiable → `400`. Jeton périmé → `409 CONCURRENT_MODIFICATION`.
+
+### Transition d'état (`transition` / `close` / `reopen`)
+`POST /affaires/:id/transition`
+```json
+{ "to": "CLOTUREE", "reason": null, "expected_updated_at": "<jeton>" }
+```
+→ `200` `{ id, statut, updated_at }`. `reason` obligatoire pour `SUSPENDUE` et `ANNULEE`. Transitions
+autorisées : OUVERTE→{EN_COURS,SUSPENDUE,CLOTUREE,ANNULEE} · EN_COURS→{SUSPENDUE,CLOTUREE,ANNULEE} ·
+SUSPENDUE→{OUVERTE,EN_COURS,CLOTUREE,ANNULEE} · CLOTUREE→{OUVERTE,EN_COURS} (**réouverture auditée**) ·
+ANNULEE→∅ (terminal). Transition interdite → `422 INVALID_TRANSITION` (`details.allowed`). La capacité fine
+(close / reopen / cancel) est renforcée côté serveur une fois le statut courant connu.
+
+### Archivage (`archive`) — aucune suppression physique
+`POST /affaires/:id/archive`
+```json
+{ "reason": "dossier soldé", "expected_updated_at": "<jeton>" }
+```
+→ `200` `{ id, statut: "ANNULEE", updated_at, already_archived }`. Idempotent (une affaire déjà archivée
+renvoie son état sans nouvelle écriture). La ligne et **toute la traçabilité** (mappings commande↔affaire,
+OF, BL, factures) sont conservées.
+
+## Ne fait jamais
+Aucune création automatique de BL ou de facture. Aucune écriture d'un total métier modifiable. Aucune
+suppression physique d'affaire. La génération depuis une commande reste orchestrée par le moteur commande
+(`POST /api/v1/commandes/:id/generate-affaires`, idempotent, transaction unique).
+
+## Codes d'erreur
+`400` (validation / aucun champ) · `401` · `403 FORBIDDEN` (capacité manquante) · `404` · `409
+CONCURRENT_MODIFICATION` · `422 INVALID_TRANSITION` · `5xx` générique (message masqué, corréler via
+`X-Request-Id`).

--- a/src/__tests__/affaires.routes.test.ts
+++ b/src/__tests__/affaires.routes.test.ts
@@ -33,13 +33,19 @@ vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
 }));
 
+// Auth mock : rôle injecté via l'en-tête `x-test-role` (défaut administrateur) pour tester le RBAC.
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
-  authenticateToken: (req: { user?: { id: number; username: string; email: string; role: string } }, _res: unknown, next: () => void) => {
+  authenticateToken: (
+    req: { user?: { id: number; username: string; email: string; role: string }; headers: Record<string, unknown> },
+    _res: unknown,
+    next: () => void
+  ) => {
+    const roleHeader = typeof req.headers["x-test-role"] === "string" ? (req.headers["x-test-role"] as string) : "administrateur";
     req.user = {
       id: 1,
       username: "test-admin",
       email: "admin@example.test",
-      role: "administrateur",
+      role: roleHeader,
     };
     next();
   },
@@ -329,87 +335,245 @@ describe("/api/v1/affaires", () => {
     expect(String(mocks.poolQuery.mock.calls[1][0])).toContain("FROM affaire a");
   });
 
-  it("POST /api/v1/affaires generates reference when missing and returns {id}", async () => {
+  // ---------------------------------------------------------------------------
+  // #169 — création : code serveur immuable AFF-AAAA-NNNN, jamais fourni par le client
+  // ---------------------------------------------------------------------------
+  it("POST /api/v1/affaires assigns a server AFF-YYYY-NNNN code and returns {id,reference,updated_at}", async () => {
     mocks.clientQuery
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [{ id: "7" }] }) // nextval
-      .mockResolvedValueOnce({ rows: [{ id: "7" }] }) // INSERT
+      .mockResolvedValueOnce({ rows: [{ id: "7" }] }) // nextval(affaire_id_seq)
+      .mockResolvedValueOnce({ rows: [{ v: "1" }] }) // fn_next_issued_code_value (AFF:<year>)
+      .mockResolvedValueOnce({ rows: [{ id: "7", updated_at: "2026-02-02T10:00:00.000Z" }] }) // INSERT
       .mockResolvedValueOnce({ rows: [{ id: "audit-1", created_at: "2026-02-01T10:00:00.000Z" }] }) // audit
-      .mockResolvedValueOnce({ rows: [] }) // notify
+      .mockResolvedValueOnce({ rows: [] }) // pg_notify
       .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
-    const res = await request(app).post("/api/v1/affaires").send({ client_id: "001" });
+    // Le client tente d'imposer une référence : elle DOIT être ignorée (code serveur).
+    const res = await request(app).post("/api/v1/affaires").send({ client_id: "001", reference: "HACK-1" });
 
     expect(res.status).toBe(201);
-    expect(res.body).toMatchObject({ id: 7 });
-    expect(mocks.poolConnect).toHaveBeenCalledTimes(1);
+    expect(res.body.id).toBe(7);
+    expect(res.body.reference).toMatch(/^AFF-\d{4}-0001$/);
+    expect(res.body).toHaveProperty("updated_at", "2026-02-02T10:00:00.000Z");
 
     const insertCall = mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("INSERT INTO affaire"));
     expect(insertCall).toBeTruthy();
     const params = insertCall?.[1] as unknown[];
     expect(params[0]).toBe(7);
-    expect(params[1]).toBe("AFF-7");
+    expect(String(params[1])).toMatch(/^AFF-\d{4}-0001$/);
+    expect(params[1]).not.toBe("HACK-1"); // le code client est ignoré
   });
 
-  it("POST /api/v1/affaires returns 409 on duplicate reference", async () => {
-    const dup = Object.assign(new Error("duplicate"), {
-      code: "23505",
-      constraint: "affaire_reference_key",
-    });
+  it("POST /api/v1/affaires rejects a livraison without client_id (400 VALIDATION_ERROR)", async () => {
+    const res = await request(app).post("/api/v1/affaires").send({ type_affaire: "livraison" });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("VALIDATION_ERROR");
+    expect((res.body.errors as Array<{ field: string }>).some((e) => e.field === "client_id")).toBe(true);
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
 
+  it("POST /api/v1/affaires allows a projet without client_id", async () => {
     mocks.clientQuery
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [{ id: "8" }] }) // nextval
-      .mockImplementationOnce(() => {
-        throw dup;
-      }) // INSERT
+      .mockResolvedValueOnce({ rows: [{ id: "9" }] }) // nextval
+      .mockResolvedValueOnce({ rows: [{ v: "2" }] }) // code
+      .mockResolvedValueOnce({ rows: [{ id: "9", updated_at: "2026-02-02T10:00:00.000Z" }] }) // INSERT
+      .mockResolvedValueOnce({ rows: [{ id: "audit-1", created_at: "2026-02-01T10:00:00.000Z" }] }) // audit
+      .mockResolvedValueOnce({ rows: [] }) // notify
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await request(app).post("/api/v1/affaires").send({ type_affaire: "projet" });
+    expect(res.status).toBe(201);
+    expect(res.body.id).toBe(9);
+  });
+
+  it("POST /api/v1/affaires is forbidden for a read-only role (403)", async () => {
+    const res = await request(app).post("/api/v1/affaires").set("x-test-role", "lecture").send({ client_id: "001" });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("FORBIDDEN");
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
+  it("GET /api/v1/affaires is forbidden for an unknown role (403 deny-by-default)", async () => {
+    const res = await request(app).get("/api/v1/affaires").set("x-test-role", "role-inconnu");
+    expect(res.status).toBe(403);
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // #169 — PATCH métadonnées : verrou optimiste, statut/reference non modifiables
+  // ---------------------------------------------------------------------------
+  it("PATCH /api/v1/affaires/:id updates metadata and returns the fresh optimistic token", async () => {
+    mocks.clientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ before: { id: 7, statut: "EN_COURS" }, updated_at_text: "2026-02-02T10:00:00.000Z" }] }) // lock
+      .mockResolvedValueOnce({ rows: [{ id: "7", statut: "EN_COURS", updated_at: "2026-02-02T11:00:00.000Z" }] }) // update
+      .mockResolvedValueOnce({ rows: [{ id: "audit-1", created_at: "2026-02-01T10:00:00.000Z" }] }) // audit
+      .mockResolvedValueOnce({ rows: [] }) // notify
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await request(app)
+      .patch("/api/v1/affaires/7")
+      .send({ commentaire: "note", expected_updated_at: "2026-02-02T10:00:00.000Z" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: 7, statut: "EN_COURS", updated_at: "2026-02-02T11:00:00.000Z" });
+    const updateCall = mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("UPDATE affaire"));
+    expect(String(updateCall?.[0])).not.toContain("statut =");
+    expect(String(updateCall?.[0])).not.toContain("reference =");
+  });
+
+  it("PATCH /api/v1/affaires/:id returns 409 CONCURRENT_MODIFICATION on a stale token", async () => {
+    mocks.clientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ before: { id: 7 }, updated_at_text: "2026-02-02T10:00:00.000Z" }] }) // lock
       .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
 
     const res = await request(app)
-      .post("/api/v1/affaires")
-      .send({ reference: "AFF-1", client_id: "001" });
+      .patch("/api/v1/affaires/7")
+      .send({ commentaire: "note", expected_updated_at: "STALE" });
 
     expect(res.status).toBe(409);
-    expect(res.body).toHaveProperty("message");
-    expect(String(res.body.message)).toContain("Reference");
+    expect(res.body.code).toBe("CONCURRENT_MODIFICATION");
+    expect(mocks.clientQuery.mock.calls.some((c) => String(c[0]).includes("UPDATE affaire"))).toBe(false);
     expect(mocks.clientQuery.mock.calls.some((c) => String(c[0]) === "ROLLBACK")).toBe(true);
   });
 
-  it("PATCH /api/v1/affaires/:id sets date_cloture when statut=CLOTUREE and missing date_cloture", async () => {
-    mocks.clientQuery
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [{ before: { id: 7, statut: "EN_COURS" } }] }) // lock before
-      .mockResolvedValueOnce({ rows: [{ id: "7" }] }) // update
-      .mockResolvedValueOnce({ rows: [{ id: "audit-1", created_at: "2026-02-01T10:00:00.000Z" }] }) // audit
-      .mockResolvedValueOnce({ rows: [] }) // notify
-      .mockResolvedValueOnce({ rows: [] }); // COMMIT
-
-    const res = await request(app).patch("/api/v1/affaires/7").send({ statut: "CLOTUREE" });
-
-    expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({ id: 7 });
-
-    const updateCall = mocks.clientQuery.mock.calls[2];
-    expect(String(updateCall[0])).toContain("UPDATE affaire");
-    expect(String(updateCall[0])).toContain("date_cloture = COALESCE(date_cloture, CURRENT_DATE)");
-    expect(updateCall[1]).toEqual([7, "CLOTUREE"]);
+  it("PATCH /api/v1/affaires/:id ignores statut/reference (immutable) -> 400 No fields", async () => {
+    const res = await request(app).patch("/api/v1/affaires/7").send({ statut: "CLOTUREE", reference: "AFF-X" });
+    expect(res.status).toBe(400);
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
   });
 
-  it("DELETE /api/v1/affaires/:id deletes successfully", async () => {
+  // ---------------------------------------------------------------------------
+  // #169 — machine d'état : transitions valides / interdites / RBAC / concurrence
+  // ---------------------------------------------------------------------------
+  it("POST /api/v1/affaires/:id/transition performs a legal transition (EN_COURS -> CLOTUREE) and sets date_cloture", async () => {
     mocks.clientQuery
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [{ before: { id: 7, reference: "AFF-7" } }] }) // lock before
-      .mockResolvedValueOnce({ rows: [{ count: 1 }] }) // mapping count
-      .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // delete links
-      .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // delete affaire
+      .mockResolvedValueOnce({ rows: [{ statut: "EN_COURS", updated_at_text: "2026-02-02T10:00:00.000Z", before: { id: 7, statut: "EN_COURS" } }] }) // lock
+      .mockResolvedValueOnce({ rows: [{ id: "7", statut: "CLOTUREE", updated_at: "2026-02-02T12:00:00.000Z" }] }) // update
       .mockResolvedValueOnce({ rows: [{ id: "audit-1", created_at: "2026-02-01T10:00:00.000Z" }] }) // audit
       .mockResolvedValueOnce({ rows: [] }) // notify
       .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
-    const res = await request(app).delete("/api/v1/affaires/7");
-    expect(res.status).toBe(204);
+    const res = await request(app).post("/api/v1/affaires/7/transition").send({ to: "CLOTUREE" });
 
-    expect(String(mocks.clientQuery.mock.calls[3][0])).toContain("DELETE FROM commande_to_affaire");
-    expect(String(mocks.clientQuery.mock.calls[4][0])).toContain("DELETE FROM affaire");
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: 7, statut: "CLOTUREE" });
+    const updateCall = mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("UPDATE affaire"));
+    expect(String(updateCall?.[0])).toContain("date_cloture = COALESCE(date_cloture, CURRENT_DATE)");
+    const auditCall = mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("INSERT INTO erp_audit_logs"));
+    expect((auditCall?.[1] as unknown[])?.[2]).toBe("affaires.transition.close");
+  });
+
+  it("POST /api/v1/affaires/:id/transition rejects an illegal transition (EN_COURS -> OUVERTE) with 422", async () => {
+    mocks.clientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ statut: "EN_COURS", updated_at_text: "2026-02-02T10:00:00.000Z", before: { id: 7 } }] }) // lock
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await request(app).post("/api/v1/affaires/7/transition").send({ to: "OUVERTE" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("INVALID_TRANSITION");
+    expect(res.body.details).toMatchObject({ from: "EN_COURS", to: "OUVERTE" });
+    expect(mocks.clientQuery.mock.calls.some((c) => String(c[0]).includes("UPDATE affaire"))).toBe(false);
+  });
+
+  it("POST /api/v1/affaires/:id/transition requires a reason for ANNULEE (400)", async () => {
+    const res = await request(app).post("/api/v1/affaires/7/transition").send({ to: "ANNULEE" });
+    expect(res.status).toBe(400);
+    expect((res.body.errors as Array<{ field: string }>).some((e) => e.field === "reason")).toBe(true);
+  });
+
+  it("POST /api/v1/affaires/:id/transition forbids CLOTURE for a role lacking 'close' (403 at route)", async () => {
+    const res = await request(app).post("/api/v1/affaires/7/transition").set("x-test-role", "logistique").send({ to: "CLOTUREE" });
+    expect(res.status).toBe(403);
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
+  it("POST /api/v1/affaires/:id/transition forbids reopen for a role lacking 'reopen' (403 in service)", async () => {
+    mocks.clientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ statut: "CLOTUREE", updated_at_text: "2026-02-02T10:00:00.000Z", before: { id: 7 } }] }) // lock
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    // commercial : possède 'transition' (passe le middleware) mais pas 'reopen' -> 403 en service
+    const res = await request(app).post("/api/v1/affaires/7/transition").set("x-test-role", "commercial").send({ to: "OUVERTE" });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("FORBIDDEN");
+    expect(mocks.clientQuery.mock.calls.some((c) => String(c[0]).includes("UPDATE affaire"))).toBe(false);
+  });
+
+  // ---------------------------------------------------------------------------
+  // #169 — archivage : aucune suppression physique, idempotent, RBAC
+  // ---------------------------------------------------------------------------
+  it("POST /api/v1/affaires/:id/archive archives without any physical delete", async () => {
+    mocks.clientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ statut: "EN_COURS", updated_at_text: "2026-02-02T10:00:00.000Z", before: { id: 7 } }] }) // lock
+      .mockResolvedValueOnce({ rows: [{ id: "7", statut: "ANNULEE", updated_at: "2026-02-02T13:00:00.000Z" }] }) // update
+      .mockResolvedValueOnce({ rows: [{ id: "audit-1", created_at: "2026-02-01T10:00:00.000Z" }] }) // audit
+      .mockResolvedValueOnce({ rows: [] }) // notify
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await request(app).post("/api/v1/affaires/7/archive").send({ reason: "dossier soldé" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: 7, statut: "ANNULEE", already_archived: false });
+    expect(mocks.clientQuery.mock.calls.some((c) => String(c[0]).includes("DELETE FROM affaire"))).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some((c) => String(c[0]).includes("DELETE FROM commande_to_affaire"))).toBe(false);
+  });
+
+  it("POST /api/v1/affaires/:id/archive is idempotent for an already-archived affaire", async () => {
+    mocks.clientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ statut: "ANNULEE", updated_at_text: "2026-02-02T10:00:00.000Z", before: { id: 7 } }] }) // lock
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const res = await request(app).post("/api/v1/affaires/7/archive").send({ reason: "again" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ statut: "ANNULEE", already_archived: true });
+    expect(mocks.clientQuery.mock.calls.some((c) => String(c[0]).includes("UPDATE affaire"))).toBe(false);
+  });
+
+  it("POST /api/v1/affaires/:id/archive is forbidden for a role lacking 'archive' (403)", async () => {
+    const res = await request(app).post("/api/v1/affaires/7/archive").set("x-test-role", "logistique").send({ reason: "x" });
+    expect(res.status).toBe(403);
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
+  // ---------------------------------------------------------------------------
+  // #169 — aperçu de création manuelle : lecture seule, aucun effet de bord
+  // ---------------------------------------------------------------------------
+  it("POST /api/v1/affaires/preview returns code format + linked entities with no side effect", async () => {
+    mocks.poolQuery
+      .mockResolvedValueOnce({ rows: [{ client_id: "001", company_name: "ACME", email: null, phone: null, delivery_address_id: null, bill_address_id: null }] }) // client
+      .mockResolvedValueOnce({ rows: [{ id: "123", numero: "CC-123", client_id: "001", statut: "brouillon" }] }) // commande
+      .mockResolvedValueOnce({ rows: [{ n: 0 }] }); // existing affaire count
+
+    const res = await request(app).post("/api/v1/affaires/preview").send({ client_id: "001", commande_id: 123 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.code_format).toMatch(/^AFF-\d{4}-NNNN$/);
+    expect(res.body.can_create).toBe(true);
+    expect(res.body.client).toMatchObject({ company_name: "ACME" });
+    expect(res.body.commande).toMatchObject({ id: 123, numero: "CC-123" });
+    expect(mocks.poolConnect).not.toHaveBeenCalled(); // aucune transaction, aucun effet de bord
+  });
+
+  it("POST /api/v1/affaires/preview flags COMMANDE_NOT_FOUND as a blocker", async () => {
+    mocks.poolQuery
+      .mockResolvedValueOnce({ rows: [{ client_id: "001", company_name: "ACME", email: null, phone: null, delivery_address_id: null, bill_address_id: null }] }) // client
+      .mockResolvedValueOnce({ rows: [] }); // commande not found
+
+    const res = await request(app).post("/api/v1/affaires/preview").send({ client_id: "001", commande_id: 999 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.can_create).toBe(false);
+    expect(res.body.blockers).toContain("COMMANDE_NOT_FOUND");
   });
 });

--- a/src/module/affaire/controllers/affaire.controller.ts
+++ b/src/module/affaire/controllers/affaire.controller.ts
@@ -3,20 +3,25 @@ import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 import {
   affaireIdParamsSchema,
+  archiveAffaireBodySchema,
   createAffaireBodySchema,
   getAffaireQuerySchema,
   listAffairesCommandCenterQuerySchema,
   listAffairesQuerySchema,
+  previewAffaireBodySchema,
+  transitionAffaireBodySchema,
   updateAffaireBodySchema,
 } from "../validators/affaire.validators";
 import type { AuditContext } from "../types/affaire.types";
 import {
+  svcArchiveAffaire,
   svcCreateAffaire,
-  svcDeleteAffaire,
   svcGetAffaire,
   svcGetAffaireOperations,
   svcListAffairesCommandCenter,
   svcListAffaires,
+  svcPreviewAffaire,
+  svcTransitionAffaire,
   svcUpdateAffaire,
 } from "../services/affaire.service";
 
@@ -38,6 +43,7 @@ function buildAuditContext(req: Request): AuditContext {
 
   return {
     user_id: user.id,
+    user_role: typeof user.role === "string" ? user.role : null,
     ip: getClientIp(req),
     user_agent: userAgent,
     device_type: device.device_type,
@@ -101,6 +107,17 @@ export const getAffaireOperations: RequestHandler = async (req, res, next) => {
   }
 };
 
+// Aperçu de création manuelle : lecture seule, aucun effet de bord (ne consomme pas de code).
+export const previewAffaire: RequestHandler = async (req, res, next) => {
+  try {
+    const dto = previewAffaireBodySchema.parse(req.body ?? {});
+    const out = await svcPreviewAffaire(dto);
+    res.status(200).json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
 export const createAffaire: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req);
@@ -117,7 +134,10 @@ export const updateAffaire: RequestHandler = async (req, res, next) => {
     const audit = buildAuditContext(req);
     const { id } = affaireIdParamsSchema.parse(req.params);
     const dto = updateAffaireBodySchema.parse(req.body);
-    if (Object.keys(dto).length === 0) {
+    // `expected_updated_at` est un jeton de verrou, pas un champ modifiable.
+    const { expected_updated_at, ...mutations } = dto;
+    void expected_updated_at;
+    if (Object.keys(mutations).length === 0) {
       res.status(400).json({ error: "No fields to update" });
       return;
     }
@@ -133,16 +153,35 @@ export const updateAffaire: RequestHandler = async (req, res, next) => {
   }
 };
 
-export const deleteAffaire: RequestHandler = async (req, res, next) => {
+// Transition d'état serveur (machine d'état). Transition interdite -> 422 INVALID_TRANSITION.
+export const transitionAffaire: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req);
     const { id } = affaireIdParamsSchema.parse(req.params);
-    const ok = await svcDeleteAffaire(id, audit);
-    if (!ok) {
+    const dto = transitionAffaireBodySchema.parse(req.body);
+    const out = await svcTransitionAffaire(id, dto, audit);
+    if (!out) {
       res.status(404).json({ error: "Not found" });
       return;
     }
-    res.status(204).send();
+    res.status(200).json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+// Archivage (aucune suppression physique). Remplace l'ancien DELETE.
+export const archiveAffaire: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req);
+    const { id } = affaireIdParamsSchema.parse(req.params);
+    const dto = archiveAffaireBodySchema.parse(req.body ?? {});
+    const out = await svcArchiveAffaire(id, dto, audit);
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.status(200).json(out);
   } catch (err) {
     next(err);
   }

--- a/src/module/affaire/domain/affaire-rbac.ts
+++ b/src/module/affaire/domain/affaire-rbac.ts
@@ -1,0 +1,68 @@
+import type { AffaireTransitionKind } from "./affaire-transitions";
+
+/**
+ * Capacités RBAC distinctes de l'affaire (#169) — refus par défaut. Chaque capacité correspond à
+ * un ensemble de rôles (recherche par sous-chaîne, cohérente avec le modèle de rôles existant).
+ * L'autorisation est vérifiée côté serveur, indépendamment de la visibilité des boutons.
+ */
+export type AffaireCapability =
+  | "read"
+  | "write"
+  | "allocate"
+  | "transition"
+  | "close"
+  | "reopen"
+  | "archive"
+  | "finance";
+
+const CAPABILITY_ROLE_NEEDLES: Record<AffaireCapability, readonly string[]> = {
+  // Lecture large : tous les métiers de l'atelier + support. (Refus si aucun rôle connu.)
+  read: [
+    "admin",
+    "administrateur",
+    "directeur",
+    "secr",
+    "secret",
+    "commercial",
+    "logistique",
+    "production",
+    "atelier",
+    "compt",
+    "qualit",
+    "achat",
+    "planif",
+    "program",
+    "magasin",
+    "lecture",
+    "viewer",
+    "read",
+  ],
+  write: ["admin", "administrateur", "directeur", "secr", "secret", "commercial", "logistique", "production", "atelier", "compt"],
+  allocate: ["admin", "administrateur", "directeur", "production", "atelier", "logistique", "program", "planif"],
+  transition: ["admin", "administrateur", "directeur", "commercial", "logistique", "production", "atelier"],
+  close: ["admin", "administrateur", "directeur", "commercial"],
+  reopen: ["admin", "administrateur", "directeur"],
+  archive: ["admin", "administrateur", "directeur"],
+  finance: ["admin", "administrateur", "directeur", "compt", "commercial"],
+};
+
+export function roleHasAffaireCapability(role: string | null | undefined, capability: AffaireCapability): boolean {
+  if (!role) return false;
+  const normalized = role.trim().toLowerCase();
+  if (!normalized) return false;
+  return CAPABILITY_ROLE_NEEDLES[capability].some((needle) => normalized.includes(needle));
+}
+
+/** Capacité fine requise pour une transition, selon sa nature. */
+export function capabilityForTransition(kind: AffaireTransitionKind): AffaireCapability {
+  switch (kind) {
+    case "close":
+      return "close";
+    case "reopen":
+      return "reopen";
+    case "cancel":
+      return "archive";
+    default:
+      return "transition";
+  }
+}

--- a/src/module/affaire/domain/affaire-transitions.ts
+++ b/src/module/affaire/domain/affaire-transitions.ts
@@ -1,0 +1,48 @@
+import type { AffaireStatut } from "../validators/affaire.validators";
+
+/**
+ * Machine d'état serveur de l'affaire (#169).
+ *
+ * Le statut n'est jamais posé librement via un PATCH générique : toute évolution passe par une
+ * transition explicite validée ici. `ANNULEE` est terminal. `CLOTUREE` n'autorise qu'une
+ * réouverture auditée. Aucune suppression physique : l'archivage est une transition (`cancel`)
+ * qui conserve la ligne et toute la traçabilité.
+ */
+export const AFFAIRE_TRANSITIONS: Record<AffaireStatut, readonly AffaireStatut[]> = {
+  OUVERTE: ["EN_COURS", "SUSPENDUE", "CLOTUREE", "ANNULEE"],
+  EN_COURS: ["SUSPENDUE", "CLOTUREE", "ANNULEE"],
+  SUSPENDUE: ["OUVERTE", "EN_COURS", "CLOTUREE", "ANNULEE"],
+  CLOTUREE: ["OUVERTE", "EN_COURS"], // réouverture auditée uniquement
+  ANNULEE: [], // terminal
+};
+
+/** États terminaux : aucune nouvelle allocation / OF ne doit être créée (hors réouverture auditée). */
+export const AFFAIRE_TERMINAL_STATUSES: readonly AffaireStatut[] = ["CLOTUREE", "ANNULEE"];
+
+export function isTerminalStatus(statut: AffaireStatut): boolean {
+  return AFFAIRE_TERMINAL_STATUSES.includes(statut);
+}
+
+export function isAllowedTransition(from: AffaireStatut, to: AffaireStatut): boolean {
+  if (from === to) return false;
+  return (AFFAIRE_TRANSITIONS[from] ?? []).includes(to);
+}
+
+export function allowedTargetsFrom(from: AffaireStatut): readonly AffaireStatut[] {
+  return AFFAIRE_TRANSITIONS[from] ?? [];
+}
+
+/**
+ * Nature métier d'une transition — sert à router vers la capacité RBAC distincte
+ * (close / reopen / cancel / transition) et à enrichir l'audit.
+ */
+export type AffaireTransitionKind = "start" | "suspend" | "resume" | "close" | "reopen" | "cancel";
+
+export function classifyTransition(from: AffaireStatut, to: AffaireStatut): AffaireTransitionKind {
+  if (to === "ANNULEE") return "cancel";
+  if (to === "CLOTUREE") return "close";
+  if (from === "CLOTUREE") return "reopen";
+  if (to === "SUSPENDUE") return "suspend";
+  if (from === "SUSPENDUE" && (to === "OUVERTE" || to === "EN_COURS")) return "resume";
+  return "start";
+}

--- a/src/module/affaire/repository/affaire.repository.ts
+++ b/src/module/affaire/repository/affaire.repository.ts
@@ -2,12 +2,23 @@ import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
+import { generateAffaireCode } from "../../../shared/codes/code-generator.service";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import {
+  classifyTransition,
+  isAllowedTransition,
+  allowedTargetsFrom,
+} from "../domain/affaire-transitions";
+import { capabilityForTransition, roleHasAffaireCapability } from "../domain/affaire-rbac";
 import type {
   ListAffairesCommandCenterQueryDTO,
   ListAffairesQueryDTO,
   CreateAffaireBodyDTO,
   UpdateAffaireBodyDTO,
+  TransitionAffaireBodyDTO,
+  ArchiveAffaireBodyDTO,
+  PreviewAffaireBodyDTO,
+  AffaireStatut,
 } from "../validators/affaire.validators";
 import type {
   Affaire,
@@ -1186,7 +1197,12 @@ export async function repoCreateAffaire(input: CreateAffaireBodyDTO, audit?: Aud
     if (!idRaw) throw new Error("Failed to allocate affaire id");
     const id = toInt(idRaw, "affaire.id");
 
-    const reference = (input.reference ?? `AFF-${id}`).slice(0, 30);
+    // Code métier serveur immuable AFF-AAAA-NNNN — jamais fourni par le client, jamais une FK.
+    // Séquence transactionnelle centrale (cf. shared/codes) ; client_code accepté mais non encodé.
+    const reference = await generateAffaireCode(client, { type: "LIV", client_code: input.client_id ?? "" });
+
+    // Statut initial imposé par le serveur (machine d'état). Toute évolution passe par /transition.
+    const typeAffaire = input.type_affaire ?? "livraison";
 
     const insertSql = `
       INSERT INTO affaire (
@@ -1201,29 +1217,28 @@ export async function repoCreateAffaire(input: CreateAffaireBodyDTO, audit?: Aud
         date_cloture,
         commentaire
       ) VALUES (
-        $1,$2,$3,$4,$5,$6,$7,
-        COALESCE($8::date, CURRENT_DATE),
-        $9::date,
-        $10
+        $1,$2,$3,$4,$5,$6,'OUVERTE',
+        COALESCE($7::date, CURRENT_DATE),
+        NULL,
+        $8
       )
-      RETURNING id::text AS id
+      RETURNING id::text AS id, updated_at::text AS updated_at
     `;
 
-    const ins = await client.query<{ id: string }>(insertSql, [
+    const ins = await client.query<{ id: string; updated_at: string }>(insertSql, [
       id,
       reference,
-      input.client_id,
+      input.client_id ?? null,
       input.commande_id ?? null,
       input.devis_id ?? null,
-      input.type_affaire,
-      input.statut,
+      typeAffaire,
       input.date_ouverture ?? null,
-      input.date_cloture ?? null,
       input.commentaire ?? null,
     ]);
 
     const insertedId = ins.rows[0]?.id;
     const affaireId = insertedId ? toInt(insertedId, "affaire.id") : id;
+    const updatedAt = ins.rows[0]?.updated_at ?? null;
 
     if (audit) {
       await insertAffaireAuditLog(client, audit, {
@@ -1231,22 +1246,23 @@ export async function repoCreateAffaire(input: CreateAffaireBodyDTO, audit?: Aud
         entity_id: String(affaireId),
         details: {
           reference,
-          client_id: input.client_id,
+          client_id: input.client_id ?? null,
           commande_id: input.commande_id ?? null,
           devis_id: input.devis_id ?? null,
-          statut: input.statut,
-          type_affaire: input.type_affaire ?? "livraison",
+          statut: "OUVERTE",
+          type_affaire: typeAffaire,
         },
       });
     }
 
     await client.query("COMMIT");
-    return { id: affaireId };
+    return { id: affaireId, reference, updated_at: updatedAt };
   } catch (err) {
     await client.query("ROLLBACK");
 
     const { code, constraint } = getPgErrorInfo(err);
     if (code === "23505" && constraint === "affaire_reference_key") {
+      // Collision improbable sur un code séquentiel serveur : signalée comme conflit transitoire.
       throw new HttpError(409, "AFFAIRE_REFERENCE_EXISTS", "Reference already exists");
     }
     throw err;
@@ -1255,6 +1271,22 @@ export async function repoCreateAffaire(input: CreateAffaireBodyDTO, audit?: Aud
   }
 }
 
+type MutationResult = { id: number; statut: AffaireStatut; updated_at: string | null };
+
+function assertOptimisticToken(expected: string | undefined, current: string | null) {
+  if (expected && current && expected !== current) {
+    throw new HttpError(
+      409,
+      "CONCURRENT_MODIFICATION",
+      "L'affaire a été modifiée entre-temps. Rechargez la fiche avant de réessayer."
+    );
+  }
+}
+
+/**
+ * PATCH métadonnées uniquement. Le `statut` (machine d'état) et la `reference` (code serveur
+ * immuable) ne sont jamais modifiables ici. Verrou optimiste via `expected_updated_at`.
+ */
 export async function repoUpdateAffaire(id: number, input: UpdateAffaireBodyDTO, audit?: AuditContext) {
   const sets: string[] = [];
   const values: unknown[] = [id];
@@ -1263,42 +1295,12 @@ export async function repoUpdateAffaire(id: number, input: UpdateAffaireBodyDTO,
     return `$${values.length}`;
   };
 
-  if (input.reference !== undefined) {
-    sets.push(`reference = ${push(input.reference)}`);
-  }
-  if (input.client_id !== undefined) {
-    sets.push(`client_id = ${push(input.client_id)}`);
-  }
-  if (input.commande_id !== undefined) {
-    sets.push(`commande_id = ${push(input.commande_id)}::bigint`);
-  }
-  if (input.devis_id !== undefined) {
-    sets.push(`devis_id = ${push(input.devis_id)}::bigint`);
-  }
-  if (input.type_affaire !== undefined) {
-    sets.push(`type_affaire = ${push(input.type_affaire)}`);
-  }
-  if (input.date_ouverture !== undefined) {
-    sets.push(`date_ouverture = ${push(input.date_ouverture)}::date`);
-  }
-  if (input.commentaire !== undefined) {
-    sets.push(`commentaire = ${push(input.commentaire)}`);
-  }
-
-  if (input.statut !== undefined) {
-    sets.push(`statut = ${push(input.statut)}`);
-    if (input.statut === "CLOTUREE") {
-      if (input.date_cloture) {
-        sets.push(`date_cloture = ${push(input.date_cloture)}::date`);
-      } else {
-        sets.push(`date_cloture = COALESCE(date_cloture, CURRENT_DATE)`);
-      }
-    } else if (input.date_cloture !== undefined) {
-      sets.push(`date_cloture = ${push(input.date_cloture)}::date`);
-    }
-  } else if (input.date_cloture !== undefined) {
-    sets.push(`date_cloture = ${push(input.date_cloture)}::date`);
-  }
+  if (input.client_id !== undefined) sets.push(`client_id = ${push(input.client_id)}`);
+  if (input.commande_id !== undefined) sets.push(`commande_id = ${push(input.commande_id)}::bigint`);
+  if (input.devis_id !== undefined) sets.push(`devis_id = ${push(input.devis_id)}::bigint`);
+  if (input.type_affaire !== undefined) sets.push(`type_affaire = ${push(input.type_affaire)}`);
+  if (input.date_ouverture !== undefined) sets.push(`date_ouverture = ${push(input.date_ouverture)}::date`);
+  if (input.commentaire !== undefined) sets.push(`commentaire = ${push(input.commentaire)}`);
 
   if (sets.length === 0) {
     return null;
@@ -1309,24 +1311,115 @@ export async function repoUpdateAffaire(id: number, input: UpdateAffaireBodyDTO,
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
-    const beforeRes = await client.query<Record<string, unknown>>(
-      `SELECT row_to_json(a.*) AS before FROM affaire a WHERE a.id = $1 FOR UPDATE`,
+    const beforeRes = await client.query<{ before: Record<string, unknown> | null; updated_at_text: string | null }>(
+      `SELECT row_to_json(a.*) AS before, a.updated_at::text AS updated_at_text FROM affaire a WHERE a.id = $1 FOR UPDATE`,
       [id]
     );
-    const before = beforeRes.rows[0]?.before ?? null;
-    if (!before) {
+    const beforeRow = beforeRes.rows[0] ?? null;
+    if (!beforeRow || !beforeRow.before) {
       await client.query("ROLLBACK");
       return null;
     }
+
+    assertOptimisticToken(input.expected_updated_at, beforeRow.updated_at_text);
 
     const sql = `
       UPDATE affaire
       SET ${sets.join(", ")}
       WHERE id = $1
-      RETURNING id::text AS id
+      RETURNING id::text AS id, statut, updated_at::text AS updated_at
     `;
 
-    const res = await client.query<{ id: string }>(sql, values);
+    const res = await client.query<{ id: string; statut: AffaireStatut; updated_at: string }>(sql, values);
+    const row = res.rows[0] ?? null;
+    if (!row) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+
+    if (audit) {
+      const { expected_updated_at, ...patch } = input;
+      void expected_updated_at;
+      await insertAffaireAuditLog(client, audit, {
+        action: "affaires.update",
+        entity_id: String(id),
+        details: { before: beforeRow.before, patch },
+      });
+    }
+
+    await client.query("COMMIT");
+    return { id: toInt(row.id, "affaire.id"), statut: row.statut, updated_at: row.updated_at } satisfies MutationResult;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Transition d'état serveur validée par la machine d'état. Transition interdite -> 422
+ * INVALID_TRANSITION ; conflit de version -> 409. Audit transactionnel avec la nature de la
+ * transition (start/suspend/resume/close/reopen/cancel).
+ */
+export async function repoTransitionAffaire(id: number, input: TransitionAffaireBodyDTO, audit?: AuditContext) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const curRes = await client.query<{
+      statut: AffaireStatut;
+      updated_at_text: string | null;
+      before: Record<string, unknown> | null;
+    }>(
+      `SELECT a.statut AS statut, a.updated_at::text AS updated_at_text, row_to_json(a.*) AS before
+       FROM affaire a WHERE a.id = $1 FOR UPDATE`,
+      [id]
+    );
+    const cur = curRes.rows[0] ?? null;
+    if (!cur || !cur.before) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+
+    assertOptimisticToken(input.expected_updated_at, cur.updated_at_text);
+
+    const from = cur.statut;
+    const to = input.to;
+    if (!isAllowedTransition(from, to)) {
+      throw new HttpError(422, "INVALID_TRANSITION", `Transition ${from} → ${to} non autorisée.`, {
+        from,
+        to,
+        allowed: allowedTargetsFrom(from),
+      });
+    }
+    const kind = classifyTransition(from, to);
+
+    // RBAC fin dépendant de l'état (réouverture/clôture/annulation) — vérifié ici où `from`/`to`
+    // sont connus (le middleware de route ne peut pas classifier une réouverture sans l'état courant).
+    const requiredCapability = capabilityForTransition(kind);
+    if (audit && !roleHasAffaireCapability(audit.user_role, requiredCapability)) {
+      throw new HttpError(403, "FORBIDDEN", `Capacité « ${requiredCapability} » requise pour cette transition.`);
+    }
+
+    const sets: string[] = ["statut = $2"];
+    const values: unknown[] = [id, to];
+    if (to === "CLOTUREE") {
+      if (input.date_cloture) {
+        values.push(input.date_cloture);
+        sets.push(`date_cloture = $${values.length}::date`);
+      } else {
+        sets.push(`date_cloture = COALESCE(date_cloture, CURRENT_DATE)`);
+      }
+    } else {
+      // Toute sortie de clôture (réouverture) ou état non clôturé efface la date de clôture.
+      sets.push(`date_cloture = NULL`);
+    }
+    sets.push(`updated_at = now()`);
+
+    const res = await client.query<{ id: string; statut: AffaireStatut; updated_at: string }>(
+      `UPDATE affaire SET ${sets.join(", ")} WHERE id = $1 RETURNING id::text AS id, statut, updated_at::text AS updated_at`,
+      values
+    );
     const row = res.rows[0] ?? null;
     if (!row) {
       await client.query("ROLLBACK");
@@ -1335,69 +1428,150 @@ export async function repoUpdateAffaire(id: number, input: UpdateAffaireBodyDTO,
 
     if (audit) {
       await insertAffaireAuditLog(client, audit, {
-        action: "affaires.update",
+        action: `affaires.transition.${kind}`,
         entity_id: String(id),
-        details: {
-          before,
-          patch: input,
-        },
+        details: { from, to, kind, reason: input.reason ?? null, before: cur.before },
       });
     }
 
     await client.query("COMMIT");
-    return { id: toInt(row.id, "affaire.id") };
+    return { id: toInt(row.id, "affaire.id"), statut: row.statut, updated_at: row.updated_at } satisfies MutationResult;
   } catch (err) {
     await client.query("ROLLBACK");
-    const { code, constraint } = getPgErrorInfo(err);
-    if (code === "23505" && constraint === "affaire_reference_key") {
-      throw new HttpError(409, "AFFAIRE_REFERENCE_EXISTS", "Reference already exists");
-    }
     throw err;
   } finally {
     client.release();
   }
 }
 
-export async function repoDeleteAffaire(id: number, audit?: AuditContext) {
+/**
+ * Archivage : aucune suppression physique (remplace l'ancien hard-delete). L'affaire passe à
+ * ANNULEE, la ligne et les mappings commande↔affaire sont CONSERVÉS (traçabilité). Idempotent :
+ * une affaire déjà ANNULEE renvoie son état sans nouvelle écriture. Verrou optimiste facultatif.
+ */
+export async function repoArchiveAffaire(id: number, input: ArchiveAffaireBodyDTO, audit?: AuditContext) {
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
-    const beforeRes = await client.query<Record<string, unknown>>(
-      `SELECT row_to_json(a.*) AS before FROM affaire a WHERE a.id = $1 FOR UPDATE`,
+    const curRes = await client.query<{
+      statut: AffaireStatut;
+      updated_at_text: string | null;
+      before: Record<string, unknown> | null;
+    }>(
+      `SELECT a.statut AS statut, a.updated_at::text AS updated_at_text, row_to_json(a.*) AS before
+       FROM affaire a WHERE a.id = $1 FOR UPDATE`,
       [id]
     );
-    const before = beforeRes.rows[0]?.before ?? null;
-    if (!before) {
+    const cur = curRes.rows[0] ?? null;
+    if (!cur || !cur.before) {
       await client.query("ROLLBACK");
-      return false;
+      return null;
     }
 
-    const links = await client.query<{ count: number }>(
-      `SELECT COUNT(*)::int AS count FROM commande_to_affaire WHERE affaire_id = $1`,
+    assertOptimisticToken(input.expected_updated_at, cur.updated_at_text);
+
+    if (audit && !roleHasAffaireCapability(audit.user_role, "archive")) {
+      throw new HttpError(403, "FORBIDDEN", "Capacité « archive » requise pour archiver une affaire.");
+    }
+
+    if (cur.statut === "ANNULEE") {
+      // Déjà archivée : rejeu idempotent, aucune écriture.
+      await client.query("COMMIT");
+      return { id, statut: "ANNULEE", updated_at: cur.updated_at_text, already_archived: true };
+    }
+
+    const res = await client.query<{ id: string; statut: AffaireStatut; updated_at: string }>(
+      `UPDATE affaire SET statut = 'ANNULEE', updated_at = now() WHERE id = $1
+       RETURNING id::text AS id, statut, updated_at::text AS updated_at`,
       [id]
     );
-    const mappingCount = links.rows[0]?.count ?? 0;
+    const row = res.rows[0] ?? null;
+    if (!row) {
+      await client.query("ROLLBACK");
+      return null;
+    }
 
-    await client.query(`DELETE FROM commande_to_affaire WHERE affaire_id = $1`, [id]);
-    const del = await client.query(`DELETE FROM affaire WHERE id = $1`, [id]);
-
-    if ((del.rowCount ?? 0) > 0 && audit) {
+    if (audit) {
       await insertAffaireAuditLog(client, audit, {
-        action: "affaires.delete",
+        action: "affaires.archive",
         entity_id: String(id),
-        details: {
-          before,
-          deleted_commande_mappings: mappingCount,
-        },
+        details: { before: cur.before, from: cur.statut, reason: input.reason ?? null },
       });
     }
 
     await client.query("COMMIT");
-    return (del.rowCount ?? 0) > 0;
+    return { id: toInt(row.id, "affaire.id"), statut: row.statut, updated_at: row.updated_at, already_archived: false };
   } catch (err) {
     await client.query("ROLLBACK");
     throw err;
   } finally {
     client.release();
   }
+}
+
+export type AffairePreviewResult = {
+  code_format: string;
+  type_affaire: "livraison" | "projet";
+  client: ClientLite | null;
+  commande: { id: number; numero: string | null; client_id: string | null; statut: string | null } | null;
+  warnings: string[];
+  blockers: string[];
+  can_create: boolean;
+};
+
+/**
+ * Aperçu de création manuelle SANS effet de bord : ne consomme pas la séquence de code (le
+ * numéro réel est attribué à la confirmation), ne crée rien. Renvoie le format de code attendu,
+ * les entités liées et les avertissements/bloqueurs métier.
+ */
+export async function repoPreviewAffaire(input: PreviewAffaireBodyDTO): Promise<AffairePreviewResult> {
+  const warnings: string[] = [];
+  const blockers: string[] = [];
+
+  let client: ClientLite | null = null;
+  if (input.client_id) {
+    const r = await pool.query<ClientLite>(
+      `SELECT client_id, company_name, email, phone,
+              delivery_address_id::text AS delivery_address_id,
+              bill_address_id::text AS bill_address_id
+       FROM clients WHERE client_id = $1 LIMIT 1`,
+      [input.client_id]
+    );
+    client = r.rows[0] ?? null;
+    if (!client) blockers.push("CLIENT_NOT_FOUND");
+  }
+
+  let commande: AffairePreviewResult["commande"] = null;
+  if (input.commande_id) {
+    const r = await pool.query<{ id: string; numero: string | null; client_id: string | null; statut: string | null }>(
+      `SELECT cc.id::text AS id, cc.numero, cc.client_id,
+              (SELECT ch.nouveau_statut FROM commande_historique ch
+                WHERE ch.commande_id = cc.id ORDER BY ch.date_action DESC, ch.id DESC LIMIT 1) AS statut
+       FROM commande_client cc WHERE cc.id = $1 LIMIT 1`,
+      [input.commande_id]
+    );
+    const found = r.rows[0] ?? null;
+    if (!found) {
+      blockers.push("COMMANDE_NOT_FOUND");
+    } else {
+      commande = { id: toInt(found.id, "commande.id"), numero: found.numero, client_id: found.client_id, statut: found.statut };
+      const existing = await pool.query<{ n: number }>(
+        `SELECT COUNT(*)::int AS n FROM affaire WHERE commande_id = $1`,
+        [input.commande_id]
+      );
+      if ((existing.rows[0]?.n ?? 0) > 0) warnings.push("COMMANDE_ALREADY_HAS_AFFAIRE");
+      if (input.client_id && found.client_id && found.client_id !== input.client_id) warnings.push("CLIENT_MISMATCH");
+    }
+  }
+
+  const year = new Date().getUTCFullYear();
+  return {
+    code_format: `AFF-${year}-NNNN`,
+    type_affaire: input.type_affaire ?? "livraison",
+    client,
+    commande,
+    warnings,
+    blockers,
+    can_create: blockers.length === 0,
+  };
 }

--- a/src/module/affaire/routes/affaire.routes.ts
+++ b/src/module/affaire/routes/affaire.routes.ts
@@ -1,61 +1,61 @@
 import { Router, type RequestHandler } from "express";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { HttpError } from "../../../utils/httpError";
+import { roleHasAffaireCapability, type AffaireCapability } from "../domain/affaire-rbac";
 import {
+  archiveAffaire,
   createAffaire,
-  deleteAffaire,
   getAffaire,
   getAffaireOperations,
   listAffaires,
   listAffairesCommandCenter,
+  previewAffaire,
+  transitionAffaire,
   updateAffaire,
 } from "../controllers/affaire.controller";
 
 const router = Router();
 
-function hasAnyRole(role: string | undefined, needles: string[]): boolean {
-  if (!role) return false;
-  const normalized = role.trim().toLowerCase();
-  return needles.some((needle) => normalized.includes(needle));
+// Refus par défaut : chaque route exige une capacité distincte, vérifiée côté serveur.
+function requireAffaireCapability(capability: AffaireCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (roleHasAffaireCapability(req.user?.role, capability)) {
+      next();
+      return;
+    }
+    next(new HttpError(403, "FORBIDDEN", `Capacité « ${capability} » requise sur les affaires.`));
+  };
 }
 
-const requireAffairesWrite: RequestHandler = (req, _res, next) => {
-  if (
-    hasAnyRole(req.user?.role, [
-      "admin",
-      "administrateur",
-      "directeur",
-      "secr",
-      "secret",
-      "commercial",
-      "logistique",
-      "production",
-      "atelier",
-      "compt",
-    ])
-  ) {
+// Transition : capacité coarse selon la cible (close/annulation) ; le RBAC fin dépendant de l'état
+// (réouverture) est renforcé dans le service une fois le statut courant connu.
+const requireAffaireTransitionCapability: RequestHandler = (req, _res, next) => {
+  const role = req.user?.role;
+  const to = typeof req.body?.to === "string" ? req.body.to : null;
+  let capability: AffaireCapability = "transition";
+  if (to === "CLOTUREE") capability = "close";
+  else if (to === "ANNULEE") capability = "archive";
+  if (roleHasAffaireCapability(role, capability)) {
     next();
     return;
   }
-  next(new HttpError(403, "FORBIDDEN", "Affaires write role required"));
-};
-
-const requireAffairesAdmin: RequestHandler = (req, _res, next) => {
-  if (hasAnyRole(req.user?.role, ["admin", "administrateur", "directeur"])) {
-    next();
-    return;
-  }
-  next(new HttpError(403, "FORBIDDEN", "Affaires admin role required"));
+  next(new HttpError(403, "FORBIDDEN", `Capacité « ${capability} » requise pour cette transition.`));
 };
 
 router.use(authenticateToken);
 
-router.get("/command-center", listAffairesCommandCenter);
-router.get("/", listAffaires);
-router.get("/:id/operations", getAffaireOperations);
-router.get("/:id", getAffaire);
-router.post("/", requireAffairesWrite, createAffaire);
-router.patch("/:id", requireAffairesWrite, updateAffaire);
-router.delete("/:id", requireAffairesAdmin, deleteAffaire);
+// Lectures
+router.get("/command-center", requireAffaireCapability("read"), listAffairesCommandCenter);
+router.get("/", requireAffaireCapability("read"), listAffaires);
+router.get("/:id/operations", requireAffaireCapability("read"), getAffaireOperations);
+router.get("/:id", requireAffaireCapability("read"), getAffaire);
+
+// Écritures
+router.post("/preview", requireAffaireCapability("write"), previewAffaire);
+router.post("/", requireAffaireCapability("write"), createAffaire);
+router.patch("/:id", requireAffaireCapability("write"), updateAffaire);
+router.post("/:id/transition", requireAffaireTransitionCapability, transitionAffaire);
+// Archivage (aucune suppression physique) — remplace l'ancien DELETE /:id.
+router.post("/:id/archive", requireAffaireCapability("archive"), archiveAffaire);
 
 export default router;

--- a/src/module/affaire/services/affaire.service.ts
+++ b/src/module/affaire/services/affaire.service.ts
@@ -3,15 +3,20 @@ import type {
   ListAffairesCommandCenterQueryDTO,
   ListAffairesQueryDTO,
   UpdateAffaireBodyDTO,
+  TransitionAffaireBodyDTO,
+  ArchiveAffaireBodyDTO,
+  PreviewAffaireBodyDTO,
 } from "../validators/affaire.validators";
 import type { AuditContext } from "../types/affaire.types";
 import {
+  repoArchiveAffaire,
   repoCreateAffaire,
-  repoDeleteAffaire,
   repoGetAffaireOperations,
   repoGetAffaire,
   repoListAffairesCommandCenter,
   repoListAffaires,
+  repoPreviewAffaire,
+  repoTransitionAffaire,
   repoUpdateAffaire,
 } from "../repository/affaire.repository";
 
@@ -24,9 +29,15 @@ export const svcGetAffaire = (id: number, include: string) => repoGetAffaire(id,
 
 export const svcGetAffaireOperations = (id: number) => repoGetAffaireOperations(id);
 
+export const svcPreviewAffaire = (input: PreviewAffaireBodyDTO) => repoPreviewAffaire(input);
+
 export const svcCreateAffaire = (input: CreateAffaireBodyDTO, audit?: AuditContext) => repoCreateAffaire(input, audit);
 
 export const svcUpdateAffaire = (id: number, input: UpdateAffaireBodyDTO, audit?: AuditContext) =>
   repoUpdateAffaire(id, input, audit);
 
-export const svcDeleteAffaire = (id: number, audit?: AuditContext) => repoDeleteAffaire(id, audit);
+export const svcTransitionAffaire = (id: number, input: TransitionAffaireBodyDTO, audit?: AuditContext) =>
+  repoTransitionAffaire(id, input, audit);
+
+export const svcArchiveAffaire = (id: number, input: ArchiveAffaireBodyDTO, audit?: AuditContext) =>
+  repoArchiveAffaire(id, input, audit);

--- a/src/module/affaire/types/affaire.types.ts
+++ b/src/module/affaire/types/affaire.types.ts
@@ -208,6 +208,7 @@ export type AffaireUpsertPayload = {
 
 export type AuditContext = {
   user_id: number;
+  user_role: string | null;
   ip: string | null;
   user_agent: string | null;
   device_type: string | null;

--- a/src/module/affaire/validators/affaire.validators.ts
+++ b/src/module/affaire/validators/affaire.validators.ts
@@ -17,6 +17,7 @@ export const affaireIdParamsSchema = z.object({
 });
 
 export const affaireStatutSchema = z.enum(["OUVERTE", "EN_COURS", "SUSPENDUE", "CLOTUREE", "ANNULEE"]);
+export type AffaireStatut = z.infer<typeof affaireStatutSchema>;
 // livraison = affaire de livraison client (client requis) ; projet = regroupement interne (client optionnel)
 export const affaireTypeSchema = z.enum(["livraison", "projet"]);
 export const affaireCommandCenterSegmentSchema = z.enum([
@@ -30,6 +31,11 @@ export const affaireCommandCenterSegmentSchema = z.enum([
   "blocked",
   "late",
 ]);
+
+// Jeton de verrou optimiste : le frontend renvoie la valeur `updated_at` reçue lors du
+// dernier GET. Le serveur compare la représentation `::text` exacte (cf. commande V3
+// `expected_updated_at`). Format libre volontairement : c'est un jeton d'égalité, pas une date.
+const optimisticToken = z.preprocess(emptyStringToUndefined, z.string().trim().min(1)).optional();
 
 export const listAffairesQuerySchema = z.object({
   q: z.string().optional(),
@@ -79,37 +85,91 @@ export const getAffaireQuerySchema = z.object({
     .default(""),
 });
 
-export const createAffaireBodySchema = z.object({
-  reference: z.preprocess(emptyStringToUndefined, z.string().trim().min(1).max(30)).optional(),
-  client_id: z.preprocess(emptyStringToNull, z.string().trim().min(1)).optional().nullable(),
-  commande_id: z.coerce.number().int().positive().optional().nullable(),
-  devis_id: z.coerce.number().int().positive().optional().nullable(),
-  type_affaire: affaireTypeSchema.optional().default("livraison"),
-  statut: affaireStatutSchema.optional().default("OUVERTE"),
-  date_ouverture: z.preprocess(emptyStringToUndefined, isoDate).optional(),
-  date_cloture: z.preprocess(emptyStringToNull, isoDate).optional().nullable(),
-  commentaire: z.preprocess(emptyStringToNull, z.string().trim().min(1)).optional().nullable(),
-}).superRefine((value, ctx) => {
-  // Client requis pour une affaire de livraison, optionnel pour un projet.
-  const isProjet = value.type_affaire === "projet";
-  const hasClient = typeof value.client_id === "string" && value.client_id.trim().length > 0;
-  if (!isProjet && !hasClient) {
-    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "client_id is required for livraison", path: ["client_id"] });
-  }
-});
+// Création : le `statut` initial n'est pas librement posé (machine d'état = transitions
+// dédiées) ; le code `reference` est TOUJOURS attribué par le serveur (AFF-AAAA-NNNN) et
+// n'est jamais accepté depuis le client. Toute clé `reference` reçue est silencieusement ignorée.
+export const createAffaireBodySchema = z
+  .object({
+    client_id: z.preprocess(emptyStringToNull, z.string().trim().min(1)).optional().nullable(),
+    commande_id: z.coerce.number().int().positive().optional().nullable(),
+    devis_id: z.coerce.number().int().positive().optional().nullable(),
+    type_affaire: affaireTypeSchema.optional().default("livraison"),
+    date_ouverture: z.preprocess(emptyStringToUndefined, isoDate).optional(),
+    commentaire: z.preprocess(emptyStringToNull, z.string().trim().min(1)).optional().nullable(),
+  })
+  .superRefine((value, ctx) => {
+    // Client requis pour une affaire de livraison, optionnel pour un projet.
+    const isProjet = value.type_affaire === "projet";
+    const hasClient = typeof value.client_id === "string" && value.client_id.trim().length > 0;
+    if (!isProjet && !hasClient) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "client_id is required for livraison", path: ["client_id"] });
+    }
+  });
 
 export type CreateAffaireBodyDTO = z.infer<typeof createAffaireBodySchema>;
 
+// Aperçu de création manuelle : mêmes champs métier que la création, sans clé d'idempotence
+// (aucun effet de bord). Le serveur renvoie code/version attendue/avertissements/bloqueurs.
+export const previewAffaireBodySchema = z
+  .object({
+    client_id: z.preprocess(emptyStringToNull, z.string().trim().min(1)).optional().nullable(),
+    commande_id: z.coerce.number().int().positive().optional().nullable(),
+    devis_id: z.coerce.number().int().positive().optional().nullable(),
+    type_affaire: affaireTypeSchema.optional().default("livraison"),
+    commentaire: z.preprocess(emptyStringToNull, z.string().trim().min(1)).optional().nullable(),
+  })
+  .superRefine((value, ctx) => {
+    const isProjet = value.type_affaire === "projet";
+    const hasClient = typeof value.client_id === "string" && value.client_id.trim().length > 0;
+    if (!isProjet && !hasClient) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "client_id is required for livraison", path: ["client_id"] });
+    }
+  });
+
+export type PreviewAffaireBodyDTO = z.infer<typeof previewAffaireBodySchema>;
+
+// PATCH générique = métadonnées seulement. Le `statut` (machine d'état) et la `reference`
+// (code serveur immuable) sont volontairement absents : ils passent par /transition et ne
+// sont jamais modifiables. `expected_updated_at` porte le verrou optimiste.
 export const updateAffaireBodySchema = z.object({
-  reference: z.preprocess(emptyStringToUndefined, z.string().trim().min(1).max(30)).optional(),
   client_id: z.preprocess(emptyStringToNull, z.string().trim().min(1)).optional().nullable(),
   commande_id: z.coerce.number().int().positive().optional().nullable(),
   devis_id: z.coerce.number().int().positive().optional().nullable(),
   type_affaire: affaireTypeSchema.optional(),
-  statut: affaireStatutSchema.optional(),
   date_ouverture: z.preprocess(emptyStringToUndefined, isoDate).optional(),
-  date_cloture: z.preprocess(emptyStringToNull, isoDate).optional().nullable(),
   commentaire: z.preprocess(emptyStringToNull, z.string().trim().min(1)).optional().nullable(),
+  expected_updated_at: optimisticToken,
 });
 
 export type UpdateAffaireBodyDTO = z.infer<typeof updateAffaireBodySchema>;
+
+// Transition d'état serveur. `to` = statut cible ; `reason` = motif audité (obligatoire pour
+// suspension/annulation/réouverture) ; `expected_updated_at` = verrou optimiste.
+export const transitionAffaireBodySchema = z
+  .object({
+    to: affaireStatutSchema,
+    reason: z.preprocess(emptyStringToNull, z.string().trim().min(1).max(500)).optional().nullable(),
+    date_cloture: z.preprocess(emptyStringToNull, isoDate).optional().nullable(),
+    expected_updated_at: optimisticToken,
+  })
+  .superRefine((value, ctx) => {
+    const reasonRequired = value.to === "SUSPENDUE" || value.to === "ANNULEE";
+    const hasReason = typeof value.reason === "string" && value.reason.trim().length > 0;
+    if (reasonRequired && !hasReason) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `reason is required to transition to ${value.to}`,
+        path: ["reason"],
+      });
+    }
+  });
+
+export type TransitionAffaireBodyDTO = z.infer<typeof transitionAffaireBodySchema>;
+
+// Archivage : aucune suppression physique. `reason` audité, verrou optimiste facultatif.
+export const archiveAffaireBodySchema = z.object({
+  reason: z.preprocess(emptyStringToNull, z.string().trim().min(1).max(500)).optional().nullable(),
+  expected_updated_at: optimisticToken,
+});
+
+export type ArchiveAffaireBodyDTO = z.infer<typeof archiveAffaireBodySchema>;


### PR DESCRIPTION
## #169 — Affaires 360 : durcissement gouvernance backend (brouillon)

> **PR brouillon — checkpoint testé, non prêt à fusionner.** Aucune fusion, aucun `main`, aucun déploiement, **aucune migration** (0 changement DB dans cette PR). **`cerp_prod` non modifié.**

### Liens croisés
- Issue : https://github.com/BigFootLime/crp-systems-web/issues/169
- PR frontend/gouvernance associée : https://github.com/BigFootLime/crp-systems-web/pull/185

### Livré (backend, sans migration)
Réutilise `affaire.updated_at` comme jeton de verrou optimiste (même approche que le moteur commande V3), donc **zéro migration DB**.

- **Machine d'état** serveur (`src/module/affaire/domain/affaire-transitions.ts`) — `POST /affaires/:id/transition` ; transition interdite → **422 `INVALID_TRANSITION`** ; `statut` retiré du PATCH générique.
- **Verrou optimiste** `expected_updated_at` → **409 `CONCURRENT_MODIFICATION`** (PATCH / transition / archive).
- **Code serveur immuable** `AFF-AAAA-NNNN` (création via `generateAffaireCode`, `reference` cliente ignorée / retirée du PATCH).
- **Aperçu sans effet de bord** `POST /affaires/preview` (ne consomme pas de code, ne crée rien).
- **Archivage sans suppression physique** `POST /affaires/:id/archive` (→ `ANNULEE`, ligne + traçabilité conservées, idempotent) ; `DELETE /affaires/:id` retiré.
- **RBAC granulaire** refus-par-défaut (`src/module/affaire/domain/affaire-rbac.ts`) : lecture / écriture / allocations / transition / clôture / réouverture / archivage / finance ; RBAC fin (réouverture) renforcé en service.
- Doc contrat : `docs/http/affaires.md`.

### Preuves
`npm run build` (tsc, typecheck réel) OK · `npm run test:run` → **384 tests verts** (21 sur l'affaire : code immuable, projet sans client, 403 RBAC, PATCH optimiste 200/409, statut immuable, transitions légales/illégales 422, reason requise, reopen/close RBAC, archivage sans delete + idempotent, aperçu no-write + blockers).

### Reste à faire
Patch DB **additif** (cerp_test uniquement, sur autorisation) : `is_principal` + index unique, `archived_at`, trigger somme-allocations ≤ qté, `version` optionnel (+ verify/rollback). Extension tests (concurrence, idempotence, ≥100 combinaisons). Détails : `docs/task-reports/issue-169-progress.md` (dépôt frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Harden the Affaires 360 backend around server-controlled codes, state transitions, optimistic concurrency, and RBAC, and prepare additive database support for principal/archived affaires.

New Features:
- Introduce a server-generated immutable affaire code (AFF-YYYY-NNNN) and return it with creation responses.
- Add a dedicated state transition endpoint for affaires, including classification of transition types and audit logging.
- Add an affaire archive endpoint that replaces hard deletion while preserving data and traceability.
- Expose an affaire creation preview endpoint that reports expected code format, linked entities, and blockers/warnings without side effects.

Enhancements:
- Enforce optimistic concurrency on affaire updates, transitions, and archiving using the updated_at token.
- Restrict generic PATCH to metadata-only changes, making statut and reference immutable outside transitions.
- Implement granular RBAC capabilities for affaires (read, write, transition, close, reopen, archive, allocate, finance) with deny-by-default routing.
- Strengthen controllers and routes to propagate user roles into audit context and to gate each endpoint on the appropriate capability.
- Document the Affaires HTTP contract, including endpoints, RBAC, optimistic locking, transitions, and error codes.

Deployment:
- Add additive SQL migration, preflight, verify, and rollback scripts to support principal/archived affaire columns and a partial unique index per commande.

Documentation:
- Add user-facing documentation for the Affaires HTTP API and governance rules.

Tests:
- Extend affaires route tests to cover RBAC behaviors, optimistic locking, server-side code generation, state transitions, archiving semantics, and preview responses.