### PR TITLE
release: dev → main — module Commandes fournisseurs BCF (#172)

### DIFF
--- a/db/patches/20260721_commandes_fournisseurs_core.sql
+++ b/db/patches/20260721_commandes_fournisseurs_core.sql
@@ -1,0 +1,633 @@
+-- 20260721_commandes_fournisseurs_core.sql
+-- Issue #172 — Commandes fournisseurs (bounded context absent, créé from scratch).
+-- Additive, idempotent, non-destructive. Safe to run multiple times.
+--
+-- Creates the supplier purchase-order aggregate:
+--   * commande_fournisseur            (header, BCF-AAAA-NNNN server code, 9-state machine)
+--   * commande_fournisseur_ligne      (ordered lines, typed, quality requirements)
+--   * commande_fournisseur_transition (append-only state history)
+--   * commande_fournisseur_document   (frozen document versions, canonical JSON + SHA-256)
+--   * commande_fournisseur_ligne_besoin (immutable need->line coverage links, anti double-order)
+--   * commande_fournisseur_idempotence  (idempotency keys for create/generate/send replay)
+-- Extends (additive, nullable — NO second reception subsystem, cf. #172 contract):
+--   * receptions_fournisseurs.commande_fournisseur_id
+--   * reception_fournisseur_lignes.commande_fournisseur_ligne_id
+-- Extends the central business-code allocator whitelist with the BCF scope
+-- (fn_next_issued_code_value — body identical to 20260713, only the regex gains BCF).
+--
+-- SOURCE OF TRUTH (unchanged): public.fournisseurs (UUID) canonical supplier master;
+-- public.fournisseur_catalogue price/lead-time source; public.receptions_fournisseurs
+-- stays the ONLY reception subsystem. Quantities received are NEVER duplicated on the
+-- order lines: they are computed server-side by SUM over linked reception lines.
+--
+-- No DROP/DELETE/UPDATE of existing data. ADD COLUMN ... nullable => metadata-only.
+-- Support scripts (run manually, NOT picked up by db:patches:up):
+--   db/patches/support/20260721_commandes_fournisseurs_core.preflight.sql (read-only, BEFORE)
+--   db/patches/support/20260721_commandes_fournisseurs_core.verify.sql    (read-only, AFTER)
+--   db/patches/support/20260721_commandes_fournisseurs_core.rollback.sql  (guarded, non-destructive)
+
+BEGIN;
+
+/* -------------------------------------------------------------------------- */
+/* 0) Guards: upstream canonical tables must already exist                     */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF to_regclass('public.fournisseurs') IS NULL THEN
+    RAISE EXCEPTION '#172: public.fournisseurs is missing — apply the fournisseurs patches first';
+  END IF;
+  IF to_regclass('public.articles') IS NULL THEN
+    RAISE EXCEPTION '#172: public.articles is missing';
+  END IF;
+  IF to_regclass('public.receptions_fournisseurs') IS NULL THEN
+    RAISE EXCEPTION '#172: public.receptions_fournisseurs is missing — reception subsystem is a hard dependency';
+  END IF;
+  IF to_regprocedure('public.fn_next_issued_code_value(text)') IS NULL THEN
+    RAISE EXCEPTION '#172: public.fn_next_issued_code_value(text) is missing — apply 20260713_codification_versions_of_vsm.sql first';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 1) Codification: add the BCF scope to the whitelisted allocator             */
+/*    Body identical to 20260713 — ONLY the regex gains |BCF (additive).       */
+/* -------------------------------------------------------------------------- */
+
+CREATE OR REPLACE FUNCTION public.fn_next_issued_code_value(p_scope text)
+RETURNS bigint
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+DECLARE
+  v_scope text := upper(btrim(COALESCE(p_scope, '')));
+BEGIN
+  IF v_scope !~ '^(CLI|FOU|ART:[A-Z0-9]{1,48}|(DEV|CMD|AFF|OF|LOT|MVT|CQ|NC|CAPA|BL|FACT|BCF):[0-9]{4})$' THEN
+    RAISE EXCEPTION 'Unsupported business-code sequence scope: %', p_scope
+      USING ERRCODE = '22023';
+  END IF;
+  RETURN nextval('public.cerp_business_code_issue_seq'::regclass);
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_next_issued_code_value(text) IS
+  'Whitelisted, non-reusable business-code allocator backed by a native PostgreSQL sequence. #172 adds the BCF scope (bons de commande fournisseurs).';
+
+/* -------------------------------------------------------------------------- */
+/* 2) Header: commande_fournisseur                                             */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.commande_fournisseur (
+  id                       uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code                     text NOT NULL,
+  statut                   text NOT NULL DEFAULT 'BROUILLON',
+  origine                  text NOT NULL DEFAULT 'MANUEL',
+  fournisseur_id           uuid NOT NULL,
+  contact_id               uuid,
+  adresse_commande_id      uuid,
+  magasin_livraison_id     uuid,
+  adresse_livraison_texte  text,
+  adresse_facturation_texte text,
+  devise                   text NOT NULL DEFAULT 'EUR',
+  conditions_paiement      text,
+  incoterm                 text,
+  mode_transport           text,
+  date_besoin              date,
+  date_promesse            date,
+  date_envoi               timestamptz,
+  date_accuse              timestamptz,
+  date_cloture             timestamptz,
+  date_annulation          timestamptz,
+  reference_fournisseur    text,
+  commentaire_public       text,
+  note_interne             text,
+  motif_revision           text,
+  motif_annulation         text,
+  motif_cloture            text,
+  version_document         integer NOT NULL DEFAULT 0,
+  fournisseur_snapshot     jsonb,
+  conditions_snapshot      jsonb,
+  total_ht                 numeric(14,2) NOT NULL DEFAULT 0,
+  total_remise             numeric(14,2) NOT NULL DEFAULT 0,
+  total_tva                numeric(14,2) NOT NULL DEFAULT 0,
+  frais_port_ht            numeric(12,2) NOT NULL DEFAULT 0,
+  tva_frais_pct            numeric(5,2)  NOT NULL DEFAULT 20,
+  total_ttc                numeric(14,2) NOT NULL DEFAULT 0,
+  idempotency_key          text,
+  submitted_at             timestamptz,
+  submitted_by             integer,
+  approved_at              timestamptz,
+  approved_by              integer,
+  sent_by                  integer,
+  acknowledged_by          integer,
+  created_at               timestamptz NOT NULL DEFAULT now(),
+  updated_at               timestamptz NOT NULL DEFAULT now(),
+  created_by               integer,
+  updated_by               integer
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_code_uniq') THEN
+    ALTER TABLE public.commande_fournisseur
+      ADD CONSTRAINT commande_fournisseur_code_uniq UNIQUE (code);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_statut_chk') THEN
+    ALTER TABLE public.commande_fournisseur
+      ADD CONSTRAINT commande_fournisseur_statut_chk CHECK (statut = ANY (ARRAY[
+        'BROUILLON','A_VALIDER','APPROUVEE','ENVOYEE','ACCUSE_RECU',
+        'PARTIELLEMENT_RECUE','RECUE','CLOTUREE','ANNULEE']));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_origine_chk') THEN
+    ALTER TABLE public.commande_fournisseur
+      ADD CONSTRAINT commande_fournisseur_origine_chk CHECK (origine = ANY (ARRAY[
+        'MANUEL','SEUIL_STOCK','RUPTURE_OF','PROPOSITION_MRP','SOUS_TRAITANCE','AUTRE']));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_incoterm_chk') THEN
+    ALTER TABLE public.commande_fournisseur
+      ADD CONSTRAINT commande_fournisseur_incoterm_chk CHECK (incoterm IS NULL OR incoterm = ANY (ARRAY[
+        'EXW','FCA','FAS','FOB','CFR','CIF','CPT','CIP','DAP','DPU','DDP']));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_montants_chk') THEN
+    ALTER TABLE public.commande_fournisseur
+      ADD CONSTRAINT commande_fournisseur_montants_chk CHECK (
+        total_ht >= 0 AND total_remise >= 0 AND total_tva >= 0 AND total_ttc >= 0
+        AND frais_port_ht >= 0 AND tva_frais_pct >= 0 AND tva_frais_pct <= 100
+        AND version_document >= 0);
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_fournisseur_fkey') THEN
+    ALTER TABLE public.commande_fournisseur
+      ADD CONSTRAINT commande_fournisseur_fournisseur_fkey
+      FOREIGN KEY (fournisseur_id) REFERENCES public.fournisseurs(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF to_regclass('public.fournisseur_contacts') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_contact_fkey') THEN
+    ALTER TABLE public.commande_fournisseur
+      ADD CONSTRAINT commande_fournisseur_contact_fkey
+      FOREIGN KEY (contact_id) REFERENCES public.fournisseur_contacts(id) ON DELETE SET NULL;
+  END IF;
+
+  IF to_regclass('public.fournisseur_adresses') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_adresse_cmd_fkey') THEN
+    ALTER TABLE public.commande_fournisseur
+      ADD CONSTRAINT commande_fournisseur_adresse_cmd_fkey
+      FOREIGN KEY (adresse_commande_id) REFERENCES public.fournisseur_adresses(id) ON DELETE SET NULL;
+  END IF;
+
+  IF to_regclass('public.magasins') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_magasin_fkey') THEN
+    ALTER TABLE public.commande_fournisseur
+      ADD CONSTRAINT commande_fournisseur_magasin_fkey
+      FOREIGN KEY (magasin_livraison_id) REFERENCES public.magasins(id) ON DELETE SET NULL;
+  END IF;
+
+  IF to_regclass('public.currencies') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_devise_fkey') THEN
+    ALTER TABLE public.commande_fournisseur
+      ADD CONSTRAINT commande_fournisseur_devise_fkey
+      FOREIGN KEY (devise) REFERENCES public.currencies(code) ON DELETE RESTRICT;
+  END IF;
+
+  IF to_regclass('public.users') IS NOT NULL THEN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_created_by_fkey') THEN
+      ALTER TABLE public.commande_fournisseur
+        ADD CONSTRAINT commande_fournisseur_created_by_fkey
+        FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_updated_by_fkey') THEN
+      ALTER TABLE public.commande_fournisseur
+        ADD CONSTRAINT commande_fournisseur_updated_by_fkey
+        FOREIGN KEY (updated_by) REFERENCES public.users(id) ON DELETE SET NULL;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_submitted_by_fkey') THEN
+      ALTER TABLE public.commande_fournisseur
+        ADD CONSTRAINT commande_fournisseur_submitted_by_fkey
+        FOREIGN KEY (submitted_by) REFERENCES public.users(id) ON DELETE SET NULL;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_approved_by_fkey') THEN
+      ALTER TABLE public.commande_fournisseur
+        ADD CONSTRAINT commande_fournisseur_approved_by_fkey
+        FOREIGN KEY (approved_by) REFERENCES public.users(id) ON DELETE SET NULL;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_sent_by_fkey') THEN
+      ALTER TABLE public.commande_fournisseur
+        ADD CONSTRAINT commande_fournisseur_sent_by_fkey
+        FOREIGN KEY (sent_by) REFERENCES public.users(id) ON DELETE SET NULL;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ack_by_fkey') THEN
+      ALTER TABLE public.commande_fournisseur
+        ADD CONSTRAINT commande_fournisseur_ack_by_fkey
+        FOREIGN KEY (acknowledged_by) REFERENCES public.users(id) ON DELETE SET NULL;
+    END IF;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS commande_fournisseur_statut_idx      ON public.commande_fournisseur (statut);
+CREATE INDEX IF NOT EXISTS commande_fournisseur_fournisseur_idx ON public.commande_fournisseur (fournisseur_id);
+CREATE INDEX IF NOT EXISTS commande_fournisseur_origine_idx     ON public.commande_fournisseur (origine);
+CREATE INDEX IF NOT EXISTS commande_fournisseur_date_besoin_idx ON public.commande_fournisseur (date_besoin);
+CREATE INDEX IF NOT EXISTS commande_fournisseur_updated_at_idx  ON public.commande_fournisseur (updated_at);
+CREATE INDEX IF NOT EXISTS commande_fournisseur_created_at_idx  ON public.commande_fournisseur (created_at);
+-- Idempotent creation replay: at most one order per idempotency key.
+CREATE UNIQUE INDEX IF NOT EXISTS commande_fournisseur_idem_uniq
+  ON public.commande_fournisseur (idempotency_key) WHERE idempotency_key IS NOT NULL;
+
+COMMENT ON TABLE public.commande_fournisseur IS
+  '#172 : en-tête de commande fournisseur (BCF). Code visible immuable généré serveur (BCF-AAAA-NNNN). Jamais supprimée : ANNULEE/CLOTUREE + archivage.';
+COMMENT ON COLUMN public.commande_fournisseur.fournisseur_snapshot IS
+  '#172 : snapshot fournisseur/contact/adresses figé à l''envoi — une modification ultérieure de la fiche fournisseur ne réécrit pas l''historique.';
+COMMENT ON COLUMN public.commande_fournisseur.version_document IS
+  '#172 : nombre de versions documentaires figées ; l''envoi exige version_document >= 1.';
+
+/* -------------------------------------------------------------------------- */
+/* 3) Lines: commande_fournisseur_ligne                                        */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.commande_fournisseur_ligne (
+  id                     uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  commande_id            uuid NOT NULL,
+  position               integer NOT NULL DEFAULT 1,
+  type                   text NOT NULL DEFAULT 'ARTICLE',
+  article_id             uuid,
+  catalogue_id           uuid,
+  reference_fournisseur  text,
+  designation            text NOT NULL,
+  designation_interne    text,
+  unite                  text,
+  unite_stock            text,
+  coef_conversion        numeric(12,6),
+  quantite               numeric(14,3) NOT NULL,
+  prix_unitaire_ht       numeric(14,4) NOT NULL DEFAULT 0,
+  remise_pct             numeric(5,2)  NOT NULL DEFAULT 0,
+  tva_pct                numeric(5,2)  NOT NULL DEFAULT 20,
+  frais_ht               numeric(12,2) NOT NULL DEFAULT 0,
+  date_besoin            date,
+  date_promesse          date,
+  delai_jours            integer,
+  affaire_id             bigint,
+  commande_client_id     bigint,
+  of_id                  bigint,
+  piece_technique_id     uuid,
+  operation_libelle      text,
+  magasin_id             uuid,
+  exigences_qualite      jsonb NOT NULL DEFAULT '[]'::jsonb,
+  documents_attendus     text[] NOT NULL DEFAULT '{}',
+  qty_confirmee          numeric(14,3),
+  qty_annulee            numeric(14,3) NOT NULL DEFAULT 0,
+  statut_ligne           text NOT NULL DEFAULT 'ACTIVE',
+  motif_annulation       text,
+  created_at             timestamptz NOT NULL DEFAULT now(),
+  updated_at             timestamptz NOT NULL DEFAULT now(),
+  created_by             integer,
+  updated_by             integer
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_commande_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_ligne
+      ADD CONSTRAINT commande_fournisseur_ligne_commande_fkey
+      FOREIGN KEY (commande_id) REFERENCES public.commande_fournisseur(id) ON DELETE CASCADE;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_type_chk') THEN
+    ALTER TABLE public.commande_fournisseur_ligne
+      ADD CONSTRAINT commande_fournisseur_ligne_type_chk CHECK (type = ANY (ARRAY[
+        'ARTICLE','MATIERE','COMPOSANT','SOUS_TRAITANCE','PRESTATION','LIBRE_CONTROLEE']));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_statut_chk') THEN
+    ALTER TABLE public.commande_fournisseur_ligne
+      ADD CONSTRAINT commande_fournisseur_ligne_statut_chk CHECK (statut_ligne = ANY (ARRAY['ACTIVE','ANNULEE']));
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_nombres_chk') THEN
+    ALTER TABLE public.commande_fournisseur_ligne
+      ADD CONSTRAINT commande_fournisseur_ligne_nombres_chk CHECK (
+        quantite > 0
+        AND prix_unitaire_ht >= 0
+        AND remise_pct >= 0 AND remise_pct <= 100
+        AND tva_pct >= 0 AND tva_pct <= 100
+        AND frais_ht >= 0
+        AND (coef_conversion IS NULL OR coef_conversion > 0)
+        AND (delai_jours IS NULL OR delai_jours >= 0)
+        AND (qty_confirmee IS NULL OR qty_confirmee >= 0)
+        AND qty_annulee >= 0 AND qty_annulee <= quantite
+        AND position >= 1);
+  END IF;
+
+  -- Stable, reorderable position (deferred so transactional swaps never trip it).
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_position_uniq') THEN
+    ALTER TABLE public.commande_fournisseur_ligne
+      ADD CONSTRAINT commande_fournisseur_ligne_position_uniq
+      UNIQUE (commande_id, position) DEFERRABLE INITIALLY DEFERRED;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_article_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_ligne
+      ADD CONSTRAINT commande_fournisseur_ligne_article_fkey
+      FOREIGN KEY (article_id) REFERENCES public.articles(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF to_regclass('public.fournisseur_catalogue') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_catalogue_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_ligne
+      ADD CONSTRAINT commande_fournisseur_ligne_catalogue_fkey
+      FOREIGN KEY (catalogue_id) REFERENCES public.fournisseur_catalogue(id) ON DELETE SET NULL;
+  END IF;
+
+  IF to_regclass('public.affaire') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_affaire_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_ligne
+      ADD CONSTRAINT commande_fournisseur_ligne_affaire_fkey
+      FOREIGN KEY (affaire_id) REFERENCES public.affaire(id) ON DELETE SET NULL;
+  END IF;
+
+  IF to_regclass('public.commande_client') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_cc_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_ligne
+      ADD CONSTRAINT commande_fournisseur_ligne_cc_fkey
+      FOREIGN KEY (commande_client_id) REFERENCES public.commande_client(id) ON DELETE SET NULL;
+  END IF;
+
+  IF to_regclass('public.ordres_fabrication') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_of_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_ligne
+      ADD CONSTRAINT commande_fournisseur_ligne_of_fkey
+      FOREIGN KEY (of_id) REFERENCES public.ordres_fabrication(id) ON DELETE SET NULL;
+  END IF;
+
+  IF to_regclass('public.pieces_techniques') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_pt_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_ligne
+      ADD CONSTRAINT commande_fournisseur_ligne_pt_fkey
+      FOREIGN KEY (piece_technique_id) REFERENCES public.pieces_techniques(id) ON DELETE SET NULL;
+  END IF;
+
+  IF to_regclass('public.magasins') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_magasin_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_ligne
+      ADD CONSTRAINT commande_fournisseur_ligne_magasin_fkey
+      FOREIGN KEY (magasin_id) REFERENCES public.magasins(id) ON DELETE SET NULL;
+  END IF;
+
+  IF to_regclass('public.users') IS NOT NULL THEN
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_created_by_fkey') THEN
+      ALTER TABLE public.commande_fournisseur_ligne
+        ADD CONSTRAINT commande_fournisseur_ligne_created_by_fkey
+        FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_ligne_updated_by_fkey') THEN
+      ALTER TABLE public.commande_fournisseur_ligne
+        ADD CONSTRAINT commande_fournisseur_ligne_updated_by_fkey
+        FOREIGN KEY (updated_by) REFERENCES public.users(id) ON DELETE SET NULL;
+    END IF;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS commande_fournisseur_ligne_commande_idx ON public.commande_fournisseur_ligne (commande_id);
+CREATE INDEX IF NOT EXISTS commande_fournisseur_ligne_article_idx  ON public.commande_fournisseur_ligne (article_id);
+CREATE INDEX IF NOT EXISTS commande_fournisseur_ligne_of_idx       ON public.commande_fournisseur_ligne (of_id);
+CREATE INDEX IF NOT EXISTS commande_fournisseur_ligne_affaire_idx  ON public.commande_fournisseur_ligne (affaire_id);
+
+COMMENT ON TABLE public.commande_fournisseur_ligne IS
+  '#172 : ligne de commande fournisseur. Quantités reçues JAMAIS stockées ici : calculées par SUM sur reception_fournisseur_lignes.commande_fournisseur_ligne_id (une seule vérité).';
+
+/* -------------------------------------------------------------------------- */
+/* 4) Append-only state history: commande_fournisseur_transition               */
+/*    ON DELETE RESTRICT: la traçabilité bloque toute suppression d'en-tête.   */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.commande_fournisseur_transition (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  commande_id  uuid NOT NULL,
+  from_statut  text,
+  to_statut    text NOT NULL,
+  motif        text,
+  acteur_id    integer,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_transition_commande_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_transition
+      ADD CONSTRAINT commande_fournisseur_transition_commande_fkey
+      FOREIGN KEY (commande_id) REFERENCES public.commande_fournisseur(id) ON DELETE RESTRICT;
+  END IF;
+  IF to_regclass('public.users') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_transition_acteur_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_transition
+      ADD CONSTRAINT commande_fournisseur_transition_acteur_fkey
+      FOREIGN KEY (acteur_id) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS commande_fournisseur_transition_commande_idx
+  ON public.commande_fournisseur_transition (commande_id, created_at);
+
+/* -------------------------------------------------------------------------- */
+/* 5) Frozen document versions: commande_fournisseur_document                  */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.commande_fournisseur_document (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  commande_id   uuid NOT NULL,
+  version       integer NOT NULL,
+  titre         text NOT NULL,
+  payload       jsonb NOT NULL,
+  sha256        text NOT NULL,
+  motif_revision text,
+  generated_by  integer,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  sent_at       timestamptz
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_document_commande_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_document
+      ADD CONSTRAINT commande_fournisseur_document_commande_fkey
+      FOREIGN KEY (commande_id) REFERENCES public.commande_fournisseur(id) ON DELETE RESTRICT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_document_version_uniq') THEN
+    ALTER TABLE public.commande_fournisseur_document
+      ADD CONSTRAINT commande_fournisseur_document_version_uniq UNIQUE (commande_id, version);
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_document_sha_chk') THEN
+    ALTER TABLE public.commande_fournisseur_document
+      ADD CONSTRAINT commande_fournisseur_document_sha_chk CHECK (sha256 ~ '^[0-9a-f]{64}$');
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_document_version_chk') THEN
+    ALTER TABLE public.commande_fournisseur_document
+      ADD CONSTRAINT commande_fournisseur_document_version_chk CHECK (version >= 1);
+  END IF;
+  IF to_regclass('public.users') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_document_genby_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_document
+      ADD CONSTRAINT commande_fournisseur_document_genby_fkey
+      FOREIGN KEY (generated_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS commande_fournisseur_document_commande_idx
+  ON public.commande_fournisseur_document (commande_id, version);
+
+COMMENT ON TABLE public.commande_fournisseur_document IS
+  '#172 : versions figées du bon de commande (payload JSON canonique + empreinte SHA-256). Une version envoyée est immuable ; toute modification passe par une nouvelle version motivée.';
+
+/* -------------------------------------------------------------------------- */
+/* 6) Immutable need coverage links: commande_fournisseur_ligne_besoin         */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.commande_fournisseur_ligne_besoin (
+  id                 uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  ligne_id           uuid NOT NULL,
+  besoin_type        text NOT NULL,
+  besoin_ref         text NOT NULL,
+  besoin_of_id       bigint NOT NULL DEFAULT 0,
+  of_id              bigint,
+  quantite_couverte  numeric(14,3) NOT NULL,
+  annule             boolean NOT NULL DEFAULT false,
+  created_at         timestamptz NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'cf_ligne_besoin_ligne_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_ligne_besoin
+      ADD CONSTRAINT cf_ligne_besoin_ligne_fkey
+      FOREIGN KEY (ligne_id) REFERENCES public.commande_fournisseur_ligne(id) ON DELETE CASCADE;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'cf_ligne_besoin_type_chk') THEN
+    ALTER TABLE public.commande_fournisseur_ligne_besoin
+      ADD CONSTRAINT cf_ligne_besoin_type_chk CHECK (besoin_type = ANY (ARRAY[
+        'PIECE_TECHNIQUE_ACHAT','STOCK_LEVEL','MANUEL']));
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'cf_ligne_besoin_qty_chk') THEN
+    ALTER TABLE public.commande_fournisseur_ligne_besoin
+      ADD CONSTRAINT cf_ligne_besoin_qty_chk CHECK (quantite_couverte > 0 AND besoin_of_id >= 0);
+  END IF;
+  IF to_regclass('public.ordres_fabrication') IS NOT NULL
+     AND NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'cf_ligne_besoin_of_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_ligne_besoin
+      ADD CONSTRAINT cf_ligne_besoin_of_fkey
+      FOREIGN KEY (of_id) REFERENCES public.ordres_fabrication(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Anti double-commande : un besoin non-manuel ne peut être couvert que par UNE ligne vivante.
+-- besoin_of_id = 0 quand le besoin n'est pas contextualisé par un OF (portable pré-PG15,
+-- évite NULLS NOT DISTINCT).
+CREATE UNIQUE INDEX IF NOT EXISTS cf_ligne_besoin_couverture_uniq
+  ON public.commande_fournisseur_ligne_besoin (besoin_type, besoin_ref, besoin_of_id)
+  WHERE NOT annule AND besoin_type <> 'MANUEL';
+
+CREATE INDEX IF NOT EXISTS cf_ligne_besoin_ligne_idx ON public.commande_fournisseur_ligne_besoin (ligne_id);
+
+COMMENT ON TABLE public.commande_fournisseur_ligne_besoin IS
+  '#172 : lien immuable besoin source -> ligne générée (anti double-commande). Jamais supprimé : annule=true si la ligne est annulée.';
+
+/* -------------------------------------------------------------------------- */
+/* 7) Idempotency replay: commande_fournisseur_idempotence                     */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.commande_fournisseur_idempotence (
+  cle          text PRIMARY KEY,
+  action       text NOT NULL,
+  commande_id  uuid,
+  resultat     jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at   timestamptz NOT NULL DEFAULT now()
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'cf_idempotence_commande_fkey') THEN
+    ALTER TABLE public.commande_fournisseur_idempotence
+      ADD CONSTRAINT cf_idempotence_commande_fkey
+      FOREIGN KEY (commande_id) REFERENCES public.commande_fournisseur(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'cf_idempotence_action_chk') THEN
+    ALTER TABLE public.commande_fournisseur_idempotence
+      ADD CONSTRAINT cf_idempotence_action_chk CHECK (action = ANY (ARRAY[
+        'CREATE','GENERATE','SEND']));
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 8) Additive link on the EXISTING reception subsystem (no second subsystem)  */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.receptions_fournisseurs
+  ADD COLUMN IF NOT EXISTS commande_fournisseur_id uuid;
+
+ALTER TABLE public.reception_fournisseur_lignes
+  ADD COLUMN IF NOT EXISTS commande_fournisseur_ligne_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'receptions_fournisseurs_cf_fkey') THEN
+    ALTER TABLE public.receptions_fournisseurs
+      ADD CONSTRAINT receptions_fournisseurs_cf_fkey
+      FOREIGN KEY (commande_fournisseur_id) REFERENCES public.commande_fournisseur(id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'reception_fournisseur_lignes_cf_ligne_fkey') THEN
+    ALTER TABLE public.reception_fournisseur_lignes
+      ADD CONSTRAINT reception_fournisseur_lignes_cf_ligne_fkey
+      FOREIGN KEY (commande_fournisseur_ligne_id) REFERENCES public.commande_fournisseur_ligne(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS receptions_fournisseurs_cf_idx
+  ON public.receptions_fournisseurs (commande_fournisseur_id) WHERE commande_fournisseur_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS reception_fournisseur_lignes_cf_ligne_idx
+  ON public.reception_fournisseur_lignes (commande_fournisseur_ligne_id) WHERE commande_fournisseur_ligne_id IS NOT NULL;
+
+COMMENT ON COLUMN public.receptions_fournisseurs.commande_fournisseur_id IS
+  '#172 : rattachement facultatif d''une réception à une commande fournisseur (le module réceptions reste la seule vérité réception).';
+COMMENT ON COLUMN public.reception_fournisseur_lignes.commande_fournisseur_ligne_id IS
+  '#172 : imputation facultative d''une ligne de réception sur une ligne de commande fournisseur (quantités reçues calculées par SUM).';
+
+/* -------------------------------------------------------------------------- */
+/* 9) updated_at triggers (shared helper public.tg_set_updated_at)             */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF to_regprocedure('public.tg_set_updated_at()') IS NOT NULL THEN
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'commande_fournisseur_set_updated_at') THEN
+      CREATE TRIGGER commande_fournisseur_set_updated_at
+        BEFORE UPDATE ON public.commande_fournisseur
+        FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at();
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'commande_fournisseur_ligne_set_updated_at') THEN
+      CREATE TRIGGER commande_fournisseur_ligne_set_updated_at
+        BEFORE UPDATE ON public.commande_fournisseur_ligne
+        FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at();
+    END IF;
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 10) Ownership: application role must own the new tables (42501 lesson,      */
+/*     2026-07-21). No-op when applied by cerp_app itself via db:patches:up.   */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    ALTER TABLE public.commande_fournisseur              OWNER TO cerp_app;
+    ALTER TABLE public.commande_fournisseur_ligne        OWNER TO cerp_app;
+    ALTER TABLE public.commande_fournisseur_transition   OWNER TO cerp_app;
+    ALTER TABLE public.commande_fournisseur_document     OWNER TO cerp_app;
+    ALTER TABLE public.commande_fournisseur_ligne_besoin OWNER TO cerp_app;
+    ALTER TABLE public.commande_fournisseur_idempotence  OWNER TO cerp_app;
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/support/20260721_commandes_fournisseurs_core.preflight.sql
+++ b/db/patches/support/20260721_commandes_fournisseurs_core.preflight.sql
@@ -1,0 +1,48 @@
+-- 20260721_commandes_fournisseurs_core.preflight.sql — READ-ONLY, run BEFORE apply.
+-- #172 : vérifie les prérequis réels de la base (jamais déduits du dépôt — leçon "baseliné ≠ exécuté").
+
+\echo '--- Preflight #172 commandes fournisseurs ---'
+SELECT current_database() AS db, now() AS at;
+
+-- 1) Dépendances amont obligatoires
+SELECT
+  to_regclass('public.fournisseurs')                IS NOT NULL AS has_fournisseurs,
+  to_regclass('public.fournisseur_catalogue')       IS NOT NULL AS has_catalogue,
+  to_regclass('public.fournisseur_contacts')        IS NOT NULL AS has_contacts,
+  to_regclass('public.fournisseur_adresses')        IS NOT NULL AS has_adresses,
+  to_regclass('public.articles')                    IS NOT NULL AS has_articles,
+  to_regclass('public.receptions_fournisseurs')     IS NOT NULL AS has_receptions,
+  to_regclass('public.reception_fournisseur_lignes')IS NOT NULL AS has_reception_lignes,
+  to_regclass('public.currencies')                  IS NOT NULL AS has_currencies,
+  to_regclass('public.magasins')                    IS NOT NULL AS has_magasins,
+  to_regclass('public.users')                       IS NOT NULL AS has_users,
+  to_regprocedure('public.fn_next_issued_code_value(text)') IS NOT NULL AS has_code_fn,
+  to_regprocedure('public.tg_set_updated_at()')          IS NOT NULL AS has_updated_at_trigger_fn;
+
+-- 2) État actuel des objets #172 (attendu : tout à false avant le premier apply)
+SELECT
+  to_regclass('public.commande_fournisseur')              IS NOT NULL AS has_cf,
+  to_regclass('public.commande_fournisseur_ligne')        IS NOT NULL AS has_cf_ligne,
+  to_regclass('public.commande_fournisseur_transition')   IS NOT NULL AS has_cf_transition,
+  to_regclass('public.commande_fournisseur_document')     IS NOT NULL AS has_cf_document,
+  to_regclass('public.commande_fournisseur_ligne_besoin') IS NOT NULL AS has_cf_besoin,
+  to_regclass('public.commande_fournisseur_idempotence')  IS NOT NULL AS has_cf_idem;
+
+-- 3) Colonnes additives réceptions déjà présentes ?
+SELECT
+  EXISTS (SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='receptions_fournisseurs'
+            AND column_name='commande_fournisseur_id')  AS reception_header_linked,
+  EXISTS (SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='reception_fournisseur_lignes'
+            AND column_name='commande_fournisseur_ligne_id') AS reception_line_linked;
+
+-- 4) Whitelist codification actuelle (doit refuser BCF avant apply → 22023 attendu)
+SELECT prosrc ~ 'BCF' AS whitelist_already_has_bcf
+FROM pg_proc WHERE proname = 'fn_next_issued_code_value' AND pronamespace = 'public'::regnamespace;
+
+-- 5) Migration déjà enregistrée ?
+SELECT EXISTS (
+  SELECT 1 FROM public.cerp_schema_migrations
+  WHERE filename = '20260721_commandes_fournisseurs_core.sql'
+) AS migration_already_recorded;

--- a/db/patches/support/20260721_commandes_fournisseurs_core.rollback.sql
+++ b/db/patches/support/20260721_commandes_fournisseurs_core.rollback.sql
@@ -1,0 +1,42 @@
+-- 20260721_commandes_fournisseurs_core.rollback.sql — GUARDED, non-destructive by default.
+-- #172 : le rollback ne détruit JAMAIS des données métier. Il refuse de s'exécuter si une
+-- commande fournisseur existe. À n'utiliser qu'immédiatement après un apply raté/vide,
+-- après sauvegarde, et avec validation humaine.
+
+BEGIN;
+
+DO $$
+DECLARE n bigint;
+BEGIN
+  IF to_regclass('public.commande_fournisseur') IS NULL THEN
+    RAISE NOTICE '#172 rollback: rien à faire (tables absentes)';
+    RETURN;
+  END IF;
+
+  EXECUTE 'SELECT count(*) FROM public.commande_fournisseur' INTO n;
+  IF n > 0 THEN
+    RAISE EXCEPTION '#172 rollback REFUSÉ : % commande(s) fournisseur existent. Archiver/annuler métier, jamais DROP.', n;
+  END IF;
+
+  -- Ordre inverse des dépendances. Les colonnes additives réceptions sont conservées
+  -- (nullable, inertes) pour ne pas toucher au sous-système réceptions ; seules les FK
+  -- vers les tables supprimées doivent tomber avec elles.
+  EXECUTE 'ALTER TABLE public.receptions_fournisseurs DROP CONSTRAINT IF EXISTS receptions_fournisseurs_cf_fkey';
+  EXECUTE 'ALTER TABLE public.reception_fournisseur_lignes DROP CONSTRAINT IF EXISTS reception_fournisseur_lignes_cf_ligne_fkey';
+
+  EXECUTE 'DROP TABLE IF EXISTS public.commande_fournisseur_idempotence';
+  EXECUTE 'DROP TABLE IF EXISTS public.commande_fournisseur_ligne_besoin';
+  EXECUTE 'DROP TABLE IF EXISTS public.commande_fournisseur_document';
+  EXECUTE 'DROP TABLE IF EXISTS public.commande_fournisseur_transition';
+  EXECUTE 'DROP TABLE IF EXISTS public.commande_fournisseur_ligne';
+  EXECUTE 'DROP TABLE IF EXISTS public.commande_fournisseur';
+
+  RAISE NOTICE '#172 rollback: tables vides supprimées. La whitelist BCF de fn_next_issued_code_value est conservée (inerte, non risquée).';
+END $$;
+
+-- Nettoyage du registre si (et seulement si) le rollback ci-dessus a abouti.
+DELETE FROM public.cerp_schema_migrations
+WHERE filename = '20260721_commandes_fournisseurs_core.sql'
+  AND to_regclass('public.commande_fournisseur') IS NULL;
+
+COMMIT;

--- a/db/patches/support/20260721_commandes_fournisseurs_core.verify.sql
+++ b/db/patches/support/20260721_commandes_fournisseurs_core.verify.sql
@@ -1,0 +1,74 @@
+-- 20260721_commandes_fournisseurs_core.verify.sql — READ-ONLY, run AFTER apply.
+-- #172 : prouve que le schéma est réellement en place ET accessible au rôle applicatif.
+
+\echo '--- Verify #172 commandes fournisseurs ---'
+SELECT current_database() AS db, now() AS at;
+
+-- 1) Tables créées
+SELECT
+  to_regclass('public.commande_fournisseur')              IS NOT NULL AS has_cf,
+  to_regclass('public.commande_fournisseur_ligne')        IS NOT NULL AS has_cf_ligne,
+  to_regclass('public.commande_fournisseur_transition')   IS NOT NULL AS has_cf_transition,
+  to_regclass('public.commande_fournisseur_document')     IS NOT NULL AS has_cf_document,
+  to_regclass('public.commande_fournisseur_ligne_besoin') IS NOT NULL AS has_cf_besoin,
+  to_regclass('public.commande_fournisseur_idempotence')  IS NOT NULL AS has_cf_idem;
+
+-- 2) Contraintes clés
+SELECT conname FROM pg_constraint
+WHERE conname IN (
+  'commande_fournisseur_code_uniq',
+  'commande_fournisseur_statut_chk',
+  'commande_fournisseur_origine_chk',
+  'commande_fournisseur_montants_chk',
+  'commande_fournisseur_ligne_position_uniq',
+  'commande_fournisseur_ligne_nombres_chk',
+  'commande_fournisseur_document_version_uniq',
+  'commande_fournisseur_document_sha_chk',
+  'cf_ligne_besoin_type_chk',
+  'receptions_fournisseurs_cf_fkey',
+  'reception_fournisseur_lignes_cf_ligne_fkey')
+ORDER BY conname;
+
+-- 3) Index d'unicité métier
+SELECT indexname FROM pg_indexes
+WHERE schemaname='public' AND indexname IN (
+  'commande_fournisseur_idem_uniq',
+  'cf_ligne_besoin_couverture_uniq',
+  'receptions_fournisseurs_cf_idx',
+  'reception_fournisseur_lignes_cf_ligne_idx')
+ORDER BY indexname;
+
+-- 4) Whitelist codification étendue (BCF accepté, scope invalide toujours refusé)
+SELECT prosrc ~ 'BCF' AS whitelist_has_bcf
+FROM pg_proc WHERE proname='fn_next_issued_code_value' AND pronamespace='public'::regnamespace;
+
+DO $$
+DECLARE v bigint;
+BEGIN
+  -- Un scope hors whitelist doit toujours lever 22023.
+  BEGIN
+    v := public.fn_next_issued_code_value('HACK:2026');
+    RAISE EXCEPTION 'verify FAILED: rogue scope was accepted';
+  EXCEPTION WHEN SQLSTATE '22023' THEN
+    RAISE NOTICE 'ok: rogue scope still rejected (22023)';
+  END;
+END $$;
+
+-- 5) Ownership + accès applicatif (42501 sentinel)
+SELECT relname, pg_get_userbyid(relowner) AS owner
+FROM pg_class
+WHERE relname LIKE 'commande_fournisseur%' AND relkind='r'
+ORDER BY relname;
+
+SET ROLE cerp_app;
+SELECT count(*) AS cf_rows            FROM public.commande_fournisseur;
+SELECT count(*) AS cf_ligne_rows      FROM public.commande_fournisseur_ligne;
+SELECT count(*) AS cf_transition_rows FROM public.commande_fournisseur_transition;
+SELECT count(*) AS cf_document_rows   FROM public.commande_fournisseur_document;
+SELECT count(*) AS cf_besoin_rows     FROM public.commande_fournisseur_ligne_besoin;
+SELECT count(*) AS cf_idem_rows       FROM public.commande_fournisseur_idempotence;
+RESET ROLE;
+
+-- 6) Migration enregistrée
+SELECT filename, applied_at FROM public.cerp_schema_migrations
+WHERE filename = '20260721_commandes_fournisseurs_core.sql';

--- a/docs/http/commandes-fournisseurs.md
+++ b/docs/http/commandes-fournisseurs.md
@@ -1,0 +1,101 @@
+# Contrat HTTP — Commandes fournisseurs (#172, BCF)
+
+Base : `/api/v1/commandes-fournisseurs` — derrière le socle default-deny
+(`authenticateToken`) + gardes de capacité par route (refus par défaut). Zod strict :
+tout champ inconnu est rejeté. Enveloppe d'erreur commune
+`{ success:false, message, code, path, details? }` ; validation →
+`400 { error:"VALIDATION_ERROR", errors:[{field,message}] }`. Corrélation `X-Request-Id`.
+Idempotence : header `Idempotency-Key` (≥ 8 car.) ou champ body dédié.
+
+Le `code` (`BCF-AAAA-NNNN`) est généré serveur (whitelist `fn_next_issued_code_value`),
+immuable, jamais accepté du client. Les montants sont masqués (`null` +
+`prices_masked:true`) pour les rôles sans capacité `prices`.
+
+## Lecture
+
+- `GET /` — capacité `read`. Query bornée : `q` (≤120), `statut` (enum, multiple),
+  `fournisseur_id` (uuid), `origine` (enum), `en_retard` (`true|false`),
+  `page` (≤10000), `page_size` (≤100), `sort`
+  (`created_at|date_besoin|date_promesse|code|total_ttc|updated_at`), `dir`.
+  → `{ items[], total, page, page_size }` (items : fournisseur mini, `en_retard`,
+  `nb_lignes`, `qty_commandee`, `qty_recue`, totaux masquables).
+- `GET /kpis` — `read`. → `{ brouillons, a_valider, a_envoyer, sans_accuse, en_retard, a_recevoir }`.
+- `GET /:id` — `read`. Détail complet : en-tête, `allowed_transitions`, lignes (avec
+  `qty_recue`/`qty_recue_nc` (lots BLOQUE/QUARANTAINE)/`qty_restante` **calculées**,
+  besoins couverts), `transitions` (append-only), `documents` (métadonnées + SHA-256),
+  `receptions` liées. 404 `COMMANDE_FOURNISSEUR_NOT_FOUND`.
+- `GET /:id/documents/:documentId` — `read`. → `{ meta, payload }` (payload JSON canonique
+  dont le SHA-256 est l'empreinte d'autorité). 404 `DOCUMENT_NOT_FOUND`.
+
+## Écriture (brouillon)
+
+- `POST /` — `create`. Body : `fournisseur_id` (uuid requis), `origine`, devise ISO,
+  conditions, incoterm (enum), dates, commentaires public/interne, frais de port,
+  `lignes[]` (≤200 ; type enum ; article/catalogue requis sauf LIBRE_CONTROLEE/PRESTATION ;
+  quantité > 0 ; remise/TVA 0–100 ; conversion unité complète ou absente ; `besoins[]`
+  optionnels). → `201 { id, code }` ; replay → `200 { …, idempotent_replay:true }` ;
+  clé réutilisée sur autre action → 409 `IDEMPOTENCY_KEY_REUSED` ; fournisseur inactif →
+  422 `FOURNISSEUR_INACTIF` ; besoin déjà couvert → 409 `BESOIN_DEJA_COUVERT`.
+- `PATCH /:id` — `update_draft`. Tri-state (seules les clés présentes changent) +
+  `expected_updated_at` (verrou → 409 `CONCURRENT_MODIFICATION`). Brouillon uniquement
+  (422 `DRAFT_ONLY`). Totaux recalculés serveur. → 204.
+- `POST /:id/lignes` / `PATCH /:id/lignes/:ligneId` / `DELETE /:id/lignes/:ligneId` /
+  `POST /:id/lignes/reorder` — `update_draft`, brouillon uniquement, verrou en-tête,
+  totaux recalculés ; reorder = permutation complète validée (422 `REORDER_MISMATCH`),
+  position UNIQUE DEFERRABLE. Suppression physique en brouillon seulement (libère la
+  couverture besoin).
+- `POST /totaux/simulate` — `read`. Calcul pur serveur (arrondi half-away-from-zero,
+  centimes exacts) : `{ total_ht, total_remise, total_tva, total_ttc, frais_port_ht }`.
+
+## Cycle de vie
+
+- `POST /:id/transition` — garde coarse (une capacité de transition au moins) + RBAC fin
+  par nature dans le repository une fois l'état source verrouillé (`FOR UPDATE`).
+  Body : `{ to, motif?, expected_updated_at?, idempotency_key? }`.
+  - 422 `INVALID_TRANSITION` `{from,to,allowed}` ; 422 `MOTIF_REQUIS` (annulation, rejet,
+    réédition, clôture avec reliquat) ; 422 `COMMANDE_SANS_LIGNE` ; 422
+    `FOURNISSEUR_INACTIF` ; 422 `DOCUMENT_VERSION_REQUISE` (envoi sans version figée) ;
+    422 `RECEPTION_DERIVED_STATUS` (`PARTIELLEMENT_RECUE`/`RECUE` manuels interdits) ;
+    422 `ANNULATION_IMPOSSIBLE_RECEPTIONNEE` (quantités déjà reçues) ; 403
+    `FORBIDDEN_TRANSITION` ; 409 verrou. État déjà atteint → `200 { statut,
+    idempotent_replay:true }` (double-clic sûr).
+  - Envoi (`APPROUVEE→ENVOYEE`) : fige `fournisseur_snapshot`/`conditions_snapshot`,
+    `date_envoi`, `sent_by`, marque `sent_at` de la version documentaire courante.
+    L'envoi est explicite et simulable : aucun email réel n'est émis par l'API.
+- `POST /:id/accuse` — `acknowledge`. `{ reference_fournisseur (requis), date_accuse?,
+  date_promesse?, expected_updated_at? }` ; exige `ENVOYEE`. → `{ statut:"ACCUSE_RECU" }`.
+- `POST /:id/documents` — `send`. Exige `APPROUVEE` ; v≥2 exige `motif_revision`.
+  Fige le payload JSON canonique + SHA-256. → 201 métadonnées.
+- `POST /:id/receptions/resync` — `read` (recalcul idempotent de l'état de réception ;
+  la sur-réception n'est tolérée que si le rôle porte `over_receipt`).
+- `POST /:id/duplicate` — `create`. Nouveau brouillon, nouveau code, lignes ACTIVE
+  copiées SANS les liens besoins.
+
+## Propositions d'achat
+
+- `POST /propositions/preview` — `create`. `{ origines:["SEUIL_STOCK"|"RUPTURE_OF"],
+  of_ids?, fournisseur_id?, limit≤200 }`. **Lecture seule.** Sélectionne les besoins
+  éligibles NON couverts (index unique de couverture), explique fournisseur proposé
+  (stock_levels.supplier_id sinon meilleur catalogue actif), prix (+source
+  CATALOGUE_FOURNISSEUR/NOMENCLATURE_ACHAT), délai, alertes (`MOQ_APPLIQUE`,
+  `PRIX_MANQUANT`), groupe par fournisseur+devise, liste les bloqués
+  (`AUCUN_FOURNISSEUR`, `FOURNISSEUR_INACTIF`).
+- `POST /propositions/confirm` — `create`. `{ idempotency_key (requis), groupes[] }` →
+  `201 { commandes:[{id,code,fournisseur_id}] }`. Transactionnel, crée des **BROUILLONS**
+  uniquement (jamais soumis/approuvés/envoyés) ; course sur un besoin → 409
+  `BESOIN_DEJA_COUVERT` ; replay → mêmes commandes + `idempotent_replay:true`.
+
+## Intégration réceptions (module `receptions`, additif)
+
+`POST /receptions` accepte `commande_fournisseur_id` (même fournisseur, commande
+ENVOYEE/ACCUSE_RECU/PARTIELLEMENT_RECUE — sinon 422) ; `POST /receptions/:id/lines`
+accepte `commande_fournisseur_ligne_id` (cohérence fournisseur/article/état vérifiée :
+422 `ARTICLE_MISMATCH`, `LIGNE_COMMANDE_ANNULEE`, `COMMANDE_FOURNISSEUR_NON_RECEVABLE`),
+puis recalcule transactionnellement l'état de la commande (sur-réception → 422
+`OVER_RECEIPT` sauf rôle `over_receipt` + notes ≥ 3 car.).
+
+## Audit & événements
+
+Chaque écriture journalise `erp_audit_logs` (action `commandes_fournisseurs.*`, acteur,
+entité, détails non sensibles, corrélation) dans la transaction métier ; l'historique des
+transitions est append-only (FK RESTRICT : l'en-tête ne peut pas être supprimé).

--- a/src/__tests__/commande-fournisseur.domain.test.ts
+++ b/src/__tests__/commande-fournisseur.domain.test.ts
@@ -1,0 +1,258 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  COMMANDE_FOURNISSEUR_STATUTS,
+  COMMANDE_FOURNISSEUR_TRANSITIONS,
+  allowedTargetsFrom,
+  classifyTransition,
+  isAllowedTransition,
+  isReceptionDerivedStatut,
+  isTerminalStatut,
+  transitionRequiresMotif,
+  type CommandeFournisseurStatut,
+} from "../module/commande-fournisseur/domain/commande-fournisseur-transitions";
+import {
+  capabilityForTransition,
+  roleHasCommandeFournisseurCapability,
+} from "../module/commande-fournisseur/domain/commande-fournisseur-rbac";
+import {
+  computeCommandeTotaux,
+  computeLigneTotaux,
+  roundMoney,
+} from "../module/commande-fournisseur/domain/commande-fournisseur-totaux";
+import {
+  sha256Hex,
+  stableStringify,
+} from "../module/commande-fournisseur/repository/commande-fournisseur.repository";
+
+describe("machine d'état commandes fournisseurs (#172)", () => {
+  it("couvre exactement les 9 statuts du contrat", () => {
+    expect(COMMANDE_FOURNISSEUR_STATUTS).toEqual([
+      "BROUILLON",
+      "A_VALIDER",
+      "APPROUVEE",
+      "ENVOYEE",
+      "ACCUSE_RECU",
+      "PARTIELLEMENT_RECUE",
+      "RECUE",
+      "CLOTUREE",
+      "ANNULEE",
+    ]);
+  });
+
+  it("CLOTUREE et ANNULEE sont terminaux (aucune sortie)", () => {
+    expect(allowedTargetsFrom("CLOTUREE")).toEqual([]);
+    expect(allowedTargetsFrom("ANNULEE")).toEqual([]);
+    expect(isTerminalStatut("CLOTUREE")).toBe(true);
+    expect(isTerminalStatut("ANNULEE")).toBe(true);
+    expect(isTerminalStatut("BROUILLON")).toBe(false);
+  });
+
+  it("refuse toute transition non déclarée (matrice exhaustive)", () => {
+    for (const from of COMMANDE_FOURNISSEUR_STATUTS) {
+      for (const to of COMMANDE_FOURNISSEUR_STATUTS) {
+        const expected = from !== to && COMMANDE_FOURNISSEUR_TRANSITIONS[from].includes(to);
+        expect(isAllowedTransition(from, to)).toBe(expected);
+      }
+    }
+  });
+
+  it("refuse l'auto-transition (double-clic) et les sauts d'étape", () => {
+    expect(isAllowedTransition("BROUILLON", "BROUILLON")).toBe(false);
+    expect(isAllowedTransition("BROUILLON", "APPROUVEE")).toBe(false);
+    expect(isAllowedTransition("BROUILLON", "ENVOYEE")).toBe(false);
+    expect(isAllowedTransition("A_VALIDER", "ENVOYEE")).toBe(false);
+    expect(isAllowedTransition("ENVOYEE", "BROUILLON")).toBe(false);
+    expect(isAllowedTransition("RECUE", "ANNULEE")).toBe(false);
+    expect(isAllowedTransition("PARTIELLEMENT_RECUE", "ANNULEE")).toBe(false);
+  });
+
+  it("classifie les transitions vers la bonne nature métier", () => {
+    expect(classifyTransition("BROUILLON", "A_VALIDER")).toBe("submit");
+    expect(classifyTransition("A_VALIDER", "APPROUVEE")).toBe("approve");
+    expect(classifyTransition("A_VALIDER", "BROUILLON")).toBe("reject");
+    expect(classifyTransition("APPROUVEE", "BROUILLON")).toBe("reopen_draft");
+    expect(classifyTransition("APPROUVEE", "ENVOYEE")).toBe("send");
+    expect(classifyTransition("ENVOYEE", "ACCUSE_RECU")).toBe("acknowledge");
+    expect(classifyTransition("ENVOYEE", "PARTIELLEMENT_RECUE")).toBe("receive_partial");
+    expect(classifyTransition("ACCUSE_RECU", "RECUE")).toBe("receive_full");
+    expect(classifyTransition("PARTIELLEMENT_RECUE", "CLOTUREE")).toBe("close");
+    expect(classifyTransition("BROUILLON", "ANNULEE")).toBe("cancel");
+  });
+
+  it("les états de réception sont dérivés, jamais manuels", () => {
+    expect(isReceptionDerivedStatut("PARTIELLEMENT_RECUE")).toBe(true);
+    expect(isReceptionDerivedStatut("RECUE")).toBe(true);
+    expect(isReceptionDerivedStatut("ENVOYEE")).toBe(false);
+  });
+
+  it("exige un motif pour annulation, rejet, réédition et clôture", () => {
+    expect(transitionRequiresMotif("cancel")).toBe(true);
+    expect(transitionRequiresMotif("reject")).toBe(true);
+    expect(transitionRequiresMotif("reopen_draft")).toBe(true);
+    expect(transitionRequiresMotif("close")).toBe(true);
+    expect(transitionRequiresMotif("submit")).toBe(false);
+    expect(transitionRequiresMotif("approve")).toBe(false);
+    expect(transitionRequiresMotif("send")).toBe(false);
+  });
+});
+
+describe("RBAC capacités commandes fournisseurs (#172) — refus par défaut", () => {
+  const ROLES_REELS = {
+    directeur: "Directeur",
+    admin: "Administrateur Systeme et Reseau",
+    secretaire: "Secretaire",
+    prog: "Responsable Programmation",
+    qualite: "Responsable Qualité",
+    employee: "Employee",
+    rh: "RESPONSABLE_RH",
+  } as const;
+
+  it("refuse tout pour un rôle vide, null ou inconnu", () => {
+    for (const cap of ["read", "create", "approve", "send", "cancel", "prices", "over_receipt"] as const) {
+      expect(roleHasCommandeFournisseurCapability(null, cap)).toBe(false);
+      expect(roleHasCommandeFournisseurCapability(undefined, cap)).toBe(false);
+      expect(roleHasCommandeFournisseurCapability("", cap)).toBe(false);
+      expect(roleHasCommandeFournisseurCapability("   ", cap)).toBe(false);
+      expect(roleHasCommandeFournisseurCapability("Stagiaire", cap)).toBe(false);
+    }
+  });
+
+  it("Employee et RESPONSABLE_RH n'ont aucun accès achats", () => {
+    for (const cap of ["read", "create", "update_draft", "submit", "approve", "send", "cancel", "close", "export", "prices", "over_receipt"] as const) {
+      expect(roleHasCommandeFournisseurCapability(ROLES_REELS.employee, cap)).toBe(false);
+      expect(roleHasCommandeFournisseurCapability(ROLES_REELS.rh, cap)).toBe(false);
+    }
+  });
+
+  it("l'approbation et l'annulation sont réservées Directeur/Admin", () => {
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.directeur, "approve")).toBe(true);
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.admin, "approve")).toBe(true);
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.secretaire, "approve")).toBe(false);
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.prog, "approve")).toBe(false);
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.qualite, "approve")).toBe(false);
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.secretaire, "cancel")).toBe(false);
+  });
+
+  it("la Secrétaire et le Resp. Programmation créent/éditent/soumettent, la Qualité lit", () => {
+    for (const role of [ROLES_REELS.secretaire, ROLES_REELS.prog]) {
+      expect(roleHasCommandeFournisseurCapability(role, "create")).toBe(true);
+      expect(roleHasCommandeFournisseurCapability(role, "update_draft")).toBe(true);
+      expect(roleHasCommandeFournisseurCapability(role, "submit")).toBe(true);
+    }
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.qualite, "read")).toBe(true);
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.qualite, "create")).toBe(false);
+  });
+
+  it("la sur-réception est réservée Directeur/Admin/Qualité", () => {
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.qualite, "over_receipt")).toBe(true);
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.directeur, "over_receipt")).toBe(true);
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.secretaire, "over_receipt")).toBe(false);
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.prog, "over_receipt")).toBe(false);
+  });
+
+  it("les prix restent masqués à la Qualité (capacité prices)", () => {
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.qualite, "prices")).toBe(false);
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.secretaire, "prices")).toBe(true);
+    expect(roleHasCommandeFournisseurCapability(ROLES_REELS.directeur, "prices")).toBe(true);
+  });
+
+  it("route chaque nature de transition vers la capacité attendue", () => {
+    expect(capabilityForTransition("submit")).toBe("submit");
+    expect(capabilityForTransition("approve")).toBe("approve");
+    expect(capabilityForTransition("reject")).toBe("approve");
+    expect(capabilityForTransition("reopen_draft")).toBe("update_draft");
+    expect(capabilityForTransition("send")).toBe("send");
+    expect(capabilityForTransition("acknowledge")).toBe("acknowledge");
+    expect(capabilityForTransition("close")).toBe("close");
+    expect(capabilityForTransition("cancel")).toBe("cancel");
+    expect(capabilityForTransition("receive_partial")).toBe("cancel");
+    expect(capabilityForTransition("receive_full")).toBe("cancel");
+  });
+});
+
+describe("totaux serveur (#172) — arrondis testés", () => {
+  it("arrondit half away from zero à 2 décimales", () => {
+    expect(roundMoney(1.005)).toBe(1.01);
+    expect(roundMoney(2.675)).toBe(2.68);
+    expect(roundMoney(-1.005)).toBe(-1.01);
+    expect(roundMoney(0.1 + 0.2)).toBe(0.3);
+    expect(roundMoney(10)).toBe(10);
+  });
+
+  it("calcule une ligne simple sans dérive flottante", () => {
+    const t = computeLigneTotaux({ quantite: 3, prix_unitaire_ht: 19.99, remise_pct: 0, tva_pct: 20, frais_ht: 0 });
+    expect(t.brut_ht).toBe(59.97);
+    expect(t.remise_montant).toBe(0);
+    expect(t.net_ht).toBe(59.97);
+    expect(t.tva_montant).toBe(11.99);
+    expect(t.ttc).toBe(71.96);
+  });
+
+  it("applique remise puis frais puis TVA sur le net", () => {
+    const t = computeLigneTotaux({ quantite: 10, prix_unitaire_ht: 12.345, remise_pct: 33.33, tva_pct: 5.5, frais_ht: 2.5 });
+    // brut = 123.45 ; remise = 41.15 (123.45*0.3333=41.145... -> 41.15) ; net = 123.45-41.15+2.5 = 84.80
+    expect(t.brut_ht).toBe(123.45);
+    expect(t.remise_montant).toBe(41.15);
+    expect(t.net_ht).toBe(84.8);
+    expect(t.tva_montant).toBe(4.66); // 84.80*0.055 = 4.664 -> 4.66
+  });
+
+  it("exclut les lignes annulées et ajoute les frais de port avec leur TVA", () => {
+    const totaux = computeCommandeTotaux(
+      [
+        { quantite: 2, prix_unitaire_ht: 100, remise_pct: 10, tva_pct: 20, frais_ht: 0, statut_ligne: "ACTIVE" },
+        { quantite: 5, prix_unitaire_ht: 999, remise_pct: 0, tva_pct: 20, frais_ht: 0, statut_ligne: "ANNULEE" },
+      ],
+      { frais_port_ht: 25, tva_frais_pct: 20 }
+    );
+    // ligne active : brut 200, remise 20, net 180, tva 36 ; frais 25 (+5 tva)
+    expect(totaux.total_ht).toBe(205);
+    expect(totaux.total_remise).toBe(20);
+    expect(totaux.total_tva).toBe(41);
+    expect(totaux.total_ttc).toBe(246);
+  });
+
+  it("total vide = frais de port seuls", () => {
+    const totaux = computeCommandeTotaux([], { frais_port_ht: 0, tva_frais_pct: 20 });
+    expect(totaux).toMatchObject({ total_ht: 0, total_remise: 0, total_tva: 0, total_ttc: 0 });
+  });
+
+  it("reste cohérent sur 120 variantes générées (TTC = HT + TVA, centimes exacts)", () => {
+    let checked = 0;
+    for (let i = 1; i <= 120; i += 1) {
+      const quantite = (i % 17) + 0.25;
+      const prix = ((i * 7919) % 100000) / 100; // 0.00 .. 999.99
+      const remise = i % 3 === 0 ? 33.33 : i % 3 === 1 ? 0 : 12.5;
+      const tva = i % 2 === 0 ? 20 : 5.5;
+      const frais = (i % 5) * 1.11;
+      const totaux = computeCommandeTotaux(
+        [{ quantite, prix_unitaire_ht: prix, remise_pct: remise, tva_pct: tva, frais_ht: frais }],
+        { frais_port_ht: (i % 4) * 3.33, tva_frais_pct: 20 }
+      );
+      // Invariants : montants à 2 décimales exactes, TTC = HT + TVA au centime près.
+      for (const v of [totaux.total_ht, totaux.total_remise, totaux.total_tva, totaux.total_ttc]) {
+        expect(Math.round(v * 100)).toBeCloseTo(v * 100, 6);
+        expect(v).toBeGreaterThanOrEqual(0);
+      }
+      expect(roundMoney(totaux.total_ht + totaux.total_tva)).toBe(totaux.total_ttc);
+      checked += 1;
+    }
+    expect(checked).toBe(120);
+  });
+});
+
+describe("empreinte documentaire (#172)", () => {
+  it("stableStringify est indépendant de l'ordre des clés", () => {
+    const a = stableStringify({ b: 1, a: { z: [3, 2], y: null } });
+    const b = stableStringify({ a: { y: null, z: [3, 2] }, b: 1 });
+    expect(a).toBe(b);
+  });
+
+  it("sha256Hex produit une empreinte hexadécimale de 64 caractères, stable", () => {
+    const h1 = sha256Hex(stableStringify({ code: "BCF-2026-0001", total: 100 }));
+    const h2 = sha256Hex(stableStringify({ total: 100, code: "BCF-2026-0001" }));
+    expect(h1).toMatch(/^[0-9a-f]{64}$/);
+    expect(h1).toBe(h2);
+  });
+});

--- a/src/__tests__/commande-fournisseur.routes.test.ts
+++ b/src/__tests__/commande-fournisseur.routes.test.ts
@@ -1,0 +1,356 @@
+import request from "supertest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = {
+    on: emitter.on.bind(emitter),
+    query: mocks.poolQuery,
+    connect: mocks.poolConnect,
+  };
+  mocks.poolConnect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease });
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+// Auth mock : rôle injecté via l'en-tête `x-test-role` (refus par défaut testé avec Employee).
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; username: string; email: string; role: string }; headers: Record<string, unknown> },
+    _res: unknown,
+    next: () => void
+  ) => {
+    const roleHeader =
+      typeof req.headers["x-test-role"] === "string" ? (req.headers["x-test-role"] as string) : "Administrateur Systeme et Reseau";
+    req.user = { id: 1, username: "test", email: "test@example.test", role: roleHeader };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import app from "../config/app";
+
+const UUID = "3b9f2a44-6d3e-4f7a-9c2d-1e5b8a7c6d90";
+
+/** État configurable du dispatcher SQL (mock pg robuste par contenu de requête). */
+const state = {
+  header: {
+    id: UUID,
+    code: "BCF-2026-0001",
+    statut: "BROUILLON",
+    fournisseur_id: UUID,
+    devise: "EUR",
+    version_document: 0,
+    frais_port_ht: "0",
+    tva_frais_pct: "20",
+    updated_at_token: "2026-07-21 10:00:00+00",
+  },
+  fournisseur: { id: UUID, code: "FOU-001", nom: "Aciers Rhône", status: "actif", actif: true },
+  idemRow: null as null | { action: string; resultat: Record<string, unknown> },
+  qtyRecue: "0",
+};
+
+function dispatch(sqlRaw: unknown): { rows: unknown[]; rowCount?: number } {
+  const sql = String(sqlRaw);
+  if (/fn_next_issued_code_value/.test(sql)) return { rows: [{ v: "7" }] };
+  if (/FROM public\.commande_fournisseur_idempotence WHERE cle/.test(sql)) {
+    return { rows: state.idemRow ? [state.idemRow] : [] };
+  }
+  if (/INSERT INTO public\.commande_fournisseur_idempotence/.test(sql)) return { rows: [] };
+  if (/FROM public\.commande_fournisseur\s+WHERE id = \$1::uuid\s+FOR UPDATE/.test(sql)) {
+    return { rows: [state.header] };
+  }
+  if (/INSERT INTO public\.commande_fournisseur_ligne_besoin/.test(sql)) return { rows: [] };
+  if (/INSERT INTO public\.commande_fournisseur_ligne/.test(sql)) return { rows: [{ id: "11111111-2222-4333-8444-555555555555" }] };
+  if (/INSERT INTO public\.commande_fournisseur_transition/.test(sql)) return { rows: [] };
+  if (/INSERT INTO public\.commande_fournisseur/.test(sql)) return { rows: [{ id: UUID }] };
+  if (/SELECT quantite::text, prix_unitaire_ht::text/.test(sql)) return { rows: [] };
+  if (/SELECT frais_port_ht::text, tva_frais_pct::text FROM public\.commande_fournisseur/.test(sql)) {
+    return { rows: [{ frais_port_ht: state.header.frais_port_ht, tva_frais_pct: state.header.tva_frais_pct }] };
+  }
+  if (/count\(\*\) AS n FROM public\.commande_fournisseur_ligne/.test(sql)) return { rows: [{ n: "2" }] };
+  if (/COALESCE\(sum\(rl\.qty_received\), 0\) AS q/.test(sql)) return { rows: [{ q: state.qtyRecue }] };
+  if (/FROM public\.fournisseurs WHERE id/.test(sql)) return { rows: [state.fournisseur] };
+  if (/FROM public\.fournisseur_adresses/.test(sql)) return { rows: [] };
+  if (/UPDATE public\.commande_fournisseur_document/.test(sql)) return { rows: [], rowCount: 0 };
+  if (/UPDATE public\.commande_fournisseur/.test(sql)) return { rows: [], rowCount: 1 };
+  if (/erp_audit_logs/i.test(sql)) return { rows: [{ id: 99 }] };
+  if (/pg_notify/i.test(sql)) return { rows: [] };
+  return { rows: [] };
+}
+
+beforeEach(() => {
+  mocks.poolQuery.mockReset();
+  mocks.poolConnect.mockReset();
+  mocks.clientQuery.mockReset();
+  mocks.clientRelease.mockReset();
+  mocks.poolConnect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease });
+  mocks.poolQuery.mockImplementation(async (sql: unknown) => dispatch(sql));
+  mocks.clientQuery.mockImplementation(async (sql: unknown) => dispatch(sql));
+  state.header = {
+    id: UUID,
+    code: "BCF-2026-0001",
+    statut: "BROUILLON",
+    fournisseur_id: UUID,
+    devise: "EUR",
+    version_document: 0,
+    frais_port_ht: "0",
+    tva_frais_pct: "20",
+    updated_at_token: "2026-07-21 10:00:00+00",
+  };
+  state.fournisseur = { id: UUID, code: "FOU-001", nom: "Aciers Rhône", status: "actif", actif: true };
+  state.idemRow = null;
+  state.qtyRecue = "0";
+});
+
+describe("/api/v1/commandes-fournisseurs — RBAC refus par défaut", () => {
+  it("Employee ne lit pas les commandes fournisseurs (403)", async () => {
+    const res = await request(app).get("/api/v1/commandes-fournisseurs").set("x-test-role", "Employee");
+    expect(res.status).toBe(403);
+  });
+
+  it("un rôle inconnu est refusé par défaut sur toutes les surfaces", async () => {
+    for (const call of [
+      request(app).get("/api/v1/commandes-fournisseurs").set("x-test-role", "Stagiaire"),
+      request(app).post("/api/v1/commandes-fournisseurs").set("x-test-role", "Stagiaire").send({}),
+      request(app).post(`/api/v1/commandes-fournisseurs/${UUID}/transition`).set("x-test-role", "Stagiaire").send({ to: "A_VALIDER" }),
+    ]) {
+      const res = await call;
+      expect(res.status).toBe(403);
+    }
+  });
+
+  it("Responsable Qualité lit mais ne crée pas (403 create)", async () => {
+    const read = await request(app).get("/api/v1/commandes-fournisseurs/kpis").set("x-test-role", "Responsable Qualité");
+    expect(read.status).toBe(200);
+    const write = await request(app)
+      .post("/api/v1/commandes-fournisseurs")
+      .set("x-test-role", "Responsable Qualité")
+      .send({ fournisseur_id: UUID, lignes: [] });
+    expect(write.status).toBe(403);
+  });
+
+  it("l'approbation par la Secrétaire est refusée au niveau fin (403 FORBIDDEN_TRANSITION)", async () => {
+    state.header.statut = "A_VALIDER";
+    const res = await request(app)
+      .post(`/api/v1/commandes-fournisseurs/${UUID}/transition`)
+      .set("x-test-role", "Secretaire")
+      .send({ to: "APPROUVEE" });
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("FORBIDDEN_TRANSITION");
+  });
+});
+
+describe("/api/v1/commandes-fournisseurs — création", () => {
+  it("crée un brouillon avec code BCF serveur (201) et refuse le code client", async () => {
+    const res = await request(app)
+      .post("/api/v1/commandes-fournisseurs")
+      .send({ fournisseur_id: UUID, lignes: [{ type: "LIBRE_CONTROLEE", designation: "Prestation contrôle 3D", quantite: 1, prix_unitaire_ht: 120 }] });
+    expect(res.status).toBe(201);
+    expect(res.body.code).toMatch(/^BCF-\d{4}-0007$/);
+    expect(res.body.idempotent_replay).toBe(false);
+
+    const forbidden = await request(app)
+      .post("/api/v1/commandes-fournisseurs")
+      .send({ fournisseur_id: UUID, code: "BCF-2026-9999", lignes: [] });
+    expect(forbidden.status).toBe(400);
+    expect(forbidden.body.error).toBe("VALIDATION_ERROR");
+  });
+
+  it("rejoue une création idempotente sans dupliquer (200 + idempotent_replay)", async () => {
+    state.idemRow = { action: "CREATE", resultat: { id: UUID, code: "BCF-2026-0001" } };
+    const res = await request(app)
+      .post("/api/v1/commandes-fournisseurs")
+      .set("Idempotency-Key", "cle-idempotente-0001")
+      .send({ fournisseur_id: UUID, lignes: [] });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: UUID, code: "BCF-2026-0001", idempotent_replay: true });
+  });
+
+  it("refuse la réutilisation d'une clé d'idempotence sur une autre action (409)", async () => {
+    state.idemRow = { action: "GENERATE", resultat: {} };
+    const res = await request(app)
+      .post("/api/v1/commandes-fournisseurs")
+      .set("Idempotency-Key", "cle-idempotente-0001")
+      .send({ fournisseur_id: UUID, lignes: [] });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("IDEMPOTENCY_KEY_REUSED");
+  });
+
+  it("refuse un fournisseur inactif (422 FOURNISSEUR_INACTIF)", async () => {
+    state.fournisseur = { ...state.fournisseur, actif: false, status: "inactif" };
+    const res = await request(app)
+      .post("/api/v1/commandes-fournisseurs")
+      .send({ fournisseur_id: UUID, lignes: [] });
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("FOURNISSEUR_INACTIF");
+  });
+});
+
+describe("/api/v1/commandes-fournisseurs — verrou optimiste & brouillon", () => {
+  it("PATCH avec jeton périmé → 409 CONCURRENT_MODIFICATION", async () => {
+    const res = await request(app)
+      .patch(`/api/v1/commandes-fournisseurs/${UUID}`)
+      .send({ expected_updated_at: "2026-07-20T09:00:00.000+00:00", note_interne: "maj" });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("CONCURRENT_MODIFICATION");
+  });
+
+  it("PATCH hors brouillon → 422 DRAFT_ONLY", async () => {
+    state.header.statut = "ENVOYEE";
+    const res = await request(app).patch(`/api/v1/commandes-fournisseurs/${UUID}`).send({ note_interne: "maj" });
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("DRAFT_ONLY");
+  });
+});
+
+describe("/api/v1/commandes-fournisseurs — machine d'état", () => {
+  it("transition interdite → 422 INVALID_TRANSITION avec {from,to,allowed}", async () => {
+    state.header.statut = "CLOTUREE";
+    const res = await request(app)
+      .post(`/api/v1/commandes-fournisseurs/${UUID}/transition`)
+      .send({ to: "ENVOYEE" });
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("INVALID_TRANSITION");
+    expect(res.body.details).toMatchObject({ from: "CLOTUREE", to: "ENVOYEE", allowed: [] });
+  });
+
+  it("soumission sans ligne active → 422 COMMANDE_SANS_LIGNE", async () => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      if (/count\(\*\) AS n FROM public\.commande_fournisseur_ligne/.test(String(sql))) return { rows: [{ n: "0" }] };
+      return dispatch(sql);
+    });
+    const res = await request(app)
+      .post(`/api/v1/commandes-fournisseurs/${UUID}/transition`)
+      .send({ to: "A_VALIDER" });
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("COMMANDE_SANS_LIGNE");
+  });
+
+  it("envoi sans version documentaire figée → 422 DOCUMENT_VERSION_REQUISE", async () => {
+    state.header.statut = "APPROUVEE";
+    state.header.version_document = 0;
+    const res = await request(app)
+      .post(`/api/v1/commandes-fournisseurs/${UUID}/transition`)
+      .set("x-test-role", "Directeur")
+      .send({ to: "ENVOYEE" });
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("DOCUMENT_VERSION_REQUISE");
+  });
+
+  it("l'envoi fige snapshot + date (200) quand une version documentaire existe", async () => {
+    state.header.statut = "APPROUVEE";
+    state.header.version_document = 1;
+    const res = await request(app)
+      .post(`/api/v1/commandes-fournisseurs/${UUID}/transition`)
+      .set("x-test-role", "Directeur")
+      .send({ to: "ENVOYEE" });
+    expect(res.status).toBe(200);
+    expect(res.body.statut).toBe("ENVOYEE");
+  });
+
+  it("les statuts de réception ne se posent jamais à la main → 422 RECEPTION_DERIVED_STATUS", async () => {
+    state.header.statut = "ENVOYEE";
+    const res = await request(app)
+      .post(`/api/v1/commandes-fournisseurs/${UUID}/transition`)
+      .send({ to: "RECUE" });
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("RECEPTION_DERIVED_STATUS");
+  });
+
+  it("annulation motivée obligatoire → 422 MOTIF_REQUIS puis 200 avec motif", async () => {
+    const sans = await request(app)
+      .post(`/api/v1/commandes-fournisseurs/${UUID}/transition`)
+      .set("x-test-role", "Directeur")
+      .send({ to: "ANNULEE" });
+    expect(sans.status).toBe(422);
+    expect(sans.body.code).toBe("MOTIF_REQUIS");
+
+    const avec = await request(app)
+      .post(`/api/v1/commandes-fournisseurs/${UUID}/transition`)
+      .set("x-test-role", "Directeur")
+      .send({ to: "ANNULEE", motif: "Erreur de saisie fournisseur" });
+    expect(avec.status).toBe(200);
+    expect(avec.body.statut).toBe("ANNULEE");
+  });
+
+  it("annulation impossible si des quantités sont déjà reçues → 422", async () => {
+    state.header.statut = "ENVOYEE";
+    state.qtyRecue = "5";
+    const res = await request(app)
+      .post(`/api/v1/commandes-fournisseurs/${UUID}/transition`)
+      .set("x-test-role", "Directeur")
+      .send({ to: "ANNULEE", motif: "tentative" });
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("ANNULATION_IMPOSSIBLE_RECEPTIONNEE");
+  });
+
+  it("double-clic : retransitionner vers l'état courant est un replay sans écriture (200)", async () => {
+    state.header.statut = "A_VALIDER";
+    const res = await request(app)
+      .post(`/api/v1/commandes-fournisseurs/${UUID}/transition`)
+      .send({ to: "A_VALIDER" });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ statut: "A_VALIDER", idempotent_replay: true });
+  });
+});
+
+describe("/api/v1/commandes-fournisseurs — accusé & 404", () => {
+  it("l'accusé exige une commande envoyée (422 sinon)", async () => {
+    state.header.statut = "BROUILLON";
+    const res = await request(app)
+      .post(`/api/v1/commandes-fournisseurs/${UUID}/accuse`)
+      .send({ reference_fournisseur: "AR-2233" });
+    expect(res.status).toBe(422);
+  });
+
+  it("enregistre l'accusé fournisseur sur une commande envoyée (200)", async () => {
+    state.header.statut = "ENVOYEE";
+    const res = await request(app)
+      .post(`/api/v1/commandes-fournisseurs/${UUID}/accuse`)
+      .send({ reference_fournisseur: "AR-2233", date_promesse: "2026-08-30" });
+    expect(res.status).toBe(200);
+    expect(res.body.statut).toBe("ACCUSE_RECU");
+  });
+
+  it("GET détail introuvable → 404 sans fuite d'information", async () => {
+    mocks.poolQuery.mockImplementation(async (sql: unknown) => {
+      if (/FROM public\.commande_fournisseur cf/.test(String(sql))) return { rows: [] };
+      return dispatch(sql);
+    });
+    const res = await request(app).get(`/api/v1/commandes-fournisseurs/${UUID}`);
+    expect(res.status).toBe(404);
+    expect(JSON.stringify(res.body)).not.toMatch(/sql|stack|SELECT/i);
+  });
+
+  it("id non-UUID → 400 VALIDATION_ERROR (pas de fuite SQL)", async () => {
+    const res = await request(app).get("/api/v1/commandes-fournisseurs/1;DROP");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("VALIDATION_ERROR");
+  });
+});
+
+describe("/api/v1/commandes-fournisseurs — totaux serveur", () => {
+  it("simule les totaux côté serveur (HT/TVA/TTC arrondis)", async () => {
+    const res = await request(app)
+      .post("/api/v1/commandes-fournisseurs/totaux/simulate")
+      .send({
+        frais_port_ht: 25,
+        tva_frais_pct: 20,
+        lignes: [{ quantite: 2, prix_unitaire_ht: 100, remise_pct: 10, tva_pct: 20, frais_ht: 0 }],
+      });
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ total_ht: 205, total_remise: 20, total_tva: 41, total_ttc: 246 });
+  });
+});

--- a/src/__tests__/commande-fournisseur.validators.test.ts
+++ b/src/__tests__/commande-fournisseur.validators.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  accuseSchema,
+  createCommandeSchema,
+  ligneInputSchema,
+  listCommandesQuerySchema,
+  propositionsConfirmSchema,
+  simulateTotauxSchema,
+  transitionSchema,
+  updateCommandeSchema,
+} from "../module/commande-fournisseur/validators/commande-fournisseur.validators";
+
+const UUID = "3b9f2a44-6d3e-4f7a-9c2d-1e5b8a7c6d90";
+
+const baseLigne = {
+  type: "ARTICLE",
+  article_id: UUID,
+  designation: "Rond acier 42CD4 Ø30",
+  quantite: 12,
+  prix_unitaire_ht: 8.5,
+};
+
+const baseCreate = {
+  fournisseur_id: UUID,
+  devise: "EUR",
+  lignes: [baseLigne],
+};
+
+describe("validators commandes fournisseurs (#172) — Zod strict", () => {
+  it("accepte une création minimale valide et applique les défauts serveur", () => {
+    const parsed = createCommandeSchema.parse({ body: baseCreate });
+    expect(parsed.body.origine).toBe("MANUEL");
+    expect(parsed.body.frais_port_ht).toBe(0);
+    expect(parsed.body.lignes[0].tva_pct).toBe(20);
+    expect(parsed.body.lignes[0].remise_pct).toBe(0);
+  });
+
+  it("rejette tout champ inconnu (mode strict, création et PATCH)", () => {
+    expect(() => createCommandeSchema.parse({ body: { ...baseCreate, code: "BCF-2026-9999" } })).toThrow();
+    expect(() => createCommandeSchema.parse({ body: { ...baseCreate, statut: "APPROUVEE" } })).toThrow();
+    expect(() => createCommandeSchema.parse({ body: { ...baseCreate, total_ttc: 1 } })).toThrow();
+    expect(() => updateCommandeSchema.parse({ body: { code: "BCF-2026-0001" } })).toThrow();
+    expect(() => updateCommandeSchema.parse({ body: { statut: "ENVOYEE" } })).toThrow();
+  });
+
+  it("le code n'est jamais accepté du client (immuable, généré serveur)", () => {
+    expect("code" in createCommandeSchema.shape.body.shape).toBe(false);
+    expect("code" in updateCommandeSchema.shape.body.shape).toBe(false);
+    expect("statut" in updateCommandeSchema.shape.body.shape).toBe(false);
+  });
+
+  it("exige article ou catalogue pour les lignes non libres, et conversion complète", () => {
+    expect(() =>
+      ligneInputSchema.parse({ ...baseLigne, article_id: undefined, catalogue_id: undefined })
+    ).toThrow(/article ou une entrée de catalogue/i);
+    // LIBRE_CONTROLEE passe sans article
+    expect(() =>
+      ligneInputSchema.parse({ type: "LIBRE_CONTROLEE", designation: "Prestation gravure", quantite: 1, prix_unitaire_ht: 50 })
+    ).not.toThrow();
+    // conversion incomplète refusée
+    expect(() => ligneInputSchema.parse({ ...baseLigne, coef_conversion: 2 })).toThrow(/Conversion/i);
+    expect(() => ligneInputSchema.parse({ ...baseLigne, unite_stock: "kg" })).toThrow(/Conversion/i);
+    expect(() => ligneInputSchema.parse({ ...baseLigne, unite_stock: "kg", coef_conversion: 2.5 })).not.toThrow();
+  });
+
+  it("borne pagination, tri et filtres de liste", () => {
+    const q = listCommandesQuerySchema.parse({ query: {} }).query;
+    expect(q).toMatchObject({ page: 1, page_size: 25, sort: "created_at", dir: "desc" });
+    expect(() => listCommandesQuerySchema.parse({ query: { page_size: "500" } })).toThrow();
+    expect(() => listCommandesQuerySchema.parse({ query: { sort: "evil_column" } })).toThrow();
+    expect(() => listCommandesQuerySchema.parse({ query: { statut: "N_IMPORTE_QUOI" } })).toThrow();
+    expect(() => listCommandesQuerySchema.parse({ query: { injection: "1;DROP TABLE" } })).toThrow();
+  });
+
+  it("transition : statut contrôlé par enum, jamais de chaîne arbitraire", () => {
+    expect(() => transitionSchema.parse({ body: { to: "ENVOYEE" } })).not.toThrow();
+    expect(() => transitionSchema.parse({ body: { to: "SUPPRIMEE" } })).toThrow();
+    expect(() => transitionSchema.parse({ body: { to: "ENVOYEE", extra: true } })).toThrow();
+  });
+
+  it("accusé : référence fournisseur obligatoire, dates au bon format", () => {
+    expect(() => accuseSchema.parse({ body: { reference_fournisseur: "AR-778812" } })).not.toThrow();
+    expect(() => accuseSchema.parse({ body: {} })).toThrow();
+    expect(() =>
+      accuseSchema.parse({ body: { reference_fournisseur: "AR-1", date_promesse: "21/07/2026" } })
+    ).toThrow();
+  });
+
+  it("propositions/confirm : clé d'idempotence obligatoire et bornée", () => {
+    const groupe = {
+      fournisseur_id: UUID,
+      devise: "EUR",
+      lignes: [
+        { besoin_type: "STOCK_LEVEL", besoin_ref: UUID, designation: "Insert carbure", quantite: 10, type: "ARTICLE" },
+      ],
+    };
+    expect(() =>
+      propositionsConfirmSchema.parse({ body: { idempotency_key: "k".repeat(16), groupes: [groupe] } })
+    ).not.toThrow();
+    expect(() => propositionsConfirmSchema.parse({ body: { groupes: [groupe] } })).toThrow();
+    expect(() => propositionsConfirmSchema.parse({ body: { idempotency_key: "court", groupes: [groupe] } })).toThrow();
+  });
+
+  it("simulate : lignes bornées à 200", () => {
+    const ligne = { quantite: 1, prix_unitaire_ht: 1 };
+    expect(() => simulateTotauxSchema.parse({ body: { lignes: Array(200).fill(ligne) } })).not.toThrow();
+    expect(() => simulateTotauxSchema.parse({ body: { lignes: Array(201).fill(ligne) } })).toThrow();
+  });
+
+  it("résiste à 140 variantes valides / manquantes / limites / malformées sans crash", () => {
+    type Variant = { payload: unknown; valid: boolean };
+    const variants: Variant[] = [];
+
+    // 40 variantes valides (quantités/prix/remises/TVA aux limites)
+    for (let i = 0; i < 40; i += 1) {
+      variants.push({
+        valid: true,
+        payload: {
+          ...baseCreate,
+          origine: (["MANUEL", "SEUIL_STOCK", "RUPTURE_OF", "SOUS_TRAITANCE"] as const)[i % 4],
+          frais_port_ht: (i % 7) * 10.55,
+          tva_frais_pct: i % 2 ? 20 : 5.5,
+          lignes: [
+            {
+              ...baseLigne,
+              quantite: i === 0 ? 0.001 : (i % 13) + 0.5,
+              prix_unitaire_ht: (i * 997) % 10000 === 0 ? 0 : ((i * 997) % 10000) / 100,
+              remise_pct: i % 5 === 0 ? 100 : (i % 5) * 12.5,
+              tva_pct: i % 3 === 0 ? 0 : 20,
+              date_besoin: i % 2 ? "2026-08-15" : undefined,
+            },
+          ],
+        },
+      });
+    }
+
+    // 100 variantes invalides : champ par champ, hors bornes, mal typé, inconnu, malformé
+    const invalidLignePatches: Array<Record<string, unknown>> = [
+      { quantite: 0 },
+      { quantite: -5 },
+      { quantite: "douze" },
+      { quantite: Number.NaN },
+      { quantite: Infinity },
+      { quantite: 10_000_000_000 },
+      { prix_unitaire_ht: -1 },
+      { prix_unitaire_ht: "gratuit" },
+      { remise_pct: 101 },
+      { remise_pct: -0.01 },
+      { tva_pct: 250 },
+      { frais_ht: -3 },
+      { designation: "" },
+      { designation: "x".repeat(201) },
+      { type: "CADEAU" },
+      { article_id: "pas-un-uuid" },
+      { catalogue_id: 42 },
+      { date_besoin: "2026-13-45" },
+      { date_besoin: "hier" },
+      { delai_jours: -1 },
+      { delai_jours: 3.7 },
+      { of_id: "OF-12" },
+      { affaire_id: -8 },
+      { exigences_qualite: [{ type: "INCONNU" }] },
+      { documents_attendus: [""] },
+      { champ_pirate: true },
+      { besoins: [{ besoin_type: "MANUEL", besoin_ref: "", quantite_couverte: 1 }] },
+      { besoins: [{ besoin_type: "STOCK_LEVEL", besoin_ref: UUID, quantite_couverte: 0 }] },
+      { unite: "x".repeat(21) },
+      { coef_conversion: 0 },
+    ];
+    for (const patch of invalidLignePatches) {
+      variants.push({ valid: false, payload: { ...baseCreate, lignes: [{ ...baseLigne, ...patch }] } });
+    }
+    const invalidHeaderPatches: Array<Record<string, unknown>> = [
+      { fournisseur_id: "42" },
+      { fournisseur_id: null },
+      { devise: "EURO" },
+      { devise: "" },
+      { incoterm: "XXX" },
+      { origine: "IMPORT_CLIPPER" },
+      { frais_port_ht: -10 },
+      { tva_frais_pct: 120 },
+      { commentaire_public: "x".repeat(4001) },
+      { idempotency_key: "abc" },
+      { lignes: "aucune" },
+      { lignes: Array(201).fill(baseLigne) },
+      { date_besoin: "2026/07/21" },
+      { note_interne: 12345 },
+      { contact_id: "contact-1" },
+      { magasin_livraison_id: "MAG1" },
+      { adresse_livraison_texte: "x".repeat(4001) },
+      { mode_transport: "x".repeat(121) },
+      { conditions_paiement: "x".repeat(201) },
+      { code: "BCF-2026-0001" },
+    ];
+    for (const patch of invalidHeaderPatches) {
+      variants.push({ valid: false, payload: { ...baseCreate, ...patch } });
+    }
+    // 50 payloads structurellement malformés
+    const malformed: unknown[] = [
+      null,
+      undefined,
+      [],
+      "BCF",
+      42,
+      true,
+      { lignes: [baseLigne] }, // fournisseur manquant
+      {},
+      { fournisseur_id: UUID, lignes: [null] },
+      { fournisseur_id: UUID, lignes: [[]] },
+    ];
+    for (let i = 0; i < 50; i += 1) {
+      variants.push({ valid: false, payload: malformed[i % malformed.length] });
+    }
+
+    expect(variants.length).toBeGreaterThanOrEqual(140);
+    let validCount = 0;
+    let invalidCount = 0;
+    for (const variant of variants) {
+      const result = createCommandeSchema.safeParse({ body: variant.payload });
+      if (variant.valid) {
+        expect(result.success, `attendu valide: ${JSON.stringify(variant.payload).slice(0, 120)}`).toBe(true);
+        validCount += 1;
+      } else {
+        expect(result.success, `attendu rejeté: ${JSON.stringify(variant.payload)?.slice(0, 120)}`).toBe(false);
+        invalidCount += 1;
+      }
+    }
+    expect(validCount).toBe(40);
+    expect(invalidCount).toBeGreaterThanOrEqual(100);
+  });
+});

--- a/src/module/commande-fournisseur/controllers/commande-fournisseur.controller.ts
+++ b/src/module/commande-fournisseur/controllers/commande-fournisseur.controller.ts
@@ -1,0 +1,286 @@
+import type { Request, RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import { roleHasCommandeFournisseurCapability } from "../domain/commande-fournisseur-rbac";
+import type { AuditContext } from "../repository/commande-fournisseur.repository";
+import {
+  accuseSchema,
+  addLigneSchema,
+  commandeIdParamSchema,
+  createCommandeSchema,
+  deleteLigneSchema,
+  documentIdParamSchema,
+  duplicateSchema,
+  generateDocumentSchema,
+  ligneIdParamSchema,
+  listCommandesQuerySchema,
+  propositionsConfirmSchema,
+  propositionsPreviewSchema,
+  reorderLignesSchema,
+  simulateTotauxSchema,
+  transitionSchema,
+  updateCommandeSchema,
+  updateLigneSchema,
+} from "../validators/commande-fournisseur.validators";
+import {
+  accuseReceptionSVC,
+  addLigneSVC,
+  confirmPropositionsSVC,
+  createCommandeFournisseurSVC,
+  deleteLigneSVC,
+  duplicateAsDraftSVC,
+  generateDocumentSVC,
+  getCommandeFournisseurKpisSVC,
+  getCommandeFournisseurSVC,
+  getDocumentSVC,
+  listCommandesFournisseursSVC,
+  previewPropositionsSVC,
+  reorderLignesSVC,
+  resyncReceptionsSVC,
+  simulateTotauxSVC,
+  transitionCommandeFournisseurSVC,
+  updateCommandeFournisseurSVC,
+  updateLigneSVC,
+} from "../services/commande-fournisseur.service";
+
+function buildAuditContext(req: Request): AuditContext {
+  const user = req.user;
+  if (!user) throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
+
+  const forwardedFor = req.headers["x-forwarded-for"];
+  const ipFromHeader = typeof forwardedFor === "string" ? forwardedFor.split(",")[0]?.trim() : null;
+  const ua = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null;
+  const pageKey = typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null;
+  const clientSessionId =
+    typeof req.headers["x-client-session-id"] === "string"
+      ? req.headers["x-client-session-id"]
+      : typeof req.headers["x-session-id"] === "string"
+        ? req.headers["x-session-id"]
+        : null;
+
+  return {
+    user_id: user.id,
+    role: user.role ?? null,
+    ip: ipFromHeader ?? req.ip ?? null,
+    user_agent: ua,
+    device_type: null,
+    os: null,
+    browser: null,
+    path: req.originalUrl ?? null,
+    page_key: pageKey,
+    client_session_id: clientSessionId,
+  };
+}
+
+function includePricesFor(req: Request): boolean {
+  return roleHasCommandeFournisseurCapability(req.user?.role, "prices");
+}
+
+/** Clé d'idempotence : header standard prioritaire, sinon champ body. */
+function idempotencyKeyFrom(req: Request, bodyKey?: string): string | undefined {
+  const header = req.headers["idempotency-key"];
+  if (typeof header === "string" && header.trim().length >= 8) return header.trim().slice(0, 120);
+  return bodyKey;
+}
+
+export const listCommandesFournisseurs: RequestHandler = async (req, res, next) => {
+  try {
+    const { query } = listCommandesQuerySchema.parse({ query: req.query });
+    const out = await listCommandesFournisseursSVC(query, includePricesFor(req));
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getCommandeFournisseurKpis: RequestHandler = async (_req, res, next) => {
+  try {
+    res.json(await getCommandeFournisseurKpisSVC());
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getCommandeFournisseur: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = commandeIdParamSchema.parse({ params: req.params });
+    const out = await getCommandeFournisseurSVC(params.id, includePricesFor(req));
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const createCommandeFournisseur: RequestHandler = async (req, res, next) => {
+  try {
+    const { body } = createCommandeSchema.parse({ body: req.body });
+    const audit = buildAuditContext(req);
+    const out = await createCommandeFournisseurSVC(
+      { ...body, idempotency_key: idempotencyKeyFrom(req, body.idempotency_key) },
+      audit
+    );
+    res.status(out.idempotent_replay ? 200 : 201).json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const updateCommandeFournisseur: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = commandeIdParamSchema.parse({ params: req.params });
+    const { body } = updateCommandeSchema.parse({ body: req.body });
+    const audit = buildAuditContext(req);
+    await updateCommandeFournisseurSVC(params.id, body, audit);
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const addLigne: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = commandeIdParamSchema.parse({ params: req.params });
+    const { body } = addLigneSchema.parse({ body: req.body });
+    const audit = buildAuditContext(req);
+    res.status(201).json(await addLigneSVC(params.id, body, audit));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const updateLigne: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = ligneIdParamSchema.parse({ params: req.params });
+    const { body } = updateLigneSchema.parse({ body: req.body });
+    const audit = buildAuditContext(req);
+    await updateLigneSVC(params.id, params.ligneId, body, audit);
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const deleteLigne: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = ligneIdParamSchema.parse({ params: req.params });
+    const parsed = deleteLigneSchema.parse({ body: req.body ?? {} });
+    const audit = buildAuditContext(req);
+    await deleteLigneSVC(params.id, params.ligneId, parsed.body?.expected_updated_at, audit);
+    res.status(204).send();
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const reorderLignes: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = commandeIdParamSchema.parse({ params: req.params });
+    const { body } = reorderLignesSchema.parse({ body: req.body });
+    const audit = buildAuditContext(req);
+    res.json(await reorderLignesSVC(params.id, body, audit));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const transitionCommandeFournisseur: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = commandeIdParamSchema.parse({ params: req.params });
+    const { body } = transitionSchema.parse({ body: req.body });
+    const audit = buildAuditContext(req);
+    res.json(
+      await transitionCommandeFournisseurSVC(
+        params.id,
+        { ...body, idempotency_key: idempotencyKeyFrom(req, body.idempotency_key) },
+        audit
+      )
+    );
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const accuseReception: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = commandeIdParamSchema.parse({ params: req.params });
+    const { body } = accuseSchema.parse({ body: req.body });
+    const audit = buildAuditContext(req);
+    res.json(await accuseReceptionSVC(params.id, body, audit));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const generateDocument: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = commandeIdParamSchema.parse({ params: req.params });
+    const parsed = generateDocumentSchema.parse({ body: req.body ?? {} });
+    const audit = buildAuditContext(req);
+    res
+      .status(201)
+      .json(await generateDocumentSVC(params.id, parsed.body?.motif_revision, parsed.body?.expected_updated_at, audit));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getDocument: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = documentIdParamSchema.parse({ params: req.params });
+    res.json(await getDocumentSVC(params.id, params.documentId));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const simulateTotaux: RequestHandler = async (req, res, next) => {
+  try {
+    const { body } = simulateTotauxSchema.parse({ body: req.body });
+    res.json(simulateTotauxSVC(body));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const previewPropositions: RequestHandler = async (req, res, next) => {
+  try {
+    const { body } = propositionsPreviewSchema.parse({ body: req.body });
+    res.json(await previewPropositionsSVC(body));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const confirmPropositions: RequestHandler = async (req, res, next) => {
+  try {
+    const { body } = propositionsConfirmSchema.parse({ body: req.body });
+    const audit = buildAuditContext(req);
+    const key = idempotencyKeyFrom(req, body.idempotency_key);
+    if (!key) throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "Une clé d'idempotence est requise.");
+    res.status(201).json(await confirmPropositionsSVC({ ...body, idempotency_key: key }, audit));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const resyncReceptions: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = commandeIdParamSchema.parse({ params: req.params });
+    const audit = buildAuditContext(req);
+    const allowOver = roleHasCommandeFournisseurCapability(req.user?.role, "over_receipt");
+    res.json(await resyncReceptionsSVC(params.id, audit, allowOver));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const duplicateCommandeFournisseur: RequestHandler = async (req, res, next) => {
+  try {
+    const { params } = commandeIdParamSchema.parse({ params: req.params });
+    const parsed = duplicateSchema.parse({ body: req.body ?? {} });
+    const audit = buildAuditContext(req);
+    res.status(201).json(await duplicateAsDraftSVC(params.id, parsed.body?.note, audit));
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/module/commande-fournisseur/domain/commande-fournisseur-rbac.ts
+++ b/src/module/commande-fournisseur/domain/commande-fournisseur-rbac.ts
@@ -1,0 +1,92 @@
+import type { CommandeFournisseurTransitionKind } from "./commande-fournisseur-transitions";
+
+/**
+ * Capacités RBAC distinctes des commandes fournisseurs (#172) — refus par défaut.
+ * Chaque capacité correspond à un ensemble de rôles (recherche par sous-chaîne, cohérente
+ * avec le modèle de rôles existant — aucun rôle inventé : Directeur, Administrateur Systeme
+ * et Reseau, Secretaire, Responsable Programmation, Responsable Qualité, Employee…).
+ * L'autorisation est vérifiée côté serveur, indépendamment de la visibilité des boutons.
+ *
+ * `prices` protège les prix/totaux d'achat (donnée commercialement sensible) ;
+ * `over_receipt` protège la sur-réception ; `close` couvre la clôture avec reliquat.
+ */
+export type CommandeFournisseurCapability =
+  | "read"
+  | "create"
+  | "update_draft"
+  | "submit"
+  | "approve"
+  | "send"
+  | "acknowledge"
+  | "cancel"
+  | "close"
+  | "export"
+  | "prices"
+  | "over_receipt";
+
+const CAPABILITY_ROLE_NEEDLES: Record<CommandeFournisseurCapability, readonly string[]> = {
+  // Lecture : métiers concernés par les achats (refus si aucun rôle connu — Employee ne lit pas).
+  read: [
+    "admin",
+    "administrateur",
+    "directeur",
+    "secr",
+    "secret",
+    "achat",
+    "logistique",
+    "magasin",
+    "compt",
+    "qualit",
+    "program",
+    "planif",
+    "commercial",
+  ],
+  create: ["admin", "administrateur", "directeur", "secr", "secret", "achat", "program", "logistique"],
+  update_draft: ["admin", "administrateur", "directeur", "secr", "secret", "achat", "program", "logistique"],
+  submit: ["admin", "administrateur", "directeur", "secr", "secret", "achat", "program", "logistique"],
+  // Approbation = engagement de dépense : périmètre resserré.
+  approve: ["admin", "administrateur", "directeur"],
+  send: ["admin", "administrateur", "directeur", "secr", "secret", "achat"],
+  acknowledge: ["admin", "administrateur", "directeur", "secr", "secret", "achat", "logistique"],
+  cancel: ["admin", "administrateur", "directeur"],
+  close: ["admin", "administrateur", "directeur", "achat"],
+  export: ["admin", "administrateur", "directeur", "secr", "secret", "achat", "compt"],
+  prices: ["admin", "administrateur", "directeur", "secr", "secret", "achat", "compt", "program"],
+  over_receipt: ["admin", "administrateur", "directeur", "qualit"],
+};
+
+export function roleHasCommandeFournisseurCapability(
+  role: string | null | undefined,
+  capability: CommandeFournisseurCapability
+): boolean {
+  if (!role) return false;
+  const normalized = role.trim().toLowerCase();
+  if (!normalized) return false;
+  return CAPABILITY_ROLE_NEEDLES[capability].some((needle) => normalized.includes(needle));
+}
+
+/** Capacité fine requise pour une transition, selon sa nature. */
+export function capabilityForTransition(
+  kind: CommandeFournisseurTransitionKind
+): CommandeFournisseurCapability {
+  switch (kind) {
+    case "submit":
+      return "submit";
+    case "approve":
+    case "reject":
+      return "approve";
+    case "reopen_draft":
+      return "update_draft";
+    case "send":
+      return "send";
+    case "acknowledge":
+      return "acknowledge";
+    case "close":
+      return "close";
+    case "cancel":
+      return "cancel";
+    default:
+      // receive_partial / receive_full : dérivées des réceptions, jamais manuelles.
+      return "cancel";
+  }
+}

--- a/src/module/commande-fournisseur/domain/commande-fournisseur-totaux.ts
+++ b/src/module/commande-fournisseur/domain/commande-fournisseur-totaux.ts
@@ -1,0 +1,101 @@
+/**
+ * Calcul serveur des totaux d'une commande fournisseur (#172).
+ *
+ * Règles d'arrondi (documentées + testées) :
+ *  - tout calcul passe par des centimes entiers (pas d'accumulation flottante) ;
+ *  - arrondi « half away from zero » (comme round() PostgreSQL), au niveau de CHAQUE
+ *    agrégat de ligne (net HT, remise, TVA), puis sommation exacte des centimes ;
+ *  - les frais de port s'ajoutent au total HT et portent leur propre taux de TVA.
+ *
+ * Le frontend n'est jamais autoritaire : il affiche ces montants, il ne les recalcule pas
+ * pour décider.
+ */
+
+export type LigneTotauxInput = {
+  quantite: number;
+  prix_unitaire_ht: number;
+  remise_pct: number;
+  tva_pct: number;
+  frais_ht: number;
+  statut_ligne?: "ACTIVE" | "ANNULEE";
+};
+
+export type LigneTotaux = {
+  brut_ht: number;
+  remise_montant: number;
+  net_ht: number;
+  tva_montant: number;
+  ttc: number;
+};
+
+export type CommandeTotaux = {
+  total_ht: number;
+  total_remise: number;
+  total_tva: number;
+  total_ttc: number;
+  frais_port_ht: number;
+};
+
+/**
+ * Arrondi « half away from zero » à 2 décimales. Le passage par `toFixed(6)` neutralise le
+ * bruit binaire IEEE 754 (ex. 2.675*100 = 267.49999999999997) bien en dessous du 1e-6,
+ * puis l'arrondi entier s'applique sur des centimes exacts.
+ */
+export function roundMoney(value: number): number {
+  const sign = value < 0 ? -1 : 1;
+  const cents = Math.round(Number((Math.abs(value) * 100).toFixed(6)));
+  return (sign * cents) / 100;
+}
+
+function toCents(value: number): number {
+  const sign = value < 0 ? -1 : 1;
+  return sign * Math.round(Number((Math.abs(value) * 100).toFixed(6)));
+}
+
+export function computeLigneTotaux(ligne: LigneTotauxInput): LigneTotaux {
+  const brut = ligne.quantite * ligne.prix_unitaire_ht;
+  const remise = brut * (ligne.remise_pct / 100);
+  const brutR = roundMoney(brut);
+  const remiseR = roundMoney(remise);
+  const netR = roundMoney(brutR - remiseR + ligne.frais_ht);
+  const tvaR = roundMoney(netR * (ligne.tva_pct / 100));
+  return {
+    brut_ht: brutR,
+    remise_montant: remiseR,
+    net_ht: netR,
+    tva_montant: tvaR,
+    ttc: roundMoney(netR + tvaR),
+  };
+}
+
+export function computeCommandeTotaux(
+  lignes: readonly LigneTotauxInput[],
+  options: { frais_port_ht: number; tva_frais_pct: number }
+): CommandeTotaux {
+  let htCents = 0;
+  let remiseCents = 0;
+  let tvaCents = 0;
+
+  for (const ligne of lignes) {
+    if (ligne.statut_ligne === "ANNULEE") continue;
+    const t = computeLigneTotaux(ligne);
+    htCents += toCents(t.net_ht);
+    remiseCents += toCents(t.remise_montant);
+    tvaCents += toCents(t.tva_montant);
+  }
+
+  const fraisPort = roundMoney(options.frais_port_ht);
+  const tvaFrais = roundMoney(fraisPort * (options.tva_frais_pct / 100));
+  htCents += toCents(fraisPort);
+  tvaCents += toCents(tvaFrais);
+
+  const total_ht = htCents / 100;
+  const total_tva = tvaCents / 100;
+  return {
+    total_ht,
+    total_remise: remiseCents / 100,
+    total_tva,
+    total_ttc: (htCents + tvaCents) / 100,
+    frais_port_ht: fraisPort,
+  };
+}

--- a/src/module/commande-fournisseur/domain/commande-fournisseur-transitions.ts
+++ b/src/module/commande-fournisseur/domain/commande-fournisseur-transitions.ts
@@ -1,0 +1,104 @@
+/**
+ * Machine d'état serveur des commandes fournisseurs (#172).
+ *
+ * Le statut n'est jamais posé librement via un PATCH générique : toute évolution passe par
+ * une transition explicite validée ici (pattern affaire #169). `ANNULEE` et `CLOTUREE` sont
+ * terminaux. Les états de réception (`PARTIELLEMENT_RECUE`, `RECUE`) sont DÉRIVÉS des
+ * réceptions réelles saisies par un humain dans le module réceptions : ils ne s'atteignent
+ * jamais par une transition manuelle arbitraire (voir `isReceptionDerivedStatus`).
+ * Aucune suppression physique : l'annulation/clôture conserve la ligne et la traçabilité.
+ */
+
+export const COMMANDE_FOURNISSEUR_STATUTS = [
+  "BROUILLON",
+  "A_VALIDER",
+  "APPROUVEE",
+  "ENVOYEE",
+  "ACCUSE_RECU",
+  "PARTIELLEMENT_RECUE",
+  "RECUE",
+  "CLOTUREE",
+  "ANNULEE",
+] as const;
+
+export type CommandeFournisseurStatut = (typeof COMMANDE_FOURNISSEUR_STATUTS)[number];
+
+export const COMMANDE_FOURNISSEUR_TRANSITIONS: Record<
+  CommandeFournisseurStatut,
+  readonly CommandeFournisseurStatut[]
+> = {
+  BROUILLON: ["A_VALIDER", "ANNULEE"],
+  A_VALIDER: ["APPROUVEE", "BROUILLON", "ANNULEE"],
+  APPROUVEE: ["ENVOYEE", "BROUILLON", "ANNULEE"],
+  ENVOYEE: ["ACCUSE_RECU", "PARTIELLEMENT_RECUE", "RECUE", "ANNULEE"],
+  ACCUSE_RECU: ["PARTIELLEMENT_RECUE", "RECUE", "ANNULEE"],
+  PARTIELLEMENT_RECUE: ["RECUE", "CLOTUREE"],
+  RECUE: ["CLOTUREE"],
+  CLOTUREE: [], // terminal
+  ANNULEE: [], // terminal
+};
+
+export const COMMANDE_FOURNISSEUR_TERMINAL_STATUTS: readonly CommandeFournisseurStatut[] = [
+  "CLOTUREE",
+  "ANNULEE",
+];
+
+export function isTerminalStatut(statut: CommandeFournisseurStatut): boolean {
+  return COMMANDE_FOURNISSEUR_TERMINAL_STATUTS.includes(statut);
+}
+
+export function isAllowedTransition(
+  from: CommandeFournisseurStatut,
+  to: CommandeFournisseurStatut
+): boolean {
+  if (from === to) return false;
+  return (COMMANDE_FOURNISSEUR_TRANSITIONS[from] ?? []).includes(to);
+}
+
+export function allowedTargetsFrom(
+  from: CommandeFournisseurStatut
+): readonly CommandeFournisseurStatut[] {
+  return COMMANDE_FOURNISSEUR_TRANSITIONS[from] ?? [];
+}
+
+/** Les états de réception sont dérivés des réceptions liées, jamais choisis à la main. */
+export function isReceptionDerivedStatut(statut: CommandeFournisseurStatut): boolean {
+  return statut === "PARTIELLEMENT_RECUE" || statut === "RECUE";
+}
+
+/**
+ * Nature métier d'une transition — route vers la capacité RBAC distincte et enrichit l'audit.
+ * `receive_partial`/`receive_full` ne sont émises que par l'imputation de réception (système).
+ */
+export type CommandeFournisseurTransitionKind =
+  | "submit"
+  | "reject"
+  | "reopen_draft"
+  | "approve"
+  | "send"
+  | "acknowledge"
+  | "receive_partial"
+  | "receive_full"
+  | "close"
+  | "cancel";
+
+export function classifyTransition(
+  from: CommandeFournisseurStatut,
+  to: CommandeFournisseurStatut
+): CommandeFournisseurTransitionKind {
+  if (to === "ANNULEE") return "cancel";
+  if (to === "CLOTUREE") return "close";
+  if (to === "A_VALIDER") return "submit";
+  if (to === "APPROUVEE") return "approve";
+  if (to === "ENVOYEE") return "send";
+  if (to === "ACCUSE_RECU") return "acknowledge";
+  if (to === "PARTIELLEMENT_RECUE") return "receive_partial";
+  if (to === "RECUE") return "receive_full";
+  if (to === "BROUILLON" && from === "A_VALIDER") return "reject";
+  return "reopen_draft"; // APPROUVEE -> BROUILLON (réédition motivée avant envoi)
+}
+
+/** Transitions dont le motif est obligatoire (auditabilité). */
+export function transitionRequiresMotif(kind: CommandeFournisseurTransitionKind): boolean {
+  return kind === "cancel" || kind === "reject" || kind === "reopen_draft" || kind === "close";
+}

--- a/src/module/commande-fournisseur/repository/commande-fournisseur.repository.ts
+++ b/src/module/commande-fournisseur/repository/commande-fournisseur.repository.ts
@@ -1,0 +1,2057 @@
+import type { PoolClient } from "pg";
+import crypto from "node:crypto";
+
+import db from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { generateCommandeFournisseurCode } from "../../../shared/codes/code-generator.service";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
+import {
+  allowedTargetsFrom,
+  classifyTransition,
+  isAllowedTransition,
+  isReceptionDerivedStatut,
+  transitionRequiresMotif,
+  type CommandeFournisseurStatut,
+} from "../domain/commande-fournisseur-transitions";
+import {
+  capabilityForTransition,
+  roleHasCommandeFournisseurCapability,
+} from "../domain/commande-fournisseur-rbac";
+import { computeCommandeTotaux, computeLigneTotaux, roundMoney } from "../domain/commande-fournisseur-totaux";
+import type {
+  AccuseBodyDTO,
+  AddLigneBodyDTO,
+  CreateCommandeBodyDTO,
+  PropositionsConfirmBodyDTO,
+  PropositionsPreviewBodyDTO,
+  ReorderLignesBodyDTO,
+  TransitionBodyDTO,
+  UpdateCommandeBodyDTO,
+  UpdateLigneBodyDTO,
+} from "../validators/commande-fournisseur.validators";
+import type {
+  CommandeFournisseur,
+  CommandeFournisseurDocumentMeta,
+  CommandeFournisseurKpis,
+  CommandeFournisseurLigne,
+  CommandeFournisseurListItem,
+  CommandeFournisseurReceptionLiee,
+  FournisseurMini,
+  Paginated,
+  PropositionGroupe,
+  PropositionLigne,
+  PropositionsPreview,
+} from "../types/commande-fournisseur.types";
+
+export type AuditContext = {
+  user_id: number;
+  role?: string | null;
+  ip: string | null;
+  user_agent: string | null;
+  device_type: string | null;
+  os: string | null;
+  browser: string | null;
+  path: string | null;
+  page_key: string | null;
+  client_session_id: string | null;
+};
+
+type DbQueryer = Pick<PoolClient, "query">;
+
+/* ------------------------------- shared helpers ------------------------------ */
+
+function num(value: unknown): number {
+  if (typeof value === "number") return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+  }
+  return 0;
+}
+
+function numOrNull(value: unknown): number | null {
+  if (value == null) return null;
+  const n = num(value);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Sérialisation JSON stable (clés triées récursivement) pour une empreinte reproductible. */
+export function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+    .map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`);
+  return `{${entries.join(",")}}`;
+}
+
+export function sha256Hex(payload: string): string {
+  return crypto.createHash("sha256").update(payload, "utf8").digest("hex");
+}
+
+async function insertAuditLog(
+  tx: DbQueryer,
+  audit: AuditContext,
+  entry: {
+    action: string;
+    entity_type: string | null;
+    entity_id: string | null;
+    details?: Record<string, unknown> | null;
+  }
+) {
+  const body: CreateAuditLogBodyDTO = {
+    event_type: "ACTION",
+    action: entry.action,
+    page_key: audit.page_key,
+    entity_type: entry.entity_type,
+    entity_id: entry.entity_id,
+    path: audit.path,
+    client_session_id: audit.client_session_id,
+    details: entry.details ?? null,
+  };
+  await repoInsertAuditLog({
+    user_id: audit.user_id,
+    body,
+    ip: audit.ip,
+    user_agent: audit.user_agent,
+    device_type: audit.device_type,
+    os: audit.os,
+    browser: audit.browser,
+    tx,
+  });
+}
+
+async function insertTransitionRow(
+  tx: DbQueryer,
+  commandeId: string,
+  from: CommandeFournisseurStatut | null,
+  to: CommandeFournisseurStatut,
+  motif: string | null,
+  acteurId: number | null
+) {
+  await tx.query(
+    `INSERT INTO public.commande_fournisseur_transition (commande_id, from_statut, to_statut, motif, acteur_id)
+     VALUES ($1::uuid, $2, $3, $4, $5)`,
+    [commandeId, from, to, motif, acteurId]
+  );
+}
+
+function isPgUniqueViolation(err: unknown): boolean {
+  return (err as { code?: unknown } | null)?.code === "23505";
+}
+
+/** Jeton de concurrence optimiste : représentation ::text exacte (pattern affaire #169). */
+function assertOptimisticToken(expected: string | undefined, current: string | null) {
+  if (expected && current && expected !== current) {
+    throw new HttpError(
+      409,
+      "CONCURRENT_MODIFICATION",
+      "La commande a été modifiée entre-temps. Rechargez la fiche avant de réessayer."
+    );
+  }
+}
+
+type HeaderLockRow = {
+  id: string;
+  code: string;
+  statut: CommandeFournisseurStatut;
+  fournisseur_id: string;
+  devise: string;
+  version_document: number;
+  frais_port_ht: string;
+  tva_frais_pct: string;
+  updated_at_token: string;
+};
+
+async function lockHeader(tx: DbQueryer, id: string): Promise<HeaderLockRow> {
+  const res = await tx.query<HeaderLockRow>(
+    `SELECT id, code, statut, fournisseur_id, devise, version_document,
+            frais_port_ht::text, tva_frais_pct::text, updated_at::text AS updated_at_token
+       FROM public.commande_fournisseur
+      WHERE id = $1::uuid
+      FOR UPDATE`,
+    [id]
+  );
+  const row = res.rows[0];
+  if (!row) throw new HttpError(404, "COMMANDE_FOURNISSEUR_NOT_FOUND", "Commande fournisseur introuvable.");
+  return row;
+}
+
+/** Recalcule et persiste les totaux serveur à partir des lignes ACTIVE (source unique). */
+async function recomputeTotauxTx(tx: DbQueryer, commandeId: string): Promise<void> {
+  const lignes = await tx.query<{
+    quantite: string;
+    prix_unitaire_ht: string;
+    remise_pct: string;
+    tva_pct: string;
+    frais_ht: string;
+    statut_ligne: "ACTIVE" | "ANNULEE";
+  }>(
+    `SELECT quantite::text, prix_unitaire_ht::text, remise_pct::text, tva_pct::text, frais_ht::text, statut_ligne
+       FROM public.commande_fournisseur_ligne WHERE commande_id = $1::uuid`,
+    [commandeId]
+  );
+  const header = await tx.query<{ frais_port_ht: string; tva_frais_pct: string }>(
+    `SELECT frais_port_ht::text, tva_frais_pct::text FROM public.commande_fournisseur WHERE id = $1::uuid`,
+    [commandeId]
+  );
+  const h = header.rows[0];
+  const totaux = computeCommandeTotaux(
+    lignes.rows.map((l) => ({
+      quantite: num(l.quantite),
+      prix_unitaire_ht: num(l.prix_unitaire_ht),
+      remise_pct: num(l.remise_pct),
+      tva_pct: num(l.tva_pct),
+      frais_ht: num(l.frais_ht),
+      statut_ligne: l.statut_ligne,
+    })),
+    { frais_port_ht: num(h?.frais_port_ht), tva_frais_pct: num(h?.tva_frais_pct) }
+  );
+  await tx.query(
+    `UPDATE public.commande_fournisseur
+        SET total_ht = $2, total_remise = $3, total_tva = $4, total_ttc = $5
+      WHERE id = $1::uuid`,
+    [commandeId, totaux.total_ht, totaux.total_remise, totaux.total_tva, totaux.total_ttc]
+  );
+}
+
+/* --------------------------------- fournisseur -------------------------------- */
+
+type FournisseurRow = {
+  id: string;
+  code: string | null;
+  nom: string | null;
+  status: string | null;
+  actif: boolean | null;
+};
+
+async function fetchFournisseurMini(tx: DbQueryer, fournisseurId: string): Promise<FournisseurMini> {
+  const res = await tx.query<FournisseurRow>(
+    `SELECT id, COALESCE(code, code_fournisseur) AS code, COALESCE(nom, raison_sociale) AS nom, status, actif
+       FROM public.fournisseurs WHERE id = $1::uuid`,
+    [fournisseurId]
+  );
+  const row = res.rows[0];
+  if (!row) throw new HttpError(422, "FOURNISSEUR_INTROUVABLE", "Le fournisseur sélectionné n'existe pas.");
+  return { id: row.id, code: row.code, nom: row.nom, status: row.status, actif: row.actif };
+}
+
+function assertFournisseurCommandable(f: FournisseurMini) {
+  const inactive = f.actif === false || f.status === "archive" || f.status === "inactif";
+  if (inactive) {
+    throw new HttpError(
+      422,
+      "FOURNISSEUR_INACTIF",
+      "Ce fournisseur est inactif ou archivé : aucune commande ne peut lui être adressée."
+    );
+  }
+}
+
+/* ------------------------------------ list ----------------------------------- */
+
+export type ListCommandesParams = {
+  q?: string;
+  statut?: CommandeFournisseurStatut | CommandeFournisseurStatut[];
+  fournisseur_id?: string;
+  origine?: string;
+  en_retard?: "true" | "false";
+  date_from?: string;
+  date_to?: string;
+  page: number;
+  page_size: number;
+  sort: "created_at" | "date_besoin" | "date_promesse" | "code" | "total_ttc" | "updated_at";
+  dir: "asc" | "desc";
+};
+
+const SORT_COLUMNS: Record<ListCommandesParams["sort"], string> = {
+  created_at: "cf.created_at",
+  date_besoin: "cf.date_besoin",
+  date_promesse: "cf.date_promesse",
+  code: "cf.code",
+  total_ttc: "cf.total_ttc",
+  updated_at: "cf.updated_at",
+};
+
+const ACTIVE_STATUTS_FOR_LATE: readonly CommandeFournisseurStatut[] = [
+  "ENVOYEE",
+  "ACCUSE_RECU",
+  "PARTIELLEMENT_RECUE",
+];
+
+export async function repoListCommandesFournisseurs(
+  params: ListCommandesParams,
+  options: { includePrices: boolean }
+): Promise<Paginated<CommandeFournisseurListItem>> {
+  const values: unknown[] = [];
+  const push = (v: unknown) => {
+    values.push(v);
+    return `$${values.length}`;
+  };
+  const where: string[] = [];
+
+  if (params.q) {
+    const p = push(`%${params.q}%`);
+    where.push(
+      `(cf.code ILIKE ${p} OR cf.reference_fournisseur ILIKE ${p} OR f.nom ILIKE ${p} OR f.raison_sociale ILIKE ${p}
+        OR EXISTS (SELECT 1 FROM public.commande_fournisseur_ligne lq
+                   WHERE lq.commande_id = cf.id
+                     AND (lq.designation ILIKE ${p} OR lq.reference_fournisseur ILIKE ${p})))`
+    );
+  }
+  const statuts = Array.isArray(params.statut) ? params.statut : params.statut ? [params.statut] : [];
+  if (statuts.length > 0) where.push(`cf.statut = ANY(${push(statuts)})`);
+  if (params.fournisseur_id) where.push(`cf.fournisseur_id = ${push(params.fournisseur_id)}::uuid`);
+  if (params.origine) where.push(`cf.origine = ${push(params.origine)}`);
+  if (params.date_from) where.push(`cf.created_at >= ${push(params.date_from)}::date`);
+  if (params.date_to) where.push(`cf.created_at < (${push(params.date_to)}::date + 1)`);
+  if (params.en_retard === "true") {
+    where.push(
+      `(cf.date_promesse IS NOT NULL AND cf.date_promesse < CURRENT_DATE AND cf.statut = ANY(${push(ACTIVE_STATUTS_FOR_LATE)}))`
+    );
+  }
+
+  const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+  const orderSql = `ORDER BY ${SORT_COLUMNS[params.sort]} ${params.dir === "asc" ? "ASC" : "DESC"} NULLS LAST, cf.id`;
+  const offset = (params.page - 1) * params.page_size;
+
+  const listSql = `
+    SELECT cf.id, cf.code, cf.statut, cf.origine, cf.devise,
+           cf.date_besoin::text, cf.date_promesse::text, cf.date_envoi::text,
+           cf.version_document, cf.created_at::text, cf.updated_at::text,
+           cf.total_ht::text, cf.total_ttc::text,
+           f.id AS f_id, COALESCE(f.code, f.code_fournisseur) AS f_code,
+           COALESCE(f.nom, f.raison_sociale) AS f_nom, f.status AS f_status, f.actif AS f_actif,
+           (cf.date_promesse IS NOT NULL AND cf.date_promesse < CURRENT_DATE
+             AND cf.statut IN ('ENVOYEE','ACCUSE_RECU','PARTIELLEMENT_RECUE')) AS en_retard,
+           lg.nb_lignes, lg.qty_commandee::text, COALESCE(rc.qty_recue, 0)::text AS qty_recue,
+           count(*) OVER() AS total_count
+      FROM public.commande_fournisseur cf
+      JOIN public.fournisseurs f ON f.id = cf.fournisseur_id
+      LEFT JOIN LATERAL (
+        SELECT count(*) FILTER (WHERE l.statut_ligne = 'ACTIVE') AS nb_lignes,
+               COALESCE(sum(l.quantite - l.qty_annulee) FILTER (WHERE l.statut_ligne = 'ACTIVE'), 0) AS qty_commandee
+          FROM public.commande_fournisseur_ligne l WHERE l.commande_id = cf.id
+      ) lg ON TRUE
+      LEFT JOIN LATERAL (
+        SELECT sum(rl.qty_received) AS qty_recue
+          FROM public.reception_fournisseur_lignes rl
+          JOIN public.commande_fournisseur_ligne l2 ON l2.id = rl.commande_fournisseur_ligne_id
+         WHERE l2.commande_id = cf.id
+      ) rc ON TRUE
+      ${whereSql}
+      ${orderSql}
+      LIMIT ${push(params.page_size)} OFFSET ${push(offset)}`;
+
+  const res = await db.query(listSql, values);
+  const total = res.rows.length > 0 ? Number(res.rows[0].total_count) : 0;
+
+  const items: CommandeFournisseurListItem[] = res.rows.map((r) => ({
+    id: r.id,
+    code: r.code,
+    statut: r.statut,
+    origine: r.origine,
+    fournisseur: { id: r.f_id, code: r.f_code, nom: r.f_nom, status: r.f_status, actif: r.f_actif },
+    devise: r.devise,
+    date_besoin: r.date_besoin,
+    date_promesse: r.date_promesse,
+    date_envoi: r.date_envoi,
+    en_retard: Boolean(r.en_retard),
+    nb_lignes: Number(r.nb_lignes ?? 0),
+    qty_commandee: num(r.qty_commandee),
+    qty_recue: num(r.qty_recue),
+    total_ht: options.includePrices ? numOrNull(r.total_ht) : null,
+    total_ttc: options.includePrices ? numOrNull(r.total_ttc) : null,
+    version_document: Number(r.version_document ?? 0),
+    created_at: r.created_at,
+    updated_at: r.updated_at,
+  }));
+
+  return { items, total, page: params.page, page_size: params.page_size };
+}
+
+export async function repoGetKpis(): Promise<CommandeFournisseurKpis> {
+  const res = await db.query<{
+    brouillons: string;
+    a_valider: string;
+    a_envoyer: string;
+    sans_accuse: string;
+    en_retard: string;
+    a_recevoir: string;
+  }>(
+    `SELECT
+       count(*) FILTER (WHERE statut = 'BROUILLON')  AS brouillons,
+       count(*) FILTER (WHERE statut = 'A_VALIDER')  AS a_valider,
+       count(*) FILTER (WHERE statut = 'APPROUVEE')  AS a_envoyer,
+       count(*) FILTER (WHERE statut = 'ENVOYEE')    AS sans_accuse,
+       count(*) FILTER (WHERE date_promesse IS NOT NULL AND date_promesse < CURRENT_DATE
+                          AND statut IN ('ENVOYEE','ACCUSE_RECU','PARTIELLEMENT_RECUE')) AS en_retard,
+       count(*) FILTER (WHERE statut IN ('ENVOYEE','ACCUSE_RECU','PARTIELLEMENT_RECUE')) AS a_recevoir
+     FROM public.commande_fournisseur`
+  );
+  const r = res.rows[0];
+  return {
+    brouillons: num(r?.brouillons),
+    a_valider: num(r?.a_valider),
+    a_envoyer: num(r?.a_envoyer),
+    sans_accuse: num(r?.sans_accuse),
+    en_retard: num(r?.en_retard),
+    a_recevoir: num(r?.a_recevoir),
+  };
+}
+
+/* ------------------------------------ get ------------------------------------ */
+
+async function fetchLignes(tx: DbQueryer, commandeId: string): Promise<CommandeFournisseurLigne[]> {
+  const res = await tx.query(
+    `SELECT l.*, l.quantite::text AS quantite_t, l.prix_unitaire_ht::text AS pu_t,
+            l.remise_pct::text AS remise_t, l.tva_pct::text AS tva_t, l.frais_ht::text AS frais_t,
+            l.coef_conversion::text AS coef_t, l.qty_confirmee::text AS qtyc_t, l.qty_annulee::text AS qtya_t,
+            l.date_besoin::text AS date_besoin_t, l.date_promesse::text AS date_promesse_t,
+            a.code AS article_code, a.designation AS article_designation,
+            COALESCE(rc.qty_recue, 0)::text AS qty_recue_t,
+            COALESCE(rc.qty_nc, 0)::text AS qty_nc_t
+       FROM public.commande_fournisseur_ligne l
+       LEFT JOIN public.articles a ON a.id = l.article_id
+       LEFT JOIN LATERAL (
+         SELECT sum(rl.qty_received) AS qty_recue,
+                sum(CASE WHEN lo.lot_status IN ('BLOQUE','QUARANTAINE') THEN rl.qty_received ELSE 0 END) AS qty_nc
+           FROM public.reception_fournisseur_lignes rl
+           LEFT JOIN public.lots lo ON lo.id = rl.lot_id
+          WHERE rl.commande_fournisseur_ligne_id = l.id
+       ) rc ON TRUE
+      WHERE l.commande_id = $1::uuid
+      ORDER BY l.position, l.created_at`,
+    [commandeId]
+  );
+
+  const ids = res.rows.map((r) => r.id);
+  const besoinsByLigne = new Map<string, CommandeFournisseurLigne["besoins"]>();
+  if (ids.length > 0) {
+    const besoins = await tx.query(
+      `SELECT id, ligne_id, besoin_type, besoin_ref, of_id, quantite_couverte::text AS q, annule
+         FROM public.commande_fournisseur_ligne_besoin WHERE ligne_id = ANY($1::uuid[]) ORDER BY created_at`,
+      [ids]
+    );
+    for (const b of besoins.rows) {
+      const list = besoinsByLigne.get(b.ligne_id) ?? [];
+      list.push({
+        id: b.id,
+        besoin_type: b.besoin_type,
+        besoin_ref: b.besoin_ref,
+        of_id: b.of_id == null ? null : Number(b.of_id),
+        quantite_couverte: num(b.q),
+        annule: Boolean(b.annule),
+      });
+      besoinsByLigne.set(b.ligne_id, list);
+    }
+  }
+
+  return res.rows.map((r) => {
+    const quantite = num(r.quantite_t);
+    const qtyAnnulee = num(r.qtya_t);
+    const qtyRecue = num(r.qty_recue_t);
+    const net = computeLigneTotaux({
+      quantite,
+      prix_unitaire_ht: num(r.pu_t),
+      remise_pct: num(r.remise_t),
+      tva_pct: num(r.tva_t),
+      frais_ht: num(r.frais_t),
+    }).net_ht;
+    return {
+      id: r.id,
+      commande_id: r.commande_id,
+      position: Number(r.position),
+      type: r.type,
+      article_id: r.article_id,
+      article_code: r.article_code ?? null,
+      article_designation: r.article_designation ?? null,
+      catalogue_id: r.catalogue_id,
+      reference_fournisseur: r.reference_fournisseur,
+      designation: r.designation,
+      designation_interne: r.designation_interne,
+      unite: r.unite,
+      unite_stock: r.unite_stock,
+      coef_conversion: numOrNull(r.coef_t),
+      quantite,
+      prix_unitaire_ht: num(r.pu_t),
+      remise_pct: num(r.remise_t),
+      tva_pct: num(r.tva_t),
+      frais_ht: num(r.frais_t),
+      net_ht: net,
+      date_besoin: r.date_besoin_t,
+      date_promesse: r.date_promesse_t,
+      delai_jours: r.delai_jours == null ? null : Number(r.delai_jours),
+      affaire_id: r.affaire_id == null ? null : Number(r.affaire_id),
+      commande_client_id: r.commande_client_id == null ? null : Number(r.commande_client_id),
+      of_id: r.of_id == null ? null : Number(r.of_id),
+      piece_technique_id: r.piece_technique_id,
+      operation_libelle: r.operation_libelle,
+      magasin_id: r.magasin_id,
+      exigences_qualite: Array.isArray(r.exigences_qualite) ? r.exigences_qualite : [],
+      documents_attendus: Array.isArray(r.documents_attendus) ? r.documents_attendus : [],
+      qty_confirmee: numOrNull(r.qtyc_t),
+      qty_recue: qtyRecue,
+      qty_recue_nc: num(r.qty_nc_t),
+      qty_annulee: qtyAnnulee,
+      qty_restante: Math.max(0, roundMoney(quantite - qtyAnnulee - qtyRecue)),
+      statut_ligne: r.statut_ligne,
+      motif_annulation: r.motif_annulation,
+      besoins: besoinsByLigne.get(r.id) ?? [],
+    };
+  });
+}
+
+async function fetchReceptionsLiees(tx: DbQueryer, commandeId: string): Promise<CommandeFournisseurReceptionLiee[]> {
+  const res = await tx.query(
+    `SELECT r.id AS reception_id, r.reception_no, r.status, r.reception_date::text,
+            rl.id AS reception_ligne_id, rl.commande_fournisseur_ligne_id, rl.article_id,
+            rl.qty_received::text AS qty_t, rl.lot_id, lo.lot_status AS lot_status
+       FROM public.receptions_fournisseurs r
+       JOIN public.reception_fournisseur_lignes rl ON rl.reception_id = r.id
+       LEFT JOIN public.lots lo ON lo.id = rl.lot_id
+      WHERE r.commande_fournisseur_id = $1::uuid
+         OR rl.commande_fournisseur_ligne_id IN (
+              SELECT id FROM public.commande_fournisseur_ligne WHERE commande_id = $1::uuid)
+      ORDER BY r.reception_date DESC, r.reception_no, rl.line_no`,
+    [commandeId]
+  );
+  const map = new Map<string, CommandeFournisseurReceptionLiee>();
+  for (const r of res.rows) {
+    let entry = map.get(r.reception_id);
+    if (!entry) {
+      entry = {
+        reception_id: r.reception_id,
+        reception_no: r.reception_no,
+        status: r.status,
+        reception_date: r.reception_date,
+        lignes: [],
+      };
+      map.set(r.reception_id, entry);
+    }
+    entry.lignes.push({
+      reception_ligne_id: r.reception_ligne_id,
+      commande_fournisseur_ligne_id: r.commande_fournisseur_ligne_id,
+      article_id: r.article_id,
+      qty_received: num(r.qty_t),
+      lot_id: r.lot_id,
+      lot_status: r.lot_status ?? null,
+    });
+  }
+  return Array.from(map.values());
+}
+
+export async function repoGetCommandeFournisseur(
+  id: string,
+  options: { includePrices: boolean }
+): Promise<CommandeFournisseur> {
+  const res = await db.query(
+    `SELECT cf.*, cf.created_at::text AS created_at_t, cf.updated_at::text AS updated_at_t,
+            cf.date_besoin::text AS date_besoin_t, cf.date_promesse::text AS date_promesse_t,
+            cf.date_envoi::text AS date_envoi_t, cf.date_accuse::text AS date_accuse_t,
+            cf.date_cloture::text AS date_cloture_t, cf.date_annulation::text AS date_annulation_t,
+            cf.total_ht::text AS total_ht_t, cf.total_remise::text AS total_remise_t,
+            cf.total_tva::text AS total_tva_t, cf.total_ttc::text AS total_ttc_t,
+            cf.frais_port_ht::text AS frais_port_t, cf.tva_frais_pct::text AS tva_frais_t,
+            f.id AS f_id, COALESCE(f.code, f.code_fournisseur) AS f_code,
+            COALESCE(f.nom, f.raison_sociale) AS f_nom, f.status AS f_status, f.actif AS f_actif
+       FROM public.commande_fournisseur cf
+       JOIN public.fournisseurs f ON f.id = cf.fournisseur_id
+      WHERE cf.id = $1::uuid`,
+    [id]
+  );
+  const r = res.rows[0];
+  if (!r) throw new HttpError(404, "COMMANDE_FOURNISSEUR_NOT_FOUND", "Commande fournisseur introuvable.");
+
+  const [lignes, receptions, transitions, documents] = await Promise.all([
+    fetchLignes(db, id),
+    fetchReceptionsLiees(db, id),
+    db.query(
+      `SELECT t.id, t.from_statut, t.to_statut, t.motif, t.acteur_id, t.created_at::text,
+              trim(concat(u.name, ' ', u.surname)) AS acteur_nom
+         FROM public.commande_fournisseur_transition t
+         LEFT JOIN public.users u ON u.id = t.acteur_id
+        WHERE t.commande_id = $1::uuid ORDER BY t.created_at DESC, t.id DESC`,
+      [id]
+    ),
+    db.query(
+      `SELECT id, version, titre, sha256, motif_revision, generated_by, created_at::text, sent_at::text
+         FROM public.commande_fournisseur_document WHERE commande_id = $1::uuid ORDER BY version DESC`,
+      [id]
+    ),
+  ]);
+
+  const includePrices = options.includePrices;
+  const maskedLignes = includePrices
+    ? lignes
+    : lignes.map((l) => ({ ...l, prix_unitaire_ht: null, remise_pct: null, frais_ht: null, net_ht: null }));
+
+  return {
+    id: r.id,
+    code: r.code,
+    statut: r.statut,
+    origine: r.origine,
+    fournisseur: { id: r.f_id, code: r.f_code, nom: r.f_nom, status: r.f_status, actif: r.f_actif },
+    contact_id: r.contact_id,
+    adresse_commande_id: r.adresse_commande_id,
+    magasin_livraison_id: r.magasin_livraison_id,
+    adresse_livraison_texte: r.adresse_livraison_texte,
+    adresse_facturation_texte: r.adresse_facturation_texte,
+    devise: r.devise,
+    conditions_paiement: r.conditions_paiement,
+    incoterm: r.incoterm,
+    mode_transport: r.mode_transport,
+    date_besoin: r.date_besoin_t,
+    date_promesse: r.date_promesse_t,
+    date_envoi: r.date_envoi_t,
+    date_accuse: r.date_accuse_t,
+    date_cloture: r.date_cloture_t,
+    date_annulation: r.date_annulation_t,
+    reference_fournisseur: r.reference_fournisseur,
+    commentaire_public: r.commentaire_public,
+    note_interne: r.note_interne,
+    motif_revision: r.motif_revision,
+    motif_annulation: r.motif_annulation,
+    motif_cloture: r.motif_cloture,
+    version_document: Number(r.version_document ?? 0),
+    fournisseur_snapshot: r.fournisseur_snapshot ?? null,
+    conditions_snapshot: r.conditions_snapshot ?? null,
+    total_ht: includePrices ? numOrNull(r.total_ht_t) : null,
+    total_remise: includePrices ? numOrNull(r.total_remise_t) : null,
+    total_tva: includePrices ? numOrNull(r.total_tva_t) : null,
+    frais_port_ht: includePrices ? numOrNull(r.frais_port_t) : null,
+    tva_frais_pct: includePrices ? numOrNull(r.tva_frais_t) : null,
+    total_ttc: includePrices ? numOrNull(r.total_ttc_t) : null,
+    prices_masked: !includePrices,
+    allowed_transitions: [...allowedTargetsFrom(r.statut as CommandeFournisseurStatut)],
+    lignes: maskedLignes,
+    transitions: transitions.rows.map((t) => ({
+      id: t.id,
+      from_statut: t.from_statut,
+      to_statut: t.to_statut,
+      motif: t.motif,
+      acteur_id: t.acteur_id == null ? null : Number(t.acteur_id),
+      acteur_nom: t.acteur_nom || null,
+      created_at: t.created_at,
+    })),
+    documents: documents.rows.map((d) => ({
+      id: d.id,
+      version: Number(d.version),
+      titre: d.titre,
+      sha256: d.sha256,
+      motif_revision: d.motif_revision,
+      generated_by: d.generated_by == null ? null : Number(d.generated_by),
+      created_at: d.created_at,
+      sent_at: d.sent_at,
+    })),
+    receptions,
+    created_at: r.created_at_t,
+    updated_at: r.updated_at_t,
+    created_by: r.created_by == null ? null : Number(r.created_by),
+    submitted_by: r.submitted_by == null ? null : Number(r.submitted_by),
+    approved_by: r.approved_by == null ? null : Number(r.approved_by),
+    sent_by: r.sent_by == null ? null : Number(r.sent_by),
+  };
+}
+
+/* ----------------------------------- create ----------------------------------- */
+
+async function insertLigneTx(
+  tx: DbQueryer,
+  commandeId: string,
+  position: number,
+  ligne: CreateCommandeBodyDTO["lignes"][number],
+  userId: number
+): Promise<string> {
+  const res = await tx.query<{ id: string }>(
+    `INSERT INTO public.commande_fournisseur_ligne (
+        commande_id, position, type, article_id, catalogue_id, reference_fournisseur,
+        designation, designation_interne, unite, unite_stock, coef_conversion,
+        quantite, prix_unitaire_ht, remise_pct, tva_pct, frais_ht,
+        date_besoin, date_promesse, delai_jours,
+        affaire_id, commande_client_id, of_id, piece_technique_id, operation_libelle, magasin_id,
+        exigences_qualite, documents_attendus, created_by, updated_by)
+     VALUES ($1::uuid,$2,$3,$4::uuid,$5::uuid,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,
+             $17::date,$18::date,$19,$20,$21,$22,$23::uuid,$24,$25::uuid,$26::jsonb,$27,$28,$28)
+     RETURNING id`,
+    [
+      commandeId,
+      position,
+      ligne.type,
+      ligne.article_id ?? null,
+      ligne.catalogue_id ?? null,
+      ligne.reference_fournisseur ?? null,
+      ligne.designation,
+      ligne.designation_interne ?? null,
+      ligne.unite ?? null,
+      ligne.unite_stock ?? null,
+      ligne.coef_conversion ?? null,
+      ligne.quantite,
+      ligne.prix_unitaire_ht,
+      ligne.remise_pct,
+      ligne.tva_pct,
+      ligne.frais_ht,
+      ligne.date_besoin ?? null,
+      ligne.date_promesse ?? null,
+      ligne.delai_jours ?? null,
+      ligne.affaire_id ?? null,
+      ligne.commande_client_id ?? null,
+      ligne.of_id ?? null,
+      ligne.piece_technique_id ?? null,
+      ligne.operation_libelle ?? null,
+      ligne.magasin_id ?? null,
+      JSON.stringify(ligne.exigences_qualite ?? []),
+      ligne.documents_attendus ?? [],
+      userId,
+    ]
+  );
+  const ligneId = res.rows[0].id;
+
+  for (const besoin of ligne.besoins ?? []) {
+    try {
+      await tx.query(
+        `INSERT INTO public.commande_fournisseur_ligne_besoin
+           (ligne_id, besoin_type, besoin_ref, besoin_of_id, of_id, quantite_couverte)
+         VALUES ($1::uuid,$2,$3,$4,$5,$6)`,
+        [ligneId, besoin.besoin_type, besoin.besoin_ref, besoin.of_id ?? 0, besoin.of_id ?? null, besoin.quantite_couverte]
+      );
+    } catch (err) {
+      if (isPgUniqueViolation(err)) {
+        throw new HttpError(
+          409,
+          "BESOIN_DEJA_COUVERT",
+          `Le besoin ${besoin.besoin_ref} est déjà couvert par une autre ligne de commande vivante.`
+        );
+      }
+      throw err;
+    }
+  }
+  return ligneId;
+}
+
+async function readIdempotentReplay(
+  tx: DbQueryer,
+  key: string,
+  action: "CREATE" | "GENERATE" | "SEND"
+): Promise<Record<string, unknown> | null> {
+  const res = await tx.query<{ action: string; resultat: Record<string, unknown> }>(
+    `SELECT action, resultat FROM public.commande_fournisseur_idempotence WHERE cle = $1`,
+    [key]
+  );
+  const row = res.rows[0];
+  if (!row) return null;
+  if (row.action !== action) {
+    throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Cette clé d'idempotence a déjà servi à une autre action.");
+  }
+  return { ...row.resultat, idempotent_replay: true };
+}
+
+async function recordIdempotence(
+  tx: DbQueryer,
+  key: string,
+  action: "CREATE" | "GENERATE" | "SEND",
+  commandeId: string | null,
+  resultat: Record<string, unknown>
+) {
+  await tx.query(
+    `INSERT INTO public.commande_fournisseur_idempotence (cle, action, commande_id, resultat)
+     VALUES ($1,$2,$3::uuid,$4::jsonb) ON CONFLICT (cle) DO NOTHING`,
+    [key, action, commandeId, JSON.stringify(resultat)]
+  );
+}
+
+export async function repoCreateCommandeFournisseur(
+  body: CreateCommandeBodyDTO,
+  audit: AuditContext
+): Promise<{ id: string; code: string; idempotent_replay: boolean }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+
+    if (body.idempotency_key) {
+      const replay = await readIdempotentReplay(client, body.idempotency_key, "CREATE");
+      if (replay) {
+        await client.query("COMMIT");
+        return replay as { id: string; code: string; idempotent_replay: boolean };
+      }
+    }
+
+    const fournisseur = await fetchFournisseurMini(client, body.fournisseur_id);
+    assertFournisseurCommandable(fournisseur);
+
+    const code = await generateCommandeFournisseurCode(client);
+    const inserted = await client.query<{ id: string }>(
+      `INSERT INTO public.commande_fournisseur (
+          code, origine, fournisseur_id, contact_id, adresse_commande_id, magasin_livraison_id,
+          adresse_livraison_texte, adresse_facturation_texte, devise, conditions_paiement, incoterm,
+          mode_transport, date_besoin, commentaire_public, note_interne, frais_port_ht, tva_frais_pct,
+          idempotency_key, created_by, updated_by)
+       VALUES ($1,$2,$3::uuid,$4::uuid,$5::uuid,$6::uuid,$7,$8,$9,$10,$11,$12,$13::date,$14,$15,$16,$17,$18,$19,$19)
+       RETURNING id`,
+      [
+        code,
+        body.origine,
+        body.fournisseur_id,
+        body.contact_id ?? null,
+        body.adresse_commande_id ?? null,
+        body.magasin_livraison_id ?? null,
+        body.adresse_livraison_texte ?? null,
+        body.adresse_facturation_texte ?? null,
+        body.devise,
+        body.conditions_paiement ?? null,
+        body.incoterm ?? null,
+        body.mode_transport ?? null,
+        body.date_besoin ?? null,
+        body.commentaire_public ?? null,
+        body.note_interne ?? null,
+        body.frais_port_ht,
+        body.tva_frais_pct,
+        body.idempotency_key ?? null,
+        audit.user_id,
+      ]
+    );
+    const id = inserted.rows[0].id;
+
+    let position = 1;
+    for (const ligne of body.lignes) {
+      await insertLigneTx(client, id, position, ligne, audit.user_id);
+      position += 1;
+    }
+
+    await recomputeTotauxTx(client, id);
+    await insertTransitionRow(client, id, null, "BROUILLON", null, audit.user_id);
+    await insertAuditLog(client, audit, {
+      action: "commandes_fournisseurs.create",
+      entity_type: "commande_fournisseur",
+      entity_id: id,
+      details: { code, origine: body.origine, fournisseur_id: body.fournisseur_id, nb_lignes: body.lignes.length },
+    });
+
+    const resultat = { id, code, idempotent_replay: false };
+    if (body.idempotency_key) {
+      await recordIdempotence(client, body.idempotency_key, "CREATE", id, { id, code });
+    }
+    await client.query("COMMIT");
+    return resultat;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    // Double-clic concurrent : la même clé a gagné dans une autre transaction -> rejouer.
+    if (body.idempotency_key && isPgUniqueViolation(err)) {
+      const replayRes = await db.query<{ id: string; code: string }>(
+        `SELECT id, code FROM public.commande_fournisseur WHERE idempotency_key = $1`,
+        [body.idempotency_key]
+      );
+      const row = replayRes.rows[0];
+      if (row) return { id: row.id, code: row.code, idempotent_replay: true };
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/* --------------------------------- update draft -------------------------------- */
+
+function assertDraft(statut: CommandeFournisseurStatut) {
+  if (statut !== "BROUILLON") {
+    throw new HttpError(
+      422,
+      "DRAFT_ONLY",
+      "Seul un brouillon est modifiable. Une commande engagée passe par une transition ou une révision documentaire motivée."
+    );
+  }
+}
+
+const HEADER_PATCH_COLUMNS: Record<string, string> = {
+  contact_id: "contact_id",
+  adresse_commande_id: "adresse_commande_id",
+  magasin_livraison_id: "magasin_livraison_id",
+  adresse_livraison_texte: "adresse_livraison_texte",
+  adresse_facturation_texte: "adresse_facturation_texte",
+  devise: "devise",
+  conditions_paiement: "conditions_paiement",
+  incoterm: "incoterm",
+  mode_transport: "mode_transport",
+  date_besoin: "date_besoin",
+  commentaire_public: "commentaire_public",
+  note_interne: "note_interne",
+  frais_port_ht: "frais_port_ht",
+  tva_frais_pct: "tva_frais_pct",
+  origine: "origine",
+};
+
+export async function repoUpdateCommandeFournisseur(
+  id: string,
+  body: UpdateCommandeBodyDTO,
+  audit: AuditContext
+): Promise<{ updated: true }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const header = await lockHeader(client, id);
+    assertOptimisticToken(body.expected_updated_at, header.updated_at_token);
+    assertDraft(header.statut);
+
+    const sets: string[] = [];
+    const values: unknown[] = [id];
+    const changed: string[] = [];
+    for (const [key, column] of Object.entries(HEADER_PATCH_COLUMNS)) {
+      if (!(key in body)) continue; // tri-state : seules les clés fournies changent
+      values.push((body as Record<string, unknown>)[key] ?? null);
+      sets.push(`${column} = $${values.length}`);
+      changed.push(key);
+    }
+    if (sets.length > 0) {
+      values.push(audit.user_id);
+      sets.push(`updated_by = $${values.length}`);
+      await client.query(`UPDATE public.commande_fournisseur SET ${sets.join(", ")} WHERE id = $1::uuid`, values);
+      await recomputeTotauxTx(client, id);
+      await insertAuditLog(client, audit, {
+        action: "commandes_fournisseurs.update",
+        entity_type: "commande_fournisseur",
+        entity_id: id,
+        details: { champs: changed },
+      });
+    }
+    await client.query("COMMIT");
+    return { updated: true };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/* ------------------------------------ lignes ----------------------------------- */
+
+export async function repoAddLigne(id: string, body: AddLigneBodyDTO, audit: AuditContext): Promise<{ ligne_id: string }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const header = await lockHeader(client, id);
+    assertOptimisticToken(body.expected_updated_at, header.updated_at_token);
+    assertDraft(header.statut);
+
+    const posRes = await client.query<{ next_pos: number }>(
+      `SELECT COALESCE(max(position), 0) + 1 AS next_pos FROM public.commande_fournisseur_ligne WHERE commande_id = $1::uuid`,
+      [id]
+    );
+    const ligneId = await insertLigneTx(client, id, Number(posRes.rows[0].next_pos), body.ligne, audit.user_id);
+    await recomputeTotauxTx(client, id);
+    await client.query(`UPDATE public.commande_fournisseur SET updated_by = $2 WHERE id = $1::uuid`, [id, audit.user_id]);
+    await insertAuditLog(client, audit, {
+      action: "commandes_fournisseurs.lignes.add",
+      entity_type: "commande_fournisseur",
+      entity_id: id,
+      details: { ligne_id: ligneId, designation: body.ligne.designation },
+    });
+    await client.query("COMMIT");
+    return { ligne_id: ligneId };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+const LIGNE_PATCH_COLUMNS: Record<string, string> = {
+  type: "type",
+  article_id: "article_id",
+  catalogue_id: "catalogue_id",
+  reference_fournisseur: "reference_fournisseur",
+  designation: "designation",
+  designation_interne: "designation_interne",
+  unite: "unite",
+  unite_stock: "unite_stock",
+  coef_conversion: "coef_conversion",
+  quantite: "quantite",
+  prix_unitaire_ht: "prix_unitaire_ht",
+  remise_pct: "remise_pct",
+  tva_pct: "tva_pct",
+  frais_ht: "frais_ht",
+  date_besoin: "date_besoin",
+  date_promesse: "date_promesse",
+  delai_jours: "delai_jours",
+  affaire_id: "affaire_id",
+  commande_client_id: "commande_client_id",
+  of_id: "of_id",
+  piece_technique_id: "piece_technique_id",
+  operation_libelle: "operation_libelle",
+  magasin_id: "magasin_id",
+  exigences_qualite: "exigences_qualite",
+  documents_attendus: "documents_attendus",
+};
+
+export async function repoUpdateLigne(
+  id: string,
+  ligneId: string,
+  body: UpdateLigneBodyDTO,
+  audit: AuditContext
+): Promise<{ updated: true }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const header = await lockHeader(client, id);
+    assertOptimisticToken(body.expected_updated_at, header.updated_at_token);
+    assertDraft(header.statut);
+
+    const exists = await client.query<{ id: string }>(
+      `SELECT id FROM public.commande_fournisseur_ligne WHERE id = $1::uuid AND commande_id = $2::uuid FOR UPDATE`,
+      [ligneId, id]
+    );
+    if (!exists.rows[0]) throw new HttpError(404, "LIGNE_NOT_FOUND", "Ligne introuvable sur cette commande.");
+
+    const sets: string[] = [];
+    const values: unknown[] = [ligneId];
+    for (const [key, column] of Object.entries(LIGNE_PATCH_COLUMNS)) {
+      if (!(key in body.patch)) continue;
+      const raw = (body.patch as Record<string, unknown>)[key];
+      const value = key === "exigences_qualite" ? JSON.stringify(raw ?? []) : raw ?? null;
+      values.push(value);
+      sets.push(`${column} = $${values.length}${key === "exigences_qualite" ? "::jsonb" : ""}`);
+    }
+    if (sets.length > 0) {
+      values.push(audit.user_id);
+      sets.push(`updated_by = $${values.length}`);
+      await client.query(
+        `UPDATE public.commande_fournisseur_ligne SET ${sets.join(", ")} WHERE id = $1::uuid`,
+        values
+      );
+      await recomputeTotauxTx(client, id);
+      await client.query(`UPDATE public.commande_fournisseur SET updated_by = $2 WHERE id = $1::uuid`, [id, audit.user_id]);
+      await insertAuditLog(client, audit, {
+        action: "commandes_fournisseurs.lignes.update",
+        entity_type: "commande_fournisseur",
+        entity_id: id,
+        details: { ligne_id: ligneId, champs: Object.keys(body.patch) },
+      });
+    }
+    await client.query("COMMIT");
+    return { updated: true };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoDeleteLigne(
+  id: string,
+  ligneId: string,
+  expectedUpdatedAt: string | undefined,
+  audit: AuditContext
+): Promise<{ deleted: true }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const header = await lockHeader(client, id);
+    assertOptimisticToken(expectedUpdatedAt, header.updated_at_token);
+    assertDraft(header.statut);
+
+    // Suppression physique UNIQUEMENT en brouillon (rien n'a été engagé) : les liens besoins
+    // tombent en cascade et libèrent la couverture. Après soumission, une ligne s'annule.
+    const res = await client.query(
+      `DELETE FROM public.commande_fournisseur_ligne WHERE id = $1::uuid AND commande_id = $2::uuid`,
+      [ligneId, id]
+    );
+    if (res.rowCount === 0) throw new HttpError(404, "LIGNE_NOT_FOUND", "Ligne introuvable sur cette commande.");
+    await recomputeTotauxTx(client, id);
+    await client.query(`UPDATE public.commande_fournisseur SET updated_by = $2 WHERE id = $1::uuid`, [id, audit.user_id]);
+    await insertAuditLog(client, audit, {
+      action: "commandes_fournisseurs.lignes.delete",
+      entity_type: "commande_fournisseur",
+      entity_id: id,
+      details: { ligne_id: ligneId },
+    });
+    await client.query("COMMIT");
+    return { deleted: true };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoReorderLignes(
+  id: string,
+  body: ReorderLignesBodyDTO,
+  audit: AuditContext
+): Promise<{ reordered: true }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const header = await lockHeader(client, id);
+    assertOptimisticToken(body.expected_updated_at, header.updated_at_token);
+    assertDraft(header.statut);
+
+    const current = await client.query<{ id: string }>(
+      `SELECT id FROM public.commande_fournisseur_ligne WHERE commande_id = $1::uuid`,
+      [id]
+    );
+    const currentIds = new Set(current.rows.map((r) => r.id));
+    if (currentIds.size !== body.ordre.length || body.ordre.some((l) => !currentIds.has(l))) {
+      throw new HttpError(422, "REORDER_MISMATCH", "L'ordre fourni ne correspond pas aux lignes de la commande.");
+    }
+    // La contrainte UNIQUE (commande_id, position) est DEFERRABLE : le swap transactionnel passe.
+    for (let index = 0; index < body.ordre.length; index += 1) {
+      await client.query(`UPDATE public.commande_fournisseur_ligne SET position = $2 WHERE id = $1::uuid`, [
+        body.ordre[index],
+        index + 1,
+      ]);
+    }
+    await client.query(`UPDATE public.commande_fournisseur SET updated_by = $2 WHERE id = $1::uuid`, [id, audit.user_id]);
+    await insertAuditLog(client, audit, {
+      action: "commandes_fournisseurs.lignes.reorder",
+      entity_type: "commande_fournisseur",
+      entity_id: id,
+      details: { nb_lignes: body.ordre.length },
+    });
+    await client.query("COMMIT");
+    return { reordered: true };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/* ---------------------------------- transitions --------------------------------- */
+
+async function buildFournisseurSnapshot(tx: DbQueryer, fournisseurId: string): Promise<Record<string, unknown>> {
+  const f = await tx.query(
+    `SELECT id, COALESCE(code, code_fournisseur) AS code, COALESCE(nom, raison_sociale) AS nom,
+            status, actif, email, telephone
+       FROM public.fournisseurs WHERE id = $1::uuid`,
+    [fournisseurId]
+  );
+  const adresses = await tx.query(
+    `SELECT type, label, ligne1, ligne2, house_no, postcode, city, country, is_primary
+       FROM public.fournisseur_adresses WHERE fournisseur_id = $1::uuid AND actif IS NOT FALSE
+       ORDER BY type, is_primary DESC NULLS LAST`,
+    [fournisseurId]
+  ).catch(() => ({ rows: [] as unknown[] }));
+  return { fournisseur: f.rows[0] ?? null, adresses: adresses.rows, snapshot_at: new Date().toISOString() };
+}
+
+async function countLignesActives(tx: DbQueryer, commandeId: string): Promise<number> {
+  const res = await tx.query<{ n: string }>(
+    `SELECT count(*) AS n FROM public.commande_fournisseur_ligne
+      WHERE commande_id = $1::uuid AND statut_ligne = 'ACTIVE'`,
+    [commandeId]
+  );
+  return num(res.rows[0]?.n);
+}
+
+async function sumQtyRecue(tx: DbQueryer, commandeId: string): Promise<number> {
+  const res = await tx.query<{ q: string }>(
+    `SELECT COALESCE(sum(rl.qty_received), 0) AS q
+       FROM public.reception_fournisseur_lignes rl
+       JOIN public.commande_fournisseur_ligne l ON l.id = rl.commande_fournisseur_ligne_id
+      WHERE l.commande_id = $1::uuid`,
+    [commandeId]
+  );
+  return num(res.rows[0]?.q);
+}
+
+export async function repoTransitionCommandeFournisseur(
+  id: string,
+  body: TransitionBodyDTO,
+  audit: AuditContext,
+  options?: { system?: boolean }
+): Promise<{ statut: CommandeFournisseurStatut; idempotent_replay?: boolean }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+
+    if (body.idempotency_key) {
+      const replay = await readIdempotentReplay(client, body.idempotency_key, "SEND");
+      if (replay) {
+        await client.query("COMMIT");
+        return replay as { statut: CommandeFournisseurStatut; idempotent_replay: boolean };
+      }
+    }
+
+    const header = await lockHeader(client, id);
+    assertOptimisticToken(body.expected_updated_at, header.updated_at_token);
+
+    const from = header.statut;
+    const to = body.to;
+
+    if (from === to) {
+      // Idempotence naturelle (double-clic) : l'état demandé est déjà atteint, aucune écriture.
+      await client.query("COMMIT");
+      return { statut: from, idempotent_replay: true };
+    }
+
+    if (!isAllowedTransition(from, to)) {
+      throw new HttpError(422, "INVALID_TRANSITION", "Transition de statut interdite.", {
+        from,
+        to,
+        allowed: allowedTargetsFrom(from),
+      });
+    }
+
+    const kind = classifyTransition(from, to);
+
+    // Les états de réception sont dérivés des réceptions réelles, jamais posés à la main.
+    if (isReceptionDerivedStatut(to) && !options?.system) {
+      throw new HttpError(
+        422,
+        "RECEPTION_DERIVED_STATUS",
+        "Ce statut est calculé depuis les réceptions liées : créez une réception dans le module Réceptions."
+      );
+    }
+
+    // RBAC fin re-vérifié une fois `from` connu (le garde de route est volontairement coarse).
+    if (!options?.system) {
+      const capability = capabilityForTransition(kind);
+      if (!roleHasCommandeFournisseurCapability(audit.role, capability)) {
+        throw new HttpError(403, "FORBIDDEN_TRANSITION", "Votre rôle ne permet pas cette transition.");
+      }
+    }
+
+    const motif = body.motif?.trim() || null;
+    if (transitionRequiresMotif(kind) && !motif) {
+      throw new HttpError(422, "MOTIF_REQUIS", "Un motif est obligatoire pour cette transition.", { kind });
+    }
+
+    // Préconditions métier par nature de transition.
+    if (kind === "submit" || kind === "approve") {
+      const nbLignes = await countLignesActives(client, id);
+      if (nbLignes === 0) {
+        throw new HttpError(422, "COMMANDE_SANS_LIGNE", "Impossible sans au moins une ligne active.");
+      }
+      const fournisseur = await fetchFournisseurMini(client, header.fournisseur_id);
+      assertFournisseurCommandable(fournisseur);
+    }
+    if (kind === "send") {
+      if (Number(header.version_document) < 1) {
+        throw new HttpError(
+          422,
+          "DOCUMENT_VERSION_REQUISE",
+          "Impossible d'envoyer sans version figée du bon de commande : générez d'abord le document."
+        );
+      }
+    }
+    if (kind === "cancel") {
+      const recue = await sumQtyRecue(client, id);
+      if (recue > 0) {
+        throw new HttpError(
+          422,
+          "ANNULATION_IMPOSSIBLE_RECEPTIONNEE",
+          "Des quantités ont déjà été réceptionnées : clôturez avec motif au lieu d'annuler."
+        );
+      }
+    }
+    if (kind === "close" && from === "PARTIELLEMENT_RECUE" && !motif) {
+      throw new HttpError(422, "MOTIF_REQUIS", "La clôture avec reliquat exige un motif explicite.");
+    }
+
+    // Effets par transition.
+    const sets: string[] = [`statut = $2`, `updated_by = $3`];
+    const values: unknown[] = [id, to, audit.user_id];
+    const pushSet = (fragment: string, value?: unknown) => {
+      if (value !== undefined) {
+        values.push(value);
+        sets.push(`${fragment} $${values.length}`);
+      } else {
+        sets.push(fragment);
+      }
+    };
+
+    if (kind === "submit") {
+      pushSet("submitted_at = now()");
+      pushSet("submitted_by =", audit.user_id);
+    }
+    if (kind === "approve") {
+      pushSet("approved_at = now()");
+      pushSet("approved_by =", audit.user_id);
+    }
+    if (kind === "reject" || kind === "reopen_draft") {
+      pushSet("motif_revision =", motif);
+    }
+    if (kind === "send") {
+      const snapshot = await buildFournisseurSnapshot(client, header.fournisseur_id);
+      pushSet("date_envoi = now()");
+      pushSet("sent_by =", audit.user_id);
+      pushSet("fournisseur_snapshot =", JSON.stringify(snapshot));
+      pushSet(
+        "conditions_snapshot =",
+        JSON.stringify({
+          devise: header.devise,
+          version_document: header.version_document,
+          snapshot_at: new Date().toISOString(),
+        })
+      );
+      await client.query(
+        `UPDATE public.commande_fournisseur_document SET sent_at = now()
+          WHERE commande_id = $1::uuid AND version = $2 AND sent_at IS NULL`,
+        [id, header.version_document]
+      );
+    }
+    if (kind === "cancel") {
+      pushSet("date_annulation = now()");
+      pushSet("motif_annulation =", motif);
+    }
+    if (kind === "close") {
+      pushSet("date_cloture = now()");
+      pushSet("motif_cloture =", motif);
+    }
+
+    await client.query(`UPDATE public.commande_fournisseur SET ${sets.join(", ")} WHERE id = $1::uuid`, values);
+    await insertTransitionRow(client, id, from, to, motif, options?.system ? null : audit.user_id);
+    await insertAuditLog(client, audit, {
+      action: `commandes_fournisseurs.transition.${kind}`,
+      entity_type: "commande_fournisseur",
+      entity_id: id,
+      details: { from, to, motif, system: Boolean(options?.system) },
+    });
+
+    const resultat = { statut: to };
+    if (body.idempotency_key) {
+      await recordIdempotence(client, body.idempotency_key, "SEND", id, resultat);
+    }
+    await client.query("COMMIT");
+    return resultat;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/* ------------------------------------ accusé ------------------------------------ */
+
+export async function repoAccuseReception(
+  id: string,
+  body: AccuseBodyDTO,
+  audit: AuditContext
+): Promise<{ statut: CommandeFournisseurStatut }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const header = await lockHeader(client, id);
+    assertOptimisticToken(body.expected_updated_at, header.updated_at_token);
+
+    if (header.statut !== "ENVOYEE") {
+      throw new HttpError(422, "INVALID_TRANSITION", "L'accusé ne peut être saisi que sur une commande envoyée.", {
+        from: header.statut,
+        to: "ACCUSE_RECU",
+        allowed: allowedTargetsFrom(header.statut),
+      });
+    }
+
+    await client.query(
+      `UPDATE public.commande_fournisseur
+          SET statut = 'ACCUSE_RECU',
+              reference_fournisseur = $2,
+              date_accuse = COALESCE($3::timestamptz, now()),
+              date_promesse = COALESCE($4::date, date_promesse),
+              acknowledged_by = $5,
+              updated_by = $5
+        WHERE id = $1::uuid`,
+      [id, body.reference_fournisseur, body.date_accuse ?? null, body.date_promesse ?? null, audit.user_id]
+    );
+    await insertTransitionRow(client, id, "ENVOYEE", "ACCUSE_RECU", null, audit.user_id);
+    await insertAuditLog(client, audit, {
+      action: "commandes_fournisseurs.transition.acknowledge",
+      entity_type: "commande_fournisseur",
+      entity_id: id,
+      details: { reference_fournisseur: body.reference_fournisseur },
+    });
+    await client.query("COMMIT");
+    return { statut: "ACCUSE_RECU" };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/* ----------------------------------- documents ----------------------------------- */
+
+export async function repoGenerateDocumentVersion(
+  id: string,
+  motifRevision: string | undefined,
+  expectedUpdatedAt: string | undefined,
+  audit: AuditContext
+): Promise<CommandeFournisseurDocumentMeta> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const header = await lockHeader(client, id);
+    assertOptimisticToken(expectedUpdatedAt, header.updated_at_token);
+
+    if (header.statut !== "APPROUVEE") {
+      throw new HttpError(
+        422,
+        "DOCUMENT_STATUT_INVALIDE",
+        "La version documentaire se génère sur une commande approuvée (avant envoi)."
+      );
+    }
+    if (Number(header.version_document) >= 1 && !motifRevision) {
+      throw new HttpError(422, "MOTIF_REQUIS", "Une nouvelle version documentaire exige un motif de révision.");
+    }
+
+    const detail = await repoGetCommandeFournisseurTx(client, id);
+    const version = Number(header.version_document) + 1;
+    const payload = {
+      type: "BON_DE_COMMANDE_FOURNISSEUR",
+      version,
+      code: detail.code,
+      statut: detail.statut,
+      fournisseur: detail.fournisseur,
+      devise: detail.devise,
+      incoterm: detail.incoterm,
+      conditions_paiement: detail.conditions_paiement,
+      mode_transport: detail.mode_transport,
+      date_besoin: detail.date_besoin,
+      commentaire_public: detail.commentaire_public,
+      lignes: detail.lignes
+        .filter((l) => l.statut_ligne === "ACTIVE")
+        .map((l) => ({
+          position: l.position,
+          type: l.type,
+          article_code: l.article_code,
+          reference_fournisseur: l.reference_fournisseur,
+          designation: l.designation,
+          unite: l.unite,
+          quantite: l.quantite,
+          prix_unitaire_ht: l.prix_unitaire_ht,
+          remise_pct: l.remise_pct,
+          tva_pct: l.tva_pct,
+          net_ht: l.net_ht,
+          date_besoin: l.date_besoin,
+          exigences_qualite: l.exigences_qualite,
+          documents_attendus: l.documents_attendus,
+        })),
+      totaux: {
+        total_ht: detail.total_ht,
+        total_remise: detail.total_remise,
+        total_tva: detail.total_tva,
+        frais_port_ht: detail.frais_port_ht,
+        total_ttc: detail.total_ttc,
+      },
+    };
+    const canonical = stableStringify(payload);
+    const sha = sha256Hex(canonical);
+
+    const inserted = await client.query(
+      `INSERT INTO public.commande_fournisseur_document
+         (commande_id, version, titre, payload, sha256, motif_revision, generated_by)
+       VALUES ($1::uuid, $2, $3, $4::jsonb, $5, $6, $7)
+       RETURNING id, version, titre, sha256, motif_revision, generated_by, created_at::text, sent_at::text`,
+      [id, version, `Bon de commande ${detail.code} — v${version}`, canonical, sha, motifRevision ?? null, audit.user_id]
+    );
+    await client.query(
+      `UPDATE public.commande_fournisseur SET version_document = $2, motif_revision = $3, updated_by = $4 WHERE id = $1::uuid`,
+      [id, version, motifRevision ?? null, audit.user_id]
+    );
+    await insertAuditLog(client, audit, {
+      action: "commandes_fournisseurs.document.generate",
+      entity_type: "commande_fournisseur",
+      entity_id: id,
+      details: { version, sha256: sha },
+    });
+    await client.query("COMMIT");
+    const d = inserted.rows[0];
+    return {
+      id: d.id,
+      version: Number(d.version),
+      titre: d.titre,
+      sha256: d.sha256,
+      motif_revision: d.motif_revision,
+      generated_by: d.generated_by == null ? null : Number(d.generated_by),
+      created_at: d.created_at,
+      sent_at: d.sent_at,
+    };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+// Variante transactionnelle interne du détail (utilisée par la génération documentaire).
+async function repoGetCommandeFournisseurTx(tx: DbQueryer, id: string): Promise<CommandeFournisseur> {
+  const res = await tx.query(
+    `SELECT cf.*, cf.date_besoin::text AS date_besoin_t,
+            cf.total_ht::text AS total_ht_t, cf.total_remise::text AS total_remise_t,
+            cf.total_tva::text AS total_tva_t, cf.total_ttc::text AS total_ttc_t,
+            cf.frais_port_ht::text AS frais_port_t,
+            f.id AS f_id, COALESCE(f.code, f.code_fournisseur) AS f_code,
+            COALESCE(f.nom, f.raison_sociale) AS f_nom, f.status AS f_status, f.actif AS f_actif
+       FROM public.commande_fournisseur cf
+       JOIN public.fournisseurs f ON f.id = cf.fournisseur_id
+      WHERE cf.id = $1::uuid`,
+    [id]
+  );
+  const r = res.rows[0];
+  if (!r) throw new HttpError(404, "COMMANDE_FOURNISSEUR_NOT_FOUND", "Commande fournisseur introuvable.");
+  const lignes = await fetchLignes(tx, id);
+  return {
+    id: r.id,
+    code: r.code,
+    statut: r.statut,
+    origine: r.origine,
+    fournisseur: { id: r.f_id, code: r.f_code, nom: r.f_nom, status: r.f_status, actif: r.f_actif },
+    contact_id: r.contact_id,
+    adresse_commande_id: r.adresse_commande_id,
+    magasin_livraison_id: r.magasin_livraison_id,
+    adresse_livraison_texte: r.adresse_livraison_texte,
+    adresse_facturation_texte: r.adresse_facturation_texte,
+    devise: r.devise,
+    conditions_paiement: r.conditions_paiement,
+    incoterm: r.incoterm,
+    mode_transport: r.mode_transport,
+    date_besoin: r.date_besoin_t,
+    date_promesse: null,
+    date_envoi: null,
+    date_accuse: null,
+    date_cloture: null,
+    date_annulation: null,
+    reference_fournisseur: r.reference_fournisseur,
+    commentaire_public: r.commentaire_public,
+    note_interne: r.note_interne,
+    motif_revision: r.motif_revision,
+    motif_annulation: r.motif_annulation,
+    motif_cloture: r.motif_cloture,
+    version_document: Number(r.version_document ?? 0),
+    fournisseur_snapshot: r.fournisseur_snapshot ?? null,
+    conditions_snapshot: r.conditions_snapshot ?? null,
+    total_ht: numOrNull(r.total_ht_t),
+    total_remise: numOrNull(r.total_remise_t),
+    total_tva: numOrNull(r.total_tva_t),
+    frais_port_ht: numOrNull(r.frais_port_t),
+    tva_frais_pct: null,
+    total_ttc: numOrNull(r.total_ttc_t),
+    prices_masked: false,
+    allowed_transitions: [...allowedTargetsFrom(r.statut as CommandeFournisseurStatut)],
+    lignes,
+    transitions: [],
+    documents: [],
+    receptions: [],
+    created_at: "",
+    updated_at: "",
+    created_by: null,
+    submitted_by: null,
+    approved_by: null,
+    sent_by: null,
+  };
+}
+
+export async function repoGetDocument(
+  id: string,
+  documentId: string
+): Promise<{ meta: CommandeFournisseurDocumentMeta; payload: unknown }> {
+  const res = await db.query(
+    `SELECT id, commande_id, version, titre, payload, sha256, motif_revision, generated_by,
+            created_at::text, sent_at::text
+       FROM public.commande_fournisseur_document
+      WHERE id = $1::uuid AND commande_id = $2::uuid`,
+    [documentId, id]
+  );
+  const d = res.rows[0];
+  if (!d) throw new HttpError(404, "DOCUMENT_NOT_FOUND", "Version documentaire introuvable.");
+  return {
+    meta: {
+      id: d.id,
+      version: Number(d.version),
+      titre: d.titre,
+      sha256: d.sha256,
+      motif_revision: d.motif_revision,
+      generated_by: d.generated_by == null ? null : Number(d.generated_by),
+      created_at: d.created_at,
+      sent_at: d.sent_at,
+    },
+    payload: typeof d.payload === "string" ? JSON.parse(d.payload) : d.payload,
+  };
+}
+
+/* ------------------------ imputation réceptions (système) ------------------------ */
+
+/**
+ * Recalcule l'état de réception d'une commande à partir des réceptions LIÉES (SUM).
+ * Appelé dans la MÊME transaction que l'écriture de réception (module réceptions), ou via
+ * l'endpoint de resynchronisation idempotent. Contrôle la sur-réception (permission dédiée).
+ */
+export async function repoRefreshCommandeReceptionState(
+  tx: DbQueryer,
+  commandeId: string,
+  options: { allowOverReceipt: boolean; audit?: AuditContext }
+): Promise<{ statut: CommandeFournisseurStatut; changed: boolean }> {
+  const headerRes = await tx.query<{ statut: CommandeFournisseurStatut }>(
+    `SELECT statut FROM public.commande_fournisseur WHERE id = $1::uuid FOR UPDATE`,
+    [commandeId]
+  );
+  const header = headerRes.rows[0];
+  if (!header) throw new HttpError(404, "COMMANDE_FOURNISSEUR_NOT_FOUND", "Commande fournisseur introuvable.");
+
+  const lignes = await tx.query<{
+    id: string;
+    quantite: string;
+    qty_annulee: string;
+    statut_ligne: string;
+    qty_recue: string;
+  }>(
+    `SELECT l.id, l.quantite::text, l.qty_annulee::text, l.statut_ligne,
+            COALESCE((SELECT sum(rl.qty_received) FROM public.reception_fournisseur_lignes rl
+                       WHERE rl.commande_fournisseur_ligne_id = l.id), 0)::text AS qty_recue
+       FROM public.commande_fournisseur_ligne l
+      WHERE l.commande_id = $1::uuid`,
+    [commandeId]
+  );
+
+  let totalRecue = 0;
+  let resteGlobal = 0;
+  for (const l of lignes.rows) {
+    if (l.statut_ligne !== "ACTIVE") continue;
+    const attendue = num(l.quantite) - num(l.qty_annulee);
+    const recue = num(l.qty_recue);
+    totalRecue += recue;
+    if (recue > attendue && !options.allowOverReceipt) {
+      throw new HttpError(422, "OVER_RECEIPT", "Sur-réception détectée sur une ligne de commande.", {
+        ligne_id: l.id,
+        attendue,
+        recue,
+      });
+    }
+    resteGlobal += Math.max(0, attendue - recue);
+  }
+
+  let cible: CommandeFournisseurStatut | null = null;
+  if (["ENVOYEE", "ACCUSE_RECU", "PARTIELLEMENT_RECUE"].includes(header.statut)) {
+    if (totalRecue > 0 && resteGlobal <= 0) cible = "RECUE";
+    else if (totalRecue > 0) cible = "PARTIELLEMENT_RECUE";
+  }
+
+  if (cible && cible !== header.statut) {
+    await tx.query(`UPDATE public.commande_fournisseur SET statut = $2 WHERE id = $1::uuid`, [commandeId, cible]);
+    await insertTransitionRow(tx, commandeId, header.statut, cible, "Imputation des réceptions liées", options.audit?.user_id ?? null);
+    if (options.audit) {
+      await insertAuditLog(tx, options.audit, {
+        action: `commandes_fournisseurs.transition.${cible === "RECUE" ? "receive_full" : "receive_partial"}`,
+        entity_type: "commande_fournisseur",
+        entity_id: commandeId,
+        details: { from: header.statut, to: cible, total_recue: totalRecue, reste: resteGlobal, system: true },
+      });
+    }
+    return { statut: cible, changed: true };
+  }
+  return { statut: (cible ?? header.statut) as CommandeFournisseurStatut, changed: false };
+}
+
+/** Resynchronisation manuelle idempotente (bouton fiche / job). */
+export async function repoResyncReceptions(
+  id: string,
+  audit: AuditContext,
+  allowOverReceipt: boolean
+): Promise<{ statut: CommandeFournisseurStatut; changed: boolean }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const out = await repoRefreshCommandeReceptionState(client, id, { allowOverReceipt, audit });
+    await client.query("COMMIT");
+    return out;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/* ----------------------------------- propositions ---------------------------------- */
+
+export async function repoPreviewPropositions(body: PropositionsPreviewBodyDTO): Promise<PropositionsPreview> {
+  const lignes: PropositionLigne[] = [];
+  const bloques: PropositionsPreview["bloques"] = [];
+
+  if (body.origines.includes("SEUIL_STOCK")) {
+    const res = await db.query(
+      `SELECT sl.id AS stock_level_id, sl.article_id, sl.min_qty::text, sl.reorder_qty::text,
+              sl.lead_time_days, sl.supplier_id,
+              (sl.qty_total - sl.qty_reserved)::text AS disponible,
+              a.code AS article_code, a.designation, a.unite,
+              f.id AS f_id, COALESCE(f.code, f.code_fournisseur) AS f_code,
+              COALESCE(f.nom, f.raison_sociale) AS f_nom, f.status AS f_status, f.actif AS f_actif,
+              cat.id AS catalogue_id, cat.prix_unitaire::text AS cat_prix, cat.devise AS cat_devise,
+              cat.delai_jours AS cat_delai, cat.moq::text AS cat_moq, cat.actif AS cat_actif,
+              cat.fournisseur_id AS cat_fournisseur_id
+         FROM public.stock_levels sl
+         JOIN public.articles a ON a.id = sl.article_id
+         LEFT JOIN public.fournisseurs f ON f.id = sl.supplier_id
+         LEFT JOIN LATERAL (
+           SELECT c.* FROM public.fournisseur_catalogue c
+            WHERE c.article_id = sl.article_id AND c.actif
+            ORDER BY (c.fournisseur_id = sl.supplier_id) DESC, c.prix_unitaire ASC NULLS LAST
+            LIMIT 1
+         ) cat ON TRUE
+        WHERE sl.managed_in_stock IS TRUE
+          AND sl.min_qty IS NOT NULL AND sl.min_qty > 0
+          AND (sl.qty_total - sl.qty_reserved) < sl.min_qty
+          AND NOT EXISTS (
+            SELECT 1 FROM public.commande_fournisseur_ligne_besoin b
+             WHERE b.besoin_type = 'STOCK_LEVEL' AND b.besoin_ref = sl.id::text AND NOT b.annule)
+        ORDER BY a.code
+        LIMIT $1`,
+      [body.limit]
+    );
+    for (const r of res.rows) {
+      const disponible = num(r.disponible);
+      const minQty = num(r.min_qty);
+      const reorder = num(r.reorder_qty);
+      const moq = numOrNull(r.cat_moq);
+      let quantite = reorder > 0 ? reorder : roundMoney(minQty - disponible);
+      const alertes: string[] = [];
+      if (moq != null && quantite < moq) {
+        quantite = moq;
+        alertes.push("MOQ_APPLIQUE");
+      }
+      const fournisseurId: string | null = r.f_id ?? r.cat_fournisseur_id ?? null;
+      const ligne: PropositionLigne = {
+        besoin_type: "STOCK_LEVEL",
+        besoin_ref: r.stock_level_id,
+        of_id: null,
+        of_numero: null,
+        article_id: r.article_id,
+        article_code: r.article_code,
+        designation: r.designation ?? r.article_code ?? "Article",
+        type: "ARTICLE",
+        quantite,
+        unite: r.unite ?? null,
+        prix_unitaire_ht: numOrNull(r.cat_prix),
+        prix_source: r.catalogue_id ? "CATALOGUE_FOURNISSEUR" : null,
+        delai_jours: r.cat_delai ?? r.lead_time_days ?? null,
+        date_besoin: null,
+        catalogue_id: r.catalogue_id ?? null,
+        alertes,
+      };
+      if (!fournisseurId) {
+        bloques.push({ ...ligne, raison: "AUCUN_FOURNISSEUR" });
+        continue;
+      }
+      if (r.f_actif === false || r.f_status === "archive" || r.f_status === "inactif") {
+        bloques.push({ ...ligne, raison: "FOURNISSEUR_INACTIF" });
+        continue;
+      }
+      if (ligne.prix_unitaire_ht == null) alertes.push("PRIX_MANQUANT");
+      lignes.push({ ...ligne, alertes, ...(r.f_id ? {} : {}) });
+      // fournisseur porté via groupement ci-dessous
+      (ligne as PropositionLigne & { __fournisseur?: FournisseurMini; __devise?: string }).__fournisseur = {
+        id: fournisseurId,
+        code: r.f_code ?? null,
+        nom: r.f_nom ?? null,
+        status: r.f_status ?? null,
+        actif: r.f_actif ?? null,
+      };
+      (ligne as PropositionLigne & { __devise?: string }).__devise = r.cat_devise ?? "EUR";
+    }
+  }
+
+  if (body.origines.includes("RUPTURE_OF")) {
+    const values: unknown[] = [body.limit];
+    let ofFilter = `upper(COALESCE(o.statut, '')) NOT IN ('TERMINE','TERMINEE','CLOTURE','CLOTUREE','ANNULE','ANNULEE','ARCHIVE')`;
+    if (body.of_ids && body.of_ids.length > 0) {
+      values.push(body.of_ids);
+      ofFilter = `o.id = ANY($${values.length}::bigint[])`;
+    }
+    const res = await db.query(
+      `SELECT pta.id AS pta_id, pta.nom, pta.designation AS pta_designation, pta.type_achat,
+              pta.quantite::text AS pta_quantite, pta.pu_achat::text, pta.tva_achat::text,
+              pta.article_id, pta.fournisseur_id AS pta_fournisseur_id,
+              o.id AS of_id, o.numero AS of_numero, o.quantite_lancee::text,
+              a.code AS article_code, a.designation AS article_designation, a.unite AS article_unite,
+              f.id AS f_id, COALESCE(f.code, f.code_fournisseur) AS f_code,
+              COALESCE(f.nom, f.raison_sociale) AS f_nom, f.status AS f_status, f.actif AS f_actif,
+              cat.id AS catalogue_id, cat.prix_unitaire::text AS cat_prix, cat.devise AS cat_devise,
+              cat.delai_jours AS cat_delai, cat.fournisseur_id AS cat_fournisseur_id
+         FROM public.ordres_fabrication o
+         JOIN public.pieces_techniques_achats pta ON pta.piece_technique_id = o.piece_technique_id
+         LEFT JOIN public.articles a ON a.id = pta.article_id
+         LEFT JOIN public.fournisseurs f ON f.id = pta.fournisseur_id
+         LEFT JOIN LATERAL (
+           SELECT c.* FROM public.fournisseur_catalogue c
+            WHERE c.article_id = pta.article_id AND c.actif
+            ORDER BY (c.fournisseur_id = pta.fournisseur_id) DESC, c.prix_unitaire ASC NULLS LAST
+            LIMIT 1
+         ) cat ON TRUE
+        WHERE ${ofFilter}
+          AND NOT EXISTS (
+            SELECT 1 FROM public.commande_fournisseur_ligne_besoin b
+             WHERE b.besoin_type = 'PIECE_TECHNIQUE_ACHAT'
+               AND b.besoin_ref = pta.id::text
+               AND b.besoin_of_id = o.id
+               AND NOT b.annule)
+        ORDER BY o.id DESC, pta.nom
+        LIMIT $1`,
+      values
+    );
+    for (const r of res.rows) {
+      const parPiece = num(r.pta_quantite) || 1;
+      const lancee = num(r.quantite_lancee) || 1;
+      const quantite = roundMoney(parPiece * lancee) || parPiece;
+      const alertes: string[] = [];
+      const typeAchat = String(r.type_achat ?? "").toUpperCase();
+      const type =
+        typeAchat === "MATIERE"
+          ? "MATIERE"
+          : typeAchat === "SOUS_TRAITANCE" || typeAchat === "TRAITEMENT"
+            ? "SOUS_TRAITANCE"
+            : typeAchat === "VISSERIE" || typeAchat === "COMPOSANT_CATALOGUE"
+              ? "COMPOSANT"
+              : typeAchat === "CERTIFICAT"
+                ? "PRESTATION"
+                : "ARTICLE";
+      const fournisseurId: string | null = r.f_id ?? r.cat_fournisseur_id ?? null;
+      const prix = numOrNull(r.cat_prix) ?? numOrNull(r.pu_achat);
+      const ligne: PropositionLigne = {
+        besoin_type: "PIECE_TECHNIQUE_ACHAT",
+        besoin_ref: r.pta_id,
+        of_id: Number(r.of_id),
+        of_numero: r.of_numero ?? null,
+        article_id: r.article_id ?? null,
+        article_code: r.article_code ?? null,
+        designation: r.pta_designation || r.nom || r.article_designation || "Besoin d'achat",
+        type,
+        quantite,
+        unite: r.article_unite ?? null,
+        prix_unitaire_ht: prix,
+        prix_source: r.catalogue_id ? "CATALOGUE_FOURNISSEUR" : numOrNull(r.pu_achat) != null ? "NOMENCLATURE_ACHAT" : null,
+        delai_jours: r.cat_delai ?? null,
+        date_besoin: null,
+        catalogue_id: r.catalogue_id ?? null,
+        alertes,
+      };
+      if (!fournisseurId) {
+        bloques.push({ ...ligne, raison: "AUCUN_FOURNISSEUR" });
+        continue;
+      }
+      if (r.f_actif === false || r.f_status === "archive" || r.f_status === "inactif") {
+        bloques.push({ ...ligne, raison: "FOURNISSEUR_INACTIF" });
+        continue;
+      }
+      if (prix == null) alertes.push("PRIX_MANQUANT");
+      (ligne as PropositionLigne & { __fournisseur?: FournisseurMini }).__fournisseur = {
+        id: fournisseurId,
+        code: r.f_code ?? null,
+        nom: r.f_nom ?? null,
+        status: r.f_status ?? null,
+        actif: r.f_actif ?? null,
+      };
+      (ligne as PropositionLigne & { __devise?: string }).__devise = r.cat_devise ?? "EUR";
+      lignes.push(ligne);
+    }
+  }
+
+  // Groupement par fournisseur + devise (seules les lignes compatibles voyagent ensemble).
+  const groupes = new Map<string, PropositionGroupe>();
+  for (const ligne of lignes) {
+    const meta = ligne as PropositionLigne & { __fournisseur?: FournisseurMini; __devise?: string };
+    const fournisseur = meta.__fournisseur;
+    if (!fournisseur) continue;
+    if (body.fournisseur_id && fournisseur.id !== body.fournisseur_id) continue;
+    const devise = meta.__devise ?? "EUR";
+    const key = `${fournisseur.id}:${devise}`;
+    let groupe = groupes.get(key);
+    if (!groupe) {
+      groupe = { fournisseur, devise, lignes: [], total_estime_ht: 0 };
+      groupes.set(key, groupe);
+    }
+    delete meta.__fournisseur;
+    delete meta.__devise;
+    groupe.lignes.push(ligne);
+    if (ligne.prix_unitaire_ht != null && groupe.total_estime_ht != null) {
+      groupe.total_estime_ht = roundMoney(groupe.total_estime_ht + ligne.prix_unitaire_ht * ligne.quantite);
+    } else {
+      groupe.total_estime_ht = groupe.total_estime_ht ?? null;
+    }
+  }
+
+  return {
+    groupes: Array.from(groupes.values()),
+    bloques,
+    genere_le: new Date().toISOString(),
+  };
+}
+
+export async function repoConfirmPropositions(
+  body: PropositionsConfirmBodyDTO,
+  audit: AuditContext
+): Promise<{ commandes: Array<{ id: string; code: string; fournisseur_id: string }>; idempotent_replay: boolean }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+
+    const replay = await readIdempotentReplay(client, body.idempotency_key, "GENERATE");
+    if (replay) {
+      await client.query("COMMIT");
+      return replay as { commandes: Array<{ id: string; code: string; fournisseur_id: string }>; idempotent_replay: boolean };
+    }
+
+    const commandes: Array<{ id: string; code: string; fournisseur_id: string }> = [];
+    for (const groupe of body.groupes) {
+      const fournisseur = await fetchFournisseurMini(client, groupe.fournisseur_id);
+      assertFournisseurCommandable(fournisseur);
+
+      const code = await generateCommandeFournisseurCode(client);
+      const origine = groupe.lignes.some((l) => l.besoin_type === "PIECE_TECHNIQUE_ACHAT") ? "RUPTURE_OF" : "SEUIL_STOCK";
+      const inserted = await client.query<{ id: string }>(
+        `INSERT INTO public.commande_fournisseur
+           (code, origine, fournisseur_id, devise, date_besoin, created_by, updated_by)
+         VALUES ($1,$2,$3::uuid,$4,$5::date,$6,$6) RETURNING id`,
+        [code, origine, groupe.fournisseur_id, groupe.devise, groupe.date_besoin ?? null, audit.user_id]
+      );
+      const commandeId = inserted.rows[0].id;
+
+      let position = 1;
+      for (const l of groupe.lignes) {
+        await insertLigneTx(
+          client,
+          commandeId,
+          position,
+          {
+            type: l.type,
+            article_id: l.article_id ?? null,
+            catalogue_id: l.catalogue_id ?? null,
+            reference_fournisseur: null,
+            designation: l.designation,
+            designation_interne: null,
+            unite: l.unite ?? null,
+            unite_stock: null,
+            coef_conversion: null,
+            quantite: l.quantite,
+            prix_unitaire_ht: l.prix_unitaire_ht,
+            remise_pct: 0,
+            tva_pct: l.tva_pct,
+            frais_ht: 0,
+            date_besoin: l.date_besoin ?? null,
+            date_promesse: null,
+            delai_jours: l.delai_jours ?? null,
+            affaire_id: null,
+            commande_client_id: null,
+            of_id: l.of_id ?? null,
+            piece_technique_id: null,
+            operation_libelle: null,
+            magasin_id: null,
+            exigences_qualite: [],
+            documents_attendus: [],
+            besoins: [
+              {
+                besoin_type: l.besoin_type,
+                besoin_ref: l.besoin_ref,
+                of_id: l.of_id ?? null,
+                quantite_couverte: l.quantite,
+              },
+            ],
+          },
+          audit.user_id
+        );
+        position += 1;
+      }
+
+      await recomputeTotauxTx(client, commandeId);
+      await insertTransitionRow(client, commandeId, null, "BROUILLON", "Généré depuis propositions d'achat", audit.user_id);
+      await insertAuditLog(client, audit, {
+        action: "commandes_fournisseurs.propositions.confirm",
+        entity_type: "commande_fournisseur",
+        entity_id: commandeId,
+        details: { code, fournisseur_id: groupe.fournisseur_id, nb_lignes: groupe.lignes.length, origine },
+      });
+      commandes.push({ id: commandeId, code, fournisseur_id: groupe.fournisseur_id });
+    }
+
+    const resultat = { commandes, idempotent_replay: false };
+    await recordIdempotence(client, body.idempotency_key, "GENERATE", commandes[0]?.id ?? null, { commandes });
+    await client.query("COMMIT");
+    return resultat;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/* ----------------------------------- duplication ----------------------------------- */
+
+export async function repoDuplicateAsDraft(
+  id: string,
+  note: string | undefined,
+  audit: AuditContext
+): Promise<{ id: string; code: string }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const sourceRes = await client.query(
+      `SELECT * FROM public.commande_fournisseur WHERE id = $1::uuid`,
+      [id]
+    );
+    const source = sourceRes.rows[0];
+    if (!source) throw new HttpError(404, "COMMANDE_FOURNISSEUR_NOT_FOUND", "Commande fournisseur introuvable.");
+
+    const fournisseur = await fetchFournisseurMini(client, source.fournisseur_id);
+    assertFournisseurCommandable(fournisseur);
+
+    const code = await generateCommandeFournisseurCode(client);
+    const inserted = await client.query<{ id: string }>(
+      `INSERT INTO public.commande_fournisseur (
+          code, origine, fournisseur_id, contact_id, adresse_commande_id, magasin_livraison_id,
+          adresse_livraison_texte, adresse_facturation_texte, devise, conditions_paiement, incoterm,
+          mode_transport, date_besoin, commentaire_public, note_interne, frais_port_ht, tva_frais_pct,
+          created_by, updated_by)
+       SELECT $2, 'MANUEL', fournisseur_id, contact_id, adresse_commande_id, magasin_livraison_id,
+              adresse_livraison_texte, adresse_facturation_texte, devise, conditions_paiement, incoterm,
+              mode_transport, date_besoin, commentaire_public, $3, frais_port_ht, tva_frais_pct, $4, $4
+         FROM public.commande_fournisseur WHERE id = $1::uuid
+       RETURNING id`,
+      [id, code, note ?? `Dupliquée depuis ${source.code}`, audit.user_id]
+    );
+    const newId = inserted.rows[0].id;
+
+    // Copie des lignes ACTIVE — SANS les liens besoins (une couverture ne se duplique jamais).
+    await client.query(
+      `INSERT INTO public.commande_fournisseur_ligne (
+          commande_id, position, type, article_id, catalogue_id, reference_fournisseur,
+          designation, designation_interne, unite, unite_stock, coef_conversion,
+          quantite, prix_unitaire_ht, remise_pct, tva_pct, frais_ht,
+          date_besoin, date_promesse, delai_jours, affaire_id, commande_client_id, of_id,
+          piece_technique_id, operation_libelle, magasin_id, exigences_qualite, documents_attendus,
+          created_by, updated_by)
+       SELECT $2::uuid, position, type, article_id, catalogue_id, reference_fournisseur,
+              designation, designation_interne, unite, unite_stock, coef_conversion,
+              quantite, prix_unitaire_ht, remise_pct, tva_pct, frais_ht,
+              date_besoin, date_promesse, delai_jours, affaire_id, commande_client_id, of_id,
+              piece_technique_id, operation_libelle, magasin_id, exigences_qualite, documents_attendus,
+              $3, $3
+         FROM public.commande_fournisseur_ligne
+        WHERE commande_id = $1::uuid AND statut_ligne = 'ACTIVE'`,
+      [id, newId, audit.user_id]
+    );
+
+    await recomputeTotauxTx(client, newId);
+    await insertTransitionRow(client, newId, null, "BROUILLON", `Duplication de ${source.code}`, audit.user_id);
+    await insertAuditLog(client, audit, {
+      action: "commandes_fournisseurs.duplicate",
+      entity_type: "commande_fournisseur",
+      entity_id: newId,
+      details: { source_id: id, source_code: source.code, code },
+    });
+    await client.query("COMMIT");
+    return { id: newId, code };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts
+++ b/src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts
@@ -1,0 +1,85 @@
+import { Router, type RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import {
+  roleHasCommandeFournisseurCapability,
+  type CommandeFournisseurCapability,
+} from "../domain/commande-fournisseur-rbac";
+import {
+  accuseReception,
+  addLigne,
+  confirmPropositions,
+  createCommandeFournisseur,
+  deleteLigne,
+  duplicateCommandeFournisseur,
+  generateDocument,
+  getCommandeFournisseur,
+  getCommandeFournisseurKpis,
+  getDocument,
+  listCommandesFournisseurs,
+  previewPropositions,
+  reorderLignes,
+  resyncReceptions,
+  simulateTotaux,
+  transitionCommandeFournisseur,
+  updateCommandeFournisseur,
+  updateLigne,
+} from "../controllers/commande-fournisseur.controller";
+
+/**
+ * Routes commandes fournisseurs (#172) — montées derrière le socle default-deny
+ * (`authenticateToken` global de v1.routes.ts). Chaque écriture porte en plus une garde
+ * de capacité RBAC refusée par défaut ; le RBAC fin dépendant de l'état (transition) est
+ * re-vérifié dans le repository une fois l'état source connu (pattern affaire #169).
+ * Masquer un bouton frontend n'est jamais une autorisation.
+ */
+function requireCapability(capability: CommandeFournisseurCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (!roleHasCommandeFournisseurCapability(req.user?.role, capability)) {
+      next(new HttpError(403, "FORBIDDEN", "Votre rôle ne permet pas cette action sur les commandes fournisseurs."));
+      return;
+    }
+    next();
+  };
+}
+
+/** Garde coarse de transition : la capacité fine est re-vérifiée dans le repo (état connu). */
+const requireAnyTransitionCapability: RequestHandler = (req, _res, next) => {
+  const role = req.user?.role;
+  const capabilities: CommandeFournisseurCapability[] = ["submit", "approve", "send", "acknowledge", "cancel", "close"];
+  if (!capabilities.some((cap) => roleHasCommandeFournisseurCapability(role, cap))) {
+    next(new HttpError(403, "FORBIDDEN", "Votre rôle ne permet aucune transition de commande fournisseur."));
+    return;
+  }
+  next();
+};
+
+const router = Router();
+
+router.get("/", requireCapability("read"), listCommandesFournisseurs);
+router.get("/kpis", requireCapability("read"), getCommandeFournisseurKpis);
+
+router.post("/", requireCapability("create"), createCommandeFournisseur);
+router.post("/totaux/simulate", requireCapability("read"), simulateTotaux);
+
+router.post("/propositions/preview", requireCapability("create"), previewPropositions);
+router.post("/propositions/confirm", requireCapability("create"), confirmPropositions);
+
+router.get("/:id", requireCapability("read"), getCommandeFournisseur);
+router.patch("/:id", requireCapability("update_draft"), updateCommandeFournisseur);
+
+router.post("/:id/lignes", requireCapability("update_draft"), addLigne);
+router.post("/:id/lignes/reorder", requireCapability("update_draft"), reorderLignes);
+router.patch("/:id/lignes/:ligneId", requireCapability("update_draft"), updateLigne);
+router.delete("/:id/lignes/:ligneId", requireCapability("update_draft"), deleteLigne);
+
+router.post("/:id/transition", requireAnyTransitionCapability, transitionCommandeFournisseur);
+router.post("/:id/accuse", requireCapability("acknowledge"), accuseReception);
+
+router.post("/:id/documents", requireCapability("send"), generateDocument);
+router.get("/:id/documents/:documentId", requireCapability("read"), getDocument);
+
+router.post("/:id/receptions/resync", requireCapability("read"), resyncReceptions);
+router.post("/:id/duplicate", requireCapability("create"), duplicateCommandeFournisseur);
+
+export default router;

--- a/src/module/commande-fournisseur/services/commande-fournisseur.service.ts
+++ b/src/module/commande-fournisseur/services/commande-fournisseur.service.ts
@@ -1,0 +1,95 @@
+import type {
+  AccuseBodyDTO,
+  AddLigneBodyDTO,
+  CreateCommandeBodyDTO,
+  PropositionsConfirmBodyDTO,
+  PropositionsPreviewBodyDTO,
+  ReorderLignesBodyDTO,
+  SimulateTotauxBodyDTO,
+  TransitionBodyDTO,
+  UpdateCommandeBodyDTO,
+  UpdateLigneBodyDTO,
+} from "../validators/commande-fournisseur.validators";
+import { computeCommandeTotaux } from "../domain/commande-fournisseur-totaux";
+import {
+  repoAccuseReception,
+  repoAddLigne,
+  repoConfirmPropositions,
+  repoCreateCommandeFournisseur,
+  repoDeleteLigne,
+  repoDuplicateAsDraft,
+  repoGenerateDocumentVersion,
+  repoGetCommandeFournisseur,
+  repoGetDocument,
+  repoGetKpis,
+  repoListCommandesFournisseurs,
+  repoPreviewPropositions,
+  repoReorderLignes,
+  repoResyncReceptions,
+  repoTransitionCommandeFournisseur,
+  repoUpdateCommandeFournisseur,
+  repoUpdateLigne,
+  type AuditContext,
+  type ListCommandesParams,
+} from "../repository/commande-fournisseur.repository";
+
+export const listCommandesFournisseursSVC = (params: ListCommandesParams, includePrices: boolean) =>
+  repoListCommandesFournisseurs(params, { includePrices });
+
+export const getCommandeFournisseurKpisSVC = () => repoGetKpis();
+
+export const getCommandeFournisseurSVC = (id: string, includePrices: boolean) =>
+  repoGetCommandeFournisseur(id, { includePrices });
+
+export const createCommandeFournisseurSVC = (body: CreateCommandeBodyDTO, audit: AuditContext) =>
+  repoCreateCommandeFournisseur(body, audit);
+
+export const updateCommandeFournisseurSVC = (id: string, body: UpdateCommandeBodyDTO, audit: AuditContext) =>
+  repoUpdateCommandeFournisseur(id, body, audit);
+
+export const addLigneSVC = (id: string, body: AddLigneBodyDTO, audit: AuditContext) => repoAddLigne(id, body, audit);
+
+export const updateLigneSVC = (id: string, ligneId: string, body: UpdateLigneBodyDTO, audit: AuditContext) =>
+  repoUpdateLigne(id, ligneId, body, audit);
+
+export const deleteLigneSVC = (
+  id: string,
+  ligneId: string,
+  expectedUpdatedAt: string | undefined,
+  audit: AuditContext
+) => repoDeleteLigne(id, ligneId, expectedUpdatedAt, audit);
+
+export const reorderLignesSVC = (id: string, body: ReorderLignesBodyDTO, audit: AuditContext) =>
+  repoReorderLignes(id, body, audit);
+
+export const transitionCommandeFournisseurSVC = (id: string, body: TransitionBodyDTO, audit: AuditContext) =>
+  repoTransitionCommandeFournisseur(id, body, audit);
+
+export const accuseReceptionSVC = (id: string, body: AccuseBodyDTO, audit: AuditContext) =>
+  repoAccuseReception(id, body, audit);
+
+export const generateDocumentSVC = (
+  id: string,
+  motifRevision: string | undefined,
+  expectedUpdatedAt: string | undefined,
+  audit: AuditContext
+) => repoGenerateDocumentVersion(id, motifRevision, expectedUpdatedAt, audit);
+
+export const getDocumentSVC = (id: string, documentId: string) => repoGetDocument(id, documentId);
+
+export const simulateTotauxSVC = (body: SimulateTotauxBodyDTO) =>
+  computeCommandeTotaux(
+    body.lignes.map((l) => ({ ...l, statut_ligne: "ACTIVE" as const })),
+    { frais_port_ht: body.frais_port_ht, tva_frais_pct: body.tva_frais_pct }
+  );
+
+export const previewPropositionsSVC = (body: PropositionsPreviewBodyDTO) => repoPreviewPropositions(body);
+
+export const confirmPropositionsSVC = (body: PropositionsConfirmBodyDTO, audit: AuditContext) =>
+  repoConfirmPropositions(body, audit);
+
+export const resyncReceptionsSVC = (id: string, audit: AuditContext, allowOverReceipt: boolean) =>
+  repoResyncReceptions(id, audit, allowOverReceipt);
+
+export const duplicateAsDraftSVC = (id: string, note: string | undefined, audit: AuditContext) =>
+  repoDuplicateAsDraft(id, note, audit);

--- a/src/module/commande-fournisseur/types/commande-fournisseur.types.ts
+++ b/src/module/commande-fournisseur/types/commande-fournisseur.types.ts
@@ -1,0 +1,233 @@
+import type { CommandeFournisseurStatut } from "../domain/commande-fournisseur-transitions";
+
+export type Paginated<T> = {
+  items: T[];
+  total: number;
+  page: number;
+  page_size: number;
+};
+
+export type CommandeFournisseurOrigine =
+  | "MANUEL"
+  | "SEUIL_STOCK"
+  | "RUPTURE_OF"
+  | "PROPOSITION_MRP"
+  | "SOUS_TRAITANCE"
+  | "AUTRE";
+
+export type CommandeFournisseurLigneType =
+  | "ARTICLE"
+  | "MATIERE"
+  | "COMPOSANT"
+  | "SOUS_TRAITANCE"
+  | "PRESTATION"
+  | "LIBRE_CONTROLEE";
+
+export type FournisseurMini = {
+  id: string;
+  code: string | null;
+  nom: string | null;
+  status: string | null;
+  actif: boolean | null;
+};
+
+export type CommandeFournisseurListItem = {
+  id: string;
+  code: string;
+  statut: CommandeFournisseurStatut;
+  origine: CommandeFournisseurOrigine;
+  fournisseur: FournisseurMini;
+  devise: string;
+  date_besoin: string | null;
+  date_promesse: string | null;
+  date_envoi: string | null;
+  en_retard: boolean;
+  nb_lignes: number;
+  qty_commandee: number;
+  qty_recue: number;
+  /** null quand le rôle n'a pas la capacité `prices` (masquage serveur). */
+  total_ht: number | null;
+  total_ttc: number | null;
+  version_document: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type CommandeFournisseurLigne = {
+  id: string;
+  commande_id: string;
+  position: number;
+  type: CommandeFournisseurLigneType;
+  article_id: string | null;
+  article_code: string | null;
+  article_designation: string | null;
+  catalogue_id: string | null;
+  reference_fournisseur: string | null;
+  designation: string;
+  designation_interne: string | null;
+  unite: string | null;
+  unite_stock: string | null;
+  coef_conversion: number | null;
+  quantite: number;
+  prix_unitaire_ht: number | null;
+  remise_pct: number | null;
+  tva_pct: number | null;
+  frais_ht: number | null;
+  net_ht: number | null;
+  date_besoin: string | null;
+  date_promesse: string | null;
+  delai_jours: number | null;
+  affaire_id: number | null;
+  commande_client_id: number | null;
+  of_id: number | null;
+  piece_technique_id: string | null;
+  operation_libelle: string | null;
+  magasin_id: string | null;
+  exigences_qualite: unknown[];
+  documents_attendus: string[];
+  qty_confirmee: number | null;
+  qty_recue: number;
+  qty_recue_nc: number;
+  qty_annulee: number;
+  qty_restante: number;
+  statut_ligne: "ACTIVE" | "ANNULEE";
+  motif_annulation: string | null;
+  besoins: CommandeFournisseurLigneBesoin[];
+};
+
+export type CommandeFournisseurLigneBesoin = {
+  id: string;
+  besoin_type: "PIECE_TECHNIQUE_ACHAT" | "STOCK_LEVEL" | "MANUEL";
+  besoin_ref: string;
+  of_id: number | null;
+  quantite_couverte: number;
+  annule: boolean;
+};
+
+export type CommandeFournisseurTransitionEntry = {
+  id: string;
+  from_statut: CommandeFournisseurStatut | null;
+  to_statut: CommandeFournisseurStatut;
+  motif: string | null;
+  acteur_id: number | null;
+  acteur_nom: string | null;
+  created_at: string;
+};
+
+export type CommandeFournisseurDocumentMeta = {
+  id: string;
+  version: number;
+  titre: string;
+  sha256: string;
+  motif_revision: string | null;
+  generated_by: number | null;
+  created_at: string;
+  sent_at: string | null;
+};
+
+export type CommandeFournisseurReceptionLiee = {
+  reception_id: string;
+  reception_no: string;
+  status: string;
+  reception_date: string;
+  lignes: Array<{
+    reception_ligne_id: string;
+    commande_fournisseur_ligne_id: string | null;
+    article_id: string;
+    qty_received: number;
+    lot_id: string | null;
+    lot_status: string | null;
+  }>;
+};
+
+export type CommandeFournisseur = {
+  id: string;
+  code: string;
+  statut: CommandeFournisseurStatut;
+  origine: CommandeFournisseurOrigine;
+  fournisseur: FournisseurMini;
+  contact_id: string | null;
+  adresse_commande_id: string | null;
+  magasin_livraison_id: string | null;
+  adresse_livraison_texte: string | null;
+  adresse_facturation_texte: string | null;
+  devise: string;
+  conditions_paiement: string | null;
+  incoterm: string | null;
+  mode_transport: string | null;
+  date_besoin: string | null;
+  date_promesse: string | null;
+  date_envoi: string | null;
+  date_accuse: string | null;
+  date_cloture: string | null;
+  date_annulation: string | null;
+  reference_fournisseur: string | null;
+  commentaire_public: string | null;
+  note_interne: string | null;
+  motif_revision: string | null;
+  motif_annulation: string | null;
+  motif_cloture: string | null;
+  version_document: number;
+  fournisseur_snapshot: Record<string, unknown> | null;
+  conditions_snapshot: Record<string, unknown> | null;
+  total_ht: number | null;
+  total_remise: number | null;
+  total_tva: number | null;
+  frais_port_ht: number | null;
+  tva_frais_pct: number | null;
+  total_ttc: number | null;
+  prices_masked: boolean;
+  allowed_transitions: CommandeFournisseurStatut[];
+  lignes: CommandeFournisseurLigne[];
+  transitions: CommandeFournisseurTransitionEntry[];
+  documents: CommandeFournisseurDocumentMeta[];
+  receptions: CommandeFournisseurReceptionLiee[];
+  created_at: string;
+  updated_at: string;
+  created_by: number | null;
+  submitted_by: number | null;
+  approved_by: number | null;
+  sent_by: number | null;
+};
+
+export type CommandeFournisseurKpis = {
+  brouillons: number;
+  a_valider: number;
+  a_envoyer: number;
+  sans_accuse: number;
+  en_retard: number;
+  a_recevoir: number;
+};
+
+/** Une proposition d'achat expliquée, avant toute écriture. */
+export type PropositionLigne = {
+  besoin_type: "PIECE_TECHNIQUE_ACHAT" | "STOCK_LEVEL";
+  besoin_ref: string;
+  of_id: number | null;
+  of_numero: string | null;
+  article_id: string | null;
+  article_code: string | null;
+  designation: string;
+  type: CommandeFournisseurLigneType;
+  quantite: number;
+  unite: string | null;
+  prix_unitaire_ht: number | null;
+  prix_source: string | null;
+  delai_jours: number | null;
+  date_besoin: string | null;
+  catalogue_id: string | null;
+  alertes: string[];
+};
+
+export type PropositionGroupe = {
+  fournisseur: FournisseurMini;
+  devise: string;
+  lignes: PropositionLigne[];
+  total_estime_ht: number | null;
+};
+
+export type PropositionsPreview = {
+  groupes: PropositionGroupe[];
+  bloques: Array<PropositionLigne & { raison: string }>;
+  genere_le: string;
+};

--- a/src/module/commande-fournisseur/validators/commande-fournisseur.validators.ts
+++ b/src/module/commande-fournisseur/validators/commande-fournisseur.validators.ts
@@ -1,0 +1,354 @@
+import { z } from "zod";
+
+import {
+  COMMANDE_FOURNISSEUR_STATUTS,
+} from "../domain/commande-fournisseur-transitions";
+
+/**
+ * Validation Zod stricte (#172) — params/query/body en mode strict : les champs inconnus
+ * sensibles sont rejetés. Le `code` est volontairement absent de toute écriture : il est
+ * généré côté serveur (BCF-AAAA-NNNN) et immuable. Pagination/tri/filtres bornés.
+ */
+
+const uuid = z.string().uuid();
+const dateOnly = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Date attendue au format AAAA-MM-JJ")
+  .refine((v) => {
+    const t = Date.parse(`${v}T00:00:00Z`);
+    return Number.isFinite(t) && new Date(t).toISOString().slice(0, 10) === v;
+  }, "Date calendaire invalide");
+const isoDateTime = z.string().datetime({ offset: true });
+const money = z.number().finite().min(0).max(99_999_999);
+const pct = z.number().finite().min(0).max(100);
+const qty = z.number().finite().gt(0).max(9_999_999);
+const positiveInt = z.number().int().min(0).max(100_000);
+const shortText = z.string().trim().min(1).max(200);
+const longText = z.string().trim().max(4000);
+
+export const ORIGINES = ["MANUEL", "SEUIL_STOCK", "RUPTURE_OF", "PROPOSITION_MRP", "SOUS_TRAITANCE", "AUTRE"] as const;
+export const LIGNE_TYPES = ["ARTICLE", "MATIERE", "COMPOSANT", "SOUS_TRAITANCE", "PRESTATION", "LIBRE_CONTROLEE"] as const;
+export const INCOTERMS = ["EXW", "FCA", "FAS", "FOB", "CFR", "CIF", "CPT", "CIP", "DAP", "DPU", "DDP"] as const;
+
+export const commandeFournisseurStatutSchema = z.enum(COMMANDE_FOURNISSEUR_STATUTS);
+
+/* ----------------------------- params / query ----------------------------- */
+
+export const commandeIdParamSchema = z.object({
+  params: z.object({ id: uuid }).strict(),
+});
+
+export const ligneIdParamSchema = z.object({
+  params: z.object({ id: uuid, ligneId: uuid }).strict(),
+});
+
+export const documentIdParamSchema = z.object({
+  params: z.object({ id: uuid, documentId: uuid }).strict(),
+});
+
+export const listCommandesQuerySchema = z.object({
+  query: z
+    .object({
+      q: z.string().trim().max(120).optional(),
+      statut: z
+        .union([commandeFournisseurStatutSchema, z.array(commandeFournisseurStatutSchema).max(9)])
+        .optional(),
+      fournisseur_id: uuid.optional(),
+      origine: z.enum(ORIGINES).optional(),
+      en_retard: z.enum(["true", "false"]).optional(),
+      date_from: dateOnly.optional(),
+      date_to: dateOnly.optional(),
+      page: z.coerce.number().int().min(1).max(10_000).default(1),
+      page_size: z.coerce.number().int().min(1).max(100).default(25),
+      sort: z.enum(["created_at", "date_besoin", "date_promesse", "code", "total_ttc", "updated_at"]).default("created_at"),
+      dir: z.enum(["asc", "desc"]).default("desc"),
+    })
+    .strict(),
+});
+
+/* --------------------------------- lignes --------------------------------- */
+
+const exigenceQualiteSchema = z
+  .object({
+    type: z.enum([
+      "CERTIFICAT_MATIERE",
+      "CERTIFICAT_CONFORMITE",
+      "LOT",
+      "COULEE",
+      "PLAN_INDICE",
+      "SPECIFICATION",
+      "CONTROLE_RECEPTION",
+      "AUTRE",
+    ]),
+    valeur: z.string().trim().max(300).optional(),
+    obligatoire: z.boolean().default(true),
+  })
+  .strict();
+
+export const ligneInputSchema = z
+  .object({
+    type: z.enum(LIGNE_TYPES).default("ARTICLE"),
+    article_id: uuid.nullish(),
+    catalogue_id: uuid.nullish(),
+    reference_fournisseur: z.string().trim().max(120).nullish(),
+    designation: shortText,
+    designation_interne: z.string().trim().max(200).nullish(),
+    unite: z.string().trim().max(20).nullish(),
+    unite_stock: z.string().trim().max(20).nullish(),
+    coef_conversion: z.number().finite().gt(0).max(1_000_000).nullish(),
+    quantite: qty,
+    prix_unitaire_ht: money.default(0),
+    remise_pct: pct.default(0),
+    tva_pct: pct.default(20),
+    frais_ht: money.default(0),
+    date_besoin: dateOnly.nullish(),
+    date_promesse: dateOnly.nullish(),
+    delai_jours: positiveInt.nullish(),
+    affaire_id: z.number().int().positive().nullish(),
+    commande_client_id: z.number().int().positive().nullish(),
+    of_id: z.number().int().positive().nullish(),
+    piece_technique_id: uuid.nullish(),
+    operation_libelle: z.string().trim().max(200).nullish(),
+    magasin_id: uuid.nullish(),
+    exigences_qualite: z.array(exigenceQualiteSchema).max(20).default([]),
+    documents_attendus: z.array(z.string().trim().min(1).max(120)).max(20).default([]),
+    besoins: z
+      .array(
+        z
+          .object({
+            besoin_type: z.enum(["PIECE_TECHNIQUE_ACHAT", "STOCK_LEVEL", "MANUEL"]),
+            besoin_ref: z.string().trim().min(1).max(120),
+            of_id: z.number().int().positive().nullish(),
+            quantite_couverte: qty,
+          })
+          .strict()
+      )
+      .max(20)
+      .default([]),
+  })
+  .strict()
+  .superRefine((val, ctx) => {
+    if (val.type !== "LIBRE_CONTROLEE" && val.type !== "PRESTATION" && !val.article_id && !val.catalogue_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["article_id"],
+        message: "Un article ou une entrée de catalogue est requis pour ce type de ligne.",
+      });
+    }
+    if ((val.coef_conversion == null) !== (val.unite_stock == null)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["coef_conversion"],
+        message: "Conversion d'unité incomplète : fournir l'unité de stock ET le coefficient.",
+      });
+    }
+  });
+
+/* --------------------------------- création -------------------------------- */
+
+export const createCommandeSchema = z.object({
+  body: z
+    .object({
+      idempotency_key: z.string().trim().min(8).max(120).optional(),
+      origine: z.enum(ORIGINES).default("MANUEL"),
+      fournisseur_id: uuid,
+      contact_id: uuid.nullish(),
+      adresse_commande_id: uuid.nullish(),
+      magasin_livraison_id: uuid.nullish(),
+      adresse_livraison_texte: longText.nullish(),
+      adresse_facturation_texte: longText.nullish(),
+      devise: z.string().trim().length(3).toUpperCase().default("EUR"),
+      conditions_paiement: z.string().trim().max(200).nullish(),
+      incoterm: z.enum(INCOTERMS).nullish(),
+      mode_transport: z.string().trim().max(120).nullish(),
+      date_besoin: dateOnly.nullish(),
+      commentaire_public: longText.nullish(),
+      note_interne: longText.nullish(),
+      frais_port_ht: money.default(0),
+      tva_frais_pct: pct.default(20),
+      lignes: z.array(ligneInputSchema).min(0).max(200).default([]),
+    })
+    .strict(),
+});
+export type CreateCommandeBodyDTO = z.infer<typeof createCommandeSchema>["body"];
+
+/* ------------------------------ PATCH (tri-state) --------------------------- */
+
+export const updateCommandeSchema = z.object({
+  body: z
+    .object({
+      expected_updated_at: isoDateTime.optional(),
+      contact_id: uuid.nullish(),
+      adresse_commande_id: uuid.nullish(),
+      magasin_livraison_id: uuid.nullish(),
+      adresse_livraison_texte: longText.nullish(),
+      adresse_facturation_texte: longText.nullish(),
+      devise: z.string().trim().length(3).toUpperCase().optional(),
+      conditions_paiement: z.string().trim().max(200).nullish(),
+      incoterm: z.enum(INCOTERMS).nullish(),
+      mode_transport: z.string().trim().max(120).nullish(),
+      date_besoin: dateOnly.nullish(),
+      commentaire_public: longText.nullish(),
+      note_interne: longText.nullish(),
+      frais_port_ht: money.optional(),
+      tva_frais_pct: pct.optional(),
+      origine: z.enum(ORIGINES).optional(),
+    })
+    .strict(),
+});
+export type UpdateCommandeBodyDTO = z.infer<typeof updateCommandeSchema>["body"];
+
+export const addLigneSchema = z.object({
+  body: z.object({ ligne: ligneInputSchema, expected_updated_at: isoDateTime.optional() }).strict(),
+});
+export type AddLigneBodyDTO = z.infer<typeof addLigneSchema>["body"];
+
+export const updateLigneSchema = z.object({
+  body: z
+    .object({
+      expected_updated_at: isoDateTime.optional(),
+      patch: ligneInputSchema
+        .innerType()
+        .partial()
+        .strict(),
+    })
+    .strict(),
+});
+export type UpdateLigneBodyDTO = z.infer<typeof updateLigneSchema>["body"];
+
+export const deleteLigneSchema = z.object({
+  body: z.object({ expected_updated_at: isoDateTime.optional() }).strict().optional(),
+});
+
+export const reorderLignesSchema = z.object({
+  body: z
+    .object({
+      expected_updated_at: isoDateTime.optional(),
+      ordre: z.array(uuid).min(1).max(200),
+    })
+    .strict(),
+});
+export type ReorderLignesBodyDTO = z.infer<typeof reorderLignesSchema>["body"];
+
+/* ------------------------------- transitions -------------------------------- */
+
+export const transitionSchema = z.object({
+  body: z
+    .object({
+      to: commandeFournisseurStatutSchema,
+      motif: z.string().trim().min(3).max(1000).optional(),
+      expected_updated_at: isoDateTime.optional(),
+      idempotency_key: z.string().trim().min(8).max(120).optional(),
+    })
+    .strict(),
+});
+export type TransitionBodyDTO = z.infer<typeof transitionSchema>["body"];
+
+export const accuseSchema = z.object({
+  body: z
+    .object({
+      reference_fournisseur: shortText,
+      date_accuse: isoDateTime.optional(),
+      date_promesse: dateOnly.nullish(),
+      expected_updated_at: isoDateTime.optional(),
+    })
+    .strict(),
+});
+export type AccuseBodyDTO = z.infer<typeof accuseSchema>["body"];
+
+export const generateDocumentSchema = z.object({
+  body: z
+    .object({
+      motif_revision: z.string().trim().min(3).max(500).optional(),
+      expected_updated_at: isoDateTime.optional(),
+    })
+    .strict()
+    .optional(),
+});
+export type GenerateDocumentBodyDTO = z.infer<typeof generateDocumentSchema>["body"];
+
+export const simulateTotauxSchema = z.object({
+  body: z
+    .object({
+      frais_port_ht: money.default(0),
+      tva_frais_pct: pct.default(20),
+      lignes: z
+        .array(
+          z
+            .object({
+              quantite: qty,
+              prix_unitaire_ht: money.default(0),
+              remise_pct: pct.default(0),
+              tva_pct: pct.default(20),
+              frais_ht: money.default(0),
+            })
+            .strict()
+        )
+        .max(200),
+    })
+    .strict(),
+});
+export type SimulateTotauxBodyDTO = z.infer<typeof simulateTotauxSchema>["body"];
+
+/* ------------------------------- propositions ------------------------------- */
+
+export const propositionsPreviewSchema = z.object({
+  body: z
+    .object({
+      origines: z.array(z.enum(["SEUIL_STOCK", "RUPTURE_OF"])).min(1).max(2),
+      of_ids: z.array(z.number().int().positive()).max(50).optional(),
+      fournisseur_id: uuid.optional(),
+      limit: z.number().int().min(1).max(200).default(100),
+    })
+    .strict(),
+});
+export type PropositionsPreviewBodyDTO = z.infer<typeof propositionsPreviewSchema>["body"];
+
+export const propositionsConfirmSchema = z.object({
+  body: z
+    .object({
+      idempotency_key: z.string().trim().min(8).max(120),
+      groupes: z
+        .array(
+          z
+            .object({
+              fournisseur_id: uuid,
+              devise: z.string().trim().length(3).toUpperCase().default("EUR"),
+              date_besoin: dateOnly.nullish(),
+              lignes: z
+                .array(
+                  z
+                    .object({
+                      besoin_type: z.enum(["PIECE_TECHNIQUE_ACHAT", "STOCK_LEVEL"]),
+                      besoin_ref: z.string().trim().min(1).max(120),
+                      of_id: z.number().int().positive().nullish(),
+                      article_id: uuid.nullish(),
+                      catalogue_id: uuid.nullish(),
+                      type: z.enum(LIGNE_TYPES).default("ARTICLE"),
+                      designation: shortText,
+                      quantite: qty,
+                      unite: z.string().trim().max(20).nullish(),
+                      prix_unitaire_ht: money.default(0),
+                      tva_pct: pct.default(20),
+                      date_besoin: dateOnly.nullish(),
+                      delai_jours: positiveInt.nullish(),
+                    })
+                    .strict()
+                )
+                .min(1)
+                .max(100),
+            })
+            .strict()
+        )
+        .min(1)
+        .max(20),
+    })
+    .strict(),
+});
+export type PropositionsConfirmBodyDTO = z.infer<typeof propositionsConfirmSchema>["body"];
+
+/* -------------------------------- duplication ------------------------------- */
+
+export const duplicateSchema = z.object({
+  body: z.object({ note: z.string().trim().max(500).optional() }).strict().optional(),
+});

--- a/src/module/receptions/repository/receptions.repository.ts
+++ b/src/module/receptions/repository/receptions.repository.ts
@@ -10,6 +10,8 @@ import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators"
+import { roleHasCommandeFournisseurCapability } from "../../commande-fournisseur/domain/commande-fournisseur-rbac"
+import { repoRefreshCommandeReceptionState } from "../../commande-fournisseur/repository/commande-fournisseur.repository"
 import { repoCreateMovement, repoPostMovement } from "../../stock/repository/stock.repository"
 import type { StockMovementDetail } from "../../stock/types/stock.types"
 import type {
@@ -645,6 +647,32 @@ export async function repoCreateReception(body: CreateReceptionBodyDTO, audit: A
     await client.query("BEGIN")
     const receptionNo = await reserveReceptionNo(client)
 
+    // #172 — rattachement facultatif à une commande fournisseur : même fournisseur, et la
+    // commande doit avoir été réellement envoyée (jamais de réception sur un brouillon).
+    if (body.commande_fournisseur_id) {
+      const cf = await client.query<{ fournisseur_id: string; statut: string; code: string }>(
+        `SELECT fournisseur_id::text AS fournisseur_id, statut, code
+           FROM public.commande_fournisseur WHERE id = $1::uuid`,
+        [body.commande_fournisseur_id]
+      )
+      const cfRow = cf.rows[0]
+      if (!cfRow) throw new HttpError(422, "COMMANDE_FOURNISSEUR_INTROUVABLE", "Commande fournisseur liée introuvable.")
+      if (cfRow.fournisseur_id !== body.fournisseur_id) {
+        throw new HttpError(
+          422,
+          "COMMANDE_FOURNISSEUR_MISMATCH",
+          "La commande liée n'appartient pas à ce fournisseur."
+        )
+      }
+      if (!["ENVOYEE", "ACCUSE_RECU", "PARTIELLEMENT_RECUE"].includes(cfRow.statut)) {
+        throw new HttpError(
+          422,
+          "COMMANDE_FOURNISSEUR_NON_RECEVABLE",
+          `La commande ${cfRow.code} (${cfRow.statut}) n'est pas en attente de réception.`
+        )
+      }
+    }
+
     const ins = await client.query<ReceptionRow>(
       `
         INSERT INTO public.receptions_fournisseurs (
@@ -654,10 +682,11 @@ export async function repoCreateReception(body: CreateReceptionBodyDTO, audit: A
           reception_date,
           supplier_reference,
           commentaire,
+          commande_fournisseur_id,
           created_by,
           updated_by
         )
-        VALUES ($1,$2::uuid,'OPEN',$3::date,$4,$5,$6,$6)
+        VALUES ($1,$2::uuid,'OPEN',$3::date,$4,$5,$6::uuid,$7,$7)
         RETURNING
           id::text AS id,
           reception_no,
@@ -677,6 +706,7 @@ export async function repoCreateReception(body: CreateReceptionBodyDTO, audit: A
         body.reception_date ?? null,
         body.supplier_reference ?? null,
         body.commentaire ?? null,
+        body.commande_fournisseur_id ?? null,
         audit.user_id,
       ]
     )
@@ -784,6 +814,52 @@ export async function repoCreateLine(receptionId: string, body: CreateLineBodyDT
     )
     const lineNo = next.rows[0]?.next_no ?? 1
 
+    // #172 — imputation facultative sur une ligne de commande fournisseur : cohérence
+    // fournisseur/article/état vérifiée, puis recalcul transactionnel de l'état de la
+    // commande (sur-réception bloquée sans la capacité dédiée — motif requis).
+    let commandeIdToRefresh: string | null = null
+    if (body.commande_fournisseur_ligne_id) {
+      const cfl = await client.query<{
+        ligne_id: string
+        commande_id: string
+        statut_ligne: string
+        ligne_article_id: string | null
+        cf_statut: string
+        cf_fournisseur_id: string
+        cf_code: string
+        reception_fournisseur_id: string
+      }>(
+        `SELECT l.id::text AS ligne_id, l.commande_id::text AS commande_id, l.statut_ligne,
+                l.article_id::text AS ligne_article_id,
+                c.statut AS cf_statut, c.fournisseur_id::text AS cf_fournisseur_id, c.code AS cf_code,
+                r.fournisseur_id::text AS reception_fournisseur_id
+           FROM public.commande_fournisseur_ligne l
+           JOIN public.commande_fournisseur c ON c.id = l.commande_id
+           CROSS JOIN (SELECT fournisseur_id FROM public.receptions_fournisseurs WHERE id = $2::uuid) r
+          WHERE l.id = $1::uuid`,
+        [body.commande_fournisseur_ligne_id, receptionId]
+      )
+      const link = cfl.rows[0]
+      if (!link) throw new HttpError(422, "LIGNE_COMMANDE_INTROUVABLE", "Ligne de commande fournisseur introuvable.")
+      if (link.statut_ligne !== "ACTIVE") {
+        throw new HttpError(422, "LIGNE_COMMANDE_ANNULEE", "Impossible d'imputer une ligne de commande annulée.")
+      }
+      if (link.cf_fournisseur_id !== link.reception_fournisseur_id) {
+        throw new HttpError(422, "COMMANDE_FOURNISSEUR_MISMATCH", "La ligne de commande n'appartient pas au fournisseur de cette réception.")
+      }
+      if (!["ENVOYEE", "ACCUSE_RECU", "PARTIELLEMENT_RECUE"].includes(link.cf_statut)) {
+        throw new HttpError(
+          422,
+          "COMMANDE_FOURNISSEUR_NON_RECEVABLE",
+          `La commande ${link.cf_code} (${link.cf_statut}) n'est pas en attente de réception.`
+        )
+      }
+      if (link.ligne_article_id && link.ligne_article_id !== body.article_id) {
+        throw new HttpError(422, "ARTICLE_MISMATCH", "L'article reçu ne correspond pas à la ligne de commande imputée.")
+      }
+      commandeIdToRefresh = link.commande_id
+    }
+
     const ins = await client.query<{ id: string }>(
       `
         INSERT INTO public.reception_fournisseur_lignes (
@@ -795,10 +871,11 @@ export async function repoCreateLine(receptionId: string, body: CreateLineBodyDT
           unite,
           supplier_lot_code,
           notes,
+          commande_fournisseur_ligne_id,
           created_by,
           updated_by
         )
-        VALUES ($1::uuid,$2,$3::uuid,$4,$5,$6,$7,$8,$9,$9)
+        VALUES ($1::uuid,$2,$3::uuid,$4,$5,$6,$7,$8,$9::uuid,$10,$10)
         RETURNING id::text AS id
       `,
       [
@@ -810,6 +887,7 @@ export async function repoCreateLine(receptionId: string, body: CreateLineBodyDT
         body.unite ?? null,
         body.supplier_lot_code ?? null,
         body.notes ?? null,
+        body.commande_fournisseur_ligne_id ?? null,
         audit.user_id,
       ]
     )
@@ -822,6 +900,22 @@ export async function repoCreateLine(receptionId: string, body: CreateLineBodyDT
       entity_id: lineId,
       details: { reception_id: receptionId, line_no: lineNo, article_id: body.article_id, qty_received: body.qty_received },
     })
+
+    if (commandeIdToRefresh) {
+      // Sur-réception : autorisée uniquement si le rôle porte la capacité dédiée ET qu'un
+      // motif est saisi dans les notes de la ligne (permission + motif explicites, #172).
+      const roleRes = await client.query<{ role: string | null }>(
+        `SELECT role FROM public.users WHERE id = $1`,
+        [audit.user_id]
+      )
+      const role = roleRes.rows[0]?.role ?? null
+      const allowOverReceipt =
+        roleHasCommandeFournisseurCapability(role, "over_receipt") && Boolean(body.notes && body.notes.trim().length >= 3)
+      await repoRefreshCommandeReceptionState(client, commandeIdToRefresh, {
+        allowOverReceipt,
+        audit: { ...audit, role },
+      })
+    }
 
     const detail = await selectLineDetail(client, lineId)
 

--- a/src/module/receptions/validators/receptions.validators.ts
+++ b/src/module/receptions/validators/receptions.validators.ts
@@ -55,6 +55,8 @@ export const createReceptionSchema = z.object({
       reception_date: isoDate.optional().nullable(),
       supplier_reference: z.string().trim().min(1).max(120).optional().nullable(),
       commentaire: z.string().trim().min(1).max(5000).optional().nullable(),
+      // #172 — rattachement facultatif à une commande fournisseur (BCF) du même fournisseur.
+      commande_fournisseur_id: uuid.optional().nullable(),
     })
     .strict(),
 })
@@ -83,6 +85,8 @@ export const createLineSchema = z.object({
       unite: z.string().trim().min(1).max(30).optional().nullable(),
       supplier_lot_code: z.string().trim().min(1).max(120).optional().nullable(),
       notes: z.string().trim().min(1).max(5000).optional().nullable(),
+      // #172 — imputation facultative sur une ligne de commande fournisseur (BCF).
+      commande_fournisseur_ligne_id: uuid.optional().nullable(),
     })
     .strict(),
 })

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -28,6 +28,7 @@ import stockRoutes from "../module/stock/routes/stock.routes";
 import programmationRoutes from "../module/programmation/routes/programmation.routes";
 import operationDossiersRoutes from "../module/operation-dossiers/routes/operation-dossiers.routes";
 import fournisseursRoutes from "../module/fournisseurs/routes/fournisseurs.routes";
+import commandeFournisseurRoutes from "../module/commande-fournisseur/routes/commande-fournisseur.routes";
 import receptionsRoutes from "../module/receptions/routes/receptions.routes";
 import metrologieRoutes from "../module/metrologie/routes/metrologie.routes";
 import codesRoutes from "../module/codes/routes/codes.routes";
@@ -80,6 +81,7 @@ router.use("/livraisons", livraisonsRoutes);
 router.use("/stock", stockRoutes);
 router.use("/dossiers", operationDossiersRoutes);
 router.use("/fournisseurs", fournisseursRoutes);
+router.use("/commandes-fournisseurs", commandeFournisseurRoutes); // Module « Commandes fournisseurs » (#172) — BCF
 router.use("/receptions", receptionsRoutes);
 router.use("/metrologie", metrologieRoutes);
 router.use("/codes", codesRoutes);

--- a/src/shared/codes/code-generator.service.ts
+++ b/src/shared/codes/code-generator.service.ts
@@ -101,10 +101,12 @@ export async function generateArticleBusinessCode(tx: DbQueryer, familyCode: str
 
 export async function generateTransactionalBusinessCode(
   tx: DbQueryer,
-  input: { prefix: "DEV" | "CMD" | "AFF" | "OF" | "LOT" | "MVT" | "CQ" | "NC" | "CAPA" | "BL" | "FACT"; date?: Date; width?: number }
+  input: { prefix: "DEV" | "CMD" | "AFF" | "OF" | "LOT" | "MVT" | "CQ" | "NC" | "CAPA" | "BL" | "FACT" | "BCF"; date?: Date; width?: number }
 ): Promise<string> {
   const year = yearFromDate(input.date ?? new Date());
-  const width = input.width ?? (input.prefix === "DEV" || input.prefix === "CMD" || input.prefix === "AFF" ? 4 : 6);
+  const width =
+    input.width ??
+    (input.prefix === "DEV" || input.prefix === "CMD" || input.prefix === "AFF" || input.prefix === "BCF" ? 4 : 6);
   const seq = await nextCodeValue(tx, `${input.prefix}:${year}`);
   return `${input.prefix}-${year}-${pad(seq, width)}`;
 }
@@ -143,6 +145,11 @@ export async function generateOfCode(tx: DbQueryer, params: { date?: Date }): Pr
 export async function generateFournisseurCode(tx: DbQueryer): Promise<string> {
   const seq = await nextCodeValue(tx, `FOU`);
   return `FOU-${pad(seq, 3)}`;
+}
+
+/** #172 — Bon de commande fournisseur : BCF-AAAA-NNNN, alloué en transaction, immuable. */
+export async function generateCommandeFournisseurCode(tx: DbQueryer, params?: { date?: Date }): Promise<string> {
+  return generateTransactionalBusinessCode(tx, { prefix: "BCF", date: params?.date });
 }
 
 export async function generateArticleCode(_tx: DbQueryer): Promise<string> {

--- a/src/shared/codes/code-validator.ts
+++ b/src/shared/codes/code-validator.ts
@@ -44,6 +44,11 @@ export const CODE_FORMATS = {
     example: "FOU-001",
     hintText: "Format attendu: FOU-001",
   },
+  commandeFournisseur: {
+    regex: /^BCF-\d{4}-\d{4}$/,
+    example: "BCF-2026-0001",
+    hintText: "Format attendu: BCF-2026-0001",
+  },
   article: {
     regex: /^(ART-[A-Z0-9]+-\d{6}|ART-\d{4})$/,
     example: "ART-USI-000042",


### PR DESCRIPTION
Release du bounded context Commandes fournisseurs (BCF) validé sur dev.

- Module `commande-fournisseur` complet (machine d'état 9 statuts, RBAC capacités refus-par-défaut, verrou optimiste 409, code BCF-AAAA-NNNN serveur, idempotence, documents SHA-256, propositions d'achat, intégration réceptions).
- Patch `20260721_commandes_fournisseurs_core.sql` **déjà appliqué et vérifié sur cerp_test ET cerp_prod** (backups pris, ownership cerp_app, migration enregistrée) — le schéma précède le code.
- 439/439 tests, build tsc strict vert. PR source : #98. Frontend apparié : https://github.com/BigFootLime/crp-systems-web/pull/187

🤖 Generated with [Claude Code](https://claude.com/claude-code)