### PR TITLE
chore(release): synchroniser main dans dev avant #165

### DIFF
--- a/db/patches/20260721_clients_compta_fields.sql
+++ b/db/patches/20260721_clients_compta_fields.sql
@@ -1,0 +1,27 @@
+-- 20260721_clients_compta_fields.sql
+-- Référentiel client : ajout de 2 champs comptables sans équivalent existant.
+--
+-- STRICTEMENT ADDITIF : aucune colonne existante modifiée/supprimée, aucune ligne
+-- détruite, idempotent (IF NOT EXISTS partout). L'application actuelle fonctionne
+-- inchangée sans ce patch ; le read-back backend lit déjà ces colonnes de façon
+-- défensive (to_jsonb(c)->>'...') donc le code peut coexister avec ou sans patch.
+-- Ordre de release : appliquer ce patch (cerp_test d'abord) AVANT de déployer le code
+-- qui écrit ces colonnes.
+-- Verify   : db/patches/support/20260721_clients_compta_fields.verify.sql
+-- Rollback : db/patches/support/20260721_clients_compta_fields.rollback.sql
+--
+-- Contenu :
+--   1. compte_tiers     — compte tiers comptable (compte auxiliaire du grand livre,
+--                         pour le rapprochement comptabilité). Distinct du client_code
+--                         CERP (identité fonctionnelle générée serveur, ADR-0013).
+--   2. groupe_financier — groupe de consolidation financière (société mère / groupe
+--                         de facturation), pour regrouper plusieurs clients.
+
+BEGIN;
+
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS compte_tiers text NULL;
+ALTER TABLE public.clients
+  ADD COLUMN IF NOT EXISTS groupe_financier text NULL;
+
+COMMIT;

--- a/db/patches/support/20260721_clients_compta_fields.rollback.sql
+++ b/db/patches/support/20260721_clients_compta_fields.rollback.sql
@@ -1,0 +1,15 @@
+-- 20260721_clients_compta_fields.rollback.sql
+-- Rollback — À N'EXÉCUTER QUE SUR DÉCISION HUMAINE EXPLICITE.
+-- Le patch étant strictement additif, ce rollback retire uniquement ce qu'il a ajouté.
+-- PERTE DE DONNÉES ASSUMÉE : les valeurs compte_tiers/groupe_financier saisies sont
+-- supprimées. Aucune donnée préexistante n'est touchée.
+-- Après rollback, retirer aussi la ligne correspondante de public.cerp_schema_migrations
+-- si l'on veut ré-appliquer le patch :
+--   DELETE FROM public.cerp_schema_migrations WHERE filename = '20260721_clients_compta_fields.sql';
+
+BEGIN;
+
+ALTER TABLE public.clients DROP COLUMN IF EXISTS groupe_financier;
+ALTER TABLE public.clients DROP COLUMN IF EXISTS compte_tiers;
+
+COMMIT;

--- a/db/patches/support/20260721_clients_compta_fields.verify.sql
+++ b/db/patches/support/20260721_clients_compta_fields.verify.sql
@@ -1,0 +1,10 @@
+-- 20260721_clients_compta_fields.verify.sql
+-- Vérification post-application (lecture seule, aucun effet de bord).
+-- Usage : psql "$DATABASE_URL" -f db/patches/support/20260721_clients_compta_fields.verify.sql
+-- Attendu : chaque colonne présente (ok=true).
+
+SELECT
+  COUNT(*) FILTER (WHERE column_name = 'compte_tiers')     = 1 AS has_compte_tiers,
+  COUNT(*) FILTER (WHERE column_name = 'groupe_financier') = 1 AS has_groupe_financier
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'clients';

--- a/src/module/client/controllers/client.controller.ts
+++ b/src/module/client/controllers/client.controller.ts
@@ -127,8 +127,11 @@ export const listClients: RequestHandler = async (req, res, next) => {
           ? req.query.limit
           : NaN;
 
-    const limitCandidate = Number.isFinite(limitCandidateRaw) ? limitCandidateRaw : 25;
-    const limit = Math.min(Math.max(limitCandidate, 1), 100);
+    // Défaut relevé (25 -> 2000) et plafond (100 -> 2000) pour que la liste clients
+    // affiche l'intégralité du parc (191 fiches importées depuis Clipper) sans
+    // pagination côté UI. Pagination = évolution ciblée si le parc dépasse ce seuil.
+    const limitCandidate = Number.isFinite(limitCandidateRaw) ? limitCandidateRaw : 2000;
+    const limit = Math.min(Math.max(limitCandidate, 1), 2000);
 
     const rows = await clientService.listClients(q, limit);
     res.json(rows);

--- a/src/module/client/repository/client.repository.ts
+++ b/src/module/client/repository/client.repository.ts
@@ -157,6 +157,7 @@ async function insertClient(
     observations, provided_documents_id,
     quality_levels,
     devise, encours_max, incoterm, langue,
+    compte_tiers, groupe_financier,
     created_by, updated_by
   ) VALUES (
     $1,$2,$3,
@@ -168,7 +169,8 @@ async function insertClient(
     NULLIF($18,''), $19,
     COALESCE($20::text[], '{}'),
     NULLIF($21,''), $22, NULLIF($23,''), NULLIF($24,''),
-    $25, $25
+    NULLIF($25,''), NULLIF($26,''),
+    $27, $27
   )
   RETURNING client_id
 `;
@@ -185,6 +187,7 @@ async function insertClient(
    dto.observations ?? "", normalizedProvidedDocsId,
    dto.quality_levels ?? [],
    dto.devise ?? "", dto.encours_max ?? null, dto.incoterm ?? "", dto.langue ?? "",
+   dto.compte_tiers ?? "", dto.groupe_financier ?? "",
    createdBy
 ]);
 
@@ -524,6 +527,8 @@ export async function repoPatchClient(
     if (has("encours_max")) put((p) => `encours_max = ${p}`, patch.encours_max ?? null);
     if (has("incoterm")) put((p) => `incoterm = NULLIF(${p}, '')`, patch.incoterm ?? "");
     if (has("langue")) put((p) => `langue = NULLIF(${p}, '')`, patch.langue ?? "");
+    if (has("compte_tiers")) put((p) => `compte_tiers = NULLIF(${p}, '')`, patch.compte_tiers ?? "");
+    if (has("groupe_financier")) put((p) => `groupe_financier = NULLIF(${p}, '')`, patch.groupe_financier ?? "");
     // Réactivation : repasser en prospect/client efface l'horodatage d'archivage.
     if (has("status") && patch.status && patch.status !== "inactif") {
       sets.push("archived_at = NULL");

--- a/src/module/client/repository/clients.read.repository.ts
+++ b/src/module/client/repository/clients.read.repository.ts
@@ -75,6 +75,10 @@ export async function repoGetClientById(clientId: string, options: ClientReadOpt
       NULLIF(btrim(to_jsonb(c)->>'encours_max'), '')::numeric AS encours_max,
       NULLIF(btrim(to_jsonb(c)->>'incoterm'), '') AS incoterm,
       NULLIF(btrim(to_jsonb(c)->>'langue'), '') AS langue,
+      -- Champs compta — lecture défensive : n'échoue pas si le patch
+      -- 20260721_clients_compta_fields n'est pas encore appliqué.
+      NULLIF(btrim(to_jsonb(c)->>'compte_tiers'), '') AS compte_tiers,
+      NULLIF(btrim(to_jsonb(c)->>'groupe_financier'), '') AS groupe_financier,
 
       -- biller
       f.biller_id, f.biller_name,
@@ -140,6 +144,8 @@ export async function repoGetClientById(clientId: string, options: ClientReadOpt
       encours_max: r.encours_max === null || typeof r.encours_max === "undefined" ? null : Number(r.encours_max),
       incoterm: r.incoterm ?? null,
       langue: r.langue ?? null,
+      compte_tiers: r.compte_tiers ?? null,
+      groupe_financier: r.groupe_financier ?? null,
     },
     biller: r.biller_id
       ? { id: r.biller_id, name: r.biller_name }
@@ -270,6 +276,9 @@ export async function repoListClients(q: string, limit = 25) {
       c.siret, c.vat_number, c.naf_code,
       c.status, c.blocked, c.reason, c.creation_date,
       c.observations, c.provided_documents_id,
+      -- Champs compta — lecture défensive (PK client_id → dépendance fonctionnelle OK sous GROUP BY).
+      NULLIF(btrim(to_jsonb(c)->>'compte_tiers'), '') AS compte_tiers,
+      NULLIF(btrim(to_jsonb(c)->>'groupe_financier'), '') AS groupe_financier,
 
       -- Adresse de facturation (aplaties)
       af.name  AS bill_name,
@@ -345,6 +354,7 @@ export async function repoListClients(q: string, limit = 25) {
     creation_date: string;
     observations: string | null;
     provided_documents_id: string | null;
+    compte_tiers: string | null; groupe_financier: string | null;
 
     bill_name: string | null; bill_street: string | null; bill_house_number: string | null;
     bill_postal_code: string | null; bill_city: string | null; bill_country: string | null;

--- a/src/module/client/validators/client.validators.ts
+++ b/src/module/client/validators/client.validators.ts
@@ -259,6 +259,12 @@ export const createClientSchema = z.object({
     emptyStringToUndefined,
     z.string().trim().regex(langueRegex, "Code langue à 2 lettres (ex. fr)").transform((v) => v.toLowerCase()).optional()
   ),
+  // Champs comptables du référentiel client (patch 20260721_clients_compta_fields requis).
+  // compte_tiers : compte tiers comptable (compte auxiliaire, rapprochement compta).
+  // groupe_financier : groupe de consolidation financière. Validation permissive
+  // (bornes de longueur) : ne jamais rejeter une donnée d'import.
+  compte_tiers: z.preprocess(emptyStringToUndefined, z.string().trim().max(64, "Compte tiers trop long").optional()),
+  groupe_financier: z.preprocess(emptyStringToUndefined, z.string().trim().max(120, "Groupe financier trop long").optional()),
 });
 
 export type CreateClientDTO = z.infer<typeof createClientSchema>;


### PR DESCRIPTION
Synchronise main dans dev avant la release du parc machines #165 et preserve les correctifs Clients deja presents sur main. Validation locale : suite backend complete reussie ; le quality gate GitHub fera foi pour le typecheck verrouille.

## Summary by Sourcery

Add new accounting fields to the client referential and align backend, database patch, and validation to support them, while increasing the client list pagination limit to cover the full machine park.

New Features:
- Expose new compta fields compte_tiers and groupe_financier in client read and list endpoints.
- Allow creating and patching clients with optional compte_tiers and groupe_financier values.

Enhancements:
- Increase the client list default and maximum limit to 2000 entries to display the full client park without UI pagination.

Build:
- Add additive, idempotent database migration to introduce compte_tiers and groupe_financier columns on public.clients, with associated rollback and verification scripts.