### PR TITLE
release: gouvernance parc machines #165

### DIFF
--- a/db/patches/20260722_machine_park_165.sql
+++ b/db/patches/20260722_machine_park_165.sql
@@ -1,0 +1,195 @@
+-- Issue #165 — Machine park, availability and maintenance governance.
+-- Additive/idempotent repository patch. Apply to cerp_test only after preflight.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.machines') IS NULL
+     OR to_regclass('public.production_machine_models') IS NULL
+     OR to_regclass('public.planning_events') IS NULL
+     OR to_regclass('public.production_machine_documents') IS NULL THEN
+    RAISE EXCEPTION '#165 prerequisites missing: machines, production_machine_models, planning_events and production_machine_documents are required';
+  END IF;
+  IF to_regprocedure('public.fn_next_issued_code_value(text)') IS NULL THEN
+    RAISE EXCEPTION '#165 prerequisite missing: fn_next_issued_code_value(text)';
+  END IF;
+END $$;
+
+-- Extend the existing non-reusable allocator whitelist with the stable machine scope.
+CREATE OR REPLACE FUNCTION public.fn_next_issued_code_value(p_scope text)
+RETURNS bigint
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+DECLARE
+  v_scope text := upper(btrim(COALESCE(p_scope, '')));
+BEGIN
+  IF v_scope !~ '^(CLI|FOU|MCH|ART:[A-Z0-9]{1,48}|(DEV|CMD|AFF|OF|LOT|MVT|CQ|NC|CAPA|BL|FACT|BCF):[0-9]{4})$' THEN
+    RAISE EXCEPTION 'Unsupported business-code sequence scope: %', p_scope
+      USING ERRCODE = '22023';
+  END IF;
+  RETURN nextval('public.cerp_business_code_issue_seq'::regclass);
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_next_issued_code_value(text) IS
+  'Whitelisted, non-reusable business-code allocator. #165 adds MCH for physical machines.';
+
+-- A missing rate is materially different from a zero rate.
+ALTER TABLE public.machines ALTER COLUMN hourly_rate DROP DEFAULT;
+ALTER TABLE public.machines ALTER COLUMN hourly_rate DROP NOT NULL;
+ALTER TABLE public.machines
+  ADD COLUMN IF NOT EXISTS hourly_rate_source text NULL,
+  ADD COLUMN IF NOT EXISTS hourly_rate_effective_at date NULL,
+  ADD COLUMN IF NOT EXISTS hourly_rate_is_override boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS legacy_alias text NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'machines_hourly_rate_source_ck'
+      AND conrelid = 'public.machines'::regclass
+  ) THEN
+    ALTER TABLE public.machines
+      ADD CONSTRAINT machines_hourly_rate_source_ck
+      CHECK (hourly_rate_source IS NULL OR hourly_rate_source IN ('INTERNAL_COST', 'POSTE_INHERITED', 'IMPORTED', 'MANUAL_OVERRIDE', 'UNKNOWN'));
+  END IF;
+END $$;
+
+UPDATE public.machines
+SET hourly_rate_source = 'UNKNOWN'
+WHERE hourly_rate IS NOT NULL
+  AND hourly_rate_source IS NULL;
+
+CREATE OR REPLACE FUNCTION public.fn_prevent_machine_code_mutation()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.code IS DISTINCT FROM NEW.code THEN
+    RAISE EXCEPTION 'Machine code is immutable' USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prevent_machine_code_mutation ON public.machines;
+CREATE TRIGGER trg_prevent_machine_code_mutation
+BEFORE UPDATE OF code ON public.machines
+FOR EACH ROW EXECUTE FUNCTION public.fn_prevent_machine_code_mutation();
+
+CREATE TABLE IF NOT EXISTS public.production_machine_idempotence (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  machine_id uuid NOT NULL REFERENCES public.machines(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT production_machine_idempotence_key_uq UNIQUE (idempotency_key),
+  CONSTRAINT production_machine_idempotence_key_len CHECK (char_length(idempotency_key) BETWEEN 8 AND 200)
+);
+
+CREATE TABLE IF NOT EXISTS public.production_machine_maintenance_plans (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  machine_id uuid NOT NULL REFERENCES public.machines(id) ON DELETE RESTRICT,
+  title text NOT NULL,
+  status text NOT NULL DEFAULT 'ACTIVE',
+  frequency_days integer NULL,
+  frequency_counter numeric(14,3) NULL,
+  counter_unit text NULL,
+  next_due_at date NULL,
+  responsible_user_id integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  checklist jsonb NOT NULL DEFAULT '[]'::jsonb,
+  document_id uuid NULL REFERENCES public.production_machine_documents(id) ON DELETE SET NULL,
+  source text NOT NULL DEFAULT 'internal',
+  notes text NULL,
+  version integer NOT NULL DEFAULT 1,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  updated_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  archived_at timestamptz NULL,
+  archived_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  CONSTRAINT production_machine_maintenance_status_ck CHECK (status IN ('ACTIVE', 'PAUSED', 'COMPLETED')),
+  CONSTRAINT production_machine_maintenance_frequency_ck CHECK (frequency_days IS NULL OR frequency_days > 0),
+  CONSTRAINT production_machine_maintenance_counter_ck CHECK (frequency_counter IS NULL OR frequency_counter > 0),
+  CONSTRAINT production_machine_maintenance_checklist_ck CHECK (jsonb_typeof(checklist) = 'array')
+);
+
+CREATE TABLE IF NOT EXISTS public.production_machine_unavailability (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  machine_id uuid NOT NULL REFERENCES public.machines(id) ON DELETE RESTRICT,
+  planning_event_id uuid NOT NULL REFERENCES public.planning_events(id) ON DELETE RESTRICT,
+  cause text NOT NULL,
+  comment text NULL,
+  source text NOT NULL DEFAULT 'machine_park',
+  maintenance_plan_id uuid NULL REFERENCES public.production_machine_maintenance_plans(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  updated_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  archived_at timestamptz NULL,
+  archived_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  CONSTRAINT production_machine_unavailability_event_uq UNIQUE (planning_event_id),
+  CONSTRAINT production_machine_unavailability_cause_ck CHECK (cause IN (
+    'PREVENTIVE_MAINTENANCE', 'BREAKDOWN', 'QUALIFICATION', 'RESERVATION',
+    'WORKSHOP_CLOSURE', 'OPERATOR_ABSENCE', 'OTHER'
+  ))
+);
+
+CREATE TABLE IF NOT EXISTS public.production_machine_maintenance_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  machine_id uuid NOT NULL REFERENCES public.machines(id) ON DELETE RESTRICT,
+  maintenance_plan_id uuid NULL REFERENCES public.production_machine_maintenance_plans(id) ON DELETE SET NULL,
+  event_type text NOT NULL,
+  occurred_at timestamptz NOT NULL DEFAULT now(),
+  due_at timestamptz NULL,
+  planning_event_id uuid NULL REFERENCES public.planning_events(id) ON DELETE SET NULL,
+  unavailability_id uuid NULL REFERENCES public.production_machine_unavailability(id) ON DELETE SET NULL,
+  checklist_result jsonb NOT NULL DEFAULT '[]'::jsonb,
+  notes text NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  CONSTRAINT production_machine_maintenance_event_type_ck CHECK (event_type IN ('SCHEDULED', 'STARTED', 'COMPLETED', 'CANCELLED', 'NOTE')),
+  CONSTRAINT production_machine_maintenance_event_checklist_ck CHECK (jsonb_typeof(checklist_result) = 'array')
+);
+
+ALTER TABLE public.production_machine_documents
+  ADD COLUMN IF NOT EXISTS revision text NULL,
+  ADD COLUMN IF NOT EXISTS sha256 text NULL,
+  ADD COLUMN IF NOT EXISTS mime_type text NULL,
+  ADD COLUMN IF NOT EXISTS size_bytes bigint NULL,
+  ADD COLUMN IF NOT EXISTS authored_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now(),
+  ADD COLUMN IF NOT EXISTS removed_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS removed_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL;
+
+ALTER TABLE public.production_machine_documents
+  DROP CONSTRAINT IF EXISTS production_machine_documents_type_ck;
+ALTER TABLE public.production_machine_documents
+  ADD CONSTRAINT production_machine_documents_type_ck CHECK (
+    document_type IN ('OFFICIAL_PAGE', 'BROCHURE_PDF', 'MANUAL', 'IMAGE', 'RESALE_LISTING', 'INTERNAL_NOTE',
+                      'CERTIFICATE', 'MAINTENANCE', 'PHOTO', 'MODEL_3D')
+  );
+
+CREATE INDEX IF NOT EXISTS production_machine_idempotence_machine_idx
+  ON public.production_machine_idempotence(machine_id);
+CREATE INDEX IF NOT EXISTS production_machine_maintenance_machine_due_idx
+  ON public.production_machine_maintenance_plans(machine_id, next_due_at)
+  WHERE archived_at IS NULL;
+CREATE INDEX IF NOT EXISTS production_machine_unavailability_machine_idx
+  ON public.production_machine_unavailability(machine_id, created_at DESC)
+  WHERE archived_at IS NULL;
+CREATE INDEX IF NOT EXISTS production_machine_maintenance_events_machine_idx
+  ON public.production_machine_maintenance_events(machine_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS production_machine_documents_active_idx
+  ON public.production_machine_documents(machine_id, machine_model_id)
+  WHERE removed_at IS NULL;
+
+COMMENT ON TABLE public.production_machine_unavailability IS
+  'Machine unavailability metadata. The canonical interval is the linked planning_events row.';
+COMMENT ON TABLE public.production_machine_maintenance_events IS
+  'Append-only maintenance history. Corrections are represented by a new event.';
+COMMENT ON COLUMN public.machines.legacy_alias IS
+  'Optional legacy/import alias; never used as a PK or FK.';
+
+COMMIT;

--- a/db/patches/support/20260722_machine_park_165.preflight.sql
+++ b/db/patches/support/20260722_machine_park_165.preflight.sql
@@ -1,0 +1,22 @@
+\set ON_ERROR_STOP on
+
+SELECT
+  to_regclass('public.machines') IS NOT NULL AS has_machines,
+  to_regclass('public.production_machine_models') IS NOT NULL AS has_machine_models,
+  to_regclass('public.planning_events') IS NOT NULL AS has_planning_events,
+  to_regprocedure('public.fn_next_issued_code_value(text)') IS NOT NULL AS has_code_allocator;
+
+SELECT
+  count(*) AS machines,
+  count(*) FILTER (WHERE hourly_rate = 0) AS zero_rates_to_review,
+  count(*) FILTER (WHERE archived_at IS NOT NULL) AS archived_machines
+FROM public.machines;
+
+SELECT prosrc ~ 'MCH' AS whitelist_already_has_mch
+FROM pg_proc
+WHERE proname = 'fn_next_issued_code_value' AND pronamespace = 'public'::regnamespace;
+
+SELECT EXISTS (
+  SELECT 1 FROM public.cerp_schema_migrations
+  WHERE filename = '20260722_machine_park_165.sql'
+) AS migration_already_recorded;

--- a/db/patches/support/20260722_machine_park_165.rollback.sql
+++ b/db/patches/support/20260722_machine_park_165.rollback.sql
@@ -1,0 +1,25 @@
+\set ON_ERROR_STOP on
+BEGIN;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM public.production_machine_maintenance_events)
+     OR EXISTS (SELECT 1 FROM public.production_machine_unavailability)
+     OR EXISTS (SELECT 1 FROM public.production_machine_maintenance_plans)
+     OR EXISTS (SELECT 1 FROM public.production_machine_idempotence) THEN
+    RAISE EXCEPTION '#165 rollback refused: business rows exist; preserve industrial traceability';
+  END IF;
+END $$;
+
+DROP TABLE IF EXISTS public.production_machine_maintenance_events;
+DROP TABLE IF EXISTS public.production_machine_unavailability;
+DROP TABLE IF EXISTS public.production_machine_maintenance_plans;
+DROP TABLE IF EXISTS public.production_machine_idempotence;
+
+-- The inert MCH whitelist entry, nullable rate semantics, immutable-code trigger and
+-- additive document metadata are intentionally preserved by the safe rollback.
+DELETE FROM public.cerp_schema_migrations
+WHERE filename = '20260722_machine_park_165.sql'
+  AND to_regclass('public.production_machine_unavailability') IS NULL;
+
+COMMIT;

--- a/db/patches/support/20260722_machine_park_165.verify.sql
+++ b/db/patches/support/20260722_machine_park_165.verify.sql
@@ -1,0 +1,32 @@
+\set ON_ERROR_STOP on
+
+SELECT
+  to_regclass('public.production_machine_idempotence') IS NOT NULL AS has_idempotence,
+  to_regclass('public.production_machine_maintenance_plans') IS NOT NULL AS has_maintenance_plans,
+  to_regclass('public.production_machine_unavailability') IS NOT NULL AS has_unavailability,
+  to_regclass('public.production_machine_maintenance_events') IS NOT NULL AS has_maintenance_events;
+
+SELECT
+  is_nullable,
+  column_default
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'machines' AND column_name = 'hourly_rate';
+
+SELECT prosrc ~ 'MCH' AS whitelist_has_mch
+FROM pg_proc
+WHERE proname = 'fn_next_issued_code_value' AND pronamespace = 'public'::regnamespace;
+
+DO $$
+DECLARE v bigint;
+BEGIN
+  BEGIN
+    v := public.fn_next_issued_code_value('ROGUE');
+    RAISE EXCEPTION 'verify FAILED: rogue code scope accepted';
+  EXCEPTION WHEN SQLSTATE '22023' THEN
+    RAISE NOTICE 'ok: rogue code scope rejected';
+  END;
+END $$;
+
+SELECT indexname FROM pg_indexes
+WHERE schemaname = 'public' AND indexname LIKE 'production_machine_%'
+ORDER BY indexname;

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -94,3 +94,9 @@ The VSM file category is enforced by the dedicated
 `project_evidence_files_category_check` table constraint. The patch deliberately
 does not alter the historical `po_evidence_type` enum, which can be owned by the
 administrative PostgreSQL role while runtime patches are executed by `cerp_app`.
+
+## Issue #165 - Parc machines
+
+Patch `20260722_machine_park_165.sql` is additive and idempotent. It reserves the central `MCH` scope, makes unknown hourly rates nullable with explicit provenance, adds a legacy alias, enforces code immutability, records creation idempotency, links machine unavailability to canonical `planning_events`, and adds maintenance plans/events plus document metadata/removal fields.
+
+Before any application, run `db/patches/support/20260722_machine_park_165.preflight.sql`. Apply only to `cerp_test` after an approved backup, then run `20260722_machine_park_165.verify.sql`. The guarded rollback refuses to drop structures once machine-park business rows exist and intentionally preserves rate provenance/code immutability where reverting would lose traceability. No #165 script is authorized to write `cerp_prod` without a later human production decision.

--- a/docs/http/machine-park.md
+++ b/docs/http/machine-park.md
@@ -1,0 +1,52 @@
+# API Parc machines — issue #165
+
+Base : `/api/v1/production`. Toutes les routes exigent une session authentifiee et une capacite Machine. Les payloads sont Zod `strict` ; les identifiants sont des UUID opaques.
+
+## Machines et modeles
+
+| Methode | Route | Capacite | Objet |
+| --- | --- | --- | --- |
+| GET | `/machines` | `read` | Liste paginee, recherche, filtres type/statut/disponibilite/archive |
+| GET | `/machines/:id` | `read` | Detail instance + modele/specs/capacites/outillages/documents |
+| POST | `/machines/onboarding` | `create` | Creation transactionnelle multipart (`data`, `image?`), `Idempotency-Key` |
+| PATCH | `/machines/:id/onboarding` | `update` (+ `model_update` si partage) | Edition avec `expected_updated_at`, confirmation/diff modele |
+| DELETE | `/machines/:id` | `archive` | Archive logique |
+| POST | `/machines/:id/reactivate` | `restore` | Reactivation avec `expected_updated_at` |
+| GET | `/machine-models` / `/:id` | `read` | Catalogue et detail du modele partage |
+
+Le client ne fournit jamais `code` ni `is_available`. Le serveur alloue `MCH-{SEQ6}` dans la transaction. Un taux horaire non nul exige source/date ; les champs de cout sont retires des DTO sans `costs`.
+
+## Disponibilite et maintenance
+
+| Methode | Route | Capacite | Objet |
+| --- | --- | --- | --- |
+| GET | `/machines/:id/context` | `read` | Disponibilite actuelle, prochaines periodes, maintenance due, charge/OF ; capacite `null` + raison si incalculable |
+| GET/POST | `/machines/:id/unavailability` | `read` / `availability` | Periodes liees aux `planning_events` canoniques |
+| DELETE | `/machines/:id/unavailability/:unavailabilityId` | `availability` | Archive la periode et annule/archive l'evenement Planning |
+| GET/POST | `/machines/:id/maintenance/plans` | `read` / `maintenance` | Plans date/frequence/checklist |
+| PATCH | `/machines/:id/maintenance/plans/:planId` | `maintenance` | Verrou `expected_updated_at`, audit before/after |
+| GET/POST | `/machines/:id/maintenance/events` | `read` / `maintenance` | Historique append-only ; completion recalcule la prochaine date si possible |
+
+Les intervalles sont `[start_ts, end_ts)`. Une fin egale au prochain debut est admise ; un chevauchement renvoie `409 MACHINE_UNAVAILABILITY_OVERLAP`.
+
+## Documents
+
+| Methode | Route | Capacite | Objet |
+| --- | --- | --- | --- |
+| GET | `/machines/:id/documents` | `read` | Metadonnees actives sans `storage_path` |
+| POST | `/machines/:id/documents` | `documents` | Enregistre un lien externe source |
+| POST | `/machines/:id/documents/upload` | `documents` | Multipart `data` JSON + `document`, 50 Mo maximum |
+| GET | `/machines/:id/documents/:documentId/download` | `read` | Telechargement authentifie, controle horizontal, audit |
+| DELETE | `/machines/:id/documents/:documentId` | `documents` | Retrait logique |
+
+Le depot controle extension, MIME et signature, calcule SHA-256, conserve type/revision/taille/provenance et n'expose jamais le chemin interne. Formats : PDF, images, texte/CSV, bureautique et STEP/STL.
+
+## Erreurs stables principales
+
+- `400 INVALID_JSON`, `UNSUPPORTED_FILE_TYPE`, `UNSUPPORTED_MIME_TYPE`, `FILE_SIGNATURE_MISMATCH`
+- `403 MACHINE_FORBIDDEN`
+- `404 MACHINE_NOT_FOUND`, `MACHINE_DOCUMENT_NOT_FOUND`, `MACHINE_DOCUMENT_FILE_NOT_FOUND`
+- `409 CONCURRENT_MODIFICATION`, `CONCURRENT_MODEL_MODIFICATION`, `IDEMPOTENCY_KEY_REUSED`, `MACHINE_UNAVAILABILITY_OVERLAP`
+- `422 SHARED_MODEL_CONFIRMATION_REQUIRED`, `MACHINE_MODEL_REQUIRED_FOR_INTELLIGENCE`, `MAINTENANCE_PLAN_INVALID`
+
+Le middleware global complete les erreurs avec le request ID selon le contrat HTTP commun.

--- a/src/__tests__/codification-business-codes.test.ts
+++ b/src/__tests__/codification-business-codes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   generateArticleBusinessCode,
+  generateMachineCode,
   generateTransactionalBusinessCode,
   previewPieceTechniqueCode,
 } from "../shared/codes/code-generator.service";
@@ -42,6 +43,13 @@ describe("Codification métier centralisée", () => {
     await expect(generateTransactionalBusinessCode(sequenceTx(7).tx as never, { prefix: "CMD", date })).resolves.toBe("CMD-2026-0007");
     await expect(generateTransactionalBusinessCode(sequenceTx(7).tx as never, { prefix: "AFF", date })).resolves.toBe("AFF-2026-0007");
     await expect(generateTransactionalBusinessCode(sequenceTx(7).tx as never, { prefix: "OF", date })).resolves.toBe("OF-2026-000007");
+  });
+
+  it("reserve le code machine MCH transactionnellement dans le registre central", async () => {
+    const { tx, calls } = sequenceTx(42);
+    await expect(generateMachineCode(tx as never)).resolves.toBe("MCH-000042");
+    expect(calls[0]?.sql).toContain("fn_next_issued_code_value");
+    expect(calls[0]?.values).toEqual(["MCH"]);
   });
 
   it("expose les formats canoniques tout en gardant les références historiques lisibles", () => {

--- a/src/__tests__/machine-park.migration-guards.test.ts
+++ b/src/__tests__/machine-park.migration-guards.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const patch = readFileSync(resolve(root, "db/patches/20260722_machine_park_165.sql"), "utf8");
+const preflight = readFileSync(resolve(root, "db/patches/support/20260722_machine_park_165.preflight.sql"), "utf8");
+const verify = readFileSync(resolve(root, "db/patches/support/20260722_machine_park_165.verify.sql"), "utf8");
+const rollback = readFileSync(resolve(root, "db/patches/support/20260722_machine_park_165.rollback.sql"), "utf8");
+const intelligenceRepo = readFileSync(resolve(root, "src/module/production/repository/machine-intelligence.repository.ts"), "utf8");
+
+describe("#165 migration safety guards", () => {
+  it("uses the central MCH allocator and an immutable machine-code trigger", () => {
+    expect(patch).toMatch(/\bMCH\b/);
+    expect(patch).toContain("fn_prevent_machine_code_mutation");
+    expect(patch).toContain("Machine code is immutable");
+    expect(patch).not.toMatch(/MAX\s*\(\s*code\s*\)/i);
+  });
+
+  it("separates unknown rate from zero and records explicit provenance", () => {
+    expect(patch).toContain("ALTER COLUMN hourly_rate DROP DEFAULT");
+    expect(patch).toContain("ALTER COLUMN hourly_rate DROP NOT NULL");
+    expect(patch).toContain("hourly_rate_source");
+    expect(patch).toContain("hourly_rate_effective_at");
+    expect(patch).toContain("hourly_rate_is_override");
+    expect(patch).toContain("SET hourly_rate_source = 'UNKNOWN'");
+  });
+
+  it("reuses canonical planning events for temporal unavailability", () => {
+    expect(patch).toContain("planning_event_id uuid NOT NULL");
+    expect(patch).toContain("REFERENCES public.planning_events(id)");
+    expect(patch).toContain("UNIQUE (planning_event_id)");
+  });
+
+  it("keeps maintenance history append-only and rollback traceability-safe", () => {
+    expect(patch).toContain("production_machine_maintenance_events");
+    expect(rollback).toContain("rollback refused: business rows exist");
+    expect(rollback).toContain("intentionally preserved");
+  });
+
+  it("provides preflight and verification without production writes", () => {
+    expect(preflight).toContain("zero_rates_to_review");
+    expect(verify).toContain("rogue code scope rejected");
+    expect(verify).toContain("has_unavailability");
+  });
+
+  it("never exposes document storage paths through the machine intelligence repository", () => {
+    expect(intelligenceRepo).not.toContain("storage_path");
+    expect(intelligenceRepo).toContain("removed_at IS NULL");
+  });
+});

--- a/src/__tests__/machine-park.validators.test.ts
+++ b/src/__tests__/machine-park.validators.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+
+import { roleHasMachineCapability, type MachineCapability } from "../module/production/domain/machine-rbac";
+import {
+  createMachineMaintenancePlanSchema,
+  createMachineUnavailabilitySchema,
+  uploadMachineDocumentSchema,
+} from "../module/production/validators/machine-park.validators";
+import {
+  createMachineSchema,
+  updateMachineSchema,
+} from "../module/production/validators/production.validators";
+
+const causes = [
+  "PREVENTIVE_MAINTENANCE",
+  "BREAKDOWN",
+  "QUALIFICATION",
+  "RESERVATION",
+  "WORKSHOP_CLOSURE",
+  "OPERATOR_ABSENCE",
+  "OTHER",
+] as const;
+
+const validPeriods = causes.flatMap((cause, causeIndex) =>
+  Array.from({ length: 12 }, (_, index) => {
+    const startHour = (causeIndex + index) % 20;
+    const endHour = startHour + 1 + (index % 3);
+    return {
+      label: `${cause}-${index + 1}`,
+      body: {
+        cause,
+        comment: cause === "OTHER" ? `Justification ${index + 1}` : null,
+        start_ts: `2026-08-${String(1 + causeIndex).padStart(2, "0")}T${String(startHour).padStart(2, "0")}:00:00.000Z`,
+        end_ts: `2026-08-${String(1 + causeIndex).padStart(2, "0")}T${String(endHour).padStart(2, "0")}:00:00.000Z`,
+      },
+    };
+  })
+);
+
+const invalidPeriods = Array.from({ length: 24 }, (_, index) => {
+  const hour = index % 20;
+  return {
+    label: `invalid-order-${index + 1}`,
+    body: {
+      cause: "BREAKDOWN",
+      comment: "Panne",
+      start_ts: `2026-09-01T${String(hour).padStart(2, "0")}:30:00.000Z`,
+      end_ts: `2026-09-01T${String(hour).padStart(2, "0")}:00:00.000Z`,
+    },
+  };
+});
+
+describe("machine park strict validation matrix", () => {
+  it.each(validPeriods)("accepts canonical period $label", ({ body }) => {
+    expect(createMachineUnavailabilitySchema.safeParse({ body }).success).toBe(true);
+  });
+
+  it.each(invalidPeriods)("rejects malformed period $label", ({ body }) => {
+    expect(createMachineUnavailabilitySchema.safeParse({ body }).success).toBe(false);
+  });
+
+  it.each(Array.from({ length: 12 }, (_, index) => index + 1))(
+    "rejects OTHER without a justification, combination %s",
+    (index) => {
+      const start = String(index).padStart(2, "0");
+      const end = String(index + 1).padStart(2, "0");
+      expect(createMachineUnavailabilitySchema.safeParse({
+        body: { cause: "OTHER", start_ts: `2026-09-02T${start}:00:00.000Z`, end_ts: `2026-09-02T${end}:00:00.000Z` },
+      }).success).toBe(false);
+    }
+  );
+
+  it.each(Array.from({ length: 12 }, (_, index) => index + 1))(
+    "accepts maintenance by due date or frequency, combination %s",
+    (index) => {
+      const body = index % 2 === 0
+        ? { title: `Controle ${index}`, frequency_days: index * 5 }
+        : { title: `Controle ${index}`, next_due_at: `2027-01-${String(index).padStart(2, "0")}` };
+      expect(createMachineMaintenancePlanSchema.safeParse({ body }).success).toBe(true);
+    }
+  );
+
+  it("keeps a missing hourly rate null and refuses client-owned machine codes", () => {
+    const base = { name: "Centre 1", type: "MILLING", status: "ACTIVE", hourly_rate: null };
+    const parsed = createMachineSchema.parse({ body: base }).body;
+    expect(parsed.hourly_rate).toBeNull();
+    expect(createMachineSchema.safeParse({ body: { ...base, code: "CLIENT-001" } }).success).toBe(false);
+    expect(createMachineSchema.safeParse({ body: { ...base, is_available: true } }).success).toBe(false);
+  });
+
+  it("requires optimistic concurrency and rejects code mutation", () => {
+    expect(updateMachineSchema.safeParse({ body: { name: "Nouveau nom" } }).success).toBe(false);
+    expect(updateMachineSchema.safeParse({ body: { code: "MCH-999999", expected_updated_at: "2026-07-22T10:00:00.000Z" } }).success).toBe(false);
+    expect(updateMachineSchema.safeParse({ body: { name: "Nouveau nom", expected_updated_at: "2026-07-22T10:00:00.000Z" } }).success).toBe(true);
+  });
+
+  it("validates private document metadata without accepting an internal path", () => {
+    const body = {
+      title: "Manuel constructeur",
+      document_type: "MANUAL",
+      revision: "B",
+      source_type: "manufacturer_pdf",
+      source_confidence: "official",
+      source_notes: "Document constructeur verifie",
+    };
+    expect(uploadMachineDocumentSchema.safeParse({ body }).success).toBe(true);
+    expect(uploadMachineDocumentSchema.safeParse({ body: { ...body, storage_path: "C:/secret/manual.pdf" } }).success).toBe(false);
+  });
+});
+
+describe("machine park RBAC deny-by-default matrix", () => {
+  const capabilities: MachineCapability[] = ["read", "create", "update", "archive", "restore", "model_update", "availability", "maintenance", "documents", "costs"];
+
+  it.each(capabilities)("denies anonymous role for %s", (capability) => {
+    expect(roleHasMachineCapability("", capability)).toBe(false);
+    expect(roleHasMachineCapability(undefined, capability)).toBe(false);
+  });
+
+  it.each(capabilities)("grants administrator role for %s", (capability) => {
+    expect(roleHasMachineCapability("Administrateur", capability)).toBe(true);
+  });
+
+  it("separates operational and sensitive capabilities", () => {
+    expect(roleHasMachineCapability("Atelier", "availability")).toBe(true);
+    expect(roleHasMachineCapability("Atelier", "archive")).toBe(false);
+    expect(roleHasMachineCapability("Maintenance", "maintenance")).toBe(true);
+    expect(roleHasMachineCapability("Maintenance", "costs")).toBe(false);
+    expect(roleHasMachineCapability("Comptabilite", "costs")).toBe(true);
+    expect(roleHasMachineCapability("Comptabilite", "update")).toBe(false);
+  });
+});

--- a/src/__tests__/production-machine-intelligence.routes.test.ts
+++ b/src/__tests__/production-machine-intelligence.routes.test.ts
@@ -35,7 +35,7 @@ vi.mock("../utils/checkNetworkDrive", () => ({
 
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authenticateToken: (req: { user?: { id: number; role: string } }, _res: unknown, next: () => void) => {
-    req.user = { id: 1, role: "Atelier" };
+    req.user = { id: 1, role: "Administrateur" };
     next();
   },
   authorizeRole:
@@ -162,27 +162,18 @@ describe("/api/v1/production machine intelligence", () => {
     const modelId = "11111111-1111-1111-1111-111111111111";
     const machineId = "33333333-3333-3333-3333-333333333333";
 
-    mocks.clientQuery
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({
-        rows: [
-          {
-            id: modelId,
-            model_code: "HURCO-VM10",
-            manufacturer: "Hurco",
-            model: "VM10",
-            display_name: "Hurco VM10",
-          },
-        ],
-      })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({
-        rows: [
-          {
+    mocks.clientQuery.mockImplementation(async (statement: unknown) => {
+      const sql = String(statement);
+      if (sql.includes("production_machine_idempotence") && sql.includes("SELECT")) return { rows: [] };
+      if (sql.includes("fn_next_issued_code_value")) return { rows: [{ v: "1" }] };
+      if (sql.includes("production_machine_models") && sql.includes("RETURNING")) {
+        return { rows: [{ id: modelId, model_code: "HURCO-VM10", manufacturer: "Hurco", model: "VM10", display_name: "Hurco VM10", updated_at: "2026-06-15T08:00:00.000Z" }] };
+      }
+      if (sql.includes("INSERT INTO machines")) {
+        return {
+          rows: [{
             id: machineId,
-            code: "VM10-01",
+            code: "MCH-000001",
             name: "Hurco VM10 #1",
             type: "MILLING",
             status: "ACTIVE",
@@ -211,28 +202,26 @@ describe("/api/v1/production machine intelligence", () => {
             updated_by: 1,
             archived_at: null,
             archived_by: null,
-          },
-        ],
-      })
-      .mockResolvedValueOnce({ rows: [{ id: "audit-1", created_at: "2026-06-15T08:00:00.000Z" }] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+          }],
+        };
+      }
+      if (sql.includes("audit_log")) return { rows: [{ id: "audit-1", created_at: "2026-06-15T08:00:00.000Z" }] };
+      return { rows: [] };
+    });
 
     const res = await request(app)
       .post("/api/v1/production/machines/onboarding")
       .set("Authorization", "Bearer fake")
+      .set("Idempotency-Key", "machine-create-test-001")
       .send({
         machine: {
-          code: "VM10-01",
           name: "Hurco VM10 #1",
           type: "MILLING",
           display_name: "VM10 #1",
           brand: "Hurco",
           model: "VM10",
-          hourly_rate: 0,
           currency: "EUR",
           status: "ACTIVE",
-          is_available: true,
           scheduling_enabled: true,
           outillage_enabled: true,
           location: "Atelier principal",
@@ -265,7 +254,7 @@ describe("/api/v1/production machine intelligence", () => {
     expect(res.status).toBe(201);
     expect(res.body).toMatchObject({
       id: machineId,
-      code: "VM10-01",
+      code: "MCH-000001",
       machine_model_id: modelId,
       manufacturer: "Hurco",
       model_name: "VM10",
@@ -287,7 +276,7 @@ describe("/api/v1/production machine intelligence", () => {
     mocks.clientQuery
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({
-        rows: [{ id: machineId, machine_model_id: modelId, archived_at: null }],
+        rows: [{ id: machineId, machine_model_id: modelId, archived_at: null, updated_at: "2026-06-15T08:00:00.000Z" }],
       })
       .mockResolvedValueOnce({
         rows: [
@@ -297,6 +286,7 @@ describe("/api/v1/production machine intelligence", () => {
             manufacturer: "Hurco",
             model: "VM10",
             display_name: "Hurco VM10",
+            updated_at: "2026-06-15T08:00:00.000Z",
           },
         ],
       })
@@ -362,17 +352,15 @@ describe("/api/v1/production machine intelligence", () => {
       .set("Authorization", "Bearer fake")
       .send({
         machine: {
-          code: "VM10-01",
           name: "Hurco VM10 cellule 1",
           type: "MILLING",
           machine_model_id: modelId,
           display_name: "VM10 cellule 1",
           brand: "Hurco",
           model: "VM10",
-          hourly_rate: 0,
           currency: "EUR",
           status: "ACTIVE",
-          is_available: true,
+          expected_updated_at: "2026-06-15T08:00:00.000Z",
           model_3d_path: "/models/machines/cnc-01.glb",
           scheduling_enabled: true,
           outillage_enabled: true,
@@ -394,6 +382,8 @@ describe("/api/v1/production machine intelligence", () => {
         },
         capabilities: [{ process_type: "Fraisage 3 axes", material_family: "Aluminium", capability_level: "preferred" }],
         tooling: [{ holder_type: "CAT 40", spindle_taper: "CAT 40", compatible: true }],
+        update_shared_model: true,
+        expected_model_updated_at: "2026-06-15T08:00:00.000Z",
       });
 
     expect(res.status).toBe(200);

--- a/src/module/production/controllers/machine-park.controller.ts
+++ b/src/module/production/controllers/machine-park.controller.ts
@@ -1,0 +1,158 @@
+import fs from "node:fs/promises";
+
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { getDocumentStoragePath, isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage";
+import { HttpError } from "../../../utils/httpError";
+import { buildAuditContext } from "./production.controller";
+import {
+  createMachineMaintenanceEventSchema,
+  createMachineMaintenancePlanSchema,
+  createMachineDocumentSchema,
+  createMachineUnavailabilitySchema,
+  listMachineUnavailabilitySchema,
+  machineMaintenancePlanIdParamSchema,
+  machineDocumentIdParamSchema,
+  machineParkIdParamSchema,
+  machineUnavailabilityIdParamSchema,
+  reactivateMachineSchema,
+  updateMachineMaintenancePlanSchema,
+  uploadMachineDocumentSchema,
+} from "../validators/machine-park.validators";
+import {
+  svcArchiveMachineUnavailability,
+  svcCreateMachineMaintenanceEvent,
+  svcCreateMachineMaintenancePlan,
+  svcCreateMachineDocument,
+  svcCreateMachineUnavailability,
+  svcGetMachineParkContext,
+  svcGetMachineDocumentForDownload,
+  svcListMachineMaintenanceEvents,
+  svcListMachineMaintenancePlans,
+  svcListMachineUnavailability,
+  svcReactivateMachine,
+  svcRemoveMachineDocument,
+  svcUpdateMachineMaintenancePlan,
+  svcUploadMachineDocument,
+} from "../services/machine-park.service";
+
+export const getMachineParkContext = asyncHandler(async (req, res) => {
+  const { id } = machineParkIdParamSchema.parse({ params: req.params }).params;
+  const result = await svcGetMachineParkContext(id);
+  if (!result) {
+    res.status(404).json({ error: "MACHINE_NOT_FOUND" });
+    return;
+  }
+  res.json(result);
+});
+
+export const listMachineUnavailability = asyncHandler(async (req, res) => {
+  const { id } = machineParkIdParamSchema.parse({ params: req.params }).params;
+  const query = listMachineUnavailabilitySchema.parse({ query: req.query }).query;
+  res.json(await svcListMachineUnavailability(id, query));
+});
+
+export const createMachineUnavailability = asyncHandler(async (req, res) => {
+  const { id } = machineParkIdParamSchema.parse({ params: req.params }).params;
+  const body = createMachineUnavailabilitySchema.parse({ body: req.body }).body;
+  res.status(201).json(await svcCreateMachineUnavailability({ machineId: id, body, audit: buildAuditContext(req) }));
+});
+
+export const archiveMachineUnavailability = asyncHandler(async (req, res) => {
+  const { id, unavailabilityId } = machineUnavailabilityIdParamSchema.parse({ params: req.params }).params;
+  await svcArchiveMachineUnavailability({ machineId: id, unavailabilityId, audit: buildAuditContext(req) });
+  res.status(204).send();
+});
+
+export const listMachineMaintenancePlans = asyncHandler(async (req, res) => {
+  const { id } = machineParkIdParamSchema.parse({ params: req.params }).params;
+  res.json(await svcListMachineMaintenancePlans(id));
+});
+
+export const createMachineMaintenancePlan = asyncHandler(async (req, res) => {
+  const { id } = machineParkIdParamSchema.parse({ params: req.params }).params;
+  const body = createMachineMaintenancePlanSchema.parse({ body: req.body }).body;
+  res.status(201).json(await svcCreateMachineMaintenancePlan({ machineId: id, body, audit: buildAuditContext(req) }));
+});
+
+export const updateMachineMaintenancePlan = asyncHandler(async (req, res) => {
+  const { id, planId } = machineMaintenancePlanIdParamSchema.parse({ params: req.params }).params;
+  const body = updateMachineMaintenancePlanSchema.parse({ body: req.body }).body;
+  res.json(await svcUpdateMachineMaintenancePlan({ machineId: id, planId, body, audit: buildAuditContext(req) }));
+});
+
+export const listMachineMaintenanceEvents = asyncHandler(async (req, res) => {
+  const { id } = machineParkIdParamSchema.parse({ params: req.params }).params;
+  res.json(await svcListMachineMaintenanceEvents(id));
+});
+
+export const createMachineMaintenanceEvent = asyncHandler(async (req, res) => {
+  const { id } = machineParkIdParamSchema.parse({ params: req.params }).params;
+  const body = createMachineMaintenanceEventSchema.parse({ body: req.body }).body;
+  res.status(201).json(await svcCreateMachineMaintenanceEvent({ machineId: id, body, audit: buildAuditContext(req) }));
+});
+
+export const reactivateMachine = asyncHandler(async (req, res) => {
+  const { id } = machineParkIdParamSchema.parse({ params: req.params }).params;
+  const { expected_updated_at } = reactivateMachineSchema.parse({ body: req.body }).body;
+  await svcReactivateMachine({ machineId: id, expectedUpdatedAt: expected_updated_at, audit: buildAuditContext(req) });
+  res.status(204).send();
+});
+
+export const createMachineDocument = asyncHandler(async (req, res) => {
+  const { id } = machineParkIdParamSchema.parse({ params: req.params }).params;
+  const body = createMachineDocumentSchema.parse({ body: req.body }).body;
+  res.status(201).json(await svcCreateMachineDocument({ machineId: id, body, audit: buildAuditContext(req) }));
+});
+
+export const uploadMachineDocument = asyncHandler(async (req, res) => {
+  const { id } = machineParkIdParamSchema.parse({ params: req.params }).params;
+  if (!req.file) throw new HttpError(400, "MACHINE_DOCUMENT_FILE_REQUIRED", "A document file is required.");
+  const rawData = typeof req.body?.data === "string" ? req.body.data : null;
+  if (!rawData) {
+    await fs.unlink(req.file.path).catch(() => undefined);
+    throw new HttpError(400, "MACHINE_DOCUMENT_METADATA_REQUIRED", "Document metadata is required.");
+  }
+  let parsedData: unknown;
+  try {
+    parsedData = JSON.parse(rawData);
+  } catch {
+    await fs.unlink(req.file.path).catch(() => undefined);
+    throw new HttpError(400, "INVALID_JSON", "Invalid JSON payload in 'data'.");
+  }
+  const validation = uploadMachineDocumentSchema.safeParse({ body: parsedData });
+  if (!validation.success) {
+    await fs.unlink(req.file.path).catch(() => undefined);
+    throw validation.error;
+  }
+  const body = validation.data.body;
+  res.status(201).json(await svcUploadMachineDocument({ machineId: id, body, file: req.file, audit: buildAuditContext(req) }));
+});
+
+export const downloadMachineDocument = asyncHandler(async (req, res) => {
+  const { id, documentId } = machineDocumentIdParamSchema.parse({ params: req.params }).params;
+  const document = await svcGetMachineDocumentForDownload({ machineId: id, documentId, audit: buildAuditContext(req) });
+  if (!document) throw new HttpError(404, "MACHINE_DOCUMENT_NOT_FOUND", "Machine document not found.");
+  const baseDirectory = getDocumentStoragePath("machines");
+  const absolutePath = resolveCerpStoragePath(document.storage_path, baseDirectory);
+  if (!isPathInsideDirectory(baseDirectory, absolutePath)) {
+    throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path.");
+  }
+  try {
+    await fs.access(absolutePath);
+  } catch {
+    throw new HttpError(404, "MACHINE_DOCUMENT_FILE_NOT_FOUND", "Machine document file not found.");
+  }
+  res.setHeader("Content-Type", document.mime_type);
+  const download = req.query.download === "true" || req.query.download === "1";
+  res.setHeader(
+    "Content-Disposition",
+    `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(document.original_name)}"`
+  );
+  res.sendFile(absolutePath);
+});
+
+export const removeMachineDocument = asyncHandler(async (req, res) => {
+  const { id, documentId } = machineDocumentIdParamSchema.parse({ params: req.params }).params;
+  await svcRemoveMachineDocument({ machineId: id, documentId, audit: buildAuditContext(req) });
+  res.status(204).send();
+});

--- a/src/module/production/controllers/production.controller.ts
+++ b/src/module/production/controllers/production.controller.ts
@@ -50,6 +50,7 @@ import {
   svcUpdatePoste,
 } from "../services/production.service";
 import { svcGetMachineIntelligence } from "../services/machine-intelligence.service";
+import { roleHasMachineCapability } from "../domain/machine-rbac";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -77,7 +78,7 @@ function isMulterFile(value: unknown): value is Express.Multer.File {
   );
 }
 
-function buildAuditContext(req: Request): AuditContext {
+export function buildAuditContext(req: Request): AuditContext {
   const user = req.user;
   if (!user) throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
 
@@ -130,10 +131,37 @@ function emitOfChanged(req: Request, params: { ofId: number; action: "created" |
   });
 }
 
+function hasMachineCostMutation(value: object): boolean {
+  return ["hourly_rate", "hourly_rate_source", "hourly_rate_effective_at"].some((key) =>
+    Object.prototype.hasOwnProperty.call(value, key)
+  );
+}
+
+function assertMachineRateProvenance(value: {
+  hourly_rate?: number | null;
+  hourly_rate_source?: string | null;
+  hourly_rate_effective_at?: string | null;
+}): void {
+  if (value.hourly_rate == null) return;
+  if (!value.hourly_rate_source || !value.hourly_rate_effective_at) {
+    throw new HttpError(422, "MACHINE_RATE_PROVENANCE_REQUIRED", "A non-null hourly rate requires its source and effective date.");
+  }
+}
+
+function redactMachineCosts<T extends object>(value: T) {
+  return {
+    ...value,
+    hourly_rate: null,
+    hourly_rate_source: null,
+    hourly_rate_effective_at: null,
+    hourly_rate_is_override: false,
+  };
+}
+
 export const listMachines = asyncHandler(async (req, res) => {
   const query = listMachinesQuerySchema.parse(req.query);
   const out = await svcListMachines(query);
-  res.json(out);
+  res.json(roleHasMachineCapability(req.user?.role, "costs") ? out : { ...out, items: out.items.map(redactMachineCosts) });
 });
 
 export const getMachine = asyncHandler(async (req, res) => {
@@ -144,27 +172,40 @@ export const getMachine = asyncHandler(async (req, res) => {
     return;
   }
   const intelligence = await svcGetMachineIntelligence(id);
-  res.json({ ...out, ...(intelligence ?? {}) });
+  const detail = { ...out, ...(intelligence ?? {}) };
+  res.json(roleHasMachineCapability(req.user?.role, "costs") ? detail : redactMachineCosts(detail));
 });
 
 export const createMachine = asyncHandler(async (req, res) => {
   const audit = buildAuditContext(req);
   const raw = parseBody(req);
   const body = createMachineSchema.parse({ body: raw }).body;
+  assertMachineRateProvenance(body);
+  if (hasMachineCostMutation(body) && !roleHasMachineCapability(req.user?.role, "costs")) {
+    throw new HttpError(403, "MACHINE_COST_FORBIDDEN", "Machine cost capability required.");
+  }
   const file = (req as Request & { file?: unknown }).file;
   const imagePath = isMulterFile(file) ? file.path : null;
-  const out = await svcCreateMachine({ body, image_path: imagePath, audit });
-  res.status(201).json(out);
+  const idempotencyKey = typeof req.headers["idempotency-key"] === "string" ? req.headers["idempotency-key"].trim() : null;
+  if (idempotencyKey && (idempotencyKey.length < 8 || idempotencyKey.length > 200)) throw new HttpError(400, "INVALID_IDEMPOTENCY_KEY", "Idempotency-Key must contain 8 to 200 characters.");
+  const out = await svcCreateMachine({ body, image_path: imagePath, idempotency_key: idempotencyKey, audit });
+  res.status(201).json(roleHasMachineCapability(req.user?.role, "costs") ? out : redactMachineCosts(out));
 });
 
 export const createMachineOnboarding = asyncHandler(async (req, res) => {
   const audit = buildAuditContext(req);
   const raw = parseBody(req);
   const body = createMachineOnboardingSchema.parse({ body: raw }).body;
+  assertMachineRateProvenance(body.machine);
+  if (hasMachineCostMutation(body.machine) && !roleHasMachineCapability(req.user?.role, "costs")) {
+    throw new HttpError(403, "MACHINE_COST_FORBIDDEN", "Machine cost capability required.");
+  }
   const file = (req as Request & { file?: unknown }).file;
   const imagePath = isMulterFile(file) ? file.path : null;
-  const out = await svcCreateMachineOnboarding({ body, image_path: imagePath, audit });
-  res.status(201).json(out);
+  const idempotencyKey = typeof req.headers["idempotency-key"] === "string" ? req.headers["idempotency-key"].trim() : null;
+  if (!idempotencyKey || idempotencyKey.length < 8 || idempotencyKey.length > 200) throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "A stable Idempotency-Key containing 8 to 200 characters is required.");
+  const out = await svcCreateMachineOnboarding({ body, image_path: imagePath, idempotency_key: idempotencyKey, audit });
+  res.status(201).json(roleHasMachineCapability(req.user?.role, "costs") ? out : redactMachineCosts(out));
 });
 
 export const updateMachine = asyncHandler(async (req, res) => {
@@ -172,6 +213,10 @@ export const updateMachine = asyncHandler(async (req, res) => {
   const { id } = machineIdParamSchema.parse({ params: req.params }).params;
   const raw = parseBody(req);
   const patch = updateMachineSchema.parse({ body: raw }).body;
+  assertMachineRateProvenance(patch);
+  if (hasMachineCostMutation(patch) && !roleHasMachineCapability(req.user?.role, "costs")) {
+    throw new HttpError(403, "MACHINE_COST_FORBIDDEN", "Machine cost capability required.");
+  }
   const file = (req as Request & { file?: unknown }).file;
   const imagePath = isMulterFile(file) ? file.path : undefined;
   const out = await svcUpdateMachine({ id, patch, image_path: imagePath, audit });
@@ -179,7 +224,7 @@ export const updateMachine = asyncHandler(async (req, res) => {
     res.status(404).json({ error: "Not found" });
     return;
   }
-  res.status(200).json(out);
+  res.status(200).json(roleHasMachineCapability(req.user?.role, "costs") ? out : redactMachineCosts(out));
 });
 
 export const updateMachineOnboarding = asyncHandler(async (req, res) => {
@@ -187,6 +232,13 @@ export const updateMachineOnboarding = asyncHandler(async (req, res) => {
   const { id } = machineIdParamSchema.parse({ params: req.params }).params;
   const raw = parseBody(req);
   const body = updateMachineOnboardingSchema.parse({ body: raw }).body;
+  assertMachineRateProvenance(body.machine);
+  if (hasMachineCostMutation(body.machine) && !roleHasMachineCapability(req.user?.role, "costs")) {
+    throw new HttpError(403, "MACHINE_COST_FORBIDDEN", "Machine cost capability required.");
+  }
+  if (body.update_shared_model && !roleHasMachineCapability(req.user?.role, "model_update")) {
+    throw new HttpError(403, "MACHINE_MODEL_UPDATE_FORBIDDEN", "Shared machine model update capability required.");
+  }
   const file = (req as Request & { file?: unknown }).file;
   const imagePath = isMulterFile(file) ? file.path : undefined;
   const out = await svcUpdateMachineOnboarding({ id, body, image_path: imagePath, audit });
@@ -194,7 +246,7 @@ export const updateMachineOnboarding = asyncHandler(async (req, res) => {
     res.status(404).json({ error: "Not found" });
     return;
   }
-  res.status(200).json(out);
+  res.status(200).json(roleHasMachineCapability(req.user?.role, "costs") ? out : redactMachineCosts(out));
 });
 
 export const archiveMachine = asyncHandler(async (req, res) => {

--- a/src/module/production/domain/machine-rbac.ts
+++ b/src/module/production/domain/machine-rbac.ts
@@ -1,0 +1,30 @@
+export type MachineCapability =
+  | "read"
+  | "create"
+  | "update"
+  | "archive"
+  | "restore"
+  | "model_update"
+  | "availability"
+  | "maintenance"
+  | "documents"
+  | "costs";
+
+const NEEDLES: Record<MachineCapability, readonly string[]> = {
+  read: ["admin", "administrateur", "directeur", "production", "atelier", "maintenance", "program", "planif", "qualit", "outillage", "secr", "secret", "method"],
+  create: ["admin", "administrateur", "directeur", "production", "atelier", "maintenance", "program", "method"],
+  update: ["admin", "administrateur", "directeur", "production", "atelier", "maintenance", "program", "method"],
+  archive: ["admin", "administrateur", "directeur"],
+  restore: ["admin", "administrateur", "directeur"],
+  model_update: ["admin", "administrateur", "directeur", "program", "method"],
+  availability: ["admin", "administrateur", "directeur", "production", "atelier", "maintenance", "program", "planif"],
+  maintenance: ["admin", "administrateur", "directeur", "maintenance", "production", "atelier"],
+  documents: ["admin", "administrateur", "directeur", "maintenance", "program", "method", "qualit"],
+  costs: ["admin", "administrateur", "directeur", "compt", "program"],
+};
+
+export function roleHasMachineCapability(role: string | null | undefined, capability: MachineCapability): boolean {
+  const normalized = (role ?? "").trim().toLowerCase();
+  if (!normalized) return false;
+  return NEEDLES[capability].some((needle) => normalized.includes(needle));
+}

--- a/src/module/production/repository/machine-intelligence.repository.ts
+++ b/src/module/production/repository/machine-intelligence.repository.ts
@@ -378,13 +378,18 @@ async function selectDocuments(params: { model_id?: string | null; machine_id?: 
         title,
         document_type,
         url,
-        storage_path,
+        revision,
+        sha256,
+        mime_type,
+        size_bytes::float8 AS size_bytes,
+        authored_at::text AS authored_at,
         source_type,
         source_confidence,
         source_notes,
-        retrieved_at::text AS retrieved_at
+        retrieved_at::text AS retrieved_at,
+        removed_at::text AS removed_at
       FROM public.production_machine_documents
-      WHERE ${where.join(" OR ")}
+      WHERE (${where.join(" OR ")}) AND removed_at IS NULL
       ORDER BY
         CASE document_type
           WHEN 'MANUAL' THEN 1

--- a/src/module/production/repository/machine-park.repository.ts
+++ b/src/module/production/repository/machine-park.repository.ts
@@ -1,0 +1,618 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
+import {
+  assertDocumentUploadAllowed,
+  sha256DocumentFile,
+  toPosixStoragePath,
+} from "../../../shared/documents/document-upload";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
+import type { AuditContext } from "./production.repository";
+import type {
+  MachineMaintenanceEvent,
+  MachineMaintenancePlan,
+  MachineParkContext,
+  MachineUnavailability,
+} from "../types/machine-park.types";
+import type { MachineDocument } from "../types/machine-intelligence.types";
+import type {
+  CreateMachineDocumentBodyDTO,
+  CreateMachineMaintenanceEventBodyDTO,
+  CreateMachineMaintenancePlanBodyDTO,
+  CreateMachineUnavailabilityBodyDTO,
+  ListMachineUnavailabilityQueryDTO,
+  UpdateMachineMaintenancePlanBodyDTO,
+  UploadMachineDocumentBodyDTO,
+} from "../validators/machine-park.validators";
+
+type DbQueryer = Pick<PoolClient, "query">;
+
+export type MachineDocumentDownload = {
+  storage_path: string;
+  mime_type: string;
+  original_name: string;
+};
+
+async function audit(tx: DbQueryer, context: AuditContext, input: {
+  action: string;
+  entityType: string;
+  entityId: string;
+  details?: Record<string, unknown>;
+}) {
+  const body: CreateAuditLogBodyDTO = {
+    event_type: "ACTION",
+    action: input.action,
+    page_key: context.page_key,
+    entity_type: input.entityType,
+    entity_id: input.entityId,
+    path: context.path,
+    client_session_id: context.client_session_id,
+    details: input.details ?? null,
+  };
+  await repoInsertAuditLog({
+    user_id: context.user_id,
+    body,
+    ip: context.ip,
+    user_agent: context.user_agent,
+    device_type: context.device_type,
+    os: context.os,
+    browser: context.browser,
+    tx,
+  });
+}
+
+function isExclusionViolation(error: unknown): boolean {
+  return (error as { code?: unknown } | null)?.code === "23P01";
+}
+
+async function requireActiveMachine(tx: DbQueryer, machineId: string) {
+  const result = await tx.query<{ id: string; status: string; scheduling_enabled: boolean; archived_at: string | null }>(
+    `SELECT id::text AS id, status::text AS status, scheduling_enabled, archived_at::text AS archived_at
+       FROM public.machines WHERE id = $1::uuid FOR UPDATE`,
+    [machineId]
+  );
+  const machine = result.rows[0];
+  if (!machine) throw new HttpError(404, "MACHINE_NOT_FOUND", "Machine not found.");
+  if (machine.archived_at) throw new HttpError(409, "MACHINE_ARCHIVED", "Archived machine cannot be scheduled.");
+  return machine;
+}
+
+const UNAVAILABILITY_SELECT = `
+  SELECT
+    u.id::text AS id,
+    u.machine_id::text AS machine_id,
+    u.planning_event_id::text AS planning_event_id,
+    u.cause,
+    u.comment,
+    u.source,
+    u.maintenance_plan_id::text AS maintenance_plan_id,
+    e.start_ts::text AS start_ts,
+    e.end_ts::text AS end_ts,
+    e.status::text AS status,
+    u.created_at::text AS created_at,
+    u.created_by,
+    u.archived_at::text AS archived_at
+  FROM public.production_machine_unavailability u
+  JOIN public.planning_events e ON e.id = u.planning_event_id
+`;
+
+export async function repoListMachineUnavailability(machineId: string, query: ListMachineUnavailabilityQueryDTO): Promise<MachineUnavailability[]> {
+  const values: unknown[] = [machineId];
+  const where = ["u.machine_id = $1::uuid"];
+  if (!query.include_archived) where.push("u.archived_at IS NULL", "e.archived_at IS NULL");
+  if (query.from && query.to) {
+    values.push(query.from, query.to);
+    where.push(`tstzrange(e.start_ts, e.end_ts, '[)') && tstzrange($2::timestamptz, $3::timestamptz, '[)')`);
+  }
+  const result = await pool.query<MachineUnavailability>(
+    `${UNAVAILABILITY_SELECT} WHERE ${where.join(" AND ")} ORDER BY e.start_ts ASC`,
+    values
+  );
+  return result.rows;
+}
+
+export async function repoGetMachineParkContext(machineId: string): Promise<MachineParkContext | null> {
+  const machineResult = await pool.query<{ status: string; scheduling_enabled: boolean; archived_at: string | null }>(
+    `SELECT status::text AS status, scheduling_enabled, archived_at::text AS archived_at
+       FROM public.machines WHERE id = $1::uuid`,
+    [machineId]
+  );
+  const machine = machineResult.rows[0];
+  if (!machine) return null;
+
+  const [unavailabilityResult, dueResult, loadResult, ofsResult] = await Promise.all([
+    pool.query<MachineUnavailability>(
+      `${UNAVAILABILITY_SELECT}
+       WHERE u.machine_id = $1::uuid AND u.archived_at IS NULL AND e.archived_at IS NULL
+         AND e.status NOT IN ('DONE', 'CANCELLED') AND e.end_ts > now()
+       ORDER BY e.start_ts ASC LIMIT 25`,
+      [machineId]
+    ),
+    pool.query<MachineMaintenancePlan>(
+      `SELECT id::text AS id, machine_id::text AS machine_id, title, status,
+              frequency_days, frequency_counter::float8 AS frequency_counter, counter_unit,
+              next_due_at::text AS next_due_at, responsible_user_id, checklist,
+              document_id::text AS document_id, source, notes, version,
+              created_at::text AS created_at, updated_at::text AS updated_at,
+              archived_at::text AS archived_at
+         FROM public.production_machine_maintenance_plans
+        WHERE machine_id = $1::uuid AND archived_at IS NULL AND status = 'ACTIVE'
+          AND next_due_at IS NOT NULL AND next_due_at <= current_date + 30
+        ORDER BY next_due_at ASC`,
+      [machineId]
+    ),
+    pool.query<{ planned_minutes: number }>(
+      `SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (LEAST(end_ts, now() + interval '7 days') - GREATEST(start_ts, now()))) / 60), 0)::int AS planned_minutes
+         FROM public.planning_events
+        WHERE machine_id = $1::uuid AND archived_at IS NULL AND status NOT IN ('CANCELLED')
+          AND end_ts > now() AND start_ts < now() + interval '7 days'`,
+      [machineId]
+    ),
+    pool.query<{ id: number; numero: string; statut: string; operation_count: number }>(
+      `SELECT o.id::int AS id, o.numero, o.statut::text AS statut, count(op.id)::int AS operation_count
+         FROM public.ordres_fabrication o
+         JOIN public.of_operations op ON op.of_id = o.id
+        WHERE op.machine_id = $1::uuid AND o.statut NOT IN ('CLOTURE', 'ANNULE')
+        GROUP BY o.id, o.numero, o.statut ORDER BY o.updated_at DESC LIMIT 20`,
+      [machineId]
+    ),
+  ]);
+
+  const now = Date.now();
+  const active = unavailabilityResult.rows.find((item) => Date.parse(item.start_ts) <= now && Date.parse(item.end_ts) > now) ?? null;
+  let availableNow = true;
+  let reason = "No active unavailability in the canonical planning calendar.";
+  if (machine.archived_at) {
+    availableNow = false;
+    reason = "Machine archived.";
+  } else if (machine.status !== "ACTIVE") {
+    availableNow = false;
+    reason = `Structural status: ${machine.status}.`;
+  } else if (!machine.scheduling_enabled) {
+    availableNow = false;
+    reason = "Planning disabled for this machine.";
+  } else if (active) {
+    availableNow = false;
+    reason = `Active unavailability: ${active.cause}.`;
+  }
+
+  return {
+    available_now: availableNow,
+    availability_reason: reason,
+    active_unavailability: active,
+    upcoming_unavailability: unavailabilityResult.rows.filter((item) => Date.parse(item.start_ts) > now),
+    maintenance_due: dueResult.rows,
+    planned_minutes_next_7d: Number(loadResult.rows[0]?.planned_minutes ?? 0),
+    capacity_minutes_next_7d: null,
+    capacity_reason: "Not calculated: no canonical workshop opening-hours calendar is configured.",
+    linked_open_ofs: ofsResult.rows,
+  };
+}
+
+export async function repoCreateMachineUnavailability(params: {
+  machineId: string;
+  body: CreateMachineUnavailabilityBodyDTO;
+  audit: AuditContext;
+}): Promise<MachineUnavailability> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await requireActiveMachine(client, params.machineId);
+    if (params.body.maintenance_plan_id) {
+      const plan = await client.query(`SELECT 1 FROM public.production_machine_maintenance_plans WHERE id = $1::uuid AND machine_id = $2::uuid AND archived_at IS NULL`, [params.body.maintenance_plan_id, params.machineId]);
+      if (!plan.rowCount) throw new HttpError(422, "MAINTENANCE_PLAN_INVALID", "Maintenance plan does not belong to the machine.");
+    }
+
+    const planningEventId = crypto.randomUUID();
+    await client.query(
+      `INSERT INTO public.planning_events (
+         id, kind, status, priority, machine_id, title, description,
+         start_ts, end_ts, allow_overlap, created_by, updated_by
+       ) VALUES ($1::uuid, $2::planning_event_kind, 'PLANNED', $3::planning_priority, $4::uuid, $5, $6, $7::timestamptz, $8::timestamptz, false, $9, $9)`,
+      [
+        planningEventId,
+        params.body.cause === "PREVENTIVE_MAINTENANCE" || params.body.cause === "BREAKDOWN" ? "MAINTENANCE" : "CUSTOM",
+        params.body.cause === "BREAKDOWN" ? "CRITICAL" : "NORMAL",
+        params.machineId,
+        `Indisponibilité machine — ${params.body.cause}`,
+        params.body.comment ?? null,
+        params.body.start_ts,
+        params.body.end_ts,
+        params.audit.user_id,
+      ]
+    );
+
+    const id = crypto.randomUUID();
+    await client.query(
+      `INSERT INTO public.production_machine_unavailability (
+         id, machine_id, planning_event_id, cause, comment, source, maintenance_plan_id, created_by, updated_by
+       ) VALUES ($1::uuid, $2::uuid, $3::uuid, $4, $5, $6, $7::uuid, $8, $8)`,
+      [id, params.machineId, planningEventId, params.body.cause, params.body.comment ?? null, params.body.source, params.body.maintenance_plan_id ?? null, params.audit.user_id]
+    );
+    await audit(client, params.audit, {
+      action: "production.machines.unavailability.create",
+      entityType: "production_machine_unavailability",
+      entityId: id,
+      details: { machine_id: params.machineId, planning_event_id: planningEventId, cause: params.body.cause, start_ts: params.body.start_ts, end_ts: params.body.end_ts },
+    });
+    await client.query("COMMIT");
+    const rows = await repoListMachineUnavailability(params.machineId, { include_archived: false });
+    const created = rows.find((row) => row.id === id);
+    if (!created) throw new Error("Failed to reload machine unavailability");
+    return created;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    if (isExclusionViolation(error)) {
+      throw new HttpError(409, "MACHINE_UNAVAILABILITY_OVERLAP", "The machine already has a planning event that overlaps this period.");
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoArchiveMachineUnavailability(params: { machineId: string; unavailabilityId: string; audit: AuditContext }): Promise<boolean> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const row = await client.query<{ planning_event_id: string }>(
+      `SELECT planning_event_id::text AS planning_event_id FROM public.production_machine_unavailability
+        WHERE id = $1::uuid AND machine_id = $2::uuid AND archived_at IS NULL FOR UPDATE`,
+      [params.unavailabilityId, params.machineId]
+    );
+    const existing = row.rows[0];
+    if (!existing) throw new HttpError(404, "MACHINE_UNAVAILABILITY_NOT_FOUND", "Machine unavailability not found.");
+    await client.query(`UPDATE public.production_machine_unavailability SET archived_at = now(), archived_by = $3, updated_at = now(), updated_by = $3 WHERE id = $1::uuid AND machine_id = $2::uuid`, [params.unavailabilityId, params.machineId, params.audit.user_id]);
+    await client.query(`UPDATE public.planning_events SET status = 'CANCELLED', archived_at = now(), archived_by = $2, updated_at = now(), updated_by = $2 WHERE id = $1::uuid`, [existing.planning_event_id, params.audit.user_id]);
+    await audit(client, params.audit, { action: "production.machines.unavailability.archive", entityType: "production_machine_unavailability", entityId: params.unavailabilityId, details: { machine_id: params.machineId, planning_event_id: existing.planning_event_id } });
+    await client.query("COMMIT");
+    return true;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoListMachineMaintenancePlans(machineId: string): Promise<MachineMaintenancePlan[]> {
+  const result = await pool.query<MachineMaintenancePlan>(
+    `SELECT id::text AS id, machine_id::text AS machine_id, title, status,
+            frequency_days, frequency_counter::float8 AS frequency_counter, counter_unit,
+            next_due_at::text AS next_due_at, responsible_user_id, checklist,
+            document_id::text AS document_id, source, notes, version,
+            created_at::text AS created_at, updated_at::text AS updated_at,
+            archived_at::text AS archived_at
+       FROM public.production_machine_maintenance_plans
+      WHERE machine_id = $1::uuid AND archived_at IS NULL ORDER BY next_due_at NULLS LAST, title`,
+    [machineId]
+  );
+  return result.rows;
+}
+
+export async function repoCreateMachineMaintenancePlan(params: { machineId: string; body: CreateMachineMaintenancePlanBodyDTO; audit: AuditContext }): Promise<MachineMaintenancePlan> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await requireActiveMachine(client, params.machineId);
+    const id = crypto.randomUUID();
+    const b = params.body;
+    await client.query(
+      `INSERT INTO public.production_machine_maintenance_plans (
+         id, machine_id, title, status, frequency_days, frequency_counter, counter_unit,
+         next_due_at, responsible_user_id, checklist, document_id, source, notes, created_by, updated_by
+       ) VALUES ($1::uuid,$2::uuid,$3,$4,$5,$6,$7,$8::date,$9,$10::jsonb,$11::uuid,$12,$13,$14,$14)`,
+      [id, params.machineId, b.title, b.status, b.frequency_days ?? null, b.frequency_counter ?? null, b.counter_unit ?? null, b.next_due_at ?? null, b.responsible_user_id ?? null, JSON.stringify(b.checklist), b.document_id ?? null, b.source, b.notes ?? null, params.audit.user_id]
+    );
+    await audit(client, params.audit, { action: "production.machines.maintenance-plan.create", entityType: "production_machine_maintenance_plans", entityId: id, details: { machine_id: params.machineId, title: b.title, next_due_at: b.next_due_at } });
+    await client.query("COMMIT");
+    const created = (await repoListMachineMaintenancePlans(params.machineId)).find((row) => row.id === id);
+    if (!created) throw new Error("Failed to reload maintenance plan");
+    return created;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoUpdateMachineMaintenancePlan(params: { machineId: string; planId: string; body: UpdateMachineMaintenancePlanBodyDTO; audit: AuditContext }): Promise<MachineMaintenancePlan> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const currentResult = await client.query<MachineMaintenancePlan>(
+      `SELECT id::text AS id, machine_id::text AS machine_id, title, status, frequency_days,
+              frequency_counter::float8 AS frequency_counter, counter_unit, next_due_at::text AS next_due_at,
+              responsible_user_id, checklist, document_id::text AS document_id, source, notes, version,
+              created_at::text AS created_at, updated_at::text AS updated_at, archived_at::text AS archived_at
+         FROM public.production_machine_maintenance_plans
+        WHERE id = $1::uuid AND machine_id = $2::uuid AND archived_at IS NULL FOR UPDATE`,
+      [params.planId, params.machineId]
+    );
+    const current = currentResult.rows[0];
+    if (!current) throw new HttpError(404, "MAINTENANCE_PLAN_NOT_FOUND", "Maintenance plan not found.");
+    if (current.updated_at !== params.body.expected_updated_at) throw new HttpError(409, "CONCURRENT_MODIFICATION", "Maintenance plan has changed.");
+    const b = params.body;
+    const next = {
+      title: b.title ?? current.title,
+      status: b.status ?? current.status,
+      frequency_days: b.frequency_days === undefined ? current.frequency_days : b.frequency_days,
+      frequency_counter: b.frequency_counter === undefined ? current.frequency_counter : b.frequency_counter,
+      counter_unit: b.counter_unit === undefined ? current.counter_unit : b.counter_unit,
+      next_due_at: b.next_due_at === undefined ? current.next_due_at : b.next_due_at,
+      responsible_user_id: b.responsible_user_id === undefined ? current.responsible_user_id : b.responsible_user_id,
+      checklist: b.checklist ?? current.checklist,
+      document_id: b.document_id === undefined ? current.document_id : b.document_id,
+      source: b.source ?? current.source,
+      notes: b.notes === undefined ? current.notes : b.notes,
+    };
+    await client.query(
+      `UPDATE public.production_machine_maintenance_plans SET
+         title=$3,status=$4,frequency_days=$5,frequency_counter=$6,counter_unit=$7,next_due_at=$8::date,
+         responsible_user_id=$9,checklist=$10::jsonb,document_id=$11::uuid,source=$12,notes=$13,
+         version=version+1,updated_at=now(),updated_by=$14
+       WHERE id=$1::uuid AND machine_id=$2::uuid AND updated_at::text=$15`,
+      [params.planId, params.machineId, next.title, next.status, next.frequency_days, next.frequency_counter, next.counter_unit, next.next_due_at, next.responsible_user_id, JSON.stringify(next.checklist), next.document_id, next.source, next.notes, params.audit.user_id, params.body.expected_updated_at]
+    );
+    await audit(client, params.audit, { action: "production.machines.maintenance-plan.update", entityType: "production_machine_maintenance_plans", entityId: params.planId, details: { before: current, after: next } });
+    await client.query("COMMIT");
+    const updated = (await repoListMachineMaintenancePlans(params.machineId)).find((row) => row.id === params.planId);
+    if (!updated) throw new Error("Failed to reload maintenance plan");
+    return updated;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoListMachineMaintenanceEvents(machineId: string): Promise<MachineMaintenanceEvent[]> {
+  const result = await pool.query<MachineMaintenanceEvent>(
+    `SELECT id::text AS id, machine_id::text AS machine_id, maintenance_plan_id::text AS maintenance_plan_id,
+            event_type, occurred_at::text AS occurred_at, due_at::text AS due_at,
+            planning_event_id::text AS planning_event_id, unavailability_id::text AS unavailability_id,
+            checklist_result, notes, created_at::text AS created_at, created_by
+       FROM public.production_machine_maintenance_events
+      WHERE machine_id = $1::uuid ORDER BY occurred_at DESC, created_at DESC LIMIT 500`,
+    [machineId]
+  );
+  return result.rows;
+}
+
+export async function repoCreateMachineMaintenanceEvent(params: { machineId: string; body: CreateMachineMaintenanceEventBodyDTO; audit: AuditContext }): Promise<MachineMaintenanceEvent> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await requireActiveMachine(client, params.machineId);
+    if (params.body.maintenance_plan_id) {
+      const plan = await client.query<{ frequency_days: number | null }>(`SELECT frequency_days FROM public.production_machine_maintenance_plans WHERE id=$1::uuid AND machine_id=$2::uuid AND archived_at IS NULL FOR UPDATE`, [params.body.maintenance_plan_id, params.machineId]);
+      if (!plan.rows[0]) throw new HttpError(422, "MAINTENANCE_PLAN_INVALID", "Maintenance plan does not belong to the machine.");
+      if (params.body.event_type === "COMPLETED" && plan.rows[0].frequency_days) {
+        await client.query(`UPDATE public.production_machine_maintenance_plans SET next_due_at=COALESCE($3::timestamptz, now())::date + frequency_days, version=version+1, updated_at=now(), updated_by=$4 WHERE id=$1::uuid AND machine_id=$2::uuid`, [params.body.maintenance_plan_id, params.machineId, params.body.occurred_at ?? null, params.audit.user_id]);
+      }
+    }
+    const id = crypto.randomUUID();
+    const b = params.body;
+    await client.query(
+      `INSERT INTO public.production_machine_maintenance_events (
+         id,machine_id,maintenance_plan_id,event_type,occurred_at,due_at,checklist_result,notes,created_by
+       ) VALUES ($1::uuid,$2::uuid,$3::uuid,$4,COALESCE($5::timestamptz,now()),$6::timestamptz,$7::jsonb,$8,$9)`,
+      [id, params.machineId, b.maintenance_plan_id ?? null, b.event_type, b.occurred_at ?? null, b.due_at ?? null, JSON.stringify(b.checklist_result), b.notes ?? null, params.audit.user_id]
+    );
+    await audit(client, params.audit, { action: "production.machines.maintenance-event.create", entityType: "production_machine_maintenance_events", entityId: id, details: { machine_id: params.machineId, maintenance_plan_id: b.maintenance_plan_id, event_type: b.event_type } });
+    await client.query("COMMIT");
+    const created = (await repoListMachineMaintenanceEvents(params.machineId)).find((row) => row.id === id);
+    if (!created) throw new Error("Failed to reload maintenance event");
+    return created;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoReactivateMachine(params: { machineId: string; expectedUpdatedAt: string; audit: AuditContext }): Promise<boolean> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const updated = await client.query(
+      `UPDATE public.machines SET archived_at=NULL,archived_by=NULL,status='ACTIVE',is_available=true,updated_at=now(),updated_by=$3
+        WHERE id=$1::uuid AND archived_at IS NOT NULL AND updated_at::text=$2`,
+      [params.machineId, params.expectedUpdatedAt, params.audit.user_id]
+    );
+    if (!updated.rowCount) throw new HttpError(409, "CONCURRENT_MODIFICATION", "Machine cannot be reactivated from the supplied version.");
+    await audit(client, params.audit, { action: "production.machines.reactivate", entityType: "machines", entityId: params.machineId });
+    await client.query("COMMIT");
+    return true;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoCreateMachineDocument(params: { machineId: string; body: CreateMachineDocumentBodyDTO; audit: AuditContext }): Promise<MachineDocument> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await requireActiveMachine(client, params.machineId);
+    const id = crypto.randomUUID();
+    const b = params.body;
+    const result = await client.query<MachineDocument>(
+      `INSERT INTO public.production_machine_documents (
+         id,machine_id,title,document_type,url,revision,sha256,mime_type,size_bytes,authored_at,
+         source_type,source_confidence,source_notes,retrieved_at,created_by
+       ) VALUES ($1::uuid,$2::uuid,$3,$4,$5,$6,$7,$8,$9,$10::timestamptz,$11,$12,$13,now(),$14)
+       RETURNING id::text AS id,machine_model_id::text AS machine_model_id,machine_id::text AS machine_id,
+         title,document_type,url,revision,sha256,mime_type,size_bytes::float8 AS size_bytes,
+         authored_at::text AS authored_at,source_type,source_confidence,source_notes,
+         retrieved_at::text AS retrieved_at,removed_at::text AS removed_at`,
+      [id, params.machineId, b.title, b.document_type, b.url, b.revision ?? null, b.sha256 ?? null, b.mime_type ?? null, b.size_bytes ?? null, b.authored_at ?? null, b.source_type, b.source_confidence, b.source_notes ?? null, params.audit.user_id]
+    );
+    const created = result.rows[0];
+    if (!created) throw new Error("Failed to create machine document");
+    await audit(client, params.audit, { action: "production.machines.document.create", entityType: "production_machine_documents", entityId: id, details: { machine_id: params.machineId, document_type: b.document_type, revision: b.revision, sha256: b.sha256 } });
+    await client.query("COMMIT");
+    return created;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoUploadMachineDocument(params: {
+  machineId: string;
+  body: UploadMachineDocumentBodyDTO;
+  file: Express.Multer.File;
+  audit: AuditContext;
+}): Promise<MachineDocument> {
+  let extension: string;
+  try {
+    extension = await assertDocumentUploadAllowed(params.file);
+  } catch (error) {
+    await fs.unlink(params.file.path).catch(() => undefined);
+    throw error;
+  }
+
+  const client = await pool.connect();
+  const documentsDirectory = ensureDocumentStoragePath("machines");
+  const id = crypto.randomUUID();
+  const finalPath = path.join(documentsDirectory, `${id}${extension}`);
+  let moved = false;
+  try {
+    await client.query("BEGIN");
+    await requireActiveMachine(client, params.machineId);
+    try {
+      await fs.rename(path.resolve(params.file.path), finalPath);
+    } catch {
+      await fs.copyFile(path.resolve(params.file.path), finalPath);
+      await fs.unlink(path.resolve(params.file.path));
+    }
+    moved = true;
+    const sha256 = await sha256DocumentFile(finalPath);
+    const b = params.body;
+    const result = await client.query<MachineDocument>(
+      `INSERT INTO public.production_machine_documents (
+         id,machine_id,title,document_type,url,storage_path,revision,sha256,mime_type,size_bytes,authored_at,
+         source_type,source_confidence,source_notes,retrieved_at,created_by
+       ) VALUES ($1::uuid,$2::uuid,$3,$4,NULL,$5,$6,$7,$8,$9,$10::timestamptz,$11,$12,$13,now(),$14)
+       RETURNING id::text AS id,machine_model_id::text AS machine_model_id,machine_id::text AS machine_id,
+         title,document_type,url,revision,sha256,mime_type,size_bytes::float8 AS size_bytes,
+         authored_at::text AS authored_at,source_type,source_confidence,source_notes,
+         retrieved_at::text AS retrieved_at,removed_at::text AS removed_at`,
+      [
+        id,
+        params.machineId,
+        b.title,
+        b.document_type,
+        toPosixStoragePath(finalPath),
+        b.revision ?? null,
+        sha256,
+        params.file.mimetype,
+        params.file.size,
+        b.authored_at ?? null,
+        b.source_type,
+        b.source_confidence,
+        b.source_notes ?? null,
+        params.audit.user_id,
+      ]
+    );
+    const created = result.rows[0];
+    if (!created) throw new Error("Failed to upload machine document");
+    await audit(client, params.audit, {
+      action: "production.machines.document.upload",
+      entityType: "production_machine_documents",
+      entityId: id,
+      details: {
+        machine_id: params.machineId,
+        title: b.title,
+        document_type: b.document_type,
+        mime_type: params.file.mimetype,
+        size_bytes: params.file.size,
+        sha256,
+      },
+    });
+    await client.query("COMMIT");
+    return created;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    if (moved) await fs.unlink(finalPath).catch(() => undefined);
+    else await fs.unlink(params.file.path).catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoGetMachineDocumentForDownload(params: {
+  machineId: string;
+  documentId: string;
+  audit: AuditContext;
+}): Promise<MachineDocumentDownload | null> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await client.query<{ storage_path: string | null; mime_type: string | null; title: string }>(
+      `SELECT storage_path, mime_type, title
+         FROM public.production_machine_documents
+        WHERE id=$1::uuid AND machine_id=$2::uuid AND removed_at IS NULL
+        LIMIT 1`,
+      [params.documentId, params.machineId]
+    );
+    const document = result.rows[0];
+    if (!document?.storage_path) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+    await audit(client, params.audit, {
+      action: "production.machines.document.download",
+      entityType: "production_machine_documents",
+      entityId: params.documentId,
+      details: { machine_id: params.machineId, title: document.title },
+    });
+    await client.query("COMMIT");
+    return {
+      storage_path: document.storage_path,
+      mime_type: document.mime_type ?? "application/octet-stream",
+      original_name: document.title,
+    };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoRemoveMachineDocument(params: { machineId: string; documentId: string; audit: AuditContext }): Promise<boolean> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const updated = await client.query(
+      `UPDATE public.production_machine_documents SET removed_at=now(),removed_by=$3,updated_at=now()
+        WHERE id=$1::uuid AND machine_id=$2::uuid AND removed_at IS NULL`,
+      [params.documentId, params.machineId, params.audit.user_id]
+    );
+    if (!updated.rowCount) throw new HttpError(404, "MACHINE_DOCUMENT_NOT_FOUND", "Machine document not found.");
+    await audit(client, params.audit, { action: "production.machines.document.remove", entityType: "production_machine_documents", entityId: params.documentId, details: { machine_id: params.machineId } });
+    await client.query("COMMIT");
+    return true;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/src/module/production/repository/production.repository.ts
+++ b/src/module/production/repository/production.repository.ts
@@ -3,7 +3,7 @@ import crypto from "node:crypto";
 import path from "node:path";
 
 import pool from "../../../config/database";
-import { generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
+import { generateMachineCode, generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
@@ -145,6 +145,7 @@ type MachineModelMini = {
   manufacturer: string;
   model: string;
   display_name: string;
+  updated_at?: string;
 };
 
 type MachineOnboardingSpecInput = NonNullable<CreateMachineOnboardingBodyDTO["specs"]>;
@@ -159,7 +160,8 @@ async function selectMachineModelMini(tx: DbQueryer, id: string): Promise<Machin
         model_code,
         manufacturer,
         model,
-        display_name
+        display_name,
+        updated_at::text AS updated_at
       FROM public.production_machine_models
       WHERE id = $1::uuid
       LIMIT 1
@@ -198,40 +200,42 @@ async function upsertMachineSpecs(
         compatible_holders,
         operations_notes,
         maintenance_notes,
+        source_url,
         source_type,
         source_confidence,
         source_notes
       )
       VALUES (
-        $1::uuid,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17::text[],$18,$19,$20,$21,$22
+        $1::uuid,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17::text[],$18,$19,$20,$21,$22,$23
       )
       ON CONFLICT (machine_model_id) DO UPDATE
       SET
-        x_travel_mm = CASE WHEN $23::boolean THEN EXCLUDED.x_travel_mm ELSE COALESCE(EXCLUDED.x_travel_mm, public.production_machine_specs.x_travel_mm) END,
-        y_travel_mm = CASE WHEN $23::boolean THEN EXCLUDED.y_travel_mm ELSE COALESCE(EXCLUDED.y_travel_mm, public.production_machine_specs.y_travel_mm) END,
-        z_travel_mm = CASE WHEN $23::boolean THEN EXCLUDED.z_travel_mm ELSE COALESCE(EXCLUDED.z_travel_mm, public.production_machine_specs.z_travel_mm) END,
-        table_length_mm = CASE WHEN $23::boolean THEN EXCLUDED.table_length_mm ELSE COALESCE(EXCLUDED.table_length_mm, public.production_machine_specs.table_length_mm) END,
-        table_width_mm = CASE WHEN $23::boolean THEN EXCLUDED.table_width_mm ELSE COALESCE(EXCLUDED.table_width_mm, public.production_machine_specs.table_width_mm) END,
-        max_table_load_kg = CASE WHEN $23::boolean THEN EXCLUDED.max_table_load_kg ELSE COALESCE(EXCLUDED.max_table_load_kg, public.production_machine_specs.max_table_load_kg) END,
-        spindle_taper = CASE WHEN $23::boolean THEN EXCLUDED.spindle_taper ELSE COALESCE(EXCLUDED.spindle_taper, public.production_machine_specs.spindle_taper) END,
-        spindle_speed_max_rpm = CASE WHEN $23::boolean THEN EXCLUDED.spindle_speed_max_rpm ELSE COALESCE(EXCLUDED.spindle_speed_max_rpm, public.production_machine_specs.spindle_speed_max_rpm) END,
-        spindle_power_kw = CASE WHEN $23::boolean THEN EXCLUDED.spindle_power_kw ELSE COALESCE(EXCLUDED.spindle_power_kw, public.production_machine_specs.spindle_power_kw) END,
-        spindle_torque_nm = CASE WHEN $23::boolean THEN EXCLUDED.spindle_torque_nm ELSE COALESCE(EXCLUDED.spindle_torque_nm, public.production_machine_specs.spindle_torque_nm) END,
-        tool_magazine_capacity = CASE WHEN $23::boolean THEN EXCLUDED.tool_magazine_capacity ELSE COALESCE(EXCLUDED.tool_magazine_capacity, public.production_machine_specs.tool_magazine_capacity) END,
-        max_tool_diameter_mm = CASE WHEN $23::boolean THEN EXCLUDED.max_tool_diameter_mm ELSE COALESCE(EXCLUDED.max_tool_diameter_mm, public.production_machine_specs.max_tool_diameter_mm) END,
-        max_tool_length_mm = CASE WHEN $23::boolean THEN EXCLUDED.max_tool_length_mm ELSE COALESCE(EXCLUDED.max_tool_length_mm, public.production_machine_specs.max_tool_length_mm) END,
-        max_tool_weight_kg = CASE WHEN $23::boolean THEN EXCLUDED.max_tool_weight_kg ELSE COALESCE(EXCLUDED.max_tool_weight_kg, public.production_machine_specs.max_tool_weight_kg) END,
-        tool_change_time_sec = CASE WHEN $23::boolean THEN EXCLUDED.tool_change_time_sec ELSE COALESCE(EXCLUDED.tool_change_time_sec, public.production_machine_specs.tool_change_time_sec) END,
+        x_travel_mm = CASE WHEN $24::boolean THEN EXCLUDED.x_travel_mm ELSE COALESCE(EXCLUDED.x_travel_mm, public.production_machine_specs.x_travel_mm) END,
+        y_travel_mm = CASE WHEN $24::boolean THEN EXCLUDED.y_travel_mm ELSE COALESCE(EXCLUDED.y_travel_mm, public.production_machine_specs.y_travel_mm) END,
+        z_travel_mm = CASE WHEN $24::boolean THEN EXCLUDED.z_travel_mm ELSE COALESCE(EXCLUDED.z_travel_mm, public.production_machine_specs.z_travel_mm) END,
+        table_length_mm = CASE WHEN $24::boolean THEN EXCLUDED.table_length_mm ELSE COALESCE(EXCLUDED.table_length_mm, public.production_machine_specs.table_length_mm) END,
+        table_width_mm = CASE WHEN $24::boolean THEN EXCLUDED.table_width_mm ELSE COALESCE(EXCLUDED.table_width_mm, public.production_machine_specs.table_width_mm) END,
+        max_table_load_kg = CASE WHEN $24::boolean THEN EXCLUDED.max_table_load_kg ELSE COALESCE(EXCLUDED.max_table_load_kg, public.production_machine_specs.max_table_load_kg) END,
+        spindle_taper = CASE WHEN $24::boolean THEN EXCLUDED.spindle_taper ELSE COALESCE(EXCLUDED.spindle_taper, public.production_machine_specs.spindle_taper) END,
+        spindle_speed_max_rpm = CASE WHEN $24::boolean THEN EXCLUDED.spindle_speed_max_rpm ELSE COALESCE(EXCLUDED.spindle_speed_max_rpm, public.production_machine_specs.spindle_speed_max_rpm) END,
+        spindle_power_kw = CASE WHEN $24::boolean THEN EXCLUDED.spindle_power_kw ELSE COALESCE(EXCLUDED.spindle_power_kw, public.production_machine_specs.spindle_power_kw) END,
+        spindle_torque_nm = CASE WHEN $24::boolean THEN EXCLUDED.spindle_torque_nm ELSE COALESCE(EXCLUDED.spindle_torque_nm, public.production_machine_specs.spindle_torque_nm) END,
+        tool_magazine_capacity = CASE WHEN $24::boolean THEN EXCLUDED.tool_magazine_capacity ELSE COALESCE(EXCLUDED.tool_magazine_capacity, public.production_machine_specs.tool_magazine_capacity) END,
+        max_tool_diameter_mm = CASE WHEN $24::boolean THEN EXCLUDED.max_tool_diameter_mm ELSE COALESCE(EXCLUDED.max_tool_diameter_mm, public.production_machine_specs.max_tool_diameter_mm) END,
+        max_tool_length_mm = CASE WHEN $24::boolean THEN EXCLUDED.max_tool_length_mm ELSE COALESCE(EXCLUDED.max_tool_length_mm, public.production_machine_specs.max_tool_length_mm) END,
+        max_tool_weight_kg = CASE WHEN $24::boolean THEN EXCLUDED.max_tool_weight_kg ELSE COALESCE(EXCLUDED.max_tool_weight_kg, public.production_machine_specs.max_tool_weight_kg) END,
+        tool_change_time_sec = CASE WHEN $24::boolean THEN EXCLUDED.tool_change_time_sec ELSE COALESCE(EXCLUDED.tool_change_time_sec, public.production_machine_specs.tool_change_time_sec) END,
         compatible_holders = CASE
-          WHEN $23::boolean THEN EXCLUDED.compatible_holders
+          WHEN $24::boolean THEN EXCLUDED.compatible_holders
           WHEN array_length(EXCLUDED.compatible_holders, 1) IS NULL THEN public.production_machine_specs.compatible_holders
           ELSE EXCLUDED.compatible_holders
         END,
-        operations_notes = CASE WHEN $23::boolean THEN EXCLUDED.operations_notes ELSE COALESCE(EXCLUDED.operations_notes, public.production_machine_specs.operations_notes) END,
-        maintenance_notes = CASE WHEN $23::boolean THEN EXCLUDED.maintenance_notes ELSE COALESCE(EXCLUDED.maintenance_notes, public.production_machine_specs.maintenance_notes) END,
+        operations_notes = CASE WHEN $24::boolean THEN EXCLUDED.operations_notes ELSE COALESCE(EXCLUDED.operations_notes, public.production_machine_specs.operations_notes) END,
+        maintenance_notes = CASE WHEN $24::boolean THEN EXCLUDED.maintenance_notes ELSE COALESCE(EXCLUDED.maintenance_notes, public.production_machine_specs.maintenance_notes) END,
+        source_url = CASE WHEN $24::boolean THEN EXCLUDED.source_url ELSE COALESCE(EXCLUDED.source_url, public.production_machine_specs.source_url) END,
         source_type = EXCLUDED.source_type,
         source_confidence = EXCLUDED.source_confidence,
-        source_notes = CASE WHEN $23::boolean THEN EXCLUDED.source_notes ELSE COALESCE(EXCLUDED.source_notes, public.production_machine_specs.source_notes) END,
+        source_notes = CASE WHEN $24::boolean THEN EXCLUDED.source_notes ELSE COALESCE(EXCLUDED.source_notes, public.production_machine_specs.source_notes) END,
         updated_at = now()
     `,
     [
@@ -254,6 +258,7 @@ async function upsertMachineSpecs(
       specs.compatible_holders ?? [],
       textOrNull(specs.operations_notes),
       textOrNull(specs.maintenance_notes),
+      textOrNull(specs.source_url),
       specs.source_type ?? "internal_note",
       specs.source_confidence ?? "internal",
       textOrNull(specs.source_notes),
@@ -419,7 +424,10 @@ export async function repoListMachines(filters: ListMachinesQueryDTO): Promise<P
     model_name: string | null;
     display_name: string | null;
     status: MachineListItem["status"];
-    hourly_rate: number;
+    hourly_rate: number | null;
+    hourly_rate_source: MachineListItem["hourly_rate_source"];
+    hourly_rate_effective_at: string | null;
+    hourly_rate_is_override: boolean;
     currency: string;
     is_available: boolean;
     image_path: string | null;
@@ -447,6 +455,9 @@ export async function repoListMachines(filters: ListMachinesQueryDTO): Promise<P
         m.display_name,
         m.status::text AS status,
         m.hourly_rate::float8 AS hourly_rate,
+        m.hourly_rate_source,
+        m.hourly_rate_effective_at::text AS hourly_rate_effective_at,
+        m.hourly_rate_is_override,
         m.currency,
         m.is_available,
         m.image_path,
@@ -479,7 +490,10 @@ export async function repoListMachines(filters: ListMachinesQueryDTO): Promise<P
     model_name: r.model_name,
     display_name: r.display_name,
     status: r.status,
-    hourly_rate: Number(r.hourly_rate),
+    hourly_rate: r.hourly_rate === null ? null : Number(r.hourly_rate),
+    hourly_rate_source: r.hourly_rate_source,
+    hourly_rate_effective_at: r.hourly_rate_effective_at,
+    hourly_rate_is_override: r.hourly_rate_is_override,
     currency: r.currency,
     is_available: r.is_available,
     image_url: imageUrl(r.image_path),
@@ -513,7 +527,10 @@ export async function repoGetMachine(id: string): Promise<MachineDetail | null> 
     serial_number: string | null;
     commissioned_year: number | null;
     image_path: string | null;
-    hourly_rate: number;
+    hourly_rate: number | null;
+    hourly_rate_source: MachineDetail["hourly_rate_source"];
+    hourly_rate_effective_at: string | null;
+    hourly_rate_is_override: boolean;
     currency: string;
     is_available: boolean;
     dashboard_color: string | null;
@@ -552,6 +569,9 @@ export async function repoGetMachine(id: string): Promise<MachineDetail | null> 
         m.commissioned_year,
         m.image_path,
         m.hourly_rate::float8 AS hourly_rate,
+        m.hourly_rate_source,
+        m.hourly_rate_effective_at::text AS hourly_rate_effective_at,
+        m.hourly_rate_is_override,
         m.currency,
         m.is_available,
         m.dashboard_color,
@@ -590,7 +610,10 @@ export async function repoGetMachine(id: string): Promise<MachineDetail | null> 
     model_name: row.model_name,
     display_name: row.display_name,
     status: row.status,
-    hourly_rate: Number(row.hourly_rate),
+    hourly_rate: row.hourly_rate === null ? null : Number(row.hourly_rate),
+    hourly_rate_source: row.hourly_rate_source,
+    hourly_rate_effective_at: row.hourly_rate_effective_at,
+    hourly_rate_is_override: row.hourly_rate_is_override,
     currency: row.currency,
     is_available: row.is_available,
     image_url: imageUrl(row.image_path),
@@ -620,6 +643,7 @@ export async function repoGetMachine(id: string): Promise<MachineDetail | null> 
 export async function repoCreateMachine(params: {
   body: CreateMachineBodyDTO;
   image_path: string | null;
+  idempotency_key?: string | null;
   audit: AuditContext;
 }): Promise<MachineDetail> {
   const client = await pool.connect();
@@ -639,7 +663,10 @@ export async function repoCreateMachine(params: {
       serial_number: string | null;
       commissioned_year: number | null;
       image_path: string | null;
-      hourly_rate: number;
+      hourly_rate: number | null;
+      hourly_rate_source: MachineDetail["hourly_rate_source"];
+      hourly_rate_effective_at: string | null;
+      hourly_rate_is_override: boolean;
       currency: string;
       is_available: boolean;
       dashboard_color: string | null;
@@ -662,6 +689,21 @@ export async function repoCreateMachine(params: {
     const createdBy = params.audit.user_id;
     const updatedBy = params.audit.user_id;
     const b = params.body;
+    const requestHash = crypto.createHash("sha256").update(JSON.stringify(b)).digest("hex");
+    if (params.idempotency_key) {
+      const replay = await client.query<{ machine_id: string; request_hash: string }>(
+        `SELECT machine_id::text AS machine_id, request_hash FROM public.production_machine_idempotence WHERE idempotency_key = $1 FOR UPDATE`,
+        [params.idempotency_key]
+      );
+      if (replay.rows[0]) {
+        if (replay.rows[0].request_hash !== requestHash) throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Idempotency key was reused with a different payload.");
+        await client.query("COMMIT");
+        const existing = await repoGetMachine(replay.rows[0].machine_id);
+        if (!existing) throw new Error("Idempotent machine no longer exists");
+        return existing;
+      }
+    }
+    const code = await generateMachineCode(client);
 
     const ins = await client.query<Row>(
       `
@@ -677,6 +719,9 @@ export async function repoCreateMachine(params: {
           commissioned_year,
           image_path,
           hourly_rate,
+          hourly_rate_source,
+          hourly_rate_effective_at,
+          hourly_rate_is_override,
           currency,
           status,
           is_available,
@@ -694,7 +739,7 @@ export async function repoCreateMachine(params: {
         )
         VALUES (
           $1,$2,$3::machine_type,$4::uuid,$5,$6,$7,$8,$9,$10,
-          $11,$12,$13::machine_status,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25
+          $11,$12,$13,$14,$15,$16::machine_status,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28
         )
         RETURNING
           id::text AS id,
@@ -710,6 +755,9 @@ export async function repoCreateMachine(params: {
           commissioned_year,
           image_path,
           hourly_rate::float8 AS hourly_rate,
+          hourly_rate_source,
+          hourly_rate_effective_at::text AS hourly_rate_effective_at,
+          hourly_rate_is_override,
           currency,
           is_available,
           dashboard_color,
@@ -729,7 +777,7 @@ export async function repoCreateMachine(params: {
           archived_by
       `,
       [
-        b.code,
+        code,
         b.name,
         b.type,
         b.machine_model_id ?? null,
@@ -740,9 +788,12 @@ export async function repoCreateMachine(params: {
         b.commissioned_year ?? null,
         params.image_path,
         b.hourly_rate,
+        b.hourly_rate_source ?? null,
+        b.hourly_rate_effective_at ?? null,
+        b.hourly_rate_source === "MANUAL_OVERRIDE",
         b.currency,
         b.status,
-        b.is_available,
+        b.status === "ACTIVE",
         b.dashboard_color ?? null,
         b.model_3d_path ?? null,
         b.documentation_url ?? null,
@@ -759,6 +810,13 @@ export async function repoCreateMachine(params: {
 
     const row = ins.rows[0];
     if (!row) throw new Error("Failed to create machine");
+
+    if (params.idempotency_key) {
+      await client.query(
+        `INSERT INTO public.production_machine_idempotence (idempotency_key, request_hash, machine_id) VALUES ($1,$2,$3::uuid)`,
+        [params.idempotency_key, requestHash, row.id]
+      );
+    }
 
     await insertAuditLog(client, params.audit, {
       action: "production.machines.create",
@@ -785,7 +843,10 @@ export async function repoCreateMachine(params: {
       model_name: null,
       display_name: row.display_name,
       status: row.status,
-      hourly_rate: Number(row.hourly_rate),
+      hourly_rate: row.hourly_rate === null ? null : Number(row.hourly_rate),
+      hourly_rate_source: row.hourly_rate_source,
+      hourly_rate_effective_at: row.hourly_rate_effective_at,
+      hourly_rate_is_override: row.hourly_rate_is_override,
       currency: row.currency,
       is_available: row.is_available,
       image_url: imageUrl(row.image_path),
@@ -824,6 +885,7 @@ export async function repoCreateMachine(params: {
 export async function repoCreateMachineOnboarding(params: {
   body: CreateMachineOnboardingBodyDTO;
   image_path: string | null;
+  idempotency_key?: string | null;
   audit: AuditContext;
 }): Promise<MachineDetail> {
   const client = await pool.connect();
@@ -831,6 +893,20 @@ export async function repoCreateMachineOnboarding(params: {
     await client.query("BEGIN");
 
     const b = params.body;
+    const requestHash = crypto.createHash("sha256").update(JSON.stringify(b)).digest("hex");
+    if (params.idempotency_key) {
+      const replay = await client.query<{ machine_id: string; request_hash: string }>(
+        `SELECT machine_id::text AS machine_id, request_hash FROM public.production_machine_idempotence WHERE idempotency_key = $1 FOR UPDATE`,
+        [params.idempotency_key]
+      );
+      if (replay.rows[0]) {
+        if (replay.rows[0].request_hash !== requestHash) throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Idempotency key was reused with a different payload.");
+        await client.query("COMMIT");
+        const replayMachine = await repoGetMachine(replay.rows[0].machine_id);
+        if (!replayMachine) throw new Error("Idempotent machine no longer exists");
+        return replayMachine;
+      }
+    }
     const modelInput = b.machine_model ?? null;
     const explicitMachineModelId = b.machine.machine_model_id ?? null;
     const explicitDraftModelId = modelInput?.id ?? null;
@@ -946,7 +1022,10 @@ export async function repoCreateMachineOnboarding(params: {
       serial_number: string | null;
       commissioned_year: number | null;
       image_path: string | null;
-      hourly_rate: number;
+      hourly_rate: number | null;
+      hourly_rate_source: MachineDetail["hourly_rate_source"];
+      hourly_rate_effective_at: string | null;
+      hourly_rate_is_override: boolean;
       currency: string;
       is_available: boolean;
       dashboard_color: string | null;
@@ -967,6 +1046,7 @@ export async function repoCreateMachineOnboarding(params: {
     };
 
     const machine = b.machine;
+    const code = await generateMachineCode(client);
     const ins = await client.query<Row>(
       `
         INSERT INTO machines (
@@ -981,6 +1061,9 @@ export async function repoCreateMachineOnboarding(params: {
           commissioned_year,
           image_path,
           hourly_rate,
+          hourly_rate_source,
+          hourly_rate_effective_at,
+          hourly_rate_is_override,
           currency,
           status,
           is_available,
@@ -998,7 +1081,7 @@ export async function repoCreateMachineOnboarding(params: {
         )
         VALUES (
           $1,$2,$3::machine_type,$4::uuid,$5,$6,$7,$8,$9,$10,
-          $11,$12,$13::machine_status,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25
+          $11,$12,$13,$14,$15,$16::machine_status,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28
         )
         RETURNING
           id::text AS id,
@@ -1014,6 +1097,9 @@ export async function repoCreateMachineOnboarding(params: {
           commissioned_year,
           image_path,
           hourly_rate::float8 AS hourly_rate,
+          hourly_rate_source,
+          hourly_rate_effective_at::text AS hourly_rate_effective_at,
+          hourly_rate_is_override,
           currency,
           is_available,
           dashboard_color,
@@ -1033,7 +1119,7 @@ export async function repoCreateMachineOnboarding(params: {
           archived_by
       `,
       [
-        machine.code,
+        code,
         machine.name,
         machine.type,
         resolvedModelId,
@@ -1044,9 +1130,12 @@ export async function repoCreateMachineOnboarding(params: {
         machine.commissioned_year ?? null,
         params.image_path,
         machine.hourly_rate,
+        machine.hourly_rate_source ?? null,
+        machine.hourly_rate_effective_at ?? null,
+        machine.hourly_rate_source === "MANUAL_OVERRIDE",
         machine.currency,
         machine.status,
-        machine.is_available,
+        machine.status === "ACTIVE",
         machine.dashboard_color ?? null,
         machine.model_3d_path ?? null,
         machine.documentation_url ?? null,
@@ -1063,6 +1152,13 @@ export async function repoCreateMachineOnboarding(params: {
 
     const row = ins.rows[0];
     if (!row) throw new Error("Failed to create machine from onboarding");
+
+    if (params.idempotency_key) {
+      await client.query(
+        `INSERT INTO public.production_machine_idempotence (idempotency_key, request_hash, machine_id) VALUES ($1,$2,$3::uuid)`,
+        [params.idempotency_key, requestHash, row.id]
+      );
+    }
 
     await insertAuditLog(client, params.audit, {
       action: "production.machines.onboarding.create",
@@ -1093,7 +1189,10 @@ export async function repoCreateMachineOnboarding(params: {
       model_name: resolvedModel?.model ?? null,
       display_name: row.display_name,
       status: row.status,
-      hourly_rate: Number(row.hourly_rate),
+      hourly_rate: row.hourly_rate === null ? null : Number(row.hourly_rate),
+      hourly_rate_source: row.hourly_rate_source,
+      hourly_rate_effective_at: row.hourly_rate_effective_at,
+      hourly_rate_is_override: row.hourly_rate_is_override,
       currency: row.currency,
       is_available: row.is_available,
       image_url: imageUrl(row.image_path),
@@ -1149,12 +1248,34 @@ export async function repoUpdateMachineOnboarding(params: {
   try {
     await client.query("BEGIN");
 
-    const existingMachine = await client.query<{ id: string; machine_model_id: string | null; archived_at: string | null }>(
+    const existingMachine = await client.query<{
+      id: string;
+      code: string;
+      name: string;
+      type: string;
+      status: string;
+      machine_model_id: string | null;
+      serial_number: string | null;
+      commissioned_year: number | null;
+      location: string | null;
+      workshop_zone: string | null;
+      archived_at: string | null;
+      updated_at: string;
+    }>(
       `
         SELECT
           id::text AS id,
+          code,
+          name,
+          type::text AS type,
+          status::text AS status,
           machine_model_id::text AS machine_model_id,
-          archived_at::text AS archived_at
+          serial_number,
+          commissioned_year,
+          location,
+          workshop_zone,
+          archived_at::text AS archived_at,
+          updated_at::text AS updated_at
         FROM machines
         WHERE id = $1::uuid
         FOR UPDATE
@@ -1169,6 +1290,9 @@ export async function repoUpdateMachineOnboarding(params: {
     if (existing.archived_at) {
       throw new HttpError(409, "MACHINE_ARCHIVED", "Archived machine cannot be edited");
     }
+    if (existing.updated_at !== params.body.machine.expected_updated_at) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Machine has been modified by another user.");
+    }
 
     const b = params.body;
     const machine = b.machine;
@@ -1182,6 +1306,7 @@ export async function repoUpdateMachineOnboarding(params: {
     }
 
     let resolvedModel: MachineModelMini | null = null;
+    let sharedModelBeforeAudit: MachineModelMini | null = null;
     let resolvedModelId =
       explicitMachineModelId !== undefined
         ? explicitMachineModelId
@@ -1194,6 +1319,13 @@ export async function repoUpdateMachineOnboarding(params: {
       }
 
       if (hasModelDraft(modelInput)) {
+        sharedModelBeforeAudit = currentModel;
+        if (!b.update_shared_model) {
+          throw new HttpError(422, "SHARED_MODEL_CONFIRMATION_REQUIRED", "Explicit confirmation is required before updating a shared machine model.");
+        }
+        if (!b.expected_model_updated_at || currentModel.updated_at !== b.expected_model_updated_at) {
+          throw new HttpError(409, "CONCURRENT_MODEL_MODIFICATION", "The shared machine model has changed. Reload before saving.");
+        }
         const manufacturer = textOrNull(modelInput.manufacturer) ?? currentModel.manufacturer ?? textOrNull(machine.brand);
         const modelName = textOrNull(modelInput.model) ?? currentModel.model ?? textOrNull(machine.model);
         if (!manufacturer || !modelName) {
@@ -1214,13 +1346,14 @@ export async function repoUpdateMachineOnboarding(params: {
               source_summary = COALESCE($9, source_summary),
               is_active = COALESCE($10, is_active),
               updated_at = now()
-            WHERE id = $1::uuid
+            WHERE id = $1::uuid AND updated_at::text = $11
             RETURNING
               id::text AS id,
               model_code,
               manufacturer,
               model,
-              display_name
+              display_name,
+              updated_at::text AS updated_at
           `,
           [
             resolvedModelId,
@@ -1233,9 +1366,13 @@ export async function repoUpdateMachineOnboarding(params: {
             textOrNull(modelInput.description),
             textOrNull(modelInput.source_summary),
             modelInput.is_active ?? null,
+            b.expected_model_updated_at,
           ]
         );
-        resolvedModel = updatedModel.rows[0] ?? currentModel;
+        resolvedModel = updatedModel.rows[0] ?? null;
+        if (!resolvedModel) {
+          throw new HttpError(409, "CONCURRENT_MODEL_MODIFICATION", "The shared machine model has changed. Reload before saving.");
+        }
       } else {
         resolvedModel = currentModel;
       }
@@ -1302,6 +1439,19 @@ export async function repoUpdateMachineOnboarding(params: {
       throw new HttpError(422, "MACHINE_MODEL_REQUIRED_FOR_INTELLIGENCE", "A machine model is required to persist specs, capabilities or tooling");
     }
 
+    const sharedDataMutationRequested = hasSpecDraft(b.specs) || (b.capabilities ?? []).length > 0 || (b.tooling ?? []).length > 0;
+    if (existing.machine_model_id && sharedDataMutationRequested && !b.update_shared_model) {
+      throw new HttpError(422, "SHARED_MODEL_CONFIRMATION_REQUIRED", "Explicit confirmation is required before updating shared specifications, capabilities or tooling.");
+    }
+    if (
+      existing.machine_model_id &&
+      sharedDataMutationRequested &&
+      !hasModelDraft(modelInput) &&
+      (!b.expected_model_updated_at || resolvedModel?.updated_at !== b.expected_model_updated_at)
+    ) {
+      throw new HttpError(409, "CONCURRENT_MODEL_MODIFICATION", "The shared machine model has changed. Reload before saving.");
+    }
+
     if (resolvedModelId && hasSpecDraft(b.specs)) {
       await upsertMachineSpecs(client, resolvedModelId, b.specs, "replace");
     }
@@ -1318,7 +1468,6 @@ export async function repoUpdateMachineOnboarding(params: {
       return `$${values.length}`;
     };
 
-    sets.push(`code = ${push(machine.code)}`);
     sets.push(`name = ${push(machine.name)}`);
     sets.push(`type = ${push(machine.type)}::machine_type`);
     sets.push(`machine_model_id = ${push(resolvedModelId)}::uuid`);
@@ -1328,9 +1477,12 @@ export async function repoUpdateMachineOnboarding(params: {
     sets.push(`serial_number = ${push(machine.serial_number ?? null)}`);
     sets.push(`commissioned_year = ${push(machine.commissioned_year ?? null)}`);
     sets.push(`hourly_rate = ${push(machine.hourly_rate)}`);
+    sets.push(`hourly_rate_source = ${push(machine.hourly_rate_source ?? null)}`);
+    sets.push(`hourly_rate_effective_at = ${push(machine.hourly_rate_effective_at ?? null)}::date`);
+    sets.push(`hourly_rate_is_override = ${push(machine.hourly_rate_source === "MANUAL_OVERRIDE")}`);
     sets.push(`currency = ${push(machine.currency)}`);
     sets.push(`status = ${push(machine.status)}::machine_status`);
-    sets.push(`is_available = ${push(machine.is_available)}`);
+    sets.push(`is_available = ${push(machine.status === "ACTIVE")}`);
     sets.push(`dashboard_color = ${push(machine.dashboard_color ?? null)}`);
     sets.push(`model_3d_path = ${push(machine.model_3d_path ?? null)}`);
     sets.push(`documentation_url = ${push(machine.documentation_url ?? null)}`);
@@ -1346,37 +1498,71 @@ export async function repoUpdateMachineOnboarding(params: {
     sets.push(`updated_by = ${push(params.audit.user_id)}`);
     sets.push(`updated_at = now()`);
 
-    const upd = await client.query<{ id: string; code: string; name: string; type: string; status: string }>(
+    const upd = await client.query<{
+      id: string;
+      code: string;
+      name: string;
+      type: string;
+      status: string;
+      machine_model_id: string | null;
+      serial_number: string | null;
+      commissioned_year: number | null;
+      location: string | null;
+      workshop_zone: string | null;
+    }>(
       `
         UPDATE machines
         SET ${sets.join(", ")}
         WHERE id = ${push(params.id)}::uuid
+          AND updated_at::text = ${push(machine.expected_updated_at)}
         RETURNING
           id::text AS id,
           code,
           name,
           type::text AS type,
-          status::text AS status
+          status::text AS status,
+          machine_model_id::text AS machine_model_id,
+          serial_number,
+          commissioned_year,
+          location,
+          workshop_zone
       `,
       values
     );
 
     const row = upd.rows[0] ?? null;
-    if (!row) {
-      await client.query("ROLLBACK");
-      return null;
-    }
+    if (!row) throw new HttpError(409, "CONCURRENT_MODIFICATION", "Machine has been modified by another user.");
 
     await insertAuditLog(client, params.audit, {
       action: "production.machines.onboarding.update",
       entity_type: "machines",
       entity_id: row.id,
       details: {
-        code: row.code,
-        name: row.name,
-        type: row.type,
-        status: row.status,
-        machine_model_id: resolvedModelId,
+        before: {
+          code: existing.code,
+          name: existing.name,
+          type: existing.type,
+          status: existing.status,
+          machine_model_id: existing.machine_model_id,
+          serial_number: existing.serial_number,
+          commissioned_year: existing.commissioned_year,
+          location: existing.location,
+          workshop_zone: existing.workshop_zone,
+        },
+        after: {
+          code: row.code,
+          name: row.name,
+          type: row.type,
+          status: row.status,
+          machine_model_id: row.machine_model_id,
+          serial_number: row.serial_number,
+          commissioned_year: row.commissioned_year,
+          location: row.location,
+          workshop_zone: row.workshop_zone,
+        },
+        shared_model_before: sharedModelBeforeAudit,
+        shared_model_after: sharedModelBeforeAudit ? resolvedModel : null,
+        redacted_fields: ["hourly_rate", "hourly_rate_source", "hourly_rate_effective_at", "notes"],
         model_updated: hasModelDraft(modelInput),
         specs_written: hasSpecDraft(b.specs),
         capabilities_count: b.capabilities?.length ?? 0,
@@ -1423,8 +1609,8 @@ export async function repoUpdateMachine(params: {
   try {
     await client.query("BEGIN");
 
-    const before = await client.query<{ id: string; archived_at: string | null }>(
-      `SELECT id::text AS id, archived_at::text AS archived_at FROM machines WHERE id = $1::uuid FOR UPDATE`,
+    const before = await client.query<{ id: string; archived_at: string | null; updated_at: string }>(
+      `SELECT id::text AS id, archived_at::text AS archived_at, updated_at::text AS updated_at FROM machines WHERE id = $1::uuid FOR UPDATE`,
       [params.id]
     );
     const existing = before.rows[0];
@@ -1435,6 +1621,9 @@ export async function repoUpdateMachine(params: {
     if (existing.archived_at) {
       throw new HttpError(409, "MACHINE_ARCHIVED", "Archived machine cannot be edited");
     }
+    if (existing.updated_at !== params.patch.expected_updated_at) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Machine has been modified by another user.");
+    }
 
     const sets: string[] = [];
     const values: unknown[] = [];
@@ -1444,7 +1633,6 @@ export async function repoUpdateMachine(params: {
     };
 
     const p = params.patch;
-    if (p.code !== undefined) sets.push(`code = ${push(p.code)}`);
     if (p.name !== undefined) sets.push(`name = ${push(p.name)}`);
     if (p.type !== undefined) sets.push(`type = ${push(p.type)}::machine_type`);
     if (p.machine_model_id !== undefined) sets.push(`machine_model_id = ${push(p.machine_model_id ?? null)}::uuid`);
@@ -1454,9 +1642,14 @@ export async function repoUpdateMachine(params: {
     if (p.serial_number !== undefined) sets.push(`serial_number = ${push(p.serial_number ?? null)}`);
     if (p.commissioned_year !== undefined) sets.push(`commissioned_year = ${push(p.commissioned_year ?? null)}`);
     if (p.hourly_rate !== undefined) sets.push(`hourly_rate = ${push(p.hourly_rate)}`);
+    if (p.hourly_rate_source !== undefined) {
+      sets.push(`hourly_rate_source = ${push(p.hourly_rate_source)}`);
+      sets.push(`hourly_rate_is_override = ${push(p.hourly_rate_source === "MANUAL_OVERRIDE")}`);
+    }
+    if (p.hourly_rate_effective_at !== undefined) sets.push(`hourly_rate_effective_at = ${push(p.hourly_rate_effective_at)}::date`);
     if (p.currency !== undefined) sets.push(`currency = ${push(p.currency)}`);
     if (p.status !== undefined) sets.push(`status = ${push(p.status)}::machine_status`);
-    if (p.is_available !== undefined) sets.push(`is_available = ${push(p.is_available)}`);
+    if (p.status !== undefined) sets.push(`is_available = ${push(p.status === "ACTIVE")}`);
     if (p.dashboard_color !== undefined) sets.push(`dashboard_color = ${push(p.dashboard_color ?? null)}`);
     if (p.model_3d_path !== undefined) sets.push(`model_3d_path = ${push(p.model_3d_path ?? null)}`);
     if (p.documentation_url !== undefined) sets.push(`documentation_url = ${push(p.documentation_url ?? null)}`);
@@ -1487,7 +1680,10 @@ export async function repoUpdateMachine(params: {
       serial_number: string | null;
       commissioned_year: number | null;
       image_path: string | null;
-      hourly_rate: number;
+      hourly_rate: number | null;
+      hourly_rate_source: MachineDetail["hourly_rate_source"];
+      hourly_rate_effective_at: string | null;
+      hourly_rate_is_override: boolean;
       currency: string;
       is_available: boolean;
       dashboard_color: string | null;
@@ -1512,6 +1708,7 @@ export async function repoUpdateMachine(params: {
         UPDATE machines
         SET ${sets.join(", ")}
         WHERE id = ${push(params.id)}::uuid
+          AND updated_at::text = ${push(p.expected_updated_at)}
         RETURNING
           id::text AS id,
           code,
@@ -1526,6 +1723,9 @@ export async function repoUpdateMachine(params: {
           commissioned_year,
           image_path,
           hourly_rate::float8 AS hourly_rate,
+          hourly_rate_source,
+          hourly_rate_effective_at::text AS hourly_rate_effective_at,
+          hourly_rate_is_override,
           currency,
           is_available,
           dashboard_color,
@@ -1576,7 +1776,10 @@ export async function repoUpdateMachine(params: {
       model_name: null,
       display_name: row.display_name,
       status: row.status,
-      hourly_rate: Number(row.hourly_rate),
+      hourly_rate: row.hourly_rate === null ? null : Number(row.hourly_rate),
+      hourly_rate_source: row.hourly_rate_source,
+      hourly_rate_effective_at: row.hourly_rate_effective_at,
+      hourly_rate_is_override: row.hourly_rate_is_override,
       currency: row.currency,
       is_available: row.is_available,
       image_url: imageUrl(row.image_path),

--- a/src/module/production/routes/production.routes.ts
+++ b/src/module/production/routes/production.routes.ts
@@ -1,8 +1,11 @@
 import { Router, type RequestHandler } from "express";
+import multer from "multer";
 
 import { upload } from "../../../middlewares/upload";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { HttpError } from "../../../utils/httpError";
+import { roleHasMachineCapability, type MachineCapability } from "../domain/machine-rbac";
 import {
   archiveMachine,
   archivePoste,
@@ -55,6 +58,22 @@ import {
   listMachineModelDocuments,
   listMachineModels,
 } from "../controllers/machine-intelligence.controller";
+import {
+  archiveMachineUnavailability,
+  createMachineMaintenanceEvent,
+  createMachineMaintenancePlan,
+  createMachineDocument,
+  createMachineUnavailability,
+  downloadMachineDocument,
+  getMachineParkContext,
+  listMachineMaintenanceEvents,
+  listMachineMaintenancePlans,
+  listMachineUnavailability,
+  reactivateMachine,
+  removeMachineDocument,
+  uploadMachineDocument,
+  updateMachineMaintenancePlan,
+} from "../controllers/machine-park.controller";
 
 function isAdminRole(role: string | undefined): boolean {
   if (!role) return false;
@@ -85,25 +104,51 @@ const requireProductionOrAdmin: RequestHandler = (req, _res, next) => {
   next();
 };
 
+const requireMachineCapability = (capability: MachineCapability): RequestHandler => (req, _res, next) => {
+  if (!roleHasMachineCapability(req.user?.role, capability)) {
+    next(new HttpError(403, "MACHINE_FORBIDDEN", `Machine capability required: ${capability}`));
+    return;
+  }
+  next();
+};
+
 const router = Router();
+const machineDocumentUpload = multer({
+  dest: ensureDocumentStoragePath("machines"),
+  limits: { fileSize: 50 * 1024 * 1024, files: 1 },
+});
 
 router.use(authenticateToken);
 
 // Machines
-router.get("/machine-models", listMachineModels);
-router.get("/machine-models/:id", getMachineModel);
-router.get("/machine-models/:id/capabilities", listMachineModelCapabilities);
-router.get("/machine-models/:id/documents", listMachineModelDocuments);
+router.get("/machine-models", requireMachineCapability("read"), listMachineModels);
+router.get("/machine-models/:id", requireMachineCapability("read"), getMachineModel);
+router.get("/machine-models/:id/capabilities", requireMachineCapability("read"), listMachineModelCapabilities);
+router.get("/machine-models/:id/documents", requireMachineCapability("read"), listMachineModelDocuments);
 
-router.get("/machines", listMachines);
-router.get("/machines/:id/capabilities", listMachineCapabilities);
-router.get("/machines/:id/documents", listMachineDocuments);
-router.get("/machines/:id", getMachine);
-router.post("/machines/onboarding", requireProductionOrAdmin, upload.single("image"), createMachineOnboarding);
-router.post("/machines", upload.single("image"), createMachine);
-router.patch("/machines/:id/onboarding", requireProductionOrAdmin, upload.single("image"), updateMachineOnboarding);
-router.patch("/machines/:id", upload.single("image"), updateMachine);
-router.delete("/machines/:id", requireAdmin, archiveMachine);
+router.get("/machines", requireMachineCapability("read"), listMachines);
+router.get("/machines/:id/context", requireMachineCapability("read"), getMachineParkContext);
+router.get("/machines/:id/unavailability", requireMachineCapability("read"), listMachineUnavailability);
+router.post("/machines/:id/unavailability", requireMachineCapability("availability"), createMachineUnavailability);
+router.delete("/machines/:id/unavailability/:unavailabilityId", requireMachineCapability("availability"), archiveMachineUnavailability);
+router.get("/machines/:id/maintenance/plans", requireMachineCapability("read"), listMachineMaintenancePlans);
+router.post("/machines/:id/maintenance/plans", requireMachineCapability("maintenance"), createMachineMaintenancePlan);
+router.patch("/machines/:id/maintenance/plans/:planId", requireMachineCapability("maintenance"), updateMachineMaintenancePlan);
+router.get("/machines/:id/maintenance/events", requireMachineCapability("read"), listMachineMaintenanceEvents);
+router.post("/machines/:id/maintenance/events", requireMachineCapability("maintenance"), createMachineMaintenanceEvent);
+router.post("/machines/:id/reactivate", requireMachineCapability("restore"), reactivateMachine);
+router.get("/machines/:id/capabilities", requireMachineCapability("read"), listMachineCapabilities);
+router.get("/machines/:id/documents", requireMachineCapability("read"), listMachineDocuments);
+router.post("/machines/:id/documents/upload", requireMachineCapability("documents"), machineDocumentUpload.single("document"), uploadMachineDocument);
+router.post("/machines/:id/documents", requireMachineCapability("documents"), createMachineDocument);
+router.get("/machines/:id/documents/:documentId/download", requireMachineCapability("read"), downloadMachineDocument);
+router.delete("/machines/:id/documents/:documentId", requireMachineCapability("documents"), removeMachineDocument);
+router.get("/machines/:id", requireMachineCapability("read"), getMachine);
+router.post("/machines/onboarding", requireMachineCapability("create"), upload.single("image"), createMachineOnboarding);
+router.post("/machines", requireMachineCapability("create"), upload.single("image"), createMachine);
+router.patch("/machines/:id/onboarding", requireMachineCapability("update"), upload.single("image"), updateMachineOnboarding);
+router.patch("/machines/:id", requireMachineCapability("update"), upload.single("image"), updateMachine);
+router.delete("/machines/:id", requireMachineCapability("archive"), archiveMachine);
 
 // Postes
 router.get("/postes", listPostes);

--- a/src/module/production/services/machine-park.service.ts
+++ b/src/module/production/services/machine-park.service.ts
@@ -1,0 +1,16 @@
+import * as repo from "../repository/machine-park.repository";
+
+export const svcGetMachineParkContext = repo.repoGetMachineParkContext;
+export const svcListMachineUnavailability = repo.repoListMachineUnavailability;
+export const svcCreateMachineUnavailability = repo.repoCreateMachineUnavailability;
+export const svcArchiveMachineUnavailability = repo.repoArchiveMachineUnavailability;
+export const svcListMachineMaintenancePlans = repo.repoListMachineMaintenancePlans;
+export const svcCreateMachineMaintenancePlan = repo.repoCreateMachineMaintenancePlan;
+export const svcUpdateMachineMaintenancePlan = repo.repoUpdateMachineMaintenancePlan;
+export const svcListMachineMaintenanceEvents = repo.repoListMachineMaintenanceEvents;
+export const svcCreateMachineMaintenanceEvent = repo.repoCreateMachineMaintenanceEvent;
+export const svcReactivateMachine = repo.repoReactivateMachine;
+export const svcCreateMachineDocument = repo.repoCreateMachineDocument;
+export const svcUploadMachineDocument = repo.repoUploadMachineDocument;
+export const svcGetMachineDocumentForDownload = repo.repoGetMachineDocumentForDownload;
+export const svcRemoveMachineDocument = repo.repoRemoveMachineDocument;

--- a/src/module/production/services/production.service.ts
+++ b/src/module/production/services/production.service.ts
@@ -25,12 +25,14 @@ export const svcGetMachine = (id: string) => repo.repoGetMachine(id);
 export const svcCreateMachine = (params: {
   body: CreateMachineBodyDTO;
   image_path: string | null;
+  idempotency_key?: string | null;
   audit: repo.AuditContext;
 }) => repo.repoCreateMachine(params);
 
 export const svcCreateMachineOnboarding = (params: {
   body: CreateMachineOnboardingBodyDTO;
   image_path: string | null;
+  idempotency_key?: string | null;
   audit: repo.AuditContext;
 }) => repo.repoCreateMachineOnboarding(params);
 

--- a/src/module/production/types/machine-intelligence.types.ts
+++ b/src/module/production/types/machine-intelligence.types.ts
@@ -106,13 +106,18 @@ export type MachineDocument = {
   machine_model_id: string | null;
   machine_id: string | null;
   title: string;
-  document_type: "OFFICIAL_PAGE" | "BROCHURE_PDF" | "MANUAL" | "IMAGE" | "RESALE_LISTING" | "INTERNAL_NOTE";
+  document_type: "OFFICIAL_PAGE" | "BROCHURE_PDF" | "MANUAL" | "IMAGE" | "RESALE_LISTING" | "INTERNAL_NOTE" | "CERTIFICATE" | "MAINTENANCE" | "PHOTO" | "MODEL_3D";
   url: string | null;
-  storage_path: string | null;
+  revision: string | null;
+  sha256: string | null;
+  mime_type: string | null;
+  size_bytes: number | null;
+  authored_at: string | null;
   source_type: SourceType;
   source_confidence: SourceConfidence;
   source_notes: string | null;
   retrieved_at: string;
+  removed_at: string | null;
 };
 
 export type MachineInstanceLite = {

--- a/src/module/production/types/machine-park.types.ts
+++ b/src/module/production/types/machine-park.types.ts
@@ -1,0 +1,71 @@
+export type MachineUnavailabilityCause =
+  | "PREVENTIVE_MAINTENANCE"
+  | "BREAKDOWN"
+  | "QUALIFICATION"
+  | "RESERVATION"
+  | "WORKSHOP_CLOSURE"
+  | "OPERATOR_ABSENCE"
+  | "OTHER";
+
+export type MachineUnavailability = {
+  id: string;
+  machine_id: string;
+  planning_event_id: string;
+  cause: MachineUnavailabilityCause;
+  comment: string | null;
+  source: string;
+  maintenance_plan_id: string | null;
+  start_ts: string;
+  end_ts: string;
+  status: string;
+  created_at: string;
+  created_by: number | null;
+  archived_at: string | null;
+};
+
+export type MachineMaintenancePlan = {
+  id: string;
+  machine_id: string;
+  title: string;
+  status: "ACTIVE" | "PAUSED" | "COMPLETED";
+  frequency_days: number | null;
+  frequency_counter: number | null;
+  counter_unit: string | null;
+  next_due_at: string | null;
+  responsible_user_id: number | null;
+  checklist: unknown[];
+  document_id: string | null;
+  source: string;
+  notes: string | null;
+  version: number;
+  created_at: string;
+  updated_at: string;
+  archived_at: string | null;
+};
+
+export type MachineMaintenanceEvent = {
+  id: string;
+  machine_id: string;
+  maintenance_plan_id: string | null;
+  event_type: "SCHEDULED" | "STARTED" | "COMPLETED" | "CANCELLED" | "NOTE";
+  occurred_at: string;
+  due_at: string | null;
+  planning_event_id: string | null;
+  unavailability_id: string | null;
+  checklist_result: unknown[];
+  notes: string | null;
+  created_at: string;
+  created_by: number | null;
+};
+
+export type MachineParkContext = {
+  available_now: boolean;
+  availability_reason: string;
+  active_unavailability: MachineUnavailability | null;
+  upcoming_unavailability: MachineUnavailability[];
+  maintenance_due: MachineMaintenancePlan[];
+  planned_minutes_next_7d: number;
+  capacity_minutes_next_7d: null;
+  capacity_reason: string;
+  linked_open_ofs: Array<{ id: number; numero: string; statut: string; operation_count: number }>;
+};

--- a/src/module/production/types/production.types.ts
+++ b/src/module/production/types/production.types.ts
@@ -27,7 +27,10 @@ export type MachineListItem = {
   model_name: string | null;
   display_name: string | null;
   status: MachineStatusDTO;
-  hourly_rate: number;
+  hourly_rate: number | null;
+  hourly_rate_source: "INTERNAL_COST" | "POSTE_INHERITED" | "IMPORTED" | "MANUAL_OVERRIDE" | "UNKNOWN" | null;
+  hourly_rate_effective_at: string | null;
+  hourly_rate_is_override: boolean;
   currency: string;
   is_available: boolean;
   image_url: string | null;

--- a/src/module/production/validators/machine-park.validators.ts
+++ b/src/module/production/validators/machine-park.validators.ts
@@ -1,0 +1,142 @@
+import { z } from "zod";
+
+const uuid = z.string().uuid();
+const isoDateTime = z.string().datetime({ offset: true });
+const optionalText = (max: number) => z.string().trim().min(1).max(max).optional().nullable();
+
+export const machineUnavailabilityCauseSchema = z.enum([
+  "PREVENTIVE_MAINTENANCE",
+  "BREAKDOWN",
+  "QUALIFICATION",
+  "RESERVATION",
+  "WORKSHOP_CLOSURE",
+  "OPERATOR_ABSENCE",
+  "OTHER",
+]);
+
+export const machineParkIdParamSchema = z.object({ params: z.object({ id: uuid }).strict() }).strict();
+export const machineUnavailabilityIdParamSchema = z.object({
+  params: z.object({ id: uuid, unavailabilityId: uuid }).strict(),
+}).strict();
+export const machineMaintenancePlanIdParamSchema = z.object({
+  params: z.object({ id: uuid, planId: uuid }).strict(),
+}).strict();
+
+export const listMachineUnavailabilitySchema = z.object({
+  query: z.object({
+    from: isoDateTime.optional(),
+    to: isoDateTime.optional(),
+    include_archived: z.enum(["true", "false"]).optional().default("false").transform((v) => v === "true"),
+  }).strict().superRefine((v, ctx) => {
+    if ((v.from && !v.to) || (!v.from && v.to)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: [v.from ? "to" : "from"], message: "from and to must be provided together" });
+    }
+    if (v.from && v.to && Date.parse(v.from) >= Date.parse(v.to)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["to"], message: "from must be before to" });
+    }
+  }),
+}).strict();
+
+export const createMachineUnavailabilitySchema = z.object({
+  body: z.object({
+    cause: machineUnavailabilityCauseSchema,
+    comment: optionalText(4000),
+    source: z.string().trim().min(1).max(120).optional().default("machine_park"),
+    start_ts: isoDateTime,
+    end_ts: isoDateTime,
+    maintenance_plan_id: uuid.optional().nullable(),
+  }).strict().superRefine((v, ctx) => {
+    if (Date.parse(v.start_ts) >= Date.parse(v.end_ts)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["end_ts"], message: "start_ts must be before end_ts" });
+    }
+    if (v.cause === "OTHER" && !v.comment) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["comment"], message: "A reason is required for OTHER" });
+    }
+  }),
+}).strict();
+
+const machineMaintenancePlanBody = z.object({
+    title: z.string().trim().min(1).max(240),
+    status: z.enum(["ACTIVE", "PAUSED", "COMPLETED"]).optional().default("ACTIVE"),
+    frequency_days: z.number().int().positive().max(3650).optional().nullable(),
+    frequency_counter: z.number().positive().max(999999999).optional().nullable(),
+    counter_unit: optionalText(40),
+    next_due_at: z.string().date().optional().nullable(),
+    responsible_user_id: z.number().int().positive().optional().nullable(),
+    checklist: z.array(z.object({ id: z.string().min(1).max(80), label: z.string().min(1).max(240) }).strict()).max(100).optional().default([]),
+    document_id: uuid.optional().nullable(),
+    source: z.string().trim().min(1).max(120).optional().default("internal"),
+    notes: optionalText(4000),
+  }).strict();
+
+export const createMachineMaintenancePlanSchema = z.object({
+  body: machineMaintenancePlanBody.superRefine((v, ctx) => {
+    if (!v.frequency_days && !v.frequency_counter && !v.next_due_at) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["next_due_at"], message: "A date or frequency is required" });
+    }
+    if (v.frequency_counter && !v.counter_unit) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["counter_unit"], message: "Counter unit is required" });
+    }
+  }),
+}).strict();
+
+export const updateMachineMaintenancePlanSchema = z.object({
+  body: machineMaintenancePlanBody.partial().extend({
+    expected_updated_at: isoDateTime,
+  }).strict(),
+}).strict();
+
+export const reactivateMachineSchema = z.object({
+  body: z.object({ expected_updated_at: isoDateTime }).strict(),
+}).strict();
+
+export const machineDocumentIdParamSchema = z.object({
+  params: z.object({ id: uuid, documentId: uuid }).strict(),
+}).strict();
+
+export const createMachineDocumentSchema = z.object({
+  body: z.object({
+    title: z.string().trim().min(1).max(240),
+    document_type: z.enum(["OFFICIAL_PAGE", "BROCHURE_PDF", "MANUAL", "IMAGE", "RESALE_LISTING", "INTERNAL_NOTE", "CERTIFICATE", "MAINTENANCE", "PHOTO", "MODEL_3D"]),
+    url: z.string().url().max(2000),
+    revision: optionalText(80),
+    sha256: z.string().regex(/^[a-f0-9]{64}$/i).optional().nullable(),
+    mime_type: optionalText(160),
+    size_bytes: z.number().int().positive().max(2_000_000_000).optional().nullable(),
+    authored_at: isoDateTime.optional().nullable(),
+    source_type: z.enum(["manufacturer_page", "manufacturer_pdf", "resale_listing", "internal_note", "mixed", "unknown"]),
+    source_confidence: z.enum(["official", "resale_listing", "estimated", "internal", "unknown"]),
+    source_notes: optionalText(2000),
+  }).strict(),
+}).strict();
+
+export const uploadMachineDocumentSchema = z.object({
+  body: z.object({
+    title: z.string().trim().min(1).max(240),
+    document_type: z.enum(["OFFICIAL_PAGE", "BROCHURE_PDF", "MANUAL", "IMAGE", "RESALE_LISTING", "INTERNAL_NOTE", "CERTIFICATE", "MAINTENANCE", "PHOTO", "MODEL_3D"]),
+    revision: optionalText(80),
+    authored_at: isoDateTime.optional().nullable(),
+    source_type: z.enum(["manufacturer_page", "manufacturer_pdf", "resale_listing", "internal_note", "mixed", "unknown"]),
+    source_confidence: z.enum(["official", "resale_listing", "estimated", "internal", "unknown"]),
+    source_notes: optionalText(2000),
+  }).strict(),
+}).strict();
+
+export const createMachineMaintenanceEventSchema = z.object({
+  body: z.object({
+    maintenance_plan_id: uuid.optional().nullable(),
+    event_type: z.enum(["SCHEDULED", "STARTED", "COMPLETED", "CANCELLED", "NOTE"]),
+    occurred_at: isoDateTime.optional(),
+    due_at: isoDateTime.optional().nullable(),
+    checklist_result: z.array(z.object({ id: z.string().min(1).max(80), completed: z.boolean(), note: optionalText(1000) }).strict()).max(100).optional().default([]),
+    notes: optionalText(4000),
+  }).strict(),
+}).strict();
+
+export type ListMachineUnavailabilityQueryDTO = z.infer<typeof listMachineUnavailabilitySchema>["query"];
+export type CreateMachineUnavailabilityBodyDTO = z.infer<typeof createMachineUnavailabilitySchema>["body"];
+export type CreateMachineMaintenancePlanBodyDTO = z.infer<typeof createMachineMaintenancePlanSchema>["body"];
+export type UpdateMachineMaintenancePlanBodyDTO = z.infer<typeof updateMachineMaintenancePlanSchema>["body"];
+export type CreateMachineMaintenanceEventBodyDTO = z.infer<typeof createMachineMaintenanceEventSchema>["body"];
+export type CreateMachineDocumentBodyDTO = z.infer<typeof createMachineDocumentSchema>["body"];
+export type UploadMachineDocumentBodyDTO = z.infer<typeof uploadMachineDocumentSchema>["body"];

--- a/src/module/production/validators/production.validators.ts
+++ b/src/module/production/validators/production.validators.ts
@@ -51,10 +51,10 @@ const onboardingTextArraySchema = z.array(z.string().trim().min(1).max(120)).max
 const sourceConfidenceSchema = z.enum(["official", "resale_listing", "estimated", "internal", "unknown"]);
 const sourceTypeSchema = z.enum(["manufacturer_page", "manufacturer_pdf", "resale_listing", "internal_note", "mixed", "unknown"]);
 const capabilityLevelSchema = z.enum(["preferred", "primary", "supported", "limited", "unknown"]);
+const hourlyRateSourceSchema = z.enum(["INTERNAL_COST", "POSTE_INHERITED", "IMPORTED", "MANUAL_OVERRIDE", "UNKNOWN"]);
 
 export const createMachineSchema = z.object({
   body: z.object({
-    code: z.string().trim().min(1).max(50),
     name: z.string().trim().min(1).max(200),
     type: machineTypeSchema.optional().default("OTHER"),
     machine_model_id: uuid.optional().nullable(),
@@ -63,10 +63,11 @@ export const createMachineSchema = z.object({
     model: z.string().trim().min(1).max(120).optional().nullable(),
     serial_number: z.string().trim().min(1).max(120).optional().nullable(),
     commissioned_year: optionalYearSchema,
-    hourly_rate: z.coerce.number().min(0).optional().default(0),
+    hourly_rate: z.coerce.number().min(0).optional().nullable(),
+    hourly_rate_source: hourlyRateSourceSchema.optional().nullable(),
+    hourly_rate_effective_at: z.string().date().optional().nullable(),
     currency: currencySchema,
     status: machineStatusSchema.optional().default("ACTIVE"),
-    is_available: z.boolean().optional().default(true),
     dashboard_color: z.string().trim().min(1).max(40).optional().nullable(),
     model_3d_path: optionalPathSchema,
     documentation_url: optionalUrlSchema,
@@ -76,7 +77,7 @@ export const createMachineSchema = z.object({
     location: z.string().trim().min(1).max(200).optional().nullable(),
     workshop_zone: z.string().trim().min(1).max(200).optional().nullable(),
     notes: z.string().trim().min(1).optional().nullable(),
-  }),
+  }).strict(),
 });
 
 export type CreateMachineBodyDTO = z.infer<typeof createMachineSchema>["body"];
@@ -96,7 +97,7 @@ export const createMachineOnboardingSchema = z.object({
         description: z.string().trim().min(1).max(2000).optional().nullable(),
         source_summary: z.string().trim().min(1).max(2000).optional().nullable(),
         is_active: z.boolean().optional().default(true),
-      })
+      }).strict()
       .optional()
       .nullable(),
     specs: z
@@ -121,8 +122,9 @@ export const createMachineOnboardingSchema = z.object({
         maintenance_notes: optionalMediumTextSchema,
         source_type: sourceTypeSchema.optional().default("internal_note"),
         source_confidence: sourceConfidenceSchema.optional().default("internal"),
+        source_url: optionalUrlSchema,
         source_notes: optionalMediumTextSchema,
-      })
+      }).strict()
       .optional()
       .nullable(),
     capabilities: z
@@ -133,7 +135,7 @@ export const createMachineOnboardingSchema = z.object({
           capability_level: capabilityLevelSchema.optional().default("supported"),
           notes: optionalMediumTextSchema,
           source_confidence: sourceConfidenceSchema.optional().default("internal"),
-        })
+        }).strict()
       )
       .max(80)
       .optional()
@@ -147,22 +149,29 @@ export const createMachineOnboardingSchema = z.object({
           compatible: z.boolean().optional().default(true),
           notes: optionalMediumTextSchema,
           source_confidence: sourceConfidenceSchema.optional().default("internal"),
-        })
+        }).strict()
       )
       .max(80)
       .optional()
       .default([]),
-  }),
+    update_shared_model: z.boolean().optional().default(false),
+    expected_model_updated_at: z.string().datetime({ offset: true }).optional().nullable(),
+  }).strict(),
 });
 
 export type CreateMachineOnboardingBodyDTO = z.infer<typeof createMachineOnboardingSchema>["body"];
 
-export const updateMachineOnboardingSchema = createMachineOnboardingSchema;
-export type UpdateMachineOnboardingBodyDTO = CreateMachineOnboardingBodyDTO;
+export const updateMachineOnboardingSchema = z.object({
+  body: createMachineOnboardingSchema.shape.body.extend({
+    machine: createMachineSchema.shape.body.extend({
+      expected_updated_at: z.string().datetime({ offset: true }),
+    }).strict(),
+  }).strict(),
+});
+export type UpdateMachineOnboardingBodyDTO = z.infer<typeof updateMachineOnboardingSchema>["body"];
 
 export const updateMachineSchema = z.object({
   body: z.object({
-    code: z.string().trim().min(1).max(50).optional(),
     name: z.string().trim().min(1).max(200).optional(),
     type: machineTypeSchema.optional(),
     machine_model_id: uuid.optional().nullable(),
@@ -171,10 +180,11 @@ export const updateMachineSchema = z.object({
     model: z.string().trim().min(1).max(120).optional().nullable(),
     serial_number: z.string().trim().min(1).max(120).optional().nullable(),
     commissioned_year: optionalYearSchema,
-    hourly_rate: z.coerce.number().min(0).optional(),
+    hourly_rate: z.coerce.number().min(0).optional().nullable(),
+    hourly_rate_source: hourlyRateSourceSchema.optional().nullable(),
+    hourly_rate_effective_at: z.string().date().optional().nullable(),
     currency: currencyPatchSchema,
     status: machineStatusSchema.optional(),
-    is_available: z.boolean().optional(),
     dashboard_color: z.string().trim().min(1).max(40).optional().nullable(),
     model_3d_path: optionalPathSchema,
     documentation_url: optionalUrlSchema,
@@ -184,7 +194,8 @@ export const updateMachineSchema = z.object({
     location: z.string().trim().min(1).max(200).optional().nullable(),
     workshop_zone: z.string().trim().min(1).max(200).optional().nullable(),
     notes: z.string().trim().min(1).optional().nullable(),
-  }),
+    expected_updated_at: z.string().datetime({ offset: true }),
+  }).strict(),
 });
 
 export type UpdateMachineBodyDTO = z.infer<typeof updateMachineSchema>["body"];

--- a/src/shared/codes/code-generator.service.ts
+++ b/src/shared/codes/code-generator.service.ts
@@ -147,6 +147,12 @@ export async function generateFournisseurCode(tx: DbQueryer): Promise<string> {
   return `FOU-${pad(seq, 3)}`;
 }
 
+/** #165 — Physical machine: MCH-NNNNNN, allocated server-side in the creation transaction. */
+export async function generateMachineCode(tx: DbQueryer): Promise<string> {
+  const seq = await nextCodeValue(tx, "MCH");
+  return `MCH-${pad(seq, 6)}`;
+}
+
 /** #172 — Bon de commande fournisseur : BCF-AAAA-NNNN, alloué en transaction, immuable. */
 export async function generateCommandeFournisseurCode(tx: DbQueryer, params?: { date?: Date }): Promise<string> {
   return generateTransactionalBusinessCode(tx, { prefix: "BCF", date: params?.date });

--- a/src/shared/documents/document-upload.ts
+++ b/src/shared/documents/document-upload.ts
@@ -1,0 +1,80 @@
+import { createReadStream } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { HttpError } from "../../utils/httpError";
+
+const ALLOWED_DOCUMENT_EXTENSIONS = new Set([
+  ".pdf", ".png", ".jpg", ".jpeg", ".webp", ".gif", ".txt", ".csv",
+  ".doc", ".docx", ".xls", ".xlsx", ".odt", ".ods", ".stp", ".step", ".stl",
+]);
+
+const ALLOWED_DOCUMENT_MIME_TYPES = new Set([
+  "application/pdf", "image/png", "image/jpeg", "image/webp", "image/gif",
+  "text/plain", "text/csv", "application/vnd.ms-excel", "application/msword",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  "application/vnd.oasis.opendocument.text", "application/vnd.oasis.opendocument.spreadsheet",
+  "model/step", "model/stl", "application/step", "application/sla", "application/octet-stream",
+]);
+
+export function safeDocumentExtension(originalName: string): string {
+  const extension = path.extname(originalName).toLowerCase();
+  return /^\.[a-z0-9]+$/.test(extension) && extension.length <= 10 ? extension : "";
+}
+
+export function toPosixStoragePath(value: string): string {
+  return value.split(path.sep).join(path.posix.sep);
+}
+
+export async function sha256DocumentFile(filePath: string): Promise<string> {
+  const crypto = await import("node:crypto");
+  const hash = crypto.createHash("sha256");
+  const stream = createReadStream(filePath);
+  for await (const chunk of stream) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+async function hasExpectedMagicBytes(filePath: string, extension: string): Promise<boolean> {
+  let handle: fs.FileHandle | null = null;
+  try {
+    handle = await fs.open(filePath, "r");
+    const buffer = Buffer.alloc(8);
+    const { bytesRead } = await handle.read(buffer, 0, 8, 0);
+    const head = buffer.subarray(0, bytesRead);
+    const startsWith = (signature: number[]) => signature.every((byte, index) => head[index] === byte);
+    switch (extension) {
+      case ".pdf": return head.subarray(0, 5).toString("latin1") === "%PDF-";
+      case ".png": return startsWith([0x89, 0x50, 0x4e, 0x47]);
+      case ".jpg":
+      case ".jpeg": return startsWith([0xff, 0xd8, 0xff]);
+      case ".gif": return head.subarray(0, 3).toString("latin1") === "GIF";
+      case ".webp": return head.subarray(0, 4).toString("latin1") === "RIFF";
+      case ".docx":
+      case ".xlsx":
+      case ".ods":
+      case ".odt": return startsWith([0x50, 0x4b]);
+      case ".doc":
+      case ".xls": return startsWith([0xd0, 0xcf, 0x11, 0xe0]);
+      default: return true;
+    }
+  } catch {
+    return false;
+  } finally {
+    await handle?.close();
+  }
+}
+
+export async function assertDocumentUploadAllowed(file: Express.Multer.File): Promise<string> {
+  const extension = safeDocumentExtension(file.originalname);
+  if (!extension || !ALLOWED_DOCUMENT_EXTENSIONS.has(extension)) {
+    throw new HttpError(400, "UNSUPPORTED_FILE_TYPE", `Extension de fichier non autorisee: ${file.originalname}`);
+  }
+  if (!ALLOWED_DOCUMENT_MIME_TYPES.has(file.mimetype)) {
+    throw new HttpError(400, "UNSUPPORTED_MIME_TYPE", `Type MIME non autorise: ${file.mimetype}`);
+  }
+  if (!(await hasExpectedMagicBytes(file.path, extension))) {
+    throw new HttpError(400, "FILE_SIGNATURE_MISMATCH", `La signature du fichier ne correspond pas a ${extension}`);
+  }
+  return extension;
+}


### PR DESCRIPTION
Release backend du parc machines #165 depuis dev. Inclus : code MCH serveur, RBAC, audit, concurrence, Planning, maintenance, documents prives et patch SQL additif. Tests complets et CI GitHub verts. Blocage avant merge : preflight, sauvegarde, application et verify du patch sur cerp_test ; aucune ecriture cerp_prod autorisee depuis ce run.