### PR TITLE
feat(stock): sécuriser le référentiel maître Articles (#164)

### DIFF
--- a/db/patches/20260722_articles_164_master_data.sql
+++ b/db/patches/20260722_articles_164_master_data.sql
@@ -1,0 +1,180 @@
+-- Issue #164 - Article master data, traceability and lifecycle hardening.
+-- Additive/idempotent patch. Apply to cerp_test only after the matching preflight.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.articles') IS NULL
+     OR to_regclass('public.article_documents') IS NULL
+     OR to_regclass('public.fournisseur_catalogue') IS NULL THEN
+    RAISE EXCEPTION '#164 prerequisites missing: articles, article_documents and fournisseur_catalogue are required';
+  END IF;
+END $$;
+
+ALTER TABLE public.articles
+  ADD COLUMN IF NOT EXISTS designation_secondary text NULL,
+  ADD COLUMN IF NOT EXISTS is_sold boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS row_version integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS archived_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS archived_by integer NULL,
+  ADD COLUMN IF NOT EXISTS archive_reason text NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'articles_row_version_ck'
+      AND conrelid = 'public.articles'::regclass
+  ) THEN
+    ALTER TABLE public.articles
+      ADD CONSTRAINT articles_row_version_ck CHECK (row_version > 0);
+  END IF;
+
+  IF to_regclass('public.users') IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'articles_archived_by_fkey'
+      AND conrelid = 'public.articles'::regclass
+  ) THEN
+    ALTER TABLE public.articles
+      ADD CONSTRAINT articles_archived_by_fkey
+      FOREIGN KEY (archived_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS articles_archived_at_idx
+  ON public.articles(archived_at)
+  WHERE archived_at IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS articles_is_sold_idx
+  ON public.articles(is_sold)
+  WHERE is_sold = true;
+
+CREATE OR REPLACE FUNCTION public.fn_articles_master_data_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.code IS DISTINCT FROM NEW.code THEN
+    RAISE EXCEPTION 'ARTICLE_CODE_IMMUTABLE: Article code is immutable' USING ERRCODE = '23514';
+  END IF;
+
+  IF NEW.row_version <= OLD.row_version THEN
+    NEW.row_version := OLD.row_version + 1;
+  END IF;
+
+  IF NEW.is_active = true THEN
+    NEW.archived_at := NULL;
+    NEW.archived_by := NULL;
+    NEW.archive_reason := NULL;
+  ELSIF OLD.is_active = true AND NEW.archived_at IS NULL THEN
+    NEW.archived_at := now();
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_articles_master_data_guard ON public.articles;
+CREATE TRIGGER trg_articles_master_data_guard
+BEFORE UPDATE ON public.articles
+FOR EACH ROW EXECUTE FUNCTION public.fn_articles_master_data_guard();
+
+CREATE TABLE IF NOT EXISTS public.article_create_idempotence (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  article_id uuid NOT NULL REFERENCES public.articles(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT article_create_idempotence_key_uq UNIQUE (idempotency_key),
+  CONSTRAINT article_create_idempotence_key_len_ck CHECK (char_length(idempotency_key) BETWEEN 8 AND 200),
+  CONSTRAINT article_create_idempotence_hash_ck CHECK (request_hash ~ '^[0-9a-f]{64}$')
+);
+
+CREATE INDEX IF NOT EXISTS article_create_idempotence_article_idx
+  ON public.article_create_idempotence(article_id);
+
+CREATE TABLE IF NOT EXISTS public.article_procurement_profile (
+  article_id uuid PRIMARY KEY REFERENCES public.articles(id) ON DELETE CASCADE,
+  manufacturer_name text NULL,
+  manufacturer_reference text NULL,
+  preferred_catalogue_id uuid NULL,
+  packaging text NULL,
+  process text NULL,
+  finish text NULL,
+  requirements text NULL,
+  certificate_required boolean NOT NULL DEFAULT false,
+  min_stock numeric(18,3) NULL,
+  max_stock numeric(18,3) NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL,
+  updated_by integer NULL,
+  CONSTRAINT article_procurement_stock_ck CHECK (
+    (min_stock IS NULL OR min_stock >= 0)
+    AND (max_stock IS NULL OR max_stock >= 0)
+    AND (min_stock IS NULL OR max_stock IS NULL OR min_stock <= max_stock)
+  )
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'article_procurement_preferred_catalogue_fkey'
+      AND conrelid = 'public.article_procurement_profile'::regclass
+  ) THEN
+    ALTER TABLE public.article_procurement_profile
+      ADD CONSTRAINT article_procurement_preferred_catalogue_fkey
+      FOREIGN KEY (preferred_catalogue_id) REFERENCES public.fournisseur_catalogue(id) ON DELETE SET NULL;
+  END IF;
+
+  IF to_regclass('public.users') IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'article_procurement_created_by_fkey'
+      AND conrelid = 'public.article_procurement_profile'::regclass
+  ) THEN
+    ALTER TABLE public.article_procurement_profile
+      ADD CONSTRAINT article_procurement_created_by_fkey
+      FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+
+  IF to_regclass('public.users') IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'article_procurement_updated_by_fkey'
+      AND conrelid = 'public.article_procurement_profile'::regclass
+  ) THEN
+    ALTER TABLE public.article_procurement_profile
+      ADD CONSTRAINT article_procurement_updated_by_fkey
+      FOREIGN KEY (updated_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS article_procurement_manufacturer_idx
+  ON public.article_procurement_profile(lower(manufacturer_name))
+  WHERE manufacturer_name IS NOT NULL;
+
+ALTER TABLE public.article_documents
+  ADD COLUMN IF NOT EXISTS revision text NULL,
+  ADD COLUMN IF NOT EXISTS is_active boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS retired_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS retired_by integer NULL;
+
+DO $$
+BEGIN
+  IF to_regclass('public.users') IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'article_documents_retired_by_fkey'
+      AND conrelid = 'public.article_documents'::regclass
+  ) THEN
+    ALTER TABLE public.article_documents
+      ADD CONSTRAINT article_documents_retired_by_fkey
+      FOREIGN KEY (retired_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS article_documents_active_idx
+  ON public.article_documents(article_id, is_active)
+  WHERE is_active = true;
+
+COMMIT;

--- a/db/patches/support/20260722_articles_164_master_data.preflight.sql
+++ b/db/patches/support/20260722_articles_164_master_data.preflight.sql
@@ -1,0 +1,22 @@
+\set ON_ERROR_STOP on
+
+SELECT current_database() AS database_name, current_user AS database_user;
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#164 preflight is restricted to cerp_test (current=%)', current_database();
+  END IF;
+  IF to_regclass('public.articles') IS NULL
+     OR to_regclass('public.article_documents') IS NULL
+     OR to_regclass('public.fournisseur_catalogue') IS NULL THEN
+    RAISE EXCEPTION '#164 prerequisites are missing';
+  END IF;
+END $$;
+
+SELECT filename, applied_at
+FROM public.cerp_schema_migrations
+WHERE filename = '20260722_articles_164_master_data.sql';
+
+SELECT COUNT(*) AS articles_before FROM public.articles;
+SELECT COUNT(*) AS article_documents_before FROM public.article_documents;

--- a/db/patches/support/20260722_articles_164_master_data.rollback.sql
+++ b/db/patches/support/20260722_articles_164_master_data.rollback.sql
@@ -1,0 +1,48 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#164 rollback is restricted to cerp_test (current=%)', current_database();
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.article_create_idempotence)
+     OR EXISTS (SELECT 1 FROM public.article_procurement_profile)
+     OR EXISTS (
+       SELECT 1 FROM public.articles
+       WHERE designation_secondary IS NOT NULL OR is_sold OR archived_at IS NOT NULL OR archive_reason IS NOT NULL
+     )
+     OR EXISTS (
+       SELECT 1 FROM public.article_documents
+       WHERE revision IS NOT NULL OR is_active = false OR retired_at IS NOT NULL
+     ) THEN
+    RAISE EXCEPTION '#164 rollback refused: post-migration Article data exists';
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS public.article_documents_active_idx;
+ALTER TABLE public.article_documents
+  DROP CONSTRAINT IF EXISTS article_documents_retired_by_fkey,
+  DROP COLUMN IF EXISTS retired_by,
+  DROP COLUMN IF EXISTS retired_at,
+  DROP COLUMN IF EXISTS is_active,
+  DROP COLUMN IF EXISTS revision;
+
+DROP TABLE IF EXISTS public.article_procurement_profile;
+DROP TABLE IF EXISTS public.article_create_idempotence;
+
+DROP TRIGGER IF EXISTS trg_articles_master_data_guard ON public.articles;
+DROP FUNCTION IF EXISTS public.fn_articles_master_data_guard();
+DROP INDEX IF EXISTS public.articles_archived_at_idx;
+DROP INDEX IF EXISTS public.articles_is_sold_idx;
+ALTER TABLE public.articles
+  DROP CONSTRAINT IF EXISTS articles_archived_by_fkey,
+  DROP CONSTRAINT IF EXISTS articles_row_version_ck,
+  DROP COLUMN IF EXISTS archive_reason,
+  DROP COLUMN IF EXISTS archived_by,
+  DROP COLUMN IF EXISTS archived_at,
+  DROP COLUMN IF EXISTS row_version,
+  DROP COLUMN IF EXISTS is_sold,
+  DROP COLUMN IF EXISTS designation_secondary;
+
+DELETE FROM public.cerp_schema_migrations
+WHERE filename = '20260722_articles_164_master_data.sql';

--- a/db/patches/support/20260722_articles_164_master_data.verify.sql
+++ b/db/patches/support/20260722_articles_164_master_data.verify.sql
@@ -1,0 +1,21 @@
+\set ON_ERROR_STOP on
+
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'articles'
+  AND column_name IN ('designation_secondary','is_sold','row_version','archived_at','archived_by','archive_reason')
+ORDER BY column_name;
+
+SELECT to_regclass('public.article_create_idempotence') IS NOT NULL AS has_article_idempotence,
+       to_regclass('public.article_procurement_profile') IS NOT NULL AS has_procurement_profile;
+
+SELECT tgname
+FROM pg_trigger
+WHERE tgrelid = 'public.articles'::regclass
+  AND tgname = 'trg_articles_master_data_guard'
+  AND NOT tgisinternal;
+
+SELECT filename, applied_at
+FROM public.cerp_schema_migrations
+WHERE filename = '20260722_articles_164_master_data.sql';

--- a/docs/articles-master-data-164.md
+++ b/docs/articles-master-data-164.md
@@ -1,0 +1,48 @@
+# Articles — référentiel maître (#164)
+
+## Décision de source de vérité
+
+`public.articles` reste la source de vérité Article. Aucune table `article_master` parallèle n’est créée. Le code métier est réservé exclusivement par le serveur au format `ART-{FAM}-{SEQ6}` et devient immuable après insertion.
+
+Une version ou un indice technique appartient à `piece_technique_versions`. L’Article lié garde la même identité ; l’API expose seulement sa version technique actuellement applicable et l’historique des versions de la Pièce.
+
+## Contrat HTTP
+
+| Méthode | Route | Usage |
+|---|---|---|
+| `GET` | `/api/v1/stock/articles` | Recherche, filtres, tri et pagination serveur |
+| `POST` | `/api/v1/stock/articles` | Création idempotente ; en-tête `Idempotency-Key` obligatoire |
+| `GET` | `/api/v1/stock/articles/:id` | Fiche enrichie, approvisionnement, fournisseurs, documents |
+| `PATCH` | `/api/v1/stock/articles/:id` | Modification avec `expected_row_version` obligatoire |
+| `POST` | `/api/v1/stock/articles/:id/archive` | Archivage si aucun usage métier n’existe |
+| `POST` | `/api/v1/stock/articles/:id/reactivate` | Réactivation contrôlée |
+| `GET` | `/api/v1/stock/articles/:id/versions` | Versions techniques de la Pièce liée |
+| `GET` | `/api/v1/stock/articles/:id/where-used` | Nomenclatures, devis, commandes, OF, réceptions, lots, mouvements, livraisons |
+| `GET/POST/DELETE` | `/api/v1/stock/articles/:id/documents[...]` | Documents validés et retrait logique traçable |
+
+Le client ne peut envoyer `code` ni le modifier. Les écritures concurrentes retournent `409 ARTICLE_VERSION_CONFLICT`. Une clé d’idempotence réutilisée avec un autre contenu retourne `409 IDEMPOTENCY_KEY_REUSED`. L’archivage d’un Article utilisé retourne `409 ARTICLE_IN_USE` avec le nombre d’usages.
+
+## Sécurité et données sensibles
+
+- Lecture : utilisateur authentifié.
+- Écriture Article et documents : Directeur, Administrateur Système et Réseau, Secrétaire, Responsable Programmation, Responsable Qualité.
+- Archivage/réactivation : Directeur et Administrateur Système et Réseau.
+- Coûts fournisseurs : Directeur, Administrateur Système et Réseau et Secrétaire ; les autres rôles reçoivent des montants et devises à `null` avec `costs_redacted=true`.
+- Documents : dix fichiers maximum, 25 Mio chacun, extension/MIME/signature cohérents. Les chemins de stockage ne sont jamais exposés par l’API.
+- Toutes les créations, modifications, archives, réactivations et opérations documentaires alimentent le journal d’audit.
+
+## Base de données et exploitation
+
+Le patch additif est `db/patches/20260722_articles_164_master_data.sql`. Les scripts de préflight, vérification et rollback sont dans `db/patches/support/` ; préflight et rollback refusent toute base autre que `cerp_test`.
+
+La migration n’a pas été exécutée depuis ce workspace : aucun `DATABASE_URL` de test n’est configuré. Aucun accès à `cerp_prod` n’a été tenté. Procédure de validation :
+
+1. charger explicitement les identifiants de `cerp_test` ;
+2. exécuter le préflight ;
+3. appliquer le patch avec le registre `cerp_schema_migrations` ;
+4. exécuter le script de vérification ;
+5. tester création répétée avec la même clé, conflit de version, archivage utilisé et masquage des coûts.
+
+## Couverture automatisée
+
+`article-master-data-164.test.ts` couvre 125 scénarios de validation, auxquels s’ajoutent les tests de routes stock et de lien Article/Pièce. Le build TypeScript constitue le contrôle de contrat transversal.

--- a/src/__tests__/article-master-data-164.test.ts
+++ b/src/__tests__/article-master-data-164.test.ts
@@ -1,0 +1,109 @@
+import fs from "node:fs"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+import {
+  archiveArticleSchema,
+  createArticleSchema,
+  reactivateArticleSchema,
+  updateArticleSchema,
+} from "../module/stock/validators/stock.validators"
+import { canViewArticleCosts } from "../module/stock/stock-article.permissions"
+
+const validPurchasingCases = Array.from({ length: 40 }, (_, index) => ({
+  designation: `Article approvisionné ${index}`,
+  article_category: "achat" as const,
+  article_categories: [index % 2 ? "achat_revente" as const : "achat_transforme" as const],
+  family_code: `ACH${index}`,
+  stock_managed: index % 3 !== 0,
+  lot_tracking: false,
+  is_sold: index % 2 === 0,
+  procurement: {
+    manufacturer_name: `Fabricant ${index}`,
+    manufacturer_reference: `REF-${index}`,
+    min_stock: index,
+    max_stock: index + 10,
+    certificate_required: index % 2 === 0,
+  },
+}))
+
+const validMaterialCases = Array.from({ length: 20 }, (_, index) => ({
+  designation: `Matière ${index}`,
+  article_category: "matiere" as const,
+  article_categories: ["matiere_premiere" as const],
+  family_code: "MAT",
+  article_matiere: index % 2 === 0
+    ? { barre_a_decouper: true, longueur_unitaire_mm: index + 1, largeur_mm: 10 }
+    : { barre_a_decouper: false, longueur_mm: index + 1, diametre_mm: 12 },
+}))
+
+describe("#164 Article master-data validation matrix", () => {
+  it.each(validPurchasingCases)("accepts purchasing master-data case %#", (body) => {
+    const parsed = createArticleSchema.safeParse({ body })
+    expect(parsed.success).toBe(true)
+  })
+
+  it.each(validMaterialCases)("accepts material geometry case %#", (body) => {
+    const parsed = createArticleSchema.safeParse({ body })
+    expect(parsed.success).toBe(true)
+  })
+
+  it.each(Array.from({ length: 20 }, (_, index) => index))("rejects client supplied Article code case %#", (index) => {
+    const parsed = createArticleSchema.safeParse({
+      body: { code: `FORCED-${index}`, designation: "Injection interdite", family_code: "ACH" },
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it("rejects client-supplied technical version fields", () => {
+    expect(createArticleSchema.safeParse({
+      body: { designation: "Indice injecté", family_code: "ACH", version_number: 2 },
+    }).success).toBe(false)
+    expect(createArticleSchema.safeParse({
+      body: { designation: "Plan injecté", family_code: "ACH", plan_index: 3 },
+    }).success).toBe(false)
+  })
+
+  it.each(Array.from({ length: 20 }, (_, index) => index))("rejects lot tracking without stock case %#", (index) => {
+    const parsed = createArticleSchema.safeParse({
+      body: { designation: `Lot invalide ${index}`, family_code: "ACH", stock_managed: false, lot_tracking: true },
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it.each(Array.from({ length: 20 }, (_, index) => index))("rejects incoherent procurement thresholds case %#", (index) => {
+    const parsed = createArticleSchema.safeParse({
+      body: { designation: `Seuil invalide ${index}`, family_code: "ACH", procurement: { min_stock: 20 + index, max_stock: index } },
+    })
+    expect(parsed.success).toBe(false)
+  })
+
+  it("requires optimistic locking and keeps code outside the update contract", () => {
+    expect(updateArticleSchema.safeParse({ body: { designation: "X" } }).success).toBe(false)
+    expect(updateArticleSchema.safeParse({ body: { expected_row_version: 1, code: "FORCED" } }).success).toBe(false)
+    expect(updateArticleSchema.safeParse({ body: { expected_row_version: 1, designation: "Désignation corrigée" } }).success).toBe(true)
+  })
+
+  it("requires row versions on archive and reactivation", () => {
+    expect(archiveArticleSchema.safeParse({ body: { expected_row_version: 2, reason: "Obsolète" } }).success).toBe(true)
+    expect(archiveArticleSchema.safeParse({ body: {} }).success).toBe(false)
+    expect(reactivateArticleSchema.safeParse({ body: { expected_row_version: 3 } }).success).toBe(true)
+  })
+
+  it("redacts supplier costs outside the explicit role allow-list", () => {
+    expect(canViewArticleCosts("Directeur")).toBe(true)
+    expect(canViewArticleCosts("Secretaire")).toBe(true)
+    expect(canViewArticleCosts("Operateur")).toBe(false)
+    expect(canViewArticleCosts(undefined)).toBe(false)
+  })
+
+  it("ships immutable-code, idempotence and test-only rollback guards", () => {
+    const patch = fs.readFileSync(path.resolve("db/patches/20260722_articles_164_master_data.sql"), "utf8")
+    const rollback = fs.readFileSync(path.resolve("db/patches/support/20260722_articles_164_master_data.rollback.sql"), "utf8")
+    expect(patch).toContain("ARTICLE_CODE_IMMUTABLE")
+    expect(patch).toContain("article_create_idempotence")
+    expect(patch).toContain("row_version")
+    expect(rollback).toContain("current_database() <> 'cerp_test'")
+  })
+})

--- a/src/__tests__/article-piece-link.test.ts
+++ b/src/__tests__/article-piece-link.test.ts
@@ -11,7 +11,7 @@ describe("B5 — cohérence article fabriqué ↔ pièce technique (schéma de c
   it("rejette un article 'fabrique' SANS piece_technique_id", () => {
     expect(() =>
       createArticleSchema.parse({
-        body: { code: "PT-X", designation: "Test", family_code: "FAB", article_category: "fabrique" },
+        body: { designation: "Test", family_code: "FAB", article_category: "fabrique" },
       })
     ).toThrow()
   })
@@ -19,7 +19,6 @@ describe("B5 — cohérence article fabriqué ↔ pièce technique (schéma de c
   it("accepte un article 'fabrique' AVEC piece_technique_id", () => {
     const r = createArticleSchema.parse({
       body: {
-        code: "PT-X",
         designation: "Test",
         family_code: "FAB",
         article_category: "fabrique",
@@ -34,7 +33,6 @@ describe("B5 — cohérence article fabriqué ↔ pièce technique (schéma de c
     expect(() =>
       createArticleSchema.parse({
         body: {
-          code: "ACH-X",
           designation: "Test",
           family_code: "ACH",
           article_category: "achat",

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -153,8 +153,8 @@ describe("/api/v1/stock", () => {
     const res = await request(app)
       .post("/api/v1/stock/articles")
       .set("Authorization", "Bearer fake")
+      .set("Idempotency-Key", "test-fabricated-article-001")
       .send({
-        code: "PT-001-P1",
         projet_id: null,
         designation: "Pièce stockée",
         article_category: "fabrique",
@@ -162,7 +162,6 @@ describe("/api/v1/stock", () => {
         family_code: "PT",
         stock_managed: true,
         piece_technique_id: "22222222-2222-2222-2222-222222222222",
-        plan_index: 1,
         lot_tracking: false,
         is_active: true,
       });
@@ -251,8 +250,8 @@ describe("/api/v1/stock", () => {
     const res = await request(app)
       .post("/api/v1/stock/articles")
       .set("Authorization", "Bearer fake")
+      .set("Idempotency-Key", "test-material-article-001")
       .send({
-        code: "MP-PL-ALU-ETAT-50x10x1000",
         designation: "Alu plat",
         article_category: "matiere",
         article_categories: ["matiere_premiere"],

--- a/src/module/pieces-techniques/controllers/piece-article.controller.ts
+++ b/src/module/pieces-techniques/controllers/piece-article.controller.ts
@@ -14,11 +14,10 @@ import { createArticleSchema } from "../../stock/validators/stock.validators"
 
 const uuidSchema = z.string().uuid()
 const createOrLinkSchema = z.object({
-  code: z.string().trim().min(1).max(80).optional(),
   designation: z.string().trim().min(1).max(400).optional(),
   family_code: z.string().trim().min(1).max(40),
   stock_managed: z.boolean().optional(),
-})
+}).strict()
 
 function buildAuditContext(req: Request): AuditContext {
   const user = req.user
@@ -93,7 +92,6 @@ export const createOrLinkArticleFabrique: RequestHandler = async (req, res, next
       body: {
         // Placeholder pour satisfaire min(1) ; remplacé par "" ci-dessous si l'utilisateur ne fournit
         // pas de code → le backend génère alors le code fabriqué normalisé ({code_piece}-P{plan_index}).
-        code: input.code ?? "AUTO",
         designation: input.designation ?? p.rows[0].designation,
         family_code: input.family_code,
         article_category: "fabrique",
@@ -101,10 +99,10 @@ export const createOrLinkArticleFabrique: RequestHandler = async (req, res, next
         stock_managed: input.stock_managed ?? true,
       },
     }).body
-    const body = input.code ? parsed : { ...parsed, code: "" }
+    const body = parsed
 
     try {
-      const article = await createStockArticleSVC(body, audit)
+      const article = await createStockArticleSVC(body, audit, `piece-article-${id}`)
       res.status(201).json({ created: true, article })
     } catch (e) {
       if (isUniqueViolation(e)) {

--- a/src/module/stock/controllers/stock.controller.ts
+++ b/src/module/stock/controllers/stock.controller.ts
@@ -33,6 +33,11 @@ import {
   magasinIdParamSchema,
   upsertInventoryLineSchema,
   updateArticleSchema,
+  archiveArticleSchema,
+  reactivateArticleSchema,
+  listArticleVersionsQuerySchema,
+  listArticleWhereUsedQuerySchema,
+  articleDocumentMetadataSchema,
   updateEmplacementSchema,
   updateLotSchema,
   updateMagasinSchema,
@@ -52,6 +57,8 @@ import {
   type ListMatiereNuancesQueryDTO,
   type ListMatiereSousEtatsQueryDTO,
   type UpdateArticleBodyDTO,
+  type ArchiveArticleBodyDTO,
+  type ReactivateArticleBodyDTO,
   type UpdateEmplacementBodyDTO,
   type UpdateLotBodyDTO,
   type UpdateMagasinBodyDTO,
@@ -100,6 +107,10 @@ import {
   removeStockArticleDocumentSVC,
   removeStockMovementDocumentSVC,
   updateStockArticleSVC,
+  archiveStockArticleSVC,
+  reactivateStockArticleSVC,
+  listStockArticleVersionsSVC,
+  listStockArticleWhereUsedSVC,
   updateStockEmplacementSVC,
   updateStockLotSVC,
   updateStockMagasinSVC,
@@ -109,6 +120,8 @@ import {
   createStockMatiereNuanceSVC,
   createStockMatiereSousEtatSVC,
 } from "../services/stock.service";
+import { canViewArticleCosts } from "../stock-article.permissions";
+import { removeTemporaryArticleDocuments, validateArticleDocuments } from "../services/article-document-validation";
 
 export const listStockInventorySessions: RequestHandler = async (req, res, next) => {
   try {
@@ -232,6 +245,18 @@ function getMulterFiles(req: Request): Express.Multer.File[] {
   const files = (req as Request & { files?: unknown }).files;
   if (!Array.isArray(files)) return [];
   return files.filter(isMulterFile);
+}
+
+function getRequiredIdempotencyKey(req: Request): string {
+  const value = req.headers["idempotency-key"];
+  if (typeof value !== "string" || value.trim().length < 8 || value.trim().length > 200) {
+    throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "A valid Idempotency-Key header is required (8 to 200 characters).");
+  }
+  return value.trim();
+}
+
+function includeArticleCosts(req: Request): boolean {
+  return canViewArticleCosts(req.user?.role);
 }
 
 async function sendDocumentFile(
@@ -402,7 +427,7 @@ export const getStockArticlesKpis: RequestHandler = async (_req, res, next) => {
 export const getStockArticle: RequestHandler = async (req, res, next) => {
   try {
     const { id } = idParamSchema.parse({ params: req.params }).params;
-    const out = await getStockArticleSVC(id);
+    const out = await getStockArticleSVC(id, includeArticleCosts(req));
     if (!out) {
       res.status(404).json({ error: "Not found" });
       return;
@@ -417,7 +442,7 @@ export const createStockArticle: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req);
     const body: CreateArticleBodyDTO = createArticleSchema.parse({ body: req.body }).body;
-    const out = await createStockArticleSVC(body, audit);
+    const out = await createStockArticleSVC(body, audit, getRequiredIdempotencyKey(req), includeArticleCosts(req));
     res.status(201).json(out);
   } catch (err) {
     next(err);
@@ -441,7 +466,69 @@ export const updateStockArticle: RequestHandler = async (req, res, next) => {
     const audit = buildAuditContext(req);
     const { id } = idParamSchema.parse({ params: req.params }).params;
     const body: UpdateArticleBodyDTO = updateArticleSchema.parse({ body: req.body }).body;
-    const out = await updateStockArticleSVC(id, body, audit);
+    const out = await updateStockArticleSVC(id, body, audit, includeArticleCosts(req));
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const archiveStockArticle: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req);
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const body: ArchiveArticleBodyDTO = archiveArticleSchema.parse({ body: req.body }).body;
+    const out = await archiveStockArticleSVC(id, body, audit, includeArticleCosts(req));
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const reactivateStockArticle: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req);
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const body: ReactivateArticleBodyDTO = reactivateArticleSchema.parse({ body: req.body }).body;
+    const out = await reactivateStockArticleSVC(id, body, audit, includeArticleCosts(req));
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const listStockArticleVersions: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const filters = listArticleVersionsQuerySchema.parse(req.query);
+    const out = await listStockArticleVersionsSVC(id, filters);
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const listStockArticleWhereUsed: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const filters = listArticleWhereUsedQuerySchema.parse(req.query);
+    const out = await listStockArticleWhereUsedSVC(id, filters);
     if (!out) {
       res.status(404).json({ error: "Not found" });
       return;
@@ -746,17 +833,21 @@ export const listStockArticleDocuments: RequestHandler = async (req, res, next) 
 };
 
 export const attachStockArticleDocuments: RequestHandler = async (req, res, next) => {
+  const files = getMulterFiles(req);
   try {
     const audit = buildAuditContext(req);
     const { id } = idParamSchema.parse({ params: req.params }).params;
-    const files = getMulterFiles(req);
-    const out = await attachStockArticleDocumentsSVC(id, files, audit);
+    await validateArticleDocuments(files);
+    const metadata = articleDocumentMetadataSchema.parse({ body: req.body }).body;
+    const out = await attachStockArticleDocumentsSVC(id, files, metadata, audit);
     if (out === null) {
+      await removeTemporaryArticleDocuments(files);
       res.status(404).json({ error: "Not found" });
       return;
     }
     res.status(201).json(out);
   } catch (err) {
+    await removeTemporaryArticleDocuments(files);
     next(err);
   }
 };

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -13,6 +13,8 @@ import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-lo
 import type {
   ArticleCategory,
   ArticleBusinessCategory,
+  ArticleTechnicalVersion,
+  ArticleWhereUsedItem,
   Paginated,
   StockAnalytics,
   StockArticleCategoryOption,
@@ -67,6 +69,11 @@ import type {
   StockMovementTypeDTO,
   UpsertInventoryLineBodyDTO,
   UpdateArticleBodyDTO,
+  ArchiveArticleBodyDTO,
+  ReactivateArticleBodyDTO,
+  ListArticleVersionsQueryDTO,
+  ListArticleWhereUsedQueryDTO,
+  ArticleDocumentMetadataDTO,
   UpdateEmplacementBodyDTO,
   UpdateLotBodyDTO,
   UpdateMagasinBodyDTO,
@@ -1238,6 +1245,66 @@ async function syncArticleSubtypeDetails(
   );
 }
 
+async function syncArticleProcurementProfile(
+  client: Pick<PoolClient, "query">,
+  articleId: string,
+  procurement: CreateArticleBodyDTO["procurement"] | UpdateArticleBodyDTO["procurement"],
+  actorUserId: number
+) {
+  if (!procurement) return;
+
+  if (procurement.preferred_catalogue_id) {
+    const preferred = await client.query<{ ok: number }>(
+      `SELECT 1::int AS ok
+       FROM public.fournisseur_catalogue
+       WHERE id = $1::uuid AND article_id = $2::uuid AND actif = true
+       LIMIT 1`,
+      [procurement.preferred_catalogue_id, articleId]
+    );
+    if (!preferred.rows[0]?.ok) {
+      throw new HttpError(400, "INVALID_PREFERRED_SUPPLIER_REFERENCE", "The preferred supplier catalogue reference must be active and linked to this article.");
+    }
+  }
+
+  await client.query(
+    `
+      INSERT INTO public.article_procurement_profile (
+        article_id, manufacturer_name, manufacturer_reference, preferred_catalogue_id,
+        packaging, process, finish, requirements, certificate_required,
+        min_stock, max_stock, created_by, updated_by
+      )
+      VALUES ($1::uuid,$2,$3,$4::uuid,$5,$6,$7,$8,$9,$10,$11,$12,$12)
+      ON CONFLICT (article_id) DO UPDATE SET
+        manufacturer_name = EXCLUDED.manufacturer_name,
+        manufacturer_reference = EXCLUDED.manufacturer_reference,
+        preferred_catalogue_id = EXCLUDED.preferred_catalogue_id,
+        packaging = EXCLUDED.packaging,
+        process = EXCLUDED.process,
+        finish = EXCLUDED.finish,
+        requirements = EXCLUDED.requirements,
+        certificate_required = EXCLUDED.certificate_required,
+        min_stock = EXCLUDED.min_stock,
+        max_stock = EXCLUDED.max_stock,
+        updated_at = now(),
+        updated_by = EXCLUDED.updated_by
+    `,
+    [
+      articleId,
+      procurement.manufacturer_name ?? null,
+      procurement.manufacturer_reference ?? null,
+      procurement.preferred_catalogue_id ?? null,
+      procurement.packaging ?? null,
+      procurement.process ?? null,
+      procurement.finish ?? null,
+      procurement.requirements ?? null,
+      procurement.certificate_required ?? false,
+      procurement.min_stock ?? null,
+      procurement.max_stock ?? null,
+      actorUserId,
+    ]
+  );
+}
+
 async function getArticleStockSettings(client: Pick<PoolClient, "query">, articleId: string) {
   const res = await client.query<{ stock_managed: boolean; lot_tracking: boolean }>(
     `SELECT stock_managed, lot_tracking FROM public.articles WHERE id = $1::uuid LIMIT 1`,
@@ -1794,6 +1861,27 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
       OR COALESCE(pt.code_piece, '') ILIKE ${p}
       OR COALESCE(pt.designation, '') ILIKE ${p}
       OR COALESCE(pt.designation_2, '') ILIKE ${p}
+      OR EXISTS (
+        SELECT 1 FROM public.article_procurement_profile app
+        WHERE app.article_id = a.id
+          AND (COALESCE(app.manufacturer_name, '') ILIKE ${p} OR COALESCE(app.manufacturer_reference, '') ILIKE ${p})
+      )
+      OR EXISTS (
+        SELECT 1
+        FROM public.fournisseur_catalogue fc
+        JOIN public.fournisseurs f ON f.id = fc.fournisseur_id
+        WHERE fc.article_id = a.id
+          AND (
+            COALESCE(fc.reference_fournisseur, '') ILIKE ${p}
+            OR COALESCE(f.nom, f.raison_sociale, '') ILIKE ${p}
+            OR COALESCE(f.code, f.code_fournisseur, '') ILIKE ${p}
+          )
+      )
+      OR EXISTS (
+        SELECT 1 FROM public.piece_technique_versions ptv_search
+        WHERE ptv_search.piece_technique_id = a.piece_technique_id
+          AND (COALESCE(ptv_search.plan_reference, '') ILIKE ${p} OR COALESCE(ptv_search.indice, '') ILIKE ${p})
+      )
     )`);
   }
   if (filters.article_type) {
@@ -1848,6 +1936,7 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
       a.projet_id::int AS projet_id,
       a.code,
       a.designation,
+      a.designation_secondary,
       CASE WHEN ${normalizedArticleCategorySql("a.article_category")} = 'fabrique' THEN 'PIECE_TECHNIQUE' ELSE 'PURCHASED' END AS article_type,
       ${normalizedArticleCategorySql("a.article_category")} AS article_category,
       COALESCE(ac.categories, ARRAY[${normalizedBusinessCategorySql("a.article_category")}]::text[]) AS article_categories,
@@ -1858,7 +1947,18 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
       pt.designation AS piece_designation,
       a.unite,
       a.lot_tracking,
+      a.is_sold,
       a.is_active,
+      a.row_version::int AS row_version,
+      a.archived_at::text AS archived_at,
+      a.archive_reason,
+      CASE WHEN av.id IS NULL THEN NULL ELSE jsonb_build_object(
+        'id', av.id::text,
+        'indice', av.indice,
+        'statut', av.statut,
+        'plan_reference', av.plan_reference,
+        'date_application', av.date_application
+      ) END AS applicable_version,
       COALESCE(bs.qty_available, 0)::float8 AS qty_available,
       COALESCE(bs.qty_reserved, 0)::float8 AS qty_reserved,
       COALESCE(bs.qty_total, 0)::float8 AS qty_total,
@@ -1868,6 +1968,14 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
     FROM public.articles a
     LEFT JOIN public.pieces_techniques pt
       ON pt.id = a.piece_technique_id
+    LEFT JOIN LATERAL (
+      SELECT v.id, v.indice, v.statut, v.plan_reference, v.date_application::text AS date_application
+      FROM public.piece_technique_versions v
+      WHERE v.piece_technique_id = a.piece_technique_id
+        AND v.statut = 'APPLICABLE'
+      ORDER BY v.date_application DESC NULLS LAST, v.created_at DESC
+      LIMIT 1
+    ) av ON TRUE
     LEFT JOIN (
       SELECT
         article_id::text AS article_id,
@@ -1893,7 +2001,7 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
   return { items: rows.rows, total };
 }
 
-export async function repoGetArticle(id: string): Promise<StockArticleDetail | null> {
+export async function repoGetArticle(id: string, includeCosts = false): Promise<StockArticleDetail | null> {
   const res = await db.query<StockArticleDetail>(
     `
       SELECT
@@ -1906,6 +2014,7 @@ export async function repoGetArticle(id: string): Promise<StockArticleDetail | n
         a.projet_id::int AS projet_id,
         a.code,
         a.designation,
+        a.designation_secondary,
         CASE WHEN ${normalizedArticleCategorySql("a.article_category")} = 'fabrique' THEN 'PIECE_TECHNIQUE' ELSE 'PURCHASED' END AS article_type,
         ${normalizedArticleCategorySql("a.article_category")} AS article_category,
       COALESCE(ac.categories, ARRAY[${normalizedBusinessCategorySql("a.article_category")}]::text[]) AS article_categories,
@@ -1916,7 +2025,18 @@ export async function repoGetArticle(id: string): Promise<StockArticleDetail | n
         pt.designation AS piece_designation,
         a.unite,
          a.lot_tracking,
+         a.is_sold,
          a.is_active,
+         a.row_version::int AS row_version,
+         a.archived_at::text AS archived_at,
+         a.archive_reason,
+         CASE WHEN av.id IS NULL THEN NULL ELSE jsonb_build_object(
+           'id', av.id::text,
+           'indice', av.indice,
+           'statut', av.statut,
+           'plan_reference', av.plan_reference,
+           'date_application', av.date_application
+         ) END AS applicable_version,
          a.notes,
          CASE
            WHEN ${normalizedArticleCategorySql("a.article_category")} <> 'matiere' THEN NULL
@@ -1946,6 +2066,14 @@ export async function repoGetArticle(id: string): Promise<StockArticleDetail | n
          ON pt.id = a.piece_technique_id
        LEFT JOIN public.articles_matiere am
          ON am.article_id = a.id
+       LEFT JOIN LATERAL (
+         SELECT v.id, v.indice, v.statut, v.plan_reference, v.date_application::text AS date_application
+         FROM public.piece_technique_versions v
+         WHERE v.piece_technique_id = a.piece_technique_id
+           AND v.statut = 'APPLICABLE'
+         ORDER BY v.date_application DESC NULLS LAST, v.created_at DESC
+         LIMIT 1
+       ) av ON TRUE
        LEFT JOIN (
          SELECT
            article_id::text AS article_id,
@@ -1965,7 +2093,58 @@ export async function repoGetArticle(id: string): Promise<StockArticleDetail | n
     `,
     [id]
   );
-  return res.rows[0] ?? null;
+  const article = res.rows[0] ?? null;
+  if (!article) return null;
+
+  const [procurementRes, suppliersRes, documents] = await Promise.all([
+    db.query<NonNullable<StockArticleDetail["procurement"]>>(
+      `SELECT
+         manufacturer_name,
+         manufacturer_reference,
+         preferred_catalogue_id::text AS preferred_catalogue_id,
+         packaging,
+         process,
+         finish,
+         requirements,
+         certificate_required,
+         min_stock::float8 AS min_stock,
+         max_stock::float8 AS max_stock
+       FROM public.article_procurement_profile
+       WHERE article_id = $1::uuid`,
+      [id]
+    ),
+    db.query<StockArticleDetail["suppliers"][number]>(
+      `SELECT
+         fc.id::text AS catalogue_id,
+         f.id::text AS supplier_id,
+         COALESCE(f.code, f.code_fournisseur)::text AS supplier_code,
+         COALESCE(f.nom, f.raison_sociale)::text AS supplier_name,
+         fc.reference_fournisseur AS supplier_reference,
+         fc.unite AS unit,
+         CASE WHEN $2::boolean THEN fc.prix_unitaire::float8 ELSE NULL END AS unit_price,
+         CASE WHEN $2::boolean THEN fc.devise ELSE NULL END AS currency,
+         fc.delai_jours::int AS lead_time_days,
+         fc.moq::float8 AS moq,
+         fc.conditions,
+         (app.preferred_catalogue_id = fc.id) AS preferred,
+         fc.actif AS active
+       FROM public.fournisseur_catalogue fc
+       JOIN public.fournisseurs f ON f.id = fc.fournisseur_id
+       LEFT JOIN public.article_procurement_profile app ON app.article_id = fc.article_id
+       WHERE fc.article_id = $1::uuid
+       ORDER BY (app.preferred_catalogue_id = fc.id) DESC, fc.actif DESC, supplier_name ASC`,
+      [id, includeCosts]
+    ),
+    repoListArticleDocuments(id),
+  ]);
+
+  return {
+    ...article,
+    procurement: procurementRes.rows[0] ?? null,
+    suppliers: suppliersRes.rows,
+    documents: documents ?? [],
+    costs_redacted: !includeCosts,
+  };
 }
 
 export async function repoGetArticlesKpis(): Promise<StockArticleKpis> {
@@ -1999,18 +2178,44 @@ export async function repoGetArticlesKpis(): Promise<StockArticleKpis> {
   );
 }
 
-export async function repoCreateArticle(body: CreateArticleBodyDTO, audit: AuditContext): Promise<StockArticleDetail> {
+export async function repoCreateArticle(
+  body: CreateArticleBodyDTO,
+  audit: AuditContext,
+  idempotencyKey?: string | null,
+  includeCosts = false
+): Promise<StockArticleDetail> {
   const client = await db.connect();
+  const requestHash = crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex");
   try {
     await client.query("BEGIN");
+
+    if (idempotencyKey) {
+      const replay = await client.query<{ article_id: string; request_hash: string }>(
+        `SELECT article_id::text AS article_id, request_hash
+         FROM public.article_create_idempotence
+         WHERE idempotency_key = $1
+         FOR UPDATE`,
+        [idempotencyKey]
+      );
+      const existing = replay.rows[0];
+      if (existing) {
+        if (existing.request_hash !== requestHash) {
+          throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Idempotency-Key was reused with a different Article payload.");
+        }
+        await client.query("ROLLBACK");
+        const replayed = await repoGetArticle(existing.article_id, includeCosts);
+        if (!replayed) throw new Error("Failed to read idempotent Article replay");
+        return replayed;
+      }
+    }
 
     const normalized = await normalizeArticleState({
       article_type: body.article_type,
       article_category: body.article_category,
       article_categories: body.article_categories,
       family_code: body.family_code,
-      version_number: body.version_number,
-      plan_index: body.plan_index,
+      version_number: 1,
+      plan_index: 1,
       status: body.status,
       projet_id: body.projet_id ?? null,
       piece_technique_id: body.piece_technique_id ?? null,
@@ -2034,18 +2239,19 @@ export async function repoCreateArticle(body: CreateArticleBodyDTO, audit: Audit
       `
         INSERT INTO public.articles (
           id,
-          code, designation, article_type, article_category, family_code, stock_managed, piece_technique_id, unite,
+          code, designation, designation_secondary, article_type, article_category, family_code, stock_managed, piece_technique_id, unite,
           root_article_id, parent_article_id, version_number, plan_index, status, projet_id,
-          lot_tracking, is_active, notes,
+          lot_tracking, is_sold, is_active, notes,
           created_by, updated_by
         )
-        VALUES ($1::uuid,$2,$3,$4,$5,$6,$7,$8::uuid,$9,$10::uuid,$11::uuid,$12,$13,$14,$15,$16,$17,$18,$19,$19)
+        VALUES ($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9::uuid,$10,$11::uuid,$12::uuid,$13,$14,$15,$16,$17,$18,$19,$20,$21,$21)
         RETURNING id::text AS id
       `,
       [
         articleId,
         generatedCode,
         body.designation,
+        body.designation_secondary ?? null,
         normalized.article_type,
         normalized.article_category,
         normalized.family_code,
@@ -2059,6 +2265,7 @@ export async function repoCreateArticle(body: CreateArticleBodyDTO, audit: Audit
         normalized.status,
         normalized.projet_id,
         normalized.lot_tracking,
+        body.is_sold,
         body.is_active,
         body.notes ?? null,
         audit.user_id,
@@ -2082,6 +2289,15 @@ export async function repoCreateArticle(body: CreateArticleBodyDTO, audit: Audit
       piece_technique_id: normalized.piece_technique_id,
       article_matiere: body.article_matiere,
     });
+    await syncArticleProcurementProfile(client, id, body.procurement, audit.user_id);
+
+    if (idempotencyKey) {
+      await client.query(
+        `INSERT INTO public.article_create_idempotence (idempotency_key, request_hash, article_id)
+         VALUES ($1,$2,$3::uuid)`,
+        [idempotencyKey, requestHash, id]
+      );
+    }
 
     await insertAuditLog(client, audit, {
       action: "stock.articles.create",
@@ -2099,17 +2315,34 @@ export async function repoCreateArticle(body: CreateArticleBodyDTO, audit: Audit
         status: normalized.status,
         projet_id: normalized.projet_id,
         stock_managed: normalized.stock_managed,
+        is_sold: body.is_sold,
       },
     });
 
     await client.query("COMMIT");
 
-    const out = await repoGetArticle(id);
+    const out = await repoGetArticle(id, includeCosts);
     if (!out) throw new Error("Failed to read created article");
 
     return out;
   } catch (err) {
     await client.query("ROLLBACK");
+    if (idempotencyKey && isPgUniqueViolation(err)) {
+      const replay = await db.query<{ article_id: string; request_hash: string }>(
+        `SELECT article_id::text AS article_id, request_hash
+         FROM public.article_create_idempotence
+         WHERE idempotency_key = $1`,
+        [idempotencyKey]
+      );
+      const existing = replay.rows[0];
+      if (existing) {
+        if (existing.request_hash !== requestHash) {
+          throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Idempotency-Key was reused with a different Article payload.");
+        }
+        const replayed = await repoGetArticle(existing.article_id, includeCosts);
+        if (replayed) return replayed;
+      }
+    }
     if (isPgUniqueViolation(err)) {
       throw new HttpError(409, "DUPLICATE", "Article code already exists");
     }
@@ -2122,7 +2355,8 @@ export async function repoCreateArticle(body: CreateArticleBodyDTO, audit: Audit
 export async function repoUpdateArticle(
   id: string,
   patch: UpdateArticleBodyDTO,
-  audit: AuditContext
+  audit: AuditContext,
+  includeCosts = false
 ): Promise<StockArticleDetail | null> {
   const client = await db.connect();
   const sets: string[] = [];
@@ -2151,6 +2385,9 @@ export async function repoUpdateArticle(
       piece_technique_id: string | null;
       stock_managed: boolean;
       lot_tracking: boolean;
+      row_version: number;
+      designation_secondary: string | null;
+      is_sold: boolean;
     }>(
       `
         SELECT
@@ -2172,7 +2409,10 @@ export async function repoUpdateArticle(
           family_code,
           piece_technique_id::text AS piece_technique_id,
           stock_managed,
-          lot_tracking
+          lot_tracking,
+          row_version::int AS row_version,
+          designation_secondary,
+          is_sold
         FROM public.articles
         WHERE id = $1::uuid
         FOR UPDATE
@@ -2184,8 +2424,11 @@ export async function repoUpdateArticle(
       await client.query("ROLLBACK");
       return null;
     }
-    if (patch.code !== undefined) {
-      throw new HttpError(400, "CODE_IMMUTABLE", "Article business codes are server-generated and cannot be supplied on update.");
+    if (patch.expected_row_version !== current.row_version) {
+      throw new HttpError(409, "ARTICLE_VERSION_CONFLICT", "The Article changed since it was loaded.", {
+        expected_row_version: patch.expected_row_version,
+        current_row_version: current.row_version,
+      });
     }
 
     const normalized = await normalizeArticleState({
@@ -2193,8 +2436,8 @@ export async function repoUpdateArticle(
       article_category: patch.article_category ?? current.article_category,
       article_categories: patch.article_categories ?? current.article_categories,
       family_code: patch.family_code ?? current.family_code,
-      version_number: patch.version_number ?? current.version_number,
-      plan_index: patch.plan_index ?? current.plan_index,
+      version_number: current.version_number,
+      plan_index: current.plan_index,
       status: patch.status ?? current.status,
       projet_id: patch.projet_id !== undefined ? patch.projet_id : current.projet_id,
       piece_technique_id: patch.piece_technique_id !== undefined ? patch.piece_technique_id : current.piece_technique_id,
@@ -2210,6 +2453,7 @@ export async function repoUpdateArticle(
     }
 
     if (patch.designation !== undefined) sets.push(`designation = ${push(patch.designation)}`);
+    if (patch.designation_secondary !== undefined) sets.push(`designation_secondary = ${push(patch.designation_secondary)}`);
     sets.push(`article_type = ${push(normalized.article_type)}`);
     sets.push(`article_category = ${push(normalized.article_category)}`);
     sets.push(`version_number = ${push(normalized.version_number)}`);
@@ -2221,11 +2465,12 @@ export async function repoUpdateArticle(
     sets.push(`piece_technique_id = ${push(normalized.piece_technique_id)}::uuid`);
     if (patch.unite !== undefined) sets.push(`unite = ${push(patch.unite)}`);
     sets.push(`lot_tracking = ${push(normalized.lot_tracking)}`);
-    if (patch.is_active !== undefined) sets.push(`is_active = ${push(patch.is_active)}`);
+    if (patch.is_sold !== undefined) sets.push(`is_sold = ${push(patch.is_sold)}`);
     if (patch.notes !== undefined) sets.push(`notes = ${push(patch.notes)}`);
 
     sets.push(`updated_at = now()`);
     sets.push(`updated_by = ${push(audit.user_id)}`);
+    sets.push(`row_version = row_version + 1`);
 
     const sql = `
       UPDATE public.articles
@@ -2251,26 +2496,280 @@ export async function repoUpdateArticle(
       category: normalized.article_category,
       family_code: normalized.family_code,
       piece_technique_id: normalized.piece_technique_id,
+      article_matiere: patch.article_matiere,
     });
+    await syncArticleProcurementProfile(client, id, patch.procurement, audit.user_id);
 
     await insertAuditLog(client, audit, {
       action: "stock.articles.update",
       entity_type: "articles",
       entity_id: id,
       details: {
-        patch,
-        normalized,
+        before: current,
+        after: { ...normalized, designation_secondary: patch.designation_secondary ?? current.designation_secondary, is_sold: patch.is_sold ?? current.is_sold },
       },
     });
 
     await client.query("COMMIT");
 
-    return repoGetArticle(id);
+    return repoGetArticle(id, includeCosts);
   } catch (err) {
     await client.query("ROLLBACK");
     if (isPgUniqueViolation(err)) {
       throw new HttpError(409, "DUPLICATE", "Article code already exists");
     }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoListArticleVersions(
+  articleId: string,
+  filters: ListArticleVersionsQueryDTO
+): Promise<Paginated<ArticleTechnicalVersion> | null> {
+  const exists = await db.query<{ piece_technique_id: string | null }>(
+    `SELECT piece_technique_id::text AS piece_technique_id FROM public.articles WHERE id = $1::uuid`,
+    [articleId]
+  );
+  const article = exists.rows[0];
+  if (!article) return null;
+  if (!article.piece_technique_id) return { items: [], total: 0 };
+
+  const page = filters.page ?? 1;
+  const pageSize = filters.pageSize ?? 25;
+  const offset = (page - 1) * pageSize;
+  const count = await db.query<{ total: number }>(
+    `SELECT COUNT(*)::int AS total
+     FROM public.piece_technique_versions
+     WHERE piece_technique_id = $1::uuid`,
+    [article.piece_technique_id]
+  );
+  const rows = await db.query<ArticleTechnicalVersion>(
+    `SELECT
+       id::text AS id,
+       indice,
+       statut,
+       plan_reference,
+       date_application::text AS date_application
+     FROM public.piece_technique_versions
+     WHERE piece_technique_id = $1::uuid
+     ORDER BY date_application DESC NULLS LAST, created_at DESC, id DESC
+     LIMIT $2 OFFSET $3`,
+    [article.piece_technique_id, pageSize, offset]
+  );
+  return { items: rows.rows, total: count.rows[0]?.total ?? 0 };
+}
+
+const ARTICLE_WHERE_USED_CTE = `
+  WITH article_context AS (
+    SELECT id, piece_technique_id
+    FROM public.articles
+    WHERE id = $1::uuid
+  ), usages AS (
+    SELECT
+      CASE WHEN parent_version.statut = 'APPLICABLE' THEN 'PIECE_CURRENT' ELSE 'PIECE_HISTORICAL' END::text AS usage_type,
+      bom.id::text AS usage_id,
+      bom.parent_piece_technique_id::text AS parent_id,
+      concat('Nomenclature ', COALESCE(parent_piece.code_piece, bom.parent_piece_technique_id::text)) AS label,
+      bom.created_at::text AS occurred_at
+    FROM public.pieces_techniques_nomenclature bom
+    JOIN article_context ac ON bom.child_article_id = ac.id
+    LEFT JOIN public.piece_technique_versions parent_version ON parent_version.id = bom.parent_piece_technique_version_id
+    LEFT JOIN public.pieces_techniques parent_piece ON parent_piece.id = bom.parent_piece_technique_id
+
+    UNION ALL
+    SELECT 'QUOTE', dl.id::text, dl.devis_id::text,
+      concat('Devis ', dl.devis_id::text, ' · ligne ', dl.id::text), NULL::text
+    FROM public.devis_ligne dl JOIN article_context ac ON dl.article_id = ac.id
+
+    UNION ALL
+    SELECT 'CUSTOMER_ORDER', cl.id::text, cl.commande_id::text,
+      concat('Commande client ', cl.commande_id::text, ' · ligne ', cl.id::text), NULL::text
+    FROM public.commande_ligne cl JOIN article_context ac ON cl.article_id = ac.id
+
+    UNION ALL
+    SELECT 'SUPPLIER_ORDER', cfl.id::text, cfl.commande_id::text,
+      concat('Commande fournisseur ', cfl.commande_id::text, ' · ligne ', cfl.position::text), cfl.created_at::text
+    FROM public.commande_fournisseur_ligne cfl JOIN article_context ac ON cfl.article_id = ac.id
+
+    UNION ALL
+    SELECT 'WORK_ORDER', ofa.id::text, ofa.id::text,
+      concat('OF ', ofa.numero), ofa.created_at::text
+    FROM public.ordres_fabrication ofa JOIN article_context ac ON ofa.piece_technique_id = ac.piece_technique_id
+    WHERE ac.piece_technique_id IS NOT NULL
+
+    UNION ALL
+    SELECT 'RECEIPT', rfl.id::text, rfl.reception_id::text,
+      concat('Réception ', rfl.reception_id::text, ' · ligne ', rfl.line_no::text), rfl.created_at::text
+    FROM public.reception_fournisseur_lignes rfl JOIN article_context ac ON rfl.article_id = ac.id
+
+    UNION ALL
+    SELECT 'LOT', l.id::text, NULL::text,
+      concat('Lot ', l.lot_code), l.created_at::text
+    FROM public.lots l JOIN article_context ac ON l.article_id::text = ac.id::text
+
+    UNION ALL
+    SELECT 'STOCK_MOVEMENT', sml.id::text, sml.movement_id::text,
+      concat('Mouvement de stock ', sml.movement_id::text, ' · ligne ', sml.line_no::text), sml.created_at::text
+    FROM public.stock_movement_lines sml JOIN article_context ac ON sml.article_id::text = ac.id::text
+
+    UNION ALL
+    SELECT 'DELIVERY', blla.id::text, blla.bon_livraison_ligne_id::text,
+      concat('Livraison · ligne ', blla.bon_livraison_ligne_id::text), blla.created_at::text
+    FROM public.bon_livraison_ligne_allocations blla JOIN article_context ac ON blla.article_id = ac.id
+  )`;
+
+export async function repoListArticleWhereUsed(
+  articleId: string,
+  filters: ListArticleWhereUsedQueryDTO
+): Promise<Paginated<ArticleWhereUsedItem> | null> {
+  const exists = await db.query<{ ok: number }>(`SELECT 1::int AS ok FROM public.articles WHERE id = $1::uuid`, [articleId]);
+  if (!exists.rows[0]?.ok) return null;
+
+  const page = filters.page ?? 1;
+  const pageSize = filters.pageSize ?? 25;
+  const offset = (page - 1) * pageSize;
+  const usageType = filters.usage_type ?? null;
+  const count = await db.query<{ total: number }>(
+    `${ARTICLE_WHERE_USED_CTE}
+     SELECT COUNT(*)::int AS total FROM usages WHERE ($2::text IS NULL OR usage_type = $2)`,
+    [articleId, usageType]
+  );
+  const rows = await db.query<ArticleWhereUsedItem>(
+    `${ARTICLE_WHERE_USED_CTE}
+     SELECT usage_type, usage_id, parent_id, label, occurred_at
+     FROM usages
+     WHERE ($2::text IS NULL OR usage_type = $2)
+     ORDER BY occurred_at DESC NULLS LAST, usage_type ASC, usage_id DESC
+     LIMIT $3 OFFSET $4`,
+    [articleId, usageType, pageSize, offset]
+  );
+  return { items: rows.rows, total: count.rows[0]?.total ?? 0 };
+}
+
+async function countArticleUsages(client: PoolClient, articleId: string): Promise<number> {
+  const result = await client.query<{ total: number }>(
+    `${ARTICLE_WHERE_USED_CTE} SELECT COUNT(*)::int AS total FROM usages`,
+    [articleId]
+  );
+  return result.rows[0]?.total ?? 0;
+}
+
+export async function repoArchiveArticle(
+  articleId: string,
+  body: ArchiveArticleBodyDTO,
+  audit: AuditContext,
+  includeCosts = false
+): Promise<StockArticleDetail | null> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const currentRes = await client.query<{ code: string; row_version: number; is_active: boolean }>(
+      `SELECT code, row_version::int AS row_version, is_active
+       FROM public.articles WHERE id = $1::uuid FOR UPDATE`,
+      [articleId]
+    );
+    const current = currentRes.rows[0];
+    if (!current) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+    if (body.expected_row_version !== current.row_version) {
+      throw new HttpError(409, "ARTICLE_VERSION_CONFLICT", "The Article changed since it was loaded.", {
+        expected_row_version: body.expected_row_version,
+        current_row_version: current.row_version,
+      });
+    }
+    if (!current.is_active) {
+      await client.query("COMMIT");
+      return repoGetArticle(articleId, includeCosts);
+    }
+    const usageCount = await countArticleUsages(client, articleId);
+    if (usageCount > 0) {
+      throw new HttpError(409, "ARTICLE_IN_USE", "An Article referenced by business records cannot be archived.", {
+        usage_count: usageCount,
+      });
+    }
+    await client.query(
+      `UPDATE public.articles
+       SET is_active = false,
+           archived_at = now(),
+           archived_by = $2,
+           archive_reason = $3,
+           row_version = row_version + 1,
+           updated_at = now(),
+           updated_by = $2
+       WHERE id = $1::uuid`,
+      [articleId, audit.user_id, body.reason ?? null]
+    );
+    await insertAuditLog(client, audit, {
+      action: "stock.articles.archive",
+      entity_type: "articles",
+      entity_id: articleId,
+      details: { code: current.code, before: { is_active: true }, after: { is_active: false, reason: body.reason ?? null } },
+    });
+    await client.query("COMMIT");
+    return repoGetArticle(articleId, includeCosts);
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoReactivateArticle(
+  articleId: string,
+  body: ReactivateArticleBodyDTO,
+  audit: AuditContext,
+  includeCosts = false
+): Promise<StockArticleDetail | null> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const currentRes = await client.query<{ code: string; row_version: number; is_active: boolean }>(
+      `SELECT code, row_version::int AS row_version, is_active
+       FROM public.articles WHERE id = $1::uuid FOR UPDATE`,
+      [articleId]
+    );
+    const current = currentRes.rows[0];
+    if (!current) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+    if (body.expected_row_version !== current.row_version) {
+      throw new HttpError(409, "ARTICLE_VERSION_CONFLICT", "The Article changed since it was loaded.", {
+        expected_row_version: body.expected_row_version,
+        current_row_version: current.row_version,
+      });
+    }
+    if (current.is_active) {
+      await client.query("COMMIT");
+      return repoGetArticle(articleId, includeCosts);
+    }
+    await client.query(
+      `UPDATE public.articles
+       SET is_active = true,
+           archived_at = NULL,
+           archived_by = NULL,
+           archive_reason = NULL,
+           row_version = row_version + 1,
+           updated_at = now(),
+           updated_by = $2
+       WHERE id = $1::uuid`,
+      [articleId, audit.user_id]
+    );
+    await insertAuditLog(client, audit, {
+      action: "stock.articles.reactivate",
+      entity_type: "articles",
+      entity_id: articleId,
+      details: { code: current.code, before: { is_active: false }, after: { is_active: true } },
+    });
+    await client.query("COMMIT");
+    return repoGetArticle(articleId, includeCosts);
+  } catch (err) {
+    await client.query("ROLLBACK");
     throw err;
   } finally {
     client.release();
@@ -4235,10 +4734,20 @@ export async function repoListArticleDocuments(articleId: string): Promise<Stock
       SELECT
         sd.id::text AS document_id,
         sd.original_name AS document_name,
-        ad.type
+        ad.type,
+        ad.revision,
+        ad.version::int AS version,
+        sd.mime_type,
+        sd.size_bytes::float8 AS size_bytes,
+        sd.sha256,
+        ad.uploaded_by,
+        ad.created_at::text AS created_at,
+        ad.updated_at::text AS updated_at,
+        ad.is_active
       FROM public.article_documents ad
       JOIN public.stock_documents sd ON sd.id = ad.document_id
       WHERE ad.article_id = $1::uuid
+        AND ad.is_active = true
         AND sd.removed_at IS NULL
       ORDER BY ad.created_at DESC, ad.id DESC
     `,
@@ -4250,6 +4759,7 @@ export async function repoListArticleDocuments(articleId: string): Promise<Stock
 export async function repoAttachArticleDocuments(
   articleId: string,
   documents: UploadedDocument[],
+  metadata: ArticleDocumentMetadataDTO,
   audit: AuditContext
 ): Promise<StockDocument[] | null> {
   const client = await db.connect();
@@ -4270,11 +4780,14 @@ export async function repoAttachArticleDocuments(
     for (const d of inserted) {
       await client.query(
         `
-          INSERT INTO public.article_documents (article_id, document_id, type, version, uploaded_by, created_by, updated_by)
-          VALUES ($1::uuid,$2::uuid,$3,$4,$5,$5,$5)
+          INSERT INTO public.article_documents (
+            article_id, document_id, type, revision, version, is_active,
+            uploaded_by, created_by, updated_by
+          )
+          VALUES ($1::uuid,$2::uuid,$3,$4,$5,true,$6,$6,$6)
           ON CONFLICT DO NOTHING
         `,
-        [articleId, d.id, null, 1, audit.user_id]
+        [articleId, d.id, metadata.type ?? null, metadata.revision ?? null, 1, audit.user_id]
       );
     }
 
@@ -4284,6 +4797,7 @@ export async function repoAttachArticleDocuments(
       entity_id: articleId,
       details: {
         count: inserted.length,
+        metadata,
         documents: inserted.map((d) => ({
           id: d.id,
           original_name: d.original_name,
@@ -4322,19 +4836,22 @@ export async function repoRemoveArticleDocument(
     }
 
     const del = await client.query(
-      `DELETE FROM public.article_documents WHERE article_id = $1::uuid AND document_id = $2::uuid`,
-      [articleId, documentId]
+      `UPDATE public.article_documents
+       SET is_active = false,
+           retired_at = now(),
+           retired_by = $3,
+           updated_at = now(),
+           updated_by = $3
+       WHERE article_id = $1::uuid
+         AND document_id = $2::uuid
+         AND is_active = true`,
+      [articleId, documentId, audit.user_id]
     );
     const removed = (del.rowCount ?? 0) > 0;
     if (!removed) {
       await client.query("ROLLBACK");
       return false;
     }
-
-    await client.query(
-      `UPDATE public.stock_documents SET removed_at = now(), removed_by = $2, updated_at = now(), updated_by = $2 WHERE id = $1::uuid AND removed_at IS NULL`,
-      [documentId, audit.user_id]
-    );
 
     await insertAuditLog(client, audit, {
       action: "stock.articles.documents.remove",
@@ -4368,6 +4885,7 @@ export async function repoGetArticleDocumentForDownload(
       JOIN public.stock_documents sd ON sd.id = ad.document_id
       WHERE ad.article_id = $1::uuid
         AND ad.document_id = $2::uuid
+        AND ad.is_active = true
         AND sd.removed_at IS NULL
       LIMIT 1
     `,

--- a/src/module/stock/routes/stock.routes.ts
+++ b/src/module/stock/routes/stock.routes.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import multer from "multer";
 
-import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import { authenticateToken, authorizeRole } from "../../auth/middlewares/auth.middleware";
 import { ensureTmpStoragePath } from "../../../utils/cerpStorage";
 import {
   attachStockArticleDocuments,
@@ -51,6 +51,10 @@ import {
   removeStockMovementDocument,
   upsertStockInventorySessionLine,
   updateStockArticle,
+  archiveStockArticle,
+  reactivateStockArticle,
+  listStockArticleVersions,
+  listStockArticleWhereUsed,
   updateStockEmplacement,
   updateStockLot,
   updateStockMagasin,
@@ -60,6 +64,11 @@ import {
   linkArticlePieceTechnique,
   unlinkArticlePieceTechnique,
 } from "../controllers/article-piece-link.controller";
+import {
+  ARTICLE_ARCHIVE_ROLES,
+  ARTICLE_DOCUMENT_WRITE_ROLES,
+  ARTICLE_WRITE_ROLES,
+} from "../stock-article.permissions";
 
 const router = Router();
 
@@ -74,22 +83,30 @@ const upload = multer({
 
 router.use(authenticateToken);
 
+const requireArticleWrite = authorizeRole(...ARTICLE_WRITE_ROLES);
+const requireArticleArchive = authorizeRole(...ARTICLE_ARCHIVE_ROLES);
+const requireArticleDocumentWrite = authorizeRole(...ARTICLE_DOCUMENT_WRITE_ROLES);
+
 router.get("/analytics", getStockAnalytics);
 router.get("/article-categories", listStockArticleCategories);
 router.get("/article-families", listStockArticleFamilies);
-router.post("/article-families", createStockArticleFamily);
+router.post("/article-families", requireArticleWrite, createStockArticleFamily);
 router.get("/matiere-nuances", listStockMatiereNuances);
-router.post("/matiere-nuances", createStockMatiereNuance);
+router.post("/matiere-nuances", requireArticleWrite, createStockMatiereNuance);
 router.get("/matiere-etats", listStockMatiereEtats);
-router.post("/matiere-etats", createStockMatiereEtat);
+router.post("/matiere-etats", requireArticleWrite, createStockMatiereEtat);
 router.get("/matiere-sous-etats", listStockMatiereSousEtats);
-router.post("/matiere-sous-etats", createStockMatiereSousEtat);
+router.post("/matiere-sous-etats", requireArticleWrite, createStockMatiereSousEtat);
 router.get("/articles", listStockArticles);
 router.get("/articles/kpis", getStockArticlesKpis);
 router.get("/articles/code-preview", previewStockArticleCode);
-router.post("/articles", createStockArticle);
+router.post("/articles", requireArticleWrite, createStockArticle);
 router.get("/articles/:id", getStockArticle);
-router.patch("/articles/:id", updateStockArticle);
+router.patch("/articles/:id", requireArticleWrite, updateStockArticle);
+router.post("/articles/:id/archive", requireArticleArchive, archiveStockArticle);
+router.post("/articles/:id/reactivate", requireArticleArchive, reactivateStockArticle);
+router.get("/articles/:id/versions", listStockArticleVersions);
+router.get("/articles/:id/where-used", listStockArticleWhereUsed);
 
 router.get("/inventory-sessions", listStockInventorySessions);
 router.post("/inventory-sessions", createStockInventorySession);
@@ -100,12 +117,12 @@ router.post("/inventory-sessions/:id/close", closeStockInventorySession);
 
 // GPAO B5 — lien Article fabriqué ↔ Pièce technique
 router.get("/articles/:id/definition-technique", getArticleDefinitionTechnique);
-router.post("/articles/:id/link-piece-technique", linkArticlePieceTechnique);
-router.delete("/articles/:id/link-piece-technique", unlinkArticlePieceTechnique);
+router.post("/articles/:id/link-piece-technique", requireArticleWrite, linkArticlePieceTechnique);
+router.delete("/articles/:id/link-piece-technique", requireArticleWrite, unlinkArticlePieceTechnique);
 
 router.get("/articles/:id/documents", listStockArticleDocuments);
-router.post("/articles/:id/documents", upload.array("documents[]"), attachStockArticleDocuments);
-router.delete("/articles/:id/documents/:docId", removeStockArticleDocument);
+router.post("/articles/:id/documents", requireArticleDocumentWrite, upload.array("documents[]", 10), attachStockArticleDocuments);
+router.delete("/articles/:id/documents/:docId", requireArticleDocumentWrite, removeStockArticleDocument);
 router.get("/articles/:id/documents/:docId/file", downloadStockArticleDocument);
 
 router.get("/magasins", listStockMagasins);

--- a/src/module/stock/services/article-document-validation.ts
+++ b/src/module/stock/services/article-document-validation.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { HttpError } from "../../../utils/httpError";
+
+const MIME_BY_EXTENSION: Record<string, readonly string[]> = {
+  ".pdf": ["application/pdf"],
+  ".png": ["image/png"],
+  ".jpg": ["image/jpeg"],
+  ".jpeg": ["image/jpeg"],
+  ".docx": ["application/vnd.openxmlformats-officedocument.wordprocessingml.document", "application/zip", "application/octet-stream"],
+  ".xlsx": ["application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", "application/zip", "application/octet-stream"],
+  ".pptx": ["application/vnd.openxmlformats-officedocument.presentationml.presentation", "application/zip", "application/octet-stream"],
+  ".txt": ["text/plain", "application/octet-stream"],
+  ".csv": ["text/csv", "text/plain", "application/vnd.ms-excel", "application/octet-stream"],
+  ".dxf": ["application/dxf", "image/vnd.dxf", "text/plain", "application/octet-stream"],
+  ".step": ["application/step", "model/step", "text/plain", "application/octet-stream"],
+  ".stp": ["application/step", "model/step", "text/plain", "application/octet-stream"],
+};
+
+function startsWith(bytes: Buffer, signature: readonly number[]): boolean {
+  return signature.every((value, index) => bytes[index] === value);
+}
+
+function signatureMatches(ext: string, bytes: Buffer): boolean {
+  if (ext === ".pdf") return bytes.subarray(0, 5).toString("ascii") === "%PDF-";
+  if (ext === ".png") return startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  if (ext === ".jpg" || ext === ".jpeg") return startsWith(bytes, [0xff, 0xd8, 0xff]);
+  if (ext === ".docx" || ext === ".xlsx" || ext === ".pptx") return startsWith(bytes, [0x50, 0x4b, 0x03, 0x04]);
+
+  if ([".txt", ".csv", ".dxf", ".step", ".stp"].includes(ext)) {
+    return !bytes.includes(0x00);
+  }
+  return false;
+}
+
+async function readPrefix(filePath: string): Promise<Buffer> {
+  const handle = await fs.open(filePath, "r");
+  try {
+    const bytes = Buffer.alloc(512);
+    const result = await handle.read(bytes, 0, bytes.length, 0);
+    return bytes.subarray(0, result.bytesRead);
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function validateArticleDocuments(files: Express.Multer.File[]): Promise<void> {
+  if (files.length === 0) throw new HttpError(400, "ARTICLE_DOCUMENT_REQUIRED", "At least one document is required.");
+  if (files.length > 10) throw new HttpError(400, "ARTICLE_DOCUMENT_LIMIT", "At most 10 documents may be uploaded at once.");
+
+  for (const file of files) {
+    if (!file.size) throw new HttpError(400, "ARTICLE_DOCUMENT_EMPTY", `Document ${file.originalname} is empty.`);
+    const ext = path.extname(file.originalname).toLowerCase();
+    const allowedMimes = MIME_BY_EXTENSION[ext];
+    if (!allowedMimes) {
+      throw new HttpError(415, "ARTICLE_DOCUMENT_EXTENSION_UNSUPPORTED", `Document extension ${ext || "(none)"} is not allowed.`);
+    }
+    if (!allowedMimes.includes(file.mimetype.toLowerCase())) {
+      throw new HttpError(415, "ARTICLE_DOCUMENT_MIME_MISMATCH", `Document ${file.originalname} has an unexpected MIME type.`);
+    }
+    const prefix = await readPrefix(file.path);
+    if (!signatureMatches(ext, prefix)) {
+      throw new HttpError(415, "ARTICLE_DOCUMENT_SIGNATURE_MISMATCH", `Document ${file.originalname} does not match its declared format.`);
+    }
+  }
+}
+
+export async function removeTemporaryArticleDocuments(files: Express.Multer.File[]): Promise<void> {
+  await Promise.all(files.map((file) => fs.unlink(file.path).catch(() => undefined)));
+}

--- a/src/module/stock/services/stock.service.ts
+++ b/src/module/stock/services/stock.service.ts
@@ -35,6 +35,8 @@ import type {
   ListAnalyticsQueryDTO,
   ListInventorySessionsQueryDTO,
   ListArticlesQueryDTO,
+  ListArticleVersionsQueryDTO,
+  ListArticleWhereUsedQueryDTO,
   ListArticleFamiliesQueryDTO,
   ListMatiereEtatsQueryDTO,
   ListMatiereNuancesQueryDTO,
@@ -46,6 +48,9 @@ import type {
   ListMovementsQueryDTO,
   UpsertInventoryLineBodyDTO,
   UpdateArticleBodyDTO,
+  ArchiveArticleBodyDTO,
+  ReactivateArticleBodyDTO,
+  ArticleDocumentMetadataDTO,
   UpdateEmplacementBodyDTO,
   UpdateLotBodyDTO,
   UpdateMagasinBodyDTO,
@@ -96,6 +101,10 @@ import {
   repoRemoveMovementDocument,
   repoUpsertInventoryLine,
   repoUpdateArticle,
+  repoArchiveArticle,
+  repoReactivateArticle,
+  repoListArticleVersions,
+  repoListArticleWhereUsed,
   repoUpdateEmplacement,
   repoUpdateLot,
   repoUpdateMagasin,
@@ -135,8 +144,8 @@ export async function listStockArticlesSVC(filters: ListArticlesQueryDTO) {
   return repoListArticles(filters);
 }
 
-export async function getStockArticleSVC(id: string): Promise<StockArticleDetail | null> {
-  return repoGetArticle(id);
+export async function getStockArticleSVC(id: string, includeCosts = false): Promise<StockArticleDetail | null> {
+  return repoGetArticle(id, includeCosts);
 }
 
 export async function getStockArticlesKpisSVC(): Promise<StockArticleKpis> {
@@ -182,16 +191,48 @@ export async function createStockArticleFamilySVC(
   return repoCreateArticleFamily(body, audit);
 }
 
-export async function createStockArticleSVC(body: CreateArticleBodyDTO, audit: AuditContext): Promise<StockArticleDetail> {
-  return repoCreateArticle(body, audit);
+export async function createStockArticleSVC(
+  body: CreateArticleBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string,
+  includeCosts = false
+): Promise<StockArticleDetail> {
+  return repoCreateArticle(body, audit, idempotencyKey, includeCosts);
 }
 
 export async function updateStockArticleSVC(
   id: string,
   patch: UpdateArticleBodyDTO,
-  audit: AuditContext
+  audit: AuditContext,
+  includeCosts = false
 ): Promise<StockArticleDetail | null> {
-  return repoUpdateArticle(id, patch, audit);
+  return repoUpdateArticle(id, patch, audit, includeCosts);
+}
+
+export async function archiveStockArticleSVC(
+  id: string,
+  body: ArchiveArticleBodyDTO,
+  audit: AuditContext,
+  includeCosts = false
+): Promise<StockArticleDetail | null> {
+  return repoArchiveArticle(id, body, audit, includeCosts);
+}
+
+export async function reactivateStockArticleSVC(
+  id: string,
+  body: ReactivateArticleBodyDTO,
+  audit: AuditContext,
+  includeCosts = false
+): Promise<StockArticleDetail | null> {
+  return repoReactivateArticle(id, body, audit, includeCosts);
+}
+
+export async function listStockArticleVersionsSVC(id: string, filters: ListArticleVersionsQueryDTO) {
+  return repoListArticleVersions(id, filters);
+}
+
+export async function listStockArticleWhereUsedSVC(id: string, filters: ListArticleWhereUsedQueryDTO) {
+  return repoListArticleWhereUsed(id, filters);
 }
 
 export async function listStockMagasinsSVC(filters: ListMagasinsQueryDTO) {
@@ -297,9 +338,10 @@ export async function listStockArticleDocumentsSVC(articleId: string): Promise<S
 export async function attachStockArticleDocumentsSVC(
   articleId: string,
   documents: Express.Multer.File[],
+  metadata: ArticleDocumentMetadataDTO,
   audit: AuditContext
 ): Promise<StockDocument[] | null> {
-  return repoAttachArticleDocuments(articleId, documents, audit);
+  return repoAttachArticleDocuments(articleId, documents, metadata, audit);
 }
 
 export async function removeStockArticleDocumentSVC(

--- a/src/module/stock/stock-article.permissions.ts
+++ b/src/module/stock/stock-article.permissions.ts
@@ -1,0 +1,24 @@
+export const ARTICLE_WRITE_ROLES = [
+  "Directeur",
+  "Administrateur Systeme et Reseau",
+  "Secretaire",
+  "Responsable Programmation",
+  "Responsable Qualité",
+] as const;
+
+export const ARTICLE_ARCHIVE_ROLES = [
+  "Directeur",
+  "Administrateur Systeme et Reseau",
+] as const;
+
+export const ARTICLE_DOCUMENT_WRITE_ROLES = ARTICLE_WRITE_ROLES;
+
+export const ARTICLE_COST_ROLES = [
+  "Directeur",
+  "Administrateur Systeme et Reseau",
+  "Secretaire",
+] as const;
+
+export function canViewArticleCosts(role: string | null | undefined): boolean {
+  return typeof role === "string" && (ARTICLE_COST_ROLES as readonly string[]).includes(role);
+}

--- a/src/module/stock/types/stock.types.ts
+++ b/src/module/stock/types/stock.types.ts
@@ -72,6 +72,43 @@ export type ArticleMatierePayload = {
   largeur_plat_mm?: number | null;
 };
 
+export type ArticleTechnicalVersion = {
+  id: string;
+  indice: string;
+  statut: string;
+  plan_reference: string | null;
+  date_application: string | null;
+};
+
+export type ArticleProcurementProfile = {
+  manufacturer_name: string | null;
+  manufacturer_reference: string | null;
+  preferred_catalogue_id: string | null;
+  packaging: string | null;
+  process: string | null;
+  finish: string | null;
+  requirements: string | null;
+  certificate_required: boolean;
+  min_stock: number | null;
+  max_stock: number | null;
+};
+
+export type ArticleSupplierReference = {
+  catalogue_id: string;
+  supplier_id: string;
+  supplier_code: string | null;
+  supplier_name: string;
+  supplier_reference: string | null;
+  unit: string | null;
+  unit_price: number | null;
+  currency: string | null;
+  lead_time_days: number | null;
+  moq: number | null;
+  conditions: string | null;
+  preferred: boolean;
+  active: boolean;
+};
+
 export type StockArticleListItem = {
   id: string;
   root_article_id: string;
@@ -82,6 +119,7 @@ export type StockArticleListItem = {
   projet_id: number | null;
   code: string;
   designation: string;
+  designation_secondary: string | null;
   article_type: ArticleType;
   article_category: ArticleCategory;
   article_categories: ArticleBusinessCategory[];
@@ -92,7 +130,12 @@ export type StockArticleListItem = {
   piece_designation: string | null;
   unite: string | null;
   lot_tracking: boolean;
+  is_sold: boolean;
   is_active: boolean;
+  row_version: number;
+  archived_at: string | null;
+  archive_reason: string | null;
+  applicable_version: ArticleTechnicalVersion | null;
   qty_available: number;
   qty_reserved: number;
   qty_total: number;
@@ -104,6 +147,30 @@ export type StockArticleListItem = {
 export type StockArticleDetail = StockArticleListItem & {
   notes: string | null;
   article_matiere: ArticleMatierePayload | null;
+  procurement: ArticleProcurementProfile | null;
+  suppliers: ArticleSupplierReference[];
+  documents: StockDocument[];
+  costs_redacted: boolean;
+};
+
+export type ArticleWhereUsedType =
+  | "PIECE_CURRENT"
+  | "PIECE_HISTORICAL"
+  | "QUOTE"
+  | "CUSTOMER_ORDER"
+  | "SUPPLIER_ORDER"
+  | "WORK_ORDER"
+  | "RECEIPT"
+  | "LOT"
+  | "STOCK_MOVEMENT"
+  | "DELIVERY";
+
+export type ArticleWhereUsedItem = {
+  usage_type: ArticleWhereUsedType;
+  usage_id: string;
+  parent_id: string | null;
+  label: string;
+  occurred_at: string | null;
 };
 
 export type StockArticleKpis = {
@@ -273,6 +340,15 @@ export type StockDocument = {
   document_id: string;
   document_name: string;
   type: string | null;
+  revision?: string | null;
+  version?: number;
+  mime_type?: string;
+  size_bytes?: number;
+  sha256?: string | null;
+  uploaded_by?: number | null;
+  created_at?: string;
+  updated_at?: string;
+  is_active?: boolean;
 };
 
 export type StockMovementEvent = {

--- a/src/module/stock/validators/stock.validators.ts
+++ b/src/module/stock/validators/stock.validators.ts
@@ -93,7 +93,7 @@ export const listArticlesQuerySchema = z.object({
   pageSize: z.coerce.number().int().min(1).max(200).optional().default(20),
   sortBy: z.enum(["updated_at", "created_at", "code", "designation"]).optional().default("updated_at"),
   sortDir: sortDirSchema.optional().default("desc"),
-});
+}).strict();
 
 export type ListArticlesQueryDTO = z.infer<typeof listArticlesQuerySchema>;
 
@@ -172,43 +172,73 @@ export const createArticleFamilySchema = z.object({
 });
 export type CreateArticleFamilyBodyDTO = z.infer<typeof createArticleFamilySchema>["body"];
 
+const articleMatiereSchema = z
+  .object({
+    nuance_id: nullablePositiveInt.optional(),
+    etat_id: nullablePositiveInt.optional(),
+    sous_etat_id: nullablePositiveInt.optional(),
+    barre_a_decouper: z.boolean().optional().default(false),
+    longueur_mm: nullablePositiveInt.optional(),
+    longueur_unitaire_mm: nullablePositiveInt.optional(),
+    largeur_mm: nullablePositiveInt.optional(),
+    hauteur_mm: nullablePositiveInt.optional(),
+    epaisseur_mm: nullablePositiveInt.optional(),
+    diametre_mm: nullablePositiveInt.optional(),
+    largeur_plat_mm: nullablePositiveInt.optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.barre_a_decouper && !value.longueur_unitaire_mm) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "longueur_unitaire_mm is required for cut bars", path: ["longueur_unitaire_mm"] });
+    }
+    if (value.barre_a_decouper && value.longueur_mm) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "longueur_mm is not allowed for cut bars", path: ["longueur_mm"] });
+    }
+    if (!value.barre_a_decouper && value.longueur_unitaire_mm) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "longueur_unitaire_mm requires barre_a_decouper=true", path: ["longueur_unitaire_mm"] });
+    }
+  });
+
+const articleProcurementSchema = z
+  .object({
+    manufacturer_name: z.string().trim().min(1).max(200).optional().nullable(),
+    manufacturer_reference: z.string().trim().min(1).max(200).optional().nullable(),
+    preferred_catalogue_id: uuid.optional().nullable(),
+    packaging: z.string().trim().min(1).max(200).optional().nullable(),
+    process: z.string().trim().min(1).max(200).optional().nullable(),
+    finish: z.string().trim().min(1).max(200).optional().nullable(),
+    requirements: z.string().trim().min(1).max(2000).optional().nullable(),
+    certificate_required: z.boolean().optional().default(false),
+    min_stock: z.coerce.number().min(0).optional().nullable(),
+    max_stock: z.coerce.number().min(0).optional().nullable(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.min_stock != null && value.max_stock != null && value.min_stock > value.max_stock) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, message: "min_stock must be less than or equal to max_stock", path: ["max_stock"] });
+    }
+  });
+
 export const createArticleSchema = z.object({
   body: z
     .object({
-      // The backend issues the final code atomically. A legacy client value is
-      // accepted for compatibility but deliberately ignored on creation.
-      code: z.string().trim().min(1).max(80).optional(),
       designation: z.string().trim().min(1).max(400),
+      designation_secondary: z.string().trim().min(1).max(400).optional().nullable(),
       article_type: articleTypeSchema.optional(),
       article_category: articleCategorySchema.optional().default("achat"),
       article_categories: z.array(articleBusinessCategorySchema).min(1).max(8).optional(),
       family_code: z.string().trim().min(1).max(40),
-      version_number: z.coerce.number().int().positive().optional(),
-      plan_index: z.coerce.number().int().positive().optional().default(1),
       status: articleWorkflowStatusSchema.optional().default("VALIDE"),
       projet_id: z.coerce.number().int().positive().optional().nullable(),
       stock_managed: z.boolean().optional().default(true),
       piece_technique_id: uuid.optional().nullable(),
       unite: z.string().trim().min(1).max(30).optional().nullable(),
       lot_tracking: z.boolean().optional().default(false),
+      is_sold: z.boolean().optional().default(false),
       is_active: z.boolean().optional().default(true),
       notes: z.string().trim().min(1).optional().nullable(),
-      article_matiere: z
-        .object({
-          nuance_id: nullablePositiveInt.optional(),
-          etat_id: nullablePositiveInt.optional(),
-          sous_etat_id: nullablePositiveInt.optional(),
-          barre_a_decouper: z.boolean().optional().default(false),
-          longueur_mm: nullablePositiveInt.optional(),
-          longueur_unitaire_mm: nullablePositiveInt.optional(),
-          largeur_mm: nullablePositiveInt.optional(),
-          hauteur_mm: nullablePositiveInt.optional(),
-          epaisseur_mm: nullablePositiveInt.optional(),
-          diametre_mm: nullablePositiveInt.optional(),
-          largeur_plat_mm: nullablePositiveInt.optional(),
-        })
-        .strict()
-        .optional(),
+      article_matiere: articleMatiereSchema.optional(),
+      procurement: articleProcurementSchema.optional(),
     })
     .strict()
     .superRefine((body, ctx) => {
@@ -239,27 +269,73 @@ export type CreateArticleBodyDTO = z.infer<typeof createArticleSchema>["body"];
 export const updateArticleSchema = z.object({
   body: z
     .object({
-      code: z.string().trim().min(1).max(80).optional(),
+      expected_row_version: positiveInt,
       designation: z.string().trim().min(1).max(400).optional(),
+      designation_secondary: z.string().trim().min(1).max(400).optional().nullable(),
       article_type: articleTypeSchema.optional(),
       article_category: articleCategorySchema.optional(),
       article_categories: z.array(articleBusinessCategorySchema).min(1).max(8).optional(),
       family_code: z.string().trim().min(1).max(40).optional(),
-      version_number: z.coerce.number().int().positive().optional(),
-      plan_index: z.coerce.number().int().positive().optional(),
       status: articleWorkflowStatusSchema.optional(),
       projet_id: z.coerce.number().int().positive().optional().nullable(),
       stock_managed: z.boolean().optional(),
       piece_technique_id: uuid.optional().nullable(),
       unite: z.string().trim().min(1).max(30).optional().nullable(),
       lot_tracking: z.boolean().optional(),
-      is_active: z.boolean().optional(),
+      is_sold: z.boolean().optional(),
       notes: z.string().trim().min(1).optional().nullable(),
+      article_matiere: articleMatiereSchema.optional(),
+      procurement: articleProcurementSchema.optional(),
     })
-    .strict(),
+    .strict()
+    .superRefine((body, ctx) => {
+      if (body.stock_managed === false && body.lot_tracking === true) {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "lot_tracking requires stock_managed=true", path: ["lot_tracking"] });
+      }
+      if (body.article_matiere && body.article_category && body.article_category !== "matiere") {
+        ctx.addIssue({ code: z.ZodIssueCode.custom, message: "article_matiere is only allowed for article_category=matiere", path: ["article_matiere"] });
+      }
+    }),
 });
 
 export type UpdateArticleBodyDTO = z.infer<typeof updateArticleSchema>["body"];
+
+export const archiveArticleSchema = z.object({
+  body: z.object({
+    expected_row_version: positiveInt,
+    reason: z.string().trim().min(3).max(500).optional().nullable(),
+  }).strict(),
+});
+export type ArchiveArticleBodyDTO = z.infer<typeof archiveArticleSchema>["body"];
+
+export const reactivateArticleSchema = z.object({
+  body: z.object({ expected_row_version: positiveInt }).strict(),
+});
+export type ReactivateArticleBodyDTO = z.infer<typeof reactivateArticleSchema>["body"];
+
+export const listArticleWhereUsedQuerySchema = z.object({
+  usage_type: z.enum([
+    "PIECE_CURRENT", "PIECE_HISTORICAL", "QUOTE", "CUSTOMER_ORDER", "SUPPLIER_ORDER",
+    "WORK_ORDER", "RECEIPT", "LOT", "STOCK_MOVEMENT", "DELIVERY",
+  ]).optional(),
+  page: z.coerce.number().int().min(1).optional().default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).optional().default(25),
+}).strict();
+export type ListArticleWhereUsedQueryDTO = z.infer<typeof listArticleWhereUsedQuerySchema>;
+
+export const listArticleVersionsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).optional().default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).optional().default(25),
+}).strict();
+export type ListArticleVersionsQueryDTO = z.infer<typeof listArticleVersionsQuerySchema>;
+
+export const articleDocumentMetadataSchema = z.object({
+  body: z.object({
+    type: z.string().trim().min(1).max(80).optional().nullable(),
+    revision: z.string().trim().min(1).max(80).optional().nullable(),
+  }).strict(),
+});
+export type ArticleDocumentMetadataDTO = z.infer<typeof articleDocumentMetadataSchema>["body"];
 
 export const listMagasinsQuerySchema = z.object({
   q: z.string().trim().optional(),


### PR DESCRIPTION
Supports BigFootLime/crp-systems-web#164. Ajoute idempotence, code immuable, verrou optimiste, RBAC, masquage des coûts, approvisionnement, archivage, vue des usages, versions Pièce, validation documentaire, audit et patch additif. Validation : build TypeScript, suite backend complète et 132 tests ciblés réussis. Migration non appliquée : préflight, patch, vérification et recette obligatoires sur cerp_test. Aucun accès cerp_prod, merge ou déploiement effectué.

## Summary by Sourcery

Harden Article master data and lifecycle in the stock module with idempotent creation, optimistic concurrency, archival/reactivation workflows, procurement and document metadata, and RBAC-enforced access to sensitive fields and operations.

New Features:
- Expose procurement profile, supplier references, technical version info, where-used views, and enriched document metadata on Article detail endpoints.
- Add Article archival and reactivation endpoints with validation of usages and audit logging.
- Introduce listing endpoints for technical versions of linked Pieces and business usages of an Article.
- Support uploading Article documents with typed metadata, strict content validation, and logical retirement instead of physical deletion.

Enhancements:
- Make Article creation idempotent via an idempotency-key registry and enforce immutable business codes and server-owned technical versioning.
- Enforce optimistic locking on Article updates and archiving through row versions and database guard triggers.
- Extend Article search, schemas, and types with secondary designation, sales flag, archival fields, procurement data, and stricter validation of material geometry and stock constraints.
- Mask supplier cost data unless the caller has an allowed role, exposing a redaction flag to clients.
- Add database patches, preflight/verify/rollback scripts, and extensive validator and permission tests to safely roll out the hardened Article master-data model.

Documentation:
- Document the Article master-data design, HTTP contract, security model, and rollout procedure for change set #164.

Tests:
- Add a dedicated validation and permissions test matrix for Article master data, idempotence, optimistic locking, and migration guards.
- Update existing stock route and Article–Pièce link tests to align with the new Article contract and idempotency requirements.