### PR TITLE
release: réceptions d’OF transactionnelles #223

### DIFF
--- a/db/patches/20260723_production_receipts_223.sql
+++ b/db/patches/20260723_production_receipts_223.sql
@@ -1,0 +1,199 @@
+-- Issue #223 - Fin d'OF, reception de production et mise en stock.
+-- Additive/idempotent patch. Validate on cerp_test before any production proposal.
+-- This patch does not delete or rewrite historical production/stock rows.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.ordres_fabrication') IS NULL
+     OR to_regclass('public.of_output_lots') IS NULL
+     OR to_regclass('public.lots') IS NULL
+     OR to_regclass('public.stock_levels') IS NULL
+     OR to_regclass('public.stock_batches') IS NULL
+     OR to_regclass('public.stock_movements') IS NULL
+     OR to_regclass('public.stock_reservations') IS NULL
+     OR to_regclass('public.non_conformity') IS NULL THEN
+    RAISE EXCEPTION '#223 prerequisites missing: OF, lot, stock, reservation and quality tables are required';
+  END IF;
+END $$;
+
+-- A batch is the physical stock representation of one internal lot at one
+-- stock level. Existing rows are linked only when article + batch code identify
+-- exactly the canonical lot; no guessed link is introduced.
+ALTER TABLE public.stock_batches
+  ADD COLUMN IF NOT EXISTS lot_id uuid NULL;
+
+UPDATE public.stock_batches sb
+SET lot_id = l.id
+FROM public.stock_levels sl
+JOIN public.lots l ON l.article_id = sl.article_id
+WHERE sl.id = sb.stock_level_id
+  AND sb.lot_id IS NULL
+  AND l.lot_code::text = sb.batch_code::text;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_batches_lot_id_fkey'
+      AND conrelid = 'public.stock_batches'::regclass
+  ) THEN
+    ALTER TABLE public.stock_batches
+      ADD CONSTRAINT stock_batches_lot_id_fkey
+      FOREIGN KEY (lot_id) REFERENCES public.lots(id) ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS stock_batches_lot_idx
+  ON public.stock_batches(lot_id)
+  WHERE lot_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS stock_batches_level_lot_uq
+  ON public.stock_batches(stock_level_id, lot_id)
+  WHERE lot_id IS NOT NULL;
+
+-- Reservations created from production receipts keep their exact lot/batch
+-- allocation. Historical reservations remain valid with nullable links.
+ALTER TABLE public.stock_reservations
+  ADD COLUMN IF NOT EXISTS lot_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS stock_batch_id uuid NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_reservations_lot_id_fkey'
+      AND conrelid = 'public.stock_reservations'::regclass
+  ) THEN
+    ALTER TABLE public.stock_reservations
+      ADD CONSTRAINT stock_reservations_lot_id_fkey
+      FOREIGN KEY (lot_id) REFERENCES public.lots(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_reservations_stock_batch_id_fkey'
+      AND conrelid = 'public.stock_reservations'::regclass
+  ) THEN
+    ALTER TABLE public.stock_reservations
+      ADD CONSTRAINT stock_reservations_stock_batch_id_fkey
+      FOREIGN KEY (stock_batch_id) REFERENCES public.stock_batches(id) ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS stock_reservations_lot_idx
+  ON public.stock_reservations(lot_id)
+  WHERE lot_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS stock_reservations_batch_idx
+  ON public.stock_reservations(stock_batch_id)
+  WHERE stock_batch_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS stock_reservations_active_source_lot_uq
+  ON public.stock_reservations(source_type, source_id, article_id, location_id, lot_id)
+  WHERE status = 'ACTIVE' AND lot_id IS NOT NULL;
+
+-- Immutable command ledger: one actor/key identifies one semantic request and
+-- stores the committed result for safe HTTP retries.
+CREATE TABLE IF NOT EXISTS public.of_receipts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  of_id bigint NOT NULL REFERENCES public.ordres_fabrication(id) ON DELETE RESTRICT,
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  request_payload jsonb NOT NULL,
+  result_payload jsonb NOT NULL,
+  expected_of_updated_at timestamptz NOT NULL,
+  qty_ok numeric(12,3) NOT NULL,
+  qty_scrap numeric(12,3) NOT NULL DEFAULT 0,
+  qty_rework numeric(12,3) NOT NULL DEFAULT 0,
+  quality_status text NOT NULL,
+  quality_reason text NULL,
+  location_id uuid NOT NULL REFERENCES public.locations(id) ON DELETE RESTRICT,
+  lot_id uuid NOT NULL REFERENCES public.lots(id) ON DELETE RESTRICT,
+  stock_level_id uuid NOT NULL REFERENCES public.stock_levels(id) ON DELETE RESTRICT,
+  stock_batch_id uuid NOT NULL REFERENCES public.stock_batches(id) ON DELETE RESTRICT,
+  stock_movement_id uuid NOT NULL REFERENCES public.stock_movements(id) ON DELETE RESTRICT,
+  reservation_id uuid NULL REFERENCES public.stock_reservations(id) ON DELETE SET NULL,
+  non_conformity_id uuid NULL REFERENCES public.non_conformity(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT of_receipts_actor_key_uq UNIQUE (actor_user_id, idempotency_key),
+  CONSTRAINT of_receipts_movement_uq UNIQUE (stock_movement_id),
+  CONSTRAINT of_receipts_key_len_ck CHECK (char_length(idempotency_key) BETWEEN 8 AND 200),
+  CONSTRAINT of_receipts_request_hash_ck CHECK (request_hash ~ '^[A-Fa-f0-9]{64}$'),
+  CONSTRAINT of_receipts_qty_ck CHECK (qty_ok > 0 AND qty_scrap >= 0 AND qty_rework >= 0),
+  CONSTRAINT of_receipts_quality_status_ck CHECK (quality_status IN ('LIBERE', 'QUARANTAINE', 'BLOQUE')),
+  CONSTRAINT of_receipts_quality_reason_ck CHECK (
+    quality_status = 'LIBERE' OR NULLIF(btrim(quality_reason), '') IS NOT NULL
+  )
+);
+
+CREATE INDEX IF NOT EXISTS of_receipts_of_created_idx
+  ON public.of_receipts(of_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS of_receipts_lot_idx
+  ON public.of_receipts(lot_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS of_receipts_nc_idx
+  ON public.of_receipts(non_conformity_id)
+  WHERE non_conformity_id IS NOT NULL;
+
+COMMENT ON TABLE public.of_receipts IS
+  'Immutable, idempotent production-receipt command ledger for issue #223.';
+COMMENT ON COLUMN public.of_receipts.request_hash IS
+  'SHA-256 of the canonical OF id + validated request body. A reused key with another hash is rejected.';
+
+CREATE OR REPLACE FUNCTION public.fn_protect_of_receipt()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'OF receipts are immutable audit evidence'
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_of_receipt ON public.of_receipts;
+CREATE TRIGGER trg_protect_of_receipt
+BEFORE UPDATE OR DELETE ON public.of_receipts
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_of_receipt();
+
+-- Reader-facing availability: on-hand is physical stock, while usable stock is
+-- released stock net of reservation/depreciation. Quarantine and blocked stock
+-- remain visible but can never be promised as available.
+CREATE OR REPLACE VIEW public.v_stock_lot_availability AS
+SELECT
+  sb.id AS stock_batch_id,
+  sb.stock_level_id,
+  sl.article_id,
+  sl.location_id,
+  sb.lot_id,
+  l.lot_code,
+  l.lot_status,
+  sb.qty_total AS qty_on_hand,
+  sb.qty_reserved,
+  sb.qty_depreciated,
+  CASE
+    WHEN l.lot_status IN ('QUARANTAINE', 'EN_ATTENTE') THEN GREATEST(sb.qty_total - sb.qty_depreciated, 0)
+    ELSE 0
+  END AS qty_quarantine,
+  CASE
+    WHEN l.lot_status = 'BLOQUE' THEN GREATEST(sb.qty_total - sb.qty_depreciated, 0)
+    ELSE 0
+  END AS qty_blocked,
+  CASE
+    WHEN l.lot_status = 'LIBERE' THEN GREATEST(sb.qty_total - sb.qty_reserved - sb.qty_depreciated, 0)
+    ELSE 0
+  END AS qty_available
+FROM public.stock_batches sb
+JOIN public.stock_levels sl ON sl.id = sb.stock_level_id
+LEFT JOIN public.lots l ON l.id = sb.lot_id;
+
+COMMENT ON VIEW public.v_stock_lot_availability IS
+  'Explicit on-hand/quarantine/blocked/reserved/available quantities by stock batch and internal lot.';
+
+-- Runtime least privilege. The migration remains portable when the deployment
+-- role has another name; grants are applied only when cerp_app exists.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT, INSERT ON public.of_receipts TO cerp_app;
+    GRANT SELECT ON public.v_stock_lot_availability TO cerp_app;
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/support/20260723_production_receipts_223.preflight.sql
+++ b/db/patches/support/20260723_production_receipts_223.preflight.sql
@@ -1,0 +1,34 @@
+\set ON_ERROR_STOP on
+
+-- Read-only preflight for issue #223. Run against cerp_test before the patch.
+SELECT current_database() AS database_name, current_user AS database_user, now() AS checked_at;
+
+SELECT prerequisite, present
+FROM (
+  VALUES
+    ('ordres_fabrication', to_regclass('public.ordres_fabrication') IS NOT NULL),
+    ('of_output_lots', to_regclass('public.of_output_lots') IS NOT NULL),
+    ('lots', to_regclass('public.lots') IS NOT NULL),
+    ('stock_levels', to_regclass('public.stock_levels') IS NOT NULL),
+    ('stock_batches', to_regclass('public.stock_batches') IS NOT NULL),
+    ('stock_movements', to_regclass('public.stock_movements') IS NOT NULL),
+    ('stock_reservations', to_regclass('public.stock_reservations') IS NOT NULL),
+    ('non_conformity', to_regclass('public.non_conformity') IS NOT NULL)
+) AS checks(prerequisite, present)
+ORDER BY prerequisite;
+
+-- Ambiguous article/batch codes would make the safe backfill non-deterministic.
+SELECT sl.article_id, sb.batch_code::text, count(DISTINCT l.id) AS matching_lots
+FROM public.stock_batches sb
+JOIN public.stock_levels sl ON sl.id = sb.stock_level_id
+JOIN public.lots l
+  ON l.article_id = sl.article_id
+ AND l.lot_code::text = sb.batch_code::text
+GROUP BY sl.article_id, sb.batch_code
+HAVING count(DISTINCT l.id) > 1;
+
+SELECT
+  (SELECT count(*) FROM public.stock_batches) AS stock_batches,
+  (SELECT count(*) FROM public.stock_reservations WHERE status = 'ACTIVE') AS active_reservations,
+  (SELECT count(*) FROM public.of_output_lots) AS output_lots,
+  (SELECT count(*) FROM public.non_conformity WHERE status = 'OPEN') AS open_non_conformities;

--- a/db/patches/support/20260723_production_receipts_223.rollback.sql
+++ b/db/patches/support/20260723_production_receipts_223.rollback.sql
@@ -1,0 +1,43 @@
+\set ON_ERROR_STOP on
+
+-- Guarded compensation for an empty #223 installation only.
+-- Never run after business receipts have been recorded.
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#223 rollback is restricted to cerp_test';
+  END IF;
+  IF to_regclass('public.of_receipts') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM public.of_receipts) THEN
+    RAISE EXCEPTION '#223 rollback refused: immutable production receipts exist';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.stock_reservations
+    WHERE lot_id IS NOT NULL OR stock_batch_id IS NOT NULL
+  ) THEN
+    RAISE EXCEPTION '#223 rollback refused: lot-level reservations exist';
+  END IF;
+END $$;
+
+DROP VIEW IF EXISTS public.v_stock_lot_availability;
+DROP TABLE IF EXISTS public.of_receipts;
+DROP FUNCTION IF EXISTS public.fn_protect_of_receipt();
+
+DROP INDEX IF EXISTS public.stock_reservations_active_source_lot_uq;
+DROP INDEX IF EXISTS public.stock_reservations_lot_idx;
+DROP INDEX IF EXISTS public.stock_reservations_batch_idx;
+ALTER TABLE public.stock_reservations
+  DROP CONSTRAINT IF EXISTS stock_reservations_lot_id_fkey,
+  DROP CONSTRAINT IF EXISTS stock_reservations_stock_batch_id_fkey,
+  DROP COLUMN IF EXISTS lot_id,
+  DROP COLUMN IF EXISTS stock_batch_id;
+
+DROP INDEX IF EXISTS public.stock_batches_level_lot_uq;
+DROP INDEX IF EXISTS public.stock_batches_lot_idx;
+ALTER TABLE public.stock_batches
+  DROP CONSTRAINT IF EXISTS stock_batches_lot_id_fkey,
+  DROP COLUMN IF EXISTS lot_id;
+
+COMMIT;

--- a/db/patches/support/20260723_production_receipts_223.verify.sql
+++ b/db/patches/support/20260723_production_receipts_223.verify.sql
@@ -1,0 +1,52 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#223 verification is restricted to cerp_test, got %', current_database();
+  END IF;
+  IF to_regclass('public.of_receipts') IS NULL
+     OR to_regclass('public.v_stock_lot_availability') IS NULL THEN
+    RAISE EXCEPTION '#223 ledger or availability view is missing';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_receipts_actor_key_uq'
+      AND conrelid = 'public.of_receipts'::regclass
+  ) THEN
+    RAISE EXCEPTION '#223 actor/idempotency uniqueness is missing';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_protect_of_receipt'
+      AND tgrelid = 'public.of_receipts'::regclass
+      AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION '#223 immutable-ledger trigger is missing';
+  END IF;
+END $$;
+
+SELECT
+  (SELECT count(*) FROM public.of_receipts) AS receipts,
+  (SELECT count(*) FROM public.of_receipts WHERE result_payload IS NULL) AS incomplete_receipts,
+  (SELECT count(*) FROM public.stock_batches WHERE lot_id IS NOT NULL) AS linked_batches,
+  (SELECT count(*) FROM public.stock_reservations WHERE lot_id IS NOT NULL AND stock_batch_id IS NULL) AS incomplete_lot_reservations,
+  (SELECT count(*) FROM public.v_stock_lot_availability WHERE qty_available < 0) AS negative_available_rows;
+
+SELECT
+  c.relname,
+  c.relkind,
+  pg_get_userbyid(c.relowner) AS owner
+FROM pg_class c
+WHERE c.oid IN ('public.of_receipts'::regclass, 'public.v_stock_lot_availability'::regclass)
+ORDER BY c.relname;
+
+SELECT
+  CASE WHEN EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app')
+    THEN has_table_privilege('cerp_app', 'public.of_receipts', 'SELECT,INSERT')
+    ELSE NULL
+  END AS cerp_app_receipt_runtime_access,
+  CASE WHEN EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app')
+    THEN has_table_privilege('cerp_app', 'public.v_stock_lot_availability', 'SELECT')
+    ELSE NULL
+  END AS cerp_app_availability_read_access;

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -100,3 +100,19 @@ administrative PostgreSQL role while runtime patches are executed by `cerp_app`.
 Patch `20260722_machine_park_165.sql` is additive and idempotent. It reserves the central `MCH` scope, makes unknown hourly rates nullable with explicit provenance, adds a legacy alias, enforces code immutability, records creation idempotency, links machine unavailability to canonical `planning_events`, and adds maintenance plans/events plus document metadata/removal fields.
 
 Before any application, run `db/patches/support/20260722_machine_park_165.preflight.sql`. Apply only to `cerp_test` after an approved backup, then run `20260722_machine_park_165.verify.sql`. The guarded rollback refuses to drop structures once machine-park business rows exist and intentionally preserves rate provenance/code immutability where reverting would lose traceability. No #165 script is authorized to write `cerp_prod` without a later human production decision.
+
+## Issue #223 - Réceptions de production
+
+Patch `20260723_production_receipts_223.sql` adds an immutable, actor-scoped
+idempotency ledger (`of_receipts`), explicit lot links on stock batches and
+reservations, and the read model `v_stock_lot_availability`. Physical on-hand,
+quarantine, blocked, reserved and available quantities remain distinct.
+
+Run the matching `preflight` and `verify` scripts from `db/patches/support`.
+The rollback is restricted to `cerp_test` and refuses to continue once a
+receipt or lot-level reservation exists. Validation on 2026-07-23 used the
+isolated `cerp_test` clone first. After explicit human approval, production was
+backed up to `cerp_prod_pre_223_20260723_145750.backup` (SHA-256
+`9a037c37563e1bbc57fa34b7e8c3fd2aaa1cca09e0b994628e5f0d4e9ab83dc1`),
+then the patch was applied, verified and recorded in
+`public.cerp_schema_migrations`.

--- a/src/__tests__/production-of-170.routes.test.ts
+++ b/src/__tests__/production-of-170.routes.test.ts
@@ -739,6 +739,16 @@ describe("#170 recursive generation (POST /production/ofs/generate)", () => {
 });
 
 describe("#170 bounded production receipt", () => {
+  const receiptBody = {
+    qty_ok: 1,
+    qty_scrap: 0,
+    qty_rework: 0,
+    location_id: "88888888-8888-8888-8888-888888888888",
+    lot_mode: "NEW",
+    quality_status: "LIBERE",
+    expected_of_updated_at: OF_UPDATED_AT,
+  } as const;
+
   function installReceiptMocks(params: { statut: string; quantite_bonne: number; already: number }) {
     mocks.clientQuery.mockImplementation(async (sql: unknown) => {
       const q = String(sql);
@@ -750,9 +760,11 @@ describe("#170 bounded production receipt", () => {
               numero: "OF-2026-000005",
               piece_technique_id: PIECE_ROOT,
               article_id: "11111111-1111-1111-1111-111111111111",
+              affaire_id: null,
               commande_ligne_id: null,
               quantite_bonne: params.quantite_bonne,
               statut: params.statut,
+              updated_at: OF_UPDATED_AT,
             },
           ],
         };
@@ -769,7 +781,8 @@ describe("#170 bounded production receipt", () => {
     const res = await request(app)
       .post("/api/v1/production/ofs/5/receipt")
       .set("x-test-role", "Responsable Production")
-      .send({ qty_ok: 5, location_id: "88888888-8888-8888-8888-888888888888", lot_mode: "NEW" });
+      .set("Idempotency-Key", "receipt-223-overflow")
+      .send({ ...receiptBody, qty_ok: 5 });
     expect(res.status).toBe(422);
     expect(res.body).toMatchObject({ code: "OF_RECEIPT_EXCEEDS_RECEIVABLE" });
   });
@@ -779,7 +792,8 @@ describe("#170 bounded production receipt", () => {
     const res = await request(app)
       .post("/api/v1/production/ofs/5/receipt")
       .set("x-test-role", "Responsable Production")
-      .send({ qty_ok: 1, location_id: "88888888-8888-8888-8888-888888888888", lot_mode: "NEW" });
+      .set("Idempotency-Key", "receipt-223-cancelled")
+      .send(receiptBody);
     expect(res.status).toBe(409);
     expect(res.body).toMatchObject({ code: "OF_RECEIPT_STATUS_INVALID" });
   });
@@ -788,8 +802,37 @@ describe("#170 bounded production receipt", () => {
     const res = await request(app)
       .post("/api/v1/production/ofs/5/receipt")
       .set("x-test-role", "Comptabilite")
-      .send({ qty_ok: 1, location_id: "88888888-8888-8888-8888-888888888888", lot_mode: "NEW" });
+      .send(receiptBody);
     expect(res.status).toBe(403);
+  });
+
+  it("requires an idempotency key before writing", async () => {
+    const res = await request(app)
+      .post("/api/v1/production/ofs/5/receipt")
+      .set("x-test-role", "Responsable Production")
+      .send(receiptBody);
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "IDEMPOTENCY_KEY_REQUIRED" });
+  });
+
+  it("allows workshop receipt only in quarantine, not direct release", async () => {
+    const res = await request(app)
+      .post("/api/v1/production/ofs/5/receipt")
+      .set("x-test-role", "Operateur Atelier")
+      .set("Idempotency-Key", "receipt-223-workshop")
+      .send(receiptBody);
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: "OF_QUALITY_DECISION_FORBIDDEN" });
+  });
+
+  it("does not let workshop block a lot through a crafted receipt request", async () => {
+    const res = await request(app)
+      .post("/api/v1/production/ofs/5/receipt")
+      .set("x-test-role", "Operateur Atelier")
+      .set("Idempotency-Key", "receipt-223-workshop-block")
+      .send({ ...receiptBody, quality_status: "BLOQUE", quality_reason: "Blocage qualite requis" });
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: "OF_QUALITY_DECISION_FORBIDDEN" });
   });
 
   it("gates traceability behind the traceability capability", async () => {

--- a/src/__tests__/production-of-170.validators.test.ts
+++ b/src/__tests__/production-of-170.validators.test.ts
@@ -173,7 +173,13 @@ runMatrix("generateOfsSchema", generateCases, (value) => generateOfsSchema.safeP
 // ---------------------------------------------------------------------------
 // ofReceiptBodySchema — 18 combinaisons
 // ---------------------------------------------------------------------------
-const receiptBase = { qty_ok: 5, location_id: UUID, lot_mode: "NEW" };
+const receiptBase = {
+  qty_ok: 5,
+  location_id: UUID,
+  lot_mode: "NEW",
+  quality_status: "LIBERE",
+  expected_of_updated_at: ISO_TS,
+};
 const receiptCases: Case[] = [
   { name: "réception nominale (nouveau lot serveur)", value: receiptBase, ok: true },
   { name: "réception partielle décimale", value: { ...receiptBase, qty_ok: 0.5 }, ok: true },

--- a/src/__tests__/production-receipts-223.contract.test.ts
+++ b/src/__tests__/production-receipts-223.contract.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+
+import { roleHasOfCapability } from "../module/production/domain/of-rbac";
+import { ofReceiptBodySchema } from "../module/production/validators/production.validators";
+
+const base = {
+  qty_ok: 4,
+  qty_scrap: 0,
+  qty_rework: 0,
+  location_id: "88888888-8888-8888-8888-888888888888",
+  lot_mode: "NEW" as const,
+  quality_status: "LIBERE" as const,
+  expected_of_updated_at: "2026-07-23T10:00:00.000+02:00",
+};
+
+describe("#223 production receipt contract", () => {
+  it("normalizes optional scrap and rework quantities", () => {
+    const parsed = ofReceiptBodySchema.parse({
+      qty_ok: 4,
+      location_id: base.location_id,
+      lot_mode: "NEW",
+      quality_status: "LIBERE",
+      expected_of_updated_at: base.expected_of_updated_at,
+    });
+    expect(parsed).toMatchObject({ qty_scrap: 0, qty_rework: 0 });
+  });
+
+  it.each(["QUARANTAINE", "BLOQUE"] as const)("requires a quality reason for %s", (quality_status) => {
+    const parsed = ofReceiptBodySchema.safeParse({ ...base, quality_status });
+    expect(parsed.success).toBe(false);
+  });
+
+  it.each(["LIBERE", "QUARANTAINE", "BLOQUE"] as const)("accepts the governed quality state %s", (quality_status) => {
+    const parsed = ofReceiptBodySchema.safeParse({
+      ...base,
+      quality_status,
+      quality_reason: quality_status === "LIBERE" ? null : "Decision qualite documentee",
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("requires an existing lot id in EXISTING mode", () => {
+    expect(ofReceiptBodySchema.safeParse({ ...base, lot_mode: "EXISTING" }).success).toBe(false);
+  });
+
+  it("rejects an existing lot id in NEW mode", () => {
+    expect(
+      ofReceiptBodySchema.safeParse({ ...base, lot_id: "11111111-1111-1111-1111-111111111111" }).success
+    ).toBe(false);
+  });
+
+  it("rejects zero good quantity and negative quality quantities", () => {
+    expect(ofReceiptBodySchema.safeParse({ ...base, qty_ok: 0 }).success).toBe(false);
+    expect(ofReceiptBodySchema.safeParse({ ...base, qty_scrap: -1 }).success).toBe(false);
+    expect(ofReceiptBodySchema.safeParse({ ...base, qty_rework: -1 }).success).toBe(false);
+  });
+});
+
+describe("#223 quality decision RBAC", () => {
+  it.each(["Administrateur", "Directeur industriel", "Responsable Production", "Responsable Qualite"])(
+    "allows governed release for %s",
+    (role) => {
+      expect(roleHasOfCapability(role, "quality_decision")).toBe(true);
+    }
+  );
+
+  it.each(["Operateur Atelier", "Logistique", "Comptabilite", "Employe"])(
+    "keeps direct release denied for %s",
+    (role) => {
+      expect(roleHasOfCapability(role, "quality_decision")).toBe(false);
+    }
+  );
+
+  it("allows quality to receive and decide, while workshop can only receive", () => {
+    expect(roleHasOfCapability("Responsable Qualite", "receipt")).toBe(true);
+    expect(roleHasOfCapability("Responsable Qualite", "quality_decision")).toBe(true);
+    expect(roleHasOfCapability("Operateur Atelier", "receipt")).toBe(true);
+    expect(roleHasOfCapability("Operateur Atelier", "quality_decision")).toBe(false);
+  });
+});

--- a/src/module/production/controllers/production.controller.ts
+++ b/src/module/production/controllers/production.controller.ts
@@ -58,6 +58,7 @@ import {
 } from "../services/production.service";
 import { svcGetMachineIntelligence } from "../services/machine-intelligence.service";
 import { roleHasMachineCapability } from "../domain/machine-rbac";
+import { roleHasOfCapability } from "../domain/of-rbac";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -472,7 +473,15 @@ async function withGenerationDependencyGuard<T>(fn: () => Promise<T>): Promise<T
 export const getOfReceiptContext = asyncHandler(async (req, res) => {
   const { id } = ofIdParamSchema.parse({ params: req.params }).params;
   const out = await svcGetOfReceiptContext({ of_id: id });
-  res.json(out);
+  const canDecideQuality = roleHasOfCapability(req.user?.role, "quality_decision");
+  res.json({
+    ...out,
+    permissions: {
+      can_receive: true,
+      can_release: canDecideQuality,
+      allowed_quality_statuses: canDecideQuality ? ["LIBERE", "QUARANTAINE", "BLOQUE"] : ["QUARANTAINE"],
+    },
+  });
 });
 
 export const createOfReceipt = asyncHandler(async (req, res) => {
@@ -480,9 +489,22 @@ export const createOfReceipt = asyncHandler(async (req, res) => {
   const { id } = ofIdParamSchema.parse({ params: req.params }).params;
   const raw = parseBody(req);
   const body = createOfReceiptSchema.parse({ body: raw }).body;
-  const out = await svcCreateOfReceipt({ of_id: id, body, audit });
-  emitOfChanged(req, { ofId: id, action: "status_changed" });
-  res.status(201).json(out);
+  const idempotencyKey = typeof req.headers["idempotency-key"] === "string" ? req.headers["idempotency-key"].trim() : null;
+  if (!idempotencyKey || idempotencyKey.length < 8 || idempotencyKey.length > 200) {
+    throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "Une cle Idempotency-Key stable de 8 a 200 caracteres est requise.");
+  }
+  if (body.quality_status !== "QUARANTAINE" && !roleHasOfCapability(req.user?.role, "quality_decision")) {
+    throw new HttpError(
+      403,
+      "OF_QUALITY_DECISION_FORBIDDEN",
+      "Votre role peut receptionner en quarantaine, mais pas liberer ou bloquer le lot."
+    );
+  }
+  const out = await svcCreateOfReceipt({ of_id: id, body, idempotency_key: idempotencyKey, audit });
+  if (!out.idempotent_replay) {
+    emitOfChanged(req, { ofId: id, action: "status_changed" });
+  }
+  res.status(out.idempotent_replay ? 200 : 201).json(out);
 });
 
 export const getOfTraceability = asyncHandler(async (req, res) => {

--- a/src/module/production/domain/of-rbac.ts
+++ b/src/module/production/domain/of-rbac.ts
@@ -12,6 +12,7 @@ export type OfCapability =
   | "launch"
   | "operate"
   | "receipt"
+  | "quality_decision"
   | "cancel"
   | "archive"
   | "traceability";
@@ -23,7 +24,8 @@ const NEEDLES: Record<OfCapability, readonly string[]> = {
   edit_prelaunch: ["admin", "administrateur", "directeur", "production", "method"],
   launch: ["admin", "administrateur", "directeur", "production"],
   operate: ["admin", "administrateur", "directeur", "production", "atelier"],
-  receipt: ["admin", "administrateur", "directeur", "production", "atelier", "logisti"],
+  receipt: ["admin", "administrateur", "directeur", "production", "atelier", "logisti", "qualit"],
+  quality_decision: ["admin", "administrateur", "directeur", "production", "qualit"],
   cancel: ["admin", "administrateur", "directeur", "production"],
   archive: ["admin", "administrateur", "directeur"],
   traceability: ["admin", "administrateur", "directeur", "production", "atelier", "qualit", "method", "logisti"],

--- a/src/module/production/repository/production-receipts.repository.ts
+++ b/src/module/production/repository/production-receipts.repository.ts
@@ -1,4 +1,5 @@
 import type { PoolClient } from "pg";
+import { createHash, randomUUID } from "crypto";
 
 import pool from "../../../config/database";
 import { generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
@@ -18,6 +19,11 @@ export type OfReceiptContext = {
     piece_designation: string;
     quantite_lancee: number;
     quantite_bonne: number;
+    statut: string;
+    updated_at: string;
+    affaire_id: number | null;
+    commande_id: number | null;
+    commande_ligne_id: number | null;
   };
   article_id: string;
   unite: string | null;
@@ -27,7 +33,17 @@ export type OfReceiptContext = {
   output_lots: Array<{
     lot_id: string;
     lot_code: string;
+    lot_status: string;
     qty_ok: number;
+    qty_scrap: number;
+    qty_rework: number;
+    updated_at: string;
+  }>;
+  existing_lots: Array<{
+    lot_id: string;
+    lot_code: string;
+    lot_status: string;
+    qty_on_hand: number;
     updated_at: string;
   }>;
   locations: {
@@ -37,21 +53,35 @@ export type OfReceiptContext = {
 };
 
 export type OfReceiptResult = {
+  receipt_id: string;
   lot_id: string;
   lot_code: string;
   stock_movement_id: string;
   movement_no: string;
   qty_ok: number;
+  qty_scrap: number;
+  qty_rework: number;
+  quality_status: string;
+  reservation_id: string | null;
+  reserved_qty: number;
+  non_conformity_id: string | null;
+  idempotent_replay: boolean;
 };
 
 export type OfTraceability = {
   output_lots: OfReceiptContext["output_lots"];
   receipts: Array<{
+    receipt_id: string | null;
     stock_movement_id: string;
     movement_no: string | null;
     status: string;
     posted_at: string | null;
     qty: number;
+    qty_scrap: number;
+    qty_rework: number;
+    quality_status: string | null;
+    reservation_id: string | null;
+    non_conformity_id: string | null;
     lot_id: string | null;
     lot_code: string | null;
     magasin_id: string | null;
@@ -66,6 +96,22 @@ export type OfTraceability = {
 function movementNoFromSeq(n: number): string {
   const padded = String(n).padStart(8, "0");
   return `SM-${padded}`;
+}
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`;
+  if (value && typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function receiptRequestHash(ofId: number, body: OfReceiptBodyDTO): string {
+  return createHash("sha256").update(canonicalJson({ of_id: ofId, ...body })).digest("hex");
 }
 
 async function reserveMovementNo(client: Pick<PoolClient, "query">): Promise<string> {
@@ -132,6 +178,8 @@ async function reserveProducedQtyForCommandeLine(
     article_id: string;
     location_id: string;
     stock_level_id: string;
+    stock_batch_id: string;
+    lot_id: string;
     qty_ok: number;
     actor_user_id: number;
   }
@@ -145,7 +193,7 @@ async function reserveProducedQtyForCommandeLine(
         article_id::text AS article_id
       FROM public.commande_ligne
       WHERE id = $1::bigint
-      LIMIT 1
+      FOR UPDATE
     `,
     [args.commande_ligne_id]
   );
@@ -202,6 +250,32 @@ async function reserveProducedQtyForCommandeLine(
     [args.stock_level_id, qtyToReserve, args.actor_user_id]
   );
 
+  const stockBatchRes = await client.query<{ qty_total: number; qty_reserved: number }>(
+    `
+      SELECT qty_total::float8 AS qty_total, qty_reserved::float8 AS qty_reserved
+      FROM public.stock_batches
+      WHERE id = $1::uuid AND lot_id = $2::uuid
+      FOR UPDATE
+    `,
+    [args.stock_batch_id, args.lot_id]
+  );
+  const stockBatch = stockBatchRes.rows[0] ?? null;
+  if (!stockBatch) {
+    throw new HttpError(409, "STOCK_BATCH_NOT_FOUND", "Lot de stock introuvable pour la reservation automatique");
+  }
+  const batchAvailableQty = Number(stockBatch.qty_total) - Number(stockBatch.qty_reserved);
+  if (batchAvailableQty + 1e-9 < qtyToReserve) {
+    throw new HttpError(409, "INSUFFICIENT_LOT_STOCK", "Le lot produit n'est pas disponible pour la reservation automatique");
+  }
+  await client.query(
+    `
+      UPDATE public.stock_batches
+      SET qty_reserved = qty_reserved + $2
+      WHERE id = $1::uuid
+    `,
+    [args.stock_batch_id, qtyToReserve]
+  );
+
   const existingReservation = await client.query<{ id: string }>(
     `
       SELECT id::text AS id
@@ -210,12 +284,14 @@ async function reserveProducedQtyForCommandeLine(
         AND location_id = $2::uuid
         AND source_type = 'COMMANDE_LIGNE'
         AND source_id = $3
+        AND lot_id = $4::uuid
+        AND stock_batch_id = $5::uuid
         AND status = 'ACTIVE'
       ORDER BY created_at ASC
       LIMIT 1
       FOR UPDATE
     `,
-    [args.article_id, args.location_id, String(args.commande_ligne_id)]
+    [args.article_id, args.location_id, String(args.commande_ligne_id), args.lot_id, args.stock_batch_id]
   );
 
   const existingId = existingReservation.rows[0]?.id ?? null;
@@ -242,12 +318,22 @@ async function reserveProducedQtyForCommandeLine(
         source_type,
         source_id,
         status,
+        lot_id,
+        stock_batch_id,
         created_by,
         updated_by
-      ) VALUES ($1::uuid,$2::uuid,$3,'COMMANDE_LIGNE',$4,'ACTIVE',$5,$5)
+      ) VALUES ($1::uuid,$2::uuid,$3,'COMMANDE_LIGNE',$4,'ACTIVE',$5::uuid,$6::uuid,$7,$7)
       RETURNING id::text AS id
     `,
-    [args.article_id, args.location_id, qtyToReserve, String(args.commande_ligne_id), args.actor_user_id]
+    [
+      args.article_id,
+      args.location_id,
+      qtyToReserve,
+      String(args.commande_ligne_id),
+      args.lot_id,
+      args.stock_batch_id,
+      args.actor_user_id,
+    ]
   );
 
   const reservationId = insertReservation.rows[0]?.id ?? null;
@@ -375,19 +461,29 @@ async function ensureStockBatchId(client: Pick<PoolClient, "query">, args: { sto
 
   await client.query(
     `
-      INSERT INTO public.stock_batches (stock_level_id, batch_code)
-      VALUES ($1::uuid,$2)
+      INSERT INTO public.stock_batches (stock_level_id, batch_code, lot_id)
+      VALUES ($1::uuid,$2,$3::uuid)
       ON CONFLICT (stock_level_id, batch_code) DO NOTHING
     `,
-    [args.stock_level_id, lotCode]
+    [args.stock_level_id, lotCode, args.lot_id]
   );
 
-  const b = await client.query<{ id: string }>(
-    `SELECT id::text AS id FROM public.stock_batches WHERE stock_level_id = $1::uuid AND batch_code = $2`,
+  const b = await client.query<{ id: string; lot_id: string | null }>(
+    `SELECT id::text AS id, lot_id::text AS lot_id
+     FROM public.stock_batches
+     WHERE stock_level_id = $1::uuid AND batch_code = $2
+     FOR UPDATE`,
     [args.stock_level_id, lotCode]
   );
-  const id = b.rows[0]?.id;
+  const row = b.rows[0] ?? null;
+  const id = row?.id;
   if (!id) throw new Error("Failed to ensure stock batch");
+  if (row.lot_id && row.lot_id !== args.lot_id) {
+    throw new HttpError(409, "STOCK_BATCH_LOT_MISMATCH", "Le lot de stock est deja rattache a un autre lot interne");
+  }
+  if (!row.lot_id) {
+    await client.query(`UPDATE public.stock_batches SET lot_id = $2::uuid WHERE id = $1::uuid`, [id, args.lot_id]);
+  }
   return id;
 }
 
@@ -425,6 +521,11 @@ export async function repoGetOfReceiptContext(params: { of_id: number }): Promis
     piece_designation: string;
     quantite_lancee: number;
     quantite_bonne: number;
+    statut: string;
+    updated_at: string;
+    affaire_id: number | null;
+    commande_id: number | null;
+    commande_ligne_id: number | null;
   };
 
   const ofRes = await pool.query<OfRow>(
@@ -437,7 +538,12 @@ export async function repoGetOfReceiptContext(params: { of_id: number }): Promis
         pt.code AS piece_code,
         pt.designation AS piece_designation,
         o.quantite_lancee::float8 AS quantite_lancee,
-        o.quantite_bonne::float8 AS quantite_bonne
+        o.quantite_bonne::float8 AS quantite_bonne,
+        o.statut::text AS statut,
+        o.updated_at::text AS updated_at,
+        o.affaire_id::bigint::int AS affaire_id,
+        o.commande_id::bigint::int AS commande_id,
+        o.commande_ligne_id::bigint::int AS commande_ligne_id
       FROM public.ordres_fabrication o
       JOIN public.pieces_techniques pt ON pt.id = o.piece_technique_id
       WHERE o.id = $1::bigint
@@ -459,12 +565,23 @@ export async function repoGetOfReceiptContext(params: { of_id: number }): Promis
         ).rows[0]?.unite ?? null,
       }
     : await resolveArticleForPieceTechnique(pool, ofRow.piece_technique_id);
-  const outputLotsRes = await pool.query<{ lot_id: string; lot_code: string; qty_ok: number; updated_at: string }>(
+  const outputLotsRes = await pool.query<{
+    lot_id: string;
+    lot_code: string;
+    lot_status: string;
+    qty_ok: number;
+    qty_scrap: number;
+    qty_rework: number;
+    updated_at: string;
+  }>(
     `
       SELECT
         ool.lot_id::text AS lot_id,
         l.lot_code,
+        l.lot_status,
         ool.qty_ok::float8 AS qty_ok,
+        ool.qty_scrap::float8 AS qty_scrap,
+        ool.qty_rework::float8 AS qty_rework,
         ool.updated_at::text AS updated_at
       FROM public.of_output_lots ool
       JOIN public.lots l ON l.id = ool.lot_id
@@ -472,6 +589,29 @@ export async function repoGetOfReceiptContext(params: { of_id: number }): Promis
       ORDER BY ool.updated_at DESC, ool.id DESC
     `,
     [params.of_id]
+  );
+  const existingLotsRes = await pool.query<{
+    lot_id: string;
+    lot_code: string;
+    lot_status: string;
+    qty_on_hand: number;
+    updated_at: string;
+  }>(
+    `
+      SELECT
+        l.id::text AS lot_id,
+        l.lot_code,
+        l.lot_status,
+        COALESCE(SUM(sb.qty_total), 0)::float8 AS qty_on_hand,
+        l.updated_at::text AS updated_at
+      FROM public.lots l
+      LEFT JOIN public.stock_batches sb ON sb.lot_id = l.id
+      WHERE l.article_id = $1::uuid
+      GROUP BY l.id, l.lot_code, l.lot_status, l.updated_at
+      ORDER BY l.updated_at DESC, l.lot_code ASC
+      LIMIT 200
+    `,
+    [article.id]
   );
 
   const receivedQty = outputLotsRes.rows.reduce((acc, r) => acc + (Number.isFinite(r.qty_ok) ? r.qty_ok : 0), 0);
@@ -521,6 +661,11 @@ export async function repoGetOfReceiptContext(params: { of_id: number }): Promis
       piece_designation: ofRow.piece_designation,
       quantite_lancee: Number(ofRow.quantite_lancee),
       quantite_bonne: Number(ofRow.quantite_bonne),
+      statut: ofRow.statut,
+      updated_at: ofRow.updated_at,
+      affaire_id: ofRow.affaire_id === null ? null : Number(ofRow.affaire_id),
+      commande_id: ofRow.commande_id === null ? null : Number(ofRow.commande_id),
+      commande_ligne_id: ofRow.commande_ligne_id === null ? null : Number(ofRow.commande_ligne_id),
     },
     article_id: article.id,
     unite: article.unite,
@@ -530,7 +675,17 @@ export async function repoGetOfReceiptContext(params: { of_id: number }): Promis
     output_lots: outputLotsRes.rows.map((r) => ({
       lot_id: r.lot_id,
       lot_code: r.lot_code,
+      lot_status: r.lot_status,
       qty_ok: Number(r.qty_ok),
+      qty_scrap: Number(r.qty_scrap),
+      qty_rework: Number(r.qty_rework),
+      updated_at: r.updated_at,
+    })),
+    existing_lots: existingLotsRes.rows.map((r) => ({
+      lot_id: r.lot_id,
+      lot_code: r.lot_code,
+      lot_status: r.lot_status,
+      qty_on_hand: Number(r.qty_on_hand),
       updated_at: r.updated_at,
     })),
     locations: {
@@ -546,27 +701,63 @@ export async function repoGetOfReceiptContext(params: { of_id: number }): Promis
   };
 }
 
-export async function repoCreateOfReceipt(params: { of_id: number; body: OfReceiptBodyDTO; audit: AuditContext }): Promise<OfReceiptResult> {
+export async function repoCreateOfReceipt(params: {
+  of_id: number;
+  body: OfReceiptBodyDTO;
+  idempotency_key: string;
+  audit: AuditContext;
+}): Promise<OfReceiptResult> {
   const client = await pool.connect();
+  const requestHash = receiptRequestHash(params.of_id, params.body);
   try {
     await client.query("BEGIN");
+    await client.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`, [
+      `of-receipt:${params.audit.user_id}:${params.idempotency_key}`,
+    ]);
+
+    const replayRes = await client.query<{ request_hash: string; result_payload: OfReceiptResult }>(
+      `
+        SELECT request_hash, result_payload
+        FROM public.of_receipts
+        WHERE actor_user_id = $1
+          AND idempotency_key = $2
+        LIMIT 1
+      `,
+      [params.audit.user_id, params.idempotency_key]
+    );
+    const replay = replayRes.rows[0] ?? null;
+    if (replay) {
+      if (replay.request_hash !== requestHash) {
+        throw new HttpError(
+          409,
+          "IDEMPOTENCY_KEY_REUSED",
+          "Cette cle d'idempotence a deja ete utilisee avec un contenu different."
+        );
+      }
+      await client.query("COMMIT");
+      return { ...replay.result_payload, idempotent_replay: true };
+    }
 
     const ofRes = await client.query<{
       numero: string;
       piece_technique_id: string;
       article_id: string | null;
+      affaire_id: number | null;
       commande_ligne_id: number | null;
       quantite_bonne: number;
       statut: string;
+      updated_at: string;
     }>(
       `
         SELECT
           numero,
           piece_technique_id::text AS piece_technique_id,
           article_id::text AS article_id,
+          affaire_id::bigint::int AS affaire_id,
           commande_ligne_id::bigint::int AS commande_ligne_id,
           quantite_bonne::float8 AS quantite_bonne,
-          statut::text AS statut
+          statut::text AS statut,
+          updated_at::text AS updated_at
         FROM public.ordres_fabrication
         WHERE id = $1::bigint
         FOR UPDATE
@@ -575,6 +766,15 @@ export async function repoCreateOfReceipt(params: { of_id: number; body: OfRecei
     );
     const ofRow = ofRes.rows[0] ?? null;
     if (!ofRow) throw new HttpError(404, "OF_NOT_FOUND", "Ordre de fabrication introuvable");
+
+    if (Date.parse(ofRow.updated_at) !== Date.parse(params.body.expected_of_updated_at)) {
+      throw new HttpError(
+        409,
+        "CONCURRENT_MODIFICATION",
+        "L'OF a ete modifie depuis l'apercu. Rechargez les donnees avant de confirmer.",
+        { expected: params.body.expected_of_updated_at, actual: ofRow.updated_at }
+      );
+    }
 
     // #170 : pas de réception sur un OF annulé/clôturé/non démarré.
     const ofStatut = ofRow.statut as OfStatut;
@@ -645,8 +845,12 @@ export async function repoCreateOfReceipt(params: { of_id: number; body: OfRecei
       if (!row) throw new HttpError(400, "INVALID_LOT", "Lot introuvable pour cet article");
 
       const lotStatus = row.lot_status ?? "LIBERE";
-      if (lotStatus === "BLOQUE" || lotStatus === "EN_ATTENTE" || lotStatus === "QUARANTAINE") {
-        throw new HttpError(409, "LOT_NOT_CONSUMABLE", `Ce lot n'est pas consommable (statut: ${lotStatus})`);
+      if (lotStatus !== params.body.quality_status) {
+        throw new HttpError(
+          409,
+          "LOT_QUALITY_STATUS_MISMATCH",
+          `Le lot existant est au statut ${lotStatus}; la reception demandee est ${params.body.quality_status}.`
+        );
       }
 
       lotId = row.id;
@@ -659,11 +863,20 @@ export async function repoCreateOfReceipt(params: { of_id: number; body: OfRecei
       try {
         const ins = await client.query<{ id: string }>(
           `
-            INSERT INTO public.lots (article_id, lot_code, notes, created_by, updated_by)
-            VALUES ($1::uuid,$2,$3,$4,$4)
+            INSERT INTO public.lots (
+              article_id, lot_code, lot_status, lot_status_note, notes, created_by, updated_by
+            )
+            VALUES ($1::uuid,$2,$3,$4,$5,$6,$6)
             RETURNING id::text AS id
           `,
-          [article.id, code, params.body.commentaire ?? null, params.audit.user_id]
+          [
+            article.id,
+            code,
+            params.body.quality_status,
+            params.body.quality_reason ?? null,
+            params.body.commentaire ?? null,
+            params.audit.user_id,
+          ]
         );
         const id = ins.rows[0]?.id;
         if (!id) throw new Error("Failed to create lot");
@@ -698,6 +911,7 @@ export async function repoCreateOfReceipt(params: { of_id: number; body: OfRecei
           source_document_type,
           source_document_id,
           reason_code,
+          idempotency_key,
           created_by,
           updated_by
         )
@@ -716,12 +930,23 @@ export async function repoCreateOfReceipt(params: { of_id: number; body: OfRecei
           'OF',
           $8,
           'OF_RECEIPT',
+          $9,
           $6,
           $6
         )
         RETURNING id::text AS id
       `,
-      [article.id, stockLevelId, stockBatchId, params.body.qty_ok, params.body.commentaire ?? null, params.audit.user_id, movementNo, String(params.of_id)]
+      [
+        article.id,
+        stockLevelId,
+        stockBatchId,
+        params.body.qty_ok,
+        params.body.commentaire ?? null,
+        params.audit.user_id,
+        movementNo,
+        String(params.of_id),
+        `of-receipt:${params.audit.user_id}:${params.idempotency_key}`,
+      ]
     );
     const movementId = movementIns.rows[0]?.id;
     if (!movementId) throw new Error("Failed to create stock movement");
@@ -797,27 +1022,164 @@ export async function repoCreateOfReceipt(params: { of_id: number; body: OfRecei
           created_by,
           updated_by
         )
-        VALUES ($1::bigint,$2::uuid,$3,0,0,$4,$4)
+        VALUES ($1::bigint,$2::uuid,$3,$4,$5,$6,$6)
         ON CONFLICT (of_id, lot_id)
         DO UPDATE SET
           qty_ok = public.of_output_lots.qty_ok + EXCLUDED.qty_ok,
+          qty_scrap = public.of_output_lots.qty_scrap + EXCLUDED.qty_scrap,
+          qty_rework = public.of_output_lots.qty_rework + EXCLUDED.qty_rework,
           updated_at = now(),
           updated_by = EXCLUDED.updated_by
       `,
-      [params.of_id, lotId, params.body.qty_ok, params.audit.user_id]
+      [
+        params.of_id,
+        lotId,
+        params.body.qty_ok,
+        params.body.qty_scrap,
+        params.body.qty_rework,
+        params.audit.user_id,
+      ]
     );
 
+    let nonConformityId: string | null = null;
+    if (params.body.quality_status === "BLOQUE" || params.body.qty_scrap > 0 || params.body.qty_rework > 0) {
+      const ncRes = await client.query<{ id: string }>(
+        `
+          INSERT INTO public.non_conformity (
+            affaire_id,
+            of_id,
+            piece_technique_id,
+            lot_id,
+            description,
+            severity,
+            status,
+            detected_by,
+            created_by,
+            updated_by
+          )
+          VALUES (
+            $1::bigint,
+            $2::bigint,
+            $3::uuid,
+            $4::uuid,
+            $5,
+            $6::public.quality_nc_severity,
+            'OPEN'::public.quality_nc_status,
+            $7,
+            $7,
+            $7
+          )
+          RETURNING id::text AS id
+        `,
+        [
+          ofRow.affaire_id,
+          params.of_id,
+          ofRow.piece_technique_id,
+          lotId,
+          params.body.quality_reason ??
+            `Ecart constate a la reception de production: rebut ${params.body.qty_scrap}, retouche ${params.body.qty_rework}.`,
+          params.body.quality_status === "BLOQUE" ? "MAJOR" : "MINOR",
+          params.audit.user_id,
+        ]
+      );
+      nonConformityId = ncRes.rows[0]?.id ?? null;
+      if (!nonConformityId) throw new Error("Failed to create production non-conformity");
+    }
+
     const autoReservation =
-      typeof ofRow.commande_ligne_id === "number"
+      params.body.quality_status === "LIBERE" && typeof ofRow.commande_ligne_id === "number"
         ? await reserveProducedQtyForCommandeLine(client, {
             commande_ligne_id: ofRow.commande_ligne_id,
             article_id: article.id,
             location_id: map.location_id,
             stock_level_id: stockLevelId,
+            stock_batch_id: stockBatchId,
+            lot_id: lotId,
             qty_ok: params.body.qty_ok,
             actor_user_id: params.audit.user_id,
           })
         : null;
+
+    const receiptId = randomUUID();
+    const receiptResult: OfReceiptResult = {
+      receipt_id: receiptId,
+      lot_id: lotId,
+      lot_code: lotCode,
+      stock_movement_id: movementId,
+      movement_no: movementNo,
+      qty_ok: params.body.qty_ok,
+      qty_scrap: params.body.qty_scrap,
+      qty_rework: params.body.qty_rework,
+      quality_status: params.body.quality_status,
+      reservation_id: autoReservation?.reservation_id ?? null,
+      reserved_qty: autoReservation?.qty_reserved ?? 0,
+      non_conformity_id: nonConformityId,
+      idempotent_replay: false,
+    };
+
+    await client.query(
+      `
+        UPDATE public.ordres_fabrication
+        SET updated_at = clock_timestamp(),
+            updated_by = $2
+        WHERE id = $1::bigint
+      `,
+      [params.of_id, params.audit.user_id]
+    );
+
+    await client.query(
+      `
+        INSERT INTO public.of_receipts (
+          id,
+          of_id,
+          actor_user_id,
+          idempotency_key,
+          request_hash,
+          request_payload,
+          result_payload,
+          expected_of_updated_at,
+          qty_ok,
+          qty_scrap,
+          qty_rework,
+          quality_status,
+          quality_reason,
+          location_id,
+          lot_id,
+          stock_level_id,
+          stock_batch_id,
+          stock_movement_id,
+          reservation_id,
+          non_conformity_id
+        )
+        VALUES (
+          $1::uuid,$2::bigint,$3,$4,$5,$6::jsonb,$7::jsonb,$8::timestamptz,
+          $9,$10,$11,$12,$13,$14::uuid,$15::uuid,$16::uuid,$17::uuid,$18::uuid,
+          $19::uuid,$20::uuid
+        )
+      `,
+      [
+        receiptId,
+        params.of_id,
+        params.audit.user_id,
+        params.idempotency_key,
+        requestHash,
+        params.body,
+        receiptResult,
+        params.body.expected_of_updated_at,
+        params.body.qty_ok,
+        params.body.qty_scrap,
+        params.body.qty_rework,
+        params.body.quality_status,
+        params.body.quality_reason ?? null,
+        map.location_id,
+        lotId,
+        stockLevelId,
+        stockBatchId,
+        movementId,
+        autoReservation?.reservation_id ?? null,
+        nonConformityId,
+      ]
+    );
 
     await insertAuditLog(client, params.audit, {
       action: "production.of.receipt",
@@ -827,24 +1189,25 @@ export async function repoCreateOfReceipt(params: { of_id: number; body: OfRecei
         lot_id: lotId,
         lot_code: lotCode,
         qty_ok: params.body.qty_ok,
+        qty_scrap: params.body.qty_scrap,
+        qty_rework: params.body.qty_rework,
+        quality_status: params.body.quality_status,
+        quality_reason: params.body.quality_reason ?? null,
         location_id: map.location_id,
+        receipt_id: receiptId,
         stock_movement_id: movementId,
         movement_no: movementNo,
         commande_ligne_id: ofRow.commande_ligne_id ?? null,
         article_id: article.id,
         auto_reservation_id: autoReservation?.reservation_id ?? null,
         auto_reserved_qty: autoReservation?.qty_reserved ?? 0,
+        non_conformity_id: nonConformityId,
+        idempotency_key: params.idempotency_key,
       },
     });
 
     await client.query("COMMIT");
-    return {
-      lot_id: lotId,
-      lot_code: lotCode,
-      stock_movement_id: movementId,
-      movement_no: movementNo,
-      qty_ok: params.body.qty_ok,
-    };
+    return receiptResult;
   } catch (err) {
     await client.query("ROLLBACK");
     throw err;
@@ -854,12 +1217,23 @@ export async function repoCreateOfReceipt(params: { of_id: number; body: OfRecei
 }
 
 export async function repoGetOfTraceability(params: { of_id: number }): Promise<OfTraceability> {
-  const outputLotsRes = await pool.query<{ lot_id: string; lot_code: string; qty_ok: number; updated_at: string }>(
+  const outputLotsRes = await pool.query<{
+    lot_id: string;
+    lot_code: string;
+    lot_status: string;
+    qty_ok: number;
+    qty_scrap: number;
+    qty_rework: number;
+    updated_at: string;
+  }>(
     `
       SELECT
         ool.lot_id::text AS lot_id,
         l.lot_code,
+        l.lot_status,
         ool.qty_ok::float8 AS qty_ok,
+        ool.qty_scrap::float8 AS qty_scrap,
+        ool.qty_rework::float8 AS qty_rework,
         ool.updated_at::text AS updated_at
       FROM public.of_output_lots ool
       JOIN public.lots l ON l.id = ool.lot_id
@@ -870,11 +1244,17 @@ export async function repoGetOfTraceability(params: { of_id: number }): Promise<
   );
 
   const receiptsRes = await pool.query<{
+    receipt_id: string | null;
     stock_movement_id: string;
     movement_no: string | null;
     status: string;
     posted_at: string | null;
     qty: number;
+    qty_scrap: number;
+    qty_rework: number;
+    quality_status: string | null;
+    reservation_id: string | null;
+    non_conformity_id: string | null;
     lot_id: string | null;
     lot_code: string | null;
     magasin_id: string | null;
@@ -886,11 +1266,17 @@ export async function repoGetOfTraceability(params: { of_id: number }): Promise<
   }>(
     `
       SELECT
+        r.id::text AS receipt_id,
         m.id::text AS stock_movement_id,
         m.movement_no,
         m.status,
         m.posted_at::text AS posted_at,
         m.qty::float8 AS qty,
+        COALESCE(r.qty_scrap, 0)::float8 AS qty_scrap,
+        COALESCE(r.qty_rework, 0)::float8 AS qty_rework,
+        r.quality_status,
+        r.reservation_id::text AS reservation_id,
+        r.non_conformity_id::text AS non_conformity_id,
         ml.lot_id::text AS lot_id,
         l.lot_code,
         ml.dst_magasin_id::text AS magasin_id,
@@ -900,6 +1286,7 @@ export async function repoGetOfTraceability(params: { of_id: number }): Promise<
         e.code AS emplacement_code,
         e.location_id::text AS location_id
       FROM public.stock_movements m
+      LEFT JOIN public.of_receipts r ON r.stock_movement_id = m.id
       JOIN public.stock_movement_lines ml ON ml.movement_id = m.id
       LEFT JOIN public.lots l ON l.id = ml.lot_id
       LEFT JOIN public.emplacements e ON e.id = ml.dst_emplacement_id
@@ -917,15 +1304,24 @@ export async function repoGetOfTraceability(params: { of_id: number }): Promise<
     output_lots: outputLotsRes.rows.map((r) => ({
       lot_id: r.lot_id,
       lot_code: r.lot_code,
+      lot_status: r.lot_status,
       qty_ok: Number(r.qty_ok),
+      qty_scrap: Number(r.qty_scrap),
+      qty_rework: Number(r.qty_rework),
       updated_at: r.updated_at,
     })),
     receipts: receiptsRes.rows.map((r) => ({
+      receipt_id: r.receipt_id,
       stock_movement_id: r.stock_movement_id,
       movement_no: r.movement_no,
       status: r.status,
       posted_at: r.posted_at,
       qty: Number(r.qty),
+      qty_scrap: Number(r.qty_scrap),
+      qty_rework: Number(r.qty_rework),
+      quality_status: r.quality_status,
+      reservation_id: r.reservation_id,
+      non_conformity_id: r.non_conformity_id,
       lot_id: r.lot_id,
       lot_code: r.lot_code,
       magasin_id: r.magasin_id,

--- a/src/module/production/routes/production.routes.ts
+++ b/src/module/production/routes/production.routes.ts
@@ -197,7 +197,7 @@ router.post("/ofs/:id/operations/:opId/time-logs/start", requireOfCapability("op
 router.post("/ofs/:id/operations/:opId/time-logs/stop", requireOfCapability("operate"), stopOfOperationTimeLog);
 
 // Phase 5 - Fin de production -> Entree en stock
-router.get("/ofs/:id/receipt-context", getOfReceiptContext);
+router.get("/ofs/:id/receipt-context", requireOfCapability("receipt"), getOfReceiptContext);
 router.post("/ofs/:id/receipt", requireOfCapability("receipt"), createOfReceipt);
 router.get("/ofs/:id/traceability", requireOfCapability("traceability"), getOfTraceability);
 

--- a/src/module/production/services/production.service.ts
+++ b/src/module/production/services/production.service.ts
@@ -130,7 +130,12 @@ export const svcGetOfTechnicalSnapshot = (params: { of_id: number }) =>
 
 export const svcGetOfReceiptContext = (params: { of_id: number }) => receiptsRepo.repoGetOfReceiptContext(params);
 
-export const svcCreateOfReceipt = (params: { of_id: number; body: OfReceiptBodyDTO; audit: repo.AuditContext }) =>
+export const svcCreateOfReceipt = (params: {
+  of_id: number;
+  body: OfReceiptBodyDTO;
+  idempotency_key: string;
+  audit: repo.AuditContext;
+}) =>
   receiptsRepo.repoCreateOfReceipt(params);
 
 export const svcGetOfTraceability = (params: { of_id: number }) => receiptsRepo.repoGetOfTraceability(params);

--- a/src/module/production/validators/production.validators.ts
+++ b/src/module/production/validators/production.validators.ts
@@ -278,18 +278,45 @@ export const ofOperationIdParamSchema = z.object({
 // Phase 5 - OF -> Entree en stock
 // -------------------------
 
+export const ofReceiptQualityStatusSchema = z.enum(["LIBERE", "QUARANTAINE", "BLOQUE"]);
+export type OfReceiptQualityStatusDTO = z.infer<typeof ofReceiptQualityStatusSchema>;
+
 export const ofReceiptBodySchema = z
   .object({
     article_id: uuid.optional(),
     qty_ok: z.coerce.number().positive(),
+    qty_scrap: z.coerce.number().min(0).optional().default(0),
+    qty_rework: z.coerce.number().min(0).optional().default(0),
     unite: z.string().trim().min(1).max(30).optional().nullable(),
     location_id: uuid,
     lot_mode: z.enum(["NEW", "EXISTING"]),
     lot_id: uuid.optional().nullable(),
     lot_number: z.string().trim().min(1).max(80).optional().nullable(),
+    quality_status: ofReceiptQualityStatusSchema,
+    quality_reason: z.string().trim().min(3).max(1000).optional().nullable(),
+    expected_of_updated_at: z.string().datetime({ offset: true }),
     commentaire: z.string().trim().min(1).max(2000).optional().nullable(),
   })
-  .strict();
+  .strict()
+  .superRefine((body, ctx) => {
+    if (body.lot_mode === "EXISTING" && !body.lot_id) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["lot_id"], message: "Un lot existant doit etre selectionne." });
+    }
+    if (body.lot_mode === "NEW" && body.lot_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["lot_id"],
+        message: "Un nouveau lot ne peut pas reutiliser un identifiant existant.",
+      });
+    }
+    if (body.quality_status !== "LIBERE" && !body.quality_reason?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["quality_reason"],
+        message: "Un motif qualite est requis pour un lot en quarantaine ou bloque.",
+      });
+    }
+  });
 
 export const createOfReceiptSchema = z.object({
   body: ofReceiptBodySchema,


### PR DESCRIPTION
## Contenu de la release

Cette release promeut depuis `dev` uniquement le backend #223 : réception atomique et idempotente, qualité, lots, mouvement stock, réservation, non-conformité, audit et patch PostgreSQL.

## Validation

- PR d’intégration #113 fusionnée dans `dev`
- Backend CI vert
- TypeScript vert
- Vitest 1 117/1 117, dont 51/51 contrats ciblés
- patch sauvegardé, appliqué, vérifié et enregistré dans `cerp_schema_migrations` sur `cerp_prod`

## Limites documentées

La recette transactionnelle par injection exhaustive reste une validation complémentaire ; aucun déploiement applicatif n’est inclus dans cette PR.

Supports BigFootLime/crp-systems-web#223