### PR TITLE
release: promouvoir le backend Stock #225

### DIFF
--- a/db/patches/20260723_stock_traceability_225.sql
+++ b/db/patches/20260723_stock_traceability_225.sql
@@ -1,0 +1,858 @@
+-- Issue #225 - Stock, lots, movements, reservations and inventories.
+-- Additive/idempotent patch. Validate on cerp_test before any production proposal.
+-- No industrial evidence is deleted or rewritten by this patch.
+
+BEGIN;
+
+DO $$
+DECLARE
+  required_table text;
+BEGIN
+  FOREACH required_table IN ARRAY ARRAY[
+    'articles',
+    'users',
+    'units',
+    'warehouses',
+    'locations',
+    'magasins',
+    'emplacements',
+    'lots',
+    'stock_levels',
+    'stock_batches',
+    'stock_movements',
+    'stock_movement_lines',
+    'stock_movement_event_log',
+    'stock_reservations',
+    'commande_ligne',
+    'ordres_fabrication',
+    'bon_livraison_ligne',
+    'affaire',
+    'stock_inventory_sessions',
+    'stock_inventory_lines',
+    'stock_inventory_session_movements'
+  ]
+  LOOP
+    IF to_regclass(format('public.%I', required_table)) IS NULL THEN
+      RAISE EXCEPTION '#225 prerequisite missing: public.%', required_table;
+    END IF;
+  END LOOP;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'stock_movements'
+      AND column_name = 'id'
+      AND data_type = 'uuid'
+  ) THEN
+    RAISE EXCEPTION '#225 requires the canonical UUID stock movement spine';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* Physical topology                                                          */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.emplacements
+  ADD COLUMN IF NOT EXISTS location_type text NOT NULL DEFAULT 'STORAGE',
+  ADD COLUMN IF NOT EXISTS allow_inbound boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS allow_outbound boolean NOT NULL DEFAULT true,
+  ADD COLUMN IF NOT EXISTS restrictions jsonb NOT NULL DEFAULT '{}'::jsonb;
+
+UPDATE public.emplacements
+SET
+  location_type = 'SCRAP',
+  allow_outbound = false
+WHERE is_scrap = true
+  AND location_type = 'STORAGE';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'emplacements_location_type_ck'
+      AND conrelid = 'public.emplacements'::regclass
+  ) THEN
+    ALTER TABLE public.emplacements
+      ADD CONSTRAINT emplacements_location_type_ck
+      CHECK (location_type IN (
+        'RECEIVING',
+        'PRODUCTION',
+        'QUARANTINE',
+        'SCRAP',
+        'SHIPPING',
+        'STORAGE'
+      ));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'emplacements_restrictions_object_ck'
+      AND conrelid = 'public.emplacements'::regclass
+  ) THEN
+    ALTER TABLE public.emplacements
+      ADD CONSTRAINT emplacements_restrictions_object_ck
+      CHECK (jsonb_typeof(restrictions) = 'object');
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS emplacements_location_type_idx
+  ON public.emplacements(location_type, is_active);
+
+/* -------------------------------------------------------------------------- */
+/* Immutable movement correlation and generic command idempotence             */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.stock_movements
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS reversal_of_id uuid NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_movements_reversal_of_id_fkey'
+      AND conrelid = 'public.stock_movements'::regclass
+  ) THEN
+    ALTER TABLE public.stock_movements
+      ADD CONSTRAINT stock_movements_reversal_of_id_fkey
+      FOREIGN KEY (reversal_of_id) REFERENCES public.stock_movements(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_movements_not_self_reversal_ck'
+      AND conrelid = 'public.stock_movements'::regclass
+  ) THEN
+    ALTER TABLE public.stock_movements
+      ADD CONSTRAINT stock_movements_not_self_reversal_ck
+      CHECK (reversal_of_id IS NULL OR reversal_of_id <> id);
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS stock_movements_reversal_once_uq
+  ON public.stock_movements(reversal_of_id)
+  WHERE reversal_of_id IS NOT NULL
+    AND status::text <> 'CANCELLED';
+CREATE INDEX IF NOT EXISTS stock_movements_correlation_idx
+  ON public.stock_movements(correlation_id)
+  WHERE correlation_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.stock_command_receipts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  command_type text NOT NULL,
+  resource_type text NOT NULL,
+  resource_id text NOT NULL,
+  request_payload jsonb NOT NULL,
+  result_payload jsonb NOT NULL,
+  correlation_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT stock_command_receipts_actor_key_uq UNIQUE (actor_user_id, idempotency_key),
+  CONSTRAINT stock_command_receipts_key_len_ck CHECK (char_length(idempotency_key) BETWEEN 8 AND 200),
+  CONSTRAINT stock_command_receipts_request_hash_ck CHECK (request_hash ~ '^[A-Fa-f0-9]{64}$'),
+  CONSTRAINT stock_command_receipts_command_type_ck CHECK (command_type IN (
+    'MOVEMENT_CREATE',
+    'MOVEMENT_POST',
+    'MOVEMENT_CANCEL',
+    'MOVEMENT_COMPENSATE',
+    'RESERVATION_CREATE',
+    'RESERVATION_RELEASE',
+    'RESERVATION_CONSUME',
+    'LOT_QUALITY_CHANGE',
+    'LOT_GENEALOGY_RECORD',
+    'INVENTORY_CREATE',
+    'INVENTORY_START',
+    'INVENTORY_COUNT',
+    'INVENTORY_APPROVE',
+    'INVENTORY_CANCEL',
+    'INVENTORY_CLOSE'
+  ))
+);
+
+CREATE INDEX IF NOT EXISTS stock_command_receipts_resource_idx
+  ON public.stock_command_receipts(resource_type, resource_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS stock_command_receipts_correlation_idx
+  ON public.stock_command_receipts(correlation_id);
+
+CREATE OR REPLACE FUNCTION public.fn_protect_stock_immutable_evidence()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'stock audit evidence is immutable'
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_stock_command_receipt ON public.stock_command_receipts;
+CREATE TRIGGER trg_protect_stock_command_receipt
+BEFORE UPDATE OR DELETE ON public.stock_command_receipts
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_stock_immutable_evidence();
+
+CREATE OR REPLACE FUNCTION public.fn_protect_posted_stock_movement()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'stock movements cannot be deleted'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status::text IN ('POSTED', 'CANCELLED') THEN
+    RAISE EXCEPTION 'posted or cancelled stock movements are immutable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_posted_stock_movement ON public.stock_movements;
+CREATE TRIGGER trg_protect_posted_stock_movement
+BEFORE UPDATE OR DELETE ON public.stock_movements
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_posted_stock_movement();
+
+CREATE OR REPLACE FUNCTION public.fn_protect_posted_stock_movement_line()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  movement_status text;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    SELECT status::text INTO movement_status
+    FROM public.stock_movements
+    WHERE id = OLD.movement_id;
+  ELSE
+    SELECT status::text INTO movement_status
+    FROM public.stock_movements
+    WHERE id = NEW.movement_id;
+  END IF;
+
+  IF movement_status IS DISTINCT FROM 'DRAFT' THEN
+    RAISE EXCEPTION 'lines of a posted or cancelled stock movement are immutable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_posted_stock_movement_line ON public.stock_movement_lines;
+CREATE TRIGGER trg_protect_posted_stock_movement_line
+BEFORE UPDATE OR DELETE ON public.stock_movement_lines
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_posted_stock_movement_line();
+
+DROP TRIGGER IF EXISTS trg_protect_stock_movement_event ON public.stock_movement_event_log;
+CREATE TRIGGER trg_protect_stock_movement_event
+BEFORE UPDATE OR DELETE ON public.stock_movement_event_log
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_stock_immutable_evidence();
+
+/* -------------------------------------------------------------------------- */
+/* Reservation lifecycle                                                      */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.stock_reservations
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS commande_ligne_id bigint NULL,
+  ADD COLUMN IF NOT EXISTS of_id bigint NULL,
+  ADD COLUMN IF NOT EXISTS bon_livraison_ligne_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS affaire_id bigint NULL,
+  ADD COLUMN IF NOT EXISTS reason text NULL,
+  ADD COLUMN IF NOT EXISTS expires_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS released_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS released_by integer NULL,
+  ADD COLUMN IF NOT EXISTS consumed_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS consumed_by integer NULL,
+  ADD COLUMN IF NOT EXISTS consumed_stock_movement_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS row_version integer NOT NULL DEFAULT 1;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_reservations_consumed_movement_fkey'
+      AND conrelid = 'public.stock_reservations'::regclass
+  ) THEN
+    ALTER TABLE public.stock_reservations
+      ADD CONSTRAINT stock_reservations_consumed_movement_fkey
+      FOREIGN KEY (consumed_stock_movement_id) REFERENCES public.stock_movements(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_reservations_commande_ligne_fkey'
+      AND conrelid = 'public.stock_reservations'::regclass
+  ) THEN
+    ALTER TABLE public.stock_reservations
+      ADD CONSTRAINT stock_reservations_commande_ligne_fkey
+      FOREIGN KEY (commande_ligne_id) REFERENCES public.commande_ligne(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_reservations_of_fkey'
+      AND conrelid = 'public.stock_reservations'::regclass
+  ) THEN
+    ALTER TABLE public.stock_reservations
+      ADD CONSTRAINT stock_reservations_of_fkey
+      FOREIGN KEY (of_id) REFERENCES public.ordres_fabrication(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_reservations_bon_livraison_ligne_fkey'
+      AND conrelid = 'public.stock_reservations'::regclass
+  ) THEN
+    ALTER TABLE public.stock_reservations
+      ADD CONSTRAINT stock_reservations_bon_livraison_ligne_fkey
+      FOREIGN KEY (bon_livraison_ligne_id) REFERENCES public.bon_livraison_ligne(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_reservations_affaire_fkey'
+      AND conrelid = 'public.stock_reservations'::regclass
+  ) THEN
+    ALTER TABLE public.stock_reservations
+      ADD CONSTRAINT stock_reservations_affaire_fkey
+      FOREIGN KEY (affaire_id) REFERENCES public.affaire(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_reservations_released_by_fkey'
+      AND conrelid = 'public.stock_reservations'::regclass
+  ) THEN
+    ALTER TABLE public.stock_reservations
+      ADD CONSTRAINT stock_reservations_released_by_fkey
+      FOREIGN KEY (released_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_reservations_consumed_by_fkey'
+      AND conrelid = 'public.stock_reservations'::regclass
+  ) THEN
+    ALTER TABLE public.stock_reservations
+      ADD CONSTRAINT stock_reservations_consumed_by_fkey
+      FOREIGN KEY (consumed_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_reservations_status_225_ck'
+      AND conrelid = 'public.stock_reservations'::regclass
+  ) THEN
+    ALTER TABLE public.stock_reservations
+      ADD CONSTRAINT stock_reservations_status_225_ck
+      CHECK (status IN ('ACTIVE', 'RELEASED', 'CONSUMED', 'EXPIRED', 'CANCELLED')) NOT VALID;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS stock_reservations_expiry_idx
+  ON public.stock_reservations(expires_at)
+  WHERE status = 'ACTIVE' AND expires_at IS NOT NULL;
+CREATE INDEX IF NOT EXISTS stock_reservations_correlation_idx
+  ON public.stock_reservations(correlation_id)
+  WHERE correlation_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.stock_reservation_event_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  reservation_id uuid NOT NULL REFERENCES public.stock_reservations(id) ON DELETE RESTRICT,
+  event_type text NOT NULL,
+  old_values jsonb NULL,
+  new_values jsonb NULL,
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT stock_reservation_event_type_ck CHECK (event_type IN (
+    'CREATED',
+    'UPDATED',
+    'RELEASED',
+    'CONSUMED',
+    'EXPIRED',
+    'COMPENSATED'
+  ))
+);
+
+CREATE INDEX IF NOT EXISTS stock_reservation_event_reservation_idx
+  ON public.stock_reservation_event_log(reservation_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS stock_reservation_event_correlation_idx
+  ON public.stock_reservation_event_log(correlation_id);
+
+DROP TRIGGER IF EXISTS trg_protect_stock_reservation_event ON public.stock_reservation_event_log;
+CREATE TRIGGER trg_protect_stock_reservation_event
+BEFORE UPDATE OR DELETE ON public.stock_reservation_event_log
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_stock_immutable_evidence();
+
+CREATE OR REPLACE FUNCTION public.fn_prepare_stock_reservation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    NEW.correlation_id := COALESCE(NEW.correlation_id, gen_random_uuid());
+    NEW.row_version := 1;
+  ELSE
+    IF OLD.status <> 'ACTIVE' THEN
+      RAISE EXCEPTION 'inactive stock reservations are immutable'
+        USING ERRCODE = '55000';
+    END IF;
+    NEW.correlation_id := COALESCE(NEW.correlation_id, OLD.correlation_id, gen_random_uuid());
+    NEW.row_version := OLD.row_version + 1;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_log_stock_reservation_event()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  actor_id integer;
+  emitted_event text;
+BEGIN
+  actor_id := COALESCE(NEW.updated_by, NEW.created_by);
+  IF actor_id IS NULL THEN
+    RAISE EXCEPTION 'stock reservation evidence requires an actor'
+      USING ERRCODE = '23514';
+  END IF;
+
+  IF TG_OP = 'INSERT' THEN
+    emitted_event := 'CREATED';
+  ELSIF NEW.status IS DISTINCT FROM OLD.status THEN
+    emitted_event := CASE NEW.status
+      WHEN 'RELEASED' THEN 'RELEASED'
+      WHEN 'CONSUMED' THEN 'CONSUMED'
+      WHEN 'EXPIRED' THEN 'EXPIRED'
+      WHEN 'CANCELLED' THEN 'COMPENSATED'
+      ELSE 'UPDATED'
+    END;
+  ELSE
+    emitted_event := 'UPDATED';
+  END IF;
+
+  INSERT INTO public.stock_reservation_event_log (
+    reservation_id,
+    event_type,
+    old_values,
+    new_values,
+    actor_user_id,
+    correlation_id
+  )
+  VALUES (
+    NEW.id,
+    emitted_event,
+    CASE WHEN TG_OP = 'INSERT' THEN NULL ELSE to_jsonb(OLD) END,
+    to_jsonb(NEW),
+    actor_id,
+    NEW.correlation_id
+  );
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_prepare_stock_reservation ON public.stock_reservations;
+CREATE TRIGGER trg_prepare_stock_reservation
+BEFORE INSERT OR UPDATE ON public.stock_reservations
+FOR EACH ROW EXECUTE FUNCTION public.fn_prepare_stock_reservation();
+
+DROP TRIGGER IF EXISTS trg_log_stock_reservation_event ON public.stock_reservations;
+CREATE TRIGGER trg_log_stock_reservation_event
+AFTER INSERT OR UPDATE ON public.stock_reservations
+FOR EACH ROW EXECUTE FUNCTION public.fn_log_stock_reservation_event();
+
+/* -------------------------------------------------------------------------- */
+/* Lot quality history and genealogy                                          */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.stock_lot_event_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  lot_id uuid NOT NULL REFERENCES public.lots(id) ON DELETE RESTRICT,
+  event_type text NOT NULL,
+  old_values jsonb NULL,
+  new_values jsonb NULL,
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS stock_lot_event_lot_idx
+  ON public.stock_lot_event_log(lot_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS stock_lot_event_correlation_idx
+  ON public.stock_lot_event_log(correlation_id);
+
+CREATE TABLE IF NOT EXISTS public.stock_lot_genealogy_edges (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  parent_lot_id uuid NOT NULL REFERENCES public.lots(id) ON DELETE RESTRICT,
+  child_lot_id uuid NOT NULL REFERENCES public.lots(id) ON DELETE RESTRICT,
+  operation_type text NOT NULL,
+  qty_contributed numeric(18,3) NOT NULL,
+  unit_code text NOT NULL,
+  stock_movement_id uuid NULL REFERENCES public.stock_movements(id) ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL,
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT stock_lot_genealogy_not_self_ck CHECK (parent_lot_id <> child_lot_id),
+  CONSTRAINT stock_lot_genealogy_qty_ck CHECK (qty_contributed > 0),
+  CONSTRAINT stock_lot_genealogy_operation_ck CHECK (operation_type IN ('SPLIT', 'MERGE', 'TRANSFORM'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS stock_lot_genealogy_edge_uq
+  ON public.stock_lot_genealogy_edges(parent_lot_id, child_lot_id, operation_type, correlation_id);
+CREATE INDEX IF NOT EXISTS stock_lot_genealogy_parent_idx
+  ON public.stock_lot_genealogy_edges(parent_lot_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS stock_lot_genealogy_child_idx
+  ON public.stock_lot_genealogy_edges(child_lot_id, created_at DESC);
+
+DROP TRIGGER IF EXISTS trg_protect_stock_lot_event ON public.stock_lot_event_log;
+CREATE TRIGGER trg_protect_stock_lot_event
+BEFORE UPDATE OR DELETE ON public.stock_lot_event_log
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_stock_immutable_evidence();
+
+DROP TRIGGER IF EXISTS trg_protect_stock_lot_genealogy ON public.stock_lot_genealogy_edges;
+CREATE TRIGGER trg_protect_stock_lot_genealogy
+BEFORE UPDATE OR DELETE ON public.stock_lot_genealogy_edges
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_stock_immutable_evidence();
+
+/* -------------------------------------------------------------------------- */
+/* Inventory snapshot, append-only counts, approval and cancellation          */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.stock_inventory_sessions
+  DROP CONSTRAINT IF EXISTS stock_inventory_sessions_status_check;
+
+ALTER TABLE public.stock_inventory_sessions
+  ALTER COLUMN started_at DROP NOT NULL,
+  ALTER COLUMN started_at DROP DEFAULT;
+
+ALTER TABLE public.stock_inventory_sessions
+  ADD COLUMN IF NOT EXISTS scope_magasin_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS scope_emplacement_id bigint NULL,
+  ADD COLUMN IF NOT EXISTS scope_article_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS scope_article_category text NULL,
+  ADD COLUMN IF NOT EXISTS blind_count boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS requires_second_count boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS snapshot_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS approved_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS approved_by integer NULL,
+  ADD COLUMN IF NOT EXISTS cancelled_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS cancelled_by integer NULL,
+  ADD COLUMN IF NOT EXISTS cancellation_reason text NULL,
+  ADD COLUMN IF NOT EXISTS row_version integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_inventory_sessions_status_check'
+      AND conrelid = 'public.stock_inventory_sessions'::regclass
+  ) THEN
+    ALTER TABLE public.stock_inventory_sessions
+      ADD CONSTRAINT stock_inventory_sessions_status_check
+      CHECK (status IN ('DRAFT', 'OPEN', 'APPROVED', 'CLOSED', 'CANCELLED'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_inventory_sessions_scope_magasin_fkey'
+      AND conrelid = 'public.stock_inventory_sessions'::regclass
+  ) THEN
+    ALTER TABLE public.stock_inventory_sessions
+      ADD CONSTRAINT stock_inventory_sessions_scope_magasin_fkey
+      FOREIGN KEY (scope_magasin_id) REFERENCES public.magasins(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_inventory_sessions_scope_emplacement_fkey'
+      AND conrelid = 'public.stock_inventory_sessions'::regclass
+  ) THEN
+    ALTER TABLE public.stock_inventory_sessions
+      ADD CONSTRAINT stock_inventory_sessions_scope_emplacement_fkey
+      FOREIGN KEY (scope_emplacement_id) REFERENCES public.emplacements(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_inventory_sessions_scope_article_fkey'
+      AND conrelid = 'public.stock_inventory_sessions'::regclass
+  ) THEN
+    ALTER TABLE public.stock_inventory_sessions
+      ADD CONSTRAINT stock_inventory_sessions_scope_article_fkey
+      FOREIGN KEY (scope_article_id) REFERENCES public.articles(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_inventory_sessions_approved_by_fkey'
+      AND conrelid = 'public.stock_inventory_sessions'::regclass
+  ) THEN
+    ALTER TABLE public.stock_inventory_sessions
+      ADD CONSTRAINT stock_inventory_sessions_approved_by_fkey
+      FOREIGN KEY (approved_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_inventory_sessions_cancelled_by_fkey'
+      AND conrelid = 'public.stock_inventory_sessions'::regclass
+  ) THEN
+    ALTER TABLE public.stock_inventory_sessions
+      ADD CONSTRAINT stock_inventory_sessions_cancelled_by_fkey
+      FOREIGN KEY (cancelled_by) REFERENCES public.users(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.stock_inventory_snapshot_lines (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES public.stock_inventory_sessions(id) ON DELETE RESTRICT,
+  line_no integer NOT NULL,
+  article_id uuid NOT NULL REFERENCES public.articles(id) ON DELETE RESTRICT,
+  magasin_id uuid NOT NULL REFERENCES public.magasins(id) ON DELETE RESTRICT,
+  emplacement_id bigint NOT NULL REFERENCES public.emplacements(id) ON DELETE RESTRICT,
+  lot_id uuid NULL REFERENCES public.lots(id) ON DELETE RESTRICT,
+  stock_level_id uuid NOT NULL REFERENCES public.stock_levels(id) ON DELETE RESTRICT,
+  stock_batch_id uuid NULL REFERENCES public.stock_batches(id) ON DELETE RESTRICT,
+  theoretical_qty numeric(18,3) NOT NULL,
+  unit_code text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS stock_inventory_snapshot_line_no_uq
+  ON public.stock_inventory_snapshot_lines(session_id, line_no);
+CREATE UNIQUE INDEX IF NOT EXISTS stock_inventory_snapshot_no_lot_uq
+  ON public.stock_inventory_snapshot_lines(session_id, article_id, emplacement_id)
+  WHERE lot_id IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS stock_inventory_snapshot_with_lot_uq
+  ON public.stock_inventory_snapshot_lines(session_id, article_id, emplacement_id, lot_id)
+  WHERE lot_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.stock_inventory_count_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  session_id uuid NOT NULL REFERENCES public.stock_inventory_sessions(id) ON DELETE RESTRICT,
+  snapshot_line_id uuid NOT NULL REFERENCES public.stock_inventory_snapshot_lines(id) ON DELETE RESTRICT,
+  count_round integer NOT NULL,
+  counted_qty numeric(18,3) NOT NULL,
+  reason_code text NULL,
+  note text NULL,
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT stock_inventory_count_round_ck CHECK (count_round IN (1, 2)),
+  CONSTRAINT stock_inventory_count_qty_ck CHECK (counted_qty >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS stock_inventory_count_session_idx
+  ON public.stock_inventory_count_events(session_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS stock_inventory_count_line_idx
+  ON public.stock_inventory_count_events(snapshot_line_id, count_round, created_at DESC);
+
+DROP TRIGGER IF EXISTS trg_protect_stock_inventory_snapshot ON public.stock_inventory_snapshot_lines;
+CREATE TRIGGER trg_protect_stock_inventory_snapshot
+BEFORE UPDATE OR DELETE ON public.stock_inventory_snapshot_lines
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_stock_immutable_evidence();
+
+DROP TRIGGER IF EXISTS trg_protect_stock_inventory_count ON public.stock_inventory_count_events;
+CREATE TRIGGER trg_protect_stock_inventory_count
+BEFORE UPDATE OR DELETE ON public.stock_inventory_count_events
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_stock_immutable_evidence();
+
+CREATE OR REPLACE FUNCTION public.fn_protect_stock_inventory_session()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'inventory sessions cannot be deleted'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status IN ('CLOSED', 'CANCELLED') THEN
+    RAISE EXCEPTION 'closed or cancelled inventory sessions are immutable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.status <> 'DRAFT' AND (
+    NEW.scope_magasin_id IS DISTINCT FROM OLD.scope_magasin_id
+    OR NEW.scope_emplacement_id IS DISTINCT FROM OLD.scope_emplacement_id
+    OR NEW.scope_article_id IS DISTINCT FROM OLD.scope_article_id
+    OR NEW.scope_article_category IS DISTINCT FROM OLD.scope_article_category
+    OR NEW.blind_count IS DISTINCT FROM OLD.blind_count
+    OR NEW.requires_second_count IS DISTINCT FROM OLD.requires_second_count
+    OR NEW.snapshot_at IS DISTINCT FROM OLD.snapshot_at
+  ) THEN
+    RAISE EXCEPTION 'inventory scope and snapshot are frozen after start'
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_protect_stock_inventory_line()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  session_status text;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'inventory lines cannot be deleted'
+      USING ERRCODE = '55000';
+  END IF;
+
+  SELECT status INTO session_status
+  FROM public.stock_inventory_sessions
+  WHERE id = NEW.session_id;
+  IF session_status <> 'OPEN' THEN
+    RAISE EXCEPTION 'inventory lines are editable only while the session is open'
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_stock_inventory_session ON public.stock_inventory_sessions;
+CREATE TRIGGER trg_protect_stock_inventory_session
+BEFORE UPDATE OR DELETE ON public.stock_inventory_sessions
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_stock_inventory_session();
+
+DROP TRIGGER IF EXISTS trg_protect_stock_inventory_line ON public.stock_inventory_lines;
+CREATE TRIGGER trg_protect_stock_inventory_line
+BEFORE INSERT OR UPDATE OR DELETE ON public.stock_inventory_lines
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_stock_inventory_line();
+
+DROP TRIGGER IF EXISTS trg_protect_stock_inventory_session_movement
+  ON public.stock_inventory_session_movements;
+CREATE TRIGGER trg_protect_stock_inventory_session_movement
+BEFORE UPDATE OR DELETE ON public.stock_inventory_session_movements
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_stock_immutable_evidence();
+
+/* -------------------------------------------------------------------------- */
+/* Authoritative availability projection                                      */
+/* -------------------------------------------------------------------------- */
+
+CREATE OR REPLACE VIEW public.v_stock_availability_225 AS
+WITH scrap_flow AS (
+  SELECT
+    movement.stock_level_id,
+    movement.stock_batch_id,
+    SUM(ABS(movement.qty))::numeric AS qty_scrap_recorded
+  FROM public.stock_movements movement
+  WHERE movement.status::text = 'POSTED'
+    AND movement.movement_type::text = 'SCRAP'
+  GROUP BY movement.stock_level_id, movement.stock_batch_id
+),
+batch_rows AS (
+  SELECT
+    batch.id AS availability_id,
+    level.id AS stock_level_id,
+    batch.id AS stock_batch_id,
+    level.article_id,
+    level.warehouse_id,
+    level.location_id,
+    level.unit_id,
+    level.managed_in_stock,
+    batch.lot_id,
+    lot.lot_code,
+    lot.lot_status,
+    batch.qty_total,
+    batch.qty_reserved,
+    batch.qty_depreciated,
+    batch.updated_at
+  FROM public.stock_batches batch
+  JOIN public.stock_levels level ON level.id = batch.stock_level_id
+  LEFT JOIN public.lots lot ON lot.id = batch.lot_id
+),
+unbatched_rows AS (
+  SELECT
+    level.id AS availability_id,
+    level.id AS stock_level_id,
+    NULL::uuid AS stock_batch_id,
+    level.article_id,
+    level.warehouse_id,
+    level.location_id,
+    level.unit_id,
+    level.managed_in_stock,
+    NULL::uuid AS lot_id,
+    NULL::text AS lot_code,
+    NULL::text AS lot_status,
+    level.qty_total,
+    level.qty_reserved,
+    level.qty_depreciated,
+    level.updated_at
+  FROM public.stock_levels level
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.stock_batches batch
+    WHERE batch.stock_level_id = level.id
+  )
+),
+availability_rows AS (
+  SELECT * FROM batch_rows
+  UNION ALL
+  SELECT * FROM unbatched_rows
+)
+SELECT
+  row.availability_id AS id,
+  row.availability_id,
+  row.stock_level_id,
+  row.stock_batch_id,
+  row.article_id,
+  row.warehouse_id,
+  row.location_id,
+  row.unit_id,
+  row.managed_in_stock,
+  row.lot_id,
+  row.lot_code,
+  row.lot_status,
+  row.qty_total,
+  row.qty_total AS qty_on_hand,
+  row.qty_reserved,
+  row.qty_depreciated,
+  CASE
+    WHEN row.lot_status IN ('EN_ATTENTE', 'QUARANTAINE')
+      THEN GREATEST(row.qty_total - row.qty_depreciated, 0)
+    ELSE 0
+  END AS qty_quarantine,
+  CASE
+    WHEN row.lot_status = 'BLOQUE'
+      THEN GREATEST(row.qty_total - row.qty_depreciated, 0)
+    ELSE 0
+  END AS qty_blocked,
+  CASE
+    WHEN row.lot_status IS NULL OR row.lot_status = 'LIBERE'
+      THEN GREATEST(row.qty_total - row.qty_reserved - row.qty_depreciated, 0)
+    ELSE 0
+  END AS qty_available,
+  COALESCE(scrap.qty_scrap_recorded, 0) AS qty_scrap_recorded,
+  row.updated_at
+FROM availability_rows row
+LEFT JOIN scrap_flow scrap
+  ON scrap.stock_level_id = row.stock_level_id
+ AND scrap.stock_batch_id IS NOT DISTINCT FROM row.stock_batch_id;
+
+COMMENT ON VIEW public.v_stock_availability_225 IS
+  'Issue #225 authoritative physical, reserved, depreciated, quarantine, blocked and available stock by level/batch.';
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT, INSERT ON public.stock_command_receipts TO cerp_app;
+    GRANT SELECT, INSERT ON public.stock_reservation_event_log TO cerp_app;
+    GRANT SELECT, INSERT ON public.stock_lot_event_log TO cerp_app;
+    GRANT SELECT, INSERT ON public.stock_lot_genealogy_edges TO cerp_app;
+    GRANT SELECT, INSERT ON public.stock_inventory_snapshot_lines TO cerp_app;
+    GRANT SELECT, INSERT ON public.stock_inventory_count_events TO cerp_app;
+    GRANT SELECT ON public.v_stock_availability_225 TO cerp_app;
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/support/20260723_stock_traceability_225.preflight.sql
+++ b/db/patches/support/20260723_stock_traceability_225.preflight.sql
@@ -1,0 +1,200 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#225 preflight is restricted to cerp_test, got %', current_database();
+  END IF;
+END $$;
+
+SELECT current_database() AS database_name, current_user AS database_user, now() AS checked_at;
+
+SELECT prerequisite, present
+FROM (
+  VALUES
+    ('articles', to_regclass('public.articles') IS NOT NULL),
+    ('users', to_regclass('public.users') IS NOT NULL),
+    ('units', to_regclass('public.units') IS NOT NULL),
+    ('warehouses', to_regclass('public.warehouses') IS NOT NULL),
+    ('locations', to_regclass('public.locations') IS NOT NULL),
+    ('magasins', to_regclass('public.magasins') IS NOT NULL),
+    ('emplacements', to_regclass('public.emplacements') IS NOT NULL),
+    ('lots', to_regclass('public.lots') IS NOT NULL),
+    ('stock_levels', to_regclass('public.stock_levels') IS NOT NULL),
+    ('stock_batches', to_regclass('public.stock_batches') IS NOT NULL),
+    ('stock_movements', to_regclass('public.stock_movements') IS NOT NULL),
+    ('stock_movement_lines', to_regclass('public.stock_movement_lines') IS NOT NULL),
+    ('stock_movement_event_log', to_regclass('public.stock_movement_event_log') IS NOT NULL),
+    ('stock_reservations', to_regclass('public.stock_reservations') IS NOT NULL),
+    ('stock_inventory_sessions', to_regclass('public.stock_inventory_sessions') IS NOT NULL),
+    ('stock_inventory_lines', to_regclass('public.stock_inventory_lines') IS NOT NULL),
+    ('stock_inventory_session_movements', to_regclass('public.stock_inventory_session_movements') IS NOT NULL),
+    ('commande_ligne', to_regclass('public.commande_ligne') IS NOT NULL),
+    ('ordres_fabrication', to_regclass('public.ordres_fabrication') IS NOT NULL),
+    ('bon_livraison_ligne', to_regclass('public.bon_livraison_ligne') IS NOT NULL),
+    ('affaire', to_regclass('public.affaire') IS NOT NULL)
+) AS checks(prerequisite, present)
+ORDER BY prerequisite;
+
+SELECT column_name, data_type
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND (
+    (table_name = 'stock_movements' AND column_name IN (
+      'id',
+      'movement_type',
+      'status',
+      'article_id',
+      'stock_level_id',
+      'stock_batch_id',
+      'qty',
+      'user_id'
+    ))
+    OR (table_name = 'stock_movement_lines' AND column_name IN ('id', 'movement_id'))
+    OR (table_name = 'stock_movement_event_log' AND column_name IN ('id', 'movement_id', 'event_type'))
+    OR (table_name = 'stock_levels' AND column_name IN ('id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
+    OR (table_name = 'stock_batches' AND column_name IN ('id', 'lot_id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
+    OR (table_name = 'stock_inventory_sessions' AND column_name IN ('id', 'status', 'started_at'))
+    OR (table_name = 'stock_inventory_lines' AND column_name IN (
+      'id',
+      'session_id',
+      'article_id',
+      'magasin_id',
+      'emplacement_id',
+      'lot_id'
+    ))
+    OR (table_name = 'stock_inventory_session_movements' AND column_name IN (
+      'session_id',
+      'stock_movement_id'
+    ))
+    OR (table_name = 'stock_reservations' AND column_name IN ('lot_id', 'stock_batch_id'))
+  )
+ORDER BY table_name, ordinal_position;
+
+DO $$
+DECLARE
+  required_columns_count integer;
+BEGIN
+  SELECT count(*)::integer
+  INTO required_columns_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND (
+      (table_name = 'stock_movements' AND column_name IN (
+        'id',
+        'movement_type',
+        'status',
+        'article_id',
+        'stock_level_id',
+        'stock_batch_id',
+        'qty',
+        'user_id'
+      ))
+      OR (table_name = 'stock_movement_lines' AND column_name IN ('id', 'movement_id'))
+      OR (table_name = 'stock_movement_event_log' AND column_name IN ('id', 'movement_id', 'event_type'))
+      OR (table_name = 'stock_levels' AND column_name IN ('id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
+      OR (table_name = 'stock_batches' AND column_name IN ('id', 'lot_id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
+      OR (table_name = 'stock_inventory_sessions' AND column_name IN ('id', 'status', 'started_at'))
+      OR (table_name = 'stock_inventory_lines' AND column_name IN (
+        'id',
+        'session_id',
+        'article_id',
+        'magasin_id',
+        'emplacement_id',
+        'lot_id'
+      ))
+      OR (table_name = 'stock_inventory_session_movements' AND column_name IN (
+        'session_id',
+        'stock_movement_id'
+      ))
+      OR (table_name = 'stock_reservations' AND column_name IN ('lot_id', 'stock_batch_id'))
+    );
+
+  IF required_columns_count <> 35 THEN
+    RAISE EXCEPTION '#225 preflight found %/35 required stock columns', required_columns_count;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'stock_movements'
+      AND column_name = 'id'
+      AND data_type = 'uuid'
+  ) THEN
+    RAISE EXCEPTION '#225 requires the canonical UUID stock movement spine';
+  END IF;
+END $$;
+
+SELECT status, count(*) AS rows_count
+FROM public.stock_reservations
+GROUP BY status
+ORDER BY status;
+
+SELECT status::text, count(*) AS rows_count
+FROM public.stock_movements
+GROUP BY status
+ORDER BY status;
+
+SELECT
+  source_type,
+  source_id,
+  article_id,
+  location_id,
+  lot_id,
+  count(*) AS active_duplicates
+FROM public.stock_reservations
+WHERE status = 'ACTIVE'
+GROUP BY source_type, source_id, article_id, location_id, lot_id
+HAVING count(*) > 1
+ORDER BY active_duplicates DESC, source_type, source_id;
+
+SELECT
+  count(*) FILTER (WHERE qty_total < 0) AS negative_total_levels,
+  count(*) FILTER (WHERE qty_reserved < 0) AS negative_reserved_levels,
+  count(*) FILTER (WHERE qty_depreciated < 0) AS negative_depreciated_levels,
+  count(*) FILTER (WHERE qty_reserved + qty_depreciated > qty_total) AS overcommitted_levels
+FROM public.stock_levels;
+
+SELECT
+  count(*) FILTER (WHERE qty_total < 0) AS negative_total_batches,
+  count(*) FILTER (WHERE qty_reserved < 0) AS negative_reserved_batches,
+  count(*) FILTER (WHERE qty_depreciated < 0) AS negative_depreciated_batches,
+  count(*) FILTER (WHERE qty_reserved + qty_depreciated > qty_total) AS overcommitted_batches
+FROM public.stock_batches;
+
+SELECT
+  count(*) FILTER (WHERE lot_id IS NULL) AS reservations_without_lot,
+  count(*) FILTER (WHERE stock_batch_id IS NULL) AS reservations_without_batch,
+  count(*) FILTER (
+    WHERE lot_id IS NOT NULL AND stock_batch_id IS NULL
+  ) AS lot_reservations_without_batch
+FROM public.stock_reservations;
+
+SELECT
+  count(*) FILTER (
+    WHERE reservation.source_type = 'COMMANDE_LIGNE'
+      AND reservation.source_id !~ '^[0-9]+$'
+  ) AS invalid_commande_ligne_source_ids,
+  count(*) FILTER (
+    WHERE reservation.source_type = 'COMMANDE_LIGNE'
+      AND reservation.source_id ~ '^[0-9]+$'
+      AND NOT EXISTS (
+        SELECT 1
+        FROM public.commande_ligne
+        WHERE id = CASE
+          WHEN reservation.source_id ~ '^[0-9]+$'
+            THEN reservation.source_id::bigint
+          ELSE NULL
+        END
+      )
+  ) AS missing_commande_ligne_sources,
+  count(*) FILTER (
+    WHERE reservation.source_type NOT IN (
+      'COMMANDE_LIGNE',
+      'OF',
+      'BON_LIVRAISON_LIGNE',
+      'AFFAIRE'
+    )
+  ) AS legacy_source_types_to_review
+FROM public.stock_reservations reservation;

--- a/db/patches/support/20260723_stock_traceability_225.rollback.sql
+++ b/db/patches/support/20260723_stock_traceability_225.rollback.sql
@@ -1,0 +1,163 @@
+\set ON_ERROR_STOP on
+
+-- Guarded compensation for an empty #225 installation only.
+-- Never run after any #225 command, reservation event, lot event, genealogy
+-- edge, inventory snapshot or inventory count has been recorded.
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#225 rollback is restricted to cerp_test';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.stock_command_receipts)
+     OR EXISTS (SELECT 1 FROM public.stock_reservation_event_log)
+     OR EXISTS (SELECT 1 FROM public.stock_lot_event_log)
+     OR EXISTS (SELECT 1 FROM public.stock_lot_genealogy_edges)
+     OR EXISTS (SELECT 1 FROM public.stock_inventory_snapshot_lines)
+     OR EXISTS (SELECT 1 FROM public.stock_inventory_count_events)
+     OR EXISTS (
+       SELECT 1
+       FROM public.stock_movements
+       WHERE correlation_id IS NOT NULL OR reversal_of_id IS NOT NULL
+     )
+     OR EXISTS (
+       SELECT 1
+       FROM public.stock_inventory_sessions
+       WHERE status NOT IN ('OPEN', 'CLOSED')
+          OR started_at IS NULL
+          OR scope_magasin_id IS NOT NULL
+          OR scope_emplacement_id IS NOT NULL
+          OR scope_article_id IS NOT NULL
+          OR scope_article_category IS NOT NULL
+          OR blind_count
+          OR requires_second_count
+          OR snapshot_at IS NOT NULL
+          OR approved_at IS NOT NULL
+          OR cancelled_at IS NOT NULL
+          OR correlation_id IS NOT NULL
+          OR row_version <> 1
+     ) THEN
+    RAISE EXCEPTION '#225 rollback refused: immutable stock evidence exists';
+  END IF;
+END $$;
+
+DROP VIEW IF EXISTS public.v_stock_availability_225;
+
+DROP INDEX IF EXISTS public.stock_inventory_count_line_idx;
+DROP INDEX IF EXISTS public.stock_inventory_count_session_idx;
+DROP INDEX IF EXISTS public.stock_inventory_snapshot_with_lot_uq;
+DROP INDEX IF EXISTS public.stock_inventory_snapshot_no_lot_uq;
+DROP INDEX IF EXISTS public.stock_inventory_snapshot_line_no_uq;
+DROP INDEX IF EXISTS public.stock_lot_genealogy_child_idx;
+DROP INDEX IF EXISTS public.stock_lot_genealogy_parent_idx;
+DROP INDEX IF EXISTS public.stock_lot_genealogy_edge_uq;
+DROP INDEX IF EXISTS public.stock_lot_event_correlation_idx;
+DROP INDEX IF EXISTS public.stock_lot_event_lot_idx;
+DROP INDEX IF EXISTS public.stock_reservation_event_correlation_idx;
+DROP INDEX IF EXISTS public.stock_reservation_event_reservation_idx;
+DROP INDEX IF EXISTS public.stock_reservations_correlation_idx;
+DROP INDEX IF EXISTS public.stock_reservations_expiry_idx;
+DROP INDEX IF EXISTS public.stock_command_receipts_correlation_idx;
+DROP INDEX IF EXISTS public.stock_command_receipts_resource_idx;
+DROP INDEX IF EXISTS public.stock_movements_correlation_idx;
+DROP INDEX IF EXISTS public.stock_movements_reversal_once_uq;
+DROP INDEX IF EXISTS public.emplacements_location_type_idx;
+
+DROP TRIGGER IF EXISTS trg_protect_stock_inventory_count ON public.stock_inventory_count_events;
+DROP TRIGGER IF EXISTS trg_protect_stock_inventory_snapshot ON public.stock_inventory_snapshot_lines;
+DROP TRIGGER IF EXISTS trg_protect_stock_inventory_session_movement ON public.stock_inventory_session_movements;
+DROP TRIGGER IF EXISTS trg_protect_stock_inventory_line ON public.stock_inventory_lines;
+DROP TRIGGER IF EXISTS trg_protect_stock_inventory_session ON public.stock_inventory_sessions;
+DROP TRIGGER IF EXISTS trg_protect_stock_lot_genealogy ON public.stock_lot_genealogy_edges;
+DROP TRIGGER IF EXISTS trg_protect_stock_lot_event ON public.stock_lot_event_log;
+DROP TRIGGER IF EXISTS trg_protect_stock_reservation_event ON public.stock_reservation_event_log;
+DROP TRIGGER IF EXISTS trg_log_stock_reservation_event ON public.stock_reservations;
+DROP TRIGGER IF EXISTS trg_prepare_stock_reservation ON public.stock_reservations;
+DROP TRIGGER IF EXISTS trg_protect_stock_command_receipt ON public.stock_command_receipts;
+DROP TRIGGER IF EXISTS trg_protect_stock_movement_event ON public.stock_movement_event_log;
+DROP TRIGGER IF EXISTS trg_protect_posted_stock_movement_line ON public.stock_movement_lines;
+DROP TRIGGER IF EXISTS trg_protect_posted_stock_movement ON public.stock_movements;
+
+DROP TABLE IF EXISTS public.stock_inventory_count_events;
+DROP TABLE IF EXISTS public.stock_inventory_snapshot_lines;
+DROP TABLE IF EXISTS public.stock_lot_genealogy_edges;
+DROP TABLE IF EXISTS public.stock_lot_event_log;
+DROP TABLE IF EXISTS public.stock_reservation_event_log;
+DROP TABLE IF EXISTS public.stock_command_receipts;
+
+DROP FUNCTION IF EXISTS public.fn_protect_posted_stock_movement_line();
+DROP FUNCTION IF EXISTS public.fn_protect_posted_stock_movement();
+DROP FUNCTION IF EXISTS public.fn_protect_stock_inventory_line();
+DROP FUNCTION IF EXISTS public.fn_protect_stock_inventory_session();
+DROP FUNCTION IF EXISTS public.fn_log_stock_reservation_event();
+DROP FUNCTION IF EXISTS public.fn_prepare_stock_reservation();
+DROP FUNCTION IF EXISTS public.fn_protect_stock_immutable_evidence();
+
+ALTER TABLE public.stock_inventory_sessions
+  DROP CONSTRAINT IF EXISTS stock_inventory_sessions_scope_magasin_fkey,
+  DROP CONSTRAINT IF EXISTS stock_inventory_sessions_scope_emplacement_fkey,
+  DROP CONSTRAINT IF EXISTS stock_inventory_sessions_scope_article_fkey,
+  DROP CONSTRAINT IF EXISTS stock_inventory_sessions_approved_by_fkey,
+  DROP CONSTRAINT IF EXISTS stock_inventory_sessions_cancelled_by_fkey,
+  DROP CONSTRAINT IF EXISTS stock_inventory_sessions_status_check,
+  DROP COLUMN IF EXISTS scope_magasin_id,
+  DROP COLUMN IF EXISTS scope_emplacement_id,
+  DROP COLUMN IF EXISTS scope_article_id,
+  DROP COLUMN IF EXISTS scope_article_category,
+  DROP COLUMN IF EXISTS blind_count,
+  DROP COLUMN IF EXISTS requires_second_count,
+  DROP COLUMN IF EXISTS snapshot_at,
+  DROP COLUMN IF EXISTS approved_at,
+  DROP COLUMN IF EXISTS approved_by,
+  DROP COLUMN IF EXISTS cancelled_at,
+  DROP COLUMN IF EXISTS cancelled_by,
+  DROP COLUMN IF EXISTS cancellation_reason,
+  DROP COLUMN IF EXISTS row_version,
+  DROP COLUMN IF EXISTS correlation_id,
+  ALTER COLUMN started_at SET DEFAULT now(),
+  ALTER COLUMN started_at SET NOT NULL;
+
+ALTER TABLE public.stock_inventory_sessions
+  ADD CONSTRAINT stock_inventory_sessions_status_check
+  CHECK (status IN ('OPEN', 'CLOSED'));
+
+ALTER TABLE public.stock_reservations
+  DROP CONSTRAINT IF EXISTS stock_reservations_consumed_movement_fkey,
+  DROP CONSTRAINT IF EXISTS stock_reservations_commande_ligne_fkey,
+  DROP CONSTRAINT IF EXISTS stock_reservations_of_fkey,
+  DROP CONSTRAINT IF EXISTS stock_reservations_bon_livraison_ligne_fkey,
+  DROP CONSTRAINT IF EXISTS stock_reservations_affaire_fkey,
+  DROP CONSTRAINT IF EXISTS stock_reservations_released_by_fkey,
+  DROP CONSTRAINT IF EXISTS stock_reservations_consumed_by_fkey,
+  DROP CONSTRAINT IF EXISTS stock_reservations_status_225_ck,
+  DROP COLUMN IF EXISTS correlation_id,
+  DROP COLUMN IF EXISTS commande_ligne_id,
+  DROP COLUMN IF EXISTS of_id,
+  DROP COLUMN IF EXISTS bon_livraison_ligne_id,
+  DROP COLUMN IF EXISTS affaire_id,
+  DROP COLUMN IF EXISTS reason,
+  DROP COLUMN IF EXISTS expires_at,
+  DROP COLUMN IF EXISTS released_at,
+  DROP COLUMN IF EXISTS released_by,
+  DROP COLUMN IF EXISTS consumed_at,
+  DROP COLUMN IF EXISTS consumed_by,
+  DROP COLUMN IF EXISTS consumed_stock_movement_id,
+  DROP COLUMN IF EXISTS row_version;
+
+ALTER TABLE public.stock_movements
+  DROP CONSTRAINT IF EXISTS stock_movements_reversal_of_id_fkey,
+  DROP CONSTRAINT IF EXISTS stock_movements_not_self_reversal_ck,
+  DROP COLUMN IF EXISTS correlation_id,
+  DROP COLUMN IF EXISTS reversal_of_id;
+
+ALTER TABLE public.emplacements
+  DROP CONSTRAINT IF EXISTS emplacements_location_type_ck,
+  DROP CONSTRAINT IF EXISTS emplacements_restrictions_object_ck,
+  DROP COLUMN IF EXISTS location_type,
+  DROP COLUMN IF EXISTS allow_inbound,
+  DROP COLUMN IF EXISTS allow_outbound,
+  DROP COLUMN IF EXISTS restrictions;
+
+COMMIT;

--- a/db/patches/support/20260723_stock_traceability_225.verify.sql
+++ b/db/patches/support/20260723_stock_traceability_225.verify.sql
@@ -1,0 +1,98 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#225 verification is restricted to cerp_test, got %', current_database();
+  END IF;
+
+  IF to_regclass('public.stock_command_receipts') IS NULL
+     OR to_regclass('public.stock_reservation_event_log') IS NULL
+     OR to_regclass('public.stock_lot_event_log') IS NULL
+     OR to_regclass('public.stock_lot_genealogy_edges') IS NULL
+     OR to_regclass('public.stock_inventory_snapshot_lines') IS NULL
+     OR to_regclass('public.stock_inventory_count_events') IS NULL
+     OR to_regclass('public.v_stock_availability_225') IS NULL THEN
+    RAISE EXCEPTION '#225 ledger, history, inventory snapshot or availability objects are missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'stock_command_receipts_actor_key_uq'
+      AND conrelid = 'public.stock_command_receipts'::regclass
+  ) THEN
+    RAISE EXCEPTION '#225 actor/idempotency uniqueness is missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_protect_posted_stock_movement'
+      AND tgrelid = 'public.stock_movements'::regclass
+      AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION '#225 posted movement immutability trigger is missing';
+  END IF;
+END $$;
+
+SELECT
+  (SELECT count(*) FROM public.v_stock_availability_225 WHERE qty_available < 0) AS negative_available_rows,
+  (SELECT count(*) FROM public.v_stock_availability_225 WHERE qty_quarantine < 0) AS negative_quarantine_rows,
+  (SELECT count(*) FROM public.v_stock_availability_225 WHERE qty_blocked < 0) AS negative_blocked_rows,
+  (
+    SELECT count(*)
+    FROM public.v_stock_availability_225
+    WHERE lot_status IN ('EN_ATTENTE', 'QUARANTAINE', 'BLOQUE')
+      AND qty_available <> 0
+  ) AS nonreleased_available_rows,
+  (
+    SELECT count(*)
+    FROM public.stock_inventory_sessions
+    WHERE status = 'CLOSED'
+      AND snapshot_at IS NULL
+  ) AS legacy_closed_without_snapshot,
+  (
+    SELECT count(*)
+    FROM public.stock_inventory_sessions
+    WHERE status = 'DRAFT'
+      AND started_at IS NOT NULL
+  ) AS draft_sessions_started_too_early,
+  (
+    SELECT count(*)
+    FROM public.stock_inventory_sessions
+    WHERE status IN ('OPEN', 'APPROVED', 'CLOSED')
+      AND started_at IS NULL
+  ) AS active_sessions_without_start;
+
+SELECT
+  trigger_name,
+  event_manipulation,
+  event_object_table
+FROM information_schema.triggers
+WHERE trigger_schema = 'public'
+  AND trigger_name IN (
+    'trg_protect_stock_command_receipt',
+    'trg_protect_posted_stock_movement',
+    'trg_protect_posted_stock_movement_line',
+    'trg_protect_stock_movement_event',
+    'trg_protect_stock_reservation_event',
+    'trg_protect_stock_lot_event',
+    'trg_protect_stock_lot_genealogy',
+    'trg_protect_stock_inventory_session',
+    'trg_protect_stock_inventory_line',
+    'trg_protect_stock_inventory_session_movement',
+    'trg_protect_stock_inventory_snapshot',
+    'trg_protect_stock_inventory_count',
+    'trg_prepare_stock_reservation',
+    'trg_log_stock_reservation_event'
+  )
+ORDER BY event_object_table, trigger_name, event_manipulation;
+
+SELECT
+  CASE WHEN EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app')
+    THEN has_table_privilege('cerp_app', 'public.stock_command_receipts', 'SELECT,INSERT')
+    ELSE NULL
+  END AS cerp_app_command_receipt_access,
+  CASE WHEN EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app')
+    THEN has_table_privilege('cerp_app', 'public.v_stock_availability_225', 'SELECT')
+    ELSE NULL
+  END AS cerp_app_availability_access;

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -116,3 +116,24 @@ backed up to `cerp_prod_pre_223_20260723_145750.backup` (SHA-256
 `9a037c37563e1bbc57fa34b7e8c3fd2aaa1cca09e0b994628e5f0d4e9ab83dc1`),
 then the patch was applied, verified and recorded in
 `public.cerp_schema_migrations`.
+
+## Issue #225 - Stock, lots, mouvements, magasins et inventaires
+
+Patch `20260723_stock_traceability_225.sql` extends the existing stock ledger
+with actor-scoped immutable command receipts, correlated reversals/transfers,
+quality-aware availability, source-backed reservations, lot genealogy and
+versioned inventory snapshots/count events. Posted and cancelled industrial
+evidence cannot be rewritten.
+
+Run `20260723_stock_traceability_225.preflight.sql` before applying the patch
+and `20260723_stock_traceability_225.verify.sql` afterwards. The #225 support
+scripts are restricted to `cerp_test`; the guarded rollback refuses to drop
+structures once #225 evidence exists. Patch application itself remains under
+the migration runner, backup policy and explicit human environment gate. The
+preflight also checks the cross-module users, units, warehouses, locations,
+orders, OF, BL, affairs, lot and batch prerequisites inherited from the active
+schema.
+
+No `DATABASE_URL` for `cerp_test` was configured in the #225 workspace on
+2026-07-23, so the patch was not applied or registered on any database.
+`cerp_prod` was not modified.

--- a/docs/http/stock-traceability-225.md
+++ b/docs/http/stock-traceability-225.md
@@ -1,0 +1,87 @@
+# API stock et traçabilité — issue #225
+
+Base : `/api/v1/stock`. Toutes les routes sont authentifiées et protégées par
+une capacité stock. Les commandes mutantes indiquées ci-dessous exigent
+`Idempotency-Key: <8..200 caractères>`.
+
+## Mouvements
+
+| Méthode et route | Effet |
+|---|---|
+| `GET /analytics` | cockpit autoritaire, `as_of` et périmètre |
+| `GET /balances` | disponibilité par article/emplacement/lot |
+| `GET /movements` | liste des mouvements |
+| `POST /movements/preview` | impact sans écriture |
+| `POST /movements` | crée un brouillon idempotent |
+| `GET /movements/:id` | détail et corrélations |
+| `POST /movements/:id/post` | comptabilise après revalidation |
+| `POST /movements/:id/cancel` | annule en conservant la preuve |
+| `POST /movements/:id/compensation-preview` | aperçu inverse |
+| `POST /movements/:id/compensate` | crée le brouillon compensatoire |
+
+Les sources production, réception fournisseur et sortie BL sont refusées sur
+la commande générique. Les modules propriétaires utilisent le service interne
+de confiance.
+
+### Dérogation négative
+
+`POST /movements/:id/post` accepte une dérogation uniquement avec la capacité
+`negative_stock_override` :
+
+```json
+{
+  "negative_stock_override": {
+    "reason": "Motif industriel contrôlé",
+    "max_negative_quantity": 5
+  }
+}
+```
+
+Elle reste refusée pour le stock réservé, déprécié, en quarantaine ou bloqué.
+
+## Réservations
+
+| Méthode et route | Effet |
+|---|---|
+| `GET /reservations` | liste filtrable |
+| `POST /reservations` | crée une réservation active |
+| `GET /reservations/:id` | détail |
+| `POST /reservations/:id/release` | libère avec version attendue |
+| `POST /reservations/:id/consume` | consomme avec mouvement `OUT` posté |
+
+Les types de source autorisés sont `COMMANDE_LIGNE`, `OF`,
+`BON_LIVRAISON_LIGNE` et `AFFAIRE`.
+
+## Lots
+
+| Méthode et route | Effet |
+|---|---|
+| `GET /lots` | liste avec état qualité |
+| `POST /lots` | crée un lot |
+| `GET /lots/:id` | détail |
+| `POST /lots/:id/quality-status` | décision qualité auditée |
+| `POST /lots/genealogy` | lien parent/enfant |
+| `GET /lots/:id/genealogy` | ascendants, descendants et mouvements |
+
+## Inventaires
+
+| Méthode et route | Effet |
+|---|---|
+| `POST /inventory-sessions` | crée une session `DRAFT` |
+| `POST /inventory-sessions/:id/start` | fige le snapshot et ouvre |
+| `GET /inventory-sessions/:id/lines` | lignes gelées |
+| `PUT /inventory-sessions/:id/lines` | ajoute une version de comptage |
+| `POST /inventory-sessions/:id/approve` | contrôle et approuve |
+| `POST /inventory-sessions/:id/cancel` | annule sans effacer |
+| `POST /inventory-sessions/:id/close` | crée les ajustements et clôture |
+
+Les retours de conflit utilisent `409`. Les incohérences métier utilisent
+`422` lorsque la requête est valide mais impossible à exécuter. Aucun client
+ne doit recalculer un solde autoritaire.
+
+## Migration
+
+Le contrat nécessite `20260723_stock_traceability_225.sql`. Exécuter le
+préflight et la vérification sur `cerp_test` seulement. Au 2026-07-23, ces
+scripts n'ont pas été exécutés : aucune connexion test n'était configurée et
+aucune base de production n'a été touchée.

--- a/src/__tests__/stock-traceability-225.migration-guards.test.ts
+++ b/src/__tests__/stock-traceability-225.migration-guards.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const patch = readFileSync(
+  resolve(root, "db/patches/20260723_stock_traceability_225.sql"),
+  "utf8"
+);
+const preflight = readFileSync(
+  resolve(root, "db/patches/support/20260723_stock_traceability_225.preflight.sql"),
+  "utf8"
+);
+const verify = readFileSync(
+  resolve(root, "db/patches/support/20260723_stock_traceability_225.verify.sql"),
+  "utf8"
+);
+const rollback = readFileSync(
+  resolve(root, "db/patches/support/20260723_stock_traceability_225.rollback.sql"),
+  "utf8"
+);
+
+describe("#225 migration guards", () => {
+  it("keeps the forward patch additive and transactional", () => {
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("COMMIT;");
+    expect(patch).not.toMatch(/\bDROP\s+TABLE\b/i);
+    expect(patch).not.toMatch(/\bDELETE\s+FROM\b/i);
+  });
+
+  it("protects posted movements and append-only evidence", () => {
+    expect(patch).toContain("trg_protect_posted_stock_movement");
+    expect(patch).toContain("trg_protect_posted_stock_movement_line");
+    expect(patch).toContain("trg_protect_stock_command_receipt");
+    expect(patch).toContain("trg_protect_stock_inventory_count");
+    expect(patch).toContain("stock audit evidence is immutable");
+  });
+
+  it("separates draft creation time from inventory start time", () => {
+    expect(patch).toContain("ALTER COLUMN started_at DROP NOT NULL");
+    expect(patch).toContain("ALTER COLUMN started_at DROP DEFAULT");
+    expect(patch).not.toContain(
+      "CONSTRAINT stock_inventory_snapshot_qty_ck CHECK (theoretical_qty >= 0)"
+    );
+    expect(verify).toContain("draft_sessions_started_too_early");
+    expect(verify).toContain("active_sessions_without_start");
+  });
+
+  it("keeps quality-aware availability explicit", () => {
+    expect(patch).toContain("CREATE OR REPLACE VIEW public.v_stock_availability_225");
+    expect(patch).toContain("qty_quarantine");
+    expect(patch).toContain("qty_blocked");
+    expect(patch).toContain("qty_available");
+    expect(patch).toContain("row.lot_status IS NULL OR row.lot_status = 'LIBERE'");
+  });
+
+  it("restricts support scripts and refuses a lossy rollback", () => {
+    for (const script of [preflight, verify, rollback]) {
+      expect(script).toContain("current_database() <> 'cerp_test'");
+    }
+    expect(preflight).toContain("required stock columns");
+    expect(rollback).toContain(
+      "#225 rollback refused: immutable stock evidence exists"
+    );
+    expect(rollback).toContain("DROP COLUMN IF EXISTS reversal_of_id");
+    expect(rollback).toContain("ALTER COLUMN started_at SET NOT NULL");
+  });
+});

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -67,6 +67,16 @@ describe("/api/v1/stock", () => {
   it("GET /api/v1/stock/analytics returns analytics payload", async () => {
     mocks.poolQuery
       .mockResolvedValueOnce({ rows: [{ articles_count: 12, stock_managed_articles: 9, qty_on_hand: 120, qty_available: 100, qty_reserved: 20 }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          ruptures_count: 2,
+          below_minimum_count: 3,
+          at_risk_reservations_count: 1,
+          quarantine_lots_count: 1,
+          active_inventory_count: 1,
+          discrepancies_to_review_count: 4,
+        }],
+      })
       .mockResolvedValueOnce({ rows: [{ id: "mag-1", code: "MAT", name: "Matières" }] })
       .mockResolvedValueOnce({ rows: [{ article_category: "matiere", articles_count: 5, stock_managed_count: 5 }] })
       .mockResolvedValueOnce({ rows: [{ date: "2026-03-13", qty_in: 10, qty_out: 3, net_qty: 7 }] })
@@ -78,7 +88,13 @@ describe("/api/v1/stock", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({
-      kpis: { articles_count: 12, stock_managed_articles: 9 },
+      authoritative: true,
+      kpis: {
+        articles_count: 12,
+        stock_managed_articles: 9,
+        ruptures_count: 2,
+        discrepancies_to_review_count: 4,
+      },
       magasins: [{ code: "MAT" }],
       category_counts: [{ article_category: "matiere" }],
     });
@@ -295,6 +311,7 @@ describe("/api/v1/stock", () => {
     const res = await request(app)
       .post("/api/v1/stock/movements")
       .set("Authorization", "Bearer fake")
+      .set("Idempotency-Key", "test-lot-required-movement-001")
       .send({
         movement_type: "IN",
         lines: [

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -3579,10 +3579,11 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
               qty_reserved,
               source_type,
               source_id,
+              commande_ligne_id,
               status,
               created_by,
               updated_by
-            ) VALUES ($1::uuid,$2::uuid,$3,'COMMANDE_LIGNE',$4,'ACTIVE',$5,$5)
+            ) VALUES ($1::uuid,$2::uuid,$3,'COMMANDE_LIGNE',$4,$4::bigint,'ACTIVE',$5,$5)
             RETURNING id::text AS id
           `,
           [articleId, stockLocationId, it.qty, String(it.line.commande_ligne_id), audit.user_id]

--- a/src/module/production/repository/production-receipts.repository.ts
+++ b/src/module/production/repository/production-receipts.repository.ts
@@ -300,11 +300,12 @@ async function reserveProducedQtyForCommandeLine(
       `
         UPDATE public.stock_reservations
         SET qty_reserved = qty_reserved + $2,
+            commande_ligne_id = COALESCE(commande_ligne_id, $4::bigint),
             updated_at = now(),
             updated_by = $3
         WHERE id = $1::uuid
       `,
-      [existingId, qtyToReserve, args.actor_user_id]
+      [existingId, qtyToReserve, args.actor_user_id, args.commande_ligne_id]
     );
     return { reservation_id: existingId, qty_reserved: qtyToReserve };
   }
@@ -317,12 +318,13 @@ async function reserveProducedQtyForCommandeLine(
         qty_reserved,
         source_type,
         source_id,
+        commande_ligne_id,
         status,
         lot_id,
         stock_batch_id,
         created_by,
         updated_by
-      ) VALUES ($1::uuid,$2::uuid,$3,'COMMANDE_LIGNE',$4,'ACTIVE',$5::uuid,$6::uuid,$7,$7)
+      ) VALUES ($1::uuid,$2::uuid,$3,'COMMANDE_LIGNE',$4,$4::bigint,'ACTIVE',$5::uuid,$6::uuid,$7,$7)
       RETURNING id::text AS id
     `,
     [

--- a/src/module/receptions/controllers/receptions.controller.ts
+++ b/src/module/receptions/controllers/receptions.controller.ts
@@ -71,6 +71,18 @@ function getUserRef(req: Request): { id: number; name: string } {
   return { id: user.id, name }
 }
 
+function getRequiredIdempotencyKey(req: Request): string {
+  const value = req.headers["idempotency-key"]
+  if (typeof value !== "string" || value.trim().length < 8 || value.trim().length > 200) {
+    throw new HttpError(
+      400,
+      "IDEMPOTENCY_KEY_REQUIRED",
+      "A valid Idempotency-Key header is required (8 to 200 characters)."
+    )
+  }
+  return value.trim()
+}
+
 function emitReceptionChanged(
   req: Request,
   params: { receptionId: string; action: "created" | "updated" | "deleted" | "status_changed" }
@@ -327,7 +339,7 @@ export const createReceptionStockReceipt: RequestHandler = async (req, res, next
     const audit = buildAuditContext(req)
     const { id, lineId } = lineIdParamSchema.parse({ params: req.params }).params
     const body = stockReceiptSchema.parse({ body: req.body }).body
-    const out = await createReceptionStockReceiptSVC(id, lineId, body, audit)
+    const out = await createReceptionStockReceiptSVC(id, lineId, body, audit, getRequiredIdempotencyKey(req))
     if (!out) {
       res.status(404).json({ error: "Not found" })
       return

--- a/src/module/receptions/repository/receptions.repository.ts
+++ b/src/module/receptions/repository/receptions.repository.ts
@@ -13,6 +13,7 @@ import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-lo
 import { roleHasCommandeFournisseurCapability } from "../../commande-fournisseur/domain/commande-fournisseur-rbac"
 import { repoRefreshCommandeReceptionState } from "../../commande-fournisseur/repository/commande-fournisseur.repository"
 import { repoCreateMovement, repoPostMovement } from "../../stock/repository/stock.repository"
+import { hashStockCommand } from "../../stock/domain/stock-command"
 import type { StockMovementDetail } from "../../stock/types/stock.types"
 import type {
   AddMeasurementBodyDTO,
@@ -1684,7 +1685,8 @@ export async function repoCreateStockReceipt(
   receptionId: string,
   lineId: string,
   body: StockReceiptBodyDTO,
-  audit: AuditContext
+  audit: AuditContext,
+  idempotencyKey: string
 ): Promise<{ stock_movement_id: string; movement_no: string | null; posted: StockMovementDetail } | null> {
   const lineRes = await db.query<{
     id: string
@@ -1727,6 +1729,10 @@ export async function repoCreateStockReceipt(
     throw new HttpError(409, "OVER_RECEIPT", "Quantite superieure a la quantite restante a mettre en stock")
   }
 
+  const stockCommandKey = hashStockCommand("RECEPTION_STOCK_KEY", {
+    actor_user_id: audit.user_id,
+    idempotency_key: idempotencyKey,
+  })
   const created = await repoCreateMovement(
     {
       movement_type: "IN",
@@ -1735,7 +1741,7 @@ export async function repoCreateStockReceipt(
       source_document_id: receptionId,
       reason_code: "RECEPTION_FOURNISSEUR",
       notes: body.notes ?? `Reception ${line.reception_no}`,
-      idempotency_key: null,
+      idempotency_key: `rf-create-${stockCommandKey}`,
       lines: [
         {
           article_id: line.article_id,
@@ -1752,10 +1758,16 @@ export async function repoCreateStockReceipt(
         },
       ],
     },
-    audit
+    audit,
+    { trusted_source_flow: true }
   )
 
-  const posted = await repoPostMovement(created.movement.id, audit)
+  const posted = await repoPostMovement(
+    created.movement.id,
+    {},
+    audit,
+    `rf-post-${stockCommandKey}`
+  )
   if (!posted) throw new Error("Failed to post stock movement")
 
   await db.query(

--- a/src/module/receptions/services/receptions.service.ts
+++ b/src/module/receptions/services/receptions.service.ts
@@ -48,5 +48,10 @@ export const addIncomingMeasurementSVC = (receptionId: string, lineId: string, b
 export const decideIncomingInspectionSVC = (receptionId: string, lineId: string, body: DecideInspectionBodyDTO, audit: AuditContext) =>
   repo.repoDecideInspection(receptionId, lineId, body, audit)
 
-export const createReceptionStockReceiptSVC = (receptionId: string, lineId: string, body: StockReceiptBodyDTO, audit: AuditContext) =>
-  repo.repoCreateStockReceipt(receptionId, lineId, body, audit)
+export const createReceptionStockReceiptSVC = (
+  receptionId: string,
+  lineId: string,
+  body: StockReceiptBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+) => repo.repoCreateStockReceipt(receptionId, lineId, body, audit, idempotencyKey)

--- a/src/module/stock/controllers/stock-reservation.controller.ts
+++ b/src/module/stock/controllers/stock-reservation.controller.ts
@@ -1,0 +1,128 @@
+import type { Request, RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import type { AuditContext } from "../repository/stock.repository";
+import {
+  consumeStockReservationSchema,
+  createStockReservationSchema,
+  listStockReservationsQuerySchema,
+  stockReservationActionSchema,
+} from "../validators/stock-reservation.validators";
+import {
+  consumeStockReservationSVC,
+  createStockReservationSVC,
+  getStockReservationSVC,
+  listStockReservationsSVC,
+  releaseStockReservationSVC,
+} from "../services/stock-reservation.service";
+import { idParamSchema } from "../validators/stock.validators";
+
+function buildAuditContext(req: Request): AuditContext {
+  const user = req.user;
+  if (!user) throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
+  const forwardedFor = req.headers["x-forwarded-for"];
+  const ipFromHeader = typeof forwardedFor === "string" ? forwardedFor.split(",")[0]?.trim() : null;
+  return {
+    user_id: user.id,
+    ip: ipFromHeader ?? req.ip ?? null,
+    user_agent: typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null,
+    device_type: null,
+    os: null,
+    browser: null,
+    path: req.originalUrl ?? null,
+    page_key: typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null,
+    client_session_id:
+      typeof req.headers["x-client-session-id"] === "string"
+        ? req.headers["x-client-session-id"]
+        : null,
+  };
+}
+
+function getRequiredIdempotencyKey(req: Request): string {
+  const value = req.headers["idempotency-key"];
+  if (typeof value !== "string" || value.trim().length < 8 || value.trim().length > 200) {
+    throw new HttpError(
+      400,
+      "IDEMPOTENCY_KEY_REQUIRED",
+      "A valid Idempotency-Key header is required (8 to 200 characters)."
+    );
+  }
+  return value.trim();
+}
+
+export const listStockReservations: RequestHandler = async (req, res, next) => {
+  try {
+    const query = listStockReservationsQuerySchema.parse(req.query);
+    res.json(await listStockReservationsSVC(query));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getStockReservation: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const out = await getStockReservationSVC(id);
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createStockReservation: RequestHandler = async (req, res, next) => {
+  try {
+    const body = createStockReservationSchema.parse({ body: req.body }).body;
+    const out = await createStockReservationSVC(
+      body,
+      buildAuditContext(req),
+      getRequiredIdempotencyKey(req)
+    );
+    res.status(201).json(out);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const releaseStockReservation: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const body = stockReservationActionSchema.parse({ body: req.body }).body;
+    const out = await releaseStockReservationSVC(
+      id,
+      body,
+      buildAuditContext(req),
+      getRequiredIdempotencyKey(req)
+    );
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const consumeStockReservation: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const body = consumeStockReservationSchema.parse({ body: req.body }).body;
+    const out = await consumeStockReservationSVC(
+      id,
+      body,
+      buildAuditContext(req),
+      getRequiredIdempotencyKey(req)
+    );
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/module/stock/controllers/stock.controller.ts
+++ b/src/module/stock/controllers/stock.controller.ts
@@ -13,8 +13,11 @@ import {
   createMatiereSousEtatSchema,
   createEmplacementSchema,
   createLotSchema,
+  createLotGenealogySchema,
   createMagasinSchema,
   createMovementSchema,
+  compensateMovementSchema,
+  postMovementSchema,
   docIdParamSchema,
   emplacementIdParamSchema,
   idParamSchema,
@@ -32,6 +35,8 @@ import {
   listMovementsQuerySchema,
   magasinIdParamSchema,
   upsertInventoryLineSchema,
+  inventorySessionActionSchema,
+  cancelInventorySessionSchema,
   updateArticleSchema,
   archiveArticleSchema,
   reactivateArticleSchema,
@@ -40,6 +45,7 @@ import {
   articleDocumentMetadataSchema,
   updateEmplacementSchema,
   updateLotSchema,
+  updateLotQualitySchema,
   updateMagasinSchema,
   type CreateInventorySessionBodyDTO,
   type CreateArticleBodyDTO,
@@ -49,8 +55,11 @@ import {
   type CreateMatiereSousEtatBodyDTO,
   type CreateEmplacementBodyDTO,
   type CreateLotBodyDTO,
+  type CreateLotGenealogyBodyDTO,
   type CreateMagasinBodyDTO,
   type CreateMovementBodyDTO,
+  type CompensateMovementBodyDTO,
+  type PostMovementBodyDTO,
   type ListAnalyticsQueryDTO,
   type ListBalancesQueryDTO,
   type ListMatiereEtatsQueryDTO,
@@ -61,12 +70,19 @@ import {
   type ReactivateArticleBodyDTO,
   type UpdateEmplacementBodyDTO,
   type UpdateLotBodyDTO,
+  type UpdateLotQualityBodyDTO,
   type UpdateMagasinBodyDTO,
   type UpsertInventoryLineBodyDTO,
+  type InventorySessionActionBodyDTO,
+  type CancelInventorySessionBodyDTO,
 } from "../validators/stock.validators";
+import { roleHasStockCapability } from "../domain/stock-rbac";
 import type { AuditContext } from "../repository/stock.repository";
 import {
   closeStockInventorySessionSVC,
+  startStockInventorySessionSVC,
+  approveStockInventorySessionSVC,
+  cancelStockInventorySessionSVC,
   createStockInventorySessionSVC,
   createStockArticleFamilySVC,
   getStockInventorySessionSVC,
@@ -80,8 +96,12 @@ import {
   createStockArticleSVC,
   createStockEmplacementSVC,
   createStockLotSVC,
+  createStockLotGenealogySVC,
   createStockMagasinSVC,
   createStockMovementSVC,
+  previewStockMovementSVC,
+  compensateStockMovementSVC,
+  previewStockMovementCompensationSVC,
   getStockArticleDocumentForDownloadSVC,
   getStockArticleSVC,
   getStockArticlesKpisSVC,
@@ -91,6 +111,7 @@ import {
   listStockMatiereNuancesSVC,
   listStockMatiereSousEtatsSVC,
   getStockLotSVC,
+  getStockLotGenealogySVC,
   getStockMagasinSVC,
   getStockMagasinsKpisSVC,
   getStockMovementDocumentForDownloadSVC,
@@ -113,6 +134,7 @@ import {
   listStockArticleWhereUsedSVC,
   updateStockEmplacementSVC,
   updateStockLotSVC,
+  updateStockLotQualitySVC,
   updateStockMagasinSVC,
   deactivateStockMagasinSVC,
   activateStockMagasinSVC,
@@ -141,7 +163,7 @@ export const createStockInventorySession: RequestHandler = async (req, res, next
   try {
     const audit = buildAuditContext(req);
     const body: CreateInventorySessionBodyDTO = createInventorySessionSchema.parse({ body: req.body }).body;
-    const out = await createStockInventorySessionSVC(body, audit);
+    const out = await createStockInventorySessionSVC(body, audit, getRequiredIdempotencyKey(req));
     res.status(201).json(out);
   } catch (err) {
     next(err);
@@ -181,7 +203,12 @@ export const upsertStockInventorySessionLine: RequestHandler = async (req, res, 
     const audit = buildAuditContext(req);
     const { id } = idParamSchema.parse({ params: req.params }).params;
     const body: UpsertInventoryLineBodyDTO = upsertInventoryLineSchema.parse({ body: req.body }).body;
-    const out = await upsertStockInventorySessionLineSVC(id, body, audit);
+    const out = await upsertStockInventorySessionLineSVC(
+      id,
+      body,
+      audit,
+      getRequiredIdempotencyKey(req)
+    );
     if (!out) {
       res.status(404).json({ error: "Not found" });
       return;
@@ -196,7 +223,15 @@ export const closeStockInventorySession: RequestHandler = async (req, res, next)
   try {
     const audit = buildAuditContext(req);
     const { id } = idParamSchema.parse({ params: req.params }).params;
-    const out = await closeStockInventorySessionSVC(id, audit);
+    const body: InventorySessionActionBodyDTO = inventorySessionActionSchema.parse({
+      body: req.body,
+    }).body;
+    const out = await closeStockInventorySessionSVC(
+      id,
+      body,
+      audit,
+      getRequiredIdempotencyKey(req)
+    );
     if (!out) {
       res.status(404).json({ error: "Not found" });
       return;
@@ -734,6 +769,125 @@ export const updateStockLot: RequestHandler = async (req, res, next) => {
   }
 };
 
+export const updateStockLotQuality: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req);
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const body: UpdateLotQualityBodyDTO = updateLotQualitySchema.parse({ body: req.body }).body;
+    const out = await updateStockLotQualitySVC(
+      id,
+      body,
+      audit,
+      getRequiredIdempotencyKey(req)
+    );
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const startStockInventorySession: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req);
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const body: InventorySessionActionBodyDTO = inventorySessionActionSchema.parse({
+      body: req.body,
+    }).body;
+    const out = await startStockInventorySessionSVC(
+      id,
+      body,
+      audit,
+      getRequiredIdempotencyKey(req)
+    );
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const approveStockInventorySession: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req);
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const body: InventorySessionActionBodyDTO = inventorySessionActionSchema.parse({
+      body: req.body,
+    }).body;
+    const out = await approveStockInventorySessionSVC(
+      id,
+      body,
+      audit,
+      getRequiredIdempotencyKey(req)
+    );
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const cancelStockInventorySession: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req);
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const body: CancelInventorySessionBodyDTO = cancelInventorySessionSchema.parse({
+      body: req.body,
+    }).body;
+    const out = await cancelStockInventorySessionSVC(
+      id,
+      body,
+      audit,
+      getRequiredIdempotencyKey(req)
+    );
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getStockLotGenealogy: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const out = await getStockLotGenealogySVC(id);
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const createStockLotGenealogy: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req);
+    const body: CreateLotGenealogyBodyDTO = createLotGenealogySchema.parse({ body: req.body }).body;
+    const out = await createStockLotGenealogySVC(
+      body,
+      audit,
+      getRequiredIdempotencyKey(req)
+    );
+    res.status(201).json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
 export const listStockBalances: RequestHandler = async (req, res, next) => {
   try {
     const parsed = listBalancesQuerySchema.safeParse(req.query);
@@ -780,8 +934,58 @@ export const getStockMovement: RequestHandler = async (req, res, next) => {
 export const createStockMovement: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req);
-    const body: CreateMovementBodyDTO = createMovementSchema.parse({ body: req.body }).body;
+    const parsedBody: CreateMovementBodyDTO = createMovementSchema.parse({ body: req.body }).body;
+    const body: CreateMovementBodyDTO = {
+      ...parsedBody,
+      idempotency_key: getRequiredIdempotencyKey(req),
+    };
     const out = await createStockMovementSVC(body, audit);
+    res.status(201).json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const previewStockMovement: RequestHandler = async (req, res, next) => {
+  try {
+    const body: CreateMovementBodyDTO = createMovementSchema.parse({ body: req.body }).body;
+    const out = await previewStockMovementSVC(body);
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const previewStockMovementCompensation: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const body: CompensateMovementBodyDTO = compensateMovementSchema.parse({ body: req.body }).body;
+    const out = await previewStockMovementCompensationSVC(id, body);
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
+    res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const compensateStockMovement: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req);
+    const { id } = idParamSchema.parse({ params: req.params }).params;
+    const body: CompensateMovementBodyDTO = compensateMovementSchema.parse({ body: req.body }).body;
+    const out = await compensateStockMovementSVC(
+      id,
+      body,
+      audit,
+      getRequiredIdempotencyKey(req)
+    );
+    if (!out) {
+      res.status(404).json({ error: "Not found" });
+      return;
+    }
     res.status(201).json(out);
   } catch (err) {
     next(err);
@@ -792,7 +996,23 @@ export const postStockMovement: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req);
     const { id } = idParamSchema.parse({ params: req.params }).params;
-    const out = await postStockMovementSVC(id, audit);
+    const body: PostMovementBodyDTO = postMovementSchema.parse({ body: req.body }).body;
+    if (
+      body.negative_stock_override &&
+      !roleHasStockCapability(req.user?.role, "negative_stock_override")
+    ) {
+      throw new HttpError(
+        403,
+        "NEGATIVE_STOCK_OVERRIDE_FORBIDDEN",
+        "Negative-stock override capability is required"
+      );
+    }
+    const out = await postStockMovementSVC(
+      id,
+      body,
+      audit,
+      getRequiredIdempotencyKey(req)
+    );
     if (!out) {
       res.status(404).json({ error: "Not found" });
       return;
@@ -807,7 +1027,7 @@ export const cancelStockMovement: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req);
     const { id } = idParamSchema.parse({ params: req.params }).params;
-    const out = await cancelStockMovementSVC(id, audit);
+    const out = await cancelStockMovementSVC(id, audit, getRequiredIdempotencyKey(req));
     if (!out) {
       res.status(404).json({ error: "Not found" });
       return;

--- a/src/module/stock/domain/stock-availability.test.ts
+++ b/src/module/stock/domain/stock-availability.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  calculateStockAvailability,
+  evaluateNegativeStockOverride,
+} from "./stock-availability";
+
+describe("stock availability", () => {
+  it("subtracts reservations and depreciation for released stock", () => {
+    expect(
+      calculateStockAvailability({
+        qty_on_hand: 20,
+        qty_reserved: 6,
+        qty_depreciated: 2,
+        lot_status: "LIBERE",
+      })
+    ).toEqual({
+      qty_on_hand: 20,
+      qty_reserved: 6,
+      qty_depreciated: 2,
+      qty_quarantine: 0,
+      qty_blocked: 0,
+      qty_available: 12,
+    });
+  });
+
+  it("keeps non-lot stock eligible", () => {
+    expect(
+      calculateStockAvailability({
+        qty_on_hand: 7,
+        qty_reserved: 1,
+        qty_depreciated: 0,
+        lot_status: null,
+      }).qty_available
+    ).toBe(6);
+  });
+
+  it.each(["EN_ATTENTE", "QUARANTAINE"] as const)(
+    "excludes %s stock from availability and exposes quarantine",
+    (lotStatus) => {
+      const out = calculateStockAvailability({
+        qty_on_hand: 9,
+        qty_reserved: 1,
+        qty_depreciated: 2,
+        lot_status: lotStatus,
+      });
+      expect(out.qty_available).toBe(0);
+      expect(out.qty_quarantine).toBe(7);
+    }
+  );
+
+  it("excludes blocked stock and never returns negative values", () => {
+    expect(
+      calculateStockAvailability({
+        qty_on_hand: 3,
+        qty_reserved: 10,
+        qty_depreciated: 1,
+        lot_status: "BLOQUE",
+      })
+    ).toMatchObject({ qty_blocked: 2, qty_available: 0 });
+  });
+
+  it("allows a bounded negative-stock override only on clean released stock", () => {
+    expect(
+      evaluateNegativeStockOverride(
+        {
+          qty_on_hand: 2,
+          qty_reserved: 0,
+          qty_depreciated: 0,
+          lot_status: "LIBERE",
+        },
+        5,
+        { maximum_negative_qty: 4, reason: "Arrêt machine évité" }
+      )
+    ).toEqual({
+      allowed: true,
+      projected_qty_on_hand: -3,
+      code: "ALLOWED",
+    });
+  });
+
+  it("refuses overrides that consume reserved stock or exceed the approved floor", () => {
+    expect(
+      evaluateNegativeStockOverride(
+        {
+          qty_on_hand: 2,
+          qty_reserved: 1,
+          qty_depreciated: 0,
+          lot_status: null,
+        },
+        5,
+        { maximum_negative_qty: 4, reason: "Dérogation" }
+      ).code
+    ).toBe("RESERVED_STOCK_PRESENT");
+
+    expect(
+      evaluateNegativeStockOverride(
+        {
+          qty_on_hand: 2,
+          qty_reserved: 0,
+          qty_depreciated: 0,
+          lot_status: null,
+        },
+        10,
+        { maximum_negative_qty: 4, reason: "Dérogation" }
+      ).code
+    ).toBe("LIMIT_EXCEEDED");
+  });
+});

--- a/src/module/stock/domain/stock-availability.ts
+++ b/src/module/stock/domain/stock-availability.ts
@@ -1,0 +1,97 @@
+export type StockLotQualityStatus = "LIBERE" | "EN_ATTENTE" | "QUARANTAINE" | "BLOQUE" | null;
+
+export type StockAvailabilityInput = {
+  qty_on_hand: number;
+  qty_reserved: number;
+  qty_depreciated: number;
+  lot_status: StockLotQualityStatus;
+};
+
+export type StockAvailability = {
+  qty_on_hand: number;
+  qty_reserved: number;
+  qty_depreciated: number;
+  qty_quarantine: number;
+  qty_blocked: number;
+  qty_available: number;
+};
+
+export type NegativeStockOverride = {
+  maximum_negative_qty: number;
+  reason: string;
+};
+
+export type NegativeStockOverrideEvaluation = {
+  allowed: boolean;
+  projected_qty_on_hand: number;
+  code:
+    | "ALLOWED"
+    | "INVALID_LIMIT"
+    | "LOT_NOT_RELEASED"
+    | "RESERVED_STOCK_PRESENT"
+    | "DEPRECIATED_STOCK_PRESENT"
+    | "LIMIT_EXCEEDED";
+};
+
+function nonNegative(value: number): number {
+  if (!Number.isFinite(value)) return 0;
+  return Math.max(value, 0);
+}
+
+export function calculateStockAvailability(input: StockAvailabilityInput): StockAvailability {
+  const qtyOnHand = nonNegative(input.qty_on_hand);
+  const qtyReserved = nonNegative(input.qty_reserved);
+  const qtyDepreciated = nonNegative(input.qty_depreciated);
+  const physicalNetOfDepreciation = nonNegative(qtyOnHand - qtyDepreciated);
+  const isQuarantine = input.lot_status === "EN_ATTENTE" || input.lot_status === "QUARANTAINE";
+  const isBlocked = input.lot_status === "BLOQUE";
+  const isReleased = input.lot_status === null || input.lot_status === "LIBERE";
+
+  return {
+    qty_on_hand: qtyOnHand,
+    qty_reserved: qtyReserved,
+    qty_depreciated: qtyDepreciated,
+    qty_quarantine: isQuarantine ? physicalNetOfDepreciation : 0,
+    qty_blocked: isBlocked ? physicalNetOfDepreciation : 0,
+    qty_available: isReleased ? nonNegative(qtyOnHand - qtyReserved - qtyDepreciated) : 0,
+  };
+}
+
+export function evaluateNegativeStockOverride(
+  input: StockAvailabilityInput,
+  consumedQty: number,
+  override: NegativeStockOverride
+): NegativeStockOverrideEvaluation {
+  const projectedQtyOnHand = input.qty_on_hand - Math.abs(consumedQty);
+  const deny = (
+    code: Exclude<NegativeStockOverrideEvaluation["code"], "ALLOWED">
+  ): NegativeStockOverrideEvaluation => ({
+    allowed: false,
+    projected_qty_on_hand: projectedQtyOnHand,
+    code,
+  });
+
+  if (
+    !Number.isFinite(override.maximum_negative_qty) ||
+    override.maximum_negative_qty <= 0
+  ) {
+    return deny("INVALID_LIMIT");
+  }
+  if (input.lot_status !== null && input.lot_status !== "LIBERE") {
+    return deny("LOT_NOT_RELEASED");
+  }
+  if (input.qty_reserved > 1e-9) {
+    return deny("RESERVED_STOCK_PRESENT");
+  }
+  if (input.qty_depreciated > 1e-9) {
+    return deny("DEPRECIATED_STOCK_PRESENT");
+  }
+  if (projectedQtyOnHand < -override.maximum_negative_qty - 1e-9) {
+    return deny("LIMIT_EXCEEDED");
+  }
+  return {
+    allowed: true,
+    projected_qty_on_hand: projectedQtyOnHand,
+    code: "ALLOWED",
+  };
+}

--- a/src/module/stock/domain/stock-command.test.ts
+++ b/src/module/stock/domain/stock-command.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import { canonicalStockCommandPayload, hashStockCommand } from "./stock-command";
+
+describe("stock command hashing", () => {
+  it("is stable across object key order", () => {
+    const left = hashStockCommand("POST", { id: "m-1", nested: { qty: 4, lot: null } });
+    const right = hashStockCommand("POST", { nested: { lot: null, qty: 4 }, id: "m-1" });
+    expect(left).toBe(right);
+  });
+
+  it("keeps array order because stock line order is semantic", () => {
+    const left = hashStockCommand("CREATE", { lines: [{ qty: 1 }, { qty: 2 }] });
+    const right = hashStockCommand("CREATE", { lines: [{ qty: 2 }, { qty: 1 }] });
+    expect(left).not.toBe(right);
+  });
+
+  it("omits undefined values but retains null", () => {
+    expect(canonicalStockCommandPayload("CREATE", { a: undefined, b: null })).toBe(
+      '{"command":"CREATE","payload":{"b":null}}'
+    );
+  });
+});

--- a/src/module/stock/domain/stock-command.ts
+++ b/src/module/stock/domain/stock-command.ts
@@ -1,0 +1,36 @@
+import crypto from "node:crypto";
+
+import { HttpError } from "../../../utils/httpError";
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, nested]) => nested !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, nested]) => [key, canonicalize(nested)])
+    );
+  }
+  return value;
+}
+
+export function canonicalStockCommandPayload(command: string, payload: unknown): string {
+  return JSON.stringify(canonicalize({ command, payload }));
+}
+
+export function hashStockCommand(command: string, payload: unknown): string {
+  return crypto.createHash("sha256").update(canonicalStockCommandPayload(command, payload)).digest("hex");
+}
+
+export function normalizeIdempotencyKey(raw: string | null | undefined): string {
+  const key = raw?.trim() ?? "";
+  if (key.length < 8 || key.length > 200) {
+    throw new HttpError(
+      400,
+      "IDEMPOTENCY_KEY_REQUIRED",
+      "Idempotency-Key must contain between 8 and 200 characters"
+    );
+  }
+  return key;
+}

--- a/src/module/stock/domain/stock-rbac.test.ts
+++ b/src/module/stock/domain/stock-rbac.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { roleHasStockCapability } from "./stock-rbac";
+
+describe("stock RBAC", () => {
+  it("fails closed for an absent or unknown role", () => {
+    expect(roleHasStockCapability(undefined, "read")).toBe(false);
+    expect(roleHasStockCapability("Role sans habilitation", "movement_create")).toBe(false);
+  });
+
+  it("grants every critical capability to administrators", () => {
+    expect(roleHasStockCapability("Administrateur Systeme et Reseau", "movement_post")).toBe(true);
+    expect(roleHasStockCapability("Administrateur Systeme et Reseau", "negative_stock_override")).toBe(true);
+    expect(roleHasStockCapability("Administrateur Systeme et Reseau", "inventory_close")).toBe(true);
+  });
+
+  it("separates quality decisions from stock posting", () => {
+    expect(roleHasStockCapability("Responsable Qualité", "lot_quality")).toBe(true);
+    expect(roleHasStockCapability("Responsable Qualité", "movement_post")).toBe(false);
+  });
+
+  it("lets employees read and count but not approve or post", () => {
+    expect(roleHasStockCapability("Employee", "read")).toBe(true);
+    expect(roleHasStockCapability("Employee", "inventory_count")).toBe(true);
+    expect(roleHasStockCapability("Employee", "inventory_approve")).toBe(false);
+    expect(roleHasStockCapability("Employee", "movement_post")).toBe(false);
+  });
+});

--- a/src/module/stock/domain/stock-rbac.ts
+++ b/src/module/stock/domain/stock-rbac.ts
@@ -1,0 +1,69 @@
+export type StockCapability =
+  | "read"
+  | "referential_manage"
+  | "movement_create"
+  | "movement_post"
+  | "movement_cancel"
+  | "movement_compensate"
+  | "negative_stock_override"
+  | "reservation_manage"
+  | "lot_quality"
+  | "inventory_create"
+  | "inventory_count"
+  | "inventory_approve"
+  | "inventory_close"
+  | "documents_manage"
+  | "costs_read"
+  | "export";
+
+const ADMIN_OR_DIRECTOR = ["admin", "administrateur", "directeur"] as const;
+const STOCK_OPERATIONS = [
+  ...ADMIN_OR_DIRECTOR,
+  "stock",
+  "logisti",
+  "magasin",
+  "production",
+  "atelier",
+  "program",
+  "planif",
+] as const;
+const READERS = [
+  ...STOCK_OPERATIONS,
+  "qualit",
+  "audit",
+  "method",
+  "achat",
+  "appro",
+  "secr",
+  "secret",
+  "employee",
+  "employe",
+] as const;
+
+const NEEDLES: Record<StockCapability, readonly string[]> = {
+  read: READERS,
+  referential_manage: [...ADMIN_OR_DIRECTOR, "stock", "logisti", "magasin", "program", "method", "achat", "appro"],
+  movement_create: STOCK_OPERATIONS,
+  movement_post: [...ADMIN_OR_DIRECTOR, "stock", "logisti", "magasin", "production", "program"],
+  movement_cancel: [...ADMIN_OR_DIRECTOR, "stock", "logisti", "magasin", "program"],
+  movement_compensate: [...ADMIN_OR_DIRECTOR, "stock", "logisti"],
+  negative_stock_override: ADMIN_OR_DIRECTOR,
+  reservation_manage: [...ADMIN_OR_DIRECTOR, "stock", "logisti", "magasin", "planif", "program"],
+  lot_quality: [...ADMIN_OR_DIRECTOR, "qualit"],
+  inventory_create: [...ADMIN_OR_DIRECTOR, "stock", "logisti", "magasin"],
+  inventory_count: [...ADMIN_OR_DIRECTOR, "stock", "logisti", "magasin", "employee", "employe"],
+  inventory_approve: [...ADMIN_OR_DIRECTOR, "stock", "logisti", "qualit"],
+  inventory_close: [...ADMIN_OR_DIRECTOR, "stock", "logisti"],
+  documents_manage: [...ADMIN_OR_DIRECTOR, "stock", "logisti", "magasin", "qualit", "achat", "appro"],
+  costs_read: [...ADMIN_OR_DIRECTOR, "compt", "achat", "appro", "secr", "secret"],
+  export: [...ADMIN_OR_DIRECTOR, "stock", "logisti", "qualit", "audit", "compt"],
+};
+
+export function roleHasStockCapability(
+  role: string | null | undefined,
+  capability: StockCapability
+): boolean {
+  const normalized = (role ?? "").trim().toLowerCase();
+  if (!normalized) return false;
+  return NEEDLES[capability].some((needle) => normalized.includes(needle));
+}

--- a/src/module/stock/repository/stock-reservation.repository.ts
+++ b/src/module/stock/repository/stock-reservation.repository.ts
@@ -1,0 +1,607 @@
+import db from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import type {
+  StockReservationDetail,
+  StockReservationEvent,
+  StockReservationListItem,
+} from "../types/stock-reservation.types";
+import type {
+  ConsumeStockReservationBodyDTO,
+  CreateStockReservationBodyDTO,
+  ListStockReservationsQueryDTO,
+  StockReservationActionBodyDTO,
+} from "../validators/stock-reservation.validators";
+import {
+  assertStockConsumptionAllowed,
+  beginStockCommand,
+  completeStockCommand,
+  getEmplacementMapping,
+  lockStockStates,
+  stockTargetKey,
+  type AuditContext,
+} from "./stock.repository";
+
+type Paginated<T> = { items: T[]; total: number };
+
+function reservationSortColumn(sortBy: ListStockReservationsQueryDTO["sortBy"]): string {
+  switch (sortBy) {
+    case "updated_at":
+      return "reservation.updated_at";
+    case "expires_at":
+      return "reservation.expires_at";
+    case "qty_reserved":
+      return "reservation.qty_reserved";
+    default:
+      return "reservation.created_at";
+  }
+}
+
+function reservationSortDirection(sortDir: ListStockReservationsQueryDTO["sortDir"]): "ASC" | "DESC" {
+  return sortDir === "asc" ? "ASC" : "DESC";
+}
+
+function sourceReference(body: CreateStockReservationBodyDTO): {
+  source_type: string;
+  source_id: string;
+  commande_ligne_id: number | null;
+  of_id: number | null;
+  bon_livraison_ligne_id: string | null;
+  affaire_id: number | null;
+} {
+  switch (body.source.source_type) {
+    case "COMMANDE_LIGNE":
+      return {
+        source_type: body.source.source_type,
+        source_id: String(body.source.commande_ligne_id),
+        commande_ligne_id: body.source.commande_ligne_id,
+        of_id: null,
+        bon_livraison_ligne_id: null,
+        affaire_id: null,
+      };
+    case "OF":
+      return {
+        source_type: body.source.source_type,
+        source_id: String(body.source.of_id),
+        commande_ligne_id: null,
+        of_id: body.source.of_id,
+        bon_livraison_ligne_id: null,
+        affaire_id: null,
+      };
+    case "BON_LIVRAISON_LIGNE":
+      return {
+        source_type: body.source.source_type,
+        source_id: body.source.bon_livraison_ligne_id,
+        commande_ligne_id: null,
+        of_id: null,
+        bon_livraison_ligne_id: body.source.bon_livraison_ligne_id,
+        affaire_id: null,
+      };
+    case "AFFAIRE":
+      return {
+        source_type: body.source.source_type,
+        source_id: String(body.source.affaire_id),
+        commande_ligne_id: null,
+        of_id: null,
+        bon_livraison_ligne_id: null,
+        affaire_id: body.source.affaire_id,
+      };
+  }
+}
+
+const RESERVATION_SELECT = `
+  SELECT
+    reservation.id::text AS id,
+    reservation.article_id::text AS article_id,
+    article.code AS article_code,
+    article.designation AS article_designation,
+    reservation.location_id::text AS location_id,
+    emplacement.magasin_id::text AS magasin_id,
+    COALESCE(magasin.code, magasin.code_magasin)::text AS magasin_code,
+    emplacement.id::int AS emplacement_id,
+    emplacement.code AS emplacement_code,
+    reservation.lot_id::text AS lot_id,
+    lot.lot_code,
+    reservation.stock_batch_id::text AS stock_batch_id,
+    reservation.qty_reserved::float8 AS qty_reserved,
+    reservation.source_type,
+    reservation.source_id,
+    reservation.status,
+    reservation.reason,
+    reservation.expires_at::text AS expires_at,
+    reservation.released_at::text AS released_at,
+    reservation.consumed_at::text AS consumed_at,
+    reservation.consumed_stock_movement_id::text AS consumed_stock_movement_id,
+    reservation.row_version::int AS row_version,
+    reservation.correlation_id::text AS correlation_id,
+    reservation.updated_at::text AS updated_at,
+    reservation.created_at::text AS created_at
+  FROM public.stock_reservations reservation
+  JOIN public.articles article ON article.id = reservation.article_id
+  LEFT JOIN public.emplacements emplacement ON emplacement.location_id = reservation.location_id
+  LEFT JOIN public.magasins magasin ON magasin.id = emplacement.magasin_id
+  LEFT JOIN public.lots lot ON lot.id = reservation.lot_id
+`;
+
+export async function repoListStockReservations(
+  filters: ListStockReservationsQueryDTO
+): Promise<Paginated<StockReservationListItem>> {
+  const page = filters.page ?? 1;
+  const pageSize = filters.pageSize ?? 50;
+  const offset = (page - 1) * pageSize;
+  const values: unknown[] = [];
+  const where: string[] = [];
+  const push = (value: unknown) => {
+    values.push(value);
+    return `$${values.length}`;
+  };
+
+  if (filters.article_id) where.push(`reservation.article_id = ${push(filters.article_id)}::uuid`);
+  if (filters.magasin_id) where.push(`emplacement.magasin_id = ${push(filters.magasin_id)}::uuid`);
+  if (filters.emplacement_id) where.push(`emplacement.id = ${push(filters.emplacement_id)}::bigint`);
+  if (filters.lot_id) where.push(`reservation.lot_id = ${push(filters.lot_id)}::uuid`);
+  if (filters.status) where.push(`reservation.status = ${push(filters.status)}`);
+  if (filters.source_type) where.push(`reservation.source_type = ${push(filters.source_type)}`);
+  if (filters.q) {
+    const query = `%${filters.q.replace(/[%_]/g, "\\$&")}%`;
+    const p = push(query);
+    where.push(
+      `(
+        article.code ILIKE ${p} ESCAPE '\\'
+        OR article.designation ILIKE ${p} ESCAPE '\\'
+        OR COALESCE(lot.lot_code, '') ILIKE ${p} ESCAPE '\\'
+        OR reservation.source_id ILIKE ${p} ESCAPE '\\'
+      )`
+    );
+  }
+  const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
+  const count = await db.query<{ total: number }>(
+    `
+      SELECT COUNT(*)::int AS total
+      FROM public.stock_reservations reservation
+      JOIN public.articles article ON article.id = reservation.article_id
+      LEFT JOIN public.emplacements emplacement ON emplacement.location_id = reservation.location_id
+      LEFT JOIN public.lots lot ON lot.id = reservation.lot_id
+      ${whereSql}
+    `,
+    values
+  );
+  const rows = await db.query<StockReservationListItem>(
+    `
+      ${RESERVATION_SELECT}
+      ${whereSql}
+      ORDER BY ${reservationSortColumn(filters.sortBy)} ${reservationSortDirection(filters.sortDir)}, reservation.id
+      LIMIT $${values.length + 1}
+      OFFSET $${values.length + 2}
+    `,
+    [...values, pageSize, offset]
+  );
+  return { items: rows.rows, total: count.rows[0]?.total ?? 0 };
+}
+
+export async function repoGetStockReservation(id: string): Promise<StockReservationDetail | null> {
+  const reservation = await db.query<StockReservationListItem>(
+    `${RESERVATION_SELECT} WHERE reservation.id = $1::uuid`,
+    [id]
+  );
+  const row = reservation.rows[0] ?? null;
+  if (!row) return null;
+
+  const events = await db.query<StockReservationEvent>(
+    `
+      SELECT
+        id::text AS id,
+        event_type,
+        old_values,
+        new_values,
+        actor_user_id,
+        correlation_id::text AS correlation_id,
+        created_at::text AS created_at
+      FROM public.stock_reservation_event_log
+      WHERE reservation_id = $1::uuid
+      ORDER BY created_at DESC, id DESC
+      LIMIT 500
+    `,
+    [id]
+  );
+  return { reservation: row, events: events.rows };
+}
+
+export async function repoCreateStockReservation(
+  body: CreateStockReservationBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockReservationDetail> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: idempotencyKey,
+      command_type: "RESERVATION_CREATE",
+      request_payload: body,
+    });
+    if (command.existing) {
+      await client.query("COMMIT");
+      const existing = await repoGetStockReservation(command.existing.resource_id);
+      if (!existing) throw new Error("Idempotent reservation receipt points to a missing reservation");
+      return existing;
+    }
+
+    const article = await client.query<{ stock_managed: boolean; lot_tracking: boolean }>(
+      `SELECT stock_managed, lot_tracking FROM public.articles WHERE id = $1::uuid`,
+      [body.article_id]
+    );
+    const articleSettings = article.rows[0] ?? null;
+    if (!articleSettings) throw new HttpError(400, "INVALID_ARTICLE", "Unknown article_id");
+    if (!articleSettings.stock_managed) {
+      throw new HttpError(409, "ARTICLE_NOT_STOCK_MANAGED", "Article is not managed in stock");
+    }
+    if (articleSettings.lot_tracking && !body.lot_id) {
+      throw new HttpError(409, "LOT_REQUIRED", "A lot-tracked article requires lot_id");
+    }
+
+    const location = await getEmplacementMapping(
+      client,
+      body.magasin_id,
+      body.emplacement_id,
+      "src"
+    );
+    const level = await client.query<{ id: string }>(
+      `
+        SELECT id::text AS id
+        FROM public.stock_levels
+        WHERE article_id = $1::uuid
+          AND location_id = $2::uuid
+        LIMIT 1
+      `,
+      [body.article_id, location.location_id]
+    );
+    const stockLevelId = level.rows[0]?.id;
+    if (!stockLevelId) {
+      throw new HttpError(409, "INSUFFICIENT_STOCK", "No stock level exists at this emplacement");
+    }
+
+    let stockBatchId: string | null = null;
+    if (body.lot_id) {
+      const batch = await client.query<{ id: string }>(
+        `
+          SELECT batch.id::text AS id
+          FROM public.stock_batches batch
+          JOIN public.lots lot
+            ON lot.id = batch.lot_id
+           AND lot.article_id = $3::uuid
+          WHERE batch.stock_level_id = $1::uuid
+            AND batch.lot_id = $2::uuid
+          LIMIT 1
+        `,
+        [stockLevelId, body.lot_id, body.article_id]
+      );
+      stockBatchId = batch.rows[0]?.id ?? null;
+      if (!stockBatchId) {
+        throw new HttpError(409, "STOCK_BATCH_MISSING", "The lot has no stock batch at this emplacement");
+      }
+    }
+
+    const states = await lockStockStates(client, [
+      { stock_level_id: stockLevelId, stock_batch_id: stockBatchId },
+    ]);
+    const state = states.get(
+      stockTargetKey({ stock_level_id: stockLevelId, stock_batch_id: stockBatchId })
+    );
+    if (!state) throw new Error("Locked reservation stock state missing");
+    assertStockConsumptionAllowed(state, { movement_type: "RESERVE", qty: body.qty });
+
+    await client.query(
+      `
+        UPDATE public.stock_levels
+        SET qty_reserved = qty_reserved + $2,
+            updated_at = now(),
+            updated_by = $3
+        WHERE id = $1::uuid
+      `,
+      [stockLevelId, body.qty, audit.user_id]
+    );
+    if (stockBatchId) {
+      await client.query(
+        `
+          UPDATE public.stock_batches
+          SET qty_reserved = qty_reserved + $2
+          WHERE id = $1::uuid
+        `,
+        [stockBatchId, body.qty]
+      );
+    }
+
+    const source = sourceReference(body);
+    const inserted = await client.query<{ id: string }>(
+      `
+        INSERT INTO public.stock_reservations (
+          article_id,
+          location_id,
+          lot_id,
+          stock_batch_id,
+          qty_reserved,
+          source_type,
+          source_id,
+          commande_ligne_id,
+          of_id,
+          bon_livraison_ligne_id,
+          affaire_id,
+          status,
+          reason,
+          expires_at,
+          correlation_id,
+          created_by,
+          updated_by
+        )
+        VALUES (
+          $1::uuid,$2::uuid,$3::uuid,$4::uuid,$5,$6,$7,
+          $8::bigint,$9::bigint,$10::uuid,$11::bigint,
+          'ACTIVE',$12,$13::timestamptz,$14::uuid,$15,$15
+        )
+        RETURNING id::text AS id
+      `,
+      [
+        body.article_id,
+        location.location_id,
+        body.lot_id ?? null,
+        stockBatchId,
+        body.qty,
+        source.source_type,
+        source.source_id,
+        source.commande_ligne_id,
+        source.of_id,
+        source.bon_livraison_ligne_id,
+        source.affaire_id,
+        body.reason,
+        body.expires_at ?? null,
+        command.correlation_id,
+        audit.user_id,
+      ]
+    );
+    const reservationId = inserted.rows[0]?.id;
+    if (!reservationId) throw new Error("Failed to create stock reservation");
+
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: "RESERVATION_CREATE",
+      resource_type: "stock_reservation",
+      resource_id: reservationId,
+      result_payload: {
+        reservation_id: reservationId,
+        status: "ACTIVE",
+        qty_reserved: body.qty,
+      },
+    });
+    await client.query("COMMIT");
+
+    const out = await repoGetStockReservation(reservationId);
+    if (!out) throw new Error("Failed to reload stock reservation");
+    return out;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    const pgCode = (error as { code?: unknown })?.code;
+    if (pgCode === "23503") {
+      throw new HttpError(409, "INVALID_SOURCE_REFERENCE", "Reservation source does not exist");
+    }
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function transitionReservation(
+  id: string,
+  audit: AuditContext,
+  idempotencyKey: string,
+  args:
+    | {
+        command_type: "RESERVATION_RELEASE";
+        body: StockReservationActionBodyDTO;
+      }
+    | {
+        command_type: "RESERVATION_CONSUME";
+        body: ConsumeStockReservationBodyDTO;
+      }
+): Promise<StockReservationDetail | null> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: idempotencyKey,
+      command_type: args.command_type,
+      request_payload: { reservation_id: id, ...args.body },
+    });
+    if (command.existing) {
+      await client.query("COMMIT");
+      return repoGetStockReservation(command.existing.resource_id);
+    }
+
+    const reservation = await client.query<{
+      article_id: string;
+      location_id: string;
+      stock_batch_id: string | null;
+      qty_reserved: number;
+      status: string;
+      row_version: number;
+    }>(
+      `
+        SELECT
+          article_id::text AS article_id,
+          location_id::text AS location_id,
+          stock_batch_id::text AS stock_batch_id,
+          qty_reserved::float8 AS qty_reserved,
+          status,
+          row_version::int AS row_version
+        FROM public.stock_reservations
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
+      [id]
+    );
+    const row = reservation.rows[0] ?? null;
+    if (!row) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+    if (row.status !== "ACTIVE") {
+      throw new HttpError(409, "INVALID_STATUS", "Only ACTIVE reservations can transition");
+    }
+    if (row.row_version !== args.body.expected_version) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Reservation version has changed");
+    }
+
+    const level = await client.query<{ id: string }>(
+      `
+        SELECT id::text AS id
+        FROM public.stock_levels
+        WHERE article_id = $1::uuid
+          AND location_id = $2::uuid
+        LIMIT 1
+      `,
+      [row.article_id, row.location_id]
+    );
+    const stockLevelId = level.rows[0]?.id;
+    if (!stockLevelId) throw new HttpError(409, "STOCK_LEVEL_MISSING", "Reservation stock level is missing");
+
+    const states = await lockStockStates(client, [
+      { stock_level_id: stockLevelId, stock_batch_id: row.stock_batch_id },
+    ]);
+    const state = states.get(
+      stockTargetKey({ stock_level_id: stockLevelId, stock_batch_id: row.stock_batch_id })
+    );
+    if (!state) throw new Error("Locked reservation stock state missing");
+    assertStockConsumptionAllowed(state, {
+      movement_type: "UNRESERVE",
+      qty: row.qty_reserved,
+    });
+
+    let consumedMovementId: string | null = null;
+    if (args.command_type === "RESERVATION_CONSUME") {
+      const movement = await client.query<{ id: string }>(
+        `
+          SELECT id::text AS id
+          FROM public.stock_movements
+          WHERE id = $1::uuid
+            AND status::text = 'POSTED'
+            AND movement_type::text = 'OUT'
+            AND article_id = $2::uuid
+            AND stock_level_id = $3::uuid
+            AND (stock_batch_id IS NOT DISTINCT FROM $4::uuid)
+            AND ABS(qty) + 1e-9 >= $5
+          LIMIT 1
+        `,
+        [
+          args.body.stock_movement_id,
+          row.article_id,
+          stockLevelId,
+          row.stock_batch_id,
+          row.qty_reserved,
+        ]
+      );
+      consumedMovementId = movement.rows[0]?.id ?? null;
+      if (!consumedMovementId) {
+        throw new HttpError(
+          409,
+          "MOVEMENT_RESERVATION_MISMATCH",
+          "A matching posted OUT movement is required to consume a reservation"
+        );
+      }
+    }
+
+    await client.query(
+      `
+        UPDATE public.stock_levels
+        SET qty_reserved = qty_reserved - $2,
+            updated_at = now(),
+            updated_by = $3
+        WHERE id = $1::uuid
+      `,
+      [stockLevelId, row.qty_reserved, audit.user_id]
+    );
+    if (row.stock_batch_id) {
+      await client.query(
+        `
+          UPDATE public.stock_batches
+          SET qty_reserved = qty_reserved - $2
+          WHERE id = $1::uuid
+        `,
+        [row.stock_batch_id, row.qty_reserved]
+      );
+    }
+
+    const nextStatus = args.command_type === "RESERVATION_CONSUME" ? "CONSUMED" : "RELEASED";
+    await client.query(
+      `
+        UPDATE public.stock_reservations
+        SET
+          status = $2,
+          reason = $3,
+          released_at = CASE WHEN $2 = 'RELEASED' THEN now() ELSE released_at END,
+          released_by = CASE WHEN $2 = 'RELEASED' THEN $4 ELSE released_by END,
+          consumed_at = CASE WHEN $2 = 'CONSUMED' THEN now() ELSE consumed_at END,
+          consumed_by = CASE WHEN $2 = 'CONSUMED' THEN $4 ELSE consumed_by END,
+          consumed_stock_movement_id = $5::uuid,
+          correlation_id = $6::uuid,
+          updated_at = now(),
+          updated_by = $4
+        WHERE id = $1::uuid
+      `,
+      [
+        id,
+        nextStatus,
+        args.body.reason,
+        audit.user_id,
+        consumedMovementId,
+        command.correlation_id,
+      ]
+    );
+
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: args.command_type,
+      resource_type: "stock_reservation",
+      resource_id: id,
+      result_payload: {
+        reservation_id: id,
+        status: nextStatus,
+        consumed_stock_movement_id: consumedMovementId,
+      },
+    });
+    await client.query("COMMIT");
+    return repoGetStockReservation(id);
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export function repoReleaseStockReservation(
+  id: string,
+  body: StockReservationActionBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockReservationDetail | null> {
+  return transitionReservation(id, audit, idempotencyKey, {
+    command_type: "RESERVATION_RELEASE",
+    body,
+  });
+}
+
+export function repoConsumeStockReservation(
+  id: string,
+  body: ConsumeStockReservationBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockReservationDetail | null> {
+  return transitionReservation(id, audit, idempotencyKey, {
+    command_type: "RESERVATION_CONSUME",
+    body,
+  });
+}

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -10,6 +10,13 @@ import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
+import {
+  calculateStockAvailability,
+  evaluateNegativeStockOverride,
+  type NegativeStockOverride,
+  type StockLotQualityStatus,
+} from "../domain/stock-availability";
+import { hashStockCommand, normalizeIdempotencyKey } from "../domain/stock-command";
 import type {
   ArticleCategory,
   ArticleBusinessCategory,
@@ -32,11 +39,15 @@ import type {
   StockInventorySessionLine,
   StockInventorySessionListItem,
   StockLotDetail,
+  StockLotGenealogy,
+  StockLotGenealogyEdge,
   StockLotListItem,
   StockMagasinDetail,
   StockMagasinKpis,
   StockMagasinListItem,
   StockMovementDetail,
+  StockMovementCompensationPreview,
+  StockMovementImpactPreview,
   StockMovementEvent,
   StockMovementLineDetail,
   StockMovementListItem,
@@ -53,6 +64,8 @@ import type {
   CreateLotBodyDTO,
   CreateMagasinBodyDTO,
   CreateMovementBodyDTO,
+  CompensateMovementBodyDTO,
+  PostMovementBodyDTO,
   CreateMovementLineDTO,
   ListAnalyticsQueryDTO,
   ListArticlesQueryDTO,
@@ -68,6 +81,8 @@ import type {
   ListMovementsQueryDTO,
   StockMovementTypeDTO,
   UpsertInventoryLineBodyDTO,
+  InventorySessionActionBodyDTO,
+  CancelInventorySessionBodyDTO,
   UpdateArticleBodyDTO,
   ArchiveArticleBodyDTO,
   ReactivateArticleBodyDTO,
@@ -76,6 +91,8 @@ import type {
   ArticleDocumentMetadataDTO,
   UpdateEmplacementBodyDTO,
   UpdateLotBodyDTO,
+  UpdateLotQualityBodyDTO,
+  CreateLotGenealogyBodyDTO,
   UpdateMagasinBodyDTO,
 } from "../validators/stock.validators";
 
@@ -90,6 +107,130 @@ export type AuditContext = {
   page_key: string | null;
   client_session_id: string | null;
 };
+
+export type StockCommandType =
+  | "MOVEMENT_CREATE"
+  | "MOVEMENT_POST"
+  | "MOVEMENT_CANCEL"
+  | "MOVEMENT_COMPENSATE"
+  | "RESERVATION_CREATE"
+  | "RESERVATION_RELEASE"
+  | "RESERVATION_CONSUME"
+  | "LOT_QUALITY_CHANGE"
+  | "LOT_GENEALOGY_RECORD"
+  | "INVENTORY_CREATE"
+  | "INVENTORY_START"
+  | "INVENTORY_COUNT"
+  | "INVENTORY_APPROVE"
+  | "INVENTORY_CANCEL"
+  | "INVENTORY_CLOSE";
+
+export type StockCommandReceipt = {
+  request_hash: string;
+  resource_type: string;
+  resource_id: string;
+  result_payload: Record<string, unknown>;
+  correlation_id: string;
+};
+
+export type BegunStockCommand = {
+  key: string;
+  request_hash: string;
+  request_payload: unknown;
+  correlation_id: string;
+  existing: StockCommandReceipt | null;
+};
+
+export async function beginStockCommand(
+  client: Pick<PoolClient, "query">,
+  args: {
+    audit: AuditContext;
+    idempotency_key: string;
+    command_type: StockCommandType;
+    request_payload: unknown;
+  }
+): Promise<BegunStockCommand> {
+  const key = normalizeIdempotencyKey(args.idempotency_key);
+  const requestHash = hashStockCommand(args.command_type, args.request_payload);
+
+  await client.query(
+    `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+    [`stock:${args.audit.user_id}:${key}`]
+  );
+
+  const receipt = await client.query<StockCommandReceipt>(
+    `
+      SELECT
+        request_hash,
+        resource_type,
+        resource_id,
+        result_payload,
+        correlation_id::text AS correlation_id
+      FROM public.stock_command_receipts
+      WHERE actor_user_id = $1
+        AND idempotency_key = $2
+      LIMIT 1
+    `,
+    [args.audit.user_id, key]
+  );
+  const existing = receipt.rows[0] ?? null;
+  if (existing && existing.request_hash !== requestHash) {
+    throw new HttpError(
+      409,
+      "IDEMPOTENCY_KEY_REUSED",
+      "This Idempotency-Key was already used with a different stock command"
+    );
+  }
+
+  return {
+    key,
+    request_hash: requestHash,
+    request_payload: args.request_payload,
+    correlation_id: existing?.correlation_id ?? crypto.randomUUID(),
+    existing,
+  };
+}
+
+export async function completeStockCommand(
+  client: Pick<PoolClient, "query">,
+  args: {
+    audit: AuditContext;
+    command: BegunStockCommand;
+    command_type: StockCommandType;
+    resource_type: string;
+    resource_id: string;
+    result_payload: Record<string, unknown>;
+  }
+): Promise<void> {
+  await client.query(
+    `
+      INSERT INTO public.stock_command_receipts (
+        actor_user_id,
+        idempotency_key,
+        request_hash,
+        command_type,
+        resource_type,
+        resource_id,
+        request_payload,
+        result_payload,
+        correlation_id
+      )
+      VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8::jsonb,$9::uuid)
+      ON CONFLICT (actor_user_id, idempotency_key) DO NOTHING
+    `,
+    [
+      args.audit.user_id,
+      args.command.key,
+      args.command.request_hash,
+      args.command_type,
+      args.resource_type,
+      args.resource_id,
+      JSON.stringify(args.command.request_payload),
+      JSON.stringify(args.result_payload),
+      args.command.correlation_id,
+    ]
+  );
+}
 
 const ARTICLE_PRIMARY_CATEGORY_OPTIONS: Array<{ code: ArticleCategory }> = [
   { code: "fabrique" },
@@ -1339,7 +1480,7 @@ async function ensureArticleCanDisableStockManagement(client: Pick<PoolClient, "
       SELECT
         COALESCE(SUM(qty_total), 0)::float8 AS qty_total,
         COALESCE(SUM(qty_reserved), 0)::float8 AS qty_reserved
-      FROM public.v_stock_current
+      FROM public.v_stock_availability_225
       WHERE article_id = $1::uuid
     `,
     [articleId]
@@ -1561,13 +1702,15 @@ async function resolveUnitIdForArticle(
   return unitId;
 }
 
-type EmplacementMapping = {
+export type EmplacementMapping = {
   magasin_id: string;
   location_id: string;
   warehouse_id: string;
+  location_type: string;
+  restrictions: Record<string, unknown>;
 };
 
-async function getEmplacementMapping(
+export async function getEmplacementMapping(
   client: Pick<PoolClient, "query">,
   magasinId: string,
   emplacementId: number,
@@ -1577,13 +1720,26 @@ async function getEmplacementMapping(
     magasin_id: string;
     location_id: string | null;
     warehouse_id: string | null;
+    emplacement_active: boolean;
+    magasin_active: boolean;
+    location_type: string;
+    allow_inbound: boolean;
+    allow_outbound: boolean;
+    restrictions: Record<string, unknown>;
   }>(
     `
       SELECT
         e.magasin_id::text AS magasin_id,
         e.location_id::text AS location_id,
-        l.warehouse_id::text AS warehouse_id
+        l.warehouse_id::text AS warehouse_id,
+        e.is_active AS emplacement_active,
+        m.is_active AS magasin_active,
+        e.location_type,
+        e.allow_inbound,
+        e.allow_outbound,
+        e.restrictions
       FROM public.emplacements e
+      JOIN public.magasins m ON m.id = e.magasin_id
       LEFT JOIN public.locations l ON l.id = e.location_id
       WHERE e.id = $1::bigint
     `,
@@ -1597,18 +1753,29 @@ async function getEmplacementMapping(
   if (row.magasin_id !== magasinId) {
     throw new HttpError(400, "INVALID_LOCATION", `${label}_emplacement_id does not belong to ${label}_magasin_id`);
   }
+  if (!row.emplacement_active || !row.magasin_active) {
+    throw new HttpError(409, "LOCATION_INACTIVE", `${label} magasin or emplacement is inactive`);
+  }
   if (!row.location_id || !row.warehouse_id) {
     throw new HttpError(409, "LOCATION_NOT_MAPPED", `Emplacement is missing ${label} location mapping`);
+  }
+  if (label === "src" && !row.allow_outbound) {
+    throw new HttpError(409, "LOCATION_INCOMPATIBLE", "Source emplacement does not allow outbound stock");
+  }
+  if (label === "dst" && !row.allow_inbound) {
+    throw new HttpError(409, "LOCATION_INCOMPATIBLE", "Destination emplacement does not allow inbound stock");
   }
 
   return {
     magasin_id: row.magasin_id,
     location_id: row.location_id,
     warehouse_id: row.warehouse_id,
+    location_type: row.location_type,
+    restrictions: row.restrictions ?? {},
   };
 }
 
-async function ensureStockLevel(
+export async function ensureStockLevel(
   client: Pick<PoolClient, "query">,
   args: {
     article_id: string;
@@ -1667,7 +1834,7 @@ async function ensureStockLevel(
   return id;
 }
 
-async function ensureStockBatchId(
+export async function ensureStockBatchId(
   client: Pick<PoolClient, "query">,
   args: {
     stock_level_id: string;
@@ -1675,28 +1842,272 @@ async function ensureStockBatchId(
   }
 ): Promise<string> {
   const lot = await client.query<{ lot_code: string }>(
-    `SELECT lot_code FROM public.lots WHERE id = $1::uuid`,
-    [args.lot_id]
+    `
+      SELECT lot.lot_code
+      FROM public.lots lot
+      JOIN public.stock_levels level
+        ON level.id = $2::uuid
+       AND level.article_id = lot.article_id
+      WHERE lot.id = $1::uuid
+    `,
+    [args.lot_id, args.stock_level_id]
   );
   const lotCode = lot.rows[0]?.lot_code;
-  if (!lotCode) throw new HttpError(400, "INVALID_LOT", "Unknown lot_id");
+  if (!lotCode) {
+    throw new HttpError(409, "LOT_ARTICLE_MISMATCH", "Lot does not belong to the movement article");
+  }
 
   await client.query(
     `
-      INSERT INTO public.stock_batches (stock_level_id, batch_code)
-      VALUES ($1::uuid,$2)
-      ON CONFLICT (stock_level_id, batch_code) DO NOTHING
+      INSERT INTO public.stock_batches (stock_level_id, batch_code, lot_id)
+      VALUES ($1::uuid,$2,$3::uuid)
+      ON CONFLICT (stock_level_id, batch_code)
+      DO UPDATE SET lot_id = COALESCE(public.stock_batches.lot_id, EXCLUDED.lot_id)
     `,
-    [args.stock_level_id, lotCode]
+    [args.stock_level_id, lotCode, args.lot_id]
   );
 
   const b = await client.query<{ id: string }>(
-    `SELECT id::text AS id FROM public.stock_batches WHERE stock_level_id = $1::uuid AND batch_code = $2`,
-    [args.stock_level_id, lotCode]
+    `
+      SELECT id::text AS id
+      FROM public.stock_batches
+      WHERE stock_level_id = $1::uuid
+        AND lot_id = $2::uuid
+    `,
+    [args.stock_level_id, args.lot_id]
   );
   const id = b.rows[0]?.id;
   if (!id) throw new Error("Failed to ensure stock batch");
   return id;
+}
+
+export type StockLockTarget = {
+  stock_level_id: string;
+  stock_batch_id: string | null;
+};
+
+export type LockedStockState = {
+  stock_level_id: string;
+  stock_batch_id: string | null;
+  qty_on_hand: number;
+  qty_reserved: number;
+  qty_depreciated: number;
+  lot_status: StockLotQualityStatus;
+};
+
+export function stockTargetKey(target: StockLockTarget): string {
+  return `${target.stock_level_id}:${target.stock_batch_id ?? "-"}`;
+}
+
+export async function lockStockStates(
+  client: Pick<PoolClient, "query">,
+  targets: StockLockTarget[]
+): Promise<Map<string, LockedStockState>> {
+  const uniqueTargets = new Map<string, StockLockTarget>();
+  for (const target of targets) uniqueTargets.set(stockTargetKey(target), target);
+
+  const levelIds = [...new Set([...uniqueTargets.values()].map((target) => target.stock_level_id))].sort();
+  const levelRows = new Map<
+    string,
+    { qty_total: number; qty_reserved: number; qty_depreciated: number }
+  >();
+  for (const levelId of levelIds) {
+    const level = await client.query<{
+      qty_total: number;
+      qty_reserved: number;
+      qty_depreciated: number;
+    }>(
+      `
+        SELECT
+          qty_total::float8 AS qty_total,
+          qty_reserved::float8 AS qty_reserved,
+          qty_depreciated::float8 AS qty_depreciated
+        FROM public.stock_levels
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
+      [levelId]
+    );
+    const row = level.rows[0] ?? null;
+    if (!row) throw new HttpError(409, "STOCK_LEVEL_MISSING", "Stock level no longer exists");
+    levelRows.set(levelId, row);
+  }
+
+  const batchIds = [
+    ...new Set(
+      [...uniqueTargets.values()]
+        .map((target) => target.stock_batch_id)
+        .filter((id): id is string => typeof id === "string")
+    ),
+  ].sort();
+  const batchRows = new Map<
+    string,
+    {
+      stock_level_id: string;
+      lot_id: string | null;
+      qty_total: number;
+      qty_reserved: number;
+      qty_depreciated: number;
+    }
+  >();
+  for (const batchId of batchIds) {
+    const batch = await client.query<{
+      stock_level_id: string;
+      lot_id: string | null;
+      qty_total: number;
+      qty_reserved: number;
+      qty_depreciated: number;
+    }>(
+      `
+        SELECT
+          stock_level_id::text AS stock_level_id,
+          lot_id::text AS lot_id,
+          qty_total::float8 AS qty_total,
+          qty_reserved::float8 AS qty_reserved,
+          qty_depreciated::float8 AS qty_depreciated
+        FROM public.stock_batches
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
+      [batchId]
+    );
+    const row = batch.rows[0] ?? null;
+    if (!row) throw new HttpError(409, "STOCK_BATCH_MISSING", "Stock batch no longer exists");
+    batchRows.set(batchId, row);
+  }
+
+  const lotIds = [
+    ...new Set(
+      [...batchRows.values()]
+        .map((batch) => batch.lot_id)
+        .filter((id): id is string => typeof id === "string")
+    ),
+  ].sort();
+  const lotStatuses = new Map<string, StockLotQualityStatus>();
+  for (const lotId of lotIds) {
+    const lot = await client.query<{ lot_status: StockLotQualityStatus }>(
+      `SELECT lot_status FROM public.lots WHERE id = $1::uuid FOR SHARE`,
+      [lotId]
+    );
+    const row = lot.rows[0] ?? null;
+    if (!row) throw new HttpError(409, "LOT_MISSING", "Stock lot no longer exists");
+    lotStatuses.set(lotId, row.lot_status ?? "LIBERE");
+  }
+
+  const states = new Map<string, LockedStockState>();
+  for (const target of uniqueTargets.values()) {
+    const level = levelRows.get(target.stock_level_id);
+    if (!level) throw new Error("Locked stock level state missing");
+    if (!target.stock_batch_id) {
+      states.set(stockTargetKey(target), {
+        stock_level_id: target.stock_level_id,
+        stock_batch_id: null,
+        qty_on_hand: Number(level.qty_total),
+        qty_reserved: Number(level.qty_reserved),
+        qty_depreciated: Number(level.qty_depreciated),
+        lot_status: null,
+      });
+      continue;
+    }
+
+    const batch = batchRows.get(target.stock_batch_id);
+    if (!batch || batch.stock_level_id !== target.stock_level_id) {
+      throw new HttpError(409, "STOCK_BATCH_MISMATCH", "Stock batch does not belong to stock level");
+    }
+    states.set(stockTargetKey(target), {
+      stock_level_id: target.stock_level_id,
+      stock_batch_id: target.stock_batch_id,
+      qty_on_hand: Number(batch.qty_total),
+      qty_reserved: Number(batch.qty_reserved),
+      qty_depreciated: Number(batch.qty_depreciated),
+      lot_status: batch.lot_id ? lotStatuses.get(batch.lot_id) ?? null : null,
+    });
+  }
+  return states;
+}
+
+export function assertStockConsumptionAllowed(
+  state: LockedStockState,
+  args: {
+    movement_type: StockMovementTypeDTO;
+    qty: number;
+    allow_nonreleased_adjustment?: boolean;
+    negative_stock_override?: NegativeStockOverride;
+  }
+): void {
+  const qty = Math.abs(args.qty);
+  if (!Number.isFinite(qty) || qty <= 0) {
+    throw new HttpError(400, "INVALID_MOVEMENT", "Movement quantity must be positive");
+  }
+
+  const availability = calculateStockAvailability(state);
+  const consumesAvailable =
+    args.movement_type === "OUT" ||
+    args.movement_type === "TRANSFER" ||
+    args.movement_type === "RESERVE" ||
+    args.movement_type === "SCRAP" ||
+    args.movement_type === "DEPRECIATE" ||
+    ((args.movement_type === "ADJUST" || args.movement_type === "ADJUSTMENT") && args.qty < 0);
+
+  if (
+    consumesAvailable &&
+    state.lot_status !== null &&
+    state.lot_status !== "LIBERE" &&
+    args.movement_type !== "SCRAP" &&
+    args.movement_type !== "DEPRECIATE" &&
+    !(
+      args.allow_nonreleased_adjustment &&
+      (args.movement_type === "ADJUST" || args.movement_type === "ADJUSTMENT")
+    )
+  ) {
+    throw new HttpError(
+      409,
+      "LOT_NOT_RELEASED",
+      `Lot status ${state.lot_status} does not allow stock consumption`
+    );
+  }
+
+  if (args.movement_type === "UNRESERVE") {
+    if (availability.qty_reserved + 1e-9 < qty) {
+      throw new HttpError(409, "RESERVATION_UNDERFLOW", "Cannot release more stock than is reserved");
+    }
+    return;
+  }
+
+  const consumableQty =
+    args.movement_type === "SCRAP" || args.movement_type === "DEPRECIATE"
+      ? Math.max(
+          availability.qty_on_hand - availability.qty_reserved - availability.qty_depreciated,
+          0
+        )
+      : args.allow_nonreleased_adjustment &&
+          (args.movement_type === "ADJUST" || args.movement_type === "ADJUSTMENT")
+        ? Math.max(
+            availability.qty_on_hand - availability.qty_reserved - availability.qty_depreciated,
+            0
+          )
+      : availability.qty_available;
+
+  if (consumesAvailable && consumableQty + 1e-9 < qty) {
+    if (args.negative_stock_override) {
+      const override = evaluateNegativeStockOverride(
+        state,
+        qty,
+        args.negative_stock_override
+      );
+      if (override.allowed) return;
+      throw new HttpError(
+        409,
+        "NEGATIVE_STOCK_OVERRIDE_REFUSED",
+        "Negative-stock override does not satisfy the approved policy",
+        {
+          override_code: override.code,
+          projected_qty_on_hand: override.projected_qty_on_hand,
+        }
+      );
+    }
+    throw new HttpError(409, "INSUFFICIENT_STOCK", "Insufficient available stock for this movement");
+  }
 }
 
 function sumQty(lines: CreateMovementLineDTO[]): number {
@@ -1717,7 +2128,13 @@ function assertSameLotIfSet(lines: CreateMovementLineDTO[]): string | null {
   const firstLot = lines[0]?.lot_id ?? null;
   for (const l of lines) {
     const lot = l.lot_id ?? null;
-    if (lot !== firstLot) return null;
+    if (lot !== firstLot) {
+      throw new HttpError(
+        409,
+        "MULTIPLE_LOTS_UNSUPPORTED",
+        "One stock movement header can reference only one lot"
+      );
+    }
   }
   return firstLot;
 }
@@ -1983,7 +2400,7 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
         COALESCE(SUM(qty_available), 0)::float8 AS qty_available,
         COALESCE(SUM(qty_reserved), 0)::float8 AS qty_reserved,
         COALESCE(SUM(qty_total), 0)::float8 AS qty_total
-      FROM public.v_stock_current
+      FROM public.v_stock_availability_225
       GROUP BY article_id
     ) bs ON bs.article_id = a.id::text
     LEFT JOIN LATERAL (
@@ -2081,7 +2498,7 @@ export async function repoGetArticle(id: string, includeCosts = false): Promise<
            COALESCE(SUM(qty_available), 0)::float8 AS qty_available,
            COALESCE(SUM(qty_reserved), 0)::float8 AS qty_reserved,
            COALESCE(SUM(qty_total), 0)::float8 AS qty_total
-        FROM public.v_stock_current
+        FROM public.v_stock_availability_225
         GROUP BY article_id
       ) bs ON bs.article_id = a.id::text
       LEFT JOIN LATERAL (
@@ -2870,6 +3287,10 @@ export async function repoGetMagasin(id: string): Promise<StockMagasinDetail | n
         e.name,
         e.is_scrap,
         e.is_active,
+        e.location_type,
+        e.allow_inbound,
+        e.allow_outbound,
+        e.restrictions,
         e.updated_at::text AS updated_at,
         e.created_at::text AS created_at
       FROM public.emplacements e
@@ -3133,6 +3554,7 @@ export async function repoListEmplacements(filters: ListEmplacementsQueryDTO): P
   if (filters.magasin_id) where.push(`e.magasin_id = ${push(filters.magasin_id)}::uuid`);
   if (filters.is_active !== undefined) where.push(`e.is_active = ${push(filters.is_active)}`);
   if (filters.is_scrap !== undefined) where.push(`e.is_scrap = ${push(filters.is_scrap)}`);
+  if (filters.location_type) where.push(`e.location_type = ${push(filters.location_type)}`);
   if (filters.q && filters.q.trim().length > 0) {
     const q = normalizeLikeQuery(filters.q);
     const p = push(q);
@@ -3165,6 +3587,10 @@ export async function repoListEmplacements(filters: ListEmplacementsQueryDTO): P
       e.name,
       e.is_scrap,
       e.is_active,
+      e.location_type,
+      e.allow_inbound,
+      e.allow_outbound,
+      e.restrictions,
       e.updated_at::text AS updated_at,
       e.created_at::text AS created_at
     FROM public.emplacements e
@@ -3207,11 +3633,36 @@ export async function repoCreateEmplacement(
 
     const ins = await client.query<{ id: number }>(
       `
-        INSERT INTO public.emplacements (magasin_id, code, name, is_scrap, is_active, notes, created_by, updated_by)
-        VALUES ($1::uuid,$2,$3,$4,$5,$6,$7,$7)
+        INSERT INTO public.emplacements (
+          magasin_id,
+          code,
+          name,
+          is_scrap,
+          is_active,
+          location_type,
+          allow_inbound,
+          allow_outbound,
+          restrictions,
+          notes,
+          created_by,
+          updated_by
+        )
+        VALUES ($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9::jsonb,$10,$11,$11)
         RETURNING id::int AS id
       `,
-      [magasinId, body.code, body.name ?? null, body.is_scrap, body.is_active, body.notes ?? null, audit.user_id]
+      [
+        magasinId,
+        body.code,
+        body.name ?? null,
+        body.is_scrap,
+        body.is_active,
+        body.location_type,
+        body.allow_inbound,
+        body.allow_outbound,
+        JSON.stringify(body.restrictions),
+        body.notes ?? null,
+        audit.user_id,
+      ]
     );
     const id = ins.rows[0]?.id;
     if (!id) throw new Error("Failed to create emplacement");
@@ -3318,6 +3769,10 @@ export async function repoCreateEmplacement(
           e.name,
           e.is_scrap,
           e.is_active,
+          e.location_type,
+          e.allow_inbound,
+          e.allow_outbound,
+          e.restrictions,
           e.updated_at::text AS updated_at,
           e.created_at::text AS created_at
         FROM public.emplacements e
@@ -3343,36 +3798,84 @@ export async function repoUpdateEmplacement(
   patch: UpdateEmplacementBodyDTO,
   audit: AuditContext
 ): Promise<StockEmplacementListItem | null> {
-  const sets: string[] = [];
-  const values: unknown[] = [];
-  const push = (v: unknown) => {
-    values.push(v);
-    return `$${values.length}`;
-  };
-
-  if (patch.code !== undefined) sets.push(`code = ${push(patch.code)}`);
-  if (patch.name !== undefined) sets.push(`name = ${push(patch.name)}`);
-  if (patch.is_scrap !== undefined) sets.push(`is_scrap = ${push(patch.is_scrap)}`);
-  if (patch.is_active !== undefined) sets.push(`is_active = ${push(patch.is_active)}`);
-  if (patch.notes !== undefined) sets.push(`notes = ${push(patch.notes)}`);
-  sets.push(`updated_at = now()`);
-  sets.push(`updated_by = ${push(audit.user_id)}`);
-
+  const client = await db.connect();
   try {
-    const res = await db.query<{ id: number }>(
-      `UPDATE public.emplacements SET ${sets.join(", ")} WHERE id = ${push(id)}::bigint RETURNING id::int AS id`,
+    await client.query("BEGIN");
+    const current = await client.query<{
+      is_scrap: boolean;
+      location_type: StockEmplacementListItem["location_type"];
+      allow_outbound: boolean;
+    }>(
+      `
+        SELECT is_scrap, location_type, allow_outbound
+        FROM public.emplacements
+        WHERE id = $1::bigint
+        FOR UPDATE
+      `,
+      [id]
+    );
+    const row = current.rows[0] ?? null;
+    if (!row) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+
+    const nextIsScrap = patch.is_scrap ?? row.is_scrap;
+    const nextLocationType = patch.location_type ?? row.location_type;
+    const nextAllowOutbound = patch.allow_outbound ?? row.allow_outbound;
+    if (nextIsScrap !== (nextLocationType === "SCRAP")) {
+      throw new HttpError(
+        409,
+        "LOCATION_TYPE_INCONSISTENT",
+        "SCRAP location type and scrap flag must be changed together"
+      );
+    }
+    if (nextLocationType === "SCRAP" && nextAllowOutbound) {
+      throw new HttpError(409, "LOCATION_TYPE_INCONSISTENT", "A SCRAP location cannot provide stock");
+    }
+
+    const sets: string[] = [];
+    const values: unknown[] = [];
+    const push = (v: unknown) => {
+      values.push(v);
+      return `$${values.length}`;
+    };
+
+    if (patch.code !== undefined) sets.push(`code = ${push(patch.code)}`);
+    if (patch.name !== undefined) sets.push(`name = ${push(patch.name)}`);
+    if (patch.is_scrap !== undefined) sets.push(`is_scrap = ${push(patch.is_scrap)}`);
+    if (patch.is_active !== undefined) sets.push(`is_active = ${push(patch.is_active)}`);
+    if (patch.location_type !== undefined) sets.push(`location_type = ${push(patch.location_type)}`);
+    if (patch.allow_inbound !== undefined) sets.push(`allow_inbound = ${push(patch.allow_inbound)}`);
+    if (patch.allow_outbound !== undefined) sets.push(`allow_outbound = ${push(patch.allow_outbound)}`);
+    if (patch.restrictions !== undefined) {
+      sets.push(`restrictions = ${push(JSON.stringify(patch.restrictions))}::jsonb`);
+    }
+    if (patch.notes !== undefined) sets.push(`notes = ${push(patch.notes)}`);
+    sets.push(`updated_at = now()`);
+    sets.push(`updated_by = ${push(audit.user_id)}`);
+
+    await client.query(
+      `UPDATE public.emplacements SET ${sets.join(", ")} WHERE id = ${push(id)}::bigint`,
       values
     );
-    if (!res.rows[0]?.id) return null;
 
-    await insertAuditLog(db, audit, {
+    await insertAuditLog(client, audit, {
       action: "stock.emplacements.update",
       entity_type: "emplacements",
       entity_id: String(id),
-      details: { patch },
+      details: {
+        before: row,
+        patch,
+        after: {
+          is_scrap: nextIsScrap,
+          location_type: nextLocationType,
+          allow_outbound: nextAllowOutbound,
+        },
+      },
     });
 
-    const out = await db.query<StockEmplacementListItem>(
+    const out = await client.query<StockEmplacementListItem>(
       `
         SELECT
           e.id::int AS id,
@@ -3383,6 +3886,10 @@ export async function repoUpdateEmplacement(
           e.name,
           e.is_scrap,
           e.is_active,
+          e.location_type,
+          e.allow_inbound,
+          e.allow_outbound,
+          e.restrictions,
           e.updated_at::text AS updated_at,
           e.created_at::text AS created_at
         FROM public.emplacements e
@@ -3391,12 +3898,16 @@ export async function repoUpdateEmplacement(
       `,
       [id]
     );
+    await client.query("COMMIT");
     return out.rows[0] ?? null;
   } catch (err) {
+    await client.query("ROLLBACK");
     if (isPgUniqueViolation(err)) {
       throw new HttpError(409, "DUPLICATE", "Emplacement code already exists in this magasin");
     }
     throw err;
+  } finally {
+    client.release();
   }
 }
 
@@ -3413,6 +3924,7 @@ export async function repoListLots(filters: ListLotsQueryDTO): Promise<Paginated
   };
 
   if (filters.article_id) where.push(`l.article_id = ${push(filters.article_id)}::uuid`);
+  if (filters.lot_status) where.push(`l.lot_status = ${push(filters.lot_status)}`);
   if (filters.q && filters.q.trim().length > 0) {
     const q = normalizeLikeQuery(filters.q);
     const p = push(q);
@@ -3443,6 +3955,8 @@ export async function repoListLots(filters: ListLotsQueryDTO): Promise<Paginated
       a.code AS article_code,
       a.designation AS article_designation,
       l.lot_code,
+      l.lot_status,
+      l.lot_status_note,
       l.supplier_lot_code,
       l.received_at::text AS received_at,
       l.manufactured_at::text AS manufactured_at,
@@ -3470,6 +3984,8 @@ export async function repoGetLot(id: string): Promise<StockLotDetail | null> {
         a.code AS article_code,
         a.designation AS article_designation,
         l.lot_code,
+        l.lot_status,
+        l.lot_status_note,
         l.supplier_lot_code,
         l.received_at::text AS received_at,
         l.manufactured_at::text AS manufactured_at,
@@ -3583,6 +4099,382 @@ export async function repoUpdateLot(id: string, patch: UpdateLotBodyDTO, audit: 
   }
 }
 
+export async function repoUpdateLotQuality(
+  id: string,
+  body: UpdateLotQualityBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockLotDetail | null> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: idempotencyKey,
+      command_type: "LOT_QUALITY_CHANGE",
+      request_payload: { lot_id: id, ...body },
+    });
+    if (command.existing) {
+      await client.query("COMMIT");
+      return repoGetLot(command.existing.resource_id);
+    }
+
+    const locked = await client.query<{
+      lot_status: StockLotDetail["lot_status"];
+      lot_status_note: string | null;
+      updated_at: string;
+    }>(
+      `
+        SELECT lot_status, lot_status_note, updated_at::text AS updated_at
+        FROM public.lots
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
+      [id]
+    );
+    const lot = locked.rows[0] ?? null;
+    if (!lot) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+    if (new Date(lot.updated_at).getTime() !== new Date(body.expected_updated_at).getTime()) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Lot quality status has changed");
+    }
+    if (lot.lot_status === body.lot_status) {
+      throw new HttpError(409, "QUALITY_STATUS_UNCHANGED", "Lot already has this quality status");
+    }
+
+    if (body.lot_status === "LIBERE") {
+      const openNc = await client.query<{ count: number }>(
+        `
+          SELECT COUNT(*)::int AS count
+          FROM public.non_conformity
+          WHERE lot_id = $1::uuid
+            AND status::text <> 'CLOSED'
+        `,
+        [id]
+      );
+      if ((openNc.rows[0]?.count ?? 0) > 0) {
+        throw new HttpError(
+          409,
+          "LOT_OPEN_NON_CONFORMITY",
+          "Lot cannot be released while a non-conformity remains open"
+        );
+      }
+    }
+
+    await client.query(
+      `
+        UPDATE public.lots
+        SET
+          lot_status = $2,
+          lot_status_note = $3,
+          updated_at = now(),
+          updated_by = $4
+        WHERE id = $1::uuid
+      `,
+      [id, body.lot_status, body.reason, audit.user_id]
+    );
+    await client.query(
+      `
+        INSERT INTO public.stock_lot_event_log (
+          lot_id,
+          event_type,
+          old_values,
+          new_values,
+          actor_user_id,
+          correlation_id
+        )
+        VALUES (
+          $1::uuid,
+          'QUALITY_STATUS_CHANGED',
+          $2::jsonb,
+          $3::jsonb,
+          $4,
+          $5::uuid
+        )
+      `,
+      [
+        id,
+        JSON.stringify({
+          lot_status: lot.lot_status,
+          lot_status_note: lot.lot_status_note,
+          updated_at: lot.updated_at,
+        }),
+        JSON.stringify({ lot_status: body.lot_status, reason: body.reason }),
+        audit.user_id,
+        command.correlation_id,
+      ]
+    );
+    await insertAuditLog(client, audit, {
+      action: "stock.lots.quality_status.change",
+      entity_type: "lots",
+      entity_id: id,
+      details: {
+        before: { lot_status: lot.lot_status, lot_status_note: lot.lot_status_note },
+        after: { lot_status: body.lot_status, lot_status_note: body.reason },
+        correlation_id: command.correlation_id,
+      },
+    });
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: "LOT_QUALITY_CHANGE",
+      resource_type: "stock_lot",
+      resource_id: id,
+      result_payload: { lot_id: id, lot_status: body.lot_status },
+    });
+    await client.query("COMMIT");
+    return repoGetLot(id);
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+const LOT_GENEALOGY_EDGE_SELECT = `
+  SELECT
+    edge.id::text AS id,
+    edge.parent_lot_id::text AS parent_lot_id,
+    parent_lot.lot_code AS parent_lot_code,
+    parent_lot.article_id::text AS parent_article_id,
+    parent_article.code AS parent_article_code,
+    edge.child_lot_id::text AS child_lot_id,
+    child_lot.lot_code AS child_lot_code,
+    child_lot.article_id::text AS child_article_id,
+    child_article.code AS child_article_code,
+    edge.operation_type,
+    edge.qty_contributed::float8 AS qty_contributed,
+    edge.unit_code,
+    edge.stock_movement_id::text AS stock_movement_id,
+    edge.correlation_id::text AS correlation_id,
+    edge.created_at::text AS created_at
+  FROM genealogy edge
+  JOIN public.lots parent_lot ON parent_lot.id = edge.parent_lot_id
+  JOIN public.articles parent_article ON parent_article.id = parent_lot.article_id
+  JOIN public.lots child_lot ON child_lot.id = edge.child_lot_id
+  JOIN public.articles child_article ON child_article.id = child_lot.article_id
+`;
+
+export async function repoGetLotGenealogy(id: string): Promise<StockLotGenealogy | null> {
+  const lot = await repoGetLot(id);
+  if (!lot) return null;
+
+  const ancestors = await db.query<StockLotGenealogyEdge>(
+    `
+      WITH RECURSIVE genealogy AS (
+        SELECT edge.*
+        FROM public.stock_lot_genealogy_edges edge
+        WHERE edge.child_lot_id = $1::uuid
+        UNION
+        SELECT parent_edge.*
+        FROM public.stock_lot_genealogy_edges parent_edge
+        JOIN genealogy current_edge
+          ON parent_edge.child_lot_id = current_edge.parent_lot_id
+      )
+      ${LOT_GENEALOGY_EDGE_SELECT}
+      ORDER BY edge.created_at DESC, edge.id
+    `,
+    [id]
+  );
+  const descendants = await db.query<StockLotGenealogyEdge>(
+    `
+      WITH RECURSIVE genealogy AS (
+        SELECT edge.*
+        FROM public.stock_lot_genealogy_edges edge
+        WHERE edge.parent_lot_id = $1::uuid
+        UNION
+        SELECT child_edge.*
+        FROM public.stock_lot_genealogy_edges child_edge
+        JOIN genealogy current_edge
+          ON child_edge.parent_lot_id = current_edge.child_lot_id
+      )
+      ${LOT_GENEALOGY_EDGE_SELECT}
+      ORDER BY edge.created_at ASC, edge.id
+    `,
+    [id]
+  );
+  return { lot, ancestors: ancestors.rows, descendants: descendants.rows };
+}
+
+export async function repoCreateLotGenealogy(
+  body: CreateLotGenealogyBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<{ correlation_id: string; edges: StockLotGenealogyEdge[] }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: idempotencyKey,
+      command_type: "LOT_GENEALOGY_RECORD",
+      request_payload: body,
+    });
+    if (command.existing) {
+      const edges = await db.query<StockLotGenealogyEdge>(
+        `
+          WITH genealogy AS (
+            SELECT *
+            FROM public.stock_lot_genealogy_edges
+            WHERE correlation_id = $1::uuid
+          )
+          ${LOT_GENEALOGY_EDGE_SELECT}
+          ORDER BY edge.created_at, edge.id
+        `,
+        [command.existing.correlation_id]
+      );
+      await client.query("COMMIT");
+      return { correlation_id: command.existing.correlation_id, edges: edges.rows };
+    }
+
+    const movement = await client.query<{ id: string }>(
+      `
+        SELECT id::text AS id
+        FROM public.stock_movements
+        WHERE id = $1::uuid
+          AND status::text = 'POSTED'
+        FOR SHARE
+      `,
+      [body.stock_movement_id]
+    );
+    if (!movement.rows[0]?.id) {
+      throw new HttpError(
+        409,
+        "POSTED_MOVEMENT_REQUIRED",
+        "A posted stock movement is required for lot genealogy"
+      );
+    }
+
+    const parentQty = body.parents.reduce((sum, item) => sum + item.qty, 0);
+    const childQty = body.children.reduce((sum, item) => sum + item.qty, 0);
+    if (Math.abs(parentQty - childQty) > 1e-6) {
+      throw new HttpError(
+        409,
+        "GENEALOGY_QTY_MISMATCH",
+        "Parent and child genealogy quantities must balance"
+      );
+    }
+
+    const lotIds = [...body.parents, ...body.children].map((item) => item.lot_id).sort();
+    for (const lotId of lotIds) {
+      const lot = await client.query<{ id: string }>(
+        `SELECT id::text AS id FROM public.lots WHERE id = $1::uuid FOR SHARE`,
+        [lotId]
+      );
+      if (!lot.rows[0]?.id) throw new HttpError(400, "INVALID_LOT", "Unknown genealogy lot");
+    }
+
+    const contributions =
+      body.operation_type === "SPLIT"
+        ? body.children.map((child) => ({
+            parent_lot_id: body.parents[0]!.lot_id,
+            child_lot_id: child.lot_id,
+            qty: child.qty,
+          }))
+        : body.operation_type === "MERGE"
+          ? body.parents.map((parent) => ({
+              parent_lot_id: parent.lot_id,
+              child_lot_id: body.children[0]!.lot_id,
+              qty: parent.qty,
+            }))
+          : [
+              {
+                parent_lot_id: body.parents[0]!.lot_id,
+                child_lot_id: body.children[0]!.lot_id,
+                qty: body.children[0]!.qty,
+              },
+            ];
+
+    for (const contribution of contributions) {
+      await client.query(
+        `
+          INSERT INTO public.stock_lot_genealogy_edges (
+            parent_lot_id,
+            child_lot_id,
+            operation_type,
+            qty_contributed,
+            unit_code,
+            stock_movement_id,
+            correlation_id,
+            created_by
+          )
+          VALUES ($1::uuid,$2::uuid,$3,$4,$5,$6::uuid,$7::uuid,$8)
+        `,
+        [
+          contribution.parent_lot_id,
+          contribution.child_lot_id,
+          body.operation_type,
+          contribution.qty,
+          body.unit_code,
+          body.stock_movement_id,
+          command.correlation_id,
+          audit.user_id,
+        ]
+      );
+    }
+
+    const touchedLots = [...new Set(lotIds)];
+    for (const lotId of touchedLots) {
+      await client.query(
+        `
+          INSERT INTO public.stock_lot_event_log (
+            lot_id,
+            event_type,
+            old_values,
+            new_values,
+            actor_user_id,
+            correlation_id
+          )
+          VALUES ($1::uuid,'GENEALOGY_RECORDED',NULL,$2::jsonb,$3,$4::uuid)
+        `,
+        [
+          lotId,
+          JSON.stringify({
+            operation_type: body.operation_type,
+            stock_movement_id: body.stock_movement_id,
+          }),
+          audit.user_id,
+          command.correlation_id,
+        ]
+      );
+    }
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: "LOT_GENEALOGY_RECORD",
+      resource_type: "stock_lot_genealogy",
+      resource_id: command.correlation_id,
+      result_payload: {
+        correlation_id: command.correlation_id,
+        edges_count: contributions.length,
+      },
+    });
+    await client.query("COMMIT");
+
+    const edges = await db.query<StockLotGenealogyEdge>(
+      `
+        WITH genealogy AS (
+          SELECT *
+          FROM public.stock_lot_genealogy_edges
+          WHERE correlation_id = $1::uuid
+        )
+        ${LOT_GENEALOGY_EDGE_SELECT}
+        ORDER BY edge.created_at, edge.id
+      `,
+      [command.correlation_id]
+    );
+    return { correlation_id: command.correlation_id, edges: edges.rows };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
 export async function repoListBalances(filters: ListBalancesQueryDTO): Promise<Paginated<StockBalanceRow>> {
   const page = filters.page ?? 1;
   const pageSize = filters.pageSize ?? 100;
@@ -3598,15 +4490,28 @@ export async function repoListBalances(filters: ListBalancesQueryDTO): Promise<P
   if (filters.article_id) where.push(`b.article_id = ${push(filters.article_id)}::uuid`);
   if (filters.magasin_id) where.push(`e.magasin_id = ${push(filters.magasin_id)}::uuid`);
   if (filters.emplacement_id) where.push(`e.id = ${push(filters.emplacement_id)}::bigint`);
-  if (filters.lot_id) where.push(`1 = 0`);
+  if (filters.lot_id) where.push(`b.lot_id = ${push(filters.lot_id)}::uuid`);
+  if (filters.lot_status) where.push(`b.lot_status = ${push(filters.lot_status)}`);
+  if (filters.only_available === true) where.push(`b.qty_available > 0`);
   if (filters.warehouse_id) where.push(`b.warehouse_id = ${push(filters.warehouse_id)}::uuid`);
   if (filters.location_id) where.push(`b.location_id = ${push(filters.location_id)}::uuid`);
+  if (filters.q && filters.q.trim().length > 0) {
+    const p = push(normalizeLikeQuery(filters.q));
+    where.push(
+      `(
+        a.code ILIKE ${p}
+        OR a.designation ILIKE ${p}
+        OR COALESCE(b.lot_code, '') ILIKE ${p}
+      )`
+    );
+  }
   const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
 
   const countRes = await db.query<{ total: number }>(
     `
       SELECT COUNT(*)::int AS total
-      FROM public.v_stock_current b
+      FROM public.v_stock_availability_225 b
+      JOIN public.articles a ON a.id = b.article_id
       LEFT JOIN public.emplacements e ON e.location_id = b.location_id
       ${whereSql}
     `,
@@ -3626,8 +4531,9 @@ export async function repoListBalances(filters: ListBalancesQueryDTO): Promise<P
       e.id::int AS emplacement_id,
       e.code AS emplacement_code,
       e.name AS emplacement_name,
-      NULL::text AS lot_id,
-      NULL::text AS lot_code,
+      b.lot_id::text AS lot_id,
+      b.lot_code,
+      b.lot_status,
       b.warehouse_id::text AS warehouse_id,
       w.code::text AS warehouse_code,
       w.name AS warehouse_name,
@@ -3639,9 +4545,13 @@ export async function repoListBalances(filters: ListBalancesQueryDTO): Promise<P
       b.managed_in_stock,
       b.qty_total::float8 AS qty_on_hand,
       b.qty_reserved::float8 AS qty_reserved,
+      b.qty_depreciated::float8 AS qty_depreciated,
+      b.qty_quarantine::float8 AS qty_quarantine,
+      b.qty_blocked::float8 AS qty_blocked,
       b.qty_available::float8 AS qty_available,
+      b.qty_scrap_recorded::float8 AS qty_scrap_recorded,
       b.updated_at::text AS updated_at
-    FROM public.v_stock_current b
+    FROM public.v_stock_availability_225 b
     JOIN public.articles a ON a.id = b.article_id
     JOIN public.warehouses w ON w.id = b.warehouse_id
     JOIN public.locations l ON l.id = b.location_id
@@ -3689,7 +4599,7 @@ export async function repoGetStockAnalytics(filters: ListAnalyticsQueryDTO): Pro
   const currentWhereSql = currentWhere.length ? `WHERE ${currentWhere.join(" AND ")}` : "";
   const currentWhereSqlCombined = currentWhereSql.replace(/\$(\d+)/g, (_match, n: string) => `$${Number(n) + movementValues.length}`);
 
-  const [kpisRes, magasinsRes, categoriesRes, seriesRes, topArticlesRes] = await Promise.all([
+  const [kpisRes, cockpitRes, magasinsRes, categoriesRes, seriesRes, topArticlesRes] = await Promise.all([
     db.query<StockAnalytics["kpis"]>(
       `
         SELECT
@@ -3705,13 +4615,117 @@ export async function repoGetStockAnalytics(filters: ListAnalyticsQueryDTO): Pro
             SUM(b.qty_total)::float8 AS qty_total,
             SUM(b.qty_available)::float8 AS qty_available,
             SUM(b.qty_reserved)::float8 AS qty_reserved
-          FROM public.v_stock_current b
+          FROM public.v_stock_availability_225 b
           LEFT JOIN public.emplacements e ON e.location_id = b.location_id
           ${currentWhereSql}
           GROUP BY b.article_id
         ) cur ON cur.article_id = a.id
       `,
       currentValues
+    ),
+    db.query<{
+      ruptures_count: number;
+      below_minimum_count: number;
+      at_risk_reservations_count: number;
+      quarantine_lots_count: number;
+      active_inventory_count: number;
+      discrepancies_to_review_count: number;
+    }>(
+      `
+        WITH scoped_availability AS (
+          SELECT
+            availability.*,
+            level.min_qty::float8 AS min_qty
+          FROM public.v_stock_availability_225 availability
+          JOIN public.stock_levels level ON level.id = availability.stock_level_id
+          LEFT JOIN public.emplacements e ON e.location_id = availability.location_id
+          ${currentWhereSql}
+        ),
+        stock_alerts AS (
+          SELECT
+            COUNT(*) FILTER (
+              WHERE managed_in_stock = true
+                AND COALESCE(min_qty, 0) > 0
+                AND qty_available <= 0
+            )::int AS ruptures_count,
+            COUNT(*) FILTER (
+              WHERE managed_in_stock = true
+                AND COALESCE(min_qty, 0) > 0
+                AND qty_available > 0
+                AND qty_available < min_qty
+            )::int AS below_minimum_count,
+            COUNT(DISTINCT lot_id) FILTER (
+              WHERE lot_id IS NOT NULL
+                AND lot_status IN ('EN_ATTENTE', 'QUARANTAINE', 'BLOQUE')
+                AND qty_on_hand > 0
+            )::int AS quarantine_lots_count
+          FROM scoped_availability
+        ),
+        reservation_alerts AS (
+          SELECT COUNT(*)::int AS at_risk_reservations_count
+          FROM public.stock_reservations reservation
+          LEFT JOIN scoped_availability availability
+            ON availability.article_id = reservation.article_id
+           AND availability.location_id = reservation.location_id
+           AND availability.lot_id IS NOT DISTINCT FROM reservation.lot_id
+          WHERE reservation.status = 'ACTIVE'
+            AND (
+              (reservation.expires_at IS NOT NULL AND reservation.expires_at <= now() + interval '7 days')
+              OR COALESCE(
+                availability.qty_on_hand - availability.qty_depreciated,
+                0
+              ) < reservation.qty_reserved
+            )
+        ),
+        scoped_inventory AS (
+          SELECT DISTINCT session.id, session.status
+          FROM public.stock_inventory_sessions session
+          LEFT JOIN public.stock_inventory_snapshot_lines snapshot
+            ON snapshot.session_id = session.id
+          WHERE (
+            $${currentValues.length + 1}::uuid IS NULL
+            OR session.scope_magasin_id = $${currentValues.length + 1}::uuid
+            OR snapshot.magasin_id = $${currentValues.length + 1}::uuid
+          )
+        ),
+        inventory_alerts AS (
+          SELECT
+            COUNT(*) FILTER (WHERE status IN ('DRAFT', 'OPEN', 'APPROVED'))::int
+              AS active_inventory_count
+          FROM scoped_inventory
+        ),
+        discrepancy_alerts AS (
+          SELECT COUNT(*)::int AS discrepancies_to_review_count
+          FROM public.stock_inventory_snapshot_lines snapshot
+          JOIN public.stock_inventory_sessions session ON session.id = snapshot.session_id
+          LEFT JOIN LATERAL (
+            SELECT event.counted_qty
+            FROM public.stock_inventory_count_events event
+            WHERE event.snapshot_line_id = snapshot.id
+            ORDER BY event.count_round DESC, event.created_at DESC, event.id DESC
+            LIMIT 1
+          ) latest_count ON true
+          WHERE session.status IN ('OPEN', 'APPROVED')
+            AND latest_count.counted_qty IS NOT NULL
+            AND ABS(latest_count.counted_qty - snapshot.theoretical_qty) > 1e-9
+            AND (
+              $${currentValues.length + 1}::uuid IS NULL
+              OR snapshot.magasin_id = $${currentValues.length + 1}::uuid
+            )
+        )
+        SELECT
+          stock_alerts.ruptures_count,
+          stock_alerts.below_minimum_count,
+          reservation_alerts.at_risk_reservations_count,
+          stock_alerts.quarantine_lots_count,
+          inventory_alerts.active_inventory_count,
+          discrepancy_alerts.discrepancies_to_review_count
+        FROM stock_alerts
+        CROSS JOIN reservation_alerts
+        CROSS JOIN inventory_alerts
+        CROSS JOIN discrepancy_alerts
+      `,
+      [...currentValues, filters.magasin_id ?? null]
     ),
     db.query<{ id: string; code: string; name: string }>(
       `
@@ -3784,7 +4798,7 @@ export async function repoGetStockAnalytics(filters: ListAnalyticsQueryDTO): Pro
             b.article_id,
             SUM(b.qty_total)::float8 AS qty_on_hand,
             SUM(b.qty_available)::float8 AS qty_available
-          FROM public.v_stock_current b
+            FROM public.v_stock_availability_225 b
           LEFT JOIN public.emplacements e ON e.location_id = b.location_id
           ${currentWhereSqlCombined}
           GROUP BY b.article_id
@@ -3808,14 +4822,30 @@ export async function repoGetStockAnalytics(filters: ListAnalyticsQueryDTO): Pro
   ]);
 
   return {
-    kpis:
-      kpisRes.rows[0] ?? {
+    authoritative: true,
+    as_of: new Date().toISOString(),
+    scope: {
+      magasin_id: filters.magasin_id ?? null,
+      from: filters.from ?? null,
+      to: filters.to ?? null,
+    },
+    kpis: {
+      ...(kpisRes.rows[0] ?? {
         articles_count: 0,
         stock_managed_articles: 0,
         qty_on_hand: 0,
         qty_available: 0,
         qty_reserved: 0,
-      },
+      }),
+      ...(cockpitRes.rows[0] ?? {
+        ruptures_count: 0,
+        below_minimum_count: 0,
+        at_risk_reservations_count: 0,
+        quarantine_lots_count: 0,
+        active_inventory_count: 0,
+        discrepancies_to_review_count: 0,
+      }),
+    },
     magasins: magasinsRes.rows,
     category_counts: categoriesRes.rows,
     series: {
@@ -3870,6 +4900,8 @@ export async function repoListMovements(filters: ListMovementsQueryDTO): Promise
       m.source_document_type,
       m.source_document_id,
       m.reason_code,
+      m.correlation_id::text AS correlation_id,
+      m.reversal_of_id::text AS reversal_of_id,
       m.updated_at::text AS updated_at,
       m.created_at::text AS created_at,
       COALESCE(ml.lines_count, 0)::int AS lines_count
@@ -3909,6 +4941,8 @@ export async function repoGetMovement(id: string): Promise<StockMovementDetail |
         source_document_type,
         source_document_id,
         reason_code,
+        correlation_id::text AS correlation_id,
+        reversal_of_id::text AS reversal_of_id,
         notes,
         created_at::text AS created_at,
         updated_at::text AS updated_at,
@@ -4006,10 +5040,599 @@ export async function repoGetMovement(id: string): Promise<StockMovementDetail |
   };
 }
 
-export async function repoCreateMovement(body: CreateMovementBodyDTO, audit: AuditContext): Promise<StockMovementDetail> {
+export async function repoPreviewMovement(
+  body: CreateMovementBodyDTO
+): Promise<StockMovementImpactPreview> {
+  assertSameArticle(body.lines);
+  assertConsistentLocations(body.lines, body.movement_type);
+  if (body.movement_type === "RESERVE" || body.movement_type === "UNRESERVE") {
+    throw new HttpError(
+      422,
+      "USE_RESERVATION_API",
+      "Reservations are non-physical allocations and must use the stock reservation API"
+    );
+  }
+
+  const articleId = body.lines[0]?.article_id;
+  const first = body.lines[0];
+  if (!articleId || !first) throw new HttpError(400, "INVALID_MOVEMENT", "Missing movement lines");
+  await ensureArticleStockManaged(db, articleId);
+  await ensureLotTrackingRespected(db, articleId, body.lines);
+  const lotId = assertSameLotIfSet(body.lines);
+  const totalQty = sumQty(body.lines);
+  if (!Number.isFinite(totalQty) || totalQty <= 0) {
+    throw new HttpError(400, "INVALID_MOVEMENT", "Movement quantity must be positive");
+  }
+
+  let lotStatus: StockLotQualityStatus = null;
+  if (lotId) {
+    const lot = await db.query<{ lot_status: StockLotQualityStatus }>(
+      `
+        SELECT lot_status
+        FROM public.lots
+        WHERE id = $1::uuid
+          AND article_id = $2::uuid
+      `,
+      [lotId, articleId]
+    );
+    const row = lot.rows[0] ?? null;
+    if (!row) throw new HttpError(409, "LOT_ARTICLE_MISMATCH", "Lot does not belong to article");
+    lotStatus = row.lot_status ?? "LIBERE";
+  }
+
+  const readState = async (locationId: string): Promise<LockedStockState> => {
+    const state = await db.query<{
+      stock_level_id: string;
+      stock_batch_id: string | null;
+      qty_on_hand: number;
+      qty_reserved: number;
+      qty_depreciated: number;
+      lot_status: StockLotQualityStatus;
+    }>(
+      `
+        SELECT
+          stock_level_id::text AS stock_level_id,
+          stock_batch_id::text AS stock_batch_id,
+          qty_on_hand::float8 AS qty_on_hand,
+          qty_reserved::float8 AS qty_reserved,
+          qty_depreciated::float8 AS qty_depreciated,
+          lot_status
+        FROM public.v_stock_availability_225
+        WHERE article_id = $1::uuid
+          AND location_id = $2::uuid
+          AND lot_id IS NOT DISTINCT FROM $3::uuid
+        LIMIT 1
+      `,
+      [articleId, locationId, lotId]
+    );
+    return (
+      state.rows[0] ?? {
+        stock_level_id: "00000000-0000-0000-0000-000000000000",
+        stock_batch_id: null,
+        qty_on_hand: 0,
+        qty_reserved: 0,
+        qty_depreciated: 0,
+        lot_status: lotStatus,
+      }
+    );
+  };
+
+  const impacts: StockMovementImpactPreview["impacts"] = [];
+  const blockers: StockMovementImpactPreview["blockers"] = [];
+  const addImpact = async (
+    side: "SOURCE" | "DESTINATION",
+    magasinId: string,
+    emplacementId: number,
+    effect:
+      | "IN"
+      | "OUT"
+      | "DEPRECIATE"
+      | "ADJUSTMENT_IN"
+      | "ADJUSTMENT_OUT"
+  ) => {
+    const mapping = await getEmplacementMapping(
+      db,
+      magasinId,
+      emplacementId,
+      side === "SOURCE" ? "src" : "dst"
+    );
+    const state = await readState(mapping.location_id);
+    const before = calculateStockAvailability(state);
+    if (side === "SOURCE") {
+      try {
+        assertStockConsumptionAllowed(state, {
+          movement_type: body.movement_type,
+          qty: effect === "ADJUSTMENT_OUT" ? -totalQty : totalQty,
+        });
+      } catch (error) {
+        if (error instanceof HttpError) {
+          blockers.push({ code: error.code, message: error.message });
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    const afterInput = {
+      qty_on_hand: state.qty_on_hand,
+      qty_reserved: state.qty_reserved,
+      qty_depreciated: state.qty_depreciated,
+      lot_status: state.lot_status,
+    };
+    if (effect === "IN" || effect === "ADJUSTMENT_IN") {
+      afterInput.qty_on_hand += totalQty;
+    } else if (effect === "OUT" || effect === "ADJUSTMENT_OUT") {
+      afterInput.qty_on_hand -= totalQty;
+    } else if (effect === "DEPRECIATE") {
+      afterInput.qty_depreciated += totalQty;
+    }
+
+    impacts.push({
+      side,
+      magasin_id: magasinId,
+      emplacement_id: emplacementId,
+      lot_id: lotId,
+      before,
+      after: calculateStockAvailability(afterInput),
+    });
+  };
+
+  if (body.movement_type === "IN") {
+    if (!first.dst_magasin_id || !first.dst_emplacement_id) {
+      throw new HttpError(400, "INVALID_MOVEMENT", "IN requires destination location");
+    }
+    await addImpact("DESTINATION", first.dst_magasin_id, first.dst_emplacement_id, "IN");
+  } else if (body.movement_type === "TRANSFER") {
+    if (
+      !first.src_magasin_id ||
+      !first.src_emplacement_id ||
+      !first.dst_magasin_id ||
+      !first.dst_emplacement_id
+    ) {
+      throw new HttpError(400, "INVALID_MOVEMENT", "TRANSFER requires source and destination");
+    }
+    await addImpact("SOURCE", first.src_magasin_id, first.src_emplacement_id, "OUT");
+    await addImpact("DESTINATION", first.dst_magasin_id, first.dst_emplacement_id, "IN");
+  } else if (body.movement_type === "ADJUST" || body.movement_type === "ADJUSTMENT") {
+    if (first.direction === "IN") {
+      if (!first.dst_magasin_id || !first.dst_emplacement_id) {
+        throw new HttpError(400, "INVALID_MOVEMENT", "ADJUSTMENT IN requires destination");
+      }
+      await addImpact(
+        "DESTINATION",
+        first.dst_magasin_id,
+        first.dst_emplacement_id,
+        "ADJUSTMENT_IN"
+      );
+    } else {
+      if (!first.src_magasin_id || !first.src_emplacement_id) {
+        throw new HttpError(400, "INVALID_MOVEMENT", "ADJUSTMENT OUT requires source");
+      }
+      await addImpact("SOURCE", first.src_magasin_id, first.src_emplacement_id, "ADJUSTMENT_OUT");
+    }
+  } else {
+    if (!first.src_magasin_id || !first.src_emplacement_id) {
+      throw new HttpError(400, "INVALID_MOVEMENT", `${body.movement_type} requires source`);
+    }
+    await addImpact(
+      "SOURCE",
+      first.src_magasin_id,
+      first.src_emplacement_id,
+      body.movement_type === "DEPRECIATE" || body.movement_type === "SCRAP"
+        ? "DEPRECIATE"
+        : "OUT"
+    );
+  }
+
+  return {
+    authoritative: true,
+    as_of: new Date().toISOString(),
+    movement_type: body.movement_type,
+    qty_total: totalQty,
+    can_post: blockers.length === 0,
+    blockers,
+    impacts,
+  };
+}
+
+function buildCompensatingMovementBody(
+  detail: StockMovementDetail,
+  body: CompensateMovementBodyDTO
+): { movement: CreateMovementBodyDTO | null; blockers: Array<{ code: string; message: string }> } {
+  const blockers: Array<{ code: string; message: string }> = [];
+  if (detail.movement.status !== "POSTED") {
+    blockers.push({ code: "INVALID_STATUS", message: "Only POSTED movements can be compensated" });
+  }
+  if (!detail.movement.posted_at) {
+    blockers.push({ code: "POSTED_AT_MISSING", message: "Posted movement timestamp is missing" });
+  } else if (
+    new Date(detail.movement.posted_at).getTime() !== new Date(body.expected_posted_at).getTime()
+  ) {
+    blockers.push({
+      code: "CONCURRENT_MODIFICATION",
+      message: "Movement posting timestamp no longer matches the preview",
+    });
+  }
+  if (!detail.lines.length) {
+    blockers.push({ code: "MOVEMENT_LINES_MISSING", message: "Movement has no traceable lines" });
+  }
+  if (
+    detail.movement.movement_type === "SCRAP" ||
+    detail.movement.movement_type === "DEPRECIATE"
+  ) {
+    blockers.push({
+      code: "QUALITY_FLOW_REQUIRED",
+      message: "Scrap and depreciation reversals require a dedicated quality decision",
+    });
+  }
+  if (
+    detail.movement.movement_type === "RESERVE" ||
+    detail.movement.movement_type === "UNRESERVE"
+  ) {
+    blockers.push({
+      code: "RESERVATION_FLOW_REQUIRED",
+      message: "Reservation corrections must use the reservation lifecycle",
+    });
+  }
+  if (blockers.length) return { movement: null, blockers };
+
+  let reverseType: CreateMovementBodyDTO["movement_type"];
+  switch (detail.movement.movement_type) {
+    case "IN":
+      reverseType = "OUT";
+      break;
+    case "OUT":
+      reverseType = "IN";
+      break;
+    case "TRANSFER":
+      reverseType = "TRANSFER";
+      break;
+    case "ADJUST":
+    case "ADJUSTMENT":
+      reverseType = "ADJUSTMENT";
+      break;
+    default:
+      return {
+        movement: null,
+        blockers: [{ code: "MOVEMENT_NOT_COMPENSABLE", message: "Movement type cannot be compensated" }],
+      };
+  }
+
+  const reverseLines: CreateMovementLineDTO[] = detail.lines.map((line) => {
+    const base = {
+      line_no: line.line_no,
+      article_id: line.article_id,
+      lot_id: line.lot_id,
+      qty: Math.abs(line.qty),
+      unite: line.unite,
+      unit_cost: line.unit_cost,
+      currency: line.currency,
+      note: `Compensation ${detail.movement.movement_no ?? detail.movement.id}`,
+    };
+    if (reverseType === "OUT") {
+      return {
+        ...base,
+        src_magasin_id: line.dst_magasin_id,
+        src_emplacement_id: line.dst_emplacement_id,
+        dst_magasin_id: null,
+        dst_emplacement_id: null,
+      };
+    }
+    if (reverseType === "IN") {
+      return {
+        ...base,
+        src_magasin_id: null,
+        src_emplacement_id: null,
+        dst_magasin_id: line.src_magasin_id,
+        dst_emplacement_id: line.src_emplacement_id,
+      };
+    }
+    if (reverseType === "TRANSFER") {
+      return {
+        ...base,
+        src_magasin_id: line.dst_magasin_id,
+        src_emplacement_id: line.dst_emplacement_id,
+        dst_magasin_id: line.src_magasin_id,
+        dst_emplacement_id: line.src_emplacement_id,
+      };
+    }
+
+    const originalWasInbound = detail.movement.qty > 0;
+    return originalWasInbound
+      ? {
+          ...base,
+          src_magasin_id: line.dst_magasin_id,
+          src_emplacement_id: line.dst_emplacement_id,
+          dst_magasin_id: null,
+          dst_emplacement_id: null,
+          direction: "OUT" as const,
+        }
+      : {
+          ...base,
+          src_magasin_id: null,
+          src_emplacement_id: null,
+          dst_magasin_id: line.src_magasin_id,
+          dst_emplacement_id: line.src_emplacement_id,
+          direction: "IN" as const,
+        };
+  });
+
+  return {
+    blockers,
+    movement: {
+      movement_type: reverseType,
+      effective_at: new Date().toISOString(),
+      source_document_type: "STOCK_COMPENSATION",
+      source_document_id: detail.movement.id,
+      reason_code: "COMPENSATION",
+      notes:
+        body.notes ??
+        `${body.reason} — compensation de ${detail.movement.movement_no ?? detail.movement.id}`,
+      idempotency_key: null,
+      lines: reverseLines,
+    },
+  };
+}
+
+export async function repoPreviewMovementCompensation(
+  id: string,
+  body: CompensateMovementBodyDTO
+): Promise<StockMovementCompensationPreview | null> {
+  const detail = await repoGetMovement(id);
+  if (!detail) return null;
+  const existing = await db.query<{ id: string; movement_no: string | null; status: string }>(
+    `
+      SELECT id::text AS id, movement_no, status
+      FROM public.stock_movements
+      WHERE reversal_of_id = $1::uuid
+        AND status::text <> 'CANCELLED'
+      LIMIT 1
+    `,
+    [id]
+  );
+  const built = buildCompensatingMovementBody(detail, body);
+  if (existing.rows[0]) {
+    built.blockers.push({
+      code: "COMPENSATION_ALREADY_EXISTS",
+      message: `A ${existing.rows[0].status} compensation already exists`,
+    });
+  }
+  const proposed = built.movement
+    ? {
+        movement_type: built.movement.movement_type,
+        source_document_type: "STOCK_COMPENSATION" as const,
+        source_document_id: id,
+        reason_code: "COMPENSATION" as const,
+        notes: built.movement.notes ?? body.reason,
+        lines: built.movement.lines.map((line) => ({
+          article_id: line.article_id,
+          lot_id: line.lot_id ?? null,
+          qty: line.qty,
+          unite: line.unite ?? null,
+          src_magasin_id: line.src_magasin_id ?? null,
+          src_emplacement_id: line.src_emplacement_id ?? null,
+          dst_magasin_id: line.dst_magasin_id ?? null,
+          dst_emplacement_id: line.dst_emplacement_id ?? null,
+          ...(line.direction ? { direction: line.direction } : {}),
+        })),
+      }
+    : null;
+
+  return {
+    original_movement_id: id,
+    original_movement_no: detail.movement.movement_no,
+    compensable: built.blockers.length === 0,
+    blockers: built.blockers,
+    proposed_movement: proposed,
+  };
+}
+
+export async function repoCompensateMovement(
+  id: string,
+  body: CompensateMovementBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockMovementDetail | null> {
+  const key = normalizeIdempotencyKey(idempotencyKey);
+  const lockClient = await db.connect();
+  let sessionLockHeld = false;
+  try {
+    await lockClient.query(`SELECT pg_advisory_lock(hashtextextended($1, 0))`, [
+      `stock-compensation:${id}`,
+    ]);
+    sessionLockHeld = true;
+
+    await lockClient.query("BEGIN");
+    const existingCommand = await beginStockCommand(lockClient, {
+      audit,
+      idempotency_key: key,
+      command_type: "MOVEMENT_COMPENSATE",
+      request_payload: { movement_id: id, ...body },
+    });
+    if (existingCommand.existing) {
+      await lockClient.query("COMMIT");
+      return repoGetMovement(existingCommand.existing.resource_id);
+    }
+    await lockClient.query("COMMIT");
+
+    const preview = await repoPreviewMovementCompensation(id, body);
+    if (!preview) return null;
+    if (!preview.compensable || !preview.proposed_movement) {
+      const blocker = preview.blockers[0] ?? {
+        code: "MOVEMENT_NOT_COMPENSABLE",
+        message: "Movement cannot be compensated",
+      };
+      throw new HttpError(409, blocker.code, blocker.message, { blockers: preview.blockers });
+    }
+
+    const detail = await repoGetMovement(id);
+    if (!detail) return null;
+    const built = buildCompensatingMovementBody(detail, body);
+    if (!built.movement) {
+      throw new HttpError(409, "MOVEMENT_NOT_COMPENSABLE", "Movement cannot be compensated");
+    }
+    const derivedKeyHash = hashStockCommand("MOVEMENT_COMPENSATION_CREATE_KEY", {
+      actor_user_id: audit.user_id,
+      idempotency_key: key,
+    });
+    const compensation = await repoCreateMovement(
+      {
+        ...built.movement,
+        idempotency_key: `comp-create-${derivedKeyHash}`,
+      },
+      audit,
+      { trusted_source_flow: true }
+    );
+
+    await lockClient.query("BEGIN");
+    const command = await beginStockCommand(lockClient, {
+      audit,
+      idempotency_key: key,
+      command_type: "MOVEMENT_COMPENSATE",
+      request_payload: { movement_id: id, ...body },
+    });
+    if (command.existing) {
+      await lockClient.query("COMMIT");
+      return repoGetMovement(command.existing.resource_id);
+    }
+
+    const locked = await lockClient.query<{ original_status: string; compensation_status: string }>(
+      `
+        SELECT
+          original.status::text AS original_status,
+          compensation.status::text AS compensation_status
+        FROM public.stock_movements original
+        JOIN public.stock_movements compensation ON compensation.id = $2::uuid
+        WHERE original.id = $1::uuid
+        FOR UPDATE OF original, compensation
+      `,
+      [id, compensation.movement.id]
+    );
+    const state = locked.rows[0] ?? null;
+    if (!state) throw new HttpError(409, "MOVEMENT_MISSING", "Movement disappeared during compensation");
+    if (state.original_status !== "POSTED" || state.compensation_status !== "DRAFT") {
+      throw new HttpError(409, "INVALID_STATUS", "Compensation status changed concurrently");
+    }
+
+    await lockClient.query(
+      `
+        UPDATE public.stock_movements
+        SET
+          reversal_of_id = $2::uuid,
+          correlation_id = $3::uuid,
+          updated_at = now(),
+          updated_by = $4
+        WHERE id = $1::uuid
+      `,
+      [compensation.movement.id, id, command.correlation_id, audit.user_id]
+    );
+    await insertMovementEvent(lockClient, {
+      movement_id: id,
+      event_type: "COMPENSATION_PREPARED",
+      old_values: null,
+      new_values: {
+        compensation_movement_id: compensation.movement.id,
+        correlation_id: command.correlation_id,
+      },
+      user_id: audit.user_id,
+    });
+    await insertMovementEvent(lockClient, {
+      movement_id: compensation.movement.id,
+      event_type: "LINKED_AS_COMPENSATION",
+      old_values: null,
+      new_values: {
+        reversal_of_id: id,
+        correlation_id: command.correlation_id,
+      },
+      user_id: audit.user_id,
+    });
+    await insertAuditLog(lockClient, audit, {
+      action: "stock.movements.compensation.prepare",
+      entity_type: "stock_movements",
+      entity_id: compensation.movement.id,
+      details: {
+        reversal_of_id: id,
+        reason: body.reason,
+        correlation_id: command.correlation_id,
+      },
+    });
+    await completeStockCommand(lockClient, {
+      audit,
+      command,
+      command_type: "MOVEMENT_COMPENSATE",
+      resource_type: "stock_movement",
+      resource_id: compensation.movement.id,
+      result_payload: {
+        compensation_movement_id: compensation.movement.id,
+        reversal_of_id: id,
+        status: "DRAFT",
+      },
+    });
+    await lockClient.query("COMMIT");
+    return repoGetMovement(compensation.movement.id);
+  } catch (error) {
+    await lockClient.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    if (sessionLockHeld) {
+      await lockClient
+        .query(`SELECT pg_advisory_unlock(hashtextextended($1, 0))`, [`stock-compensation:${id}`])
+        .catch(() => undefined);
+    }
+    lockClient.release();
+  }
+}
+
+export async function repoCreateMovement(
+  body: CreateMovementBodyDTO,
+  audit: AuditContext,
+  options: { trusted_source_flow?: boolean } = {}
+): Promise<StockMovementDetail> {
   const client = await db.connect();
   try {
     await client.query("BEGIN");
+
+    const { idempotency_key: _bodyIdempotencyKey, ...requestPayload } = body;
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: body.idempotency_key ?? "",
+      command_type: "MOVEMENT_CREATE",
+      request_payload: requestPayload,
+    });
+    if (command.existing) {
+      const existingId = command.existing.resource_id;
+      await client.query("COMMIT");
+      const existing = await repoGetMovement(existingId);
+      if (!existing) throw new Error("Idempotent movement receipt points to a missing movement");
+      return existing;
+    }
+
+    if (body.movement_type === "RESERVE" || body.movement_type === "UNRESERVE") {
+      throw new HttpError(
+        422,
+        "USE_RESERVATION_API",
+        "Reservations are non-physical allocations and must use the stock reservation API"
+      );
+    }
+    const protectedSourceTypes = new Set([
+      "OF",
+      "PRODUCTION_RECEIPT",
+      "SUPPLIER_RECEIPT",
+      "RECEPTION_FOURNISSEUR",
+      "BON_LIVRAISON",
+      "DELIVERY",
+    ]);
+    if (
+      !options.trusted_source_flow &&
+      body.source_document_type &&
+      protectedSourceTypes.has(body.source_document_type.trim().toUpperCase())
+    ) {
+      throw new HttpError(
+        422,
+        "CANONICAL_SOURCE_FLOW_REQUIRED",
+        "This stock source must be posted by its owning production, supplier-receipt or delivery service"
+      );
+    }
 
     assertSameArticle(body.lines);
     assertConsistentLocations(body.lines, body.movement_type);
@@ -4051,8 +5674,6 @@ export async function repoCreateMovement(body: CreateMovementBodyDTO, audit: Aud
       qtyForMovement = totalQty;
     } else if (
       body.movement_type === "OUT" ||
-      body.movement_type === "RESERVE" ||
-      body.movement_type === "UNRESERVE" ||
       body.movement_type === "DEPRECIATE" ||
       body.movement_type === "SCRAP"
     ) {
@@ -4140,15 +5761,17 @@ export async function repoCreateMovement(body: CreateMovementBodyDTO, audit: Aud
         reason_code,
         notes,
         idempotency_key,
+        correlation_id,
         user_id,
         created_by,
         updated_by
       )
-      VALUES ($1,$2::public.movement_type,'DRAFT',$3::uuid,$4::uuid,$5::uuid,$6,'EUR',$7,$8,$9,$10,$11,$12,$13,$13,$13)
+      VALUES ($1,$2::public.movement_type,'DRAFT',$3::uuid,$4::uuid,$5::uuid,$6,'EUR',$7,$8,$9,$10,$11,$12,$13::uuid,$14,$14,$14)
       RETURNING id::text AS id
     `;
 
     let movementId: string;
+    const storedIdempotencyKey = `${audit.user_id}:${command.key}`;
     try {
       const ins = await client.query<{ id: string }>(insertMovementSql, [
         movementNo,
@@ -4162,19 +5785,32 @@ export async function repoCreateMovement(body: CreateMovementBodyDTO, audit: Aud
         body.source_document_id ?? null,
         body.reason_code ?? null,
         body.notes ?? null,
-        body.idempotency_key ?? null,
+        storedIdempotencyKey,
+        command.correlation_id,
         audit.user_id,
       ]);
       movementId = ins.rows[0]?.id ?? "";
       if (!movementId) throw new Error("Failed to create movement");
     } catch (err) {
-      if (body.idempotency_key && isPgUniqueViolation(err)) {
+      if (isPgUniqueViolation(err)) {
         const existing = await client.query<{ id: string }>(
           `SELECT id::text AS id FROM public.stock_movements WHERE idempotency_key = $1`,
-          [body.idempotency_key]
+          [storedIdempotencyKey]
         );
         const id = existing.rows[0]?.id;
         if (!id) throw err;
+        await completeStockCommand(client, {
+          audit,
+          command,
+          command_type: "MOVEMENT_CREATE",
+          resource_type: "stock_movement",
+          resource_id: id,
+          result_payload: {
+            movement_id: id,
+            status: "DRAFT",
+            legacy_idempotency_recovery: true,
+          },
+        });
         await client.query("COMMIT");
         const out = await repoGetMovement(id);
         if (!out) throw new Error("Failed to read existing idempotent movement");
@@ -4260,6 +5896,20 @@ export async function repoCreateMovement(body: CreateMovementBodyDTO, audit: Aud
         movement_type: body.movement_type,
         lines_count: body.lines.length,
         idempotency_key: body.idempotency_key ?? null,
+        correlation_id: command.correlation_id,
+      },
+    });
+
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: "MOVEMENT_CREATE",
+      resource_type: "stock_movement",
+      resource_id: movementId,
+      result_payload: {
+        movement_id: movementId,
+        movement_no: movementNo,
+        status: "DRAFT",
       },
     });
 
@@ -4275,10 +5925,27 @@ export async function repoCreateMovement(body: CreateMovementBodyDTO, audit: Aud
   }
 }
 
-export async function repoPostMovement(id: string, audit: AuditContext): Promise<StockMovementDetail | null> {
+export async function repoPostMovement(
+  id: string,
+  body: PostMovementBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockMovementDetail | null> {
   const client = await db.connect();
   try {
     await client.query("BEGIN");
+
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: idempotencyKey,
+      command_type: "MOVEMENT_POST",
+      request_payload: { movement_id: id, ...body },
+    });
+    if (command.existing) {
+      const existingId = command.existing.resource_id;
+      await client.query("COMMIT");
+      return repoGetMovement(existingId);
+    }
 
     const lock = await client.query<{
       id: string;
@@ -4287,6 +5954,9 @@ export async function repoPostMovement(id: string, audit: AuditContext): Promise
       movement_no: string | null;
       effective_at: string;
       article_id: string;
+      stock_level_id: string;
+      stock_batch_id: string | null;
+      qty: number;
       notes: string | null;
     }>(
       `
@@ -4297,6 +5967,9 @@ export async function repoPostMovement(id: string, audit: AuditContext): Promise
           movement_no,
           effective_at::text AS effective_at,
           article_id::text AS article_id,
+          stock_level_id::text AS stock_level_id,
+          stock_batch_id::text AS stock_batch_id,
+          qty::float8 AS qty,
           notes
         FROM public.stock_movements
         WHERE id = $1::uuid
@@ -4382,6 +6055,20 @@ export async function repoPostMovement(id: string, audit: AuditContext): Promise
       const srcBatchId = uniformLotId ? await ensureStockBatchId(client, { stock_level_id: srcStockLevelId, lot_id: uniformLotId }) : null;
       const dstBatchId = uniformLotId ? await ensureStockBatchId(client, { stock_level_id: dstStockLevelId, lot_id: uniformLotId }) : null;
 
+      const lockedStates = await lockStockStates(client, [
+        { stock_level_id: srcStockLevelId, stock_batch_id: srcBatchId },
+        { stock_level_id: dstStockLevelId, stock_batch_id: dstBatchId },
+      ]);
+      const sourceState = lockedStates.get(
+        stockTargetKey({ stock_level_id: srcStockLevelId, stock_batch_id: srcBatchId })
+      );
+      if (!sourceState) throw new Error("Locked transfer source state missing");
+      assertStockConsumptionAllowed(sourceState, {
+        movement_type: "TRANSFER",
+        qty: totalQty,
+        negative_stock_override: body.negative_stock_override,
+      });
+
       const postedAt = new Date().toISOString();
       const outMovementNo = await reserveMovementNo(client);
       const inMovementNo = await reserveMovementNo(client);
@@ -4402,15 +6089,28 @@ export async function repoPostMovement(id: string, audit: AuditContext): Promise
             posted_by,
             doc_type,
             doc_id,
+            correlation_id,
             notes,
             user_id,
             created_by,
             updated_by
           )
-          VALUES ($1,'OUT','POSTED',$2::uuid,$3::uuid,$4::uuid,$5,'EUR',$6,$7,$8,'STOCK_TRANSFER_INTERNAL',$9::uuid,$10,$8,$8,$8)
+          VALUES ($1,'OUT','POSTED',$2::uuid,$3::uuid,$4::uuid,$5,'EUR',$6,$7,$8,'STOCK_TRANSFER_INTERNAL',$9::uuid,$10::uuid,$11,$8,$8,$8)
           RETURNING id::text AS id
         `,
-        [outMovementNo, m.article_id, srcStockLevelId, srcBatchId, totalQty, m.effective_at, postedAt, audit.user_id, id, m.notes ?? null]
+        [
+          outMovementNo,
+          m.article_id,
+          srcStockLevelId,
+          srcBatchId,
+          totalQty,
+          m.effective_at,
+          postedAt,
+          audit.user_id,
+          id,
+          command.correlation_id,
+          m.notes ?? null,
+        ]
       );
       const outMovementId = outMovement.rows[0]?.id;
       if (!outMovementId) throw new Error("Failed to create OUT transfer movement");
@@ -4431,15 +6131,28 @@ export async function repoPostMovement(id: string, audit: AuditContext): Promise
             posted_by,
             doc_type,
             doc_id,
+            correlation_id,
             notes,
             user_id,
             created_by,
             updated_by
           )
-          VALUES ($1,'IN','POSTED',$2::uuid,$3::uuid,$4::uuid,$5,'EUR',$6,$7,$8,'STOCK_TRANSFER_INTERNAL',$9::uuid,$10,$8,$8,$8)
+          VALUES ($1,'IN','POSTED',$2::uuid,$3::uuid,$4::uuid,$5,'EUR',$6,$7,$8,'STOCK_TRANSFER_INTERNAL',$9::uuid,$10::uuid,$11,$8,$8,$8)
           RETURNING id::text AS id
         `,
-        [inMovementNo, m.article_id, dstStockLevelId, dstBatchId, totalQty, m.effective_at, postedAt, audit.user_id, id, m.notes ?? null]
+        [
+          inMovementNo,
+          m.article_id,
+          dstStockLevelId,
+          dstBatchId,
+          totalQty,
+          m.effective_at,
+          postedAt,
+          audit.user_id,
+          id,
+          command.correlation_id,
+          m.notes ?? null,
+        ]
       );
       const inMovementId = inMovement.rows[0]?.id;
       if (!inMovementId) throw new Error("Failed to create IN transfer movement");
@@ -4522,10 +6235,16 @@ export async function repoPostMovement(id: string, audit: AuditContext): Promise
       await client.query(
         `
           UPDATE public.stock_movements
-          SET status = 'POSTED', posted_at = now(), posted_by = $2, updated_at = now(), updated_by = $2
+          SET
+            status = 'POSTED',
+            posted_at = now(),
+            posted_by = $2,
+            correlation_id = $3::uuid,
+            updated_at = now(),
+            updated_by = $2
           WHERE id = $1::uuid
         `,
-        [id, audit.user_id]
+        [id, audit.user_id, command.correlation_id]
       );
 
       await insertMovementEvent(client, {
@@ -4543,6 +6262,13 @@ export async function repoPostMovement(id: string, audit: AuditContext): Promise
         details: {
           movement_no: m.movement_no,
           movement_type: "TRANSFER",
+          negative_stock_override: body.negative_stock_override
+            ? {
+                maximum_negative_qty:
+                  body.negative_stock_override.maximum_negative_qty,
+                reason: body.negative_stock_override.reason,
+              }
+            : null,
           legs: [
             { movement_id: outMovementId, movement_no: outMovementNo, movement_type: "OUT" },
             { movement_id: inMovementId, movement_no: inMovementNo, movement_type: "IN" },
@@ -4550,24 +6276,61 @@ export async function repoPostMovement(id: string, audit: AuditContext): Promise
         },
       });
 
+      await completeStockCommand(client, {
+        audit,
+        command,
+        command_type: "MOVEMENT_POST",
+        resource_type: "stock_movement",
+        resource_id: id,
+        result_payload: {
+          movement_id: id,
+          status: "POSTED",
+          movement_type: "TRANSFER",
+          out_movement_id: outMovementId,
+          in_movement_id: inMovementId,
+        },
+      });
+
       await client.query("COMMIT");
       return repoGetMovement(id);
     }
 
+    const lockedStates = await lockStockStates(client, [
+      { stock_level_id: m.stock_level_id, stock_batch_id: m.stock_batch_id },
+    ]);
+    const sourceState = lockedStates.get(
+      stockTargetKey({ stock_level_id: m.stock_level_id, stock_batch_id: m.stock_batch_id })
+    );
+    if (!sourceState) throw new Error("Locked stock state missing");
+    assertStockConsumptionAllowed(sourceState, {
+      movement_type: m.movement_type,
+      qty: m.qty,
+      negative_stock_override: body.negative_stock_override,
+    });
+
     await client.query(
       `
         UPDATE public.stock_movements
-        SET status = 'POSTED', posted_at = now(), posted_by = $2, updated_at = now(), updated_by = $2
+        SET
+          status = 'POSTED',
+          posted_at = now(),
+          posted_by = $2,
+          correlation_id = $3::uuid,
+          updated_at = now(),
+          updated_by = $2
         WHERE id = $1::uuid
       `,
-      [id, audit.user_id]
+      [id, audit.user_id, command.correlation_id]
     );
 
     await insertMovementEvent(client, {
       movement_id: id,
       event_type: "POSTED",
       old_values: { status: "DRAFT" },
-      new_values: { status: "POSTED" },
+      new_values: {
+        status: "POSTED",
+        negative_stock_override: body.negative_stock_override ?? null,
+      },
       user_id: audit.user_id,
     });
 
@@ -4575,7 +6338,24 @@ export async function repoPostMovement(id: string, audit: AuditContext): Promise
       action: "stock.movements.post",
       entity_type: "stock_movements",
       entity_id: id,
-      details: { movement_no: m.movement_no, movement_type: m.movement_type },
+      details: {
+        movement_no: m.movement_no,
+        movement_type: m.movement_type,
+        negative_stock_override: body.negative_stock_override ?? null,
+      },
+    });
+
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: "MOVEMENT_POST",
+      resource_type: "stock_movement",
+      resource_id: id,
+      result_payload: {
+        movement_id: id,
+        status: "POSTED",
+        movement_type: m.movement_type,
+      },
     });
 
     await client.query("COMMIT");
@@ -4588,10 +6368,26 @@ export async function repoPostMovement(id: string, audit: AuditContext): Promise
   }
 }
 
-export async function repoCancelMovement(id: string, audit: AuditContext): Promise<StockMovementDetail | null> {
+export async function repoCancelMovement(
+  id: string,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockMovementDetail | null> {
   const client = await db.connect();
   try {
     await client.query("BEGIN");
+
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: idempotencyKey,
+      command_type: "MOVEMENT_CANCEL",
+      request_payload: { movement_id: id },
+    });
+    if (command.existing) {
+      const existingId = command.existing.resource_id;
+      await client.query("COMMIT");
+      return repoGetMovement(existingId);
+    }
 
     const lock = await client.query<{ status: string; movement_no: string | null }>(
       `SELECT status, movement_no FROM public.stock_movements WHERE id = $1::uuid FOR UPDATE`,
@@ -4607,8 +6403,16 @@ export async function repoCancelMovement(id: string, audit: AuditContext): Promi
     }
 
     await client.query(
-      `UPDATE public.stock_movements SET status = 'CANCELLED', updated_at = now(), updated_by = $2 WHERE id = $1::uuid`,
-      [id, audit.user_id]
+      `
+        UPDATE public.stock_movements
+        SET
+          status = 'CANCELLED',
+          correlation_id = $3::uuid,
+          updated_at = now(),
+          updated_by = $2
+        WHERE id = $1::uuid
+      `,
+      [id, audit.user_id, command.correlation_id]
     );
 
     await insertMovementEvent(client, {
@@ -4624,6 +6428,18 @@ export async function repoCancelMovement(id: string, audit: AuditContext): Promi
       entity_type: "stock_movements",
       entity_id: id,
       details: { movement_no: m.movement_no },
+    });
+
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: "MOVEMENT_CANCEL",
+      resource_type: "stock_movement",
+      resource_id: id,
+      result_payload: {
+        movement_id: id,
+        status: "CANCELLED",
+      },
     });
 
     await client.query("COMMIT");
@@ -5103,6 +6919,18 @@ export async function repoListInventorySessions(
       s.id::text AS id,
       s.session_no,
       s.status,
+      s.scope_magasin_id::text AS scope_magasin_id,
+      s.scope_emplacement_id::int AS scope_emplacement_id,
+      s.scope_article_id::text AS scope_article_id,
+      s.scope_article_category,
+      s.blind_count,
+      s.requires_second_count,
+      s.snapshot_at::text AS snapshot_at,
+      s.approved_at::text AS approved_at,
+      s.cancelled_at::text AS cancelled_at,
+      s.cancellation_reason,
+      s.row_version::int AS row_version,
+      s.correlation_id::text AS correlation_id,
       s.started_at::text AS started_at,
       s.closed_at::text AS closed_at,
       s.notes,
@@ -5135,20 +6963,59 @@ export async function repoListInventorySessions(
 
 export async function repoCreateInventorySession(
   body: CreateInventorySessionBodyDTO,
-  audit: AuditContext
+  audit: AuditContext,
+  idempotencyKey: string
 ): Promise<StockInventorySessionListItem> {
   const client = await db.connect();
   try {
     await client.query("BEGIN");
 
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: idempotencyKey,
+      command_type: "INVENTORY_CREATE",
+      request_payload: { phase: "CREATE_DRAFT", ...body },
+    });
+    if (command.existing) {
+      await client.query("COMMIT");
+      const existing = await repoGetInventorySession(command.existing.resource_id);
+      if (!existing) throw new Error("Idempotent inventory receipt points to a missing session");
+      return existing.session;
+    }
+
     const sessionNo = await reserveInventorySessionNo(client);
     const ins = await client.query<{ id: string }>(
       `
-        INSERT INTO public.stock_inventory_sessions (session_no, status, notes, created_by, updated_by)
-        VALUES ($1,'OPEN',$2,$3,$3)
+        INSERT INTO public.stock_inventory_sessions (
+          session_no,
+          status,
+          started_at,
+          notes,
+          scope_magasin_id,
+          scope_emplacement_id,
+          scope_article_id,
+          scope_article_category,
+          blind_count,
+          requires_second_count,
+          correlation_id,
+          created_by,
+          updated_by
+        )
+        VALUES ($1,'DRAFT',NULL,$2,$3::uuid,$4::bigint,$5::uuid,$6,$7,$8,$9::uuid,$10,$10)
         RETURNING id::text AS id
       `,
-      [sessionNo, body.notes ?? null, audit.user_id]
+      [
+        sessionNo,
+        body.notes ?? null,
+        body.scope_magasin_id ?? null,
+        body.scope_emplacement_id ?? null,
+        body.scope_article_id ?? null,
+        body.scope_article_category ?? null,
+        body.blind_count,
+        body.requires_second_count,
+        command.correlation_id,
+        audit.user_id,
+      ]
     );
     const id = ins.rows[0]?.id;
     if (!id) throw new Error("Failed to create inventory session");
@@ -5157,7 +7024,25 @@ export async function repoCreateInventorySession(
       action: "stock.inventory_sessions.create",
       entity_type: "stock_inventory_sessions",
       entity_id: id,
-      details: { session_no: sessionNo },
+      details: {
+        session_no: sessionNo,
+        status: "DRAFT",
+        scope: {
+          magasin_id: body.scope_magasin_id ?? null,
+          emplacement_id: body.scope_emplacement_id ?? null,
+          article_id: body.scope_article_id ?? null,
+          article_category: body.scope_article_category ?? null,
+        },
+      },
+    });
+
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: "INVENTORY_CREATE",
+      resource_type: "stock_inventory_session",
+      resource_id: id,
+      result_payload: { inventory_session_id: id, session_no: sessionNo, status: "DRAFT" },
     });
 
     await client.query("COMMIT");
@@ -5173,6 +7058,180 @@ export async function repoCreateInventorySession(
   }
 }
 
+export async function repoStartInventorySession(
+  id: string,
+  body: InventorySessionActionBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockInventorySessionDetail | null> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: idempotencyKey,
+      command_type: "INVENTORY_START",
+      request_payload: { inventory_session_id: id, ...body },
+    });
+    if (command.existing) {
+      await client.query("COMMIT");
+      return repoGetInventorySession(command.existing.resource_id);
+    }
+
+    const session = await client.query<{
+      status: string;
+      session_no: string;
+      row_version: number;
+      scope_magasin_id: string | null;
+      scope_emplacement_id: number | null;
+      scope_article_id: string | null;
+      scope_article_category: string | null;
+    }>(
+      `
+        SELECT
+          status,
+          session_no,
+          row_version::int AS row_version,
+          scope_magasin_id::text AS scope_magasin_id,
+          scope_emplacement_id::int AS scope_emplacement_id,
+          scope_article_id::text AS scope_article_id,
+          scope_article_category
+        FROM public.stock_inventory_sessions
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
+      [id]
+    );
+    const row = session.rows[0] ?? null;
+    if (!row) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+    if (row.status !== "DRAFT") {
+      throw new HttpError(409, "INVALID_STATUS", "Only DRAFT inventory sessions can be started");
+    }
+    if (row.row_version !== body.expected_version) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Inventory session version has changed");
+    }
+
+    if (row.scope_emplacement_id && row.scope_magasin_id) {
+      const scopedLocation = await client.query<{ ok: number }>(
+        `
+          SELECT 1::int AS ok
+          FROM public.emplacements emplacement
+          JOIN public.magasins magasin ON magasin.id = emplacement.magasin_id
+          WHERE emplacement.id = $1::bigint
+            AND magasin.id = $2::uuid
+            AND emplacement.is_active = true
+            AND magasin.is_active = true
+        `,
+        [row.scope_emplacement_id, row.scope_magasin_id]
+      );
+      if (!scopedLocation.rows[0]?.ok) {
+        throw new HttpError(409, "INVENTORY_SCOPE_INVALID", "Scoped emplacement is inactive or outside magasin");
+      }
+    }
+
+    const inserted = await client.query<{ id: string }>(
+      `
+        INSERT INTO public.stock_inventory_snapshot_lines (
+          session_id,
+          line_no,
+          article_id,
+          magasin_id,
+          emplacement_id,
+          lot_id,
+          stock_level_id,
+          stock_batch_id,
+          theoretical_qty,
+          unit_code
+        )
+        SELECT
+          $1::uuid,
+          row_number() OVER (
+            ORDER BY article.code, magasin.id, emplacement.code, availability.lot_code NULLS FIRST
+          )::int,
+          availability.article_id,
+          magasin.id,
+          emplacement.id,
+          availability.lot_id,
+          availability.stock_level_id,
+          availability.stock_batch_id,
+          availability.qty_on_hand,
+          unit.code::text
+        FROM public.v_stock_availability_225 availability
+        JOIN public.articles article ON article.id = availability.article_id
+        JOIN public.emplacements emplacement ON emplacement.location_id = availability.location_id
+        JOIN public.magasins magasin ON magasin.id = emplacement.magasin_id
+        JOIN public.units unit ON unit.id = availability.unit_id
+        WHERE availability.managed_in_stock = true
+          AND magasin.is_active = true
+          AND emplacement.is_active = true
+          AND ($2::uuid IS NULL OR magasin.id = $2::uuid)
+          AND ($3::bigint IS NULL OR emplacement.id = $3::bigint)
+          AND ($4::uuid IS NULL OR article.id = $4::uuid)
+          AND ($5::text IS NULL OR article.article_category::text = $5::text)
+        RETURNING id::text AS id
+      `,
+      [
+        id,
+        row.scope_magasin_id,
+        row.scope_emplacement_id,
+        row.scope_article_id,
+        row.scope_article_category,
+      ]
+    );
+    if (!inserted.rows.length) {
+      throw new HttpError(409, "INVENTORY_SCOPE_EMPTY", "Inventory scope contains no stock balance");
+    }
+
+    await client.query(
+      `
+        UPDATE public.stock_inventory_sessions
+        SET
+          status = 'OPEN',
+          started_at = now(),
+          snapshot_at = now(),
+          row_version = row_version + 1,
+          correlation_id = $2::uuid,
+          updated_at = now(),
+          updated_by = $3
+        WHERE id = $1::uuid
+      `,
+      [id, command.correlation_id, audit.user_id]
+    );
+    await insertAuditLog(client, audit, {
+      action: "stock.inventory_sessions.start",
+      entity_type: "stock_inventory_sessions",
+      entity_id: id,
+      details: {
+        session_no: row.session_no,
+        snapshot_lines_count: inserted.rows.length,
+        correlation_id: command.correlation_id,
+      },
+    });
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: "INVENTORY_START",
+      resource_type: "stock_inventory_session",
+      resource_id: id,
+      result_payload: {
+        inventory_session_id: id,
+        status: "OPEN",
+        snapshot_lines_count: inserted.rows.length,
+      },
+    });
+    await client.query("COMMIT");
+    return repoGetInventorySession(id);
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
 async function repoGetInventorySessionRow(id: string): Promise<StockInventorySessionListItem | null> {
   const res = await db.query<StockInventorySessionListItem>(
     `
@@ -5180,6 +7239,18 @@ async function repoGetInventorySessionRow(id: string): Promise<StockInventorySes
         s.id::text AS id,
         s.session_no,
         s.status,
+        s.scope_magasin_id::text AS scope_magasin_id,
+        s.scope_emplacement_id::int AS scope_emplacement_id,
+        s.scope_article_id::text AS scope_article_id,
+        s.scope_article_category,
+        s.blind_count,
+        s.requires_second_count,
+        s.snapshot_at::text AS snapshot_at,
+        s.approved_at::text AS approved_at,
+        s.cancelled_at::text AS cancelled_at,
+        s.cancellation_reason,
+        s.row_version::int AS row_version,
+        s.correlation_id::text AS correlation_id,
         s.started_at::text AS started_at,
         s.closed_at::text AS closed_at,
         s.notes,
@@ -5232,125 +7303,143 @@ export async function repoGetInventorySession(id: string): Promise<StockInventor
 }
 
 export async function repoListInventorySessionLines(id: string): Promise<StockInventorySessionLine[] | null> {
+  const res = await queryInventorySessionLines(id, null);
+  return res;
+}
+
+async function queryInventorySessionLines(
+  sessionId: string,
+  lineId: string | null
+): Promise<StockInventorySessionLine[] | null> {
   const session = await db.query<{ ok: number }>(
     `SELECT 1::int AS ok FROM public.stock_inventory_sessions WHERE id = $1::uuid`,
-    [id]
+    [sessionId]
   );
   if (!session.rows[0]?.ok) return null;
 
   const res = await db.query<StockInventorySessionLine>(
     `
       SELECT
-        l.id::text AS id,
-        l.session_id::text AS session_id,
-        l.line_no::int AS line_no,
-        l.article_id::text AS article_id,
-        a.code AS article_code,
-        a.designation AS article_designation,
-        l.magasin_id::text AS magasin_id,
-        COALESCE(m.code, m.code_magasin)::text AS magasin_code,
-        COALESCE(m.name, m.libelle)::text AS magasin_name,
-        l.emplacement_id::int AS emplacement_id,
-        e.code AS emplacement_code,
-        e.name AS emplacement_name,
-        l.lot_id::text AS lot_id,
+        COALESCE(materialized.id, snapshot.id)::text AS id,
+        snapshot.id::text AS snapshot_line_id,
+        snapshot.session_id::text AS session_id,
+        snapshot.line_no::int AS line_no,
+        snapshot.article_id::text AS article_id,
+        article.code AS article_code,
+        article.designation AS article_designation,
+        snapshot.magasin_id::text AS magasin_id,
+        COALESCE(magasin.code, magasin.code_magasin)::text AS magasin_code,
+        COALESCE(magasin.name, magasin.libelle)::text AS magasin_name,
+        snapshot.emplacement_id::int AS emplacement_id,
+        emplacement.code AS emplacement_code,
+        emplacement.name AS emplacement_name,
+        snapshot.lot_id::text AS lot_id,
         lot.lot_code AS lot_code,
-        l.counted_qty::float8 AS counted_qty,
-        (
-          CASE
-            WHEN l.lot_id IS NOT NULL THEN COALESCE(sb.qty_total, 0)
-            ELSE COALESCE(sl.qty_total, 0)
-          END
-        )::float8 AS qty_on_hand,
-        (
-          l.counted_qty - (
-            CASE
-              WHEN l.lot_id IS NOT NULL THEN COALESCE(sb.qty_total, 0)
-              ELSE COALESCE(sl.qty_total, 0)
-            END
-          )
-        )::float8 AS delta_qty,
-        l.note,
-        l.updated_at::text AS updated_at,
-        l.created_at::text AS created_at
-      FROM public.stock_inventory_lines l
-      JOIN public.articles a ON a.id = l.article_id
-      JOIN public.magasins m ON m.id = l.magasin_id
-      JOIN public.emplacements e ON e.id = l.emplacement_id
-      LEFT JOIN public.lots lot ON lot.id = l.lot_id
-      LEFT JOIN public.stock_levels sl ON sl.article_id = l.article_id AND sl.location_id = e.location_id
-      LEFT JOIN public.stock_batches sb ON sb.stock_level_id = sl.id AND sb.batch_code = lot.lot_code
-      WHERE l.session_id = $1::uuid
-      ORDER BY l.line_no ASC, l.id ASC
+        latest_count.counted_qty::float8 AS counted_qty,
+        CASE
+          WHEN session.blind_count = true AND session.status = 'OPEN' THEN NULL
+          ELSE snapshot.theoretical_qty::float8
+        END AS qty_on_hand,
+        CASE
+          WHEN latest_count.counted_qty IS NULL THEN NULL
+          WHEN session.blind_count = true AND session.status = 'OPEN' THEN NULL
+          ELSE (latest_count.counted_qty - snapshot.theoretical_qty)::float8
+        END AS delta_qty,
+        latest_count.count_round::int AS count_round,
+        latest_count.reason_code,
+        latest_count.note,
+        COALESCE(latest_count.created_at, snapshot.created_at)::text AS updated_at,
+        snapshot.created_at::text AS created_at
+      FROM public.stock_inventory_snapshot_lines snapshot
+      JOIN public.stock_inventory_sessions session ON session.id = snapshot.session_id
+      JOIN public.articles article ON article.id = snapshot.article_id
+      JOIN public.magasins magasin ON magasin.id = snapshot.magasin_id
+      JOIN public.emplacements emplacement ON emplacement.id = snapshot.emplacement_id
+      LEFT JOIN public.lots lot ON lot.id = snapshot.lot_id
+      LEFT JOIN public.stock_inventory_lines materialized
+        ON materialized.session_id = snapshot.session_id
+       AND materialized.article_id = snapshot.article_id
+       AND materialized.magasin_id = snapshot.magasin_id
+       AND materialized.emplacement_id = snapshot.emplacement_id
+       AND materialized.lot_id IS NOT DISTINCT FROM snapshot.lot_id
+      LEFT JOIN LATERAL (
+        SELECT
+          event.count_round,
+          event.counted_qty,
+          event.reason_code,
+          event.note,
+          event.created_at
+        FROM public.stock_inventory_count_events event
+        WHERE event.snapshot_line_id = snapshot.id
+        ORDER BY event.count_round DESC, event.created_at DESC, event.id DESC
+        LIMIT 1
+      ) latest_count ON true
+      WHERE snapshot.session_id = $1::uuid
+        AND (
+          $2::uuid IS NULL
+          OR materialized.id = $2::uuid
+          OR snapshot.id = $2::uuid
+        )
+      ORDER BY snapshot.line_no ASC, snapshot.id ASC
     `,
-    [id]
+    [sessionId, lineId]
   );
 
   return res.rows;
 }
 
 async function repoGetInventoryLineById(lineId: string): Promise<StockInventorySessionLine | null> {
-  const res = await db.query<StockInventorySessionLine>(
+  const session = await db.query<{ session_id: string }>(
     `
-      SELECT
-        l.id::text AS id,
-        l.session_id::text AS session_id,
-        l.line_no::int AS line_no,
-        l.article_id::text AS article_id,
-        a.code AS article_code,
-        a.designation AS article_designation,
-        l.magasin_id::text AS magasin_id,
-        COALESCE(m.code, m.code_magasin)::text AS magasin_code,
-        COALESCE(m.name, m.libelle)::text AS magasin_name,
-        l.emplacement_id::int AS emplacement_id,
-        e.code AS emplacement_code,
-        e.name AS emplacement_name,
-        l.lot_id::text AS lot_id,
-        lot.lot_code AS lot_code,
-        l.counted_qty::float8 AS counted_qty,
-        (
-          CASE
-            WHEN l.lot_id IS NOT NULL THEN COALESCE(sb.qty_total, 0)
-            ELSE COALESCE(sl.qty_total, 0)
-          END
-        )::float8 AS qty_on_hand,
-        (
-          l.counted_qty - (
-            CASE
-              WHEN l.lot_id IS NOT NULL THEN COALESCE(sb.qty_total, 0)
-              ELSE COALESCE(sl.qty_total, 0)
-            END
-          )
-        )::float8 AS delta_qty,
-        l.note,
-        l.updated_at::text AS updated_at,
-        l.created_at::text AS created_at
-      FROM public.stock_inventory_lines l
-      JOIN public.articles a ON a.id = l.article_id
-      JOIN public.magasins m ON m.id = l.magasin_id
-      JOIN public.emplacements e ON e.id = l.emplacement_id
-      LEFT JOIN public.lots lot ON lot.id = l.lot_id
-      LEFT JOIN public.stock_levels sl ON sl.article_id = l.article_id AND sl.location_id = e.location_id
-      LEFT JOIN public.stock_batches sb ON sb.stock_level_id = sl.id AND sb.batch_code = lot.lot_code
-      WHERE l.id = $1::uuid
+      SELECT session_id::text AS session_id
+      FROM public.stock_inventory_lines
+      WHERE id = $1::uuid
+      UNION ALL
+      SELECT session_id::text AS session_id
+      FROM public.stock_inventory_snapshot_lines
+      WHERE id = $1::uuid
       LIMIT 1
     `,
     [lineId]
   );
-  return res.rows[0] ?? null;
+  const sessionId = session.rows[0]?.session_id;
+  if (!sessionId) return null;
+  const rows = await queryInventorySessionLines(sessionId, lineId);
+  return rows?.[0] ?? null;
 }
 
 export async function repoUpsertInventoryLine(
   sessionId: string,
   body: UpsertInventoryLineBodyDTO,
-  audit: AuditContext
+  audit: AuditContext,
+  idempotencyKey: string
 ): Promise<StockInventorySessionLine | null> {
   const client = await db.connect();
   try {
     await client.query("BEGIN");
 
-    const lock = await client.query<{ status: string }>(
-      `SELECT status FROM public.stock_inventory_sessions WHERE id = $1::uuid FOR UPDATE`,
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: idempotencyKey,
+      command_type: "INVENTORY_COUNT",
+      request_payload: { inventory_session_id: sessionId, ...body },
+    });
+    if (command.existing) {
+      await client.query("COMMIT");
+      return repoGetInventoryLineById(command.existing.resource_id);
+    }
+
+    const lock = await client.query<{
+      status: string;
+      row_version: number;
+      requires_second_count: boolean;
+    }>(
+      `
+        SELECT status, row_version::int AS row_version, requires_second_count
+        FROM public.stock_inventory_sessions
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
       [sessionId]
     );
     const s = lock.rows[0] ?? null;
@@ -5361,6 +7450,95 @@ export async function repoUpsertInventoryLine(
     if (s.status !== "OPEN") {
       throw new HttpError(409, "INVALID_STATUS", "Only OPEN sessions can be edited");
     }
+    if (s.row_version !== body.expected_session_version) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Inventory session version has changed");
+    }
+    if (body.count_round === 2 && !s.requires_second_count) {
+      throw new HttpError(409, "SECOND_COUNT_NOT_REQUIRED", "This inventory does not allow a second count");
+    }
+
+    const snapshot = await client.query<{
+      id: string;
+      line_no: number;
+      theoretical_qty: number;
+    }>(
+      `
+        SELECT
+          id::text AS id,
+          line_no::int AS line_no,
+          theoretical_qty::float8 AS theoretical_qty
+        FROM public.stock_inventory_snapshot_lines
+        WHERE session_id = $1::uuid
+          AND article_id = $2::uuid
+          AND magasin_id = $3::uuid
+          AND emplacement_id = $4::bigint
+          AND lot_id IS NOT DISTINCT FROM $5::uuid
+        FOR SHARE
+      `,
+      [sessionId, body.article_id, body.magasin_id, body.emplacement_id, body.lot_id ?? null]
+    );
+    const snapshotLine = snapshot.rows[0] ?? null;
+    if (!snapshotLine) {
+      throw new HttpError(
+        409,
+        "INVENTORY_SCOPE_MISMATCH",
+        "Counted item is outside the frozen inventory scope"
+      );
+    }
+    if (
+      Math.abs(body.counted_qty - snapshotLine.theoretical_qty) > 1e-9 &&
+      !body.reason_code
+    ) {
+      throw new HttpError(
+        422,
+        "INVENTORY_REASON_REQUIRED",
+        "A reason code is required for an inventory discrepancy"
+      );
+    }
+    if (body.count_round === 2) {
+      const firstCount = await client.query<{ ok: number }>(
+        `
+          SELECT 1::int AS ok
+          FROM public.stock_inventory_count_events
+          WHERE snapshot_line_id = $1::uuid
+            AND count_round = 1
+          LIMIT 1
+        `,
+        [snapshotLine.id]
+      );
+      if (!firstCount.rows[0]?.ok) {
+        throw new HttpError(409, "FIRST_COUNT_REQUIRED", "First count is required before second count");
+      }
+    }
+
+    const countEvent = await client.query<{ id: string }>(
+      `
+        INSERT INTO public.stock_inventory_count_events (
+          session_id,
+          snapshot_line_id,
+          count_round,
+          counted_qty,
+          reason_code,
+          note,
+          actor_user_id,
+          correlation_id
+        )
+        VALUES ($1::uuid,$2::uuid,$3,$4,$5,$6,$7,$8::uuid)
+        RETURNING id::text AS id
+      `,
+      [
+        sessionId,
+        snapshotLine.id,
+        body.count_round,
+        body.counted_qty,
+        body.reason_code ?? null,
+        body.note ?? null,
+        audit.user_id,
+        command.correlation_id,
+      ]
+    );
+    const countEventId = countEvent.rows[0]?.id;
+    if (!countEventId) throw new Error("Failed to append inventory count event");
 
     const existing = await client.query<{ id: string }>(
       `
@@ -5388,13 +7566,6 @@ export async function repoUpsertInventoryLine(
         [lineId, body.counted_qty, body.note ?? null, audit.user_id]
       );
     } else {
-      const next = await client.query<{ n: number }>(
-        `SELECT (COALESCE(MAX(line_no), 0) + 1)::int AS n FROM public.stock_inventory_lines WHERE session_id = $1::uuid`,
-        [sessionId]
-      );
-      const lineNo = next.rows[0]?.n;
-      if (!lineNo) throw new Error("Failed to allocate inventory line number");
-
       const ins = await client.query<{ id: string }>(
         `
           INSERT INTO public.stock_inventory_lines (
@@ -5408,7 +7579,7 @@ export async function repoUpsertInventoryLine(
         `,
         [
           sessionId,
-          lineNo,
+          snapshotLine.line_no,
           body.article_id,
           body.magasin_id,
           body.emplacement_id,
@@ -5429,11 +7600,39 @@ export async function repoUpsertInventoryLine(
       entity_id: lineId,
       details: {
         session_id: sessionId,
+        snapshot_line_id: snapshotLine.id,
+        count_event_id: countEventId,
+        count_round: body.count_round,
         article_id: body.article_id,
         magasin_id: body.magasin_id,
         emplacement_id: body.emplacement_id,
         lot_id: body.lot_id ?? null,
         counted_qty: body.counted_qty,
+        theoretical_qty: snapshotLine.theoretical_qty,
+        reason_code: body.reason_code ?? null,
+      },
+    });
+
+    await client.query(
+      `
+        UPDATE public.stock_inventory_sessions
+        SET row_version = row_version + 1, updated_at = now(), updated_by = $2
+        WHERE id = $1::uuid
+      `,
+      [sessionId, audit.user_id]
+    );
+
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: "INVENTORY_COUNT",
+      resource_type: "stock_inventory_line",
+      resource_id: lineId,
+      result_payload: {
+        inventory_session_id: sessionId,
+        inventory_line_id: lineId,
+        count_event_id: countEventId,
+        count_round: body.count_round,
       },
     });
 
@@ -5447,13 +7646,284 @@ export async function repoUpsertInventoryLine(
   }
 }
 
-export async function repoCloseInventorySession(id: string, audit: AuditContext): Promise<StockInventorySessionDetail | null> {
+export async function repoApproveInventorySession(
+  id: string,
+  body: InventorySessionActionBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockInventorySessionDetail | null> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: idempotencyKey,
+      command_type: "INVENTORY_APPROVE",
+      request_payload: { inventory_session_id: id, ...body },
+    });
+    if (command.existing) {
+      await client.query("COMMIT");
+      return repoGetInventorySession(command.existing.resource_id);
+    }
+
+    const session = await client.query<{
+      status: string;
+      session_no: string;
+      row_version: number;
+      requires_second_count: boolean;
+    }>(
+      `
+        SELECT
+          status,
+          session_no,
+          row_version::int AS row_version,
+          requires_second_count
+        FROM public.stock_inventory_sessions
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
+      [id]
+    );
+    const row = session.rows[0] ?? null;
+    if (!row) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+    if (row.status !== "OPEN") {
+      throw new HttpError(409, "INVALID_STATUS", "Only OPEN inventory sessions can be approved");
+    }
+    if (row.row_version !== body.expected_version) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Inventory session version has changed");
+    }
+
+    const readiness = await client.query<{
+      lines_count: number;
+      missing_first_count: number;
+      missing_second_count: number;
+      discrepancy_without_reason: number;
+    }>(
+      `
+        SELECT
+          COUNT(*)::int AS lines_count,
+          COUNT(*) FILTER (WHERE first_count.counted_qty IS NULL)::int AS missing_first_count,
+          COUNT(*) FILTER (
+            WHERE $2::boolean = true
+              AND first_count.counted_qty IS NOT NULL
+              AND ABS(first_count.counted_qty - snapshot.theoretical_qty) > 1e-9
+              AND second_count.counted_qty IS NULL
+          )::int AS missing_second_count,
+          COUNT(*) FILTER (
+            WHERE COALESCE(second_count.counted_qty, first_count.counted_qty) IS NOT NULL
+              AND ABS(COALESCE(second_count.counted_qty, first_count.counted_qty) - snapshot.theoretical_qty) > 1e-9
+              AND NULLIF(
+                btrim(COALESCE(second_count.reason_code, first_count.reason_code, '')),
+                ''
+              ) IS NULL
+          )::int AS discrepancy_without_reason
+        FROM public.stock_inventory_snapshot_lines snapshot
+        LEFT JOIN LATERAL (
+          SELECT counted_qty, reason_code
+          FROM public.stock_inventory_count_events event
+          WHERE event.snapshot_line_id = snapshot.id
+            AND event.count_round = 1
+          ORDER BY event.created_at DESC, event.id DESC
+          LIMIT 1
+        ) first_count ON true
+        LEFT JOIN LATERAL (
+          SELECT counted_qty, reason_code
+          FROM public.stock_inventory_count_events event
+          WHERE event.snapshot_line_id = snapshot.id
+            AND event.count_round = 2
+          ORDER BY event.created_at DESC, event.id DESC
+          LIMIT 1
+        ) second_count ON true
+        WHERE snapshot.session_id = $1::uuid
+      `,
+      [id, row.requires_second_count]
+    );
+    const counts = readiness.rows[0];
+    if (!counts || counts.lines_count === 0) {
+      throw new HttpError(409, "INVENTORY_SCOPE_EMPTY", "Inventory snapshot contains no lines");
+    }
+    if (counts.missing_first_count > 0) {
+      throw new HttpError(
+        409,
+        "INVENTORY_COUNTS_INCOMPLETE",
+        `${counts.missing_first_count} first counts are missing`
+      );
+    }
+    if (counts.missing_second_count > 0) {
+      throw new HttpError(
+        409,
+        "INVENTORY_SECOND_COUNTS_INCOMPLETE",
+        `${counts.missing_second_count} required second counts are missing`
+      );
+    }
+    if (counts.discrepancy_without_reason > 0) {
+      throw new HttpError(
+        422,
+        "INVENTORY_REASON_REQUIRED",
+        `${counts.discrepancy_without_reason} discrepancies have no reason`
+      );
+    }
+
+    await client.query(
+      `
+        UPDATE public.stock_inventory_sessions
+        SET
+          status = 'APPROVED',
+          approved_at = now(),
+          approved_by = $2,
+          row_version = row_version + 1,
+          correlation_id = $3::uuid,
+          updated_at = now(),
+          updated_by = $2
+        WHERE id = $1::uuid
+      `,
+      [id, audit.user_id, command.correlation_id]
+    );
+    await insertAuditLog(client, audit, {
+      action: "stock.inventory_sessions.approve",
+      entity_type: "stock_inventory_sessions",
+      entity_id: id,
+      details: {
+        session_no: row.session_no,
+        reason: body.reason ?? null,
+        correlation_id: command.correlation_id,
+      },
+    });
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: "INVENTORY_APPROVE",
+      resource_type: "stock_inventory_session",
+      resource_id: id,
+      result_payload: { inventory_session_id: id, status: "APPROVED" },
+    });
+    await client.query("COMMIT");
+    return repoGetInventorySession(id);
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoCancelInventorySession(
+  id: string,
+  body: CancelInventorySessionBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockInventorySessionDetail | null> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: idempotencyKey,
+      command_type: "INVENTORY_CANCEL",
+      request_payload: { inventory_session_id: id, ...body },
+    });
+    if (command.existing) {
+      await client.query("COMMIT");
+      return repoGetInventorySession(command.existing.resource_id);
+    }
+
+    const session = await client.query<{ status: string; session_no: string; row_version: number }>(
+      `
+        SELECT status, session_no, row_version::int AS row_version
+        FROM public.stock_inventory_sessions
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
+      [id]
+    );
+    const row = session.rows[0] ?? null;
+    if (!row) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+    if (!["DRAFT", "OPEN", "APPROVED"].includes(row.status)) {
+      throw new HttpError(409, "INVALID_STATUS", "Inventory session can no longer be cancelled");
+    }
+    if (row.row_version !== body.expected_version) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Inventory session version has changed");
+    }
+
+    await client.query(
+      `
+        UPDATE public.stock_inventory_sessions
+        SET
+          status = 'CANCELLED',
+          cancelled_at = now(),
+          cancelled_by = $2,
+          cancellation_reason = $3,
+          row_version = row_version + 1,
+          correlation_id = $4::uuid,
+          updated_at = now(),
+          updated_by = $2
+        WHERE id = $1::uuid
+      `,
+      [id, audit.user_id, body.reason, command.correlation_id]
+    );
+    await insertAuditLog(client, audit, {
+      action: "stock.inventory_sessions.cancel",
+      entity_type: "stock_inventory_sessions",
+      entity_id: id,
+      details: {
+        session_no: row.session_no,
+        previous_status: row.status,
+        reason: body.reason,
+        correlation_id: command.correlation_id,
+      },
+    });
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: "INVENTORY_CANCEL",
+      resource_type: "stock_inventory_session",
+      resource_id: id,
+      result_payload: { inventory_session_id: id, status: "CANCELLED" },
+    });
+    await client.query("COMMIT");
+    return repoGetInventorySession(id);
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoCloseInventorySession(
+  id: string,
+  body: InventorySessionActionBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockInventorySessionDetail | null> {
   const client = await db.connect();
   try {
     await client.query("BEGIN");
 
-    const lock = await client.query<{ status: string; session_no: string }>(
-      `SELECT status, session_no FROM public.stock_inventory_sessions WHERE id = $1::uuid FOR UPDATE`,
+    const command = await beginStockCommand(client, {
+      audit,
+      idempotency_key: idempotencyKey,
+      command_type: "INVENTORY_CLOSE",
+      request_payload: { inventory_session_id: id, ...body },
+    });
+    if (command.existing) {
+      await client.query("COMMIT");
+      return repoGetInventorySession(command.existing.resource_id);
+    }
+
+    const lock = await client.query<{ status: string; session_no: string; row_version: number }>(
+      `
+        SELECT status, session_no, row_version::int AS row_version
+        FROM public.stock_inventory_sessions
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
       [id]
     );
     const s = lock.rows[0] ?? null;
@@ -5461,82 +7931,125 @@ export async function repoCloseInventorySession(id: string, audit: AuditContext)
       await client.query("ROLLBACK");
       return null;
     }
-    if (s.status !== "OPEN") {
-      throw new HttpError(409, "INVALID_STATUS", "Only OPEN sessions can be closed");
+    if (s.status !== "APPROVED") {
+      throw new HttpError(409, "INVALID_STATUS", "Only APPROVED inventory sessions can be closed");
+    }
+    if (s.row_version !== body.expected_version) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Inventory session version has changed");
     }
 
-    const lines = await client.query<StockInventorySessionLine>(
+    type InventoryCloseLine = {
+      snapshot_line_id: string;
+      line_no: number;
+      article_id: string;
+      magasin_id: string;
+      emplacement_id: number;
+      lot_id: string | null;
+      stock_level_id: string;
+      stock_batch_id: string | null;
+      theoretical_qty: number;
+      counted_qty: number | null;
+      unit_code: string;
+      reason_code: string | null;
+      note: string | null;
+    };
+    const lines = await client.query<InventoryCloseLine>(
       `
         SELECT
-          l.id::text AS id,
-          l.session_id::text AS session_id,
-          l.line_no::int AS line_no,
-          l.article_id::text AS article_id,
-          a.code AS article_code,
-          a.designation AS article_designation,
-          l.magasin_id::text AS magasin_id,
-          COALESCE(m.code, m.code_magasin)::text AS magasin_code,
-          COALESCE(m.name, m.libelle)::text AS magasin_name,
-          l.emplacement_id::int AS emplacement_id,
-          e.code AS emplacement_code,
-          e.name AS emplacement_name,
-          l.lot_id::text AS lot_id,
-          lot.lot_code AS lot_code,
-          l.counted_qty::float8 AS counted_qty,
-          (
-            CASE
-              WHEN l.lot_id IS NOT NULL THEN COALESCE(sb.qty_total, 0)
-              ELSE COALESCE(sl.qty_total, 0)
-            END
-          )::float8 AS qty_on_hand,
-          (
-            l.counted_qty - (
-              CASE
-                WHEN l.lot_id IS NOT NULL THEN COALESCE(sb.qty_total, 0)
-                ELSE COALESCE(sl.qty_total, 0)
-              END
-            )
-          )::float8 AS delta_qty,
-          l.note,
-          l.updated_at::text AS updated_at,
-          l.created_at::text AS created_at
-        FROM public.stock_inventory_lines l
-        JOIN public.articles a ON a.id = l.article_id
-        JOIN public.magasins m ON m.id = l.magasin_id
-        JOIN public.emplacements e ON e.id = l.emplacement_id
-        LEFT JOIN public.lots lot ON lot.id = l.lot_id
-        LEFT JOIN public.stock_levels sl ON sl.article_id = l.article_id AND sl.location_id = e.location_id
-        LEFT JOIN public.stock_batches sb ON sb.stock_level_id = sl.id AND sb.batch_code = lot.lot_code
-        WHERE l.session_id = $1::uuid
-        ORDER BY l.line_no ASC
+          snapshot.id::text AS snapshot_line_id,
+          snapshot.line_no::int AS line_no,
+          snapshot.article_id::text AS article_id,
+          snapshot.magasin_id::text AS magasin_id,
+          snapshot.emplacement_id::int AS emplacement_id,
+          snapshot.lot_id::text AS lot_id,
+          snapshot.stock_level_id::text AS stock_level_id,
+          snapshot.stock_batch_id::text AS stock_batch_id,
+          snapshot.theoretical_qty::float8 AS theoretical_qty,
+          effective_count.counted_qty::float8 AS counted_qty,
+          snapshot.unit_code,
+          effective_count.reason_code,
+          effective_count.note
+        FROM public.stock_inventory_snapshot_lines snapshot
+        LEFT JOIN LATERAL (
+          SELECT counted_qty, reason_code, note
+          FROM public.stock_inventory_count_events event
+          WHERE event.snapshot_line_id = snapshot.id
+          ORDER BY event.count_round DESC, event.created_at DESC, event.id DESC
+          LIMIT 1
+        ) effective_count ON true
+        WHERE snapshot.session_id = $1::uuid
+        ORDER BY snapshot.line_no ASC, snapshot.id ASC
       `,
       [id]
     );
 
-    const adjustments = lines.rows.filter((l) => Math.abs(l.delta_qty) > 1e-9);
+    if (!lines.rows.length) {
+      throw new HttpError(409, "INVENTORY_SCOPE_EMPTY", "Inventory snapshot contains no lines");
+    }
+    const missingCount = lines.rows.filter((line) => line.counted_qty === null).length;
+    if (missingCount > 0) {
+      throw new HttpError(
+        409,
+        "INVENTORY_COUNTS_INCOMPLETE",
+        `${missingCount} inventory counts are missing`
+      );
+    }
+
+    const states = await lockStockStates(
+      client,
+      lines.rows.map((line) => ({
+        stock_level_id: line.stock_level_id,
+        stock_batch_id: line.stock_batch_id,
+      }))
+    );
+    for (const line of lines.rows) {
+      const state = states.get(
+        stockTargetKey({
+          stock_level_id: line.stock_level_id,
+          stock_batch_id: line.stock_batch_id,
+        })
+      );
+      if (!state) throw new Error("Locked inventory stock state missing");
+      if (Math.abs(state.qty_on_hand - line.theoretical_qty) > 1e-9) {
+        throw new HttpError(
+          409,
+          "INVENTORY_SNAPSHOT_STALE",
+          "Stock changed after the inventory snapshot; cancel and restart the inventory",
+          {
+            snapshot_line_id: line.snapshot_line_id,
+            theoretical_qty: line.theoretical_qty,
+            current_qty: state.qty_on_hand,
+          }
+        );
+      }
+    }
+
+    const adjustments = lines.rows
+      .map((line) => ({
+        ...line,
+        counted_qty: line.counted_qty as number,
+        delta_qty: (line.counted_qty as number) - line.theoretical_qty,
+      }))
+      .filter((line) => Math.abs(line.delta_qty) > 1e-9);
     const postedAt = new Date().toISOString();
-    const unitCache = new Map<string, string>();
 
     for (const adj of adjustments) {
       const delta = adj.delta_qty;
       const direction: "IN" | "OUT" = delta > 0 ? "IN" : "OUT";
-
-      let unitId = unitCache.get(adj.article_id);
-      if (!unitId) {
-        unitId = await resolveUnitIdForArticle(client, adj.article_id, null);
-        unitCache.set(adj.article_id, unitId);
+      const state = states.get(
+        stockTargetKey({
+          stock_level_id: adj.stock_level_id,
+          stock_batch_id: adj.stock_batch_id,
+        })
+      );
+      if (!state) throw new Error("Locked inventory stock state missing");
+      if (delta < 0) {
+        assertStockConsumptionAllowed(state, {
+          movement_type: "ADJUSTMENT",
+          qty: delta,
+          allow_nonreleased_adjustment: true,
+        });
       }
-
-      const map = await getEmplacementMapping(client, adj.magasin_id, adj.emplacement_id, direction === "IN" ? "dst" : "src");
-      const stockLevelId = await ensureStockLevel(client, {
-        article_id: adj.article_id,
-        unit_id: unitId,
-        warehouse_id: map.warehouse_id,
-        location_id: map.location_id,
-        actor_user_id: audit.user_id,
-      });
-
-      const stockBatchId = adj.lot_id ? await ensureStockBatchId(client, { stock_level_id: stockLevelId, lot_id: adj.lot_id }) : null;
       const movementNo = await reserveMovementNo(client);
 
       const movement = await client.query<{ id: string }>(
@@ -5556,25 +8069,30 @@ export async function repoCloseInventorySession(id: string, audit: AuditContext)
             source_document_type,
             source_document_id,
             reason_code,
+            correlation_id,
             notes,
             user_id,
             created_by,
             updated_by
           )
-          VALUES ($1,'ADJUSTMENT','POSTED',$2::uuid,$3::uuid,$4::uuid,$5,'EUR',now(),$6,$7,$8,$9,'INVENTORY', $10,$7,$7,$7)
+          VALUES (
+            $1,'ADJUSTMENT','POSTED',$2::uuid,$3::uuid,$4::uuid,$5,'EUR',
+            now(),$6,$7,$8,$9,'INVENTORY',$10::uuid,$11,$7,$7,$7
+          )
           RETURNING id::text AS id
         `,
         [
           movementNo,
           adj.article_id,
-          stockLevelId,
-          stockBatchId,
+          adj.stock_level_id,
+          adj.stock_batch_id,
           delta,
           postedAt,
           audit.user_id,
           "stock_inventory_session",
           id,
-          `inventory ${s.session_no}`,
+          command.correlation_id,
+          body.reason ?? `inventory ${s.session_no}`,
         ]
       );
       const movementId = movement.rows[0]?.id;
@@ -5598,13 +8116,13 @@ export async function repoCloseInventorySession(id: string, audit: AuditContext)
           adj.article_id,
           adj.lot_id ?? null,
           Math.abs(delta),
-          null,
+          adj.unit_code,
           direction === "OUT" ? adj.magasin_id : null,
           direction === "OUT" ? adj.emplacement_id : null,
           direction === "IN" ? adj.magasin_id : null,
           direction === "IN" ? adj.emplacement_id : null,
           direction,
-          adj.note ?? null,
+          adj.note ?? adj.reason_code ?? body.reason ?? null,
           audit.user_id,
         ]
       );
@@ -5613,7 +8131,16 @@ export async function repoCloseInventorySession(id: string, audit: AuditContext)
         movement_id: movementId,
         event_type: "CREATED_POSTED",
         old_values: null,
-        new_values: { status: "POSTED", movement_type: "ADJUSTMENT", delta },
+        new_values: {
+          status: "POSTED",
+          movement_type: "ADJUSTMENT",
+          delta,
+          inventory_session_id: id,
+          snapshot_line_id: adj.snapshot_line_id,
+          theoretical_qty: adj.theoretical_qty,
+          counted_qty: adj.counted_qty,
+          correlation_id: command.correlation_id,
+        },
         user_id: audit.user_id,
       });
 
@@ -5630,10 +8157,17 @@ export async function repoCloseInventorySession(id: string, audit: AuditContext)
     await client.query(
       `
         UPDATE public.stock_inventory_sessions
-        SET status = 'CLOSED', closed_at = now(), closed_by = $2, updated_at = now(), updated_by = $2
+        SET
+          status = 'CLOSED',
+          closed_at = now(),
+          closed_by = $2,
+          row_version = row_version + 1,
+          correlation_id = $3::uuid,
+          updated_at = now(),
+          updated_by = $2
         WHERE id = $1::uuid
       `,
-      [id, audit.user_id]
+      [id, audit.user_id, command.correlation_id]
     );
 
     await insertAuditLog(client, audit, {
@@ -5642,6 +8176,21 @@ export async function repoCloseInventorySession(id: string, audit: AuditContext)
       entity_id: id,
       details: {
         session_no: s.session_no,
+        adjustments_count: adjustments.length,
+        reason: body.reason ?? null,
+        correlation_id: command.correlation_id,
+      },
+    });
+
+    await completeStockCommand(client, {
+      audit,
+      command,
+      command_type: "INVENTORY_CLOSE",
+      resource_type: "stock_inventory_session",
+      resource_id: id,
+      result_payload: {
+        inventory_session_id: id,
+        status: "CLOSED",
         adjustments_count: adjustments.length,
       },
     });

--- a/src/module/stock/routes/stock.routes.ts
+++ b/src/module/stock/routes/stock.routes.ts
@@ -1,13 +1,17 @@
-import { Router } from "express";
+import { Router, type RequestHandler } from "express";
 import multer from "multer";
 
 import { authenticateToken, authorizeRole } from "../../auth/middlewares/auth.middleware";
 import { ensureTmpStoragePath } from "../../../utils/cerpStorage";
+import { HttpError } from "../../../utils/httpError";
 import {
   attachStockArticleDocuments,
   attachStockMovementDocuments,
   cancelStockMovement,
   closeStockInventorySession,
+  startStockInventorySession,
+  approveStockInventorySession,
+  cancelStockInventorySession,
   createStockInventorySession,
   createStockArticle,
   previewStockArticleCode,
@@ -17,10 +21,14 @@ import {
   createStockMatiereSousEtat,
   createStockEmplacement,
   createStockLot,
+  createStockLotGenealogy,
   createStockMagasin,
   deactivateStockMagasin,
   activateStockMagasin,
   createStockMovement,
+  compensateStockMovement,
+  previewStockMovementCompensation,
+  previewStockMovement,
   downloadStockArticleDocument,
   downloadStockMovementDocument,
   getStockAnalytics,
@@ -30,6 +38,7 @@ import {
   listStockArticleFamilies,
   getStockArticlesKpis,
   getStockLot,
+  getStockLotGenealogy,
   getStockMagasin,
   getStockMagasinsKpis,
   getStockMovement,
@@ -57,6 +66,7 @@ import {
   listStockArticleWhereUsed,
   updateStockEmplacement,
   updateStockLot,
+  updateStockLotQuality,
   updateStockMagasin,
 } from "../controllers/stock.controller";
 import {
@@ -65,10 +75,18 @@ import {
   unlinkArticlePieceTechnique,
 } from "../controllers/article-piece-link.controller";
 import {
+  consumeStockReservation,
+  createStockReservation,
+  getStockReservation,
+  listStockReservations,
+  releaseStockReservation,
+} from "../controllers/stock-reservation.controller";
+import {
   ARTICLE_ARCHIVE_ROLES,
   ARTICLE_DOCUMENT_WRITE_ROLES,
   ARTICLE_WRITE_ROLES,
 } from "../stock-article.permissions";
+import { roleHasStockCapability, type StockCapability } from "../domain/stock-rbac";
 
 const router = Router();
 
@@ -87,72 +105,172 @@ const requireArticleWrite = authorizeRole(...ARTICLE_WRITE_ROLES);
 const requireArticleArchive = authorizeRole(...ARTICLE_ARCHIVE_ROLES);
 const requireArticleDocumentWrite = authorizeRole(...ARTICLE_DOCUMENT_WRITE_ROLES);
 
-router.get("/analytics", getStockAnalytics);
-router.get("/article-categories", listStockArticleCategories);
-router.get("/article-families", listStockArticleFamilies);
+const requireStockCapability = (capability: StockCapability): RequestHandler => (req, _res, next) => {
+  if (!roleHasStockCapability(req.user?.role, capability)) {
+    next(new HttpError(403, "STOCK_FORBIDDEN", `Stock capability required: ${capability}`));
+    return;
+  }
+  next();
+};
+
+router.get("/analytics", requireStockCapability("read"), getStockAnalytics);
+router.get("/article-categories", requireStockCapability("read"), listStockArticleCategories);
+router.get("/article-families", requireStockCapability("read"), listStockArticleFamilies);
 router.post("/article-families", requireArticleWrite, createStockArticleFamily);
-router.get("/matiere-nuances", listStockMatiereNuances);
+router.get("/matiere-nuances", requireStockCapability("read"), listStockMatiereNuances);
 router.post("/matiere-nuances", requireArticleWrite, createStockMatiereNuance);
-router.get("/matiere-etats", listStockMatiereEtats);
+router.get("/matiere-etats", requireStockCapability("read"), listStockMatiereEtats);
 router.post("/matiere-etats", requireArticleWrite, createStockMatiereEtat);
-router.get("/matiere-sous-etats", listStockMatiereSousEtats);
+router.get("/matiere-sous-etats", requireStockCapability("read"), listStockMatiereSousEtats);
 router.post("/matiere-sous-etats", requireArticleWrite, createStockMatiereSousEtat);
-router.get("/articles", listStockArticles);
-router.get("/articles/kpis", getStockArticlesKpis);
-router.get("/articles/code-preview", previewStockArticleCode);
+router.get("/articles", requireStockCapability("read"), listStockArticles);
+router.get("/articles/kpis", requireStockCapability("read"), getStockArticlesKpis);
+router.get("/articles/code-preview", requireStockCapability("read"), previewStockArticleCode);
 router.post("/articles", requireArticleWrite, createStockArticle);
-router.get("/articles/:id", getStockArticle);
+router.get("/articles/:id", requireStockCapability("read"), getStockArticle);
 router.patch("/articles/:id", requireArticleWrite, updateStockArticle);
 router.post("/articles/:id/archive", requireArticleArchive, archiveStockArticle);
 router.post("/articles/:id/reactivate", requireArticleArchive, reactivateStockArticle);
-router.get("/articles/:id/versions", listStockArticleVersions);
-router.get("/articles/:id/where-used", listStockArticleWhereUsed);
+router.get("/articles/:id/versions", requireStockCapability("read"), listStockArticleVersions);
+router.get("/articles/:id/where-used", requireStockCapability("read"), listStockArticleWhereUsed);
 
-router.get("/inventory-sessions", listStockInventorySessions);
-router.post("/inventory-sessions", createStockInventorySession);
-router.get("/inventory-sessions/:id", getStockInventorySession);
-router.get("/inventory-sessions/:id/lines", listStockInventorySessionLines);
-router.put("/inventory-sessions/:id/lines", upsertStockInventorySessionLine);
-router.post("/inventory-sessions/:id/close", closeStockInventorySession);
+router.get("/inventory-sessions", requireStockCapability("read"), listStockInventorySessions);
+router.post("/inventory-sessions", requireStockCapability("inventory_create"), createStockInventorySession);
+router.get("/inventory-sessions/:id", requireStockCapability("read"), getStockInventorySession);
+router.get("/inventory-sessions/:id/lines", requireStockCapability("read"), listStockInventorySessionLines);
+router.post(
+  "/inventory-sessions/:id/start",
+  requireStockCapability("inventory_create"),
+  startStockInventorySession
+);
+router.put(
+  "/inventory-sessions/:id/lines",
+  requireStockCapability("inventory_count"),
+  upsertStockInventorySessionLine
+);
+router.post(
+  "/inventory-sessions/:id/approve",
+  requireStockCapability("inventory_approve"),
+  approveStockInventorySession
+);
+router.post(
+  "/inventory-sessions/:id/cancel",
+  requireStockCapability("inventory_approve"),
+  cancelStockInventorySession
+);
+router.post(
+  "/inventory-sessions/:id/close",
+  requireStockCapability("inventory_close"),
+  closeStockInventorySession
+);
 
 // GPAO B5 — lien Article fabriqué ↔ Pièce technique
-router.get("/articles/:id/definition-technique", getArticleDefinitionTechnique);
+router.get("/articles/:id/definition-technique", requireStockCapability("read"), getArticleDefinitionTechnique);
 router.post("/articles/:id/link-piece-technique", requireArticleWrite, linkArticlePieceTechnique);
 router.delete("/articles/:id/link-piece-technique", requireArticleWrite, unlinkArticlePieceTechnique);
 
-router.get("/articles/:id/documents", listStockArticleDocuments);
+router.get("/articles/:id/documents", requireStockCapability("read"), listStockArticleDocuments);
 router.post("/articles/:id/documents", requireArticleDocumentWrite, upload.array("documents[]", 10), attachStockArticleDocuments);
 router.delete("/articles/:id/documents/:docId", requireArticleDocumentWrite, removeStockArticleDocument);
-router.get("/articles/:id/documents/:docId/file", downloadStockArticleDocument);
+router.get(
+  "/articles/:id/documents/:docId/file",
+  requireStockCapability("read"),
+  downloadStockArticleDocument
+);
 
-router.get("/magasins", listStockMagasins);
-router.get("/magasins/kpis", getStockMagasinsKpis);
-router.post("/magasins", createStockMagasin);
-router.get("/magasins/:id", getStockMagasin);
-router.patch("/magasins/:id", updateStockMagasin);
-router.post("/magasins/:id/deactivate", deactivateStockMagasin);
-router.post("/magasins/:id/activate", activateStockMagasin);
-router.post("/magasins/:magasinId/emplacements", createStockEmplacement);
+router.get("/magasins", requireStockCapability("read"), listStockMagasins);
+router.get("/magasins/kpis", requireStockCapability("read"), getStockMagasinsKpis);
+router.post("/magasins", requireStockCapability("referential_manage"), createStockMagasin);
+router.get("/magasins/:id", requireStockCapability("read"), getStockMagasin);
+router.patch("/magasins/:id", requireStockCapability("referential_manage"), updateStockMagasin);
+router.post(
+  "/magasins/:id/deactivate",
+  requireStockCapability("referential_manage"),
+  deactivateStockMagasin
+);
+router.post("/magasins/:id/activate", requireStockCapability("referential_manage"), activateStockMagasin);
+router.post(
+  "/magasins/:magasinId/emplacements",
+  requireStockCapability("referential_manage"),
+  createStockEmplacement
+);
 
-router.get("/emplacements", listStockEmplacements);
-router.patch("/emplacements/:id", updateStockEmplacement);
+router.get("/emplacements", requireStockCapability("read"), listStockEmplacements);
+router.patch(
+  "/emplacements/:id",
+  requireStockCapability("referential_manage"),
+  updateStockEmplacement
+);
 
-router.get("/lots", listStockLots);
-router.post("/lots", createStockLot);
-router.get("/lots/:id", getStockLot);
-router.patch("/lots/:id", updateStockLot);
+router.get("/lots", requireStockCapability("read"), listStockLots);
+router.post("/lots", requireStockCapability("referential_manage"), createStockLot);
+router.post(
+  "/lots/genealogy",
+  requireStockCapability("movement_post"),
+  createStockLotGenealogy
+);
+router.get("/lots/:id", requireStockCapability("read"), getStockLot);
+router.patch("/lots/:id", requireStockCapability("referential_manage"), updateStockLot);
+router.post(
+  "/lots/:id/quality-status",
+  requireStockCapability("lot_quality"),
+  updateStockLotQuality
+);
+router.get("/lots/:id/genealogy", requireStockCapability("read"), getStockLotGenealogy);
 
-router.get("/balances", listStockBalances);
+router.get("/balances", requireStockCapability("read"), listStockBalances);
 
-router.get("/movements", listStockMovements);
-router.post("/movements", createStockMovement);
-router.get("/movements/:id", getStockMovement);
-router.post("/movements/:id/post", postStockMovement);
-router.post("/movements/:id/cancel", cancelStockMovement);
+router.get("/reservations", requireStockCapability("read"), listStockReservations);
+router.post(
+  "/reservations",
+  requireStockCapability("reservation_manage"),
+  createStockReservation
+);
+router.get("/reservations/:id", requireStockCapability("read"), getStockReservation);
+router.post(
+  "/reservations/:id/release",
+  requireStockCapability("reservation_manage"),
+  releaseStockReservation
+);
+router.post(
+  "/reservations/:id/consume",
+  requireStockCapability("reservation_manage"),
+  consumeStockReservation
+);
 
-router.get("/movements/:id/documents", listStockMovementDocuments);
-router.post("/movements/:id/documents", upload.array("documents[]"), attachStockMovementDocuments);
-router.delete("/movements/:id/documents/:docId", removeStockMovementDocument);
-router.get("/movements/:id/documents/:docId/file", downloadStockMovementDocument);
+router.get("/movements", requireStockCapability("read"), listStockMovements);
+router.post("/movements/preview", requireStockCapability("movement_create"), previewStockMovement);
+router.post("/movements", requireStockCapability("movement_create"), createStockMovement);
+router.get("/movements/:id", requireStockCapability("read"), getStockMovement);
+router.post(
+  "/movements/:id/compensation-preview",
+  requireStockCapability("movement_compensate"),
+  previewStockMovementCompensation
+);
+router.post(
+  "/movements/:id/compensate",
+  requireStockCapability("movement_compensate"),
+  compensateStockMovement
+);
+router.post("/movements/:id/post", requireStockCapability("movement_post"), postStockMovement);
+router.post("/movements/:id/cancel", requireStockCapability("movement_cancel"), cancelStockMovement);
+
+router.get("/movements/:id/documents", requireStockCapability("read"), listStockMovementDocuments);
+router.post(
+  "/movements/:id/documents",
+  requireStockCapability("documents_manage"),
+  upload.array("documents[]"),
+  attachStockMovementDocuments
+);
+router.delete(
+  "/movements/:id/documents/:docId",
+  requireStockCapability("documents_manage"),
+  removeStockMovementDocument
+);
+router.get(
+  "/movements/:id/documents/:docId/file",
+  requireStockCapability("read"),
+  downloadStockMovementDocument
+);
 
 export default router;

--- a/src/module/stock/services/stock-reservation.service.ts
+++ b/src/module/stock/services/stock-reservation.service.ts
@@ -1,0 +1,39 @@
+import type { AuditContext } from "../repository/stock.repository";
+import {
+  repoConsumeStockReservation,
+  repoCreateStockReservation,
+  repoGetStockReservation,
+  repoListStockReservations,
+  repoReleaseStockReservation,
+} from "../repository/stock-reservation.repository";
+import type {
+  ConsumeStockReservationBodyDTO,
+  CreateStockReservationBodyDTO,
+  ListStockReservationsQueryDTO,
+  StockReservationActionBodyDTO,
+} from "../validators/stock-reservation.validators";
+
+export const listStockReservationsSVC = (query: ListStockReservationsQueryDTO) =>
+  repoListStockReservations(query);
+
+export const getStockReservationSVC = (id: string) => repoGetStockReservation(id);
+
+export const createStockReservationSVC = (
+  body: CreateStockReservationBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+) => repoCreateStockReservation(body, audit, idempotencyKey);
+
+export const releaseStockReservationSVC = (
+  id: string,
+  body: StockReservationActionBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+) => repoReleaseStockReservation(id, body, audit, idempotencyKey);
+
+export const consumeStockReservationSVC = (
+  id: string,
+  body: ConsumeStockReservationBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+) => repoConsumeStockReservation(id, body, audit, idempotencyKey);

--- a/src/module/stock/services/stock.service.ts
+++ b/src/module/stock/services/stock.service.ts
@@ -14,11 +14,14 @@ import type {
   StockInventorySessionLine,
   StockInventorySessionListItem,
   StockLotDetail,
+  StockLotGenealogy,
   StockLotListItem,
   StockMagasinDetail,
   StockMagasinKpis,
   StockMagasinListItem,
   StockMovementDetail,
+  StockMovementCompensationPreview,
+  StockMovementImpactPreview,
   StockMovementListItem,
 } from "../types/stock.types";
 import type {
@@ -32,6 +35,8 @@ import type {
   CreateLotBodyDTO,
   CreateMagasinBodyDTO,
   CreateMovementBodyDTO,
+  CompensateMovementBodyDTO,
+  PostMovementBodyDTO,
   ListAnalyticsQueryDTO,
   ListInventorySessionsQueryDTO,
   ListArticlesQueryDTO,
@@ -47,17 +52,24 @@ import type {
   ListMagasinsQueryDTO,
   ListMovementsQueryDTO,
   UpsertInventoryLineBodyDTO,
+  InventorySessionActionBodyDTO,
+  CancelInventorySessionBodyDTO,
   UpdateArticleBodyDTO,
   ArchiveArticleBodyDTO,
   ReactivateArticleBodyDTO,
   ArticleDocumentMetadataDTO,
   UpdateEmplacementBodyDTO,
   UpdateLotBodyDTO,
+  UpdateLotQualityBodyDTO,
+  CreateLotGenealogyBodyDTO,
   UpdateMagasinBodyDTO,
 } from "../validators/stock.validators";
 import type { AuditContext } from "../repository/stock.repository";
 import {
   repoCloseInventorySession,
+  repoStartInventorySession,
+  repoApproveInventorySession,
+  repoCancelInventorySession,
   repoCreateInventorySession,
   repoCreateArticleFamily,
   repoCreateMatiereEtat,
@@ -71,6 +83,9 @@ import {
   repoCreateLot,
   repoCreateMagasin,
   repoCreateMovement,
+  repoPreviewMovement,
+  repoCompensateMovement,
+  repoPreviewMovementCompensation,
   repoGetInventorySession,
   repoGetStockAnalytics,
   repoGetArticle,
@@ -107,6 +122,9 @@ import {
   repoListArticleWhereUsed,
   repoUpdateEmplacement,
   repoUpdateLot,
+  repoUpdateLotQuality,
+  repoGetLotGenealogy,
+  repoCreateLotGenealogy,
   repoUpdateMagasin,
   repoDeactivateMagasin,
   repoActivateMagasin,
@@ -116,8 +134,12 @@ export async function listStockInventorySessionsSVC(filters: ListInventorySessio
   return repoListInventorySessions(filters);
 }
 
-export async function createStockInventorySessionSVC(body: CreateInventorySessionBodyDTO, audit: AuditContext): Promise<StockInventorySessionListItem> {
-  return repoCreateInventorySession(body, audit);
+export async function createStockInventorySessionSVC(
+  body: CreateInventorySessionBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockInventorySessionListItem> {
+  return repoCreateInventorySession(body, audit, idempotencyKey);
 }
 
 export async function getStockInventorySessionSVC(id: string): Promise<StockInventorySessionDetail | null> {
@@ -131,13 +153,46 @@ export async function listStockInventorySessionLinesSVC(id: string): Promise<Sto
 export async function upsertStockInventorySessionLineSVC(
   sessionId: string,
   body: UpsertInventoryLineBodyDTO,
-  audit: AuditContext
+  audit: AuditContext,
+  idempotencyKey: string
 ): Promise<StockInventorySessionLine | null> {
-  return repoUpsertInventoryLine(sessionId, body, audit);
+  return repoUpsertInventoryLine(sessionId, body, audit, idempotencyKey);
 }
 
-export async function closeStockInventorySessionSVC(id: string, audit: AuditContext): Promise<StockInventorySessionDetail | null> {
-  return repoCloseInventorySession(id, audit);
+export async function startStockInventorySessionSVC(
+  id: string,
+  body: InventorySessionActionBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockInventorySessionDetail | null> {
+  return repoStartInventorySession(id, body, audit, idempotencyKey);
+}
+
+export async function approveStockInventorySessionSVC(
+  id: string,
+  body: InventorySessionActionBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockInventorySessionDetail | null> {
+  return repoApproveInventorySession(id, body, audit, idempotencyKey);
+}
+
+export async function cancelStockInventorySessionSVC(
+  id: string,
+  body: CancelInventorySessionBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockInventorySessionDetail | null> {
+  return repoCancelInventorySession(id, body, audit, idempotencyKey);
+}
+
+export async function closeStockInventorySessionSVC(
+  id: string,
+  body: InventorySessionActionBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockInventorySessionDetail | null> {
+  return repoCloseInventorySession(id, body, audit, idempotencyKey);
 }
 
 export async function listStockArticlesSVC(filters: ListArticlesQueryDTO) {
@@ -303,6 +358,27 @@ export async function updateStockLotSVC(id: string, patch: UpdateLotBodyDTO, aud
   return repoUpdateLot(id, patch, audit);
 }
 
+export async function updateStockLotQualitySVC(
+  id: string,
+  body: UpdateLotQualityBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockLotDetail | null> {
+  return repoUpdateLotQuality(id, body, audit, idempotencyKey);
+}
+
+export async function getStockLotGenealogySVC(id: string): Promise<StockLotGenealogy | null> {
+  return repoGetLotGenealogy(id);
+}
+
+export async function createStockLotGenealogySVC(
+  body: CreateLotGenealogyBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+) {
+  return repoCreateLotGenealogy(body, audit, idempotencyKey);
+}
+
 export async function listStockBalancesSVC(filters: ListBalancesQueryDTO) {
   return repoListBalances(filters);
 }
@@ -323,12 +399,43 @@ export async function createStockMovementSVC(body: CreateMovementBodyDTO, audit:
   return repoCreateMovement(body, audit);
 }
 
-export async function postStockMovementSVC(id: string, audit: AuditContext): Promise<StockMovementDetail | null> {
-  return repoPostMovement(id, audit);
+export async function previewStockMovementSVC(
+  body: CreateMovementBodyDTO
+): Promise<StockMovementImpactPreview> {
+  return repoPreviewMovement(body);
 }
 
-export async function cancelStockMovementSVC(id: string, audit: AuditContext): Promise<StockMovementDetail | null> {
-  return repoCancelMovement(id, audit);
+export async function previewStockMovementCompensationSVC(
+  id: string,
+  body: CompensateMovementBodyDTO
+): Promise<StockMovementCompensationPreview | null> {
+  return repoPreviewMovementCompensation(id, body);
+}
+
+export async function compensateStockMovementSVC(
+  id: string,
+  body: CompensateMovementBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockMovementDetail | null> {
+  return repoCompensateMovement(id, body, audit, idempotencyKey);
+}
+
+export async function postStockMovementSVC(
+  id: string,
+  body: PostMovementBodyDTO,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockMovementDetail | null> {
+  return repoPostMovement(id, body, audit, idempotencyKey);
+}
+
+export async function cancelStockMovementSVC(
+  id: string,
+  audit: AuditContext,
+  idempotencyKey: string
+): Promise<StockMovementDetail | null> {
+  return repoCancelMovement(id, audit, idempotencyKey);
 }
 
 export async function listStockArticleDocumentsSVC(articleId: string): Promise<StockDocument[] | null> {

--- a/src/module/stock/types/stock-reservation.types.ts
+++ b/src/module/stock/types/stock-reservation.types.ts
@@ -1,0 +1,50 @@
+export type StockReservationStatus = "ACTIVE" | "RELEASED" | "CONSUMED" | "EXPIRED" | "CANCELLED";
+
+export type StockReservationSourceType =
+  | "COMMANDE_LIGNE"
+  | "OF"
+  | "BON_LIVRAISON_LIGNE"
+  | "AFFAIRE";
+
+export type StockReservationListItem = {
+  id: string;
+  article_id: string;
+  article_code: string;
+  article_designation: string;
+  location_id: string;
+  magasin_id: string | null;
+  magasin_code: string | null;
+  emplacement_id: number | null;
+  emplacement_code: string | null;
+  lot_id: string | null;
+  lot_code: string | null;
+  stock_batch_id: string | null;
+  qty_reserved: number;
+  source_type: StockReservationSourceType;
+  source_id: string;
+  status: StockReservationStatus;
+  reason: string | null;
+  expires_at: string | null;
+  released_at: string | null;
+  consumed_at: string | null;
+  consumed_stock_movement_id: string | null;
+  row_version: number;
+  correlation_id: string;
+  updated_at: string;
+  created_at: string;
+};
+
+export type StockReservationEvent = {
+  id: string;
+  event_type: "CREATED" | "UPDATED" | "RELEASED" | "CONSUMED" | "EXPIRED" | "COMPENSATED";
+  old_values: unknown | null;
+  new_values: unknown | null;
+  actor_user_id: number;
+  correlation_id: string;
+  created_at: string;
+};
+
+export type StockReservationDetail = {
+  reservation: StockReservationListItem;
+  events: StockReservationEvent[];
+};

--- a/src/module/stock/types/stock.types.ts
+++ b/src/module/stock/types/stock.types.ts
@@ -225,6 +225,10 @@ export type StockEmplacementListItem = {
   name: string | null;
   is_scrap: boolean;
   is_active: boolean;
+  location_type: "RECEIVING" | "PRODUCTION" | "QUARANTINE" | "SCRAP" | "SHIPPING" | "STORAGE";
+  allow_inbound: boolean;
+  allow_outbound: boolean;
+  restrictions: Record<string, unknown>;
   updated_at: string;
   created_at: string;
 };
@@ -235,6 +239,8 @@ export type StockLotListItem = {
   article_code: string;
   article_designation: string;
   lot_code: string;
+  lot_status: "LIBERE" | "EN_ATTENTE" | "QUARANTAINE" | "BLOQUE";
+  lot_status_note: string | null;
   supplier_lot_code: string | null;
   received_at: string | null;
   manufactured_at: string | null;
@@ -245,6 +251,30 @@ export type StockLotListItem = {
 
 export type StockLotDetail = StockLotListItem & {
   notes: string | null;
+};
+
+export type StockLotGenealogyEdge = {
+  id: string;
+  parent_lot_id: string;
+  parent_lot_code: string;
+  parent_article_id: string;
+  parent_article_code: string;
+  child_lot_id: string;
+  child_lot_code: string;
+  child_article_id: string;
+  child_article_code: string;
+  operation_type: "SPLIT" | "MERGE" | "TRANSFORM";
+  qty_contributed: number;
+  unit_code: string;
+  stock_movement_id: string | null;
+  correlation_id: string;
+  created_at: string;
+};
+
+export type StockLotGenealogy = {
+  lot: StockLotDetail;
+  ancestors: StockLotGenealogyEdge[];
+  descendants: StockLotGenealogyEdge[];
 };
 
 // This endpoint now reflects stock_levels (via v_stock_current).
@@ -271,7 +301,12 @@ export type StockBalanceRow = {
   managed_in_stock: boolean;
   qty_on_hand: number;
   qty_reserved: number;
+  qty_depreciated: number;
+  qty_quarantine: number;
+  qty_blocked: number;
   qty_available: number;
+  qty_scrap_recorded: number;
+  lot_status: "LIBERE" | "EN_ATTENTE" | "QUARANTAINE" | "BLOQUE" | null;
   updated_at: string;
 };
 
@@ -302,6 +337,8 @@ export type StockMovementListItem = {
   source_document_type: string | null;
   source_document_id: string | null;
   reason_code: string | null;
+  correlation_id: string | null;
+  reversal_of_id: string | null;
   updated_at: string;
   created_at: string;
   lines_count: number;
@@ -376,6 +413,8 @@ export type StockMovementDetail = {
     source_document_type: string | null;
     source_document_id: string | null;
     reason_code: string | null;
+    correlation_id: string | null;
+    reversal_of_id: string | null;
     notes: string | null;
     created_at: string;
     updated_at: string;
@@ -388,6 +427,62 @@ export type StockMovementDetail = {
   events: StockMovementEvent[];
 };
 
+export type StockMovementCompensationPreview = {
+  original_movement_id: string;
+  original_movement_no: string | null;
+  compensable: boolean;
+  blockers: Array<{ code: string; message: string }>;
+  proposed_movement: {
+    movement_type: StockMovementType;
+    source_document_type: "STOCK_COMPENSATION";
+    source_document_id: string;
+    reason_code: "COMPENSATION";
+    notes: string;
+    lines: Array<{
+      article_id: string;
+      lot_id: string | null;
+      qty: number;
+      unite: string | null;
+      src_magasin_id: string | null;
+      src_emplacement_id: number | null;
+      dst_magasin_id: string | null;
+      dst_emplacement_id: number | null;
+      direction?: "IN" | "OUT";
+    }>;
+  } | null;
+};
+
+export type StockMovementImpactPreview = {
+  authoritative: true;
+  as_of: string;
+  movement_type: StockMovementType;
+  qty_total: number;
+  can_post: boolean;
+  blockers: Array<{ code: string; message: string }>;
+  impacts: Array<{
+    side: "SOURCE" | "DESTINATION";
+    magasin_id: string;
+    emplacement_id: number;
+    lot_id: string | null;
+    before: {
+      qty_on_hand: number;
+      qty_reserved: number;
+      qty_depreciated: number;
+      qty_quarantine: number;
+      qty_blocked: number;
+      qty_available: number;
+    };
+    after: {
+      qty_on_hand: number;
+      qty_reserved: number;
+      qty_depreciated: number;
+      qty_quarantine: number;
+      qty_blocked: number;
+      qty_available: number;
+    };
+  }>;
+};
+
 export type StockMovementKpis = {
   movements_total: number;
   movements_posted: number;
@@ -397,12 +492,25 @@ export type StockMovementKpis = {
 };
 
 export type StockAnalytics = {
+  authoritative: true;
+  as_of: string;
+  scope: {
+    magasin_id: string | null;
+    from: string | null;
+    to: string | null;
+  };
   kpis: {
     articles_count: number;
     stock_managed_articles: number;
     qty_on_hand: number;
     qty_available: number;
     qty_reserved: number;
+    ruptures_count: number;
+    below_minimum_count: number;
+    at_risk_reservations_count: number;
+    quarantine_lots_count: number;
+    active_inventory_count: number;
+    discrepancies_to_review_count: number;
   };
   magasins: Array<{
     id: string;
@@ -432,13 +540,25 @@ export type StockAnalytics = {
   };
 };
 
-export type StockInventorySessionStatus = "OPEN" | "CLOSED";
+export type StockInventorySessionStatus = "DRAFT" | "OPEN" | "APPROVED" | "CLOSED" | "CANCELLED";
 
 export type StockInventorySessionListItem = {
   id: string;
   session_no: string;
   status: StockInventorySessionStatus;
-  started_at: string;
+  scope_magasin_id: string | null;
+  scope_emplacement_id: number | null;
+  scope_article_id: string | null;
+  scope_article_category: ArticleCategory | null;
+  blind_count: boolean;
+  requires_second_count: boolean;
+  snapshot_at: string | null;
+  approved_at: string | null;
+  cancelled_at: string | null;
+  cancellation_reason: string | null;
+  row_version: number;
+  correlation_id: string | null;
+  started_at: string | null;
   closed_at: string | null;
   notes: string | null;
   updated_at: string;
@@ -449,6 +569,7 @@ export type StockInventorySessionListItem = {
 
 export type StockInventorySessionLine = {
   id: string;
+  snapshot_line_id: string;
   session_id: string;
   line_no: number;
   article_id: string;
@@ -462,9 +583,11 @@ export type StockInventorySessionLine = {
   emplacement_name: string | null;
   lot_id: string | null;
   lot_code: string | null;
-  counted_qty: number;
-  qty_on_hand: number;
-  delta_qty: number;
+  counted_qty: number | null;
+  qty_on_hand: number | null;
+  delta_qty: number | null;
+  count_round: 1 | 2 | null;
+  reason_code: string | null;
   note: string | null;
   updated_at: string;
   created_at: string;

--- a/src/module/stock/validators/stock-225.validators.test.ts
+++ b/src/module/stock/validators/stock-225.validators.test.ts
@@ -1,0 +1,275 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createInventorySessionSchema,
+  createLotGenealogySchema,
+  createMovementSchema,
+  postMovementSchema,
+  upsertInventoryLineSchema,
+} from "./stock.validators";
+import {
+  createStockReservationSchema,
+  consumeStockReservationSchema,
+  stockReservationActionSchema,
+} from "./stock-reservation.validators";
+
+const UUID_A = "11111111-1111-4111-8111-111111111111";
+const UUID_B = "22222222-2222-4222-8222-222222222222";
+const UUID_C = "33333333-3333-4333-8333-333333333333";
+
+describe("#225 stock validators", () => {
+  const movementCases: Array<{
+    name: string;
+    body: Record<string, unknown>;
+    valid: boolean;
+  }> = [
+    {
+      name: "inbound",
+      body: {
+        movement_type: "IN",
+        lines: [{ article_id: UUID_A, qty: 1, dst_magasin_id: UUID_B, dst_emplacement_id: 1 }],
+      },
+      valid: true,
+    },
+    {
+      name: "outbound",
+      body: {
+        movement_type: "OUT",
+        lines: [{ article_id: UUID_A, qty: 1, src_magasin_id: UUID_B, src_emplacement_id: 1 }],
+      },
+      valid: true,
+    },
+    {
+      name: "transfer",
+      body: {
+        movement_type: "TRANSFER",
+        lines: [{
+          article_id: UUID_A,
+          qty: 1,
+          src_magasin_id: UUID_B,
+          src_emplacement_id: 1,
+          dst_magasin_id: UUID_C,
+          dst_emplacement_id: 2,
+        }],
+      },
+      valid: true,
+    },
+    {
+      name: "adjustment in",
+      body: {
+        movement_type: "ADJUSTMENT",
+        lines: [{
+          article_id: UUID_A,
+          qty: 1,
+          direction: "IN",
+          dst_magasin_id: UUID_B,
+          dst_emplacement_id: 1,
+        }],
+      },
+      valid: true,
+    },
+    {
+      name: "zero quantity",
+      body: {
+        movement_type: "IN",
+        lines: [{ article_id: UUID_A, qty: 0, dst_magasin_id: UUID_B, dst_emplacement_id: 1 }],
+      },
+      valid: false,
+    },
+    {
+      name: "negative quantity",
+      body: {
+        movement_type: "OUT",
+        lines: [{ article_id: UUID_A, qty: -1, src_magasin_id: UUID_B, src_emplacement_id: 1 }],
+      },
+      valid: false,
+    },
+    {
+      name: "missing source",
+      body: { movement_type: "OUT", lines: [{ article_id: UUID_A, qty: 1 }] },
+      valid: false,
+    },
+    {
+      name: "missing destination",
+      body: { movement_type: "IN", lines: [{ article_id: UUID_A, qty: 1 }] },
+      valid: false,
+    },
+    {
+      name: "mixed articles",
+      body: {
+        movement_type: "IN",
+        lines: [
+          { article_id: UUID_A, qty: 1, dst_magasin_id: UUID_B, dst_emplacement_id: 1 },
+          { article_id: UUID_C, qty: 1, dst_magasin_id: UUID_B, dst_emplacement_id: 1 },
+        ],
+      },
+      valid: false,
+    },
+    {
+      name: "unknown key",
+      body: {
+        movement_type: "IN",
+        bypass: true,
+        lines: [{ article_id: UUID_A, qty: 1, dst_magasin_id: UUID_B, dst_emplacement_id: 1 }],
+      },
+      valid: false,
+    },
+  ];
+
+  for (const testCase of movementCases) {
+    it(`validates movement: ${testCase.name}`, () => {
+      expect(
+        createMovementSchema.safeParse({ body: testCase.body }).success
+      ).toBe(testCase.valid);
+    });
+  }
+
+  it("requires a bounded and justified negative-stock override", () => {
+    expect(
+      postMovementSchema.safeParse({
+        body: {
+          negative_stock_override: {
+            maximum_negative_qty: 5,
+            reason: "Arrêt de production évité",
+          },
+        },
+      }).success
+    ).toBe(true);
+    expect(
+      postMovementSchema.safeParse({
+        body: {
+          negative_stock_override: {
+            maximum_negative_qty: 0,
+            reason: "trop court",
+          },
+        },
+      }).success
+    ).toBe(false);
+  });
+
+  const inventoryCases: Array<{
+    name: string;
+    body: Record<string, unknown>;
+    valid: boolean;
+  }> = [
+    { name: "magasin scope", body: { scope_magasin_id: UUID_A }, valid: true },
+    { name: "article scope", body: { scope_article_id: UUID_A }, valid: true },
+    { name: "category scope", body: { scope_article_category: "matiere" }, valid: true },
+    {
+      name: "emplacement with parent",
+      body: { scope_magasin_id: UUID_A, scope_emplacement_id: 1 },
+      valid: true,
+    },
+    { name: "empty scope", body: {}, valid: false },
+    { name: "orphan emplacement", body: { scope_emplacement_id: 1 }, valid: false },
+    { name: "bad category", body: { scope_article_category: "autre" }, valid: false },
+    { name: "unknown field", body: { scope_article_id: UUID_A, delete_history: true }, valid: false },
+  ];
+
+  for (const testCase of inventoryCases) {
+    it(`validates inventory: ${testCase.name}`, () => {
+      expect(
+        createInventorySessionSchema.safeParse({ body: testCase.body }).success
+      ).toBe(testCase.valid);
+    });
+  }
+
+  it("validates count rounds, optimistic version and discrepancy metadata", () => {
+    const base = {
+      article_id: UUID_A,
+      magasin_id: UUID_B,
+      emplacement_id: 1,
+      counted_qty: 2,
+      expected_session_version: 1,
+    };
+    expect(upsertInventoryLineSchema.safeParse({ body: base }).success).toBe(true);
+    expect(
+      upsertInventoryLineSchema.safeParse({
+        body: { ...base, count_round: 3 },
+      }).success
+    ).toBe(false);
+    expect(
+      upsertInventoryLineSchema.safeParse({
+        body: { ...base, expected_session_version: 0 },
+      }).success
+    ).toBe(false);
+  });
+
+  it("validates split, merge and transform genealogy shapes", () => {
+    const contribution = (lot_id: string, qty: number) => ({ lot_id, qty });
+    expect(
+      createLotGenealogySchema.safeParse({
+        body: {
+          operation_type: "SPLIT",
+          parents: [contribution(UUID_A, 2)],
+          children: [contribution(UUID_B, 1), contribution(UUID_C, 1)],
+          unit_code: "PC",
+          stock_movement_id: UUID_A,
+        },
+      }).success
+    ).toBe(true);
+    expect(
+      createLotGenealogySchema.safeParse({
+        body: {
+          operation_type: "MERGE",
+          parents: [contribution(UUID_A, 1)],
+          children: [contribution(UUID_B, 1)],
+          unit_code: "PC",
+          stock_movement_id: UUID_C,
+        },
+      }).success
+    ).toBe(false);
+  });
+
+  it("requires a real business source for reservations", () => {
+    const base = {
+      article_id: UUID_A,
+      magasin_id: UUID_B,
+      emplacement_id: 1,
+      qty: 2,
+      reason: "Allocation commande",
+    };
+    expect(
+      createStockReservationSchema.safeParse({
+        body: {
+          ...base,
+          source: { source_type: "OF", of_id: 42 },
+        },
+      }).success
+    ).toBe(true);
+    expect(
+      createStockReservationSchema.safeParse({
+        body: {
+          ...base,
+          source: { source_type: "OF", source_id: "42" },
+        },
+      }).success
+    ).toBe(false);
+  });
+
+  it("requires optimistic versions and a posted movement when consuming", () => {
+    expect(
+      stockReservationActionSchema.safeParse({
+        body: { expected_version: 1, reason: "Commande annulée" },
+      }).success
+    ).toBe(true);
+    expect(
+      consumeStockReservationSchema.safeParse({
+        body: {
+          expected_version: 1,
+          reason: "Préparation expédiée",
+          stock_movement_id: UUID_A,
+        },
+      }).success
+    ).toBe(true);
+    expect(
+      consumeStockReservationSchema.safeParse({
+        body: {
+          expected_version: 0,
+          reason: "Préparation expédiée",
+          stock_movement_id: "invalid",
+        },
+      }).success
+    ).toBe(false);
+  });
+});

--- a/src/module/stock/validators/stock-reservation.validators.ts
+++ b/src/module/stock/validators/stock-reservation.validators.ts
@@ -1,0 +1,98 @@
+import { z } from "zod";
+
+const uuid = z.string().uuid();
+
+export const stockReservationStatusSchema = z.enum([
+  "ACTIVE",
+  "RELEASED",
+  "CONSUMED",
+  "EXPIRED",
+  "CANCELLED",
+]);
+
+export const stockReservationSourceSchema = z.discriminatedUnion("source_type", [
+  z
+    .object({
+      source_type: z.literal("COMMANDE_LIGNE"),
+      commande_ligne_id: z.coerce.number().int().positive(),
+    })
+    .strict(),
+  z
+    .object({
+      source_type: z.literal("OF"),
+      of_id: z.coerce.number().int().positive(),
+    })
+    .strict(),
+  z
+    .object({
+      source_type: z.literal("BON_LIVRAISON_LIGNE"),
+      bon_livraison_ligne_id: uuid,
+    })
+    .strict(),
+  z
+    .object({
+      source_type: z.literal("AFFAIRE"),
+      affaire_id: z.coerce.number().int().positive(),
+    })
+    .strict(),
+]);
+
+export const listStockReservationsQuerySchema = z
+  .object({
+    q: z.string().trim().max(120).optional(),
+    article_id: uuid.optional(),
+    magasin_id: uuid.optional(),
+    emplacement_id: z.coerce.number().int().positive().optional(),
+    lot_id: uuid.optional(),
+    status: stockReservationStatusSchema.optional(),
+    source_type: z
+      .enum(["COMMANDE_LIGNE", "OF", "BON_LIVRAISON_LIGNE", "AFFAIRE"])
+      .optional(),
+    page: z.coerce.number().int().min(1).optional().default(1),
+    pageSize: z.coerce.number().int().min(1).max(200).optional().default(50),
+    sortBy: z
+      .enum(["created_at", "updated_at", "expires_at", "qty_reserved"])
+      .optional()
+      .default("created_at"),
+    sortDir: z.enum(["asc", "desc"]).optional().default("desc"),
+  })
+  .strict();
+
+export const createStockReservationSchema = z.object({
+  body: z
+    .object({
+      article_id: uuid,
+      magasin_id: uuid,
+      emplacement_id: z.coerce.number().int().positive(),
+      lot_id: uuid.optional().nullable(),
+      qty: z.coerce.number().positive().max(1_000_000_000),
+      source: stockReservationSourceSchema,
+      reason: z.string().trim().min(3).max(500),
+      expires_at: z.string().datetime({ offset: true }).optional().nullable(),
+    })
+    .strict(),
+});
+
+export const stockReservationActionSchema = z.object({
+  body: z
+    .object({
+      expected_version: z.coerce.number().int().positive(),
+      reason: z.string().trim().min(3).max(500),
+    })
+    .strict(),
+});
+
+export const consumeStockReservationSchema = z.object({
+  body: z
+    .object({
+      expected_version: z.coerce.number().int().positive(),
+      reason: z.string().trim().min(3).max(500),
+      stock_movement_id: uuid,
+    })
+    .strict(),
+});
+
+export type ListStockReservationsQueryDTO = z.infer<typeof listStockReservationsQuerySchema>;
+export type CreateStockReservationBodyDTO = z.infer<typeof createStockReservationSchema>["body"];
+export type StockReservationActionBodyDTO = z.infer<typeof stockReservationActionSchema>["body"];
+export type ConsumeStockReservationBodyDTO = z.infer<typeof consumeStockReservationSchema>["body"];

--- a/src/module/stock/validators/stock.validators.ts
+++ b/src/module/stock/validators/stock.validators.ts
@@ -387,6 +387,9 @@ export const listEmplacementsQuerySchema = z.object({
   magasin_id: uuid.optional(),
   is_active: z.preprocess(parseBoolean, z.boolean().optional()),
   is_scrap: z.preprocess(parseBoolean, z.boolean().optional()),
+  location_type: z
+    .enum(["RECEIVING", "PRODUCTION", "QUARANTINE", "SCRAP", "SHIPPING", "STORAGE"])
+    .optional(),
   page: z.coerce.number().int().min(1).optional().default(1),
   pageSize: z.coerce.number().int().min(1).max(200).optional().default(50),
   sortBy: z.enum(["updated_at", "created_at", "code"]).optional().default("updated_at"),
@@ -395,6 +398,15 @@ export const listEmplacementsQuerySchema = z.object({
 
 export type ListEmplacementsQueryDTO = z.infer<typeof listEmplacementsQuerySchema>;
 
+export const stockLocationTypeSchema = z.enum([
+  "RECEIVING",
+  "PRODUCTION",
+  "QUARANTINE",
+  "SCRAP",
+  "SHIPPING",
+  "STORAGE",
+]);
+
 export const createEmplacementSchema = z.object({
   body: z
     .object({
@@ -402,9 +414,36 @@ export const createEmplacementSchema = z.object({
       name: z.string().trim().min(1).max(200).optional().nullable(),
       is_scrap: z.boolean().optional().default(false),
       is_active: z.boolean().optional().default(true),
+      location_type: stockLocationTypeSchema.optional().default("STORAGE"),
+      allow_inbound: z.boolean().optional().default(true),
+      allow_outbound: z.boolean().optional().default(true),
+      restrictions: z.record(z.unknown()).optional().default({}),
       notes: z.string().trim().min(1).optional().nullable(),
     })
-    .strict(),
+    .strict()
+    .superRefine((body, ctx) => {
+      if (body.is_scrap && body.location_type !== "SCRAP") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["location_type"],
+          message: "A scrap emplacement must use location_type SCRAP",
+        });
+      }
+      if (body.location_type === "SCRAP" && !body.is_scrap) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["is_scrap"],
+          message: "A SCRAP location must be marked as scrap",
+        });
+      }
+      if (body.location_type === "SCRAP" && body.allow_outbound) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["allow_outbound"],
+          message: "A SCRAP location cannot provide stock",
+        });
+      }
+    }),
 });
 
 export type CreateEmplacementBodyDTO = z.infer<typeof createEmplacementSchema>["body"];
@@ -416,6 +455,10 @@ export const updateEmplacementSchema = z.object({
       name: z.string().trim().min(1).max(200).optional().nullable(),
       is_scrap: z.boolean().optional(),
       is_active: z.boolean().optional(),
+      location_type: stockLocationTypeSchema.optional(),
+      allow_inbound: z.boolean().optional(),
+      allow_outbound: z.boolean().optional(),
+      restrictions: z.record(z.unknown()).optional(),
       notes: z.string().trim().min(1).optional().nullable(),
     })
     .strict(),
@@ -426,6 +469,7 @@ export type UpdateEmplacementBodyDTO = z.infer<typeof updateEmplacementSchema>["
 export const listLotsQuerySchema = z.object({
   q: z.string().trim().optional(),
   article_id: uuid.optional(),
+  lot_status: z.enum(["LIBERE", "EN_ATTENTE", "QUARANTAINE", "BLOQUE"]).optional(),
   page: z.coerce.number().int().min(1).optional().default(1),
   pageSize: z.coerce.number().int().min(1).max(200).optional().default(50),
   sortBy: z.enum(["updated_at", "created_at", "lot_code", "received_at"]).optional().default("updated_at"),
@@ -465,11 +509,78 @@ export const updateLotSchema = z.object({
 
 export type UpdateLotBodyDTO = z.infer<typeof updateLotSchema>["body"];
 
+export const updateLotQualitySchema = z.object({
+  body: z
+    .object({
+      lot_status: z.enum(["LIBERE", "EN_ATTENTE", "QUARANTAINE", "BLOQUE"]),
+      reason: z.string().trim().min(3).max(500),
+      expected_updated_at: z.string().datetime({ offset: true }),
+    })
+    .strict(),
+});
+
+export type UpdateLotQualityBodyDTO = z.infer<typeof updateLotQualitySchema>["body"];
+
+const lotGenealogyContributionSchema = z
+  .object({
+    lot_id: uuid,
+    qty: z.coerce.number().positive().max(1_000_000_000),
+  })
+  .strict();
+
+export const createLotGenealogySchema = z.object({
+  body: z
+    .object({
+      operation_type: z.enum(["SPLIT", "MERGE", "TRANSFORM"]),
+      parents: z.array(lotGenealogyContributionSchema).min(1).max(100),
+      children: z.array(lotGenealogyContributionSchema).min(1).max(100),
+      unit_code: z.string().trim().min(1).max(30),
+      stock_movement_id: uuid,
+    })
+    .strict()
+    .superRefine((body, ctx) => {
+      if (body.operation_type === "SPLIT" && (body.parents.length !== 1 || body.children.length < 2)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["children"],
+          message: "SPLIT requires exactly one parent and at least two children",
+        });
+      }
+      if (body.operation_type === "MERGE" && (body.parents.length < 2 || body.children.length !== 1)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["parents"],
+          message: "MERGE requires at least two parents and exactly one child",
+        });
+      }
+      if (body.operation_type === "TRANSFORM" && (body.parents.length !== 1 || body.children.length !== 1)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["parents"],
+          message: "TRANSFORM requires exactly one parent and one child",
+        });
+      }
+      const allIds = [...body.parents, ...body.children].map((item) => item.lot_id);
+      if (new Set(allIds).size !== allIds.length) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["children"],
+          message: "A lot cannot appear twice or on both sides of one genealogy operation",
+        });
+      }
+    }),
+});
+
+export type CreateLotGenealogyBodyDTO = z.infer<typeof createLotGenealogySchema>["body"];
+
 export const listBalancesQuerySchema = z.object({
+  q: z.string().trim().max(120).optional(),
   article_id: uuid.optional(),
   magasin_id: uuid.optional(),
   emplacement_id: z.coerce.number().int().positive().optional(),
   lot_id: uuid.optional(),
+  lot_status: z.enum(["LIBERE", "EN_ATTENTE", "QUARANTAINE", "BLOQUE"]).optional(),
+  only_available: z.preprocess(parseBoolean, z.boolean().optional()),
   warehouse_id: uuid.optional(),
   location_id: uuid.optional(),
   page: z.coerce.number().int().min(1).optional().default(1),
@@ -596,7 +707,43 @@ export const createMovementSchema = z.object({
 
 export type CreateMovementBodyDTO = z.infer<typeof createMovementSchema>["body"];
 
-export const stockInventorySessionStatusSchema = z.enum(["OPEN", "CLOSED"]);
+export const compensateMovementSchema = z.object({
+  body: z
+    .object({
+      reason: z.string().trim().min(3).max(500),
+      notes: z.string().trim().min(1).max(2_000).optional().nullable(),
+      expected_posted_at: z.string().datetime({ offset: true }),
+    })
+    .strict(),
+});
+
+export type CompensateMovementBodyDTO = z.infer<typeof compensateMovementSchema>["body"];
+
+export const postMovementSchema = z.object({
+  body: z
+    .object({
+      negative_stock_override: z
+        .object({
+          maximum_negative_qty: z.coerce.number().positive().max(1_000_000),
+          reason: z.string().trim().min(10).max(500),
+        })
+        .strict()
+        .optional(),
+    })
+    .strict()
+    .optional()
+    .default({}),
+});
+
+export type PostMovementBodyDTO = z.infer<typeof postMovementSchema>["body"];
+
+export const stockInventorySessionStatusSchema = z.enum([
+  "DRAFT",
+  "OPEN",
+  "APPROVED",
+  "CLOSED",
+  "CANCELLED",
+]);
 export type StockInventorySessionStatusDTO = z.infer<typeof stockInventorySessionStatusSchema>;
 
 export const listInventorySessionsQuerySchema = z.object({
@@ -614,8 +761,35 @@ export const createInventorySessionSchema = z.object({
   body: z
     .object({
       notes: z.string().trim().min(1).optional().nullable(),
+      scope_magasin_id: uuid.optional().nullable(),
+      scope_emplacement_id: z.coerce.number().int().positive().optional().nullable(),
+      scope_article_id: uuid.optional().nullable(),
+      scope_article_category: articleCategorySchema.optional().nullable(),
+      blind_count: z.boolean().optional().default(false),
+      requires_second_count: z.boolean().optional().default(false),
     })
-    .strict(),
+    .strict()
+    .superRefine((body, ctx) => {
+      if (
+        !body.scope_magasin_id &&
+        !body.scope_emplacement_id &&
+        !body.scope_article_id &&
+        !body.scope_article_category
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["scope_magasin_id"],
+          message: "Inventory scope must include a magasin, emplacement, article or category",
+        });
+      }
+      if (body.scope_emplacement_id && !body.scope_magasin_id) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["scope_magasin_id"],
+          message: "scope_magasin_id is required with scope_emplacement_id",
+        });
+      }
+    }),
 });
 
 export type CreateInventorySessionBodyDTO = z.infer<typeof createInventorySessionSchema>["body"];
@@ -628,9 +802,34 @@ export const upsertInventoryLineSchema = z.object({
       emplacement_id: z.coerce.number().int().positive(),
       lot_id: uuid.optional().nullable(),
       counted_qty: z.coerce.number().min(0),
+      count_round: z.coerce.number().int().min(1).max(2).optional().default(1),
+      reason_code: z.string().trim().min(2).max(80).optional().nullable(),
+      expected_session_version: z.coerce.number().int().positive(),
       note: z.string().trim().min(1).optional().nullable(),
     })
     .strict(),
 });
 
 export type UpsertInventoryLineBodyDTO = z.infer<typeof upsertInventoryLineSchema>["body"];
+
+export const inventorySessionActionSchema = z.object({
+  body: z
+    .object({
+      expected_version: z.coerce.number().int().positive(),
+      reason: z.string().trim().min(3).max(500).optional().nullable(),
+    })
+    .strict(),
+});
+
+export type InventorySessionActionBodyDTO = z.infer<typeof inventorySessionActionSchema>["body"];
+
+export const cancelInventorySessionSchema = z.object({
+  body: z
+    .object({
+      expected_version: z.coerce.number().int().positive(),
+      reason: z.string().trim().min(3).max(500),
+    })
+    .strict(),
+});
+
+export type CancelInventorySessionBodyDTO = z.infer<typeof cancelInventorySessionSchema>["body"];


### PR DESCRIPTION
## Release production — backend Stock #225

Promeut vers `main` la couche backend autoritaire de traçabilité Stock validée sur `dev`.

Cette release contient uniquement le commit de l’issue BigFootLime/crp-systems-web#225 : RBAC fail-closed, idempotence, réservations, mouvements compensatoires, lots/généalogie, inventaires et patch SQL additif.

## Validation

- suite backend Vitest complète réussie
- 46 tests ciblés #225 réussis
- TypeScript et gardes statiques de migration réussis
- PR d’intégration : #115

La migration `cerp_prod` et le redéploiement Coolify restent des actions distinctes avec contrôles dédiés.