### PR TITLE
fix(stock): aligner le préflight sur le schéma des événements (#225)

### DIFF
--- a/db/patches/support/20260723_stock_traceability_225.preflight.sql
+++ b/db/patches/support/20260723_stock_traceability_225.preflight.sql
@@ -51,7 +51,7 @@ WHERE table_schema = 'public'
       'user_id'
     ))
     OR (table_name = 'stock_movement_lines' AND column_name IN ('id', 'movement_id'))
-    OR (table_name = 'stock_movement_event_log' AND column_name IN ('id', 'movement_id', 'event_type'))
+    OR (table_name = 'stock_movement_event_log' AND column_name IN ('id', 'stock_movement_id', 'event_type'))
     OR (table_name = 'stock_levels' AND column_name IN ('id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
     OR (table_name = 'stock_batches' AND column_name IN ('id', 'lot_id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
     OR (table_name = 'stock_inventory_sessions' AND column_name IN ('id', 'status', 'started_at'))
@@ -91,7 +91,7 @@ BEGIN
         'user_id'
       ))
       OR (table_name = 'stock_movement_lines' AND column_name IN ('id', 'movement_id'))
-      OR (table_name = 'stock_movement_event_log' AND column_name IN ('id', 'movement_id', 'event_type'))
+      OR (table_name = 'stock_movement_event_log' AND column_name IN ('id', 'stock_movement_id', 'event_type'))
       OR (table_name = 'stock_levels' AND column_name IN ('id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
       OR (table_name = 'stock_batches' AND column_name IN ('id', 'lot_id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
       OR (table_name = 'stock_inventory_sessions' AND column_name IN ('id', 'status', 'started_at'))

--- a/src/__tests__/stock-traceability-225.migration-guards.test.ts
+++ b/src/__tests__/stock-traceability-225.migration-guards.test.ts
@@ -59,6 +59,12 @@ describe("#225 migration guards", () => {
       expect(script).toContain("current_database() <> 'cerp_test'");
     }
     expect(preflight).toContain("required stock columns");
+    expect(preflight).toContain(
+      "table_name = 'stock_movement_event_log' AND column_name IN ('id', 'stock_movement_id', 'event_type')"
+    );
+    expect(preflight).not.toContain(
+      "table_name = 'stock_movement_event_log' AND column_name IN ('id', 'movement_id', 'event_type')"
+    );
     expect(rollback).toContain(
       "#225 rollback refused: immutable stock evidence exists"
     );


### PR DESCRIPTION
## Correctif de migration #225

Le préflight attendait `movement_id` dans `stock_movement_event_log`, alors que le schéma canonique de `cerp_test` et `cerp_prod` expose `stock_movement_id`. Le contrôle bloquait donc à tort avec 34/35 colonnes avant toute modification.

## Correction

- aligne les deux contrôles du préflight sur `stock_movement_id`
- ajoute une assertion de non-régression interdisant l’ancien nom

## Validation

- préflight réel : écart reproduit sans aucune modification de base
- test de garde #225 : 5/5 réussi
- build TypeScript réussi

Référence : BigFootLime/crp-systems-web#225

## Summary by Sourcery

Align stock migration preflight checks with the canonical stock movement event log schema for migration #225.

Bug Fixes:
- Fix preflight column validation to expect stock_movement_id instead of movement_id for stock_movement_event_log, avoiding false migration blocking.

Tests:
- Add migration guard test ensuring preflight requires stock_movement_id and explicitly rejects the legacy movement_id column name.