### PR TITLE
release: corriger le préflight Stock #225

### DIFF
--- a/db/patches/support/20260723_stock_traceability_225.preflight.sql
+++ b/db/patches/support/20260723_stock_traceability_225.preflight.sql
@@ -51,7 +51,7 @@ WHERE table_schema = 'public'
       'user_id'
     ))
     OR (table_name = 'stock_movement_lines' AND column_name IN ('id', 'movement_id'))
-    OR (table_name = 'stock_movement_event_log' AND column_name IN ('id', 'movement_id', 'event_type'))
+    OR (table_name = 'stock_movement_event_log' AND column_name IN ('id', 'stock_movement_id', 'event_type'))
     OR (table_name = 'stock_levels' AND column_name IN ('id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
     OR (table_name = 'stock_batches' AND column_name IN ('id', 'lot_id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
     OR (table_name = 'stock_inventory_sessions' AND column_name IN ('id', 'status', 'started_at'))
@@ -91,7 +91,7 @@ BEGIN
         'user_id'
       ))
       OR (table_name = 'stock_movement_lines' AND column_name IN ('id', 'movement_id'))
-      OR (table_name = 'stock_movement_event_log' AND column_name IN ('id', 'movement_id', 'event_type'))
+      OR (table_name = 'stock_movement_event_log' AND column_name IN ('id', 'stock_movement_id', 'event_type'))
       OR (table_name = 'stock_levels' AND column_name IN ('id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
       OR (table_name = 'stock_batches' AND column_name IN ('id', 'lot_id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
       OR (table_name = 'stock_inventory_sessions' AND column_name IN ('id', 'status', 'started_at'))

--- a/src/__tests__/stock-traceability-225.migration-guards.test.ts
+++ b/src/__tests__/stock-traceability-225.migration-guards.test.ts
@@ -59,6 +59,12 @@ describe("#225 migration guards", () => {
       expect(script).toContain("current_database() <> 'cerp_test'");
     }
     expect(preflight).toContain("required stock columns");
+    expect(preflight).toContain(
+      "table_name = 'stock_movement_event_log' AND column_name IN ('id', 'stock_movement_id', 'event_type')"
+    );
+    expect(preflight).not.toContain(
+      "table_name = 'stock_movement_event_log' AND column_name IN ('id', 'movement_id', 'event_type')"
+    );
     expect(rollback).toContain(
       "#225 rollback refused: immutable stock evidence exists"
     );


### PR DESCRIPTION
## Hotfix production — préflight Stock #225

Promeut le correctif validé sur `dev` : le garde-fou de migration utilise désormais le nom canonique `stock_movement_id` de `stock_movement_event_log`.

- test de garde #225 : 5/5 réussi
- build TypeScript réussi
- PR d’intégration : #117

## Summary by Sourcery

Align the #225 stock traceability migration preflight guard with the canonical schema for production release.

Bug Fixes:
- Update the stock preflight SQL guard to reference the canonical stock_movement_event_log column name stock_movement_id instead of movement_id.

Tests:
- Extend the #225 migration guard test to assert the use of stock_movement_id and the absence of the old movement_id column reference in the generated preflight script.