### PR TITLE
fix(stock): utiliser l’horodatage canonique de disponibilité (#225)

### DIFF
--- a/db/patches/20260723_stock_traceability_225.sql
+++ b/db/patches/20260723_stock_traceability_225.sql
@@ -766,7 +766,7 @@ batch_rows AS (
     batch.qty_total,
     batch.qty_reserved,
     batch.qty_depreciated,
-    batch.updated_at
+    level.updated_at
   FROM public.stock_batches batch
   JOIN public.stock_levels level ON level.id = batch.stock_level_id
   LEFT JOIN public.lots lot ON lot.id = batch.lot_id

--- a/db/patches/support/20260723_stock_traceability_225.preflight.sql
+++ b/db/patches/support/20260723_stock_traceability_225.preflight.sql
@@ -52,7 +52,13 @@ WHERE table_schema = 'public'
     ))
     OR (table_name = 'stock_movement_lines' AND column_name IN ('id', 'movement_id'))
     OR (table_name = 'stock_movement_event_log' AND column_name IN ('id', 'stock_movement_id', 'event_type'))
-    OR (table_name = 'stock_levels' AND column_name IN ('id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
+    OR (table_name = 'stock_levels' AND column_name IN (
+      'id',
+      'qty_total',
+      'qty_reserved',
+      'qty_depreciated',
+      'updated_at'
+    ))
     OR (table_name = 'stock_batches' AND column_name IN ('id', 'lot_id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
     OR (table_name = 'stock_inventory_sessions' AND column_name IN ('id', 'status', 'started_at'))
     OR (table_name = 'stock_inventory_lines' AND column_name IN (
@@ -92,7 +98,13 @@ BEGIN
       ))
       OR (table_name = 'stock_movement_lines' AND column_name IN ('id', 'movement_id'))
       OR (table_name = 'stock_movement_event_log' AND column_name IN ('id', 'stock_movement_id', 'event_type'))
-      OR (table_name = 'stock_levels' AND column_name IN ('id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
+      OR (table_name = 'stock_levels' AND column_name IN (
+        'id',
+        'qty_total',
+        'qty_reserved',
+        'qty_depreciated',
+        'updated_at'
+      ))
       OR (table_name = 'stock_batches' AND column_name IN ('id', 'lot_id', 'qty_total', 'qty_reserved', 'qty_depreciated'))
       OR (table_name = 'stock_inventory_sessions' AND column_name IN ('id', 'status', 'started_at'))
       OR (table_name = 'stock_inventory_lines' AND column_name IN (
@@ -110,8 +122,8 @@ BEGIN
       OR (table_name = 'stock_reservations' AND column_name IN ('lot_id', 'stock_batch_id'))
     );
 
-  IF required_columns_count <> 35 THEN
-    RAISE EXCEPTION '#225 preflight found %/35 required stock columns', required_columns_count;
+  IF required_columns_count <> 36 THEN
+    RAISE EXCEPTION '#225 preflight found %/36 required stock columns', required_columns_count;
   END IF;
 
   IF NOT EXISTS (

--- a/src/__tests__/stock-traceability-225.migration-guards.test.ts
+++ b/src/__tests__/stock-traceability-225.migration-guards.test.ts
@@ -52,6 +52,8 @@ describe("#225 migration guards", () => {
     expect(patch).toContain("qty_blocked");
     expect(patch).toContain("qty_available");
     expect(patch).toContain("row.lot_status IS NULL OR row.lot_status = 'LIBERE'");
+    expect(patch).toContain("level.updated_at");
+    expect(patch).not.toContain("batch.updated_at");
   });
 
   it("restricts support scripts and refuses a lossy rollback", () => {
@@ -59,6 +61,10 @@ describe("#225 migration guards", () => {
       expect(script).toContain("current_database() <> 'cerp_test'");
     }
     expect(preflight).toContain("required stock columns");
+    expect(preflight).toContain("%/36 required stock columns");
+    expect(preflight).toMatch(
+      /table_name = 'stock_levels'[\s\S]*?'updated_at'/
+    );
     expect(preflight).toContain(
       "table_name = 'stock_movement_event_log' AND column_name IN ('id', 'stock_movement_id', 'event_type')"
     );


### PR DESCRIPTION
## Correctif de migration #225

L’exécution réelle sur `cerp_test` a révélé que `stock_batches` n’expose pas `updated_at`. La vue de disponibilité doit utiliser `stock_levels.updated_at`, qui est bien la date mise à jour par les mouvements de stock.

## Correction

- remplace `batch.updated_at` par `level.updated_at` dans la vue
- ajoute `stock_levels.updated_at` aux prérequis (36/36 colonnes)
- ajoute les assertions de non-régression

## Validation

- essai SQL transactionnel annulé intégralement au premier écart
- test de garde #225 : 5/5 réussi
- build TypeScript réussi

Référence : BigFootLime/crp-systems-web#225

## Summary by Sourcery

Use the canonical stock level timestamp for availability and enforce it in migration preflight and guards.

Bug Fixes:
- Correct availability view to use stock_levels.updated_at instead of stock_batches.updated_at for stock movement timestamping.

Enhancements:
- Extend migration preflight checks to require stock_levels.updated_at and update the expected required column count to 36.
- Strengthen migration guard tests to assert use of level.updated_at, disallow batch.updated_at, and validate the updated preflight configuration.

Tests:
- Add and update migration guard tests to cover the new timestamp source and preflight column requirements.