### PR TITLE
release: expédition et bons de livraison #226

### DIFF
--- a/db/patches/20260724_expedition_deliveries_226.sql
+++ b/db/patches/20260724_expedition_deliveries_226.sql
@@ -1,0 +1,279 @@
+-- Issue #226 - Préparation expédition, allocations sourcées et bons de livraison.
+-- Additive and idempotent. This patch must be applied through the normal reviewed
+-- migration workflow; it is never executed automatically by the application.
+
+BEGIN;
+
+ALTER TABLE public.bon_livraison
+  ADD COLUMN IF NOT EXISTS row_version integer NOT NULL DEFAULT 1;
+
+ALTER TABLE public.bon_livraison_ligne_allocations
+  ADD COLUMN IF NOT EXISTS magasin_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS emplacement_id bigint NULL,
+  ADD COLUMN IF NOT EXISTS location_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS stock_level_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS stock_batch_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS reservation_id uuid NULL;
+
+ALTER TABLE public.bon_livraison_documents
+  ADD COLUMN IF NOT EXISTS checksum_sha256 text NULL,
+  ADD COLUMN IF NOT EXISTS file_size_bytes bigint NULL,
+  ADD COLUMN IF NOT EXISTS mime_type text NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'bl_allocations_source_shape_226_ck'
+      AND conrelid = 'public.bon_livraison_ligne_allocations'::regclass
+  ) THEN
+    ALTER TABLE public.bon_livraison_ligne_allocations
+      ADD CONSTRAINT bl_allocations_source_shape_226_ck
+      CHECK (
+        (
+          magasin_id IS NULL
+          AND emplacement_id IS NULL
+          AND location_id IS NULL
+          AND stock_level_id IS NULL
+          AND stock_batch_id IS NULL
+          AND reservation_id IS NULL
+        )
+        OR (
+          magasin_id IS NOT NULL
+          AND emplacement_id IS NOT NULL
+          AND location_id IS NOT NULL
+          AND stock_level_id IS NOT NULL
+          AND (
+            (lot_id IS NULL AND stock_batch_id IS NULL)
+            OR (lot_id IS NOT NULL AND stock_batch_id IS NOT NULL)
+          )
+        )
+      ) NOT VALID;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'bl_allocations_magasin_226_fkey'
+      AND conrelid = 'public.bon_livraison_ligne_allocations'::regclass
+  ) THEN
+    ALTER TABLE public.bon_livraison_ligne_allocations
+      ADD CONSTRAINT bl_allocations_magasin_226_fkey
+      FOREIGN KEY (magasin_id) REFERENCES public.magasins(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'bl_allocations_emplacement_226_fkey'
+      AND conrelid = 'public.bon_livraison_ligne_allocations'::regclass
+  ) THEN
+    ALTER TABLE public.bon_livraison_ligne_allocations
+      ADD CONSTRAINT bl_allocations_emplacement_226_fkey
+      FOREIGN KEY (emplacement_id) REFERENCES public.emplacements(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'bl_allocations_location_226_fkey'
+      AND conrelid = 'public.bon_livraison_ligne_allocations'::regclass
+  ) THEN
+    ALTER TABLE public.bon_livraison_ligne_allocations
+      ADD CONSTRAINT bl_allocations_location_226_fkey
+      FOREIGN KEY (location_id) REFERENCES public.locations(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'bl_allocations_stock_level_226_fkey'
+      AND conrelid = 'public.bon_livraison_ligne_allocations'::regclass
+  ) THEN
+    ALTER TABLE public.bon_livraison_ligne_allocations
+      ADD CONSTRAINT bl_allocations_stock_level_226_fkey
+      FOREIGN KEY (stock_level_id) REFERENCES public.stock_levels(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'bl_allocations_stock_batch_226_fkey'
+      AND conrelid = 'public.bon_livraison_ligne_allocations'::regclass
+  ) THEN
+    ALTER TABLE public.bon_livraison_ligne_allocations
+      ADD CONSTRAINT bl_allocations_stock_batch_226_fkey
+      FOREIGN KEY (stock_batch_id) REFERENCES public.stock_batches(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'bl_allocations_reservation_226_fkey'
+      AND conrelid = 'public.bon_livraison_ligne_allocations'::regclass
+  ) THEN
+    ALTER TABLE public.bon_livraison_ligne_allocations
+      ADD CONSTRAINT bl_allocations_reservation_226_fkey
+      FOREIGN KEY (reservation_id) REFERENCES public.stock_reservations(id) ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'bl_documents_checksum_226_ck'
+      AND conrelid = 'public.bon_livraison_documents'::regclass
+  ) THEN
+    ALTER TABLE public.bon_livraison_documents
+      ADD CONSTRAINT bl_documents_checksum_226_ck
+      CHECK (checksum_sha256 IS NULL OR checksum_sha256 ~ '^[A-Fa-f0-9]{64}$') NOT VALID;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'bl_documents_size_226_ck'
+      AND conrelid = 'public.bon_livraison_documents'::regclass
+  ) THEN
+    ALTER TABLE public.bon_livraison_documents
+      ADD CONSTRAINT bl_documents_size_226_ck
+      CHECK (file_size_bytes IS NULL OR file_size_bytes > 0) NOT VALID;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS bl_allocations_source_226_idx
+  ON public.bon_livraison_ligne_allocations(stock_level_id, stock_batch_id);
+CREATE UNIQUE INDEX IF NOT EXISTS bl_allocations_reservation_226_uq
+  ON public.bon_livraison_ligne_allocations(reservation_id)
+  WHERE reservation_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.bon_livraison_command_receipts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  command_type text NOT NULL,
+  bon_livraison_id uuid NOT NULL REFERENCES public.bon_livraison(id) ON DELETE RESTRICT,
+  request_payload jsonb NOT NULL,
+  result_payload jsonb NOT NULL,
+  correlation_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT bl_command_receipts_actor_key_226_uq UNIQUE (actor_user_id, idempotency_key),
+  CONSTRAINT bl_command_receipts_key_len_226_ck CHECK (char_length(idempotency_key) BETWEEN 8 AND 200),
+  CONSTRAINT bl_command_receipts_hash_226_ck CHECK (request_hash ~ '^[A-Fa-f0-9]{64}$'),
+  CONSTRAINT bl_command_receipts_type_226_ck CHECK (command_type IN ('SHIP'))
+);
+
+CREATE INDEX IF NOT EXISTS bl_command_receipts_bl_226_idx
+  ON public.bon_livraison_command_receipts(bon_livraison_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS bl_command_receipts_correlation_226_idx
+  ON public.bon_livraison_command_receipts(correlation_id);
+
+CREATE TABLE IF NOT EXISTS public.bon_livraison_delivery_proofs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  bon_livraison_id uuid NOT NULL REFERENCES public.bon_livraison(id) ON DELETE RESTRICT,
+  proof_type text NOT NULL,
+  delivered_at timestamptz NOT NULL,
+  received_by_name text NULL,
+  document_id uuid NULL REFERENCES public.documents_clients(id) ON DELETE RESTRICT,
+  note text NULL,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT bl_delivery_proof_type_226_ck CHECK (
+    proof_type IN ('RECIPIENT_ACK', 'CARRIER_DOCUMENT', 'PHOTO', 'EXTERNAL_SIGNATURE')
+  ),
+  CONSTRAINT bl_delivery_proof_name_226_ck CHECK (
+    received_by_name IS NULL OR char_length(received_by_name) BETWEEN 1 AND 200
+  ),
+  CONSTRAINT bl_delivery_proof_note_226_ck CHECK (
+    note IS NULL OR char_length(note) <= 2000
+  )
+);
+
+CREATE INDEX IF NOT EXISTS bl_delivery_proofs_bl_226_idx
+  ON public.bon_livraison_delivery_proofs(bon_livraison_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.erp_outbox_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_key text NOT NULL UNIQUE,
+  aggregate_type text NOT NULL,
+  aggregate_id text NOT NULL,
+  event_type text NOT NULL,
+  payload jsonb NOT NULL,
+  correlation_id uuid NOT NULL,
+  status text NOT NULL DEFAULT 'PENDING',
+  attempt_count integer NOT NULL DEFAULT 0,
+  available_at timestamptz NOT NULL DEFAULT now(),
+  published_at timestamptz NULL,
+  last_error text NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT erp_outbox_status_226_ck CHECK (status IN ('PENDING', 'PROCESSING', 'PUBLISHED', 'FAILED')),
+  CONSTRAINT erp_outbox_attempt_226_ck CHECK (attempt_count >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS erp_outbox_pending_226_idx
+  ON public.erp_outbox_events(status, available_at, created_at)
+  WHERE status IN ('PENDING', 'FAILED');
+CREATE INDEX IF NOT EXISTS erp_outbox_aggregate_226_idx
+  ON public.erp_outbox_events(aggregate_type, aggregate_id, created_at DESC);
+
+CREATE OR REPLACE FUNCTION public.fn_bump_bon_livraison_version_226()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.row_version := OLD.row_version + 1;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_bump_bon_livraison_version_226 ON public.bon_livraison;
+CREATE TRIGGER trg_bump_bon_livraison_version_226
+BEFORE UPDATE ON public.bon_livraison
+FOR EACH ROW EXECUTE FUNCTION public.fn_bump_bon_livraison_version_226();
+
+CREATE OR REPLACE FUNCTION public.fn_protect_livraison_evidence_226()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'delivery evidence is immutable'
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_bl_event_log_226 ON public.bon_livraison_event_log;
+CREATE TRIGGER trg_protect_bl_event_log_226
+BEFORE UPDATE OR DELETE ON public.bon_livraison_event_log
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_livraison_evidence_226();
+
+DROP TRIGGER IF EXISTS trg_protect_bl_command_receipts_226 ON public.bon_livraison_command_receipts;
+CREATE TRIGGER trg_protect_bl_command_receipts_226
+BEFORE UPDATE OR DELETE ON public.bon_livraison_command_receipts
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_livraison_evidence_226();
+
+DROP TRIGGER IF EXISTS trg_protect_bl_delivery_proofs_226 ON public.bon_livraison_delivery_proofs;
+CREATE TRIGGER trg_protect_bl_delivery_proofs_226
+BEFORE UPDATE OR DELETE ON public.bon_livraison_delivery_proofs
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_livraison_evidence_226();
+
+CREATE OR REPLACE VIEW public.v_bon_livraison_reliquats_226 AS
+SELECT
+  cl.id AS commande_ligne_id,
+  cl.commande_id,
+  cl.quantite::numeric(18, 3) AS quantite_commandee,
+  COALESCE(SUM(
+    CASE
+      WHEN bl.statut IN ('SHIPPED', 'DELIVERED') THEN bll.quantite
+      ELSE 0
+    END
+  ), 0)::numeric(18, 3) AS quantite_expediee,
+  GREATEST(
+    cl.quantite - COALESCE(SUM(
+      CASE
+        WHEN bl.statut IN ('SHIPPED', 'DELIVERED') THEN bll.quantite
+        ELSE 0
+      END
+    ), 0),
+    0
+  )::numeric(18, 3) AS quantite_restante
+FROM public.commande_ligne cl
+LEFT JOIN public.bon_livraison_ligne bll ON bll.commande_ligne_id = cl.id
+LEFT JOIN public.bon_livraison bl ON bl.id = bll.bon_livraison_id
+GROUP BY cl.id, cl.commande_id, cl.quantite;
+
+COMMIT;

--- a/db/patches/support/20260724_expedition_deliveries_226.preflight.sql
+++ b/db/patches/support/20260724_expedition_deliveries_226.preflight.sql
@@ -1,0 +1,48 @@
+-- Read-only preflight for issue #226.
+SELECT prerequisite, ok
+FROM (
+  VALUES
+    ('bon_livraison', to_regclass('public.bon_livraison') IS NOT NULL),
+    ('bon_livraison_ligne', to_regclass('public.bon_livraison_ligne') IS NOT NULL),
+    ('bon_livraison_ligne_allocations', to_regclass('public.bon_livraison_ligne_allocations') IS NOT NULL),
+    ('bon_livraison_documents', to_regclass('public.bon_livraison_documents') IS NOT NULL),
+    ('bon_livraison_event_log', to_regclass('public.bon_livraison_event_log') IS NOT NULL),
+    ('commande_ligne', to_regclass('public.commande_ligne') IS NOT NULL),
+    ('documents_clients', to_regclass('public.documents_clients') IS NOT NULL),
+    ('emplacements', to_regclass('public.emplacements') IS NOT NULL),
+    ('locations', to_regclass('public.locations') IS NOT NULL),
+    ('magasins', to_regclass('public.magasins') IS NOT NULL),
+    ('stock_levels', to_regclass('public.stock_levels') IS NOT NULL),
+    ('stock_batches', to_regclass('public.stock_batches') IS NOT NULL),
+    ('stock_reservations', to_regclass('public.stock_reservations') IS NOT NULL),
+    ('stock_command_receipts', to_regclass('public.stock_command_receipts') IS NOT NULL),
+    ('stock_movement_event_log', to_regclass('public.stock_movement_event_log') IS NOT NULL),
+    ('users', to_regclass('public.users') IS NOT NULL),
+    ('gen_random_uuid', to_regprocedure('gen_random_uuid()') IS NOT NULL)
+) AS checks(prerequisite, ok)
+ORDER BY prerequisite;
+
+SELECT
+  table_name,
+  column_name,
+  data_type,
+  udt_name
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND (
+    (table_name = 'bon_livraison' AND column_name = 'id')
+    OR (table_name = 'bon_livraison_ligne' AND column_name IN ('id', 'commande_ligne_id'))
+    OR (table_name = 'bon_livraison_ligne_allocations' AND column_name IN ('article_id', 'lot_id'))
+    OR (table_name = 'magasins' AND column_name = 'id')
+    OR (table_name = 'emplacements' AND column_name = 'id')
+    OR (table_name = 'locations' AND column_name = 'id')
+    OR (table_name = 'stock_levels' AND column_name = 'id')
+    OR (table_name = 'stock_batches' AND column_name = 'id')
+    OR (table_name = 'stock_reservations' AND column_name = 'id')
+  )
+ORDER BY table_name, column_name;
+
+SELECT
+  count(*) FILTER (WHERE statut = 'READY') AS ready_count,
+  count(*) FILTER (WHERE statut IN ('SHIPPED', 'DELIVERED')) AS immutable_business_count
+FROM public.bon_livraison;

--- a/db/patches/support/20260724_expedition_deliveries_226.rollback.sql
+++ b/db/patches/support/20260724_expedition_deliveries_226.rollback.sql
@@ -1,0 +1,65 @@
+-- Guarded rollback for issue #226. Never run automatically.
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM public.bon_livraison_command_receipts LIMIT 1)
+    OR EXISTS (SELECT 1 FROM public.bon_livraison_delivery_proofs LIMIT 1)
+    OR EXISTS (
+      SELECT 1
+      FROM public.bon_livraison_ligne_allocations
+      WHERE magasin_id IS NOT NULL
+         OR reservation_id IS NOT NULL
+      LIMIT 1
+    )
+    OR EXISTS (
+      SELECT 1
+      FROM public.bon_livraison_documents
+      WHERE checksum_sha256 IS NOT NULL
+         OR file_size_bytes IS NOT NULL
+         OR mime_type IS NOT NULL
+      LIMIT 1
+    )
+  THEN
+    RAISE EXCEPTION '#226 rollback refused: delivery evidence or sourced allocations exist';
+  END IF;
+END $$;
+
+BEGIN;
+
+DROP VIEW IF EXISTS public.v_bon_livraison_reliquats_226;
+DROP TRIGGER IF EXISTS trg_protect_bl_delivery_proofs_226 ON public.bon_livraison_delivery_proofs;
+DROP TRIGGER IF EXISTS trg_protect_bl_command_receipts_226 ON public.bon_livraison_command_receipts;
+DROP TRIGGER IF EXISTS trg_protect_bl_event_log_226 ON public.bon_livraison_event_log;
+DROP TRIGGER IF EXISTS trg_bump_bon_livraison_version_226 ON public.bon_livraison;
+DROP FUNCTION IF EXISTS public.fn_protect_livraison_evidence_226();
+DROP FUNCTION IF EXISTS public.fn_bump_bon_livraison_version_226();
+DROP TABLE IF EXISTS public.bon_livraison_delivery_proofs;
+DROP TABLE IF EXISTS public.bon_livraison_command_receipts;
+
+ALTER TABLE public.bon_livraison_ligne_allocations
+  DROP CONSTRAINT IF EXISTS bl_allocations_reservation_226_fkey,
+  DROP CONSTRAINT IF EXISTS bl_allocations_stock_batch_226_fkey,
+  DROP CONSTRAINT IF EXISTS bl_allocations_stock_level_226_fkey,
+  DROP CONSTRAINT IF EXISTS bl_allocations_location_226_fkey,
+  DROP CONSTRAINT IF EXISTS bl_allocations_emplacement_226_fkey,
+  DROP CONSTRAINT IF EXISTS bl_allocations_magasin_226_fkey,
+  DROP CONSTRAINT IF EXISTS bl_allocations_source_shape_226_ck,
+  DROP COLUMN IF EXISTS reservation_id,
+  DROP COLUMN IF EXISTS stock_batch_id,
+  DROP COLUMN IF EXISTS stock_level_id,
+  DROP COLUMN IF EXISTS location_id,
+  DROP COLUMN IF EXISTS emplacement_id,
+  DROP COLUMN IF EXISTS magasin_id;
+
+ALTER TABLE public.bon_livraison
+  DROP COLUMN IF EXISTS row_version;
+
+ALTER TABLE public.bon_livraison_documents
+  DROP CONSTRAINT IF EXISTS bl_documents_size_226_ck,
+  DROP CONSTRAINT IF EXISTS bl_documents_checksum_226_ck,
+  DROP COLUMN IF EXISTS mime_type,
+  DROP COLUMN IF EXISTS file_size_bytes,
+  DROP COLUMN IF EXISTS checksum_sha256;
+
+-- erp_outbox_events is intentionally retained: it is a shared integration seam.
+
+COMMIT;

--- a/db/patches/support/20260724_expedition_deliveries_226.verify.sql
+++ b/db/patches/support/20260724_expedition_deliveries_226.verify.sql
@@ -1,0 +1,42 @@
+-- Read-only verification for issue #226.
+SELECT object_name, present
+FROM (
+  VALUES
+    ('bon_livraison_command_receipts', to_regclass('public.bon_livraison_command_receipts') IS NOT NULL),
+    ('bon_livraison_delivery_proofs', to_regclass('public.bon_livraison_delivery_proofs') IS NOT NULL),
+    ('erp_outbox_events', to_regclass('public.erp_outbox_events') IS NOT NULL),
+    ('v_bon_livraison_reliquats_226', to_regclass('public.v_bon_livraison_reliquats_226') IS NOT NULL)
+) AS checks(object_name, present)
+ORDER BY object_name;
+
+SELECT
+  count(*) FILTER (
+    WHERE stock_movement_line_id IS NOT NULL
+      AND (
+        magasin_id IS NULL
+        OR emplacement_id IS NULL
+        OR location_id IS NULL
+        OR stock_level_id IS NULL
+      )
+  ) AS shipped_allocations_without_source,
+  count(*) FILTER (
+    WHERE reservation_id IS NOT NULL
+      AND stock_movement_line_id IS NULL
+  ) AS active_or_unconsumed_allocation_links
+FROM public.bon_livraison_ligne_allocations;
+
+SELECT
+  count(*) FILTER (WHERE status = 'ACTIVE' AND bon_livraison_ligne_id IS NOT NULL) AS active_bl_reservations,
+  count(*) FILTER (WHERE status = 'CONSUMED' AND consumed_stock_movement_id IS NULL) AS invalid_consumed_reservations
+FROM public.stock_reservations;
+
+SELECT
+  count(*) FILTER (WHERE checksum_sha256 IS NULL) AS documents_without_checksum,
+  count(*) FILTER (WHERE checksum_sha256 IS NOT NULL AND checksum_sha256 !~ '^[A-Fa-f0-9]{64}$') AS invalid_checksums,
+  count(*) FILTER (WHERE file_size_bytes IS NOT NULL AND file_size_bytes <= 0) AS invalid_file_sizes
+FROM public.bon_livraison_documents;
+
+SELECT
+  count(*) FILTER (WHERE status IN ('PENDING', 'FAILED')) AS outbox_to_publish,
+  count(*) FILTER (WHERE event_type = 'DELIVERY.SHIPPED') AS shipment_events
+FROM public.erp_outbox_events;

--- a/docs/http/livraisons-226.md
+++ b/docs/http/livraisons-226.md
@@ -1,0 +1,43 @@
+# API autoritaire Livraison — issue #226
+
+Le module `src/module/livraisons` est monté sous `/api/v1/livraisons`.
+
+## Écritures critiques
+
+- `POST /:id/status` prépare `READY`, annule avec motif ou déclare livré après
+  preuve. Il refuse `SHIPPED`.
+- `GET /:id/shipment-preview` calcule l'aperçu sans écriture.
+- `POST /:id/ship` exige `Idempotency-Key`, `expected_version` et
+  `preview_hash`.
+- `POST /:id/proofs` ajoute une preuve append-only.
+
+La confirmation `ship` utilise une transaction unique et des verrous
+déterministes. Elle poste les mouvements `OUT` depuis les allocations réelles,
+consomme les réservations, écrit event log, audit, outbox et reçu
+d'idempotence. Le résultat contient obligatoirement :
+
+```json
+{
+  "billing_event": "DELIVERY.SHIPPED",
+  "invoice_created": false
+}
+```
+
+Il n'existe aucun import ou appel Facture dans ce flux.
+
+## Patch
+
+`db/patches/20260724_expedition_deliveries_226.sql` et ses scripts
+`preflight`, `verify`, `rollback` sont préparés, non exécutés. Le code exige le
+patch avant déploiement. Ne pas démarrer le backend #226 sur un schéma ancien.
+
+## Permissions
+
+Capacités : `read`, `prepare`, `allocate`, `ship`, `deliver`, `cancel`,
+`documents_manage`, `proof_manage`, `export`. Résolution fail-closed.
+
+## Documents
+
+Les uploads sont contrôlés extension/MIME/signature, limités à 10 × 20 Mo,
+hashés SHA-256 et stockés hors exposition publique. `storage_path` n'est jamais
+retourné.

--- a/src/module/livraisons/controllers/livraisons.controller.ts
+++ b/src/module/livraisons/controllers/livraisons.controller.ts
@@ -12,11 +12,17 @@ import {
   livraisonLineIdParamsSchema,
   livraisonLineAllocationIdParamsSchema,
   livraisonStatusBodySchema,
+  livraisonProofBodySchema,
+  shipLivraisonBodySchema,
   updateLivraisonBodySchema,
   updateLivraisonLineBodySchema,
 } from "../validators/livraisons.validators"
 import * as service from "../services/livraisons.service"
 import * as pdfService from "../services/pdf.service"
+import {
+  removeTemporaryLivraisonDocuments,
+  validateLivraisonDocuments,
+} from "../services/livraisons-document-validation"
 import { repoFindDocumentFilePath, repoGetDocumentName, repoIsLivraisonDocumentLinked } from "../repository/livraisons.repository"
 import { emitEntityChanged } from "../../../shared/realtime/realtime.service"
 
@@ -34,6 +40,18 @@ function getUserId(req: Express.Request): number {
   const userId = typeof req.user?.id === "number" ? req.user.id : null
   if (!userId) throw new HttpError(401, "UNAUTHORIZED", "Authentication required")
   return userId
+}
+
+function getRequiredIdempotencyKey(req: Request): string {
+  const value = req.headers["idempotency-key"]
+  if (typeof value !== "string" || value.trim().length < 8 || value.trim().length > 200) {
+    throw new HttpError(
+      400,
+      "IDEMPOTENCY_KEY_REQUIRED",
+      "A valid Idempotency-Key header is required (8 to 200 characters)."
+    )
+  }
+  return value.trim()
 }
 
 function routeParam(req: Request, name: string): string {
@@ -233,16 +251,55 @@ export const updateLivraisonStatus: RequestHandler = async (req, res, next) => {
   }
 }
 
+export const getLivraisonShipmentPreview: RequestHandler = async (req, res, next) => {
+  try {
+    getUserId(req)
+    const { id } = livraisonIdParamsSchema.parse(req.params)
+    const out = await service.svcGetLivraisonShipmentPreview(id)
+    res.status(200).json(out)
+  } catch (e) {
+    next(e)
+  }
+}
+
+export const shipLivraison: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = getUserId(req)
+    const { id } = livraisonIdParamsSchema.parse(req.params)
+    const body = shipLivraisonBodySchema.parse(req.body)
+    const out = await service.svcShipLivraison(
+      id,
+      body,
+      userId,
+      getRequiredIdempotencyKey(req)
+    )
+    emitLivraisonChanged(req, { entityId: id, action: "status_changed" })
+    res.status(200).json(out)
+  } catch (e) {
+    next(e)
+  }
+}
+
+export const createLivraisonProof: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = getUserId(req)
+    const { id } = livraisonIdParamsSchema.parse(req.params)
+    const body = livraisonProofBodySchema.parse(req.body)
+    const out = await service.svcCreateLivraisonProof(id, body, userId)
+    emitLivraisonChanged(req, { entityId: id, action: "updated" })
+    res.status(201).json(out)
+  } catch (e) {
+    next(e)
+  }
+}
+
 export const uploadLivraisonDocuments: RequestHandler = async (req, res, next) => {
+  const files = (req.files ?? []) as Express.Multer.File[]
   try {
     const userId = getUserId(req)
     const { id } = livraisonIdParamsSchema.parse(req.params)
 
-    const files = (req.files ?? []) as Express.Multer.File[]
-    if (!files.length) {
-      res.status(400).json({ error: "No documents uploaded" })
-      return
-    }
+    await validateLivraisonDocuments(files)
 
     const body = req.body
     const type =
@@ -254,7 +311,12 @@ export const uploadLivraisonDocuments: RequestHandler = async (req, res, next) =
         : null
     const out = await service.svcAttachLivraisonDocuments({
       bonLivraisonId: id,
-      documents: files.map((f) => ({ originalname: f.originalname, path: f.path, mimetype: f.mimetype })),
+      documents: files.map((f) => ({
+        originalname: f.originalname,
+        path: f.path,
+        mimetype: f.mimetype,
+        size: f.size,
+      })),
       type,
       userId,
     })
@@ -262,6 +324,7 @@ export const uploadLivraisonDocuments: RequestHandler = async (req, res, next) =
     emitLivraisonChanged(req, { entityId: id, action: "updated" })
     res.status(201).json({ documents: out })
   } catch (e) {
+    await removeTemporaryLivraisonDocuments(files)
     next(e)
   }
 }

--- a/src/module/livraisons/domain/livraisons-policy.test.ts
+++ b/src/module/livraisons/domain/livraisons-policy.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  deliveryLotIsConsumable,
+  deliveryQuantitiesMatch,
+  deliveryQuantityAvailable,
+  isLivraisonTransitionAllowed,
+  shipmentBillingBoundary,
+  shipmentConfirmationMatches,
+  shipmentReceiptDecision,
+} from "./livraisons-policy"
+
+const statuses = ["DRAFT", "READY", "SHIPPED", "DELIVERED", "CANCELLED"] as const
+const transitionCases = statuses.flatMap((from) =>
+  statuses.map((to) => ({ from, to }))
+)
+
+describe("issue #226 — matrice métier factorisée", () => {
+  it.each(transitionCases.map((testCase, index) => ({ id: `T${String(index + 1).padStart(3, "0")}`, ...testCase })))(
+    "$id transition $from -> $to",
+    ({ from, to }) => {
+      const expected =
+        from === to ||
+        (from === "DRAFT" && (to === "READY" || to === "CANCELLED")) ||
+        (from === "READY" && (to === "SHIPPED" || to === "CANCELLED")) ||
+        (from === "SHIPPED" && to === "DELIVERED")
+      expect(isLivraisonTransitionAllowed(from, to)).toBe(expected)
+    }
+  )
+
+  const expectedQuantities = [0.001, 1, 2.5, 10, 999.999]
+  const allocatedQuantities = [0, 0.001, 1, 2.5, 10, 999.999, 1000]
+  const quantityCases = expectedQuantities.flatMap((expected) =>
+    allocatedQuantities.map((allocated) => ({ expected, allocated }))
+  )
+  it.each(quantityCases.map((testCase, index) => ({ id: `Q${String(index + 1).padStart(3, "0")}`, ...testCase })))(
+    "$id couverture $allocated / $expected",
+    ({ expected, allocated }) => {
+      expect(deliveryQuantitiesMatch(expected, allocated)).toBe(
+        Math.abs(expected - allocated) <= 1e-9 && allocated > 0
+      )
+    }
+  )
+
+  const availabilityCases = [0, 1, 10, 100].flatMap((qty_on_hand) =>
+    [0, 2].flatMap((qty_reserved) =>
+      [0, 1].flatMap((qty_depreciated) =>
+        [0, 2].map((own_reservation) => ({
+          qty_on_hand,
+          qty_reserved,
+          qty_depreciated,
+          own_reservation,
+        }))
+      )
+    )
+  )
+  it.each(availabilityCases.map((testCase, index) => ({ id: `S${String(index + 1).padStart(3, "0")}`, ...testCase })))(
+    "$id disponible physique/réservé/déprécié/propre",
+    (testCase) => {
+      expect(deliveryQuantityAvailable(testCase)).toBe(
+        Math.max(
+          testCase.qty_on_hand -
+            testCase.qty_reserved -
+            testCase.qty_depreciated +
+            testCase.own_reservation,
+          0
+        )
+      )
+    }
+  )
+
+  const lotCases = [null, "lot-1"].flatMap((lotId) =>
+    [null, "LIBERE", "BLOQUE", "EN_ATTENTE", "QUARANTAINE"].map((lotStatus) => ({
+      lotId,
+      lotStatus,
+    }))
+  )
+  it.each(lotCases.map((testCase, index) => ({ id: `L${String(index + 1).padStart(3, "0")}`, ...testCase })))(
+    "$id qualité lot $lotStatus",
+    ({ lotId, lotStatus }) => {
+      expect(deliveryLotIsConsumable(lotId, lotStatus)).toBe(
+        lotId === null || lotStatus === "LIBERE"
+      )
+    }
+  )
+
+  it.each(Array.from({ length: 16 }, (_, index) => ({ id: `F${String(index + 1).padStart(3, "0")}` })))(
+    "$id frontière de facturation constante",
+    () => {
+      expect(shipmentBillingBoundary()).toEqual({
+        event_type: "DELIVERY.SHIPPED",
+        invoice_created: false,
+        billing_decision: "PENDING_DOWNSTREAM_REVIEW",
+      })
+    }
+  )
+
+  it.each([
+    [null, "hash-a", "NEW"],
+    ["hash-a", "hash-a", "REPLAY"],
+    ["hash-a", "hash-b", "CONFLICT"],
+  ] as const)("idempotence %s / %s -> %s", (existing, current, expected) => {
+    expect(shipmentReceiptDecision(existing, current)).toBe(expected)
+  })
+
+  it.each([
+    [1, 1, "a", "a", true],
+    [1, 2, "a", "a", false],
+    [2, 2, "a", "b", false],
+    [3, 2, "a", "b", false],
+  ] as const)(
+    "confirmation version/hash %s/%s %s/%s",
+    (expectedVersion, actualVersion, expectedHash, actualHash, valid) => {
+      expect(
+        shipmentConfirmationMatches({
+          expectedVersion,
+          actualVersion,
+          expectedPreviewHash: expectedHash,
+          actualPreviewHash: actualHash,
+        })
+      ).toBe(valid)
+    }
+  )
+})

--- a/src/module/livraisons/domain/livraisons-policy.ts
+++ b/src/module/livraisons/domain/livraisons-policy.ts
@@ -1,0 +1,74 @@
+import type { BonLivraisonStatut } from "../types/livraisons.types"
+
+const ALLOWED_TRANSITIONS: Record<BonLivraisonStatut, readonly BonLivraisonStatut[]> = {
+  DRAFT: ["READY", "CANCELLED"],
+  READY: ["SHIPPED", "CANCELLED"],
+  SHIPPED: ["DELIVERED"],
+  DELIVERED: [],
+  CANCELLED: [],
+}
+
+export function isLivraisonTransitionAllowed(
+  from: BonLivraisonStatut,
+  to: BonLivraisonStatut
+): boolean {
+  return from === to || ALLOWED_TRANSITIONS[from].includes(to)
+}
+
+export function deliveryQuantitiesMatch(expected: number, allocated: number): boolean {
+  return Number.isFinite(expected) &&
+    Number.isFinite(allocated) &&
+    expected > 0 &&
+    allocated > 0 &&
+    Math.abs(expected - allocated) <= 1e-9
+}
+
+export function deliveryQuantityAvailable(args: {
+  qty_on_hand: number
+  qty_reserved: number
+  qty_depreciated: number
+  own_reservation: number
+}): number {
+  return Math.max(
+    args.qty_on_hand -
+      args.qty_reserved -
+      args.qty_depreciated +
+      args.own_reservation,
+    0
+  )
+}
+
+export function deliveryLotIsConsumable(
+  lotId: string | null,
+  lotStatus: string | null
+): boolean {
+  return lotId === null || lotStatus === "LIBERE"
+}
+
+export function shipmentBillingBoundary() {
+  return {
+    event_type: "DELIVERY.SHIPPED" as const,
+    invoice_created: false as const,
+    billing_decision: "PENDING_DOWNSTREAM_REVIEW" as const,
+  }
+}
+
+export function shipmentReceiptDecision(
+  existingRequestHash: string | null,
+  currentRequestHash: string
+): "NEW" | "REPLAY" | "CONFLICT" {
+  if (existingRequestHash === null) return "NEW"
+  return existingRequestHash === currentRequestHash ? "REPLAY" : "CONFLICT"
+}
+
+export function shipmentConfirmationMatches(args: {
+  expectedVersion: number
+  actualVersion: number
+  expectedPreviewHash: string
+  actualPreviewHash: string
+}): boolean {
+  return (
+    args.expectedVersion === args.actualVersion &&
+    args.expectedPreviewHash === args.actualPreviewHash
+  )
+}

--- a/src/module/livraisons/domain/livraisons-rbac.test.ts
+++ b/src/module/livraisons/domain/livraisons-rbac.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest"
+
+import { roleHasLivraisonCapability } from "./livraisons-rbac"
+
+describe("livraisons RBAC", () => {
+  it.each([
+    ["Administrateur Systeme et Reseau", "ship"],
+    ["Directeur", "cancel"],
+    ["Responsable Logistique", "allocate"],
+    ["Magasinier", "deliver"],
+    ["Responsable Qualité", "read"],
+    ["Secretaire", "proof_manage"],
+  ] as const)("accorde %s -> %s", (role, capability) => {
+    expect(roleHasLivraisonCapability(role, capability)).toBe(true)
+  })
+
+  it.each([
+    [null, "read"],
+    ["", "read"],
+    ["Employe", "ship"],
+    ["Responsable Qualité", "ship"],
+    ["Comptable", "allocate"],
+    ["Commercial", "cancel"],
+  ] as const)("refuse %s -> %s", (role, capability) => {
+    expect(roleHasLivraisonCapability(role, capability)).toBe(false)
+  })
+})

--- a/src/module/livraisons/domain/livraisons-rbac.ts
+++ b/src/module/livraisons/domain/livraisons-rbac.ts
@@ -1,0 +1,36 @@
+export type LivraisonCapability =
+  | "read"
+  | "prepare"
+  | "allocate"
+  | "ship"
+  | "deliver"
+  | "cancel"
+  | "documents_manage"
+  | "proof_manage"
+  | "export"
+
+const ADMIN_OR_DIRECTOR = ["admin", "administrateur", "directeur"] as const
+const LOGISTICS = [...ADMIN_OR_DIRECTOR, "stock", "logisti", "magasin"] as const
+const PREPARERS = [...LOGISTICS, "production", "atelier", "program", "planif", "secr", "secret"] as const
+const READERS = [...PREPARERS, "qualit", "audit", "commercial", "compt", "employee", "employe"] as const
+
+const NEEDLES: Record<LivraisonCapability, readonly string[]> = {
+  read: READERS,
+  prepare: PREPARERS,
+  allocate: [...LOGISTICS, "planif", "program"],
+  ship: LOGISTICS,
+  deliver: LOGISTICS,
+  cancel: [...ADMIN_OR_DIRECTOR, "logisti", "stock"],
+  documents_manage: [...LOGISTICS, "qualit", "secr", "secret"],
+  proof_manage: [...LOGISTICS, "commercial", "secr", "secret"],
+  export: [...ADMIN_OR_DIRECTOR, "logisti", "stock", "qualit", "audit", "commercial"],
+}
+
+export function roleHasLivraisonCapability(
+  role: string | null | undefined,
+  capability: LivraisonCapability
+): boolean {
+  const normalized = (role ?? "").trim().toLowerCase()
+  if (!normalized) return false
+  return NEEDLES[capability].some((needle) => normalized.includes(needle))
+}

--- a/src/module/livraisons/repository/livraisons-shipment.repository.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.ts
@@ -1,0 +1,1330 @@
+import crypto from "node:crypto"
+import type { PoolClient } from "pg"
+
+import pool from "../../../config/database"
+import { HttpError } from "../../../utils/httpError"
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
+import { hashStockCommand, normalizeIdempotencyKey } from "../../stock/domain/stock-command"
+import {
+  assertStockConsumptionAllowed,
+  lockStockStates,
+  stockTargetKey,
+  type LockedStockState,
+  type StockLockTarget,
+} from "../../stock/repository/stock.repository"
+import type {
+  BonLivraisonDeliveryProof,
+  BonLivraisonShipmentPreview,
+  BonLivraisonShipResult,
+  ShipmentPreviewAllocation,
+  ShipmentPreviewBlocker,
+  ShipmentPreviewPack,
+} from "../types/livraisons.types"
+import type {
+  LivraisonProofBodyDTO,
+  ShipLivraisonBodyDTO,
+} from "../validators/livraisons.validators"
+import {
+  deliveryLotIsConsumable,
+  deliveryQuantitiesMatch,
+  deliveryQuantityAvailable,
+  shipmentConfirmationMatches,
+  shipmentBillingBoundary,
+  shipmentReceiptDecision,
+} from "../domain/livraisons-policy"
+
+type Queryable = Pick<PoolClient, "query">
+
+type HeaderRow = {
+  id: string
+  numero: string
+  statut: "DRAFT" | "READY" | "SHIPPED" | "DELIVERED" | "CANCELLED"
+  row_version: number
+  commande_id: string | null
+  affaire_id: string | null
+}
+
+type LineRow = {
+  id: string
+  ordre: number
+  quantite: number
+  commande_ligne_id: number | null
+  quantite_commandee: number | null
+  quantite_expediee: number | null
+  quantite_restante: number | null
+}
+
+type AllocationRow = {
+  id: string
+  bon_livraison_ligne_id: string
+  line_order: number
+  line_quantity: number
+  article_id: string
+  lot_id: string | null
+  lot_article_id: string | null
+  lot_status: string | null
+  magasin_id: string | null
+  emplacement_id: number | null
+  location_id: string | null
+  stock_level_id: string | null
+  stock_batch_id: string | null
+  reservation_id: string | null
+  reservation_status: string | null
+  reservation_quantity: number | null
+  stock_movement_line_id: string | null
+  quantite: number
+  unite: string | null
+  qty_on_hand: number | null
+  qty_reserved: number | null
+  qty_depreciated: number | null
+}
+
+type ShipmentSnapshot = {
+  header: HeaderRow
+  lines: LineRow[]
+  allocations: AllocationRow[]
+  document_pack: ShipmentPreviewPack | null
+}
+
+type AllocationGroup = {
+  key: string
+  article_id: string
+  stock_level_id: string
+  stock_batch_id: string | null
+  lot_id: string | null
+  magasin_id: string
+  emplacement_id: number
+  unite: string | null
+  quantity: number
+  own_reserved: number
+  allocations: AllocationRow[]
+}
+
+const EPSILON = 1e-9
+
+async function loadShipmentSnapshot(
+  client: Queryable,
+  bonLivraisonId: string,
+  forUpdate = false
+): Promise<ShipmentSnapshot | null> {
+  const header = await client.query<HeaderRow>(
+    `
+      SELECT
+        id::text AS id,
+        numero,
+        statut,
+        row_version::int AS row_version,
+        commande_id::text AS commande_id,
+        affaire_id::text AS affaire_id
+      FROM public.bon_livraison
+      WHERE id = $1::uuid
+      ${forUpdate ? "FOR UPDATE" : ""}
+    `,
+    [bonLivraisonId]
+  )
+  const row = header.rows[0] ?? null
+  if (!row) return null
+
+  const lines = await client.query<LineRow>(
+    `
+      SELECT
+        line.id::text AS id,
+        line.ordre,
+        line.quantite::float8 AS quantite,
+        line.commande_ligne_id,
+        remainder.quantite_commandee::float8 AS quantite_commandee,
+        remainder.quantite_expediee::float8 AS quantite_expediee,
+        remainder.quantite_restante::float8 AS quantite_restante
+      FROM public.bon_livraison_ligne line
+      LEFT JOIN public.v_bon_livraison_reliquats_226 remainder
+        ON remainder.commande_ligne_id = line.commande_ligne_id
+      WHERE line.bon_livraison_id = $1::uuid
+      ORDER BY line.ordre, line.id
+      ${forUpdate ? "FOR UPDATE OF line" : ""}
+    `,
+    [bonLivraisonId]
+  )
+
+  const allocations = await client.query<AllocationRow>(
+    `
+      SELECT
+        allocation.id::text AS id,
+        allocation.bon_livraison_ligne_id::text AS bon_livraison_ligne_id,
+        line.ordre AS line_order,
+        line.quantite::float8 AS line_quantity,
+        allocation.article_id::text AS article_id,
+        allocation.lot_id::text AS lot_id,
+        lot.article_id::text AS lot_article_id,
+        lot.lot_status,
+        allocation.magasin_id::text AS magasin_id,
+        allocation.emplacement_id::int AS emplacement_id,
+        allocation.location_id::text AS location_id,
+        allocation.stock_level_id::text AS stock_level_id,
+        allocation.stock_batch_id::text AS stock_batch_id,
+        allocation.reservation_id::text AS reservation_id,
+        reservation.status AS reservation_status,
+        reservation.qty_reserved::float8 AS reservation_quantity,
+        allocation.stock_movement_line_id::text AS stock_movement_line_id,
+        allocation.quantite::float8 AS quantite,
+        allocation.unite,
+        level.qty_total::float8 AS qty_on_hand,
+        level.qty_reserved::float8 AS qty_reserved,
+        level.qty_depreciated::float8 AS qty_depreciated
+      FROM public.bon_livraison_ligne_allocations allocation
+      JOIN public.bon_livraison_ligne line
+        ON line.id = allocation.bon_livraison_ligne_id
+      LEFT JOIN public.lots lot ON lot.id = allocation.lot_id
+      LEFT JOIN public.stock_levels level ON level.id = allocation.stock_level_id
+      LEFT JOIN public.stock_reservations reservation ON reservation.id = allocation.reservation_id
+      WHERE line.bon_livraison_id = $1::uuid
+      ORDER BY line.ordre, allocation.id
+      ${forUpdate ? "FOR UPDATE OF allocation" : ""}
+    `,
+    [bonLivraisonId]
+  )
+
+  const pack = await client.query<ShipmentPreviewPack>(
+    `
+      SELECT
+        id::text AS version_id,
+        version,
+        checksum_sha256
+      FROM public.bon_livraison_pack_versions
+      WHERE bon_livraison_id = $1::uuid
+        AND status = 'GENERATED'
+      ORDER BY version DESC, created_at DESC, id DESC
+      LIMIT 1
+    `,
+    [bonLivraisonId]
+  )
+
+  return {
+    header: row,
+    lines: lines.rows,
+    allocations: allocations.rows,
+    document_pack: pack.rows[0] ?? null,
+  }
+}
+
+function buildGroups(rows: AllocationRow[]): AllocationGroup[] {
+  const groups = new Map<string, AllocationGroup>()
+  for (const row of rows) {
+    if (
+      !row.magasin_id ||
+      !row.emplacement_id ||
+      !row.location_id ||
+      !row.stock_level_id
+    ) {
+      continue
+    }
+    const key = `${row.article_id}:${row.stock_level_id}:${row.stock_batch_id ?? "-"}`
+    const current = groups.get(key) ?? {
+      key,
+      article_id: row.article_id,
+      stock_level_id: row.stock_level_id,
+      stock_batch_id: row.stock_batch_id,
+      lot_id: row.lot_id,
+      magasin_id: row.magasin_id,
+      emplacement_id: row.emplacement_id,
+      unite: row.unite,
+      quantity: 0,
+      own_reserved: 0,
+      allocations: [],
+    }
+    current.quantity += row.quantite
+    current.own_reserved += row.reservation_status === "ACTIVE"
+      ? Number(row.reservation_quantity ?? 0)
+      : 0
+    current.allocations.push(row)
+    groups.set(key, current)
+  }
+  return [...groups.values()].sort((left, right) => left.key.localeCompare(right.key))
+}
+
+function buildPreview(snapshot: ShipmentSnapshot): BonLivraisonShipmentPreview {
+  const blockers: ShipmentPreviewBlocker[] = []
+  const byLine = new Map<string, AllocationRow[]>()
+  for (const allocation of snapshot.allocations) {
+    const rows = byLine.get(allocation.bon_livraison_ligne_id) ?? []
+    rows.push(allocation)
+    byLine.set(allocation.bon_livraison_ligne_id, rows)
+  }
+
+  if (snapshot.header.statut !== "READY") {
+    blockers.push({
+      code: "SHIPMENT_NOT_READY",
+      message: "Le bon de livraison doit être au statut READY avant expédition.",
+    })
+  }
+  if (!snapshot.lines.length) {
+    blockers.push({ code: "LINES_REQUIRED", message: "Le bon de livraison ne contient aucune ligne." })
+  }
+  if (!snapshot.document_pack) {
+    blockers.push({
+      code: "DOCUMENT_PACK_REQUIRED",
+      message: "Un pack documentaire figé doit être généré avant l’expédition.",
+    })
+  }
+
+  for (const line of snapshot.lines) {
+    const allocations = byLine.get(line.id) ?? []
+    if (!allocations.length) {
+      blockers.push({
+        code: "ALLOCATIONS_REQUIRED",
+        message: `La ligne ${line.ordre} ne possède aucune allocation.`,
+        line_id: line.id,
+      })
+      continue
+    }
+    const allocated = allocations.reduce((sum, allocation) => sum + allocation.quantite, 0)
+    if (!deliveryQuantitiesMatch(line.quantite, allocated)) {
+      blockers.push({
+        code: "ALLOCATION_QUANTITY_MISMATCH",
+        message: `La ligne ${line.ordre} doit être allouée exactement à hauteur de ${line.quantite}.`,
+        line_id: line.id,
+      })
+    }
+  }
+
+  const previewAllocations: ShipmentPreviewAllocation[] = []
+  for (const allocation of snapshot.allocations) {
+    if (
+      !allocation.magasin_id ||
+      !allocation.emplacement_id ||
+      !allocation.location_id ||
+      !allocation.stock_level_id
+    ) {
+      blockers.push({
+        code: "ALLOCATION_SOURCE_REQUIRED",
+        message: "Une allocation ne possède pas de source magasin/emplacement complète.",
+        allocation_id: allocation.id,
+        line_id: allocation.bon_livraison_ligne_id,
+      })
+      continue
+    }
+    if (allocation.lot_id && allocation.lot_article_id !== allocation.article_id) {
+      blockers.push({
+        code: "LOT_ARTICLE_MISMATCH",
+        message: "Le lot alloué ne correspond pas à l’article.",
+        allocation_id: allocation.id,
+      })
+    }
+    if (!deliveryLotIsConsumable(allocation.lot_id, allocation.lot_status)) {
+      blockers.push({
+        code: "LOT_NOT_RELEASED",
+        message: `Le lot alloué n’est pas libéré (${allocation.lot_status ?? "statut inconnu"}).`,
+        allocation_id: allocation.id,
+      })
+    }
+    if (allocation.lot_id && !allocation.stock_batch_id) {
+      blockers.push({
+        code: "STOCK_BATCH_MISSING",
+        message: "Le lot ne possède pas de batch de stock sur l’emplacement alloué.",
+        allocation_id: allocation.id,
+      })
+    }
+    if (!allocation.reservation_id || allocation.reservation_status !== "ACTIVE") {
+      blockers.push({
+        code: "ACTIVE_RESERVATION_REQUIRED",
+        message: "L’allocation doit être couverte par une réservation active.",
+        allocation_id: allocation.id,
+      })
+    }
+    if (
+      allocation.reservation_quantity !== null &&
+      Math.abs(allocation.reservation_quantity - allocation.quantite) > EPSILON
+    ) {
+      blockers.push({
+        code: "RESERVATION_QUANTITY_MISMATCH",
+        message: "La réservation ne couvre pas exactement la quantité allouée.",
+        allocation_id: allocation.id,
+      })
+    }
+    if (allocation.stock_movement_line_id) {
+      blockers.push({
+        code: "ALLOCATION_ALREADY_SHIPPED",
+        message: "L’allocation est déjà liée à une sortie de stock.",
+        allocation_id: allocation.id,
+      })
+    }
+
+    const available = deliveryQuantityAvailable({
+      qty_on_hand: Number(allocation.qty_on_hand ?? 0),
+      qty_reserved: Number(allocation.qty_reserved ?? 0),
+      qty_depreciated: Number(allocation.qty_depreciated ?? 0),
+      own_reservation:
+        allocation.reservation_status === "ACTIVE"
+          ? Number(allocation.reservation_quantity ?? 0)
+          : 0,
+    })
+    if (available + EPSILON < allocation.quantite) {
+      blockers.push({
+        code: "INSUFFICIENT_STOCK",
+        message: "Le disponible, réservation de ce BL incluse, est insuffisant.",
+        allocation_id: allocation.id,
+      })
+    }
+
+    previewAllocations.push({
+      allocation_id: allocation.id,
+      line_id: allocation.bon_livraison_ligne_id,
+      line_order: allocation.line_order,
+      article_id: allocation.article_id,
+      lot_id: allocation.lot_id,
+      magasin_id: allocation.magasin_id,
+      emplacement_id: allocation.emplacement_id,
+      location_id: allocation.location_id,
+      stock_level_id: allocation.stock_level_id,
+      stock_batch_id: allocation.stock_batch_id,
+      reservation_id: allocation.reservation_id,
+      quantity: allocation.quantite,
+      unit: allocation.unite,
+      quantity_available: Math.max(available, 0),
+    })
+  }
+
+  const hashPayload = {
+    bon_livraison_id: snapshot.header.id,
+    status: snapshot.header.statut,
+    row_version: snapshot.header.row_version,
+    allocations: previewAllocations.map((allocation) => ({
+      allocation_id: allocation.allocation_id,
+      article_id: allocation.article_id,
+      lot_id: allocation.lot_id,
+      stock_level_id: allocation.stock_level_id,
+      stock_batch_id: allocation.stock_batch_id,
+      reservation_id: allocation.reservation_id,
+      quantity: allocation.quantity,
+      quantity_available: allocation.quantity_available,
+    })),
+    blockers: blockers.map((blocker) => blocker.code).sort(),
+    document_pack: snapshot.document_pack,
+  }
+
+  const reliquats = snapshot.lines.map((line) => ({
+    line_id: line.id,
+    commande_ligne_id: line.commande_ligne_id,
+    quantity_ordered: line.quantite_commandee,
+    quantity_already_shipped: line.quantite_expediee,
+    quantity_remaining_before_shipment: line.quantite_restante,
+    quantity_in_shipment: line.quantite,
+    quantity_remaining_after_shipment:
+      line.quantite_restante === null
+        ? null
+        : Math.max(line.quantite_restante - line.quantite, 0),
+  }))
+  const simulatedMovements = buildGroups(snapshot.allocations).map((group) => ({
+    movement_type: "OUT" as const,
+    article_id: group.article_id,
+    lot_id: group.lot_id,
+    magasin_id: group.magasin_id,
+    emplacement_id: group.emplacement_id,
+    stock_level_id: group.stock_level_id,
+    stock_batch_id: group.stock_batch_id,
+    quantity: group.quantity,
+    unit: group.unite,
+  }))
+
+  return {
+    bon_livraison_id: snapshot.header.id,
+    numero: snapshot.header.numero,
+    status: snapshot.header.statut,
+    row_version: snapshot.header.row_version,
+    preview_hash: hashStockCommand("DELIVERY_SHIPMENT_PREVIEW", hashPayload),
+    can_ship: blockers.length === 0,
+    blockers,
+    allocations: previewAllocations,
+    reliquats,
+    simulated_movements: simulatedMovements,
+    document_pack: snapshot.document_pack,
+    totals: {
+      lines: snapshot.lines.length,
+      allocations: snapshot.allocations.length,
+      quantity: snapshot.lines.reduce((sum, line) => sum + line.quantite, 0),
+    },
+  }
+}
+
+async function insertLivraisonEvent(
+  client: Queryable,
+  args: {
+    bon_livraison_id: string
+    event_type: string
+    user_id: number
+    old_values?: unknown
+    new_values?: unknown
+  }
+) {
+  await client.query(
+    `
+      INSERT INTO public.bon_livraison_event_log (
+        bon_livraison_id, event_type, old_values, new_values, user_id
+      )
+      VALUES ($1::uuid,$2,$3::jsonb,$4::jsonb,$5)
+    `,
+    [
+      args.bon_livraison_id,
+      args.event_type,
+      args.old_values === undefined ? null : JSON.stringify(args.old_values),
+      args.new_values === undefined ? null : JSON.stringify(args.new_values),
+      args.user_id,
+    ]
+  )
+}
+
+async function insertMovementEvent(
+  client: Queryable,
+  args: {
+    movement_id: string
+    event_type: "CREATED" | "POSTED"
+    old_values: unknown
+    new_values: unknown
+    user_id: number
+    correlation_id: string
+  }
+) {
+  await client.query(
+    `
+      INSERT INTO public.stock_movement_event_log (
+        movement_id, event_type, old_values, new_values, user_id, correlation_id
+      )
+      VALUES ($1::uuid,$2,$3::jsonb,$4::jsonb,$5,$6::uuid)
+    `,
+    [
+      args.movement_id,
+      args.event_type,
+      JSON.stringify(args.old_values),
+      JSON.stringify(args.new_values),
+      args.user_id,
+      args.correlation_id,
+    ]
+  )
+}
+
+async function reserveMovementNumber(client: Queryable): Promise<string> {
+  const result = await client.query<{ value: string }>(
+    `SELECT nextval('public.stock_movement_no_seq')::text AS value`
+  )
+  const numeric = Number(result.rows[0]?.value)
+  if (!Number.isFinite(numeric)) throw new Error("Failed to reserve stock movement number")
+  return `SM-${String(numeric).padStart(8, "0")}`
+}
+
+function adjustedForOwnReservation(
+  state: LockedStockState,
+  ownReserved: number
+): LockedStockState {
+  return {
+    ...state,
+    qty_reserved: Math.max(state.qty_reserved - ownReserved, 0),
+  }
+}
+
+export async function repoGetLivraisonShipmentPreview(
+  bonLivraisonId: string
+): Promise<BonLivraisonShipmentPreview | null> {
+  const snapshot = await loadShipmentSnapshot(pool, bonLivraisonId)
+  return snapshot ? buildPreview(snapshot) : null
+}
+
+export async function prepareLivraisonInTransaction(
+  client: PoolClient,
+  bonLivraisonId: string,
+  userId: number
+): Promise<void> {
+  const snapshot = await loadShipmentSnapshot(client, bonLivraisonId, true)
+  if (!snapshot) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+  if (snapshot.header.statut === "READY") return
+  if (snapshot.header.statut !== "DRAFT") {
+    throw new HttpError(409, "INVALID_TRANSITION", "Only a DRAFT delivery can be prepared")
+  }
+
+  const draftPreview = buildPreview({
+    ...snapshot,
+    header: { ...snapshot.header, statut: "READY" },
+    allocations: snapshot.allocations.map((allocation) => ({
+      ...allocation,
+      reservation_id: crypto.randomUUID(),
+      reservation_status: "ACTIVE",
+      reservation_quantity: allocation.quantite,
+    })),
+  })
+  const relevantBlockers = draftPreview.blockers.filter(
+    (blocker) =>
+      blocker.code !== "ACTIVE_RESERVATION_REQUIRED" &&
+      blocker.code !== "DOCUMENT_PACK_REQUIRED"
+  )
+  if (relevantBlockers.length) {
+    throw new HttpError(
+      409,
+      "DELIVERY_PREPARATION_BLOCKED",
+      "La préparation est bloquée par des allocations incomplètes ou non disponibles.",
+      { blockers: relevantBlockers }
+    )
+  }
+
+  const groups = buildGroups(snapshot.allocations)
+  const targets: StockLockTarget[] = groups.map((group) => ({
+    stock_level_id: group.stock_level_id,
+    stock_batch_id: group.stock_batch_id,
+  }))
+  const states = await lockStockStates(client, targets)
+  for (const group of groups) {
+    const state = states.get(stockTargetKey(group))
+    if (!state) throw new Error("Locked stock state missing during delivery preparation")
+    assertStockConsumptionAllowed(state, { movement_type: "RESERVE", qty: group.quantity })
+  }
+
+  const correlationId = crypto.randomUUID()
+  for (const group of groups) {
+    await client.query(
+      `
+        UPDATE public.stock_levels
+        SET qty_reserved = qty_reserved + $2,
+            updated_at = now(),
+            updated_by = $3
+        WHERE id = $1::uuid
+      `,
+      [group.stock_level_id, group.quantity, userId]
+    )
+    if (group.stock_batch_id) {
+      await client.query(
+        `UPDATE public.stock_batches SET qty_reserved = qty_reserved + $2 WHERE id = $1::uuid`,
+        [group.stock_batch_id, group.quantity]
+      )
+    }
+
+    for (const allocation of group.allocations) {
+      const reservation = await client.query<{ id: string }>(
+        `
+          INSERT INTO public.stock_reservations (
+            article_id,
+            location_id,
+            lot_id,
+            stock_batch_id,
+            qty_reserved,
+            source_type,
+            source_id,
+            commande_ligne_id,
+            bon_livraison_ligne_id,
+            affaire_id,
+            status,
+            reason,
+            correlation_id,
+            created_by,
+            updated_by
+          )
+          SELECT
+            $1::uuid,
+            $2::uuid,
+            $3::uuid,
+            $4::uuid,
+            $5,
+            'BON_LIVRAISON_LIGNE',
+            $6,
+            line.commande_ligne_id,
+            line.id,
+            delivery.affaire_id,
+            'ACTIVE',
+            'Préparation du bon de livraison ' || delivery.numero,
+            $7::uuid,
+            $8,
+            $8
+          FROM public.bon_livraison_ligne line
+          JOIN public.bon_livraison delivery ON delivery.id = line.bon_livraison_id
+          WHERE line.id = $6::uuid
+            AND delivery.id = $9::uuid
+          RETURNING id::text AS id
+        `,
+        [
+          allocation.article_id,
+          allocation.location_id,
+          allocation.lot_id,
+          allocation.stock_batch_id,
+          allocation.quantite,
+          allocation.bon_livraison_ligne_id,
+          correlationId,
+          userId,
+          bonLivraisonId,
+        ]
+      )
+      const reservationId = reservation.rows[0]?.id
+      if (!reservationId) throw new Error("Failed to create delivery stock reservation")
+      await client.query(
+        `
+          UPDATE public.bon_livraison_ligne_allocations
+          SET reservation_id = $2::uuid,
+              updated_at = now(),
+              updated_by = $3
+          WHERE id = $1::uuid
+        `,
+        [allocation.id, reservationId, userId]
+      )
+    }
+  }
+
+  await client.query(
+    `
+      UPDATE public.bon_livraison
+      SET statut = 'READY',
+          updated_at = now(),
+          updated_by = $2
+      WHERE id = $1::uuid
+    `,
+    [bonLivraisonId, userId]
+  )
+  await insertLivraisonEvent(client, {
+    bon_livraison_id: bonLivraisonId,
+    event_type: "PREPARATION_READY",
+    user_id: userId,
+    old_values: { statut: "DRAFT" },
+    new_values: {
+      statut: "READY",
+      reservations_count: snapshot.allocations.length,
+      correlation_id: correlationId,
+    },
+  })
+}
+
+export async function releaseLivraisonReservationsInTransaction(
+  client: PoolClient,
+  bonLivraisonId: string,
+  userId: number,
+  reason: string
+): Promise<void> {
+  const reservations = await client.query<{
+    id: string
+    stock_level_id: string
+    stock_batch_id: string | null
+    qty_reserved: number
+  }>(
+    `
+      SELECT
+        reservation.id::text AS id,
+        allocation.stock_level_id::text AS stock_level_id,
+        allocation.stock_batch_id::text AS stock_batch_id,
+        reservation.qty_reserved::float8 AS qty_reserved
+      FROM public.bon_livraison_ligne_allocations allocation
+      JOIN public.bon_livraison_ligne line ON line.id = allocation.bon_livraison_ligne_id
+      JOIN public.stock_reservations reservation ON reservation.id = allocation.reservation_id
+      WHERE line.bon_livraison_id = $1::uuid
+        AND reservation.status = 'ACTIVE'
+      ORDER BY allocation.stock_level_id, allocation.stock_batch_id, reservation.id
+      FOR UPDATE OF reservation
+    `,
+    [bonLivraisonId]
+  )
+  if (!reservations.rows.length) return
+
+  const grouped = new Map<string, { level: string; batch: string | null; qty: number }>()
+  for (const reservation of reservations.rows) {
+    const key = `${reservation.stock_level_id}:${reservation.stock_batch_id ?? "-"}`
+    const current = grouped.get(key) ?? {
+      level: reservation.stock_level_id,
+      batch: reservation.stock_batch_id,
+      qty: 0,
+    }
+    current.qty += reservation.qty_reserved
+    grouped.set(key, current)
+  }
+  const groups = [...grouped.values()].sort((left, right) =>
+    `${left.level}:${left.batch ?? "-"}`.localeCompare(`${right.level}:${right.batch ?? "-"}`)
+  )
+  const states = await lockStockStates(
+    client,
+    groups.map((group) => ({ stock_level_id: group.level, stock_batch_id: group.batch }))
+  )
+  for (const group of groups) {
+    const state = states.get(stockTargetKey({ stock_level_id: group.level, stock_batch_id: group.batch }))
+    if (!state) throw new Error("Locked stock state missing while releasing delivery")
+    assertStockConsumptionAllowed(state, { movement_type: "UNRESERVE", qty: group.qty })
+    await client.query(
+      `
+        UPDATE public.stock_levels
+        SET qty_reserved = qty_reserved - $2,
+            updated_at = now(),
+            updated_by = $3
+        WHERE id = $1::uuid
+      `,
+      [group.level, group.qty, userId]
+    )
+    if (group.batch) {
+      await client.query(
+        `UPDATE public.stock_batches SET qty_reserved = qty_reserved - $2 WHERE id = $1::uuid`,
+        [group.batch, group.qty]
+      )
+    }
+  }
+  await client.query(
+    `
+      UPDATE public.stock_reservations
+      SET status = 'RELEASED',
+          reason = $2,
+          released_at = now(),
+          released_by = $3,
+          updated_at = now(),
+          updated_by = $3
+      WHERE id = ANY($1::uuid[])
+    `,
+    [reservations.rows.map((row) => row.id), reason, userId]
+  )
+}
+
+export async function repoShipLivraison(
+  bonLivraisonId: string,
+  body: ShipLivraisonBodyDTO,
+  userId: number,
+  idempotencyKeyRaw: string
+): Promise<BonLivraisonShipResult> {
+  const client = await pool.connect()
+  try {
+    await client.query("BEGIN")
+    const idempotencyKey = normalizeIdempotencyKey(idempotencyKeyRaw)
+    const requestPayload = { bon_livraison_id: bonLivraisonId, ...body }
+    const requestHash = hashStockCommand("DELIVERY_SHIP", requestPayload)
+    await client.query(
+      `SELECT pg_advisory_xact_lock(hashtextextended($1, 0))`,
+      [`delivery:${userId}:${idempotencyKey}`]
+    )
+    const existing = await client.query<{
+      request_hash: string
+      result_payload: BonLivraisonShipResult
+    }>(
+      `
+        SELECT request_hash, result_payload
+        FROM public.bon_livraison_command_receipts
+        WHERE actor_user_id = $1
+          AND idempotency_key = $2
+        LIMIT 1
+      `,
+      [userId, idempotencyKey]
+    )
+    const receipt = existing.rows[0] ?? null
+    const receiptDecision = shipmentReceiptDecision(receipt?.request_hash ?? null, requestHash)
+    if (receiptDecision === "CONFLICT") {
+      throw new HttpError(
+        409,
+        "IDEMPOTENCY_KEY_REUSED",
+        "Cette Idempotency-Key a déjà été utilisée avec une autre confirmation."
+      )
+    }
+    if (receiptDecision === "REPLAY" && receipt) {
+      await client.query("COMMIT")
+      return { ...receipt.result_payload, idempotent_replay: true }
+    }
+
+    const snapshot = await loadShipmentSnapshot(client, bonLivraisonId, true)
+    if (!snapshot) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    const preview = buildPreview(snapshot)
+    if (
+      !shipmentConfirmationMatches({
+        expectedVersion: body.expected_version,
+        actualVersion: preview.row_version,
+        expectedPreviewHash: body.preview_hash,
+        actualPreviewHash: preview.preview_hash,
+      })
+    ) {
+      if (body.expected_version !== preview.row_version) {
+        throw new HttpError(
+          409,
+          "CONCURRENT_MODIFICATION",
+          "Le bon de livraison a changé depuis l’aperçu."
+        )
+      }
+      throw new HttpError(
+        409,
+        "SHIPMENT_PREVIEW_CHANGED",
+        "Les allocations ou le stock ont changé depuis l’aperçu."
+      )
+    }
+    if (!preview.can_ship) {
+      throw new HttpError(409, "SHIPMENT_BLOCKED", "L’expédition est bloquée.", {
+        blockers: preview.blockers,
+      })
+    }
+
+    const groups = buildGroups(snapshot.allocations)
+    const states = await lockStockStates(
+      client,
+      groups.map((group) => ({
+        stock_level_id: group.stock_level_id,
+        stock_batch_id: group.stock_batch_id,
+      }))
+    )
+    for (const group of groups) {
+      const state = states.get(stockTargetKey(group))
+      if (!state) throw new Error("Locked stock state missing during shipment")
+      assertStockConsumptionAllowed(adjustedForOwnReservation(state, group.own_reserved), {
+        movement_type: "OUT",
+        qty: group.quantity,
+      })
+    }
+
+    const correlationId = crypto.randomUUID()
+    const movementIds: string[] = []
+    for (const group of groups) {
+      const movementNumber = await reserveMovementNumber(client)
+      const inserted = await client.query<{ id: string }>(
+        `
+          INSERT INTO public.stock_movements (
+            movement_no,
+            movement_type,
+            status,
+            article_id,
+            stock_level_id,
+            stock_batch_id,
+            qty,
+            currency,
+            effective_at,
+            source_document_type,
+            source_document_id,
+            reason_code,
+            notes,
+            idempotency_key,
+            correlation_id,
+            user_id,
+            created_by,
+            updated_by
+          )
+          VALUES (
+            $1,
+            'OUT'::public.movement_type,
+            'DRAFT',
+            $2::uuid,
+            $3::uuid,
+            $4::uuid,
+            $5,
+            'EUR',
+            now(),
+            'BON_LIVRAISON',
+            $6,
+            'BON_LIVRAISON_SHIPMENT',
+            $7,
+            $8,
+            $9::uuid,
+            $10,
+            $10,
+            $10
+          )
+          RETURNING id::text AS id
+        `,
+        [
+          movementNumber,
+          group.article_id,
+          group.stock_level_id,
+          group.stock_batch_id,
+          group.quantity,
+          bonLivraisonId,
+          `Expédition BL ${snapshot.header.numero}`,
+          `delivery:${bonLivraisonId}:${group.key}`,
+          correlationId,
+          userId,
+        ]
+      )
+      const movementId = inserted.rows[0]?.id
+      if (!movementId) throw new Error("Failed to create delivery stock movement")
+      movementIds.push(movementId)
+      await insertMovementEvent(client, {
+        movement_id: movementId,
+        event_type: "CREATED",
+        old_values: null,
+        new_values: {
+          status: "DRAFT",
+          movement_type: "OUT",
+          source_document_type: "BON_LIVRAISON",
+          source_document_id: bonLivraisonId,
+        },
+        user_id: userId,
+        correlation_id: correlationId,
+      })
+
+      let lineNumber = 1
+      for (const allocation of group.allocations) {
+        const movementLine = await client.query<{ id: string }>(
+          `
+            INSERT INTO public.stock_movement_lines (
+              movement_id,
+              line_no,
+              article_id,
+              lot_id,
+              qty,
+              unite,
+              src_magasin_id,
+              src_emplacement_id,
+              note,
+              created_by,
+              updated_by
+            )
+            VALUES ($1::uuid,$2,$3::uuid,$4::uuid,$5,$6,$7::uuid,$8::bigint,$9,$10,$10)
+            RETURNING id::text AS id
+          `,
+          [
+            movementId,
+            lineNumber,
+            allocation.article_id,
+            allocation.lot_id,
+            allocation.quantite,
+            allocation.unite,
+            allocation.magasin_id,
+            allocation.emplacement_id,
+            `BL ${snapshot.header.numero} — allocation ${allocation.id}`,
+            userId,
+          ]
+        )
+        const movementLineId = movementLine.rows[0]?.id
+        if (!movementLineId) throw new Error("Failed to create delivery stock movement line")
+        await client.query(
+          `
+            UPDATE public.bon_livraison_ligne_allocations
+            SET stock_movement_line_id = $2::uuid,
+                updated_at = now(),
+                updated_by = $3
+            WHERE id = $1::uuid
+              AND stock_movement_line_id IS NULL
+          `,
+          [allocation.id, movementLineId, userId]
+        )
+        lineNumber += 1
+      }
+
+      await client.query(
+        `
+          UPDATE public.stock_movements
+          SET status = 'POSTED',
+              posted_at = now(),
+              posted_by = $2,
+              updated_at = now(),
+              updated_by = $2
+          WHERE id = $1::uuid
+            AND status = 'DRAFT'
+        `,
+        [movementId, userId]
+      )
+      await insertMovementEvent(client, {
+        movement_id: movementId,
+        event_type: "POSTED",
+        old_values: { status: "DRAFT" },
+        new_values: { status: "POSTED" },
+        user_id: userId,
+        correlation_id: correlationId,
+      })
+
+      await client.query(
+        `
+          UPDATE public.stock_levels
+          SET qty_reserved = qty_reserved - $2,
+              updated_at = now(),
+              updated_by = $3
+          WHERE id = $1::uuid
+        `,
+        [group.stock_level_id, group.own_reserved, userId]
+      )
+      if (group.stock_batch_id) {
+        await client.query(
+          `UPDATE public.stock_batches SET qty_reserved = qty_reserved - $2 WHERE id = $1::uuid`,
+          [group.stock_batch_id, group.own_reserved]
+        )
+      }
+      await client.query(
+        `
+          UPDATE public.stock_reservations
+          SET status = 'CONSUMED',
+              reason = 'Consommée par expédition du BL ' || $2,
+              consumed_at = now(),
+              consumed_by = $3,
+              consumed_stock_movement_id = $4::uuid,
+              correlation_id = $5::uuid,
+              updated_at = now(),
+              updated_by = $3
+          WHERE id = ANY($1::uuid[])
+            AND status = 'ACTIVE'
+        `,
+        [
+          group.allocations.map((allocation) => allocation.reservation_id),
+          snapshot.header.numero,
+          userId,
+          movementId,
+          correlationId,
+        ]
+      )
+    }
+
+    const updated = await client.query<{ row_version: number }>(
+      `
+        UPDATE public.bon_livraison
+        SET statut = 'SHIPPED',
+            date_expedition = COALESCE(date_expedition, CURRENT_DATE),
+            updated_at = now(),
+            updated_by = $2
+        WHERE id = $1::uuid
+          AND statut = 'READY'
+        RETURNING row_version::int AS row_version
+      `,
+      [bonLivraisonId, userId]
+    )
+    const rowVersion = updated.rows[0]?.row_version
+    if (!rowVersion) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Le statut du BL a changé pendant l’expédition.")
+    }
+
+    await insertLivraisonEvent(client, {
+      bon_livraison_id: bonLivraisonId,
+      event_type: "SHIPMENT_VALIDATED",
+      user_id: userId,
+      old_values: { statut: "READY" },
+      new_values: {
+        statut: "SHIPPED",
+        stock_movement_ids: movementIds,
+        document_pack: preview.document_pack,
+        correlation_id: correlationId,
+        invoice_created: false,
+        commentaire: body.commentaire ?? null,
+      },
+    })
+    await client.query(
+      `
+        INSERT INTO public.erp_outbox_events (
+          event_key,
+          aggregate_type,
+          aggregate_id,
+          event_type,
+          payload,
+          correlation_id
+        )
+        VALUES ($1,'BON_LIVRAISON',$2,'DELIVERY.SHIPPED',$3::jsonb,$4::uuid)
+        ON CONFLICT (event_key) DO NOTHING
+      `,
+      [
+        `delivery.shipped:${bonLivraisonId}`,
+        bonLivraisonId,
+        JSON.stringify({
+          bon_livraison_id: bonLivraisonId,
+          numero: snapshot.header.numero,
+          commande_id: snapshot.header.commande_id,
+          affaire_id: snapshot.header.affaire_id,
+          stock_movement_ids: movementIds,
+          document_pack: preview.document_pack,
+          ...shipmentBillingBoundary(),
+        }),
+        correlationId,
+      ]
+    )
+    await repoInsertAuditLog({
+      user_id: userId,
+      body: {
+        event_type: "ACTION",
+        action: "livraisons.shipped",
+        page_key: "livraisons",
+        entity_type: "bon_livraison",
+        entity_id: bonLivraisonId,
+        path: `/api/v1/livraisons/${bonLivraisonId}/ship`,
+        client_session_id: null,
+        details: {
+          bon_livraison_numero: snapshot.header.numero,
+          stock_movement_ids: movementIds,
+          correlation_id: correlationId,
+          invoice_created: false,
+        },
+      },
+      ip: null,
+      user_agent: null,
+      device_type: null,
+      os: null,
+      browser: null,
+      tx: client,
+    })
+
+    const result: BonLivraisonShipResult = {
+      id: bonLivraisonId,
+      statut: "SHIPPED",
+      row_version: rowVersion,
+      stock_movement_ids: movementIds,
+      correlation_id: correlationId,
+      idempotent_replay: false,
+      billing_event: "DELIVERY.SHIPPED",
+      invoice_created: false,
+    }
+    await client.query(
+      `
+        INSERT INTO public.bon_livraison_command_receipts (
+          actor_user_id,
+          idempotency_key,
+          request_hash,
+          command_type,
+          bon_livraison_id,
+          request_payload,
+          result_payload,
+          correlation_id
+        )
+        VALUES ($1,$2,$3,'SHIP',$4::uuid,$5::jsonb,$6::jsonb,$7::uuid)
+      `,
+      [
+        userId,
+        idempotencyKey,
+        requestHash,
+        bonLivraisonId,
+        JSON.stringify(requestPayload),
+        JSON.stringify(result),
+        correlationId,
+      ]
+    )
+    await client.query("COMMIT")
+    return result
+  } catch (error) {
+    await client.query("ROLLBACK")
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+export async function repoListLivraisonProofs(
+  bonLivraisonId: string,
+  queryable: Queryable = pool
+): Promise<BonLivraisonDeliveryProof[]> {
+  const result = await queryable.query<BonLivraisonDeliveryProof>(
+    `
+      SELECT
+        proof.id::text AS id,
+        proof.bon_livraison_id::text AS bon_livraison_id,
+        proof.proof_type,
+        proof.delivered_at::text AS delivered_at,
+        proof.received_by_name,
+        proof.document_id::text AS document_id,
+        document.document_name,
+        proof.note,
+        proof.correlation_id::text AS correlation_id,
+        CASE
+          WHEN actor.id IS NULL THEN NULL
+          ELSE json_build_object(
+            'id', actor.id,
+            'username', actor.username,
+            'name', actor.name,
+            'surname', actor.surname,
+            'label', trim(concat_ws(' ', actor.name, actor.surname, actor.username))
+          )
+        END AS created_by,
+        proof.created_at::text AS created_at
+      FROM public.bon_livraison_delivery_proofs proof
+      LEFT JOIN public.documents_clients document ON document.id = proof.document_id
+      LEFT JOIN public.users actor ON actor.id = proof.created_by
+      WHERE proof.bon_livraison_id = $1::uuid
+      ORDER BY proof.created_at DESC, proof.id DESC
+    `,
+    [bonLivraisonId]
+  )
+  return result.rows
+}
+
+export async function repoCreateLivraisonProof(
+  bonLivraisonId: string,
+  body: LivraisonProofBodyDTO,
+  userId: number
+): Promise<BonLivraisonDeliveryProof> {
+  const client = await pool.connect()
+  try {
+    await client.query("BEGIN")
+    const delivery = await client.query<{ statut: string }>(
+      `SELECT statut FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
+      [bonLivraisonId]
+    )
+    const row = delivery.rows[0] ?? null
+    if (!row) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    if (row.statut !== "SHIPPED" && row.statut !== "DELIVERED") {
+      throw new HttpError(409, "PROOF_NOT_ALLOWED", "Une preuve ne peut être ajoutée qu’après expédition.")
+    }
+    if (body.document_id) {
+      const linked = await client.query<{ ok: number }>(
+        `
+          SELECT 1::int AS ok
+          FROM public.bon_livraison_documents
+          WHERE bon_livraison_id = $1::uuid
+            AND document_id = $2::uuid
+        `,
+        [bonLivraisonId, body.document_id]
+      )
+      if (!linked.rows[0]?.ok) {
+        throw new HttpError(
+          409,
+          "PROOF_DOCUMENT_NOT_LINKED",
+          "Le document de preuve doit d’abord être rattaché au bon de livraison."
+        )
+      }
+    }
+    const correlationId = crypto.randomUUID()
+    const inserted = await client.query<{ id: string }>(
+      `
+        INSERT INTO public.bon_livraison_delivery_proofs (
+          bon_livraison_id,
+          proof_type,
+          delivered_at,
+          received_by_name,
+          document_id,
+          note,
+          correlation_id,
+          created_by
+        )
+        VALUES ($1::uuid,$2,$3::timestamptz,$4,$5::uuid,$6,$7::uuid,$8)
+        RETURNING id::text AS id
+      `,
+      [
+        bonLivraisonId,
+        body.proof_type,
+        body.delivered_at,
+        body.received_by_name ?? null,
+        body.document_id ?? null,
+        body.note ?? null,
+        correlationId,
+        userId,
+      ]
+    )
+    const proofId = inserted.rows[0]?.id
+    if (!proofId) throw new Error("Failed to create delivery proof")
+    await insertLivraisonEvent(client, {
+      bon_livraison_id: bonLivraisonId,
+      event_type: "DELIVERY_PROOF_ADDED",
+      user_id: userId,
+      new_values: {
+        proof_id: proofId,
+        proof_type: body.proof_type,
+        delivered_at: body.delivered_at,
+        document_id: body.document_id ?? null,
+        correlation_id: correlationId,
+      },
+    })
+    await repoInsertAuditLog({
+      user_id: userId,
+      body: {
+        event_type: "ACTION",
+        action: "livraisons.delivery_proof.added",
+        page_key: "livraisons",
+        entity_type: "bon_livraison",
+        entity_id: bonLivraisonId,
+        path: `/api/v1/livraisons/${bonLivraisonId}/proofs`,
+        client_session_id: null,
+        details: {
+          proof_id: proofId,
+          proof_type: body.proof_type,
+          document_id: body.document_id ?? null,
+          correlation_id: correlationId,
+        },
+      },
+      ip: null,
+      user_agent: null,
+      device_type: null,
+      os: null,
+      browser: null,
+      tx: client,
+    })
+    await client.query("COMMIT")
+    const proofs = await repoListLivraisonProofs(bonLivraisonId)
+    const proof = proofs.find((item) => item.id === proofId)
+    if (!proof) throw new Error("Failed to reload delivery proof")
+    return proof
+  } catch (error) {
+    await client.query("ROLLBACK")
+    throw error
+  } finally {
+    client.release()
+  }
+}

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -8,6 +8,18 @@ import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
+import { isLivraisonTransitionAllowed } from "../domain/livraisons-policy"
+import {
+  assertStockConsumptionAllowed,
+  getEmplacementMapping as getStockEmplacementMapping,
+  lockStockStates,
+  stockTargetKey,
+} from "../../stock/repository/stock.repository"
+import {
+  prepareLivraisonInTransaction,
+  releaseLivraisonReservationsInTransaction,
+  repoListLivraisonProofs,
+} from "./livraisons-shipment.repository"
 
 import type {
   AdresseLivraisonLite,
@@ -18,6 +30,7 @@ import type {
   BonLivraisonLigne,
   BonLivraisonLigneAllocation,
   BonLivraisonListItem,
+  BonLivraisonListSummary,
   BonLivraisonStatut,
   Paginated,
   UploadedDocument,
@@ -409,7 +422,9 @@ function buildListWhere(filters: ListLivraisonsQueryDTO): ListWhere {
   }
 }
 
-export async function repoListLivraisons(filters: ListLivraisonsQueryDTO): Promise<Paginated<BonLivraisonListItem>> {
+export async function repoListLivraisons(
+  filters: ListLivraisonsQueryDTO
+): Promise<Paginated<BonLivraisonListItem> & { summary: BonLivraisonListSummary }> {
   const page = filters.page ?? 1
   const pageSize = filters.pageSize ?? 50
   const offset = (page - 1) * pageSize
@@ -427,6 +442,30 @@ export async function repoListLivraisons(filters: ListLivraisonsQueryDTO): Promi
   `
   const countRes = await pool.query<{ total: number }>(countSql, values)
   const total = countRes.rows[0]?.total ?? 0
+  const summaryRes = await pool.query<BonLivraisonListSummary>(
+    `
+      SELECT
+        COUNT(*)::int AS total,
+        COUNT(*) FILTER (WHERE bl.statut = 'DRAFT')::int AS draft,
+        COUNT(*) FILTER (WHERE bl.statut = 'READY')::int AS ready,
+        COUNT(*) FILTER (WHERE bl.statut = 'SHIPPED')::int AS shipped,
+        COUNT(*) FILTER (WHERE bl.statut = 'DELIVERED')::int AS delivered,
+        COUNT(*) FILTER (WHERE bl.statut = 'CANCELLED')::int AS cancelled
+      FROM public.bon_livraison bl
+      JOIN public.clients c ON c.client_id = bl.client_id
+      LEFT JOIN public.commande_client cc ON cc.id = bl.commande_id
+      ${whereSql}
+    `,
+    values
+  )
+  const summary = summaryRes.rows[0] ?? {
+    total: 0,
+    draft: 0,
+    ready: 0,
+    shipped: 0,
+    delivered: 0,
+    cancelled: 0,
+  }
 
   type Row = {
     id: string
@@ -489,7 +528,7 @@ export async function repoListLivraisons(filters: ListLivraisonsQueryDTO): Promi
     updated_at: r.updated_at,
   }))
 
-  return { items, total }
+  return { items, total, summary }
 }
 
 type HeaderRow = {
@@ -518,6 +557,7 @@ type HeaderRow = {
   commentaire_client: string | null
   reception_nom_signataire: string | null
   reception_date_signature: string | null
+  row_version: number
   created_at: string
   updated_at: string
   created_by_id: number | null
@@ -559,6 +599,7 @@ async function getHeader(client: PoolClient, id: string, opts?: { forUpdate?: bo
       bl.commentaire_client,
       bl.reception_nom_signataire,
       bl.reception_date_signature::text AS reception_date_signature,
+      bl.row_version::int AS row_version,
       bl.created_at::text AS created_at,
       bl.updated_at::text AS updated_at,
       cb.id AS created_by_id,
@@ -643,6 +684,7 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
       commentaire_client: headerRow.commentaire_client,
       reception_nom_signataire: headerRow.reception_nom_signataire,
       reception_date_signature: headerRow.reception_date_signature,
+      row_version: headerRow.row_version,
       created_at: headerRow.created_at,
       updated_at: headerRow.updated_at,
       created_by: createdBy,
@@ -738,6 +780,17 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
       bon_livraison_ligne_id: string
       article_id: string
       lot_id: string | null
+      lot_code: string | null
+      lot_status: string | null
+      magasin_id: string | null
+      magasin_code: string | null
+      emplacement_id: number | null
+      emplacement_code: string | null
+      location_id: string | null
+      stock_level_id: string | null
+      stock_batch_id: string | null
+      reservation_id: string | null
+      reservation_status: string | null
       stock_movement_line_id: string | null
       quantite: string | number
       unite: string | null
@@ -760,6 +813,17 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
         a.bon_livraison_ligne_id::text AS bon_livraison_ligne_id,
         a.article_id::text AS article_id,
         a.lot_id::text AS lot_id,
+        lot.lot_code,
+        lot.lot_status,
+        a.magasin_id::text AS magasin_id,
+        COALESCE(magasin.code, magasin.code_magasin)::text AS magasin_code,
+        a.emplacement_id::int AS emplacement_id,
+        emplacement.code AS emplacement_code,
+        a.location_id::text AS location_id,
+        a.stock_level_id::text AS stock_level_id,
+        a.stock_batch_id::text AS stock_batch_id,
+        a.reservation_id::text AS reservation_id,
+        reservation.status AS reservation_status,
         a.stock_movement_line_id::text AS stock_movement_line_id,
         a.quantite,
         a.unite,
@@ -775,6 +839,10 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
         ub.surname AS updated_by_surname
       FROM public.bon_livraison_ligne_allocations a
       JOIN public.bon_livraison_ligne l ON l.id = a.bon_livraison_ligne_id
+      LEFT JOIN public.lots lot ON lot.id = a.lot_id
+      LEFT JOIN public.magasins magasin ON magasin.id = a.magasin_id
+      LEFT JOIN public.emplacements emplacement ON emplacement.id = a.emplacement_id
+      LEFT JOIN public.stock_reservations reservation ON reservation.id = a.reservation_id
       LEFT JOIN users cb ON cb.id = a.created_by
       LEFT JOIN users ub ON ub.id = a.updated_by
       WHERE l.bon_livraison_id = $1::uuid
@@ -789,6 +857,17 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
         bon_livraison_ligne_id: r.bon_livraison_ligne_id,
         article_id: r.article_id,
         lot_id: r.lot_id,
+        lot_code: r.lot_code,
+        lot_status: r.lot_status,
+        magasin_id: r.magasin_id,
+        magasin_code: r.magasin_code,
+        emplacement_id: r.emplacement_id,
+        emplacement_code: r.emplacement_code,
+        location_id: r.location_id,
+        stock_level_id: r.stock_level_id,
+        stock_batch_id: r.stock_batch_id,
+        reservation_id: r.reservation_id,
+        reservation_status: r.reservation_status,
         stock_movement_line_id: r.stock_movement_line_id,
         quantite: toFloat(r.quantite, "bon_livraison_ligne_allocations.quantite"),
         unite: r.unite,
@@ -826,6 +905,9 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
       uploaded_by_surname: string | null
       document_name: string | null
       document_type: string | null
+      checksum_sha256: string | null
+      file_size_bytes: number | null
+      mime_type: string | null
     }
 
     const docsRes = await db.query<DocRow>(
@@ -842,7 +924,10 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
         u.name AS uploaded_by_name,
         u.surname AS uploaded_by_surname,
         dc.document_name,
-        dc.type AS document_type
+        dc.type AS document_type,
+        d.checksum_sha256,
+        d.file_size_bytes::float8 AS file_size_bytes,
+        d.mime_type
       FROM bon_livraison_documents d
       LEFT JOIN documents_clients dc ON dc.id = d.document_id
       LEFT JOIN users u ON u.id = d.uploaded_by
@@ -866,6 +951,9 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
       }),
       document_name: r.document_name,
       document_type: r.document_type,
+      checksum_sha256: r.checksum_sha256,
+      file_size_bytes: r.file_size_bytes,
+      mime_type: r.mime_type,
     }))
 
     // Events
@@ -913,7 +1001,9 @@ export async function repoGetLivraisonDetail(id: string): Promise<BonLivraisonDe
       created_at: r.created_at,
     }))
 
-    return { bon_livraison, lignes, documents, events }
+    const proofs = await repoListLivraisonProofs(id, db)
+
+    return { bon_livraison, lignes, documents, proofs, events }
   } finally {
     db.release()
   }
@@ -1088,6 +1178,13 @@ export async function repoUpdateLivraisonHeader(id: string, patch: UpdateLivrais
       await db.query("ROLLBACK")
       return null
     }
+    if (current.statut !== "DRAFT" && current.statut !== "READY") {
+      throw new HttpError(
+        409,
+        "LOCKED",
+        `Update is not allowed when statut=${current.statut}`
+      )
+    }
 
     const fields: string[] = []
     const values: unknown[] = []
@@ -1190,6 +1287,9 @@ export async function repoAddLivraisonLine(
     await db.query("BEGIN")
     const current = await getHeader(db, bonLivraisonId, { forUpdate: true })
     if (!current) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    if (current.statut !== "DRAFT") {
+      throw new HttpError(409, "LOCKED", "Add line is only allowed when statut=DRAFT")
+    }
 
     const ordreRes = await db.query<{ next_ordre: number }>(
       `SELECT COALESCE(MAX(ordre), 0)::int + 1 AS next_ordre FROM bon_livraison_ligne WHERE bon_livraison_id = $1::uuid`,
@@ -1261,6 +1361,9 @@ export async function repoUpdateLivraisonLine(
     if (!header) {
       await db.query("ROLLBACK")
       return null
+    }
+    if (header.statut !== "DRAFT") {
+      throw new HttpError(409, "LOCKED", "Update line is only allowed when statut=DRAFT")
     }
 
     const currentRes = await db.query<{
@@ -1384,6 +1487,9 @@ export async function repoDeleteLivraisonLine(bonLivraisonId: string, lineId: st
       await db.query("ROLLBACK")
       return false
     }
+    if (header.statut !== "DRAFT") {
+      throw new HttpError(409, "LOCKED", "Delete line is only allowed when statut=DRAFT")
+    }
 
     const delRes = await db.query(`DELETE FROM bon_livraison_ligne WHERE bon_livraison_id = $1::uuid AND id = $2::uuid`, [bonLivraisonId, lineId])
     const ok = (delRes.rowCount ?? 0) > 0
@@ -1419,17 +1525,78 @@ export async function repoCreateLivraisonLineAllocation(
     await db.query("BEGIN")
     const header = await getHeader(db, bonLivraisonId, { forUpdate: true })
     if (!header) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    if (header.statut !== "DRAFT") {
+      throw new HttpError(409, "ALLOCATION_LOCKED", "Les allocations ne sont modifiables qu’au statut DRAFT.")
+    }
 
-    const lineRes = await db.query<{ id: string }>(
-      `SELECT id::text AS id FROM bon_livraison_ligne WHERE bon_livraison_id = $1::uuid AND id = $2::uuid FOR UPDATE`,
+    const lineRes = await db.query<{
+      id: string
+      quantite: number
+      commande_article_id: string | null
+    }>(
+      `
+        SELECT
+          line.id::text AS id,
+          line.quantite::float8 AS quantite,
+          commande_line.article_id::text AS commande_article_id
+        FROM public.bon_livraison_ligne line
+        LEFT JOIN public.commande_ligne commande_line ON commande_line.id = line.commande_ligne_id
+        WHERE line.bon_livraison_id = $1::uuid
+          AND line.id = $2::uuid
+        FOR UPDATE OF line
+      `,
       [bonLivraisonId, lineId]
     )
     const line = lineRes.rows[0] ?? null
     if (!line) throw new HttpError(404, "LINE_NOT_FOUND", "Bon de livraison line not found")
+    const allocated = await db.query<{ quantity: number }>(
+      `
+        SELECT COALESCE(SUM(quantite), 0)::float8 AS quantity
+        FROM public.bon_livraison_ligne_allocations
+        WHERE bon_livraison_ligne_id = $1::uuid
+      `,
+      [lineId]
+    )
+    const allocatedQuantity = Number(allocated.rows[0]?.quantity ?? 0)
+    if (
+      line.commande_article_id &&
+      line.commande_article_id !== input.article_id
+    ) {
+      throw new HttpError(
+        409,
+        "LINE_ARTICLE_MISMATCH",
+        "L’article alloué ne correspond pas à l’article de la ligne de commande."
+      )
+    }
+    if (allocatedQuantity + input.quantite > line.quantite + 1e-9) {
+      throw new HttpError(
+        409,
+        "ALLOCATION_EXCEEDS_LINE",
+        "La quantité allouée dépasserait la quantité de la ligne."
+      )
+    }
 
-    const articleOk = await db.query<{ ok: number }>(`SELECT 1::int AS ok FROM public.articles WHERE id = $1::uuid LIMIT 1`, [input.article_id])
-    if (!articleOk.rows[0]?.ok) {
+    const article = await db.query<{
+      stock_managed: boolean
+      lot_tracking: boolean
+    }>(
+      `
+        SELECT stock_managed, lot_tracking
+        FROM public.articles
+        WHERE id = $1::uuid
+        LIMIT 1
+      `,
+      [input.article_id]
+    )
+    const articleSettings = article.rows[0] ?? null
+    if (!articleSettings) {
       throw new HttpError(400, "INVALID_ARTICLE", "Unknown article_id")
+    }
+    if (!articleSettings.stock_managed) {
+      throw new HttpError(409, "ARTICLE_NOT_STOCK_MANAGED", "Cet article n’est pas géré en stock.")
+    }
+    if (articleSettings.lot_tracking && !input.lot_id) {
+      throw new HttpError(409, "LOT_REQUIRED", "Un lot est obligatoire pour cet article.")
     }
 
     if (input.lot_id) {
@@ -1452,21 +1619,112 @@ export async function repoCreateLivraisonLineAllocation(
       }
     }
 
+    const source = await getStockEmplacementMapping(
+      db,
+      input.magasin_id,
+      input.emplacement_id,
+      "src"
+    )
+    const stockLevel = await db.query<{ id: string }>(
+      `
+        SELECT id::text AS id
+        FROM public.stock_levels
+        WHERE article_id = $1::uuid
+          AND location_id = $2::uuid
+        LIMIT 1
+      `,
+      [input.article_id, source.location_id]
+    )
+    const stockLevelId = stockLevel.rows[0]?.id
+    if (!stockLevelId) {
+      throw new HttpError(
+        409,
+        "STOCK_LEVEL_MISSING",
+        "Aucun stock n’existe pour cet article sur l’emplacement choisi."
+      )
+    }
+
+    let stockBatchId: string | null = null
+    if (input.lot_id) {
+      const stockBatch = await db.query<{ id: string }>(
+        `
+          SELECT batch.id::text AS id
+          FROM public.stock_batches batch
+          JOIN public.lots lot ON lot.id = batch.lot_id
+          WHERE batch.stock_level_id = $1::uuid
+            AND batch.lot_id = $2::uuid
+            AND lot.article_id = $3::uuid
+          LIMIT 1
+        `,
+        [stockLevelId, input.lot_id, input.article_id]
+      )
+      stockBatchId = stockBatch.rows[0]?.id ?? null
+      if (!stockBatchId) {
+        throw new HttpError(
+          409,
+          "STOCK_BATCH_MISSING",
+          "Le lot ne possède pas de stock sur l’emplacement choisi."
+        )
+      }
+    }
+
+    const states = await lockStockStates(db, [
+      { stock_level_id: stockLevelId, stock_batch_id: stockBatchId },
+    ])
+    const state = states.get(
+      stockTargetKey({ stock_level_id: stockLevelId, stock_batch_id: stockBatchId })
+    )
+    if (!state) throw new Error("Locked allocation stock state missing")
+    assertStockConsumptionAllowed(state, { movement_type: "RESERVE", qty: input.quantite })
+
     const ins = await db.query<{ id: string }>(
       `
         INSERT INTO public.bon_livraison_ligne_allocations (
           bon_livraison_ligne_id,
           article_id,
           lot_id,
+          magasin_id,
+          emplacement_id,
+          location_id,
+          stock_level_id,
+          stock_batch_id,
+          reservation_id,
           stock_movement_line_id,
           quantite,
           unite,
           created_by,
           updated_by
-        ) VALUES ($1::uuid,$2::uuid,$3::uuid,NULL,$4,$5,$6,$6)
+        ) VALUES (
+          $1::uuid,
+          $2::uuid,
+          $3::uuid,
+          $4::uuid,
+          $5::bigint,
+          $6::uuid,
+          $7::uuid,
+          $8::uuid,
+          NULL,
+          NULL,
+          $9,
+          $10,
+          $11,
+          $11
+        )
         RETURNING id::text AS id
       `,
-      [lineId, input.article_id, input.lot_id ?? null, input.quantite, input.unite ?? null, userId]
+      [
+        lineId,
+        input.article_id,
+        input.lot_id ?? null,
+        input.magasin_id,
+        input.emplacement_id,
+        source.location_id,
+        stockLevelId,
+        stockBatchId,
+        input.quantite,
+        input.unite ?? null,
+        userId,
+      ]
     )
     const allocationId = ins.rows[0]?.id
     if (!allocationId) throw new Error("Failed to insert allocation")
@@ -1482,6 +1740,11 @@ export async function repoCreateLivraisonLineAllocation(
         line_id: lineId,
         article_id: input.article_id,
         lot_id: input.lot_id ?? null,
+        magasin_id: input.magasin_id,
+        emplacement_id: input.emplacement_id,
+        location_id: source.location_id,
+        stock_level_id: stockLevelId,
+        stock_batch_id: stockBatchId,
         quantite: input.quantite,
         unite: input.unite ?? null,
       },
@@ -1510,6 +1773,13 @@ export async function repoDeleteLivraisonLineAllocation(
     if (!header) {
       await db.query("ROLLBACK")
       return false
+    }
+    if (header.statut !== "DRAFT") {
+      throw new HttpError(
+        409,
+        "LOCKED",
+        "Delete allocation is only allowed when statut=DRAFT"
+      )
     }
 
     const lockRes = await db.query<{ stock_movement_line_id: string | null }>(
@@ -1559,7 +1829,7 @@ export async function repoDeleteLivraisonLineAllocation(
   }
 }
 
-export async function repoUpdateLivraisonStatus(
+async function repoUpdateLivraisonStatusLegacy(
   bonLivraisonId: string,
   statut: BonLivraisonStatut,
   userId: number,
@@ -1903,6 +2173,115 @@ export async function repoUpdateLivraisonStatus(
   }
 }
 
+export async function repoUpdateLivraisonStatus(
+  bonLivraisonId: string,
+  statut: BonLivraisonStatut,
+  userId: number,
+  meta?: { commentaire?: string | null }
+): Promise<{ id: string; statut: BonLivraisonStatut }> {
+  if (statut === "SHIPPED") {
+    throw new HttpError(
+      409,
+      "SHIPMENT_CONFIRMATION_REQUIRED",
+      "Utilisez la confirmation d’expédition avec aperçu et Idempotency-Key."
+    )
+  }
+
+  const db = await pool.connect()
+  try {
+    await db.query("BEGIN")
+    const current = await getHeader(db, bonLivraisonId, { forUpdate: true })
+    if (!current) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    if (current.statut === statut) {
+      await db.query("COMMIT")
+      return { id: bonLivraisonId, statut }
+    }
+    if (!isLivraisonTransitionAllowed(current.statut, statut)) {
+      throw new HttpError(
+        409,
+        "INVALID_TRANSITION",
+        `Invalid transition from ${current.statut} to ${statut}`
+      )
+    }
+    if (
+      current.statut === "READY" &&
+      statut === "CANCELLED" &&
+      !meta?.commentaire?.trim()
+    ) {
+      throw new HttpError(
+        422,
+        "CANCELLATION_REASON_REQUIRED",
+        "Un motif est obligatoire pour annuler une préparation READY."
+      )
+    }
+
+    if (current.statut === "DRAFT" && statut === "READY") {
+      await prepareLivraisonInTransaction(db, bonLivraisonId, userId)
+      await db.query("COMMIT")
+      return { id: bonLivraisonId, statut: "READY" }
+    }
+
+    if (current.statut === "READY" && statut === "CANCELLED") {
+      await releaseLivraisonReservationsInTransaction(
+        db,
+        bonLivraisonId,
+        userId,
+        meta?.commentaire ?? "Annulation du bon de livraison"
+      )
+    }
+    if (current.statut === "SHIPPED" && statut === "DELIVERED") {
+      const proof = await db.query<{ count: number }>(
+        `
+          SELECT COUNT(*)::int AS count
+          FROM public.bon_livraison_delivery_proofs
+          WHERE bon_livraison_id = $1::uuid
+        `,
+        [bonLivraisonId]
+      )
+      if (!proof.rows[0]?.count) {
+        throw new HttpError(
+          422,
+          "DELIVERY_PROOF_REQUIRED",
+          "Une preuve de livraison est obligatoire avant de déclarer le BL livré."
+        )
+      }
+    }
+
+    const updated = await db.query(
+      `
+        UPDATE public.bon_livraison
+        SET statut = $2,
+            date_livraison = CASE
+              WHEN $2 = 'DELIVERED' THEN COALESCE(date_livraison, CURRENT_DATE)
+              ELSE date_livraison
+            END,
+            updated_at = now(),
+            updated_by = $3
+        WHERE id = $1::uuid
+          AND statut = $4
+      `,
+      [bonLivraisonId, statut, userId, current.statut]
+    )
+    if ((updated.rowCount ?? 0) !== 1) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Le statut du BL a changé.")
+    }
+    await insertEvent(db, {
+      bon_livraison_id: bonLivraisonId,
+      event_type: "STATUS_CHANGED",
+      user_id: userId,
+      old_values: { statut: current.statut },
+      new_values: { statut, commentaire: meta?.commentaire ?? null },
+    })
+    await db.query("COMMIT")
+    return { id: bonLivraisonId, statut }
+  } catch (error) {
+    await db.query("ROLLBACK")
+    throw error
+  } finally {
+    db.release()
+  }
+}
+
 export async function repoCreateLivraisonFromCommande(commandeId: number, userId: number): Promise<{ id: string }> {
   const db = await pool.connect()
   try {
@@ -1988,14 +2367,30 @@ export async function repoCreateLivraisonFromCommande(commandeId: number, userId
       delai_client: string | null
     }>(
       `
-      SELECT id, designation, code_piece, quantite::float8 AS quantite, unite, delai_client
-      FROM commande_ligne
-      WHERE commande_id = $1
-      ORDER BY id ASC
+      SELECT
+        line.id,
+        line.designation,
+        line.code_piece,
+        remainder.quantite_restante::float8 AS quantite,
+        line.unite,
+        line.delai_client
+      FROM public.commande_ligne line
+      JOIN public.v_bon_livraison_reliquats_226 remainder
+        ON remainder.commande_ligne_id = line.id
+      WHERE line.commande_id = $1
+        AND remainder.quantite_restante > 0
+      ORDER BY line.id ASC
       `,
       [commandeId]
     )
     const lignes = lignesRes.rows
+    if (!lignes.length) {
+      throw new HttpError(
+        409,
+        "NO_DELIVERABLE_REMAINDER",
+        "Cette commande ne possède plus de reliquat livrable."
+      )
+    }
     const outLines: InsertLineInput[] = lignes.map((l, idx) => ({
       ordre: idx + 1,
       designation: l.designation,
@@ -2039,10 +2434,18 @@ export async function repoAttachLivraisonDocuments(params: {
 }): Promise<BonLivraisonDocument[]> {
   const db = await pool.connect()
   const docsDir = await ensureDocsDir()
+  const storedPaths: string[] = []
   try {
     await db.query("BEGIN")
     const header = await getHeader(db, params.bonLivraisonId, { forUpdate: true })
     if (!header) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    if (header.statut === "DELIVERED" || header.statut === "CANCELLED") {
+      throw new HttpError(
+        409,
+        "LOCKED",
+        `Document upload is not allowed when statut=${header.statut}`
+      )
+    }
 
     const insertedDocIds: string[] = []
 
@@ -2050,6 +2453,10 @@ export async function repoAttachLivraisonDocuments(params: {
       const documentId = crypto.randomUUID()
       const isPdf = doc.originalname.toLowerCase().endsWith(".pdf")
       const docType = isPdf ? "PDF" : doc.mimetype
+      const checksumSha256 = crypto
+        .createHash("sha256")
+        .update(await fs.readFile(doc.path))
+        .digest("hex")
 
       const extCandidate = path.extname(doc.originalname).toLowerCase()
       const safeExt = /^\.[a-z0-9]+$/.test(extCandidate) && extCandidate.length <= 10 ? extCandidate : ""
@@ -2061,6 +2468,7 @@ export async function repoAttachLivraisonDocuments(params: {
         await fs.copyFile(doc.path, finalPath)
         await fs.unlink(doc.path)
       }
+      storedPaths.push(finalPath)
 
       await db.query(`INSERT INTO documents_clients (id, document_name, type) VALUES ($1, $2, $3)`, [
         documentId,
@@ -2069,10 +2477,27 @@ export async function repoAttachLivraisonDocuments(params: {
       ])
       await db.query(
         `
-        INSERT INTO bon_livraison_documents (bon_livraison_id, document_id, type, version, uploaded_by)
-        VALUES ($1, $2, $3, 1, $4)
+        INSERT INTO bon_livraison_documents (
+          bon_livraison_id,
+          document_id,
+          type,
+          version,
+          uploaded_by,
+          checksum_sha256,
+          file_size_bytes,
+          mime_type
+        )
+        VALUES ($1, $2, $3, 1, $4, $5, $6, $7)
         `,
-        [params.bonLivraisonId, documentId, params.type ?? (isPdf ? "PDF" : null), params.userId]
+        [
+          params.bonLivraisonId,
+          documentId,
+          params.type ?? (isPdf ? "PDF" : null),
+          params.userId,
+          checksumSha256,
+          doc.size,
+          doc.mimetype,
+        ]
       )
 
       insertedDocIds.push(documentId)
@@ -2097,6 +2522,9 @@ export async function repoAttachLivraisonDocuments(params: {
         created_at: string
         document_name: string | null
         document_type: string | null
+        checksum_sha256: string | null
+        file_size_bytes: number | null
+        mime_type: string | null
       }>(
         `
         SELECT
@@ -2107,7 +2535,10 @@ export async function repoAttachLivraisonDocuments(params: {
           d.version,
           d.created_at::text AS created_at,
           dc.document_name,
-          dc.type AS document_type
+          dc.type AS document_type,
+          d.checksum_sha256,
+          d.file_size_bytes::float8 AS file_size_bytes,
+          d.mime_type
         FROM bon_livraison_documents d
         LEFT JOIN documents_clients dc ON dc.id = d.document_id
         WHERE d.bon_livraison_id = $1::uuid
@@ -2126,6 +2557,9 @@ export async function repoAttachLivraisonDocuments(params: {
         uploaded_by: null,
         document_name: r.document_name,
         document_type: r.document_type,
+        checksum_sha256: r.checksum_sha256,
+        file_size_bytes: r.file_size_bytes,
+        mime_type: r.mime_type,
       }))
     }
 
@@ -2133,6 +2567,7 @@ export async function repoAttachLivraisonDocuments(params: {
     return docsOut
   } catch (err) {
     await db.query("ROLLBACK")
+    await Promise.all(storedPaths.map((filePath) => fs.unlink(filePath).catch(() => undefined)))
     throw err
   } finally {
     db.release()
@@ -2151,6 +2586,13 @@ export async function repoRemoveLivraisonDocument(params: {
     if (!header) {
       await db.query("ROLLBACK")
       return false
+    }
+    if (header.statut !== "DRAFT") {
+      throw new HttpError(
+        409,
+        "DOCUMENT_IMMUTABLE",
+        "Un document ne peut être retiré qu’au statut DRAFT."
+      )
     }
 
     const delRes = await db.query(

--- a/src/module/livraisons/routes/livraisons.routes.ts
+++ b/src/module/livraisons/routes/livraisons.routes.ts
@@ -1,21 +1,29 @@
-import { Router } from "express"
+import { Router, type RequestHandler } from "express"
 import multer from "multer"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
 import { ensureTmpStoragePath } from "../../../utils/cerpStorage"
+import { HttpError } from "../../../utils/httpError"
+import {
+  roleHasLivraisonCapability,
+  type LivraisonCapability,
+} from "../domain/livraisons-rbac"
 import {
   addLivraisonLine,
   addLivraisonLineAllocation,
   createLivraison,
   createLivraisonFromCommande,
+  createLivraisonProof,
   deleteLivraisonDocument,
   deleteLivraisonLine,
   deleteLivraisonLineAllocation,
   generateLivraisonPdf,
   getLivraison,
+  getLivraisonShipmentPreview,
   getLivraisonDocumentFile,
   getLivraisonPdf,
   listLivraisons,
+  shipLivraison,
   updateLivraison,
   updateLivraisonLine,
   updateLivraisonStatus,
@@ -31,38 +39,128 @@ import {
 } from "../controllers/pack.controller"
 
 const uploadTmpDir = ensureTmpStoragePath("livraisons")
-const upload = multer({ dest: uploadTmpDir })
+const upload = multer({
+  dest: uploadTmpDir,
+  limits: {
+    files: 10,
+    fileSize: 20 * 1024 * 1024,
+    fields: 10,
+  },
+})
 
 const router = Router()
 
 router.use(authenticateToken)
 
-router.get("/", listLivraisons)
-router.post("/", createLivraison)
-router.post("/from-commande/:commandeId", createLivraisonFromCommande)
+const requireLivraisonCapability = (capability: LivraisonCapability): RequestHandler =>
+  (req, _res, next) => {
+    if (!roleHasLivraisonCapability(req.user?.role, capability)) {
+      next(
+        new HttpError(
+          403,
+          "LIVRAISON_FORBIDDEN",
+          `Livraison capability required: ${capability}`
+        )
+      )
+      return
+    }
+    next()
+  }
 
-router.get("/:id", getLivraison)
-router.put("/:id", updateLivraison)
+const requireStatusCapability: RequestHandler = (req, _res, next) => {
+  const status =
+    typeof req.body === "object" && req.body !== null && "statut" in req.body
+      ? String((req.body as { statut?: unknown }).statut ?? "")
+      : ""
+  const capability: LivraisonCapability =
+    status === "CANCELLED"
+      ? "cancel"
+      : status === "DELIVERED"
+        ? "deliver"
+        : status === "SHIPPED"
+          ? "ship"
+          : "prepare"
+  requireLivraisonCapability(capability)(req, _res, next)
+}
 
-router.post("/:id/lines", addLivraisonLine)
-router.put("/:id/lines/:lineId", updateLivraisonLine)
-router.delete("/:id/lines/:lineId", deleteLivraisonLine)
+router.get("/", requireLivraisonCapability("read"), listLivraisons)
+router.post("/", requireLivraisonCapability("prepare"), createLivraison)
+router.post(
+  "/from-commande/:commandeId",
+  requireLivraisonCapability("prepare"),
+  createLivraisonFromCommande
+)
 
-router.post("/:id/lignes/:lineId/allocations", addLivraisonLineAllocation)
-router.delete("/:id/lignes/:lineId/allocations/:allocationId", deleteLivraisonLineAllocation)
+router.get("/:id", requireLivraisonCapability("read"), getLivraison)
+router.put("/:id", requireLivraisonCapability("prepare"), updateLivraison)
 
-router.post("/:id/status", updateLivraisonStatus)
+router.post("/:id/lines", requireLivraisonCapability("prepare"), addLivraisonLine)
+router.put("/:id/lines/:lineId", requireLivraisonCapability("prepare"), updateLivraisonLine)
+router.delete("/:id/lines/:lineId", requireLivraisonCapability("prepare"), deleteLivraisonLine)
 
-router.post("/:id/documents", upload.array("documents[]"), uploadLivraisonDocuments)
-router.delete("/:id/documents/:docId", deleteLivraisonDocument)
-router.get("/:id/documents/:docId/file", getLivraisonDocumentFile)
+router.post(
+  "/:id/lignes/:lineId/allocations",
+  requireLivraisonCapability("allocate"),
+  addLivraisonLineAllocation
+)
+router.delete(
+  "/:id/lignes/:lineId/allocations/:allocationId",
+  requireLivraisonCapability("allocate"),
+  deleteLivraisonLineAllocation
+)
 
-router.get("/:id/pdf", getLivraisonPdf)
-router.post("/:id/pdf", generateLivraisonPdf)
+router.get(
+  "/:id/shipment-preview",
+  requireLivraisonCapability("ship"),
+  getLivraisonShipmentPreview
+)
+router.post("/:id/ship", requireLivraisonCapability("ship"), shipLivraison)
+router.post("/:id/status", requireStatusCapability, updateLivraisonStatus)
+router.post("/:id/proofs", requireLivraisonCapability("proof_manage"), createLivraisonProof)
 
-router.get("/:id/pack/preview", getLivraisonPackPreview)
-router.post("/:id/pack/generate", generateLivraisonPack)
-router.get("/:id/pack/download/:documentId", downloadLivraisonPackDocument)
-router.post("/:id/pack/revoke/:versionId", revokeLivraisonPackVersion)
+router.post(
+  "/:id/documents",
+  requireLivraisonCapability("documents_manage"),
+  upload.array("documents[]"),
+  uploadLivraisonDocuments
+)
+router.delete(
+  "/:id/documents/:docId",
+  requireLivraisonCapability("documents_manage"),
+  deleteLivraisonDocument
+)
+router.get(
+  "/:id/documents/:docId/file",
+  requireLivraisonCapability("read"),
+  getLivraisonDocumentFile
+)
+
+router.get("/:id/pdf", requireLivraisonCapability("read"), getLivraisonPdf)
+router.post(
+  "/:id/pdf",
+  requireLivraisonCapability("documents_manage"),
+  generateLivraisonPdf
+)
+
+router.get(
+  "/:id/pack/preview",
+  requireLivraisonCapability("read"),
+  getLivraisonPackPreview
+)
+router.post(
+  "/:id/pack/generate",
+  requireLivraisonCapability("documents_manage"),
+  generateLivraisonPack
+)
+router.get(
+  "/:id/pack/download/:documentId",
+  requireLivraisonCapability("read"),
+  downloadLivraisonPackDocument
+)
+router.post(
+  "/:id/pack/revoke/:versionId",
+  requireLivraisonCapability("documents_manage"),
+  revokeLivraisonPackVersion
+)
 
 export default router

--- a/src/module/livraisons/services/livraisons-document-validation.test.ts
+++ b/src/module/livraisons/services/livraisons-document-validation.test.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+
+import { afterEach, describe, expect, it } from "vitest"
+
+import {
+  removeTemporaryLivraisonDocuments,
+  validateLivraisonDocuments,
+} from "./livraisons-document-validation"
+
+const temporaryDirectories: string[] = []
+
+async function fileFixture(
+  originalname: string,
+  mimetype: string,
+  bytes: Buffer
+): Promise<Express.Multer.File> {
+  const directory = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-livraison-doc-"))
+  temporaryDirectories.push(directory)
+  const filePath = path.join(directory, "upload")
+  await fs.writeFile(filePath, bytes)
+  return {
+    fieldname: "documents",
+    originalname,
+    encoding: "7bit",
+    mimetype,
+    destination: directory,
+    filename: "upload",
+    path: filePath,
+    size: bytes.length,
+    stream: undefined as never,
+    buffer: bytes,
+  }
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories.splice(0).map((directory) =>
+      fs.rm(directory, { recursive: true, force: true })
+    )
+  )
+})
+
+describe("validation des documents Livraison #226", () => {
+  it("accepte un PDF dont extension, MIME et signature concordent", async () => {
+    const file = await fileFixture(
+      "preuve.pdf",
+      "application/pdf",
+      Buffer.from("%PDF-1.7\npreuve synthétique")
+    )
+
+    await expect(validateLivraisonDocuments([file])).resolves.toBeUndefined()
+  })
+
+  it("refuse une extension non autorisée", async () => {
+    const file = await fileFixture(
+      "preuve.exe",
+      "application/octet-stream",
+      Buffer.from("MZ")
+    )
+
+    await expect(validateLivraisonDocuments([file])).rejects.toMatchObject({
+      status: 415,
+      code: "LIVRAISON_DOCUMENT_EXTENSION_UNSUPPORTED",
+    })
+  })
+
+  it("refuse un MIME incohérent avec l'extension", async () => {
+    const file = await fileFixture(
+      "preuve.pdf",
+      "image/png",
+      Buffer.from("%PDF-1.7")
+    )
+
+    await expect(validateLivraisonDocuments([file])).rejects.toMatchObject({
+      status: 415,
+      code: "LIVRAISON_DOCUMENT_MIME_MISMATCH",
+    })
+  })
+
+  it("refuse une signature binaire incohérente", async () => {
+    const file = await fileFixture(
+      "preuve.pdf",
+      "application/pdf",
+      Buffer.from("faux document")
+    )
+
+    await expect(validateLivraisonDocuments([file])).rejects.toMatchObject({
+      status: 415,
+      code: "LIVRAISON_DOCUMENT_SIGNATURE_MISMATCH",
+    })
+  })
+
+  it("refuse les lots de plus de dix documents", async () => {
+    const file = await fileFixture(
+      "preuve.pdf",
+      "application/pdf",
+      Buffer.from("%PDF-1.7")
+    )
+
+    await expect(
+      validateLivraisonDocuments(Array.from({ length: 11 }, () => file))
+    ).rejects.toMatchObject({
+      status: 400,
+      code: "LIVRAISON_DOCUMENT_LIMIT",
+    })
+  })
+
+  it("refuse un fichier vide", async () => {
+    const file = await fileFixture("vide.txt", "text/plain", Buffer.alloc(0))
+
+    await expect(validateLivraisonDocuments([file])).rejects.toMatchObject({
+      status: 400,
+      code: "LIVRAISON_DOCUMENT_EMPTY",
+    })
+  })
+
+  it("supprime le fichier temporaire après traitement", async () => {
+    const file = await fileFixture(
+      "preuve.pdf",
+      "application/pdf",
+      Buffer.from("%PDF-1.7")
+    )
+
+    await removeTemporaryLivraisonDocuments([file])
+
+    await expect(fs.stat(file.path)).rejects.toMatchObject({ code: "ENOENT" })
+  })
+})

--- a/src/module/livraisons/services/livraisons-document-validation.ts
+++ b/src/module/livraisons/services/livraisons-document-validation.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises"
+import path from "node:path"
+
+import { HttpError } from "../../../utils/httpError"
+
+const MAX_DOCUMENTS = 10
+const MAX_DOCUMENT_BYTES = 20 * 1024 * 1024
+
+const MIME_BY_EXTENSION: Record<string, readonly string[]> = {
+  ".pdf": ["application/pdf"],
+  ".png": ["image/png"],
+  ".jpg": ["image/jpeg"],
+  ".jpeg": ["image/jpeg"],
+  ".docx": [
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/zip",
+    "application/octet-stream",
+  ],
+  ".xlsx": [
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/zip",
+    "application/octet-stream",
+  ],
+  ".txt": ["text/plain", "application/octet-stream"],
+  ".csv": ["text/csv", "text/plain", "application/vnd.ms-excel", "application/octet-stream"],
+}
+
+function startsWith(bytes: Buffer, signature: readonly number[]): boolean {
+  return signature.every((value, index) => bytes[index] === value)
+}
+
+function signatureMatches(extension: string, bytes: Buffer): boolean {
+  if (extension === ".pdf") return bytes.subarray(0, 5).toString("ascii") === "%PDF-"
+  if (extension === ".png") {
+    return startsWith(bytes, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a])
+  }
+  if (extension === ".jpg" || extension === ".jpeg") {
+    return startsWith(bytes, [0xff, 0xd8, 0xff])
+  }
+  if (extension === ".docx" || extension === ".xlsx") {
+    return startsWith(bytes, [0x50, 0x4b, 0x03, 0x04])
+  }
+  if (extension === ".txt" || extension === ".csv") return !bytes.includes(0x00)
+  return false
+}
+
+async function readPrefix(filePath: string): Promise<Buffer> {
+  const handle = await fs.open(filePath, "r")
+  try {
+    const bytes = Buffer.alloc(512)
+    const read = await handle.read(bytes, 0, bytes.length, 0)
+    return bytes.subarray(0, read.bytesRead)
+  } finally {
+    await handle.close()
+  }
+}
+
+export async function validateLivraisonDocuments(
+  files: Express.Multer.File[]
+): Promise<void> {
+  if (!files.length) {
+    throw new HttpError(400, "LIVRAISON_DOCUMENT_REQUIRED", "Ajoutez au moins un document.")
+  }
+  if (files.length > MAX_DOCUMENTS) {
+    throw new HttpError(
+      400,
+      "LIVRAISON_DOCUMENT_LIMIT",
+      `Au maximum ${MAX_DOCUMENTS} documents peuvent être ajoutés à la fois.`
+    )
+  }
+
+  for (const file of files) {
+    if (!file.size) {
+      throw new HttpError(400, "LIVRAISON_DOCUMENT_EMPTY", "Un document est vide.")
+    }
+    if (file.size > MAX_DOCUMENT_BYTES) {
+      throw new HttpError(
+        413,
+        "LIVRAISON_DOCUMENT_TOO_LARGE",
+        "Un document dépasse la taille maximale de 20 Mo."
+      )
+    }
+    const extension = path.extname(file.originalname).toLowerCase()
+    const allowedMimes = MIME_BY_EXTENSION[extension]
+    if (!allowedMimes) {
+      throw new HttpError(
+        415,
+        "LIVRAISON_DOCUMENT_EXTENSION_UNSUPPORTED",
+        "Le format du document n’est pas autorisé."
+      )
+    }
+    if (!allowedMimes.includes(file.mimetype.toLowerCase())) {
+      throw new HttpError(
+        415,
+        "LIVRAISON_DOCUMENT_MIME_MISMATCH",
+        "Le type MIME du document ne correspond pas à son extension."
+      )
+    }
+    if (!signatureMatches(extension, await readPrefix(file.path))) {
+      throw new HttpError(
+        415,
+        "LIVRAISON_DOCUMENT_SIGNATURE_MISMATCH",
+        "La signature binaire du document ne correspond pas au format déclaré."
+      )
+    }
+  }
+}
+
+export async function removeTemporaryLivraisonDocuments(
+  files: Express.Multer.File[]
+): Promise<void> {
+  await Promise.all(files.map((file) => fs.unlink(file.path).catch(() => undefined)))
+}

--- a/src/module/livraisons/services/livraisons.service.ts
+++ b/src/module/livraisons/services/livraisons.service.ts
@@ -1,12 +1,15 @@
 import { HttpError } from "../../../utils/httpError"
 
 import type { BonLivraisonStatut } from "../types/livraisons.types"
+import { isLivraisonTransitionAllowed } from "../domain/livraisons-policy"
 import type {
   CreateLivraisonBodyDTO,
   CreateLivraisonAllocationBodyDTO,
   CreateLivraisonLineBodyDTO,
   ListLivraisonsQueryDTO,
   LivraisonStatusBodyDTO,
+  LivraisonProofBodyDTO,
+  ShipLivraisonBodyDTO,
   UpdateLivraisonBodyDTO,
   UpdateLivraisonLineBodyDTO,
 } from "../validators/livraisons.validators"
@@ -27,23 +30,24 @@ import {
   repoUpdateLivraisonLine,
   repoUpdateLivraisonStatus,
 } from "../repository/livraisons.repository"
+import {
+  repoCreateLivraisonProof,
+  repoGetLivraisonShipmentPreview,
+  repoShipLivraison,
+} from "../repository/livraisons-shipment.repository"
 
 function assertEditable(statut: BonLivraisonStatut, action: string) {
   if (statut === "DRAFT" || statut === "READY") return
   throw new HttpError(409, "LOCKED", `${action} is not allowed when statut=${statut}`)
 }
 
-function assertAllowedTransition(from: BonLivraisonStatut, to: BonLivraisonStatut) {
-  const allowed: Record<BonLivraisonStatut, BonLivraisonStatut[]> = {
-    DRAFT: ["READY", "CANCELLED"],
-    READY: ["SHIPPED", "CANCELLED"],
-    SHIPPED: ["DELIVERED"],
-    DELIVERED: [],
-    CANCELLED: [],
-  }
+function assertDraft(statut: BonLivraisonStatut, action: string) {
+  if (statut === "DRAFT") return
+  throw new HttpError(409, "LOCKED", `${action} is only allowed when statut=DRAFT`)
+}
 
-  if (from === to) return
-  if (allowed[from].includes(to)) return
+function assertAllowedTransition(from: BonLivraisonStatut, to: BonLivraisonStatut) {
+  if (isLivraisonTransitionAllowed(from, to)) return
   throw new HttpError(409, "INVALID_TRANSITION", `Invalid transition from ${from} to ${to}`)
 }
 
@@ -67,53 +71,42 @@ export async function svcUpdateLivraisonHeader(id: string, patch: UpdateLivraiso
   const statut = await repoGetLivraisonStatut(id)
   if (!statut) return null
 
-  // Allow only reception signature fields when delivered.
-  if (statut === "DELIVERED") {
-    const keys = Object.keys(patch) as Array<keyof UpdateLivraisonBodyDTO>
-    const allowedKeys: Array<keyof UpdateLivraisonBodyDTO> = ["reception_nom_signataire", "reception_date_signature"]
-    const forbidden = keys.filter((k) => !allowedKeys.includes(k))
-    if (forbidden.length) {
-      throw new HttpError(409, "LOCKED", `Only reception fields can be updated when statut=${statut}`)
-    }
-  } else {
-    assertEditable(statut, "Update")
-  }
-
+  assertEditable(statut, "Update")
   return repoUpdateLivraisonHeader(id, patch, userId)
 }
 
 export async function svcAddLivraisonLine(id: string, dto: CreateLivraisonLineBodyDTO, userId: number) {
   const statut = await repoGetLivraisonStatut(id)
   if (!statut) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
-  assertEditable(statut, "Add line")
+  assertDraft(statut, "Add line")
   return repoAddLivraisonLine(id, dto, userId)
 }
 
 export async function svcUpdateLivraisonLine(id: string, lineId: string, patch: UpdateLivraisonLineBodyDTO, userId: number) {
   const statut = await repoGetLivraisonStatut(id)
   if (!statut) return null
-  assertEditable(statut, "Update line")
+  assertDraft(statut, "Update line")
   return repoUpdateLivraisonLine(id, lineId, patch, userId)
 }
 
 export async function svcDeleteLivraisonLine(id: string, lineId: string, userId: number) {
   const statut = await repoGetLivraisonStatut(id)
   if (!statut) return false
-  assertEditable(statut, "Delete line")
+  assertDraft(statut, "Delete line")
   return repoDeleteLivraisonLine(id, lineId, userId)
 }
 
 export async function svcCreateLivraisonLineAllocation(id: string, lineId: string, dto: CreateLivraisonAllocationBodyDTO, userId: number) {
   const statut = await repoGetLivraisonStatut(id)
   if (!statut) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
-  assertEditable(statut, "Allocate line")
+  assertDraft(statut, "Allocate line")
   return repoCreateLivraisonLineAllocation(id, lineId, dto, userId)
 }
 
 export async function svcDeleteLivraisonLineAllocation(id: string, lineId: string, allocationId: string, userId: number) {
   const statut = await repoGetLivraisonStatut(id)
   if (!statut) return false
-  assertEditable(statut, "Delete allocation")
+  assertDraft(statut, "Delete allocation")
   return repoDeleteLivraisonLineAllocation(id, lineId, allocationId, userId)
 }
 
@@ -121,15 +114,56 @@ export async function svcUpdateLivraisonStatus(id: string, body: LivraisonStatus
   const current = await repoGetLivraisonStatut(id)
   if (!current) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
   assertAllowedTransition(current, body.statut)
+  if (
+    current === "READY" &&
+    body.statut === "CANCELLED" &&
+    !body.commentaire?.trim()
+  ) {
+    throw new HttpError(
+      422,
+      "CANCELLATION_REASON_REQUIRED",
+      "Un motif est obligatoire pour annuler une préparation READY."
+    )
+  }
   return repoUpdateLivraisonStatus(id, body.statut, userId, { commentaire: body.commentaire ?? null })
+}
+
+export async function svcGetLivraisonShipmentPreview(id: string) {
+  const preview = await repoGetLivraisonShipmentPreview(id)
+  if (!preview) {
+    throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+  }
+  return preview
+}
+
+export function svcShipLivraison(
+  id: string,
+  body: ShipLivraisonBodyDTO,
+  userId: number,
+  idempotencyKey: string
+) {
+  return repoShipLivraison(id, body, userId, idempotencyKey)
+}
+
+export function svcCreateLivraisonProof(
+  id: string,
+  body: LivraisonProofBodyDTO,
+  userId: number
+) {
+  return repoCreateLivraisonProof(id, body, userId)
 }
 
 export async function svcAttachLivraisonDocuments(params: {
   bonLivraisonId: string
-  documents: Array<{ originalname: string; path: string; mimetype: string }>
+  documents: Array<{ originalname: string; path: string; mimetype: string; size: number }>
   type?: string | null
   userId: number
 }) {
+  const statut = await repoGetLivraisonStatut(params.bonLivraisonId)
+  if (!statut) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+  if (statut === "DELIVERED" || statut === "CANCELLED") {
+    throw new HttpError(409, "LOCKED", `Document upload is not allowed when statut=${statut}`)
+  }
   return repoAttachLivraisonDocuments({
     bonLivraisonId: params.bonLivraisonId,
     documents: params.documents,
@@ -139,5 +173,10 @@ export async function svcAttachLivraisonDocuments(params: {
 }
 
 export async function svcRemoveLivraisonDocument(params: { bonLivraisonId: string; documentId: string; userId: number }) {
+  const statut = await repoGetLivraisonStatut(params.bonLivraisonId)
+  if (!statut) return false
+  if (statut !== "DRAFT") {
+    throw new HttpError(409, "DOCUMENT_IMMUTABLE", "Un document ne peut être retiré qu’au statut DRAFT.")
+  }
   return repoRemoveLivraisonDocument(params)
 }

--- a/src/module/livraisons/services/pack-pdf.service.ts
+++ b/src/module/livraisons/services/pack-pdf.service.ts
@@ -205,14 +205,25 @@ export async function svcRenderPackBonLivraisonPdf(args: { preview: LivraisonPac
     const table = renderBlLinesTable(doc, {
       startY: doc.y,
       pageNoStart: 1,
-      lines: lines.map((l) => ({
-        ordre: l.ordre,
-        designation: l.designation,
-        code_piece: l.code_piece,
-        quantite: l.quantite,
-        unite: l.unite,
-        delai_client: l.delai_client,
-      })),
+      lines: lines.map((line) => {
+        const lots = Array.from(
+          new Set(
+            (line.allocations ?? [])
+              .map((allocation) => allocation.lot?.lot_code ?? null)
+              .filter((lotCode): lotCode is string => Boolean(lotCode))
+          )
+        )
+        return {
+          ordre: line.ordre,
+          designation: lots.length
+            ? `${line.designation}\nLot(s) : ${lots.join(", ")}`
+            : line.designation,
+          code_piece: line.code_piece,
+          quantite: line.quantite,
+          unite: line.unite,
+          delai_client: line.delai_client,
+        }
+      }),
     })
 
     const boxY = Math.min(table.y + 10, doc.page.height - doc.page.margins.bottom - 70)

--- a/src/module/livraisons/services/pack.service.ts
+++ b/src/module/livraisons/services/pack.service.ts
@@ -205,6 +205,8 @@ export async function svcGenerateLivraisonPack(params: {
     })
 
     const checksum = crypto.createHash("sha256").update(blPdf).update(cofcPdf).digest("hex")
+    const blChecksum = crypto.createHash("sha256").update(blPdf).digest("hex")
+    const cofcChecksum = crypto.createHash("sha256").update(cofcPdf).digest("hex")
 
     await fs.writeFile(blPath, blPdf)
     await fs.writeFile(cofcPath, cofcPdf)
@@ -226,22 +228,56 @@ export async function svcGenerateLivraisonPack(params: {
 
       const blRow = await db.query<{ id: string }>(
         `
-          INSERT INTO public.bon_livraison_documents (bon_livraison_id, document_id, type, version, uploaded_by)
-          VALUES ($1::uuid, $2::uuid, $3, $4, $5)
+          INSERT INTO public.bon_livraison_documents (
+            bon_livraison_id,
+            document_id,
+            type,
+            version,
+            uploaded_by,
+            checksum_sha256,
+            file_size_bytes,
+            mime_type
+          )
+          VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6, $7, 'application/pdf')
           RETURNING id::text AS id
         `,
-        [params.bonLivraisonId, blDocumentId, "GENERATED_BL_PDF", version, params.actorUserId]
+        [
+          params.bonLivraisonId,
+          blDocumentId,
+          "GENERATED_BL_PDF",
+          version,
+          params.actorUserId,
+          blChecksum,
+          blPdf.byteLength,
+        ]
       )
       const blDocRowId = blRow.rows[0]?.id
       if (!blDocRowId) throw new Error("Failed to create bon_livraison_documents row for BL PDF")
 
       const cofcRow = await db.query<{ id: string }>(
         `
-          INSERT INTO public.bon_livraison_documents (bon_livraison_id, document_id, type, version, uploaded_by)
-          VALUES ($1::uuid, $2::uuid, $3, $4, $5)
+          INSERT INTO public.bon_livraison_documents (
+            bon_livraison_id,
+            document_id,
+            type,
+            version,
+            uploaded_by,
+            checksum_sha256,
+            file_size_bytes,
+            mime_type
+          )
+          VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6, $7, 'application/pdf')
           RETURNING id::text AS id
         `,
-        [params.bonLivraisonId, cofcDocumentId, "GENERATED_COFC_PDF", version, params.actorUserId]
+        [
+          params.bonLivraisonId,
+          cofcDocumentId,
+          "GENERATED_COFC_PDF",
+          version,
+          params.actorUserId,
+          cofcChecksum,
+          cofcPdf.byteLength,
+        ]
       )
       const cofcDocRowId = cofcRow.rows[0]?.id
       if (!cofcDocRowId) throw new Error("Failed to create bon_livraison_documents row for CofC PDF")

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -160,7 +160,22 @@ export async function svcGenerateLivraisonPdf(bonLivraisonId: string, userId: nu
     doc.moveDown(1)
     const afterLinesY = renderLines(
       doc,
-      detail.lignes.map((l) => ({ designation: l.designation, quantite: l.quantite, unite: l.unite })),
+      detail.lignes.map((line) => {
+        const lots = Array.from(
+          new Set(
+            line.allocations
+              .map((allocation) => allocation.lot_code)
+              .filter((lotCode): lotCode is string => Boolean(lotCode))
+          )
+        )
+        const code = line.code_piece ? `${line.code_piece} — ` : ""
+        const lotLabel = lots.length ? `\nLot(s) : ${lots.join(", ")}` : ""
+        return {
+          designation: `${code}${line.designation}${lotLabel}`,
+          quantite: line.quantite,
+          unite: line.unite,
+        }
+      }),
       doc.y
     )
 
@@ -173,19 +188,39 @@ export async function svcGenerateLivraisonPdf(bonLivraisonId: string, userId: nu
     doc.moveDown(0.5)
     doc.text("Date:")
   })
+  const pdfBytes = await fs.readFile(filePath)
+  const checksumSha256 = crypto.createHash("sha256").update(pdfBytes).digest("hex")
 
   const db = await pool.connect()
   try {
     await db.query("BEGIN")
     await db.query(`INSERT INTO documents_clients (id, document_name, type) VALUES ($1, $2, $3)`, [documentId, fileName, "PDF"])
     await db.query(
-      `INSERT INTO bon_livraison_documents (bon_livraison_id, document_id, type, version, uploaded_by) VALUES ($1, $2, $3, $4, $5)`,
-      [bonLivraisonId, documentId, "PDF", version, userId]
+      `
+        INSERT INTO bon_livraison_documents (
+          bon_livraison_id,
+          document_id,
+          type,
+          version,
+          uploaded_by,
+          checksum_sha256,
+          file_size_bytes,
+          mime_type
+        )
+        VALUES ($1, $2, $3, $4, $5, $6, $7, 'application/pdf')
+      `,
+      [bonLivraisonId, documentId, "PDF", version, userId, checksumSha256, pdfBytes.byteLength]
     )
     await db.query(
       `INSERT INTO bon_livraison_event_log (bon_livraison_id, event_type, old_values, new_values, user_id)
        VALUES ($1, $2, $3::jsonb, $4::jsonb, $5)`,
-      [bonLivraisonId, "PDF_GENERATED", null, JSON.stringify({ document_id: documentId, version }), userId]
+      [
+        bonLivraisonId,
+        "PDF_GENERATED",
+        null,
+        JSON.stringify({ document_id: documentId, version, checksum_sha256: checksumSha256 }),
+        userId,
+      ]
     )
     await db.query(`UPDATE bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`, [bonLivraisonId, userId])
     await db.query("COMMIT")

--- a/src/module/livraisons/types/livraisons.types.ts
+++ b/src/module/livraisons/types/livraisons.types.ts
@@ -3,12 +3,22 @@ export type Paginated<T> = {
   total: number
 }
 
+export type BonLivraisonListSummary = {
+  total: number
+  draft: number
+  ready: number
+  shipped: number
+  delivered: number
+  cancelled: number
+}
+
 export type BonLivraisonStatut = "DRAFT" | "READY" | "SHIPPED" | "DELIVERED" | "CANCELLED"
 
 export type UploadedDocument = {
   originalname: string
   path: string
   mimetype: string
+  size: number
 }
 
 export type UserLite = {
@@ -77,6 +87,7 @@ export type BonLivraisonHeader = {
   commentaire_client: string | null
   reception_nom_signataire: string | null
   reception_date_signature: string | null
+  row_version: number
   created_at: string
   updated_at: string
   created_by: UserLite | null
@@ -105,6 +116,17 @@ export type BonLivraisonLigneAllocation = {
   bon_livraison_ligne_id: string
   article_id: string
   lot_id: string | null
+  lot_code: string | null
+  lot_status: string | null
+  magasin_id: string | null
+  magasin_code: string | null
+  emplacement_id: number | null
+  emplacement_code: string | null
+  location_id: string | null
+  stock_level_id: string | null
+  stock_batch_id: string | null
+  reservation_id: string | null
+  reservation_status: string | null
   stock_movement_line_id: string | null
   quantite: number
   unite: string | null
@@ -112,6 +134,26 @@ export type BonLivraisonLigneAllocation = {
   updated_at: string
   created_by: UserLite | null
   updated_by: UserLite | null
+}
+
+export type BonLivraisonProofType =
+  | "RECIPIENT_ACK"
+  | "CARRIER_DOCUMENT"
+  | "PHOTO"
+  | "EXTERNAL_SIGNATURE"
+
+export type BonLivraisonDeliveryProof = {
+  id: string
+  bon_livraison_id: string
+  proof_type: BonLivraisonProofType
+  delivered_at: string
+  received_by_name: string | null
+  document_id: string | null
+  document_name: string | null
+  note: string | null
+  correlation_id: string
+  created_by: UserLite | null
+  created_at: string
 }
 
 export type BonLivraisonDocument = {
@@ -124,6 +166,9 @@ export type BonLivraisonDocument = {
   uploaded_by: UserLite | null
   document_name: string | null
   document_type: string | null
+  checksum_sha256: string | null
+  file_size_bytes: number | null
+  mime_type: string | null
 }
 
 export type BonLivraisonEventLog = {
@@ -140,5 +185,88 @@ export type BonLivraisonDetail = {
   bon_livraison: BonLivraisonHeader
   lignes: BonLivraisonLigne[]
   documents: BonLivraisonDocument[]
+  proofs: BonLivraisonDeliveryProof[]
   events: BonLivraisonEventLog[]
+}
+
+export type ShipmentPreviewBlocker = {
+  code: string
+  message: string
+  line_id?: string
+  allocation_id?: string
+}
+
+export type ShipmentPreviewAllocation = {
+  allocation_id: string
+  line_id: string
+  line_order: number
+  article_id: string
+  lot_id: string | null
+  magasin_id: string
+  emplacement_id: number
+  location_id: string
+  stock_level_id: string
+  stock_batch_id: string | null
+  reservation_id: string | null
+  quantity: number
+  unit: string | null
+  quantity_available: number
+}
+
+export type ShipmentPreviewRemainder = {
+  line_id: string
+  commande_ligne_id: number | null
+  quantity_ordered: number | null
+  quantity_already_shipped: number | null
+  quantity_remaining_before_shipment: number | null
+  quantity_in_shipment: number
+  quantity_remaining_after_shipment: number | null
+}
+
+export type ShipmentPreviewMovement = {
+  movement_type: "OUT"
+  article_id: string
+  lot_id: string | null
+  magasin_id: string
+  emplacement_id: number
+  stock_level_id: string
+  stock_batch_id: string | null
+  quantity: number
+  unit: string | null
+}
+
+export type ShipmentPreviewPack = {
+  version_id: string
+  version: number
+  checksum_sha256: string
+}
+
+export type BonLivraisonShipmentPreview = {
+  bon_livraison_id: string
+  numero: string
+  status: BonLivraisonStatut
+  row_version: number
+  preview_hash: string
+  can_ship: boolean
+  blockers: ShipmentPreviewBlocker[]
+  allocations: ShipmentPreviewAllocation[]
+  reliquats: ShipmentPreviewRemainder[]
+  simulated_movements: ShipmentPreviewMovement[]
+  document_pack: ShipmentPreviewPack | null
+  totals: {
+    lines: number
+    allocations: number
+    quantity: number
+  }
+}
+
+export type BonLivraisonShipResult = {
+  id: string
+  statut: "SHIPPED"
+  row_version: number
+  stock_movement_ids: string[]
+  correlation_id: string
+  idempotent_replay: boolean
+  billing_event: "DELIVERY.SHIPPED"
+  invoice_created: false
 }

--- a/src/module/livraisons/validators/livraisons.validators.ts
+++ b/src/module/livraisons/validators/livraisons.validators.ts
@@ -1,46 +1,50 @@
 import { z } from "zod"
 import type { BonLivraisonStatut } from "../types/livraisons.types"
 
+const uuid = z.string().uuid()
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date attendue au format AAAA-MM-JJ")
+const nullableText = (max: number) => z.string().trim().min(1).max(max).optional().nullable()
+
 export const bonLivraisonStatutSchema = z
   .enum(["DRAFT", "READY", "SHIPPED", "DELIVERED", "CANCELLED"]) satisfies z.ZodType<BonLivraisonStatut>
 
 export const livraisonIdParamsSchema = z.object({
-  id: z.string().uuid(),
-})
+  id: uuid,
+}).strict()
 
 export const livraisonLineIdParamsSchema = z.object({
-  id: z.string().uuid(),
-  lineId: z.string().uuid(),
-})
+  id: uuid,
+  lineId: uuid,
+}).strict()
 
 export const livraisonLineAllocationIdParamsSchema = z.object({
-  id: z.string().uuid(),
-  lineId: z.string().uuid(),
-  allocationId: z.string().uuid(),
-})
+  id: uuid,
+  lineId: uuid,
+  allocationId: uuid,
+}).strict()
 
 export const livraisonDocParamsSchema = z.object({
-  id: z.string().uuid(),
-  docId: z.string().uuid(),
-})
+  id: uuid,
+  docId: uuid,
+}).strict()
 
 export const fromCommandeParamsSchema = z.object({
   commandeId: z.coerce.number().int().positive(),
-})
+}).strict()
 
 export const listLivraisonsQuerySchema = z
   .object({
-    q: z.string().trim().min(1).optional(),
+    q: z.string().trim().min(1).max(120).optional(),
     client_id: z.string().trim().min(1).optional(),
     statut: bonLivraisonStatutSchema.optional(),
-    from: z.string().trim().min(1).optional(),
-    to: z.string().trim().min(1).optional(),
+    from: isoDate.optional(),
+    to: isoDate.optional(),
     page: z.coerce.number().int().positive().optional(),
     pageSize: z.coerce.number().int().positive().max(200).optional(),
     sortBy: z.enum(["date_creation", "updated_at", "numero", "statut"]).optional(),
     sortDir: z.enum(["asc", "desc"]).optional(),
   })
-  .passthrough()
+  .strict()
 
 export type ListLivraisonsQueryDTO = z.infer<typeof listLivraisonsQuerySchema>
 
@@ -49,27 +53,30 @@ export const createLivraisonBodySchema = z
     client_id: z.string().trim().min(1),
     commande_id: z.coerce.number().int().positive().optional().nullable(),
     affaire_id: z.coerce.number().int().positive().optional().nullable(),
-    adresse_livraison_id: z.string().uuid().optional().nullable(),
-    date_creation: z.string().trim().min(1).optional(),
-    commentaire_interne: z.string().optional().nullable(),
-    commentaire_client: z.string().optional().nullable(),
-    transporteur: z.string().optional().nullable(),
-    tracking_number: z.string().optional().nullable(),
+    adresse_livraison_id: uuid.optional().nullable(),
+    date_creation: isoDate.optional(),
+    commentaire_interne: nullableText(5000),
+    commentaire_client: nullableText(2000),
+    transporteur: nullableText(200),
+    tracking_number: nullableText(200),
     lignes: z
       .array(
-        z.object({
-          ordre: z.coerce.number().int().positive().optional(),
-          designation: z.string().trim().min(1).max(10000),
-          code_piece: z.string().trim().min(1).max(200).optional().nullable(),
-          quantite: z.coerce.number().positive(),
-          unite: z.string().trim().min(1).max(30).optional().nullable(),
-          commande_ligne_id: z.coerce.number().int().positive().optional().nullable(),
-          delai_client: z.string().trim().min(1).max(100).optional().nullable(),
-        })
+        z
+          .object({
+            ordre: z.coerce.number().int().positive().optional(),
+            designation: z.string().trim().min(1).max(10000),
+            code_piece: nullableText(200),
+            quantite: z.coerce.number().positive().max(1_000_000_000),
+            unite: nullableText(30),
+            commande_ligne_id: z.coerce.number().int().positive().optional().nullable(),
+            delai_client: isoDate.optional().nullable(),
+          })
+          .strict()
       )
+      .max(500)
       .optional(),
   })
-  .passthrough()
+  .strict()
 
 export type CreateLivraisonBodyDTO = z.infer<typeof createLivraisonBodySchema>
 
@@ -77,18 +84,18 @@ export const updateLivraisonBodySchema = z
   .object({
     commande_id: z.coerce.number().int().positive().optional().nullable(),
     affaire_id: z.coerce.number().int().positive().optional().nullable(),
-    adresse_livraison_id: z.string().uuid().optional().nullable(),
-    date_creation: z.string().trim().min(1).optional(),
-    date_expedition: z.string().trim().min(1).optional().nullable(),
-    date_livraison: z.string().trim().min(1).optional().nullable(),
-    transporteur: z.string().optional().nullable(),
-    tracking_number: z.string().optional().nullable(),
-    commentaire_interne: z.string().optional().nullable(),
-    commentaire_client: z.string().optional().nullable(),
-    reception_nom_signataire: z.string().optional().nullable(),
-    reception_date_signature: z.string().trim().min(1).optional().nullable(),
+    adresse_livraison_id: uuid.optional().nullable(),
+    date_creation: isoDate.optional(),
+    date_expedition: isoDate.optional().nullable(),
+    date_livraison: isoDate.optional().nullable(),
+    transporteur: nullableText(200),
+    tracking_number: nullableText(200),
+    commentaire_interne: nullableText(5000),
+    commentaire_client: nullableText(2000),
+    reception_nom_signataire: nullableText(200),
+    reception_date_signature: z.string().datetime({ offset: true }).optional().nullable(),
   })
-  .passthrough()
+  .strict()
 
 export type UpdateLivraisonBodyDTO = z.infer<typeof updateLivraisonBodySchema>
 
@@ -96,13 +103,13 @@ export const createLivraisonLineBodySchema = z
   .object({
     ordre: z.coerce.number().int().positive().optional(),
     designation: z.string().trim().min(1).max(10000),
-    code_piece: z.string().trim().min(1).max(200).optional().nullable(),
-    quantite: z.coerce.number().positive(),
-    unite: z.string().trim().min(1).max(30).optional().nullable(),
+    code_piece: nullableText(200),
+    quantite: z.coerce.number().positive().max(1_000_000_000),
+    unite: nullableText(30),
     commande_ligne_id: z.coerce.number().int().positive().optional().nullable(),
-    delai_client: z.string().trim().min(1).max(100).optional().nullable(),
+    delai_client: isoDate.optional().nullable(),
   })
-  .passthrough()
+  .strict()
 
 export type CreateLivraisonLineBodyDTO = z.infer<typeof createLivraisonLineBodySchema>
 
@@ -110,13 +117,13 @@ export const updateLivraisonLineBodySchema = z
   .object({
     ordre: z.coerce.number().int().positive().optional(),
     designation: z.string().trim().min(1).max(10000).optional(),
-    code_piece: z.string().trim().min(1).max(200).optional().nullable(),
-    quantite: z.coerce.number().positive().optional(),
-    unite: z.string().trim().min(1).max(30).optional().nullable(),
+    code_piece: nullableText(200),
+    quantite: z.coerce.number().positive().max(1_000_000_000).optional(),
+    unite: nullableText(30),
     commande_ligne_id: z.coerce.number().int().positive().optional().nullable(),
-    delai_client: z.string().trim().min(1).max(100).optional().nullable(),
+    delai_client: isoDate.optional().nullable(),
   })
-  .passthrough()
+  .strict()
 
 export type UpdateLivraisonLineBodyDTO = z.infer<typeof updateLivraisonLineBodySchema>
 
@@ -125,17 +132,41 @@ export const livraisonStatusBodySchema = z
     statut: bonLivraisonStatutSchema,
     commentaire: z.string().trim().min(1).max(5000).optional().nullable(),
   })
-  .passthrough()
+  .strict()
 
 export type LivraisonStatusBodyDTO = z.infer<typeof livraisonStatusBodySchema>
 
 export const createLivraisonAllocationBodySchema = z
   .object({
-    article_id: z.string().uuid(),
-    lot_id: z.string().uuid().optional().nullable(),
-    quantite: z.coerce.number().positive(),
-    unite: z.string().trim().min(1).max(30).optional().nullable(),
+    article_id: uuid,
+    magasin_id: uuid,
+    emplacement_id: z.coerce.number().int().positive(),
+    lot_id: uuid.optional().nullable(),
+    quantite: z.coerce.number().positive().max(1_000_000_000),
+    unite: nullableText(30),
   })
-  .passthrough()
+  .strict()
 
 export type CreateLivraisonAllocationBodyDTO = z.infer<typeof createLivraisonAllocationBodySchema>
+
+export const shipLivraisonBodySchema = z
+  .object({
+    expected_version: z.coerce.number().int().positive(),
+    preview_hash: z.string().regex(/^[A-Fa-f0-9]{64}$/),
+    commentaire: nullableText(2000),
+  })
+  .strict()
+
+export type ShipLivraisonBodyDTO = z.infer<typeof shipLivraisonBodySchema>
+
+export const livraisonProofBodySchema = z
+  .object({
+    proof_type: z.enum(["RECIPIENT_ACK", "CARRIER_DOCUMENT", "PHOTO", "EXTERNAL_SIGNATURE"]),
+    delivered_at: z.string().datetime({ offset: true }),
+    received_by_name: nullableText(200),
+    document_id: uuid.optional().nullable(),
+    note: nullableText(2000),
+  })
+  .strict()
+
+export type LivraisonProofBodyDTO = z.infer<typeof livraisonProofBodySchema>


### PR DESCRIPTION
## Release

Promotion de `dev` vers `main` du backend autoritaire Livraison #226.

- réservations READY et mouvements Stock OUT transactionnels ;
- idempotence, concurrence, RBAC, audit et outbox ;
- preuves append-only et documents contrôlés ;
- patch SQL additif avec préflight, vérification et rollback gardé ;
- frontière Finance explicite sans création automatique de facture.

## Validation

- PR d’intégration #122 fusionnée dans `dev` ;
- build TypeScript réussi ;
- 1 303 tests backend réussis.

L’application du patch à `cerp_prod` reste une étape contrôlée après merge.