### PR TITLE
feat(facturation): secure invoicing, credits and payments

### DIFF
--- a/db/patches/20260725_facturation_payments_227.sql
+++ b/db/patches/20260725_facturation_payments_227.sql
@@ -1,0 +1,598 @@
+-- Issue #227 - Invoicing, credit notes, due dates and payments.
+-- Additive/idempotent foundation only. It never issues an invoice, enables a
+-- Finance rule or changes legacy business data. Apply only after the matching
+-- read-only preflight and an approved backup.
+
+BEGIN;
+
+DO $$
+DECLARE
+  required_table text;
+BEGIN
+  FOREACH required_table IN ARRAY ARRAY[
+    'facture', 'facture_ligne', 'avoir', 'avoir_ligne', 'paiement',
+    'clients', 'users', 'documents_clients', 'bon_livraison_ligne', 'commande_ligne'
+  ]
+  LOOP
+    IF to_regclass(format('public.%I', required_table)) IS NULL THEN
+      RAISE EXCEPTION '#227 prerequisite missing: public.%', required_table;
+    END IF;
+  END LOOP;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'facture'
+      AND column_name = 'id' AND data_type = 'bigint'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'facture_ligne'
+      AND column_name = 'id' AND data_type = 'bigint'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'avoir'
+      AND column_name = 'id' AND data_type = 'bigint'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'paiement'
+      AND column_name = 'id' AND data_type = 'bigint'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'bon_livraison_ligne'
+      AND column_name = 'id' AND data_type = 'uuid'
+  ) THEN
+    RAISE EXCEPTION '#227 requires bigint facture/line/avoir/paiement ids and UUID bon_livraison_ligne ids';
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.finance_billing_policies (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  policy_version text NOT NULL UNIQUE,
+  legal_entity_code text NOT NULL,
+  eligible_delivery_statuses text[] NOT NULL DEFAULT ARRAY['SHIPPED','DELIVERED']::text[],
+  require_distinct_issuer boolean NOT NULL DEFAULT true,
+  active boolean NOT NULL DEFAULT false,
+  effective_from date NOT NULL DEFAULT CURRENT_DATE,
+  effective_to date NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT finance_billing_policies_dates_ck CHECK (effective_to IS NULL OR effective_to >= effective_from),
+  CONSTRAINT finance_billing_policies_statuses_ck CHECK (cardinality(eligible_delivery_statuses) > 0)
+);
+
+CREATE TABLE IF NOT EXISTS public.finance_legal_sequences (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_type text NOT NULL CHECK (document_type IN ('FACTURE','AVOIR')),
+  entity_code text NOT NULL,
+  period_key text NOT NULL CHECK (period_key ~ '^[0-9]{4}$'),
+  prefix text NOT NULL,
+  next_value bigint NOT NULL DEFAULT 1 CHECK (next_value > 0),
+  padding integer NOT NULL DEFAULT 6 CHECK (padding BETWEEN 1 AND 12),
+  active boolean NOT NULL DEFAULT false,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT finance_legal_sequences_scope_uq UNIQUE (document_type, entity_code, period_key)
+);
+
+ALTER TABLE public.facture
+  ADD COLUMN IF NOT EXISTS uuid uuid NULL,
+  ADD COLUMN IF NOT EXISTS draft_reference text NULL,
+  ADD COLUMN IF NOT EXISTS legal_number text NULL,
+  ADD COLUMN IF NOT EXISTS legal_period text NULL,
+  ADD COLUMN IF NOT EXISTS legal_sequence_value bigint NULL,
+  ADD COLUMN IF NOT EXISTS total_tax numeric(18,2) NULL,
+  ADD COLUMN IF NOT EXISTS currency text NOT NULL DEFAULT 'EUR',
+  ADD COLUMN IF NOT EXISTS customer_text text NULL,
+  ADD COLUMN IF NOT EXISTS preview_hash text NULL,
+  ADD COLUMN IF NOT EXISTS policy_version text NULL,
+  ADD COLUMN IF NOT EXISTS legal_entity_code text NULL,
+  ADD COLUMN IF NOT EXISTS client_snapshot jsonb NULL,
+  ADD COLUMN IF NOT EXISTS issuer_snapshot jsonb NULL,
+  ADD COLUMN IF NOT EXISTS immutable_snapshot jsonb NULL,
+  ADD COLUMN IF NOT EXISTS document_checksum_sha256 text NULL,
+  ADD COLUMN IF NOT EXISTS created_by integer NULL,
+  ADD COLUMN IF NOT EXISTS validation_requested_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS validation_requested_by integer NULL,
+  ADD COLUMN IF NOT EXISTS approved_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS approved_by integer NULL,
+  ADD COLUMN IF NOT EXISTS validation_reason text NULL,
+  ADD COLUMN IF NOT EXISTS issued_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS issued_by integer NULL,
+  ADD COLUMN IF NOT EXISTS issue_snapshot jsonb NULL,
+  ADD COLUMN IF NOT EXISTS issue_snapshot_sha256 text NULL,
+  ADD COLUMN IF NOT EXISTS due_date_locked_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS row_version integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NULL;
+
+ALTER TABLE public.avoir
+  ADD COLUMN IF NOT EXISTS uuid uuid NULL,
+  ADD COLUMN IF NOT EXISTS draft_reference text NULL,
+  ADD COLUMN IF NOT EXISTS legal_number text NULL,
+  ADD COLUMN IF NOT EXISTS legal_period text NULL,
+  ADD COLUMN IF NOT EXISTS legal_sequence_value bigint NULL,
+  ADD COLUMN IF NOT EXISTS total_tax numeric(18,2) NULL,
+  ADD COLUMN IF NOT EXISTS currency text NOT NULL DEFAULT 'EUR',
+  ADD COLUMN IF NOT EXISTS reason_code text NULL,
+  ADD COLUMN IF NOT EXISTS preview_hash text NULL,
+  ADD COLUMN IF NOT EXISTS client_snapshot jsonb NULL,
+  ADD COLUMN IF NOT EXISTS issuer_snapshot jsonb NULL,
+  ADD COLUMN IF NOT EXISTS immutable_snapshot jsonb NULL,
+  ADD COLUMN IF NOT EXISTS document_checksum_sha256 text NULL,
+  ADD COLUMN IF NOT EXISTS legal_entity_code text NULL,
+  ADD COLUMN IF NOT EXISTS created_by integer NULL,
+  ADD COLUMN IF NOT EXISTS validation_requested_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS validation_requested_by integer NULL,
+  ADD COLUMN IF NOT EXISTS approved_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS approved_by integer NULL,
+  ADD COLUMN IF NOT EXISTS validation_reason text NULL,
+  ADD COLUMN IF NOT EXISTS issued_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS issued_by integer NULL,
+  ADD COLUMN IF NOT EXISTS issue_snapshot jsonb NULL,
+  ADD COLUMN IF NOT EXISTS issue_snapshot_sha256 text NULL,
+  ADD COLUMN IF NOT EXISTS row_version integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NULL;
+
+ALTER TABLE public.facture_ligne
+  ADD COLUMN IF NOT EXISTS tax_amount numeric(18,2) NULL,
+  ADD COLUMN IF NOT EXISTS snapshot_json jsonb NULL;
+
+ALTER TABLE public.avoir_ligne
+  ADD COLUMN IF NOT EXISTS tax_amount numeric(18,2) NULL,
+  ADD COLUMN IF NOT EXISTS snapshot_json jsonb NULL;
+
+ALTER TABLE public.paiement
+  ADD COLUMN IF NOT EXISTS uuid uuid NULL,
+  ADD COLUMN IF NOT EXISTS code text NULL,
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'UNALLOCATED',
+  ADD COLUMN IF NOT EXISTS currency text NOT NULL DEFAULT 'EUR',
+  ADD COLUMN IF NOT EXISTS value_date date NULL,
+  ADD COLUMN IF NOT EXISTS booking_date date NULL,
+  ADD COLUMN IF NOT EXISTS row_version integer NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS proof_document_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS created_by integer NULL,
+  ADD COLUMN IF NOT EXISTS workflow_status text NOT NULL DEFAULT 'RECORDED',
+  ADD COLUMN IF NOT EXISTS received_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS received_by integer NULL,
+  ADD COLUMN IF NOT EXISTS reversal_of_id bigint NULL,
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS idempotency_key text NULL,
+  ADD COLUMN IF NOT EXISTS request_hash text NULL;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'paiement'
+      AND column_name = 'facture_id'
+      AND is_nullable = 'NO'
+  ) THEN
+    ALTER TABLE public.paiement ALTER COLUMN facture_id DROP NOT NULL;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'paiement_created_by_227_fkey' AND conrelid = 'public.paiement'::regclass) THEN
+    ALTER TABLE public.paiement ADD CONSTRAINT paiement_created_by_227_fkey
+      FOREIGN KEY (created_by) REFERENCES public.users(id) ON DELETE RESTRICT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'paiement_proof_document_227_fkey' AND conrelid = 'public.paiement'::regclass) THEN
+    ALTER TABLE public.paiement ADD CONSTRAINT paiement_proof_document_227_fkey
+      FOREIGN KEY (proof_document_id) REFERENCES public.documents_clients(id) ON DELETE RESTRICT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'facture_issued_by_227_fkey' AND conrelid = 'public.facture'::regclass) THEN
+    ALTER TABLE public.facture ADD CONSTRAINT facture_issued_by_227_fkey
+      FOREIGN KEY (issued_by) REFERENCES public.users(id) ON DELETE RESTRICT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'avoir_issued_by_227_fkey' AND conrelid = 'public.avoir'::regclass) THEN
+    ALTER TABLE public.avoir ADD CONSTRAINT avoir_issued_by_227_fkey
+      FOREIGN KEY (issued_by) REFERENCES public.users(id) ON DELETE RESTRICT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'paiement_received_by_227_fkey' AND conrelid = 'public.paiement'::regclass) THEN
+    ALTER TABLE public.paiement ADD CONSTRAINT paiement_received_by_227_fkey
+      FOREIGN KEY (received_by) REFERENCES public.users(id) ON DELETE RESTRICT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'paiement_reversal_227_fkey' AND conrelid = 'public.paiement'::regclass) THEN
+    ALTER TABLE public.paiement ADD CONSTRAINT paiement_reversal_227_fkey
+      FOREIGN KEY (reversal_of_id) REFERENCES public.paiement(id) ON DELETE RESTRICT;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'paiement_workflow_status_227_ck' AND conrelid = 'public.paiement'::regclass) THEN
+    ALTER TABLE public.paiement ADD CONSTRAINT paiement_workflow_status_227_ck
+      CHECK (workflow_status IN ('RECORDED', 'ALLOCATED', 'REVERSED')) NOT VALID;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'paiement_status_227_ck' AND conrelid = 'public.paiement'::regclass) THEN
+    ALTER TABLE public.paiement ADD CONSTRAINT paiement_status_227_ck
+      CHECK (status IN ('UNALLOCATED','PARTIALLY_ALLOCATED','ALLOCATED','REJECTED','REVERSED')) NOT VALID;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'facture_issue_snapshot_227_ck' AND conrelid = 'public.facture'::regclass) THEN
+    ALTER TABLE public.facture ADD CONSTRAINT facture_issue_snapshot_227_ck CHECK (
+      statut <> 'ISSUED' OR (
+        legal_number IS NOT NULL AND issued_at IS NOT NULL AND issued_by IS NOT NULL
+        AND immutable_snapshot IS NOT NULL AND document_checksum_sha256 ~ '^[A-Fa-f0-9]{64}$'
+      )
+    ) NOT VALID;
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'avoir_issue_snapshot_227_ck' AND conrelid = 'public.avoir'::regclass) THEN
+    ALTER TABLE public.avoir ADD CONSTRAINT avoir_issue_snapshot_227_ck CHECK (
+      statut <> 'ISSUED' OR (
+        legal_number IS NOT NULL AND issued_at IS NOT NULL AND issued_by IS NOT NULL
+        AND immutable_snapshot IS NOT NULL AND document_checksum_sha256 ~ '^[A-Fa-f0-9]{64}$'
+      )
+    ) NOT VALID;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS facture_legal_number_227_uq
+  ON public.facture(legal_number) WHERE legal_number IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS avoir_legal_number_227_uq
+  ON public.avoir(legal_number) WHERE legal_number IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS paiement_reversal_once_227_uq
+  ON public.paiement(reversal_of_id) WHERE reversal_of_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS paiement_idempotency_227_uq
+  ON public.paiement(client_id, idempotency_key) WHERE idempotency_key IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS facture_uuid_227_uq ON public.facture(uuid) WHERE uuid IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS facture_draft_reference_227_uq ON public.facture(draft_reference) WHERE draft_reference IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS avoir_uuid_227_uq ON public.avoir(uuid) WHERE uuid IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS avoir_draft_reference_227_uq ON public.avoir(draft_reference) WHERE draft_reference IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS paiement_uuid_227_uq ON public.paiement(uuid) WHERE uuid IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS paiement_code_227_uq ON public.paiement(code) WHERE code IS NOT NULL;
+CREATE INDEX IF NOT EXISTS facture_workflow_227_idx ON public.facture(statut, issued_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.facture_echeance (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  facture_id bigint NOT NULL REFERENCES public.facture(id) ON DELETE RESTRICT,
+  avoir_line_id bigint NULL REFERENCES public.avoir_ligne(id) ON DELETE RESTRICT,
+  due_date date NOT NULL,
+  label text NOT NULL,
+  amount_due numeric(18,2) NOT NULL CHECK (amount_due > 0),
+  amount_allocated numeric(18,2) NOT NULL DEFAULT 0 CHECK (amount_allocated >= 0),
+  status text NOT NULL DEFAULT 'OPEN' CHECK (status IN ('OPEN', 'PARTIALLY_PAID', 'PAID', 'OVERDUE', 'CANCELLED')),
+  locked_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid()
+);
+CREATE INDEX IF NOT EXISTS facture_echeance_open_227_idx
+  ON public.facture_echeance(due_date, facture_id) WHERE status IN ('OPEN','PARTIALLY_PAID','OVERDUE');
+
+CREATE TABLE IF NOT EXISTS public.facture_source_allocations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  facture_id bigint NOT NULL REFERENCES public.facture(id) ON DELETE RESTRICT,
+  facture_ligne_id bigint NOT NULL REFERENCES public.facture_ligne(id) ON DELETE RESTRICT,
+  source_type text NOT NULL CHECK (source_type IN ('DELIVERY_LINE','MILESTONE','DEPOSIT')),
+  source_id text NOT NULL,
+  source_line_id text NOT NULL,
+  quantity_selected numeric(18,3) NOT NULL CHECK (quantity_selected > 0),
+  quantity_consumed numeric(18,3) NOT NULL DEFAULT 0 CHECK (quantity_consumed >= 0),
+  amount_ex_tax numeric(18,2) NOT NULL DEFAULT 0,
+  amount_incl_tax numeric(18,2) NOT NULL DEFAULT 0,
+  allocation_status text NOT NULL DEFAULT 'DRAFT' CHECK (allocation_status IN ('DRAFT','CONSUMED','REVERSED')),
+  source_snapshot jsonb NOT NULL,
+  rule_code text NOT NULL,
+  consumed_at timestamptz NULL,
+  consumed_by integer NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT facture_source_allocations_227_uq UNIQUE (facture_ligne_id, source_type, source_line_id),
+  CONSTRAINT facture_source_snapshot_227_ck CHECK (jsonb_typeof(source_snapshot) = 'object')
+);
+CREATE INDEX IF NOT EXISTS facture_source_delivery_line_227_idx
+  ON public.facture_source_allocations(source_type, source_line_id, allocation_status);
+CREATE INDEX IF NOT EXISTS facture_source_facture_227_idx
+  ON public.facture_source_allocations(facture_id, facture_ligne_id);
+
+CREATE TABLE IF NOT EXISTS public.paiement_allocations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  paiement_id bigint NOT NULL REFERENCES public.paiement(id) ON DELETE RESTRICT,
+  facture_id bigint NOT NULL REFERENCES public.facture(id) ON DELETE RESTRICT,
+  facture_due_date_id uuid NULL REFERENCES public.facture_echeance(id) ON DELETE RESTRICT,
+  amount_ttc numeric(18,2) NOT NULL CHECK (amount_ttc > 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  CONSTRAINT paiement_allocation_227_uq UNIQUE (paiement_id, facture_id, facture_due_date_id)
+);
+CREATE INDEX IF NOT EXISTS paiement_allocations_facture_227_idx
+  ON public.paiement_allocations(facture_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.avoir_source_allocations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  avoir_id bigint NOT NULL REFERENCES public.avoir(id) ON DELETE RESTRICT,
+  avoir_line_id bigint NULL REFERENCES public.avoir_ligne(id) ON DELETE RESTRICT,
+  facture_id bigint NOT NULL REFERENCES public.facture(id) ON DELETE RESTRICT,
+  facture_ligne_id bigint NULL REFERENCES public.facture_ligne(id) ON DELETE RESTRICT,
+  source_type text NOT NULL DEFAULT 'INVOICE_LINE',
+  source_id text NOT NULL DEFAULT '',
+  source_line_id text NOT NULL DEFAULT '',
+  quantity_selected numeric(18,3) NOT NULL DEFAULT 0 CHECK (quantity_selected >= 0),
+  quantity_credited numeric(18,3) NOT NULL DEFAULT 0 CHECK (quantity_credited >= 0),
+  amount_ttc numeric(18,2) NOT NULL DEFAULT 0 CHECK (amount_ttc >= 0),
+  allocation_status text NOT NULL DEFAULT 'DRAFT' CHECK (allocation_status IN ('DRAFT','CONSUMED','REVERSED')),
+  consumed_at timestamptz NULL,
+  consumed_by integer NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  CONSTRAINT avoir_source_allocations_227_uq UNIQUE (avoir_id, source_type, source_line_id)
+);
+CREATE INDEX IF NOT EXISTS avoir_allocations_facture_227_idx
+  ON public.avoir_source_allocations(facture_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.finance_command_receipts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  command_type text NOT NULL,
+  aggregate_type text NOT NULL CHECK (aggregate_type IN ('FACTURE','AVOIR','PAIEMENT')),
+  aggregate_id text NOT NULL,
+  request_payload jsonb NOT NULL,
+  result_payload jsonb NOT NULL,
+  correlation_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT finance_command_receipts_actor_key_227_uq UNIQUE (actor_user_id, idempotency_key),
+  CONSTRAINT facturation_command_receipts_key_227_ck CHECK (char_length(idempotency_key) BETWEEN 8 AND 200),
+  CONSTRAINT facturation_command_receipts_hash_227_ck CHECK (request_hash ~ '^[A-Fa-f0-9]{64}$'),
+  CONSTRAINT facturation_command_receipts_type_227_ck CHECK (char_length(command_type) BETWEEN 3 AND 120)
+);
+CREATE INDEX IF NOT EXISTS finance_command_receipts_resource_227_idx
+  ON public.finance_command_receipts(aggregate_type, aggregate_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.finance_event_log (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  aggregate_type text NOT NULL CHECK (aggregate_type IN ('FACTURE', 'AVOIR', 'PAIEMENT')),
+  aggregate_id text NOT NULL,
+  event_type text NOT NULL CHECK (char_length(event_type) BETWEEN 3 AND 120),
+  old_values jsonb NULL,
+  new_values jsonb NULL,
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL,
+  idempotency_key text NULL,
+  rule_code text NULL,
+  reason text NULL,
+  request_id text NULL,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX IF NOT EXISTS finance_event_log_aggregate_227_idx
+  ON public.finance_event_log(aggregate_type, aggregate_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.finance_document_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  aggregate_type text NOT NULL CHECK (aggregate_type IN ('FACTURE','AVOIR')),
+  aggregate_id text NOT NULL,
+  document_id uuid NOT NULL REFERENCES public.documents_clients(id) ON DELETE RESTRICT,
+  version integer NOT NULL CHECK (version > 0),
+  status text NOT NULL CHECK (status IN ('ISSUED','SUPERSEDED')),
+  checksum_sha256 text NOT NULL CHECK (checksum_sha256 ~ '^[A-Fa-f0-9]{64}$'),
+  file_size_bytes bigint NOT NULL CHECK (file_size_bytes > 0),
+  mime_type text NOT NULL,
+  snapshot_json jsonb NOT NULL CHECK (jsonb_typeof(snapshot_json) = 'object'),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  CONSTRAINT finance_document_versions_document_227_uq UNIQUE (document_id),
+  CONSTRAINT finance_document_versions_aggregate_227_uq UNIQUE (aggregate_type, aggregate_id, version)
+);
+
+CREATE OR REPLACE FUNCTION public.fn_protect_facturation_immutable_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.statut IN (
+      'ISSUED', 'PARTIALLY_PAID', 'PAID', 'CANCELLED',
+      'emise', 'envoyee', 'partielle', 'payee', 'annulee', 'emis', 'annule'
+    ) THEN
+      RAISE EXCEPTION 'issued or cancelled finance evidence cannot be deleted' USING ERRCODE = '55000';
+    END IF;
+    RETURN OLD;
+  END IF;
+  IF OLD.statut IN (
+    'ISSUED', 'PARTIALLY_PAID', 'PAID', 'CANCELLED',
+    'emise', 'envoyee', 'partielle', 'payee', 'annulee', 'emis', 'annule'
+  ) THEN
+    RAISE EXCEPTION 'issued or cancelled finance evidence is immutable' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.statut = 'DRAFT' AND NEW.statut = 'CANCELLED' THEN
+    RAISE EXCEPTION 'draft finance evidence must not be cancelled as legal evidence' USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_protect_facturation_child_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  parent_status text;
+BEGIN
+  IF TG_TABLE_NAME IN ('facture_ligne', 'facture_source_allocations', 'facture_echeance') THEN
+    IF TG_OP = 'DELETE' THEN
+      SELECT statut INTO parent_status FROM public.facture WHERE id = OLD.facture_id;
+    ELSE
+      SELECT statut INTO parent_status FROM public.facture WHERE id = NEW.facture_id;
+    END IF;
+  ELSIF TG_TABLE_NAME = 'avoir_ligne' THEN
+    IF TG_OP = 'DELETE' THEN
+      SELECT statut INTO parent_status FROM public.avoir WHERE id = OLD.avoir_id;
+    ELSE
+      SELECT statut INTO parent_status FROM public.avoir WHERE id = NEW.avoir_id;
+    END IF;
+  ELSIF TG_TABLE_NAME = 'avoir_source_allocations' THEN
+    IF TG_OP = 'DELETE' THEN
+      SELECT statut INTO parent_status FROM public.avoir WHERE id = OLD.avoir_id;
+    ELSE
+      SELECT statut INTO parent_status FROM public.avoir WHERE id = NEW.avoir_id;
+    END IF;
+  END IF;
+  IF TG_TABLE_NAME = 'facture_echeance'
+     AND TG_OP = 'UPDATE'
+     AND parent_status IN ('ISSUED', 'PARTIALLY_PAID', 'PAID')
+     AND NEW.facture_id = OLD.facture_id
+     AND NEW.due_date = OLD.due_date
+     AND NEW.label = OLD.label
+     AND NEW.amount_due = OLD.amount_due
+     AND NEW.created_by = OLD.created_by
+     AND NEW.amount_allocated >= OLD.amount_allocated THEN
+    RETURN NEW;
+  END IF;
+  IF parent_status IN (
+    'ISSUED', 'PARTIALLY_PAID', 'PAID', 'CANCELLED',
+    'emise', 'envoyee', 'partielle', 'payee', 'annulee', 'emis', 'annule'
+  ) THEN
+    RAISE EXCEPTION 'children of issued or cancelled finance evidence are immutable' USING ERRCODE = '55000';
+  END IF;
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_validate_facturation_allocation_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  payment_amount numeric(18,2);
+  allocated_amount numeric(18,2);
+  invoice_amount numeric(18,2);
+  invoice_allocated numeric(18,2);
+  credit_amount numeric(18,2);
+  credit_allocated numeric(18,2);
+  delivery_qty numeric(18,3);
+  sourced_qty numeric(18,3);
+  source_client text;
+  target_client text;
+BEGIN
+  IF TG_TABLE_NAME = 'paiement_allocations' THEN
+    SELECT montant::numeric(18,2) INTO payment_amount FROM public.paiement WHERE id = NEW.paiement_id FOR UPDATE;
+    SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2) INTO allocated_amount
+    FROM public.paiement_allocations WHERE paiement_id = NEW.paiement_id;
+    IF payment_amount IS NULL OR allocated_amount + NEW.amount_ttc > payment_amount THEN
+      RAISE EXCEPTION 'payment allocations exceed recorded payment' USING ERRCODE = '23514';
+    END IF;
+    SELECT total_ttc::numeric(18,2) INTO invoice_amount FROM public.facture WHERE id = NEW.facture_id FOR UPDATE;
+    SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2) INTO invoice_allocated
+    FROM public.paiement_allocations WHERE facture_id = NEW.facture_id;
+    SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2) INTO credit_allocated
+    FROM public.avoir_source_allocations WHERE facture_id = NEW.facture_id;
+    IF invoice_amount IS NULL OR invoice_allocated + credit_allocated + NEW.amount_ttc > invoice_amount THEN
+      RAISE EXCEPTION 'payment and credit allocations exceed invoice total' USING ERRCODE = '23514';
+    END IF;
+  ELSIF TG_TABLE_NAME = 'avoir_source_allocations' THEN
+    SELECT a.total_ttc::numeric(18,2), a.client_id, f.client_id
+    INTO credit_amount, source_client, target_client
+    FROM public.avoir a JOIN public.facture f ON f.id = NEW.facture_id
+    WHERE a.id = NEW.avoir_id FOR UPDATE;
+    SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2) INTO credit_allocated
+    FROM public.avoir_source_allocations WHERE avoir_id = NEW.avoir_id;
+    IF source_client IS DISTINCT FROM target_client OR credit_amount IS NULL OR credit_allocated + NEW.amount_ttc > credit_amount THEN
+      RAISE EXCEPTION 'credit allocation has a client mismatch or exceeds the credit note' USING ERRCODE = '23514';
+    END IF;
+    SELECT total_ttc::numeric(18,2) INTO invoice_amount FROM public.facture WHERE id = NEW.facture_id FOR UPDATE;
+    SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2) INTO invoice_allocated
+    FROM public.paiement_allocations WHERE facture_id = NEW.facture_id;
+    IF invoice_amount IS NULL OR invoice_allocated + credit_allocated + NEW.amount_ttc > invoice_amount THEN
+      RAISE EXCEPTION 'payment and credit allocations exceed invoice total' USING ERRCODE = '23514';
+    END IF;
+  ELSIF TG_TABLE_NAME = 'facture_source_allocations' THEN
+    SELECT bll.quantite::numeric(18,3), bl.client_id, f.client_id
+    INTO delivery_qty, source_client, target_client
+    FROM public.bon_livraison_ligne bll
+    JOIN public.bon_livraison bl ON bl.id = bll.bon_livraison_id
+    JOIN public.facture f ON f.id = NEW.facture_id
+    WHERE NEW.source_type = 'DELIVERY_LINE' AND bll.id::text = NEW.source_line_id
+    FOR UPDATE OF bll, bl, f;
+    SELECT COALESCE(SUM(quantity_selected), 0)::numeric(18,3) INTO sourced_qty
+    FROM public.facture_source_allocations
+    WHERE source_type = 'DELIVERY_LINE' AND source_line_id = NEW.source_line_id
+      AND allocation_status IN ('DRAFT','CONSUMED');
+    IF delivery_qty IS NULL OR source_client IS DISTINCT FROM target_client OR sourced_qty + NEW.quantity_selected > delivery_qty THEN
+      RAISE EXCEPTION 'invoice source allocations have a client mismatch or exceed delivered quantity' USING ERRCODE = '23514';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_protect_facturation_evidence_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'facturation audit evidence is immutable' USING ERRCODE = '55000';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_protect_paiement_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.uuid IS NULL THEN
+    RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+  END IF;
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'recorded payment evidence cannot be deleted' USING ERRCODE = '55000';
+  END IF;
+  IF NEW.uuid IS DISTINCT FROM OLD.uuid
+     OR NEW.code IS DISTINCT FROM OLD.code
+     OR NEW.client_id IS DISTINCT FROM OLD.client_id
+     OR NEW.facture_id IS DISTINCT FROM OLD.facture_id
+     OR NEW.montant IS DISTINCT FROM OLD.montant
+     OR NEW.currency IS DISTINCT FROM OLD.currency
+     OR NEW.date_paiement IS DISTINCT FROM OLD.date_paiement
+     OR NEW.value_date IS DISTINCT FROM OLD.value_date
+     OR NEW.booking_date IS DISTINCT FROM OLD.booking_date
+     OR NEW.mode IS DISTINCT FROM OLD.mode
+     OR NEW.reference IS DISTINCT FROM OLD.reference
+     OR NEW.commentaire IS DISTINCT FROM OLD.commentaire
+     OR NEW.proof_document_id IS DISTINCT FROM OLD.proof_document_id
+     OR NEW.created_by IS DISTINCT FROM OLD.created_by THEN
+    RAISE EXCEPTION 'recorded payment identity and amount are immutable' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_facture_immutable_227 ON public.facture;
+CREATE TRIGGER trg_protect_facture_immutable_227 BEFORE UPDATE OR DELETE ON public.facture
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_immutable_227();
+DROP TRIGGER IF EXISTS trg_protect_avoir_immutable_227 ON public.avoir;
+CREATE TRIGGER trg_protect_avoir_immutable_227 BEFORE UPDATE OR DELETE ON public.avoir
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_immutable_227();
+
+DROP TRIGGER IF EXISTS trg_protect_facture_ligne_227 ON public.facture_ligne;
+CREATE TRIGGER trg_protect_facture_ligne_227 BEFORE INSERT OR UPDATE OR DELETE ON public.facture_ligne
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+DROP TRIGGER IF EXISTS trg_protect_avoir_ligne_227 ON public.avoir_ligne;
+CREATE TRIGGER trg_protect_avoir_ligne_227 BEFORE INSERT OR UPDATE OR DELETE ON public.avoir_ligne
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+DROP TRIGGER IF EXISTS trg_protect_facture_source_227 ON public.facture_source_allocations;
+CREATE TRIGGER trg_protect_facture_source_227 BEFORE INSERT OR UPDATE OR DELETE ON public.facture_source_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+DROP TRIGGER IF EXISTS trg_protect_facture_echeance_227 ON public.facture_echeance;
+CREATE TRIGGER trg_protect_facture_echeance_227 BEFORE INSERT OR UPDATE OR DELETE ON public.facture_echeance
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+DROP TRIGGER IF EXISTS trg_protect_avoir_source_227 ON public.avoir_source_allocations;
+CREATE TRIGGER trg_protect_avoir_source_227 BEFORE INSERT OR UPDATE OR DELETE ON public.avoir_source_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+
+DROP TRIGGER IF EXISTS trg_validate_facture_source_allocation_227 ON public.facture_source_allocations;
+CREATE TRIGGER trg_validate_facture_source_allocation_227 BEFORE INSERT ON public.facture_source_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_validate_facturation_allocation_227();
+DROP TRIGGER IF EXISTS trg_validate_paiement_allocation_227 ON public.paiement_allocations;
+CREATE TRIGGER trg_validate_paiement_allocation_227 BEFORE INSERT ON public.paiement_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_validate_facturation_allocation_227();
+DROP TRIGGER IF EXISTS trg_validate_avoir_allocation_227 ON public.avoir_source_allocations;
+CREATE TRIGGER trg_validate_avoir_allocation_227 BEFORE INSERT ON public.avoir_source_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_validate_facturation_allocation_227();
+DROP TRIGGER IF EXISTS trg_protect_paiement_227 ON public.paiement;
+CREATE TRIGGER trg_protect_paiement_227 BEFORE UPDATE OR DELETE ON public.paiement
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_paiement_227();
+
+DO $$
+DECLARE t text;
+BEGIN
+  FOREACH t IN ARRAY ARRAY[
+    'finance_command_receipts', 'finance_event_log', 'finance_document_versions'
+  ] LOOP
+    EXECUTE format('DROP TRIGGER IF EXISTS %I ON public.%I', 'trg_protect_' || t, t);
+    EXECUTE format('CREATE TRIGGER %I BEFORE UPDATE OR DELETE ON public.%I FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_evidence_227()', 'trg_protect_' || t, t);
+  END LOOP;
+END $$;
+
+COMMENT ON TABLE public.finance_billing_policies IS
+  'Issue #227 Finance policies. No active row is inserted by this patch.';
+COMMENT ON TABLE public.facture_source_allocations IS
+  'Invoice-source allocations. Selected quantities are locked transactionally and consumed only by explicit issue.';
+
+COMMIT;

--- a/db/patches/support/20260725_facturation_payments_227.preflight.sql
+++ b/db/patches/support/20260725_facturation_payments_227.preflight.sql
@@ -1,0 +1,64 @@
+\set ON_ERROR_STOP on
+
+-- Read-only preflight for issue #227. It intentionally does not enable Finance.
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#227 preflight is restricted to cerp_test';
+  END IF;
+END $$;
+
+SELECT current_database() AS database_name, current_user AS database_user, now() AS checked_at;
+
+SELECT prerequisite, present
+FROM (
+  VALUES
+    ('facture', to_regclass('public.facture') IS NOT NULL),
+    ('facture_ligne', to_regclass('public.facture_ligne') IS NOT NULL),
+    ('avoir', to_regclass('public.avoir') IS NOT NULL),
+    ('avoir_ligne', to_regclass('public.avoir_ligne') IS NOT NULL),
+    ('paiement', to_regclass('public.paiement') IS NOT NULL),
+    ('clients', to_regclass('public.clients') IS NOT NULL),
+    ('users', to_regclass('public.users') IS NOT NULL),
+    ('documents_clients', to_regclass('public.documents_clients') IS NOT NULL),
+    ('bon_livraison_ligne', to_regclass('public.bon_livraison_ligne') IS NOT NULL),
+    ('commande_ligne', to_regclass('public.commande_ligne') IS NOT NULL),
+    ('gen_random_uuid', to_regprocedure('gen_random_uuid()') IS NOT NULL)
+) AS checks(prerequisite, present)
+ORDER BY prerequisite;
+
+SELECT table_name, column_name, data_type, udt_name
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND (
+    (table_name IN ('facture', 'facture_ligne', 'avoir', 'avoir_ligne', 'paiement') AND column_name = 'id')
+    OR (table_name = 'bon_livraison_ligne' AND column_name = 'id')
+    OR (table_name = 'facture' AND column_name IN ('client_id', 'total_ttc', 'statut', 'numero'))
+    OR (table_name = 'avoir' AND column_name IN ('client_id', 'total_ttc', 'facture_id', 'statut', 'numero'))
+    OR (table_name = 'paiement' AND column_name IN ('facture_id', 'client_id', 'montant'))
+  )
+ORDER BY table_name, ordinal_position;
+
+SELECT
+  to_regclass('public.facture_id_seq') IS NOT NULL AS facture_sequence_present,
+  to_regclass('public.avoir_id_seq') IS NOT NULL AS avoir_sequence_present,
+  to_regclass('public.paiement_id_seq') IS NOT NULL AS paiement_sequence_present,
+  to_regclass('public.finance_legal_sequences') IS NOT NULL AS issue_227_already_present;
+
+SELECT statut, count(*) AS rows_count FROM public.facture GROUP BY statut ORDER BY statut;
+SELECT statut, count(*) AS rows_count FROM public.avoir GROUP BY statut ORDER BY statut;
+
+SELECT
+  count(*) FILTER (WHERE total_ttc IS NULL OR total_ttc < 0) AS invalid_facture_totals,
+  count(*) FILTER (WHERE client_id IS NULL OR btrim(client_id) = '') AS invalid_facture_clients
+FROM public.facture;
+
+SELECT
+  count(*) FILTER (WHERE montant IS NULL OR montant < 0) AS invalid_payment_amounts,
+  count(*) FILTER (WHERE facture_id IS NULL) AS payments_without_invoice
+FROM public.paiement;
+
+SELECT
+  count(*) FILTER (WHERE a.facture_id IS NOT NULL AND a.client_id IS DISTINCT FROM f.client_id) AS credit_invoice_client_mismatches
+FROM public.avoir a
+LEFT JOIN public.facture f ON f.id = a.facture_id;

--- a/db/patches/support/20260725_facturation_payments_227.rollback.sql
+++ b/db/patches/support/20260725_facturation_payments_227.rollback.sql
@@ -1,0 +1,53 @@
+\set ON_ERROR_STOP on
+
+-- Guarded rollback for new #227 tables/triggers on an empty installation only.
+-- Additive columns are intentionally preserved because IF NOT EXISTS cannot
+-- prove they were introduced by this patch. Never run automatically.
+BEGIN;
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#227 rollback is restricted to cerp_test';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.facture_source_allocations)
+     OR EXISTS (SELECT 1 FROM public.avoir_source_allocations)
+     OR EXISTS (SELECT 1 FROM public.facture_echeance)
+     OR EXISTS (SELECT 1 FROM public.paiement_allocations)
+     OR EXISTS (SELECT 1 FROM public.finance_command_receipts)
+     OR EXISTS (SELECT 1 FROM public.finance_event_log)
+     OR EXISTS (SELECT 1 FROM public.finance_document_versions)
+     OR EXISTS (SELECT 1 FROM public.facture WHERE statut = 'ISSUED' OR legal_number IS NOT NULL)
+  THEN
+    RAISE EXCEPTION '#227 rollback refused: Finance evidence exists';
+  END IF;
+END $$;
+
+DROP TRIGGER IF EXISTS trg_protect_facture_immutable_227 ON public.facture;
+DROP TRIGGER IF EXISTS trg_protect_avoir_immutable_227 ON public.avoir;
+DROP TRIGGER IF EXISTS trg_protect_facture_ligne_227 ON public.facture_ligne;
+DROP TRIGGER IF EXISTS trg_protect_avoir_ligne_227 ON public.avoir_ligne;
+DROP TRIGGER IF EXISTS trg_protect_facture_source_227 ON public.facture_source_allocations;
+DROP TRIGGER IF EXISTS trg_protect_facture_echeance_227 ON public.facture_echeance;
+DROP TRIGGER IF EXISTS trg_protect_avoir_source_227 ON public.avoir_source_allocations;
+DROP TRIGGER IF EXISTS trg_protect_paiement_227 ON public.paiement;
+DROP TRIGGER IF EXISTS trg_validate_facture_source_allocation_227 ON public.facture_source_allocations;
+DROP TRIGGER IF EXISTS trg_validate_paiement_allocation_227 ON public.paiement_allocations;
+DROP TRIGGER IF EXISTS trg_validate_avoir_allocation_227 ON public.avoir_source_allocations;
+DROP TRIGGER IF EXISTS trg_protect_finance_command_receipts ON public.finance_command_receipts;
+DROP TRIGGER IF EXISTS trg_protect_finance_event_log ON public.finance_event_log;
+DROP TRIGGER IF EXISTS trg_protect_finance_document_versions ON public.finance_document_versions;
+DROP TABLE IF EXISTS public.finance_document_versions;
+DROP TABLE IF EXISTS public.finance_event_log;
+DROP TABLE IF EXISTS public.finance_command_receipts;
+DROP TABLE IF EXISTS public.paiement_allocations;
+DROP TABLE IF EXISTS public.avoir_source_allocations;
+DROP TABLE IF EXISTS public.facture_source_allocations;
+DROP TABLE IF EXISTS public.facture_echeance;
+DROP TABLE IF EXISTS public.finance_legal_sequences;
+DROP TABLE IF EXISTS public.finance_billing_policies;
+DROP FUNCTION IF EXISTS public.fn_protect_facturation_evidence_227();
+DROP FUNCTION IF EXISTS public.fn_protect_paiement_227();
+DROP FUNCTION IF EXISTS public.fn_validate_facturation_allocation_227();
+DROP FUNCTION IF EXISTS public.fn_protect_facturation_child_227();
+DROP FUNCTION IF EXISTS public.fn_protect_facturation_immutable_227();
+COMMIT;

--- a/db/patches/support/20260725_facturation_payments_227.verify.sql
+++ b/db/patches/support/20260725_facturation_payments_227.verify.sql
@@ -1,0 +1,60 @@
+\set ON_ERROR_STOP on
+
+-- Read-only verification for issue #227.
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#227 verification is restricted to cerp_test';
+  END IF;
+  IF to_regclass('public.finance_billing_policies') IS NULL
+     OR to_regclass('public.finance_legal_sequences') IS NULL
+     OR to_regclass('public.facture_source_allocations') IS NULL
+     OR to_regclass('public.avoir_source_allocations') IS NULL
+     OR to_regclass('public.facture_echeance') IS NULL
+     OR to_regclass('public.paiement_allocations') IS NULL
+     OR to_regclass('public.finance_command_receipts') IS NULL
+     OR to_regclass('public.finance_event_log') IS NULL
+     OR to_regclass('public.finance_document_versions') IS NULL THEN
+    RAISE EXCEPTION '#227 finance workflow objects are missing';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_protect_facture_immutable_227' AND tgrelid = 'public.facture'::regclass AND NOT tgisinternal)
+     OR NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_protect_avoir_immutable_227' AND tgrelid = 'public.avoir'::regclass AND NOT tgisinternal) THEN
+    RAISE EXCEPTION '#227 issued-document immutability triggers are missing';
+  END IF;
+END $$;
+
+SELECT count(*) FILTER (WHERE active) AS active_policy_count
+FROM public.finance_billing_policies;
+
+SELECT
+  count(*) FILTER (WHERE statut = 'ISSUED' AND (legal_number IS NULL OR immutable_snapshot IS NULL OR document_checksum_sha256 IS NULL)) AS issued_factures_without_snapshot,
+  count(*) FILTER (WHERE statut = 'ISSUED' AND issued_at IS NULL) AS issued_factures_without_timestamp
+FROM public.facture;
+
+SELECT
+  count(*) FILTER (WHERE statut = 'ISSUED' AND (legal_number IS NULL OR immutable_snapshot IS NULL OR document_checksum_sha256 IS NULL)) AS issued_avoirs_without_snapshot
+FROM public.avoir;
+
+SELECT
+  count(*) FILTER (WHERE source_total > delivered_quantity) AS overallocated_delivery_lines
+FROM (
+  SELECT a.source_line_id, SUM(a.quantity_consumed) AS source_total, bl.quantite AS delivered_quantity
+  FROM public.facture_source_allocations a
+  JOIN public.bon_livraison_ligne bl ON bl.id::text = a.source_line_id
+  WHERE a.source_type = 'DELIVERY_LINE' AND a.allocation_status = 'CONSUMED'
+  GROUP BY a.source_line_id, bl.quantite
+) x;
+
+SELECT
+  count(*) FILTER (WHERE allocated_total > recorded_total) AS overallocated_payments
+FROM (
+  SELECT a.paiement_id, SUM(a.amount_ttc) AS allocated_total, p.montant AS recorded_total
+  FROM public.paiement_allocations a
+  JOIN public.paiement p ON p.id = a.paiement_id
+  GROUP BY a.paiement_id, p.montant
+) x;
+
+SELECT
+  (SELECT count(*) FROM public.finance_command_receipts) AS command_receipts,
+  (SELECT count(*) FROM public.finance_event_log) AS finance_events,
+  (SELECT count(*) FROM public.finance_document_versions) AS versioned_documents;

--- a/docs/http/facturation-227.md
+++ b/docs/http/facturation-227.md
@@ -1,0 +1,66 @@
+# API Facturation, avoirs et paiements — issue #227
+
+Préfixe : `/api/v1`. Toutes les routes sont authentifiées et protégées par une
+capacité Finance exacte. Toutes les mutations de workflow exigent
+`Idempotency-Key` (8 à 200 caractères).
+
+## Facture
+
+- `GET /factures/workflow/eligible-sources`
+- `POST /factures/workflow/preview`
+- `POST /factures/workflow/drafts`
+- `POST /factures/workflow/:id/request-validation`
+- `POST /factures/workflow/:id/validate`
+- `POST /factures/workflow/:id/issue`
+
+L'aperçu reçoit le client, la devise, les lignes source BL, les quantités et
+l'échéancier. Pour une échéance unique, le montant absent est rempli par le
+total TTC calculé par le serveur. Le brouillon exige le `preview_hash`.
+Validation et émission portent `expected_version`; l'émission porte également
+le hash et `confirm: true`.
+
+Statuts : `DRAFT → PENDING_VALIDATION → APPROVED → ISSUED`. Les états de
+paiement sont dérivés des allocations; une facture émise n'est jamais
+réécrite ni supprimée.
+
+## Avoir
+
+- `GET /avoirs/workflow/invoices/:id/eligible-lines`
+- `POST /avoirs/workflow/preview`
+- `POST /avoirs/workflow/drafts`
+- `POST /avoirs/workflow/:id/request-validation`
+- `POST /avoirs/workflow/:id/validate`
+- `POST /avoirs/workflow/:id/issue`
+
+Chaque ligne reste rattachée à une ligne de facture émise. Le serveur soustrait
+les quantités déjà créditées sous verrou et refuse tout dépassement. Le motif
+codifié et son explication sont obligatoires.
+
+## Paiement
+
+- `POST /paiements/workflow/register`
+- `POST /paiements/workflow/:id/allocations`
+
+Les montants sont des chaînes décimales exactes. L'enregistrement accepte zéro
+ou plusieurs allocations `FACTURE`/`ECHEANCE`; chaque allocation contrôle le
+client, la devise, le disponible du paiement et le solde de la cible dans la
+même transaction. Un paiement enregistré est immuable et ne se supprime pas.
+
+## Garanties transactionnelles
+
+- reçu d'idempotence et hash de requête par acteur;
+- verrous ordonnés sur sources, documents, échéances et cibles;
+- séquence légale par type/entité/année, verrouillée sans `MAX()+1`;
+- totaux exacts `BigInt`, quantité 3 décimales, prix/taux 4, monnaie 2,
+  arrondi half-up documenté comme règle technique à valider;
+- snapshot client/émetteur/lignes/totaux et PDF version 1 avec SHA-256;
+- journal Finance, audit global et outbox écrits dans la transaction;
+- aucune facture créée automatiquement depuis commande, OF, réception, stock,
+  expédition ou `DELIVERY.SHIPPED`.
+
+## Activation
+
+Le patch `db/patches/20260725_facturation_payments_227.sql` ne crée aucune
+politique ni séquence active. Finance et Juridique doivent valider puis
+configurer ces lignes sur `cerp_test` avant toute recette d'émission. Aucune
+migration n'a été exécutée pendant l'implémentation.

--- a/src/__tests__/facturation-227.migration-guards.test.ts
+++ b/src/__tests__/facturation-227.migration-guards.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const patch = readFileSync(
+  resolve(root, "db/patches/20260725_facturation_payments_227.sql"),
+  "utf8"
+);
+const preflight = readFileSync(
+  resolve(root, "db/patches/support/20260725_facturation_payments_227.preflight.sql"),
+  "utf8"
+);
+const verify = readFileSync(
+  resolve(root, "db/patches/support/20260725_facturation_payments_227.verify.sql"),
+  "utf8"
+);
+const rollback = readFileSync(
+  resolve(root, "db/patches/support/20260725_facturation_payments_227.rollback.sql"),
+  "utf8"
+);
+
+describe("#227 migration guards", () => {
+  it("keeps the forward patch additive, transactional and inactive", () => {
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("COMMIT;");
+    expect(patch).not.toMatch(/\bDROP\s+TABLE\b/i);
+    expect(patch).not.toMatch(/\bDELETE\s+FROM\b/i);
+    expect(patch).not.toMatch(/\bINSERT\s+INTO\s+public\.finance_billing_policies\b/i);
+    expect(patch).not.toMatch(/\bINSERT\s+INTO\s+public\.finance_legal_sequences\b/i);
+  });
+
+  it("protects issued documents, children, payments and evidence", () => {
+    expect(patch).toContain("trg_protect_facture_immutable_227");
+    expect(patch).toContain("trg_protect_avoir_immutable_227");
+    expect(patch).toContain(
+      "trg_protect_facture_source_227 BEFORE INSERT OR UPDATE OR DELETE"
+    );
+    expect(patch).toContain(
+      "trg_protect_facture_echeance_227 BEFORE INSERT OR UPDATE OR DELETE"
+    );
+    expect(patch).toContain(
+      "trg_protect_avoir_source_227 BEFORE INSERT OR UPDATE OR DELETE"
+    );
+    expect(patch).toContain("recorded payment identity and amount are immutable");
+    expect(patch).toContain("facturation audit evidence is immutable");
+  });
+
+  it("enforces source, credit and payment allocation caps", () => {
+    expect(patch).toContain("payment allocations exceed recorded payment");
+    expect(patch).toContain("payment and credit allocations exceed invoice total");
+    expect(patch).toContain(
+      "invoice source allocations have a client mismatch or exceed delivered quantity"
+    );
+  });
+
+  it("restricts every support script to cerp_test", () => {
+    for (const script of [preflight, verify, rollback]) {
+      expect(script).toContain("current_database() <> 'cerp_test'");
+    }
+    expect(rollback).toContain("#227 rollback refused: Finance evidence exists");
+  });
+});

--- a/src/module/facturation/controllers/avoir-workflow.controller.ts
+++ b/src/module/facturation/controllers/avoir-workflow.controller.ts
@@ -1,0 +1,116 @@
+import type { Request, RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import type { FinanceActorContext } from "../repository/workflow.repository.shared";
+import {
+  svcCreateAvoirDraftWorkflow,
+  svcIssueAvoirWorkflow,
+  svcListAvoirEligibleLines,
+  svcPreviewAvoir,
+  svcRequestAvoirValidation,
+  svcValidateAvoirWorkflow,
+} from "../services/avoir-workflow.service";
+import {
+  avoirPreviewBodySchema,
+  createAvoirDraftBodySchema,
+  financeLegacyIdParamsSchema,
+  validationDecisionBodySchema,
+  workflowConfirmationBodySchema,
+} from "../validators/workflow.validators";
+
+function actor(req: Request): FinanceActorContext {
+  const userId = req.user?.id;
+  if (typeof userId !== "number" || userId <= 0) {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  return {
+    userId,
+    requestId: req.requestId ?? "missing-request-id",
+    path: req.originalUrl.split("?")[0] ?? req.path,
+  };
+}
+
+function key(req: Request): string | undefined {
+  const value = req.headers["idempotency-key"];
+  return typeof value === "string" ? value : undefined;
+}
+
+export const previewAvoirWorkflow: RequestHandler = async (req, res, next) => {
+  try {
+    actor(req);
+    res.json(await svcPreviewAvoir(avoirPreviewBodySchema.parse(req.body)));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const listAvoirEligibleLines: RequestHandler = async (req, res, next) => {
+  try {
+    actor(req);
+    const { id } = financeLegacyIdParamsSchema.parse(req.params);
+    res.json(await svcListAvoirEligibleLines(id));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createAvoirDraftWorkflow: RequestHandler = async (req, res, next) => {
+  try {
+    const result = await svcCreateAvoirDraftWorkflow({
+      input: createAvoirDraftBodySchema.parse(req.body),
+      actor: actor(req),
+      idempotencyKey: key(req),
+    });
+    res.status(result.idempotent_replay ? 200 : 201).json(result);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const requestAvoirValidationWorkflow: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = financeLegacyIdParamsSchema.parse(req.params);
+    res.json(
+      await svcRequestAvoirValidation({
+        avoirId: id,
+        input: workflowConfirmationBodySchema.parse(req.body),
+        actor: actor(req),
+        idempotencyKey: key(req),
+      })
+    );
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const validateAvoirWorkflow: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = financeLegacyIdParamsSchema.parse(req.params);
+    res.json(
+      await svcValidateAvoirWorkflow({
+        avoirId: id,
+        input: validationDecisionBodySchema.parse(req.body),
+        actor: actor(req),
+        idempotencyKey: key(req),
+      })
+    );
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const issueAvoirWorkflow: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = financeLegacyIdParamsSchema.parse(req.params);
+    res.json(
+      await svcIssueAvoirWorkflow({
+        avoirId: id,
+        input: workflowConfirmationBodySchema.parse(req.body),
+        actor: actor(req),
+        idempotencyKey: key(req),
+      })
+    );
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/module/facturation/controllers/facture-workflow.controller.ts
+++ b/src/module/facturation/controllers/facture-workflow.controller.ts
@@ -1,0 +1,122 @@
+import type { Request, RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import type { FinanceActorContext } from "../repository/workflow.repository.shared";
+import {
+  svcCreateFactureDraft,
+  svcIssueFacture,
+  svcListEligibleFactureSources,
+  svcPreviewFacture,
+  svcRequestFactureValidation,
+  svcValidateFacture,
+} from "../services/facture-workflow.service";
+import {
+  createFactureDraftBodySchema,
+  eligibleSourcesQuerySchema,
+  financeLegacyIdParamsSchema,
+  facturePreviewBodySchema,
+  validationDecisionBodySchema,
+  workflowConfirmationBodySchema,
+} from "../validators/workflow.validators";
+
+function actorFromRequest(req: Request): FinanceActorContext {
+  const userId = req.user?.id;
+  if (typeof userId !== "number" || !Number.isInteger(userId) || userId <= 0) {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  return {
+    userId,
+    requestId: req.requestId ?? "missing-request-id",
+    path: req.originalUrl.split("?")[0] ?? req.path,
+  };
+}
+
+function idempotencyKey(req: Request): string | undefined {
+  const value = req.headers["idempotency-key"];
+  return typeof value === "string" ? value : undefined;
+}
+
+export const listEligibleFactureSources: RequestHandler = async (req, res, next) => {
+  try {
+    actorFromRequest(req);
+    const filters = eligibleSourcesQuerySchema.parse(req.query);
+    res.json(await svcListEligibleFactureSources(filters));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const previewFacture: RequestHandler = async (req, res, next) => {
+  try {
+    actorFromRequest(req);
+    const input = facturePreviewBodySchema.parse(req.body);
+    res.json(await svcPreviewFacture(input));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createFactureDraftWorkflow: RequestHandler = async (req, res, next) => {
+  try {
+    const input = createFactureDraftBodySchema.parse(req.body);
+    const result = await svcCreateFactureDraft({
+      input,
+      actor: actorFromRequest(req),
+      idempotencyKey: idempotencyKey(req),
+    });
+    res.status(result.idempotent_replay ? 200 : 201).json(result);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const requestFactureValidation: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = financeLegacyIdParamsSchema.parse(req.params);
+    const input = workflowConfirmationBodySchema.parse(req.body);
+    res.json(
+      await svcRequestFactureValidation({
+        factureId: id,
+        input,
+        actor: actorFromRequest(req),
+        idempotencyKey: idempotencyKey(req),
+      })
+    );
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const validateFactureWorkflow: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = financeLegacyIdParamsSchema.parse(req.params);
+    const input = validationDecisionBodySchema.parse(req.body);
+    res.json(
+      await svcValidateFacture({
+        factureId: id,
+        input,
+        actor: actorFromRequest(req),
+        idempotencyKey: idempotencyKey(req),
+      })
+    );
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const issueFactureWorkflow: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = financeLegacyIdParamsSchema.parse(req.params);
+    const input = workflowConfirmationBodySchema.parse(req.body);
+    res.json(
+      await svcIssueFacture({
+        factureId: id,
+        input,
+        actor: actorFromRequest(req),
+        idempotencyKey: idempotencyKey(req),
+      })
+    );
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/module/facturation/controllers/payment-workflow.controller.ts
+++ b/src/module/facturation/controllers/payment-workflow.controller.ts
@@ -1,0 +1,59 @@
+import type { Request, RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import type { FinanceActorContext } from "../repository/workflow.repository.shared";
+import {
+  svcAllocatePaymentWorkflow,
+  svcRegisterPaymentWorkflow,
+} from "../services/payment-workflow.service";
+import {
+  allocatePaymentBodySchema,
+  financeLegacyIdParamsSchema,
+  registerPaymentBodySchema,
+} from "../validators/workflow.validators";
+
+function actor(req: Request): FinanceActorContext {
+  const userId = req.user?.id;
+  if (typeof userId !== "number" || userId <= 0) {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  return {
+    userId,
+    requestId: req.requestId ?? "missing-request-id",
+    path: req.originalUrl.split("?")[0] ?? req.path,
+  };
+}
+
+function key(req: Request): string | undefined {
+  const value = req.headers["idempotency-key"];
+  return typeof value === "string" ? value : undefined;
+}
+
+export const registerPaymentWorkflow: RequestHandler = async (req, res, next) => {
+  try {
+    const result = await svcRegisterPaymentWorkflow({
+      input: registerPaymentBodySchema.parse(req.body),
+      actor: actor(req),
+      idempotencyKey: key(req),
+    });
+    res.status(result.idempotent_replay ? 200 : 201).json(result);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const allocatePaymentWorkflow: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = financeLegacyIdParamsSchema.parse(req.params);
+    res.json(
+      await svcAllocatePaymentWorkflow({
+        paymentId: id,
+        input: allocatePaymentBodySchema.parse(req.body),
+        actor: actor(req),
+        idempotencyKey: key(req),
+      })
+    );
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/module/facturation/domain/decimal-money.test.ts
+++ b/src/module/facturation/domain/decimal-money.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeExactDocumentTotals,
+  computeExactLineTotals,
+  divideHalfUp,
+  formatDecimal,
+  parseDecimal,
+} from "./decimal-money";
+
+describe("issue #227 — décimales exactes", () => {
+  it.each([
+    ["0", 2, 0n],
+    ["1", 2, 100n],
+    ["1.2", 2, 120n],
+    ["1.23", 2, 123n],
+    ["999999.99", 2, 99_999_999n],
+    ["0.001", 3, 1n],
+    ["12.3456", 4, 123_456n],
+    ["-1.25", 2, -125n],
+  ] as const)("parse %s scale %s", (value, scale, expected) => {
+    expect(parseDecimal(value, scale, "test")).toBe(expected);
+    expect(formatDecimal(expected, scale)).toBe(
+      `${expected < 0n ? "-" : ""}${(() => {
+        const absolute = expected < 0n ? -expected : expected;
+        const divisor = 10n ** BigInt(scale);
+        return `${absolute / divisor}.${String(absolute % divisor).padStart(scale, "0")}`;
+      })()}`
+    );
+  });
+
+  it.each([
+    [1n, 2n, 1n],
+    [2n, 3n, 1n],
+    [1n, 3n, 0n],
+    [5n, 10n, 1n],
+    [-5n, 10n, -1n],
+  ] as const)("arrondi half-up %s/%s", (numerator, denominator, expected) => {
+    expect(divideHalfUp(numerator, denominator)).toBe(expected);
+  });
+
+  it("calcule une ligne sans flottants", () => {
+    expect(
+      computeExactLineTotals({
+        quantity: "3.000",
+        unitPriceExTax: "19.9900",
+        discountPercent: "10.0000",
+        taxRatePercent: "20.0000",
+      })
+    ).toEqual({
+      totalExTax: "53.97",
+      taxAmount: "10.79",
+      totalInclTax: "64.76",
+    });
+  });
+
+  it("applique la remise globale aux bases et taxes agrégées", () => {
+    expect(
+      computeExactDocumentTotals(
+        [
+          {
+            quantity: "1.000",
+            unitPriceExTax: "100.0000",
+            discountPercent: "0",
+            taxRatePercent: "20",
+          },
+          {
+            quantity: "2.000",
+            unitPriceExTax: "50.0000",
+            discountPercent: "0",
+            taxRatePercent: "10",
+          },
+        ],
+        "5"
+      )
+    ).toEqual({
+      subtotalExTax: "200.00",
+      discountPercent: "5.0000",
+      discountAmount: "10.00",
+      totalExTax: "190.00",
+      totalTax: "28.50",
+      totalInclTax: "218.50",
+    });
+  });
+
+  it.each(["1.234", "NaN", "1e3", "", " 1,20 "])("refuse %s à l'échelle monétaire", (value) => {
+    expect(() => parseDecimal(value, 2, "test")).toThrow();
+  });
+});

--- a/src/module/facturation/domain/decimal-money.ts
+++ b/src/module/facturation/domain/decimal-money.ts
@@ -1,0 +1,145 @@
+import { HttpError } from "../../../utils/httpError";
+
+const DECIMAL_PATTERN = /^-?(?:0|[1-9]\d*)(?:\.\d+)?$/;
+
+function pow10(scale: number): bigint {
+  return 10n ** BigInt(scale);
+}
+
+export function parseDecimal(value: string, scale: number, label: string): bigint {
+  const normalized = value.trim();
+  if (!DECIMAL_PATTERN.test(normalized)) {
+    throw new HttpError(422, "DECIMAL_INVALID", `${label} doit être un nombre décimal exact.`);
+  }
+  const negative = normalized.startsWith("-");
+  const unsigned = negative ? normalized.slice(1) : normalized;
+  const [whole, fraction = ""] = unsigned.split(".");
+  if (fraction.length > scale) {
+    throw new HttpError(
+      422,
+      "DECIMAL_PRECISION_EXCEEDED",
+      `${label} accepte au maximum ${scale} décimales.`
+    );
+  }
+  const units = BigInt(whole) * pow10(scale) + BigInt((fraction + "0".repeat(scale)).slice(0, scale) || "0");
+  return negative ? -units : units;
+}
+
+export function formatDecimal(value: bigint, scale: number): string {
+  const negative = value < 0n;
+  const absolute = negative ? -value : value;
+  const divisor = pow10(scale);
+  const whole = absolute / divisor;
+  const fraction = (absolute % divisor).toString().padStart(scale, "0");
+  return `${negative ? "-" : ""}${whole.toString()}${scale ? `.${fraction}` : ""}`;
+}
+
+export function divideHalfUp(numerator: bigint, denominator: bigint): bigint {
+  if (denominator <= 0n) throw new Error("denominator must be positive");
+  const negative = numerator < 0n;
+  const absolute = negative ? -numerator : numerator;
+  const quotient = absolute / denominator;
+  const remainder = absolute % denominator;
+  const rounded = remainder * 2n >= denominator ? quotient + 1n : quotient;
+  return negative ? -rounded : rounded;
+}
+
+export type ExactLineInput = {
+  quantity: string;
+  unitPriceExTax: string;
+  discountPercent: string;
+  taxRatePercent: string;
+};
+
+export type ExactLineTotals = {
+  totalExTax: string;
+  taxAmount: string;
+  totalInclTax: string;
+};
+
+const QUANTITY_SCALE = 3;
+const PRICE_SCALE = 4;
+const PERCENT_SCALE = 4;
+const MONEY_SCALE = 2;
+const PERCENT_DENOMINATOR = 100n * pow10(PERCENT_SCALE);
+
+function assertPercent(value: bigint, label: string): void {
+  if (value < 0n || value > PERCENT_DENOMINATOR) {
+    throw new HttpError(422, "PERCENT_OUT_OF_RANGE", `${label} doit être compris entre 0 et 100.`);
+  }
+}
+
+function roundScale(value: bigint, fromScale: number, toScale: number): bigint {
+  if (fromScale === toScale) return value;
+  if (fromScale < toScale) return value * pow10(toScale - fromScale);
+  return divideHalfUp(value, pow10(fromScale - toScale));
+}
+
+export function computeExactLineTotals(line: ExactLineInput): ExactLineTotals {
+  const quantity = parseDecimal(line.quantity, QUANTITY_SCALE, "Quantité");
+  const price = parseDecimal(line.unitPriceExTax, PRICE_SCALE, "Prix unitaire HT");
+  const discount = parseDecimal(line.discountPercent, PERCENT_SCALE, "Remise");
+  const taxRate = parseDecimal(line.taxRatePercent, PERCENT_SCALE, "Taux de taxe");
+  if (quantity <= 0n) throw new HttpError(422, "QUANTITY_INVALID", "La quantité doit être strictement positive.");
+  if (price < 0n) throw new HttpError(422, "PRICE_INVALID", "Le prix unitaire ne peut pas être négatif.");
+  assertPercent(discount, "Remise");
+  assertPercent(taxRate, "Taux de taxe");
+
+  const rawExTax = divideHalfUp(
+    quantity * price * (PERCENT_DENOMINATOR - discount),
+    PERCENT_DENOMINATOR
+  );
+  const totalExTaxCents = roundScale(rawExTax, QUANTITY_SCALE + PRICE_SCALE, MONEY_SCALE);
+  const taxCents = divideHalfUp(totalExTaxCents * taxRate, PERCENT_DENOMINATOR);
+  return {
+    totalExTax: formatDecimal(totalExTaxCents, MONEY_SCALE),
+    taxAmount: formatDecimal(taxCents, MONEY_SCALE),
+    totalInclTax: formatDecimal(totalExTaxCents + taxCents, MONEY_SCALE),
+  };
+}
+
+export type ExactDocumentTotals = {
+  subtotalExTax: string;
+  discountPercent: string;
+  discountAmount: string;
+  totalExTax: string;
+  totalTax: string;
+  totalInclTax: string;
+};
+
+export function computeExactDocumentTotals(
+  lines: readonly ExactLineInput[],
+  globalDiscountPercent: string
+): ExactDocumentTotals {
+  const discount = parseDecimal(globalDiscountPercent, PERCENT_SCALE, "Remise globale");
+  assertPercent(discount, "Remise globale");
+  const lineTotals = lines.map(computeExactLineTotals);
+  const subtotalCents = lineTotals.reduce(
+    (sum, line) => sum + parseDecimal(line.totalExTax, MONEY_SCALE, "Total HT"),
+    0n
+  );
+  const taxBeforeDiscountCents = lineTotals.reduce(
+    (sum, line) => sum + parseDecimal(line.taxAmount, MONEY_SCALE, "Taxe"),
+    0n
+  );
+  const totalExTaxCents = divideHalfUp(
+    subtotalCents * (PERCENT_DENOMINATOR - discount),
+    PERCENT_DENOMINATOR
+  );
+  const totalTaxCents = divideHalfUp(
+    taxBeforeDiscountCents * (PERCENT_DENOMINATOR - discount),
+    PERCENT_DENOMINATOR
+  );
+  return {
+    subtotalExTax: formatDecimal(subtotalCents, MONEY_SCALE),
+    discountPercent: formatDecimal(discount, PERCENT_SCALE),
+    discountAmount: formatDecimal(subtotalCents - totalExTaxCents, MONEY_SCALE),
+    totalExTax: formatDecimal(totalExTaxCents, MONEY_SCALE),
+    totalTax: formatDecimal(totalTaxCents, MONEY_SCALE),
+    totalInclTax: formatDecimal(totalExTaxCents + totalTaxCents, MONEY_SCALE),
+  };
+}
+
+export function moneyToCents(value: string, label = "Montant"): bigint {
+  return parseDecimal(value, MONEY_SCALE, label);
+}

--- a/src/module/facturation/domain/finance-policy.test.ts
+++ b/src/module/facturation/domain/finance-policy.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import { HttpError } from "../../../utils/httpError";
+import {
+  assertAvoirTransition,
+  assertFactureTransition,
+  decideReceipt,
+  financeRequestHash,
+  invoiceStatusFromBalance,
+  paymentStatusFromAllocation,
+  roleHasFinanceCapability,
+} from "./finance-policy";
+
+const factureStatuses = [
+  "DRAFT",
+  "PENDING_VALIDATION",
+  "APPROVED",
+  "ISSUED",
+  "PARTIALLY_PAID",
+  "PAID",
+  "CANCELLED",
+] as const;
+
+const allowedFactureTransitions = new Set([
+  "DRAFT:PENDING_VALIDATION",
+  "DRAFT:CANCELLED",
+  "PENDING_VALIDATION:DRAFT",
+  "PENDING_VALIDATION:APPROVED",
+  "APPROVED:DRAFT",
+  "APPROVED:ISSUED",
+  "ISSUED:PARTIALLY_PAID",
+  "ISSUED:PAID",
+  "PARTIALLY_PAID:ISSUED",
+  "PARTIALLY_PAID:PAID",
+  "PAID:PARTIALLY_PAID",
+]);
+
+describe("issue #227 — transitions facture", () => {
+  it.each(
+    factureStatuses.flatMap((from) =>
+      factureStatuses.map((to, index) => ({
+        id: `FIN-TR-${from}-${String(index + 1).padStart(2, "0")}`,
+        from,
+        to,
+      }))
+    )
+  )("$id $from -> $to", ({ from, to }) => {
+    const expected = allowedFactureTransitions.has(`${from}:${to}`);
+    if (expected) {
+      expect(() => assertFactureTransition(from, to)).not.toThrow();
+    } else {
+      expect(() => assertFactureTransition(from, to)).toThrowError(HttpError);
+    }
+  });
+});
+
+const avoirStatuses = ["DRAFT", "PENDING_VALIDATION", "APPROVED", "ISSUED", "CANCELLED"] as const;
+const allowedAvoirTransitions = new Set([
+  "DRAFT:PENDING_VALIDATION",
+  "DRAFT:CANCELLED",
+  "PENDING_VALIDATION:DRAFT",
+  "PENDING_VALIDATION:APPROVED",
+  "APPROVED:DRAFT",
+  "APPROVED:ISSUED",
+]);
+
+describe("issue #227 — transitions avoir", () => {
+  it.each(
+    avoirStatuses.flatMap((from) =>
+      avoirStatuses.map((to, index) => ({
+        id: `CRD-TR-${from}-${String(index + 1).padStart(2, "0")}`,
+        from,
+        to,
+      }))
+    )
+  )("$id $from -> $to", ({ from, to }) => {
+    const expected = allowedAvoirTransitions.has(`${from}:${to}`);
+    if (expected) {
+      expect(() => assertAvoirTransition(from, to)).not.toThrow();
+    } else {
+      expect(() => assertAvoirTransition(from, to)).toThrowError(HttpError);
+    }
+  });
+});
+
+describe("issue #227 — RBAC fail-closed", () => {
+  it.each([
+    ["Secretaire", "draft_write", true],
+    ["Secretaire", "issue", false],
+    ["Comptabilite", "issue", true],
+    ["Comptable", "payment_allocate", true],
+    ["Directeur", "credit_issue", true],
+    ["Administrateur Systeme et Reseau", "settings_manage", true],
+    ["Administrateur Systeme et Reseau", "issue", false],
+    ["Responsable Comptabilite", "issue", false],
+    ["admin", "settings_manage", false],
+    ["", "read", false],
+  ] as const)("%s / %s", (role, capability, expected) => {
+    expect(roleHasFinanceCapability(role, capability)).toBe(expected);
+  });
+});
+
+describe("issue #227 — idempotence et soldes", () => {
+  it("stabilise le hash malgré l'ordre des propriétés", () => {
+    expect(financeRequestHash("PAYMENT_REGISTER", { b: 2, a: 1 })).toBe(
+      financeRequestHash("PAYMENT_REGISTER", { a: 1, b: 2 })
+    );
+  });
+
+  it.each([
+    [null, "abc", "NEW"],
+    ["abc", "abc", "REPLAY"],
+    ["abc", "def", "CONFLICT"],
+  ] as const)("receipt %s/%s", (stored, incoming, expected) => {
+    expect(decideReceipt(stored, incoming)).toBe(expected);
+  });
+
+  it.each([
+    [10_000n, 0n, "ISSUED"],
+    [10_000n, 1n, "PARTIALLY_PAID"],
+    [10_000n, 9_999n, "PARTIALLY_PAID"],
+    [10_000n, 10_000n, "PAID"],
+  ] as const)("statut facture %s/%s", (totalCents, settledCents, expected) => {
+    expect(invoiceStatusFromBalance({ totalCents, settledCents })).toBe(expected);
+  });
+
+  it.each([
+    [10_000n, 0n, "UNALLOCATED"],
+    [10_000n, 1n, "PARTIALLY_ALLOCATED"],
+    [10_000n, 9_999n, "PARTIALLY_ALLOCATED"],
+    [10_000n, 10_000n, "ALLOCATED"],
+  ] as const)("statut paiement %s/%s", (paymentCents, allocatedCents, expected) => {
+    expect(paymentStatusFromAllocation({ paymentCents, allocatedCents })).toBe(expected);
+  });
+});

--- a/src/module/facturation/domain/finance-policy.ts
+++ b/src/module/facturation/domain/finance-policy.ts
@@ -1,0 +1,204 @@
+import crypto from "node:crypto";
+
+import { HttpError } from "../../../utils/httpError";
+
+export const FACTURE_WORKFLOW_STATUSES = [
+  "DRAFT",
+  "PENDING_VALIDATION",
+  "APPROVED",
+  "ISSUED",
+  "PARTIALLY_PAID",
+  "PAID",
+  "CANCELLED",
+] as const;
+
+export type FactureWorkflowStatus = (typeof FACTURE_WORKFLOW_STATUSES)[number];
+
+export const AVOIR_WORKFLOW_STATUSES = [
+  "DRAFT",
+  "PENDING_VALIDATION",
+  "APPROVED",
+  "ISSUED",
+  "CANCELLED",
+] as const;
+
+export type AvoirWorkflowStatus = (typeof AVOIR_WORKFLOW_STATUSES)[number];
+
+export const PAYMENT_STATUSES = [
+  "UNALLOCATED",
+  "PARTIALLY_ALLOCATED",
+  "ALLOCATED",
+  "REJECTED",
+  "REVERSED",
+] as const;
+
+export type PaymentStatus = (typeof PAYMENT_STATUSES)[number];
+
+export type FinanceCapability =
+  | "read"
+  | "draft_write"
+  | "request_validation"
+  | "validate"
+  | "issue"
+  | "credit_write"
+  | "credit_issue"
+  | "payment_register"
+  | "payment_allocate"
+  | "documents_read"
+  | "audit_read"
+  | "reporting_read"
+  | "settings_manage";
+
+const ROLES = {
+  director: "Directeur",
+  administrator: "Administrateur Systeme et Reseau",
+  secretary: "Secretaire",
+  accounting: "Comptabilite",
+  accountant: "Comptable",
+} as const;
+
+const CAPABILITY_ROLES: Record<FinanceCapability, ReadonlySet<string>> = {
+  read: new Set(Object.values(ROLES)),
+  draft_write: new Set([ROLES.secretary, ROLES.accounting, ROLES.accountant, ROLES.director]),
+  request_validation: new Set([ROLES.secretary, ROLES.accounting, ROLES.accountant, ROLES.director]),
+  validate: new Set([ROLES.accounting, ROLES.accountant, ROLES.director]),
+  issue: new Set([ROLES.accounting, ROLES.accountant, ROLES.director]),
+  credit_write: new Set([ROLES.secretary, ROLES.accounting, ROLES.accountant, ROLES.director]),
+  credit_issue: new Set([ROLES.accounting, ROLES.accountant, ROLES.director]),
+  payment_register: new Set([ROLES.secretary, ROLES.accounting, ROLES.accountant, ROLES.director]),
+  payment_allocate: new Set([ROLES.accounting, ROLES.accountant, ROLES.director]),
+  documents_read: new Set(Object.values(ROLES)),
+  audit_read: new Set([ROLES.accounting, ROLES.accountant, ROLES.director, ROLES.administrator]),
+  reporting_read: new Set([ROLES.secretary, ROLES.accounting, ROLES.accountant, ROLES.director]),
+  settings_manage: new Set([ROLES.director, ROLES.administrator]),
+};
+
+export function roleHasFinanceCapability(
+  role: string | null | undefined,
+  capability: FinanceCapability
+): boolean {
+  if (typeof role !== "string" || !role.trim()) return false;
+  return CAPABILITY_ROLES[capability].has(role.trim());
+}
+
+const FACTURE_TRANSITIONS: Readonly<Record<FactureWorkflowStatus, readonly FactureWorkflowStatus[]>> = {
+  DRAFT: ["PENDING_VALIDATION", "CANCELLED"],
+  PENDING_VALIDATION: ["DRAFT", "APPROVED"],
+  APPROVED: ["DRAFT", "ISSUED"],
+  ISSUED: ["PARTIALLY_PAID", "PAID"],
+  PARTIALLY_PAID: ["ISSUED", "PAID"],
+  PAID: ["PARTIALLY_PAID"],
+  CANCELLED: [],
+};
+
+const AVOIR_TRANSITIONS: Readonly<Record<AvoirWorkflowStatus, readonly AvoirWorkflowStatus[]>> = {
+  DRAFT: ["PENDING_VALIDATION", "CANCELLED"],
+  PENDING_VALIDATION: ["DRAFT", "APPROVED"],
+  APPROVED: ["DRAFT", "ISSUED"],
+  ISSUED: [],
+  CANCELLED: [],
+};
+
+export function assertFactureTransition(
+  current: FactureWorkflowStatus,
+  target: FactureWorkflowStatus
+): void {
+  if (!FACTURE_TRANSITIONS[current]?.includes(target)) {
+    throw new HttpError(
+      409,
+      "FACTURE_TRANSITION_FORBIDDEN",
+      `Transition de facture interdite: ${current} vers ${target}.`
+    );
+  }
+}
+
+export function assertAvoirTransition(
+  current: AvoirWorkflowStatus,
+  target: AvoirWorkflowStatus
+): void {
+  if (!AVOIR_TRANSITIONS[current]?.includes(target)) {
+    throw new HttpError(
+      409,
+      "AVOIR_TRANSITION_FORBIDDEN",
+      `Transition d'avoir interdite: ${current} vers ${target}.`
+    );
+  }
+}
+
+export function assertSeparationOfDuties(params: {
+  creatorUserId: number | null;
+  validatorUserId: number;
+}): void {
+  if (params.creatorUserId !== null && params.creatorUserId === params.validatorUserId) {
+    throw new HttpError(
+      403,
+      "FINANCE_SEPARATION_OF_DUTIES",
+      "Le créateur ne peut pas valider son propre document financier."
+    );
+  }
+}
+
+export function normalizeIdempotencyKey(value: string | null | undefined): string {
+  const normalized = (value ?? "").trim();
+  if (normalized.length < 8 || normalized.length > 200) {
+    throw new HttpError(
+      400,
+      "IDEMPOTENCY_KEY_INVALID",
+      "Idempotency-Key doit contenir entre 8 et 200 caractères."
+    );
+  }
+  return normalized;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, canonicalize(child)])
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function financeRequestHash(commandType: string, payload: unknown): string {
+  return crypto
+    .createHash("sha256")
+    .update(canonicalJson({ command_type: commandType, payload }))
+    .digest("hex");
+}
+
+export function financePreviewHash(payload: unknown): string {
+  return crypto.createHash("sha256").update(canonicalJson(payload)).digest("hex");
+}
+
+export function decideReceipt(
+  existingHash: string | null | undefined,
+  incomingHash: string
+): "NEW" | "REPLAY" | "CONFLICT" {
+  if (!existingHash) return "NEW";
+  return existingHash === incomingHash ? "REPLAY" : "CONFLICT";
+}
+
+export function invoiceStatusFromBalance(params: {
+  totalCents: bigint;
+  settledCents: bigint;
+}): "ISSUED" | "PARTIALLY_PAID" | "PAID" {
+  if (params.settledCents <= 0n) return "ISSUED";
+  if (params.settledCents < params.totalCents) return "PARTIALLY_PAID";
+  return "PAID";
+}
+
+export function paymentStatusFromAllocation(params: {
+  paymentCents: bigint;
+  allocatedCents: bigint;
+}): PaymentStatus {
+  if (params.allocatedCents <= 0n) return "UNALLOCATED";
+  if (params.allocatedCents < params.paymentCents) return "PARTIALLY_ALLOCATED";
+  return "ALLOCATED";
+}

--- a/src/module/facturation/middlewares/finance-authorization.middleware.ts
+++ b/src/module/facturation/middlewares/finance-authorization.middleware.ts
@@ -1,0 +1,27 @@
+import type { RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import {
+  roleHasFinanceCapability,
+  type FinanceCapability,
+} from "../domain/finance-policy";
+
+export function requireFinanceCapability(capability: FinanceCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (!req.user) {
+      next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
+      return;
+    }
+    if (!roleHasFinanceCapability(req.user.role, capability)) {
+      next(
+        new HttpError(
+          403,
+          "FINANCE_CAPABILITY_REQUIRED",
+          `La capacité Finance '${capability}' est requise.`
+        )
+      );
+      return;
+    }
+    next();
+  };
+}

--- a/src/module/facturation/repository/avoir-workflow.repository.ts
+++ b/src/module/facturation/repository/avoir-workflow.repository.ts
@@ -1,0 +1,937 @@
+import crypto from "node:crypto";
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import {
+  assertAvoirTransition,
+  assertSeparationOfDuties,
+  financePreviewHash,
+  type AvoirWorkflowStatus,
+} from "../domain/finance-policy";
+import {
+  computeExactDocumentTotals,
+  computeExactLineTotals,
+  parseDecimal,
+} from "../domain/decimal-money";
+import type {
+  AvoirPreview,
+  AvoirPreviewLine,
+  FinanceCommandResult,
+} from "../types/workflow.types";
+import type {
+  AvoirPreviewBodyDTO,
+  CreateAvoirDraftBodyDTO,
+  ValidationDecisionBodyDTO,
+  WorkflowConfirmationBodyDTO,
+} from "../validators/workflow.validators";
+import {
+  acquireFinanceIdempotency,
+  allocateLegalNumber,
+  type FinanceActorContext,
+  insertFinanceEvent,
+  insertFinanceOutbox,
+  insertGlobalFinanceAudit,
+  newCorrelationId,
+  nextLegacyId,
+  saveFinanceReceipt,
+} from "./workflow.repository.shared";
+
+type AvoirSourceRow = {
+  facture_id: string;
+  facture_number: string;
+  facture_status: string;
+  client_id: string;
+  currency: string;
+  client_snapshot: Record<string, unknown>;
+  issuer_snapshot: Record<string, unknown>;
+  legal_entity_code: string;
+  facture_line_id: string;
+  designation: string;
+  code_piece: string | null;
+  quantity_invoiced: string;
+  quantity_already_credited: string;
+  unit: string | null;
+  unit_price_ex_tax: string;
+  discount_percent: string;
+  tax_rate_percent: string;
+};
+
+export type AvoirDocumentSnapshot = {
+  document_type: "AVOIR";
+  uuid: string;
+  draft_reference: string;
+  legal_number: string;
+  issue_date: string;
+  facture_id: number;
+  facture_number: string;
+  currency: string;
+  client_snapshot: Record<string, unknown>;
+  issuer_snapshot: Record<string, unknown>;
+  reason_code: string;
+  reason: string;
+  lines: AvoirPreviewLine[];
+  totals: AvoirPreview["totals"];
+};
+
+export type AvoirDocumentArtifact = {
+  documentId: string;
+  fileName: string;
+  checksumSha256: string;
+  fileSizeBytes: number;
+  cleanup: () => Promise<void>;
+};
+
+export type AvoirDocumentWriter = (
+  snapshot: AvoirDocumentSnapshot
+) => Promise<AvoirDocumentArtifact>;
+
+async function loadAvoirSources(
+  factureId: number,
+  client?: PoolClient,
+  lock = false
+): Promise<AvoirSourceRow[]> {
+  const queryer = client ?? pool;
+  if (lock && client) {
+    await client.query(
+      `SELECT id FROM public.facture_ligne WHERE facture_id = $1 ORDER BY id FOR UPDATE`,
+      [factureId]
+    );
+  }
+  const result = await queryer.query<AvoirSourceRow>(
+    `
+      SELECT
+        f.id::text AS facture_id,
+        f.numero AS facture_number,
+        f.statut AS facture_status,
+        f.client_id,
+        COALESCE(f.currency, 'EUR') AS currency,
+        COALESCE(f.client_snapshot, '{}'::jsonb) AS client_snapshot,
+        COALESCE(f.issuer_snapshot, '{}'::jsonb) AS issuer_snapshot,
+        COALESCE(f.legal_entity_code, '') AS legal_entity_code,
+        fl.id::text AS facture_line_id,
+        fl.designation,
+        fl.code_piece,
+        fl.quantite::numeric(18,3)::text AS quantity_invoiced,
+        COALESCE(credited.quantity, 0)::numeric(18,3)::text AS quantity_already_credited,
+        fl.unite AS unit,
+        fl.prix_unitaire_ht::numeric(18,4)::text AS unit_price_ex_tax,
+        COALESCE(fl.remise_ligne, 0)::numeric(9,4)::text AS discount_percent,
+        COALESCE(fl.taux_tva, 0)::numeric(9,4)::text AS tax_rate_percent
+      FROM public.facture f
+      JOIN public.facture_ligne fl ON fl.facture_id = f.id
+      LEFT JOIN LATERAL (
+        SELECT COALESCE(SUM(source.quantity_credited), 0) AS quantity
+        FROM public.avoir_source_allocations source
+        WHERE source.facture_line_id = fl.id
+          AND source.allocation_status = 'CONSUMED'
+      ) credited ON TRUE
+      WHERE f.id = $1
+      ORDER BY fl.ordre, fl.id
+    `,
+    [factureId]
+  );
+  return result.rows;
+}
+
+async function buildAvoirPreview(
+  input: AvoirPreviewBodyDTO,
+  client?: PoolClient,
+  lock = false
+): Promise<AvoirPreview> {
+  const rows = await loadAvoirSources(input.facture_id, client, lock);
+  if (rows.length === 0) {
+    throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture ou lignes de facture introuvables.");
+  }
+  const header = rows[0]!;
+  if (!["ISSUED", "PARTIALLY_PAID", "PAID"].includes(header.facture_status)) {
+    throw new HttpError(
+      409,
+      "AVOIR_FACTURE_NOT_ISSUED",
+      "Un avoir ne peut corriger qu'une facture émise."
+    );
+  }
+
+  const byId = new Map(rows.map((row) => [Number.parseInt(row.facture_line_id, 10), row]));
+  const seen = new Set<number>();
+  const lines: AvoirPreviewLine[] = [];
+
+  for (const selection of input.lines) {
+    if (seen.has(selection.facture_line_id)) {
+      throw new HttpError(
+        422,
+        "AVOIR_LINE_DUPLICATED",
+        "Une ligne de facture ne peut être sélectionnée qu'une fois."
+      );
+    }
+    seen.add(selection.facture_line_id);
+    const row = byId.get(selection.facture_line_id);
+    if (!row) {
+      throw new HttpError(
+        422,
+        "AVOIR_LINE_NOT_IN_FACTURE",
+        "La ligne sélectionnée n'appartient pas à la facture."
+      );
+    }
+    const invoiced = parseDecimal(row.quantity_invoiced, 3, "Quantité facturée");
+    const credited = parseDecimal(row.quantity_already_credited, 3, "Quantité déjà créditée");
+    const selected = parseDecimal(selection.quantity, 3, "Quantité créditée");
+    const remaining = invoiced - credited;
+    if (selected <= 0n || selected > remaining) {
+      throw new HttpError(
+        409,
+        "AVOIR_QUANTITY_EXCEEDS_REMAINING",
+        "La quantité d'avoir dépasse la quantité encore créditable."
+      );
+    }
+    const totals = computeExactLineTotals({
+      quantity: selection.quantity,
+      unitPriceExTax: row.unit_price_ex_tax,
+      discountPercent: row.discount_percent,
+      taxRatePercent: row.tax_rate_percent,
+    });
+    lines.push({
+      facture_line_id: selection.facture_line_id,
+      designation: row.designation,
+      code_piece: row.code_piece,
+      quantity_invoiced: row.quantity_invoiced,
+      quantity_already_credited: row.quantity_already_credited,
+      quantity_remaining: `${remaining / 1000n}.${(remaining % 1000n)
+        .toString()
+        .padStart(3, "0")}`,
+      quantity_selected: selection.quantity,
+      unit: row.unit,
+      unit_price_ex_tax: row.unit_price_ex_tax,
+      discount_percent: row.discount_percent,
+      tax_rate_percent: row.tax_rate_percent,
+      total_ex_tax: totals.totalExTax,
+      tax_amount: totals.taxAmount,
+      total_incl_tax: totals.totalInclTax,
+    });
+  }
+
+  const totals = computeExactDocumentTotals(
+    lines.map((line) => ({
+      quantity: line.quantity_selected,
+      unitPriceExTax: line.unit_price_ex_tax,
+      discountPercent: line.discount_percent,
+      taxRatePercent: line.tax_rate_percent,
+    })),
+    "0"
+  );
+  const unsigned = {
+    preview_version: 1 as const,
+    facture_id: input.facture_id,
+    facture_number: header.facture_number,
+    client_id: header.client_id,
+    currency: header.currency,
+    reason_code: input.reason_code,
+    reason: input.reason,
+    lines,
+    totals: {
+      subtotal_ex_tax: totals.subtotalExTax,
+      global_discount_percent: totals.discountPercent,
+      global_discount_amount: totals.discountAmount,
+      total_ex_tax: totals.totalExTax,
+      total_tax: totals.totalTax,
+      total_incl_tax: totals.totalInclTax,
+    },
+    blockers: [],
+    warnings: [],
+  };
+  return { ...unsigned, preview_hash: financePreviewHash(unsigned) };
+}
+
+export function repoPreviewAvoir(input: AvoirPreviewBodyDTO): Promise<AvoirPreview> {
+  return buildAvoirPreview(input);
+}
+
+export async function repoListAvoirEligibleLines(factureId: number): Promise<{
+  facture_id: number;
+  facture_number: string;
+  client_id: string;
+  currency: string;
+  lines: Array<{
+    facture_line_id: number;
+    designation: string;
+    code_piece: string | null;
+    unit: string | null;
+    quantity_invoiced: string;
+    quantity_already_credited: string;
+    quantity_remaining: string;
+    eligible: boolean;
+  }>;
+}> {
+  const rows = await loadAvoirSources(factureId);
+  if (rows.length === 0) {
+    throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture ou lignes introuvables.");
+  }
+  const header = rows[0]!;
+  if (!["ISSUED", "PARTIALLY_PAID", "PAID"].includes(header.facture_status)) {
+    throw new HttpError(409, "AVOIR_FACTURE_NOT_ISSUED", "La facture n'est pas émise.");
+  }
+  return {
+    facture_id: factureId,
+    facture_number: header.facture_number,
+    client_id: header.client_id,
+    currency: header.currency,
+    lines: rows.map((row) => {
+      const remaining =
+        parseDecimal(row.quantity_invoiced, 3, "Quantité facturée") -
+        parseDecimal(row.quantity_already_credited, 3, "Quantité déjà créditée");
+      return {
+        facture_line_id: Number.parseInt(row.facture_line_id, 10),
+        designation: row.designation,
+        code_piece: row.code_piece,
+        unit: row.unit,
+        quantity_invoiced: row.quantity_invoiced,
+        quantity_already_credited: row.quantity_already_credited,
+        quantity_remaining: `${remaining / 1000n}.${(remaining % 1000n).toString().padStart(3, "0")}`,
+        eligible: remaining > 0n,
+      };
+    }),
+  };
+}
+
+export async function repoCreateAvoirDraft(params: {
+  input: CreateAvoirDraftBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}): Promise<FinanceCommandResult> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const receipt = await acquireFinanceIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "AVOIR_DRAFT_CREATE",
+      requestPayload: params.input,
+    });
+    if (receipt.replay) {
+      await client.query("COMMIT");
+      return { ...(receipt.replay as unknown as FinanceCommandResult), idempotent_replay: true };
+    }
+    const { preview_hash: expectedPreviewHash, ...previewInput } = params.input;
+    const preview = await buildAvoirPreview(previewInput, client, true);
+    if (preview.preview_hash !== expectedPreviewHash) {
+      throw new HttpError(409, "AVOIR_PREVIEW_CHANGED", "L'aperçu de l'avoir a changé.");
+    }
+    const sources = await loadAvoirSources(params.input.facture_id, client);
+    const header = sources[0]!;
+    const avoirId = await nextLegacyId(client, "avoir_id_seq");
+    const uuid = crypto.randomUUID();
+    const draftReference = `AV-DRAFT-${avoirId}`;
+    await client.query(
+      `
+        INSERT INTO public.avoir (
+          id, uuid, numero, draft_reference, client_id, facture_id,
+          date_emission, statut, motif, reason_code,
+          total_ht, total_tax, total_ttc, currency,
+          preview_hash, row_version, client_snapshot, issuer_snapshot,
+          legal_entity_code, created_by
+        )
+        VALUES (
+          $1,$2::uuid,$3,$3,$4,$5,CURRENT_DATE,'DRAFT',$6,$7,
+          $8,$9,$10,$11,$12,1,$13::jsonb,$14::jsonb,$15,$16
+        )
+      `,
+      [
+        avoirId,
+        uuid,
+        draftReference,
+        preview.client_id,
+        preview.facture_id,
+        preview.reason,
+        preview.reason_code,
+        preview.totals.total_ex_tax,
+        preview.totals.total_tax,
+        preview.totals.total_incl_tax,
+        preview.currency,
+        preview.preview_hash,
+        JSON.stringify(header.client_snapshot),
+        JSON.stringify(header.issuer_snapshot),
+        header.legal_entity_code,
+        params.actor.userId,
+      ]
+    );
+    for (let index = 0; index < preview.lines.length; index += 1) {
+      const line = preview.lines[index]!;
+      const inserted = await client.query<{ id: string }>(
+        `
+          INSERT INTO public.avoir_ligne (
+            avoir_id, ordre, designation, code_piece, quantite, unite,
+            prix_unitaire_ht, remise_ligne, taux_tva,
+            total_ht, tax_amount, total_ttc, snapshot_json
+          )
+          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13::jsonb)
+          RETURNING id::text AS id
+        `,
+        [
+          avoirId,
+          index + 1,
+          line.designation,
+          line.code_piece,
+          line.quantity_selected,
+          line.unit,
+          line.unit_price_ex_tax,
+          line.discount_percent,
+          line.tax_rate_percent,
+          line.total_ex_tax,
+          line.tax_amount,
+          line.total_incl_tax,
+          JSON.stringify(line),
+        ]
+      );
+      await client.query(
+        `
+          INSERT INTO public.avoir_source_allocations (
+            avoir_id, avoir_line_id, facture_id, facture_line_id,
+            source_type, source_line_id, quantity_selected,
+            quantity_credited, amount_ttc, allocation_status, created_by
+          )
+          VALUES ($1,$2,$3,$4,'INVOICE_LINE',$4::text,$5,0,$6,'DRAFT',$7)
+        `,
+        [
+          avoirId,
+          Number.parseInt(inserted.rows[0]!.id, 10),
+          preview.facture_id,
+          line.facture_line_id,
+          line.quantity_selected,
+          line.total_incl_tax,
+          params.actor.userId,
+        ]
+      );
+    }
+    const correlationId = newCorrelationId();
+    const result: FinanceCommandResult = {
+      id: avoirId,
+      uuid,
+      draft_reference: draftReference,
+      legal_number: null,
+      status: "DRAFT",
+      row_version: 1,
+      correlation_id: correlationId,
+      idempotent_replay: false,
+    };
+    await insertFinanceEvent({
+      client,
+      aggregateType: "AVOIR",
+      aggregateId: uuid,
+      eventType: "AVOIR_DRAFT_CREATED",
+      newValues: { facture_id: preview.facture_id, preview_hash: preview.preview_hash },
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
+      reason: preview.reason,
+    });
+    await insertGlobalFinanceAudit({
+      client,
+      actor: params.actor,
+      action: "facturation.avoir_draft_created",
+      entityType: "avoir",
+      entityId: uuid,
+      details: { facture_id: preview.facture_id, correlation_id: correlationId },
+    });
+    await saveFinanceReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: receipt.idempotencyKey,
+      requestHash: receipt.requestHash,
+      commandType: "AVOIR_DRAFT_CREATE",
+      aggregateType: "AVOIR",
+      aggregateId: uuid,
+      requestPayload: params.input,
+      resultPayload: result,
+      correlationId,
+    });
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+type LockedAvoir = {
+  id: number;
+  uuid: string;
+  statut: AvoirWorkflowStatus;
+  row_version: number;
+  preview_hash: string;
+  created_by: number | null;
+  approved_by: number | null;
+  draft_reference: string;
+  facture_id: number;
+  client_snapshot: Record<string, unknown>;
+  issuer_snapshot: Record<string, unknown>;
+  legal_entity_code: string;
+};
+
+async function lockAvoir(client: PoolClient, id: number): Promise<LockedAvoir | null> {
+  const result = await client.query<LockedAvoir>(
+    `
+      SELECT
+        id, uuid::text AS uuid, statut, row_version, preview_hash,
+        created_by, approved_by, draft_reference, facture_id,
+        client_snapshot, issuer_snapshot, legal_entity_code
+      FROM public.avoir
+      WHERE id = $1
+      FOR UPDATE
+    `,
+    [id]
+  );
+  return result.rows[0] ?? null;
+}
+
+async function savedAvoirInput(client: PoolClient, avoirId: number): Promise<AvoirPreviewBodyDTO> {
+  const header = await client.query<{
+    facture_id: number;
+    reason_code: AvoirPreviewBodyDTO["reason_code"];
+    motif: string;
+  }>(
+    `SELECT facture_id, reason_code, motif FROM public.avoir WHERE id = $1`,
+    [avoirId]
+  );
+  const row = header.rows[0];
+  if (!row) throw new HttpError(404, "AVOIR_NOT_FOUND", "Avoir introuvable.");
+  const lines = await client.query<{ facture_line_id: number; quantity: string }>(
+    `
+      SELECT facture_line_id, quantity_selected::text AS quantity
+      FROM public.avoir_source_allocations
+      WHERE avoir_id = $1
+      ORDER BY avoir_line_id, id
+    `,
+    [avoirId]
+  );
+  return {
+    facture_id: row.facture_id,
+    reason_code: row.reason_code,
+    reason: row.motif,
+    lines: lines.rows,
+  };
+}
+
+async function transitionAvoir(params: {
+  avoirId: number;
+  input: WorkflowConfirmationBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+  commandType: string;
+  expectedStatus: AvoirWorkflowStatus;
+  targetStatus: AvoirWorkflowStatus;
+}): Promise<FinanceCommandResult> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const receipt = await acquireFinanceIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: params.commandType,
+      requestPayload: { avoir_id: params.avoirId, ...params.input },
+    });
+    if (receipt.replay) {
+      await client.query("COMMIT");
+      return { ...(receipt.replay as unknown as FinanceCommandResult), idempotent_replay: true };
+    }
+    const avoir = await lockAvoir(client, params.avoirId);
+    if (!avoir) throw new HttpError(404, "AVOIR_NOT_FOUND", "Avoir introuvable.");
+    if (avoir.statut !== params.expectedStatus || avoir.row_version !== params.input.expected_version) {
+      throw new HttpError(409, "AVOIR_CONCURRENT_MODIFICATION", "L'avoir a changé.");
+    }
+    if (avoir.preview_hash !== params.input.preview_hash) {
+      throw new HttpError(409, "AVOIR_PREVIEW_CHANGED", "L'aperçu de l'avoir a changé.");
+    }
+    assertAvoirTransition(avoir.statut, params.targetStatus);
+    const updated = await client.query<{ row_version: number }>(
+      `
+        UPDATE public.avoir
+        SET statut = $2,
+            validation_requested_at = now(),
+            validation_requested_by = $3,
+            row_version = row_version + 1,
+            updated_at = now()
+        WHERE id = $1
+        RETURNING row_version
+      `,
+      [params.avoirId, params.targetStatus, params.actor.userId]
+    );
+    const correlationId = newCorrelationId();
+    const result: FinanceCommandResult = {
+      id: avoir.id,
+      uuid: avoir.uuid,
+      draft_reference: avoir.draft_reference,
+      legal_number: null,
+      status: params.targetStatus,
+      row_version: updated.rows[0]!.row_version,
+      correlation_id: correlationId,
+      idempotent_replay: false,
+    };
+    await insertFinanceEvent({
+      client,
+      aggregateType: "AVOIR",
+      aggregateId: avoir.uuid,
+      eventType: params.commandType,
+      oldValues: { status: avoir.statut },
+      newValues: { status: params.targetStatus },
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
+    });
+    await saveFinanceReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: receipt.idempotencyKey,
+      requestHash: receipt.requestHash,
+      commandType: params.commandType,
+      aggregateType: "AVOIR",
+      aggregateId: avoir.uuid,
+      requestPayload: params.input,
+      resultPayload: result,
+      correlationId,
+    });
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export function repoRequestAvoirValidation(params: {
+  avoirId: number;
+  input: WorkflowConfirmationBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}): Promise<FinanceCommandResult> {
+  return transitionAvoir({
+    ...params,
+    commandType: "AVOIR_REQUEST_VALIDATION",
+    expectedStatus: "DRAFT",
+    targetStatus: "PENDING_VALIDATION",
+  });
+}
+
+export async function repoValidateAvoir(params: {
+  avoirId: number;
+  input: ValidationDecisionBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}): Promise<FinanceCommandResult> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const commandType = params.input.decision === "APPROVE" ? "AVOIR_APPROVE" : "AVOIR_RETURN";
+    const receipt = await acquireFinanceIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType,
+      requestPayload: { avoir_id: params.avoirId, ...params.input },
+    });
+    if (receipt.replay) {
+      await client.query("COMMIT");
+      return { ...(receipt.replay as unknown as FinanceCommandResult), idempotent_replay: true };
+    }
+    const avoir = await lockAvoir(client, params.avoirId);
+    if (!avoir) throw new HttpError(404, "AVOIR_NOT_FOUND", "Avoir introuvable.");
+    if (avoir.statut !== "PENDING_VALIDATION" || avoir.row_version !== params.input.expected_version) {
+      throw new HttpError(409, "AVOIR_CONCURRENT_MODIFICATION", "L'avoir a changé.");
+    }
+    if (params.input.decision === "APPROVE") {
+      assertSeparationOfDuties({
+        creatorUserId: avoir.created_by,
+        validatorUserId: params.actor.userId,
+      });
+    }
+    const target: AvoirWorkflowStatus =
+      params.input.decision === "APPROVE" ? "APPROVED" : "DRAFT";
+    assertAvoirTransition(avoir.statut, target);
+    const updated = await client.query<{ row_version: number }>(
+      `
+        UPDATE public.avoir
+        SET statut = $2,
+            approved_at = CASE WHEN $2 = 'APPROVED' THEN now() ELSE NULL END,
+            approved_by = CASE WHEN $2 = 'APPROVED' THEN $3 ELSE NULL END,
+            validation_reason = $4,
+            row_version = row_version + 1,
+            updated_at = now()
+        WHERE id = $1
+        RETURNING row_version
+      `,
+      [params.avoirId, target, params.actor.userId, params.input.reason ?? null]
+    );
+    const correlationId = newCorrelationId();
+    const result: FinanceCommandResult = {
+      id: avoir.id,
+      uuid: avoir.uuid,
+      draft_reference: avoir.draft_reference,
+      legal_number: null,
+      status: target,
+      row_version: updated.rows[0]!.row_version,
+      correlation_id: correlationId,
+      idempotent_replay: false,
+    };
+    await insertFinanceEvent({
+      client,
+      aggregateType: "AVOIR",
+      aggregateId: avoir.uuid,
+      eventType: commandType,
+      oldValues: { status: avoir.statut },
+      newValues: { status: target },
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
+      reason: params.input.reason,
+    });
+    await saveFinanceReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: receipt.idempotencyKey,
+      requestHash: receipt.requestHash,
+      commandType,
+      aggregateType: "AVOIR",
+      aggregateId: avoir.uuid,
+      requestPayload: params.input,
+      resultPayload: result,
+      correlationId,
+    });
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoIssueAvoir(params: {
+  avoirId: number;
+  input: WorkflowConfirmationBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+  writeDocument: AvoirDocumentWriter;
+}): Promise<FinanceCommandResult> {
+  const client = await pool.connect();
+  let artifact: AvoirDocumentArtifact | null = null;
+  try {
+    await client.query("BEGIN");
+    const receipt = await acquireFinanceIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "AVOIR_ISSUE",
+      requestPayload: { avoir_id: params.avoirId, ...params.input },
+    });
+    if (receipt.replay) {
+      await client.query("COMMIT");
+      return { ...(receipt.replay as unknown as FinanceCommandResult), idempotent_replay: true };
+    }
+    const avoir = await lockAvoir(client, params.avoirId);
+    if (!avoir) throw new HttpError(404, "AVOIR_NOT_FOUND", "Avoir introuvable.");
+    if (avoir.statut !== "APPROVED" || avoir.row_version !== params.input.expected_version) {
+      throw new HttpError(409, "AVOIR_NOT_APPROVED", "L'avoir doit être validé avant émission.");
+    }
+    const savedInput = await savedAvoirInput(client, params.avoirId);
+    const preview = await buildAvoirPreview(savedInput, client, true);
+    if (
+      preview.preview_hash !== params.input.preview_hash ||
+      preview.preview_hash !== avoir.preview_hash
+    ) {
+      throw new HttpError(409, "AVOIR_PREVIEW_CHANGED", "L'aperçu de l'avoir a changé.");
+    }
+    const policy = await client.query<{ policy_version: string; require_distinct_issuer: boolean }>(
+      `
+        SELECT policy_version, require_distinct_issuer
+        FROM public.finance_billing_policies
+        WHERE active = TRUE
+          AND effective_from <= CURRENT_DATE
+          AND (effective_to IS NULL OR effective_to >= CURRENT_DATE)
+        ORDER BY effective_from DESC, created_at DESC
+        LIMIT 1
+      `
+    );
+    const activePolicy = policy.rows[0];
+    if (!activePolicy) {
+      throw new HttpError(503, "BILLING_POLICY_NOT_ACTIVE", "Politique Finance absente.");
+    }
+    if (
+      activePolicy.require_distinct_issuer &&
+      avoir.approved_by !== null &&
+      avoir.approved_by === params.actor.userId
+    ) {
+      throw new HttpError(
+        403,
+        "FINANCE_ISSUER_VALIDATOR_CONFLICT",
+        "La politique active impose un émetteur distinct du valideur."
+      );
+    }
+    const issueDate = new Date().toISOString().slice(0, 10);
+    const legal = await allocateLegalNumber({
+      client,
+      documentType: "AVOIR",
+      entityCode: avoir.legal_entity_code,
+      issueDate,
+    });
+    const snapshot: AvoirDocumentSnapshot = {
+      document_type: "AVOIR",
+      uuid: avoir.uuid,
+      draft_reference: avoir.draft_reference,
+      legal_number: legal.legalNumber,
+      issue_date: issueDate,
+      facture_id: preview.facture_id,
+      facture_number: preview.facture_number,
+      currency: preview.currency,
+      client_snapshot: avoir.client_snapshot,
+      issuer_snapshot: avoir.issuer_snapshot,
+      reason_code: preview.reason_code,
+      reason: preview.reason,
+      lines: preview.lines,
+      totals: preview.totals,
+    };
+    artifact = await params.writeDocument(snapshot);
+    const correlationId = newCorrelationId();
+    await client.query(
+      `
+        UPDATE public.avoir_source_allocations
+        SET allocation_status = 'CONSUMED',
+            quantity_credited = quantity_selected,
+            consumed_at = now(),
+            consumed_by = $2
+        WHERE avoir_id = $1
+          AND allocation_status = 'DRAFT'
+      `,
+      [params.avoirId, params.actor.userId]
+    );
+    const updated = await client.query<{ row_version: number }>(
+      `
+        UPDATE public.avoir
+        SET numero = $2,
+            legal_number = $2,
+            legal_period = $3,
+            legal_sequence_value = $4,
+            date_emission = $5::date,
+            statut = 'ISSUED',
+            issued_at = now(),
+            issued_by = $6,
+            immutable_snapshot = $7::jsonb,
+            document_checksum_sha256 = $8,
+            row_version = row_version + 1,
+            updated_at = now()
+        WHERE id = $1
+        RETURNING row_version
+      `,
+      [
+        params.avoirId,
+        legal.legalNumber,
+        legal.periodKey,
+        legal.sequenceValue,
+        issueDate,
+        params.actor.userId,
+        JSON.stringify(snapshot),
+        artifact.checksumSha256,
+      ]
+    );
+    await client.query(
+      `INSERT INTO public.documents_clients (id, document_name, type) VALUES ($1::uuid,$2,'PDF')`,
+      [artifact.documentId, artifact.fileName]
+    );
+    await client.query(
+      `INSERT INTO public.avoir_documents (avoir_id, document_id, type) VALUES ($1,$2::uuid,'LEGAL_PDF')`,
+      [params.avoirId, artifact.documentId]
+    );
+    await client.query(
+      `
+        INSERT INTO public.finance_document_versions (
+          aggregate_type, aggregate_id, document_id, version, status,
+          checksum_sha256, file_size_bytes, mime_type, snapshot_json,
+          created_by, correlation_id
+        )
+        VALUES ('AVOIR',$1,$2::uuid,1,'ISSUED',$3,$4,'application/pdf',$5::jsonb,$6,$7::uuid)
+      `,
+      [
+        avoir.uuid,
+        artifact.documentId,
+        artifact.checksumSha256,
+        artifact.fileSizeBytes,
+        JSON.stringify(snapshot),
+        params.actor.userId,
+        correlationId,
+      ]
+    );
+    const result: FinanceCommandResult = {
+      id: avoir.id,
+      uuid: avoir.uuid,
+      draft_reference: avoir.draft_reference,
+      legal_number: legal.legalNumber,
+      status: "ISSUED",
+      row_version: updated.rows[0]!.row_version,
+      correlation_id: correlationId,
+      idempotent_replay: false,
+    };
+    await insertFinanceEvent({
+      client,
+      aggregateType: "AVOIR",
+      aggregateId: avoir.uuid,
+      eventType: "AVOIR_ISSUED",
+      oldValues: { status: avoir.statut },
+      newValues: { status: "ISSUED", legal_number: legal.legalNumber },
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
+      ruleCode: activePolicy.policy_version,
+      reason: preview.reason,
+    });
+    await insertFinanceOutbox({
+      client,
+      eventKey: `finance.avoir.issued:${avoir.uuid}`,
+      aggregateType: "AVOIR",
+      aggregateId: avoir.uuid,
+      eventType: "FINANCE.CREDIT_NOTE_ISSUED",
+      payload: {
+        avoir_uuid: avoir.uuid,
+        facture_id: preview.facture_id,
+        legal_number: legal.legalNumber,
+        total_incl_tax: preview.totals.total_incl_tax,
+        currency: preview.currency,
+        correlation_id: correlationId,
+      },
+      correlationId,
+    });
+    await insertGlobalFinanceAudit({
+      client,
+      actor: params.actor,
+      action: "facturation.avoir_issued",
+      entityType: "avoir",
+      entityId: avoir.uuid,
+      details: { facture_id: preview.facture_id, legal_number: legal.legalNumber, correlation_id: correlationId },
+    });
+    await saveFinanceReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: receipt.idempotencyKey,
+      requestHash: receipt.requestHash,
+      commandType: "AVOIR_ISSUE",
+      aggregateType: "AVOIR",
+      aggregateId: avoir.uuid,
+      requestPayload: params.input,
+      resultPayload: result,
+      correlationId,
+    });
+    await client.query("COMMIT");
+    artifact = null;
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    if (artifact) await artifact.cleanup().catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/src/module/facturation/repository/facture-workflow.repository.ts
+++ b/src/module/facturation/repository/facture-workflow.repository.ts
@@ -1,0 +1,1289 @@
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import {
+  assertFactureTransition,
+  assertSeparationOfDuties,
+  financePreviewHash,
+  type FactureWorkflowStatus,
+} from "../domain/finance-policy";
+import {
+  computeExactDocumentTotals,
+  computeExactLineTotals,
+  moneyToCents,
+  parseDecimal,
+} from "../domain/decimal-money";
+import type {
+  EligibleDeliverySource,
+  FacturePreview,
+  FacturePreviewLine,
+  FinanceBlocker,
+  FinanceCommandResult,
+} from "../types/workflow.types";
+import type {
+  CreateFactureDraftBodyDTO,
+  EligibleSourcesQueryDTO,
+  FacturePreviewBodyDTO,
+  ValidationDecisionBodyDTO,
+  WorkflowConfirmationBodyDTO,
+} from "../validators/workflow.validators";
+import {
+  acquireFinanceIdempotency,
+  allocateLegalNumber,
+  type DbQueryer,
+  type FinanceActorContext,
+  insertFinanceEvent,
+  insertFinanceOutbox,
+  insertGlobalFinanceAudit,
+  newCorrelationId,
+  nextLegacyId,
+  saveFinanceReceipt,
+} from "./workflow.repository.shared";
+
+type BillingPolicyRow = {
+  policy_version: string;
+  legal_entity_code: string;
+  eligible_delivery_statuses: string[];
+  require_distinct_issuer: boolean;
+  active: boolean;
+};
+
+type DeliverySourceRow = {
+  source_id: string;
+  source_line_id: string;
+  delivery_number: string;
+  delivery_status: "SHIPPED" | "DELIVERED";
+  client_id: string;
+  client_name: string;
+  client_blocked: boolean;
+  commande_id: string | null;
+  affaire_id: string | null;
+  commande_line_id: string | null;
+  designation: string;
+  code_piece: string | null;
+  unit: string | null;
+  quantity_source: string;
+  quantity_already_invoiced: string;
+  quantity_already_credited: string;
+  unit_price_ex_tax: string | null;
+  discount_percent: string | null;
+  tax_rate_percent: string | null;
+  pricing_version: string | null;
+};
+
+export type FinanceDocumentSnapshot = {
+  document_type: "FACTURE";
+  uuid: string;
+  draft_reference: string;
+  legal_number: string;
+  issue_date: string;
+  due_dates: Array<{ due_date: string; label: string; amount: string }>;
+  currency: string;
+  client_snapshot: Record<string, unknown>;
+  issuer_snapshot: Record<string, unknown>;
+  lines: FacturePreviewLine[];
+  totals: FacturePreview["totals"];
+  internal_comment: string | null;
+  customer_text: string | null;
+};
+
+export type FinanceDocumentArtifact = {
+  documentId: string;
+  fileName: string;
+  checksumSha256: string;
+  fileSizeBytes: number;
+  cleanup: () => Promise<void>;
+};
+
+export type FinanceDocumentWriter = (
+  snapshot: FinanceDocumentSnapshot
+) => Promise<FinanceDocumentArtifact>;
+
+async function loadActiveBillingPolicy(queryer: DbQueryer): Promise<BillingPolicyRow | null> {
+  const result = await queryer.query<BillingPolicyRow>(
+    `
+      SELECT
+        policy_version,
+        legal_entity_code,
+        eligible_delivery_statuses,
+        require_distinct_issuer,
+        active
+      FROM public.finance_billing_policies
+      WHERE active = TRUE
+        AND effective_from <= CURRENT_DATE
+        AND (effective_to IS NULL OR effective_to >= CURRENT_DATE)
+      ORDER BY effective_from DESC, created_at DESC
+      LIMIT 1
+    `
+  );
+  return result.rows[0] ?? null;
+}
+
+function listWhere(filters: EligibleSourcesQueryDTO): { sql: string; values: unknown[] } {
+  const where = [`bl.statut IN ('SHIPPED','DELIVERED')`];
+  const values: unknown[] = [];
+  const push = (value: unknown) => {
+    values.push(value);
+    return `$${values.length}`;
+  };
+  if (filters.client_id) where.push(`bl.client_id = ${push(filters.client_id)}`);
+  if (filters.commande_id) where.push(`bl.commande_id = ${push(filters.commande_id)}::bigint`);
+  if (filters.affaire_id) where.push(`bl.affaire_id = ${push(filters.affaire_id)}::bigint`);
+  if (filters.q) {
+    const parameter = push(`%${filters.q}%`);
+    where.push(`(
+      bl.numero ILIKE ${parameter}
+      OR c.company_name ILIKE ${parameter}
+      OR bll.designation ILIKE ${parameter}
+      OR COALESCE(bll.code_piece, '') ILIKE ${parameter}
+    )`);
+  }
+  return { sql: `WHERE ${where.join(" AND ")}`, values };
+}
+
+const DELIVERY_SOURCE_SELECT = `
+  SELECT
+    bl.id::text AS source_id,
+    bll.id::text AS source_line_id,
+    bl.numero AS delivery_number,
+    bl.statut AS delivery_status,
+    bl.client_id,
+    c.company_name AS client_name,
+    COALESCE(c.blocked, FALSE) AS client_blocked,
+    bl.commande_id::text AS commande_id,
+    bl.affaire_id::text AS affaire_id,
+    bll.commande_ligne_id::text AS commande_line_id,
+    bll.designation,
+    bll.code_piece,
+    bll.unite AS unit,
+    bll.quantite::text AS quantity_source,
+    COALESCE(invoiced.quantity, 0)::numeric(18,3)::text AS quantity_already_invoiced,
+    COALESCE(credited.quantity, 0)::numeric(18,3)::text AS quantity_already_credited,
+    cl.prix_unitaire_ht::numeric(18,4)::text AS unit_price_ex_tax,
+    COALESCE(cl.remise_ligne, 0)::numeric(9,4)::text AS discount_percent,
+    COALESCE(cl.taux_tva, 0)::numeric(9,4)::text AS tax_rate_percent,
+    CASE
+      WHEN cl.id IS NULL THEN NULL
+      ELSE concat('COMMANDE_LINE:', cl.id::text, ':', COALESCE(cl.updated_at::text, 'unknown'))
+    END AS pricing_version
+  FROM public.bon_livraison_ligne bll
+  JOIN public.bon_livraison bl ON bl.id = bll.bon_livraison_id
+  JOIN public.clients c ON c.client_id = bl.client_id
+  LEFT JOIN public.commande_ligne cl ON cl.id = bll.commande_ligne_id
+  LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(source.quantity_consumed), 0) AS quantity
+    FROM public.facture_source_allocations source
+    WHERE source.source_type = 'DELIVERY_LINE'
+      AND source.source_line_id = bll.id::text
+      AND source.allocation_status = 'CONSUMED'
+  ) invoiced ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT COALESCE(SUM(source.quantity_credited), 0) AS quantity
+    FROM public.avoir_source_allocations source
+    WHERE source.source_type = 'DELIVERY_LINE'
+      AND source.source_line_id = bll.id::text
+      AND source.allocation_status = 'CONSUMED'
+  ) credited ON TRUE
+`;
+
+function sourceBlockers(
+  row: DeliverySourceRow,
+  policy: BillingPolicyRow | null
+): FinanceBlocker[] {
+  const blockers: FinanceBlocker[] = [];
+  if (!policy) {
+    blockers.push({
+      code: "BILLING_POLICY_NOT_ACTIVE",
+      message: "Aucune politique de facturation Finance validée n'est active.",
+      source_line_id: row.source_line_id,
+    });
+  } else if (!policy.eligible_delivery_statuses.includes(row.delivery_status)) {
+    blockers.push({
+      code: "DELIVERY_STATUS_NOT_ELIGIBLE",
+      message: `Le statut ${row.delivery_status} n'est pas autorisé par la politique ${policy.policy_version}.`,
+      source_line_id: row.source_line_id,
+    });
+  }
+  if (row.client_blocked) {
+    blockers.push({
+      code: "CLIENT_BLOCKED",
+      message: "Le client est bloqué.",
+      source_line_id: row.source_line_id,
+    });
+  }
+  if (!row.commande_line_id || row.unit_price_ex_tax === null) {
+    blockers.push({
+      code: "PRICING_SOURCE_MISSING",
+      message: "La ligne de commande et son prix contractuel sont requis.",
+      source_line_id: row.source_line_id,
+    });
+  }
+  const source = parseDecimal(row.quantity_source, 3, "Quantité source");
+  const invoiced = parseDecimal(row.quantity_already_invoiced, 3, "Quantité facturée");
+  if (source - invoiced <= 0n) {
+    blockers.push({
+      code: "SOURCE_FULLY_INVOICED",
+      message: "La ligne de livraison est déjà intégralement facturée.",
+      source_line_id: row.source_line_id,
+    });
+  }
+  return blockers;
+}
+
+function mapEligibleSource(
+  row: DeliverySourceRow,
+  policy: BillingPolicyRow | null
+): EligibleDeliverySource {
+  const remaining =
+    parseDecimal(row.quantity_source, 3, "Quantité source") -
+    parseDecimal(row.quantity_already_invoiced, 3, "Quantité facturée");
+  return {
+    source_type: "DELIVERY_LINE",
+    source_id: row.source_id,
+    source_line_id: row.source_line_id,
+    delivery_number: row.delivery_number,
+    delivery_status: row.delivery_status,
+    client_id: row.client_id,
+    client_name: row.client_name,
+    commande_id: row.commande_id ? Number.parseInt(row.commande_id, 10) : null,
+    affaire_id: row.affaire_id ? Number.parseInt(row.affaire_id, 10) : null,
+    commande_line_id: row.commande_line_id ? Number.parseInt(row.commande_line_id, 10) : null,
+    designation: row.designation,
+    code_piece: row.code_piece,
+    unit: row.unit,
+    quantity_source: row.quantity_source,
+    quantity_already_invoiced: row.quantity_already_invoiced,
+    quantity_already_credited: row.quantity_already_credited,
+    quantity_remaining: remaining > 0n ? `${remaining / 1000n}.${(remaining % 1000n).toString().padStart(3, "0")}` : "0.000",
+    unit_price_ex_tax: row.unit_price_ex_tax,
+    discount_percent: row.discount_percent,
+    tax_rate_percent: row.tax_rate_percent,
+    pricing_version: row.pricing_version,
+    rule_code: policy ? `DELIVERY_${row.delivery_status}:${policy.policy_version}` : "POLICY_REQUIRED",
+    blockers: sourceBlockers(row, policy),
+  };
+}
+
+export async function repoListEligibleFactureSources(
+  filters: EligibleSourcesQueryDTO
+): Promise<{ items: EligibleDeliverySource[]; total: number; policy_active: boolean }> {
+  const policy = await loadActiveBillingPolicy(pool);
+  const { sql, values } = listWhere(filters);
+  const page = filters.page ?? 1;
+  const pageSize = filters.pageSize ?? 25;
+  const count = await pool.query<{ total: number }>(
+    `
+      SELECT COUNT(*)::int AS total
+      FROM public.bon_livraison_ligne bll
+      JOIN public.bon_livraison bl ON bl.id = bll.bon_livraison_id
+      JOIN public.clients c ON c.client_id = bl.client_id
+      ${sql}
+    `,
+    values
+  );
+  const result = await pool.query<DeliverySourceRow>(
+    `
+      ${DELIVERY_SOURCE_SELECT}
+      ${sql}
+      ORDER BY bl.date_expedition DESC NULLS LAST, bl.numero DESC, bll.ordre, bll.id
+      LIMIT $${values.length + 1}
+      OFFSET $${values.length + 2}
+    `,
+    [...values, pageSize, (page - 1) * pageSize]
+  );
+  return {
+    items: result.rows.map((row) => mapEligibleSource(row, policy)),
+    total: count.rows[0]?.total ?? 0,
+    policy_active: Boolean(policy),
+  };
+}
+
+async function loadSelectedDeliverySources(
+  queryer: DbQueryer,
+  sourceLineIds: string[],
+  lock: boolean
+): Promise<DeliverySourceRow[]> {
+  if (!sourceLineIds.length) return [];
+  const result = await queryer.query<DeliverySourceRow>(
+    `
+      ${DELIVERY_SOURCE_SELECT}
+      WHERE bll.id = ANY($1::uuid[])
+        AND bl.statut IN ('SHIPPED','DELIVERED')
+      ORDER BY bll.id
+      ${lock ? "FOR UPDATE OF bll" : ""}
+    `,
+    [sourceLineIds]
+  );
+  return result.rows;
+}
+
+function assertDueDates(preview: FacturePreview): void {
+  if (preview.due_dates.some((due) => !due.amount)) return;
+  const dueTotal = preview.due_dates.reduce(
+    (sum, due) => sum + moneyToCents(due.amount, "Montant d'échéance"),
+    0n
+  );
+  const invoiceTotal = moneyToCents(preview.totals.total_incl_tax, "Total TTC");
+  if (dueTotal !== invoiceTotal) {
+    preview.blockers.push({
+      code: "DUE_DATES_TOTAL_MISMATCH",
+      message: "La somme des échéances doit être exactement égale au total TTC.",
+    });
+  }
+}
+
+async function buildFacturePreview(
+  queryer: DbQueryer,
+  input: FacturePreviewBodyDTO,
+  lock: boolean
+): Promise<{ preview: FacturePreview; policy: BillingPolicyRow | null; sources: DeliverySourceRow[] }> {
+  const unsupported = input.sources.filter((source) => source.source_type !== "DELIVERY_LINE");
+  const sourceLineIds = input.sources
+    .filter((source) => source.source_type === "DELIVERY_LINE")
+    .map((source) => source.source_line_id);
+  if (new Set(sourceLineIds).size !== sourceLineIds.length) {
+    throw new HttpError(422, "DUPLICATE_SOURCE_LINE", "Une ligne source ne peut apparaître qu'une fois.");
+  }
+  const policy = await loadActiveBillingPolicy(queryer);
+  const rows = await loadSelectedDeliverySources(queryer, sourceLineIds, lock);
+  const byId = new Map(rows.map((row) => [row.source_line_id, row]));
+  const blockers: FinanceBlocker[] = unsupported.map((source) => ({
+    code: "SOURCE_TYPE_NOT_ENABLED",
+    message: `${source.source_type} reste désactivé jusqu'à validation Finance de sa règle contractuelle.`,
+    source_line_id: source.source_line_id,
+  }));
+  const lines: FacturePreviewLine[] = [];
+
+  for (const selection of input.sources) {
+    if (selection.source_type !== "DELIVERY_LINE") continue;
+    const row = byId.get(selection.source_line_id);
+    if (!row || row.source_id !== selection.source_id) {
+      blockers.push({
+        code: "SOURCE_NOT_FOUND",
+        message: "La source facturable n'existe plus ou ne correspond pas au BL.",
+        source_line_id: selection.source_line_id,
+      });
+      continue;
+    }
+    blockers.push(...sourceBlockers(row, policy));
+    if (row.client_id !== input.client_id) {
+      blockers.push({
+        code: "SOURCE_CLIENT_MISMATCH",
+        message: "Toutes les sources doivent appartenir au client facturé.",
+        source_line_id: row.source_line_id,
+      });
+    }
+    const selectedQuantity = parseDecimal(selection.quantity, 3, "Quantité sélectionnée");
+    const sourceQuantity = parseDecimal(row.quantity_source, 3, "Quantité source");
+    const invoicedQuantity = parseDecimal(row.quantity_already_invoiced, 3, "Quantité facturée");
+    if (selectedQuantity > sourceQuantity - invoicedQuantity) {
+      blockers.push({
+        code: "SOURCE_QUANTITY_EXCEEDED",
+        message: "La quantité sélectionnée dépasse le reliquat facturable.",
+        source_line_id: row.source_line_id,
+      });
+    }
+    if (!row.unit_price_ex_tax || row.discount_percent === null || row.tax_rate_percent === null) continue;
+    const exact = computeExactLineTotals({
+      quantity: selection.quantity,
+      unitPriceExTax: row.unit_price_ex_tax,
+      discountPercent: row.discount_percent,
+      taxRatePercent: row.tax_rate_percent,
+    });
+    lines.push({
+      source_type: "DELIVERY_LINE",
+      source_id: row.source_id,
+      source_line_id: row.source_line_id,
+      designation: row.designation,
+      code_piece: row.code_piece,
+      quantity: selection.quantity,
+      unit: row.unit,
+      unit_price_ex_tax: row.unit_price_ex_tax,
+      discount_percent: row.discount_percent,
+      tax_rate_percent: row.tax_rate_percent,
+      total_ex_tax: exact.totalExTax,
+      tax_amount: exact.taxAmount,
+      total_incl_tax: exact.totalInclTax,
+      pricing_version: row.pricing_version,
+      rule_code: policy ? `DELIVERY_${row.delivery_status}:${policy.policy_version}` : "POLICY_REQUIRED",
+    });
+  }
+
+  const totals = computeExactDocumentTotals(
+    lines.map((line) => ({
+      quantity: line.quantity,
+      unitPriceExTax: line.unit_price_ex_tax,
+      discountPercent: line.discount_percent,
+      taxRatePercent: line.tax_rate_percent,
+    })),
+    input.global_discount_percent
+  );
+  const dueDates = input.due_dates.map((due) => ({
+    ...due,
+    amount:
+      due.amount ??
+      (input.due_dates.length === 1 ? totals.totalInclTax : ""),
+  }));
+  if (dueDates.some((due) => !due.amount)) {
+    blockers.push({
+      code: "DUE_DATE_AMOUNT_REQUIRED",
+      message: "Chaque montant est requis lorsqu'un échéancier comporte plusieurs échéances.",
+    });
+  }
+  const previewWithoutHash: Omit<FacturePreview, "preview_hash"> = {
+    preview_version: 1,
+    client_id: input.client_id,
+    currency: input.currency,
+    lines,
+    totals: {
+      subtotal_ex_tax: totals.subtotalExTax,
+      global_discount_percent: totals.discountPercent,
+      global_discount_amount: totals.discountAmount,
+      total_ex_tax: totals.totalExTax,
+      total_tax: totals.totalTax,
+      total_incl_tax: totals.totalInclTax,
+    },
+    due_dates: dueDates,
+    blockers,
+    warnings: [
+      {
+        code: "FINANCE_LEGAL_VALIDATION_REQUIRED",
+        message:
+          "La fiscalité, les mentions, la séquence et l'archivage restent soumis à validation Finance/Juridique avant production.",
+      },
+    ],
+  };
+  const preview: FacturePreview = {
+    ...previewWithoutHash,
+    preview_hash: financePreviewHash(previewWithoutHash),
+  };
+  assertDueDates(preview);
+  if (preview.blockers.length) {
+    preview.preview_hash = financePreviewHash({
+      ...previewWithoutHash,
+      blockers: preview.blockers,
+    });
+  }
+  return { preview, policy, sources: rows };
+}
+
+export async function repoPreviewFacture(input: FacturePreviewBodyDTO): Promise<FacturePreview> {
+  return (await buildFacturePreview(pool, input, false)).preview;
+}
+
+async function clientSnapshot(queryer: DbQueryer, clientId: string): Promise<Record<string, unknown>> {
+  const result = await queryer.query<Record<string, unknown>>(
+    `
+      SELECT jsonb_build_object(
+        'client_id', c.client_id,
+        'company_name', c.company_name,
+        'siret', c.siret,
+        'vat_number', c.vat_number,
+        'billing_address', jsonb_build_object(
+          'name', af.name,
+          'street', af.street,
+          'house_number', af.house_number,
+          'address_complement', af.address_complement,
+          'postal_code', af.postal_code,
+          'city', af.city,
+          'country', af.country
+        )
+      ) AS snapshot
+      FROM public.clients c
+      LEFT JOIN public.adresse_facturation af ON af.bill_address_id = c.bill_address_id
+      WHERE c.client_id = $1
+    `,
+    [clientId]
+  );
+  const snapshot = result.rows[0]?.snapshot;
+  if (!snapshot || typeof snapshot !== "object") {
+    throw new HttpError(404, "CLIENT_NOT_FOUND", "Client introuvable.");
+  }
+  return snapshot as Record<string, unknown>;
+}
+
+async function issuerSnapshot(queryer: DbQueryer, entityCode: string): Promise<Record<string, unknown>> {
+  const result = await queryer.query<Record<string, unknown>>(
+    `
+      SELECT jsonb_build_object(
+        'entity_code', $1::text,
+        'biller_id', f.biller_id,
+        'biller_name', f.biller_name
+      ) AS snapshot
+      FROM public.factureur f
+      WHERE f.biller_id::text = $1
+      LIMIT 1
+    `,
+    [entityCode]
+  );
+  const snapshot = result.rows[0]?.snapshot;
+  if (!snapshot || typeof snapshot !== "object") {
+    throw new HttpError(
+      503,
+      "FINANCE_ISSUER_NOT_CONFIGURED",
+      "L'entité émettrice de la politique Finance est introuvable."
+    );
+  }
+  return snapshot as Record<string, unknown>;
+}
+
+function ensurePreviewUsable(preview: FacturePreview, expectedHash: string): void {
+  if (preview.preview_hash !== expectedHash) {
+    throw new HttpError(
+      409,
+      "FACTURE_PREVIEW_CHANGED",
+      "Les sources, tarifs, taxes ou échéances ont changé depuis l'aperçu.",
+      { preview }
+    );
+  }
+  if (preview.blockers.length) {
+    throw new HttpError(422, "FACTURE_PREVIEW_BLOCKED", "Le brouillon est bloqué.", {
+      blockers: preview.blockers,
+    });
+  }
+}
+
+export async function repoCreateFactureDraft(params: {
+  input: CreateFactureDraftBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}): Promise<FinanceCommandResult> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const receipt = await acquireFinanceIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "FACTURE_DRAFT_CREATE",
+      requestPayload: params.input,
+    });
+    if (receipt.replay) {
+      await client.query("COMMIT");
+      return { ...(receipt.replay as unknown as FinanceCommandResult), idempotent_replay: true };
+    }
+    const { preview_hash: expectedPreviewHash, ...previewInput } = params.input;
+    const { preview, policy, sources } = await buildFacturePreview(client, previewInput, true);
+    ensurePreviewUsable(preview, expectedPreviewHash);
+    if (!policy) throw new HttpError(503, "BILLING_POLICY_NOT_ACTIVE", "Politique Finance absente.");
+
+    const factureId = await nextLegacyId(client, "facture_id_seq");
+    const uuidResult = await client.query<{ uuid: string }>("SELECT gen_random_uuid()::text AS uuid");
+    const uuid = uuidResult.rows[0]?.uuid;
+    if (!uuid) throw new Error("Failed to allocate facture uuid");
+    const year = new Date().getUTCFullYear();
+    const draftReference = `DFT-${year}-${String(factureId).padStart(6, "0")}`;
+    const clientData = await clientSnapshot(client, params.input.client_id);
+    const issuerData = await issuerSnapshot(client, policy.legal_entity_code);
+    const commandeIds = [...new Set(sources.map((row) => row.commande_id).filter(Boolean))];
+    const affaireIds = [...new Set(sources.map((row) => row.affaire_id).filter(Boolean))];
+    const dueDate = [...params.input.due_dates].sort((a, b) => a.due_date.localeCompare(b.due_date)).at(-1);
+
+    await client.query(
+      `
+        INSERT INTO public.facture (
+          id, uuid, numero, draft_reference, legal_number, client_id,
+          commande_id, affaire_id, date_emission, date_echeance, statut,
+          remise_globale, total_ht, total_ttc, total_tax, currency,
+          commentaires, customer_text, row_version, preview_hash,
+          policy_version, legal_entity_code, client_snapshot, issuer_snapshot,
+          created_by
+        )
+        VALUES (
+          $1,$2::uuid,$3,$3,NULL,$4,
+          $5::bigint,$6::bigint,CURRENT_DATE,$7::date,'DRAFT',
+          $8,$9,$10,$11,$12,
+          $13,$14,1,$15,
+          $16,$17,$18::jsonb,$19::jsonb,
+          $20
+        )
+      `,
+      [
+        factureId,
+        uuid,
+        draftReference,
+        params.input.client_id,
+        commandeIds.length === 1 ? commandeIds[0] : null,
+        affaireIds.length === 1 ? affaireIds[0] : null,
+        dueDate?.due_date ?? null,
+        preview.totals.global_discount_percent,
+        preview.totals.total_ex_tax,
+        preview.totals.total_incl_tax,
+        preview.totals.total_tax,
+        params.input.currency,
+        params.input.internal_comment ?? null,
+        params.input.customer_text ?? null,
+        preview.preview_hash,
+        policy.policy_version,
+        policy.legal_entity_code,
+        JSON.stringify(clientData),
+        JSON.stringify(issuerData),
+        params.actor.userId,
+      ]
+    );
+
+    for (let index = 0; index < preview.lines.length; index += 1) {
+      const line = preview.lines[index];
+      const lineInsert = await client.query<{ id: string }>(
+        `
+          INSERT INTO public.facture_ligne (
+            facture_id, ordre, designation, code_piece, quantite, unite,
+            prix_unitaire_ht, remise_ligne, taux_tva, total_ht, total_ttc,
+            tax_amount, snapshot_json
+          )
+          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13::jsonb)
+          RETURNING id::text AS id
+        `,
+        [
+          factureId,
+          index + 1,
+          line.designation,
+          line.code_piece,
+          line.quantity,
+          line.unit,
+          line.unit_price_ex_tax,
+          line.discount_percent,
+          line.tax_rate_percent,
+          line.total_ex_tax,
+          line.total_incl_tax,
+          line.tax_amount,
+          JSON.stringify(line),
+        ]
+      );
+      const factureLineId = lineInsert.rows[0]?.id;
+      if (!factureLineId) throw new Error("Failed to insert facture line");
+      await client.query(
+        `
+          INSERT INTO public.facture_source_allocations (
+            facture_id, facture_line_id, source_type, source_id, source_line_id,
+            quantity_selected, quantity_consumed, amount_ex_tax, amount_incl_tax,
+            allocation_status, source_snapshot, rule_code, created_by
+          )
+          VALUES ($1,$2,$3,$4,$5,$6,0,$7,$8,'DRAFT',$9::jsonb,$10,$11)
+        `,
+        [
+          factureId,
+          factureLineId,
+          line.source_type,
+          line.source_id,
+          line.source_line_id,
+          line.quantity,
+          line.total_ex_tax,
+          line.total_incl_tax,
+          JSON.stringify(line),
+          line.rule_code,
+          params.actor.userId,
+        ]
+      );
+    }
+    for (const due of preview.due_dates) {
+      await client.query(
+        `
+          INSERT INTO public.facture_echeance (
+            facture_id, due_date, label, amount_due, status, created_by
+          )
+          VALUES ($1,$2::date,$3,$4,'OPEN',$5)
+        `,
+        [factureId, due.due_date, due.label, due.amount, params.actor.userId]
+      );
+    }
+    const correlationId = newCorrelationId();
+    const result: FinanceCommandResult = {
+      id: factureId,
+      uuid,
+      draft_reference: draftReference,
+      legal_number: null,
+      status: "DRAFT",
+      row_version: 1,
+      correlation_id: correlationId,
+      idempotent_replay: false,
+    };
+    await insertFinanceEvent({
+      client,
+      aggregateType: "FACTURE",
+      aggregateId: uuid,
+      eventType: "FACTURE_DRAFT_CREATED",
+      newValues: { preview_hash: preview.preview_hash, source_count: preview.lines.length },
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
+      ruleCode: policy.policy_version,
+    });
+    await insertGlobalFinanceAudit({
+      client,
+      actor: params.actor,
+      action: "facturation.facture_draft_created",
+      entityType: "facture",
+      entityId: uuid,
+      details: { facture_id: factureId, draft_reference: draftReference, correlation_id: correlationId },
+    });
+    await saveFinanceReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: receipt.idempotencyKey,
+      requestHash: receipt.requestHash,
+      commandType: "FACTURE_DRAFT_CREATE",
+      aggregateType: "FACTURE",
+      aggregateId: uuid,
+      requestPayload: params.input,
+      resultPayload: result,
+      correlationId,
+    });
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function lockFacture(
+  client: PoolClient,
+  factureId: number
+): Promise<{
+  id: number;
+  uuid: string;
+  statut: FactureWorkflowStatus;
+  row_version: number;
+  preview_hash: string;
+  created_by: number | null;
+  approved_by: number | null;
+  legal_entity_code: string;
+  draft_reference: string;
+  client_snapshot: Record<string, unknown>;
+  issuer_snapshot: Record<string, unknown>;
+  currency: string;
+  commentaires: string | null;
+  customer_text: string | null;
+} | null> {
+  const result = await client.query<{
+    id: number;
+    uuid: string;
+    statut: FactureWorkflowStatus;
+    row_version: number;
+    preview_hash: string;
+    created_by: number | null;
+    approved_by: number | null;
+    legal_entity_code: string;
+    draft_reference: string;
+    client_snapshot: Record<string, unknown>;
+    issuer_snapshot: Record<string, unknown>;
+    currency: string;
+    commentaires: string | null;
+    customer_text: string | null;
+  }>(
+    `
+      SELECT
+        id, uuid::text AS uuid, statut, row_version, preview_hash,
+        created_by, approved_by, legal_entity_code, draft_reference,
+        client_snapshot, issuer_snapshot, currency, commentaires, customer_text
+      FROM public.facture
+      WHERE id = $1
+      FOR UPDATE
+    `,
+    [factureId]
+  );
+  return result.rows[0] ?? null;
+}
+
+async function savedPreviewInput(client: PoolClient, factureId: number): Promise<FacturePreviewBodyDTO> {
+  const header = await client.query<{
+    client_id: string;
+    currency: string;
+    remise_globale: string;
+    commentaires: string | null;
+    customer_text: string | null;
+  }>(
+    `
+      SELECT client_id, currency, remise_globale::text AS remise_globale, commentaires, customer_text
+      FROM public.facture
+      WHERE id = $1
+    `,
+    [factureId]
+  );
+  const row = header.rows[0];
+  if (!row) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
+  const sources = await client.query<{
+    source_type: "DELIVERY_LINE" | "MILESTONE" | "DEPOSIT";
+    source_id: string;
+    source_line_id: string;
+    quantity: string;
+  }>(
+    `
+      SELECT source_type, source_id, source_line_id, quantity_selected::text AS quantity
+      FROM public.facture_source_allocations
+      WHERE facture_id = $1
+      ORDER BY facture_line_id, id
+    `,
+    [factureId]
+  );
+  const dueDates = await client.query<{ due_date: string; amount: string; label: string }>(
+    `
+      SELECT due_date::text AS due_date, amount_due::text AS amount, label
+      FROM public.facture_echeance
+      WHERE facture_id = $1
+      ORDER BY due_date, id
+    `,
+    [factureId]
+  );
+  return {
+    client_id: row.client_id,
+    currency: row.currency,
+    sources: sources.rows,
+    global_discount_percent: row.remise_globale,
+    due_dates: dueDates.rows,
+    internal_comment: row.commentaires,
+    customer_text: row.customer_text,
+  };
+}
+
+export async function repoRequestFactureValidation(params: {
+  factureId: number;
+  input: WorkflowConfirmationBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}): Promise<FinanceCommandResult> {
+  return transitionFacture({
+    ...params,
+    commandType: "FACTURE_REQUEST_VALIDATION",
+    expectedStatus: "DRAFT",
+    targetStatus: "PENDING_VALIDATION",
+  });
+}
+
+async function transitionFacture(params: {
+  factureId: number;
+  input: WorkflowConfirmationBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+  commandType: string;
+  expectedStatus: FactureWorkflowStatus;
+  targetStatus: FactureWorkflowStatus;
+}): Promise<FinanceCommandResult> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const receipt = await acquireFinanceIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: params.commandType,
+      requestPayload: { facture_id: params.factureId, ...params.input },
+    });
+    if (receipt.replay) {
+      await client.query("COMMIT");
+      return { ...(receipt.replay as unknown as FinanceCommandResult), idempotent_replay: true };
+    }
+    const facture = await lockFacture(client, params.factureId);
+    if (!facture) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
+    if (facture.statut !== params.expectedStatus) {
+      throw new HttpError(409, "FACTURE_STATUS_CONFLICT", "Le statut de la facture a changé.");
+    }
+    if (facture.row_version !== params.input.expected_version) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "La facture a changé.");
+    }
+    if (facture.preview_hash !== params.input.preview_hash) {
+      throw new HttpError(409, "FACTURE_PREVIEW_CHANGED", "L'aperçu de la facture a changé.");
+    }
+    assertFactureTransition(facture.statut, params.targetStatus);
+    const updated = await client.query<{ row_version: number }>(
+      `
+        UPDATE public.facture
+        SET statut = $2,
+            validation_requested_at = CASE WHEN $2 = 'PENDING_VALIDATION' THEN now() ELSE validation_requested_at END,
+            validation_requested_by = CASE WHEN $2 = 'PENDING_VALIDATION' THEN $3 ELSE validation_requested_by END,
+            row_version = row_version + 1,
+            updated_at = now()
+        WHERE id = $1
+        RETURNING row_version
+      `,
+      [params.factureId, params.targetStatus, params.actor.userId]
+    );
+    const correlationId = newCorrelationId();
+    const result: FinanceCommandResult = {
+      id: facture.id,
+      uuid: facture.uuid,
+      draft_reference: facture.draft_reference,
+      legal_number: null,
+      status: params.targetStatus,
+      row_version: updated.rows[0]?.row_version ?? facture.row_version + 1,
+      correlation_id: correlationId,
+      idempotent_replay: false,
+    };
+    await insertFinanceEvent({
+      client,
+      aggregateType: "FACTURE",
+      aggregateId: facture.uuid,
+      eventType: params.commandType,
+      oldValues: { status: facture.statut },
+      newValues: { status: params.targetStatus },
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
+    });
+    await insertGlobalFinanceAudit({
+      client,
+      actor: params.actor,
+      action: `facturation.${params.commandType.toLowerCase()}`,
+      entityType: "facture",
+      entityId: facture.uuid,
+      details: { from: facture.statut, to: params.targetStatus, correlation_id: correlationId },
+    });
+    await saveFinanceReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: receipt.idempotencyKey,
+      requestHash: receipt.requestHash,
+      commandType: params.commandType,
+      aggregateType: "FACTURE",
+      aggregateId: facture.uuid,
+      requestPayload: params.input,
+      resultPayload: result,
+      correlationId,
+    });
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoValidateFacture(params: {
+  factureId: number;
+  input: ValidationDecisionBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}): Promise<FinanceCommandResult> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const commandType = params.input.decision === "APPROVE" ? "FACTURE_APPROVE" : "FACTURE_RETURN";
+    const receipt = await acquireFinanceIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType,
+      requestPayload: { facture_id: params.factureId, ...params.input },
+    });
+    if (receipt.replay) {
+      await client.query("COMMIT");
+      return { ...(receipt.replay as unknown as FinanceCommandResult), idempotent_replay: true };
+    }
+    const facture = await lockFacture(client, params.factureId);
+    if (!facture) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
+    if (facture.statut !== "PENDING_VALIDATION") {
+      throw new HttpError(409, "FACTURE_STATUS_CONFLICT", "La facture n'attend pas de validation.");
+    }
+    if (facture.row_version !== params.input.expected_version) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "La facture a changé.");
+    }
+    if (params.input.decision === "APPROVE") {
+      assertSeparationOfDuties({
+        creatorUserId: facture.created_by,
+        validatorUserId: params.actor.userId,
+      });
+    }
+    const target: FactureWorkflowStatus = params.input.decision === "APPROVE" ? "APPROVED" : "DRAFT";
+    assertFactureTransition(facture.statut, target);
+    const updated = await client.query<{ row_version: number }>(
+      `
+        UPDATE public.facture
+        SET statut = $2,
+            approved_at = CASE WHEN $2 = 'APPROVED' THEN now() ELSE NULL END,
+            approved_by = CASE WHEN $2 = 'APPROVED' THEN $3 ELSE NULL END,
+            validation_reason = $4,
+            row_version = row_version + 1,
+            updated_at = now()
+        WHERE id = $1
+        RETURNING row_version
+      `,
+      [params.factureId, target, params.actor.userId, params.input.reason ?? null]
+    );
+    const correlationId = newCorrelationId();
+    const result: FinanceCommandResult = {
+      id: facture.id,
+      uuid: facture.uuid,
+      draft_reference: facture.draft_reference,
+      legal_number: null,
+      status: target,
+      row_version: updated.rows[0]?.row_version ?? facture.row_version + 1,
+      correlation_id: correlationId,
+      idempotent_replay: false,
+    };
+    await insertFinanceEvent({
+      client,
+      aggregateType: "FACTURE",
+      aggregateId: facture.uuid,
+      eventType: commandType,
+      oldValues: { status: facture.statut },
+      newValues: { status: target },
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
+      reason: params.input.reason,
+    });
+    await insertGlobalFinanceAudit({
+      client,
+      actor: params.actor,
+      action: `facturation.${commandType.toLowerCase()}`,
+      entityType: "facture",
+      entityId: facture.uuid,
+      details: { decision: params.input.decision, correlation_id: correlationId },
+    });
+    await saveFinanceReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: receipt.idempotencyKey,
+      requestHash: receipt.requestHash,
+      commandType,
+      aggregateType: "FACTURE",
+      aggregateId: facture.uuid,
+      requestPayload: params.input,
+      resultPayload: result,
+      correlationId,
+    });
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoIssueFacture(params: {
+  factureId: number;
+  input: WorkflowConfirmationBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+  writeDocument: FinanceDocumentWriter;
+}): Promise<FinanceCommandResult> {
+  const client = await pool.connect();
+  let artifact: FinanceDocumentArtifact | null = null;
+  try {
+    await client.query("BEGIN");
+    const receipt = await acquireFinanceIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "FACTURE_ISSUE",
+      requestPayload: { facture_id: params.factureId, ...params.input },
+    });
+    if (receipt.replay) {
+      await client.query("COMMIT");
+      return { ...(receipt.replay as unknown as FinanceCommandResult), idempotent_replay: true };
+    }
+    const facture = await lockFacture(client, params.factureId);
+    if (!facture) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
+    if (facture.statut !== "APPROVED") {
+      throw new HttpError(409, "FACTURE_NOT_APPROVED", "La facture doit être validée avant émission.");
+    }
+    if (facture.row_version !== params.input.expected_version) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "La facture a changé.");
+    }
+    const previewInput = await savedPreviewInput(client, params.factureId);
+    const { preview, policy } = await buildFacturePreview(client, previewInput, true);
+    ensurePreviewUsable(preview, params.input.preview_hash);
+    if (facture.preview_hash !== preview.preview_hash) {
+      throw new HttpError(
+        409,
+        "FACTURE_PREVIEW_CHANGED",
+        "Le brouillon doit être revalidé après le changement des sources ou tarifs."
+      );
+    }
+    if (!policy) throw new HttpError(503, "BILLING_POLICY_NOT_ACTIVE", "Politique Finance absente.");
+    if (
+      policy.require_distinct_issuer &&
+      facture.approved_by !== null &&
+      facture.approved_by === params.actor.userId
+    ) {
+      throw new HttpError(
+        403,
+        "FINANCE_ISSUER_VALIDATOR_CONFLICT",
+        "La politique active impose un émetteur distinct du valideur."
+      );
+    }
+    assertFactureTransition(facture.statut, "ISSUED");
+    const issueDate = new Date().toISOString().slice(0, 10);
+    const legal = await allocateLegalNumber({
+      client,
+      documentType: "FACTURE",
+      entityCode: facture.legal_entity_code,
+      issueDate,
+    });
+    const dueDates = preview.due_dates.map((due) => ({
+      due_date: due.due_date,
+      label: due.label,
+      amount: due.amount,
+    }));
+    const snapshot: FinanceDocumentSnapshot = {
+      document_type: "FACTURE",
+      uuid: facture.uuid,
+      draft_reference: facture.draft_reference,
+      legal_number: legal.legalNumber,
+      issue_date: issueDate,
+      due_dates: dueDates,
+      currency: facture.currency,
+      client_snapshot: facture.client_snapshot,
+      issuer_snapshot: facture.issuer_snapshot,
+      lines: preview.lines,
+      totals: preview.totals,
+      internal_comment: facture.commentaires,
+      customer_text: facture.customer_text,
+    };
+    artifact = await params.writeDocument(snapshot);
+    const correlationId = newCorrelationId();
+    await client.query(
+      `
+        UPDATE public.facture_source_allocations
+        SET allocation_status = 'CONSUMED',
+            quantity_consumed = quantity_selected,
+            consumed_at = now(),
+            consumed_by = $2
+        WHERE facture_id = $1
+          AND allocation_status = 'DRAFT'
+      `,
+      [params.factureId, params.actor.userId]
+    );
+    const updated = await client.query<{ row_version: number }>(
+      `
+        UPDATE public.facture
+        SET numero = $2,
+            legal_number = $2,
+            legal_period = $3,
+            legal_sequence_value = $4,
+            date_emission = $5::date,
+            statut = 'ISSUED',
+            issued_at = now(),
+            issued_by = $6,
+            immutable_snapshot = $7::jsonb,
+            document_checksum_sha256 = $8,
+            row_version = row_version + 1,
+            updated_at = now()
+        WHERE id = $1
+        RETURNING row_version
+      `,
+      [
+        params.factureId,
+        legal.legalNumber,
+        legal.periodKey,
+        legal.sequenceValue,
+        issueDate,
+        params.actor.userId,
+        JSON.stringify(snapshot),
+        artifact.checksumSha256,
+      ]
+    );
+    await client.query(
+      `INSERT INTO public.documents_clients (id, document_name, type) VALUES ($1::uuid,$2,'PDF')`,
+      [artifact.documentId, artifact.fileName]
+    );
+    await client.query(
+      `
+        INSERT INTO public.facture_documents (facture_id, document_id, type)
+        VALUES ($1,$2::uuid,'LEGAL_PDF')
+      `,
+      [params.factureId, artifact.documentId]
+    );
+    await client.query(
+      `
+        INSERT INTO public.finance_document_versions (
+          aggregate_type, aggregate_id, document_id, version, status,
+          checksum_sha256, file_size_bytes, mime_type, snapshot_json,
+          created_by, correlation_id
+        )
+        VALUES ('FACTURE',$1,$2::uuid,1,'ISSUED',$3,$4,'application/pdf',$5::jsonb,$6,$7::uuid)
+      `,
+      [
+        facture.uuid,
+        artifact.documentId,
+        artifact.checksumSha256,
+        artifact.fileSizeBytes,
+        JSON.stringify(snapshot),
+        params.actor.userId,
+        correlationId,
+      ]
+    );
+    const result: FinanceCommandResult = {
+      id: facture.id,
+      uuid: facture.uuid,
+      draft_reference: facture.draft_reference,
+      legal_number: legal.legalNumber,
+      status: "ISSUED",
+      row_version: updated.rows[0]?.row_version ?? facture.row_version + 1,
+      correlation_id: correlationId,
+      idempotent_replay: false,
+    };
+    await insertFinanceEvent({
+      client,
+      aggregateType: "FACTURE",
+      aggregateId: facture.uuid,
+      eventType: "FACTURE_ISSUED",
+      oldValues: { status: facture.statut },
+      newValues: {
+        status: "ISSUED",
+        legal_number: legal.legalNumber,
+        document_checksum_sha256: artifact.checksumSha256,
+      },
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
+      ruleCode: policy.policy_version,
+    });
+    await insertFinanceOutbox({
+      client,
+      eventKey: `finance.facture.issued:${facture.uuid}`,
+      aggregateType: "FACTURE",
+      aggregateId: facture.uuid,
+      eventType: "FINANCE.INVOICE_ISSUED",
+      payload: {
+        facture_uuid: facture.uuid,
+        legal_number: legal.legalNumber,
+        total_incl_tax: preview.totals.total_incl_tax,
+        currency: facture.currency,
+        correlation_id: correlationId,
+      },
+      correlationId,
+    });
+    await insertGlobalFinanceAudit({
+      client,
+      actor: params.actor,
+      action: "facturation.facture_issued",
+      entityType: "facture",
+      entityId: facture.uuid,
+      details: {
+        legal_number: legal.legalNumber,
+        document_checksum_sha256: artifact.checksumSha256,
+        correlation_id: correlationId,
+      },
+    });
+    await saveFinanceReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: receipt.idempotencyKey,
+      requestHash: receipt.requestHash,
+      commandType: "FACTURE_ISSUE",
+      aggregateType: "FACTURE",
+      aggregateId: facture.uuid,
+      requestPayload: params.input,
+      resultPayload: result,
+      correlationId,
+    });
+    await client.query("COMMIT");
+    artifact = null;
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    if (artifact) await artifact.cleanup().catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/src/module/facturation/repository/factures.repository.ts
+++ b/src/module/facturation/repository/factures.repository.ts
@@ -522,9 +522,10 @@ export async function repoUpdateFacture(id: number, input: UpdateFactureBodyDTO)
     const baseRes = await client.query<{
       id: string;
       remise_globale: number;
+      statut: string;
     }>(
       `
-      SELECT id::text AS id, remise_globale::float8 AS remise_globale
+      SELECT id::text AS id, remise_globale::float8 AS remise_globale, statut
       FROM facture
       WHERE id = $1
       FOR UPDATE
@@ -535,6 +536,20 @@ export async function repoUpdateFacture(id: number, input: UpdateFactureBodyDTO)
     if (!base) {
       await client.query("ROLLBACK");
       return null;
+    }
+    if (!["DRAFT", "brouillon"].includes(base.statut)) {
+      throw new HttpError(
+        409,
+        "FACTURE_IMMUTABLE",
+        "Seul un brouillon peut être modifié. Un document émis se corrige par avoir."
+      );
+    }
+    if (input.statut !== undefined && !["DRAFT", "brouillon"].includes(input.statut)) {
+      throw new HttpError(
+        409,
+        "FACTURE_WORKFLOW_REQUIRED",
+        "Les changements de statut passent par les commandes du workflow Finance."
+      );
     }
 
     const hasAnyFieldUpdate = Object.keys(input).length > 0;
@@ -631,6 +646,19 @@ export async function repoUpdateFacture(id: number, input: UpdateFactureBodyDTO)
 }
 
 export async function repoDeleteFacture(id: number) {
-  const { rowCount } = await pool.query(`DELETE FROM facture WHERE id = $1`, [id]);
+  const { rowCount } = await pool.query(
+    `DELETE FROM facture WHERE id = $1 AND statut IN ('DRAFT', 'brouillon')`,
+    [id]
+  );
+  if ((rowCount ?? 0) === 0) {
+    const exists = await pool.query(`SELECT 1 FROM facture WHERE id = $1`, [id]);
+    if ((exists.rowCount ?? 0) > 0) {
+      throw new HttpError(
+        409,
+        "FACTURE_IMMUTABLE",
+        "Un document financier émis ne peut pas être supprimé."
+      );
+    }
+  }
   return (rowCount ?? 0) > 0;
 }

--- a/src/module/facturation/repository/payment-workflow.repository.ts
+++ b/src/module/facturation/repository/payment-workflow.repository.ts
@@ -1,0 +1,599 @@
+import crypto from "node:crypto";
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import {
+  paymentStatusFromAllocation,
+  type PaymentStatus,
+} from "../domain/finance-policy";
+import { formatDecimal, moneyToCents } from "../domain/decimal-money";
+import type { PaymentCommandResult } from "../types/workflow.types";
+import type {
+  AllocatePaymentBodyDTO,
+  RegisterPaymentBodyDTO,
+} from "../validators/workflow.validators";
+import {
+  acquireFinanceIdempotency,
+  type FinanceActorContext,
+  insertFinanceEvent,
+  insertFinanceOutbox,
+  insertGlobalFinanceAudit,
+  newCorrelationId,
+  nextLegacyId,
+  saveFinanceReceipt,
+} from "./workflow.repository.shared";
+
+type LockedPayment = {
+  id: number;
+  uuid: string;
+  code: string;
+  client_id: string;
+  montant: string;
+  currency: string;
+  status: PaymentStatus;
+  row_version: number;
+};
+
+type AllocationInput = RegisterPaymentBodyDTO["allocations"][number];
+
+async function lockPayment(client: PoolClient, paymentId: number): Promise<LockedPayment | null> {
+  const result = await client.query<LockedPayment>(
+    `
+      SELECT
+        id, uuid::text AS uuid, code, client_id,
+        montant::numeric(18,2)::text AS montant,
+        currency, status, row_version
+      FROM public.paiement
+      WHERE id = $1
+      FOR UPDATE
+    `,
+    [paymentId]
+  );
+  return result.rows[0] ?? null;
+}
+
+async function allocatedPaymentCents(client: PoolClient, paymentId: number): Promise<bigint> {
+  const result = await client.query<{ amount: string }>(
+    `
+      SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2)::text AS amount
+      FROM public.paiement_allocations
+      WHERE paiement_id = $1
+    `,
+    [paymentId]
+  );
+  return moneyToCents(result.rows[0]?.amount ?? "0.00", "Montant alloué");
+}
+
+type ResolvedAllocation = {
+  targetType: "FACTURE" | "ECHEANCE";
+  targetId: string;
+  factureId: number;
+  dueDateId: string | null;
+  amount: string;
+};
+
+async function resolveAndValidateAllocations(params: {
+  client: PoolClient;
+  clientId: string;
+  currency: string;
+  paymentId: number;
+  paymentAvailableCents: bigint;
+  allocations: readonly AllocationInput[];
+}): Promise<ResolvedAllocation[]> {
+  const uniqueTargets = new Set<string>();
+  const resolved: ResolvedAllocation[] = [];
+  let requestedCents = 0n;
+
+  const sorted = [...params.allocations].sort((left, right) =>
+    `${left.target_type}:${left.target_id}`.localeCompare(
+      `${right.target_type}:${right.target_id}`
+    )
+  );
+
+  for (const allocation of sorted) {
+    const targetKey = `${allocation.target_type}:${allocation.target_id}`;
+    if (uniqueTargets.has(targetKey)) {
+      throw new HttpError(
+        422,
+        "PAYMENT_ALLOCATION_DUPLICATED",
+        "Une cible ne peut être allouée qu'une fois par commande."
+      );
+    }
+    uniqueTargets.add(targetKey);
+    const amountCents = moneyToCents(allocation.amount, "Montant alloué");
+    if (amountCents <= 0n) {
+      throw new HttpError(422, "PAYMENT_ALLOCATION_INVALID", "Le montant doit être positif.");
+    }
+    requestedCents += amountCents;
+
+    let factureId: number;
+    let dueDateId: string | null = null;
+    let dueAvailableCents: bigint | null = null;
+    if (allocation.target_type === "ECHEANCE") {
+      const due = await params.client.query<{
+        id: string;
+        facture_id: number;
+        amount_due: string;
+        amount_allocated: string;
+        status: string;
+      }>(
+        `
+          SELECT
+            id::text AS id, facture_id,
+            amount_due::numeric(18,2)::text AS amount_due,
+            amount_allocated::numeric(18,2)::text AS amount_allocated,
+            status
+          FROM public.facture_echeance
+          WHERE id = $1::uuid
+          FOR UPDATE
+        `,
+        [allocation.target_id]
+      );
+      const row = due.rows[0];
+      if (!row) {
+        throw new HttpError(404, "PAYMENT_DUE_DATE_NOT_FOUND", "Échéance introuvable.");
+      }
+      factureId = row.facture_id;
+      dueDateId = row.id;
+      dueAvailableCents =
+        moneyToCents(row.amount_due, "Échéance") -
+        moneyToCents(row.amount_allocated, "Échéance allouée");
+      if (row.status === "CANCELLED" || amountCents > dueAvailableCents) {
+        throw new HttpError(
+          409,
+          "PAYMENT_DUE_DATE_EXCEEDED",
+          "L'allocation dépasse le solde de l'échéance."
+        );
+      }
+    } else {
+      if (!/^\d+$/.test(allocation.target_id)) {
+        throw new HttpError(422, "PAYMENT_FACTURE_ID_INVALID", "Identifiant facture invalide.");
+      }
+      factureId = Number.parseInt(allocation.target_id, 10);
+    }
+
+    const facture = await params.client.query<{
+      client_id: string;
+      currency: string;
+      statut: string;
+      total_ttc: string;
+      settled_ttc: string;
+    }>(
+      `
+        SELECT
+          f.client_id,
+          COALESCE(f.currency, 'EUR') AS currency,
+          f.statut,
+          f.total_ttc::numeric(18,2)::text AS total_ttc,
+          (
+            COALESCE((
+              SELECT SUM(pa.amount_ttc)
+              FROM public.paiement_allocations pa
+              WHERE pa.facture_id = f.id
+            ), 0)
+            +
+            COALESCE((
+              SELECT SUM(asa.amount_ttc)
+              FROM public.avoir_source_allocations asa
+              WHERE asa.facture_id = f.id
+                AND asa.allocation_status = 'CONSUMED'
+            ), 0)
+          )::numeric(18,2)::text AS settled_ttc
+        FROM public.facture f
+        WHERE f.id = $1
+        FOR UPDATE
+      `,
+      [factureId]
+    );
+    const invoice = facture.rows[0];
+    if (!invoice) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
+    if (!["ISSUED", "PARTIALLY_PAID", "PAID"].includes(invoice.statut)) {
+      throw new HttpError(
+        409,
+        "PAYMENT_FACTURE_NOT_ISSUED",
+        "Un paiement ne peut être alloué qu'à une facture émise."
+      );
+    }
+    if (invoice.client_id !== params.clientId) {
+      throw new HttpError(
+        422,
+        "PAYMENT_CLIENT_MISMATCH",
+        "Le paiement et la facture doivent appartenir au même client."
+      );
+    }
+    if (invoice.currency !== params.currency) {
+      throw new HttpError(
+        422,
+        "PAYMENT_CURRENCY_MISMATCH",
+        "Le paiement et la facture doivent avoir la même devise."
+      );
+    }
+    const invoiceAvailableCents =
+      moneyToCents(invoice.total_ttc, "Total facture") -
+      moneyToCents(invoice.settled_ttc, "Total réglé");
+    if (amountCents > invoiceAvailableCents) {
+      throw new HttpError(
+        409,
+        "PAYMENT_INVOICE_BALANCE_EXCEEDED",
+        "L'allocation dépasse le solde de la facture."
+      );
+    }
+    resolved.push({
+      targetType: allocation.target_type,
+      targetId: allocation.target_id,
+      factureId,
+      dueDateId,
+      amount: allocation.amount,
+    });
+  }
+
+  if (requestedCents > params.paymentAvailableCents) {
+    throw new HttpError(
+      409,
+      "PAYMENT_AMOUNT_EXCEEDED",
+      "Les allocations dépassent le montant disponible du paiement."
+    );
+  }
+  return resolved;
+}
+
+async function insertAllocations(params: {
+  client: PoolClient;
+  paymentId: number;
+  actor: FinanceActorContext;
+  correlationId: string;
+  allocations: readonly ResolvedAllocation[];
+}): Promise<void> {
+  for (const allocation of params.allocations) {
+    await params.client.query(
+      `
+        INSERT INTO public.paiement_allocations (
+          paiement_id, facture_id, facture_due_date_id,
+          amount_ttc, created_by, correlation_id
+        )
+        VALUES ($1,$2,$3::uuid,$4,$5,$6::uuid)
+      `,
+      [
+        params.paymentId,
+        allocation.factureId,
+        allocation.dueDateId,
+        allocation.amount,
+        params.actor.userId,
+        params.correlationId,
+      ]
+    );
+    if (allocation.dueDateId) {
+      await params.client.query(
+        `
+          UPDATE public.facture_echeance
+          SET amount_allocated = amount_allocated + $2,
+              status = CASE
+                WHEN amount_allocated + $2 >= amount_due THEN 'PAID'
+                WHEN amount_allocated + $2 > 0 THEN 'PARTIALLY_PAID'
+                ELSE status
+              END
+          WHERE id = $1::uuid
+        `,
+        [allocation.dueDateId, allocation.amount]
+      );
+    }
+  }
+}
+
+function paymentResult(params: {
+  payment: LockedPayment;
+  allocatedCents: bigint;
+  correlationId: string;
+  replay: boolean;
+}): PaymentCommandResult {
+  const amountCents = moneyToCents(params.payment.montant, "Montant du paiement");
+  return {
+    id: params.payment.id,
+    uuid: params.payment.uuid,
+    code: params.payment.code,
+    status: paymentStatusFromAllocation({
+      paymentCents: amountCents,
+      allocatedCents: params.allocatedCents,
+    }),
+    row_version: params.payment.row_version,
+    amount: formatDecimal(amountCents, 2),
+    allocated_amount: formatDecimal(params.allocatedCents, 2),
+    available_amount: formatDecimal(amountCents - params.allocatedCents, 2),
+    correlation_id: params.correlationId,
+    idempotent_replay: params.replay,
+  };
+}
+
+export async function repoRegisterPayment(params: {
+  input: RegisterPaymentBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}): Promise<PaymentCommandResult> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const receipt = await acquireFinanceIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "PAYMENT_REGISTER",
+      requestPayload: params.input,
+    });
+    if (receipt.replay) {
+      await client.query("COMMIT");
+      return { ...(receipt.replay as unknown as PaymentCommandResult), idempotent_replay: true };
+    }
+    const amountCents = moneyToCents(params.input.amount, "Montant du paiement");
+    if (amountCents <= 0n) {
+      throw new HttpError(422, "PAYMENT_AMOUNT_INVALID", "Le montant doit être positif.");
+    }
+    const clientExists = await client.query(
+      `SELECT 1 FROM public.clients WHERE client_id = $1`,
+      [params.input.client_id]
+    );
+    if ((clientExists.rowCount ?? 0) === 0) {
+      throw new HttpError(404, "CLIENT_NOT_FOUND", "Client introuvable.");
+    }
+    const id = await nextLegacyId(client, "paiement_id_seq");
+    const uuid = crypto.randomUUID();
+    const code = `PAY-${new Date().getUTCFullYear()}-${String(id).padStart(6, "0")}`;
+    const correlationId = newCorrelationId();
+    const allocations = await resolveAndValidateAllocations({
+      client,
+      clientId: params.input.client_id,
+      currency: params.input.currency,
+      paymentId: id,
+      paymentAvailableCents: amountCents,
+      allocations: params.input.allocations,
+    });
+    const firstFactureId = allocations[0]?.factureId ?? null;
+    await client.query(
+      `
+        INSERT INTO public.paiement (
+          id, uuid, code, facture_id, client_id, date_paiement,
+          value_date, booking_date, montant, currency, mode, reference,
+          commentaire, proof_document_id, status, workflow_status,
+          row_version, received_at, received_by, created_by,
+          correlation_id, idempotency_key, request_hash
+        )
+        VALUES (
+          $1,$2::uuid,$3,$4,$5,$6::date,$6::date,$7::date,$8,$9,$10,$11,
+          $12,$13::uuid,'UNALLOCATED','RECORDED',1,now(),$14,$14,
+          $15::uuid,$16,$17
+        )
+      `,
+      [
+        id,
+        uuid,
+        code,
+        firstFactureId,
+        params.input.client_id,
+        params.input.value_date,
+        params.input.booking_date,
+        params.input.amount,
+        params.input.currency,
+        params.input.mode,
+        params.input.reference,
+        params.input.comment ?? null,
+        params.input.proof_document_id ?? null,
+        params.actor.userId,
+        correlationId,
+        receipt.idempotencyKey,
+        receipt.requestHash,
+      ]
+    );
+    await insertAllocations({
+      client,
+      paymentId: id,
+      actor: params.actor,
+      correlationId,
+      allocations,
+    });
+    const allocatedCents = allocations.reduce(
+      (sum, allocation) => sum + moneyToCents(allocation.amount, "Montant alloué"),
+      0n
+    );
+    const status = paymentStatusFromAllocation({
+      paymentCents: amountCents,
+      allocatedCents,
+    });
+    await client.query(
+      `
+        UPDATE public.paiement
+        SET status = $2,
+            workflow_status = CASE WHEN $2 = 'ALLOCATED' THEN 'ALLOCATED' ELSE 'RECORDED' END
+        WHERE id = $1
+      `,
+      [id, status]
+    );
+    const payment: LockedPayment = {
+      id,
+      uuid,
+      code,
+      client_id: params.input.client_id,
+      montant: params.input.amount,
+      currency: params.input.currency,
+      status,
+      row_version: 1,
+    };
+    const result = paymentResult({
+      payment,
+      allocatedCents,
+      correlationId,
+      replay: false,
+    });
+    await insertFinanceEvent({
+      client,
+      aggregateType: "PAIEMENT",
+      aggregateId: uuid,
+      eventType: "PAYMENT_REGISTERED",
+      newValues: {
+        code,
+        amount: params.input.amount,
+        allocated_amount: result.allocated_amount,
+        currency: params.input.currency,
+      },
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
+    });
+    await insertFinanceOutbox({
+      client,
+      eventKey: `finance.payment.registered:${uuid}`,
+      aggregateType: "PAIEMENT",
+      aggregateId: uuid,
+      eventType: "FINANCE.PAYMENT_REGISTERED",
+      payload: {
+        payment_uuid: uuid,
+        code,
+        amount: params.input.amount,
+        allocated_amount: result.allocated_amount,
+        currency: params.input.currency,
+        correlation_id: correlationId,
+      },
+      correlationId,
+    });
+    await insertGlobalFinanceAudit({
+      client,
+      actor: params.actor,
+      action: "facturation.payment_registered",
+      entityType: "paiement",
+      entityId: uuid,
+      details: { code, allocation_count: allocations.length, correlation_id: correlationId },
+    });
+    await saveFinanceReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: receipt.idempotencyKey,
+      requestHash: receipt.requestHash,
+      commandType: "PAYMENT_REGISTER",
+      aggregateType: "PAIEMENT",
+      aggregateId: uuid,
+      requestPayload: params.input,
+      resultPayload: result,
+      correlationId,
+    });
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoAllocatePayment(params: {
+  paymentId: number;
+  input: AllocatePaymentBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}): Promise<PaymentCommandResult> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const receipt = await acquireFinanceIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "PAYMENT_ALLOCATE",
+      requestPayload: { payment_id: params.paymentId, ...params.input },
+    });
+    if (receipt.replay) {
+      await client.query("COMMIT");
+      return { ...(receipt.replay as unknown as PaymentCommandResult), idempotent_replay: true };
+    }
+    const payment = await lockPayment(client, params.paymentId);
+    if (!payment) throw new HttpError(404, "PAYMENT_NOT_FOUND", "Paiement introuvable.");
+    if (["REJECTED", "REVERSED"].includes(payment.status)) {
+      throw new HttpError(409, "PAYMENT_IMMUTABLE", "Ce paiement ne peut plus être alloué.");
+    }
+    if (payment.row_version !== params.input.expected_version) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Le paiement a changé.");
+    }
+    const amountCents = moneyToCents(payment.montant, "Montant du paiement");
+    const alreadyAllocated = await allocatedPaymentCents(client, payment.id);
+    const allocations = await resolveAndValidateAllocations({
+      client,
+      clientId: payment.client_id,
+      currency: payment.currency,
+      paymentId: payment.id,
+      paymentAvailableCents: amountCents - alreadyAllocated,
+      allocations: params.input.allocations,
+    });
+    const correlationId = newCorrelationId();
+    await insertAllocations({
+      client,
+      paymentId: payment.id,
+      actor: params.actor,
+      correlationId,
+      allocations,
+    });
+    const newlyAllocated = allocations.reduce(
+      (sum, allocation) => sum + moneyToCents(allocation.amount, "Montant alloué"),
+      0n
+    );
+    const allocatedCents = alreadyAllocated + newlyAllocated;
+    const status = paymentStatusFromAllocation({
+      paymentCents: amountCents,
+      allocatedCents,
+    });
+    const updated = await client.query<{ row_version: number }>(
+      `
+        UPDATE public.paiement
+        SET status = $2,
+            workflow_status = CASE WHEN $2 = 'ALLOCATED' THEN 'ALLOCATED' ELSE 'RECORDED' END,
+            row_version = row_version + 1,
+            updated_at = now()
+        WHERE id = $1
+        RETURNING row_version
+      `,
+      [payment.id, status]
+    );
+    const result = paymentResult({
+      payment: { ...payment, status, row_version: updated.rows[0]!.row_version },
+      allocatedCents,
+      correlationId,
+      replay: false,
+    });
+    await insertFinanceEvent({
+      client,
+      aggregateType: "PAIEMENT",
+      aggregateId: payment.uuid,
+      eventType: "PAYMENT_ALLOCATED",
+      oldValues: { allocated_amount: formatDecimal(alreadyAllocated, 2) },
+      newValues: { allocated_amount: result.allocated_amount, status },
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
+    });
+    await insertGlobalFinanceAudit({
+      client,
+      actor: params.actor,
+      action: "facturation.payment_allocated",
+      entityType: "paiement",
+      entityId: payment.uuid,
+      details: { allocation_count: allocations.length, correlation_id: correlationId },
+    });
+    await saveFinanceReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: receipt.idempotencyKey,
+      requestHash: receipt.requestHash,
+      commandType: "PAYMENT_ALLOCATE",
+      aggregateType: "PAIEMENT",
+      aggregateId: payment.uuid,
+      requestPayload: params.input,
+      resultPayload: result,
+      correlationId,
+    });
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/src/module/facturation/repository/workflow.repository.shared.ts
+++ b/src/module/facturation/repository/workflow.repository.shared.ts
@@ -1,0 +1,286 @@
+import crypto from "node:crypto";
+import type { PoolClient, QueryResultRow } from "pg";
+
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import { HttpError } from "../../../utils/httpError";
+import {
+  decideReceipt,
+  financeRequestHash,
+  normalizeIdempotencyKey,
+} from "../domain/finance-policy";
+
+export type FinanceActorContext = {
+  userId: number;
+  requestId: string;
+  path: string;
+};
+
+export type DbQueryer = Pick<PoolClient, "query">;
+
+export async function acquireFinanceIdempotency(params: {
+  client: PoolClient;
+  actor: FinanceActorContext;
+  idempotencyKeyRaw: string | null | undefined;
+  commandType: string;
+  requestPayload: unknown;
+}): Promise<{
+  idempotencyKey: string;
+  requestHash: string;
+  replay: Record<string, unknown> | null;
+}> {
+  const idempotencyKey = normalizeIdempotencyKey(params.idempotencyKeyRaw);
+  const requestHash = financeRequestHash(params.commandType, params.requestPayload);
+  await params.client.query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
+    `finance:${params.actor.userId}:${idempotencyKey}`,
+  ]);
+  const existing = await params.client.query<{
+    request_hash: string;
+    result_payload: Record<string, unknown>;
+  }>(
+    `
+      SELECT request_hash, result_payload
+      FROM public.finance_command_receipts
+      WHERE actor_user_id = $1
+        AND idempotency_key = $2
+      LIMIT 1
+    `,
+    [params.actor.userId, idempotencyKey]
+  );
+  const receipt = existing.rows[0] ?? null;
+  const decision = decideReceipt(receipt?.request_hash, requestHash);
+  if (decision === "CONFLICT") {
+    throw new HttpError(
+      409,
+      "IDEMPOTENCY_KEY_REUSED",
+      "Cette Idempotency-Key a déjà été utilisée avec un autre contenu."
+    );
+  }
+  return {
+    idempotencyKey,
+    requestHash,
+    replay: decision === "REPLAY" ? receipt?.result_payload ?? null : null,
+  };
+}
+
+export async function saveFinanceReceipt(params: {
+  client: PoolClient;
+  actor: FinanceActorContext;
+  idempotencyKey: string;
+  requestHash: string;
+  commandType: string;
+  aggregateType: "FACTURE" | "AVOIR" | "PAIEMENT";
+  aggregateId: string;
+  requestPayload: unknown;
+  resultPayload: unknown;
+  correlationId: string;
+}): Promise<void> {
+  await params.client.query(
+    `
+      INSERT INTO public.finance_command_receipts (
+        actor_user_id,
+        idempotency_key,
+        request_hash,
+        command_type,
+        aggregate_type,
+        aggregate_id,
+        request_payload,
+        result_payload,
+        correlation_id
+      )
+      VALUES ($1,$2,$3,$4,$5,$6,$7::jsonb,$8::jsonb,$9::uuid)
+    `,
+    [
+      params.actor.userId,
+      params.idempotencyKey,
+      params.requestHash,
+      params.commandType,
+      params.aggregateType,
+      params.aggregateId,
+      JSON.stringify(params.requestPayload),
+      JSON.stringify(params.resultPayload),
+      params.correlationId,
+    ]
+  );
+}
+
+export async function insertFinanceEvent(params: {
+  client: PoolClient;
+  aggregateType: "FACTURE" | "AVOIR" | "PAIEMENT";
+  aggregateId: string;
+  eventType: string;
+  oldValues?: unknown;
+  newValues?: unknown;
+  actor: FinanceActorContext;
+  correlationId: string;
+  idempotencyKey?: string | null;
+  ruleCode?: string | null;
+  reason?: string | null;
+}): Promise<void> {
+  await params.client.query(
+    `
+      INSERT INTO public.finance_event_log (
+        aggregate_type,
+        aggregate_id,
+        event_type,
+        old_values,
+        new_values,
+        actor_user_id,
+        correlation_id,
+        idempotency_key,
+        rule_code,
+        reason,
+        request_id
+      )
+      VALUES ($1,$2,$3,$4::jsonb,$5::jsonb,$6,$7::uuid,$8,$9,$10,$11)
+    `,
+    [
+      params.aggregateType,
+      params.aggregateId,
+      params.eventType,
+      params.oldValues === undefined ? null : JSON.stringify(params.oldValues),
+      params.newValues === undefined ? null : JSON.stringify(params.newValues),
+      params.actor.userId,
+      params.correlationId,
+      params.idempotencyKey ?? null,
+      params.ruleCode ?? null,
+      params.reason ?? null,
+      params.actor.requestId,
+    ]
+  );
+}
+
+export async function insertFinanceOutbox(params: {
+  client: PoolClient;
+  eventKey: string;
+  aggregateType: "FACTURE" | "AVOIR" | "PAIEMENT";
+  aggregateId: string;
+  eventType: string;
+  payload: unknown;
+  correlationId: string;
+}): Promise<void> {
+  await params.client.query(
+    `
+      INSERT INTO public.erp_outbox_events (
+        event_key,
+        aggregate_type,
+        aggregate_id,
+        event_type,
+        payload,
+        correlation_id
+      )
+      VALUES ($1,$2,$3,$4,$5::jsonb,$6::uuid)
+      ON CONFLICT (event_key) DO NOTHING
+    `,
+    [
+      params.eventKey,
+      params.aggregateType,
+      params.aggregateId,
+      params.eventType,
+      JSON.stringify(params.payload),
+      params.correlationId,
+    ]
+  );
+}
+
+export async function insertGlobalFinanceAudit(params: {
+  client: PoolClient;
+  actor: FinanceActorContext;
+  action: string;
+  entityType: string;
+  entityId: string;
+  details: Record<string, unknown>;
+}): Promise<void> {
+  await repoInsertAuditLog({
+    user_id: params.actor.userId,
+    body: {
+      event_type: "ACTION",
+      action: params.action,
+      page_key: "facturation",
+      entity_type: params.entityType,
+      entity_id: params.entityId,
+      path: params.actor.path,
+      client_session_id: null,
+      details: {
+        ...params.details,
+        request_id: params.actor.requestId,
+      },
+    },
+    ip: null,
+    user_agent: null,
+    device_type: null,
+    os: null,
+    browser: null,
+    tx: params.client,
+  });
+}
+
+export async function nextLegacyId(client: PoolClient, sequenceName: string): Promise<number> {
+  if (!/^[a-z_][a-z0-9_]*$/i.test(sequenceName)) throw new Error("Invalid sequence name");
+  const result = await client.query<{ id: string }>(
+    `SELECT nextval('public.${sequenceName}')::bigint::text AS id`
+  );
+  const raw = result.rows[0]?.id;
+  if (!raw || !/^\d+$/.test(raw)) throw new Error(`Failed to allocate ${sequenceName}`);
+  const id = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(id) || id <= 0) {
+    throw new Error(`Unsafe legacy identifier allocated by ${sequenceName}`);
+  }
+  return id;
+}
+
+export async function allocateLegalNumber(params: {
+  client: PoolClient;
+  documentType: "FACTURE" | "AVOIR";
+  entityCode: string;
+  issueDate: string;
+}): Promise<{ legalNumber: string; periodKey: string; sequenceValue: number }> {
+  const periodKey = params.issueDate.slice(0, 4);
+  const sequence = await params.client.query<{
+    id: string;
+    prefix: string;
+    next_value: string;
+    padding: number;
+  }>(
+    `
+      SELECT id::text AS id, prefix, next_value::text AS next_value, padding
+      FROM public.finance_legal_sequences
+      WHERE document_type = $1
+        AND entity_code = $2
+        AND period_key = $3
+        AND active = TRUE
+      FOR UPDATE
+    `,
+    [params.documentType, params.entityCode, periodKey]
+  );
+  const row = sequence.rows[0] ?? null;
+  if (!row) {
+    throw new HttpError(
+      503,
+      "FINANCE_LEGAL_SEQUENCE_NOT_CONFIGURED",
+      "Aucune séquence Finance validée n'est active pour cette entité et cette période."
+    );
+  }
+  const sequenceValue = Number.parseInt(row.next_value, 10);
+  if (!Number.isSafeInteger(sequenceValue) || sequenceValue <= 0) {
+    throw new Error("Invalid finance legal sequence value");
+  }
+  const legalNumber = `${row.prefix}${String(sequenceValue).padStart(row.padding, "0")}`;
+  await params.client.query(
+    `
+      UPDATE public.finance_legal_sequences
+      SET next_value = next_value + 1,
+          updated_at = now()
+      WHERE id = $1::uuid
+    `,
+    [row.id]
+  );
+  return { legalNumber, periodKey, sequenceValue };
+}
+
+export function newCorrelationId(): string {
+  return crypto.randomUUID();
+}
+
+export function mapNumericStrings<T extends QueryResultRow>(rows: T[]): T[] {
+  return rows;
+}

--- a/src/module/facturation/routes/avoirs.routes.ts
+++ b/src/module/facturation/routes/avoirs.routes.ts
@@ -8,15 +8,43 @@ import {
   listAvoirs,
   updateAvoir,
 } from "../controllers/avoirs.controller";
+import { requireFinanceCapability } from "../middlewares/finance-authorization.middleware";
+import {
+  createAvoirDraftWorkflow,
+  issueAvoirWorkflow,
+  listAvoirEligibleLines,
+  previewAvoirWorkflow,
+  requestAvoirValidationWorkflow,
+  validateAvoirWorkflow,
+} from "../controllers/avoir-workflow.controller";
 
 const router = Router();
 
-router.get("/", listAvoirs);
-router.get("/:id", getAvoir);
-router.get("/:id/pdf", getAvoirPdf);
-router.post("/", createAvoir);
-router.post("/:id/pdf", generateAvoirPdf);
-router.patch("/:id", updateAvoir);
-router.delete("/:id", deleteAvoir);
+router.get(
+  "/workflow/invoices/:id/eligible-lines",
+  requireFinanceCapability("read"),
+  listAvoirEligibleLines
+);
+router.post("/workflow/preview", requireFinanceCapability("credit_write"), previewAvoirWorkflow);
+router.post("/workflow/drafts", requireFinanceCapability("credit_write"), createAvoirDraftWorkflow);
+router.post(
+  "/workflow/:id/request-validation",
+  requireFinanceCapability("request_validation"),
+  requestAvoirValidationWorkflow
+);
+router.post(
+  "/workflow/:id/validate",
+  requireFinanceCapability("validate"),
+  validateAvoirWorkflow
+);
+router.post("/workflow/:id/issue", requireFinanceCapability("credit_issue"), issueAvoirWorkflow);
+
+router.get("/", requireFinanceCapability("read"), listAvoirs);
+router.get("/:id", requireFinanceCapability("read"), getAvoir);
+router.get("/:id/pdf", requireFinanceCapability("documents_read"), getAvoirPdf);
+router.post("/", requireFinanceCapability("credit_write"), createAvoir);
+router.post("/:id/pdf", requireFinanceCapability("credit_write"), generateAvoirPdf);
+router.patch("/:id", requireFinanceCapability("credit_write"), updateAvoir);
+router.delete("/:id", requireFinanceCapability("settings_manage"), deleteAvoir);
 
 export default router;

--- a/src/module/facturation/routes/factures.routes.ts
+++ b/src/module/facturation/routes/factures.routes.ts
@@ -1,6 +1,4 @@
-import { Router, type RequestHandler } from "express";
-import { authenticateToken } from "../../auth/middlewares/auth.middleware";
-import { HttpError } from "../../../utils/httpError";
+import { Router } from "express";
 import {
   createFacture,
   deleteFacture,
@@ -10,39 +8,43 @@ import {
   listFactures,
   updateFacture,
 } from "../controllers/factures.controller";
+import {
+  createFactureDraftWorkflow,
+  issueFactureWorkflow,
+  listEligibleFactureSources,
+  previewFacture,
+  requestFactureValidation,
+  validateFactureWorkflow,
+} from "../controllers/facture-workflow.controller";
+import { requireFinanceCapability } from "../middlewares/finance-authorization.middleware";
 
 const router = Router();
 
-function hasAnyRole(role: string | undefined, needles: string[]): boolean {
-  if (!role) return false;
-  const normalized = role.trim().toLowerCase();
-  return needles.some((needle) => normalized.includes(needle));
-}
+router.get(
+  "/workflow/eligible-sources",
+  requireFinanceCapability("read"),
+  listEligibleFactureSources
+);
+router.post("/workflow/preview", requireFinanceCapability("draft_write"), previewFacture);
+router.post("/workflow/drafts", requireFinanceCapability("draft_write"), createFactureDraftWorkflow);
+router.post(
+  "/workflow/:id/request-validation",
+  requireFinanceCapability("request_validation"),
+  requestFactureValidation
+);
+router.post(
+  "/workflow/:id/validate",
+  requireFinanceCapability("validate"),
+  validateFactureWorkflow
+);
+router.post("/workflow/:id/issue", requireFinanceCapability("issue"), issueFactureWorkflow);
 
-const requireFacturationWrite: RequestHandler = (req, _res, next) => {
-  if (hasAnyRole(req.user?.role, ["admin", "administrateur", "directeur", "compt", "secr", "secret"])) {
-    next();
-    return;
-  }
-  next(new HttpError(403, "FORBIDDEN", "Facturation role required"));
-};
-
-const requireFacturationAdmin: RequestHandler = (req, _res, next) => {
-  if (hasAnyRole(req.user?.role, ["admin", "administrateur", "directeur"])) {
-    next();
-    return;
-  }
-  next(new HttpError(403, "FORBIDDEN", "Facturation admin role required"));
-};
-
-router.use(authenticateToken);
-
-router.get("/", listFactures);
-router.get("/:id", getFacture);
-router.get("/:id/pdf", getFacturePdf);
-router.post("/", requireFacturationWrite, createFacture);
-router.post("/:id/pdf", requireFacturationWrite, generateFacturePdf);
-router.patch("/:id", requireFacturationWrite, updateFacture);
-router.delete("/:id", requireFacturationAdmin, deleteFacture);
+router.get("/", requireFinanceCapability("read"), listFactures);
+router.get("/:id", requireFinanceCapability("read"), getFacture);
+router.get("/:id/pdf", requireFinanceCapability("documents_read"), getFacturePdf);
+router.post("/", requireFinanceCapability("draft_write"), createFacture);
+router.post("/:id/pdf", requireFinanceCapability("draft_write"), generateFacturePdf);
+router.patch("/:id", requireFinanceCapability("draft_write"), updateFacture);
+router.delete("/:id", requireFinanceCapability("settings_manage"), deleteFacture);
 
 export default router;

--- a/src/module/facturation/routes/paiements.routes.ts
+++ b/src/module/facturation/routes/paiements.routes.ts
@@ -6,13 +6,25 @@ import {
   listPaiements,
   updatePaiement,
 } from "../controllers/paiements.controller";
+import { requireFinanceCapability } from "../middlewares/finance-authorization.middleware";
+import {
+  allocatePaymentWorkflow,
+  registerPaymentWorkflow,
+} from "../controllers/payment-workflow.controller";
 
 const router = Router();
 
-router.get("/", listPaiements);
-router.get("/:id", getPaiement);
-router.post("/", createPaiement);
-router.patch("/:id", updatePaiement);
-router.delete("/:id", deletePaiement);
+router.post("/workflow/register", requireFinanceCapability("payment_register"), registerPaymentWorkflow);
+router.post(
+  "/workflow/:id/allocations",
+  requireFinanceCapability("payment_allocate"),
+  allocatePaymentWorkflow
+);
+
+router.get("/", requireFinanceCapability("read"), listPaiements);
+router.get("/:id", requireFinanceCapability("read"), getPaiement);
+router.post("/", requireFinanceCapability("payment_register"), createPaiement);
+router.patch("/:id", requireFinanceCapability("payment_register"), updatePaiement);
+router.delete("/:id", requireFinanceCapability("settings_manage"), deletePaiement);
 
 export default router;

--- a/src/module/facturation/routes/reporting.routes.ts
+++ b/src/module/facturation/routes/reporting.routes.ts
@@ -1,10 +1,11 @@
 import { Router } from "express";
 import { commercialOutstanding, commercialRevenue, commercialTopClients } from "../controllers/reporting.controller";
+import { requireFinanceCapability } from "../middlewares/finance-authorization.middleware";
 
 const router = Router();
 
-router.get("/commercial/revenue", commercialRevenue);
-router.get("/commercial/outstanding", commercialOutstanding);
-router.get("/commercial/top-clients", commercialTopClients);
+router.get("/commercial/revenue", requireFinanceCapability("reporting_read"), commercialRevenue);
+router.get("/commercial/outstanding", requireFinanceCapability("reporting_read"), commercialOutstanding);
+router.get("/commercial/top-clients", requireFinanceCapability("reporting_read"), commercialTopClients);
 
 export default router;

--- a/src/module/facturation/routes/tarification.routes.ts
+++ b/src/module/facturation/routes/tarification.routes.ts
@@ -6,13 +6,14 @@ import {
   listTarificationClients,
   updateTarificationClient,
 } from "../controllers/tarification.controller";
+import { requireFinanceCapability } from "../middlewares/finance-authorization.middleware";
 
 const router = Router();
 
-router.get("/clients", listTarificationClients);
-router.get("/clients/:id", getTarificationClient);
-router.post("/clients", createTarificationClient);
-router.patch("/clients/:id", updateTarificationClient);
-router.delete("/clients/:id", deleteTarificationClient);
+router.get("/clients", requireFinanceCapability("read"), listTarificationClients);
+router.get("/clients/:id", requireFinanceCapability("read"), getTarificationClient);
+router.post("/clients", requireFinanceCapability("settings_manage"), createTarificationClient);
+router.patch("/clients/:id", requireFinanceCapability("settings_manage"), updateTarificationClient);
+router.delete("/clients/:id", requireFinanceCapability("settings_manage"), deleteTarificationClient);
 
 export default router;

--- a/src/module/facturation/services/avoir-document.service.ts
+++ b/src/module/facturation/services/avoir-document.service.ts
@@ -1,0 +1,102 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import PDFDocument from "pdfkit";
+
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
+import type {
+  AvoirDocumentArtifact,
+  AvoirDocumentSnapshot,
+} from "../repository/avoir-workflow.repository";
+
+function partyName(snapshot: Record<string, unknown>): string {
+  for (const key of ["company_name", "name", "raison_sociale"]) {
+    const value = snapshot[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "Non renseigné";
+}
+
+async function render(snapshot: AvoirDocumentSnapshot): Promise<Buffer> {
+  const doc = new PDFDocument({ size: "A4", margin: 44, compress: true });
+  const chunks: Buffer[] = [];
+  doc.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+
+  doc.info.Title = `Avoir ${snapshot.legal_number}`;
+  doc.font("Helvetica-Bold").fontSize(22).fillColor("#172033").text("AVOIR", { align: "right" });
+  doc.font("Helvetica").fontSize(10);
+  doc.text(`N° ${snapshot.legal_number}`, { align: "right" });
+  doc.text(`Date : ${snapshot.issue_date}`, { align: "right" });
+  doc.text(`Facture corrigée : ${snapshot.facture_number}`, { align: "right" });
+  doc.moveDown(1.5);
+  doc.font("Helvetica-Bold").text("Émetteur");
+  doc.font("Helvetica").text(partyName(snapshot.issuer_snapshot));
+  doc.moveDown(0.8);
+  doc.font("Helvetica-Bold").text("Client");
+  doc.font("Helvetica").text(partyName(snapshot.client_snapshot));
+  doc.moveDown(1);
+  doc.font("Helvetica-Bold").text(`Motif (${snapshot.reason_code})`);
+  doc.font("Helvetica").text(snapshot.reason);
+  doc.moveDown(1.2);
+
+  for (const line of snapshot.lines) {
+    if (doc.y > 700) doc.addPage();
+    doc.font("Helvetica-Bold").fontSize(9).text(line.designation, { continued: false });
+    doc
+      .font("Helvetica")
+      .text(
+        `${line.quantity_selected} × ${line.unit_price_ex_tax} ${snapshot.currency} HT — TVA ${line.tax_rate_percent} % — ${line.total_incl_tax} ${snapshot.currency} TTC`
+      );
+    doc.moveDown(0.5);
+  }
+
+  doc.moveDown(1);
+  doc.font("Helvetica").fontSize(10).text(`Total HT : ${snapshot.totals.total_ex_tax} ${snapshot.currency}`, {
+    align: "right",
+  });
+  doc.text(`TVA : ${snapshot.totals.total_tax} ${snapshot.currency}`, { align: "right" });
+  doc
+    .font("Helvetica-Bold")
+    .fontSize(12)
+    .text(`Total TTC : ${snapshot.totals.total_incl_tax} ${snapshot.currency}`, { align: "right" });
+  doc
+    .font("Helvetica")
+    .fontSize(7)
+    .fillColor("#667085")
+    .text(
+      `Document légal version 1 — instantané immuable ${snapshot.uuid}.`,
+      44,
+      doc.page.height - 48,
+      { width: 507, align: "center" }
+    );
+
+  doc.end();
+  await new Promise<void>((resolve, reject) => {
+    doc.once("end", resolve);
+    doc.once("error", reject);
+  });
+  return Buffer.concat(chunks);
+}
+
+export async function writeImmutableAvoirDocument(
+  snapshot: AvoirDocumentSnapshot
+): Promise<AvoirDocumentArtifact> {
+  const documentId = crypto.randomUUID();
+  const safeNumber = snapshot.legal_number.replace(/[^a-zA-Z0-9_-]+/g, "_");
+  const fileName = `Avoir_${safeNumber}_v1.pdf`;
+  const filePath = path.join(ensureDocumentStoragePath(), `${documentId}.pdf`);
+  const pdf = await render(snapshot);
+  await fs.writeFile(filePath, pdf, { flag: "wx" });
+  return {
+    documentId,
+    fileName,
+    checksumSha256: crypto.createHash("sha256").update(pdf).digest("hex"),
+    fileSizeBytes: pdf.byteLength,
+    cleanup: async () => {
+      await fs.unlink(filePath).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== "ENOENT") throw error;
+      });
+    },
+  };
+}

--- a/src/module/facturation/services/avoir-workflow.service.ts
+++ b/src/module/facturation/services/avoir-workflow.service.ts
@@ -1,0 +1,47 @@
+import {
+  repoCreateAvoirDraft,
+  repoIssueAvoir,
+  repoListAvoirEligibleLines,
+  repoPreviewAvoir,
+  repoRequestAvoirValidation,
+  repoValidateAvoir,
+} from "../repository/avoir-workflow.repository";
+import type { FinanceActorContext } from "../repository/workflow.repository.shared";
+import type {
+  AvoirPreviewBodyDTO,
+  CreateAvoirDraftBodyDTO,
+  ValidationDecisionBodyDTO,
+  WorkflowConfirmationBodyDTO,
+} from "../validators/workflow.validators";
+import { writeImmutableAvoirDocument } from "./avoir-document.service";
+
+export const svcPreviewAvoir = (input: AvoirPreviewBodyDTO) => repoPreviewAvoir(input);
+export const svcListAvoirEligibleLines = (factureId: number) =>
+  repoListAvoirEligibleLines(factureId);
+
+export const svcCreateAvoirDraftWorkflow = (params: {
+  input: CreateAvoirDraftBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}) => repoCreateAvoirDraft(params);
+
+export const svcRequestAvoirValidation = (params: {
+  avoirId: number;
+  input: WorkflowConfirmationBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}) => repoRequestAvoirValidation(params);
+
+export const svcValidateAvoirWorkflow = (params: {
+  avoirId: number;
+  input: ValidationDecisionBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}) => repoValidateAvoir(params);
+
+export const svcIssueAvoirWorkflow = (params: {
+  avoirId: number;
+  input: WorkflowConfirmationBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}) => repoIssueAvoir({ ...params, writeDocument: writeImmutableAvoirDocument });

--- a/src/module/facturation/services/avoirs.service.ts
+++ b/src/module/facturation/services/avoirs.service.ts
@@ -1,12 +1,31 @@
 import type { CreateAvoirBodyDTO, ListAvoirsQueryDTO, UpdateAvoirBodyDTO } from "../validators/avoirs.validators";
-import { repoCreateAvoir, repoDeleteAvoir, repoGetAvoir, repoListAvoirs, repoUpdateAvoir } from "../repository/avoirs.repository";
+import { repoGetAvoir, repoListAvoirs } from "../repository/avoirs.repository";
+import { HttpError } from "../../../utils/httpError";
 
 export const svcListAvoirs = (filters: ListAvoirsQueryDTO) => repoListAvoirs(filters);
 
 export const svcGetAvoir = (id: number, include: string) => repoGetAvoir(id, include);
 
-export const svcCreateAvoir = (input: CreateAvoirBodyDTO) => repoCreateAvoir(input);
+export const svcCreateAvoir = (_input: CreateAvoirBodyDTO) => {
+  throw new HttpError(
+    409,
+    "AVOIR_WORKFLOW_REQUIRED",
+    "La création directe est désactivée. Utilisez l'aperçu puis le workflow d'avoir."
+  );
+};
 
-export const svcUpdateAvoir = (id: number, input: UpdateAvoirBodyDTO) => repoUpdateAvoir(id, input);
+export const svcUpdateAvoir = (_id: number, _input: UpdateAvoirBodyDTO) => {
+  throw new HttpError(
+    409,
+    "AVOIR_WORKFLOW_REQUIRED",
+    "La modification directe est désactivée. Recréez l'aperçu dans le workflow d'avoir."
+  );
+};
 
-export const svcDeleteAvoir = (id: number) => repoDeleteAvoir(id);
+export const svcDeleteAvoir = (_id: number) => {
+  throw new HttpError(
+    409,
+    "AVOIR_DELETE_FORBIDDEN",
+    "Un avoir financier ne se supprime pas."
+  );
+};

--- a/src/module/facturation/services/facture-workflow.service.ts
+++ b/src/module/facturation/services/facture-workflow.service.ts
@@ -1,0 +1,53 @@
+import {
+  repoCreateFactureDraft,
+  repoIssueFacture,
+  repoListEligibleFactureSources,
+  repoPreviewFacture,
+  repoRequestFactureValidation,
+  repoValidateFacture,
+} from "../repository/facture-workflow.repository";
+import type { FinanceActorContext } from "../repository/workflow.repository.shared";
+import type {
+  CreateFactureDraftBodyDTO,
+  EligibleSourcesQueryDTO,
+  FacturePreviewBodyDTO,
+  ValidationDecisionBodyDTO,
+  WorkflowConfirmationBodyDTO,
+} from "../validators/workflow.validators";
+import { writeImmutableFactureDocument } from "./finance-document.service";
+
+export const svcListEligibleFactureSources = (filters: EligibleSourcesQueryDTO) =>
+  repoListEligibleFactureSources(filters);
+
+export const svcPreviewFacture = (input: FacturePreviewBodyDTO) => repoPreviewFacture(input);
+
+export const svcCreateFactureDraft = (params: {
+  input: CreateFactureDraftBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}) => repoCreateFactureDraft(params);
+
+export const svcRequestFactureValidation = (params: {
+  factureId: number;
+  input: WorkflowConfirmationBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}) => repoRequestFactureValidation(params);
+
+export const svcValidateFacture = (params: {
+  factureId: number;
+  input: ValidationDecisionBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}) => repoValidateFacture(params);
+
+export const svcIssueFacture = (params: {
+  factureId: number;
+  input: WorkflowConfirmationBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}) =>
+  repoIssueFacture({
+    ...params,
+    writeDocument: writeImmutableFactureDocument,
+  });

--- a/src/module/facturation/services/factures.service.ts
+++ b/src/module/facturation/services/factures.service.ts
@@ -4,19 +4,35 @@ import type {
   UpdateFactureBodyDTO,
 } from "../validators/factures.validators";
 import {
-  repoCreateFacture,
-  repoDeleteFacture,
   repoGetFacture,
   repoListFactures,
-  repoUpdateFacture,
 } from "../repository/factures.repository";
+import { HttpError } from "../../../utils/httpError";
 
 export const svcListFactures = (filters: ListFacturesQueryDTO) => repoListFactures(filters);
 
 export const svcGetFacture = (id: number, include: string) => repoGetFacture(id, include);
 
-export const svcCreateFacture = (input: CreateFactureBodyDTO) => repoCreateFacture(input);
+export const svcCreateFacture = (_input: CreateFactureBodyDTO) => {
+  throw new HttpError(
+    409,
+    "FACTURE_WORKFLOW_REQUIRED",
+    "La création directe est désactivée. Utilisez l'aperçu puis la création explicite du workflow Finance."
+  );
+};
 
-export const svcUpdateFacture = (id: number, input: UpdateFactureBodyDTO) => repoUpdateFacture(id, input);
+export const svcUpdateFacture = (_id: number, _input: UpdateFactureBodyDTO) => {
+  throw new HttpError(
+    409,
+    "FACTURE_WORKFLOW_REQUIRED",
+    "La modification directe est désactivée. Recréez l'aperçu dans le workflow Finance."
+  );
+};
 
-export const svcDeleteFacture = (id: number) => repoDeleteFacture(id);
+export const svcDeleteFacture = (_id: number) => {
+  throw new HttpError(
+    409,
+    "FACTURE_DELETE_FORBIDDEN",
+    "Une facture ne se supprime pas. Un document émis se corrige par avoir."
+  );
+};

--- a/src/module/facturation/services/finance-document.service.ts
+++ b/src/module/facturation/services/finance-document.service.ts
@@ -1,0 +1,274 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import PDFDocument from "pdfkit";
+
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
+import type {
+  FinanceDocumentArtifact,
+  FinanceDocumentSnapshot,
+} from "../repository/facture-workflow.repository";
+
+function textValue(source: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = source[key];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function renderParty(
+  doc: PDFKit.PDFDocument,
+  title: string,
+  party: Record<string, unknown>
+): void {
+  doc.font("Helvetica-Bold").fontSize(10).fillColor("#172033").text(title);
+  doc.font("Helvetica").fontSize(9).fillColor("#172033");
+
+  const nestedAddress =
+    party.billing_address && typeof party.billing_address === "object"
+      ? (party.billing_address as Record<string, unknown>)
+      : {};
+  const addressLine = [
+    textValue(nestedAddress, "house_number"),
+    textValue(nestedAddress, "street"),
+  ]
+    .filter(Boolean)
+    .join(" ");
+  const lines = [
+    textValue(party, "company_name", "name", "raison_sociale"),
+    textValue(party, "address_line_1", "address", "adresse") || addressLine,
+    textValue(party, "address_line_2", "adresse_complement") ||
+      textValue(nestedAddress, "address_complement"),
+    [
+      textValue(party, "postal_code", "code_postal") ||
+        textValue(nestedAddress, "postal_code"),
+      textValue(party, "city", "ville") || textValue(nestedAddress, "city"),
+    ]
+      .filter(Boolean)
+      .join(" "),
+    textValue(party, "country", "pays") || textValue(nestedAddress, "country"),
+  ].filter((value): value is string => Boolean(value));
+
+  for (const line of lines) doc.text(line);
+
+  const siret = textValue(party, "siret");
+  const vat = textValue(party, "vat_number", "numero_tva", "tva_intracommunautaire");
+  if (siret) doc.text(`SIRET : ${siret}`);
+  if (vat) doc.text(`TVA : ${vat}`);
+}
+
+function formatDate(value: string): string {
+  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  return match ? `${match[3]}/${match[2]}/${match[1]}` : value;
+}
+
+function renderSnapshot(doc: PDFKit.PDFDocument, snapshot: FinanceDocumentSnapshot): void {
+  doc.info.Title = `Facture ${snapshot.legal_number}`;
+  doc.info.Subject = "Facture émise depuis un instantané immuable";
+  doc.info.CreationDate = new Date(`${snapshot.issue_date}T12:00:00.000Z`);
+
+  doc
+    .font("Helvetica-Bold")
+    .fontSize(21)
+    .fillColor("#172033")
+    .text("FACTURE", { align: "right" });
+  doc.font("Helvetica").fontSize(10);
+  doc.text(`N° ${snapshot.legal_number}`, { align: "right" });
+  doc.text(`Émise le ${formatDate(snapshot.issue_date)}`, { align: "right" });
+  doc.text(`Référence brouillon ${snapshot.draft_reference}`, { align: "right" });
+
+  const partyY = Math.max(doc.y + 22, 105);
+  doc.save();
+  doc.rect(40, partyY, 250, 112).fillAndStroke("#f7f9fc", "#d8dee9");
+  doc.restore();
+  doc.x = 52;
+  doc.y = partyY + 12;
+  renderParty(doc, "Émetteur", snapshot.issuer_snapshot);
+
+  doc.save();
+  doc.rect(305, partyY, 250, 112).fillAndStroke("#ffffff", "#d8dee9");
+  doc.restore();
+  doc.x = 317;
+  doc.y = partyY + 12;
+  renderParty(doc, "Client facturé", snapshot.client_snapshot);
+
+  let y = partyY + 140;
+  const columns = {
+    designation: 218,
+    quantity: 55,
+    unitPrice: 72,
+    tax: 52,
+    total: 78,
+  };
+  const tableWidth = Object.values(columns).reduce((sum, value) => sum + value, 0);
+
+  const drawHeader = () => {
+    doc.save();
+    doc.rect(40, y, tableWidth, 22).fill("#172033");
+    doc.restore();
+    doc.font("Helvetica-Bold").fontSize(8).fillColor("#ffffff");
+    doc.text("Désignation", 46, y + 7, { width: columns.designation - 12 });
+    doc.text("Qté", 40 + columns.designation, y + 7, {
+      width: columns.quantity - 6,
+      align: "right",
+    });
+    doc.text("PU HT", 40 + columns.designation + columns.quantity, y + 7, {
+      width: columns.unitPrice - 6,
+      align: "right",
+    });
+    doc.text("TVA", 40 + columns.designation + columns.quantity + columns.unitPrice, y + 7, {
+      width: columns.tax - 6,
+      align: "right",
+    });
+    doc.text(
+      "Total TTC",
+      40 + columns.designation + columns.quantity + columns.unitPrice + columns.tax,
+      y + 7,
+      { width: columns.total - 6, align: "right" }
+    );
+    y += 22;
+  };
+
+  drawHeader();
+  for (const line of snapshot.lines) {
+    const rowHeight = Math.max(
+      25,
+      doc.heightOfString(line.designation, { width: columns.designation - 12 }) + 12
+    );
+    if (y + rowHeight > doc.page.height - 150) {
+      doc.addPage();
+      y = 45;
+      drawHeader();
+    }
+    doc.save();
+    doc.rect(40, y, tableWidth, rowHeight).fillAndStroke("#ffffff", "#e5e9f0");
+    doc.restore();
+    doc.font("Helvetica").fontSize(8).fillColor("#172033");
+    doc.text(line.designation, 46, y + 7, { width: columns.designation - 12 });
+    doc.text(line.quantity, 40 + columns.designation, y + 7, {
+      width: columns.quantity - 6,
+      align: "right",
+    });
+    doc.text(`${line.unit_price_ex_tax} ${snapshot.currency}`, 40 + columns.designation + columns.quantity, y + 7, {
+      width: columns.unitPrice - 6,
+      align: "right",
+    });
+    doc.text(`${line.tax_rate_percent} %`, 40 + columns.designation + columns.quantity + columns.unitPrice, y + 7, {
+      width: columns.tax - 6,
+      align: "right",
+    });
+    doc.text(
+      `${line.total_incl_tax} ${snapshot.currency}`,
+      40 + columns.designation + columns.quantity + columns.unitPrice + columns.tax,
+      y + 7,
+      { width: columns.total - 6, align: "right" }
+    );
+    y += rowHeight;
+  }
+
+  y += 16;
+  if (y > doc.page.height - 185) {
+    doc.addPage();
+    y = 55;
+  }
+  doc.font("Helvetica").fontSize(9).fillColor("#172033");
+  doc.text(`Sous-total HT : ${snapshot.totals.subtotal_ex_tax} ${snapshot.currency}`, 315, y, {
+    width: 240,
+    align: "right",
+  });
+  y += 15;
+  if (snapshot.totals.global_discount_amount !== "0.00") {
+    doc.text(
+      `Remise globale (${snapshot.totals.global_discount_percent} %) : -${snapshot.totals.global_discount_amount} ${snapshot.currency}`,
+      315,
+      y,
+      { width: 240, align: "right" }
+    );
+    y += 15;
+  }
+  doc.text(`Total HT : ${snapshot.totals.total_ex_tax} ${snapshot.currency}`, 315, y, {
+    width: 240,
+    align: "right",
+  });
+  y += 15;
+  doc.text(`TVA : ${snapshot.totals.total_tax} ${snapshot.currency}`, 315, y, {
+    width: 240,
+    align: "right",
+  });
+  y += 17;
+  doc.font("Helvetica-Bold").fontSize(12);
+  doc.text(`Total TTC : ${snapshot.totals.total_incl_tax} ${snapshot.currency}`, 315, y, {
+    width: 240,
+    align: "right",
+  });
+  y += 29;
+
+  doc.font("Helvetica-Bold").fontSize(9).text("Échéances", 40, y);
+  doc.font("Helvetica").fontSize(9);
+  y += 15;
+  for (const due of snapshot.due_dates) {
+    doc.text(
+      `${formatDate(due.due_date)} — ${due.label} — ${due.amount} ${snapshot.currency}`,
+      40,
+      y
+    );
+    y += 14;
+  }
+
+  if (snapshot.customer_text) {
+    y += 10;
+    doc.font("Helvetica-Bold").text("Informations client", 40, y);
+    y += 14;
+    doc.font("Helvetica").text(snapshot.customer_text, 40, y, { width: 515 });
+  }
+
+  doc
+    .font("Helvetica")
+    .fontSize(7)
+    .fillColor("#667085")
+    .text(
+      `Document légal version 1 — instantané immuable ${snapshot.uuid}.`,
+      40,
+      doc.page.height - 48,
+      { width: 515, align: "center" }
+    );
+}
+
+async function buildPdf(snapshot: FinanceDocumentSnapshot): Promise<Buffer> {
+  const doc = new PDFDocument({ size: "A4", margin: 40, compress: true });
+  const chunks: Buffer[] = [];
+  doc.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
+  renderSnapshot(doc, snapshot);
+  doc.end();
+  await new Promise<void>((resolve, reject) => {
+    doc.once("end", resolve);
+    doc.once("error", reject);
+  });
+  return Buffer.concat(chunks);
+}
+
+export async function writeImmutableFactureDocument(
+  snapshot: FinanceDocumentSnapshot
+): Promise<FinanceDocumentArtifact> {
+  const documentId = crypto.randomUUID();
+  const safeNumber = snapshot.legal_number.replace(/[^a-zA-Z0-9_-]+/g, "_");
+  const fileName = `Facture_${safeNumber}_v1.pdf`;
+  const storageRoot = ensureDocumentStoragePath();
+  const filePath = path.join(storageRoot, `${documentId}.pdf`);
+  const pdf = await buildPdf(snapshot);
+  await fs.writeFile(filePath, pdf, { flag: "wx" });
+
+  return {
+    documentId,
+    fileName,
+    checksumSha256: crypto.createHash("sha256").update(pdf).digest("hex"),
+    fileSizeBytes: pdf.byteLength,
+    cleanup: async () => {
+      await fs.unlink(filePath).catch((error: NodeJS.ErrnoException) => {
+        if (error.code !== "ENOENT") throw error;
+      });
+    },
+  };
+}

--- a/src/module/facturation/services/paiements.service.ts
+++ b/src/module/facturation/services/paiements.service.ts
@@ -1,18 +1,34 @@
 import type { CreatePaiementBodyDTO, ListPaiementsQueryDTO, UpdatePaiementBodyDTO } from "../validators/paiements.validators";
 import {
-  repoCreatePaiement,
-  repoDeletePaiement,
   repoGetPaiement,
   repoListPaiements,
-  repoUpdatePaiement,
 } from "../repository/paiements.repository";
+import { HttpError } from "../../../utils/httpError";
 
 export const svcListPaiements = (filters: ListPaiementsQueryDTO) => repoListPaiements(filters);
 
 export const svcGetPaiement = (id: number, include: string) => repoGetPaiement(id, include);
 
-export const svcCreatePaiement = (input: CreatePaiementBodyDTO) => repoCreatePaiement(input);
+export const svcCreatePaiement = (_input: CreatePaiementBodyDTO) => {
+  throw new HttpError(
+    409,
+    "PAYMENT_WORKFLOW_REQUIRED",
+    "La création directe est désactivée. Utilisez l'enregistrement idempotent du workflow Finance."
+  );
+};
 
-export const svcUpdatePaiement = (id: number, input: UpdatePaiementBodyDTO) => repoUpdatePaiement(id, input);
+export const svcUpdatePaiement = (_id: number, _input: UpdatePaiementBodyDTO) => {
+  throw new HttpError(
+    409,
+    "PAYMENT_WORKFLOW_REQUIRED",
+    "La modification directe est désactivée. Utilisez une commande Finance compensatoire."
+  );
+};
 
-export const svcDeletePaiement = (id: number) => repoDeletePaiement(id);
+export const svcDeletePaiement = (_id: number) => {
+  throw new HttpError(
+    409,
+    "PAYMENT_DELETE_FORBIDDEN",
+    "Un paiement enregistré ne se supprime pas."
+  );
+};

--- a/src/module/facturation/services/payment-workflow.service.ts
+++ b/src/module/facturation/services/payment-workflow.service.ts
@@ -1,0 +1,22 @@
+import {
+  repoAllocatePayment,
+  repoRegisterPayment,
+} from "../repository/payment-workflow.repository";
+import type { FinanceActorContext } from "../repository/workflow.repository.shared";
+import type {
+  AllocatePaymentBodyDTO,
+  RegisterPaymentBodyDTO,
+} from "../validators/workflow.validators";
+
+export const svcRegisterPaymentWorkflow = (params: {
+  input: RegisterPaymentBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}) => repoRegisterPayment(params);
+
+export const svcAllocatePaymentWorkflow = (params: {
+  paymentId: number;
+  input: AllocatePaymentBodyDTO;
+  actor: FinanceActorContext;
+  idempotencyKey: string | undefined;
+}) => repoAllocatePayment(params);

--- a/src/module/facturation/services/pdf.service.ts
+++ b/src/module/facturation/services/pdf.service.ts
@@ -118,6 +118,13 @@ async function writePdfToFile(
 export async function svcGenerateFacturePdf(factureId: number): Promise<{ document_id: string }> {
   const detail = await repoGetFacture(factureId, "client,lignes");
   if (!detail) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture not found");
+  if (["ISSUED", "PARTIALLY_PAID", "PAID"].includes(detail.facture.statut)) {
+    throw new HttpError(
+      409,
+      "FACTURE_DOCUMENT_IMMUTABLE",
+      "Le PDF légal émis est immuable et ne peut pas être régénéré."
+    );
+  }
 
   const docsDir = await ensureDocsDir();
   const documentId = crypto.randomUUID();
@@ -190,6 +197,13 @@ export async function svcGenerateFacturePdf(factureId: number): Promise<{ docume
 export async function svcGenerateAvoirPdf(avoirId: number): Promise<{ document_id: string }> {
   const detail = await repoGetAvoir(avoirId, "client,lignes,facture");
   if (!detail) throw new HttpError(404, "AVOIR_NOT_FOUND", "Avoir not found");
+  if (detail.avoir.statut === "ISSUED") {
+    throw new HttpError(
+      409,
+      "AVOIR_DOCUMENT_IMMUTABLE",
+      "Le PDF légal émis est immuable et ne peut pas être régénéré."
+    );
+  }
 
   const docsDir = await ensureDocsDir();
   const documentId = crypto.randomUUID();

--- a/src/module/facturation/types/workflow.types.ts
+++ b/src/module/facturation/types/workflow.types.ts
@@ -1,0 +1,147 @@
+import type {
+  AvoirWorkflowStatus,
+  FactureWorkflowStatus,
+  PaymentStatus,
+} from "../domain/finance-policy";
+
+export type FinanceBlocker = {
+  code: string;
+  message: string;
+  source_line_id?: string;
+};
+
+export type EligibleDeliverySource = {
+  source_type: "DELIVERY_LINE";
+  source_id: string;
+  source_line_id: string;
+  delivery_number: string;
+  delivery_status: "SHIPPED" | "DELIVERED";
+  client_id: string;
+  client_name: string;
+  commande_id: number | null;
+  affaire_id: number | null;
+  commande_line_id: number | null;
+  designation: string;
+  code_piece: string | null;
+  unit: string | null;
+  quantity_source: string;
+  quantity_already_invoiced: string;
+  quantity_already_credited: string;
+  quantity_remaining: string;
+  unit_price_ex_tax: string | null;
+  discount_percent: string | null;
+  tax_rate_percent: string | null;
+  pricing_version: string | null;
+  rule_code: string;
+  blockers: FinanceBlocker[];
+};
+
+export type FacturePreviewLine = {
+  source_type: "DELIVERY_LINE" | "MILESTONE" | "DEPOSIT";
+  source_id: string;
+  source_line_id: string;
+  designation: string;
+  code_piece: string | null;
+  quantity: string;
+  unit: string | null;
+  unit_price_ex_tax: string;
+  discount_percent: string;
+  tax_rate_percent: string;
+  total_ex_tax: string;
+  tax_amount: string;
+  total_incl_tax: string;
+  pricing_version: string | null;
+  rule_code: string;
+};
+
+export type FinanceDueDate = {
+  id?: string;
+  due_date: string;
+  label: string;
+  amount: string;
+  allocated_amount?: string;
+  balance?: string;
+  status?: "OPEN" | "PARTIALLY_PAID" | "PAID" | "OVERDUE";
+};
+
+export type FacturePreview = {
+  preview_version: 1;
+  client_id: string;
+  currency: string;
+  lines: FacturePreviewLine[];
+  totals: {
+    subtotal_ex_tax: string;
+    global_discount_percent: string;
+    global_discount_amount: string;
+    total_ex_tax: string;
+    total_tax: string;
+    total_incl_tax: string;
+  };
+  due_dates: FinanceDueDate[];
+  blockers: FinanceBlocker[];
+  warnings: FinanceBlocker[];
+  preview_hash: string;
+};
+
+export type FinanceCommandResult = {
+  id: number;
+  uuid: string;
+  draft_reference: string;
+  legal_number: string | null;
+  status: FactureWorkflowStatus | AvoirWorkflowStatus;
+  row_version: number;
+  correlation_id: string;
+  idempotent_replay: boolean;
+};
+
+export type AvoirPreviewLine = {
+  facture_line_id: number;
+  designation: string;
+  code_piece: string | null;
+  quantity_invoiced: string;
+  quantity_already_credited: string;
+  quantity_remaining: string;
+  quantity_selected: string;
+  unit: string | null;
+  unit_price_ex_tax: string;
+  discount_percent: string;
+  tax_rate_percent: string;
+  total_ex_tax: string;
+  tax_amount: string;
+  total_incl_tax: string;
+};
+
+export type AvoirPreview = {
+  preview_version: 1;
+  facture_id: number;
+  facture_number: string;
+  client_id: string;
+  currency: string;
+  reason_code: string;
+  reason: string;
+  lines: AvoirPreviewLine[];
+  totals: {
+    subtotal_ex_tax: string;
+    global_discount_percent: string;
+    global_discount_amount: string;
+    total_ex_tax: string;
+    total_tax: string;
+    total_incl_tax: string;
+  };
+  blockers: FinanceBlocker[];
+  warnings: FinanceBlocker[];
+  preview_hash: string;
+};
+
+export type PaymentCommandResult = {
+  id: number;
+  uuid: string;
+  code: string;
+  status: PaymentStatus;
+  row_version: number;
+  amount: string;
+  allocated_amount: string;
+  available_amount: string;
+  correlation_id: string;
+  idempotent_replay: boolean;
+};

--- a/src/module/facturation/validators/workflow.validators.ts
+++ b/src/module/facturation/validators/workflow.validators.ts
@@ -1,0 +1,197 @@
+import { z } from "zod";
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date attendue au format YYYY-MM-DD");
+const decimal = (maxDecimals: number, label: string) =>
+  z
+    .string()
+    .trim()
+    .regex(
+      new RegExp(`^(?:0|[1-9]\\d*)(?:\\.\\d{1,${maxDecimals}})?$`),
+      `${label} doit être un nombre décimal positif avec au plus ${maxDecimals} décimales`
+    );
+
+export const financeUuidParamsSchema = z
+  .object({
+    id: z.string().uuid(),
+  })
+  .strict();
+
+export const financeLegacyIdParamsSchema = z
+  .object({
+    id: z.coerce.number().int().positive(),
+  })
+  .strict();
+
+export const eligibleSourcesQuerySchema = z
+  .object({
+    q: z.string().trim().max(120).optional(),
+    client_id: z.string().trim().min(1).max(120).optional(),
+    commande_id: z.coerce.number().int().positive().optional(),
+    affaire_id: z.coerce.number().int().positive().optional(),
+    page: z.coerce.number().int().min(1).optional().default(1),
+    pageSize: z.coerce.number().int().min(1).max(100).optional().default(25),
+  })
+  .strict();
+
+export type EligibleSourcesQueryDTO = z.infer<typeof eligibleSourcesQuerySchema>;
+
+const sourceSelectionSchema = z
+  .object({
+    source_type: z.enum(["DELIVERY_LINE", "MILESTONE", "DEPOSIT"]),
+    source_id: z.string().trim().min(1).max(200),
+    source_line_id: z.string().trim().min(1).max(200),
+    quantity: decimal(3, "Quantité"),
+  })
+  .strict();
+
+const dueDateSchema = z
+  .object({
+    due_date: isoDate,
+    amount: decimal(2, "Montant d'échéance").optional(),
+    label: z.string().trim().min(1).max(120),
+  })
+  .strict();
+
+export const facturePreviewBodySchema = z
+  .object({
+    client_id: z.string().trim().min(1).max(120),
+    currency: z.string().trim().toUpperCase().regex(/^[A-Z]{3}$/).default("EUR"),
+    sources: z.array(sourceSelectionSchema).min(1).max(200),
+    global_discount_percent: decimal(4, "Remise globale").default("0"),
+    due_dates: z.array(dueDateSchema).min(1).max(24),
+    internal_comment: z.string().trim().max(4000).optional().nullable(),
+    customer_text: z.string().trim().max(4000).optional().nullable(),
+  })
+  .strict();
+
+export type FacturePreviewBodyDTO = z.infer<typeof facturePreviewBodySchema>;
+
+export const createFactureDraftBodySchema = facturePreviewBodySchema
+  .extend({
+    preview_hash: z.string().regex(/^[a-f0-9]{64}$/i),
+  })
+  .strict();
+
+export type CreateFactureDraftBodyDTO = z.infer<typeof createFactureDraftBodySchema>;
+
+export const workflowConfirmationBodySchema = z
+  .object({
+    expected_version: z.coerce.number().int().positive(),
+    preview_hash: z.string().regex(/^[a-f0-9]{64}$/i),
+    confirm: z.literal(true),
+  })
+  .strict();
+
+export type WorkflowConfirmationBodyDTO = z.infer<typeof workflowConfirmationBodySchema>;
+
+export const validationDecisionBodySchema = z
+  .object({
+    expected_version: z.coerce.number().int().positive(),
+    decision: z.enum(["APPROVE", "RETURN"]),
+    reason: z.string().trim().min(3).max(2000).optional().nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.decision === "RETURN" && !value.reason) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["reason"],
+        message: "Un motif est requis pour retourner le brouillon.",
+      });
+    }
+  });
+
+export type ValidationDecisionBodyDTO = z.infer<typeof validationDecisionBodySchema>;
+
+const avoirLineSelectionSchema = z
+  .object({
+    facture_line_id: z.coerce.number().int().positive(),
+    quantity: decimal(3, "Quantité créditée"),
+  })
+  .strict();
+
+export const avoirPreviewBodySchema = z
+  .object({
+    facture_id: z.coerce.number().int().positive(),
+    reason_code: z.enum([
+      "RETURN",
+      "QUALITY",
+      "PRICE_CORRECTION",
+      "QUANTITY_CORRECTION",
+      "COMMERCIAL_GESTURE",
+      "OTHER",
+    ]),
+    reason: z.string().trim().min(3).max(2000),
+    lines: z.array(avoirLineSelectionSchema).min(1).max(200),
+  })
+  .strict();
+
+export type AvoirPreviewBodyDTO = z.infer<typeof avoirPreviewBodySchema>;
+
+export const createAvoirDraftBodySchema = avoirPreviewBodySchema
+  .extend({
+    preview_hash: z.string().regex(/^[a-f0-9]{64}$/i),
+  })
+  .strict();
+
+export type CreateAvoirDraftBodyDTO = z.infer<typeof createAvoirDraftBodySchema>;
+
+const paymentAllocationSchema = z
+  .object({
+    target_type: z.enum(["FACTURE", "ECHEANCE"]),
+    target_id: z.string().trim().min(1).max(120),
+    amount: decimal(2, "Montant alloué"),
+    variance_reason: z.string().trim().min(3).max(500).optional().nullable(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (/^0(?:\.0+)?$/.test(value.amount)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["amount"],
+        message: "Le montant alloué doit être strictement positif.",
+      });
+    }
+  });
+
+export const registerPaymentBodySchema = z
+  .object({
+    client_id: z.string().trim().min(1).max(120),
+    value_date: isoDate,
+    booking_date: isoDate,
+    amount: decimal(2, "Montant du paiement"),
+    currency: z.string().trim().toUpperCase().regex(/^[A-Z]{3}$/).default("EUR"),
+    mode: z.string().trim().min(1).max(80),
+    reference: z.string().trim().min(1).max(200),
+    proof_document_id: z.string().uuid().optional().nullable(),
+    comment: z.string().trim().max(2000).optional().nullable(),
+    allocations: z.array(paymentAllocationSchema).max(200).optional().default([]),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (/^0(?:\.0+)?$/.test(value.amount)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["amount"],
+        message: "Le montant du paiement doit être strictement positif.",
+      });
+    }
+    if (value.booking_date < value.value_date) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["booking_date"],
+        message: "La date comptable ne peut pas précéder la date de valeur.",
+      });
+    }
+  });
+
+export type RegisterPaymentBodyDTO = z.infer<typeof registerPaymentBodySchema>;
+
+export const allocatePaymentBodySchema = z
+  .object({
+    expected_version: z.coerce.number().int().positive(),
+    allocations: z.array(paymentAllocationSchema).min(1).max(200),
+  })
+  .strict();
+
+export type AllocatePaymentBodyDTO = z.infer<typeof allocatePaymentBodySchema>;


### PR DESCRIPTION
## Résumé

Ajoute le workflow Finance autoritaire associé à BigFootLime/crp-systems-web#227.

- factures explicites depuis les lignes de BL éligibles
- montants décimaux exacts et aperçus signés par hash
- transitions, séparation des tâches, RBAC exact et idempotence
- avoirs plafonnés aux quantités encore créditables
- paiements partiels et allocations multi-cibles contrôlées
- snapshots/PDF immuables, audit et outbox
- patch SQL additif avec preflight, vérification et rollback gardés sur `cerp_test`

## Validation

- typecheck réussi
- 86 fichiers de tests et 1 423 tests réussis
- `git diff --check` réussi

## Activation

Le patch SQL n’a pas été appliqué. Il n’insère aucune politique Finance active ni séquence légale active. L’activation reste soumise à validation Finance/Juridique et aux 120 scénarios d’intégration documentés dans le dépôt frontend.