### PR TITLE
release: promouvoir le correctif Paiements #126 vers main

### DIFF
--- a/src/module/facturation/repository/paiements.repository.test.ts
+++ b/src/module/facturation/repository/paiements.repository.test.ts
@@ -1,0 +1,174 @@
+// #126 — Garde-fou : un reglement enregistre mais pas encore affecte
+// (`facture_id IS NULL`, `status='UNALLOCATED'`) doit rester VISIBLE dans la liste et
+// compte dans le total. Un INNER JOIN sur `facture` le faisait disparaitre en silence.
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { repoGetPaiement, repoListPaiements } from "./paiements.repository";
+
+const query = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../config/database", () => ({
+  default: { query },
+}));
+
+type Sql = { text: string; values: unknown[] };
+
+function capturedSql(): Sql[] {
+  return query.mock.calls.map(([text, values]) => ({ text: String(text), values: values ?? [] }));
+}
+
+const baseFilters = {
+  page: 1,
+  pageSize: 20,
+  sortBy: "date_paiement" as const,
+  sortDir: "desc" as const,
+  include: "client,facture",
+};
+
+describe("repoListPaiements — visibilite des reglements non affectes", () => {
+  beforeEach(() => {
+    query.mockReset();
+  });
+
+  it("joint la facture en LEFT JOIN dans le comptage ET dans les donnees", async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ total: 1 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await repoListPaiements({ ...baseFilters });
+
+    const [countSql, dataSql] = capturedSql();
+    expect(countSql.text).toContain("LEFT JOIN facture");
+    expect(countSql.text).not.toMatch(/(?<!LEFT )JOIN facture/);
+    expect(dataSql.text).toContain("LEFT JOIN facture");
+    expect(dataSql.text).not.toMatch(/(?<!LEFT )JOIN facture/);
+  });
+
+  it("expose status et workflow_status dans le contrat de liste", async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ total: 0 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await repoListPaiements({ ...baseFilters });
+
+    const [, dataSql] = capturedSql();
+    expect(dataSql.text).toContain("p.status");
+    expect(dataSql.text).toContain("p.workflow_status");
+  });
+
+  it("renvoie facture_id null et facture null sans lever, pour un reglement non affecte", async () => {
+    query.mockResolvedValueOnce({ rows: [{ total: 1 }] }).mockResolvedValueOnce({
+      rows: [
+        {
+          id: "42",
+          facture_id: null,
+          client_id: "CLI-1",
+          date_paiement: "2026-07-20",
+          montant: 1500.5,
+          mode: "Virement",
+          reference: "VIR-9001",
+          status: "UNALLOCATED",
+          workflow_status: "RECORDED",
+          updated_at: "2026-07-20T10:00:00.000Z",
+          client: null,
+          facture: null,
+        },
+      ],
+    });
+
+    const result = await repoListPaiements({ ...baseFilters });
+
+    expect(result.total).toBe(1);
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0].id).toBe(42);
+    expect(result.items[0].facture_id).toBeNull();
+    expect(result.items[0].facture).toBeNull();
+    expect(result.items[0].status).toBe("UNALLOCATED");
+    expect(result.items[0].workflow_status).toBe("RECORDED");
+  });
+
+  it("convertit toujours facture_id en entier quand le reglement est affecte", async () => {
+    query.mockResolvedValueOnce({ rows: [{ total: 1 }] }).mockResolvedValueOnce({
+      rows: [
+        {
+          id: "7",
+          facture_id: "1234",
+          client_id: "CLI-1",
+          date_paiement: "2026-07-20",
+          montant: 100,
+          mode: null,
+          reference: null,
+          status: "ALLOCATED",
+          workflow_status: "ALLOCATED",
+          updated_at: "2026-07-20T10:00:00.000Z",
+          client: null,
+          facture: { id: 1234, numero: "FA-2026-0001", client_id: "CLI-1" },
+        },
+      ],
+    });
+
+    const result = await repoListPaiements({ ...baseFilters });
+
+    expect(result.items[0].facture_id).toBe(1234);
+    expect(result.items[0].facture).toEqual({ id: 1234, numero: "FA-2026-0001", client_id: "CLI-1" });
+  });
+
+  it("filtre sur status cote serveur", async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ total: 0 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await repoListPaiements({ ...baseFilters, status: "UNALLOCATED" });
+
+    const [countSql] = capturedSql();
+    expect(countSql.text).toContain("p.status =");
+    expect(countSql.values).toContain("UNALLOCATED");
+  });
+
+  it("expose un raccourci `unallocated` qui filtre sur l'absence de facture", async () => {
+    query
+      .mockResolvedValueOnce({ rows: [{ total: 0 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await repoListPaiements({ ...baseFilters, unallocated: true });
+
+    const [countSql] = capturedSql();
+    expect(countSql.text).toContain("p.facture_id IS NULL");
+  });
+});
+
+describe("repoGetPaiement — lecture d'un reglement non affecte", () => {
+  beforeEach(() => {
+    query.mockReset();
+  });
+
+  it("ne renvoie plus 404 faute de facture rattachee", async () => {
+    query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "42",
+          facture_id: null,
+          client_id: "CLI-1",
+          date_paiement: "2026-07-20",
+          montant: 1500.5,
+          mode: "Virement",
+          reference: "VIR-9001",
+          commentaire: null,
+          status: "UNALLOCATED",
+          workflow_status: "RECORDED",
+          created_at: "2026-07-20T10:00:00.000Z",
+          updated_at: "2026-07-20T10:00:00.000Z",
+          client: null,
+          facture: null,
+        },
+      ],
+    });
+
+    const paiement = await repoGetPaiement(42, "client,facture");
+
+    expect(paiement).not.toBeNull();
+    expect(paiement?.facture_id).toBeNull();
+    expect(paiement?.status).toBe("UNALLOCATED");
+    expect(capturedSql()[0].text).toContain("LEFT JOIN facture");
+  });
+});

--- a/src/module/facturation/repository/paiements.repository.ts
+++ b/src/module/facturation/repository/paiements.repository.ts
@@ -76,6 +76,17 @@ function buildListWhere(filters: ListPaiementsQueryDTO, includeClientInSearch: b
     where.push(`p.facture_id = ${p}::bigint`);
   }
 
+  // #126 — Filtre serveur sur l'etat d'affectation, pour alimenter une file
+  // « reglements a affecter » sans calcul cote interface.
+  if (filters.status && filters.status.trim().length > 0) {
+    const p = push(filters.status.trim());
+    where.push(`p.status = ${p}`);
+  }
+
+  if (filters.unallocated === true) {
+    where.push(`p.facture_id IS NULL`);
+  }
+
   if (filters.from) {
     const p = push(filters.from);
     where.push(`p.date_paiement >= ${p}::date`);
@@ -102,7 +113,10 @@ export async function repoListPaiements(filters: ListPaiementsQueryDTO): Promise
   const pageSize = filters.pageSize ?? 20;
   const offset = (page - 1) * pageSize;
 
-  const joinFactureSql = "JOIN facture f ON f.id = p.facture_id";
+  // #126 — LEFT JOIN obligatoire : `paiement.facture_id` est nullable (un reglement est
+  // d'abord enregistre `RECORDED`/`UNALLOCATED` puis affecte). Un INNER JOIN faisait
+  // disparaitre silencieusement de la liste ET du comptage tout reglement non affecte.
+  const joinFactureSql = "LEFT JOIN facture f ON f.id = p.facture_id";
   const joinClientSql = joinClient ? "LEFT JOIN clients c ON c.client_id = p.client_id" : "";
 
   const clientSelectSql = includeClient
@@ -116,12 +130,13 @@ export async function repoListPaiements(filters: ListPaiementsQueryDTO): Promise
       ) END AS client`
     : "NULL AS client";
 
+  // Le reglement peut n'avoir aucune facture : on renvoie alors `null`, pas un objet vide.
   const factureSelectSql = includeFacture
-    ? `jsonb_build_object(
+    ? `CASE WHEN f.id IS NULL THEN NULL ELSE jsonb_build_object(
         'id', f.id,
         'numero', f.numero,
         'client_id', f.client_id
-      ) AS facture`
+      ) END AS facture`
     : "NULL AS facture";
 
   const { whereSql, values } = buildListWhere(filters, joinClient);
@@ -147,6 +162,8 @@ export async function repoListPaiements(filters: ListPaiementsQueryDTO): Promise
       p.montant::float8 AS montant,
       p.mode,
       p.reference,
+      p.status,
+      p.workflow_status,
       p.updated_at::text AS updated_at,
       ${clientSelectSql},
       ${factureSelectSql}
@@ -162,7 +179,7 @@ export async function repoListPaiements(filters: ListPaiementsQueryDTO): Promise
 
   type Row = Omit<PaiementListItem, "id" | "facture_id" | "client" | "facture"> & {
     id: string;
-    facture_id: string;
+    facture_id: string | null;
     client: ClientLite | null;
     facture: { id: number; numero: string; client_id: string } | null;
   };
@@ -171,7 +188,7 @@ export async function repoListPaiements(filters: ListPaiementsQueryDTO): Promise
   const items: PaiementListItem[] = dataRes.rows.map((r) => ({
     ...r,
     id: toInt(r.id, "paiement.id"),
-    facture_id: toInt(r.facture_id, "paiement.facture_id"),
+    facture_id: r.facture_id === null ? null : toInt(r.facture_id, "paiement.facture_id"),
     client: includeClient ? r.client : undefined,
     facture: includeFacture ? r.facture : undefined,
   }));
@@ -184,7 +201,8 @@ export async function repoGetPaiement(id: number, includeValue: string): Promise
   const includeClient = includes.has("client");
   const includeFacture = includes.has("facture");
 
-  const joinFactureSql = includeFacture ? "JOIN facture f ON f.id = p.facture_id" : "";
+  // #126 — LEFT JOIN : sinon la lecture d'un reglement non affecte renvoyait 404.
+  const joinFactureSql = includeFacture ? "LEFT JOIN facture f ON f.id = p.facture_id" : "";
   const joinClientSql = includeClient ? "LEFT JOIN clients c ON c.client_id = p.client_id" : "";
 
   const clientSelectSql = includeClient
@@ -199,11 +217,11 @@ export async function repoGetPaiement(id: number, includeValue: string): Promise
     : "NULL AS client";
 
   const factureSelectSql = includeFacture
-    ? `jsonb_build_object(
+    ? `CASE WHEN f.id IS NULL THEN NULL ELSE jsonb_build_object(
         'id', f.id,
         'numero', f.numero,
         'client_id', f.client_id
-      ) AS facture`
+      ) END AS facture`
     : "NULL AS facture";
 
   const sql = `
@@ -216,6 +234,8 @@ export async function repoGetPaiement(id: number, includeValue: string): Promise
       p.mode,
       p.reference,
       p.commentaire,
+      p.status,
+      p.workflow_status,
       p.created_at::text AS created_at,
       p.updated_at::text AS updated_at,
       ${clientSelectSql},
@@ -228,7 +248,7 @@ export async function repoGetPaiement(id: number, includeValue: string): Promise
 
   type Row = Omit<Paiement, "id" | "facture_id" | "client" | "facture"> & {
     id: string;
-    facture_id: string;
+    facture_id: string | null;
     client: ClientLite | null;
     facture: { id: number; numero: string; client_id: string } | null;
   };
@@ -240,7 +260,7 @@ export async function repoGetPaiement(id: number, includeValue: string): Promise
   return {
     ...row,
     id: toInt(row.id, "paiement.id"),
-    facture_id: toInt(row.facture_id, "paiement.facture_id"),
+    facture_id: row.facture_id === null ? null : toInt(row.facture_id, "paiement.facture_id"),
     client: includeClient ? row.client : undefined,
     facture: includeFacture ? row.facture : undefined,
   };

--- a/src/module/facturation/types/paiements.types.ts
+++ b/src/module/facturation/types/paiements.types.ts
@@ -6,15 +6,32 @@ export type FactureLite = {
   client_id: string;
 };
 
+// #126 — Statuts portes par la base depuis le patch #227 :
+// contraintes `paiement_status_227_ck` et `paiement_workflow_status_227_ck`.
+export const PAIEMENT_STATUSES = [
+  "UNALLOCATED",
+  "PARTIALLY_ALLOCATED",
+  "ALLOCATED",
+  "REJECTED",
+  "REVERSED",
+] as const;
+export type PaiementStatus = (typeof PAIEMENT_STATUSES)[number];
+
+export const PAIEMENT_WORKFLOW_STATUSES = ["RECORDED", "ALLOCATED", "REVERSED"] as const;
+export type PaiementWorkflowStatus = (typeof PAIEMENT_WORKFLOW_STATUSES)[number];
+
 export type Paiement = {
   id: number;
-  facture_id: number;
+  /** Nullable : un reglement enregistre n'est pas encore forcement affecte a une facture. */
+  facture_id: number | null;
   client_id: string;
   date_paiement: string;
   montant: number;
   mode: string | null;
   reference: string | null;
   commentaire: string | null;
+  status: string | null;
+  workflow_status: string | null;
   created_at: string;
   updated_at: string;
   facture?: FactureLite | null;
@@ -23,12 +40,15 @@ export type Paiement = {
 
 export type PaiementListItem = {
   id: number;
-  facture_id: number;
+  /** Nullable : voir `Paiement.facture_id`. */
+  facture_id: number | null;
   client_id: string;
   date_paiement: string;
   montant: number;
   mode: string | null;
   reference: string | null;
+  status: string | null;
+  workflow_status: string | null;
   updated_at: string;
   facture?: FactureLite | null;
   client?: ClientLite | null;

--- a/src/module/facturation/validators/paiements.validators.ts
+++ b/src/module/facturation/validators/paiements.validators.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+import { PAIEMENT_STATUSES } from "../types/paiements.types";
+
 const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date (expected YYYY-MM-DD)");
 
 function emptyStringToUndefined(value: unknown) {
@@ -20,6 +22,16 @@ export const listPaiementsQuerySchema = z.object({
   q: z.string().optional(),
   client_id: z.string().optional(),
   facture_id: z.coerce.number().int().positive().optional(),
+  // #126 — Etat d'affectation expose et filtrable (contrainte `paiement_status_227_ck`).
+  status: z.enum(PAIEMENT_STATUSES).optional(),
+  /** Raccourci « reglements sans facture rattachee » (file a affecter). */
+  unallocated: z
+    .preprocess((value) => {
+      if (value === "true" || value === true) return true;
+      if (value === "false" || value === false) return false;
+      return undefined;
+    }, z.boolean())
+    .optional(),
   from: isoDate.optional(),
   to: isoDate.optional(),
   page: z.coerce.number().int().min(1).optional().default(1),


### PR DESCRIPTION
## Ce qui change

- promeut le correctif Paiements #126 déjà fusionné dans `dev` via la PR #127
- rend les règlements non affectés visibles dans le workflow Facturation
- conserve l’historique de release après synchronisation `main` → `dev` via la PR #128

## Validation

- TypeScript : réussi
- suite backend complète : réussie
- arbre testé identique à l’état fonctionnel de `dev`

Release demandée explicitement pour réaligner `main` sur l’état validé de `dev`.

## Summary by Sourcery

Align payments listing and retrieval with nullable invoice associations and new status fields to keep unallocated payments visible and filterable.

New Features:
- Expose payment allocation and workflow status in list and detail endpoints.
- Add server-side filters for payment status and unallocated payments in the billing workflow.

Bug Fixes:
- Ensure payments without an attached invoice remain visible in listings, counts, and individual retrievals instead of being dropped or returning 404.

Enhancements:
- Update payments types and validators to support nullable invoice IDs and constrained status values.
- Add repository-level tests to guard visibility and filtering behavior for unallocated payments.