### PR TITLE
release: promouvoir Qualité industrielle 360 vers main

### DIFF
--- a/db/patches/20260725_qualite_360_228.sql
+++ b/db/patches/20260725_qualite_360_228.sql
@@ -1,0 +1,1228 @@
+-- 20260725_qualite_360_228.sql
+-- Issue #228 — Qualité industrielle 360 : plans de contrôle versionnés,
+-- exécutions/mesures tracées, libération partielle, non-conformités
+-- structurées, dérogations/concessions et CAPA.
+--
+-- Propriétés du patch :
+--   * ADDITIF uniquement : aucune table/colonne/contrainte existante supprimée,
+--     aucune donnée historique modifiée, aucune valeur d'enum retirée.
+--   * IDEMPOTENT : rejouable sans effet de bord.
+--   * TRANSACTIONNEL : BEGIN/COMMIT, rien de partiel.
+--   * INACTIF : ne crée aucun plan, aucune dérogation, aucune libération et ne
+--     modifie aucun statut de lot. Le module reste piloté par l'API.
+--   * Les enums historiques (`quality_nc_status`, `quality_entity_type`) sont
+--     ÉTENDUS, jamais dupliqués par une seconde nomenclature.
+--
+-- Prérequis : PostgreSQL 12+ (ALTER TYPE ... ADD VALUE dans une transaction).
+-- Les valeurs d'enum ajoutées ici ne sont volontairement PAS utilisées dans
+-- cette même transaction (contrainte PostgreSQL documentée).
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.quality_control') IS NULL THEN
+    RAISE EXCEPTION '#228 requires the Qualité baseline (20260213_qualite_module.sql)';
+  END IF;
+  IF to_regclass('public.non_conformity') IS NULL THEN
+    RAISE EXCEPTION '#228 requires public.non_conformity';
+  END IF;
+  IF to_regclass('public.users') IS NULL THEN
+    RAISE EXCEPTION '#228 requires public.users';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 1) Extension additive des enums historiques                                */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  -- Cycle de vie NC complet demandé par #228, en conservant OPEN/ANALYSIS/
+  -- ACTION_PLAN/CLOSED déjà utilisés en production.
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'quality_nc_status') THEN
+    ALTER TYPE public.quality_nc_status ADD VALUE IF NOT EXISTS 'DRAFT';
+    ALTER TYPE public.quality_nc_status ADD VALUE IF NOT EXISTS 'DISPOSITION';
+    ALTER TYPE public.quality_nc_status ADD VALUE IF NOT EXISTS 'VERIFICATION';
+    ALTER TYPE public.quality_nc_status ADD VALUE IF NOT EXISTS 'CANCELLED';
+  END IF;
+
+  -- Nouvelles entités porteuses de documents et d'événements qualité.
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'quality_entity_type') THEN
+    ALTER TYPE public.quality_entity_type ADD VALUE IF NOT EXISTS 'PLAN';
+    ALTER TYPE public.quality_entity_type ADD VALUE IF NOT EXISTS 'DEROGATION';
+    ALTER TYPE public.quality_entity_type ADD VALUE IF NOT EXISTS 'RELEASE';
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM pg_type WHERE typname = 'quality_document_type') THEN
+    ALTER TYPE public.quality_document_type ADD VALUE IF NOT EXISTS 'PLAN';
+    ALTER TYPE public.quality_document_type ADD VALUE IF NOT EXISTS 'DEROGATION';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 2) Plans de contrôle versionnés                                            */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.quality_control_plan (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text NOT NULL,
+  version integer NOT NULL DEFAULT 1,
+  label text NOT NULL,
+  status text NOT NULL DEFAULT 'DRAFT',
+
+  trigger_type text NOT NULL,
+
+  -- Périmètre d'applicabilité (axes optionnels, au moins un axe produit).
+  article_id uuid NULL,
+  piece_technique_id uuid NULL,
+  piece_version_id uuid NULL,
+  famille_id uuid NULL,
+  operation_code text NULL,
+  fournisseur_id uuid NULL,
+
+  sampling_rule text NOT NULL DEFAULT 'ALL',
+  sampling_value numeric(12, 4) NULL,
+  sampling_justification text NULL,
+
+  owner_user_id integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  revision_reason text NULL,
+  effective_from timestamptz NULL,
+  effective_to timestamptz NULL,
+
+  supersedes_plan_id uuid NULL REFERENCES public.quality_control_plan(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  submitted_at timestamptz NULL,
+  submitted_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  published_at timestamptz NULL,
+  published_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  archived_at timestamptz NULL,
+  archived_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  updated_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+
+  CONSTRAINT quality_control_plan_status_228_ck
+    CHECK (status IN ('DRAFT', 'IN_REVIEW', 'PUBLISHED', 'ARCHIVED')),
+  CONSTRAINT quality_control_plan_trigger_228_ck
+    CHECK (trigger_type IN ('RECEPTION', 'FIRST_ARTICLE', 'IN_PROCESS', 'FINAL', 'LOT_RELEASE', 'PERIODIC', 'RECHECK')),
+  CONSTRAINT quality_control_plan_sampling_228_ck
+    CHECK (sampling_rule IN ('ALL', 'FIXED', 'PERCENT', 'FIRST_ARTICLE', 'LOT')),
+  CONSTRAINT quality_control_plan_sampling_value_228_ck
+    CHECK (
+      (sampling_rule = 'FIXED' AND sampling_value IS NOT NULL AND sampling_value >= 1)
+      OR (sampling_rule = 'PERCENT' AND sampling_value IS NOT NULL AND sampling_value > 0 AND sampling_value <= 100)
+      OR (sampling_rule NOT IN ('FIXED', 'PERCENT') AND sampling_value IS NULL)
+    ),
+  CONSTRAINT quality_control_plan_version_228_ck CHECK (version >= 1),
+  CONSTRAINT quality_control_plan_scope_228_ck
+    CHECK (
+      article_id IS NOT NULL
+      OR piece_technique_id IS NOT NULL
+      OR piece_version_id IS NOT NULL
+      OR famille_id IS NOT NULL
+    ),
+  CONSTRAINT quality_control_plan_period_228_ck
+    CHECK (effective_from IS NULL OR effective_to IS NULL OR effective_from <= effective_to),
+  CONSTRAINT quality_control_plan_published_pair_228_ck
+    CHECK ((published_at IS NULL) = (published_by IS NULL)),
+  CONSTRAINT quality_control_plan_archived_pair_228_ck
+    CHECK ((archived_at IS NULL) = (archived_by IS NULL)),
+  CONSTRAINT quality_control_plan_published_status_228_ck
+    CHECK (published_at IS NOT NULL OR status <> 'PUBLISHED'),
+  CONSTRAINT quality_control_plan_code_version_228_uq UNIQUE (code, version)
+);
+
+CREATE INDEX IF NOT EXISTS quality_control_plan_status_228_idx
+  ON public.quality_control_plan (status, trigger_type);
+CREATE INDEX IF NOT EXISTS quality_control_plan_scope_228_idx
+  ON public.quality_control_plan (piece_version_id, piece_technique_id, article_id, famille_id);
+CREATE INDEX IF NOT EXISTS quality_control_plan_code_228_idx
+  ON public.quality_control_plan (code, version DESC);
+
+CREATE TABLE IF NOT EXISTS public.quality_control_plan_characteristic (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  plan_id uuid NOT NULL
+    REFERENCES public.quality_control_plan(id) ON UPDATE RESTRICT ON DELETE CASCADE,
+
+  characteristic_key text NOT NULL,
+  position integer NOT NULL,
+  label text NOT NULL,
+  characteristic_type text NOT NULL DEFAULT 'DIMENSIONAL',
+  value_kind text NOT NULL DEFAULT 'NUMERIC',
+
+  unit text NULL,
+  nominal numeric NULL,
+  tolerance_min numeric NULL,
+  tolerance_max numeric NULL,
+  precision_digits integer NULL,
+  expected_boolean boolean NULL,
+  allowed_values jsonb NULL,
+
+  criticality text NOT NULL DEFAULT 'MAJOR',
+  mandatory boolean NOT NULL DEFAULT true,
+  requires_instrument boolean NOT NULL DEFAULT false,
+  instrument_category text NULL,
+  method text NULL,
+  acceptance_rule text NULL,
+
+  sampling_rule text NOT NULL DEFAULT 'ALL',
+  sampling_value numeric(12, 4) NULL,
+  sampling_justification text NULL,
+  trigger_type text NOT NULL DEFAULT 'FINAL',
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT quality_plan_char_type_228_ck
+    CHECK (characteristic_type IN ('DIMENSIONAL', 'VISUAL', 'DOCUMENTARY', 'MATERIAL', 'FUNCTIONAL', 'OTHER')),
+  CONSTRAINT quality_plan_char_value_kind_228_ck
+    CHECK (value_kind IN ('NUMERIC', 'BOOLEAN', 'ENUM', 'TEXT')),
+  CONSTRAINT quality_plan_char_criticality_228_ck
+    CHECK (criticality IN ('CRITICAL', 'MAJOR', 'MINOR')),
+  CONSTRAINT quality_plan_char_sampling_228_ck
+    CHECK (sampling_rule IN ('ALL', 'FIXED', 'PERCENT', 'FIRST_ARTICLE', 'LOT')),
+  CONSTRAINT quality_plan_char_sampling_value_228_ck
+    CHECK (
+      (sampling_rule = 'FIXED' AND sampling_value IS NOT NULL AND sampling_value >= 1)
+      OR (sampling_rule = 'PERCENT' AND sampling_value IS NOT NULL AND sampling_value > 0 AND sampling_value <= 100)
+      OR (sampling_rule NOT IN ('FIXED', 'PERCENT') AND sampling_value IS NULL)
+    ),
+  CONSTRAINT quality_plan_char_trigger_228_ck
+    CHECK (trigger_type IN ('RECEPTION', 'FIRST_ARTICLE', 'IN_PROCESS', 'FINAL', 'LOT_RELEASE', 'PERIODIC', 'RECHECK')),
+  CONSTRAINT quality_plan_char_position_228_ck CHECK (position >= 1),
+  CONSTRAINT quality_plan_char_tolerance_228_ck
+    CHECK (tolerance_min IS NULL OR tolerance_max IS NULL OR tolerance_min <= tolerance_max),
+  CONSTRAINT quality_plan_char_numeric_unit_228_ck
+    CHECK (value_kind <> 'NUMERIC' OR (unit IS NOT NULL AND btrim(unit) <> '')),
+  CONSTRAINT quality_plan_char_numeric_bounds_228_ck
+    CHECK (value_kind <> 'NUMERIC' OR tolerance_min IS NOT NULL OR tolerance_max IS NOT NULL),
+  CONSTRAINT quality_plan_char_boolean_228_ck
+    CHECK (value_kind <> 'BOOLEAN' OR expected_boolean IS NOT NULL),
+  CONSTRAINT quality_plan_char_enum_228_ck
+    CHECK (
+      value_kind <> 'ENUM'
+      OR (allowed_values IS NOT NULL AND jsonb_typeof(allowed_values) = 'array' AND jsonb_array_length(allowed_values) >= 1)
+    ),
+  CONSTRAINT quality_plan_char_key_228_uq UNIQUE (plan_id, characteristic_key),
+  CONSTRAINT quality_plan_char_position_228_uq UNIQUE (plan_id, position) DEFERRABLE INITIALLY DEFERRED
+);
+
+CREATE INDEX IF NOT EXISTS quality_plan_char_plan_228_idx
+  ON public.quality_control_plan_characteristic (plan_id, position);
+
+/* -------------------------------------------------------------------------- */
+/* 3) Exécutions : source typée, snapshot figé, registre de quantités         */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.quality_control
+  ADD COLUMN IF NOT EXISTS plan_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS plan_version integer NULL,
+  ADD COLUMN IF NOT EXISTS plan_snapshot jsonb NULL,
+  ADD COLUMN IF NOT EXISTS plan_snapshot_sha256 text NULL,
+  ADD COLUMN IF NOT EXISTS source_type text NULL,
+  ADD COLUMN IF NOT EXISTS source_id text NULL,
+  ADD COLUMN IF NOT EXISTS reception_ligne_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS reception_inspection_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS lot_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS article_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS fournisseur_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS bon_livraison_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS trigger_type text NULL,
+  ADD COLUMN IF NOT EXISTS verdict text NULL,
+  ADD COLUMN IF NOT EXISTS verdict_computed text NULL,
+  ADD COLUMN IF NOT EXISTS verdict_override_reason text NULL,
+  ADD COLUMN IF NOT EXISTS verdict_overridden_by integer NULL,
+  ADD COLUMN IF NOT EXISTS unite text NULL,
+  ADD COLUMN IF NOT EXISTS qty_population numeric(18, 3) NULL,
+  ADD COLUMN IF NOT EXISTS qty_controlled numeric(18, 3) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS qty_conforming numeric(18, 3) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS qty_released numeric(18, 3) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS qty_held numeric(18, 3) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS qty_scrapped numeric(18, 3) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS qty_reworked numeric(18, 3) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS qty_sorted numeric(18, 3) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS qty_returned numeric(18, 3) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS qty_consumed numeric(18, 3) NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NOT NULL DEFAULT gen_random_uuid();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_plan_228_fkey'
+      AND conrelid = 'public.quality_control'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control
+      ADD CONSTRAINT quality_control_plan_228_fkey
+      FOREIGN KEY (plan_id) REFERENCES public.quality_control_plan(id)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_verdict_228_ck'
+      AND conrelid = 'public.quality_control'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control
+      ADD CONSTRAINT quality_control_verdict_228_ck
+      CHECK (verdict IS NULL OR verdict IN ('CONFORME', 'NON_CONFORME', 'PARTIEL', 'EN_ATTENTE'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_source_type_228_ck'
+      AND conrelid = 'public.quality_control'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control
+      ADD CONSTRAINT quality_control_source_type_228_ck
+      CHECK (
+        source_type IS NULL
+        OR source_type IN (
+          'RECEPTION_LINE', 'OF', 'OF_OPERATION', 'LOT', 'STOCK_LEVEL',
+          'ARTICLE', 'PIECE_TECHNIQUE', 'FOURNISSEUR', 'DELIVERY_LINE'
+        )
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_source_pair_228_ck'
+      AND conrelid = 'public.quality_control'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control
+      ADD CONSTRAINT quality_control_source_pair_228_ck
+      CHECK ((source_type IS NULL) = (source_id IS NULL));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_snapshot_pair_228_ck'
+      AND conrelid = 'public.quality_control'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control
+      ADD CONSTRAINT quality_control_snapshot_pair_228_ck
+      CHECK ((plan_snapshot IS NULL) = (plan_snapshot_sha256 IS NULL));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_snapshot_hash_228_ck'
+      AND conrelid = 'public.quality_control'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control
+      ADD CONSTRAINT quality_control_snapshot_hash_228_ck
+      CHECK (plan_snapshot_sha256 IS NULL OR plan_snapshot_sha256 ~ '^[a-f0-9]{64}$');
+  END IF;
+
+  -- Registre de quantités : jamais négatif, jamais au-delà de la population,
+  -- cumuls cohérents. Ajouté NOT VALID puis validé pour rester non bloquant
+  -- sur des données historiques éventuellement partielles.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_qty_nonneg_228_ck'
+      AND conrelid = 'public.quality_control'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control
+      ADD CONSTRAINT quality_control_qty_nonneg_228_ck
+      CHECK (
+        qty_controlled >= 0 AND qty_conforming >= 0 AND qty_released >= 0
+        AND qty_held >= 0 AND qty_scrapped >= 0 AND qty_reworked >= 0
+        AND qty_sorted >= 0 AND qty_returned >= 0 AND qty_consumed >= 0
+        AND (qty_population IS NULL OR qty_population > 0)
+      ) NOT VALID;
+    ALTER TABLE public.quality_control VALIDATE CONSTRAINT quality_control_qty_nonneg_228_ck;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_qty_ledger_228_ck'
+      AND conrelid = 'public.quality_control'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control
+      ADD CONSTRAINT quality_control_qty_ledger_228_ck
+      CHECK (
+        qty_population IS NULL
+        OR (
+          qty_controlled <= qty_population
+          AND qty_conforming <= qty_controlled
+          AND qty_released <= qty_conforming
+          AND qty_consumed <= qty_released
+          AND (qty_released + qty_held + qty_scrapped + qty_reworked + qty_sorted + qty_returned) <= qty_population
+        )
+      ) NOT VALID;
+    ALTER TABLE public.quality_control VALIDATE CONSTRAINT quality_control_qty_ledger_228_ck;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS quality_control_plan_228_idx ON public.quality_control (plan_id);
+CREATE INDEX IF NOT EXISTS quality_control_source_228_idx ON public.quality_control (source_type, source_id);
+CREATE INDEX IF NOT EXISTS quality_control_lot_228_idx ON public.quality_control (lot_id);
+CREATE INDEX IF NOT EXISTS quality_control_reception_line_228_idx ON public.quality_control (reception_ligne_id);
+CREATE INDEX IF NOT EXISTS quality_control_verdict_228_idx ON public.quality_control (verdict);
+
+/* -------------------------------------------------------------------------- */
+/* 4) Mesures : clé de caractéristique, échantillon, instrument               */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.quality_control_points
+  ADD COLUMN IF NOT EXISTS characteristic_key text NULL,
+  ADD COLUMN IF NOT EXISTS sample_no integer NULL,
+  ADD COLUMN IF NOT EXISTS value_boolean boolean NULL,
+  ADD COLUMN IF NOT EXISTS value_text text NULL,
+  ADD COLUMN IF NOT EXISTS instrument_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS instrument_snapshot jsonb NULL,
+  ADD COLUMN IF NOT EXISTS evaluation_code text NULL,
+  ADD COLUMN IF NOT EXISTS criticality text NULL,
+  ADD COLUMN IF NOT EXISTS measured_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS recorded_by integer NULL,
+  ADD COLUMN IF NOT EXISTS revision integer NOT NULL DEFAULT 1;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_points_sample_228_ck'
+      AND conrelid = 'public.quality_control_points'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control_points
+      ADD CONSTRAINT quality_control_points_sample_228_ck
+      CHECK (sample_no IS NULL OR sample_no >= 1);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_points_criticality_228_ck'
+      AND conrelid = 'public.quality_control_points'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control_points
+      ADD CONSTRAINT quality_control_points_criticality_228_ck
+      CHECK (criticality IS NULL OR criticality IN ('CRITICAL', 'MAJOR', 'MINOR'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_points_revision_228_ck'
+      AND conrelid = 'public.quality_control_points'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control_points
+      ADD CONSTRAINT quality_control_points_revision_228_ck CHECK (revision >= 1);
+  END IF;
+
+  IF to_regclass('public.metrologie_equipements') IS NOT NULL AND NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_points_instrument_228_fkey'
+      AND conrelid = 'public.quality_control_points'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control_points
+      ADD CONSTRAINT quality_control_points_instrument_228_fkey
+      FOREIGN KEY (instrument_id) REFERENCES public.metrologie_equipements(id)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+-- Un échantillon donné n'existe qu'une fois par caractéristique et exécution.
+CREATE UNIQUE INDEX IF NOT EXISTS quality_control_points_sample_228_uq
+  ON public.quality_control_points (quality_control_id, characteristic_key, sample_no)
+  WHERE characteristic_key IS NOT NULL AND sample_no IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS quality_control_points_instrument_228_idx
+  ON public.quality_control_points (instrument_id);
+
+-- Historique des corrections de mesure : append-only, jamais d'écrasement.
+CREATE TABLE IF NOT EXISTS public.quality_measurement_revisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  point_id uuid NOT NULL
+    REFERENCES public.quality_control_points(id) ON UPDATE RESTRICT ON DELETE CASCADE,
+  quality_control_id uuid NOT NULL
+    REFERENCES public.quality_control(id) ON UPDATE RESTRICT ON DELETE CASCADE,
+  revision integer NOT NULL,
+  old_values jsonb NULL,
+  new_values jsonb NOT NULL,
+  reason text NOT NULL,
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT quality_measurement_revisions_revision_228_ck CHECK (revision >= 1),
+  CONSTRAINT quality_measurement_revisions_reason_228_ck CHECK (char_length(btrim(reason)) >= 5),
+  CONSTRAINT quality_measurement_revisions_228_uq UNIQUE (point_id, revision)
+);
+
+CREATE INDEX IF NOT EXISTS quality_measurement_revisions_control_228_idx
+  ON public.quality_measurement_revisions (quality_control_id, created_at DESC);
+
+/* -------------------------------------------------------------------------- */
+/* 5) Décisions de libération                                                 */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.quality_release_decision (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  quality_control_id uuid NOT NULL
+    REFERENCES public.quality_control(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+
+  decision text NOT NULL,
+  object_type text NOT NULL,
+  object_id text NOT NULL,
+  qty numeric(18, 3) NOT NULL,
+  unite text NOT NULL,
+
+  verdict text NOT NULL,
+  derogation_id uuid NULL,
+  justification text NULL,
+
+  decided_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  decided_at timestamptz NOT NULL DEFAULT now(),
+  executed_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  preview_sha256 text NOT NULL,
+  idempotency_key text NULL,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT quality_release_decision_228_ck
+    CHECK (decision IN ('FULL', 'PARTIAL', 'HOLD', 'REJECT')),
+  CONSTRAINT quality_release_object_228_ck
+    CHECK (object_type IN (
+      'RECEPTION_LINE', 'OF', 'OF_OPERATION', 'LOT', 'STOCK_LEVEL',
+      'ARTICLE', 'PIECE_TECHNIQUE', 'FOURNISSEUR', 'DELIVERY_LINE'
+    )),
+  CONSTRAINT quality_release_verdict_228_ck
+    CHECK (verdict IN ('CONFORME', 'NON_CONFORME', 'PARTIEL', 'EN_ATTENTE')),
+  CONSTRAINT quality_release_qty_228_ck CHECK (qty >= 0),
+  CONSTRAINT quality_release_preview_228_ck CHECK (preview_sha256 ~ '^[a-f0-9]{64}$')
+);
+
+CREATE INDEX IF NOT EXISTS quality_release_decision_control_228_idx
+  ON public.quality_release_decision (quality_control_id, decided_at DESC);
+CREATE INDEX IF NOT EXISTS quality_release_decision_object_228_idx
+  ON public.quality_release_decision (object_type, object_id, decided_at DESC);
+
+/* -------------------------------------------------------------------------- */
+/* 6) Dérogations / concessions                                               */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.quality_derogation (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text NOT NULL UNIQUE,
+  derogation_type text NOT NULL DEFAULT 'CONCESSION',
+  status text NOT NULL DEFAULT 'DRAFT',
+
+  non_conformity_id uuid NULL
+    REFERENCES public.non_conformity(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  client_id text NULL,
+  fournisseur_id uuid NULL,
+
+  article_id uuid NULL,
+  piece_technique_id uuid NULL,
+  piece_version_id uuid NULL,
+  lot_id uuid NULL,
+  of_id bigint NULL,
+  commande_id uuid NULL,
+  bon_livraison_id uuid NULL,
+
+  requirement text NOT NULL,
+  deviation text NOT NULL,
+  risk_analysis text NULL,
+  conditions text NULL,
+
+  max_qty numeric(18, 3) NULL,
+  unite text NULL,
+  consumed_qty numeric(18, 3) NOT NULL DEFAULT 0,
+
+  valid_from timestamptz NULL,
+  valid_to timestamptz NULL,
+
+  requested_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  requested_at timestamptz NOT NULL DEFAULT now(),
+  submitted_at timestamptz NULL,
+  approved_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  approved_at timestamptz NULL,
+  rejected_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  rejected_at timestamptz NULL,
+  rejection_reason text NULL,
+  revoked_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  revoked_at timestamptz NULL,
+  revocation_reason text NULL,
+  customer_agreement_reference text NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  updated_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+
+  CONSTRAINT quality_derogation_status_228_ck
+    CHECK (status IN ('DRAFT', 'SUBMITTED', 'APPROVED', 'REJECTED', 'CONSUMED', 'EXPIRED', 'REVOKED')),
+  CONSTRAINT quality_derogation_type_228_ck
+    CHECK (derogation_type IN ('CONCESSION', 'DEVIATION_PERMIT', 'SPECIAL_ACCEPTANCE')),
+  CONSTRAINT quality_derogation_scope_228_ck
+    CHECK (
+      article_id IS NOT NULL OR piece_technique_id IS NOT NULL OR piece_version_id IS NOT NULL
+      OR lot_id IS NOT NULL OR of_id IS NOT NULL OR commande_id IS NOT NULL
+      OR bon_livraison_id IS NOT NULL
+    ),
+  CONSTRAINT quality_derogation_qty_228_ck
+    CHECK (
+      consumed_qty >= 0
+      AND (max_qty IS NULL OR (max_qty > 0 AND consumed_qty <= max_qty))
+      AND (max_qty IS NULL OR (unite IS NOT NULL AND btrim(unite) <> ''))
+    ),
+  CONSTRAINT quality_derogation_period_228_ck
+    CHECK (valid_from IS NULL OR valid_to IS NULL OR valid_from <= valid_to),
+  CONSTRAINT quality_derogation_approval_pair_228_ck
+    CHECK ((approved_at IS NULL) = (approved_by IS NULL)),
+  CONSTRAINT quality_derogation_rejection_pair_228_ck
+    CHECK ((rejected_at IS NULL) = (rejected_by IS NULL)),
+  CONSTRAINT quality_derogation_revocation_pair_228_ck
+    CHECK ((revoked_at IS NULL) = (revoked_by IS NULL)),
+  CONSTRAINT quality_derogation_approved_state_228_ck
+    CHECK (status NOT IN ('APPROVED', 'CONSUMED') OR approved_at IS NOT NULL),
+  -- Séparation des tâches gravée en base : le demandeur n'approuve pas.
+  CONSTRAINT quality_derogation_separation_228_ck
+    CHECK (approved_by IS NULL OR approved_by <> requested_by),
+  CONSTRAINT quality_derogation_requirement_228_ck
+    CHECK (char_length(btrim(requirement)) >= 3 AND char_length(btrim(deviation)) >= 3)
+);
+
+CREATE INDEX IF NOT EXISTS quality_derogation_status_228_idx
+  ON public.quality_derogation (status, valid_to);
+CREATE INDEX IF NOT EXISTS quality_derogation_nc_228_idx
+  ON public.quality_derogation (non_conformity_id);
+CREATE INDEX IF NOT EXISTS quality_derogation_scope_228_idx
+  ON public.quality_derogation (lot_id, piece_version_id, article_id);
+
+CREATE TABLE IF NOT EXISTS public.quality_derogation_consumption (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  derogation_id uuid NOT NULL
+    REFERENCES public.quality_derogation(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  quality_control_id uuid NULL
+    REFERENCES public.quality_control(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  release_decision_id uuid NULL
+    REFERENCES public.quality_release_decision(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  bon_livraison_id uuid NULL,
+
+  qty numeric(18, 3) NOT NULL,
+  unite text NOT NULL,
+  context jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  idempotency_key text NULL,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT quality_derogation_consumption_qty_228_ck CHECK (qty > 0),
+  CONSTRAINT quality_derogation_consumption_context_228_ck
+    CHECK (jsonb_typeof(context) = 'object'),
+  -- Une même décision de libération ne consomme pas deux fois la concession.
+  CONSTRAINT quality_derogation_consumption_release_228_uq UNIQUE (derogation_id, release_decision_id)
+);
+
+CREATE INDEX IF NOT EXISTS quality_derogation_consumption_derogation_228_idx
+  ON public.quality_derogation_consumption (derogation_id, created_at DESC);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_release_derogation_228_fkey'
+      AND conrelid = 'public.quality_release_decision'::regclass
+  ) THEN
+    ALTER TABLE public.quality_release_decision
+      ADD CONSTRAINT quality_release_derogation_228_fkey
+      FOREIGN KEY (derogation_id) REFERENCES public.quality_derogation(id)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 7) Non-conformités : origine, quantité, 5 Why / 8D, CAPA                   */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.non_conformity
+  ADD COLUMN IF NOT EXISTS origin text NULL,
+  ADD COLUMN IF NOT EXISTS defect_category text NULL,
+  ADD COLUMN IF NOT EXISTS qty numeric(18, 3) NULL,
+  ADD COLUMN IF NOT EXISTS unite text NULL,
+  ADD COLUMN IF NOT EXISTS owner_user_id integer NULL,
+  ADD COLUMN IF NOT EXISTS confidentiality text NOT NULL DEFAULT 'INTERNAL',
+  ADD COLUMN IF NOT EXISTS capa_required boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS effectiveness_verified_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS effectiveness_verified_by integer NULL,
+  ADD COLUMN IF NOT EXISTS reopened_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS reopened_by integer NULL,
+  ADD COLUMN IF NOT EXISTS reopen_reason text NULL,
+  ADD COLUMN IF NOT EXISTS cancelled_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS cancelled_by integer NULL,
+  ADD COLUMN IF NOT EXISTS cancellation_reason text NULL,
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NOT NULL DEFAULT gen_random_uuid();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'non_conformity_origin_228_ck'
+      AND conrelid = 'public.non_conformity'::regclass
+  ) THEN
+    ALTER TABLE public.non_conformity
+      ADD CONSTRAINT non_conformity_origin_228_ck
+      CHECK (
+        origin IS NULL
+        OR origin IN (
+          'CONTROL', 'RECEPTION', 'PRODUCTION', 'OPERATION', 'STOCK',
+          'DELIVERY', 'CUSTOMER_CLAIM', 'SUPPLIER', 'AUDIT', 'OTHER'
+        )
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'non_conformity_confidentiality_228_ck'
+      AND conrelid = 'public.non_conformity'::regclass
+  ) THEN
+    ALTER TABLE public.non_conformity
+      ADD CONSTRAINT non_conformity_confidentiality_228_ck
+      CHECK (confidentiality IN ('INTERNAL', 'RESTRICTED', 'CUSTOMER_VISIBLE'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'non_conformity_qty_228_ck'
+      AND conrelid = 'public.non_conformity'::regclass
+  ) THEN
+    ALTER TABLE public.non_conformity
+      ADD CONSTRAINT non_conformity_qty_228_ck
+      CHECK (qty IS NULL OR (qty > 0 AND unite IS NOT NULL AND btrim(unite) <> ''));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'non_conformity_owner_228_fkey'
+      AND conrelid = 'public.non_conformity'::regclass
+  ) THEN
+    ALTER TABLE public.non_conformity
+      ADD CONSTRAINT non_conformity_owner_228_fkey
+      FOREIGN KEY (owner_user_id) REFERENCES public.users(id)
+      ON UPDATE RESTRICT ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS non_conformity_origin_228_idx ON public.non_conformity (origin);
+CREATE INDEX IF NOT EXISTS non_conformity_owner_228_idx ON public.non_conformity (owner_user_id);
+
+-- Résolution guidée 5 Why / 8D : une ligne par étape, bornée et gouvernée.
+CREATE TABLE IF NOT EXISTS public.non_conformity_analysis (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  non_conformity_id uuid NOT NULL
+    REFERENCES public.non_conformity(id) ON UPDATE RESTRICT ON DELETE CASCADE,
+  method text NOT NULL,
+  step_code text NOT NULL,
+  position integer NOT NULL,
+  question text NULL,
+  answer text NULL,
+  owner_user_id integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  due_date date NULL,
+  completed_at timestamptz NULL,
+  completed_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  updated_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+
+  CONSTRAINT non_conformity_analysis_method_228_ck CHECK (method IN ('FIVE_WHY', 'EIGHT_D')),
+  CONSTRAINT non_conformity_analysis_position_228_ck CHECK (position BETWEEN 1 AND 20),
+  CONSTRAINT non_conformity_analysis_answer_228_ck
+    CHECK (answer IS NULL OR char_length(answer) <= 4000),
+  CONSTRAINT non_conformity_analysis_question_228_ck
+    CHECK (question IS NULL OR char_length(question) <= 1000),
+  CONSTRAINT non_conformity_analysis_completed_pair_228_ck
+    CHECK ((completed_at IS NULL) = (completed_by IS NULL)),
+  CONSTRAINT non_conformity_analysis_step_228_uq UNIQUE (non_conformity_id, method, step_code)
+);
+
+CREATE INDEX IF NOT EXISTS non_conformity_analysis_nc_228_idx
+  ON public.non_conformity_analysis (non_conformity_id, method, position);
+
+ALTER TABLE public.quality_action
+  ADD COLUMN IF NOT EXISTS priority text NOT NULL DEFAULT 'NORMAL',
+  ADD COLUMN IF NOT EXISTS mandatory boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS started_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS completed_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS evidence_required boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS analysis_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NOT NULL DEFAULT gen_random_uuid();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_action_priority_228_ck'
+      AND conrelid = 'public.quality_action'::regclass
+  ) THEN
+    ALTER TABLE public.quality_action
+      ADD CONSTRAINT quality_action_priority_228_ck
+      CHECK (priority IN ('LOW', 'NORMAL', 'HIGH', 'CRITICAL'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_action_analysis_228_fkey'
+      AND conrelid = 'public.quality_action'::regclass
+  ) THEN
+    ALTER TABLE public.quality_action
+      ADD CONSTRAINT quality_action_analysis_228_fkey
+      FOREIGN KEY (analysis_id) REFERENCES public.non_conformity_analysis(id)
+      ON UPDATE RESTRICT ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Reprise de contrôle ajoutée à la liste des dispositions existantes.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'non_conformity_dispositions_type_check'
+      AND conrelid = 'public.non_conformity_dispositions'::regclass
+  ) THEN
+    ALTER TABLE public.non_conformity_dispositions
+      DROP CONSTRAINT non_conformity_dispositions_type_check;
+  END IF;
+
+  ALTER TABLE public.non_conformity_dispositions
+    ADD CONSTRAINT non_conformity_dispositions_type_check
+    CHECK (disposition_type IN (
+      'HOLD', 'RELEASE', 'USE_AS_IS', 'REWORK', 'SORT', 'SCRAP', 'RETURN_SUPPLIER', 'RECHECK'
+    )) NOT VALID;
+  ALTER TABLE public.non_conformity_dispositions
+    VALIDATE CONSTRAINT non_conformity_dispositions_type_check;
+END $$;
+
+ALTER TABLE public.non_conformity_dispositions
+  ADD COLUMN IF NOT EXISTS derogation_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS quality_control_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS instructions text NULL,
+  ADD COLUMN IF NOT EXISTS idempotency_key text NULL,
+  ADD COLUMN IF NOT EXISTS preview_sha256 text NULL,
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NOT NULL DEFAULT gen_random_uuid();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'non_conformity_dispositions_derogation_228_fkey'
+      AND conrelid = 'public.non_conformity_dispositions'::regclass
+  ) THEN
+    ALTER TABLE public.non_conformity_dispositions
+      ADD CONSTRAINT non_conformity_dispositions_derogation_228_fkey
+      FOREIGN KEY (derogation_id) REFERENCES public.quality_derogation(id)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'non_conformity_dispositions_control_228_fkey'
+      AND conrelid = 'public.non_conformity_dispositions'::regclass
+  ) THEN
+    ALTER TABLE public.non_conformity_dispositions
+      ADD CONSTRAINT non_conformity_dispositions_control_228_fkey
+      FOREIGN KEY (quality_control_id) REFERENCES public.quality_control(id)
+      ON UPDATE RESTRICT ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Une clé d'idempotence ne produit qu'une disposition.
+CREATE UNIQUE INDEX IF NOT EXISTS non_conformity_dispositions_idem_228_uq
+  ON public.non_conformity_dispositions (non_conformity_id, idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+/* -------------------------------------------------------------------------- */
+/* 8) Documents, idempotence et journal                                       */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.quality_documents
+  ADD COLUMN IF NOT EXISTS revision text NULL,
+  ADD COLUMN IF NOT EXISTS confidentiality text NOT NULL DEFAULT 'INTERNAL',
+  ADD COLUMN IF NOT EXISTS retention_until date NULL,
+  ADD COLUMN IF NOT EXISTS decision_evidence boolean NOT NULL DEFAULT false;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_documents_confidentiality_228_ck'
+      AND conrelid = 'public.quality_documents'::regclass
+  ) THEN
+    ALTER TABLE public.quality_documents
+      ADD CONSTRAINT quality_documents_confidentiality_228_ck
+      CHECK (confidentiality IN ('INTERNAL', 'RESTRICTED', 'CUSTOMER_VISIBLE'));
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.quality_command_receipts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  command_type text NOT NULL,
+  aggregate_type text NOT NULL,
+  aggregate_id text NOT NULL,
+  request_payload jsonb NOT NULL,
+  result_payload jsonb NOT NULL,
+  correlation_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT quality_command_receipts_actor_key_228_uq UNIQUE (actor_user_id, idempotency_key),
+  CONSTRAINT quality_command_receipts_key_228_ck
+    CHECK (char_length(idempotency_key) BETWEEN 8 AND 200),
+  CONSTRAINT quality_command_receipts_hash_228_ck CHECK (request_hash ~ '^[A-Fa-f0-9]{64}$'),
+  CONSTRAINT quality_command_receipts_type_228_ck
+    CHECK (char_length(command_type) BETWEEN 3 AND 120),
+  CONSTRAINT quality_command_receipts_aggregate_228_ck
+    CHECK (aggregate_type IN ('PLAN', 'CONTROL', 'NON_CONFORMITY', 'ACTION', 'DEROGATION', 'RELEASE', 'DISPOSITION'))
+);
+
+CREATE INDEX IF NOT EXISTS quality_command_receipts_resource_228_idx
+  ON public.quality_command_receipts (aggregate_type, aggregate_id, created_at DESC);
+
+ALTER TABLE public.quality_event_log
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS idempotency_key text NULL,
+  ADD COLUMN IF NOT EXISTS rule_code text NULL,
+  ADD COLUMN IF NOT EXISTS reason text NULL,
+  ADD COLUMN IF NOT EXISTS request_id text NULL,
+  ADD COLUMN IF NOT EXISTS source text NULL;
+
+CREATE INDEX IF NOT EXISTS quality_event_log_correlation_228_idx
+  ON public.quality_event_log (correlation_id);
+
+/* -------------------------------------------------------------------------- */
+/* 9) Immuabilité et append-only                                              */
+/* -------------------------------------------------------------------------- */
+
+-- Un plan publié ou archivé est figé : seul le passage de statut piloté par
+-- l'API (avec ses horodatages) reste autorisé.
+CREATE OR REPLACE FUNCTION public.fn_protect_quality_plan_228()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.status IN ('PUBLISHED', 'ARCHIVED') THEN
+      RAISE EXCEPTION 'a published quality control plan is immutable and cannot be deleted';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF OLD.status IN ('PUBLISHED', 'ARCHIVED') THEN
+    IF NEW.code <> OLD.code
+      OR NEW.version <> OLD.version
+      OR NEW.label <> OLD.label
+      OR NEW.trigger_type <> OLD.trigger_type
+      OR COALESCE(NEW.article_id::text, '') <> COALESCE(OLD.article_id::text, '')
+      OR COALESCE(NEW.piece_technique_id::text, '') <> COALESCE(OLD.piece_technique_id::text, '')
+      OR COALESCE(NEW.piece_version_id::text, '') <> COALESCE(OLD.piece_version_id::text, '')
+      OR COALESCE(NEW.famille_id::text, '') <> COALESCE(OLD.famille_id::text, '')
+      OR COALESCE(NEW.operation_code, '') <> COALESCE(OLD.operation_code, '')
+      OR COALESCE(NEW.fournisseur_id::text, '') <> COALESCE(OLD.fournisseur_id::text, '')
+      OR NEW.sampling_rule <> OLD.sampling_rule
+      OR COALESCE(NEW.sampling_value, -1) <> COALESCE(OLD.sampling_value, -1)
+      OR COALESCE(NEW.effective_from::text, '') <> COALESCE(OLD.effective_from::text, '')
+      OR COALESCE(NEW.published_at::text, '') <> COALESCE(OLD.published_at::text, '')
+    THEN
+      RAISE EXCEPTION 'a published quality control plan is immutable: create a new version';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_quality_plan_228 ON public.quality_control_plan;
+CREATE TRIGGER trg_protect_quality_plan_228
+  BEFORE UPDATE OR DELETE ON public.quality_control_plan
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_quality_plan_228();
+
+CREATE OR REPLACE FUNCTION public.fn_protect_quality_plan_characteristic_228()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_status text;
+  v_plan uuid;
+BEGIN
+  v_plan := COALESCE(NEW.plan_id, OLD.plan_id);
+  SELECT status INTO v_status FROM public.quality_control_plan WHERE id = v_plan;
+  IF v_status IN ('PUBLISHED', 'ARCHIVED') THEN
+    RAISE EXCEPTION 'characteristics of a published quality control plan are immutable';
+  END IF;
+  IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_quality_plan_char_228 ON public.quality_control_plan_characteristic;
+CREATE TRIGGER trg_protect_quality_plan_char_228
+  BEFORE INSERT OR UPDATE OR DELETE ON public.quality_control_plan_characteristic
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_quality_plan_characteristic_228();
+
+-- Le snapshot appliqué et son empreinte ne se réécrivent jamais après coup.
+CREATE OR REPLACE FUNCTION public.fn_protect_quality_snapshot_228()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.plan_snapshot_sha256 IS NOT NULL
+    AND (
+      COALESCE(NEW.plan_snapshot_sha256, '') <> OLD.plan_snapshot_sha256
+      OR NEW.plan_snapshot::text <> OLD.plan_snapshot::text
+      OR COALESCE(NEW.plan_id::text, '') <> COALESCE(OLD.plan_id::text, '')
+      OR COALESCE(NEW.plan_version, -1) <> COALESCE(OLD.plan_version, -1)
+    )
+  THEN
+    RAISE EXCEPTION 'the applied quality plan snapshot is immutable';
+  END IF;
+
+  IF OLD.validation_date IS NOT NULL
+    AND (
+      COALESCE(NEW.qty_population, -1) <> COALESCE(OLD.qty_population, -1)
+      OR COALESCE(NEW.unite, '') <> COALESCE(OLD.unite, '')
+      OR COALESCE(NEW.source_type, '') <> COALESCE(OLD.source_type, '')
+      OR COALESCE(NEW.source_id, '') <> COALESCE(OLD.source_id, '')
+    )
+  THEN
+    RAISE EXCEPTION 'a validated quality control keeps its population, unit and source';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_quality_snapshot_228 ON public.quality_control;
+CREATE TRIGGER trg_protect_quality_snapshot_228
+  BEFORE UPDATE ON public.quality_control
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_quality_snapshot_228();
+
+-- Une mesure d'un contrôle déjà validé ne s'écrase pas : elle se corrige par
+-- révision auditée (quality_measurement_revisions).
+CREATE OR REPLACE FUNCTION public.fn_protect_quality_measurement_228()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_validated timestamptz;
+BEGIN
+  SELECT validation_date INTO v_validated
+  FROM public.quality_control
+  WHERE id = COALESCE(NEW.quality_control_id, OLD.quality_control_id);
+
+  IF v_validated IS NOT NULL THEN
+    IF TG_OP = 'DELETE' THEN
+      RAISE EXCEPTION 'measurements of a validated quality control cannot be deleted';
+    END IF;
+    IF TG_OP = 'UPDATE' AND NEW.revision <= OLD.revision THEN
+      RAISE EXCEPTION 'a measurement of a validated quality control requires an audited revision';
+    END IF;
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN RETURN OLD; END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_quality_measurement_228 ON public.quality_control_points;
+CREATE TRIGGER trg_protect_quality_measurement_228
+  BEFORE UPDATE OR DELETE ON public.quality_control_points
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_quality_measurement_228();
+
+-- Append-only générique : preuves, décisions et journal.
+CREATE OR REPLACE FUNCTION public.fn_quality_append_only_228()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'quality audit evidence is immutable (append-only): %', TG_TABLE_NAME;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_quality_event_log_append_only_228 ON public.quality_event_log;
+CREATE TRIGGER trg_quality_event_log_append_only_228
+  BEFORE UPDATE OR DELETE ON public.quality_event_log
+  FOR EACH ROW EXECUTE FUNCTION public.fn_quality_append_only_228();
+
+DROP TRIGGER IF EXISTS trg_quality_measurement_revisions_append_only_228 ON public.quality_measurement_revisions;
+CREATE TRIGGER trg_quality_measurement_revisions_append_only_228
+  BEFORE UPDATE OR DELETE ON public.quality_measurement_revisions
+  FOR EACH ROW EXECUTE FUNCTION public.fn_quality_append_only_228();
+
+DROP TRIGGER IF EXISTS trg_quality_release_decision_append_only_228 ON public.quality_release_decision;
+CREATE TRIGGER trg_quality_release_decision_append_only_228
+  BEFORE UPDATE OR DELETE ON public.quality_release_decision
+  FOR EACH ROW EXECUTE FUNCTION public.fn_quality_append_only_228();
+
+DROP TRIGGER IF EXISTS trg_quality_derogation_consumption_append_only_228 ON public.quality_derogation_consumption;
+CREATE TRIGGER trg_quality_derogation_consumption_append_only_228
+  BEFORE UPDATE OR DELETE ON public.quality_derogation_consumption
+  FOR EACH ROW EXECUTE FUNCTION public.fn_quality_append_only_228();
+
+DROP TRIGGER IF EXISTS trg_quality_command_receipts_append_only_228 ON public.quality_command_receipts;
+CREATE TRIGGER trg_quality_command_receipts_append_only_228
+  BEFORE UPDATE OR DELETE ON public.quality_command_receipts
+  FOR EACH ROW EXECUTE FUNCTION public.fn_quality_append_only_228();
+
+-- Une dérogation approuvée garde son périmètre, son écart et ses plafonds.
+CREATE OR REPLACE FUNCTION public.fn_protect_quality_derogation_228()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.status <> 'DRAFT' THEN
+      RAISE EXCEPTION 'only a draft derogation can be deleted';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF OLD.status IN ('APPROVED', 'CONSUMED', 'REJECTED', 'EXPIRED', 'REVOKED') THEN
+    IF NEW.code <> OLD.code
+      OR NEW.derogation_type <> OLD.derogation_type
+      OR NEW.requirement <> OLD.requirement
+      OR NEW.deviation <> OLD.deviation
+      OR COALESCE(NEW.max_qty, -1) <> COALESCE(OLD.max_qty, -1)
+      OR COALESCE(NEW.unite, '') <> COALESCE(OLD.unite, '')
+      OR COALESCE(NEW.valid_from::text, '') <> COALESCE(OLD.valid_from::text, '')
+      OR COALESCE(NEW.valid_to::text, '') <> COALESCE(OLD.valid_to::text, '')
+      OR COALESCE(NEW.lot_id::text, '') <> COALESCE(OLD.lot_id::text, '')
+      OR COALESCE(NEW.piece_version_id::text, '') <> COALESCE(OLD.piece_version_id::text, '')
+      OR COALESCE(NEW.article_id::text, '') <> COALESCE(OLD.article_id::text, '')
+      OR NEW.requested_by <> OLD.requested_by
+    THEN
+      RAISE EXCEPTION 'an approved or closed derogation is immutable: request a new one';
+    END IF;
+  END IF;
+
+  IF NEW.consumed_qty < OLD.consumed_qty THEN
+    RAISE EXCEPTION 'derogation consumption cannot decrease';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_quality_derogation_228 ON public.quality_derogation;
+CREATE TRIGGER trg_protect_quality_derogation_228
+  BEFORE UPDATE OR DELETE ON public.quality_derogation
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_quality_derogation_228();
+
+-- Les consommations ne peuvent pas dépasser le plafond de la concession.
+CREATE OR REPLACE FUNCTION public.fn_check_quality_derogation_cap_228()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_max numeric(18, 3);
+  v_status text;
+  v_total numeric(18, 3);
+BEGIN
+  SELECT max_qty, status INTO v_max, v_status
+  FROM public.quality_derogation
+  WHERE id = NEW.derogation_id
+  FOR UPDATE;
+
+  IF v_status IS NULL THEN
+    RAISE EXCEPTION 'unknown derogation';
+  END IF;
+  IF v_status NOT IN ('APPROVED', 'CONSUMED') THEN
+    RAISE EXCEPTION 'a derogation must be approved before being consumed (status %)', v_status;
+  END IF;
+
+  SELECT COALESCE(SUM(qty), 0) INTO v_total
+  FROM public.quality_derogation_consumption
+  WHERE derogation_id = NEW.derogation_id;
+
+  IF v_max IS NOT NULL AND v_total > v_max THEN
+    RAISE EXCEPTION 'derogation consumptions exceed the approved maximum quantity';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_check_quality_derogation_cap_228 ON public.quality_derogation_consumption;
+CREATE TRIGGER trg_check_quality_derogation_cap_228
+  AFTER INSERT ON public.quality_derogation_consumption
+  FOR EACH ROW EXECUTE FUNCTION public.fn_check_quality_derogation_cap_228();
+
+-- Les documents qualité se suppriment logiquement ; une preuve de décision
+-- approuvée n'est jamais effacée.
+CREATE OR REPLACE FUNCTION public.fn_protect_quality_documents_228()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'quality documents are removed logically (removed_at), never deleted';
+  END IF;
+  IF OLD.decision_evidence AND NEW.removed_at IS NOT NULL AND OLD.removed_at IS NULL THEN
+    RAISE EXCEPTION 'a decision evidence document cannot be removed';
+  END IF;
+  IF NEW.sha256 IS DISTINCT FROM OLD.sha256 OR NEW.storage_path <> OLD.storage_path THEN
+    RAISE EXCEPTION 'quality document identity (hash, storage) is immutable';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_quality_documents_228 ON public.quality_documents;
+CREATE TRIGGER trg_protect_quality_documents_228
+  BEFORE UPDATE OR DELETE ON public.quality_documents
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_quality_documents_228();
+
+/* -------------------------------------------------------------------------- */
+/* 10) updated_at triggers                                                    */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF to_regprocedure('public.tg_set_updated_at()') IS NULL THEN
+    RAISE NOTICE 'tg_set_updated_at() not found; skipping #228 updated_at triggers.';
+    RETURN;
+  END IF;
+
+  EXECUTE 'DROP TRIGGER IF EXISTS quality_control_plan_set_updated_at ON public.quality_control_plan';
+  EXECUTE 'CREATE TRIGGER quality_control_plan_set_updated_at BEFORE UPDATE ON public.quality_control_plan FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
+
+  EXECUTE 'DROP TRIGGER IF EXISTS quality_plan_char_set_updated_at ON public.quality_control_plan_characteristic';
+  EXECUTE 'CREATE TRIGGER quality_plan_char_set_updated_at BEFORE UPDATE ON public.quality_control_plan_characteristic FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
+
+  EXECUTE 'DROP TRIGGER IF EXISTS quality_derogation_set_updated_at ON public.quality_derogation';
+  EXECUTE 'CREATE TRIGGER quality_derogation_set_updated_at BEFORE UPDATE ON public.quality_derogation FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
+
+  EXECUTE 'DROP TRIGGER IF EXISTS non_conformity_analysis_set_updated_at ON public.non_conformity_analysis';
+  EXECUTE 'CREATE TRIGGER non_conformity_analysis_set_updated_at BEFORE UPDATE ON public.non_conformity_analysis FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 11) Commentaires                                                           */
+/* -------------------------------------------------------------------------- */
+
+COMMENT ON TABLE public.quality_control_plan IS
+  '#228 Plans de contrôle versionnés : périmètre, déclencheur, échantillonnage, cycle DRAFT/IN_REVIEW/PUBLISHED/ARCHIVED. Un plan publié est immuable.';
+COMMENT ON TABLE public.quality_control_plan_characteristic IS
+  '#228 Caractéristiques ordonnées et stables d''un plan de contrôle.';
+COMMENT ON TABLE public.quality_measurement_revisions IS
+  '#228 Historique append-only des corrections de mesure (avant/après, motif, acteur).';
+COMMENT ON TABLE public.quality_release_decision IS
+  '#228 Décisions de libération/quarantaine sur objet et quantité exacts, append-only.';
+COMMENT ON TABLE public.quality_derogation IS
+  '#228 Registre des dérogations/concessions : périmètre, écart, risque, plafond, validité, approbations.';
+COMMENT ON TABLE public.quality_derogation_consumption IS
+  '#228 Consommations immuables d''une concession, liées au contrôle/libération/BL.';
+COMMENT ON TABLE public.non_conformity_analysis IS
+  '#228 Résolution guidée 5 Why / 8D attachée à une non-conformité.';
+COMMENT ON TABLE public.quality_command_receipts IS
+  '#228 Reçus d''idempotence des commandes qualité (acteur + Idempotency-Key).';
+COMMENT ON COLUMN public.quality_control.plan_snapshot IS
+  '#228 Contenu canonique du plan réellement appliqué. Le verdict historique ne se recalcule jamais depuis le plan courant.';
+COMMENT ON COLUMN public.quality_control.plan_snapshot_sha256 IS
+  '#228 Empreinte SHA-256 du snapshot : toute divergence est une alerte d''intégrité.';
+
+COMMIT;

--- a/db/patches/20260725_qualite_360_228.sql
+++ b/db/patches/20260725_qualite_360_228.sql
@@ -30,7 +30,34 @@ BEGIN
   IF to_regclass('public.users') IS NULL THEN
     RAISE EXCEPTION '#228 requires public.users';
   END IF;
+  IF to_regprocedure('public.fn_next_issued_code_value(text)') IS NULL THEN
+    RAISE EXCEPTION '#228: public.fn_next_issued_code_value(text) is missing — apply 20260713_codification_versions_of_vsm.sql first';
+  END IF;
 END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 0) Codification : ajoute les périmètres PC et DER à l'allocateur whitelisté */
+/*    Corps identique à 20260713/20260721 — SEUL le regex gagne |PC|DER.       */
+/* -------------------------------------------------------------------------- */
+
+CREATE OR REPLACE FUNCTION public.fn_next_issued_code_value(p_scope text)
+RETURNS bigint
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+DECLARE
+  v_scope text := upper(btrim(COALESCE(p_scope, '')));
+BEGIN
+  IF v_scope !~ '^(CLI|FOU|ART:[A-Z0-9]{1,48}|(DEV|CMD|AFF|OF|LOT|MVT|CQ|NC|CAPA|BL|FACT|BCF|PC|DER):[0-9]{4})$' THEN
+    RAISE EXCEPTION 'Unsupported business-code sequence scope: %', p_scope
+      USING ERRCODE = '22023';
+  END IF;
+  RETURN nextval('public.cerp_business_code_issue_seq'::regclass);
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_next_issued_code_value(text) IS
+  'Whitelisted, non-reusable business-code allocator backed by a native PostgreSQL sequence. #228 adds the PC (plans de contrôle) and DER (dérogations) scopes.';
 
 /* -------------------------------------------------------------------------- */
 /* 1) Extension additive des enums historiques                                */

--- a/db/patches/support/20260725_qualite_360_228.preflight.sql
+++ b/db/patches/support/20260725_qualite_360_228.preflight.sql
@@ -1,0 +1,91 @@
+\set ON_ERROR_STOP on
+
+-- Read-only preflight for issue #228 (Qualité industrielle 360).
+-- It changes nothing and never enables a quality decision.
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#228 preflight is restricted to cerp_test';
+  END IF;
+END $$;
+
+SELECT current_database() AS database_name, current_user AS database_user, now() AS checked_at;
+SELECT current_setting('server_version') AS server_version;
+
+-- 1) Prerequisites the forward patch relies on.
+SELECT prerequisite, present
+FROM (
+  VALUES
+    ('quality_control', to_regclass('public.quality_control') IS NOT NULL),
+    ('quality_control_points', to_regclass('public.quality_control_points') IS NOT NULL),
+    ('quality_documents', to_regclass('public.quality_documents') IS NOT NULL),
+    ('quality_event_log', to_regclass('public.quality_event_log') IS NOT NULL),
+    ('quality_action', to_regclass('public.quality_action') IS NOT NULL),
+    ('non_conformity', to_regclass('public.non_conformity') IS NOT NULL),
+    ('non_conformity_dispositions', to_regclass('public.non_conformity_dispositions') IS NOT NULL),
+    ('users', to_regclass('public.users') IS NOT NULL),
+    ('lots', to_regclass('public.lots') IS NOT NULL),
+    ('metrologie_equipements', to_regclass('public.metrologie_equipements') IS NOT NULL),
+    ('reception_fournisseur_lignes', to_regclass('public.reception_fournisseur_lignes') IS NOT NULL),
+    ('reception_incoming_inspections', to_regclass('public.reception_incoming_inspections') IS NOT NULL),
+    ('gen_random_uuid', to_regprocedure('gen_random_uuid()') IS NOT NULL),
+    ('tg_set_updated_at', to_regprocedure('public.tg_set_updated_at()') IS NOT NULL)
+) AS checks(prerequisite, present)
+ORDER BY prerequisite;
+
+-- 2) Objects the patch would create (must all be absent before the first run).
+SELECT target, already_present
+FROM (
+  VALUES
+    ('quality_control_plan', to_regclass('public.quality_control_plan') IS NOT NULL),
+    ('quality_control_plan_characteristic', to_regclass('public.quality_control_plan_characteristic') IS NOT NULL),
+    ('quality_measurement_revisions', to_regclass('public.quality_measurement_revisions') IS NOT NULL),
+    ('quality_release_decision', to_regclass('public.quality_release_decision') IS NOT NULL),
+    ('quality_derogation', to_regclass('public.quality_derogation') IS NOT NULL),
+    ('quality_derogation_consumption', to_regclass('public.quality_derogation_consumption') IS NOT NULL),
+    ('non_conformity_analysis', to_regclass('public.non_conformity_analysis') IS NOT NULL),
+    ('quality_command_receipts', to_regclass('public.quality_command_receipts') IS NOT NULL)
+) AS targets(target, already_present)
+ORDER BY target;
+
+-- 3) Enum values that the patch extends additively.
+SELECT t.typname AS enum_type, e.enumlabel AS value, e.enumsortorder
+FROM pg_type t
+JOIN pg_enum e ON e.enumtypid = t.oid
+WHERE t.typname IN ('quality_nc_status', 'quality_entity_type', 'quality_document_type')
+ORDER BY t.typname, e.enumsortorder;
+
+-- 4) Volume actually impacted by the additive columns (rewrite window).
+SELECT 'quality_control' AS table_name, COUNT(*)::bigint AS rows FROM public.quality_control
+UNION ALL SELECT 'quality_control_points', COUNT(*)::bigint FROM public.quality_control_points
+UNION ALL SELECT 'non_conformity', COUNT(*)::bigint FROM public.non_conformity
+UNION ALL SELECT 'non_conformity_dispositions', COUNT(*)::bigint FROM public.non_conformity_dispositions
+UNION ALL SELECT 'quality_action', COUNT(*)::bigint FROM public.quality_action
+UNION ALL SELECT 'quality_documents', COUNT(*)::bigint FROM public.quality_documents
+UNION ALL SELECT 'quality_event_log', COUNT(*)::bigint FROM public.quality_event_log
+ORDER BY table_name;
+
+-- 5) Existing data that would violate the new quantity ledger constraints.
+--    Expected: zero rows. The patch adds the constraints NOT VALID then
+--    validates them, so a non-empty result here is a stop signal.
+SELECT id, status, result
+FROM public.quality_control
+WHERE FALSE -- placeholder: new quantity columns do not exist before the patch
+LIMIT 0;
+
+-- 6) Dispositions using a type outside the extended CHECK list.
+SELECT DISTINCT disposition_type
+FROM public.non_conformity_dispositions
+WHERE disposition_type NOT IN (
+  'HOLD', 'RELEASE', 'USE_AS_IS', 'REWORK', 'SORT', 'SCRAP', 'RETURN_SUPPLIER', 'RECHECK'
+)
+ORDER BY disposition_type;
+
+-- 7) Documents whose identity columns are incomplete (hash immutability trigger).
+SELECT COUNT(*)::bigint AS quality_documents_without_sha256
+FROM public.quality_documents
+WHERE sha256 IS NULL AND removed_at IS NULL;
+
+-- 8) Reception quality overlap to consolidate later (read-only observation).
+SELECT COUNT(*)::bigint AS reception_incoming_inspections
+FROM public.reception_incoming_inspections;

--- a/db/patches/support/20260725_qualite_360_228.rollback.sql
+++ b/db/patches/support/20260725_qualite_360_228.rollback.sql
@@ -1,0 +1,289 @@
+\set ON_ERROR_STOP on
+
+-- Rollback for issue #228, restricted to cerp_test.
+--
+-- IMPORTANT — irreversible parts:
+--   * PostgreSQL cannot remove a value from an enum type. The values added to
+--     `quality_nc_status`, `quality_entity_type` and `quality_document_type`
+--     stay in place. They are additive and unused by historical rows, so they
+--     are harmless; this script refuses to run if any row uses them.
+--   * Additive columns are dropped only when they are entirely empty, so a
+--     recorded measurement, decision or snapshot is never destroyed here.
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#228 rollback is restricted to cerp_test';
+  END IF;
+END $$;
+
+BEGIN;
+
+-- 0) Refuse to roll back over real quality data.
+DO $$
+DECLARE
+  v_count bigint;
+BEGIN
+  IF to_regclass('public.quality_release_decision') IS NOT NULL THEN
+    SELECT COUNT(*) INTO v_count FROM public.quality_release_decision;
+    IF v_count > 0 THEN
+      RAISE EXCEPTION '#228 rollback refused: % release decision(s) recorded', v_count;
+    END IF;
+  END IF;
+
+  IF to_regclass('public.quality_derogation_consumption') IS NOT NULL THEN
+    SELECT COUNT(*) INTO v_count FROM public.quality_derogation_consumption;
+    IF v_count > 0 THEN
+      RAISE EXCEPTION '#228 rollback refused: % derogation consumption(s) recorded', v_count;
+    END IF;
+  END IF;
+
+  IF to_regclass('public.quality_measurement_revisions') IS NOT NULL THEN
+    SELECT COUNT(*) INTO v_count FROM public.quality_measurement_revisions;
+    IF v_count > 0 THEN
+      RAISE EXCEPTION '#228 rollback refused: % measurement revision(s) recorded', v_count;
+    END IF;
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+  FROM public.quality_control
+  WHERE plan_snapshot_sha256 IS NOT NULL;
+  IF v_count > 0 THEN
+    RAISE EXCEPTION '#228 rollback refused: % control(s) already carry a plan snapshot', v_count;
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+  FROM public.non_conformity
+  WHERE status::text IN ('DRAFT', 'DISPOSITION', 'VERIFICATION', 'CANCELLED');
+  IF v_count > 0 THEN
+    RAISE EXCEPTION '#228 rollback refused: % non-conformity(ies) use an extended status', v_count;
+  END IF;
+END $$;
+
+-- 1) Guard triggers and functions.
+DROP TRIGGER IF EXISTS trg_protect_quality_plan_228 ON public.quality_control_plan;
+DROP TRIGGER IF EXISTS trg_protect_quality_plan_char_228 ON public.quality_control_plan_characteristic;
+DROP TRIGGER IF EXISTS trg_protect_quality_snapshot_228 ON public.quality_control;
+DROP TRIGGER IF EXISTS trg_protect_quality_measurement_228 ON public.quality_control_points;
+DROP TRIGGER IF EXISTS trg_quality_event_log_append_only_228 ON public.quality_event_log;
+DROP TRIGGER IF EXISTS trg_quality_measurement_revisions_append_only_228 ON public.quality_measurement_revisions;
+DROP TRIGGER IF EXISTS trg_quality_release_decision_append_only_228 ON public.quality_release_decision;
+DROP TRIGGER IF EXISTS trg_quality_derogation_consumption_append_only_228 ON public.quality_derogation_consumption;
+DROP TRIGGER IF EXISTS trg_quality_command_receipts_append_only_228 ON public.quality_command_receipts;
+DROP TRIGGER IF EXISTS trg_protect_quality_derogation_228 ON public.quality_derogation;
+DROP TRIGGER IF EXISTS trg_check_quality_derogation_cap_228 ON public.quality_derogation_consumption;
+DROP TRIGGER IF EXISTS trg_protect_quality_documents_228 ON public.quality_documents;
+DROP TRIGGER IF EXISTS quality_control_plan_set_updated_at ON public.quality_control_plan;
+DROP TRIGGER IF EXISTS quality_plan_char_set_updated_at ON public.quality_control_plan_characteristic;
+DROP TRIGGER IF EXISTS quality_derogation_set_updated_at ON public.quality_derogation;
+DROP TRIGGER IF EXISTS non_conformity_analysis_set_updated_at ON public.non_conformity_analysis;
+
+DROP FUNCTION IF EXISTS public.fn_protect_quality_plan_228();
+DROP FUNCTION IF EXISTS public.fn_protect_quality_plan_characteristic_228();
+DROP FUNCTION IF EXISTS public.fn_protect_quality_snapshot_228();
+DROP FUNCTION IF EXISTS public.fn_protect_quality_measurement_228();
+DROP FUNCTION IF EXISTS public.fn_quality_append_only_228();
+DROP FUNCTION IF EXISTS public.fn_protect_quality_derogation_228();
+DROP FUNCTION IF EXISTS public.fn_check_quality_derogation_cap_228();
+DROP FUNCTION IF EXISTS public.fn_protect_quality_documents_228();
+
+-- 2) New tables (empty by construction, see step 0).
+DROP TABLE IF EXISTS public.quality_derogation_consumption;
+DROP TABLE IF EXISTS public.quality_command_receipts;
+DROP TABLE IF EXISTS public.quality_measurement_revisions;
+DROP TABLE IF EXISTS public.quality_release_decision;
+DROP TABLE IF EXISTS public.quality_derogation;
+DROP TABLE IF EXISTS public.non_conformity_analysis;
+DROP TABLE IF EXISTS public.quality_control_plan_characteristic;
+DROP TABLE IF EXISTS public.quality_control_plan;
+
+-- 3) Constraints and indexes added on existing tables.
+ALTER TABLE public.quality_control
+  DROP CONSTRAINT IF EXISTS quality_control_plan_228_fkey,
+  DROP CONSTRAINT IF EXISTS quality_control_verdict_228_ck,
+  DROP CONSTRAINT IF EXISTS quality_control_source_type_228_ck,
+  DROP CONSTRAINT IF EXISTS quality_control_source_pair_228_ck,
+  DROP CONSTRAINT IF EXISTS quality_control_snapshot_pair_228_ck,
+  DROP CONSTRAINT IF EXISTS quality_control_snapshot_hash_228_ck,
+  DROP CONSTRAINT IF EXISTS quality_control_qty_nonneg_228_ck,
+  DROP CONSTRAINT IF EXISTS quality_control_qty_ledger_228_ck;
+
+ALTER TABLE public.quality_control_points
+  DROP CONSTRAINT IF EXISTS quality_control_points_sample_228_ck,
+  DROP CONSTRAINT IF EXISTS quality_control_points_criticality_228_ck,
+  DROP CONSTRAINT IF EXISTS quality_control_points_revision_228_ck,
+  DROP CONSTRAINT IF EXISTS quality_control_points_instrument_228_fkey;
+
+ALTER TABLE public.non_conformity
+  DROP CONSTRAINT IF EXISTS non_conformity_origin_228_ck,
+  DROP CONSTRAINT IF EXISTS non_conformity_confidentiality_228_ck,
+  DROP CONSTRAINT IF EXISTS non_conformity_qty_228_ck,
+  DROP CONSTRAINT IF EXISTS non_conformity_owner_228_fkey;
+
+ALTER TABLE public.non_conformity_dispositions
+  DROP CONSTRAINT IF EXISTS non_conformity_dispositions_derogation_228_fkey,
+  DROP CONSTRAINT IF EXISTS non_conformity_dispositions_control_228_fkey;
+
+ALTER TABLE public.quality_action
+  DROP CONSTRAINT IF EXISTS quality_action_priority_228_ck,
+  DROP CONSTRAINT IF EXISTS quality_action_analysis_228_fkey;
+
+ALTER TABLE public.quality_documents
+  DROP CONSTRAINT IF EXISTS quality_documents_confidentiality_228_ck;
+
+DROP INDEX IF EXISTS public.quality_control_plan_228_idx;
+DROP INDEX IF EXISTS public.quality_control_source_228_idx;
+DROP INDEX IF EXISTS public.quality_control_lot_228_idx;
+DROP INDEX IF EXISTS public.quality_control_reception_line_228_idx;
+DROP INDEX IF EXISTS public.quality_control_verdict_228_idx;
+DROP INDEX IF EXISTS public.quality_control_points_sample_228_uq;
+DROP INDEX IF EXISTS public.quality_control_points_instrument_228_idx;
+DROP INDEX IF EXISTS public.non_conformity_origin_228_idx;
+DROP INDEX IF EXISTS public.non_conformity_owner_228_idx;
+DROP INDEX IF EXISTS public.non_conformity_dispositions_idem_228_uq;
+DROP INDEX IF EXISTS public.quality_event_log_correlation_228_idx;
+
+-- 4) Restore the historical disposition CHECK list (without RECHECK).
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'non_conformity_dispositions_type_check'
+      AND conrelid = 'public.non_conformity_dispositions'::regclass
+  ) THEN
+    ALTER TABLE public.non_conformity_dispositions
+      DROP CONSTRAINT non_conformity_dispositions_type_check;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.non_conformity_dispositions WHERE disposition_type = 'RECHECK'
+  ) THEN
+    ALTER TABLE public.non_conformity_dispositions
+      ADD CONSTRAINT non_conformity_dispositions_type_check
+      CHECK (disposition_type IN (
+        'HOLD', 'RELEASE', 'USE_AS_IS', 'REWORK', 'SORT', 'SCRAP', 'RETURN_SUPPLIER'
+      ));
+  ELSE
+    RAISE NOTICE 'RECHECK dispositions exist; keeping the extended CHECK list.';
+  END IF;
+END $$;
+
+-- 5) Additive columns, dropped only when empty.
+DO $$
+DECLARE
+  v_used bigint;
+BEGIN
+  SELECT COUNT(*) INTO v_used
+  FROM public.quality_control
+  WHERE plan_id IS NOT NULL
+     OR plan_snapshot IS NOT NULL
+     OR source_type IS NOT NULL
+     OR verdict IS NOT NULL
+     OR qty_population IS NOT NULL
+     OR qty_released <> 0
+     OR qty_held <> 0;
+  IF v_used > 0 THEN
+    RAISE EXCEPTION '#228 rollback refused: % quality control(s) use the new columns', v_used;
+  END IF;
+
+  ALTER TABLE public.quality_control
+    DROP COLUMN IF EXISTS plan_id,
+    DROP COLUMN IF EXISTS plan_version,
+    DROP COLUMN IF EXISTS plan_snapshot,
+    DROP COLUMN IF EXISTS plan_snapshot_sha256,
+    DROP COLUMN IF EXISTS source_type,
+    DROP COLUMN IF EXISTS source_id,
+    DROP COLUMN IF EXISTS reception_ligne_id,
+    DROP COLUMN IF EXISTS reception_inspection_id,
+    DROP COLUMN IF EXISTS lot_id,
+    DROP COLUMN IF EXISTS article_id,
+    DROP COLUMN IF EXISTS fournisseur_id,
+    DROP COLUMN IF EXISTS bon_livraison_id,
+    DROP COLUMN IF EXISTS trigger_type,
+    DROP COLUMN IF EXISTS verdict,
+    DROP COLUMN IF EXISTS verdict_computed,
+    DROP COLUMN IF EXISTS verdict_override_reason,
+    DROP COLUMN IF EXISTS verdict_overridden_by,
+    DROP COLUMN IF EXISTS unite,
+    DROP COLUMN IF EXISTS qty_population,
+    DROP COLUMN IF EXISTS qty_controlled,
+    DROP COLUMN IF EXISTS qty_conforming,
+    DROP COLUMN IF EXISTS qty_released,
+    DROP COLUMN IF EXISTS qty_held,
+    DROP COLUMN IF EXISTS qty_scrapped,
+    DROP COLUMN IF EXISTS qty_reworked,
+    DROP COLUMN IF EXISTS qty_sorted,
+    DROP COLUMN IF EXISTS qty_returned,
+    DROP COLUMN IF EXISTS qty_consumed,
+    DROP COLUMN IF EXISTS correlation_id;
+
+  ALTER TABLE public.quality_control_points
+    DROP COLUMN IF EXISTS characteristic_key,
+    DROP COLUMN IF EXISTS sample_no,
+    DROP COLUMN IF EXISTS value_boolean,
+    DROP COLUMN IF EXISTS value_text,
+    DROP COLUMN IF EXISTS instrument_id,
+    DROP COLUMN IF EXISTS instrument_snapshot,
+    DROP COLUMN IF EXISTS evaluation_code,
+    DROP COLUMN IF EXISTS criticality,
+    DROP COLUMN IF EXISTS measured_at,
+    DROP COLUMN IF EXISTS recorded_by,
+    DROP COLUMN IF EXISTS revision;
+
+  ALTER TABLE public.non_conformity
+    DROP COLUMN IF EXISTS origin,
+    DROP COLUMN IF EXISTS defect_category,
+    DROP COLUMN IF EXISTS qty,
+    DROP COLUMN IF EXISTS unite,
+    DROP COLUMN IF EXISTS owner_user_id,
+    DROP COLUMN IF EXISTS confidentiality,
+    DROP COLUMN IF EXISTS capa_required,
+    DROP COLUMN IF EXISTS effectiveness_verified_at,
+    DROP COLUMN IF EXISTS effectiveness_verified_by,
+    DROP COLUMN IF EXISTS reopened_at,
+    DROP COLUMN IF EXISTS reopened_by,
+    DROP COLUMN IF EXISTS reopen_reason,
+    DROP COLUMN IF EXISTS cancelled_at,
+    DROP COLUMN IF EXISTS cancelled_by,
+    DROP COLUMN IF EXISTS cancellation_reason,
+    DROP COLUMN IF EXISTS correlation_id;
+
+  ALTER TABLE public.non_conformity_dispositions
+    DROP COLUMN IF EXISTS derogation_id,
+    DROP COLUMN IF EXISTS quality_control_id,
+    DROP COLUMN IF EXISTS instructions,
+    DROP COLUMN IF EXISTS idempotency_key,
+    DROP COLUMN IF EXISTS preview_sha256,
+    DROP COLUMN IF EXISTS correlation_id;
+
+  ALTER TABLE public.quality_action
+    DROP COLUMN IF EXISTS priority,
+    DROP COLUMN IF EXISTS mandatory,
+    DROP COLUMN IF EXISTS started_at,
+    DROP COLUMN IF EXISTS completed_at,
+    DROP COLUMN IF EXISTS evidence_required,
+    DROP COLUMN IF EXISTS analysis_id,
+    DROP COLUMN IF EXISTS correlation_id;
+
+  ALTER TABLE public.quality_documents
+    DROP COLUMN IF EXISTS revision,
+    DROP COLUMN IF EXISTS confidentiality,
+    DROP COLUMN IF EXISTS retention_until,
+    DROP COLUMN IF EXISTS decision_evidence;
+
+  ALTER TABLE public.quality_event_log
+    DROP COLUMN IF EXISTS correlation_id,
+    DROP COLUMN IF EXISTS idempotency_key,
+    DROP COLUMN IF EXISTS rule_code,
+    DROP COLUMN IF EXISTS reason,
+    DROP COLUMN IF EXISTS request_id,
+    DROP COLUMN IF EXISTS source;
+END $$;
+
+COMMIT;
+
+-- Reminder: enum values added by #228 remain in place (PostgreSQL limitation).
+SELECT t.typname AS enum_type, e.enumlabel AS value
+FROM pg_type t
+JOIN pg_enum e ON e.enumtypid = t.oid
+WHERE t.typname IN ('quality_nc_status', 'quality_entity_type', 'quality_document_type')
+ORDER BY t.typname, e.enumsortorder;

--- a/db/patches/support/20260725_qualite_360_228.verify.sql
+++ b/db/patches/support/20260725_qualite_360_228.verify.sql
@@ -1,0 +1,112 @@
+\set ON_ERROR_STOP on
+
+-- Read-only verification for issue #228 after applying the forward patch.
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#228 verify is restricted to cerp_test';
+  END IF;
+END $$;
+
+SELECT current_database() AS database_name, now() AS verified_at;
+
+-- 1) Tables created.
+SELECT object_name, present
+FROM (
+  VALUES
+    ('quality_control_plan', to_regclass('public.quality_control_plan') IS NOT NULL),
+    ('quality_control_plan_characteristic', to_regclass('public.quality_control_plan_characteristic') IS NOT NULL),
+    ('quality_measurement_revisions', to_regclass('public.quality_measurement_revisions') IS NOT NULL),
+    ('quality_release_decision', to_regclass('public.quality_release_decision') IS NOT NULL),
+    ('quality_derogation', to_regclass('public.quality_derogation') IS NOT NULL),
+    ('quality_derogation_consumption', to_regclass('public.quality_derogation_consumption') IS NOT NULL),
+    ('non_conformity_analysis', to_regclass('public.non_conformity_analysis') IS NOT NULL),
+    ('quality_command_receipts', to_regclass('public.quality_command_receipts') IS NOT NULL)
+) AS checks(object_name, present)
+ORDER BY object_name;
+
+-- 2) Additive columns on existing tables.
+SELECT table_name, column_name, data_type, is_nullable, column_default
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND (
+    (table_name = 'quality_control' AND column_name IN (
+      'plan_id', 'plan_version', 'plan_snapshot', 'plan_snapshot_sha256', 'source_type', 'source_id',
+      'verdict', 'verdict_computed', 'unite', 'qty_population', 'qty_controlled', 'qty_conforming',
+      'qty_released', 'qty_held', 'qty_scrapped', 'qty_reworked', 'qty_sorted', 'qty_returned',
+      'qty_consumed', 'correlation_id', 'reception_inspection_id'))
+    OR (table_name = 'quality_control_points' AND column_name IN (
+      'characteristic_key', 'sample_no', 'value_boolean', 'value_text', 'instrument_id',
+      'instrument_snapshot', 'evaluation_code', 'criticality', 'revision'))
+    OR (table_name = 'non_conformity' AND column_name IN (
+      'origin', 'defect_category', 'qty', 'unite', 'owner_user_id', 'confidentiality',
+      'capa_required', 'reopened_at', 'cancelled_at', 'correlation_id'))
+    OR (table_name = 'non_conformity_dispositions' AND column_name IN (
+      'derogation_id', 'quality_control_id', 'instructions', 'idempotency_key', 'preview_sha256'))
+    OR (table_name = 'quality_action' AND column_name IN (
+      'priority', 'mandatory', 'started_at', 'completed_at', 'evidence_required', 'analysis_id'))
+    OR (table_name = 'quality_documents' AND column_name IN (
+      'revision', 'confidentiality', 'retention_until', 'decision_evidence'))
+    OR (table_name = 'quality_event_log' AND column_name IN (
+      'correlation_id', 'idempotency_key', 'rule_code', 'reason', 'request_id', 'source'))
+  )
+ORDER BY table_name, column_name;
+
+-- 3) Extended enum values are present (historical values must remain first).
+SELECT t.typname AS enum_type, e.enumlabel AS value, e.enumsortorder
+FROM pg_type t
+JOIN pg_enum e ON e.enumtypid = t.oid
+WHERE t.typname IN ('quality_nc_status', 'quality_entity_type', 'quality_document_type')
+ORDER BY t.typname, e.enumsortorder;
+
+-- 4) Guard triggers installed.
+SELECT c.relname AS table_name, t.tgname AS trigger_name, NOT t.tgisinternal AS user_trigger
+FROM pg_trigger t
+JOIN pg_class c ON c.oid = t.tgrelid
+WHERE NOT t.tgisinternal
+  AND t.tgname LIKE '%\_228'
+ORDER BY c.relname, t.tgname;
+
+-- 5) Quantity ledger constraints are VALID (not left NOT VALID).
+SELECT conname, convalidated
+FROM pg_constraint
+WHERE conname IN (
+  'quality_control_qty_nonneg_228_ck',
+  'quality_control_qty_ledger_228_ck',
+  'non_conformity_dispositions_type_check'
+)
+ORDER BY conname;
+
+-- 6) Uniqueness guarantees.
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND indexname IN (
+    'quality_control_points_sample_228_uq',
+    'non_conformity_dispositions_idem_228_uq',
+    'quality_command_receipts_resource_228_idx'
+  )
+ORDER BY indexname;
+
+-- 7) The patch stays inactive: no plan, no derogation, no release decision.
+SELECT 'quality_control_plan' AS table_name, COUNT(*)::bigint AS rows FROM public.quality_control_plan
+UNION ALL SELECT 'quality_control_plan_characteristic', COUNT(*)::bigint FROM public.quality_control_plan_characteristic
+UNION ALL SELECT 'quality_derogation', COUNT(*)::bigint FROM public.quality_derogation
+UNION ALL SELECT 'quality_derogation_consumption', COUNT(*)::bigint FROM public.quality_derogation_consumption
+UNION ALL SELECT 'quality_release_decision', COUNT(*)::bigint FROM public.quality_release_decision
+UNION ALL SELECT 'quality_measurement_revisions', COUNT(*)::bigint FROM public.quality_measurement_revisions
+UNION ALL SELECT 'non_conformity_analysis', COUNT(*)::bigint FROM public.non_conformity_analysis
+UNION ALL SELECT 'quality_command_receipts', COUNT(*)::bigint FROM public.quality_command_receipts
+ORDER BY table_name;
+
+-- 8) Historical quality data untouched: no lot status was changed by the patch.
+SELECT lot_status, COUNT(*)::bigint AS rows
+FROM public.lots
+GROUP BY lot_status
+ORDER BY lot_status;
+
+-- 9) Historical controls keep their result and validation identity.
+SELECT status, result, COUNT(*)::bigint AS rows
+FROM public.quality_control
+GROUP BY status, result
+ORDER BY status, result;

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -137,3 +137,55 @@ schema.
 No `DATABASE_URL` for `cerp_test` was configured in the #225 workspace on
 2026-07-23, so the patch was not applied or registered on any database.
 `cerp_prod` was not modified.
+
+## Issue #228 - Qualite industrielle 360 : plans, controles, liberation, NC, derogations et CAPA
+
+Patch `20260725_qualite_360_228.sql` adds the governance layer the Qualite
+module was missing: versioned control plans with an immutable published state,
+a canonical plan snapshot with its SHA-256 fingerprint frozen on each control
+execution, a quantity ledger enforced by CHECK constraints (controlled <=
+population, conforming <= controlled, released <= conforming, consumed <=
+released, dispositions <= population), append-only release decisions, a
+derogation/concession registry with immutable consumptions, a bounded 5 Why /
+8D structure, and actor-scoped idempotency receipts.
+
+The patch is **additive, idempotent, transactional and inactive**: it creates
+no plan, no derogation, no release decision and no disposition, it never
+touches `public.lots` statuses and it never writes a stock movement. Historical
+enums are **extended, never duplicated** — `quality_nc_status` gains `DRAFT`,
+`DISPOSITION`, `VERIFICATION` and `CANCELLED`; `quality_entity_type` gains
+`PLAN`, `DEROGATION` and `RELEASE`; the disposition CHECK list gains `RECHECK`.
+The new enum values are deliberately not consumed inside the same transaction,
+per the documented PostgreSQL 12+ restriction on `ALTER TYPE ... ADD VALUE`.
+
+Codification: `public.fn_next_issued_code_value` gains the `PC` (control plans)
+and `DER` (derogations) scopes, exactly as `#172` added `BCF`. The function body
+is otherwise identical; only the whitelist regex changes.
+
+Guard triggers installed by the patch:
+
+- `trg_protect_quality_plan_228` / `trg_protect_quality_plan_char_228` — a
+  published or archived plan and its characteristics are immutable.
+- `trg_protect_quality_snapshot_228` — the applied plan snapshot, its hash, the
+  population, the unit and the source of a validated control cannot be rewritten.
+- `trg_protect_quality_measurement_228` — a measurement of a validated control
+  requires an audited revision and can never be deleted.
+- `trg_quality_*_append_only_228` — event log, measurement revisions, release
+  decisions, derogation consumptions and command receipts are append-only.
+- `trg_protect_quality_derogation_228` / `trg_check_quality_derogation_cap_228`
+  — an approved derogation keeps its scope, deviation and caps, consumption
+  never decreases, and consumptions cannot exceed the approved maximum.
+- `trg_protect_quality_documents_228` — quality documents are removed logically
+  only, a decision-evidence document cannot be removed, and the file identity
+  (hash, storage path) is immutable.
+
+Run `db/patches/support/20260725_qualite_360_228.preflight.sql` before applying
+and `...verify.sql` afterwards. All three support scripts are restricted to
+`cerp_test`. The rollback refuses to continue once a release decision, a
+derogation consumption, a measurement revision, a plan snapshot, an extended NC
+status or any new column value exists; enum values added by #228 cannot be
+removed by PostgreSQL and stay in place.
+
+No `DATABASE_URL` for `cerp_test` was configured in the #228 workspace on
+2026-07-25, so the patch was **not** applied or registered on any database.
+`cerp_prod` was not modified.

--- a/src/__tests__/qualite-360-228.domain.test.ts
+++ b/src/__tests__/qualite-360-228.domain.test.ts
@@ -1,0 +1,1757 @@
+import { describe, expect, it } from "vitest";
+
+import { HttpError } from "../utils/httpError";
+import {
+  assertDerogationApprovalSeparation,
+  assertDerogationTransition,
+  assertManualVerdictOverride,
+  assertNcClosureAllowed,
+  assertNcTransition,
+  assertOptimisticVersion,
+  assertPlanContentMutable,
+  assertPlanSelectableForExecution,
+  assertPlanTransition,
+  assertPreviewFresh,
+  assertQualityCapability,
+  assertReleaseSeparation,
+  canonicalJson,
+  decideQualityReceipt,
+  dispositionImpactsStock,
+  dispositionRequiresDerogation,
+  executionStatusForVerdict,
+  legacyResultToVerdict,
+  normalizeQualityIdempotencyKey,
+  QUALITY_CAPABILITIES,
+  qualityRequestHash,
+  qualitySha256,
+  roleHasQualityCapability,
+  verdictToLegacyResult,
+  type QualityCapability,
+  type QualityNcStatus,
+  type QualityPlanStatus,
+} from "../module/qualite/domain/quality-policy";
+import {
+  assertCharacteristicSpec,
+  assertNoApplicabilityOverlap,
+  assertSnapshotIntegrity,
+  buildPlanSnapshot,
+  characteristicsFromSnapshot,
+  computeExecutionVerdict,
+  evaluateSample,
+  isLotLevelCharacteristic,
+  planScopeSpecificity,
+  requiredSampleCount,
+  resolveCharacteristicBounds,
+  selectApplicablePlan,
+  TRIGGER_SEMANTICS,
+  type PlanApplicabilityScope,
+  type PlanCandidate,
+  type QualityCharacteristicSpec,
+  type QualitySampleValue,
+} from "../module/qualite/domain/quality-plan";
+import {
+  assertQualityEligibility,
+  assertQuantityLedger,
+  assertSourceRef,
+  derogationStatusAfterConsumption,
+  EMPTY_LEDGER,
+  evaluateDerogationUsage,
+  evaluateInstrumentUsage,
+  evaluateQualityEligibility,
+  evaluateReleaseRequest,
+  isInstrumentOverdue,
+  releasableQty,
+  remainingUndisposedQty,
+  type DerogationState,
+  type EligibilityTarget,
+  type InstrumentState,
+  type QuantityLedger,
+} from "../module/qualite/domain/quality-release";
+
+const NOW = new Date("2026-07-25T10:00:00.000Z");
+
+function httpErrorOf(fn: () => unknown): HttpError {
+  try {
+    fn();
+  } catch (err) {
+    if (err instanceof HttpError) return err;
+    throw err;
+  }
+  throw new Error("expected an HttpError to be thrown");
+}
+
+function characteristic(
+  overrides: Partial<QualityCharacteristicSpec> = {}
+): QualityCharacteristicSpec {
+  return {
+    key: "DIM-01",
+    position: 1,
+    label: "Diamètre extérieur",
+    characteristic_type: "DIMENSIONAL",
+    value_kind: "NUMERIC",
+    unit: "mm",
+    nominal: 20,
+    tolerance_min: -0.05,
+    tolerance_max: 0.05,
+    precision: 3,
+    expected_boolean: null,
+    allowed_values: null,
+    criticality: "MAJOR",
+    mandatory: true,
+    requires_instrument: true,
+    instrument_category: "MICROMETRE",
+    method: "Micromètre 0-25",
+    acceptance_rule: "Dans la tolérance",
+    sampling: { rule: "FIXED", value: 3, justification: null },
+    trigger: "FINAL",
+    ...overrides,
+  };
+}
+
+function sample(overrides: Partial<QualitySampleValue> = {}): QualitySampleValue {
+  return {
+    characteristic_key: "DIM-01",
+    sample_no: 1,
+    value_numeric: 20,
+    value_boolean: null,
+    value_text: null,
+    unit: "mm",
+    evidence_count: 0,
+    ...overrides,
+  };
+}
+
+function ledger(overrides: Partial<QuantityLedger> = {}): QuantityLedger {
+  return { ...EMPTY_LEDGER, population: 100, controlled: 100, conforming: 100, ...overrides };
+}
+
+function scope(overrides: Partial<PlanApplicabilityScope> = {}): PlanApplicabilityScope {
+  return {
+    article_id: null,
+    piece_technique_id: null,
+    piece_version_id: null,
+    famille_id: null,
+    operation_code: null,
+    fournisseur_id: null,
+    trigger: "FINAL",
+    effective_from: null,
+    effective_to: null,
+    ...overrides,
+  };
+}
+
+function plan(overrides: Partial<PlanCandidate> = {}): PlanCandidate {
+  return {
+    id: "plan-1",
+    code: "PC-2026-0001",
+    version: 1,
+    status: "PUBLISHED",
+    scope: scope({ piece_technique_id: "piece-1" }),
+    ...overrides,
+  };
+}
+
+function instrument(overrides: Partial<InstrumentState> = {}): InstrumentState {
+  return {
+    id: "instr-1",
+    code: "MIC-001",
+    designation: "Micromètre 0-25",
+    statut: "ACTIF",
+    criticite: "CRITIQUE",
+    categorie: "MICROMETRE",
+    next_due_date: "2026-12-31",
+    deleted: false,
+    ...overrides,
+  };
+}
+
+function derogation(overrides: Partial<DerogationState> = {}): DerogationState {
+  return {
+    id: "der-1",
+    code: "DER-2026-0001",
+    status: "APPROVED",
+    article_id: null,
+    piece_technique_id: null,
+    piece_version_id: null,
+    lot_id: "lot-1",
+    of_id: null,
+    commande_id: null,
+    bon_livraison_id: null,
+    max_qty: 50,
+    unit: "pce",
+    consumed_qty: 0,
+    valid_from: "2026-07-01T00:00:00.000Z",
+    valid_to: "2026-08-31T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function target(overrides: Partial<EligibilityTarget> = {}): EligibilityTarget {
+  return {
+    object_type: "LOT",
+    object_id: "lot-1",
+    label: "LOT-2026-0001",
+    qty_requested: 10,
+    lot_status: "LIBERE",
+    qty_released: 100,
+    qty_held: 0,
+    qty_consumed: 0,
+    open_nc_without_disposition: 0,
+    pending_mandatory_controls: 0,
+    derogation: null,
+    ...overrides,
+  };
+}
+
+/* ========================================================================== */
+/* RBAC                                                                       */
+/* ========================================================================== */
+
+describe("#228 RBAC qualité — refus par défaut", () => {
+  it.each(QUALITY_CAPABILITIES)("refuse un rôle vide pour '%s'", (capability) => {
+    expect(roleHasQualityCapability(null, capability)).toBe(false);
+    expect(roleHasQualityCapability(undefined, capability)).toBe(false);
+    expect(roleHasQualityCapability("", capability)).toBe(false);
+    expect(roleHasQualityCapability("   ", capability)).toBe(false);
+  });
+
+  it.each(QUALITY_CAPABILITIES)("refuse un rôle inconnu pour '%s'", (capability) => {
+    expect(roleHasQualityCapability("Stagiaire", capability)).toBe(false);
+    expect(roleHasQualityCapability("Client externe", capability)).toBe(false);
+  });
+
+  it("autorise le responsable qualité sur les décisions", () => {
+    for (const capability of [
+      "read",
+      "plan_publish",
+      "execution_run",
+      "release_decide",
+      "disposition_stock",
+      "nc_manage",
+      "capa_manage",
+      "derogation_approve",
+      "closure_verify",
+    ] as QualityCapability[]) {
+      expect(roleHasQualityCapability("Responsable Qualite", capability)).toBe(true);
+    }
+  });
+
+  it("laisse l'atelier saisir sans lui donner la décision", () => {
+    expect(roleHasQualityCapability("Chef d'atelier", "measurement_write")).toBe(true);
+    expect(roleHasQualityCapability("Chef d'atelier", "execution_run")).toBe(true);
+    expect(roleHasQualityCapability("Chef d'atelier", "release_decide")).toBe(false);
+    expect(roleHasQualityCapability("Chef d'atelier", "disposition_stock")).toBe(false);
+    expect(roleHasQualityCapability("Chef d'atelier", "derogation_approve")).toBe(false);
+    expect(roleHasQualityCapability("Chef d'atelier", "plan_publish")).toBe(false);
+  });
+
+  it("réserve la gestion des réglages à l'administration et à la direction", () => {
+    expect(roleHasQualityCapability("Administrateur Systeme et Reseau", "settings_manage")).toBe(true);
+    expect(roleHasQualityCapability("Directeur industriel", "settings_manage")).toBe(true);
+    expect(roleHasQualityCapability("Responsable Qualite", "settings_manage")).toBe(false);
+  });
+
+  it("lève un 403 explicite quand la capacité manque", () => {
+    const err = httpErrorOf(() => assertQualityCapability("Secretaire", "release_decide"));
+    expect(err.status).toBe(403);
+    expect(err.code).toBe("QUALITY_CAPABILITY_REQUIRED");
+  });
+
+  it("n'autorise pas une capacité inventée", () => {
+    expect(roleHasQualityCapability("Responsable Qualite", "hack" as QualityCapability)).toBe(false);
+  });
+});
+
+/* ========================================================================== */
+/* Cycles de vie                                                              */
+/* ========================================================================== */
+
+describe("#228 cycle de vie des plans de contrôle", () => {
+  const legal: Array<[QualityPlanStatus, QualityPlanStatus]> = [
+    ["DRAFT", "IN_REVIEW"],
+    ["DRAFT", "PUBLISHED"],
+    ["DRAFT", "ARCHIVED"],
+    ["IN_REVIEW", "DRAFT"],
+    ["IN_REVIEW", "PUBLISHED"],
+    ["IN_REVIEW", "ARCHIVED"],
+    ["PUBLISHED", "ARCHIVED"],
+  ];
+  const illegal: Array<[QualityPlanStatus, QualityPlanStatus]> = [
+    ["PUBLISHED", "DRAFT"],
+    ["PUBLISHED", "IN_REVIEW"],
+    ["PUBLISHED", "PUBLISHED"],
+    ["ARCHIVED", "DRAFT"],
+    ["ARCHIVED", "IN_REVIEW"],
+    ["ARCHIVED", "PUBLISHED"],
+    ["ARCHIVED", "ARCHIVED"],
+    ["DRAFT", "DRAFT"],
+  ];
+
+  it.each(legal)("autorise %s → %s", (from, to) => {
+    expect(() => assertPlanTransition(from, to)).not.toThrow();
+  });
+
+  it.each(illegal)("refuse %s → %s", (from, to) => {
+    const err = httpErrorOf(() => assertPlanTransition(from, to));
+    expect(err.status).toBe(409);
+    expect(err.code).toBe("QUALITY_PLAN_TRANSITION_FORBIDDEN");
+  });
+
+  it("interdit de modifier le contenu d'un plan publié ou archivé", () => {
+    expect(() => assertPlanContentMutable("DRAFT")).not.toThrow();
+    expect(() => assertPlanContentMutable("IN_REVIEW")).not.toThrow();
+    expect(httpErrorOf(() => assertPlanContentMutable("PUBLISHED")).code).toBe("QUALITY_PLAN_IMMUTABLE");
+    expect(httpErrorOf(() => assertPlanContentMutable("ARCHIVED")).code).toBe("QUALITY_PLAN_IMMUTABLE");
+  });
+
+  it("n'accepte qu'un plan publié pour une exécution", () => {
+    expect(() => assertPlanSelectableForExecution("PUBLISHED")).not.toThrow();
+    for (const status of ["DRAFT", "IN_REVIEW", "ARCHIVED"] as QualityPlanStatus[]) {
+      expect(httpErrorOf(() => assertPlanSelectableForExecution(status)).code).toBe(
+        "QUALITY_PLAN_NOT_PUBLISHED"
+      );
+    }
+  });
+});
+
+describe("#228 cycle de vie des non-conformités", () => {
+  const legal: Array<[QualityNcStatus, QualityNcStatus]> = [
+    ["DRAFT", "OPEN"],
+    ["DRAFT", "CANCELLED"],
+    ["OPEN", "ANALYSIS"],
+    ["OPEN", "DISPOSITION"],
+    ["ANALYSIS", "DISPOSITION"],
+    ["ANALYSIS", "ACTION_PLAN"],
+    ["DISPOSITION", "ACTION_PLAN"],
+    ["DISPOSITION", "VERIFICATION"],
+    ["ACTION_PLAN", "VERIFICATION"],
+    ["VERIFICATION", "CLOSED"],
+    ["VERIFICATION", "ACTION_PLAN"],
+    ["CLOSED", "OPEN"],
+  ];
+  const illegal: Array<[QualityNcStatus, QualityNcStatus]> = [
+    ["DRAFT", "CLOSED"],
+    ["OPEN", "CLOSED"],
+    ["OPEN", "VERIFICATION"],
+    ["ANALYSIS", "CLOSED"],
+    ["ACTION_PLAN", "CLOSED"],
+    ["CLOSED", "CLOSED"],
+    ["CLOSED", "CANCELLED"],
+    ["CANCELLED", "OPEN"],
+    ["CANCELLED", "CLOSED"],
+    ["DISPOSITION", "CLOSED"],
+  ];
+
+  it.each(legal)("autorise %s → %s", (from, to) => {
+    expect(() => assertNcTransition(from, to)).not.toThrow();
+  });
+
+  it.each(illegal)("refuse %s → %s", (from, to) => {
+    const err = httpErrorOf(() => assertNcTransition(from, to));
+    expect(err.status).toBe(409);
+    expect(err.code).toBe("QUALITY_NC_TRANSITION_FORBIDDEN");
+  });
+
+  it("exige disposition, cause, CAPA vérifiées et preuve pour clôturer", () => {
+    const complete = {
+      hasDisposition: true,
+      mandatoryCapaCount: 2,
+      verifiedCapaCount: 2,
+      hasRootCause: true,
+      hasEffectivenessEvidence: true,
+    };
+    expect(() => assertNcClosureAllowed(complete)).not.toThrow();
+
+    const cases: Array<[Partial<typeof complete>, string]> = [
+      [{ hasDisposition: false }, "disposition"],
+      [{ hasRootCause: false }, "root_cause"],
+      [{ verifiedCapaCount: 1 }, "capa_verification"],
+      [{ verifiedCapaCount: 0 }, "capa_verification"],
+      [{ hasEffectivenessEvidence: false }, "effectiveness_evidence"],
+    ];
+    for (const [override, expectedMissing] of cases) {
+      const err = httpErrorOf(() => assertNcClosureAllowed({ ...complete, ...override }));
+      expect(err.status).toBe(422);
+      expect(err.code).toBe("QUALITY_NC_CLOSURE_INCOMPLETE");
+      expect(err.details.missing).toContain(expectedMissing);
+    }
+  });
+
+  it("n'exige pas de CAPA vérifiée quand aucune CAPA n'est obligatoire", () => {
+    expect(() =>
+      assertNcClosureAllowed({
+        hasDisposition: true,
+        mandatoryCapaCount: 0,
+        verifiedCapaCount: 0,
+        hasRootCause: true,
+        hasEffectivenessEvidence: true,
+      })
+    ).not.toThrow();
+  });
+});
+
+describe("#228 cycle de vie des dérogations", () => {
+  it.each([
+    ["DRAFT", "SUBMITTED"],
+    ["SUBMITTED", "APPROVED"],
+    ["SUBMITTED", "REJECTED"],
+    ["SUBMITTED", "DRAFT"],
+    ["APPROVED", "CONSUMED"],
+    ["APPROVED", "EXPIRED"],
+    ["APPROVED", "REVOKED"],
+    ["CONSUMED", "REVOKED"],
+  ] as const)("autorise %s → %s", (from, to) => {
+    expect(() => assertDerogationTransition(from, to)).not.toThrow();
+  });
+
+  it.each([
+    ["DRAFT", "APPROVED"],
+    ["DRAFT", "CONSUMED"],
+    ["SUBMITTED", "CONSUMED"],
+    ["REJECTED", "APPROVED"],
+    ["REJECTED", "SUBMITTED"],
+    ["EXPIRED", "APPROVED"],
+    ["REVOKED", "APPROVED"],
+    ["CONSUMED", "APPROVED"],
+    ["APPROVED", "SUBMITTED"],
+    ["APPROVED", "APPROVED"],
+  ] as const)("refuse %s → %s", (from, to) => {
+    const err = httpErrorOf(() => assertDerogationTransition(from, to));
+    expect(err.status).toBe(409);
+    expect(err.code).toBe("QUALITY_DEROGATION_TRANSITION_FORBIDDEN");
+  });
+});
+
+describe("#228 séparation des tâches", () => {
+  it("interdit l'auto-libération et l'auto-approbation", () => {
+    expect(httpErrorOf(() => assertReleaseSeparation({ executorUserId: 7, deciderUserId: 7 })).code).toBe(
+      "QUALITY_SEPARATION_OF_DUTIES"
+    );
+    expect(
+      httpErrorOf(() => assertDerogationApprovalSeparation({ requesterUserId: 7, approverUserId: 7 })).code
+    ).toBe("QUALITY_SEPARATION_OF_DUTIES");
+  });
+
+  it("autorise deux acteurs distincts", () => {
+    expect(() => assertReleaseSeparation({ executorUserId: 7, deciderUserId: 8 })).not.toThrow();
+    expect(() =>
+      assertDerogationApprovalSeparation({ requesterUserId: 7, approverUserId: 8 })
+    ).not.toThrow();
+  });
+
+  it("n'assouplit la règle que par exception explicitement configurée", () => {
+    expect(() =>
+      assertReleaseSeparation({
+        executorUserId: 7,
+        deciderUserId: 7,
+        policy: { allowSelfRelease: true, allowSelfDerogationApproval: false },
+      })
+    ).not.toThrow();
+    expect(
+      httpErrorOf(() =>
+        assertDerogationApprovalSeparation({
+          requesterUserId: 7,
+          approverUserId: 7,
+          policy: { allowSelfRelease: true, allowSelfDerogationApproval: false },
+        })
+      ).code
+    ).toBe("QUALITY_SEPARATION_OF_DUTIES");
+  });
+
+  it("ne bloque pas quand l'exécutant est inconnu", () => {
+    expect(() => assertReleaseSeparation({ executorUserId: null, deciderUserId: 7 })).not.toThrow();
+  });
+});
+
+/* ========================================================================== */
+/* Verdicts et compatibilité                                                  */
+/* ========================================================================== */
+
+describe("#228 mapping verdict ↔ enum historique", () => {
+  it("conserve la compatibilité OK/NOK/PARTIAL", () => {
+    expect(verdictToLegacyResult("CONFORME")).toBe("OK");
+    expect(verdictToLegacyResult("NON_CONFORME")).toBe("NOK");
+    expect(verdictToLegacyResult("PARTIEL")).toBe("PARTIAL");
+    expect(verdictToLegacyResult("EN_ATTENTE")).toBeNull();
+    expect(legacyResultToVerdict("OK")).toBe("CONFORME");
+    expect(legacyResultToVerdict("NOK")).toBe("NON_CONFORME");
+    expect(legacyResultToVerdict("PARTIAL")).toBe("PARTIEL");
+    expect(legacyResultToVerdict(null)).toBe("EN_ATTENTE");
+    expect(legacyResultToVerdict(undefined)).toBe("EN_ATTENTE");
+  });
+
+  it("dérive le statut d'exécution du verdict", () => {
+    expect(executionStatusForVerdict("CONFORME")).toBe("VALIDATED");
+    expect(executionStatusForVerdict("NON_CONFORME")).toBe("REJECTED");
+    expect(executionStatusForVerdict("PARTIEL")).toBe("REJECTED");
+    expect(executionStatusForVerdict("EN_ATTENTE")).toBe("IN_PROGRESS");
+  });
+});
+
+describe("#228 verdict manuel contraire au calcul", () => {
+  const base = {
+    computed: "PARTIEL" as const,
+    requested: "NON_CONFORME" as const,
+    justification: "Écart confirmé sur les 3 pièces mesurées après recontrôle croisé.",
+    evidenceCount: 1,
+    requireEvidence: true,
+  };
+
+  it("accepte un verdict identique sans justification", () => {
+    expect(() =>
+      assertManualVerdictOverride({ ...base, requested: "PARTIEL", justification: null, evidenceCount: 0 })
+    ).not.toThrow();
+  });
+
+  it("accepte un écart justifié et documenté", () => {
+    expect(() => assertManualVerdictOverride(base)).not.toThrow();
+  });
+
+  it.each([
+    [{ justification: null }, "QUALITY_VERDICT_OVERRIDE_JUSTIFICATION_REQUIRED"],
+    [{ justification: "   " }, "QUALITY_VERDICT_OVERRIDE_JUSTIFICATION_REQUIRED"],
+    [{ justification: "trop court" }, "QUALITY_VERDICT_OVERRIDE_JUSTIFICATION_REQUIRED"],
+    [{ evidenceCount: 0 }, "QUALITY_VERDICT_OVERRIDE_EVIDENCE_REQUIRED"],
+  ] as const)("refuse un écart incomplet (%o)", (override, code) => {
+    const err = httpErrorOf(() => assertManualVerdictOverride({ ...base, ...override }));
+    expect(err.status).toBe(422);
+    expect(err.code).toBe(code);
+  });
+
+  it("interdit de transformer NON_CONFORME en CONFORME sans dérogation", () => {
+    const err = httpErrorOf(() =>
+      assertManualVerdictOverride({
+        computed: "NON_CONFORME",
+        requested: "CONFORME",
+        justification: "Le client accepte la pièce malgré l'écart mesuré sur la cote 12H7.",
+        evidenceCount: 2,
+        requireEvidence: true,
+      })
+    );
+    expect(err.code).toBe("QUALITY_VERDICT_OVERRIDE_FORBIDDEN");
+  });
+});
+
+/* ========================================================================== */
+/* Idempotence, empreintes et verrou optimiste                                */
+/* ========================================================================== */
+
+describe("#228 idempotence et empreintes", () => {
+  it.each([
+    [null],
+    [undefined],
+    [""],
+    ["   "],
+    ["short"],
+    ["1234567"],
+    ["x".repeat(201)],
+  ])("refuse une Idempotency-Key invalide (%s)", (value) => {
+    const err = httpErrorOf(() => normalizeQualityIdempotencyKey(value as string | null));
+    expect(err.status).toBe(400);
+    expect(err.code).toBe("IDEMPOTENCY_KEY_INVALID");
+  });
+
+  it("accepte et normalise une clé valide", () => {
+    expect(normalizeQualityIdempotencyKey("  release-2026-0001  ")).toBe("release-2026-0001");
+    expect(normalizeQualityIdempotencyKey("x".repeat(200))).toHaveLength(200);
+  });
+
+  it("produit un JSON canonique indépendant de l'ordre des clés", () => {
+    expect(canonicalJson({ b: 1, a: { d: 2, c: 3 } })).toBe(canonicalJson({ a: { c: 3, d: 2 }, b: 1 }));
+    expect(qualitySha256({ b: 1, a: 2 })).toBe(qualitySha256({ a: 2, b: 1 }));
+  });
+
+  it("ignore les clés indéfinies mais distingue null", () => {
+    expect(canonicalJson({ a: 1, b: undefined })).toBe(canonicalJson({ a: 1 }));
+    expect(canonicalJson({ a: 1, b: null })).not.toBe(canonicalJson({ a: 1 }));
+  });
+
+  it("préserve l'ordre des tableaux", () => {
+    expect(qualitySha256([1, 2])).not.toBe(qualitySha256([2, 1]));
+  });
+
+  it("produit une empreinte SHA-256 hexadécimale de 64 caractères", () => {
+    expect(qualityRequestHash("quality.release.confirm", { qty: 10 })).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("distingue rejeu et conflit d'Idempotency-Key", () => {
+    const hash = qualityRequestHash("quality.release.confirm", { qty: 10 });
+    expect(decideQualityReceipt(null, hash)).toBe("NEW");
+    expect(decideQualityReceipt(undefined, hash)).toBe("NEW");
+    expect(decideQualityReceipt("", hash)).toBe("NEW");
+    expect(decideQualityReceipt(hash, hash)).toBe("REPLAY");
+    expect(decideQualityReceipt("f".repeat(64), hash)).toBe("CONFLICT");
+  });
+
+  it("exige un aperçu frais avant une décision", () => {
+    const hash = qualitySha256({ qty: 10 });
+    expect(() => assertPreviewFresh({ expectedHash: hash, currentHash: hash })).not.toThrow();
+    expect(httpErrorOf(() => assertPreviewFresh({ expectedHash: null, currentHash: hash })).code).toBe(
+      "QUALITY_PREVIEW_REQUIRED"
+    );
+    const stale = httpErrorOf(() =>
+      assertPreviewFresh({ expectedHash: "a".repeat(64), currentHash: hash })
+    );
+    expect(stale.status).toBe(409);
+    expect(stale.code).toBe("QUALITY_PREVIEW_STALE");
+  });
+
+  it("applique le verrou optimiste sur expected_updated_at", () => {
+    const current = "2026-07-25T10:00:00.000Z";
+    expect(() =>
+      assertOptimisticVersion({ expectedUpdatedAt: current, currentUpdatedAt: current })
+    ).not.toThrow();
+    expect(() =>
+      assertOptimisticVersion({ expectedUpdatedAt: current, currentUpdatedAt: new Date(current) })
+    ).not.toThrow();
+    expect(
+      httpErrorOf(() => assertOptimisticVersion({ expectedUpdatedAt: null, currentUpdatedAt: current })).code
+    ).toBe("QUALITY_EXPECTED_VERSION_REQUIRED");
+    expect(
+      httpErrorOf(() => assertOptimisticVersion({ expectedUpdatedAt: "nope", currentUpdatedAt: current }))
+        .code
+    ).toBe("QUALITY_EXPECTED_VERSION_INVALID");
+    const conflict = httpErrorOf(() =>
+      assertOptimisticVersion({
+        expectedUpdatedAt: "2026-07-25T09:59:59.000Z",
+        currentUpdatedAt: current,
+      })
+    );
+    expect(conflict.status).toBe(409);
+    expect(conflict.code).toBe("QUALITY_VERSION_CONFLICT");
+  });
+});
+
+/* ========================================================================== */
+/* Dispositions                                                               */
+/* ========================================================================== */
+
+describe("#228 dispositions qualité", () => {
+  it("n'écrit un mouvement de stock que pour le rebut et le retour fournisseur", () => {
+    expect(dispositionImpactsStock("SCRAP")).toBe(true);
+    expect(dispositionImpactsStock("RETURN_SUPPLIER")).toBe(true);
+    for (const type of ["HOLD", "RELEASE", "USE_AS_IS", "REWORK", "SORT", "RECHECK"] as const) {
+      expect(dispositionImpactsStock(type)).toBe(false);
+    }
+  });
+
+  it("exige une dérogation pour l'acceptation en l'état", () => {
+    expect(dispositionRequiresDerogation("USE_AS_IS")).toBe(true);
+    expect(dispositionRequiresDerogation("RELEASE")).toBe(false);
+  });
+});
+
+/* ========================================================================== */
+/* Caractéristiques, tolérances et échantillonnage                            */
+/* ========================================================================== */
+
+describe("#228 tolérances : sémantique historique préservée", () => {
+  it("traite tolerance_min/max comme des écarts quand un nominal existe", () => {
+    expect(resolveCharacteristicBounds({ nominal: 20, tolerance_min: -0.05, tolerance_max: 0.05 })).toEqual({
+      min: 19.95,
+      max: 20.05,
+    });
+  });
+
+  it("traite tolerance_min/max comme des bornes absolues sans nominal", () => {
+    expect(resolveCharacteristicBounds({ nominal: null, tolerance_min: 10, tolerance_max: 12 })).toEqual({
+      min: 10,
+      max: 12,
+    });
+  });
+
+  it("supporte une borne unique", () => {
+    expect(resolveCharacteristicBounds({ nominal: 20, tolerance_min: null, tolerance_max: 0.1 })).toEqual({
+      min: null,
+      max: 20.1,
+    });
+    expect(resolveCharacteristicBounds({ nominal: null, tolerance_min: 5, tolerance_max: null })).toEqual({
+      min: 5,
+      max: null,
+    });
+  });
+});
+
+describe("#228 validation d'une caractéristique de plan", () => {
+  it("accepte une caractéristique numérique complète", () => {
+    expect(() => assertCharacteristicSpec(characteristic())).not.toThrow();
+  });
+
+  const invalid: Array<[string, Partial<QualityCharacteristicSpec>, string]> = [
+    ["clé vide", { key: "  " }, "QUALITY_CHARACTERISTIC_KEY_REQUIRED"],
+    ["position 0", { position: 0 }, "QUALITY_CHARACTERISTIC_POSITION_INVALID"],
+    ["position négative", { position: -3 }, "QUALITY_CHARACTERISTIC_POSITION_INVALID"],
+    ["position décimale", { position: 1.5 }, "QUALITY_CHARACTERISTIC_POSITION_INVALID"],
+    ["libellé vide", { label: "" }, "QUALITY_CHARACTERISTIC_LABEL_REQUIRED"],
+    ["nominal NaN", { nominal: Number.NaN }, "QUALITY_CHARACTERISTIC_NUMBER_INVALID"],
+    ["nominal Infinity", { nominal: Number.POSITIVE_INFINITY }, "QUALITY_CHARACTERISTIC_NUMBER_INVALID"],
+    ["tolérance -Infinity", { tolerance_min: Number.NEGATIVE_INFINITY }, "QUALITY_CHARACTERISTIC_NUMBER_INVALID"],
+    ["précision NaN", { precision: Number.NaN }, "QUALITY_CHARACTERISTIC_NUMBER_INVALID"],
+    [
+      "numérique sans tolérance",
+      { tolerance_min: null, tolerance_max: null },
+      "QUALITY_CHARACTERISTIC_TOLERANCE_REQUIRED",
+    ],
+    [
+      "tolérance inversée",
+      { nominal: null, tolerance_min: 12, tolerance_max: 10 },
+      "QUALITY_CHARACTERISTIC_TOLERANCE_RANGE",
+    ],
+    ["numérique sans unité", { unit: null }, "QUALITY_CHARACTERISTIC_UNIT_REQUIRED"],
+    ["numérique unité vide", { unit: "  " }, "QUALITY_CHARACTERISTIC_UNIT_REQUIRED"],
+    [
+      "booléen sans attendu",
+      { value_kind: "BOOLEAN", expected_boolean: null, unit: null, tolerance_min: null, tolerance_max: null },
+      "QUALITY_CHARACTERISTIC_EXPECTED_REQUIRED",
+    ],
+    [
+      "liste sans valeurs",
+      { value_kind: "ENUM", allowed_values: [], unit: null, tolerance_min: null, tolerance_max: null },
+      "QUALITY_CHARACTERISTIC_ENUM_REQUIRED",
+    ],
+    [
+      "liste avec doublons",
+      {
+        value_kind: "ENUM",
+        allowed_values: ["OK", "OK"],
+        unit: null,
+        tolerance_min: null,
+        tolerance_max: null,
+      },
+      "QUALITY_CHARACTERISTIC_ENUM_DUPLICATE",
+    ],
+    [
+      "texte avec instrument",
+      {
+        value_kind: "TEXT",
+        requires_instrument: true,
+        unit: null,
+        tolerance_min: null,
+        tolerance_max: null,
+      },
+      "QUALITY_CHARACTERISTIC_INSTRUMENT_UNSUPPORTED",
+    ],
+    [
+      "échantillonnage FIXED sans valeur",
+      { sampling: { rule: "FIXED", value: null, justification: null } },
+      "QUALITY_SAMPLING_FIXED_INVALID",
+    ],
+    [
+      "échantillonnage FIXED à 0",
+      { sampling: { rule: "FIXED", value: 0, justification: null } },
+      "QUALITY_SAMPLING_FIXED_INVALID",
+    ],
+    [
+      "échantillonnage FIXED décimal",
+      { sampling: { rule: "FIXED", value: 2.5, justification: null } },
+      "QUALITY_SAMPLING_FIXED_INVALID",
+    ],
+    [
+      "échantillonnage PERCENT à 0",
+      { sampling: { rule: "PERCENT", value: 0, justification: null } },
+      "QUALITY_SAMPLING_PERCENT_INVALID",
+    ],
+    [
+      "échantillonnage PERCENT > 100",
+      { sampling: { rule: "PERCENT", value: 120, justification: null } },
+      "QUALITY_SAMPLING_PERCENT_INVALID",
+    ],
+    [
+      "échantillonnage PERCENT NaN",
+      { sampling: { rule: "PERCENT", value: Number.NaN, justification: null } },
+      "QUALITY_SAMPLING_PERCENT_INVALID",
+    ],
+    [
+      "échantillonnage ALL avec valeur",
+      { sampling: { rule: "ALL", value: 5, justification: null } },
+      "QUALITY_SAMPLING_VALUE_UNEXPECTED",
+    ],
+    [
+      "échantillonnage LOT avec valeur",
+      { sampling: { rule: "LOT", value: 1, justification: null } },
+      "QUALITY_SAMPLING_VALUE_UNEXPECTED",
+    ],
+  ];
+
+  it.each(invalid)("refuse %s", (_label, override, code) => {
+    const err = httpErrorOf(() => assertCharacteristicSpec(characteristic(override)));
+    expect(err.status).toBe(422);
+    expect(err.code).toBe(code);
+  });
+});
+
+describe("#228 taille d'échantillon", () => {
+  it.each([
+    ["ALL", null, 100, 100],
+    ["ALL", null, 1, 1],
+    ["LOT", null, 100, 1],
+    ["FIRST_ARTICLE", null, 100, 1],
+    ["FIXED", 3, 100, 3],
+    ["FIXED", 300, 100, 100],
+    ["FIXED", 1, 1, 1],
+    ["PERCENT", 10, 100, 10],
+    ["PERCENT", 10, 95, 10],
+    ["PERCENT", 1, 10, 1],
+    ["PERCENT", 100, 7, 7],
+    ["PERCENT", 33, 10, 4],
+  ] as const)("calcule %s(%s) sur %d unités → %d", (rule, value, population, expected) => {
+    const spec = characteristic({ sampling: { rule, value, justification: null } });
+    expect(requiredSampleCount(spec, population)).toBe(expected);
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])(
+    "renvoie 0 pour une population invalide (%s)",
+    (population) => {
+      expect(requiredSampleCount(characteristic(), population)).toBe(0);
+    }
+  );
+
+  it("identifie les caractéristiques de niveau lot", () => {
+    expect(isLotLevelCharacteristic(characteristic({ sampling: { rule: "LOT", value: null, justification: null } }))).toBe(true);
+    expect(
+      isLotLevelCharacteristic(
+        characteristic({
+          characteristic_type: "DOCUMENTARY",
+          value_kind: "TEXT",
+          unit: null,
+          requires_instrument: false,
+        })
+      )
+    ).toBe(true);
+    expect(isLotLevelCharacteristic(characteristic())).toBe(false);
+  });
+
+  it("documente la sémantique de chaque déclencheur", () => {
+    expect(TRIGGER_SEMANTICS.RECEPTION).toBe("REQUIRES_EXECUTION");
+    expect(TRIGGER_SEMANTICS.FINAL).toBe("REQUIRES_EXECUTION");
+    expect(TRIGGER_SEMANTICS.LOT_RELEASE).toBe("REQUIRES_EXECUTION");
+    expect(TRIGGER_SEMANTICS.IN_PROCESS).toBe("CREATES_REQUIREMENT");
+    expect(TRIGGER_SEMANTICS.PERIODIC).toBe("CREATES_REQUIREMENT");
+  });
+});
+
+/* ========================================================================== */
+/* Évaluation des mesures                                                     */
+/* ========================================================================== */
+
+describe("#228 évaluation d'un échantillon", () => {
+  it.each([
+    [20, "OK", "OK"],
+    [19.95, "OK", "OK"],
+    [20.05, "OK", "OK"],
+    [19.949, "NOK", "OUT_OF_TOLERANCE"],
+    [20.051, "NOK", "OUT_OF_TOLERANCE"],
+    [-5, "NOK", "OUT_OF_TOLERANCE"],
+    [0, "NOK", "OUT_OF_TOLERANCE"],
+  ] as const)("évalue une mesure numérique %s → %s", (value, result, code) => {
+    const evaluation = evaluateSample(characteristic(), sample({ value_numeric: value }));
+    expect(evaluation.result).toBe(result);
+    expect(evaluation.code).toBe(code);
+  });
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY])(
+    "refuse une valeur non finie (%s)",
+    (value) => {
+      const evaluation = evaluateSample(characteristic(), sample({ value_numeric: value }));
+      expect(evaluation.result).toBe("NOK");
+      expect(evaluation.code).toBe("VALUE_NOT_FINITE");
+    }
+  );
+
+  it("met en attente une mesure absente", () => {
+    expect(evaluateSample(characteristic(), sample({ value_numeric: null })).code).toBe("PENDING_VALUE");
+  });
+
+  it("refuse une unité incohérente", () => {
+    const evaluation = evaluateSample(characteristic(), sample({ unit: "cm" }));
+    expect(evaluation.result).toBe("NOK");
+    expect(evaluation.code).toBe("UNIT_MISMATCH");
+  });
+
+  it("tolère une unité non renseignée côté saisie", () => {
+    expect(evaluateSample(characteristic(), sample({ unit: null })).result).toBe("OK");
+  });
+
+  it("évalue un booléen", () => {
+    const spec = characteristic({
+      value_kind: "BOOLEAN",
+      expected_boolean: true,
+      unit: null,
+      tolerance_min: null,
+      tolerance_max: null,
+      requires_instrument: false,
+    });
+    expect(evaluateSample(spec, sample({ value_boolean: true, value_numeric: null })).result).toBe("OK");
+    const nok = evaluateSample(spec, sample({ value_boolean: false, value_numeric: null }));
+    expect(nok.result).toBe("NOK");
+    expect(nok.code).toBe("BOOLEAN_MISMATCH");
+    expect(evaluateSample(spec, sample({ value_boolean: null, value_numeric: null })).code).toBe(
+      "PENDING_VALUE"
+    );
+  });
+
+  it("évalue une liste contrôlée", () => {
+    const spec = characteristic({
+      value_kind: "ENUM",
+      allowed_values: ["CONFORME", "RAYURE", "BAVURE"],
+      unit: null,
+      tolerance_min: null,
+      tolerance_max: null,
+      requires_instrument: false,
+    });
+    expect(evaluateSample(spec, sample({ value_text: "CONFORME", value_numeric: null })).result).toBe("OK");
+    expect(evaluateSample(spec, sample({ value_text: " RAYURE ", value_numeric: null })).result).toBe("OK");
+    const nok = evaluateSample(spec, sample({ value_text: "AUTRE", value_numeric: null }));
+    expect(nok.result).toBe("NOK");
+    expect(nok.code).toBe("ENUM_NOT_ALLOWED");
+    expect(evaluateSample(spec, sample({ value_text: "  ", value_numeric: null })).code).toBe(
+      "PENDING_VALUE"
+    );
+  });
+
+  it("exige une preuve sur une caractéristique textuelle critique", () => {
+    const spec = characteristic({
+      value_kind: "TEXT",
+      criticality: "CRITICAL",
+      unit: null,
+      tolerance_min: null,
+      tolerance_max: null,
+      requires_instrument: false,
+    });
+    const nok = evaluateSample(spec, sample({ value_text: "Certificat 3.1 reçu", value_numeric: null }));
+    expect(nok.result).toBe("NOK");
+    expect(nok.code).toBe("EVIDENCE_REQUIRED");
+    expect(
+      evaluateSample(spec, sample({ value_text: "Certificat 3.1 reçu", value_numeric: null, evidence_count: 1 }))
+        .result
+    ).toBe("OK");
+  });
+});
+
+describe("#228 calcul du verdict d'exécution", () => {
+  const spec = characteristic({ sampling: { rule: "FIXED", value: 2, justification: null } });
+
+  it("reste EN_ATTENTE tant que les échantillons obligatoires manquent", () => {
+    const out = computeExecutionVerdict({
+      characteristics: [spec],
+      samples: [sample({ sample_no: 1 })],
+      population: 10,
+    });
+    expect(out.verdict).toBe("EN_ATTENTE");
+    expect(out.missing[0]).toMatchObject({ characteristic_key: "DIM-01", expected_samples: 2, recorded_samples: 1 });
+  });
+
+  it("est CONFORME quand tous les échantillons sont bons", () => {
+    const out = computeExecutionVerdict({
+      characteristics: [spec],
+      samples: [sample({ sample_no: 1 }), sample({ sample_no: 2 })],
+      population: 10,
+    });
+    expect(out.verdict).toBe("CONFORME");
+    expect(out.ok_count).toBe(2);
+    expect(out.nok_count).toBe(0);
+  });
+
+  it("est NON_CONFORME quand tous les échantillons sont mauvais", () => {
+    const out = computeExecutionVerdict({
+      characteristics: [spec],
+      samples: [
+        sample({ sample_no: 1, value_numeric: 25 }),
+        sample({ sample_no: 2, value_numeric: 26 }),
+      ],
+      population: 10,
+    });
+    expect(out.verdict).toBe("NON_CONFORME");
+  });
+
+  it("est PARTIEL quand le résultat est mixte", () => {
+    const out = computeExecutionVerdict({
+      characteristics: [spec],
+      samples: [sample({ sample_no: 1 }), sample({ sample_no: 2, value_numeric: 25 })],
+      population: 10,
+    });
+    expect(out.verdict).toBe("PARTIEL");
+    expect(out.blocking).toHaveLength(1);
+  });
+
+  it("disqualifie l'ensemble sur un échec documentaire de niveau lot", () => {
+    const documentary = characteristic({
+      key: "DOC-01",
+      position: 2,
+      characteristic_type: "DOCUMENTARY",
+      value_kind: "ENUM",
+      allowed_values: ["RECU"],
+      unit: null,
+      tolerance_min: null,
+      tolerance_max: null,
+      requires_instrument: false,
+      sampling: { rule: "LOT", value: null, justification: null },
+    });
+    const out = computeExecutionVerdict({
+      characteristics: [spec, documentary],
+      samples: [
+        sample({ sample_no: 1 }),
+        sample({ sample_no: 2 }),
+        sample({ characteristic_key: "DOC-01", sample_no: 1, value_numeric: null, value_text: "ABSENT" }),
+      ],
+      population: 10,
+    });
+    expect(out.verdict).toBe("NON_CONFORME");
+  });
+
+  it("ignore l'incomplétude d'une caractéristique non obligatoire", () => {
+    const optional = characteristic({ key: "OPT-01", position: 2, mandatory: false });
+    const out = computeExecutionVerdict({
+      characteristics: [spec, optional],
+      samples: [sample({ sample_no: 1 }), sample({ sample_no: 2 })],
+      population: 10,
+    });
+    expect(out.verdict).toBe("CONFORME");
+    expect(out.missing.some((m) => m.characteristic_key === "OPT-01")).toBe(true);
+  });
+
+  it("refuse un échantillon dupliqué", () => {
+    const err = httpErrorOf(() =>
+      computeExecutionVerdict({
+        characteristics: [spec],
+        samples: [sample({ sample_no: 1 }), sample({ sample_no: 1, value_numeric: 25 })],
+        population: 10,
+      })
+    );
+    expect(err.status).toBe(422);
+    expect(err.code).toBe("QUALITY_SAMPLE_DUPLICATE");
+  });
+
+  it("reste EN_ATTENTE sans aucune caractéristique évaluée", () => {
+    expect(
+      computeExecutionVerdict({ characteristics: [], samples: [], population: 10 }).verdict
+    ).toBe("EN_ATTENTE");
+  });
+});
+
+/* ========================================================================== */
+/* Applicabilité des plans                                                    */
+/* ========================================================================== */
+
+describe("#228 sélection du plan applicable", () => {
+  const context = {
+    article_id: "art-1",
+    piece_technique_id: "piece-1",
+    piece_version_id: "ver-1",
+    famille_id: "fam-1",
+    operation_code: "10",
+    fournisseur_id: null,
+    trigger: "FINAL" as const,
+  };
+
+  it("classe la spécificité du plus général au plus précis", () => {
+    expect(planScopeSpecificity(scope({ famille_id: "fam-1" }))).toBeLessThan(
+      planScopeSpecificity(scope({ article_id: "art-1" }))
+    );
+    expect(planScopeSpecificity(scope({ article_id: "art-1" }))).toBeLessThan(
+      planScopeSpecificity(scope({ piece_technique_id: "piece-1" }))
+    );
+    expect(planScopeSpecificity(scope({ piece_technique_id: "piece-1" }))).toBeLessThan(
+      planScopeSpecificity(scope({ piece_version_id: "ver-1" }))
+    );
+  });
+
+  it("retient le plan le plus spécifique", () => {
+    const selection = selectApplicablePlan(
+      [
+        plan({ id: "general", scope: scope({ famille_id: "fam-1" }) }),
+        plan({ id: "precis", scope: scope({ piece_version_id: "ver-1" }) }),
+      ],
+      context,
+      NOW
+    );
+    expect(selection.plan.id).toBe("precis");
+    expect(selection.discarded).toEqual(
+      expect.arrayContaining([{ id: "general", reason: "LESS_SPECIFIC" }])
+    );
+  });
+
+  it("refuse deux plans publiés de même spécificité", () => {
+    const err = httpErrorOf(() =>
+      selectApplicablePlan(
+        [
+          plan({ id: "a", code: "PC-A", scope: scope({ piece_technique_id: "piece-1" }) }),
+          plan({ id: "b", code: "PC-B", scope: scope({ piece_technique_id: "piece-1" }) }),
+        ],
+        context,
+        NOW
+      )
+    );
+    expect(err.status).toBe(409);
+    expect(err.code).toBe("QUALITY_PLAN_AMBIGUOUS");
+    expect(err.details.candidates).toHaveLength(2);
+  });
+
+  it("écarte les brouillons et les archives", () => {
+    const err = httpErrorOf(() =>
+      selectApplicablePlan(
+        [
+          plan({ id: "draft", status: "DRAFT" }),
+          plan({ id: "archived", status: "ARCHIVED" }),
+          plan({ id: "review", status: "IN_REVIEW" }),
+        ],
+        context,
+        NOW
+      )
+    );
+    expect(err.code).toBe("QUALITY_PLAN_NOT_APPLICABLE");
+    expect(err.details.discarded).toEqual(
+      expect.arrayContaining([
+        { id: "draft", reason: "STATUS" },
+        { id: "archived", reason: "STATUS" },
+        { id: "review", reason: "STATUS" },
+      ])
+    );
+  });
+
+  it("écarte un plan hors période d'effet", () => {
+    const err = httpErrorOf(() =>
+      selectApplicablePlan(
+        [
+          plan({
+            id: "expired",
+            scope: scope({ piece_technique_id: "piece-1", effective_to: "2026-01-01T00:00:00.000Z" }),
+          }),
+          plan({
+            id: "future",
+            scope: scope({ piece_technique_id: "piece-1", effective_from: "2027-01-01T00:00:00.000Z" }),
+          }),
+        ],
+        context,
+        NOW
+      )
+    );
+    expect(err.details.discarded).toEqual(
+      expect.arrayContaining([
+        { id: "expired", reason: "PERIOD" },
+        { id: "future", reason: "PERIOD" },
+      ])
+    );
+  });
+
+  it("écarte un plan d'un autre déclencheur ou d'un autre périmètre", () => {
+    const err = httpErrorOf(() =>
+      selectApplicablePlan(
+        [
+          plan({ id: "other-trigger", scope: scope({ piece_technique_id: "piece-1", trigger: "RECEPTION" }) }),
+          plan({ id: "other-piece", scope: scope({ piece_technique_id: "piece-2" }) }),
+          plan({ id: "other-supplier", scope: scope({ piece_technique_id: "piece-1", fournisseur_id: "f-9" }) }),
+        ],
+        context,
+        NOW
+      )
+    );
+    expect(err.details.discarded).toEqual(
+      expect.arrayContaining([
+        { id: "other-trigger", reason: "SCOPE" },
+        { id: "other-piece", reason: "SCOPE" },
+        { id: "other-supplier", reason: "SCOPE" },
+      ])
+    );
+  });
+
+  it("n'applique jamais un plan sans axe produit", () => {
+    const err = httpErrorOf(() =>
+      selectApplicablePlan([plan({ id: "wildcard", scope: scope({ operation_code: "10" }) })], context, NOW)
+    );
+    expect(err.code).toBe("QUALITY_PLAN_NOT_APPLICABLE");
+  });
+
+  it("refuse une publication qui recouvre un plan publié identique", () => {
+    const candidate = plan({ id: "new", code: "PC-NEW", version: 2 });
+    const err = httpErrorOf(() =>
+      assertNoApplicabilityOverlap({ candidate, published: [plan({ id: "old", code: "PC-OLD" })] })
+    );
+    expect(err.status).toBe(409);
+    expect(err.code).toBe("QUALITY_PLAN_APPLICABILITY_OVERLAP");
+  });
+
+  it("autorise une publication dont la période ne recouvre pas l'existant", () => {
+    const candidate = plan({
+      id: "new",
+      scope: scope({ piece_technique_id: "piece-1", effective_from: "2027-01-01T00:00:00.000Z" }),
+    });
+    expect(() =>
+      assertNoApplicabilityOverlap({
+        candidate,
+        published: [
+          plan({
+            id: "old",
+            scope: scope({ piece_technique_id: "piece-1", effective_to: "2026-12-31T00:00:00.000Z" }),
+          }),
+        ],
+      })
+    ).not.toThrow();
+  });
+
+  it("autorise une publication sur un périmètre différent", () => {
+    expect(() =>
+      assertNoApplicabilityOverlap({
+        candidate: plan({ id: "new", scope: scope({ piece_technique_id: "piece-9" }) }),
+        published: [plan({ id: "old", scope: scope({ piece_technique_id: "piece-1" }) })],
+      })
+    ).not.toThrow();
+  });
+});
+
+/* ========================================================================== */
+/* Snapshot                                                                   */
+/* ========================================================================== */
+
+describe("#228 snapshot canonique du plan", () => {
+  const sources = {
+    plan: {
+      id: "plan-1",
+      code: "PC-2026-0001",
+      version: 3,
+      label: "Contrôle final bride",
+      trigger: "FINAL" as const,
+      scope: scope({ piece_version_id: "ver-1" }),
+      published_at: "2026-07-01T08:00:00.000Z",
+    },
+    characteristics: [
+      characteristic({ key: "DIM-02", position: 2 }),
+      characteristic({ key: "DIM-01", position: 1 }),
+    ],
+    article: { id: "art-1", code: "ART-001", designation: "Bride" },
+    piece: { id: "piece-1", code: "PT-001", designation: "Bride usinée", version: "C" },
+    population: 10,
+    sampling_algorithm: "cerp.sampling.v1",
+    required_documents: [{ id: "doc-1", label: "Plan de définition", revision: "C" }],
+  };
+
+  it("fige un contenu ordonné et une empreinte de 64 hexadécimaux", () => {
+    const snapshot = buildPlanSnapshot(sources);
+    expect(snapshot.sha256).toMatch(/^[a-f0-9]{64}$/);
+    const keys = characteristicsFromSnapshot(snapshot.payload).map((c) => c.key);
+    expect(keys).toEqual(["DIM-01", "DIM-02"]);
+  });
+
+  it("mémorise le nombre d'échantillons exigé au moment du figeage", () => {
+    const snapshot = buildPlanSnapshot(sources);
+    const first = characteristicsFromSnapshot(snapshot.payload)[0] as unknown as {
+      required_samples: number;
+    };
+    expect(first.required_samples).toBe(3);
+  });
+
+  it("produit la même empreinte quel que soit l'ordre d'entrée", () => {
+    const reversed = { ...sources, characteristics: [...sources.characteristics].reverse() };
+    expect(buildPlanSnapshot(sources).sha256).toBe(buildPlanSnapshot(reversed).sha256);
+  });
+
+  it("change d'empreinte dès qu'une tolérance change", () => {
+    const modified = {
+      ...sources,
+      characteristics: [characteristic({ key: "DIM-01", position: 1, tolerance_max: 0.2 })],
+    };
+    expect(buildPlanSnapshot(modified).sha256).not.toBe(buildPlanSnapshot(sources).sha256);
+  });
+
+  it("détecte une altération du snapshot", () => {
+    const snapshot = buildPlanSnapshot(sources);
+    expect(() => assertSnapshotIntegrity(snapshot.payload, snapshot.sha256)).not.toThrow();
+
+    const tampered = JSON.parse(JSON.stringify(snapshot.payload)) as Record<string, unknown>;
+    (tampered.characteristics as Array<{ tolerance_max: number }>)[0].tolerance_max = 9;
+    const err = httpErrorOf(() => assertSnapshotIntegrity(tampered, snapshot.sha256));
+    expect(err.status).toBe(409);
+    expect(err.code).toBe("QUALITY_SNAPSHOT_TAMPERED");
+    expect(err.details.expected_sha256).toBe(snapshot.sha256);
+  });
+
+  it("renvoie une liste vide pour un snapshot malformé", () => {
+    expect(characteristicsFromSnapshot(null)).toEqual([]);
+    expect(characteristicsFromSnapshot("nope")).toEqual([]);
+    expect(characteristicsFromSnapshot({})).toEqual([]);
+    expect(characteristicsFromSnapshot({ characteristics: "nope" })).toEqual([]);
+  });
+});
+
+/* ========================================================================== */
+/* Source typée et registre de quantités                                      */
+/* ========================================================================== */
+
+describe("#228 source typée obligatoire", () => {
+  it("accepte une source valide", () => {
+    expect(assertSourceRef({ source_type: "LOT", source_id: " lot-1 " })).toEqual({
+      source_type: "LOT",
+      source_id: "lot-1",
+    });
+  });
+
+  it.each([
+    [null, "QUALITY_SOURCE_TYPE_REQUIRED"],
+    [undefined, "QUALITY_SOURCE_TYPE_REQUIRED"],
+    [{}, "QUALITY_SOURCE_TYPE_REQUIRED"],
+    [{ source_id: "lot-1" }, "QUALITY_SOURCE_TYPE_REQUIRED"],
+    [{ source_type: "INVENTED", source_id: "x" }, "QUALITY_SOURCE_TYPE_REQUIRED"],
+    [{ source_type: "LOT" }, "QUALITY_SOURCE_ID_REQUIRED"],
+    [{ source_type: "LOT", source_id: "   " }, "QUALITY_SOURCE_ID_REQUIRED"],
+  ] as const)("refuse une source invalide (%o)", (input, code) => {
+    const err = httpErrorOf(() => assertSourceRef(input as never));
+    expect(err.status).toBe(422);
+    expect(err.code).toBe(code);
+  });
+});
+
+describe("#228 registre de quantités", () => {
+  it("accepte un registre cohérent", () => {
+    expect(() => assertQuantityLedger(ledger({ released: 40, held: 60 }))).not.toThrow();
+  });
+
+  const invalid: Array<[string, Partial<QuantityLedger>, string]> = [
+    ["population nulle", { population: 0 }, "QUALITY_POPULATION_REQUIRED"],
+    ["population négative", { population: -10 }, "QUALITY_QUANTITY_INVALID"],
+    ["population NaN", { population: Number.NaN }, "QUALITY_QUANTITY_INVALID"],
+    ["contrôlé négatif", { controlled: -1 }, "QUALITY_QUANTITY_INVALID"],
+    ["libéré Infinity", { released: Number.POSITIVE_INFINITY }, "QUALITY_QUANTITY_INVALID"],
+    ["contrôlé > population", { controlled: 120 }, "QUALITY_CONTROLLED_EXCEEDS_POPULATION"],
+    ["conforme > contrôlé", { controlled: 50, conforming: 60 }, "QUALITY_CONFORMING_EXCEEDS_CONTROLLED"],
+    ["libéré > conforme", { conforming: 10, released: 20 }, "QUALITY_RELEASED_EXCEEDS_CONFORMING"],
+    [
+      "cumul dispositions > population",
+      { released: 60, held: 30, scrapped: 30 },
+      "QUALITY_DISPOSITIONS_EXCEED_POPULATION",
+    ],
+    ["consommé > libéré", { released: 10, consumed: 20 }, "QUALITY_CONSUMED_EXCEEDS_RELEASED"],
+  ];
+
+  it.each(invalid)("refuse %s", (_label, override, code) => {
+    const err = httpErrorOf(() => assertQuantityLedger(ledger(override)));
+    expect(err.status).toBe(422);
+    expect(err.code).toBe(code);
+  });
+
+  it("calcule le reste non disposé et la quantité libérable", () => {
+    const current = ledger({ released: 30, held: 20, scrapped: 10 });
+    expect(remainingUndisposedQty(current)).toBe(40);
+    expect(releasableQty(current)).toBe(40);
+    expect(releasableQty(ledger({ conforming: 35, released: 30 }))).toBe(5);
+    expect(releasableQty(ledger({ conforming: 30, released: 30 }))).toBe(0);
+  });
+});
+
+/* ========================================================================== */
+/* Libération                                                                 */
+/* ========================================================================== */
+
+describe("#228 décision de libération", () => {
+  const base = {
+    decision: "PARTIAL" as const,
+    qty: 40,
+    unit: "pce",
+    ledger: ledger({ conforming: 60 }),
+    verdict: "PARTIEL" as const,
+    hasDerogation: false,
+    evidenceCount: 1,
+  };
+
+  it("libère partiellement et laisse le reste bloqué", () => {
+    const out = evaluateReleaseRequest(base);
+    expect(out.qty_released).toBe(40);
+    expect(out.ledger.released).toBe(40);
+    expect(out.qty_held).toBe(60);
+  });
+
+  it("libère la totalité quand le verdict est conforme", () => {
+    const out = evaluateReleaseRequest({
+      ...base,
+      decision: "FULL",
+      qty: 100,
+      verdict: "CONFORME",
+      ledger: ledger(),
+    });
+    expect(out.qty_released).toBe(100);
+  });
+
+  it("met en quarantaine le solde restant", () => {
+    const out = evaluateReleaseRequest({ ...base, decision: "HOLD", qty: 25, verdict: "PARTIEL" });
+    expect(out.qty_held).toBe(25);
+    expect(out.ledger.held).toBe(25);
+    expect(out.qty_released).toBe(0);
+  });
+
+  it("refuse toute décision sur un verdict incomplet", () => {
+    const err = httpErrorOf(() => evaluateReleaseRequest({ ...base, verdict: "EN_ATTENTE" }));
+    expect(err.code).toBe("QUALITY_VERDICT_INCOMPLETE");
+  });
+
+  it("refuse la libération d'un non conforme sans dérogation", () => {
+    const err = httpErrorOf(() =>
+      evaluateReleaseRequest({ ...base, verdict: "NON_CONFORME", hasDerogation: false })
+    );
+    expect(err.code).toBe("QUALITY_RELEASE_REQUIRES_DEROGATION");
+  });
+
+  it("autorise la libération d'un non conforme couvert par une dérogation", () => {
+    const out = evaluateReleaseRequest({
+      ...base,
+      verdict: "NON_CONFORME",
+      hasDerogation: true,
+      decision: "PARTIAL",
+      qty: 10,
+    });
+    expect(out.qty_released).toBe(10);
+  });
+
+  it("interdit une libération totale sur verdict partiel", () => {
+    const err = httpErrorOf(() =>
+      evaluateReleaseRequest({ ...base, decision: "FULL", qty: 60, verdict: "PARTIEL" })
+    );
+    expect(err.code).toBe("QUALITY_RELEASE_PARTIAL_ONLY");
+  });
+
+  it.each([
+    [{ qty: 0 }, "QUALITY_RELEASE_QTY_REQUIRED"],
+    [{ qty: -5 }, "QUALITY_RELEASE_QTY_REQUIRED"],
+    [{ qty: Number.NaN }, "QUALITY_RELEASE_QTY_INVALID"],
+    [{ qty: Number.POSITIVE_INFINITY }, "QUALITY_RELEASE_QTY_INVALID"],
+    [{ unit: null }, "QUALITY_RELEASE_UNIT_REQUIRED"],
+    [{ unit: "  " }, "QUALITY_RELEASE_UNIT_REQUIRED"],
+    [{ qty: 500 }, "QUALITY_RELEASE_QTY_EXCEEDS_ALLOWED"],
+  ] as const)("refuse une demande malformée (%o)", (override, code) => {
+    const err = httpErrorOf(() => evaluateReleaseRequest({ ...base, ...override }));
+    expect(err.status).toBe(422);
+    expect(err.code).toBe(code);
+  });
+
+  it("refuse une libération totale partielle en quantité", () => {
+    const err = httpErrorOf(() =>
+      evaluateReleaseRequest({ ...base, decision: "FULL", qty: 10, verdict: "CONFORME", ledger: ledger() })
+    );
+    expect(err.code).toBe("QUALITY_RELEASE_FULL_MISMATCH");
+  });
+
+  it("refuse une mise en quarantaine sans solde disponible", () => {
+    const err = httpErrorOf(() =>
+      evaluateReleaseRequest({
+        ...base,
+        decision: "HOLD",
+        qty: 5,
+        ledger: ledger({ released: 100 }),
+      })
+    );
+    expect(err.code).toBe("QUALITY_NOTHING_TO_HOLD");
+  });
+
+  it("laisse le registre inchangé sur un refus", () => {
+    const out = evaluateReleaseRequest({ ...base, decision: "REJECT", qty: 10 });
+    expect(out.ledger).toEqual(base.ledger);
+    expect(out.qty_released).toBe(0);
+  });
+
+  it("propage l'invalidité du registre", () => {
+    const err = httpErrorOf(() =>
+      evaluateReleaseRequest({ ...base, ledger: ledger({ conforming: 10, released: 20 }) })
+    );
+    expect(err.code).toBe("QUALITY_RELEASED_EXCEEDS_CONFORMING");
+  });
+});
+
+/* ========================================================================== */
+/* Instruments                                                                */
+/* ========================================================================== */
+
+describe("#228 instrument réellement utilisé", () => {
+  const policy = { block_on_overdue_critical: true };
+
+  it("n'exige rien quand la caractéristique ne demande pas d'instrument", () => {
+    const out = evaluateInstrumentUsage({
+      characteristic: { key: "VIS-01", requires_instrument: false, instrument_category: null },
+      instrument: null,
+      at: NOW,
+      policy,
+    });
+    expect(out.allowed).toBe(true);
+    expect(out.code).toBe("OK");
+  });
+
+  it("exige l'instrument quand la caractéristique le demande", () => {
+    const out = evaluateInstrumentUsage({
+      characteristic: characteristic(),
+      instrument: null,
+      at: NOW,
+      policy,
+    });
+    expect(out.allowed).toBe(false);
+    expect(out.code).toBe("INSTRUMENT_REQUIRED");
+  });
+
+  it("accepte un instrument valide", () => {
+    const out = evaluateInstrumentUsage({
+      characteristic: characteristic(),
+      instrument: instrument(),
+      at: NOW,
+      policy,
+    });
+    expect(out.allowed).toBe(true);
+    expect(out.severity).toBe("OK");
+  });
+
+  it.each([
+    [{ deleted: true }, "INSTRUMENT_DELETED"],
+    [{ statut: "HORS_SERVICE" }, "INSTRUMENT_INACTIVE"],
+    [{ statut: null }, "INSTRUMENT_INACTIVE"],
+    [{ categorie: "PIED_A_COULISSE" }, "INSTRUMENT_OUT_OF_SCOPE"],
+    [{ categorie: null }, "INSTRUMENT_OUT_OF_SCOPE"],
+  ] as const)("bloque un instrument inutilisable (%o)", (override, code) => {
+    const out = evaluateInstrumentUsage({
+      characteristic: characteristic(),
+      instrument: instrument(override),
+      at: NOW,
+      policy,
+    });
+    expect(out.allowed).toBe(false);
+    expect(out.severity).toBe("BLOCKING");
+    expect(out.code).toBe(code);
+  });
+
+  it("bloque un instrument critique en retard quand le réglage est actif", () => {
+    const out = evaluateInstrumentUsage({
+      characteristic: characteristic(),
+      instrument: instrument({ next_due_date: "2026-01-01" }),
+      at: NOW,
+      policy,
+    });
+    expect(out.allowed).toBe(false);
+    expect(out.code).toBe("INSTRUMENT_OVERDUE_CRITICAL");
+  });
+
+  it("n'applique le blocage qu'à l'instrument concerné quand le réglage est inactif", () => {
+    const out = evaluateInstrumentUsage({
+      characteristic: characteristic(),
+      instrument: instrument({ next_due_date: "2026-01-01" }),
+      at: NOW,
+      policy: { block_on_overdue_critical: false },
+    });
+    expect(out.allowed).toBe(true);
+    expect(out.severity).toBe("WARNING");
+  });
+
+  it("avertit sans bloquer pour un instrument non critique en retard", () => {
+    const out = evaluateInstrumentUsage({
+      characteristic: characteristic(),
+      instrument: instrument({ criticite: "NORMAL", next_due_date: "2026-01-01" }),
+      at: NOW,
+      policy,
+    });
+    expect(out.allowed).toBe(true);
+    expect(out.code).toBe("INSTRUMENT_OVERDUE");
+  });
+
+  it.each([
+    [null, false],
+    ["", false],
+    ["not-a-date", false],
+    ["2026-12-31", false],
+    ["2026-01-01", true],
+  ] as const)("évalue l'échéance %s → en retard=%s", (dueDate, expected) => {
+    expect(isInstrumentOverdue(instrument({ next_due_date: dueDate }), NOW)).toBe(expected);
+  });
+});
+
+/* ========================================================================== */
+/* Dérogations : usage                                                        */
+/* ========================================================================== */
+
+describe("#228 usage d'une concession", () => {
+  const context = {
+    article_id: null,
+    piece_technique_id: null,
+    piece_version_id: null,
+    lot_id: "lot-1",
+    of_id: null,
+    commande_id: null,
+    bon_livraison_id: null,
+    unit: "pce",
+  };
+
+  it("autorise une concession approuvée dans son périmètre", () => {
+    const out = evaluateDerogationUsage({ derogation: derogation(), context, qty: 10, at: NOW });
+    expect(out.allowed).toBe(true);
+    expect(out.remaining_qty).toBe(50);
+  });
+
+  it.each([
+    [{ status: "DRAFT" }, "DEROGATION_NOT_APPROVED"],
+    [{ status: "SUBMITTED" }, "DEROGATION_NOT_APPROVED"],
+    [{ status: "REJECTED" }, "DEROGATION_NOT_APPROVED"],
+    [{ status: "" }, "DEROGATION_NOT_APPROVED"],
+    [{ status: "REVOKED" }, "DEROGATION_REVOKED"],
+    [{ status: "EXPIRED" }, "DEROGATION_EXPIRED"],
+    [{ valid_to: "2026-07-01T00:00:00.000Z" }, "DEROGATION_EXPIRED"],
+    [{ valid_from: "2026-08-01T00:00:00.000Z" }, "DEROGATION_NOT_YET_VALID"],
+    [{ lot_id: "lot-9" }, "DEROGATION_OUT_OF_SCOPE"],
+    [{ lot_id: null }, "DEROGATION_OUT_OF_SCOPE"],
+    [{ piece_version_id: "ver-9" }, "DEROGATION_OUT_OF_SCOPE"],
+    [{ unit: "kg" }, "DEROGATION_UNIT_MISMATCH"],
+    [{ max_qty: 50, consumed_qty: 45 }, "DEROGATION_QTY_EXCEEDED"],
+    [{ max_qty: 50, consumed_qty: 50 }, "DEROGATION_QTY_EXCEEDED"],
+  ] as const)("refuse un usage invalide (%o)", (override, code) => {
+    const out = evaluateDerogationUsage({
+      derogation: derogation(override),
+      context,
+      qty: 10,
+      at: NOW,
+    });
+    expect(out.allowed).toBe(false);
+    expect(out.code).toBe(code);
+  });
+
+  it.each([0, -1, Number.NaN, Number.POSITIVE_INFINITY])("refuse une quantité invalide (%s)", (qty) => {
+    const out = evaluateDerogationUsage({ derogation: derogation(), context, qty, at: NOW });
+    expect(out.allowed).toBe(false);
+    expect(out.code).toBe("DEROGATION_QTY_EXCEEDED");
+  });
+
+  it("accepte une concession sans plafond", () => {
+    const out = evaluateDerogationUsage({
+      derogation: derogation({ max_qty: null, unit: null }),
+      context,
+      qty: 999,
+      at: NOW,
+    });
+    expect(out.allowed).toBe(true);
+    expect(out.remaining_qty).toBeNull();
+  });
+
+  it("bascule en CONSUMED quand le plafond est atteint", () => {
+    expect(derogationStatusAfterConsumption({ max_qty: 50, consumed_qty: 50 })).toBe("CONSUMED");
+    expect(derogationStatusAfterConsumption({ max_qty: 50, consumed_qty: 49 })).toBe("APPROVED");
+    expect(derogationStatusAfterConsumption({ max_qty: null, consumed_qty: 999 })).toBe("APPROVED");
+  });
+
+  it("réévalue le périmètre à chaque usage, y compris après consommation partielle", () => {
+    const partiallyConsumed = derogation({ status: "APPROVED", consumed_qty: 45 });
+    expect(evaluateDerogationUsage({ derogation: partiallyConsumed, context, qty: 5, at: NOW }).allowed).toBe(
+      true
+    );
+    expect(evaluateDerogationUsage({ derogation: partiallyConsumed, context, qty: 6, at: NOW }).code).toBe(
+      "DEROGATION_QTY_EXCEEDED"
+    );
+  });
+});
+
+/* ========================================================================== */
+/* Moteur d'éligibilité                                                       */
+/* ========================================================================== */
+
+describe("#228 éligibilité ciblée réservation / expédition / facturation", () => {
+  it.each(["RESERVE", "SHIP", "INVOICE"] as const)("autorise un lot libéré pour %s", (purpose) => {
+    const verdict = evaluateQualityEligibility(target(), purpose, NOW);
+    expect(verdict.allowed).toBe(true);
+    expect(verdict.qty_allowed).toBe(10);
+    expect(verdict.blocks).toEqual([]);
+  });
+
+  it.each([
+    [{ lot_status: "BLOQUE" as const }, "LOT_NOT_RELEASED"],
+    [{ lot_status: "QUARANTAINE" as const }, "LOT_QUARANTINE"],
+    [{ lot_status: "EN_ATTENTE" as const }, "LOT_QUARANTINE"],
+    [{ pending_mandatory_controls: 2 }, "MANDATORY_CONTROL_PENDING"],
+    [{ open_nc_without_disposition: 1 }, "OPEN_NON_CONFORMITY"],
+    [{ qty_requested: 200 }, "QTY_NOT_RELEASED"],
+    [{ qty_released: 0 }, "QTY_NOT_RELEASED"],
+    [{ qty_released: 10, qty_consumed: 10 }, "QTY_NOT_RELEASED"],
+    [
+      { derogation: { status: "EXPIRED", valid_to: null } },
+      "DEROGATION_EXPIRED",
+    ],
+    [
+      { derogation: { status: "APPROVED", valid_to: "2026-07-01T00:00:00.000Z" } },
+      "DEROGATION_EXPIRED",
+    ],
+    [{ derogation: { status: "REVOKED", valid_to: null } }, "DEROGATION_EXPIRED"],
+  ] as const)("bloque avec le code attendu (%o)", (override, code) => {
+    const verdict = evaluateQualityEligibility(target(override), "SHIP", NOW);
+    expect(verdict.allowed).toBe(false);
+    expect(verdict.blocks.map((b) => b.code)).toContain(code);
+  });
+
+  it("n'invente pas de blocage sur un objet voisin", () => {
+    const blocked = evaluateQualityEligibility(
+      target({ object_id: "lot-1", lot_status: "QUARANTAINE" }),
+      "SHIP",
+      NOW
+    );
+    const neighbour = evaluateQualityEligibility(target({ object_id: "lot-2" }), "SHIP", NOW);
+    expect(blocked.allowed).toBe(false);
+    expect(blocked.blocks.every((b) => b.object_id === "lot-1")).toBe(true);
+    expect(neighbour.allowed).toBe(true);
+  });
+
+  it("explique la cause et l'action attendue", () => {
+    const verdict = evaluateQualityEligibility(target({ lot_status: "QUARANTAINE" }), "SHIP", NOW);
+    expect(verdict.blocks[0]?.message).toContain("quarantaine");
+    expect(verdict.blocks[0]?.expected_action).toBeTruthy();
+    expect(verdict.blocks[0]?.object_type).toBe("LOT");
+  });
+
+  it("adapte le message de quantité au but poursuivi", () => {
+    const invoice = evaluateQualityEligibility(target({ qty_requested: 200 }), "INVOICE", NOW);
+    expect(invoice.blocks[0]?.expected_action).toContain("Facturer uniquement");
+    const ship = evaluateQualityEligibility(target({ qty_requested: 200 }), "SHIP", NOW);
+    expect(ship.blocks[0]?.expected_action).toContain("Libérer");
+  });
+
+  it("plafonne la quantité autorisée à la quantité libérée disponible", () => {
+    const verdict = evaluateQualityEligibility(
+      target({ qty_requested: 200, qty_released: 80, qty_consumed: 30 }),
+      "SHIP",
+      NOW
+    );
+    expect(verdict.allowed).toBe(false);
+    expect(verdict.qty_allowed).toBe(50);
+  });
+
+  it("neutralise une quantité demandée non finie", () => {
+    const verdict = evaluateQualityEligibility(
+      target({ qty_requested: Number.NaN }),
+      "RESERVE",
+      NOW
+    );
+    expect(verdict.allowed).toBe(true);
+    expect(verdict.qty_allowed).toBe(0);
+  });
+
+  it("cumule plusieurs causes de blocage", () => {
+    const verdict = evaluateQualityEligibility(
+      target({
+        lot_status: "BLOQUE",
+        open_nc_without_disposition: 2,
+        pending_mandatory_controls: 1,
+        qty_requested: 999,
+      }),
+      "SHIP",
+      NOW
+    );
+    expect(verdict.blocks.map((b) => b.code).sort()).toEqual([
+      "LOT_NOT_RELEASED",
+      "MANDATORY_CONTROL_PENDING",
+      "OPEN_NON_CONFORMITY",
+      "QTY_NOT_RELEASED",
+    ]);
+    expect(verdict.qty_allowed).toBe(0);
+  });
+
+  it("lève un 409 métier détaillé via assertQualityEligibility", () => {
+    expect(() => assertQualityEligibility(target(), "SHIP", NOW)).not.toThrow();
+    const err = httpErrorOf(() =>
+      assertQualityEligibility(target({ lot_status: "BLOQUE" }), "SHIP", NOW)
+    );
+    expect(err.status).toBe(409);
+    expect(err.code).toBe("QUALITY_NOT_ELIGIBLE");
+    expect(err.details.purpose).toBe("SHIP");
+    expect(err.details.blocks).toHaveLength(1);
+  });
+
+  it("traite un lot sans statut qualité comme libéré (compatibilité stock)", () => {
+    expect(evaluateQualityEligibility(target({ lot_status: null }), "RESERVE", NOW).allowed).toBe(true);
+  });
+});

--- a/src/__tests__/qualite-360-228.migration-guards.test.ts
+++ b/src/__tests__/qualite-360-228.migration-guards.test.ts
@@ -1,0 +1,178 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const patch = readFileSync(resolve(root, "db/patches/20260725_qualite_360_228.sql"), "utf8");
+const preflight = readFileSync(
+  resolve(root, "db/patches/support/20260725_qualite_360_228.preflight.sql"),
+  "utf8"
+);
+const verify = readFileSync(
+  resolve(root, "db/patches/support/20260725_qualite_360_228.verify.sql"),
+  "utf8"
+);
+const rollback = readFileSync(
+  resolve(root, "db/patches/support/20260725_qualite_360_228.rollback.sql"),
+  "utf8"
+);
+
+describe("#228 migration guards", () => {
+  it("keeps the forward patch transactional, additive and inactive", () => {
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("COMMIT;");
+    expect(patch).not.toMatch(/\bDROP\s+TABLE\b/i);
+    expect(patch).not.toMatch(/\bDROP\s+COLUMN\b/i);
+    expect(patch).not.toMatch(/\bDELETE\s+FROM\b/i);
+    expect(patch).not.toMatch(/\bTRUNCATE\b/i);
+    // The patch never creates a plan, a derogation, a release or a disposition.
+    expect(patch).not.toMatch(/\bINSERT\s+INTO\s+public\.quality_control_plan\b/i);
+    expect(patch).not.toMatch(/\bINSERT\s+INTO\s+public\.quality_derogation\b/i);
+    expect(patch).not.toMatch(/\bINSERT\s+INTO\s+public\.quality_release_decision\b/i);
+    expect(patch).not.toMatch(/\bINSERT\s+INTO\s+public\.non_conformity\b/i);
+    // It never touches lot statuses or stock movements.
+    expect(patch).not.toMatch(/\bUPDATE\s+public\.lots\b/i);
+    expect(patch).not.toMatch(/\bINSERT\s+INTO\s+public\.stock_movements\b/i);
+    // It never seeds or flips a setting.
+    expect(patch).not.toMatch(/\bINSERT\s+INTO\s+public\.erp_settings\b/i);
+  });
+
+  it("refuses to run without the Qualité baseline", () => {
+    expect(patch).toContain("#228 requires the Qualité baseline");
+    expect(patch).toContain("#228 requires public.non_conformity");
+  });
+
+  it("creates the versioned plan referential", () => {
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.quality_control_plan");
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.quality_control_plan_characteristic");
+    expect(patch).toContain("quality_control_plan_code_version_228_uq UNIQUE (code, version)");
+    expect(patch).toContain("quality_control_plan_status_228_ck");
+    expect(patch).toContain("quality_control_plan_scope_228_ck");
+    expect(patch).toContain("quality_plan_char_key_228_uq UNIQUE (plan_id, characteristic_key)");
+    expect(patch).toContain("DEFERRABLE INITIALLY DEFERRED");
+  });
+
+  it("stores the applied snapshot with its SHA-256 fingerprint", () => {
+    expect(patch).toContain("ADD COLUMN IF NOT EXISTS plan_snapshot jsonb");
+    expect(patch).toContain("ADD COLUMN IF NOT EXISTS plan_snapshot_sha256 text");
+    expect(patch).toContain("quality_control_snapshot_hash_228_ck");
+    expect(patch).toContain("'^[a-f0-9]{64}$'");
+    expect(patch).toContain("the applied quality plan snapshot is immutable");
+  });
+
+  it("enforces the quantity ledger in the database", () => {
+    expect(patch).toContain("quality_control_qty_nonneg_228_ck");
+    expect(patch).toContain("quality_control_qty_ledger_228_ck");
+    expect(patch).toContain("VALIDATE CONSTRAINT quality_control_qty_nonneg_228_ck");
+    expect(patch).toContain("VALIDATE CONSTRAINT quality_control_qty_ledger_228_ck");
+    expect(patch).toContain("qty_conforming <= qty_controlled");
+    expect(patch).toContain("qty_released <= qty_conforming");
+    expect(patch).toContain("qty_consumed <= qty_released");
+  });
+
+  it("keeps published plans, measurements and evidence immutable", () => {
+    expect(patch).toContain("a published quality control plan is immutable");
+    expect(patch).toContain("characteristics of a published quality control plan are immutable");
+    expect(patch).toContain(
+      "a measurement of a validated quality control requires an audited revision"
+    );
+    expect(patch).toContain("quality audit evidence is immutable (append-only)");
+    expect(patch).toContain("trg_quality_event_log_append_only_228");
+    expect(patch).toContain("trg_quality_release_decision_append_only_228");
+    expect(patch).toContain("trg_quality_derogation_consumption_append_only_228");
+    expect(patch).toContain("trg_quality_command_receipts_append_only_228");
+  });
+
+  it("guards derogations: separation of duties, immutability and quantity cap", () => {
+    expect(patch).toContain("quality_derogation_separation_228_ck");
+    expect(patch).toContain("approved_by IS NULL OR approved_by <> requested_by");
+    expect(patch).toContain("an approved or closed derogation is immutable");
+    expect(patch).toContain("derogation consumption cannot decrease");
+    expect(patch).toContain("derogation consumptions exceed the approved maximum quantity");
+    expect(patch).toContain("a derogation must be approved before being consumed");
+    expect(patch).toContain(
+      "quality_derogation_consumption_release_228_uq UNIQUE (derogation_id, release_decision_id)"
+    );
+  });
+
+  it("protects quality documents from hard deletion and hash rewriting", () => {
+    expect(patch).toContain("quality documents are removed logically (removed_at), never deleted");
+    expect(patch).toContain("a decision evidence document cannot be removed");
+    expect(patch).toContain("quality document identity (hash, storage) is immutable");
+  });
+
+  it("extends historical enums additively instead of duplicating them", () => {
+    for (const value of ["DRAFT", "DISPOSITION", "VERIFICATION", "CANCELLED"]) {
+      expect(patch).toContain(`ALTER TYPE public.quality_nc_status ADD VALUE IF NOT EXISTS '${value}'`);
+    }
+    for (const value of ["PLAN", "DEROGATION", "RELEASE"]) {
+      expect(patch).toContain(`ALTER TYPE public.quality_entity_type ADD VALUE IF NOT EXISTS '${value}'`);
+    }
+    expect(patch).not.toMatch(/\bDROP\s+TYPE\b/i);
+    // New enum values must not be consumed inside the same transaction.
+    expect(patch).not.toMatch(/quality_nc_status\s*=\s*'DISPOSITION'/i);
+    expect(patch).not.toMatch(/status\s*=\s*'VERIFICATION'::public\.quality_nc_status/i);
+  });
+
+  it("keeps the historical disposition list and only adds RECHECK", () => {
+    expect(patch).toContain("'HOLD', 'RELEASE', 'USE_AS_IS', 'REWORK', 'SORT', 'SCRAP', 'RETURN_SUPPLIER', 'RECHECK'");
+    expect(patch).toContain("VALIDATE CONSTRAINT non_conformity_dispositions_type_check");
+  });
+
+  it("adds idempotency receipts and correlation on the audit journal", () => {
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.quality_command_receipts");
+    expect(patch).toContain(
+      "quality_command_receipts_actor_key_228_uq UNIQUE (actor_user_id, idempotency_key)"
+    );
+    expect(patch).toContain("char_length(idempotency_key) BETWEEN 8 AND 200");
+    expect(patch).toContain("ADD COLUMN IF NOT EXISTS correlation_id uuid NULL");
+    expect(patch).toContain("non_conformity_dispositions_idem_228_uq");
+  });
+
+  it("adds the 5 Why / 8D structure bounded and governed", () => {
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.non_conformity_analysis");
+    expect(patch).toContain("method IN ('FIVE_WHY', 'EIGHT_D')");
+    expect(patch).toContain("char_length(answer) <= 4000");
+    expect(patch).toContain("non_conformity_analysis_step_228_uq");
+  });
+
+  it("links measurements to the instrument actually used", () => {
+    expect(patch).toContain("ADD COLUMN IF NOT EXISTS instrument_id uuid");
+    expect(patch).toContain("ADD COLUMN IF NOT EXISTS instrument_snapshot jsonb");
+    expect(patch).toContain("quality_control_points_instrument_228_fkey");
+    expect(patch).toContain("quality_control_points_sample_228_uq");
+  });
+
+  it("restricts every support script to cerp_test", () => {
+    for (const script of [preflight, verify, rollback]) {
+      expect(script).toContain("current_database() <> 'cerp_test'");
+      expect(script).toContain("\\set ON_ERROR_STOP on");
+    }
+  });
+
+  it("keeps preflight and verify read-only", () => {
+    for (const script of [preflight, verify]) {
+      expect(script).not.toMatch(/\bINSERT\s+INTO\b/i);
+      expect(script).not.toMatch(/\bUPDATE\s+public\./i);
+      expect(script).not.toMatch(/\bDELETE\s+FROM\b/i);
+      expect(script).not.toMatch(/\bALTER\s+TABLE\b/i);
+      expect(script).not.toMatch(/\bDROP\s+/i);
+    }
+  });
+
+  it("refuses to roll back over recorded quality decisions", () => {
+    expect(rollback).toContain("release decision(s) recorded");
+    expect(rollback).toContain("derogation consumption(s) recorded");
+    expect(rollback).toContain("measurement revision(s) recorded");
+    expect(rollback).toContain("already carry a plan snapshot");
+    expect(rollback).toContain("use an extended status");
+    expect(rollback).toContain("use the new columns");
+    expect(rollback).toContain("PostgreSQL cannot remove a value from an enum type");
+  });
+
+  it("declares itself in the patch inventory conventions", () => {
+    expect(patch.startsWith("-- 20260725_qualite_360_228.sql")).toBe(true);
+    expect(patch).toContain("Issue #228");
+  });
+});

--- a/src/__tests__/qualite-360-228.routes.test.ts
+++ b/src/__tests__/qualite-360-228.routes.test.ts
@@ -1,0 +1,470 @@
+// #228 — Qualité industrielle 360.
+// Tests d'orchestration HTTP (pg mocké, mêmes conventions que
+// production-of-170.routes.test.ts) : RBAC par capacité, refus par défaut,
+// validation Zod mappée par champ, 401/403/404/422, absence de `storage_path`.
+
+import request from "supertest";
+import { EventEmitter } from "events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = {
+    on: emitter.on.bind(emitter),
+    query: mocks.poolQuery,
+    connect: mocks.poolConnect,
+  };
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; role: string }; headers?: Record<string, string | string[] | undefined> },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void
+  ) => {
+    // `x-test-anonymous` simule une requête non authentifiée.
+    if (req.headers?.["x-test-anonymous"] === "1") {
+      res.status(401).json({ success: false, code: "UNAUTHORIZED" });
+      return;
+    }
+    const requestedRole = req.headers?.["x-test-role"];
+    req.user = {
+      id: 1,
+      role: typeof requestedRole === "string" ? requestedRole : "Administrateur Systeme et Reseau",
+    };
+    next();
+  },
+  authorizeRole:
+    () =>
+    (_req: unknown, _res: unknown, next: () => void) => {
+      next();
+    },
+}));
+
+import app from "../config/app";
+
+const BASE = "/api/v1/qualite/v2";
+const PLAN_ID = "11111111-1111-1111-1111-111111111111";
+const CONTROL_ID = "22222222-2222-2222-2222-222222222222";
+const DEROGATION_ID = "33333333-3333-3333-3333-333333333333";
+const NC_ID = "44444444-4444-4444-4444-444444444444";
+const LOT_ID = "55555555-5555-5555-5555-555555555555";
+const PIECE_ID = "66666666-6666-6666-6666-666666666666";
+
+beforeEach(() => {
+  mocks.poolQuery.mockReset();
+  mocks.clientQuery.mockReset();
+  mocks.clientRelease.mockReset();
+  mocks.poolConnect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease });
+});
+
+function validPlanBody() {
+  return {
+    label: "Contrôle final bride",
+    trigger_type: "FINAL",
+    piece_technique_id: PIECE_ID,
+    sampling: { rule: "FIXED", value: 3, justification: "Plan client" },
+    characteristics: [
+      {
+        characteristic_key: "DIM-01",
+        position: 1,
+        label: "Diamètre",
+        characteristic_type: "DIMENSIONAL",
+        value_kind: "NUMERIC",
+        unit: "mm",
+        nominal: 20,
+        tolerance_min: -0.05,
+        tolerance_max: 0.05,
+        criticality: "MAJOR",
+        sampling: { rule: "FIXED", value: 3, justification: null },
+        trigger: "FINAL",
+      },
+    ],
+  };
+}
+
+/* ========================================================================== */
+/* Authentification                                                           */
+/* ========================================================================== */
+
+describe("#228 authentification", () => {
+  it.each([
+    ["get", "/center"],
+    ["get", "/plans"],
+    ["get", "/executions"],
+    ["get", "/derogations"],
+  ] as const)("renvoie 401 sans authentification (%s %s)", async (method, path) => {
+    const res = await request(app)[method](`${BASE}${path}`).set("x-test-anonymous", "1");
+    expect(res.status).toBe(401);
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+  });
+});
+
+/* ========================================================================== */
+/* RBAC : refus par défaut                                                    */
+/* ========================================================================== */
+
+describe("#228 RBAC par capacité", () => {
+  const forbiddenReads: Array<[string, string]> = [
+    ["get", "/center"],
+    ["get", "/plans"],
+    ["get", `/plans/${PLAN_ID}`],
+    ["get", "/executions"],
+    ["get", `/executions/${CONTROL_ID}`],
+    ["get", "/derogations"],
+    ["get", `/derogations/${DEROGATION_ID}`],
+  ];
+
+  it.each(forbiddenReads)("refuse la lecture qualité à un rôle non habilité (%s %s)", async (method, path) => {
+    const res = await request(app)
+      [method as "get"](`${BASE}${path}`)
+      .set("x-test-role", "Comptabilite");
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("QUALITY_CAPABILITY_REQUIRED");
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+  });
+
+  it("laisse l'atelier lire la qualité", async () => {
+    mocks.poolQuery.mockResolvedValue({ rows: [{ total: 0 }], rowCount: 1 });
+    const res = await request(app).get(`${BASE}/plans`).set("x-test-role", "Chef d'atelier");
+    expect(res.status).not.toBe(403);
+  });
+
+  it("refuse à l'atelier la publication d'un plan", async () => {
+    const res = await request(app)
+      .post(`${BASE}/plans/${PLAN_ID}/transitions`)
+      .set("x-test-role", "Chef d'atelier")
+      .send({ target_status: "PUBLISHED", expected_updated_at: "2026-07-25T10:00:00.000Z" });
+    expect(res.status).toBe(403);
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
+  it("refuse à l'atelier la décision de libération", async () => {
+    const res = await request(app)
+      .post(`${BASE}/executions/${CONTROL_ID}/decision`)
+      .set("x-test-role", "Operateur Atelier")
+      .send({});
+    expect(res.status).toBe(403);
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
+  it("refuse à l'atelier la création d'un plan", async () => {
+    const res = await request(app)
+      .post(`${BASE}/plans`)
+      .set("x-test-role", "Operateur Atelier")
+      .send(validPlanBody());
+    expect(res.status).toBe(403);
+  });
+
+  it("autorise l'atelier à saisir une mesure", async () => {
+    mocks.clientQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    const res = await request(app)
+      .post(`${BASE}/executions/${CONTROL_ID}/measurements`)
+      .set("x-test-role", "Chef d'atelier")
+      .send({});
+    // La capacité passe : c'est la validation Zod qui refuse un corps vide.
+    expect(res.status).toBe(422);
+  });
+
+  it("exige la capacité d'approbation pour approuver une dérogation", async () => {
+    const res = await request(app)
+      .post(`${BASE}/derogations/${DEROGATION_ID}/transitions`)
+      .set("x-test-role", "Responsable Methodes")
+      .send({ target_status: "APPROVED", expected_updated_at: "2026-07-25T10:00:00.000Z" });
+    expect(res.status).toBe(403);
+  });
+
+  it("laisse les méthodes soumettre une dérogation", async () => {
+    mocks.clientQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    const res = await request(app)
+      .post(`${BASE}/derogations/${DEROGATION_ID}/transitions`)
+      .set("x-test-role", "Responsable Methodes")
+      .send({ target_status: "SUBMITTED", expected_updated_at: "2026-07-25T10:00:00.000Z" });
+    expect(res.status).not.toBe(403);
+  });
+});
+
+/* ========================================================================== */
+/* Validation                                                                 */
+/* ========================================================================== */
+
+describe("#228 validation Zod stricte et mappée par champ", () => {
+  const role = "Responsable Qualite";
+
+  it("refuse un plan sans axe produit", async () => {
+    const body = validPlanBody();
+    delete (body as Record<string, unknown>).piece_technique_id;
+    const res = await request(app).post(`${BASE}/plans`).set("x-test-role", role).send(body);
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("QUALITY_VALIDATION_ERROR");
+    expect(Object.keys(res.body.details.fields).length).toBeGreaterThan(0);
+  });
+
+  it("refuse un champ inconnu (schéma strict)", async () => {
+    const res = await request(app)
+      .post(`${BASE}/plans`)
+      .set("x-test-role", role)
+      .send({ ...validPlanBody(), injected: "x" });
+    expect(res.status).toBe(422);
+  });
+
+  it("refuse un plan sans caractéristique", async () => {
+    const res = await request(app)
+      .post(`${BASE}/plans`)
+      .set("x-test-role", role)
+      .send({ ...validPlanBody(), characteristics: [] });
+    expect(res.status).toBe(422);
+  });
+
+  it.each([
+    ["quantité négative", { population: -5 }],
+    ["quantité nulle", { population: 0 }],
+    ["source inconnue", { source_type: "INVENTED" }],
+    ["source vide", { source_id: "" }],
+    ["unité vide", { unite: "" }],
+    ["déclencheur inconnu", { trigger: "MAGIC" }],
+  ])("refuse un aperçu d'exécution invalide (%s)", async (_label, override) => {
+    const res = await request(app)
+      .post(`${BASE}/executions/preview`)
+      .set("x-test-role", role)
+      .send({
+        source_type: "LOT",
+        source_id: LOT_ID,
+        trigger: "FINAL",
+        population: 10,
+        unite: "pce",
+        piece_technique_id: PIECE_ID,
+        ...override,
+      });
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("QUALITY_VALIDATION_ERROR");
+  });
+
+  it("refuse une décision sans empreinte d'aperçu", async () => {
+    const res = await request(app)
+      .post(`${BASE}/executions/${CONTROL_ID}/decision`)
+      .set("x-test-role", role)
+      .send({
+        expected_updated_at: "2026-07-25T10:00:00.000Z",
+        decision: "FULL",
+        qty: 10,
+        unite: "pce",
+        object_type: "LOT",
+        object_id: LOT_ID,
+      });
+    expect(res.status).toBe(422);
+    expect(res.body.details.fields).toHaveProperty("preview_sha256");
+  });
+
+  it.each(["not-a-hash", "ABC", "a".repeat(63), "z".repeat(64)])(
+    "refuse une empreinte d'aperçu malformée (%s)",
+    async (hash) => {
+      const res = await request(app)
+        .post(`${BASE}/executions/${CONTROL_ID}/decision`)
+        .set("x-test-role", role)
+        .send({
+          expected_updated_at: "2026-07-25T10:00:00.000Z",
+          preview_sha256: hash,
+          decision: "FULL",
+          qty: 10,
+          unite: "pce",
+          object_type: "LOT",
+          object_id: LOT_ID,
+        });
+      expect(res.status).toBe(422);
+    }
+  );
+
+  it("refuse un identifiant de route non UUID", async () => {
+    const res = await request(app).get(`${BASE}/plans/not-a-uuid`).set("x-test-role", role);
+    expect(res.status).toBe(422);
+  });
+
+  it("refuse une dérogation sans périmètre", async () => {
+    const res = await request(app)
+      .post(`${BASE}/derogations`)
+      .set("x-test-role", role)
+      .send({
+        derogation_type: "CONCESSION",
+        requirement: "Cote 12H7",
+        deviation: "Écart de 0,03 mm au-dessus de la tolérance haute",
+      });
+    expect(res.status).toBe(422);
+  });
+
+  it("refuse une quantité maximale de dérogation sans unité", async () => {
+    const res = await request(app)
+      .post(`${BASE}/derogations`)
+      .set("x-test-role", role)
+      .send({
+        derogation_type: "CONCESSION",
+        lot_id: LOT_ID,
+        requirement: "Cote 12H7",
+        deviation: "Écart de 0,03 mm",
+        max_qty: 10,
+      });
+    expect(res.status).toBe(422);
+    expect(res.body.details.fields).toHaveProperty("unite");
+  });
+
+  it("refuse un refus de dérogation sans motif", async () => {
+    const res = await request(app)
+      .post(`${BASE}/derogations/${DEROGATION_ID}/transitions`)
+      .set("x-test-role", role)
+      .send({ target_status: "REJECTED", expected_updated_at: "2026-07-25T10:00:00.000Z" });
+    expect(res.status).toBe(422);
+    expect(res.body.details.fields).toHaveProperty("reason");
+  });
+
+  it("refuse une analyse 5 Why hors bornes", async () => {
+    const res = await request(app)
+      .put(`${BASE}/non-conformities/${NC_ID}/analysis`)
+      .set("x-test-role", role)
+      .send({
+        expected_updated_at: "2026-07-25T10:00:00.000Z",
+        method: "FIVE_WHY",
+        steps: [
+          { method: "FIVE_WHY", step_code: "WHY1", position: 99, question: "Pourquoi ?", answer: "Parce que" },
+        ],
+      });
+    expect(res.status).toBe(422);
+  });
+
+  it("borne la pagination des listes", async () => {
+    const res = await request(app).get(`${BASE}/plans?pageSize=5000`).set("x-test-role", role);
+    expect(res.status).toBe(422);
+  });
+
+  it.each(["RESERVE", "SHIP", "INVOICE"])("accepte le but d'éligibilité %s", async (purpose) => {
+    mocks.poolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    const res = await request(app)
+      .get(`${BASE}/eligibility?purpose=${purpose}&object_type=LOT&object_id=${LOT_ID}&qty=5`)
+      .set("x-test-role", role);
+    expect(res.status).not.toBe(422);
+  });
+
+  it("refuse un but d'éligibilité inconnu", async () => {
+    const res = await request(app)
+      .get(`${BASE}/eligibility?purpose=STEAL&object_type=LOT&object_id=${LOT_ID}&qty=5`)
+      .set("x-test-role", role);
+    expect(res.status).toBe(422);
+  });
+});
+
+/* ========================================================================== */
+/* 404 et DTO                                                                 */
+/* ========================================================================== */
+
+describe("#228 ressources absentes et DTO", () => {
+  const role = "Responsable Qualite";
+
+  it("renvoie 404 pour un plan inconnu", async () => {
+    mocks.poolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    const res = await request(app).get(`${BASE}/plans/${PLAN_ID}`).set("x-test-role", role);
+    expect(res.status).toBe(404);
+    expect(res.body.code).toBe("NOT_FOUND");
+  });
+
+  it("renvoie 404 pour un contrôle inconnu", async () => {
+    mocks.poolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    const res = await request(app).get(`${BASE}/executions/${CONTROL_ID}`).set("x-test-role", role);
+    expect(res.status).toBe(404);
+  });
+
+  it("renvoie 404 pour une dérogation inconnue", async () => {
+    mocks.poolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    const res = await request(app).get(`${BASE}/derogations/${DEROGATION_ID}`).set("x-test-role", role);
+    expect(res.status).toBe(404);
+  });
+
+  it("ne fait jamais fuiter storage_path ni chemin local dans un DTO qualité", async () => {
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (/COUNT\(\*\)/i.test(sql)) return Promise.resolve({ rows: [{ total: 1 }], rowCount: 1 });
+      return Promise.resolve({
+        rows: [
+          {
+            id: PLAN_ID,
+            code: "PC-2026-000001",
+            version: 1,
+            label: "Contrôle final",
+            status: "PUBLISHED",
+            trigger_type: "FINAL",
+            article_id: null,
+            piece_technique_id: PIECE_ID,
+            piece_version_id: null,
+            famille_id: null,
+            operation_code: null,
+            fournisseur_id: null,
+            sampling_rule: "ALL",
+            sampling_value: null,
+            sampling_justification: null,
+            owner_user_id: null,
+            revision_reason: null,
+            effective_from: null,
+            effective_to: null,
+            supersedes_plan_id: null,
+            published_at: "2026-07-01T00:00:00.000Z",
+            published_by: 2,
+            archived_at: null,
+            created_at: "2026-07-01T00:00:00.000Z",
+            updated_at: "2026-07-01T00:00:00.000Z",
+            created_by: 1,
+            updated_by: 1,
+            characteristic_count: 1,
+          },
+        ],
+        rowCount: 1,
+      });
+    });
+
+    const res = await request(app).get(`${BASE}/plans`).set("x-test-role", role);
+    expect(res.status).toBe(200);
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toMatch(/storage_path/i);
+    expect(serialized).not.toMatch(/stored_name/i);
+    expect(serialized).not.toMatch(/[A-Za-z]:\\\\/);
+    expect(serialized).not.toMatch(/\/var\/cerp/i);
+  });
+
+  it("n'expose ni SQL ni stack dans une erreur serveur", async () => {
+    mocks.poolQuery.mockRejectedValue(new Error('relation "public.quality_control_plan" does not exist'));
+    const res = await request(app).get(`${BASE}/plans`).set("x-test-role", role);
+    expect(res.status).toBe(500);
+    expect(JSON.stringify(res.body)).not.toMatch(/relation|does not exist|stack/i);
+    expect(res.body.code).toBe("INTERNAL_ERROR");
+  });
+});
+
+/* ========================================================================== */
+/* Le routeur historique reste intact                                         */
+/* ========================================================================== */
+
+describe("#228 compatibilité du routeur Qualité historique", () => {
+  it("conserve le garde global du routeur historique", async () => {
+    const res = await request(app).get("/api/v1/qualite/controls").set("x-test-role", "Comptabilite");
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("FORBIDDEN");
+  });
+
+  it("ne capture pas les routes historiques avec le préfixe v2", async () => {
+    mocks.poolQuery.mockResolvedValue({ rows: [{ total: 0 }], rowCount: 1 });
+    const res = await request(app).get("/api/v1/qualite/kpis").set("x-test-role", "Responsable Qualite");
+    expect(res.status).not.toBe(404);
+  });
+});

--- a/src/module/qualite/controllers/quality-360.controller.ts
+++ b/src/module/qualite/controllers/quality-360.controller.ts
@@ -1,0 +1,328 @@
+// Contrôleurs Qualité 360 (#228).
+//
+// Chaque handler : valide (Zod strict) → construit le contexte d'acteur →
+// délègue au service. Aucune règle métier ici, aucun `storage_path` renvoyé,
+// aucune décision prise côté client.
+
+import type { Request, RequestHandler } from "express";
+import { ZodError, type ZodTypeAny, type z } from "zod";
+
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { HttpError } from "../../../utils/httpError";
+import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+
+import type { QualityActor } from "../repository/quality-360.repository";
+import {
+  consumeDerogationSchema,
+  createDerogationSchema,
+  createExecutionSchema,
+  createPlanSchema,
+  decideExecutionSchema,
+  derogationTransitionSchema,
+  eligibilityQuerySchema,
+  executionPreviewSchema,
+  idParamSchema,
+  listDerogationsQuerySchema,
+  listExecutionsQuerySchema,
+  listPlansQuerySchema,
+  ncTransitionSchema,
+  planApplicabilityQuerySchema,
+  planTransitionSchema,
+  qualityCenterQuerySchema,
+  recordMeasurementsSchema,
+  revisePlanSchema,
+  updatePlanSchema,
+  upsertAnalysisSchema,
+} from "../validators/quality-360.validators";
+import {
+  svcConsumeDerogation,
+  svcCreateDerogation,
+  svcCreateExecution,
+  svcCreatePlan,
+  svcDecideExecution,
+  svcEvaluateEligibility,
+  svcGetDerogation,
+  svcGetExecution,
+  svcGetNcAnalysis,
+  svcGetPlan,
+  svcListDerogations,
+  svcListExecutions,
+  svcListPlans,
+  svcPlanApplicability,
+  svcPreviewExecution,
+  svcPreviewVerdict,
+  svcQualityCenter,
+  svcRecordMeasurements,
+  svcRevisePlan,
+  svcTransitionDerogation,
+  svcTransitionNc,
+  svcTransitionPlan,
+  svcUpdatePlan,
+  svcUpsertNcAnalysis,
+} from "../services/quality-360.service";
+
+/**
+ * Parse strict avec mapping par champ : le frontend peut recoller chaque
+ * message sur son input (ADR-0016) au lieu d'afficher une erreur générique.
+ * Sans ce garde, une ZodError remonterait en 500 via le gestionnaire global.
+ */
+function parseOrThrow<S extends ZodTypeAny>(schema: S, payload: unknown): z.infer<S> {
+  const parsed = schema.safeParse(payload);
+  if (parsed.success) return parsed.data;
+  const error: ZodError = parsed.error;
+  const fieldErrors: Record<string, string[]> = {};
+  for (const issue of error.issues) {
+    const path = issue.path.filter((segment) => segment !== "body" && segment !== "params").join(".") || "_";
+    (fieldErrors[path] ??= []).push(issue.message);
+  }
+  throw new HttpError(422, "QUALITY_VALIDATION_ERROR", "Champs invalides.", { fields: fieldErrors });
+}
+
+function buildActor(req: Request): QualityActor {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  const userAgent = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null;
+  const device = parseDevice(userAgent);
+  return {
+    user_id: user.id,
+    role: typeof user.role === "string" ? user.role : null,
+    ip: getClientIp(req),
+    user_agent: userAgent,
+    device_type: device.device_type,
+    os: device.os,
+    browser: device.browser,
+    path: req.originalUrl ?? null,
+    page_key: typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null,
+    client_session_id:
+      typeof req.headers["x-client-session-id"] === "string"
+        ? req.headers["x-client-session-id"]
+        : typeof req.headers["x-session-id"] === "string"
+          ? req.headers["x-session-id"]
+          : null,
+    request_id: typeof req.headers["x-request-id"] === "string" ? req.headers["x-request-id"] : null,
+  };
+}
+
+function idempotencyKey(req: Request): string | null {
+  const raw = req.headers["idempotency-key"];
+  return typeof raw === "string" ? raw : null;
+}
+
+function notFound(entity: string): never {
+  throw new HttpError(404, "NOT_FOUND", `${entity} introuvable.`);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Plans                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const listPlans: RequestHandler = asyncHandler(async (req, res) => {
+  const filters = parseOrThrow(listPlansQuerySchema, req.query);
+  const out = await svcListPlans(filters);
+  res.json({ items: out.items, total: out.total, page: filters.page, pageSize: filters.pageSize });
+});
+
+export const getPlan: RequestHandler = asyncHandler(async (req, res) => {
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  const out = await svcGetPlan(params.id);
+  if (!out) notFound("Plan de contrôle");
+  res.json(out);
+});
+
+export const createPlan: RequestHandler = asyncHandler(async (req, res) => {
+  const { body } = parseOrThrow(createPlanSchema, { body: req.body });
+  const out = await svcCreatePlan({
+    body,
+    actor: buildActor(req),
+    idempotencyKey: idempotencyKey(req),
+  });
+  res.status(201).json(out);
+});
+
+export const updatePlan: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(updatePlanSchema, { params: req.params, body: req.body });
+  const out = await svcUpdatePlan({ id: parsed.params.id, body: parsed.body, actor: buildActor(req) });
+  if (!out) notFound("Plan de contrôle");
+  res.json(out);
+});
+
+export const transitionPlan: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(planTransitionSchema, { params: req.params, body: req.body });
+  const out = await svcTransitionPlan({
+    id: parsed.params.id,
+    body: parsed.body,
+    actor: buildActor(req),
+  });
+  if (!out) notFound("Plan de contrôle");
+  res.json(out);
+});
+
+export const revisePlan: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(revisePlanSchema, { params: req.params, body: req.body });
+  const out = await svcRevisePlan({
+    id: parsed.params.id,
+    revisionReason: parsed.body.revision_reason,
+    actor: buildActor(req),
+  });
+  if (!out) notFound("Plan de contrôle");
+  res.status(201).json(out);
+});
+
+export const planApplicability: RequestHandler = asyncHandler(async (req, res) => {
+  const query = parseOrThrow(planApplicabilityQuerySchema, req.query);
+  res.json(await svcPlanApplicability(query));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Exécutions                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export const listExecutions: RequestHandler = asyncHandler(async (req, res) => {
+  const filters = parseOrThrow(listExecutionsQuerySchema, req.query);
+  const out = await svcListExecutions(filters);
+  res.json({ items: out.items, total: out.total, page: filters.page, pageSize: filters.pageSize });
+});
+
+export const getExecution: RequestHandler = asyncHandler(async (req, res) => {
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  const out = await svcGetExecution(params.id);
+  if (!out) notFound("Contrôle");
+  res.json(out);
+});
+
+export const previewExecution: RequestHandler = asyncHandler(async (req, res) => {
+  const { body } = parseOrThrow(executionPreviewSchema, { body: req.body });
+  res.json(await svcPreviewExecution(body));
+});
+
+export const createExecution: RequestHandler = asyncHandler(async (req, res) => {
+  const { body } = parseOrThrow(createExecutionSchema, { body: req.body });
+  const out = await svcCreateExecution({
+    body,
+    actor: buildActor(req),
+    idempotencyKey: idempotencyKey(req),
+  });
+  res.status(201).json(out);
+});
+
+export const recordMeasurements: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(recordMeasurementsSchema, { params: req.params, body: req.body });
+  const out = await svcRecordMeasurements({
+    id: parsed.params.id,
+    body: parsed.body,
+    actor: buildActor(req),
+  });
+  if (!out) notFound("Contrôle");
+  res.json(out);
+});
+
+export const previewVerdict: RequestHandler = asyncHandler(async (req, res) => {
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  const out = await svcPreviewVerdict(params.id);
+  if (!out) notFound("Contrôle");
+  res.json(out);
+});
+
+export const decideExecution: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(decideExecutionSchema, { params: req.params, body: req.body });
+  const out = await svcDecideExecution({
+    id: parsed.params.id,
+    body: parsed.body,
+    actor: buildActor(req),
+    idempotencyKey: idempotencyKey(req),
+  });
+  if (!out) notFound("Contrôle");
+  res.json(out);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Dérogations                                                                */
+/* -------------------------------------------------------------------------- */
+
+export const listDerogations: RequestHandler = asyncHandler(async (req, res) => {
+  const filters = parseOrThrow(listDerogationsQuerySchema, req.query);
+  const out = await svcListDerogations(filters);
+  res.json({ items: out.items, total: out.total, page: filters.page, pageSize: filters.pageSize });
+});
+
+export const getDerogation: RequestHandler = asyncHandler(async (req, res) => {
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  const out = await svcGetDerogation(params.id);
+  if (!out) notFound("Dérogation");
+  res.json(out);
+});
+
+export const createDerogation: RequestHandler = asyncHandler(async (req, res) => {
+  const { body } = parseOrThrow(createDerogationSchema, { body: req.body });
+  res.status(201).json(await svcCreateDerogation({ body, actor: buildActor(req) }));
+});
+
+export const transitionDerogation: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(derogationTransitionSchema, { params: req.params, body: req.body });
+  const out = await svcTransitionDerogation({
+    id: parsed.params.id,
+    body: parsed.body,
+    actor: buildActor(req),
+  });
+  if (!out) notFound("Dérogation");
+  res.json(out);
+});
+
+export const consumeDerogation: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(consumeDerogationSchema, { params: req.params, body: req.body });
+  const out = await svcConsumeDerogation({
+    id: parsed.params.id,
+    body: parsed.body,
+    actor: buildActor(req),
+    idempotencyKey: idempotencyKey(req),
+  });
+  if (!out) notFound("Dérogation");
+  res.status(201).json(out);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Non-conformités : analyse guidée et transitions                             */
+/* -------------------------------------------------------------------------- */
+
+export const getNcAnalysis: RequestHandler = asyncHandler(async (req, res) => {
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  res.json({ steps: await svcGetNcAnalysis(params.id) });
+});
+
+export const upsertNcAnalysis: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(upsertAnalysisSchema, { params: req.params, body: req.body });
+  const out = await svcUpsertNcAnalysis({
+    id: parsed.params.id,
+    body: parsed.body,
+    actor: buildActor(req),
+  });
+  if (!out) notFound("Non-conformité");
+  res.json(out);
+});
+
+export const transitionNc: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(ncTransitionSchema, { params: req.params, body: req.body });
+  const out = await svcTransitionNc({
+    id: parsed.params.id,
+    body: parsed.body,
+    actor: buildActor(req),
+  });
+  if (!out) notFound("Non-conformité");
+  res.json(out);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Éligibilité et centre Qualité                                              */
+/* -------------------------------------------------------------------------- */
+
+export const evaluateEligibility: RequestHandler = asyncHandler(async (req, res) => {
+  const query = parseOrThrow(eligibilityQuerySchema, req.query);
+  res.json(await svcEvaluateEligibility(query));
+});
+
+export const qualityCenter: RequestHandler = asyncHandler(async (req, res) => {
+  const query = parseOrThrow(qualityCenterQuerySchema, req.query);
+  res.json(await svcQualityCenter({ horizonDays: query.horizon_days }));
+});

--- a/src/module/qualite/domain/quality-plan.ts
+++ b/src/module/qualite/domain/quality-plan.ts
@@ -1,0 +1,682 @@
+// Plans de contrôle versionnés, applicabilité, échantillonnage, verdict et
+// snapshot canonique (#228). Pur : aucune I/O, aucune dépendance SQL.
+
+import { HttpError } from "../../../utils/httpError";
+import { qualitySha256, type QualityVerdict } from "./quality-policy";
+
+/* -------------------------------------------------------------------------- */
+/* 1) Référentiels gouvernés                                                  */
+/* -------------------------------------------------------------------------- */
+
+export const QUALITY_CHARACTERISTIC_TYPES = [
+  "DIMENSIONAL",
+  "VISUAL",
+  "DOCUMENTARY",
+  "MATERIAL",
+  "FUNCTIONAL",
+  "OTHER",
+] as const;
+export type QualityCharacteristicType = (typeof QUALITY_CHARACTERISTIC_TYPES)[number];
+
+export const QUALITY_VALUE_KINDS = ["NUMERIC", "BOOLEAN", "ENUM", "TEXT"] as const;
+export type QualityValueKind = (typeof QUALITY_VALUE_KINDS)[number];
+
+export const QUALITY_CRITICALITIES = ["CRITICAL", "MAJOR", "MINOR"] as const;
+export type QualityCriticality = (typeof QUALITY_CRITICALITIES)[number];
+
+export const QUALITY_TRIGGERS = [
+  "RECEPTION",
+  "FIRST_ARTICLE",
+  "IN_PROCESS",
+  "FINAL",
+  "LOT_RELEASE",
+  "PERIODIC",
+  "RECHECK",
+] as const;
+export type QualityTrigger = (typeof QUALITY_TRIGGERS)[number];
+
+// Quel déclencheur crée une exigence, lequel demande une exécution, lequel est
+// informatif : la règle est explicite et testée, pas implicite.
+export const TRIGGER_SEMANTICS: Readonly<
+  Record<QualityTrigger, "REQUIRES_EXECUTION" | "CREATES_REQUIREMENT" | "INFORMATIVE">
+> = {
+  RECEPTION: "REQUIRES_EXECUTION",
+  FIRST_ARTICLE: "REQUIRES_EXECUTION",
+  IN_PROCESS: "CREATES_REQUIREMENT",
+  FINAL: "REQUIRES_EXECUTION",
+  LOT_RELEASE: "REQUIRES_EXECUTION",
+  PERIODIC: "CREATES_REQUIREMENT",
+  RECHECK: "REQUIRES_EXECUTION",
+};
+
+export const QUALITY_SAMPLING_RULES = ["ALL", "FIXED", "PERCENT", "FIRST_ARTICLE", "LOT"] as const;
+export type QualitySamplingRule = (typeof QUALITY_SAMPLING_RULES)[number];
+
+export type QualitySampling = {
+  rule: QualitySamplingRule;
+  // FIXED → nombre d'unités ; PERCENT → pourcentage 0 < p ≤ 100 ; sinon null.
+  value: number | null;
+  justification: string | null;
+};
+
+/* -------------------------------------------------------------------------- */
+/* 2) Caractéristique de plan                                                 */
+/* -------------------------------------------------------------------------- */
+
+export type QualityCharacteristicSpec = {
+  key: string;
+  position: number;
+  label: string;
+  characteristic_type: QualityCharacteristicType;
+  value_kind: QualityValueKind;
+  unit: string | null;
+  // Sémantique conservée du module historique : quand `nominal` est présent,
+  // tolerance_min/max sont des ÉCARTS ; sinon ce sont des bornes absolues.
+  nominal: number | null;
+  tolerance_min: number | null;
+  tolerance_max: number | null;
+  precision: number | null;
+  expected_boolean: boolean | null;
+  allowed_values: readonly string[] | null;
+  criticality: QualityCriticality;
+  mandatory: boolean;
+  requires_instrument: boolean;
+  instrument_category: string | null;
+  method: string | null;
+  acceptance_rule: string | null;
+  sampling: QualitySampling;
+  trigger: QualityTrigger;
+};
+
+export function resolveCharacteristicBounds(spec: {
+  nominal: number | null;
+  tolerance_min: number | null;
+  tolerance_max: number | null;
+}): { min: number | null; max: number | null } {
+  const hasNominal = spec.nominal !== null && Number.isFinite(spec.nominal);
+  const hasTolerance = spec.tolerance_min !== null || spec.tolerance_max !== null;
+  if (hasNominal && hasTolerance) {
+    return {
+      min: spec.tolerance_min === null ? null : Number(spec.nominal) + Number(spec.tolerance_min),
+      max: spec.tolerance_max === null ? null : Number(spec.nominal) + Number(spec.tolerance_max),
+    };
+  }
+  return {
+    min: spec.tolerance_min === null ? null : Number(spec.tolerance_min),
+    max: spec.tolerance_max === null ? null : Number(spec.tolerance_max),
+  };
+}
+
+export function assertCharacteristicSpec(spec: QualityCharacteristicSpec): void {
+  const fail = (code: string, message: string, details?: unknown): never => {
+    throw new HttpError(422, code, message, details ?? { characteristic: spec.key });
+  };
+
+  if (!spec.key.trim()) fail("QUALITY_CHARACTERISTIC_KEY_REQUIRED", "Identifiant de caractéristique requis.");
+  if (!Number.isInteger(spec.position) || spec.position < 1) {
+    fail("QUALITY_CHARACTERISTIC_POSITION_INVALID", "La position doit être un entier ≥ 1.");
+  }
+  if (!spec.label.trim()) fail("QUALITY_CHARACTERISTIC_LABEL_REQUIRED", "Désignation requise.");
+
+  for (const numeric of [spec.nominal, spec.tolerance_min, spec.tolerance_max, spec.precision]) {
+    if (numeric !== null && !Number.isFinite(numeric)) {
+      fail("QUALITY_CHARACTERISTIC_NUMBER_INVALID", "Valeur numérique non finie interdite.");
+    }
+  }
+
+  if (spec.value_kind === "NUMERIC") {
+    const bounds = resolveCharacteristicBounds(spec);
+    if (bounds.min === null && bounds.max === null) {
+      fail(
+        "QUALITY_CHARACTERISTIC_TOLERANCE_REQUIRED",
+        "Une caractéristique numérique exige au moins une borne de tolérance."
+      );
+    }
+    if (bounds.min !== null && bounds.max !== null && bounds.min > bounds.max) {
+      fail("QUALITY_CHARACTERISTIC_TOLERANCE_RANGE", "Tolérance incohérente : min > max.");
+    }
+    if (!spec.unit || !spec.unit.trim()) {
+      fail("QUALITY_CHARACTERISTIC_UNIT_REQUIRED", "Une caractéristique numérique exige une unité.");
+    }
+  }
+
+  if (spec.value_kind === "BOOLEAN" && spec.expected_boolean === null) {
+    fail("QUALITY_CHARACTERISTIC_EXPECTED_REQUIRED", "Attendu booléen manquant.");
+  }
+
+  if (spec.value_kind === "ENUM") {
+    const values = (spec.allowed_values ?? []).map((v) => v.trim()).filter(Boolean);
+    if (values.length < 1) {
+      fail("QUALITY_CHARACTERISTIC_ENUM_REQUIRED", "Une caractéristique liste exige des valeurs autorisées.");
+    }
+    if (new Set(values).size !== values.length) {
+      fail("QUALITY_CHARACTERISTIC_ENUM_DUPLICATE", "Valeurs autorisées dupliquées.");
+    }
+  }
+
+  if (spec.requires_instrument && spec.value_kind === "TEXT") {
+    fail(
+      "QUALITY_CHARACTERISTIC_INSTRUMENT_UNSUPPORTED",
+      "Un moyen de contrôle ne s'associe pas à une caractéristique purement textuelle."
+    );
+  }
+
+  assertSampling(spec.sampling, spec.key);
+}
+
+export function assertSampling(sampling: QualitySampling, characteristicKey: string): void {
+  const fail = (code: string, message: string): never => {
+    throw new HttpError(422, code, message, { characteristic: characteristicKey });
+  };
+  if (sampling.rule === "FIXED") {
+    if (!Number.isInteger(sampling.value) || (sampling.value ?? 0) < 1) {
+      fail("QUALITY_SAMPLING_FIXED_INVALID", "Un échantillonnage FIXED exige un entier ≥ 1.");
+    }
+  } else if (sampling.rule === "PERCENT") {
+    const value = sampling.value ?? Number.NaN;
+    if (!Number.isFinite(value) || value <= 0 || value > 100) {
+      fail("QUALITY_SAMPLING_PERCENT_INVALID", "Un échantillonnage PERCENT exige 0 < p ≤ 100.");
+    }
+  } else if (sampling.value !== null) {
+    fail("QUALITY_SAMPLING_VALUE_UNEXPECTED", "Cette règle d'échantillonnage n'accepte pas de valeur.");
+  }
+}
+
+/**
+ * Taille d'échantillon exigée. Aucune norme d'échantillonnage statistique
+ * (ISO 2859, AQL…) n'est revendiquée ici : seules les règles explicitement
+ * validées avec la Qualité sont implémentées.
+ */
+export function requiredSampleCount(spec: QualityCharacteristicSpec, population: number): number {
+  if (!Number.isFinite(population) || population <= 0) return 0;
+  const pop = Math.floor(population);
+  switch (spec.sampling.rule) {
+    case "ALL":
+      return pop;
+    case "LOT":
+      return 1;
+    case "FIRST_ARTICLE":
+      return 1;
+    case "FIXED":
+      return Math.min(pop, Math.max(1, Math.floor(spec.sampling.value ?? 1)));
+    case "PERCENT":
+      return Math.min(pop, Math.max(1, Math.ceil((pop * (spec.sampling.value ?? 0)) / 100)));
+  }
+}
+
+// Une caractéristique documentaire ou évaluée au niveau du lot ne peut pas être
+// « partiellement » conforme : son échec disqualifie l'ensemble.
+export function isLotLevelCharacteristic(spec: QualityCharacteristicSpec): boolean {
+  return spec.sampling.rule === "LOT" || spec.characteristic_type === "DOCUMENTARY";
+}
+
+/* -------------------------------------------------------------------------- */
+/* 3) Évaluation d'une mesure                                                 */
+/* -------------------------------------------------------------------------- */
+
+export type QualitySampleValue = {
+  characteristic_key: string;
+  sample_no: number;
+  value_numeric: number | null;
+  value_boolean: boolean | null;
+  value_text: string | null;
+  unit: string | null;
+  evidence_count: number;
+};
+
+export type CharacteristicEvaluation = {
+  characteristic_key: string;
+  sample_no: number;
+  result: "OK" | "NOK" | "PENDING";
+  code:
+    | "OK"
+    | "PENDING_VALUE"
+    | "OUT_OF_TOLERANCE"
+    | "UNIT_MISMATCH"
+    | "VALUE_NOT_FINITE"
+    | "BOOLEAN_MISMATCH"
+    | "ENUM_NOT_ALLOWED"
+    | "TEXT_REQUIRED"
+    | "EVIDENCE_REQUIRED";
+};
+
+export function evaluateSample(
+  spec: QualityCharacteristicSpec,
+  sample: QualitySampleValue
+): CharacteristicEvaluation {
+  const base = { characteristic_key: spec.key, sample_no: sample.sample_no };
+
+  if (spec.value_kind === "NUMERIC") {
+    if (sample.value_numeric === null || sample.value_numeric === undefined) {
+      return { ...base, result: "PENDING", code: "PENDING_VALUE" };
+    }
+    if (!Number.isFinite(sample.value_numeric)) {
+      return { ...base, result: "NOK", code: "VALUE_NOT_FINITE" };
+    }
+    if (spec.unit && sample.unit && spec.unit.trim() !== sample.unit.trim()) {
+      return { ...base, result: "NOK", code: "UNIT_MISMATCH" };
+    }
+    const bounds = resolveCharacteristicBounds(spec);
+    if (bounds.min !== null && sample.value_numeric < bounds.min) {
+      return { ...base, result: "NOK", code: "OUT_OF_TOLERANCE" };
+    }
+    if (bounds.max !== null && sample.value_numeric > bounds.max) {
+      return { ...base, result: "NOK", code: "OUT_OF_TOLERANCE" };
+    }
+    return { ...base, result: "OK", code: "OK" };
+  }
+
+  if (spec.value_kind === "BOOLEAN") {
+    if (sample.value_boolean === null || sample.value_boolean === undefined) {
+      return { ...base, result: "PENDING", code: "PENDING_VALUE" };
+    }
+    if (spec.expected_boolean !== null && sample.value_boolean !== spec.expected_boolean) {
+      return { ...base, result: "NOK", code: "BOOLEAN_MISMATCH" };
+    }
+    return { ...base, result: "OK", code: "OK" };
+  }
+
+  if (spec.value_kind === "ENUM") {
+    const raw = (sample.value_text ?? "").trim();
+    if (!raw) return { ...base, result: "PENDING", code: "PENDING_VALUE" };
+    const allowed = (spec.allowed_values ?? []).map((v) => v.trim());
+    if (!allowed.includes(raw)) {
+      return { ...base, result: "NOK", code: "ENUM_NOT_ALLOWED" };
+    }
+    return { ...base, result: "OK", code: "OK" };
+  }
+
+  // TEXT : documentaire ou observation. La preuve jointe est exigée quand la
+  // caractéristique est critique.
+  const text = (sample.value_text ?? "").trim();
+  if (!text) return { ...base, result: "PENDING", code: "PENDING_VALUE" };
+  if (spec.criticality === "CRITICAL" && sample.evidence_count <= 0) {
+    return { ...base, result: "NOK", code: "EVIDENCE_REQUIRED" };
+  }
+  return { ...base, result: "OK", code: "OK" };
+}
+
+/* -------------------------------------------------------------------------- */
+/* 4) Verdict d'exécution                                                     */
+/* -------------------------------------------------------------------------- */
+
+export type VerdictComputation = {
+  verdict: QualityVerdict;
+  evaluations: CharacteristicEvaluation[];
+  missing: Array<{ characteristic_key: string; expected_samples: number; recorded_samples: number }>;
+  blocking: Array<{ characteristic_key: string; criticality: QualityCriticality; code: string }>;
+  ok_count: number;
+  nok_count: number;
+};
+
+export function computeExecutionVerdict(params: {
+  characteristics: readonly QualityCharacteristicSpec[];
+  samples: readonly QualitySampleValue[];
+  population: number;
+}): VerdictComputation {
+  const evaluations: CharacteristicEvaluation[] = [];
+  const missing: VerdictComputation["missing"] = [];
+  const blocking: VerdictComputation["blocking"] = [];
+
+  let okCount = 0;
+  let nokCount = 0;
+  let lotLevelFailure = false;
+  let mandatoryIncomplete = false;
+
+  for (const spec of params.characteristics) {
+    const expected = requiredSampleCount(spec, params.population);
+    const specSamples = params.samples.filter((s) => s.characteristic_key === spec.key);
+
+    const seen = new Set<number>();
+    for (const sample of specSamples) {
+      if (seen.has(sample.sample_no)) {
+        throw new HttpError(
+          422,
+          "QUALITY_SAMPLE_DUPLICATE",
+          `Échantillon dupliqué pour ${spec.key} (n° ${sample.sample_no}).`
+        );
+      }
+      seen.add(sample.sample_no);
+    }
+
+    const evaluated = specSamples.map((sample) => evaluateSample(spec, sample));
+    evaluations.push(...evaluated);
+
+    const decided = evaluated.filter((e) => e.result !== "PENDING");
+    if (decided.length < expected) {
+      missing.push({
+        characteristic_key: spec.key,
+        expected_samples: expected,
+        recorded_samples: decided.length,
+      });
+      if (spec.mandatory) mandatoryIncomplete = true;
+    }
+
+    for (const evaluation of evaluated) {
+      if (evaluation.result === "OK") okCount += 1;
+      if (evaluation.result === "NOK") {
+        nokCount += 1;
+        blocking.push({
+          characteristic_key: spec.key,
+          criticality: spec.criticality,
+          code: evaluation.code,
+        });
+        if (isLotLevelCharacteristic(spec)) lotLevelFailure = true;
+      }
+    }
+  }
+
+  let verdict: QualityVerdict;
+  if (mandatoryIncomplete) {
+    verdict = "EN_ATTENTE";
+  } else if (lotLevelFailure) {
+    verdict = "NON_CONFORME";
+  } else if (nokCount === 0 && okCount === 0) {
+    verdict = "EN_ATTENTE";
+  } else if (nokCount === 0) {
+    verdict = "CONFORME";
+  } else if (okCount === 0) {
+    verdict = "NON_CONFORME";
+  } else {
+    verdict = "PARTIEL";
+  }
+
+  return { verdict, evaluations, missing, blocking, ok_count: okCount, nok_count: nokCount };
+}
+
+/* -------------------------------------------------------------------------- */
+/* 5) Applicabilité d'un plan                                                 */
+/* -------------------------------------------------------------------------- */
+
+export type PlanApplicabilityScope = {
+  article_id: string | null;
+  piece_technique_id: string | null;
+  piece_version_id: string | null;
+  famille_id: string | null;
+  operation_code: string | null;
+  fournisseur_id: string | null;
+  trigger: QualityTrigger;
+  effective_from: string | null;
+  effective_to: string | null;
+};
+
+export type PlanCandidate = {
+  id: string;
+  code: string;
+  version: number;
+  status: "DRAFT" | "IN_REVIEW" | "PUBLISHED" | "ARCHIVED";
+  scope: PlanApplicabilityScope;
+};
+
+export type ApplicabilityContext = {
+  article_id: string | null;
+  piece_technique_id: string | null;
+  piece_version_id: string | null;
+  famille_id: string | null;
+  operation_code: string | null;
+  fournisseur_id: string | null;
+  trigger: QualityTrigger;
+};
+
+// Règle de priorité documentée : le périmètre le plus spécifique gagne.
+// version de pièce (8) > pièce technique (4) > article (2) > famille (1),
+// plus un bonus opération (16) et fournisseur (32) qui ne remplacent jamais
+// l'axe produit mais le précisent.
+const SPECIFICITY_WEIGHTS = {
+  piece_version_id: 8,
+  piece_technique_id: 4,
+  article_id: 2,
+  famille_id: 1,
+  operation_code: 16,
+  fournisseur_id: 32,
+} as const;
+
+export function planScopeSpecificity(scope: PlanApplicabilityScope): number {
+  let score = 0;
+  for (const [field, weight] of Object.entries(SPECIFICITY_WEIGHTS)) {
+    if (scope[field as keyof typeof SPECIFICITY_WEIGHTS]) score += weight;
+  }
+  return score;
+}
+
+function scopeMatchesContext(scope: PlanApplicabilityScope, context: ApplicabilityContext): boolean {
+  if (scope.trigger !== context.trigger) return false;
+  const axes: Array<keyof typeof SPECIFICITY_WEIGHTS> = [
+    "piece_version_id",
+    "piece_technique_id",
+    "article_id",
+    "famille_id",
+    "operation_code",
+    "fournisseur_id",
+  ];
+  for (const axis of axes) {
+    const expected = scope[axis];
+    if (!expected) continue; // périmètre ouvert sur cet axe
+    if (context[axis] !== expected) return false;
+  }
+  // Un plan sans aucun axe produit ne s'applique pas implicitement à tout.
+  return Boolean(
+    scope.piece_version_id || scope.piece_technique_id || scope.article_id || scope.famille_id
+  );
+}
+
+function isEffectiveAt(scope: PlanApplicabilityScope, at: Date): boolean {
+  if (scope.effective_from) {
+    const from = new Date(scope.effective_from);
+    if (!Number.isNaN(from.getTime()) && at < from) return false;
+  }
+  if (scope.effective_to) {
+    const to = new Date(scope.effective_to);
+    if (!Number.isNaN(to.getTime()) && at > to) return false;
+  }
+  return true;
+}
+
+export type PlanSelection = {
+  plan: PlanCandidate;
+  specificity: number;
+  discarded: Array<{ id: string; reason: "SCOPE" | "STATUS" | "PERIOD" | "LESS_SPECIFIC" }>;
+};
+
+/**
+ * Sélectionne le plan applicable côté serveur. Deux plans publiés de même
+ * spécificité sur le même périmètre au même instant = ambiguïté refusée (409),
+ * jamais un choix arbitraire.
+ */
+export function selectApplicablePlan(
+  candidates: readonly PlanCandidate[],
+  context: ApplicabilityContext,
+  at: Date
+): PlanSelection {
+  const discarded: PlanSelection["discarded"] = [];
+  const eligible: Array<{ plan: PlanCandidate; specificity: number }> = [];
+
+  for (const candidate of candidates) {
+    if (candidate.status !== "PUBLISHED") {
+      discarded.push({ id: candidate.id, reason: "STATUS" });
+      continue;
+    }
+    if (!scopeMatchesContext(candidate.scope, context)) {
+      discarded.push({ id: candidate.id, reason: "SCOPE" });
+      continue;
+    }
+    if (!isEffectiveAt(candidate.scope, at)) {
+      discarded.push({ id: candidate.id, reason: "PERIOD" });
+      continue;
+    }
+    eligible.push({ plan: candidate, specificity: planScopeSpecificity(candidate.scope) });
+  }
+
+  if (eligible.length === 0) {
+    throw new HttpError(
+      422,
+      "QUALITY_PLAN_NOT_APPLICABLE",
+      "Aucun plan de contrôle publié n'est applicable à ce contexte.",
+      { discarded }
+    );
+  }
+
+  const best = Math.max(...eligible.map((e) => e.specificity));
+  const top = eligible.filter((e) => e.specificity === best);
+  for (const entry of eligible) {
+    if (entry.specificity !== best) discarded.push({ id: entry.plan.id, reason: "LESS_SPECIFIC" });
+  }
+
+  if (top.length > 1) {
+    throw new HttpError(
+      409,
+      "QUALITY_PLAN_AMBIGUOUS",
+      "Plusieurs plans de contrôle publiés sont applicables avec la même spécificité.",
+      { candidates: top.map((e) => ({ id: e.plan.id, code: e.plan.code, version: e.plan.version })) }
+    );
+  }
+
+  return { plan: top[0]!.plan, specificity: best, discarded };
+}
+
+/**
+ * Empêche de publier une version qui rendrait deux plans ambigus sur la même
+ * fenêtre d'effet : appelée avant `PUBLISHED`.
+ */
+export function assertNoApplicabilityOverlap(params: {
+  candidate: PlanCandidate;
+  published: readonly PlanCandidate[];
+}): void {
+  const candidateSpecificity = planScopeSpecificity(params.candidate.scope);
+  const conflicts = params.published.filter((other) => {
+    if (other.id === params.candidate.id) return false;
+    if (other.status !== "PUBLISHED") return false;
+    if (other.scope.trigger !== params.candidate.scope.trigger) return false;
+    if (planScopeSpecificity(other.scope) !== candidateSpecificity) return false;
+    const axes: Array<keyof typeof SPECIFICITY_WEIGHTS> = [
+      "piece_version_id",
+      "piece_technique_id",
+      "article_id",
+      "famille_id",
+      "operation_code",
+      "fournisseur_id",
+    ];
+    const sameScope = axes.every((axis) => (other.scope[axis] ?? null) === (params.candidate.scope[axis] ?? null));
+    if (!sameScope) return false;
+    return periodsOverlap(other.scope, params.candidate.scope);
+  });
+
+  if (conflicts.length > 0) {
+    throw new HttpError(
+      409,
+      "QUALITY_PLAN_APPLICABILITY_OVERLAP",
+      "Publication refusée : un plan publié couvre déjà ce périmètre sur la même période.",
+      { conflicts: conflicts.map((c) => ({ id: c.id, code: c.code, version: c.version })) }
+    );
+  }
+}
+
+function periodsOverlap(left: PlanApplicabilityScope, right: PlanApplicabilityScope): boolean {
+  const leftFrom = left.effective_from ? new Date(left.effective_from).getTime() : Number.NEGATIVE_INFINITY;
+  const leftTo = left.effective_to ? new Date(left.effective_to).getTime() : Number.POSITIVE_INFINITY;
+  const rightFrom = right.effective_from ? new Date(right.effective_from).getTime() : Number.NEGATIVE_INFINITY;
+  const rightTo = right.effective_to ? new Date(right.effective_to).getTime() : Number.POSITIVE_INFINITY;
+  return leftFrom <= rightTo && rightFrom <= leftTo;
+}
+
+/* -------------------------------------------------------------------------- */
+/* 6) Snapshot canonique + intégrité                                          */
+/* -------------------------------------------------------------------------- */
+
+export type PlanSnapshotSources = {
+  plan: {
+    id: string;
+    code: string;
+    version: number;
+    label: string;
+    trigger: QualityTrigger;
+    scope: PlanApplicabilityScope;
+    published_at: string | null;
+  };
+  characteristics: readonly QualityCharacteristicSpec[];
+  article: { id: string | null; code: string | null; designation: string | null };
+  piece: { id: string | null; code: string | null; designation: string | null; version: string | null };
+  population: number;
+  sampling_algorithm: string;
+  required_documents: readonly { id: string; label: string; revision: string | null }[];
+};
+
+export type PlanSnapshot = {
+  payload: Record<string, unknown>;
+  sha256: string;
+};
+
+/**
+ * Fige le contenu réellement appliqué à l'exécution. On stocke le payload
+ * canonique ET son empreinte : le verdict historique ne doit jamais être
+ * recalculé depuis le plan courant.
+ */
+export function buildPlanSnapshot(sources: PlanSnapshotSources): PlanSnapshot {
+  const payload: Record<string, unknown> = {
+    schema: "cerp.quality.plan-snapshot.v1",
+    plan: {
+      id: sources.plan.id,
+      code: sources.plan.code,
+      version: sources.plan.version,
+      label: sources.plan.label,
+      trigger: sources.plan.trigger,
+      published_at: sources.plan.published_at,
+      scope: sources.plan.scope,
+    },
+    article: sources.article,
+    piece: sources.piece,
+    population: sources.population,
+    sampling_algorithm: sources.sampling_algorithm,
+    required_documents: sources.required_documents.map((doc) => ({
+      id: doc.id,
+      label: doc.label,
+      revision: doc.revision,
+    })),
+    characteristics: [...sources.characteristics]
+      .sort((a, b) => a.position - b.position || a.key.localeCompare(b.key))
+      .map((spec) => ({
+        key: spec.key,
+        position: spec.position,
+        label: spec.label,
+        characteristic_type: spec.characteristic_type,
+        value_kind: spec.value_kind,
+        unit: spec.unit,
+        nominal: spec.nominal,
+        tolerance_min: spec.tolerance_min,
+        tolerance_max: spec.tolerance_max,
+        precision: spec.precision,
+        expected_boolean: spec.expected_boolean,
+        allowed_values: spec.allowed_values ? [...spec.allowed_values] : null,
+        criticality: spec.criticality,
+        mandatory: spec.mandatory,
+        requires_instrument: spec.requires_instrument,
+        instrument_category: spec.instrument_category,
+        method: spec.method,
+        acceptance_rule: spec.acceptance_rule,
+        sampling: spec.sampling,
+        trigger: spec.trigger,
+        required_samples: requiredSampleCount(spec, sources.population),
+      })),
+  };
+
+  return { payload, sha256: qualitySha256(payload) };
+}
+
+export function assertSnapshotIntegrity(payload: unknown, expectedSha256: string): void {
+  const actual = qualitySha256(payload);
+  if (actual !== expectedSha256) {
+    throw new HttpError(
+      409,
+      "QUALITY_SNAPSHOT_TAMPERED",
+      "Alerte d'intégrité : le snapshot du plan ne correspond plus à son empreinte SHA-256.",
+      { expected_sha256: expectedSha256, actual_sha256: actual }
+    );
+  }
+}
+
+export function characteristicsFromSnapshot(payload: unknown): QualityCharacteristicSpec[] {
+  if (!payload || typeof payload !== "object") return [];
+  const raw = (payload as { characteristics?: unknown }).characteristics;
+  if (!Array.isArray(raw)) return [];
+  return raw as QualityCharacteristicSpec[];
+}

--- a/src/module/qualite/domain/quality-policy.ts
+++ b/src/module/qualite/domain/quality-policy.ts
@@ -1,0 +1,527 @@
+// Gouvernance Qualité 360 (#228) — politiques pures, sans I/O.
+//
+// Ce fichier concentre les règles qui ne doivent jamais dépendre d'un appel
+// réseau, d'un client SQL ou du navigateur : capacités RBAC, cycles de vie,
+// séparation des tâches, idempotence et empreinte canonique des snapshots.
+//
+// Compatibilité : les enums historiques du module Qualité (#0 patchs
+// `20260213_qualite_module.sql` / `20260226_qualite_complete_ncr_capa_stock.sql`)
+// sont conservés et étendus, jamais remplacés par une seconde nomenclature.
+
+import crypto from "node:crypto";
+
+import { HttpError } from "../../../utils/httpError";
+
+/* -------------------------------------------------------------------------- */
+/* 1) Capacités RBAC — refus par défaut                                       */
+/* -------------------------------------------------------------------------- */
+
+export const QUALITY_CAPABILITIES = [
+  "read",
+  "referential_manage",
+  "plan_publish",
+  "execution_run",
+  "measurement_write",
+  "release_decide",
+  "disposition_stock",
+  "nc_manage",
+  "capa_manage",
+  "derogation_request",
+  "derogation_approve",
+  "closure_verify",
+  "documents_read",
+  "audit_read",
+  "settings_manage",
+] as const;
+
+export type QualityCapability = (typeof QUALITY_CAPABILITIES)[number];
+
+// Les rôles CERP sont du texte libre en base ; on garde la mécanique par
+// « needles » déjà utilisée par `of-rbac.ts` et `machine-rbac.ts` au lieu
+// d'inventer une table de rôles parallèle.
+const CAPABILITY_NEEDLES: Record<QualityCapability, readonly string[]> = {
+  // Lecture qualité : qualité, direction, production/atelier et méthodes en ont
+  // besoin pour travailler, mais elle reste fermée aux autres rôles.
+  read: [
+    "admin",
+    "administrateur",
+    "directeur",
+    "qualit",
+    "quality",
+    "qse",
+    "production",
+    "atelier",
+    "method",
+    "logisti",
+  ],
+  referential_manage: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "method"],
+  plan_publish: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+  execution_run: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "production", "atelier"],
+  measurement_write: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "production", "atelier"],
+  release_decide: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+  disposition_stock: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+  nc_manage: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+  capa_manage: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+  derogation_request: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "method", "production"],
+  derogation_approve: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+  closure_verify: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+  documents_read: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "production", "atelier", "method"],
+  audit_read: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+  settings_manage: ["admin", "administrateur", "directeur"],
+};
+
+export function roleHasQualityCapability(
+  role: string | null | undefined,
+  capability: QualityCapability
+): boolean {
+  const normalized = (role ?? "").trim().toLowerCase();
+  if (!normalized) return false;
+  const needles = CAPABILITY_NEEDLES[capability];
+  if (!needles) return false;
+  return needles.some((needle) => normalized.includes(needle));
+}
+
+export function assertQualityCapability(
+  role: string | null | undefined,
+  capability: QualityCapability
+): void {
+  if (!roleHasQualityCapability(role, capability)) {
+    throw new HttpError(
+      403,
+      "QUALITY_CAPABILITY_REQUIRED",
+      `La capacité Qualité '${capability}' est requise.`
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 2) Plans de contrôle — cycle de vie et immuabilité                         */
+/* -------------------------------------------------------------------------- */
+
+export const QUALITY_PLAN_STATUSES = ["DRAFT", "IN_REVIEW", "PUBLISHED", "ARCHIVED"] as const;
+export type QualityPlanStatus = (typeof QUALITY_PLAN_STATUSES)[number];
+
+const PLAN_TRANSITIONS: Readonly<Record<QualityPlanStatus, readonly QualityPlanStatus[]>> = {
+  DRAFT: ["IN_REVIEW", "PUBLISHED", "ARCHIVED"],
+  IN_REVIEW: ["DRAFT", "PUBLISHED", "ARCHIVED"],
+  // Un plan publié est immuable : on l'archive, on ne le rouvre pas.
+  PUBLISHED: ["ARCHIVED"],
+  ARCHIVED: [],
+};
+
+export function assertPlanTransition(from: QualityPlanStatus, to: QualityPlanStatus): void {
+  if (!PLAN_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "QUALITY_PLAN_TRANSITION_FORBIDDEN",
+      `Transition de plan de contrôle interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+export function assertPlanContentMutable(status: QualityPlanStatus): void {
+  if (status !== "DRAFT" && status !== "IN_REVIEW") {
+    throw new HttpError(
+      409,
+      "QUALITY_PLAN_IMMUTABLE",
+      "Un plan publié ou archivé ne se modifie pas : créez une nouvelle version."
+    );
+  }
+}
+
+export function assertPlanSelectableForExecution(status: QualityPlanStatus): void {
+  if (status !== "PUBLISHED") {
+    throw new HttpError(
+      409,
+      "QUALITY_PLAN_NOT_PUBLISHED",
+      "Seul un plan de contrôle publié peut être appliqué à une exécution."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 3) Exécutions de contrôle — statuts et verdicts                            */
+/* -------------------------------------------------------------------------- */
+
+export const QUALITY_EXECUTION_STATUSES = [
+  "PLANNED",
+  "IN_PROGRESS",
+  "VALIDATED",
+  "REJECTED",
+] as const;
+export type QualityExecutionStatus = (typeof QUALITY_EXECUTION_STATUSES)[number];
+
+export const QUALITY_VERDICTS = ["CONFORME", "NON_CONFORME", "PARTIEL", "EN_ATTENTE"] as const;
+export type QualityVerdict = (typeof QUALITY_VERDICTS)[number];
+
+// Mapping canonique vers l'enum historique `quality_control_result` (OK/NOK/PARTIAL)
+// pour ne pas casser les listes, KPI et écrans déjà en production.
+export function verdictToLegacyResult(verdict: QualityVerdict): "OK" | "NOK" | "PARTIAL" | null {
+  switch (verdict) {
+    case "CONFORME":
+      return "OK";
+    case "NON_CONFORME":
+      return "NOK";
+    case "PARTIEL":
+      return "PARTIAL";
+    case "EN_ATTENTE":
+      return null;
+  }
+}
+
+export function legacyResultToVerdict(
+  result: "OK" | "NOK" | "PARTIAL" | null | undefined
+): QualityVerdict {
+  switch (result) {
+    case "OK":
+      return "CONFORME";
+    case "NOK":
+      return "NON_CONFORME";
+    case "PARTIAL":
+      return "PARTIEL";
+    default:
+      return "EN_ATTENTE";
+  }
+}
+
+export function executionStatusForVerdict(verdict: QualityVerdict): QualityExecutionStatus {
+  if (verdict === "EN_ATTENTE") return "IN_PROGRESS";
+  return verdict === "CONFORME" ? "VALIDATED" : "REJECTED";
+}
+
+/* -------------------------------------------------------------------------- */
+/* 4) Non-conformités — cycle de vie étendu                                   */
+/* -------------------------------------------------------------------------- */
+
+// L'enum PostgreSQL `quality_nc_status` est étendu de façon additive par le
+// patch #228 : les 4 valeurs historiques restent en tête.
+export const QUALITY_NC_STATUSES = [
+  "OPEN",
+  "ANALYSIS",
+  "ACTION_PLAN",
+  "CLOSED",
+  "DRAFT",
+  "DISPOSITION",
+  "VERIFICATION",
+  "CANCELLED",
+] as const;
+export type QualityNcStatus = (typeof QUALITY_NC_STATUSES)[number];
+
+const NC_TRANSITIONS: Readonly<Record<QualityNcStatus, readonly QualityNcStatus[]>> = {
+  DRAFT: ["OPEN", "CANCELLED"],
+  OPEN: ["ANALYSIS", "DISPOSITION", "CANCELLED"],
+  ANALYSIS: ["DISPOSITION", "ACTION_PLAN", "OPEN", "CANCELLED"],
+  DISPOSITION: ["ACTION_PLAN", "VERIFICATION", "ANALYSIS", "CANCELLED"],
+  ACTION_PLAN: ["VERIFICATION", "DISPOSITION", "CANCELLED"],
+  VERIFICATION: ["CLOSED", "ACTION_PLAN"],
+  // Une NC clôturée se réouvre par action auditée, jamais par simple édition.
+  CLOSED: ["OPEN"],
+  CANCELLED: [],
+};
+
+export function assertNcTransition(from: QualityNcStatus, to: QualityNcStatus): void {
+  if (!NC_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "QUALITY_NC_TRANSITION_FORBIDDEN",
+      `Transition de non-conformité interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+export type NcClosurePrecondition = {
+  hasDisposition: boolean;
+  mandatoryCapaCount: number;
+  verifiedCapaCount: number;
+  hasRootCause: boolean;
+  hasEffectivenessEvidence: boolean;
+};
+
+// Une NC ne se clôture pas parce qu'un champ texte est rempli : on exige la
+// disposition, la cause et la vérification d'efficacité des CAPA obligatoires.
+export function assertNcClosureAllowed(pre: NcClosurePrecondition): void {
+  const missing: string[] = [];
+  if (!pre.hasDisposition) missing.push("disposition");
+  if (!pre.hasRootCause) missing.push("root_cause");
+  if (pre.mandatoryCapaCount > 0 && pre.verifiedCapaCount < pre.mandatoryCapaCount) {
+    missing.push("capa_verification");
+  }
+  if (!pre.hasEffectivenessEvidence) missing.push("effectiveness_evidence");
+  if (missing.length > 0) {
+    throw new HttpError(
+      422,
+      "QUALITY_NC_CLOSURE_INCOMPLETE",
+      "Clôture impossible : éléments obligatoires manquants.",
+      { missing }
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 5) Dispositions qualité                                                    */
+/* -------------------------------------------------------------------------- */
+
+// Types historiques conservés à l'identique (contrainte CHECK #0226) + reprise
+// de contrôle demandée par #228.
+export const QUALITY_DISPOSITION_TYPES = [
+  "HOLD",
+  "RELEASE",
+  "USE_AS_IS",
+  "REWORK",
+  "SORT",
+  "SCRAP",
+  "RETURN_SUPPLIER",
+  "RECHECK",
+] as const;
+export type QualityDispositionType = (typeof QUALITY_DISPOSITION_TYPES)[number];
+
+// Seules ces dispositions écrivent un mouvement de stock : elles exigent
+// preview + Idempotency-Key + transaction.
+const STOCK_IMPACTING: ReadonlySet<QualityDispositionType> = new Set<QualityDispositionType>([
+  "SCRAP",
+  "RETURN_SUPPLIER",
+]);
+
+export function dispositionImpactsStock(type: QualityDispositionType): boolean {
+  return STOCK_IMPACTING.has(type);
+}
+
+// `USE_AS_IS` est une acceptation en l'état : elle exige une dérogation active.
+export function dispositionRequiresDerogation(type: QualityDispositionType): boolean {
+  return type === "USE_AS_IS";
+}
+
+export function dispositionRequiresQuantity(type: QualityDispositionType): boolean {
+  return type !== "RECHECK";
+}
+
+/* -------------------------------------------------------------------------- */
+/* 6) Dérogations / concessions                                               */
+/* -------------------------------------------------------------------------- */
+
+export const QUALITY_DEROGATION_STATUSES = [
+  "DRAFT",
+  "SUBMITTED",
+  "APPROVED",
+  "REJECTED",
+  "CONSUMED",
+  "EXPIRED",
+  "REVOKED",
+] as const;
+export type QualityDerogationStatus = (typeof QUALITY_DEROGATION_STATUSES)[number];
+
+const DEROGATION_TRANSITIONS: Readonly<
+  Record<QualityDerogationStatus, readonly QualityDerogationStatus[]>
+> = {
+  DRAFT: ["SUBMITTED"],
+  SUBMITTED: ["APPROVED", "REJECTED", "DRAFT"],
+  APPROVED: ["CONSUMED", "EXPIRED", "REVOKED"],
+  REJECTED: [],
+  CONSUMED: ["REVOKED"],
+  EXPIRED: [],
+  REVOKED: [],
+};
+
+export function assertDerogationTransition(
+  from: QualityDerogationStatus,
+  to: QualityDerogationStatus
+): void {
+  if (!DEROGATION_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "QUALITY_DEROGATION_TRANSITION_FORBIDDEN",
+      `Transition de dérogation interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 7) Séparation des tâches                                                   */
+/* -------------------------------------------------------------------------- */
+
+export type SeparationPolicy = {
+  // Exception explicitement configurée, justifiée et auditée (jamais implicite).
+  allowSelfRelease: boolean;
+  allowSelfDerogationApproval: boolean;
+};
+
+export const DEFAULT_SEPARATION_POLICY: SeparationPolicy = {
+  allowSelfRelease: false,
+  allowSelfDerogationApproval: false,
+};
+
+export function assertReleaseSeparation(params: {
+  executorUserId: number | null;
+  deciderUserId: number;
+  policy?: SeparationPolicy;
+}): void {
+  const policy = params.policy ?? DEFAULT_SEPARATION_POLICY;
+  if (policy.allowSelfRelease) return;
+  if (params.executorUserId !== null && params.executorUserId === params.deciderUserId) {
+    throw new HttpError(
+      403,
+      "QUALITY_SEPARATION_OF_DUTIES",
+      "L'auteur de l'exécution ne peut pas prononcer lui-même la libération."
+    );
+  }
+}
+
+export function assertDerogationApprovalSeparation(params: {
+  requesterUserId: number | null;
+  approverUserId: number;
+  policy?: SeparationPolicy;
+}): void {
+  const policy = params.policy ?? DEFAULT_SEPARATION_POLICY;
+  if (policy.allowSelfDerogationApproval) return;
+  if (params.requesterUserId !== null && params.requesterUserId === params.approverUserId) {
+    throw new HttpError(
+      403,
+      "QUALITY_SEPARATION_OF_DUTIES",
+      "Le demandeur ne peut pas approuver sa propre dérogation."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 8) Verdict manuel contraire au calcul                                      */
+/* -------------------------------------------------------------------------- */
+
+export type ManualVerdictOverride = {
+  computed: QualityVerdict;
+  requested: QualityVerdict;
+  justification: string | null;
+  evidenceCount: number;
+  requireEvidence: boolean;
+};
+
+export function assertManualVerdictOverride(input: ManualVerdictOverride): void {
+  if (input.requested === input.computed) return;
+  const justification = (input.justification ?? "").trim();
+  if (justification.length < 20) {
+    throw new HttpError(
+      422,
+      "QUALITY_VERDICT_OVERRIDE_JUSTIFICATION_REQUIRED",
+      "Un verdict contraire au calcul exige une justification d'au moins 20 caractères."
+    );
+  }
+  if (input.requireEvidence && input.evidenceCount <= 0) {
+    throw new HttpError(
+      422,
+      "QUALITY_VERDICT_OVERRIDE_EVIDENCE_REQUIRED",
+      "Un verdict contraire au calcul exige au moins une pièce jointe de preuve."
+    );
+  }
+  // Un verdict manuel ne peut pas transformer une non-conformité en conformité
+  // sans passer par une dérogation : c'est le rôle de la concession, pas du
+  // contrôleur.
+  if (input.computed === "NON_CONFORME" && input.requested === "CONFORME") {
+    throw new HttpError(
+      422,
+      "QUALITY_VERDICT_OVERRIDE_FORBIDDEN",
+      "Un résultat non conforme ne devient pas conforme par décision manuelle : utilisez une dérogation."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 9) Idempotence et empreinte canonique                                      */
+/* -------------------------------------------------------------------------- */
+
+export function normalizeQualityIdempotencyKey(value: string | null | undefined): string {
+  const normalized = (value ?? "").trim();
+  if (normalized.length < 8 || normalized.length > 200) {
+    throw new HttpError(
+      400,
+      "IDEMPOTENCY_KEY_INVALID",
+      "Idempotency-Key doit contenir entre 8 et 200 caractères."
+    );
+  }
+  return normalized;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, child]) => child !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, canonicalize(child)])
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function qualitySha256(value: unknown): string {
+  return crypto.createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+export function qualityRequestHash(commandType: string, payload: unknown): string {
+  return qualitySha256({ command_type: commandType, payload });
+}
+
+export function decideQualityReceipt(
+  existingHash: string | null | undefined,
+  incomingHash: string
+): "NEW" | "REPLAY" | "CONFLICT" {
+  if (!existingHash) return "NEW";
+  return existingHash === incomingHash ? "REPLAY" : "CONFLICT";
+}
+
+export function assertPreviewFresh(params: {
+  expectedHash: string | null | undefined;
+  currentHash: string;
+}): void {
+  const expected = (params.expectedHash ?? "").trim();
+  if (!expected) {
+    throw new HttpError(
+      422,
+      "QUALITY_PREVIEW_REQUIRED",
+      "Un aperçu serveur est obligatoire avant de confirmer cette décision."
+    );
+  }
+  if (expected !== params.currentHash) {
+    throw new HttpError(
+      409,
+      "QUALITY_PREVIEW_STALE",
+      "L'aperçu n'est plus à jour : rechargez-le avant de confirmer."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 10) Verrou optimiste                                                       */
+/* -------------------------------------------------------------------------- */
+
+export function assertOptimisticVersion(params: {
+  expectedUpdatedAt: string | null | undefined;
+  currentUpdatedAt: string | Date;
+}): void {
+  const expected = (params.expectedUpdatedAt ?? "").trim();
+  if (!expected) {
+    throw new HttpError(
+      422,
+      "QUALITY_EXPECTED_VERSION_REQUIRED",
+      "expected_updated_at est obligatoire pour modifier cet objet qualité."
+    );
+  }
+  const current =
+    params.currentUpdatedAt instanceof Date
+      ? params.currentUpdatedAt.toISOString()
+      : new Date(params.currentUpdatedAt).toISOString();
+  const parsedExpected = new Date(expected);
+  if (Number.isNaN(parsedExpected.getTime())) {
+    throw new HttpError(422, "QUALITY_EXPECTED_VERSION_INVALID", "expected_updated_at est invalide.");
+  }
+  if (parsedExpected.toISOString() !== current) {
+    throw new HttpError(
+      409,
+      "QUALITY_VERSION_CONFLICT",
+      "Cet objet qualité a été modifié entre-temps : rechargez la fiche."
+    );
+  }
+}

--- a/src/module/qualite/domain/quality-release.ts
+++ b/src/module/qualite/domain/quality-release.ts
@@ -1,0 +1,662 @@
+// Libération, quantités, quarantaine, instruments, dérogations et moteur
+// d'éligibilité ciblé (#228). Pur : aucune I/O.
+
+import { HttpError } from "../../../utils/httpError";
+import type { QualityCharacteristicSpec } from "./quality-plan";
+import type { QualityVerdict } from "./quality-policy";
+
+const EPS = 1e-9;
+
+/* -------------------------------------------------------------------------- */
+/* 1) Objet contrôlé — typage obligatoire de la source                        */
+/* -------------------------------------------------------------------------- */
+
+export const QUALITY_SOURCE_TYPES = [
+  "RECEPTION_LINE",
+  "OF",
+  "OF_OPERATION",
+  "LOT",
+  "STOCK_LEVEL",
+  "ARTICLE",
+  "PIECE_TECHNIQUE",
+  "FOURNISSEUR",
+  "DELIVERY_LINE",
+] as const;
+export type QualitySourceType = (typeof QUALITY_SOURCE_TYPES)[number];
+
+export type QualitySourceRef = {
+  source_type: QualitySourceType;
+  source_id: string;
+};
+
+export function assertSourceRef(ref: Partial<QualitySourceRef> | null | undefined): QualitySourceRef {
+  const type = ref?.source_type;
+  const id = (ref?.source_id ?? "").trim();
+  if (!type || !QUALITY_SOURCE_TYPES.includes(type)) {
+    throw new HttpError(422, "QUALITY_SOURCE_TYPE_REQUIRED", "Type de source obligatoire et typé.");
+  }
+  if (!id) {
+    throw new HttpError(422, "QUALITY_SOURCE_ID_REQUIRED", "Identifiant de source obligatoire.");
+  }
+  return { source_type: type, source_id: id };
+}
+
+/* -------------------------------------------------------------------------- */
+/* 2) Registre de quantités                                                   */
+/* -------------------------------------------------------------------------- */
+
+export type QuantityLedger = {
+  population: number;
+  controlled: number;
+  conforming: number;
+  released: number;
+  held: number;
+  scrapped: number;
+  reworked: number;
+  sorted: number;
+  returned: number;
+  consumed: number;
+};
+
+export const EMPTY_LEDGER: QuantityLedger = {
+  population: 0,
+  controlled: 0,
+  conforming: 0,
+  released: 0,
+  held: 0,
+  scrapped: 0,
+  reworked: 0,
+  sorted: 0,
+  returned: 0,
+  consumed: 0,
+};
+
+const LEDGER_DISPOSED_FIELDS = [
+  "released",
+  "held",
+  "scrapped",
+  "reworked",
+  "sorted",
+  "returned",
+] as const;
+
+export function assertQuantityLedger(ledger: QuantityLedger): void {
+  const problems: Array<{ field: string; code: string }> = [];
+
+  for (const [field, value] of Object.entries(ledger)) {
+    if (!Number.isFinite(value)) {
+      problems.push({ field, code: "NOT_FINITE" });
+      continue;
+    }
+    if (value < -EPS) problems.push({ field, code: "NEGATIVE" });
+  }
+  if (problems.length > 0) {
+    throw new HttpError(422, "QUALITY_QUANTITY_INVALID", "Quantité qualité invalide.", { problems });
+  }
+
+  if (ledger.population <= EPS) {
+    throw new HttpError(
+      422,
+      "QUALITY_POPULATION_REQUIRED",
+      "La population contrôlée doit être strictement positive."
+    );
+  }
+  if (ledger.controlled > ledger.population + EPS) {
+    throw new HttpError(
+      422,
+      "QUALITY_CONTROLLED_EXCEEDS_POPULATION",
+      "La quantité contrôlée dépasse la population."
+    );
+  }
+  if (ledger.conforming > ledger.controlled + EPS) {
+    throw new HttpError(
+      422,
+      "QUALITY_CONFORMING_EXCEEDS_CONTROLLED",
+      "La quantité conforme dépasse la quantité contrôlée."
+    );
+  }
+  if (ledger.released > ledger.conforming + EPS) {
+    throw new HttpError(
+      422,
+      "QUALITY_RELEASED_EXCEEDS_CONFORMING",
+      "La quantité libérée dépasse la quantité conforme."
+    );
+  }
+  const disposed = LEDGER_DISPOSED_FIELDS.reduce((sum, field) => sum + ledger[field], 0);
+  if (disposed > ledger.population + EPS) {
+    throw new HttpError(
+      422,
+      "QUALITY_DISPOSITIONS_EXCEED_POPULATION",
+      "Le cumul des dispositions dépasse la population.",
+      { disposed, population: ledger.population }
+    );
+  }
+  if (ledger.consumed > ledger.released + EPS) {
+    throw new HttpError(
+      422,
+      "QUALITY_CONSUMED_EXCEEDS_RELEASED",
+      "La quantité déjà consommée dépasse la quantité libérée."
+    );
+  }
+}
+
+export function remainingUndisposedQty(ledger: QuantityLedger): number {
+  const disposed = LEDGER_DISPOSED_FIELDS.reduce((sum, field) => sum + ledger[field], 0);
+  return Math.max(0, ledger.population - disposed);
+}
+
+export function releasableQty(ledger: QuantityLedger): number {
+  return Math.max(0, Math.min(ledger.conforming - ledger.released, remainingUndisposedQty(ledger)));
+}
+
+/* -------------------------------------------------------------------------- */
+/* 3) Décision de libération                                                  */
+/* -------------------------------------------------------------------------- */
+
+export const QUALITY_RELEASE_DECISIONS = ["FULL", "PARTIAL", "HOLD", "REJECT"] as const;
+export type QualityReleaseDecision = (typeof QUALITY_RELEASE_DECISIONS)[number];
+
+export type ReleaseRequest = {
+  decision: QualityReleaseDecision;
+  qty: number;
+  unit: string | null;
+  ledger: QuantityLedger;
+  verdict: QualityVerdict;
+  hasDerogation: boolean;
+  evidenceCount: number;
+};
+
+export type ReleaseOutcome = {
+  decision: QualityReleaseDecision;
+  qty_released: number;
+  qty_held: number;
+  ledger: QuantityLedger;
+};
+
+/**
+ * Aucune libération automatique : cette fonction n'est appelée que par une
+ * commande explicite, avec rôle autorisé, verrou optimiste et preuve
+ * suffisante vérifiés en amont.
+ */
+export function evaluateReleaseRequest(request: ReleaseRequest): ReleaseOutcome {
+  assertQuantityLedger(request.ledger);
+
+  if (!Number.isFinite(request.qty)) {
+    throw new HttpError(422, "QUALITY_RELEASE_QTY_INVALID", "Quantité de libération invalide.");
+  }
+  if (request.decision !== "HOLD" && request.qty <= EPS) {
+    throw new HttpError(
+      422,
+      "QUALITY_RELEASE_QTY_REQUIRED",
+      "Une libération exige une quantité strictement positive."
+    );
+  }
+  if (!request.unit || !request.unit.trim()) {
+    throw new HttpError(422, "QUALITY_RELEASE_UNIT_REQUIRED", "L'unité de la décision est obligatoire.");
+  }
+
+  if (request.verdict === "EN_ATTENTE") {
+    throw new HttpError(
+      422,
+      "QUALITY_VERDICT_INCOMPLETE",
+      "Le verdict n'est pas calculé : contrôle incomplet, aucune décision possible."
+    );
+  }
+
+  if (request.decision === "HOLD") {
+    const held = Math.min(remainingUndisposedQty(request.ledger), request.qty > EPS ? request.qty : remainingUndisposedQty(request.ledger));
+    if (held <= EPS) {
+      throw new HttpError(
+        422,
+        "QUALITY_NOTHING_TO_HOLD",
+        "Aucune quantité disponible à mettre en quarantaine."
+      );
+    }
+    return {
+      decision: "HOLD",
+      qty_released: 0,
+      qty_held: held,
+      ledger: { ...request.ledger, held: request.ledger.held + held },
+    };
+  }
+
+  if (request.decision === "REJECT") {
+    return { decision: "REJECT", qty_released: 0, qty_held: 0, ledger: request.ledger };
+  }
+
+  if (request.verdict === "NON_CONFORME" && !request.hasDerogation) {
+    throw new HttpError(
+      422,
+      "QUALITY_RELEASE_REQUIRES_DEROGATION",
+      "Libérer un résultat non conforme exige une dérogation approuvée et active."
+    );
+  }
+  if (request.verdict === "PARTIEL" && request.decision === "FULL") {
+    throw new HttpError(
+      422,
+      "QUALITY_RELEASE_PARTIAL_ONLY",
+      "Un verdict partiel n'autorise qu'une libération partielle : le reste demeure bloqué."
+    );
+  }
+
+  const maximum = releasableQty(request.ledger);
+  if (request.qty > maximum + EPS) {
+    throw new HttpError(
+      422,
+      "QUALITY_RELEASE_QTY_EXCEEDS_ALLOWED",
+      "La quantité demandée dépasse la quantité libérable.",
+      { requested: request.qty, releasable: maximum }
+    );
+  }
+  if (request.decision === "FULL" && request.qty + EPS < maximum) {
+    throw new HttpError(
+      422,
+      "QUALITY_RELEASE_FULL_MISMATCH",
+      "Une libération totale doit porter sur la totalité de la quantité libérable.",
+      { requested: request.qty, releasable: maximum }
+    );
+  }
+  if (request.evidenceCount < 0) {
+    throw new HttpError(422, "QUALITY_EVIDENCE_INVALID", "Nombre de preuves invalide.");
+  }
+
+  const nextLedger: QuantityLedger = {
+    ...request.ledger,
+    released: request.ledger.released + request.qty,
+  };
+  const held = Math.max(0, remainingUndisposedQty(nextLedger));
+
+  return {
+    decision: request.decision,
+    qty_released: request.qty,
+    qty_held: request.decision === "PARTIAL" ? held : 0,
+    ledger: nextLedger,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* 4) Instruments de métrologie                                               */
+/* -------------------------------------------------------------------------- */
+
+export type InstrumentState = {
+  id: string;
+  code: string | null;
+  designation: string | null;
+  statut: string | null;
+  criticite: string | null;
+  categorie: string | null;
+  next_due_date: string | null;
+  deleted: boolean;
+};
+
+export type MetrologyPolicy = {
+  // Réglage historique `metrologie.block_on_overdue_critical` : conservé, mais
+  // appliqué à l'instrument réellement utilisé, jamais en blocage global.
+  block_on_overdue_critical: boolean;
+};
+
+export type InstrumentUsageEvaluation = {
+  allowed: boolean;
+  severity: "OK" | "WARNING" | "BLOCKING";
+  code:
+    | "OK"
+    | "INSTRUMENT_REQUIRED"
+    | "INSTRUMENT_UNKNOWN"
+    | "INSTRUMENT_DELETED"
+    | "INSTRUMENT_INACTIVE"
+    | "INSTRUMENT_OUT_OF_SCOPE"
+    | "INSTRUMENT_OVERDUE_CRITICAL"
+    | "INSTRUMENT_OVERDUE";
+  message: string;
+};
+
+export function evaluateInstrumentUsage(params: {
+  characteristic: Pick<QualityCharacteristicSpec, "key" | "requires_instrument" | "instrument_category">;
+  instrument: InstrumentState | null;
+  at: Date;
+  policy: MetrologyPolicy;
+}): InstrumentUsageEvaluation {
+  const { characteristic, instrument, at, policy } = params;
+
+  if (!characteristic.requires_instrument) {
+    return { allowed: true, severity: "OK", code: "OK", message: "Aucun moyen de contrôle requis." };
+  }
+  if (!instrument) {
+    return {
+      allowed: false,
+      severity: "BLOCKING",
+      code: "INSTRUMENT_REQUIRED",
+      message: `La caractéristique ${characteristic.key} exige l'instrument réellement utilisé.`,
+    };
+  }
+  if (instrument.deleted) {
+    return {
+      allowed: false,
+      severity: "BLOCKING",
+      code: "INSTRUMENT_DELETED",
+      message: "Instrument supprimé du parc de métrologie.",
+    };
+  }
+  if ((instrument.statut ?? "").toUpperCase() !== "ACTIF") {
+    return {
+      allowed: false,
+      severity: "BLOCKING",
+      code: "INSTRUMENT_INACTIVE",
+      message: `Instrument non actif (${instrument.statut ?? "statut inconnu"}).`,
+    };
+  }
+  if (
+    characteristic.instrument_category &&
+    (instrument.categorie ?? "").trim().toLowerCase() !==
+      characteristic.instrument_category.trim().toLowerCase()
+  ) {
+    return {
+      allowed: false,
+      severity: "BLOCKING",
+      code: "INSTRUMENT_OUT_OF_SCOPE",
+      message: `Instrument hors périmètre : catégorie ${characteristic.instrument_category} attendue.`,
+    };
+  }
+
+  const overdue = isInstrumentOverdue(instrument, at);
+  if (!overdue) {
+    return { allowed: true, severity: "OK", code: "OK", message: "Instrument valide." };
+  }
+
+  const critical = (instrument.criticite ?? "").toUpperCase() === "CRITIQUE";
+  if (critical && policy.block_on_overdue_critical) {
+    return {
+      allowed: false,
+      severity: "BLOCKING",
+      code: "INSTRUMENT_OVERDUE_CRITICAL",
+      message: `Instrument critique en retard d'étalonnage (échéance ${instrument.next_due_date}).`,
+    };
+  }
+  return {
+    allowed: true,
+    severity: "WARNING",
+    code: critical ? "INSTRUMENT_OVERDUE_CRITICAL" : "INSTRUMENT_OVERDUE",
+    message: `Étalonnage dépassé (échéance ${instrument.next_due_date}) : traçabilité dégradée.`,
+  };
+}
+
+export function isInstrumentOverdue(instrument: InstrumentState, at: Date): boolean {
+  if (!instrument.next_due_date) return false;
+  const due = new Date(instrument.next_due_date);
+  if (Number.isNaN(due.getTime())) return false;
+  return due.getTime() < at.getTime();
+}
+
+/* -------------------------------------------------------------------------- */
+/* 5) Dérogations / concessions — usage                                       */
+/* -------------------------------------------------------------------------- */
+
+export type DerogationState = {
+  id: string;
+  code: string;
+  status: string;
+  article_id: string | null;
+  piece_technique_id: string | null;
+  piece_version_id: string | null;
+  lot_id: string | null;
+  of_id: string | null;
+  commande_id: string | null;
+  bon_livraison_id: string | null;
+  max_qty: number | null;
+  unit: string | null;
+  consumed_qty: number;
+  valid_from: string | null;
+  valid_to: string | null;
+};
+
+export type DerogationUsageContext = {
+  article_id: string | null;
+  piece_technique_id: string | null;
+  piece_version_id: string | null;
+  lot_id: string | null;
+  of_id: string | null;
+  commande_id: string | null;
+  bon_livraison_id: string | null;
+  unit: string | null;
+};
+
+export type DerogationUsageEvaluation = {
+  allowed: boolean;
+  code:
+    | "OK"
+    | "DEROGATION_NOT_APPROVED"
+    | "DEROGATION_EXPIRED"
+    | "DEROGATION_NOT_YET_VALID"
+    | "DEROGATION_REVOKED"
+    | "DEROGATION_OUT_OF_SCOPE"
+    | "DEROGATION_UNIT_MISMATCH"
+    | "DEROGATION_QTY_EXCEEDED";
+  remaining_qty: number | null;
+  message: string;
+};
+
+const DEROGATION_SCOPE_AXES = [
+  "article_id",
+  "piece_technique_id",
+  "piece_version_id",
+  "lot_id",
+  "of_id",
+  "commande_id",
+  "bon_livraison_id",
+] as const;
+
+export function evaluateDerogationUsage(params: {
+  derogation: DerogationState;
+  context: DerogationUsageContext;
+  qty: number;
+  at: Date;
+}): DerogationUsageEvaluation {
+  const { derogation, context, qty, at } = params;
+  const remaining =
+    derogation.max_qty === null ? null : Math.max(0, derogation.max_qty - derogation.consumed_qty);
+
+  const deny = (
+    code: Exclude<DerogationUsageEvaluation["code"], "OK">,
+    message: string
+  ): DerogationUsageEvaluation => ({ allowed: false, code, remaining_qty: remaining, message });
+
+  const status = (derogation.status ?? "").toUpperCase();
+  if (status === "REVOKED") return deny("DEROGATION_REVOKED", "Dérogation révoquée.");
+  if (status === "EXPIRED") return deny("DEROGATION_EXPIRED", "Dérogation expirée.");
+  if (status !== "APPROVED" && status !== "CONSUMED") {
+    return deny("DEROGATION_NOT_APPROVED", `Dérogation non approuvée (${status || "statut inconnu"}).`);
+  }
+
+  if (derogation.valid_from) {
+    const from = new Date(derogation.valid_from);
+    if (!Number.isNaN(from.getTime()) && at.getTime() < from.getTime()) {
+      return deny("DEROGATION_NOT_YET_VALID", "Dérogation pas encore valide.");
+    }
+  }
+  if (derogation.valid_to) {
+    const to = new Date(derogation.valid_to);
+    if (!Number.isNaN(to.getTime()) && at.getTime() > to.getTime()) {
+      return deny("DEROGATION_EXPIRED", "Dérogation expirée.");
+    }
+  }
+
+  for (const axis of DEROGATION_SCOPE_AXES) {
+    const expected = derogation[axis];
+    if (!expected) continue;
+    if (context[axis] !== expected) {
+      return deny("DEROGATION_OUT_OF_SCOPE", `Dérogation hors périmètre sur ${axis}.`);
+    }
+  }
+  // Une concession sans aucun axe ne couvre rien : elle ne peut pas devenir un
+  // blanc-seing global.
+  const hasScope = DEROGATION_SCOPE_AXES.some((axis) => Boolean(derogation[axis]));
+  if (!hasScope) {
+    return deny("DEROGATION_OUT_OF_SCOPE", "Dérogation sans périmètre exploitable.");
+  }
+
+  if (derogation.unit && context.unit && derogation.unit.trim() !== context.unit.trim()) {
+    return deny("DEROGATION_UNIT_MISMATCH", "Unité de la concession incohérente avec la décision.");
+  }
+
+  if (!Number.isFinite(qty) || qty <= EPS) {
+    return deny("DEROGATION_QTY_EXCEEDED", "Quantité de consommation invalide.");
+  }
+  if (remaining !== null && qty > remaining + EPS) {
+    return deny(
+      "DEROGATION_QTY_EXCEEDED",
+      `Quantité résiduelle insuffisante (${remaining} restant).`
+    );
+  }
+
+  return { allowed: true, code: "OK", remaining_qty: remaining, message: "Concession applicable." };
+}
+
+export function derogationStatusAfterConsumption(params: {
+  max_qty: number | null;
+  consumed_qty: number;
+}): "APPROVED" | "CONSUMED" {
+  if (params.max_qty === null) return "APPROVED";
+  return params.consumed_qty + EPS >= params.max_qty ? "CONSUMED" : "APPROVED";
+}
+
+/* -------------------------------------------------------------------------- */
+/* 6) Moteur d'éligibilité ciblé                                              */
+/* -------------------------------------------------------------------------- */
+
+export const QUALITY_ELIGIBILITY_PURPOSES = ["RESERVE", "SHIP", "INVOICE"] as const;
+export type QualityEligibilityPurpose = (typeof QUALITY_ELIGIBILITY_PURPOSES)[number];
+
+export type EligibilityTarget = {
+  object_type: QualitySourceType;
+  object_id: string;
+  label: string | null;
+  qty_requested: number;
+  // État qualité de l'objet exact, jamais de l'usine entière.
+  lot_status: "LIBERE" | "EN_ATTENTE" | "QUARANTAINE" | "BLOQUE" | null;
+  qty_released: number;
+  qty_held: number;
+  qty_consumed: number;
+  open_nc_without_disposition: number;
+  pending_mandatory_controls: number;
+  derogation: { status: string; valid_to: string | null } | null;
+};
+
+export type EligibilityBlock = {
+  code:
+    | "LOT_NOT_RELEASED"
+    | "LOT_QUARANTINE"
+    | "QTY_NOT_RELEASED"
+    | "OPEN_NON_CONFORMITY"
+    | "MANDATORY_CONTROL_PENDING"
+    | "DEROGATION_EXPIRED";
+  message: string;
+  expected_action: string;
+  object_type: QualitySourceType;
+  object_id: string;
+};
+
+export type EligibilityVerdict = {
+  allowed: boolean;
+  qty_allowed: number;
+  blocks: EligibilityBlock[];
+};
+
+/**
+ * Décide si une quantité identifiée peut être réservée, expédiée ou facturée.
+ * Le blocage est ciblé objet + quantité + statut et il explique la cause et
+ * l'action attendue. Aucun blocage global d'articles non concernés.
+ */
+export function evaluateQualityEligibility(
+  target: EligibilityTarget,
+  purpose: QualityEligibilityPurpose,
+  at: Date
+): EligibilityVerdict {
+  const blocks: EligibilityBlock[] = [];
+  const anchor = { object_type: target.object_type, object_id: target.object_id };
+
+  if (target.lot_status === "BLOQUE") {
+    blocks.push({
+      ...anchor,
+      code: "LOT_NOT_RELEASED",
+      message: `Lot ${target.label ?? target.object_id} bloqué qualité.`,
+      expected_action: "Prononcer une disposition qualité (libération, tri, rebut ou retour).",
+    });
+  }
+  if (target.lot_status === "QUARANTAINE" || target.lot_status === "EN_ATTENTE") {
+    blocks.push({
+      ...anchor,
+      code: "LOT_QUARANTINE",
+      message: `Lot ${target.label ?? target.object_id} en quarantaine.`,
+      expected_action: "Terminer le contrôle puis décider la libération de la quantité acceptée.",
+    });
+  }
+  if (target.pending_mandatory_controls > 0) {
+    blocks.push({
+      ...anchor,
+      code: "MANDATORY_CONTROL_PENDING",
+      message: `${target.pending_mandatory_controls} contrôle(s) obligatoire(s) non terminé(s).`,
+      expected_action: "Exécuter les contrôles obligatoires du plan applicable.",
+    });
+  }
+  if (target.open_nc_without_disposition > 0) {
+    blocks.push({
+      ...anchor,
+      code: "OPEN_NON_CONFORMITY",
+      message: `${target.open_nc_without_disposition} non-conformité(s) sans disposition.`,
+      expected_action: "Prononcer la disposition de chaque non-conformité ouverte.",
+    });
+  }
+  if (target.derogation) {
+    const status = target.derogation.status.toUpperCase();
+    const expired =
+      status === "EXPIRED" ||
+      status === "REVOKED" ||
+      (target.derogation.valid_to
+        ? new Date(target.derogation.valid_to).getTime() < at.getTime()
+        : false);
+    if (expired) {
+      blocks.push({
+        ...anchor,
+        code: "DEROGATION_EXPIRED",
+        message: "La dérogation invoquée est expirée ou révoquée.",
+        expected_action: "Obtenir une nouvelle dérogation approuvée ou traiter la non-conformité.",
+      });
+    }
+  }
+
+  const availableReleased = Math.max(0, target.qty_released - target.qty_consumed);
+  const requested = Number.isFinite(target.qty_requested) ? Math.max(0, target.qty_requested) : 0;
+  if (requested > availableReleased + EPS) {
+    blocks.push({
+      ...anchor,
+      code: "QTY_NOT_RELEASED",
+      message: `Quantité non libérée : ${requested} demandé, ${availableReleased} libéré.`,
+      expected_action:
+        purpose === "INVOICE"
+          ? "Facturer uniquement la quantité libérée."
+          : "Libérer la quantité complémentaire ou réduire la demande.",
+    });
+  }
+
+  const qtyAllowed = blocks.some((b) => b.code !== "QTY_NOT_RELEASED")
+    ? 0
+    : Math.min(requested, availableReleased);
+
+  return { allowed: blocks.length === 0, qty_allowed: qtyAllowed, blocks };
+}
+
+export function assertQualityEligibility(
+  target: EligibilityTarget,
+  purpose: QualityEligibilityPurpose,
+  at: Date
+): void {
+  const verdict = evaluateQualityEligibility(target, purpose, at);
+  if (!verdict.allowed) {
+    throw new HttpError(
+      409,
+      "QUALITY_NOT_ELIGIBLE",
+      "Quantité non éligible : la Qualité bloque cet objet précis.",
+      { purpose, qty_allowed: verdict.qty_allowed, blocks: verdict.blocks }
+    );
+  }
+}

--- a/src/module/qualite/middlewares/quality-authorization.middleware.ts
+++ b/src/module/qualite/middlewares/quality-authorization.middleware.ts
@@ -1,0 +1,29 @@
+import type { RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import { roleHasQualityCapability, type QualityCapability } from "../domain/quality-policy";
+
+/**
+ * Garde de capacité Qualité (#228). Refus par défaut : un utilisateur
+ * authentifié n'obtient aucun droit implicite. Masquer un bouton côté UI n'est
+ * jamais une autorisation, cette garde est rejouée pour chaque requête.
+ */
+export function requireQualityCapability(capability: QualityCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (!req.user || typeof req.user.id !== "number") {
+      next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
+      return;
+    }
+    if (!roleHasQualityCapability(req.user.role, capability)) {
+      next(
+        new HttpError(
+          403,
+          "QUALITY_CAPABILITY_REQUIRED",
+          `La capacité Qualité '${capability}' est requise.`
+        )
+      );
+      return;
+    }
+    next();
+  };
+}

--- a/src/module/qualite/repository/quality-360.repository.ts
+++ b/src/module/qualite/repository/quality-360.repository.ts
@@ -1,0 +1,2846 @@
+// Repository Qualité 360 (#228).
+//
+// Toutes les décisions passent par une transaction, un verrou optimiste, un
+// journal append-only et — dès qu'un effet est transactionnel — un reçu
+// d'idempotence. Aucun code métier n'est calculé côté client, aucun MAX()+1.
+
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
+import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+
+import {
+  assertDerogationApprovalSeparation,
+  assertDerogationTransition,
+  assertManualVerdictOverride,
+  assertNcClosureAllowed,
+  assertNcTransition,
+  assertOptimisticVersion,
+  assertPlanContentMutable,
+  assertPlanTransition,
+  assertPreviewFresh,
+  assertReleaseSeparation,
+  decideQualityReceipt,
+  executionStatusForVerdict,
+  legacyResultToVerdict,
+  normalizeQualityIdempotencyKey,
+  qualityRequestHash,
+  qualitySha256,
+  verdictToLegacyResult,
+  type QualityDerogationStatus,
+  type QualityNcStatus,
+  type QualityPlanStatus,
+  type QualityVerdict,
+} from "../domain/quality-policy";
+import {
+  assertCharacteristicSpec,
+  assertNoApplicabilityOverlap,
+  assertSnapshotIntegrity,
+  buildPlanSnapshot,
+  characteristicsFromSnapshot,
+  computeExecutionVerdict,
+  evaluateSample,
+  requiredSampleCount,
+  selectApplicablePlan,
+  type ApplicabilityContext,
+  type PlanCandidate,
+  type QualityCharacteristicSpec,
+  type QualitySampleValue,
+} from "../domain/quality-plan";
+import {
+  assertQuantityLedger,
+  assertSourceRef,
+  derogationStatusAfterConsumption,
+  evaluateDerogationUsage,
+  evaluateInstrumentUsage,
+  evaluateQualityEligibility,
+  evaluateReleaseRequest,
+  releasableQty,
+  type DerogationState,
+  type EligibilityTarget,
+  type InstrumentState,
+  type QualityEligibilityPurpose,
+  type QuantityLedger,
+} from "../domain/quality-release";
+import type {
+  ConsumeDerogationBodyDTO,
+  CreateDerogationBodyDTO,
+  CreateExecutionBodyDTO,
+  CreatePlanBodyDTO,
+  DecideExecutionBodyDTO,
+  DerogationTransitionBodyDTO,
+  EligibilityQueryDTO,
+  ExecutionPreviewBodyDTO,
+  ListDerogationsQueryDTO,
+  ListExecutionsQueryDTO,
+  ListPlansQueryDTO,
+  NcTransitionBodyDTO,
+  PlanApplicabilityQueryDTO,
+  PlanTransitionBodyDTO,
+  RecordMeasurementsBodyDTO,
+  UpdatePlanBodyDTO,
+  UpsertAnalysisBodyDTO,
+} from "../validators/quality-360.validators";
+import type { AuditContext } from "./qualite.repository";
+
+type DbQueryer = Pick<PoolClient, "query">;
+
+export type QualityActor = AuditContext & { role: string | null; request_id: string | null };
+
+const METROLOGY_SETTING_KEY = "metrologie.block_on_overdue_critical";
+
+/* ========================================================================== */
+/* Helpers transversaux                                                       */
+/* ========================================================================== */
+
+async function insertAuditLog(
+  tx: DbQueryer,
+  actor: QualityActor,
+  entry: { action: string; entity_type: string; entity_id: string; details?: Record<string, unknown> }
+): Promise<void> {
+  await repoInsertAuditLog({
+    user_id: actor.user_id,
+    body: {
+      event_type: "ACTION",
+      action: entry.action,
+      page_key: actor.page_key,
+      entity_type: entry.entity_type,
+      entity_id: entry.entity_id,
+      path: actor.path,
+      client_session_id: actor.client_session_id,
+      details: entry.details ?? null,
+    },
+    ip: actor.ip,
+    user_agent: actor.user_agent,
+    device_type: actor.device_type,
+    os: actor.os,
+    browser: actor.browser,
+    tx,
+  });
+}
+
+/**
+ * Journal métier append-only. Écrit dans la MÊME transaction que la décision :
+ * une décision sans trace est impossible.
+ */
+async function insertQualityEvent(
+  tx: DbQueryer,
+  params: {
+    entity_type: "CONTROL" | "NON_CONFORMITY" | "ACTION" | "PLAN" | "DEROGATION" | "RELEASE";
+    entity_id: string;
+    event_type: string;
+    actor: QualityActor;
+    old_values: Record<string, unknown> | null;
+    new_values: Record<string, unknown> | null;
+    correlation_id: string;
+    idempotency_key?: string | null;
+    rule_code?: string | null;
+    reason?: string | null;
+  }
+): Promise<void> {
+  await tx.query(
+    `
+      INSERT INTO public.quality_event_log (
+        entity_type, entity_id, event_type, old_values, new_values, user_id,
+        correlation_id, idempotency_key, rule_code, reason, request_id, source
+      )
+      VALUES (
+        $1::public.quality_entity_type, $2::uuid, $3, $4::jsonb, $5::jsonb, $6,
+        $7::uuid, $8, $9, $10, $11, 'api'
+      )
+    `,
+    [
+      params.entity_type,
+      params.entity_id,
+      params.event_type,
+      params.old_values ? JSON.stringify(params.old_values) : null,
+      params.new_values ? JSON.stringify(params.new_values) : null,
+      params.actor.user_id,
+      params.correlation_id,
+      params.idempotency_key ?? null,
+      params.rule_code ?? null,
+      params.reason ?? null,
+      params.actor.request_id,
+    ]
+  );
+}
+
+async function acquireIdempotency(params: {
+  client: PoolClient;
+  actor: QualityActor;
+  idempotencyKeyRaw: string | null | undefined;
+  commandType: string;
+  requestPayload: unknown;
+}): Promise<{ idempotencyKey: string; requestHash: string; replay: Record<string, unknown> | null }> {
+  const idempotencyKey = normalizeQualityIdempotencyKey(params.idempotencyKeyRaw);
+  const requestHash = qualityRequestHash(params.commandType, params.requestPayload);
+  await params.client.query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
+    `quality:${params.actor.user_id}:${idempotencyKey}`,
+  ]);
+  const existing = await params.client.query<{ request_hash: string; result_payload: Record<string, unknown> }>(
+    `
+      SELECT request_hash, result_payload
+      FROM public.quality_command_receipts
+      WHERE actor_user_id = $1 AND idempotency_key = $2
+      LIMIT 1
+    `,
+    [params.actor.user_id, idempotencyKey]
+  );
+  const receipt = existing.rows[0] ?? null;
+  const decision = decideQualityReceipt(receipt?.request_hash, requestHash);
+  if (decision === "CONFLICT") {
+    throw new HttpError(
+      409,
+      "IDEMPOTENCY_KEY_REUSED",
+      "Cette Idempotency-Key a déjà été utilisée avec un autre contenu."
+    );
+  }
+  return { idempotencyKey, requestHash, replay: decision === "REPLAY" ? receipt?.result_payload ?? null : null };
+}
+
+async function saveReceipt(params: {
+  client: PoolClient;
+  actor: QualityActor;
+  idempotencyKey: string;
+  requestHash: string;
+  commandType: string;
+  aggregateType: "PLAN" | "CONTROL" | "NON_CONFORMITY" | "ACTION" | "DEROGATION" | "RELEASE" | "DISPOSITION";
+  aggregateId: string;
+  requestPayload: unknown;
+  resultPayload: unknown;
+  correlationId: string;
+}): Promise<void> {
+  await params.client.query(
+    `
+      INSERT INTO public.quality_command_receipts (
+        actor_user_id, idempotency_key, request_hash, command_type,
+        aggregate_type, aggregate_id, request_payload, result_payload, correlation_id
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9::uuid)
+    `,
+    [
+      params.actor.user_id,
+      params.idempotencyKey,
+      params.requestHash,
+      params.commandType,
+      params.aggregateType,
+      params.aggregateId,
+      JSON.stringify(params.requestPayload ?? null),
+      JSON.stringify(params.resultPayload ?? null),
+      params.correlationId,
+    ]
+  );
+}
+
+async function withTransaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const out = await fn(client);
+    await client.query("COMMIT");
+    return out;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+function toNumber(value: unknown, fallback = 0): number {
+  if (value === null || value === undefined) return fallback;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+function sortDirection(dir: "asc" | "desc"): "ASC" | "DESC" {
+  return dir === "asc" ? "ASC" : "DESC";
+}
+
+async function metrologyPolicy(q: DbQueryer): Promise<{ block_on_overdue_critical: boolean }> {
+  try {
+    const res = await q.query<{ value_json: unknown }>(
+      `SELECT value_json FROM public.erp_settings WHERE key = $1`,
+      [METROLOGY_SETTING_KEY]
+    );
+    const raw = res.rows[0]?.value_json ?? null;
+    const enabled = Boolean(raw && typeof raw === "object" && (raw as { enabled?: unknown }).enabled === true);
+    return { block_on_overdue_critical: enabled };
+  } catch {
+    return { block_on_overdue_critical: false };
+  }
+}
+
+/* ========================================================================== */
+/* Plans de contrôle                                                          */
+/* ========================================================================== */
+
+export type QualityPlanRow = {
+  id: string;
+  code: string;
+  version: number;
+  label: string;
+  status: QualityPlanStatus;
+  trigger_type: string;
+  article_id: string | null;
+  piece_technique_id: string | null;
+  piece_version_id: string | null;
+  famille_id: string | null;
+  operation_code: string | null;
+  fournisseur_id: string | null;
+  sampling_rule: string;
+  sampling_value: string | number | null;
+  sampling_justification: string | null;
+  owner_user_id: number | null;
+  revision_reason: string | null;
+  effective_from: string | null;
+  effective_to: string | null;
+  supersedes_plan_id: string | null;
+  published_at: string | null;
+  published_by: number | null;
+  archived_at: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: number;
+  updated_by: number;
+  characteristic_count?: number;
+};
+
+const PLAN_COLUMNS = `
+  p.id, p.code, p.version, p.label, p.status, p.trigger_type,
+  p.article_id, p.piece_technique_id, p.piece_version_id, p.famille_id,
+  p.operation_code, p.fournisseur_id,
+  p.sampling_rule, p.sampling_value, p.sampling_justification,
+  p.owner_user_id, p.revision_reason, p.effective_from, p.effective_to,
+  p.supersedes_plan_id, p.published_at, p.published_by, p.archived_at,
+  p.created_at, p.updated_at, p.created_by, p.updated_by
+`;
+
+const PLAN_SORT_COLUMNS: Record<ListPlansQueryDTO["sortBy"], string> = {
+  code: "p.code",
+  version: "p.version",
+  label: "p.label",
+  status: "p.status",
+  updated_at: "p.updated_at",
+  published_at: "p.published_at",
+};
+
+export async function repoListPlans(
+  filters: ListPlansQueryDTO
+): Promise<{ items: QualityPlanRow[]; total: number }> {
+  const where: string[] = ["TRUE"];
+  const values: unknown[] = [];
+  // `$?` est remplacé par l'index du paramètre ajouté : toutes les occurrences
+  // partagent la même valeur, ce qui évite un placeholder orphelin.
+  const push = (sql: string, value: unknown) => {
+    values.push(value);
+    where.push(sql.replace(/\$\?/g, `$${values.length}`));
+  };
+
+  if (filters.q) push("(p.code ILIKE $? OR p.label ILIKE $?)", `%${filters.q}%`);
+  if (filters.status) push("p.status = $?", filters.status);
+  if (filters.trigger_type) push("p.trigger_type = $?", filters.trigger_type);
+  if (filters.article_id) push("p.article_id = $?::uuid", filters.article_id);
+  if (filters.piece_technique_id) push("p.piece_technique_id = $?::uuid", filters.piece_technique_id);
+  if (filters.piece_version_id) push("p.piece_version_id = $?::uuid", filters.piece_version_id);
+  if (filters.famille_id) push("p.famille_id = $?::uuid", filters.famille_id);
+  if (filters.fournisseur_id) push("p.fournisseur_id = $?::uuid", filters.fournisseur_id);
+
+  const whereSql = where.join(" AND ");
+
+  const totalRes = await pool.query<{ total: number }>(
+    `SELECT COUNT(*)::int AS total FROM public.quality_control_plan p WHERE ${whereSql}`,
+    values
+  );
+
+  const limit = filters.pageSize;
+  const offset = (filters.page - 1) * filters.pageSize;
+  const itemsRes = await pool.query<QualityPlanRow>(
+    `
+      SELECT ${PLAN_COLUMNS},
+        (SELECT COUNT(*)::int FROM public.quality_control_plan_characteristic c WHERE c.plan_id = p.id) AS characteristic_count
+      FROM public.quality_control_plan p
+      WHERE ${whereSql}
+      ORDER BY ${PLAN_SORT_COLUMNS[filters.sortBy]} ${sortDirection(filters.sortDir)} NULLS LAST, p.code ASC, p.version DESC
+      LIMIT ${limit} OFFSET ${offset}
+    `,
+    values
+  );
+
+  return { items: itemsRes.rows, total: totalRes.rows[0]?.total ?? 0 };
+}
+
+async function selectPlanCharacteristics(
+  q: DbQueryer,
+  planId: string
+): Promise<QualityCharacteristicSpec[]> {
+  const res = await q.query<{
+    characteristic_key: string;
+    position: number;
+    label: string;
+    characteristic_type: string;
+    value_kind: string;
+    unit: string | null;
+    nominal: string | null;
+    tolerance_min: string | null;
+    tolerance_max: string | null;
+    precision_digits: number | null;
+    expected_boolean: boolean | null;
+    allowed_values: string[] | null;
+    criticality: string;
+    mandatory: boolean;
+    requires_instrument: boolean;
+    instrument_category: string | null;
+    method: string | null;
+    acceptance_rule: string | null;
+    sampling_rule: string;
+    sampling_value: string | null;
+    sampling_justification: string | null;
+    trigger_type: string;
+  }>(
+    `
+      SELECT characteristic_key, position, label, characteristic_type, value_kind, unit,
+             nominal, tolerance_min, tolerance_max, precision_digits, expected_boolean,
+             allowed_values, criticality, mandatory, requires_instrument, instrument_category,
+             method, acceptance_rule, sampling_rule, sampling_value, sampling_justification, trigger_type
+      FROM public.quality_control_plan_characteristic
+      WHERE plan_id = $1::uuid
+      ORDER BY position ASC, characteristic_key ASC
+    `,
+    [planId]
+  );
+
+  return res.rows.map((row) => ({
+    key: row.characteristic_key,
+    position: row.position,
+    label: row.label,
+    characteristic_type: row.characteristic_type as QualityCharacteristicSpec["characteristic_type"],
+    value_kind: row.value_kind as QualityCharacteristicSpec["value_kind"],
+    unit: row.unit,
+    nominal: row.nominal === null ? null : Number(row.nominal),
+    tolerance_min: row.tolerance_min === null ? null : Number(row.tolerance_min),
+    tolerance_max: row.tolerance_max === null ? null : Number(row.tolerance_max),
+    precision: row.precision_digits,
+    expected_boolean: row.expected_boolean,
+    allowed_values: row.allowed_values,
+    criticality: row.criticality as QualityCharacteristicSpec["criticality"],
+    mandatory: row.mandatory,
+    requires_instrument: row.requires_instrument,
+    instrument_category: row.instrument_category,
+    method: row.method,
+    acceptance_rule: row.acceptance_rule,
+    sampling: {
+      rule: row.sampling_rule as QualityCharacteristicSpec["sampling"]["rule"],
+      value: row.sampling_value === null ? null : Number(row.sampling_value),
+      justification: row.sampling_justification,
+    },
+    trigger: row.trigger_type as QualityCharacteristicSpec["trigger"],
+  }));
+}
+
+async function selectPlanRow(q: DbQueryer, id: string, forUpdate = false): Promise<QualityPlanRow | null> {
+  const res = await q.query<QualityPlanRow>(
+    `SELECT ${PLAN_COLUMNS} FROM public.quality_control_plan p WHERE p.id = $1::uuid ${forUpdate ? "FOR UPDATE" : ""}`,
+    [id]
+  );
+  return res.rows[0] ?? null;
+}
+
+export async function repoGetPlan(
+  id: string
+): Promise<{ plan: QualityPlanRow; characteristics: QualityCharacteristicSpec[] } | null> {
+  const plan = await selectPlanRow(pool, id);
+  if (!plan) return null;
+  const characteristics = await selectPlanCharacteristics(pool, id);
+  return { plan, characteristics };
+}
+
+async function replacePlanCharacteristics(
+  tx: DbQueryer,
+  planId: string,
+  characteristics: readonly QualityCharacteristicSpec[]
+): Promise<void> {
+  const keys = new Set<string>();
+  const positions = new Set<number>();
+  for (const spec of characteristics) {
+    assertCharacteristicSpec(spec);
+    if (keys.has(spec.key)) {
+      throw new HttpError(422, "QUALITY_CHARACTERISTIC_KEY_DUPLICATE", `Clé dupliquée : ${spec.key}.`);
+    }
+    if (positions.has(spec.position)) {
+      throw new HttpError(
+        422,
+        "QUALITY_CHARACTERISTIC_POSITION_DUPLICATE",
+        `Position dupliquée : ${spec.position}.`
+      );
+    }
+    keys.add(spec.key);
+    positions.add(spec.position);
+  }
+
+  await tx.query(`DELETE FROM public.quality_control_plan_characteristic WHERE plan_id = $1::uuid`, [planId]);
+
+  for (const spec of characteristics) {
+    await tx.query(
+      `
+        INSERT INTO public.quality_control_plan_characteristic (
+          plan_id, characteristic_key, position, label, characteristic_type, value_kind,
+          unit, nominal, tolerance_min, tolerance_max, precision_digits, expected_boolean,
+          allowed_values, criticality, mandatory, requires_instrument, instrument_category,
+          method, acceptance_rule, sampling_rule, sampling_value, sampling_justification, trigger_type
+        )
+        VALUES (
+          $1::uuid, $2, $3, $4, $5, $6,
+          $7, $8, $9, $10, $11, $12,
+          $13::jsonb, $14, $15, $16, $17,
+          $18, $19, $20, $21, $22, $23
+        )
+      `,
+      [
+        planId,
+        spec.key,
+        spec.position,
+        spec.label,
+        spec.characteristic_type,
+        spec.value_kind,
+        spec.unit,
+        spec.nominal,
+        spec.tolerance_min,
+        spec.tolerance_max,
+        spec.precision,
+        spec.expected_boolean,
+        spec.allowed_values ? JSON.stringify(spec.allowed_values) : null,
+        spec.criticality,
+        spec.mandatory,
+        spec.requires_instrument,
+        spec.instrument_category,
+        spec.method,
+        spec.acceptance_rule,
+        spec.sampling.rule,
+        spec.sampling.value,
+        spec.sampling.justification,
+        spec.trigger,
+      ]
+    );
+  }
+}
+
+function toSpec(input: CreatePlanBodyDTO["characteristics"][number]): QualityCharacteristicSpec {
+  return {
+    key: input.characteristic_key,
+    position: input.position,
+    label: input.label,
+    characteristic_type: input.characteristic_type,
+    value_kind: input.value_kind,
+    unit: input.unit,
+    nominal: input.nominal,
+    tolerance_min: input.tolerance_min,
+    tolerance_max: input.tolerance_max,
+    precision: input.precision,
+    expected_boolean: input.expected_boolean,
+    allowed_values: input.allowed_values,
+    criticality: input.criticality,
+    mandatory: input.mandatory,
+    requires_instrument: input.requires_instrument,
+    instrument_category: input.instrument_category,
+    method: input.method,
+    acceptance_rule: input.acceptance_rule,
+    sampling: input.sampling,
+    trigger: input.trigger,
+  };
+}
+
+export async function repoCreatePlan(params: {
+  body: CreatePlanBodyDTO;
+  actor: QualityActor;
+  idempotencyKey: string | null | undefined;
+}): Promise<{ plan: QualityPlanRow; characteristics: QualityCharacteristicSpec[] }> {
+  return withTransaction(async (client) => {
+    const idem = await acquireIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "quality.plan.create",
+      requestPayload: params.body,
+    });
+    if (idem.replay) {
+      const replayed = await repoGetPlan(String(idem.replay.plan_id));
+      if (replayed) return replayed;
+    }
+
+    // Le code est serveur : séquence whitelistée, jamais MAX()+1.
+    const code = await generateTransactionalBusinessCode(client, { prefix: "PC" });
+    const insert = await client.query<{ id: string; correlation_id: string }>(
+      `
+        INSERT INTO public.quality_control_plan (
+          code, version, label, status, trigger_type,
+          article_id, piece_technique_id, piece_version_id, famille_id, operation_code, fournisseur_id,
+          sampling_rule, sampling_value, sampling_justification,
+          owner_user_id, revision_reason, effective_from, effective_to,
+          created_by, updated_by
+        )
+        VALUES (
+          $1, 1, $2, 'DRAFT', $3,
+          $4::uuid, $5::uuid, $6::uuid, $7::uuid, $8, $9::uuid,
+          $10, $11, $12,
+          $13, $14, $15::timestamptz, $16::timestamptz,
+          $17, $17
+        )
+        RETURNING id, correlation_id
+      `,
+      [
+        code,
+        params.body.label,
+        params.body.trigger_type,
+        params.body.article_id ?? null,
+        params.body.piece_technique_id ?? null,
+        params.body.piece_version_id ?? null,
+        params.body.famille_id ?? null,
+        params.body.operation_code ?? null,
+        params.body.fournisseur_id ?? null,
+        params.body.sampling.rule,
+        params.body.sampling.value,
+        params.body.sampling.justification,
+        params.body.owner_user_id ?? null,
+        params.body.revision_reason ?? null,
+        params.body.effective_from ?? null,
+        params.body.effective_to ?? null,
+        params.actor.user_id,
+      ]
+    );
+
+    const planId = insert.rows[0]!.id;
+    const correlationId = insert.rows[0]!.correlation_id;
+    await replacePlanCharacteristics(client, planId, params.body.characteristics.map(toSpec));
+
+    await insertQualityEvent(client, {
+      entity_type: "PLAN",
+      entity_id: planId,
+      event_type: "PLAN_CREATED",
+      actor: params.actor,
+      old_values: null,
+      new_values: { code, label: params.body.label, trigger_type: params.body.trigger_type },
+      correlation_id: correlationId,
+      idempotency_key: idem.idempotencyKey,
+    });
+    await insertAuditLog(client, params.actor, {
+      action: "qualite.plans.create",
+      entity_type: "quality_control_plan",
+      entity_id: planId,
+      details: { code, characteristics: params.body.characteristics.length },
+    });
+    await saveReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: idem.idempotencyKey,
+      requestHash: idem.requestHash,
+      commandType: "quality.plan.create",
+      aggregateType: "PLAN",
+      aggregateId: planId,
+      requestPayload: params.body,
+      resultPayload: { plan_id: planId, code },
+      correlationId,
+    });
+
+    const plan = await selectPlanRow(client, planId);
+    const characteristics = await selectPlanCharacteristics(client, planId);
+    return { plan: plan!, characteristics };
+  });
+}
+
+export async function repoUpdatePlan(params: {
+  id: string;
+  body: UpdatePlanBodyDTO;
+  actor: QualityActor;
+}): Promise<{ plan: QualityPlanRow; characteristics: QualityCharacteristicSpec[] } | null> {
+  return withTransaction(async (client) => {
+    const before = await selectPlanRow(client, params.id, true);
+    if (!before) return null;
+
+    assertOptimisticVersion({
+      expectedUpdatedAt: params.body.expected_updated_at,
+      currentUpdatedAt: before.updated_at,
+    });
+    assertPlanContentMutable(before.status);
+
+    await client.query(
+      `
+        UPDATE public.quality_control_plan
+        SET label = COALESCE($2, label),
+            sampling_rule = COALESCE($3, sampling_rule),
+            sampling_value = CASE WHEN $3 IS NULL THEN sampling_value ELSE $4 END,
+            sampling_justification = CASE WHEN $3 IS NULL THEN sampling_justification ELSE $5 END,
+            owner_user_id = COALESCE($6, owner_user_id),
+            revision_reason = COALESCE($7, revision_reason),
+            effective_from = COALESCE($8::timestamptz, effective_from),
+            effective_to = COALESCE($9::timestamptz, effective_to),
+            updated_by = $10
+        WHERE id = $1::uuid
+      `,
+      [
+        params.id,
+        params.body.label ?? null,
+        params.body.sampling?.rule ?? null,
+        params.body.sampling?.value ?? null,
+        params.body.sampling?.justification ?? null,
+        params.body.owner_user_id ?? null,
+        params.body.revision_reason ?? null,
+        params.body.effective_from ?? null,
+        params.body.effective_to ?? null,
+        params.actor.user_id,
+      ]
+    );
+
+    if (params.body.characteristics) {
+      await replacePlanCharacteristics(client, params.id, params.body.characteristics.map(toSpec));
+    }
+
+    const after = await selectPlanRow(client, params.id);
+    await insertQualityEvent(client, {
+      entity_type: "PLAN",
+      entity_id: params.id,
+      event_type: "PLAN_UPDATED",
+      actor: params.actor,
+      old_values: before as unknown as Record<string, unknown>,
+      new_values: after as unknown as Record<string, unknown>,
+      correlation_id: before.id,
+    });
+    await insertAuditLog(client, params.actor, {
+      action: "qualite.plans.update",
+      entity_type: "quality_control_plan",
+      entity_id: params.id,
+    });
+
+    return { plan: after!, characteristics: await selectPlanCharacteristics(client, params.id) };
+  });
+}
+
+async function publishedPlanCandidates(q: DbQueryer, excludePlanId: string): Promise<PlanCandidate[]> {
+  const res = await q.query<QualityPlanRow>(
+    `SELECT ${PLAN_COLUMNS} FROM public.quality_control_plan p WHERE p.status = 'PUBLISHED' AND p.id <> $1::uuid`,
+    [excludePlanId]
+  );
+  return res.rows.map(planRowToCandidate);
+}
+
+function planRowToCandidate(row: QualityPlanRow): PlanCandidate {
+  return {
+    id: row.id,
+    code: row.code,
+    version: row.version,
+    status: row.status,
+    scope: {
+      article_id: row.article_id,
+      piece_technique_id: row.piece_technique_id,
+      piece_version_id: row.piece_version_id,
+      famille_id: row.famille_id,
+      operation_code: row.operation_code,
+      fournisseur_id: row.fournisseur_id,
+      trigger: row.trigger_type as PlanCandidate["scope"]["trigger"],
+      effective_from: row.effective_from,
+      effective_to: row.effective_to,
+    },
+  };
+}
+
+export async function repoTransitionPlan(params: {
+  id: string;
+  body: PlanTransitionBodyDTO;
+  actor: QualityActor;
+}): Promise<{ plan: QualityPlanRow; characteristics: QualityCharacteristicSpec[] } | null> {
+  return withTransaction(async (client) => {
+    const before = await selectPlanRow(client, params.id, true);
+    if (!before) return null;
+
+    assertOptimisticVersion({
+      expectedUpdatedAt: params.body.expected_updated_at,
+      currentUpdatedAt: before.updated_at,
+    });
+    assertPlanTransition(before.status, params.body.target_status);
+
+    if (params.body.target_status === "PUBLISHED") {
+      const characteristics = await selectPlanCharacteristics(client, params.id);
+      if (characteristics.length === 0) {
+        throw new HttpError(
+          422,
+          "QUALITY_PLAN_WITHOUT_CHARACTERISTIC",
+          "Un plan sans caractéristique ne peut pas être publié."
+        );
+      }
+      for (const spec of characteristics) assertCharacteristicSpec(spec);
+      assertNoApplicabilityOverlap({
+        candidate: planRowToCandidate(before),
+        published: await publishedPlanCandidates(client, params.id),
+      });
+    }
+
+    const timestamps =
+      params.body.target_status === "PUBLISHED"
+        ? `published_at = now(), published_by = $3`
+        : params.body.target_status === "ARCHIVED"
+          ? `archived_at = now(), archived_by = $3`
+          : params.body.target_status === "IN_REVIEW"
+            ? `submitted_at = now(), submitted_by = $3`
+            : `submitted_at = submitted_at`;
+
+    await client.query(
+      `
+        UPDATE public.quality_control_plan
+        SET status = $2, ${timestamps}, updated_by = $3
+        WHERE id = $1::uuid
+      `,
+      [params.id, params.body.target_status, params.actor.user_id]
+    );
+
+    const after = await selectPlanRow(client, params.id);
+    await insertQualityEvent(client, {
+      entity_type: "PLAN",
+      entity_id: params.id,
+      event_type: `PLAN_${params.body.target_status}`,
+      actor: params.actor,
+      old_values: { status: before.status },
+      new_values: { status: params.body.target_status },
+      correlation_id: before.id,
+      rule_code: "QUALITY_PLAN_TRANSITION",
+      reason: params.body.reason ?? null,
+    });
+    await insertAuditLog(client, params.actor, {
+      action: `qualite.plans.${params.body.target_status.toLowerCase()}`,
+      entity_type: "quality_control_plan",
+      entity_id: params.id,
+      details: { from: before.status, to: params.body.target_status, reason: params.body.reason ?? null },
+    });
+
+    return { plan: after!, characteristics: await selectPlanCharacteristics(client, params.id) };
+  });
+}
+
+/** Crée la version suivante d'un plan publié : l'historique n'est jamais modifié. */
+export async function repoRevisePlan(params: {
+  id: string;
+  revisionReason: string;
+  actor: QualityActor;
+}): Promise<{ plan: QualityPlanRow; characteristics: QualityCharacteristicSpec[] } | null> {
+  return withTransaction(async (client) => {
+    const source = await selectPlanRow(client, params.id, true);
+    if (!source) return null;
+
+    const nextVersionRes = await client.query<{ next_version: number }>(
+      `SELECT COALESCE(MAX(version), 0) + 1 AS next_version FROM public.quality_control_plan WHERE code = $1`,
+      [source.code]
+    );
+    const nextVersion = nextVersionRes.rows[0]?.next_version ?? source.version + 1;
+
+    const insert = await client.query<{ id: string; correlation_id: string }>(
+      `
+        INSERT INTO public.quality_control_plan (
+          code, version, label, status, trigger_type,
+          article_id, piece_technique_id, piece_version_id, famille_id, operation_code, fournisseur_id,
+          sampling_rule, sampling_value, sampling_justification,
+          owner_user_id, revision_reason, effective_from, effective_to, supersedes_plan_id,
+          created_by, updated_by
+        )
+        SELECT code, $2, label, 'DRAFT', trigger_type,
+               article_id, piece_technique_id, piece_version_id, famille_id, operation_code, fournisseur_id,
+               sampling_rule, sampling_value, sampling_justification,
+               owner_user_id, $3, effective_from, effective_to, id,
+               $4, $4
+        FROM public.quality_control_plan
+        WHERE id = $1::uuid
+        RETURNING id, correlation_id
+      `,
+      [params.id, nextVersion, params.revisionReason, params.actor.user_id]
+    );
+
+    const newId = insert.rows[0]!.id;
+    await client.query(
+      `
+        INSERT INTO public.quality_control_plan_characteristic (
+          plan_id, characteristic_key, position, label, characteristic_type, value_kind,
+          unit, nominal, tolerance_min, tolerance_max, precision_digits, expected_boolean,
+          allowed_values, criticality, mandatory, requires_instrument, instrument_category,
+          method, acceptance_rule, sampling_rule, sampling_value, sampling_justification, trigger_type
+        )
+        SELECT $2::uuid, characteristic_key, position, label, characteristic_type, value_kind,
+               unit, nominal, tolerance_min, tolerance_max, precision_digits, expected_boolean,
+               allowed_values, criticality, mandatory, requires_instrument, instrument_category,
+               method, acceptance_rule, sampling_rule, sampling_value, sampling_justification, trigger_type
+        FROM public.quality_control_plan_characteristic
+        WHERE plan_id = $1::uuid
+      `,
+      [params.id, newId]
+    );
+
+    await insertQualityEvent(client, {
+      entity_type: "PLAN",
+      entity_id: newId,
+      event_type: "PLAN_REVISED",
+      actor: params.actor,
+      old_values: { plan_id: params.id, version: source.version },
+      new_values: { plan_id: newId, version: nextVersion },
+      correlation_id: insert.rows[0]!.correlation_id,
+      reason: params.revisionReason,
+    });
+    await insertAuditLog(client, params.actor, {
+      action: "qualite.plans.revise",
+      entity_type: "quality_control_plan",
+      entity_id: newId,
+      details: { source_plan_id: params.id, version: nextVersion },
+    });
+
+    return { plan: (await selectPlanRow(client, newId))!, characteristics: await selectPlanCharacteristics(client, newId) };
+  });
+}
+
+export async function repoPlanApplicability(query: PlanApplicabilityQueryDTO): Promise<{
+  plan: PlanCandidate;
+  label: string;
+  specificity: number;
+  discarded: Array<{ id: string; reason: string }>;
+  characteristics: Array<QualityCharacteristicSpec & { required_samples: number | null }>;
+}> {
+  const resolved = await resolveApplicablePlan(pool, query);
+  return {
+    plan: resolved.plan,
+    label: resolved.label,
+    specificity: resolved.specificity,
+    discarded: resolved.discarded,
+    characteristics: resolved.characteristics.map((spec) => ({ ...spec, required_samples: null })),
+  };
+}
+
+/* ========================================================================== */
+/* Exécutions de contrôle                                                     */
+/* ========================================================================== */
+
+async function buildExecutionSnapshot(
+  q: DbQueryer,
+  body: ExecutionPreviewBodyDTO
+): Promise<{
+  plan: PlanCandidate;
+  characteristics: QualityCharacteristicSpec[];
+  snapshot: { payload: Record<string, unknown>; sha256: string };
+}> {
+  const applicability = await resolveApplicablePlan(q, {
+    trigger: body.trigger,
+    article_id: body.article_id ?? undefined,
+    piece_technique_id: body.piece_technique_id ?? undefined,
+    piece_version_id: body.piece_version_id ?? undefined,
+    famille_id: body.famille_id ?? undefined,
+    operation_code: body.operation_code ?? undefined,
+    fournisseur_id: body.fournisseur_id ?? undefined,
+  });
+
+  const snapshot = buildPlanSnapshot({
+    plan: {
+      id: applicability.plan.id,
+      code: applicability.plan.code,
+      version: applicability.plan.version,
+      label: applicability.label,
+      trigger: body.trigger,
+      scope: applicability.plan.scope,
+      published_at: applicability.published_at,
+    },
+    characteristics: applicability.characteristics,
+    article: { id: body.article_id ?? null, code: null, designation: null },
+    piece: {
+      id: body.piece_technique_id ?? null,
+      code: null,
+      designation: null,
+      version: body.piece_version_id ?? null,
+    },
+    population: body.population,
+    sampling_algorithm: "cerp.quality.sampling.v1",
+    required_documents: [],
+  });
+
+  return { plan: applicability.plan, characteristics: applicability.characteristics, snapshot };
+}
+
+/**
+ * Sélection serveur du plan applicable : un seul chemin de code pour l'aperçu
+ * d'applicabilité, l'aperçu d'exécution et la création réelle.
+ */
+async function resolveApplicablePlan(
+  q: DbQueryer,
+  query: PlanApplicabilityQueryDTO
+): Promise<{
+  plan: PlanCandidate;
+  label: string;
+  published_at: string | null;
+  specificity: number;
+  discarded: Array<{ id: string; reason: string }>;
+  characteristics: QualityCharacteristicSpec[];
+}> {
+  const candidatesRes = await q.query<QualityPlanRow>(
+    `SELECT ${PLAN_COLUMNS} FROM public.quality_control_plan p WHERE p.trigger_type = $1`,
+    [query.trigger]
+  );
+  const context: ApplicabilityContext = {
+    article_id: query.article_id ?? null,
+    piece_technique_id: query.piece_technique_id ?? null,
+    piece_version_id: query.piece_version_id ?? null,
+    famille_id: query.famille_id ?? null,
+    operation_code: query.operation_code ?? null,
+    fournisseur_id: query.fournisseur_id ?? null,
+    trigger: query.trigger,
+  };
+  const selection = selectApplicablePlan(
+    candidatesRes.rows.map(planRowToCandidate),
+    context,
+    query.at ? new Date(query.at) : new Date()
+  );
+  const row = candidatesRes.rows.find((r) => r.id === selection.plan.id)!;
+  return {
+    plan: selection.plan,
+    label: row.label,
+    published_at: row.published_at,
+    specificity: selection.specificity,
+    discarded: selection.discarded,
+    characteristics: await selectPlanCharacteristics(q, selection.plan.id),
+  };
+}
+
+export type ExecutionPreview = {
+  plan: { id: string; code: string; version: number };
+  snapshot_sha256: string;
+  population: number;
+  unite: string;
+  characteristics: Array<QualityCharacteristicSpec & { required_samples: number }>;
+};
+
+export async function repoPreviewExecution(body: ExecutionPreviewBodyDTO): Promise<ExecutionPreview> {
+  assertSourceRef({ source_type: body.source_type, source_id: body.source_id });
+  const built = await buildExecutionSnapshot(pool, body);
+  return {
+    plan: { id: built.plan.id, code: built.plan.code, version: built.plan.version },
+    snapshot_sha256: built.snapshot.sha256,
+    population: body.population,
+    unite: body.unite,
+    characteristics: built.characteristics.map((spec) => ({
+      ...spec,
+      required_samples: requiredSampleCount(spec, body.population),
+    })),
+  };
+}
+
+export type ExecutionDetail = {
+  id: string;
+  reference: string;
+  status: string;
+  verdict: QualityVerdict;
+  verdict_computed: QualityVerdict | null;
+  control_type: string;
+  trigger_type: string | null;
+  source_type: string | null;
+  source_id: string | null;
+  plan: { id: string; code: string; version: number } | null;
+  plan_snapshot_sha256: string | null;
+  snapshot_integrity: "OK" | "TAMPERED" | "ABSENT";
+  unite: string | null;
+  ledger: QuantityLedger;
+  releasable_qty: number;
+  control_date: string;
+  validation_date: string | null;
+  created_at: string;
+  updated_at: string;
+  controlled_by: number;
+  measurements: Array<{
+    id: string;
+    characteristic_key: string | null;
+    sample_no: number | null;
+    measured_value: number | null;
+    value_boolean: boolean | null;
+    value_text: string | null;
+    unit: string | null;
+    result: string | null;
+    evaluation_code: string | null;
+    instrument_id: string | null;
+    revision: number;
+    comment: string | null;
+  }>;
+};
+
+type ExecutionRow = {
+  id: string;
+  reference: string;
+  status: string;
+  result: "OK" | "NOK" | "PARTIAL" | null;
+  verdict: QualityVerdict | null;
+  verdict_computed: QualityVerdict | null;
+  control_type: string;
+  trigger_type: string | null;
+  source_type: string | null;
+  source_id: string | null;
+  plan_id: string | null;
+  plan_version: number | null;
+  plan_code: string | null;
+  plan_snapshot: unknown;
+  plan_snapshot_sha256: string | null;
+  unite: string | null;
+  qty_population: string | null;
+  qty_controlled: string;
+  qty_conforming: string;
+  qty_released: string;
+  qty_held: string;
+  qty_scrapped: string;
+  qty_reworked: string;
+  qty_sorted: string;
+  qty_returned: string;
+  qty_consumed: string;
+  control_date: string;
+  validation_date: string | null;
+  created_at: string;
+  updated_at: string;
+  controlled_by: number;
+  correlation_id: string;
+};
+
+const EXECUTION_COLUMNS = `
+  qc.id, qc.reference, qc.status::text AS status, qc.result::text AS result,
+  qc.verdict, qc.verdict_computed, qc.control_type::text AS control_type, qc.trigger_type,
+  qc.source_type, qc.source_id, qc.plan_id, qc.plan_version, qc.plan_snapshot, qc.plan_snapshot_sha256,
+  qc.unite, qc.qty_population, qc.qty_controlled, qc.qty_conforming, qc.qty_released, qc.qty_held,
+  qc.qty_scrapped, qc.qty_reworked, qc.qty_sorted, qc.qty_returned, qc.qty_consumed,
+  qc.control_date, qc.validation_date, qc.created_at, qc.updated_at, qc.controlled_by, qc.correlation_id,
+  p.code AS plan_code
+`;
+
+function rowToLedger(row: ExecutionRow): QuantityLedger {
+  return {
+    population: toNumber(row.qty_population),
+    controlled: toNumber(row.qty_controlled),
+    conforming: toNumber(row.qty_conforming),
+    released: toNumber(row.qty_released),
+    held: toNumber(row.qty_held),
+    scrapped: toNumber(row.qty_scrapped),
+    reworked: toNumber(row.qty_reworked),
+    sorted: toNumber(row.qty_sorted),
+    returned: toNumber(row.qty_returned),
+    consumed: toNumber(row.qty_consumed),
+  };
+}
+
+async function selectExecutionRow(q: DbQueryer, id: string, forUpdate = false): Promise<ExecutionRow | null> {
+  const res = await q.query<ExecutionRow>(
+    `
+      SELECT ${EXECUTION_COLUMNS}
+      FROM public.quality_control qc
+      LEFT JOIN public.quality_control_plan p ON p.id = qc.plan_id
+      WHERE qc.id = $1::uuid
+      ${forUpdate ? "FOR UPDATE OF qc" : ""}
+    `,
+    [id]
+  );
+  return res.rows[0] ?? null;
+}
+
+async function selectMeasurements(q: DbQueryer, controlId: string): Promise<ExecutionDetail["measurements"]> {
+  const res = await q.query<{
+    id: string;
+    characteristic_key: string | null;
+    sample_no: number | null;
+    measured_value: string | null;
+    value_boolean: boolean | null;
+    value_text: string | null;
+    unit: string | null;
+    result: string | null;
+    evaluation_code: string | null;
+    instrument_id: string | null;
+    revision: number;
+    comment: string | null;
+  }>(
+    `
+      SELECT id, characteristic_key, sample_no, measured_value, value_boolean, value_text,
+             unit, result::text AS result, evaluation_code, instrument_id, revision, comment
+      FROM public.quality_control_points
+      WHERE quality_control_id = $1::uuid
+      ORDER BY characteristic_key NULLS LAST, sample_no NULLS LAST, created_at ASC
+    `,
+    [controlId]
+  );
+  return res.rows.map((row) => ({
+    ...row,
+    measured_value: row.measured_value === null ? null : Number(row.measured_value),
+  }));
+}
+
+function buildExecutionDetail(row: ExecutionRow, measurements: ExecutionDetail["measurements"]): ExecutionDetail {
+  const ledger = rowToLedger(row);
+  let integrity: ExecutionDetail["snapshot_integrity"] = "ABSENT";
+  if (row.plan_snapshot_sha256) {
+    try {
+      assertSnapshotIntegrity(row.plan_snapshot, row.plan_snapshot_sha256);
+      integrity = "OK";
+    } catch {
+      integrity = "TAMPERED";
+    }
+  }
+  return {
+    id: row.id,
+    reference: row.reference,
+    status: row.status,
+    verdict: row.verdict ?? legacyResultToVerdict(row.result),
+    verdict_computed: row.verdict_computed,
+    control_type: row.control_type,
+    trigger_type: row.trigger_type,
+    source_type: row.source_type,
+    source_id: row.source_id,
+    plan: row.plan_id ? { id: row.plan_id, code: row.plan_code ?? "", version: row.plan_version ?? 1 } : null,
+    plan_snapshot_sha256: row.plan_snapshot_sha256,
+    snapshot_integrity: integrity,
+    unite: row.unite,
+    ledger,
+    releasable_qty: ledger.population > 0 ? releasableQty(ledger) : 0,
+    control_date: row.control_date,
+    validation_date: row.validation_date,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    controlled_by: row.controlled_by,
+    measurements,
+  };
+}
+
+export async function repoGetExecution(id: string): Promise<ExecutionDetail | null> {
+  const row = await selectExecutionRow(pool, id);
+  if (!row) return null;
+  return buildExecutionDetail(row, await selectMeasurements(pool, id));
+}
+
+const EXECUTION_SORT_COLUMNS: Record<ListExecutionsQueryDTO["sortBy"], string> = {
+  control_date: "qc.control_date",
+  updated_at: "qc.updated_at",
+  verdict: "qc.verdict",
+  reference: "qc.reference",
+};
+
+export async function repoListExecutions(
+  filters: ListExecutionsQueryDTO
+): Promise<{ items: ExecutionDetail[]; total: number }> {
+  const clauses: string[] = ["TRUE"];
+  const values: unknown[] = [];
+  const push = (sql: string, value: unknown) => {
+    values.push(value);
+    clauses.push(sql.replace("$?", `$${values.length}`));
+  };
+
+  if (filters.q) push("qc.reference ILIKE $?", `%${filters.q}%`);
+  if (filters.status) push("qc.status = $?::public.quality_control_status", filters.status);
+  if (filters.verdict) push("qc.verdict = $?", filters.verdict);
+  if (filters.trigger) push("qc.trigger_type = $?", filters.trigger);
+  if (filters.source_type) push("qc.source_type = $?", filters.source_type);
+  if (filters.source_id) push("qc.source_id = $?", filters.source_id);
+  if (filters.plan_id) push("qc.plan_id = $?::uuid", filters.plan_id);
+  if (filters.lot_id) push("qc.lot_id = $?::uuid", filters.lot_id);
+
+  const whereSql = clauses.join(" AND ");
+  const totalRes = await pool.query<{ total: number }>(
+    `SELECT COUNT(*)::int AS total FROM public.quality_control qc WHERE ${whereSql}`,
+    values
+  );
+  const itemsRes = await pool.query<ExecutionRow>(
+    `
+      SELECT ${EXECUTION_COLUMNS}
+      FROM public.quality_control qc
+      LEFT JOIN public.quality_control_plan p ON p.id = qc.plan_id
+      WHERE ${whereSql}
+      ORDER BY ${EXECUTION_SORT_COLUMNS[filters.sortBy]} ${sortDirection(filters.sortDir)} NULLS LAST, qc.id ASC
+      LIMIT ${filters.pageSize} OFFSET ${(filters.page - 1) * filters.pageSize}
+    `,
+    values
+  );
+
+  return {
+    items: itemsRes.rows.map((row) => buildExecutionDetail(row, [])),
+    total: totalRes.rows[0]?.total ?? 0,
+  };
+}
+
+export async function repoCreateExecution(params: {
+  body: CreateExecutionBodyDTO;
+  actor: QualityActor;
+  idempotencyKey: string | null | undefined;
+}): Promise<ExecutionDetail> {
+  const source = assertSourceRef({
+    source_type: params.body.source_type,
+    source_id: params.body.source_id,
+  });
+
+  return withTransaction(async (client) => {
+    const idem = await acquireIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "quality.execution.create",
+      requestPayload: params.body,
+    });
+    if (idem.replay) {
+      const replayed = await selectExecutionRow(client, String(idem.replay.control_id));
+      if (replayed) return buildExecutionDetail(replayed, await selectMeasurements(client, replayed.id));
+    }
+
+    const built = await buildExecutionSnapshot(client, params.body);
+    // L'aperçu doit encore correspondre au plan applicable : sinon le référentiel
+    // a bougé entre l'aperçu et la confirmation.
+    assertPreviewFresh({
+      expectedHash: params.body.preview_sha256,
+      currentHash: built.snapshot.sha256,
+    });
+
+    const reference = await generateTransactionalBusinessCode(client, { prefix: "CQ" });
+    const controlType = legacyControlType(params.body.trigger);
+
+    const insert = await client.query<{ id: string; correlation_id: string }>(
+      `
+        INSERT INTO public.quality_control (
+          reference, control_type, status, control_date, controlled_by,
+          affaire_id, of_id, piece_technique_id, operation_id,
+          plan_id, plan_version, plan_snapshot, plan_snapshot_sha256,
+          source_type, source_id, trigger_type,
+          lot_id, article_id, fournisseur_id, reception_ligne_id,
+          unite, qty_population, verdict, verdict_computed, comments,
+          created_by, updated_by
+        )
+        VALUES (
+          $1, $2::public.quality_control_type, 'IN_PROGRESS', now(), $3,
+          NULL, $4, $5::uuid, NULL,
+          $6::uuid, $7, $8::jsonb, $9,
+          $10, $11, $12,
+          $13::uuid, $14::uuid, $15::uuid, $16::uuid,
+          $17, $18, 'EN_ATTENTE', 'EN_ATTENTE', $19,
+          $20, $20
+        )
+        RETURNING id, correlation_id
+      `,
+      [
+        reference,
+        controlType,
+        params.body.controlled_by ?? params.actor.user_id,
+        params.body.of_id ?? null,
+        params.body.piece_technique_id ?? null,
+        built.plan.id,
+        built.plan.version,
+        JSON.stringify(built.snapshot.payload),
+        built.snapshot.sha256,
+        source.source_type,
+        source.source_id,
+        params.body.trigger,
+        params.body.lot_id ?? null,
+        params.body.article_id ?? null,
+        params.body.fournisseur_id ?? null,
+        params.body.reception_ligne_id ?? null,
+        params.body.unite,
+        params.body.population,
+        params.body.comments ?? null,
+        params.actor.user_id,
+      ]
+    );
+
+    const controlId = insert.rows[0]!.id;
+    const correlationId = insert.rows[0]!.correlation_id;
+
+    await insertQualityEvent(client, {
+      entity_type: "CONTROL",
+      entity_id: controlId,
+      event_type: "EXECUTION_CREATED",
+      actor: params.actor,
+      old_values: null,
+      new_values: {
+        reference,
+        plan_id: built.plan.id,
+        plan_version: built.plan.version,
+        plan_snapshot_sha256: built.snapshot.sha256,
+        source: source,
+        population: params.body.population,
+      },
+      correlation_id: correlationId,
+      idempotency_key: idem.idempotencyKey,
+    });
+    await insertAuditLog(client, params.actor, {
+      action: "qualite.executions.create",
+      entity_type: "quality_control",
+      entity_id: controlId,
+      details: { reference, plan_code: built.plan.code, sha256: built.snapshot.sha256 },
+    });
+    await saveReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: idem.idempotencyKey,
+      requestHash: idem.requestHash,
+      commandType: "quality.execution.create",
+      aggregateType: "CONTROL",
+      aggregateId: controlId,
+      requestPayload: params.body,
+      resultPayload: { control_id: controlId, reference },
+      correlationId,
+    });
+
+    const row = await selectExecutionRow(client, controlId);
+    return buildExecutionDetail(row!, []);
+  });
+}
+
+// Le type historique `quality_control_type` reste la colonne de compatibilité.
+function legacyControlType(trigger: string): "IN_PROCESS" | "FINAL" | "RECEPTION" | "PERIODIC" {
+  switch (trigger) {
+    case "RECEPTION":
+      return "RECEPTION";
+    case "PERIODIC":
+      return "PERIODIC";
+    case "IN_PROCESS":
+    case "FIRST_ARTICLE":
+      return "IN_PROCESS";
+    default:
+      return "FINAL";
+  }
+}
+
+async function loadInstrument(q: DbQueryer, instrumentId: string): Promise<InstrumentState | null> {
+  const res = await q.query<{
+    id: string;
+    code: string | null;
+    designation: string;
+    statut: string;
+    criticite: string;
+    categorie: string | null;
+    deleted_at: string | null;
+    next_due_date: string | null;
+  }>(
+    `
+      SELECT e.id, e.code, e.designation, e.statut, e.criticite, e.categorie, e.deleted_at,
+             (SELECT MIN(p.next_due_date)::text
+                FROM public.metrologie_plan p
+               WHERE p.equipement_id = e.id AND p.deleted_at IS NULL AND p.statut = 'EN_COURS') AS next_due_date
+      FROM public.metrologie_equipements e
+      WHERE e.id = $1::uuid
+    `,
+    [instrumentId]
+  );
+  const row = res.rows[0];
+  if (!row) return null;
+  return {
+    id: row.id,
+    code: row.code,
+    designation: row.designation,
+    statut: row.statut,
+    criticite: row.criticite,
+    categorie: row.categorie,
+    next_due_date: row.next_due_date,
+    deleted: row.deleted_at !== null,
+  };
+}
+
+export async function repoRecordMeasurements(params: {
+  id: string;
+  body: RecordMeasurementsBodyDTO;
+  actor: QualityActor;
+}): Promise<ExecutionDetail | null> {
+  return withTransaction(async (client) => {
+    const before = await selectExecutionRow(client, params.id, true);
+    if (!before) return null;
+
+    assertOptimisticVersion({
+      expectedUpdatedAt: params.body.expected_updated_at,
+      currentUpdatedAt: before.updated_at,
+    });
+    if (before.validation_date) {
+      throw new HttpError(
+        409,
+        "QUALITY_EXECUTION_CLOSED",
+        "Ce contrôle est validé : une correction passe par une révision auditée."
+      );
+    }
+    if (!before.plan_snapshot_sha256) {
+      throw new HttpError(
+        409,
+        "QUALITY_SNAPSHOT_MISSING",
+        "Cette exécution n'a pas de plan figé : elle ne peut pas recevoir de mesure."
+      );
+    }
+    assertSnapshotIntegrity(before.plan_snapshot, before.plan_snapshot_sha256);
+
+    const specs = characteristicsFromSnapshot(before.plan_snapshot);
+    const specByKey = new Map(specs.map((spec) => [spec.key, spec]));
+    const policy = await metrologyPolicy(client);
+    const now = new Date();
+    const warnings: Array<{ characteristic_key: string; code: string; message: string }> = [];
+
+    for (const measurement of params.body.measurements) {
+      const spec = specByKey.get(measurement.characteristic_key);
+      if (!spec) {
+        throw new HttpError(
+          422,
+          "QUALITY_CHARACTERISTIC_UNKNOWN",
+          `La caractéristique ${measurement.characteristic_key} n'appartient pas au plan figé.`
+        );
+      }
+      const expected = requiredSampleCount(spec, toNumber(before.qty_population));
+      if (measurement.sample_no > Math.max(expected, 1)) {
+        throw new HttpError(
+          422,
+          "QUALITY_SAMPLE_OUT_OF_RANGE",
+          `Échantillon ${measurement.sample_no} hors du plan d'échantillonnage (${expected} attendu(s)).`,
+          { characteristic: spec.key, expected_samples: expected }
+        );
+      }
+
+      let instrumentSnapshot: InstrumentState | null = null;
+      if (measurement.instrument_id) {
+        instrumentSnapshot = await loadInstrument(client, measurement.instrument_id);
+        if (!instrumentSnapshot) {
+          throw new HttpError(422, "INSTRUMENT_UNKNOWN", "Instrument de métrologie inconnu.");
+        }
+      }
+      const instrumentCheck = evaluateInstrumentUsage({
+        characteristic: spec,
+        instrument: instrumentSnapshot,
+        at: now,
+        policy,
+      });
+      if (!instrumentCheck.allowed) {
+        throw new HttpError(409, instrumentCheck.code, instrumentCheck.message, {
+          characteristic: spec.key,
+          instrument_id: measurement.instrument_id ?? null,
+        });
+      }
+      if (instrumentCheck.severity === "WARNING") {
+        warnings.push({
+          characteristic_key: spec.key,
+          code: instrumentCheck.code,
+          message: instrumentCheck.message,
+        });
+      }
+
+      const evaluation = evaluateSampleForSpec(spec, measurement);
+
+      const existing = await client.query<{ id: string; revision: number; snapshot: Record<string, unknown> }>(
+        `
+          SELECT id, revision,
+                 jsonb_build_object(
+                   'measured_value', measured_value, 'value_boolean', value_boolean,
+                   'value_text', value_text, 'unit', unit, 'result', result::text,
+                   'instrument_id', instrument_id, 'evaluation_code', evaluation_code
+                 ) AS snapshot
+          FROM public.quality_control_points
+          WHERE quality_control_id = $1::uuid AND characteristic_key = $2 AND sample_no = $3
+          FOR UPDATE
+        `,
+        [params.id, spec.key, measurement.sample_no]
+      );
+
+      const previous = existing.rows[0] ?? null;
+      if (previous) {
+        const reason = (params.body.correction_reason ?? "").trim();
+        if (reason.length < 5) {
+          throw new HttpError(
+            422,
+            "QUALITY_MEASUREMENT_CORRECTION_REASON_REQUIRED",
+            "Corriger une mesure existante exige un motif d'au moins 5 caractères."
+          );
+        }
+        const nextRevision = previous.revision + 1;
+        await client.query(
+          `
+            UPDATE public.quality_control_points
+            SET measured_value = $2, value_boolean = $3, value_text = $4, unit = $5,
+                result = $6::public.quality_point_result, evaluation_code = $7,
+                instrument_id = $8::uuid, instrument_snapshot = $9::jsonb, criticality = $10,
+                comment = $11, measured_at = now(), recorded_by = $12, revision = $13
+            WHERE id = $1::uuid
+          `,
+          [
+            previous.id,
+            measurement.value_numeric,
+            measurement.value_boolean,
+            measurement.value_text,
+            measurement.unit ?? spec.unit,
+            evaluation.result === "PENDING" ? null : evaluation.result,
+            evaluation.code,
+            measurement.instrument_id ?? null,
+            instrumentSnapshot ? JSON.stringify(instrumentSnapshot) : null,
+            spec.criticality,
+            measurement.comment,
+            params.actor.user_id,
+            nextRevision,
+          ]
+        );
+        // Historique avant/après : jamais d'écrasement silencieux.
+        await client.query(
+          `
+            INSERT INTO public.quality_measurement_revisions (
+              point_id, quality_control_id, revision, old_values, new_values, reason, actor_user_id
+            )
+            VALUES ($1::uuid, $2::uuid, $3, $4::jsonb, $5::jsonb, $6, $7)
+          `,
+          [
+            previous.id,
+            params.id,
+            nextRevision,
+            JSON.stringify(previous.snapshot),
+            JSON.stringify({
+              measured_value: measurement.value_numeric,
+              value_boolean: measurement.value_boolean,
+              value_text: measurement.value_text,
+              unit: measurement.unit ?? spec.unit,
+              result: evaluation.result,
+              evaluation_code: evaluation.code,
+              instrument_id: measurement.instrument_id ?? null,
+            }),
+            reason,
+            params.actor.user_id,
+          ]
+        );
+      } else {
+        await client.query(
+          `
+            INSERT INTO public.quality_control_points (
+              quality_control_id, characteristic, characteristic_key, sample_no,
+              nominal_value, tolerance_min, tolerance_max, measured_value,
+              value_boolean, value_text, unit, result, evaluation_code,
+              instrument_id, instrument_snapshot, criticality, comment, measured_at, recorded_by
+            )
+            VALUES (
+              $1::uuid, $2, $3, $4,
+              $5, $6, $7, $8,
+              $9, $10, $11, $12::public.quality_point_result, $13,
+              $14::uuid, $15::jsonb, $16, $17, now(), $18
+            )
+          `,
+          [
+            params.id,
+            spec.label,
+            spec.key,
+            measurement.sample_no,
+            spec.nominal,
+            spec.tolerance_min,
+            spec.tolerance_max,
+            measurement.value_numeric,
+            measurement.value_boolean,
+            measurement.value_text,
+            measurement.unit ?? spec.unit,
+            evaluation.result === "PENDING" ? null : evaluation.result,
+            evaluation.code,
+            measurement.instrument_id ?? null,
+            instrumentSnapshot ? JSON.stringify(instrumentSnapshot) : null,
+            spec.criticality,
+            measurement.comment,
+            params.actor.user_id,
+          ]
+        );
+      }
+    }
+
+    const computed = await recomputeExecutionLedger(client, params.id, specs);
+
+    await client.query(
+      `UPDATE public.quality_control SET updated_by = $2 WHERE id = $1::uuid`,
+      [params.id, params.actor.user_id]
+    );
+
+    await insertQualityEvent(client, {
+      entity_type: "CONTROL",
+      entity_id: params.id,
+      event_type: "MEASUREMENTS_RECORDED",
+      actor: params.actor,
+      old_values: { verdict_computed: before.verdict_computed },
+      new_values: {
+        verdict_computed: computed.verdict,
+        recorded: params.body.measurements.length,
+        warnings,
+      },
+      correlation_id: before.correlation_id,
+      reason: params.body.correction_reason ?? null,
+    });
+    await insertAuditLog(client, params.actor, {
+      action: "qualite.executions.measurements",
+      entity_type: "quality_control",
+      entity_id: params.id,
+      details: { recorded: params.body.measurements.length, verdict_computed: computed.verdict },
+    });
+
+    const after = await selectExecutionRow(client, params.id);
+    return buildExecutionDetail(after!, await selectMeasurements(client, params.id));
+  });
+}
+
+function evaluateSampleForSpec(
+  spec: QualityCharacteristicSpec,
+  measurement: {
+    characteristic_key: string;
+    sample_no: number;
+    value_numeric: number | null;
+    value_boolean: boolean | null;
+    value_text: string | null;
+    unit: string | null;
+  }
+) {
+  const sample: QualitySampleValue = {
+    characteristic_key: measurement.characteristic_key,
+    sample_no: measurement.sample_no,
+    value_numeric: measurement.value_numeric,
+    value_boolean: measurement.value_boolean,
+    value_text: measurement.value_text,
+    unit: measurement.unit,
+    evidence_count: 0,
+  };
+  return evaluateSample(spec, sample);
+}
+
+async function loadSamples(q: DbQueryer, controlId: string): Promise<QualitySampleValue[]> {
+  const res = await q.query<{
+    characteristic_key: string | null;
+    sample_no: number | null;
+    measured_value: string | null;
+    value_boolean: boolean | null;
+    value_text: string | null;
+    unit: string | null;
+    evidence_count: number;
+  }>(
+    `
+      SELECT p.characteristic_key, p.sample_no, p.measured_value, p.value_boolean, p.value_text, p.unit,
+             (SELECT COUNT(*)::int FROM public.quality_documents d
+               WHERE d.entity_type = 'CONTROL' AND d.entity_id = p.quality_control_id AND d.removed_at IS NULL
+             ) AS evidence_count
+      FROM public.quality_control_points p
+      WHERE p.quality_control_id = $1::uuid AND p.characteristic_key IS NOT NULL AND p.sample_no IS NOT NULL
+    `,
+    [controlId]
+  );
+  return res.rows.map((row) => ({
+    characteristic_key: row.characteristic_key!,
+    sample_no: row.sample_no!,
+    value_numeric: row.measured_value === null ? null : Number(row.measured_value),
+    value_boolean: row.value_boolean,
+    value_text: row.value_text,
+    unit: row.unit,
+    evidence_count: row.evidence_count,
+  }));
+}
+
+async function recomputeExecutionLedger(
+  tx: DbQueryer,
+  controlId: string,
+  specs: readonly QualityCharacteristicSpec[]
+): Promise<{ verdict: QualityVerdict; controlled: number; conforming: number }> {
+  const row = await selectExecutionRow(tx, controlId);
+  if (!row) throw new HttpError(404, "NOT_FOUND", "Contrôle introuvable.");
+
+  const population = toNumber(row.qty_population);
+  const samples = await loadSamples(tx, controlId);
+  const computation = computeExecutionVerdict({ characteristics: specs, samples, population });
+
+  // Quantité contrôlée = nombre d'unités distinctes réellement évaluées,
+  // plafonné par la population. Quantité conforme = unités sans aucun NOK.
+  const unitsEvaluated = new Set<number>();
+  const unitsWithNok = new Set<number>();
+  for (const evaluation of computation.evaluations) {
+    if (evaluation.result === "PENDING") continue;
+    unitsEvaluated.add(evaluation.sample_no);
+    if (evaluation.result === "NOK") unitsWithNok.add(evaluation.sample_no);
+  }
+  const sampled = Math.min(unitsEvaluated.size, population > 0 ? population : unitsEvaluated.size);
+  const conformingSamples = Math.max(0, sampled - unitsWithNok.size);
+
+  // L'extrapolation à la population n'est jamais implicite : quand le plan est
+  // en échantillonnage, la quantité conforme reste la quantité réellement
+  // contrôlée, sauf verdict CONFORME sur la totalité de la population.
+  const controlled =
+    computation.verdict === "CONFORME" && sampled > 0 && population > 0 ? population : sampled;
+  const conforming =
+    computation.verdict === "CONFORME"
+      ? controlled
+      : computation.verdict === "NON_CONFORME"
+        ? 0
+        : conformingSamples;
+
+  const ledger: QuantityLedger = { ...rowToLedger(row), controlled, conforming };
+  if (population > 0) assertQuantityLedger(ledger);
+
+  await tx.query(
+    `
+      UPDATE public.quality_control
+      SET qty_controlled = $2, qty_conforming = $3, verdict_computed = $4,
+          verdict = CASE WHEN validation_date IS NULL THEN $4 ELSE verdict END,
+          status = CASE WHEN validation_date IS NULL THEN $5::public.quality_control_status ELSE status END
+      WHERE id = $1::uuid
+    `,
+    [controlId, controlled, conforming, computation.verdict, executionStatusForVerdict(computation.verdict)]
+  );
+
+  return { verdict: computation.verdict, controlled, conforming };
+}
+
+export type VerdictPreview = {
+  control_id: string;
+  verdict: QualityVerdict;
+  missing: Array<{ characteristic_key: string; expected_samples: number; recorded_samples: number }>;
+  blocking: Array<{ characteristic_key: string; criticality: string; code: string }>;
+  ledger: QuantityLedger;
+  releasable_qty: number;
+  preview_sha256: string;
+};
+
+export async function repoPreviewVerdict(id: string): Promise<VerdictPreview | null> {
+  const row = await selectExecutionRow(pool, id);
+  if (!row) return null;
+  if (!row.plan_snapshot_sha256) {
+    throw new HttpError(409, "QUALITY_SNAPSHOT_MISSING", "Cette exécution n'a pas de plan figé.");
+  }
+  assertSnapshotIntegrity(row.plan_snapshot, row.plan_snapshot_sha256);
+
+  const specs = characteristicsFromSnapshot(row.plan_snapshot);
+  const samples = await loadSamples(pool, id);
+  const population = toNumber(row.qty_population);
+  const computation = computeExecutionVerdict({ characteristics: specs, samples, population });
+  const ledger = rowToLedger(row);
+
+  const payload = {
+    control_id: id,
+    verdict: computation.verdict,
+    ledger,
+    snapshot_sha256: row.plan_snapshot_sha256,
+  };
+
+  return {
+    control_id: id,
+    verdict: computation.verdict,
+    missing: computation.missing,
+    blocking: computation.blocking,
+    ledger,
+    releasable_qty: population > 0 ? releasableQty(ledger) : 0,
+    preview_sha256: qualitySha256(payload),
+  };
+}
+
+export async function repoDecideExecution(params: {
+  id: string;
+  body: DecideExecutionBodyDTO;
+  actor: QualityActor;
+  idempotencyKey: string | null | undefined;
+}): Promise<ExecutionDetail | null> {
+  return withTransaction(async (client) => {
+    const before = await selectExecutionRow(client, params.id, true);
+    if (!before) return null;
+
+    const idem = await acquireIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "quality.execution.decide",
+      requestPayload: { id: params.id, ...params.body },
+    });
+    if (idem.replay) {
+      const replayed = await selectExecutionRow(client, params.id);
+      return buildExecutionDetail(replayed!, await selectMeasurements(client, params.id));
+    }
+
+    assertOptimisticVersion({
+      expectedUpdatedAt: params.body.expected_updated_at,
+      currentUpdatedAt: before.updated_at,
+    });
+    if (before.validation_date) {
+      throw new HttpError(409, "ALREADY_VALIDATED", "Ce contrôle est déjà décidé.");
+    }
+    if (!before.plan_snapshot_sha256) {
+      throw new HttpError(409, "QUALITY_SNAPSHOT_MISSING", "Cette exécution n'a pas de plan figé.");
+    }
+    assertSnapshotIntegrity(before.plan_snapshot, before.plan_snapshot_sha256);
+
+    // L'auteur de l'exécution ne prononce pas lui-même la libération.
+    if (params.body.decision === "FULL" || params.body.decision === "PARTIAL") {
+      assertReleaseSeparation({
+        executorUserId: before.controlled_by,
+        deciderUserId: params.actor.user_id,
+      });
+    }
+
+    const specs = characteristicsFromSnapshot(before.plan_snapshot);
+    const samples = await loadSamples(client, params.id);
+    const population = toNumber(before.qty_population);
+    const computation = computeExecutionVerdict({ characteristics: specs, samples, population });
+
+    const evidenceRes = await client.query<{ total: number }>(
+      `
+        SELECT COUNT(*)::int AS total FROM public.quality_documents
+        WHERE entity_type = 'CONTROL' AND entity_id = $1::uuid AND removed_at IS NULL
+      `,
+      [params.id]
+    );
+    const evidenceCount = evidenceRes.rows[0]?.total ?? 0;
+
+    const requestedVerdict = params.body.verdict_override ?? computation.verdict;
+    assertManualVerdictOverride({
+      computed: computation.verdict,
+      requested: requestedVerdict,
+      justification: params.body.justification ?? null,
+      evidenceCount,
+      requireEvidence: true,
+    });
+
+    // L'aperçu doit être frais : il porte le verdict calculé et le registre.
+    assertPreviewFresh({
+      expectedHash: params.body.preview_sha256,
+      currentHash: qualitySha256({
+        control_id: params.id,
+        verdict: computation.verdict,
+        ledger: rowToLedger(before),
+        snapshot_sha256: before.plan_snapshot_sha256,
+      }),
+    });
+
+    let derogation: DerogationState | null = null;
+    if (params.body.derogation_id) {
+      derogation = await loadDerogation(client, params.body.derogation_id, true);
+      if (!derogation) throw new HttpError(404, "NOT_FOUND", "Dérogation introuvable.");
+      const usage = evaluateDerogationUsage({
+        derogation,
+        context: {
+          article_id: null,
+          piece_technique_id: null,
+          piece_version_id: null,
+          lot_id: params.body.object_type === "LOT" ? params.body.object_id : null,
+          of_id: null,
+          commande_id: null,
+          bon_livraison_id: null,
+          unit: params.body.unite,
+        },
+        qty: params.body.qty,
+        at: new Date(),
+      });
+      if (!usage.allowed) {
+        throw new HttpError(409, usage.code, usage.message, { derogation_id: derogation.id });
+      }
+    }
+
+    const outcome = evaluateReleaseRequest({
+      decision: params.body.decision,
+      qty: params.body.qty,
+      unit: params.body.unite,
+      ledger: rowToLedger(before),
+      verdict: requestedVerdict,
+      hasDerogation: derogation !== null,
+      evidenceCount,
+    });
+
+    await client.query(
+      `
+        UPDATE public.quality_control
+        SET verdict = $2, verdict_computed = $3,
+            verdict_override_reason = $4, verdict_overridden_by = $5,
+            result = $6::public.quality_control_result,
+            status = $7::public.quality_control_status,
+            validated_by = $8, validation_date = now(),
+            qty_released = $9, qty_held = $10, updated_by = $8
+        WHERE id = $1::uuid
+      `,
+      [
+        params.id,
+        requestedVerdict,
+        computation.verdict,
+        requestedVerdict === computation.verdict ? null : params.body.justification ?? null,
+        requestedVerdict === computation.verdict ? null : params.actor.user_id,
+        verdictToLegacyResult(requestedVerdict),
+        executionStatusForVerdict(requestedVerdict),
+        params.actor.user_id,
+        outcome.ledger.released,
+        outcome.ledger.held,
+      ]
+    );
+
+    const decisionRes = await client.query<{ id: string }>(
+      `
+        INSERT INTO public.quality_release_decision (
+          quality_control_id, decision, object_type, object_id, qty, unite,
+          verdict, derogation_id, justification, decided_by, executed_by,
+          preview_sha256, idempotency_key, correlation_id
+        )
+        VALUES ($1::uuid, $2, $3, $4, $5, $6, $7, $8::uuid, $9, $10, $11, $12, $13, $14::uuid)
+        RETURNING id
+      `,
+      [
+        params.id,
+        params.body.decision,
+        params.body.object_type,
+        params.body.object_id,
+        params.body.decision === "HOLD" ? outcome.qty_held : outcome.qty_released,
+        params.body.unite,
+        requestedVerdict,
+        derogation?.id ?? null,
+        params.body.justification ?? null,
+        params.actor.user_id,
+        before.controlled_by,
+        params.body.preview_sha256,
+        idem.idempotencyKey,
+        before.correlation_id,
+      ]
+    );
+    const decisionId = decisionRes.rows[0]!.id;
+
+    if (derogation) {
+      await consumeDerogationInternal(client, {
+        derogationId: derogation.id,
+        qty: params.body.qty,
+        unite: params.body.unite,
+        actor: params.actor,
+        releaseDecisionId: decisionId,
+        qualityControlId: params.id,
+        idempotencyKey: idem.idempotencyKey,
+        context: { source: "release_decision" },
+      });
+    }
+
+    await insertQualityEvent(client, {
+      entity_type: "RELEASE",
+      entity_id: decisionId,
+      event_type: `RELEASE_${params.body.decision}`,
+      actor: params.actor,
+      old_values: { verdict: before.verdict, ledger: rowToLedger(before) },
+      new_values: {
+        verdict: requestedVerdict,
+        verdict_computed: computation.verdict,
+        ledger: outcome.ledger,
+        qty_released: outcome.qty_released,
+        qty_held: outcome.qty_held,
+        derogation_id: derogation?.id ?? null,
+      },
+      correlation_id: before.correlation_id,
+      idempotency_key: idem.idempotencyKey,
+      rule_code: "QUALITY_RELEASE_DECISION",
+      reason: params.body.justification ?? null,
+    });
+    await insertAuditLog(client, params.actor, {
+      action: "qualite.executions.decide",
+      entity_type: "quality_control",
+      entity_id: params.id,
+      details: {
+        decision: params.body.decision,
+        qty: params.body.qty,
+        verdict: requestedVerdict,
+        derogation_id: derogation?.id ?? null,
+      },
+    });
+    await saveReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: idem.idempotencyKey,
+      requestHash: idem.requestHash,
+      commandType: "quality.execution.decide",
+      aggregateType: "RELEASE",
+      aggregateId: decisionId,
+      requestPayload: { id: params.id, ...params.body },
+      resultPayload: { control_id: params.id, decision_id: decisionId },
+      correlationId: before.correlation_id,
+    });
+
+    const after = await selectExecutionRow(client, params.id);
+    return buildExecutionDetail(after!, await selectMeasurements(client, params.id));
+  });
+}
+
+/* ========================================================================== */
+/* Dérogations                                                                */
+/* ========================================================================== */
+
+type DerogationRow = DerogationState & {
+  derogation_type: string;
+  non_conformity_id: string | null;
+  requirement: string;
+  deviation: string;
+  risk_analysis: string | null;
+  conditions: string | null;
+  requested_by: number;
+  approved_by: number | null;
+  approved_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+async function loadDerogation(
+  q: DbQueryer,
+  id: string,
+  forUpdate = false
+): Promise<DerogationRow | null> {
+  const res = await q.query<{
+    id: string;
+    code: string;
+    status: string;
+    derogation_type: string;
+    non_conformity_id: string | null;
+    article_id: string | null;
+    piece_technique_id: string | null;
+    piece_version_id: string | null;
+    lot_id: string | null;
+    of_id: string | null;
+    commande_id: string | null;
+    bon_livraison_id: string | null;
+    requirement: string;
+    deviation: string;
+    risk_analysis: string | null;
+    conditions: string | null;
+    max_qty: string | null;
+    unite: string | null;
+    consumed_qty: string;
+    valid_from: string | null;
+    valid_to: string | null;
+    requested_by: number;
+    approved_by: number | null;
+    approved_at: string | null;
+    created_at: string;
+    updated_at: string;
+  }>(
+    `
+      SELECT id, code, status, derogation_type, non_conformity_id,
+             article_id, piece_technique_id, piece_version_id, lot_id,
+             of_id::text AS of_id, commande_id, bon_livraison_id,
+             requirement, deviation, risk_analysis, conditions,
+             max_qty, unite, consumed_qty, valid_from, valid_to,
+             requested_by, approved_by, approved_at, created_at, updated_at
+      FROM public.quality_derogation
+      WHERE id = $1::uuid
+      ${forUpdate ? "FOR UPDATE" : ""}
+    `,
+    [id]
+  );
+  const row = res.rows[0];
+  if (!row) return null;
+  return {
+    ...row,
+    max_qty: row.max_qty === null ? null : Number(row.max_qty),
+    consumed_qty: Number(row.consumed_qty),
+    unit: row.unite,
+  } as unknown as DerogationRow;
+}
+
+const DEROGATION_SORT_COLUMNS: Record<ListDerogationsQueryDTO["sortBy"], string> = {
+  code: "d.code",
+  status: "d.status",
+  valid_to: "d.valid_to",
+  updated_at: "d.updated_at",
+};
+
+export async function repoListDerogations(
+  filters: ListDerogationsQueryDTO
+): Promise<{ items: unknown[]; total: number }> {
+  const clauses: string[] = ["TRUE"];
+  const values: unknown[] = [];
+  const push = (sql: string, value: unknown) => {
+    values.push(value);
+    clauses.push(sql.replace(/\$\?/g, `$${values.length}`));
+  };
+
+  if (filters.q) push("(d.code ILIKE $? OR d.requirement ILIKE $?)", `%${filters.q}%`);
+  if (filters.status) push("d.status = $?", filters.status);
+  if (filters.non_conformity_id) push("d.non_conformity_id = $?::uuid", filters.non_conformity_id);
+  if (filters.lot_id) push("d.lot_id = $?::uuid", filters.lot_id);
+  if (filters.expiring_within_days) {
+    push("(d.valid_to IS NOT NULL AND d.valid_to <= now() + ($? || ' days')::interval)", String(filters.expiring_within_days));
+  }
+
+  const whereSql = clauses.join(" AND ");
+
+  const totalRes = await pool.query<{ total: number }>(
+    `SELECT COUNT(*)::int AS total FROM public.quality_derogation d WHERE ${whereSql}`,
+    values
+  );
+  const itemsRes = await pool.query(
+    `
+      SELECT d.id, d.code, d.status, d.derogation_type, d.non_conformity_id,
+             d.article_id, d.piece_technique_id, d.piece_version_id, d.lot_id,
+             d.requirement, d.deviation, d.max_qty, d.unite, d.consumed_qty,
+             d.valid_from, d.valid_to, d.requested_by, d.approved_by, d.approved_at,
+             d.created_at, d.updated_at,
+             GREATEST(COALESCE(d.max_qty, 0) - d.consumed_qty, 0) AS remaining_qty
+      FROM public.quality_derogation d
+      WHERE ${whereSql}
+      ORDER BY ${DEROGATION_SORT_COLUMNS[filters.sortBy]} ${sortDirection(filters.sortDir)} NULLS LAST, d.code ASC
+      LIMIT ${filters.pageSize} OFFSET ${(filters.page - 1) * filters.pageSize}
+    `,
+    values
+  );
+  return { items: itemsRes.rows, total: totalRes.rows[0]?.total ?? 0 };
+}
+
+export async function repoGetDerogation(id: string): Promise<{
+  derogation: DerogationRow;
+  consumptions: unknown[];
+} | null> {
+  const derogation = await loadDerogation(pool, id);
+  if (!derogation) return null;
+  const consumptions = await pool.query(
+    `
+      SELECT id, qty, unite, quality_control_id, release_decision_id, bon_livraison_id,
+             actor_user_id, created_at, context
+      FROM public.quality_derogation_consumption
+      WHERE derogation_id = $1::uuid
+      ORDER BY created_at DESC
+    `,
+    [id]
+  );
+  return { derogation, consumptions: consumptions.rows };
+}
+
+export async function repoCreateDerogation(params: {
+  body: CreateDerogationBodyDTO;
+  actor: QualityActor;
+}): Promise<DerogationRow> {
+  return withTransaction(async (client) => {
+    const code = await generateTransactionalBusinessCode(client, { prefix: "DER" });
+    const insert = await client.query<{ id: string; correlation_id: string }>(
+      `
+        INSERT INTO public.quality_derogation (
+          code, derogation_type, status, non_conformity_id, client_id, fournisseur_id,
+          article_id, piece_technique_id, piece_version_id, lot_id, of_id, commande_id, bon_livraison_id,
+          requirement, deviation, risk_analysis, conditions,
+          max_qty, unite, valid_from, valid_to, customer_agreement_reference,
+          requested_by, created_by, updated_by
+        )
+        VALUES (
+          $1, $2, 'DRAFT', $3::uuid, $4, $5::uuid,
+          $6::uuid, $7::uuid, $8::uuid, $9::uuid, $10, $11::uuid, $12::uuid,
+          $13, $14, $15, $16,
+          $17, $18, $19::timestamptz, $20::timestamptz, $21,
+          $22, $22, $22
+        )
+        RETURNING id, correlation_id
+      `,
+      [
+        code,
+        params.body.derogation_type,
+        params.body.non_conformity_id ?? null,
+        params.body.client_id ?? null,
+        params.body.fournisseur_id ?? null,
+        params.body.article_id ?? null,
+        params.body.piece_technique_id ?? null,
+        params.body.piece_version_id ?? null,
+        params.body.lot_id ?? null,
+        params.body.of_id ?? null,
+        params.body.commande_id ?? null,
+        params.body.bon_livraison_id ?? null,
+        params.body.requirement,
+        params.body.deviation,
+        params.body.risk_analysis ?? null,
+        params.body.conditions ?? null,
+        params.body.max_qty ?? null,
+        params.body.unite ?? null,
+        params.body.valid_from ?? null,
+        params.body.valid_to ?? null,
+        params.body.customer_agreement_reference ?? null,
+        params.actor.user_id,
+      ]
+    );
+    const id = insert.rows[0]!.id;
+
+    await insertQualityEvent(client, {
+      entity_type: "DEROGATION",
+      entity_id: id,
+      event_type: "DEROGATION_CREATED",
+      actor: params.actor,
+      old_values: null,
+      new_values: { code, status: "DRAFT", requirement: params.body.requirement },
+      correlation_id: insert.rows[0]!.correlation_id,
+    });
+    await insertAuditLog(client, params.actor, {
+      action: "qualite.derogations.create",
+      entity_type: "quality_derogation",
+      entity_id: id,
+      details: { code },
+    });
+
+    return (await loadDerogation(client, id))!;
+  });
+}
+
+export async function repoTransitionDerogation(params: {
+  id: string;
+  body: DerogationTransitionBodyDTO;
+  actor: QualityActor;
+}): Promise<DerogationRow | null> {
+  return withTransaction(async (client) => {
+    const before = await loadDerogation(client, params.id, true);
+    if (!before) return null;
+
+    assertOptimisticVersion({
+      expectedUpdatedAt: params.body.expected_updated_at,
+      currentUpdatedAt: before.updated_at,
+    });
+    assertDerogationTransition(
+      before.status as QualityDerogationStatus,
+      params.body.target_status as QualityDerogationStatus
+    );
+
+    if (params.body.target_status === "APPROVED") {
+      assertDerogationApprovalSeparation({
+        requesterUserId: before.requested_by,
+        approverUserId: params.actor.user_id,
+      });
+    }
+
+    const setters: Record<QualityDerogationStatus, string> = {
+      DRAFT: "submitted_at = NULL",
+      SUBMITTED: "submitted_at = now()",
+      APPROVED: "approved_at = now(), approved_by = $3",
+      REJECTED: "rejected_at = now(), rejected_by = $3, rejection_reason = $4",
+      CONSUMED: "updated_at = now()",
+      EXPIRED: "updated_at = now()",
+      REVOKED: "revoked_at = now(), revoked_by = $3, revocation_reason = $4",
+    };
+
+    await client.query(
+      `
+        UPDATE public.quality_derogation
+        SET status = $2, ${setters[params.body.target_status as QualityDerogationStatus]}, updated_by = $3
+        WHERE id = $1::uuid
+      `,
+      [params.id, params.body.target_status, params.actor.user_id, params.body.reason ?? null]
+    );
+
+    await insertQualityEvent(client, {
+      entity_type: "DEROGATION",
+      entity_id: params.id,
+      event_type: `DEROGATION_${params.body.target_status}`,
+      actor: params.actor,
+      old_values: { status: before.status },
+      new_values: { status: params.body.target_status },
+      correlation_id: params.id,
+      rule_code: "QUALITY_DEROGATION_TRANSITION",
+      reason: params.body.reason ?? null,
+    });
+    await insertAuditLog(client, params.actor, {
+      action: `qualite.derogations.${params.body.target_status.toLowerCase()}`,
+      entity_type: "quality_derogation",
+      entity_id: params.id,
+      details: { from: before.status, to: params.body.target_status, reason: params.body.reason ?? null },
+    });
+
+    return (await loadDerogation(client, params.id))!;
+  });
+}
+
+async function consumeDerogationInternal(
+  tx: DbQueryer,
+  params: {
+    derogationId: string;
+    qty: number;
+    unite: string;
+    actor: QualityActor;
+    releaseDecisionId: string | null;
+    qualityControlId: string | null;
+    bonLivraisonId?: string | null;
+    idempotencyKey: string | null;
+    context: Record<string, unknown>;
+  }
+): Promise<string> {
+  const res = await tx.query<{ id: string }>(
+    `
+      INSERT INTO public.quality_derogation_consumption (
+        derogation_id, quality_control_id, release_decision_id, bon_livraison_id,
+        qty, unite, context, actor_user_id, idempotency_key
+      )
+      VALUES ($1::uuid, $2::uuid, $3::uuid, $4::uuid, $5, $6, $7::jsonb, $8, $9)
+      RETURNING id
+    `,
+    [
+      params.derogationId,
+      params.qualityControlId,
+      params.releaseDecisionId,
+      params.bonLivraisonId ?? null,
+      params.qty,
+      params.unite,
+      JSON.stringify(params.context),
+      params.actor.user_id,
+      params.idempotencyKey,
+    ]
+  );
+
+  const totals = await tx.query<{ consumed: string; max_qty: string | null }>(
+    `
+      SELECT COALESCE(SUM(c.qty), 0)::text AS consumed, d.max_qty::text AS max_qty
+      FROM public.quality_derogation d
+      LEFT JOIN public.quality_derogation_consumption c ON c.derogation_id = d.id
+      WHERE d.id = $1::uuid
+      GROUP BY d.max_qty
+    `,
+    [params.derogationId]
+  );
+  const consumed = toNumber(totals.rows[0]?.consumed);
+  const maxQty = totals.rows[0]?.max_qty === null || totals.rows[0]?.max_qty === undefined ? null : Number(totals.rows[0].max_qty);
+
+  await tx.query(
+    `UPDATE public.quality_derogation SET consumed_qty = $2, status = $3, updated_by = $4 WHERE id = $1::uuid`,
+    [
+      params.derogationId,
+      consumed,
+      derogationStatusAfterConsumption({ max_qty: maxQty, consumed_qty: consumed }),
+      params.actor.user_id,
+    ]
+  );
+
+  return res.rows[0]!.id;
+}
+
+export async function repoConsumeDerogation(params: {
+  id: string;
+  body: ConsumeDerogationBodyDTO;
+  actor: QualityActor;
+  idempotencyKey: string | null | undefined;
+}): Promise<{ consumption_id: string; derogation: DerogationRow } | null> {
+  return withTransaction(async (client) => {
+    const derogation = await loadDerogation(client, params.id, true);
+    if (!derogation) return null;
+
+    const idem = await acquireIdempotency({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "quality.derogation.consume",
+      requestPayload: { id: params.id, ...params.body },
+    });
+    if (idem.replay) {
+      return {
+        consumption_id: String(idem.replay.consumption_id),
+        derogation: (await loadDerogation(client, params.id))!,
+      };
+    }
+
+    const usage = evaluateDerogationUsage({
+      derogation,
+      context: {
+        article_id: null,
+        piece_technique_id: null,
+        piece_version_id: null,
+        lot_id: derogation.lot_id,
+        of_id: derogation.of_id,
+        commande_id: derogation.commande_id,
+        bon_livraison_id: params.body.bon_livraison_id ?? derogation.bon_livraison_id,
+        unit: params.body.unite,
+      },
+      qty: params.body.qty,
+      at: new Date(),
+    });
+    if (!usage.allowed) {
+      throw new HttpError(409, usage.code, usage.message, { derogation_id: params.id });
+    }
+
+    const consumptionId = await consumeDerogationInternal(client, {
+      derogationId: params.id,
+      qty: params.body.qty,
+      unite: params.body.unite,
+      actor: params.actor,
+      releaseDecisionId: params.body.release_decision_id ?? null,
+      qualityControlId: params.body.quality_control_id ?? null,
+      bonLivraisonId: params.body.bon_livraison_id ?? null,
+      idempotencyKey: idem.idempotencyKey,
+      context: params.body.context,
+    });
+
+    await insertQualityEvent(client, {
+      entity_type: "DEROGATION",
+      entity_id: params.id,
+      event_type: "DEROGATION_CONSUMED",
+      actor: params.actor,
+      old_values: { consumed_qty: derogation.consumed_qty },
+      new_values: { consumption_id: consumptionId, qty: params.body.qty },
+      correlation_id: params.id,
+      idempotency_key: idem.idempotencyKey,
+      rule_code: "QUALITY_DEROGATION_CONSUMPTION",
+    });
+    await insertAuditLog(client, params.actor, {
+      action: "qualite.derogations.consume",
+      entity_type: "quality_derogation",
+      entity_id: params.id,
+      details: { qty: params.body.qty, unite: params.body.unite },
+    });
+    await saveReceipt({
+      client,
+      actor: params.actor,
+      idempotencyKey: idem.idempotencyKey,
+      requestHash: idem.requestHash,
+      commandType: "quality.derogation.consume",
+      aggregateType: "DEROGATION",
+      aggregateId: params.id,
+      requestPayload: { id: params.id, ...params.body },
+      resultPayload: { consumption_id: consumptionId },
+      correlationId: params.id,
+    });
+
+    return { consumption_id: consumptionId, derogation: (await loadDerogation(client, params.id))! };
+  });
+}
+
+/* ========================================================================== */
+/* Non-conformités : analyse guidée et transitions étendues                    */
+/* ========================================================================== */
+
+export async function repoUpsertNcAnalysis(params: {
+  id: string;
+  body: UpsertAnalysisBodyDTO;
+  actor: QualityActor;
+}): Promise<{ steps: unknown[] } | null> {
+  return withTransaction(async (client) => {
+    const before = await client.query<{ id: string; updated_at: string; status: string }>(
+      `SELECT id, updated_at, status::text AS status FROM public.non_conformity WHERE id = $1::uuid FOR UPDATE`,
+      [params.id]
+    );
+    const nc = before.rows[0];
+    if (!nc) return null;
+
+    assertOptimisticVersion({
+      expectedUpdatedAt: params.body.expected_updated_at,
+      currentUpdatedAt: nc.updated_at,
+    });
+    if (nc.status === "CLOSED" || nc.status === "CANCELLED") {
+      throw new HttpError(
+        409,
+        "QUALITY_NC_CLOSED",
+        "Une non-conformité clôturée ou annulée ne se modifie pas : réouvrez-la."
+      );
+    }
+
+    const positions = new Set<number>();
+    const codes = new Set<string>();
+    for (const step of params.body.steps) {
+      if (step.method !== params.body.method) {
+        throw new HttpError(
+          422,
+          "QUALITY_ANALYSIS_METHOD_MISMATCH",
+          "Toutes les étapes doivent appartenir à la méthode demandée."
+        );
+      }
+      if (positions.has(step.position)) {
+        throw new HttpError(422, "QUALITY_ANALYSIS_POSITION_DUPLICATE", `Position dupliquée : ${step.position}.`);
+      }
+      if (codes.has(step.step_code)) {
+        throw new HttpError(422, "QUALITY_ANALYSIS_STEP_DUPLICATE", `Étape dupliquée : ${step.step_code}.`);
+      }
+      positions.add(step.position);
+      codes.add(step.step_code);
+    }
+
+    for (const step of params.body.steps) {
+      await client.query(
+        `
+          INSERT INTO public.non_conformity_analysis (
+            non_conformity_id, method, step_code, position, question, answer,
+            owner_user_id, due_date, completed_at, completed_by, created_by, updated_by
+          )
+          VALUES (
+            $1::uuid, $2, $3, $4, $5, $6,
+            $7, $8::date,
+            CASE WHEN $9 THEN now() ELSE NULL END,
+            CASE WHEN $9 THEN $10 ELSE NULL END,
+            $10, $10
+          )
+          ON CONFLICT (non_conformity_id, method, step_code) DO UPDATE
+          SET position = EXCLUDED.position,
+              question = EXCLUDED.question,
+              answer = EXCLUDED.answer,
+              owner_user_id = EXCLUDED.owner_user_id,
+              due_date = EXCLUDED.due_date,
+              completed_at = EXCLUDED.completed_at,
+              completed_by = EXCLUDED.completed_by,
+              updated_by = EXCLUDED.updated_by
+        `,
+        [
+          params.id,
+          step.method,
+          step.step_code,
+          step.position,
+          step.question,
+          step.answer,
+          step.owner_user_id,
+          step.due_date,
+          step.completed,
+          params.actor.user_id,
+        ]
+      );
+    }
+
+    await client.query(`UPDATE public.non_conformity SET updated_by = $2 WHERE id = $1::uuid`, [
+      params.id,
+      params.actor.user_id,
+    ]);
+
+    await insertQualityEvent(client, {
+      entity_type: "NON_CONFORMITY",
+      entity_id: params.id,
+      event_type: `ANALYSIS_${params.body.method}`,
+      actor: params.actor,
+      old_values: null,
+      new_values: { method: params.body.method, steps: params.body.steps.length },
+      correlation_id: params.id,
+    });
+    await insertAuditLog(client, params.actor, {
+      action: "qualite.nc.analysis",
+      entity_type: "non_conformity",
+      entity_id: params.id,
+      details: { method: params.body.method, steps: params.body.steps.length },
+    });
+
+    const steps = await client.query(
+      `
+        SELECT id, method, step_code, position, question, answer, owner_user_id,
+               due_date, completed_at, completed_by, created_at, updated_at
+        FROM public.non_conformity_analysis
+        WHERE non_conformity_id = $1::uuid
+        ORDER BY method ASC, position ASC
+      `,
+      [params.id]
+    );
+    return { steps: steps.rows };
+  });
+}
+
+export async function repoGetNcAnalysis(id: string): Promise<unknown[]> {
+  const res = await pool.query(
+    `
+      SELECT id, method, step_code, position, question, answer, owner_user_id,
+             due_date, completed_at, completed_by, created_at, updated_at
+      FROM public.non_conformity_analysis
+      WHERE non_conformity_id = $1::uuid
+      ORDER BY method ASC, position ASC
+    `,
+    [id]
+  );
+  return res.rows;
+}
+
+export async function repoTransitionNc(params: {
+  id: string;
+  body: NcTransitionBodyDTO;
+  actor: QualityActor;
+}): Promise<{ id: string; status: string } | null> {
+  return withTransaction(async (client) => {
+    const before = await client.query<{
+      id: string;
+      status: string;
+      updated_at: string;
+      root_cause: string | null;
+      capa_required: boolean;
+    }>(
+      `
+        SELECT id, status::text AS status, updated_at, root_cause, capa_required
+        FROM public.non_conformity WHERE id = $1::uuid FOR UPDATE
+      `,
+      [params.id]
+    );
+    const nc = before.rows[0];
+    if (!nc) return null;
+
+    assertOptimisticVersion({
+      expectedUpdatedAt: params.body.expected_updated_at,
+      currentUpdatedAt: nc.updated_at,
+    });
+    assertNcTransition(nc.status as QualityNcStatus, params.body.target_status as QualityNcStatus);
+
+    if (params.body.target_status === "CLOSED") {
+      const checks = await client.query<{
+        dispositions: number;
+        mandatory_capa: number;
+        verified_capa: number;
+        evidence: number;
+      }>(
+        `
+          SELECT
+            (SELECT COUNT(*)::int FROM public.non_conformity_dispositions WHERE non_conformity_id = $1::uuid) AS dispositions,
+            (SELECT COUNT(*)::int FROM public.quality_action WHERE non_conformity_id = $1::uuid AND mandatory) AS mandatory_capa,
+            (SELECT COUNT(*)::int FROM public.quality_action WHERE non_conformity_id = $1::uuid AND mandatory AND status = 'VERIFIED') AS verified_capa,
+            (SELECT COUNT(*)::int FROM public.quality_documents WHERE entity_type = 'NON_CONFORMITY' AND entity_id = $1::uuid AND removed_at IS NULL) AS evidence
+        `,
+        [params.id]
+      );
+      const row = checks.rows[0]!;
+      assertNcClosureAllowed({
+        hasDisposition: row.dispositions > 0,
+        mandatoryCapaCount: row.mandatory_capa,
+        verifiedCapaCount: row.verified_capa,
+        hasRootCause: Boolean((nc.root_cause ?? "").trim()),
+        hasEffectivenessEvidence: row.evidence > 0,
+      });
+    }
+
+    const extras: Record<string, string> = {
+      CLOSED: "closed_at = now(), closed_by = $3",
+      CANCELLED: "cancelled_at = now(), cancelled_by = $3, cancellation_reason = $4",
+      OPEN: nc.status === "CLOSED" ? "reopened_at = now(), reopened_by = $3, reopen_reason = $4, closed_at = NULL, closed_by = NULL" : "updated_at = now()",
+    };
+
+    await client.query(
+      `
+        UPDATE public.non_conformity
+        SET status = $2::public.quality_nc_status,
+            ${extras[params.body.target_status] ?? "updated_at = now()"},
+            updated_by = $3
+        WHERE id = $1::uuid
+      `,
+      [params.id, params.body.target_status, params.actor.user_id, params.body.reason ?? null]
+    );
+
+    await insertQualityEvent(client, {
+      entity_type: "NON_CONFORMITY",
+      entity_id: params.id,
+      event_type: `NC_${params.body.target_status}`,
+      actor: params.actor,
+      old_values: { status: nc.status },
+      new_values: { status: params.body.target_status },
+      correlation_id: params.id,
+      rule_code: "QUALITY_NC_TRANSITION",
+      reason: params.body.reason ?? null,
+    });
+    await insertAuditLog(client, params.actor, {
+      action: `qualite.nc.${params.body.target_status.toLowerCase()}`,
+      entity_type: "non_conformity",
+      entity_id: params.id,
+      details: { from: nc.status, to: params.body.target_status, reason: params.body.reason ?? null },
+    });
+
+    return { id: params.id, status: params.body.target_status };
+  });
+}
+
+/* ========================================================================== */
+/* Éligibilité et centre Qualité                                              */
+/* ========================================================================== */
+
+export async function repoEvaluateEligibility(
+  query: EligibilityQueryDTO
+): Promise<{ target: EligibilityTarget; verdict: ReturnType<typeof evaluateQualityEligibility> }> {
+  const lotRes =
+    query.object_type === "LOT"
+      ? await pool.query<{ lot_code: string | null; lot_status: string | null }>(
+          `SELECT lot_code, lot_status FROM public.lots WHERE id = $1::uuid`,
+          [query.object_id]
+        )
+      : { rows: [] as Array<{ lot_code: string | null; lot_status: string | null }> };
+
+  const aggregates = await pool.query<{
+    qty_released: string;
+    qty_held: string;
+    qty_consumed: string;
+    pending_controls: number;
+  }>(
+    `
+      SELECT COALESCE(SUM(qty_released), 0)::text AS qty_released,
+             COALESCE(SUM(qty_held), 0)::text AS qty_held,
+             COALESCE(SUM(qty_consumed), 0)::text AS qty_consumed,
+             COUNT(*) FILTER (WHERE validation_date IS NULL)::int AS pending_controls
+      FROM public.quality_control
+      WHERE source_type = $1 AND source_id = $2
+    `,
+    [query.object_type, query.object_id]
+  );
+
+  // Les NC ouvertes ne bloquent que l'objet exact auquel elles sont rattachées :
+  // pas de blocage global d'articles non concernés.
+  const ncRes =
+    query.object_type === "LOT"
+      ? await pool.query<{ total: number }>(
+          `
+            SELECT COUNT(*)::int AS total
+            FROM public.non_conformity nc
+            WHERE nc.status::text NOT IN ('CLOSED', 'CANCELLED')
+              AND nc.lot_id = $1::uuid
+              AND NOT EXISTS (
+                SELECT 1 FROM public.non_conformity_dispositions d WHERE d.non_conformity_id = nc.id
+              )
+          `,
+          [query.object_id]
+        )
+      : { rows: [{ total: 0 }] };
+
+  const agg = aggregates.rows[0];
+  const target: EligibilityTarget = {
+    object_type: query.object_type,
+    object_id: query.object_id,
+    label: lotRes.rows[0]?.lot_code ?? null,
+    qty_requested: query.qty,
+    lot_status: (lotRes.rows[0]?.lot_status ?? null) as EligibilityTarget["lot_status"],
+    qty_released: toNumber(agg?.qty_released),
+    qty_held: toNumber(agg?.qty_held),
+    qty_consumed: toNumber(agg?.qty_consumed),
+    open_nc_without_disposition: ncRes.rows[0]?.total ?? 0,
+    pending_mandatory_controls: agg?.pending_controls ?? 0,
+    derogation: null,
+  };
+
+  return {
+    target,
+    verdict: evaluateQualityEligibility(target, query.purpose as QualityEligibilityPurpose, new Date()),
+  };
+}
+
+export type QualityCenter = {
+  queues: {
+    to_control: number;
+    awaiting_decision: number;
+    quarantine_lots: number;
+    open_non_conformities: number;
+    overdue_capa: number;
+    derogations_to_approve: number;
+    derogations_expiring: number;
+    snapshot_integrity_alerts: number;
+  };
+};
+
+export async function repoQualityCenter(params: { horizonDays: number }): Promise<QualityCenter> {
+  const res = await pool.query<{
+    to_control: number;
+    awaiting_decision: number;
+    quarantine_lots: number;
+    open_non_conformities: number;
+    overdue_capa: number;
+    derogations_to_approve: number;
+    derogations_expiring: number;
+  }>(
+    `
+      SELECT
+        (SELECT COUNT(*)::int FROM public.quality_control
+          WHERE status IN ('PLANNED', 'IN_PROGRESS')) AS to_control,
+        (SELECT COUNT(*)::int FROM public.quality_control
+          WHERE validation_date IS NULL AND verdict_computed IS NOT NULL AND verdict_computed <> 'EN_ATTENTE') AS awaiting_decision,
+        (SELECT COUNT(*)::int FROM public.lots
+          WHERE lot_status IN ('QUARANTAINE', 'EN_ATTENTE', 'BLOQUE')) AS quarantine_lots,
+        (SELECT COUNT(*)::int FROM public.non_conformity
+          WHERE status::text NOT IN ('CLOSED', 'CANCELLED')) AS open_non_conformities,
+        (SELECT COUNT(*)::int FROM public.quality_action
+          WHERE status <> 'VERIFIED' AND due_date IS NOT NULL AND due_date < CURRENT_DATE) AS overdue_capa,
+        (SELECT COUNT(*)::int FROM public.quality_derogation
+          WHERE status = 'SUBMITTED') AS derogations_to_approve,
+        (SELECT COUNT(*)::int FROM public.quality_derogation
+          WHERE status = 'APPROVED' AND valid_to IS NOT NULL
+            AND valid_to <= now() + ($1 || ' days')::interval) AS derogations_expiring
+    `,
+    [String(params.horizonDays)]
+  );
+
+  // Alertes d'intégrité : contrôles dont le snapshot ne correspond plus à son
+  // empreinte. Le calcul est fait en TypeScript avec le même JSON canonique.
+  const snapshots = await pool.query<{ id: string; plan_snapshot: unknown; plan_snapshot_sha256: string }>(
+    `
+      SELECT id, plan_snapshot, plan_snapshot_sha256
+      FROM public.quality_control
+      WHERE plan_snapshot_sha256 IS NOT NULL
+      ORDER BY updated_at DESC
+      LIMIT 500
+    `
+  );
+  let integrityAlerts = 0;
+  for (const row of snapshots.rows) {
+    if (qualitySha256(row.plan_snapshot) !== row.plan_snapshot_sha256) integrityAlerts += 1;
+  }
+
+  const row = res.rows[0]!;
+  return {
+    queues: {
+      to_control: row.to_control,
+      awaiting_decision: row.awaiting_decision,
+      quarantine_lots: row.quarantine_lots,
+      open_non_conformities: row.open_non_conformities,
+      overdue_capa: row.overdue_capa,
+      derogations_to_approve: row.derogations_to_approve,
+      derogations_expiring: row.derogations_expiring,
+      snapshot_integrity_alerts: integrityAlerts,
+    },
+  };
+}

--- a/src/module/qualite/routes/quality-360.routes.ts
+++ b/src/module/qualite/routes/quality-360.routes.ts
@@ -1,0 +1,103 @@
+import { Router, type RequestHandler } from "express";
+
+import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import { requireQualityCapability } from "../middlewares/quality-authorization.middleware";
+import {
+  consumeDerogation,
+  createDerogation,
+  createExecution,
+  createPlan,
+  decideExecution,
+  evaluateEligibility,
+  getDerogation,
+  getExecution,
+  getNcAnalysis,
+  getPlan,
+  listDerogations,
+  listExecutions,
+  listPlans,
+  planApplicability,
+  previewExecution,
+  previewVerdict,
+  qualityCenter,
+  recordMeasurements,
+  revisePlan,
+  transitionDerogation,
+  transitionNc,
+  transitionPlan,
+  updatePlan,
+  upsertNcAnalysis,
+} from "../controllers/quality-360.controller";
+
+/**
+ * Surface Qualité 360 (#228), montée sous `/qualite/v2`.
+ *
+ * Elle n'hérite PAS du garde global `requireQualityOrAdmin` du routeur
+ * historique : chaque route déclare sa capacité fine, refus par défaut. Le
+ * routeur historique reste inchangé pour ne casser aucun écran en production.
+ */
+const router = Router();
+router.use(authenticateToken);
+
+/**
+ * La capacité exigée dépend de la transition demandée : soumettre relève du
+ * demandeur, approuver/refuser/révoquer de l'approbateur. Le corps est relu par
+ * le validateur puis par le domaine ; ce garde n'est qu'un premier filtre.
+ */
+const requireDerogationTransitionCapability: RequestHandler = (req, res, next) => {
+  const target = (req.body as { target_status?: unknown } | undefined)?.target_status;
+  const capability =
+    target === "SUBMITTED" || target === "DRAFT" ? "derogation_request" : "derogation_approve";
+  requireQualityCapability(capability)(req, res, next);
+};
+
+// Centre Qualité et éligibilité (lecture).
+router.get("/center", requireQualityCapability("read"), qualityCenter);
+router.get("/eligibility", requireQualityCapability("read"), evaluateEligibility);
+
+// Plans de contrôle.
+router.get("/plans", requireQualityCapability("read"), listPlans);
+router.get("/plans/applicability", requireQualityCapability("read"), planApplicability);
+router.get("/plans/:id", requireQualityCapability("read"), getPlan);
+router.post("/plans", requireQualityCapability("referential_manage"), createPlan);
+router.patch("/plans/:id", requireQualityCapability("referential_manage"), updatePlan);
+router.post("/plans/:id/revisions", requireQualityCapability("referential_manage"), revisePlan);
+// Publier/archiver est une capacité distincte de l'édition du référentiel.
+router.post("/plans/:id/transitions", requireQualityCapability("plan_publish"), transitionPlan);
+
+// Exécutions de contrôle.
+router.get("/executions", requireQualityCapability("read"), listExecutions);
+router.get("/executions/:id", requireQualityCapability("read"), getExecution);
+router.post("/executions/preview", requireQualityCapability("execution_run"), previewExecution);
+router.post("/executions", requireQualityCapability("execution_run"), createExecution);
+router.post(
+  "/executions/:id/measurements",
+  requireQualityCapability("measurement_write"),
+  recordMeasurements
+);
+router.get("/executions/:id/verdict-preview", requireQualityCapability("read"), previewVerdict);
+// La décision de libération est séparée de la saisie de mesure.
+router.post("/executions/:id/decision", requireQualityCapability("release_decide"), decideExecution);
+
+// Dérogations / concessions.
+router.get("/derogations", requireQualityCapability("read"), listDerogations);
+router.get("/derogations/:id", requireQualityCapability("read"), getDerogation);
+router.post("/derogations", requireQualityCapability("derogation_request"), createDerogation);
+// Soumettre est un droit de demandeur ; approuver/refuser/révoquer non.
+router.post(
+  "/derogations/:id/transitions",
+  requireDerogationTransitionCapability,
+  transitionDerogation
+);
+router.post(
+  "/derogations/:id/consumptions",
+  requireQualityCapability("release_decide"),
+  consumeDerogation
+);
+
+// Non-conformités : analyse guidée et cycle de vie étendu.
+router.get("/non-conformities/:id/analysis", requireQualityCapability("read"), getNcAnalysis);
+router.put("/non-conformities/:id/analysis", requireQualityCapability("nc_manage"), upsertNcAnalysis);
+router.post("/non-conformities/:id/transitions", requireQualityCapability("nc_manage"), transitionNc);
+
+export default router;

--- a/src/module/qualite/services/quality-360.service.ts
+++ b/src/module/qualite/services/quality-360.service.ts
@@ -1,0 +1,58 @@
+// Service Qualité 360 (#228) — couche mince : la règle métier vit dans
+// `domain/` et l'accès transactionnel dans `repository/`.
+
+import {
+  repoConsumeDerogation,
+  repoCreateDerogation,
+  repoCreateExecution,
+  repoCreatePlan,
+  repoDecideExecution,
+  repoEvaluateEligibility,
+  repoGetDerogation,
+  repoGetExecution,
+  repoGetNcAnalysis,
+  repoGetPlan,
+  repoListDerogations,
+  repoListExecutions,
+  repoListPlans,
+  repoPlanApplicability,
+  repoPreviewExecution,
+  repoPreviewVerdict,
+  repoQualityCenter,
+  repoRecordMeasurements,
+  repoRevisePlan,
+  repoTransitionDerogation,
+  repoTransitionNc,
+  repoTransitionPlan,
+  repoUpdatePlan,
+  repoUpsertNcAnalysis,
+} from "../repository/quality-360.repository";
+
+export const svcListPlans = repoListPlans;
+export const svcGetPlan = repoGetPlan;
+export const svcCreatePlan = repoCreatePlan;
+export const svcUpdatePlan = repoUpdatePlan;
+export const svcTransitionPlan = repoTransitionPlan;
+export const svcRevisePlan = repoRevisePlan;
+export const svcPlanApplicability = repoPlanApplicability;
+
+export const svcListExecutions = repoListExecutions;
+export const svcGetExecution = repoGetExecution;
+export const svcPreviewExecution = repoPreviewExecution;
+export const svcCreateExecution = repoCreateExecution;
+export const svcRecordMeasurements = repoRecordMeasurements;
+export const svcPreviewVerdict = repoPreviewVerdict;
+export const svcDecideExecution = repoDecideExecution;
+
+export const svcListDerogations = repoListDerogations;
+export const svcGetDerogation = repoGetDerogation;
+export const svcCreateDerogation = repoCreateDerogation;
+export const svcTransitionDerogation = repoTransitionDerogation;
+export const svcConsumeDerogation = repoConsumeDerogation;
+
+export const svcGetNcAnalysis = repoGetNcAnalysis;
+export const svcUpsertNcAnalysis = repoUpsertNcAnalysis;
+export const svcTransitionNc = repoTransitionNc;
+
+export const svcEvaluateEligibility = repoEvaluateEligibility;
+export const svcQualityCenter = repoQualityCenter;

--- a/src/module/qualite/validators/quality-360.validators.ts
+++ b/src/module/qualite/validators/quality-360.validators.ts
@@ -1,0 +1,500 @@
+// Validateurs Zod stricts pour la surface Qualité 360 (#228).
+// Toutes les bornes (pagination, tri, longueurs, quantités) sont serveur ;
+// aucun champ inconnu n'est accepté.
+
+import { z } from "zod";
+
+import {
+  QUALITY_CHARACTERISTIC_TYPES,
+  QUALITY_CRITICALITIES,
+  QUALITY_SAMPLING_RULES,
+  QUALITY_TRIGGERS,
+  QUALITY_VALUE_KINDS,
+} from "../domain/quality-plan";
+import {
+  QUALITY_DEROGATION_STATUSES,
+  QUALITY_DISPOSITION_TYPES,
+  QUALITY_NC_STATUSES,
+  QUALITY_PLAN_STATUSES,
+  QUALITY_VERDICTS,
+} from "../domain/quality-policy";
+import {
+  QUALITY_ELIGIBILITY_PURPOSES,
+  QUALITY_RELEASE_DECISIONS,
+  QUALITY_SOURCE_TYPES,
+} from "../domain/quality-release";
+
+const uuid = z.string().uuid();
+const optionalUuid = uuid.nullable().optional();
+
+const isoDateTime = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((v) => Number.isFinite(Date.parse(v)), "Date-heure invalide");
+
+const shortText = (max: number) => z.string().trim().min(1).max(max);
+const longText = (max: number) => z.string().trim().max(max);
+
+// Les quantités sont finies, positives ou nulles et bornées : un Infinity ou un
+// NaN ne franchit jamais la validation.
+const quantity = z
+  .number()
+  .refine((v) => Number.isFinite(v), "Quantité non finie")
+  .refine((v) => v >= 0, "Quantité négative")
+  .refine((v) => v <= 1_000_000_000, "Quantité hors limites");
+
+const positiveQuantity = quantity.refine((v) => v > 0, "Quantité strictement positive requise");
+
+const unite = z.string().trim().min(1).max(16);
+
+export const paginationSchema = z.object({
+  page: z.coerce.number().int().min(1).max(10_000).default(1),
+  pageSize: z.coerce.number().int().min(1).max(200).default(25),
+  sortDir: z.enum(["asc", "desc"]).default("desc"),
+});
+
+export const idParamSchema = z.object({ params: z.object({ id: uuid }) });
+
+/* -------------------------------------------------------------------------- */
+/* Plans de contrôle                                                          */
+/* -------------------------------------------------------------------------- */
+
+export const samplingSchema = z
+  .object({
+    rule: z.enum(QUALITY_SAMPLING_RULES),
+    value: z.number().finite().positive().max(100_000).nullable().default(null),
+    justification: longText(500).nullable().default(null),
+  })
+  .strict();
+
+export const planCharacteristicInputSchema = z
+  .object({
+    characteristic_key: z
+      .string()
+      .trim()
+      .min(1)
+      .max(40)
+      .regex(/^[A-Z0-9][A-Z0-9._-]*$/i, "Clé de caractéristique invalide (A-Z, 0-9, . _ -)"),
+    position: z.number().int().min(1).max(500),
+    label: shortText(200),
+    characteristic_type: z.enum(QUALITY_CHARACTERISTIC_TYPES),
+    value_kind: z.enum(QUALITY_VALUE_KINDS),
+    unit: z.string().trim().min(1).max(16).nullable().default(null),
+    nominal: z.number().finite().nullable().default(null),
+    tolerance_min: z.number().finite().nullable().default(null),
+    tolerance_max: z.number().finite().nullable().default(null),
+    precision: z.number().int().min(0).max(9).nullable().default(null),
+    expected_boolean: z.boolean().nullable().default(null),
+    allowed_values: z.array(shortText(80)).min(1).max(50).nullable().default(null),
+    criticality: z.enum(QUALITY_CRITICALITIES),
+    mandatory: z.boolean().default(true),
+    requires_instrument: z.boolean().default(false),
+    instrument_category: z.string().trim().min(1).max(60).nullable().default(null),
+    method: longText(500).nullable().default(null),
+    acceptance_rule: longText(500).nullable().default(null),
+    sampling: samplingSchema,
+    trigger: z.enum(QUALITY_TRIGGERS),
+  })
+  .strict();
+
+export type PlanCharacteristicInputDTO = z.infer<typeof planCharacteristicInputSchema>;
+
+const planScopeShape = {
+  article_id: optionalUuid,
+  piece_technique_id: optionalUuid,
+  piece_version_id: optionalUuid,
+  famille_id: optionalUuid,
+  operation_code: z.string().trim().min(1).max(40).nullable().optional(),
+  fournisseur_id: optionalUuid,
+};
+
+export const createPlanSchema = z.object({
+  body: z
+    .object({
+      label: shortText(200),
+      trigger_type: z.enum(QUALITY_TRIGGERS),
+      ...planScopeShape,
+      sampling: samplingSchema,
+      owner_user_id: z.number().int().positive().nullable().optional(),
+      revision_reason: longText(500).nullable().optional(),
+      effective_from: isoDateTime.nullable().optional(),
+      effective_to: isoDateTime.nullable().optional(),
+      characteristics: z.array(planCharacteristicInputSchema).min(1).max(200),
+    })
+    .strict()
+    .refine(
+      (b) =>
+        Boolean(b.article_id || b.piece_technique_id || b.piece_version_id || b.famille_id),
+      { message: "Au moins un axe produit est requis (article, pièce, version ou famille)", path: ["piece_technique_id"] }
+    ),
+});
+export type CreatePlanBodyDTO = z.infer<typeof createPlanSchema>["body"];
+
+export const updatePlanSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      expected_updated_at: isoDateTime,
+      label: shortText(200).optional(),
+      sampling: samplingSchema.optional(),
+      owner_user_id: z.number().int().positive().nullable().optional(),
+      revision_reason: longText(500).nullable().optional(),
+      effective_from: isoDateTime.nullable().optional(),
+      effective_to: isoDateTime.nullable().optional(),
+      characteristics: z.array(planCharacteristicInputSchema).min(1).max(200).optional(),
+    })
+    .strict(),
+});
+export type UpdatePlanBodyDTO = z.infer<typeof updatePlanSchema>["body"];
+
+export const planTransitionSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      target_status: z.enum(QUALITY_PLAN_STATUSES),
+      expected_updated_at: isoDateTime,
+      reason: longText(500).nullable().optional(),
+    })
+    .strict(),
+});
+export type PlanTransitionBodyDTO = z.infer<typeof planTransitionSchema>["body"];
+
+export const revisePlanSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      revision_reason: shortText(500),
+    })
+    .strict(),
+});
+
+export const listPlansQuerySchema = paginationSchema.extend({
+  q: z.string().trim().max(120).optional(),
+  status: z.enum(QUALITY_PLAN_STATUSES).optional(),
+  trigger_type: z.enum(QUALITY_TRIGGERS).optional(),
+  article_id: uuid.optional(),
+  piece_technique_id: uuid.optional(),
+  piece_version_id: uuid.optional(),
+  famille_id: uuid.optional(),
+  fournisseur_id: uuid.optional(),
+  sortBy: z.enum(["code", "version", "label", "status", "updated_at", "published_at"]).default("updated_at"),
+});
+export type ListPlansQueryDTO = z.infer<typeof listPlansQuerySchema>;
+
+export const planApplicabilityQuerySchema = z
+  .object({
+    trigger: z.enum(QUALITY_TRIGGERS),
+    article_id: uuid.optional(),
+    piece_technique_id: uuid.optional(),
+    piece_version_id: uuid.optional(),
+    famille_id: uuid.optional(),
+    operation_code: z.string().trim().min(1).max(40).optional(),
+    fournisseur_id: uuid.optional(),
+    at: isoDateTime.optional(),
+  })
+  .strict();
+export type PlanApplicabilityQueryDTO = z.infer<typeof planApplicabilityQuerySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Exécutions de contrôle                                                     */
+/* -------------------------------------------------------------------------- */
+
+export const executionPreviewSchema = z.object({
+  body: z
+    .object({
+      source_type: z.enum(QUALITY_SOURCE_TYPES),
+      source_id: shortText(64),
+      trigger: z.enum(QUALITY_TRIGGERS),
+      population: positiveQuantity,
+      unite,
+      article_id: optionalUuid,
+      piece_technique_id: optionalUuid,
+      piece_version_id: optionalUuid,
+      famille_id: optionalUuid,
+      operation_code: z.string().trim().min(1).max(40).nullable().optional(),
+      fournisseur_id: optionalUuid,
+      lot_id: optionalUuid,
+      of_id: z.number().int().positive().nullable().optional(),
+      reception_ligne_id: optionalUuid,
+    })
+    .strict(),
+});
+export type ExecutionPreviewBodyDTO = z.infer<typeof executionPreviewSchema>["body"];
+
+export const createExecutionSchema = z.object({
+  body: executionPreviewSchema.shape.body.extend({
+    preview_sha256: z
+      .string()
+      .trim()
+      .regex(/^[a-f0-9]{64}$/, "Empreinte d'aperçu invalide"),
+    controlled_by: z.number().int().positive().nullable().optional(),
+    comments: longText(2000).nullable().optional(),
+  }),
+});
+export type CreateExecutionBodyDTO = z.infer<typeof createExecutionSchema>["body"];
+
+export const measurementInputSchema = z
+  .object({
+    characteristic_key: shortText(40),
+    sample_no: z.number().int().min(1).max(10_000),
+    value_numeric: z.number().finite().nullable().default(null),
+    value_boolean: z.boolean().nullable().default(null),
+    value_text: longText(2000).nullable().default(null),
+    unit: z.string().trim().min(1).max(16).nullable().default(null),
+    instrument_id: optionalUuid,
+    comment: longText(1000).nullable().default(null),
+  })
+  .strict();
+export type MeasurementInputDTO = z.infer<typeof measurementInputSchema>;
+
+export const recordMeasurementsSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      expected_updated_at: isoDateTime,
+      measurements: z.array(measurementInputSchema).min(1).max(500),
+      // Motif obligatoire dès qu'une mesure existante est corrigée.
+      correction_reason: z.string().trim().min(5).max(500).nullable().optional(),
+    })
+    .strict(),
+});
+export type RecordMeasurementsBodyDTO = z.infer<typeof recordMeasurementsSchema>["body"];
+
+export const verdictPreviewSchema = z.object({ params: z.object({ id: uuid }) });
+
+export const decideExecutionSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      expected_updated_at: isoDateTime,
+      preview_sha256: z.string().trim().regex(/^[a-f0-9]{64}$/, "Empreinte d'aperçu invalide"),
+      decision: z.enum(QUALITY_RELEASE_DECISIONS),
+      qty: quantity,
+      unite,
+      object_type: z.enum(QUALITY_SOURCE_TYPES),
+      object_id: shortText(64),
+      verdict_override: z.enum(QUALITY_VERDICTS).nullable().optional(),
+      justification: longText(2000).nullable().optional(),
+      derogation_id: optionalUuid,
+    })
+    .strict(),
+});
+export type DecideExecutionBodyDTO = z.infer<typeof decideExecutionSchema>["body"];
+
+export const listExecutionsQuerySchema = paginationSchema.extend({
+  q: z.string().trim().max(120).optional(),
+  status: z.enum(["PLANNED", "IN_PROGRESS", "VALIDATED", "REJECTED"]).optional(),
+  verdict: z.enum(QUALITY_VERDICTS).optional(),
+  trigger: z.enum(QUALITY_TRIGGERS).optional(),
+  source_type: z.enum(QUALITY_SOURCE_TYPES).optional(),
+  source_id: z.string().trim().max(64).optional(),
+  plan_id: uuid.optional(),
+  lot_id: uuid.optional(),
+  sortBy: z.enum(["control_date", "updated_at", "verdict", "reference"]).default("control_date"),
+});
+export type ListExecutionsQueryDTO = z.infer<typeof listExecutionsQuerySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Dérogations / concessions                                                  */
+/* -------------------------------------------------------------------------- */
+
+const derogationScopeShape = {
+  article_id: optionalUuid,
+  piece_technique_id: optionalUuid,
+  piece_version_id: optionalUuid,
+  lot_id: optionalUuid,
+  of_id: z.number().int().positive().nullable().optional(),
+  commande_id: optionalUuid,
+  bon_livraison_id: optionalUuid,
+};
+
+export const createDerogationSchema = z.object({
+  body: z
+    .object({
+      derogation_type: z.enum(["CONCESSION", "DEVIATION_PERMIT", "SPECIAL_ACCEPTANCE"]),
+      non_conformity_id: optionalUuid,
+      client_id: z.string().trim().min(1).max(40).nullable().optional(),
+      fournisseur_id: optionalUuid,
+      ...derogationScopeShape,
+      requirement: shortText(500),
+      deviation: shortText(2000),
+      risk_analysis: longText(4000).nullable().optional(),
+      conditions: longText(4000).nullable().optional(),
+      max_qty: positiveQuantity.nullable().optional(),
+      unite: unite.nullable().optional(),
+      valid_from: isoDateTime.nullable().optional(),
+      valid_to: isoDateTime.nullable().optional(),
+      customer_agreement_reference: z.string().trim().min(1).max(120).nullable().optional(),
+    })
+    .strict()
+    .refine(
+      (b) =>
+        Boolean(
+          b.article_id ||
+            b.piece_technique_id ||
+            b.piece_version_id ||
+            b.lot_id ||
+            b.of_id ||
+            b.commande_id ||
+            b.bon_livraison_id
+        ),
+      { message: "Une dérogation exige un périmètre exploitable", path: ["lot_id"] }
+    )
+    .refine((b) => (b.max_qty === null || b.max_qty === undefined ? true : Boolean(b.unite)), {
+      message: "Une quantité maximale exige une unité",
+      path: ["unite"],
+    }),
+});
+export type CreateDerogationBodyDTO = z.infer<typeof createDerogationSchema>["body"];
+
+export const derogationTransitionSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      target_status: z.enum(QUALITY_DEROGATION_STATUSES),
+      expected_updated_at: isoDateTime,
+      reason: longText(1000).nullable().optional(),
+    })
+    .strict()
+    .refine(
+      (b) =>
+        b.target_status === "REJECTED" || b.target_status === "REVOKED"
+          ? Boolean((b.reason ?? "").trim())
+          : true,
+      { message: "Un refus ou une révocation exige un motif", path: ["reason"] }
+    ),
+});
+export type DerogationTransitionBodyDTO = z.infer<typeof derogationTransitionSchema>["body"];
+
+export const consumeDerogationSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      qty: positiveQuantity,
+      unite,
+      quality_control_id: optionalUuid,
+      release_decision_id: optionalUuid,
+      bon_livraison_id: optionalUuid,
+      context: z.record(z.union([z.string(), z.number(), z.boolean(), z.null()])).default({}),
+    })
+    .strict(),
+});
+export type ConsumeDerogationBodyDTO = z.infer<typeof consumeDerogationSchema>["body"];
+
+export const listDerogationsQuerySchema = paginationSchema.extend({
+  q: z.string().trim().max(120).optional(),
+  status: z.enum(QUALITY_DEROGATION_STATUSES).optional(),
+  non_conformity_id: uuid.optional(),
+  lot_id: uuid.optional(),
+  expiring_within_days: z.coerce.number().int().min(1).max(365).optional(),
+  sortBy: z.enum(["code", "status", "valid_to", "updated_at"]).default("updated_at"),
+});
+export type ListDerogationsQueryDTO = z.infer<typeof listDerogationsQuerySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Non-conformités : analyse guidée et transitions étendues                    */
+/* -------------------------------------------------------------------------- */
+
+export const analysisStepInputSchema = z
+  .object({
+    method: z.enum(["FIVE_WHY", "EIGHT_D"]),
+    step_code: shortText(20),
+    position: z.number().int().min(1).max(20),
+    question: longText(1000).nullable().default(null),
+    answer: longText(4000).nullable().default(null),
+    owner_user_id: z.number().int().positive().nullable().default(null),
+    due_date: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Date attendue au format YYYY-MM-DD")
+      .nullable()
+      .default(null),
+    completed: z.boolean().default(false),
+  })
+  .strict();
+export type AnalysisStepInputDTO = z.infer<typeof analysisStepInputSchema>;
+
+export const upsertAnalysisSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      expected_updated_at: isoDateTime,
+      method: z.enum(["FIVE_WHY", "EIGHT_D"]),
+      steps: z.array(analysisStepInputSchema).min(1).max(20),
+    })
+    .strict(),
+});
+export type UpsertAnalysisBodyDTO = z.infer<typeof upsertAnalysisSchema>["body"];
+
+export const ncTransitionSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      target_status: z.enum(QUALITY_NC_STATUSES),
+      expected_updated_at: isoDateTime,
+      reason: longText(1000).nullable().optional(),
+    })
+    .strict()
+    .refine(
+      (b) =>
+        b.target_status === "CANCELLED" || b.target_status === "OPEN"
+          ? true
+          : true,
+      { message: "Motif requis", path: ["reason"] }
+    ),
+});
+export type NcTransitionBodyDTO = z.infer<typeof ncTransitionSchema>["body"];
+
+export const dispositionPreviewSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      disposition_type: z.enum(QUALITY_DISPOSITION_TYPES),
+      qty: quantity,
+      unite,
+      instructions: longText(2000).nullable().optional(),
+      derogation_id: optionalUuid,
+      quality_control_id: optionalUuid,
+    })
+    .strict(),
+});
+export type DispositionPreviewBodyDTO = z.infer<typeof dispositionPreviewSchema>["body"];
+
+export const dispositionConfirmSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: dispositionPreviewSchema.shape.body.extend({
+    preview_sha256: z.string().trim().regex(/^[a-f0-9]{64}$/, "Empreinte d'aperçu invalide"),
+  }),
+});
+export type DispositionConfirmBodyDTO = z.infer<typeof dispositionConfirmSchema>["body"];
+
+/* -------------------------------------------------------------------------- */
+/* Éligibilité                                                                */
+/* -------------------------------------------------------------------------- */
+
+export const eligibilityQuerySchema = z
+  .object({
+    purpose: z.enum(QUALITY_ELIGIBILITY_PURPOSES),
+    object_type: z.enum(QUALITY_SOURCE_TYPES),
+    object_id: shortText(64),
+    // Query string : la quantité arrive en texte, on la contraint puis on
+    // applique les mêmes bornes que dans un corps JSON.
+    qty: z.coerce
+      .number()
+      .refine((v) => Number.isFinite(v), "Quantité non finie")
+      .refine((v) => v >= 0, "Quantité négative")
+      .refine((v) => v <= 1_000_000_000, "Quantité hors limites"),
+  })
+  .strict();
+export type EligibilityQueryDTO = z.infer<typeof eligibilityQuerySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Centre Qualité                                                             */
+/* -------------------------------------------------------------------------- */
+
+export const qualityCenterQuerySchema = z
+  .object({
+    horizon_days: z.coerce.number().int().min(1).max(365).default(30),
+  })
+  .strict();
+export type QualityCenterQueryDTO = z.infer<typeof qualityCenterQuerySchema>;

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -22,6 +22,7 @@ import tarificationRoutes from "../module/facturation/routes/tarification.routes
 import reportingRoutes from "../module/facturation/routes/reporting.routes";
 import productionRoutes from "../module/production/routes/production.routes";
 import qualiteRoutes from "../module/qualite/routes/qualite.routes";
+import quality360Routes from "../module/qualite/routes/quality-360.routes";
 import livraisonsRoutes from "../module/livraisons/routes/livraisons.routes";
 import planningRoutes from "../module/planning/routes/planning.routes";
 import stockRoutes from "../module/stock/routes/stock.routes";
@@ -76,6 +77,9 @@ router.use("/reporting", reportingRoutes);
 router.use("/production", productionRoutes);
 router.use("/planning", planningRoutes);
 router.use("/programmations", programmationRoutes);
+// Qualité 360 (#228) monté AVANT le routeur historique : ses routes déclarent
+// des capacités fines et ne doivent pas hériter du garde global hérité.
+router.use("/qualite/v2", quality360Routes);
 router.use("/qualite", qualiteRoutes);
 router.use("/livraisons", livraisonsRoutes);
 router.use("/stock", stockRoutes);

--- a/src/shared/codes/code-generator.service.ts
+++ b/src/shared/codes/code-generator.service.ts
@@ -101,7 +101,26 @@ export async function generateArticleBusinessCode(tx: DbQueryer, familyCode: str
 
 export async function generateTransactionalBusinessCode(
   tx: DbQueryer,
-  input: { prefix: "DEV" | "CMD" | "AFF" | "OF" | "LOT" | "MVT" | "CQ" | "NC" | "CAPA" | "BL" | "FACT" | "BCF"; date?: Date; width?: number }
+  input: {
+    prefix:
+      | "DEV"
+      | "CMD"
+      | "AFF"
+      | "OF"
+      | "LOT"
+      | "MVT"
+      | "CQ"
+      | "NC"
+      | "CAPA"
+      | "BL"
+      | "FACT"
+      | "BCF"
+      // #228: plans de contrôle et dérogations qualité.
+      | "PC"
+      | "DER";
+    date?: Date;
+    width?: number;
+  }
 ): Promise<string> {
   const year = yearFromDate(input.date ?? new Date());
   const width =

--- a/src/shared/codes/code-validator.ts
+++ b/src/shared/codes/code-validator.ts
@@ -64,6 +64,17 @@ export const CODE_FORMATS = {
     example: "CAPA-2026-000001",
     hintText: "Format cible: CAPA-2026-000001 (CAP historique accepté)",
   },
+  // #228 — plans de contrôle versionnés et dérogations/concessions qualité.
+  controlPlan: {
+    regex: /^PC-\d{4}-\d{6}$/,
+    example: "PC-2026-000001",
+    hintText: "Format attendu: PC-2026-000001",
+  },
+  derogation: {
+    regex: /^DER-\d{4}-\d{6}$/,
+    example: "DER-2026-000001",
+    hintText: "Format attendu: DER-2026-000001",
+  },
 } as const;
 
 export type CodeFormatKey = keyof typeof CODE_FORMATS;


### PR DESCRIPTION
## Release
Promouvoir `dev` vers `main` après fusion de la PR #130 pour le chantier Qualité industrielle 360.

## Validation
- build réussi
- 90 fichiers de tests / 1 805 tests réussis
- patch `20260725_qualite_360_228.sql` appliqué et vérifié sur `cerp_test`
- sauvegarde de test : `/var/backups/cerp/cerp_test_20260725-1947_quality228_pre.dump`

## Exploitation
Après fusion, sauvegarde obligatoire de `cerp_prod`, application transactionnelle du patch, enregistrement du checksum et vérification prod-safe.