### PR TITLE
fix(rbac): tous les droits métier pour l’administrateur

### DIFF
--- a/docs/http/facturation-227.md
+++ b/docs/http/facturation-227.md
@@ -4,6 +4,11 @@ Préfixe : `/api/v1`. Toutes les routes sont authentifiées et protégées par u
 capacité Finance exacte. Toutes les mutations de workflow exigent
 `Idempotency-Key` (8 à 200 caractères).
 
+Le rôle `Administrateur Systeme et Reseau` dispose de toutes les capacités
+Finance. Les autres rôles restent évalués par capacité et les rôles inconnus
+sont refusés. Cette autorisation ne désactive ni la séparation des tâches sur
+un même document ni les écritures d'audit.
+
 ## Facture
 
 - `GET /factures/workflow/eligible-sources`

--- a/src/module/facturation/domain/finance-policy.test.ts
+++ b/src/module/facturation/domain/finance-policy.test.ts
@@ -91,12 +91,30 @@ describe("issue #227 — RBAC fail-closed", () => {
     ["Comptable", "payment_allocate", true],
     ["Directeur", "credit_issue", true],
     ["Administrateur Systeme et Reseau", "settings_manage", true],
-    ["Administrateur Systeme et Reseau", "issue", false],
+    ["Administrateur Systeme et Reseau", "issue", true],
     ["Responsable Comptabilite", "issue", false],
     ["admin", "settings_manage", false],
     ["", "read", false],
   ] as const)("%s / %s", (role, capability, expected) => {
     expect(roleHasFinanceCapability(role, capability)).toBe(expected);
+  });
+
+  it.each([
+    "read",
+    "draft_write",
+    "request_validation",
+    "validate",
+    "issue",
+    "credit_write",
+    "credit_issue",
+    "payment_register",
+    "payment_allocate",
+    "documents_read",
+    "audit_read",
+    "reporting_read",
+    "settings_manage",
+  ] as const)("accorde la capacité %s à l'administrateur système", (capability) => {
+    expect(roleHasFinanceCapability("Administrateur Systeme et Reseau", capability)).toBe(true);
   });
 });
 

--- a/src/module/facturation/domain/finance-policy.ts
+++ b/src/module/facturation/domain/finance-policy.ts
@@ -78,7 +78,9 @@ export function roleHasFinanceCapability(
   capability: FinanceCapability
 ): boolean {
   if (typeof role !== "string" || !role.trim()) return false;
-  return CAPABILITY_ROLES[capability].has(role.trim());
+  const normalizedRole = role.trim();
+  if (normalizedRole === ROLES.administrator) return true;
+  return CAPABILITY_ROLES[capability].has(normalizedRole);
 }
 
 const FACTURE_TRANSITIONS: Readonly<Record<FactureWorkflowStatus, readonly FactureWorkflowStatus[]>> = {


### PR DESCRIPTION
Closes #135. Le rôle Administrateur Systeme et Reseau obtient toutes les capacités Finance côté API. Les rôles inconnus et la séparation des tâches restent protégés; 109 tests ciblés passent.

## Summary by Sourcery

Grant the `Administrateur Systeme et Reseau` role full Finance capabilities while preserving fail-closed behavior for other and unknown roles.

New Features:
- Authorize the `Administrateur Systeme et Reseau` role for all Finance capabilities at the API level.

Bug Fixes:
- Ensure RBAC remains fail-closed for unknown roles and maintains task separation despite administrator Finance privileges.

Documentation:
- Document that the `Administrateur Systeme et Reseau` role now has all Finance capabilities while other roles remain capability-based.

Tests:
- Add targeted RBAC tests verifying that `Administrateur Systeme et Reseau` is granted each Finance capability and that other protections remain.