### PR TITLE
release: déployer le backend Métrologie 360 (#229)

### DIFF
--- a/db/patches/20260726_metrologie_360_229.sql
+++ b/db/patches/20260726_metrologie_360_229.sql
@@ -1,0 +1,1258 @@
+-- 20260726_metrologie_360_229.sql
+-- Issue #229 — Métrologie 360 : référentiel équipements, plans versionnés,
+-- étalonnages / vérifications, certificats privés, hors tolérance, quarantaine
+-- et analyse d'impact bornée.
+--
+-- Propriétés du patch :
+--   * ADDITIF uniquement : aucune table, colonne, contrainte ou donnée
+--     historique supprimée. `metrologie_equipements`, `metrologie_plan`,
+--     `metrologie_certificats` et `metrologie_event_log` sont ÉTENDUS, jamais
+--     remplacés par une seconde nomenclature.
+--   * IDEMPOTENT : rejouable sans effet de bord.
+--   * TRANSACTIONNEL : BEGIN/COMMIT, rien de partiel.
+--   * INACTIF sur le métier : ne crée aucun équipement, aucun plan, aucune
+--     exécution, aucune quarantaine et aucun dossier d'impact. Il ne renumérote
+--     rien et ne modifie aucun statut existant. Seules les CATÉGORIES (données
+--     de référentiel, désactivables) sont semées.
+--   * Réversible : `db/patches/support/20260726_metrologie_360_229.rollback.sql`
+--     (restreint à cerp_test, refuse de s'exécuter sur des données réelles).
+--
+-- Jamais exécuté en production par ce patch : l'application se fait sur
+-- cerp_test, puis cerp_prod uniquement sur autorisation humaine explicite.
+
+BEGIN;
+
+/* -------------------------------------------------------------------------- */
+/* 0) Pré-requis                                                              */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF to_regclass('public.metrologie_equipements') IS NULL THEN
+    RAISE EXCEPTION '#229 requires the Métrologie baseline (20260227_metrologie_calibration.sql)';
+  END IF;
+  IF to_regclass('public.metrologie_plan') IS NULL THEN
+    RAISE EXCEPTION '#229 requires public.metrologie_plan';
+  END IF;
+  IF to_regclass('public.metrologie_certificats') IS NULL THEN
+    RAISE EXCEPTION '#229 requires public.metrologie_certificats';
+  END IF;
+  IF to_regclass('public.quality_control') IS NULL THEN
+    RAISE EXCEPTION '#229 requires the Qualité baseline (20260213_qualite_module.sql)';
+  END IF;
+  IF to_regclass('public.users') IS NULL THEN
+    RAISE EXCEPTION '#229 requires public.users';
+  END IF;
+  IF to_regprocedure('public.fn_next_issued_code_value(text)') IS NULL THEN
+    RAISE EXCEPTION '#229: public.fn_next_issued_code_value(text) is missing — apply 20260713_codification_versions_of_vsm.sql first';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 1) Codification serveur                                                    */
+/*                                                                            */
+/*    Corps identique aux versions 20260713 / 20260721 / 20260722 / 20260725 : */
+/*    SEUL le périmètre autorisé change. #229 :                                */
+/*      - ajoute MET (équipement), MEX:AAAA (exécution), MIA:AAAA (impact) ;   */
+/*      - RESTAURE MCH (parc machines #165), perdu lors de la réécriture du    */
+/*        garde par 20260725_qualite_360_228.sql — sans quoi la création d'une */
+/*        machine échoue en 22023 sur une base à jour.                         */
+/* -------------------------------------------------------------------------- */
+
+CREATE OR REPLACE FUNCTION public.fn_next_issued_code_value(p_scope text)
+RETURNS bigint
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+DECLARE
+  v_scope text := upper(btrim(COALESCE(p_scope, '')));
+BEGIN
+  IF v_scope !~ '^(CLI|FOU|MCH|MET|ART:[A-Z0-9]{1,48}|(DEV|CMD|AFF|OF|LOT|MVT|CQ|NC|CAPA|BL|FACT|BCF|PC|DER|MEX|MIA):[0-9]{4})$' THEN
+    RAISE EXCEPTION 'Unsupported business-code sequence scope: %', p_scope
+      USING ERRCODE = '22023';
+  END IF;
+  RETURN nextval('public.cerp_business_code_issue_seq'::regclass);
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_next_issued_code_value(text) IS
+  'Whitelisted, non-reusable business-code allocator backed by a native PostgreSQL sequence. #229 adds MET/MEX/MIA (métrologie) and restores MCH (#165).';
+
+/* -------------------------------------------------------------------------- */
+/* 2) Référentiel des catégories d''équipement                                */
+/*                                                                            */
+/*    Référentiel administré et versionné : on DÉSACTIVE une catégorie         */
+/*    utilisée, on ne la supprime pas. Il ne remplace pas les familles         */
+/*    Articles/Stock : il ne décrit que des moyens de mesure.                  */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.metrologie_categories (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text NOT NULL,
+  parent_code text NULL,
+  label text NOT NULL,
+  description text NULL,
+  version integer NOT NULL DEFAULT 1,
+  active boolean NOT NULL DEFAULT true,
+  display_order integer NOT NULL DEFAULT 100,
+
+  -- Exigences de saisie pilotées par le référentiel : elles conditionnent la
+  -- validation serveur des spécifications de l'équipement.
+  requires_range boolean NOT NULL DEFAULT false,
+  requires_resolution boolean NOT NULL DEFAULT false,
+  requires_uncertainty boolean NOT NULL DEFAULT false,
+  requires_unit boolean NOT NULL DEFAULT false,
+  default_unit text NULL,
+  default_periodicity_months integer NULL,
+  default_operation_type text NOT NULL DEFAULT 'ETALONNAGE',
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  updated_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  CONSTRAINT metrologie_categories_code_229_uq UNIQUE (code),
+  CONSTRAINT metrologie_categories_code_229_ck CHECK (code ~ '^[A-Z0-9_]{2,40}$'),
+  CONSTRAINT metrologie_categories_parent_229_ck CHECK (parent_code IS NULL OR parent_code <> code),
+  CONSTRAINT metrologie_categories_version_229_ck CHECK (version >= 1),
+  CONSTRAINT metrologie_categories_periodicity_229_ck
+    CHECK (default_periodicity_months IS NULL OR default_periodicity_months BETWEEN 1 AND 600),
+  CONSTRAINT metrologie_categories_operation_229_ck
+    CHECK (default_operation_type IN ('ETALONNAGE', 'VERIFICATION'))
+);
+
+CREATE INDEX IF NOT EXISTS metrologie_categories_active_229_idx
+  ON public.metrologie_categories (active, display_order, code);
+
+CREATE INDEX IF NOT EXISTS metrologie_categories_parent_229_idx
+  ON public.metrologie_categories (parent_code);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_categories_parent_229_fkey'
+      AND conrelid = 'public.metrologie_categories'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_categories
+      ADD CONSTRAINT metrologie_categories_parent_229_fkey
+      FOREIGN KEY (parent_code) REFERENCES public.metrologie_categories(code)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+-- Semis du référentiel de base (données de référentiel, pas de données métier).
+INSERT INTO public.metrologie_categories
+  (code, label, display_order, requires_range, requires_resolution, requires_unit,
+   requires_uncertainty, default_unit, default_periodicity_months, default_operation_type)
+VALUES
+  ('PIED_A_COULISSE', 'Pied à coulisse',        10, true,  true,  true,  false, 'mm',   12, 'ETALONNAGE'),
+  ('MICROMETRE',      'Micromètre',             20, true,  true,  true,  false, 'mm',   12, 'ETALONNAGE'),
+  ('COMPARATEUR',     'Comparateur',            30, true,  true,  true,  false, 'mm',   12, 'ETALONNAGE'),
+  ('CALIBRE',         'Calibre / tampon',       40, false, false, true,  false, 'mm',   12, 'VERIFICATION'),
+  ('MMT',             'Machine à mesurer (MMT)',50, true,  true,  true,  true,  'mm',   12, 'ETALONNAGE'),
+  ('MACHINE_MESURE',  'Machine de mesure',      60, true,  true,  true,  true,  'mm',   12, 'ETALONNAGE'),
+  ('BALANCE',         'Balance / pesage',       70, true,  true,  true,  true,  'g',    12, 'ETALONNAGE'),
+  ('TEMPERATURE',     'Température',            80, true,  true,  true,  true,  '°C',   12, 'ETALONNAGE'),
+  ('PRESSION',        'Pression',               90, true,  true,  true,  true,  'bar',  12, 'ETALONNAGE'),
+  ('ETALON',          'Étalon / référence',    100, true,  true,  true,  true,  'mm',   24, 'ETALONNAGE'),
+  ('AUTRE',           'Autre (justifié)',      900, false, false, false, false, NULL,   12, 'VERIFICATION')
+ON CONFLICT (code) DO NOTHING;
+
+/* -------------------------------------------------------------------------- */
+/* 3) Registre équipement — extension                                         */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.metrologie_equipements
+  -- Référentiel contrôlé (le champ texte libre `categorie` reste en place pour
+  -- l'historique et les écrans existants).
+  ADD COLUMN IF NOT EXISTS categorie_code text NULL,
+  ADD COLUMN IF NOT EXISTS sous_categorie_code text NULL,
+
+  -- État de gouvernance. `statut` (ACTIF/INACTIF/REBUT) reste la vue héritée et
+  -- est tenu à jour par trigger : aucun écran existant ne casse.
+  ADD COLUMN IF NOT EXISTS etat text NOT NULL DEFAULT 'ACTIVE',
+  ADD COLUMN IF NOT EXISTS etat_motif text NULL,
+  ADD COLUMN IF NOT EXISTS etat_changed_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS etat_changed_by integer NULL,
+
+  -- Propriété, responsabilité, implantation.
+  ADD COLUMN IF NOT EXISTS proprietaire_service text NULL,
+  ADD COLUMN IF NOT EXISTS responsable_user_id integer NULL,
+  ADD COLUMN IF NOT EXISTS site text NULL,
+  ADD COLUMN IF NOT EXISTS magasin text NULL,
+  ADD COLUMN IF NOT EXISTS zone text NULL,
+  ADD COLUMN IF NOT EXISTS localisation_precise text NULL,
+
+  -- Cycle de vie physique.
+  ADD COLUMN IF NOT EXISTS date_mise_en_service date NULL,
+  ADD COLUMN IF NOT EXISTS date_retrait date NULL,
+
+  -- Spécifications STRUCTURÉES : tout ce qui conditionne l'éligibilité est une
+  -- colonne typée, jamais un blob texte.
+  ADD COLUMN IF NOT EXISTS unite text NULL,
+  ADD COLUMN IF NOT EXISTS plage_min numeric(18, 6) NULL,
+  ADD COLUMN IF NOT EXISTS plage_max numeric(18, 6) NULL,
+  ADD COLUMN IF NOT EXISTS resolution numeric(18, 6) NULL,
+  ADD COLUMN IF NOT EXISTS mpe numeric(18, 6) NULL,
+  ADD COLUMN IF NOT EXISTS incertitude numeric(18, 6) NULL,
+  ADD COLUMN IF NOT EXISTS methodes text[] NOT NULL DEFAULT '{}'::text[],
+  ADD COLUMN IF NOT EXISTS conditions_utilisation text NULL,
+  ADD COLUMN IF NOT EXISTS restrictions text NULL,
+  ADD COLUMN IF NOT EXISTS etalon_reference text NULL,
+  ADD COLUMN IF NOT EXISTS exige_certificat boolean NOT NULL DEFAULT false,
+  -- Complément non structurant (jamais source de vérité pour l'éligibilité).
+  ADD COLUMN IF NOT EXISTS specifications jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Quarantaine.
+  ADD COLUMN IF NOT EXISTS quarantine_reason text NULL,
+  ADD COLUMN IF NOT EXISTS quarantined_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS quarantined_by integer NULL,
+
+  -- Dernière preuve conforme admissible : borne basse de l'analyse d'impact.
+  ADD COLUMN IF NOT EXISTS last_conforme_execution_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS last_conforme_at timestamptz NULL;
+
+-- Reprise de l'état à partir du statut historique, une seule fois.
+UPDATE public.metrologie_equipements
+SET etat = CASE statut
+             WHEN 'ACTIF' THEN 'ACTIVE'
+             WHEN 'INACTIF' THEN 'SUSPENDED'
+             WHEN 'REBUT' THEN 'RETIRED'
+             ELSE 'ACTIVE'
+           END
+WHERE etat = 'ACTIVE'
+  AND statut <> 'ACTIF';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_equipements_etat_229_ck'
+      AND conrelid = 'public.metrologie_equipements'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_equipements
+      ADD CONSTRAINT metrologie_equipements_etat_229_ck
+      CHECK (etat IN (
+        'DRAFT', 'ACTIVE', 'QUALIFIED', 'SUSPENDED',
+        'QUARANTINE', 'OUT_OF_TOLERANCE', 'UNDER_REPAIR', 'RETIRED'
+      ));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_equipements_plage_229_ck'
+      AND conrelid = 'public.metrologie_equipements'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_equipements
+      ADD CONSTRAINT metrologie_equipements_plage_229_ck
+      CHECK (plage_min IS NULL OR plage_max IS NULL OR plage_min <= plage_max);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_equipements_positive_specs_229_ck'
+      AND conrelid = 'public.metrologie_equipements'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_equipements
+      ADD CONSTRAINT metrologie_equipements_positive_specs_229_ck
+      CHECK (
+        (resolution IS NULL OR resolution > 0)
+        AND (mpe IS NULL OR mpe >= 0)
+        AND (incertitude IS NULL OR incertitude >= 0)
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_equipements_quarantine_pair_229_ck'
+      AND conrelid = 'public.metrologie_equipements'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_equipements
+      ADD CONSTRAINT metrologie_equipements_quarantine_pair_229_ck
+      CHECK ((quarantined_at IS NULL) = (quarantine_reason IS NULL));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_equipements_retrait_229_ck'
+      AND conrelid = 'public.metrologie_equipements'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_equipements
+      ADD CONSTRAINT metrologie_equipements_retrait_229_ck
+      CHECK (date_retrait IS NULL OR date_mise_en_service IS NULL OR date_retrait >= date_mise_en_service);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_equipements_categorie_229_fkey'
+      AND conrelid = 'public.metrologie_equipements'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_equipements
+      ADD CONSTRAINT metrologie_equipements_categorie_229_fkey
+      FOREIGN KEY (categorie_code) REFERENCES public.metrologie_categories(code)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_equipements_sous_categorie_229_fkey'
+      AND conrelid = 'public.metrologie_equipements'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_equipements
+      ADD CONSTRAINT metrologie_equipements_sous_categorie_229_fkey
+      FOREIGN KEY (sous_categorie_code) REFERENCES public.metrologie_categories(code)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_equipements_responsable_229_fkey'
+      AND conrelid = 'public.metrologie_equipements'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_equipements
+      ADD CONSTRAINT metrologie_equipements_responsable_229_fkey
+      FOREIGN KEY (responsable_user_id) REFERENCES public.users(id)
+      ON UPDATE RESTRICT ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_equipements_quarantined_by_229_fkey'
+      AND conrelid = 'public.metrologie_equipements'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_equipements
+      ADD CONSTRAINT metrologie_equipements_quarantined_by_229_fkey
+      FOREIGN KEY (quarantined_by) REFERENCES public.users(id)
+      ON UPDATE RESTRICT ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_equipements_etat_changed_by_229_fkey'
+      AND conrelid = 'public.metrologie_equipements'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_equipements
+      ADD CONSTRAINT metrologie_equipements_etat_changed_by_229_fkey
+      FOREIGN KEY (etat_changed_by) REFERENCES public.users(id)
+      ON UPDATE RESTRICT ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS metrologie_equipements_etat_229_idx
+  ON public.metrologie_equipements (etat)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS metrologie_equipements_categorie_229_idx
+  ON public.metrologie_equipements (categorie_code)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS metrologie_equipements_site_229_idx
+  ON public.metrologie_equipements (site, zone)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS metrologie_equipements_serial_229_idx
+  ON public.metrologie_equipements (numero_serie)
+  WHERE deleted_at IS NULL;
+
+/* -------------------------------------------------------------------------- */
+/* 4) Plans métrologiques versionnés                                          */
+/*                                                                            */
+/*    `metrologie_plan` (1 ligne par équipement) reste la vue héritée lue par  */
+/*    les écrans et KPI existants. La règle versionnée vit ici ; le miroir     */
+/*    hérité est tenu à jour par l'API dans la même transaction.               */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.metrologie_plan_version (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  equipement_id uuid NOT NULL
+    REFERENCES public.metrologie_equipements(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  version integer NOT NULL DEFAULT 1,
+  status text NOT NULL DEFAULT 'DRAFT',
+
+  operation_type text NOT NULL,
+  methode text NULL,
+  procedure_ref text NULL,
+
+  -- Règle de périodicité et base de calcul de l'échéance.
+  periodicite_valeur integer NOT NULL,
+  periodicite_unite text NOT NULL DEFAULT 'MONTH',
+  base_calcul text NOT NULL DEFAULT 'LAST_PROOF',
+  alert_window_days integer NOT NULL DEFAULT 30,
+
+  -- Critères d'acceptation appliqués aux mesures de l'exécution.
+  criteres jsonb NOT NULL DEFAULT '{}'::jsonb,
+  tolerance_min numeric(18, 6) NULL,
+  tolerance_max numeric(18, 6) NULL,
+  unite text NULL,
+
+  -- Qui a le droit d'exécuter, et blocage associé.
+  prestataire_type text NOT NULL DEFAULT 'INTERNE',
+  prestataire_label text NULL,
+  fournisseur_id uuid NULL,
+  role_habilite text NULL,
+  criticite text NOT NULL DEFAULT 'NORMAL',
+  blocking_strategy text NOT NULL DEFAULT 'BLOCK',
+  exige_certificat boolean NOT NULL DEFAULT false,
+
+  -- Dérivés serveur : dernière preuve admissible et échéance suivante.
+  last_proof_execution_id uuid NULL,
+  last_proof_date date NULL,
+  next_due_date date NULL,
+
+  effective_from date NULL,
+  published_at timestamptz NULL,
+  archived_at timestamptz NULL,
+  notes text NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  updated_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  CONSTRAINT metrologie_plan_version_229_uq UNIQUE (equipement_id, operation_type, version),
+  CONSTRAINT metrologie_plan_version_version_229_ck CHECK (version >= 1),
+  CONSTRAINT metrologie_plan_version_status_229_ck
+    CHECK (status IN ('DRAFT', 'ACTIVE', 'ARCHIVED')),
+  CONSTRAINT metrologie_plan_version_operation_229_ck
+    CHECK (operation_type IN ('ETALONNAGE', 'VERIFICATION')),
+  CONSTRAINT metrologie_plan_version_periodicite_229_ck
+    CHECK (periodicite_valeur BETWEEN 1 AND 3650),
+  CONSTRAINT metrologie_plan_version_unite_229_ck
+    CHECK (periodicite_unite IN ('DAY', 'WEEK', 'MONTH', 'YEAR')),
+  CONSTRAINT metrologie_plan_version_base_229_ck
+    CHECK (base_calcul IN ('LAST_PROOF', 'FIXED_DATE')),
+  CONSTRAINT metrologie_plan_version_alert_229_ck
+    CHECK (alert_window_days BETWEEN 0 AND 365),
+  CONSTRAINT metrologie_plan_version_prestataire_229_ck
+    CHECK (prestataire_type IN ('INTERNE', 'EXTERNE')),
+  CONSTRAINT metrologie_plan_version_criticite_229_ck
+    CHECK (criticite IN ('NORMAL', 'CRITIQUE')),
+  CONSTRAINT metrologie_plan_version_blocking_229_ck
+    CHECK (blocking_strategy IN ('BLOCK', 'WARN', 'NONE')),
+  CONSTRAINT metrologie_plan_version_tolerance_229_ck
+    CHECK (tolerance_min IS NULL OR tolerance_max IS NULL OR tolerance_min <= tolerance_max),
+  -- Un étalonnage externe déclare son prestataire : on ne maquille pas une
+  -- vérification interne en certificat externe.
+  CONSTRAINT metrologie_plan_version_externe_229_ck
+    CHECK (prestataire_type <> 'EXTERNE' OR prestataire_label IS NOT NULL OR fournisseur_id IS NOT NULL)
+);
+
+-- Une seule version ACTIVE par équipement et par type d'opération.
+CREATE UNIQUE INDEX IF NOT EXISTS metrologie_plan_version_active_229_uq
+  ON public.metrologie_plan_version (equipement_id, operation_type)
+  WHERE status = 'ACTIVE';
+
+CREATE INDEX IF NOT EXISTS metrologie_plan_version_due_229_idx
+  ON public.metrologie_plan_version (next_due_date)
+  WHERE status = 'ACTIVE';
+
+CREATE INDEX IF NOT EXISTS metrologie_plan_version_equipement_229_idx
+  ON public.metrologie_plan_version (equipement_id, status, version DESC);
+
+/* -------------------------------------------------------------------------- */
+/* 5) Exécutions : étalonnage, vérification, ajustage, réparation             */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.metrologie_execution (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text NOT NULL,
+  equipement_id uuid NOT NULL
+    REFERENCES public.metrologie_equipements(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  plan_version_id uuid NULL
+    REFERENCES public.metrologie_plan_version(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  plan_version integer NULL,
+
+  operation_type text NOT NULL,
+  status text NOT NULL DEFAULT 'DRAFT',
+
+  started_at timestamptz NOT NULL DEFAULT now(),
+  ended_at timestamptz NULL,
+
+  operator_user_id integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  provider_label text NULL,
+  fournisseur_id uuid NULL,
+
+  methode text NULL,
+  procedure_ref text NULL,
+  etalon_reference text NULL,
+  environnement jsonb NOT NULL DEFAULT '{}'::jsonb,
+  incertitude numeric(18, 6) NULL,
+
+  -- Verdict calculé par le domaine puis verdict retenu (override justifié).
+  verdict_computed text NULL,
+  verdict text NULL,
+  verdict_justification text NULL,
+  observations text NULL,
+
+  decision text NULL,
+  decision_reason text NULL,
+  decided_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  decided_at timestamptz NULL,
+
+  next_due_date date NULL,
+  restriction text NULL,
+
+  correlation_id uuid NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  updated_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  CONSTRAINT metrologie_execution_code_229_uq UNIQUE (code),
+  CONSTRAINT metrologie_execution_code_229_ck CHECK (code ~ '^MEX-[0-9]{4}-[0-9]{6,}$'),
+  CONSTRAINT metrologie_execution_operation_229_ck
+    CHECK (operation_type IN ('ETALONNAGE', 'VERIFICATION', 'AJUSTAGE', 'REPARATION')),
+  CONSTRAINT metrologie_execution_status_229_ck
+    CHECK (status IN ('DRAFT', 'IN_PROGRESS', 'VALIDATED', 'CANCELLED')),
+  CONSTRAINT metrologie_execution_verdict_229_ck
+    CHECK (verdict IS NULL OR verdict IN ('CONFORME', 'NON_CONFORME', 'CONFORME_AVEC_RESTRICTION', 'INCONCLU')),
+  CONSTRAINT metrologie_execution_verdict_computed_229_ck
+    CHECK (verdict_computed IS NULL OR verdict_computed IN ('CONFORME', 'NON_CONFORME', 'CONFORME_AVEC_RESTRICTION', 'INCONCLU')),
+  CONSTRAINT metrologie_execution_decision_229_ck
+    CHECK (decision IS NULL OR decision IN ('REMISE_EN_SERVICE', 'QUARANTAINE', 'AJUSTAGE_REQUIS', 'REPARATION_REQUISE', 'RETRAIT')),
+  -- Une exécution validée porte toujours un verdict et une décision datée.
+  CONSTRAINT metrologie_execution_validated_229_ck
+    CHECK (
+      status <> 'VALIDATED'
+      OR (verdict IS NOT NULL AND ended_at IS NOT NULL AND decided_at IS NOT NULL AND decided_by IS NOT NULL)
+    ),
+  CONSTRAINT metrologie_execution_restriction_229_ck
+    CHECK (verdict <> 'CONFORME_AVEC_RESTRICTION' OR restriction IS NOT NULL),
+  CONSTRAINT metrologie_execution_dates_229_ck
+    CHECK (ended_at IS NULL OR ended_at >= started_at),
+  -- Un étalonnage/vérification s'adosse à une version de plan ; un ajustage ou
+  -- une réparation est une intervention technique qui peut s'en passer.
+  CONSTRAINT metrologie_execution_plan_229_ck
+    CHECK (operation_type IN ('AJUSTAGE', 'REPARATION') OR plan_version_id IS NOT NULL)
+);
+
+CREATE INDEX IF NOT EXISTS metrologie_execution_equipement_229_idx
+  ON public.metrologie_execution (equipement_id, started_at DESC);
+
+CREATE INDEX IF NOT EXISTS metrologie_execution_status_229_idx
+  ON public.metrologie_execution (status, verdict);
+
+CREATE INDEX IF NOT EXISTS metrologie_execution_proof_229_idx
+  ON public.metrologie_execution (equipement_id, ended_at DESC)
+  WHERE status = 'VALIDATED' AND verdict IN ('CONFORME', 'CONFORME_AVEC_RESTRICTION');
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_equipements_last_conforme_229_fkey'
+      AND conrelid = 'public.metrologie_equipements'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_equipements
+      ADD CONSTRAINT metrologie_equipements_last_conforme_229_fkey
+      FOREIGN KEY (last_conforme_execution_id) REFERENCES public.metrologie_execution(id)
+      ON UPDATE RESTRICT ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_plan_version_last_proof_229_fkey'
+      AND conrelid = 'public.metrologie_plan_version'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_plan_version
+      ADD CONSTRAINT metrologie_plan_version_last_proof_229_fkey
+      FOREIGN KEY (last_proof_execution_id) REFERENCES public.metrologie_execution(id)
+      ON UPDATE RESTRICT ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.metrologie_execution_measurement (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  execution_id uuid NOT NULL
+    REFERENCES public.metrologie_execution(id) ON UPDATE RESTRICT ON DELETE CASCADE,
+  point_key text NOT NULL,
+  label text NULL,
+  sample_no integer NOT NULL DEFAULT 1,
+
+  nominal numeric(18, 6) NULL,
+  tolerance_min numeric(18, 6) NULL,
+  tolerance_max numeric(18, 6) NULL,
+  measured numeric(18, 6) NULL,
+  unite text NULL,
+  incertitude numeric(18, 6) NULL,
+  ecart numeric(18, 6) NULL,
+
+  verdict text NULL,
+  comment text NULL,
+  revision integer NOT NULL DEFAULT 1,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  updated_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  CONSTRAINT metrologie_measurement_229_uq UNIQUE (execution_id, point_key, sample_no),
+  CONSTRAINT metrologie_measurement_sample_229_ck CHECK (sample_no >= 1),
+  CONSTRAINT metrologie_measurement_revision_229_ck CHECK (revision >= 1),
+  CONSTRAINT metrologie_measurement_tolerance_229_ck
+    CHECK (tolerance_min IS NULL OR tolerance_max IS NULL OR tolerance_min <= tolerance_max),
+  CONSTRAINT metrologie_measurement_verdict_229_ck
+    CHECK (verdict IS NULL OR verdict IN ('CONFORME', 'NON_CONFORME', 'INCONCLU'))
+);
+
+CREATE INDEX IF NOT EXISTS metrologie_measurement_execution_229_idx
+  ON public.metrologie_execution_measurement (execution_id, point_key, sample_no);
+
+-- Historique append-only des corrections de mesure : on n'écrase jamais une
+-- valeur relevée, on empile une révision motivée.
+CREATE TABLE IF NOT EXISTS public.metrologie_measurement_revision (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  measurement_id uuid NOT NULL
+    REFERENCES public.metrologie_execution_measurement(id) ON UPDATE RESTRICT ON DELETE CASCADE,
+  revision integer NOT NULL,
+  previous_values jsonb NOT NULL,
+  reason text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  CONSTRAINT metrologie_measurement_revision_229_uq UNIQUE (measurement_id, revision),
+  CONSTRAINT metrologie_measurement_revision_reason_229_ck CHECK (char_length(btrim(reason)) >= 5)
+);
+
+/* -------------------------------------------------------------------------- */
+/* 6) Certificats et PV — extension                                           */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.metrologie_certificats
+  ADD COLUMN IF NOT EXISTS execution_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS document_kind text NOT NULL DEFAULT 'CERTIFICAT',
+  ADD COLUMN IF NOT EXISTS numero_externe text NULL,
+  ADD COLUMN IF NOT EXISTS emetteur text NULL,
+  ADD COLUMN IF NOT EXISTS couverture jsonb NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS statut text NOT NULL DEFAULT 'VALIDE',
+  ADD COLUMN IF NOT EXISTS cancel_reason text NULL,
+  ADD COLUMN IF NOT EXISTS cancelled_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS cancelled_by integer NULL,
+  ADD COLUMN IF NOT EXISTS replaced_by_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS confidentiality text NOT NULL DEFAULT 'RESTRICTED';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_certificats_kind_229_ck'
+      AND conrelid = 'public.metrologie_certificats'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_certificats
+      ADD CONSTRAINT metrologie_certificats_kind_229_ck
+      CHECK (document_kind IN ('CERTIFICAT', 'PV_INTERNE', 'RAPPORT', 'AUTRE'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_certificats_statut_229_ck'
+      AND conrelid = 'public.metrologie_certificats'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_certificats
+      ADD CONSTRAINT metrologie_certificats_statut_229_ck
+      CHECK (statut IN ('VALIDE', 'ANNULE', 'REMPLACE'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_certificats_cancel_pair_229_ck'
+      AND conrelid = 'public.metrologie_certificats'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_certificats
+      ADD CONSTRAINT metrologie_certificats_cancel_pair_229_ck
+      CHECK (statut <> 'ANNULE' OR (cancel_reason IS NOT NULL AND cancelled_at IS NOT NULL));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_certificats_confidentiality_229_ck'
+      AND conrelid = 'public.metrologie_certificats'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_certificats
+      ADD CONSTRAINT metrologie_certificats_confidentiality_229_ck
+      CHECK (confidentiality IN ('INTERNAL', 'RESTRICTED', 'CUSTOMER_VISIBLE'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_certificats_execution_229_fkey'
+      AND conrelid = 'public.metrologie_certificats'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_certificats
+      ADD CONSTRAINT metrologie_certificats_execution_229_fkey
+      FOREIGN KEY (execution_id) REFERENCES public.metrologie_execution(id)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_certificats_replaced_by_229_fkey'
+      AND conrelid = 'public.metrologie_certificats'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_certificats
+      ADD CONSTRAINT metrologie_certificats_replaced_by_229_fkey
+      FOREIGN KEY (replaced_by_id) REFERENCES public.metrologie_certificats(id)
+      ON UPDATE RESTRICT ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'metrologie_certificats_cancelled_by_229_fkey'
+      AND conrelid = 'public.metrologie_certificats'::regclass
+  ) THEN
+    ALTER TABLE public.metrologie_certificats
+      ADD CONSTRAINT metrologie_certificats_cancelled_by_229_fkey
+      FOREIGN KEY (cancelled_by) REFERENCES public.users(id)
+      ON UPDATE RESTRICT ON DELETE SET NULL;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS metrologie_certificats_execution_229_idx
+  ON public.metrologie_certificats (execution_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS metrologie_certificats_numero_externe_229_uq
+  ON public.metrologie_certificats (emetteur, numero_externe)
+  WHERE numero_externe IS NOT NULL AND emetteur IS NOT NULL AND deleted_at IS NULL;
+
+/* -------------------------------------------------------------------------- */
+/* 7) Analyse d'impact bornée                                                 */
+/*                                                                            */
+/*    Un dossier = un périmètre explicite (fenêtre temporelle bornée par la    */
+/*    dernière preuve conforme) + une liste explicable d'usages. Il ne         */
+/*    présume aucune non-conformité produit et ne déclenche AUCUNE action      */
+/*    automatique sur les contrôles, OF, lots, BL ou factures.                 */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.metrologie_impact_dossier (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text NOT NULL,
+  equipement_id uuid NOT NULL
+    REFERENCES public.metrologie_equipements(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  execution_id uuid NULL
+    REFERENCES public.metrologie_execution(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  certificat_id uuid NULL
+    REFERENCES public.metrologie_certificats(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+
+  trigger_type text NOT NULL,
+  status text NOT NULL DEFAULT 'OPEN',
+  priority text NOT NULL DEFAULT 'NORMAL',
+
+  -- Fenêtre d'analyse : bornée, jamais ouverte.
+  window_from timestamptz NOT NULL,
+  window_to timestamptz NOT NULL,
+  window_source text NOT NULL DEFAULT 'LAST_CONFORME_PROOF',
+
+  method text NOT NULL,
+  scope jsonb NOT NULL DEFAULT '{}'::jsonb,
+  exclusions text NULL,
+  volumes jsonb NOT NULL DEFAULT '{}'::jsonb,
+  truncated boolean NOT NULL DEFAULT false,
+
+  owner_user_id integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  conclusion text NULL,
+  closed_at timestamptz NULL,
+  closed_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  correlation_id uuid NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  updated_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  CONSTRAINT metrologie_impact_dossier_code_229_uq UNIQUE (code),
+  CONSTRAINT metrologie_impact_dossier_code_229_ck CHECK (code ~ '^MIA-[0-9]{4}-[0-9]{5,}$'),
+  CONSTRAINT metrologie_impact_dossier_trigger_229_ck
+    CHECK (trigger_type IN ('VERDICT_NON_CONFORME', 'CERTIFICAT_INVALIDE', 'MANUEL')),
+  CONSTRAINT metrologie_impact_dossier_status_229_ck
+    CHECK (status IN ('OPEN', 'IN_REVIEW', 'CLOSED', 'CANCELLED')),
+  CONSTRAINT metrologie_impact_dossier_priority_229_ck
+    CHECK (priority IN ('LOW', 'NORMAL', 'HIGH', 'CRITICAL')),
+  CONSTRAINT metrologie_impact_dossier_window_229_ck CHECK (window_to >= window_from),
+  CONSTRAINT metrologie_impact_dossier_window_source_229_ck
+    CHECK (window_source IN ('LAST_CONFORME_PROOF', 'APPROVED_WINDOW', 'EQUIPMENT_CREATION')),
+  CONSTRAINT metrologie_impact_dossier_closed_229_ck
+    CHECK (status <> 'CLOSED' OR (closed_at IS NOT NULL AND closed_by IS NOT NULL AND conclusion IS NOT NULL))
+);
+
+-- Un seul dossier ouvert par exécution déclenchante : garantit l'idempotence de
+-- la transaction « hors tolérance ».
+CREATE UNIQUE INDEX IF NOT EXISTS metrologie_impact_dossier_execution_229_uq
+  ON public.metrologie_impact_dossier (execution_id)
+  WHERE execution_id IS NOT NULL AND status <> 'CANCELLED';
+
+CREATE INDEX IF NOT EXISTS metrologie_impact_dossier_equipement_229_idx
+  ON public.metrologie_impact_dossier (equipement_id, status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.metrologie_impact_item (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  dossier_id uuid NOT NULL
+    REFERENCES public.metrologie_impact_dossier(id) ON UPDATE RESTRICT ON DELETE CASCADE,
+
+  quality_control_id uuid NULL
+    REFERENCES public.quality_control(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  control_reference text NULL,
+  control_type text NULL,
+  control_date timestamptz NULL,
+  characteristic_key text NULL,
+
+  -- Références souples vers les autres modules (même convention que
+  -- `quality_control` : pas de FK, pour ne jamais bloquer un module tiers).
+  of_id bigint NULL,
+  lot_id uuid NULL,
+  bon_livraison_id uuid NULL,
+  article_id uuid NULL,
+  affaire_id bigint NULL,
+
+  decision text NOT NULL DEFAULT 'PENDING',
+  decision_reason text NULL,
+  decided_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  decided_at timestamptz NULL,
+  non_conformity_id uuid NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT metrologie_impact_item_control_229_uq UNIQUE (dossier_id, quality_control_id, characteristic_key),
+  CONSTRAINT metrologie_impact_item_decision_229_ck
+    CHECK (decision IN (
+      'PENDING', 'NO_IMPACT', 'RECHECK', 'HOLD_LOT',
+      'OPEN_NC', 'REISSUE_DOCUMENT', 'INFORM_CUSTOMER'
+    )),
+  -- Une décision autre que « à traiter » est motivée, datée et attribuée.
+  CONSTRAINT metrologie_impact_item_decided_229_ck
+    CHECK (
+      decision = 'PENDING'
+      OR (decided_by IS NOT NULL AND decided_at IS NOT NULL AND char_length(btrim(COALESCE(decision_reason, ''))) >= 5)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS metrologie_impact_item_dossier_229_idx
+  ON public.metrologie_impact_item (dossier_id, decision, control_date DESC);
+
+CREATE INDEX IF NOT EXISTS metrologie_impact_item_of_229_idx
+  ON public.metrologie_impact_item (of_id);
+
+CREATE INDEX IF NOT EXISTS metrologie_impact_item_lot_229_idx
+  ON public.metrologie_impact_item (lot_id);
+
+CREATE INDEX IF NOT EXISTS metrologie_impact_item_bl_229_idx
+  ON public.metrologie_impact_item (bon_livraison_id);
+
+/* -------------------------------------------------------------------------- */
+/* 8) Idempotence, audit et journal                                           */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.metrologie_command_receipts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_user_id integer NOT NULL
+    REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  command_type text NOT NULL,
+  aggregate_type text NOT NULL,
+  aggregate_id text NOT NULL,
+  request_payload jsonb NOT NULL,
+  result_payload jsonb NOT NULL,
+  correlation_id uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT metrologie_command_receipts_229_uq UNIQUE (actor_user_id, idempotency_key),
+  CONSTRAINT metrologie_command_receipts_key_229_ck
+    CHECK (char_length(idempotency_key) BETWEEN 8 AND 200),
+  CONSTRAINT metrologie_command_receipts_hash_229_ck CHECK (request_hash ~ '^[A-Fa-f0-9]{64}$'),
+  CONSTRAINT metrologie_command_receipts_type_229_ck
+    CHECK (char_length(command_type) BETWEEN 3 AND 120),
+  CONSTRAINT metrologie_command_receipts_aggregate_229_ck
+    CHECK (aggregate_type IN ('EQUIPEMENT', 'CATEGORIE', 'PLAN', 'EXECUTION', 'CERTIFICAT', 'IMPACT'))
+);
+
+CREATE INDEX IF NOT EXISTS metrologie_command_receipts_resource_229_idx
+  ON public.metrologie_command_receipts (aggregate_type, aggregate_id, created_at DESC);
+
+ALTER TABLE public.metrologie_event_log
+  ADD COLUMN IF NOT EXISTS entity_type text NULL,
+  ADD COLUMN IF NOT EXISTS entity_id text NULL,
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS idempotency_key text NULL,
+  ADD COLUMN IF NOT EXISTS rule_code text NULL,
+  ADD COLUMN IF NOT EXISTS reason text NULL,
+  ADD COLUMN IF NOT EXISTS request_id text NULL,
+  ADD COLUMN IF NOT EXISTS source text NULL;
+
+CREATE INDEX IF NOT EXISTS metrologie_event_log_correlation_229_idx
+  ON public.metrologie_event_log (correlation_id);
+
+CREATE INDEX IF NOT EXISTS metrologie_event_log_entity_229_idx
+  ON public.metrologie_event_log (entity_type, entity_id, created_at DESC);
+
+-- Réglage historique : la portée est documentée en base pour lever toute
+-- ambiguïté. Il reste `false` par défaut et n'est JAMAIS un verrou global.
+UPDATE public.erp_settings
+SET value_json = COALESCE(value_json, '{}'::jsonb) || jsonb_build_object(
+      'scope', 'PER_INSTRUMENT',
+      'applies_to', 'CRITICAL_OVERDUE_ONLY',
+      'documented_by', '#229'
+    ),
+    updated_at = now()
+WHERE key = 'metrologie.block_on_overdue_critical'
+  AND NOT (COALESCE(value_json, '{}'::jsonb) ? 'scope');
+
+/* -------------------------------------------------------------------------- */
+/* 9) Immuabilité, append-only et cohérence héritée                           */
+/* -------------------------------------------------------------------------- */
+
+-- Le code visible d'un équipement est immuable une fois attribué, et un
+-- équipement déjà utilisé par un contrôle qualité, une exécution ou un dossier
+-- d'impact ne se supprime jamais physiquement.
+CREATE OR REPLACE FUNCTION public.fn_protect_metrologie_equipement_229()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_used bigint;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    SELECT COUNT(*) INTO v_used
+    FROM public.quality_control_points
+    WHERE instrument_id = OLD.id;
+    IF v_used > 0 THEN
+      RAISE EXCEPTION 'metrologie equipement % is referenced by % quality measurement(s): archive it instead', OLD.id, v_used;
+    END IF;
+
+    SELECT COUNT(*) INTO v_used FROM public.metrologie_execution WHERE equipement_id = OLD.id;
+    IF v_used > 0 THEN
+      RAISE EXCEPTION 'metrologie equipement % carries % execution(s): archive it instead', OLD.id, v_used;
+    END IF;
+
+    SELECT COUNT(*) INTO v_used FROM public.metrologie_impact_dossier WHERE equipement_id = OLD.id;
+    IF v_used > 0 THEN
+      RAISE EXCEPTION 'metrologie equipement % carries % impact dossier(s): archive it instead', OLD.id, v_used;
+    END IF;
+
+    RETURN OLD;
+  END IF;
+
+  IF OLD.code IS NOT NULL AND NEW.code IS DISTINCT FROM OLD.code THEN
+    RAISE EXCEPTION 'metrologie equipement code is immutable once issued (% -> %)', OLD.code, NEW.code;
+  END IF;
+
+  -- Miroir hérité : `statut` reste cohérent avec l'état de gouvernance pour ne
+  -- casser ni les KPI ni les écrans déjà en production. La synchronisation est
+  -- bidirectionnelle : le routeur historique (qui ne connaît que `statut`) ne
+  -- peut pas laisser les deux colonnes diverger.
+  IF NEW.etat IS DISTINCT FROM OLD.etat THEN
+    NEW.statut := CASE NEW.etat
+                    WHEN 'ACTIVE' THEN 'ACTIF'
+                    WHEN 'QUALIFIED' THEN 'ACTIF'
+                    WHEN 'RETIRED' THEN 'REBUT'
+                    ELSE 'INACTIF'
+                  END;
+  ELSIF NEW.statut IS DISTINCT FROM OLD.statut THEN
+    NEW.etat := CASE NEW.statut
+                  WHEN 'ACTIF' THEN
+                    -- Une remise en service ne sort JAMAIS d'une quarantaine ou
+                    -- d'un hors tolérance par simple changement de statut.
+                    CASE WHEN OLD.etat IN ('QUARANTINE', 'OUT_OF_TOLERANCE', 'UNDER_REPAIR')
+                         THEN OLD.etat ELSE 'ACTIVE' END
+                  WHEN 'REBUT' THEN 'RETIRED'
+                  ELSE
+                    CASE WHEN OLD.etat IN ('QUARANTINE', 'OUT_OF_TOLERANCE', 'UNDER_REPAIR')
+                         THEN OLD.etat ELSE 'SUSPENDED' END
+                END;
+    -- Le statut hérité est recalculé depuis l'état retenu pour rester cohérent
+    -- lorsque la quarantaine a été préservée.
+    NEW.statut := CASE NEW.etat
+                    WHEN 'ACTIVE' THEN 'ACTIF'
+                    WHEN 'QUALIFIED' THEN 'ACTIF'
+                    WHEN 'RETIRED' THEN 'REBUT'
+                    ELSE 'INACTIF'
+                  END;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_metrologie_equipement_229 ON public.metrologie_equipements;
+CREATE TRIGGER trg_protect_metrologie_equipement_229
+  BEFORE UPDATE OR DELETE ON public.metrologie_equipements
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_metrologie_equipement_229();
+
+-- Une version de plan ACTIVE ou ARCHIVED est figée : seuls les dérivés
+-- (dernière preuve, échéance) et le statut évoluent. Toute autre modification
+-- exige une nouvelle version.
+CREATE OR REPLACE FUNCTION public.fn_protect_metrologie_plan_version_229()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.status <> 'DRAFT' THEN
+      RAISE EXCEPTION 'an active or archived metrology plan version is immutable and cannot be deleted';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF OLD.status IN ('ACTIVE', 'ARCHIVED') THEN
+    IF NEW.version <> OLD.version
+      OR NEW.equipement_id <> OLD.equipement_id
+      OR NEW.operation_type <> OLD.operation_type
+      OR NEW.periodicite_valeur <> OLD.periodicite_valeur
+      OR NEW.periodicite_unite <> OLD.periodicite_unite
+      OR NEW.base_calcul <> OLD.base_calcul
+      OR NEW.criteres::text <> OLD.criteres::text
+      OR COALESCE(NEW.methode, '') <> COALESCE(OLD.methode, '')
+      OR COALESCE(NEW.procedure_ref, '') <> COALESCE(OLD.procedure_ref, '')
+      OR COALESCE(NEW.tolerance_min, -1e18) <> COALESCE(OLD.tolerance_min, -1e18)
+      OR COALESCE(NEW.tolerance_max, -1e18) <> COALESCE(OLD.tolerance_max, -1e18)
+      OR NEW.prestataire_type <> OLD.prestataire_type
+      OR NEW.criticite <> OLD.criticite
+      OR NEW.blocking_strategy <> OLD.blocking_strategy
+      OR NEW.exige_certificat <> OLD.exige_certificat
+      OR COALESCE(NEW.effective_from::text, '') <> COALESCE(OLD.effective_from::text, '')
+    THEN
+      RAISE EXCEPTION 'metrology plan version %/% is frozen: create a new version', OLD.equipement_id, OLD.version;
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_metrologie_plan_version_229 ON public.metrologie_plan_version;
+CREATE TRIGGER trg_protect_metrologie_plan_version_229
+  BEFORE UPDATE OR DELETE ON public.metrologie_plan_version
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_metrologie_plan_version_229();
+
+-- Une exécution validée ne se réécrit pas : ni son verdict, ni ses dates, ni
+-- son opérateur. Elle ne se supprime jamais.
+CREATE OR REPLACE FUNCTION public.fn_protect_metrologie_execution_229()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'a metrology execution is an audit record and cannot be deleted';
+  END IF;
+
+  IF NEW.code IS DISTINCT FROM OLD.code THEN
+    RAISE EXCEPTION 'metrology execution code is immutable';
+  END IF;
+
+  IF OLD.status = 'VALIDATED' THEN
+    IF NEW.verdict IS DISTINCT FROM OLD.verdict
+      OR NEW.verdict_computed IS DISTINCT FROM OLD.verdict_computed
+      OR NEW.status <> OLD.status
+      OR NEW.operation_type <> OLD.operation_type
+      OR NEW.equipement_id <> OLD.equipement_id
+      OR NEW.started_at IS DISTINCT FROM OLD.started_at
+      OR NEW.ended_at IS DISTINCT FROM OLD.ended_at
+      OR NEW.operator_user_id IS DISTINCT FROM OLD.operator_user_id
+      OR NEW.decision IS DISTINCT FROM OLD.decision
+      OR NEW.decided_by IS DISTINCT FROM OLD.decided_by
+      OR NEW.decided_at IS DISTINCT FROM OLD.decided_at
+    THEN
+      RAISE EXCEPTION 'a validated metrology execution is immutable';
+    END IF;
+  END IF;
+
+  IF OLD.status = 'CANCELLED' AND NEW.status <> 'CANCELLED' THEN
+    RAISE EXCEPTION 'a cancelled metrology execution cannot be reopened';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_metrologie_execution_229 ON public.metrologie_execution;
+CREATE TRIGGER trg_protect_metrologie_execution_229
+  BEFORE UPDATE OR DELETE ON public.metrologie_execution
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_metrologie_execution_229();
+
+-- Une mesure rattachée à une exécution validée est figée ; une correction passe
+-- par une révision motivée (append-only).
+CREATE OR REPLACE FUNCTION public.fn_protect_metrologie_measurement_229()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_status text;
+BEGIN
+  SELECT status INTO v_status
+  FROM public.metrologie_execution
+  WHERE id = COALESCE(NEW.execution_id, OLD.execution_id);
+
+  IF v_status = 'VALIDATED' THEN
+    RAISE EXCEPTION 'measurements of a validated metrology execution are immutable';
+  END IF;
+
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND NEW.revision <= OLD.revision THEN
+    RAISE EXCEPTION 'a metrology measurement correction must increment its revision';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_metrologie_measurement_229 ON public.metrologie_execution_measurement;
+CREATE TRIGGER trg_protect_metrologie_measurement_229
+  BEFORE UPDATE OR DELETE ON public.metrologie_execution_measurement
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_metrologie_measurement_229();
+
+-- Un certificat est une preuve : il s'annule ou se remplace avec motif, il ne
+-- se réécrit pas et ne se supprime pas physiquement.
+CREATE OR REPLACE FUNCTION public.fn_protect_metrologie_certificat_229()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'a metrology certificate is evidence and cannot be hard-deleted';
+  END IF;
+
+  IF NEW.sha256 IS DISTINCT FROM OLD.sha256 AND OLD.sha256 IS NOT NULL THEN
+    RAISE EXCEPTION 'the SHA-256 fingerprint of a metrology certificate is immutable';
+  END IF;
+  IF NEW.date_etalonnage IS DISTINCT FROM OLD.date_etalonnage AND OLD.deleted_at IS NULL AND OLD.statut = 'VALIDE' AND NEW.statut = 'VALIDE' THEN
+    RAISE EXCEPTION 'the calibration date of a valid certificate is immutable: cancel and replace it';
+  END IF;
+  IF OLD.statut IN ('ANNULE', 'REMPLACE') AND NEW.statut = 'VALIDE' THEN
+    RAISE EXCEPTION 'a cancelled or superseded certificate never becomes valid again';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_metrologie_certificat_229 ON public.metrologie_certificats;
+CREATE TRIGGER trg_protect_metrologie_certificat_229
+  BEFORE UPDATE OR DELETE ON public.metrologie_certificats
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_metrologie_certificat_229();
+
+-- Journal et reçus : strictement append-only.
+CREATE OR REPLACE FUNCTION public.fn_metrologie_append_only_229()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION '% is append-only', TG_TABLE_NAME;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_metrologie_event_log_append_only_229 ON public.metrologie_event_log;
+CREATE TRIGGER trg_metrologie_event_log_append_only_229
+  BEFORE UPDATE OR DELETE ON public.metrologie_event_log
+  FOR EACH ROW EXECUTE FUNCTION public.fn_metrologie_append_only_229();
+
+DROP TRIGGER IF EXISTS trg_metrologie_receipts_append_only_229 ON public.metrologie_command_receipts;
+CREATE TRIGGER trg_metrologie_receipts_append_only_229
+  BEFORE UPDATE OR DELETE ON public.metrologie_command_receipts
+  FOR EACH ROW EXECUTE FUNCTION public.fn_metrologie_append_only_229();
+
+DROP TRIGGER IF EXISTS trg_metrologie_measurement_revision_append_only_229 ON public.metrologie_measurement_revision;
+CREATE TRIGGER trg_metrologie_measurement_revision_append_only_229
+  BEFORE UPDATE OR DELETE ON public.metrologie_measurement_revision
+  FOR EACH ROW EXECUTE FUNCTION public.fn_metrologie_append_only_229();
+
+-- Une catégorie utilisée se désactive, elle ne se supprime pas.
+CREATE OR REPLACE FUNCTION public.fn_protect_metrologie_categorie_229()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_used bigint;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    SELECT COUNT(*) INTO v_used
+    FROM public.metrologie_equipements
+    WHERE categorie_code = OLD.code OR sous_categorie_code = OLD.code;
+    IF v_used > 0 THEN
+      RAISE EXCEPTION 'metrology category % is used by % equipment(s): deactivate it instead', OLD.code, v_used;
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF NEW.code <> OLD.code THEN
+    RAISE EXCEPTION 'metrology category code is immutable';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_metrologie_categorie_229 ON public.metrologie_categories;
+CREATE TRIGGER trg_protect_metrologie_categorie_229
+  BEFORE UPDATE OR DELETE ON public.metrologie_categories
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_metrologie_categorie_229();
+
+-- Un dossier d'impact clos est figé.
+CREATE OR REPLACE FUNCTION public.fn_protect_metrologie_impact_229()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'a metrology impact dossier is an audit record and cannot be deleted';
+  END IF;
+  IF OLD.status = 'CLOSED' AND NEW.status <> 'CLOSED' THEN
+    RAISE EXCEPTION 'a closed metrology impact dossier cannot be reopened';
+  END IF;
+  IF NEW.code IS DISTINCT FROM OLD.code THEN
+    RAISE EXCEPTION 'metrology impact dossier code is immutable';
+  END IF;
+  IF NEW.window_from IS DISTINCT FROM OLD.window_from OR NEW.window_to IS DISTINCT FROM OLD.window_to THEN
+    RAISE EXCEPTION 'the analysis window of an impact dossier is immutable';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_metrologie_impact_229 ON public.metrologie_impact_dossier;
+CREATE TRIGGER trg_protect_metrologie_impact_229
+  BEFORE UPDATE OR DELETE ON public.metrologie_impact_dossier
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_metrologie_impact_229();
+
+-- Une décision d'impact prise est définitive : on en reprend une nouvelle,
+-- on ne la réécrit pas silencieusement.
+CREATE OR REPLACE FUNCTION public.fn_protect_metrologie_impact_item_229()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'a metrology impact item is an audit record and cannot be deleted';
+  END IF;
+  IF OLD.decision <> 'PENDING' AND NEW.decision IS DISTINCT FROM OLD.decision THEN
+    RAISE EXCEPTION 'a metrology impact decision is final (% already decided)', OLD.id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_protect_metrologie_impact_item_229 ON public.metrologie_impact_item;
+CREATE TRIGGER trg_protect_metrologie_impact_item_229
+  BEFORE UPDATE OR DELETE ON public.metrologie_impact_item
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_metrologie_impact_item_229();
+
+/* -------------------------------------------------------------------------- */
+/* 10) Commentaires                                                           */
+/* -------------------------------------------------------------------------- */
+
+COMMENT ON TABLE public.metrologie_categories IS
+  '#229 — Référentiel administré des catégories de moyens de mesure. Désactivation, jamais suppression, quand la catégorie est utilisée.';
+COMMENT ON TABLE public.metrologie_plan_version IS
+  '#229 — Règle métrologique versionnée (périodicité, méthode, tolérances, habilitation). Une version ACTIVE ou ARCHIVED est figée.';
+COMMENT ON TABLE public.metrologie_execution IS
+  '#229 — Étalonnage, vérification, ajustage ou réparation. Une exécution validée est immuable et ne se supprime pas.';
+COMMENT ON TABLE public.metrologie_impact_dossier IS
+  '#229 — Analyse d''impact BORNÉE depuis la dernière preuve conforme. Ne déclenche aucune action automatique sur contrôles, OF, lots, BL ou factures.';
+COMMENT ON COLUMN public.metrologie_equipements.etat IS
+  '#229 — État de gouvernance serveur. DUE_SOON/OVERDUE ne sont PAS stockés : ils sont dérivés du plan actif pour ne jamais dériver de la réalité.';
+COMMENT ON COLUMN public.metrologie_equipements.statut IS
+  'Statut hérité (ACTIF/INACTIF/REBUT) conservé pour les écrans existants, tenu à jour par trigger depuis `etat` (#229).';
+
+COMMIT;

--- a/db/patches/support/20260726_metrologie_360_229.rollback.sql
+++ b/db/patches/support/20260726_metrologie_360_229.rollback.sql
@@ -1,0 +1,278 @@
+\set ON_ERROR_STOP on
+
+-- Rollback de l'issue #229 (Métrologie 360), restreint à cerp_test.
+--
+-- Principe : ce script ne détruit AUCUNE preuve métrologique. Il refuse de
+-- s'exécuter dès qu'une exécution, une mesure, un certificat rattaché, un
+-- dossier d'impact ou une quarantaine existe. Il ne sait défaire qu'un patch
+-- appliqué « à blanc ».
+--
+-- Parties volontairement non défaites :
+--   * le périmètre MET/MEX/MIA/MCH de `fn_next_issued_code_value` est laissé en
+--     place (additif, et retirer MCH re-casserait le parc machines #165) ;
+--   * les colonnes additives ne sont supprimées que si elles sont entièrement
+--     vides, afin qu'un relevé, un état ou une localisation saisis ne soient
+--     jamais perdus.
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#229 rollback is restricted to cerp_test (current: %)', current_database();
+  END IF;
+END $$;
+
+BEGIN;
+
+/* -------------------------------------------------------------------------- */
+/* 0) Refus si des données métier existent                                    */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+DECLARE
+  v_count bigint;
+BEGIN
+  IF to_regclass('public.metrologie_execution') IS NOT NULL THEN
+    SELECT COUNT(*) INTO v_count FROM public.metrologie_execution;
+    IF v_count > 0 THEN
+      RAISE EXCEPTION '#229 rollback refused: % metrology execution(s) recorded', v_count;
+    END IF;
+  END IF;
+
+  IF to_regclass('public.metrologie_impact_dossier') IS NOT NULL THEN
+    SELECT COUNT(*) INTO v_count FROM public.metrologie_impact_dossier;
+    IF v_count > 0 THEN
+      RAISE EXCEPTION '#229 rollback refused: % impact dossier(s) recorded', v_count;
+    END IF;
+  END IF;
+
+  IF to_regclass('public.metrologie_plan_version') IS NOT NULL THEN
+    SELECT COUNT(*) INTO v_count FROM public.metrologie_plan_version;
+    IF v_count > 0 THEN
+      RAISE EXCEPTION '#229 rollback refused: % versioned plan(s) recorded', v_count;
+    END IF;
+  END IF;
+
+  IF to_regclass('public.metrologie_command_receipts') IS NOT NULL THEN
+    SELECT COUNT(*) INTO v_count FROM public.metrologie_command_receipts;
+    IF v_count > 0 THEN
+      RAISE EXCEPTION '#229 rollback refused: % idempotency receipt(s) recorded', v_count;
+    END IF;
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+  FROM public.metrologie_equipements
+  WHERE etat NOT IN ('ACTIVE', 'SUSPENDED', 'RETIRED')
+     OR quarantined_at IS NOT NULL
+     OR last_conforme_execution_id IS NOT NULL;
+  IF v_count > 0 THEN
+    RAISE EXCEPTION '#229 rollback refused: % equipment(s) already use a #229 governance state', v_count;
+  END IF;
+
+  SELECT COUNT(*) INTO v_count
+  FROM public.metrologie_certificats
+  WHERE execution_id IS NOT NULL OR statut <> 'VALIDE' OR numero_externe IS NOT NULL;
+  IF v_count > 0 THEN
+    RAISE EXCEPTION '#229 rollback refused: % certificate(s) already carry #229 metadata', v_count;
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 1) Triggers et fonctions                                                   */
+/* -------------------------------------------------------------------------- */
+
+DROP TRIGGER IF EXISTS trg_protect_metrologie_impact_item_229 ON public.metrologie_impact_item;
+DROP TRIGGER IF EXISTS trg_protect_metrologie_impact_229 ON public.metrologie_impact_dossier;
+DROP TRIGGER IF EXISTS trg_protect_metrologie_categorie_229 ON public.metrologie_categories;
+DROP TRIGGER IF EXISTS trg_metrologie_measurement_revision_append_only_229 ON public.metrologie_measurement_revision;
+DROP TRIGGER IF EXISTS trg_metrologie_receipts_append_only_229 ON public.metrologie_command_receipts;
+DROP TRIGGER IF EXISTS trg_metrologie_event_log_append_only_229 ON public.metrologie_event_log;
+DROP TRIGGER IF EXISTS trg_protect_metrologie_certificat_229 ON public.metrologie_certificats;
+DROP TRIGGER IF EXISTS trg_protect_metrologie_measurement_229 ON public.metrologie_execution_measurement;
+DROP TRIGGER IF EXISTS trg_protect_metrologie_execution_229 ON public.metrologie_execution;
+DROP TRIGGER IF EXISTS trg_protect_metrologie_plan_version_229 ON public.metrologie_plan_version;
+DROP TRIGGER IF EXISTS trg_protect_metrologie_equipement_229 ON public.metrologie_equipements;
+
+DROP FUNCTION IF EXISTS public.fn_protect_metrologie_impact_item_229();
+DROP FUNCTION IF EXISTS public.fn_protect_metrologie_impact_229();
+DROP FUNCTION IF EXISTS public.fn_protect_metrologie_categorie_229();
+DROP FUNCTION IF EXISTS public.fn_metrologie_append_only_229();
+DROP FUNCTION IF EXISTS public.fn_protect_metrologie_certificat_229();
+DROP FUNCTION IF EXISTS public.fn_protect_metrologie_measurement_229();
+DROP FUNCTION IF EXISTS public.fn_protect_metrologie_execution_229();
+DROP FUNCTION IF EXISTS public.fn_protect_metrologie_plan_version_229();
+DROP FUNCTION IF EXISTS public.fn_protect_metrologie_equipement_229();
+
+/* -------------------------------------------------------------------------- */
+/* 2) Tables créées par #229                                                  */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.metrologie_equipements
+  DROP CONSTRAINT IF EXISTS metrologie_equipements_last_conforme_229_fkey;
+ALTER TABLE public.metrologie_plan_version
+  DROP CONSTRAINT IF EXISTS metrologie_plan_version_last_proof_229_fkey;
+ALTER TABLE public.metrologie_certificats
+  DROP CONSTRAINT IF EXISTS metrologie_certificats_execution_229_fkey;
+
+DROP TABLE IF EXISTS public.metrologie_impact_item;
+DROP TABLE IF EXISTS public.metrologie_impact_dossier;
+DROP TABLE IF EXISTS public.metrologie_measurement_revision;
+DROP TABLE IF EXISTS public.metrologie_execution_measurement;
+DROP TABLE IF EXISTS public.metrologie_execution;
+DROP TABLE IF EXISTS public.metrologie_plan_version;
+DROP TABLE IF EXISTS public.metrologie_command_receipts;
+
+/* -------------------------------------------------------------------------- */
+/* 3) Colonnes additives (uniquement si vides)                                */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+DECLARE
+  v_count bigint;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+  FROM public.metrologie_equipements
+  WHERE categorie_code IS NOT NULL
+     OR sous_categorie_code IS NOT NULL
+     OR responsable_user_id IS NOT NULL
+     OR site IS NOT NULL
+     OR zone IS NOT NULL
+     OR localisation_precise IS NOT NULL
+     OR unite IS NOT NULL
+     OR plage_min IS NOT NULL
+     OR plage_max IS NOT NULL
+     OR resolution IS NOT NULL
+     OR mpe IS NOT NULL
+     OR incertitude IS NOT NULL
+     OR COALESCE(array_length(methodes, 1), 0) > 0
+     OR specifications <> '{}'::jsonb;
+
+  IF v_count > 0 THEN
+    RAISE NOTICE '#229 rollback: % equipment(s) carry #229 data — additive columns kept', v_count;
+  ELSE
+    ALTER TABLE public.metrologie_equipements
+      DROP CONSTRAINT IF EXISTS metrologie_equipements_etat_229_ck,
+      DROP CONSTRAINT IF EXISTS metrologie_equipements_plage_229_ck,
+      DROP CONSTRAINT IF EXISTS metrologie_equipements_positive_specs_229_ck,
+      DROP CONSTRAINT IF EXISTS metrologie_equipements_quarantine_pair_229_ck,
+      DROP CONSTRAINT IF EXISTS metrologie_equipements_retrait_229_ck,
+      DROP CONSTRAINT IF EXISTS metrologie_equipements_categorie_229_fkey,
+      DROP CONSTRAINT IF EXISTS metrologie_equipements_sous_categorie_229_fkey,
+      DROP CONSTRAINT IF EXISTS metrologie_equipements_responsable_229_fkey,
+      DROP CONSTRAINT IF EXISTS metrologie_equipements_quarantined_by_229_fkey,
+      DROP CONSTRAINT IF EXISTS metrologie_equipements_etat_changed_by_229_fkey;
+
+    ALTER TABLE public.metrologie_equipements
+      DROP COLUMN IF EXISTS categorie_code,
+      DROP COLUMN IF EXISTS sous_categorie_code,
+      DROP COLUMN IF EXISTS etat,
+      DROP COLUMN IF EXISTS etat_motif,
+      DROP COLUMN IF EXISTS etat_changed_at,
+      DROP COLUMN IF EXISTS etat_changed_by,
+      DROP COLUMN IF EXISTS proprietaire_service,
+      DROP COLUMN IF EXISTS responsable_user_id,
+      DROP COLUMN IF EXISTS site,
+      DROP COLUMN IF EXISTS magasin,
+      DROP COLUMN IF EXISTS zone,
+      DROP COLUMN IF EXISTS localisation_precise,
+      DROP COLUMN IF EXISTS date_mise_en_service,
+      DROP COLUMN IF EXISTS date_retrait,
+      DROP COLUMN IF EXISTS unite,
+      DROP COLUMN IF EXISTS plage_min,
+      DROP COLUMN IF EXISTS plage_max,
+      DROP COLUMN IF EXISTS resolution,
+      DROP COLUMN IF EXISTS mpe,
+      DROP COLUMN IF EXISTS incertitude,
+      DROP COLUMN IF EXISTS methodes,
+      DROP COLUMN IF EXISTS conditions_utilisation,
+      DROP COLUMN IF EXISTS restrictions,
+      DROP COLUMN IF EXISTS etalon_reference,
+      DROP COLUMN IF EXISTS exige_certificat,
+      DROP COLUMN IF EXISTS specifications,
+      DROP COLUMN IF EXISTS quarantine_reason,
+      DROP COLUMN IF EXISTS quarantined_at,
+      DROP COLUMN IF EXISTS quarantined_by,
+      DROP COLUMN IF EXISTS last_conforme_execution_id,
+      DROP COLUMN IF EXISTS last_conforme_at;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_count bigint;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+  FROM public.metrologie_certificats
+  WHERE emetteur IS NOT NULL
+     OR couverture <> '{}'::jsonb
+     OR document_kind <> 'CERTIFICAT';
+
+  IF v_count > 0 THEN
+    RAISE NOTICE '#229 rollback: % certificate(s) carry #229 metadata — additive columns kept', v_count;
+  ELSE
+    ALTER TABLE public.metrologie_certificats
+      DROP CONSTRAINT IF EXISTS metrologie_certificats_kind_229_ck,
+      DROP CONSTRAINT IF EXISTS metrologie_certificats_statut_229_ck,
+      DROP CONSTRAINT IF EXISTS metrologie_certificats_cancel_pair_229_ck,
+      DROP CONSTRAINT IF EXISTS metrologie_certificats_confidentiality_229_ck,
+      DROP CONSTRAINT IF EXISTS metrologie_certificats_replaced_by_229_fkey,
+      DROP CONSTRAINT IF EXISTS metrologie_certificats_cancelled_by_229_fkey;
+
+    DROP INDEX IF EXISTS public.metrologie_certificats_numero_externe_229_uq;
+    DROP INDEX IF EXISTS public.metrologie_certificats_execution_229_idx;
+
+    ALTER TABLE public.metrologie_certificats
+      DROP COLUMN IF EXISTS execution_id,
+      DROP COLUMN IF EXISTS document_kind,
+      DROP COLUMN IF EXISTS numero_externe,
+      DROP COLUMN IF EXISTS emetteur,
+      DROP COLUMN IF EXISTS couverture,
+      DROP COLUMN IF EXISTS statut,
+      DROP COLUMN IF EXISTS cancel_reason,
+      DROP COLUMN IF EXISTS cancelled_at,
+      DROP COLUMN IF EXISTS cancelled_by,
+      DROP COLUMN IF EXISTS replaced_by_id,
+      DROP COLUMN IF EXISTS confidentiality;
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_count bigint;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+  FROM public.metrologie_event_log
+  WHERE correlation_id IS NOT NULL OR entity_type IS NOT NULL OR idempotency_key IS NOT NULL;
+
+  IF v_count > 0 THEN
+    RAISE NOTICE '#229 rollback: % event(s) carry #229 metadata — additive columns kept', v_count;
+  ELSE
+    DROP INDEX IF EXISTS public.metrologie_event_log_correlation_229_idx;
+    DROP INDEX IF EXISTS public.metrologie_event_log_entity_229_idx;
+    ALTER TABLE public.metrologie_event_log
+      DROP COLUMN IF EXISTS entity_type,
+      DROP COLUMN IF EXISTS entity_id,
+      DROP COLUMN IF EXISTS correlation_id,
+      DROP COLUMN IF EXISTS idempotency_key,
+      DROP COLUMN IF EXISTS rule_code,
+      DROP COLUMN IF EXISTS reason,
+      DROP COLUMN IF EXISTS request_id,
+      DROP COLUMN IF EXISTS source;
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 4) Référentiel des catégories (uniquement si inutilisé)                    */
+/* -------------------------------------------------------------------------- */
+
+DROP TABLE IF EXISTS public.metrologie_categories;
+
+/* -------------------------------------------------------------------------- */
+/* 5) Réglage historique : retour à la valeur d'origine                       */
+/* -------------------------------------------------------------------------- */
+
+UPDATE public.erp_settings
+SET value_json = value_json - 'scope' - 'applies_to' - 'documented_by',
+    updated_at = now()
+WHERE key = 'metrologie.block_on_overdue_critical';
+
+COMMIT;

--- a/db/privileged/20260726_metrologie_360_229_runtime_grants.rollback.sql
+++ b/db/privileged/20260726_metrologie_360_229_runtime_grants.rollback.sql
@@ -1,0 +1,53 @@
+-- Emergency rollback for #229 runtime grants.
+-- PRIVILEGED — SUPERUSER ONLY.
+--
+-- This restores conventional cerp_app ownership and therefore weakens the
+-- append-only ownership boundary. Use only as part of an approved rollback.
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF NOT COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false) THEN
+    RAISE EXCEPTION
+      'metrologie_360_229_runtime_grants rollback: superuser required; current_user=%',
+      current_user;
+  END IF;
+END
+$guard$;
+
+DO $rollback$
+DECLARE
+  table_name text;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'metrologie_categories',
+    'metrologie_plan_version',
+    'metrologie_execution',
+    'metrologie_execution_measurement',
+    'metrologie_measurement_revision',
+    'metrologie_impact_dossier',
+    'metrologie_impact_item',
+    'metrologie_command_receipts',
+    'metrologie_event_log'
+  ]
+  LOOP
+    IF to_regclass('public.' || table_name) IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.%I OWNER TO cerp_app', table_name);
+      EXECUTE format('GRANT ALL ON TABLE public.%I TO cerp_app', table_name);
+    END IF;
+  END LOOP;
+END
+$rollback$;
+
+ALTER FUNCTION public.fn_protect_metrologie_equipement_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_plan_version_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_execution_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_measurement_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_certificat_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_metrologie_append_only_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_categorie_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_impact_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_impact_item_229() OWNER TO cerp_app;
+
+COMMIT;

--- a/db/privileged/20260726_metrologie_360_229_runtime_grants.sql
+++ b/db/privileged/20260726_metrologie_360_229_runtime_grants.sql
@@ -1,0 +1,103 @@
+-- 20260726_metrologie_360_229_runtime_grants.sql
+-- PRIVILEGED — SUPERUSER ONLY
+--
+-- The #229 patch can be applied either by the patch runner (cerp_app) or
+-- directly by postgres during a controlled release. Direct application makes
+-- the new tables postgres-owned, so the runtime role would otherwise have no
+-- access. This script makes ownership and least-privilege grants reproducible.
+--
+-- Mutable workflow tables remain postgres-owned and expose only the operations
+-- used by the API. Evidence tables are strictly SELECT + INSERT for cerp_app.
+--
+-- Apply after db/patches/20260726_metrologie_360_229.sql.
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF NOT COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false) THEN
+    RAISE EXCEPTION
+      'metrologie_360_229_runtime_grants: superuser required; current_user=%',
+      current_user;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'metrologie_360_229_runtime_grants: role cerp_app is missing';
+  END IF;
+END
+$guard$;
+
+DO $mutable_tables$
+DECLARE
+  table_name text;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'metrologie_categories',
+    'metrologie_plan_version',
+    'metrologie_execution',
+    'metrologie_execution_measurement',
+    'metrologie_impact_dossier',
+    'metrologie_impact_item'
+  ]
+  LOOP
+    IF to_regclass('public.' || table_name) IS NULL THEN
+      RAISE EXCEPTION
+        'metrologie_360_229_runtime_grants: missing table public.%',
+        table_name;
+    END IF;
+
+    EXECUTE format('ALTER TABLE public.%I OWNER TO postgres', table_name);
+    EXECUTE format('REVOKE ALL ON TABLE public.%I FROM cerp_app', table_name);
+    EXECUTE format(
+      'REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE public.%I FROM PUBLIC',
+      table_name
+    );
+    EXECUTE format(
+      'GRANT SELECT, INSERT, UPDATE ON TABLE public.%I TO cerp_app',
+      table_name
+    );
+  END LOOP;
+END
+$mutable_tables$;
+
+DO $append_only_tables$
+DECLARE
+  table_name text;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'metrologie_event_log',
+    'metrologie_measurement_revision',
+    'metrologie_command_receipts'
+  ]
+  LOOP
+    IF to_regclass('public.' || table_name) IS NULL THEN
+      RAISE EXCEPTION
+        'metrologie_360_229_runtime_grants: missing table public.%',
+        table_name;
+    END IF;
+
+    EXECUTE format('ALTER TABLE public.%I OWNER TO postgres', table_name);
+    EXECUTE format('REVOKE ALL ON TABLE public.%I FROM cerp_app', table_name);
+    EXECUTE format(
+      'REVOKE UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE public.%I FROM PUBLIC',
+      table_name
+    );
+    EXECUTE format(
+      'GRANT SELECT, INSERT ON TABLE public.%I TO cerp_app',
+      table_name
+    );
+  END LOOP;
+END
+$append_only_tables$;
+
+ALTER FUNCTION public.fn_protect_metrologie_equipement_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_plan_version_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_execution_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_measurement_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_certificat_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_metrologie_append_only_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_categorie_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_impact_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_impact_item_229() OWNER TO postgres;
+
+COMMIT;

--- a/db/privileged/20260726_metrologie_360_229_runtime_grants.verify.sql
+++ b/db/privileged/20260726_metrologie_360_229_runtime_grants.verify.sql
@@ -1,0 +1,95 @@
+-- Verify #229 runtime ownership and least-privilege grants.
+-- Read-only; safe on cerp_test and cerp_prod.
+
+BEGIN READ ONLY;
+
+DO $verify$
+DECLARE
+  table_name text;
+  function_name text;
+  actual_owner text;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'metrologie_categories',
+    'metrologie_plan_version',
+    'metrologie_execution',
+    'metrologie_execution_measurement',
+    'metrologie_impact_dossier',
+    'metrologie_impact_item'
+  ]
+  LOOP
+    SELECT tableowner
+      INTO actual_owner
+      FROM pg_tables
+     WHERE schemaname = 'public'
+       AND tablename = table_name;
+
+    IF actual_owner IS DISTINCT FROM 'postgres' THEN
+      RAISE EXCEPTION 'public.% owner is %, expected postgres', table_name, actual_owner;
+    END IF;
+
+    IF NOT has_table_privilege('cerp_app', format('public.%I', table_name), 'SELECT')
+       OR NOT has_table_privilege('cerp_app', format('public.%I', table_name), 'INSERT')
+       OR NOT has_table_privilege('cerp_app', format('public.%I', table_name), 'UPDATE')
+       OR has_table_privilege('cerp_app', format('public.%I', table_name), 'DELETE')
+       OR has_table_privilege('cerp_app', format('public.%I', table_name), 'TRUNCATE') THEN
+      RAISE EXCEPTION 'public.% mutable-table grants are not least privilege', table_name;
+    END IF;
+  END LOOP;
+
+  FOREACH table_name IN ARRAY ARRAY[
+    'metrologie_event_log',
+    'metrologie_measurement_revision',
+    'metrologie_command_receipts'
+  ]
+  LOOP
+    SELECT tableowner
+      INTO actual_owner
+      FROM pg_tables
+     WHERE schemaname = 'public'
+       AND tablename = table_name;
+
+    IF actual_owner IS DISTINCT FROM 'postgres' THEN
+      RAISE EXCEPTION 'public.% owner is %, expected postgres', table_name, actual_owner;
+    END IF;
+
+    IF NOT has_table_privilege('cerp_app', format('public.%I', table_name), 'SELECT')
+       OR NOT has_table_privilege('cerp_app', format('public.%I', table_name), 'INSERT')
+       OR has_table_privilege('cerp_app', format('public.%I', table_name), 'UPDATE')
+       OR has_table_privilege('cerp_app', format('public.%I', table_name), 'DELETE')
+       OR has_table_privilege('cerp_app', format('public.%I', table_name), 'TRUNCATE') THEN
+      RAISE EXCEPTION 'public.% append-only grants are not least privilege', table_name;
+    END IF;
+  END LOOP;
+
+  FOREACH function_name IN ARRAY ARRAY[
+    'fn_protect_metrologie_equipement_229',
+    'fn_protect_metrologie_plan_version_229',
+    'fn_protect_metrologie_execution_229',
+    'fn_protect_metrologie_measurement_229',
+    'fn_protect_metrologie_certificat_229',
+    'fn_metrologie_append_only_229',
+    'fn_protect_metrologie_categorie_229',
+    'fn_protect_metrologie_impact_229',
+    'fn_protect_metrologie_impact_item_229'
+  ]
+  LOOP
+    SELECT pg_get_userbyid(proowner)
+      INTO actual_owner
+      FROM pg_proc
+     WHERE pronamespace = 'public'::regnamespace
+       AND proname = function_name
+       AND pronargs = 0;
+
+    IF actual_owner IS DISTINCT FROM 'postgres' THEN
+      RAISE EXCEPTION 'public.%() owner is %, expected postgres', function_name, actual_owner;
+    END IF;
+  END LOOP;
+END
+$verify$;
+
+SELECT
+  current_database() AS database_name,
+  'metrologie_360_229_runtime_grants_ok' AS verification;
+
+ROLLBACK;

--- a/docs/http/metrologie-229.md
+++ b/docs/http/metrologie-229.md
@@ -311,3 +311,25 @@ Aucune trace SQL ni pile d'appel ne remonte au client.
   idempotence et verrou optimiste.
 - `src/__tests__/metrologie-360-229.routes.test.ts` — 32 cas : RBAC refusé par
   défaut, validation stricte, non-fuite de `storage_path`, éligibilité.
+
+---
+
+## 10. Ordre de déploiement PostgreSQL
+
+Le patch fonctionnel et le durcissement privilégié sont deux étapes
+obligatoires, dans cet ordre :
+
+1. `db/patches/20260726_metrologie_360_229.sql`
+2. `db/privileged/20260726_metrologie_360_229_runtime_grants.sql`
+3. `db/privileged/20260726_metrologie_360_229_runtime_grants.verify.sql`
+
+La deuxième étape rend le résultat identique quel que soit le rôle ayant
+appliqué le premier patch. Les tables de workflow restent détenues par
+`postgres` avec `SELECT/INSERT/UPDATE` pour `cerp_app`. Les preuves
+`metrologie_event_log`, `metrologie_measurement_revision` et
+`metrologie_command_receipts` sont détenues par `postgres` et limitées à
+`SELECT/INSERT` pour le rôle applicatif.
+
+Une sauvegarde restaurable est requise avant toute application sur
+`cerp_prod`. Le script `verify.sql` est en lecture seule et doit terminer avec
+`metrologie_360_229_runtime_grants_ok`.

--- a/docs/http/metrologie-229.md
+++ b/docs/http/metrologie-229.md
@@ -1,0 +1,313 @@
+# Métrologie 360 (#229) — modèle, API, états et impacts
+
+Surface : `/api/v1/metrologie/v2`. Le routeur historique `/api/v1/metrologie`
+reste en place, chemins et contrats inchangés ; il gagne seulement les mêmes
+gardes RBAC.
+
+Patch : `db/patches/20260726_metrologie_360_229.sql`
+Rollback : `db/patches/support/20260726_metrologie_360_229.rollback.sql`
+(restreint à `cerp_test`, refuse de s'exécuter dès qu'une preuve existe).
+
+---
+
+## 1. Vocabulaire — ce qui n'est pas interchangeable
+
+| Terme | Ce que c'est | Ce que ce n'est pas |
+| --- | --- | --- |
+| **Plan métrologique** | Règle versionnée : périodicité, méthode, tolérances, responsable, échéance | Une date saisie à la main |
+| **Étalonnage** | Comparaison à un étalon/référence, avec résultat et certificat | Une vérification interne |
+| **Vérification interne** | Contrôle d'aptitude périodique défini par procédure, tracé par un PV | Un certificat externe |
+| **Ajustage / réparation** | Intervention technique, exige une requalification avant remise en service | Une preuve d'aptitude |
+| **Contrôle qualité produit** | Exécution sur pièce/lot/OF qui *référence* l'instrument utilisé | L'historique métrologique de l'instrument |
+
+---
+
+## 2. Flux cible
+
+```
+Référentiel équipement
+      │
+      ▼
+Qualification + spécifications structurées (unité, plage, résolution, EMT, incertitude, méthodes)
+      │
+      ▼
+Plan versionné (DRAFT → ACTIVE → ARCHIVED)   ── publier archive la version précédente
+      │
+      ▼
+Exécution : ETALONNAGE | VERIFICATION | AJUSTAGE | REPARATION
+      │
+      ▼
+Mesures → verdict CALCULÉ → aperçu serveur (empreinte) → verdict RETENU + décision
+      │
+      ├── CONFORME / CONFORME_AVEC_RESTRICTION ──► dernière preuve + prochaine échéance
+      │
+      └── NON_CONFORME ──► quarantaine ciblée + analyse d'impact BORNÉE
+                                   │
+                                   ▼
+                    contrôles → OF / lots / BL  (liste explicable, paginée)
+                                   │
+                                   ▼
+                      décisions HUMAINES motivées, définitives
+```
+
+---
+
+## 3. Modèle de données
+
+### Tables créées
+
+| Table | Rôle |
+| --- | --- |
+| `metrologie_categories` | Référentiel administré des catégories de moyens de mesure. Désactivation, jamais suppression, quand elle est utilisée. Porte les exigences de saisie (`requires_range`, `requires_unit`, …). |
+| `metrologie_plan_version` | Règle versionnée par équipement et par type d'opération. Une seule version `ACTIVE` par couple (index unique partiel). |
+| `metrologie_execution` | Étalonnage, vérification, ajustage ou réparation. Immuable une fois validée, jamais supprimable. |
+| `metrologie_execution_measurement` | Points de mesure, avec verdict et écart calculés serveur. |
+| `metrologie_measurement_revision` | Historique append-only des corrections de relevé (motif obligatoire). |
+| `metrologie_impact_dossier` | Analyse d'impact bornée : fenêtre, méthode, exclusions, volumes, troncature. |
+| `metrologie_impact_item` | Un usage de l'instrument (contrôle, OF, lot, BL) et sa décision. |
+| `metrologie_command_receipts` | Reçus d'idempotence (acteur + clé unique). |
+
+### Tables étendues (additif)
+
+- `metrologie_equipements` : `categorie_code`, `etat`, spécifications structurées
+  (`unite`, `plage_min/max`, `resolution`, `mpe`, `incertitude`, `methodes[]`,
+  `restrictions`, `etalon_reference`, `exige_certificat`), implantation
+  (`site`, `magasin`, `zone`, `localisation_precise`), responsabilité,
+  quarantaine et dernière preuve conforme.
+- `metrologie_certificats` : `execution_id`, `document_kind`, `emetteur`,
+  `numero_externe`, `couverture`, `statut`, `confidentiality`, chaînage
+  `replaced_by_id`.
+- `metrologie_event_log` : `entity_type`, `entity_id`, `correlation_id`,
+  `idempotency_key`, `rule_code`, `reason`, `request_id`, `source`.
+
+### États
+
+**Stockés** (gouvernance) : `DRAFT`, `ACTIVE`, `QUALIFIED`, `SUSPENDED`,
+`QUARANTINE`, `OUT_OF_TOLERANCE`, `UNDER_REPAIR`, `RETIRED`.
+
+**Dérivés** (jamais stockés) : `DUE_SOON`, `OVERDUE`. Ils sont recalculés à
+chaque lecture depuis le plan actif et la date du jour, pour ne jamais dériver
+de la réalité. L'API expose `etat` (stocké) **et** `etat_effectif` (affiché).
+
+`statut` (`ACTIF/INACTIF/REBUT`) reste la vue héritée, synchronisée dans les
+deux sens par trigger. Une remise à `ACTIF` par le routeur historique ne fait
+**pas** sortir un instrument de quarantaine.
+
+Transitions autorisées :
+
+```
+DRAFT            → ACTIVE, QUALIFIED, RETIRED
+ACTIVE           → QUALIFIED, SUSPENDED, QUARANTINE, OUT_OF_TOLERANCE, UNDER_REPAIR, RETIRED
+QUALIFIED        → ACTIVE, SUSPENDED, QUARANTINE, OUT_OF_TOLERANCE, UNDER_REPAIR, RETIRED
+SUSPENDED        → ACTIVE, QUALIFIED, QUARANTINE, UNDER_REPAIR, RETIRED
+QUARANTINE       → UNDER_REPAIR, OUT_OF_TOLERANCE, QUALIFIED, RETIRED
+OUT_OF_TOLERANCE → UNDER_REPAIR, QUARANTINE, QUALIFIED, RETIRED
+UNDER_REPAIR     → QUARANTINE, QUALIFIED, RETIRED
+RETIRED          → (aucune)
+```
+
+Tout retour vers `ACTIVE`/`QUALIFIED` depuis `QUARANTINE`, `OUT_OF_TOLERANCE` ou
+`UNDER_REPAIR` est une **libération** : capacité `equipment_release`, réparation
+faite quand elle était exigée, preuve conforme valide et motif écrit.
+
+### Codification
+
+Allouée par le serveur dans la transaction, immuable ensuite (trigger).
+
+| Objet | Format | Périmètre |
+| --- | --- | --- |
+| Équipement | `MET-000001` | `MET` |
+| Exécution | `MEX-2026-000001` | `MEX:AAAA` |
+| Dossier d'impact | `MIA-2026-00001` | `MIA:AAAA` |
+
+Le patch restaure aussi `MCH` (parc machines #165), retiré par erreur lors de la
+réécriture du garde par `20260725_qualite_360_228.sql`.
+
+---
+
+## 4. Éligibilité — la règle vit à un seul endroit
+
+`src/module/metrologie/domain/metrology-eligibility.ts`. Le module Qualité la
+**consomme**, il ne la ré-implémente pas.
+
+Codes bloquants : `INSTRUMENT_REQUIRED`, `INSTRUMENT_UNKNOWN`,
+`INSTRUMENT_DELETED`, `INSTRUMENT_RETIRED`, `INSTRUMENT_QUARANTINE`,
+`INSTRUMENT_OUT_OF_TOLERANCE`, `INSTRUMENT_UNDER_REPAIR`,
+`INSTRUMENT_NOT_QUALIFIED`, `INSTRUMENT_OUT_OF_SCOPE`,
+`INSTRUMENT_METHOD_MISMATCH`, `INSTRUMENT_UNIT_MISMATCH`,
+`INSTRUMENT_RANGE_MISMATCH`, `INSTRUMENT_CERTIFICATE_MISSING`,
+`INSTRUMENT_OVERDUE_CRITICAL`, `OPERATOR_NOT_ALLOWED`.
+
+Codes d'avertissement (n'interdisent pas) : `INSTRUMENT_DUE_SOON`,
+`INSTRUMENT_OVERDUE`, `INSTRUMENT_UNIT_UNKNOWN`,
+`INSTRUMENT_RESOLUTION_INSUFFICIENT`, `INSTRUMENT_UNCERTAINTY_EXCESSIVE`,
+`INSTRUMENT_RESTRICTED`.
+
+Notes :
+
+- les unités sont normalisées par dimension (longueur, masse, température,
+  pression, angle, force, temps) ; comparer deux dimensions différentes est un
+  refus explicite, jamais une conversion « au mieux » ;
+- l'aptitude suit les règles d'atelier 1/10 (résolution) et 1/3 (incertitude)
+  face à l'intervalle de tolérance : c'est un **avertissement**, pas une
+  interdiction réglementaire ;
+- le blocage à échéance dépassée vient de `blocking_strategy` du plan
+  applicable (`BLOCK` / `WARN` / `NONE`) ou du réglage
+  `metrologie.block_on_overdue_critical` restreint aux instruments **critiques
+  et échus**. Sa portée est écrite en base (`scope = PER_INSTRUMENT`).
+
+---
+
+## 5. Endpoints
+
+Toutes les commandes à effet exigent `Idempotency-Key` ; toutes les
+modifications d'un agrégat existant exigent `expected_updated_at`.
+
+### Référentiels
+
+| Méthode | Chemin | Capacité |
+| --- | --- | --- |
+| `GET` | `/categories` | `read` |
+| `PUT` | `/categories` | `categories_manage` |
+| `GET` | `/units` | `read` |
+
+### Command center et éligibilité
+
+| Méthode | Chemin | Capacité |
+| --- | --- | --- |
+| `GET` | `/center` | `read` |
+| `GET` | `/eligibility?mode=single\|candidates` | `read` |
+
+### Registre
+
+| Méthode | Chemin | Capacité |
+| --- | --- | --- |
+| `GET` | `/equipements` | `read` |
+| `POST` | `/equipements` | `equipment_write` |
+| `GET` | `/equipements/:id` | `read` |
+| `PATCH` | `/equipements/:id` | `equipment_write` |
+| `POST` | `/equipements/:id/quarantine` | `quarantine_set` |
+| `POST` | `/equipements/:id/transitions` | `repair_manage` (+ `equipment_release` sur libération) |
+| `GET` | `/equipements/:id/timeline` | `audit_read` |
+| `GET` | `/equipements/:id/usage` | `impact_read` |
+
+`POST /equipements` **refuse** un champ `code` : il est alloué par le serveur.
+
+### Plans
+
+| Méthode | Chemin | Capacité |
+| --- | --- | --- |
+| `GET` | `/equipements/:id/schedule-preview` | `read` |
+| `POST` | `/equipements/:id/plans` | `plan_manage` |
+| `POST` | `/equipements/:id/plans/:childId/revisions` | `plan_manage` |
+| `POST` | `/equipements/:id/plans/:childId/transitions` | `plan_manage` |
+
+### Exécutions
+
+| Méthode | Chemin | Capacité |
+| --- | --- | --- |
+| `GET` | `/executions`, `/executions/:id` | `read` |
+| `POST` | `/equipements/:id/executions` | `execution_record` |
+| `POST` | `/executions/:id/measurements` | `execution_record` |
+| `GET` | `/executions/:id/verdict-preview` | `read` |
+| `POST` | `/executions/:id/validate` | `verdict_validate` |
+| `POST` | `/executions/:id/cancel` | `execution_record` |
+
+`validate` exige le `preview_hash` de l'aperçu : une saisie modifiée entre
+l'aperçu et la confirmation renvoie `409 METROLOGY_PREVIEW_STALE`.
+
+### Certificats et PV
+
+| Méthode | Chemin | Capacité |
+| --- | --- | --- |
+| `POST` | `/equipements/:id/certificats` (multipart, champ `document`) | `documents_write` |
+| `POST` | `/equipements/:id/certificats/:childId/cancel` | `documents_write` |
+| `GET` | `/equipements/:id/certificats/:childId/file` | `documents_read` |
+
+Contrôles : extension, MIME, **signature réelle** (magic bytes), taille ≤ 25 Mo,
+SHA-256. `storage_path` ne sort jamais d'un DTO, d'un log ni d'une URL.
+
+### Analyse d'impact
+
+| Méthode | Chemin | Capacité |
+| --- | --- | --- |
+| `GET` | `/impacts`, `/impacts/:id` | `impact_read` |
+| `POST` | `/equipements/:id/impacts` | `impact_create` |
+| `POST` | `/impacts/:id/items/:childId/decision` | `impact_decide` |
+| `POST` | `/impacts/:id/transitions` | `impact_decide` |
+
+---
+
+## 6. Matrice des permissions
+
+Refus par défaut. Les rôles CERP sont du texte libre : la correspondance se fait
+par sous-chaîne, comme pour `quality-policy.ts`.
+
+| Capacité | Admin / Direction | Métrologie | Qualité / QSE | Méthodes | Production / Atelier | Magasin, ADV, Finance |
+| --- | :-: | :-: | :-: | :-: | :-: | :-: |
+| `read` | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| `categories_manage` | ✓ | ✓ | ✓ | — | — | — |
+| `equipment_write` | ✓ | ✓ | ✓ | ✓ | — | — |
+| `plan_manage` | ✓ | ✓ | ✓ | — | — | — |
+| `execution_record` | ✓ | ✓ | ✓ | — | ✓ | — |
+| `verdict_validate` | ✓ | ✓ | ✓ | — | — | — |
+| `documents_read` | ✓ | ✓ | ✓ | ✓ | ✓ | — |
+| `documents_write` | ✓ | ✓ | ✓ | — | — | — |
+| `quarantine_set` | ✓ | ✓ | ✓ | — | ✓ | — |
+| `repair_manage` | ✓ | ✓ | ✓ | ✓ | — | — |
+| `equipment_release` | ✓ | ✓ | ✓ | — | — | — |
+| `impact_read` | ✓ | ✓ | ✓ | ✓ | — | — |
+| `impact_create` | ✓ | ✓ | ✓ | — | — | — |
+| `impact_decide` | ✓ | — | ✓ | — | — | — |
+| `settings_manage` | ✓ | — | — | — | — | — |
+
+Lectures utiles :
+
+- l'atelier **alerte** (quarantaine) et **relève** (mesures), il ne conclut pas
+  et ne libère pas ;
+- la **décision d'impact** appartient à la Qualité et à la direction, pas à la
+  métrologie qui a constaté le défaut ;
+- **séparation des tâches** : l'opérateur d'une vérification interne ne valide
+  pas son propre verdict, et l'auteur d'une intervention ne prononce pas sa
+  propre remise en service.
+
+---
+
+## 7. Ce que le module ne fait JAMAIS
+
+L'analyse d'impact est une **liste explicable**, pas un moteur d'action. Elle
+n'annule aucun contrôle, ne déstocke aucun lot, n'annule aucun bon de livraison,
+ne crée aucun avoir, ne bloque aucune expédition et ne déclenche aucun rappel
+client. Chaque décision (`RECHECK`, `HOLD_LOT`, `OPEN_NC`, `REISSUE_DOCUMENT`,
+`INFORM_CUSTOMER`) est **tracée ici** et **exécutée dans le module concerné**,
+par un humain habilité, avec motif.
+
+Le journal l'écrit noir sur blanc : `automatic_actions: "none"` sur l'ouverture
+du dossier, `executed_by_this_module: false` sur chaque décision.
+
+---
+
+## 8. Erreurs
+
+| Statut | Codes |
+| --- | --- |
+| `400` | `IDEMPOTENCY_KEY_INVALID`, `INVALID_STORAGE_PATH` |
+| `401` | `UNAUTHORIZED` |
+| `403` | `METROLOGY_CAPABILITY_REQUIRED`, `METROLOGY_SEPARATION_OF_DUTIES` |
+| `404` | `NOT_FOUND` |
+| `409` | `METROLOGY_VERSION_CONFLICT`, `METROLOGY_PREVIEW_STALE`, `IDEMPOTENCY_KEY_REUSED`, `METROLOGY_*_TRANSITION_FORBIDDEN`, `METROLOGY_EXECUTION_IMMUTABLE`, `METROLOGY_IMPACT_ALREADY_DECIDED`, `METROLOGY_CODE_DUPLICATE` |
+| `413` | `METROLOGY_DOCUMENT_TOO_LARGE` |
+| `422` | `METROLOGY_VALIDATION_ERROR` (avec `details.fields`), `METROLOGY_SPECIFICATIONS_INCOMPLETE`, `METROLOGY_CERTIFICATE_REQUIRED`, `METROLOGY_RELEASE_INCOMPLETE`, `METROLOGY_IMPACT_WINDOW_TOO_WIDE`, `METROLOGY_DOCUMENT_SIGNATURE_REJECTED` |
+
+Aucune trace SQL ni pile d'appel ne remonte au client.
+
+---
+
+## 9. Tests
+
+- `src/__tests__/metrologie-360-229.domain.test.ts` — 82 cas : RBAC, machine à
+  états, échéances (dont bornage du quantième), unités et conversions,
+  éligibilité (matrice complète), snapshot, verdicts, fenêtre d'impact,
+  idempotence et verrou optimiste.
+- `src/__tests__/metrologie-360-229.routes.test.ts` — 32 cas : RBAC refusé par
+  défaut, validation stricte, non-fuite de `storage_path`, éligibilité.

--- a/scripts/project-office/data/wp-transverse.ts
+++ b/scripts/project-office/data/wp-transverse.ts
@@ -24,8 +24,14 @@ export const WP_TRANSVERSE: WorkPackageDef[] = [
   },
   {
     code: "LOT-08.3", parent: "EPIC-08", title: "Métrologie et moyens de mesure", type: "LOT",
-    status: "IN_PROGRESS", start: "2026-02-01", due: "2026-12-18", progress: 50,
-    description: "Module métrologie (2026-02) ; gestion complète des moyens de mesure (étalonnage, échéances) à compléter. Sources : GIT_COMMIT 2026-02, note du 25/06 — réalisé VALIDÉ, reste À PLANIFIER (2026-T4).",
+    status: "IN_PROGRESS", start: "2026-02-01", due: "2026-12-18", progress: 80,
+    description: "Module métrologie (2026-02) puis Métrologie 360 (#229, 2026-07-26) : registre qualifié, plans versionnés, étalonnages/vérifications, certificats privés, quarantaine et analyse d'impact. Sources : GIT_COMMIT 2026-02, GITHUB_PR crp-systems-web#229, note du 25/06 — réalisé VALIDÉ, recette navigateur et application DB À VALIDER.",
+  },
+  {
+    code: "TSK-08.3.1", parent: "LOT-08.3", title: "Métrologie 360 (#229) : plans versionnés, verdicts, quarantaine, impact qualité", type: "TASK",
+    status: "IN_PROGRESS", priority: "HIGH", start: "2026-07-26", due: "2026-08-29", progress: 85,
+    description:
+      "Consolidation du module métrologie existant (aucun second module concurrent) : référentiel de catégories, spécifications structurées conditionnant l'éligibilité, plans versionnés DRAFT→ACTIVE→ARCHIVED avec échéance dérivée serveur, exécutions étalonnage/vérification/ajustage, verdict calculé + aperçu à empreinte, certificats privés (extension/MIME/signature/SHA-256), quarantaine ciblée et analyse d'impact BORNÉE depuis la dernière preuve conforme — sans aucune action automatique sur contrôles, OF, lots, BL, factures ou expéditions. Corrige trois risques préexistants : routeur historique seulement authentifié, `storage_path` exposé dans les DTO, périmètre MCH perdu dans `fn_next_issued_code_value`. Sources : GITHUB_PR crp-systems-web#229, docs/http/metrologie-229.md, docs/security/metrologie-229.md, docs/testing/metrologie-360-229-matrix.md — code et tests VALIDÉS (1938 backend + 793 frontend) ; patch DB `20260726_metrologie_360_229.sql` NON APPLIQUÉ (ni cerp_test ni cerp_prod) et recette navigateur À VALIDER.",
   },
   {
     code: "LOT-08.4", parent: "EPIC-08", title: "Traçabilité : lots, rebut, généalogie", type: "LOT",

--- a/src/__tests__/metrologie-360-229.domain.test.ts
+++ b/src/__tests__/metrologie-360-229.domain.test.ts
@@ -1,0 +1,1073 @@
+// Tests du domaine Métrologie 360 (#229).
+//
+// Le domaine est pur : ces tests n'ouvrent aucune connexion, ne montent aucun
+// serveur et couvrent la matrice réelle (catégories, états, échéances, unités,
+// plages, criticités, droits, verdicts, fenêtres d'impact).
+
+import { describe, it, expect } from "vitest";
+
+import {
+  assertEquipmentReleaseAllowed,
+  assertEquipmentTransition,
+  assertImpactClosureAllowed,
+  assertImpactDecision,
+  assertImpactTransition,
+  assertManualVerdictOverride,
+  assertOptimisticVersion,
+  assertPlanContentMutable,
+  assertPlanSelectableForExecution,
+  assertPlanTransition,
+  assertReleaseSeparation,
+  assertVerdictSeparation,
+  decideMetrologyReceipt,
+  equipmentStateBlocksUsage,
+  metrologyRequestHash,
+  metrologySha256,
+  normalizeMetrologyIdempotencyKey,
+  roleHasMetrologyCapability,
+  transitionRequiresRelease,
+  verdictIsAdmissibleProof,
+  verdictToLegacyCertificatResult,
+  verdictTriggersQuarantine,
+  METROLOGY_CAPABILITIES,
+  type MetrologyEquipmentState,
+} from "../module/metrologie/domain/metrology-policy";
+import {
+  addPeriod,
+  assertScheduleOverrideAllowed,
+  computeNextDueDate,
+  deriveEffectiveState,
+  evaluateDue,
+  parseIsoDate,
+  toIsoDate,
+} from "../module/metrologie/domain/metrology-schedule";
+import {
+  convertValue,
+  isKnownUnit,
+  listSupportedUnits,
+  resolveUnit,
+  sameDimension,
+  toBaseValue,
+} from "../module/metrologie/domain/metrology-units";
+import {
+  buildInstrumentSnapshot,
+  evaluateInstrumentEligibility,
+  type MetrologyInstrumentState,
+  type MetrologyUsageRequirement,
+} from "../module/metrologie/domain/metrology-eligibility";
+import {
+  computeExecutionVerdict,
+  evaluateMeasurement,
+} from "../module/metrologie/domain/metrology-verdict";
+import {
+  computeImpactWindow,
+  describeTruncation,
+  IMPACT_ITEM_HARD_LIMIT,
+  suggestImpactPriority,
+} from "../module/metrologie/domain/metrology-impact";
+
+/* -------------------------------------------------------------------------- */
+/* Fixtures                                                                   */
+/* -------------------------------------------------------------------------- */
+
+const AT = new Date("2026-07-26T09:00:00.000Z");
+
+function instrument(overrides: Partial<MetrologyInstrumentState> = {}): MetrologyInstrumentState {
+  return {
+    id: "11111111-1111-4111-8111-111111111111",
+    code: "MET-000001",
+    designation: "Pied à coulisse 150",
+    categorie_code: "PIED_A_COULISSE",
+    sous_categorie_code: null,
+    categorie_legacy: null,
+    etat: "QUALIFIED",
+    criticite: "NORMAL",
+    deleted: false,
+    unite: "mm",
+    plage_min: 0,
+    plage_max: 150,
+    resolution: 0.01,
+    mpe: 0.03,
+    incertitude: 0.02,
+    methodes: [],
+    restrictions: null,
+    exige_certificat: false,
+    plan_version_id: "22222222-2222-4222-8222-222222222222",
+    plan_version: 1,
+    plan_blocking_strategy: "BLOCK",
+    plan_alert_window_days: 30,
+    next_due_date: "2026-12-31",
+    last_proof_execution_id: "33333333-3333-4333-8333-333333333333",
+    last_proof_date: "2025-12-31",
+    last_proof_verdict: "CONFORME",
+    has_valid_certificate: true,
+    certificate_id: "44444444-4444-4444-8444-444444444444",
+    ...overrides,
+  };
+}
+
+function requirement(
+  overrides: Partial<MetrologyUsageRequirement> = {}
+): MetrologyUsageRequirement {
+  return {
+    characteristic_key: "COTE_A",
+    requires_instrument: true,
+    instrument_category: null,
+    method: null,
+    unit: "mm",
+    nominal: 20,
+    tolerance_min: 19.9,
+    tolerance_max: 20.1,
+    requires_certificate: false,
+    ...overrides,
+  };
+}
+
+function evaluate(
+  inst: MetrologyInstrumentState | null,
+  req: Partial<MetrologyUsageRequirement> = {},
+  policy = { block_on_overdue_critical: false }
+) {
+  return evaluateInstrumentEligibility({
+    requirement: requirement(req),
+    instrument: inst,
+    at: AT,
+    policy,
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/* 1) RBAC — refus par défaut                                                 */
+/* -------------------------------------------------------------------------- */
+
+describe("#229 RBAC métrologie", () => {
+  it("refuse toute capacité à un rôle vide ou inconnu", () => {
+    for (const capability of METROLOGY_CAPABILITIES) {
+      expect(roleHasMetrologyCapability(null, capability)).toBe(false);
+      expect(roleHasMetrologyCapability("", capability)).toBe(false);
+      expect(roleHasMetrologyCapability("stagiaire-accueil", capability)).toBe(false);
+      expect(roleHasMetrologyCapability("commercial", capability)).toBe(false);
+    }
+  });
+
+  it("accorde toutes les capacités à l'administrateur", () => {
+    for (const capability of METROLOGY_CAPABILITIES) {
+      expect(roleHasMetrologyCapability("administrateur", capability)).toBe(true);
+    }
+  });
+
+  it("donne à l'atelier la saisie mais jamais la validation ni la libération", () => {
+    expect(roleHasMetrologyCapability("operateur atelier", "execution_record")).toBe(true);
+    expect(roleHasMetrologyCapability("operateur atelier", "quarantine_set")).toBe(true);
+    expect(roleHasMetrologyCapability("operateur atelier", "verdict_validate")).toBe(false);
+    expect(roleHasMetrologyCapability("operateur atelier", "equipment_release")).toBe(false);
+    expect(roleHasMetrologyCapability("operateur atelier", "impact_decide")).toBe(false);
+    expect(roleHasMetrologyCapability("operateur atelier", "settings_manage")).toBe(false);
+  });
+
+  it("n'accorde aucun droit implicite au magasin, à l'ADV ni à la finance", () => {
+    for (const role of ["magasinier", "adv", "assistante adv", "comptable", "finance"]) {
+      for (const capability of METROLOGY_CAPABILITIES) {
+        expect(roleHasMetrologyCapability(role, capability)).toBe(false);
+      }
+    }
+  });
+
+  it("réserve la décision d'impact à la qualité et à la direction", () => {
+    expect(roleHasMetrologyCapability("responsable qualite", "impact_decide")).toBe(true);
+    expect(roleHasMetrologyCapability("directeur", "impact_decide")).toBe(true);
+    expect(roleHasMetrologyCapability("metrologue", "impact_decide")).toBe(false);
+    expect(roleHasMetrologyCapability("methodes", "impact_decide")).toBe(false);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 2) Machine à états équipement                                              */
+/* -------------------------------------------------------------------------- */
+
+describe("#229 états d'équipement", () => {
+  const usable: MetrologyEquipmentState[] = ["ACTIVE", "QUALIFIED"];
+  const blocked: MetrologyEquipmentState[] = [
+    "DRAFT",
+    "SUSPENDED",
+    "QUARANTINE",
+    "OUT_OF_TOLERANCE",
+    "UNDER_REPAIR",
+    "RETIRED",
+  ];
+
+  it("classe correctement les états utilisables et bloquants", () => {
+    for (const state of usable) expect(equipmentStateBlocksUsage(state)).toBe(false);
+    for (const state of blocked) expect(equipmentStateBlocksUsage(state)).toBe(true);
+  });
+
+  it("refuse une transition vers le même état", () => {
+    expect(() => assertEquipmentTransition("ACTIVE", "ACTIVE")).toThrowError(
+      /déjà dans l'état ACTIVE/
+    );
+  });
+
+  it("interdit toute sortie d'un équipement retiré", () => {
+    for (const target of [...usable, ...blocked]) {
+      if (target === "RETIRED") continue;
+      expect(() => assertEquipmentTransition("RETIRED", target)).toThrowError(/interdite/);
+    }
+  });
+
+  it("interdit le passage direct de quarantaine à ACTIVE", () => {
+    expect(() => assertEquipmentTransition("QUARANTINE", "ACTIVE")).toThrowError(/interdite/);
+    expect(() => assertEquipmentTransition("OUT_OF_TOLERANCE", "ACTIVE")).toThrowError(/interdite/);
+  });
+
+  it("autorise quarantaine → réparation → qualifié", () => {
+    expect(() => assertEquipmentTransition("QUARANTINE", "UNDER_REPAIR")).not.toThrow();
+    expect(() => assertEquipmentTransition("UNDER_REPAIR", "QUALIFIED")).not.toThrow();
+  });
+
+  it("exige une libération pour tout retour en service", () => {
+    expect(transitionRequiresRelease("QUARANTINE", "QUALIFIED")).toBe(true);
+    expect(transitionRequiresRelease("OUT_OF_TOLERANCE", "QUALIFIED")).toBe(true);
+    expect(transitionRequiresRelease("UNDER_REPAIR", "QUALIFIED")).toBe(true);
+    expect(transitionRequiresRelease("ACTIVE", "QUALIFIED")).toBe(false);
+    expect(transitionRequiresRelease("QUARANTINE", "RETIRED")).toBe(false);
+  });
+
+  it("refuse une remise en service sans preuve conforme, sans réparation ou sans motif", () => {
+    expect(() =>
+      assertEquipmentReleaseAllowed({
+        hasValidConformeProof: false,
+        proofExecutionId: null,
+        repairRequired: false,
+        repairDone: false,
+        reason: "Instrument revenu du fournisseur.",
+      })
+    ).toThrowError(/éléments obligatoires manquants/);
+
+    expect(() =>
+      assertEquipmentReleaseAllowed({
+        hasValidConformeProof: true,
+        proofExecutionId: "exec",
+        repairRequired: true,
+        repairDone: false,
+        reason: "Instrument revenu du fournisseur.",
+      })
+    ).toThrowError(/éléments obligatoires manquants/);
+
+    expect(() =>
+      assertEquipmentReleaseAllowed({
+        hasValidConformeProof: true,
+        proofExecutionId: "exec",
+        repairRequired: false,
+        repairDone: false,
+        reason: "court",
+      })
+    ).toThrowError(/éléments obligatoires manquants/);
+
+    expect(() =>
+      assertEquipmentReleaseAllowed({
+        hasValidConformeProof: true,
+        proofExecutionId: "exec",
+        repairRequired: true,
+        repairDone: true,
+        reason: "Réparé chez le fabricant puis réétalonné conforme.",
+      })
+    ).not.toThrow();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 3) Plans versionnés                                                        */
+/* -------------------------------------------------------------------------- */
+
+describe("#229 plans versionnés", () => {
+  it("fige une version active ou archivée", () => {
+    expect(() => assertPlanContentMutable("DRAFT")).not.toThrow();
+    expect(() => assertPlanContentMutable("ACTIVE")).toThrowError(/nouvelle version/);
+    expect(() => assertPlanContentMutable("ARCHIVED")).toThrowError(/nouvelle version/);
+  });
+
+  it("n'autorise que DRAFT→ACTIVE, DRAFT→ARCHIVED et ACTIVE→ARCHIVED", () => {
+    expect(() => assertPlanTransition("DRAFT", "ACTIVE")).not.toThrow();
+    expect(() => assertPlanTransition("DRAFT", "ARCHIVED")).not.toThrow();
+    expect(() => assertPlanTransition("ACTIVE", "ARCHIVED")).not.toThrow();
+    expect(() => assertPlanTransition("ACTIVE", "DRAFT")).toThrowError(/interdite/);
+    expect(() => assertPlanTransition("ARCHIVED", "ACTIVE")).toThrowError(/interdite/);
+  });
+
+  it("n'exécute que sur une version active", () => {
+    expect(() => assertPlanSelectableForExecution("ACTIVE")).not.toThrow();
+    expect(() => assertPlanSelectableForExecution("DRAFT")).toThrowError(/active/);
+    expect(() => assertPlanSelectableForExecution("ARCHIVED")).toThrowError(/active/);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 4) Échéances                                                               */
+/* -------------------------------------------------------------------------- */
+
+describe("#229 calcul d'échéance", () => {
+  const plan = {
+    periodicite_valeur: 12,
+    periodicite_unite: "MONTH" as const,
+    base_calcul: "LAST_PROOF" as const,
+    alert_window_days: 30,
+    effective_from: null,
+  };
+
+  it("borne le quantième lors d'un ajout de mois", () => {
+    expect(toIsoDate(addPeriod(parseIsoDate("2026-01-31") as Date, 1, "MONTH"))).toBe("2026-02-28");
+    expect(toIsoDate(addPeriod(parseIsoDate("2024-01-31") as Date, 1, "MONTH"))).toBe("2024-02-29");
+    expect(toIsoDate(addPeriod(parseIsoDate("2026-03-31") as Date, 1, "MONTH"))).toBe("2026-04-30");
+  });
+
+  it("gère jours, semaines, mois et années", () => {
+    const base = parseIsoDate("2026-07-26") as Date;
+    expect(toIsoDate(addPeriod(base, 10, "DAY"))).toBe("2026-08-05");
+    expect(toIsoDate(addPeriod(base, 2, "WEEK"))).toBe("2026-08-09");
+    expect(toIsoDate(addPeriod(base, 6, "MONTH"))).toBe("2027-01-26");
+    expect(toIsoDate(addPeriod(base, 2, "YEAR"))).toBe("2028-07-26");
+  });
+
+  it("dérive l'échéance de la dernière preuve", () => {
+    const result = computeNextDueDate({
+      plan,
+      lastProofDate: "2026-01-15",
+      fallbackDate: "2020-01-01",
+    });
+    expect(result).toMatchObject({ next_due_date: "2027-01-15", source: "LAST_PROOF" });
+  });
+
+  it("laisse le certificat externe primer sur le calcul interne", () => {
+    const result = computeNextDueDate({
+      plan,
+      lastProofDate: "2026-01-15",
+      certificateDueDate: "2026-09-30",
+      fallbackDate: "2020-01-01",
+    });
+    expect(result).toMatchObject({ next_due_date: "2026-09-30", source: "CERTIFICATE" });
+  });
+
+  it("retombe sur la mise en service quand aucune preuve n'existe", () => {
+    const result = computeNextDueDate({ plan, lastProofDate: null, fallbackDate: "2026-02-01" });
+    expect(result).toMatchObject({ next_due_date: "2027-02-01", source: "FALLBACK" });
+  });
+
+  it("exige une date d'effet pour une échéance à date fixe", () => {
+    const fixed = { ...plan, base_calcul: "FIXED_DATE" as const };
+    expect(computeNextDueDate({ plan: fixed, lastProofDate: null, fallbackDate: null })).toMatchObject({
+      next_due_date: null,
+      source: "NONE",
+    });
+    expect(
+      computeNextDueDate({
+        plan: { ...fixed, effective_from: "2026-03-01" },
+        lastProofDate: "2026-01-01",
+        fallbackDate: null,
+      })
+    ).toMatchObject({ next_due_date: "2027-03-01", source: "EFFECTIVE_FROM" });
+  });
+
+  it("classe OK / DUE_SOON / OVERDUE / UNKNOWN", () => {
+    expect(evaluateDue({ nextDueDate: null, alertWindowDays: 30, at: AT }).status).toBe("UNKNOWN");
+    expect(evaluateDue({ nextDueDate: "2026-12-31", alertWindowDays: 30, at: AT }).status).toBe("OK");
+    expect(evaluateDue({ nextDueDate: "2026-08-10", alertWindowDays: 30, at: AT }).status).toBe(
+      "DUE_SOON"
+    );
+    const overdue = evaluateDue({ nextDueDate: "2026-07-01", alertWindowDays: 30, at: AT });
+    expect(overdue.status).toBe("OVERDUE");
+    expect(overdue.days_overdue).toBe(25);
+  });
+
+  it("laisse l'état de gouvernance primer sur le dérivé d'échéance", () => {
+    const overdue = evaluateDue({ nextDueDate: "2026-01-01", alertWindowDays: 30, at: AT });
+    expect(deriveEffectiveState({ storedState: "ACTIVE", due: overdue })).toBe("OVERDUE");
+    expect(deriveEffectiveState({ storedState: "QUARANTINE", due: overdue })).toBe("QUARANTINE");
+    expect(deriveEffectiveState({ storedState: "RETIRED", due: overdue })).toBe("RETIRED");
+    expect(deriveEffectiveState({ storedState: "UNDER_REPAIR", due: overdue })).toBe("UNDER_REPAIR");
+  });
+
+  it("encadre strictement une échéance dérogatoire", () => {
+    const base = {
+      requestedDueDate: "2027-06-01",
+      computedDueDate: "2027-01-15",
+      requestedByUserId: 7,
+    };
+    expect(() =>
+      assertScheduleOverrideAllowed({ ...base, reason: "trop court", approvedByUserId: 9 })
+    ).toThrowError(/20 caractères/);
+    expect(() =>
+      assertScheduleOverrideAllowed({
+        ...base,
+        reason: "Report validé par la direction qualité après analyse de risque.",
+        approvedByUserId: null,
+      })
+    ).toThrowError(/approbation/);
+    expect(() =>
+      assertScheduleOverrideAllowed({
+        ...base,
+        reason: "Report validé par la direction qualité après analyse de risque.",
+        approvedByUserId: 7,
+      })
+    ).toThrowError(/propre dérogation/);
+    expect(() =>
+      assertScheduleOverrideAllowed({
+        ...base,
+        requestedDueDate: "2029-01-01",
+        reason: "Report validé par la direction qualité après analyse de risque.",
+        approvedByUserId: 9,
+      })
+    ).toThrowError(/dépasser d'un an/);
+    expect(() =>
+      assertScheduleOverrideAllowed({
+        ...base,
+        reason: "Report validé par la direction qualité après analyse de risque.",
+        approvedByUserId: 9,
+      })
+    ).not.toThrow();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 5) Unités                                                                  */
+/* -------------------------------------------------------------------------- */
+
+describe("#229 unités", () => {
+  it("reconnaît les unités usuelles et refuse les inconnues", () => {
+    for (const unit of ["mm", "cm", "m", "µm", "um", "in", "g", "kg", "°C", "K", "bar", "MPa", "N", "°"]) {
+      expect(isKnownUnit(unit)).toBe(true);
+    }
+    for (const unit of ["banane", "", "mmm", "quintal"]) {
+      expect(isKnownUnit(unit)).toBe(false);
+    }
+  });
+
+  it("convertit dans la même dimension", () => {
+    expect(convertValue(1, "m", "mm")).toEqual({ ok: true, value: 1000 });
+    expect(convertValue(1000, "µm", "mm")).toEqual({ ok: true, value: 1 });
+    expect(convertValue(1, "in", "mm")).toEqual({ ok: true, value: 25.4 });
+    expect(convertValue(1, "kg", "g")).toEqual({ ok: true, value: 1000 });
+    const kelvin = convertValue(273.15, "K", "°C");
+    expect(kelvin.ok && Math.abs(kelvin.value - 0) < 1e-9).toBe(true);
+  });
+
+  it("refuse de comparer deux dimensions différentes", () => {
+    expect(convertValue(1, "mm", "g")).toEqual({ ok: false, reason: "DIMENSION_MISMATCH" });
+    expect(convertValue(1, "bar", "°C")).toEqual({ ok: false, reason: "DIMENSION_MISMATCH" });
+    expect(sameDimension("mm", "in")).toBe(true);
+    expect(sameDimension("mm", "kg")).toBe(false);
+    expect(sameDimension("mm", null)).toBe(false);
+  });
+
+  it("signale une unité source ou cible inconnue", () => {
+    expect(convertValue(1, "banane", "mm")).toEqual({ ok: false, reason: "UNKNOWN_SOURCE" });
+    expect(convertValue(1, "mm", "banane")).toEqual({ ok: false, reason: "UNKNOWN_TARGET" });
+  });
+
+  it("normalise vers l'unité de base et expose le référentiel", () => {
+    expect(toBaseValue(1, "m")).toBe(1000);
+    expect(resolveUnit("UM")?.canonical).toBe("µm");
+    expect(listSupportedUnits().length).toBeGreaterThan(10);
+    expect(listSupportedUnits().some((u) => u.canonical === "mm" && u.dimension === "LENGTH")).toBe(true);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 6) Éligibilité — la matrice                                                */
+/* -------------------------------------------------------------------------- */
+
+describe("#229 éligibilité d'un instrument", () => {
+  it("n'exige rien quand la caractéristique n'exige pas d'instrument", () => {
+    const result = evaluate(null, { requires_instrument: false });
+    expect(result).toMatchObject({ eligible: true, code: "OK" });
+  });
+
+  it("bloque quand l'instrument est exigé mais absent", () => {
+    expect(evaluate(null)).toMatchObject({ eligible: false, code: "INSTRUMENT_REQUIRED" });
+  });
+
+  it("bloque un instrument supprimé", () => {
+    expect(evaluate(instrument({ deleted: true }))).toMatchObject({
+      eligible: false,
+      code: "INSTRUMENT_DELETED",
+    });
+  });
+
+  it.each([
+    ["QUARANTINE", "INSTRUMENT_QUARANTINE"],
+    ["OUT_OF_TOLERANCE", "INSTRUMENT_OUT_OF_TOLERANCE"],
+    ["UNDER_REPAIR", "INSTRUMENT_UNDER_REPAIR"],
+    ["RETIRED", "INSTRUMENT_RETIRED"],
+    ["DRAFT", "INSTRUMENT_NOT_QUALIFIED"],
+    ["SUSPENDED", "INSTRUMENT_NOT_QUALIFIED"],
+  ] as Array<[MetrologyEquipmentState, string]>)("bloque l'état %s", (etat, code) => {
+    const result = evaluate(instrument({ etat }));
+    expect(result.eligible).toBe(false);
+    expect(result.code).toBe(code);
+  });
+
+  it.each(["ACTIVE", "QUALIFIED"] as MetrologyEquipmentState[])(
+    "accepte l'état %s",
+    (etat) => {
+      expect(evaluate(instrument({ etat })).eligible).toBe(true);
+    }
+  );
+
+  it("bloque un instrument hors catégorie attendue", () => {
+    const result = evaluate(instrument(), { instrument_category: "MICROMETRE" });
+    expect(result).toMatchObject({ eligible: false, code: "INSTRUMENT_OUT_OF_SCOPE" });
+  });
+
+  it("accepte la catégorie par code, sous-catégorie ou libellé historique", () => {
+    expect(evaluate(instrument(), { instrument_category: "pied_a_coulisse" }).eligible).toBe(true);
+    expect(
+      evaluate(instrument({ sous_categorie_code: "MICROMETRE" }), {
+        instrument_category: "MICROMETRE",
+      }).eligible
+    ).toBe(true);
+    expect(
+      evaluate(instrument({ categorie_code: null, categorie_legacy: "Micromètre" }), {
+        instrument_category: "Micromètre",
+      }).eligible
+    ).toBe(true);
+  });
+
+  it("bloque une méthode non déclarée mais reste muet si l'instrument n'en déclare aucune", () => {
+    expect(
+      evaluate(instrument({ methodes: ["ISO-1", "ISO-2"] }), { method: "ISO-9" })
+    ).toMatchObject({ eligible: false, code: "INSTRUMENT_METHOD_MISMATCH" });
+    expect(evaluate(instrument({ methodes: ["ISO-1"] }), { method: "iso-1" }).eligible).toBe(true);
+    expect(evaluate(instrument({ methodes: [] }), { method: "ISO-9" }).eligible).toBe(true);
+  });
+
+  it("bloque une incompatibilité d'unité et signale une unité inconnue", () => {
+    expect(evaluate(instrument({ unite: "kg" }), { unit: "mm" })).toMatchObject({
+      eligible: false,
+      code: "INSTRUMENT_UNIT_MISMATCH",
+    });
+    const unknown = evaluate(instrument({ unite: "banane" }), { unit: "mm" });
+    expect(unknown.eligible).toBe(true);
+    expect(unknown.reasons.some((r) => r.code === "INSTRUMENT_UNIT_UNKNOWN")).toBe(true);
+  });
+
+  it("bloque une cote hors plage, y compris après conversion d'unité", () => {
+    expect(
+      evaluate(instrument(), { nominal: 400, tolerance_min: 399, tolerance_max: 401 })
+    ).toMatchObject({ eligible: false, code: "INSTRUMENT_RANGE_MISMATCH" });
+
+    // 300 mm exprimés en cm : 30 cm → hors plage 0–150 mm.
+    expect(
+      evaluate(instrument(), {
+        unit: "cm",
+        nominal: 30,
+        tolerance_min: 29.9,
+        tolerance_max: 30.1,
+      })
+    ).toMatchObject({ eligible: false, code: "INSTRUMENT_RANGE_MISMATCH" });
+
+    // 100 mm exprimés en cm : 10 cm → dans la plage.
+    expect(
+      evaluate(instrument(), { unit: "cm", nominal: 10, tolerance_min: 9.9, tolerance_max: 10.1 })
+        .eligible
+    ).toBe(true);
+  });
+
+  it("avertit sur une aptitude dégradée sans jamais bloquer", () => {
+    // IT = 0,02 mm ⇒ résolution max 0,002 mm, incertitude max ~0,0067 mm.
+    const result = evaluate(instrument({ resolution: 0.01, incertitude: 0.02 }), {
+      tolerance_min: 19.99,
+      tolerance_max: 20.01,
+    });
+    expect(result.eligible).toBe(true);
+    expect(result.severity).toBe("WARNING");
+    expect(result.reasons.map((r) => r.code)).toEqual(
+      expect.arrayContaining([
+        "INSTRUMENT_RESOLUTION_INSUFFICIENT",
+        "INSTRUMENT_UNCERTAINTY_EXCESSIVE",
+      ])
+    );
+  });
+
+  it("bloque quand une preuve documentaire exigée manque", () => {
+    expect(
+      evaluate(instrument({ has_valid_certificate: false }), { requires_certificate: true })
+    ).toMatchObject({ eligible: false, code: "INSTRUMENT_CERTIFICATE_MISSING" });
+    expect(
+      evaluate(instrument({ has_valid_certificate: false, exige_certificat: true }))
+    ).toMatchObject({ eligible: false, code: "INSTRUMENT_CERTIFICATE_MISSING" });
+    expect(
+      evaluate(instrument({ has_valid_certificate: true }), { requires_certificate: true }).eligible
+    ).toBe(true);
+  });
+
+  it("avertit d'une échéance proche", () => {
+    const result = evaluate(instrument({ next_due_date: "2026-08-10" }));
+    expect(result.eligible).toBe(true);
+    expect(result.reasons.some((r) => r.code === "INSTRUMENT_DUE_SOON")).toBe(true);
+  });
+
+  it("bloque un retard selon la stratégie du plan applicable", () => {
+    const overdue = { next_due_date: "2026-01-01" };
+    expect(
+      evaluate(instrument({ ...overdue, plan_blocking_strategy: "BLOCK" }))
+    ).toMatchObject({ eligible: false });
+    const warn = evaluate(instrument({ ...overdue, plan_blocking_strategy: "WARN" }));
+    expect(warn.eligible).toBe(true);
+    expect(warn.severity).toBe("WARNING");
+    const none = evaluate(instrument({ ...overdue, plan_blocking_strategy: "NONE" }));
+    expect(none.eligible).toBe(true);
+  });
+
+  it("applique le réglage historique UNIQUEMENT aux instruments critiques échus", () => {
+    const policy = { block_on_overdue_critical: true };
+    // Critique + échu + stratégie NONE : le réglage reprend la main.
+    expect(
+      evaluate(
+        instrument({
+          next_due_date: "2026-01-01",
+          criticite: "CRITIQUE",
+          plan_blocking_strategy: "NONE",
+        }),
+        {},
+        policy
+      )
+    ).toMatchObject({ eligible: false, code: "INSTRUMENT_OVERDUE_CRITICAL" });
+
+    // Non critique + échu + stratégie NONE : le réglage NE bloque pas l'usine.
+    expect(
+      evaluate(
+        instrument({
+          next_due_date: "2026-01-01",
+          criticite: "NORMAL",
+          plan_blocking_strategy: "NONE",
+        }),
+        {},
+        policy
+      ).eligible
+    ).toBe(true);
+
+    // Critique mais À JOUR : le réglage ne bloque rien.
+    expect(
+      evaluate(instrument({ criticite: "CRITIQUE", next_due_date: "2026-12-31" }), {}, policy)
+        .eligible
+    ).toBe(true);
+  });
+
+  it("bloque un opérateur sans droit de saisie", () => {
+    const result = evaluateInstrumentEligibility({
+      requirement: requirement(),
+      instrument: instrument(),
+      at: AT,
+      policy: { block_on_overdue_critical: false },
+      rights: { canRecordMeasurement: false },
+    });
+    expect(result).toMatchObject({ eligible: false, code: "OPERATOR_NOT_ALLOWED" });
+  });
+
+  it("expose la restriction documentée sans bloquer", () => {
+    const result = evaluate(instrument({ restrictions: "Ne pas utiliser au-delà de 100 mm." }));
+    expect(result.eligible).toBe(true);
+    expect(result.reasons.some((r) => r.code === "INSTRUMENT_RESTRICTED")).toBe(true);
+  });
+
+  it("cumule plusieurs raisons et retourne la première bloquante", () => {
+    const result = evaluate(
+      instrument({ etat: "QUARANTINE", next_due_date: "2026-01-01", restrictions: "Usage limité." })
+    );
+    expect(result.eligible).toBe(false);
+    expect(result.code).toBe("INSTRUMENT_QUARANTINE");
+    expect(result.reasons.length).toBeGreaterThan(1);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 7) Snapshot immuable                                                       */
+/* -------------------------------------------------------------------------- */
+
+describe("#229 snapshot instrument", () => {
+  it("fige l'état, l'éligibilité, le plan et la preuve, sans donnée sensible", () => {
+    const inst = instrument();
+    const eligibility = evaluate(inst);
+    const snapshot = buildInstrumentSnapshot({ instrument: inst, eligibility, at: AT });
+
+    expect(snapshot).toMatchObject({
+      snapshot_version: 2,
+      instrument_id: inst.id,
+      code: "MET-000001",
+      etat: "QUALIFIED",
+      eligible: true,
+      plan_version: 1,
+      next_due_date: "2026-12-31",
+      last_proof_verdict: "CONFORME",
+      used_at: AT.toISOString(),
+    });
+
+    const serialized = JSON.stringify(snapshot);
+    for (const forbidden of ["storage_path", "bucket", "token", "signature", "/srv/", "C:\\"]) {
+      expect(serialized).not.toContain(forbidden);
+    }
+  });
+
+  it("conserve la raison de refus quand l'instrument était inéligible", () => {
+    const inst = instrument({ etat: "OUT_OF_TOLERANCE" });
+    const eligibility = evaluate(inst);
+    const snapshot = buildInstrumentSnapshot({ instrument: inst, eligibility, at: AT });
+    expect(snapshot.eligible).toBe(false);
+    expect(snapshot.eligibility_code).toBe("INSTRUMENT_OUT_OF_TOLERANCE");
+    expect(snapshot.reasons.length).toBeGreaterThan(0);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 8) Verdicts                                                                */
+/* -------------------------------------------------------------------------- */
+
+describe("#229 verdict d'exécution", () => {
+  const criteria = { tolerance_min: 19.9, tolerance_max: 20.1, unite: "mm", min_points: null };
+
+  function point(overrides: Record<string, unknown> = {}) {
+    return {
+      point_key: "P1",
+      sample_no: 1,
+      nominal: 20,
+      tolerance_min: null,
+      tolerance_max: null,
+      measured: 20,
+      unite: "mm",
+      incertitude: null,
+      ...overrides,
+    };
+  }
+
+  it("juge un point dans, sous et au-dessus de la tolérance", () => {
+    expect(evaluateMeasurement(point({ measured: 20 }), criteria).verdict).toBe("CONFORME");
+    expect(evaluateMeasurement(point({ measured: 19.5 }), criteria).verdict).toBe("NON_CONFORME");
+    expect(evaluateMeasurement(point({ measured: 20.5 }), criteria).verdict).toBe("NON_CONFORME");
+  });
+
+  it("rend inconclusif un point sans valeur ou sans critère", () => {
+    expect(evaluateMeasurement(point({ measured: null }), criteria).verdict).toBe("INCONCLU");
+    expect(
+      evaluateMeasurement(point(), { tolerance_min: null, tolerance_max: null, unite: null, min_points: null })
+        .verdict
+    ).toBe("INCONCLU");
+  });
+
+  it("fait primer les bornes du point sur celles du plan", () => {
+    const result = evaluateMeasurement(
+      point({ measured: 25, tolerance_min: 24, tolerance_max: 26 }),
+      criteria
+    );
+    expect(result.verdict).toBe("CONFORME");
+  });
+
+  it("convertit le critère du plan dans l'unité du relevé", () => {
+    const inCm = evaluateMeasurement(point({ measured: 2, unite: "cm" }), criteria);
+    expect(inCm.verdict).toBe("CONFORME");
+    const outOfRange = evaluateMeasurement(point({ measured: 2.5, unite: "cm" }), criteria);
+    expect(outOfRange.verdict).toBe("NON_CONFORME");
+  });
+
+  it("rend inconclusif un relevé dont l'unité n'est pas comparable au critère", () => {
+    const result = evaluateMeasurement(point({ measured: 20, unite: "kg" }), criteria);
+    expect(result.verdict).toBe("INCONCLU");
+    expect(result.reason).toMatch(/Unités incompatibles/);
+  });
+
+  it("suffit d'un point hors tolérance pour rendre l'exécution non conforme", () => {
+    const result = computeExecutionVerdict({
+      operationType: "ETALONNAGE",
+      measurements: [point(), point({ point_key: "P2", measured: 25 }), point({ point_key: "P3" })],
+      criteria,
+    });
+    expect(result.verdict).toBe("NON_CONFORME");
+    expect(result.counts).toMatchObject({ total: 3, conforme: 2, non_conforme: 1 });
+  });
+
+  it("est inconclusif sans relevé, et le dit différemment pour un ajustage", () => {
+    expect(
+      computeExecutionVerdict({ operationType: "ETALONNAGE", measurements: [], criteria }).explanation
+    ).toMatch(/Aucun relevé/);
+    expect(
+      computeExecutionVerdict({ operationType: "AJUSTAGE", measurements: [], criteria }).explanation
+    ).toMatch(/requalification/);
+  });
+
+  it("est inconclusif si la procédure exige plus de points", () => {
+    const result = computeExecutionVerdict({
+      operationType: "ETALONNAGE",
+      measurements: [point()],
+      criteria: { ...criteria, min_points: 3 },
+    });
+    expect(result.verdict).toBe("INCONCLU");
+    expect(result.explanation).toMatch(/1 point\(s\) relevé\(s\) pour 3/);
+  });
+
+  it("mappe les verdicts vers l'enum historique des certificats", () => {
+    expect(verdictToLegacyCertificatResult("CONFORME", "ETALONNAGE")).toBe("CONFORME");
+    expect(verdictToLegacyCertificatResult("CONFORME_AVEC_RESTRICTION", "ETALONNAGE")).toBe("CONFORME");
+    expect(verdictToLegacyCertificatResult("NON_CONFORME", "ETALONNAGE")).toBe("NON_CONFORME");
+    expect(verdictToLegacyCertificatResult("INCONCLU", "ETALONNAGE")).toBe("NON_CONFORME");
+    expect(verdictToLegacyCertificatResult("CONFORME", "AJUSTAGE")).toBe("AJUSTAGE");
+    expect(verdictToLegacyCertificatResult("CONFORME", "REPARATION")).toBe("AJUSTAGE");
+  });
+
+  it("distingue preuve admissible et déclencheur de quarantaine", () => {
+    expect(verdictIsAdmissibleProof("CONFORME")).toBe(true);
+    expect(verdictIsAdmissibleProof("CONFORME_AVEC_RESTRICTION")).toBe(true);
+    expect(verdictIsAdmissibleProof("INCONCLU")).toBe(false);
+    expect(verdictIsAdmissibleProof("NON_CONFORME")).toBe(false);
+    expect(verdictTriggersQuarantine("NON_CONFORME")).toBe(true);
+    expect(verdictTriggersQuarantine("INCONCLU")).toBe(false);
+  });
+
+  it("interdit de transformer un hors tolérance en conformité par décision manuelle", () => {
+    expect(() =>
+      assertManualVerdictOverride({
+        computed: "NON_CONFORME",
+        requested: "CONFORME",
+        justification: "Le relevé était faussé par la température ambiante mesurée.",
+        evidenceCount: 1,
+        requireEvidence: true,
+      })
+    ).toThrowError(/utilisez « conforme avec restriction »/);
+  });
+
+  it("exige justification et preuve pour tout verdict contraire au calcul", () => {
+    expect(() =>
+      assertManualVerdictOverride({
+        computed: "CONFORME",
+        requested: "CONFORME_AVEC_RESTRICTION",
+        justification: "trop court",
+        evidenceCount: 1,
+        requireEvidence: true,
+      })
+    ).toThrowError(/20 caractères/);
+
+    expect(() =>
+      assertManualVerdictOverride({
+        computed: "CONFORME",
+        requested: "CONFORME_AVEC_RESTRICTION",
+        justification: "Dérive constatée en haut de plage, emploi restreint à 0-100 mm.",
+        evidenceCount: 0,
+        requireEvidence: true,
+      })
+    ).toThrowError(/pièce jointe/);
+
+    expect(() =>
+      assertManualVerdictOverride({
+        computed: "CONFORME",
+        requested: "CONFORME",
+        justification: null,
+        evidenceCount: 0,
+        requireEvidence: true,
+      })
+    ).not.toThrow();
+  });
+
+  it("interdit l'auto-validation, sauf étalonnage externe sans opérateur interne", () => {
+    expect(() =>
+      assertVerdictSeparation({ operatorUserId: 5, validatorUserId: 5, operationType: "VERIFICATION" })
+    ).toThrowError(/ne peut pas valider lui-même/);
+    expect(() =>
+      assertVerdictSeparation({ operatorUserId: 5, validatorUserId: 9, operationType: "VERIFICATION" })
+    ).not.toThrow();
+    expect(() =>
+      assertVerdictSeparation({ operatorUserId: null, validatorUserId: 5, operationType: "ETALONNAGE" })
+    ).not.toThrow();
+  });
+
+  it("interdit l'auto-libération après intervention", () => {
+    expect(() => assertReleaseSeparation({ operatorUserId: 4, releaserUserId: 4 })).toThrowError(
+      /pas prononcer lui-même/
+    );
+    expect(() => assertReleaseSeparation({ operatorUserId: 4, releaserUserId: 8 })).not.toThrow();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 9) Analyse d'impact                                                        */
+/* -------------------------------------------------------------------------- */
+
+describe("#229 analyse d'impact", () => {
+  const eventAt = new Date("2026-07-26T10:00:00.000Z");
+  const created = new Date("2024-01-01T00:00:00.000Z");
+
+  it("borne la fenêtre à la dernière preuve conforme", () => {
+    const window = computeImpactWindow({
+      trigger: "VERDICT_NON_CONFORME",
+      eventAt,
+      lastConformeProofAt: new Date("2026-01-15T00:00:00.000Z"),
+      equipmentCreatedAt: created,
+    });
+    expect(window.source).toBe("LAST_CONFORME_PROOF");
+    expect(window.from.toISOString()).toBe("2026-01-15T00:00:00.000Z");
+    expect(window.to).toBe(eventAt);
+    expect(window.span_days).toBe(193);
+  });
+
+  it("remonte à l'entrée au registre quand aucune preuve conforme n'existe", () => {
+    const window = computeImpactWindow({
+      trigger: "VERDICT_NON_CONFORME",
+      eventAt,
+      lastConformeProofAt: null,
+      equipmentCreatedAt: new Date("2025-09-01T00:00:00.000Z"),
+    });
+    expect(window.source).toBe("EQUIPMENT_CREATION");
+    expect(window.method).toMatch(/Aucune preuve conforme/);
+  });
+
+  it("refuse une fenêtre non bornée", () => {
+    expect(() =>
+      computeImpactWindow({
+        trigger: "MANUEL",
+        eventAt,
+        lastConformeProofAt: null,
+        equipmentCreatedAt: new Date("2000-01-01T00:00:00.000Z"),
+      })
+    ).toThrowError(/dépasse 1826 jours/);
+  });
+
+  it("accepte une fenêtre approuvée justifiée et refuse les incohérentes", () => {
+    expect(() =>
+      computeImpactWindow({
+        trigger: "MANUEL",
+        eventAt,
+        lastConformeProofAt: null,
+        equipmentCreatedAt: created,
+        approvedFrom: new Date("2026-06-01T00:00:00.000Z"),
+        approvedTo: new Date("2026-05-01T00:00:00.000Z"),
+        approvedReason: "Analyse restreinte au mois de juin après revue documentaire.",
+      })
+    ).toThrowError(/se termine avant/);
+
+    expect(() =>
+      computeImpactWindow({
+        trigger: "MANUEL",
+        eventAt,
+        lastConformeProofAt: null,
+        equipmentCreatedAt: created,
+        approvedFrom: new Date("2026-06-01T00:00:00.000Z"),
+        approvedTo: new Date("2026-07-01T00:00:00.000Z"),
+        approvedReason: "court",
+      })
+    ).toThrowError(/20 caractères/);
+
+    const window = computeImpactWindow({
+      trigger: "MANUEL",
+      eventAt,
+      lastConformeProofAt: null,
+      equipmentCreatedAt: created,
+      approvedFrom: new Date("2026-06-01T00:00:00.000Z"),
+      approvedTo: new Date("2026-07-01T00:00:00.000Z"),
+      approvedReason: "Analyse restreinte au mois de juin après revue documentaire complète.",
+    });
+    expect(window.source).toBe("APPROVED_WINDOW");
+  });
+
+  it("propose une priorité guidée par l'exposition client", () => {
+    const base = { controls: 5, work_orders: 2, lots: 1, deliveries: 0, truncated: false };
+    expect(suggestImpactPriority({ volumes: base, criticite: "NORMAL" })).toBe("NORMAL");
+    expect(suggestImpactPriority({ volumes: base, criticite: "CRITIQUE" })).toBe("HIGH");
+    expect(
+      suggestImpactPriority({ volumes: { ...base, deliveries: 3 }, criticite: "NORMAL" })
+    ).toBe("HIGH");
+    expect(
+      suggestImpactPriority({ volumes: { ...base, deliveries: 3 }, criticite: "CRITIQUE" })
+    ).toBe("CRITICAL");
+    expect(
+      suggestImpactPriority({ volumes: { ...base, controls: 0 }, criticite: "NORMAL" })
+    ).toBe("LOW");
+    expect(
+      suggestImpactPriority({ volumes: { ...base, controls: 80 }, criticite: "NORMAL" })
+    ).toBe("HIGH");
+  });
+
+  it("annonce explicitement une troncature au lieu de la taire", () => {
+    expect(describeTruncation(2000, 2000)).toBeNull();
+    expect(describeTruncation(2000, 5000)).toMatch(/2000 usages matérialisés sur 5000/);
+    expect(IMPACT_ITEM_HARD_LIMIT).toBe(2000);
+  });
+
+  it("exige une décision motivée, jamais « à traiter »", () => {
+    expect(() => assertImpactDecision({ decision: "PENDING", reason: "peu importe" })).toThrowError(
+      /n'est pas une décision/
+    );
+    expect(() => assertImpactDecision({ decision: "HOLD_LOT", reason: "abc" })).toThrowError(
+      /motif écrit/
+    );
+    expect(() =>
+      assertImpactDecision({ decision: "HOLD_LOT", reason: "Lot mis en attente qualité." })
+    ).not.toThrow();
+  });
+
+  it("ne clôt un dossier qu'avec zéro usage en attente et une conclusion écrite", () => {
+    expect(() =>
+      assertImpactClosureAllowed({ pendingItems: 3, conclusion: "Conclusion suffisamment longue." })
+    ).toThrowError(/éléments obligatoires|décidé/);
+    expect(() => assertImpactClosureAllowed({ pendingItems: 0, conclusion: "trop court" })).toThrowError(
+      /décidé|obligatoires/
+    );
+    expect(() =>
+      assertImpactClosureAllowed({
+        pendingItems: 0,
+        conclusion: "Aucun impact produit avéré après recontrôle de la totalité des lots.",
+      })
+    ).not.toThrow();
+  });
+
+  it("interdit la réouverture d'un dossier clos", () => {
+    expect(() => assertImpactTransition("OPEN", "IN_REVIEW")).not.toThrow();
+    expect(() => assertImpactTransition("IN_REVIEW", "CLOSED")).not.toThrow();
+    expect(() => assertImpactTransition("CLOSED", "OPEN")).toThrowError(/interdite/);
+    expect(() => assertImpactTransition("CANCELLED", "OPEN")).toThrowError(/interdite/);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 10) Idempotence et concurrence                                             */
+/* -------------------------------------------------------------------------- */
+
+describe("#229 idempotence et verrou optimiste", () => {
+  it("borne la clé d'idempotence", () => {
+    expect(() => normalizeMetrologyIdempotencyKey(null)).toThrowError(/8 et 200/);
+    expect(() => normalizeMetrologyIdempotencyKey("court")).toThrowError(/8 et 200/);
+    expect(() => normalizeMetrologyIdempotencyKey("x".repeat(201))).toThrowError(/8 et 200/);
+    expect(normalizeMetrologyIdempotencyKey("  clef-valide-1234  ")).toBe("clef-valide-1234");
+  });
+
+  it("produit une empreinte canonique indépendante de l'ordre des clés", () => {
+    expect(metrologySha256({ a: 1, b: 2 })).toBe(metrologySha256({ b: 2, a: 1 }));
+    expect(metrologySha256({ a: 1, b: undefined })).toBe(metrologySha256({ a: 1 }));
+    expect(metrologyRequestHash("cmd", { a: 1 })).not.toBe(metrologyRequestHash("cmd2", { a: 1 }));
+    expect(metrologyRequestHash("cmd", { a: 1 })).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("distingue nouvelle commande, rejeu et conflit", () => {
+    const hash = metrologyRequestHash("cmd", { a: 1 });
+    expect(decideMetrologyReceipt(null, hash)).toBe("NEW");
+    expect(decideMetrologyReceipt(hash, hash)).toBe("REPLAY");
+    expect(decideMetrologyReceipt("autre", hash)).toBe("CONFLICT");
+  });
+
+  it("exige et vérifie expected_updated_at", () => {
+    const current = "2026-07-26T09:00:00.000Z";
+    expect(() =>
+      assertOptimisticVersion({ expectedUpdatedAt: null, currentUpdatedAt: current })
+    ).toThrowError(/obligatoire/);
+    expect(() =>
+      assertOptimisticVersion({ expectedUpdatedAt: "pas-une-date", currentUpdatedAt: current })
+    ).toThrowError(/invalide/);
+    expect(() =>
+      assertOptimisticVersion({
+        expectedUpdatedAt: "2026-07-26T08:00:00.000Z",
+        currentUpdatedAt: current,
+      })
+    ).toThrowError(/modifié entre-temps/);
+    expect(() =>
+      assertOptimisticVersion({ expectedUpdatedAt: current, currentUpdatedAt: current })
+    ).not.toThrow();
+    expect(() =>
+      assertOptimisticVersion({ expectedUpdatedAt: current, currentUpdatedAt: new Date(current) })
+    ).not.toThrow();
+  });
+});

--- a/src/__tests__/metrologie-360-229.routes.test.ts
+++ b/src/__tests__/metrologie-360-229.routes.test.ts
@@ -1,0 +1,456 @@
+// Surface HTTP Métrologie 360 (#229) : RBAC refusé par défaut, validation
+// stricte, verrou optimiste obligatoire et non-fuite des chemins de stockage.
+
+import request from "supertest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+  currentRole: { value: "administrateur" as string | null },
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = {
+    on: emitter.on.bind(emitter),
+    query: mocks.poolQuery,
+    connect: mocks.poolConnect,
+  };
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; username: string; email: string; role: string } },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void
+  ) => {
+    if (mocks.currentRole.value === null) {
+      res.status(401).json({ error: "UNAUTHORIZED" });
+      return;
+    }
+    req.user = {
+      id: 1,
+      username: "tester",
+      email: "tester@example.test",
+      role: mocks.currentRole.value,
+    };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import app from "../config/app";
+
+const BASE = "/api/v1/metrologie/v2";
+const EQUIP_ID = "11111111-1111-4111-8111-111111111111";
+const CHILD_ID = "22222222-2222-4222-8222-222222222222";
+
+beforeEach(() => {
+  mocks.poolQuery.mockReset();
+  mocks.poolConnect.mockReset();
+  mocks.clientQuery.mockReset();
+  mocks.clientRelease.mockReset();
+  mocks.currentRole.value = "administrateur";
+
+  mocks.poolQuery.mockResolvedValue({ rows: [] });
+  mocks.clientQuery.mockResolvedValue({ rows: [] });
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+});
+
+describe("#229 authentification", () => {
+  it("refuse un appel non authentifié", async () => {
+    mocks.currentRole.value = null;
+    const res = await request(app).get(`${BASE}/center`);
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("#229 RBAC — refus par défaut", () => {
+  const readRoutes: Array<[string, string]> = [
+    ["get", `${BASE}/center`],
+    ["get", `${BASE}/categories`],
+    ["get", `${BASE}/units`],
+    ["get", `${BASE}/equipements`],
+    ["get", `${BASE}/executions`],
+  ];
+
+  it.each(readRoutes)("refuse %s %s à un rôle sans droit", async (method, url) => {
+    mocks.currentRole.value = "commercial";
+    const res = await (request(app) as unknown as Record<string, (u: string) => Promise<{ status: number; body: Record<string, unknown> }>>)[
+      method
+    ](url);
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: "METROLOGY_CAPABILITY_REQUIRED" });
+  });
+
+  it("autorise la lecture à l'atelier mais refuse la validation de verdict", async () => {
+    mocks.currentRole.value = "operateur atelier";
+    const read = await request(app).get(`${BASE}/units`);
+    expect(read.status).toBe(200);
+
+    const validate = await request(app)
+      .post(`${BASE}/executions/${EQUIP_ID}/validate`)
+      .send({});
+    expect(validate.status).toBe(403);
+    expect(validate.body).toMatchObject({ code: "METROLOGY_CAPABILITY_REQUIRED" });
+  });
+
+  it("refuse au métrologue la décision d'impact, réservée à la qualité", async () => {
+    mocks.currentRole.value = "metrologue";
+    const res = await request(app)
+      .post(`${BASE}/impacts/${EQUIP_ID}/items/${CHILD_ID}/decision`)
+      .send({ decision: "NO_IMPACT", reason: "Aucun impact." });
+    expect(res.status).toBe(403);
+  });
+
+  it("refuse au magasin toute écriture sur le registre", async () => {
+    mocks.currentRole.value = "magasinier";
+    const res = await request(app).post(`${BASE}/equipements`).send({ designation: "X" });
+    expect(res.status).toBe(403);
+  });
+
+  it("refuse la gestion des catégories hors qualité/métrologie/direction", async () => {
+    mocks.currentRole.value = "methodes";
+    const res = await request(app)
+      .put(`${BASE}/categories`)
+      .send({ code: "TEST", label: "Test" });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("#229 validation stricte", () => {
+  it("refuse un code d'équipement envoyé par le client (alloué serveur)", async () => {
+    const res = await request(app)
+      .post(`${BASE}/equipements`)
+      .send({ code: "MET-000042", designation: "Pied à coulisse", categorie_code: "PIED_A_COULISSE" });
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({ code: "METROLOGY_VALIDATION_ERROR" });
+  });
+
+  it("refuse une plage sans unité", async () => {
+    const res = await request(app).post(`${BASE}/equipements`).send({
+      designation: "Micromètre",
+      categorie_code: "MICROMETRE",
+      plage_min: 0,
+      plage_max: 25,
+    });
+    expect(res.status).toBe(422);
+    expect(res.body?.details?.fields).toHaveProperty("unite");
+  });
+
+  it("refuse une borne haute inférieure à la borne basse", async () => {
+    const res = await request(app).post(`${BASE}/equipements`).send({
+      designation: "Micromètre",
+      categorie_code: "MICROMETRE",
+      unite: "mm",
+      plage_min: 25,
+      plage_max: 0,
+    });
+    expect(res.status).toBe(422);
+    expect(res.body?.details?.fields).toHaveProperty("plage_max");
+  });
+
+  it("refuse une valeur non finie", async () => {
+    const res = await request(app)
+      .post(`${BASE}/equipements`)
+      .send({
+        designation: "Balance",
+        categorie_code: "BALANCE",
+        unite: "g",
+        resolution: 1e12,
+      });
+    expect(res.status).toBe(422);
+  });
+
+  it("exige expected_updated_at pour toute modification", async () => {
+    const res = await request(app)
+      .patch(`${BASE}/equipements/${EQUIP_ID}`)
+      .send({ designation: "Nouveau nom", categorie_code: "MICROMETRE" });
+    expect(res.status).toBe(422);
+    expect(res.body?.details?.fields).toHaveProperty("expected_updated_at");
+  });
+
+  it("exige un motif d'au moins 10 caractères pour une quarantaine", async () => {
+    const res = await request(app)
+      .post(`${BASE}/equipements/${EQUIP_ID}/quarantine`)
+      .send({ expected_updated_at: "2026-07-26T09:00:00.000Z", reason: "cassé" });
+    expect(res.status).toBe(422);
+    expect(res.body?.details?.fields).toHaveProperty("reason");
+  });
+
+  it("exige une empreinte d'aperçu pour valider un verdict", async () => {
+    const res = await request(app)
+      .post(`${BASE}/executions/${EQUIP_ID}/validate`)
+      .send({
+        expected_updated_at: "2026-07-26T09:00:00.000Z",
+        verdict: "CONFORME",
+        decision: "REMISE_EN_SERVICE",
+        decision_reason: "Étalonnage conforme sur toute la plage.",
+      });
+    expect(res.status).toBe(422);
+    expect(res.body?.details?.fields).toHaveProperty("preview_hash");
+  });
+
+  it("exige une restriction quand le verdict est conforme avec restriction", async () => {
+    const res = await request(app)
+      .post(`${BASE}/executions/${EQUIP_ID}/validate`)
+      .send({
+        expected_updated_at: "2026-07-26T09:00:00.000Z",
+        preview_hash: "a".repeat(64),
+        verdict: "CONFORME_AVEC_RESTRICTION",
+        decision: "REMISE_EN_SERVICE",
+        decision_reason: "Emploi restreint au bas de plage.",
+      });
+    expect(res.status).toBe(422);
+    expect(res.body?.details?.fields).toHaveProperty("restriction");
+  });
+
+  it("exige une approbation pour une échéance dérogatoire", async () => {
+    const res = await request(app)
+      .post(`${BASE}/executions/${EQUIP_ID}/validate`)
+      .send({
+        expected_updated_at: "2026-07-26T09:00:00.000Z",
+        preview_hash: "a".repeat(64),
+        verdict: "CONFORME",
+        decision: "REMISE_EN_SERVICE",
+        decision_reason: "Étalonnage conforme sur toute la plage.",
+        override_next_due_date: "2028-01-01",
+      });
+    expect(res.status).toBe(422);
+    expect(res.body?.details?.fields).toHaveProperty("override_approved_by");
+  });
+
+  it("exige un prestataire déclaré pour un étalonnage externe", async () => {
+    const res = await request(app)
+      .post(`${BASE}/equipements/${EQUIP_ID}/plans`)
+      .send({
+        operation_type: "ETALONNAGE",
+        periodicite_valeur: 12,
+        prestataire_type: "EXTERNE",
+      });
+    expect(res.status).toBe(422);
+    expect(res.body?.details?.fields).toHaveProperty("prestataire_label");
+  });
+
+  it("exige une date d'effet pour une échéance à date fixe", async () => {
+    const res = await request(app)
+      .post(`${BASE}/equipements/${EQUIP_ID}/plans`)
+      .send({
+        operation_type: "VERIFICATION",
+        periodicite_valeur: 6,
+        base_calcul: "FIXED_DATE",
+      });
+    expect(res.status).toBe(422);
+    expect(res.body?.details?.fields).toHaveProperty("effective_from");
+  });
+
+  it("exige une version de plan pour un étalonnage", async () => {
+    const res = await request(app)
+      .post(`${BASE}/equipements/${EQUIP_ID}/executions`)
+      .send({ operation_type: "ETALONNAGE" });
+    expect(res.status).toBe(422);
+    expect(res.body?.details?.fields).toHaveProperty("plan_version_id");
+  });
+
+  it("exige les deux bornes et une justification pour une fenêtre d'impact imposée", async () => {
+    const partial = await request(app)
+      .post(`${BASE}/equipements/${EQUIP_ID}/impacts`)
+      .send({ window_from: "2026-01-01T00:00:00.000Z" });
+    expect(partial.status).toBe(422);
+    expect(partial.body?.details?.fields).toHaveProperty("window_to");
+
+    const unjustified = await request(app)
+      .post(`${BASE}/equipements/${EQUIP_ID}/impacts`)
+      .send({
+        window_from: "2026-01-01T00:00:00.000Z",
+        window_to: "2026-06-01T00:00:00.000Z",
+        window_reason: "court",
+      });
+    expect(unjustified.status).toBe(422);
+    expect(unjustified.body?.details?.fields).toHaveProperty("window_reason");
+  });
+
+  it("refuse « à traiter » comme décision d'impact", async () => {
+    const res = await request(app)
+      .post(`${BASE}/impacts/${EQUIP_ID}/items/${CHILD_ID}/decision`)
+      .send({ decision: "PENDING", reason: "Sans avis pour l'instant." });
+    expect(res.status).toBe(422);
+  });
+
+  it("refuse un identifiant qui n'est pas un UUID", async () => {
+    const res = await request(app).get(`${BASE}/equipements/pas-un-uuid`);
+    expect(res.status).toBe(422);
+  });
+
+  it("borne la pagination", async () => {
+    const res = await request(app).get(`${BASE}/equipements?pageSize=5000`);
+    expect(res.status).toBe(422);
+  });
+
+  it("refuse un segment inconnu du command center", async () => {
+    const res = await request(app).get(`${BASE}/equipements?segment=inconnu`);
+    expect(res.status).toBe(422);
+  });
+
+  it("refuse un paramètre de requête inconnu (schéma strict)", async () => {
+    const res = await request(app).get(`${BASE}/equipements?sqlInjection=1`);
+    expect(res.status).toBe(422);
+  });
+});
+
+describe("#229 éligibilité", () => {
+  it("exige l'instrument en mode single", async () => {
+    const res = await request(app).get(`${BASE}/eligibility?mode=single`);
+    expect(res.status).toBe(422);
+    expect(res.body?.details?.fields).toHaveProperty("instrument_id");
+  });
+
+  it("évalue un instrument inconnu sans jamais tomber en 500", async () => {
+    mocks.poolQuery.mockResolvedValue({ rows: [] });
+    const res = await request(app).get(
+      `${BASE}/eligibility?mode=single&instrument_id=${EQUIP_ID}&characteristic_key=COTE_A`
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.results[0]).toMatchObject({
+      eligible: false,
+      reason_code: "INSTRUMENT_REQUIRED",
+    });
+  });
+});
+
+describe("#229 référentiel d'unités", () => {
+  it("expose la liste serveur des unités supportées", async () => {
+    const res = await request(app).get(`${BASE}/units`);
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body.items)).toBe(true);
+    expect(res.body.items.some((u: { canonical: string }) => u.canonical === "mm")).toBe(true);
+  });
+});
+
+describe("#229 non-fuite du stockage", () => {
+  it("ne renvoie jamais storage_path dans le détail d'un équipement", async () => {
+    const now = "2026-07-26T09:00:00.000Z";
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.metrologie_equipements e") && sql.includes("cat.label AS categorie_label")) {
+        return Promise.resolve({
+          rows: [
+            {
+              id: EQUIP_ID,
+              code: "MET-000001",
+              designation: "Pied à coulisse",
+              categorie_code: "PIED_A_COULISSE",
+              categorie_label: "Pied à coulisse",
+              sous_categorie_code: null,
+              marque: null,
+              modele: null,
+              numero_serie: null,
+              criticite: "NORMAL",
+              etat: "QUALIFIED",
+              etat_motif: null,
+              etat_changed_at: null,
+              statut: "ACTIF",
+              proprietaire_service: null,
+              site: null,
+              magasin: null,
+              zone: null,
+              localisation_precise: null,
+              date_mise_en_service: null,
+              date_retrait: null,
+              unite: "mm",
+              plage_min: "0",
+              plage_max: "150",
+              resolution: "0.01",
+              mpe: null,
+              incertitude: null,
+              methodes: [],
+              conditions_utilisation: null,
+              restrictions: null,
+              etalon_reference: null,
+              exige_certificat: false,
+              specifications: {},
+              quarantine_reason: null,
+              quarantined_at: null,
+              last_conforme_at: null,
+              last_conforme_execution_id: null,
+              notes: null,
+              created_at: now,
+              updated_at: now,
+              responsable_id: null,
+              responsable_username: null,
+              responsable_name: null,
+              responsable_surname: null,
+              created_by_id: null,
+              created_by_username: null,
+              created_by_name: null,
+              created_by_surname: null,
+              updated_by_id: null,
+              updated_by_username: null,
+              updated_by_name: null,
+              updated_by_surname: null,
+            },
+          ],
+        });
+      }
+      if (sql.includes("FROM public.metrologie_certificats c")) {
+        return Promise.resolve({
+          rows: [
+            {
+              id: CHILD_ID,
+              equipement_id: EQUIP_ID,
+              execution_id: null,
+              document_kind: "CERTIFICAT",
+              date_etalonnage: "2026-01-15",
+              date_echeance: "2027-01-15",
+              resultat: "CONFORME",
+              statut: "VALIDE",
+              emetteur: "LNE",
+              numero_externe: "LNE-2026-1",
+              organisme: null,
+              commentaire: null,
+              confidentiality: "RESTRICTED",
+              cancel_reason: null,
+              cancelled_at: null,
+              replaced_by_id: null,
+              file_original_name: "certificat.pdf",
+              mime_type: "application/pdf",
+              size_bytes: "12345",
+              sha256: "f".repeat(64),
+              has_file: true,
+              created_at: now,
+              created_by_id: null,
+              created_by_username: null,
+              created_by_name: null,
+              created_by_surname: null,
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+
+    const res = await request(app).get(`${BASE}/equipements/${EQUIP_ID}`);
+    expect(res.status).toBe(200);
+    const serialized = JSON.stringify(res.body);
+    expect(serialized).not.toContain("storage_path");
+    expect(serialized).not.toContain("/srv/");
+    expect(res.body.certificats[0]).toMatchObject({ has_file: true, sha256: "f".repeat(64) });
+    // Les capacités sont renvoyées par le serveur : l'UI n'invente aucun droit.
+    expect(res.body.capabilities).toMatchObject({ read: true, equipment_release: true });
+  });
+});

--- a/src/module/metrologie/controllers/metrology-360.controller.ts
+++ b/src/module/metrologie/controllers/metrology-360.controller.ts
@@ -1,0 +1,564 @@
+// Contrôleurs Métrologie 360 (#229).
+//
+// Chaque handler : valide (Zod strict) → construit le contexte d'acteur →
+// délègue au service. Aucune règle métier ici, aucun `storage_path` renvoyé,
+// aucune décision prise côté client.
+
+import type { Request, RequestHandler } from "express";
+import fs from "node:fs/promises";
+import { ZodError, type ZodTypeAny, type z } from "zod";
+
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage";
+import { HttpError } from "../../../utils/httpError";
+import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import { emitEntityChanged } from "../../../shared/realtime/realtime.service";
+
+import type { MetrologyActor } from "../repository/metrology-shared.repository";
+import {
+  cancelCertificateSchema,
+  cancelExecutionSchema,
+  centerQuerySchema,
+  createEquipmentSchema,
+  createExecutionSchema,
+  createImpactSchema,
+  createPlanSchema,
+  decideImpactItemSchema,
+  eligibilityQuerySchema,
+  equipmentTransitionSchema,
+  idParamSchema,
+  listCategoriesQuerySchema,
+  listEquipmentQuerySchema,
+  listExecutionsQuerySchema,
+  listImpactItemsQuerySchema,
+  listImpactsQuerySchema,
+  nestedIdParamSchema,
+  planTransitionSchema,
+  quarantineSchema,
+  recordMeasurementsSchema,
+  revisePlanSchema,
+  schedulePreviewQuerySchema,
+  timelineQuerySchema,
+  transitionImpactSchema,
+  updateEquipmentSchema,
+  uploadCertificateSchema,
+  upsertCategorySchema,
+  usageQuerySchema,
+  validateExecutionSchema,
+} from "../validators/metrology-360.validators";
+import {
+  svcCancelCertificate,
+  svcCancelExecution,
+  svcCenter,
+  svcCreateEquipment,
+  svcCreateExecution,
+  svcCreateImpact,
+  svcCreatePlanVersion,
+  svcDecideImpactItem,
+  svcEvaluateEligibility,
+  svcGetCertificateFile,
+  svcGetEquipmentDetail,
+  svcGetExecution,
+  svcGetImpact,
+  svcInstrumentUsage,
+  svcListCategories,
+  svcListEquipment,
+  svcListExecutions,
+  svcListImpacts,
+  svcListUnits,
+  svcMetrologyDocsBaseDir,
+  svcPreviewVerdict,
+  svcQuarantineEquipment,
+  svcRecordMeasurements,
+  svcRevisePlanVersion,
+  svcSchedulePreview,
+  svcTimeline,
+  svcTransitionEquipment,
+  svcTransitionImpact,
+  svcTransitionPlanVersion,
+  svcUpdateEquipment,
+  svcUploadCertificate,
+  svcUpsertCategory,
+  svcValidateExecution,
+} from "../services/metrology-360.service";
+
+/**
+ * Parse strict avec mapping par champ : le frontend peut recoller chaque
+ * message sur son input (ADR-0016) au lieu d'afficher une erreur générique.
+ * Sans ce garde, une ZodError remonterait en 500 via le gestionnaire global.
+ */
+function parseOrThrow<S extends ZodTypeAny>(schema: S, payload: unknown): z.infer<S> {
+  const parsed = schema.safeParse(payload);
+  if (parsed.success) return parsed.data;
+  const error: ZodError = parsed.error;
+  const fieldErrors: Record<string, string[]> = {};
+  for (const issue of error.issues) {
+    const path =
+      issue.path.filter((segment) => segment !== "body" && segment !== "params").join(".") || "_";
+    (fieldErrors[path] ??= []).push(issue.message);
+  }
+  throw new HttpError(422, "METROLOGY_VALIDATION_ERROR", "Champs invalides.", { fields: fieldErrors });
+}
+
+function buildActor(req: Request): MetrologyActor {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  const userAgent = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null;
+  const device = parseDevice(userAgent);
+  return {
+    user_id: user.id,
+    role: typeof user.role === "string" ? user.role : null,
+    ip: getClientIp(req),
+    user_agent: userAgent,
+    device_type: device.device_type,
+    os: device.os,
+    browser: device.browser,
+    path: req.originalUrl ?? null,
+    page_key: typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null,
+    client_session_id:
+      typeof req.headers["x-client-session-id"] === "string"
+        ? req.headers["x-client-session-id"]
+        : typeof req.headers["x-session-id"] === "string"
+          ? req.headers["x-session-id"]
+          : null,
+    request_id: typeof req.headers["x-request-id"] === "string" ? req.headers["x-request-id"] : null,
+  };
+}
+
+function idempotencyKey(req: Request): string | null {
+  const raw = req.headers["idempotency-key"];
+  return typeof raw === "string" ? raw : null;
+}
+
+function notFound(entity: string): never {
+  throw new HttpError(404, "NOT_FOUND", `${entity} introuvable.`);
+}
+
+function emitChanged(
+  req: Request,
+  params: { equipementId: string; action: "created" | "updated" | "deleted" | "status_changed" }
+) {
+  const user = req.user;
+  emitEntityChanged({
+    entityType: "METROLOGIE_EQUIPEMENT",
+    entityId: params.equipementId,
+    action: params.action,
+    module: "metrologie",
+    at: new Date().toISOString(),
+    by: {
+      id: typeof user?.id === "number" ? user.id : 0,
+      name: typeof user?.username === "string" ? user.username : "",
+    },
+    invalidateKeys: [
+      "metrologie:equipements",
+      "metrologie:kpis",
+      "metrologie:alerts",
+      "metrologie:center",
+      `metrologie:equipement:${params.equipementId}`,
+    ],
+  });
+}
+
+function firstFile(req: Request): Express.Multer.File | null {
+  const single = (req as Request & { file?: Express.Multer.File }).file;
+  if (single) return single;
+  const files = (req as Request & { files?: unknown }).files;
+  if (Array.isArray(files) && files.length > 0) return files[0] as Express.Multer.File;
+  return null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Référentiels                                                               */
+/* -------------------------------------------------------------------------- */
+
+export const listCategories: RequestHandler = asyncHandler(async (req, res) => {
+  const query = parseOrThrow(listCategoriesQuerySchema, req.query);
+  res.json(await svcListCategories(query));
+});
+
+export const upsertCategory: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { body } = parseOrThrow(upsertCategorySchema, { body: req.body });
+  const out = await svcUpsertCategory({ body, actor, idempotencyKey: idempotencyKey(req) });
+  res.status(200).json(out);
+});
+
+export const listUnits: RequestHandler = asyncHandler(async (_req, res) => {
+  res.json(svcListUnits());
+});
+
+/* -------------------------------------------------------------------------- */
+/* Command center et éligibilité                                              */
+/* -------------------------------------------------------------------------- */
+
+export const center: RequestHandler = asyncHandler(async (req, res) => {
+  const query = parseOrThrow(centerQuerySchema, req.query);
+  res.json(
+    await svcCenter({
+      site: query.site ?? null,
+      categorieCode: query.categorie_code ?? null,
+      horizonDays: query.horizon_days,
+    })
+  );
+});
+
+export const evaluateEligibility: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const query = parseOrThrow(eligibilityQuerySchema, req.query);
+  res.json(await svcEvaluateEligibility({ query, actor }));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Équipements                                                                */
+/* -------------------------------------------------------------------------- */
+
+export const listEquipment: RequestHandler = asyncHandler(async (req, res) => {
+  const query = parseOrThrow(listEquipmentQuerySchema, req.query);
+  res.json(await svcListEquipment(query));
+});
+
+export const getEquipment: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  const out = await svcGetEquipmentDetail({ id: params.id, actor });
+  if (!out) notFound("Équipement");
+  res.json(out);
+});
+
+export const createEquipment: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { body } = parseOrThrow(createEquipmentSchema, { body: req.body });
+  const out = await svcCreateEquipment({ body, actor, idempotencyKey: idempotencyKey(req) });
+  emitChanged(req, { equipementId: out.equipement.id, action: "created" });
+  res.status(201).json(out);
+});
+
+export const updateEquipment: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(
+    updateEquipmentSchema.extend(idParamSchema.shape),
+    { params: req.params, body: req.body }
+  );
+  const out = await svcUpdateEquipment({ id: params.id, body, actor });
+  emitChanged(req, { equipementId: params.id, action: "updated" });
+  res.json(out);
+});
+
+export const transitionEquipment: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(
+    equipmentTransitionSchema.extend(idParamSchema.shape),
+    { params: req.params, body: req.body }
+  );
+  const out = await svcTransitionEquipment({
+    id: params.id,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  emitChanged(req, { equipementId: params.id, action: "status_changed" });
+  res.json(out);
+});
+
+export const quarantineEquipment: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(quarantineSchema.extend(idParamSchema.shape), {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcQuarantineEquipment({
+    id: params.id,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  emitChanged(req, { equipementId: params.id, action: "status_changed" });
+  res.json(out);
+});
+
+export const equipmentTimeline: RequestHandler = asyncHandler(async (req, res) => {
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  const query = parseOrThrow(timelineQuerySchema, req.query);
+  res.json(await svcTimeline({ equipementId: params.id, query }));
+});
+
+export const equipmentUsage: RequestHandler = asyncHandler(async (req, res) => {
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  const query = parseOrThrow(usageQuerySchema, req.query);
+  res.json(await svcInstrumentUsage({ equipementId: params.id, query }));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Plans                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const createPlan: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(createPlanSchema, {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcCreatePlanVersion({
+    equipementId: params.id,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  res.status(201).json(out);
+});
+
+export const revisePlan: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(revisePlanSchema, {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcRevisePlanVersion({
+    equipementId: params.id,
+    planId: params.childId,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  res.json(out);
+});
+
+export const transitionPlan: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(planTransitionSchema, {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcTransitionPlanVersion({
+    equipementId: params.id,
+    planId: params.childId,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  emitChanged(req, { equipementId: params.id, action: "status_changed" });
+  res.json(out);
+});
+
+export const schedulePreview: RequestHandler = asyncHandler(async (req, res) => {
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  const query = parseOrThrow(schedulePreviewQuerySchema, req.query);
+  res.json(await svcSchedulePreview({ equipementId: params.id, query }));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Exécutions                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export const listExecutions: RequestHandler = asyncHandler(async (req, res) => {
+  const query = parseOrThrow(listExecutionsQuerySchema, req.query);
+  res.json(await svcListExecutions(query));
+});
+
+export const getExecution: RequestHandler = asyncHandler(async (req, res) => {
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  const out = await svcGetExecution(params.id);
+  if (!out) notFound("Exécution");
+  res.json(out);
+});
+
+export const createExecution: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(createExecutionSchema, {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcCreateExecution({
+    equipementId: params.id,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  emitChanged(req, { equipementId: params.id, action: "updated" });
+  res.status(201).json(out);
+});
+
+export const recordMeasurements: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(recordMeasurementsSchema, {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcRecordMeasurements({
+    executionId: params.id,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  res.json(out);
+});
+
+export const previewVerdict: RequestHandler = asyncHandler(async (req, res) => {
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  res.json(await svcPreviewVerdict(params.id));
+});
+
+export const validateExecution: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(validateExecutionSchema, {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcValidateExecution({
+    executionId: params.id,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  emitChanged(req, { equipementId: out.execution.equipement_id, action: "status_changed" });
+  res.json(out);
+});
+
+export const cancelExecution: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(cancelExecutionSchema, {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcCancelExecution({
+    executionId: params.id,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  res.json(out);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Certificats                                                                */
+/* -------------------------------------------------------------------------- */
+
+export const uploadCertificate: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(uploadCertificateSchema, {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcUploadCertificate({
+    equipementId: params.id,
+    body,
+    file: firstFile(req),
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  emitChanged(req, { equipementId: params.id, action: "updated" });
+  res.status(201).json(out);
+});
+
+export const cancelCertificate: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(cancelCertificateSchema, {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcCancelCertificate({
+    equipementId: params.id,
+    certificateId: params.childId,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  emitChanged(req, { equipementId: params.id, action: "updated" });
+  res.json(out);
+});
+
+export const downloadCertificate: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params } = parseOrThrow(nestedIdParamSchema, { params: req.params });
+  const doc = await svcGetCertificateFile({
+    equipementId: params.id,
+    certificateId: params.childId,
+    actor,
+  });
+
+  const baseDir = svcMetrologyDocsBaseDir();
+  const absPath = resolveCerpStoragePath(doc.storage_path, baseDir);
+  // Défense en profondeur : même si un chemin corrompu franchissait la base, il
+  // ne peut pas sortir du répertoire privé des documents.
+  if (!isPathInsideDirectory(baseDir, absPath)) {
+    throw new HttpError(400, "INVALID_STORAGE_PATH", "Chemin de document invalide.");
+  }
+  await fs.access(absPath);
+
+  res.setHeader("Content-Type", doc.mime_type ?? "application/octet-stream");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Cache-Control", "private, no-store");
+  const download = req.query.download === "true" || req.query.download === "1";
+  const name = doc.file_original_name ?? `certificat-${params.childId}`;
+  res.setHeader(
+    "Content-Disposition",
+    `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(name)}"`
+  );
+  res.sendFile(absPath);
+});
+
+/* -------------------------------------------------------------------------- */
+/* Analyse d'impact                                                           */
+/* -------------------------------------------------------------------------- */
+
+export const listImpacts: RequestHandler = asyncHandler(async (req, res) => {
+  const query = parseOrThrow(listImpactsQuerySchema, req.query);
+  res.json(await svcListImpacts(query));
+});
+
+export const getImpact: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  const itemsQuery = parseOrThrow(listImpactItemsQuerySchema, req.query);
+  const out = await svcGetImpact({ id: params.id, actor, itemsQuery });
+  if (!out) notFound("Dossier d'impact");
+  res.json(out);
+});
+
+export const createImpact: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(createImpactSchema, {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcCreateImpact({
+    equipementId: params.id,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  res.status(201).json(out);
+});
+
+export const decideImpactItem: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(decideImpactItemSchema, {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcDecideImpactItem({
+    dossierId: params.id,
+    itemId: params.childId,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  res.json(out);
+});
+
+export const transitionImpact: RequestHandler = asyncHandler(async (req, res) => {
+  const actor = buildActor(req);
+  const { params, body } = parseOrThrow(transitionImpactSchema, {
+    params: req.params,
+    body: req.body,
+  });
+  const out = await svcTransitionImpact({
+    id: params.id,
+    body,
+    actor,
+    idempotencyKey: idempotencyKey(req),
+  });
+  res.json(out);
+});

--- a/src/module/metrologie/domain/metrology-eligibility.ts
+++ b/src/module/metrologie/domain/metrology-eligibility.ts
@@ -1,0 +1,568 @@
+// Éligibilité d'emploi d'un instrument (#229) — décision pure, sans I/O.
+//
+// SEUL LE SERVEUR décide qu'un instrument peut servir à une mesure. Le
+// frontend affiche l'explication produite ici ; il ne rejoue jamais la règle et
+// ne peut pas la contourner en masquant un message.
+//
+// L'évaluation produit une LISTE de raisons explicables (et pas un simple
+// booléen) parce qu'un opérateur d'atelier doit comprendre pourquoi son pied à
+// coulisse est refusé, sans appeler la métrologie.
+
+import {
+  convertValue,
+  resolveUnit,
+  sameDimension,
+} from "./metrology-units";
+import type { MetrologyEquipmentState } from "./metrology-policy";
+import { equipmentStateBlocksUsage } from "./metrology-policy";
+import { evaluateDue, type DueEvaluation } from "./metrology-schedule";
+
+/* -------------------------------------------------------------------------- */
+/* 1) Entrées                                                                 */
+/* -------------------------------------------------------------------------- */
+
+/** Photographie serveur d'un instrument, telle que chargée en base. */
+export type MetrologyInstrumentState = {
+  id: string;
+  code: string | null;
+  designation: string | null;
+  categorie_code: string | null;
+  sous_categorie_code: string | null;
+  /** Champ texte historique, conservé pour les instruments non recatégorisés. */
+  categorie_legacy: string | null;
+  etat: MetrologyEquipmentState;
+  criticite: "NORMAL" | "CRITIQUE" | string | null;
+  deleted: boolean;
+
+  unite: string | null;
+  plage_min: number | null;
+  plage_max: number | null;
+  resolution: number | null;
+  mpe: number | null;
+  incertitude: number | null;
+  methodes: readonly string[];
+  restrictions: string | null;
+  exige_certificat: boolean;
+
+  /** Plan actif applicable au type d'opération qui fait foi pour l'échéance. */
+  plan_version_id: string | null;
+  plan_version: number | null;
+  plan_blocking_strategy: "BLOCK" | "WARN" | "NONE" | null;
+  plan_alert_window_days: number | null;
+  next_due_date: string | null;
+
+  /** Dernière preuve admissible et sa pièce justificative. */
+  last_proof_execution_id: string | null;
+  last_proof_date: string | null;
+  last_proof_verdict: string | null;
+  has_valid_certificate: boolean;
+  certificate_id: string | null;
+};
+
+/** Ce que la caractéristique qualité exige de l'instrument. */
+export type MetrologyUsageRequirement = {
+  characteristic_key: string;
+  requires_instrument: boolean;
+  /** Catégorie attendue : code référentiel #229 ou libellé historique #228. */
+  instrument_category: string | null;
+  method: string | null;
+  unit: string | null;
+  nominal: number | null;
+  tolerance_min: number | null;
+  tolerance_max: number | null;
+  /** Preuve documentaire exigée par le plan de contrôle. */
+  requires_certificate: boolean;
+};
+
+export type MetrologyPolicySettings = {
+  /**
+   * Réglage historique `metrologie.block_on_overdue_critical`. Portée
+   * PER_INSTRUMENT : il ne bloque QUE l'instrument critique réellement échu et
+   * réellement utilisé. Il n'a jamais valeur de verrou global d'usine.
+   */
+  block_on_overdue_critical: boolean;
+};
+
+export type MetrologyActorRights = {
+  canRecordMeasurement: boolean;
+};
+
+/* -------------------------------------------------------------------------- */
+/* 2) Sorties                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export const METROLOGY_ELIGIBILITY_CODES = [
+  "OK",
+  "INSTRUMENT_REQUIRED",
+  "INSTRUMENT_UNKNOWN",
+  "INSTRUMENT_DELETED",
+  "INSTRUMENT_RETIRED",
+  "INSTRUMENT_QUARANTINE",
+  "INSTRUMENT_OUT_OF_TOLERANCE",
+  "INSTRUMENT_UNDER_REPAIR",
+  "INSTRUMENT_NOT_QUALIFIED",
+  "INSTRUMENT_OUT_OF_SCOPE",
+  "INSTRUMENT_METHOD_MISMATCH",
+  "INSTRUMENT_UNIT_MISMATCH",
+  "INSTRUMENT_UNIT_UNKNOWN",
+  "INSTRUMENT_RANGE_MISMATCH",
+  "INSTRUMENT_RESOLUTION_INSUFFICIENT",
+  "INSTRUMENT_UNCERTAINTY_EXCESSIVE",
+  "INSTRUMENT_CERTIFICATE_MISSING",
+  "INSTRUMENT_OVERDUE_CRITICAL",
+  "INSTRUMENT_OVERDUE",
+  "INSTRUMENT_DUE_SOON",
+  "INSTRUMENT_RESTRICTED",
+  "OPERATOR_NOT_ALLOWED",
+] as const;
+export type MetrologyEligibilityCode = (typeof METROLOGY_ELIGIBILITY_CODES)[number];
+
+export type EligibilitySeverity = "OK" | "WARNING" | "BLOCKING";
+
+export type EligibilityReason = {
+  code: MetrologyEligibilityCode;
+  severity: EligibilitySeverity;
+  message: string;
+  /** Détail chiffré affichable tel quel (aucune donnée sensible). */
+  details?: Record<string, unknown>;
+};
+
+export type MetrologyEligibility = {
+  eligible: boolean;
+  severity: EligibilitySeverity;
+  code: MetrologyEligibilityCode;
+  message: string;
+  reasons: EligibilityReason[];
+  due: DueEvaluation;
+};
+
+/* -------------------------------------------------------------------------- */
+/* 3) Moteur                                                                  */
+/* -------------------------------------------------------------------------- */
+
+const STATE_BLOCKING_CODES: Partial<Record<MetrologyEquipmentState, MetrologyEligibilityCode>> = {
+  QUARANTINE: "INSTRUMENT_QUARANTINE",
+  OUT_OF_TOLERANCE: "INSTRUMENT_OUT_OF_TOLERANCE",
+  UNDER_REPAIR: "INSTRUMENT_UNDER_REPAIR",
+  RETIRED: "INSTRUMENT_RETIRED",
+  DRAFT: "INSTRUMENT_NOT_QUALIFIED",
+  SUSPENDED: "INSTRUMENT_NOT_QUALIFIED",
+};
+
+const STATE_MESSAGES: Partial<Record<MetrologyEquipmentState, string>> = {
+  QUARANTINE: "Instrument en quarantaine : usage interdit tant qu'il n'est pas libéré.",
+  OUT_OF_TOLERANCE: "Instrument hors tolérance : usage interdit tant qu'il n'est pas libéré.",
+  UNDER_REPAIR: "Instrument en réparation ou ajustage : requalification requise avant emploi.",
+  RETIRED: "Instrument retiré du parc.",
+  DRAFT: "Instrument non qualifié : sa fiche n'est pas encore validée.",
+  SUSPENDED: "Instrument suspendu : il n'est pas disponible pour la mesure.",
+};
+
+export function evaluateInstrumentEligibility(params: {
+  requirement: MetrologyUsageRequirement;
+  instrument: MetrologyInstrumentState | null;
+  at: Date;
+  policy: MetrologyPolicySettings;
+  rights?: MetrologyActorRights;
+}): MetrologyEligibility {
+  const { requirement, instrument, at, policy } = params;
+  const reasons: EligibilityReason[] = [];
+
+  const emptyDue: DueEvaluation = {
+    status: "UNKNOWN",
+    next_due_date: null,
+    days_remaining: null,
+    days_overdue: 0,
+  };
+
+  if (!requirement.requires_instrument) {
+    return ok("Aucun moyen de contrôle requis pour cette caractéristique.", emptyDue);
+  }
+
+  if (params.rights && !params.rights.canRecordMeasurement) {
+    reasons.push({
+      code: "OPERATOR_NOT_ALLOWED",
+      severity: "BLOCKING",
+      message: "Vous n'avez pas le droit d'enregistrer une mesure avec un instrument.",
+    });
+    return decide(reasons, emptyDue);
+  }
+
+  if (!instrument) {
+    reasons.push({
+      code: "INSTRUMENT_REQUIRED",
+      severity: "BLOCKING",
+      message: `La caractéristique ${requirement.characteristic_key} exige l'instrument réellement utilisé.`,
+    });
+    return decide(reasons, emptyDue);
+  }
+
+  if (instrument.deleted) {
+    reasons.push({
+      code: "INSTRUMENT_DELETED",
+      severity: "BLOCKING",
+      message: "Instrument retiré du registre de métrologie.",
+    });
+    return decide(reasons, emptyDue);
+  }
+
+  // 1) État de gouvernance : il prime sur tout le reste.
+  const stateCode = STATE_BLOCKING_CODES[instrument.etat];
+  if (stateCode && equipmentStateBlocksUsage(instrument.etat)) {
+    reasons.push({
+      code: stateCode,
+      severity: "BLOCKING",
+      message: STATE_MESSAGES[instrument.etat] ?? `Instrument indisponible (${instrument.etat}).`,
+      details: { etat: instrument.etat },
+    });
+  }
+
+  // 2) Périmètre : catégorie référentielle #229, ou libellé historique #228.
+  if (requirement.instrument_category) {
+    const expected = requirement.instrument_category.trim().toLowerCase();
+    const candidates = [
+      instrument.categorie_code,
+      instrument.sous_categorie_code,
+      instrument.categorie_legacy,
+    ]
+      .filter((value): value is string => Boolean(value))
+      .map((value) => value.trim().toLowerCase());
+    if (!candidates.includes(expected)) {
+      reasons.push({
+        code: "INSTRUMENT_OUT_OF_SCOPE",
+        severity: "BLOCKING",
+        message: `Instrument hors périmètre : catégorie « ${requirement.instrument_category} » attendue.`,
+        details: { expected: requirement.instrument_category, actual: candidates },
+      });
+    }
+  }
+
+  // 3) Méthode déclarée. Un instrument sans méthode déclarée reste utilisable :
+  //    on n'invente pas une exigence là où le référentiel est muet.
+  if (requirement.method && instrument.methodes.length > 0) {
+    const expected = requirement.method.trim().toLowerCase();
+    const supported = instrument.methodes.map((value) => value.trim().toLowerCase());
+    if (!supported.includes(expected)) {
+      reasons.push({
+        code: "INSTRUMENT_METHOD_MISMATCH",
+        severity: "BLOCKING",
+        message: `Méthode « ${requirement.method} » non déclarée pour cet instrument.`,
+        details: { expected: requirement.method, supported: instrument.methodes },
+      });
+    }
+  }
+
+  // 4) Unité et plage.
+  evaluateRange(requirement, instrument, reasons);
+
+  // 5) Résolution et incertitude face à l'intervalle de tolérance.
+  evaluateCapability(requirement, instrument, reasons);
+
+  // 6) Preuve documentaire exigée.
+  if ((requirement.requires_certificate || instrument.exige_certificat) && !instrument.has_valid_certificate) {
+    reasons.push({
+      code: "INSTRUMENT_CERTIFICATE_MISSING",
+      severity: "BLOCKING",
+      message: "Aucun certificat ou PV valide n'est rattaché à la dernière preuve conforme.",
+    });
+  }
+
+  // 7) Échéance : blocage CIBLÉ, piloté par la stratégie du plan applicable et
+  //    par le réglage historique pour les instruments critiques.
+  const due = evaluateDue({
+    nextDueDate: instrument.next_due_date,
+    alertWindowDays: instrument.plan_alert_window_days ?? 30,
+    at,
+  });
+  evaluateSchedule(instrument, due, policy, reasons);
+
+  // 8) Restriction documentée : jamais bloquante, toujours affichée.
+  if (instrument.restrictions && instrument.restrictions.trim()) {
+    reasons.push({
+      code: "INSTRUMENT_RESTRICTED",
+      severity: "WARNING",
+      message: `Restriction d'emploi : ${instrument.restrictions.trim()}`,
+    });
+  }
+
+  return decide(reasons, due);
+}
+
+function evaluateRange(
+  requirement: MetrologyUsageRequirement,
+  instrument: MetrologyInstrumentState,
+  reasons: EligibilityReason[]
+): void {
+  const targets = [requirement.nominal, requirement.tolerance_min, requirement.tolerance_max].filter(
+    (value): value is number => typeof value === "number" && Number.isFinite(value)
+  );
+  if (targets.length === 0) return;
+  if (instrument.plage_min === null && instrument.plage_max === null) return;
+
+  const requirementUnit = requirement.unit;
+  const instrumentUnit = instrument.unite;
+
+  if (!requirementUnit || !instrumentUnit) {
+    // Sans unité des deux côtés on ne compare pas des nombres nus : on le dit.
+    reasons.push({
+      code: "INSTRUMENT_UNIT_UNKNOWN",
+      severity: "WARNING",
+      message: "Unité manquante : la compatibilité de plage n'a pas pu être vérifiée.",
+      details: { requirement_unit: requirementUnit, instrument_unit: instrumentUnit },
+    });
+    return;
+  }
+
+  if (!resolveUnit(requirementUnit) || !resolveUnit(instrumentUnit)) {
+    reasons.push({
+      code: "INSTRUMENT_UNIT_UNKNOWN",
+      severity: "WARNING",
+      message: `Unité non reconnue (${requirementUnit} / ${instrumentUnit}) : plage non vérifiée.`,
+      details: { requirement_unit: requirementUnit, instrument_unit: instrumentUnit },
+    });
+    return;
+  }
+
+  if (!sameDimension(requirementUnit, instrumentUnit)) {
+    reasons.push({
+      code: "INSTRUMENT_UNIT_MISMATCH",
+      severity: "BLOCKING",
+      message: `Unités incompatibles : la caractéristique est en ${requirementUnit}, l'instrument en ${instrumentUnit}.`,
+      details: { requirement_unit: requirementUnit, instrument_unit: instrumentUnit },
+    });
+    return;
+  }
+
+  const converted = targets
+    .map((value) => convertValue(value, requirementUnit, instrumentUnit))
+    .filter((result): result is { ok: true; value: number } => result.ok)
+    .map((result) => result.value);
+  if (converted.length === 0) return;
+
+  const min = instrument.plage_min;
+  const max = instrument.plage_max;
+  const outside = converted.filter(
+    (value) => (min !== null && value < min) || (max !== null && value > max)
+  );
+  if (outside.length > 0) {
+    reasons.push({
+      code: "INSTRUMENT_RANGE_MISMATCH",
+      severity: "BLOCKING",
+      message: `Valeur hors plage de l'instrument (${min ?? "-∞"} – ${max ?? "+∞"} ${instrumentUnit}).`,
+      details: {
+        instrument_unit: instrumentUnit,
+        plage_min: min,
+        plage_max: max,
+        out_of_range: outside,
+      },
+    });
+  }
+}
+
+/**
+ * Aptitude de l'instrument à l'intervalle de tolérance demandé.
+ *
+ * Règle usuelle d'atelier : la résolution doit valoir au plus 1/10 de
+ * l'intervalle de tolérance, et l'incertitude élargie au plus 1/3. Le
+ * dépassement est signalé, mais reste un AVERTISSEMENT — c'est un critère
+ * d'aptitude, pas une interdiction réglementaire.
+ */
+function evaluateCapability(
+  requirement: MetrologyUsageRequirement,
+  instrument: MetrologyInstrumentState,
+  reasons: EligibilityReason[]
+): void {
+  const { tolerance_min: lo, tolerance_max: hi, unit } = requirement;
+  if (lo === null || hi === null || !unit || !instrument.unite) return;
+  if (!sameDimension(unit, instrument.unite)) return;
+
+  const span = Math.abs(hi - lo);
+  if (!Number.isFinite(span) || span <= 0) return;
+
+  const spanInInstrumentUnit = convertValue(span, unit, instrument.unite);
+  if (!spanInInstrumentUnit.ok || spanInInstrumentUnit.value <= 0) return;
+  const tolerance = spanInInstrumentUnit.value;
+
+  if (instrument.resolution !== null && instrument.resolution > tolerance / 10) {
+    reasons.push({
+      code: "INSTRUMENT_RESOLUTION_INSUFFICIENT",
+      severity: "WARNING",
+      message: `Résolution ${instrument.resolution} ${instrument.unite} pour un IT de ${round(tolerance)} ${instrument.unite} : aptitude dégradée (règle 1/10).`,
+      details: { resolution: instrument.resolution, tolerance_span: round(tolerance) },
+    });
+  }
+
+  const uncertainty = instrument.incertitude ?? instrument.mpe;
+  if (uncertainty !== null && uncertainty > tolerance / 3) {
+    reasons.push({
+      code: "INSTRUMENT_UNCERTAINTY_EXCESSIVE",
+      severity: "WARNING",
+      message: `Incertitude ${uncertainty} ${instrument.unite} pour un IT de ${round(tolerance)} ${instrument.unite} : aptitude dégradée (règle 1/3).`,
+      details: { uncertainty, tolerance_span: round(tolerance) },
+    });
+  }
+}
+
+function evaluateSchedule(
+  instrument: MetrologyInstrumentState,
+  due: DueEvaluation,
+  policy: MetrologyPolicySettings,
+  reasons: EligibilityReason[]
+): void {
+  if (due.status === "DUE_SOON") {
+    reasons.push({
+      code: "INSTRUMENT_DUE_SOON",
+      severity: "WARNING",
+      message: `Échéance proche (${due.next_due_date}, dans ${due.days_remaining} j).`,
+      details: { next_due_date: due.next_due_date, days_remaining: due.days_remaining },
+    });
+    return;
+  }
+  if (due.status !== "OVERDUE") return;
+
+  const critical = String(instrument.criticite ?? "").toUpperCase() === "CRITIQUE";
+  const strategy = instrument.plan_blocking_strategy ?? "WARN";
+
+  // Le blocage est ciblé : il vient de la stratégie du plan applicable, ou du
+  // réglage historique restreint aux instruments critiques échus.
+  const blocking = strategy === "BLOCK" || (critical && policy.block_on_overdue_critical);
+  if (strategy === "NONE" && !(critical && policy.block_on_overdue_critical)) {
+    reasons.push({
+      code: "INSTRUMENT_OVERDUE",
+      severity: "WARNING",
+      message: `Étalonnage dépassé depuis ${due.days_overdue} j (échéance ${due.next_due_date}) : traçabilité dégradée.`,
+      details: { next_due_date: due.next_due_date, days_overdue: due.days_overdue },
+    });
+    return;
+  }
+
+  reasons.push({
+    code: critical ? "INSTRUMENT_OVERDUE_CRITICAL" : "INSTRUMENT_OVERDUE",
+    severity: blocking ? "BLOCKING" : "WARNING",
+    message: blocking
+      ? `Instrument ${critical ? "critique " : ""}en retard d'étalonnage (échéance ${due.next_due_date}, ${due.days_overdue} j) : usage bloqué.`
+      : `Étalonnage dépassé depuis ${due.days_overdue} j (échéance ${due.next_due_date}) : traçabilité dégradée.`,
+    details: {
+      next_due_date: due.next_due_date,
+      days_overdue: due.days_overdue,
+      criticite: instrument.criticite,
+      blocking_strategy: strategy,
+      setting_applied: critical && policy.block_on_overdue_critical,
+    },
+  });
+}
+
+function round(value: number): number {
+  return Math.round(value * 1e6) / 1e6;
+}
+
+function ok(message: string, due: DueEvaluation): MetrologyEligibility {
+  return { eligible: true, severity: "OK", code: "OK", message, reasons: [], due };
+}
+
+function decide(reasons: EligibilityReason[], due: DueEvaluation): MetrologyEligibility {
+  const blocking = reasons.find((reason) => reason.severity === "BLOCKING");
+  if (blocking) {
+    return {
+      eligible: false,
+      severity: "BLOCKING",
+      code: blocking.code,
+      message: blocking.message,
+      reasons,
+      due,
+    };
+  }
+  const warning = reasons.find((reason) => reason.severity === "WARNING");
+  if (warning) {
+    return {
+      eligible: true,
+      severity: "WARNING",
+      code: warning.code,
+      message: warning.message,
+      reasons,
+      due,
+    };
+  }
+  return { eligible: true, severity: "OK", code: "OK", message: "Instrument valide.", reasons, due };
+}
+
+/* -------------------------------------------------------------------------- */
+/* 4) Snapshot immuable                                                       */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Photographie figée écrite dans le résultat qualité. Elle protège l'historique :
+ * une modification ultérieure du registre, du plan ou du certificat ne réécrit
+ * PAS le contrôle déjà exécuté.
+ *
+ * Elle ne contient jamais de `storage_path`, de chemin local, de jeton ni de
+ * donnée personnelle : uniquement des identifiants et des valeurs métier.
+ */
+export type MetrologyInstrumentSnapshot = {
+  snapshot_version: 2;
+  instrument_id: string;
+  code: string | null;
+  designation: string | null;
+  categorie_code: string | null;
+  etat: MetrologyEquipmentState;
+  criticite: string | null;
+  eligibility_code: MetrologyEligibilityCode;
+  eligibility_severity: EligibilitySeverity;
+  eligible: boolean;
+  plan_version_id: string | null;
+  plan_version: number | null;
+  next_due_date: string | null;
+  days_overdue: number;
+  last_proof_execution_id: string | null;
+  last_proof_date: string | null;
+  last_proof_verdict: string | null;
+  certificate_id: string | null;
+  unite: string | null;
+  plage_min: number | null;
+  plage_max: number | null;
+  resolution: number | null;
+  mpe: number | null;
+  incertitude: number | null;
+  used_at: string;
+  reasons: Array<Pick<EligibilityReason, "code" | "severity" | "message">>;
+};
+
+export function buildInstrumentSnapshot(params: {
+  instrument: MetrologyInstrumentState;
+  eligibility: MetrologyEligibility;
+  at: Date;
+}): MetrologyInstrumentSnapshot {
+  const { instrument, eligibility, at } = params;
+  return {
+    snapshot_version: 2,
+    instrument_id: instrument.id,
+    code: instrument.code,
+    designation: instrument.designation,
+    categorie_code: instrument.categorie_code ?? instrument.categorie_legacy,
+    etat: instrument.etat,
+    criticite: instrument.criticite === null ? null : String(instrument.criticite),
+    eligibility_code: eligibility.code,
+    eligibility_severity: eligibility.severity,
+    eligible: eligibility.eligible,
+    plan_version_id: instrument.plan_version_id,
+    plan_version: instrument.plan_version,
+    next_due_date: instrument.next_due_date,
+    days_overdue: eligibility.due.days_overdue,
+    last_proof_execution_id: instrument.last_proof_execution_id,
+    last_proof_date: instrument.last_proof_date,
+    last_proof_verdict: instrument.last_proof_verdict,
+    certificate_id: instrument.certificate_id,
+    unite: instrument.unite,
+    plage_min: instrument.plage_min,
+    plage_max: instrument.plage_max,
+    resolution: instrument.resolution,
+    mpe: instrument.mpe,
+    incertitude: instrument.incertitude,
+    used_at: at.toISOString(),
+    reasons: eligibility.reasons.map((reason) => ({
+      code: reason.code,
+      severity: reason.severity,
+      message: reason.message,
+    })),
+  };
+}

--- a/src/module/metrologie/domain/metrology-impact.ts
+++ b/src/module/metrologie/domain/metrology-impact.ts
@@ -1,0 +1,165 @@
+// Analyse d'impact métrologique (#229) — bornage pur, sans I/O.
+//
+// Un instrument déclaré hors tolérance jette un doute sur les mesures qu'il a
+// produites DEPUIS la dernière preuve conforme admissible. Ce fichier calcule
+// cette fenêtre et rien d'autre.
+//
+// Ce que l'analyse N'EST PAS :
+//   * une présomption de non-conformité produit ;
+//   * une recherche non bornée dans tout l'historique ;
+//   * un déclencheur d'action automatique. Aucun contrôle n'est annulé, aucun
+//     lot déstocké, aucun BL annulé, aucun avoir créé, aucune expédition
+//     bloquée et aucun rappel client lancé par ce module.
+
+import { HttpError } from "../../../utils/httpError";
+
+export type ImpactTrigger = "VERDICT_NON_CONFORME" | "CERTIFICAT_INVALIDE" | "MANUEL";
+export type ImpactWindowSource = "LAST_CONFORME_PROOF" | "APPROVED_WINDOW" | "EQUIPMENT_CREATION";
+
+export type ImpactWindowInput = {
+  trigger: ImpactTrigger;
+  /** Fin de fenêtre : l'événement déclenchant (verdict, invalidation). */
+  eventAt: Date;
+  /** Dernière preuve conforme admissible connue. */
+  lastConformeProofAt: Date | null;
+  /** Repli : création de l'équipement, quand aucune preuve conforme n'existe. */
+  equipmentCreatedAt: Date;
+  /** Fenêtre explicitement approuvée par un humain (remplace le calcul). */
+  approvedFrom?: Date | null;
+  approvedTo?: Date | null;
+  approvedReason?: string | null;
+};
+
+export type ImpactWindow = {
+  from: Date;
+  to: Date;
+  source: ImpactWindowSource;
+  /** Explication affichable : l'analyse doit être auditable sans lire le code. */
+  method: string;
+  span_days: number;
+};
+
+/** Garde-fou : une fenêtre d'analyse reste bornée, jamais « tout l'historique ». */
+const MAX_WINDOW_DAYS = 1826; // 5 ans
+
+export function computeImpactWindow(input: ImpactWindowInput): ImpactWindow {
+  const to = input.eventAt;
+
+  if (input.approvedFrom && input.approvedTo) {
+    if (input.approvedTo < input.approvedFrom) {
+      throw new HttpError(
+        422,
+        "METROLOGY_IMPACT_WINDOW_INVALID",
+        "La fenêtre approuvée se termine avant de commencer."
+      );
+    }
+    if ((input.approvedReason ?? "").trim().length < 20) {
+      throw new HttpError(
+        422,
+        "METROLOGY_IMPACT_WINDOW_JUSTIFICATION_REQUIRED",
+        "Une fenêtre d'analyse imposée exige une justification d'au moins 20 caractères."
+      );
+    }
+    const span = spanDays(input.approvedFrom, input.approvedTo);
+    assertBounded(span);
+    return {
+      from: input.approvedFrom,
+      to: input.approvedTo,
+      source: "APPROVED_WINDOW",
+      method: `Fenêtre approuvée manuellement (${span} j) : ${(input.approvedReason ?? "").trim()}`,
+      span_days: span,
+    };
+  }
+
+  if (input.lastConformeProofAt && input.lastConformeProofAt <= to) {
+    const span = spanDays(input.lastConformeProofAt, to);
+    assertBounded(span);
+    return {
+      from: input.lastConformeProofAt,
+      to,
+      source: "LAST_CONFORME_PROOF",
+      method:
+        "Usages de l'instrument depuis la dernière preuve conforme admissible jusqu'à l'événement déclenchant.",
+      span_days: span,
+    };
+  }
+
+  // Aucune preuve conforme : le doute remonte à la mise en service. On borne
+  // quand même, et on le dit explicitement dans la méthode.
+  const from = input.equipmentCreatedAt <= to ? input.equipmentCreatedAt : to;
+  const span = spanDays(from, to);
+  assertBounded(span);
+  return {
+    from,
+    to,
+    source: "EQUIPMENT_CREATION",
+    method:
+      "Aucune preuve conforme antérieure : la fenêtre remonte à l'entrée de l'instrument au registre.",
+    span_days: span,
+  };
+}
+
+function spanDays(from: Date, to: Date): number {
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+  return Math.max(0, Math.ceil((to.getTime() - from.getTime()) / MS_PER_DAY));
+}
+
+function assertBounded(span: number): void {
+  if (span > MAX_WINDOW_DAYS) {
+    throw new HttpError(
+      422,
+      "METROLOGY_IMPACT_WINDOW_TOO_WIDE",
+      `La fenêtre d'analyse dépasse ${MAX_WINDOW_DAYS} jours : approuvez explicitement une fenêtre restreinte.`,
+      { span_days: span, max_days: MAX_WINDOW_DAYS }
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Priorité et volumétrie                                                     */
+/* -------------------------------------------------------------------------- */
+
+export type ImpactVolumes = {
+  controls: number;
+  work_orders: number;
+  lots: number;
+  deliveries: number;
+  /** Vrai quand la liste a été tronquée par la borne dure de pagination. */
+  truncated: boolean;
+};
+
+export type ImpactPriority = "LOW" | "NORMAL" | "HIGH" | "CRITICAL";
+
+/**
+ * Priorité proposée par le serveur. Elle oriente le travail humain ; elle ne
+ * décide de rien et n'est jamais un verdict produit.
+ */
+export function suggestImpactPriority(params: {
+  volumes: ImpactVolumes;
+  criticite: string | null;
+}): ImpactPriority {
+  const critical = String(params.criticite ?? "").toUpperCase() === "CRITIQUE";
+  // Une pièce déjà partie chez le client est ce qui coûte le plus cher à
+  // rattraper : la présence de BL pèse plus lourd que le volume brut.
+  if (params.volumes.deliveries > 0) return critical ? "CRITICAL" : "HIGH";
+  if (critical && params.volumes.controls > 0) return "HIGH";
+  if (params.volumes.controls === 0) return "LOW";
+  if (params.volumes.controls > 50 || params.volumes.lots > 10) return "HIGH";
+  return "NORMAL";
+}
+
+/* -------------------------------------------------------------------------- */
+/* Borne dure de collecte                                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Nombre maximum d'usages matérialisés dans un dossier. Au-delà, le dossier est
+ * marqué `truncated` et le volume réel est conservé : une troncature silencieuse
+ * se lirait comme « tout est couvert » alors que non.
+ */
+export const IMPACT_ITEM_HARD_LIMIT = 2000;
+
+export function describeTruncation(collected: number, total: number): string | null {
+  if (total <= collected) return null;
+  return `Dossier tronqué : ${collected} usages matérialisés sur ${total} identifiés. Restreignez la fenêtre ou traitez par lots.`;
+}

--- a/src/module/metrologie/domain/metrology-policy.ts
+++ b/src/module/metrologie/domain/metrology-policy.ts
@@ -1,0 +1,693 @@
+// Gouvernance Métrologie 360 (#229) — politiques pures, sans I/O.
+//
+// Ce fichier concentre les règles qui ne doivent jamais dépendre d'un appel
+// réseau, d'un client SQL ou du navigateur : capacités RBAC, cycles de vie,
+// séparation des tâches, idempotence et empreinte canonique.
+//
+// Compatibilité : les enums historiques du module Métrologie (patch
+// `20260227_metrologie_calibration.sql`) sont CONSERVÉS et étendus. `statut`
+// (ACTIF/INACTIF/REBUT) reste la vue héritée ; `etat` est l'état de gouvernance
+// introduit par #229 et tenu cohérent par trigger.
+
+import crypto from "node:crypto";
+
+import { HttpError } from "../../../utils/httpError";
+
+/* -------------------------------------------------------------------------- */
+/* 1) Capacités RBAC — refus par défaut                                       */
+/* -------------------------------------------------------------------------- */
+
+export const METROLOGY_CAPABILITIES = [
+  "read",
+  "categories_manage",
+  "equipment_write",
+  "plan_manage",
+  "execution_record",
+  "verdict_validate",
+  "documents_read",
+  "documents_write",
+  "quarantine_set",
+  "repair_manage",
+  "equipment_release",
+  "impact_read",
+  "impact_create",
+  "impact_decide",
+  "settings_manage",
+  "audit_read",
+] as const;
+
+export type MetrologyCapability = (typeof METROLOGY_CAPABILITIES)[number];
+
+// Les rôles CERP sont du texte libre en base : on garde la mécanique par
+// « needles » déjà utilisée par `quality-policy.ts`, `of-rbac.ts` et
+// `machine-rbac.ts` plutôt que d'inventer une table de rôles parallèle.
+//
+// Aucun rôle n'obtient de droit implicite : Qualité, Métrologie, Production,
+// Magasin, ADV et Finance n'apparaissent que là où le métier l'exige.
+const CAPABILITY_NEEDLES: Record<MetrologyCapability, readonly string[]> = {
+  // Lire le parc est nécessaire pour choisir un instrument en atelier.
+  read: [
+    "admin",
+    "administrateur",
+    "directeur",
+    "metrolog",
+    "métrolog",
+    "qualit",
+    "quality",
+    "qse",
+    "production",
+    "atelier",
+    "method",
+  ],
+  categories_manage: ["admin", "administrateur", "directeur", "metrolog", "métrolog", "qualit", "quality", "qse"],
+  equipment_write: ["admin", "administrateur", "directeur", "metrolog", "métrolog", "qualit", "quality", "qse", "method"],
+  plan_manage: ["admin", "administrateur", "directeur", "metrolog", "métrolog", "qualit", "quality", "qse"],
+  // L'atelier peut relever une vérification interne ; il ne la valide pas.
+  execution_record: [
+    "admin",
+    "administrateur",
+    "directeur",
+    "metrolog",
+    "métrolog",
+    "qualit",
+    "quality",
+    "qse",
+    "production",
+    "atelier",
+  ],
+  verdict_validate: ["admin", "administrateur", "directeur", "metrolog", "métrolog", "qualit", "quality", "qse"],
+  documents_read: [
+    "admin",
+    "administrateur",
+    "directeur",
+    "metrolog",
+    "métrolog",
+    "qualit",
+    "quality",
+    "qse",
+    "production",
+    "atelier",
+    "method",
+  ],
+  documents_write: ["admin", "administrateur", "directeur", "metrolog", "métrolog", "qualit", "quality", "qse"],
+  quarantine_set: [
+    "admin",
+    "administrateur",
+    "directeur",
+    "metrolog",
+    "métrolog",
+    "qualit",
+    "quality",
+    "qse",
+    "production",
+    "atelier",
+  ],
+  repair_manage: ["admin", "administrateur", "directeur", "metrolog", "métrolog", "qualit", "quality", "qse", "method"],
+  // Remettre un instrument en service est un acte de libération : jamais l'atelier.
+  equipment_release: ["admin", "administrateur", "directeur", "metrolog", "métrolog", "qualit", "quality", "qse"],
+  impact_read: ["admin", "administrateur", "directeur", "metrolog", "métrolog", "qualit", "quality", "qse", "method"],
+  impact_create: ["admin", "administrateur", "directeur", "metrolog", "métrolog", "qualit", "quality", "qse"],
+  impact_decide: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+  settings_manage: ["admin", "administrateur", "directeur"],
+  audit_read: ["admin", "administrateur", "directeur", "metrolog", "métrolog", "qualit", "quality", "qse"],
+};
+
+export function roleHasMetrologyCapability(
+  role: string | null | undefined,
+  capability: MetrologyCapability
+): boolean {
+  const normalized = (role ?? "").trim().toLowerCase();
+  if (!normalized) return false;
+  const needles = CAPABILITY_NEEDLES[capability];
+  if (!needles) return false;
+  return needles.some((needle) => normalized.includes(needle));
+}
+
+export function assertMetrologyCapability(
+  role: string | null | undefined,
+  capability: MetrologyCapability
+): void {
+  if (!roleHasMetrologyCapability(role, capability)) {
+    throw new HttpError(
+      403,
+      "METROLOGY_CAPABILITY_REQUIRED",
+      `La capacité Métrologie '${capability}' est requise.`
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 2) États d'équipement — machine à états serveur                            */
+/* -------------------------------------------------------------------------- */
+
+// États STOCKÉS (gouvernance). `DUE_SOON` et `OVERDUE` ne sont volontairement
+// pas stockés : ce sont des dérivés du plan actif et de la date du jour, calculés
+// à chaque lecture pour ne jamais dériver de la réalité (cf. `metrology-schedule`).
+export const METROLOGY_EQUIPMENT_STATES = [
+  "DRAFT",
+  "ACTIVE",
+  "QUALIFIED",
+  "SUSPENDED",
+  "QUARANTINE",
+  "OUT_OF_TOLERANCE",
+  "UNDER_REPAIR",
+  "RETIRED",
+] as const;
+export type MetrologyEquipmentState = (typeof METROLOGY_EQUIPMENT_STATES)[number];
+
+// État EFFECTIF exposé à l'UI : état stocké enrichi des dérivés d'échéance.
+export const METROLOGY_EFFECTIVE_STATES = [
+  ...METROLOGY_EQUIPMENT_STATES,
+  "DUE_SOON",
+  "OVERDUE",
+] as const;
+export type MetrologyEffectiveState = (typeof METROLOGY_EFFECTIVE_STATES)[number];
+
+const EQUIPMENT_TRANSITIONS: Readonly<
+  Record<MetrologyEquipmentState, readonly MetrologyEquipmentState[]>
+> = {
+  DRAFT: ["ACTIVE", "QUALIFIED", "RETIRED"],
+  ACTIVE: ["QUALIFIED", "SUSPENDED", "QUARANTINE", "OUT_OF_TOLERANCE", "UNDER_REPAIR", "RETIRED"],
+  QUALIFIED: ["ACTIVE", "SUSPENDED", "QUARANTINE", "OUT_OF_TOLERANCE", "UNDER_REPAIR", "RETIRED"],
+  SUSPENDED: ["ACTIVE", "QUALIFIED", "QUARANTINE", "UNDER_REPAIR", "RETIRED"],
+  // Sortir de quarantaine passe par une réparation/ajustage ou par une
+  // libération explicite, jamais par un simple changement de statut.
+  QUARANTINE: ["UNDER_REPAIR", "OUT_OF_TOLERANCE", "QUALIFIED", "RETIRED"],
+  OUT_OF_TOLERANCE: ["UNDER_REPAIR", "QUARANTINE", "QUALIFIED", "RETIRED"],
+  UNDER_REPAIR: ["QUARANTINE", "QUALIFIED", "RETIRED"],
+  RETIRED: [],
+};
+
+// Une remise en service (retour vers un état utilisable) exige une preuve
+// conforme valide ET la capacité `equipment_release`.
+const RELEASE_TARGETS: ReadonlySet<MetrologyEquipmentState> = new Set<MetrologyEquipmentState>([
+  "ACTIVE",
+  "QUALIFIED",
+]);
+
+const BLOCKED_STATES: ReadonlySet<MetrologyEquipmentState> = new Set<MetrologyEquipmentState>([
+  "DRAFT",
+  "SUSPENDED",
+  "QUARANTINE",
+  "OUT_OF_TOLERANCE",
+  "UNDER_REPAIR",
+  "RETIRED",
+]);
+
+export function equipmentStateBlocksUsage(state: MetrologyEquipmentState): boolean {
+  return BLOCKED_STATES.has(state);
+}
+
+export function assertEquipmentTransition(
+  from: MetrologyEquipmentState,
+  to: MetrologyEquipmentState
+): void {
+  if (from === to) {
+    throw new HttpError(
+      409,
+      "METROLOGY_EQUIPMENT_TRANSITION_NOOP",
+      `L'équipement est déjà dans l'état ${from}.`
+    );
+  }
+  if (!EQUIPMENT_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "METROLOGY_EQUIPMENT_TRANSITION_FORBIDDEN",
+      `Transition d'équipement interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+export function transitionRequiresRelease(
+  from: MetrologyEquipmentState,
+  to: MetrologyEquipmentState
+): boolean {
+  if (!RELEASE_TARGETS.has(to)) return false;
+  return from === "QUARANTINE" || from === "OUT_OF_TOLERANCE" || from === "UNDER_REPAIR";
+}
+
+export type ReleasePrecondition = {
+  hasValidConformeProof: boolean;
+  proofExecutionId: string | null;
+  repairRequired: boolean;
+  repairDone: boolean;
+  reason: string | null;
+};
+
+/**
+ * Remise en service : jamais une simple modification de statut. Il faut la
+ * réparation/ajustage quand elle a été exigée, une preuve conforme valide, et
+ * un motif écrit conservé dans l'audit.
+ */
+export function assertEquipmentReleaseAllowed(pre: ReleasePrecondition): void {
+  const missing: string[] = [];
+  if (pre.repairRequired && !pre.repairDone) missing.push("repair_or_adjustment");
+  if (!pre.hasValidConformeProof || !pre.proofExecutionId) missing.push("conforming_proof");
+  if ((pre.reason ?? "").trim().length < 10) missing.push("reason");
+  if (missing.length > 0) {
+    throw new HttpError(
+      422,
+      "METROLOGY_RELEASE_INCOMPLETE",
+      "Remise en service impossible : éléments obligatoires manquants.",
+      { missing }
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 3) Plans versionnés — cycle de vie et immuabilité                          */
+/* -------------------------------------------------------------------------- */
+
+export const METROLOGY_PLAN_STATUSES = ["DRAFT", "ACTIVE", "ARCHIVED"] as const;
+export type MetrologyPlanStatus = (typeof METROLOGY_PLAN_STATUSES)[number];
+
+const PLAN_TRANSITIONS: Readonly<Record<MetrologyPlanStatus, readonly MetrologyPlanStatus[]>> = {
+  DRAFT: ["ACTIVE", "ARCHIVED"],
+  // Une version active est figée : on l'archive en publiant sa remplaçante.
+  ACTIVE: ["ARCHIVED"],
+  ARCHIVED: [],
+};
+
+export function assertPlanTransition(from: MetrologyPlanStatus, to: MetrologyPlanStatus): void {
+  if (!PLAN_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "METROLOGY_PLAN_TRANSITION_FORBIDDEN",
+      `Transition de plan métrologique interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+export function assertPlanContentMutable(status: MetrologyPlanStatus): void {
+  if (status !== "DRAFT") {
+    throw new HttpError(
+      409,
+      "METROLOGY_PLAN_IMMUTABLE",
+      "Une version de plan active ou archivée ne se modifie pas : créez une nouvelle version."
+    );
+  }
+}
+
+export function assertPlanSelectableForExecution(status: MetrologyPlanStatus): void {
+  if (status !== "ACTIVE") {
+    throw new HttpError(
+      409,
+      "METROLOGY_PLAN_NOT_ACTIVE",
+      "Seule une version de plan active peut porter un étalonnage ou une vérification."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 4) Exécutions — types, statuts et verdicts                                 */
+/* -------------------------------------------------------------------------- */
+
+export const METROLOGY_OPERATION_TYPES = [
+  "ETALONNAGE",
+  "VERIFICATION",
+  "AJUSTAGE",
+  "REPARATION",
+] as const;
+export type MetrologyOperationType = (typeof METROLOGY_OPERATION_TYPES)[number];
+
+export const METROLOGY_EXECUTION_STATUSES = [
+  "DRAFT",
+  "IN_PROGRESS",
+  "VALIDATED",
+  "CANCELLED",
+] as const;
+export type MetrologyExecutionStatus = (typeof METROLOGY_EXECUTION_STATUSES)[number];
+
+export const METROLOGY_VERDICTS = [
+  "CONFORME",
+  "NON_CONFORME",
+  "CONFORME_AVEC_RESTRICTION",
+  "INCONCLU",
+] as const;
+export type MetrologyVerdict = (typeof METROLOGY_VERDICTS)[number];
+
+/**
+ * Mapping canonique vers l'enum historique `metrologie_certificats.resultat`
+ * (CONFORME/NON_CONFORME/AJUSTAGE), pour ne casser ni la liste des certificats
+ * ni les écrans déjà en production.
+ */
+export function verdictToLegacyCertificatResult(
+  verdict: MetrologyVerdict,
+  operationType: MetrologyOperationType
+): "CONFORME" | "NON_CONFORME" | "AJUSTAGE" {
+  if (operationType === "AJUSTAGE" || operationType === "REPARATION") return "AJUSTAGE";
+  switch (verdict) {
+    case "CONFORME":
+    case "CONFORME_AVEC_RESTRICTION":
+      return "CONFORME";
+    case "NON_CONFORME":
+      return "NON_CONFORME";
+    case "INCONCLU":
+      // Un résultat non concluant n'est pas une conformité : il reste bloquant
+      // côté éligibilité, et il est tracé comme non conforme côté certificat.
+      return "NON_CONFORME";
+  }
+}
+
+/** Une exécution qui produit une preuve d'aptitude opposable. */
+export function verdictIsAdmissibleProof(verdict: MetrologyVerdict): boolean {
+  return verdict === "CONFORME" || verdict === "CONFORME_AVEC_RESTRICTION";
+}
+
+/** Un verdict qui déclenche quarantaine + analyse d'impact. */
+export function verdictTriggersQuarantine(verdict: MetrologyVerdict): boolean {
+  return verdict === "NON_CONFORME";
+}
+
+const EXECUTION_TRANSITIONS: Readonly<
+  Record<MetrologyExecutionStatus, readonly MetrologyExecutionStatus[]>
+> = {
+  DRAFT: ["IN_PROGRESS", "CANCELLED"],
+  IN_PROGRESS: ["VALIDATED", "CANCELLED"],
+  VALIDATED: [],
+  CANCELLED: [],
+};
+
+export function assertExecutionTransition(
+  from: MetrologyExecutionStatus,
+  to: MetrologyExecutionStatus
+): void {
+  if (!EXECUTION_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "METROLOGY_EXECUTION_TRANSITION_FORBIDDEN",
+      `Transition d'exécution interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+export function assertExecutionMutable(status: MetrologyExecutionStatus): void {
+  if (status === "VALIDATED") {
+    throw new HttpError(
+      409,
+      "METROLOGY_EXECUTION_IMMUTABLE",
+      "Une exécution validée est immuable : elle ne se réécrit pas."
+    );
+  }
+  if (status === "CANCELLED") {
+    throw new HttpError(
+      409,
+      "METROLOGY_EXECUTION_CANCELLED",
+      "Une exécution annulée ne se rouvre pas."
+    );
+  }
+}
+
+export type ManualVerdictOverride = {
+  computed: MetrologyVerdict;
+  requested: MetrologyVerdict;
+  justification: string | null;
+  evidenceCount: number;
+  requireEvidence: boolean;
+};
+
+/**
+ * Un verdict retenu contraire au calcul est possible (l'humain décide), mais il
+ * est justifié, tracé, et il ne transforme JAMAIS un hors tolérance en
+ * conformité : au mieux en conformité avec restriction documentée.
+ */
+export function assertManualVerdictOverride(input: ManualVerdictOverride): void {
+  if (input.requested === input.computed) return;
+
+  const justification = (input.justification ?? "").trim();
+  if (justification.length < 20) {
+    throw new HttpError(
+      422,
+      "METROLOGY_VERDICT_OVERRIDE_JUSTIFICATION_REQUIRED",
+      "Un verdict contraire au calcul exige une justification d'au moins 20 caractères."
+    );
+  }
+  if (input.requireEvidence && input.evidenceCount <= 0) {
+    throw new HttpError(
+      422,
+      "METROLOGY_VERDICT_OVERRIDE_EVIDENCE_REQUIRED",
+      "Un verdict contraire au calcul exige au moins une pièce jointe de preuve."
+    );
+  }
+  if (input.computed === "NON_CONFORME" && input.requested === "CONFORME") {
+    throw new HttpError(
+      422,
+      "METROLOGY_VERDICT_OVERRIDE_FORBIDDEN",
+      "Un relevé hors tolérance ne devient pas conforme par décision manuelle : utilisez « conforme avec restriction » et documentez-la."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 5) Séparation des tâches                                                   */
+/* -------------------------------------------------------------------------- */
+
+export type SeparationPolicy = {
+  // Exception explicitement configurée, justifiée et auditée (jamais implicite).
+  allowSelfVerdictValidation: boolean;
+  allowSelfRelease: boolean;
+};
+
+export const DEFAULT_METROLOGY_SEPARATION: SeparationPolicy = {
+  allowSelfVerdictValidation: false,
+  allowSelfRelease: false,
+};
+
+export function assertVerdictSeparation(params: {
+  operatorUserId: number | null;
+  validatorUserId: number;
+  operationType: MetrologyOperationType;
+  policy?: SeparationPolicy;
+}): void {
+  const policy = params.policy ?? DEFAULT_METROLOGY_SEPARATION;
+  if (policy.allowSelfVerdictValidation) return;
+  // Un étalonnage externe est validé par l'interne : la séparation ne
+  // s'applique qu'aux opérations réellement exécutées en interne.
+  if (params.operatorUserId === null) return;
+  if (params.operatorUserId === params.validatorUserId) {
+    throw new HttpError(
+      403,
+      "METROLOGY_SEPARATION_OF_DUTIES",
+      "L'opérateur qui a exécuté la vérification ne peut pas valider lui-même le verdict."
+    );
+  }
+}
+
+export function assertReleaseSeparation(params: {
+  operatorUserId: number | null;
+  releaserUserId: number;
+  policy?: SeparationPolicy;
+}): void {
+  const policy = params.policy ?? DEFAULT_METROLOGY_SEPARATION;
+  if (policy.allowSelfRelease) return;
+  if (params.operatorUserId !== null && params.operatorUserId === params.releaserUserId) {
+    throw new HttpError(
+      403,
+      "METROLOGY_SEPARATION_OF_DUTIES",
+      "L'auteur de l'intervention ne peut pas prononcer lui-même la remise en service."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 6) Décisions d'impact                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const METROLOGY_IMPACT_DECISIONS = [
+  "PENDING",
+  "NO_IMPACT",
+  "RECHECK",
+  "HOLD_LOT",
+  "OPEN_NC",
+  "REISSUE_DOCUMENT",
+  "INFORM_CUSTOMER",
+] as const;
+export type MetrologyImpactDecision = (typeof METROLOGY_IMPACT_DECISIONS)[number];
+
+/**
+ * Aucune décision d'impact n'est automatique. Cette liste dit précisément ce
+ * que le module de métrologie a le droit d'écrire lui-même : rien d'autre que
+ * la trace de la décision humaine. Annuler un contrôle, déstocker un lot,
+ * annuler un BL, créer un avoir ou déclencher un rappel client restent des
+ * actions des modules concernés, jamais un effet de bord d'ici.
+ */
+export const IMPACT_DECISION_SIDE_EFFECTS: Readonly<
+  Record<MetrologyImpactDecision, readonly string[]>
+> = {
+  PENDING: [],
+  NO_IMPACT: [],
+  RECHECK: [],
+  HOLD_LOT: [],
+  OPEN_NC: [],
+  REISSUE_DOCUMENT: [],
+  INFORM_CUSTOMER: [],
+};
+
+export function assertImpactDecision(params: {
+  decision: MetrologyImpactDecision;
+  reason: string | null;
+}): void {
+  if (params.decision === "PENDING") {
+    throw new HttpError(
+      422,
+      "METROLOGY_IMPACT_DECISION_REQUIRED",
+      "Choisissez une décision : « à traiter » n'est pas une décision."
+    );
+  }
+  if ((params.reason ?? "").trim().length < 5) {
+    throw new HttpError(
+      422,
+      "METROLOGY_IMPACT_DECISION_REASON_REQUIRED",
+      "Chaque décision d'impact exige un motif écrit."
+    );
+  }
+}
+
+export const METROLOGY_IMPACT_STATUSES = ["OPEN", "IN_REVIEW", "CLOSED", "CANCELLED"] as const;
+export type MetrologyImpactStatus = (typeof METROLOGY_IMPACT_STATUSES)[number];
+
+const IMPACT_TRANSITIONS: Readonly<
+  Record<MetrologyImpactStatus, readonly MetrologyImpactStatus[]>
+> = {
+  OPEN: ["IN_REVIEW", "CANCELLED"],
+  IN_REVIEW: ["CLOSED", "OPEN", "CANCELLED"],
+  CLOSED: [],
+  CANCELLED: [],
+};
+
+export function assertImpactTransition(
+  from: MetrologyImpactStatus,
+  to: MetrologyImpactStatus
+): void {
+  if (!IMPACT_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "METROLOGY_IMPACT_TRANSITION_FORBIDDEN",
+      `Transition de dossier d'impact interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+export function assertImpactClosureAllowed(params: {
+  pendingItems: number;
+  conclusion: string | null;
+}): void {
+  const missing: string[] = [];
+  if (params.pendingItems > 0) missing.push("pending_items");
+  if ((params.conclusion ?? "").trim().length < 20) missing.push("conclusion");
+  if (missing.length > 0) {
+    throw new HttpError(
+      422,
+      "METROLOGY_IMPACT_CLOSURE_INCOMPLETE",
+      "Clôture impossible : chaque usage doit être décidé et la conclusion écrite.",
+      { missing, pending_items: params.pendingItems }
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 7) Idempotence et empreinte canonique                                      */
+/* -------------------------------------------------------------------------- */
+
+export function normalizeMetrologyIdempotencyKey(value: string | null | undefined): string {
+  const normalized = (value ?? "").trim();
+  if (normalized.length < 8 || normalized.length > 200) {
+    throw new HttpError(
+      400,
+      "IDEMPOTENCY_KEY_INVALID",
+      "Idempotency-Key doit contenir entre 8 et 200 caractères."
+    );
+  }
+  return normalized;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, child]) => child !== undefined)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, child]) => [key, canonicalize(child)])
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function metrologySha256(value: unknown): string {
+  return crypto.createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+export function metrologyRequestHash(commandType: string, payload: unknown): string {
+  return metrologySha256({ command_type: commandType, payload });
+}
+
+export function decideMetrologyReceipt(
+  existingHash: string | null | undefined,
+  incomingHash: string
+): "NEW" | "REPLAY" | "CONFLICT" {
+  if (!existingHash) return "NEW";
+  return existingHash === incomingHash ? "REPLAY" : "CONFLICT";
+}
+
+export function assertPreviewFresh(params: {
+  expectedHash: string | null | undefined;
+  currentHash: string;
+}): void {
+  const expected = (params.expectedHash ?? "").trim();
+  if (!expected) {
+    throw new HttpError(
+      422,
+      "METROLOGY_PREVIEW_REQUIRED",
+      "Un aperçu serveur est obligatoire avant de confirmer cette décision."
+    );
+  }
+  if (expected !== params.currentHash) {
+    throw new HttpError(
+      409,
+      "METROLOGY_PREVIEW_STALE",
+      "L'aperçu n'est plus à jour : rechargez-le avant de confirmer."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 8) Verrou optimiste                                                        */
+/* -------------------------------------------------------------------------- */
+
+export function assertOptimisticVersion(params: {
+  expectedUpdatedAt: string | null | undefined;
+  currentUpdatedAt: string | Date;
+}): void {
+  const expected = (params.expectedUpdatedAt ?? "").trim();
+  if (!expected) {
+    throw new HttpError(
+      422,
+      "METROLOGY_EXPECTED_VERSION_REQUIRED",
+      "expected_updated_at est obligatoire pour modifier cet objet métrologique."
+    );
+  }
+  const current =
+    params.currentUpdatedAt instanceof Date
+      ? params.currentUpdatedAt.toISOString()
+      : new Date(params.currentUpdatedAt).toISOString();
+  const parsedExpected = new Date(expected);
+  if (Number.isNaN(parsedExpected.getTime())) {
+    throw new HttpError(
+      422,
+      "METROLOGY_EXPECTED_VERSION_INVALID",
+      "expected_updated_at est invalide."
+    );
+  }
+  if (parsedExpected.toISOString() !== current) {
+    throw new HttpError(
+      409,
+      "METROLOGY_VERSION_CONFLICT",
+      "Cet objet métrologique a été modifié entre-temps : rechargez la fiche."
+    );
+  }
+}

--- a/src/module/metrologie/domain/metrology-schedule.ts
+++ b/src/module/metrologie/domain/metrology-schedule.ts
@@ -1,0 +1,252 @@
+// Échéances métrologiques (#229) — calcul pur, sans I/O.
+//
+// Règle : une échéance est DÉRIVÉE de la dernière preuve admissible et de la
+// version de plan applicable. Elle n'est jamais saisie à la main sans dérogation
+// justifiée et approuvée (`ScheduleOverride`), et le frontend ne la calcule
+// jamais lui-même.
+
+import { HttpError } from "../../../utils/httpError";
+
+import type { MetrologyEffectiveState, MetrologyEquipmentState } from "./metrology-policy";
+
+export type PeriodicityUnit = "DAY" | "WEEK" | "MONTH" | "YEAR";
+export type ScheduleBase = "LAST_PROOF" | "FIXED_DATE";
+
+export type SchedulePlan = {
+  periodicite_valeur: number;
+  periodicite_unite: PeriodicityUnit;
+  base_calcul: ScheduleBase;
+  alert_window_days: number;
+  effective_from: string | null;
+};
+
+export type ScheduleInput = {
+  plan: SchedulePlan;
+  /** Date de la dernière preuve admissible (verdict conforme ou conforme avec restriction). */
+  lastProofDate: string | null;
+  /** Échéance imposée par le certificat externe, quand le prestataire en fixe une. */
+  certificateDueDate?: string | null;
+  /** Repli quand aucune preuve n'existe encore : mise en service ou création. */
+  fallbackDate: string | null;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Utilitaires de date (UTC strict, aucun fuseau implicite)                    */
+/* -------------------------------------------------------------------------- */
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+export function parseIsoDate(value: string | null | undefined): Date | null {
+  if (!value) return null;
+  const raw = value.length > 10 ? value.slice(0, 10) : value;
+  if (!ISO_DATE.test(raw)) return null;
+  const parsed = new Date(`${raw}T00:00:00.000Z`);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+export function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export function addPeriod(date: Date, value: number, unit: PeriodicityUnit): Date {
+  const next = new Date(date.getTime());
+  switch (unit) {
+    case "DAY":
+      next.setUTCDate(next.getUTCDate() + value);
+      return next;
+    case "WEEK":
+      next.setUTCDate(next.getUTCDate() + value * 7);
+      return next;
+    case "YEAR":
+      return addMonthsClamped(next, value * 12);
+    case "MONTH":
+    default:
+      return addMonthsClamped(next, value);
+  }
+}
+
+/**
+ * Ajout de mois avec bornage du quantième : le 31/01 + 1 mois donne le 28/02
+ * (ou 29/02), jamais le 03/03. Une échéance métrologique qui « saute » un mois
+ * est un écart d'audit.
+ */
+function addMonthsClamped(date: Date, months: number): Date {
+  const day = date.getUTCDate();
+  const anchor = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), 1));
+  anchor.setUTCMonth(anchor.getUTCMonth() + months);
+  const lastDayOfTargetMonth = new Date(
+    Date.UTC(anchor.getUTCFullYear(), anchor.getUTCMonth() + 1, 0)
+  ).getUTCDate();
+  anchor.setUTCDate(Math.min(day, lastDayOfTargetMonth));
+  return anchor;
+}
+
+export function daysBetween(from: Date, to: Date): number {
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+  return Math.round((to.getTime() - from.getTime()) / MS_PER_DAY);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Calcul d'échéance                                                          */
+/* -------------------------------------------------------------------------- */
+
+export type ScheduleResult = {
+  next_due_date: string | null;
+  /** D'où vient la date : utile pour l'expliquer dans l'UI sans la recalculer. */
+  source: "CERTIFICATE" | "LAST_PROOF" | "EFFECTIVE_FROM" | "FALLBACK" | "NONE";
+  base_date: string | null;
+};
+
+export function computeNextDueDate(input: ScheduleInput): ScheduleResult {
+  const { plan } = input;
+
+  // Une échéance imposée par le certificat externe prime : le prestataire est
+  // l'autorité sur la validité de SON étalonnage.
+  const certificate = parseIsoDate(input.certificateDueDate ?? null);
+  if (certificate) {
+    return { next_due_date: toIsoDate(certificate), source: "CERTIFICATE", base_date: null };
+  }
+
+  if (plan.base_calcul === "FIXED_DATE") {
+    const effective = parseIsoDate(plan.effective_from);
+    if (!effective) return { next_due_date: null, source: "NONE", base_date: null };
+    return {
+      next_due_date: toIsoDate(addPeriod(effective, plan.periodicite_valeur, plan.periodicite_unite)),
+      source: "EFFECTIVE_FROM",
+      base_date: toIsoDate(effective),
+    };
+  }
+
+  const proof = parseIsoDate(input.lastProofDate);
+  if (proof) {
+    return {
+      next_due_date: toIsoDate(addPeriod(proof, plan.periodicite_valeur, plan.periodicite_unite)),
+      source: "LAST_PROOF",
+      base_date: toIsoDate(proof),
+    };
+  }
+
+  const fallback = parseIsoDate(input.fallbackDate);
+  if (fallback) {
+    return {
+      next_due_date: toIsoDate(addPeriod(fallback, plan.periodicite_valeur, plan.periodicite_unite)),
+      source: "FALLBACK",
+      base_date: toIsoDate(fallback),
+    };
+  }
+
+  return { next_due_date: null, source: "NONE", base_date: null };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Dérivation de l'état effectif                                              */
+/* -------------------------------------------------------------------------- */
+
+export type DueStatus = "OK" | "DUE_SOON" | "OVERDUE" | "UNKNOWN";
+
+export type DueEvaluation = {
+  status: DueStatus;
+  next_due_date: string | null;
+  days_remaining: number | null;
+  days_overdue: number;
+};
+
+export function evaluateDue(params: {
+  nextDueDate: string | null;
+  alertWindowDays: number;
+  at: Date;
+}): DueEvaluation {
+  const due = parseIsoDate(params.nextDueDate);
+  if (!due) {
+    return { status: "UNKNOWN", next_due_date: null, days_remaining: null, days_overdue: 0 };
+  }
+  const today = parseIsoDate(toIsoDate(params.at)) as Date;
+  const remaining = daysBetween(today, due);
+  if (remaining < 0) {
+    return {
+      status: "OVERDUE",
+      next_due_date: toIsoDate(due),
+      days_remaining: remaining,
+      days_overdue: Math.abs(remaining),
+    };
+  }
+  const window = Number.isFinite(params.alertWindowDays) ? Math.max(0, params.alertWindowDays) : 0;
+  return {
+    status: remaining <= window ? "DUE_SOON" : "OK",
+    next_due_date: toIsoDate(due),
+    days_remaining: remaining,
+    days_overdue: 0,
+  };
+}
+
+/**
+ * État effectif exposé à l'UI : l'état de gouvernance stocké l'emporte toujours
+ * sur le dérivé d'échéance (une quarantaine ne devient pas « bientôt dû »).
+ */
+export function deriveEffectiveState(params: {
+  storedState: MetrologyEquipmentState;
+  due: DueEvaluation;
+}): MetrologyEffectiveState {
+  const stored = params.storedState;
+  if (stored !== "ACTIVE" && stored !== "QUALIFIED") return stored;
+  if (params.due.status === "OVERDUE") return "OVERDUE";
+  if (params.due.status === "DUE_SOON") return "DUE_SOON";
+  return stored;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Dérogation d'échéance                                                      */
+/* -------------------------------------------------------------------------- */
+
+export type ScheduleOverride = {
+  requestedDueDate: string;
+  computedDueDate: string | null;
+  reason: string | null;
+  approvedByUserId: number | null;
+  requestedByUserId: number;
+};
+
+/**
+ * Repousser une échéance calculée est une dérogation : motif obligatoire,
+ * approbateur distinct du demandeur, et jamais au-delà d'un an après le calcul.
+ */
+export function assertScheduleOverrideAllowed(input: ScheduleOverride): void {
+  const requested = parseIsoDate(input.requestedDueDate);
+  if (!requested) {
+    throw new HttpError(422, "METROLOGY_DUE_DATE_INVALID", "Échéance dérogatoire invalide.");
+  }
+  if ((input.reason ?? "").trim().length < 20) {
+    throw new HttpError(
+      422,
+      "METROLOGY_DUE_OVERRIDE_JUSTIFICATION_REQUIRED",
+      "Repousser une échéance calculée exige une justification d'au moins 20 caractères."
+    );
+  }
+  if (input.approvedByUserId === null) {
+    throw new HttpError(
+      422,
+      "METROLOGY_DUE_OVERRIDE_APPROVAL_REQUIRED",
+      "Une échéance dérogatoire exige une approbation explicite."
+    );
+  }
+  if (input.approvedByUserId === input.requestedByUserId) {
+    throw new HttpError(
+      403,
+      "METROLOGY_SEPARATION_OF_DUTIES",
+      "Le demandeur ne peut pas approuver sa propre dérogation d'échéance."
+    );
+  }
+
+  const computed = parseIsoDate(input.computedDueDate);
+  if (computed) {
+    const drift = daysBetween(computed, requested);
+    if (drift > 365) {
+      throw new HttpError(
+        422,
+        "METROLOGY_DUE_OVERRIDE_TOO_FAR",
+        "Une échéance dérogatoire ne peut pas dépasser d'un an l'échéance calculée.",
+        { computed_due_date: toIsoDate(computed), drift_days: drift }
+      );
+    }
+  }
+}

--- a/src/module/metrologie/domain/metrology-units.ts
+++ b/src/module/metrologie/domain/metrology-units.ts
@@ -1,0 +1,163 @@
+// Unités métrologiques (#229) — normalisation pure, sans I/O.
+//
+// L'éligibilité d'un instrument dépend de sa plage : comparer « 0–150 mm » à une
+// cote exprimée en µm sans conversion produirait un refus (ou pire, une
+// acceptation) absurde. On normalise donc vers une unité de base par dimension,
+// et on refuse explicitement de comparer deux dimensions différentes.
+//
+// Le tableau est volontairement fermé : une unité inconnue n'est jamais
+// « convertie au mieux », elle est signalée.
+
+export type Dimension = "LENGTH" | "MASS" | "TEMPERATURE" | "PRESSURE" | "ANGLE" | "FORCE" | "TIME";
+
+type UnitDefinition = {
+  dimension: Dimension;
+  /** Facteur vers l'unité de base de la dimension. */
+  factor: number;
+  /** Décalage appliqué APRÈS le facteur (températures). */
+  offset?: number;
+  canonical: string;
+};
+
+const BASE_UNITS: Record<Dimension, string> = {
+  LENGTH: "mm",
+  MASS: "g",
+  TEMPERATURE: "°C",
+  PRESSURE: "bar",
+  ANGLE: "°",
+  FORCE: "N",
+  TIME: "s",
+};
+
+const UNITS: Record<string, UnitDefinition> = {
+  // Longueur — base : millimètre.
+  nm: { dimension: "LENGTH", factor: 1e-6, canonical: "nm" },
+  um: { dimension: "LENGTH", factor: 1e-3, canonical: "µm" },
+  µm: { dimension: "LENGTH", factor: 1e-3, canonical: "µm" },
+  micron: { dimension: "LENGTH", factor: 1e-3, canonical: "µm" },
+  microns: { dimension: "LENGTH", factor: 1e-3, canonical: "µm" },
+  mm: { dimension: "LENGTH", factor: 1, canonical: "mm" },
+  cm: { dimension: "LENGTH", factor: 10, canonical: "cm" },
+  dm: { dimension: "LENGTH", factor: 100, canonical: "dm" },
+  m: { dimension: "LENGTH", factor: 1000, canonical: "m" },
+  in: { dimension: "LENGTH", factor: 25.4, canonical: "in" },
+  inch: { dimension: "LENGTH", factor: 25.4, canonical: "in" },
+  pouce: { dimension: "LENGTH", factor: 25.4, canonical: "in" },
+
+  // Masse — base : gramme.
+  mg: { dimension: "MASS", factor: 1e-3, canonical: "mg" },
+  g: { dimension: "MASS", factor: 1, canonical: "g" },
+  kg: { dimension: "MASS", factor: 1000, canonical: "kg" },
+  t: { dimension: "MASS", factor: 1e6, canonical: "t" },
+
+  // Température — base : degré Celsius (offset appliqué après facteur).
+  "°c": { dimension: "TEMPERATURE", factor: 1, canonical: "°C" },
+  c: { dimension: "TEMPERATURE", factor: 1, canonical: "°C" },
+  celsius: { dimension: "TEMPERATURE", factor: 1, canonical: "°C" },
+  k: { dimension: "TEMPERATURE", factor: 1, offset: -273.15, canonical: "K" },
+  kelvin: { dimension: "TEMPERATURE", factor: 1, offset: -273.15, canonical: "K" },
+
+  // Pression — base : bar.
+  pa: { dimension: "PRESSURE", factor: 1e-5, canonical: "Pa" },
+  kpa: { dimension: "PRESSURE", factor: 1e-2, canonical: "kPa" },
+  mpa: { dimension: "PRESSURE", factor: 10, canonical: "MPa" },
+  mbar: { dimension: "PRESSURE", factor: 1e-3, canonical: "mbar" },
+  bar: { dimension: "PRESSURE", factor: 1, canonical: "bar" },
+  psi: { dimension: "PRESSURE", factor: 0.0689476, canonical: "psi" },
+
+  // Angle — base : degré.
+  "°": { dimension: "ANGLE", factor: 1, canonical: "°" },
+  deg: { dimension: "ANGLE", factor: 1, canonical: "°" },
+  degre: { dimension: "ANGLE", factor: 1, canonical: "°" },
+  rad: { dimension: "ANGLE", factor: 180 / Math.PI, canonical: "rad" },
+  arcmin: { dimension: "ANGLE", factor: 1 / 60, canonical: "'" },
+  "'": { dimension: "ANGLE", factor: 1 / 60, canonical: "'" },
+
+  // Force — base : newton.
+  n: { dimension: "FORCE", factor: 1, canonical: "N" },
+  kn: { dimension: "FORCE", factor: 1000, canonical: "kN" },
+  dan: { dimension: "FORCE", factor: 10, canonical: "daN" },
+
+  // Temps — base : seconde.
+  ms: { dimension: "TIME", factor: 1e-3, canonical: "ms" },
+  s: { dimension: "TIME", factor: 1, canonical: "s" },
+  min: { dimension: "TIME", factor: 60, canonical: "min" },
+  h: { dimension: "TIME", factor: 3600, canonical: "h" },
+};
+
+function normalizeKey(unit: string): string {
+  return unit
+    .trim()
+    .toLowerCase()
+    .replace(/\s+/g, "")
+    .replace(/^degc$/, "°c")
+    .replace(/^degre?s?$/, "deg");
+}
+
+export type ResolvedUnit = {
+  input: string;
+  canonical: string;
+  dimension: Dimension;
+  baseUnit: string;
+};
+
+export function resolveUnit(unit: string | null | undefined): ResolvedUnit | null {
+  if (!unit) return null;
+  const definition = UNITS[normalizeKey(unit)];
+  if (!definition) return null;
+  return {
+    input: unit,
+    canonical: definition.canonical,
+    dimension: definition.dimension,
+    baseUnit: BASE_UNITS[definition.dimension],
+  };
+}
+
+export function isKnownUnit(unit: string | null | undefined): boolean {
+  return resolveUnit(unit) !== null;
+}
+
+/** Convertit une valeur vers l'unité de base de sa dimension. */
+export function toBaseValue(value: number, unit: string): number | null {
+  const definition = UNITS[normalizeKey(unit)];
+  if (!definition || !Number.isFinite(value)) return null;
+  return value * definition.factor + (definition.offset ?? 0);
+}
+
+export type UnitConversion =
+  | { ok: true; value: number }
+  | { ok: false; reason: "UNKNOWN_SOURCE" | "UNKNOWN_TARGET" | "DIMENSION_MISMATCH" };
+
+/** Convertit une valeur d'une unité vers une autre de la MÊME dimension. */
+export function convertValue(value: number, from: string, to: string): UnitConversion {
+  const source = UNITS[normalizeKey(from)];
+  if (!source) return { ok: false, reason: "UNKNOWN_SOURCE" };
+  const target = UNITS[normalizeKey(to)];
+  if (!target) return { ok: false, reason: "UNKNOWN_TARGET" };
+  if (source.dimension !== target.dimension) return { ok: false, reason: "DIMENSION_MISMATCH" };
+
+  const base = value * source.factor + (source.offset ?? 0);
+  return { ok: true, value: (base - (target.offset ?? 0)) / target.factor };
+}
+
+export function sameDimension(left: string | null | undefined, right: string | null | undefined): boolean {
+  const a = resolveUnit(left);
+  const b = resolveUnit(right);
+  if (!a || !b) return false;
+  return a.dimension === b.dimension;
+}
+
+/** Liste des unités acceptées, pour alimenter les listes déroulantes serveur. */
+export function listSupportedUnits(): Array<{ canonical: string; dimension: Dimension }> {
+  const seen = new Map<string, Dimension>();
+  for (const definition of Object.values(UNITS)) {
+    if (!seen.has(definition.canonical)) seen.set(definition.canonical, definition.dimension);
+  }
+  return Array.from(seen.entries())
+    .map(([canonical, dimension]) => ({ canonical, dimension }))
+    .sort((left, right) =>
+      left.dimension === right.dimension
+        ? left.canonical.localeCompare(right.canonical)
+        : left.dimension.localeCompare(right.dimension)
+    );
+}

--- a/src/module/metrologie/domain/metrology-verdict.ts
+++ b/src/module/metrologie/domain/metrology-verdict.ts
@@ -1,0 +1,218 @@
+// Calcul du verdict d'une exécution métrologique (#229) — pur, sans I/O.
+//
+// Le verdict CALCULÉ est la vérité du relevé. Le verdict RETENU peut en
+// différer, mais uniquement par décision humaine justifiée et tracée
+// (`assertManualVerdictOverride` dans `metrology-policy`).
+
+import { convertValue, sameDimension } from "./metrology-units";
+import type { MetrologyOperationType, MetrologyVerdict } from "./metrology-policy";
+
+export type MeasurementInput = {
+  point_key: string;
+  sample_no: number;
+  nominal: number | null;
+  tolerance_min: number | null;
+  tolerance_max: number | null;
+  measured: number | null;
+  unite: string | null;
+  incertitude: number | null;
+};
+
+export type PlanCriteria = {
+  tolerance_min: number | null;
+  tolerance_max: number | null;
+  unite: string | null;
+  /**
+   * Nombre minimum de points attendus par la procédure. Une exécution qui n'en
+   * couvre pas assez n'est pas conforme : elle est INCONCLUE.
+   */
+  min_points: number | null;
+};
+
+export type MeasurementVerdict = {
+  point_key: string;
+  sample_no: number;
+  verdict: "CONFORME" | "NON_CONFORME" | "INCONCLU";
+  ecart: number | null;
+  reason: string | null;
+};
+
+export type VerdictComputation = {
+  verdict: MetrologyVerdict;
+  points: MeasurementVerdict[];
+  counts: {
+    total: number;
+    conforme: number;
+    non_conforme: number;
+    inconclu: number;
+  };
+  /** Explication affichable telle quelle par l'assistant de saisie. */
+  explanation: string;
+};
+
+/**
+ * Verdict d'un point de mesure.
+ *
+ * Les bornes du point priment sur celles du plan : un plan donne le critère par
+ * défaut, la procédure peut le préciser point par point.
+ */
+export function evaluateMeasurement(
+  measurement: MeasurementInput,
+  criteria: PlanCriteria
+): MeasurementVerdict {
+  const base: Pick<MeasurementVerdict, "point_key" | "sample_no"> = {
+    point_key: measurement.point_key,
+    sample_no: measurement.sample_no,
+  };
+
+  if (measurement.measured === null || !Number.isFinite(measurement.measured)) {
+    return { ...base, verdict: "INCONCLU", ecart: null, reason: "Aucune valeur relevée." };
+  }
+
+  const bounds = resolveBounds(measurement, criteria);
+  if (bounds === "UNIT_MISMATCH") {
+    return {
+      ...base,
+      verdict: "INCONCLU",
+      ecart: null,
+      reason: "Unités incompatibles entre le relevé et le critère du plan.",
+    };
+  }
+
+  const ecart =
+    measurement.nominal !== null && Number.isFinite(measurement.nominal)
+      ? round(measurement.measured - measurement.nominal)
+      : null;
+
+  if (bounds.min === null && bounds.max === null) {
+    return {
+      ...base,
+      verdict: "INCONCLU",
+      ecart,
+      reason: "Aucun critère d'acceptation : le point ne peut pas être jugé.",
+    };
+  }
+
+  if (bounds.min !== null && measurement.measured < bounds.min) {
+    return {
+      ...base,
+      verdict: "NON_CONFORME",
+      ecart,
+      reason: `Valeur ${measurement.measured} sous la borne basse ${bounds.min}.`,
+    };
+  }
+  if (bounds.max !== null && measurement.measured > bounds.max) {
+    return {
+      ...base,
+      verdict: "NON_CONFORME",
+      ecart,
+      reason: `Valeur ${measurement.measured} au-dessus de la borne haute ${bounds.max}.`,
+    };
+  }
+
+  return { ...base, verdict: "CONFORME", ecart, reason: null };
+}
+
+function resolveBounds(
+  measurement: MeasurementInput,
+  criteria: PlanCriteria
+): { min: number | null; max: number | null } | "UNIT_MISMATCH" {
+  if (measurement.tolerance_min !== null || measurement.tolerance_max !== null) {
+    return { min: measurement.tolerance_min, max: measurement.tolerance_max };
+  }
+  if (criteria.tolerance_min === null && criteria.tolerance_max === null) {
+    return { min: null, max: null };
+  }
+
+  const from = criteria.unite;
+  const to = measurement.unite;
+  if (!from || !to || from.trim().toLowerCase() === to.trim().toLowerCase()) {
+    return { min: criteria.tolerance_min, max: criteria.tolerance_max };
+  }
+  if (!sameDimension(from, to)) return "UNIT_MISMATCH";
+
+  const min = criteria.tolerance_min === null ? null : convertValue(criteria.tolerance_min, from, to);
+  const max = criteria.tolerance_max === null ? null : convertValue(criteria.tolerance_max, from, to);
+  if ((min && !min.ok) || (max && !max.ok)) return "UNIT_MISMATCH";
+
+  return {
+    min: min && min.ok ? round(min.value) : null,
+    max: max && max.ok ? round(max.value) : null,
+  };
+}
+
+/**
+ * Verdict global.
+ *
+ * Ordre de priorité — un seul point hors tolérance suffit à rendre l'exécution
+ * non conforme : on ne « moyenne » jamais des relevés métrologiques.
+ */
+export function computeExecutionVerdict(params: {
+  operationType: MetrologyOperationType;
+  measurements: readonly MeasurementInput[];
+  criteria: PlanCriteria;
+}): VerdictComputation {
+  const points = params.measurements.map((measurement) =>
+    evaluateMeasurement(measurement, params.criteria)
+  );
+
+  const counts = {
+    total: points.length,
+    conforme: points.filter((point) => point.verdict === "CONFORME").length,
+    non_conforme: points.filter((point) => point.verdict === "NON_CONFORME").length,
+    inconclu: points.filter((point) => point.verdict === "INCONCLU").length,
+  };
+
+  // Un ajustage ou une réparation n'est pas un jugement d'aptitude : sans
+  // relevé, il reste inconclusif et n'ouvre aucun droit d'emploi.
+  if (points.length === 0) {
+    return {
+      verdict: "INCONCLU",
+      points,
+      counts,
+      explanation:
+        params.operationType === "AJUSTAGE" || params.operationType === "REPARATION"
+          ? "Intervention technique sans relevé : une requalification est nécessaire avant remise en service."
+          : "Aucun relevé saisi : l'exécution ne peut pas conclure.",
+    };
+  }
+
+  const minPoints = params.criteria.min_points;
+  if (minPoints !== null && points.length < minPoints) {
+    return {
+      verdict: "INCONCLU",
+      points,
+      counts,
+      explanation: `Procédure incomplète : ${points.length} point(s) relevé(s) pour ${minPoints} attendu(s).`,
+    };
+  }
+
+  if (counts.non_conforme > 0) {
+    return {
+      verdict: "NON_CONFORME",
+      points,
+      counts,
+      explanation: `${counts.non_conforme} point(s) hors tolérance sur ${counts.total}.`,
+    };
+  }
+
+  if (counts.inconclu > 0) {
+    return {
+      verdict: "INCONCLU",
+      points,
+      counts,
+      explanation: `${counts.inconclu} point(s) non jugeable(s) sur ${counts.total} : complétez le relevé ou le critère.`,
+    };
+  }
+
+  return {
+    verdict: "CONFORME",
+    points,
+    counts,
+    explanation: `${counts.conforme} point(s) dans la tolérance sur ${counts.total}.`,
+  };
+}
+
+function round(value: number): number {
+  return Math.round(value * 1e6) / 1e6;
+}

--- a/src/module/metrologie/middlewares/metrology-authorization.middleware.ts
+++ b/src/module/metrologie/middlewares/metrology-authorization.middleware.ts
@@ -1,0 +1,30 @@
+import type { RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import { roleHasMetrologyCapability, type MetrologyCapability } from "../domain/metrology-policy";
+
+/**
+ * Garde de capacité Métrologie (#229). Refus par défaut : un utilisateur
+ * authentifié n'obtient aucun droit implicite. Masquer un bouton côté UI n'est
+ * jamais une autorisation ; cette garde est rejouée à chaque requête, et le
+ * domaine la revérifie pour les règles qui dépendent de l'objet manipulé.
+ */
+export function requireMetrologyCapability(capability: MetrologyCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (!req.user || typeof req.user.id !== "number") {
+      next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
+      return;
+    }
+    if (!roleHasMetrologyCapability(req.user.role, capability)) {
+      next(
+        new HttpError(
+          403,
+          "METROLOGY_CAPABILITY_REQUIRED",
+          `La capacité Métrologie '${capability}' est requise.`
+        )
+      );
+      return;
+    }
+    next();
+  };
+}

--- a/src/module/metrologie/repository/metrologie.repository.ts
+++ b/src/module/metrologie/repository/metrologie.repository.ts
@@ -571,7 +571,8 @@ function mapCertRow(r: CertRow): MetrologieCertificat {
     organisme: r.organisme,
     commentaire: r.commentaire,
     file_original_name: r.file_original_name,
-    storage_path: r.storage_path,
+    // Le chemin de stockage reste strictement interne (#229).
+    has_file: r.storage_path !== null && r.storage_path !== undefined,
     mime_type: r.mime_type,
     size_bytes: r.size_bytes !== null && r.size_bytes !== undefined ? Number(r.size_bytes) : null,
     sha256: r.sha256,
@@ -1498,7 +1499,7 @@ export async function repoGetCertificatForDownload(params: {
   equipement_id: string;
   certificat_id: string;
   audit: AuditContext;
-}): Promise<Pick<MetrologieCertificat, "storage_path" | "mime_type" | "file_original_name"> | null> {
+}): Promise<{ storage_path: string | null; mime_type: string | null; file_original_name: string | null } | null> {
   const { equipement_id, certificat_id, audit } = params;
   const client = await pool.connect();
   try {

--- a/src/module/metrologie/repository/metrology-execution.repository.ts
+++ b/src/module/metrologie/repository/metrology-execution.repository.ts
@@ -1,0 +1,1679 @@
+// Exécutions métrologiques et preuves documentaires (#229).
+//
+// La transaction « hors tolérance » vit ici : verrouillage, événement
+// append-only, quarantaine de l'instrument, analyse d'impact bornée, audit —
+// le tout dans UN SEUL commit. Un échec ne laisse ni double certificat, ni
+// double quarantaine, ni double dossier d'impact.
+
+import crypto from "node:crypto";
+import { createReadStream } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import type { PoolClient } from "pg";
+
+import { generateMetrologieExecutionCode } from "../../../shared/codes/code-generator.service";
+import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
+import { HttpError } from "../../../utils/httpError";
+
+import {
+  assertExecutionMutable,
+  assertExecutionTransition,
+  assertManualVerdictOverride,
+  assertOptimisticVersion,
+  assertPlanSelectableForExecution,
+  assertVerdictSeparation,
+  metrologySha256,
+  verdictIsAdmissibleProof,
+  verdictToLegacyCertificatResult,
+  verdictTriggersQuarantine,
+  type MetrologyOperationType,
+  type MetrologyVerdict,
+} from "../domain/metrology-policy";
+import {
+  assertScheduleOverrideAllowed,
+  computeNextDueDate,
+  type PeriodicityUnit,
+} from "../domain/metrology-schedule";
+import { computeExecutionVerdict, type MeasurementInput } from "../domain/metrology-verdict";
+import type {
+  CancelCertificateBodyDTO,
+  CancelExecutionBodyDTO,
+  CreateExecutionBodyDTO,
+  ListExecutionsQueryDTO,
+  RecordMeasurementsBodyDTO,
+  UploadCertificateBodyDTO,
+  ValidateExecutionBodyDTO,
+} from "../validators/metrology-360.validators";
+import type {
+  MetrologyCertificateDTO,
+  MetrologyExecutionDTO,
+  MetrologyExecutionListItemDTO,
+  MetrologyVerdictPreviewDTO,
+  Paginated,
+  UserRef,
+} from "../types/metrology-360.types";
+import {
+  acquireIdempotency,
+  db,
+  insertAuditLog,
+  insertMetrologyEvent,
+  isRecord,
+  rethrowMapped,
+  saveReceipt,
+  sortDirection,
+  toInt,
+  toNumber,
+  withTransaction,
+  type MetrologyActor,
+} from "./metrology-shared.repository";
+import { monthsFromPeriodicity, syncLegacyPlan } from "./metrology-registry.repository";
+import { openImpactDossier } from "./metrology-impact.repository";
+
+function mapUserRef(row: {
+  id: number | null;
+  username: string | null;
+  name: string | null;
+  surname: string | null;
+}): UserRef | null {
+  if (!row.id || !row.username) return null;
+  const parts = [row.surname ?? "", row.name ?? ""].map((s) => s.trim()).filter(Boolean);
+  return { id: row.id, username: row.username, label: parts.join(" ").trim() || row.username };
+}
+
+/* ========================================================================== */
+/* Chargement                                                                 */
+/* ========================================================================== */
+
+type ExecutionLock = {
+  id: string;
+  code: string;
+  equipement_id: string;
+  operation_type: MetrologyOperationType;
+  status: "DRAFT" | "IN_PROGRESS" | "VALIDATED" | "CANCELLED";
+  plan_version_id: string | null;
+  operator_user_id: number | null;
+  started_at: string;
+  updated_at: string;
+};
+
+async function lockExecution(client: PoolClient, id: string): Promise<ExecutionLock> {
+  const res = await client.query<ExecutionLock>(
+    `
+      SELECT id::text AS id, code, equipement_id::text AS equipement_id, operation_type, status,
+             plan_version_id::text AS plan_version_id, operator_user_id,
+             started_at::text AS started_at, updated_at::text AS updated_at
+      FROM public.metrologie_execution
+      WHERE id = $1::uuid
+      FOR UPDATE
+    `,
+    [id]
+  );
+  const row = res.rows[0] ?? null;
+  if (!row) throw new HttpError(404, "NOT_FOUND", "Exécution métrologique introuvable.");
+  return row;
+}
+
+type PlanContext = {
+  id: string;
+  version: number;
+  status: "DRAFT" | "ACTIVE" | "ARCHIVED";
+  operation_type: "ETALONNAGE" | "VERIFICATION";
+  tolerance_min: number | null;
+  tolerance_max: number | null;
+  unite: string | null;
+  min_points: number | null;
+  periodicite_valeur: number;
+  periodicite_unite: PeriodicityUnit;
+  base_calcul: "LAST_PROOF" | "FIXED_DATE";
+  alert_window_days: number;
+  effective_from: string | null;
+  exige_certificat: boolean;
+  criticite: "NORMAL" | "CRITIQUE";
+  role_habilite: string | null;
+};
+
+async function loadPlanContext(
+  q: Pick<PoolClient, "query">,
+  planVersionId: string,
+  equipementId: string
+): Promise<PlanContext> {
+  const res = await q.query<Record<string, unknown>>(
+    `
+      SELECT id::text AS id, version, status, operation_type,
+             tolerance_min::text AS tolerance_min, tolerance_max::text AS tolerance_max,
+             unite, criteres, periodicite_valeur, periodicite_unite, base_calcul,
+             alert_window_days, effective_from::text AS effective_from,
+             exige_certificat, criticite, role_habilite
+      FROM public.metrologie_plan_version
+      WHERE id = $1::uuid AND equipement_id = $2::uuid
+    `,
+    [planVersionId, equipementId]
+  );
+  const row = res.rows[0] ?? null;
+  if (!row) throw new HttpError(404, "NOT_FOUND", "Version de plan introuvable pour cet équipement.");
+  const criteres = isRecord(row.criteres) ? row.criteres : {};
+  return {
+    id: String(row.id),
+    version: toInt(row.version, 1),
+    status: row.status as PlanContext["status"],
+    operation_type: row.operation_type as PlanContext["operation_type"],
+    tolerance_min: toNumber(row.tolerance_min),
+    tolerance_max: toNumber(row.tolerance_max),
+    unite: (row.unite ?? null) as string | null,
+    min_points: toNumber(criteres.min_points),
+    periodicite_valeur: toInt(row.periodicite_valeur, 12),
+    periodicite_unite: row.periodicite_unite as PeriodicityUnit,
+    base_calcul: row.base_calcul as PlanContext["base_calcul"],
+    alert_window_days: toInt(row.alert_window_days, 30),
+    effective_from: (row.effective_from ?? null) as string | null,
+    exige_certificat: row.exige_certificat === true,
+    criticite: row.criticite as PlanContext["criticite"],
+    role_habilite: (row.role_habilite ?? null) as string | null,
+  };
+}
+
+async function loadMeasurements(
+  q: Pick<PoolClient, "query">,
+  executionId: string
+): Promise<MeasurementInput[]> {
+  const res = await q.query<Record<string, unknown>>(
+    `
+      SELECT point_key, sample_no, nominal::text AS nominal,
+             tolerance_min::text AS tolerance_min, tolerance_max::text AS tolerance_max,
+             measured::text AS measured, unite, incertitude::text AS incertitude
+      FROM public.metrologie_execution_measurement
+      WHERE execution_id = $1::uuid
+      ORDER BY point_key, sample_no
+    `,
+    [executionId]
+  );
+  return res.rows.map((row) => ({
+    point_key: String(row.point_key),
+    sample_no: toInt(row.sample_no, 1),
+    nominal: toNumber(row.nominal),
+    tolerance_min: toNumber(row.tolerance_min),
+    tolerance_max: toNumber(row.tolerance_max),
+    measured: toNumber(row.measured),
+    unite: (row.unite ?? null) as string | null,
+    incertitude: toNumber(row.incertitude),
+  }));
+}
+
+/* ========================================================================== */
+/* Création et saisie                                                         */
+/* ========================================================================== */
+
+export async function repoCreateExecution(params: {
+  equipementId: string;
+  body: CreateExecutionBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyExecutionDTO> {
+  const { equipementId, body, actor } = params;
+  const executionId = await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.execution.create",
+      requestPayload: { equipementId, ...body },
+    });
+    if (claim.replay && typeof claim.replay.id === "string") return claim.replay.id;
+
+    const equip = await client.query<{ id: string; etat: string; designation: string }>(
+      `SELECT id::text AS id, etat, designation FROM public.metrologie_equipements
+        WHERE id = $1::uuid AND deleted_at IS NULL FOR UPDATE`,
+      [equipementId]
+    );
+    if (!equip.rows[0]) throw new HttpError(404, "NOT_FOUND", "Équipement introuvable.");
+    if (equip.rows[0].etat === "RETIRED") {
+      throw new HttpError(
+        409,
+        "METROLOGY_EQUIPMENT_RETIRED",
+        "Un équipement retiré ne reçoit plus d'étalonnage ni de vérification."
+      );
+    }
+
+    let planVersion: number | null = null;
+    if (body.plan_version_id) {
+      const plan = await loadPlanContext(client, body.plan_version_id, equipementId);
+      assertPlanSelectableForExecution(plan.status);
+      if (plan.operation_type !== body.operation_type && body.operation_type !== "AJUSTAGE" && body.operation_type !== "REPARATION") {
+        throw new HttpError(
+          422,
+          "METROLOGY_PLAN_OPERATION_MISMATCH",
+          `Cette version de plan couvre ${plan.operation_type}, pas ${body.operation_type}.`
+        );
+      }
+      planVersion = plan.version;
+    }
+
+    const code = await generateMetrologieExecutionCode(client, {
+      date: body.started_at ? new Date(body.started_at) : new Date(),
+    });
+
+    let newId: string;
+    try {
+      const ins = await client.query<{ id: string }>(
+        `
+          INSERT INTO public.metrologie_execution (
+            code, equipement_id, plan_version_id, plan_version, operation_type, status,
+            started_at, operator_user_id, provider_label, fournisseur_id,
+            methode, procedure_ref, etalon_reference, environnement, observations,
+            correlation_id, created_by, updated_by
+          )
+          VALUES (
+            $1,$2::uuid,$3::uuid,$4,$5,'IN_PROGRESS',
+            COALESCE($6::timestamptz, now()),$7,$8,$9::uuid,
+            $10,$11,$12,$13::jsonb,$14,
+            $15::uuid,$16,$16
+          )
+          RETURNING id::text AS id
+        `,
+        [
+          code,
+          equipementId,
+          body.plan_version_id ?? null,
+          planVersion,
+          body.operation_type,
+          body.started_at ?? null,
+          body.operator_user_id ?? actor.user_id,
+          body.provider_label,
+          body.fournisseur_id ?? null,
+          body.methode,
+          body.procedure_ref,
+          body.etalon_reference,
+          JSON.stringify(body.environnement ?? {}),
+          body.observations,
+          crypto.randomUUID(),
+          actor.user_id,
+        ]
+      );
+      newId = ins.rows[0]?.id ?? "";
+    } catch (err) {
+      rethrowMapped(err);
+    }
+    if (!newId) throw new HttpError(500, "METROLOGY_EXECUTION_CREATE_FAILED", "Création impossible.");
+
+    const correlationId = crypto.randomUUID();
+    await insertMetrologyEvent(client, {
+      equipement_id: equipementId,
+      entity_type: "EXECUTION",
+      entity_id: newId,
+      event_type: "EXECUTION_OPENED",
+      actor,
+      old_values: null,
+      new_values: { code, operation_type: body.operation_type, plan_version_id: body.plan_version_id ?? null },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.executions.create",
+      entity_type: "metrologie_execution",
+      entity_id: newId,
+      details: { code, equipement_id: equipementId, operation_type: body.operation_type },
+    });
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.execution.create",
+      aggregateType: "EXECUTION",
+      aggregateId: newId,
+      requestPayload: { equipementId, ...body },
+      resultPayload: { id: newId, code },
+      correlationId,
+    });
+    return newId;
+  });
+
+  const detail = await repoGetExecution(executionId);
+  if (!detail) throw new HttpError(500, "METROLOGY_EXECUTION_RELOAD_FAILED", "Exécution introuvable après création.");
+  return detail;
+}
+
+export async function repoRecordMeasurements(params: {
+  executionId: string;
+  body: RecordMeasurementsBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyExecutionDTO> {
+  const { executionId, body, actor } = params;
+  await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.execution.measurements",
+      requestPayload: { executionId, ...body },
+    });
+    if (claim.replay) return;
+
+    const execution = await lockExecution(client, executionId);
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: execution.updated_at,
+    });
+    assertExecutionMutable(execution.status);
+
+    for (const measurement of body.measurements) {
+      const existing = await client.query<{
+        id: string;
+        revision: number;
+        nominal: string | null;
+        tolerance_min: string | null;
+        tolerance_max: string | null;
+        measured: string | null;
+        unite: string | null;
+      }>(
+        `
+          SELECT id::text AS id, revision, nominal::text AS nominal,
+                 tolerance_min::text AS tolerance_min, tolerance_max::text AS tolerance_max,
+                 measured::text AS measured, unite
+          FROM public.metrologie_execution_measurement
+          WHERE execution_id = $1::uuid AND point_key = $2 AND sample_no = $3
+          FOR UPDATE
+        `,
+        [executionId, measurement.point_key, measurement.sample_no]
+      );
+      const current = existing.rows[0] ?? null;
+
+      if (current) {
+        // Corriger un relevé déjà saisi exige un motif : on empile une révision
+        // append-only, on n'écrase jamais silencieusement une valeur mesurée.
+        if (!measurement.revision_reason) {
+          throw new HttpError(
+            422,
+            "METROLOGY_MEASUREMENT_REVISION_REASON_REQUIRED",
+            `Corriger le point ${measurement.point_key} (échantillon ${measurement.sample_no}) exige un motif.`,
+            { fields: { revision_reason: ["Motif de correction obligatoire."] } }
+          );
+        }
+        await client.query(
+          `
+            INSERT INTO public.metrologie_measurement_revision (
+              measurement_id, revision, previous_values, reason, created_by
+            )
+            VALUES ($1::uuid, $2, $3::jsonb, $4, $5)
+          `,
+          [
+            current.id,
+            current.revision,
+            JSON.stringify({
+              nominal: current.nominal,
+              tolerance_min: current.tolerance_min,
+              tolerance_max: current.tolerance_max,
+              measured: current.measured,
+              unite: current.unite,
+            }),
+            measurement.revision_reason,
+            actor.user_id,
+          ]
+        );
+        await client.query(
+          `
+            UPDATE public.metrologie_execution_measurement
+            SET label = $2, nominal = $3, tolerance_min = $4, tolerance_max = $5,
+                measured = $6, unite = $7, incertitude = $8, comment = $9,
+                revision = revision + 1, updated_at = now(), updated_by = $10
+            WHERE id = $1::uuid
+          `,
+          [
+            current.id,
+            measurement.label,
+            measurement.nominal,
+            measurement.tolerance_min,
+            measurement.tolerance_max,
+            measurement.measured,
+            measurement.unite,
+            measurement.incertitude,
+            measurement.comment,
+            actor.user_id,
+          ]
+        );
+        continue;
+      }
+
+      await client.query(
+        `
+          INSERT INTO public.metrologie_execution_measurement (
+            execution_id, point_key, sample_no, label, nominal,
+            tolerance_min, tolerance_max, measured, unite, incertitude, comment,
+            created_by, updated_by
+          )
+          VALUES ($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$12)
+        `,
+        [
+          executionId,
+          measurement.point_key,
+          measurement.sample_no,
+          measurement.label,
+          measurement.nominal,
+          measurement.tolerance_min,
+          measurement.tolerance_max,
+          measurement.measured,
+          measurement.unite,
+          measurement.incertitude,
+          measurement.comment,
+          actor.user_id,
+        ]
+      );
+    }
+
+    // Verdict recalculé et écart persistés à chaque saisie : la liste des
+    // points affichée vient du serveur, jamais d'un calcul navigateur.
+    await refreshMeasurementVerdicts(client, executionId, execution.plan_version_id, execution.equipement_id);
+
+    await client.query(
+      `UPDATE public.metrologie_execution SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`,
+      [executionId, actor.user_id]
+    );
+
+    const correlationId = crypto.randomUUID();
+    await insertMetrologyEvent(client, {
+      equipement_id: execution.equipement_id,
+      entity_type: "EXECUTION",
+      entity_id: executionId,
+      event_type: "EXECUTION_MEASUREMENTS_RECORDED",
+      actor,
+      old_values: null,
+      new_values: { points: body.measurements.length },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+    });
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.execution.measurements",
+      aggregateType: "EXECUTION",
+      aggregateId: executionId,
+      requestPayload: { executionId, ...body },
+      resultPayload: { id: executionId, points: body.measurements.length },
+      correlationId,
+    });
+  });
+
+  const detail = await repoGetExecution(executionId);
+  if (!detail) throw new HttpError(404, "NOT_FOUND", "Exécution introuvable.");
+  return detail;
+}
+
+async function refreshMeasurementVerdicts(
+  client: PoolClient,
+  executionId: string,
+  planVersionId: string | null,
+  equipementId: string
+): Promise<void> {
+  const plan = planVersionId ? await loadPlanContext(client, planVersionId, equipementId) : null;
+  const measurements = await loadMeasurements(client, executionId);
+  const computation = computeExecutionVerdict({
+    operationType: "ETALONNAGE",
+    measurements,
+    criteria: {
+      tolerance_min: plan?.tolerance_min ?? null,
+      tolerance_max: plan?.tolerance_max ?? null,
+      unite: plan?.unite ?? null,
+      min_points: plan?.min_points ?? null,
+    },
+  });
+
+  for (const point of computation.points) {
+    await client.query(
+      `
+        UPDATE public.metrologie_execution_measurement
+        SET verdict = $3, ecart = $4, updated_at = now()
+        WHERE execution_id = $1::uuid AND point_key = $2 AND sample_no = $5
+      `,
+      [executionId, point.point_key, point.verdict, point.ecart, point.sample_no]
+    );
+  }
+}
+
+/* ========================================================================== */
+/* Aperçu du verdict                                                          */
+/* ========================================================================== */
+
+export async function repoPreviewVerdict(
+  executionId: string
+): Promise<MetrologyVerdictPreviewDTO> {
+  const execRes = await db().query<Record<string, unknown>>(
+    `
+      SELECT x.id::text AS id, x.equipement_id::text AS equipement_id, x.operation_type,
+             x.plan_version_id::text AS plan_version_id, x.status,
+             e.created_at::text AS equipement_created_at,
+             e.date_mise_en_service::text AS date_mise_en_service
+      FROM public.metrologie_execution x
+      JOIN public.metrologie_equipements e ON e.id = x.equipement_id
+      WHERE x.id = $1::uuid
+    `,
+    [executionId]
+  );
+  const execution = execRes.rows[0] ?? null;
+  if (!execution) throw new HttpError(404, "NOT_FOUND", "Exécution introuvable.");
+
+  const planVersionId = (execution.plan_version_id ?? null) as string | null;
+  const plan = planVersionId
+    ? await loadPlanContext(db(), planVersionId, String(execution.equipement_id))
+    : null;
+  const measurements = await loadMeasurements(db(), executionId);
+
+  const computation = computeExecutionVerdict({
+    operationType: execution.operation_type as MetrologyOperationType,
+    measurements,
+    criteria: {
+      tolerance_min: plan?.tolerance_min ?? null,
+      tolerance_max: plan?.tolerance_max ?? null,
+      unite: plan?.unite ?? null,
+      min_points: plan?.min_points ?? null,
+    },
+  });
+
+  const today = new Date().toISOString().slice(0, 10);
+  const schedule = plan
+    ? computeNextDueDate({
+        plan: {
+          periodicite_valeur: plan.periodicite_valeur,
+          periodicite_unite: plan.periodicite_unite,
+          base_calcul: plan.base_calcul,
+          alert_window_days: plan.alert_window_days,
+          effective_from: plan.effective_from,
+        },
+        lastProofDate: verdictIsAdmissibleProof(computation.verdict) ? today : null,
+        fallbackDate:
+          (execution.date_mise_en_service as string | null) ??
+          String(execution.equipement_created_at).slice(0, 10),
+      })
+    : { next_due_date: null, source: "NONE" as const, base_date: null };
+
+  // Les effets réels sont annoncés AVANT confirmation : aucune surprise après
+  // le clic, et aucune action implicite sur les autres modules.
+  const effects: string[] = [];
+  if (verdictIsAdmissibleProof(computation.verdict)) {
+    effects.push("La preuve devient la dernière preuve conforme de l'instrument.");
+    if (schedule.next_due_date) {
+      effects.push(`La prochaine échéance est fixée au ${schedule.next_due_date}.`);
+    }
+    effects.push("L'instrument redevient sélectionnable pour les contrôles compatibles.");
+  }
+  if (verdictTriggersQuarantine(computation.verdict)) {
+    effects.push("L'instrument passe en quarantaine : plus aucune nouvelle mesure ne l'acceptera.");
+    effects.push(
+      "Un dossier d'analyse d'impact est ouvert sur la période depuis la dernière preuve conforme."
+    );
+    effects.push(
+      "Aucun contrôle n'est annulé, aucun lot n'est déstocké, aucun BL n'est annulé : chaque usage devra être décidé à la main."
+    );
+  }
+  if (computation.verdict === "INCONCLU") {
+    effects.push("Aucune preuve d'aptitude n'est produite : l'échéance en cours reste inchangée.");
+  }
+  if (computation.verdict === "CONFORME_AVEC_RESTRICTION") {
+    effects.push("La restriction saisie sera affichée à chaque sélection de l'instrument.");
+  }
+
+  const preview = {
+    execution_id: executionId,
+    verdict_computed: computation.verdict,
+    explanation: computation.explanation,
+    counts: computation.counts,
+    points: computation.points,
+    next_due_date: schedule.next_due_date,
+    next_due_source: schedule.source,
+    effects,
+  };
+
+  return { ...preview, preview_hash: metrologySha256(preview) };
+}
+
+/* ========================================================================== */
+/* Validation : la transaction « hors tolérance »                             */
+/* ========================================================================== */
+
+export async function repoValidateExecution(params: {
+  executionId: string;
+  body: ValidateExecutionBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<{ execution: MetrologyExecutionDTO; impact_dossier_id: string | null }> {
+  const { executionId, body, actor } = params;
+
+  const outcome = await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.execution.validate",
+      requestPayload: { executionId, ...body },
+    });
+    if (claim.replay) {
+      return {
+        impactDossierId: (claim.replay.impact_dossier_id ?? null) as string | null,
+        replayed: true,
+      };
+    }
+
+    // 1) Verrouiller équipement, plan et exécution ; vérifier version.
+    const execution = await lockExecution(client, executionId);
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: execution.updated_at,
+    });
+    assertExecutionTransition(execution.status, "VALIDATED");
+
+    const equipRes = await client.query<{
+      id: string;
+      etat: string;
+      criticite: string;
+      created_at: string;
+      date_mise_en_service: string | null;
+    }>(
+      `SELECT id::text AS id, etat, criticite, created_at::text AS created_at,
+              date_mise_en_service::text AS date_mise_en_service
+         FROM public.metrologie_equipements WHERE id = $1::uuid FOR UPDATE`,
+      [execution.equipement_id]
+    );
+    const equipment = equipRes.rows[0];
+    if (!equipment) throw new HttpError(404, "NOT_FOUND", "Équipement introuvable.");
+
+    const plan = execution.plan_version_id
+      ? await loadPlanContext(client, execution.plan_version_id, execution.equipement_id)
+      : null;
+    if (plan) {
+      await client.query(`SELECT 1 FROM public.metrologie_plan_version WHERE id = $1::uuid FOR UPDATE`, [
+        plan.id,
+      ]);
+    }
+
+    // 2) Séparation des tâches et fraîcheur de l'aperçu.
+    assertVerdictSeparation({
+      operatorUserId: execution.operator_user_id,
+      validatorUserId: actor.user_id,
+      operationType: execution.operation_type,
+    });
+
+    const preview = await repoPreviewVerdictInTx(client, executionId);
+    if (preview.preview_hash !== body.preview_hash) {
+      throw new HttpError(
+        409,
+        "METROLOGY_PREVIEW_STALE",
+        "L'aperçu n'est plus à jour : rechargez-le avant de confirmer le verdict."
+      );
+    }
+
+    const evidenceRes = await client.query<{ total: string }>(
+      `SELECT COUNT(*)::text AS total FROM public.metrologie_certificats
+        WHERE execution_id = $1::uuid AND deleted_at IS NULL AND statut = 'VALIDE'`,
+      [executionId]
+    );
+    const evidenceCount = toInt(evidenceRes.rows[0]?.total, 0);
+
+    assertManualVerdictOverride({
+      computed: preview.verdict_computed,
+      requested: body.verdict,
+      justification: body.verdict_justification,
+      evidenceCount,
+      requireEvidence: true,
+    });
+
+    if (plan?.exige_certificat && verdictIsAdmissibleProof(body.verdict) && evidenceCount === 0) {
+      throw new HttpError(
+        422,
+        "METROLOGY_CERTIFICATE_REQUIRED",
+        "Ce plan exige un certificat ou un PV valide avant de conclure à la conformité."
+      );
+    }
+
+    // 3) Échéance : calculée serveur, dérogation possible mais approuvée.
+    let nextDueDate = preview.next_due_date;
+    if (body.override_next_due_date) {
+      assertScheduleOverrideAllowed({
+        requestedDueDate: body.override_next_due_date,
+        computedDueDate: preview.next_due_date,
+        reason: body.override_reason,
+        approvedByUserId: body.override_approved_by,
+        requestedByUserId: actor.user_id,
+      });
+      nextDueDate = body.override_next_due_date;
+    }
+
+    // 4) Figer l'exécution.
+    await client.query(
+      `
+        UPDATE public.metrologie_execution
+        SET status = 'VALIDATED',
+            ended_at = COALESCE($2::timestamptz, now()),
+            verdict_computed = $3,
+            verdict = $4,
+            verdict_justification = $5,
+            restriction = $6,
+            decision = $7,
+            decision_reason = $8,
+            decided_by = $9,
+            decided_at = now(),
+            next_due_date = $10::date,
+            updated_at = now(),
+            updated_by = $9
+        WHERE id = $1::uuid
+      `,
+      [
+        executionId,
+        body.ended_at ?? null,
+        preview.verdict_computed,
+        body.verdict,
+        body.verdict_justification,
+        body.restriction,
+        body.decision,
+        body.decision_reason,
+        actor.user_id,
+        nextDueDate,
+      ]
+    );
+
+    const correlationId = crypto.randomUUID();
+    let impactDossierId: string | null = null;
+
+    if (verdictIsAdmissibleProof(body.verdict)) {
+      const proofDate = (body.ended_at ?? new Date().toISOString()).slice(0, 10);
+      if (plan) {
+        await client.query(
+          `
+            UPDATE public.metrologie_plan_version
+            SET last_proof_execution_id = $2::uuid, last_proof_date = $3::date,
+                next_due_date = $4::date, updated_at = now(), updated_by = $5
+            WHERE id = $1::uuid
+          `,
+          [plan.id, executionId, proofDate, nextDueDate, actor.user_id]
+        );
+        await syncLegacyPlan(client, {
+          equipementId: execution.equipement_id,
+          actorId: actor.user_id,
+          periodiciteMois: monthsFromPeriodicity(plan.periodicite_valeur, plan.periodicite_unite),
+          lastDoneDate: proofDate,
+          nextDueDate,
+          statut: "EN_COURS",
+        });
+      }
+
+      await client.query(
+        `
+          UPDATE public.metrologie_equipements
+          SET last_conforme_execution_id = $2::uuid, last_conforme_at = COALESCE($3::timestamptz, now()),
+              updated_at = now(), updated_by = $4
+          WHERE id = $1::uuid
+        `,
+        [execution.equipement_id, executionId, body.ended_at ?? null, actor.user_id]
+      );
+
+      // Une preuve conforme ne libère PAS automatiquement un instrument en
+      // quarantaine : la remise en service reste un acte humain habilité.
+      if (body.decision === "REMISE_EN_SERVICE" && equipment.etat === "ACTIVE") {
+        await client.query(
+          `UPDATE public.metrologie_equipements
+             SET etat = 'QUALIFIED', etat_motif = $2, etat_changed_at = now(), etat_changed_by = $3,
+                 updated_at = now(), updated_by = $3
+           WHERE id = $1::uuid`,
+          [execution.equipement_id, body.decision_reason, actor.user_id]
+        );
+      }
+    }
+
+    // 5) Hors tolérance : quarantaine ciblée + analyse d'impact bornée.
+    if (verdictTriggersQuarantine(body.verdict)) {
+      await client.query(
+        `
+          UPDATE public.metrologie_equipements
+          SET etat = 'OUT_OF_TOLERANCE',
+              etat_motif = $2, etat_changed_at = now(), etat_changed_by = $3,
+              quarantine_reason = $2, quarantined_at = now(), quarantined_by = $3,
+              updated_at = now(), updated_by = $3
+          WHERE id = $1::uuid
+        `,
+        [execution.equipement_id, body.decision_reason, actor.user_id]
+      );
+
+      if (plan) {
+        await syncLegacyPlan(client, {
+          equipementId: execution.equipement_id,
+          actorId: actor.user_id,
+          periodiciteMois: monthsFromPeriodicity(plan.periodicite_valeur, plan.periodicite_unite),
+          lastDoneDate: null,
+          nextDueDate: null,
+          statut: "HORS_TOLERANCE",
+        });
+      }
+
+      const dossier = await openImpactDossier(client, {
+        equipementId: execution.equipement_id,
+        executionId,
+        certificatId: null,
+        trigger: "VERDICT_NON_CONFORME",
+        actor,
+        correlationId,
+        approvedWindow: null,
+        exclusions: null,
+        ownerUserId: null,
+      });
+      impactDossierId = dossier.id;
+    }
+
+    // 6) Journal, audit et reçu — même commit.
+    await insertMetrologyEvent(client, {
+      equipement_id: execution.equipement_id,
+      entity_type: "EXECUTION",
+      entity_id: executionId,
+      event_type: "EXECUTION_VALIDATED",
+      actor,
+      old_values: { status: execution.status },
+      new_values: {
+        verdict_computed: preview.verdict_computed,
+        verdict: body.verdict,
+        decision: body.decision,
+        next_due_date: nextDueDate,
+        impact_dossier_id: impactDossierId,
+      },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+      rule_code: preview.verdict_computed === body.verdict ? "VERDICT_COMPUTED" : "VERDICT_OVERRIDDEN",
+      reason: body.decision_reason,
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.executions.validate",
+      entity_type: "metrologie_execution",
+      entity_id: executionId,
+      details: {
+        code: execution.code,
+        verdict: body.verdict,
+        verdict_computed: preview.verdict_computed,
+        decision: body.decision,
+        impact_dossier_id: impactDossierId,
+      },
+    });
+
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.execution.validate",
+      aggregateType: "EXECUTION",
+      aggregateId: executionId,
+      requestPayload: { executionId, ...body },
+      resultPayload: { id: executionId, verdict: body.verdict, impact_dossier_id: impactDossierId },
+      correlationId,
+    });
+
+    return { impactDossierId, replayed: false };
+  });
+
+  const detail = await repoGetExecution(executionId);
+  if (!detail) throw new HttpError(404, "NOT_FOUND", "Exécution introuvable.");
+  return { execution: detail, impact_dossier_id: outcome.impactDossierId };
+}
+
+/** Version transactionnelle de l'aperçu, pour comparer l'empreinte sous verrou. */
+async function repoPreviewVerdictInTx(
+  client: PoolClient,
+  executionId: string
+): Promise<MetrologyVerdictPreviewDTO> {
+  const execRes = await client.query<Record<string, unknown>>(
+    `
+      SELECT x.id::text AS id, x.equipement_id::text AS equipement_id, x.operation_type,
+             x.plan_version_id::text AS plan_version_id,
+             e.created_at::text AS equipement_created_at,
+             e.date_mise_en_service::text AS date_mise_en_service
+      FROM public.metrologie_execution x
+      JOIN public.metrologie_equipements e ON e.id = x.equipement_id
+      WHERE x.id = $1::uuid
+    `,
+    [executionId]
+  );
+  const execution = execRes.rows[0];
+  if (!execution) throw new HttpError(404, "NOT_FOUND", "Exécution introuvable.");
+
+  const planVersionId = (execution.plan_version_id ?? null) as string | null;
+  const plan = planVersionId
+    ? await loadPlanContext(client, planVersionId, String(execution.equipement_id))
+    : null;
+  const measurements = await loadMeasurements(client, executionId);
+
+  const computation = computeExecutionVerdict({
+    operationType: execution.operation_type as MetrologyOperationType,
+    measurements,
+    criteria: {
+      tolerance_min: plan?.tolerance_min ?? null,
+      tolerance_max: plan?.tolerance_max ?? null,
+      unite: plan?.unite ?? null,
+      min_points: plan?.min_points ?? null,
+    },
+  });
+
+  const today = new Date().toISOString().slice(0, 10);
+  const schedule = plan
+    ? computeNextDueDate({
+        plan: {
+          periodicite_valeur: plan.periodicite_valeur,
+          periodicite_unite: plan.periodicite_unite,
+          base_calcul: plan.base_calcul,
+          alert_window_days: plan.alert_window_days,
+          effective_from: plan.effective_from,
+        },
+        lastProofDate: verdictIsAdmissibleProof(computation.verdict) ? today : null,
+        fallbackDate:
+          (execution.date_mise_en_service as string | null) ??
+          String(execution.equipement_created_at).slice(0, 10),
+      })
+    : { next_due_date: null, source: "NONE" as const, base_date: null };
+
+  const effects: string[] = [];
+  if (verdictIsAdmissibleProof(computation.verdict)) {
+    effects.push("La preuve devient la dernière preuve conforme de l'instrument.");
+    if (schedule.next_due_date) effects.push(`La prochaine échéance est fixée au ${schedule.next_due_date}.`);
+    effects.push("L'instrument redevient sélectionnable pour les contrôles compatibles.");
+  }
+  if (verdictTriggersQuarantine(computation.verdict)) {
+    effects.push("L'instrument passe en quarantaine : plus aucune nouvelle mesure ne l'acceptera.");
+    effects.push(
+      "Un dossier d'analyse d'impact est ouvert sur la période depuis la dernière preuve conforme."
+    );
+    effects.push(
+      "Aucun contrôle n'est annulé, aucun lot n'est déstocké, aucun BL n'est annulé : chaque usage devra être décidé à la main."
+    );
+  }
+  if (computation.verdict === "INCONCLU") {
+    effects.push("Aucune preuve d'aptitude n'est produite : l'échéance en cours reste inchangée.");
+  }
+  if (computation.verdict === "CONFORME_AVEC_RESTRICTION") {
+    effects.push("La restriction saisie sera affichée à chaque sélection de l'instrument.");
+  }
+
+  const preview = {
+    execution_id: executionId,
+    verdict_computed: computation.verdict,
+    explanation: computation.explanation,
+    counts: computation.counts,
+    points: computation.points,
+    next_due_date: schedule.next_due_date,
+    next_due_source: schedule.source,
+    effects,
+  };
+  return { ...preview, preview_hash: metrologySha256(preview) };
+}
+
+export async function repoCancelExecution(params: {
+  executionId: string;
+  body: CancelExecutionBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyExecutionDTO> {
+  const { executionId, body, actor } = params;
+  await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.execution.cancel",
+      requestPayload: { executionId, ...body },
+    });
+    if (claim.replay) return;
+
+    const execution = await lockExecution(client, executionId);
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: execution.updated_at,
+    });
+    assertExecutionTransition(execution.status, "CANCELLED");
+
+    await client.query(
+      `
+        UPDATE public.metrologie_execution
+        SET status = 'CANCELLED', decision_reason = $2, updated_at = now(), updated_by = $3
+        WHERE id = $1::uuid
+      `,
+      [executionId, body.reason, actor.user_id]
+    );
+
+    const correlationId = crypto.randomUUID();
+    await insertMetrologyEvent(client, {
+      equipement_id: execution.equipement_id,
+      entity_type: "EXECUTION",
+      entity_id: executionId,
+      event_type: "EXECUTION_CANCELLED",
+      actor,
+      old_values: { status: execution.status },
+      new_values: { status: "CANCELLED" },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+      reason: body.reason,
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.executions.cancel",
+      entity_type: "metrologie_execution",
+      entity_id: executionId,
+      details: { reason: body.reason },
+    });
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.execution.cancel",
+      aggregateType: "EXECUTION",
+      aggregateId: executionId,
+      requestPayload: { executionId, ...body },
+      resultPayload: { id: executionId, status: "CANCELLED" },
+      correlationId,
+    });
+  });
+
+  const detail = await repoGetExecution(executionId);
+  if (!detail) throw new HttpError(404, "NOT_FOUND", "Exécution introuvable.");
+  return detail;
+}
+
+/* ========================================================================== */
+/* Lecture des exécutions                                                     */
+/* ========================================================================== */
+
+const EXECUTION_SELECT = `
+  SELECT
+    x.id::text AS id, x.code, x.equipement_id::text AS equipement_id,
+    x.plan_version_id::text AS plan_version_id, x.plan_version,
+    x.operation_type, x.status, x.verdict, x.verdict_computed, x.verdict_justification,
+    x.started_at::text AS started_at, x.ended_at::text AS ended_at,
+    x.provider_label, x.methode, x.procedure_ref, x.etalon_reference,
+    x.environnement, x.incertitude::text AS incertitude, x.observations,
+    x.decision, x.decision_reason, x.decided_at::text AS decided_at,
+    x.restriction, x.next_due_date::text AS next_due_date,
+    x.created_at::text AS created_at, x.updated_at::text AS updated_at,
+    ou.id AS operator_id, ou.username AS operator_username,
+    ou.name AS operator_name, ou.surname AS operator_surname,
+    du.id AS decided_by_id, du.username AS decided_by_username,
+    du.name AS decided_by_name, du.surname AS decided_by_surname,
+    (SELECT COUNT(*)::int FROM public.metrologie_certificats c
+      WHERE c.execution_id = x.id AND c.deleted_at IS NULL) AS certificate_count
+  FROM public.metrologie_execution x
+  LEFT JOIN public.users ou ON ou.id = x.operator_user_id
+  LEFT JOIN public.users du ON du.id = x.decided_by
+`;
+
+function mapExecutionListItem(row: Record<string, unknown>): MetrologyExecutionListItemDTO {
+  return {
+    id: String(row.id),
+    code: String(row.code),
+    equipement_id: String(row.equipement_id),
+    operation_type: row.operation_type as MetrologyOperationType,
+    status: row.status as MetrologyExecutionListItemDTO["status"],
+    verdict: (row.verdict ?? null) as MetrologyVerdict | null,
+    started_at: String(row.started_at),
+    ended_at: (row.ended_at ?? null) as string | null,
+    operator: mapUserRef({
+      id: (row.operator_id ?? null) as number | null,
+      username: (row.operator_username ?? null) as string | null,
+      name: (row.operator_name ?? null) as string | null,
+      surname: (row.operator_surname ?? null) as string | null,
+    }),
+    provider_label: (row.provider_label ?? null) as string | null,
+    next_due_date: (row.next_due_date ?? null) as string | null,
+    certificate_count: toInt(row.certificate_count, 0),
+    updated_at: String(row.updated_at),
+  };
+}
+
+export async function repoListExecutions(
+  query: ListExecutionsQueryDTO
+): Promise<Paginated<MetrologyExecutionListItemDTO>> {
+  const values: unknown[] = [];
+  const where: string[] = [];
+  const push = (v: unknown) => {
+    values.push(v);
+    return `$${values.length}`;
+  };
+  if (query.equipement_id) where.push(`x.equipement_id = ${push(query.equipement_id)}::uuid`);
+  if (query.operation_type) where.push(`x.operation_type = ${push(query.operation_type)}`);
+  if (query.status) where.push(`x.status = ${push(query.status)}`);
+  if (query.verdict) where.push(`x.verdict = ${push(query.verdict)}`);
+  const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
+  const countRes = await db().query<{ total: string }>(
+    `SELECT COUNT(*)::text AS total FROM public.metrologie_execution x ${whereSql}`,
+    values
+  );
+
+  const offset = (query.page - 1) * query.pageSize;
+  const res = await db().query(
+    `${EXECUTION_SELECT} ${whereSql}
+     ORDER BY x.${query.sortBy} ${sortDirection(query.sortDir)} NULLS LAST, x.id DESC
+     LIMIT ${push(query.pageSize)} OFFSET ${push(offset)}`,
+    values
+  );
+
+  return {
+    items: res.rows.map(mapExecutionListItem),
+    total: toInt(countRes.rows[0]?.total, 0),
+    page: query.page,
+    pageSize: query.pageSize,
+  };
+}
+
+export async function repoGetExecution(id: string): Promise<MetrologyExecutionDTO | null> {
+  const res = await db().query(`${EXECUTION_SELECT} WHERE x.id = $1::uuid LIMIT 1`, [id]);
+  const row = res.rows[0] ?? null;
+  if (!row) return null;
+
+  const measurementsRes = await db().query(
+    `
+      SELECT id::text AS id, point_key, sample_no, label,
+             nominal::text AS nominal, tolerance_min::text AS tolerance_min,
+             tolerance_max::text AS tolerance_max, measured::text AS measured,
+             unite, incertitude::text AS incertitude, ecart::text AS ecart,
+             verdict, comment, revision
+      FROM public.metrologie_execution_measurement
+      WHERE execution_id = $1::uuid
+      ORDER BY point_key, sample_no
+    `,
+    [id]
+  );
+
+  const certificatsRes = await db().query(
+    `
+      SELECT
+        c.id::text AS id, c.equipement_id::text AS equipement_id, c.execution_id::text AS execution_id,
+        c.document_kind, c.date_etalonnage::text AS date_etalonnage,
+        c.date_echeance::text AS date_echeance, c.resultat, c.statut,
+        c.emetteur, c.numero_externe, c.organisme, c.commentaire, c.confidentiality,
+        c.cancel_reason, c.cancelled_at::text AS cancelled_at, c.replaced_by_id::text AS replaced_by_id,
+        c.file_original_name, c.mime_type, c.size_bytes::text AS size_bytes, c.sha256,
+        (c.storage_path IS NOT NULL) AS has_file, c.created_at::text AS created_at,
+        cb.id AS created_by_id, cb.username AS created_by_username,
+        cb.name AS created_by_name, cb.surname AS created_by_surname
+      FROM public.metrologie_certificats c
+      LEFT JOIN public.users cb ON cb.id = c.created_by
+      WHERE c.execution_id = $1::uuid AND c.deleted_at IS NULL
+      ORDER BY c.created_at DESC
+    `,
+    [id]
+  );
+
+  return {
+    ...mapExecutionListItem(row),
+    plan_version_id: (row.plan_version_id ?? null) as string | null,
+    plan_version: row.plan_version === null ? null : toInt(row.plan_version, 0),
+    methode: (row.methode ?? null) as string | null,
+    procedure_ref: (row.procedure_ref ?? null) as string | null,
+    etalon_reference: (row.etalon_reference ?? null) as string | null,
+    environnement: isRecord(row.environnement) ? row.environnement : {},
+    incertitude: toNumber(row.incertitude),
+    verdict_computed: (row.verdict_computed ?? null) as MetrologyVerdict | null,
+    verdict_justification: (row.verdict_justification ?? null) as string | null,
+    observations: (row.observations ?? null) as string | null,
+    decision: (row.decision ?? null) as string | null,
+    decision_reason: (row.decision_reason ?? null) as string | null,
+    decided_by: mapUserRef({
+      id: (row.decided_by_id ?? null) as number | null,
+      username: (row.decided_by_username ?? null) as string | null,
+      name: (row.decided_by_name ?? null) as string | null,
+      surname: (row.decided_by_surname ?? null) as string | null,
+    }),
+    decided_at: (row.decided_at ?? null) as string | null,
+    restriction: (row.restriction ?? null) as string | null,
+    created_at: String(row.created_at),
+    measurements: measurementsRes.rows.map((m: Record<string, unknown>) => ({
+      id: String(m.id),
+      point_key: String(m.point_key),
+      sample_no: toInt(m.sample_no, 1),
+      label: (m.label ?? null) as string | null,
+      nominal: toNumber(m.nominal),
+      tolerance_min: toNumber(m.tolerance_min),
+      tolerance_max: toNumber(m.tolerance_max),
+      measured: toNumber(m.measured),
+      unite: (m.unite ?? null) as string | null,
+      incertitude: toNumber(m.incertitude),
+      ecart: toNumber(m.ecart),
+      verdict: (m.verdict ?? null) as "CONFORME" | "NON_CONFORME" | "INCONCLU" | null,
+      comment: (m.comment ?? null) as string | null,
+      revision: toInt(m.revision, 1),
+    })),
+    certificats: certificatsRes.rows.map(mapCertificate),
+  };
+}
+
+function mapCertificate(row: Record<string, unknown>): MetrologyCertificateDTO {
+  return {
+    id: String(row.id),
+    equipement_id: String(row.equipement_id),
+    execution_id: (row.execution_id ?? null) as string | null,
+    document_kind: row.document_kind as MetrologyCertificateDTO["document_kind"],
+    date_etalonnage: String(row.date_etalonnage),
+    date_echeance: (row.date_echeance ?? null) as string | null,
+    resultat: row.resultat as MetrologyCertificateDTO["resultat"],
+    statut: row.statut as MetrologyCertificateDTO["statut"],
+    emetteur: (row.emetteur ?? null) as string | null,
+    numero_externe: (row.numero_externe ?? null) as string | null,
+    organisme: (row.organisme ?? null) as string | null,
+    commentaire: (row.commentaire ?? null) as string | null,
+    confidentiality: row.confidentiality as MetrologyCertificateDTO["confidentiality"],
+    cancel_reason: (row.cancel_reason ?? null) as string | null,
+    cancelled_at: (row.cancelled_at ?? null) as string | null,
+    replaced_by_id: (row.replaced_by_id ?? null) as string | null,
+    file_original_name: (row.file_original_name ?? null) as string | null,
+    mime_type: (row.mime_type ?? null) as string | null,
+    size_bytes: toNumber(row.size_bytes),
+    sha256: (row.sha256 ?? null) as string | null,
+    has_file: row.has_file === true,
+    created_at: String(row.created_at),
+    created_by: mapUserRef({
+      id: (row.created_by_id ?? null) as number | null,
+      username: (row.created_by_username ?? null) as string | null,
+      name: (row.created_by_name ?? null) as string | null,
+      surname: (row.created_by_surname ?? null) as string | null,
+    }),
+  };
+}
+
+/* ========================================================================== */
+/* Certificats et PV                                                          */
+/* ========================================================================== */
+
+const ALLOWED_DOCUMENT_TYPES: ReadonlyArray<{
+  extension: string;
+  mime: readonly string[];
+  signature: readonly number[] | null;
+}> = [
+  { extension: ".pdf", mime: ["application/pdf"], signature: [0x25, 0x50, 0x44, 0x46] },
+  { extension: ".png", mime: ["image/png"], signature: [0x89, 0x50, 0x4e, 0x47] },
+  { extension: ".jpg", mime: ["image/jpeg"], signature: [0xff, 0xd8, 0xff] },
+  { extension: ".jpeg", mime: ["image/jpeg"], signature: [0xff, 0xd8, 0xff] },
+  { extension: ".tif", mime: ["image/tiff"], signature: null },
+  { extension: ".tiff", mime: ["image/tiff"], signature: null },
+];
+
+const MAX_DOCUMENT_BYTES = 25 * 1024 * 1024;
+
+/**
+ * Contrôle extension + MIME + signature + taille. Un fichier renommé `.pdf`
+ * mais dont les premiers octets ne sont pas ceux d'un PDF est refusé : le nom
+ * de fichier n'est pas une preuve de format.
+ */
+async function assertDocumentSafe(file: Express.Multer.File): Promise<void> {
+  if (file.size <= 0) {
+    throw new HttpError(422, "METROLOGY_DOCUMENT_EMPTY", "Le document est vide.");
+  }
+  if (file.size > MAX_DOCUMENT_BYTES) {
+    throw new HttpError(413, "METROLOGY_DOCUMENT_TOO_LARGE", "Le document dépasse 25 Mo.");
+  }
+
+  const extension = path.extname(file.originalname).toLowerCase();
+  const allowed = ALLOWED_DOCUMENT_TYPES.find((entry) => entry.extension === extension);
+  if (!allowed) {
+    throw new HttpError(
+      422,
+      "METROLOGY_DOCUMENT_EXTENSION_REJECTED",
+      "Format non accepté : PDF, PNG, JPEG ou TIFF uniquement."
+    );
+  }
+  if (!allowed.mime.includes(file.mimetype)) {
+    throw new HttpError(
+      422,
+      "METROLOGY_DOCUMENT_MIME_REJECTED",
+      `Type MIME incohérent avec l'extension ${extension}.`
+    );
+  }
+  if (allowed.signature) {
+    const handle = await fs.open(file.path, "r");
+    try {
+      const buffer = Buffer.alloc(allowed.signature.length);
+      await handle.read(buffer, 0, allowed.signature.length, 0);
+      const matches = allowed.signature.every((byte, index) => buffer[index] === byte);
+      if (!matches) {
+        throw new HttpError(
+          422,
+          "METROLOGY_DOCUMENT_SIGNATURE_REJECTED",
+          "Le contenu du fichier ne correspond pas à son extension."
+        );
+      }
+    } finally {
+      await handle.close();
+    }
+  }
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = crypto.createHash("sha256");
+  const stream = createReadStream(filePath);
+  for await (const chunk of stream) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+export function metrologyDocsBaseDir(): string {
+  return ensureDocumentStoragePath("metrologie");
+}
+
+export async function repoUploadCertificate(params: {
+  equipementId: string;
+  body: UploadCertificateBodyDTO;
+  file: Express.Multer.File | null;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyCertificateDTO> {
+  const { equipementId, body, file, actor } = params;
+  if (!file) {
+    throw new HttpError(422, "METROLOGY_DOCUMENT_REQUIRED", "Le fichier du certificat est obligatoire.");
+  }
+  await assertDocumentSafe(file);
+
+  const docsDirRel = ensureDocumentStoragePath("metrologie");
+  const docsDirAbs = path.resolve(docsDirRel);
+  await fs.mkdir(docsDirAbs, { recursive: true });
+
+  const certId = crypto.randomUUID();
+  const extension = path.extname(file.originalname).toLowerCase();
+  const storedName = `${certId}${extension}`;
+  const relPath = path.join(docsDirRel, storedName).split(path.sep).join(path.posix.sep);
+  const absPath = path.join(docsDirAbs, storedName);
+
+  try {
+    await fs.rename(path.resolve(file.path), absPath);
+  } catch {
+    await fs.copyFile(path.resolve(file.path), absPath);
+    await fs.unlink(path.resolve(file.path));
+  }
+  const hash = await sha256File(absPath);
+
+  try {
+    await withTransaction(async (client) => {
+      const claim = await acquireIdempotency({
+        client,
+        actor,
+        idempotencyKeyRaw: params.idempotencyKey,
+        commandType: "metrology.certificate.upload",
+        requestPayload: { equipementId, ...body, sha256: hash },
+      });
+      if (claim.replay) return;
+
+      const equip = await client.query<{ id: string }>(
+        `SELECT id::text AS id FROM public.metrologie_equipements
+          WHERE id = $1::uuid AND deleted_at IS NULL FOR UPDATE`,
+        [equipementId]
+      );
+      if (!equip.rows[0]) throw new HttpError(404, "NOT_FOUND", "Équipement introuvable.");
+
+      if (body.execution_id) {
+        const exec = await client.query<{ id: string }>(
+          `SELECT id::text AS id FROM public.metrologie_execution
+            WHERE id = $1::uuid AND equipement_id = $2::uuid`,
+          [body.execution_id, equipementId]
+        );
+        if (!exec.rows[0]) {
+          throw new HttpError(422, "METROLOGY_EXECUTION_MISMATCH", "Cette exécution n'appartient pas à l'équipement.");
+        }
+      }
+
+      try {
+        await client.query(
+          `
+            INSERT INTO public.metrologie_certificats (
+              id, equipement_id, execution_id, document_kind,
+              date_etalonnage, date_echeance, resultat, statut,
+              emetteur, numero_externe, organisme, commentaire, confidentiality,
+              file_original_name, storage_path, mime_type, size_bytes, sha256,
+              created_by, updated_by
+            )
+            VALUES (
+              $1::uuid,$2::uuid,$3::uuid,$4,
+              $5::date,$6::date,$7,'VALIDE',
+              $8,$9,$10,$11,$12,
+              $13,$14,$15,$16,$17,
+              $18,$18
+            )
+          `,
+          [
+            certId,
+            equipementId,
+            body.execution_id ?? null,
+            body.document_kind,
+            body.date_etalonnage,
+            body.date_echeance ?? null,
+            body.resultat,
+            body.emetteur ?? null,
+            body.numero_externe ?? null,
+            body.organisme ?? null,
+            body.commentaire ?? null,
+            body.confidentiality,
+            file.originalname,
+            relPath,
+            file.mimetype,
+            file.size,
+            hash,
+            actor.user_id,
+          ]
+        );
+      } catch (err) {
+        rethrowMapped(err);
+      }
+
+      const correlationId = crypto.randomUUID();
+      await insertMetrologyEvent(client, {
+        equipement_id: equipementId,
+        entity_type: "CERTIFICAT",
+        entity_id: certId,
+        event_type: "CERTIFICAT_ATTACHED",
+        actor,
+        old_values: null,
+        // Le journal porte l'empreinte, jamais le chemin de stockage.
+        new_values: {
+          document_kind: body.document_kind,
+          resultat: body.resultat,
+          emetteur: body.emetteur ?? null,
+          sha256: hash,
+        },
+        correlation_id: correlationId,
+        idempotency_key: claim.idempotencyKey,
+      });
+      await insertAuditLog(client, actor, {
+        action: "metrologie.certificats.upload",
+        entity_type: "metrologie_certificats",
+        entity_id: certId,
+        details: { equipement_id: equipementId, document_kind: body.document_kind, sha256: hash },
+      });
+      await saveReceipt({
+        client,
+        actor,
+        claim,
+        commandType: "metrology.certificate.upload",
+        aggregateType: "CERTIFICAT",
+        aggregateId: certId,
+        requestPayload: { equipementId, ...body, sha256: hash },
+        resultPayload: { id: certId, sha256: hash },
+        correlationId,
+      });
+    });
+  } catch (err) {
+    // Le fichier ne doit pas survivre à une transaction annulée : sinon on
+    // accumule des preuves orphelines dans le stockage privé.
+    await fs.unlink(absPath).catch(() => undefined);
+    throw err;
+  }
+
+  const res = await db().query(
+    `
+      SELECT
+        c.id::text AS id, c.equipement_id::text AS equipement_id, c.execution_id::text AS execution_id,
+        c.document_kind, c.date_etalonnage::text AS date_etalonnage,
+        c.date_echeance::text AS date_echeance, c.resultat, c.statut,
+        c.emetteur, c.numero_externe, c.organisme, c.commentaire, c.confidentiality,
+        c.cancel_reason, c.cancelled_at::text AS cancelled_at, c.replaced_by_id::text AS replaced_by_id,
+        c.file_original_name, c.mime_type, c.size_bytes::text AS size_bytes, c.sha256,
+        (c.storage_path IS NOT NULL) AS has_file, c.created_at::text AS created_at,
+        cb.id AS created_by_id, cb.username AS created_by_username,
+        cb.name AS created_by_name, cb.surname AS created_by_surname
+      FROM public.metrologie_certificats c
+      LEFT JOIN public.users cb ON cb.id = c.created_by
+      WHERE c.id = $1::uuid
+    `,
+    [certId]
+  );
+  const row = res.rows[0];
+  if (!row) throw new HttpError(500, "METROLOGY_CERTIFICATE_RELOAD_FAILED", "Certificat introuvable après dépôt.");
+  return mapCertificate(row);
+}
+
+export async function repoCancelCertificate(params: {
+  equipementId: string;
+  certificateId: string;
+  body: CancelCertificateBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<{ certificate: MetrologyCertificateDTO; impact_dossier_id: string | null }> {
+  const { equipementId, certificateId, body, actor } = params;
+  const impactDossierId = await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.certificate.cancel",
+      requestPayload: { equipementId, certificateId, ...body },
+    });
+    if (claim.replay) return (claim.replay.impact_dossier_id ?? null) as string | null;
+
+    const res = await client.query<{ id: string; statut: string }>(
+      `SELECT id::text AS id, statut FROM public.metrologie_certificats
+        WHERE id = $1::uuid AND equipement_id = $2::uuid AND deleted_at IS NULL FOR UPDATE`,
+      [certificateId, equipementId]
+    );
+    const current = res.rows[0] ?? null;
+    if (!current) throw new HttpError(404, "NOT_FOUND", "Certificat introuvable.");
+    if (current.statut !== "VALIDE") {
+      throw new HttpError(
+        409,
+        "METROLOGY_CERTIFICATE_NOT_VALID",
+        "Ce certificat n'est plus valide : son statut ne se réécrit pas."
+      );
+    }
+
+    await client.query(
+      `
+        UPDATE public.metrologie_certificats
+        SET statut = CASE WHEN $3::uuid IS NULL THEN 'ANNULE' ELSE 'REMPLACE' END,
+            cancel_reason = $2, cancelled_at = now(), cancelled_by = $4,
+            replaced_by_id = $3::uuid, updated_at = now(), updated_by = $4
+        WHERE id = $1::uuid
+      `,
+      [certificateId, body.reason, body.replaced_by_id ?? null, actor.user_id]
+    );
+
+    const correlationId = crypto.randomUUID();
+    let dossierId: string | null = null;
+    if (body.open_impact_analysis) {
+      const dossier = await openImpactDossier(client, {
+        equipementId,
+        executionId: null,
+        certificatId: certificateId,
+        trigger: "CERTIFICAT_INVALIDE",
+        actor,
+        correlationId,
+        approvedWindow: null,
+        exclusions: null,
+        ownerUserId: null,
+      });
+      dossierId = dossier.id;
+    }
+
+    await insertMetrologyEvent(client, {
+      equipement_id: equipementId,
+      entity_type: "CERTIFICAT",
+      entity_id: certificateId,
+      event_type: body.replaced_by_id ? "CERTIFICAT_REPLACED" : "CERTIFICAT_CANCELLED",
+      actor,
+      old_values: { statut: current.statut },
+      new_values: {
+        statut: body.replaced_by_id ? "REMPLACE" : "ANNULE",
+        impact_dossier_id: dossierId,
+      },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+      reason: body.reason,
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.certificats.cancel",
+      entity_type: "metrologie_certificats",
+      entity_id: certificateId,
+      details: { reason: body.reason, impact_dossier_id: dossierId },
+    });
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.certificate.cancel",
+      aggregateType: "CERTIFICAT",
+      aggregateId: certificateId,
+      requestPayload: { equipementId, certificateId, ...body },
+      resultPayload: { id: certificateId, impact_dossier_id: dossierId },
+      correlationId,
+    });
+    return dossierId;
+  });
+
+  const res = await db().query(
+    `
+      SELECT
+        c.id::text AS id, c.equipement_id::text AS equipement_id, c.execution_id::text AS execution_id,
+        c.document_kind, c.date_etalonnage::text AS date_etalonnage,
+        c.date_echeance::text AS date_echeance, c.resultat, c.statut,
+        c.emetteur, c.numero_externe, c.organisme, c.commentaire, c.confidentiality,
+        c.cancel_reason, c.cancelled_at::text AS cancelled_at, c.replaced_by_id::text AS replaced_by_id,
+        c.file_original_name, c.mime_type, c.size_bytes::text AS size_bytes, c.sha256,
+        (c.storage_path IS NOT NULL) AS has_file, c.created_at::text AS created_at,
+        cb.id AS created_by_id, cb.username AS created_by_username,
+        cb.name AS created_by_name, cb.surname AS created_by_surname
+      FROM public.metrologie_certificats c
+      LEFT JOIN public.users cb ON cb.id = c.created_by
+      WHERE c.id = $1::uuid
+    `,
+    [certificateId]
+  );
+  const row = res.rows[0];
+  if (!row) throw new HttpError(404, "NOT_FOUND", "Certificat introuvable.");
+  return { certificate: mapCertificate(row), impact_dossier_id: impactDossierId };
+}
+
+/**
+ * Lecture d'un document : le chemin de stockage ne sort JAMAIS de cette
+ * fonction. Le contrôleur reçoit un chemin résolu, vérifié comme interne au
+ * répertoire privé, et ne le renvoie pas au client.
+ */
+export async function repoGetCertificateFile(params: {
+  equipementId: string;
+  certificateId: string;
+  actor: MetrologyActor;
+}): Promise<{ storage_path: string; mime_type: string | null; file_original_name: string | null }> {
+  return withTransaction(async (client) => {
+    const res = await client.query<{
+      storage_path: string | null;
+      mime_type: string | null;
+      file_original_name: string | null;
+    }>(
+      `
+        SELECT storage_path, mime_type, file_original_name
+        FROM public.metrologie_certificats
+        WHERE id = $1::uuid AND equipement_id = $2::uuid AND deleted_at IS NULL
+        LIMIT 1
+      `,
+      [params.certificateId, params.equipementId]
+    );
+    const row = res.rows[0] ?? null;
+    if (!row || !row.storage_path) throw new HttpError(404, "NOT_FOUND", "Document introuvable.");
+
+    // Chaque accès à une preuve est journalisé : « qui a lu quoi, quand ».
+    await insertAuditLog(client, params.actor, {
+      action: "metrologie.certificats.download",
+      entity_type: "metrologie_certificats",
+      entity_id: params.certificateId,
+      details: { equipement_id: params.equipementId },
+    });
+
+    return {
+      storage_path: row.storage_path,
+      mime_type: row.mime_type,
+      file_original_name: row.file_original_name,
+    };
+  });
+}

--- a/src/module/metrologie/repository/metrology-impact.repository.ts
+++ b/src/module/metrologie/repository/metrology-impact.repository.ts
@@ -1,0 +1,892 @@
+// Analyse d'impact métrologique (#229).
+//
+// Ce dépôt matérialise une LISTE EXPLICABLE d'usages d'un instrument sur une
+// fenêtre bornée. Il n'annule aucun contrôle, ne déstocke aucun lot, n'annule
+// aucun BL, ne crée aucun avoir, ne bloque aucune expédition et ne déclenche
+// aucun rappel client. Les seules écritures hors métrologie sont… aucune.
+
+import crypto from "node:crypto";
+import type { PoolClient } from "pg";
+
+import { generateMetrologieImpactCode } from "../../../shared/codes/code-generator.service";
+import { HttpError } from "../../../utils/httpError";
+
+import {
+  assertImpactClosureAllowed,
+  assertImpactDecision,
+  assertImpactTransition,
+  assertOptimisticVersion,
+  roleHasMetrologyCapability,
+  type MetrologyImpactStatus,
+} from "../domain/metrology-policy";
+import {
+  computeImpactWindow,
+  describeTruncation,
+  IMPACT_ITEM_HARD_LIMIT,
+  suggestImpactPriority,
+  type ImpactTrigger,
+  type ImpactVolumes,
+} from "../domain/metrology-impact";
+import type {
+  CreateImpactBodyDTO,
+  DecideImpactItemBodyDTO,
+  ListImpactItemsQueryDTO,
+  ListImpactsQueryDTO,
+  TransitionImpactBodyDTO,
+  UsageQueryDTO,
+} from "../validators/metrology-360.validators";
+import type {
+  MetrologyImpactDetailDTO,
+  MetrologyImpactItemDTO,
+  MetrologyImpactListItemDTO,
+  MetrologyUsageEntryDTO,
+  Paginated,
+  UserRef,
+} from "../types/metrology-360.types";
+import {
+  acquireIdempotency,
+  db,
+  insertAuditLog,
+  insertMetrologyEvent,
+  isRecord,
+  rethrowMapped,
+  saveReceipt,
+  sortDirection,
+  toInt,
+  withTransaction,
+  type MetrologyActor,
+} from "./metrology-shared.repository";
+import { mapImpactListRow } from "./metrology-registry.repository";
+
+function mapUserRef(row: {
+  id: number | null;
+  username: string | null;
+  name: string | null;
+  surname: string | null;
+}): UserRef | null {
+  if (!row.id || !row.username) return null;
+  const parts = [row.surname ?? "", row.name ?? ""].map((s) => s.trim()).filter(Boolean);
+  return { id: row.id, username: row.username, label: parts.join(" ").trim() || row.username };
+}
+
+/* ========================================================================== */
+/* Collecte bornée des usages                                                 */
+/* ========================================================================== */
+
+type UsageRow = {
+  quality_control_id: string;
+  control_reference: string | null;
+  control_type: string | null;
+  control_date: string | null;
+  characteristic_key: string | null;
+  of_id: string | null;
+  lot_id: string | null;
+  bon_livraison_id: string | null;
+  article_id: string | null;
+  affaire_id: string | null;
+};
+
+/**
+ * Usages de l'instrument dans la fenêtre. La requête est BORNÉE (LIMIT dur) et
+ * le total réel est compté à part : une troncature silencieuse se lirait comme
+ * « tout est couvert » alors que non.
+ *
+ * On s'appuie sur `quality_control_points.instrument_id` (#228), la seule
+ * référence fiable de l'instrument réellement utilisé sur une mesure.
+ */
+async function collectUsages(
+  q: Pick<PoolClient, "query">,
+  params: { equipementId: string; from: Date; to: Date; limit: number }
+): Promise<{ rows: UsageRow[]; total: number }> {
+  const countRes = await q.query<{ total: string }>(
+    `
+      SELECT COUNT(*)::text AS total
+      FROM public.quality_control_points p
+      JOIN public.quality_control c ON c.id = p.quality_control_id
+      WHERE p.instrument_id = $1::uuid
+        AND COALESCE(p.measured_at, c.control_date) >= $2::timestamptz
+        AND COALESCE(p.measured_at, c.control_date) <= $3::timestamptz
+    `,
+    [params.equipementId, params.from.toISOString(), params.to.toISOString()]
+  );
+
+  const res = await q.query<UsageRow>(
+    `
+      SELECT
+        c.id::text                 AS quality_control_id,
+        c.reference                AS control_reference,
+        c.control_type::text       AS control_type,
+        COALESCE(p.measured_at, c.control_date)::text AS control_date,
+        p.characteristic_key,
+        c.of_id::text              AS of_id,
+        c.lot_id::text             AS lot_id,
+        c.bon_livraison_id::text   AS bon_livraison_id,
+        c.article_id::text         AS article_id,
+        c.affaire_id::text         AS affaire_id
+      FROM public.quality_control_points p
+      JOIN public.quality_control c ON c.id = p.quality_control_id
+      WHERE p.instrument_id = $1::uuid
+        AND COALESCE(p.measured_at, c.control_date) >= $2::timestamptz
+        AND COALESCE(p.measured_at, c.control_date) <= $3::timestamptz
+      ORDER BY COALESCE(p.measured_at, c.control_date) DESC, c.id, p.characteristic_key
+      LIMIT $4
+    `,
+    [params.equipementId, params.from.toISOString(), params.to.toISOString(), params.limit]
+  );
+
+  return { rows: res.rows, total: toInt(countRes.rows[0]?.total, 0) };
+}
+
+function computeVolumes(rows: UsageRow[], total: number): ImpactVolumes {
+  const controls = new Set(rows.map((row) => row.quality_control_id));
+  const ofs = new Set(rows.map((row) => row.of_id).filter(Boolean));
+  const lots = new Set(rows.map((row) => row.lot_id).filter(Boolean));
+  const bls = new Set(rows.map((row) => row.bon_livraison_id).filter(Boolean));
+  return {
+    controls: controls.size,
+    work_orders: ofs.size,
+    lots: lots.size,
+    deliveries: bls.size,
+    truncated: total > rows.length,
+  };
+}
+
+/* ========================================================================== */
+/* Ouverture d'un dossier                                                     */
+/* ========================================================================== */
+
+export type OpenImpactParams = {
+  equipementId: string;
+  executionId: string | null;
+  certificatId: string | null;
+  trigger: ImpactTrigger;
+  actor: MetrologyActor;
+  correlationId: string;
+  approvedWindow: { from: Date; to: Date; reason: string } | null;
+  exclusions: string | null;
+  ownerUserId: number | null;
+};
+
+/**
+ * Ouverture idempotente : appelée depuis la transaction « hors tolérance », la
+ * quarantaine manuelle ou l'invalidation de certificat. Un dossier déjà ouvert
+ * pour la même exécution est réutilisé (index unique partiel côté base).
+ */
+export async function openImpactDossier(
+  client: PoolClient,
+  params: OpenImpactParams
+): Promise<{ id: string; code: string; created: boolean; volumes: ImpactVolumes }> {
+  if (params.executionId) {
+    const existing = await client.query<{ id: string; code: string; volumes: unknown }>(
+      `SELECT id::text AS id, code, volumes FROM public.metrologie_impact_dossier
+        WHERE execution_id = $1::uuid AND status <> 'CANCELLED' LIMIT 1`,
+      [params.executionId]
+    );
+    const row = existing.rows[0];
+    if (row) {
+      const volumes = isRecord(row.volumes) ? row.volumes : {};
+      return {
+        id: row.id,
+        code: row.code,
+        created: false,
+        volumes: {
+          controls: toInt(volumes.controls, 0),
+          work_orders: toInt(volumes.work_orders, 0),
+          lots: toInt(volumes.lots, 0),
+          deliveries: toInt(volumes.deliveries, 0),
+          truncated: volumes.truncated === true,
+        },
+      };
+    }
+  }
+
+  const equipRes = await client.query<{
+    created_at: string;
+    criticite: string;
+    last_conforme_at: string | null;
+  }>(
+    `SELECT created_at::text AS created_at, criticite, last_conforme_at::text AS last_conforme_at
+       FROM public.metrologie_equipements WHERE id = $1::uuid`,
+    [params.equipementId]
+  );
+  const equip = equipRes.rows[0] ?? null;
+  if (!equip) throw new HttpError(404, "NOT_FOUND", "Équipement introuvable.");
+
+  const eventAtRes = params.executionId
+    ? await client.query<{ ended_at: string | null }>(
+        `SELECT COALESCE(ended_at, started_at)::text AS ended_at
+           FROM public.metrologie_execution WHERE id = $1::uuid`,
+        [params.executionId]
+      )
+    : null;
+
+  const window = computeImpactWindow({
+    trigger: params.trigger,
+    eventAt: new Date(eventAtRes?.rows[0]?.ended_at ?? new Date().toISOString()),
+    lastConformeProofAt: equip.last_conforme_at ? new Date(equip.last_conforme_at) : null,
+    equipmentCreatedAt: new Date(equip.created_at),
+    approvedFrom: params.approvedWindow?.from ?? null,
+    approvedTo: params.approvedWindow?.to ?? null,
+    approvedReason: params.approvedWindow?.reason ?? null,
+  });
+
+  const usages = await collectUsages(client, {
+    equipementId: params.equipementId,
+    from: window.from,
+    to: window.to,
+    limit: IMPACT_ITEM_HARD_LIMIT,
+  });
+  const volumes = computeVolumes(usages.rows, usages.total);
+  const priority = suggestImpactPriority({ volumes, criticite: equip.criticite });
+  const code = await generateMetrologieImpactCode(client, { date: window.to });
+
+  const truncationNote = describeTruncation(usages.rows.length, usages.total);
+  const method = truncationNote ? `${window.method} ${truncationNote}` : window.method;
+
+  let dossierId: string;
+  try {
+    const ins = await client.query<{ id: string }>(
+      `
+        INSERT INTO public.metrologie_impact_dossier (
+          code, equipement_id, execution_id, certificat_id, trigger_type,
+          status, priority, window_from, window_to, window_source,
+          method, scope, exclusions, volumes, truncated, owner_user_id,
+          correlation_id, created_by, updated_by
+        )
+        VALUES (
+          $1,$2::uuid,$3::uuid,$4::uuid,$5,
+          'OPEN',$6,$7::timestamptz,$8::timestamptz,$9,
+          $10,$11::jsonb,$12,$13::jsonb,$14,$15,
+          $16::uuid,$17,$17
+        )
+        RETURNING id::text AS id
+      `,
+      [
+        code,
+        params.equipementId,
+        params.executionId,
+        params.certificatId,
+        params.trigger,
+        priority,
+        window.from.toISOString(),
+        window.to.toISOString(),
+        window.source,
+        method,
+        JSON.stringify({
+          span_days: window.span_days,
+          identified_usages: usages.total,
+          materialized_usages: usages.rows.length,
+          hard_limit: IMPACT_ITEM_HARD_LIMIT,
+        }),
+        params.exclusions,
+        JSON.stringify(volumes),
+        volumes.truncated,
+        params.ownerUserId,
+        params.correlationId,
+        params.actor.user_id,
+      ]
+    );
+    dossierId = ins.rows[0]?.id ?? "";
+  } catch (err) {
+    rethrowMapped(err);
+  }
+  if (!dossierId) throw new HttpError(500, "METROLOGY_IMPACT_CREATE_FAILED", "Ouverture du dossier impossible.");
+
+  for (const row of usages.rows) {
+    await client.query(
+      `
+        INSERT INTO public.metrologie_impact_item (
+          dossier_id, quality_control_id, control_reference, control_type, control_date,
+          characteristic_key, of_id, lot_id, bon_livraison_id, article_id, affaire_id
+        )
+        VALUES ($1::uuid,$2::uuid,$3,$4,$5::timestamptz,$6,$7::bigint,$8::uuid,$9::uuid,$10::uuid,$11::bigint)
+        ON CONFLICT (dossier_id, quality_control_id, characteristic_key) DO NOTHING
+      `,
+      [
+        dossierId,
+        row.quality_control_id,
+        row.control_reference,
+        row.control_type,
+        row.control_date,
+        row.characteristic_key,
+        row.of_id,
+        row.lot_id,
+        row.bon_livraison_id,
+        row.article_id,
+        row.affaire_id,
+      ]
+    );
+  }
+
+  await insertMetrologyEvent(client, {
+    equipement_id: params.equipementId,
+    entity_type: "IMPACT",
+    entity_id: dossierId,
+    event_type: "IMPACT_DOSSIER_OPENED",
+    actor: params.actor,
+    old_values: null,
+    new_values: {
+      code,
+      trigger: params.trigger,
+      window_from: window.from.toISOString(),
+      window_to: window.to.toISOString(),
+      window_source: window.source,
+      volumes,
+      // Ce que le module n'a PAS fait, écrit noir sur blanc dans le journal.
+      automatic_actions: "none",
+    },
+    correlation_id: params.correlationId,
+    rule_code: "IMPACT_BOUNDED_WINDOW",
+    reason: method,
+  });
+  await insertAuditLog(client, params.actor, {
+    action: "metrologie.impacts.open",
+    entity_type: "metrologie_impact_dossier",
+    entity_id: dossierId,
+    details: { code, equipement_id: params.equipementId, volumes, trigger: params.trigger },
+  });
+
+  return { id: dossierId, code, created: true, volumes };
+}
+
+/* ========================================================================== */
+/* API publique                                                               */
+/* ========================================================================== */
+
+export async function repoCreateImpact(params: {
+  equipementId: string;
+  body: CreateImpactBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyImpactDetailDTO> {
+  const { equipementId, body, actor } = params;
+  const dossierId = await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.impact.create",
+      requestPayload: { equipementId, ...body },
+    });
+    if (claim.replay && typeof claim.replay.id === "string") return claim.replay.id;
+
+    await client.query(
+      `SELECT 1 FROM public.metrologie_equipements WHERE id = $1::uuid AND deleted_at IS NULL FOR UPDATE`,
+      [equipementId]
+    );
+
+    const correlationId = crypto.randomUUID();
+    const dossier = await openImpactDossier(client, {
+      equipementId,
+      executionId: body.execution_id ?? null,
+      certificatId: body.certificat_id ?? null,
+      trigger: body.trigger_type,
+      actor,
+      correlationId,
+      approvedWindow:
+        body.window_from && body.window_to
+          ? {
+              from: new Date(body.window_from),
+              to: new Date(body.window_to),
+              reason: body.window_reason ?? "",
+            }
+          : null,
+      exclusions: body.exclusions,
+      ownerUserId: body.owner_user_id,
+    });
+
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.impact.create",
+      aggregateType: "IMPACT",
+      aggregateId: dossier.id,
+      requestPayload: { equipementId, ...body },
+      resultPayload: { id: dossier.id, code: dossier.code },
+      correlationId,
+    });
+    return dossier.id;
+  });
+
+  const detail = await repoGetImpact({
+    id: dossierId,
+    actor,
+    itemsQuery: { page: 1, pageSize: 25, sortDir: "desc", sortBy: "control_date" },
+  });
+  if (!detail) throw new HttpError(500, "METROLOGY_IMPACT_RELOAD_FAILED", "Dossier introuvable après ouverture.");
+  return detail;
+}
+
+const IMPACT_LIST_SELECT = `
+  SELECT
+    d.id::text AS id, d.code, d.equipement_id::text AS equipement_id,
+    e.code AS equipement_code, e.designation AS equipement_designation,
+    d.trigger_type, d.status, d.priority,
+    d.window_from::text AS window_from, d.window_to::text AS window_to,
+    d.volumes, d.truncated,
+    d.created_at::text AS created_at, d.updated_at::text AS updated_at,
+    (SELECT COUNT(*)::int FROM public.metrologie_impact_item i
+      WHERE i.dossier_id = d.id AND i.decision = 'PENDING') AS pending_items
+  FROM public.metrologie_impact_dossier d
+  JOIN public.metrologie_equipements e ON e.id = d.equipement_id
+`;
+
+export async function repoListImpacts(
+  query: ListImpactsQueryDTO
+): Promise<Paginated<MetrologyImpactListItemDTO>> {
+  const values: unknown[] = [];
+  const where: string[] = [];
+  const push = (v: unknown) => {
+    values.push(v);
+    return `$${values.length}`;
+  };
+  if (query.equipement_id) where.push(`d.equipement_id = ${push(query.equipement_id)}::uuid`);
+  if (query.status) where.push(`d.status = ${push(query.status)}`);
+  if (query.priority) where.push(`d.priority = ${push(query.priority)}`);
+  const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
+  const countRes = await db().query<{ total: string }>(
+    `SELECT COUNT(*)::text AS total FROM public.metrologie_impact_dossier d ${whereSql.replace(/\be\./g, "d.")}`,
+    values
+  );
+
+  const sortColumn =
+    query.sortBy === "priority"
+      ? `CASE d.priority WHEN 'CRITICAL' THEN 0 WHEN 'HIGH' THEN 1 WHEN 'NORMAL' THEN 2 ELSE 3 END`
+      : `d.${query.sortBy}`;
+
+  const offset = (query.page - 1) * query.pageSize;
+  const res = await db().query(
+    `${IMPACT_LIST_SELECT} ${whereSql}
+     ORDER BY ${sortColumn} ${sortDirection(query.sortDir)}, d.id DESC
+     LIMIT ${push(query.pageSize)} OFFSET ${push(offset)}`,
+    values
+  );
+
+  return {
+    items: res.rows.map(mapImpactListRow),
+    total: toInt(countRes.rows[0]?.total, 0),
+    page: query.page,
+    pageSize: query.pageSize,
+  };
+}
+
+export async function repoGetImpact(params: {
+  id: string;
+  actor: MetrologyActor;
+  itemsQuery: ListImpactItemsQueryDTO;
+}): Promise<MetrologyImpactDetailDTO | null> {
+  const res = await db().query(
+    `
+      ${IMPACT_LIST_SELECT}
+      , LATERAL (SELECT 1) noop
+      WHERE d.id = $1::uuid
+      LIMIT 1
+    `.replace(", LATERAL (SELECT 1) noop", ""),
+    [params.id]
+  );
+  const row = res.rows[0] ?? null;
+  if (!row) return null;
+
+  const extraRes = await db().query(
+    `
+      SELECT
+        d.execution_id::text AS execution_id, d.certificat_id::text AS certificat_id,
+        d.window_source, d.method, d.scope, d.exclusions, d.truncated,
+        d.conclusion, d.closed_at::text AS closed_at,
+        ou.id AS owner_id, ou.username AS owner_username, ou.name AS owner_name, ou.surname AS owner_surname
+      FROM public.metrologie_impact_dossier d
+      LEFT JOIN public.users ou ON ou.id = d.owner_user_id
+      WHERE d.id = $1::uuid
+    `,
+    [params.id]
+  );
+  const extra = extraRes.rows[0] ?? {};
+
+  const items = await repoListImpactItems({ dossierId: params.id, query: params.itemsQuery });
+
+  return {
+    ...mapImpactListRow(row),
+    execution_id: (extra.execution_id ?? null) as string | null,
+    certificat_id: (extra.certificat_id ?? null) as string | null,
+    window_source: String(extra.window_source ?? "LAST_CONFORME_PROOF"),
+    method: String(extra.method ?? ""),
+    scope: isRecord(extra.scope) ? extra.scope : {},
+    exclusions: (extra.exclusions ?? null) as string | null,
+    truncated: extra.truncated === true,
+    owner: mapUserRef({
+      id: (extra.owner_id ?? null) as number | null,
+      username: (extra.owner_username ?? null) as string | null,
+      name: (extra.owner_name ?? null) as string | null,
+      surname: (extra.owner_surname ?? null) as string | null,
+    }),
+    conclusion: (extra.conclusion ?? null) as string | null,
+    closed_at: (extra.closed_at ?? null) as string | null,
+    items,
+    capabilities: {
+      impact_decide: roleHasMetrologyCapability(params.actor.role, "impact_decide"),
+      impact_create: roleHasMetrologyCapability(params.actor.role, "impact_create"),
+    },
+  };
+}
+
+export async function repoListImpactItems(params: {
+  dossierId: string;
+  query: ListImpactItemsQueryDTO;
+}): Promise<Paginated<MetrologyImpactItemDTO>> {
+  const values: unknown[] = [params.dossierId];
+  const where: string[] = ["i.dossier_id = $1::uuid"];
+  if (params.query.decision) {
+    values.push(params.query.decision);
+    where.push(`i.decision = $${values.length}`);
+  }
+
+  const countRes = await db().query<{ total: string }>(
+    `SELECT COUNT(*)::text AS total FROM public.metrologie_impact_item i WHERE ${where.join(" AND ")}`,
+    values
+  );
+
+  const offset = (params.query.page - 1) * params.query.pageSize;
+  values.push(params.query.pageSize, offset);
+  const res = await db().query(
+    `
+      SELECT
+        i.id::text AS id, i.quality_control_id::text AS quality_control_id,
+        i.control_reference, i.control_type, i.control_date::text AS control_date,
+        i.characteristic_key, i.of_id::text AS of_id, i.lot_id::text AS lot_id,
+        i.bon_livraison_id::text AS bon_livraison_id, i.article_id::text AS article_id,
+        i.affaire_id::text AS affaire_id,
+        i.decision, i.decision_reason, i.decided_at::text AS decided_at,
+        i.non_conformity_id::text AS non_conformity_id,
+        du.id AS decided_by_id, du.username AS decided_by_username,
+        du.name AS decided_by_name, du.surname AS decided_by_surname
+      FROM public.metrologie_impact_item i
+      LEFT JOIN public.users du ON du.id = i.decided_by
+      WHERE ${where.join(" AND ")}
+      ORDER BY i.${params.query.sortBy} ${sortDirection(params.query.sortDir)} NULLS LAST, i.id
+      LIMIT $${values.length - 1} OFFSET $${values.length}
+    `,
+    values
+  );
+
+  return {
+    items: res.rows.map((row: Record<string, unknown>) => ({
+      id: String(row.id),
+      quality_control_id: (row.quality_control_id ?? null) as string | null,
+      control_reference: (row.control_reference ?? null) as string | null,
+      control_type: (row.control_type ?? null) as string | null,
+      control_date: (row.control_date ?? null) as string | null,
+      characteristic_key: (row.characteristic_key ?? null) as string | null,
+      of_id: row.of_id === null || row.of_id === undefined ? null : Number(row.of_id),
+      lot_id: (row.lot_id ?? null) as string | null,
+      bon_livraison_id: (row.bon_livraison_id ?? null) as string | null,
+      article_id: (row.article_id ?? null) as string | null,
+      affaire_id:
+        row.affaire_id === null || row.affaire_id === undefined ? null : Number(row.affaire_id),
+      decision: row.decision as MetrologyImpactItemDTO["decision"],
+      decision_reason: (row.decision_reason ?? null) as string | null,
+      decided_by: mapUserRef({
+        id: (row.decided_by_id ?? null) as number | null,
+        username: (row.decided_by_username ?? null) as string | null,
+        name: (row.decided_by_name ?? null) as string | null,
+        surname: (row.decided_by_surname ?? null) as string | null,
+      }),
+      decided_at: (row.decided_at ?? null) as string | null,
+      non_conformity_id: (row.non_conformity_id ?? null) as string | null,
+    })),
+    total: toInt(countRes.rows[0]?.total, 0),
+    page: params.query.page,
+    pageSize: params.query.pageSize,
+  };
+}
+
+export async function repoDecideImpactItem(params: {
+  dossierId: string;
+  itemId: string;
+  body: DecideImpactItemBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyImpactItemDTO> {
+  const { dossierId, itemId, body, actor } = params;
+  await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.impact.decide",
+      requestPayload: { dossierId, itemId, ...body },
+    });
+    if (claim.replay) return;
+
+    assertImpactDecision({ decision: body.decision, reason: body.reason });
+
+    const res = await client.query<{
+      id: string;
+      decision: string;
+      equipement_id: string;
+      dossier_status: MetrologyImpactStatus;
+    }>(
+      `
+        SELECT i.id::text AS id, i.decision, d.equipement_id::text AS equipement_id,
+               d.status AS dossier_status
+        FROM public.metrologie_impact_item i
+        JOIN public.metrologie_impact_dossier d ON d.id = i.dossier_id
+        WHERE i.id = $1::uuid AND i.dossier_id = $2::uuid
+        FOR UPDATE OF i
+      `,
+      [itemId, dossierId]
+    );
+    const current = res.rows[0] ?? null;
+    if (!current) throw new HttpError(404, "NOT_FOUND", "Usage introuvable dans ce dossier.");
+    if (current.dossier_status === "CLOSED" || current.dossier_status === "CANCELLED") {
+      throw new HttpError(
+        409,
+        "METROLOGY_IMPACT_CLOSED",
+        "Ce dossier d'impact est clos : aucune nouvelle décision n'y est enregistrée."
+      );
+    }
+    if (current.decision !== "PENDING") {
+      throw new HttpError(
+        409,
+        "METROLOGY_IMPACT_ALREADY_DECIDED",
+        "Cet usage a déjà été décidé : la décision est définitive."
+      );
+    }
+
+    await client.query(
+      `
+        UPDATE public.metrologie_impact_item
+        SET decision = $2, decision_reason = $3, decided_by = $4, decided_at = now(),
+            non_conformity_id = $5::uuid, updated_at = now()
+        WHERE id = $1::uuid
+      `,
+      [itemId, body.decision, body.reason, actor.user_id, body.non_conformity_id ?? null]
+    );
+
+    const correlationId = crypto.randomUUID();
+    await insertMetrologyEvent(client, {
+      equipement_id: current.equipement_id,
+      entity_type: "IMPACT",
+      entity_id: dossierId,
+      event_type: `IMPACT_ITEM_${body.decision}`,
+      actor,
+      old_values: { item_id: itemId, decision: "PENDING" },
+      new_values: {
+        item_id: itemId,
+        decision: body.decision,
+        non_conformity_id: body.non_conformity_id ?? null,
+        // La décision est TRACÉE ici ; son exécution appartient au module
+        // concerné (Qualité, Stock, ADV) et reste une action humaine.
+        executed_by_this_module: false,
+      },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+      reason: body.reason,
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.impacts.decide",
+      entity_type: "metrologie_impact_item",
+      entity_id: itemId,
+      details: { dossier_id: dossierId, decision: body.decision },
+    });
+
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.impact.decide",
+      aggregateType: "IMPACT",
+      aggregateId: dossierId,
+      requestPayload: { dossierId, itemId, ...body },
+      resultPayload: { item_id: itemId, decision: body.decision },
+      correlationId,
+    });
+  });
+
+  const items = await repoListImpactItems({
+    dossierId,
+    query: { page: 1, pageSize: 200, sortDir: "desc", sortBy: "control_date" },
+  });
+  const item = items.items.find((entry) => entry.id === itemId);
+  if (!item) throw new HttpError(404, "NOT_FOUND", "Usage introuvable après décision.");
+  return item;
+}
+
+export async function repoTransitionImpact(params: {
+  id: string;
+  body: TransitionImpactBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyImpactDetailDTO> {
+  const { id, body, actor } = params;
+  await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.impact.transition",
+      requestPayload: { id, ...body },
+    });
+    if (claim.replay) return;
+
+    const res = await client.query<{
+      id: string;
+      status: MetrologyImpactStatus;
+      equipement_id: string;
+      updated_at: string;
+    }>(
+      `SELECT id::text AS id, status, equipement_id::text AS equipement_id,
+              updated_at::text AS updated_at
+         FROM public.metrologie_impact_dossier WHERE id = $1::uuid FOR UPDATE`,
+      [id]
+    );
+    const current = res.rows[0] ?? null;
+    if (!current) throw new HttpError(404, "NOT_FOUND", "Dossier d'impact introuvable.");
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: current.updated_at,
+    });
+    assertImpactTransition(current.status, body.target_status);
+
+    if (body.target_status === "CLOSED") {
+      const pending = await client.query<{ total: string }>(
+        `SELECT COUNT(*)::text AS total FROM public.metrologie_impact_item
+          WHERE dossier_id = $1::uuid AND decision = 'PENDING'`,
+        [id]
+      );
+      assertImpactClosureAllowed({
+        pendingItems: toInt(pending.rows[0]?.total, 0),
+        conclusion: body.conclusion,
+      });
+      await client.query(
+        `
+          UPDATE public.metrologie_impact_dossier
+          SET status = 'CLOSED', conclusion = $2, closed_at = now(), closed_by = $3,
+              updated_at = now(), updated_by = $3
+          WHERE id = $1::uuid
+        `,
+        [id, body.conclusion, actor.user_id]
+      );
+    } else {
+      await client.query(
+        `
+          UPDATE public.metrologie_impact_dossier
+          SET status = $2, updated_at = now(), updated_by = $3
+          WHERE id = $1::uuid
+        `,
+        [id, body.target_status, actor.user_id]
+      );
+    }
+
+    const correlationId = crypto.randomUUID();
+    await insertMetrologyEvent(client, {
+      equipement_id: current.equipement_id,
+      entity_type: "IMPACT",
+      entity_id: id,
+      event_type: `IMPACT_DOSSIER_${body.target_status}`,
+      actor,
+      old_values: { status: current.status },
+      new_values: { status: body.target_status },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+      reason: body.conclusion,
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.impacts.transition",
+      entity_type: "metrologie_impact_dossier",
+      entity_id: id,
+      details: { from: current.status, to: body.target_status },
+    });
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.impact.transition",
+      aggregateType: "IMPACT",
+      aggregateId: id,
+      requestPayload: { id, ...body },
+      resultPayload: { id, status: body.target_status },
+      correlationId,
+    });
+  });
+
+  const detail = await repoGetImpact({
+    id,
+    actor,
+    itemsQuery: { page: 1, pageSize: 25, sortDir: "desc", sortBy: "control_date" },
+  });
+  if (!detail) throw new HttpError(404, "NOT_FOUND", "Dossier d'impact introuvable.");
+  return detail;
+}
+
+/* ========================================================================== */
+/* Usages instrument → contrôles → OF / lots / BL                             */
+/* ========================================================================== */
+
+export async function repoInstrumentUsage(params: {
+  equipementId: string;
+  query: UsageQueryDTO;
+}): Promise<Paginated<MetrologyUsageEntryDTO>> {
+  const values: unknown[] = [params.equipementId];
+  const where: string[] = ["p.instrument_id = $1::uuid"];
+  if (params.query.from) {
+    values.push(params.query.from);
+    where.push(`COALESCE(p.measured_at, c.control_date) >= $${values.length}::timestamptz`);
+  }
+  if (params.query.to) {
+    values.push(params.query.to);
+    where.push(`COALESCE(p.measured_at, c.control_date) <= $${values.length}::timestamptz`);
+  }
+
+  const countRes = await db().query<{ total: string }>(
+    `
+      SELECT COUNT(*)::text AS total
+      FROM public.quality_control_points p
+      JOIN public.quality_control c ON c.id = p.quality_control_id
+      WHERE ${where.join(" AND ")}
+    `,
+    values
+  );
+
+  const offset = (params.query.page - 1) * params.query.pageSize;
+  values.push(params.query.pageSize, offset);
+  const res = await db().query(
+    `
+      SELECT
+        c.id::text AS quality_control_id, c.reference AS control_reference,
+        c.control_type::text AS control_type,
+        COALESCE(p.measured_at, c.control_date)::text AS control_date,
+        p.characteristic_key, p.instrument_snapshot,
+        c.of_id::text AS of_id, c.lot_id::text AS lot_id,
+        c.bon_livraison_id::text AS bon_livraison_id, c.affaire_id::text AS affaire_id
+      FROM public.quality_control_points p
+      JOIN public.quality_control c ON c.id = p.quality_control_id
+      WHERE ${where.join(" AND ")}
+      ORDER BY COALESCE(p.measured_at, c.control_date) ${sortDirection(params.query.sortDir)}
+      LIMIT $${values.length - 1} OFFSET $${values.length}
+    `,
+    values
+  );
+
+  return {
+    items: res.rows.map((row: Record<string, unknown>) => ({
+      quality_control_id: String(row.quality_control_id),
+      control_reference: (row.control_reference ?? null) as string | null,
+      control_type: (row.control_type ?? null) as string | null,
+      control_date: (row.control_date ?? null) as string | null,
+      characteristic_key: (row.characteristic_key ?? null) as string | null,
+      of_id: row.of_id === null || row.of_id === undefined ? null : Number(row.of_id),
+      lot_id: (row.lot_id ?? null) as string | null,
+      bon_livraison_id: (row.bon_livraison_id ?? null) as string | null,
+      affaire_id:
+        row.affaire_id === null || row.affaire_id === undefined ? null : Number(row.affaire_id),
+      snapshot: isRecord(row.instrument_snapshot)
+        ? (row.instrument_snapshot as MetrologyUsageEntryDTO["snapshot"])
+        : null,
+    })),
+    total: toInt(countRes.rows[0]?.total, 0),
+    page: params.query.page,
+    pageSize: params.query.pageSize,
+  };
+}

--- a/src/module/metrologie/repository/metrology-registry.repository.ts
+++ b/src/module/metrologie/repository/metrology-registry.repository.ts
@@ -1,0 +1,2482 @@
+// Registre Métrologie 360 (#229) : catégories, équipements, plans versionnés,
+// échéances, éligibilité et command center.
+//
+// Toute écriture est transactionnelle, verrouillée (verrou optimiste +
+// `FOR UPDATE`), idempotente lorsqu'elle a un effet, et tracée dans le même
+// commit (journal métier + audit). Aucun code métier n'est calculé côté client.
+
+import crypto from "node:crypto";
+import type { PoolClient } from "pg";
+
+import { generateMetrologieEquipementCode } from "../../../shared/codes/code-generator.service";
+import { HttpError } from "../../../utils/httpError";
+
+import {
+  assertEquipmentReleaseAllowed,
+  assertEquipmentTransition,
+  assertOptimisticVersion,
+  assertPlanContentMutable,
+  assertPlanTransition,
+  roleHasMetrologyCapability,
+  transitionRequiresRelease,
+  type MetrologyEquipmentState,
+} from "../domain/metrology-policy";
+import {
+  buildInstrumentSnapshot,
+  evaluateInstrumentEligibility,
+  type MetrologyUsageRequirement,
+} from "../domain/metrology-eligibility";
+import {
+  computeNextDueDate,
+  deriveEffectiveState,
+  evaluateDue,
+  type DueEvaluation,
+  type SchedulePlan,
+} from "../domain/metrology-schedule";
+import type {
+  CreateEquipmentBodyDTO,
+  CreatePlanBodyDTO,
+  EligibilityQueryDTO,
+  EquipmentTransitionBodyDTO,
+  ListCategoriesQueryDTO,
+  ListEquipmentQueryDTO,
+  PlanTransitionBodyDTO,
+  QuarantineBodyDTO,
+  RevisePlanBodyDTO,
+  SchedulePreviewQueryDTO,
+  TimelineQueryDTO,
+  UpdateEquipmentBodyDTO,
+  UpsertCategoryBodyDTO,
+} from "../validators/metrology-360.validators";
+import type {
+  MetrologyCategoryDTO,
+  MetrologyCenterDTO,
+  MetrologyDueDTO,
+  MetrologyEligibilityResultDTO,
+  MetrologyEquipmentDTO,
+  MetrologyEquipmentDetailDTO,
+  MetrologyEquipmentListItemDTO,
+  MetrologyPlanVersionDTO,
+  MetrologyTimelineEntryDTO,
+  Paginated,
+  UserRef,
+} from "../types/metrology-360.types";
+import {
+  acquireIdempotency,
+  db,
+  insertAuditLog,
+  insertMetrologyEvent,
+  isRecord,
+  loadInstrumentCandidates,
+  loadInstrumentState,
+  loadMetrologyPolicy,
+  rethrowMapped,
+  saveReceipt,
+  sortDirection,
+  toInt,
+  toNumber,
+  withTransaction,
+  type DbQueryer,
+  type MetrologyActor,
+} from "./metrology-shared.repository";
+import { openImpactDossier } from "./metrology-impact.repository";
+
+/* ========================================================================== */
+/* Mappers                                                                    */
+/* ========================================================================== */
+
+function mapUserRef(row: {
+  id: number | null;
+  username: string | null;
+  name: string | null;
+  surname: string | null;
+}): UserRef | null {
+  if (!row.id || !row.username) return null;
+  const parts = [row.surname ?? "", row.name ?? ""].map((s) => s.trim()).filter(Boolean);
+  return { id: row.id, username: row.username, label: parts.join(" ").trim() || row.username };
+}
+
+function mapDue(due: DueEvaluation): MetrologyDueDTO {
+  return {
+    status: due.status,
+    next_due_date: due.next_due_date,
+    days_remaining: due.days_remaining,
+    days_overdue: due.days_overdue,
+  };
+}
+
+function capabilitiesFor(role: string | null): Record<string, boolean> {
+  return {
+    read: roleHasMetrologyCapability(role, "read"),
+    equipment_write: roleHasMetrologyCapability(role, "equipment_write"),
+    plan_manage: roleHasMetrologyCapability(role, "plan_manage"),
+    execution_record: roleHasMetrologyCapability(role, "execution_record"),
+    verdict_validate: roleHasMetrologyCapability(role, "verdict_validate"),
+    documents_read: roleHasMetrologyCapability(role, "documents_read"),
+    documents_write: roleHasMetrologyCapability(role, "documents_write"),
+    quarantine_set: roleHasMetrologyCapability(role, "quarantine_set"),
+    repair_manage: roleHasMetrologyCapability(role, "repair_manage"),
+    equipment_release: roleHasMetrologyCapability(role, "equipment_release"),
+    impact_read: roleHasMetrologyCapability(role, "impact_read"),
+    impact_create: roleHasMetrologyCapability(role, "impact_create"),
+    impact_decide: roleHasMetrologyCapability(role, "impact_decide"),
+    categories_manage: roleHasMetrologyCapability(role, "categories_manage"),
+  };
+}
+
+/* ========================================================================== */
+/* Catégories                                                                 */
+/* ========================================================================== */
+
+export async function repoListCategories(
+  filters: ListCategoriesQueryDTO
+): Promise<{ items: MetrologyCategoryDTO[] }> {
+  const values: unknown[] = [];
+  const where: string[] = [];
+  const push = (v: unknown) => {
+    values.push(v);
+    return `$${values.length}`;
+  };
+
+  if (filters.active === "true") where.push("c.active = TRUE");
+  else if (filters.active === "false") where.push("c.active = FALSE");
+  if (filters.q) {
+    const p = push(`%${filters.q.replace(/%/g, "\\%")}%`);
+    where.push(`(c.code ILIKE ${p} OR c.label ILIKE ${p})`);
+  }
+
+  const res = await db().query<
+    MetrologyCategoryDTO & { in_use: boolean; default_periodicity_months: number | null }
+  >(
+    `
+      SELECT
+        c.code, c.parent_code, c.label, c.description, c.version, c.active, c.display_order,
+        c.requires_range, c.requires_resolution, c.requires_uncertainty, c.requires_unit,
+        c.default_unit, c.default_periodicity_months, c.default_operation_type,
+        EXISTS (
+          SELECT 1 FROM public.metrologie_equipements e
+          WHERE e.categorie_code = c.code OR e.sous_categorie_code = c.code
+        ) AS in_use
+      FROM public.metrologie_categories c
+      ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+      ORDER BY c.display_order ASC, c.label ASC
+      LIMIT 500
+    `,
+    values
+  );
+  return { items: res.rows };
+}
+
+export async function repoUpsertCategory(params: {
+  body: UpsertCategoryBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyCategoryDTO> {
+  const { body, actor } = params;
+  return withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.category.upsert",
+      requestPayload: body,
+    });
+    if (claim.replay) return claim.replay as unknown as MetrologyCategoryDTO;
+
+    const before = await client.query<{ code: string; active: boolean; label: string }>(
+      `SELECT code, active, label FROM public.metrologie_categories WHERE code = $1 FOR UPDATE`,
+      [body.code]
+    );
+    const existing = before.rows[0] ?? null;
+
+    // Une catégorie utilisée ne se supprime pas : on la désactive. Le trigger
+    // le garantit côté base, l'API le rend explicite côté message.
+    if (existing && !body.active) {
+      const used = await client.query<{ total: string }>(
+        `SELECT COUNT(*)::text AS total FROM public.metrologie_equipements
+          WHERE (categorie_code = $1 OR sous_categorie_code = $1) AND deleted_at IS NULL`,
+        [body.code]
+      );
+      const total = toInt(used.rows[0]?.total, 0);
+      if (total > 0) {
+        // Désactivation autorisée : elle empêche les NOUVEAUX usages sans
+        // toucher aux équipements déjà rattachés.
+        await insertMetrologyEvent(client, {
+          equipement_id: null,
+          entity_type: "CATEGORIE",
+          entity_id: body.code,
+          event_type: "CATEGORIE_DEACTIVATED_WHILE_USED",
+          actor,
+          old_values: { active: true },
+          new_values: { active: false, equipements_rattaches: total },
+          correlation_id: crypto.randomUUID(),
+          reason: "Désactivation d'une catégorie encore rattachée à des équipements.",
+        });
+      }
+    }
+
+    try {
+      await client.query(
+        `
+          INSERT INTO public.metrologie_categories (
+            code, parent_code, label, description, active, display_order,
+            requires_range, requires_resolution, requires_uncertainty, requires_unit,
+            default_unit, default_periodicity_months, default_operation_type,
+            created_by, updated_by
+          )
+          VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$14)
+          ON CONFLICT (code) DO UPDATE SET
+            parent_code = EXCLUDED.parent_code,
+            label = EXCLUDED.label,
+            description = EXCLUDED.description,
+            active = EXCLUDED.active,
+            display_order = EXCLUDED.display_order,
+            requires_range = EXCLUDED.requires_range,
+            requires_resolution = EXCLUDED.requires_resolution,
+            requires_uncertainty = EXCLUDED.requires_uncertainty,
+            requires_unit = EXCLUDED.requires_unit,
+            default_unit = EXCLUDED.default_unit,
+            default_periodicity_months = EXCLUDED.default_periodicity_months,
+            default_operation_type = EXCLUDED.default_operation_type,
+            version = public.metrologie_categories.version + 1,
+            updated_at = now(),
+            updated_by = EXCLUDED.updated_by
+        `,
+        [
+          body.code,
+          body.parent_code,
+          body.label,
+          body.description,
+          body.active,
+          body.display_order,
+          body.requires_range,
+          body.requires_resolution,
+          body.requires_uncertainty,
+          body.requires_unit,
+          body.default_unit,
+          body.default_periodicity_months,
+          body.default_operation_type,
+          actor.user_id,
+        ]
+      );
+    } catch (err) {
+      rethrowMapped(err);
+    }
+
+    const correlationId = crypto.randomUUID();
+    await insertMetrologyEvent(client, {
+      equipement_id: null,
+      entity_type: "CATEGORIE",
+      entity_id: body.code,
+      event_type: existing ? "CATEGORIE_UPDATED" : "CATEGORIE_CREATED",
+      actor,
+      old_values: existing ? { label: existing.label, active: existing.active } : null,
+      new_values: { label: body.label, active: body.active },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+    });
+    await insertAuditLog(client, actor, {
+      action: existing ? "metrologie.categories.update" : "metrologie.categories.create",
+      entity_type: "metrologie_categories",
+      entity_id: body.code,
+      details: { label: body.label, active: body.active },
+    });
+
+    const reloaded = await client.query<MetrologyCategoryDTO>(
+      `
+        SELECT
+          c.code, c.parent_code, c.label, c.description, c.version, c.active, c.display_order,
+          c.requires_range, c.requires_resolution, c.requires_uncertainty, c.requires_unit,
+          c.default_unit, c.default_periodicity_months, c.default_operation_type,
+          EXISTS (
+            SELECT 1 FROM public.metrologie_equipements e
+            WHERE e.categorie_code = c.code OR e.sous_categorie_code = c.code
+          ) AS in_use
+        FROM public.metrologie_categories c
+        WHERE c.code = $1
+      `,
+      [body.code]
+    );
+    const out = reloaded.rows[0];
+    if (!out) throw new HttpError(500, "METROLOGY_CATEGORY_RELOAD_FAILED", "Catégorie introuvable après écriture.");
+
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.category.upsert",
+      aggregateType: "CATEGORIE",
+      aggregateId: body.code,
+      requestPayload: body,
+      resultPayload: out,
+      correlationId,
+    });
+    return out;
+  });
+}
+
+/* ========================================================================== */
+/* Équipements — lecture                                                      */
+/* ========================================================================== */
+
+const EQUIPMENT_LIST_SELECT = `
+  SELECT
+    e.id::text                                  AS id,
+    e.code,
+    e.designation,
+    e.categorie_code,
+    cat.label                                   AS categorie_label,
+    e.etat,
+    e.criticite,
+    e.site,
+    e.zone,
+    e.localisation_precise,
+    e.numero_serie,
+    COALESCE(pv.next_due_date, legacy.next_due_date)::text AS next_due_date,
+    COALESCE(pv.alert_window_days, 30)          AS alert_window_days,
+    e.updated_at::text                          AS updated_at,
+    COALESCE(imp.open_count, 0)                 AS open_impact_count
+  FROM public.metrologie_equipements e
+  LEFT JOIN public.metrologie_categories cat ON cat.code = e.categorie_code
+  LEFT JOIN LATERAL (
+    SELECT p.next_due_date, p.alert_window_days
+    FROM public.metrologie_plan_version p
+    WHERE p.equipement_id = e.id AND p.status = 'ACTIVE'
+    ORDER BY p.next_due_date ASC NULLS LAST, p.version DESC
+    LIMIT 1
+  ) pv ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT lp.next_due_date
+    FROM public.metrologie_plan lp
+    WHERE lp.equipement_id = e.id AND lp.deleted_at IS NULL AND lp.statut <> 'SUSPENDU'
+    ORDER BY lp.created_at DESC
+    LIMIT 1
+  ) legacy ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT COUNT(*)::int AS open_count
+    FROM public.metrologie_impact_dossier d
+    WHERE d.equipement_id = e.id AND d.status IN ('OPEN', 'IN_REVIEW')
+  ) imp ON TRUE
+`;
+
+type EquipmentListRow = {
+  id: string;
+  code: string | null;
+  designation: string;
+  categorie_code: string | null;
+  categorie_label: string | null;
+  etat: MetrologyEquipmentState;
+  criticite: "NORMAL" | "CRITIQUE";
+  site: string | null;
+  zone: string | null;
+  localisation_precise: string | null;
+  numero_serie: string | null;
+  next_due_date: string | null;
+  alert_window_days: number;
+  updated_at: string;
+  open_impact_count: number;
+};
+
+function mapEquipmentListItem(row: EquipmentListRow, at: Date): MetrologyEquipmentListItemDTO {
+  const due = evaluateDue({
+    nextDueDate: row.next_due_date ? row.next_due_date.slice(0, 10) : null,
+    alertWindowDays: row.alert_window_days,
+    at,
+  });
+  return {
+    id: row.id,
+    code: row.code,
+    designation: row.designation,
+    categorie_code: row.categorie_code,
+    categorie_label: row.categorie_label,
+    etat: row.etat,
+    etat_effectif: deriveEffectiveState({ storedState: row.etat, due }),
+    criticite: row.criticite,
+    site: row.site,
+    zone: row.zone,
+    localisation_precise: row.localisation_precise,
+    numero_serie: row.numero_serie,
+    next_due_date: due.next_due_date,
+    due_status: due.status,
+    days_overdue: due.days_overdue,
+    days_remaining: due.days_remaining,
+    open_impact_count: toInt(row.open_impact_count, 0),
+    updated_at: row.updated_at,
+  };
+}
+
+/**
+ * Les segments du command center sont des filtres SERVEUR. `due_soon` et
+ * `overdue` sont calculés en SQL sur la même règle que le domaine : la page
+ * courante n'est jamais re-triée côté navigateur.
+ */
+function segmentClause(segment: ListEquipmentQueryDTO["segment"]): string | null {
+  switch (segment) {
+    case "due_soon":
+      return `(e.etat IN ('ACTIVE','QUALIFIED')
+               AND COALESCE(pv.next_due_date, legacy.next_due_date) IS NOT NULL
+               AND COALESCE(pv.next_due_date, legacy.next_due_date) >= CURRENT_DATE
+               AND COALESCE(pv.next_due_date, legacy.next_due_date)
+                   <= CURRENT_DATE + (COALESCE(pv.alert_window_days, 30) || ' days')::interval)`;
+    case "overdue":
+      return `(e.etat IN ('ACTIVE','QUALIFIED')
+               AND COALESCE(pv.next_due_date, legacy.next_due_date) IS NOT NULL
+               AND COALESCE(pv.next_due_date, legacy.next_due_date) < CURRENT_DATE)`;
+    case "quarantine":
+      return `e.etat = 'QUARANTINE'`;
+    case "out_of_tolerance":
+      return `e.etat = 'OUT_OF_TOLERANCE'`;
+    case "repair":
+      return `e.etat = 'UNDER_REPAIR'`;
+    case "retired":
+      return `e.etat = 'RETIRED'`;
+    case "all":
+    default:
+      return null;
+  }
+}
+
+function equipmentSortColumn(sortBy: ListEquipmentQueryDTO["sortBy"]): string {
+  switch (sortBy) {
+    case "code":
+      return "e.code";
+    case "designation":
+      return "e.designation";
+    case "created_at":
+      return "e.created_at";
+    case "etat":
+      return "e.etat";
+    case "next_due_date":
+      return "COALESCE(pv.next_due_date, legacy.next_due_date)";
+    case "updated_at":
+    default:
+      return "e.updated_at";
+  }
+}
+
+export async function repoListEquipment(
+  filters: ListEquipmentQueryDTO
+): Promise<Paginated<MetrologyEquipmentListItemDTO>> {
+  const values: unknown[] = [];
+  const push = (v: unknown) => {
+    values.push(v);
+    return `$${values.length}`;
+  };
+
+  const where: string[] = ["e.deleted_at IS NULL"];
+  if (filters.q) {
+    const p = push(`%${filters.q.replace(/%/g, "\\%")}%`);
+    where.push(
+      `(COALESCE(e.code,'') ILIKE ${p}
+        OR e.designation ILIKE ${p}
+        OR COALESCE(e.numero_serie,'') ILIKE ${p}
+        OR COALESCE(e.modele,'') ILIKE ${p}
+        OR COALESCE(e.localisation_precise,'') ILIKE ${p}
+        OR COALESCE(e.zone,'') ILIKE ${p})`
+    );
+  }
+  if (filters.categorie_code) where.push(`e.categorie_code = ${push(filters.categorie_code)}`);
+  if (filters.etat) where.push(`e.etat = ${push(filters.etat)}`);
+  if (filters.criticite) where.push(`e.criticite = ${push(filters.criticite)}`);
+  if (filters.site) where.push(`e.site = ${push(filters.site)}`);
+
+  const segment = segmentClause(filters.segment);
+  if (segment) where.push(segment);
+
+  const whereSql = `WHERE ${where.join(" AND ")}`;
+  const offset = (filters.page - 1) * filters.pageSize;
+
+  const countRes = await db().query<{ total: string }>(
+    `SELECT COUNT(*)::text AS total FROM (${EQUIPMENT_LIST_SELECT} ${whereSql}) s`,
+    values
+  );
+  const total = toInt(countRes.rows[0]?.total, 0);
+
+  const dataRes = await db().query<EquipmentListRow>(
+    `${EQUIPMENT_LIST_SELECT} ${whereSql}
+     ORDER BY ${equipmentSortColumn(filters.sortBy)} ${sortDirection(filters.sortDir)} NULLS LAST, e.id ASC
+     LIMIT ${push(filters.pageSize)} OFFSET ${push(offset)}`,
+    values
+  );
+
+  const at = new Date();
+  return {
+    items: dataRes.rows.map((row) => mapEquipmentListItem(row, at)),
+    total,
+    page: filters.page,
+    pageSize: filters.pageSize,
+  };
+}
+
+type EquipmentRow = {
+  id: string;
+  code: string | null;
+  designation: string;
+  categorie_code: string | null;
+  categorie_label: string | null;
+  sous_categorie_code: string | null;
+  marque: string | null;
+  modele: string | null;
+  numero_serie: string | null;
+  criticite: "NORMAL" | "CRITIQUE";
+  etat: MetrologyEquipmentState;
+  etat_motif: string | null;
+  etat_changed_at: string | null;
+  statut: string;
+  proprietaire_service: string | null;
+  site: string | null;
+  magasin: string | null;
+  zone: string | null;
+  localisation_precise: string | null;
+  date_mise_en_service: string | null;
+  date_retrait: string | null;
+  unite: string | null;
+  plage_min: string | null;
+  plage_max: string | null;
+  resolution: string | null;
+  mpe: string | null;
+  incertitude: string | null;
+  methodes: string[] | null;
+  conditions_utilisation: string | null;
+  restrictions: string | null;
+  etalon_reference: string | null;
+  exige_certificat: boolean;
+  specifications: unknown;
+  quarantine_reason: string | null;
+  quarantined_at: string | null;
+  last_conforme_at: string | null;
+  last_conforme_execution_id: string | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+  responsable_id: number | null;
+  responsable_username: string | null;
+  responsable_name: string | null;
+  responsable_surname: string | null;
+  created_by_id: number | null;
+  created_by_username: string | null;
+  created_by_name: string | null;
+  created_by_surname: string | null;
+  updated_by_id: number | null;
+  updated_by_username: string | null;
+  updated_by_name: string | null;
+  updated_by_surname: string | null;
+};
+
+const EQUIPMENT_DETAIL_SELECT = `
+  SELECT
+    e.id::text AS id, e.code, e.designation, e.categorie_code, cat.label AS categorie_label,
+    e.sous_categorie_code, e.marque, e.modele, e.numero_serie, e.criticite,
+    e.etat, e.etat_motif, e.etat_changed_at::text AS etat_changed_at, e.statut,
+    e.proprietaire_service, e.site, e.magasin, e.zone, e.localisation_precise,
+    e.date_mise_en_service::text AS date_mise_en_service,
+    e.date_retrait::text AS date_retrait,
+    e.unite, e.plage_min::text AS plage_min, e.plage_max::text AS plage_max,
+    e.resolution::text AS resolution, e.mpe::text AS mpe, e.incertitude::text AS incertitude,
+    e.methodes, e.conditions_utilisation, e.restrictions, e.etalon_reference,
+    e.exige_certificat, e.specifications,
+    e.quarantine_reason, e.quarantined_at::text AS quarantined_at,
+    e.last_conforme_at::text AS last_conforme_at,
+    e.last_conforme_execution_id::text AS last_conforme_execution_id,
+    e.notes, e.created_at::text AS created_at, e.updated_at::text AS updated_at,
+    ru.id AS responsable_id, ru.username AS responsable_username,
+    ru.name AS responsable_name, ru.surname AS responsable_surname,
+    cb.id AS created_by_id, cb.username AS created_by_username,
+    cb.name AS created_by_name, cb.surname AS created_by_surname,
+    ub.id AS updated_by_id, ub.username AS updated_by_username,
+    ub.name AS updated_by_name, ub.surname AS updated_by_surname
+  FROM public.metrologie_equipements e
+  LEFT JOIN public.metrologie_categories cat ON cat.code = e.categorie_code
+  LEFT JOIN public.users ru ON ru.id = e.responsable_user_id
+  LEFT JOIN public.users cb ON cb.id = e.created_by
+  LEFT JOIN public.users ub ON ub.id = e.updated_by
+`;
+
+function mapEquipment(row: EquipmentRow, due: DueEvaluation): MetrologyEquipmentDTO {
+  return {
+    id: row.id,
+    code: row.code,
+    designation: row.designation,
+    categorie_code: row.categorie_code,
+    categorie_label: row.categorie_label,
+    sous_categorie_code: row.sous_categorie_code,
+    marque: row.marque,
+    modele: row.modele,
+    numero_serie: row.numero_serie,
+    criticite: row.criticite,
+    etat: row.etat,
+    etat_effectif: deriveEffectiveState({ storedState: row.etat, due }),
+    etat_motif: row.etat_motif,
+    etat_changed_at: row.etat_changed_at,
+    statut_legacy: row.statut,
+    proprietaire_service: row.proprietaire_service,
+    responsable: mapUserRef({
+      id: row.responsable_id,
+      username: row.responsable_username,
+      name: row.responsable_name,
+      surname: row.responsable_surname,
+    }),
+    site: row.site,
+    magasin: row.magasin,
+    zone: row.zone,
+    localisation_precise: row.localisation_precise,
+    date_mise_en_service: row.date_mise_en_service,
+    date_retrait: row.date_retrait,
+    unite: row.unite,
+    plage_min: toNumber(row.plage_min),
+    plage_max: toNumber(row.plage_max),
+    resolution: toNumber(row.resolution),
+    mpe: toNumber(row.mpe),
+    incertitude: toNumber(row.incertitude),
+    methodes: row.methodes ?? [],
+    conditions_utilisation: row.conditions_utilisation,
+    restrictions: row.restrictions,
+    etalon_reference: row.etalon_reference,
+    exige_certificat: row.exige_certificat === true,
+    specifications: isRecord(row.specifications) ? row.specifications : {},
+    quarantine_reason: row.quarantine_reason,
+    quarantined_at: row.quarantined_at,
+    last_conforme_at: row.last_conforme_at,
+    last_conforme_execution_id: row.last_conforme_execution_id,
+    notes: row.notes,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+    created_by: mapUserRef({
+      id: row.created_by_id,
+      username: row.created_by_username,
+      name: row.created_by_name,
+      surname: row.created_by_surname,
+    }),
+    updated_by: mapUserRef({
+      id: row.updated_by_id,
+      username: row.updated_by_username,
+      name: row.updated_by_name,
+      surname: row.updated_by_surname,
+    }),
+  };
+}
+
+type PlanRow = {
+  id: string;
+  equipement_id: string;
+  version: number;
+  status: "DRAFT" | "ACTIVE" | "ARCHIVED";
+  operation_type: "ETALONNAGE" | "VERIFICATION";
+  methode: string | null;
+  procedure_ref: string | null;
+  periodicite_valeur: number;
+  periodicite_unite: "DAY" | "WEEK" | "MONTH" | "YEAR";
+  base_calcul: "LAST_PROOF" | "FIXED_DATE";
+  alert_window_days: number;
+  criteres: unknown;
+  tolerance_min: string | null;
+  tolerance_max: string | null;
+  unite: string | null;
+  prestataire_type: "INTERNE" | "EXTERNE";
+  prestataire_label: string | null;
+  fournisseur_id: string | null;
+  role_habilite: string | null;
+  criticite: "NORMAL" | "CRITIQUE";
+  blocking_strategy: "BLOCK" | "WARN" | "NONE";
+  exige_certificat: boolean;
+  effective_from: string | null;
+  last_proof_date: string | null;
+  last_proof_execution_id: string | null;
+  next_due_date: string | null;
+  notes: string | null;
+  published_at: string | null;
+  archived_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+function mapPlan(row: PlanRow, at: Date): MetrologyPlanVersionDTO {
+  const criteres = isRecord(row.criteres) ? row.criteres : {};
+  const due = evaluateDue({
+    nextDueDate: row.next_due_date ? row.next_due_date.slice(0, 10) : null,
+    alertWindowDays: row.alert_window_days,
+    at,
+  });
+  return {
+    id: row.id,
+    equipement_id: row.equipement_id,
+    version: row.version,
+    status: row.status,
+    operation_type: row.operation_type,
+    methode: row.methode,
+    procedure_ref: row.procedure_ref,
+    periodicite_valeur: row.periodicite_valeur,
+    periodicite_unite: row.periodicite_unite,
+    base_calcul: row.base_calcul,
+    alert_window_days: row.alert_window_days,
+    tolerance_min: toNumber(row.tolerance_min),
+    tolerance_max: toNumber(row.tolerance_max),
+    unite: row.unite,
+    min_points: toNumber(criteres.min_points),
+    prestataire_type: row.prestataire_type,
+    prestataire_label: row.prestataire_label,
+    fournisseur_id: row.fournisseur_id,
+    role_habilite: row.role_habilite,
+    criticite: row.criticite,
+    blocking_strategy: row.blocking_strategy,
+    exige_certificat: row.exige_certificat === true,
+    effective_from: row.effective_from,
+    last_proof_date: row.last_proof_date,
+    last_proof_execution_id: row.last_proof_execution_id,
+    next_due_date: row.next_due_date,
+    due: mapDue(due),
+    notes: row.notes,
+    published_at: row.published_at,
+    archived_at: row.archived_at,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+const PLAN_SELECT = `
+  SELECT
+    p.id::text AS id, p.equipement_id::text AS equipement_id, p.version, p.status,
+    p.operation_type, p.methode, p.procedure_ref,
+    p.periodicite_valeur, p.periodicite_unite, p.base_calcul, p.alert_window_days,
+    p.criteres, p.tolerance_min::text AS tolerance_min, p.tolerance_max::text AS tolerance_max,
+    p.unite, p.prestataire_type, p.prestataire_label, p.fournisseur_id::text AS fournisseur_id,
+    p.role_habilite, p.criticite, p.blocking_strategy, p.exige_certificat,
+    p.effective_from::text AS effective_from,
+    p.last_proof_date::text AS last_proof_date,
+    p.last_proof_execution_id::text AS last_proof_execution_id,
+    p.next_due_date::text AS next_due_date,
+    p.notes, p.published_at::text AS published_at, p.archived_at::text AS archived_at,
+    p.created_at::text AS created_at, p.updated_at::text AS updated_at
+  FROM public.metrologie_plan_version p
+`;
+
+export async function repoGetEquipmentDetail(params: {
+  id: string;
+  actor: MetrologyActor;
+}): Promise<MetrologyEquipmentDetailDTO | null> {
+  const coreRes = await db().query<EquipmentRow>(
+    `${EQUIPMENT_DETAIL_SELECT} WHERE e.id = $1::uuid AND e.deleted_at IS NULL LIMIT 1`,
+    [params.id]
+  );
+  const core = coreRes.rows[0] ?? null;
+  if (!core) return null;
+
+  const at = new Date();
+  const plansRes = await db().query<PlanRow>(
+    `${PLAN_SELECT} WHERE p.equipement_id = $1::uuid ORDER BY p.operation_type ASC, p.version DESC`,
+    [params.id]
+  );
+  const plans = plansRes.rows.map((row) => mapPlan(row, at));
+
+  const activePlan = plans
+    .filter((plan) => plan.status === "ACTIVE")
+    .sort((left, right) => compareNullableDate(left.next_due_date, right.next_due_date))[0];
+
+  const instrument = await loadInstrumentState(db(), params.id);
+  const due = evaluateDue({
+    nextDueDate: instrument?.next_due_date ?? activePlan?.next_due_date ?? null,
+    alertWindowDays: activePlan?.alert_window_days ?? 30,
+    at,
+  });
+
+  const [executions, certificats, impacts] = await Promise.all([
+    listRecentExecutions(params.id),
+    listCertificates(params.id),
+    listRecentImpacts(params.id),
+  ]);
+
+  return {
+    equipement: mapEquipment(core, due),
+    due: mapDue(due),
+    plans,
+    executions,
+    certificats,
+    impacts,
+    capabilities: capabilitiesFor(params.actor.role),
+  };
+}
+
+function compareNullableDate(left: string | null, right: string | null): number {
+  if (left === right) return 0;
+  if (left === null) return 1;
+  if (right === null) return -1;
+  return left < right ? -1 : 1;
+}
+
+async function listRecentExecutions(
+  equipementId: string
+): Promise<MetrologyEquipmentDetailDTO["executions"]> {
+  const res = await db().query(
+    `
+      SELECT
+        x.id::text AS id, x.code, x.equipement_id::text AS equipement_id,
+        x.operation_type, x.status, x.verdict,
+        x.started_at::text AS started_at, x.ended_at::text AS ended_at,
+        x.provider_label, x.next_due_date::text AS next_due_date,
+        x.updated_at::text AS updated_at,
+        ou.id AS operator_id, ou.username AS operator_username,
+        ou.name AS operator_name, ou.surname AS operator_surname,
+        (SELECT COUNT(*)::int FROM public.metrologie_certificats c
+          WHERE c.execution_id = x.id AND c.deleted_at IS NULL) AS certificate_count
+      FROM public.metrologie_execution x
+      LEFT JOIN public.users ou ON ou.id = x.operator_user_id
+      WHERE x.equipement_id = $1::uuid
+      ORDER BY x.started_at DESC, x.id DESC
+      LIMIT 50
+    `,
+    [equipementId]
+  );
+  return res.rows.map((row: Record<string, unknown>) => ({
+    id: String(row.id),
+    code: String(row.code),
+    equipement_id: String(row.equipement_id),
+    operation_type: row.operation_type as MetrologyEquipmentDetailDTO["executions"][number]["operation_type"],
+    status: row.status as MetrologyEquipmentDetailDTO["executions"][number]["status"],
+    verdict: (row.verdict ?? null) as MetrologyEquipmentDetailDTO["executions"][number]["verdict"],
+    started_at: String(row.started_at),
+    ended_at: (row.ended_at ?? null) as string | null,
+    operator: mapUserRef({
+      id: (row.operator_id ?? null) as number | null,
+      username: (row.operator_username ?? null) as string | null,
+      name: (row.operator_name ?? null) as string | null,
+      surname: (row.operator_surname ?? null) as string | null,
+    }),
+    provider_label: (row.provider_label ?? null) as string | null,
+    next_due_date: (row.next_due_date ?? null) as string | null,
+    certificate_count: toInt(row.certificate_count, 0),
+    updated_at: String(row.updated_at),
+  }));
+}
+
+async function listCertificates(
+  equipementId: string
+): Promise<MetrologyEquipmentDetailDTO["certificats"]> {
+  const res = await db().query(
+    `
+      SELECT
+        c.id::text AS id, c.equipement_id::text AS equipement_id,
+        c.execution_id::text AS execution_id, c.document_kind,
+        c.date_etalonnage::text AS date_etalonnage, c.date_echeance::text AS date_echeance,
+        c.resultat, c.statut, c.emetteur, c.numero_externe, c.organisme, c.commentaire,
+        c.confidentiality, c.cancel_reason, c.cancelled_at::text AS cancelled_at,
+        c.replaced_by_id::text AS replaced_by_id,
+        c.file_original_name, c.mime_type, c.size_bytes::text AS size_bytes, c.sha256,
+        (c.storage_path IS NOT NULL) AS has_file,
+        c.created_at::text AS created_at,
+        cb.id AS created_by_id, cb.username AS created_by_username,
+        cb.name AS created_by_name, cb.surname AS created_by_surname
+      FROM public.metrologie_certificats c
+      LEFT JOIN public.users cb ON cb.id = c.created_by
+      WHERE c.equipement_id = $1::uuid AND c.deleted_at IS NULL
+      ORDER BY c.date_etalonnage DESC, c.created_at DESC
+      LIMIT 100
+    `,
+    [equipementId]
+  );
+  return res.rows.map((row: Record<string, unknown>) => ({
+    id: String(row.id),
+    equipement_id: String(row.equipement_id),
+    execution_id: (row.execution_id ?? null) as string | null,
+    document_kind: row.document_kind as MetrologyEquipmentDetailDTO["certificats"][number]["document_kind"],
+    date_etalonnage: String(row.date_etalonnage),
+    date_echeance: (row.date_echeance ?? null) as string | null,
+    resultat: row.resultat as MetrologyEquipmentDetailDTO["certificats"][number]["resultat"],
+    statut: row.statut as MetrologyEquipmentDetailDTO["certificats"][number]["statut"],
+    emetteur: (row.emetteur ?? null) as string | null,
+    numero_externe: (row.numero_externe ?? null) as string | null,
+    organisme: (row.organisme ?? null) as string | null,
+    commentaire: (row.commentaire ?? null) as string | null,
+    confidentiality:
+      row.confidentiality as MetrologyEquipmentDetailDTO["certificats"][number]["confidentiality"],
+    cancel_reason: (row.cancel_reason ?? null) as string | null,
+    cancelled_at: (row.cancelled_at ?? null) as string | null,
+    replaced_by_id: (row.replaced_by_id ?? null) as string | null,
+    file_original_name: (row.file_original_name ?? null) as string | null,
+    mime_type: (row.mime_type ?? null) as string | null,
+    size_bytes: toNumber(row.size_bytes),
+    sha256: (row.sha256 ?? null) as string | null,
+    has_file: row.has_file === true,
+    created_at: String(row.created_at),
+    created_by: mapUserRef({
+      id: (row.created_by_id ?? null) as number | null,
+      username: (row.created_by_username ?? null) as string | null,
+      name: (row.created_by_name ?? null) as string | null,
+      surname: (row.created_by_surname ?? null) as string | null,
+    }),
+  }));
+}
+
+async function listRecentImpacts(
+  equipementId: string
+): Promise<MetrologyEquipmentDetailDTO["impacts"]> {
+  const res = await db().query(
+    `
+      SELECT
+        d.id::text AS id, d.code, d.equipement_id::text AS equipement_id,
+        e.code AS equipement_code, e.designation AS equipement_designation,
+        d.trigger_type, d.status, d.priority,
+        d.window_from::text AS window_from, d.window_to::text AS window_to,
+        d.volumes, d.truncated,
+        d.created_at::text AS created_at, d.updated_at::text AS updated_at,
+        (SELECT COUNT(*)::int FROM public.metrologie_impact_item i
+          WHERE i.dossier_id = d.id AND i.decision = 'PENDING') AS pending_items
+      FROM public.metrologie_impact_dossier d
+      JOIN public.metrologie_equipements e ON e.id = d.equipement_id
+      WHERE d.equipement_id = $1::uuid
+      ORDER BY d.created_at DESC
+      LIMIT 20
+    `,
+    [equipementId]
+  );
+  return res.rows.map(mapImpactListRow);
+}
+
+export function mapImpactListRow(
+  row: Record<string, unknown>
+): MetrologyEquipmentDetailDTO["impacts"][number] {
+  const volumes = isRecord(row.volumes) ? row.volumes : {};
+  return {
+    id: String(row.id),
+    code: String(row.code),
+    equipement_id: String(row.equipement_id),
+    equipement_code: (row.equipement_code ?? null) as string | null,
+    equipement_designation: (row.equipement_designation ?? null) as string | null,
+    trigger_type: row.trigger_type as "VERDICT_NON_CONFORME" | "CERTIFICAT_INVALIDE" | "MANUEL",
+    status: row.status as MetrologyEquipmentDetailDTO["impacts"][number]["status"],
+    priority: row.priority as "LOW" | "NORMAL" | "HIGH" | "CRITICAL",
+    window_from: String(row.window_from),
+    window_to: String(row.window_to),
+    volumes: {
+      controls: toInt(volumes.controls, 0),
+      work_orders: toInt(volumes.work_orders, 0),
+      lots: toInt(volumes.lots, 0),
+      deliveries: toInt(volumes.deliveries, 0),
+      truncated: row.truncated === true,
+    },
+    pending_items: toInt(row.pending_items, 0),
+    created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+  };
+}
+
+/* ========================================================================== */
+/* Équipements — écriture                                                     */
+/* ========================================================================== */
+
+type EquipmentLock = {
+  id: string;
+  code: string | null;
+  etat: MetrologyEquipmentState;
+  updated_at: string;
+  created_at: string;
+  criticite: string;
+  designation: string;
+};
+
+async function lockEquipment(client: PoolClient, id: string): Promise<EquipmentLock> {
+  const res = await client.query<EquipmentLock>(
+    `
+      SELECT id::text AS id, code, etat, criticite, designation,
+             updated_at::text AS updated_at, created_at::text AS created_at
+      FROM public.metrologie_equipements
+      WHERE id = $1::uuid AND deleted_at IS NULL
+      FOR UPDATE
+    `,
+    [id]
+  );
+  const row = res.rows[0] ?? null;
+  if (!row) throw new HttpError(404, "NOT_FOUND", "Équipement de métrologie introuvable.");
+  return row;
+}
+
+async function assertCategoryUsable(
+  q: DbQueryer,
+  code: string,
+  field: string
+): Promise<{
+  requires_range: boolean;
+  requires_resolution: boolean;
+  requires_uncertainty: boolean;
+  requires_unit: boolean;
+}> {
+  const res = await q.query<{
+    active: boolean;
+    requires_range: boolean;
+    requires_resolution: boolean;
+    requires_uncertainty: boolean;
+    requires_unit: boolean;
+  }>(
+    `SELECT active, requires_range, requires_resolution, requires_uncertainty, requires_unit
+       FROM public.metrologie_categories WHERE code = $1`,
+    [code]
+  );
+  const row = res.rows[0] ?? null;
+  if (!row) {
+    throw new HttpError(422, "METROLOGY_CATEGORY_UNKNOWN", "Catégorie d'équipement inconnue.", {
+      fields: { [field]: ["Catégorie inconnue."] },
+    });
+  }
+  if (!row.active) {
+    throw new HttpError(422, "METROLOGY_CATEGORY_INACTIVE", "Cette catégorie est désactivée.", {
+      fields: { [field]: ["Catégorie désactivée : choisissez une catégorie active."] },
+    });
+  }
+  return row;
+}
+
+/**
+ * Les exigences déclarées par la catégorie sont vérifiées SERVEUR : une MMT sans
+ * plage ni unité n'est pas un enregistrement valide, quoi qu'affiche l'UI.
+ */
+function assertSpecificationsMatchCategory(
+  requirements: {
+    requires_range: boolean;
+    requires_resolution: boolean;
+    requires_uncertainty: boolean;
+    requires_unit: boolean;
+  },
+  body: CreateEquipmentBodyDTO | UpdateEquipmentBodyDTO
+): void {
+  const fields: Record<string, string[]> = {};
+  if (requirements.requires_unit && !body.unite) {
+    fields.unite = ["Cette catégorie exige une unité normalisée."];
+  }
+  if (requirements.requires_range && (body.plage_min === null || body.plage_max === null)) {
+    if (body.plage_min === null) fields.plage_min = ["Cette catégorie exige une plage de mesure."];
+    if (body.plage_max === null) fields.plage_max = ["Cette catégorie exige une plage de mesure."];
+  }
+  if (requirements.requires_resolution && body.resolution === null) {
+    fields.resolution = ["Cette catégorie exige une résolution."];
+  }
+  if (requirements.requires_uncertainty && body.incertitude === null && body.mpe === null) {
+    fields.incertitude = ["Cette catégorie exige une incertitude ou une EMT."];
+  }
+  if (Object.keys(fields).length > 0) {
+    throw new HttpError(
+      422,
+      "METROLOGY_SPECIFICATIONS_INCOMPLETE",
+      "Spécifications incomplètes pour cette catégorie.",
+      { fields }
+    );
+  }
+}
+
+export async function repoCreateEquipment(params: {
+  body: CreateEquipmentBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyEquipmentDetailDTO> {
+  const { body, actor } = params;
+  const id = await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.equipment.create",
+      requestPayload: body,
+    });
+    if (claim.replay && typeof claim.replay.id === "string") return claim.replay.id;
+
+    const requirements = await assertCategoryUsable(client, body.categorie_code, "categorie_code");
+    if (body.sous_categorie_code) {
+      await assertCategoryUsable(client, body.sous_categorie_code, "sous_categorie_code");
+    }
+    assertSpecificationsMatchCategory(requirements, body);
+
+    // Le code visible est alloué par le serveur, dans la transaction, et devient
+    // immuable (trigger). Un code proposé par le client n'est jamais retenu.
+    const code = await generateMetrologieEquipementCode(client);
+
+    let newId: string;
+    try {
+      const ins = await client.query<{ id: string }>(
+        `
+          INSERT INTO public.metrologie_equipements (
+            code, designation, categorie, categorie_code, sous_categorie_code,
+            marque, modele, numero_serie, criticite, statut, etat, notes,
+            proprietaire_service, responsable_user_id, site, magasin, zone, localisation_precise,
+            date_mise_en_service,
+            unite, plage_min, plage_max, resolution, mpe, incertitude, methodes,
+            conditions_utilisation, restrictions, etalon_reference, exige_certificat, specifications,
+            created_by, updated_by
+          )
+          VALUES (
+            $1,$2,$3,$3,$4,
+            $5,$6,$7,$8,'ACTIF','DRAFT',$9,
+            $10,$11,$12,$13,$14,$15,
+            $16::date,
+            $17,$18,$19,$20,$21,$22,$23::text[],
+            $24,$25,$26,$27,$28::jsonb,
+            $29,$29
+          )
+          RETURNING id::text AS id
+        `,
+        [
+          code,
+          body.designation,
+          body.categorie_code,
+          body.sous_categorie_code,
+          body.marque,
+          body.modele,
+          body.numero_serie,
+          body.criticite,
+          body.notes,
+          body.proprietaire_service,
+          body.responsable_user_id,
+          body.site,
+          body.magasin,
+          body.zone,
+          body.localisation_precise,
+          body.date_mise_en_service,
+          body.unite,
+          body.plage_min,
+          body.plage_max,
+          body.resolution,
+          body.mpe,
+          body.incertitude,
+          body.methodes,
+          body.conditions_utilisation,
+          body.restrictions,
+          body.etalon_reference,
+          body.exige_certificat,
+          JSON.stringify(body.specifications ?? {}),
+          actor.user_id,
+        ]
+      );
+      newId = ins.rows[0]?.id ?? "";
+    } catch (err) {
+      rethrowMapped(err);
+    }
+    if (!newId) throw new HttpError(500, "METROLOGY_EQUIPMENT_CREATE_FAILED", "Création impossible.");
+
+    const correlationId = crypto.randomUUID();
+    await insertMetrologyEvent(client, {
+      equipement_id: newId,
+      entity_type: "EQUIPEMENT",
+      entity_id: newId,
+      event_type: "EQUIPEMENT_CREATED",
+      actor,
+      old_values: null,
+      new_values: { code, designation: body.designation, categorie_code: body.categorie_code, etat: "DRAFT" },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.equipements.create",
+      entity_type: "metrologie_equipements",
+      entity_id: newId,
+      details: { code, designation: body.designation, criticite: body.criticite },
+    });
+
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.equipment.create",
+      aggregateType: "EQUIPEMENT",
+      aggregateId: newId,
+      requestPayload: body,
+      resultPayload: { id: newId, code },
+      correlationId,
+    });
+    return newId;
+  });
+
+  const detail = await repoGetEquipmentDetail({ id, actor });
+  if (!detail) throw new HttpError(500, "METROLOGY_EQUIPMENT_RELOAD_FAILED", "Équipement introuvable après création.");
+  return detail;
+}
+
+export async function repoUpdateEquipment(params: {
+  id: string;
+  body: UpdateEquipmentBodyDTO;
+  actor: MetrologyActor;
+}): Promise<MetrologyEquipmentDetailDTO> {
+  const { id, body, actor } = params;
+  await withTransaction(async (client) => {
+    const current = await lockEquipment(client, id);
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: current.updated_at,
+    });
+
+    const requirements = await assertCategoryUsable(client, body.categorie_code, "categorie_code");
+    if (body.sous_categorie_code) {
+      await assertCategoryUsable(client, body.sous_categorie_code, "sous_categorie_code");
+    }
+    assertSpecificationsMatchCategory(requirements, body);
+
+    try {
+      await client.query(
+        `
+          UPDATE public.metrologie_equipements SET
+            designation = $2,
+            categorie = $3,
+            categorie_code = $3,
+            sous_categorie_code = $4,
+            marque = $5, modele = $6, numero_serie = $7, criticite = $8, notes = $9,
+            proprietaire_service = $10, responsable_user_id = $11,
+            site = $12, magasin = $13, zone = $14, localisation_precise = $15,
+            date_mise_en_service = $16::date, date_retrait = $17::date,
+            unite = $18, plage_min = $19, plage_max = $20, resolution = $21,
+            mpe = $22, incertitude = $23, methodes = $24::text[],
+            conditions_utilisation = $25, restrictions = $26, etalon_reference = $27,
+            exige_certificat = $28, specifications = $29::jsonb,
+            updated_at = now(), updated_by = $30
+          WHERE id = $1::uuid
+        `,
+        [
+          id,
+          body.designation,
+          body.categorie_code,
+          body.sous_categorie_code,
+          body.marque,
+          body.modele,
+          body.numero_serie,
+          body.criticite,
+          body.notes,
+          body.proprietaire_service,
+          body.responsable_user_id,
+          body.site,
+          body.magasin,
+          body.zone,
+          body.localisation_precise,
+          body.date_mise_en_service,
+          body.date_retrait,
+          body.unite,
+          body.plage_min,
+          body.plage_max,
+          body.resolution,
+          body.mpe,
+          body.incertitude,
+          body.methodes,
+          body.conditions_utilisation,
+          body.restrictions,
+          body.etalon_reference,
+          body.exige_certificat,
+          JSON.stringify(body.specifications ?? {}),
+          actor.user_id,
+        ]
+      );
+    } catch (err) {
+      rethrowMapped(err);
+    }
+
+    await insertMetrologyEvent(client, {
+      equipement_id: id,
+      entity_type: "EQUIPEMENT",
+      entity_id: id,
+      event_type: "EQUIPEMENT_UPDATED",
+      actor,
+      old_values: { designation: current.designation, criticite: current.criticite },
+      new_values: { designation: body.designation, criticite: body.criticite },
+      correlation_id: crypto.randomUUID(),
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.equipements.update",
+      entity_type: "metrologie_equipements",
+      entity_id: id,
+      details: { designation: body.designation },
+    });
+  });
+
+  const detail = await repoGetEquipmentDetail({ id, actor });
+  if (!detail) throw new HttpError(404, "NOT_FOUND", "Équipement introuvable.");
+  return detail;
+}
+
+export async function repoTransitionEquipment(params: {
+  id: string;
+  body: EquipmentTransitionBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyEquipmentDetailDTO> {
+  const { id, body, actor } = params;
+  await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.equipment.transition",
+      requestPayload: { id, ...body },
+    });
+    if (claim.replay) return;
+
+    const current = await lockEquipment(client, id);
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: current.updated_at,
+    });
+    assertEquipmentTransition(current.etat, body.target_state);
+
+    // Une remise en service après quarantaine / hors tolérance / réparation
+    // n'est jamais un simple changement de statut.
+    if (transitionRequiresRelease(current.etat, body.target_state)) {
+      if (!roleHasMetrologyCapability(actor.role, "equipment_release")) {
+        throw new HttpError(
+          403,
+          "METROLOGY_CAPABILITY_REQUIRED",
+          "La capacité Métrologie 'equipment_release' est requise pour remettre un instrument en service."
+        );
+      }
+      const proof = await loadReleaseProof(client, id, body.proof_execution_id ?? null);
+      assertEquipmentReleaseAllowed({
+        hasValidConformeProof: proof.valid,
+        proofExecutionId: proof.executionId,
+        repairRequired: current.etat === "UNDER_REPAIR" || current.etat === "OUT_OF_TOLERANCE",
+        repairDone: proof.repairDone,
+        reason: body.reason,
+      });
+    }
+
+    await client.query(
+      `
+        UPDATE public.metrologie_equipements
+        SET etat = $2, etat_motif = $3, etat_changed_at = now(), etat_changed_by = $4,
+            quarantine_reason = CASE WHEN $2 IN ('QUARANTINE','OUT_OF_TOLERANCE') THEN quarantine_reason ELSE NULL END,
+            quarantined_at = CASE WHEN $2 IN ('QUARANTINE','OUT_OF_TOLERANCE') THEN quarantined_at ELSE NULL END,
+            quarantined_by = CASE WHEN $2 IN ('QUARANTINE','OUT_OF_TOLERANCE') THEN quarantined_by ELSE NULL END,
+            date_retrait = CASE WHEN $2 = 'RETIRED' THEN COALESCE(date_retrait, CURRENT_DATE) ELSE date_retrait END,
+            updated_at = now(), updated_by = $4
+        WHERE id = $1::uuid
+      `,
+      [id, body.target_state, body.reason, actor.user_id]
+    );
+
+    const correlationId = crypto.randomUUID();
+    await insertMetrologyEvent(client, {
+      equipement_id: id,
+      entity_type: "EQUIPEMENT",
+      entity_id: id,
+      event_type: `EQUIPEMENT_STATE_${body.target_state}`,
+      actor,
+      old_values: { etat: current.etat },
+      new_values: { etat: body.target_state, proof_execution_id: body.proof_execution_id ?? null },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+      reason: body.reason,
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.equipements.transition",
+      entity_type: "metrologie_equipements",
+      entity_id: id,
+      details: { from: current.etat, to: body.target_state, reason: body.reason },
+    });
+
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.equipment.transition",
+      aggregateType: "EQUIPEMENT",
+      aggregateId: id,
+      requestPayload: { id, ...body },
+      resultPayload: { id, etat: body.target_state },
+      correlationId,
+    });
+  });
+
+  const detail = await repoGetEquipmentDetail({ id, actor });
+  if (!detail) throw new HttpError(404, "NOT_FOUND", "Équipement introuvable.");
+  return detail;
+}
+
+async function loadReleaseProof(
+  client: PoolClient,
+  equipementId: string,
+  requestedExecutionId: string | null
+): Promise<{ valid: boolean; executionId: string | null; repairDone: boolean }> {
+  const res = await client.query<{ id: string; verdict: string; ended_at: string; operation_type: string }>(
+    `
+      SELECT id::text AS id, verdict, ended_at::text AS ended_at, operation_type
+      FROM public.metrologie_execution
+      WHERE equipement_id = $1::uuid
+        AND status = 'VALIDATED'
+        AND verdict IN ('CONFORME', 'CONFORME_AVEC_RESTRICTION')
+        AND ($2::uuid IS NULL OR id = $2::uuid)
+      ORDER BY ended_at DESC NULLS LAST
+      LIMIT 1
+    `,
+    [equipementId, requestedExecutionId]
+  );
+  const proof = res.rows[0] ?? null;
+
+  const repair = await client.query<{ total: string }>(
+    `
+      SELECT COUNT(*)::text AS total
+      FROM public.metrologie_execution
+      WHERE equipement_id = $1::uuid
+        AND status = 'VALIDATED'
+        AND operation_type IN ('AJUSTAGE', 'REPARATION')
+        AND ($2::timestamptz IS NULL OR ended_at >= $2::timestamptz)
+    `,
+    [equipementId, null]
+  );
+
+  return {
+    valid: Boolean(proof),
+    executionId: proof?.id ?? null,
+    repairDone: toInt(repair.rows[0]?.total, 0) > 0,
+  };
+}
+
+export async function repoQuarantineEquipment(params: {
+  id: string;
+  body: QuarantineBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyEquipmentDetailDTO> {
+  const { id, body, actor } = params;
+  await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.equipment.quarantine",
+      requestPayload: { id, ...body },
+    });
+    if (claim.replay) return;
+
+    const current = await lockEquipment(client, id);
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: current.updated_at,
+    });
+    if (current.etat !== "QUARANTINE") {
+      assertEquipmentTransition(current.etat, "QUARANTINE");
+    }
+
+    await client.query(
+      `
+        UPDATE public.metrologie_equipements
+        SET etat = 'QUARANTINE', etat_motif = $2, etat_changed_at = now(), etat_changed_by = $3,
+            quarantine_reason = $2, quarantined_at = now(), quarantined_by = $3,
+            updated_at = now(), updated_by = $3
+        WHERE id = $1::uuid
+      `,
+      [id, body.reason, actor.user_id]
+    );
+
+    const correlationId = crypto.randomUUID();
+    let dossierId: string | null = null;
+    if (body.open_impact_analysis) {
+      const dossier = await openImpactDossier(client, {
+        equipementId: id,
+        executionId: null,
+        certificatId: null,
+        trigger: "MANUEL",
+        actor,
+        correlationId,
+        approvedWindow: null,
+        exclusions: null,
+        ownerUserId: null,
+      });
+      dossierId = dossier.id;
+    }
+
+    await insertMetrologyEvent(client, {
+      equipement_id: id,
+      entity_type: "EQUIPEMENT",
+      entity_id: id,
+      event_type: "EQUIPEMENT_QUARANTINE",
+      actor,
+      old_values: { etat: current.etat },
+      new_values: { etat: "QUARANTINE", impact_dossier_id: dossierId },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+      reason: body.reason,
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.equipements.quarantine",
+      entity_type: "metrologie_equipements",
+      entity_id: id,
+      details: { reason: body.reason, impact_dossier_id: dossierId },
+    });
+
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.equipment.quarantine",
+      aggregateType: "EQUIPEMENT",
+      aggregateId: id,
+      requestPayload: { id, ...body },
+      resultPayload: { id, etat: "QUARANTINE", impact_dossier_id: dossierId },
+      correlationId,
+    });
+  });
+
+  const detail = await repoGetEquipmentDetail({ id, actor });
+  if (!detail) throw new HttpError(404, "NOT_FOUND", "Équipement introuvable.");
+  return detail;
+}
+
+/* ========================================================================== */
+/* Plans versionnés                                                           */
+/* ========================================================================== */
+
+function planCriteria(body: CreatePlanBodyDTO | RevisePlanBodyDTO): Record<string, unknown> {
+  return { min_points: body.min_points };
+}
+
+export async function repoCreatePlanVersion(params: {
+  equipementId: string;
+  body: CreatePlanBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyPlanVersionDTO> {
+  const { equipementId, body, actor } = params;
+  const planId = await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.plan.create",
+      requestPayload: { equipementId, ...body },
+    });
+    if (claim.replay && typeof claim.replay.id === "string") return claim.replay.id;
+
+    await lockEquipment(client, equipementId);
+
+    const versionRes = await client.query<{ next_version: number }>(
+      `SELECT COALESCE(MAX(version), 0) + 1 AS next_version
+         FROM public.metrologie_plan_version
+        WHERE equipement_id = $1::uuid AND operation_type = $2`,
+      [equipementId, body.operation_type]
+    );
+    const version = toInt(versionRes.rows[0]?.next_version, 1);
+
+    let newId: string;
+    try {
+      const ins = await client.query<{ id: string }>(
+        `
+          INSERT INTO public.metrologie_plan_version (
+            equipement_id, version, status, operation_type, methode, procedure_ref,
+            periodicite_valeur, periodicite_unite, base_calcul, alert_window_days,
+            criteres, tolerance_min, tolerance_max, unite,
+            prestataire_type, prestataire_label, fournisseur_id, role_habilite,
+            criticite, blocking_strategy, exige_certificat, effective_from, notes,
+            created_by, updated_by
+          )
+          VALUES (
+            $1::uuid,$2,'DRAFT',$3,$4,$5,
+            $6,$7,$8,$9,
+            $10::jsonb,$11,$12,$13,
+            $14,$15,$16::uuid,$17,
+            $18,$19,$20,$21::date,$22,
+            $23,$23
+          )
+          RETURNING id::text AS id
+        `,
+        [
+          equipementId,
+          version,
+          body.operation_type,
+          body.methode,
+          body.procedure_ref,
+          body.periodicite_valeur,
+          body.periodicite_unite,
+          body.base_calcul,
+          body.alert_window_days,
+          JSON.stringify(planCriteria(body)),
+          body.tolerance_min,
+          body.tolerance_max,
+          body.unite,
+          body.prestataire_type,
+          body.prestataire_label,
+          body.fournisseur_id ?? null,
+          body.role_habilite,
+          body.criticite,
+          body.blocking_strategy,
+          body.exige_certificat,
+          body.effective_from,
+          body.notes,
+          actor.user_id,
+        ]
+      );
+      newId = ins.rows[0]?.id ?? "";
+    } catch (err) {
+      rethrowMapped(err);
+    }
+    if (!newId) throw new HttpError(500, "METROLOGY_PLAN_CREATE_FAILED", "Création du plan impossible.");
+
+    const correlationId = crypto.randomUUID();
+    await insertMetrologyEvent(client, {
+      equipement_id: equipementId,
+      entity_type: "PLAN",
+      entity_id: newId,
+      event_type: "PLAN_VERSION_CREATED",
+      actor,
+      old_values: null,
+      new_values: { version, operation_type: body.operation_type, status: "DRAFT" },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.plans.create",
+      entity_type: "metrologie_plan_version",
+      entity_id: newId,
+      details: { equipement_id: equipementId, version, operation_type: body.operation_type },
+    });
+
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.plan.create",
+      aggregateType: "PLAN",
+      aggregateId: newId,
+      requestPayload: { equipementId, ...body },
+      resultPayload: { id: newId, version },
+      correlationId,
+    });
+    return newId;
+  });
+
+  return loadPlan(planId);
+}
+
+export async function repoRevisePlanVersion(params: {
+  equipementId: string;
+  planId: string;
+  body: RevisePlanBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyPlanVersionDTO> {
+  const { equipementId, planId, body, actor } = params;
+  const newPlanId = await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.plan.revise",
+      requestPayload: { equipementId, planId, ...body },
+    });
+    if (claim.replay && typeof claim.replay.id === "string") return claim.replay.id;
+
+    await lockEquipment(client, equipementId);
+    const source = await client.query<{
+      id: string;
+      version: number;
+      status: "DRAFT" | "ACTIVE" | "ARCHIVED";
+      operation_type: string;
+      updated_at: string;
+    }>(
+      `SELECT id::text AS id, version, status, operation_type, updated_at::text AS updated_at
+         FROM public.metrologie_plan_version
+        WHERE id = $1::uuid AND equipement_id = $2::uuid
+        FOR UPDATE`,
+      [planId, equipementId]
+    );
+    const current = source.rows[0] ?? null;
+    if (!current) throw new HttpError(404, "NOT_FOUND", "Version de plan introuvable.");
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: current.updated_at,
+    });
+
+    // Réviser un brouillon = l'éditer sur place. Réviser une version publiée =
+    // créer la version suivante : la publiée reste figée.
+    if (current.status === "DRAFT") {
+      await client.query(
+        `
+          UPDATE public.metrologie_plan_version SET
+            operation_type = $2, methode = $3, procedure_ref = $4,
+            periodicite_valeur = $5, periodicite_unite = $6, base_calcul = $7,
+            alert_window_days = $8, criteres = $9::jsonb,
+            tolerance_min = $10, tolerance_max = $11, unite = $12,
+            prestataire_type = $13, prestataire_label = $14, fournisseur_id = $15::uuid,
+            role_habilite = $16, criticite = $17, blocking_strategy = $18,
+            exige_certificat = $19, effective_from = $20::date, notes = $21,
+            updated_at = now(), updated_by = $22
+          WHERE id = $1::uuid
+        `,
+        [
+          planId,
+          body.operation_type,
+          body.methode,
+          body.procedure_ref,
+          body.periodicite_valeur,
+          body.periodicite_unite,
+          body.base_calcul,
+          body.alert_window_days,
+          JSON.stringify(planCriteria(body)),
+          body.tolerance_min,
+          body.tolerance_max,
+          body.unite,
+          body.prestataire_type,
+          body.prestataire_label,
+          body.fournisseur_id ?? null,
+          body.role_habilite,
+          body.criticite,
+          body.blocking_strategy,
+          body.exige_certificat,
+          body.effective_from,
+          body.notes,
+          actor.user_id,
+        ]
+      );
+
+      await insertMetrologyEvent(client, {
+        equipement_id: equipementId,
+        entity_type: "PLAN",
+        entity_id: planId,
+        event_type: "PLAN_VERSION_EDITED",
+        actor,
+        old_values: { version: current.version, status: current.status },
+        new_values: { version: current.version },
+        correlation_id: crypto.randomUUID(),
+        idempotency_key: claim.idempotencyKey,
+        reason: body.revision_reason,
+      });
+      await saveReceipt({
+        client,
+        actor,
+        claim,
+        commandType: "metrology.plan.revise",
+        aggregateType: "PLAN",
+        aggregateId: planId,
+        requestPayload: { equipementId, planId, ...body },
+        resultPayload: { id: planId, version: current.version },
+        correlationId: crypto.randomUUID(),
+      });
+      return planId;
+    }
+
+    assertPlanContentMutable("DRAFT"); // Documente l'intention : le contenu publié est figé.
+    const versionRes = await client.query<{ next_version: number }>(
+      `SELECT COALESCE(MAX(version), 0) + 1 AS next_version
+         FROM public.metrologie_plan_version
+        WHERE equipement_id = $1::uuid AND operation_type = $2`,
+      [equipementId, body.operation_type]
+    );
+    const version = toInt(versionRes.rows[0]?.next_version, current.version + 1);
+
+    let createdId: string;
+    try {
+      const ins = await client.query<{ id: string }>(
+        `
+          INSERT INTO public.metrologie_plan_version (
+            equipement_id, version, status, operation_type, methode, procedure_ref,
+            periodicite_valeur, periodicite_unite, base_calcul, alert_window_days,
+            criteres, tolerance_min, tolerance_max, unite,
+            prestataire_type, prestataire_label, fournisseur_id, role_habilite,
+            criticite, blocking_strategy, exige_certificat, effective_from, notes,
+            created_by, updated_by
+          )
+          VALUES (
+            $1::uuid,$2,'DRAFT',$3,$4,$5,$6,$7,$8,$9,
+            $10::jsonb,$11,$12,$13,$14,$15,$16::uuid,$17,$18,$19,$20,$21::date,$22,$23,$23
+          )
+          RETURNING id::text AS id
+        `,
+        [
+          equipementId,
+          version,
+          body.operation_type,
+          body.methode,
+          body.procedure_ref,
+          body.periodicite_valeur,
+          body.periodicite_unite,
+          body.base_calcul,
+          body.alert_window_days,
+          JSON.stringify(planCriteria(body)),
+          body.tolerance_min,
+          body.tolerance_max,
+          body.unite,
+          body.prestataire_type,
+          body.prestataire_label,
+          body.fournisseur_id ?? null,
+          body.role_habilite,
+          body.criticite,
+          body.blocking_strategy,
+          body.exige_certificat,
+          body.effective_from,
+          body.notes,
+          actor.user_id,
+        ]
+      );
+      createdId = ins.rows[0]?.id ?? "";
+    } catch (err) {
+      rethrowMapped(err);
+    }
+    if (!createdId) throw new HttpError(500, "METROLOGY_PLAN_REVISE_FAILED", "Révision impossible.");
+
+    const correlationId = crypto.randomUUID();
+    await insertMetrologyEvent(client, {
+      equipement_id: equipementId,
+      entity_type: "PLAN",
+      entity_id: createdId,
+      event_type: "PLAN_VERSION_REVISED",
+      actor,
+      old_values: { from_plan_id: planId, from_version: current.version },
+      new_values: { version, status: "DRAFT" },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+      reason: body.revision_reason,
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.plans.revise",
+      entity_type: "metrologie_plan_version",
+      entity_id: createdId,
+      details: { equipement_id: equipementId, from_version: current.version, version },
+    });
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.plan.revise",
+      aggregateType: "PLAN",
+      aggregateId: createdId,
+      requestPayload: { equipementId, planId, ...body },
+      resultPayload: { id: createdId, version },
+      correlationId,
+    });
+    return createdId;
+  });
+
+  return loadPlan(newPlanId);
+}
+
+export async function repoTransitionPlanVersion(params: {
+  equipementId: string;
+  planId: string;
+  body: PlanTransitionBodyDTO;
+  actor: MetrologyActor;
+  idempotencyKey: string | null;
+}): Promise<MetrologyPlanVersionDTO> {
+  const { equipementId, planId, body, actor } = params;
+  await withTransaction(async (client) => {
+    const claim = await acquireIdempotency({
+      client,
+      actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "metrology.plan.transition",
+      requestPayload: { equipementId, planId, ...body },
+    });
+    if (claim.replay) return;
+
+    const equipment = await lockEquipment(client, equipementId);
+    const res = await client.query<{
+      id: string;
+      status: "DRAFT" | "ACTIVE" | "ARCHIVED";
+      version: number;
+      operation_type: string;
+      updated_at: string;
+      periodicite_valeur: number;
+      periodicite_unite: "DAY" | "WEEK" | "MONTH" | "YEAR";
+      base_calcul: "LAST_PROOF" | "FIXED_DATE";
+      alert_window_days: number;
+      effective_from: string | null;
+    }>(
+      `SELECT id::text AS id, status, version, operation_type, updated_at::text AS updated_at,
+              periodicite_valeur, periodicite_unite, base_calcul, alert_window_days,
+              effective_from::text AS effective_from
+         FROM public.metrologie_plan_version
+        WHERE id = $1::uuid AND equipement_id = $2::uuid
+        FOR UPDATE`,
+      [planId, equipementId]
+    );
+    const current = res.rows[0] ?? null;
+    if (!current) throw new HttpError(404, "NOT_FOUND", "Version de plan introuvable.");
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: current.updated_at,
+    });
+    assertPlanTransition(current.status, body.target_status);
+
+    if (body.target_status === "ACTIVE") {
+      // Publier une version archive la précédente : une seule règle applicable
+      // à la fois, jamais deux périodicités concurrentes.
+      await client.query(
+        `
+          UPDATE public.metrologie_plan_version
+          SET status = 'ARCHIVED', archived_at = now(), updated_at = now(), updated_by = $3
+          WHERE equipement_id = $1::uuid AND operation_type = $2 AND status = 'ACTIVE'
+        `,
+        [equipementId, current.operation_type, actor.user_id]
+      );
+
+      const proof = await client.query<{ ended_at: string | null }>(
+        `SELECT ended_at::text AS ended_at
+           FROM public.metrologie_execution
+          WHERE equipement_id = $1::uuid AND status = 'VALIDATED'
+            AND verdict IN ('CONFORME','CONFORME_AVEC_RESTRICTION')
+          ORDER BY ended_at DESC NULLS LAST LIMIT 1`,
+        [equipementId]
+      );
+      const schedule = computeNextDueDate({
+        plan: {
+          periodicite_valeur: current.periodicite_valeur,
+          periodicite_unite: current.periodicite_unite,
+          base_calcul: current.base_calcul,
+          alert_window_days: current.alert_window_days,
+          effective_from: current.effective_from,
+        },
+        lastProofDate: proof.rows[0]?.ended_at ?? null,
+        fallbackDate: equipment.created_at,
+      });
+
+      await client.query(
+        `
+          UPDATE public.metrologie_plan_version
+          SET status = 'ACTIVE', published_at = now(),
+              last_proof_date = $2::date, next_due_date = $3::date,
+              updated_at = now(), updated_by = $4
+          WHERE id = $1::uuid
+        `,
+        [planId, proof.rows[0]?.ended_at?.slice(0, 10) ?? null, schedule.next_due_date, actor.user_id]
+      );
+
+      // Miroir hérité : `metrologie_plan` reste exact pour les KPI existants.
+      await syncLegacyPlan(client, {
+        equipementId,
+        actorId: actor.user_id,
+        periodiciteMois: monthsFromPeriodicity(current.periodicite_valeur, current.periodicite_unite),
+        lastDoneDate: proof.rows[0]?.ended_at?.slice(0, 10) ?? null,
+        nextDueDate: schedule.next_due_date,
+      });
+    } else {
+      await client.query(
+        `
+          UPDATE public.metrologie_plan_version
+          SET status = 'ARCHIVED', archived_at = now(), updated_at = now(), updated_by = $2
+          WHERE id = $1::uuid
+        `,
+        [planId, actor.user_id]
+      );
+    }
+
+    const correlationId = crypto.randomUUID();
+    await insertMetrologyEvent(client, {
+      equipement_id: equipementId,
+      entity_type: "PLAN",
+      entity_id: planId,
+      event_type: `PLAN_VERSION_${body.target_status}`,
+      actor,
+      old_values: { status: current.status },
+      new_values: { status: body.target_status, version: current.version },
+      correlation_id: correlationId,
+      idempotency_key: claim.idempotencyKey,
+      reason: body.reason,
+    });
+    await insertAuditLog(client, actor, {
+      action: "metrologie.plans.transition",
+      entity_type: "metrologie_plan_version",
+      entity_id: planId,
+      details: { from: current.status, to: body.target_status },
+    });
+    await saveReceipt({
+      client,
+      actor,
+      claim,
+      commandType: "metrology.plan.transition",
+      aggregateType: "PLAN",
+      aggregateId: planId,
+      requestPayload: { equipementId, planId, ...body },
+      resultPayload: { id: planId, status: body.target_status },
+      correlationId,
+    });
+  });
+
+  return loadPlan(planId);
+}
+
+export function monthsFromPeriodicity(
+  value: number,
+  unit: "DAY" | "WEEK" | "MONTH" | "YEAR"
+): number {
+  switch (unit) {
+    case "DAY":
+      return Math.max(1, Math.round(value / 30));
+    case "WEEK":
+      return Math.max(1, Math.round((value * 7) / 30));
+    case "YEAR":
+      return Math.max(1, value * 12);
+    case "MONTH":
+    default:
+      return Math.max(1, value);
+  }
+}
+
+/**
+ * Miroir de la table héritée `metrologie_plan`. Les KPI, alertes et écrans déjà
+ * en production la lisent : la laisser diverger ferait mentir des tableaux de
+ * bord réels.
+ */
+export async function syncLegacyPlan(
+  client: PoolClient,
+  params: {
+    equipementId: string;
+    actorId: number;
+    periodiciteMois: number;
+    lastDoneDate: string | null;
+    nextDueDate: string | null;
+    statut?: "EN_COURS" | "SUSPENDU" | "EN_RETARD" | "HORS_TOLERANCE";
+  }
+): Promise<void> {
+  const existing = await client.query<{ id: string }>(
+    `SELECT id::text AS id FROM public.metrologie_plan
+      WHERE equipement_id = $1::uuid AND deleted_at IS NULL FOR UPDATE`,
+    [params.equipementId]
+  );
+  const statut = params.statut ?? "EN_COURS";
+
+  if (existing.rows[0]) {
+    await client.query(
+      `
+        UPDATE public.metrologie_plan
+        SET periodicite_mois = $2,
+            last_done_date = COALESCE($3::date, last_done_date),
+            next_due_date = $4::date,
+            statut = $5,
+            updated_at = now(), updated_by = $6
+        WHERE id = $1::uuid
+      `,
+      [
+        existing.rows[0].id,
+        params.periodiciteMois,
+        params.lastDoneDate,
+        params.nextDueDate,
+        statut,
+        params.actorId,
+      ]
+    );
+    return;
+  }
+
+  await client.query(
+    `
+      INSERT INTO public.metrologie_plan (
+        equipement_id, periodicite_mois, last_done_date, next_due_date, statut, created_by, updated_by
+      )
+      VALUES ($1::uuid, $2, $3::date, $4::date, $5, $6, $6)
+    `,
+    [
+      params.equipementId,
+      params.periodiciteMois,
+      params.lastDoneDate,
+      params.nextDueDate,
+      statut,
+      params.actorId,
+    ]
+  );
+}
+
+async function loadPlan(planId: string): Promise<MetrologyPlanVersionDTO> {
+  const res = await db().query<PlanRow>(`${PLAN_SELECT} WHERE p.id = $1::uuid LIMIT 1`, [planId]);
+  const row = res.rows[0] ?? null;
+  if (!row) throw new HttpError(404, "NOT_FOUND", "Version de plan introuvable.");
+  return mapPlan(row, new Date());
+}
+
+/* ========================================================================== */
+/* Aperçu d'échéance                                                          */
+/* ========================================================================== */
+
+export async function repoSchedulePreview(params: {
+  equipementId: string;
+  query: SchedulePreviewQueryDTO;
+}): Promise<{
+  next_due_date: string | null;
+  source: string;
+  base_date: string | null;
+  due: MetrologyDueDTO;
+}> {
+  const equipment = await db().query<{ created_at: string; date_mise_en_service: string | null }>(
+    `SELECT created_at::text AS created_at, date_mise_en_service::text AS date_mise_en_service
+       FROM public.metrologie_equipements WHERE id = $1::uuid AND deleted_at IS NULL`,
+    [params.equipementId]
+  );
+  const equip = equipment.rows[0] ?? null;
+  if (!equip) throw new HttpError(404, "NOT_FOUND", "Équipement introuvable.");
+
+  let plan: SchedulePlan | null = null;
+  if (params.query.plan_version_id) {
+    const res = await db().query<{
+      periodicite_valeur: number;
+      periodicite_unite: "DAY" | "WEEK" | "MONTH" | "YEAR";
+      base_calcul: "LAST_PROOF" | "FIXED_DATE";
+      alert_window_days: number;
+      effective_from: string | null;
+    }>(
+      `SELECT periodicite_valeur, periodicite_unite, base_calcul, alert_window_days,
+              effective_from::text AS effective_from
+         FROM public.metrologie_plan_version WHERE id = $1::uuid AND equipement_id = $2::uuid`,
+      [params.query.plan_version_id, params.equipementId]
+    );
+    const row = res.rows[0] ?? null;
+    if (!row) throw new HttpError(404, "NOT_FOUND", "Version de plan introuvable.");
+    plan = row;
+  } else if (params.query.periodicite_valeur) {
+    plan = {
+      periodicite_valeur: params.query.periodicite_valeur,
+      periodicite_unite: params.query.periodicite_unite ?? "MONTH",
+      base_calcul: params.query.base_calcul ?? "LAST_PROOF",
+      alert_window_days: params.query.alert_window_days ?? 30,
+      effective_from: params.query.effective_from ?? null,
+    };
+  }
+
+  if (!plan) {
+    throw new HttpError(
+      422,
+      "METROLOGY_SCHEDULE_INPUT_REQUIRED",
+      "Fournissez une version de plan ou une périodicité à simuler."
+    );
+  }
+
+  const proof = await db().query<{ ended_at: string | null }>(
+    `SELECT ended_at::text AS ended_at FROM public.metrologie_execution
+      WHERE equipement_id = $1::uuid AND status = 'VALIDATED'
+        AND verdict IN ('CONFORME','CONFORME_AVEC_RESTRICTION')
+      ORDER BY ended_at DESC NULLS LAST LIMIT 1`,
+    [params.equipementId]
+  );
+
+  const result = computeNextDueDate({
+    plan,
+    lastProofDate: params.query.last_proof_date ?? proof.rows[0]?.ended_at?.slice(0, 10) ?? null,
+    certificateDueDate: params.query.certificate_due_date ?? null,
+    fallbackDate: equip.date_mise_en_service ?? equip.created_at,
+  });
+
+  return {
+    next_due_date: result.next_due_date,
+    source: result.source,
+    base_date: result.base_date,
+    due: mapDue(
+      evaluateDue({
+        nextDueDate: result.next_due_date,
+        alertWindowDays: plan.alert_window_days,
+        at: new Date(),
+      })
+    ),
+  };
+}
+
+/* ========================================================================== */
+/* Éligibilité                                                                */
+/* ========================================================================== */
+
+export async function repoEvaluateEligibility(params: {
+  query: EligibilityQueryDTO;
+  actor: MetrologyActor;
+}): Promise<MetrologyEligibilityResultDTO> {
+  const { query, actor } = params;
+  const at = new Date();
+  const policy = await loadMetrologyPolicy(db());
+
+  const requirement: MetrologyUsageRequirement = {
+    characteristic_key: query.characteristic_key,
+    requires_instrument: true,
+    instrument_category: query.instrument_category ?? null,
+    method: query.method ?? null,
+    unit: query.unit ?? null,
+    nominal: query.nominal ?? null,
+    tolerance_min: query.tolerance_min ?? null,
+    tolerance_max: query.tolerance_max ?? null,
+    requires_certificate: query.requires_certificate === "true",
+  };
+
+  const rights = { canRecordMeasurement: roleHasMetrologyCapability(actor.role, "execution_record") };
+
+  const instruments =
+    query.mode === "single"
+      ? [await loadInstrumentState(db(), query.instrument_id as string)]
+      : await loadInstrumentCandidates(db(), {
+          category: query.instrument_category ?? null,
+          search: null,
+          limit: query.limit,
+        });
+
+  const results = instruments.map((instrument) => {
+    const eligibility = evaluateInstrumentEligibility({ requirement, instrument, at, policy, rights });
+    return {
+      instrument_id: instrument?.id ?? (query.instrument_id ?? ""),
+      code: instrument?.code ?? null,
+      designation: instrument?.designation ?? null,
+      eligible: eligibility.eligible,
+      severity: eligibility.severity,
+      reason_code: eligibility.code,
+      message: eligibility.message,
+      reasons: eligibility.reasons.map((reason) => ({
+        code: reason.code,
+        severity: reason.severity,
+        message: reason.message,
+      })),
+      due: mapDue(eligibility.due),
+    };
+  });
+
+  // Les instruments utilisables d'abord : l'atelier doit voir le bon outil en
+  // tête, pas devoir lire toute la liste.
+  results.sort((left, right) => {
+    if (left.eligible !== right.eligible) return left.eligible ? -1 : 1;
+    if (left.severity !== right.severity) return left.severity === "OK" ? -1 : 1;
+    return (left.code ?? "").localeCompare(right.code ?? "");
+  });
+
+  return { mode: query.mode, evaluated_at: at.toISOString(), policy, results };
+}
+
+/**
+ * Point d'entrée réutilisé par le module Qualité pour construire le snapshot
+ * immuable. La règle vit ici et NULLE PART AILLEURS.
+ */
+export async function repoBuildInstrumentSnapshot(params: {
+  q: DbQueryer;
+  instrumentId: string;
+  requirement: MetrologyUsageRequirement;
+  at: Date;
+}) {
+  const instrument = await loadInstrumentState(params.q, params.instrumentId);
+  if (!instrument) return null;
+  const policy = await loadMetrologyPolicy(params.q);
+  const eligibility = evaluateInstrumentEligibility({
+    requirement: params.requirement,
+    instrument,
+    at: params.at,
+    policy,
+  });
+  return {
+    instrument,
+    eligibility,
+    snapshot: buildInstrumentSnapshot({ instrument, eligibility, at: params.at }),
+  };
+}
+
+/* ========================================================================== */
+/* Command center                                                             */
+/* ========================================================================== */
+
+export async function repoCenter(params: {
+  site: string | null;
+  categorieCode: string | null;
+  horizonDays: number;
+}): Promise<MetrologyCenterDTO> {
+  const values: unknown[] = [params.horizonDays];
+  const filters: string[] = ["e.deleted_at IS NULL"];
+  const push = (v: unknown) => {
+    values.push(v);
+    return `$${values.length}`;
+  };
+  if (params.site) filters.push(`e.site = ${push(params.site)}`);
+  if (params.categorieCode) filters.push(`e.categorie_code = ${push(params.categorieCode)}`);
+  const whereSql = `WHERE ${filters.join(" AND ")}`;
+
+  const kpiRes = await db().query<Record<string, string>>(
+    `
+      WITH scoped AS (
+        SELECT
+          e.id, e.etat, e.criticite,
+          COALESCE(pv.next_due_date, legacy.next_due_date) AS next_due_date
+        FROM public.metrologie_equipements e
+        LEFT JOIN LATERAL (
+          SELECT p.next_due_date FROM public.metrologie_plan_version p
+          WHERE p.equipement_id = e.id AND p.status = 'ACTIVE'
+          ORDER BY p.next_due_date ASC NULLS LAST LIMIT 1
+        ) pv ON TRUE
+        LEFT JOIN LATERAL (
+          SELECT lp.next_due_date FROM public.metrologie_plan lp
+          WHERE lp.equipement_id = e.id AND lp.deleted_at IS NULL AND lp.statut <> 'SUSPENDU'
+          ORDER BY lp.created_at DESC LIMIT 1
+        ) legacy ON TRUE
+        ${whereSql}
+      )
+      SELECT
+        COUNT(*)::text AS total,
+        COUNT(*) FILTER (WHERE etat IN ('ACTIVE','QUALIFIED'))::text AS usable,
+        COUNT(*) FILTER (
+          WHERE etat IN ('ACTIVE','QUALIFIED') AND next_due_date IS NOT NULL
+            AND next_due_date >= CURRENT_DATE
+            AND next_due_date <= CURRENT_DATE + ($1::int || ' days')::interval
+        )::text AS due_soon,
+        COUNT(*) FILTER (
+          WHERE etat IN ('ACTIVE','QUALIFIED') AND next_due_date IS NOT NULL AND next_due_date < CURRENT_DATE
+        )::text AS overdue,
+        COUNT(*) FILTER (
+          WHERE etat IN ('ACTIVE','QUALIFIED') AND criticite = 'CRITIQUE'
+            AND next_due_date IS NOT NULL AND next_due_date < CURRENT_DATE
+        )::text AS overdue_critical,
+        COUNT(*) FILTER (WHERE etat = 'QUARANTINE')::text AS quarantine,
+        COUNT(*) FILTER (WHERE etat = 'OUT_OF_TOLERANCE')::text AS out_of_tolerance,
+        COUNT(*) FILTER (WHERE etat = 'UNDER_REPAIR')::text AS under_repair,
+        COUNT(*) FILTER (WHERE etat = 'RETIRED')::text AS retired
+      FROM scoped
+    `,
+    values
+  );
+  const kpiRow = kpiRes.rows[0] ?? {};
+
+  const impactRes = await db().query<{ total: string }>(
+    `SELECT COUNT(*)::text AS total FROM public.metrologie_impact_dossier WHERE status IN ('OPEN','IN_REVIEW')`
+  );
+
+  const coverageRes = await db().query<{
+    key: string;
+    label: string;
+    total: string;
+    overdue: string;
+    due_soon: string;
+  }>(
+    `
+      SELECT
+        COALESCE(e.categorie_code, 'NON_CLASSE') AS key,
+        COALESCE(cat.label, 'Non classé') AS label,
+        COUNT(*)::text AS total,
+        COUNT(*) FILTER (
+          WHERE COALESCE(pv.next_due_date, legacy.next_due_date) < CURRENT_DATE
+        )::text AS overdue,
+        COUNT(*) FILTER (
+          WHERE COALESCE(pv.next_due_date, legacy.next_due_date) >= CURRENT_DATE
+            AND COALESCE(pv.next_due_date, legacy.next_due_date)
+                <= CURRENT_DATE + ($1::int || ' days')::interval
+        )::text AS due_soon
+      FROM public.metrologie_equipements e
+      LEFT JOIN public.metrologie_categories cat ON cat.code = e.categorie_code
+      LEFT JOIN LATERAL (
+        SELECT p.next_due_date FROM public.metrologie_plan_version p
+        WHERE p.equipement_id = e.id AND p.status = 'ACTIVE'
+        ORDER BY p.next_due_date ASC NULLS LAST LIMIT 1
+      ) pv ON TRUE
+      LEFT JOIN LATERAL (
+        SELECT lp.next_due_date FROM public.metrologie_plan lp
+        WHERE lp.equipement_id = e.id AND lp.deleted_at IS NULL AND lp.statut <> 'SUSPENDU'
+        ORDER BY lp.created_at DESC LIMIT 1
+      ) legacy ON TRUE
+      ${whereSql}
+      GROUP BY 1, 2
+      ORDER BY 3 DESC
+      LIMIT 20
+    `,
+    values
+  );
+
+  const at = new Date();
+  const upcoming = await db().query<EquipmentListRow>(
+    `${EQUIPMENT_LIST_SELECT} ${whereSql}
+       AND e.etat IN ('ACTIVE','QUALIFIED')
+       AND COALESCE(pv.next_due_date, legacy.next_due_date) IS NOT NULL
+       AND COALESCE(pv.next_due_date, legacy.next_due_date)
+           <= CURRENT_DATE + ($1::int || ' days')::interval
+     ORDER BY COALESCE(pv.next_due_date, legacy.next_due_date) ASC
+     LIMIT 12`,
+    values
+  );
+
+  const quarantined = await db().query<EquipmentListRow>(
+    `${EQUIPMENT_LIST_SELECT} ${whereSql}
+       AND e.etat IN ('QUARANTINE','OUT_OF_TOLERANCE','UNDER_REPAIR')
+     ORDER BY e.updated_at DESC
+     LIMIT 12`,
+    values
+  );
+
+  const openImpacts = await db().query(
+    `
+      SELECT
+        d.id::text AS id, d.code, d.equipement_id::text AS equipement_id,
+        e.code AS equipement_code, e.designation AS equipement_designation,
+        d.trigger_type, d.status, d.priority,
+        d.window_from::text AS window_from, d.window_to::text AS window_to,
+        d.volumes, d.truncated,
+        d.created_at::text AS created_at, d.updated_at::text AS updated_at,
+        (SELECT COUNT(*)::int FROM public.metrologie_impact_item i
+          WHERE i.dossier_id = d.id AND i.decision = 'PENDING') AS pending_items
+      FROM public.metrologie_impact_dossier d
+      JOIN public.metrologie_equipements e ON e.id = d.equipement_id
+      WHERE d.status IN ('OPEN','IN_REVIEW')
+      ORDER BY
+        CASE d.priority WHEN 'CRITICAL' THEN 0 WHEN 'HIGH' THEN 1 WHEN 'NORMAL' THEN 2 ELSE 3 END,
+        d.created_at DESC
+      LIMIT 12
+    `
+  );
+
+  return {
+    kpis: {
+      total: toInt(kpiRow.total, 0),
+      usable: toInt(kpiRow.usable, 0),
+      due_soon: toInt(kpiRow.due_soon, 0),
+      overdue: toInt(kpiRow.overdue, 0),
+      overdue_critical: toInt(kpiRow.overdue_critical, 0),
+      quarantine: toInt(kpiRow.quarantine, 0),
+      out_of_tolerance: toInt(kpiRow.out_of_tolerance, 0),
+      under_repair: toInt(kpiRow.under_repair, 0),
+      retired: toInt(kpiRow.retired, 0),
+      open_impacts: toInt(impactRes.rows[0]?.total, 0),
+    },
+    coverage: coverageRes.rows.map((row) => ({
+      key: row.key,
+      label: row.label,
+      total: toInt(row.total, 0),
+      overdue: toInt(row.overdue, 0),
+      due_soon: toInt(row.due_soon, 0),
+    })),
+    upcoming: upcoming.rows.map((row) => mapEquipmentListItem(row, at)),
+    quarantined: quarantined.rows.map((row) => mapEquipmentListItem(row, at)),
+    open_impacts: openImpacts.rows.map(mapImpactListRow),
+    generated_at: at.toISOString(),
+  };
+}
+
+/* ========================================================================== */
+/* Timeline                                                                   */
+/* ========================================================================== */
+
+export async function repoTimeline(params: {
+  equipementId: string;
+  query: TimelineQueryDTO;
+}): Promise<Paginated<MetrologyTimelineEntryDTO>> {
+  const offset = (params.query.page - 1) * params.query.pageSize;
+  const values: unknown[] = [params.equipementId];
+  const where: string[] = ["l.equipement_id = $1::uuid"];
+  if (params.query.entity_type) {
+    values.push(params.query.entity_type);
+    where.push(`l.entity_type = $${values.length}`);
+  }
+
+  const countRes = await db().query<{ total: string }>(
+    `SELECT COUNT(*)::text AS total FROM public.metrologie_event_log l WHERE ${where.join(" AND ")}`,
+    values
+  );
+
+  values.push(params.query.pageSize, offset);
+  const res = await db().query(
+    `
+      SELECT
+        l.id::text AS id, l.entity_type, l.entity_id, l.event_type, l.reason, l.rule_code,
+        l.correlation_id::text AS correlation_id, l.created_at::text AS created_at,
+        u.id AS user_id, u.username, u.name, u.surname
+      FROM public.metrologie_event_log l
+      LEFT JOIN public.users u ON u.id = l.user_id
+      WHERE ${where.join(" AND ")}
+      ORDER BY l.created_at ${sortDirection(params.query.sortDir)}, l.id DESC
+      LIMIT $${values.length - 1} OFFSET $${values.length}
+    `,
+    values
+  );
+
+  return {
+    items: res.rows.map((row: Record<string, unknown>) => ({
+      id: String(row.id),
+      entity_type: (row.entity_type ?? null) as string | null,
+      entity_id: (row.entity_id ?? null) as string | null,
+      event_type: String(row.event_type),
+      reason: (row.reason ?? null) as string | null,
+      rule_code: (row.rule_code ?? null) as string | null,
+      correlation_id: (row.correlation_id ?? null) as string | null,
+      user: mapUserRef({
+        id: (row.user_id ?? null) as number | null,
+        username: (row.username ?? null) as string | null,
+        name: (row.name ?? null) as string | null,
+        surname: (row.surname ?? null) as string | null,
+      }),
+      created_at: String(row.created_at),
+    })),
+    total: toInt(countRes.rows[0]?.total, 0),
+    page: params.query.page,
+    pageSize: params.query.pageSize,
+  };
+}

--- a/src/module/metrologie/repository/metrology-shared.repository.ts
+++ b/src/module/metrologie/repository/metrology-shared.repository.ts
@@ -1,0 +1,566 @@
+// Socle transactionnel de la surface Métrologie 360 (#229).
+//
+// Tout ce qui est partagé par les dépôts du module : contexte d'acteur,
+// transaction, idempotence, journal append-only, audit, et surtout le
+// chargement de l'ÉTAT SERVEUR d'un instrument — la seule source de vérité de
+// l'éligibilité, consommée aussi bien par la métrologie que par la qualité.
+
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+
+import {
+  decideMetrologyReceipt,
+  metrologyRequestHash,
+  normalizeMetrologyIdempotencyKey,
+} from "../domain/metrology-policy";
+import type { MetrologyEquipmentState } from "../domain/metrology-policy";
+import type { MetrologyInstrumentState, MetrologyPolicySettings } from "../domain/metrology-eligibility";
+
+export type DbQueryer = Pick<PoolClient, "query">;
+
+export type MetrologyActor = {
+  user_id: number;
+  role: string | null;
+  ip: string | null;
+  user_agent: string | null;
+  device_type: string | null;
+  os: string | null;
+  browser: string | null;
+  path: string | null;
+  page_key: string | null;
+  client_session_id: string | null;
+  request_id: string | null;
+};
+
+export type MetrologyAggregateType =
+  | "EQUIPEMENT"
+  | "CATEGORIE"
+  | "PLAN"
+  | "EXECUTION"
+  | "CERTIFICAT"
+  | "IMPACT";
+
+export const METROLOGY_SETTING_KEY = "metrologie.block_on_overdue_critical";
+
+/* ========================================================================== */
+/* Transaction, journal, audit                                                */
+/* ========================================================================== */
+
+export async function withTransaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const out = await fn(client);
+    await client.query("COMMIT");
+    return out;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export function db(): typeof pool {
+  return pool;
+}
+
+export async function insertAuditLog(
+  tx: DbQueryer,
+  actor: MetrologyActor,
+  entry: {
+    action: string;
+    entity_type: string;
+    entity_id: string;
+    details?: Record<string, unknown> | null;
+  }
+): Promise<void> {
+  await repoInsertAuditLog({
+    user_id: actor.user_id,
+    body: {
+      event_type: "ACTION",
+      action: entry.action,
+      page_key: actor.page_key,
+      entity_type: entry.entity_type,
+      entity_id: entry.entity_id,
+      path: actor.path,
+      client_session_id: actor.client_session_id,
+      details: entry.details ?? null,
+    },
+    ip: actor.ip,
+    user_agent: actor.user_agent,
+    device_type: actor.device_type,
+    os: actor.os,
+    browser: actor.browser,
+    tx,
+  });
+}
+
+/**
+ * Journal métier append-only. Écrit dans la MÊME transaction que la décision :
+ * une décision sans trace est impossible. Le trigger
+ * `trg_metrologie_event_log_append_only_229` interdit toute réécriture.
+ */
+export async function insertMetrologyEvent(
+  tx: DbQueryer,
+  params: {
+    equipement_id: string | null;
+    entity_type: MetrologyAggregateType;
+    entity_id: string;
+    event_type: string;
+    actor: MetrologyActor;
+    old_values: Record<string, unknown> | null;
+    new_values: Record<string, unknown> | null;
+    correlation_id: string;
+    idempotency_key?: string | null;
+    rule_code?: string | null;
+    reason?: string | null;
+  }
+): Promise<void> {
+  await tx.query(
+    `
+      INSERT INTO public.metrologie_event_log (
+        equipement_id, entity_type, entity_id, event_type,
+        old_values, new_values, user_id,
+        correlation_id, idempotency_key, rule_code, reason, request_id, source
+      )
+      VALUES (
+        $1::uuid, $2, $3, $4,
+        $5::jsonb, $6::jsonb, $7,
+        $8::uuid, $9, $10, $11, $12, 'api'
+      )
+    `,
+    [
+      params.equipement_id,
+      params.entity_type,
+      params.entity_id,
+      params.event_type,
+      params.old_values ? JSON.stringify(params.old_values) : null,
+      params.new_values ? JSON.stringify(params.new_values) : null,
+      params.actor.user_id,
+      params.correlation_id,
+      params.idempotency_key ?? null,
+      params.rule_code ?? null,
+      params.reason ?? null,
+      params.actor.request_id,
+    ]
+  );
+}
+
+/* ========================================================================== */
+/* Idempotence                                                                */
+/* ========================================================================== */
+
+export type IdempotencyClaim = {
+  idempotencyKey: string;
+  requestHash: string;
+  replay: Record<string, unknown> | null;
+};
+
+/**
+ * Même clé + même payload ⇒ même résultat (rejeu). Même clé + autre payload ⇒
+ * 409. Le verrou consultatif transactionnel sérialise deux requêtes concurrentes
+ * portant la même clé : la seconde attend et lit le reçu de la première.
+ */
+export async function acquireIdempotency(params: {
+  client: PoolClient;
+  actor: MetrologyActor;
+  idempotencyKeyRaw: string | null | undefined;
+  commandType: string;
+  requestPayload: unknown;
+}): Promise<IdempotencyClaim> {
+  const idempotencyKey = normalizeMetrologyIdempotencyKey(params.idempotencyKeyRaw);
+  const requestHash = metrologyRequestHash(params.commandType, params.requestPayload);
+
+  await params.client.query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
+    `metrology:${params.actor.user_id}:${idempotencyKey}`,
+  ]);
+
+  const existing = await params.client.query<{
+    request_hash: string;
+    result_payload: Record<string, unknown>;
+  }>(
+    `
+      SELECT request_hash, result_payload
+      FROM public.metrologie_command_receipts
+      WHERE actor_user_id = $1 AND idempotency_key = $2
+      LIMIT 1
+    `,
+    [params.actor.user_id, idempotencyKey]
+  );
+
+  const receipt = existing.rows[0] ?? null;
+  const decision = decideMetrologyReceipt(receipt?.request_hash, requestHash);
+  if (decision === "CONFLICT") {
+    throw new HttpError(
+      409,
+      "IDEMPOTENCY_KEY_REUSED",
+      "Cette Idempotency-Key a déjà été utilisée avec un autre contenu."
+    );
+  }
+
+  return {
+    idempotencyKey,
+    requestHash,
+    replay: decision === "REPLAY" ? (receipt?.result_payload ?? null) : null,
+  };
+}
+
+export async function saveReceipt(params: {
+  client: PoolClient;
+  actor: MetrologyActor;
+  claim: IdempotencyClaim;
+  commandType: string;
+  aggregateType: MetrologyAggregateType;
+  aggregateId: string;
+  requestPayload: unknown;
+  resultPayload: unknown;
+  correlationId: string;
+}): Promise<void> {
+  await params.client.query(
+    `
+      INSERT INTO public.metrologie_command_receipts (
+        actor_user_id, idempotency_key, request_hash, command_type,
+        aggregate_type, aggregate_id, request_payload, result_payload, correlation_id
+      )
+      VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8::jsonb, $9::uuid)
+    `,
+    [
+      params.actor.user_id,
+      params.claim.idempotencyKey,
+      params.claim.requestHash,
+      params.commandType,
+      params.aggregateType,
+      params.aggregateId,
+      JSON.stringify(params.requestPayload ?? null),
+      JSON.stringify(params.resultPayload ?? null),
+      params.correlationId,
+    ]
+  );
+}
+
+/* ========================================================================== */
+/* Utilitaires                                                                */
+/* ========================================================================== */
+
+export function toNumber(value: unknown, fallback: number | null = null): number | null {
+  if (value === null || value === undefined) return fallback;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : fallback;
+}
+
+export function toInt(value: unknown, fallback = 0): number {
+  const n = toNumber(value, fallback);
+  return n === null ? fallback : Math.trunc(n);
+}
+
+export function sortDirection(dir: "asc" | "desc"): "ASC" | "DESC" {
+  return dir === "asc" ? "ASC" : "DESC";
+}
+
+export function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export type UserLite = {
+  id: number;
+  username: string;
+  name: string | null;
+  surname: string | null;
+  label: string;
+};
+
+export function mapUserLite(row: {
+  id: number | null;
+  username: string | null;
+  name: string | null;
+  surname: string | null;
+}): UserLite | null {
+  if (!row.id || !row.username) return null;
+  const parts = [row.surname ?? "", row.name ?? ""].map((s) => s.trim()).filter(Boolean);
+  const label = parts.join(" ").trim() || row.username;
+  return { id: row.id, username: row.username, name: row.name, surname: row.surname, label };
+}
+
+export async function loadMetrologyPolicy(q: DbQueryer): Promise<MetrologyPolicySettings> {
+  try {
+    const res = await q.query<{ value_json: unknown }>(
+      `SELECT value_json FROM public.erp_settings WHERE key = $1`,
+      [METROLOGY_SETTING_KEY]
+    );
+    const raw = res.rows[0]?.value_json ?? null;
+    const enabled = Boolean(isRecord(raw) && raw.enabled === true);
+    return { block_on_overdue_critical: enabled };
+  } catch {
+    // Un réglage illisible ne doit jamais bloquer l'atelier : on retombe sur
+    // le comportement le moins intrusif, et l'éligibilité reste évaluée par le
+    // plan applicable.
+    return { block_on_overdue_critical: false };
+  }
+}
+
+/* ========================================================================== */
+/* État serveur d'un instrument                                               */
+/* ========================================================================== */
+
+type InstrumentRow = {
+  id: string;
+  code: string | null;
+  designation: string | null;
+  categorie_code: string | null;
+  sous_categorie_code: string | null;
+  categorie_legacy: string | null;
+  etat: MetrologyEquipmentState;
+  criticite: string | null;
+  deleted: boolean;
+  unite: string | null;
+  plage_min: string | null;
+  plage_max: string | null;
+  resolution: string | null;
+  mpe: string | null;
+  incertitude: string | null;
+  methodes: string[] | null;
+  restrictions: string | null;
+  exige_certificat: boolean;
+  plan_version_id: string | null;
+  plan_version: number | null;
+  plan_blocking_strategy: "BLOCK" | "WARN" | "NONE" | null;
+  plan_alert_window_days: number | null;
+  next_due_date: string | null;
+  last_proof_execution_id: string | null;
+  last_proof_date: string | null;
+  last_proof_verdict: string | null;
+  certificate_id: string | null;
+};
+
+/**
+ * Sélection du plan applicable : parmi les versions ACTIVE de l'équipement, on
+ * retient LA PLUS CONTRAIGNANTE, c'est-à-dire celle dont l'échéance tombe le
+ * plus tôt. Un instrument dont la vérification interne est échue n'est pas
+ * « à jour » parce que son étalonnage annuel, lui, ne l'est pas encore.
+ *
+ * Repli : `metrologie_plan` (table historique, une ligne par équipement) pour
+ * les instruments qui n'ont pas encore de plan versionné — aucun écran existant
+ * ne change de comportement.
+ */
+const INSTRUMENT_SELECT = `
+  SELECT
+    e.id::text                       AS id,
+    e.code,
+    e.designation,
+    e.categorie_code,
+    e.sous_categorie_code,
+    e.categorie                      AS categorie_legacy,
+    e.etat,
+    e.criticite,
+    (e.deleted_at IS NOT NULL)       AS deleted,
+    e.unite,
+    e.plage_min::text                AS plage_min,
+    e.plage_max::text                AS plage_max,
+    e.resolution::text               AS resolution,
+    e.mpe::text                      AS mpe,
+    e.incertitude::text              AS incertitude,
+    e.methodes,
+    e.restrictions,
+    e.exige_certificat,
+    pv.id::text                      AS plan_version_id,
+    pv.version                       AS plan_version,
+    pv.blocking_strategy             AS plan_blocking_strategy,
+    pv.alert_window_days             AS plan_alert_window_days,
+    COALESCE(pv.next_due_date, legacy.next_due_date)::text AS next_due_date,
+    proof.id::text                   AS last_proof_execution_id,
+    proof.ended_at::text             AS last_proof_date,
+    proof.verdict                    AS last_proof_verdict,
+    cert.id::text                    AS certificate_id
+  FROM public.metrologie_equipements e
+  LEFT JOIN LATERAL (
+    SELECT p.id, p.version, p.blocking_strategy, p.alert_window_days, p.next_due_date
+    FROM public.metrologie_plan_version p
+    WHERE p.equipement_id = e.id
+      AND p.status = 'ACTIVE'
+    ORDER BY p.next_due_date ASC NULLS LAST, p.version DESC
+    LIMIT 1
+  ) pv ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT lp.next_due_date
+    FROM public.metrologie_plan lp
+    WHERE lp.equipement_id = e.id
+      AND lp.deleted_at IS NULL
+      AND lp.statut <> 'SUSPENDU'
+    ORDER BY lp.created_at DESC
+    LIMIT 1
+  ) legacy ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT x.id, x.ended_at, x.verdict
+    FROM public.metrologie_execution x
+    WHERE x.equipement_id = e.id
+      AND x.status = 'VALIDATED'
+      AND x.verdict IN ('CONFORME', 'CONFORME_AVEC_RESTRICTION')
+    ORDER BY x.ended_at DESC NULLS LAST
+    LIMIT 1
+  ) proof ON TRUE
+  LEFT JOIN LATERAL (
+    SELECT c.id
+    FROM public.metrologie_certificats c
+    WHERE c.equipement_id = e.id
+      AND c.deleted_at IS NULL
+      AND c.statut = 'VALIDE'
+      AND c.resultat = 'CONFORME'
+      AND (c.date_echeance IS NULL OR c.date_echeance >= CURRENT_DATE)
+    ORDER BY c.date_etalonnage DESC, c.created_at DESC
+    LIMIT 1
+  ) cert ON TRUE
+`;
+
+function mapInstrumentRow(row: InstrumentRow): MetrologyInstrumentState {
+  return {
+    id: row.id,
+    code: row.code,
+    designation: row.designation,
+    categorie_code: row.categorie_code,
+    sous_categorie_code: row.sous_categorie_code,
+    categorie_legacy: row.categorie_legacy,
+    etat: row.etat,
+    criticite: row.criticite,
+    deleted: row.deleted,
+    unite: row.unite,
+    plage_min: toNumber(row.plage_min),
+    plage_max: toNumber(row.plage_max),
+    resolution: toNumber(row.resolution),
+    mpe: toNumber(row.mpe),
+    incertitude: toNumber(row.incertitude),
+    methodes: row.methodes ?? [],
+    restrictions: row.restrictions,
+    exige_certificat: row.exige_certificat === true,
+    plan_version_id: row.plan_version_id,
+    plan_version: row.plan_version,
+    plan_blocking_strategy: row.plan_blocking_strategy,
+    plan_alert_window_days: row.plan_alert_window_days,
+    next_due_date: row.next_due_date ? row.next_due_date.slice(0, 10) : null,
+    last_proof_execution_id: row.last_proof_execution_id,
+    last_proof_date: row.last_proof_date ? row.last_proof_date.slice(0, 10) : null,
+    last_proof_verdict: row.last_proof_verdict,
+    has_valid_certificate: Boolean(row.certificate_id),
+    certificate_id: row.certificate_id,
+  };
+}
+
+export async function loadInstrumentState(
+  q: DbQueryer,
+  instrumentId: string
+): Promise<MetrologyInstrumentState | null> {
+  const res = await q.query<InstrumentRow>(`${INSTRUMENT_SELECT} WHERE e.id = $1::uuid LIMIT 1`, [
+    instrumentId,
+  ]);
+  const row = res.rows[0] ?? null;
+  return row ? mapInstrumentRow(row) : null;
+}
+
+/**
+ * Instruments candidats pour une caractéristique. Le filtrage grossier est fait
+ * en SQL (parc utilisable, catégorie) ; le verdict fin reste au domaine, pour
+ * qu'une règle d'éligibilité ne vive jamais à deux endroits.
+ */
+export async function loadInstrumentCandidates(
+  q: DbQueryer,
+  params: { category: string | null; search: string | null; limit: number }
+): Promise<MetrologyInstrumentState[]> {
+  const values: unknown[] = [];
+  const push = (v: unknown) => {
+    values.push(v);
+    return `$${values.length}`;
+  };
+
+  const where: string[] = [
+    "e.deleted_at IS NULL",
+    "e.etat IN ('ACTIVE','QUALIFIED')",
+  ];
+
+  if (params.category) {
+    const p = push(params.category);
+    where.push(
+      `(upper(COALESCE(e.categorie_code,'')) = upper(${p})
+        OR upper(COALESCE(e.sous_categorie_code,'')) = upper(${p})
+        OR upper(COALESCE(e.categorie,'')) = upper(${p}))`
+    );
+  }
+  if (params.search) {
+    const p = push(`%${params.search.replace(/%/g, "\\%")}%`);
+    where.push(
+      `(COALESCE(e.code,'') ILIKE ${p} OR e.designation ILIKE ${p} OR COALESCE(e.numero_serie,'') ILIKE ${p})`
+    );
+  }
+
+  const res = await q.query<InstrumentRow>(
+    `${INSTRUMENT_SELECT} WHERE ${where.join(" AND ")}
+     ORDER BY COALESCE(pv.next_due_date, legacy.next_due_date) DESC NULLS LAST, e.designation ASC
+     LIMIT ${push(params.limit)}`,
+    values
+  );
+  return res.rows.map(mapInstrumentRow);
+}
+
+/* ========================================================================== */
+/* Erreurs PostgreSQL                                                         */
+/* ========================================================================== */
+
+export function pgErrorInfo(err: unknown): { code: string | null; constraint: string | null } {
+  if (!isRecord(err)) return { code: null, constraint: null };
+  return {
+    code: typeof err.code === "string" ? err.code : null,
+    constraint: typeof err.constraint === "string" ? err.constraint : null,
+  };
+}
+
+/**
+ * Traduit une violation de contrainte en erreur métier lisible. Aucune trace
+ * SQL, aucun nom de table brut ne remonte au client.
+ */
+export function mapConstraintError(err: unknown): HttpError | null {
+  const { code, constraint } = pgErrorInfo(err);
+  if (code !== "23505") return null;
+  switch (constraint) {
+    case "metrologie_equipements_code_uniq":
+      return new HttpError(409, "METROLOGY_CODE_DUPLICATE", "Ce code d'équipement existe déjà.");
+    case "metrologie_categories_code_229_uq":
+      return new HttpError(409, "METROLOGY_CATEGORY_DUPLICATE", "Ce code de catégorie existe déjà.");
+    case "metrologie_plan_version_229_uq":
+    case "metrologie_plan_version_active_229_uq":
+      return new HttpError(
+        409,
+        "METROLOGY_PLAN_ALREADY_ACTIVE",
+        "Une version de plan est déjà active pour ce type d'opération."
+      );
+    case "metrologie_execution_code_229_uq":
+      return new HttpError(409, "METROLOGY_EXECUTION_DUPLICATE", "Ce code d'exécution existe déjà.");
+    case "metrologie_certificats_numero_externe_229_uq":
+      return new HttpError(
+        409,
+        "METROLOGY_CERTIFICATE_DUPLICATE",
+        "Ce numéro de certificat est déjà enregistré pour cet émetteur."
+      );
+    case "metrologie_impact_dossier_execution_229_uq":
+      return new HttpError(
+        409,
+        "METROLOGY_IMPACT_ALREADY_OPEN",
+        "Un dossier d'impact existe déjà pour cette exécution."
+      );
+    case "metrologie_command_receipts_229_uq":
+      return new HttpError(
+        409,
+        "IDEMPOTENCY_KEY_REUSED",
+        "Cette Idempotency-Key a déjà été utilisée."
+      );
+    default:
+      return null;
+  }
+}
+
+export function rethrowMapped(err: unknown): never {
+  const mapped = mapConstraintError(err);
+  if (mapped) throw mapped;
+  throw err;
+}

--- a/src/module/metrologie/routes/metrologie.routes.ts
+++ b/src/module/metrologie/routes/metrologie.routes.ts
@@ -3,6 +3,7 @@ import multer from "multer";
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { ensureTmpStoragePath } from "../../../utils/cerpStorage";
+import { requireMetrologyCapability } from "../middlewares/metrology-authorization.middleware";
 import {
   attachCertificats,
   createEquipement,
@@ -28,24 +29,52 @@ const upload = multer({
   },
 });
 
+/**
+ * Routeur historique du module Métrologie.
+ *
+ * Les CHEMINS et les CONTRATS restent identiques : aucun écran en production
+ * ne casse. En revanche, #229 corrige un risque réel — ces routes étaient
+ * seulement authentifiées, sans aucune autorisation : n'importe quel compte
+ * connecté pouvait créer, modifier ou supprimer un équipement de métrologie, et
+ * télécharger un certificat. Elles déclarent désormais les mêmes capacités
+ * fines que la surface v2.
+ */
 const router = Router();
 router.use(authenticateToken);
 
-router.get("/kpis", metrologieKpis);
-router.get("/alerts/summary", metrologieAlertsSummary);
-router.get("/alerts", metrologieAlerts);
+router.get("/kpis", requireMetrologyCapability("read"), metrologieKpis);
+router.get("/alerts/summary", requireMetrologyCapability("read"), metrologieAlertsSummary);
+router.get("/alerts", requireMetrologyCapability("read"), metrologieAlerts);
 
-router.get("/equipements", listEquipements);
-router.post("/equipements", createEquipement);
-router.get("/equipements/:id", getEquipement);
-router.patch("/equipements/:id", patchEquipement);
-router.delete("/equipements/:id", deleteEquipement);
+router.get("/equipements", requireMetrologyCapability("read"), listEquipements);
+router.post("/equipements", requireMetrologyCapability("equipment_write"), createEquipement);
+router.get("/equipements/:id", requireMetrologyCapability("read"), getEquipement);
+router.patch("/equipements/:id", requireMetrologyCapability("equipment_write"), patchEquipement);
+// Le retrait logique d'un instrument est une décision de parc, pas une édition.
+router.delete("/equipements/:id", requireMetrologyCapability("repair_manage"), deleteEquipement);
 
-router.put("/equipements/:id/plan", upsertPlan);
+router.put("/equipements/:id/plan", requireMetrologyCapability("plan_manage"), upsertPlan);
 
-router.get("/equipements/:id/certificats", listCertificats);
-router.post("/equipements/:id/certificats", upload.array("documents[]"), attachCertificats);
-router.delete("/equipements/:id/certificats/:certificatId", removeCertificat);
-router.get("/equipements/:id/certificats/:certificatId/file", downloadCertificatFile);
+router.get(
+  "/equipements/:id/certificats",
+  requireMetrologyCapability("documents_read"),
+  listCertificats
+);
+router.post(
+  "/equipements/:id/certificats",
+  requireMetrologyCapability("documents_write"),
+  upload.array("documents[]"),
+  attachCertificats
+);
+router.delete(
+  "/equipements/:id/certificats/:certificatId",
+  requireMetrologyCapability("documents_write"),
+  removeCertificat
+);
+router.get(
+  "/equipements/:id/certificats/:certificatId/file",
+  requireMetrologyCapability("documents_read"),
+  downloadCertificatFile
+);
 
 export default router;

--- a/src/module/metrologie/routes/metrology-360.routes.ts
+++ b/src/module/metrologie/routes/metrology-360.routes.ts
@@ -1,0 +1,163 @@
+import { Router } from "express";
+import multer from "multer";
+
+import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import { ensureTmpStoragePath } from "../../../utils/cerpStorage";
+import { requireMetrologyCapability } from "../middlewares/metrology-authorization.middleware";
+import {
+  cancelCertificate,
+  cancelExecution,
+  center,
+  createEquipment,
+  createExecution,
+  createImpact,
+  createPlan,
+  decideImpactItem,
+  downloadCertificate,
+  equipmentTimeline,
+  equipmentUsage,
+  evaluateEligibility,
+  getEquipment,
+  getExecution,
+  getImpact,
+  listCategories,
+  listEquipment,
+  listExecutions,
+  listImpacts,
+  listUnits,
+  previewVerdict,
+  quarantineEquipment,
+  recordMeasurements,
+  revisePlan,
+  schedulePreview,
+  transitionEquipment,
+  transitionImpact,
+  transitionPlan,
+  updateEquipment,
+  uploadCertificate,
+  upsertCategory,
+  validateExecution,
+} from "../controllers/metrology-360.controller";
+
+/**
+ * Surface Métrologie 360 (#229), montée sous `/metrologie/v2`.
+ *
+ * Chaque route déclare sa capacité fine — refus par défaut. Le routeur
+ * historique `/metrologie` reste inchangé dans ses chemins pour ne casser aucun
+ * écran en production ; il gagne seulement les mêmes gardes RBAC.
+ */
+const router = Router();
+router.use(authenticateToken);
+
+// Les fichiers transitent par un répertoire temporaire privé, jamais par le
+// répertoire des documents avant d'avoir été contrôlés.
+const upload = multer({
+  dest: ensureTmpStoragePath("metrologie"),
+  limits: { fileSize: 25 * 1024 * 1024, files: 1 },
+});
+
+/* Référentiels ------------------------------------------------------------ */
+router.get("/categories", requireMetrologyCapability("read"), listCategories);
+router.put("/categories", requireMetrologyCapability("categories_manage"), upsertCategory);
+router.get("/units", requireMetrologyCapability("read"), listUnits);
+
+/* Command center et éligibilité ------------------------------------------- */
+router.get("/center", requireMetrologyCapability("read"), center);
+router.get("/eligibility", requireMetrologyCapability("read"), evaluateEligibility);
+
+/* Registre ---------------------------------------------------------------- */
+router.get("/equipements", requireMetrologyCapability("read"), listEquipment);
+router.post("/equipements", requireMetrologyCapability("equipment_write"), createEquipment);
+router.get("/equipements/:id", requireMetrologyCapability("read"), getEquipment);
+router.patch("/equipements/:id", requireMetrologyCapability("equipment_write"), updateEquipment);
+router.get("/equipements/:id/timeline", requireMetrologyCapability("audit_read"), equipmentTimeline);
+router.get("/equipements/:id/usage", requireMetrologyCapability("impact_read"), equipmentUsage);
+
+// Mettre en quarantaine est un droit d'alerte largement ouvert ; en sortir ne
+// l'est pas — la garde de sortie est rejouée dans le domaine.
+router.post(
+  "/equipements/:id/quarantine",
+  requireMetrologyCapability("quarantine_set"),
+  quarantineEquipment
+);
+router.post(
+  "/equipements/:id/transitions",
+  requireMetrologyCapability("repair_manage"),
+  transitionEquipment
+);
+
+/* Plans ------------------------------------------------------------------- */
+router.get("/equipements/:id/schedule-preview", requireMetrologyCapability("read"), schedulePreview);
+router.post("/equipements/:id/plans", requireMetrologyCapability("plan_manage"), createPlan);
+router.post(
+  "/equipements/:id/plans/:childId/revisions",
+  requireMetrologyCapability("plan_manage"),
+  revisePlan
+);
+router.post(
+  "/equipements/:id/plans/:childId/transitions",
+  requireMetrologyCapability("plan_manage"),
+  transitionPlan
+);
+
+/* Exécutions -------------------------------------------------------------- */
+router.get("/executions", requireMetrologyCapability("read"), listExecutions);
+router.get("/executions/:id", requireMetrologyCapability("read"), getExecution);
+router.post(
+  "/equipements/:id/executions",
+  requireMetrologyCapability("execution_record"),
+  createExecution
+);
+router.post(
+  "/executions/:id/measurements",
+  requireMetrologyCapability("execution_record"),
+  recordMeasurements
+);
+router.get("/executions/:id/verdict-preview", requireMetrologyCapability("read"), previewVerdict);
+// Valider le verdict est une capacité distincte de la saisie : l'opérateur
+// d'atelier relève, la métrologie/qualité conclut.
+router.post(
+  "/executions/:id/validate",
+  requireMetrologyCapability("verdict_validate"),
+  validateExecution
+);
+router.post(
+  "/executions/:id/cancel",
+  requireMetrologyCapability("execution_record"),
+  cancelExecution
+);
+
+/* Certificats et PV ------------------------------------------------------- */
+router.post(
+  "/equipements/:id/certificats",
+  requireMetrologyCapability("documents_write"),
+  upload.single("document"),
+  uploadCertificate
+);
+router.post(
+  "/equipements/:id/certificats/:childId/cancel",
+  requireMetrologyCapability("documents_write"),
+  cancelCertificate
+);
+router.get(
+  "/equipements/:id/certificats/:childId/file",
+  requireMetrologyCapability("documents_read"),
+  downloadCertificate
+);
+
+/* Analyse d'impact -------------------------------------------------------- */
+router.get("/impacts", requireMetrologyCapability("impact_read"), listImpacts);
+router.get("/impacts/:id", requireMetrologyCapability("impact_read"), getImpact);
+router.post("/equipements/:id/impacts", requireMetrologyCapability("impact_create"), createImpact);
+router.post(
+  "/impacts/:id/items/:childId/decision",
+  requireMetrologyCapability("impact_decide"),
+  decideImpactItem
+);
+router.post(
+  "/impacts/:id/transitions",
+  requireMetrologyCapability("impact_decide"),
+  transitionImpact
+);
+
+export default router;

--- a/src/module/metrologie/services/metrology-360.service.ts
+++ b/src/module/metrologie/services/metrology-360.service.ts
@@ -1,0 +1,89 @@
+// Services Métrologie 360 (#229).
+//
+// Couche de délégation : elle expose une API stable aux contrôleurs et garde
+// la règle métier dans le domaine et l'accès dans les dépôts. Aucune requête
+// SQL ici, aucun objet Express non plus.
+
+import {
+  repoCancelCertificate,
+  repoCancelExecution,
+  repoCreateExecution,
+  repoGetCertificateFile,
+  repoGetExecution,
+  repoListExecutions,
+  repoPreviewVerdict,
+  repoRecordMeasurements,
+  repoUploadCertificate,
+  repoValidateExecution,
+  metrologyDocsBaseDir,
+} from "../repository/metrology-execution.repository";
+import {
+  repoCreateImpact,
+  repoDecideImpactItem,
+  repoGetImpact,
+  repoInstrumentUsage,
+  repoListImpacts,
+  repoTransitionImpact,
+} from "../repository/metrology-impact.repository";
+import {
+  repoCenter,
+  repoCreateEquipment,
+  repoCreatePlanVersion,
+  repoEvaluateEligibility,
+  repoGetEquipmentDetail,
+  repoListCategories,
+  repoListEquipment,
+  repoQuarantineEquipment,
+  repoRevisePlanVersion,
+  repoSchedulePreview,
+  repoTimeline,
+  repoTransitionEquipment,
+  repoTransitionPlanVersion,
+  repoUpdateEquipment,
+  repoUpsertCategory,
+} from "../repository/metrology-registry.repository";
+import { listSupportedUnits } from "../domain/metrology-units";
+
+export const svcListCategories = repoListCategories;
+export const svcUpsertCategory = repoUpsertCategory;
+
+export const svcListEquipment = repoListEquipment;
+export const svcGetEquipmentDetail = repoGetEquipmentDetail;
+export const svcCreateEquipment = repoCreateEquipment;
+export const svcUpdateEquipment = repoUpdateEquipment;
+export const svcTransitionEquipment = repoTransitionEquipment;
+export const svcQuarantineEquipment = repoQuarantineEquipment;
+
+export const svcCreatePlanVersion = repoCreatePlanVersion;
+export const svcRevisePlanVersion = repoRevisePlanVersion;
+export const svcTransitionPlanVersion = repoTransitionPlanVersion;
+export const svcSchedulePreview = repoSchedulePreview;
+
+export const svcCreateExecution = repoCreateExecution;
+export const svcRecordMeasurements = repoRecordMeasurements;
+export const svcPreviewVerdict = repoPreviewVerdict;
+export const svcValidateExecution = repoValidateExecution;
+export const svcCancelExecution = repoCancelExecution;
+export const svcListExecutions = repoListExecutions;
+export const svcGetExecution = repoGetExecution;
+
+export const svcUploadCertificate = repoUploadCertificate;
+export const svcCancelCertificate = repoCancelCertificate;
+export const svcGetCertificateFile = repoGetCertificateFile;
+export const svcMetrologyDocsBaseDir = metrologyDocsBaseDir;
+
+export const svcCreateImpact = repoCreateImpact;
+export const svcListImpacts = repoListImpacts;
+export const svcGetImpact = repoGetImpact;
+export const svcDecideImpactItem = repoDecideImpactItem;
+export const svcTransitionImpact = repoTransitionImpact;
+export const svcInstrumentUsage = repoInstrumentUsage;
+
+export const svcEvaluateEligibility = repoEvaluateEligibility;
+export const svcCenter = repoCenter;
+export const svcTimeline = repoTimeline;
+
+/** Référentiel d'unités supportées : la liste vient du serveur, pas de l'UI. */
+export function svcListUnits() {
+  return { items: listSupportedUnits() };
+}

--- a/src/module/metrologie/types/metrologie.types.ts
+++ b/src/module/metrologie/types/metrologie.types.ts
@@ -57,7 +57,14 @@ export type MetrologieCertificat = {
   organisme: string | null;
   commentaire: string | null;
   file_original_name: string | null;
-  storage_path: string | null;
+  /**
+   * #229 — `storage_path` N'EST PLUS exposé : un chemin de stockage privé dans
+   * un DTO est une fuite (il fuite l'arborescence serveur et invite au path
+   * traversal). Le frontend n'en avait besoin que pour savoir si un fichier
+   * existe : c'est exactement ce que dit `has_file`. Le téléchargement passe
+   * par l'endpoint authentifié dédié.
+   */
+  has_file: boolean;
   mime_type: string | null;
   size_bytes: number | null;
   sha256: string | null;

--- a/src/module/metrologie/types/metrology-360.types.ts
+++ b/src/module/metrologie/types/metrology-360.types.ts
@@ -1,0 +1,431 @@
+// DTO de la surface Métrologie 360 (#229).
+//
+// Règle de sécurité : AUCUN de ces types ne porte `storage_path`, chemin local,
+// bucket, jeton, signature ou binaire. Un document se lit uniquement par son
+// endpoint authentifié `/metrologie/v2/equipements/:id/certificats/:childId/file`.
+//
+// Les DTO de LISTE, de DÉTAIL et d'ACTION sont distincts : une liste ne charge
+// jamais la charge utile d'un détail, et une action ne renvoie jamais plus que
+// ce que l'appelant a le droit de voir.
+
+import type {
+  MetrologyEligibilityCode,
+  EligibilitySeverity,
+  MetrologyInstrumentSnapshot,
+} from "../domain/metrology-eligibility";
+import type {
+  MetrologyEquipmentState,
+  MetrologyImpactDecision,
+  MetrologyImpactStatus,
+  MetrologyOperationType,
+  MetrologyVerdict,
+} from "../domain/metrology-policy";
+import type { DueStatus } from "../domain/metrology-schedule";
+
+export type Paginated<T> = {
+  items: T[];
+  total: number;
+  page: number;
+  pageSize: number;
+};
+
+export type UserRef = {
+  id: number;
+  username: string;
+  label: string;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Référentiel                                                                */
+/* -------------------------------------------------------------------------- */
+
+export type MetrologyCategoryDTO = {
+  code: string;
+  parent_code: string | null;
+  label: string;
+  description: string | null;
+  version: number;
+  active: boolean;
+  display_order: number;
+  requires_range: boolean;
+  requires_resolution: boolean;
+  requires_uncertainty: boolean;
+  requires_unit: boolean;
+  default_unit: string | null;
+  default_periodicity_months: number | null;
+  default_operation_type: "ETALONNAGE" | "VERIFICATION";
+  in_use: boolean;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Équipement                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export type MetrologyEquipmentListItemDTO = {
+  id: string;
+  code: string | null;
+  designation: string;
+  categorie_code: string | null;
+  categorie_label: string | null;
+  etat: MetrologyEquipmentState;
+  /** État affiché : `etat` enrichi de DUE_SOON / OVERDUE calculés serveur. */
+  etat_effectif: string;
+  criticite: "NORMAL" | "CRITIQUE";
+  site: string | null;
+  zone: string | null;
+  localisation_precise: string | null;
+  numero_serie: string | null;
+  next_due_date: string | null;
+  due_status: DueStatus;
+  days_overdue: number;
+  days_remaining: number | null;
+  open_impact_count: number;
+  updated_at: string;
+};
+
+export type MetrologyEquipmentSpecificationsDTO = {
+  unite: string | null;
+  plage_min: number | null;
+  plage_max: number | null;
+  resolution: number | null;
+  mpe: number | null;
+  incertitude: number | null;
+  methodes: string[];
+  conditions_utilisation: string | null;
+  restrictions: string | null;
+  etalon_reference: string | null;
+  exige_certificat: boolean;
+  specifications: Record<string, unknown>;
+};
+
+export type MetrologyEquipmentDTO = MetrologyEquipmentSpecificationsDTO & {
+  id: string;
+  code: string | null;
+  designation: string;
+  categorie_code: string | null;
+  categorie_label: string | null;
+  sous_categorie_code: string | null;
+  marque: string | null;
+  modele: string | null;
+  numero_serie: string | null;
+  criticite: "NORMAL" | "CRITIQUE";
+  etat: MetrologyEquipmentState;
+  etat_effectif: string;
+  etat_motif: string | null;
+  etat_changed_at: string | null;
+  statut_legacy: string;
+  proprietaire_service: string | null;
+  responsable: UserRef | null;
+  site: string | null;
+  magasin: string | null;
+  zone: string | null;
+  localisation_precise: string | null;
+  date_mise_en_service: string | null;
+  date_retrait: string | null;
+  quarantine_reason: string | null;
+  quarantined_at: string | null;
+  last_conforme_at: string | null;
+  last_conforme_execution_id: string | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: UserRef | null;
+  updated_by: UserRef | null;
+};
+
+export type MetrologyDueDTO = {
+  status: DueStatus;
+  next_due_date: string | null;
+  days_remaining: number | null;
+  days_overdue: number;
+};
+
+export type MetrologyPlanVersionDTO = {
+  id: string;
+  equipement_id: string;
+  version: number;
+  status: "DRAFT" | "ACTIVE" | "ARCHIVED";
+  operation_type: "ETALONNAGE" | "VERIFICATION";
+  methode: string | null;
+  procedure_ref: string | null;
+  periodicite_valeur: number;
+  periodicite_unite: "DAY" | "WEEK" | "MONTH" | "YEAR";
+  base_calcul: "LAST_PROOF" | "FIXED_DATE";
+  alert_window_days: number;
+  tolerance_min: number | null;
+  tolerance_max: number | null;
+  unite: string | null;
+  min_points: number | null;
+  prestataire_type: "INTERNE" | "EXTERNE";
+  prestataire_label: string | null;
+  fournisseur_id: string | null;
+  role_habilite: string | null;
+  criticite: "NORMAL" | "CRITIQUE";
+  blocking_strategy: "BLOCK" | "WARN" | "NONE";
+  exige_certificat: boolean;
+  effective_from: string | null;
+  last_proof_date: string | null;
+  last_proof_execution_id: string | null;
+  next_due_date: string | null;
+  due: MetrologyDueDTO;
+  notes: string | null;
+  published_at: string | null;
+  archived_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export type MetrologyEquipmentDetailDTO = {
+  equipement: MetrologyEquipmentDTO;
+  due: MetrologyDueDTO;
+  plans: MetrologyPlanVersionDTO[];
+  executions: MetrologyExecutionListItemDTO[];
+  certificats: MetrologyCertificateDTO[];
+  impacts: MetrologyImpactListItemDTO[];
+  /** Ce que l'utilisateur courant a le droit de faire : l'UI ne devine rien. */
+  capabilities: Record<string, boolean>;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Exécutions                                                                 */
+/* -------------------------------------------------------------------------- */
+
+export type MetrologyExecutionListItemDTO = {
+  id: string;
+  code: string;
+  equipement_id: string;
+  operation_type: MetrologyOperationType;
+  status: "DRAFT" | "IN_PROGRESS" | "VALIDATED" | "CANCELLED";
+  verdict: MetrologyVerdict | null;
+  started_at: string;
+  ended_at: string | null;
+  operator: UserRef | null;
+  provider_label: string | null;
+  next_due_date: string | null;
+  certificate_count: number;
+  updated_at: string;
+};
+
+export type MetrologyMeasurementDTO = {
+  id: string;
+  point_key: string;
+  sample_no: number;
+  label: string | null;
+  nominal: number | null;
+  tolerance_min: number | null;
+  tolerance_max: number | null;
+  measured: number | null;
+  unite: string | null;
+  incertitude: number | null;
+  ecart: number | null;
+  verdict: "CONFORME" | "NON_CONFORME" | "INCONCLU" | null;
+  comment: string | null;
+  revision: number;
+};
+
+export type MetrologyExecutionDTO = MetrologyExecutionListItemDTO & {
+  plan_version_id: string | null;
+  plan_version: number | null;
+  methode: string | null;
+  procedure_ref: string | null;
+  etalon_reference: string | null;
+  environnement: Record<string, unknown>;
+  incertitude: number | null;
+  verdict_computed: MetrologyVerdict | null;
+  verdict_justification: string | null;
+  observations: string | null;
+  decision: string | null;
+  decision_reason: string | null;
+  decided_by: UserRef | null;
+  decided_at: string | null;
+  restriction: string | null;
+  measurements: MetrologyMeasurementDTO[];
+  certificats: MetrologyCertificateDTO[];
+  created_at: string;
+};
+
+/** Aperçu serveur obligatoire avant validation : il porte son empreinte. */
+export type MetrologyVerdictPreviewDTO = {
+  execution_id: string;
+  verdict_computed: MetrologyVerdict;
+  explanation: string;
+  counts: { total: number; conforme: number; non_conforme: number; inconclu: number };
+  points: Array<{
+    point_key: string;
+    sample_no: number;
+    verdict: "CONFORME" | "NON_CONFORME" | "INCONCLU";
+    ecart: number | null;
+    reason: string | null;
+  }>;
+  next_due_date: string | null;
+  next_due_source: string;
+  /** Effets réels annoncés avant confirmation : jamais de surprise après clic. */
+  effects: string[];
+  preview_hash: string;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Certificats                                                                */
+/* -------------------------------------------------------------------------- */
+
+export type MetrologyCertificateDTO = {
+  id: string;
+  equipement_id: string;
+  execution_id: string | null;
+  document_kind: "CERTIFICAT" | "PV_INTERNE" | "RAPPORT" | "AUTRE";
+  date_etalonnage: string;
+  date_echeance: string | null;
+  resultat: "CONFORME" | "NON_CONFORME" | "AJUSTAGE";
+  statut: "VALIDE" | "ANNULE" | "REMPLACE";
+  emetteur: string | null;
+  numero_externe: string | null;
+  organisme: string | null;
+  commentaire: string | null;
+  confidentiality: "INTERNAL" | "RESTRICTED" | "CUSTOMER_VISIBLE";
+  cancel_reason: string | null;
+  cancelled_at: string | null;
+  replaced_by_id: string | null;
+  /** Métadonnées non sensibles du fichier. Le chemin réel n'est jamais exposé. */
+  file_original_name: string | null;
+  mime_type: string | null;
+  size_bytes: number | null;
+  sha256: string | null;
+  has_file: boolean;
+  created_at: string;
+  created_by: UserRef | null;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Impact                                                                     */
+/* -------------------------------------------------------------------------- */
+
+export type MetrologyImpactListItemDTO = {
+  id: string;
+  code: string;
+  equipement_id: string;
+  equipement_code: string | null;
+  equipement_designation: string | null;
+  trigger_type: "VERDICT_NON_CONFORME" | "CERTIFICAT_INVALIDE" | "MANUEL";
+  status: MetrologyImpactStatus;
+  priority: "LOW" | "NORMAL" | "HIGH" | "CRITICAL";
+  window_from: string;
+  window_to: string;
+  volumes: {
+    controls: number;
+    work_orders: number;
+    lots: number;
+    deliveries: number;
+    truncated: boolean;
+  };
+  pending_items: number;
+  created_at: string;
+  updated_at: string;
+};
+
+export type MetrologyImpactItemDTO = {
+  id: string;
+  quality_control_id: string | null;
+  control_reference: string | null;
+  control_type: string | null;
+  control_date: string | null;
+  characteristic_key: string | null;
+  of_id: number | null;
+  lot_id: string | null;
+  bon_livraison_id: string | null;
+  article_id: string | null;
+  affaire_id: number | null;
+  decision: MetrologyImpactDecision;
+  decision_reason: string | null;
+  decided_by: UserRef | null;
+  decided_at: string | null;
+  non_conformity_id: string | null;
+};
+
+export type MetrologyImpactDetailDTO = MetrologyImpactListItemDTO & {
+  execution_id: string | null;
+  certificat_id: string | null;
+  window_source: string;
+  method: string;
+  scope: Record<string, unknown>;
+  exclusions: string | null;
+  truncated: boolean;
+  owner: UserRef | null;
+  conclusion: string | null;
+  closed_at: string | null;
+  items: Paginated<MetrologyImpactItemDTO>;
+  capabilities: Record<string, boolean>;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Éligibilité et command center                                              */
+/* -------------------------------------------------------------------------- */
+
+export type MetrologyEligibilityDTO = {
+  instrument_id: string;
+  code: string | null;
+  designation: string | null;
+  eligible: boolean;
+  severity: EligibilitySeverity;
+  reason_code: MetrologyEligibilityCode;
+  message: string;
+  reasons: Array<{ code: string; severity: EligibilitySeverity; message: string }>;
+  due: MetrologyDueDTO;
+};
+
+export type MetrologyEligibilityResultDTO = {
+  mode: "single" | "candidates";
+  evaluated_at: string;
+  policy: { block_on_overdue_critical: boolean };
+  results: MetrologyEligibilityDTO[];
+};
+
+export type MetrologyCenterDTO = {
+  kpis: {
+    total: number;
+    usable: number;
+    due_soon: number;
+    overdue: number;
+    overdue_critical: number;
+    quarantine: number;
+    out_of_tolerance: number;
+    under_repair: number;
+    retired: number;
+    open_impacts: number;
+  };
+  coverage: Array<{
+    key: string;
+    label: string;
+    total: number;
+    overdue: number;
+    due_soon: number;
+  }>;
+  upcoming: MetrologyEquipmentListItemDTO[];
+  quarantined: MetrologyEquipmentListItemDTO[];
+  open_impacts: MetrologyImpactListItemDTO[];
+  generated_at: string;
+};
+
+export type MetrologyTimelineEntryDTO = {
+  id: string;
+  entity_type: string | null;
+  entity_id: string | null;
+  event_type: string;
+  reason: string | null;
+  rule_code: string | null;
+  correlation_id: string | null;
+  user: UserRef | null;
+  created_at: string;
+};
+
+export type MetrologyUsageEntryDTO = {
+  quality_control_id: string;
+  control_reference: string | null;
+  control_type: string | null;
+  control_date: string | null;
+  characteristic_key: string | null;
+  of_id: number | null;
+  lot_id: string | null;
+  bon_livraison_id: string | null;
+  affaire_id: number | null;
+  snapshot: MetrologyInstrumentSnapshot | null;
+};

--- a/src/module/metrologie/validators/metrology-360.validators.ts
+++ b/src/module/metrologie/validators/metrology-360.validators.ts
@@ -1,0 +1,678 @@
+// Validateurs Zod stricts pour la surface Métrologie 360 (#229).
+//
+// Toutes les bornes (pagination, tri, longueurs, plages) sont serveur ; aucun
+// champ inconnu n'est accepté (`.strict()`), et aucun code métier n'est reçu du
+// client : il est alloué par le serveur.
+
+import { z } from "zod";
+
+import {
+  METROLOGY_EQUIPMENT_STATES,
+  METROLOGY_IMPACT_DECISIONS,
+  METROLOGY_IMPACT_STATUSES,
+  METROLOGY_OPERATION_TYPES,
+  METROLOGY_VERDICTS,
+} from "../domain/metrology-policy";
+
+const uuid = z.string().uuid();
+const optionalUuid = uuid.nullable().optional();
+
+const isoDate = z
+  .string()
+  .trim()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Date invalide (format attendu AAAA-MM-JJ)");
+
+const isoDateTime = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((value) => Number.isFinite(Date.parse(value)), "Date-heure invalide");
+
+const shortText = (max: number) => z.string().trim().min(1).max(max);
+const longText = (max: number) => z.string().trim().max(max);
+
+// Les grandeurs physiques sont finies et bornées : ni NaN, ni Infinity, ni
+// valeur absurde qui ferait sauter une comparaison de plage.
+const measure = z
+  .number()
+  .refine((value) => Number.isFinite(value), "Valeur non finie")
+  .refine((value) => Math.abs(value) <= 1_000_000_000, "Valeur hors limites");
+
+const positiveMeasure = measure.refine((value) => value > 0, "Valeur strictement positive requise");
+const nonNegativeMeasure = measure.refine((value) => value >= 0, "Valeur négative interdite");
+
+const unite = z.string().trim().min(1).max(16);
+const categoryCode = z
+  .string()
+  .trim()
+  .regex(/^[A-Z0-9_]{2,40}$/, "Code de catégorie invalide (A-Z, 0-9, _)");
+
+const reason = (min: number, max = 2000) =>
+  z.string().trim().min(min, `Motif d'au moins ${min} caractères requis`).max(max);
+
+export const paginationSchema = z.object({
+  page: z.coerce.number().int().min(1).max(10_000).default(1),
+  pageSize: z.coerce.number().int().min(1).max(200).default(25),
+  sortDir: z.enum(["asc", "desc"]).default("desc"),
+});
+
+export const idParamSchema = z.object({ params: z.object({ id: uuid }) });
+
+export const nestedIdParamSchema = z.object({
+  params: z.object({ id: uuid, childId: uuid }),
+});
+
+/** Verrou optimiste : obligatoire sur toute écriture d'un agrégat existant. */
+const expectedVersion = { expected_updated_at: isoDateTime };
+
+/* -------------------------------------------------------------------------- */
+/* Référentiel des catégories                                                 */
+/* -------------------------------------------------------------------------- */
+
+export const listCategoriesQuerySchema = z
+  .object({
+    q: z.string().trim().max(120).optional(),
+    active: z.enum(["true", "false", "all"]).default("true"),
+  })
+  .strict();
+export type ListCategoriesQueryDTO = z.infer<typeof listCategoriesQuerySchema>;
+
+export const upsertCategorySchema = z.object({
+  body: z
+    .object({
+      code: categoryCode,
+      parent_code: categoryCode.nullable().default(null),
+      label: shortText(120),
+      description: longText(1000).nullable().default(null),
+      active: z.boolean().default(true),
+      display_order: z.number().int().min(0).max(10_000).default(100),
+      requires_range: z.boolean().default(false),
+      requires_resolution: z.boolean().default(false),
+      requires_uncertainty: z.boolean().default(false),
+      requires_unit: z.boolean().default(false),
+      default_unit: unite.nullable().default(null),
+      default_periodicity_months: z.number().int().min(1).max(600).nullable().default(null),
+      default_operation_type: z.enum(["ETALONNAGE", "VERIFICATION"]).default("ETALONNAGE"),
+    })
+    .strict(),
+});
+export type UpsertCategoryBodyDTO = z.infer<typeof upsertCategorySchema>["body"];
+
+/* -------------------------------------------------------------------------- */
+/* Registre équipement                                                        */
+/* -------------------------------------------------------------------------- */
+
+const equipmentSpecShape = {
+  unite: unite.nullable().default(null),
+  plage_min: measure.nullable().default(null),
+  plage_max: measure.nullable().default(null),
+  resolution: positiveMeasure.nullable().default(null),
+  mpe: nonNegativeMeasure.nullable().default(null),
+  incertitude: nonNegativeMeasure.nullable().default(null),
+  methodes: z.array(shortText(80)).max(20).default([]),
+  conditions_utilisation: longText(2000).nullable().default(null),
+  restrictions: longText(2000).nullable().default(null),
+  etalon_reference: shortText(200).nullable().default(null),
+  exige_certificat: z.boolean().default(false),
+  // Complément libre : jamais source de vérité pour l'éligibilité.
+  specifications: z.record(z.string().max(60), z.unknown()).default({}),
+};
+
+const equipmentIdentityShape = {
+  designation: shortText(400),
+  categorie_code: categoryCode,
+  sous_categorie_code: categoryCode.nullable().default(null),
+  marque: shortText(120).nullable().default(null),
+  modele: shortText(120).nullable().default(null),
+  numero_serie: shortText(200).nullable().default(null),
+  criticite: z.enum(["NORMAL", "CRITIQUE"]).default("NORMAL"),
+  proprietaire_service: shortText(120).nullable().default(null),
+  responsable_user_id: z.number().int().positive().nullable().default(null),
+  site: shortText(120).nullable().default(null),
+  magasin: shortText(120).nullable().default(null),
+  zone: shortText(120).nullable().default(null),
+  localisation_precise: shortText(200).nullable().default(null),
+  date_mise_en_service: isoDate.nullable().default(null),
+  notes: longText(5000).nullable().default(null),
+};
+
+// Le `code` est ABSENT de l'entrée : il est alloué par le serveur. Envoyer un
+// code déclenche donc une 422 par `.strict()`, ce qui est le comportement voulu.
+export const createEquipmentSchema = z.object({
+  body: z
+    .object({ ...equipmentIdentityShape, ...equipmentSpecShape })
+    .strict()
+    .superRefine(assertRangeCoherent),
+});
+export type CreateEquipmentBodyDTO = z.infer<typeof createEquipmentSchema>["body"];
+
+export const updateEquipmentSchema = z.object({
+  body: z
+    .object({
+      ...expectedVersion,
+      ...equipmentIdentityShape,
+      ...equipmentSpecShape,
+      date_retrait: isoDate.nullable().default(null),
+    })
+    .strict()
+    .superRefine(assertRangeCoherent),
+});
+export type UpdateEquipmentBodyDTO = z.infer<typeof updateEquipmentSchema>["body"];
+
+function assertRangeCoherent(
+  value: { plage_min: number | null; plage_max: number | null; unite: string | null },
+  ctx: z.RefinementCtx
+): void {
+  if (value.plage_min !== null && value.plage_max !== null && value.plage_min > value.plage_max) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["plage_max"],
+      message: "La borne haute doit être supérieure ou égale à la borne basse.",
+    });
+  }
+  if ((value.plage_min !== null || value.plage_max !== null) && !value.unite) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["unite"],
+      message: "Une plage exige son unité : une valeur nue n'est pas comparable.",
+    });
+  }
+}
+
+export const equipmentTransitionSchema = z.object({
+  body: z
+    .object({
+      ...expectedVersion,
+      target_state: z.enum(METROLOGY_EQUIPMENT_STATES),
+      reason: reason(10),
+      // Requis uniquement pour une remise en service après quarantaine.
+      proof_execution_id: optionalUuid,
+    })
+    .strict(),
+});
+export type EquipmentTransitionBodyDTO = z.infer<typeof equipmentTransitionSchema>["body"];
+
+export const quarantineSchema = z.object({
+  body: z
+    .object({
+      ...expectedVersion,
+      reason: reason(10),
+      open_impact_analysis: z.boolean().default(true),
+    })
+    .strict(),
+});
+export type QuarantineBodyDTO = z.infer<typeof quarantineSchema>["body"];
+
+export const listEquipmentQuerySchema = paginationSchema
+  .extend({
+    q: z.string().trim().max(200).optional(),
+    categorie_code: categoryCode.optional(),
+    etat: z.enum(METROLOGY_EQUIPMENT_STATES).optional(),
+    criticite: z.enum(["NORMAL", "CRITIQUE"]).optional(),
+    site: z.string().trim().max(120).optional(),
+    // Segments du command center : filtres SERVEUR, jamais un tri client.
+    segment: z
+      .enum(["all", "due_soon", "overdue", "quarantine", "out_of_tolerance", "repair", "retired"])
+      .default("all"),
+    sortBy: z
+      .enum(["updated_at", "created_at", "designation", "code", "next_due_date", "etat"])
+      .default("updated_at"),
+  })
+  .strict();
+export type ListEquipmentQueryDTO = z.infer<typeof listEquipmentQuerySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Plans versionnés                                                           */
+/* -------------------------------------------------------------------------- */
+
+const planShape = {
+  operation_type: z.enum(["ETALONNAGE", "VERIFICATION"]),
+  methode: shortText(200).nullable().default(null),
+  procedure_ref: shortText(200).nullable().default(null),
+  periodicite_valeur: z.number().int().min(1).max(3650),
+  periodicite_unite: z.enum(["DAY", "WEEK", "MONTH", "YEAR"]).default("MONTH"),
+  base_calcul: z.enum(["LAST_PROOF", "FIXED_DATE"]).default("LAST_PROOF"),
+  alert_window_days: z.number().int().min(0).max(365).default(30),
+  tolerance_min: measure.nullable().default(null),
+  tolerance_max: measure.nullable().default(null),
+  unite: unite.nullable().default(null),
+  min_points: z.number().int().min(1).max(200).nullable().default(null),
+  prestataire_type: z.enum(["INTERNE", "EXTERNE"]).default("INTERNE"),
+  prestataire_label: shortText(200).nullable().default(null),
+  fournisseur_id: optionalUuid,
+  role_habilite: shortText(120).nullable().default(null),
+  criticite: z.enum(["NORMAL", "CRITIQUE"]).default("NORMAL"),
+  blocking_strategy: z.enum(["BLOCK", "WARN", "NONE"]).default("BLOCK"),
+  exige_certificat: z.boolean().default(false),
+  effective_from: isoDate.nullable().default(null),
+  notes: longText(2000).nullable().default(null),
+};
+
+function assertPlanCoherent(
+  value: {
+    prestataire_type: "INTERNE" | "EXTERNE";
+    prestataire_label: string | null;
+    fournisseur_id?: string | null;
+    tolerance_min: number | null;
+    tolerance_max: number | null;
+    base_calcul: "LAST_PROOF" | "FIXED_DATE";
+    effective_from: string | null;
+  },
+  ctx: z.RefinementCtx
+): void {
+  if (value.prestataire_type === "EXTERNE" && !value.prestataire_label && !value.fournisseur_id) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["prestataire_label"],
+      message: "Un étalonnage externe déclare son prestataire qualifié.",
+    });
+  }
+  if (
+    value.tolerance_min !== null &&
+    value.tolerance_max !== null &&
+    value.tolerance_min > value.tolerance_max
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["tolerance_max"],
+      message: "La tolérance haute doit être supérieure ou égale à la tolérance basse.",
+    });
+  }
+  if (value.base_calcul === "FIXED_DATE" && !value.effective_from) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["effective_from"],
+      message: "Une échéance à date fixe exige sa date d'effet.",
+    });
+  }
+}
+
+export const createPlanSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z.object(planShape).strict().superRefine(assertPlanCoherent),
+});
+export type CreatePlanBodyDTO = z.infer<typeof createPlanSchema>["body"];
+
+export const revisePlanSchema = z.object({
+  params: z.object({ id: uuid, childId: uuid }),
+  body: z
+    .object({ ...expectedVersion, ...planShape, revision_reason: reason(10) })
+    .strict()
+    .superRefine(assertPlanCoherent),
+});
+export type RevisePlanBodyDTO = z.infer<typeof revisePlanSchema>["body"];
+
+export const planTransitionSchema = z.object({
+  params: z.object({ id: uuid, childId: uuid }),
+  body: z
+    .object({
+      ...expectedVersion,
+      target_status: z.enum(["ACTIVE", "ARCHIVED"]),
+      reason: reason(5).nullable().default(null),
+    })
+    .strict(),
+});
+export type PlanTransitionBodyDTO = z.infer<typeof planTransitionSchema>["body"];
+
+export const schedulePreviewQuerySchema = z
+  .object({
+    plan_version_id: uuid.optional(),
+    periodicite_valeur: z.coerce.number().int().min(1).max(3650).optional(),
+    periodicite_unite: z.enum(["DAY", "WEEK", "MONTH", "YEAR"]).optional(),
+    base_calcul: z.enum(["LAST_PROOF", "FIXED_DATE"]).optional(),
+    alert_window_days: z.coerce.number().int().min(0).max(365).optional(),
+    effective_from: isoDate.optional(),
+    last_proof_date: isoDate.optional(),
+    certificate_due_date: isoDate.optional(),
+  })
+  .strict();
+export type SchedulePreviewQueryDTO = z.infer<typeof schedulePreviewQuerySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Exécutions et mesures                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const createExecutionSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      operation_type: z.enum(METROLOGY_OPERATION_TYPES),
+      plan_version_id: optionalUuid,
+      started_at: isoDateTime.optional(),
+      operator_user_id: z.number().int().positive().nullable().default(null),
+      provider_label: shortText(200).nullable().default(null),
+      fournisseur_id: optionalUuid,
+      methode: shortText(200).nullable().default(null),
+      procedure_ref: shortText(200).nullable().default(null),
+      etalon_reference: shortText(200).nullable().default(null),
+      environnement: z
+        .object({
+          temperature_c: measure.nullable().default(null),
+          humidite_pct: measure.nullable().default(null),
+          pression_hpa: measure.nullable().default(null),
+          commentaire: longText(500).nullable().default(null),
+        })
+        .strict()
+        .default({
+          temperature_c: null,
+          humidite_pct: null,
+          pression_hpa: null,
+          commentaire: null,
+        }),
+      observations: longText(5000).nullable().default(null),
+    })
+    .strict()
+    .superRefine((value, ctx) => {
+      const needsPlan = value.operation_type === "ETALONNAGE" || value.operation_type === "VERIFICATION";
+      if (needsPlan && !value.plan_version_id) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["plan_version_id"],
+          message: "Un étalonnage ou une vérification s'adosse à une version de plan active.",
+        });
+      }
+    }),
+});
+export type CreateExecutionBodyDTO = z.infer<typeof createExecutionSchema>["body"];
+
+export const measurementInputSchema = z
+  .object({
+    point_key: z
+      .string()
+      .trim()
+      .min(1)
+      .max(40)
+      .regex(/^[A-Z0-9][A-Z0-9._-]*$/i, "Clé de point invalide (A-Z, 0-9, . _ -)"),
+    sample_no: z.number().int().min(1).max(500).default(1),
+    label: shortText(200).nullable().default(null),
+    nominal: measure.nullable().default(null),
+    tolerance_min: measure.nullable().default(null),
+    tolerance_max: measure.nullable().default(null),
+    measured: measure.nullable().default(null),
+    unite: unite.nullable().default(null),
+    incertitude: nonNegativeMeasure.nullable().default(null),
+    comment: longText(1000).nullable().default(null),
+    /** Motif obligatoire quand on corrige un point déjà saisi. */
+    revision_reason: reason(5, 1000).nullable().default(null),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (
+      value.tolerance_min !== null &&
+      value.tolerance_max !== null &&
+      value.tolerance_min > value.tolerance_max
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["tolerance_max"],
+        message: "La borne haute doit être supérieure ou égale à la borne basse.",
+      });
+    }
+  });
+export type MeasurementInputDTO = z.infer<typeof measurementInputSchema>;
+
+export const recordMeasurementsSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      ...expectedVersion,
+      measurements: z.array(measurementInputSchema).min(1).max(500),
+    })
+    .strict(),
+});
+export type RecordMeasurementsBodyDTO = z.infer<typeof recordMeasurementsSchema>["body"];
+
+export const validateExecutionSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      ...expectedVersion,
+      /** Empreinte de l'aperçu serveur : refuse une confirmation sur données périmées. */
+      preview_hash: z.string().trim().regex(/^[A-Fa-f0-9]{64}$/, "Empreinte d'aperçu invalide"),
+      verdict: z.enum(METROLOGY_VERDICTS),
+      verdict_justification: longText(2000).nullable().default(null),
+      restriction: longText(1000).nullable().default(null),
+      decision: z.enum([
+        "REMISE_EN_SERVICE",
+        "QUARANTAINE",
+        "AJUSTAGE_REQUIS",
+        "REPARATION_REQUISE",
+        "RETRAIT",
+      ]),
+      decision_reason: reason(10),
+      ended_at: isoDateTime.optional(),
+      /** Échéance dérogatoire : exige motif + approbateur distinct. */
+      override_next_due_date: isoDate.nullable().default(null),
+      override_reason: longText(2000).nullable().default(null),
+      override_approved_by: z.number().int().positive().nullable().default(null),
+    })
+    .strict()
+    .superRefine((value, ctx) => {
+      if (value.verdict === "CONFORME_AVEC_RESTRICTION" && !value.restriction) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["restriction"],
+          message: "Une conformité avec restriction décrit la restriction appliquée.",
+        });
+      }
+      if (value.override_next_due_date && !value.override_approved_by) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["override_approved_by"],
+          message: "Une échéance dérogatoire exige une approbation explicite.",
+        });
+      }
+    }),
+});
+export type ValidateExecutionBodyDTO = z.infer<typeof validateExecutionSchema>["body"];
+
+export const cancelExecutionSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z.object({ ...expectedVersion, reason: reason(10) }).strict(),
+});
+export type CancelExecutionBodyDTO = z.infer<typeof cancelExecutionSchema>["body"];
+
+export const listExecutionsQuerySchema = paginationSchema
+  .extend({
+    equipement_id: uuid.optional(),
+    operation_type: z.enum(METROLOGY_OPERATION_TYPES).optional(),
+    status: z.enum(["DRAFT", "IN_PROGRESS", "VALIDATED", "CANCELLED"]).optional(),
+    verdict: z.enum(METROLOGY_VERDICTS).optional(),
+    sortBy: z.enum(["started_at", "ended_at", "created_at", "code"]).default("started_at"),
+  })
+  .strict();
+export type ListExecutionsQueryDTO = z.infer<typeof listExecutionsQuerySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Certificats et PV                                                          */
+/* -------------------------------------------------------------------------- */
+
+// Le fichier arrive en multipart ; ce schéma valide les champs textuels.
+export const uploadCertificateSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      execution_id: optionalUuid,
+      document_kind: z.enum(["CERTIFICAT", "PV_INTERNE", "RAPPORT", "AUTRE"]).default("CERTIFICAT"),
+      date_etalonnage: isoDate,
+      date_echeance: isoDate.nullable().optional().default(null),
+      resultat: z.enum(["CONFORME", "NON_CONFORME", "AJUSTAGE"]),
+      emetteur: shortText(200).nullable().optional().default(null),
+      numero_externe: shortText(120).nullable().optional().default(null),
+      organisme: shortText(200).nullable().optional().default(null),
+      commentaire: longText(5000).nullable().optional().default(null),
+      confidentiality: z
+        .enum(["INTERNAL", "RESTRICTED", "CUSTOMER_VISIBLE"])
+        .default("RESTRICTED"),
+    })
+    .strict()
+    .superRefine((value, ctx) => {
+      // Un certificat externe est émis par un tiers : sans émetteur, c'est un PV
+      // interne, et le confondre fausserait la traçabilité.
+      if (value.document_kind === "CERTIFICAT" && !value.emetteur) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["emetteur"],
+          message: "Un certificat externe déclare son émetteur ; sinon enregistrez un PV interne.",
+        });
+      }
+    }),
+});
+export type UploadCertificateBodyDTO = z.infer<typeof uploadCertificateSchema>["body"];
+
+export const cancelCertificateSchema = z.object({
+  params: z.object({ id: uuid, childId: uuid }),
+  body: z
+    .object({
+      reason: reason(10),
+      replaced_by_id: optionalUuid,
+      open_impact_analysis: z.boolean().default(true),
+    })
+    .strict(),
+});
+export type CancelCertificateBodyDTO = z.infer<typeof cancelCertificateSchema>["body"];
+
+/* -------------------------------------------------------------------------- */
+/* Analyse d'impact                                                           */
+/* -------------------------------------------------------------------------- */
+
+export const createImpactSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      execution_id: optionalUuid,
+      certificat_id: optionalUuid,
+      trigger_type: z
+        .enum(["VERDICT_NON_CONFORME", "CERTIFICAT_INVALIDE", "MANUEL"])
+        .default("MANUEL"),
+      window_from: isoDateTime.nullable().default(null),
+      window_to: isoDateTime.nullable().default(null),
+      window_reason: longText(2000).nullable().default(null),
+      exclusions: longText(2000).nullable().default(null),
+      owner_user_id: z.number().int().positive().nullable().default(null),
+    })
+    .strict()
+    .superRefine((value, ctx) => {
+      const hasFrom = Boolean(value.window_from);
+      const hasTo = Boolean(value.window_to);
+      if (hasFrom !== hasTo) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: [hasFrom ? "window_to" : "window_from"],
+          message: "Une fenêtre imposée déclare ses deux bornes.",
+        });
+      }
+      if (hasFrom && hasTo && (value.window_reason ?? "").trim().length < 20) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["window_reason"],
+          message: "Une fenêtre imposée exige une justification d'au moins 20 caractères.",
+        });
+      }
+    }),
+});
+export type CreateImpactBodyDTO = z.infer<typeof createImpactSchema>["body"];
+
+export const listImpactsQuerySchema = paginationSchema
+  .extend({
+    equipement_id: uuid.optional(),
+    status: z.enum(METROLOGY_IMPACT_STATUSES).optional(),
+    priority: z.enum(["LOW", "NORMAL", "HIGH", "CRITICAL"]).optional(),
+    sortBy: z.enum(["created_at", "updated_at", "priority", "code"]).default("created_at"),
+  })
+  .strict();
+export type ListImpactsQueryDTO = z.infer<typeof listImpactsQuerySchema>;
+
+export const listImpactItemsQuerySchema = paginationSchema
+  .extend({
+    decision: z.enum(METROLOGY_IMPACT_DECISIONS).optional(),
+    sortBy: z.enum(["control_date", "decision"]).default("control_date"),
+  })
+  .strict();
+export type ListImpactItemsQueryDTO = z.infer<typeof listImpactItemsQuerySchema>;
+
+export const decideImpactItemSchema = z.object({
+  params: z.object({ id: uuid, childId: uuid }),
+  body: z
+    .object({
+      decision: z.enum([
+        "NO_IMPACT",
+        "RECHECK",
+        "HOLD_LOT",
+        "OPEN_NC",
+        "REISSUE_DOCUMENT",
+        "INFORM_CUSTOMER",
+      ]),
+      reason: reason(5),
+      non_conformity_id: optionalUuid,
+    })
+    .strict(),
+});
+export type DecideImpactItemBodyDTO = z.infer<typeof decideImpactItemSchema>["body"];
+
+export const transitionImpactSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      ...expectedVersion,
+      target_status: z.enum(["IN_REVIEW", "OPEN", "CLOSED", "CANCELLED"]),
+      conclusion: longText(5000).nullable().default(null),
+    })
+    .strict(),
+});
+export type TransitionImpactBodyDTO = z.infer<typeof transitionImpactSchema>["body"];
+
+/* -------------------------------------------------------------------------- */
+/* Éligibilité et centre de commande                                          */
+/* -------------------------------------------------------------------------- */
+
+export const eligibilityQuerySchema = z
+  .object({
+    characteristic_key: z.string().trim().min(1).max(40).default("MESURE"),
+    instrument_id: uuid.optional(),
+    instrument_category: z.string().trim().min(1).max(60).optional(),
+    method: z.string().trim().min(1).max(200).optional(),
+    unit: unite.optional(),
+    nominal: z.coerce.number().finite().optional(),
+    tolerance_min: z.coerce.number().finite().optional(),
+    tolerance_max: z.coerce.number().finite().optional(),
+    requires_certificate: z.enum(["true", "false"]).default("false"),
+    /** Liste des instruments candidats plutôt qu'un seul verdict. */
+    mode: z.enum(["single", "candidates"]).default("single"),
+    limit: z.coerce.number().int().min(1).max(50).default(20),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if (value.mode === "single" && !value.instrument_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["instrument_id"],
+        message: "Le mode « single » exige l'instrument à évaluer.",
+      });
+    }
+  });
+export type EligibilityQueryDTO = z.infer<typeof eligibilityQuerySchema>;
+
+export const centerQuerySchema = z
+  .object({
+    site: z.string().trim().max(120).optional(),
+    categorie_code: categoryCode.optional(),
+    horizon_days: z.coerce.number().int().min(1).max(365).default(30),
+  })
+  .strict();
+export type CenterQueryDTO = z.infer<typeof centerQuerySchema>;
+
+export const timelineQuerySchema = paginationSchema
+  .extend({
+    entity_type: z.string().trim().max(60).optional(),
+  })
+  .strict();
+export type TimelineQueryDTO = z.infer<typeof timelineQuerySchema>;
+
+export const usageQuerySchema = paginationSchema
+  .extend({
+    from: isoDateTime.optional(),
+    to: isoDateTime.optional(),
+  })
+  .strict();
+export type UsageQueryDTO = z.infer<typeof usageQuerySchema>;

--- a/src/module/qualite/repository/quality-360.repository.ts
+++ b/src/module/qualite/repository/quality-360.repository.ts
@@ -43,6 +43,7 @@ import {
   computeExecutionVerdict,
   evaluateSample,
   requiredSampleCount,
+  resolveCharacteristicBounds,
   selectApplicablePlan,
   type ApplicabilityContext,
   type PlanCandidate,
@@ -54,16 +55,21 @@ import {
   assertSourceRef,
   derogationStatusAfterConsumption,
   evaluateDerogationUsage,
-  evaluateInstrumentUsage,
   evaluateQualityEligibility,
   evaluateReleaseRequest,
   releasableQty,
   type DerogationState,
   type EligibilityTarget,
-  type InstrumentState,
   type QualityEligibilityPurpose,
   type QuantityLedger,
 } from "../domain/quality-release";
+// #229 — Source de vérité unique de l'éligibilité d'un instrument : le module
+// Métrologie. Le module Qualité la consomme, il ne la ré-implémente pas.
+import { repoBuildInstrumentSnapshot } from "../../metrologie/repository/metrology-registry.repository";
+import type {
+  MetrologyInstrumentSnapshot,
+  MetrologyUsageRequirement,
+} from "../../metrologie/domain/metrology-eligibility";
 import type {
   ConsumeDerogationBodyDTO,
   CreateDerogationBodyDTO,
@@ -88,8 +94,6 @@ import type { AuditContext } from "./qualite.repository";
 type DbQueryer = Pick<PoolClient, "query">;
 
 export type QualityActor = AuditContext & { role: string | null; request_id: string | null };
-
-const METROLOGY_SETTING_KEY = "metrologie.block_on_overdue_critical";
 
 /* ========================================================================== */
 /* Helpers transversaux                                                       */
@@ -259,19 +263,11 @@ function sortDirection(dir: "asc" | "desc"): "ASC" | "DESC" {
   return dir === "asc" ? "ASC" : "DESC";
 }
 
-async function metrologyPolicy(q: DbQueryer): Promise<{ block_on_overdue_critical: boolean }> {
-  try {
-    const res = await q.query<{ value_json: unknown }>(
-      `SELECT value_json FROM public.erp_settings WHERE key = $1`,
-      [METROLOGY_SETTING_KEY]
-    );
-    const raw = res.rows[0]?.value_json ?? null;
-    const enabled = Boolean(raw && typeof raw === "object" && (raw as { enabled?: unknown }).enabled === true);
-    return { block_on_overdue_critical: enabled };
-  } catch {
-    return { block_on_overdue_critical: false };
-  }
-}
+// #229 — La lecture du réglage `metrologie.block_on_overdue_critical` a migré
+// dans `module/metrologie/repository/metrology-shared.repository.ts`
+// (`loadMetrologyPolicy`). Elle est appliquée à l'instrument réellement utilisé,
+// jamais en verrou global : garder une seconde lecture ici ferait diverger deux
+// interprétations du même réglage.
 
 /* ========================================================================== */
 /* Plans de contrôle                                                          */
@@ -1397,38 +1393,88 @@ function legacyControlType(trigger: string): "IN_PROCESS" | "FINAL" | "RECEPTION
   }
 }
 
-async function loadInstrument(q: DbQueryer, instrumentId: string): Promise<InstrumentState | null> {
-  const res = await q.query<{
-    id: string;
-    code: string | null;
-    designation: string;
-    statut: string;
-    criticite: string;
-    categorie: string | null;
-    deleted_at: string | null;
-    next_due_date: string | null;
-  }>(
-    `
-      SELECT e.id, e.code, e.designation, e.statut, e.criticite, e.categorie, e.deleted_at,
-             (SELECT MIN(p.next_due_date)::text
-                FROM public.metrologie_plan p
-               WHERE p.equipement_id = e.id AND p.deleted_at IS NULL AND p.statut = 'EN_COURS') AS next_due_date
-      FROM public.metrologie_equipements e
-      WHERE e.id = $1::uuid
-    `,
-    [instrumentId]
-  );
-  const row = res.rows[0];
-  if (!row) return null;
+/**
+ * #229 — L'éligibilité d'un instrument est décidée par le MOTEUR DE MÉTROLOGIE,
+ * pas ici. La règle vivait à deux endroits (une lecture SQL locale + une
+ * évaluation partielle) ; elle vit désormais dans
+ * `module/metrologie/domain/metrology-eligibility.ts` et le module Qualité s'y
+ * adresse. Cela apporte, sans changer un seul contrat consommateur :
+ *   - la quarantaine et le hors tolérance (états #229) ;
+ *   - la compatibilité méthode / unité / plage / résolution ;
+ *   - l'exigence de certificat valide ;
+ *   - la stratégie de blocage portée par la version de plan applicable.
+ */
+async function evaluateInstrumentForCharacteristic(
+  q: DbQueryer,
+  params: {
+    spec: QualityCharacteristicSpec;
+    instrumentId: string | null;
+    at: Date;
+  }
+): Promise<{
+  allowed: boolean;
+  severity: "OK" | "WARNING" | "BLOCKING";
+  code: string;
+  message: string;
+  snapshot: MetrologyInstrumentSnapshot | null;
+}> {
+  const { spec } = params;
+  const bounds = resolveCharacteristicBounds(spec);
+  const requirement: MetrologyUsageRequirement = {
+    characteristic_key: spec.key,
+    requires_instrument: spec.requires_instrument,
+    instrument_category: spec.instrument_category,
+    method: spec.method,
+    unit: spec.unit,
+    nominal: spec.nominal,
+    tolerance_min: bounds.min,
+    tolerance_max: bounds.max,
+    // Une caractéristique critique exige une preuve documentaire opposable.
+    requires_certificate: spec.criticality === "CRITICAL",
+  };
+
+  if (!spec.requires_instrument && !params.instrumentId) {
+    return {
+      allowed: true,
+      severity: "OK",
+      code: "OK",
+      message: "Aucun moyen de contrôle requis.",
+      snapshot: null,
+    };
+  }
+
+  if (!params.instrumentId) {
+    return {
+      allowed: false,
+      severity: "BLOCKING",
+      code: "INSTRUMENT_REQUIRED",
+      message: `La caractéristique ${spec.key} exige l'instrument réellement utilisé.`,
+      snapshot: null,
+    };
+  }
+
+  const evaluation = await repoBuildInstrumentSnapshot({
+    q,
+    instrumentId: params.instrumentId,
+    requirement,
+    at: params.at,
+  });
+  if (!evaluation) {
+    return {
+      allowed: false,
+      severity: "BLOCKING",
+      code: "INSTRUMENT_UNKNOWN",
+      message: "Instrument de métrologie inconnu.",
+      snapshot: null,
+    };
+  }
+
   return {
-    id: row.id,
-    code: row.code,
-    designation: row.designation,
-    statut: row.statut,
-    criticite: row.criticite,
-    categorie: row.categorie,
-    next_due_date: row.next_due_date,
-    deleted: row.deleted_at !== null,
+    allowed: evaluation.eligibility.eligible,
+    severity: evaluation.eligibility.severity,
+    code: evaluation.eligibility.code,
+    message: evaluation.eligibility.message,
+    snapshot: evaluation.snapshot,
   };
 }
 
@@ -1463,7 +1509,6 @@ export async function repoRecordMeasurements(params: {
 
     const specs = characteristicsFromSnapshot(before.plan_snapshot);
     const specByKey = new Map(specs.map((spec) => [spec.key, spec]));
-    const policy = await metrologyPolicy(client);
     const now = new Date();
     const warnings: Array<{ characteristic_key: string; code: string; message: string }> = [];
 
@@ -1486,19 +1531,18 @@ export async function repoRecordMeasurements(params: {
         );
       }
 
-      let instrumentSnapshot: InstrumentState | null = null;
-      if (measurement.instrument_id) {
-        instrumentSnapshot = await loadInstrument(client, measurement.instrument_id);
-        if (!instrumentSnapshot) {
-          throw new HttpError(422, "INSTRUMENT_UNKNOWN", "Instrument de métrologie inconnu.");
-        }
-      }
-      const instrumentCheck = evaluateInstrumentUsage({
-        characteristic: spec,
-        instrument: instrumentSnapshot,
+      // #229 — Le serveur arbitre l'emploi de l'instrument et fige un snapshot
+      // immuable : une modification future du registre, du plan ou du
+      // certificat ne réécrira pas ce contrôle déjà exécuté.
+      const instrumentCheck = await evaluateInstrumentForCharacteristic(client, {
+        spec,
+        instrumentId: measurement.instrument_id ?? null,
         at: now,
-        policy,
       });
+      const instrumentSnapshot = instrumentCheck.snapshot;
+      if (instrumentCheck.code === "INSTRUMENT_UNKNOWN") {
+        throw new HttpError(422, "INSTRUMENT_UNKNOWN", "Instrument de métrologie inconnu.");
+      }
       if (!instrumentCheck.allowed) {
         throw new HttpError(409, instrumentCheck.code, instrumentCheck.message, {
           characteristic: spec.key,

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -32,6 +32,7 @@ import fournisseursRoutes from "../module/fournisseurs/routes/fournisseurs.route
 import commandeFournisseurRoutes from "../module/commande-fournisseur/routes/commande-fournisseur.routes";
 import receptionsRoutes from "../module/receptions/routes/receptions.routes";
 import metrologieRoutes from "../module/metrologie/routes/metrologie.routes";
+import metrology360Routes from "../module/metrologie/routes/metrology-360.routes";
 import codesRoutes from "../module/codes/routes/codes.routes";
 import notificationsRoutes from "../module/notifications/routes/notifications.routes";
 import chatRoutes from "../module/chat/routes/chat.routes";
@@ -87,6 +88,10 @@ router.use("/dossiers", operationDossiersRoutes);
 router.use("/fournisseurs", fournisseursRoutes);
 router.use("/commandes-fournisseurs", commandeFournisseurRoutes); // Module « Commandes fournisseurs » (#172) — BCF
 router.use("/receptions", receptionsRoutes);
+// Métrologie 360 (#229) monté AVANT le routeur historique : ses routes
+// déclarent des capacités fines (refus par défaut) et ne partagent pas les
+// chemins hérités, qui restent inchangés pour les écrans en production.
+router.use("/metrologie/v2", metrology360Routes);
 router.use("/metrologie", metrologieRoutes);
 router.use("/codes", codesRoutes);
 router.use("/notifications", notificationsRoutes);

--- a/src/shared/codes/code-generator.service.ts
+++ b/src/shared/codes/code-generator.service.ts
@@ -117,7 +117,10 @@ export async function generateTransactionalBusinessCode(
       | "BCF"
       // #228: plans de contrôle et dérogations qualité.
       | "PC"
-      | "DER";
+      | "DER"
+      // #229: exécutions métrologiques et dossiers d'analyse d'impact.
+      | "MEX"
+      | "MIA";
     date?: Date;
     width?: number;
   }
@@ -170,6 +173,34 @@ export async function generateFournisseurCode(tx: DbQueryer): Promise<string> {
 export async function generateMachineCode(tx: DbQueryer): Promise<string> {
   const seq = await nextCodeValue(tx, "MCH");
   return `MCH-${pad(seq, 6)}`;
+}
+
+/**
+ * #229 — Équipement de métrologie : MET-NNNNNN.
+ *
+ * Le code visible est alloué par le SERVEUR dans la transaction de création. Un
+ * code proposé par l'interface n'est jamais retenu, et le code attribué est
+ * ensuite immuable (trigger `fn_protect_metrologie_equipement_229`).
+ */
+export async function generateMetrologieEquipementCode(tx: DbQueryer): Promise<string> {
+  const seq = await nextCodeValue(tx, "MET");
+  return `MET-${pad(seq, 6)}`;
+}
+
+/** #229 — Exécution métrologique (étalonnage/vérification) : MEX-AAAA-NNNNNN. */
+export async function generateMetrologieExecutionCode(
+  tx: DbQueryer,
+  params?: { date?: Date }
+): Promise<string> {
+  return generateTransactionalBusinessCode(tx, { prefix: "MEX", date: params?.date, width: 6 });
+}
+
+/** #229 — Dossier d'analyse d'impact métrologique : MIA-AAAA-NNNNN. */
+export async function generateMetrologieImpactCode(
+  tx: DbQueryer,
+  params?: { date?: Date }
+): Promise<string> {
+  return generateTransactionalBusinessCode(tx, { prefix: "MIA", date: params?.date, width: 5 });
 }
 
 /** #172 — Bon de commande fournisseur : BCF-AAAA-NNNN, alloué en transaction, immuable. */


### PR DESCRIPTION
## Release Métrologie 360
Promotion de `dev` vers `main` après fusion de #138.

### Contenu
- Domaine et API Métrologie 360.
- RBAC, audit, idempotence, quarantaine et analyse d'impact bornée.
- Patch PostgreSQL additif pour `cerp_prod`.

### Validation et déploiement
- Suite backend complète : 1938 tests verts.
- TypeScript propre.
- Backup vérifié avant application SQL, contrôles post-migration et smoke API.

Référence : BigFootLime/crp-systems-web#229