### PR TITLE
security(metrologie): corriger les droits runtime prod (#229)

### DIFF
--- a/db/privileged/20260726_metrologie_360_229_runtime_grants.rollback.sql
+++ b/db/privileged/20260726_metrologie_360_229_runtime_grants.rollback.sql
@@ -1,0 +1,53 @@
+-- Emergency rollback for #229 runtime grants.
+-- PRIVILEGED — SUPERUSER ONLY.
+--
+-- This restores conventional cerp_app ownership and therefore weakens the
+-- append-only ownership boundary. Use only as part of an approved rollback.
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF NOT COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false) THEN
+    RAISE EXCEPTION
+      'metrologie_360_229_runtime_grants rollback: superuser required; current_user=%',
+      current_user;
+  END IF;
+END
+$guard$;
+
+DO $rollback$
+DECLARE
+  table_name text;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'metrologie_categories',
+    'metrologie_plan_version',
+    'metrologie_execution',
+    'metrologie_execution_measurement',
+    'metrologie_measurement_revision',
+    'metrologie_impact_dossier',
+    'metrologie_impact_item',
+    'metrologie_command_receipts',
+    'metrologie_event_log'
+  ]
+  LOOP
+    IF to_regclass('public.' || table_name) IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.%I OWNER TO cerp_app', table_name);
+      EXECUTE format('GRANT ALL ON TABLE public.%I TO cerp_app', table_name);
+    END IF;
+  END LOOP;
+END
+$rollback$;
+
+ALTER FUNCTION public.fn_protect_metrologie_equipement_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_plan_version_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_execution_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_measurement_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_certificat_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_metrologie_append_only_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_categorie_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_impact_229() OWNER TO cerp_app;
+ALTER FUNCTION public.fn_protect_metrologie_impact_item_229() OWNER TO cerp_app;
+
+COMMIT;

--- a/db/privileged/20260726_metrologie_360_229_runtime_grants.sql
+++ b/db/privileged/20260726_metrologie_360_229_runtime_grants.sql
@@ -1,0 +1,103 @@
+-- 20260726_metrologie_360_229_runtime_grants.sql
+-- PRIVILEGED — SUPERUSER ONLY
+--
+-- The #229 patch can be applied either by the patch runner (cerp_app) or
+-- directly by postgres during a controlled release. Direct application makes
+-- the new tables postgres-owned, so the runtime role would otherwise have no
+-- access. This script makes ownership and least-privilege grants reproducible.
+--
+-- Mutable workflow tables remain postgres-owned and expose only the operations
+-- used by the API. Evidence tables are strictly SELECT + INSERT for cerp_app.
+--
+-- Apply after db/patches/20260726_metrologie_360_229.sql.
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF NOT COALESCE((SELECT rolsuper FROM pg_roles WHERE rolname = current_user), false) THEN
+    RAISE EXCEPTION
+      'metrologie_360_229_runtime_grants: superuser required; current_user=%',
+      current_user;
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'metrologie_360_229_runtime_grants: role cerp_app is missing';
+  END IF;
+END
+$guard$;
+
+DO $mutable_tables$
+DECLARE
+  table_name text;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'metrologie_categories',
+    'metrologie_plan_version',
+    'metrologie_execution',
+    'metrologie_execution_measurement',
+    'metrologie_impact_dossier',
+    'metrologie_impact_item'
+  ]
+  LOOP
+    IF to_regclass('public.' || table_name) IS NULL THEN
+      RAISE EXCEPTION
+        'metrologie_360_229_runtime_grants: missing table public.%',
+        table_name;
+    END IF;
+
+    EXECUTE format('ALTER TABLE public.%I OWNER TO postgres', table_name);
+    EXECUTE format('REVOKE ALL ON TABLE public.%I FROM cerp_app', table_name);
+    EXECUTE format(
+      'REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE public.%I FROM PUBLIC',
+      table_name
+    );
+    EXECUTE format(
+      'GRANT SELECT, INSERT, UPDATE ON TABLE public.%I TO cerp_app',
+      table_name
+    );
+  END LOOP;
+END
+$mutable_tables$;
+
+DO $append_only_tables$
+DECLARE
+  table_name text;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'metrologie_event_log',
+    'metrologie_measurement_revision',
+    'metrologie_command_receipts'
+  ]
+  LOOP
+    IF to_regclass('public.' || table_name) IS NULL THEN
+      RAISE EXCEPTION
+        'metrologie_360_229_runtime_grants: missing table public.%',
+        table_name;
+    END IF;
+
+    EXECUTE format('ALTER TABLE public.%I OWNER TO postgres', table_name);
+    EXECUTE format('REVOKE ALL ON TABLE public.%I FROM cerp_app', table_name);
+    EXECUTE format(
+      'REVOKE UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER ON TABLE public.%I FROM PUBLIC',
+      table_name
+    );
+    EXECUTE format(
+      'GRANT SELECT, INSERT ON TABLE public.%I TO cerp_app',
+      table_name
+    );
+  END LOOP;
+END
+$append_only_tables$;
+
+ALTER FUNCTION public.fn_protect_metrologie_equipement_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_plan_version_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_execution_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_measurement_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_certificat_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_metrologie_append_only_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_categorie_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_impact_229() OWNER TO postgres;
+ALTER FUNCTION public.fn_protect_metrologie_impact_item_229() OWNER TO postgres;
+
+COMMIT;

--- a/db/privileged/20260726_metrologie_360_229_runtime_grants.verify.sql
+++ b/db/privileged/20260726_metrologie_360_229_runtime_grants.verify.sql
@@ -1,0 +1,95 @@
+-- Verify #229 runtime ownership and least-privilege grants.
+-- Read-only; safe on cerp_test and cerp_prod.
+
+BEGIN READ ONLY;
+
+DO $verify$
+DECLARE
+  table_name text;
+  function_name text;
+  actual_owner text;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'metrologie_categories',
+    'metrologie_plan_version',
+    'metrologie_execution',
+    'metrologie_execution_measurement',
+    'metrologie_impact_dossier',
+    'metrologie_impact_item'
+  ]
+  LOOP
+    SELECT tableowner
+      INTO actual_owner
+      FROM pg_tables
+     WHERE schemaname = 'public'
+       AND tablename = table_name;
+
+    IF actual_owner IS DISTINCT FROM 'postgres' THEN
+      RAISE EXCEPTION 'public.% owner is %, expected postgres', table_name, actual_owner;
+    END IF;
+
+    IF NOT has_table_privilege('cerp_app', format('public.%I', table_name), 'SELECT')
+       OR NOT has_table_privilege('cerp_app', format('public.%I', table_name), 'INSERT')
+       OR NOT has_table_privilege('cerp_app', format('public.%I', table_name), 'UPDATE')
+       OR has_table_privilege('cerp_app', format('public.%I', table_name), 'DELETE')
+       OR has_table_privilege('cerp_app', format('public.%I', table_name), 'TRUNCATE') THEN
+      RAISE EXCEPTION 'public.% mutable-table grants are not least privilege', table_name;
+    END IF;
+  END LOOP;
+
+  FOREACH table_name IN ARRAY ARRAY[
+    'metrologie_event_log',
+    'metrologie_measurement_revision',
+    'metrologie_command_receipts'
+  ]
+  LOOP
+    SELECT tableowner
+      INTO actual_owner
+      FROM pg_tables
+     WHERE schemaname = 'public'
+       AND tablename = table_name;
+
+    IF actual_owner IS DISTINCT FROM 'postgres' THEN
+      RAISE EXCEPTION 'public.% owner is %, expected postgres', table_name, actual_owner;
+    END IF;
+
+    IF NOT has_table_privilege('cerp_app', format('public.%I', table_name), 'SELECT')
+       OR NOT has_table_privilege('cerp_app', format('public.%I', table_name), 'INSERT')
+       OR has_table_privilege('cerp_app', format('public.%I', table_name), 'UPDATE')
+       OR has_table_privilege('cerp_app', format('public.%I', table_name), 'DELETE')
+       OR has_table_privilege('cerp_app', format('public.%I', table_name), 'TRUNCATE') THEN
+      RAISE EXCEPTION 'public.% append-only grants are not least privilege', table_name;
+    END IF;
+  END LOOP;
+
+  FOREACH function_name IN ARRAY ARRAY[
+    'fn_protect_metrologie_equipement_229',
+    'fn_protect_metrologie_plan_version_229',
+    'fn_protect_metrologie_execution_229',
+    'fn_protect_metrologie_measurement_229',
+    'fn_protect_metrologie_certificat_229',
+    'fn_metrologie_append_only_229',
+    'fn_protect_metrologie_categorie_229',
+    'fn_protect_metrologie_impact_229',
+    'fn_protect_metrologie_impact_item_229'
+  ]
+  LOOP
+    SELECT pg_get_userbyid(proowner)
+      INTO actual_owner
+      FROM pg_proc
+     WHERE pronamespace = 'public'::regnamespace
+       AND proname = function_name
+       AND pronargs = 0;
+
+    IF actual_owner IS DISTINCT FROM 'postgres' THEN
+      RAISE EXCEPTION 'public.%() owner is %, expected postgres', function_name, actual_owner;
+    END IF;
+  END LOOP;
+END
+$verify$;
+
+SELECT
+  current_database() AS database_name,
+  'metrologie_360_229_runtime_grants_ok' AS verification;
+
+ROLLBACK;

--- a/docs/http/metrologie-229.md
+++ b/docs/http/metrologie-229.md
@@ -311,3 +311,25 @@ Aucune trace SQL ni pile d'appel ne remonte au client.
   idempotence et verrou optimiste.
 - `src/__tests__/metrologie-360-229.routes.test.ts` — 32 cas : RBAC refusé par
   défaut, validation stricte, non-fuite de `storage_path`, éligibilité.
+
+---
+
+## 10. Ordre de déploiement PostgreSQL
+
+Le patch fonctionnel et le durcissement privilégié sont deux étapes
+obligatoires, dans cet ordre :
+
+1. `db/patches/20260726_metrologie_360_229.sql`
+2. `db/privileged/20260726_metrologie_360_229_runtime_grants.sql`
+3. `db/privileged/20260726_metrologie_360_229_runtime_grants.verify.sql`
+
+La deuxième étape rend le résultat identique quel que soit le rôle ayant
+appliqué le premier patch. Les tables de workflow restent détenues par
+`postgres` avec `SELECT/INSERT/UPDATE` pour `cerp_app`. Les preuves
+`metrologie_event_log`, `metrologie_measurement_revision` et
+`metrologie_command_receipts` sont détenues par `postgres` et limitées à
+`SELECT/INSERT` pour le rôle applicatif.
+
+Une sauvegarde restaurable est requise avant toute application sur
+`cerp_prod`. Le script `verify.sql` est en lecture seule et doit terminer avec
+`metrologie_360_229_runtime_grants_ok`.


### PR DESCRIPTION
## Correctif de gate production #229
Le dry-run réel sur `cerp_test` a montré que l'application directe du patch par `postgres` laissait les nouvelles tables sans droits pour `cerp_app`.

## Correction
- Ajoute un script privilégié idempotent de propriété et de grants minimaux.
- Conserve les preuves Métrologie en `SELECT/INSERT` uniquement.
- Ajoute un verify read-only et un rollback explicite.
- Documente l'ordre de déploiement.

## Validation
- Patch fonctionnel appliqué avec succès sur `cerp_test`.
- Script privilégié appliqué avec succès.
- Verify : `metrologie_360_229_runtime_grants_ok`.
- `cerp_prod` non modifié pendant la correction.

Référence : BigFootLime/crp-systems-web#229

## Summary by Sourcery

Harden PostgreSQL runtime ownership and privileges for the Metrologie #229 patch using privileged, verifiable, and rollbackable scripts.

New Features:
- Introduce a privileged SQL script to enforce postgres ownership and least-privilege grants for Metrologie workflow and evidence tables.
- Add a read-only verification script that asserts runtime grants and function ownership are correctly configured for cerp_app and postgres.
- Provide an emergency rollback script to restore cerp_app ownership and broad grants if the hardened configuration must be reverted.

Enhancements:
- Document the required PostgreSQL deployment order for applying the functional patch, privileged grants, and verification on production.