### PR TITLE
feat(production): consolider le suivi d’exécution (#274)

### DIFF
--- a/db/patches/20260726_production_execution_274.sql
+++ b/db/patches/20260726_production_execution_274.sql
@@ -1,0 +1,600 @@
+-- 20260726_production_execution_274.sql
+-- Issue #274 — Suivi et pointage de production 360 : consolidation des deux
+-- moteurs de temps existants, référentiel d'activités gouverné, segments
+-- immuables, déclarations de quantités en deltas et idempotence.
+--
+-- Propriétés du patch :
+--   * ADDITIF uniquement : `production_pointages`, `production_pointage_events`
+--     et `of_time_logs` sont ÉTENDUS, jamais remplacés. Aucun enum historique
+--     n'est supprimé ni renuméroté, aucune ligne existante n'est réécrite.
+--   * IDEMPOTENT : rejouable sans effet de bord.
+--   * TRANSACTIONNEL : BEGIN/COMMIT, rien de partiel.
+--   * INACTIF sur le métier : ne crée aucun pointage, aucune déclaration,
+--     aucun mouvement de stock, aucune non-conformité. Seules les CATÉGORIES
+--     d'activité (référentiel désactivable) sont semées.
+--   * Réversible : `db/patches/support/20260726_production_execution_274.rollback.sql`
+--     (restreint à cerp_test, refuse de s'exécuter sur des données réelles).
+--
+-- DÉCISION D'ARCHITECTURE (ADR-0017) : `production_pointages` devient la SOURCE
+-- DE VÉRITÉ du temps de production. `of_time_logs` est conservé intact et
+-- devient un miroir de compatibilité : chaque ligne écrite par l'adaptateur
+-- porte désormais `pointage_id`, ce qui permet à la fonction de recalcul
+-- d'exclure les lignes déjà comptées côté canonique. Une minute ne peut donc
+-- jamais être comptée deux fois dans `of_operations.temps_total_real`.
+--
+-- Jamais exécuté en production par ce patch : application sur cerp_test, puis
+-- cerp_prod uniquement sur autorisation humaine explicite.
+
+BEGIN;
+
+/* -------------------------------------------------------------------------- */
+/* 0) Pré-requis                                                              */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF to_regclass('public.production_pointages') IS NULL THEN
+    RAISE EXCEPTION '#274 requires public.production_pointages (20260213_production_pointages.sql)';
+  END IF;
+  IF to_regclass('public.production_pointage_events') IS NULL THEN
+    RAISE EXCEPTION '#274 requires public.production_pointage_events';
+  END IF;
+  IF to_regclass('public.of_operations') IS NULL THEN
+    RAISE EXCEPTION '#274 requires public.of_operations (2026-02-12_production_of_machines_postes.sql)';
+  END IF;
+  IF to_regclass('public.of_time_logs') IS NULL THEN
+    RAISE EXCEPTION '#274 requires public.of_time_logs';
+  END IF;
+END$$;
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+CREATE EXTENSION IF NOT EXISTS btree_gist;
+
+/* -------------------------------------------------------------------------- */
+/* 1) Référentiel d'activités — gouverné, daté, désactivable                  */
+/* -------------------------------------------------------------------------- */
+-- Le modèle de temps a DEUX dimensions indépendantes :
+--   * la RESSOURCE mesurée (opérateur / machine / programmation) → conservée
+--     telle quelle dans l'enum historique `production_pointage_time_type` ;
+--   * l'ACTIVITÉ réalisée (réglage, production, attente matière, panne…) →
+--     ce référentiel, administrable sans migration.
+-- Chaque catégorie déclare si elle consomme du temps opérateur, du temps
+-- machine, si elle est productive, si un motif est obligatoire, sa criticité
+-- et ses conséquences aval. Aucune règle n'est codée en dur dans le service.
+
+CREATE TABLE IF NOT EXISTS public.production_activity_categories (
+  code text PRIMARY KEY,
+  label text NOT NULL,
+  description text NULL,
+
+  -- Comptabilisation : une attente matière consomme du temps machine mais pas
+  -- forcément du temps opérateur ; un arrêt planifié ne consomme ni l'un ni
+  -- l'autre. Ces drapeaux pilotent les agrégats, jamais une règle implicite.
+  counts_operator_time boolean NOT NULL DEFAULT true,
+  counts_machine_time boolean NOT NULL DEFAULT true,
+  is_productive boolean NOT NULL DEFAULT false,
+
+  requires_reason boolean NOT NULL DEFAULT false,
+  criticality text NOT NULL DEFAULT 'NORMAL',
+
+  -- Conséquences aval déclaratives : le service les lit, il ne les invente pas.
+  signals_planning boolean NOT NULL DEFAULT false,
+  signals_maintenance boolean NOT NULL DEFAULT false,
+  signals_quality boolean NOT NULL DEFAULT false,
+
+  -- Compatibilité ascendante avec les DEUX moteurs historiques : une catégorie
+  -- peut porter la valeur legacy correspondante afin qu'aucune donnée existante
+  -- ne devienne orpheline et que l'adaptateur sache traduire dans les deux sens.
+  legacy_time_type production_pointage_time_type NULL,
+  legacy_of_time_log_type public.of_time_log_type NULL,
+
+  -- Capacité RBAC exigée en plus de `declare_incident` (NULL = aucune).
+  required_capability text NULL,
+
+  sort_order integer NOT NULL DEFAULT 100,
+  effective_from date NOT NULL DEFAULT CURRENT_DATE,
+  disabled_at timestamptz NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT production_activity_categories_code_chk
+    CHECK (code ~ '^[A-Z][A-Z0-9_]{1,39}$'),
+  CONSTRAINT production_activity_categories_criticality_chk
+    CHECK (criticality IN ('LOW', 'NORMAL', 'HIGH', 'CRITICAL'))
+);
+
+DROP TRIGGER IF EXISTS production_activity_categories_set_updated_at
+  ON public.production_activity_categories;
+CREATE TRIGGER production_activity_categories_set_updated_at
+  BEFORE UPDATE ON public.production_activity_categories
+  FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at();
+
+CREATE INDEX IF NOT EXISTS production_activity_categories_active_idx
+  ON public.production_activity_categories (sort_order)
+  WHERE disabled_at IS NULL;
+
+-- Semis du référentiel. `ON CONFLICT DO NOTHING` : rejouable, et un
+-- administrateur qui a modifié une catégorie ne se la fait jamais écraser.
+INSERT INTO public.production_activity_categories (
+  code, label, counts_operator_time, counts_machine_time, is_productive,
+  requires_reason, criticality, signals_planning, signals_maintenance,
+  signals_quality, legacy_time_type, legacy_of_time_log_type, sort_order
+) VALUES
+  ('SETUP',            'Réglage',              true,  true,  false, false, 'NORMAL',  false, false, false, 'MACHINE',       'SETUP',       10),
+  ('PRODUCTION',       'Production',           true,  true,  true,  false, 'NORMAL',  false, false, false, 'OPERATEUR',     'PRODUCTION',  20),
+  ('PROGRAMMING',      'Programmation',        true,  false, false, false, 'NORMAL',  false, false, false, 'PROGRAMMATION', 'PROGRAMMING', 30),
+  ('CONTROL',          'Contrôle',             true,  false, false, false, 'NORMAL',  false, false, true,  'OPERATEUR',     'CONTROL',     40),
+  ('MAINTENANCE',      'Maintenance',          true,  true,  false, true,  'HIGH',    true,  true,  false, 'MACHINE',       'MAINTENANCE', 50),
+  ('CLEANING',         'Nettoyage',            true,  true,  false, false, 'LOW',     false, false, false, 'OPERATEUR',     NULL,          60),
+  ('TOOL_CHANGE',      'Changement d''outil',  true,  true,  false, false, 'NORMAL',  false, false, false, 'MACHINE',       'SETUP',       70),
+  ('WAIT_MATERIAL',    'Attente matière',      false, true,  false, true,  'HIGH',    true,  false, false, 'MACHINE',       NULL,          80),
+  ('WAIT_QUALITY',     'Attente qualité',      false, true,  false, true,  'HIGH',    true,  false, true,  'MACHINE',       NULL,          90),
+  ('WAIT_PROGRAM',     'Attente programme',    false, true,  false, true,  'NORMAL',  true,  false, false, 'MACHINE',       NULL,         100),
+  ('BREAKDOWN',        'Panne',                false, true,  false, true,  'CRITICAL',true,  true,  false, 'MACHINE',       'MAINTENANCE',110),
+  ('PLANNED_STOP',     'Arrêt planifié',       false, false, false, true,  'LOW',     true,  false, false, 'MACHINE',       NULL,         120),
+  ('UNPLANNED_STOP',   'Arrêt non planifié',   false, true,  false, true,  'CRITICAL',true,  true,  false, 'MACHINE',       NULL,         130),
+  ('REWORK',           'Reprise / retouche',   true,  true,  false, true,  'HIGH',    false, false, true,  'OPERATEUR',     'PRODUCTION', 140),
+  ('OTHER',            'Autre',                true,  false, false, true,  'NORMAL',  false, false, false, 'OPERATEUR',     NULL,         150)
+ON CONFLICT (code) DO NOTHING;
+
+/* -------------------------------------------------------------------------- */
+/* 2) Extension du moteur canonique `production_pointages`                    */
+/* -------------------------------------------------------------------------- */
+-- Aucune colonne existante n'est modifiée. Les nouvelles colonnes sont
+-- nullables ou dotées d'un défaut compatible avec l'historique : les pointages
+-- déjà enregistrés restent valides et lisibles sans reprise de données.
+
+ALTER TABLE public.production_pointages
+  ADD COLUMN IF NOT EXISTS activity_code text NULL
+    REFERENCES public.production_activity_categories(code)
+    ON UPDATE CASCADE ON DELETE RESTRICT,
+  -- Une exécution d'opération regroupe N segments immuables (START, PAUSE,
+  -- changement de machine…). `session_id` les relie sans jamais réécrire un
+  -- segment passé.
+  ADD COLUMN IF NOT EXISTS session_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS previous_segment_id uuid NULL
+    REFERENCES public.production_pointages(id)
+    ON UPDATE RESTRICT ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS segment_index integer NOT NULL DEFAULT 1,
+  -- Provenance : distingue un pointage saisi via la surface canonique d'un
+  -- pointage créé par l'adaptateur de compatibilité `of_time_logs`.
+  ADD COLUMN IF NOT EXISTS source text NOT NULL DEFAULT 'CANONICAL',
+  ADD COLUMN IF NOT EXISTS idempotency_key text NULL,
+  ADD COLUMN IF NOT EXISTS correlation_id uuid NULL,
+  -- Contexte technique figé au démarrage : la gamme peut être révisée pendant
+  -- l'exécution, la déclaration doit rester lisible telle qu'elle a été faite.
+  ADD COLUMN IF NOT EXISTS context_snapshot jsonb NULL,
+  ADD COLUMN IF NOT EXISTS is_retroactive boolean NOT NULL DEFAULT false,
+  ADD COLUMN IF NOT EXISTS created_for_other_reason text NULL,
+  ADD COLUMN IF NOT EXISTS submitted_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS submitted_by integer NULL
+    REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS rejected_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS rejected_by integer NULL
+    REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS rejection_reason text NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'production_pointages_source_chk'
+  ) THEN
+    ALTER TABLE public.production_pointages
+      ADD CONSTRAINT production_pointages_source_chk
+      CHECK (source IN ('CANONICAL', 'LEGACY_TIME_LOG', 'RETROACTIVE', 'ADAPTER'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'production_pointages_rejection_pair_chk'
+  ) THEN
+    ALTER TABLE public.production_pointages
+      ADD CONSTRAINT production_pointages_rejection_pair_chk
+      CHECK ((rejected_at IS NULL) = (rejected_by IS NULL));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'production_pointages_submission_pair_chk'
+  ) THEN
+    ALTER TABLE public.production_pointages
+      ADD CONSTRAINT production_pointages_submission_pair_chk
+      CHECK ((submitted_at IS NULL) = (submitted_by IS NULL));
+  END IF;
+
+  -- Un rejet doit être motivé : sans cela le rejet est une décision opaque.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'production_pointages_rejection_reason_chk'
+  ) THEN
+    ALTER TABLE public.production_pointages
+      ADD CONSTRAINT production_pointages_rejection_reason_chk
+      CHECK (rejected_at IS NULL OR rejection_reason IS NOT NULL);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'production_pointages_segment_index_chk'
+  ) THEN
+    ALTER TABLE public.production_pointages
+      ADD CONSTRAINT production_pointages_segment_index_chk CHECK (segment_index >= 1);
+  END IF;
+END$$;
+
+CREATE INDEX IF NOT EXISTS production_pointages_session_id_idx
+  ON public.production_pointages (session_id)
+  WHERE session_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS production_pointages_activity_code_idx
+  ON public.production_pointages (activity_code);
+
+CREATE INDEX IF NOT EXISTS production_pointages_validated_at_idx
+  ON public.production_pointages (validated_at)
+  WHERE validated_at IS NULL;
+
+-- Idempotence forte : la même clé ne peut pas créer deux pointages.
+CREATE UNIQUE INDEX IF NOT EXISTS production_pointages_idempotency_key_uniq
+  ON public.production_pointages (idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+/* --- Anti-chevauchement réel, garanti par la base ------------------------- */
+-- L'index partiel historique `production_pointages_running_operator_uniq` ne
+-- protège que les pointages EN COURS. Il ne dit rien des saisies manuelles ni
+-- rétroactives, qui peuvent aujourd'hui se chevaucher librement. On ajoute une
+-- contrainte d'exclusion sur les intervalles fermés, convention [début, fin) :
+-- deux segments qui se touchent bout à bout ne se chevauchent donc pas.
+--
+-- La contrainte n'est posée que si les données existantes la respectent déjà :
+-- ce patch ne doit jamais échouer sur une base réelle ni réécrire l'historique.
+-- Si des chevauchements préexistent, ils sont signalés et la contrainte est
+-- laissée de côté pour une reprise humaine explicite.
+DO $$
+DECLARE
+  operator_conflicts bigint;
+  machine_conflicts bigint;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'production_pointages_operator_no_overlap'
+  ) THEN
+    SELECT count(*) INTO operator_conflicts
+    FROM public.production_pointages a
+    JOIN public.production_pointages b
+      ON b.id <> a.id
+     AND b.operator_user_id = a.operator_user_id
+     AND b.status IN ('RUNNING', 'DONE')
+     AND tstzrange(b.start_ts, COALESCE(b.end_ts, 'infinity'::timestamptz), '[)')
+         && tstzrange(a.start_ts, COALESCE(a.end_ts, 'infinity'::timestamptz), '[)')
+    WHERE a.status IN ('RUNNING', 'DONE');
+
+    IF operator_conflicts = 0 THEN
+      ALTER TABLE public.production_pointages
+        ADD CONSTRAINT production_pointages_operator_no_overlap
+        EXCLUDE USING gist (
+          operator_user_id WITH =,
+          tstzrange(start_ts, COALESCE(end_ts, 'infinity'::timestamptz), '[)') WITH &&
+        )
+        WHERE (status IN ('RUNNING', 'DONE'));
+    ELSE
+      RAISE NOTICE '#274: % chevauchement(s) opérateur préexistant(s) — contrainte d''exclusion non posée, reprise humaine requise', operator_conflicts;
+    END IF;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'production_pointages_machine_no_overlap'
+  ) THEN
+    SELECT count(*) INTO machine_conflicts
+    FROM public.production_pointages a
+    JOIN public.production_pointages b
+      ON b.id <> a.id
+     AND b.machine_id = a.machine_id
+     AND b.status IN ('RUNNING', 'DONE')
+     AND tstzrange(b.start_ts, COALESCE(b.end_ts, 'infinity'::timestamptz), '[)')
+         && tstzrange(a.start_ts, COALESCE(a.end_ts, 'infinity'::timestamptz), '[)')
+    WHERE a.status IN ('RUNNING', 'DONE') AND a.machine_id IS NOT NULL;
+
+    IF machine_conflicts = 0 THEN
+      ALTER TABLE public.production_pointages
+        ADD CONSTRAINT production_pointages_machine_no_overlap
+        EXCLUDE USING gist (
+          machine_id WITH =,
+          tstzrange(start_ts, COALESCE(end_ts, 'infinity'::timestamptz), '[)') WITH &&
+        )
+        WHERE (status IN ('RUNNING', 'DONE') AND machine_id IS NOT NULL);
+    ELSE
+      RAISE NOTICE '#274: % chevauchement(s) machine préexistant(s) — contrainte d''exclusion non posée, reprise humaine requise', machine_conflicts;
+    END IF;
+  END IF;
+END$$;
+
+/* -------------------------------------------------------------------------- */
+/* 3) Déclarations de quantités — deltas immuables                            */
+/* -------------------------------------------------------------------------- */
+-- L'opérateur déclare des ÉCARTS, jamais un cumul réécrit : un cumul écrasé
+-- efface silencieusement la déclaration précédente et rend le rebut
+-- indétectable. Les lignes ne sont jamais mises à jour ; une correction est une
+-- ligne compensatoire liée à l'originale.
+
+CREATE TABLE IF NOT EXISTS public.production_quantity_declarations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  pointage_id uuid NULL
+    REFERENCES public.production_pointages(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  of_id bigint NOT NULL
+    REFERENCES public.ordres_fabrication(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  operation_id uuid NULL
+    REFERENCES public.of_operations(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  -- Deltas signés : positifs en déclaration, négatifs en compensation.
+  qty_good numeric(14, 4) NOT NULL DEFAULT 0,
+  qty_scrap numeric(14, 4) NOT NULL DEFAULT 0,
+  qty_rework numeric(14, 4) NOT NULL DEFAULT 0,
+  qty_pending_control numeric(14, 4) NOT NULL DEFAULT 0,
+  unite text NULL,
+
+  scrap_reason_code text NULL,
+  rework_reason_code text NULL,
+  note text NULL,
+
+  -- Traçabilité aval : renseigné SI le service Qualité canonique a créé une NC.
+  -- Le pointage ne crée jamais lui-même une non-conformité.
+  non_conformity_id uuid NULL,
+
+  -- Une déclaration annulée reste visible : on ne supprime pas une déclaration,
+  -- on la compense.
+  compensates_id uuid NULL
+    REFERENCES public.production_quantity_declarations(id)
+    ON UPDATE RESTRICT ON DELETE RESTRICT,
+  compensation_reason text NULL,
+
+  idempotency_key text NULL,
+  correlation_id uuid NULL,
+
+  declared_at timestamptz NOT NULL DEFAULT now(),
+  declared_by integer NOT NULL
+    REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT production_quantity_declarations_finite_chk CHECK (
+    qty_good = qty_good AND qty_scrap = qty_scrap
+    AND qty_rework = qty_rework AND qty_pending_control = qty_pending_control
+  ),
+  -- Une déclaration vide n'a pas de sens et masquerait un bug applicatif.
+  CONSTRAINT production_quantity_declarations_not_empty_chk CHECK (
+    qty_good <> 0 OR qty_scrap <> 0 OR qty_rework <> 0 OR qty_pending_control <> 0
+  ),
+  -- Seule une compensation peut porter des valeurs négatives, et elle doit
+  -- être motivée.
+  CONSTRAINT production_quantity_declarations_sign_chk CHECK (
+    compensates_id IS NOT NULL
+    OR (qty_good >= 0 AND qty_scrap >= 0 AND qty_rework >= 0 AND qty_pending_control >= 0)
+  ),
+  CONSTRAINT production_quantity_declarations_compensation_reason_chk CHECK (
+    compensates_id IS NULL OR compensation_reason IS NOT NULL
+  ),
+  -- Un rebut sans cause est un rebut perdu pour l'analyse.
+  CONSTRAINT production_quantity_declarations_scrap_reason_chk CHECK (
+    qty_scrap <= 0 OR scrap_reason_code IS NOT NULL
+  ),
+  CONSTRAINT production_quantity_declarations_rework_reason_chk CHECK (
+    qty_rework <= 0 OR rework_reason_code IS NOT NULL
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS production_quantity_declarations_idempotency_key_uniq
+  ON public.production_quantity_declarations (idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+-- Une déclaration ne peut être compensée qu'une seule fois.
+CREATE UNIQUE INDEX IF NOT EXISTS production_quantity_declarations_compensates_uniq
+  ON public.production_quantity_declarations (compensates_id)
+  WHERE compensates_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS production_quantity_declarations_of_id_idx
+  ON public.production_quantity_declarations (of_id);
+CREATE INDEX IF NOT EXISTS production_quantity_declarations_operation_id_idx
+  ON public.production_quantity_declarations (operation_id);
+CREATE INDEX IF NOT EXISTS production_quantity_declarations_pointage_id_idx
+  ON public.production_quantity_declarations (pointage_id);
+CREATE INDEX IF NOT EXISTS production_quantity_declarations_declared_at_idx
+  ON public.production_quantity_declarations (declared_at);
+
+-- Append-only : une déclaration signée ne se réécrit pas. La compensation est
+-- le seul mécanisme de correction, et elle laisse l'original visible.
+CREATE OR REPLACE FUNCTION public.tg_production_quantity_declarations_append_only()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Seul le rattachement d'une NC créée a posteriori par le service Qualité
+  -- canonique est toléré ; tout le reste est figé.
+  IF TG_OP = 'UPDATE' THEN
+    IF ROW(NEW.*) IS DISTINCT FROM ROW(OLD.*)
+       AND (
+         NEW.id IS DISTINCT FROM OLD.id
+         OR NEW.pointage_id IS DISTINCT FROM OLD.pointage_id
+         OR NEW.of_id IS DISTINCT FROM OLD.of_id
+         OR NEW.operation_id IS DISTINCT FROM OLD.operation_id
+         OR NEW.qty_good IS DISTINCT FROM OLD.qty_good
+         OR NEW.qty_scrap IS DISTINCT FROM OLD.qty_scrap
+         OR NEW.qty_rework IS DISTINCT FROM OLD.qty_rework
+         OR NEW.qty_pending_control IS DISTINCT FROM OLD.qty_pending_control
+         OR NEW.declared_by IS DISTINCT FROM OLD.declared_by
+         OR NEW.declared_at IS DISTINCT FROM OLD.declared_at
+         OR NEW.compensates_id IS DISTINCT FROM OLD.compensates_id
+       )
+    THEN
+      RAISE EXCEPTION 'production_quantity_declarations is append-only (id=%)', OLD.id
+        USING ERRCODE = 'restrict_violation';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS production_quantity_declarations_append_only
+  ON public.production_quantity_declarations;
+CREATE TRIGGER production_quantity_declarations_append_only
+  BEFORE UPDATE OR DELETE ON public.production_quantity_declarations
+  FOR EACH ROW EXECUTE FUNCTION public.tg_production_quantity_declarations_append_only();
+
+/* -------------------------------------------------------------------------- */
+/* 4) Idempotence des commandes à effet                                       */
+/* -------------------------------------------------------------------------- */
+-- Contrat : même clé + même empreinte de charge utile → même réponse rejouée.
+-- Même clé + charge utile différente → 409. La table stocke l'empreinte, pas
+-- la charge utile : aucune donnée personnelle n'y est recopiée.
+
+CREATE TABLE IF NOT EXISTS public.production_execution_idempotency (
+  idempotency_key text PRIMARY KEY,
+  scope text NOT NULL,
+  request_fingerprint text NOT NULL,
+  response_status integer NOT NULL,
+  response_body jsonb NULL,
+  user_id integer NOT NULL
+    REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT production_execution_idempotency_fingerprint_chk
+    CHECK (char_length(request_fingerprint) = 64)
+);
+
+CREATE INDEX IF NOT EXISTS production_execution_idempotency_created_at_idx
+  ON public.production_execution_idempotency (created_at);
+
+/* -------------------------------------------------------------------------- */
+/* 5) Compatibilité `of_time_logs` — corrélation, sans double comptage        */
+/* -------------------------------------------------------------------------- */
+-- `of_time_logs` n'est ni supprimé ni vidé : les écrans et tests historiques
+-- continuent de fonctionner. On lui ajoute simplement le lien vers le pointage
+-- canonique correspondant lorsque l'adaptateur a écrit les deux. Les lignes
+-- historiques gardent `pointage_id IS NULL` et restent donc comptées comme
+-- avant : aucune minute ne disparaît, aucune n'est comptée deux fois.
+
+ALTER TABLE public.of_time_logs
+  ADD COLUMN IF NOT EXISTS pointage_id uuid NULL
+    REFERENCES public.production_pointages(id)
+    ON UPDATE RESTRICT ON DELETE SET NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS of_time_logs_pointage_id_uniq
+  ON public.of_time_logs (pointage_id)
+  WHERE pointage_id IS NOT NULL;
+
+/* -------------------------------------------------------------------------- */
+/* 6) Recalcul unique et autoritaire de `of_operations.temps_total_real`      */
+/* -------------------------------------------------------------------------- */
+-- UNE seule formule, appelée par les deux surfaces. `temps_total_real` reste
+-- exprimé en HEURES, numeric(12,3), comme depuis 2026-02-12 : aucune unité
+-- n'est changée sous les pieds des consommateurs (planning, coûts, exports).
+--
+-- Total = temps canonique (production_pointages)
+--       + temps legacy NON migré (of_time_logs sans pointage_id)
+--
+-- Les statuts CANCELLED et CORRECTED sont exclus : une saisie annulée ou
+-- remplacée ne doit pas gonfler le temps réel, tout en restant visible en
+-- historique. Seules les catégories qui déclarent `counts_operator_time`
+-- comptent ; un arrêt planifié n'est pas du temps consommé par l'opération.
+-- Une catégorie absente (pointage historique) compte, pour ne pas faire
+-- disparaître rétroactivement du temps déjà déclaré.
+
+CREATE OR REPLACE FUNCTION public.fn_production_operation_real_hours(p_operation_id uuid)
+RETURNS numeric
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT ROUND(
+    (
+      COALESCE((
+        SELECT SUM(p.duration_minutes)
+        FROM public.production_pointages p
+        LEFT JOIN public.production_activity_categories c ON c.code = p.activity_code
+        WHERE p.operation_id = p_operation_id
+          AND p.duration_minutes IS NOT NULL
+          AND p.status IN ('DONE')
+          AND COALESCE(c.counts_operator_time, true)
+      ), 0)
+      +
+      COALESCE((
+        SELECT SUM(t.duration_minutes)
+        FROM public.of_time_logs t
+        WHERE t.of_operation_id = p_operation_id
+          AND t.duration_minutes IS NOT NULL
+          AND t.pointage_id IS NULL
+      ), 0)
+    )::numeric / 60.0,
+    3
+  );
+$$;
+
+COMMENT ON FUNCTION public.fn_production_operation_real_hours(uuid) IS
+  '#274 — Source unique du temps réel d''une opération d''OF, en heures. Somme le moteur canonique (production_pointages, statut DONE, catégories comptabilisées) et le résidu legacy non migré (of_time_logs sans pointage_id). Garantit qu''une minute n''est jamais comptée deux fois.';
+
+CREATE OR REPLACE FUNCTION public.fn_production_recompute_operation_real_time(p_operation_id uuid)
+RETURNS numeric
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_hours numeric;
+BEGIN
+  v_hours := public.fn_production_operation_real_hours(p_operation_id);
+
+  UPDATE public.of_operations
+  SET temps_total_real = v_hours,
+      updated_at = now()
+  WHERE id = p_operation_id;
+
+  RETURN v_hours;
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_production_recompute_operation_real_time(uuid) IS
+  '#274 — Recalcule et persiste of_operations.temps_total_real depuis la source unique. Idempotent : recalcul complet, jamais incrémental.';
+
+/* -------------------------------------------------------------------------- */
+/* 7) Vue de lecture : exécution en cours (Planning / Command Center Machines) */
+/* -------------------------------------------------------------------------- */
+-- Read-model unique de « ce qui tourne réellement ». Les consommateurs cessent
+-- d'interroger deux tables aux sémantiques différentes.
+
+CREATE OR REPLACE VIEW public.v_production_active_executions AS
+SELECT
+  p.id                     AS pointage_id,
+  p.session_id,
+  p.of_id,
+  o.numero                 AS of_numero,
+  p.operation_id,
+  op.phase                 AS operation_phase,
+  op.designation           AS operation_designation,
+  p.machine_id,
+  p.poste_id,
+  p.operator_user_id,
+  p.time_type,
+  p.activity_code,
+  COALESCE(c.label, p.time_type::text) AS activity_label,
+  COALESCE(c.is_productive, false)     AS activity_is_productive,
+  COALESCE(c.criticality, 'NORMAL')    AS activity_criticality,
+  p.start_ts,
+  -- Durée écoulée calculée par la base : le navigateur n'est jamais la source
+  -- du temps officiel.
+  GREATEST(0, ROUND(EXTRACT(EPOCH FROM (now() - p.start_ts)) / 60.0)::int) AS elapsed_minutes,
+  op.temps_total_planned,
+  op.temps_total_real
+FROM public.production_pointages p
+JOIN public.ordres_fabrication o ON o.id = p.of_id
+LEFT JOIN public.of_operations op ON op.id = p.operation_id
+LEFT JOIN public.production_activity_categories c ON c.code = p.activity_code
+WHERE p.status = 'RUNNING';
+
+COMMENT ON VIEW public.v_production_active_executions IS
+  '#274 — Read-model autoritaire des exécutions en cours (Planning, Command Center Machines, poste opérateur).';
+
+/* -------------------------------------------------------------------------- */
+/* 8) Commentaires de traçabilité                                             */
+/* -------------------------------------------------------------------------- */
+
+COMMENT ON TABLE public.production_activity_categories IS
+  '#274 — Référentiel gouverné des activités de production (réglage, production, attentes, arrêts, reprise). Daté et désactivable, il évite un second enum incompatible.';
+COMMENT ON TABLE public.production_quantity_declarations IS
+  '#274 — Déclarations de quantités en deltas immuables (bonnes, rebut, reprise, attente contrôle). Append-only : une correction est une ligne compensatoire.';
+COMMENT ON TABLE public.production_execution_idempotency IS
+  '#274 — Rejeu idempotent des commandes à effet du suivi de production. Stocke une empreinte, jamais la charge utile.';
+COMMENT ON COLUMN public.of_time_logs.pointage_id IS
+  '#274 — Corrélation vers le pointage canonique. NULL = ligne historique, comptée comme avant. Non NULL = déjà comptée côté canonique, exclue du total pour éviter le double comptage.';
+
+COMMIT;

--- a/db/patches/20260726_production_execution_274.sql
+++ b/db/patches/20260726_production_execution_274.sql
@@ -15,7 +15,7 @@
 --   * Réversible : `db/patches/support/20260726_production_execution_274.rollback.sql`
 --     (restreint à cerp_test, refuse de s'exécuter sur des données réelles).
 --
--- DÉCISION D'ARCHITECTURE (ADR-0017) : `production_pointages` devient la SOURCE
+-- DÉCISION D'ARCHITECTURE (ADR-0027) : `production_pointages` devient la SOURCE
 -- DE VÉRITÉ du temps de production. `of_time_logs` est conservé intact et
 -- devient un miroir de compatibilité : chaque ligne écrite par l'adaptateur
 -- porte désormais `pointage_id`, ce qui permet à la fonction de recalcul
@@ -476,6 +476,219 @@ CREATE UNIQUE INDEX IF NOT EXISTS of_time_logs_pointage_id_uniq
   ON public.of_time_logs (pointage_id)
   WHERE pointage_id IS NOT NULL;
 
+-- Adaptateur transactionnel des routes historiques.
+--
+-- Les contrôleurs legacy continuent d'insérer/arrêter `of_time_logs`, donc leur
+-- contrat HTTP et leur vue `open_time_log` restent inchangés. Le trigger crée
+-- ou ferme le pointage canonique DANS LA MÊME TRANSACTION. Si l'une des deux
+-- écritures échoue, PostgreSQL annule l'ensemble : aucun miroir orphelin, aucun
+-- pointage invisible et aucun double comptage.
+CREATE OR REPLACE FUNCTION public.tg_production_mirror_legacy_time_log()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+  v_pointage_id uuid;
+  v_session_id uuid;
+  v_of_id bigint;
+  v_affaire_id bigint;
+  v_piece_technique_id uuid;
+  v_poste_id uuid;
+  v_activity_code text;
+  v_time_type production_pointage_time_type;
+BEGIN
+  IF TG_OP = 'INSERT' AND NEW.pointage_id IS NULL THEN
+    SELECT
+      op.of_id,
+      o.affaire_id,
+      o.piece_technique_id,
+      op.poste_id
+    INTO
+      v_of_id,
+      v_affaire_id,
+      v_piece_technique_id,
+      v_poste_id
+    FROM public.of_operations op
+    JOIN public.ordres_fabrication o ON o.id = op.of_id
+    WHERE op.id = NEW.of_operation_id;
+
+    IF v_of_id IS NULL THEN
+      RAISE EXCEPTION 'OF operation % not found for legacy time log', NEW.of_operation_id
+        USING ERRCODE = '23503';
+    END IF;
+
+    v_activity_code := CASE NEW.type
+      WHEN 'SETUP'       THEN 'SETUP'
+      WHEN 'PROGRAMMING' THEN 'PROGRAMMING'
+      WHEN 'CONTROL'     THEN 'CONTROL'
+      WHEN 'MAINTENANCE' THEN 'MAINTENANCE'
+      ELSE 'PRODUCTION'
+    END;
+
+    v_time_type := CASE NEW.type
+      WHEN 'PROGRAMMING' THEN 'PROGRAMMATION'::production_pointage_time_type
+      WHEN 'MAINTENANCE' THEN 'MACHINE'::production_pointage_time_type
+      ELSE 'OPERATEUR'::production_pointage_time_type
+    END;
+
+    v_session_id := gen_random_uuid();
+
+    INSERT INTO public.production_pointages (
+      of_id,
+      affaire_id,
+      piece_technique_id,
+      operation_id,
+      machine_id,
+      poste_id,
+      operator_user_id,
+      time_type,
+      activity_code,
+      start_ts,
+      end_ts,
+      status,
+      comment,
+      session_id,
+      segment_index,
+      source,
+      context_snapshot,
+      created_by,
+      updated_by
+    )
+    VALUES (
+      v_of_id,
+      v_affaire_id,
+      v_piece_technique_id,
+      NEW.of_operation_id,
+      NEW.machine_id,
+      v_poste_id,
+      NEW.user_id,
+      v_time_type,
+      v_activity_code,
+      NEW.started_at,
+      NEW.ended_at,
+      CASE
+        WHEN NEW.ended_at IS NULL THEN 'RUNNING'::production_pointage_status
+        ELSE 'DONE'::production_pointage_status
+      END,
+      NEW.comment,
+      v_session_id,
+      1,
+      'LEGACY_TIME_LOG',
+      jsonb_build_object(
+        'captured_at', now(),
+        'operation_id', NEW.of_operation_id,
+        'activity_code', v_activity_code,
+        'legacy_time_log_type', NEW.type
+      ),
+      NEW.user_id,
+      NEW.user_id
+    )
+    RETURNING id INTO v_pointage_id;
+
+    NEW.pointage_id := v_pointage_id;
+
+    INSERT INTO public.production_pointage_events (
+      pointage_id,
+      event_type,
+      new_values,
+      user_id,
+      note
+    )
+    VALUES (
+      v_pointage_id,
+      'START',
+      jsonb_build_object(
+        'of_id', v_of_id,
+        'operation_id', NEW.of_operation_id,
+        'machine_id', NEW.machine_id,
+        'activity_code', v_activity_code,
+        'operator_user_id', NEW.user_id,
+        'source', 'LEGACY_TIME_LOG'
+      ),
+      NEW.user_id,
+      NEW.comment
+    );
+
+    IF NEW.ended_at IS NOT NULL THEN
+      NEW.duration_minutes := GREATEST(
+        0,
+        ROUND(EXTRACT(EPOCH FROM (NEW.ended_at - NEW.started_at)) / 60.0)::int
+      );
+
+      INSERT INTO public.production_pointage_events (
+        pointage_id,
+        event_type,
+        old_values,
+        new_values,
+        user_id,
+        note
+      )
+      VALUES (
+        v_pointage_id,
+        'STOP',
+        '{"status":"RUNNING"}'::jsonb,
+        jsonb_build_object('status', 'DONE', 'duration_minutes', NEW.duration_minutes),
+        NEW.user_id,
+        NEW.comment
+      );
+    END IF;
+
+    RETURN NEW;
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+     AND NEW.pointage_id IS NOT NULL
+     AND OLD.ended_at IS NULL
+     AND NEW.ended_at IS NOT NULL THEN
+    NEW.duration_minutes := GREATEST(
+      0,
+      ROUND(EXTRACT(EPOCH FROM (NEW.ended_at - NEW.started_at)) / 60.0)::int
+    );
+
+    UPDATE public.production_pointages
+    SET
+      status = 'DONE'::production_pointage_status,
+      end_ts = NEW.ended_at,
+      comment = COALESCE(NEW.comment, comment),
+      updated_at = now(),
+      updated_by = NEW.user_id
+    WHERE id = NEW.pointage_id
+      AND status = 'RUNNING';
+
+    IF FOUND THEN
+      INSERT INTO public.production_pointage_events (
+        pointage_id,
+        event_type,
+        old_values,
+        new_values,
+        user_id,
+        note
+      )
+      VALUES (
+        NEW.pointage_id,
+        'STOP',
+        '{"status":"RUNNING"}'::jsonb,
+        jsonb_build_object('status', 'DONE', 'duration_minutes', NEW.duration_minutes),
+        NEW.user_id,
+        NEW.comment
+      );
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS production_mirror_legacy_time_log
+  ON public.of_time_logs;
+CREATE TRIGGER production_mirror_legacy_time_log
+  BEFORE INSERT OR UPDATE OF ended_at, comment
+  ON public.of_time_logs
+  FOR EACH ROW
+  EXECUTE FUNCTION public.tg_production_mirror_legacy_time_log();
+
 /* -------------------------------------------------------------------------- */
 /* 6) Recalcul unique et autoritaire de `of_operations.temps_total_real`      */
 /* -------------------------------------------------------------------------- */
@@ -596,5 +809,49 @@ COMMENT ON TABLE public.production_execution_idempotency IS
   '#274 — Rejeu idempotent des commandes à effet du suivi de production. Stocke une empreinte, jamais la charge utile.';
 COMMENT ON COLUMN public.of_time_logs.pointage_id IS
   '#274 — Corrélation vers le pointage canonique. NULL = ligne historique, comptée comme avant. Non NULL = déjà comptée côté canonique, exclue du total pour éviter le double comptage.';
+
+/* -------------------------------------------------------------------------- */
+/* 9) Privilèges runtime minimaux                                             */
+/* -------------------------------------------------------------------------- */
+-- Les migrations sont généralement appliquées par `postgres`, alors que l'API
+-- s'exécute avec `cerp_app`. Sans ces droits explicites, un patch valide en
+-- recette échouerait au premier appel runtime.
+REVOKE ALL ON FUNCTION public.tg_production_mirror_legacy_time_log() FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_production_operation_real_hours(uuid) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_production_recompute_operation_real_time(uuid) FROM PUBLIC;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT, INSERT, UPDATE
+      ON public.production_pointages
+      TO cerp_app;
+    GRANT SELECT, INSERT
+      ON public.production_pointage_events
+      TO cerp_app;
+    GRANT SELECT
+      ON public.production_activity_categories
+      TO cerp_app;
+    GRANT SELECT, INSERT
+      ON public.production_quantity_declarations
+      TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE
+      ON public.production_execution_idempotency
+      TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE
+      ON public.of_time_logs
+      TO cerp_app;
+    GRANT SELECT
+      ON public.v_production_active_executions
+      TO cerp_app;
+    GRANT USAGE, SELECT
+      ON SEQUENCE public.production_pointage_events_id_seq
+      TO cerp_app;
+    GRANT EXECUTE
+      ON FUNCTION public.fn_production_operation_real_hours(uuid),
+                  public.fn_production_recompute_operation_real_time(uuid)
+      TO cerp_app;
+  END IF;
+END$$;
 
 COMMIT;

--- a/db/patches/support/20260726_production_execution_274.preflight.sql
+++ b/db/patches/support/20260726_production_execution_274.preflight.sql
@@ -1,0 +1,98 @@
+-- 20260726_production_execution_274.preflight.sql
+-- Issue #274 — À exécuter AVANT le patch. Lecture seule, ne modifie rien.
+--
+-- Objet : vérifier que la base cible porte bien les deux moteurs de temps
+-- historiques, mesurer l'existant, et surtout DÉTECTER les chevauchements
+-- préexistants qui empêcheraient la pose des contraintes d'exclusion.
+
+\echo '=== #274 preflight — base cible ==='
+SELECT current_database() AS database, current_user AS role, now() AS checked_at;
+
+\echo '--- Pré-requis structurels (attendu: toutes les lignes à true) ---'
+SELECT
+  to_regclass('public.production_pointages')       IS NOT NULL AS has_production_pointages,
+  to_regclass('public.production_pointage_events') IS NOT NULL AS has_pointage_events,
+  to_regclass('public.of_operations')              IS NOT NULL AS has_of_operations,
+  to_regclass('public.of_time_logs')               IS NOT NULL AS has_of_time_logs,
+  to_regclass('public.ordres_fabrication')         IS NOT NULL AS has_ofs,
+  EXISTS (SELECT 1 FROM pg_type WHERE typname = 'of_time_log_type')              AS has_of_time_log_type,
+  EXISTS (SELECT 1 FROM pg_type WHERE typname = 'production_pointage_time_type') AS has_pointage_time_type,
+  EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'tg_set_updated_at')             AS has_updated_at_helper;
+
+\echo '--- Extensions requises (pgcrypto, btree_gist) ---'
+SELECT name, installed_version
+FROM pg_available_extensions
+WHERE name IN ('pgcrypto', 'btree_gist');
+
+\echo '--- Volumétrie existante des deux moteurs ---'
+SELECT 'production_pointages' AS moteur, count(*) AS lignes,
+       count(*) FILTER (WHERE status = 'RUNNING') AS en_cours,
+       count(*) FILTER (WHERE validated_at IS NOT NULL) AS valides
+FROM public.production_pointages
+UNION ALL
+SELECT 'of_time_logs', count(*), count(*) FILTER (WHERE ended_at IS NULL), 0
+FROM public.of_time_logs;
+
+\echo '--- Temps déjà comptabilisé (heures) : mesure du sous-comptage actuel ---'
+-- Aujourd''hui, seul of_time_logs alimente of_operations.temps_total_real.
+-- Le temps saisi via production_pointages est invisible du coût et du planning.
+SELECT
+  ROUND(COALESCE(SUM(t.duration_minutes), 0)::numeric / 60.0, 3) AS heures_of_time_logs,
+  (SELECT ROUND(COALESCE(SUM(p.duration_minutes), 0)::numeric / 60.0, 3)
+     FROM public.production_pointages p
+    WHERE p.status = 'DONE' AND p.operation_id IS NOT NULL) AS heures_pointages_rattachees,
+  (SELECT ROUND(COALESCE(SUM(op.temps_total_real), 0), 3)
+     FROM public.of_operations op) AS heures_persistees_of_operations
+FROM public.of_time_logs t;
+
+\echo '--- BLOQUANT POTENTIEL : chevauchements opérateur préexistants ---'
+-- Si ce compte est > 0, la contrainte d''exclusion ne sera PAS posée par le
+-- patch (il émettra un NOTICE et continuera). Une reprise humaine est alors
+-- nécessaire avant de compter sur la garantie base.
+SELECT count(*) AS chevauchements_operateur
+FROM public.production_pointages a
+JOIN public.production_pointages b
+  ON b.id <> a.id
+ AND b.operator_user_id = a.operator_user_id
+ AND b.status IN ('RUNNING', 'DONE')
+ AND tstzrange(b.start_ts, COALESCE(b.end_ts, 'infinity'::timestamptz), '[)')
+     && tstzrange(a.start_ts, COALESCE(a.end_ts, 'infinity'::timestamptz), '[)')
+WHERE a.status IN ('RUNNING', 'DONE');
+
+\echo '--- BLOQUANT POTENTIEL : chevauchements machine préexistants ---'
+SELECT count(*) AS chevauchements_machine
+FROM public.production_pointages a
+JOIN public.production_pointages b
+  ON b.id <> a.id
+ AND b.machine_id = a.machine_id
+ AND b.status IN ('RUNNING', 'DONE')
+ AND tstzrange(b.start_ts, COALESCE(b.end_ts, 'infinity'::timestamptz), '[)')
+     && tstzrange(a.start_ts, COALESCE(a.end_ts, 'infinity'::timestamptz), '[)')
+WHERE a.status IN ('RUNNING', 'DONE') AND a.machine_id IS NOT NULL;
+
+\echo '--- Détail des 20 premiers chevauchements opérateur (pour reprise humaine) ---'
+SELECT a.id AS pointage_a, b.id AS pointage_b, a.operator_user_id,
+       a.start_ts AS a_debut, a.end_ts AS a_fin,
+       b.start_ts AS b_debut, b.end_ts AS b_fin
+FROM public.production_pointages a
+JOIN public.production_pointages b
+  ON b.id > a.id
+ AND b.operator_user_id = a.operator_user_id
+ AND b.status IN ('RUNNING', 'DONE')
+ AND tstzrange(b.start_ts, COALESCE(b.end_ts, 'infinity'::timestamptz), '[)')
+     && tstzrange(a.start_ts, COALESCE(a.end_ts, 'infinity'::timestamptz), '[)')
+WHERE a.status IN ('RUNNING', 'DONE')
+ORDER BY a.start_ts
+LIMIT 20;
+
+\echo '--- Objets #274 déjà présents (rejeu du patch) ---'
+SELECT
+  to_regclass('public.production_activity_categories')     IS NOT NULL AS has_categories,
+  to_regclass('public.production_quantity_declarations')   IS NOT NULL AS has_declarations,
+  to_regclass('public.production_execution_idempotency')   IS NOT NULL AS has_idempotency,
+  to_regclass('public.v_production_active_executions')     IS NOT NULL AS has_active_view,
+  EXISTS (SELECT 1 FROM information_schema.columns
+           WHERE table_schema = 'public' AND table_name = 'of_time_logs'
+             AND column_name = 'pointage_id') AS has_time_log_correlation;
+
+\echo '=== #274 preflight terminé ==='

--- a/db/patches/support/20260726_production_execution_274.recompute-history.sql
+++ b/db/patches/support/20260726_production_execution_274.recompute-history.sql
@@ -1,0 +1,86 @@
+-- 20260726_production_execution_274.recompute-history.sql
+-- Issue #274 — Recalcule la valeur DÉRIVÉE of_operations.temps_total_real.
+--
+-- Ce script ne modifie jamais les journaux sources (`production_pointages`,
+-- `production_pointage_events`, `of_time_logs`). Il remplace uniquement le
+-- total dérivé par la formule canonique, dans une transaction unique.
+--
+-- Usage obligatoire :
+--   psql -v ON_ERROR_STOP=1 -v expected_database=cerp_test \
+--     -f db/patches/support/20260726_production_execution_274.recompute-history.sql
+--
+-- Pour cerp_prod : sauvegarde restaurable, preflight et verify validés avant
+-- l'appel, puis `-v expected_database=cerp_prod`.
+
+\set ON_ERROR_STOP on
+
+\if :{?expected_database}
+\else
+  \echo 'ERREUR: fournir -v expected_database=cerp_test (ou cerp_prod après validation).'
+  \quit
+\endif
+
+SELECT current_database() = :'expected_database' AS production_274_target_ok \gset
+\if :production_274_target_ok
+\else
+  \echo 'ERREUR: la base courante ne correspond pas à expected_database.'
+  \quit
+\endif
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '5min';
+
+DO $$
+BEGIN
+  IF to_regprocedure('public.fn_production_operation_real_hours(uuid)') IS NULL THEN
+    RAISE EXCEPTION '#274 function fn_production_operation_real_hours(uuid) is missing';
+  END IF;
+END$$;
+
+LOCK TABLE public.of_operations IN SHARE ROW EXCLUSIVE MODE;
+
+CREATE TEMP TABLE production_274_recompute_preview
+ON COMMIT DROP
+AS
+SELECT
+  op.id,
+  op.temps_total_real AS previous_hours,
+  public.fn_production_operation_real_hours(op.id) AS target_hours
+FROM public.of_operations op
+WHERE op.temps_total_real IS DISTINCT FROM
+      public.fn_production_operation_real_hours(op.id);
+
+\echo '--- #274 rattrapage historique : aperçu ---'
+SELECT
+  count(*) AS operations_a_recalculer,
+  ROUND(COALESCE(SUM(target_hours - previous_hours), 0), 3) AS ecart_total_heures
+FROM production_274_recompute_preview;
+
+UPDATE public.of_operations op
+SET
+  temps_total_real = preview.target_hours,
+  updated_at = now()
+FROM production_274_recompute_preview preview
+WHERE op.id = preview.id;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.of_operations op
+    WHERE op.temps_total_real IS DISTINCT FROM
+          public.fn_production_operation_real_hours(op.id)
+  ) THEN
+    RAISE EXCEPTION '#274 historical recompute verification failed';
+  END IF;
+END$$;
+
+\echo '--- #274 rattrapage historique : résultat ---'
+SELECT
+  count(*) AS operations_recalculees,
+  ROUND(COALESCE(SUM(target_hours - previous_hours), 0), 3) AS ecart_total_heures_applique
+FROM production_274_recompute_preview;
+
+COMMIT;

--- a/db/patches/support/20260726_production_execution_274.rollback.sql
+++ b/db/patches/support/20260726_production_execution_274.rollback.sql
@@ -49,6 +49,9 @@ DROP FUNCTION IF EXISTS public.fn_production_recompute_operation_real_time(uuid)
 DROP FUNCTION IF EXISTS public.fn_production_operation_real_hours(uuid);
 
 -- Compatibilité of_time_logs (la colonne seulement, jamais les lignes)
+DROP TRIGGER IF EXISTS production_mirror_legacy_time_log
+  ON public.of_time_logs;
+DROP FUNCTION IF EXISTS public.tg_production_mirror_legacy_time_log();
 DROP INDEX IF EXISTS public.of_time_logs_pointage_id_uniq;
 ALTER TABLE public.of_time_logs DROP COLUMN IF EXISTS pointage_id;
 

--- a/db/patches/support/20260726_production_execution_274.rollback.sql
+++ b/db/patches/support/20260726_production_execution_274.rollback.sql
@@ -1,0 +1,97 @@
+-- 20260726_production_execution_274.rollback.sql
+-- Issue #274 — Retour arrière du patch de suivi/pointage de production.
+--
+-- GARDE-FOUS :
+--   * Refuse de s'exécuter ailleurs que sur une base de test.
+--   * Refuse de s'exécuter si des déclarations de quantités existent : ce sont
+--     des données métier réelles, elles ne se suppriment pas par script.
+--   * Ne touche JAMAIS aux données historiques : `production_pointages`,
+--     `production_pointage_events`, `of_time_logs` et `of_operations`
+--     conservent toutes leurs lignes. Seules les colonnes ajoutées par #274
+--     sont retirées.
+--   * `temps_total_real` n'est pas recalculé ni remis à zéro : les valeurs
+--     persistées restent celles produites par le moteur legacy.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_dev', 'postgres') THEN
+    RAISE EXCEPTION
+      '#274 rollback refusé sur la base « % » : réservé aux bases de test.',
+      current_database();
+  END IF;
+
+  IF to_regclass('public.production_quantity_declarations') IS NOT NULL THEN
+    IF EXISTS (SELECT 1 FROM public.production_quantity_declarations) THEN
+      RAISE EXCEPTION
+        '#274 rollback refusé : % déclaration(s) de quantité existent. Décision humaine requise.',
+        (SELECT count(*) FROM public.production_quantity_declarations);
+    END IF;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'production_pointages'
+      AND column_name = 'session_id'
+  ) THEN
+    IF EXISTS (SELECT 1 FROM public.production_pointages WHERE session_id IS NOT NULL) THEN
+      RAISE EXCEPTION
+        '#274 rollback refusé : % pointage(s) utilisent déjà le modèle par segments. Décision humaine requise.',
+        (SELECT count(*) FROM public.production_pointages WHERE session_id IS NOT NULL);
+    END IF;
+  END IF;
+END$$;
+
+-- Read-model et fonctions
+DROP VIEW IF EXISTS public.v_production_active_executions;
+DROP FUNCTION IF EXISTS public.fn_production_recompute_operation_real_time(uuid);
+DROP FUNCTION IF EXISTS public.fn_production_operation_real_hours(uuid);
+
+-- Compatibilité of_time_logs (la colonne seulement, jamais les lignes)
+DROP INDEX IF EXISTS public.of_time_logs_pointage_id_uniq;
+ALTER TABLE public.of_time_logs DROP COLUMN IF EXISTS pointage_id;
+
+-- Idempotence et déclarations (vides, garanti par la garde ci-dessus)
+DROP TABLE IF EXISTS public.production_execution_idempotency;
+DROP TRIGGER IF EXISTS production_quantity_declarations_append_only
+  ON public.production_quantity_declarations;
+DROP FUNCTION IF EXISTS public.tg_production_quantity_declarations_append_only();
+DROP TABLE IF EXISTS public.production_quantity_declarations;
+
+-- Extensions du moteur canonique
+ALTER TABLE public.production_pointages
+  DROP CONSTRAINT IF EXISTS production_pointages_operator_no_overlap,
+  DROP CONSTRAINT IF EXISTS production_pointages_machine_no_overlap,
+  DROP CONSTRAINT IF EXISTS production_pointages_source_chk,
+  DROP CONSTRAINT IF EXISTS production_pointages_rejection_pair_chk,
+  DROP CONSTRAINT IF EXISTS production_pointages_submission_pair_chk,
+  DROP CONSTRAINT IF EXISTS production_pointages_rejection_reason_chk,
+  DROP CONSTRAINT IF EXISTS production_pointages_segment_index_chk;
+
+DROP INDEX IF EXISTS public.production_pointages_idempotency_key_uniq;
+DROP INDEX IF EXISTS public.production_pointages_session_id_idx;
+DROP INDEX IF EXISTS public.production_pointages_activity_code_idx;
+DROP INDEX IF EXISTS public.production_pointages_validated_at_idx;
+
+ALTER TABLE public.production_pointages
+  DROP COLUMN IF EXISTS activity_code,
+  DROP COLUMN IF EXISTS session_id,
+  DROP COLUMN IF EXISTS previous_segment_id,
+  DROP COLUMN IF EXISTS segment_index,
+  DROP COLUMN IF EXISTS source,
+  DROP COLUMN IF EXISTS idempotency_key,
+  DROP COLUMN IF EXISTS correlation_id,
+  DROP COLUMN IF EXISTS context_snapshot,
+  DROP COLUMN IF EXISTS is_retroactive,
+  DROP COLUMN IF EXISTS created_for_other_reason,
+  DROP COLUMN IF EXISTS submitted_at,
+  DROP COLUMN IF EXISTS submitted_by,
+  DROP COLUMN IF EXISTS rejected_at,
+  DROP COLUMN IF EXISTS rejected_by,
+  DROP COLUMN IF EXISTS rejection_reason;
+
+-- Référentiel d'activités (données de référentiel semées par le patch)
+DROP TABLE IF EXISTS public.production_activity_categories;
+
+COMMIT;

--- a/db/patches/support/20260726_production_execution_274.smoke.sql
+++ b/db/patches/support/20260726_production_execution_274.smoke.sql
@@ -1,0 +1,202 @@
+-- 20260726_production_execution_274.smoke.sql
+-- Test transactionnel de l'adaptateur legacy #274.
+--
+-- Crée des fixtures minimales, exerce START / double START / STOP, vérifie la
+-- corrélation et le calcul, puis ROLLBACK : aucune donnée de test ne persiste.
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- Le smoke s'exécute avec le même rôle que l'API. Il valide donc aussi les
+-- privilèges runtime créés par le patch, pas seulement la syntaxe superuser.
+SET LOCAL ROLE cerp_app;
+
+DO $$
+DECLARE
+  v_user_id integer;
+  v_piece_id uuid;
+  v_of_id bigint;
+  v_operation_id uuid;
+  v_time_log_id uuid;
+  v_pointage_id uuid;
+  v_started_at timestamptz;
+  v_ended_at timestamptz;
+  v_legacy_duration integer;
+  v_pointage_duration integer;
+  v_real_hours numeric;
+  v_second_start_refused boolean := false;
+BEGIN
+  SELECT id INTO v_user_id
+  FROM public.users
+  ORDER BY id
+  LIMIT 1;
+
+  SELECT id INTO v_piece_id
+  FROM public.pieces_techniques
+  ORDER BY id
+  LIMIT 1;
+
+  IF v_user_id IS NULL OR v_piece_id IS NULL THEN
+    RAISE EXCEPTION '#274 smoke requires at least one user and one technical piece';
+  END IF;
+
+  INSERT INTO public.ordres_fabrication (
+    numero,
+    piece_technique_id,
+    quantite_lancee,
+    statut,
+    created_by,
+    updated_by
+  )
+  VALUES (
+    'OF-TEST-274-SMOKE',
+    v_piece_id,
+    1,
+    'EN_COURS',
+    v_user_id,
+    v_user_id
+  )
+  RETURNING id INTO v_of_id;
+
+  INSERT INTO public.of_operations (
+    of_id,
+    phase,
+    designation,
+    status
+  )
+  VALUES (
+    v_of_id,
+    10,
+    'Test adaptateur #274',
+    'RUNNING'
+  )
+  RETURNING id INTO v_operation_id;
+
+  v_started_at := date_trunc('minute', clock_timestamp()) - interval '10 minutes';
+  v_ended_at := date_trunc('minute', clock_timestamp());
+
+  INSERT INTO public.of_time_logs (
+    of_operation_id,
+    user_id,
+    started_at,
+    type,
+    comment
+  )
+  VALUES (
+    v_operation_id,
+    v_user_id,
+    v_started_at,
+    'PRODUCTION',
+    '#274 smoke start'
+  )
+  RETURNING id, pointage_id INTO v_time_log_id, v_pointage_id;
+
+  IF v_pointage_id IS NULL THEN
+    RAISE EXCEPTION '#274 smoke: legacy start was not correlated';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.production_pointages
+    WHERE id = v_pointage_id
+      AND operation_id = v_operation_id
+      AND operator_user_id = v_user_id
+      AND status = 'RUNNING'
+      AND source = 'LEGACY_TIME_LOG'
+  ) THEN
+    RAISE EXCEPTION '#274 smoke: canonical RUNNING pointage is missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.production_pointage_events
+    WHERE pointage_id = v_pointage_id
+      AND event_type = 'START'
+  ) THEN
+    RAISE EXCEPTION '#274 smoke: START event is missing';
+  END IF;
+
+  BEGIN
+    INSERT INTO public.of_time_logs (
+      of_operation_id,
+      user_id,
+      started_at,
+      type
+    )
+    VALUES (
+      v_operation_id,
+      v_user_id,
+      v_started_at,
+      'PRODUCTION'
+    );
+  EXCEPTION
+    WHEN unique_violation OR exclusion_violation THEN
+      v_second_start_refused := true;
+  END;
+
+  IF NOT v_second_start_refused THEN
+    RAISE EXCEPTION '#274 smoke: a second active segment was accepted';
+  END IF;
+
+  UPDATE public.of_time_logs
+  SET
+    ended_at = v_ended_at,
+    comment = '#274 smoke stop'
+  WHERE id = v_time_log_id;
+
+  SELECT duration_minutes
+  INTO v_legacy_duration
+  FROM public.of_time_logs
+  WHERE id = v_time_log_id;
+
+  SELECT duration_minutes
+  INTO v_pointage_duration
+  FROM public.production_pointages
+  WHERE id = v_pointage_id
+    AND status = 'DONE';
+
+  IF v_legacy_duration IS DISTINCT FROM 10
+     OR v_pointage_duration IS DISTINCT FROM 10 THEN
+    RAISE EXCEPTION
+      '#274 smoke: duration mismatch (legacy %, canonical %)',
+      v_legacy_duration,
+      v_pointage_duration;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.production_pointage_events
+    WHERE pointage_id = v_pointage_id
+      AND event_type = 'STOP'
+  ) THEN
+    RAISE EXCEPTION '#274 smoke: STOP event is missing';
+  END IF;
+
+  v_real_hours := public.fn_production_operation_real_hours(v_operation_id);
+  IF v_real_hours IS DISTINCT FROM 0.167::numeric THEN
+    RAISE EXCEPTION '#274 smoke: expected 0.167 real hour, got %', v_real_hours;
+  END IF;
+
+  PERFORM public.fn_production_recompute_operation_real_time(v_operation_id);
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.of_operations
+    WHERE id = v_operation_id
+      AND temps_total_real = 0.167::numeric
+  ) THEN
+    RAISE EXCEPTION '#274 smoke: persisted real time is inconsistent';
+  END IF;
+
+  RAISE NOTICE
+    '#274 smoke OK: legacy %, pointage %, duration % minutes, total % hour',
+    v_time_log_id,
+    v_pointage_id,
+    v_pointage_duration,
+    v_real_hours;
+END$$;
+
+ROLLBACK;
+
+\echo '=== #274 smoke terminé — transaction annulée, aucune fixture persistée ==='

--- a/db/patches/support/20260726_production_execution_274.verify.sql
+++ b/db/patches/support/20260726_production_execution_274.verify.sql
@@ -56,18 +56,45 @@ WHERE conrelid = 'public.production_pointages'::regclass
 ORDER BY conname;
 
 \echo '--- PREUVE ANTI-DOUBLE-COMPTAGE : aucune minute comptée deux fois ---'
--- Toute ligne of_time_logs corrélée à un pointage est exclue du résidu legacy.
--- Ce compte DOIT être 0 : sinon une même minute alimenterait les deux sommes.
+-- Compare la fonction autoritaire à une recomposition indépendante :
+-- pointages canoniques DONE + résidu legacy STRICTEMENT non corrélé.
+-- Ce compte DOIT être 0.
+WITH independently_recomputed AS (
+  SELECT
+    op.id,
+    ROUND((
+      COALESCE((
+        SELECT SUM(p.duration_minutes)
+        FROM public.production_pointages p
+        LEFT JOIN public.production_activity_categories c
+          ON c.code = p.activity_code
+        WHERE p.operation_id = op.id
+          AND p.status = 'DONE'
+          AND COALESCE(c.counts_operator_time, true)
+      ), 0)
+      +
+      COALESCE((
+        SELECT SUM(t.duration_minutes)
+        FROM public.of_time_logs t
+        WHERE t.of_operation_id = op.id
+          AND t.duration_minutes IS NOT NULL
+          AND t.pointage_id IS NULL
+      ), 0)
+    )::numeric / 60.0, 3) AS expected_hours
+  FROM public.of_operations op
+)
 SELECT count(*) AS lignes_legacy_comptees_en_double
-FROM public.of_time_logs t
-JOIN public.production_pointages p ON p.id = t.pointage_id
-WHERE t.pointage_id IS NOT NULL
-  AND t.duration_minutes IS NOT NULL
-  AND p.status = 'DONE'
-  AND p.duration_minutes IS NOT NULL
-  -- La fonction exclut déjà ces lignes ; on vérifie que l''exclusion est bien
-  -- la seule sémantique possible (pas de chemin alternatif).
-  AND FALSE;
+FROM independently_recomputed expected
+WHERE public.fn_production_operation_real_hours(expected.id)
+      IS DISTINCT FROM expected.expected_hours;
+
+\echo '--- Miroirs legacy corrélés et explicitement exclus du résidu ---'
+SELECT
+  count(*) FILTER (WHERE pointage_id IS NOT NULL) AS lignes_miroirs_exclues,
+  COALESCE(SUM(duration_minutes) FILTER (WHERE pointage_id IS NOT NULL), 0)
+    AS minutes_miroirs_exclues,
+  count(*) FILTER (WHERE pointage_id IS NULL) AS lignes_legacy_residuelles
+FROM public.of_time_logs;
 
 \echo '--- Cohérence : temps persisté vs source unique recalculée ---'
 -- Les écarts sont NORMAUX tant que le recalcul n''a pas été rejoué sur

--- a/db/patches/support/20260726_production_execution_274.verify.sql
+++ b/db/patches/support/20260726_production_execution_274.verify.sql
@@ -1,0 +1,95 @@
+-- 20260726_production_execution_274.verify.sql
+-- Issue #274 — À exécuter APRÈS le patch. Lecture seule.
+--
+-- Objet : prouver que la structure est en place, que le référentiel est semé,
+-- et surtout que la source unique de temps ne double-compte AUCUNE minute.
+
+\echo '=== #274 verify — base cible ==='
+SELECT current_database() AS database, now() AS checked_at;
+
+\echo '--- Objets créés (attendu: toutes les lignes à true) ---'
+SELECT
+  to_regclass('public.production_activity_categories')   IS NOT NULL AS has_categories,
+  to_regclass('public.production_quantity_declarations') IS NOT NULL AS has_declarations,
+  to_regclass('public.production_execution_idempotency') IS NOT NULL AS has_idempotency,
+  to_regclass('public.v_production_active_executions')   IS NOT NULL AS has_active_view,
+  EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'fn_production_operation_real_hours')          AS has_real_hours_fn,
+  EXISTS (SELECT 1 FROM pg_proc WHERE proname = 'fn_production_recompute_operation_real_time') AS has_recompute_fn,
+  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'production_quantity_declarations_append_only') AS has_append_only_trigger;
+
+\echo '--- Colonnes ajoutées à production_pointages (attendu: 15) ---'
+SELECT count(*) AS colonnes_274
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'production_pointages'
+  AND column_name IN (
+    'activity_code','session_id','previous_segment_id','segment_index','source',
+    'idempotency_key','correlation_id','context_snapshot','is_retroactive',
+    'created_for_other_reason','submitted_at','submitted_by','rejected_at',
+    'rejected_by','rejection_reason'
+  );
+
+\echo '--- Corrélation de compatibilité of_time_logs (attendu: true) ---'
+SELECT EXISTS (
+  SELECT 1 FROM information_schema.columns
+  WHERE table_schema = 'public' AND table_name = 'of_time_logs' AND column_name = 'pointage_id'
+) AS has_pointage_correlation;
+
+\echo '--- Référentiel d''activités semé (attendu: 15 actives) ---'
+SELECT count(*) AS categories_actives
+FROM public.production_activity_categories
+WHERE disabled_at IS NULL;
+
+\echo '--- Matrice de comptabilisation du référentiel ---'
+SELECT code, label, counts_operator_time, counts_machine_time, is_productive,
+       requires_reason, criticality, legacy_time_type, legacy_of_time_log_type
+FROM public.production_activity_categories
+ORDER BY sort_order;
+
+\echo '--- Contraintes d''exclusion anti-chevauchement ---'
+-- Absentes = des chevauchements préexistaient (voir le NOTICE du patch et le
+-- preflight). Ce n''est pas un échec du patch, c''est une reprise humaine due.
+SELECT conname, contype
+FROM pg_constraint
+WHERE conrelid = 'public.production_pointages'::regclass
+  AND conname IN ('production_pointages_operator_no_overlap',
+                  'production_pointages_machine_no_overlap')
+ORDER BY conname;
+
+\echo '--- PREUVE ANTI-DOUBLE-COMPTAGE : aucune minute comptée deux fois ---'
+-- Toute ligne of_time_logs corrélée à un pointage est exclue du résidu legacy.
+-- Ce compte DOIT être 0 : sinon une même minute alimenterait les deux sommes.
+SELECT count(*) AS lignes_legacy_comptees_en_double
+FROM public.of_time_logs t
+JOIN public.production_pointages p ON p.id = t.pointage_id
+WHERE t.pointage_id IS NOT NULL
+  AND t.duration_minutes IS NOT NULL
+  AND p.status = 'DONE'
+  AND p.duration_minutes IS NOT NULL
+  -- La fonction exclut déjà ces lignes ; on vérifie que l''exclusion est bien
+  -- la seule sémantique possible (pas de chemin alternatif).
+  AND FALSE;
+
+\echo '--- Cohérence : temps persisté vs source unique recalculée ---'
+-- Les écarts sont NORMAUX tant que le recalcul n''a pas été rejoué sur
+-- l''historique : le patch ne réécrit AUCUNE donnée métier. Cette requête
+-- mesure l''ampleur du sous-comptage historique sans rien corriger.
+SELECT
+  count(*) AS operations,
+  count(*) FILTER (
+    WHERE ROUND(op.temps_total_real, 3)
+       <> public.fn_production_operation_real_hours(op.id)
+  ) AS operations_en_ecart,
+  ROUND(COALESCE(SUM(
+    public.fn_production_operation_real_hours(op.id) - op.temps_total_real
+  ), 0), 3) AS heures_non_comptees_aujourdhui
+FROM public.of_operations op;
+
+\echo '--- Read-model des exécutions en cours ---'
+SELECT count(*) AS executions_en_cours FROM public.v_production_active_executions;
+
+\echo '--- Inactivité métier du patch (attendu: 0 déclaration, 0 clé) ---'
+SELECT
+  (SELECT count(*) FROM public.production_quantity_declarations) AS declarations_creees,
+  (SELECT count(*) FROM public.production_execution_idempotency) AS cles_idempotence;
+
+\echo '=== #274 verify terminé ==='

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -138,6 +138,34 @@ No `DATABASE_URL` for `cerp_test` was configured in the #225 workspace on
 2026-07-23, so the patch was not applied or registered on any database.
 `cerp_prod` was not modified.
 
+## Issue #274 - Suivi et pointage de production 360
+
+Patch `20260726_production_execution_274.sql` consolidates
+`production_pointages` and `of_time_logs` without deleting or rewriting either
+history. `production_pointages` is canonical; correlated legacy rows carry
+`pointage_id` and are excluded from the residual term of
+`fn_production_operation_real_hours`, so a minute is counted exactly once.
+
+The compatibility adapter is a PostgreSQL trigger on `of_time_logs`. It mirrors
+legacy START/STOP into the canonical pointage inside the same transaction,
+preserving the historical HTTP contract and preventing partial state.
+
+Support files:
+
+- `preflight.sql`: read-only prerequisites, volumes and overlap detection;
+- `verify.sql`: structure, categories, constraints and independent
+  anti-double-counting proof;
+- `smoke.sql`: runs as `cerp_app`, exercises START/double START/STOP and rolls
+  back all fixtures;
+- `recompute-history.sql`: updates only derived `temps_total_real`, guarded by
+  an explicit `expected_database`;
+- `rollback.sql`: test-only and refuses to remove structures carrying evidence.
+
+On 2026-07-26, `cerp_test` was backed up, migrated, verified, replayed and
+smoke-tested successfully. Preflight found no overlaps and no historical gap;
+the recompute changed zero operations. The production application remains a
+separate backup/preflight/verify gate.
+
 ## Issue #228 - Qualite industrielle 360 : plans, controles, liberation, NC, derogations et CAPA
 
 Patch `20260725_qualite_360_228.sql` adds the governance layer the Qualite

--- a/src/__tests__/production-execution-274.domain.test.ts
+++ b/src/__tests__/production-execution-274.domain.test.ts
@@ -1,0 +1,421 @@
+// #274 — Suivi et pointage de production 360.
+// Tests des règles PURES : capacités RBAC, machine d'états, immuabilité,
+// séparation des tâches, temps, quantités, idempotence et frontières
+// inter-modules. Aucune I/O : ces règles doivent tenir seules.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  activityToLegacyTimeLogType,
+  assertActivityUsable,
+  assertExecutionTransition,
+  assertFiniteQuantities,
+  assertIdempotencyMatch,
+  assertMutable,
+  assertOwnershipOrSupervision,
+  assertPlausibleDuration,
+  assertReasonProvided,
+  assertRetroactiveAllowed,
+  assertSeparationOfDuties,
+  assertWithinRemaining,
+  computeDurationMinutes,
+  EXECUTION_EVENT_TYPES,
+  fingerprintPayload,
+  FORBIDDEN_SIDE_EFFECTS,
+  INTERVAL_CONVENTION,
+  LEGACY_TIME_LOG_TO_ACTIVITY,
+  MAX_SEGMENT_MINUTES,
+  PRODUCTION_EXECUTION_CAPABILITIES,
+  RETROACTIVE_WINDOW_DAYS,
+  roleHasProductionExecutionCapability,
+  type ActivityCategory,
+} from "../module/production/domain/production-execution";
+
+const OPERATOR = "Opérateur CN";
+const CHEF = "Chef d'atelier";
+const ADMIN = "Administrateur Systeme et Reseau";
+const COMPTA = "Comptabilité";
+
+function category(overrides: Partial<ActivityCategory> = {}): ActivityCategory {
+  return {
+    code: "PRODUCTION",
+    label: "Production",
+    counts_operator_time: true,
+    counts_machine_time: true,
+    is_productive: true,
+    requires_reason: false,
+    criticality: "NORMAL",
+    signals_planning: false,
+    signals_maintenance: false,
+    signals_quality: false,
+    legacy_time_type: "OPERATEUR",
+    legacy_of_time_log_type: "PRODUCTION",
+    required_capability: null,
+    disabled_at: null,
+    ...overrides,
+  };
+}
+
+describe("#274 capacités RBAC — refus par défaut", () => {
+  it("refuse toute capacité à un rôle vide ou inconnu", () => {
+    for (const capability of PRODUCTION_EXECUTION_CAPABILITIES) {
+      expect(roleHasProductionExecutionCapability(null, capability)).toBe(false);
+      expect(roleHasProductionExecutionCapability("", capability)).toBe(false);
+      expect(roleHasProductionExecutionCapability("Visiteur externe", capability)).toBe(false);
+    }
+  });
+
+  it("autorise l'opérateur à pointer pour lui, pas à valider ni à pointer pour autrui", () => {
+    expect(roleHasProductionExecutionCapability(OPERATOR, "start_self")).toBe(true);
+    expect(roleHasProductionExecutionCapability(OPERATOR, "stop_self")).toBe(true);
+    expect(roleHasProductionExecutionCapability(OPERATOR, "declare_quantity")).toBe(true);
+    expect(roleHasProductionExecutionCapability(OPERATOR, "validate")).toBe(false);
+    expect(roleHasProductionExecutionCapability(OPERATOR, "create_for_other")).toBe(false);
+    expect(roleHasProductionExecutionCapability(OPERATOR, "correct")).toBe(false);
+  });
+
+  it("réserve la validation et la correction à la hiérarchie", () => {
+    expect(roleHasProductionExecutionCapability(CHEF, "validate")).toBe(true);
+    expect(roleHasProductionExecutionCapability(CHEF, "reject")).toBe(true);
+    expect(roleHasProductionExecutionCapability(CHEF, "correct")).toBe(true);
+  });
+
+  it("sépare l'accès aux coûts de l'accès au temps", () => {
+    // Un opérateur voit son temps mais jamais l'argent.
+    expect(roleHasProductionExecutionCapability(OPERATOR, "read")).toBe(true);
+    expect(roleHasProductionExecutionCapability(OPERATOR, "view_costs")).toBe(false);
+    expect(roleHasProductionExecutionCapability(CHEF, "view_costs")).toBe(false);
+    expect(roleHasProductionExecutionCapability(COMPTA, "view_costs")).toBe(true);
+    // Et la compta ne pointe pas.
+    expect(roleHasProductionExecutionCapability(COMPTA, "start_self")).toBe(false);
+  });
+});
+
+describe("#274 anti-IDOR", () => {
+  it("laisse un opérateur agir sur son propre pointage", () => {
+    expect(() =>
+      assertOwnershipOrSupervision({ actorUserId: 7, actorRole: OPERATOR, ownerUserId: 7, action: "arrêt" })
+    ).not.toThrow();
+  });
+
+  it("refuse à un opérateur d'agir sur le pointage d'un tiers", () => {
+    expect(() =>
+      assertOwnershipOrSupervision({ actorUserId: 7, actorRole: OPERATOR, ownerUserId: 9, action: "arrêt" })
+    ).toThrowError(/appartient à un autre opérateur/i);
+  });
+
+  it("autorise le chef d'atelier à superviser le pointage d'un tiers", () => {
+    expect(() =>
+      assertOwnershipOrSupervision({ actorUserId: 1, actorRole: CHEF, ownerUserId: 9, action: "arrêt" })
+    ).not.toThrow();
+  });
+});
+
+describe("#274 machine d'états", () => {
+  it("autorise RUNNING vers DONE et CANCELLED uniquement", () => {
+    expect(() => assertExecutionTransition("RUNNING", "DONE")).not.toThrow();
+    expect(() => assertExecutionTransition("RUNNING", "CANCELLED")).not.toThrow();
+    expect(() => assertExecutionTransition("RUNNING", "CORRECTED")).toThrowError(/interdite/i);
+  });
+
+  it("ferme définitivement CANCELLED et CORRECTED", () => {
+    expect(() => assertExecutionTransition("CANCELLED", "DONE")).toThrowError(/interdite/i);
+    expect(() => assertExecutionTransition("CORRECTED", "DONE")).toThrowError(/interdite/i);
+  });
+});
+
+describe("#274 immuabilité après validation", () => {
+  it("refuse toute modification d'un pointage validé", () => {
+    expect(() =>
+      assertMutable({ id: "p1", status: "DONE", validated_at: "2026-07-26T08:00:00Z" })
+    ).toThrowError(/immuable/i);
+  });
+
+  it("refuse de modifier un pointage annulé ou corrigé", () => {
+    expect(() => assertMutable({ id: "p1", status: "CANCELLED", validated_at: null })).toThrowError(
+      /CANCELLED/
+    );
+    expect(() => assertMutable({ id: "p1", status: "CORRECTED", validated_at: null })).toThrowError(
+      /CORRECTED/
+    );
+  });
+
+  it("laisse passer un pointage arrêté non validé", () => {
+    expect(() => assertMutable({ id: "p1", status: "DONE", validated_at: null })).not.toThrow();
+  });
+});
+
+describe("#274 séparation des tâches", () => {
+  it("interdit à un opérateur de valider son propre pointage", () => {
+    expect(() =>
+      assertSeparationOfDuties({ actorUserId: 7, ownerUserId: 7, actorRole: OPERATOR })
+    ).toThrowError(/propre auteur/i);
+  });
+
+  it("autorise la validation du pointage d'un tiers", () => {
+    expect(() =>
+      assertSeparationOfDuties({ actorUserId: 1, ownerUserId: 7, actorRole: CHEF })
+    ).not.toThrow();
+  });
+
+  it("exempte la direction, qui n'a personne au-dessus d'elle", () => {
+    expect(() =>
+      assertSeparationOfDuties({ actorUserId: 1, ownerUserId: 1, actorRole: ADMIN })
+    ).not.toThrow();
+  });
+});
+
+describe("#274 temps", () => {
+  it("documente la convention d'intervalle [début, fin)", () => {
+    expect(INTERVAL_CONVENTION).toBe("[start, end)");
+  });
+
+  it("ne compte pas deux fois la minute de bascule entre deux segments", () => {
+    // Segment A 08:00 → 09:00, segment B 09:00 → 10:00 : 60 + 60, pas 121.
+    const a = computeDurationMinutes("2026-07-26T08:00:00Z", "2026-07-26T09:00:00Z");
+    const b = computeDurationMinutes("2026-07-26T09:00:00Z", "2026-07-26T10:00:00Z");
+    expect(a + b).toBe(120);
+  });
+
+  it("calcule la durée indépendamment du fuseau d'écriture", () => {
+    // Même instant, deux représentations : la durée ne change pas.
+    expect(computeDurationMinutes("2026-07-26T08:00:00Z", "2026-07-26T12:00:00+02:00")).toBe(120);
+  });
+
+  it("traverse un changement d'heure sans perdre ni inventer de minutes", () => {
+    // 2026-10-25, passage à l'heure d'hiver en Europe/Paris : 03:00 CEST → 02:00 CET.
+    // En UTC l'intervalle reste continu : 2 heures réelles.
+    expect(computeDurationMinutes("2026-10-25T00:00:00Z", "2026-10-25T02:00:00Z")).toBe(120);
+  });
+
+  it("refuse une durée négative", () => {
+    expect(() => computeDurationMinutes("2026-07-26T10:00:00Z", "2026-07-26T09:00:00Z")).toThrowError(
+      /ne peut pas précéder/i
+    );
+  });
+
+  it("refuse un horodatage illisible", () => {
+    expect(() => computeDurationMinutes("pas-une-date", "2026-07-26T09:00:00Z")).toThrowError(
+      /invalides/i
+    );
+  });
+
+  it("refuse un segment aberrant au-delà de 24 h", () => {
+    expect(() => assertPlausibleDuration(MAX_SEGMENT_MINUTES)).not.toThrow();
+    expect(() => assertPlausibleDuration(MAX_SEGMENT_MINUTES + 1)).toThrowError(/dépasser/i);
+  });
+
+  it("borne la saisie rétroactive et refuse le futur", () => {
+    const now = "2026-07-26T12:00:00Z";
+    expect(() => assertRetroactiveAllowed("2026-07-25T12:00:00Z", now)).not.toThrow();
+    expect(() =>
+      assertRetroactiveAllowed(`2026-07-${String(26 - RETROACTIVE_WINDOW_DAYS - 1).padStart(2, "0")}T12:00:00Z`, now)
+    ).toThrowError(/rétroactive/i);
+    expect(() => assertRetroactiveAllowed("2026-07-26T13:00:00Z", now)).toThrowError(/futur/i);
+  });
+});
+
+describe("#274 référentiel d'activités", () => {
+  it("refuse une catégorie inconnue ou désactivée", () => {
+    expect(() => assertActivityUsable(undefined, "INEXISTANT")).toThrowError(/inconnue/i);
+    expect(() =>
+      assertActivityUsable(category({ disabled_at: "2026-01-01T00:00:00Z" }), "PRODUCTION")
+    ).toThrowError(/désactivée/i);
+  });
+
+  it("exige un motif quand la catégorie le demande", () => {
+    const panne = category({ code: "BREAKDOWN", requires_reason: true });
+    expect(() => assertReasonProvided(panne, null)).toThrowError(/motif/i);
+    expect(() => assertReasonProvided(panne, "ab")).toThrowError(/motif/i);
+    expect(() => assertReasonProvided(panne, "Broche bloquée")).not.toThrow();
+  });
+
+  it("n'exige pas de motif pour une catégorie ordinaire", () => {
+    expect(() => assertReasonProvided(category(), null)).not.toThrow();
+  });
+
+  it("mappe les cinq types legacy of_time_logs sans perte", () => {
+    expect(Object.keys(LEGACY_TIME_LOG_TO_ACTIVITY).sort()).toEqual([
+      "CONTROL",
+      "MAINTENANCE",
+      "PRODUCTION",
+      "PROGRAMMING",
+      "SETUP",
+    ]);
+  });
+
+  it("ne fabrique pas de temps legacy pour une activité non comptabilisée", () => {
+    // Un arrêt planifié ne consomme pas de temps opérateur : rien à écrire côté
+    // legacy, sinon on inventerait des heures de travail.
+    const arret = category({
+      code: "PLANNED_STOP",
+      counts_operator_time: false,
+      legacy_of_time_log_type: null,
+    });
+    expect(activityToLegacyTimeLogType(arret)).toBeNull();
+    // Une attente matière qui compte du temps machine mais pas opérateur non plus.
+    const attente = category({
+      code: "WAIT_MATERIAL",
+      counts_operator_time: false,
+      legacy_of_time_log_type: null,
+    });
+    expect(activityToLegacyTimeLogType(attente)).toBeNull();
+    // Une catégorie comptabilisée sans équivalent retombe sur PRODUCTION.
+    const nettoyage = category({ code: "CLEANING", legacy_of_time_log_type: null });
+    expect(activityToLegacyTimeLogType(nettoyage)).toBe("PRODUCTION");
+  });
+});
+
+describe("#274 quantités", () => {
+  it("refuse une valeur non finie ou négative", () => {
+    expect(() =>
+      assertFiniteQuantities({ qty_good: Number.NaN, qty_scrap: 0, qty_rework: 0, qty_pending_control: 0 })
+    ).toThrowError(/invalide/i);
+    expect(() =>
+      assertFiniteQuantities({ qty_good: -1, qty_scrap: 0, qty_rework: 0, qty_pending_control: 0 })
+    ).toThrowError(/positives/i);
+    expect(() =>
+      assertFiniteQuantities({
+        qty_good: Number.POSITIVE_INFINITY,
+        qty_scrap: 0,
+        qty_rework: 0,
+        qty_pending_control: 0,
+      })
+    ).toThrowError(/invalide/i);
+  });
+
+  it("refuse une déclaration vide, qui n'aurait aucun effet", () => {
+    expect(() =>
+      assertFiniteQuantities({ qty_good: 0, qty_scrap: 0, qty_rework: 0, qty_pending_control: 0 })
+    ).toThrowError(/vide/i);
+  });
+
+  it("interdit la surproduction sans tolérance", () => {
+    expect(() =>
+      assertWithinRemaining({
+        declared: 11,
+        alreadyDeclared: 0,
+        quantityTarget: 10,
+        overproductionTolerance: 0,
+        reason: "on en a fait un de plus",
+      })
+    ).toThrowError(/supérieure au restant/i);
+  });
+
+  it("exige un motif quand la surproduction est tolérée", () => {
+    expect(() =>
+      assertWithinRemaining({
+        declared: 11,
+        alreadyDeclared: 0,
+        quantityTarget: 10,
+        overproductionTolerance: 2,
+        reason: null,
+      })
+    ).toThrowError(/motivée/i);
+    expect(() =>
+      assertWithinRemaining({
+        declared: 11,
+        alreadyDeclared: 0,
+        quantityTarget: 10,
+        overproductionTolerance: 2,
+        reason: "Réglage : pièce de mise au point conservée",
+      })
+    ).not.toThrow();
+  });
+
+  it("tient compte de ce qui a déjà été déclaré", () => {
+    expect(() =>
+      assertWithinRemaining({
+        declared: 5,
+        alreadyDeclared: 8,
+        quantityTarget: 10,
+        overproductionTolerance: 0,
+        reason: null,
+      })
+    ).toThrowError(/restant/i);
+    expect(() =>
+      assertWithinRemaining({
+        declared: 2,
+        alreadyDeclared: 8,
+        quantityTarget: 10,
+        overproductionTolerance: 0,
+        reason: null,
+      })
+    ).not.toThrow();
+  });
+});
+
+describe("#274 idempotence", () => {
+  it("produit la même empreinte quel que soit l'ordre des clés", () => {
+    const a = fingerprintPayload("scope", { b: 2, a: 1, nested: { y: 2, x: 1 } });
+    const b = fingerprintPayload("scope", { a: 1, nested: { x: 1, y: 2 }, b: 2 });
+    expect(a).toBe(b);
+    expect(a).toHaveLength(64);
+  });
+
+  it("distingue deux portées différentes", () => {
+    expect(fingerprintPayload("start", { a: 1 })).not.toBe(fingerprintPayload("stop", { a: 1 }));
+  });
+
+  it("ignore les champs indéfinis mais pas les nuls", () => {
+    expect(fingerprintPayload("s", { a: 1, b: undefined })).toBe(fingerprintPayload("s", { a: 1 }));
+    expect(fingerprintPayload("s", { a: 1, b: null })).not.toBe(fingerprintPayload("s", { a: 1 }));
+  });
+
+  it("rejoue à l'identique et refuse une charge utile divergente", () => {
+    const fp = fingerprintPayload("start", { of_id: 1 });
+    expect(() =>
+      assertIdempotencyMatch({ key: "k", storedFingerprint: fp, incomingFingerprint: fp })
+    ).not.toThrow();
+    expect(() =>
+      assertIdempotencyMatch({
+        key: "k",
+        storedFingerprint: fp,
+        incomingFingerprint: fingerprintPayload("start", { of_id: 2 }),
+      })
+    ).toThrowError(/charge utile différente/i);
+  });
+});
+
+describe("#274 frontières inter-modules", () => {
+  it("déclare explicitement les effets de bord interdits", () => {
+    // Ces effets appartiennent à la Qualité, à la Réception de production #223,
+    // au Stock, aux Livraisons, à la Facturation et au module RH #119.
+    expect(FORBIDDEN_SIDE_EFFECTS).toContain("stock_movement");
+    expect(FORBIDDEN_SIDE_EFFECTS).toContain("lot_creation");
+    expect(FORBIDDEN_SIDE_EFFECTS).toContain("delivery_note");
+    expect(FORBIDDEN_SIDE_EFFECTS).toContain("invoice");
+    expect(FORBIDDEN_SIDE_EFFECTS).toContain("hr_attendance");
+    expect(FORBIDDEN_SIDE_EFFECTS).toContain("payroll");
+  });
+
+  it("n'expose aucune capacité de présence ou de paie", () => {
+    // Le pointage de production ne doit jamais devenir un outil RH.
+    const forbidden = ["attendance", "presence", "payroll", "overtime", "geoloc", "biometric"];
+    for (const capability of PRODUCTION_EXECUTION_CAPABILITIES) {
+      expect(forbidden.some((f) => capability.includes(f))).toBe(false);
+    }
+  });
+
+  it("couvre les quatorze événements du journal", () => {
+    expect(EXECUTION_EVENT_TYPES).toHaveLength(14);
+    for (const expected of [
+      "START",
+      "PAUSE",
+      "RESUME",
+      "CHANGE_ACTIVITY",
+      "CHANGE_OPERATOR",
+      "CHANGE_MACHINE",
+      "INCIDENT",
+      "STOP",
+      "DECLARE_QUANTITY",
+      "SUBMIT",
+      "VALIDATE",
+      "REJECT",
+      "CORRECT",
+      "CANCEL",
+    ]) {
+      expect(EXECUTION_EVENT_TYPES).toContain(expected as never);
+    }
+  });
+});

--- a/src/__tests__/production-execution-274.migration-guards.test.ts
+++ b/src/__tests__/production-execution-274.migration-guards.test.ts
@@ -1,0 +1,246 @@
+// #274 — Garde-fous du patch de base de données.
+// Le patch est lu comme du texte : ces tests interdisent qu'une évolution
+// future le rende destructif, non rejouable, ou qu'elle casse la garantie
+// anti-double-comptage.
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PATCH = path.join(process.cwd(), "db", "patches", "20260726_production_execution_274.sql");
+const SUPPORT = path.join(process.cwd(), "db", "patches", "support");
+
+const sql = fs.readFileSync(PATCH, "utf8");
+
+/**
+ * Corps du patch débarrassé des blocs `$$ ... $$` : un UPDATE écrit DANS une
+ * fonction n'est pas exécuté par la migration, il est seulement défini. La
+ * distinction est essentielle — sinon le test interdirait d'écrire la fonction
+ * de recalcul elle-même.
+ */
+const executedStatements = sql.replace(/\$\$[\s\S]*?\$\$/g, " /* body */ ");
+
+describe("#274 patch — additif et non destructif", () => {
+  it("ne supprime aucune table ni colonne existante", () => {
+    // Le patch principal n'a AUCUNE raison de supprimer quoi que ce soit :
+    // tout retour arrière passe par le fichier de rollback dédié.
+    expect(sql).not.toMatch(/\bDROP\s+TABLE\b/i);
+    expect(sql).not.toMatch(/\bDROP\s+COLUMN\b/i);
+    expect(sql).not.toMatch(/\bDROP\s+TYPE\b/i);
+    expect(sql).not.toMatch(/\bTRUNCATE\b/i);
+    expect(sql).not.toMatch(/\bDELETE\s+FROM\b/i);
+  });
+
+  it("ne réécrit aucune donnée métier existante", () => {
+    // Aucun UPDATE EXÉCUTÉ : le patch ne recalcule ni ne corrige l'historique.
+    // La reprise du sous-comptage est une décision humaine, pas un effet de
+    // bord de migration. Les UPDATE définis dans le corps des fonctions sont
+    // exclus : ils ne s'exécutent qu'à l'appel, par le service.
+    expect(executedStatements).not.toMatch(
+      /\bUPDATE\s+public\.(production_pointages|of_time_logs|of_operations|ordres_fabrication)\b/i
+    );
+  });
+
+  it("n'insère que des données de référentiel, jamais de données métier", () => {
+    const inserts = sql.match(/INSERT\s+INTO\s+public\.(\w+)/gi) ?? [];
+    for (const insert of inserts) {
+      expect(insert.toLowerCase()).toContain("production_activity_categories");
+    }
+  });
+
+  it("est transactionnel", () => {
+    // BEGIN doit précéder la première instruction exécutable, et COMMIT clore
+    // le fichier : sinon un échec en cours de route laisserait un état partiel.
+    const begin = sql.indexOf("\nBEGIN;");
+    const firstDdl = sql.search(/\n(CREATE|ALTER|INSERT|DO)\b/);
+    expect(begin).toBeGreaterThan(-1);
+    expect(firstDdl).toBeGreaterThan(begin);
+    expect(sql.trimEnd().endsWith("COMMIT;")).toBe(true);
+  });
+
+  it("est idempotent", () => {
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS/);
+    expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS/);
+    expect(sql).toMatch(/CREATE INDEX IF NOT EXISTS/);
+    expect(sql).toMatch(/ON CONFLICT \(code\) DO NOTHING/);
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION/);
+    // Les contraintes sont posées sous garde d'existence.
+    expect(sql).toMatch(/SELECT 1 FROM pg_constraint WHERE conname/);
+  });
+
+  it("vérifie ses pré-requis avant de modifier quoi que ce soit", () => {
+    for (const table of [
+      "public.production_pointages",
+      "public.production_pointage_events",
+      "public.of_operations",
+      "public.of_time_logs",
+    ]) {
+      expect(sql).toContain(`to_regclass('${table}') IS NULL`);
+    }
+  });
+});
+
+describe("#274 patch — garantie anti-double-comptage", () => {
+  it("crée la colonne de corrélation of_time_logs.pointage_id", () => {
+    expect(sql).toMatch(/ALTER TABLE public\.of_time_logs[\s\S]*ADD COLUMN IF NOT EXISTS pointage_id uuid/);
+  });
+
+  it("exclut du résidu legacy toute ligne déjà comptée côté canonique", () => {
+    // C'est LA ligne qui empêche la double comptabilisation.
+    expect(sql).toMatch(/FROM public\.of_time_logs t[\s\S]*?t\.pointage_id IS NULL/);
+  });
+
+  it("ne compte côté canonique que les segments réellement terminés", () => {
+    // CANCELLED et CORRECTED ne doivent jamais gonfler le temps réel.
+    expect(sql).toMatch(/p\.status IN \('DONE'\)/);
+  });
+
+  it("respecte les catégories qui ne comptabilisent pas le temps opérateur", () => {
+    expect(sql).toMatch(/COALESCE\(c\.counts_operator_time, true\)/);
+  });
+
+  it("expose une fonction de recalcul complet, jamais incrémentale", () => {
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION public\.fn_production_operation_real_hours/);
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION public\.fn_production_recompute_operation_real_time/);
+    // Le recalcul affecte la valeur, il ne l'additionne pas.
+    expect(sql).toMatch(/SET temps_total_real = v_hours/);
+    expect(sql).not.toMatch(/temps_total_real\s*=\s*temps_total_real\s*\+/);
+  });
+
+  it("conserve l'unité historique du temps réel (heures, 3 décimales)", () => {
+    expect(sql).toMatch(/\/ 60\.0,\s*\n?\s*3\s*\n?\s*\)/);
+  });
+});
+
+describe("#274 patch — intégrité des déclarations de quantités", () => {
+  it("rend les déclarations append-only", () => {
+    expect(sql).toMatch(/production_quantity_declarations_append_only/);
+    expect(sql).toMatch(/BEFORE UPDATE OR DELETE ON public\.production_quantity_declarations/);
+    expect(sql).toMatch(/is append-only/);
+  });
+
+  it("exige une cause pour tout rebut et toute reprise", () => {
+    expect(sql).toMatch(/qty_scrap <= 0 OR scrap_reason_code IS NOT NULL/);
+    expect(sql).toMatch(/qty_rework <= 0 OR rework_reason_code IS NOT NULL/);
+  });
+
+  it("n'autorise les valeurs négatives que sur une compensation motivée", () => {
+    expect(sql).toMatch(/compensates_id IS NOT NULL\s*\n?\s*OR \(qty_good >= 0/);
+    expect(sql).toMatch(/compensates_id IS NULL OR compensation_reason IS NOT NULL/);
+  });
+
+  it("interdit de compenser deux fois la même déclaration", () => {
+    expect(sql).toMatch(/production_quantity_declarations_compensates_uniq/);
+  });
+});
+
+describe("#274 patch — concurrence", () => {
+  it("pose des contraintes d'exclusion anti-chevauchement", () => {
+    expect(sql).toMatch(/EXCLUDE USING gist/);
+    expect(sql).toMatch(/production_pointages_operator_no_overlap/);
+    expect(sql).toMatch(/production_pointages_machine_no_overlap/);
+  });
+
+  it("utilise la convention d'intervalle [début, fin)", () => {
+    // Deux segments bout à bout ne se chevauchent pas.
+    expect(sql).toMatch(/tstzrange\(start_ts, COALESCE\(end_ts, 'infinity'::timestamptz\), '\[\)'\)/);
+  });
+
+  it("ne fait jamais échouer le patch sur des chevauchements préexistants", () => {
+    // Sur une base réelle, un chevauchement historique doit produire un avis,
+    // pas une migration bloquée.
+    expect(sql).toMatch(/RAISE NOTICE/);
+    expect(sql).toMatch(/reprise humaine requise/);
+  });
+
+  it("rend la clé d'idempotence unique", () => {
+    expect(sql).toMatch(/production_pointages_idempotency_key_uniq/);
+    expect(sql).toMatch(/production_quantity_declarations_idempotency_key_uniq/);
+  });
+
+  it("ne stocke qu'une empreinte de charge utile, jamais la charge utile", () => {
+    expect(sql).toMatch(/request_fingerprint text NOT NULL/);
+    expect(sql).toMatch(/char_length\(request_fingerprint\) = 64/);
+  });
+});
+
+describe("#274 patch — référentiel d'activités", () => {
+  it("sème les quinze catégories de la matrice", () => {
+    for (const code of [
+      "SETUP",
+      "PRODUCTION",
+      "PROGRAMMING",
+      "CONTROL",
+      "MAINTENANCE",
+      "CLEANING",
+      "TOOL_CHANGE",
+      "WAIT_MATERIAL",
+      "WAIT_QUALITY",
+      "WAIT_PROGRAM",
+      "BREAKDOWN",
+      "PLANNED_STOP",
+      "UNPLANNED_STOP",
+      "REWORK",
+      "OTHER",
+    ]) {
+      expect(sql).toContain(`'${code}'`);
+    }
+  });
+
+  it("conserve la compatibilité avec les DEUX enums historiques", () => {
+    expect(sql).toMatch(/legacy_time_type production_pointage_time_type NULL/);
+    expect(sql).toMatch(/legacy_of_time_log_type public\.of_time_log_type NULL/);
+  });
+
+  it("rend les catégories datées et désactivables plutôt que supprimables", () => {
+    expect(sql).toMatch(/effective_from date NOT NULL/);
+    expect(sql).toMatch(/disabled_at timestamptz NULL/);
+  });
+});
+
+describe("#274 patch — fichiers d'accompagnement", () => {
+  it("fournit preflight, verify et rollback", () => {
+    for (const suffix of ["preflight", "verify", "rollback"]) {
+      const file = path.join(SUPPORT, `20260726_production_execution_274.${suffix}.sql`);
+      expect(fs.existsSync(file), `${suffix} manquant`).toBe(true);
+    }
+  });
+
+  it("le rollback refuse de s'exécuter sur une base de production", () => {
+    const rollback = fs.readFileSync(
+      path.join(SUPPORT, "20260726_production_execution_274.rollback.sql"),
+      "utf8"
+    );
+    expect(rollback).toMatch(/current_database\(\) NOT IN \('cerp_test'/);
+    expect(rollback).toMatch(/rollback refusé/);
+  });
+
+  it("le rollback refuse d'effacer des déclarations réelles", () => {
+    const rollback = fs.readFileSync(
+      path.join(SUPPORT, "20260726_production_execution_274.rollback.sql"),
+      "utf8"
+    );
+    expect(rollback).toMatch(/déclaration\(s\) de quantité existent/);
+    expect(rollback).toMatch(/Décision humaine requise/);
+  });
+
+  it("le preflight détecte les chevauchements bloquants sans rien modifier", () => {
+    const preflight = fs.readFileSync(
+      path.join(SUPPORT, "20260726_production_execution_274.preflight.sql"),
+      "utf8"
+    );
+    expect(preflight).toMatch(/chevauchements_operateur/);
+    expect(preflight).toMatch(/chevauchements_machine/);
+    expect(preflight).not.toMatch(/\b(INSERT|UPDATE|DELETE|ALTER|DROP|CREATE)\b/i);
+  });
+
+  it("le verify prouve l'absence de double comptage", () => {
+    const verify = fs.readFileSync(
+      path.join(SUPPORT, "20260726_production_execution_274.verify.sql"),
+      "utf8"
+    );
+    expect(verify).toMatch(/lignes_legacy_comptees_en_double/);
+    expect(verify).toMatch(/fn_production_operation_real_hours/);
+  });
+});

--- a/src/__tests__/production-execution-274.migration-guards.test.ts
+++ b/src/__tests__/production-execution-274.migration-guards.test.ts
@@ -43,7 +43,7 @@ describe("#274 patch — additif et non destructif", () => {
   });
 
   it("n'insère que des données de référentiel, jamais de données métier", () => {
-    const inserts = sql.match(/INSERT\s+INTO\s+public\.(\w+)/gi) ?? [];
+    const inserts = executedStatements.match(/INSERT\s+INTO\s+public\.(\w+)/gi) ?? [];
     for (const insert of inserts) {
       expect(insert.toLowerCase()).toContain("production_activity_categories");
     }
@@ -89,6 +89,14 @@ describe("#274 patch — garantie anti-double-comptage", () => {
   it("exclut du résidu legacy toute ligne déjà comptée côté canonique", () => {
     // C'est LA ligne qui empêche la double comptabilisation.
     expect(sql).toMatch(/FROM public\.of_time_logs t[\s\S]*?t\.pointage_id IS NULL/);
+  });
+
+  it("miroite les routes legacy dans la même transaction PostgreSQL", () => {
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION public\.tg_production_mirror_legacy_time_log/);
+    expect(sql).toMatch(/CREATE TRIGGER production_mirror_legacy_time_log/);
+    expect(sql).toMatch(/BEFORE INSERT OR UPDATE OF ended_at, comment/);
+    expect(sql).toMatch(/NEW\.pointage_id := v_pointage_id/);
+    expect(sql).toMatch(/'LEGACY_TIME_LOG'/);
   });
 
   it("ne compte côté canonique que les segments réellement terminés", () => {
@@ -200,11 +208,22 @@ describe("#274 patch — référentiel d'activités", () => {
 });
 
 describe("#274 patch — fichiers d'accompagnement", () => {
-  it("fournit preflight, verify et rollback", () => {
-    for (const suffix of ["preflight", "verify", "rollback"]) {
+  it("fournit preflight, verify, smoke, recalcul historique et rollback", () => {
+    for (const suffix of ["preflight", "verify", "smoke", "recompute-history", "rollback"]) {
       const file = path.join(SUPPORT, `20260726_production_execution_274.${suffix}.sql`);
       expect(fs.existsSync(file), `${suffix} manquant`).toBe(true);
     }
+  });
+
+  it("borne le recalcul historique à la base explicitement nommée", () => {
+    const recompute = fs.readFileSync(
+      path.join(SUPPORT, "20260726_production_execution_274.recompute-history.sql"),
+      "utf8"
+    );
+    expect(recompute).toMatch(/expected_database/);
+    expect(recompute).toMatch(/current_database\(\) = :'expected_database'/);
+    expect(recompute).toMatch(/SET\s+temps_total_real = preview\.target_hours/);
+    expect(recompute).not.toMatch(/\b(DELETE|TRUNCATE|DROP TABLE)\b/i);
   });
 
   it("le rollback refuse de s'exécuter sur une base de production", () => {
@@ -242,5 +261,6 @@ describe("#274 patch — fichiers d'accompagnement", () => {
     );
     expect(verify).toMatch(/lignes_legacy_comptees_en_double/);
     expect(verify).toMatch(/fn_production_operation_real_hours/);
+    expect(verify).not.toMatch(/AND FALSE/i);
   });
 });

--- a/src/__tests__/production-execution-274.routes.test.ts
+++ b/src/__tests__/production-execution-274.routes.test.ts
@@ -1,0 +1,849 @@
+// #274 — Suivi et pointage de production 360.
+// Tests d'orchestration HTTP (pg mocké, mêmes conventions que
+// qualite-360-228.routes.test.ts) : refus par défaut, capacités fines,
+// idempotence obligatoire, anti-IDOR, erreurs structurées et absence d'effet
+// de bord stock/lot/BL/facture.
+
+import request from "supertest";
+import { EventEmitter } from "events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = {
+    on: emitter.on.bind(emitter),
+    query: mocks.poolQuery,
+    connect: mocks.poolConnect,
+  };
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; role: string }; headers?: Record<string, string | string[] | undefined> },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void
+  ) => {
+    if (req.headers?.["x-test-anonymous"] === "1") {
+      res.status(401).json({ success: false, code: "UNAUTHORIZED" });
+      return;
+    }
+    const requestedRole = req.headers?.["x-test-role"];
+    const requestedId = req.headers?.["x-test-user-id"];
+    req.user = {
+      id: typeof requestedId === "string" ? Number(requestedId) : 1,
+      role: typeof requestedRole === "string" ? requestedRole : "Administrateur Systeme et Reseau",
+    };
+    next();
+  },
+  authorizeRole:
+    () =>
+    (_req: unknown, _res: unknown, next: () => void) => {
+      next();
+    },
+}));
+
+import app from "../config/app";
+
+const BASE = "/api/v1/production/execution";
+const OP_ID = "11111111-1111-1111-1111-111111111111";
+const POINTAGE_ID = "22222222-2222-2222-2222-222222222222";
+const MACHINE_ID = "33333333-3333-3333-3333-333333333333";
+const KEY = "idem-key-274-000001";
+
+// Rôles en ASCII : un en-tête HTTP ne transporte pas fiablement l'UTF-8, et un
+// rôle accentué arriverait mutilé côté serveur. La correspondance accentuée est
+// couverte par les tests de domaine, qui appellent la règle directement.
+const OPERATOR = "Operateur CN";
+const CHEF = "Chef d'atelier";
+const COMPTA = "Comptabilite";
+const VISITEUR = "Visiteur externe";
+
+const CATEGORY_ROW = {
+  code: "PRODUCTION",
+  label: "Production",
+  description: null,
+  counts_operator_time: true,
+  counts_machine_time: true,
+  is_productive: true,
+  requires_reason: false,
+  criticality: "NORMAL",
+  signals_planning: false,
+  signals_maintenance: false,
+  signals_quality: false,
+  legacy_time_type: "OPERATEUR",
+  legacy_of_time_log_type: "PRODUCTION",
+  required_capability: null,
+  sort_order: 20,
+  effective_from: "2026-07-26",
+  disabled_at: null,
+};
+
+function executionRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: POINTAGE_ID,
+    status: "RUNNING",
+    time_type: "OPERATEUR",
+    activity_code: "PRODUCTION",
+    activity_label: "Production",
+    activity_is_productive: true,
+    activity_criticality: "NORMAL",
+    session_id: POINTAGE_ID,
+    segment_index: 1,
+    source: "CANONICAL",
+    start_ts: "2026-07-26T08:00:00.000Z",
+    end_ts: null,
+    duration_minutes: null,
+    elapsed_minutes: 42,
+    comment: null,
+    correction_reason: null,
+    is_retroactive: false,
+    submitted_at: null,
+    validated_at: null,
+    rejected_at: null,
+    rejection_reason: null,
+    created_at: "2026-07-26T08:00:00.000Z",
+    updated_at: "2026-07-26T08:00:00.000Z",
+    of_id: 10,
+    of_numero: "OF-2026-0010",
+    of_statut: "EN_COURS",
+    operation_id: OP_ID,
+    operation_phase: 10,
+    operation_designation: "Tournage",
+    operation_status: "RUNNING",
+    operation_temps_planned: 2,
+    operation_temps_real: 1.5,
+    affaire_id: null,
+    affaire_reference: null,
+    piece_technique_id: null,
+    piece_code: null,
+    piece_designation: null,
+    machine_id: MACHINE_ID,
+    machine_code: "TOUR-01",
+    machine_name: "Tour CN",
+    poste_id: null,
+    poste_code: null,
+    poste_label: null,
+    operator_user_id: 7,
+    operator_username: "jdupont",
+    operator_name: "Jean",
+    operator_surname: "Dupont",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+  mocks.poolQuery.mockReset();
+  mocks.clientQuery.mockReset();
+});
+
+/* -------------------------------------------------------------------------- */
+/* Authentification et refus par défaut                                       */
+/* -------------------------------------------------------------------------- */
+
+describe("#274 authentification et refus par défaut", () => {
+  it("refuse 401 sans authentification", async () => {
+    const res = await request(app).get(`${BASE}/`).set("x-test-anonymous", "1");
+    expect(res.status).toBe(401);
+  });
+
+  it("refuse 403 la lecture à un rôle sans capacité", async () => {
+    const res = await request(app).get(`${BASE}/`).set("x-test-role", VISITEUR);
+    expect(res.status).toBe(403);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_CAPABILITY_REQUIRED");
+  });
+
+  it("refuse 403 le démarrage à un rôle sans capacité de pointage", async () => {
+    const res = await request(app)
+      .post(`${BASE}/`)
+      .set("x-test-role", COMPTA)
+      .set("Idempotency-Key", KEY)
+      .send({ of_id: 10, activity_code: "PRODUCTION" });
+    expect(res.status).toBe(403);
+  });
+
+  it("refuse 403 la validation à un opérateur", async () => {
+    const res = await request(app)
+      .post(`${BASE}/${POINTAGE_ID}/validate`)
+      .set("x-test-role", OPERATOR)
+      .send({});
+    expect(res.status).toBe(403);
+  });
+
+  it("refuse 403 la correction à un opérateur", async () => {
+    const res = await request(app)
+      .post(`${BASE}/${POINTAGE_ID}/correct`)
+      .set("x-test-role", OPERATOR)
+      .send({ correction_reason: "erreur de saisie", patch: { comment: "x" } });
+    expect(res.status).toBe(403);
+  });
+
+  it("expose au client uniquement les capacités qu'il détient", async () => {
+    const res = await request(app).get(`${BASE}/capabilities`).set("x-test-role", OPERATOR);
+    expect(res.status).toBe(200);
+    expect(res.body.capabilities).toContain("start_self");
+    expect(res.body.capabilities).not.toContain("validate");
+    expect(res.body.capabilities).not.toContain("view_costs");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Idempotence obligatoire                                                    */
+/* -------------------------------------------------------------------------- */
+
+describe("#274 idempotence", () => {
+  it("refuse 400 une commande à effet sans Idempotency-Key", async () => {
+    const res = await request(app)
+      .post(`${BASE}/`)
+      .set("x-test-role", OPERATOR)
+      .send({ of_id: 10, activity_code: "PRODUCTION" });
+    expect(res.status).toBe(400);
+    expect(res.body.code ?? res.body.error?.code).toBe("IDEMPOTENCY_KEY_REQUIRED");
+  });
+
+  it("refuse 400 une clé trop courte", async () => {
+    const res = await request(app)
+      .post(`${BASE}/`)
+      .set("x-test-role", OPERATOR)
+      .set("Idempotency-Key", "court")
+      .send({ of_id: 10, activity_code: "PRODUCTION" });
+    expect(res.status).toBe(400);
+  });
+
+  it("n'exige PAS de clé sur l'aperçu, qui n'écrit rien", async () => {
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.ordres_fabrication o WHERE o.id")) {
+        return {
+          rows: [{ id: 10, numero: "OF-2026-0010", quantite_lancee: 10, quantite_bonne: 0, quantite_rebut: 0 }],
+        };
+      }
+      if (sql.includes("FROM public.of_operations op WHERE op.id")) {
+        return {
+          rows: [
+            { id: OP_ID, phase: 10, designation: "Tournage", status: "RUNNING", temps_total_real: 1.5, of_id: 10 },
+          ],
+        };
+      }
+      if (sql.includes("status = 'RUNNING'")) return { rows: [] };
+      if (sql.includes("production_quantity_declarations")) {
+        return { rows: [{ qty_good: 0, qty_scrap: 0, qty_rework: 0 }] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/operations/finish/preview`)
+      .set("x-test-role", OPERATOR)
+      .send({ of_id: 10, operation_id: OP_ID, qty_good: 3 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.preview_hash).toHaveLength(64);
+    // L'aperçu annonce explicitement ce qu'il ne fera PAS.
+    expect(res.body.warnings.join(" ")).toMatch(/aucune entrée en stock/i);
+  });
+
+  it("rejoue une commande déjà exécutée sans créer de second effet", async () => {
+    let insertCount = 0;
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_execution_idempotency")) {
+        // Clé déjà connue avec la MÊME empreinte : rejeu.
+        return {
+          rows: [
+            {
+              request_fingerprint: require("node:crypto")
+                .createHash("sha256")
+                .update(
+                  `production.execution.start ${JSON.stringify({
+                    activity_code: "PRODUCTION",
+                    of_id: 10,
+                    operator_user_id: 7,
+                  })
+                    .replace(/"of_id":10/, '"of_id":10')}`
+                )
+                .digest("hex"),
+              response_body: { id: POINTAGE_ID },
+            },
+          ],
+        };
+      }
+      if (sql.includes("INSERT INTO public.production_pointages")) {
+        insertCount += 1;
+        return { rows: [{ id: POINTAGE_ID }] };
+      }
+      return { rows: [] };
+    });
+    mocks.poolQuery.mockResolvedValue({ rows: [] });
+
+    // L'empreinte exacte dépend de la sérialisation stable ; on vérifie au
+    // minimum qu'aucune insertion n'a lieu quand le rejeu est détecté OU que la
+    // divergence est signalée en 409. Les deux issues sont correctes, un second
+    // INSERT ne l'est jamais.
+    const res = await request(app)
+      .post(`${BASE}/`)
+      .set("x-test-role", OPERATOR)
+      .set("x-test-user-id", "7")
+      .set("Idempotency-Key", KEY)
+      .send({ of_id: 10, activity_code: "PRODUCTION" });
+
+    expect([200, 201, 409]).toContain(res.status);
+    expect(insertCount).toBe(0);
+  });
+
+  it("refuse 409 la même clé avec une charge utile différente", async () => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_execution_idempotency")) {
+        return {
+          rows: [{ request_fingerprint: "a".repeat(64), response_body: { id: POINTAGE_ID } }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/`)
+      .set("x-test-role", OPERATOR)
+      .set("Idempotency-Key", KEY)
+      .send({ of_id: 999, activity_code: "PRODUCTION" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_IDEMPOTENCY_CONFLICT");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Validation Zod et erreurs structurées                                      */
+/* -------------------------------------------------------------------------- */
+
+describe("#274 validation", () => {
+  it("refuse 400 un code d'activité mal formé", async () => {
+    const res = await request(app)
+      .post(`${BASE}/`)
+      .set("x-test-role", OPERATOR)
+      .set("Idempotency-Key", KEY)
+      .send({ of_id: 10, activity_code: "production minuscule" });
+    expect(res.status).toBe(400);
+  });
+
+  it("refuse 400 un identifiant de pointage non UUID", async () => {
+    const res = await request(app)
+      .post(`${BASE}/pas-un-uuid/stop`)
+      .set("x-test-role", OPERATOR)
+      .set("Idempotency-Key", KEY)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("refuse 400 un rejet sans motif", async () => {
+    const res = await request(app).post(`${BASE}/${POINTAGE_ID}/reject`).set("x-test-role", CHEF).send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("refuse 400 un changement qui ne change rien", async () => {
+    const res = await request(app)
+      .post(`${BASE}/${POINTAGE_ID}/change`)
+      .set("x-test-role", OPERATOR)
+      .set("Idempotency-Key", KEY)
+      .send({ comment: "rien" });
+    expect(res.status).toBe(400);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Anti-IDOR                                                                  */
+/* -------------------------------------------------------------------------- */
+
+describe("#274 anti-IDOR", () => {
+  it("refuse 403 la lecture du pointage d'un tiers à un opérateur", async () => {
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_pointages p")) return { rows: [executionRow()] };
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .get(`${BASE}/${POINTAGE_ID}`)
+      .set("x-test-role", OPERATOR)
+      .set("x-test-user-id", "99"); // ≠ operator_user_id 7
+
+    expect(res.status).toBe(403);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_FOREIGN_POINTAGE");
+  });
+
+  it("laisse l'opérateur lire son propre pointage", async () => {
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_pointages p")) return { rows: [executionRow()] };
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .get(`${BASE}/${POINTAGE_ID}`)
+      .set("x-test-role", OPERATOR)
+      .set("x-test-user-id", "7");
+
+    expect(res.status).toBe(200);
+    expect(res.body.operator.id).toBe(7);
+  });
+
+  it("laisse le chef d'atelier lire le pointage d'un tiers", async () => {
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_pointages p")) return { rows: [executionRow()] };
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .get(`${BASE}/${POINTAGE_ID}`)
+      .set("x-test-role", CHEF)
+      .set("x-test-user-id", "1");
+
+    expect(res.status).toBe(200);
+  });
+
+  it("refuse 404 un pointage inexistant", async () => {
+    mocks.poolQuery.mockResolvedValue({ rows: [] });
+    const res = await request(app).get(`${BASE}/${POINTAGE_ID}`).set("x-test-role", CHEF);
+    expect(res.status).toBe(404);
+  });
+
+  it("refuse 403 la consultation du poste d'un autre opérateur", async () => {
+    const res = await request(app)
+      .get(`${BASE}/operator-board?operator_user_id=42`)
+      .set("x-test-role", OPERATOR)
+      .set("x-test-user-id", "7");
+    expect(res.status).toBe(403);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Référentiel et indicateurs                                                 */
+/* -------------------------------------------------------------------------- */
+
+describe("#274 référentiel et indicateurs", () => {
+  it("liste les catégories d'activité actives", async () => {
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes("production_activity_categories")) return { rows: [CATEGORY_ROW] };
+      return { rows: [] };
+    });
+
+    const res = await request(app).get(`${BASE}/activity-categories`).set("x-test-role", OPERATOR);
+    expect(res.status).toBe(200);
+    expect(res.body[0].code).toBe("PRODUCTION");
+    expect(res.body[0].counts_operator_time).toBe(true);
+  });
+
+  it("déclare les coûts et le TRS non calculables plutôt que d'afficher zéro", async () => {
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.of_operations op")) {
+        return {
+          rows: [{ operations: 5, with_planned: 3, planned_hours: 10, real_hours: 12, with_rate: 0 }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app).get(`${BASE}/indicators`).set("x-test-role", CHEF);
+    expect(res.status).toBe(200);
+    expect(res.body.cost.computable).toBe(false);
+    expect(res.body.cost.value).toBeNull();
+    expect(res.body.cost.missing.length).toBeGreaterThan(0);
+    expect(res.body.oee.computable).toBe(false);
+    expect(res.body.oee.value).toBeNull();
+    expect(res.body.oee.missing).toContain("cadence nominale versionnée par opération");
+    // L'écart de temps, lui, est démontrable : il est calculé.
+    expect(res.body.time.computable).toBe(true);
+    expect(res.body.time.variance_hours).toBe(2);
+  });
+
+  it("masque les coûts à un rôle sans capacité 'view_costs'", async () => {
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.of_operations op")) {
+        return {
+          rows: [{ operations: 1, with_planned: 1, planned_hours: 1, real_hours: 1, with_rate: 5 }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app).get(`${BASE}/indicators`).set("x-test-role", OPERATOR);
+    expect(res.status).toBe(200);
+    expect(res.body.cost.computable).toBe(false);
+    expect(res.body.cost.missing).toContain("capacité 'view_costs' requise");
+  });
+
+  it("calcule les KPI du command center côté serveur", async () => {
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes("WITH scoped AS")) {
+        return {
+          rows: [
+            {
+              running: 3,
+              long_running: 1,
+              to_validate: 4,
+              rejected: 0,
+              incidents: 2,
+              total_minutes: 480,
+              productive_minutes: 300,
+            },
+          ],
+        };
+      }
+      if (sql.includes("GROUP BY 1, 2")) {
+        return { rows: [{ activity_code: "PRODUCTION", label: "Production", minutes: 300, segments: 5 }] };
+      }
+      if (sql.includes("production_quantity_declarations")) {
+        return { rows: [{ qty_good: 12, qty_scrap: 1, qty_rework: 0, qty_pending_control: 3 }] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app).get(`${BASE}/center`).set("x-test-role", CHEF);
+    expect(res.status).toBe(200);
+    expect(res.body.kpis.running).toBe(3);
+    expect(res.body.kpis.long_running).toBe(1);
+    expect(res.body.quantities.qty_scrap).toBe(1);
+    expect(res.body.by_activity[0].minutes).toBe(300);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Fin d'opération : atomicité et frontières                                  */
+/* -------------------------------------------------------------------------- */
+
+describe("#274 fin d'opération", () => {
+  function mockPreviewQueries(target: typeof mocks.poolQuery | typeof mocks.clientQuery) {
+    target.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_execution_idempotency")) return { rows: [] };
+      // Verrous posés par la commande atomique avant de recalculer l'aperçu.
+      if (sql.includes("FROM public.ordres_fabrication") && sql.includes("FOR UPDATE")) {
+        return { rows: [{ id: "10", statut: "EN_COURS" }] };
+      }
+      if (sql.includes("FROM public.of_operations") && sql.includes("FOR UPDATE")) {
+        return { rows: [{ id: OP_ID, status: "RUNNING", phase: 10, of_id: "10" }] };
+      }
+      if (sql.includes("FROM public.ordres_fabrication o WHERE o.id")) {
+        return {
+          rows: [{ id: 10, numero: "OF-2026-0010", quantite_lancee: 10, quantite_bonne: 0, quantite_rebut: 0 }],
+        };
+      }
+      if (sql.includes("FROM public.of_operations op WHERE op.id")) {
+        return {
+          rows: [
+            { id: OP_ID, phase: 10, designation: "Tournage", status: "RUNNING", temps_total_real: 1.5, of_id: 10 },
+          ],
+        };
+      }
+      if (sql.includes("FROM public.production_quantity_declarations")) {
+        return { rows: [{ qty_good: 0, qty_scrap: 0, qty_rework: 0 }] };
+      }
+      if (sql.includes("FROM public.production_pointages") && sql.includes("status = 'RUNNING'")) {
+        return { rows: [] };
+      }
+      return { rows: [] };
+    });
+  }
+
+  it("refuse 409 une confirmation dont l'aperçu est périmé", async () => {
+    mockPreviewQueries(mocks.clientQuery);
+
+    const res = await request(app)
+      .post(`${BASE}/operations/finish`)
+      .set("x-test-role", OPERATOR)
+      .set("Idempotency-Key", KEY)
+      .send({
+        of_id: 10,
+        operation_id: OP_ID,
+        qty_good: 3,
+        preview_hash: "0".repeat(64), // empreinte volontairement fausse
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_PREVIEW_STALE");
+  });
+
+  it("annonce dans l'aperçu qu'aucune entrée en stock n'est créée", async () => {
+    mockPreviewQueries(mocks.poolQuery);
+
+    const res = await request(app)
+      .post(`${BASE}/operations/finish/preview`)
+      .set("x-test-role", OPERATOR)
+      .send({ of_id: 10, operation_id: OP_ID, qty_good: 2, qty_scrap: 1 });
+
+    expect(res.status).toBe(200);
+    expect(res.body.requires_quality_decision).toBe(true);
+    const warnings = res.body.warnings.join(" ");
+    expect(warnings).toMatch(/aucune entrée en stock/i);
+    expect(warnings).toMatch(/non-conformité n'est créée automatiquement/i);
+  });
+
+  it("refuse 422 une opération qui n'appartient pas à l'OF indiqué", async () => {
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.ordres_fabrication o WHERE o.id")) {
+        return {
+          rows: [{ id: 10, numero: "OF-2026-0010", quantite_lancee: 10, quantite_bonne: 0, quantite_rebut: 0 }],
+        };
+      }
+      if (sql.includes("FROM public.of_operations op WHERE op.id")) {
+        // Opération rattachée à un AUTRE OF.
+        return {
+          rows: [
+            { id: OP_ID, phase: 10, designation: "Tournage", status: "RUNNING", temps_total_real: 0, of_id: 99 },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/operations/finish/preview`)
+      .set("x-test-role", OPERATOR)
+      .send({ of_id: 10, operation_id: OP_ID, qty_good: 1 });
+
+    expect(res.status).toBe(422);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_OPERATION_MISMATCH");
+  });
+
+  it("refuse 404 un OF inexistant", async () => {
+    mocks.poolQuery.mockResolvedValue({ rows: [] });
+    const res = await request(app)
+      .post(`${BASE}/operations/finish/preview`)
+      .set("x-test-role", OPERATOR)
+      .send({ of_id: 12345, operation_id: OP_ID, qty_good: 1 });
+    expect(res.status).toBe(404);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Concurrence traduite en erreurs métier                                     */
+/* -------------------------------------------------------------------------- */
+
+describe("#274 concurrence", () => {
+  it("traduit un opérateur déjà occupé en 409 lisible", async () => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_execution_idempotency")) return { rows: [] };
+      if (sql.includes("FROM public.ordres_fabrication") && sql.includes("FOR UPDATE")) {
+        return { rows: [{ id: "10", statut: "EN_COURS" }] };
+      }
+      if (sql.includes("production_activity_categories")) return { rows: [CATEGORY_ROW] };
+      if (sql.includes("INSERT INTO public.production_pointages")) {
+        const err = new Error("duplicate key") as Error & { code: string; constraint: string };
+        err.code = "23505";
+        err.constraint = "production_pointages_running_operator_uniq";
+        throw err;
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/`)
+      .set("x-test-role", OPERATOR)
+      .set("Idempotency-Key", KEY)
+      .send({ of_id: 10, activity_code: "PRODUCTION" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_OPERATOR_BUSY");
+  });
+
+  it("traduit une machine déjà occupée en 409 lisible", async () => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_execution_idempotency")) return { rows: [] };
+      if (sql.includes("FROM public.ordres_fabrication") && sql.includes("FOR UPDATE")) {
+        return { rows: [{ id: "10", statut: "EN_COURS" }] };
+      }
+      if (sql.includes("FROM public.machines WHERE id")) return { rows: [{ statut: "DISPONIBLE" }] };
+      if (sql.includes("production_activity_categories")) return { rows: [CATEGORY_ROW] };
+      if (sql.includes("INSERT INTO public.production_pointages")) {
+        const err = new Error("duplicate key") as Error & { code: string; constraint: string };
+        err.code = "23505";
+        err.constraint = "production_pointages_running_machine_uniq";
+        throw err;
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/`)
+      .set("x-test-role", OPERATOR)
+      .set("Idempotency-Key", KEY)
+      .send({ of_id: 10, activity_code: "PRODUCTION", machine_id: MACHINE_ID });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_MACHINE_BUSY");
+  });
+
+  it("traduit un chevauchement d'intervalle en 409 lisible", async () => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_execution_idempotency")) return { rows: [] };
+      if (sql.includes("FROM public.ordres_fabrication") && sql.includes("FOR UPDATE")) {
+        return { rows: [{ id: "10", statut: "EN_COURS" }] };
+      }
+      if (sql.includes("production_activity_categories")) return { rows: [CATEGORY_ROW] };
+      if (sql.includes("INSERT INTO public.production_pointages")) {
+        const err = new Error("conflicting key value violates exclusion constraint") as Error & { code: string };
+        err.code = "23P01";
+        throw err;
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/`)
+      .set("x-test-role", OPERATOR)
+      .set("Idempotency-Key", KEY)
+      .send({
+        of_id: 10,
+        activity_code: "PRODUCTION",
+        // Une heure dans le passé, calculée à l'exécution : un horodatage figé
+        // basculerait dans le futur selon l'heure à laquelle le test tourne.
+        start_ts: new Date(Date.now() - 3_600_000).toISOString(),
+        retroactive_reason: "oubli de pointage ce matin",
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_OVERLAP");
+  });
+
+  it("refuse 409 le démarrage sur une machine en maintenance bloquante", async () => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_execution_idempotency")) return { rows: [] };
+      if (sql.includes("FROM public.ordres_fabrication") && sql.includes("FOR UPDATE")) {
+        return { rows: [{ id: "10", statut: "EN_COURS" }] };
+      }
+      if (sql.includes("FROM public.machines WHERE id")) return { rows: [{ statut: "MAINTENANCE" }] };
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/`)
+      .set("x-test-role", OPERATOR)
+      .set("Idempotency-Key", KEY)
+      .send({ of_id: 10, activity_code: "PRODUCTION", machine_id: MACHINE_ID });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_MACHINE_UNAVAILABLE");
+  });
+
+  it("refuse 422 le pointage sur un OF clos", async () => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_execution_idempotency")) return { rows: [] };
+      if (sql.includes("FROM public.ordres_fabrication") && sql.includes("FOR UPDATE")) {
+        return { rows: [{ id: "10", statut: "CLOTURE" }] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`${BASE}/`)
+      .set("x-test-role", OPERATOR)
+      .set("Idempotency-Key", KEY)
+      .send({ of_id: 10, activity_code: "PRODUCTION" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_OF_NOT_EXECUTABLE");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Cycle de validation                                                        */
+/* -------------------------------------------------------------------------- */
+
+describe("#274 cycle de validation", () => {
+  function mockLockedPointage(overrides: Record<string, unknown> = {}) {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_pointages") && sql.includes("FOR UPDATE")) {
+        return {
+          rows: [
+            {
+              id: POINTAGE_ID,
+              of_id: 10,
+              operation_id: OP_ID,
+              machine_id: null,
+              poste_id: null,
+              operator_user_id: 7,
+              activity_code: "PRODUCTION",
+              time_type: "OPERATEUR",
+              status: "DONE",
+              start_ts: "2026-07-26T08:00:00.000Z",
+              end_ts: "2026-07-26T09:00:00.000Z",
+              session_id: POINTAGE_ID,
+              segment_index: 1,
+              validated_at: null,
+              submitted_at: null,
+              ...overrides,
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+    mocks.poolQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_pointages p")) {
+        return { rows: [executionRow({ status: "DONE", validated_at: "2026-07-26T10:00:00.000Z" })] };
+      }
+      return { rows: [] };
+    });
+  }
+
+  it("refuse 409 la validation de son propre pointage", async () => {
+    mockLockedPointage({ operator_user_id: 5 });
+    const res = await request(app)
+      .post(`${BASE}/${POINTAGE_ID}/validate`)
+      .set("x-test-role", CHEF)
+      .set("x-test-user-id", "5")
+      .send({});
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe(
+      "PRODUCTION_EXECUTION_SELF_VALIDATION_FORBIDDEN"
+    );
+  });
+
+  it("refuse 409 toute action sur un pointage déjà validé", async () => {
+    mockLockedPointage({ validated_at: "2026-07-26T10:00:00.000Z" });
+    const res = await request(app)
+      .post(`${BASE}/${POINTAGE_ID}/cancel`)
+      .set("x-test-role", CHEF)
+      .send({ reason: "erreur de saisie" });
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_VALIDATED_IMMUTABLE");
+  });
+
+  it("refuse 409 la correction d'un pointage encore en cours", async () => {
+    mockLockedPointage({ status: "RUNNING", end_ts: null });
+    const res = await request(app)
+      .post(`${BASE}/${POINTAGE_ID}/correct`)
+      .set("x-test-role", CHEF)
+      .send({ correction_reason: "mauvaise machine", patch: { comment: "corrigé" } });
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe(
+      "PRODUCTION_EXECUTION_RUNNING_NOT_CORRECTABLE"
+    );
+  });
+
+  it("refuse 409 la soumission d'un pointage non arrêté", async () => {
+    mockLockedPointage({ status: "RUNNING", end_ts: null });
+    const res = await request(app)
+      .post(`${BASE}/${POINTAGE_ID}/submit`)
+      .set("x-test-role", OPERATOR)
+      .set("x-test-user-id", "7")
+      .send({});
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_NOT_STOPPED");
+  });
+});

--- a/src/module/production/controllers/production-execution.controller.ts
+++ b/src/module/production/controllers/production-execution.controller.ts
@@ -1,0 +1,298 @@
+import type { Request } from "express";
+
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { HttpError } from "../../../utils/httpError";
+import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+
+import type { AuditContext } from "../repository/production.repository";
+import {
+  cancelExecutionSchema,
+  changeExecutionSchema,
+  correctExecutionSchema,
+  declareQuantitySchema,
+  executionCenterQuerySchema,
+  executionIdParamSchema,
+  finishOperationPreviewSchema,
+  finishOperationSchema,
+  incidentExecutionSchema,
+  listActivityCategoriesQuerySchema,
+  listExecutionsQuerySchema,
+  operatorBoardQuerySchema,
+  pauseExecutionSchema,
+  rejectExecutionSchema,
+  resumeExecutionSchema,
+  startExecutionSchema,
+  stopExecutionSchema,
+  submitExecutionSchema,
+  validateExecutionSchema,
+} from "../validators/production-execution.validators";
+import {
+  svcCancelExecution,
+  svcCapabilities,
+  svcChangeExecution,
+  svcCorrectExecution,
+  svcDeclareIncident,
+  svcDeclareQuantity,
+  svcExecutionCenter,
+  svcExecutionIndicators,
+  svcFinishOperation,
+  svcGetExecution,
+  svcListActivityCategories,
+  svcListExecutions,
+  svcOperatorBoard,
+  svcPauseExecution,
+  svcPreviewFinishOperation,
+  svcRejectExecution,
+  svcResumeExecution,
+  svcStartExecution,
+  svcStopExecution,
+  svcSubmitExecution,
+  svcValidateExecution,
+  type Actor,
+} from "../services/production-execution.service";
+
+function requireActor(req: Request): Actor {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  return { id: user.id, role: user.role ?? null };
+}
+
+function buildAuditContext(req: Request): AuditContext {
+  const actor = requireActor(req);
+  const userAgent = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null;
+  const device = parseDevice(userAgent);
+  const pageKey = typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null;
+  const clientSessionId =
+    typeof req.headers["x-client-session-id"] === "string"
+      ? req.headers["x-client-session-id"]
+      : typeof req.headers["x-session-id"] === "string"
+        ? req.headers["x-session-id"]
+        : null;
+
+  return {
+    user_id: actor.id,
+    user_role: actor.role,
+    ip: getClientIp(req),
+    user_agent: userAgent,
+    device_type: device.device_type,
+    os: device.os,
+    browser: device.browser,
+    path: req.originalUrl ?? null,
+    page_key: pageKey,
+    client_session_id: clientSessionId,
+  };
+}
+
+/** La garde `requireIdempotencyKey` a déjà validé la présence et la forme. */
+function idempotencyKey(req: Request): string {
+  return String(req.headers["idempotency-key"]).trim();
+}
+
+function executionId(req: Request): string {
+  return executionIdParamSchema.parse({ params: req.params }).params.id;
+}
+
+/* ------------------------------- Lecture --------------------------------- */
+
+export const listActivityCategories = asyncHandler(async (req, res) => {
+  const query = listActivityCategoriesQuerySchema.parse(req.query);
+  res.json(await svcListActivityCategories(query));
+});
+
+export const capabilities = asyncHandler(async (req, res) => {
+  res.json(await svcCapabilities(requireActor(req)));
+});
+
+export const listExecutions = asyncHandler(async (req, res) => {
+  const query = listExecutionsQuerySchema.parse(req.query);
+  res.json(await svcListExecutions(requireActor(req), query));
+});
+
+export const getExecution = asyncHandler(async (req, res) => {
+  res.json(await svcGetExecution(requireActor(req), executionId(req)));
+});
+
+export const executionCenter = asyncHandler(async (req, res) => {
+  const query = executionCenterQuerySchema.parse(req.query);
+  res.json(await svcExecutionCenter(requireActor(req), query));
+});
+
+export const executionIndicators = asyncHandler(async (req, res) => {
+  const query = executionCenterQuerySchema.parse(req.query);
+  res.json(await svcExecutionIndicators(requireActor(req), query));
+});
+
+export const operatorBoard = asyncHandler(async (req, res) => {
+  const query = operatorBoardQuerySchema.parse(req.query);
+  res.json(await svcOperatorBoard(requireActor(req), query));
+});
+
+/* ------------------------------ Commandes -------------------------------- */
+
+export const startExecution = asyncHandler(async (req, res) => {
+  const { body } = startExecutionSchema.parse({ body: req.body });
+  const created = await svcStartExecution({
+    actor: requireActor(req),
+    body,
+    idempotencyKey: idempotencyKey(req),
+    audit: buildAuditContext(req),
+  });
+  res.status(201).json(created);
+});
+
+export const stopExecution = asyncHandler(async (req, res) => {
+  const { body } = stopExecutionSchema.parse({ body: req.body });
+  res.json(
+    await svcStopExecution({
+      actor: requireActor(req),
+      id: executionId(req),
+      body,
+      idempotencyKey: idempotencyKey(req),
+      audit: buildAuditContext(req),
+    })
+  );
+});
+
+export const pauseExecution = asyncHandler(async (req, res) => {
+  const { body } = pauseExecutionSchema.parse({ body: req.body ?? {} });
+  res.json(
+    await svcPauseExecution({
+      actor: requireActor(req),
+      id: executionId(req),
+      body,
+      idempotencyKey: idempotencyKey(req),
+      audit: buildAuditContext(req),
+    })
+  );
+});
+
+export const resumeExecution = asyncHandler(async (req, res) => {
+  const { body } = resumeExecutionSchema.parse({ body: req.body ?? {} });
+  res.json(
+    await svcResumeExecution({
+      actor: requireActor(req),
+      id: executionId(req),
+      body,
+      idempotencyKey: idempotencyKey(req),
+      audit: buildAuditContext(req),
+    })
+  );
+});
+
+export const changeExecution = asyncHandler(async (req, res) => {
+  const { body } = changeExecutionSchema.parse({ body: req.body });
+  res.json(
+    await svcChangeExecution({
+      actor: requireActor(req),
+      id: executionId(req),
+      body,
+      idempotencyKey: idempotencyKey(req),
+      audit: buildAuditContext(req),
+    })
+  );
+});
+
+export const declareIncident = asyncHandler(async (req, res) => {
+  const { body } = incidentExecutionSchema.parse({ body: req.body });
+  res.json(
+    await svcDeclareIncident({
+      actor: requireActor(req),
+      id: executionId(req),
+      body,
+      idempotencyKey: idempotencyKey(req),
+      audit: buildAuditContext(req),
+    })
+  );
+});
+
+export const declareQuantity = asyncHandler(async (req, res) => {
+  const { body } = declareQuantitySchema.parse({ body: req.body });
+  const created = await svcDeclareQuantity({
+    actor: requireActor(req),
+    body,
+    idempotencyKey: idempotencyKey(req),
+    audit: buildAuditContext(req),
+  });
+  res.status(201).json(created);
+});
+
+export const previewFinishOperation = asyncHandler(async (req, res) => {
+  const { body } = finishOperationPreviewSchema.parse({ body: req.body });
+  res.json(await svcPreviewFinishOperation({ actor: requireActor(req), body }));
+});
+
+export const finishOperation = asyncHandler(async (req, res) => {
+  const { body } = finishOperationSchema.parse({ body: req.body });
+  res.json(
+    await svcFinishOperation({
+      actor: requireActor(req),
+      body,
+      idempotencyKey: idempotencyKey(req),
+      audit: buildAuditContext(req),
+    })
+  );
+});
+
+/* ------------------------- Cycle de validation --------------------------- */
+
+export const submitExecution = asyncHandler(async (req, res) => {
+  const { body } = submitExecutionSchema.parse({ body: req.body ?? {} });
+  res.json(
+    await svcSubmitExecution({
+      actor: requireActor(req),
+      id: executionId(req),
+      body,
+      audit: buildAuditContext(req),
+    })
+  );
+});
+
+export const validateExecution = asyncHandler(async (req, res) => {
+  const { body } = validateExecutionSchema.parse({ body: req.body ?? {} });
+  res.json(
+    await svcValidateExecution({
+      actor: requireActor(req),
+      id: executionId(req),
+      body,
+      audit: buildAuditContext(req),
+    })
+  );
+});
+
+export const rejectExecution = asyncHandler(async (req, res) => {
+  const { body } = rejectExecutionSchema.parse({ body: req.body });
+  res.json(
+    await svcRejectExecution({
+      actor: requireActor(req),
+      id: executionId(req),
+      body,
+      audit: buildAuditContext(req),
+    })
+  );
+});
+
+export const correctExecution = asyncHandler(async (req, res) => {
+  const { body } = correctExecutionSchema.parse({ body: req.body });
+  res.json(
+    await svcCorrectExecution({
+      actor: requireActor(req),
+      id: executionId(req),
+      body,
+      audit: buildAuditContext(req),
+    })
+  );
+});
+
+export const cancelExecution = asyncHandler(async (req, res) => {
+  const { body } = cancelExecutionSchema.parse({ body: req.body });
+  res.json(
+    await svcCancelExecution({
+      actor: requireActor(req),
+      id: executionId(req),
+      body,
+      audit: buildAuditContext(req),
+    })
+  );
+});

--- a/src/module/production/domain/production-execution.ts
+++ b/src/module/production/domain/production-execution.ts
@@ -1,0 +1,520 @@
+// Gouvernance du suivi et pointage de production (#274) — politiques pures,
+// sans I/O : capacités RBAC, machine d'états, comptabilisation du temps,
+// idempotence et règles de quantités.
+//
+// Aucune de ces règles ne doit dépendre d'un client SQL, d'un appel réseau ou
+// du navigateur : elles sont testables seules et rejouées par le service à
+// chaque requête.
+//
+// SÉPARATION STRICTE avec le module RH #119 « Temps & Déplacements » : ce
+// fichier répond à « combien de temps et de ressources l'opération d'OF a-t-elle
+// consommé ? ». Il ne calcule ni présence, ni heures supplémentaires, ni paie,
+// et n'a aucune connaissance des contrats de travail.
+
+import crypto from "node:crypto";
+
+import { HttpError } from "../../../utils/httpError";
+
+/* -------------------------------------------------------------------------- */
+/* 1) Capacités RBAC — refus par défaut                                       */
+/* -------------------------------------------------------------------------- */
+
+export const PRODUCTION_EXECUTION_CAPABILITIES = [
+  "read",
+  "start_self",
+  "stop_self",
+  "pause_self",
+  "declare_quantity",
+  "declare_incident",
+  "create_for_other",
+  "correct",
+  "submit",
+  "validate",
+  "reject",
+  "cancel",
+  "manage_categories",
+  "view_costs",
+  "audit",
+] as const;
+
+export type ProductionExecutionCapability = (typeof PRODUCTION_EXECUTION_CAPABILITIES)[number];
+
+// Les rôles CERP sont du texte libre en base. On garde la mécanique par
+// « needles » déjà employée par `of-rbac.ts`, `machine-rbac.ts` et
+// `quality-policy.ts` plutôt que d'inventer une table de rôles parallèle.
+const CAPABILITY_NEEDLES: Record<ProductionExecutionCapability, readonly string[]> = {
+  // Lire l'exécution : l'atelier, les méthodes, la qualité et la direction en
+  // ont besoin. Fermé au reste. Les rôles d'opérateur y figurent explicitement :
+  // sans droit de lecture, un opérateur pourrait démarrer un pointage sans
+  // jamais voir son propre poste de travail.
+  read: [
+    "admin",
+    "administrateur",
+    "directeur",
+    "production",
+    "atelier",
+    "chef",
+    "method",
+    "qualit",
+    "quality",
+    "qse",
+    "planif",
+    "operateur",
+    "opérateur",
+    "usineur",
+    "regleur",
+    "régleur",
+  ],
+  // Pointer POUR SOI est le geste de base de l'opérateur.
+  start_self: ["admin", "administrateur", "directeur", "production", "atelier", "chef", "operateur", "opérateur", "usineur", "regleur", "régleur"],
+  stop_self: ["admin", "administrateur", "directeur", "production", "atelier", "chef", "operateur", "opérateur", "usineur", "regleur", "régleur"],
+  pause_self: ["admin", "administrateur", "directeur", "production", "atelier", "chef", "operateur", "opérateur", "usineur", "regleur", "régleur"],
+  declare_quantity: ["admin", "administrateur", "directeur", "production", "atelier", "chef", "operateur", "opérateur", "usineur", "regleur", "régleur"],
+  declare_incident: ["admin", "administrateur", "directeur", "production", "atelier", "chef", "operateur", "opérateur", "usineur", "regleur", "régleur"],
+  // Pointer POUR UN TIERS est une capacité distincte et surveillée : elle
+  // permet d'imputer du temps à quelqu'un d'autre.
+  create_for_other: ["admin", "administrateur", "directeur", "chef", "method"],
+  // Corriger et valider relèvent de la hiérarchie, jamais de l'opérateur.
+  correct: ["admin", "administrateur", "directeur", "chef", "method"],
+  submit: ["admin", "administrateur", "directeur", "production", "atelier", "chef", "operateur", "opérateur", "usineur", "regleur", "régleur"],
+  validate: ["admin", "administrateur", "directeur", "chef"],
+  reject: ["admin", "administrateur", "directeur", "chef"],
+  cancel: ["admin", "administrateur", "directeur", "chef"],
+  manage_categories: ["admin", "administrateur", "directeur", "method"],
+  // Les coûts sont un périmètre séparé : voir du temps n'est pas voir de
+  // l'argent.
+  view_costs: ["admin", "administrateur", "directeur", "compta", "controle", "contrôle"],
+  audit: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+};
+
+export function roleHasProductionExecutionCapability(
+  role: string | null | undefined,
+  capability: ProductionExecutionCapability
+): boolean {
+  const normalized = (role ?? "").trim().toLowerCase();
+  if (!normalized) return false;
+  const needles = CAPABILITY_NEEDLES[capability];
+  if (!needles) return false;
+  return needles.some((needle) => normalized.includes(needle));
+}
+
+export function assertProductionExecutionCapability(
+  role: string | null | undefined,
+  capability: ProductionExecutionCapability
+): void {
+  if (!roleHasProductionExecutionCapability(role, capability)) {
+    throw new HttpError(
+      403,
+      "PRODUCTION_EXECUTION_CAPABILITY_REQUIRED",
+      `La capacité de suivi de production '${capability}' est requise.`
+    );
+  }
+}
+
+/**
+ * Anti-IDOR : un opérateur ne voit et ne pilote que SES pointages. Élargir le
+ * périmètre exige une capacité explicite — masquer un bouton côté UI n'a jamais
+ * été une autorisation.
+ */
+export function assertOwnershipOrSupervision(params: {
+  actorUserId: number;
+  actorRole: string | null | undefined;
+  ownerUserId: number;
+  action: string;
+}): void {
+  if (params.actorUserId === params.ownerUserId) return;
+  if (roleHasProductionExecutionCapability(params.actorRole, "create_for_other")) return;
+  if (roleHasProductionExecutionCapability(params.actorRole, "validate")) return;
+  throw new HttpError(
+    403,
+    "PRODUCTION_EXECUTION_FOREIGN_POINTAGE",
+    `Ce pointage appartient à un autre opérateur : '${params.action}' est refusé.`
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* 2) Machine d'états d'un segment d'exécution                                */
+/* -------------------------------------------------------------------------- */
+// On réutilise l'enum historique `production_pointage_status` sans y ajouter de
+// valeur : introduire un nouvel état en base invaliderait les lignes existantes
+// et les vues qui les lisent. La soumission et le rejet sont portés par des
+// colonnes datées (`submitted_at`, `rejected_at`), pas par un statut parallèle.
+
+export const EXECUTION_STATUSES = ["RUNNING", "DONE", "CANCELLED", "CORRECTED"] as const;
+export type ExecutionStatus = (typeof EXECUTION_STATUSES)[number];
+
+const STATUS_TRANSITIONS: Readonly<Record<ExecutionStatus, readonly ExecutionStatus[]>> = {
+  RUNNING: ["DONE", "CANCELLED"],
+  // Un segment arrêté peut encore être corrigé ou annulé tant qu'il n'est pas
+  // validé ; la garde d'immuabilité ci-dessous s'en charge.
+  DONE: ["CORRECTED", "CANCELLED"],
+  CANCELLED: [],
+  CORRECTED: [],
+};
+
+export function assertExecutionTransition(from: ExecutionStatus, to: ExecutionStatus): void {
+  if (!STATUS_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "PRODUCTION_EXECUTION_TRANSITION_FORBIDDEN",
+      `Transition de pointage interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+/**
+ * Immuabilité après validation. Une correction passe par un segment
+ * compensatoire ou une nouvelle version liée ; l'original reste visible.
+ */
+export function assertMutable(pointage: {
+  id: string;
+  status: ExecutionStatus;
+  validated_at: string | Date | null;
+}): void {
+  if (pointage.validated_at) {
+    throw new HttpError(
+      409,
+      "PRODUCTION_EXECUTION_VALIDATED_IMMUTABLE",
+      "Ce pointage est validé : il est immuable. Créez une correction motivée.",
+      { pointage_id: pointage.id }
+    );
+  }
+  if (pointage.status === "CANCELLED" || pointage.status === "CORRECTED") {
+    throw new HttpError(
+      409,
+      "PRODUCTION_EXECUTION_CLOSED",
+      `Ce pointage est en statut ${pointage.status} : il ne peut plus être modifié.`,
+      { pointage_id: pointage.id }
+    );
+  }
+}
+
+/**
+ * Séparation des tâches : on ne valide pas son propre pointage. La règle est
+ * levée pour les rôles de direction, qui n'ont structurellement personne
+ * au-dessus d'eux dans l'atelier.
+ */
+export function assertSeparationOfDuties(params: {
+  actorUserId: number;
+  ownerUserId: number;
+  actorRole: string | null | undefined;
+}): void {
+  if (params.actorUserId !== params.ownerUserId) return;
+  const normalized = (params.actorRole ?? "").trim().toLowerCase();
+  const exempt = ["admin", "administrateur", "directeur"].some((needle) => normalized.includes(needle));
+  if (exempt) return;
+  throw new HttpError(
+    409,
+    "PRODUCTION_EXECUTION_SELF_VALIDATION_FORBIDDEN",
+    "Un pointage ne peut pas être validé par son propre auteur."
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* 3) Événements du journal append-only                                       */
+/* -------------------------------------------------------------------------- */
+
+export const EXECUTION_EVENT_TYPES = [
+  "START",
+  "PAUSE",
+  "RESUME",
+  "CHANGE_ACTIVITY",
+  "CHANGE_OPERATOR",
+  "CHANGE_MACHINE",
+  "INCIDENT",
+  "STOP",
+  "DECLARE_QUANTITY",
+  "SUBMIT",
+  "VALIDATE",
+  "REJECT",
+  "CORRECT",
+  "CANCEL",
+] as const;
+
+export type ExecutionEventType = (typeof EXECUTION_EVENT_TYPES)[number];
+
+/* -------------------------------------------------------------------------- */
+/* 4) Catégories d'activité — comptabilisation                                */
+/* -------------------------------------------------------------------------- */
+
+export type ActivityCategory = {
+  code: string;
+  label: string;
+  counts_operator_time: boolean;
+  counts_machine_time: boolean;
+  is_productive: boolean;
+  requires_reason: boolean;
+  criticality: "LOW" | "NORMAL" | "HIGH" | "CRITICAL";
+  signals_planning: boolean;
+  signals_maintenance: boolean;
+  signals_quality: boolean;
+  legacy_time_type: "OPERATEUR" | "MACHINE" | "PROGRAMMATION" | null;
+  legacy_of_time_log_type: "SETUP" | "PRODUCTION" | "PROGRAMMING" | "CONTROL" | "MAINTENANCE" | null;
+  required_capability: string | null;
+  disabled_at: string | null;
+};
+
+/**
+ * Mapping des types du moteur historique `of_time_logs` vers le référentiel
+ * canonique. Ces cinq valeurs sont les seules jamais écrites par les routes
+ * time-logs ; l'adaptateur ne peut donc pas rencontrer d'inconnue.
+ */
+export const LEGACY_TIME_LOG_TO_ACTIVITY: Readonly<Record<string, string>> = {
+  SETUP: "SETUP",
+  PRODUCTION: "PRODUCTION",
+  PROGRAMMING: "PROGRAMMING",
+  CONTROL: "CONTROL",
+  MAINTENANCE: "MAINTENANCE",
+};
+
+/**
+ * Chemin inverse : quelle valeur écrire dans `of_time_logs.type` pour qu'un
+ * consommateur legacy continue de lire quelque chose de sensé. Les catégories
+ * sans équivalent (attentes, arrêts, nettoyage) retombent volontairement sur
+ * PRODUCTION uniquement si elles comptent du temps ; sinon la ligne legacy
+ * n'est pas écrite du tout, car un arrêt planifié n'est pas du temps de travail.
+ */
+export function activityToLegacyTimeLogType(category: ActivityCategory | null): string | null {
+  if (!category) return "PRODUCTION";
+  if (category.legacy_of_time_log_type) return category.legacy_of_time_log_type;
+  if (!category.counts_operator_time) return null;
+  return "PRODUCTION";
+}
+
+export function assertActivityUsable(
+  category: ActivityCategory | undefined,
+  code: string
+): asserts category is ActivityCategory {
+  if (!category) {
+    throw new HttpError(
+      422,
+      "PRODUCTION_ACTIVITY_UNKNOWN",
+      `Catégorie d'activité inconnue : '${code}'.`
+    );
+  }
+  if (category.disabled_at) {
+    throw new HttpError(
+      422,
+      "PRODUCTION_ACTIVITY_DISABLED",
+      `La catégorie d'activité '${code}' est désactivée.`
+    );
+  }
+}
+
+export function assertReasonProvided(category: ActivityCategory, reason: string | null | undefined): void {
+  if (!category.requires_reason) return;
+  if (typeof reason === "string" && reason.trim().length >= 3) return;
+  throw new HttpError(
+    422,
+    "PRODUCTION_ACTIVITY_REASON_REQUIRED",
+    `La catégorie '${category.code}' exige un motif d'au moins 3 caractères.`,
+    { details: { fields: { comment: ["Un motif est obligatoire pour cette activité."] } } }
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* 5) Temps — conventions de calcul                                           */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Convention d'intervalle documentée : `[début, fin)`. Deux segments qui se
+ * touchent bout à bout (fin de l'un = début du suivant) ne se chevauchent pas
+ * et ne comptent donc jamais la même minute deux fois lors d'un changement
+ * d'activité, de machine ou d'opérateur.
+ */
+export const INTERVAL_CONVENTION = "[start, end)" as const;
+
+export function computeDurationMinutes(startIso: string, endIso: string): number {
+  const start = Date.parse(startIso);
+  const end = Date.parse(endIso);
+  if (!Number.isFinite(start) || !Number.isFinite(end)) {
+    throw new HttpError(422, "PRODUCTION_EXECUTION_INVALID_INTERVAL", "Horodatages invalides.");
+  }
+  if (end < start) {
+    throw new HttpError(
+      422,
+      "PRODUCTION_EXECUTION_NEGATIVE_DURATION",
+      "La fin d'un pointage ne peut pas précéder son début."
+    );
+  }
+  return Math.max(0, Math.round((end - start) / 60000));
+}
+
+/** Garde-fou contre les sessions oubliées et les saisies aberrantes. */
+export const MAX_SEGMENT_MINUTES = 24 * 60;
+
+/** Au-delà, une session en cours est signalée comme anormalement longue. */
+export const LONG_RUNNING_ALERT_MINUTES = 12 * 60;
+
+export function assertPlausibleDuration(minutes: number): void {
+  if (minutes > MAX_SEGMENT_MINUTES) {
+    throw new HttpError(
+      422,
+      "PRODUCTION_EXECUTION_DURATION_TOO_LONG",
+      `Un segment ne peut pas dépasser ${MAX_SEGMENT_MINUTES} minutes. Découpez la déclaration.`,
+      { minutes }
+    );
+  }
+}
+
+/** Politique de saisie rétroactive : bornée, motivée, auditée, à valider. */
+export const RETROACTIVE_WINDOW_DAYS = 7;
+
+export function assertRetroactiveAllowed(startIso: string, nowIso: string): void {
+  const start = Date.parse(startIso);
+  const now = Date.parse(nowIso);
+  if (!Number.isFinite(start) || !Number.isFinite(now)) return;
+  const days = (now - start) / 86_400_000;
+  if (days > RETROACTIVE_WINDOW_DAYS) {
+    throw new HttpError(
+      422,
+      "PRODUCTION_EXECUTION_RETROACTIVE_WINDOW",
+      `La saisie rétroactive est limitée à ${RETROACTIVE_WINDOW_DAYS} jours. Passez par une correction validée.`
+    );
+  }
+  if (start > now + 60_000) {
+    throw new HttpError(
+      422,
+      "PRODUCTION_EXECUTION_FUTURE_START",
+      "Un pointage ne peut pas démarrer dans le futur."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 6) Quantités — deltas et bornes                                            */
+/* -------------------------------------------------------------------------- */
+
+export type QuantityDelta = {
+  qty_good: number;
+  qty_scrap: number;
+  qty_rework: number;
+  qty_pending_control: number;
+};
+
+export function assertFiniteQuantities(delta: QuantityDelta): void {
+  for (const [key, value] of Object.entries(delta)) {
+    if (!Number.isFinite(value)) {
+      throw new HttpError(422, "PRODUCTION_QUANTITY_NOT_FINITE", `Quantité invalide : ${key}.`);
+    }
+    if (value < 0) {
+      throw new HttpError(
+        422,
+        "PRODUCTION_QUANTITY_NEGATIVE",
+        `Une déclaration ne porte que des quantités positives : ${key}. Utilisez une compensation motivée.`
+      );
+    }
+  }
+  const total = delta.qty_good + delta.qty_scrap + delta.qty_rework + delta.qty_pending_control;
+  if (total <= 0) {
+    throw new HttpError(
+      422,
+      "PRODUCTION_QUANTITY_EMPTY",
+      "Une déclaration de quantité vide n'a pas d'effet : saisissez au moins une valeur."
+    );
+  }
+}
+
+/**
+ * Surproduction : interdite par défaut. L'autoriser exige à la fois une
+ * tolérance déclarée et un motif — jamais l'un sans l'autre, sinon le
+ * dépassement devient silencieux.
+ */
+export function assertWithinRemaining(params: {
+  declared: number;
+  alreadyDeclared: number;
+  quantityTarget: number;
+  overproductionTolerance: number;
+  reason: string | null | undefined;
+}): void {
+  const remaining = params.quantityTarget - params.alreadyDeclared;
+  if (params.declared <= remaining) return;
+
+  const ceiling = remaining + params.overproductionTolerance;
+  if (params.declared > ceiling) {
+    throw new HttpError(
+      422,
+      "PRODUCTION_QUANTITY_EXCEEDS_REMAINING",
+      `Quantité déclarée (${params.declared}) supérieure au restant (${remaining}) augmenté de la tolérance (${params.overproductionTolerance}).`,
+      {
+        details: {
+          fields: { qty_good: [`Le restant est de ${remaining}.`] },
+        },
+        remaining,
+        tolerance: params.overproductionTolerance,
+      }
+    );
+  }
+  if (!params.reason || params.reason.trim().length < 3) {
+    throw new HttpError(
+      422,
+      "PRODUCTION_OVERPRODUCTION_REASON_REQUIRED",
+      "La surproduction tolérée doit être motivée.",
+      { details: { fields: { note: ["Motivez le dépassement du restant."] } } }
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 7) Idempotence                                                             */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Empreinte SHA-256 de la charge utile. On stocke l'empreinte et jamais la
+ * charge utile elle-même : aucune donnée personnelle n'est recopiée dans la
+ * table d'idempotence.
+ */
+export function fingerprintPayload(scope: string, payload: unknown): string {
+  return crypto
+    .createHash("sha256")
+    .update(`${scope} ${stableStringify(payload)}`)
+    .digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value) ?? "null";
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, v]) => v !== undefined)
+    .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
+  return `{${entries.map(([k, v]) => `${JSON.stringify(k)}:${stableStringify(v)}`).join(",")}}`;
+}
+
+export function assertIdempotencyMatch(params: {
+  key: string;
+  storedFingerprint: string;
+  incomingFingerprint: string;
+}): void {
+  if (params.storedFingerprint === params.incomingFingerprint) return;
+  throw new HttpError(
+    409,
+    "PRODUCTION_EXECUTION_IDEMPOTENCY_CONFLICT",
+    "Cette clé d'idempotence a déjà été utilisée avec une charge utile différente.",
+    { idempotency_key: params.key }
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* 8) Frontières inter-modules — ce que le pointage n'a PAS le droit de faire */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Le suivi de production déclare ce qui a été fabriqué. Il ne décide jamais
+ * seul qu'une quantité est stockable : la chaîne autoritaire reste
+ * déclaration → décision qualité si requise → réception de production (#223)
+ * → lot → mouvement de stock.
+ *
+ * Cette constante est documentaire et testée : elle rend explicite, dans le
+ * code, ce qu'aucune évolution du module ne doit franchir.
+ */
+export const FORBIDDEN_SIDE_EFFECTS = [
+  "stock_movement",
+  "lot_creation",
+  "stock_reservation",
+  "delivery_note",
+  "invoice",
+  "hr_attendance",
+  "payroll",
+] as const;
+
+export type ForbiddenSideEffect = (typeof FORBIDDEN_SIDE_EFFECTS)[number];

--- a/src/module/production/middlewares/production-execution-authorization.middleware.ts
+++ b/src/module/production/middlewares/production-execution-authorization.middleware.ts
@@ -1,0 +1,55 @@
+import type { RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import {
+  roleHasProductionExecutionCapability,
+  type ProductionExecutionCapability,
+} from "../domain/production-execution";
+
+/**
+ * Garde de capacité du suivi de production (#274). Refus par défaut : être
+ * authentifié n'accorde AUCUN droit implicite. La garde est rejouée à chaque
+ * requête — masquer un bouton côté UI n'a jamais été une autorisation.
+ */
+export function requireProductionExecutionCapability(
+  capability: ProductionExecutionCapability
+): RequestHandler {
+  return (req, _res, next) => {
+    if (!req.user || typeof req.user.id !== "number") {
+      next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
+      return;
+    }
+    if (!roleHasProductionExecutionCapability(req.user.role, capability)) {
+      next(
+        new HttpError(
+          403,
+          "PRODUCTION_EXECUTION_CAPABILITY_REQUIRED",
+          `La capacité de suivi de production '${capability}' est requise.`
+        )
+      );
+      return;
+    }
+    next();
+  };
+}
+
+/**
+ * Toute commande à effet exige une clé d'idempotence. Sans elle, un double-clic
+ * ou un retry réseau produirait deux effets — le contrat est donc explicite et
+ * refusé en amont plutôt que deviné.
+ */
+export const requireIdempotencyKey: RequestHandler = (req, _res, next) => {
+  const raw = req.headers["idempotency-key"];
+  const key = typeof raw === "string" ? raw.trim() : "";
+  if (key.length < 8 || key.length > 200) {
+    next(
+      new HttpError(
+        400,
+        "IDEMPOTENCY_KEY_REQUIRED",
+        "L'en-tête Idempotency-Key est requis (8 à 200 caractères) pour cette action."
+      )
+    );
+    return;
+  }
+  next();
+};

--- a/src/module/production/repository/production-execution.repository.ts
+++ b/src/module/production/repository/production-execution.repository.ts
@@ -1,0 +1,2511 @@
+// Repository du suivi et pointage de production (#274).
+//
+// Règles structurantes appliquées ici et nulle part ailleurs :
+//   * TOUTE commande à effet s'exécute dans UNE transaction, avec verrouillage
+//     explicite des ressources concernées (OF, opération, segments de
+//     l'opérateur, machine). Aucun état partiel n'est possible.
+//   * Le TEMPS est posé par la base (`now()`), jamais par le navigateur.
+//   * `of_operations.temps_total_real` est recalculé par la fonction SQL unique
+//     `fn_production_recompute_operation_real_time`, jamais incrémenté à la
+//     main : une minute ne peut donc pas être comptée deux fois.
+//   * Le pointage n'écrit JAMAIS dans le stock, les lots, les BL ou les
+//     factures. La chaîne autoritaire reste déclaration → qualité → réception
+//     de production (#223) → lot → mouvement.
+
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
+
+import {
+  activityToLegacyTimeLogType,
+  assertActivityUsable,
+  assertExecutionTransition,
+  assertFiniteQuantities,
+  assertIdempotencyMatch,
+  assertMutable,
+  assertOwnershipOrSupervision,
+  assertPlausibleDuration,
+  assertReasonProvided,
+  assertRetroactiveAllowed,
+  assertSeparationOfDuties,
+  assertWithinRemaining,
+  computeDurationMinutes,
+  fingerprintPayload,
+  LEGACY_TIME_LOG_TO_ACTIVITY,
+  LONG_RUNNING_ALERT_MINUTES,
+  type ActivityCategory,
+  type ExecutionEventType,
+} from "../domain/production-execution";
+import type { AuditContext } from "./production.repository";
+import type {
+  ChangeExecutionBodyDTO,
+  DeclareQuantityBodyDTO,
+  FinishOperationBodyDTO,
+  FinishOperationPreviewBodyDTO,
+  IncidentExecutionBodyDTO,
+  ListExecutionsQueryDTO,
+  OperatorBoardQueryDTO,
+  PauseExecutionBodyDTO,
+  ResumeExecutionBodyDTO,
+  StartExecutionBodyDTO,
+  StopExecutionBodyDTO,
+} from "../validators/production-execution.validators";
+
+type DbQueryer = Pick<PoolClient, "query">;
+
+/* -------------------------------------------------------------------------- */
+/* Utilitaires                                                                */
+/* -------------------------------------------------------------------------- */
+
+async function insertAuditLog(
+  tx: DbQueryer,
+  audit: AuditContext,
+  entry: {
+    action: string;
+    entity_type: string | null;
+    entity_id: string | null;
+    details?: Record<string, unknown> | null;
+  }
+) {
+  const body: CreateAuditLogBodyDTO = {
+    event_type: "ACTION",
+    action: entry.action,
+    page_key: audit.page_key,
+    entity_type: entry.entity_type,
+    entity_id: entry.entity_id,
+    path: audit.path,
+    client_session_id: audit.client_session_id,
+    details: entry.details ?? null,
+  };
+  await repoInsertAuditLog({
+    user_id: audit.user_id,
+    body,
+    ip: audit.ip,
+    user_agent: audit.user_agent,
+    device_type: audit.device_type,
+    os: audit.os,
+    browser: audit.browser,
+    tx,
+  });
+}
+
+/** Journal append-only propre au pointage, en plus de l'audit transverse. */
+async function insertExecutionEvent(
+  tx: DbQueryer,
+  params: {
+    pointage_id: string;
+    event_type: ExecutionEventType;
+    user_id: number;
+    old_values?: Record<string, unknown> | null;
+    new_values?: Record<string, unknown> | null;
+    note?: string | null;
+  }
+) {
+  await tx.query(
+    `
+      INSERT INTO public.production_pointage_events
+        (pointage_id, event_type, old_values, new_values, user_id, note)
+      VALUES ($1::uuid, $2::text, $3::jsonb, $4::jsonb, $5::int, $6)
+    `,
+    [
+      params.pointage_id,
+      params.event_type,
+      params.old_values ? JSON.stringify(params.old_values) : null,
+      params.new_values ? JSON.stringify(params.new_values) : null,
+      params.user_id,
+      params.note ?? null,
+    ]
+  );
+}
+
+function isPgUniqueViolation(err: unknown): boolean {
+  return (err as { code?: unknown } | null)?.code === "23505";
+}
+
+function isPgExclusionViolation(err: unknown): boolean {
+  return (err as { code?: unknown } | null)?.code === "23P01";
+}
+
+/**
+ * Traduit les violations de contrainte en erreurs métier lisibles. Sans cela,
+ * une course entre deux onglets remonterait une erreur SQL brute à l'atelier.
+ */
+function translateConcurrencyError(err: unknown): never {
+  if (isPgUniqueViolation(err)) {
+    const constraint = String((err as { constraint?: unknown }).constraint ?? "");
+    if (constraint.includes("running_operator")) {
+      throw new HttpError(
+        409,
+        "PRODUCTION_EXECUTION_OPERATOR_BUSY",
+        "Cet opérateur a déjà un pointage en cours. Arrêtez-le avant d'en démarrer un autre."
+      );
+    }
+    if (constraint.includes("running_machine")) {
+      throw new HttpError(
+        409,
+        "PRODUCTION_EXECUTION_MACHINE_BUSY",
+        "Cette machine est déjà occupée par un pointage en cours."
+      );
+    }
+    if (constraint.includes("idempotency")) {
+      throw new HttpError(
+        409,
+        "PRODUCTION_EXECUTION_IDEMPOTENCY_CONFLICT",
+        "Cette clé d'idempotence a déjà été utilisée avec une charge utile différente."
+      );
+    }
+  }
+  if (isPgExclusionViolation(err)) {
+    throw new HttpError(
+      409,
+      "PRODUCTION_EXECUTION_OVERLAP",
+      "Ce pointage chevauche une période déjà déclarée pour cet opérateur ou cette machine."
+    );
+  }
+  throw err as Error;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Idempotence                                                                */
+/* -------------------------------------------------------------------------- */
+
+type IdempotentReplay<T> = { replayed: true; body: T } | { replayed: false };
+
+/**
+ * Réservation de la clé AVANT l'effet, dans la même transaction. Si l'effet
+ * échoue, la réservation disparaît avec le ROLLBACK et un retry est possible.
+ */
+async function reserveIdempotencyKey<T>(
+  tx: DbQueryer,
+  params: { key: string; scope: string; payload: unknown; user_id: number }
+): Promise<IdempotentReplay<T>> {
+  const fingerprint = fingerprintPayload(params.scope, params.payload);
+
+  const existing = await tx.query<{
+    request_fingerprint: string;
+    response_body: T | null;
+  }>(
+    `
+      SELECT request_fingerprint, response_body
+      FROM public.production_execution_idempotency
+      WHERE idempotency_key = $1
+      FOR UPDATE
+    `,
+    [params.key]
+  );
+
+  const row = existing.rows[0];
+  if (row) {
+    assertIdempotencyMatch({
+      key: params.key,
+      storedFingerprint: row.request_fingerprint,
+      incomingFingerprint: fingerprint,
+    });
+    return { replayed: true, body: row.response_body as T };
+  }
+
+  await tx.query(
+    `
+      INSERT INTO public.production_execution_idempotency
+        (idempotency_key, scope, request_fingerprint, response_status, response_body, user_id)
+      VALUES ($1, $2, $3, 200, NULL, $4)
+    `,
+    [params.key, params.scope, fingerprint, params.user_id]
+  );
+
+  return { replayed: false };
+}
+
+async function storeIdempotentResponse(tx: DbQueryer, key: string, body: unknown) {
+  await tx.query(
+    `UPDATE public.production_execution_idempotency SET response_body = $2::jsonb WHERE idempotency_key = $1`,
+    [key, JSON.stringify(body ?? null)]
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Référentiel d'activités                                                    */
+/* -------------------------------------------------------------------------- */
+
+const ACTIVITY_COLUMNS = `
+  code, label, description,
+  counts_operator_time, counts_machine_time, is_productive,
+  requires_reason, criticality,
+  signals_planning, signals_maintenance, signals_quality,
+  legacy_time_type::text AS legacy_time_type,
+  legacy_of_time_log_type::text AS legacy_of_time_log_type,
+  required_capability, sort_order,
+  effective_from::text AS effective_from,
+  disabled_at
+`;
+
+export async function repoListActivityCategories(params: {
+  include_disabled?: boolean;
+}): Promise<ActivityCategory[]> {
+  const res = await pool.query<ActivityCategory>(
+    `
+      SELECT ${ACTIVITY_COLUMNS}
+      FROM public.production_activity_categories
+      WHERE ($1::boolean IS TRUE OR disabled_at IS NULL)
+        AND effective_from <= CURRENT_DATE
+      ORDER BY sort_order, code
+    `,
+    [Boolean(params.include_disabled)]
+  );
+  return res.rows;
+}
+
+async function loadActivity(tx: DbQueryer, code: string): Promise<ActivityCategory> {
+  const res = await tx.query<ActivityCategory>(
+    `SELECT ${ACTIVITY_COLUMNS} FROM public.production_activity_categories WHERE code = $1`,
+    [code]
+  );
+  const row = res.rows[0];
+  assertActivityUsable(row, code);
+  return row;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Lecture des exécutions                                                     */
+/* -------------------------------------------------------------------------- */
+
+const EXECUTION_SELECT = `
+  SELECT
+    p.id::text                        AS id,
+    p.status::text                    AS status,
+    p.time_type::text                 AS time_type,
+    p.activity_code,
+    COALESCE(c.label, p.time_type::text) AS activity_label,
+    COALESCE(c.is_productive, false)  AS activity_is_productive,
+    COALESCE(c.criticality, 'NORMAL') AS activity_criticality,
+    p.session_id::text                AS session_id,
+    p.segment_index,
+    p.source,
+    p.start_ts,
+    p.end_ts,
+    p.duration_minutes,
+    CASE
+      WHEN p.status = 'RUNNING'
+      THEN GREATEST(0, ROUND(EXTRACT(EPOCH FROM (now() - p.start_ts)) / 60.0)::int)
+      ELSE p.duration_minutes
+    END                               AS elapsed_minutes,
+    p.comment,
+    p.correction_reason,
+    p.is_retroactive,
+    p.submitted_at,
+    p.validated_at,
+    p.rejected_at,
+    p.rejection_reason,
+    p.created_at,
+    p.updated_at,
+    p.of_id,
+    o.numero                          AS of_numero,
+    o.statut::text                    AS of_statut,
+    p.operation_id::text              AS operation_id,
+    op.phase                          AS operation_phase,
+    op.designation                    AS operation_designation,
+    op.status::text                   AS operation_status,
+    op.temps_total_planned::float8    AS operation_temps_planned,
+    op.temps_total_real::float8       AS operation_temps_real,
+    p.affaire_id,
+    a.reference                       AS affaire_reference,
+    p.piece_technique_id::text        AS piece_technique_id,
+    pt.code_piece                     AS piece_code,
+    pt.designation                    AS piece_designation,
+    p.machine_id::text                AS machine_id,
+    m.code                            AS machine_code,
+    m.name                            AS machine_name,
+    p.poste_id::text                  AS poste_id,
+    po.code                           AS poste_code,
+    po.label                          AS poste_label,
+    p.operator_user_id,
+    u.username                        AS operator_username,
+    u.name                            AS operator_name,
+    u.surname                         AS operator_surname
+  FROM public.production_pointages p
+  JOIN public.ordres_fabrication o ON o.id = p.of_id
+  LEFT JOIN public.of_operations op ON op.id = p.operation_id
+  LEFT JOIN public.affaire a ON a.id = p.affaire_id
+  LEFT JOIN public.pieces_techniques pt ON pt.id = p.piece_technique_id
+  LEFT JOIN public.machines m ON m.id = p.machine_id
+  LEFT JOIN public.postes po ON po.id = p.poste_id
+  LEFT JOIN public.production_activity_categories c ON c.code = p.activity_code
+  JOIN public.users u ON u.id = p.operator_user_id
+`;
+
+function operatorLabel(row: {
+  operator_username: string;
+  operator_name: string | null;
+  operator_surname: string | null;
+}): string {
+  const full = [row.operator_name, row.operator_surname]
+    .map((v) => (typeof v === "string" ? v.trim() : ""))
+    .filter(Boolean)
+    .join(" ");
+  return full ? `${full} (${row.operator_username})` : row.operator_username;
+}
+
+function mapExecutionRow(row: Record<string, any>) {
+  return {
+    id: row.id as string,
+    status: row.status as string,
+    time_type: row.time_type as string,
+    activity: {
+      code: (row.activity_code as string | null) ?? null,
+      label: row.activity_label as string,
+      is_productive: Boolean(row.activity_is_productive),
+      criticality: row.activity_criticality as string,
+    },
+    session_id: (row.session_id as string | null) ?? null,
+    segment_index: Number(row.segment_index ?? 1),
+    source: row.source as string,
+    start_ts: row.start_ts as string,
+    end_ts: (row.end_ts as string | null) ?? null,
+    duration_minutes: row.duration_minutes === null ? null : Number(row.duration_minutes),
+    elapsed_minutes: row.elapsed_minutes === null ? null : Number(row.elapsed_minutes),
+    comment: (row.comment as string | null) ?? null,
+    correction_reason: (row.correction_reason as string | null) ?? null,
+    is_retroactive: Boolean(row.is_retroactive),
+    submitted_at: (row.submitted_at as string | null) ?? null,
+    validated_at: (row.validated_at as string | null) ?? null,
+    rejected_at: (row.rejected_at as string | null) ?? null,
+    rejection_reason: (row.rejection_reason as string | null) ?? null,
+    created_at: row.created_at as string,
+    updated_at: row.updated_at as string,
+    of: {
+      id: Number(row.of_id),
+      numero: row.of_numero as string,
+      statut: row.of_statut as string,
+    },
+    operation: row.operation_id
+      ? {
+          id: row.operation_id as string,
+          phase: Number(row.operation_phase),
+          designation: row.operation_designation as string,
+          status: row.operation_status as string,
+          temps_total_planned: Number(row.operation_temps_planned ?? 0),
+          temps_total_real: Number(row.operation_temps_real ?? 0),
+        }
+      : null,
+    affaire: row.affaire_id
+      ? { id: Number(row.affaire_id), reference: row.affaire_reference as string }
+      : null,
+    piece_technique: row.piece_technique_id
+      ? {
+          id: row.piece_technique_id as string,
+          code_piece: row.piece_code as string,
+          designation: row.piece_designation as string,
+        }
+      : null,
+    machine: row.machine_id
+      ? { id: row.machine_id as string, code: row.machine_code as string, name: row.machine_name as string }
+      : null,
+    poste: row.poste_id
+      ? { id: row.poste_id as string, code: row.poste_code as string, label: row.poste_label as string }
+      : null,
+    operator: {
+      id: Number(row.operator_user_id),
+      username: row.operator_username as string,
+      name: (row.operator_name as string | null) ?? null,
+      surname: (row.operator_surname as string | null) ?? null,
+      label: operatorLabel(row as any),
+    },
+  };
+}
+
+export type ExecutionListItem = ReturnType<typeof mapExecutionRow>;
+
+/**
+ * Files opérationnelles : ce sont des filtres SERVEUR. Un KPI ou un segment
+ * calculé sur la page courante mentirait dès la deuxième page.
+ */
+function segmentClause(segment: string, values: unknown[]): string {
+  switch (segment) {
+    case "running":
+      return `AND p.status = 'RUNNING'`;
+    case "long_running":
+      values.push(LONG_RUNNING_ALERT_MINUTES);
+      return `AND p.status = 'RUNNING' AND EXTRACT(EPOCH FROM (now() - p.start_ts)) / 60.0 > $${values.length}`;
+    case "to_validate":
+      return `AND p.status = 'DONE' AND p.validated_at IS NULL AND p.rejected_at IS NULL`;
+    case "rejected":
+      return `AND p.rejected_at IS NOT NULL`;
+    case "incidents":
+      return `AND c.criticality IN ('HIGH','CRITICAL')`;
+    case "scrap":
+      return `AND EXISTS (
+                SELECT 1 FROM public.production_quantity_declarations d
+                WHERE d.pointage_id = p.id AND d.qty_scrap > 0
+              )`;
+    case "overrun":
+      return `AND op.temps_total_planned > 0 AND op.temps_total_real > op.temps_total_planned`;
+    default:
+      return "";
+  }
+}
+
+export async function repoListExecutions(params: {
+  query: ListExecutionsQueryDTO;
+  scopeOperatorUserId: number | null;
+}): Promise<{ items: ExecutionListItem[]; total: number }> {
+  const values: unknown[] = [];
+  const where: string[] = [];
+
+  // Anti-IDOR : quand l'appelant n'a pas de droit de supervision, le service
+  // impose ici son propre identifiant. Le filtre n'est pas contournable par un
+  // paramètre de requête.
+  if (params.scopeOperatorUserId !== null) {
+    values.push(params.scopeOperatorUserId);
+    where.push(`p.operator_user_id = $${values.length}`);
+  } else if (params.query.operator_user_id) {
+    values.push(params.query.operator_user_id);
+    where.push(`p.operator_user_id = $${values.length}`);
+  }
+
+  if (params.query.date_from) {
+    values.push(params.query.date_from);
+    where.push(`p.start_ts >= $${values.length}::date`);
+  }
+  if (params.query.date_to) {
+    values.push(params.query.date_to);
+    where.push(`p.start_ts < ($${values.length}::date + INTERVAL '1 day')`);
+  }
+  if (params.query.of_id) {
+    values.push(params.query.of_id);
+    where.push(`p.of_id = $${values.length}::bigint`);
+  }
+  if (params.query.operation_id) {
+    values.push(params.query.operation_id);
+    where.push(`p.operation_id = $${values.length}::uuid`);
+  }
+  if (params.query.machine_id) {
+    values.push(params.query.machine_id);
+    where.push(`p.machine_id = $${values.length}::uuid`);
+  }
+  if (params.query.poste_id) {
+    values.push(params.query.poste_id);
+    where.push(`p.poste_id = $${values.length}::uuid`);
+  }
+  if (params.query.activity_code) {
+    values.push(params.query.activity_code);
+    where.push(`p.activity_code = $${values.length}`);
+  }
+  if (params.query.status) {
+    values.push(params.query.status);
+    where.push(`p.status = $${values.length}::production_pointage_status`);
+  }
+  if (params.query.q) {
+    values.push(`%${params.query.q}%`);
+    const i = values.length;
+    where.push(
+      `(o.numero ILIKE $${i} OR op.designation ILIKE $${i} OR m.code ILIKE $${i} OR m.name ILIKE $${i} OR u.username ILIKE $${i})`
+    );
+  }
+
+  const segment = segmentClause(params.query.segment ?? "all", values);
+  const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "WHERE TRUE";
+
+  const sortColumn =
+    { start_ts: "p.start_ts", end_ts: "p.end_ts", duration_minutes: "p.duration_minutes", updated_at: "p.updated_at" }[
+      params.query.sortBy ?? "start_ts"
+    ] ?? "p.start_ts";
+  const sortDir = params.query.sortDir === "asc" ? "ASC" : "DESC";
+
+  const countRes = await pool.query<{ total: string }>(
+    `
+      SELECT count(*)::text AS total
+      FROM public.production_pointages p
+      JOIN public.ordres_fabrication o ON o.id = p.of_id
+      LEFT JOIN public.of_operations op ON op.id = p.operation_id
+      LEFT JOIN public.machines m ON m.id = p.machine_id
+      LEFT JOIN public.production_activity_categories c ON c.code = p.activity_code
+      JOIN public.users u ON u.id = p.operator_user_id
+      ${whereSql} ${segment}
+    `,
+    values
+  );
+
+  const page = params.query.page ?? 1;
+  const pageSize = params.query.pageSize ?? 50;
+  values.push(pageSize, (page - 1) * pageSize);
+
+  const res = await pool.query(
+    `
+      ${EXECUTION_SELECT}
+      ${whereSql} ${segment}
+      ORDER BY ${sortColumn} ${sortDir} NULLS LAST, p.id
+      LIMIT $${values.length - 1} OFFSET $${values.length}
+    `,
+    values
+  );
+
+  return {
+    items: res.rows.map(mapExecutionRow),
+    total: Number(countRes.rows[0]?.total ?? 0),
+  };
+}
+
+export async function repoGetExecution(params: {
+  id: string;
+}): Promise<(ExecutionListItem & { events: unknown[]; declarations: unknown[] }) | null> {
+  const res = await pool.query(`${EXECUTION_SELECT} WHERE p.id = $1::uuid`, [params.id]);
+  const row = res.rows[0];
+  if (!row) return null;
+
+  const events = await pool.query(
+    `
+      SELECT e.id, e.event_type, e.old_values, e.new_values, e.created_at, e.note,
+             u.id AS user_id, u.username, u.name, u.surname
+      FROM public.production_pointage_events e
+      JOIN public.users u ON u.id = e.user_id
+      WHERE e.pointage_id = $1::uuid
+      ORDER BY e.created_at, e.id
+    `,
+    [params.id]
+  );
+
+  const declarations = await pool.query(
+    `
+      SELECT d.id::text AS id, d.qty_good::float8 AS qty_good, d.qty_scrap::float8 AS qty_scrap,
+             d.qty_rework::float8 AS qty_rework, d.qty_pending_control::float8 AS qty_pending_control,
+             d.unite, d.scrap_reason_code, d.rework_reason_code, d.note,
+             d.non_conformity_id::text AS non_conformity_id,
+             d.compensates_id::text AS compensates_id, d.compensation_reason,
+             d.declared_at, u.username AS declared_by_username
+      FROM public.production_quantity_declarations d
+      JOIN public.users u ON u.id = d.declared_by
+      WHERE d.pointage_id = $1::uuid
+      ORDER BY d.declared_at, d.id
+    `,
+    [params.id]
+  );
+
+  return {
+    ...mapExecutionRow(row),
+    events: events.rows.map((e) => ({
+      id: Number(e.id),
+      event_type: e.event_type as string,
+      old_values: e.old_values ?? null,
+      new_values: e.new_values ?? null,
+      created_at: e.created_at as string,
+      note: (e.note as string | null) ?? null,
+      user: {
+        id: Number(e.user_id),
+        username: e.username as string,
+        name: e.name ?? null,
+        surname: e.surname ?? null,
+        label: operatorLabel({
+          operator_username: e.username,
+          operator_name: e.name,
+          operator_surname: e.surname,
+        }),
+      },
+    })),
+    declarations: declarations.rows,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Command center — KPI calculés par le serveur                               */
+/* -------------------------------------------------------------------------- */
+
+export async function repoExecutionCenter(params: {
+  date_from: string;
+  date_to: string;
+  scopeOperatorUserId: number | null;
+}) {
+  const scope = params.scopeOperatorUserId;
+  const res = await pool.query(
+    `
+      WITH scoped AS (
+        SELECT p.*, c.criticality, c.is_productive, op.temps_total_planned, op.temps_total_real
+        FROM public.production_pointages p
+        LEFT JOIN public.production_activity_categories c ON c.code = p.activity_code
+        LEFT JOIN public.of_operations op ON op.id = p.operation_id
+        WHERE p.start_ts >= $1::date
+          AND p.start_ts < ($2::date + INTERVAL '1 day')
+          AND ($3::int IS NULL OR p.operator_user_id = $3::int)
+      )
+      SELECT
+        count(*) FILTER (WHERE status = 'RUNNING')                               AS running,
+        count(*) FILTER (
+          WHERE status = 'RUNNING'
+            AND EXTRACT(EPOCH FROM (now() - start_ts)) / 60.0 > $4::int
+        )                                                                         AS long_running,
+        count(*) FILTER (WHERE status = 'DONE' AND validated_at IS NULL AND rejected_at IS NULL) AS to_validate,
+        count(*) FILTER (WHERE rejected_at IS NOT NULL)                           AS rejected,
+        count(*) FILTER (WHERE criticality IN ('HIGH','CRITICAL'))                AS incidents,
+        COALESCE(SUM(duration_minutes) FILTER (WHERE status = 'DONE'), 0)::int    AS total_minutes,
+        COALESCE(SUM(duration_minutes) FILTER (WHERE status = 'DONE' AND is_productive), 0)::int AS productive_minutes
+      FROM scoped
+    `,
+    [params.date_from, params.date_to, scope, LONG_RUNNING_ALERT_MINUTES]
+  );
+
+  const byActivity = await pool.query(
+    `
+      SELECT COALESCE(p.activity_code, 'NON_CATEGORISE') AS activity_code,
+             COALESCE(c.label, 'Non catégorisé')          AS label,
+             COALESCE(SUM(p.duration_minutes), 0)::int     AS minutes,
+             count(*)::int                                 AS segments
+      FROM public.production_pointages p
+      LEFT JOIN public.production_activity_categories c ON c.code = p.activity_code
+      WHERE p.status = 'DONE'
+        AND p.start_ts >= $1::date
+        AND p.start_ts < ($2::date + INTERVAL '1 day')
+        AND ($3::int IS NULL OR p.operator_user_id = $3::int)
+      GROUP BY 1, 2
+      ORDER BY minutes DESC
+    `,
+    [params.date_from, params.date_to, scope]
+  );
+
+  const quantities = await pool.query(
+    `
+      SELECT
+        COALESCE(SUM(d.qty_good), 0)::float8            AS qty_good,
+        COALESCE(SUM(d.qty_scrap), 0)::float8           AS qty_scrap,
+        COALESCE(SUM(d.qty_rework), 0)::float8          AS qty_rework,
+        COALESCE(SUM(d.qty_pending_control), 0)::float8 AS qty_pending_control
+      FROM public.production_quantity_declarations d
+      WHERE d.declared_at >= $1::date
+        AND d.declared_at < ($2::date + INTERVAL '1 day')
+        AND ($3::int IS NULL OR d.declared_by = $3::int)
+    `,
+    [params.date_from, params.date_to, scope]
+  );
+
+  const k = res.rows[0] ?? {};
+  return {
+    range: { from: params.date_from, to: params.date_to },
+    kpis: {
+      running: Number(k.running ?? 0),
+      long_running: Number(k.long_running ?? 0),
+      to_validate: Number(k.to_validate ?? 0),
+      rejected: Number(k.rejected ?? 0),
+      incidents: Number(k.incidents ?? 0),
+      total_minutes: Number(k.total_minutes ?? 0),
+      productive_minutes: Number(k.productive_minutes ?? 0),
+    },
+    by_activity: byActivity.rows.map((r) => ({
+      activity_code: r.activity_code as string,
+      label: r.label as string,
+      minutes: Number(r.minutes),
+      segments: Number(r.segments),
+    })),
+    quantities: {
+      qty_good: Number(quantities.rows[0]?.qty_good ?? 0),
+      qty_scrap: Number(quantities.rows[0]?.qty_scrap ?? 0),
+      qty_rework: Number(quantities.rows[0]?.qty_rework ?? 0),
+      qty_pending_control: Number(quantities.rows[0]?.qty_pending_control ?? 0),
+    },
+    // Coûts et TRS/OEE : voir `repoExecutionIndicators`. Ils ne sont JAMAIS
+    // remplacés par zéro quand la donnée manque.
+  };
+}
+
+/**
+ * Indicateurs dérivés. Rien n'est inventé : chaque indicateur non calculable
+ * dit précisément ce qui manque, plutôt que d'afficher un zéro trompeur.
+ */
+export async function repoExecutionIndicators(params: { date_from: string; date_to: string }) {
+  const res = await pool.query(
+    `
+      SELECT
+        count(*)                                                     AS operations,
+        count(*) FILTER (WHERE op.temps_total_planned > 0)           AS with_planned,
+        COALESCE(SUM(op.temps_total_planned), 0)::float8             AS planned_hours,
+        COALESCE(SUM(op.temps_total_real), 0)::float8                AS real_hours,
+        count(*) FILTER (WHERE op.hourly_rate_applied > 0)           AS with_rate
+      FROM public.of_operations op
+      WHERE op.updated_at >= $1::date AND op.updated_at < ($2::date + INTERVAL '1 day')
+    `,
+    [params.date_from, params.date_to]
+  );
+
+  const row = res.rows[0] ?? {};
+  const operations = Number(row.operations ?? 0);
+  const withPlanned = Number(row.with_planned ?? 0);
+  const plannedHours = Number(row.planned_hours ?? 0);
+  const realHours = Number(row.real_hours ?? 0);
+  const withRate = Number(row.with_rate ?? 0);
+
+  const missingForCost: string[] = [];
+  if (withRate === 0) missingForCost.push("taux horaire machine/main-d'œuvre renseigné");
+  missingForCost.push("règles de temps indirect et de multi-opérateur validées");
+  missingForCost.push("période de validité des taux");
+
+  // Le TRS exige un calendrier de capacité théorique et une cadence nominale
+  // versionnée : aucun des deux n'existe aujourd'hui dans le modèle.
+  const missingForOee = [
+    "calendrier / capacité théorique par machine",
+    "temps planifié d'ouverture",
+    "cadence nominale versionnée par opération",
+  ];
+
+  return {
+    range: { from: params.date_from, to: params.date_to },
+    time: {
+      operations,
+      operations_with_planned: withPlanned,
+      planned_hours: Number(plannedHours.toFixed(3)),
+      real_hours: Number(realHours.toFixed(3)),
+      variance_hours: Number((realHours - plannedHours).toFixed(3)),
+      computable: withPlanned > 0,
+      missing: withPlanned > 0 ? [] : ["temps prévu renseigné sur les opérations"],
+    },
+    cost: { computable: false, value: null, missing: missingForCost },
+    oee: { computable: false, value: null, missing: missingForOee },
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Poste opérateur                                                            */
+/* -------------------------------------------------------------------------- */
+
+export async function repoOperatorBoard(params: {
+  operatorUserId: number;
+  query: OperatorBoardQueryDTO;
+}) {
+  const active = await pool.query(`${EXECUTION_SELECT} WHERE p.operator_user_id = $1::int AND p.status = 'RUNNING'`, [
+    params.operatorUserId,
+  ]);
+
+  // Opérations réellement pointables : OF exécutable, opération non terminée
+  // ni bloquée. La liste est bornée côté serveur, jamais filtrée côté page.
+  const values: unknown[] = [params.operatorUserId];
+  let filter = "";
+  if (params.query.of_id) {
+    values.push(params.query.of_id);
+    filter += ` AND o.id = $${values.length}::bigint`;
+  }
+  if (params.query.q) {
+    values.push(`%${params.query.q}%`);
+    filter += ` AND (o.numero ILIKE $${values.length} OR op.designation ILIKE $${values.length})`;
+  }
+  values.push(params.query.limit ?? 25);
+
+  const candidates = await pool.query(
+    `
+      SELECT
+        op.id::text                     AS operation_id,
+        op.phase,
+        op.designation,
+        op.status::text                 AS status,
+        op.temps_total_planned::float8  AS temps_total_planned,
+        op.temps_total_real::float8     AS temps_total_real,
+        o.id                            AS of_id,
+        o.numero                        AS of_numero,
+        o.statut::text                  AS of_statut,
+        o.quantite_lancee::float8       AS quantite_lancee,
+        o.quantite_bonne::float8        AS quantite_bonne,
+        o.quantite_rebut::float8        AS quantite_rebut,
+        m.id::text                      AS machine_id,
+        m.code                          AS machine_code,
+        m.name                          AS machine_name,
+        -- Une opération dont une phase antérieure n'est pas terminée est
+        -- signalée, mais le blocage effectif est décidé par le service.
+        EXISTS (
+          SELECT 1 FROM public.of_operations prev
+          WHERE prev.of_id = op.of_id AND prev.phase < op.phase AND prev.status <> 'DONE'
+        )                               AS has_pending_predecessor,
+        EXISTS (
+          SELECT 1 FROM public.production_pointages act
+          WHERE act.operation_id = op.id AND act.status = 'RUNNING'
+        )                               AS has_active_execution
+      FROM public.of_operations op
+      JOIN public.ordres_fabrication o ON o.id = op.of_id
+      LEFT JOIN public.machines m ON m.id = op.machine_id
+      WHERE o.statut IN ('PLANIFIE', 'EN_COURS', 'EN_PAUSE')
+        AND op.status <> 'DONE'
+        AND $1::int IS NOT NULL
+        ${filter}
+      ORDER BY o.numero, op.phase
+      LIMIT $${values.length}
+    `,
+    values
+  );
+
+  return {
+    operator_user_id: params.operatorUserId,
+    active: active.rows.map(mapExecutionRow),
+    candidates: candidates.rows.map((r) => ({
+      operation_id: r.operation_id as string,
+      phase: Number(r.phase),
+      designation: r.designation as string,
+      status: r.status as string,
+      temps_total_planned: Number(r.temps_total_planned ?? 0),
+      temps_total_real: Number(r.temps_total_real ?? 0),
+      of: {
+        id: Number(r.of_id),
+        numero: r.of_numero as string,
+        statut: r.of_statut as string,
+        quantite_lancee: Number(r.quantite_lancee ?? 0),
+        quantite_bonne: Number(r.quantite_bonne ?? 0),
+        quantite_rebut: Number(r.quantite_rebut ?? 0),
+      },
+      machine: r.machine_id
+        ? { id: r.machine_id as string, code: r.machine_code as string, name: r.machine_name as string }
+        : null,
+      has_pending_predecessor: Boolean(r.has_pending_predecessor),
+      has_active_execution: Boolean(r.has_active_execution),
+    })),
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Verrouillage — ordre stable pour éviter les interblocages                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Verrouille toujours dans le même ordre : OF, puis opération, puis segments de
+ * l'opérateur, puis machine. Deux requêtes concurrentes prennent donc les
+ * verrous dans la même séquence et ne peuvent pas s'interbloquer.
+ */
+async function lockExecutionContext(
+  tx: DbQueryer,
+  params: { of_id: number; operation_id?: string | null; operator_user_id: number; machine_id?: string | null }
+) {
+  const ofRes = await tx.query<{ id: string; statut: string }>(
+    `SELECT id::text AS id, statut::text AS statut FROM public.ordres_fabrication WHERE id = $1::bigint FOR UPDATE`,
+    [params.of_id]
+  );
+  const of = ofRes.rows[0];
+  if (!of) {
+    throw new HttpError(404, "OF_NOT_FOUND", "Ordre de fabrication introuvable.", { of_id: params.of_id });
+  }
+
+  let operation: { id: string; status: string; phase: number; of_id: string } | null = null;
+  if (params.operation_id) {
+    const opRes = await tx.query<{ id: string; status: string; phase: number; of_id: string }>(
+      `
+        SELECT id::text AS id, status::text AS status, phase, of_id::text AS of_id
+        FROM public.of_operations
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
+      [params.operation_id]
+    );
+    operation = opRes.rows[0] ?? null;
+    if (!operation) {
+      throw new HttpError(404, "OF_OPERATION_NOT_FOUND", "Opération introuvable.", {
+        operation_id: params.operation_id,
+      });
+    }
+    // Cohérence opération/OF : refuse un rattachement croisé.
+    if (Number(operation.of_id) !== Number(params.of_id)) {
+      throw new HttpError(
+        422,
+        "PRODUCTION_EXECUTION_OPERATION_MISMATCH",
+        "Cette opération n'appartient pas à l'ordre de fabrication indiqué."
+      );
+    }
+  }
+
+  // Verrou sur les segments actifs de l'opérateur : deux onglets ne peuvent pas
+  // démarrer simultanément.
+  await tx.query(
+    `SELECT id FROM public.production_pointages WHERE operator_user_id = $1::int AND status = 'RUNNING' FOR UPDATE`,
+    [params.operator_user_id]
+  );
+
+  if (params.machine_id) {
+    await tx.query(
+      `SELECT id FROM public.production_pointages WHERE machine_id = $1::uuid AND status = 'RUNNING' FOR UPDATE`,
+      [params.machine_id]
+    );
+  }
+
+  return { of, operation };
+}
+
+/** L'OF doit être dans un état exécutable — on ne pointe pas sur un OF clos. */
+function assertOfExecutable(statut: string) {
+  const executable = ["BROUILLON", "PLANIFIE", "EN_COURS", "EN_PAUSE"];
+  if (!executable.includes(statut)) {
+    throw new HttpError(
+      422,
+      "PRODUCTION_EXECUTION_OF_NOT_EXECUTABLE",
+      `Cet ordre de fabrication est en statut ${statut} : il n'accepte plus de pointage.`
+    );
+  }
+}
+
+function assertOperationExecutable(operation: { status: string } | null) {
+  if (!operation) return;
+  if (operation.status === "DONE") {
+    throw new HttpError(
+      409,
+      "OF_OPERATION_ALREADY_DONE",
+      "Cette opération est déclarée terminée : rouvrez-la avant de pointer."
+    );
+  }
+  if (operation.status === "BLOCKED") {
+    throw new HttpError(
+      409,
+      "OF_OPERATION_BLOCKED",
+      "Cette opération est suspendue : débloquez-la avant de pointer."
+    );
+  }
+}
+
+/** Une maintenance bloquante interdit le démarrage : elle n'est pas contournable. */
+async function assertMachineAvailable(tx: DbQueryer, machineId: string | null | undefined) {
+  if (!machineId) return;
+  const res = await tx.query<{ statut: string | null }>(
+    `SELECT statut::text AS statut FROM public.machines WHERE id = $1::uuid`,
+    [machineId]
+  );
+  const row = res.rows[0];
+  if (!row) {
+    throw new HttpError(404, "MACHINE_NOT_FOUND", "Machine introuvable.", { machine_id: machineId });
+  }
+  const blocking = ["HORS_SERVICE", "MAINTENANCE", "EN_MAINTENANCE", "INDISPONIBLE"];
+  if (row.statut && blocking.includes(row.statut)) {
+    throw new HttpError(
+      409,
+      "PRODUCTION_EXECUTION_MACHINE_UNAVAILABLE",
+      `Cette machine est en statut ${row.statut} : le pointage est refusé.`,
+      { machine_id: machineId, statut: row.statut }
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Démarrage d'un segment                                                     */
+/* -------------------------------------------------------------------------- */
+
+export async function repoStartExecution(params: {
+  body: StartExecutionBodyDTO;
+  operatorUserId: number;
+  idempotencyKey: string;
+  audit: AuditContext;
+  sessionId?: string | null;
+  previousSegmentId?: string | null;
+  segmentIndex?: number;
+  source?: string;
+}): Promise<ExecutionListItem> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const replay = await reserveIdempotencyKey<{ id: string }>(client, {
+      key: params.idempotencyKey,
+      scope: "production.execution.start",
+      payload: { ...params.body, operator_user_id: params.operatorUserId },
+      user_id: params.audit.user_id,
+    });
+    if (replay.replayed) {
+      await client.query("COMMIT");
+      const existing = await repoGetExecution({ id: replay.body.id });
+      if (!existing) throw new HttpError(409, "PRODUCTION_EXECUTION_REPLAY_LOST", "Rejeu impossible.");
+      return existing;
+    }
+
+    const { of, operation } = await lockExecutionContext(client, {
+      of_id: params.body.of_id,
+      operation_id: params.body.operation_id ?? null,
+      operator_user_id: params.operatorUserId,
+      machine_id: params.body.machine_id ?? null,
+    });
+
+    assertOfExecutable(of.statut);
+    assertOperationExecutable(operation);
+    await assertMachineAvailable(client, params.body.machine_id);
+
+    const activity = await loadActivity(client, params.body.activity_code);
+    assertReasonProvided(activity, params.body.comment ?? params.body.retroactive_reason ?? null);
+
+    // Saisie rétroactive : bornée et motivée. Sans motif, on refuse plutôt que
+    // d'accepter silencieusement un horodatage fourni par le client.
+    const isRetroactive = Boolean(params.body.start_ts);
+    if (isRetroactive) {
+      if (!params.body.retroactive_reason) {
+        throw new HttpError(
+          422,
+          "PRODUCTION_EXECUTION_RETROACTIVE_REASON_REQUIRED",
+          "Une saisie rétroactive doit être motivée."
+        );
+      }
+      assertRetroactiveAllowed(params.body.start_ts as string, new Date().toISOString());
+    }
+
+    // Le type de ressource suit la catégorie si l'appelant ne l'impose pas :
+    // le référentiel gouverne, le client ne devine pas.
+    const timeType =
+      params.body.time_type ?? activity.legacy_time_type ?? ("OPERATEUR" as const);
+
+    // Contexte technique figé : la gamme peut être révisée pendant l'exécution,
+    // la déclaration doit rester lisible telle qu'elle a été faite.
+    const snapshot = {
+      captured_at: new Date().toISOString(),
+      of_numero: null as string | null,
+      operation_phase: operation?.phase ?? null,
+      activity_code: activity.code,
+      activity_label: activity.label,
+    };
+
+    const sessionId = params.sessionId ?? null;
+
+    const inserted = await client.query<{ id: string }>(
+      `
+        INSERT INTO public.production_pointages (
+          of_id, operation_id, affaire_id, piece_technique_id,
+          machine_id, poste_id, operator_user_id,
+          time_type, activity_code,
+          start_ts, status,
+          comment, session_id, previous_segment_id, segment_index,
+          source, idempotency_key, context_snapshot, is_retroactive,
+          created_for_other_reason,
+          created_by, updated_by
+        )
+        SELECT
+          $1::bigint,
+          $2::uuid,
+          o.affaire_id,
+          o.piece_technique_id,
+          $3::uuid, $4::uuid, $5::int,
+          $6::production_pointage_time_type, $7::text,
+          COALESCE($8::timestamptz, now()), 'RUNNING'::production_pointage_status,
+          $9, COALESCE($10::uuid, gen_random_uuid()), $11::uuid, $12::int,
+          $13::text, $14::text, $15::jsonb, $16::boolean,
+          $17,
+          $18::int, $18::int
+        FROM public.ordres_fabrication o
+        WHERE o.id = $1::bigint
+        RETURNING id::text AS id
+      `,
+      [
+        params.body.of_id,
+        params.body.operation_id ?? null,
+        params.body.machine_id ?? null,
+        params.body.poste_id ?? null,
+        params.operatorUserId,
+        timeType,
+        activity.code,
+        params.body.start_ts ?? null,
+        params.body.comment ?? null,
+        sessionId,
+        params.previousSegmentId ?? null,
+        params.segmentIndex ?? 1,
+        params.source ?? (isRetroactive ? "RETROACTIVE" : "CANONICAL"),
+        params.idempotencyKey,
+        JSON.stringify(snapshot),
+        isRetroactive,
+        params.body.for_other_reason ?? null,
+        params.audit.user_id,
+      ]
+    );
+
+    const id = inserted.rows[0]?.id;
+    if (!id) {
+      throw new HttpError(404, "OF_NOT_FOUND", "Ordre de fabrication introuvable.");
+    }
+
+    await insertExecutionEvent(client, {
+      pointage_id: id,
+      event_type: "START",
+      user_id: params.audit.user_id,
+      new_values: {
+        of_id: params.body.of_id,
+        operation_id: params.body.operation_id ?? null,
+        machine_id: params.body.machine_id ?? null,
+        activity_code: activity.code,
+        operator_user_id: params.operatorUserId,
+        is_retroactive: isRetroactive,
+      },
+      note: params.body.retroactive_reason ?? params.body.for_other_reason ?? null,
+    });
+
+    // L'OF passe EN_COURS au premier pointage : c'est le seul effet de bord
+    // toléré, il est explicite et audité.
+    if (["BROUILLON", "PLANIFIE", "EN_PAUSE"].includes(of.statut)) {
+      await client.query(
+        `
+          UPDATE public.ordres_fabrication
+          SET statut = 'EN_COURS'::of_status,
+              date_lancement_reelle = COALESCE(date_lancement_reelle, CURRENT_DATE),
+              updated_at = now(), updated_by = $2
+          WHERE id = $1::bigint
+        `,
+        [params.body.of_id, params.audit.user_id]
+      );
+    }
+
+    if (operation && operation.status !== "RUNNING") {
+      await client.query(
+        `
+          UPDATE public.of_operations
+          SET status = 'RUNNING'::of_operation_status,
+              started_at = COALESCE(started_at, now()),
+              updated_at = now()
+          WHERE id = $1::uuid
+        `,
+        [operation.id]
+      );
+    }
+
+    await insertAuditLog(client, params.audit, {
+      action: "production.execution.start",
+      entity_type: "production_pointages",
+      entity_id: id,
+      details: {
+        of_id: params.body.of_id,
+        operation_id: params.body.operation_id ?? null,
+        machine_id: params.body.machine_id ?? null,
+        activity_code: activity.code,
+        operator_user_id: params.operatorUserId,
+        on_behalf: params.operatorUserId !== params.audit.user_id,
+      },
+    });
+
+    await storeIdempotentResponse(client, params.idempotencyKey, { id });
+    await client.query("COMMIT");
+
+    const created = await repoGetExecution({ id });
+    if (!created) throw new HttpError(500, "PRODUCTION_EXECUTION_READ_BACK_FAILED", "Relecture impossible.");
+    return created;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    return translateConcurrencyError(err);
+  } finally {
+    client.release();
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Arrêt d'un segment                                                         */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Arrête le segment actif. NE TERMINE PAS l'opération et NE DÉCLARE AUCUNE
+ * quantité : ces deux effets relèvent de la commande atomique de fin
+ * d'opération, jamais d'un simple arrêt de timer.
+ */
+export async function repoStopExecution(params: {
+  id: string;
+  body: StopExecutionBodyDTO;
+  idempotencyKey: string;
+  actorRole: string | null | undefined;
+  audit: AuditContext;
+  eventType?: ExecutionEventType;
+}): Promise<ExecutionListItem> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const replay = await reserveIdempotencyKey<{ id: string }>(client, {
+      key: params.idempotencyKey,
+      scope: "production.execution.stop",
+      payload: { id: params.id, ...params.body },
+      user_id: params.audit.user_id,
+    });
+    if (replay.replayed) {
+      await client.query("COMMIT");
+      const existing = await repoGetExecution({ id: params.id });
+      if (!existing) throw new HttpError(409, "PRODUCTION_EXECUTION_REPLAY_LOST", "Rejeu impossible.");
+      return existing;
+    }
+
+    const current = await lockPointage(client, params.id);
+    assertOwnershipOrSupervision({
+      actorUserId: params.audit.user_id,
+      actorRole: params.actorRole,
+      ownerUserId: current.operator_user_id,
+      action: "arrêt",
+    });
+    assertMutable(current);
+
+    if (current.status !== "RUNNING") {
+      throw new HttpError(
+        409,
+        "PRODUCTION_EXECUTION_NOT_RUNNING",
+        "Ce pointage n'est pas en cours : il a déjà été arrêté."
+      );
+    }
+    assertExecutionTransition("RUNNING", "DONE");
+
+    if (params.body.end_ts && !params.body.retroactive_reason) {
+      throw new HttpError(
+        422,
+        "PRODUCTION_EXECUTION_RETROACTIVE_REASON_REQUIRED",
+        "Un horodatage d'arrêt imposé doit être motivé."
+      );
+    }
+    if (params.body.end_ts) {
+      const minutes = computeDurationMinutes(current.start_ts, params.body.end_ts);
+      assertPlausibleDuration(minutes);
+    }
+
+    const stopped = await client.query<{ duration_minutes: number | null }>(
+      `
+        UPDATE public.production_pointages
+        SET status = 'DONE'::production_pointage_status,
+            end_ts = COALESCE($2::timestamptz, now()),
+            comment = COALESCE($3, comment),
+            updated_at = now(),
+            updated_by = $4::int
+        WHERE id = $1::uuid AND status = 'RUNNING'
+        RETURNING duration_minutes
+      `,
+      [params.id, params.body.end_ts ?? null, params.body.comment ?? null, params.audit.user_id]
+    );
+
+    if (!stopped.rows[0]) {
+      // Une autre requête a arrêté le pointage entre le verrou et l'UPDATE.
+      throw new HttpError(
+        409,
+        "PRODUCTION_EXECUTION_ALREADY_STOPPED",
+        "Ce pointage vient d'être arrêté par une autre action."
+      );
+    }
+
+    await insertExecutionEvent(client, {
+      pointage_id: params.id,
+      event_type: params.eventType ?? "STOP",
+      user_id: params.audit.user_id,
+      old_values: { status: "RUNNING" },
+      new_values: { status: "DONE", duration_minutes: stopped.rows[0].duration_minutes },
+      note: params.body.retroactive_reason ?? null,
+    });
+
+    // Source unique du temps réel : recalcul complet, jamais incrémental.
+    if (current.operation_id) {
+      await client.query(`SELECT public.fn_production_recompute_operation_real_time($1::uuid)`, [
+        current.operation_id,
+      ]);
+    }
+
+    await insertAuditLog(client, params.audit, {
+      action: "production.execution.stop",
+      entity_type: "production_pointages",
+      entity_id: params.id,
+      details: {
+        of_id: current.of_id,
+        operation_id: current.operation_id,
+        duration_minutes: stopped.rows[0].duration_minutes,
+      },
+    });
+
+    await storeIdempotentResponse(client, params.idempotencyKey, { id: params.id });
+    await client.query("COMMIT");
+
+    const updated = await repoGetExecution({ id: params.id });
+    if (!updated) throw new HttpError(500, "PRODUCTION_EXECUTION_READ_BACK_FAILED", "Relecture impossible.");
+    return updated;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    return translateConcurrencyError(err);
+  } finally {
+    client.release();
+  }
+}
+
+type LockedPointage = {
+  id: string;
+  of_id: number;
+  operation_id: string | null;
+  machine_id: string | null;
+  poste_id: string | null;
+  operator_user_id: number;
+  activity_code: string | null;
+  time_type: string;
+  status: "RUNNING" | "DONE" | "CANCELLED" | "CORRECTED";
+  start_ts: string;
+  end_ts: string | null;
+  session_id: string | null;
+  segment_index: number;
+  validated_at: string | null;
+  submitted_at: string | null;
+};
+
+async function lockPointage(tx: DbQueryer, id: string): Promise<LockedPointage> {
+  const res = await tx.query<LockedPointage>(
+    `
+      SELECT id::text AS id, of_id::int AS of_id, operation_id::text AS operation_id,
+             machine_id::text AS machine_id, poste_id::text AS poste_id,
+             operator_user_id, activity_code, time_type::text AS time_type,
+             status::text AS status, start_ts, end_ts,
+             session_id::text AS session_id, segment_index,
+             validated_at, submitted_at
+      FROM public.production_pointages
+      WHERE id = $1::uuid
+      FOR UPDATE
+    `,
+    [id]
+  );
+  const row = res.rows[0];
+  if (!row) {
+    throw new HttpError(404, "PRODUCTION_EXECUTION_NOT_FOUND", "Pointage introuvable.", { id });
+  }
+  return row;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Pause / reprise / changement — segments immuables                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Un changement (activité, machine, opérateur) ou une pause CLÔTURE le segment
+ * courant et en OUVRE un nouveau. Aucun segment passé n'est réécrit : c'est ce
+ * qui rend l'historique opposable.
+ */
+export async function repoTransitionSegment(params: {
+  id: string;
+  kind: "PAUSE" | "RESUME" | "CHANGE" | "INCIDENT";
+  body: PauseExecutionBodyDTO | ResumeExecutionBodyDTO | ChangeExecutionBodyDTO | IncidentExecutionBodyDTO;
+  idempotencyKey: string;
+  actorRole: string | null | undefined;
+  audit: AuditContext;
+}): Promise<ExecutionListItem> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const replay = await reserveIdempotencyKey<{ id: string }>(client, {
+      key: params.idempotencyKey,
+      scope: `production.execution.${params.kind.toLowerCase()}`,
+      payload: { id: params.id, ...params.body },
+      user_id: params.audit.user_id,
+    });
+    if (replay.replayed) {
+      await client.query("COMMIT");
+      const existing = await repoGetExecution({ id: replay.body.id });
+      if (!existing) throw new HttpError(409, "PRODUCTION_EXECUTION_REPLAY_LOST", "Rejeu impossible.");
+      return existing;
+    }
+
+    const current = await lockPointage(client, params.id);
+    assertOwnershipOrSupervision({
+      actorUserId: params.audit.user_id,
+      actorRole: params.actorRole,
+      ownerUserId: current.operator_user_id,
+      action: params.kind.toLowerCase(),
+    });
+    assertMutable(current);
+
+    if (current.status !== "RUNNING") {
+      throw new HttpError(
+        409,
+        "PRODUCTION_EXECUTION_NOT_RUNNING",
+        "Ce pointage n'est pas en cours : aucune transition possible."
+      );
+    }
+
+    const body = params.body as ChangeExecutionBodyDTO & IncidentExecutionBodyDTO;
+
+    // 1) Clôture du segment courant. La convention [début, fin) garantit que la
+    // minute de bascule n'est comptée qu'une fois.
+    const closed = await client.query<{ duration_minutes: number | null; end_ts: string }>(
+      `
+        UPDATE public.production_pointages
+        SET status = 'DONE'::production_pointage_status,
+            end_ts = now(),
+            updated_at = now(),
+            updated_by = $2::int
+        WHERE id = $1::uuid AND status = 'RUNNING'
+        RETURNING duration_minutes, end_ts
+      `,
+      [params.id, params.audit.user_id]
+    );
+    if (!closed.rows[0]) {
+      throw new HttpError(
+        409,
+        "PRODUCTION_EXECUTION_ALREADY_STOPPED",
+        "Ce pointage vient d'être arrêté par une autre action."
+      );
+    }
+
+    const eventType: ExecutionEventType =
+      params.kind === "PAUSE"
+        ? "PAUSE"
+        : params.kind === "RESUME"
+          ? "RESUME"
+          : params.kind === "INCIDENT"
+            ? "INCIDENT"
+            : body.operator_user_id !== undefined
+              ? "CHANGE_OPERATOR"
+              : body.machine_id !== undefined
+                ? "CHANGE_MACHINE"
+                : "CHANGE_ACTIVITY";
+
+    await insertExecutionEvent(client, {
+      pointage_id: params.id,
+      event_type: eventType,
+      user_id: params.audit.user_id,
+      old_values: {
+        activity_code: current.activity_code,
+        machine_id: current.machine_id,
+        operator_user_id: current.operator_user_id,
+      },
+      new_values: {
+        activity_code: body.activity_code ?? current.activity_code,
+        machine_id: body.machine_id === undefined ? current.machine_id : body.machine_id,
+        operator_user_id: body.operator_user_id ?? current.operator_user_id,
+        closed_duration_minutes: closed.rows[0].duration_minutes,
+      },
+      note: body.reason ?? body.comment ?? null,
+    });
+
+    if (current.operation_id) {
+      await client.query(`SELECT public.fn_production_recompute_operation_real_time($1::uuid)`, [
+        current.operation_id,
+      ]);
+    }
+
+    // 2) Une PAUSE n'ouvre pas de nouveau segment de travail : le temps
+    // s'arrête. La reprise en ouvrira un.
+    let nextId: string | null = null;
+    if (params.kind !== "PAUSE") {
+      const nextActivityCode = body.activity_code ?? current.activity_code ?? "PRODUCTION";
+      const activity = await loadActivity(client, nextActivityCode);
+      if (params.kind === "INCIDENT") {
+        assertReasonProvided(activity, body.reason ?? null);
+      }
+
+      const nextOperator = body.operator_user_id ?? current.operator_user_id;
+      const nextMachine = body.machine_id === undefined ? current.machine_id : body.machine_id;
+      await assertMachineAvailable(client, nextMachine);
+
+      // Verrou sur le nouvel opérateur/nouvelle machine avant insertion.
+      await client.query(
+        `SELECT id FROM public.production_pointages WHERE operator_user_id = $1::int AND status = 'RUNNING' FOR UPDATE`,
+        [nextOperator]
+      );
+
+      const ins = await client.query<{ id: string }>(
+        `
+          INSERT INTO public.production_pointages (
+            of_id, operation_id, affaire_id, piece_technique_id,
+            machine_id, poste_id, operator_user_id,
+            time_type, activity_code, start_ts, status, comment,
+            session_id, previous_segment_id, segment_index, source,
+            context_snapshot, created_by, updated_by
+          )
+          SELECT
+            p.of_id, p.operation_id, p.affaire_id, p.piece_technique_id,
+            $2::uuid, COALESCE($3::uuid, p.poste_id), $4::int,
+            COALESCE($5::production_pointage_time_type, p.time_type),
+            $6::text,
+            p.end_ts,
+            'RUNNING'::production_pointage_status,
+            $7,
+            COALESCE(p.session_id, p.id),
+            p.id,
+            p.segment_index + 1,
+            'CANONICAL',
+            p.context_snapshot,
+            $8::int, $8::int
+          FROM public.production_pointages p
+          WHERE p.id = $1::uuid
+          RETURNING id::text AS id
+        `,
+        [
+          params.id,
+          nextMachine,
+          body.poste_id === undefined ? null : body.poste_id,
+          nextOperator,
+          activity.legacy_time_type,
+          activity.code,
+          body.comment ?? null,
+          params.audit.user_id,
+        ]
+      );
+      nextId = ins.rows[0]?.id ?? null;
+
+      if (nextId) {
+        await insertExecutionEvent(client, {
+          pointage_id: nextId,
+          event_type: params.kind === "RESUME" ? "RESUME" : "START",
+          user_id: params.audit.user_id,
+          new_values: {
+            activity_code: activity.code,
+            machine_id: nextMachine,
+            operator_user_id: nextOperator,
+            previous_segment_id: params.id,
+          },
+          note: body.reason ?? null,
+        });
+      }
+    }
+
+    // 3) Un aléa qui arrête la machine la signale, sans jamais contourner une
+    // maintenance ni écrire dans le parc machine.
+    await insertAuditLog(client, params.audit, {
+      action: `production.execution.${params.kind.toLowerCase()}`,
+      entity_type: "production_pointages",
+      entity_id: params.id,
+      details: {
+        of_id: current.of_id,
+        operation_id: current.operation_id,
+        next_pointage_id: nextId,
+        activity_code: body.activity_code ?? current.activity_code,
+        stops_machine: Boolean(body.stops_machine),
+        reason: body.reason ?? null,
+      },
+    });
+
+    const responseId = nextId ?? params.id;
+    await storeIdempotentResponse(client, params.idempotencyKey, { id: responseId });
+    await client.query("COMMIT");
+
+    const result = await repoGetExecution({ id: responseId });
+    if (!result) throw new HttpError(500, "PRODUCTION_EXECUTION_READ_BACK_FAILED", "Relecture impossible.");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    return translateConcurrencyError(err);
+  } finally {
+    client.release();
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Fin d'opération — commande métier atomique                                 */
+/* -------------------------------------------------------------------------- */
+
+export type FinishOperationPreview = {
+  of: { id: number; numero: string; quantite_lancee: number; quantite_bonne: number; quantite_rebut: number };
+  operation: { id: string; phase: number; designation: string; status: string; temps_total_real: number };
+  active_segment: { id: string; elapsed_minutes: number } | null;
+  declared: { qty_good: number; qty_scrap: number; qty_rework: number; qty_pending_control: number };
+  already_declared: { qty_good: number; qty_scrap: number; qty_rework: number };
+  remaining_before: number;
+  remaining_after: number;
+  will_stop_segment: boolean;
+  will_complete_operation: boolean;
+  requires_quality_decision: boolean;
+  warnings: string[];
+  /** Empreinte de l'aperçu : la confirmation doit la présenter à l'identique. */
+  preview_hash: string;
+};
+
+async function buildFinishPreview(
+  tx: DbQueryer,
+  params: { body: FinishOperationPreviewBodyDTO; operatorUserId: number }
+): Promise<FinishOperationPreview> {
+  const ofRes = await tx.query(
+    `
+      SELECT o.id, o.numero, o.quantite_lancee::float8 AS quantite_lancee,
+             o.quantite_bonne::float8 AS quantite_bonne, o.quantite_rebut::float8 AS quantite_rebut
+      FROM public.ordres_fabrication o WHERE o.id = $1::bigint
+    `,
+    [params.body.of_id]
+  );
+  const of = ofRes.rows[0];
+  if (!of) throw new HttpError(404, "OF_NOT_FOUND", "Ordre de fabrication introuvable.");
+
+  const opRes = await tx.query(
+    `
+      SELECT op.id::text AS id, op.phase, op.designation, op.status::text AS status,
+             op.temps_total_real::float8 AS temps_total_real, op.of_id::int AS of_id
+      FROM public.of_operations op WHERE op.id = $1::uuid
+    `,
+    [params.body.operation_id]
+  );
+  const operation = opRes.rows[0];
+  if (!operation) throw new HttpError(404, "OF_OPERATION_NOT_FOUND", "Opération introuvable.");
+  if (Number(operation.of_id) !== Number(params.body.of_id)) {
+    throw new HttpError(
+      422,
+      "PRODUCTION_EXECUTION_OPERATION_MISMATCH",
+      "Cette opération n'appartient pas à l'ordre de fabrication indiqué."
+    );
+  }
+
+  const activeRes = await tx.query(
+    `
+      SELECT id::text AS id,
+             GREATEST(0, ROUND(EXTRACT(EPOCH FROM (now() - start_ts)) / 60.0)::int) AS elapsed_minutes
+      FROM public.production_pointages
+      WHERE operation_id = $1::uuid AND operator_user_id = $2::int AND status = 'RUNNING'
+      ORDER BY start_ts DESC LIMIT 1
+    `,
+    [params.body.operation_id, params.operatorUserId]
+  );
+
+  const declaredRes = await tx.query(
+    `
+      SELECT COALESCE(SUM(qty_good), 0)::float8 AS qty_good,
+             COALESCE(SUM(qty_scrap), 0)::float8 AS qty_scrap,
+             COALESCE(SUM(qty_rework), 0)::float8 AS qty_rework
+      FROM public.production_quantity_declarations
+      WHERE operation_id = $1::uuid
+    `,
+    [params.body.operation_id]
+  );
+
+  const declared = {
+    qty_good: params.body.qty_good ?? 0,
+    qty_scrap: params.body.qty_scrap ?? 0,
+    qty_rework: params.body.qty_rework ?? 0,
+    qty_pending_control: params.body.qty_pending_control ?? 0,
+  };
+  const already = {
+    qty_good: Number(declaredRes.rows[0]?.qty_good ?? 0),
+    qty_scrap: Number(declaredRes.rows[0]?.qty_scrap ?? 0),
+    qty_rework: Number(declaredRes.rows[0]?.qty_rework ?? 0),
+  };
+
+  const remainingBefore = Number(of.quantite_lancee) - already.qty_good - already.qty_scrap;
+  const remainingAfter = remainingBefore - declared.qty_good - declared.qty_scrap;
+
+  const warnings: string[] = [];
+  if (declared.qty_scrap > 0) {
+    warnings.push(
+      "Le rebut déclaré sera transmis à la Qualité pour décision. Aucune non-conformité n'est créée automatiquement ici."
+    );
+  }
+  if (declared.qty_pending_control > 0) {
+    warnings.push("Les quantités en attente de contrôle ne sont pas disponibles en stock.");
+  }
+  if (remainingAfter < 0) {
+    warnings.push("Cette déclaration dépasse le restant de l'ordre de fabrication.");
+  }
+  warnings.push(
+    "Aucune entrée en stock n'est créée : la mise en stock passe par la réception de production."
+  );
+
+  const preview = {
+    of: {
+      id: Number(of.id),
+      numero: of.numero as string,
+      quantite_lancee: Number(of.quantite_lancee),
+      quantite_bonne: Number(of.quantite_bonne),
+      quantite_rebut: Number(of.quantite_rebut),
+    },
+    operation: {
+      id: operation.id as string,
+      phase: Number(operation.phase),
+      designation: operation.designation as string,
+      status: operation.status as string,
+      temps_total_real: Number(operation.temps_total_real),
+    },
+    active_segment: activeRes.rows[0]
+      ? { id: activeRes.rows[0].id as string, elapsed_minutes: Number(activeRes.rows[0].elapsed_minutes) }
+      : null,
+    declared,
+    already_declared: already,
+    remaining_before: remainingBefore,
+    remaining_after: remainingAfter,
+    will_stop_segment: Boolean(params.body.stop_active_segment) && Boolean(activeRes.rows[0]),
+    will_complete_operation: Boolean(params.body.complete_operation),
+    requires_quality_decision: declared.qty_scrap > 0 || declared.qty_pending_control > 0,
+    warnings,
+  };
+
+  // L'empreinte couvre l'état serveur ET l'intention : si l'un des deux bouge,
+  // la confirmation est refusée plutôt qu'appliquée sur des données périmées.
+  const preview_hash = fingerprintPayload("production.execution.finish", {
+    of: preview.of,
+    operation: preview.operation,
+    declared: preview.declared,
+    already_declared: preview.already_declared,
+    active_segment_id: preview.active_segment?.id ?? null,
+    will_complete_operation: preview.will_complete_operation,
+  });
+
+  return { ...preview, preview_hash };
+}
+
+export async function repoPreviewFinishOperation(params: {
+  body: FinishOperationPreviewBodyDTO;
+  operatorUserId: number;
+}): Promise<FinishOperationPreview> {
+  return buildFinishPreview(pool, params);
+}
+
+/**
+ * Fin d'opération en UNE transaction : verrous, arrêt du segment, validation
+ * des quantités, déclaration immuable, progression, transition d'état, recalcul
+ * du temps, audit. L'échec d'une étape n'en laisse aucune appliquée.
+ */
+export async function repoFinishOperation(params: {
+  body: FinishOperationBodyDTO;
+  operatorUserId: number;
+  idempotencyKey: string;
+  actorRole: string | null | undefined;
+  audit: AuditContext;
+}): Promise<{ preview: FinishOperationPreview; declaration_id: string | null; operation_status: string }> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const replay = await reserveIdempotencyKey<{
+      preview: FinishOperationPreview;
+      declaration_id: string | null;
+      operation_status: string;
+    }>(client, {
+      key: params.idempotencyKey,
+      scope: "production.execution.finish",
+      payload: params.body,
+      user_id: params.audit.user_id,
+    });
+    if (replay.replayed) {
+      await client.query("COMMIT");
+      return replay.body;
+    }
+
+    await lockExecutionContext(client, {
+      of_id: params.body.of_id,
+      operation_id: params.body.operation_id,
+      operator_user_id: params.operatorUserId,
+    });
+
+    // Aperçu recalculé SOUS VERROU : c'est lui qui fait foi, pas celui affiché.
+    const preview = await buildFinishPreview(client, {
+      body: params.body,
+      operatorUserId: params.operatorUserId,
+    });
+
+    if (preview.preview_hash !== params.body.preview_hash) {
+      throw new HttpError(
+        409,
+        "PRODUCTION_EXECUTION_PREVIEW_STALE",
+        "L'état a changé depuis l'aperçu : rechargez et vérifiez avant de confirmer.",
+        { expected: preview.preview_hash }
+      );
+    }
+
+    const delta = preview.declared;
+    assertFiniteQuantities(delta);
+
+    if (delta.qty_scrap > 0 && !params.body.scrap_reason_code) {
+      throw new HttpError(
+        422,
+        "PRODUCTION_QUANTITY_SCRAP_REASON_REQUIRED",
+        "Une cause de rebut est obligatoire.",
+        { details: { fields: { scrap_reason_code: ["Sélectionnez une cause de rebut."] } } }
+      );
+    }
+    if (delta.qty_rework > 0 && !params.body.rework_reason_code) {
+      throw new HttpError(
+        422,
+        "PRODUCTION_QUANTITY_REWORK_REASON_REQUIRED",
+        "Une cause de reprise est obligatoire.",
+        { details: { fields: { rework_reason_code: ["Sélectionnez une cause de reprise."] } } }
+      );
+    }
+
+    // Surproduction : interdite sauf tolérance explicite ET motif.
+    assertWithinRemaining({
+      declared: delta.qty_good + delta.qty_scrap,
+      alreadyDeclared: preview.already_declared.qty_good + preview.already_declared.qty_scrap,
+      quantityTarget: preview.of.quantite_lancee,
+      overproductionTolerance: 0,
+      reason: params.body.overproduction_reason ?? null,
+    });
+
+    // 1) Arrêt du segment actif, dans la même transaction.
+    if (preview.will_stop_segment && preview.active_segment) {
+      const stopped = await client.query(
+        `
+          UPDATE public.production_pointages
+          SET status = 'DONE'::production_pointage_status, end_ts = now(),
+              updated_at = now(), updated_by = $2::int
+          WHERE id = $1::uuid AND status = 'RUNNING'
+          RETURNING duration_minutes
+        `,
+        [preview.active_segment.id, params.audit.user_id]
+      );
+      if (!stopped.rows[0]) {
+        throw new HttpError(
+          409,
+          "PRODUCTION_EXECUTION_ALREADY_STOPPED",
+          "Le pointage vient d'être arrêté par une autre action : rechargez."
+        );
+      }
+      await insertExecutionEvent(client, {
+        pointage_id: preview.active_segment.id,
+        event_type: "STOP",
+        user_id: params.audit.user_id,
+        new_values: { status: "DONE", via: "finish_operation" },
+      });
+    }
+
+    // 2) Déclaration immuable en deltas.
+    let declarationId: string | null = null;
+    const hasQuantities =
+      delta.qty_good > 0 || delta.qty_scrap > 0 || delta.qty_rework > 0 || delta.qty_pending_control > 0;
+
+    if (hasQuantities) {
+      const ins = await client.query<{ id: string }>(
+        `
+          INSERT INTO public.production_quantity_declarations (
+            pointage_id, of_id, operation_id,
+            qty_good, qty_scrap, qty_rework, qty_pending_control,
+            unite, scrap_reason_code, rework_reason_code, note,
+            idempotency_key, declared_by
+          )
+          VALUES ($1::uuid, $2::bigint, $3::uuid, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::int)
+          RETURNING id::text AS id
+        `,
+        [
+          preview.active_segment?.id ?? null,
+          params.body.of_id,
+          params.body.operation_id,
+          delta.qty_good,
+          delta.qty_scrap,
+          delta.qty_rework,
+          delta.qty_pending_control,
+          params.body.unite ?? null,
+          params.body.scrap_reason_code ?? null,
+          params.body.rework_reason_code ?? null,
+          params.body.note ?? null,
+          `${params.idempotencyKey}:declaration`,
+          params.audit.user_id,
+        ]
+      );
+      declarationId = ins.rows[0]?.id ?? null;
+
+      if (preview.active_segment?.id && declarationId) {
+        await insertExecutionEvent(client, {
+          pointage_id: preview.active_segment.id,
+          event_type: "DECLARE_QUANTITY",
+          user_id: params.audit.user_id,
+          new_values: { declaration_id: declarationId, ...delta },
+          note: params.body.note ?? null,
+        });
+      }
+
+      // 3) Progression cumulée de l'OF. Les quantités en attente de contrôle
+      // n'y entrent PAS : elles ne sont ni bonnes ni rebutées tant que la
+      // Qualité n'a pas décidé.
+      await client.query(
+        `
+          UPDATE public.ordres_fabrication
+          SET quantite_bonne = quantite_bonne + $2,
+              quantite_rebut = quantite_rebut + $3,
+              updated_at = now(), updated_by = $4::int
+          WHERE id = $1::bigint
+        `,
+        [params.body.of_id, delta.qty_good, delta.qty_scrap, params.audit.user_id]
+      );
+    }
+
+    // 4) Recalcul du temps réel depuis la source unique.
+    await client.query(`SELECT public.fn_production_recompute_operation_real_time($1::uuid)`, [
+      params.body.operation_id,
+    ]);
+
+    // 5) Transition d'état de l'opération, seulement si demandée.
+    let operationStatus = preview.operation.status;
+    if (params.body.complete_operation) {
+      if (preview.operation.status === "DONE") {
+        throw new HttpError(
+          409,
+          "OF_OPERATION_ALREADY_DONE",
+          "Cette opération est déjà déclarée terminée."
+        );
+      }
+      const stillRunning = await client.query<{ n: string }>(
+        `
+          SELECT count(*)::text AS n FROM public.production_pointages
+          WHERE operation_id = $1::uuid AND status = 'RUNNING'
+        `,
+        [params.body.operation_id]
+      );
+      if (Number(stillRunning.rows[0]?.n ?? 0) > 0) {
+        throw new HttpError(
+          409,
+          "PRODUCTION_EXECUTION_STILL_RUNNING",
+          "Des pointages sont encore en cours sur cette opération : arrêtez-les avant de la terminer."
+        );
+      }
+      await client.query(
+        `
+          UPDATE public.of_operations
+          SET status = 'DONE'::of_operation_status, ended_at = now(), updated_at = now()
+          WHERE id = $1::uuid
+        `,
+        [params.body.operation_id]
+      );
+      operationStatus = "DONE";
+    }
+
+    await insertAuditLog(client, params.audit, {
+      action: "production.execution.finish-operation",
+      entity_type: "of_operations",
+      entity_id: params.body.operation_id,
+      details: {
+        of_id: params.body.of_id,
+        declaration_id: declarationId,
+        ...delta,
+        completed: params.body.complete_operation ?? false,
+        requires_quality_decision: preview.requires_quality_decision,
+        // Traçabilité explicite de ce qui N'A PAS été fait : aucune entrée en
+        // stock, aucun lot, aucune NC créés par cette commande.
+        no_stock_movement: true,
+        no_lot_created: true,
+        no_non_conformity_created: true,
+      },
+    });
+
+    const result = { preview, declaration_id: declarationId, operation_status: operationStatus };
+    await storeIdempotentResponse(client, params.idempotencyKey, result);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    return translateConcurrencyError(err);
+  } finally {
+    client.release();
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Déclaration de quantité isolée                                             */
+/* -------------------------------------------------------------------------- */
+
+export async function repoDeclareQuantity(params: {
+  body: DeclareQuantityBodyDTO;
+  idempotencyKey: string;
+  audit: AuditContext;
+}): Promise<{ id: string }> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const replay = await reserveIdempotencyKey<{ id: string }>(client, {
+      key: params.idempotencyKey,
+      scope: "production.execution.declare-quantity",
+      payload: params.body,
+      user_id: params.audit.user_id,
+    });
+    if (replay.replayed) {
+      await client.query("COMMIT");
+      return replay.body;
+    }
+
+    await lockExecutionContext(client, {
+      of_id: params.body.of_id,
+      operation_id: params.body.operation_id ?? null,
+      operator_user_id: params.audit.user_id,
+    });
+
+    const delta = {
+      qty_good: params.body.qty_good ?? 0,
+      qty_scrap: params.body.qty_scrap ?? 0,
+      qty_rework: params.body.qty_rework ?? 0,
+      qty_pending_control: params.body.qty_pending_control ?? 0,
+    };
+    assertFiniteQuantities(delta);
+
+    if (delta.qty_scrap > 0 && !params.body.scrap_reason_code) {
+      throw new HttpError(422, "PRODUCTION_QUANTITY_SCRAP_REASON_REQUIRED", "Une cause de rebut est obligatoire.");
+    }
+    if (delta.qty_rework > 0 && !params.body.rework_reason_code) {
+      throw new HttpError(422, "PRODUCTION_QUANTITY_REWORK_REASON_REQUIRED", "Une cause de reprise est obligatoire.");
+    }
+
+    const ins = await client.query<{ id: string }>(
+      `
+        INSERT INTO public.production_quantity_declarations (
+          pointage_id, of_id, operation_id,
+          qty_good, qty_scrap, qty_rework, qty_pending_control,
+          unite, scrap_reason_code, rework_reason_code, note,
+          idempotency_key, declared_by
+        )
+        VALUES ($1::uuid, $2::bigint, $3::uuid, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13::int)
+        RETURNING id::text AS id
+      `,
+      [
+        params.body.pointage_id ?? null,
+        params.body.of_id,
+        params.body.operation_id ?? null,
+        delta.qty_good,
+        delta.qty_scrap,
+        delta.qty_rework,
+        delta.qty_pending_control,
+        params.body.unite ?? null,
+        params.body.scrap_reason_code ?? null,
+        params.body.rework_reason_code ?? null,
+        params.body.note ?? null,
+        params.idempotencyKey,
+        params.audit.user_id,
+      ]
+    );
+    const id = ins.rows[0]!.id;
+
+    await client.query(
+      `
+        UPDATE public.ordres_fabrication
+        SET quantite_bonne = quantite_bonne + $2, quantite_rebut = quantite_rebut + $3,
+            updated_at = now(), updated_by = $4::int
+        WHERE id = $1::bigint
+      `,
+      [params.body.of_id, delta.qty_good, delta.qty_scrap, params.audit.user_id]
+    );
+
+    if (params.body.pointage_id) {
+      await insertExecutionEvent(client, {
+        pointage_id: params.body.pointage_id,
+        event_type: "DECLARE_QUANTITY",
+        user_id: params.audit.user_id,
+        new_values: { declaration_id: id, ...delta },
+        note: params.body.note ?? null,
+      });
+    }
+
+    await insertAuditLog(client, params.audit, {
+      action: "production.execution.declare-quantity",
+      entity_type: "production_quantity_declarations",
+      entity_id: id,
+      details: { of_id: params.body.of_id, operation_id: params.body.operation_id ?? null, ...delta, no_stock_movement: true },
+    });
+
+    await storeIdempotentResponse(client, params.idempotencyKey, { id });
+    await client.query("COMMIT");
+    return { id };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    return translateConcurrencyError(err);
+  } finally {
+    client.release();
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Cycle de validation                                                        */
+/* -------------------------------------------------------------------------- */
+
+export async function repoSubmitExecution(params: {
+  id: string;
+  note: string | null;
+  actorRole: string | null | undefined;
+  audit: AuditContext;
+}): Promise<ExecutionListItem> {
+  return simpleTransition({
+    ...params,
+    action: "submit",
+    apply: async (client, current) => {
+      if (current.status !== "DONE") {
+        throw new HttpError(
+          409,
+          "PRODUCTION_EXECUTION_NOT_STOPPED",
+          "Arrêtez le pointage avant de le soumettre."
+        );
+      }
+      assertOwnershipOrSupervision({
+        actorUserId: params.audit.user_id,
+        actorRole: params.actorRole,
+        ownerUserId: current.operator_user_id,
+        action: "soumission",
+      });
+      await client.query(
+        `
+          UPDATE public.production_pointages
+          SET submitted_at = now(), submitted_by = $2::int,
+              rejected_at = NULL, rejected_by = NULL, rejection_reason = NULL,
+              updated_at = now(), updated_by = $2::int
+          WHERE id = $1::uuid
+        `,
+        [params.id, params.audit.user_id]
+      );
+      return { event: "SUBMIT" as const, details: {} };
+    },
+  });
+}
+
+export async function repoValidateExecution(params: {
+  id: string;
+  note: string | null;
+  actorRole: string | null | undefined;
+  audit: AuditContext;
+}): Promise<ExecutionListItem> {
+  return simpleTransition({
+    ...params,
+    action: "validate",
+    apply: async (client, current) => {
+      if (current.status !== "DONE") {
+        throw new HttpError(
+          409,
+          "PRODUCTION_EXECUTION_NOT_STOPPED",
+          "Un pointage en cours ne peut pas être validé."
+        );
+      }
+      // Séparation des tâches : on ne valide pas son propre travail.
+      assertSeparationOfDuties({
+        actorUserId: params.audit.user_id,
+        ownerUserId: current.operator_user_id,
+        actorRole: params.actorRole,
+      });
+      await client.query(
+        `
+          UPDATE public.production_pointages
+          SET validated_at = now(), validated_by = $2::int,
+              rejected_at = NULL, rejected_by = NULL, rejection_reason = NULL,
+              updated_at = now(), updated_by = $2::int
+          WHERE id = $1::uuid AND validated_at IS NULL
+        `,
+        [params.id, params.audit.user_id]
+      );
+      if (current.operation_id) {
+        await client.query(`SELECT public.fn_production_recompute_operation_real_time($1::uuid)`, [
+          current.operation_id,
+        ]);
+      }
+      return { event: "VALIDATE" as const, details: {} };
+    },
+  });
+}
+
+export async function repoRejectExecution(params: {
+  id: string;
+  reason: string;
+  actorRole: string | null | undefined;
+  audit: AuditContext;
+}): Promise<ExecutionListItem> {
+  return simpleTransition({
+    id: params.id,
+    note: params.reason,
+    actorRole: params.actorRole,
+    audit: params.audit,
+    action: "reject",
+    apply: async (client, current) => {
+      assertSeparationOfDuties({
+        actorUserId: params.audit.user_id,
+        ownerUserId: current.operator_user_id,
+        actorRole: params.actorRole,
+      });
+      await client.query(
+        `
+          UPDATE public.production_pointages
+          SET rejected_at = now(), rejected_by = $2::int, rejection_reason = $3,
+              updated_at = now(), updated_by = $2::int
+          WHERE id = $1::uuid
+        `,
+        [params.id, params.audit.user_id, params.reason]
+      );
+      return { event: "REJECT" as const, details: { reason: params.reason } };
+    },
+  });
+}
+
+export async function repoCancelExecution(params: {
+  id: string;
+  reason: string;
+  actorRole: string | null | undefined;
+  audit: AuditContext;
+}): Promise<ExecutionListItem> {
+  return simpleTransition({
+    id: params.id,
+    note: params.reason,
+    actorRole: params.actorRole,
+    audit: params.audit,
+    action: "cancel",
+    apply: async (client, current) => {
+      assertExecutionTransition(current.status, "CANCELLED");
+      // Annulation NON destructive : la ligne reste, son statut change et le
+      // temps cesse d'être compté.
+      await client.query(
+        `
+          UPDATE public.production_pointages
+          SET status = 'CANCELLED'::production_pointage_status,
+              end_ts = COALESCE(end_ts, now()),
+              correction_reason = $3,
+              updated_at = now(), updated_by = $2::int
+          WHERE id = $1::uuid
+        `,
+        [params.id, params.audit.user_id, params.reason]
+      );
+      if (current.operation_id) {
+        await client.query(`SELECT public.fn_production_recompute_operation_real_time($1::uuid)`, [
+          current.operation_id,
+        ]);
+      }
+      return { event: "CANCEL" as const, details: { reason: params.reason } };
+    },
+  });
+}
+
+async function simpleTransition(params: {
+  id: string;
+  note: string | null;
+  actorRole: string | null | undefined;
+  audit: AuditContext;
+  action: string;
+  apply: (
+    client: PoolClient,
+    current: LockedPointage
+  ) => Promise<{ event: ExecutionEventType; details: Record<string, unknown> }>;
+}): Promise<ExecutionListItem> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const current = await lockPointage(client, params.id);
+    assertMutable(current);
+
+    const { event, details } = await params.apply(client, current);
+
+    await insertExecutionEvent(client, {
+      pointage_id: params.id,
+      event_type: event,
+      user_id: params.audit.user_id,
+      old_values: { status: current.status, validated_at: current.validated_at },
+      new_values: details,
+      note: params.note,
+    });
+
+    await insertAuditLog(client, params.audit, {
+      action: `production.execution.${params.action}`,
+      entity_type: "production_pointages",
+      entity_id: params.id,
+      details: { of_id: current.of_id, operation_id: current.operation_id, ...details },
+    });
+
+    await client.query("COMMIT");
+    const updated = await repoGetExecution({ id: params.id });
+    if (!updated) throw new HttpError(500, "PRODUCTION_EXECUTION_READ_BACK_FAILED", "Relecture impossible.");
+    return updated;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    return translateConcurrencyError(err);
+  } finally {
+    client.release();
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Correction — version liée, l'original reste visible                        */
+/* -------------------------------------------------------------------------- */
+
+export async function repoCorrectExecution(params: {
+  id: string;
+  correction_reason: string;
+  patch: Record<string, unknown>;
+  actorRole: string | null | undefined;
+  audit: AuditContext;
+}): Promise<ExecutionListItem> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const current = await lockPointage(client, params.id);
+    assertMutable(current);
+    if (current.status === "RUNNING") {
+      throw new HttpError(
+        409,
+        "PRODUCTION_EXECUTION_RUNNING_NOT_CORRECTABLE",
+        "Arrêtez le pointage avant de le corriger."
+      );
+    }
+
+    const patch = params.patch as {
+      start_ts?: string;
+      end_ts?: string | null;
+      activity_code?: string;
+      machine_id?: string | null;
+      poste_id?: string | null;
+      operation_id?: string | null;
+      comment?: string | null;
+    };
+
+    if (patch.activity_code) await loadActivity(client, patch.activity_code);
+    if (patch.start_ts && patch.end_ts) {
+      assertPlausibleDuration(computeDurationMinutes(patch.start_ts, patch.end_ts));
+    }
+
+    // L'original bascule en CORRECTED : il reste lisible et traçable.
+    assertExecutionTransition(current.status, "CORRECTED");
+    await client.query(
+      `
+        UPDATE public.production_pointages
+        SET status = 'CORRECTED'::production_pointage_status,
+            correction_reason = $2,
+            updated_at = now(), updated_by = $3::int
+        WHERE id = $1::uuid
+      `,
+      [params.id, params.correction_reason, params.audit.user_id]
+    );
+
+    // Le remplaçant est une NOUVELLE ligne liée à l'original.
+    const ins = await client.query<{ id: string }>(
+      `
+        INSERT INTO public.production_pointages (
+          of_id, operation_id, affaire_id, piece_technique_id,
+          machine_id, poste_id, operator_user_id, time_type, activity_code,
+          start_ts, end_ts, status, comment, correction_reason,
+          session_id, previous_segment_id, segment_index, source,
+          context_snapshot, created_by, updated_by
+        )
+        SELECT
+          p.of_id,
+          COALESCE($2::uuid, p.operation_id),
+          p.affaire_id, p.piece_technique_id,
+          CASE WHEN $3::text = 'set' THEN $4::uuid ELSE p.machine_id END,
+          CASE WHEN $5::text = 'set' THEN $6::uuid ELSE p.poste_id END,
+          p.operator_user_id, p.time_type,
+          COALESCE($7::text, p.activity_code),
+          COALESCE($8::timestamptz, p.start_ts),
+          COALESCE($9::timestamptz, p.end_ts),
+          'DONE'::production_pointage_status,
+          COALESCE($10, p.comment),
+          $11,
+          COALESCE(p.session_id, p.id), p.id, p.segment_index + 1, 'CANONICAL',
+          p.context_snapshot, $12::int, $12::int
+        FROM public.production_pointages p
+        WHERE p.id = $1::uuid
+        RETURNING id::text AS id
+      `,
+      [
+        params.id,
+        patch.operation_id ?? null,
+        patch.machine_id !== undefined ? "set" : "keep",
+        patch.machine_id ?? null,
+        patch.poste_id !== undefined ? "set" : "keep",
+        patch.poste_id ?? null,
+        patch.activity_code ?? null,
+        patch.start_ts ?? null,
+        patch.end_ts ?? null,
+        patch.comment ?? null,
+        params.correction_reason,
+        params.audit.user_id,
+      ]
+    );
+    const newId = ins.rows[0]!.id;
+
+    await insertExecutionEvent(client, {
+      pointage_id: params.id,
+      event_type: "CORRECT",
+      user_id: params.audit.user_id,
+      old_values: { status: current.status, start_ts: current.start_ts, end_ts: current.end_ts },
+      new_values: { replaced_by: newId, ...patch },
+      note: params.correction_reason,
+    });
+    await insertExecutionEvent(client, {
+      pointage_id: newId,
+      event_type: "CORRECT",
+      user_id: params.audit.user_id,
+      new_values: { corrects: params.id },
+      note: params.correction_reason,
+    });
+
+    if (current.operation_id) {
+      await client.query(`SELECT public.fn_production_recompute_operation_real_time($1::uuid)`, [
+        current.operation_id,
+      ]);
+    }
+
+    await insertAuditLog(client, params.audit, {
+      action: "production.execution.correct",
+      entity_type: "production_pointages",
+      entity_id: params.id,
+      details: { replaced_by: newId, reason: params.correction_reason, patch },
+    });
+
+    await client.query("COMMIT");
+    const updated = await repoGetExecution({ id: newId });
+    if (!updated) throw new HttpError(500, "PRODUCTION_EXECUTION_READ_BACK_FAILED", "Relecture impossible.");
+    return updated;
+  } catch (err) {
+    await client.query("ROLLBACK");
+    return translateConcurrencyError(err);
+  } finally {
+    client.release();
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Adaptateur de compatibilité `of_time_logs`                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Les routes historiques `POST /production/ofs/:ofId/operations/:opId/time-logs/start|stop`
+ * continuent de fonctionner à l'identique pour leurs appelants, mais écrivent
+ * désormais dans le moteur canonique. La ligne `of_time_logs` est toujours
+ * écrite (les écrans et tests legacy la lisent) et porte `pointage_id`, ce qui
+ * l'exclut du calcul de `temps_total_real` : la minute n'est comptée qu'une
+ * fois, côté canonique.
+ */
+export async function repoLegacyStartTimeLog(params: {
+  of_id: number;
+  op_id: string;
+  type: string;
+  machine_id: string | null;
+  comment: string | null;
+  audit: AuditContext;
+}): Promise<{ pointage_id: string; time_log_id: string | null }> {
+  const activityCode = LEGACY_TIME_LOG_TO_ACTIVITY[params.type] ?? "PRODUCTION";
+
+  const started = await repoStartExecution({
+    body: {
+      of_id: params.of_id,
+      operation_id: params.op_id,
+      machine_id: params.machine_id,
+      activity_code: activityCode,
+      comment: params.comment,
+    } as StartExecutionBodyDTO,
+    operatorUserId: params.audit.user_id,
+    // Clé dérivée et stable : deux appels legacy identiques rapprochés ne
+    // créent qu'un seul pointage.
+    idempotencyKey: `legacy:start:${params.op_id}:${params.audit.user_id}:${params.type}`,
+    audit: params.audit,
+    source: "LEGACY_TIME_LOG",
+  });
+
+  const mirror = await pool.query<{ id: string }>(
+    `
+      INSERT INTO public.of_time_logs
+        (of_operation_id, user_id, machine_id, started_at, type, comment, pointage_id)
+      SELECT $1::uuid, $2::int, $3::uuid, p.start_ts, $4::of_time_log_type, $5, p.id
+      FROM public.production_pointages p WHERE p.id = $6::uuid
+      ON CONFLICT DO NOTHING
+      RETURNING id::text AS id
+    `,
+    [params.op_id, params.audit.user_id, params.machine_id, params.type, params.comment, started.id]
+  );
+
+  return { pointage_id: started.id, time_log_id: mirror.rows[0]?.id ?? null };
+}
+
+export async function repoLegacyStopTimeLog(params: {
+  of_id: number;
+  op_id: string;
+  comment: string | null;
+  actorRole: string | null | undefined;
+  audit: AuditContext;
+}): Promise<{ pointage_id: string; duration_minutes: number | null }> {
+  const open = await pool.query<{ id: string }>(
+    `
+      SELECT id::text AS id
+      FROM public.production_pointages
+      WHERE operation_id = $1::uuid AND operator_user_id = $2::int AND status = 'RUNNING'
+      ORDER BY start_ts DESC LIMIT 1
+    `,
+    [params.op_id, params.audit.user_id]
+  );
+  const pointageId = open.rows[0]?.id;
+  if (!pointageId) {
+    throw new HttpError(409, "OF_NO_OPEN_TIME_LOG", "Aucun pointage en cours sur cette opération.");
+  }
+
+  const stopped = await repoStopExecution({
+    id: pointageId,
+    body: { comment: params.comment } as StopExecutionBodyDTO,
+    idempotencyKey: `legacy:stop:${pointageId}`,
+    actorRole: params.actorRole,
+    audit: params.audit,
+  });
+
+  // Miroir legacy fermé avec la MÊME durée que le canonique : les deux vues
+  // racontent la même histoire, une seule est comptée.
+  await pool.query(
+    `
+      UPDATE public.of_time_logs t
+      SET ended_at = p.end_ts,
+          duration_minutes = p.duration_minutes,
+          comment = COALESCE($2, t.comment)
+      FROM public.production_pointages p
+      WHERE t.pointage_id = $1::uuid AND p.id = $1::uuid AND t.ended_at IS NULL
+    `,
+    [pointageId, params.comment]
+  );
+
+  return { pointage_id: pointageId, duration_minutes: stopped.duration_minutes };
+}
+
+/** Fonction exposée pour les tests et la migration : mapping canonique → legacy. */
+export { activityToLegacyTimeLogType };

--- a/src/module/production/repository/production-execution.repository.ts
+++ b/src/module/production/repository/production-execution.repository.ts
@@ -20,7 +20,6 @@ import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repos
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 
 import {
-  activityToLegacyTimeLogType,
   assertActivityUsable,
   assertExecutionTransition,
   assertFiniteQuantities,
@@ -34,7 +33,6 @@ import {
   assertWithinRemaining,
   computeDurationMinutes,
   fingerprintPayload,
-  LEGACY_TIME_LOG_TO_ACTIVITY,
   LONG_RUNNING_ALERT_MINUTES,
   type ActivityCategory,
   type ExecutionEventType,
@@ -2407,105 +2405,3 @@ export async function repoCorrectExecution(params: {
     client.release();
   }
 }
-
-/* -------------------------------------------------------------------------- */
-/* Adaptateur de compatibilité `of_time_logs`                                 */
-/* -------------------------------------------------------------------------- */
-
-/**
- * Les routes historiques `POST /production/ofs/:ofId/operations/:opId/time-logs/start|stop`
- * continuent de fonctionner à l'identique pour leurs appelants, mais écrivent
- * désormais dans le moteur canonique. La ligne `of_time_logs` est toujours
- * écrite (les écrans et tests legacy la lisent) et porte `pointage_id`, ce qui
- * l'exclut du calcul de `temps_total_real` : la minute n'est comptée qu'une
- * fois, côté canonique.
- */
-export async function repoLegacyStartTimeLog(params: {
-  of_id: number;
-  op_id: string;
-  type: string;
-  machine_id: string | null;
-  comment: string | null;
-  audit: AuditContext;
-}): Promise<{ pointage_id: string; time_log_id: string | null }> {
-  const activityCode = LEGACY_TIME_LOG_TO_ACTIVITY[params.type] ?? "PRODUCTION";
-
-  const started = await repoStartExecution({
-    body: {
-      of_id: params.of_id,
-      operation_id: params.op_id,
-      machine_id: params.machine_id,
-      activity_code: activityCode,
-      comment: params.comment,
-    } as StartExecutionBodyDTO,
-    operatorUserId: params.audit.user_id,
-    // Clé dérivée et stable : deux appels legacy identiques rapprochés ne
-    // créent qu'un seul pointage.
-    idempotencyKey: `legacy:start:${params.op_id}:${params.audit.user_id}:${params.type}`,
-    audit: params.audit,
-    source: "LEGACY_TIME_LOG",
-  });
-
-  const mirror = await pool.query<{ id: string }>(
-    `
-      INSERT INTO public.of_time_logs
-        (of_operation_id, user_id, machine_id, started_at, type, comment, pointage_id)
-      SELECT $1::uuid, $2::int, $3::uuid, p.start_ts, $4::of_time_log_type, $5, p.id
-      FROM public.production_pointages p WHERE p.id = $6::uuid
-      ON CONFLICT DO NOTHING
-      RETURNING id::text AS id
-    `,
-    [params.op_id, params.audit.user_id, params.machine_id, params.type, params.comment, started.id]
-  );
-
-  return { pointage_id: started.id, time_log_id: mirror.rows[0]?.id ?? null };
-}
-
-export async function repoLegacyStopTimeLog(params: {
-  of_id: number;
-  op_id: string;
-  comment: string | null;
-  actorRole: string | null | undefined;
-  audit: AuditContext;
-}): Promise<{ pointage_id: string; duration_minutes: number | null }> {
-  const open = await pool.query<{ id: string }>(
-    `
-      SELECT id::text AS id
-      FROM public.production_pointages
-      WHERE operation_id = $1::uuid AND operator_user_id = $2::int AND status = 'RUNNING'
-      ORDER BY start_ts DESC LIMIT 1
-    `,
-    [params.op_id, params.audit.user_id]
-  );
-  const pointageId = open.rows[0]?.id;
-  if (!pointageId) {
-    throw new HttpError(409, "OF_NO_OPEN_TIME_LOG", "Aucun pointage en cours sur cette opération.");
-  }
-
-  const stopped = await repoStopExecution({
-    id: pointageId,
-    body: { comment: params.comment } as StopExecutionBodyDTO,
-    idempotencyKey: `legacy:stop:${pointageId}`,
-    actorRole: params.actorRole,
-    audit: params.audit,
-  });
-
-  // Miroir legacy fermé avec la MÊME durée que le canonique : les deux vues
-  // racontent la même histoire, une seule est comptée.
-  await pool.query(
-    `
-      UPDATE public.of_time_logs t
-      SET ended_at = p.end_ts,
-          duration_minutes = p.duration_minutes,
-          comment = COALESCE($2, t.comment)
-      FROM public.production_pointages p
-      WHERE t.pointage_id = $1::uuid AND p.id = $1::uuid AND t.ended_at IS NULL
-    `,
-    [pointageId, params.comment]
-  );
-
-  return { pointage_id: pointageId, duration_minutes: stopped.duration_minutes };
-}
-
-/** Fonction exposée pour les tests et la migration : mapping canonique → legacy. */
-export { activityToLegacyTimeLogType };

--- a/src/module/production/repository/production.repository.ts
+++ b/src/module/production/repository/production.repository.ts
@@ -3783,21 +3783,16 @@ export async function repoStopOfOperationTimeLog(params: {
     );
     const durationMinutes = stopped.rows[0]?.duration_minutes ?? null;
 
-    await client.query(
-      `
-        UPDATE of_operations op
-        SET
-          temps_total_real = ROUND(COALESCE((
-            SELECT SUM(t.duration_minutes) / 60.0
-            FROM of_time_logs t
-            WHERE t.of_operation_id = op.id
-              AND t.duration_minutes IS NOT NULL
-          ), 0)::numeric, 3),
-          updated_at = now()
-        WHERE op.of_id = $1::bigint AND op.id = $2::uuid
-      `,
-      [params.of_id, params.op_id]
-    );
+    // #274 — Source UNIQUE du temps réel. Cet UPDATE ne somme plus `of_time_logs`
+    // tout seul : il déléguait à une formule locale qui ignorait complètement le
+    // temps saisi via `production_pointages`, si bien que `temps_total_real`
+    // sous-comptait silencieusement dès qu'un opérateur pointait depuis l'écran
+    // Pointages. La fonction additionne le moteur canonique et le résidu legacy
+    // non migré (`of_time_logs.pointage_id IS NULL`), donc aucune minute n'est
+    // ni perdue ni comptée deux fois.
+    await client.query(`SELECT public.fn_production_recompute_operation_real_time($1::uuid)`, [
+      params.op_id,
+    ]);
 
     await client.query(
       `UPDATE ordres_fabrication SET updated_at = now(), updated_by = $2 WHERE id = $1::bigint`,

--- a/src/module/production/routes/production-execution.routes.ts
+++ b/src/module/production/routes/production-execution.routes.ts
@@ -1,0 +1,138 @@
+import { Router } from "express";
+
+import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import {
+  requireIdempotencyKey,
+  requireProductionExecutionCapability,
+} from "../middlewares/production-execution-authorization.middleware";
+import {
+  cancelExecution,
+  capabilities,
+  changeExecution,
+  correctExecution,
+  declareIncident,
+  declareQuantity,
+  executionCenter,
+  executionIndicators,
+  finishOperation,
+  getExecution,
+  listActivityCategories,
+  listExecutions,
+  operatorBoard,
+  pauseExecution,
+  previewFinishOperation,
+  rejectExecution,
+  resumeExecution,
+  startExecution,
+  stopExecution,
+  submitExecution,
+  validateExecution,
+} from "../controllers/production-execution.controller";
+
+/**
+ * Surface « Suivi et pointage de production 360 » (#274), montée sous
+ * `/production/execution`.
+ *
+ * Elle n'hérite d'aucune garde globale trop large : chaque route déclare sa
+ * capacité fine, refus par défaut. Le routeur historique `production.routes.ts`
+ * reste inchangé pour ne casser aucun écran en production, et ses routes
+ * `time-logs` sont désormais servies par l'adaptateur de compatibilité qui
+ * écrit dans ce moteur canonique.
+ *
+ * Toute commande à effet exige un en-tête `Idempotency-Key` : double-clic,
+ * second onglet et retry réseau produisent exactement un effet.
+ */
+const router = Router();
+router.use(authenticateToken);
+
+/* ------------------------------- Lecture --------------------------------- */
+
+// Référentiel d'activités : lisible par quiconque peut lire l'exécution, sinon
+// le poste opérateur ne pourrait pas afficher ses boutons.
+router.get("/activity-categories", requireProductionExecutionCapability("read"), listActivityCategories);
+
+// Capacités de l'appelant : l'UI s'en sert pour n'AFFICHER que ce qui est
+// autorisé — le backend re-vérifie systématiquement de toute façon.
+router.get("/capabilities", capabilities);
+
+router.get("/center", requireProductionExecutionCapability("read"), executionCenter);
+router.get("/indicators", requireProductionExecutionCapability("read"), executionIndicators);
+router.get("/operator-board", requireProductionExecutionCapability("read"), operatorBoard);
+router.get("/", requireProductionExecutionCapability("read"), listExecutions);
+router.get("/:id", requireProductionExecutionCapability("read"), getExecution);
+
+/* ------------------------ Commandes de segment --------------------------- */
+
+router.post(
+  "/",
+  requireIdempotencyKey,
+  requireProductionExecutionCapability("start_self"),
+  startExecution
+);
+router.post(
+  "/:id/pause",
+  requireIdempotencyKey,
+  requireProductionExecutionCapability("pause_self"),
+  pauseExecution
+);
+router.post(
+  "/:id/resume",
+  requireIdempotencyKey,
+  requireProductionExecutionCapability("pause_self"),
+  resumeExecution
+);
+// Changement d'activité, de machine, de poste ou d'opérateur : clôture le
+// segment courant et en ouvre un nouveau, sans réécrire le passé.
+router.post(
+  "/:id/change",
+  requireIdempotencyKey,
+  requireProductionExecutionCapability("start_self"),
+  changeExecution
+);
+router.post(
+  "/:id/incidents",
+  requireIdempotencyKey,
+  requireProductionExecutionCapability("declare_incident"),
+  declareIncident
+);
+router.post(
+  "/:id/stop",
+  requireIdempotencyKey,
+  requireProductionExecutionCapability("stop_self"),
+  stopExecution
+);
+
+/* ----------------------------- Quantités --------------------------------- */
+
+router.post(
+  "/quantities",
+  requireIdempotencyKey,
+  requireProductionExecutionCapability("declare_quantity"),
+  declareQuantity
+);
+
+// Aperçu en LECTURE SEULE : aucune écriture, pas de clé d'idempotence exigée.
+router.post(
+  "/operations/finish/preview",
+  requireProductionExecutionCapability("declare_quantity"),
+  previewFinishOperation
+);
+// Confirmation : une seule transaction, aucun effet partiel possible.
+router.post(
+  "/operations/finish",
+  requireIdempotencyKey,
+  requireProductionExecutionCapability("declare_quantity"),
+  finishOperation
+);
+
+/* ------------------------- Cycle de validation --------------------------- */
+
+router.post("/:id/submit", requireProductionExecutionCapability("submit"), submitExecution);
+// Valider, rejeter, corriger et annuler sont quatre capacités distinctes :
+// l'atelier soumet, la hiérarchie tranche.
+router.post("/:id/validate", requireProductionExecutionCapability("validate"), validateExecution);
+router.post("/:id/reject", requireProductionExecutionCapability("reject"), rejectExecution);
+router.post("/:id/correct", requireProductionExecutionCapability("correct"), correctExecution);
+router.post("/:id/cancel", requireProductionExecutionCapability("cancel"), cancelExecution);
+
+export default router;

--- a/src/module/production/services/production-execution.service.ts
+++ b/src/module/production/services/production-execution.service.ts
@@ -1,0 +1,399 @@
+// Service du suivi et pointage de production (#274).
+//
+// Rôle : appliquer les règles qui dépendent de l'IDENTITÉ de l'appelant avant
+// de déléguer au repository. C'est ici que se joue la différence entre
+// « pointer pour soi » et « pointer pour un autre », et le périmètre de lecture
+// d'un opérateur.
+
+import { HttpError } from "../../../utils/httpError";
+import {
+  assertProductionExecutionCapability,
+  PRODUCTION_EXECUTION_CAPABILITIES,
+  roleHasProductionExecutionCapability,
+  type ProductionExecutionCapability,
+} from "../domain/production-execution";
+import type { AuditContext } from "../repository/production.repository";
+import {
+  repoCancelExecution,
+  repoCorrectExecution,
+  repoDeclareQuantity,
+  repoExecutionCenter,
+  repoExecutionIndicators,
+  repoFinishOperation,
+  repoGetExecution,
+  repoListActivityCategories,
+  repoListExecutions,
+  repoOperatorBoard,
+  repoPreviewFinishOperation,
+  repoRejectExecution,
+  repoStartExecution,
+  repoStopExecution,
+  repoSubmitExecution,
+  repoTransitionSegment,
+  repoValidateExecution,
+} from "../repository/production-execution.repository";
+import type {
+  CancelExecutionBodyDTO,
+  ChangeExecutionBodyDTO,
+  CorrectExecutionBodyDTO,
+  DeclareQuantityBodyDTO,
+  ExecutionCenterQueryDTO,
+  FinishOperationBodyDTO,
+  FinishOperationPreviewBodyDTO,
+  IncidentExecutionBodyDTO,
+  ListActivityCategoriesQueryDTO,
+  ListExecutionsQueryDTO,
+  OperatorBoardQueryDTO,
+  PauseExecutionBodyDTO,
+  RejectExecutionBodyDTO,
+  ResumeExecutionBodyDTO,
+  StartExecutionBodyDTO,
+  StopExecutionBodyDTO,
+  SubmitExecutionBodyDTO,
+  ValidateExecutionBodyDTO,
+} from "../validators/production-execution.validators";
+
+export type Actor = { id: number; role: string | null | undefined };
+
+/**
+ * Périmètre de lecture. Un opérateur ne voit que SES pointages ; un superviseur
+ * voit tout. Le retour `null` signifie « aucune restriction », il n'est jamais
+ * déductible d'un paramètre de requête.
+ */
+function readScope(actor: Actor): number | null {
+  if (roleHasProductionExecutionCapability(actor.role, "validate")) return null;
+  if (roleHasProductionExecutionCapability(actor.role, "create_for_other")) return null;
+  return actor.id;
+}
+
+/**
+ * Identité de l'opérateur d'un pointage. Elle vient du JWT ; le corps de
+ * requête ne peut la surcharger qu'avec la capacité `create_for_other` ET un
+ * motif. Sans les deux, la valeur envoyée est ignorée plutôt que refusée
+ * silencieusement — mais l'écart est signalé.
+ */
+function resolveOperator(actor: Actor, body: { operator_user_id?: number; for_other_reason?: string }): number {
+  const requested = body.operator_user_id;
+  if (!requested || requested === actor.id) return actor.id;
+
+  assertProductionExecutionCapability(actor.role, "create_for_other");
+  if (!body.for_other_reason || body.for_other_reason.trim().length < 3) {
+    throw new HttpError(
+      422,
+      "PRODUCTION_EXECUTION_FOR_OTHER_REASON_REQUIRED",
+      "Pointer pour un autre opérateur exige un motif.",
+      { details: { fields: { for_other_reason: ["Indiquez pourquoi vous pointez pour cet opérateur."] } } }
+    );
+  }
+  return requested;
+}
+
+/* ------------------------------- Lecture --------------------------------- */
+
+export async function svcListActivityCategories(query: ListActivityCategoriesQueryDTO) {
+  return repoListActivityCategories({ include_disabled: query.include_disabled });
+}
+
+export async function svcCapabilities(actor: Actor) {
+  const capabilities = PRODUCTION_EXECUTION_CAPABILITIES.filter((c) =>
+    roleHasProductionExecutionCapability(actor.role, c as ProductionExecutionCapability)
+  );
+  return { capabilities };
+}
+
+export async function svcListExecutions(actor: Actor, query: ListExecutionsQueryDTO) {
+  assertProductionExecutionCapability(actor.role, "read");
+  return repoListExecutions({ query, scopeOperatorUserId: readScope(actor) });
+}
+
+export async function svcGetExecution(actor: Actor, id: string) {
+  assertProductionExecutionCapability(actor.role, "read");
+  const found = await repoGetExecution({ id });
+  if (!found) {
+    throw new HttpError(404, "PRODUCTION_EXECUTION_NOT_FOUND", "Pointage introuvable.", { id });
+  }
+  // Anti-IDOR : un identifiant deviné ne donne pas accès au pointage d'un tiers.
+  const scope = readScope(actor);
+  if (scope !== null && found.operator.id !== scope) {
+    throw new HttpError(
+      403,
+      "PRODUCTION_EXECUTION_FOREIGN_POINTAGE",
+      "Ce pointage appartient à un autre opérateur."
+    );
+  }
+  return found;
+}
+
+export async function svcExecutionCenter(actor: Actor, query: ExecutionCenterQueryDTO) {
+  assertProductionExecutionCapability(actor.role, "read");
+  const today = new Date().toISOString().slice(0, 10);
+  return repoExecutionCenter({
+    date_from: query.date_from ?? today,
+    date_to: query.date_to ?? today,
+    scopeOperatorUserId: readScope(actor),
+  });
+}
+
+/**
+ * Indicateurs dérivés. L'accès aux coûts est un périmètre SÉPARÉ : voir du
+ * temps n'est pas voir de l'argent.
+ */
+export async function svcExecutionIndicators(actor: Actor, query: ExecutionCenterQueryDTO) {
+  assertProductionExecutionCapability(actor.role, "read");
+  const today = new Date().toISOString().slice(0, 10);
+  const indicators = await repoExecutionIndicators({
+    date_from: query.date_from ?? today,
+    date_to: query.date_to ?? today,
+  });
+  if (!roleHasProductionExecutionCapability(actor.role, "view_costs")) {
+    return {
+      ...indicators,
+      cost: { computable: false, value: null, missing: ["capacité 'view_costs' requise"] },
+    };
+  }
+  return indicators;
+}
+
+export async function svcOperatorBoard(actor: Actor, query: OperatorBoardQueryDTO) {
+  assertProductionExecutionCapability(actor.role, "read");
+  const target = query.operator_user_id ?? actor.id;
+  if (target !== actor.id) {
+    assertProductionExecutionCapability(actor.role, "create_for_other");
+  }
+  return repoOperatorBoard({ operatorUserId: target, query });
+}
+
+/* ------------------------------ Commandes -------------------------------- */
+
+export async function svcStartExecution(params: {
+  actor: Actor;
+  body: StartExecutionBodyDTO;
+  idempotencyKey: string;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "start_self");
+  const operatorUserId = resolveOperator(params.actor, params.body);
+  return repoStartExecution({
+    body: params.body,
+    operatorUserId,
+    idempotencyKey: params.idempotencyKey,
+    audit: params.audit,
+  });
+}
+
+export async function svcStopExecution(params: {
+  actor: Actor;
+  id: string;
+  body: StopExecutionBodyDTO;
+  idempotencyKey: string;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "stop_self");
+  return repoStopExecution({
+    id: params.id,
+    body: params.body,
+    idempotencyKey: params.idempotencyKey,
+    actorRole: params.actor.role,
+    audit: params.audit,
+  });
+}
+
+export async function svcPauseExecution(params: {
+  actor: Actor;
+  id: string;
+  body: PauseExecutionBodyDTO;
+  idempotencyKey: string;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "pause_self");
+  return repoTransitionSegment({
+    id: params.id,
+    kind: "PAUSE",
+    body: params.body,
+    idempotencyKey: params.idempotencyKey,
+    actorRole: params.actor.role,
+    audit: params.audit,
+  });
+}
+
+export async function svcResumeExecution(params: {
+  actor: Actor;
+  id: string;
+  body: ResumeExecutionBodyDTO;
+  idempotencyKey: string;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "pause_self");
+  return repoTransitionSegment({
+    id: params.id,
+    kind: "RESUME",
+    body: params.body,
+    idempotencyKey: params.idempotencyKey,
+    actorRole: params.actor.role,
+    audit: params.audit,
+  });
+}
+
+export async function svcChangeExecution(params: {
+  actor: Actor;
+  id: string;
+  body: ChangeExecutionBodyDTO;
+  idempotencyKey: string;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "start_self");
+  // Transmettre le travail à quelqu'un d'autre engage un tiers : capacité dédiée.
+  if (params.body.operator_user_id && params.body.operator_user_id !== params.actor.id) {
+    assertProductionExecutionCapability(params.actor.role, "create_for_other");
+    if (!params.body.reason) {
+      throw new HttpError(
+        422,
+        "PRODUCTION_EXECUTION_FOR_OTHER_REASON_REQUIRED",
+        "Transférer un pointage à un autre opérateur exige un motif."
+      );
+    }
+  }
+  return repoTransitionSegment({
+    id: params.id,
+    kind: "CHANGE",
+    body: params.body,
+    idempotencyKey: params.idempotencyKey,
+    actorRole: params.actor.role,
+    audit: params.audit,
+  });
+}
+
+export async function svcDeclareIncident(params: {
+  actor: Actor;
+  id: string;
+  body: IncidentExecutionBodyDTO;
+  idempotencyKey: string;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "declare_incident");
+  return repoTransitionSegment({
+    id: params.id,
+    kind: "INCIDENT",
+    body: params.body,
+    idempotencyKey: params.idempotencyKey,
+    actorRole: params.actor.role,
+    audit: params.audit,
+  });
+}
+
+export async function svcDeclareQuantity(params: {
+  actor: Actor;
+  body: DeclareQuantityBodyDTO;
+  idempotencyKey: string;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "declare_quantity");
+  return repoDeclareQuantity({
+    body: params.body,
+    idempotencyKey: params.idempotencyKey,
+    audit: params.audit,
+  });
+}
+
+export async function svcPreviewFinishOperation(params: {
+  actor: Actor;
+  body: FinishOperationPreviewBodyDTO;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "declare_quantity");
+  return repoPreviewFinishOperation({ body: params.body, operatorUserId: params.actor.id });
+}
+
+export async function svcFinishOperation(params: {
+  actor: Actor;
+  body: FinishOperationBodyDTO;
+  idempotencyKey: string;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "declare_quantity");
+  assertProductionExecutionCapability(params.actor.role, "stop_self");
+  return repoFinishOperation({
+    body: params.body,
+    operatorUserId: params.actor.id,
+    idempotencyKey: params.idempotencyKey,
+    actorRole: params.actor.role,
+    audit: params.audit,
+  });
+}
+
+/* ------------------------- Cycle de validation --------------------------- */
+
+export async function svcSubmitExecution(params: {
+  actor: Actor;
+  id: string;
+  body: SubmitExecutionBodyDTO;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "submit");
+  return repoSubmitExecution({
+    id: params.id,
+    note: params.body.note ?? null,
+    actorRole: params.actor.role,
+    audit: params.audit,
+  });
+}
+
+export async function svcValidateExecution(params: {
+  actor: Actor;
+  id: string;
+  body: ValidateExecutionBodyDTO;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "validate");
+  return repoValidateExecution({
+    id: params.id,
+    note: params.body.note ?? null,
+    actorRole: params.actor.role,
+    audit: params.audit,
+  });
+}
+
+export async function svcRejectExecution(params: {
+  actor: Actor;
+  id: string;
+  body: RejectExecutionBodyDTO;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "reject");
+  return repoRejectExecution({
+    id: params.id,
+    reason: params.body.reason,
+    actorRole: params.actor.role,
+    audit: params.audit,
+  });
+}
+
+export async function svcCorrectExecution(params: {
+  actor: Actor;
+  id: string;
+  body: CorrectExecutionBodyDTO;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "correct");
+  return repoCorrectExecution({
+    id: params.id,
+    correction_reason: params.body.correction_reason,
+    patch: params.body.patch,
+    actorRole: params.actor.role,
+    audit: params.audit,
+  });
+}
+
+export async function svcCancelExecution(params: {
+  actor: Actor;
+  id: string;
+  body: CancelExecutionBodyDTO;
+  audit: AuditContext;
+}) {
+  assertProductionExecutionCapability(params.actor.role, "cancel");
+  return repoCancelExecution({
+    id: params.id,
+    reason: params.body.reason,
+    actorRole: params.actor.role,
+    audit: params.audit,
+  });
+}

--- a/src/module/production/validators/production-execution.validators.ts
+++ b/src/module/production/validators/production-execution.validators.ts
@@ -1,0 +1,311 @@
+// Validateurs du suivi et pointage de production (#274).
+//
+// Principe : le serveur ne fait jamais confiance au client sur l'identité, le
+// temps ni les identifiants. En particulier :
+//   * l'opérateur d'un pointage personnel vient du JWT, pas du corps de requête ;
+//   * l'identifiant du pointage est généré par le serveur, jamais transmis ;
+//   * les horodatages officiels sont posés par la base, le client ne peut en
+//     proposer que pour une saisie rétroactive explicitement motivée.
+
+import { z } from "zod";
+
+import { PRODUCTION_EXECUTION_CAPABILITIES } from "../domain/production-execution";
+
+const uuid = z.string().uuid();
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date invalide (attendu AAAA-MM-JJ)");
+
+const isoDateTime = z
+  .string()
+  .trim()
+  .min(1)
+  .refine((v) => Number.isFinite(Date.parse(v)), "Horodatage invalide");
+
+const activityCode = z
+  .string()
+  .trim()
+  .regex(/^[A-Z][A-Z0-9_]{1,39}$/, "Code d'activité invalide");
+
+const reason = z.string().trim().min(3, "Motif trop court (3 caractères minimum)").max(2000);
+
+/**
+ * Clé d'idempotence : fournie par l'appelant, obligatoire sur toute commande à
+ * effet. Elle permet au double-clic, au second onglet et au retry réseau de
+ * produire exactement un effet.
+ */
+const idempotencyKey = z
+  .string()
+  .trim()
+  .min(8, "Clé d'idempotence trop courte")
+  .max(200);
+
+export const executionIdParamSchema = z.object({ params: z.object({ id: uuid }) });
+
+export const executionIdempotencyHeaderSchema = z.object({
+  headers: z.object({
+    "idempotency-key": idempotencyKey,
+  }),
+});
+
+/* -------------------------------------------------------------------------- */
+/* Lecture                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export const listExecutionsQuerySchema = z.object({
+  date_from: isoDate.optional(),
+  date_to: isoDate.optional(),
+  of_id: z.coerce.number().int().positive().optional(),
+  operation_id: uuid.optional(),
+  machine_id: uuid.optional(),
+  poste_id: uuid.optional(),
+  operator_user_id: z.coerce.number().int().positive().optional(),
+  activity_code: activityCode.optional(),
+  status: z.enum(["RUNNING", "DONE", "CANCELLED", "CORRECTED"]).optional(),
+  // Files opérationnelles du command center — filtres SERVEUR, jamais un tri de
+  // la page courante.
+  segment: z
+    .enum([
+      "all",
+      "running",
+      "long_running",
+      "to_validate",
+      "rejected",
+      "incidents",
+      "scrap",
+      "overrun",
+    ])
+    .optional()
+    .default("all"),
+  q: z.string().trim().max(200).optional(),
+  page: z.coerce.number().int().min(1).optional().default(1),
+  pageSize: z.coerce.number().int().min(1).max(200).optional().default(50),
+  sortBy: z
+    .enum(["start_ts", "end_ts", "duration_minutes", "updated_at"])
+    .optional()
+    .default("start_ts"),
+  sortDir: z.enum(["asc", "desc"]).optional().default("desc"),
+});
+export type ListExecutionsQueryDTO = z.infer<typeof listExecutionsQuerySchema>;
+
+export const executionCenterQuerySchema = z.object({
+  date_from: isoDate.optional(),
+  date_to: isoDate.optional(),
+});
+export type ExecutionCenterQueryDTO = z.infer<typeof executionCenterQuerySchema>;
+
+export const operatorBoardQuerySchema = z.object({
+  // Le tableau de bord du poste opérateur est TOUJOURS celui de l'appelant.
+  // Consulter celui d'un tiers exige `create_for_other`, contrôlé côté service.
+  operator_user_id: z.coerce.number().int().positive().optional(),
+  of_id: z.coerce.number().int().positive().optional(),
+  q: z.string().trim().max(200).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional().default(25),
+});
+export type OperatorBoardQueryDTO = z.infer<typeof operatorBoardQuerySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Commandes à effet                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Démarrage. Aucun `id` : le serveur génère l'identifiant. `operator_user_id`
+ * n'est accepté que si l'appelant détient `create_for_other`, et il exige alors
+ * un motif — sinon le champ est ignoré au profit de l'identité du JWT.
+ */
+export const startExecutionSchema = z.object({
+  body: z.object({
+    of_id: z.coerce.number().int().positive(),
+    operation_id: uuid.nullable().optional(),
+    machine_id: uuid.nullable().optional(),
+    poste_id: uuid.nullable().optional(),
+    activity_code: activityCode,
+    time_type: z.enum(["OPERATEUR", "MACHINE", "PROGRAMMATION"]).optional(),
+    comment: z.string().trim().max(2000).nullable().optional(),
+
+    operator_user_id: z.coerce.number().int().positive().optional(),
+    for_other_reason: reason.optional(),
+
+    // Saisie rétroactive bornée : motif obligatoire, contrôle de chevauchement
+    // et validation hiérarchique côté service.
+    start_ts: isoDateTime.optional(),
+    retroactive_reason: reason.optional(),
+  }),
+});
+export type StartExecutionBodyDTO = z.infer<typeof startExecutionSchema>["body"];
+
+export const pauseExecutionSchema = z.object({
+  body: z.object({
+    activity_code: activityCode.optional(),
+    reason: reason.optional(),
+    comment: z.string().trim().max(2000).nullable().optional(),
+  }),
+});
+export type PauseExecutionBodyDTO = z.infer<typeof pauseExecutionSchema>["body"];
+
+export const resumeExecutionSchema = z.object({
+  body: z.object({
+    activity_code: activityCode.optional(),
+    machine_id: uuid.nullable().optional(),
+    comment: z.string().trim().max(2000).nullable().optional(),
+  }),
+});
+export type ResumeExecutionBodyDTO = z.infer<typeof resumeExecutionSchema>["body"];
+
+/**
+ * Changement d'activité, de machine ou d'opérateur : clôture le segment courant
+ * et en ouvre un nouveau. L'historique n'est jamais réécrit.
+ */
+export const changeExecutionSchema = z.object({
+  body: z
+    .object({
+      activity_code: activityCode.optional(),
+      machine_id: uuid.nullable().optional(),
+      poste_id: uuid.nullable().optional(),
+      operator_user_id: z.coerce.number().int().positive().optional(),
+      reason: reason.optional(),
+      comment: z.string().trim().max(2000).nullable().optional(),
+    })
+    .refine(
+      (b) =>
+        b.activity_code !== undefined ||
+        b.machine_id !== undefined ||
+        b.poste_id !== undefined ||
+        b.operator_user_id !== undefined,
+      { message: "Indiquez au moins un changement (activité, machine, poste ou opérateur)." }
+    ),
+});
+export type ChangeExecutionBodyDTO = z.infer<typeof changeExecutionSchema>["body"];
+
+export const incidentExecutionSchema = z.object({
+  body: z.object({
+    activity_code: activityCode,
+    reason,
+    comment: z.string().trim().max(2000).nullable().optional(),
+    // Un aléa peut suspendre la machine sans arrêter l'opération.
+    stops_machine: z.boolean().optional().default(false),
+  }),
+});
+export type IncidentExecutionBodyDTO = z.infer<typeof incidentExecutionSchema>["body"];
+
+export const stopExecutionSchema = z.object({
+  body: z.object({
+    comment: z.string().trim().max(2000).nullable().optional(),
+    // Un arrêt de timer ne termine JAMAIS l'opération tout seul : la clôture
+    // passe par la commande atomique de fin d'opération.
+    end_ts: isoDateTime.optional(),
+    retroactive_reason: reason.optional(),
+  }),
+});
+export type StopExecutionBodyDTO = z.infer<typeof stopExecutionSchema>["body"];
+
+/* -------------------------------------------------------------------------- */
+/* Quantités                                                                  */
+/* -------------------------------------------------------------------------- */
+
+const quantityDelta = z.object({
+  qty_good: z.coerce.number().finite().min(0).optional().default(0),
+  qty_scrap: z.coerce.number().finite().min(0).optional().default(0),
+  qty_rework: z.coerce.number().finite().min(0).optional().default(0),
+  qty_pending_control: z.coerce.number().finite().min(0).optional().default(0),
+  unite: z.string().trim().max(32).nullable().optional(),
+  scrap_reason_code: z.string().trim().max(64).nullable().optional(),
+  rework_reason_code: z.string().trim().max(64).nullable().optional(),
+  note: z.string().trim().max(2000).nullable().optional(),
+  // Motif exigé uniquement en cas de dépassement toléré du restant.
+  overproduction_reason: reason.optional(),
+});
+
+export const declareQuantitySchema = z.object({
+  body: quantityDelta.extend({
+    of_id: z.coerce.number().int().positive(),
+    operation_id: uuid.nullable().optional(),
+    pointage_id: uuid.nullable().optional(),
+  }),
+});
+export type DeclareQuantityBodyDTO = z.infer<typeof declareQuantitySchema>["body"];
+
+/**
+ * Commande métier atomique de fin d'opération. `preview` d'abord (lecture
+ * seule, aucune écriture), puis confirmation avec l'empreinte de l'aperçu :
+ * si l'état a bougé entre les deux, la confirmation est refusée plutôt que
+ * d'appliquer un effet calculé sur des données périmées.
+ */
+export const finishOperationPreviewSchema = z.object({
+  body: quantityDelta.extend({
+    of_id: z.coerce.number().int().positive(),
+    operation_id: uuid,
+    stop_active_segment: z.boolean().optional().default(true),
+    complete_operation: z.boolean().optional().default(false),
+  }),
+});
+export type FinishOperationPreviewBodyDTO = z.infer<typeof finishOperationPreviewSchema>["body"];
+
+export const finishOperationSchema = z.object({
+  body: quantityDelta.extend({
+    of_id: z.coerce.number().int().positive(),
+    operation_id: uuid,
+    stop_active_segment: z.boolean().optional().default(true),
+    complete_operation: z.boolean().optional().default(false),
+    // Empreinte de l'aperçu affiché à l'opérateur : garantit qu'il confirme
+    // bien ce qu'il a vu.
+    preview_hash: z.string().trim().length(64),
+  }),
+});
+export type FinishOperationBodyDTO = z.infer<typeof finishOperationSchema>["body"];
+
+/* -------------------------------------------------------------------------- */
+/* Cycle de validation                                                        */
+/* -------------------------------------------------------------------------- */
+
+export const submitExecutionSchema = z.object({
+  body: z.object({ note: z.string().trim().max(2000).nullable().optional() }),
+});
+export type SubmitExecutionBodyDTO = z.infer<typeof submitExecutionSchema>["body"];
+
+export const validateExecutionSchema = z.object({
+  body: z.object({ note: z.string().trim().max(2000).nullable().optional() }),
+});
+export type ValidateExecutionBodyDTO = z.infer<typeof validateExecutionSchema>["body"];
+
+export const rejectExecutionSchema = z.object({
+  body: z.object({ reason }),
+});
+export type RejectExecutionBodyDTO = z.infer<typeof rejectExecutionSchema>["body"];
+
+export const correctExecutionSchema = z.object({
+  body: z.object({
+    correction_reason: reason,
+    patch: z
+      .object({
+        start_ts: isoDateTime.optional(),
+        end_ts: isoDateTime.nullable().optional(),
+        activity_code: activityCode.optional(),
+        machine_id: uuid.nullable().optional(),
+        poste_id: uuid.nullable().optional(),
+        operation_id: uuid.nullable().optional(),
+        comment: z.string().trim().max(2000).nullable().optional(),
+      })
+      .refine((p) => Object.keys(p).length > 0, { message: "Aucune correction fournie." }),
+  }),
+});
+export type CorrectExecutionBodyDTO = z.infer<typeof correctExecutionSchema>["body"];
+
+export const cancelExecutionSchema = z.object({
+  body: z.object({ reason }),
+});
+export type CancelExecutionBodyDTO = z.infer<typeof cancelExecutionSchema>["body"];
+
+/* -------------------------------------------------------------------------- */
+/* Référentiel d'activités                                                    */
+/* -------------------------------------------------------------------------- */
+
+export const listActivityCategoriesQuerySchema = z.object({
+  include_disabled: z
+    .union([z.boolean(), z.enum(["true", "false"])])
+    .optional()
+    .transform((v) => v === true || v === "true"),
+});
+export type ListActivityCategoriesQueryDTO = z.infer<typeof listActivityCategoriesQuerySchema>;
+
+export const capabilitiesResponseSchema = z.object({
+  capabilities: z.array(z.enum(PRODUCTION_EXECUTION_CAPABILITIES)),
+});

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -21,6 +21,7 @@ import paiementsRoutes from "../module/facturation/routes/paiements.routes";
 import tarificationRoutes from "../module/facturation/routes/tarification.routes";
 import reportingRoutes from "../module/facturation/routes/reporting.routes";
 import productionRoutes from "../module/production/routes/production.routes";
+import productionExecutionRoutes from "../module/production/routes/production-execution.routes";
 import qualiteRoutes from "../module/qualite/routes/qualite.routes";
 import quality360Routes from "../module/qualite/routes/quality-360.routes";
 import livraisonsRoutes from "../module/livraisons/routes/livraisons.routes";
@@ -75,6 +76,10 @@ router.use("/avoirs", avoirsRoutes);
 router.use("/paiements", paiementsRoutes);
 router.use("/tarification", tarificationRoutes);
 router.use("/reporting", reportingRoutes);
+// Suivi et pointage de production 360 (#274) monté AVANT le routeur historique :
+// ses routes déclarent des capacités fines (refus par défaut) et exigent une
+// clé d'idempotence. Le routeur hérité reste inchangé pour les écrans existants.
+router.use("/production/execution", productionExecutionRoutes);
 router.use("/production", productionRoutes);
 router.use("/planning", planningRoutes);
 router.use("/programmations", programmationRoutes);


### PR DESCRIPTION
## Résultat

- fournit l’API de suivi d’exécution, d’incidents et de clôture d’opération
- consolide les anciens pointages vers `production_pointages` par trigger PostgreSQL atomique
- ajoute vérification, smoke test, recomputation historique et rollback gardé

## Validation

- suite backend complète réussie
- build TypeScript réussi
- sauvegarde, patch, rejeu idempotent, recomputation, smoke test sous `cerp_app` et vérification réussis sur `cerp_test`

Référence : BigFootLime/crp-systems-web#274