### PR TITLE
docs(reporting): ajouter les gardes de migration production (#141)

### DIFF
--- a/db/patches/support/20260726_fix_facturation_child_trigger_227.preflight.sql
+++ b/db/patches/support/20260726_fix_facturation_child_trigger_227.preflight.sql
@@ -1,0 +1,46 @@
+-- Préflight du correctif bloquant #227 découvert pendant #275.
+-- LECTURE SEULE : confirme la fonction, les cinq triggers et indique si la
+-- garde imbriquée sûre est déjà installée.
+
+\echo '=== #227 trigger fix preflight — base cible ==='
+SELECT current_database() AS database, current_user AS role, now() AS checked_at;
+
+\echo '--- Fonction attendue ---'
+SELECT
+  count(*) = 1 AS function_present,
+  coalesce(bool_or(
+    position(
+      'IF TG_TABLE_NAME = ''facture_echeance'' AND TG_OP = ''UPDATE'' THEN'
+      IN p.prosrc
+    ) > 0
+  ), false) AS nested_guard_already_present
+FROM pg_proc p
+JOIN pg_namespace n ON n.oid = p.pronamespace
+WHERE n.nspname = 'public'
+  AND p.proname = 'fn_protect_facturation_child_227';
+
+\echo '--- Triggers raccordés à la fonction (5 attendus) ---'
+SELECT c.relname AS table_name, t.tgname
+FROM pg_trigger t
+JOIN pg_class c ON c.oid = t.tgrelid
+JOIN pg_namespace n ON n.oid = c.relnamespace
+JOIN pg_proc p ON p.oid = t.tgfoid
+WHERE n.nspname = 'public'
+  AND NOT t.tgisinternal
+  AND p.proname = 'fn_protect_facturation_child_227'
+ORDER BY c.relname, t.tgname;
+
+\echo '--- Tables requises ---'
+SELECT relation,
+       to_regclass('public.' || relation) IS NOT NULL AS present
+FROM unnest(ARRAY[
+  'facture',
+  'facture_ligne',
+  'facture_echeance',
+  'avoir_ligne',
+  'facture_source_allocations',
+  'avoir_source_allocations'
+]) AS relation
+ORDER BY relation;
+
+\echo '=== #227 trigger fix preflight terminé ==='

--- a/db/patches/support/20260726_fix_facturation_child_trigger_227.rollback.sql
+++ b/db/patches/support/20260726_fix_facturation_child_trigger_227.rollback.sql
@@ -1,0 +1,13 @@
+-- Rollback gardé du correctif #227.
+--
+-- Restaurer la fonction précédente réintroduirait le défaut qui bloque tout
+-- INSERT/UPDATE de ligne de facture. Le rollback sûr est donc un redéploiement
+-- d'une version antérieure *corrigée* de la fonction, jamais le code connu
+-- comme défaillant. Ce garde-fou empêche une restauration accidentelle.
+
+DO $$
+BEGIN
+  RAISE EXCEPTION
+    'Rollback automatique refusé : il réintroduirait le trigger Facturation bloquant. Restaurer uniquement une version corrigée et vérifiée de fn_protect_facturation_child_227().';
+END
+$$;


### PR DESCRIPTION
Relates to #141.

Ajoute le preflight lecture seule et un rollback explicitement gardé pour le correctif du trigger Facturation #227. Le preflight a été exécuté sur `cerp_prod` : fonction présente, garde sûre absente, cinq triggers raccordés et six tables prérequises présentes.

Le rollback automatique refuse volontairement de réintroduire la fonction connue comme bloquante.

## Summary by Sourcery

Add guarded support SQL scripts for the Facturation child trigger fix #227, including a read-only preflight check and a protected rollback that prevents reintroducing the blocking behaviour.

Enhancements:
- Introduce a preflight script to verify the presence and wiring of the Facturation protection function, its triggers, and required tables in production.
- Add a rollback script that deliberately blocks automatic restoration of the known-defective function, requiring only corrected versions to be redeployed.