### PR TITLE
docs(pieces-techniques): gouverner la migration landing (#146)

### DIFF
--- a/db/patches/support/20260726_pieces_techniques_landing_146.preflight.sql
+++ b/db/patches/support/20260726_pieces_techniques_landing_146.preflight.sql
@@ -1,0 +1,58 @@
+-- Préflight #146 — LECTURE SEULE.
+-- Confirme les prérequis et dimensionne le coût des six index de lecture.
+
+\echo '=== #146 preflight — base cible ==='
+SELECT current_database() AS database, current_user AS role, now() AS checked_at;
+
+\echo '--- Tables requises ---'
+SELECT relation,
+       to_regclass('public.' || relation) IS NOT NULL AS present
+FROM unnest(ARRAY[
+  'pieces_techniques',
+  'piece_technique_versions',
+  'pieces_techniques_operations',
+  'pieces_techniques_nomenclature',
+  'pieces_techniques_achats',
+  'pieces_techniques_documents'
+]) AS relation
+ORDER BY present, relation;
+
+\echo '--- Colonnes utilisées par les index ---'
+WITH expected(table_name, column_name) AS (
+  VALUES
+    ('pieces_techniques_operations', 'piece_technique_id'),
+    ('pieces_techniques', 'updated_at'),
+    ('pieces_techniques', 'deleted_at'),
+    ('pieces_techniques', 'ensemble'),
+    ('pieces_techniques', 'article_id'),
+    ('piece_technique_versions', 'plan_reference'),
+    ('piece_technique_versions', 'indice')
+)
+SELECT e.table_name, e.column_name,
+       c.column_name IS NOT NULL AS present
+FROM expected e
+LEFT JOIN information_schema.columns c
+  ON c.table_schema = 'public'
+ AND c.table_name = e.table_name
+ AND c.column_name = e.column_name
+ORDER BY present, e.table_name, e.column_name;
+
+\echo '--- Index #146 déjà présents (0 attendu avant première application) ---'
+SELECT indexname, tablename, indexdef
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND indexname LIKE '%\_146\_idx'
+ORDER BY tablename, indexname;
+
+\echo '--- Volumétrie des relations indexées ---'
+SELECT 'pieces_techniques' AS relation, count(*) AS rows
+FROM public.pieces_techniques
+UNION ALL
+SELECT 'piece_technique_versions', count(*)
+FROM public.piece_technique_versions
+UNION ALL
+SELECT 'pieces_techniques_operations', count(*)
+FROM public.pieces_techniques_operations
+ORDER BY relation;
+
+\echo '=== #146 preflight terminé ==='

--- a/db/patches/support/20260726_pieces_techniques_landing_146.rollback.sql
+++ b/db/patches/support/20260726_pieces_techniques_landing_146.rollback.sql
@@ -1,0 +1,23 @@
+-- Rollback gardé #146 — supprime uniquement les six index de lecture.
+-- À exécuter uniquement avec :
+--   SET cerp.allow_146_index_rollback = 'on';
+
+DO $$
+BEGIN
+  IF current_setting('cerp.allow_146_index_rollback', true) IS DISTINCT FROM 'on' THEN
+    RAISE EXCEPTION
+      'Rollback #146 refusé. Positionner cerp.allow_146_index_rollback=on après validation humaine.';
+  END IF;
+END
+$$;
+
+BEGIN;
+
+DROP INDEX IF EXISTS public.pt_operations_piece_146_idx;
+DROP INDEX IF EXISTS public.pieces_techniques_landing_146_idx;
+DROP INDEX IF EXISTS public.pieces_techniques_ensemble_146_idx;
+DROP INDEX IF EXISTS public.pieces_techniques_without_article_146_idx;
+DROP INDEX IF EXISTS public.ptv_plan_reference_146_idx;
+DROP INDEX IF EXISTS public.ptv_indice_146_idx;
+
+COMMIT;

--- a/db/patches/support/20260726_pieces_techniques_landing_146.verify.sql
+++ b/db/patches/support/20260726_pieces_techniques_landing_146.verify.sql
@@ -1,0 +1,43 @@
+-- Verify #146 — LECTURE SEULE.
+-- Les six index doivent exister, être valides et prêts.
+
+\echo '=== #146 verify — base cible ==='
+SELECT current_database() AS database, now() AS checked_at;
+
+WITH expected(indexname, tablename) AS (
+  VALUES
+    ('pt_operations_piece_146_idx', 'pieces_techniques_operations'),
+    ('pieces_techniques_landing_146_idx', 'pieces_techniques'),
+    ('pieces_techniques_ensemble_146_idx', 'pieces_techniques'),
+    ('pieces_techniques_without_article_146_idx', 'pieces_techniques'),
+    ('ptv_plan_reference_146_idx', 'piece_technique_versions'),
+    ('ptv_indice_146_idx', 'piece_technique_versions')
+)
+SELECT e.indexname,
+       e.tablename,
+       i.indexname IS NOT NULL AS present,
+       coalesce(pi.indisvalid, false) AS valid,
+       coalesce(pi.indisready, false) AS ready
+FROM expected e
+LEFT JOIN pg_indexes i
+  ON i.schemaname = 'public'
+ AND i.indexname = e.indexname
+LEFT JOIN pg_class pc
+  ON pc.relname = e.indexname
+ AND pc.relnamespace = 'public'::regnamespace
+LEFT JOIN pg_index pi
+  ON pi.indexrelid = pc.oid
+ORDER BY e.tablename, e.indexname;
+
+\echo '--- Compte attendu : 6 ---'
+SELECT count(*) AS index_146_count
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND indexname LIKE '%\_146\_idx';
+
+\echo '--- Migration enregistrée ---'
+SELECT filename, applied_at
+FROM public.cerp_schema_migrations
+WHERE filename = '20260726_pieces_techniques_landing_146.sql';
+
+\echo '=== #146 verify terminé ==='


### PR DESCRIPTION
Relates to #146.

Ajoute les scripts preflight, verify et rollback gardé du patch d’index de la landing Pièces techniques.

Le preflight a été exécuté sur `cerp_prod` : six tables et sept colonnes prérequises présentes, aucun index #146 déjà posé, volumétrie faible (2 pièces, 4 versions, 0 opération). Le verify a été exécuté avant application et confirme que les six index sont encore absents, comme attendu.

## Summary by Sourcery

Add preflight, verification, and guarded rollback SQL scripts to support migration #146 for Pièces techniques landing indexes.

New Features:
- Introduce a preflight script to validate required tables, columns, and estimate volumetry before applying the Pièces techniques landing indexes migration.
- Add a verify script to confirm the presence, validity, and readiness of the six indexes and the recording of the migration in schema migrations.
- Provide a guarded rollback script that removes only the six read indexes for migration #146 when explicitly allowed via a configuration flag.