### PR TITLE
fix(facturation): fiabiliser la preuve de migration #141

### DIFF
--- a/db/patches/support/20260726_fix_facturation_child_trigger_227.verify.sql
+++ b/db/patches/support/20260726_fix_facturation_child_trigger_227.verify.sql
@@ -37,8 +37,25 @@ VALUES (9990001, 1, 'Ligne de verification #275', 1, 10, 0, 20, 10, 12);
 SELECT 'facture_ligne creee' AS resultat, count(*) AS lignes
 FROM public.facture_ligne WHERE facture_id = 9990001;
 
-\echo '--- immutabilite toujours active : la meme ligne sur une facture emise doit echouer ---'
+\echo '--- immutabilite toujours active : la meme ligne sur une facture emise est bloquee ---'
 UPDATE public.facture SET statut = 'emise' WHERE id = 9990001;
+
+DO $verify$
+BEGIN
+  BEGIN
+    UPDATE public.facture_ligne
+    SET designation = 'Modification interdite'
+    WHERE facture_id = 9990001;
+
+    RAISE EXCEPTION USING
+      ERRCODE = '23514',
+      MESSAGE = 'Echec verification #227 : la ligne emise est restée modifiable';
+  EXCEPTION
+    WHEN SQLSTATE '55000' THEN
+      RAISE NOTICE 'Immutabilite confirmee : le trigger a retourne SQLSTATE 55000';
+  END;
+END
+$verify$;
 
 ROLLBACK;
 


### PR DESCRIPTION
Corrige le script de vérification production du correctif #227 découvert pendant #141. La preuve teste désormais réellement l'immutabilité d'une ligne de facture émise, capture uniquement le SQLSTATE attendu 55000, échoue si la modification passe et annule toutes les données de test. Closes #141

## Summary by Sourcery

Strengthen the production verification script for facturation trigger fix #227 by explicitly asserting invoice line immutability on emitted invoices and handling only the expected error state.

Enhancements:
- Add a procedural verification block that attempts to modify an emitted invoice line and fails the migration proof if the change is unexpectedly allowed.
- Restrict verification to the expected SQLSTATE 55000 and emit a clear notice when immutability is correctly enforced.
- Ensure test data used by the verification script is fully rolled back after execution.