### PR TITLE
docs(release): consigner les preuves cerp_prod #141 #142 #146

### DIFF
--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -242,3 +242,28 @@ Validation du 2026-07-25 :
 - les huit tables sont possédées par `cerp_app` et
   `has_table_privilege(..., 'SELECT,INSERT,UPDATE')` retourne vrai ;
 - le Centre Qualité de production recharge sans erreur API v2.
+
+## Release industrielle 360 du 2026-07-26
+
+Avant toute écriture, `cerp_prod` a été sauvegardée dans
+`/var/backups/cerp/cerp_prod_release_20260726-1615.dump`. Le fichier mesure
+37 706 913 octets et son catalogue `pg_restore --list` contient 3 146 entrées.
+
+Les préflights ont été exécutés en lecture seule, puis les patches ont été
+appliqués transactionnellement et vérifiés dans cet ordre :
+
+1. `20260726_production_execution_274.sql` : schéma déjà présent et conforme ;
+   enregistrement de l'état vérifié dans `cerp_schema_migrations` ;
+2. `20260726_tracabilite_360_142.sql` : table de consommation matière,
+   contraintes, trigger append-only, index, durcissement as-built et ownership
+   `cerp_app`, sans backfill déduit ;
+3. `20260726_fix_facturation_child_trigger_227.sql` : création d'une ligne de
+   facture prouvée, immutabilité après émission prouvée avec SQLSTATE `55000`,
+   transaction de test annulée et zéro résidu ;
+4. `20260726_reporting_commercial_360_275.sql` : 17 index présents, valides et
+   prêts, lisibilité applicative confirmée ;
+5. `20260726_pieces_techniques_landing_146.sql` : 6 index présents, valides et
+   prêts.
+
+Les cinq lignes du registre portent les empreintes SHA-256 exactes des fichiers
+versionnés. Aucun jeu de données de recette n'a été conservé dans `cerp_prod`.

--- a/docs/reporting-commercial-360-275.md
+++ b/docs/reporting-commercial-360-275.md
@@ -1,7 +1,7 @@
 # Reporting commercial 360 — contrat d'API (#275 / back #141)
 
 Base : `/api/v1/reporting/commercial/v2` · Décision :
-`crp-systems-web/docs/adr/ADR-0028-reporting-commercial-360.md`
+`crp-systems-web/docs/adr/ADR-0029-reporting-commercial-360.md`
 
 Toutes les routes sont en lecture seule, authentifiées, non mises en cache
 (`Cache-Control: no-store, private`) et refusées par défaut.
@@ -153,6 +153,13 @@ encaissements et dates d'imputation.
 
 Support : `.preflight.sql` (lecture seule), `.verify.sql` (17/17 + lisibilité `cerp_app`),
 `.rollback.sql`, `.invariants.sql` (banc de réconciliation en transaction annulée).
+
+Appliqué et vérifié sur `cerp_test`, puis sur **`cerp_prod`** le 2026-07-26 après la
+sauvegarde vérifiée
+`/var/backups/cerp/cerp_prod_release_20260726-1615.dump` (37 706 913 octets).
+Les 17 index sont présents, valides et prêts, le rôle `cerp_app` lit les huit
+relations couvertes et la migration est enregistrée avec l'empreinte
+`c3d443105dba289bb21f615ae29c83a13e1b6366616d35c5eb257291df0a5ef1`.
 
 ---
 

--- a/docs/tracabilite-360-142.md
+++ b/docs/tracabilite-360-142.md
@@ -66,9 +66,14 @@ du mouvement à `POSTED`.
 Support : `.preflight.sql`, `.verify.sql`, `.rollback.sql` (gardé : refuse de s'exécuter dès
 qu'une consommation existe).
 
-Appliqué et vérifié sur **`cerp_test` uniquement** le 2026-07-26, enregistré dans
-`cerp_schema_migrations`. **`cerp_prod` non modifié** — l'application en production exige une
-validation humaine explicite.
+Appliqué et vérifié sur `cerp_test`, puis sur **`cerp_prod`** le 2026-07-26 après la
+sauvegarde vérifiée
+`/var/backups/cerp/cerp_prod_release_20260726-1615.dump` (37 706 913 octets).
+La vérification production confirme les 19 colonnes, 14 contraintes, 15 index,
+le trigger append-only, l'ownership et la lecture par `cerp_app`, avec zéro
+backfill déduit. La migration est enregistrée dans `cerp_schema_migrations`
+avec l'empreinte
+`d4d8efdbf54855008956c1e5b0081d77cc38a10ce6feeb779ae4812f09f716d3`.
 
 Rappel du runbook HYPERBOX2 : le patch réassigne explicitement
 `of_material_consumptions` à `cerp_app`, sans quoi le rôle applicatif reçoit un `42501` qui


### PR DESCRIPTION
Met à jour la gouvernance et les guides backend après l'application autorisée à cerp_prod : sauvegarde vérifiée, ordre des cinq migrations, empreintes, contrôles post-application et zéro donnée de recette conservée. Corrige aussi le lien ADR Reporting vers ADR-0029.

## Summary by Sourcery

Document release 360 to production on 2026-07-26, including verified backup, ordered application and verification of five database migrations, and assurance of no test data retained.

Documentation:
- Add detailed release notes for cerp_prod database patches, including backup evidence, migration order, and verification outcomes.
- Update traceability documentation to reflect production application of migration 360-142 with recorded schema migration fingerprint.
- Correct the reporting commercial ADR reference and document production application and verification of migration 360-275 with its fingerprint.