### PR TITLE
ci(release): rendre le déploiement backend relançable #141

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: 🚀 Deploy ERP Backend to VPS
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
GitHub Actions était désactivé au moment du merge main de la release. Actions est réactivé et ce changement ajoute workflow_dispatch au workflow de déploiement, sans modifier le déclenchement automatique sur main. Cela permet une reprise contrôlée sans commit artificiel.

## Summary by Sourcery

CI:
- Add a workflow_dispatch trigger to the backend deploy GitHub Actions workflow to allow manual reruns without extra commits.