### PR TITLE
release: rétablir le déclenchement backend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: 🚀 Deploy ERP Backend to VPS
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main


### PR DESCRIPTION
Suite de la release #152. Actions a été réactivé ; cette PR ajoute uniquement workflow_dispatch au workflow backend et conserve le push main automatique. La CI backend de la PR #155 est verte (typecheck + tests).

## Summary by Sourcery

CI:
- Add workflow_dispatch trigger to the backend deployment GitHub Actions workflow to allow manual runs.