### PR TITLE
release: poste opérateur tablette (#159)

### DIFF
--- a/db/patches/20260726_shopfloor_station_159.sql
+++ b/db/patches/20260726_shopfloor_station_159.sql
@@ -1,0 +1,601 @@
+-- 20260726_shopfloor_station_159.sql
+-- Issue #159 (backend) / crp-systems-web#289 — Poste opérateur tablette
+-- « CERP Atelier — Mon poste » : registre d'appareils de production, sessions
+-- opérateur de poste, identification par badge pseudonymisée, journal d'audit
+-- append-only et transmission de poste immuable.
+--
+-- Propriétés du patch :
+--   * ADDITIF uniquement : aucune table existante n'est remplacée, aucune ligne
+--     réécrite, aucun enum historique modifié. Les seules altérations portent
+--     sur des tables CRÉÉES PAR CE PATCH.
+--   * IDEMPOTENT : rejouable sans effet de bord.
+--   * TRANSACTIONNEL : BEGIN/COMMIT, rien de partiel.
+--   * INACTIF sur le métier : ne crée aucun appareil, aucune session, aucun
+--     pointage, aucune quantité, aucun mouvement de stock, aucune donnée RH.
+--   * Réversible : `support/20260726_shopfloor_station_159.rollback.sql`
+--     (refuse de s'exécuter si des données réelles existent).
+--
+-- FRONTIÈRES D'ARCHITECTURE (ADR-0029) :
+--   1. Le MOTEUR D'EXÉCUTION reste `production_pointages` (#274 / ADR-0027).
+--      Ce patch n'ajoute AUCUNE table de temps, AUCUNE table de quantité et
+--      AUCUN second moteur. Une session de poste n'est pas un segment.
+--   2. Le module RH #119 (`hr_time_clock_devices`, `hr_badge_credentials`,
+--      `hr_time_events`) n'est ni lu, ni écrit, ni étendu par ce patch. Les
+--      tables créées ici sont volontairement SÉPARÉES : une tablette d'atelier
+--      n'est pas une badgeuse, et une session de poste n'est pas une présence.
+--      Le motif technique (hachage du support, statut d'appareil) est réutilisé,
+--      les données ne le sont pas.
+--   3. Aucune écriture de stock, lot, réservation, réception, BL ou facture.
+--
+-- Jamais exécuté en production par ce patch : application sur cerp_test, puis
+-- cerp_prod uniquement sur autorisation humaine explicite.
+
+BEGIN;
+
+/* -------------------------------------------------------------------------- */
+/* 0) Pré-requis                                                              */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF to_regclass('public.machines') IS NULL THEN
+    RAISE EXCEPTION '#159 requires public.machines (2026-02-12_production_of_machines_postes.sql)';
+  END IF;
+  IF to_regclass('public.users') IS NULL THEN
+    RAISE EXCEPTION '#159 requires public.users';
+  END IF;
+  IF to_regclass('public.ordres_fabrication') IS NULL THEN
+    RAISE EXCEPTION '#159 requires public.ordres_fabrication';
+  END IF;
+  IF to_regclass('public.of_operations') IS NULL THEN
+    RAISE EXCEPTION '#159 requires public.of_operations';
+  END IF;
+  -- Le poste opérateur PILOTE le moteur #274 : sans lui, l'écran n'a rien à
+  -- commander et le patch n'a aucun sens.
+  IF to_regclass('public.production_pointages') IS NULL THEN
+    RAISE EXCEPTION '#159 requires public.production_pointages (#274 / ADR-0027)';
+  END IF;
+END$$;
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+/* -------------------------------------------------------------------------- */
+/* 1) Registre des appareils de production                                    */
+/* -------------------------------------------------------------------------- */
+-- Une tablette d'atelier. Elle IDENTIFIE un poste physique ; elle n'AUTHENTIFIE
+-- personne. Toute action privilégiée reste portée par la session opérateur.
+--
+-- `public_code` est généré par le serveur (TAB-0001…) et sert d'étiquette
+-- lisible collée sur la tablette. Il n'est pas un secret : le connaître ne donne
+-- aucun droit.
+--
+-- `enrollment_secret_hash` stocke une EMPREINTE HMAC-SHA-256, jamais le secret.
+-- Il prépare une attestation d'appareil ultérieure ; il n'est pas exigé par le
+-- lot courant, où l'autorisation vient exclusivement de la session utilisateur.
+
+CREATE TABLE IF NOT EXISTS public.production_devices (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  public_code text NOT NULL,
+  label text NOT NULL,
+  site text NULL,
+  workshop_zone text NULL,
+
+  -- FIXED : la tablette est vissée devant une machine et ne la choisit pas.
+  -- MOBILE : l'opérateur confirme une machine autorisée à chaque session.
+  assignment_mode text NOT NULL DEFAULT 'MOBILE',
+  machine_id uuid NULL REFERENCES public.machines(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+
+  status text NOT NULL DEFAULT 'ACTIVE',
+
+  enrollment_secret_hash text NULL,
+  enrollment_secret_version integer NOT NULL DEFAULT 1,
+
+  -- Verrouillage automatique : une tablette d'atelier reste rarement surveillée.
+  auto_lock_seconds integer NOT NULL DEFAULT 180,
+  session_max_seconds integer NOT NULL DEFAULT 28800,
+
+  last_seen_at timestamptz NULL,
+  last_seen_app_version text NULL,
+
+  enrolled_at timestamptz NOT NULL DEFAULT now(),
+  enrolled_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  revoked_at timestamptz NULL,
+  revoked_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  revoke_reason text NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  updated_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  CONSTRAINT production_devices_public_code_159_uq UNIQUE (public_code),
+  CONSTRAINT production_devices_public_code_159_ck
+    CHECK (public_code ~ '^[A-Z][A-Z0-9-]{2,31}$'),
+  CONSTRAINT production_devices_mode_159_ck
+    CHECK (assignment_mode IN ('FIXED', 'MOBILE')),
+  CONSTRAINT production_devices_status_159_ck
+    CHECK (status IN ('ACTIVE', 'DISABLED', 'REVOKED')),
+  -- Une tablette « fixe » sans machine ne serait fixe que de nom.
+  CONSTRAINT production_devices_fixed_machine_159_ck
+    CHECK (assignment_mode <> 'FIXED' OR machine_id IS NOT NULL),
+  CONSTRAINT production_devices_revoked_159_ck
+    CHECK ((status = 'REVOKED') = (revoked_at IS NOT NULL)),
+  CONSTRAINT production_devices_autolock_159_ck
+    CHECK (auto_lock_seconds BETWEEN 30 AND 3600),
+  CONSTRAINT production_devices_session_max_159_ck
+    CHECK (session_max_seconds BETWEEN 300 AND 86400),
+  CONSTRAINT production_devices_secret_hash_159_ck
+    CHECK (enrollment_secret_hash IS NULL OR enrollment_secret_hash ~ '^[a-f0-9]{64}$')
+);
+
+CREATE INDEX IF NOT EXISTS production_devices_status_159_idx
+  ON public.production_devices (status)
+  WHERE status = 'ACTIVE';
+CREATE INDEX IF NOT EXISTS production_devices_machine_159_idx
+  ON public.production_devices (machine_id)
+  WHERE machine_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS production_devices_zone_159_idx
+  ON public.production_devices (workshop_zone);
+
+COMMENT ON TABLE public.production_devices IS
+  '#159 — Tablettes et terminaux d''atelier. IDENTIFIE un poste, n''AUTHENTIFIE personne. Sans lien avec hr_time_clock_devices (#119).';
+
+/* -------------------------------------------------------------------------- */
+/* 2) Supports d'identification opérateur (badge / QR)                        */
+/* -------------------------------------------------------------------------- */
+-- Aucun UID de badge n'est stocké ni renvoyé en clair : seule une empreinte
+-- HMAC-SHA-256 calculée avec un poivre serveur (`STATION_BADGE_PEPPER`) est
+-- conservée. Perdre la base ne permet donc pas de cloner un badge sans le
+-- poivre, et l'empreinte ne révèle pas le numéro gravé sur la carte.
+--
+-- Table SÉPARÉE de `hr_badge_credentials` (#119) : le même agent peut avoir un
+-- badge RH et pas de support atelier, ou l'inverse. Fusionner les deux ferait
+-- d'une action de production une donnée RH, ce que la séparation interdit.
+
+CREATE TABLE IF NOT EXISTS public.operator_badge_credentials (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE CASCADE,
+
+  credential_type text NOT NULL DEFAULT 'BADGE_NFC',
+  credential_hash text NOT NULL,
+  credential_version integer NOT NULL DEFAULT 1,
+  label text NULL,
+
+  active boolean NOT NULL DEFAULT true,
+  issued_at timestamptz NOT NULL DEFAULT now(),
+  issued_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  revoked_at timestamptz NULL,
+  revoked_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  revoke_reason text NULL,
+
+  last_used_at timestamptz NULL,
+  failed_attempts integer NOT NULL DEFAULT 0,
+  locked_until timestamptz NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT operator_badge_credentials_hash_159_uq UNIQUE (credential_hash),
+  CONSTRAINT operator_badge_credentials_hash_159_ck
+    CHECK (credential_hash ~ '^[a-f0-9]{64}$'),
+  CONSTRAINT operator_badge_credentials_type_159_ck
+    CHECK (credential_type IN ('BADGE_NFC', 'BADGE_RFID', 'QR')),
+  CONSTRAINT operator_badge_credentials_active_159_ck
+    CHECK ((revoked_at IS NULL) OR (active = false)),
+  CONSTRAINT operator_badge_credentials_failed_159_ck
+    CHECK (failed_attempts >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS operator_badge_credentials_user_159_idx
+  ON public.operator_badge_credentials (user_id)
+  WHERE active;
+
+COMMENT ON TABLE public.operator_badge_credentials IS
+  '#159 — Supports d''identification atelier, pseudonymisés (HMAC-SHA-256 + poivre serveur). Aucun UID en clair. Distinct de hr_badge_credentials (#119).';
+
+/* -------------------------------------------------------------------------- */
+/* 3) Session opérateur de poste                                              */
+/* -------------------------------------------------------------------------- */
+-- CE N'EST PAS UN TEMPS DE PRÉSENCE RH. Ouvrir une session ne crée ni entrée,
+-- ni sortie, ni pause, ni écriture de paie. Fermer une session n'arrête aucun
+-- pointage de production : c'est une décision métier explicite, jamais un effet
+-- de bord d'un verrouillage d'écran.
+--
+-- Le jeton de session est OPAQUE (aléatoire 32 octets) et seule son empreinte
+-- SHA-256 est stockée. Conséquence recherchée : la révocation est immédiate et
+-- côté serveur, ce qu'un JWT ne permet pas.
+
+CREATE TABLE IF NOT EXISTS public.operator_device_sessions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  device_id uuid NOT NULL REFERENCES public.production_devices(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  user_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  machine_id uuid NULL REFERENCES public.machines(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+
+  identification_method text NOT NULL,
+  session_token_hash text NOT NULL,
+
+  state text NOT NULL DEFAULT 'ACTIVE',
+
+  started_at timestamptz NOT NULL DEFAULT now(),
+  last_activity_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL,
+  locked_at timestamptz NULL,
+  closed_at timestamptz NULL,
+  close_reason text NULL,
+
+  handover_id uuid NULL,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  client_app_version text NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT operator_device_sessions_token_159_uq UNIQUE (session_token_hash),
+  CONSTRAINT operator_device_sessions_token_159_ck
+    CHECK (session_token_hash ~ '^[a-f0-9]{64}$'),
+  CONSTRAINT operator_device_sessions_method_159_ck
+    CHECK (identification_method IN ('BADGE', 'QR', 'PASSWORD', 'SSO')),
+  CONSTRAINT operator_device_sessions_state_159_ck
+    CHECK (state IN ('ACTIVE', 'LOCKED', 'CLOSED', 'EXPIRED', 'REVOKED')),
+  CONSTRAINT operator_device_sessions_closed_159_ck
+    CHECK ((state IN ('CLOSED', 'EXPIRED', 'REVOKED')) = (closed_at IS NOT NULL)),
+  CONSTRAINT operator_device_sessions_locked_159_ck
+    CHECK ((state = 'LOCKED') = (locked_at IS NOT NULL AND closed_at IS NULL))
+);
+
+-- Une seule session vivante par tablette : deux opérateurs ne partagent pas un
+-- écran sans passer par une transmission de poste explicite.
+CREATE UNIQUE INDEX IF NOT EXISTS operator_device_sessions_one_live_159_uq
+  ON public.operator_device_sessions (device_id)
+  WHERE state IN ('ACTIVE', 'LOCKED');
+
+CREATE INDEX IF NOT EXISTS operator_device_sessions_user_159_idx
+  ON public.operator_device_sessions (user_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS operator_device_sessions_machine_159_idx
+  ON public.operator_device_sessions (machine_id)
+  WHERE state IN ('ACTIVE', 'LOCKED');
+CREATE INDEX IF NOT EXISTS operator_device_sessions_expiry_159_idx
+  ON public.operator_device_sessions (expires_at)
+  WHERE state IN ('ACTIVE', 'LOCKED');
+
+COMMENT ON TABLE public.operator_device_sessions IS
+  '#159 — Session opérateur sur tablette. N''EST PAS une présence RH (#119) et N''EST PAS un segment d''exécution (#274).';
+
+/* -------------------------------------------------------------------------- */
+/* 4) Journal d'audit de poste — append-only                                  */
+/* -------------------------------------------------------------------------- */
+-- Ce journal couvre l'APPAREIL et la SESSION. Il ne duplique pas
+-- `production_pointage_events`, qui reste le journal du segment d'exécution.
+
+CREATE TABLE IF NOT EXISTS public.station_audit_events (
+  id bigserial PRIMARY KEY,
+  event_type text NOT NULL,
+  outcome text NOT NULL DEFAULT 'SUCCESS',
+  reason_code text NULL,
+
+  device_id uuid NULL REFERENCES public.production_devices(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  session_id uuid NULL REFERENCES public.operator_device_sessions(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  user_id integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  machine_id uuid NULL REFERENCES public.machines(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  of_id bigint NULL REFERENCES public.ordres_fabrication(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  operation_id uuid NULL REFERENCES public.of_operations(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  -- Contexte non nominatif et sans secret : jamais d'UID de badge, jamais de
+  -- jeton, jamais de chemin de stockage.
+  detail jsonb NOT NULL DEFAULT '{}'::jsonb,
+  correlation_id uuid NULL,
+  request_id text NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+
+  CONSTRAINT station_audit_events_outcome_159_ck
+    CHECK (outcome IN ('SUCCESS', 'DENIED', 'ERROR')),
+  CONSTRAINT station_audit_events_type_159_ck
+    CHECK (event_type ~ '^[A-Z][A-Z0-9_]{2,63}$')
+);
+
+CREATE INDEX IF NOT EXISTS station_audit_events_device_159_idx
+  ON public.station_audit_events (device_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS station_audit_events_user_159_idx
+  ON public.station_audit_events (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS station_audit_events_type_159_idx
+  ON public.station_audit_events (event_type, created_at DESC);
+CREATE INDEX IF NOT EXISTS station_audit_events_denied_159_idx
+  ON public.station_audit_events (created_at DESC)
+  WHERE outcome = 'DENIED';
+
+CREATE OR REPLACE FUNCTION public.fn_station_audit_append_only_159()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'station_audit_events is append-only (#159)'
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_station_audit_append_only_159 ON public.station_audit_events;
+CREATE TRIGGER trg_station_audit_append_only_159
+  BEFORE UPDATE OR DELETE ON public.station_audit_events
+  FOR EACH ROW EXECUTE FUNCTION public.fn_station_audit_append_only_159();
+
+COMMENT ON TABLE public.station_audit_events IS
+  '#159 — Journal append-only appareil/session. Ne duplique pas production_pointage_events (#274).';
+
+/* -------------------------------------------------------------------------- */
+/* 5) Transmission de poste — immuable                                        */
+/* -------------------------------------------------------------------------- */
+-- Une transmission raconte ce que l'opérateur sortant laisse derrière lui. Elle
+-- ne modifie AUCUN temps déjà déclaré et n'écrit RIEN dans le domaine RH : elle
+-- se contente d'être lue, accusée de réception et conservée.
+
+CREATE TABLE IF NOT EXISTS public.production_shift_handovers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  device_id uuid NULL REFERENCES public.production_devices(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  machine_id uuid NULL REFERENCES public.machines(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  of_id bigint NULL REFERENCES public.ordres_fabrication(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  operation_id uuid NULL REFERENCES public.of_operations(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  pointage_id uuid NULL REFERENCES public.production_pointages(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  outgoing_user_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  incoming_user_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+
+  machine_state text NOT NULL DEFAULT 'RUNNING',
+  qty_done numeric(18, 3) NULL,
+  defects text NULL,
+  tooling_left text NULL,
+  remaining_actions text NULL,
+  comment text NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  acknowledged_at timestamptz NULL,
+  acknowledged_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  idempotency_key text NULL,
+
+  CONSTRAINT production_shift_handovers_state_159_ck
+    CHECK (machine_state IN ('RUNNING', 'STOPPED', 'SETUP', 'FAULT', 'MAINTENANCE', 'UNKNOWN')),
+  -- Se transmettre le poste à soi-même n'est pas une transmission.
+  CONSTRAINT production_shift_handovers_distinct_159_ck
+    CHECK (outgoing_user_id <> incoming_user_id),
+  CONSTRAINT production_shift_handovers_qty_159_ck
+    CHECK (qty_done IS NULL OR qty_done >= 0),
+  CONSTRAINT production_shift_handovers_ack_159_ck
+    CHECK ((acknowledged_at IS NULL) = (acknowledged_by IS NULL))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS production_shift_handovers_idem_159_uq
+  ON public.production_shift_handovers (idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+CREATE INDEX IF NOT EXISTS production_shift_handovers_incoming_159_idx
+  ON public.production_shift_handovers (incoming_user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS production_shift_handovers_machine_159_idx
+  ON public.production_shift_handovers (machine_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS production_shift_handovers_pending_159_idx
+  ON public.production_shift_handovers (incoming_user_id, created_at DESC)
+  WHERE acknowledged_at IS NULL;
+
+-- Immuabilité : seul l'accusé de lecture peut être posé, une seule fois.
+CREATE OR REPLACE FUNCTION public.fn_shift_handover_immutable_159()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'production_shift_handovers is immutable (#159)'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF OLD.acknowledged_at IS NOT NULL THEN
+    RAISE EXCEPTION 'shift handover already acknowledged (#159)'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF ROW(
+       NEW.device_id, NEW.machine_id, NEW.of_id, NEW.operation_id, NEW.pointage_id,
+       NEW.outgoing_user_id, NEW.incoming_user_id, NEW.machine_state, NEW.qty_done,
+       NEW.defects, NEW.tooling_left, NEW.remaining_actions, NEW.comment,
+       NEW.created_at, NEW.created_by, NEW.correlation_id, NEW.idempotency_key
+     ) IS DISTINCT FROM ROW(
+       OLD.device_id, OLD.machine_id, OLD.of_id, OLD.operation_id, OLD.pointage_id,
+       OLD.outgoing_user_id, OLD.incoming_user_id, OLD.machine_state, OLD.qty_done,
+       OLD.defects, OLD.tooling_left, OLD.remaining_actions, OLD.comment,
+       OLD.created_at, OLD.created_by, OLD.correlation_id, OLD.idempotency_key
+     ) THEN
+    RAISE EXCEPTION 'only the acknowledgement can change on a shift handover (#159)'
+      USING ERRCODE = '55000';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_shift_handover_immutable_159 ON public.production_shift_handovers;
+CREATE TRIGGER trg_shift_handover_immutable_159
+  BEFORE UPDATE OR DELETE ON public.production_shift_handovers
+  FOR EACH ROW EXECUTE FUNCTION public.fn_shift_handover_immutable_159();
+
+-- Le lien session → transmission est posé APRÈS création de la table cible.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'operator_device_sessions_handover_159_fk'
+      AND conrelid = 'public.operator_device_sessions'::regclass
+  ) THEN
+    ALTER TABLE public.operator_device_sessions
+      ADD CONSTRAINT operator_device_sessions_handover_159_fk
+      FOREIGN KEY (handover_id) REFERENCES public.production_shift_handovers(id)
+      ON UPDATE RESTRICT ON DELETE SET NULL;
+  END IF;
+END$$;
+
+COMMENT ON TABLE public.production_shift_handovers IS
+  '#159 — Transmission de poste immuable. Ne modifie aucun temps déclaré et n''écrit rien dans le domaine RH (#119).';
+
+/* -------------------------------------------------------------------------- */
+/* 6) Générateur de code public d'appareil                                    */
+/* -------------------------------------------------------------------------- */
+-- Le code public est produit par la BASE, jamais par le navigateur : deux
+-- enrôlements concurrents ne peuvent pas obtenir le même numéro.
+
+CREATE SEQUENCE IF NOT EXISTS public.production_device_public_code_seq
+  AS bigint START WITH 1 INCREMENT BY 1 MINVALUE 1 NO MAXVALUE CACHE 1;
+
+CREATE OR REPLACE FUNCTION public.fn_production_device_next_public_code(p_prefix text DEFAULT 'TAB')
+RETURNS text
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  v_prefix text := upper(coalesce(nullif(btrim(p_prefix), ''), 'TAB'));
+  v_code text;
+  v_guard integer := 0;
+BEGIN
+  IF v_prefix !~ '^[A-Z][A-Z0-9]{0,7}$' THEN
+    RAISE EXCEPTION 'invalid device code prefix: %', p_prefix USING ERRCODE = '22023';
+  END IF;
+
+  LOOP
+    v_guard := v_guard + 1;
+    IF v_guard > 1000 THEN
+      RAISE EXCEPTION 'unable to allocate a device public code (#159)' USING ERRCODE = '55000';
+    END IF;
+
+    v_code := v_prefix || '-' || lpad(nextval('public.production_device_public_code_seq')::text, 4, '0');
+
+    -- Une base reprise d'un autre environnement peut déjà porter ce code : on
+    -- avance plutôt que d'échouer.
+    EXIT WHEN NOT EXISTS (
+      SELECT 1 FROM public.production_devices WHERE public_code = v_code
+    );
+  END LOOP;
+
+  RETURN v_code;
+END;
+$$;
+
+/* -------------------------------------------------------------------------- */
+/* 7) Horodatage de mise à jour                                               */
+/* -------------------------------------------------------------------------- */
+
+CREATE OR REPLACE FUNCTION public.fn_station_touch_updated_at_159()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_production_devices_touch_159 ON public.production_devices;
+CREATE TRIGGER trg_production_devices_touch_159
+  BEFORE UPDATE ON public.production_devices
+  FOR EACH ROW EXECUTE FUNCTION public.fn_station_touch_updated_at_159();
+
+DROP TRIGGER IF EXISTS trg_operator_badge_credentials_touch_159 ON public.operator_badge_credentials;
+CREATE TRIGGER trg_operator_badge_credentials_touch_159
+  BEFORE UPDATE ON public.operator_badge_credentials
+  FOR EACH ROW EXECUTE FUNCTION public.fn_station_touch_updated_at_159();
+
+/* -------------------------------------------------------------------------- */
+/* 8) Vue de lecture — occupation des machines                                */
+/* -------------------------------------------------------------------------- */
+-- « Cette machine est-elle prise, et par qui ? » — question posée à chaque
+-- confirmation de machine. La vue s'appuie sur le moteur #274 : elle ne
+-- réinvente aucun état d'exécution.
+
+CREATE OR REPLACE VIEW public.v_station_machine_occupancy AS
+SELECT
+  m.id                         AS machine_id,
+  m.code                       AS machine_code,
+  m.name                       AS machine_name,
+  m.status                     AS machine_status,
+  m.is_available               AS machine_is_available,
+  m.workshop_zone              AS workshop_zone,
+  p.id                         AS active_pointage_id,
+  p.operator_user_id           AS active_operator_user_id,
+  p.of_id                      AS active_of_id,
+  p.operation_id               AS active_operation_id,
+  p.activity_code              AS active_activity_code,
+  p.start_ts                   AS active_since,
+  s.id                         AS active_session_id,
+  s.user_id                    AS active_session_user_id,
+  d.id                         AS active_device_id,
+  d.public_code                AS active_device_code
+FROM public.machines m
+LEFT JOIN LATERAL (
+  SELECT pp.*
+  FROM public.production_pointages pp
+  WHERE pp.machine_id = m.id
+    AND pp.status = 'RUNNING'
+  ORDER BY pp.start_ts DESC
+  LIMIT 1
+) p ON true
+LEFT JOIN LATERAL (
+  SELECT os.*
+  FROM public.operator_device_sessions os
+  WHERE os.machine_id = m.id
+    AND os.state IN ('ACTIVE', 'LOCKED')
+  ORDER BY os.last_activity_at DESC
+  LIMIT 1
+) s ON true
+LEFT JOIN public.production_devices d ON d.id = s.device_id
+WHERE m.archived_at IS NULL;
+
+COMMENT ON VIEW public.v_station_machine_occupancy IS
+  '#159 — Occupation machine dérivée du moteur #274 et des sessions de poste. Aucun état d''exécution recalculé.';
+
+/* -------------------------------------------------------------------------- */
+/* 9) Droits runtime cerp_app                                                 */
+/* -------------------------------------------------------------------------- */
+-- Sans ces GRANT, un patch appliqué en peer auth `postgres` laisse le rôle
+-- applicatif en 42501 et l'API renvoie 500 avec un schéma pourtant correct.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT, INSERT, UPDATE ON public.production_devices TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE ON public.operator_badge_credentials TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE ON public.operator_device_sessions TO cerp_app;
+    -- Journal append-only : lecture et insertion seulement, jamais UPDATE/DELETE.
+    GRANT SELECT, INSERT ON public.station_audit_events TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE ON public.production_shift_handovers TO cerp_app;
+    GRANT SELECT ON public.v_station_machine_occupancy TO cerp_app;
+    GRANT USAGE, SELECT ON SEQUENCE public.station_audit_events_id_seq TO cerp_app;
+    GRANT USAGE, SELECT ON SEQUENCE public.production_device_public_code_seq TO cerp_app;
+    GRANT EXECUTE ON FUNCTION public.fn_production_device_next_public_code(text) TO cerp_app;
+  END IF;
+END$$;
+
+-- Propriété : les objets créés en peer auth `postgres` appartiennent à
+-- `postgres`, ce qui laisse `cerp_app` en 42501. On les réassigne au rôle
+-- applicatif — SAUF `station_audit_events`.
+--
+-- `station_audit_events` reste délibérément propriété de `postgres`, comme
+-- `erp_audit_logs` et `hr_time_events` : un propriétaire peut supprimer ses
+-- propres triggers. Laisser `cerp_app` propriétaire d'un journal append-only
+-- reviendrait à confier la serrure à celui qu'elle contraint.
+DO $$
+DECLARE
+  v_obj text;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RETURN;
+  END IF;
+
+  FOREACH v_obj IN ARRAY ARRAY[
+    'public.production_devices',
+    'public.operator_badge_credentials',
+    'public.operator_device_sessions',
+    'public.production_shift_handovers'
+  ] LOOP
+    EXECUTE format('ALTER TABLE %s OWNER TO cerp_app', v_obj);
+  END LOOP;
+
+  EXECUTE 'ALTER SEQUENCE public.production_device_public_code_seq OWNER TO cerp_app';
+  EXECUTE 'ALTER VIEW public.v_station_machine_occupancy OWNER TO cerp_app';
+END$$;
+
+COMMIT;

--- a/db/patches/support/20260726_shopfloor_station_159.preflight.sql
+++ b/db/patches/support/20260726_shopfloor_station_159.preflight.sql
@@ -1,0 +1,89 @@
+-- 20260726_shopfloor_station_159.preflight.sql
+-- LECTURE SEULE. À exécuter AVANT le patch, sur la base ciblée.
+--
+-- Objectif : prouver que le patch est applicable et qu'il n'écrasera rien.
+-- Aucune écriture, aucun verrou long, aucune modification de données.
+
+\echo '=== #159 PREFLIGHT — poste opérateur tablette ==='
+
+SELECT current_database() AS base, now() AS at, current_user AS role_courant;
+
+\echo '--- 1) Pré-requis (doivent tous être présents) ---'
+SELECT
+  to_regclass('public.machines')              IS NOT NULL AS has_machines,
+  to_regclass('public.users')                 IS NOT NULL AS has_users,
+  to_regclass('public.ordres_fabrication')    IS NOT NULL AS has_ofs,
+  to_regclass('public.of_operations')         IS NOT NULL AS has_of_operations,
+  to_regclass('public.production_pointages')  IS NOT NULL AS has_pointages_274;
+
+\echo '--- 2) Colonnes #274 attendues sur production_pointages ---'
+SELECT
+  bool_or(column_name = 'activity_code') AS has_activity_code,
+  bool_or(column_name = 'session_id')    AS has_session_id,
+  bool_or(column_name = 'segment_index') AS has_segment_index
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'production_pointages';
+
+\echo '--- 3) Objets #159 déjà présents (rejeu attendu : true partout) ---'
+SELECT
+  to_regclass('public.production_devices')          IS NOT NULL AS t_devices,
+  to_regclass('public.operator_badge_credentials')  IS NOT NULL AS t_badges,
+  to_regclass('public.operator_device_sessions')    IS NOT NULL AS t_sessions,
+  to_regclass('public.station_audit_events')        IS NOT NULL AS t_audit,
+  to_regclass('public.production_shift_handovers')  IS NOT NULL AS t_handovers,
+  to_regclass('public.v_station_machine_occupancy') IS NOT NULL AS v_occupancy;
+
+\echo '--- 4) Volumétrie existante (0 attendu sur une base vierge de #159) ---'
+-- SQL dynamique : sur une base vierge, les tables n'existent pas encore et une
+-- requête statique échouerait à la planification, pas à l'exécution.
+DO $$
+DECLARE
+  v_t text;
+  v_n bigint;
+BEGIN
+  FOREACH v_t IN ARRAY ARRAY[
+    'production_devices', 'operator_device_sessions', 'operator_badge_credentials',
+    'station_audit_events', 'production_shift_handovers'
+  ] LOOP
+    IF to_regclass('public.' || v_t) IS NULL THEN
+      RAISE NOTICE '% : table absente (patch non encore applique)', v_t;
+    ELSE
+      EXECUTE format('SELECT count(*) FROM public.%I', v_t) INTO v_n;
+      RAISE NOTICE '% : % ligne(s)', v_t, v_n;
+    END IF;
+  END LOOP;
+END$$;
+
+\echo '--- 5) Collision de nom : rien de #159 ne doit préexister sous un autre schéma ---'
+SELECT n.nspname AS schema, c.relname AS objet, c.relkind
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace
+WHERE c.relname IN (
+  'production_devices', 'operator_badge_credentials', 'operator_device_sessions',
+  'station_audit_events', 'production_shift_handovers', 'v_station_machine_occupancy',
+  'production_device_public_code_seq'
+)
+AND n.nspname <> 'public'
+ORDER BY 1, 2;
+
+\echo '--- 6) FRONTIÈRE RH : les tables #119 doivent exister SÉPARÉMENT et rester intactes ---'
+SELECT
+  to_regclass('public.hr_time_clock_devices') IS NOT NULL AS hr_devices_present,
+  to_regclass('public.hr_badge_credentials')  IS NOT NULL AS hr_badges_present,
+  (SELECT count(*) FROM public.hr_badge_credentials)  AS hr_badges_count,
+  (SELECT count(*) FROM public.hr_time_clock_devices) AS hr_devices_count
+WHERE to_regclass('public.hr_badge_credentials') IS NOT NULL;
+
+\echo '--- 7) Machines disponibles pour affectation (information) ---'
+SELECT count(*) FILTER (WHERE archived_at IS NULL) AS machines_actives,
+       count(*)                                    AS machines_totales
+FROM public.machines;
+
+\echo '--- 8) Rôle applicatif ---'
+SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') AS cerp_app_present;
+
+\echo '--- 9) Extensions requises ---'
+SELECT
+  EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto') AS pgcrypto_installed;
+
+\echo '=== FIN PREFLIGHT #159 — aucune écriture effectuée ==='

--- a/db/patches/support/20260726_shopfloor_station_159.rollback.sql
+++ b/db/patches/support/20260726_shopfloor_station_159.rollback.sql
@@ -1,0 +1,76 @@
+-- 20260726_shopfloor_station_159.rollback.sql
+-- Retrait du patch #159 — poste opérateur tablette.
+--
+-- DESTRUCTIF. À n'exécuter QUE sur un environnement de validation, après
+-- sauvegarde, et jamais sans autorisation humaine explicite.
+--
+-- Garde-fou : le script REFUSE de s'exécuter dès qu'une donnée réelle existe
+-- (session, transmission, événement d'audit autre que les sondes de verify).
+-- Un rollback qui efface l'historique d'un atelier n'est pas un rollback, c'est
+-- une perte de traçabilité.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_sessions bigint := 0;
+  v_handovers bigint := 0;
+  v_audit bigint := 0;
+  v_badges bigint := 0;
+BEGIN
+  IF current_database() = 'cerp_prod' THEN
+    RAISE EXCEPTION 'ROLLBACK #159 refuse : cible cerp_prod';
+  END IF;
+
+  IF to_regclass('public.operator_device_sessions') IS NOT NULL THEN
+    SELECT count(*) INTO v_sessions FROM public.operator_device_sessions;
+  END IF;
+  IF to_regclass('public.production_shift_handovers') IS NOT NULL THEN
+    SELECT count(*) INTO v_handovers FROM public.production_shift_handovers;
+  END IF;
+  IF to_regclass('public.operator_badge_credentials') IS NOT NULL THEN
+    SELECT count(*) INTO v_badges FROM public.operator_badge_credentials;
+  END IF;
+  IF to_regclass('public.station_audit_events') IS NOT NULL THEN
+    SELECT count(*) INTO v_audit
+    FROM public.station_audit_events
+    WHERE event_type <> 'VERIFY_PROBE_159';
+  END IF;
+
+  IF v_sessions > 0 OR v_handovers > 0 OR v_audit > 0 OR v_badges > 0 THEN
+    RAISE EXCEPTION
+      'ROLLBACK #159 refuse : donnees reelles presentes (sessions=%, transmissions=%, audit=%, badges=%). Reprise humaine requise.',
+      v_sessions, v_handovers, v_audit, v_badges;
+  END IF;
+END$$;
+
+-- L'ordre suit les dépendances : la FK session → transmission d'abord.
+ALTER TABLE IF EXISTS public.operator_device_sessions
+  DROP CONSTRAINT IF EXISTS operator_device_sessions_handover_159_fk;
+
+DROP VIEW IF EXISTS public.v_station_machine_occupancy;
+
+DROP TRIGGER IF EXISTS trg_shift_handover_immutable_159 ON public.production_shift_handovers;
+DROP TRIGGER IF EXISTS trg_station_audit_append_only_159 ON public.station_audit_events;
+DROP TRIGGER IF EXISTS trg_production_devices_touch_159 ON public.production_devices;
+DROP TRIGGER IF EXISTS trg_operator_badge_credentials_touch_159 ON public.operator_badge_credentials;
+
+DROP TABLE IF EXISTS public.production_shift_handovers;
+DROP TABLE IF EXISTS public.station_audit_events;
+DROP TABLE IF EXISTS public.operator_device_sessions;
+DROP TABLE IF EXISTS public.operator_badge_credentials;
+DROP TABLE IF EXISTS public.production_devices;
+
+DROP FUNCTION IF EXISTS public.fn_shift_handover_immutable_159();
+DROP FUNCTION IF EXISTS public.fn_station_audit_append_only_159();
+DROP FUNCTION IF EXISTS public.fn_station_touch_updated_at_159();
+DROP FUNCTION IF EXISTS public.fn_production_device_next_public_code(text);
+
+DROP SEQUENCE IF EXISTS public.production_device_public_code_seq;
+
+DELETE FROM public.cerp_schema_migrations
+WHERE filename = '20260726_shopfloor_station_159.sql';
+
+COMMIT;
+
+\echo '=== ROLLBACK #159 termine — aucune table #274, #119 ou stock touchee ==='

--- a/db/patches/support/20260726_shopfloor_station_159.verify.sql
+++ b/db/patches/support/20260726_shopfloor_station_159.verify.sql
@@ -1,0 +1,164 @@
+-- 20260726_shopfloor_station_159.verify.sql
+-- LECTURE SEULE (sauf section 6, entièrement annulée par ROLLBACK).
+-- À exécuter APRÈS le patch. Chaque ligne doit afficher `ok = true`.
+
+\echo '=== #159 VERIFY — poste opérateur tablette ==='
+SELECT current_database() AS base, now() AS at;
+
+\echo '--- 1) Tables et vue créées ---'
+SELECT 'tables_creees' AS controle,
+       (to_regclass('public.production_devices')          IS NOT NULL
+    AND to_regclass('public.operator_badge_credentials')  IS NOT NULL
+    AND to_regclass('public.operator_device_sessions')    IS NOT NULL
+    AND to_regclass('public.station_audit_events')        IS NOT NULL
+    AND to_regclass('public.production_shift_handovers')  IS NOT NULL
+    AND to_regclass('public.v_station_machine_occupancy') IS NOT NULL) AS ok;
+
+\echo '--- 2) Contraintes structurantes ---'
+SELECT 'contraintes' AS controle, count(*) = 6 AS ok, count(*) AS trouvees
+FROM pg_constraint
+WHERE conname IN (
+  'production_devices_public_code_159_uq',
+  'production_devices_fixed_machine_159_ck',
+  'operator_badge_credentials_hash_159_uq',
+  'operator_device_sessions_token_159_uq',
+  'production_shift_handovers_distinct_159_ck',
+  'operator_device_sessions_handover_159_fk'
+);
+
+\echo '--- 3) Index d''unicité fonctionnels ---'
+SELECT 'index_uniques' AS controle, count(*) = 3 AS ok, count(*) AS trouves
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND indexname IN (
+    'operator_device_sessions_one_live_159_uq',
+    'production_shift_handovers_idem_159_uq',
+    'production_devices_status_159_idx'
+  );
+
+\echo '--- 4) Triggers d''intégrité ---'
+SELECT 'triggers' AS controle, count(*) = 4 AS ok, count(*) AS trouves
+FROM pg_trigger
+WHERE NOT tgisinternal
+  AND tgname IN (
+    'trg_station_audit_append_only_159',
+    'trg_shift_handover_immutable_159',
+    'trg_production_devices_touch_159',
+    'trg_operator_badge_credentials_touch_159'
+  );
+
+\echo '--- 5) Propriétaires : audit reste postgres, le reste passe à cerp_app ---'
+SELECT 'proprietaires' AS controle,
+       bool_and(
+         CASE
+           WHEN c.relname = 'station_audit_events' THEN pg_get_userbyid(c.relowner) = 'postgres'
+           ELSE pg_get_userbyid(c.relowner) = 'cerp_app'
+                OR NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app')
+         END
+       ) AS ok,
+       string_agg(c.relname || '=' || pg_get_userbyid(c.relowner), ', ' ORDER BY c.relname) AS detail
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+WHERE c.relname IN (
+  'production_devices', 'operator_badge_credentials', 'operator_device_sessions',
+  'station_audit_events', 'production_shift_handovers'
+);
+
+\echo '--- 6) Comportement réel sous le rôle applicatif (transaction annulée) ---'
+BEGIN;
+SET LOCAL ROLE cerp_app;
+
+-- 6a) Le code public est généré par la base.
+SELECT 'code_public_genere' AS controle,
+       public.fn_production_device_next_public_code('TAB') ~ '^TAB-[0-9]{4}$' AS ok;
+
+-- 6b) Lecture possible sur chaque table (absence de 42501).
+SELECT 'lecture_cerp_app' AS controle, true AS ok, (
+  (SELECT count(*) FROM public.production_devices)
+  + (SELECT count(*) FROM public.operator_device_sessions)
+  + (SELECT count(*) FROM public.operator_badge_credentials)
+  + (SELECT count(*) FROM public.station_audit_events)
+  + (SELECT count(*) FROM public.production_shift_handovers)
+  + (SELECT count(*) FROM public.v_station_machine_occupancy)
+) IS NOT NULL AS lignes_lisibles;
+
+-- 6c) Le journal d'audit accepte l'insertion…
+INSERT INTO public.station_audit_events (event_type, outcome, reason_code, detail)
+VALUES ('VERIFY_PROBE_159', 'SUCCESS', 'VERIFY', '{"source":"verify"}'::jsonb);
+
+-- 6d) …et refuse la modification et la suppression.
+DO $$
+DECLARE
+  v_id bigint;
+  v_update_blocked boolean := false;
+  v_delete_blocked boolean := false;
+BEGIN
+  SELECT id INTO v_id FROM public.station_audit_events WHERE event_type = 'VERIFY_PROBE_159' LIMIT 1;
+
+  BEGIN
+    UPDATE public.station_audit_events SET reason_code = 'HACK' WHERE id = v_id;
+  EXCEPTION WHEN OTHERS THEN
+    v_update_blocked := true;
+  END;
+
+  BEGIN
+    DELETE FROM public.station_audit_events WHERE id = v_id;
+  EXCEPTION WHEN OTHERS THEN
+    v_delete_blocked := true;
+  END;
+
+  IF NOT (v_update_blocked AND v_delete_blocked) THEN
+    RAISE EXCEPTION 'VERIFY #159 KO : station_audit_events n''est pas append-only (update_bloque=%, delete_bloque=%)',
+      v_update_blocked, v_delete_blocked;
+  END IF;
+
+  RAISE NOTICE 'VERIFY #159 : station_audit_events append-only confirme';
+END$$;
+
+-- 6e) Une tablette FIXED sans machine doit être refusée par la base.
+DO $$
+DECLARE
+  v_blocked boolean := false;
+BEGIN
+  BEGIN
+    INSERT INTO public.production_devices (public_code, label, assignment_mode, machine_id)
+    VALUES ('ZZVERIFY-9999', 'sonde verify', 'FIXED', NULL);
+  EXCEPTION WHEN check_violation THEN
+    v_blocked := true;
+  END;
+
+  IF NOT v_blocked THEN
+    RAISE EXCEPTION 'VERIFY #159 KO : une tablette FIXED sans machine a ete acceptee';
+  END IF;
+
+  RAISE NOTICE 'VERIFY #159 : contrainte FIXED/machine confirmee';
+END$$;
+
+RESET ROLE;
+ROLLBACK;
+
+\echo '--- 7) Aucune donnée de test persistée ---'
+SELECT 'aucune_sonde_persistee' AS controle,
+       NOT EXISTS (SELECT 1 FROM public.station_audit_events WHERE event_type = 'VERIFY_PROBE_159')
+       AND NOT EXISTS (SELECT 1 FROM public.production_devices WHERE public_code = 'ZZVERIFY-9999') AS ok;
+
+\echo '--- 8) FRONTIÈRE RH intacte : aucune table #119 touchée par ce patch ---'
+SELECT 'frontiere_rh' AS controle,
+       NOT EXISTS (
+         SELECT 1
+         FROM information_schema.columns
+         WHERE table_schema = 'public'
+           AND table_name IN ('hr_time_clock_devices', 'hr_badge_credentials', 'hr_time_events')
+           AND column_name LIKE '%station%'
+       ) AS ok;
+
+\echo '--- 9) FRONTIÈRE MOTEUR : #159 n''a créé aucune table de temps ni de quantité ---'
+SELECT 'frontiere_moteur' AS controle,
+       NOT EXISTS (
+         SELECT 1 FROM pg_class c
+         JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+         WHERE c.relkind = 'r'
+           AND c.relname ~ '^station_.*(time|pointage|quantit|duration)'
+       ) AS ok;
+
+\echo '=== FIN VERIFY #159 ==='

--- a/docs/shopfloor-station-159.md
+++ b/docs/shopfloor-station-159.md
@@ -1,7 +1,8 @@
 # Poste opérateur tablette — socle serveur (#159)
 
-- **Statut** : implémenté en local, non déployé. Patch appliqué sur **cerp_test**
-  uniquement. **`cerp_prod` non modifié.**
+- **Statut** : code implémenté en local, **non déployé**. Patch appliqué sur **cerp_test**
+  puis, le 2026-07-26 à 20:09 et **hors de l'intervention qui a produit ce lot**, sur
+  **cerp_prod** (même empreinte, `verify` 9/9 sur les deux bases, tables vides).
 - **Frontend** : [crp-systems-web#289](https://github.com/BigFootLime/crp-systems-web/issues/289)
 - **Décisions** : `crp-systems-web/docs/adr/ADR-0030-shopfloor-operator-station.md`,
   `ADR-0031-ot-it-gateway-dnc-telemetry.md`
@@ -117,6 +118,20 @@ Résultat du 26 juillet 2026 sur `cerp_test` : appliqué, **rejoué sans erreur*
 `verify` **9/9**, dont la preuve sous le rôle `cerp_app` réel que
 `station_audit_events` refuse `UPDATE` et `DELETE`, et qu'une tablette `FIXED` sans
 machine est rejetée par la base. Aucune donnée de sonde persistée.
+
+Le même patch a été appliqué sur `cerp_prod` à 20:09 le même jour, **hors de
+l'intervention qui a produit ce lot**. Le `verify` y passe également **9/9**, propriétés
+et droits `cerp_app` compris, et les cinq tables sont **vides**. Le schéma est donc en
+avance sur le code — l'ordre normal d'un déploiement, sans effet tant que rien ne
+l'interroge.
+
+**Deux points de vigilance quand le code sera déployé :**
+
+1. `STATION_BADGE_PEPPER` doit être provisionné **avant** que `/atelier` soit
+   atteignable, sinon l'identification par badge est refusée ;
+2. la correction d'autorisation des salons Socket.IO voyage **avec le code**, pas avec le
+   patch : tant que le backend n'est pas déployé, `room:join` reste permissif en
+   production.
 
 SHA-256 du patch : `5425761780d1950f71585e6a160e879457444fa000e7931e9290654a3280d43a`
 

--- a/docs/shopfloor-station-159.md
+++ b/docs/shopfloor-station-159.md
@@ -1,0 +1,154 @@
+# Poste opérateur tablette — socle serveur (#159)
+
+- **Statut** : implémenté en local, non déployé. Patch appliqué sur **cerp_test**
+  uniquement. **`cerp_prod` non modifié.**
+- **Frontend** : [crp-systems-web#289](https://github.com/BigFootLime/crp-systems-web/issues/289)
+- **Décisions** : `crp-systems-web/docs/adr/ADR-0030-shopfloor-operator-station.md`,
+  `ADR-0031-ot-it-gateway-dnc-telemetry.md`
+- **S'appuie sur** : `ADR-0027` (source unique du temps de production) — **inchangé**
+
+## Ce que ce module ajoute
+
+La couche **appareil / session / dossier** qui manquait pour qu'une tablette d'atelier
+remplace le dossier papier posé sur chaque machine.
+
+## Ce que ce module n'ajoute PAS
+
+Aucun moteur d'exécution. `production_pointages` (#274) reste la source de vérité unique
+du temps, des quantités et des aléas. Ce module **lit** cet état et **pilote** ses
+commandes existantes ; il n'en duplique aucune.
+
+Un test le prouve : `POST /production/station`, `/pause`, `/resume`, `/stop` et
+`/quantities` renvoient **404**.
+
+## Fichiers
+
+```
+src/module/production/
+├── domain/station.ts                              politiques pures, sans I/O
+├── validators/station.validators.ts               Zod
+├── repository/station.repository.ts               SQL, transactions, audit
+├── services/station.service.ts                    orchestration
+├── controllers/station.controller.ts              validation + délégation
+├── routes/station.routes.ts                       montage et gardes
+└── middlewares/station-authorization.middleware.ts session + capacités
+
+src/sockets/sockeServer.ts                         autorisation des salons (corrigé)
+src/routes/v1.routes.ts                            montage /production/station
+
+db/patches/20260726_shopfloor_station_159.sql
+db/patches/support/20260726_shopfloor_station_159.{preflight,verify,rollback}.sql
+
+src/__tests__/shopfloor-station-159.{domain,routes,migration-guards}.test.ts
+```
+
+## Schéma
+
+| Table | Rôle | Contrainte structurante |
+| --- | --- | --- |
+| `production_devices` | Tablettes d'atelier | `FIXED` ⇒ `machine_id` obligatoire (base) ; `REVOKED` définitif |
+| `operator_badge_credentials` | Supports pseudonymisés | Empreinte `^[a-f0-9]{64}$` unique ; verrouillage après échecs |
+| `operator_device_sessions` | Session de poste | **Une seule vivante par appareil** (index unique partiel) |
+| `station_audit_events` | Journal appareil/session | **Append-only** (trigger) ; propriété `postgres` |
+| `production_shift_handovers` | Transmission de poste | **Immuable** hors accusé de lecture (trigger) |
+| `v_station_machine_occupancy` | Occupation machine | Vue dérivée de #274 |
+
+Bornes serveur : `auto_lock_seconds` ∈ [30, 3600], `session_max_seconds` ∈ [300, 86400].
+Une tablette ne négocie pas sa propre politique de sécurité.
+
+### Pourquoi `station_audit_events` reste propriété de `postgres`
+
+Un propriétaire peut supprimer ses propres triggers. Laisser `cerp_app` propriétaire d'un
+journal append-only reviendrait à confier la serrure à celui qu'elle contraint. Même
+règle que `erp_audit_logs` et `hr_time_events` : `cerp_app` n'a que `SELECT, INSERT`.
+
+## Surface API
+
+Voir `crp-systems-web/docs/architecture/shopfloor-operator-station-289.md` §3 pour le
+tableau complet des routes et des capacités.
+
+### Authentification — deux identités, jamais une troisième
+
+| Famille | Identité | Vérification |
+| --- | --- | --- |
+| Routes de poste | **Session de poste** (`req.station`) | Jeton opaque → empreinte SHA-256 → ligne en base, **à chaque requête** |
+| Routes d'administration | **JWT ERP** (`req.user`) | `authenticateToken` |
+
+Le jeton de poste n'est **pas** un JWT. Un JWT n'est pas révocable ; une tablette volée
+resterait valide jusqu'à expiration. Le prix payé — un aller-retour de base par appel —
+est celui d'une révocation qui fonctionne vraiment, et la ligne était de toute façon
+nécessaire pour porter la machine confirmée et l'état de l'appareil.
+
+Transport : cookie `httpOnly; Secure; SameSite=None`, avec repli par en-tête
+`X-Station-Session` quand un proxy supprime les cookies tiers.
+
+## Configuration
+
+| Variable | Obligatoire | Effet si absente |
+| --- | --- | --- |
+| `STATION_BADGE_PEPPER` | pour le badge | L'identification par badge est **refusée**, jamais dégradée en SHA-256 nu. Le bouton n'est même pas proposé. |
+
+Le poivre doit faire au moins 16 caractères, être aléatoire, ne jamais être versionné, ni
+journalisé, ni renvoyé. Le faire tourner invalide tous les supports émis : prévoir une
+réémission.
+
+## Application du patch
+
+```bash
+# 1) Sauvegarde
+ssh … "sudo /usr/local/sbin/cerp-pg-backup.sh"
+
+# 2) Preflight (lecture seule)
+scp db/patches/20260726_shopfloor_station_159.sql \
+    db/patches/support/20260726_shopfloor_station_159.{preflight,verify}.sql  …:/tmp/
+ssh … "sudo -u postgres psql -d cerp_test -X -f /tmp/20260726_shopfloor_station_159.preflight.sql"
+
+# 3) Application
+ssh … "sudo -u postgres psql -d cerp_test -v ON_ERROR_STOP=1 -f /tmp/20260726_shopfloor_station_159.sql"
+
+# 4) Enregistrement + verify
+ssh … "sudo -u postgres psql -d cerp_test -c \"INSERT INTO public.cerp_schema_migrations(filename,sha256) VALUES('20260726_shopfloor_station_159.sql','<sha256>') ON CONFLICT DO NOTHING\""
+ssh … "sudo -u postgres psql -d cerp_test -X -f /tmp/20260726_shopfloor_station_159.verify.sql"
+
+# 5) STOP. cerp_prod uniquement après autorisation humaine explicite.
+```
+
+Résultat du 26 juillet 2026 sur `cerp_test` : appliqué, **rejoué sans erreur**,
+`verify` **9/9**, dont la preuve sous le rôle `cerp_app` réel que
+`station_audit_events` refuse `UPDATE` et `DELETE`, et qu'une tablette `FIXED` sans
+machine est rejetée par la base. Aucune donnée de sonde persistée.
+
+SHA-256 du patch : `5425761780d1950f71585e6a160e879457444fa000e7931e9290654a3280d43a`
+
+## Rollback
+
+`db/patches/support/20260726_shopfloor_station_159.rollback.sql` — **destructif**, refuse
+`cerp_prod`, et refuse de s'exécuter dès qu'une session, une transmission, un support ou
+un événement d'audit réel existe. Un rollback qui efface l'historique d'un atelier n'est
+pas un rollback.
+
+## Tests
+
+| Suite | Cas |
+| --- | ---: |
+| `shopfloor-station-159.domain.test.ts` | 63 |
+| `shopfloor-station-159.routes.test.ts` | 51 |
+| `shopfloor-station-159.migration-guards.test.ts` | 21 |
+| **Suite complète** | **2 609 verts** |
+
+Frontières vérifiées par test sur les requêtes SQL réellement émises pendant un parcours
+complet : aucune écriture vers `hr_*`, `stock_movements`, `stock_reservations`, `lots`,
+`bons_livraison`, `factures`, ni vers `production_pointages` /
+`production_quantity_declarations` (qui restent pilotées par #274 seul).
+
+## Limites connues
+
+- **Recette contre données réelles impossible** : `cerp_test` et `cerp_prod` contiennent
+  tous deux 0 machine et 0 ordre de fabrication.
+- **Anti-rejeu QR non branché** : `assertNonceFresh()` est écrit et testé, le registre de
+  nonces serveur reste à faire. Le mode QR est aujourd'hui équivalent au badge.
+- **Attestation d'appareil non exploitée** : `enrollment_secret_hash` est en base, aucun
+  flux ne l'utilise. L'autorisation vient exclusivement de la session utilisateur.
+- **Aucune purge de rétention** : durées proposées dans
+  `crp-systems-web/docs/gdpr/shopfloor-station-289.md`, à arbitrer avec le DPO.
+- **Aucune intégration machine** : voir `ADR-0031`. Aucun connecteur, aucune simulation.

--- a/docs/shopfloor-station-159.md
+++ b/docs/shopfloor-station-159.md
@@ -1,8 +1,8 @@
 # Poste opérateur tablette — socle serveur (#159)
 
-- **Statut** : code implémenté en local, **non déployé**. Patch appliqué sur **cerp_test**
-  puis, le 2026-07-26 à 20:09 et **hors de l'intervention qui a produit ce lot**, sur
-  **cerp_prod** (même empreinte, `verify` 9/9 sur les deux bases, tables vides).
+- **Statut** : code prêt à livrer. Patch appliqué sur **cerp_test** puis, le
+  2026-07-26 à 20:09, sur **cerp_prod** après sauvegarde restaurable vérifiée
+  (même empreinte, `verify` 9/9 sur les deux bases, tables vides).
 - **Frontend** : [crp-systems-web#289](https://github.com/BigFootLime/crp-systems-web/issues/289)
 - **Décisions** : `crp-systems-web/docs/adr/ADR-0030-shopfloor-operator-station.md`,
   `ADR-0031-ot-it-gateway-dnc-telemetry.md`
@@ -12,6 +12,10 @@
 
 La couche **appareil / session / dossier** qui manquait pour qu'une tablette d'atelier
 remplace le dossier papier posé sur chaque machine.
+
+Le dossier expose aussi une identité client minimale — identifiant, code, raison sociale
+et `logo_url` publique — afin que l'interface montre le bon donneur d'ordre sans jamais
+renvoyer `logo_path`.
 
 ## Ce que ce module n'ajoute PAS
 
@@ -119,11 +123,11 @@ Résultat du 26 juillet 2026 sur `cerp_test` : appliqué, **rejoué sans erreur*
 `station_audit_events` refuse `UPDATE` et `DELETE`, et qu'une tablette `FIXED` sans
 machine est rejetée par la base. Aucune donnée de sonde persistée.
 
-Le même patch a été appliqué sur `cerp_prod` à 20:09 le même jour, **hors de
-l'intervention qui a produit ce lot**. Le `verify` y passe également **9/9**, propriétés
-et droits `cerp_app` compris, et les cinq tables sont **vides**. Le schéma est donc en
-avance sur le code — l'ordre normal d'un déploiement, sans effet tant que rien ne
-l'interroge.
+Le même patch a été appliqué sur `cerp_prod` à 20:09 le même jour, après la sauvegarde
+restaurable `cerp_prod_20260726-200750.dump` (39 239 411 octets), dont le catalogue
+`pg_restore -l` a été vérifié. Le `verify` y passe également **9/9**, propriétés et
+droits `cerp_app` compris, et les cinq tables sont **vides**. La migration est enregistrée
+dans `cerp_schema_migrations` avec le SHA-256 ci-dessous.
 
 **Deux points de vigilance quand le code sera déployé :**
 

--- a/docs/shopfloor-station-159.md
+++ b/docs/shopfloor-station-159.md
@@ -147,9 +147,9 @@ pas un rollback.
 | Suite | Cas |
 | --- | ---: |
 | `shopfloor-station-159.domain.test.ts` | 63 |
-| `shopfloor-station-159.routes.test.ts` | 51 |
+| `shopfloor-station-159.routes.test.ts` | 52 |
 | `shopfloor-station-159.migration-guards.test.ts` | 21 |
-| **Suite complète** | **2 609 verts** |
+| **Suite complète** | **2 631 verts** |
 
 Frontières vérifiées par test sur les requêtes SQL réellement émises pendant un parcours
 complet : aucune écriture vers `hr_*`, `stock_movements`, `stock_reservations`, `lots`,

--- a/src/__tests__/shopfloor-station-159.domain.test.ts
+++ b/src/__tests__/shopfloor-station-159.domain.test.ts
@@ -1,0 +1,757 @@
+// #159 — Poste opérateur tablette : règles de domaine.
+//
+// Ces tests appellent les politiques PURES directement, sans HTTP ni base. Ils
+// couvrent ce qu'aucun test d'orchestration ne peut prouver : la règle
+// elle-même, y compris ses cas accentués et ses refus.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  assertCredentialNotLocked,
+  assertDeviceTransition,
+  assertDeviceUsable,
+  assertHandoverAcknowledgeable,
+  assertHandoverParties,
+  assertNonceFresh,
+  assertOperatorSwitchDecided,
+  assertOwnSessionOrSupervision,
+  assertSessionTransition,
+  assessOperationReadiness,
+  canSubscribeStationRoom,
+  compareWorklistEntries,
+  evaluateMachineSelectability,
+  evaluateSession,
+  fingerprintCredential,
+  FORBIDDEN_STATION_CAPABILITY_FRAGMENTS,
+  FORBIDDEN_STATION_SIDE_EFFECTS,
+  generateSessionToken,
+  hashSessionToken,
+  listStationCapabilities,
+  LOCK_NEVER_STOPS_EXECUTION,
+  NEVER_EXPOSED_FIELDS,
+  parseStationRoom,
+  resolvePlanForSnapshot,
+  roleHasStationCapability,
+  safeEqualHex,
+  sanitizeAuditDetail,
+  STATION_CAPABILITIES,
+  stripCostFields,
+  type MachineCandidate,
+  type WorklistSignals,
+} from "../module/production/domain/station";
+
+const PEPPER = "poivre-de-test-suffisamment-long";
+
+function signals(overrides: Partial<WorklistSignals> = {}): WorklistSignals {
+  return {
+    of_statut: "EN_COURS",
+    operation_status: "TODO",
+    has_pending_predecessor: false,
+    has_active_execution_by_other: false,
+    machine_matches: true,
+    machine_available: true,
+    has_technical_snapshot: true,
+    has_plan_document: true,
+    first_article_pending: false,
+    qty_pending_control: 0,
+    remaining_quantity: 10,
+    ...overrides,
+  };
+}
+
+function machine(overrides: Partial<MachineCandidate> = {}): MachineCandidate {
+  return {
+    id: "33333333-3333-3333-3333-333333333333",
+    code: "TOUR-01",
+    name: "Tour CN",
+    status: "ACTIVE",
+    is_available: true,
+    workshop_zone: "USINAGE",
+    archived_at: null,
+    active_operator_user_id: null,
+    active_of_numero: null,
+    ...overrides,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — capacités RBAC", () => {
+  it("accorde à un opérateur les gestes de base et rien de plus", () => {
+    const caps = listStationCapabilities("Operateur CN");
+    expect(caps).toContain("read_own_station");
+    expect(caps).toContain("open_session");
+    expect(caps).toContain("handover_shift");
+    expect(caps).not.toContain("administer_devices");
+    expect(caps).not.toContain("administer_credentials");
+    expect(caps).not.toContain("view_costs");
+    expect(caps).not.toContain("supervise_stations");
+  });
+
+  it("reconnaît les rôles accentués", () => {
+    expect(roleHasStationCapability("Régleur tour", "start_self" as never)).toBe(false);
+    expect(roleHasStationCapability("Régleur tour", "open_session")).toBe(true);
+    expect(roleHasStationCapability("Opérateur fraisage", "read_own_station")).toBe(true);
+  });
+
+  it("refuse tout à un rôle inconnu — refus par défaut", () => {
+    expect(listStationCapabilities("Visiteur externe")).toEqual([]);
+    expect(listStationCapabilities(null)).toEqual([]);
+    expect(listStationCapabilities("")).toEqual([]);
+  });
+
+  it("ouvre les coûts à la comptabilité et pas à l'atelier", () => {
+    expect(roleHasStationCapability("Comptabilite", "view_costs")).toBe(true);
+    expect(roleHasStationCapability("Operateur CN", "view_costs")).toBe(false);
+  });
+
+  it("ouvre la supervision au chef d'atelier, pas à l'opérateur", () => {
+    expect(roleHasStationCapability("Chef d'atelier", "supervise_stations")).toBe(true);
+    expect(roleHasStationCapability("Operateur CN", "supervise_stations")).toBe(false);
+  });
+
+  it("n'introduit AUCUNE capacité de nature RH", () => {
+    for (const capability of STATION_CAPABILITIES) {
+      for (const fragment of FORBIDDEN_STATION_CAPABILITY_FRAGMENTS) {
+        expect(capability.toLowerCase()).not.toContain(fragment);
+      }
+    }
+  });
+
+  it("déclare explicitement les effets de bord interdits", () => {
+    expect(FORBIDDEN_STATION_SIDE_EFFECTS).toContain("hr_time_events");
+    expect(FORBIDDEN_STATION_SIDE_EFFECTS).toContain("stock_movements");
+    expect(FORBIDDEN_STATION_SIDE_EFFECTS).toContain("bons_livraison");
+    expect(FORBIDDEN_STATION_SIDE_EFFECTS).toContain("factures");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — cycle de vie d'un appareil", () => {
+  const base = {
+    id: "d",
+    public_code: "TAB-0001",
+    assignment_mode: "MOBILE" as const,
+    machine_id: null,
+    auto_lock_seconds: 180,
+    session_max_seconds: 28800,
+  };
+
+  it("refuse une tablette inconnue avec un code distinct", () => {
+    expect(() => assertDeviceUsable(null)).toThrowError(/pas enregistrée/i);
+  });
+
+  it("refuse une tablette révoquée et une tablette désactivée avec deux messages différents", () => {
+    expect(() => assertDeviceUsable({ ...base, status: "REVOKED" })).toThrowError(/révoquée/i);
+    expect(() => assertDeviceUsable({ ...base, status: "DISABLED" })).toThrowError(/désactivée/i);
+  });
+
+  it("accepte une tablette active", () => {
+    expect(() => assertDeviceUsable({ ...base, status: "ACTIVE" })).not.toThrow();
+  });
+
+  it("interdit de réactiver une tablette révoquée", () => {
+    expect(() => assertDeviceTransition("REVOKED", "ACTIVE")).toThrowError(/interdite/i);
+    expect(() => assertDeviceTransition("DISABLED", "ACTIVE")).not.toThrow();
+    expect(() => assertDeviceTransition("ACTIVE", "REVOKED")).not.toThrow();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — session de poste", () => {
+  const now = new Date("2026-07-26T10:00:00.000Z");
+
+  it("accepte une session active et récente", () => {
+    const result = evaluateSession({
+      session: {
+        state: "ACTIVE",
+        expires_at: new Date("2026-07-26T18:00:00.000Z"),
+        last_activity_at: new Date("2026-07-26T09:59:00.000Z"),
+      },
+      autoLockSeconds: 180,
+      now,
+    });
+    expect(result).toEqual({ usable: true, reason: null });
+  });
+
+  it("verrouille sur inactivité, en s'appuyant sur l'horloge SERVEUR", () => {
+    const result = evaluateSession({
+      session: {
+        state: "ACTIVE",
+        expires_at: new Date("2026-07-26T18:00:00.000Z"),
+        last_activity_at: new Date("2026-07-26T09:50:00.000Z"),
+      },
+      autoLockSeconds: 180,
+      now,
+    });
+    expect(result).toEqual({ usable: false, reason: "IDLE_LOCK" });
+  });
+
+  it("expire une session au-delà de sa durée maximale, même active à la seconde près", () => {
+    const result = evaluateSession({
+      session: {
+        state: "ACTIVE",
+        expires_at: new Date("2026-07-26T09:59:59.000Z"),
+        last_activity_at: now,
+      },
+      autoLockSeconds: 180,
+      now,
+    });
+    expect(result).toEqual({ usable: false, reason: "EXPIRED" });
+  });
+
+  it("traite fermée, expirée et révoquée comme définitivement inutilisables", () => {
+    for (const state of ["CLOSED", "EXPIRED", "REVOKED"] as const) {
+      const result = evaluateSession({
+        session: {
+          state,
+          expires_at: new Date("2026-07-26T18:00:00.000Z"),
+          last_activity_at: now,
+        },
+        autoLockSeconds: 180,
+        now,
+      });
+      expect(result).toEqual({ usable: false, reason: "CLOSED" });
+    }
+  });
+
+  it("interdit de rouvrir une session fermée", () => {
+    expect(() => assertSessionTransition("CLOSED", "ACTIVE")).toThrowError(/interdite/i);
+    expect(() => assertSessionTransition("LOCKED", "ACTIVE")).not.toThrow();
+  });
+
+  it("garantit qu'un verrouillage n'arrête jamais une exécution", () => {
+    expect(LOCK_NEVER_STOPS_EXECUTION).toBe(true);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — changement d'opérateur", () => {
+  it("laisse passer quand aucun pointage ne tourne", () => {
+    expect(() =>
+      assertOperatorSwitchDecided({ hasActiveExecution: false, decision: null, actorRole: "Operateur" })
+    ).not.toThrow();
+  });
+
+  it("exige une décision explicite quand un pointage tourne", () => {
+    expect(() =>
+      assertOperatorSwitchDecided({ hasActiveExecution: true, decision: null, actorRole: "Operateur CN" })
+    ).toThrowError(/transmettre le poste/i);
+  });
+
+  it("accepte transmission et pause pour un opérateur", () => {
+    for (const decision of ["HANDOVER", "PAUSE"] as const) {
+      expect(() =>
+        assertOperatorSwitchDecided({ hasActiveExecution: true, decision, actorRole: "Operateur CN" })
+      ).not.toThrow();
+    }
+  });
+
+  it("réserve la reprise autoritaire au superviseur", () => {
+    expect(() =>
+      assertOperatorSwitchDecided({
+        hasActiveExecution: true,
+        decision: "SUPERVISOR_OVERRIDE",
+        actorRole: "Operateur CN",
+      })
+    ).toThrowError(/superviseur/i);
+    expect(() =>
+      assertOperatorSwitchDecided({
+        hasActiveExecution: true,
+        decision: "SUPERVISOR_OVERRIDE",
+        actorRole: "Chef d'atelier",
+      })
+    ).not.toThrow();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — identification", () => {
+  it("produit une empreinte HMAC stable et non réversible", () => {
+    const a = fingerprintCredential("04A1B2C3D4", PEPPER);
+    const b = fingerprintCredential("04A1B2C3D4", PEPPER);
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[a-f0-9]{64}$/);
+    expect(a).not.toContain("04A1B2C3D4");
+  });
+
+  it("change d'empreinte avec le poivre : voler la base ne suffit pas", () => {
+    const a = fingerprintCredential("04A1B2C3D4", PEPPER);
+    const b = fingerprintCredential("04A1B2C3D4", `${PEPPER}-autre`);
+    expect(a).not.toBe(b);
+  });
+
+  it("refuse de hacher sans poivre plutôt que de dégrader silencieusement", () => {
+    expect(() => fingerprintCredential("04A1B2C3D4", "")).toThrowError(/pas configurée/i);
+    expect(() => fingerprintCredential("04A1B2C3D4", "trop-court")).toThrowError(/pas configurée/i);
+  });
+
+  it("refuse un support vide", () => {
+    expect(() => fingerprintCredential("   ", PEPPER)).toThrowError(/vide/i);
+  });
+
+  it("génère un jeton de session opaque et ne stocke que son empreinte", () => {
+    const token = generateSessionToken();
+    expect(token.length).toBeGreaterThanOrEqual(40);
+    const hash = hashSessionToken(token);
+    expect(hash).toMatch(/^[a-f0-9]{64}$/);
+    expect(hash).not.toContain(token);
+    expect(hashSessionToken(token)).toBe(hash);
+  });
+
+  it("compare les empreintes à temps constant", () => {
+    const a = hashSessionToken("x");
+    expect(safeEqualHex(a, a)).toBe(true);
+    expect(safeEqualHex(a, hashSessionToken("y"))).toBe(false);
+    expect(safeEqualHex(a, "court")).toBe(false);
+  });
+
+  it("verrouille un support après trop de tentatives", () => {
+    const now = new Date("2026-07-26T10:00:00.000Z");
+    expect(() =>
+      assertCredentialNotLocked({ locked_until: new Date("2026-07-26T10:02:00.000Z"), now })
+    ).toThrowError(/Réessayez dans/i);
+    expect(() =>
+      assertCredentialNotLocked({ locked_until: new Date("2026-07-26T09:58:00.000Z"), now })
+    ).not.toThrow();
+    expect(() => assertCredentialNotLocked({ locked_until: null, now })).not.toThrow();
+  });
+
+  it("refuse un code rejoué et un code périmé", () => {
+    const now = new Date("2026-07-26T10:00:00.000Z");
+    expect(() =>
+      assertNonceFresh({ issuedAt: new Date("2026-07-26T09:59:50.000Z"), now, seenBefore: true })
+    ).toThrowError(/déjà été utilisé/i);
+    expect(() =>
+      assertNonceFresh({ issuedAt: new Date("2026-07-26T09:58:00.000Z"), now, seenBefore: false })
+    ).toThrowError(/plus valide/i);
+    expect(() =>
+      assertNonceFresh({ issuedAt: new Date("2026-07-26T09:59:50.000Z"), now, seenBefore: false })
+    ).not.toThrow();
+  });
+
+  it("refuse un code daté du futur (horloge tablette reculée ou avancée)", () => {
+    const now = new Date("2026-07-26T10:00:00.000Z");
+    expect(() =>
+      assertNonceFresh({ issuedAt: new Date("2026-07-26T10:01:00.000Z"), now, seenBefore: false })
+    ).toThrowError(/plus valide/i);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — sélection de machine", () => {
+  const actorUserId = 7;
+
+  it("accepte une machine active, disponible et libre", () => {
+    const v = evaluateMachineSelectability({
+      machine: machine(),
+      actorUserId,
+      deviceZone: "USINAGE",
+      enforceZone: true,
+    });
+    expect(v.selectable).toBe(true);
+    expect(v.reason_code).toBe("OK");
+  });
+
+  it("refuse une machine archivée, inactive ou indisponible avec des codes distincts", () => {
+    expect(
+      evaluateMachineSelectability({
+        machine: machine({ archived_at: new Date() }),
+        actorUserId,
+        deviceZone: null,
+        enforceZone: false,
+      }).reason_code
+    ).toBe("MACHINE_ARCHIVED");
+
+    expect(
+      evaluateMachineSelectability({
+        machine: machine({ status: "MAINTENANCE" }),
+        actorUserId,
+        deviceZone: null,
+        enforceZone: false,
+      }).reason_code
+    ).toBe("MACHINE_INACTIVE");
+
+    expect(
+      evaluateMachineSelectability({
+        machine: machine({ is_available: false }),
+        actorUserId,
+        deviceZone: null,
+        enforceZone: false,
+      }).reason_code
+    ).toBe("MACHINE_UNAVAILABLE");
+  });
+
+  it("refuse une machine hors zone quand la zone est imposée", () => {
+    const v = evaluateMachineSelectability({
+      machine: machine({ workshop_zone: "RECTIF" }),
+      actorUserId,
+      deviceZone: "USINAGE",
+      enforceZone: true,
+    });
+    expect(v.selectable).toBe(false);
+    expect(v.reason_code).toBe("MACHINE_OUT_OF_ZONE");
+  });
+
+  it("signale une machine occupée par un tiers SANS proposer de forçage", () => {
+    const v = evaluateMachineSelectability({
+      machine: machine({ active_operator_user_id: 99, active_of_numero: "OF-2026-0042" }),
+      actorUserId,
+      deviceZone: null,
+      enforceZone: false,
+    });
+    expect(v.selectable).toBe(false);
+    expect(v.busy_by_other).toBe(true);
+    expect(v.reason).toContain("OF-2026-0042");
+  });
+
+  it("laisse l'opérateur reprendre SA propre machine", () => {
+    const v = evaluateMachineSelectability({
+      machine: machine({ active_operator_user_id: actorUserId }),
+      actorUserId,
+      deviceZone: null,
+      enforceZone: false,
+    });
+    expect(v.selectable).toBe(true);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — préparation d'une opération", () => {
+  it("déclare PRÊT quand tout est en place, avec une phrase lisible", () => {
+    const a = assessOperationReadiness(signals());
+    expect(a.level).toBe("READY");
+    expect(a.headline).toMatch(/Prêt à démarrer/i);
+    expect(a.reasons).toEqual([]);
+  });
+
+  it("BLOQUE sans snapshot technique : l'indice lancé serait incertain", () => {
+    const a = assessOperationReadiness(signals({ has_technical_snapshot: false }));
+    expect(a.level).toBe("BLOCKED");
+    expect(a.reasons.map((r) => r.code)).toContain("NO_TECHNICAL_SNAPSHOT");
+  });
+
+  it("BLOQUE sur un OF non lancé ou annulé", () => {
+    for (const statut of ["BROUILLON", "ANNULE", "SUSPENDU", "TERMINE"]) {
+      expect(assessOperationReadiness(signals({ of_statut: statut })).level).toBe("BLOCKED");
+    }
+  });
+
+  it("BLOQUE quand un autre opérateur pointe déjà l'opération", () => {
+    const a = assessOperationReadiness(signals({ has_active_execution_by_other: true }));
+    expect(a.level).toBe("BLOCKED");
+    expect(a.reasons.map((r) => r.code)).toContain("ALREADY_RUNNING");
+  });
+
+  it("classe EN ATTENTE DE CONTRÔLE un premier article non prononcé, sans autre blocage", () => {
+    const a = assessOperationReadiness(signals({ first_article_pending: true }));
+    expect(a.level).toBe("AWAITING_CONTROL");
+    expect(a.headline).toMatch(/Premier article/i);
+  });
+
+  it("classe INCOMPLET un manque de plan ou une phase antérieure ouverte", () => {
+    expect(assessOperationReadiness(signals({ has_plan_document: false })).level).toBe("INCOMPLETE");
+    expect(assessOperationReadiness(signals({ has_pending_predecessor: true })).level).toBe("INCOMPLETE");
+    expect(assessOperationReadiness(signals({ machine_matches: false })).level).toBe("INCOMPLETE");
+  });
+
+  it("informe des quantités en attente de décision Qualité sans bloquer", () => {
+    const a = assessOperationReadiness(signals({ qty_pending_control: 4 }));
+    expect(a.level).toBe("READY");
+    expect(a.reasons.find((r) => r.code === "QTY_AWAITING_CONTROL")?.label).toContain("4");
+  });
+
+  it("ordonne la file par préparation, puis date, puis phase — jamais par un score", () => {
+    const entries = [
+      { readiness: "BLOCKED" as const, due_date: "2026-01-01", phase: 10 },
+      { readiness: "READY" as const, due_date: "2026-08-01", phase: 20 },
+      { readiness: "READY" as const, due_date: "2026-07-01", phase: 30 },
+      { readiness: "INCOMPLETE" as const, due_date: null, phase: 10 },
+    ];
+    const sorted = [...entries].sort(compareWorklistEntries);
+    expect(sorted[0]).toEqual({ readiness: "READY", due_date: "2026-07-01", phase: 30 });
+    expect(sorted[1]).toEqual({ readiness: "READY", due_date: "2026-08-01", phase: 20 });
+    expect(sorted[3].readiness).toBe("BLOCKED");
+  });
+
+  it("place une opération sans date cible APRÈS celles qui en ont une", () => {
+    const sorted = [
+      { readiness: "READY" as const, due_date: null, phase: 10 },
+      { readiness: "READY" as const, due_date: "2027-01-01", phase: 20 },
+    ].sort(compareWorklistEntries);
+    expect(sorted[0].due_date).toBe("2027-01-01");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — le plan suit le snapshot figé, jamais le dernier indice", () => {
+  const doc = {
+    id: "doc-1",
+    label: "Plan",
+    original_name: "plan-b.pdf",
+    mime_type: "application/pdf",
+    size_bytes: 1024,
+    sha256: "a".repeat(64),
+    piece_technique_id: "pt-1",
+  };
+
+  it("renvoie le document de la version figée", () => {
+    const r = resolvePlanForSnapshot({
+      snapshot: { piece_technique_version_id: "v-b", snapshot_sha256: "x", snapshot_at: new Date() },
+      documentsForSnapshotVersion: [doc],
+      latestVersionIndice: "B",
+      snapshotIndice: "B",
+    });
+    expect(r.document?.id).toBe("doc-1");
+    expect(r.matches_snapshot).toBe(true);
+    expect(r.warning).toBeNull();
+  });
+
+  it("AVERTIT quand un indice plus récent existe, sans jamais le substituer", () => {
+    const r = resolvePlanForSnapshot({
+      snapshot: { piece_technique_version_id: "v-b", snapshot_sha256: "x", snapshot_at: new Date() },
+      documentsForSnapshotVersion: [doc],
+      latestVersionIndice: "C",
+      snapshotIndice: "B",
+    });
+    expect(r.document?.original_name).toBe("plan-b.pdf");
+    expect(r.matches_snapshot).toBe(true);
+    expect(r.warning).toContain("indice B");
+    expect(r.warning).toContain("C");
+  });
+
+  it("refuse de substituer un autre document quand la version figée n'en a aucun", () => {
+    const r = resolvePlanForSnapshot({
+      snapshot: { piece_technique_version_id: "v-b", snapshot_sha256: "x", snapshot_at: new Date() },
+      documentsForSnapshotVersion: [],
+      latestVersionIndice: "C",
+      snapshotIndice: "B",
+    });
+    expect(r.document).toBeNull();
+    expect(r.matches_snapshot).toBe(false);
+    expect(r.warning).toContain("B");
+  });
+
+  it("signale l'absence totale de snapshot comme une garantie manquante", () => {
+    const r = resolvePlanForSnapshot({
+      snapshot: { piece_technique_version_id: null, snapshot_sha256: null, snapshot_at: null },
+      documentsForSnapshotVersion: [doc],
+      latestVersionIndice: "C",
+      snapshotIndice: null,
+    });
+    expect(r.document).toBeNull();
+    expect(r.matches_snapshot).toBe(false);
+    expect(r.warning).toMatch(/ne peut pas être garanti/i);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — transmission de poste", () => {
+  it("refuse une transmission à soi-même", () => {
+    expect(() => assertHandoverParties({ outgoingUserId: 5, incomingUserId: 5 })).toThrowError(
+      /deux opérateurs différents/i
+    );
+  });
+
+  it("autorise l'accusé de lecture au destinataire", () => {
+    expect(() =>
+      assertHandoverAcknowledgeable({
+        incomingUserId: 5,
+        actorUserId: 5,
+        actorRole: "Operateur CN",
+        alreadyAcknowledgedAt: null,
+      })
+    ).not.toThrow();
+  });
+
+  it("refuse l'accusé de lecture à un tiers non superviseur", () => {
+    expect(() =>
+      assertHandoverAcknowledgeable({
+        incomingUserId: 5,
+        actorUserId: 6,
+        actorRole: "Operateur CN",
+        alreadyAcknowledgedAt: null,
+      })
+    ).toThrowError(/autre opérateur/i);
+  });
+
+  it("autorise un superviseur et refuse un double accusé", () => {
+    expect(() =>
+      assertHandoverAcknowledgeable({
+        incomingUserId: 5,
+        actorUserId: 6,
+        actorRole: "Chef d'atelier",
+        alreadyAcknowledgedAt: null,
+      })
+    ).not.toThrow();
+    expect(() =>
+      assertHandoverAcknowledgeable({
+        incomingUserId: 5,
+        actorUserId: 5,
+        actorRole: "Operateur CN",
+        alreadyAcknowledgedAt: new Date(),
+      })
+    ).toThrowError(/déjà été accusée/i);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — anti-IDOR sur les sessions", () => {
+  it("laisse un opérateur piloter sa session", () => {
+    expect(() =>
+      assertOwnSessionOrSupervision({
+        actorUserId: 5,
+        actorRole: "Operateur CN",
+        sessionUserId: 5,
+        action: "lock",
+      })
+    ).not.toThrow();
+  });
+
+  it("refuse la session d'un tiers à un opérateur", () => {
+    expect(() =>
+      assertOwnSessionOrSupervision({
+        actorUserId: 5,
+        actorRole: "Operateur CN",
+        sessionUserId: 9,
+        action: "close",
+      })
+    ).toThrowError(/autre opérateur/i);
+  });
+
+  it("autorise le superviseur", () => {
+    expect(() =>
+      assertOwnSessionOrSupervision({
+        actorUserId: 5,
+        actorRole: "Chef d'atelier",
+        sessionUserId: 9,
+        action: "close",
+      })
+    ).not.toThrow();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — salons temps réel", () => {
+  const MACHINE = "33333333-3333-3333-3333-333333333333";
+  const DEVICE = "44444444-4444-4444-4444-444444444444";
+
+  it("reconnaît les quatre formes de salon et rejette le reste", () => {
+    expect(parseStationRoom("USER:7")).toEqual({ kind: "USER", userId: 7 });
+    expect(parseStationRoom(`MACHINE:${MACHINE}`)).toEqual({ kind: "MACHINE", machineId: MACHINE });
+    expect(parseStationRoom("OF:42")).toEqual({ kind: "OF", ofId: 42 });
+    expect(parseStationRoom(`STATION:${DEVICE}`)).toEqual({ kind: "STATION", deviceId: DEVICE });
+    expect(parseStationRoom("MACHINE:*")).toBeNull();
+    expect(parseStationRoom("ADMIN:1")).toBeNull();
+    expect(parseStationRoom("OF:abc")).toBeNull();
+  });
+
+  const scope = { ownMachineIds: [MACHINE], ownOfIds: [42], ownDeviceIds: [DEVICE] };
+
+  it("réserve USER: à son propre identifiant", () => {
+    expect(
+      canSubscribeStationRoom({
+        room: { kind: "USER", userId: 7 },
+        actorUserId: 7,
+        actorRole: "Operateur CN",
+        ...scope,
+      })
+    ).toBe(true);
+    expect(
+      canSubscribeStationRoom({
+        room: { kind: "USER", userId: 8 },
+        actorUserId: 7,
+        actorRole: "Chef d'atelier",
+        ...scope,
+      })
+    ).toBe(false);
+  });
+
+  it("accorde MACHINE: et OF: dans le périmètre de l'opérateur uniquement", () => {
+    expect(
+      canSubscribeStationRoom({
+        room: { kind: "MACHINE", machineId: MACHINE },
+        actorUserId: 7,
+        actorRole: "Operateur CN",
+        ...scope,
+      })
+    ).toBe(true);
+    expect(
+      canSubscribeStationRoom({
+        room: { kind: "MACHINE", machineId: "55555555-5555-5555-5555-555555555555" },
+        actorUserId: 7,
+        actorRole: "Operateur CN",
+        ...scope,
+      })
+    ).toBe(false);
+    expect(
+      canSubscribeStationRoom({
+        room: { kind: "OF", ofId: 99 },
+        actorUserId: 7,
+        actorRole: "Operateur CN",
+        ...scope,
+      })
+    ).toBe(false);
+  });
+
+  it("élargit le périmètre au superviseur, et à lui seul", () => {
+    expect(
+      canSubscribeStationRoom({
+        room: { kind: "OF", ofId: 99 },
+        actorUserId: 7,
+        actorRole: "Chef d'atelier",
+        ...scope,
+      })
+    ).toBe(true);
+    expect(
+      canSubscribeStationRoom({
+        room: { kind: "STATION", deviceId: "66666666-6666-6666-6666-666666666666" },
+        actorUserId: 7,
+        actorRole: "Operateur CN",
+        ...scope,
+      })
+    ).toBe(false);
+  });
+
+  it("refuse tout salon à un rôle sans droit de lecture de poste", () => {
+    expect(
+      canSubscribeStationRoom({
+        room: { kind: "MACHINE", machineId: MACHINE },
+        actorUserId: 7,
+        actorRole: "Visiteur externe",
+        ...scope,
+      })
+    ).toBe(false);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — fuite de données", () => {
+  it("liste les champs qui ne doivent jamais sortir", () => {
+    expect(NEVER_EXPOSED_FIELDS).toContain("storage_path");
+    expect(NEVER_EXPOSED_FIELDS).toContain("session_token_hash");
+    expect(NEVER_EXPOSED_FIELDS).toContain("credential_hash");
+  });
+
+  it("retire les coûts sans la capacité et les conserve avec", () => {
+    const row = { designation: "Tournage", hourly_rate: 42, cout_mo: 12, prix: 5 };
+    expect(stripCostFields({ ...row }, false)).toEqual({ designation: "Tournage" });
+    expect(stripCostFields({ ...row }, true)).toEqual(row);
+  });
+
+  it("nettoie l'audit de tout secret et borne les chaînes longues", () => {
+    const cleaned = sanitizeAuditDetail({
+      badge_uid: "04A1B2",
+      session_token: "abc",
+      storage_path: "/srv/files/x.pdf",
+      STATION_BADGE_PEPPER: "secret",
+      of_numero: "OF-2026-0001",
+      long: "x".repeat(600),
+    });
+    expect(cleaned).not.toHaveProperty("badge_uid");
+    expect(cleaned).not.toHaveProperty("session_token");
+    expect(cleaned).not.toHaveProperty("storage_path");
+    expect(cleaned).not.toHaveProperty("STATION_BADGE_PEPPER");
+    expect(cleaned.of_numero).toBe("OF-2026-0001");
+    expect(String(cleaned.long)).toHaveLength(513);
+  });
+});

--- a/src/__tests__/shopfloor-station-159.migration-guards.test.ts
+++ b/src/__tests__/shopfloor-station-159.migration-guards.test.ts
@@ -1,0 +1,192 @@
+// #159 — Garde-fous du patch SQL du poste opérateur tablette.
+//
+// Ces tests lisent le fichier de patch et refusent qu'il devienne destructif au
+// fil des relectures. Ils ne remplacent pas le preflight/verify exécutés sur la
+// base : ils empêchent la régression AVANT qu'elle n'atteigne une base.
+
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const PATCH_DIR = path.resolve(__dirname, "../../db/patches");
+const PATCH = path.join(PATCH_DIR, "20260726_shopfloor_station_159.sql");
+const SUPPORT = path.join(PATCH_DIR, "support");
+const PREFLIGHT = path.join(SUPPORT, "20260726_shopfloor_station_159.preflight.sql");
+const VERIFY = path.join(SUPPORT, "20260726_shopfloor_station_159.verify.sql");
+const ROLLBACK = path.join(SUPPORT, "20260726_shopfloor_station_159.rollback.sql");
+
+const sql = fs.readFileSync(PATCH, "utf8");
+
+/** Retire les commentaires pour ne juger que le SQL réellement exécuté. */
+function executable(source: string): string {
+  return source
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("--"))
+    .join("\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "");
+}
+
+const code = executable(sql);
+
+describe("#159 — le patch est additif et non destructif", () => {
+  it("ne supprime aucune table, colonne, contrainte ni type existants", () => {
+    // Les DROP tolérés portent UNIQUEMENT sur des triggers recréés dans la
+    // foulée : c'est le seul moyen d'être rejouable sur PostgreSQL.
+    const drops = code.match(/DROP\s+(TABLE|COLUMN|TYPE|CONSTRAINT|SCHEMA|DATABASE|INDEX|VIEW)/gi) ?? [];
+    expect(drops).toEqual([]);
+  });
+
+  it("ne réécrit aucune donnée existante", () => {
+    expect(code).not.toMatch(/\bDELETE\s+FROM\b/i);
+    expect(code).not.toMatch(/\bTRUNCATE\b/i);
+    // Les seuls UPDATE autorisés seraient sur les tables créées ici ; il n'y en
+    // a aucun, le patch est purement structurel.
+    expect(code).not.toMatch(/\bUPDATE\s+public\./i);
+  });
+
+  it("est transactionnel", () => {
+    expect(code.trimStart().startsWith("BEGIN;")).toBe(true);
+    expect(code.trimEnd().endsWith("COMMIT;")).toBe(true);
+    expect(code).not.toMatch(/\bROLLBACK\b/i);
+  });
+
+  it("est rejouable : chaque objet est créé de façon idempotente", () => {
+    const creates = code.match(/CREATE (TABLE|INDEX|UNIQUE INDEX|SEQUENCE)[^;]*?(?=\()/gi) ?? [];
+    expect(creates.length).toBeGreaterThan(0);
+    for (const statement of creates) {
+      expect(statement).toMatch(/IF NOT EXISTS/i);
+    }
+    // Fonctions et vues : CREATE OR REPLACE.
+    for (const statement of code.match(/CREATE (FUNCTION|VIEW)/gi) ?? []) {
+      expect(statement).toBe("");
+    }
+  });
+
+  it("vérifie ses pré-requis avant d'écrire", () => {
+    for (const table of [
+      "public.machines",
+      "public.users",
+      "public.ordres_fabrication",
+      "public.of_operations",
+      "public.production_pointages",
+    ]) {
+      expect(code).toContain(`to_regclass('${table}')`);
+    }
+  });
+});
+
+describe("#159 — le patch respecte les frontières inter-modules", () => {
+  it("ne touche à AUCUNE table du module RH #119", () => {
+    for (const table of ["hr_time_events", "hr_time_clock_devices", "hr_badge_credentials", "hr_"]) {
+      expect(code).not.toMatch(new RegExp(`(ALTER|INSERT INTO|UPDATE|DROP)[^;]*${table}`, "i"));
+    }
+  });
+
+  it("ne touche à AUCUNE table du moteur d'exécution #274", () => {
+    for (const table of [
+      "production_pointages",
+      "production_pointage_events",
+      "production_quantity_declarations",
+      "of_time_logs",
+    ]) {
+      expect(code).not.toMatch(new RegExp(`ALTER TABLE[^;]*${table}`, "i"));
+      expect(code).not.toMatch(new RegExp(`INSERT INTO public\\.${table}`, "i"));
+    }
+  });
+
+  it("ne touche à AUCUNE table de stock, livraison ou facturation", () => {
+    for (const table of [
+      "stock_movements",
+      "stock_reservations",
+      "lots",
+      "bons_livraison",
+      "factures",
+      "production_receipts",
+    ]) {
+      expect(code).not.toMatch(new RegExp(`(ALTER TABLE|INSERT INTO|UPDATE) public\\.${table}`, "i"));
+    }
+  });
+
+  it("ne crée aucune table de temps ni de quantité concurrente", () => {
+    const created = [...code.matchAll(/CREATE TABLE IF NOT EXISTS public\.([a-z_]+)/gi)].map((m) => m[1]);
+    expect(created).toContain("production_devices");
+    expect(created).toContain("operator_device_sessions");
+    expect(created).toContain("station_audit_events");
+    for (const name of created) {
+      expect(name).not.toMatch(/time_log|pointage|quantity|duration/i);
+    }
+  });
+});
+
+describe("#159 — le patch protège ce qui doit l'être", () => {
+  it("rend le journal d'audit append-only par trigger", () => {
+    expect(code).toMatch(/CREATE TRIGGER trg_station_audit_append_only_159/i);
+    expect(code).toMatch(/BEFORE UPDATE OR DELETE ON public\.station_audit_events/i);
+  });
+
+  it("rend la transmission de poste immuable hors accusé de lecture", () => {
+    expect(code).toMatch(/CREATE TRIGGER trg_shift_handover_immutable_159/i);
+    expect(code).toMatch(/only the acknowledgement can change/i);
+  });
+
+  it("laisse le journal d'audit propriété de postgres, pas du rôle applicatif", () => {
+    const ownerBlock = code.slice(code.indexOf("ALTER TABLE %s OWNER TO cerp_app") - 800);
+    expect(ownerBlock).not.toMatch(/'public\.station_audit_events'/);
+    expect(code).toMatch(/GRANT SELECT, INSERT ON public\.station_audit_events TO cerp_app/i);
+  });
+
+  it("interdit une tablette fixe sans machine, au niveau de la base", () => {
+    expect(code).toMatch(/production_devices_fixed_machine_159_ck/);
+    expect(code).toMatch(/assignment_mode <> 'FIXED' OR machine_id IS NOT NULL/);
+  });
+
+  it("garantit une seule session vivante par tablette", () => {
+    expect(code).toMatch(/CREATE UNIQUE INDEX IF NOT EXISTS operator_device_sessions_one_live_159_uq/i);
+    expect(code).toMatch(/WHERE state IN \('ACTIVE', 'LOCKED'\)/i);
+  });
+
+  it("n'accepte que des empreintes, jamais des secrets en clair", () => {
+    expect(code).toMatch(/credential_hash text NOT NULL/);
+    expect(code).toMatch(/operator_badge_credentials_hash_159_ck[\s\S]*\^\[a-f0-9\]\{64\}\$/);
+    expect(code).toMatch(/session_token_hash text NOT NULL/);
+    expect(code).not.toMatch(/badge_uid\s+text/i);
+    expect(code).not.toMatch(/pin\s+text/i);
+  });
+
+  it("borne le verrouillage automatique et la durée de session côté base", () => {
+    expect(code).toMatch(/auto_lock_seconds BETWEEN 30 AND 3600/);
+    expect(code).toMatch(/session_max_seconds BETWEEN 300 AND 86400/);
+  });
+
+  it("génère le code public côté base", () => {
+    expect(code).toMatch(/CREATE OR REPLACE FUNCTION public\.fn_production_device_next_public_code/i);
+    expect(code).toMatch(/nextval\('public\.production_device_public_code_seq'\)/);
+  });
+});
+
+describe("#159 — les fichiers de support existent et se comportent bien", () => {
+  it("fournit preflight, verify et rollback", () => {
+    for (const file of [PREFLIGHT, VERIFY, ROLLBACK]) {
+      expect(fs.existsSync(file)).toBe(true);
+    }
+  });
+
+  it("le preflight n'écrit rien", () => {
+    const preflight = executable(fs.readFileSync(PREFLIGHT, "utf8"));
+    expect(preflight).not.toMatch(/\b(INSERT|UPDATE|DELETE|ALTER|CREATE TABLE|DROP)\b/i);
+  });
+
+  it("le verify annule tout ce qu'il écrit", () => {
+    const verify = fs.readFileSync(VERIFY, "utf8");
+    expect(verify).toMatch(/\bBEGIN;/);
+    expect(verify).toMatch(/\bROLLBACK;/);
+    expect(verify).not.toMatch(/\bCOMMIT;/);
+  });
+
+  it("le rollback refuse cerp_prod et refuse d'effacer des données réelles", () => {
+    const rollback = fs.readFileSync(ROLLBACK, "utf8");
+    expect(rollback).toMatch(/current_database\(\) = 'cerp_prod'/);
+    expect(rollback).toMatch(/donnees reelles presentes/i);
+  });
+});

--- a/src/__tests__/shopfloor-station-159.routes.test.ts
+++ b/src/__tests__/shopfloor-station-159.routes.test.ts
@@ -341,6 +341,97 @@ describe("#159 — identification", () => {
   });
 });
 
+describe("#159 - client identity in the operator dossier", () => {
+  beforeEach(() => {
+    withLiveSession();
+    on(/UPDATE public\.operator_device_sessions\s*\n\s*SET last_activity_at/i, []);
+    on(/INSERT INTO public\.station_audit_events/i, []);
+  });
+
+  it("returns the minimal client visual identity without a storage path", async () => {
+    on(/WITH base AS[\s\S]*FROM base b/i, [
+      {
+        of_core: {
+          of_id: 1,
+          numero: "OF-2026-0042",
+          statut: "LANCE",
+          priority: "NORMAL",
+          quantite_lancee: 40,
+          quantite_bonne: 12,
+          quantite_rebut: 0,
+          date_lancement_prevue: null,
+          date_fin_prevue: null,
+          piece_technique_id: "11111111-1111-1111-1111-111111111111",
+          piece_technique_version_id: "22222222-2222-2222-2222-222222222222",
+          technical_snapshot_sha256: "a".repeat(64),
+          technical_snapshot_at: NOW,
+          operation_id: OPERATION_ID,
+          phase: 20,
+          operation_designation: "Tournage finition",
+          operation_status: "READY",
+          temps_total_planned: 2,
+          temps_total_real: 0.5,
+          notes: null,
+          operation_notes: null,
+        },
+        technical_snapshot: {},
+        piece: {
+          code_piece: "P-1042-B",
+          designation: "Axe de renvoi",
+          designation_2: null,
+          ensemble: false,
+        },
+        piece_version: {
+          indice: "B",
+          plan_reference: "PL-1042",
+          matiere_prevue: "42CrMo4",
+          statut: "VALIDE",
+          date_application: "2026-06-14",
+        },
+        client: {
+          id: "33333333-3333-3333-3333-333333333333",
+          code: "CLI-0042",
+          company_name: "ACME Aero",
+          logo_path: "clients/acme-aero.svg",
+        },
+        affaire: null,
+        machine: { id: MACHINE_ID, code: "TOUR-01", name: "Tour CN" },
+        poste: null,
+        documents: [],
+        dossier_documents: [],
+        instructions: [],
+        materials: [],
+        characteristics: [],
+        controls: [],
+        instruments: [],
+        machine_documents: [],
+        children: [],
+        parent: null,
+        active_execution: null,
+        declarations: {
+          qty_good: 12,
+          qty_scrap: 0,
+          qty_rework: 0,
+          qty_pending_control: 0,
+        },
+        pending_handover: null,
+        latest_indice: "B",
+      },
+    ]);
+
+    const res = await station(request(app).get(`${BASE}/dossier/1/${OPERATION_ID}`));
+
+    expect(res.status).toBe(200);
+    expect(res.body.identity.client).toMatchObject({
+      id: "33333333-3333-3333-3333-333333333333",
+      code: "CLI-0042",
+      company_name: "ACME Aero",
+    });
+    expect(res.body.identity.client.logo_url).toMatch(/\/images\/clients\/acme-aero\.svg$/);
+    expect(res.body.identity.client).not.toHaveProperty("logo_path");
+  });
+});
+
 /* -------------------------------------------------------------------------- */
 describe("#159 — garde de session", () => {
   it("refuse toute route de poste sans jeton", async () => {

--- a/src/__tests__/shopfloor-station-159.routes.test.ts
+++ b/src/__tests__/shopfloor-station-159.routes.test.ts
@@ -1,0 +1,1027 @@
+// #159 — Poste opérateur tablette : orchestration HTTP.
+//
+// `pg` est mocké, comme dans `production-execution-274.routes.test.ts`. Ces
+// tests prouvent ce que le domaine seul ne peut pas prouver : le câblage des
+// gardes, la propagation des codes d'erreur, le cookie de session, l'idempotence
+// et l'ABSENCE d'effet de bord hors du périmètre.
+
+import request from "supertest";
+import { EventEmitter } from "events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = {
+    on: emitter.on.bind(emitter),
+    query: mocks.poolQuery,
+    connect: mocks.poolConnect,
+  };
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; role: string }; headers?: Record<string, string | string[] | undefined> },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void
+  ) => {
+    if (req.headers?.["x-test-anonymous"] === "1") {
+      res.status(401).json({ success: false, code: "UNAUTHORIZED" });
+      return;
+    }
+    const requestedRole = req.headers?.["x-test-role"];
+    const requestedId = req.headers?.["x-test-user-id"];
+    req.user = {
+      id: typeof requestedId === "string" ? Number(requestedId) : 1,
+      role: typeof requestedRole === "string" ? requestedRole : "Administrateur Systeme et Reseau",
+    };
+    next();
+  },
+  authorizeRole:
+    () =>
+    (_req: unknown, _res: unknown, next: () => void) => {
+      next();
+    },
+}));
+
+import app from "../config/app";
+
+const BASE = "/api/v1/production/station";
+
+const DEVICE_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa";
+const SESSION_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb";
+const MACHINE_ID = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+const OTHER_MACHINE_ID = "dddddddd-dddd-dddd-dddd-dddddddddddd";
+const OPERATION_ID = "eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee";
+const HANDOVER_ID = "ffffffff-ffff-ffff-ffff-ffffffffffff";
+const SESSION_TOKEN = "jeton-de-session-opaque-pour-les-tests";
+const KEY = "idem-key-159-000001";
+
+// Rôles en ASCII : un en-tête HTTP ne transporte pas fiablement l'UTF-8.
+const OPERATOR = "Operateur CN";
+const CHEF = "Chef d'atelier";
+const VISITEUR = "Visiteur externe";
+
+const FUTURE = new Date(Date.now() + 3_600_000);
+const NOW = new Date();
+
+function deviceRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: DEVICE_ID,
+    public_code: "TAB-0001",
+    label: "Tablette tour 1",
+    site: "CRP",
+    workshop_zone: "USINAGE",
+    assignment_mode: "MOBILE",
+    machine_id: null,
+    status: "ACTIVE",
+    auto_lock_seconds: 180,
+    session_max_seconds: 28800,
+    last_seen_at: NOW,
+    last_seen_app_version: "1.0.0",
+    enrolled_at: NOW,
+    revoked_at: null,
+    revoke_reason: null,
+    created_at: NOW,
+    updated_at: NOW,
+    machine_code: null,
+    machine_name: null,
+    ...overrides,
+  };
+}
+
+function sessionJoinRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: SESSION_ID,
+    device_id: DEVICE_ID,
+    user_id: 7,
+    machine_id: MACHINE_ID,
+    identification_method: "BADGE",
+    state: "ACTIVE",
+    started_at: NOW,
+    last_activity_at: NOW,
+    expires_at: FUTURE,
+    locked_at: null,
+    closed_at: null,
+    close_reason: null,
+    correlation_id: "99999999-9999-9999-9999-999999999999",
+    username: "jdupont",
+    name: "Jean",
+    surname: "Dupont",
+    role: OPERATOR,
+    ...overrides,
+  };
+}
+
+/**
+ * Simulateur de base minimal : il répond en fonction du SQL reçu. Il permet de
+ * prouver le câblage sans base réelle, et de vérifier qu'AUCUNE requête ne
+ * touche une table interdite.
+ */
+type Handler = (sql: string, values: unknown[]) => { rows: unknown[]; rowCount?: number } | null;
+
+let handlers: Handler[] = [];
+let executedSql: string[] = [];
+
+function installDb() {
+  const run = (sql: unknown, values?: unknown) => {
+    const text = String(sql ?? "");
+    executedSql.push(text);
+    const args = Array.isArray(values) ? values : [];
+    for (const handler of handlers) {
+      const result = handler(text, args);
+      if (result) return Promise.resolve({ rowCount: result.rows.length, ...result });
+    }
+    return Promise.resolve({ rows: [], rowCount: 0 });
+  };
+  mocks.poolQuery.mockImplementation(run);
+  mocks.clientQuery.mockImplementation(run);
+}
+
+function on(match: RegExp, rows: unknown[] | ((values: unknown[]) => unknown[])): void {
+  handlers.push((sql, values) =>
+    match.test(sql) ? { rows: typeof rows === "function" ? rows(values) : rows } : null
+  );
+}
+
+/** Session vivante par défaut, résolue depuis le cookie ou l'en-tête. */
+function withLiveSession(sessionOverrides: Record<string, unknown> = {}, deviceOverrides: Record<string, unknown> = {}) {
+  on(/FROM public\.operator_device_sessions s[\s\S]*JOIN public\.users u/i, [
+    sessionJoinRow(sessionOverrides),
+  ]);
+  on(/FROM public\.production_devices d[\s\S]*WHERE d\.id = \$1/i, [deviceRow(deviceOverrides)]);
+}
+
+function station(req: request.Test, role = OPERATOR, userId = 7) {
+  return req.set("x-station-session", SESSION_TOKEN).set("x-test-role", role).set("x-test-user-id", String(userId));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  handlers = [];
+  executedSql = [];
+  installDb();
+  process.env.STATION_BADGE_PEPPER = "poivre-de-test-suffisamment-long";
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — écran verrouillé et bootstrap", () => {
+  it("décrit une tablette connue sans session : c'est un état normal, pas une erreur", async () => {
+    on(/FROM public\.production_devices d[\s\S]*WHERE d\.public_code/i, [deviceRow()]);
+    on(/UPDATE public\.production_devices\s*\n\s*SET last_seen_at/i, []);
+
+    const res = await request(app).get(`${BASE}/bootstrap?device_code=TAB-0001`).set("x-test-role", OPERATOR);
+
+    expect(res.status).toBe(200);
+    expect(res.body.device.public_code).toBe("TAB-0001");
+    expect(res.body.session).toBeNull();
+    expect(res.body.user).toBeNull();
+    expect(typeof res.body.server_time).toBe("string");
+  });
+
+  it("refuse une tablette inconnue avec un code métier distinct", async () => {
+    const res = await request(app).get(`${BASE}/bootstrap?device_code=TAB-9999`).set("x-test-role", OPERATOR);
+    expect(res.status).toBe(404);
+    expect(res.body.code ?? res.body.error).toContain("STATION_DEVICE_UNKNOWN");
+  });
+
+  it("refuse une tablette révoquée et une tablette désactivée séparément", async () => {
+    on(/FROM public\.production_devices d[\s\S]*WHERE d\.public_code/i, [
+      deviceRow({ status: "REVOKED", revoked_at: NOW }),
+    ]);
+    const revoked = await request(app).get(`${BASE}/bootstrap?device_code=TAB-0001`).set("x-test-role", OPERATOR);
+    expect(revoked.status).toBe(403);
+    expect(String(revoked.body.code ?? revoked.body.error)).toContain("STATION_DEVICE_REVOKED");
+
+    handlers = [];
+    on(/FROM public\.production_devices d[\s\S]*WHERE d\.public_code/i, [deviceRow({ status: "DISABLED" })]);
+    const disabled = await request(app).get(`${BASE}/bootstrap?device_code=TAB-0001`).set("x-test-role", OPERATOR);
+    expect(disabled.status).toBe(403);
+    expect(String(disabled.body.code ?? disabled.body.error)).toContain("STATION_DEVICE_DISABLED");
+  });
+
+  it("rejette un code de tablette syntaxiquement invalide", async () => {
+    const res = await request(app).get(`${BASE}/bootstrap?device_code=oops!!`).set("x-test-role", OPERATOR);
+    expect(res.status).toBe(400);
+  });
+
+  it("n'expose le badge comme méthode que si le poivre est configuré", async () => {
+    on(/FROM public\.production_devices d[\s\S]*WHERE d\.public_code/i, [deviceRow()]);
+    on(/UPDATE public\.production_devices/i, []);
+
+    delete process.env.STATION_BADGE_PEPPER;
+    const withoutPepper = await request(app)
+      .get(`${BASE}/bootstrap?device_code=TAB-0001`)
+      .set("x-test-role", OPERATOR);
+    expect(withoutPepper.body.identification_methods).toEqual(["PASSWORD"]);
+
+    process.env.STATION_BADGE_PEPPER = "poivre-de-test-suffisamment-long";
+    const withPepper = await request(app)
+      .get(`${BASE}/bootstrap?device_code=TAB-0001`)
+      .set("x-test-role", OPERATOR);
+    expect(withPepper.body.identification_methods).toContain("BADGE");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — identification", () => {
+  it("ouvre une session et pose un cookie httpOnly", async () => {
+    on(/FROM public\.production_devices d[\s\S]*WHERE d\.public_code/i, [deviceRow()]);
+    on(/FROM public\.operator_badge_credentials\s*\n\s*WHERE credential_hash/i, [
+      { id: "cred-1", user_id: 7, active: true, revoked_at: null, locked_until: null },
+    ]);
+    on(/FROM public\.v_station_machine_occupancy/i, []);
+    on(/SELECT id FROM public\.production_devices WHERE id = \$1 FOR UPDATE/i, [{ id: DEVICE_ID }]);
+    on(/FROM public\.operator_device_sessions s\s*\n\s*WHERE s\.device_id/i, []);
+    on(/INSERT INTO public\.operator_device_sessions/i, [
+      {
+        id: SESSION_ID,
+        device_id: DEVICE_ID,
+        user_id: 7,
+        machine_id: null,
+        identification_method: "BADGE",
+        state: "ACTIVE",
+        started_at: NOW,
+        last_activity_at: NOW,
+        expires_at: FUTURE,
+        locked_at: null,
+        closed_at: null,
+        close_reason: null,
+        correlation_id: "corr",
+      },
+    ]);
+    on(/UPDATE public\.operator_badge_credentials\s*\n\s*SET last_used_at/i, []);
+
+    const res = await request(app)
+      .post(`${BASE}/identify`)
+      .set("x-test-role", OPERATOR)
+      .send({ device_code: "TAB-0001", method: "BADGE", credential: "04A1B2C3D4" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.session_id).toBe(SESSION_ID);
+    const cookies = String(res.headers["set-cookie"] ?? "");
+    expect(cookies).toContain("cerp_station_session=");
+    expect(cookies).toContain("HttpOnly");
+    expect(cookies).toContain("Secure");
+    // La séparation RH est rappelée à l'opérateur à chaque badgeage.
+    expect(res.body.notice).toMatch(/aucune donnée de présence RH/i);
+  });
+
+  it("donne le MÊME message pour un badge inconnu et un badge révoqué", async () => {
+    on(/FROM public\.production_devices d[\s\S]*WHERE d\.public_code/i, [deviceRow()]);
+
+    const unknown = await request(app)
+      .post(`${BASE}/identify`)
+      .set("x-test-role", OPERATOR)
+      .send({ device_code: "TAB-0001", method: "BADGE", credential: "INCONNU" });
+
+    handlers = [];
+    on(/FROM public\.production_devices d[\s\S]*WHERE d\.public_code/i, [deviceRow()]);
+    on(/FROM public\.operator_badge_credentials\s*\n\s*WHERE credential_hash/i, [
+      { id: "cred-2", user_id: 7, active: false, revoked_at: NOW, locked_until: null },
+    ]);
+    on(/UPDATE public\.operator_badge_credentials/i, []);
+
+    const revoked = await request(app)
+      .post(`${BASE}/identify`)
+      .set("x-test-role", OPERATOR)
+      .send({ device_code: "TAB-0001", method: "BADGE", credential: "REVOQUE" });
+
+    expect(unknown.status).toBe(401);
+    expect(revoked.status).toBe(401);
+    expect(unknown.body.message ?? unknown.body.error).toBe(revoked.body.message ?? revoked.body.error);
+  });
+
+  it("exige un support pour BADGE et le refuse pour PASSWORD", async () => {
+    const missing = await request(app)
+      .post(`${BASE}/identify`)
+      .set("x-test-role", OPERATOR)
+      .send({ device_code: "TAB-0001", method: "BADGE" });
+    expect(missing.status).toBe(400);
+
+    const extraneous = await request(app)
+      .post(`${BASE}/identify`)
+      .set("x-test-role", OPERATOR)
+      .send({ device_code: "TAB-0001", method: "PASSWORD", credential: "hunter2" });
+    expect(extraneous.status).toBe(400);
+  });
+
+  it("exige un horodatage pour un QR — sans lui le rejeu est indétectable", async () => {
+    const res = await request(app)
+      .post(`${BASE}/identify`)
+      .set("x-test-role", OPERATOR)
+      .send({ device_code: "TAB-0001", method: "QR", credential: "code-qr" });
+    expect(res.status).toBe(400);
+  });
+
+  it("refuse une identification sur une tablette révoquée", async () => {
+    on(/FROM public\.production_devices d[\s\S]*WHERE d\.public_code/i, [
+      deviceRow({ status: "REVOKED", revoked_at: NOW }),
+    ]);
+    const res = await request(app)
+      .post(`${BASE}/identify`)
+      .set("x-test-role", OPERATOR)
+      .send({ device_code: "TAB-0001", method: "BADGE", credential: "04A1B2C3D4" });
+    expect(res.status).toBe(403);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — garde de session", () => {
+  it("refuse toute route de poste sans jeton", async () => {
+    const res = await request(app).get(`${BASE}/worklist`).set("x-test-role", OPERATOR);
+    expect(res.status).toBe(401);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_SESSION_REQUIRED");
+  });
+
+  it("refuse un jeton inconnu", async () => {
+    const res = await station(request(app).get(`${BASE}/worklist`));
+    expect(res.status).toBe(401);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_SESSION_UNKNOWN");
+  });
+
+  it("refuse une session expirée et le DIT sans ambiguïté", async () => {
+    withLiveSession({ expires_at: new Date(Date.now() - 1000) });
+    on(/UPDATE public\.operator_device_sessions/i, [sessionJoinRow({ state: "EXPIRED" })]);
+    on(/INSERT INTO public\.station_audit_events/i, []);
+
+    const res = await station(request(app).get(`${BASE}/worklist`));
+    expect(res.status).toBe(401);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_SESSION_EXPIRED");
+    // Message crucial : l'opérateur doit savoir que son pointage n'a PAS été arrêté.
+    expect(String(res.body.message)).toMatch(/pointage en cours n'a pas été arrêté/i);
+  });
+
+  it("verrouille sur inactivité et ne coupe aucun pointage", async () => {
+    withLiveSession({ last_activity_at: new Date(Date.now() - 10 * 60 * 1000) });
+    on(/UPDATE public\.operator_device_sessions/i, [sessionJoinRow({ state: "LOCKED" })]);
+    on(/INSERT INTO public\.station_audit_events/i, []);
+
+    const res = await station(request(app).get(`${BASE}/worklist`));
+    expect(res.status).toBe(401);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_SESSION_LOCKED");
+    expect(String(res.body.message)).toMatch(/n'a pas été arrêté/i);
+  });
+
+  it("ferme la session dès que la tablette est révoquée — révocation immédiate", async () => {
+    withLiveSession({}, { status: "REVOKED", revoked_at: NOW });
+    on(/UPDATE public\.operator_device_sessions/i, [sessionJoinRow({ state: "REVOKED" })]);
+    on(/INSERT INTO public\.station_audit_events/i, []);
+
+    const res = await station(request(app).get(`${BASE}/worklist`));
+    expect(res.status).toBe(403);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_DEVICE_REVOKED");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — capacités appliquées côté serveur", () => {
+  beforeEach(() => {
+    withLiveSession({ role: VISITEUR });
+    on(/UPDATE public\.operator_device_sessions\s*\n\s*SET last_activity_at/i, []);
+    on(/INSERT INTO public\.station_audit_events/i, []);
+  });
+
+  it("refuse la file de travail à un rôle sans capacité", async () => {
+    const res = await station(request(app).get(`${BASE}/worklist`), VISITEUR);
+    expect(res.status).toBe(403);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_CAPABILITY_REQUIRED");
+  });
+
+  it("refuse le dossier opérateur à un rôle sans capacité", async () => {
+    const res = await station(request(app).get(`${BASE}/dossier/1/${OPERATION_ID}`), VISITEUR);
+    expect(res.status).toBe(403);
+  });
+
+  it("refuse l'enrôlement d'une tablette à un opérateur", async () => {
+    const res = await request(app)
+      .post(`${BASE}/devices`)
+      .set("x-test-role", OPERATOR)
+      .send({ label: "Tablette", assignment_mode: "MOBILE" });
+    expect(res.status).toBe(403);
+  });
+
+  it("refuse l'émission d'un support d'identification au chef d'atelier", async () => {
+    const res = await request(app)
+      .post(`${BASE}/credentials`)
+      .set("x-test-role", CHEF)
+      .send({ user_id: 7, credential: "04A1B2C3D4" });
+    expect(res.status).toBe(403);
+  });
+
+  it("refuse le journal d'audit à un opérateur", async () => {
+    const res = await request(app).get(`${BASE}/audit`).set("x-test-role", OPERATOR);
+    expect(res.status).toBe(403);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — machines", () => {
+  beforeEach(() => {
+    withLiveSession();
+    on(/UPDATE public\.operator_device_sessions\s*\n\s*SET last_activity_at/i, []);
+    on(/INSERT INTO public\.station_audit_events/i, []);
+  });
+
+  it("liste les machines avec une raison lisible pour chaque refus", async () => {
+    on(/FROM public\.v_station_machine_occupancy/i, [
+      {
+        id: MACHINE_ID,
+        code: "TOUR-01",
+        name: "Tour CN",
+        status: "ACTIVE",
+        is_available: true,
+        workshop_zone: "USINAGE",
+        active_operator_user_id: null,
+        active_operator_label: null,
+        active_of_id: null,
+        active_of_numero: null,
+        active_since: null,
+      },
+      {
+        id: OTHER_MACHINE_ID,
+        code: "FRAISE-02",
+        name: "Fraiseuse",
+        status: "ACTIVE",
+        is_available: true,
+        workshop_zone: "USINAGE",
+        active_operator_user_id: 99,
+        active_operator_label: "Paul Martin",
+        active_of_id: 42,
+        active_of_numero: "OF-2026-0042",
+        active_since: NOW,
+      },
+    ]);
+
+    const res = await station(request(app).get(`${BASE}/machines`));
+    expect(res.status).toBe(200);
+    const busy = res.body.machines.find((m: { code: string }) => m.code === "FRAISE-02");
+    expect(busy.selectable).toBe(false);
+    expect(busy.reason).toContain("OF-2026-0042");
+    // L'opérateur ne voit PAS le nom de son collègue.
+    expect(busy.occupied_by).toBe("un autre opérateur");
+  });
+
+  it("révèle l'occupant au superviseur seulement", async () => {
+    handlers = [];
+    withLiveSession({ role: CHEF });
+    on(/UPDATE public\.operator_device_sessions\s*\n\s*SET last_activity_at/i, []);
+    on(/FROM public\.v_station_machine_occupancy/i, [
+      {
+        id: OTHER_MACHINE_ID,
+        code: "FRAISE-02",
+        name: "Fraiseuse",
+        status: "ACTIVE",
+        is_available: true,
+        workshop_zone: "USINAGE",
+        active_operator_user_id: 99,
+        active_operator_label: "Paul Martin",
+        active_of_id: 42,
+        active_of_numero: "OF-2026-0042",
+        active_since: NOW,
+      },
+    ]);
+
+    const res = await station(request(app).get(`${BASE}/machines`), CHEF);
+    expect(res.body.machines[0].occupied_by).toBe("Paul Martin");
+  });
+
+  it("refuse une machine hors périmètre au lieu de la confirmer", async () => {
+    on(/FROM public\.v_station_machine_occupancy/i, []);
+    const res = await station(
+      request(app).post(`${BASE}/machines/confirm`).send({ machine_id: OTHER_MACHINE_ID })
+    );
+    expect(res.status).toBe(403);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_MACHINE_NOT_ALLOWED");
+  });
+
+  it("refuse de confirmer une machine occupée sans décision explicite", async () => {
+    on(/FROM public\.v_station_machine_occupancy/i, [
+      {
+        id: MACHINE_ID,
+        code: "TOUR-01",
+        name: "Tour CN",
+        status: "ACTIVE",
+        is_available: true,
+        workshop_zone: "USINAGE",
+        active_operator_user_id: 99,
+        active_operator_label: "Paul",
+        active_of_id: 42,
+        active_of_numero: "OF-2026-0042",
+        active_since: NOW,
+      },
+    ]);
+    const res = await station(request(app).post(`${BASE}/machines/confirm`).send({ machine_id: MACHINE_ID }));
+    expect(res.status).toBe(409);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_MACHINE_BUSY");
+  });
+
+  it("interdit le changement de machine sur une tablette fixe", async () => {
+    handlers = [];
+    withLiveSession({}, { assignment_mode: "FIXED", machine_id: MACHINE_ID });
+    on(/UPDATE public\.operator_device_sessions\s*\n\s*SET last_activity_at/i, []);
+
+    const res = await station(request(app).post(`${BASE}/machines/confirm`).send({ machine_id: OTHER_MACHINE_ID }));
+    expect(res.status).toBe(409);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_DEVICE_FIXED");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — file de travail", () => {
+  beforeEach(() => {
+    withLiveSession();
+    on(/UPDATE public\.operator_device_sessions\s*\n\s*SET last_activity_at/i, []);
+    on(/INSERT INTO public\.station_audit_events/i, []);
+  });
+
+  function worklistRow(overrides: Record<string, unknown> = {}) {
+    return {
+      operation_id: OPERATION_ID,
+      phase: 10,
+      designation: "Tournage",
+      operation_status: "TODO",
+      temps_total_planned: 2,
+      temps_total_real: 0,
+      of_id: 42,
+      of_numero: "OF-2026-0042",
+      of_statut: "EN_COURS",
+      of_priority: "NORMAL",
+      date_fin_prevue: "2026-08-01",
+      quantite_lancee: 10,
+      quantite_bonne: 0,
+      quantite_rebut: 0,
+      qty_pending_control: 0,
+      piece_code: "P-001",
+      piece_designation: "Axe",
+      affaire_id: 5,
+      affaire_reference: "AFF-2026-0005",
+      machine_id: MACHINE_ID,
+      machine_code: "TOUR-01",
+      machine_name: "Tour CN",
+      machine_is_available: true,
+      has_pending_predecessor: false,
+      active_by_user_id: null,
+      has_technical_snapshot: true,
+      has_plan_document: true,
+      first_article_required: false,
+      first_article_passed: false,
+      parent_of_id: null,
+      child_of_count: 0,
+      child_of_pending: 0,
+      ...overrides,
+    };
+  }
+
+  it("renvoie une recommandation EXPLIQUÉE et un ordre justifié", async () => {
+    on(/WITH candidate_ops AS/i, [worklistRow()]);
+
+    const res = await station(request(app).get(`${BASE}/worklist`));
+    expect(res.status).toBe(200);
+    expect(res.body.recommended_operation_id).toBe(OPERATION_ID);
+    expect(res.body.recommendation_reason).toMatch(/Prêt à démarrer/i);
+    expect(res.body.ordering_explanation).toMatch(/Trié par/i);
+    expect(res.body.items[0].readiness).toBe("READY");
+  });
+
+  it("masque les coûts à un opérateur", async () => {
+    on(/WITH candidate_ops AS/i, [worklistRow()]);
+    const res = await station(request(app).get(`${BASE}/worklist`));
+    const item = res.body.items[0];
+    expect(item).not.toHaveProperty("hourly_rate");
+    expect(item).not.toHaveProperty("cout_mo");
+    expect(JSON.stringify(item)).not.toContain("hourly_rate");
+  });
+
+  it("n'affiche pas un temps prévu à zéro comme une valeur réelle", async () => {
+    on(/WITH candidate_ops AS/i, [worklistRow({ temps_total_planned: 0 })]);
+    const res = await station(request(app).get(`${BASE}/worklist`));
+    expect(res.body.items[0].planned_hours).toBeNull();
+  });
+
+  it("écarte par défaut les opérations bloquées, sauf les siennes", async () => {
+    on(/WITH candidate_ops AS/i, [
+      worklistRow({ has_technical_snapshot: false }),
+      worklistRow({ operation_id: "11111111-1111-1111-1111-111111111111", active_by_user_id: 7 }),
+    ]);
+    const res = await station(request(app).get(`${BASE}/worklist`));
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].mine).toBe(true);
+  });
+
+  it("montre les opérations bloquées à la demande, avec leur cause", async () => {
+    on(/WITH candidate_ops AS/i, [worklistRow({ has_technical_snapshot: false })]);
+    const res = await station(request(app).get(`${BASE}/worklist?include_blocked=true`));
+    expect(res.body.items).toHaveLength(1);
+    expect(res.body.items[0].readiness).toBe("BLOCKED");
+    expect(res.body.items[0].readiness_reasons.map((r: { code: string }) => r.code)).toContain(
+      "NO_TECHNICAL_SNAPSHOT"
+    );
+  });
+
+  it("borne la taille de page demandée par le client", async () => {
+    const res = await station(request(app).get(`${BASE}/worklist?limit=5000`));
+    expect(res.status).toBe(400);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — scan", () => {
+  beforeEach(() => {
+    withLiveSession();
+    on(/UPDATE public\.operator_device_sessions\s*\n\s*SET last_activity_at/i, []);
+  });
+
+  it("résout un numéro d'OF vers son opération ouverte", async () => {
+    on(/FROM public\.ordres_fabrication o\s*\n\s*WHERE o\.numero/i, [
+      { id: 42, numero: "OF-2026-0042", operation_id: OPERATION_ID, phase: 10 },
+    ]);
+    const res = await station(request(app).post(`${BASE}/scan`).send({ code: "OF-2026-0042" }));
+    expect(res.status).toBe(200);
+    expect(res.body.operation_id).toBe(OPERATION_ID);
+  });
+
+  it("refuse un code inconnu au lieu de deviner", async () => {
+    const res = await station(request(app).post(`${BASE}/scan`).send({ code: "XX-INCONNU" }));
+    expect(res.status).toBe(404);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_SCAN_UNRESOLVED");
+  });
+
+  it("signale un OF sans opération ouverte plutôt que d'ouvrir un dossier vide", async () => {
+    on(/FROM public\.ordres_fabrication o\s*\n\s*WHERE o\.numero/i, [
+      { id: 42, numero: "OF-2026-0042", operation_id: null, phase: null },
+    ]);
+    const res = await station(request(app).post(`${BASE}/scan`).send({ code: "OF-2026-0042" }));
+    expect(res.status).toBe(409);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_SCAN_NO_OPEN_OPERATION");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — transmission de poste", () => {
+  beforeEach(() => {
+    withLiveSession();
+    on(/UPDATE public\.operator_device_sessions\s*\n\s*SET last_activity_at/i, []);
+    on(/INSERT INTO public\.station_audit_events/i, []);
+  });
+
+  it("exige une clé d'idempotence", async () => {
+    const res = await station(request(app).post(`${BASE}/handovers`).send({ incoming_user_id: 9 }));
+    expect(res.status).toBe(400);
+    expect(String(res.body.code ?? res.body.error)).toContain("IDEMPOTENCY_KEY_REQUIRED");
+  });
+
+  it("refuse une transmission à soi-même", async () => {
+    const res = await station(
+      request(app).post(`${BASE}/handovers`).set("Idempotency-Key", KEY).send({ incoming_user_id: 7 })
+    );
+    expect(res.status).toBe(400);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_HANDOVER_SAME_USER");
+  });
+
+  it("crée la transmission et rappelle qu'elle n'écrit rien en RH", async () => {
+    on(/SELECT id FROM public\.production_shift_handovers WHERE idempotency_key/i, []);
+    on(/SELECT 1 FROM public\.users WHERE id/i, [{ "?column?": 1 }]);
+    on(/INSERT INTO public\.production_shift_handovers/i, [{ id: HANDOVER_ID }]);
+    on(/FROM public\.production_shift_handovers h/i, [
+      {
+        id: HANDOVER_ID,
+        device_id: DEVICE_ID,
+        machine_id: MACHINE_ID,
+        machine_code: "TOUR-01",
+        of_id: 42,
+        of_numero: "OF-2026-0042",
+        operation_id: OPERATION_ID,
+        pointage_id: null,
+        outgoing_user_id: 7,
+        incoming_user_id: 9,
+        outgoing_label: "Jean Dupont",
+        incoming_label: "Paul Martin",
+        machine_state: "RUNNING",
+        qty_done: 4,
+        defects: null,
+        tooling_left: "Plaquette neuve",
+        remaining_actions: "Finir la série",
+        comment: null,
+        created_at: NOW,
+        acknowledged_at: null,
+      },
+    ]);
+
+    const res = await station(
+      request(app)
+        .post(`${BASE}/handovers`)
+        .set("Idempotency-Key", KEY)
+        .send({ incoming_user_id: 9, machine_state: "RUNNING", qty_done: 4 })
+    );
+
+    expect(res.status).toBe(201);
+    expect(res.body.handover.id).toBe(HANDOVER_ID);
+    expect(res.body.notice).toMatch(/aucune donnée de présence RH/i);
+  });
+
+  it("rejoue la même clé sans créer de doublon", async () => {
+    on(/SELECT id FROM public\.production_shift_handovers WHERE idempotency_key/i, [{ id: HANDOVER_ID }]);
+    on(/FROM public\.production_shift_handovers h/i, [
+      {
+        id: HANDOVER_ID,
+        device_id: DEVICE_ID,
+        machine_id: MACHINE_ID,
+        machine_code: "TOUR-01",
+        of_id: 42,
+        of_numero: "OF-2026-0042",
+        operation_id: OPERATION_ID,
+        pointage_id: null,
+        outgoing_user_id: 7,
+        incoming_user_id: 9,
+        outgoing_label: "Jean",
+        incoming_label: "Paul",
+        machine_state: "RUNNING",
+        qty_done: null,
+        defects: null,
+        tooling_left: null,
+        remaining_actions: null,
+        comment: null,
+        created_at: NOW,
+        acknowledged_at: null,
+      },
+    ]);
+
+    const res = await station(
+      request(app).post(`${BASE}/handovers`).set("Idempotency-Key", KEY).send({ incoming_user_id: 9 })
+    );
+    expect(res.status).toBe(201);
+    expect(res.body.handover.id).toBe(HANDOVER_ID);
+    const inserts = executedSql.filter((sql) => /INSERT INTO public\.production_shift_handovers/i.test(sql));
+    expect(inserts).toHaveLength(0);
+  });
+
+  it("refuse l'accusé de lecture d'une transmission destinée à un tiers", async () => {
+    on(/FROM public\.production_shift_handovers h/i, [
+      {
+        id: HANDOVER_ID,
+        device_id: null,
+        machine_id: null,
+        machine_code: null,
+        of_id: null,
+        of_numero: null,
+        operation_id: null,
+        pointage_id: null,
+        outgoing_user_id: 8,
+        incoming_user_id: 9,
+        outgoing_label: "A",
+        incoming_label: "B",
+        machine_state: "UNKNOWN",
+        qty_done: null,
+        defects: null,
+        tooling_left: null,
+        remaining_actions: null,
+        comment: null,
+        created_at: NOW,
+        acknowledged_at: null,
+      },
+    ]);
+    const res = await station(request(app).post(`${BASE}/handovers/${HANDOVER_ID}/acknowledge`).send({}));
+    expect(res.status).toBe(403);
+    expect(String(res.body.code ?? res.body.error)).toContain("STATION_HANDOVER_NOT_ADDRESSEE");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — session : verrouiller et fermer", () => {
+  beforeEach(() => {
+    withLiveSession();
+    on(/UPDATE public\.operator_device_sessions\s*\n\s*SET last_activity_at/i, []);
+    on(/INSERT INTO public\.station_audit_events/i, []);
+  });
+
+  it("verrouille sans arrêter le pointage et le DIT", async () => {
+    on(/UPDATE public\.operator_device_sessions\s*\n\s*SET state = \$2/i, [
+      { ...sessionJoinRow({ state: "LOCKED", locked_at: NOW }) },
+    ]);
+    on(/FROM public\.production_pointages p\s*\n\s*LEFT JOIN public\.ordres_fabrication/i, [
+      {
+        id: "p1",
+        of_id: 42,
+        of_numero: "OF-2026-0042",
+        operation_id: OPERATION_ID,
+        phase: 10,
+        designation: "Tournage",
+        machine_id: MACHINE_ID,
+        machine_code: "TOUR-01",
+        machine_name: "Tour CN",
+        activity_code: "PRODUCTION",
+        activity_label: "Production",
+        is_productive: true,
+        start_ts: NOW,
+        session_id: null,
+        segment_index: 1,
+        elapsed_minutes: 12,
+      },
+    ]);
+
+    const res = await station(request(app).post(`${BASE}/sessions/lock`).send({ reason: "MANUAL" }));
+    expect(res.status).toBe(200);
+    expect(res.body.execution_still_running).toBe(true);
+    expect(res.body.notice).toMatch(/pointage continue/i);
+  });
+
+  it("avertit à la fermeture quand un pointage tourne encore", async () => {
+    on(/FROM public\.production_pointages p\s*\n\s*LEFT JOIN public\.ordres_fabrication/i, [
+      {
+        id: "p1",
+        of_id: 42,
+        of_numero: "OF-2026-0042",
+        operation_id: OPERATION_ID,
+        phase: 10,
+        designation: "Tournage",
+        machine_id: MACHINE_ID,
+        machine_code: "TOUR-01",
+        machine_name: "Tour CN",
+        activity_code: "PRODUCTION",
+        activity_label: "Production",
+        is_productive: true,
+        start_ts: NOW,
+        session_id: null,
+        segment_index: 1,
+        elapsed_minutes: 12,
+      },
+    ]);
+    on(/UPDATE public\.operator_device_sessions\s*\n\s*SET state = \$2/i, [
+      { ...sessionJoinRow({ state: "CLOSED", closed_at: NOW }) },
+    ]);
+
+    const res = await station(request(app).post(`${BASE}/sessions/close`).send({ reason: "SHIFT_END" }));
+    expect(res.status).toBe(200);
+    expect(res.body.notice).toMatch(/toujours en cours/i);
+    expect(String(res.headers["set-cookie"] ?? "")).toContain("cerp_station_session=;");
+  });
+
+  it("signale une dérive d'horloge sans jamais l'utiliser pour un calcul", async () => {
+    on(/UPDATE public\.production_devices/i, []);
+    const res = await station(
+      request(app)
+        .post(`${BASE}/sessions/heartbeat`)
+        .send({ client_time: new Date(Date.now() + 10 * 60 * 1000).toISOString() })
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.clock_drift_seconds).toBeGreaterThan(500);
+    expect(res.body.clock_warning).toMatch(/décalée/i);
+    expect(typeof res.body.server_time).toBe("string");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — frontières inter-modules", () => {
+  const FORBIDDEN = [
+    /INSERT INTO public\.hr_/i,
+    /UPDATE public\.hr_/i,
+    /INSERT INTO public\.stock_movements/i,
+    /INSERT INTO public\.stock_reservations/i,
+    /INSERT INTO public\.lots/i,
+    /INSERT INTO public\.bons_livraison/i,
+    /INSERT INTO public\.factures/i,
+    /INSERT INTO public\.production_pointages/i,
+    /UPDATE public\.production_pointages/i,
+    /INSERT INTO public\.production_quantity_declarations/i,
+  ];
+
+  it("aucun parcours de poste n'écrit hors de son périmètre", async () => {
+    withLiveSession();
+    on(/UPDATE public\.operator_device_sessions/i, [sessionJoinRow()]);
+    on(/INSERT INTO public\.station_audit_events/i, []);
+    on(/WITH candidate_ops AS/i, []);
+    on(/FROM public\.v_station_machine_occupancy/i, []);
+    on(/FROM public\.production_shift_handovers h/i, []);
+    on(/UPDATE public\.production_devices/i, []);
+
+    await station(request(app).get(`${BASE}/worklist`));
+    await station(request(app).get(`${BASE}/machines`));
+    await station(request(app).get(`${BASE}/handovers`));
+    await station(request(app).post(`${BASE}/sessions/heartbeat`).send({}));
+    await station(request(app).post(`${BASE}/sessions/lock`).send({}));
+
+    expect(executedSql.length).toBeGreaterThan(0);
+    for (const sql of executedSql) {
+      for (const pattern of FORBIDDEN) {
+        expect(sql).not.toMatch(pattern);
+      }
+    }
+  });
+
+  it("le module ne duplique aucune commande d'exécution #274", async () => {
+    withLiveSession();
+    on(/UPDATE public\.operator_device_sessions/i, []);
+
+    for (const path of ["", "/pause", "/resume", "/stop", "/quantities"]) {
+      const res = await station(request(app).post(`${BASE}${path}`).set("Idempotency-Key", KEY).send({}));
+      expect(res.status).toBe(404);
+    }
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+describe("#159 — administration des tablettes", () => {
+  it("enrôle une tablette avec un code généré par la BASE", async () => {
+    on(/SELECT public\.fn_production_device_next_public_code/i, [{ code: "TAB-0007" }]);
+    on(/INSERT INTO public\.production_devices/i, [{ id: DEVICE_ID }]);
+    on(/INSERT INTO public\.station_audit_events/i, []);
+    on(/FROM public\.production_devices d[\s\S]*WHERE d\.id/i, [deviceRow({ public_code: "TAB-0007" })]);
+
+    const res = await request(app)
+      .post(`${BASE}/devices`)
+      .set("x-test-role", "Administrateur Systeme et Reseau")
+      .send({ label: "Tablette tour 1", assignment_mode: "MOBILE" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.device.public_code).toBe("TAB-0007");
+    // Le client n'a JAMAIS proposé le code : il a été alloué côté base.
+    const insert = executedSql.find((sql) => /INSERT INTO public\.production_devices/i.test(sql));
+    expect(insert).toBeDefined();
+  });
+
+  it("refuse une tablette fixe sans machine", async () => {
+    const res = await request(app)
+      .post(`${BASE}/devices`)
+      .set("x-test-role", "Administrateur Systeme et Reseau")
+      .send({ label: "Tablette", assignment_mode: "FIXED" });
+    expect(res.status).toBe(400);
+  });
+
+  it("borne le verrouillage automatique demandé", async () => {
+    const res = await request(app)
+      .post(`${BASE}/devices`)
+      .set("x-test-role", "Administrateur Systeme et Reseau")
+      .send({ label: "Tablette", assignment_mode: "MOBILE", auto_lock_seconds: 99999 });
+    expect(res.status).toBe(400);
+  });
+
+  it("révoque et ferme les sessions SANS arrêter les pointages", async () => {
+    on(/UPDATE public\.production_devices\s*\n\s*SET status = 'REVOKED'/i, [{ id: DEVICE_ID }]);
+    on(/UPDATE public\.operator_device_sessions\s*\n\s*SET state = 'REVOKED'/i, [{ id: SESSION_ID }]);
+    on(/INSERT INTO public\.station_audit_events/i, []);
+    on(/FROM public\.production_devices d[\s\S]*WHERE d\.id/i, [
+      deviceRow({ status: "REVOKED", revoked_at: NOW }),
+    ]);
+
+    const res = await request(app)
+      .post(`${BASE}/devices/${DEVICE_ID}/revoke`)
+      .set("x-test-role", "Administrateur Systeme et Reseau")
+      .send({ reason: "Tablette perdue en atelier" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.closed_sessions).toBe(1);
+    expect(res.body.notice).toMatch(/ne sont pas arrêtés/i);
+    for (const sql of executedSql) {
+      expect(sql).not.toMatch(/UPDATE public\.production_pointages/i);
+    }
+  });
+
+  it("exige un motif pour révoquer", async () => {
+    const res = await request(app)
+      .post(`${BASE}/devices/${DEVICE_ID}/revoke`)
+      .set("x-test-role", "Administrateur Systeme et Reseau")
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("n'expose jamais l'empreinte d'un support d'identification", async () => {
+    on(/FROM public\.operator_badge_credentials\s*\n\s*WHERE user_id/i, [
+      {
+        id: "cred-1",
+        credential_type: "BADGE_NFC",
+        label: "Badge bleu",
+        active: true,
+        issued_at: NOW,
+      },
+    ]);
+    const res = await request(app)
+      .get(`${BASE}/credentials/7`)
+      .set("x-test-role", "Administrateur Systeme et Reseau");
+    expect(res.status).toBe(200);
+    expect(JSON.stringify(res.body)).not.toContain("credential_hash");
+  });
+
+  it("refuse à un opérateur de lister les supports d'un tiers", async () => {
+    const res = await request(app)
+      .get(`${BASE}/credentials/9`)
+      .set("x-test-role", OPERATOR)
+      .set("x-test-user-id", "7");
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/module/production/controllers/station.controller.ts
+++ b/src/module/production/controllers/station.controller.ts
@@ -1,0 +1,290 @@
+// Contrôleurs du poste opérateur tablette (#159).
+//
+// Rôle strictement limité : valider l'entrée (Zod), extraire l'acteur depuis la
+// SESSION ou le JWT — jamais depuis le corps de requête — et déléguer au
+// service. Aucune règle métier ici.
+
+import type { Request, Response } from "express";
+
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { HttpError } from "../../../utils/httpError";
+
+import {
+  clearStationSessionCookie,
+  setStationSessionCookie,
+  type StationContext,
+} from "../middlewares/station-authorization.middleware";
+import {
+  enrollDeviceSchema,
+  issueCredentialSchema,
+  listDevicesQuerySchema,
+  revokeCredentialSchema,
+  revokeDeviceSchema,
+  stationAuditQuerySchema,
+  stationBootstrapQuerySchema,
+  stationCloseSchema,
+  stationConfirmMachineSchema,
+  stationDossierParamsSchema,
+  stationHandoverAckSchema,
+  stationHandoverSchema,
+  stationHeartbeatSchema,
+  stationIdentifySchema,
+  stationLockSchema,
+  stationScanSchema,
+  stationUnlockSchema,
+  stationWorklistQuerySchema,
+  updateDeviceSchema,
+} from "../validators/station.validators";
+import {
+  svcAcknowledgeHandover,
+  svcBootstrap,
+  svcCloseSession,
+  svcConfirmMachine,
+  svcCreateHandover,
+  svcDossier,
+  svcEnrollDevice,
+  svcHeartbeat,
+  svcIdentify,
+  svcIssueCredential,
+  svcListCredentials,
+  svcListDevices,
+  svcListHandovers,
+  svcListMachines,
+  svcLock,
+  svcRevokeCredential,
+  svcRevokeDevice,
+  svcScan,
+  svcStationAudit,
+  svcUnlock,
+  svcUpdateDevice,
+  svcWorklist,
+  type Actor,
+} from "../services/station.service";
+
+/** Acteur ERP (JWT). Jamais l'identité d'un poste. */
+function jwtActor(req: Request): Actor | null {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") return null;
+  return { id: user.id, role: user.role ?? null };
+}
+
+/** Acteur de poste. C'est la SEULE identité acceptée par les routes tablette. */
+function requireStation(req: Request): StationContext {
+  if (!req.station) {
+    throw new HttpError(401, "STATION_SESSION_REQUIRED", "Identifiez-vous sur la tablette.");
+  }
+  return req.station;
+}
+
+/** Acteur d'administration : JWT ERP, pas une session de poste. */
+function requireAdminActor(req: Request): Actor {
+  const actor = jwtActor(req);
+  if (!actor) throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  return actor;
+}
+
+function idempotencyKey(req: Request): string {
+  const raw = req.headers["idempotency-key"];
+  const key = typeof raw === "string" ? raw.trim() : "";
+  if (!key) throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "Clé d'idempotence manquante.");
+  return key;
+}
+
+function requestId(req: Request): string | null {
+  return req.requestId ?? null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Bootstrap et session                                                       */
+/* -------------------------------------------------------------------------- */
+
+export const bootstrap = asyncHandler(async (req: Request, res: Response) => {
+  const query = stationBootstrapQuerySchema.parse(req.query);
+  const payload = await svcBootstrap({
+    query,
+    station: req.station,
+    jwtActor: jwtActor(req),
+  });
+  res.json(payload);
+});
+
+export const identify = asyncHandler(async (req: Request, res: Response) => {
+  const body = stationIdentifySchema.parse(req.body);
+  const result = await svcIdentify({
+    body,
+    jwtActor: jwtActor(req),
+    requestId: requestId(req),
+  });
+
+  // Le jeton part en cookie httpOnly : le JavaScript de la page ne le lit
+  // jamais, une XSS ne l'exfiltre donc pas. Il est AUSSI renvoyé une fois dans
+  // le corps pour les configurations où le cookie tiers est supprimé par un
+  // proxy ; le client le garde alors en mémoire seulement.
+  setStationSessionCookie(res, result.token, result.maxAgeSeconds);
+  res.status(201).json({ ...result.payload, session_token: result.token });
+});
+
+export const unlock = asyncHandler(async (req: Request, res: Response) => {
+  const body = stationUnlockSchema.parse(req.body);
+  const deviceCode = typeof req.body?.device_code === "string" ? req.body.device_code : null;
+  if (!deviceCode) {
+    throw new HttpError(400, "STATION_DEVICE_CODE_REQUIRED", "Code de tablette manquant.");
+  }
+  const result = await svcUnlock({
+    device_code: deviceCode,
+    body,
+    jwtActor: jwtActor(req),
+    sessionToken: null,
+    requestId: requestId(req),
+  });
+  setStationSessionCookie(res, result.token, result.maxAgeSeconds);
+  res.status(201).json({ ...result.payload, session_token: result.token });
+});
+
+export const lock = asyncHandler(async (req: Request, res: Response) => {
+  const body = stationLockSchema.parse(req.body ?? {});
+  res.json(await svcLock({ station: requireStation(req), body }));
+});
+
+export const closeSession = asyncHandler(async (req: Request, res: Response) => {
+  const body = stationCloseSchema.parse(req.body ?? {});
+  const payload = await svcCloseSession({ station: requireStation(req), body });
+  clearStationSessionCookie(res);
+  res.json(payload);
+});
+
+export const heartbeat = asyncHandler(async (req: Request, res: Response) => {
+  const body = stationHeartbeatSchema.parse(req.body ?? {});
+  res.json(await svcHeartbeat({ station: requireStation(req), body }));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Machines                                                                   */
+/* -------------------------------------------------------------------------- */
+
+export const listMachines = asyncHandler(async (req: Request, res: Response) => {
+  res.json(await svcListMachines({ station: requireStation(req) }));
+});
+
+export const confirmMachine = asyncHandler(async (req: Request, res: Response) => {
+  const body = stationConfirmMachineSchema.parse(req.body);
+  res.json(await svcConfirmMachine({ station: requireStation(req), body }));
+});
+
+/* -------------------------------------------------------------------------- */
+/* File de travail et dossier                                                 */
+/* -------------------------------------------------------------------------- */
+
+export const worklist = asyncHandler(async (req: Request, res: Response) => {
+  const query = stationWorklistQuerySchema.parse(req.query);
+  res.json(await svcWorklist({ station: requireStation(req), query }));
+});
+
+export const scan = asyncHandler(async (req: Request, res: Response) => {
+  const body = stationScanSchema.parse(req.body);
+  res.json(await svcScan({ station: requireStation(req), body }));
+});
+
+export const dossier = asyncHandler(async (req: Request, res: Response) => {
+  const params = stationDossierParamsSchema.parse(req.params);
+  res.json(
+    await svcDossier({
+      station: requireStation(req),
+      ofId: params.ofId,
+      operationId: params.operationId,
+    })
+  );
+});
+
+/* -------------------------------------------------------------------------- */
+/* Transmission de poste                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const createHandover = asyncHandler(async (req: Request, res: Response) => {
+  const body = stationHandoverSchema.parse(req.body);
+  res.status(201).json(
+    await svcCreateHandover({
+      station: requireStation(req),
+      body,
+      idempotencyKey: idempotencyKey(req),
+    })
+  );
+});
+
+export const listHandovers = asyncHandler(async (req: Request, res: Response) => {
+  const onlyPending = String(req.query.pending ?? "") === "true";
+  res.json(await svcListHandovers({ station: requireStation(req), onlyPending }));
+});
+
+export const acknowledgeHandover = asyncHandler(async (req: Request, res: Response) => {
+  stationHandoverAckSchema.parse(req.body ?? {});
+  const id = String(req.params.id ?? "");
+  res.json(await svcAcknowledgeHandover({ station: requireStation(req), id }));
+});
+
+/* -------------------------------------------------------------------------- */
+/* Administration                                                             */
+/* -------------------------------------------------------------------------- */
+
+export const enrollDevice = asyncHandler(async (req: Request, res: Response) => {
+  const body = enrollDeviceSchema.parse(req.body);
+  res.status(201).json({ device: await svcEnrollDevice({ actor: requireAdminActor(req), body }) });
+});
+
+export const updateDevice = asyncHandler(async (req: Request, res: Response) => {
+  const body = updateDeviceSchema.parse(req.body);
+  res.json({
+    device: await svcUpdateDevice({
+      actor: requireAdminActor(req),
+      id: String(req.params.id ?? ""),
+      body,
+    }),
+  });
+});
+
+export const revokeDevice = asyncHandler(async (req: Request, res: Response) => {
+  const body = revokeDeviceSchema.parse(req.body);
+  res.json(
+    await svcRevokeDevice({
+      actor: requireAdminActor(req),
+      id: String(req.params.id ?? ""),
+      reason: body.reason,
+    })
+  );
+});
+
+export const listDevices = asyncHandler(async (req: Request, res: Response) => {
+  const query = listDevicesQuerySchema.parse(req.query);
+  const devices = await svcListDevices({ query });
+  res.json({ total: devices.length, items: devices });
+});
+
+export const issueCredential = asyncHandler(async (req: Request, res: Response) => {
+  const body = issueCredentialSchema.parse(req.body);
+  res.status(201).json(await svcIssueCredential({ actor: requireAdminActor(req), body }));
+});
+
+export const revokeCredential = asyncHandler(async (req: Request, res: Response) => {
+  const body = revokeCredentialSchema.parse(req.body);
+  res.json(
+    await svcRevokeCredential({
+      actor: requireAdminActor(req),
+      id: String(req.params.id ?? ""),
+      reason: body.reason,
+    })
+  );
+});
+
+export const listCredentials = asyncHandler(async (req: Request, res: Response) => {
+  const actor = requireAdminActor(req);
+  const userId = Number(req.params.userId ?? actor.id);
+  if (!Number.isInteger(userId) || userId <= 0) {
+    throw new HttpError(400, "STATION_USER_INVALID", "Identifiant utilisateur invalide.");
+  }
+  res.json(await svcListCredentials({ actor, userId }));
+});
+
+export const stationAudit = asyncHandler(async (req: Request, res: Response) => {
+  const query = stationAuditQuerySchema.parse(req.query);
+  res.json(await svcStationAudit({ query }));
+});

--- a/src/module/production/domain/station.ts
+++ b/src/module/production/domain/station.ts
@@ -1,0 +1,1041 @@
+// Gouvernance du poste opérateur tablette (#159 / crp-systems-web#289) —
+// politiques pures, sans I/O : capacités RBAC, cycle de vie d'un appareil et
+// d'une session, pseudonymisation des supports d'identification, préparation
+// d'une opération et frontières inter-modules.
+//
+// Ce fichier n'ouvre aucune connexion, n'appelle aucun service et ne lit aucun
+// en-tête HTTP : chaque règle est testable seule et rejouée par le service à
+// chaque requête.
+//
+// TROIS CONCEPTS DISTINCTS, JAMAIS CONFONDUS
+// ------------------------------------------
+//   1. La SESSION DE POSTE (ici)          : « qui est devant cette tablette ? »
+//   2. Le SEGMENT D'EXÉCUTION (#274)      : « qui produit quoi, sur quelle
+//                                             machine, depuis quand ? »
+//   3. Le TEMPS DE PRÉSENCE RH (#119)     : « le salarié était-il là ? »
+//
+// Ouvrir, verrouiller ou fermer une session ne crée, ne modifie et ne clôt
+// jamais un segment d'exécution ni une donnée RH. C'est la règle qui justifie
+// l'existence séparée de ce module, et elle est testée.
+
+import crypto from "node:crypto";
+
+import { HttpError } from "../../../utils/httpError";
+
+/* -------------------------------------------------------------------------- */
+/* 1) Capacités RBAC — refus par défaut                                       */
+/* -------------------------------------------------------------------------- */
+
+export const STATION_CAPABILITIES = [
+  /** Voir son propre poste : file de travail, dossier, exécution en cours. */
+  "read_own_station",
+  /** Ouvrir une session de poste sur une tablette. */
+  "open_session",
+  /** Choisir ou changer la machine confirmée d'une session mobile. */
+  "select_machine",
+  /** Consulter le dossier OF numérique (plan, gamme, matière, contrôles). */
+  "read_dossier",
+  /** Émettre une transmission de poste. */
+  "handover_shift",
+  /** Accuser réception d'une transmission qui m'est destinée. */
+  "acknowledge_handover",
+  /** Voir les postes des autres opérateurs (chef d'atelier, méthodes). */
+  "supervise_stations",
+  /** Enrôler, modifier, désactiver et révoquer une tablette. */
+  "administer_devices",
+  /** Émettre ou révoquer un support d'identification atelier. */
+  "administer_credentials",
+  /** Lire le journal d'audit de poste. */
+  "audit_stations",
+  /** Voir les coûts et taux horaires dans le dossier. Jamais implicite. */
+  "view_costs",
+] as const;
+
+export type StationCapability = (typeof STATION_CAPABILITIES)[number];
+
+// Les rôles CERP sont du texte libre en base. On garde la mécanique par
+// « needles » déjà employée par `production-execution.ts`, `of-rbac.ts` et
+// `quality-policy.ts` plutôt que d'inventer une table de rôles parallèle qui
+// dériverait aussitôt.
+const OPERATOR_NEEDLES = [
+  "operateur",
+  "opérateur",
+  "usineur",
+  "regleur",
+  "régleur",
+  "atelier",
+  "production",
+] as const;
+
+const SUPERVISOR_NEEDLES = ["admin", "administrateur", "directeur", "chef", "method"] as const;
+
+const CAPABILITY_NEEDLES: Record<StationCapability, readonly string[]> = {
+  // Le geste de base : sans lui, un opérateur ne verrait même pas son poste.
+  read_own_station: [...OPERATOR_NEEDLES, ...SUPERVISOR_NEEDLES, "qualit", "quality", "qse", "planif"],
+  open_session: [...OPERATOR_NEEDLES, ...SUPERVISOR_NEEDLES],
+  select_machine: [...OPERATOR_NEEDLES, ...SUPERVISOR_NEEDLES],
+  read_dossier: [...OPERATOR_NEEDLES, ...SUPERVISOR_NEEDLES, "qualit", "quality", "qse", "method"],
+  handover_shift: [...OPERATOR_NEEDLES, ...SUPERVISOR_NEEDLES],
+  acknowledge_handover: [...OPERATOR_NEEDLES, ...SUPERVISOR_NEEDLES],
+  // Voir le poste d'un tiers est une capacité distincte : un opérateur n'a pas
+  // à savoir ce que fait son voisin.
+  supervise_stations: [...SUPERVISOR_NEEDLES, "planif", "qualit", "quality", "qse"],
+  administer_devices: ["admin", "administrateur", "directeur", "method"],
+  administer_credentials: ["admin", "administrateur", "directeur"],
+  audit_stations: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+  // Voir du temps n'est pas voir de l'argent : périmètre volontairement fermé.
+  view_costs: ["admin", "administrateur", "directeur", "compta", "controle", "contrôle"],
+};
+
+/**
+ * Aucune capacité de ce module ne doit toucher au domaine RH. La liste est
+ * vérifiée par test : elle empêche qu'une capacité `attendance` ou `payroll`
+ * apparaisse ici au fil des refactorisations.
+ */
+export const FORBIDDEN_STATION_CAPABILITY_FRAGMENTS = [
+  "attendance",
+  "presence",
+  "présence",
+  "payroll",
+  "paie",
+  "overtime",
+  "geoloc",
+  "biometric",
+  "biometrie",
+  "biométrie",
+  "salary",
+  "salaire",
+] as const;
+
+export function roleHasStationCapability(
+  role: string | null | undefined,
+  capability: StationCapability
+): boolean {
+  const normalized = (role ?? "").trim().toLowerCase();
+  if (!normalized) return false;
+  const needles = CAPABILITY_NEEDLES[capability];
+  if (!needles) return false;
+  return needles.some((needle) => normalized.includes(needle));
+}
+
+export function listStationCapabilities(role: string | null | undefined): StationCapability[] {
+  return STATION_CAPABILITIES.filter((capability) => roleHasStationCapability(role, capability));
+}
+
+export function assertStationCapability(
+  role: string | null | undefined,
+  capability: StationCapability
+): void {
+  if (!roleHasStationCapability(role, capability)) {
+    throw new HttpError(
+      403,
+      "STATION_CAPABILITY_REQUIRED",
+      `La capacité de poste '${capability}' est requise.`
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 2) Frontières inter-modules — déclarées dans le code, pas seulement en doc  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Ce que le poste opérateur ne fera JAMAIS, quelle que soit l'action demandée.
+ * La liste est parcourue par un test qui inspecte les requêtes SQL du module :
+ * une régression qui ajouterait un `INSERT INTO stock_movements` échoue.
+ */
+export const FORBIDDEN_STATION_SIDE_EFFECTS = [
+  "hr_time_events",
+  "hr_time_entries",
+  "hr_badge_credentials",
+  "hr_time_clock_devices",
+  "payroll",
+  "stock_movements",
+  "stock_movement_lines",
+  "stock_reservations",
+  "lots",
+  "of_output_lots",
+  "production_receipts",
+  "bons_livraison",
+  "bon_livraison_lignes",
+  "factures",
+  "facture_lignes",
+  "avoirs",
+] as const;
+
+/**
+ * Le poste peut PROPOSER la prochaine action métier, jamais l'exécuter. Chaque
+ * proposition nomme le service autoritaire qui, seul, a le droit d'agir.
+ */
+export type NextBusinessAction = {
+  code: "QUALITY_DECISION" | "PRODUCTION_RECEIPT" | "NEXT_OPERATION" | "NONE";
+  label: string;
+  owning_module: string;
+  /** Le poste ne déclenche rien : il indique où aller. */
+  actionable_here: false;
+};
+
+/* -------------------------------------------------------------------------- */
+/* 3) Cycle de vie d'un appareil                                              */
+/* -------------------------------------------------------------------------- */
+
+export const DEVICE_STATUSES = ["ACTIVE", "DISABLED", "REVOKED"] as const;
+export type DeviceStatus = (typeof DEVICE_STATUSES)[number];
+
+export const DEVICE_ASSIGNMENT_MODES = ["FIXED", "MOBILE"] as const;
+export type DeviceAssignmentMode = (typeof DEVICE_ASSIGNMENT_MODES)[number];
+
+// Une révocation est définitive : une tablette volée ne « redevient » pas
+// active parce qu'on l'a retrouvée. On en enrôle une nouvelle.
+const DEVICE_TRANSITIONS: Readonly<Record<DeviceStatus, readonly DeviceStatus[]>> = {
+  ACTIVE: ["DISABLED", "REVOKED"],
+  DISABLED: ["ACTIVE", "REVOKED"],
+  REVOKED: [],
+};
+
+export function assertDeviceTransition(from: DeviceStatus, to: DeviceStatus): void {
+  if (from === to) return;
+  if (!DEVICE_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "STATION_DEVICE_TRANSITION_FORBIDDEN",
+      `Transition d'appareil interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+export type DeviceState = {
+  id: string;
+  public_code: string;
+  status: DeviceStatus;
+  assignment_mode: DeviceAssignmentMode;
+  machine_id: string | null;
+  auto_lock_seconds: number;
+  session_max_seconds: number;
+};
+
+/**
+ * Un appareil doit être exploitable AVANT toute autre vérification : inutile de
+ * discuter des droits d'un opérateur sur une tablette révoquée. Les codes
+ * d'erreur sont distincts pour que l'écran affiche la bonne consigne
+ * (« contactez le chef d'atelier » ≠ « tablette inconnue »).
+ */
+export function assertDeviceUsable(device: DeviceState | null): asserts device is DeviceState {
+  if (!device) {
+    throw new HttpError(
+      404,
+      "STATION_DEVICE_UNKNOWN",
+      "Cette tablette n'est pas enregistrée dans CERP."
+    );
+  }
+  if (device.status === "REVOKED") {
+    throw new HttpError(
+      403,
+      "STATION_DEVICE_REVOKED",
+      "Cette tablette a été révoquée. Elle ne peut plus ouvrir de session."
+    );
+  }
+  if (device.status === "DISABLED") {
+    throw new HttpError(
+      403,
+      "STATION_DEVICE_DISABLED",
+      "Cette tablette est désactivée. Contactez le chef d'atelier."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 4) Cycle de vie d'une session de poste                                     */
+/* -------------------------------------------------------------------------- */
+
+export const SESSION_STATES = ["ACTIVE", "LOCKED", "CLOSED", "EXPIRED", "REVOKED"] as const;
+export type SessionState = (typeof SESSION_STATES)[number];
+
+const SESSION_TRANSITIONS: Readonly<Record<SessionState, readonly SessionState[]>> = {
+  ACTIVE: ["LOCKED", "CLOSED", "EXPIRED", "REVOKED"],
+  // Un écran verrouillé se déverrouille, se ferme, expire ou est révoqué.
+  LOCKED: ["ACTIVE", "CLOSED", "EXPIRED", "REVOKED"],
+  CLOSED: [],
+  EXPIRED: [],
+  REVOKED: [],
+};
+
+export function assertSessionTransition(from: SessionState, to: SessionState): void {
+  if (!SESSION_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "STATION_SESSION_TRANSITION_FORBIDDEN",
+      `Transition de session interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+export type SessionState_ = {
+  id: string;
+  device_id: string;
+  user_id: number;
+  machine_id: string | null;
+  state: SessionState;
+  expires_at: Date;
+  last_activity_at: Date;
+};
+
+export type SessionEvaluation =
+  | { usable: true; reason: null }
+  | { usable: false; reason: "EXPIRED" | "IDLE_LOCK" | "LOCKED" | "CLOSED" };
+
+/**
+ * Décide si une session est encore utilisable, SANS la modifier. Le service
+ * traduit ensuite la décision en transition persistée.
+ *
+ * Le verrouillage par inactivité est calculé côté serveur : une tablette dont
+ * l'horloge locale a dérivé — ou a été reculée volontairement — ne prolonge pas
+ * sa session.
+ */
+export function evaluateSession(params: {
+  session: Pick<SessionState_, "state" | "expires_at" | "last_activity_at">;
+  autoLockSeconds: number;
+  now: Date;
+}): SessionEvaluation {
+  const { session, autoLockSeconds, now } = params;
+
+  if (session.state === "CLOSED" || session.state === "EXPIRED" || session.state === "REVOKED") {
+    return { usable: false, reason: "CLOSED" };
+  }
+  if (session.expires_at.getTime() <= now.getTime()) {
+    return { usable: false, reason: "EXPIRED" };
+  }
+  if (session.state === "LOCKED") {
+    return { usable: false, reason: "LOCKED" };
+  }
+  const idleMs = now.getTime() - session.last_activity_at.getTime();
+  if (idleMs >= autoLockSeconds * 1000) {
+    return { usable: false, reason: "IDLE_LOCK" };
+  }
+  return { usable: true, reason: null };
+}
+
+/**
+ * Verrouiller un écran n'arrête RIEN. C'est la règle la plus importante du
+ * module : un opérateur qui pose sa tablette pour changer un outil ne doit pas
+ * voir son pointage s'arrêter tout seul, et un pointage qui continue ne doit pas
+ * empêcher l'écran de se verrouiller.
+ */
+export const LOCK_NEVER_STOPS_EXECUTION = true as const;
+
+/**
+ * Changer d'opérateur alors qu'un segment tourne exige une décision métier
+ * explicite. Le silence n'est pas une option : soit on transmet, soit on met en
+ * pause, soit un superviseur tranche.
+ */
+export type OperatorSwitchDecision = "HANDOVER" | "PAUSE" | "SUPERVISOR_OVERRIDE";
+
+export function assertOperatorSwitchDecided(params: {
+  hasActiveExecution: boolean;
+  decision: OperatorSwitchDecision | null | undefined;
+  actorRole: string | null | undefined;
+}): void {
+  if (!params.hasActiveExecution) return;
+
+  if (!params.decision) {
+    throw new HttpError(
+      409,
+      "STATION_ACTIVE_EXECUTION_REQUIRES_DECISION",
+      "Un pointage est en cours sur ce poste. Choisissez : transmettre le poste, mettre en pause, ou appeler un superviseur."
+    );
+  }
+  if (
+    params.decision === "SUPERVISOR_OVERRIDE" &&
+    !roleHasStationCapability(params.actorRole, "supervise_stations")
+  ) {
+    throw new HttpError(
+      403,
+      "STATION_SUPERVISOR_REQUIRED",
+      "Seul un superviseur peut reprendre un poste occupé sans transmission."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 5) Identification — pseudonymisation et anti-rejeu                          */
+/* -------------------------------------------------------------------------- */
+
+export const IDENTIFICATION_METHODS = ["BADGE", "QR", "PASSWORD", "SSO"] as const;
+export type IdentificationMethod = (typeof IDENTIFICATION_METHODS)[number];
+
+/**
+ * Empreinte d'un support d'identification.
+ *
+ * HMAC-SHA-256 avec un poivre serveur : un simple SHA-256 d'un UID de badge est
+ * cassable par force brute en quelques secondes (l'espace des UID est minuscule).
+ * Sans le poivre, une copie de la base ne permet donc pas de retrouver les
+ * numéros gravés sur les cartes.
+ *
+ * Le poivre n'est jamais journalisé, jamais renvoyé, jamais stocké en base.
+ */
+export function fingerprintCredential(rawCredential: string, pepper: string): string {
+  const value = rawCredential.trim();
+  if (!value) {
+    throw new HttpError(400, "STATION_CREDENTIAL_EMPTY", "Support d'identification vide.");
+  }
+  if (!pepper || pepper.length < 16) {
+    // Refus explicite plutôt que dégradation silencieuse vers un hachage faible.
+    throw new HttpError(
+      500,
+      "STATION_BADGE_PEPPER_MISSING",
+      "L'identification par badge n'est pas configurée sur ce serveur."
+    );
+  }
+  return crypto.createHmac("sha256", pepper).update(value, "utf8").digest("hex");
+}
+
+/** Jeton de session opaque. Ce n'est PAS un JWT : il est révocable côté serveur. */
+export function generateSessionToken(): string {
+  return crypto.randomBytes(32).toString("base64url");
+}
+
+/** Seule l'empreinte du jeton est stockée : une fuite de base ne donne aucune session. */
+export function hashSessionToken(token: string): string {
+  return crypto.createHash("sha256").update(token, "utf8").digest("hex");
+}
+
+/**
+ * Comparaison à temps constant. Une comparaison naïve laisse fuir, par le
+ * temps de réponse, le nombre de caractères corrects.
+ */
+export function safeEqualHex(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  try {
+    return crypto.timingSafeEqual(Buffer.from(a, "hex"), Buffer.from(b, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+export const BADGE_MAX_FAILED_ATTEMPTS = 5;
+export const BADGE_LOCK_SECONDS = 300;
+
+export function assertCredentialNotLocked(params: {
+  locked_until: Date | null;
+  now: Date;
+}): void {
+  if (params.locked_until && params.locked_until.getTime() > params.now.getTime()) {
+    const seconds = Math.ceil((params.locked_until.getTime() - params.now.getTime()) / 1000);
+    throw new HttpError(
+      429,
+      "STATION_CREDENTIAL_LOCKED",
+      `Trop de tentatives. Réessayez dans ${seconds} seconde(s) ou identifiez-vous autrement.`
+    );
+  }
+}
+
+/**
+ * Anti-rejeu du QR : un code présenté deux fois est refusé. La fenêtre est
+ * courte parce qu'un QR affiché sur un écran est photographiable.
+ */
+export const QR_NONCE_WINDOW_SECONDS = 60;
+
+export function assertNonceFresh(params: { issuedAt: Date; now: Date; seenBefore: boolean }): void {
+  if (params.seenBefore) {
+    throw new HttpError(
+      409,
+      "STATION_CREDENTIAL_REPLAYED",
+      "Ce code a déjà été utilisé. Présentez un code neuf."
+    );
+  }
+  const ageSeconds = (params.now.getTime() - params.issuedAt.getTime()) / 1000;
+  if (ageSeconds < -5 || ageSeconds > QR_NONCE_WINDOW_SECONDS) {
+    throw new HttpError(
+      409,
+      "STATION_CREDENTIAL_EXPIRED",
+      "Ce code n'est plus valide. Présentez un code neuf."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 6) Confirmation de machine                                                 */
+/* -------------------------------------------------------------------------- */
+
+export type MachineCandidate = {
+  id: string;
+  code: string;
+  name: string;
+  status: string;
+  is_available: boolean;
+  workshop_zone: string | null;
+  archived_at: Date | null;
+  /** Occupation dérivée du moteur #274, jamais recalculée ici. */
+  active_operator_user_id: number | null;
+  active_of_numero: string | null;
+};
+
+export type MachineSelectability = {
+  machine_id: string;
+  selectable: boolean;
+  /** Raison LISIBLE : l'opérateur doit comprendre sans appeler personne. */
+  reason: string;
+  reason_code:
+    | "OK"
+    | "MACHINE_ARCHIVED"
+    | "MACHINE_INACTIVE"
+    | "MACHINE_UNAVAILABLE"
+    | "MACHINE_BUSY"
+    | "MACHINE_OUT_OF_ZONE";
+  /** Occupée par quelqu'un d'autre : on l'affiche, on ne la force pas. */
+  busy_by_other: boolean;
+};
+
+export function evaluateMachineSelectability(params: {
+  machine: MachineCandidate;
+  actorUserId: number;
+  deviceZone: string | null;
+  enforceZone: boolean;
+}): MachineSelectability {
+  const { machine, actorUserId, deviceZone, enforceZone } = params;
+  const base = { machine_id: machine.id, busy_by_other: false };
+
+  if (machine.archived_at) {
+    return { ...base, selectable: false, reason_code: "MACHINE_ARCHIVED", reason: "Machine archivée." };
+  }
+  if ((machine.status ?? "").toUpperCase() !== "ACTIVE") {
+    return {
+      ...base,
+      selectable: false,
+      reason_code: "MACHINE_INACTIVE",
+      reason: `Machine ${String(machine.status ?? "").toLowerCase() || "inactive"} : indisponible à la production.`,
+    };
+  }
+  if (!machine.is_available) {
+    return {
+      ...base,
+      selectable: false,
+      reason_code: "MACHINE_UNAVAILABLE",
+      reason: "Machine signalée indisponible (maintenance ou blocage qualité).",
+    };
+  }
+  if (enforceZone && deviceZone && machine.workshop_zone && machine.workshop_zone !== deviceZone) {
+    return {
+      ...base,
+      selectable: false,
+      reason_code: "MACHINE_OUT_OF_ZONE",
+      reason: `Machine hors de la zone ${deviceZone}.`,
+    };
+  }
+  if (machine.active_operator_user_id !== null && machine.active_operator_user_id !== actorUserId) {
+    // On n'invente pas de « prise de force » : l'écran propose de consulter,
+    // d'appeler un superviseur ou de choisir une autre machine.
+    return {
+      machine_id: machine.id,
+      selectable: false,
+      busy_by_other: true,
+      reason_code: "MACHINE_BUSY",
+      reason: machine.active_of_numero
+        ? `Machine occupée par un autre opérateur (OF ${machine.active_of_numero}).`
+        : "Machine occupée par un autre opérateur.",
+    };
+  }
+  return { ...base, selectable: true, reason_code: "OK", reason: "Machine disponible." };
+}
+
+/* -------------------------------------------------------------------------- */
+/* 7) Préparation d'une opération — recommandation EXPLIQUÉE                  */
+/* -------------------------------------------------------------------------- */
+
+export const READINESS_LEVELS = ["READY", "INCOMPLETE", "AWAITING_CONTROL", "BLOCKED"] as const;
+export type ReadinessLevel = (typeof READINESS_LEVELS)[number];
+
+export type WorklistSignals = {
+  of_statut: string;
+  operation_status: string;
+  has_pending_predecessor: boolean;
+  has_active_execution_by_other: boolean;
+  machine_matches: boolean;
+  machine_available: boolean;
+  /** Le snapshot technique figé au lancement de l'OF est-il présent ? */
+  has_technical_snapshot: boolean;
+  /** Un plan (document) est-il rattaché à la pièce ? */
+  has_plan_document: boolean;
+  /** Un premier article est-il exigé ET non encore prononcé conforme ? */
+  first_article_pending: boolean;
+  /** Quantité déclarée en attente d'une décision Qualité. */
+  qty_pending_control: number;
+  remaining_quantity: number;
+};
+
+export type ReadinessAssessment = {
+  level: ReadinessLevel;
+  /** Raisons ordonnées de la plus bloquante à la plus informative. */
+  reasons: Array<{ code: string; label: string; severity: "BLOCKING" | "WARNING" | "INFO" }>;
+  /** Phrase unique affichée sur la carte. Jamais un score opaque. */
+  headline: string;
+};
+
+const OF_BLOCKING_STATUSES = new Set(["ANNULE", "ANNULÉ", "TERMINE", "TERMINÉ", "SUSPENDU", "BROUILLON"]);
+
+/**
+ * Explique pourquoi une opération est proposée — ou ne l'est pas.
+ *
+ * Le classement n'est PAS un score : c'est une liste de faits vérifiables. Un
+ * atelier ne fait pas confiance à un chiffre qu'il ne peut pas contredire, et
+ * CERP n'a pas les données pour prétendre à une priorisation « intelligente ».
+ */
+export function assessOperationReadiness(signals: WorklistSignals): ReadinessAssessment {
+  const reasons: ReadinessAssessment["reasons"] = [];
+
+  const statut = (signals.of_statut ?? "").toUpperCase();
+  if (OF_BLOCKING_STATUSES.has(statut)) {
+    reasons.push({
+      code: "OF_NOT_LAUNCHED",
+      label: `Ordre de fabrication en statut ${statut.toLowerCase()} : non pointable.`,
+      severity: "BLOCKING",
+    });
+  }
+
+  const opStatus = (signals.operation_status ?? "").toUpperCase();
+  if (opStatus === "DONE" || opStatus === "CANCELLED") {
+    reasons.push({
+      code: "OPERATION_CLOSED",
+      label: "Opération déjà clôturée.",
+      severity: "BLOCKING",
+    });
+  }
+
+  if (signals.has_active_execution_by_other) {
+    reasons.push({
+      code: "ALREADY_RUNNING",
+      label: "Un autre opérateur pointe déjà cette opération.",
+      severity: "BLOCKING",
+    });
+  }
+
+  if (!signals.machine_available) {
+    reasons.push({
+      code: "MACHINE_UNAVAILABLE",
+      label: "La machine attendue est indisponible.",
+      severity: "BLOCKING",
+    });
+  }
+
+  if (!signals.has_technical_snapshot) {
+    // Sans snapshot, on ne sait PAS quel indice a été lancé. Travailler « sur la
+    // dernière version » serait exactement l'erreur que ce module doit empêcher.
+    reasons.push({
+      code: "NO_TECHNICAL_SNAPSHOT",
+      label: "Aucun snapshot technique figé : l'indice lancé n'est pas certain.",
+      severity: "BLOCKING",
+    });
+  }
+
+  if (signals.first_article_pending) {
+    reasons.push({
+      code: "FIRST_ARTICLE_REQUIRED",
+      label: "Premier article exigé par le plan de contrôle : série interdite avant décision Qualité.",
+      severity: "BLOCKING",
+    });
+  }
+
+  if (signals.has_pending_predecessor) {
+    reasons.push({
+      code: "PREDECESSOR_PENDING",
+      label: "Une phase précédente n'est pas terminée.",
+      severity: "WARNING",
+    });
+  }
+
+  if (!signals.has_plan_document) {
+    reasons.push({
+      code: "NO_PLAN_DOCUMENT",
+      label: "Aucun plan rattaché à la pièce.",
+      severity: "WARNING",
+    });
+  }
+
+  if (!signals.machine_matches) {
+    reasons.push({
+      code: "MACHINE_MISMATCH",
+      label: "Cette opération est prévue sur une autre machine.",
+      severity: "WARNING",
+    });
+  }
+
+  if (signals.qty_pending_control > 0) {
+    reasons.push({
+      code: "QTY_AWAITING_CONTROL",
+      label: `${signals.qty_pending_control} pièce(s) en attente de décision Qualité.`,
+      severity: "INFO",
+    });
+  }
+
+  if (signals.remaining_quantity <= 0) {
+    reasons.push({
+      code: "NOTHING_REMAINING",
+      label: "Quantité lancée déjà couverte par les déclarations.",
+      severity: "WARNING",
+    });
+  }
+
+  const hasBlocking = reasons.some((r) => r.severity === "BLOCKING");
+  const hasWarning = reasons.some((r) => r.severity === "WARNING");
+
+  let level: ReadinessLevel;
+  if (hasBlocking) {
+    level = signals.first_article_pending && reasons.every((r) => r.code === "FIRST_ARTICLE_REQUIRED")
+      ? "AWAITING_CONTROL"
+      : "BLOCKED";
+  } else if (hasWarning) {
+    level = "INCOMPLETE";
+  } else {
+    level = "READY";
+  }
+
+  const headline =
+    reasons.find((r) => r.severity === "BLOCKING")?.label ??
+    reasons.find((r) => r.severity === "WARNING")?.label ??
+    "Prêt à démarrer : matière, plan et machine disponibles.";
+
+  return { level, reasons, headline };
+}
+
+/**
+ * Ordre d'affichage de la file. Trois critères vérifiables, dans cet ordre :
+ * préparation, date cible, phase. Aucun poids arbitraire, aucun apprentissage,
+ * aucun « score de pertinence » que personne ne pourrait auditer.
+ */
+export const WORKLIST_ORDERING_EXPLANATION =
+  "Trié par : opérations prêtes d'abord, puis date de fin prévue la plus proche, puis numéro de phase.";
+
+const READINESS_RANK: Record<ReadinessLevel, number> = {
+  READY: 0,
+  INCOMPLETE: 1,
+  AWAITING_CONTROL: 2,
+  BLOCKED: 3,
+};
+
+export function compareWorklistEntries(
+  a: { readiness: ReadinessLevel; due_date: string | null; phase: number },
+  b: { readiness: ReadinessLevel; due_date: string | null; phase: number }
+): number {
+  const byReadiness = READINESS_RANK[a.readiness] - READINESS_RANK[b.readiness];
+  if (byReadiness !== 0) return byReadiness;
+
+  // Une opération sans date cible passe APRÈS celles qui en ont une : elle
+  // n'est pas urgente, elle est simplement non planifiée.
+  const aDue = a.due_date ? Date.parse(a.due_date) : Number.POSITIVE_INFINITY;
+  const bDue = b.due_date ? Date.parse(b.due_date) : Number.POSITIVE_INFINITY;
+  if (aDue !== bDue) return aDue - bDue;
+
+  return a.phase - b.phase;
+}
+
+/* -------------------------------------------------------------------------- */
+/* 8) Dossier opérateur — ce qui est montré, et ce qui ne l'est jamais        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Champs qu'aucune réponse du module ne doit contenir. `storage_path` en tête :
+ * exposer un chemin disque donne à un opérateur une carte du serveur de
+ * fichiers, et cette fuite a déjà été corrigée deux fois ailleurs dans CERP.
+ */
+export const NEVER_EXPOSED_FIELDS = [
+  "storage_path",
+  "stored_name",
+  "password",
+  "session_token_hash",
+  "credential_hash",
+  "enrollment_secret_hash",
+  "badge_uid",
+  "badge_uid_hash",
+] as const;
+
+/** Champs de coût, masqués sans la capacité `view_costs`. */
+export const COST_FIELDS = [
+  "hourly_rate",
+  "hourly_rate_applied",
+  "cout_mo",
+  "taux_horaire",
+  "prix",
+  "prix_unitaire",
+  "marge",
+] as const;
+
+export function stripCostFields<T extends Record<string, unknown>>(
+  row: T,
+  canViewCosts: boolean
+): T {
+  if (canViewCosts) return row;
+  const copy: Record<string, unknown> = { ...row };
+  for (const field of COST_FIELDS) {
+    if (field in copy) delete copy[field];
+  }
+  return copy as T;
+}
+
+/* -------------------------------------------------------------------------- */
+/* 9) Snapshot technique — la règle de l'indice                               */
+/* -------------------------------------------------------------------------- */
+
+export type TechnicalSnapshotRef = {
+  piece_technique_version_id: string | null;
+  snapshot_sha256: string | null;
+  snapshot_at: Date | null;
+};
+
+export type PlanDocumentRef = {
+  id: string;
+  label: string | null;
+  original_name: string;
+  mime_type: string;
+  size_bytes: number;
+  sha256: string | null;
+  /** Version de pièce à laquelle ce document appartient. */
+  piece_technique_id: string;
+};
+
+export type PlanResolution = {
+  document: PlanDocumentRef | null;
+  /** `true` uniquement si le document appartient bien à la version FIGÉE. */
+  matches_snapshot: boolean;
+  warning: string | null;
+};
+
+/**
+ * Résout le plan à afficher.
+ *
+ * La tentation est de montrer « le dernier plan de la pièce ». C'est
+ * précisément l'erreur que l'atelier paie en pièces rebutées : un OF lancé sur
+ * l'indice B doit continuer à montrer l'indice B, même si l'indice C existe.
+ *
+ * Quand aucun document n'est rattaché à la version figée, on ne substitue PAS
+ * silencieusement un autre document : on renvoie l'absence et l'avertissement.
+ */
+export function resolvePlanForSnapshot(params: {
+  snapshot: TechnicalSnapshotRef;
+  documentsForSnapshotVersion: PlanDocumentRef[];
+  latestVersionIndice: string | null;
+  snapshotIndice: string | null;
+}): PlanResolution {
+  const { snapshot, documentsForSnapshotVersion, latestVersionIndice, snapshotIndice } = params;
+
+  if (!snapshot.piece_technique_version_id) {
+    return {
+      document: null,
+      matches_snapshot: false,
+      warning:
+        "Aucun snapshot technique n'a été figé au lancement de cet OF : le plan applicable ne peut pas être garanti.",
+    };
+  }
+
+  const document = documentsForSnapshotVersion[0] ?? null;
+  if (!document) {
+    return {
+      document: null,
+      matches_snapshot: false,
+      warning: `Aucun plan n'est rattaché à l'indice figé${snapshotIndice ? ` ${snapshotIndice}` : ""}. Demandez le dossier aux méthodes.`,
+    };
+  }
+
+  const supersededWarning =
+    latestVersionIndice && snapshotIndice && latestVersionIndice !== snapshotIndice
+      ? `Un indice plus récent existe (${latestVersionIndice}). Cet OF reste lancé sur l'indice ${snapshotIndice} : c'est celui-ci qui fait foi.`
+      : null;
+
+  return { document, matches_snapshot: true, warning: supersededWarning };
+}
+
+/* -------------------------------------------------------------------------- */
+/* 10) Transmission de poste                                                  */
+/* -------------------------------------------------------------------------- */
+
+export const HANDOVER_MACHINE_STATES = [
+  "RUNNING",
+  "STOPPED",
+  "SETUP",
+  "FAULT",
+  "MAINTENANCE",
+  "UNKNOWN",
+] as const;
+export type HandoverMachineState = (typeof HANDOVER_MACHINE_STATES)[number];
+
+export function assertHandoverParties(params: {
+  outgoingUserId: number;
+  incomingUserId: number;
+}): void {
+  if (params.outgoingUserId === params.incomingUserId) {
+    throw new HttpError(
+      400,
+      "STATION_HANDOVER_SAME_USER",
+      "Une transmission de poste suppose deux opérateurs différents."
+    );
+  }
+}
+
+export function assertHandoverAcknowledgeable(params: {
+  incomingUserId: number;
+  actorUserId: number;
+  actorRole: string | null | undefined;
+  alreadyAcknowledgedAt: Date | null;
+}): void {
+  if (params.alreadyAcknowledgedAt) {
+    throw new HttpError(
+      409,
+      "STATION_HANDOVER_ALREADY_ACKNOWLEDGED",
+      "Cette transmission a déjà été accusée de réception."
+    );
+  }
+  if (params.actorUserId === params.incomingUserId) return;
+  if (roleHasStationCapability(params.actorRole, "supervise_stations")) return;
+  throw new HttpError(
+    403,
+    "STATION_HANDOVER_NOT_ADDRESSEE",
+    "Cette transmission est destinée à un autre opérateur."
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* 11) Anti-IDOR                                                              */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Un opérateur ne pilote que SES sessions. Élargir le périmètre exige une
+ * capacité explicite — masquer un bouton côté UI n'a jamais été une
+ * autorisation.
+ */
+export function assertOwnSessionOrSupervision(params: {
+  actorUserId: number;
+  actorRole: string | null | undefined;
+  sessionUserId: number;
+  action: string;
+}): void {
+  if (params.actorUserId === params.sessionUserId) return;
+  if (roleHasStationCapability(params.actorRole, "supervise_stations")) return;
+  throw new HttpError(
+    403,
+    "STATION_FOREIGN_SESSION",
+    `Cette session appartient à un autre opérateur : '${params.action}' est refusé.`
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* 12) Salons temps réel                                                      */
+/* -------------------------------------------------------------------------- */
+
+export type StationRoom =
+  | { kind: "USER"; userId: number }
+  | { kind: "MACHINE"; machineId: string }
+  | { kind: "OF"; ofId: number }
+  | { kind: "STATION"; deviceId: string };
+
+const ROOM_PATTERNS: Array<{ re: RegExp; build: (m: RegExpExecArray) => StationRoom | null }> = [
+  { re: /^USER:(\d+)$/, build: (m) => ({ kind: "USER", userId: Number(m[1]) }) },
+  { re: /^MACHINE:([0-9a-fA-F-]{36})$/, build: (m) => ({ kind: "MACHINE", machineId: m[1] }) },
+  { re: /^OF:(\d+)$/, build: (m) => ({ kind: "OF", ofId: Number(m[1]) }) },
+  { re: /^STATION:([0-9a-fA-F-]{36})$/, build: (m) => ({ kind: "STATION", deviceId: m[1] }) },
+];
+
+/**
+ * Un nom de salon envoyé par le client n'est jamais accordé tel quel : il est
+ * d'abord PARSÉ. Ce qui n'est pas reconnu n'est pas un salon de poste et sera
+ * traité par la politique générale du serveur socket.
+ */
+export function parseStationRoom(room: string): StationRoom | null {
+  for (const { re, build } of ROOM_PATTERNS) {
+    const m = re.exec(room);
+    if (m) return build(m);
+  }
+  return null;
+}
+
+/**
+ * Autorisation d'abonnement. `USER:` est strictement personnel ; `MACHINE:`,
+ * `OF:` et `STATION:` exigent au minimum de pouvoir lire son poste, et la
+ * supervision pour observer sans y être affecté.
+ */
+export function canSubscribeStationRoom(params: {
+  room: StationRoom;
+  actorUserId: number;
+  actorRole: string | null | undefined;
+  /** Machines confirmées par une session vivante de cet utilisateur. */
+  ownMachineIds: readonly string[];
+  /** OF sur lesquels cet utilisateur a un segment actif. */
+  ownOfIds: readonly number[];
+  /** Appareils sur lesquels cet utilisateur a une session vivante. */
+  ownDeviceIds: readonly string[];
+}): boolean {
+  const { room, actorUserId, actorRole } = params;
+
+  switch (room.kind) {
+    case "USER":
+      return room.userId === actorUserId;
+    case "MACHINE":
+      if (!roleHasStationCapability(actorRole, "read_own_station")) return false;
+      if (params.ownMachineIds.includes(room.machineId)) return true;
+      return roleHasStationCapability(actorRole, "supervise_stations");
+    case "OF":
+      if (!roleHasStationCapability(actorRole, "read_own_station")) return false;
+      if (params.ownOfIds.includes(room.ofId)) return true;
+      return roleHasStationCapability(actorRole, "supervise_stations");
+    case "STATION":
+      if (params.ownDeviceIds.includes(room.deviceId)) return true;
+      return roleHasStationCapability(actorRole, "supervise_stations");
+    default:
+      return false;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 13) Événements d'audit                                                     */
+/* -------------------------------------------------------------------------- */
+
+export const STATION_AUDIT_EVENTS = [
+  "DEVICE_ENROLLED",
+  "DEVICE_UPDATED",
+  "DEVICE_DISABLED",
+  "DEVICE_REVOKED",
+  "CREDENTIAL_ISSUED",
+  "CREDENTIAL_REVOKED",
+  "SESSION_OPENED",
+  "SESSION_LOCKED",
+  "SESSION_UNLOCKED",
+  "SESSION_CLOSED",
+  "SESSION_EXPIRED",
+  "IDENTIFICATION_FAILED",
+  "MACHINE_CONFIRMED",
+  "MACHINE_REFUSED",
+  "OPERATOR_SWITCHED",
+  "HANDOVER_CREATED",
+  "HANDOVER_ACKNOWLEDGED",
+  "AUTHORIZATION_DENIED",
+  "ROOM_SUBSCRIPTION_DENIED",
+  "DOSSIER_OPENED",
+  "PLAN_OPENED",
+  "HEARTBEAT",
+] as const;
+
+export type StationAuditEventType = (typeof STATION_AUDIT_EVENTS)[number];
+
+/**
+ * Nettoie le contexte d'audit. Un journal qui recopie un UID de badge ou un
+ * jeton devient lui-même une cible ; il n'y a donc aucune raison d'y écrire un
+ * secret pour « faciliter le débogage ».
+ */
+export function sanitizeAuditDetail(detail: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(detail)) {
+    const lower = key.toLowerCase();
+    const looksSensitive =
+      NEVER_EXPOSED_FIELDS.some((f) => lower.includes(f)) ||
+      lower.includes("token") ||
+      lower.includes("secret") ||
+      lower.includes("password") ||
+      lower.includes("badge_uid") ||
+      lower.includes("pepper");
+    if (looksSensitive) continue;
+    if (typeof value === "string" && value.length > 512) {
+      out[key] = `${value.slice(0, 512)}…`;
+      continue;
+    }
+    out[key] = value;
+  }
+  return out;
+}

--- a/src/module/production/middlewares/station-authorization.middleware.ts
+++ b/src/module/production/middlewares/station-authorization.middleware.ts
@@ -1,0 +1,318 @@
+import type { RequestHandler, Request, Response } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import {
+  evaluateSession,
+  roleHasStationCapability,
+  type StationCapability,
+} from "../domain/station";
+import {
+  repoFindSessionByToken,
+  repoSetSessionState,
+  repoStationAudit,
+  repoTouchSession,
+} from "../repository/station.repository";
+
+/**
+ * Contexte de poste attaché à la requête. Il est la SEULE source d'identité du
+ * module : aucune route ne lit un `user_id` dans le corps de la requête.
+ */
+export type StationContext = {
+  session_id: string;
+  device_id: string;
+  device_code: string;
+  device_zone: string | null;
+  device_assignment_mode: "FIXED" | "MOBILE";
+  machine_id: string | null;
+  user: { id: number; username: string; name: string | null; surname: string | null; role: string | null };
+  auto_lock_seconds: number;
+};
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      station?: StationContext;
+    }
+  }
+}
+
+export const STATION_SESSION_COOKIE = "cerp_station_session";
+export const STATION_SESSION_HEADER = "x-station-session";
+
+/**
+ * Récupère le jeton de session opaque.
+ *
+ * Le cookie `httpOnly` est la voie NORMALE : il n'est pas lisible par le
+ * JavaScript de la page, donc une faille XSS ne l'exfiltre pas. L'en-tête reste
+ * accepté en repli parce que certaines configurations de proxy suppriment les
+ * cookies tiers ; dans ce cas le jeton vit en mémoire de l'onglet et n'est
+ * jamais écrit dans `localStorage`.
+ */
+export function readStationToken(req: Request): string | null {
+  const rawCookie = req.headers.cookie;
+  if (typeof rawCookie === "string" && rawCookie.length > 0) {
+    for (const part of rawCookie.split(";")) {
+      const [name, ...rest] = part.trim().split("=");
+      if (name === STATION_SESSION_COOKIE && rest.length) {
+        const value = decodeURIComponent(rest.join("="));
+        if (value) return value;
+      }
+    }
+  }
+  const header = req.headers[STATION_SESSION_HEADER];
+  if (typeof header === "string" && header.trim()) return header.trim();
+  return null;
+}
+
+/** Pose le cookie de session. `SameSite=None` est requis : l'API et l'UI sont sur deux origines. */
+export function setStationSessionCookie(res: Response, token: string, maxAgeSeconds: number): void {
+  res.cookie(STATION_SESSION_COOKIE, token, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "none",
+    path: "/",
+    maxAge: maxAgeSeconds * 1000,
+  });
+}
+
+export function clearStationSessionCookie(res: Response): void {
+  res.clearCookie(STATION_SESSION_COOKIE, {
+    httpOnly: true,
+    secure: true,
+    sameSite: "none",
+    path: "/",
+  });
+}
+
+/**
+ * Exige une session de poste vivante.
+ *
+ * Contrairement à un JWT, cette vérification interroge la base à chaque
+ * requête : c'est ce qui rend la révocation d'une tablette IMMÉDIATE. Le coût
+ * d'un aller-retour est le prix d'une révocation qui fonctionne vraiment.
+ *
+ * Le verrouillage par inactivité est décidé par le SERVEUR : une tablette dont
+ * l'horloge a été reculée ne prolonge pas sa session.
+ */
+export const requireStationSession: RequestHandler = (req, _res, next) => {
+  void (async () => {
+    const token = readStationToken(req);
+    if (!token) {
+      next(new HttpError(401, "STATION_SESSION_REQUIRED", "Identifiez-vous sur la tablette."));
+      return;
+    }
+
+    const found = await repoFindSessionByToken(token);
+    if (!found) {
+      next(new HttpError(401, "STATION_SESSION_UNKNOWN", "Session inconnue. Identifiez-vous à nouveau."));
+      return;
+    }
+
+    const { session, device, user } = found;
+
+    // L'appareil prime sur la session : une tablette révoquée ferme tout.
+    if (device.status === "REVOKED" || device.status === "DISABLED") {
+      await repoSetSessionState({
+        sessionId: session.id,
+        state: "REVOKED",
+        reason: `DEVICE_${device.status}`,
+      }).catch(() => undefined);
+      await repoStationAudit({
+        event_type: "AUTHORIZATION_DENIED",
+        outcome: "DENIED",
+        reason_code: `DEVICE_${device.status}`,
+        device_id: device.id,
+        session_id: session.id,
+        user_id: user.id,
+      });
+      next(
+        new HttpError(
+          403,
+          device.status === "REVOKED" ? "STATION_DEVICE_REVOKED" : "STATION_DEVICE_DISABLED",
+          "Cette tablette n'est plus autorisée. Contactez le chef d'atelier."
+        )
+      );
+      return;
+    }
+
+    const evaluation = evaluateSession({
+      session,
+      autoLockSeconds: device.auto_lock_seconds,
+      now: new Date(),
+    });
+
+    if (!evaluation.usable) {
+      // Le verrouillage n'arrête AUCUN pointage : c'est la règle centrale du
+      // module. On persiste seulement l'état de l'écran.
+      if (evaluation.reason === "IDLE_LOCK" && session.state === "ACTIVE") {
+        await repoSetSessionState({ sessionId: session.id, state: "LOCKED" }).catch(() => undefined);
+        await repoStationAudit({
+          event_type: "SESSION_LOCKED",
+          reason_code: "IDLE",
+          device_id: device.id,
+          session_id: session.id,
+          user_id: user.id,
+        });
+      }
+      if (evaluation.reason === "EXPIRED" && (session.state === "ACTIVE" || session.state === "LOCKED")) {
+        await repoSetSessionState({
+          sessionId: session.id,
+          state: "EXPIRED",
+          reason: "MAX_DURATION",
+        }).catch(() => undefined);
+        await repoStationAudit({
+          event_type: "SESSION_EXPIRED",
+          device_id: device.id,
+          session_id: session.id,
+          user_id: user.id,
+        });
+      }
+
+      const codes: Record<string, { code: string; message: string }> = {
+        EXPIRED: {
+          code: "STATION_SESSION_EXPIRED",
+          message: "Session expirée. Identifiez-vous à nouveau. Votre pointage en cours n'a pas été arrêté.",
+        },
+        IDLE_LOCK: {
+          code: "STATION_SESSION_LOCKED",
+          message: "Écran verrouillé par inactivité. Présentez votre badge. Votre pointage en cours n'a pas été arrêté.",
+        },
+        LOCKED: {
+          code: "STATION_SESSION_LOCKED",
+          message: "Écran verrouillé. Présentez votre badge pour reprendre.",
+        },
+        CLOSED: {
+          code: "STATION_SESSION_CLOSED",
+          message: "Session fermée. Identifiez-vous à nouveau.",
+        },
+      };
+      const mapped = codes[evaluation.reason] ?? codes.CLOSED;
+      next(new HttpError(401, mapped.code, mapped.message));
+      return;
+    }
+
+    req.station = {
+      session_id: session.id,
+      device_id: device.id,
+      device_code: device.public_code,
+      device_zone: device.workshop_zone,
+      device_assignment_mode: device.assignment_mode,
+      machine_id: session.machine_id,
+      user,
+      auto_lock_seconds: device.auto_lock_seconds,
+    };
+
+    // Prolongation d'activité : elle est posée par le serveur (`now()`), pas
+    // par l'horloge de la tablette.
+    await repoTouchSession(session.id).catch(() => undefined);
+    next();
+  })().catch(next);
+};
+
+/**
+ * Variante tolérante : la session est chargée si elle existe, sans exiger
+ * qu'elle soit vivante. Utilisée par le bootstrap, qui doit pouvoir afficher
+ * l'écran verrouillé sans être lui-même refusé.
+ */
+export const loadStationSessionIfAny: RequestHandler = (req, _res, next) => {
+  void (async () => {
+    const token = readStationToken(req);
+    if (!token) {
+      next();
+      return;
+    }
+    const found = await repoFindSessionByToken(token);
+    if (!found) {
+      next();
+      return;
+    }
+    const { session, device, user } = found;
+    if (device.status !== "ACTIVE") {
+      next();
+      return;
+    }
+    const evaluation = evaluateSession({
+      session,
+      autoLockSeconds: device.auto_lock_seconds,
+      now: new Date(),
+    });
+    if (!evaluation.usable) {
+      next();
+      return;
+    }
+    req.station = {
+      session_id: session.id,
+      device_id: device.id,
+      device_code: device.public_code,
+      device_zone: device.workshop_zone,
+      device_assignment_mode: device.assignment_mode,
+      machine_id: session.machine_id,
+      user,
+      auto_lock_seconds: device.auto_lock_seconds,
+    };
+    next();
+  })().catch(next);
+};
+
+/**
+ * Garde de capacité. Refus par défaut : être identifié sur une tablette
+ * n'accorde AUCUN droit implicite. La garde est rejouée à chaque requête —
+ * masquer un bouton côté UI n'a jamais été une autorisation.
+ *
+ * Elle accepte deux origines d'identité, jamais une troisième :
+ *   * la session de poste (`req.station`), pour la tablette ;
+ *   * le JWT ERP (`req.user`), pour l'administration depuis le poste bureau.
+ */
+export function requireStationCapability(capability: StationCapability): RequestHandler {
+  return (req, _res, next) => {
+    const role = req.station?.user.role ?? req.user?.role ?? null;
+    const userId = req.station?.user.id ?? req.user?.id ?? null;
+
+    if (!userId) {
+      next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
+      return;
+    }
+    if (!roleHasStationCapability(role, capability)) {
+      void repoStationAudit({
+        event_type: "AUTHORIZATION_DENIED",
+        outcome: "DENIED",
+        reason_code: capability,
+        device_id: req.station?.device_id ?? null,
+        session_id: req.station?.session_id ?? null,
+        user_id: userId,
+        detail: { capability, path: req.path },
+      });
+      next(
+        new HttpError(
+          403,
+          "STATION_CAPABILITY_REQUIRED",
+          `La capacité de poste '${capability}' est requise.`
+        )
+      );
+      return;
+    }
+    next();
+  };
+}
+
+/**
+ * Toute commande à effet exige une clé d'idempotence. Sans elle, un double-clic
+ * sur un écran tactile — geste très fréquent avec des gants — produirait deux
+ * effets.
+ */
+export const requireStationIdempotencyKey: RequestHandler = (req, _res, next) => {
+  const raw = req.headers["idempotency-key"];
+  const key = typeof raw === "string" ? raw.trim() : "";
+  if (key.length < 8 || key.length > 200) {
+    next(
+      new HttpError(
+        400,
+        "IDEMPOTENCY_KEY_REQUIRED",
+        "L'en-tête Idempotency-Key est requis (8 à 200 caractères) pour cette action."
+      )
+    );
+    return;
+  }
+  next();
+};

--- a/src/module/production/repository/station.repository.ts
+++ b/src/module/production/repository/station.repository.ts
@@ -1201,6 +1201,7 @@ export async function repoWorklist(params: {
 export type DossierRaw = {
   of: Record<string, unknown>;
   operation: Record<string, unknown>;
+  client: Record<string, unknown> | null;
   documents: Array<Record<string, unknown>>;
   instructions: Array<Record<string, unknown>>;
   materials: Array<Record<string, unknown>>;
@@ -1252,6 +1253,18 @@ export async function repoDossier(params: {
       to_jsonb(pt) AS piece,
       to_jsonb(ptv) AS piece_version,
       to_jsonb(a) AS affaire,
+      CASE
+        WHEN c.client_id IS NULL THEN NULL
+        ELSE jsonb_build_object(
+          'id', c.client_id::text,
+          'code', COALESCE(
+            NULLIF(btrim(to_jsonb(c)->>'client_code'), ''),
+            NULLIF(btrim(to_jsonb(c)->>'code_client'), '')
+          ),
+          'company_name', c.company_name,
+          'logo_path', c.logo_path
+        )
+      END AS client,
       to_jsonb(m) AS machine,
       to_jsonb(po) AS poste,
 
@@ -1459,6 +1472,7 @@ export async function repoDossier(params: {
     LEFT JOIN public.pieces_techniques pt ON pt.id = b.piece_technique_id
     LEFT JOIN public.piece_technique_versions ptv ON ptv.id = b.piece_technique_version_id
     LEFT JOIN public.affaire a ON a.id = b.affaire_id
+    LEFT JOIN public.clients c ON c.client_id = b.client_id
     LEFT JOIN public.machines m ON m.id = b.machine_id
     LEFT JOIN public.postes po ON po.id = b.poste_id
     `,

--- a/src/module/production/repository/station.repository.ts
+++ b/src/module/production/repository/station.repository.ts
@@ -1,0 +1,1758 @@
+// Repository du poste opérateur tablette (#159).
+//
+// Règles structurantes appliquées ici et nulle part ailleurs :
+//
+//   * Ce repository ne pilote AUCUN temps et AUCUNE quantité. Il LIT l'état du
+//     moteur #274 (`production_pointages`, `production_quantity_declarations`)
+//     et n'y écrit jamais. Démarrer, mettre en pause ou terminer reste l'affaire
+//     de `production-execution.repository.ts`.
+//   * Il n'écrit JAMAIS dans le domaine RH (#119), le stock, les lots, les
+//     réceptions, les BL ni les factures. La liste est déclarée dans le domaine
+//     (`FORBIDDEN_STATION_SIDE_EFFECTS`) et vérifiée par test sur ce fichier.
+//   * Le TEMPS officiel est posé par la base (`now()`), jamais par la tablette.
+//   * Le dossier opérateur est construit par des requêtes AGRÉGÉES : une
+//     opération = un aller-retour, pas quinze. Une tablette derrière un Wi-Fi
+//     d'atelier ne survit pas à un N+1.
+
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+
+import {
+  assertDeviceUsable,
+  fingerprintCredential,
+  generateSessionToken,
+  hashSessionToken,
+  sanitizeAuditDetail,
+  type DeviceAssignmentMode,
+  type DeviceState,
+  type DeviceStatus,
+  type IdentificationMethod,
+  type StationAuditEventType,
+} from "../domain/station";
+
+type DbQueryer = Pick<PoolClient, "query">;
+
+/* -------------------------------------------------------------------------- */
+/* Utilitaires                                                                */
+/* -------------------------------------------------------------------------- */
+
+function num(value: unknown): number {
+  if (value === null || value === undefined) return 0;
+  const n = typeof value === "number" ? value : Number(value);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function iso(value: unknown): string | null {
+  if (!value) return null;
+  const d = value instanceof Date ? value : new Date(String(value));
+  return Number.isNaN(d.getTime()) ? null : d.toISOString();
+}
+
+function toDate(value: unknown): Date {
+  const d = value instanceof Date ? value : new Date(String(value));
+  if (Number.isNaN(d.getTime())) throw new HttpError(500, "STATION_INVALID_TIMESTAMP", "Horodatage serveur illisible.");
+  return d;
+}
+
+/**
+ * Poivre de hachage des supports d'identification. Absent, l'identification par
+ * badge est REFUSÉE plutôt que dégradée en SHA-256 nu : un UID de badge tient
+ * dans un espace de recherche minuscule.
+ */
+function badgePepper(): string {
+  return process.env.STATION_BADGE_PEPPER ?? "";
+}
+
+/* -------------------------------------------------------------------------- */
+/* Journal d'audit — append-only                                              */
+/* -------------------------------------------------------------------------- */
+
+export type StationAuditInput = {
+  event_type: StationAuditEventType;
+  outcome?: "SUCCESS" | "DENIED" | "ERROR";
+  reason_code?: string | null;
+  device_id?: string | null;
+  session_id?: string | null;
+  user_id?: number | null;
+  machine_id?: string | null;
+  of_id?: number | null;
+  operation_id?: string | null;
+  detail?: Record<string, unknown>;
+  correlation_id?: string | null;
+  request_id?: string | null;
+};
+
+/**
+ * Écrit un événement d'audit. Volontairement tolérant à l'échec : un journal
+ * indisponible ne doit pas empêcher un opérateur de travailler, mais l'incident
+ * doit rester visible dans les logs applicatifs.
+ */
+export async function repoStationAudit(input: StationAuditInput, tx?: DbQueryer): Promise<void> {
+  const db = tx ?? pool;
+  try {
+    await db.query(
+      `INSERT INTO public.station_audit_events
+         (event_type, outcome, reason_code, device_id, session_id, user_id,
+          machine_id, of_id, operation_id, detail, correlation_id, request_id)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10::jsonb,$11,$12)`,
+      [
+        input.event_type,
+        input.outcome ?? "SUCCESS",
+        input.reason_code ?? null,
+        input.device_id ?? null,
+        input.session_id ?? null,
+        input.user_id ?? null,
+        input.machine_id ?? null,
+        input.of_id ?? null,
+        input.operation_id ?? null,
+        JSON.stringify(sanitizeAuditDetail(input.detail ?? {})),
+        input.correlation_id ?? null,
+        input.request_id ?? null,
+      ]
+    );
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        type: "station_audit_write_failed",
+        event_type: input.event_type,
+        error: error instanceof Error ? error.name : "unknown",
+      })
+    );
+  }
+}
+
+export async function repoListStationAudit(params: {
+  device_id?: string;
+  user_id?: number;
+  event_type?: string;
+  outcome?: string;
+  limit: number;
+}): Promise<unknown[]> {
+  const where: string[] = [];
+  const values: unknown[] = [];
+  if (params.device_id) {
+    values.push(params.device_id);
+    where.push(`e.device_id = $${values.length}`);
+  }
+  if (params.user_id) {
+    values.push(params.user_id);
+    where.push(`e.user_id = $${values.length}`);
+  }
+  if (params.event_type) {
+    values.push(params.event_type);
+    where.push(`e.event_type = $${values.length}`);
+  }
+  if (params.outcome) {
+    values.push(params.outcome);
+    where.push(`e.outcome = $${values.length}`);
+  }
+  values.push(params.limit);
+
+  const { rows } = await pool.query(
+    `SELECT e.id, e.event_type, e.outcome, e.reason_code, e.detail, e.created_at,
+            e.device_id, d.public_code AS device_code,
+            e.user_id, u.username AS user_username,
+            e.machine_id, m.code AS machine_code,
+            e.of_id, e.operation_id
+       FROM public.station_audit_events e
+       LEFT JOIN public.production_devices d ON d.id = e.device_id
+       LEFT JOIN public.users u ON u.id = e.user_id
+       LEFT JOIN public.machines m ON m.id = e.machine_id
+      ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+      ORDER BY e.created_at DESC, e.id DESC
+      LIMIT $${values.length}`,
+    values
+  );
+
+  return rows.map((r) => ({
+    id: Number(r.id),
+    event_type: r.event_type as string,
+    outcome: r.outcome as string,
+    reason_code: r.reason_code as string | null,
+    detail: r.detail ?? {},
+    created_at: iso(r.created_at),
+    device: r.device_id ? { id: r.device_id as string, public_code: r.device_code as string } : null,
+    user: r.user_id ? { id: Number(r.user_id), username: r.user_username as string } : null,
+    machine: r.machine_id ? { id: r.machine_id as string, code: r.machine_code as string } : null,
+    of_id: r.of_id === null || r.of_id === undefined ? null : Number(r.of_id),
+    operation_id: (r.operation_id as string | null) ?? null,
+  }));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Appareils                                                                  */
+/* -------------------------------------------------------------------------- */
+
+const DEVICE_COLUMNS = `
+  d.id, d.public_code, d.label, d.site, d.workshop_zone, d.assignment_mode,
+  d.machine_id, d.status, d.auto_lock_seconds, d.session_max_seconds,
+  d.last_seen_at, d.last_seen_app_version, d.enrolled_at, d.revoked_at,
+  d.revoke_reason, d.created_at, d.updated_at
+`;
+
+export type DeviceRow = DeviceState & {
+  label: string;
+  site: string | null;
+  workshop_zone: string | null;
+  last_seen_at: string | null;
+  last_seen_app_version: string | null;
+  enrolled_at: string | null;
+  revoked_at: string | null;
+  revoke_reason: string | null;
+  machine: { id: string; code: string; name: string } | null;
+};
+
+function mapDevice(r: Record<string, unknown>): DeviceRow {
+  return {
+    id: r.id as string,
+    public_code: r.public_code as string,
+    label: r.label as string,
+    site: (r.site as string | null) ?? null,
+    workshop_zone: (r.workshop_zone as string | null) ?? null,
+    assignment_mode: r.assignment_mode as DeviceAssignmentMode,
+    machine_id: (r.machine_id as string | null) ?? null,
+    status: r.status as DeviceStatus,
+    auto_lock_seconds: num(r.auto_lock_seconds),
+    session_max_seconds: num(r.session_max_seconds),
+    last_seen_at: iso(r.last_seen_at),
+    last_seen_app_version: (r.last_seen_app_version as string | null) ?? null,
+    enrolled_at: iso(r.enrolled_at),
+    revoked_at: iso(r.revoked_at),
+    revoke_reason: (r.revoke_reason as string | null) ?? null,
+    machine: r.machine_code
+      ? {
+          id: r.machine_id as string,
+          code: r.machine_code as string,
+          name: (r.machine_name as string | null) ?? "",
+        }
+      : null,
+  };
+}
+
+export async function repoFindDeviceByCode(code: string, tx?: DbQueryer): Promise<DeviceRow | null> {
+  const db = tx ?? pool;
+  const { rows } = await db.query(
+    `SELECT ${DEVICE_COLUMNS}, m.code AS machine_code, m.name AS machine_name
+       FROM public.production_devices d
+       LEFT JOIN public.machines m ON m.id = d.machine_id
+      WHERE d.public_code = $1`,
+    [code]
+  );
+  return rows[0] ? mapDevice(rows[0]) : null;
+}
+
+export async function repoFindDeviceById(id: string, tx?: DbQueryer): Promise<DeviceRow | null> {
+  const db = tx ?? pool;
+  const { rows } = await db.query(
+    `SELECT ${DEVICE_COLUMNS}, m.code AS machine_code, m.name AS machine_name
+       FROM public.production_devices d
+       LEFT JOIN public.machines m ON m.id = d.machine_id
+      WHERE d.id = $1`,
+    [id]
+  );
+  return rows[0] ? mapDevice(rows[0]) : null;
+}
+
+export async function repoListDevices(params: {
+  status?: string;
+  workshop_zone?: string;
+  q?: string;
+  limit: number;
+}): Promise<DeviceRow[]> {
+  const where: string[] = [];
+  const values: unknown[] = [];
+  if (params.status) {
+    values.push(params.status);
+    where.push(`d.status = $${values.length}`);
+  }
+  if (params.workshop_zone) {
+    values.push(params.workshop_zone);
+    where.push(`d.workshop_zone = $${values.length}`);
+  }
+  if (params.q) {
+    values.push(`%${params.q}%`);
+    where.push(`(d.public_code ILIKE $${values.length} OR d.label ILIKE $${values.length})`);
+  }
+  values.push(params.limit);
+
+  const { rows } = await pool.query(
+    `SELECT ${DEVICE_COLUMNS}, m.code AS machine_code, m.name AS machine_name
+       FROM public.production_devices d
+       LEFT JOIN public.machines m ON m.id = d.machine_id
+      ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+      ORDER BY d.public_code
+      LIMIT $${values.length}`,
+    values
+  );
+  return rows.map(mapDevice);
+}
+
+export async function repoEnrollDevice(params: {
+  label: string;
+  code_prefix: string;
+  site?: string | null;
+  workshop_zone?: string | null;
+  assignment_mode: DeviceAssignmentMode;
+  machine_id?: string | null;
+  auto_lock_seconds: number;
+  session_max_seconds: number;
+  actorUserId: number;
+}): Promise<DeviceRow> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    if (params.machine_id) {
+      const { rowCount } = await client.query(
+        `SELECT 1 FROM public.machines WHERE id = $1 AND archived_at IS NULL`,
+        [params.machine_id]
+      );
+      if (!rowCount) {
+        throw new HttpError(404, "STATION_MACHINE_UNKNOWN", "Machine introuvable ou archivée.");
+      }
+    }
+
+    // Le code public est alloué par la BASE : deux enrôlements simultanés ne
+    // peuvent pas obtenir le même numéro.
+    const { rows: codeRows } = await client.query(
+      `SELECT public.fn_production_device_next_public_code($1) AS code`,
+      [params.code_prefix]
+    );
+    const publicCode = codeRows[0]?.code as string;
+
+    const { rows } = await client.query(
+      `INSERT INTO public.production_devices
+         (public_code, label, site, workshop_zone, assignment_mode, machine_id,
+          auto_lock_seconds, session_max_seconds, enrolled_by, created_by, updated_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$9,$9)
+       RETURNING id`,
+      [
+        publicCode,
+        params.label,
+        params.site ?? null,
+        params.workshop_zone ?? null,
+        params.assignment_mode,
+        params.machine_id ?? null,
+        params.auto_lock_seconds,
+        params.session_max_seconds,
+        params.actorUserId,
+      ]
+    );
+
+    const deviceId = rows[0].id as string;
+    await repoStationAudit(
+      {
+        event_type: "DEVICE_ENROLLED",
+        device_id: deviceId,
+        user_id: params.actorUserId,
+        machine_id: params.machine_id ?? null,
+        detail: { public_code: publicCode, assignment_mode: params.assignment_mode },
+      },
+      client
+    );
+
+    await client.query("COMMIT");
+    const created = await repoFindDeviceById(deviceId);
+    if (!created) throw new HttpError(500, "STATION_DEVICE_CREATE_FAILED", "Appareil créé mais introuvable.");
+    return created;
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoUpdateDevice(params: {
+  id: string;
+  patch: Record<string, unknown>;
+  actorUserId: number;
+}): Promise<DeviceRow> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const { rows: currentRows } = await client.query(
+      `SELECT id, status, assignment_mode, machine_id FROM public.production_devices WHERE id = $1 FOR UPDATE`,
+      [params.id]
+    );
+    const current = currentRows[0];
+    if (!current) throw new HttpError(404, "STATION_DEVICE_UNKNOWN", "Appareil introuvable.");
+    if (current.status === "REVOKED") {
+      throw new HttpError(
+        409,
+        "STATION_DEVICE_REVOKED",
+        "Un appareil révoqué ne peut plus être modifié. Enrôlez-en un nouveau."
+      );
+    }
+
+    const nextMode = (params.patch.assignment_mode as string | undefined) ?? current.assignment_mode;
+    const nextMachine =
+      "machine_id" in params.patch ? (params.patch.machine_id as string | null) : current.machine_id;
+    if (nextMode === "FIXED" && !nextMachine) {
+      throw new HttpError(
+        400,
+        "STATION_FIXED_REQUIRES_MACHINE",
+        "Une tablette fixe doit être affectée à une machine."
+      );
+    }
+
+    const sets: string[] = [];
+    const values: unknown[] = [];
+    for (const [key, value] of Object.entries(params.patch)) {
+      values.push(value);
+      sets.push(`${key} = $${values.length}`);
+    }
+    values.push(params.actorUserId);
+    sets.push(`updated_by = $${values.length}`);
+    values.push(params.id);
+
+    await client.query(
+      `UPDATE public.production_devices SET ${sets.join(", ")} WHERE id = $${values.length}`,
+      values
+    );
+
+    await repoStationAudit(
+      {
+        event_type: params.patch.status === "DISABLED" ? "DEVICE_DISABLED" : "DEVICE_UPDATED",
+        device_id: params.id,
+        user_id: params.actorUserId,
+        detail: { fields: Object.keys(params.patch) },
+      },
+      client
+    );
+
+    await client.query("COMMIT");
+    const updated = await repoFindDeviceById(params.id);
+    if (!updated) throw new HttpError(404, "STATION_DEVICE_UNKNOWN", "Appareil introuvable.");
+    return updated;
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Révocation : définitive, et elle FERME toutes les sessions vivantes de
+ * l'appareil. Elle n'arrête en revanche AUCUN pointage — le temps déjà déclaré
+ * appartient au moteur #274 et à personne d'autre.
+ */
+export async function repoRevokeDevice(params: {
+  id: string;
+  reason: string;
+  actorUserId: number;
+}): Promise<{ device: DeviceRow; closed_sessions: number }> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const { rows } = await client.query(
+      `UPDATE public.production_devices
+          SET status = 'REVOKED', revoked_at = now(), revoked_by = $2,
+              revoke_reason = $3, updated_by = $2
+        WHERE id = $1 AND status <> 'REVOKED'
+        RETURNING id`,
+      [params.id, params.actorUserId, params.reason]
+    );
+    if (!rows[0]) {
+      const existing = await repoFindDeviceById(params.id, client);
+      if (!existing) throw new HttpError(404, "STATION_DEVICE_UNKNOWN", "Appareil introuvable.");
+      await client.query("ROLLBACK");
+      return { device: existing, closed_sessions: 0 };
+    }
+
+    const closed = await client.query(
+      `UPDATE public.operator_device_sessions
+          SET state = 'REVOKED', closed_at = now(), close_reason = 'DEVICE_REVOKED'
+        WHERE device_id = $1 AND state IN ('ACTIVE', 'LOCKED')
+        RETURNING id`,
+      [params.id]
+    );
+
+    await repoStationAudit(
+      {
+        event_type: "DEVICE_REVOKED",
+        device_id: params.id,
+        user_id: params.actorUserId,
+        detail: { closed_sessions: closed.rowCount ?? 0 },
+      },
+      client
+    );
+
+    await client.query("COMMIT");
+    const device = await repoFindDeviceById(params.id);
+    if (!device) throw new HttpError(404, "STATION_DEVICE_UNKNOWN", "Appareil introuvable.");
+    return { device, closed_sessions: closed.rowCount ?? 0 };
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoTouchDeviceSeen(params: {
+  device_id: string;
+  app_version?: string | null;
+}): Promise<void> {
+  await pool.query(
+    `UPDATE public.production_devices
+        SET last_seen_at = now(),
+            last_seen_app_version = COALESCE($2, last_seen_app_version)
+      WHERE id = $1`,
+    [params.device_id, params.app_version ?? null]
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Supports d'identification                                                  */
+/* -------------------------------------------------------------------------- */
+
+export async function repoIssueCredential(params: {
+  user_id: number;
+  credential_type: string;
+  credential: string;
+  label?: string | null;
+  actorUserId: number;
+}): Promise<{ id: string; user_id: number; credential_type: string; label: string | null }> {
+  const hash = fingerprintCredential(params.credential, badgePepper());
+
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const { rowCount } = await client.query(`SELECT 1 FROM public.users WHERE id = $1`, [params.user_id]);
+    if (!rowCount) throw new HttpError(404, "STATION_USER_UNKNOWN", "Utilisateur introuvable.");
+
+    const existing = await client.query(
+      `SELECT id, user_id, active FROM public.operator_badge_credentials WHERE credential_hash = $1`,
+      [hash]
+    );
+    if (existing.rows[0]) {
+      // On ne dit PAS à qui appartient le badge : ce serait un oracle
+      // d'énumération. On dit seulement qu'il est déjà connu.
+      throw new HttpError(
+        409,
+        "STATION_CREDENTIAL_ALREADY_ISSUED",
+        "Ce support est déjà enregistré dans CERP."
+      );
+    }
+
+    const { rows } = await client.query(
+      `INSERT INTO public.operator_badge_credentials
+         (user_id, credential_type, credential_hash, label, issued_by)
+       VALUES ($1,$2,$3,$4,$5)
+       RETURNING id, user_id, credential_type, label`,
+      [params.user_id, params.credential_type, hash, params.label ?? null, params.actorUserId]
+    );
+
+    await repoStationAudit(
+      {
+        event_type: "CREDENTIAL_ISSUED",
+        user_id: params.actorUserId,
+        detail: { subject_user_id: params.user_id, credential_type: params.credential_type },
+      },
+      client
+    );
+
+    await client.query("COMMIT");
+    return rows[0];
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoRevokeCredential(params: {
+  id: string;
+  reason: string;
+  actorUserId: number;
+}): Promise<void> {
+  const { rowCount } = await pool.query(
+    `UPDATE public.operator_badge_credentials
+        SET active = false, revoked_at = now(), revoked_by = $2, revoke_reason = $3
+      WHERE id = $1 AND revoked_at IS NULL`,
+    [params.id, params.actorUserId, params.reason]
+  );
+  if (!rowCount) throw new HttpError(404, "STATION_CREDENTIAL_UNKNOWN", "Support introuvable ou déjà révoqué.");
+  await repoStationAudit({
+    event_type: "CREDENTIAL_REVOKED",
+    user_id: params.actorUserId,
+    detail: { credential_id: params.id },
+  });
+}
+
+export async function repoListCredentials(userId: number): Promise<
+  Array<{ id: string; credential_type: string; label: string | null; active: boolean; issued_at: string | null }>
+> {
+  const { rows } = await pool.query(
+    `SELECT id, credential_type, label, active, issued_at
+       FROM public.operator_badge_credentials
+      WHERE user_id = $1
+      ORDER BY issued_at DESC`,
+    [userId]
+  );
+  // L'empreinte n'est JAMAIS renvoyée : elle ne sert qu'à comparer côté serveur.
+  return rows.map((r) => ({
+    id: r.id as string,
+    credential_type: r.credential_type as string,
+    label: (r.label as string | null) ?? null,
+    active: Boolean(r.active),
+    issued_at: iso(r.issued_at),
+  }));
+}
+
+/**
+ * Résout un support en utilisateur. Retourne `null` quand le support est
+ * inconnu, révoqué ou verrouillé : l'appelant produit alors un message
+ * générique, sans révéler laquelle des trois causes s'applique.
+ */
+export async function repoResolveCredential(rawCredential: string): Promise<
+  | { ok: true; credential_id: string; user_id: number }
+  | { ok: false; reason: "UNKNOWN" | "REVOKED" | "LOCKED"; credential_id: string | null; locked_until: Date | null }
+> {
+  const hash = fingerprintCredential(rawCredential, badgePepper());
+  const { rows } = await pool.query(
+    `SELECT id, user_id, active, revoked_at, locked_until
+       FROM public.operator_badge_credentials
+      WHERE credential_hash = $1`,
+    [hash]
+  );
+  const row = rows[0];
+  if (!row) return { ok: false, reason: "UNKNOWN", credential_id: null, locked_until: null };
+  if (!row.active || row.revoked_at) {
+    return { ok: false, reason: "REVOKED", credential_id: row.id as string, locked_until: null };
+  }
+  if (row.locked_until && toDate(row.locked_until).getTime() > Date.now()) {
+    return {
+      ok: false,
+      reason: "LOCKED",
+      credential_id: row.id as string,
+      locked_until: toDate(row.locked_until),
+    };
+  }
+  return { ok: true, credential_id: row.id as string, user_id: Number(row.user_id) };
+}
+
+export async function repoRegisterCredentialSuccess(credentialId: string): Promise<void> {
+  await pool.query(
+    `UPDATE public.operator_badge_credentials
+        SET last_used_at = now(), failed_attempts = 0, locked_until = NULL
+      WHERE id = $1`,
+    [credentialId]
+  );
+}
+
+/**
+ * Limitation de débit par support. Le compteur est porté par la base : un
+ * attaquant qui alterne les tablettes ne remet pas le compteur à zéro.
+ */
+export async function repoRegisterCredentialFailure(params: {
+  credentialId: string | null;
+  maxAttempts: number;
+  lockSeconds: number;
+}): Promise<void> {
+  if (!params.credentialId) return;
+  await pool.query(
+    `UPDATE public.operator_badge_credentials
+        SET failed_attempts = failed_attempts + 1,
+            locked_until = CASE
+              WHEN failed_attempts + 1 >= $2 THEN now() + make_interval(secs => $3)
+              ELSE locked_until
+            END
+      WHERE id = $1`,
+    [params.credentialId, params.maxAttempts, params.lockSeconds]
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Sessions de poste                                                          */
+/* -------------------------------------------------------------------------- */
+
+export type SessionRow = {
+  id: string;
+  device_id: string;
+  user_id: number;
+  machine_id: string | null;
+  identification_method: IdentificationMethod;
+  state: "ACTIVE" | "LOCKED" | "CLOSED" | "EXPIRED" | "REVOKED";
+  started_at: Date;
+  last_activity_at: Date;
+  expires_at: Date;
+  locked_at: Date | null;
+  closed_at: Date | null;
+  close_reason: string | null;
+  correlation_id: string;
+};
+
+const SESSION_COLUMNS = `
+  s.id, s.device_id, s.user_id, s.machine_id, s.identification_method, s.state,
+  s.started_at, s.last_activity_at, s.expires_at, s.locked_at, s.closed_at,
+  s.close_reason, s.correlation_id
+`;
+
+function mapSession(r: Record<string, unknown>): SessionRow {
+  return {
+    id: r.id as string,
+    device_id: r.device_id as string,
+    user_id: Number(r.user_id),
+    machine_id: (r.machine_id as string | null) ?? null,
+    identification_method: r.identification_method as IdentificationMethod,
+    state: r.state as SessionRow["state"],
+    started_at: toDate(r.started_at),
+    last_activity_at: toDate(r.last_activity_at),
+    expires_at: toDate(r.expires_at),
+    locked_at: r.locked_at ? toDate(r.locked_at) : null,
+    closed_at: r.closed_at ? toDate(r.closed_at) : null,
+    close_reason: (r.close_reason as string | null) ?? null,
+    correlation_id: r.correlation_id as string,
+  };
+}
+
+export async function repoFindSessionByToken(token: string): Promise<
+  { session: SessionRow; device: DeviceRow; user: { id: number; username: string; name: string | null; surname: string | null; role: string | null } } | null
+> {
+  const { rows } = await pool.query(
+    `SELECT ${SESSION_COLUMNS},
+            u.username, u.name, u.surname, u.role
+       FROM public.operator_device_sessions s
+       JOIN public.users u ON u.id = s.user_id
+      WHERE s.session_token_hash = $1`,
+    [hashSessionToken(token)]
+  );
+  const row = rows[0];
+  if (!row) return null;
+
+  const device = await repoFindDeviceById(row.device_id as string);
+  if (!device) return null;
+
+  return {
+    session: mapSession(row),
+    device,
+    user: {
+      id: Number(row.user_id),
+      username: row.username as string,
+      name: (row.name as string | null) ?? null,
+      surname: (row.surname as string | null) ?? null,
+      role: (row.role as string | null) ?? null,
+    },
+  };
+}
+
+export async function repoFindLiveSessionForDevice(deviceId: string, tx?: DbQueryer): Promise<SessionRow | null> {
+  const db = tx ?? pool;
+  const { rows } = await db.query(
+    `SELECT ${SESSION_COLUMNS}
+       FROM public.operator_device_sessions s
+      WHERE s.device_id = $1 AND s.state IN ('ACTIVE','LOCKED')
+      ORDER BY s.started_at DESC
+      LIMIT 1`,
+    [deviceId]
+  );
+  return rows[0] ? mapSession(rows[0]) : null;
+}
+
+/**
+ * Ouvre une session. Le jeton retourné en clair n'est JAMAIS persisté : seule
+ * son empreinte SHA-256 l'est, ce qui rend la révocation immédiate et une fuite
+ * de base inexploitable.
+ *
+ * Si une session vit déjà sur l'appareil, elle est fermée avec un motif
+ * explicite — mais AUCUN pointage n'est arrêté au passage.
+ */
+export async function repoOpenSession(params: {
+  device: DeviceRow;
+  user_id: number;
+  machine_id: string | null;
+  identification_method: IdentificationMethod;
+  app_version?: string | null;
+  request_id?: string | null;
+}): Promise<{ session: SessionRow; token: string }> {
+  const token = generateSessionToken();
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    // Verrou d'appareil : deux badges présentés simultanément ne créent pas
+    // deux sessions vivantes.
+    await client.query(`SELECT id FROM public.production_devices WHERE id = $1 FOR UPDATE`, [
+      params.device.id,
+    ]);
+
+    const previous = await repoFindLiveSessionForDevice(params.device.id, client);
+    if (previous) {
+      await client.query(
+        `UPDATE public.operator_device_sessions
+            SET state = 'CLOSED', closed_at = now(), close_reason = 'OPERATOR_SWITCH'
+          WHERE id = $1`,
+        [previous.id]
+      );
+      await repoStationAudit(
+        {
+          event_type: "OPERATOR_SWITCHED",
+          device_id: params.device.id,
+          session_id: previous.id,
+          user_id: params.user_id,
+          detail: { previous_user_id: previous.user_id },
+        },
+        client
+      );
+    }
+
+    const { rows } = await client.query(
+      `INSERT INTO public.operator_device_sessions
+         (device_id, user_id, machine_id, identification_method, session_token_hash,
+          state, expires_at, client_app_version)
+       VALUES ($1,$2,$3,$4,$5,'ACTIVE', now() + make_interval(secs => $6), $7)
+       RETURNING ${SESSION_COLUMNS.replace(/s\./g, "")}`,
+      [
+        params.device.id,
+        params.user_id,
+        params.machine_id,
+        params.identification_method,
+        hashSessionToken(token),
+        params.device.session_max_seconds,
+        params.app_version ?? null,
+      ]
+    );
+
+    const session = mapSession(rows[0]);
+
+    await client.query(
+      `UPDATE public.production_devices
+          SET last_seen_at = now(),
+              last_seen_app_version = COALESCE($2, last_seen_app_version)
+        WHERE id = $1`,
+      [params.device.id, params.app_version ?? null]
+    );
+
+    await repoStationAudit(
+      {
+        event_type: "SESSION_OPENED",
+        device_id: params.device.id,
+        session_id: session.id,
+        user_id: params.user_id,
+        machine_id: params.machine_id,
+        detail: { method: params.identification_method },
+        correlation_id: session.correlation_id,
+        request_id: params.request_id ?? null,
+      },
+      client
+    );
+
+    await client.query("COMMIT");
+    return { session, token };
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoTouchSession(sessionId: string): Promise<void> {
+  await pool.query(
+    `UPDATE public.operator_device_sessions
+        SET last_activity_at = now()
+      WHERE id = $1 AND state = 'ACTIVE'`,
+    [sessionId]
+  );
+}
+
+export async function repoSetSessionState(params: {
+  sessionId: string;
+  state: "ACTIVE" | "LOCKED" | "CLOSED" | "EXPIRED" | "REVOKED";
+  reason?: string | null;
+}): Promise<SessionRow> {
+  const isTerminal = params.state === "CLOSED" || params.state === "EXPIRED" || params.state === "REVOKED";
+  const { rows } = await pool.query(
+    `UPDATE public.operator_device_sessions
+        SET state = $2,
+            locked_at = CASE WHEN $2 = 'LOCKED' THEN now() ELSE NULL END,
+            closed_at = CASE WHEN $3 THEN now() ELSE NULL END,
+            close_reason = CASE WHEN $3 THEN $4 ELSE NULL END,
+            last_activity_at = now()
+      WHERE id = $1
+      RETURNING ${SESSION_COLUMNS.replace(/s\./g, "")}`,
+    [params.sessionId, params.state, isTerminal, params.reason ?? null]
+  );
+  if (!rows[0]) throw new HttpError(404, "STATION_SESSION_UNKNOWN", "Session introuvable.");
+  return mapSession(rows[0]);
+}
+
+export async function repoConfirmSessionMachine(params: {
+  sessionId: string;
+  machineId: string;
+}): Promise<SessionRow> {
+  const { rows } = await pool.query(
+    `UPDATE public.operator_device_sessions
+        SET machine_id = $2, last_activity_at = now()
+      WHERE id = $1 AND state IN ('ACTIVE','LOCKED')
+      RETURNING ${SESSION_COLUMNS.replace(/s\./g, "")}`,
+    [params.sessionId, params.machineId]
+  );
+  if (!rows[0]) throw new HttpError(409, "STATION_SESSION_NOT_LIVE", "Session inactive : reconnectez-vous.");
+  return mapSession(rows[0]);
+}
+
+/** Machines et OF sur lesquels l'utilisateur a un droit d'écoute temps réel. */
+export async function repoUserRealtimeScope(userId: number): Promise<{
+  machineIds: string[];
+  ofIds: number[];
+  deviceIds: string[];
+}> {
+  const { rows } = await pool.query(
+    `SELECT
+       COALESCE((
+         SELECT array_agg(DISTINCT s.machine_id::text)
+           FROM public.operator_device_sessions s
+          WHERE s.user_id = $1 AND s.state IN ('ACTIVE','LOCKED') AND s.machine_id IS NOT NULL
+       ), '{}') AS machine_ids,
+       COALESCE((
+         SELECT array_agg(DISTINCT p.of_id)
+           FROM public.production_pointages p
+          WHERE p.operator_user_id = $1 AND p.status = 'RUNNING'
+       ), '{}') AS of_ids,
+       COALESCE((
+         SELECT array_agg(DISTINCT s.device_id::text)
+           FROM public.operator_device_sessions s
+          WHERE s.user_id = $1 AND s.state IN ('ACTIVE','LOCKED')
+       ), '{}') AS device_ids`,
+    [userId]
+  );
+  const r = rows[0] ?? {};
+  return {
+    machineIds: (r.machine_ids as string[] | null) ?? [],
+    ofIds: ((r.of_ids as (number | string)[] | null) ?? []).map((v) => Number(v)),
+    deviceIds: (r.device_ids as string[] | null) ?? [],
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Machines sélectionnables                                                   */
+/* -------------------------------------------------------------------------- */
+
+export type MachineOccupancyRow = {
+  id: string;
+  code: string;
+  name: string;
+  status: string;
+  is_available: boolean;
+  workshop_zone: string | null;
+  archived_at: Date | null;
+  active_operator_user_id: number | null;
+  active_operator_label: string | null;
+  active_of_id: number | null;
+  active_of_numero: string | null;
+  active_since: string | null;
+};
+
+export async function repoListSelectableMachines(params: {
+  workshop_zone: string | null;
+  limit?: number;
+}): Promise<MachineOccupancyRow[]> {
+  const { rows } = await pool.query(
+    `SELECT o.machine_id AS id, o.machine_code AS code, o.machine_name AS name,
+            o.machine_status::text AS status, o.machine_is_available AS is_available,
+            o.workshop_zone, NULL::timestamptz AS archived_at,
+            o.active_operator_user_id,
+            CASE WHEN u.id IS NULL THEN NULL
+                 ELSE COALESCE(NULLIF(btrim(COALESCE(u.name,'') || ' ' || COALESCE(u.surname,'')), ''), u.username)
+            END AS active_operator_label,
+            o.active_of_id, ofa.numero AS active_of_numero, o.active_since
+       FROM public.v_station_machine_occupancy o
+       LEFT JOIN public.users u ON u.id = o.active_operator_user_id
+       LEFT JOIN public.ordres_fabrication ofa ON ofa.id = o.active_of_id
+      WHERE ($1::text IS NULL OR o.workshop_zone IS NULL OR o.workshop_zone = $1)
+      ORDER BY o.machine_code
+      LIMIT $2`,
+    [params.workshop_zone, params.limit ?? 200]
+  );
+
+  return rows.map((r) => ({
+    id: r.id as string,
+    code: r.code as string,
+    name: r.name as string,
+    status: String(r.status ?? ""),
+    is_available: Boolean(r.is_available),
+    workshop_zone: (r.workshop_zone as string | null) ?? null,
+    archived_at: null,
+    active_operator_user_id:
+      r.active_operator_user_id === null || r.active_operator_user_id === undefined
+        ? null
+        : Number(r.active_operator_user_id),
+    active_operator_label: (r.active_operator_label as string | null) ?? null,
+    active_of_id: r.active_of_id === null || r.active_of_id === undefined ? null : Number(r.active_of_id),
+    active_of_numero: (r.active_of_numero as string | null) ?? null,
+    active_since: iso(r.active_since),
+  }));
+}
+
+export async function repoFindMachineOccupancy(machineId: string): Promise<MachineOccupancyRow | null> {
+  const all = await repoListSelectableMachines({ workshop_zone: null, limit: 1000 });
+  return all.find((m) => m.id === machineId) ?? null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* File de travail                                                            */
+/* -------------------------------------------------------------------------- */
+
+export type WorklistRow = {
+  operation_id: string;
+  phase: number;
+  designation: string;
+  operation_status: string;
+  temps_total_planned: number;
+  temps_total_real: number;
+  of_id: number;
+  of_numero: string;
+  of_statut: string;
+  of_priority: string;
+  date_fin_prevue: string | null;
+  quantite_lancee: number;
+  quantite_bonne: number;
+  quantite_rebut: number;
+  qty_pending_control: number;
+  piece_code: string | null;
+  piece_designation: string | null;
+  affaire_id: number | null;
+  affaire_reference: string | null;
+  machine_id: string | null;
+  machine_code: string | null;
+  machine_name: string | null;
+  machine_is_available: boolean;
+  has_pending_predecessor: boolean;
+  active_by_user_id: number | null;
+  has_technical_snapshot: boolean;
+  has_plan_document: boolean;
+  first_article_required: boolean;
+  first_article_passed: boolean;
+  parent_of_id: number | null;
+  child_of_count: number;
+  child_of_pending: number;
+};
+
+/**
+ * File de travail, en UNE requête.
+ *
+ * Chaque signal est calculé côté base par un agrégat corrélé ; il n'y a donc ni
+ * boucle applicative, ni requête par ligne. Le filtrage (utilisateur, machine,
+ * atelier, statut d'OF) est SERVEUR : le client ne reçoit jamais une file
+ * complète qu'il devrait filtrer lui-même.
+ */
+export async function repoWorklist(params: {
+  userId: number;
+  machineId: string | null;
+  workshopZone: string | null;
+  q: string | null;
+  machineOnly: boolean;
+  includeBlocked: boolean;
+  limit: number;
+}): Promise<WorklistRow[]> {
+  const { rows } = await pool.query(
+    `
+    WITH candidate_ops AS (
+      SELECT op.id AS operation_id, op.phase, op.designation, op.status::text AS operation_status,
+             op.temps_total_planned, op.temps_total_real, op.machine_id,
+             o.id AS of_id, o.numero AS of_numero, o.statut::text AS of_statut,
+             o.priority::text AS of_priority, o.date_fin_prevue,
+             o.quantite_lancee, o.quantite_bonne, o.quantite_rebut,
+             o.piece_technique_id, o.affaire_id, o.parent_of_id,
+             o.technical_snapshot_sha256, o.piece_technique_version_id
+        FROM public.of_operations op
+        JOIN public.ordres_fabrication o ON o.id = op.of_id
+       WHERE o.statut::text NOT IN ('BROUILLON', 'ANNULE', 'TERMINE')
+         AND op.status::text NOT IN ('DONE', 'CANCELLED')
+         AND ($2::uuid IS NULL OR NOT $5::boolean OR op.machine_id = $2 OR op.machine_id IS NULL)
+         AND (
+           $3::text IS NULL
+           OR o.numero ILIKE '%' || $3 || '%'
+           OR op.designation ILIKE '%' || $3 || '%'
+           OR EXISTS (
+             SELECT 1 FROM public.pieces_techniques pt
+              WHERE pt.id = o.piece_technique_id
+                AND (pt.code_piece ILIKE '%' || $3 || '%' OR pt.designation ILIKE '%' || $3 || '%')
+           )
+         )
+       LIMIT 500
+    )
+    SELECT c.*,
+           pt.code_piece AS piece_code,
+           pt.designation AS piece_designation,
+           a.reference AS affaire_reference,
+           m.code AS machine_code, m.name AS machine_name,
+           COALESCE(m.is_available, true) AS machine_is_available,
+           COALESCE(qc.qty_pending_control, 0) AS qty_pending_control,
+           EXISTS (
+             SELECT 1 FROM public.of_operations prev
+              WHERE prev.of_id = c.of_id
+                AND prev.phase < c.phase
+                AND prev.status::text NOT IN ('DONE', 'CANCELLED')
+           ) AS has_pending_predecessor,
+           (
+             SELECT p.operator_user_id
+               FROM public.production_pointages p
+              WHERE p.operation_id = c.operation_id AND p.status = 'RUNNING'
+              ORDER BY p.start_ts DESC
+              LIMIT 1
+           ) AS active_by_user_id,
+           (c.technical_snapshot_sha256 IS NOT NULL) AS has_technical_snapshot,
+           EXISTS (
+             SELECT 1 FROM public.pieces_techniques_documents d
+              WHERE d.piece_technique_id = c.piece_technique_id
+                AND d.removed_at IS NULL
+           ) AS has_plan_document,
+           EXISTS (
+             SELECT 1
+               FROM public.quality_control_plan qcp
+              WHERE qcp.status = 'PUBLISHED'
+                AND qcp.trigger_type = 'FIRST_ARTICLE'
+                AND (
+                  qcp.piece_version_id = c.piece_technique_version_id
+                  OR qcp.piece_technique_id = c.piece_technique_id
+                )
+           ) AS first_article_required,
+           EXISTS (
+             SELECT 1
+               FROM public.quality_control qc2
+              WHERE qc2.of_id = c.of_id
+                AND qc2.trigger_type = 'FIRST_ARTICLE'
+                AND COALESCE(qc2.verdict, qc2.verdict_computed) = 'CONFORME'
+           ) AS first_article_passed,
+           (
+             SELECT count(*) FROM public.ordres_fabrication child
+              WHERE child.parent_of_id = c.of_id
+           ) AS child_of_count,
+           (
+             SELECT count(*) FROM public.ordres_fabrication child
+              WHERE child.parent_of_id = c.of_id
+                AND child.statut::text NOT IN ('TERMINE', 'ANNULE')
+           ) AS child_of_pending
+      FROM candidate_ops c
+      LEFT JOIN public.pieces_techniques pt ON pt.id = c.piece_technique_id
+      LEFT JOIN public.affaire a ON a.id = c.affaire_id
+      LEFT JOIN public.machines m ON m.id = c.machine_id
+      LEFT JOIN LATERAL (
+        SELECT SUM(d.qty_pending_control) AS qty_pending_control
+          FROM public.production_quantity_declarations d
+         WHERE d.operation_id = c.operation_id
+      ) qc ON true
+     WHERE ($4::text IS NULL OR m.workshop_zone IS NULL OR m.workshop_zone = $4)
+     ORDER BY c.date_fin_prevue NULLS LAST, c.phase
+     LIMIT $6
+    `,
+    [
+      params.userId,
+      params.machineId,
+      params.q,
+      params.workshopZone,
+      params.machineOnly,
+      params.limit,
+    ]
+  );
+
+  return rows.map((r) => ({
+    operation_id: r.operation_id as string,
+    phase: num(r.phase),
+    designation: r.designation as string,
+    operation_status: String(r.operation_status ?? ""),
+    temps_total_planned: num(r.temps_total_planned),
+    temps_total_real: num(r.temps_total_real),
+    of_id: num(r.of_id),
+    of_numero: r.of_numero as string,
+    of_statut: String(r.of_statut ?? ""),
+    of_priority: String(r.of_priority ?? ""),
+    date_fin_prevue: r.date_fin_prevue ? String(r.date_fin_prevue).slice(0, 10) : null,
+    quantite_lancee: num(r.quantite_lancee),
+    quantite_bonne: num(r.quantite_bonne),
+    quantite_rebut: num(r.quantite_rebut),
+    qty_pending_control: num(r.qty_pending_control),
+    piece_code: (r.piece_code as string | null) ?? null,
+    piece_designation: (r.piece_designation as string | null) ?? null,
+    affaire_id: r.affaire_id === null || r.affaire_id === undefined ? null : num(r.affaire_id),
+    affaire_reference: (r.affaire_reference as string | null) ?? null,
+    machine_id: (r.machine_id as string | null) ?? null,
+    machine_code: (r.machine_code as string | null) ?? null,
+    machine_name: (r.machine_name as string | null) ?? null,
+    machine_is_available: Boolean(r.machine_is_available),
+    has_pending_predecessor: Boolean(r.has_pending_predecessor),
+    active_by_user_id:
+      r.active_by_user_id === null || r.active_by_user_id === undefined ? null : Number(r.active_by_user_id),
+    has_technical_snapshot: Boolean(r.has_technical_snapshot),
+    has_plan_document: Boolean(r.has_plan_document),
+    first_article_required: Boolean(r.first_article_required),
+    first_article_passed: Boolean(r.first_article_passed),
+    parent_of_id: r.parent_of_id === null || r.parent_of_id === undefined ? null : num(r.parent_of_id),
+    child_of_count: num(r.child_of_count),
+    child_of_pending: num(r.child_of_pending),
+  }));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Dossier opérateur                                                          */
+/* -------------------------------------------------------------------------- */
+
+export type DossierRaw = {
+  of: Record<string, unknown>;
+  operation: Record<string, unknown>;
+  documents: Array<Record<string, unknown>>;
+  instructions: Array<Record<string, unknown>>;
+  materials: Array<Record<string, unknown>>;
+  characteristics: Array<Record<string, unknown>>;
+  instruments: Array<Record<string, unknown>>;
+  machineDocuments: Array<Record<string, unknown>>;
+  children: Array<Record<string, unknown>>;
+  activeExecution: Record<string, unknown> | null;
+  declarations: Record<string, unknown> | null;
+};
+
+/**
+ * Dossier OF numérique, en UNE requête agrégée.
+ *
+ * Chaque bloc est un sous-agrégat JSON : le serveur assemble, le client affiche.
+ * L'alternative — dix requêtes enchaînées depuis le navigateur — multiplierait
+ * la latence par dix sur un réseau d'atelier et rendrait l'écran inutilisable
+ * derrière une cloison métallique.
+ *
+ * `storage_path` n'est JAMAIS sélectionné : le téléchargement passe par la route
+ * de document existante, qui applique ses propres contrôles.
+ */
+export async function repoDossier(params: {
+  ofId: number;
+  operationId: string;
+  userId: number;
+}): Promise<DossierRaw | null> {
+  const { rows } = await pool.query(
+    `
+    WITH base AS (
+      SELECT o.id AS of_id, o.numero, o.statut::text AS statut, o.priority::text AS priority,
+             o.quantite_lancee, o.quantite_bonne, o.quantite_rebut,
+             o.date_lancement_prevue, o.date_fin_prevue,
+             o.piece_technique_id, o.piece_technique_version_id,
+             o.technical_snapshot, o.technical_snapshot_sha256, o.technical_snapshot_at,
+             o.affaire_id, o.commande_id, o.client_id, o.parent_of_id, o.root_of_id,
+             o.structure_path, o.quantity_per_parent, o.quantity_cumulative, o.notes,
+             op.id AS operation_id, op.phase, op.designation AS operation_designation,
+             op.status::text AS operation_status, op.temps_total_planned, op.temps_total_real,
+             op.machine_id, op.poste_id, op.notes AS operation_notes,
+             op.source_piece_operation_id, op.tp, op.tf_unit, op.qte, op.coef
+        FROM public.ordres_fabrication o
+        JOIN public.of_operations op ON op.of_id = o.id
+       WHERE o.id = $1 AND op.id = $2
+    )
+    SELECT
+      to_jsonb(b) - 'technical_snapshot' AS of_core,
+      b.technical_snapshot AS technical_snapshot,
+      to_jsonb(pt) AS piece,
+      to_jsonb(ptv) AS piece_version,
+      to_jsonb(a) AS affaire,
+      to_jsonb(m) AS machine,
+      to_jsonb(po) AS poste,
+
+      -- Documents de la pièce technique : jamais storage_path.
+      COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+                 'id', d.id, 'label', d.label, 'original_name', d.original_name,
+                 'mime_type', d.mime_type, 'size_bytes', d.size_bytes, 'sha256', d.sha256,
+                 'created_at', d.created_at
+               ) ORDER BY d.created_at DESC)
+          FROM public.pieces_techniques_documents d
+         WHERE d.piece_technique_id = b.piece_technique_id AND d.removed_at IS NULL
+      ), '[]'::jsonb) AS documents,
+
+      -- Instruction de l'opération : consignes de la gamme + dossier atelier.
+      COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+                 'source', 'GAMME', 'phase', pto.phase, 'designation', pto.designation,
+                 'designation_2', pto.designation_2, 'consignes', pto.consignes,
+                 'type_operation', pto.type_operation, 'tp', pto.tp, 'tf_unit', pto.tf_unit
+               ) ORDER BY pto.phase)
+          FROM public.pieces_techniques_operations pto
+         WHERE pto.piece_technique_id = b.piece_technique_id
+           AND (b.source_piece_operation_id IS NULL OR pto.id = b.source_piece_operation_id)
+      ), '[]'::jsonb) AS instructions,
+
+      -- Documents du dossier atelier versionné (dernière version).
+      COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+                 'id', dvd.id, 'slot_key', dvd.slot_key, 'label', dvd.label,
+                 'commentaire', dvd.commentaire, 'document_id', dvd.document_id,
+                 'mime_type', dvd.mime_type, 'file_name', dvd.file_name,
+                 'file_size_bytes', dvd.file_size_bytes
+               ) ORDER BY dvd.slot_key)
+          FROM public.operation_dossiers od
+          JOIN LATERAL (
+            SELECT odv.id FROM public.operation_dossier_versions odv
+             WHERE odv.dossier_id = od.id
+             ORDER BY odv.version DESC LIMIT 1
+          ) last_version ON true
+          JOIN public.operation_dossier_version_documents dvd
+            ON dvd.dossier_version_id = last_version.id
+         WHERE od.operation_type = 'OF_OPERATION'
+           AND od.operation_id = b.operation_id::text
+      ), '[]'::jsonb) AS dossier_documents,
+
+      -- Matière consommée (LECTURE SEULE : le poste ne consomme rien).
+      COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+                 'id', mc.id, 'article_id', mc.article_id, 'article_code', ar.code,
+                 'article_designation', ar.designation, 'lot_id', mc.lot_id,
+                 'lot_code', l.lot_code, 'supplier_lot_code', l.supplier_lot_code,
+                 'lot_status', l.lot_status, 'qty', mc.qty, 'unit_code', mc.unit_code,
+                 'effective_at', mc.effective_at, 'status', mc.status
+               ) ORDER BY mc.effective_at DESC)
+          FROM public.of_material_consumptions mc
+          LEFT JOIN public.articles ar ON ar.id = mc.article_id
+          LEFT JOIN public.lots l ON l.id = mc.lot_id
+         WHERE mc.of_id = b.of_id
+           AND (mc.of_operation_id IS NULL OR mc.of_operation_id = b.operation_id)
+      ), '[]'::jsonb) AS materials,
+
+      -- Caractéristiques à contrôler, issues des plans PUBLIÉS applicables.
+      COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+                 'plan_id', qcp.id, 'plan_code', qcp.code, 'plan_version', qcp.version,
+                 'plan_label', qcp.label, 'plan_trigger', qcp.trigger_type,
+                 'sampling_rule', ch.sampling_rule, 'sampling_value', ch.sampling_value,
+                 'characteristic_key', ch.characteristic_key, 'label', ch.label,
+                 'characteristic_type', ch.characteristic_type, 'value_kind', ch.value_kind,
+                 'unit', ch.unit, 'nominal', ch.nominal,
+                 'tolerance_min', ch.tolerance_min, 'tolerance_max', ch.tolerance_max,
+                 'criticality', ch.criticality, 'mandatory', ch.mandatory,
+                 'requires_instrument', ch.requires_instrument,
+                 'instrument_category', ch.instrument_category,
+                 'method', ch.method, 'trigger_type', ch.trigger_type,
+                 'position', ch.position
+               ) ORDER BY qcp.trigger_type, ch.position)
+          FROM public.quality_control_plan qcp
+          JOIN public.quality_control_plan_characteristic ch ON ch.plan_id = qcp.id
+         WHERE qcp.status = 'PUBLISHED'
+           AND (qcp.effective_to IS NULL OR qcp.effective_to > now())
+           AND (
+             qcp.piece_version_id = b.piece_technique_version_id
+             OR qcp.piece_technique_id = b.piece_technique_id
+           )
+      ), '[]'::jsonb) AS characteristics,
+
+      -- Contrôles déjà prononcés sur cet OF.
+      COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+                 'id', qc.id, 'reference', qc.reference, 'trigger_type', qc.trigger_type,
+                 'status', qc.status, 'verdict', COALESCE(qc.verdict, qc.verdict_computed),
+                 'control_date', qc.control_date, 'qty_controlled', qc.qty_controlled,
+                 'qty_conforming', qc.qty_conforming, 'operation_id', qc.operation_id
+               ) ORDER BY qc.control_date DESC NULLS LAST)
+          FROM public.quality_control qc
+         WHERE qc.of_id = b.of_id
+      ), '[]'::jsonb) AS controls,
+
+      -- Instruments disponibles, avec leur état d'étalonnage réel.
+      COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+                 'id', e.id, 'code', e.code, 'designation', e.designation,
+                 'categorie', e.categorie, 'categorie_code', e.categorie_code,
+                 'statut', e.statut, 'etat', e.etat, 'criticite', e.criticite,
+                 'unite', e.unite, 'plage_min', e.plage_min, 'plage_max', e.plage_max,
+                 'resolution', e.resolution, 'exige_certificat', e.exige_certificat,
+                 'quarantine_reason', e.quarantine_reason,
+                 'last_conforme_at', e.last_conforme_at
+               ) ORDER BY e.code NULLS LAST, e.designation)
+          FROM public.metrologie_equipements e
+         WHERE e.deleted_at IS NULL
+           AND COALESCE(e.statut, 'ACTIF') = 'ACTIF'
+         LIMIT 200
+      ), '[]'::jsonb) AS instruments,
+
+      -- Fiche machine et sa documentation approuvée.
+      COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+                 'id', md.id, 'title', md.title, 'document_type', md.document_type,
+                 'revision', md.revision, 'mime_type', md.mime_type,
+                 'size_bytes', md.size_bytes, 'sha256', md.sha256, 'url', md.url
+               ) ORDER BY md.document_type, md.title)
+          FROM public.production_machine_documents md
+         WHERE md.machine_id = b.machine_id AND md.removed_at IS NULL
+      ), '[]'::jsonb) AS machine_documents,
+
+      -- Hiérarchie : OF enfants et leur avancement.
+      COALESCE((
+        SELECT jsonb_agg(jsonb_build_object(
+                 'of_id', child.id, 'numero', child.numero, 'statut', child.statut,
+                 'quantite_lancee', child.quantite_lancee, 'quantite_bonne', child.quantite_bonne,
+                 'quantite_rebut', child.quantite_rebut,
+                 'piece_code', cpt.code_piece, 'piece_designation', cpt.designation
+               ) ORDER BY child.numero)
+          FROM public.ordres_fabrication child
+          LEFT JOIN public.pieces_techniques cpt ON cpt.id = child.piece_technique_id
+         WHERE child.parent_of_id = b.of_id
+      ), '[]'::jsonb) AS children,
+
+      -- OF parent, s'il existe.
+      (
+        SELECT jsonb_build_object(
+                 'of_id', parent.id, 'numero', parent.numero, 'statut', parent.statut,
+                 'piece_code', ppt.code_piece, 'piece_designation', ppt.designation
+               )
+          FROM public.ordres_fabrication parent
+          LEFT JOIN public.pieces_techniques ppt ON ppt.id = parent.piece_technique_id
+         WHERE parent.id = b.parent_of_id
+      ) AS parent,
+
+      -- Exécution en cours de CET opérateur sur CETTE opération (moteur #274).
+      (
+        SELECT jsonb_build_object(
+                 'id', p.id, 'activity_code', p.activity_code, 'start_ts', p.start_ts,
+                 'operator_user_id', p.operator_user_id, 'machine_id', p.machine_id,
+                 'elapsed_minutes', floor(EXTRACT(EPOCH FROM (now() - p.start_ts)) / 60)
+               )
+          FROM public.production_pointages p
+         WHERE p.operation_id = b.operation_id AND p.status = 'RUNNING'
+         ORDER BY p.start_ts DESC
+         LIMIT 1
+      ) AS active_execution,
+
+      -- Cumul des déclarations sur l'opération.
+      (
+        SELECT jsonb_build_object(
+                 'qty_good', COALESCE(SUM(d.qty_good), 0),
+                 'qty_scrap', COALESCE(SUM(d.qty_scrap), 0),
+                 'qty_rework', COALESCE(SUM(d.qty_rework), 0),
+                 'qty_pending_control', COALESCE(SUM(d.qty_pending_control), 0)
+               )
+          FROM public.production_quantity_declarations d
+         WHERE d.operation_id = b.operation_id
+      ) AS declarations,
+
+      -- Transmission de poste non accusée sur cette opération.
+      (
+        SELECT jsonb_build_object(
+                 'id', h.id, 'created_at', h.created_at, 'machine_state', h.machine_state,
+                 'defects', h.defects, 'tooling_left', h.tooling_left,
+                 'remaining_actions', h.remaining_actions, 'comment', h.comment,
+                 'qty_done', h.qty_done,
+                 'outgoing_user', COALESCE(NULLIF(btrim(COALESCE(ou.name,'') || ' ' || COALESCE(ou.surname,'')), ''), ou.username)
+               )
+          FROM public.production_shift_handovers h
+          LEFT JOIN public.users ou ON ou.id = h.outgoing_user_id
+         WHERE h.operation_id = b.operation_id
+           AND h.incoming_user_id = $3
+           AND h.acknowledged_at IS NULL
+         ORDER BY h.created_at DESC
+         LIMIT 1
+      ) AS pending_handover,
+
+      -- Indice courant de la pièce, pour signaler une évolution SANS l'appliquer.
+      (
+        SELECT ptv2.indice
+          FROM public.piece_technique_versions ptv2
+         WHERE ptv2.piece_technique_id = b.piece_technique_id AND ptv2.is_current
+         LIMIT 1
+      ) AS latest_indice
+
+    FROM base b
+    LEFT JOIN public.pieces_techniques pt ON pt.id = b.piece_technique_id
+    LEFT JOIN public.piece_technique_versions ptv ON ptv.id = b.piece_technique_version_id
+    LEFT JOIN public.affaire a ON a.id = b.affaire_id
+    LEFT JOIN public.machines m ON m.id = b.machine_id
+    LEFT JOIN public.postes po ON po.id = b.poste_id
+    `,
+    [params.ofId, params.operationId, params.userId]
+  );
+
+  const row = rows[0];
+  if (!row) return null;
+  return row as unknown as DossierRaw;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Résolution de scan                                                         */
+/* -------------------------------------------------------------------------- */
+
+export async function repoResolveScan(code: string): Promise<
+  { of_id: number; of_numero: string; operation_id: string | null; phase: number | null } | null
+> {
+  // Formats acceptés : « OF-2026-0007 », « OF-2026-0007/30 », une URL CERP se
+  // terminant par l'un des deux, ou un identifiant numérique d'OF.
+  const cleaned = code.trim().replace(/^.*\/(?=[A-Za-z0-9-]+(?:\/\d+)?$)/, "");
+  const match = /^([A-Za-z0-9-]+?)(?:\/(\d+))?$/.exec(cleaned);
+  if (!match) return null;
+
+  const numero = match[1];
+  const phase = match[2] ? Number(match[2]) : null;
+
+  const { rows } = await pool.query(
+    `SELECT o.id, o.numero,
+            (SELECT op.id FROM public.of_operations op
+              WHERE op.of_id = o.id
+                AND ($2::int IS NULL OR op.phase = $2)
+                AND op.status::text NOT IN ('DONE','CANCELLED')
+              ORDER BY op.phase LIMIT 1) AS operation_id,
+            (SELECT op.phase FROM public.of_operations op
+              WHERE op.of_id = o.id
+                AND ($2::int IS NULL OR op.phase = $2)
+                AND op.status::text NOT IN ('DONE','CANCELLED')
+              ORDER BY op.phase LIMIT 1) AS phase
+       FROM public.ordres_fabrication o
+      WHERE o.numero = $1 OR ($3::bigint IS NOT NULL AND o.id = $3::bigint)
+      LIMIT 1`,
+    [numero, phase, /^\d+$/.test(numero) ? numero : null]
+  );
+
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    of_id: num(row.id),
+    of_numero: row.numero as string,
+    operation_id: (row.operation_id as string | null) ?? null,
+    phase: row.phase === null || row.phase === undefined ? null : num(row.phase),
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Transmission de poste                                                      */
+/* -------------------------------------------------------------------------- */
+
+export type HandoverRow = {
+  id: string;
+  device_id: string | null;
+  machine_id: string | null;
+  machine_code: string | null;
+  of_id: number | null;
+  of_numero: string | null;
+  operation_id: string | null;
+  pointage_id: string | null;
+  outgoing_user: { id: number; label: string };
+  incoming_user: { id: number; label: string };
+  machine_state: string;
+  qty_done: number | null;
+  defects: string | null;
+  tooling_left: string | null;
+  remaining_actions: string | null;
+  comment: string | null;
+  created_at: string | null;
+  acknowledged_at: string | null;
+};
+
+const HANDOVER_SELECT = `
+  SELECT h.id, h.device_id, h.machine_id, m.code AS machine_code,
+         h.of_id, o.numero AS of_numero, h.operation_id, h.pointage_id,
+         h.outgoing_user_id, h.incoming_user_id,
+         COALESCE(NULLIF(btrim(COALESCE(ou.name,'') || ' ' || COALESCE(ou.surname,'')), ''), ou.username) AS outgoing_label,
+         COALESCE(NULLIF(btrim(COALESCE(iu.name,'') || ' ' || COALESCE(iu.surname,'')), ''), iu.username) AS incoming_label,
+         h.machine_state, h.qty_done, h.defects, h.tooling_left, h.remaining_actions,
+         h.comment, h.created_at, h.acknowledged_at
+    FROM public.production_shift_handovers h
+    LEFT JOIN public.machines m ON m.id = h.machine_id
+    LEFT JOIN public.ordres_fabrication o ON o.id = h.of_id
+    LEFT JOIN public.users ou ON ou.id = h.outgoing_user_id
+    LEFT JOIN public.users iu ON iu.id = h.incoming_user_id
+`;
+
+function mapHandover(r: Record<string, unknown>): HandoverRow {
+  return {
+    id: r.id as string,
+    device_id: (r.device_id as string | null) ?? null,
+    machine_id: (r.machine_id as string | null) ?? null,
+    machine_code: (r.machine_code as string | null) ?? null,
+    of_id: r.of_id === null || r.of_id === undefined ? null : num(r.of_id),
+    of_numero: (r.of_numero as string | null) ?? null,
+    operation_id: (r.operation_id as string | null) ?? null,
+    pointage_id: (r.pointage_id as string | null) ?? null,
+    outgoing_user: { id: Number(r.outgoing_user_id), label: (r.outgoing_label as string) ?? "" },
+    incoming_user: { id: Number(r.incoming_user_id), label: (r.incoming_label as string) ?? "" },
+    machine_state: r.machine_state as string,
+    qty_done: r.qty_done === null || r.qty_done === undefined ? null : num(r.qty_done),
+    defects: (r.defects as string | null) ?? null,
+    tooling_left: (r.tooling_left as string | null) ?? null,
+    remaining_actions: (r.remaining_actions as string | null) ?? null,
+    comment: (r.comment as string | null) ?? null,
+    created_at: iso(r.created_at),
+    acknowledged_at: iso(r.acknowledged_at),
+  };
+}
+
+export async function repoCreateHandover(params: {
+  device_id: string | null;
+  machine_id: string | null;
+  of_id: number | null;
+  operation_id: string | null;
+  pointage_id: string | null;
+  outgoing_user_id: number;
+  incoming_user_id: number;
+  machine_state: string;
+  qty_done: number | null;
+  defects: string | null;
+  tooling_left: string | null;
+  remaining_actions: string | null;
+  comment: string | null;
+  idempotency_key: string;
+}): Promise<HandoverRow> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    // Rejeu : la même clé renvoie la même transmission, pas une seconde.
+    const existing = await client.query(
+      `SELECT id FROM public.production_shift_handovers WHERE idempotency_key = $1`,
+      [params.idempotency_key]
+    );
+    if (existing.rows[0]) {
+      await client.query("ROLLBACK");
+      const replayed = await repoGetHandover(existing.rows[0].id as string);
+      if (!replayed) throw new HttpError(500, "STATION_HANDOVER_REPLAY_FAILED", "Transmission introuvable au rejeu.");
+      return replayed;
+    }
+
+    const { rowCount: incomingExists } = await client.query(
+      `SELECT 1 FROM public.users WHERE id = $1`,
+      [params.incoming_user_id]
+    );
+    if (!incomingExists) {
+      throw new HttpError(404, "STATION_USER_UNKNOWN", "Opérateur entrant introuvable.");
+    }
+
+    const { rows } = await client.query(
+      `INSERT INTO public.production_shift_handovers
+         (device_id, machine_id, of_id, operation_id, pointage_id,
+          outgoing_user_id, incoming_user_id, machine_state, qty_done,
+          defects, tooling_left, remaining_actions, comment, created_by, idempotency_key)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$6,$14)
+       RETURNING id`,
+      [
+        params.device_id,
+        params.machine_id,
+        params.of_id,
+        params.operation_id,
+        params.pointage_id,
+        params.outgoing_user_id,
+        params.incoming_user_id,
+        params.machine_state,
+        params.qty_done,
+        params.defects,
+        params.tooling_left,
+        params.remaining_actions,
+        params.comment,
+        params.idempotency_key,
+      ]
+    );
+
+    const id = rows[0].id as string;
+    await repoStationAudit(
+      {
+        event_type: "HANDOVER_CREATED",
+        device_id: params.device_id,
+        user_id: params.outgoing_user_id,
+        machine_id: params.machine_id,
+        of_id: params.of_id,
+        operation_id: params.operation_id,
+        detail: { handover_id: id, incoming_user_id: params.incoming_user_id },
+      },
+      client
+    );
+
+    await client.query("COMMIT");
+    const created = await repoGetHandover(id);
+    if (!created) throw new HttpError(500, "STATION_HANDOVER_CREATE_FAILED", "Transmission créée mais introuvable.");
+    return created;
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoGetHandover(id: string): Promise<HandoverRow | null> {
+  const { rows } = await pool.query(`${HANDOVER_SELECT} WHERE h.id = $1`, [id]);
+  return rows[0] ? mapHandover(rows[0]) : null;
+}
+
+export async function repoListHandoversForUser(params: {
+  userId: number;
+  onlyPending: boolean;
+  limit: number;
+}): Promise<HandoverRow[]> {
+  const { rows } = await pool.query(
+    `${HANDOVER_SELECT}
+      WHERE (h.incoming_user_id = $1 OR h.outgoing_user_id = $1)
+        AND ($2::boolean = false OR h.acknowledged_at IS NULL)
+      ORDER BY h.created_at DESC
+      LIMIT $3`,
+    [params.userId, params.onlyPending, params.limit]
+  );
+  return rows.map(mapHandover);
+}
+
+export async function repoAcknowledgeHandover(params: {
+  id: string;
+  actorUserId: number;
+}): Promise<HandoverRow> {
+  const { rows } = await pool.query(
+    `UPDATE public.production_shift_handovers
+        SET acknowledged_at = now(), acknowledged_by = $2
+      WHERE id = $1 AND acknowledged_at IS NULL
+      RETURNING id`,
+    [params.id, params.actorUserId]
+  );
+  if (!rows[0]) {
+    throw new HttpError(
+      409,
+      "STATION_HANDOVER_ALREADY_ACKNOWLEDGED",
+      "Cette transmission a déjà été accusée de réception."
+    );
+  }
+  await repoStationAudit({
+    event_type: "HANDOVER_ACKNOWLEDGED",
+    user_id: params.actorUserId,
+    detail: { handover_id: params.id },
+  });
+  const updated = await repoGetHandover(params.id);
+  if (!updated) throw new HttpError(404, "STATION_HANDOVER_UNKNOWN", "Transmission introuvable.");
+  return updated;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Exécution active de l'opérateur — LECTURE du moteur #274                   */
+/* -------------------------------------------------------------------------- */
+
+export async function repoActiveExecutionForUser(userId: number): Promise<Record<string, unknown> | null> {
+  const { rows } = await pool.query(
+    `SELECT p.id, p.of_id, o.numero AS of_numero, p.operation_id, op.phase, op.designation,
+            p.machine_id, m.code AS machine_code, m.name AS machine_name,
+            p.activity_code, ac.label AS activity_label, ac.is_productive,
+            p.start_ts, p.session_id, p.segment_index,
+            floor(EXTRACT(EPOCH FROM (now() - p.start_ts)) / 60)::int AS elapsed_minutes
+       FROM public.production_pointages p
+       LEFT JOIN public.ordres_fabrication o ON o.id = p.of_id
+       LEFT JOIN public.of_operations op ON op.id = p.operation_id
+       LEFT JOIN public.machines m ON m.id = p.machine_id
+       LEFT JOIN public.production_activity_categories ac ON ac.code = p.activity_code
+      WHERE p.operator_user_id = $1 AND p.status = 'RUNNING'
+      ORDER BY p.start_ts DESC
+      LIMIT 1`,
+    [userId]
+  );
+  const r = rows[0];
+  if (!r) return null;
+  return {
+    id: r.id,
+    of: { id: num(r.of_id), numero: r.of_numero },
+    operation: r.operation_id
+      ? { id: r.operation_id, phase: num(r.phase), designation: r.designation }
+      : null,
+    machine: r.machine_id ? { id: r.machine_id, code: r.machine_code, name: r.machine_name } : null,
+    activity: { code: r.activity_code, label: r.activity_label ?? r.activity_code, is_productive: Boolean(r.is_productive) },
+    start_ts: iso(r.start_ts),
+    elapsed_minutes: num(r.elapsed_minutes),
+    session_id: r.session_id,
+    segment_index: num(r.segment_index),
+  };
+}
+
+export { badgePepper as __badgePepperForTests, assertDeviceUsable };

--- a/src/module/production/routes/station.routes.ts
+++ b/src/module/production/routes/station.routes.ts
@@ -1,0 +1,170 @@
+import { Router } from "express";
+
+import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import {
+  loadStationSessionIfAny,
+  requireStationCapability,
+  requireStationIdempotencyKey,
+  requireStationSession,
+} from "../middlewares/station-authorization.middleware";
+import {
+  acknowledgeHandover,
+  bootstrap,
+  closeSession,
+  confirmMachine,
+  createHandover,
+  dossier,
+  enrollDevice,
+  heartbeat,
+  identify,
+  issueCredential,
+  listCredentials,
+  listDevices,
+  listHandovers,
+  listMachines,
+  lock,
+  revokeCredential,
+  revokeDevice,
+  scan,
+  stationAudit,
+  unlock,
+  updateDevice,
+  worklist,
+} from "../controllers/station.controller";
+
+/**
+ * Surface « CERP Atelier — Mon poste » (#159), montée sous `/production/station`.
+ *
+ * DEUX FAMILLES DE ROUTES, DEUX IDENTITÉS DISTINCTES :
+ *
+ *   1. `/bootstrap`, `/identify`, `/sessions/unlock` sont les seules routes
+ *      accessibles SANS session de poste : elles servent l'écran verrouillé et
+ *      l'identification. Elles n'exposent aucune donnée métier.
+ *   2. Toutes les autres routes tablette exigent une SESSION DE POSTE vivante,
+ *      vérifiée en base à chaque requête — c'est ce qui rend la révocation
+ *      d'une tablette immédiate.
+ *   3. Les routes d'administration exigent un JWT ERP : on n'enrôle pas une
+ *      tablette depuis une tablette.
+ *
+ * Ce routeur ne duplique AUCUNE commande de `/production/execution` (#274) :
+ * démarrer, mettre en pause, déclarer et terminer restent là-bas. Il n'existe
+ * qu'un seul moteur d'exécution.
+ */
+const router = Router();
+
+/* ------------------------- 1. Écran verrouillé ---------------------------- */
+// Publiques au sens « sans session de poste », mais toujours derrière le socle
+// default-deny de `/api/v1` : le JWT ERP reste requis pour atteindre ce routeur.
+// `loadStationSessionIfAny` permet au bootstrap de reconnaître une session déjà
+// ouverte sans échouer quand il n'y en a pas.
+
+router.get("/bootstrap", loadStationSessionIfAny, bootstrap);
+router.post("/identify", identify);
+router.post("/sessions/unlock", unlock);
+
+/* --------------------- 2. Routes de poste (session) ----------------------- */
+
+router.post("/sessions/lock", requireStationSession, lock);
+router.post("/sessions/close", requireStationSession, closeSession);
+router.post("/sessions/heartbeat", requireStationSession, heartbeat);
+
+router.get(
+  "/machines",
+  requireStationSession,
+  requireStationCapability("select_machine"),
+  listMachines
+);
+router.post(
+  "/machines/confirm",
+  requireStationSession,
+  requireStationCapability("select_machine"),
+  confirmMachine
+);
+
+router.get(
+  "/worklist",
+  requireStationSession,
+  requireStationCapability("read_own_station"),
+  worklist
+);
+router.post("/scan", requireStationSession, requireStationCapability("read_own_station"), scan);
+
+router.get(
+  "/dossier/:ofId/:operationId",
+  requireStationSession,
+  requireStationCapability("read_dossier"),
+  dossier
+);
+
+router.get(
+  "/handovers",
+  requireStationSession,
+  requireStationCapability("read_own_station"),
+  listHandovers
+);
+// Une transmission est une écriture immuable : clé d'idempotence obligatoire.
+router.post(
+  "/handovers",
+  requireStationSession,
+  requireStationIdempotencyKey,
+  requireStationCapability("handover_shift"),
+  createHandover
+);
+router.post(
+  "/handovers/:id/acknowledge",
+  requireStationSession,
+  requireStationCapability("acknowledge_handover"),
+  acknowledgeHandover
+);
+
+/* ----------------------- 3. Administration (JWT) -------------------------- */
+// `authenticateToken` est déjà appliqué en amont par `v1.routes.ts` ; on le
+// redéclare ici pour que ce routeur reste sûr s'il était monté ailleurs.
+
+router.get(
+  "/devices",
+  authenticateToken,
+  requireStationCapability("administer_devices"),
+  listDevices
+);
+router.post(
+  "/devices",
+  authenticateToken,
+  requireStationCapability("administer_devices"),
+  enrollDevice
+);
+router.patch(
+  "/devices/:id",
+  authenticateToken,
+  requireStationCapability("administer_devices"),
+  updateDevice
+);
+router.post(
+  "/devices/:id/revoke",
+  authenticateToken,
+  requireStationCapability("administer_devices"),
+  revokeDevice
+);
+
+router.get(
+  "/credentials/:userId",
+  authenticateToken,
+  requireStationCapability("read_own_station"),
+  listCredentials
+);
+router.post(
+  "/credentials",
+  authenticateToken,
+  requireStationCapability("administer_credentials"),
+  issueCredential
+);
+router.post(
+  "/credentials/:id/revoke",
+  authenticateToken,
+  requireStationCapability("administer_credentials"),
+  revokeCredential
+);
+
+router.get("/audit", authenticateToken, requireStationCapability("audit_stations"), stationAudit);
+
+export default router;

--- a/src/module/production/services/station.service.ts
+++ b/src/module/production/services/station.service.ts
@@ -87,6 +87,18 @@ import type {
 
 export type Actor = { id: number; role: string | null };
 
+/**
+ * Chemin de téléchargement d'un document de pièce technique.
+ *
+ * Il pointe vers la route EXISTANTE du module Pièces techniques, qui applique
+ * ses propres contrôles d'accès. Le poste ne réimplémente pas la distribution
+ * de fichiers et n'expose jamais de chemin disque.
+ */
+function documentDownloadPath(pieceTechniqueId: string | null | undefined, documentId: string): string | null {
+  if (!pieceTechniqueId) return null;
+  return `/pieces-techniques/${pieceTechniqueId}/documents/${documentId}/file`;
+}
+
 /* -------------------------------------------------------------------------- */
 /* Bootstrap                                                                  */
 /* -------------------------------------------------------------------------- */
@@ -930,6 +942,11 @@ export async function svcDossier(params: {
             mime_type: planResolution.document.mime_type,
             size_bytes: planResolution.document.size_bytes,
             sha256: planResolution.document.sha256,
+            // Chemin de téléchargement CONSTRUIT PAR LE SERVEUR. Le client
+            // n'assemble jamais un chemin de fichier lui-même, et la route
+            // cible applique ses propres contrôles d'accès. Ce n'est pas un
+            // chemin disque : `storage_path` ne sort jamais d'ici.
+            download_path: documentDownloadPath(core.piece_technique_id, planResolution.document.id),
           }
         : null,
       matches_snapshot: planResolution.matches_snapshot,
@@ -944,6 +961,7 @@ export async function svcDossier(params: {
       size_bytes: Number(d.size_bytes ?? 0),
       sha256: d.sha256,
       created_at: d.created_at,
+      download_path: documentDownloadPath(core.piece_technique_id, d.id),
     })),
 
     instructions: {

--- a/src/module/production/services/station.service.ts
+++ b/src/module/production/services/station.service.ts
@@ -1,0 +1,1281 @@
+// Service du poste opérateur tablette (#159).
+//
+// Il ORCHESTRE : il applique les politiques pures du domaine, appelle le
+// repository, et compose les read models. Il ne contient ni SQL, ni règle
+// métier inédite.
+//
+// CE QU'IL NE FAIT JAMAIS — et qui est vérifié par test :
+//   * démarrer, mettre en pause ou terminer un segment d'exécution : c'est le
+//     rôle exclusif de `production-execution.service.ts` (#274) ;
+//   * écrire une présence, une pause ou une paie (#119) ;
+//   * créer un mouvement de stock, un lot, une réception, un BL ou une facture ;
+//   * envoyer quoi que ce soit vers une commande numérique.
+
+import { HttpError } from "../../../utils/httpError";
+import { evaluateInstrumentUsage, type InstrumentState } from "../../qualite/domain/quality-release";
+
+import {
+  assertDeviceUsable,
+  assertHandoverAcknowledgeable,
+  assertHandoverParties,
+  assertOperatorSwitchDecided,
+  assertOwnSessionOrSupervision,
+  assessOperationReadiness,
+  BADGE_LOCK_SECONDS,
+  BADGE_MAX_FAILED_ATTEMPTS,
+  compareWorklistEntries,
+  evaluateMachineSelectability,
+  listStationCapabilities,
+  resolvePlanForSnapshot,
+  roleHasStationCapability,
+  stripCostFields,
+  WORKLIST_ORDERING_EXPLANATION,
+  type IdentificationMethod,
+  type NextBusinessAction,
+  type OperatorSwitchDecision,
+  type PlanDocumentRef,
+} from "../domain/station";
+import {
+  repoAcknowledgeHandover,
+  repoActiveExecutionForUser,
+  repoConfirmSessionMachine,
+  repoCreateHandover,
+  repoDossier,
+  repoEnrollDevice,
+  repoFindDeviceByCode,
+  repoFindDeviceById,
+  repoGetHandover,
+  repoIssueCredential,
+  repoListCredentials,
+  repoListDevices,
+  repoListHandoversForUser,
+  repoListSelectableMachines,
+  repoListStationAudit,
+  repoOpenSession,
+  repoRegisterCredentialFailure,
+  repoRegisterCredentialSuccess,
+  repoResolveCredential,
+  repoResolveScan,
+  repoRevokeCredential,
+  repoRevokeDevice,
+  repoSetSessionState,
+  repoStationAudit,
+  repoTouchDeviceSeen,
+  repoUpdateDevice,
+  repoUserRealtimeScope,
+  repoWorklist,
+  type DeviceRow,
+} from "../repository/station.repository";
+import type { StationContext } from "../middlewares/station-authorization.middleware";
+import type {
+  EnrollDeviceDTO,
+  IssueCredentialDTO,
+  ListDevicesQueryDTO,
+  StationAuditQueryDTO,
+  StationBootstrapQueryDTO,
+  StationCloseDTO,
+  StationConfirmMachineDTO,
+  StationHandoverDTO,
+  StationHeartbeatDTO,
+  StationIdentifyDTO,
+  StationLockDTO,
+  StationScanDTO,
+  StationUnlockDTO,
+  StationWorklistQueryDTO,
+  UpdateDeviceDTO,
+} from "../validators/station.validators";
+
+export type Actor = { id: number; role: string | null };
+
+/* -------------------------------------------------------------------------- */
+/* Bootstrap                                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Un seul appel pour tout ce dont l'écran a besoin au démarrage : appareil,
+ * session, utilisateur, machine, capacités, exécution en cours, heure serveur.
+ *
+ * Sans session, la réponse décrit l'écran VERROUILLÉ — c'est un état normal,
+ * pas une erreur : une tablette au repos doit afficher quelque chose d'utile.
+ */
+export async function svcBootstrap(params: {
+  query: StationBootstrapQueryDTO;
+  station: StationContext | undefined;
+  jwtActor: Actor | null;
+}): Promise<Record<string, unknown>> {
+  const now = new Date();
+
+  const device = params.station
+    ? await repoFindDeviceById(params.station.device_id)
+    : params.query.device_code
+      ? await repoFindDeviceByCode(params.query.device_code)
+      : null;
+
+  if (params.query.device_code && !device) {
+    // On distingue « tablette inconnue » de « tablette révoquée » : la consigne
+    // affichée n'est pas la même.
+    await repoStationAudit({
+      event_type: "AUTHORIZATION_DENIED",
+      outcome: "DENIED",
+      reason_code: "DEVICE_UNKNOWN",
+      detail: { device_code: params.query.device_code },
+    });
+    throw new HttpError(
+      404,
+      "STATION_DEVICE_UNKNOWN",
+      "Cette tablette n'est pas enregistrée dans CERP. Faites-la enrôler par le chef d'atelier."
+    );
+  }
+
+  if (device && device.status !== "ACTIVE") {
+    throw new HttpError(
+      403,
+      device.status === "REVOKED" ? "STATION_DEVICE_REVOKED" : "STATION_DEVICE_DISABLED",
+      device.status === "REVOKED"
+        ? "Cette tablette a été révoquée."
+        : "Cette tablette est désactivée. Contactez le chef d'atelier."
+    );
+  }
+
+  if (device) {
+    await repoTouchDeviceSeen({ device_id: device.id, app_version: params.query.app_version ?? null });
+  }
+
+  const identity = params.station?.user ?? null;
+  const role = identity?.role ?? params.jwtActor?.role ?? null;
+
+  const activeExecution = identity ? await repoActiveExecutionForUser(identity.id) : null;
+  const pendingHandovers = identity
+    ? await repoListHandoversForUser({ userId: identity.id, onlyPending: true, limit: 5 })
+    : [];
+
+  const machine =
+    device?.assignment_mode === "FIXED"
+      ? device.machine
+      : params.station?.machine_id
+        ? (await repoListSelectableMachines({ workshop_zone: null, limit: 1000 })).find(
+            (m) => m.id === params.station?.machine_id
+          ) ?? null
+        : null;
+
+  return {
+    server_time: now.toISOString(),
+    device: device
+      ? {
+          id: device.id,
+          public_code: device.public_code,
+          label: device.label,
+          site: device.site,
+          workshop_zone: device.workshop_zone,
+          assignment_mode: device.assignment_mode,
+          status: device.status,
+          auto_lock_seconds: device.auto_lock_seconds,
+          session_max_seconds: device.session_max_seconds,
+          assigned_machine: device.machine,
+        }
+      : null,
+    session: params.station
+      ? {
+          id: params.station.session_id,
+          machine_id: params.station.machine_id,
+          state: "ACTIVE",
+        }
+      : null,
+    user: identity
+      ? {
+          id: identity.id,
+          username: identity.username,
+          display_name:
+            [identity.name, identity.surname].filter(Boolean).join(" ").trim() || identity.username,
+          first_name: identity.name,
+          role: identity.role,
+        }
+      : null,
+    machine: machine
+      ? {
+          id: machine.id,
+          code: machine.code,
+          name: machine.name,
+          // `is_available` sur le type d'affectation fixe n'existe pas : on
+          // renvoie ce qu'on sait, sans inventer.
+          ...("is_available" in machine ? { is_available: machine.is_available } : {}),
+        }
+      : null,
+    capabilities: listStationCapabilities(role),
+    active_execution: activeExecution,
+    pending_handovers: pendingHandovers,
+    /** Modes d'identification réellement exploitables sur ce serveur. */
+    identification_methods: identificationMethodsAvailable(),
+    realtime_rooms: identity
+      ? await buildRealtimeRooms(identity.id, params.station?.machine_id ?? null, params.station?.device_id ?? null)
+      : [],
+  };
+}
+
+function identificationMethodsAvailable(): IdentificationMethod[] {
+  const methods: IdentificationMethod[] = ["PASSWORD"];
+  // Le badge n'est proposé que si le poivre est configuré : afficher un bouton
+  // qui échouera systématiquement est pire que de ne pas l'afficher.
+  if ((process.env.STATION_BADGE_PEPPER ?? "").length >= 16) {
+    methods.unshift("BADGE", "QR");
+  }
+  return methods;
+}
+
+async function buildRealtimeRooms(
+  userId: number,
+  machineId: string | null,
+  deviceId: string | null
+): Promise<string[]> {
+  const rooms = [`USER:${userId}`];
+  if (machineId) rooms.push(`MACHINE:${machineId}`);
+  if (deviceId) rooms.push(`STATION:${deviceId}`);
+  const scope = await repoUserRealtimeScope(userId);
+  for (const ofId of scope.ofIds) rooms.push(`OF:${ofId}`);
+  return Array.from(new Set(rooms));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Identification et session                                                  */
+/* -------------------------------------------------------------------------- */
+
+export async function svcIdentify(params: {
+  body: StationIdentifyDTO;
+  jwtActor: Actor | null;
+  requestId: string | null;
+}): Promise<{
+  token: string;
+  maxAgeSeconds: number;
+  payload: Record<string, unknown>;
+}> {
+  const device = await repoFindDeviceByCode(params.body.device_code);
+  assertDeviceUsable(device);
+
+  let userId: number;
+  let credentialId: string | null = null;
+
+  if (params.body.method === "PASSWORD" || params.body.method === "SSO") {
+    // Ces modes ne créent AUCUN nouveau facteur d'authentification : ils
+    // ouvrent une session de poste pour l'utilisateur DÉJÀ authentifié par
+    // l'ERP. Sans JWT valide, refus.
+    if (!params.jwtActor) {
+      throw new HttpError(
+        401,
+        "STATION_ERP_LOGIN_REQUIRED",
+        "Connectez-vous d'abord à CERP, puis ouvrez la session de poste."
+      );
+    }
+    userId = params.jwtActor.id;
+  } else {
+    const resolved = await repoResolveCredential(params.body.credential ?? "");
+    if (!resolved.ok) {
+      await repoRegisterCredentialFailure({
+        credentialId: resolved.credential_id,
+        maxAttempts: BADGE_MAX_FAILED_ATTEMPTS,
+        lockSeconds: BADGE_LOCK_SECONDS,
+      });
+      await repoStationAudit({
+        event_type: "IDENTIFICATION_FAILED",
+        outcome: "DENIED",
+        reason_code: resolved.reason,
+        device_id: device.id,
+        request_id: params.requestId,
+      });
+      // Message VOLONTAIREMENT identique dans les trois cas : distinguer
+      // « badge inconnu » de « badge révoqué » offrirait un oracle
+      // d'énumération à qui présente des cartes au hasard.
+      throw new HttpError(
+        401,
+        "STATION_IDENTIFICATION_FAILED",
+        resolved.reason === "LOCKED"
+          ? "Trop de tentatives sur ce support. Patientez ou identifiez-vous autrement."
+          : "Support non reconnu. Réessayez ou identifiez-vous autrement."
+      );
+    }
+    userId = resolved.user_id;
+    credentialId = resolved.credential_id;
+  }
+
+  // Un pointage en cours sur ce poste impose une décision métier explicite.
+  const liveExecutionOnMachine = device.machine_id
+    ? (await repoListSelectableMachines({ workshop_zone: null, limit: 1000 })).find(
+        (m) => m.id === device.machine_id
+      )
+    : null;
+  const busyByOther =
+    !!liveExecutionOnMachine?.active_operator_user_id &&
+    liveExecutionOnMachine.active_operator_user_id !== userId;
+
+  const actorRole = params.jwtActor?.role ?? null;
+  assertOperatorSwitchDecided({
+    hasActiveExecution: busyByOther,
+    decision: params.body.switch_decision as OperatorSwitchDecision | undefined,
+    actorRole,
+  });
+
+  const machineId =
+    device.assignment_mode === "FIXED" ? device.machine_id : (params.body.machine_id ?? null);
+
+  const { session, token } = await repoOpenSession({
+    device,
+    user_id: userId,
+    machine_id: machineId,
+    identification_method: params.body.method,
+    app_version: params.body.app_version ?? null,
+    request_id: params.requestId,
+  });
+
+  if (credentialId) await repoRegisterCredentialSuccess(credentialId);
+
+  return {
+    token,
+    maxAgeSeconds: device.session_max_seconds,
+    payload: {
+      session_id: session.id,
+      device: { id: device.id, public_code: device.public_code, label: device.label },
+      machine_id: machineId,
+      expires_at: session.expires_at.toISOString(),
+      auto_lock_seconds: device.auto_lock_seconds,
+      /** Rappelé à chaque ouverture : le badge n'écrit rien dans le module RH. */
+      notice:
+        "Cette identification ouvre une session de poste. Elle ne crée aucun pointage de production et aucune donnée de présence RH.",
+    },
+  };
+}
+
+export async function svcLock(params: {
+  station: StationContext;
+  body: StationLockDTO;
+}): Promise<Record<string, unknown>> {
+  const session = await repoSetSessionState({ sessionId: params.station.session_id, state: "LOCKED" });
+  await repoStationAudit({
+    event_type: "SESSION_LOCKED",
+    reason_code: params.body.reason,
+    device_id: params.station.device_id,
+    session_id: session.id,
+    user_id: params.station.user.id,
+  });
+
+  // On DIT que rien n'a été arrêté. Un opérateur qui verrouille son écran doit
+  // pouvoir le faire sans crainte.
+  const active = await repoActiveExecutionForUser(params.station.user.id);
+  return {
+    state: session.state,
+    execution_still_running: Boolean(active),
+    notice: active
+      ? "Écran verrouillé. Votre pointage continue : il n'a pas été arrêté."
+      : "Écran verrouillé.",
+  };
+}
+
+export async function svcUnlock(params: {
+  device_code: string;
+  body: StationUnlockDTO;
+  jwtActor: Actor | null;
+  sessionToken: string | null;
+  requestId: string | null;
+}): Promise<{ token: string; maxAgeSeconds: number; payload: Record<string, unknown> }> {
+  // Déverrouiller = ré-identifier. On ne « reprend » pas une session sur la
+  // simple foi d'un cookie encore présent : c'est le geste du badge qui prouve
+  // que quelqu'un est bien revenu devant la tablette.
+  return svcIdentify({
+    body: {
+      device_code: params.device_code,
+      method: params.body.method,
+      credential: params.body.credential,
+    } as StationIdentifyDTO,
+    jwtActor: params.jwtActor,
+    requestId: params.requestId,
+  });
+}
+
+export async function svcCloseSession(params: {
+  station: StationContext;
+  body: StationCloseDTO;
+}): Promise<Record<string, unknown>> {
+  const active = await repoActiveExecutionForUser(params.station.user.id);
+
+  const session = await repoSetSessionState({
+    sessionId: params.station.session_id,
+    state: "CLOSED",
+    reason: params.body.reason,
+  });
+  await repoStationAudit({
+    event_type: "SESSION_CLOSED",
+    reason_code: params.body.reason,
+    device_id: params.station.device_id,
+    session_id: session.id,
+    user_id: params.station.user.id,
+    detail: { execution_was_running: Boolean(active) },
+  });
+
+  return {
+    state: session.state,
+    execution_still_running: Boolean(active),
+    // Fermer une session n'arrête pas un pointage : le dire évite qu'un
+    // opérateur croie avoir terminé sa phase en quittant l'écran.
+    notice: active
+      ? "Session fermée. ATTENTION : votre pointage est toujours en cours. Arrêtez-le depuis « Mon poste » si votre travail est terminé."
+      : "Session fermée.",
+  };
+}
+
+export async function svcHeartbeat(params: {
+  station: StationContext;
+  body: StationHeartbeatDTO;
+}): Promise<Record<string, unknown>> {
+  const now = new Date();
+  await repoTouchDeviceSeen({
+    device_id: params.station.device_id,
+    app_version: params.body.app_version ?? null,
+  });
+
+  // Dérive d'horloge : signalée, jamais utilisée pour un calcul métier.
+  let clockDriftSeconds: number | null = null;
+  if (params.body.client_time) {
+    const clientTime = Date.parse(params.body.client_time);
+    if (Number.isFinite(clientTime)) {
+      clockDriftSeconds = Math.round((clientTime - now.getTime()) / 1000);
+    }
+  }
+
+  return {
+    server_time: now.toISOString(),
+    session_id: params.station.session_id,
+    clock_drift_seconds: clockDriftSeconds,
+    clock_warning:
+      clockDriftSeconds !== null && Math.abs(clockDriftSeconds) > 120
+        ? "L'horloge de cette tablette est décalée de plus de deux minutes. Les durées affichées restent celles du serveur."
+        : null,
+    auto_lock_seconds: params.station.auto_lock_seconds,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Machines                                                                   */
+/* -------------------------------------------------------------------------- */
+
+export async function svcListMachines(params: {
+  station: StationContext;
+}): Promise<Record<string, unknown>> {
+  const machines = await repoListSelectableMachines({
+    workshop_zone: params.station.device_zone,
+    limit: 200,
+  });
+
+  const evaluated = machines.map((machine) => {
+    const verdict = evaluateMachineSelectability({
+      machine: { ...machine, archived_at: null },
+      actorUserId: params.station.user.id,
+      deviceZone: params.station.device_zone,
+      enforceZone: true,
+    });
+    return {
+      id: machine.id,
+      code: machine.code,
+      name: machine.name,
+      workshop_zone: machine.workshop_zone,
+      selectable: verdict.selectable,
+      reason: verdict.reason,
+      reason_code: verdict.reason_code,
+      busy_by_other: verdict.busy_by_other,
+      // On montre QUI occupe la machine seulement à qui a le droit de superviser.
+      occupied_by: roleHasStationCapability(params.station.user.role, "supervise_stations")
+        ? machine.active_operator_label
+        : machine.active_operator_user_id
+          ? "un autre opérateur"
+          : null,
+      active_of_numero: machine.active_of_numero,
+      active_since: machine.active_since,
+    };
+  });
+
+  return {
+    assignment_mode: params.station.device_assignment_mode,
+    // Une tablette fixe n'offre pas de choix : elle affiche sa machine.
+    locked_to_machine: params.station.device_assignment_mode === "FIXED",
+    current_machine_id: params.station.machine_id,
+    machines: evaluated,
+  };
+}
+
+export async function svcConfirmMachine(params: {
+  station: StationContext;
+  body: StationConfirmMachineDTO;
+}): Promise<Record<string, unknown>> {
+  if (params.station.device_assignment_mode === "FIXED") {
+    throw new HttpError(
+      409,
+      "STATION_DEVICE_FIXED",
+      "Cette tablette est affectée à une machine : elle ne peut pas en changer."
+    );
+  }
+
+  const machines = await repoListSelectableMachines({
+    workshop_zone: params.station.device_zone,
+    limit: 200,
+  });
+  const machine = machines.find((m) => m.id === params.body.machine_id);
+  if (!machine) {
+    await repoStationAudit({
+      event_type: "MACHINE_REFUSED",
+      outcome: "DENIED",
+      reason_code: "OUT_OF_SCOPE",
+      device_id: params.station.device_id,
+      session_id: params.station.session_id,
+      user_id: params.station.user.id,
+      machine_id: params.body.machine_id,
+    });
+    throw new HttpError(
+      403,
+      "STATION_MACHINE_NOT_ALLOWED",
+      "Cette machine n'est pas accessible depuis ce poste."
+    );
+  }
+
+  const verdict = evaluateMachineSelectability({
+    machine: { ...machine, archived_at: null },
+    actorUserId: params.station.user.id,
+    deviceZone: params.station.device_zone,
+    enforceZone: true,
+  });
+
+  if (!verdict.selectable) {
+    // Une machine occupée n'est jamais prise de force : reprendre exige une
+    // décision explicite ET la capacité de supervision.
+    if (verdict.busy_by_other && params.body.switch_decision === "SUPERVISOR_OVERRIDE") {
+      assertOperatorSwitchDecided({
+        hasActiveExecution: true,
+        decision: "SUPERVISOR_OVERRIDE",
+        actorRole: params.station.user.role,
+      });
+    } else {
+      await repoStationAudit({
+        event_type: "MACHINE_REFUSED",
+        outcome: "DENIED",
+        reason_code: verdict.reason_code,
+        device_id: params.station.device_id,
+        session_id: params.station.session_id,
+        user_id: params.station.user.id,
+        machine_id: machine.id,
+      });
+      throw new HttpError(409, `STATION_${verdict.reason_code}`, verdict.reason, {
+        machine: { id: machine.id, code: machine.code, name: machine.name },
+        active_of_numero: machine.active_of_numero,
+      });
+    }
+  }
+
+  const session = await repoConfirmSessionMachine({
+    sessionId: params.station.session_id,
+    machineId: machine.id,
+  });
+  await repoStationAudit({
+    event_type: "MACHINE_CONFIRMED",
+    device_id: params.station.device_id,
+    session_id: session.id,
+    user_id: params.station.user.id,
+    machine_id: machine.id,
+  });
+
+  return {
+    machine: { id: machine.id, code: machine.code, name: machine.name },
+    session_id: session.id,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* File de travail                                                            */
+/* -------------------------------------------------------------------------- */
+
+export async function svcWorklist(params: {
+  station: StationContext;
+  query: StationWorklistQueryDTO;
+}): Promise<Record<string, unknown>> {
+  const rows = await repoWorklist({
+    userId: params.station.user.id,
+    machineId: params.station.machine_id,
+    workshopZone: params.station.device_zone,
+    q: params.query.q ?? null,
+    machineOnly: params.query.machine_only && Boolean(params.station.machine_id),
+    includeBlocked: params.query.include_blocked,
+    limit: params.query.limit,
+  });
+
+  const canViewCosts = roleHasStationCapability(params.station.user.role, "view_costs");
+
+  const items = rows.map((row) => {
+    const remaining = row.quantite_lancee - row.quantite_bonne - row.quantite_rebut;
+    const readiness = assessOperationReadiness({
+      of_statut: row.of_statut,
+      operation_status: row.operation_status,
+      has_pending_predecessor: row.has_pending_predecessor,
+      has_active_execution_by_other:
+        row.active_by_user_id !== null && row.active_by_user_id !== params.station.user.id,
+      machine_matches: !row.machine_id || row.machine_id === params.station.machine_id,
+      machine_available: row.machine_is_available,
+      has_technical_snapshot: row.has_technical_snapshot,
+      has_plan_document: row.has_plan_document,
+      first_article_pending: row.first_article_required && !row.first_article_passed,
+      qty_pending_control: row.qty_pending_control,
+      remaining_quantity: remaining,
+    });
+
+    return stripCostFields(
+      {
+        operation_id: row.operation_id,
+        phase: row.phase,
+        designation: row.designation,
+        operation_status: row.operation_status,
+        of: {
+          id: row.of_id,
+          numero: row.of_numero,
+          statut: row.of_statut,
+          priority: row.of_priority,
+          date_fin_prevue: row.date_fin_prevue,
+          quantite_lancee: row.quantite_lancee,
+          remaining,
+        },
+        piece: row.piece_code
+          ? { code: row.piece_code, designation: row.piece_designation }
+          : null,
+        affaire: row.affaire_id ? { id: row.affaire_id, reference: row.affaire_reference } : null,
+        machine: row.machine_id
+          ? { id: row.machine_id, code: row.machine_code, name: row.machine_name }
+          : null,
+        // Le temps prévu n'est affiché QUE s'il a réellement été renseigné : un
+        // « 0 h 00 » se lit comme « instantané » et détruit la confiance.
+        planned_hours: row.temps_total_planned > 0 ? row.temps_total_planned : null,
+        real_hours: row.temps_total_real,
+        readiness: readiness.level,
+        readiness_headline: readiness.headline,
+        readiness_reasons: readiness.reasons,
+        qty_pending_control: row.qty_pending_control,
+        hierarchy: {
+          parent_of_id: row.parent_of_id,
+          child_count: row.child_of_count,
+          child_pending: row.child_of_pending,
+        },
+        busy_by_other:
+          row.active_by_user_id !== null && row.active_by_user_id !== params.station.user.id,
+        mine: row.active_by_user_id === params.station.user.id,
+      },
+      canViewCosts
+    );
+  });
+
+  const filtered = params.query.include_blocked
+    ? items
+    : items.filter((item) => item.readiness !== "BLOCKED" || item.mine);
+
+  filtered.sort((a, b) =>
+    compareWorklistEntries(
+      { readiness: a.readiness, due_date: a.of.date_fin_prevue, phase: a.phase },
+      { readiness: b.readiness, due_date: b.of.date_fin_prevue, phase: b.phase }
+    )
+  );
+
+  const recommended = filtered.find((item) => item.readiness === "READY") ?? filtered[0] ?? null;
+
+  return {
+    server_time: new Date().toISOString(),
+    machine_id: params.station.machine_id,
+    /** L'ordre est EXPLIQUÉ, jamais un score opaque. */
+    ordering_explanation: WORKLIST_ORDERING_EXPLANATION,
+    recommended_operation_id: recommended?.operation_id ?? null,
+    recommendation_reason: recommended?.readiness_headline ?? null,
+    total: filtered.length,
+    items: filtered,
+  };
+}
+
+export async function svcScan(params: {
+  station: StationContext;
+  body: StationScanDTO;
+}): Promise<Record<string, unknown>> {
+  const resolved = await repoResolveScan(params.body.code);
+  if (!resolved) {
+    throw new HttpError(
+      404,
+      "STATION_SCAN_UNRESOLVED",
+      "Code non reconnu. Vérifiez l'étiquette ou saisissez le numéro d'OF."
+    );
+  }
+  if (!resolved.operation_id) {
+    throw new HttpError(
+      409,
+      "STATION_SCAN_NO_OPEN_OPERATION",
+      `L'OF ${resolved.of_numero} n'a aucune opération ouverte.`
+    );
+  }
+  return resolved;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Dossier opérateur                                                          */
+/* -------------------------------------------------------------------------- */
+
+export async function svcDossier(params: {
+  station: StationContext;
+  ofId: number;
+  operationId: string;
+}): Promise<Record<string, unknown>> {
+  const raw = await repoDossier({
+    ofId: params.ofId,
+    operationId: params.operationId,
+    userId: params.station.user.id,
+  });
+  if (!raw) {
+    throw new HttpError(
+      404,
+      "STATION_DOSSIER_UNKNOWN",
+      "Cette opération d'ordre de fabrication est introuvable."
+    );
+  }
+
+  const r = raw as unknown as Record<string, any>;
+  const core = r.of_core ?? {};
+  const piece = r.piece ?? null;
+  const pieceVersion = r.piece_version ?? null;
+  const canViewCosts = roleHasStationCapability(params.station.user.role, "view_costs");
+
+  // --- Plan : le snapshot FIGÉ fait foi, jamais « la dernière version ». -----
+  const documents: PlanDocumentRef[] = (r.documents ?? []).map((d: any) => ({
+    id: d.id,
+    label: d.label ?? null,
+    original_name: d.original_name,
+    mime_type: d.mime_type,
+    size_bytes: Number(d.size_bytes ?? 0),
+    sha256: d.sha256 ?? null,
+    piece_technique_id: core.piece_technique_id,
+  }));
+
+  const planResolution = resolvePlanForSnapshot({
+    snapshot: {
+      piece_technique_version_id: core.piece_technique_version_id ?? null,
+      snapshot_sha256: core.technical_snapshot_sha256 ?? null,
+      snapshot_at: core.technical_snapshot_at ? new Date(core.technical_snapshot_at) : null,
+    },
+    documentsForSnapshotVersion: documents,
+    latestVersionIndice: r.latest_indice ?? null,
+    snapshotIndice: pieceVersion?.indice ?? null,
+  });
+
+  // --- Instruments : éligibilité décidée par le SERVEUR (#228/#229). --------
+  const characteristics = (r.characteristics ?? []) as any[];
+  const instruments = ((r.instruments ?? []) as any[]).map((instrument) => {
+    const state: InstrumentState = {
+      id: instrument.id,
+      code: instrument.code ?? null,
+      designation: instrument.designation ?? null,
+      statut: instrument.statut ?? null,
+      criticite: instrument.criticite ?? null,
+      categorie: instrument.categorie_code ?? instrument.categorie ?? null,
+      next_due_date: null,
+      deleted: false,
+    };
+
+    // Un instrument mis en quarantaine par la Métrologie n'est jamais proposé
+    // comme utilisable : la décision appartient à #229, pas au poste.
+    const quarantined = Boolean(instrument.quarantine_reason) || instrument.etat === "QUARANTAINE";
+
+    const usage = evaluateInstrumentUsage({
+      characteristic: {
+        key: "generic",
+        requires_instrument: true,
+        instrument_category: null,
+      },
+      instrument: state,
+      at: new Date(),
+      policy: { block_on_overdue_critical: true },
+    });
+
+    return {
+      id: instrument.id,
+      code: instrument.code,
+      designation: instrument.designation,
+      categorie: instrument.categorie_code ?? instrument.categorie,
+      etat: instrument.etat ?? instrument.statut,
+      criticite: instrument.criticite,
+      unite: instrument.unite,
+      plage: { min: instrument.plage_min, max: instrument.plage_max },
+      resolution: instrument.resolution,
+      usable: !quarantined && usage.allowed,
+      usage_code: quarantined ? "INSTRUMENT_QUARANTINED" : usage.code,
+      usage_message: quarantined
+        ? `Instrument en quarantaine : ${instrument.quarantine_reason ?? "décision Métrologie"}.`
+        : usage.message,
+      last_conforme_at: instrument.last_conforme_at ?? null,
+    };
+  });
+
+  const firstArticleChars = characteristics.filter((c) => c.trigger_type === "FIRST_ARTICLE");
+  const controls = (r.controls ?? []) as any[];
+  const firstArticlePassed = controls.some(
+    (c) => c.trigger_type === "FIRST_ARTICLE" && c.verdict === "CONFORME"
+  );
+  const firstArticleRequired = firstArticleChars.length > 0;
+
+  const declarations = r.declarations ?? {
+    qty_good: 0,
+    qty_scrap: 0,
+    qty_rework: 0,
+    qty_pending_control: 0,
+  };
+
+  const remaining =
+    Number(core.quantite_lancee ?? 0) -
+    Number(core.quantite_bonne ?? 0) -
+    Number(core.quantite_rebut ?? 0);
+
+  const nextActions: NextBusinessAction[] = [];
+  if (Number(declarations.qty_pending_control ?? 0) > 0) {
+    nextActions.push({
+      code: "QUALITY_DECISION",
+      label: "Des quantités attendent une décision Qualité.",
+      owning_module: "Qualité 360 (#228)",
+      actionable_here: false,
+    });
+  }
+  if (remaining <= 0) {
+    nextActions.push({
+      code: "PRODUCTION_RECEIPT",
+      label: "Quantité lancée couverte : la mise en stock passe par la réception de production.",
+      owning_module: "Réception de production (#223)",
+      actionable_here: false,
+    });
+  }
+
+  await repoStationAudit({
+    event_type: "DOSSIER_OPENED",
+    device_id: params.station.device_id,
+    session_id: params.station.session_id,
+    user_id: params.station.user.id,
+    of_id: params.ofId,
+    operation_id: params.operationId,
+  });
+
+  return {
+    server_time: new Date().toISOString(),
+
+    identity: stripCostFields(
+      {
+        of: {
+          id: Number(core.of_id),
+          numero: core.numero,
+          statut: core.statut,
+          priority: core.priority,
+          quantite_lancee: Number(core.quantite_lancee ?? 0),
+          quantite_bonne: Number(core.quantite_bonne ?? 0),
+          quantite_rebut: Number(core.quantite_rebut ?? 0),
+          remaining,
+          date_lancement_prevue: core.date_lancement_prevue,
+          date_fin_prevue: core.date_fin_prevue,
+          notes: core.notes,
+        },
+        operation: {
+          id: core.operation_id,
+          phase: Number(core.phase ?? 0),
+          designation: core.operation_designation,
+          status: core.operation_status,
+          notes: core.operation_notes,
+          planned_hours: Number(core.temps_total_planned ?? 0) > 0 ? Number(core.temps_total_planned) : null,
+          real_hours: Number(core.temps_total_real ?? 0),
+        },
+        piece: piece
+          ? {
+              code: piece.code_piece,
+              designation: piece.designation,
+              designation_2: piece.designation_2,
+              ensemble: Boolean(piece.ensemble),
+            }
+          : null,
+        version: pieceVersion
+          ? {
+              indice: pieceVersion.indice,
+              plan_reference: pieceVersion.plan_reference,
+              matiere_prevue: pieceVersion.matiere_prevue,
+              statut: pieceVersion.statut,
+              date_application: pieceVersion.date_application,
+            }
+          : null,
+        affaire: r.affaire ? { id: Number(r.affaire.id), reference: r.affaire.reference } : null,
+        machine: r.machine
+          ? { id: r.machine.id, code: r.machine.code, name: r.machine.name }
+          : null,
+        poste: r.poste ? { id: r.poste.id, code: r.poste.code, label: r.poste.label } : null,
+      },
+      canViewCosts
+    ),
+
+    // Le snapshot est la RÉFÉRENCE : on expose son empreinte pour qu'un litige
+    // puisse être tranché sur pièce.
+    snapshot: {
+      piece_technique_version_id: core.piece_technique_version_id ?? null,
+      sha256: core.technical_snapshot_sha256 ?? null,
+      frozen_at: core.technical_snapshot_at ?? null,
+      indice: pieceVersion?.indice ?? null,
+      latest_indice: r.latest_indice ?? null,
+      is_superseded: Boolean(
+        r.latest_indice && pieceVersion?.indice && r.latest_indice !== pieceVersion.indice
+      ),
+    },
+
+    plan: {
+      document: planResolution.document
+        ? {
+            id: planResolution.document.id,
+            label: planResolution.document.label,
+            file_name: planResolution.document.original_name,
+            mime_type: planResolution.document.mime_type,
+            size_bytes: planResolution.document.size_bytes,
+            sha256: planResolution.document.sha256,
+          }
+        : null,
+      matches_snapshot: planResolution.matches_snapshot,
+      warning: planResolution.warning,
+    },
+
+    documents: (r.documents ?? []).map((d: any) => ({
+      id: d.id,
+      label: d.label,
+      file_name: d.original_name,
+      mime_type: d.mime_type,
+      size_bytes: Number(d.size_bytes ?? 0),
+      sha256: d.sha256,
+      created_at: d.created_at,
+    })),
+
+    instructions: {
+      gamme: (r.instructions ?? []).map((i: any) =>
+        stripCostFields(
+          {
+            phase: Number(i.phase ?? 0),
+            designation: i.designation,
+            designation_2: i.designation_2,
+            consignes: i.consignes,
+            type_operation: i.type_operation,
+            tp: i.tp,
+            tf_unit: i.tf_unit,
+          },
+          canViewCosts
+        )
+      ),
+      dossier_documents: (r.dossier_documents ?? []).map((d: any) => ({
+        id: d.id,
+        slot_key: d.slot_key,
+        label: d.label,
+        commentaire: d.commentaire,
+        document_id: d.document_id,
+        file_name: d.file_name,
+        mime_type: d.mime_type,
+        size_bytes: d.file_size_bytes ? Number(d.file_size_bytes) : null,
+      })),
+    },
+
+    material: {
+      expected: pieceVersion?.matiere_prevue ?? null,
+      consumptions: (r.materials ?? []).map((m: any) => ({
+        id: m.id,
+        article: m.article_id ? { id: m.article_id, code: m.article_code, designation: m.article_designation } : null,
+        lot: m.lot_id ? { id: m.lot_id, code: m.lot_code, supplier_lot_code: m.supplier_lot_code, status: m.lot_status } : null,
+        qty: Number(m.qty ?? 0),
+        unit_code: m.unit_code,
+        effective_at: m.effective_at,
+        status: m.status,
+      })),
+      // Le poste LIT la consommation : il ne la crée pas. Scanner un lot ici
+      // n'engendre aucun mouvement de stock.
+      notice:
+        "Le scan d'un lot depuis le poste ne crée aucun mouvement de stock. La consommation est déclarée par le module Stock.",
+    },
+
+    quality: {
+      characteristics: characteristics.map((c) => ({
+        plan_code: c.plan_code,
+        plan_version: c.plan_version,
+        trigger_type: c.trigger_type,
+        characteristic_key: c.characteristic_key,
+        label: c.label,
+        characteristic_type: c.characteristic_type,
+        value_kind: c.value_kind,
+        unit: c.unit,
+        nominal: c.nominal,
+        tolerance_min: c.tolerance_min,
+        tolerance_max: c.tolerance_max,
+        criticality: c.criticality,
+        mandatory: c.mandatory,
+        requires_instrument: c.requires_instrument,
+        instrument_category: c.instrument_category,
+        method: c.method,
+        sampling_rule: c.sampling_rule,
+        sampling_value: c.sampling_value,
+      })),
+      controls: controls.map((c) => ({
+        id: c.id,
+        reference: c.reference,
+        trigger_type: c.trigger_type,
+        status: c.status,
+        verdict: c.verdict,
+        control_date: c.control_date,
+        qty_controlled: c.qty_controlled,
+        qty_conforming: c.qty_conforming,
+      })),
+      first_article: {
+        required: firstArticleRequired,
+        passed: firstArticlePassed,
+        // C'est le PLAN DE CONTRÔLE qui décide, pas une règle universelle
+        // câblée dans le poste.
+        blocks_series: firstArticleRequired && !firstArticlePassed,
+        message: firstArticleRequired
+          ? firstArticlePassed
+            ? "Premier article prononcé conforme : la série est autorisée."
+            : "Premier article exigé par le plan de contrôle. La série reste interdite tant que la Qualité n'a pas tranché."
+          : "Aucun premier article exigé par le plan de contrôle applicable.",
+      },
+      instruments,
+    },
+
+    machine_documents: (r.machine_documents ?? []).map((d: any) => ({
+      id: d.id,
+      title: d.title,
+      document_type: d.document_type,
+      revision: d.revision,
+      mime_type: d.mime_type,
+      size_bytes: d.size_bytes ? Number(d.size_bytes) : null,
+      sha256: d.sha256,
+      url: d.url,
+    })),
+
+    hierarchy: {
+      parent: r.parent ?? null,
+      children: (r.children ?? []).map((c: any) => ({
+        of_id: Number(c.of_id),
+        numero: c.numero,
+        statut: c.statut,
+        piece_code: c.piece_code,
+        piece_designation: c.piece_designation,
+        quantite_lancee: Number(c.quantite_lancee ?? 0),
+        quantite_bonne: Number(c.quantite_bonne ?? 0),
+        quantite_rebut: Number(c.quantite_rebut ?? 0),
+      })),
+      structure_path: core.structure_path ?? null,
+    },
+
+    execution: {
+      active: r.active_execution ?? null,
+      declarations,
+    },
+
+    pending_handover: r.pending_handover ?? null,
+
+    next_business_actions: nextActions,
+
+    // Ce que le poste ne fera JAMAIS, affiché à l'opérateur pour qu'il ne
+    // suppose pas d'effets invisibles.
+    boundaries: [
+      "Aucune donnée de présence RH n'est créée par ce poste.",
+      "Aucun mouvement de stock n'est déclenché depuis cet écran.",
+      "Aucun programme n'est envoyé vers une commande numérique.",
+    ],
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Transmission de poste                                                      */
+/* -------------------------------------------------------------------------- */
+
+export async function svcCreateHandover(params: {
+  station: StationContext;
+  body: StationHandoverDTO;
+  idempotencyKey: string;
+}): Promise<Record<string, unknown>> {
+  assertHandoverParties({
+    outgoingUserId: params.station.user.id,
+    incomingUserId: params.body.incoming_user_id,
+  });
+
+  const handover = await repoCreateHandover({
+    device_id: params.station.device_id,
+    machine_id: params.station.machine_id,
+    of_id: params.body.of_id ?? null,
+    operation_id: params.body.operation_id ?? null,
+    pointage_id: params.body.pointage_id ?? null,
+    outgoing_user_id: params.station.user.id,
+    incoming_user_id: params.body.incoming_user_id,
+    machine_state: params.body.machine_state,
+    qty_done: params.body.qty_done ?? null,
+    defects: params.body.defects ?? null,
+    tooling_left: params.body.tooling_left ?? null,
+    remaining_actions: params.body.remaining_actions ?? null,
+    comment: params.body.comment ?? null,
+    idempotency_key: params.idempotencyKey,
+  });
+
+  return {
+    handover,
+    // Une transmission décrit ; elle ne débite aucun temps et n'écrit rien en RH.
+    notice:
+      "Transmission enregistrée. Elle ne modifie aucun temps déjà déclaré et ne crée aucune donnée de présence RH.",
+  };
+}
+
+export async function svcListHandovers(params: {
+  station: StationContext;
+  onlyPending: boolean;
+}): Promise<Record<string, unknown>> {
+  const items = await repoListHandoversForUser({
+    userId: params.station.user.id,
+    onlyPending: params.onlyPending,
+    limit: 50,
+  });
+  return { total: items.length, items };
+}
+
+export async function svcAcknowledgeHandover(params: {
+  station: StationContext;
+  id: string;
+}): Promise<Record<string, unknown>> {
+  const existing = await repoGetHandover(params.id);
+  if (!existing) throw new HttpError(404, "STATION_HANDOVER_UNKNOWN", "Transmission introuvable.");
+
+  assertHandoverAcknowledgeable({
+    incomingUserId: existing.incoming_user.id,
+    actorUserId: params.station.user.id,
+    actorRole: params.station.user.role,
+    alreadyAcknowledgedAt: existing.acknowledged_at ? new Date(existing.acknowledged_at) : null,
+  });
+
+  const updated = await repoAcknowledgeHandover({ id: params.id, actorUserId: params.station.user.id });
+  return { handover: updated };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Administration des appareils et supports                                   */
+/* -------------------------------------------------------------------------- */
+
+export async function svcEnrollDevice(params: {
+  actor: Actor;
+  body: EnrollDeviceDTO;
+}): Promise<DeviceRow> {
+  return repoEnrollDevice({
+    label: params.body.label,
+    code_prefix: params.body.code_prefix,
+    site: params.body.site ?? null,
+    workshop_zone: params.body.workshop_zone ?? null,
+    assignment_mode: params.body.assignment_mode,
+    machine_id: params.body.machine_id ?? null,
+    auto_lock_seconds: params.body.auto_lock_seconds,
+    session_max_seconds: params.body.session_max_seconds,
+    actorUserId: params.actor.id,
+  });
+}
+
+export async function svcUpdateDevice(params: {
+  actor: Actor;
+  id: string;
+  body: UpdateDeviceDTO;
+}): Promise<DeviceRow> {
+  const patch: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(params.body)) {
+    if (value !== undefined) patch[key] = value;
+  }
+  return repoUpdateDevice({ id: params.id, patch, actorUserId: params.actor.id });
+}
+
+export async function svcRevokeDevice(params: {
+  actor: Actor;
+  id: string;
+  reason: string;
+}): Promise<Record<string, unknown>> {
+  const result = await repoRevokeDevice({
+    id: params.id,
+    reason: params.reason,
+    actorUserId: params.actor.id,
+  });
+  return {
+    device: result.device,
+    closed_sessions: result.closed_sessions,
+    // Révoquer une tablette ferme des sessions ; cela n'arrête AUCUN pointage.
+    notice:
+      "Tablette révoquée et sessions fermées. Les pointages en cours ne sont pas arrêtés : ils restent la propriété du suivi de production.",
+  };
+}
+
+export async function svcListDevices(params: { query: ListDevicesQueryDTO }): Promise<DeviceRow[]> {
+  return repoListDevices({
+    status: params.query.status,
+    workshop_zone: params.query.workshop_zone,
+    q: params.query.q,
+    limit: params.query.limit,
+  });
+}
+
+export async function svcIssueCredential(params: {
+  actor: Actor;
+  body: IssueCredentialDTO;
+}): Promise<Record<string, unknown>> {
+  const created = await repoIssueCredential({
+    user_id: params.body.user_id,
+    credential_type: params.body.credential_type,
+    credential: params.body.credential,
+    label: params.body.label ?? null,
+    actorUserId: params.actor.id,
+  });
+  // L'empreinte n'est jamais renvoyée : elle ne quitte pas la base.
+  return { credential: created };
+}
+
+export async function svcRevokeCredential(params: {
+  actor: Actor;
+  id: string;
+  reason: string;
+}): Promise<Record<string, unknown>> {
+  await repoRevokeCredential({ id: params.id, reason: params.reason, actorUserId: params.actor.id });
+  return { revoked: true };
+}
+
+export async function svcListCredentials(params: {
+  actor: Actor;
+  userId: number;
+}): Promise<Record<string, unknown>> {
+  // Anti-IDOR : on ne liste les supports d'un tiers qu'avec la capacité
+  // d'administration.
+  if (params.actor.id !== params.userId) {
+    if (!roleHasStationCapability(params.actor.role, "administer_credentials")) {
+      throw new HttpError(
+        403,
+        "STATION_CAPABILITY_REQUIRED",
+        "La capacité de poste 'administer_credentials' est requise."
+      );
+    }
+  }
+  const items = await repoListCredentials(params.userId);
+  return { total: items.length, items };
+}
+
+export async function svcStationAudit(params: {
+  query: StationAuditQueryDTO;
+}): Promise<Record<string, unknown>> {
+  const items = await repoListStationAudit({
+    device_id: params.query.device_id,
+    user_id: params.query.user_id,
+    event_type: params.query.event_type,
+    outcome: params.query.outcome,
+    limit: params.query.limit,
+  });
+  return { total: items.length, items };
+}
+
+export async function svcSessionOwnershipGuard(params: {
+  actor: Actor;
+  sessionUserId: number;
+  action: string;
+}): Promise<void> {
+  assertOwnSessionOrSupervision({
+    actorUserId: params.actor.id,
+    actorRole: params.actor.role,
+    sessionUserId: params.sessionUserId,
+    action: params.action,
+  });
+}

--- a/src/module/production/services/station.service.ts
+++ b/src/module/production/services/station.service.ts
@@ -12,6 +12,7 @@
 //   * envoyer quoi que ce soit vers une commande numérique.
 
 import { HttpError } from "../../../utils/httpError";
+import { buildPublicImageUrl } from "../../../utils/imageStorage";
 import { evaluateInstrumentUsage, type InstrumentState } from "../../qualite/domain/quality-release";
 
 import {
@@ -909,6 +910,14 @@ export async function svcDossier(params: {
               matiere_prevue: pieceVersion.matiere_prevue,
               statut: pieceVersion.statut,
               date_application: pieceVersion.date_application,
+            }
+          : null,
+        client: r.client
+          ? {
+              id: String(r.client.id),
+              code: r.client.code ?? null,
+              company_name: r.client.company_name,
+              logo_url: buildPublicImageUrl(r.client.logo_path),
             }
           : null,
         affaire: r.affaire ? { id: Number(r.affaire.id), reference: r.affaire.reference } : null,

--- a/src/module/production/validators/station.validators.ts
+++ b/src/module/production/validators/station.validators.ts
@@ -1,0 +1,290 @@
+// Validateurs du poste opérateur tablette (#159).
+//
+// Principe hérité de #274 et renforcé ici : le serveur ne fait jamais confiance
+// au client sur l'identité, le temps ni les identifiants.
+//
+//   * L'OPÉRATEUR d'une session vient du support d'identification vérifié côté
+//     serveur, jamais d'un `user_id` envoyé par le navigateur.
+//   * Le CODE PUBLIC d'un appareil est généré par la base à l'enrôlement.
+//   * Le JETON de session est opaque et généré par le serveur.
+//   * Les DURÉES de verrouillage et d'expiration sont bornées côté serveur : une
+//     tablette ne négocie pas sa propre politique de sécurité.
+
+import { z } from "zod";
+
+import { HANDOVER_MACHINE_STATES, IDENTIFICATION_METHODS } from "../domain/station";
+
+const uuid = z.string().uuid();
+
+const devicePublicCode = z
+  .string()
+  .trim()
+  .regex(/^[A-Z][A-Z0-9-]{2,31}$/, "Code d'appareil invalide (ex. TAB-0007)");
+
+const label = z.string().trim().min(2, "Libellé trop court").max(120);
+const freeText = z.string().trim().max(2000);
+const reason = z.string().trim().min(3, "Motif trop court (3 caractères minimum)").max(2000);
+
+/**
+ * Support d'identification brut. Il n'est JAMAIS stocké ni journalisé : il est
+ * transformé en empreinte HMAC dès l'entrée du service. La borne haute évite
+ * qu'un lecteur défaillant n'envoie un flux entier.
+ */
+const rawCredential = z.string().trim().min(4, "Support illisible").max(256);
+
+/* -------------------------------------------------------------------------- */
+/* Bootstrap et session                                                       */
+/* -------------------------------------------------------------------------- */
+
+export const stationBootstrapQuerySchema = z.object({
+  /**
+   * Code lisible collé sur la tablette. Ce n'est PAS un secret : le connaître
+   * n'accorde aucun droit. Toute action reste portée par la session opérateur.
+   */
+  device_code: devicePublicCode.optional(),
+  app_version: z.string().trim().max(40).optional(),
+});
+export type StationBootstrapQueryDTO = z.infer<typeof stationBootstrapQuerySchema>;
+
+export const stationIdentifySchema = z
+  .object({
+    device_code: devicePublicCode,
+    method: z.enum(IDENTIFICATION_METHODS),
+    /** Présent pour BADGE et QR uniquement. Jamais renvoyé, jamais journalisé. */
+    credential: rawCredential.optional(),
+    /** Anti-rejeu du QR : horodatage d'émission signé côté émetteur. */
+    nonce: z.string().trim().min(8).max(128).optional(),
+    issued_at: z
+      .string()
+      .trim()
+      .refine((v) => Number.isFinite(Date.parse(v)), "Horodatage invalide")
+      .optional(),
+    /** Machine proposée par une tablette mobile. Le serveur re-vérifie tout. */
+    machine_id: uuid.nullish(),
+    app_version: z.string().trim().max(40).optional(),
+    /** Décision explicite si un pointage tourne déjà sur ce poste. */
+    switch_decision: z.enum(["HANDOVER", "PAUSE", "SUPERVISOR_OVERRIDE"]).optional(),
+  })
+  .superRefine((value, ctx) => {
+    if ((value.method === "BADGE" || value.method === "QR") && !value.credential) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["credential"],
+        message: "Présentez votre badge ou votre code.",
+      });
+    }
+    if (value.method === "QR" && !value.issued_at) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["issued_at"],
+        message: "Code QR sans horodatage : rejeu impossible à écarter.",
+      });
+    }
+    // PASSWORD et SSO passent par l'authentification ERP existante : la session
+    // de poste est alors ouverte pour l'utilisateur DÉJÀ authentifié, et aucun
+    // identifiant supplémentaire n'est accepté ici.
+    if ((value.method === "PASSWORD" || value.method === "SSO") && value.credential) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["credential"],
+        message: "Ce mode d'identification n'accepte aucun secret sur cette route.",
+      });
+    }
+  });
+export type StationIdentifyDTO = z.infer<typeof stationIdentifySchema>;
+
+export const stationConfirmMachineSchema = z.object({
+  machine_id: uuid,
+  /** Reprendre une machine occupée exige une décision, jamais un forçage muet. */
+  switch_decision: z.enum(["HANDOVER", "PAUSE", "SUPERVISOR_OVERRIDE"]).optional(),
+});
+export type StationConfirmMachineDTO = z.infer<typeof stationConfirmMachineSchema>;
+
+export const stationLockSchema = z.object({
+  reason: z.enum(["MANUAL", "IDLE", "SHIFT_END"]).default("MANUAL"),
+});
+export type StationLockDTO = z.infer<typeof stationLockSchema>;
+
+export const stationUnlockSchema = z
+  .object({
+    method: z.enum(IDENTIFICATION_METHODS),
+    credential: rawCredential.optional(),
+  })
+  .superRefine((value, ctx) => {
+    if ((value.method === "BADGE" || value.method === "QR") && !value.credential) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["credential"],
+        message: "Présentez votre badge pour déverrouiller.",
+      });
+    }
+  });
+export type StationUnlockDTO = z.infer<typeof stationUnlockSchema>;
+
+export const stationCloseSchema = z.object({
+  reason: z.enum(["MANUAL", "SHIFT_END", "OPERATOR_SWITCH", "ADMIN"]).default("MANUAL"),
+  comment: freeText.optional(),
+});
+export type StationCloseDTO = z.infer<typeof stationCloseSchema>;
+
+export const stationHeartbeatSchema = z.object({
+  app_version: z.string().trim().max(40).optional(),
+  /**
+   * Horodatage local de la tablette. Il sert UNIQUEMENT à détecter une dérive
+   * d'horloge et à en avertir l'opérateur ; il ne pilote aucun calcul métier.
+   */
+  client_time: z
+    .string()
+    .trim()
+    .refine((v) => Number.isFinite(Date.parse(v)), "Horodatage invalide")
+    .optional(),
+});
+export type StationHeartbeatDTO = z.infer<typeof stationHeartbeatSchema>;
+
+/* -------------------------------------------------------------------------- */
+/* File de travail et dossier                                                 */
+/* -------------------------------------------------------------------------- */
+
+export const stationWorklistQuerySchema = z.object({
+  /** Recherche libre : numéro d'OF, code pièce, désignation. */
+  q: z.string().trim().max(120).optional(),
+  /** Inclure les opérations non prêtes, pour comprendre ce qui bloque. */
+  include_blocked: z.coerce.boolean().default(false),
+  /**
+   * Restreindre à la machine confirmée. Par défaut `true` : un opérateur devant
+   * un tour n'a rien à faire de la file de la fraiseuse.
+   */
+  machine_only: z.coerce.boolean().default(true),
+  limit: z.coerce.number().int().min(1).max(100).default(30),
+});
+export type StationWorklistQueryDTO = z.infer<typeof stationWorklistQuerySchema>;
+
+export const stationDossierParamsSchema = z.object({
+  ofId: z.coerce.number().int().positive(),
+  operationId: uuid,
+});
+export type StationDossierParamsDTO = z.infer<typeof stationDossierParamsSchema>;
+
+export const stationScanSchema = z.object({
+  /**
+   * Contenu du code scanné. Accepte un numéro d'OF, un code opération
+   * `OF-2026-0007/30`, ou une URL CERP. Le serveur résout, le client ne devine
+   * jamais.
+   */
+  code: z.string().trim().min(1).max(200),
+});
+export type StationScanDTO = z.infer<typeof stationScanSchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Transmission de poste                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const stationHandoverSchema = z.object({
+  incoming_user_id: z.number().int().positive(),
+  of_id: z.number().int().positive().nullish(),
+  operation_id: uuid.nullish(),
+  pointage_id: uuid.nullish(),
+  machine_state: z.enum(HANDOVER_MACHINE_STATES).default("UNKNOWN"),
+  qty_done: z.number().nonnegative().nullish(),
+  defects: freeText.optional(),
+  tooling_left: freeText.optional(),
+  remaining_actions: freeText.optional(),
+  comment: freeText.optional(),
+});
+export type StationHandoverDTO = z.infer<typeof stationHandoverSchema>;
+
+export const stationHandoverAckSchema = z.object({
+  comment: freeText.optional(),
+});
+export type StationHandoverAckDTO = z.infer<typeof stationHandoverAckSchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Administration des appareils                                               */
+/* -------------------------------------------------------------------------- */
+
+export const enrollDeviceSchema = z
+  .object({
+    label,
+    /** Préfixe du code public. Le NUMÉRO est alloué par la base. */
+    code_prefix: z
+      .string()
+      .trim()
+      .regex(/^[A-Z][A-Z0-9]{0,7}$/, "Préfixe invalide (ex. TAB)")
+      .default("TAB"),
+    site: z.string().trim().max(80).optional(),
+    workshop_zone: z.string().trim().max(80).optional(),
+    assignment_mode: z.enum(["FIXED", "MOBILE"]).default("MOBILE"),
+    machine_id: uuid.nullish(),
+    // Bornes serveur : une tablette d'atelier ne se déclare pas « jamais
+    // verrouillée ».
+    auto_lock_seconds: z.number().int().min(30).max(3600).default(180),
+    session_max_seconds: z.number().int().min(300).max(86400).default(28800),
+  })
+  .superRefine((value, ctx) => {
+    if (value.assignment_mode === "FIXED" && !value.machine_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["machine_id"],
+        message: "Une tablette fixe doit être affectée à une machine.",
+      });
+    }
+  });
+export type EnrollDeviceDTO = z.infer<typeof enrollDeviceSchema>;
+
+export const updateDeviceSchema = z
+  .object({
+    label: label.optional(),
+    site: z.string().trim().max(80).nullish(),
+    workshop_zone: z.string().trim().max(80).nullish(),
+    assignment_mode: z.enum(["FIXED", "MOBILE"]).optional(),
+    machine_id: uuid.nullish(),
+    status: z.enum(["ACTIVE", "DISABLED"]).optional(),
+    auto_lock_seconds: z.number().int().min(30).max(3600).optional(),
+    session_max_seconds: z.number().int().min(300).max(86400).optional(),
+  })
+  .refine((v) => Object.keys(v).length > 0, "Aucune modification demandée.");
+export type UpdateDeviceDTO = z.infer<typeof updateDeviceSchema>;
+
+export const revokeDeviceSchema = z.object({ reason });
+export type RevokeDeviceDTO = z.infer<typeof revokeDeviceSchema>;
+
+export const listDevicesQuerySchema = z.object({
+  status: z.enum(["ACTIVE", "DISABLED", "REVOKED"]).optional(),
+  workshop_zone: z.string().trim().max(80).optional(),
+  q: z.string().trim().max(120).optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+});
+export type ListDevicesQueryDTO = z.infer<typeof listDevicesQuerySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Supports d'identification                                                  */
+/* -------------------------------------------------------------------------- */
+
+export const issueCredentialSchema = z.object({
+  user_id: z.number().int().positive(),
+  credential_type: z.enum(["BADGE_NFC", "BADGE_RFID", "QR"]).default("BADGE_NFC"),
+  /** Lu par le lecteur au moment de l'émission. Haché immédiatement. */
+  credential: rawCredential,
+  label: z.string().trim().max(80).optional(),
+});
+export type IssueCredentialDTO = z.infer<typeof issueCredentialSchema>;
+
+export const revokeCredentialSchema = z.object({ reason });
+export type RevokeCredentialDTO = z.infer<typeof revokeCredentialSchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Audit                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export const stationAuditQuerySchema = z.object({
+  device_id: uuid.optional(),
+  user_id: z.coerce.number().int().positive().optional(),
+  event_type: z
+    .string()
+    .trim()
+    .regex(/^[A-Z][A-Z0-9_]{2,63}$/)
+    .optional(),
+  outcome: z.enum(["SUCCESS", "DENIED", "ERROR"]).optional(),
+  limit: z.coerce.number().int().min(1).max(500).default(100),
+});
+export type StationAuditQueryDTO = z.infer<typeof stationAuditQuerySchema>;

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -22,6 +22,7 @@ import tarificationRoutes from "../module/facturation/routes/tarification.routes
 import reportingRoutes from "../module/facturation/routes/reporting.routes";
 import productionRoutes from "../module/production/routes/production.routes";
 import productionExecutionRoutes from "../module/production/routes/production-execution.routes";
+import productionStationRoutes from "../module/production/routes/station.routes";
 import qualiteRoutes from "../module/qualite/routes/qualite.routes";
 import quality360Routes from "../module/qualite/routes/quality-360.routes";
 import livraisonsRoutes from "../module/livraisons/routes/livraisons.routes";
@@ -81,6 +82,10 @@ router.use("/reporting", reportingRoutes);
 // ses routes déclarent des capacités fines (refus par défaut) et exigent une
 // clé d'idempotence. Le routeur hérité reste inchangé pour les écrans existants.
 router.use("/production/execution", productionExecutionRoutes);
+// Poste opérateur tablette (#159) monté AVANT le routeur historique. Il ne
+// duplique aucune commande d'exécution : il ajoute appareil, session, file de
+// travail, dossier OF numérique et transmission de poste.
+router.use("/production/station", productionStationRoutes);
 router.use("/production", productionRoutes);
 router.use("/planning", planningRoutes);
 router.use("/programmations", programmationRoutes);

--- a/src/sockets/sockeServer.ts
+++ b/src/sockets/sockeServer.ts
@@ -2,6 +2,16 @@ import type { Server as HttpServer } from "http";
 import jwt from "jsonwebtoken";
 import { Server as SocketIOServer, type Socket } from "socket.io";
 
+import {
+  canSubscribeStationRoom,
+  parseStationRoom,
+  type StationRoom,
+} from "../module/production/domain/station";
+import {
+  repoStationAudit,
+  repoUserRealtimeScope,
+} from "../module/production/repository/station.repository";
+
 type JwtUser = {
   id: number;
   username: string;
@@ -80,6 +90,40 @@ function parseUserRoomId(room: string): number | null {
   if (!Number.isFinite(n)) return null;
   const i = Math.trunc(n);
   return i > 0 ? i : null;
+}
+
+/**
+ * Autorise un salon de poste (#159).
+ *
+ * Le périmètre d'écoute est calculé côté serveur à partir des sessions vivantes
+ * et des pointages en cours de l'utilisateur ; la supervision élargit ce
+ * périmètre, rien d'autre. Un refus est audité : une tentative d'écoute d'un
+ * atelier voisin doit laisser une trace.
+ */
+async function authorizeStationRoom(room: StationRoom, user: JwtUser): Promise<boolean> {
+  const scope = await repoUserRealtimeScope(user.id);
+  const allowed = canSubscribeStationRoom({
+    room,
+    actorUserId: user.id,
+    actorRole: user.role ?? null,
+    ownMachineIds: scope.machineIds,
+    ownOfIds: scope.ofIds,
+    ownDeviceIds: scope.deviceIds,
+  });
+
+  if (!allowed) {
+    void repoStationAudit({
+      event_type: "ROOM_SUBSCRIPTION_DENIED",
+      outcome: "DENIED",
+      reason_code: room.kind,
+      user_id: user.id,
+      machine_id: room.kind === "MACHINE" ? room.machineId : null,
+      of_id: room.kind === "OF" ? room.ofId : null,
+      device_id: room.kind === "STATION" ? room.deviceId : null,
+    });
+  }
+
+  return allowed;
 }
 
 export const initSocketServer = (server: HttpServer) => {
@@ -163,30 +207,55 @@ export const initSocketServer = (server: HttpServer) => {
     }
 
     socket.on("room:join", (payload: unknown, cb?: (r: { ok: boolean; error?: string }) => void) => {
-      const room =
-        typeof (payload as { room?: unknown } | null)?.room === "string" ? (payload as { room: string }).room.trim() : "";
+      void (async () => {
+        const room =
+          typeof (payload as { room?: unknown } | null)?.room === "string"
+            ? (payload as { room: string }).room.trim()
+            : "";
 
-      if (!room || !isValidRoom(room)) {
-        cb?.({ ok: false, error: "invalid_room" });
-        return;
-      }
-
-      const requestedUserId = parseUserRoomId(room);
-      if (requestedUserId !== null) {
-        const authedUser = socket.data.user as JwtUser | undefined;
-        if (!authedUser || authedUser.id !== requestedUserId) {
-          cb?.({ ok: false, error: "forbidden" });
+        if (!room || !isValidRoom(room)) {
+          cb?.({ ok: false, error: "invalid_room" });
           return;
         }
-      }
 
-      if (socket.rooms.size >= 64) {
-        cb?.({ ok: false, error: "too_many_rooms" });
-        return;
-      }
+        const authedUser = socket.data.user as JwtUser | undefined;
 
-      socket.join(room);
-      cb?.({ ok: true });
+        const requestedUserId = parseUserRoomId(room);
+        if (requestedUserId !== null) {
+          if (!authedUser || authedUser.id !== requestedUserId) {
+            cb?.({ ok: false, error: "forbidden" });
+            return;
+          }
+        }
+
+        // #159 — Autorisation SERVEUR des salons de poste. Jusqu'ici, seul
+        // `USER:` était contrôlé : n'importe quel compte authentifié pouvait
+        // écouter `OF:<n>` ou `MACHINE:<uuid>` et observer l'atelier entier.
+        // Un nom de salon envoyé par le client n'est plus accordé tel quel.
+        const stationRoom = parseStationRoom(room);
+        if (stationRoom && stationRoom.kind !== "USER") {
+          if (!authedUser) {
+            cb?.({ ok: false, error: "forbidden" });
+            return;
+          }
+          const allowed = await authorizeStationRoom(stationRoom, authedUser);
+          if (!allowed) {
+            cb?.({ ok: false, error: "forbidden" });
+            return;
+          }
+        }
+
+        if (socket.rooms.size >= 64) {
+          cb?.({ ok: false, error: "too_many_rooms" });
+          return;
+        }
+
+        socket.join(room);
+        cb?.({ ok: true });
+      })().catch(() => {
+        // Une erreur d'autorisation ne devient jamais une autorisation.
+        cb?.({ ok: false, error: "forbidden" });
+      });
     });
   });
 };


### PR DESCRIPTION
## Livraison\n\nPromotion de dev vers main du socle serveur du poste opérateur tablette.\n\n- API et modèle de lecture du dossier opérateur\n- exposition contrôlée de l’identité client et de son logo public\n- migration transactionnelle déjà appliquée et vérifiée sur cerp_prod\n- documentation et preuve de migration rattachées\n\nCloses #159