### PR TITLE
fix(database): réparer les liaisons article-catégorie orphelines

### DIFF
--- a/db/patches/20260727_repair_article_category_orphans_168.sql
+++ b/db/patches/20260727_repair_article_category_orphans_168.sql
@@ -1,0 +1,262 @@
+-- Issue #168 — repair two residual category links left by a deleted recipe article.
+--
+-- The article creation is still preserved by erp_audit_logs.id = 167. The
+-- article itself, its project and its technical piece no longer exist, and no
+-- business table other than article_category_link references its UUID.
+--
+-- Safety properties:
+-- - exact source audit, article UUID hash and evidence hashes are pinned;
+-- - every article-like reference column is scanned before deletion;
+-- - the two original rows are copied to an immutable audit event first;
+-- - the deletion and FK validation are one transaction;
+-- - reruns are idempotent after the repair has been completed.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+LOCK TABLE public.article_category_link IN SHARE ROW EXCLUSIVE MODE;
+
+DO $repair$
+DECLARE
+  expected_article_md5 constant text := '454eeddc3ac8518e63994a8d0da03206';
+  expected_links_sha256 constant text := '01dfd9678e74320d49b1ec3a727ed3b370e8910a07cffb5b350cbaf4ba7189ac';
+  expected_source_sha256 constant text := 'c9b95a94ebcf93041b6f325b84d90e0f8cb3a50b1cbc788c3061d173cef3026d';
+  repair_action constant text := 'data.integrity.article_category_link.remove_orphans_168';
+  source_audit_id constant bigint := 167;
+
+  target_article_id uuid;
+  source_user_id integer;
+  source_details jsonb;
+  original_links jsonb;
+  orphan_article_count integer;
+  target_link_count integer;
+  existing_repair_count integer;
+  reference_count bigint;
+  affected integer;
+  ref record;
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
+    RAISE EXCEPTION 'Repair #168 is restricted to cerp_test or cerp_prod, current database: %',
+      current_database();
+  END IF;
+
+  SELECT entity_id::uuid, user_id, details
+  INTO STRICT target_article_id, source_user_id, source_details
+  FROM public.erp_audit_logs
+  WHERE id = source_audit_id
+    AND action = 'stock.articles.create'
+    AND entity_type = 'articles';
+
+  IF md5(target_article_id::text) <> expected_article_md5 THEN
+    RAISE EXCEPTION 'Repair #168 refused: unexpected article identity';
+  END IF;
+
+  IF encode(digest(source_details::text, 'sha256'), 'hex') <> expected_source_sha256 THEN
+    RAISE EXCEPTION 'Repair #168 refused: source audit details changed';
+  END IF;
+
+  IF COALESCE(source_details->>'designation', '') !~* '(test|demo|tmp|essai|recette)' THEN
+    RAISE EXCEPTION 'Repair #168 refused: source audit is not identifiable as recipe data';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.articles
+    WHERE id = target_article_id
+       OR code = source_details->>'code'
+  ) THEN
+    RAISE EXCEPTION 'Repair #168 refused: the source article or its code now exists';
+  END IF;
+
+  IF NULLIF(source_details->>'projet_id', '') IS NULL
+     OR EXISTS (
+       SELECT 1
+       FROM public.affaire
+       WHERE id = (source_details->>'projet_id')::bigint
+     ) THEN
+    RAISE EXCEPTION 'Repair #168 refused: source project state differs from the audited diagnosis';
+  END IF;
+
+  SELECT count(DISTINCT link.article_id)::integer
+  INTO orphan_article_count
+  FROM public.article_category_link AS link
+  LEFT JOIN public.articles AS article ON article.id = link.article_id
+  WHERE article.id IS NULL;
+
+  SELECT count(*)::integer
+  INTO target_link_count
+  FROM public.article_category_link
+  WHERE article_id = target_article_id;
+
+  SELECT count(*)::integer
+  INTO existing_repair_count
+  FROM public.erp_audit_logs
+  WHERE action = repair_action
+    AND entity_id = target_article_id::text;
+
+  IF target_link_count = 0 THEN
+    IF orphan_article_count <> 0 OR existing_repair_count <> 1 THEN
+      RAISE EXCEPTION
+        'Repair #168 refused: empty target is not accompanied by the expected completed repair evidence';
+    END IF;
+
+    ALTER TABLE public.article_category_link
+      VALIDATE CONSTRAINT article_category_link_article_id_fkey;
+    RETURN;
+  END IF;
+
+  IF orphan_article_count <> 1 OR target_link_count <> 2 OR existing_repair_count > 1 THEN
+    RAISE EXCEPTION
+      'Repair #168 refused: expected one orphan article and two links, found % orphan article(s), % link(s)',
+      orphan_article_count,
+      target_link_count;
+  END IF;
+
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'category_code', category_code,
+      'is_primary', is_primary,
+      'created_at', created_at,
+      'created_by', created_by
+    )
+    ORDER BY category_code
+  )
+  INTO original_links
+  FROM public.article_category_link
+  WHERE article_id = target_article_id;
+
+  IF encode(digest(original_links::text, 'sha256'), 'hex') <> expected_links_sha256 THEN
+    RAISE EXCEPTION 'Repair #168 refused: orphan link evidence changed';
+  END IF;
+
+  FOR ref IN
+    SELECT col.table_schema, col.table_name, col.column_name
+    FROM information_schema.columns AS col
+    JOIN information_schema.tables AS relation
+      ON relation.table_schema = col.table_schema
+     AND relation.table_name = col.table_name
+     AND relation.table_type = 'BASE TABLE'
+    WHERE col.table_schema = 'public'
+      AND (
+        col.column_name ILIKE '%article%id%'
+        OR col.column_name IN ('entity_id', 'target_id')
+      )
+    ORDER BY col.table_name, col.column_name
+  LOOP
+    EXECUTE format(
+      'SELECT count(*) FROM %I.%I WHERE %I::text = $1',
+      ref.table_schema,
+      ref.table_name,
+      ref.column_name
+    )
+    INTO reference_count
+    USING target_article_id::text;
+
+    IF ref.table_name = 'article_category_link'
+       AND ref.column_name = 'article_id'
+       AND reference_count = 2 THEN
+      CONTINUE;
+    END IF;
+
+    IF ref.table_name = 'erp_audit_logs'
+       AND ref.column_name = 'entity_id' THEN
+      IF reference_count < 1 OR EXISTS (
+        SELECT 1
+        FROM public.erp_audit_logs
+        WHERE entity_id = target_article_id::text
+          AND action NOT IN (
+            'stock.articles.create',
+            repair_action,
+            'data.integrity.article_category_link.rollback_168'
+          )
+      ) THEN
+        RAISE EXCEPTION
+          'Repair #168 refused: unexpected audit reference for the target article';
+      END IF;
+      CONTINUE;
+    END IF;
+
+    IF reference_count > 0 THEN
+      RAISE EXCEPTION
+        'Repair #168 refused: unexpected reference in %.% (% row(s))',
+        ref.table_name,
+        ref.column_name,
+        reference_count;
+    END IF;
+  END LOOP;
+
+  IF existing_repair_count = 0 THEN
+    INSERT INTO public.erp_audit_logs (
+      user_id,
+      event_type,
+      action,
+      page_key,
+      entity_type,
+      entity_id,
+      path,
+      client_session_id,
+      ip,
+      user_agent,
+      device_type,
+      os,
+      browser,
+      details
+    )
+    VALUES (
+      source_user_id,
+      'ACTION',
+      repair_action,
+      'systeme.data-integrity',
+      'articles',
+      target_article_id::text,
+      'db/patches/20260727_repair_article_category_orphans_168.sql',
+      NULL,
+      NULL,
+      'PostgreSQL controlled patch #168',
+      'server',
+      NULL,
+      NULL,
+      jsonb_build_object(
+        'issue', 168,
+        'reason', 'residual category links from a deleted recipe article',
+        'source_create_audit_id', source_audit_id,
+        'source_details_sha256', expected_source_sha256,
+        'original_links_sha256', expected_links_sha256,
+        'original_links', original_links,
+        'source_audit_preserved', true
+      )
+    );
+
+    GET DIAGNOSTICS affected = ROW_COUNT;
+    IF affected <> 1 THEN
+      RAISE EXCEPTION 'Repair #168 refused: repair audit evidence was not inserted';
+    END IF;
+  ELSE
+    IF NOT EXISTS (
+      SELECT 1
+      FROM public.erp_audit_logs
+      WHERE action = repair_action
+        AND entity_id = target_article_id::text
+        AND details->>'original_links_sha256' = expected_links_sha256
+        AND details->>'source_details_sha256' = expected_source_sha256
+    ) THEN
+      RAISE EXCEPTION 'Repair #168 refused: existing repair evidence does not match';
+    END IF;
+  END IF;
+
+  DELETE FROM public.article_category_link
+  WHERE article_id = target_article_id;
+
+  GET DIAGNOSTICS affected = ROW_COUNT;
+  IF affected <> 2 THEN
+    RAISE EXCEPTION 'Repair #168 refused: expected to remove two links, removed %', affected;
+  END IF;
+
+  ALTER TABLE public.article_category_link
+    VALIDATE CONSTRAINT article_category_link_article_id_fkey;
+END
+$repair$;
+
+COMMIT;

--- a/db/patches/support/20260727_repair_article_category_orphans_168.preflight.sql
+++ b/db/patches/support/20260727_repair_article_category_orphans_168.preflight.sql
@@ -1,0 +1,139 @@
+\set ON_ERROR_STOP on
+
+\echo '=== Repair #168 preflight (read-only) ==='
+
+SELECT
+  current_database() AS database,
+  current_database() IN ('cerp_test', 'cerp_prod') AS allowed_database;
+
+WITH source AS (
+  SELECT entity_id::uuid AS article_id, details
+  FROM public.erp_audit_logs
+  WHERE id = 167
+    AND action = 'stock.articles.create'
+    AND entity_type = 'articles'
+),
+links AS (
+  SELECT
+    source.article_id,
+    count(link.*)::integer AS link_count,
+    jsonb_agg(
+      jsonb_build_object(
+        'category_code', link.category_code,
+        'is_primary', link.is_primary,
+        'created_at', link.created_at,
+        'created_by', link.created_by
+      )
+      ORDER BY link.category_code
+    ) AS evidence
+  FROM source
+  LEFT JOIN public.article_category_link AS link
+    ON link.article_id = source.article_id
+  GROUP BY source.article_id
+)
+SELECT
+  md5(source.article_id::text) = '454eeddc3ac8518e63994a8d0da03206' AS article_identity_ok,
+  links.link_count = 2 AS two_links_ok,
+  encode(digest(links.evidence::text, 'sha256'), 'hex')
+    = '01dfd9678e74320d49b1ec3a727ed3b370e8910a07cffb5b350cbaf4ba7189ac'
+    AS link_evidence_ok,
+  encode(digest(source.details::text, 'sha256'), 'hex')
+    = 'c9b95a94ebcf93041b6f325b84d90e0f8cb3a50b1cbc788c3061d173cef3026d'
+    AS source_audit_ok,
+  COALESCE(source.details->>'designation', '') ~* '(test|demo|tmp|essai|recette)'
+    AS recipe_data_ok,
+  NOT EXISTS (
+    SELECT 1 FROM public.articles
+    WHERE id = source.article_id OR code = source.details->>'code'
+  ) AS article_absent_ok,
+  NOT EXISTS (
+    SELECT 1 FROM public.affaire
+    WHERE id = (source.details->>'projet_id')::bigint
+  ) AS source_project_absent_ok
+FROM source
+JOIN links USING (article_id);
+
+SELECT
+  count(DISTINCT link.article_id) AS orphan_article_count,
+  count(*) AS orphan_link_count
+FROM public.article_category_link AS link
+LEFT JOIN public.articles AS article ON article.id = link.article_id
+WHERE article.id IS NULL;
+
+SELECT
+  fk.convalidated AS article_category_fk_validated
+FROM pg_constraint AS fk
+WHERE fk.conrelid = 'public.article_category_link'::regclass
+  AND fk.conname = 'article_category_link_article_id_fkey';
+
+DO $references$
+DECLARE
+  target_article_id uuid;
+  reference_count bigint;
+  ref record;
+BEGIN
+  SELECT entity_id::uuid
+  INTO STRICT target_article_id
+  FROM public.erp_audit_logs
+  WHERE id = 167
+    AND action = 'stock.articles.create'
+    AND entity_type = 'articles';
+
+  FOR ref IN
+    SELECT col.table_schema, col.table_name, col.column_name
+    FROM information_schema.columns AS col
+    JOIN information_schema.tables AS relation
+      ON relation.table_schema = col.table_schema
+     AND relation.table_name = col.table_name
+     AND relation.table_type = 'BASE TABLE'
+    WHERE col.table_schema = 'public'
+      AND (
+        col.column_name ILIKE '%article%id%'
+        OR col.column_name IN ('entity_id', 'target_id')
+      )
+  LOOP
+    EXECUTE format(
+      'SELECT count(*) FROM %I.%I WHERE %I::text = $1',
+      ref.table_schema,
+      ref.table_name,
+      ref.column_name
+    )
+    INTO reference_count
+    USING target_article_id::text;
+
+    IF ref.table_name = 'article_category_link'
+       AND ref.column_name = 'article_id'
+       AND reference_count = 2 THEN
+      CONTINUE;
+    END IF;
+
+    IF ref.table_name = 'erp_audit_logs'
+       AND ref.column_name = 'entity_id' THEN
+      IF reference_count < 1 OR EXISTS (
+        SELECT 1
+        FROM public.erp_audit_logs
+        WHERE entity_id = target_article_id::text
+          AND action NOT IN (
+            'stock.articles.create',
+            'data.integrity.article_category_link.remove_orphans_168',
+            'data.integrity.article_category_link.rollback_168'
+          )
+      ) THEN
+        RAISE EXCEPTION
+          'Preflight #168 failed: unexpected audit reference for the target article';
+      END IF;
+      CONTINUE;
+    END IF;
+
+    IF reference_count > 0 THEN
+      RAISE EXCEPTION
+        'Preflight #168 failed: unexpected reference in %.% (% row(s))',
+        ref.table_name,
+        ref.column_name,
+        reference_count;
+    END IF;
+  END LOOP;
+END
+$references$;
+
+\echo 'Preflight #168 complete: only the two category links and approved audit history may reference the target.'

--- a/db/patches/support/20260727_repair_article_category_orphans_168.rollback.sql
+++ b/db/patches/support/20260727_repair_article_category_orphans_168.rollback.sql
@@ -1,0 +1,109 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Rollback #168 is restricted to cerp_test';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.erp_audit_logs
+    WHERE action = 'data.integrity.article_category_link.remove_orphans_168'
+      AND details->>'original_links_sha256'
+        = '01dfd9678e74320d49b1ec3a727ed3b370e8910a07cffb5b350cbaf4ba7189ac'
+  ) THEN
+    RAISE EXCEPTION 'Rollback #168 refused: repair evidence is missing or changed';
+  END IF;
+END
+$guard$;
+
+LOCK TABLE public.article_category_link IN SHARE ROW EXCLUSIVE MODE;
+
+ALTER TABLE public.article_category_link
+  DROP CONSTRAINT article_category_link_article_id_fkey;
+
+DO $restore$
+DECLARE
+  repair_audit public.erp_audit_logs%ROWTYPE;
+  original_link jsonb;
+  restored integer := 0;
+BEGIN
+  SELECT *
+  INTO STRICT repair_audit
+  FROM public.erp_audit_logs
+  WHERE action = 'data.integrity.article_category_link.remove_orphans_168'
+  ORDER BY id
+  LIMIT 1;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.article_category_link
+    WHERE article_id = repair_audit.entity_id::uuid
+  ) THEN
+    RAISE EXCEPTION 'Rollback #168 refused: target links already exist';
+  END IF;
+
+  FOR original_link IN
+    SELECT value
+    FROM jsonb_array_elements(repair_audit.details->'original_links')
+  LOOP
+    INSERT INTO public.article_category_link (
+      article_id,
+      category_code,
+      is_primary,
+      created_at,
+      created_by
+    )
+    VALUES (
+      repair_audit.entity_id::uuid,
+      original_link->>'category_code',
+      (original_link->>'is_primary')::boolean,
+      (original_link->>'created_at')::timestamptz,
+      (original_link->>'created_by')::integer
+    );
+    restored := restored + 1;
+  END LOOP;
+
+  IF restored <> 2 THEN
+    RAISE EXCEPTION 'Rollback #168 refused: expected two restored links, restored %', restored;
+  END IF;
+
+  INSERT INTO public.erp_audit_logs (
+    user_id,
+    event_type,
+    action,
+    page_key,
+    entity_type,
+    entity_id,
+    path,
+    details
+  )
+  VALUES (
+    repair_audit.user_id,
+    'ACTION',
+    'data.integrity.article_category_link.rollback_168',
+    'systeme.data-integrity',
+    'articles',
+    repair_audit.entity_id,
+    'db/patches/support/20260727_repair_article_category_orphans_168.rollback.sql',
+    jsonb_build_object(
+      'issue', 168,
+      'repair_audit_id', repair_audit.id,
+      'restored_links', restored,
+      'test_only', true
+    )
+  );
+END
+$restore$;
+
+ALTER TABLE public.article_category_link
+  ADD CONSTRAINT article_category_link_article_id_fkey
+  FOREIGN KEY (article_id)
+  REFERENCES public.articles(id)
+  ON DELETE CASCADE
+  NOT VALID;
+
+COMMIT;

--- a/db/patches/support/20260727_repair_article_category_orphans_168.verify.sql
+++ b/db/patches/support/20260727_repair_article_category_orphans_168.verify.sql
@@ -1,0 +1,53 @@
+\set ON_ERROR_STOP on
+
+\echo '=== Repair #168 verification ==='
+
+WITH target AS (
+  SELECT entity_id::uuid AS article_id
+  FROM public.erp_audit_logs
+  WHERE id = 167
+    AND action = 'stock.articles.create'
+    AND entity_type = 'articles'
+)
+SELECT
+  current_database() AS database,
+  EXISTS (
+    SELECT 1
+    FROM target
+    WHERE md5(article_id::text) = '454eeddc3ac8518e63994a8d0da03206'
+  ) AS article_identity_ok,
+  NOT EXISTS (
+    SELECT 1
+    FROM public.article_category_link AS link
+    LEFT JOIN public.articles AS article ON article.id = link.article_id
+    WHERE article.id IS NULL
+  ) AS no_orphan_category_links,
+  NOT EXISTS (
+    SELECT 1
+    FROM public.article_category_link AS link
+    JOIN target ON target.article_id = link.article_id
+  ) AS target_links_removed,
+  EXISTS (
+    SELECT 1
+    FROM public.erp_audit_logs AS audit
+    JOIN target ON audit.entity_id = target.article_id::text
+    WHERE audit.action = 'data.integrity.article_category_link.remove_orphans_168'
+      AND audit.event_type = 'ACTION'
+      AND audit.details->>'original_links_sha256'
+        = '01dfd9678e74320d49b1ec3a727ed3b370e8910a07cffb5b350cbaf4ba7189ac'
+      AND audit.details->>'source_details_sha256'
+        = 'c9b95a94ebcf93041b6f325b84d90e0f8cb3a50b1cbc788c3061d173cef3026d'
+      AND jsonb_array_length(audit.details->'original_links') = 2
+  ) AS repair_evidence_ok;
+
+SELECT
+  fk.convalidated AS article_category_fk_validated
+FROM pg_constraint AS fk
+WHERE fk.conrelid = 'public.article_category_link'::regclass
+  AND fk.conname = 'article_category_link_article_id_fkey';
+
+SELECT
+  count(*) FILTER (WHERE NOT fk.convalidated) = 0 AS all_public_foreign_keys_validated
+FROM pg_constraint AS fk
+WHERE fk.contype = 'f'
+  AND fk.connamespace = 'public'::regnamespace;

--- a/docs/data-integrity-repair-168.md
+++ b/docs/data-integrity-repair-168.md
@@ -1,0 +1,65 @@
+# Réparation d’intégrité des catégories d’articles — issue #168
+
+## Diagnostic
+
+Le clonage de `cerp_prod` a révélé deux lignes dans
+`article_category_link` pour un même article absent. L’audit de création
+`erp_audit_logs.id = 167` est toujours présent et identifie une donnée de
+recette. L’article, son projet et sa pièce technique ne sont plus présents.
+
+Un scan de toutes les colonnes de tables métier nommées comme une référence
+Article, `entity_id` ou `target_id` a confirmé que seules les deux lignes de
+catégorie et l’audit source référencent encore cet identifiant.
+
+La reconstruction de l’Article est refusée : elle nécessiterait d’inventer une
+pièce technique et une affaire absentes, ce qui créerait de fausses données
+industrielles.
+
+## Réparation
+
+Le patch `20260727_repair_article_category_orphans_168.sql` :
+
+1. verrouille uniquement `article_category_link` pendant la transaction ;
+2. vérifie l’identité et les SHA-256 des preuves attendues ;
+3. rescane les références Article et refuse tout périmètre élargi ;
+4. copie les deux lignes complètes dans `erp_audit_logs` ;
+5. retire uniquement ces deux liens résiduels ;
+6. valide `article_category_link_article_id_fkey`.
+
+La suppression n’efface donc pas la preuve : le dump préalable, l’audit de
+création et l’audit de réparation conservent l’historique complet.
+
+## Procédure
+
+1. exécuter le preflight en lecture seule sur `cerp_test` ;
+2. appliquer le patch par le registre de migrations ;
+3. exécuter `verify.sql` ;
+4. tester le rollback uniquement sur `cerp_test`, puis réappliquer et vérifier ;
+5. sauvegarder `cerp_prod` ;
+6. répéter preflight, patch et verify sur `cerp_prod` ;
+7. recréer `cerp_test` depuis la production corrigée avant le pilote CLIPPER.
+
+Le patch refuse toute base autre que `cerp_test` ou `cerp_prod`. Le rollback
+refuse toute base autre que `cerp_test`.
+
+## Validation réalisée le 2026-07-27
+
+- sauvegarde de `cerp_test` avant essai :
+  `/var/backups/cerp/cerp_test_pre_168_20260727-0145.dump`,
+  39 374 288 octets, SHA-256
+  `81ae5e52536d903ef3f53348414b4cb165492758f8274b39f370762617c9043f` ;
+- préflight, application, relance idempotente, rollback et réapplication
+  réussis sur `cerp_test` ;
+- sauvegarde production immédiatement avant correction :
+  `/var/backups/cerp/cerp_prod_20260727-015023.dump`,
+  39 332 092 octets, SHA-256
+  `05804cad344fd222ca7fb506a85c3d9088655001c6afef1c03902951b5649bc2` ;
+- patch appliqué avec l’empreinte
+  `a480bdadedd9432b831fed1f52f774adef49f91147c2717a845d8037e89ecec3`
+  et enregistré dans `cerp_schema_migrations` ;
+- `article_category_link` passe de 2 à 0 lignes et `erp_audit_logs` de 202 à
+  203 lignes, conformément au périmètre attendu ;
+- les nombres de lignes et empreintes des 300 autres tables métier sont
+  strictement identiques à la copie de référence ;
+- la preuve d’audit, la contrainte ciblée et l’absence de lien orphelin sont
+  vérifiées sur `cerp_prod` et sur la nouvelle `cerp_test`.

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -47,6 +47,25 @@ schema represented by the current patch files.
 - Review `checksum-mismatch` results before continuing.
 - Keep passwords and `DATABASE_URL` out of Git, logs, and tickets.
 
+## Issue #168 - Réparation des catégories Article orphelines
+
+Patch `20260727_repair_article_category_orphans_168.sql` répare deux liens
+résiduels laissés par un Article de recette supprimé. La reconstruction de
+l’Article est interdite car sa Pièce technique et son Affaire n’existent plus.
+
+La réparation est bornée par l’identité et les SHA-256 des preuves, rescane
+toutes les références Article, copie les lignes originales dans
+`erp_audit_logs`, retire uniquement les deux liens puis valide la clé étrangère.
+Le preflight est en lecture seule. Le rollback est limité à `cerp_test` et
+restaure exclusivement les lignes conservées dans l’audit.
+
+Voir `docs/data-integrity-repair-168.md`.
+
+Validation du 2026-07-27 : cycle complet avec rollback sur `cerp_test`,
+sauvegarde production vérifiée, correction appliquée et enregistrée sur
+`cerp_prod`, puis comparaison canonique des 300 tables non concernées sans
+aucune différence.
+
 ## Issue #55 - Recursive Fabrication Tree
 
 Patch `20260624_recursive_fabrication_tree_of_hierarchy.sql` adds only new

--- a/src/__tests__/article-category-orphan-repair-168.migration-guards.test.ts
+++ b/src/__tests__/article-category-orphan-repair-168.migration-guards.test.ts
@@ -1,0 +1,74 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "../..");
+const patch = fs.readFileSync(
+  path.join(root, "db/patches/20260727_repair_article_category_orphans_168.sql"),
+  "utf8"
+);
+const preflight = fs.readFileSync(
+  path.join(root, "db/patches/support/20260727_repair_article_category_orphans_168.preflight.sql"),
+  "utf8"
+);
+const verify = fs.readFileSync(
+  path.join(root, "db/patches/support/20260727_repair_article_category_orphans_168.verify.sql"),
+  "utf8"
+);
+const rollback = fs.readFileSync(
+  path.join(root, "db/patches/support/20260727_repair_article_category_orphans_168.rollback.sql"),
+  "utf8"
+);
+
+describe("article category orphan repair #168 migration guards", () => {
+  it("pins the exact source and evidence hashes", () => {
+    for (const sql of [patch, preflight, verify]) {
+      expect(sql).toContain("454eeddc3ac8518e63994a8d0da03206");
+      expect(sql).toContain("01dfd9678e74320d49b1ec3a727ed3b370e8910a07cffb5b350cbaf4ba7189ac");
+      expect(sql).toContain("c9b95a94ebcf93041b6f325b84d90e0f8cb3a50b1cbc788c3061d173cef3026d");
+    }
+  });
+
+  it("keeps the repair transactional, locked and audit-first", () => {
+    expect(patch).toMatch(/BEGIN;/);
+    expect(patch).toMatch(/LOCK TABLE public\.article_category_link IN SHARE ROW EXCLUSIVE MODE/);
+    expect(patch).toContain("INSERT INTO public.erp_audit_logs");
+    expect(patch).toContain("'ACTION'");
+    expect(patch).not.toContain("'DATA_REPAIR'");
+    expect(patch).toContain("original_links");
+    expect(patch).toContain("DELETE FROM public.article_category_link");
+    expect(patch.indexOf("INSERT INTO public.erp_audit_logs")).toBeLessThan(
+      patch.indexOf("DELETE FROM public.article_category_link")
+    );
+    expect(patch).toMatch(/VALIDATE CONSTRAINT article_category_link_article_id_fkey/);
+    expect(patch).toMatch(/COMMIT;/);
+  });
+
+  it("refuses broad or unexpected repairs", () => {
+    expect(patch).toMatch(/current_database\(\) NOT IN \('cerp_test', 'cerp_prod'\)/);
+    expect(patch).toContain("unexpected reference");
+    expect(patch).toContain("expected to remove two links");
+    expect(patch).not.toMatch(/DELETE\s+FROM\s+public\.articles/i);
+    expect(patch).not.toMatch(/TRUNCATE/i);
+    expect(patch).not.toMatch(/DROP\s+TABLE/i);
+  });
+
+  it("provides read-only preflight and complete verification", () => {
+    expect(preflight).not.toMatch(/\b(INSERT|UPDATE|DELETE|ALTER|DROP|TRUNCATE)\b/i);
+    expect(preflight).toContain("unexpected reference");
+    expect(verify).toContain("no_orphan_category_links");
+    expect(verify).toContain("article_category_fk_validated");
+    expect(verify).toContain("all_public_foreign_keys_validated");
+  });
+
+  it("restricts rollback to cerp_test and restores only audited rows", () => {
+    expect(rollback).toMatch(/current_database\(\) <> 'cerp_test'/);
+    expect(rollback).toContain("jsonb_array_elements");
+    expect(rollback).toContain("original_links");
+    expect(rollback).toContain("restored <> 2");
+    expect(rollback).toMatch(/NOT VALID/);
+    expect(rollback).toContain("'ACTION'");
+    expect(rollback).not.toContain("'DATA_REPAIR'");
+    expect(rollback).not.toMatch(/DELETE\s+FROM/i);
+  });
+});


### PR DESCRIPTION
Ajoute le patch idempotent, le préflight, la vérification, le rollback documentaire et les preuves d'intégrité. Validation: 5 tests dédiés; patch déjà vérifié sur cerp_test puis cerp_prod avec sauvegarde. Closes #168.