### PR TITLE
feat: assistant d'import CLIPPER reprenable

### DIFF
--- a/db/patches/20260726_import_assistant_167.sql
+++ b/db/patches/20260726_import_assistant_167.sql
@@ -1,0 +1,154 @@
+-- Issue #167 — CLIPPER -> CERP import assistant staging and crosswalk.
+-- Additive and idempotent. This patch does not import any business data.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.data_import_batches (
+  id uuid PRIMARY KEY,
+  source_system text NOT NULL,
+  entity_type text NOT NULL,
+  status text NOT NULL,
+  source_name text NOT NULL,
+  source_sha256 char(64) NOT NULL,
+  source_size bigint NOT NULL CHECK (source_size >= 0),
+  source_mime text NULL,
+  sheet_name text NOT NULL,
+  headers jsonb NOT NULL DEFAULT '[]'::jsonb,
+  mapping jsonb NULL,
+  preview_hash char(64) NULL,
+  summary jsonb NOT NULL DEFAULT '{"total":0,"valid":0,"blocked":0,"duplicates":0,"already_imported":0,"imported":0,"linked":0,"failed":0}'::jsonb,
+  last_error text NULL,
+  created_by integer NOT NULL REFERENCES public.users(id),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz NULL,
+  retention_until date NOT NULL DEFAULT (CURRENT_DATE + 90),
+  CONSTRAINT data_import_batches_entity_ck CHECK (
+    entity_type IN ('CLIENT','FOURNISSEUR','ARTICLE','PIECE_TECHNIQUE','MACHINE','STOCK_INITIAL','BL_HISTORIQUE','EMPLOYE')
+  ),
+  CONSTRAINT data_import_batches_status_ck CHECK (
+    status IN ('UPLOADED','SIMULATED','READY','IMPORTING','COMPLETED','COMPLETED_WITH_ERRORS','FAILED')
+  ),
+  CONSTRAINT data_import_batches_headers_array_ck CHECK (jsonb_typeof(headers) = 'array'),
+  CONSTRAINT data_import_batches_summary_object_ck CHECK (jsonb_typeof(summary) = 'object')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS data_import_batches_source_uq
+  ON public.data_import_batches (source_system, entity_type, source_sha256, sheet_name);
+CREATE INDEX IF NOT EXISTS data_import_batches_created_idx
+  ON public.data_import_batches (created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.data_import_rows (
+  id bigserial PRIMARY KEY,
+  batch_id uuid NOT NULL REFERENCES public.data_import_batches(id) ON DELETE RESTRICT,
+  row_number integer NOT NULL CHECK (row_number >= 2),
+  legacy_key text NULL,
+  source_data jsonb NOT NULL,
+  normalized_data jsonb NULL,
+  status text NOT NULL DEFAULT 'PENDING',
+  action text NOT NULL DEFAULT 'CREATE',
+  issues jsonb NOT NULL DEFAULT '[]'::jsonb,
+  target_id text NULL,
+  target_code text NULL,
+  attempts integer NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+  processing_started_at timestamptz NULL,
+  purged_at timestamptz NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT data_import_rows_status_ck CHECK (
+    status IN ('PENDING','VALID','BLOCKED','DUPLICATE','ALREADY_IMPORTED','PROCESSING','IMPORTED','LINKED','FAILED')
+  ),
+  CONSTRAINT data_import_rows_action_ck CHECK (action IN ('CREATE','LINK','SKIP')),
+  CONSTRAINT data_import_rows_source_object_ck CHECK (jsonb_typeof(source_data) = 'object'),
+  CONSTRAINT data_import_rows_normalized_object_ck CHECK (normalized_data IS NULL OR jsonb_typeof(normalized_data) = 'object'),
+  CONSTRAINT data_import_rows_issues_array_ck CHECK (jsonb_typeof(issues) = 'array'),
+  CONSTRAINT data_import_rows_batch_row_uq UNIQUE (batch_id, row_number)
+);
+
+CREATE INDEX IF NOT EXISTS data_import_rows_batch_status_idx
+  ON public.data_import_rows (batch_id, status, row_number);
+CREATE INDEX IF NOT EXISTS data_import_rows_legacy_idx
+  ON public.data_import_rows (batch_id, legacy_key);
+
+CREATE TABLE IF NOT EXISTS public.data_import_crosswalk (
+  id bigserial PRIMARY KEY,
+  source_system text NOT NULL,
+  entity_type text NOT NULL,
+  legacy_key text NOT NULL,
+  target_id text NOT NULL,
+  target_code text NULL,
+  batch_id uuid NOT NULL REFERENCES public.data_import_batches(id) ON DELETE RESTRICT,
+  row_id bigint NULL REFERENCES public.data_import_rows(id) ON DELETE SET NULL,
+  linked_by integer NOT NULL REFERENCES public.users(id),
+  linked_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT data_import_crosswalk_source_uq UNIQUE (source_system, entity_type, legacy_key)
+);
+
+CREATE INDEX IF NOT EXISTS data_import_crosswalk_target_idx
+  ON public.data_import_crosswalk (entity_type, target_id);
+
+CREATE TABLE IF NOT EXISTS public.data_import_confirm_idempotency (
+  actor_user_id integer NOT NULL REFERENCES public.users(id),
+  idempotency_key text NOT NULL,
+  batch_id uuid NOT NULL REFERENCES public.data_import_batches(id) ON DELETE RESTRICT,
+  request_hash char(64) NOT NULL,
+  response_status integer NOT NULL,
+  response_body jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (actor_user_id, idempotency_key)
+);
+
+CREATE TABLE IF NOT EXISTS public.fournisseur_create_idempotence (
+  idempotency_key text PRIMARY KEY,
+  request_hash char(64) NOT NULL,
+  fournisseur_id uuid NOT NULL REFERENCES public.fournisseurs(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.piece_technique_create_idempotence (
+  idempotency_key text PRIMARY KEY,
+  request_hash char(64) NOT NULL,
+  piece_technique_id uuid NOT NULL REFERENCES public.pieces_techniques(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE OR REPLACE FUNCTION public.fn_purge_expired_import_staging()
+RETURNS bigint
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  affected bigint := 0;
+BEGIN
+  WITH expired_batches AS (
+    SELECT id
+    FROM public.data_import_batches
+    WHERE retention_until < CURRENT_DATE
+      AND status IN ('COMPLETED', 'COMPLETED_WITH_ERRORS', 'FAILED')
+  ),
+  purged_rows AS (
+    UPDATE public.data_import_rows AS row
+    SET source_data = '{}'::jsonb,
+        normalized_data = NULL,
+        issues = '[]'::jsonb,
+        purged_at = now(),
+        updated_at = now()
+    FROM expired_batches
+    WHERE row.batch_id = expired_batches.id
+      AND row.purged_at IS NULL
+    RETURNING row.id
+  )
+  SELECT count(*) INTO affected FROM purged_rows;
+
+  UPDATE public.data_import_batches
+  SET headers = '[]'::jsonb,
+      mapping = NULL,
+      updated_at = now()
+  WHERE retention_until < CURRENT_DATE
+    AND status IN ('COMPLETED', 'COMPLETED_WITH_ERRORS', 'FAILED')
+    AND (headers <> '[]'::jsonb OR mapping IS NOT NULL);
+
+  RETURN affected;
+END;
+$$;
+
+COMMIT;

--- a/db/patches/support/20260726_import_assistant_167.preflight.sql
+++ b/db/patches/support/20260726_import_assistant_167.preflight.sql
@@ -1,0 +1,14 @@
+\set ON_ERROR_STOP on
+
+SELECT
+  to_regclass('public.data_import_batches') AS existing_batches_table,
+  to_regclass('public.data_import_rows') AS existing_rows_table,
+  to_regclass('public.data_import_crosswalk') AS existing_crosswalk_table,
+  (SELECT count(*) FROM public.users) AS users_available;
+
+SELECT
+  to_regclass('public.clients') AS clients_table,
+  to_regclass('public.fournisseurs') AS fournisseurs_table,
+  to_regclass('public.articles') AS articles_table,
+  to_regclass('public.pieces_techniques') AS pieces_table,
+  to_regclass('public.machines') AS machines_table;

--- a/db/patches/support/20260726_import_assistant_167.rollback.sql
+++ b/db/patches/support/20260726_import_assistant_167.rollback.sql
@@ -1,0 +1,3 @@
+\echo 'Rollback intentionally guarded: import staging and crosswalk may contain audit evidence.'
+\echo 'Use a reviewed retention/archive procedure or restore a verified backup; no automatic DROP is provided.'
+\quit

--- a/db/patches/support/20260726_import_assistant_167.verify.sql
+++ b/db/patches/support/20260726_import_assistant_167.verify.sql
@@ -1,0 +1,25 @@
+\set ON_ERROR_STOP on
+
+SELECT
+  to_regclass('public.data_import_batches') IS NOT NULL AS batches_ok,
+  to_regclass('public.data_import_rows') IS NOT NULL AS rows_ok,
+  to_regclass('public.data_import_crosswalk') IS NOT NULL AS crosswalk_ok,
+  to_regclass('public.data_import_confirm_idempotency') IS NOT NULL AS confirm_idempotency_ok,
+  to_regclass('public.fournisseur_create_idempotence') IS NOT NULL AS fournisseur_idempotency_ok,
+  to_regclass('public.piece_technique_create_idempotence') IS NOT NULL AS piece_idempotency_ok,
+  to_regprocedure('public.fn_purge_expired_import_staging()') IS NOT NULL AS retention_function_ok;
+
+SELECT EXISTS (
+  SELECT 1
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'data_import_rows'
+    AND column_name = 'purged_at'
+) AS purged_at_ok;
+
+SELECT
+  count(*) FILTER (WHERE indexname = 'data_import_batches_source_uq') = 1 AS batch_source_unique_ok,
+  count(*) FILTER (WHERE indexname = 'data_import_rows_batch_status_idx') = 1 AS row_claim_index_ok,
+  count(*) FILTER (WHERE indexname = 'data_import_crosswalk_target_idx') = 1 AS crosswalk_target_index_ok
+FROM pg_indexes
+WHERE schemaname = 'public';

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -47,6 +47,45 @@ schema represented by the current patch files.
 - Review `checksum-mismatch` results before continuing.
 - Keep passwords and `DATABASE_URL` out of Git, logs, and tickets.
 
+## Issue #167 - Assistant d’import CLIPPER
+
+Patch `20260726_import_assistant_167.sql` ajoute le staging reprenable, le
+crosswalk CLIPPER vers CERP, l’idempotence de confirmation et l’idempotence de
+création fournisseur/pièce. Il n’importe aucune donnée métier.
+
+Les routes de l’assistant sont en plus verrouillées sur l’identité réelle du
+pool PostgreSQL : `SELECT current_database()` doit retourner exactement
+`cerp_test`, sinon l’API répond `409 IMPORT_TEST_DATABASE_REQUIRED`. Le routage
+HTTP ne constitue donc pas à lui seul une autorisation d’import.
+
+Ordre obligatoire sur `cerp_test` :
+
+1. exécuter `support/20260726_import_assistant_167.preflight.sql` ;
+2. appliquer le patch par le mécanisme normal ;
+3. exécuter `support/20260726_import_assistant_167.verify.sql` ;
+4. réaliser la recette pilote documentée dans `docs/import-assistant.md`.
+
+Les contenus source et normalisés de staging sont purgés après 90 jours par
+`fn_purge_expired_import_staging()`. Le crosswalk et la preuve minimale restent
+conservés. Le rollback automatique est volontairement bloqué dès qu’une preuve
+ou correspondance pourrait être perdue.
+
+Validation du 2026-07-27 :
+
+- défauts de données #168 et de validation de contraintes #169 corrigés et
+  vérifiés avant la reprise ;
+- `cerp_test` recréée depuis le dump vérifié
+  `/var/backups/cerp/cerp_prod_20260727-020006.dump` ;
+- ancienne base préservée sous
+  `cerp_test_pre_import_167_168_169_20260727_0200`, connexions désactivées ;
+- volumes et empreintes des 303 tables identiques avant patch ;
+- patch #167 appliqué avec les objets possédés par `cerp_app` ;
+- preflight, verify, accès runtime et smoke transactionnel réussis ;
+- zéro résidu du smoke test, zéro lien de catégorie orphelin et toutes les clés
+  étrangères publiques validées ;
+- assistant d’import présent uniquement dans `cerp_test`, aucune table de
+  staging #167 créée dans `cerp_prod`.
+
 ## Issue #168 - Réparation des catégories Article orphelines
 
 Patch `20260727_repair_article_category_orphans_168.sql` répare deux liens

--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -1,0 +1,105 @@
+# Assistant d’import CLIPPER
+
+## API
+
+Toutes les routes sont sous `/api/v1/import-assistant` et réservées aux rôles `Administrateur Systeme et Reseau` et `Directeur`.
+
+- `GET /capabilities`
+- `POST /batches` avec `entity_type`, `source_system` et un fichier `file`
+- `GET /batches/:id`
+- `GET /batches/:id/rows`
+- `PUT /batches/:id/preview`
+- `POST /batches/:id/confirm` avec `Idempotency-Key`
+- `GET /batches/:id/report.csv`
+
+## Garanties
+
+- Chaque requête vérifie `SELECT current_database()` et refuse l’opération avec
+  `IMPORT_TEST_DATABASE_REQUIRED` si le processus n’est pas réellement connecté
+  à `cerp_test`.
+- CSV/XLSX uniquement, 25 Mo côté upload et 64 Mo décompressés.
+- SHA-256 du fichier et unicité du lot par source, domaine, empreinte et feuille.
+- Simulation par les schémas Zod existants.
+- Création par les services métier existants et codes générés par CERP.
+- Crosswalk stable entre clé CLIPPER et fiche CERP.
+- Reprise par lots de 25 lignes avec verrouillage `SKIP LOCKED`.
+- Confirmation et création idempotentes.
+- Audit de chaque étape et rapport ligne par ligne.
+- Purge des données de staging après 90 jours ; métadonnées de preuve et crosswalk conservés.
+
+## Base de données
+
+Patch : `db/patches/20260726_import_assistant_167.sql`.
+
+Avant toute application, exécuter le preflight sur `cerp_test`, appliquer par le mécanisme de patches existant, puis lancer le script `verify`. Le rollback automatique est volontairement bloqué dès que des preuves ou correspondances peuvent exister.
+
+Le patch est additif et n’importe aucune donnée métier.
+
+Le choix affiché par le frontend n’est jamais utilisé comme preuve. Le service
+API dédié à l’import doit disposer de son propre pool PostgreSQL vers
+`cerp_test`; le middleware contrôle l’identité de cette connexion avant chaque
+route de l’assistant. Un en-tête falsifié ou une erreur de routage ne peut donc
+pas autoriser un import sur `cerp_prod`.
+
+## Validation `cerp_test` du 2026-07-27
+
+Une copie fraîche de `cerp_prod` a été construite dans une base temporaire,
+vérifiée, patchée, puis renommée en `cerp_test`. L’ancienne base de test a été
+conservée sous le nom `cerp_test_pre_import_167_20260727_0050`, avec les
+connexions désactivées.
+
+Contrôles réalisés :
+
+- sauvegarde production vérifiée :
+  `/var/backups/cerp/cerp_prod_20260727-003748.dump`, 39 332 092 octets,
+  SHA-256 `9b88c29f37fe4a81f6370e7b89851976b9362c2524316e707106c911d7729707` ;
+- sauvegarde de l’ancienne base de test vérifiée :
+  `/var/backups/cerp/cerp_test_pre_refresh_20260727-0050.dump`,
+  39 333 368 octets,
+  SHA-256 `4e8d9d1bb8645fa4d4e2024ecfe81a2f9b809de98d6f45318ebee48ccde4b930` ;
+- égalité exacte des nombres de lignes et des empreintes de contenu de toutes
+  les tables entre la production sauvegardée et la copie, avant le patch ;
+- égalité des séquences et objets volumineux ;
+- preflight réussi, patch SHA-256
+  `2527f82ac3e816b3b1289d8a5ba11d4d77ed4532ff369c76ebcd13ef8f57689a`
+  appliqué et enregistré dans `cerp_schema_migrations` ;
+- tous les contrôles du script `verify` sont vrais ;
+- propriétaires, droits d’écriture et fonction de rétention vérifiés pour
+  `cerp_app` ;
+- smoke test transactionnel exécuté puis annulé, avec zéro ligne résiduelle ;
+- connexion réelle avec les identifiants applicatifs vers `cerp_test`
+  confirmée, sans exposer le secret ;
+- empreinte de contenu de `cerp_prod` inchangée avant et après l’opération.
+
+Ce premier clonage a révélé deux liens historiques orphelins dans
+`article_category_link`. Cet état a ensuite été corrigé par le patch #168,
+avant la reprise de l’intégration.
+
+## Reconstruction après corrections #168 et #169
+
+Le 2026-07-27, après réparation des deux liens orphelins et validation des trois
+références historiques vers `articles_fabrique`, `cerp_test` a été reconstruite
+une seconde fois depuis la production corrigée.
+
+- sauvegarde source :
+  `/var/backups/cerp/cerp_prod_20260727-020006.dump`,
+  39 332 474 octets, SHA-256
+  `84a63ded269c134a1ad83e6dc734d2afe0547809c276697cfa3e6f80aa6bed2b` ;
+- sauvegarde de la base de test remplacée :
+  `/var/backups/cerp/cerp_test_pre_refresh_168_169_20260727-0200.dump`,
+  39 375 039 octets, SHA-256
+  `5fdb2ce53b4b665c68fdf799653f0a920db194dad23027d7f695f81d23f68f5f` ;
+- ancienne base conservée sous
+  `cerp_test_pre_import_167_168_169_20260727_0200`, connexions désactivées ;
+- égalité exacte des volumes et empreintes des 303 tables entre `cerp_prod` et
+  la nouvelle `cerp_test` avant réapplication du patch #167 ;
+- patch #167 réappliqué avec l’empreinte
+  `2527f82ac3e816b3b1289d8a5ba11d4d77ed4532ff369c76ebcd13ef8f57689a`
+  et enregistré dans `cerp_schema_migrations` ;
+- vérification structurelle complète réussie ;
+- connexion réelle du rôle applicatif `cerp_app`, droits d’écriture et droit
+  d’exécution de la fonction de rétention confirmés sans exposer le secret ;
+- smoke test du lot, d’une ligne, du crosswalk et de l’idempotence entièrement
+  annulé, avec zéro résidu ;
+- aucune clé étrangère publique non validée et aucun lien de catégorie
+  d’article orphelin.

--- a/docs/route-param-hardening-170.md
+++ b/docs/route-param-hardening-170.md
@@ -1,0 +1,28 @@
+# Durcissement des paramètres de route — issue #170
+
+## Problème
+
+Après la mise à jour de la branche d’intégration, les paramètres nommés
+d’Express sont typés `string | string[]`. Onze appels des contrôleurs Gammes et
+Versions transmettaient directement cette union à des services qui exigent une
+chaîne, ce qui bloquait la compilation TypeScript.
+
+Les validateurs de routes contrôlaient déjà les UUID à l’exécution, mais cette
+garantie n’était pas reflétée dans les contrôleurs.
+
+## Correction
+
+Chaque contrôleur extrait désormais le paramètre nommé avec une vérification
+défensive :
+
+- seule une chaîne non vide est acceptée ;
+- une valeur absente, vide ou multiple produit une erreur HTTP 400
+  `INVALID_ROUTE_PARAM` ;
+- les services continuent de recevoir exactement une chaîne ;
+- aucune règle métier, route ou donnée n’est modifiée.
+
+## Validation
+
+- compilation TypeScript complète ;
+- tests `gammes.test.ts` ;
+- tests `pieces-techniques-versions.test.ts`.

--- a/src/__tests__/import-assistant.domain.test.ts
+++ b/src/__tests__/import-assistant.domain.test.ts
@@ -1,0 +1,130 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { IMPORT_CAPABILITIES } from "../module/import-assistant/domain/import-capabilities";
+import {
+  assertImportAssistantDatabase,
+  IMPORT_ASSISTANT_DATABASE,
+} from "../module/import-assistant/domain/import-database-guard";
+import {
+  importRowDedupeKeys,
+  normalizeImportRow,
+  validateMapping,
+} from "../module/import-assistant/domain/import-normalization";
+import { parseTabularFile } from "../module/import-assistant/domain/tabular-file-parser";
+import type { ImportMapping } from "../module/import-assistant/types/import-assistant.types";
+
+function uploadFile(name: string, body: string) {
+  const buffer = Buffer.from(body, "utf8");
+  return {
+    originalname: name,
+    mimetype: "text/csv",
+    buffer,
+    size: buffer.byteLength,
+  } as Express.Multer.File;
+}
+
+describe("Assistant d’import CLIPPER", () => {
+  it("lit les CSV français avec guillemets, séparateurs et lignes vides", () => {
+    const parsed = parseTabularFile(uploadFile(
+      "FOURNISSEUR.csv",
+      "\uFEFFCODE;NOM;NOTE\r\nF001;Atelier Alpha;\"Usinage; contrôle\"\r\n\r\n"
+    ));
+
+    expect(parsed.sheets).toHaveLength(1);
+    expect(parsed.sheets[0].headers).toEqual(["CODE", "NOM", "NOTE"]);
+    expect(parsed.sheets[0].rows).toEqual([
+      { CODE: "F001", NOM: "Atelier Alpha", NOTE: "Usinage; contrôle" },
+    ]);
+  });
+
+  it("refuse un format qui ne passe pas par le parseur contrôlé", () => {
+    expect(() => parseTabularFile(uploadFile("legacy.xls", "CODE\tNOM"))).toThrow(
+      "Format refusé"
+    );
+  });
+
+  it("exige la référence CLIPPER et tous les champs obligatoires", () => {
+    const mapping: ImportMapping = {
+      legacy_key_column: "",
+      columns: { company_name: "NOM" },
+      constants: {},
+      approved_decisions: [],
+      duplicate_strategy: "REVIEW",
+    };
+
+    const issues = validateMapping("CLIENT", ["CODE", "NOM"], mapping);
+
+    expect(issues.map((issue) => issue.code)).toContain("LEGACY_KEY_REQUIRED");
+    expect(issues.map((issue) => issue.field)).toContain("status");
+    expect(issues.map((issue) => issue.field)).toContain("bill_address.street");
+  });
+
+  it("normalise les booléens et conserve les clés fortes de dédoublonnage", () => {
+    const mapping: ImportMapping = {
+      legacy_key_column: "CODE",
+      columns: {
+        name: "NOM",
+        type: "TYPE",
+        serial_number: "SERIE",
+        scheduling_enabled: "PLANIFIABLE",
+      },
+      constants: {},
+      approved_decisions: ["DEC-07", "DEC-14", "DEC-15"],
+      duplicate_strategy: "LINK_EXACT",
+    };
+    const result = normalizeImportRow(
+      "MACHINE",
+      {
+        CODE: "MC-12",
+        NOM: "DMG MORI 1",
+        TYPE: "MILLING",
+        SERIE: "SN-00012",
+        PLANIFIABLE: "oui",
+      },
+      mapping
+    );
+
+    expect(result.issues).toEqual([]);
+    expect(result.legacy_key).toBe("MC-12");
+    expect(result.normalized_data).toMatchObject({ scheduling_enabled: true });
+    expect(importRowDedupeKeys("MACHINE", result.normalized_data!)).toEqual({
+      siret: null,
+      secondary: "SN-00012",
+    });
+  });
+
+  it("garde stock, BL et RH visibles mais impossibles à confirmer", () => {
+    const gated = IMPORT_CAPABILITIES.filter((capability) =>
+      ["STOCK_INITIAL", "BL_HISTORIQUE", "EMPLOYE"].includes(capability.entity_type)
+    );
+
+    expect(gated).toHaveLength(3);
+    expect(gated.every((capability) => !capability.confirm_enabled)).toBe(true);
+    expect(gated.every((capability) => capability.unavailable_reason)).toBe(true);
+  });
+
+  it("verrouille toutes les routes sur la connexion réelle cerp_test", () => {
+    expect(IMPORT_ASSISTANT_DATABASE).toBe("cerp_test");
+    expect(() => assertImportAssistantDatabase("cerp_test")).not.toThrow();
+    expect(() => assertImportAssistantDatabase("cerp_prod")).toThrow(
+      "verrouillé sur la base de validation cerp_test"
+    );
+    expect(() => assertImportAssistantDatabase(undefined)).toThrow(
+      "verrouillé sur la base de validation cerp_test"
+    );
+  });
+
+  it("garde la migration additive, idempotente et soumise à rétention", () => {
+    const patch = fs.readFileSync(
+      path.resolve(process.cwd(), "db/patches/20260726_import_assistant_167.sql"),
+      "utf8"
+    );
+    expect(patch).toContain("data_import_crosswalk_source_uq");
+    expect(patch).toContain("data_import_confirm_idempotency");
+    expect(patch).toContain("fn_purge_expired_import_staging");
+    expect(patch).toContain("retention_until date NOT NULL DEFAULT (CURRENT_DATE + 90)");
+    expect(patch).not.toMatch(/\bDROP\s+(TABLE|COLUMN|SCHEMA)\b/i);
+  });
+});

--- a/src/module/fournisseurs/repository/fournisseurs.repository.ts
+++ b/src/module/fournisseurs/repository/fournisseurs.repository.ts
@@ -563,10 +563,33 @@ async function insertAdresse(tx: DbQueryer, fournisseurId: string, body: CreateA
   return res.rows[0]?.id ?? null
 }
 
-export async function repoCreateFournisseur(body: CreateFournisseurBodyDTO, audit: AuditContext): Promise<Fournisseur> {
+export async function repoCreateFournisseur(
+  body: CreateFournisseurBodyDTO,
+  audit: AuditContext,
+  idempotencyKey?: string | null
+): Promise<Fournisseur> {
   const client = await db.connect()
+  const requestHash = crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex")
   try {
     await client.query("BEGIN")
+    if (idempotencyKey) {
+      const replay = await client.query<{ fournisseur_id: string; request_hash: string }>(
+        `SELECT fournisseur_id::text AS fournisseur_id, request_hash
+         FROM public.fournisseur_create_idempotence
+         WHERE idempotency_key = $1
+         FOR UPDATE`,
+        [idempotencyKey]
+      )
+      if (replay.rows[0]) {
+        if (replay.rows[0].request_hash !== requestHash) {
+          throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Cette clé d’idempotence a déjà servi avec un autre fournisseur.")
+        }
+        await client.query("ROLLBACK")
+        const existing = await repoGetFournisseur(replay.rows[0].fournisseur_id)
+        if (!existing) throw new Error("Idempotent fournisseur no longer exists")
+        return existing
+      }
+    }
     const code = await generateFournisseurCode(client)
     const ins = await client.query<{ id: string }>(
       `INSERT INTO public.fournisseurs (
@@ -596,6 +619,14 @@ export async function repoCreateFournisseur(body: CreateFournisseurBodyDTO, audi
       for (const a of body.adresses) await insertAdresse(client, id, a, audit.user_id)
       await syncPrimaryAddressCache(client, id, audit.user_id)
     }
+    if (idempotencyKey) {
+      await client.query(
+        `INSERT INTO public.fournisseur_create_idempotence
+           (idempotency_key, request_hash, fournisseur_id)
+         VALUES ($1,$2,$3::uuid)`,
+        [idempotencyKey, requestHash, id]
+      )
+    }
 
     await insertEvent(client, id, audit.user_id, { event_type: "created", title: `Fournisseur ${code} créé` })
     await insertAuditLog(client, audit, {
@@ -608,6 +639,18 @@ export async function repoCreateFournisseur(body: CreateFournisseurBodyDTO, audi
     return created
   } catch (err) {
     await client.query("ROLLBACK")
+    const code = (err as { code?: unknown } | null)?.code
+    if (idempotencyKey && code === "23505") {
+      const replay = await db.query<{ fournisseur_id: string; request_hash: string }>(
+        `SELECT fournisseur_id::text AS fournisseur_id, request_hash
+         FROM public.fournisseur_create_idempotence WHERE idempotency_key = $1`,
+        [idempotencyKey]
+      )
+      if (replay.rows[0]?.request_hash === requestHash) {
+        const existing = await repoGetFournisseur(replay.rows[0].fournisseur_id)
+        if (existing) return existing
+      }
+    }
     throw err
   } finally {
     client.release()

--- a/src/module/fournisseurs/services/fournisseurs.service.ts
+++ b/src/module/fournisseurs/services/fournisseurs.service.ts
@@ -30,9 +30,13 @@ export const findDoublonsSVC = (filters: DoublonQueryDTO) => repo.repoFindDoublo
 
 const SIRET_TVA_CONFLICT = "Un fournisseur avec ce SIRET ou cette TVA existe déjà"
 
-export async function createFournisseurSVC(body: CreateFournisseurBodyDTO, audit: AuditContext) {
+export async function createFournisseurSVC(
+  body: CreateFournisseurBodyDTO,
+  audit: AuditContext,
+  idempotencyKey?: string | null
+) {
   try {
-    return await repo.repoCreateFournisseur(body, audit)
+    return await repo.repoCreateFournisseur(body, audit, idempotencyKey)
   } catch (err) {
     repo.assertNoUniqueViolation(err, SIRET_TVA_CONFLICT)
     throw err

--- a/src/module/gammes/controllers/gammes.controller.ts
+++ b/src/module/gammes/controllers/gammes.controller.ts
@@ -44,9 +44,17 @@ function buildAuditContext(req: Request): AuditContext {
   }
 }
 
+function routeParam(req: Request, name: string): string {
+  const value = req.params[name]
+  if (typeof value !== "string" || value.length === 0) {
+    throw new HttpError(400, "INVALID_ROUTE_PARAM", `Paramètre de route invalide : ${name}`)
+  }
+  return value
+}
+
 export const listGammesByVersion: RequestHandler = async (req, res, next) => {
   try {
-    const items = await listGammesByVersionSVC(req.params.versionId)
+    const items = await listGammesByVersionSVC(routeParam(req, "versionId"))
     res.json(items)
   } catch (err) {
     next(err)
@@ -57,7 +65,7 @@ export const createGamme: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = createGammeSchema.parse({ body: req.body }).body
-    const out = await createGammeSVC(req.params.versionId, body, audit)
+    const out = await createGammeSVC(routeParam(req, "versionId"), body, audit)
     res.status(201).json(out)
   } catch (err) {
     next(err)
@@ -68,7 +76,7 @@ export const updateGamme: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = updateGammeSchema.parse({ body: req.body }).body
-    const out = await updateGammeSVC(req.params.gammeId, body, audit)
+    const out = await updateGammeSVC(routeParam(req, "gammeId"), body, audit)
     if (!out) throw new HttpError(404, "NOT_FOUND", "Gamme introuvable")
     res.json(out)
   } catch (err) {
@@ -78,7 +86,7 @@ export const updateGamme: RequestHandler = async (req, res, next) => {
 
 export const listGammeOperations: RequestHandler = async (req, res, next) => {
   try {
-    const items = await listGammeOperationsSVC(req.params.gammeId)
+    const items = await listGammeOperationsSVC(routeParam(req, "gammeId"))
     res.json(items)
   } catch (err) {
     next(err)
@@ -89,7 +97,7 @@ export const addGammeOperation: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = addGammeOperationSchema.parse({ body: req.body }).body
-    const out = await addGammeOperationSVC(req.params.gammeId, body, audit)
+    const out = await addGammeOperationSVC(routeParam(req, "gammeId"), body, audit)
     res.status(201).json(out)
   } catch (err) {
     next(err)
@@ -100,7 +108,7 @@ export const reorderGammeOperations: RequestHandler = async (req, res, next) => 
   try {
     const audit = buildAuditContext(req)
     const body = reorderOperationsSchema.parse({ body: req.body }).body
-    const out = await reorderGammeOperationsSVC(req.params.gammeId, body.order, audit)
+    const out = await reorderGammeOperationsSVC(routeParam(req, "gammeId"), body.order, audit)
     res.json(out)
   } catch (err) {
     next(err)

--- a/src/module/import-assistant/controllers/import-assistant.controller.ts
+++ b/src/module/import-assistant/controllers/import-assistant.controller.ts
@@ -1,0 +1,133 @@
+import type { Request, RequestHandler } from "express";
+
+import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import { stripQueryFromUrl } from "../../../utils/logPath";
+import { HttpError } from "../../../utils/httpError";
+import * as service from "../services/import-assistant.service";
+import {
+  confirmImportBatchSchema,
+  createImportBatchFieldsSchema,
+  importBatchIdSchema,
+  listImportBatchesQuerySchema,
+  listImportRowsQuerySchema,
+  previewImportBatchSchema,
+} from "../validators/import-assistant.validators";
+import type { ImportAuditContext } from "../types/import-assistant.types";
+
+function auditContext(req: Request): ImportAuditContext {
+  if (!req.user || typeof req.user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  const userAgent = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null;
+  const device = parseDevice(userAgent);
+  return {
+    user_id: req.user.id,
+    ip: getClientIp(req),
+    user_agent: userAgent,
+    device_type: device.device_type,
+    os: device.os,
+    browser: device.browser,
+    path: stripQueryFromUrl(req.originalUrl),
+    page_key: typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : "import-assistant",
+    client_session_id:
+      typeof req.headers["x-client-session-id"] === "string"
+        ? req.headers["x-client-session-id"]
+        : typeof req.headers["x-session-id"] === "string"
+          ? req.headers["x-session-id"]
+          : null,
+  };
+}
+
+function uploadedFile(req: Request): Express.Multer.File {
+  if (!req.file) throw new HttpError(400, "IMPORT_FILE_REQUIRED", "Sélectionnez un fichier .xlsx ou .csv.");
+  return req.file;
+}
+
+export const getCapabilities: RequestHandler = (_req, res) => {
+  res.json({ items: service.listImportCapabilities() });
+};
+
+export const postBatch: RequestHandler = async (req, res, next) => {
+  try {
+    const fields = createImportBatchFieldsSchema.parse(req.body);
+    const result = await service.createImportBatch({
+      ...fields,
+      file: uploadedFile(req),
+      audit: auditContext(req),
+    });
+    res.status(result.reused ? 200 : 201).json(result);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getBatches: RequestHandler = async (req, res, next) => {
+  try {
+    const query = listImportBatchesQuerySchema.parse(req.query);
+    res.json(await service.listImportBatches(query));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getBatch: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = importBatchIdSchema.parse(req.params);
+    res.json(await service.getImportBatch(id));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getBatchRows: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = importBatchIdSchema.parse(req.params);
+    const query = listImportRowsQuerySchema.parse(req.query);
+    res.json(await service.listImportRows({ id, ...query }));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const putBatchPreview: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = importBatchIdSchema.parse(req.params);
+    const mapping = previewImportBatchSchema.parse(req.body);
+    res.json(await service.previewImportBatch({ id, mapping, audit: auditContext(req) }));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const postBatchConfirm: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = importBatchIdSchema.parse(req.params);
+    const body = confirmImportBatchSchema.parse(req.body);
+    const rawKey = req.headers["idempotency-key"];
+    const idempotencyKey = typeof rawKey === "string" ? rawKey.trim() : "";
+    if (idempotencyKey.length < 8 || idempotencyKey.length > 200) {
+      throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "Une clé Idempotency-Key stable de 8 à 200 caractères est requise.");
+    }
+    const result = await service.confirmImportBatch({
+      id,
+      expected_preview_hash: body.expected_preview_hash,
+      idempotency_key: idempotencyKey,
+      audit: auditContext(req),
+    });
+    res.status(result.replayed ? 200 : 202).json(result.response);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getBatchReport: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = importBatchIdSchema.parse(req.params);
+    const report = await service.buildImportReportCsv(id);
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader("Content-Disposition", `attachment; filename="${report.filename}"`);
+    res.send(report.csv);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/module/import-assistant/domain/import-capabilities.ts
+++ b/src/module/import-assistant/domain/import-capabilities.ts
@@ -1,0 +1,151 @@
+import type { ImportDecisionGate, ImportEntityCapability, ImportTargetField } from "../types/import-assistant.types";
+
+const DECISIONS: Record<string, ImportDecisionGate> = {
+  "DEC-01": { id: "DEC-01", label: "Mapping CODENATURE vers les catégories CERP", responsible: "Méthodes + Achats", evidence: "Échantillon d’articles validé" },
+  "DEC-02": { id: "DEC-02", label: "Référence plan et indice des pièces", responsible: "Méthodes", evidence: "Plans et documents vérifiés" },
+  "DEC-03": { id: "DEC-03", label: "Domaines et types fournisseurs", responsible: "Achats", evidence: "Activité, commandes et articles vérifiés" },
+  "DEC-04": { id: "DEC-04", label: "Clients actifs à enrichir en priorité", responsible: "Commerce", evidence: "Top clients et activité récente" },
+  "DEC-05": { id: "DEC-05", label: "Magasins et emplacements d’ouverture", responsible: "Production + Stock", evidence: "Plan d’implantation" },
+  "DEC-06": { id: "DEC-06", label: "Date de cut-off de l’inventaire", responsible: "Direction + Stock", evidence: "PV de bascule" },
+  "DEC-07": { id: "DEC-07", label: "Inventaire des machines CNC et de leur état", responsible: "Production + Maintenance", evidence: "Fiches terrain" },
+  "DEC-09": { id: "DEC-09", label: "Salariés actifs et correspondances utilisateurs", responsible: "RH", evidence: "Liste du personnel actuelle" },
+  "DEC-12": { id: "DEC-12", label: "Conservation des données RH", responsible: "RH + RGPD", evidence: "Politique de rétention" },
+  "DEC-13": { id: "DEC-13", label: "Sort des BL historiques et ouverts", responsible: "Commerce + Logistique", evidence: "Liste des BL réellement ouverts" },
+  "DEC-14": { id: "DEC-14", label: "Champs CLIPPER absents de CERP", responsible: "Product Owner", evidence: "Backlog extension ou archive" },
+  "DEC-15": { id: "DEC-15", label: "Spécification de l’assistant d’import", responsible: "Product + Architecture + Sécurité", evidence: "Issues #301 et #167" },
+  "DEC-16": { id: "DEC-16", label: "Flux article fabriqué vers réception et stock", responsible: "Production + Qualité + Stock", evidence: "Test E2E pilote" },
+};
+
+const field = (
+  key: string,
+  label: string,
+  kind: ImportTargetField["kind"],
+  options: Omit<ImportTargetField, "key" | "label" | "kind"> = {}
+): ImportTargetField => ({ key, label, kind, ...options });
+
+const commonOptional = {
+  email: field("email", "E-mail", "text"),
+  phone: field("phone", "Téléphone", "text"),
+  notes: field("notes", "Notes", "text", { sensitive: true }),
+};
+
+const CLIENT_FIELDS: ImportTargetField[] = [
+  field("company_name", "Raison sociale", "text", { required: true }),
+  commonOptional.email,
+  commonOptional.phone,
+  field("website_url", "Site internet", "text"),
+  field("siret", "SIRET", "text"),
+  field("vat_number", "N° TVA", "text"),
+  field("naf_code", "Code NAF", "text"),
+  field("status", "Statut", "enum", { required: true, values: ["prospect", "client", "inactif"] }),
+  field("blocked", "Bloqué", "boolean", { required: true }),
+  field("reason", "Motif de blocage", "text"),
+  field("creation_date", "Date de création", "date", { required: true }),
+  field("bill_address.name", "Nom adresse de facturation", "text", { required: true }),
+  field("bill_address.street", "Rue de facturation", "text", { required: true }),
+  field("bill_address.house_number", "N° de facturation", "text"),
+  field("bill_address.address_complement", "Complément de facturation", "text"),
+  field("bill_address.postal_code", "Code postal de facturation", "text", { required: true }),
+  field("bill_address.city", "Ville de facturation", "text", { required: true }),
+  field("bill_address.country", "Pays de facturation", "text", { required: true }),
+  field("delivery_address.name", "Nom adresse de livraison", "text", { required: true }),
+  field("delivery_address.street", "Rue de livraison", "text", { required: true }),
+  field("delivery_address.house_number", "N° de livraison", "text"),
+  field("delivery_address.address_complement", "Complément de livraison", "text"),
+  field("delivery_address.postal_code", "Code postal de livraison", "text", { required: true }),
+  field("delivery_address.city", "Ville de livraison", "text", { required: true }),
+  field("delivery_address.country", "Pays de livraison", "text", { required: true }),
+  field("observations", "Observations", "text", { sensitive: true }),
+  field("devise", "Devise ISO", "text"),
+  field("encours_max", "Encours maximum", "number", { sensitive: true }),
+  field("incoterm", "Incoterm", "enum", { values: ["EXW", "FCA", "CPT", "CIP", "DAP", "DPU", "DDP", "FAS", "FOB", "CFR", "CIF"] }),
+  field("langue", "Langue ISO", "text"),
+];
+
+const FOURNISSEUR_FIELDS: ImportTargetField[] = [
+  field("nom", "Raison sociale", "text", { required: true }),
+  field("actif", "Actif", "boolean"),
+  field("status", "Statut", "enum", { values: ["actif", "a_completer", "inactif", "archive"] }),
+  field("type_principal", "Type principal", "text"),
+  field("domaines", "Domaines fournisseurs", "list", { hint: "Codes séparés par ;" }),
+  field("tva", "N° TVA", "text"),
+  field("siret", "SIRET", "text"),
+  commonOptional.email,
+  field("telephone", "Téléphone", "text"),
+  field("site_web", "Site internet", "text"),
+  field("nom_commercial", "Nom commercial", "text"),
+  commonOptional.notes,
+  field("adresse.type", "Type d’adresse", "enum", { values: ["commande", "livraison", "facturation"] }),
+  field("adresse.label", "Libellé d’adresse", "text"),
+  field("adresse.ligne1", "Adresse", "text"),
+  field("adresse.ligne2", "Complément d’adresse", "text"),
+  field("adresse.house_no", "N°", "text"),
+  field("adresse.postcode", "Code postal", "text"),
+  field("adresse.city", "Ville", "text"),
+  field("adresse.country", "Pays", "text"),
+];
+
+const ARTICLE_FIELDS: ImportTargetField[] = [
+  field("designation", "Désignation", "text", { required: true }),
+  field("designation_secondary", "Désignation secondaire", "text"),
+  field("article_category", "Catégorie", "enum", { required: true, values: ["fabrique", "matiere", "traitement", "achat"] }),
+  field("article_categories", "Catégories métier", "list", { hint: "Valeurs séparées par ;" }),
+  field("family_code", "Code famille CERP", "text", { required: true }),
+  field("status", "Statut", "enum", { values: ["EN_DEVIS", "VALIDE"] }),
+  field("stock_managed", "Géré en stock", "boolean"),
+  field("piece_technique_id", "ID pièce technique CERP", "uuid", { hint: "Obligatoire pour un article fabriqué" }),
+  field("unite", "Unité", "text"),
+  field("lot_tracking", "Suivi par lot", "boolean"),
+  field("is_sold", "Vendu", "boolean"),
+  field("is_active", "Actif", "boolean"),
+  commonOptional.notes,
+];
+
+const PIECE_FIELDS: ImportTargetField[] = [
+  field("client_id", "Code client CERP", "text", { required: true }),
+  field("famille_id", "Famille de pièce CERP", "uuid", { required: true }),
+  field("name_piece", "Nom de pièce", "text", { required: true }),
+  field("designation", "Désignation", "text", { required: true }),
+  field("designation_2", "Désignation secondaire", "text"),
+  field("plan_reference", "Référence plan", "text", { required: true }),
+  field("indice_externe", "Indice externe", "text"),
+  field("sans_indice", "Sans indice", "boolean"),
+  field("motif_modification", "Motif de création", "text"),
+  field("date_effet", "Date d’effet", "date"),
+  field("prix_unitaire", "Prix unitaire", "number", { sensitive: true }),
+  field("statut", "Statut", "enum", { values: ["DRAFT", "ACTIVE", "IN_FABRICATION", "OBSOLETE"] }),
+  field("cycle", "Cycle", "number"),
+  field("cycle_fabrication", "Cycle de fabrication", "number"),
+  field("ensemble", "Ensemble", "boolean"),
+];
+
+const MACHINE_FIELDS: ImportTargetField[] = [
+  field("name", "Nom de la machine", "text", { required: true }),
+  field("type", "Type", "enum", { required: true, values: ["MILLING", "TURNING", "EDM", "GRINDING", "OTHER"] }),
+  field("display_name", "Nom affiché", "text"),
+  field("brand", "Marque", "text"),
+  field("model", "Modèle", "text"),
+  field("serial_number", "N° de série", "text"),
+  field("commissioned_year", "Année de mise en service", "number"),
+  field("status", "État", "enum", { values: ["ACTIVE", "IN_MAINTENANCE", "OUT_OF_SERVICE"] }),
+  field("scheduling_enabled", "Planifiable", "boolean"),
+  field("outillage_enabled", "Outillage activé", "boolean"),
+  field("location", "Emplacement", "text"),
+  field("workshop_zone", "Zone atelier", "text"),
+  commonOptional.notes,
+];
+
+export const IMPORT_CAPABILITIES: ImportEntityCapability[] = [
+  { entity_type: "CLIENT", label: "Clients", order: 10, confirm_enabled: true, unavailable_reason: null, fields: CLIENT_FIELDS, decisions: [DECISIONS["DEC-04"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
+  { entity_type: "FOURNISSEUR", label: "Fournisseurs", order: 20, confirm_enabled: true, unavailable_reason: null, fields: FOURNISSEUR_FIELDS, decisions: [DECISIONS["DEC-03"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
+  { entity_type: "PIECE_TECHNIQUE", label: "Pièces techniques", order: 30, confirm_enabled: true, unavailable_reason: null, fields: PIECE_FIELDS, decisions: [DECISIONS["DEC-02"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
+  { entity_type: "ARTICLE", label: "Articles", order: 40, confirm_enabled: true, unavailable_reason: null, fields: ARTICLE_FIELDS, decisions: [DECISIONS["DEC-01"], DECISIONS["DEC-14"], DECISIONS["DEC-15"], DECISIONS["DEC-16"]] },
+  { entity_type: "MACHINE", label: "Machines CNC", order: 50, confirm_enabled: true, unavailable_reason: null, fields: MACHINE_FIELDS, decisions: [DECISIONS["DEC-07"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
+  { entity_type: "STOCK_INITIAL", label: "Stock d’ouverture", order: 60, confirm_enabled: false, unavailable_reason: "Le stock doit passer par un inventaire ou des mouvements d’ouverture contrôlés ; les magasins, emplacements et le cut-off doivent être renseignés.", fields: [], decisions: [DECISIONS["DEC-05"], DECISIONS["DEC-06"], DECISIONS["DEC-15"], DECISIONS["DEC-16"]] },
+  { entity_type: "BL_HISTORIQUE", label: "BL historiques", order: 70, confirm_enabled: false, unavailable_reason: "Le sort des BL ouverts et historiques doit être décidé avant toute écriture.", fields: [], decisions: [DECISIONS["DEC-13"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
+  { entity_type: "EMPLOYE", label: "Salariés", order: 80, confirm_enabled: false, unavailable_reason: "L’import RH reste fermé tant que le périmètre, les correspondances utilisateurs et la rétention ne sont pas documentés.", fields: [], decisions: [DECISIONS["DEC-09"], DECISIONS["DEC-12"], DECISIONS["DEC-15"]] },
+];
+
+export function getImportCapability(entityType: string): ImportEntityCapability | null {
+  return IMPORT_CAPABILITIES.find((capability) => capability.entity_type === entityType) ?? null;
+}

--- a/src/module/import-assistant/domain/import-database-guard.ts
+++ b/src/module/import-assistant/domain/import-database-guard.ts
@@ -1,0 +1,13 @@
+import { HttpError } from "../../../utils/httpError";
+
+export const IMPORT_ASSISTANT_DATABASE = "cerp_test";
+
+export function assertImportAssistantDatabase(database: string | null | undefined): void {
+  if (database !== IMPORT_ASSISTANT_DATABASE) {
+    throw new HttpError(
+      409,
+      "IMPORT_TEST_DATABASE_REQUIRED",
+      "L’assistant d’import est verrouillé sur la base de validation cerp_test."
+    );
+  }
+}

--- a/src/module/import-assistant/domain/import-normalization.ts
+++ b/src/module/import-assistant/domain/import-normalization.ts
@@ -1,0 +1,228 @@
+import type { ZodIssue, ZodTypeAny } from "zod";
+
+import { createClientSchema } from "../../client/validators/client.validators";
+import { createFournisseurSchema } from "../../fournisseurs/validators/fournisseurs.validators";
+import { createPieceTechniqueSchema } from "../../pieces-techniques/validators/pieces-techniques.validators";
+import { createMachineSchema } from "../../production/validators/production.validators";
+import { createArticleSchema } from "../../stock/validators/stock.validators";
+import { getImportCapability } from "./import-capabilities";
+import type {
+  ImportEntityType,
+  ImportFieldKind,
+  ImportIssue,
+  ImportMapping,
+  ImportTargetField,
+} from "../types/import-assistant.types";
+
+type NormalizedResult = {
+  legacy_key: string | null;
+  normalized_data: Record<string, unknown> | null;
+  issues: ImportIssue[];
+};
+
+function hasOwn(record: Record<string, unknown>, key: string) {
+  return Object.prototype.hasOwnProperty.call(record, key);
+}
+
+function setPath(target: Record<string, unknown>, path: string, value: unknown) {
+  const parts = path.split(".");
+  let cursor = target;
+  for (let index = 0; index < parts.length - 1; index += 1) {
+    const part = parts[index];
+    const next = cursor[part];
+    if (!next || typeof next !== "object" || Array.isArray(next)) cursor[part] = {};
+    cursor = cursor[part] as Record<string, unknown>;
+  }
+  cursor[parts.at(-1)!] = value;
+}
+
+function getPath(target: Record<string, unknown>, path: string): unknown {
+  return path.split(".").reduce<unknown>((value, part) => {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return undefined;
+    return (value as Record<string, unknown>)[part];
+  }, target);
+}
+
+function normalizeBoolean(value: unknown): boolean | unknown {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value !== 0;
+  if (typeof value !== "string") return value;
+  const normalized = value.trim().toLowerCase();
+  if (["1", "true", "vrai", "oui", "o", "yes", "y", "x"].includes(normalized)) return true;
+  if (["0", "false", "faux", "non", "n", "no", ""].includes(normalized)) return false;
+  return value;
+}
+
+function normalizeNumber(value: unknown): number | unknown {
+  if (typeof value === "number") return value;
+  if (typeof value !== "string") return value;
+  const normalized = value.trim().replace(/\s/g, "").replace(",", ".");
+  if (!normalized) return undefined;
+  const parsed = Number(normalized);
+  return Number.isFinite(parsed) ? parsed : value;
+}
+
+function normalizeDate(value: unknown): string | unknown {
+  if (typeof value !== "string") return value;
+  const trimmed = value.trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed;
+  const french = /^(\d{1,2})[\/.-](\d{1,2})[\/.-](\d{4})$/.exec(trimmed);
+  if (french) return `${french[3]}-${french[2].padStart(2, "0")}-${french[1].padStart(2, "0")}`;
+  return value;
+}
+
+function normalizeValue(value: unknown, kind: ImportFieldKind): unknown {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "string" && value.trim() === "") return undefined;
+  if (kind === "boolean") return normalizeBoolean(value);
+  if (kind === "number") return normalizeNumber(value);
+  if (kind === "date") return normalizeDate(value);
+  if (kind === "list") {
+    if (Array.isArray(value)) return value.map((item) => String(item).trim()).filter(Boolean);
+    return String(value).split(/[;|]/).map((item) => item.trim()).filter(Boolean);
+  }
+  return typeof value === "string" ? value.trim() : value;
+}
+
+function sourceValue(
+  row: Record<string, unknown>,
+  mapping: ImportMapping,
+  targetField: ImportTargetField
+): unknown {
+  if (hasOwn(mapping.constants, targetField.key)) return mapping.constants[targetField.key];
+  const sourceColumn = mapping.columns[targetField.key];
+  return sourceColumn ? row[sourceColumn] : undefined;
+}
+
+function issueFromZod(issue: ZodIssue, row: Record<string, unknown>, mapping: ImportMapping, fields: ImportTargetField[]): ImportIssue {
+  const field = issue.path.filter((part) => part !== "body").join(".");
+  const definition = fields.find((candidate) => candidate.key === field);
+  const sourceColumn = definition ? mapping.columns[definition.key] : null;
+  const source = sourceColumn ? row[sourceColumn] : undefined;
+  return {
+    code: issue.code.toUpperCase(),
+    message: issue.message,
+    field: field || null,
+    ...(source !== undefined ? { source_value: definition?.sensitive ? "[MASQUÉ]" : source } : {}),
+  };
+}
+
+function entitySchema(entityType: ImportEntityType): { schema: ZodTypeAny; wrapped: boolean } | null {
+  switch (entityType) {
+    case "CLIENT":
+      return { schema: createClientSchema, wrapped: false };
+    case "FOURNISSEUR":
+      return { schema: createFournisseurSchema, wrapped: true };
+    case "ARTICLE":
+      return { schema: createArticleSchema, wrapped: true };
+    case "PIECE_TECHNIQUE":
+      return { schema: createPieceTechniqueSchema, wrapped: true };
+    case "MACHINE":
+      return { schema: createMachineSchema, wrapped: true };
+    default:
+      return null;
+  }
+}
+
+function postProcess(entityType: ImportEntityType, draft: Record<string, unknown>) {
+  if (entityType === "FOURNISSEUR") {
+    const domaines = draft.domaines;
+    if (Array.isArray(domaines)) {
+      draft.domaines = domaines.map((domaine, index) => ({
+        domaine_code: String(domaine),
+        is_primary: index === 0,
+      }));
+    }
+    const address = draft.adresse;
+    if (address && typeof address === "object" && !Array.isArray(address)) {
+      const values = Object.values(address as Record<string, unknown>).filter((value) => value !== undefined);
+      if (values.length > 0) draft.adresses = [address];
+      delete draft.adresse;
+    }
+  }
+  if (entityType === "CLIENT") {
+    draft.payment_mode_ids = [];
+    draft.quality_levels = [];
+    draft.contacts = [];
+  }
+}
+
+export function validateMapping(entityType: ImportEntityType, headers: string[], mapping: ImportMapping): ImportIssue[] {
+  const capability = getImportCapability(entityType);
+  if (!capability) return [{ code: "ENTITY_UNSUPPORTED", message: "Type d’entité inconnu.", field: null }];
+  const headerSet = new Set(headers);
+  const issues: ImportIssue[] = [];
+  if (!mapping.legacy_key_column || !headerSet.has(mapping.legacy_key_column)) {
+    issues.push({ code: "LEGACY_KEY_REQUIRED", message: "Choisissez la colonne de référence CLIPPER.", field: "legacy_key_column" });
+  }
+  for (const [target, source] of Object.entries(mapping.columns)) {
+    if (!capability.fields.some((field) => field.key === target)) {
+      issues.push({ code: "UNKNOWN_TARGET_FIELD", message: `Champ cible inconnu : ${target}`, field: target });
+    }
+    if (source && !headerSet.has(source)) {
+      issues.push({ code: "UNKNOWN_SOURCE_COLUMN", message: `Colonne source absente : ${source}`, field: target });
+    }
+  }
+  for (const field of capability.fields.filter((candidate) => candidate.required)) {
+    if (!mapping.columns[field.key] && !hasOwn(mapping.constants, field.key)) {
+      issues.push({ code: "REQUIRED_MAPPING", message: `Le champ « ${field.label} » doit être mappé ou recevoir une valeur fixe.`, field: field.key });
+    }
+  }
+  return issues;
+}
+
+export function normalizeImportRow(
+  entityType: ImportEntityType,
+  row: Record<string, unknown>,
+  mapping: ImportMapping
+): NormalizedResult {
+  const capability = getImportCapability(entityType);
+  if (!capability) return { legacy_key: null, normalized_data: null, issues: [{ code: "ENTITY_UNSUPPORTED", message: "Type d’entité inconnu.", field: null }] };
+  const legacyRaw = row[mapping.legacy_key_column];
+  const legacyKey = legacyRaw === null || legacyRaw === undefined ? "" : String(legacyRaw).trim();
+  const issues: ImportIssue[] = [];
+  if (!legacyKey) issues.push({ code: "LEGACY_KEY_EMPTY", message: "La référence CLIPPER est vide.", field: "legacy_key" });
+
+  const draft: Record<string, unknown> = {};
+  for (const targetField of capability.fields) {
+    const value = normalizeValue(sourceValue(row, mapping, targetField), targetField.kind);
+    if (value !== undefined) setPath(draft, targetField.key, value);
+  }
+  postProcess(entityType, draft);
+
+  const schemaDefinition = entitySchema(entityType);
+  if (!schemaDefinition) {
+    return {
+      legacy_key: legacyKey || null,
+      normalized_data: null,
+      issues: [...issues, { code: "CONFIRMATION_DISABLED", message: capability.unavailable_reason ?? "Confirmation indisponible.", field: null }],
+    };
+  }
+  const candidate = schemaDefinition.wrapped ? { body: draft } : draft;
+  const parsed = schemaDefinition.schema.safeParse(candidate);
+  if (!parsed.success) {
+    issues.push(...parsed.error.issues.map((issue) => issueFromZod(issue, row, mapping, capability.fields)));
+    return { legacy_key: legacyKey || null, normalized_data: draft, issues };
+  }
+  const normalized = schemaDefinition.wrapped
+    ? ((parsed.data as { body: Record<string, unknown> }).body)
+    : (parsed.data as Record<string, unknown>);
+  return { legacy_key: legacyKey || null, normalized_data: normalized, issues };
+}
+
+export function importRowDedupeKeys(entityType: ImportEntityType, normalized: Record<string, unknown>) {
+  const stringAt = (path: string) => {
+    const value = getPath(normalized, path);
+    return typeof value === "string" && value.trim() ? value.trim() : null;
+  };
+  switch (entityType) {
+    case "CLIENT":
+      return { siret: stringAt("siret"), secondary: stringAt("vat_number") };
+    case "FOURNISSEUR":
+      return { siret: stringAt("siret"), secondary: stringAt("tva") };
+    case "MACHINE":
+      return { siret: null, secondary: stringAt("serial_number") };
+    default:
+      return { siret: null, secondary: null };
+  }
+}

--- a/src/module/import-assistant/domain/tabular-file-parser.ts
+++ b/src/module/import-assistant/domain/tabular-file-parser.ts
@@ -1,0 +1,289 @@
+import path from "node:path";
+import { inflateRawSync } from "node:zlib";
+
+import { HttpError } from "../../../utils/httpError";
+import type { ParsedTabularFile, ParsedTabularSheet } from "../types/import-assistant.types";
+
+const MAX_ROWS = 100_000;
+const MAX_COLUMNS = 300;
+const MAX_UNCOMPRESSED_BYTES = 64 * 1024 * 1024;
+const MAX_SHEETS = 50;
+
+type ZipEntry = { name: string; compression: number; compressedSize: number; uncompressedSize: number; dataOffset: number };
+
+function decodeXml(value: string): string {
+  return value
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, "&")
+    .replace(/&#(\d+);/g, (_match, code: string) => String.fromCodePoint(Number(code)))
+    .replace(/&#x([0-9a-f]+);/gi, (_match, code: string) => String.fromCodePoint(Number.parseInt(code, 16)));
+}
+
+function parseZipEntries(buffer: Buffer): Map<string, ZipEntry> {
+  let eocd = -1;
+  const min = Math.max(0, buffer.length - 65_557);
+  for (let offset = buffer.length - 22; offset >= min; offset -= 1) {
+    if (buffer.readUInt32LE(offset) === 0x06054b50) {
+      eocd = offset;
+      break;
+    }
+  }
+  if (eocd < 0) throw new HttpError(400, "INVALID_XLSX", "Le fichier Excel n’est pas une archive XLSX valide.");
+
+  const entryCount = buffer.readUInt16LE(eocd + 10);
+  const centralOffset = buffer.readUInt32LE(eocd + 16);
+  const entries = new Map<string, ZipEntry>();
+  let offset = centralOffset;
+  let expandedTotal = 0;
+
+  for (let index = 0; index < entryCount; index += 1) {
+    if (offset + 46 > buffer.length || buffer.readUInt32LE(offset) !== 0x02014b50) {
+      throw new HttpError(400, "INVALID_XLSX", "Le répertoire interne du classeur est invalide.");
+    }
+    const compression = buffer.readUInt16LE(offset + 10);
+    const compressedSize = buffer.readUInt32LE(offset + 20);
+    const uncompressedSize = buffer.readUInt32LE(offset + 24);
+    const nameLength = buffer.readUInt16LE(offset + 28);
+    const extraLength = buffer.readUInt16LE(offset + 30);
+    const commentLength = buffer.readUInt16LE(offset + 32);
+    const localOffset = buffer.readUInt32LE(offset + 42);
+    const name = buffer.subarray(offset + 46, offset + 46 + nameLength).toString("utf8").replace(/\\/g, "/");
+
+    if (offset + 46 + nameLength + extraLength + commentLength > buffer.length) {
+      throw new HttpError(400, "INVALID_XLSX", "Une entrée du classeur dépasse la taille du fichier.");
+    }
+    if (name.startsWith("/") || name.includes("../")) {
+      throw new HttpError(400, "INVALID_XLSX_PATH", "Le classeur contient un chemin interne interdit.");
+    }
+    expandedTotal += uncompressedSize;
+    if (expandedTotal > MAX_UNCOMPRESSED_BYTES) {
+      throw new HttpError(413, "XLSX_EXPANDED_TOO_LARGE", "Le contenu décompressé du classeur dépasse 64 Mo.");
+    }
+    if (compressedSize > 0 && uncompressedSize / compressedSize > 200) {
+      throw new HttpError(400, "XLSX_COMPRESSION_RATIO", "Le taux de compression du classeur est anormal.");
+    }
+
+    if (localOffset + 30 > buffer.length || buffer.readUInt32LE(localOffset) !== 0x04034b50) {
+      throw new HttpError(400, "INVALID_XLSX", "Une entrée locale du classeur est invalide.");
+    }
+    const fileNameLength = buffer.readUInt16LE(localOffset + 26);
+    const localExtraLength = buffer.readUInt16LE(localOffset + 28);
+    const dataOffset = localOffset + 30 + fileNameLength + localExtraLength;
+    if (dataOffset + compressedSize > buffer.length) {
+      throw new HttpError(400, "INVALID_XLSX", "Le contenu d’une entrée du classeur est tronqué.");
+    }
+    entries.set(name, { name, compression, compressedSize, uncompressedSize, dataOffset });
+    offset += 46 + nameLength + extraLength + commentLength;
+  }
+  return entries;
+}
+
+function readZipEntry(buffer: Buffer, entries: Map<string, ZipEntry>, name: string): Buffer {
+  const entry = entries.get(name);
+  if (!entry) throw new HttpError(400, "INVALID_XLSX_PART", `Partie XLSX manquante : ${name}`);
+  const compressed = buffer.subarray(entry.dataOffset, entry.dataOffset + entry.compressedSize);
+  if (entry.compression === 0) return compressed;
+  if (entry.compression === 8) {
+    const expanded = inflateRawSync(compressed, { maxOutputLength: Math.min(entry.uncompressedSize + 1024, MAX_UNCOMPRESSED_BYTES) });
+    if (expanded.length !== entry.uncompressedSize) {
+      throw new HttpError(400, "INVALID_XLSX_SIZE", "La taille décompressée du classeur est incohérente.");
+    }
+    return expanded;
+  }
+  throw new HttpError(400, "UNSUPPORTED_XLSX_COMPRESSION", "Le classeur utilise une compression Excel non prise en charge.");
+}
+
+function columnIndex(cellRef: string): number {
+  const letters = /^[A-Z]+/i.exec(cellRef)?.[0]?.toUpperCase() ?? "";
+  let index = 0;
+  for (const letter of letters) index = index * 26 + (letter.charCodeAt(0) - 64);
+  return Math.max(0, index - 1);
+}
+
+function uniqueHeaders(values: unknown[]): string[] {
+  const seen = new Map<string, number>();
+  return values.map((value, index) => {
+    const raw = String(value ?? "").trim() || `COLONNE_${index + 1}`;
+    const count = (seen.get(raw) ?? 0) + 1;
+    seen.set(raw, count);
+    return count === 1 ? raw : `${raw}_${count}`;
+  });
+}
+
+function parseSharedStrings(xml: string): string[] {
+  const values: string[] = [];
+  for (const match of xml.matchAll(/<si\b[^>]*>([\s\S]*?)<\/si>/g)) {
+    const parts = [...match[1].matchAll(/<t\b[^>]*>([\s\S]*?)<\/t>/g)].map((part) => decodeXml(part[1]));
+    values.push(parts.join(""));
+  }
+  return values;
+}
+
+function parseDateStyleIndexes(stylesXml: string | null): Set<number> {
+  if (!stylesXml) return new Set();
+  const customFormats = new Map<number, string>();
+  for (const match of stylesXml.matchAll(/<numFmt\b[^>]*numFmtId="(\d+)"[^>]*formatCode="([^"]*)"[^>]*\/?>/g)) {
+    customFormats.set(Number(match[1]), decodeXml(match[2]));
+  }
+  const dateStyles = new Set<number>();
+  const cellXfs = /<cellXfs\b[^>]*>([\s\S]*?)<\/cellXfs>/.exec(stylesXml)?.[1] ?? "";
+  let index = 0;
+  for (const match of cellXfs.matchAll(/<xf\b([^>]*)\/?>/g)) {
+    const numFmtId = Number(/numFmtId="(\d+)"/.exec(match[1])?.[1] ?? 0);
+    const format = customFormats.get(numFmtId) ?? "";
+    if ((numFmtId >= 14 && numFmtId <= 22) || /[ymdhis]/i.test(format.replace(/\[[^\]]+\]/g, ""))) {
+      dateStyles.add(index);
+    }
+    index += 1;
+  }
+  return dateStyles;
+}
+
+function excelDate(serial: number): string {
+  const epoch = Date.UTC(1899, 11, 30);
+  return new Date(epoch + serial * 86_400_000).toISOString().slice(0, 10);
+}
+
+function parseSheetXml(
+  name: string,
+  xml: string,
+  sharedStrings: string[],
+  dateStyles: Set<number>
+): ParsedTabularSheet {
+  const matrix: unknown[][] = [];
+  for (const rowMatch of xml.matchAll(/<row\b[^>]*>([\s\S]*?)<\/row>/g)) {
+    if (matrix.length >= MAX_ROWS + 1) throw new HttpError(413, "TOO_MANY_ROWS", `La feuille ${name} dépasse ${MAX_ROWS} lignes.`);
+    const row: unknown[] = [];
+    for (const cellMatch of rowMatch[1].matchAll(/<c\b([^>]*)>([\s\S]*?)<\/c>/g)) {
+      const attrs = cellMatch[1];
+      const content = cellMatch[2];
+      const ref = /\br="([^"]+)"/.exec(attrs)?.[1] ?? `A${matrix.length + 1}`;
+      const index = columnIndex(ref);
+      if (index >= MAX_COLUMNS) throw new HttpError(413, "TOO_MANY_COLUMNS", `La feuille ${name} dépasse ${MAX_COLUMNS} colonnes.`);
+      const type = /\bt="([^"]+)"/.exec(attrs)?.[1] ?? "n";
+      const styleIndex = Number(/\bs="(\d+)"/.exec(attrs)?.[1] ?? -1);
+      const raw = /<v\b[^>]*>([\s\S]*?)<\/v>/.exec(content)?.[1] ?? "";
+      const inline = /<is\b[^>]*>([\s\S]*?)<\/is>/.exec(content)?.[1] ?? "";
+      let value: unknown = null;
+      if (type === "s") value = sharedStrings[Number(raw)] ?? "";
+      else if (type === "inlineStr") value = [...inline.matchAll(/<t\b[^>]*>([\s\S]*?)<\/t>/g)].map((m) => decodeXml(m[1])).join("");
+      else if (type === "b") value = raw === "1";
+      else if (type === "str" || type === "e") value = decodeXml(raw);
+      else if (raw !== "") {
+        const number = Number(raw);
+        value = Number.isFinite(number) ? (dateStyles.has(styleIndex) ? excelDate(number) : number) : decodeXml(raw);
+      }
+      row[index] = value;
+    }
+    matrix.push(row);
+  }
+  const headerRow = matrix.shift() ?? [];
+  const headers = uniqueHeaders(headerRow);
+  const rows = matrix
+    .filter((row) => row.some((value) => value !== null && String(value).trim() !== ""))
+    .map((row) => Object.fromEntries(headers.map((header, index) => [header, (row[index] ?? null) as string | number | boolean | null])));
+  return { name, headers, rows };
+}
+
+function resolvePart(base: string, target: string): string {
+  const normalized = path.posix.normalize(path.posix.join(path.posix.dirname(base), target));
+  if (normalized.startsWith("../") || normalized.startsWith("/")) throw new HttpError(400, "INVALID_XLSX_PATH", "Chemin de feuille XLSX interdit.");
+  return normalized;
+}
+
+function parseXlsx(buffer: Buffer): ParsedTabularFile {
+  const entries = parseZipEntries(buffer);
+  const workbookPath = entries.has("xl/workbook.xml") ? "xl/workbook.xml" : "";
+  if (!workbookPath) throw new HttpError(400, "INVALID_XLSX", "Le classeur ne contient pas xl/workbook.xml.");
+  const workbookXml = readZipEntry(buffer, entries, workbookPath).toString("utf8");
+  const relsPath = "xl/_rels/workbook.xml.rels";
+  const relsXml = readZipEntry(buffer, entries, relsPath).toString("utf8");
+  const rels = new Map<string, string>();
+  for (const match of relsXml.matchAll(/<Relationship\b([^>]*)\/?>/g)) {
+    const id = /\bId="([^"]+)"/.exec(match[1])?.[1];
+    const target = /\bTarget="([^"]+)"/.exec(match[1])?.[1];
+    if (id && target) rels.set(id, resolvePart(workbookPath, decodeXml(target)));
+  }
+
+  const sharedStrings = entries.has("xl/sharedStrings.xml")
+    ? parseSharedStrings(readZipEntry(buffer, entries, "xl/sharedStrings.xml").toString("utf8"))
+    : [];
+  const dateStyles = parseDateStyleIndexes(
+    entries.has("xl/styles.xml") ? readZipEntry(buffer, entries, "xl/styles.xml").toString("utf8") : null
+  );
+  const sheets: ParsedTabularSheet[] = [];
+  for (const match of workbookXml.matchAll(/<sheet\b([^>]*)\/?>/g)) {
+    if (sheets.length >= MAX_SHEETS) throw new HttpError(413, "TOO_MANY_SHEETS", `Le classeur dépasse ${MAX_SHEETS} feuilles.`);
+    const name = decodeXml(/\bname="([^"]+)"/.exec(match[1])?.[1] ?? `Feuille ${sheets.length + 1}`);
+    const relationId = /\br:id="([^"]+)"/.exec(match[1])?.[1];
+    const sheetPath = relationId ? rels.get(relationId) : null;
+    if (!sheetPath || !entries.has(sheetPath)) continue;
+    sheets.push(parseSheetXml(name, readZipEntry(buffer, entries, sheetPath).toString("utf8"), sharedStrings, dateStyles));
+  }
+  if (sheets.length === 0) throw new HttpError(400, "EMPTY_WORKBOOK", "Le classeur ne contient aucune feuille lisible.");
+  return { sheets };
+}
+
+function decodeCsvBuffer(buffer: Buffer): string {
+  const utf8 = new TextDecoder("utf-8", { fatal: false }).decode(buffer);
+  if (!utf8.includes("\uFFFD")) return utf8.replace(/^\uFEFF/, "");
+  return new TextDecoder("windows-1252").decode(buffer).replace(/^\uFEFF/, "");
+}
+
+function detectDelimiter(firstLine: string): string {
+  const candidates = [";", ",", "\t"];
+  return candidates
+    .map((delimiter) => ({ delimiter, count: firstLine.split(delimiter).length }))
+    .sort((a, b) => b.count - a.count)[0]?.delimiter ?? ";";
+}
+
+function parseCsv(buffer: Buffer, name: string): ParsedTabularFile {
+  const text = decodeCsvBuffer(buffer);
+  const delimiter = detectDelimiter(text.split(/\r?\n/, 1)[0] ?? "");
+  const rows: string[][] = [];
+  let row: string[] = [];
+  let value = "";
+  let quoted = false;
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index];
+    if (quoted) {
+      if (char === '"' && text[index + 1] === '"') {
+        value += '"';
+        index += 1;
+      } else if (char === '"') quoted = false;
+      else value += char;
+      continue;
+    }
+    if (char === '"') quoted = true;
+    else if (char === delimiter) {
+      row.push(value);
+      value = "";
+    } else if (char === "\n") {
+      row.push(value.replace(/\r$/, ""));
+      rows.push(row);
+      row = [];
+      value = "";
+      if (rows.length > MAX_ROWS + 1) throw new HttpError(413, "TOO_MANY_ROWS", `Le fichier CSV dépasse ${MAX_ROWS} lignes.`);
+    } else value += char;
+  }
+  if (value !== "" || row.length > 0) {
+    row.push(value.replace(/\r$/, ""));
+    rows.push(row);
+  }
+  const headers = uniqueHeaders(rows.shift() ?? []);
+  if (headers.length > MAX_COLUMNS) throw new HttpError(413, "TOO_MANY_COLUMNS", `Le fichier CSV dépasse ${MAX_COLUMNS} colonnes.`);
+  const records = rows
+    .filter((values) => values.some((cell) => cell.trim() !== ""))
+    .map((values) => Object.fromEntries(headers.map((header, index) => [header, values[index]?.trim() || null])));
+  return { sheets: [{ name, headers, rows: records }] };
+}
+
+export function parseTabularFile(file: Express.Multer.File): ParsedTabularFile {
+  const extension = path.extname(file.originalname).toLowerCase();
+  if (extension === ".csv") return parseCsv(file.buffer, path.basename(file.originalname, extension));
+  if (extension === ".xlsx") return parseXlsx(file.buffer);
+  throw new HttpError(400, "UNSUPPORTED_IMPORT_FORMAT", "Format refusé. Utilisez un fichier .xlsx ou .csv.");
+}

--- a/src/module/import-assistant/repository/import-assistant.repository.ts
+++ b/src/module/import-assistant/repository/import-assistant.repository.ts
@@ -1,0 +1,592 @@
+import crypto from "node:crypto";
+
+import type { PoolClient } from "pg";
+
+import db from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import type {
+  ImportBatchRow,
+  ImportBatchStatus,
+  ImportBatchSummary,
+  ImportEntityType,
+  ImportIssue,
+  ImportMapping,
+  ImportRowAction,
+  ImportRowStatus,
+  ImportStoredRow,
+  ImportTargetResult,
+} from "../types/import-assistant.types";
+
+type DbQueryer = Pick<PoolClient, "query">;
+
+const EMPTY_SUMMARY: ImportBatchSummary = {
+  total: 0,
+  valid: 0,
+  blocked: 0,
+  duplicates: 0,
+  already_imported: 0,
+  imported: 0,
+  linked: 0,
+  failed: 0,
+};
+
+function mapSummary(value: unknown): ImportBatchSummary {
+  const source = value && typeof value === "object" && !Array.isArray(value) ? value as Record<string, unknown> : {};
+  const n = (key: keyof ImportBatchSummary) => Number(source[key] ?? 0) || 0;
+  return {
+    total: n("total"),
+    valid: n("valid"),
+    blocked: n("blocked"),
+    duplicates: n("duplicates"),
+    already_imported: n("already_imported"),
+    imported: n("imported"),
+    linked: n("linked"),
+    failed: n("failed"),
+  };
+}
+
+function mapBatch(row: Record<string, unknown>): ImportBatchRow {
+  return {
+    id: String(row.id),
+    entity_type: row.entity_type as ImportEntityType,
+    status: row.status as ImportBatchStatus,
+    source_system: String(row.source_system),
+    source_name: String(row.source_name),
+    source_sha256: String(row.source_sha256),
+    source_size: Number(row.source_size),
+    source_mime: row.source_mime == null ? null : String(row.source_mime),
+    sheet_name: String(row.sheet_name),
+    headers: Array.isArray(row.headers) ? row.headers.map(String) : [],
+    mapping: row.mapping && typeof row.mapping === "object" ? row.mapping as ImportMapping : null,
+    preview_hash: row.preview_hash == null ? null : String(row.preview_hash),
+    summary: mapSummary(row.summary),
+    last_error: row.last_error == null ? null : String(row.last_error),
+    created_by: Number(row.created_by),
+    created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+    completed_at: row.completed_at == null ? null : String(row.completed_at),
+  };
+}
+
+function batchSelect() {
+  return `
+    SELECT
+      id::text AS id, source_system, entity_type, status, source_name, source_sha256,
+      source_size, source_mime, sheet_name, headers, mapping, preview_hash, summary,
+      last_error, created_by, created_at::text AS created_at, updated_at::text AS updated_at,
+      completed_at::text AS completed_at
+    FROM public.data_import_batches
+  `;
+}
+
+export async function repoFindBatchBySource(params: {
+  source_system: string;
+  entity_type: ImportEntityType;
+  source_sha256: string;
+  sheet_name: string;
+}): Promise<ImportBatchRow | null> {
+  const result = await db.query(
+    `${batchSelect()}
+     WHERE source_system = $1 AND entity_type = $2 AND source_sha256 = $3 AND sheet_name = $4
+     LIMIT 1`,
+    [params.source_system, params.entity_type, params.source_sha256, params.sheet_name]
+  );
+  return result.rows[0] ? mapBatch(result.rows[0]) : null;
+}
+
+export async function repoPurgeExpiredStaging(): Promise<number> {
+  const result = await db.query<{ affected: string }>(
+    "SELECT public.fn_purge_expired_import_staging()::text AS affected"
+  );
+  return Number(result.rows[0]?.affected ?? 0) || 0;
+}
+
+export async function repoCreateBatch(params: {
+  source_system: string;
+  entity_type: ImportEntityType;
+  source_name: string;
+  source_sha256: string;
+  source_size: number;
+  source_mime: string | null;
+  sheet_name: string;
+  headers: string[];
+  rows: Array<Record<string, unknown>>;
+  created_by: number;
+}): Promise<ImportBatchRow> {
+  const client = await db.connect();
+  const id = crypto.randomUUID();
+  try {
+    await client.query("BEGIN");
+    await client.query(
+      `INSERT INTO public.data_import_batches (
+         id, source_system, entity_type, status, source_name, source_sha256, source_size,
+         source_mime, sheet_name, headers, summary, created_by
+       ) VALUES ($1::uuid,$2,$3,'UPLOADED',$4,$5,$6,$7,$8,$9::jsonb,$10::jsonb,$11)`,
+      [
+        id,
+        params.source_system,
+        params.entity_type,
+        params.source_name,
+        params.source_sha256,
+        params.source_size,
+        params.source_mime,
+        params.sheet_name,
+        JSON.stringify(params.headers),
+        JSON.stringify({ ...EMPTY_SUMMARY, total: params.rows.length }),
+        params.created_by,
+      ]
+    );
+
+    for (let start = 0; start < params.rows.length; start += 1000) {
+      const chunk = params.rows.slice(start, start + 1000).map((source_data, index) => ({
+        row_number: start + index + 2,
+        source_data,
+      }));
+      await client.query(
+        `INSERT INTO public.data_import_rows (batch_id, row_number, source_data)
+         SELECT $1::uuid, x.row_number, x.source_data
+         FROM jsonb_to_recordset($2::jsonb) AS x(row_number integer, source_data jsonb)`,
+        [id, JSON.stringify(chunk)]
+      );
+    }
+    await client.query("COMMIT");
+    const created = await repoGetBatch(id);
+    if (!created) throw new Error("Failed to reload import batch");
+    return created;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoGetBatch(id: string): Promise<ImportBatchRow | null> {
+  const result = await db.query(`${batchSelect()} WHERE id = $1::uuid`, [id]);
+  return result.rows[0] ? mapBatch(result.rows[0]) : null;
+}
+
+export async function repoListBatches(params: {
+  entity_type?: ImportEntityType;
+  page: number;
+  pageSize: number;
+}): Promise<{ items: ImportBatchRow[]; total: number }> {
+  const where = params.entity_type ? "WHERE entity_type = $1" : "";
+  const baseValues: unknown[] = params.entity_type ? [params.entity_type] : [];
+  const count = await db.query<{ total: number }>(
+    `SELECT count(*)::int AS total FROM public.data_import_batches ${where}`,
+    baseValues
+  );
+  const limitIndex = baseValues.length + 1;
+  const offsetIndex = baseValues.length + 2;
+  const result = await db.query(
+    `${batchSelect()} ${where}
+     ORDER BY created_at DESC
+     LIMIT $${limitIndex} OFFSET $${offsetIndex}`,
+    [...baseValues, params.pageSize, (params.page - 1) * params.pageSize]
+  );
+  return { items: result.rows.map(mapBatch), total: count.rows[0]?.total ?? 0 };
+}
+
+export async function repoGetAllBatchRows(id: string): Promise<ImportStoredRow[]> {
+  const result = await db.query(
+    `SELECT id::text AS id, batch_id::text AS batch_id, row_number, legacy_key, source_data,
+            normalized_data, status, action, issues, target_id, target_code, attempts
+     FROM public.data_import_rows
+     WHERE batch_id = $1::uuid
+     ORDER BY row_number`,
+    [id]
+  );
+  return result.rows as ImportStoredRow[];
+}
+
+export async function repoListBatchRows(params: {
+  id: string;
+  status?: ImportRowStatus;
+  page: number;
+  pageSize: number;
+}): Promise<{ items: ImportStoredRow[]; total: number }> {
+  const values: unknown[] = [params.id];
+  const statusWhere = params.status ? ` AND status = $${values.push(params.status)}` : "";
+  const count = await db.query<{ total: number }>(
+    `SELECT count(*)::int AS total FROM public.data_import_rows WHERE batch_id = $1::uuid${statusWhere}`,
+    values
+  );
+  values.push(params.pageSize, (params.page - 1) * params.pageSize);
+  const result = await db.query(
+    `SELECT id::text AS id, batch_id::text AS batch_id, row_number, legacy_key, source_data,
+            normalized_data, status, action, issues, target_id, target_code, attempts
+     FROM public.data_import_rows
+     WHERE batch_id = $1::uuid${statusWhere}
+     ORDER BY row_number
+     LIMIT $${values.length - 1} OFFSET $${values.length}`,
+    values
+  );
+  return { items: result.rows as ImportStoredRow[], total: count.rows[0]?.total ?? 0 };
+}
+
+export type SimulatedRow = {
+  id: string;
+  legacy_key: string | null;
+  normalized_data: Record<string, unknown> | null;
+  status: ImportRowStatus;
+  action: ImportRowAction;
+  issues: ImportIssue[];
+  target_id: string | null;
+  target_code: string | null;
+};
+
+export async function repoSaveSimulation(params: {
+  batch_id: string;
+  mapping: ImportMapping;
+  preview_hash: string;
+  status: "SIMULATED" | "READY";
+  summary: ImportBatchSummary;
+  rows: SimulatedRow[];
+}) {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    for (let start = 0; start < params.rows.length; start += 1000) {
+      const chunk = params.rows.slice(start, start + 1000);
+      await client.query(
+        `UPDATE public.data_import_rows AS row
+         SET legacy_key = data.legacy_key,
+             normalized_data = data.normalized_data,
+             status = data.status,
+             action = data.action,
+             issues = data.issues,
+             target_id = data.target_id,
+             target_code = data.target_code,
+             attempts = 0,
+             processing_started_at = NULL,
+             updated_at = now()
+         FROM jsonb_to_recordset($2::jsonb) AS data(
+           id bigint, legacy_key text, normalized_data jsonb, status text, action text,
+           issues jsonb, target_id text, target_code text
+         )
+         WHERE row.batch_id = $1::uuid AND row.id = data.id`,
+        [params.batch_id, JSON.stringify(chunk)]
+      );
+    }
+    await client.query(
+      `UPDATE public.data_import_batches
+       SET mapping = $2::jsonb, preview_hash = $3, status = $4, summary = $5::jsonb,
+           last_error = NULL, completed_at = NULL, updated_at = now()
+       WHERE id = $1::uuid`,
+      [params.batch_id, JSON.stringify(params.mapping), params.preview_hash, params.status, JSON.stringify(params.summary)]
+    );
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoFindCrosswalks(params: {
+  source_system: string;
+  entity_type: ImportEntityType;
+  legacy_keys: string[];
+}): Promise<Map<string, ImportTargetResult>> {
+  if (params.legacy_keys.length === 0) return new Map();
+  const result = await db.query<{ legacy_key: string; target_id: string; target_code: string | null }>(
+    `SELECT legacy_key, target_id, target_code
+     FROM public.data_import_crosswalk
+     WHERE source_system = $1 AND entity_type = $2 AND legacy_key = ANY($3::text[])`,
+    [params.source_system, params.entity_type, params.legacy_keys]
+  );
+  return new Map(result.rows.map((row) => [row.legacy_key, { id: row.target_id, code: row.target_code }]));
+}
+
+export type StrongDedupeInput = { legacy_key: string; siret: string | null; secondary: string | null };
+
+export async function repoFindStrongDuplicates(
+  entityType: ImportEntityType,
+  inputs: StrongDedupeInput[]
+): Promise<Map<string, ImportTargetResult>> {
+  const strong = inputs.filter((input) => input.siret || input.secondary);
+  if (strong.length === 0) return new Map();
+  const sirets = [...new Set(strong.map((input) => input.siret).filter((value): value is string => Boolean(value)))];
+  const secondary = [...new Set(strong.map((input) => input.secondary?.toUpperCase()).filter((value): value is string => Boolean(value)))];
+  let rows: Array<{ target_id: string; target_code: string | null; siret: string | null; secondary: string | null }> = [];
+
+  if (entityType === "CLIENT") {
+    const result = await db.query(
+      `SELECT c.client_id::text AS target_id,
+              COALESCE(NULLIF(btrim(to_jsonb(c)->>'client_code'), ''), NULLIF(btrim(to_jsonb(c)->>'code_client'), '')) AS target_code,
+              c.siret, upper(c.vat_number) AS secondary
+       FROM public.clients c
+       WHERE ($1::text[] <> '{}' AND c.siret = ANY($1::text[]))
+          OR ($2::text[] <> '{}' AND upper(c.vat_number) = ANY($2::text[]))`,
+      [sirets, secondary]
+    );
+    rows = result.rows;
+  } else if (entityType === "FOURNISSEUR") {
+    const result = await db.query(
+      `SELECT f.id::text AS target_id, COALESCE(f.code, f.code_fournisseur) AS target_code,
+              f.siret, upper(f.tva) AS secondary
+       FROM public.fournisseurs f
+       WHERE ($1::text[] <> '{}' AND f.siret = ANY($1::text[]))
+          OR ($2::text[] <> '{}' AND upper(f.tva) = ANY($2::text[]))`,
+      [sirets, secondary]
+    );
+    rows = result.rows;
+  } else if (entityType === "MACHINE") {
+    const result = await db.query(
+      `SELECT m.id::text AS target_id, m.code AS target_code, NULL::text AS siret,
+              upper(m.serial_number) AS secondary
+       FROM public.machines m
+       WHERE $1::text[] <> '{}' AND upper(m.serial_number) = ANY($1::text[])`,
+      [secondary]
+    );
+    rows = result.rows;
+  }
+
+  const matches = new Map<string, ImportTargetResult>();
+  for (const input of strong) {
+    const target = rows.find((row) =>
+      (input.siret && row.siret === input.siret)
+      || (input.secondary && row.secondary === input.secondary.toUpperCase())
+    );
+    if (target) matches.set(input.legacy_key, { id: target.target_id, code: target.target_code });
+  }
+  return matches;
+}
+
+export async function repoStartBatchImport(params: {
+  id: string;
+  expected_preview_hash: string;
+  actor_user_id: number;
+  idempotency_key: string;
+  request_hash: string;
+}): Promise<{ replayed: boolean; response: Record<string, unknown> }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const replay = await client.query<{ request_hash: string; response_body: Record<string, unknown> }>(
+      `SELECT request_hash, response_body
+       FROM public.data_import_confirm_idempotency
+       WHERE actor_user_id = $1 AND idempotency_key = $2
+       FOR UPDATE`,
+      [params.actor_user_id, params.idempotency_key]
+    );
+    if (replay.rows[0]) {
+      if (replay.rows[0].request_hash !== params.request_hash) {
+        throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Cette clé d’idempotence a déjà servi avec une autre confirmation.");
+      }
+      await client.query("COMMIT");
+      return { replayed: true, response: replay.rows[0].response_body };
+    }
+
+    const batch = await client.query<{ status: ImportBatchStatus; preview_hash: string | null }>(
+      `SELECT status, preview_hash FROM public.data_import_batches WHERE id = $1::uuid FOR UPDATE`,
+      [params.id]
+    );
+    const current = batch.rows[0];
+    if (!current) throw new HttpError(404, "IMPORT_BATCH_NOT_FOUND", "Lot d’import introuvable.");
+    if (current.preview_hash !== params.expected_preview_hash) {
+      throw new HttpError(409, "IMPORT_PREVIEW_STALE", "La simulation a changé. Relancez-la avant de confirmer.");
+    }
+    if (!["READY", "IMPORTING", "COMPLETED", "COMPLETED_WITH_ERRORS"].includes(current.status)) {
+      throw new HttpError(409, "IMPORT_BATCH_NOT_READY", "Le lot doit être entièrement simulé et sans blocage avant confirmation.");
+    }
+    const response = { batch_id: params.id, status: current.status === "READY" ? "IMPORTING" : current.status };
+    if (current.status === "READY") {
+      await client.query(
+        `UPDATE public.data_import_batches SET status = 'IMPORTING', last_error = NULL, updated_at = now()
+         WHERE id = $1::uuid`,
+        [params.id]
+      );
+    }
+    await client.query(
+      `INSERT INTO public.data_import_confirm_idempotency
+         (actor_user_id, idempotency_key, batch_id, request_hash, response_status, response_body)
+       VALUES ($1,$2,$3::uuid,$4,202,$5::jsonb)`,
+      [params.actor_user_id, params.idempotency_key, params.id, params.request_hash, JSON.stringify(response)]
+    );
+    await client.query("COMMIT");
+    return { replayed: false, response };
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoResetInterruptedRows(batchId: string) {
+  await db.query(
+    `UPDATE public.data_import_rows
+     SET status = 'VALID', attempts = attempts + 1, processing_started_at = NULL, updated_at = now()
+     WHERE batch_id = $1::uuid AND status = 'PROCESSING'
+       AND processing_started_at < now() - interval '10 minutes'`,
+    [batchId]
+  );
+}
+
+export async function repoClaimNextRows(batchId: string, limit = 25): Promise<ImportStoredRow[]> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const claimed = await client.query(
+      `WITH next_rows AS (
+         SELECT id
+         FROM public.data_import_rows
+         WHERE batch_id = $1::uuid AND status = 'VALID'
+         ORDER BY row_number
+         FOR UPDATE SKIP LOCKED
+         LIMIT $2
+       )
+       UPDATE public.data_import_rows AS row
+       SET status = 'PROCESSING', processing_started_at = now(), attempts = attempts + 1, updated_at = now()
+       FROM next_rows
+       WHERE row.id = next_rows.id
+       RETURNING row.id::text AS id, row.batch_id::text AS batch_id, row.row_number, row.legacy_key,
+                 row.source_data, row.normalized_data, row.status, row.action, row.issues,
+                 row.target_id, row.target_code, row.attempts`,
+      [batchId, limit]
+    );
+    await client.query("COMMIT");
+    return claimed.rows as ImportStoredRow[];
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoUpsertCrosswalk(params: {
+  source_system: string;
+  entity_type: ImportEntityType;
+  legacy_key: string;
+  target_id: string;
+  target_code: string | null;
+  batch_id: string;
+  row_id: string;
+  linked_by: number;
+}) {
+  const inserted = await db.query(
+    `INSERT INTO public.data_import_crosswalk
+       (source_system, entity_type, legacy_key, target_id, target_code, batch_id, row_id, linked_by)
+     VALUES ($1,$2,$3,$4,$5,$6::uuid,$7,$8)
+     ON CONFLICT (source_system, entity_type, legacy_key) DO NOTHING
+     RETURNING target_id, target_code`,
+    [
+      params.source_system,
+      params.entity_type,
+      params.legacy_key,
+      params.target_id,
+      params.target_code,
+      params.batch_id,
+      params.row_id,
+      params.linked_by,
+    ]
+  );
+  if (inserted.rows[0]) return;
+  const existing = await db.query<{ target_id: string; target_code: string | null }>(
+    `SELECT target_id, target_code FROM public.data_import_crosswalk
+     WHERE source_system = $1 AND entity_type = $2 AND legacy_key = $3`,
+    [params.source_system, params.entity_type, params.legacy_key]
+  );
+  if (!existing.rows[0] || existing.rows[0].target_id !== params.target_id) {
+    throw new HttpError(409, "IMPORT_CROSSWALK_CONFLICT", "La référence CLIPPER est déjà reliée à une autre fiche CERP.");
+  }
+}
+
+export async function repoCompleteRow(params: {
+  row_id: string;
+  status: "IMPORTED" | "LINKED";
+  target_id: string;
+  target_code: string | null;
+}) {
+  await db.query(
+    `UPDATE public.data_import_rows
+     SET status = $2, target_id = $3, target_code = $4, issues = '[]'::jsonb,
+         processing_started_at = NULL, updated_at = now()
+     WHERE id = $1`,
+    [params.row_id, params.status, params.target_id, params.target_code]
+  );
+}
+
+export async function repoFailRow(rowId: string, issue: ImportIssue) {
+  await db.query(
+    `UPDATE public.data_import_rows
+     SET status = 'FAILED', issues = $2::jsonb, processing_started_at = NULL, updated_at = now()
+     WHERE id = $1`,
+    [rowId, JSON.stringify([issue])]
+  );
+}
+
+export async function repoFinishBatch(batchId: string) {
+  const counts = await db.query<{ status: ImportRowStatus; count: number }>(
+    `SELECT status, count(*)::int AS count
+     FROM public.data_import_rows WHERE batch_id = $1::uuid GROUP BY status`,
+    [batchId]
+  );
+  const byStatus = new Map(counts.rows.map((row) => [row.status, row.count]));
+  const summary: ImportBatchSummary = {
+    total: [...byStatus.values()].reduce((total, count) => total + count, 0),
+    valid: byStatus.get("VALID") ?? 0,
+    blocked: byStatus.get("BLOCKED") ?? 0,
+    duplicates: byStatus.get("DUPLICATE") ?? 0,
+    already_imported: byStatus.get("ALREADY_IMPORTED") ?? 0,
+    imported: byStatus.get("IMPORTED") ?? 0,
+    linked: byStatus.get("LINKED") ?? 0,
+    failed: byStatus.get("FAILED") ?? 0,
+  };
+  const failed = summary.failed > 0 || summary.blocked > 0 || summary.duplicates > 0;
+  await db.query(
+    `UPDATE public.data_import_batches
+     SET status = $2, summary = $3::jsonb, completed_at = now(), updated_at = now(),
+         last_error = CASE WHEN $4::boolean THEN 'Certaines lignes nécessitent une intervention.' ELSE NULL END
+     WHERE id = $1::uuid`,
+    [batchId, failed ? "COMPLETED_WITH_ERRORS" : "COMPLETED", JSON.stringify(summary), failed]
+  );
+  return summary;
+}
+
+export async function repoMarkBatchFailed(batchId: string, message: string) {
+  await db.query(
+    `UPDATE public.data_import_batches
+     SET status = 'FAILED', last_error = $2, updated_at = now()
+     WHERE id = $1::uuid`,
+    [batchId, message.slice(0, 2000)]
+  );
+}
+
+export async function repoReportRows(batchId: string): Promise<Array<{
+  row_number: number;
+  legacy_key: string | null;
+  status: ImportRowStatus;
+  action: ImportRowAction;
+  target_id: string | null;
+  target_code: string | null;
+  issues: ImportIssue[];
+}>> {
+  const result = await db.query(
+    `SELECT row_number, legacy_key, status, action, target_id, target_code, issues
+     FROM public.data_import_rows WHERE batch_id = $1::uuid ORDER BY row_number`,
+    [batchId]
+  );
+  return result.rows;
+}
+
+export async function repoInsertBatchAudit(
+  queryer: DbQueryer,
+  params: {
+    user_id: number;
+    action: string;
+    batch_id: string;
+    details: Record<string, unknown>;
+  }
+) {
+  await queryer.query(
+    `INSERT INTO public.erp_audit_logs
+       (user_id, event_type, action, page_key, entity_type, entity_id, path, details)
+     VALUES ($1,'ACTION',$2,'import-assistant','DATA_IMPORT_BATCH',$3,'/api/v1/import-assistant',$4::jsonb)`,
+    [params.user_id, params.action, params.batch_id, JSON.stringify(params.details)]
+  );
+}

--- a/src/module/import-assistant/routes/import-assistant.routes.ts
+++ b/src/module/import-assistant/routes/import-assistant.routes.ts
@@ -1,0 +1,49 @@
+import path from "node:path";
+
+import { Router, type RequestHandler } from "express";
+import multer from "multer";
+
+import pool from "../../../config/database";
+import { authorizeRole } from "../../auth/middlewares/auth.middleware";
+import { HttpError } from "../../../utils/httpError";
+import * as controller from "../controllers/import-assistant.controller";
+import { assertImportAssistantDatabase } from "../domain/import-database-guard";
+
+const router = Router();
+const requireImportAdmin = authorizeRole("Administrateur Systeme et Reseau", "Directeur");
+const requireImportTestDatabase: RequestHandler = async (_req, _res, next) => {
+  try {
+    const result = await pool.query<{ database: string }>(
+      "SELECT current_database() AS database"
+    );
+    assertImportAssistantDatabase(result.rows[0]?.database);
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { files: 1, fileSize: 25 * 1024 * 1024 },
+  fileFilter: (_req, file, callback) => {
+    const extension = path.extname(file.originalname).toLowerCase();
+    if (![".xlsx", ".csv"].includes(extension)) {
+      callback(new HttpError(400, "UNSUPPORTED_IMPORT_FORMAT", "Format refusé. Utilisez un fichier .xlsx ou .csv."));
+      return;
+    }
+    callback(null, true);
+  },
+});
+
+router.use(requireImportAdmin, requireImportTestDatabase);
+
+router.get("/capabilities", controller.getCapabilities);
+router.get("/batches", controller.getBatches);
+router.post("/batches", upload.single("file"), controller.postBatch);
+router.get("/batches/:id/report.csv", controller.getBatchReport);
+router.get("/batches/:id/rows", controller.getBatchRows);
+router.get("/batches/:id", controller.getBatch);
+router.put("/batches/:id/preview", controller.putBatchPreview);
+router.post("/batches/:id/confirm", controller.postBatchConfirm);
+
+export default router;

--- a/src/module/import-assistant/services/import-assistant.service.ts
+++ b/src/module/import-assistant/services/import-assistant.service.ts
@@ -1,0 +1,398 @@
+import crypto from "node:crypto";
+
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import { HttpError } from "../../../utils/httpError";
+import { getImportCapability, IMPORT_CAPABILITIES } from "../domain/import-capabilities";
+import { importRowDedupeKeys, normalizeImportRow, validateMapping } from "../domain/import-normalization";
+import { parseTabularFile } from "../domain/tabular-file-parser";
+import * as repo from "../repository/import-assistant.repository";
+import type {
+  ImportAuditContext,
+  ImportBatchRow,
+  ImportBatchSummary,
+  ImportEntityType,
+  ImportIssue,
+  ImportMapping,
+} from "../types/import-assistant.types";
+import { createImportTarget, importRowIdempotencyKey } from "./import-targets.service";
+
+function sha256(value: Buffer | string): string {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function safeError(error: unknown): ImportIssue {
+  if (error instanceof HttpError) {
+    return { code: error.code, message: error.message, field: null };
+  }
+  if (error instanceof Error) {
+    return { code: "IMPORT_ROW_FAILED", message: error.message.slice(0, 500), field: null };
+  }
+  return { code: "IMPORT_ROW_FAILED", message: "Erreur inconnue pendant l’import.", field: null };
+}
+
+async function auditBatch(
+  audit: ImportAuditContext,
+  action: string,
+  batchId: string,
+  details: Record<string, unknown>
+) {
+  await repoInsertAuditLog({
+    user_id: audit.user_id,
+    body: {
+      event_type: "ACTION",
+      action,
+      page_key: "import-assistant",
+      entity_type: "DATA_IMPORT_BATCH",
+      entity_id: batchId,
+      path: audit.path ?? "/api/v1/import-assistant",
+      client_session_id: audit.client_session_id,
+      details,
+    },
+    ip: audit.ip,
+    user_agent: audit.user_agent,
+    device_type: audit.device_type,
+    os: audit.os,
+    browser: audit.browser,
+  });
+}
+
+export function listImportCapabilities() {
+  return IMPORT_CAPABILITIES;
+}
+
+export async function createImportBatch(params: {
+  entity_type: ImportEntityType;
+  source_system: string;
+  sheet_name?: string;
+  file: Express.Multer.File;
+  audit: ImportAuditContext;
+}): Promise<{ batch: ImportBatchRow; reused: boolean; available_sheets: Array<{ name: string; rows: number }> }> {
+  await repo.repoPurgeExpiredStaging();
+  const capability = getImportCapability(params.entity_type);
+  if (!capability) throw new HttpError(400, "IMPORT_ENTITY_UNKNOWN", "Domaine d’import inconnu.");
+  if (!capability.confirm_enabled) {
+    throw new HttpError(409, "IMPORT_DOMAIN_GATED", capability.unavailable_reason ?? "Ce domaine est encore bloqué.");
+  }
+
+  const parsed = parseTabularFile(params.file);
+  const availableSheets = parsed.sheets.map((sheet) => ({ name: sheet.name, rows: sheet.rows.length }));
+  const selected = params.sheet_name
+    ? parsed.sheets.find((sheet) => sheet.name === params.sheet_name)
+    : parsed.sheets.find((sheet) => sheet.rows.length > 0) ?? parsed.sheets[0];
+  if (!selected) throw new HttpError(400, "IMPORT_SHEET_NOT_FOUND", "La feuille demandée n’existe pas dans le classeur.");
+  if (selected.rows.length === 0) throw new HttpError(400, "IMPORT_SHEET_EMPTY", "La feuille sélectionnée ne contient aucune ligne de données.");
+
+  const sourceHash = sha256(params.file.buffer);
+  const existing = await repo.repoFindBatchBySource({
+    source_system: params.source_system,
+    entity_type: params.entity_type,
+    source_sha256: sourceHash,
+    sheet_name: selected.name,
+  });
+  if (existing) return { batch: existing, reused: true, available_sheets: availableSheets };
+
+  const batch = await repo.repoCreateBatch({
+    source_system: params.source_system,
+    entity_type: params.entity_type,
+    source_name: params.file.originalname,
+    source_sha256: sourceHash,
+    source_size: params.file.size,
+    source_mime: params.file.mimetype || null,
+    sheet_name: selected.name,
+    headers: selected.headers,
+    rows: selected.rows,
+    created_by: params.audit.user_id,
+  });
+  await auditBatch(params.audit, "data-import.batch.create", batch.id, {
+    entity_type: batch.entity_type,
+    source_sha256: batch.source_sha256,
+    source_size: batch.source_size,
+    rows: batch.summary.total,
+    sheet_name: batch.sheet_name,
+  });
+  return { batch, reused: false, available_sheets: availableSheets };
+}
+
+export async function getImportBatch(id: string) {
+  const batch = await repo.repoGetBatch(id);
+  if (!batch) throw new HttpError(404, "IMPORT_BATCH_NOT_FOUND", "Lot d’import introuvable.");
+  const capability = getImportCapability(batch.entity_type);
+  const approved = new Set(batch.mapping?.approved_decisions ?? []);
+  return {
+    ...batch,
+    missing_decisions: (capability?.decisions ?? []).filter((decision) => !approved.has(decision.id)),
+  };
+}
+
+export async function listImportBatches(params: Parameters<typeof repo.repoListBatches>[0]) {
+  await repo.repoPurgeExpiredStaging();
+  return repo.repoListBatches(params);
+}
+
+export function listImportRows(params: Parameters<typeof repo.repoListBatchRows>[0]) {
+  return repo.repoListBatchRows(params);
+}
+
+export async function previewImportBatch(params: {
+  id: string;
+  mapping: ImportMapping;
+  audit: ImportAuditContext;
+}) {
+  const batch = await repo.repoGetBatch(params.id);
+  if (!batch) throw new HttpError(404, "IMPORT_BATCH_NOT_FOUND", "Lot d’import introuvable.");
+  if (["IMPORTING", "COMPLETED"].includes(batch.status)) {
+    throw new HttpError(409, "IMPORT_BATCH_LOCKED", "Ce lot est déjà en cours ou terminé.");
+  }
+  const capability = getImportCapability(batch.entity_type);
+  if (!capability?.confirm_enabled) {
+    throw new HttpError(409, "IMPORT_DOMAIN_GATED", capability?.unavailable_reason ?? "Ce domaine est bloqué.");
+  }
+  const mappingIssues = validateMapping(batch.entity_type, batch.headers, params.mapping);
+  if (mappingIssues.length > 0) {
+    throw new HttpError(422, "IMPORT_MAPPING_INVALID", "Le mapping est incomplet ou invalide.", mappingIssues);
+  }
+
+  const storedRows = await repo.repoGetAllBatchRows(batch.id);
+  const normalized = storedRows.map((stored) => ({
+    stored,
+    result: normalizeImportRow(batch.entity_type, stored.source_data, params.mapping),
+  }));
+  const legacyKeys = normalized.map((row) => row.result.legacy_key).filter((value): value is string => Boolean(value));
+  const crosswalk = await repo.repoFindCrosswalks({
+    source_system: batch.source_system,
+    entity_type: batch.entity_type,
+    legacy_keys: legacyKeys,
+  });
+  const strongDedupe = await repo.repoFindStrongDuplicates(
+    batch.entity_type,
+    normalized
+      .filter((row) => row.result.legacy_key && row.result.normalized_data)
+      .map((row) => ({
+        legacy_key: row.result.legacy_key!,
+        ...importRowDedupeKeys(batch.entity_type, row.result.normalized_data!),
+      }))
+  );
+
+  const simulated: repo.SimulatedRow[] = normalized.map(({ stored, result }) => {
+    const already = result.legacy_key ? crosswalk.get(result.legacy_key) : null;
+    if (already) {
+      return {
+        id: stored.id,
+        legacy_key: result.legacy_key,
+        normalized_data: result.normalized_data,
+        status: "ALREADY_IMPORTED",
+        action: "SKIP",
+        issues: [],
+        target_id: already.id,
+        target_code: already.code,
+      };
+    }
+    if (result.issues.length > 0 || !result.normalized_data || !result.legacy_key) {
+      return {
+        id: stored.id,
+        legacy_key: result.legacy_key,
+        normalized_data: result.normalized_data,
+        status: "BLOCKED",
+        action: "CREATE",
+        issues: result.issues,
+        target_id: null,
+        target_code: null,
+      };
+    }
+    const duplicate = strongDedupe.get(result.legacy_key);
+    if (duplicate) {
+      const link = params.mapping.duplicate_strategy === "LINK_EXACT";
+      return {
+        id: stored.id,
+        legacy_key: result.legacy_key,
+        normalized_data: result.normalized_data,
+        status: link ? "VALID" : "DUPLICATE",
+        action: link ? "LINK" : "SKIP",
+        issues: link ? [] : [{
+          code: "EXACT_DUPLICATE_REVIEW",
+          message: "Une fiche CERP porte déjà le même identifiant fort. Vérifiez-la avant de choisir le rapprochement automatique.",
+          field: null,
+        }],
+        target_id: duplicate.id,
+        target_code: duplicate.code,
+      };
+    }
+    return {
+      id: stored.id,
+      legacy_key: result.legacy_key,
+      normalized_data: result.normalized_data,
+      status: "VALID",
+      action: "CREATE",
+      issues: [],
+      target_id: null,
+      target_code: null,
+    };
+  });
+
+  const approved = new Set(params.mapping.approved_decisions);
+  const missingDecisions = capability.decisions.filter((decision) => !approved.has(decision.id));
+  const summary: ImportBatchSummary = {
+    total: simulated.length,
+    valid: simulated.filter((row) => row.status === "VALID").length,
+    blocked: simulated.filter((row) => row.status === "BLOCKED").length,
+    duplicates: simulated.filter((row) => row.status === "DUPLICATE").length,
+    already_imported: simulated.filter((row) => row.status === "ALREADY_IMPORTED").length,
+    imported: 0,
+    linked: 0,
+    failed: 0,
+  };
+  const ready = summary.blocked === 0 && summary.duplicates === 0 && missingDecisions.length === 0;
+  const previewHash = sha256(JSON.stringify({
+    batch_id: batch.id,
+    source_sha256: batch.source_sha256,
+    mapping: params.mapping,
+    rows: simulated.map((row) => ({
+      id: row.id,
+      legacy_key: row.legacy_key,
+      normalized_data: row.normalized_data,
+      status: row.status,
+      action: row.action,
+      target_id: row.target_id,
+    })),
+  }));
+  await repo.repoSaveSimulation({
+    batch_id: batch.id,
+    mapping: params.mapping,
+    preview_hash: previewHash,
+    status: ready ? "READY" : "SIMULATED",
+    summary,
+    rows: simulated,
+  });
+  await auditBatch(params.audit, "data-import.batch.preview", batch.id, {
+    entity_type: batch.entity_type,
+    summary,
+    missing_decisions: missingDecisions.map((decision) => decision.id),
+    preview_hash: previewHash,
+  });
+  return {
+    batch: await getImportBatch(batch.id),
+    preview_hash: previewHash,
+    summary,
+    missing_decisions: missingDecisions,
+    ready,
+  };
+}
+
+async function processBatch(batchId: string, audit: ImportAuditContext) {
+  const batch = await repo.repoGetBatch(batchId);
+  if (!batch || batch.status !== "IMPORTING") return;
+  try {
+    await repo.repoResetInterruptedRows(batchId);
+    while (true) {
+      const rows = await repo.repoClaimNextRows(batchId, 25);
+      if (rows.length === 0) break;
+      for (const row of rows) {
+        try {
+          if (!row.legacy_key) throw new HttpError(422, "LEGACY_KEY_EMPTY", "Référence CLIPPER vide.");
+          if (row.action === "LINK") {
+            if (!row.target_id) throw new HttpError(409, "IMPORT_LINK_TARGET_MISSING", "La fiche CERP à rapprocher est introuvable.");
+            await repo.repoUpsertCrosswalk({
+              source_system: batch.source_system,
+              entity_type: batch.entity_type,
+              legacy_key: row.legacy_key,
+              target_id: row.target_id,
+              target_code: row.target_code,
+              batch_id: batch.id,
+              row_id: row.id,
+              linked_by: audit.user_id,
+            });
+            await repo.repoCompleteRow({ row_id: row.id, status: "LINKED", target_id: row.target_id, target_code: row.target_code });
+            continue;
+          }
+          if (!row.normalized_data) throw new HttpError(422, "IMPORT_NORMALIZED_DATA_MISSING", "Données normalisées absentes.");
+          const idempotencyKey = importRowIdempotencyKey({
+            source_system: batch.source_system,
+            entity_type: batch.entity_type,
+            legacy_key: row.legacy_key,
+          });
+          const target = await createImportTarget({
+            entity_type: batch.entity_type,
+            normalized_data: row.normalized_data,
+            idempotency_key: idempotencyKey,
+            audit,
+          });
+          await repo.repoUpsertCrosswalk({
+            source_system: batch.source_system,
+            entity_type: batch.entity_type,
+            legacy_key: row.legacy_key,
+            target_id: target.id,
+            target_code: target.code,
+            batch_id: batch.id,
+            row_id: row.id,
+            linked_by: audit.user_id,
+          });
+          await repo.repoCompleteRow({ row_id: row.id, status: "IMPORTED", target_id: target.id, target_code: target.code });
+        } catch (error) {
+          await repo.repoFailRow(row.id, safeError(error));
+        }
+      }
+    }
+    const summary = await repo.repoFinishBatch(batchId);
+    await auditBatch(audit, "data-import.batch.complete", batchId, { entity_type: batch.entity_type, summary });
+  } catch (error) {
+    const issue = safeError(error);
+    await repo.repoMarkBatchFailed(batchId, `${issue.code}: ${issue.message}`);
+    try {
+      await auditBatch(audit, "data-import.batch.failed", batchId, { entity_type: batch.entity_type, error_code: issue.code });
+    } catch {
+      // The batch status is already persisted; audit failure must not hide it.
+    }
+  }
+}
+
+export async function confirmImportBatch(params: {
+  id: string;
+  expected_preview_hash: string;
+  idempotency_key: string;
+  audit: ImportAuditContext;
+}) {
+  const requestHash = sha256(JSON.stringify({
+    batch_id: params.id,
+    expected_preview_hash: params.expected_preview_hash,
+  }));
+  const result = await repo.repoStartBatchImport({
+    id: params.id,
+    expected_preview_hash: params.expected_preview_hash,
+    actor_user_id: params.audit.user_id,
+    idempotency_key: params.idempotency_key,
+    request_hash: requestHash,
+  });
+  if (!result.replayed && result.response.status === "IMPORTING") {
+    setImmediate(() => {
+      void processBatch(params.id, params.audit);
+    });
+  }
+  return result;
+}
+
+function csvCell(value: unknown): string {
+  const raw = value == null ? "" : typeof value === "string" ? value : JSON.stringify(value);
+  return `"${raw.replace(/"/g, '""')}"`;
+}
+
+export async function buildImportReportCsv(id: string): Promise<{ filename: string; csv: string }> {
+  const batch = await repo.repoGetBatch(id);
+  if (!batch) throw new HttpError(404, "IMPORT_BATCH_NOT_FOUND", "Lot d’import introuvable.");
+  const rows = await repo.repoReportRows(id);
+  const lines = [
+    ["ligne", "reference_clipper", "statut", "action", "id_cerp", "code_cerp", "erreurs"].map(csvCell).join(";"),
+    ...rows.map((row) => [
+      row.row_number,
+      row.legacy_key,
+      row.status,
+      row.action,
+      row.target_id,
+      row.target_code,
+      row.issues.map((issue) => `${issue.code}: ${issue.message}${issue.field ? ` [${issue.field}]` : ""}`).join(" | "),
+    ].map(csvCell).join(";")),
+  ];
+  return {
+    filename: `rapport-import-${batch.entity_type.toLowerCase()}-${batch.id}.csv`,
+    csv: `\uFEFF${lines.join("\r\n")}`,
+  };
+}

--- a/src/module/import-assistant/services/import-targets.service.ts
+++ b/src/module/import-assistant/services/import-targets.service.ts
@@ -1,0 +1,89 @@
+import crypto from "node:crypto";
+
+import { repoCreateClient, type AuditContext as ClientAuditContext } from "../../client/repository/client.repository";
+import type { CreateClientDTO } from "../../client/validators/client.validators";
+import { createFournisseurSVC } from "../../fournisseurs/services/fournisseurs.service";
+import type { CreateFournisseurBodyDTO } from "../../fournisseurs/validators/fournisseurs.validators";
+import { createPieceTechniqueSVC } from "../../pieces-techniques/services/pieces-techniques.service";
+import type { CreatePieceTechniqueBodyDTO } from "../../pieces-techniques/validators/pieces-techniques.validators";
+import { svcCreateMachine } from "../../production/services/production.service";
+import type { CreateMachineBodyDTO } from "../../production/validators/production.validators";
+import { createStockArticleSVC } from "../../stock/services/stock.service";
+import type { CreateArticleBodyDTO } from "../../stock/validators/stock.validators";
+import { HttpError } from "../../../utils/httpError";
+import type {
+  ImportAuditContext,
+  ImportEntityType,
+  ImportTargetResult,
+} from "../types/import-assistant.types";
+
+function deterministicUuid(input: string): string {
+  const bytes = crypto.createHash("sha256").update(input).digest().subarray(0, 16);
+  bytes[6] = (bytes[6] & 0x0f) | 0x50;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+export function importRowIdempotencyKey(params: {
+  source_system: string;
+  entity_type: ImportEntityType;
+  legacy_key: string;
+}): string {
+  return deterministicUuid(`${params.source_system}|${params.entity_type}|${params.legacy_key}`);
+}
+
+export async function createImportTarget(params: {
+  entity_type: ImportEntityType;
+  normalized_data: Record<string, unknown>;
+  idempotency_key: string;
+  audit: ImportAuditContext;
+}): Promise<ImportTargetResult> {
+  const audit = params.audit as ClientAuditContext;
+  switch (params.entity_type) {
+    case "CLIENT": {
+      const result = await repoCreateClient(
+        params.normalized_data as CreateClientDTO,
+        audit,
+        params.idempotency_key
+      );
+      return { id: result.client_id, code: result.client_code };
+    }
+    case "FOURNISSEUR": {
+      const result = await createFournisseurSVC(
+        params.normalized_data as CreateFournisseurBodyDTO,
+        audit,
+        params.idempotency_key
+      );
+    return { id: result.id, code: result.code ?? null };
+    }
+    case "ARTICLE": {
+      const result = await createStockArticleSVC(
+        params.normalized_data as CreateArticleBodyDTO,
+        audit,
+        params.idempotency_key,
+        false
+      );
+      return { id: result.id, code: result.code };
+    }
+    case "PIECE_TECHNIQUE": {
+      const result = await createPieceTechniqueSVC(
+        params.normalized_data as CreatePieceTechniqueBodyDTO,
+        audit,
+        params.idempotency_key
+      );
+      return { id: result.id, code: result.code_piece };
+    }
+    case "MACHINE": {
+      const result = await svcCreateMachine({
+        body: params.normalized_data as CreateMachineBodyDTO,
+        image_path: null,
+        idempotency_key: params.idempotency_key,
+        audit,
+      });
+      return { id: result.id, code: result.code };
+    }
+    default:
+      throw new HttpError(409, "IMPORT_TARGET_DISABLED", "Ce domaine n’est pas encore ouvert à la confirmation.");
+  }
+}

--- a/src/module/import-assistant/types/import-assistant.types.ts
+++ b/src/module/import-assistant/types/import-assistant.types.ts
@@ -1,0 +1,158 @@
+export const IMPORT_ENTITY_TYPES = [
+  "CLIENT",
+  "FOURNISSEUR",
+  "ARTICLE",
+  "PIECE_TECHNIQUE",
+  "MACHINE",
+  "STOCK_INITIAL",
+  "BL_HISTORIQUE",
+  "EMPLOYE",
+] as const;
+
+export type ImportEntityType = (typeof IMPORT_ENTITY_TYPES)[number];
+
+export const IMPORT_BATCH_STATUSES = [
+  "UPLOADED",
+  "SIMULATED",
+  "READY",
+  "IMPORTING",
+  "COMPLETED",
+  "COMPLETED_WITH_ERRORS",
+  "FAILED",
+] as const;
+
+export type ImportBatchStatus = (typeof IMPORT_BATCH_STATUSES)[number];
+
+export const IMPORT_ROW_STATUSES = [
+  "PENDING",
+  "VALID",
+  "BLOCKED",
+  "DUPLICATE",
+  "ALREADY_IMPORTED",
+  "PROCESSING",
+  "IMPORTED",
+  "LINKED",
+  "FAILED",
+] as const;
+
+export type ImportRowStatus = (typeof IMPORT_ROW_STATUSES)[number];
+export type ImportRowAction = "CREATE" | "LINK" | "SKIP";
+export type ImportDuplicateStrategy = "REVIEW" | "LINK_EXACT";
+
+export type ImportFieldKind = "text" | "boolean" | "number" | "date" | "enum" | "list" | "uuid";
+
+export type ImportTargetField = {
+  key: string;
+  label: string;
+  kind: ImportFieldKind;
+  required?: boolean;
+  values?: string[];
+  sensitive?: boolean;
+  hint?: string;
+};
+
+export type ImportDecisionGate = {
+  id: string;
+  label: string;
+  responsible: string;
+  evidence: string;
+};
+
+export type ImportEntityCapability = {
+  entity_type: ImportEntityType;
+  label: string;
+  order: number;
+  confirm_enabled: boolean;
+  unavailable_reason: string | null;
+  fields: ImportTargetField[];
+  decisions: ImportDecisionGate[];
+};
+
+export type ImportMapping = {
+  legacy_key_column: string;
+  columns: Record<string, string>;
+  constants: Record<string, string | number | boolean | null>;
+  approved_decisions: string[];
+  duplicate_strategy: ImportDuplicateStrategy;
+};
+
+export type ImportIssue = {
+  code: string;
+  message: string;
+  field: string | null;
+  source_value?: unknown;
+};
+
+export type ParsedTabularSheet = {
+  name: string;
+  headers: string[];
+  rows: Array<Record<string, string | number | boolean | null>>;
+};
+
+export type ParsedTabularFile = {
+  sheets: ParsedTabularSheet[];
+};
+
+export type ImportBatchSummary = {
+  total: number;
+  valid: number;
+  blocked: number;
+  duplicates: number;
+  already_imported: number;
+  imported: number;
+  linked: number;
+  failed: number;
+};
+
+export type ImportAuditContext = {
+  user_id: number;
+  ip: string | null;
+  user_agent: string | null;
+  device_type: string | null;
+  os: string | null;
+  browser: string | null;
+  path: string | null;
+  page_key: string | null;
+  client_session_id: string | null;
+};
+
+export type ImportBatchRow = {
+  id: string;
+  entity_type: ImportEntityType;
+  status: ImportBatchStatus;
+  source_system: string;
+  source_name: string;
+  source_sha256: string;
+  source_size: number;
+  source_mime: string | null;
+  sheet_name: string;
+  headers: string[];
+  mapping: ImportMapping | null;
+  preview_hash: string | null;
+  summary: ImportBatchSummary;
+  last_error: string | null;
+  created_by: number;
+  created_at: string;
+  updated_at: string;
+  completed_at: string | null;
+};
+
+export type ImportStoredRow = {
+  id: string;
+  batch_id: string;
+  row_number: number;
+  legacy_key: string | null;
+  source_data: Record<string, unknown>;
+  normalized_data: Record<string, unknown> | null;
+  status: ImportRowStatus;
+  action: ImportRowAction;
+  issues: ImportIssue[];
+  target_id: string | null;
+  target_code: string | null;
+  attempts: number;
+};
+
+export type ImportTargetResult = {
+  id: string;
+  code: string | null;
+};

--- a/src/module/import-assistant/validators/import-assistant.validators.ts
+++ b/src/module/import-assistant/validators/import-assistant.validators.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+import { IMPORT_ENTITY_TYPES, IMPORT_ROW_STATUSES } from "../types/import-assistant.types";
+
+export const importEntityTypeSchema = z.enum(IMPORT_ENTITY_TYPES);
+
+export const createImportBatchFieldsSchema = z.object({
+  entity_type: importEntityTypeSchema,
+  source_system: z.string().trim().min(1).max(40).optional().default("CLIPPER"),
+  sheet_name: z.string().trim().min(1).max(200).optional(),
+}).strict();
+
+const mappingValueSchema = z.union([z.string(), z.number(), z.boolean(), z.null()]);
+
+export const previewImportBatchSchema = z.object({
+  columns: z.record(z.string().trim().min(1).max(200)).default({}),
+  constants: z.record(mappingValueSchema).default({}),
+  legacy_key_column: z.string().trim().min(1).max(200),
+  approved_decisions: z.array(z.string().trim().regex(/^DEC-\d{2}$/)).max(30).default([]),
+  duplicate_strategy: z.enum(["REVIEW", "LINK_EXACT"]).default("REVIEW"),
+}).strict();
+
+export const importBatchIdSchema = z.object({
+  id: z.string().uuid(),
+});
+
+export const listImportBatchesQuerySchema = z.object({
+  entity_type: importEntityTypeSchema.optional(),
+  page: z.coerce.number().int().min(1).optional().default(1),
+  pageSize: z.coerce.number().int().min(1).max(100).optional().default(20),
+}).strict();
+
+export const listImportRowsQuerySchema = z.object({
+  status: z.enum(IMPORT_ROW_STATUSES).optional(),
+  page: z.coerce.number().int().min(1).optional().default(1),
+  pageSize: z.coerce.number().int().min(1).max(200).optional().default(50),
+}).strict();
+
+export const confirmImportBatchSchema = z.object({
+  expected_preview_hash: z.string().regex(/^[a-f0-9]{64}$/),
+}).strict();

--- a/src/module/pieces-techniques/controllers/versions.controller.ts
+++ b/src/module/pieces-techniques/controllers/versions.controller.ts
@@ -43,9 +43,17 @@ function buildAuditContext(req: Request): AuditContext {
   }
 }
 
+function routeParam(req: Request, name: string): string {
+  const value = req.params[name]
+  if (typeof value !== "string" || value.length === 0) {
+    throw new HttpError(400, "INVALID_ROUTE_PARAM", `Paramètre de route invalide : ${name}`)
+  }
+  return value
+}
+
 export const listVersions: RequestHandler = async (req, res, next) => {
   try {
-    const items = await listVersionsSVC(req.params.id)
+    const items = await listVersionsSVC(routeParam(req, "id"))
     res.json(items)
   } catch (err) {
     next(err)
@@ -56,7 +64,7 @@ export const createVersion: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = createVersionSchema.parse({ body: req.body }).body
-    const out = await createVersionSVC(req.params.id, body, audit)
+    const out = await createVersionSVC(routeParam(req, "id"), body, audit)
     res.status(201).json(out)
   } catch (err) {
     next(err)
@@ -67,7 +75,12 @@ export const updateVersion: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = updateVersionSchema.parse({ body: req.body }).body
-    const out = await updateVersionSVC(req.params.id, req.params.versionId, body, audit)
+    const out = await updateVersionSVC(
+      routeParam(req, "id"),
+      routeParam(req, "versionId"),
+      body,
+      audit
+    )
     if (!out) throw new HttpError(404, "NOT_FOUND", "Version introuvable")
     res.json(out)
   } catch (err) {
@@ -79,7 +92,12 @@ export const updateVersionStatus: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = versionStatusSchema.parse({ body: req.body }).body
-    const out = await updateVersionStatusSVC(req.params.id, req.params.versionId, body, audit)
+    const out = await updateVersionStatusSVC(
+      routeParam(req, "id"),
+      routeParam(req, "versionId"),
+      body,
+      audit
+    )
     if (!out) throw new HttpError(404, "NOT_FOUND", "Version introuvable")
     res.json(out)
   } catch (err) {
@@ -91,7 +109,12 @@ export const createNextVersion: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = createNextVersionSchema.parse({ body: req.body }).body
-    const out = await createNextVersionSVC(req.params.id, req.params.versionId, body, audit)
+    const out = await createNextVersionSVC(
+      routeParam(req, "id"),
+      routeParam(req, "versionId"),
+      body,
+      audit
+    )
     res.status(201).json(out)
   } catch (err) {
     next(err)

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -1586,11 +1586,32 @@ export async function repoCreatePieceTechnique(
     operations: (AddOperationBodyDTO & { temps_total: number; cout_mo: number })[];
     achats: (AddAchatBodyDTO & { total_achat_ht: number; total_achat_ttc: number })[];
   },
-  audit: AuditContext
+  audit: AuditContext,
+  idempotencyKey?: string | null
 ): Promise<PieceTechnique> {
   const client = await db.connect();
+  const requestHash = crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex");
   try {
     await client.query("BEGIN");
+
+    if (idempotencyKey) {
+      const replay = await client.query<{ piece_technique_id: string; request_hash: string }>(
+        `SELECT piece_technique_id::text AS piece_technique_id, request_hash
+         FROM public.piece_technique_create_idempotence
+         WHERE idempotency_key = $1
+         FOR UPDATE`,
+        [idempotencyKey]
+      );
+      if (replay.rows[0]) {
+        if (replay.rows[0].request_hash !== requestHash) {
+          throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Cette clé d’idempotence a déjà servi avec une autre pièce technique.");
+        }
+        await client.query("ROLLBACK");
+        const existing = await repoGetPieceTechnique(replay.rows[0].piece_technique_id, new Set());
+        if (!existing) throw new Error("Idempotent piece technique no longer exists");
+        return existing;
+      }
+    }
 
     const actorUserId = audit.user_id;
     const createdBy = actorUserId;
@@ -1752,11 +1773,31 @@ export async function repoCreatePieceTechnique(
         achats_count: piece.achats.length,
       },
     });
+    if (idempotencyKey) {
+      await client.query(
+        `INSERT INTO public.piece_technique_create_idempotence
+           (idempotency_key, request_hash, piece_technique_id)
+         VALUES ($1,$2,$3::uuid)`,
+        [idempotencyKey, requestHash, pieceId]
+      );
+    }
 
     await client.query("COMMIT");
     return piece;
   } catch (err) {
     await client.query("ROLLBACK");
+    const code = (err as { code?: unknown } | null)?.code;
+    if (idempotencyKey && code === "23505") {
+      const replay = await db.query<{ piece_technique_id: string; request_hash: string }>(
+        `SELECT piece_technique_id::text AS piece_technique_id, request_hash
+         FROM public.piece_technique_create_idempotence WHERE idempotency_key = $1`,
+        [idempotencyKey]
+      );
+      if (replay.rows[0]?.request_hash === requestHash) {
+        const existing = await repoGetPieceTechnique(replay.rows[0].piece_technique_id, new Set());
+        if (existing) return existing;
+      }
+    }
     throw err;
   } finally {
     client.release();

--- a/src/module/pieces-techniques/services/pieces-techniques.service.ts
+++ b/src/module/pieces-techniques/services/pieces-techniques.service.ts
@@ -96,7 +96,11 @@ export const getPieceTechniqueSVC = (id: string, includes: Set<string>) => repoG
 
 export const getPieceTechniqueFabricationTreeSVC = (id: string) => repoGetFabricationTree(id);
 
-export async function createPieceTechniqueSVC(body: CreatePieceTechniqueBodyDTO, audit: AuditContext) {
+export async function createPieceTechniqueSVC(
+  body: CreatePieceTechniqueBodyDTO,
+  audit: AuditContext,
+  idempotencyKey?: string | null
+) {
   const statut = body.statut ?? "DRAFT";
   const enFabrication = statut === "IN_FABRICATION";
 
@@ -118,7 +122,8 @@ export async function createPieceTechniqueSVC(body: CreatePieceTechniqueBodyDTO,
         operations,
         achats,
       },
-      audit
+      audit,
+      idempotencyKey
     );
   } catch (err: unknown) {
     // pg unique violation

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -48,6 +48,7 @@ import tempsDeplacementsRoutes from "../module/temps-deplacements/routes/temps-d
 import projectOfficeRoutes from "../module/project-office/routes/project-office.routes"
 import gammesRoutes from "../module/gammes/routes/gammes.routes"
 import pieceTechniqueVersionsRoutes from "../module/gammes/routes/piece-technique-versions.routes"
+import importAssistantRoutes from "../module/import-assistant/routes/import-assistant.routes"
 const router = Router()
 
 // --- Routes publiques (avant authentification) ---
@@ -116,4 +117,5 @@ router.use("/asbuilt", asbuiltRoutes)
 router.use("/locks", locksRoutes)
 router.use("/time-clock", tempsDeplacementsRoutes) // Module « Temps & Déplacements » (RH pointage/kilomètres)
 router.use("/project-office", projectOfficeRoutes) // Module « Project Office » (#130) — feature gate PROJECT_OFFICE fail-closed
+router.use("/import-assistant", importAssistantRoutes) // CLIPPER -> CERP staged import assistant (#167)
 export default router


### PR DESCRIPTION
Ajoute les API d'import contrôlé, la simulation, les confirmations et l'audit, avec garde de production. Inclut le durcissement des paramètres Express. Validation: compilation TypeScript et 2638 tests. Closes #167. Closes #170.