### PR TITLE
fix(database): valider les références articles fabriqués

### DIFF
--- a/db/patches/20260727_validate_article_fabrique_references_169.sql
+++ b/db/patches/20260727_validate_article_fabrique_references_169.sql
@@ -1,0 +1,67 @@
+-- Issue #169 — validate the three historical references to articles_fabrique.
+--
+-- The constraints were installed NOT VALID by
+-- 20260319_articles_domain_subtypes.sql. The preflight proves that every
+-- existing non-null article_id has a matching articles_fabrique row.
+--
+-- This patch changes constraint validation metadata only. It does not insert,
+-- update or delete business data.
+
+BEGIN;
+
+SET LOCAL lock_timeout = '5s';
+SET LOCAL statement_timeout = '30s';
+
+DO $guard$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
+    RAISE EXCEPTION
+      'Validation #169 is restricted to cerp_test or cerp_prod, current database: %',
+      current_database();
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM (
+      SELECT source.article_id
+      FROM public.commande_ligne AS source
+      LEFT JOIN public.articles_fabrique AS target
+        ON target.article_id = source.article_id
+      WHERE source.article_id IS NOT NULL
+        AND target.article_id IS NULL
+
+      UNION ALL
+
+      SELECT source.article_id
+      FROM public.commande_cadre_release_ligne AS source
+      LEFT JOIN public.articles_fabrique AS target
+        ON target.article_id = source.article_id
+      WHERE source.article_id IS NOT NULL
+        AND target.article_id IS NULL
+
+      UNION ALL
+
+      SELECT source.article_id
+      FROM public.ordres_fabrication AS source
+      LEFT JOIN public.articles_fabrique AS target
+        ON target.article_id = source.article_id
+      WHERE source.article_id IS NOT NULL
+        AND target.article_id IS NULL
+    ) AS invalid_reference
+  ) THEN
+    RAISE EXCEPTION
+      'Validation #169 refused: at least one article_id does not reference articles_fabrique';
+  END IF;
+END
+$guard$;
+
+ALTER TABLE public.commande_ligne
+  VALIDATE CONSTRAINT commande_ligne_article_fabrique_fk;
+
+ALTER TABLE public.commande_cadre_release_ligne
+  VALIDATE CONSTRAINT commande_cadre_release_ligne_article_fabrique_fk;
+
+ALTER TABLE public.ordres_fabrication
+  VALIDATE CONSTRAINT ordres_fabrication_article_fabrique_fk;
+
+COMMIT;

--- a/db/patches/support/20260727_validate_article_fabrique_references_169.preflight.sql
+++ b/db/patches/support/20260727_validate_article_fabrique_references_169.preflight.sql
@@ -1,0 +1,59 @@
+\set ON_ERROR_STOP on
+
+\echo '=== Article fabrique FK validation #169 preflight (read-only) ==='
+
+SELECT
+  current_database() AS database,
+  current_database() IN ('cerp_test', 'cerp_prod') AS allowed_database;
+
+WITH expected(table_name, constraint_name) AS (
+  VALUES
+    ('commande_ligne', 'commande_ligne_article_fabrique_fk'),
+    ('commande_cadre_release_ligne', 'commande_cadre_release_ligne_article_fabrique_fk'),
+    ('ordres_fabrication', 'ordres_fabrication_article_fabrique_fk')
+)
+SELECT
+  expected.table_name,
+  expected.constraint_name,
+  fk.oid IS NOT NULL AS exists,
+  COALESCE(fk.contype = 'f', false) AS is_foreign_key,
+  COALESCE(
+    pg_get_constraintdef(fk.oid)
+      = 'FOREIGN KEY (article_id) REFERENCES articles_fabrique(article_id) NOT VALID',
+    false
+  ) OR COALESCE(
+    pg_get_constraintdef(fk.oid)
+      = 'FOREIGN KEY (article_id) REFERENCES articles_fabrique(article_id)',
+    false
+  ) AS definition_ok,
+  COALESCE(fk.convalidated, false) AS already_validated
+FROM expected
+LEFT JOIN pg_constraint AS fk
+  ON fk.conrelid = ('public.' || expected.table_name)::regclass
+ AND fk.conname = expected.constraint_name
+ORDER BY expected.table_name;
+
+SELECT 'commande_ligne' AS source_table, count(*) AS invalid_references
+FROM public.commande_ligne AS source
+LEFT JOIN public.articles_fabrique AS target ON target.article_id = source.article_id
+WHERE source.article_id IS NOT NULL
+  AND target.article_id IS NULL
+
+UNION ALL
+
+SELECT 'commande_cadre_release_ligne', count(*)
+FROM public.commande_cadre_release_ligne AS source
+LEFT JOIN public.articles_fabrique AS target ON target.article_id = source.article_id
+WHERE source.article_id IS NOT NULL
+  AND target.article_id IS NULL
+
+UNION ALL
+
+SELECT 'ordres_fabrication', count(*)
+FROM public.ordres_fabrication AS source
+LEFT JOIN public.articles_fabrique AS target ON target.article_id = source.article_id
+WHERE source.article_id IS NOT NULL
+  AND target.article_id IS NULL
+ORDER BY source_table;
+
+\echo 'Preflight #169 complete: every reported invalid_references value must be zero.'

--- a/db/patches/support/20260727_validate_article_fabrique_references_169.rollback.sql
+++ b/db/patches/support/20260727_validate_article_fabrique_references_169.rollback.sql
@@ -1,0 +1,34 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Rollback #169 is restricted to cerp_test';
+  END IF;
+END
+$guard$;
+
+ALTER TABLE public.commande_ligne
+  DROP CONSTRAINT commande_ligne_article_fabrique_fk,
+  ADD CONSTRAINT commande_ligne_article_fabrique_fk
+    FOREIGN KEY (article_id)
+    REFERENCES public.articles_fabrique(article_id)
+    NOT VALID;
+
+ALTER TABLE public.commande_cadre_release_ligne
+  DROP CONSTRAINT commande_cadre_release_ligne_article_fabrique_fk,
+  ADD CONSTRAINT commande_cadre_release_ligne_article_fabrique_fk
+    FOREIGN KEY (article_id)
+    REFERENCES public.articles_fabrique(article_id)
+    NOT VALID;
+
+ALTER TABLE public.ordres_fabrication
+  DROP CONSTRAINT ordres_fabrication_article_fabrique_fk,
+  ADD CONSTRAINT ordres_fabrication_article_fabrique_fk
+    FOREIGN KEY (article_id)
+    REFERENCES public.articles_fabrique(article_id)
+    NOT VALID;
+
+COMMIT;

--- a/db/patches/support/20260727_validate_article_fabrique_references_169.verify.sql
+++ b/db/patches/support/20260727_validate_article_fabrique_references_169.verify.sql
@@ -1,0 +1,48 @@
+\set ON_ERROR_STOP on
+
+\echo '=== Article fabrique FK validation #169 verification ==='
+
+WITH expected(table_name, constraint_name) AS (
+  VALUES
+    ('commande_ligne', 'commande_ligne_article_fabrique_fk'),
+    ('commande_cadre_release_ligne', 'commande_cadre_release_ligne_article_fabrique_fk'),
+    ('ordres_fabrication', 'ordres_fabrication_article_fabrique_fk')
+)
+SELECT
+  count(*) = 3 AS all_three_constraints_present,
+  count(*) FILTER (WHERE fk.convalidated) = 3 AS all_three_constraints_validated
+FROM expected
+JOIN pg_constraint AS fk
+  ON fk.conrelid = ('public.' || expected.table_name)::regclass
+ AND fk.conname = expected.constraint_name
+ AND fk.contype = 'f';
+
+SELECT
+  count(*) FILTER (WHERE NOT fk.convalidated) = 0
+    AS all_public_foreign_keys_validated
+FROM pg_constraint AS fk
+WHERE fk.contype = 'f'
+  AND fk.connamespace = 'public'::regnamespace;
+
+SELECT 'commande_ligne' AS source_table, count(*) AS invalid_references
+FROM public.commande_ligne AS source
+LEFT JOIN public.articles_fabrique AS target ON target.article_id = source.article_id
+WHERE source.article_id IS NOT NULL
+  AND target.article_id IS NULL
+
+UNION ALL
+
+SELECT 'commande_cadre_release_ligne', count(*)
+FROM public.commande_cadre_release_ligne AS source
+LEFT JOIN public.articles_fabrique AS target ON target.article_id = source.article_id
+WHERE source.article_id IS NOT NULL
+  AND target.article_id IS NULL
+
+UNION ALL
+
+SELECT 'ordres_fabrication', count(*)
+FROM public.ordres_fabrication AS source
+LEFT JOIN public.articles_fabrique AS target ON target.article_id = source.article_id
+WHERE source.article_id IS NOT NULL
+  AND target.article_id IS NULL
+ORDER BY source_table;

--- a/docs/article-fabrique-fk-validation-169.md
+++ b/docs/article-fabrique-fk-validation-169.md
@@ -1,0 +1,57 @@
+# Validation des références vers les articles fabriqués — issue #169
+
+## Constat
+
+Le patch historique `20260319_articles_domain_subtypes.sql` a créé trois clés
+étrangères avec `NOT VALID`. Cette forme protégeait immédiatement les nouvelles
+écritures sans bloquer la migration sur d’éventuelles lignes historiques :
+
+- `commande_ligne.article_id` ;
+- `commande_cadre_release_ligne.article_id` ;
+- `ordres_fabrication.article_id`.
+
+Les trois références ciblent `articles_fabrique.article_id`.
+
+## Décision
+
+Le contrôle du 2026-07-27 trouve zéro référence invalide dans les trois tables
+sur `cerp_test` et `cerp_prod`. Le patch
+`20260727_validate_article_fabrique_references_169.sql` valide donc uniquement
+ces trois contraintes.
+
+Le patch ne crée, ne modifie et ne supprime aucune ligne métier. Il est
+transactionnel, idempotent et limité à `cerp_test` et `cerp_prod`.
+
+## Procédure
+
+1. exécuter le préflight en lecture seule ;
+2. vérifier que les trois volumes `invalid_references` valent zéro ;
+3. appliquer le patch sur `cerp_test` ;
+4. exécuter la vérification et le rollback test-only ;
+5. réappliquer et vérifier ;
+6. sauvegarder `cerp_prod`, puis répéter préflight, patch et vérification ;
+7. comparer les empreintes canoniques des données avant et après.
+
+Le rollback est volontairement interdit sur `cerp_prod`. Sur `cerp_test`, il
+recrée les mêmes contraintes avec `NOT VALID` sans toucher aux données.
+
+## Validation réalisée le 2026-07-27
+
+- les trois préflights signalent zéro référence invalide ;
+- application, rollback test-only et réapplication réussis sur `cerp_test` ;
+- sauvegarde production avant validation :
+  `/var/backups/cerp/cerp_prod_20260727-015848.dump`,
+  39 332 461 octets, SHA-256
+  `d38946dbe325a5c9928780dc5455b5871c90eef0f978ecd5cd1409aefc6b104c` ;
+- patch appliqué avec l’empreinte
+  `1fb52ce37a096a28b057244aadad00d1d5cc0f98a93ae14e32e7d49249fa15f1`
+  et enregistré dans `cerp_schema_migrations` ;
+- les 302 tables métier comparées ont exactement les mêmes volumes et
+  empreintes avant et après la validation ;
+- toutes les clés étrangères du schéma `public` sont validées.
+
+La sauvegarde finale de production utilisée pour reconstruire `cerp_test` est
+`/var/backups/cerp/cerp_prod_20260727-020006.dump`, 39 332 474 octets,
+SHA-256
+`84a63ded269c134a1ad83e6dc734d2afe0547809c276697cfa3e6f80aa6bed2b`.
+Les 303 tables de la nouvelle `cerp_test` sont identiques à `cerp_prod`.

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -267,3 +267,21 @@ appliqués transactionnellement et vérifiés dans cet ordre :
 
 Les cinq lignes du registre portent les empreintes SHA-256 exactes des fichiers
 versionnés. Aucun jeu de données de recette n'a été conservé dans `cerp_prod`.
+
+## Issue #169 - Validation des références vers les articles fabriqués
+
+Patch `20260727_validate_article_fabrique_references_169.sql` valide les trois
+clés étrangères historiques de `commande_ligne`,
+`commande_cadre_release_ligne` et `ordres_fabrication` vers
+`articles_fabrique`. Elles avaient été créées avec `NOT VALID` par
+`20260319_articles_domain_subtypes.sql`.
+
+Le préflight prouve d'abord que chaque référence non nulle possède sa cible.
+Le patch est transactionnel, idempotent, limité à `cerp_test` et `cerp_prod`,
+et ne modifie aucune ligne métier. La procédure et le rollback test-only sont
+documentés dans `docs/article-fabrique-fk-validation-169.md`.
+
+Validation du 2026-07-27 : cycle complet avec rollback sur `cerp_test`,
+sauvegarde production vérifiée, trois contraintes validées sur `cerp_prod`,
+zéro référence invalide, toutes les clés étrangères publiques validées et
+empreintes des 302 tables métier inchangées.

--- a/src/__tests__/article-fabrique-fk-validation-169.migration-guards.test.ts
+++ b/src/__tests__/article-fabrique-fk-validation-169.migration-guards.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const root = path.resolve(__dirname, "../..");
+const patch = fs.readFileSync(
+  path.join(root, "db/patches/20260727_validate_article_fabrique_references_169.sql"),
+  "utf8"
+);
+const preflight = fs.readFileSync(
+  path.join(root, "db/patches/support/20260727_validate_article_fabrique_references_169.preflight.sql"),
+  "utf8"
+);
+const verify = fs.readFileSync(
+  path.join(root, "db/patches/support/20260727_validate_article_fabrique_references_169.verify.sql"),
+  "utf8"
+);
+const rollback = fs.readFileSync(
+  path.join(root, "db/patches/support/20260727_validate_article_fabrique_references_169.rollback.sql"),
+  "utf8"
+);
+const patchSql = patch.replace(/^--.*$/gm, "");
+
+const constraintNames = [
+  "commande_ligne_article_fabrique_fk",
+  "commande_cadre_release_ligne_article_fabrique_fk",
+  "ordres_fabrication_article_fabrique_fk",
+];
+
+describe("article fabrique FK validation #169 migration guards", () => {
+  it("validates exactly the three known historical constraints", () => {
+    for (const name of constraintNames) {
+      expect(patch).toContain(`VALIDATE CONSTRAINT ${name}`);
+      expect(preflight).toContain(name);
+      expect(verify).toContain(name);
+    }
+    expect(patch.match(/VALIDATE CONSTRAINT/g)).toHaveLength(3);
+  });
+
+  it("proves references before changing validation metadata", () => {
+    expect(patch).toContain("articles_fabrique AS target");
+    expect(patch).toContain("invalid_reference");
+    expect(patch.indexOf("invalid_reference")).toBeLessThan(
+      patch.indexOf("VALIDATE CONSTRAINT")
+    );
+    expect(preflight).not.toMatch(/\b(INSERT|UPDATE|DELETE|ALTER|DROP|TRUNCATE)\b/i);
+  });
+
+  it("never changes business rows", () => {
+    expect(patchSql).not.toMatch(/\b(INSERT|UPDATE|DELETE|TRUNCATE)\b/i);
+    expect(patchSql).not.toMatch(/DROP\s+(TABLE|COLUMN)/i);
+    expect(patch).toMatch(/BEGIN;/);
+    expect(patch).toMatch(/COMMIT;/);
+  });
+
+  it("keeps rollback test-only and restores NOT VALID definitions", () => {
+    expect(rollback).toMatch(/current_database\(\) <> 'cerp_test'/);
+    expect(rollback.match(/NOT VALID/g)).toHaveLength(3);
+    expect(rollback).not.toMatch(/\b(INSERT|UPDATE|DELETE|TRUNCATE)\b/i);
+  });
+});


### PR DESCRIPTION
Ajoute le patch de validation des trois clés étrangères, préflight, vérification et documentation. Validation: 4 tests dédiés; aucune référence invalide avant validation sur cerp_test et cerp_prod. Closes #169.

## Summary by Sourcery

Validate historical foreign key references to manufactured articles and document the validation procedure and safeguards.

New Features:
- Add a transactional, idempotent database patch to validate three existing foreign keys from order-related tables to articles_fabrique on production and test databases.

Enhancements:
- Introduce read-only preflight and verification SQL scripts plus a restricted rollback script to guard the FK validation migration.
- Document the manufactured-article foreign key validation procedure, scope, and completed validation results in dedicated docs and the database patches log.

Tests:
- Add migration guard tests to ensure the validation patch, preflight, verify, and rollback scripts only touch the intended constraints and do not modify business data.