### PR TITLE
fix(import): accepter les classeurs OOXML préfixés

### DIFF
--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -18,6 +18,9 @@ Toutes les routes sont sous `/api/v1/import-assistant` et réservées aux rôles
   `IMPORT_TEST_DATABASE_REQUIRED` si le processus n’est pas réellement connecté
   à `cerp_test`.
 - CSV/XLSX uniquement, 25 Mo côté upload et 64 Mo décompressés.
+- XLSX OOXML standard accepté avec ou sans préfixe d’espace de noms XML, y
+  compris les noms de parties absolus internes comme `/xl/worksheets/sheet1.xml`.
+  Les chemins relatifs sortants et les entrées ZIP dangereuses restent refusés.
 - SHA-256 du fichier et unicité du lot par source, domaine, empreinte et feuille.
 - Simulation par les schémas Zod existants.
 - Création par les services métier existants et codes générés par CERP.

--- a/src/__tests__/import-assistant.domain.test.ts
+++ b/src/__tests__/import-assistant.domain.test.ts
@@ -25,6 +25,74 @@ function uploadFile(name: string, body: string) {
   } as Express.Multer.File;
 }
 
+function storedZip(entries: Array<{ name: string; body: string }>): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let localOffset = 0;
+
+  for (const entry of entries) {
+    const name = Buffer.from(entry.name, "utf8");
+    const body = Buffer.from(entry.body, "utf8");
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(20, 4);
+    local.writeUInt32LE(body.length, 18);
+    local.writeUInt32LE(body.length, 22);
+    local.writeUInt16LE(name.length, 26);
+    localParts.push(local, name, body);
+
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(20, 4);
+    central.writeUInt16LE(20, 6);
+    central.writeUInt32LE(body.length, 20);
+    central.writeUInt32LE(body.length, 24);
+    central.writeUInt16LE(name.length, 28);
+    central.writeUInt32LE(localOffset, 42);
+    centralParts.push(central, name);
+    localOffset += local.length + name.length + body.length;
+  }
+
+  const centralDirectory = Buffer.concat(centralParts);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(centralDirectory.length, 12);
+  eocd.writeUInt32LE(localOffset, 16);
+  return Buffer.concat([...localParts, centralDirectory, eocd]);
+}
+
+function namespacedXlsxFile(worksheetTarget = "/xl/worksheets/sheet1.xml"): Express.Multer.File {
+  const serial = Math.round(
+    (Date.UTC(2026, 6, 27) - Date.UTC(1899, 11, 30)) / 86_400_000
+  );
+  const buffer = storedZip([
+    {
+      name: "xl/workbook.xml",
+      body: `<?xml version="1.0"?><x:workbook xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><x:sheets><x:sheet name="Pilote" sheetId="1" r:id="R1" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"/></x:sheets></x:workbook>`,
+    },
+    {
+      name: "xl/_rels/workbook.xml.rels",
+      body: `<?xml version="1.0"?><Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="${worksheetTarget}" Id="R1"/></Relationships>`,
+    },
+    {
+      name: "xl/styles.xml",
+      body: `<?xml version="1.0"?><x:styleSheet xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><x:cellXfs count="2"><x:xf numFmtId="0"/><x:xf numFmtId="14"/></x:cellXfs></x:styleSheet>`,
+    },
+    {
+      name: "xl/worksheets/sheet1.xml",
+      body: `<?xml version="1.0"?><x:worksheet xmlns:x="http://schemas.openxmlformats.org/spreadsheetml/2006/main"><x:sheetData><x:row r="1"><x:c r="A1" t="str"><x:v>legacy_code</x:v></x:c><x:c r="B1" t="str"><x:v>email</x:v></x:c><x:c r="C1" t="str"><x:v>siret</x:v></x:c><x:c r="D1" t="str"><x:v>creation_date</x:v></x:c></x:row><x:row r="2"><x:c r="A2" t="str"><x:v>001</x:v></x:c><x:c r="B2"/><x:c r="C2" t="str"><x:v>10539713700016</x:v></x:c><x:c r="D2" s="1"><x:v>${serial}</x:v></x:c></x:row></x:sheetData></x:worksheet>`,
+    },
+  ]);
+  return {
+    originalname: "pilote-prefixe.xlsx",
+    mimetype: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    buffer,
+    size: buffer.length,
+  } as Express.Multer.File;
+}
+
 describe("Assistant d’import CLIPPER", () => {
   it("lit les CSV français avec guillemets, séparateurs et lignes vides", () => {
     const parsed = parseTabularFile(uploadFile(
@@ -42,6 +110,31 @@ describe("Assistant d’import CLIPPER", () => {
   it("refuse un format qui ne passe pas par le parseur contrôlé", () => {
     expect(() => parseTabularFile(uploadFile("legacy.xls", "CODE\tNOM"))).toThrow(
       "Format refusé"
+    );
+  });
+
+  it("lit les XLSX avec espaces de noms préfixés et relations de partie absolues", () => {
+    const parsed = parseTabularFile(namespacedXlsxFile());
+
+    expect(parsed.sheets).toEqual([
+      {
+        name: "Pilote",
+        headers: ["legacy_code", "email", "siret", "creation_date"],
+        rows: [
+          {
+            legacy_code: "001",
+            email: null,
+            siret: "10539713700016",
+            creation_date: "2026-07-27",
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("continue de refuser une relation XLSX qui sort de l’archive", () => {
+    expect(() => parseTabularFile(namespacedXlsxFile("/../outside.xml"))).toThrow(
+      "Chemin de feuille XLSX interdit"
     );
   });
 

--- a/src/module/import-assistant/domain/tabular-file-parser.ts
+++ b/src/module/import-assistant/domain/tabular-file-parser.ts
@@ -115,8 +115,9 @@ function uniqueHeaders(values: unknown[]): string[] {
 
 function parseSharedStrings(xml: string): string[] {
   const values: string[] = [];
-  for (const match of xml.matchAll(/<si\b[^>]*>([\s\S]*?)<\/si>/g)) {
-    const parts = [...match[1].matchAll(/<t\b[^>]*>([\s\S]*?)<\/t>/g)].map((part) => decodeXml(part[1]));
+  for (const match of xml.matchAll(/<(?:[A-Za-z_][\w.-]*:)?si\b[^>]*>([\s\S]*?)<\/(?:[A-Za-z_][\w.-]*:)?si>/g)) {
+    const parts = [...match[1].matchAll(/<(?:[A-Za-z_][\w.-]*:)?t\b[^>]*>([\s\S]*?)<\/(?:[A-Za-z_][\w.-]*:)?t>/g)]
+      .map((part) => decodeXml(part[1]));
     values.push(parts.join(""));
   }
   return values;
@@ -125,13 +126,14 @@ function parseSharedStrings(xml: string): string[] {
 function parseDateStyleIndexes(stylesXml: string | null): Set<number> {
   if (!stylesXml) return new Set();
   const customFormats = new Map<number, string>();
-  for (const match of stylesXml.matchAll(/<numFmt\b[^>]*numFmtId="(\d+)"[^>]*formatCode="([^"]*)"[^>]*\/?>/g)) {
+  for (const match of stylesXml.matchAll(/<(?:[A-Za-z_][\w.-]*:)?numFmt\b[^>]*numFmtId="(\d+)"[^>]*formatCode="([^"]*)"[^>]*\/?>/g)) {
     customFormats.set(Number(match[1]), decodeXml(match[2]));
   }
   const dateStyles = new Set<number>();
-  const cellXfs = /<cellXfs\b[^>]*>([\s\S]*?)<\/cellXfs>/.exec(stylesXml)?.[1] ?? "";
+  const cellXfs = /<(?:[A-Za-z_][\w.-]*:)?cellXfs\b[^>]*>([\s\S]*?)<\/(?:[A-Za-z_][\w.-]*:)?cellXfs>/
+    .exec(stylesXml)?.[1] ?? "";
   let index = 0;
-  for (const match of cellXfs.matchAll(/<xf\b([^>]*)\/?>/g)) {
+  for (const match of cellXfs.matchAll(/<(?:[A-Za-z_][\w.-]*:)?xf\b([^>]*)\/?>/g)) {
     const numFmtId = Number(/numFmtId="(\d+)"/.exec(match[1])?.[1] ?? 0);
     const format = customFormats.get(numFmtId) ?? "";
     if ((numFmtId >= 14 && numFmtId <= 22) || /[ymdhis]/i.test(format.replace(/\[[^\]]+\]/g, ""))) {
@@ -154,22 +156,28 @@ function parseSheetXml(
   dateStyles: Set<number>
 ): ParsedTabularSheet {
   const matrix: unknown[][] = [];
-  for (const rowMatch of xml.matchAll(/<row\b[^>]*>([\s\S]*?)<\/row>/g)) {
+  for (const rowMatch of xml.matchAll(/<(?:[A-Za-z_][\w.-]*:)?row\b[^>]*>([\s\S]*?)<\/(?:[A-Za-z_][\w.-]*:)?row>/g)) {
     if (matrix.length >= MAX_ROWS + 1) throw new HttpError(413, "TOO_MANY_ROWS", `La feuille ${name} dépasse ${MAX_ROWS} lignes.`);
     const row: unknown[] = [];
-    for (const cellMatch of rowMatch[1].matchAll(/<c\b([^>]*)>([\s\S]*?)<\/c>/g)) {
+    for (const cellMatch of rowMatch[1].matchAll(
+      /<(?:[A-Za-z_][\w.-]*:)?c\b([^>]*?)(?:\/>|>([\s\S]*?)<\/(?:[A-Za-z_][\w.-]*:)?c>)/g
+    )) {
       const attrs = cellMatch[1];
-      const content = cellMatch[2];
+      const content = cellMatch[2] ?? "";
       const ref = /\br="([^"]+)"/.exec(attrs)?.[1] ?? `A${matrix.length + 1}`;
       const index = columnIndex(ref);
       if (index >= MAX_COLUMNS) throw new HttpError(413, "TOO_MANY_COLUMNS", `La feuille ${name} dépasse ${MAX_COLUMNS} colonnes.`);
       const type = /\bt="([^"]+)"/.exec(attrs)?.[1] ?? "n";
       const styleIndex = Number(/\bs="(\d+)"/.exec(attrs)?.[1] ?? -1);
-      const raw = /<v\b[^>]*>([\s\S]*?)<\/v>/.exec(content)?.[1] ?? "";
-      const inline = /<is\b[^>]*>([\s\S]*?)<\/is>/.exec(content)?.[1] ?? "";
+      const raw = /<(?:[A-Za-z_][\w.-]*:)?v\b[^>]*>([\s\S]*?)<\/(?:[A-Za-z_][\w.-]*:)?v>/.exec(content)?.[1] ?? "";
+      const inline = /<(?:[A-Za-z_][\w.-]*:)?is\b[^>]*>([\s\S]*?)<\/(?:[A-Za-z_][\w.-]*:)?is>/.exec(content)?.[1] ?? "";
       let value: unknown = null;
       if (type === "s") value = sharedStrings[Number(raw)] ?? "";
-      else if (type === "inlineStr") value = [...inline.matchAll(/<t\b[^>]*>([\s\S]*?)<\/t>/g)].map((m) => decodeXml(m[1])).join("");
+      else if (type === "inlineStr") {
+        value = [...inline.matchAll(/<(?:[A-Za-z_][\w.-]*:)?t\b[^>]*>([\s\S]*?)<\/(?:[A-Za-z_][\w.-]*:)?t>/g)]
+          .map((m) => decodeXml(m[1]))
+          .join("");
+      }
       else if (type === "b") value = raw === "1";
       else if (type === "str" || type === "e") value = decodeXml(raw);
       else if (raw !== "") {
@@ -189,7 +197,11 @@ function parseSheetXml(
 }
 
 function resolvePart(base: string, target: string): string {
-  const normalized = path.posix.normalize(path.posix.join(path.posix.dirname(base), target));
+  const portableTarget = target.replace(/\\/g, "/");
+  const candidate = portableTarget.startsWith("/")
+    ? portableTarget.replace(/^\/+/, "")
+    : path.posix.join(path.posix.dirname(base), portableTarget);
+  const normalized = path.posix.normalize(candidate);
   if (normalized.startsWith("../") || normalized.startsWith("/")) throw new HttpError(400, "INVALID_XLSX_PATH", "Chemin de feuille XLSX interdit.");
   return normalized;
 }
@@ -202,7 +214,7 @@ function parseXlsx(buffer: Buffer): ParsedTabularFile {
   const relsPath = "xl/_rels/workbook.xml.rels";
   const relsXml = readZipEntry(buffer, entries, relsPath).toString("utf8");
   const rels = new Map<string, string>();
-  for (const match of relsXml.matchAll(/<Relationship\b([^>]*)\/?>/g)) {
+  for (const match of relsXml.matchAll(/<(?:[A-Za-z_][\w.-]*:)?Relationship\b([^>]*)\/?>/g)) {
     const id = /\bId="([^"]+)"/.exec(match[1])?.[1];
     const target = /\bTarget="([^"]+)"/.exec(match[1])?.[1];
     if (id && target) rels.set(id, resolvePart(workbookPath, decodeXml(target)));
@@ -215,7 +227,7 @@ function parseXlsx(buffer: Buffer): ParsedTabularFile {
     entries.has("xl/styles.xml") ? readZipEntry(buffer, entries, "xl/styles.xml").toString("utf8") : null
   );
   const sheets: ParsedTabularSheet[] = [];
-  for (const match of workbookXml.matchAll(/<sheet\b([^>]*)\/?>/g)) {
+  for (const match of workbookXml.matchAll(/<(?:[A-Za-z_][\w.-]*:)?sheet\b([^>]*)\/?>/g)) {
     if (sheets.length >= MAX_SHEETS) throw new HttpError(413, "TOO_MANY_SHEETS", `Le classeur dépasse ${MAX_SHEETS} feuilles.`);
     const name = decodeXml(/\bname="([^"]+)"/.exec(match[1])?.[1] ?? `Feuille ${sheets.length + 1}`);
     const relationId = /\br:id="([^"]+)"/.exec(match[1])?.[1];


### PR DESCRIPTION
Rend le parseur XLSX compatible avec les espaces de noms XML préfixés, les cellules vides autofermantes et les noms de parties absolus valides, sans relâcher la protection contre les chemins sortants. Validation: classeurs pilotes réels parsés, TypeScript propre et 2649 tests. Closes #174.