### PR TITLE
fix(import): make supplier address primary

### DIFF
--- a/src/__tests__/import-assistant.domain.test.ts
+++ b/src/__tests__/import-assistant.domain.test.ts
@@ -188,6 +188,45 @@ describe("Assistant d’import CLIPPER", () => {
     });
   });
 
+  it("marque l’adresse fournisseur importée comme adresse principale", () => {
+    const mapping: ImportMapping = {
+      legacy_key_column: "CODE",
+      columns: {
+        nom: "NOM",
+        "adresse.type": "ADRESSE_TYPE",
+        "adresse.label": "ADRESSE_LABEL",
+        "adresse.city": "VILLE",
+        "adresse.country": "PAYS",
+      },
+      constants: {},
+      approved_decisions: ["DEC-03", "DEC-14", "DEC-15"],
+      duplicate_strategy: "REVIEW",
+    };
+    const result = normalizeImportRow(
+      "FOURNISSEUR",
+      {
+        CODE: "F001",
+        NOM: "Fournisseur pilote",
+        ADRESSE_TYPE: "commande",
+        ADRESSE_LABEL: "Fournisseur pilote",
+        VILLE: "Lyon",
+        PAYS: "France",
+      },
+      mapping
+    );
+
+    expect(result.issues).toEqual([]);
+    expect(result.normalized_data).toMatchObject({
+      adresses: [{
+        type: "commande",
+        label: "Fournisseur pilote",
+        city: "Lyon",
+        country: "France",
+        is_primary: true,
+      }],
+    });
+  });
+
   it("garde stock, BL et RH visibles mais impossibles à confirmer", () => {
     const gated = IMPORT_CAPABILITIES.filter((capability) =>
       ["STOCK_INITIAL", "BL_HISTORIQUE", "EMPLOYE"].includes(capability.entity_type)

--- a/src/module/import-assistant/domain/import-normalization.ts
+++ b/src/module/import-assistant/domain/import-normalization.ts
@@ -136,7 +136,12 @@ function postProcess(entityType: ImportEntityType, draft: Record<string, unknown
     const address = draft.adresse;
     if (address && typeof address === "object" && !Array.isArray(address)) {
       const values = Object.values(address as Record<string, unknown>).filter((value) => value !== undefined);
-      if (values.length > 0) draft.adresses = [address];
+      if (values.length > 0) {
+        draft.adresses = [{
+          ...(address as Record<string, unknown>),
+          is_primary: true,
+        }];
+      }
       delete draft.adresse;
     }
   }


### PR DESCRIPTION
Closes #178\n\n## Résultat\n- marque l'unique adresse fournisseur produite par l'assistant comme principale;\n- conserve le mapping et la validation Fournisseurs existants;\n- ajoute un test métier de non-régression.\n\n## Validation\n- 10 tests du domaine import verts;\n- suite backend complète verte (2651 tests);\n- build TypeScript vert;\n- régularisation du pilote prévue via l'API sur cerp_test uniquement.

## Summary by Sourcery

Ensure imported supplier addresses are stored as a primary address and covered by regression tests.

Bug Fixes:
- Mark the single supplier address produced by the import assistant as the primary address in normalized data.

Tests:
- Add a domain-level regression test verifying that an imported supplier address is flagged as primary.