### PR TITLE
fix(import): conserver le client_id varchar des contacts (#184)

### DIFF
--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -28,6 +28,10 @@ Toutes les routes sont sous `/api/v1/import-assistant` et réservées aux rôles
   mappés sont écrits, sans listes vides implicites.
 - Contacts clients rattachés par le crosswalk du client parent, avec clé
   d’idempotence propre et validation obligatoire du prénom, nom et courriel.
+- Le rattachement conserve le contrat historique `clients.client_id` /
+  `contacts.client_id` en `varchar(3)` ; seul `contacts.contact_id` est un UUID.
+  La reprise idempotente ne doit donc jamais convertir l’identifiant client en
+  UUID.
 - Crosswalk stable entre clé CLIPPER et fiche CERP.
 - Reprise par lots de 25 lignes avec verrouillage `SKIP LOCKED`.
 - Confirmation et création idempotentes.

--- a/src/__tests__/client-contact.repository.test.ts
+++ b/src/__tests__/client-contact.repository.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+  insertAuditLog: vi.fn(),
+}));
+
+vi.mock("../config/database", () => ({
+  default: { connect: mocks.poolConnect, query: vi.fn() },
+}));
+
+vi.mock("../module/audit-logs/repository/audit-logs.repository", () => ({
+  repoInsertAuditLog: mocks.insertAuditLog,
+}));
+
+import { repoCreateClientContact } from "../module/client/repository/client.repository";
+
+const audit = {
+  user_id: 1,
+  ip: null,
+  user_agent: null,
+  device_type: null,
+  os: null,
+  browser: null,
+  path: "/api/v1/import-assistant",
+  page_key: "import-assistant",
+  client_session_id: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+  mocks.insertAuditLog.mockResolvedValue(undefined);
+  mocks.clientQuery.mockImplementation(async (sql: string) => {
+    const statement = String(sql);
+    if (statement.includes("FROM client_contact_create_idempotency")) {
+      return { rows: [] };
+    }
+    if (statement.includes("SELECT 1 FROM clients")) {
+      return { rows: [{ exists: 1 }] };
+    }
+    if (statement.includes("INSERT INTO contacts")) {
+      return {
+        rows: [{
+          contact_id: "11111111-1111-4111-8111-111111111111",
+          first_name: "Daniel",
+          last_name: "Leglevic",
+          email: "daniel@example.com",
+          phone_direct: null,
+          phone_personal: null,
+          role: null,
+          civility: null,
+        }],
+      };
+    }
+    return { rows: [] };
+  });
+});
+
+describe("repoCreateClientContact (#184)", () => {
+  it("compare le client_id historique varchar(3) comme du texte lors de la reprise idempotente", async () => {
+    await repoCreateClientContact(
+      "003",
+      {
+        first_name: "Daniel",
+        last_name: "Leglevic",
+        email: "daniel@example.com",
+        set_primary: false,
+      },
+      audit,
+      "clipper-contact-003-daniel",
+    );
+
+    const replaySql = mocks.clientQuery.mock.calls
+      .map(([sql]) => String(sql))
+      .find((sql) => sql.includes("FROM client_contact_create_idempotency"));
+
+    expect(replaySql).toContain("c.client_id::text = $2::text");
+    expect(replaySql).not.toContain("c.client_id = $2::uuid");
+    expect(mocks.clientRelease).toHaveBeenCalledOnce();
+  });
+});

--- a/src/module/client/repository/client.repository.ts
+++ b/src/module/client/repository/client.repository.ts
@@ -906,7 +906,7 @@ async function findClientContactIdempotentReplay(
      FROM client_contact_create_idempotency k
      JOIN contacts c ON c.contact_id = k.contact_id
      WHERE k.idempotency_key = $1
-       AND c.client_id = $2::uuid
+       AND c.client_id::text = $2::text
      LIMIT 1`,
     [idempotencyKey, clientId]
   );


### PR DESCRIPTION
Closes #184\n\n## Résultat\n- corrige la reprise idempotente des contacts sur le contrat historique client_id varchar(3) ;\n- conserve contact_id en UUID ;\n- ajoute un test de non-régression ciblé.\n\n## Vérifications\n- 18 tests ciblés OK ;\n- build TypeScript OK ;\n- diagnostic cerp_test : 129 lignes avaient toutes la même erreur avant correction, aucune création partielle.