### PR TITLE
release(import): contacts partagés entre clients

### DIFF
--- a/db/patches/20260727_contacts_email_scope_187.sql
+++ b/db/patches/20260727_contacts_email_scope_187.sql
@@ -1,0 +1,58 @@
+-- Issue #187 — l'unicité d'un courriel de contact appartient au client.
+-- Ce patch ne modifie aucune valeur métier : il remplace uniquement la
+-- contrainte globale historique par une unicité normalisée des contacts actifs
+-- d'un même client.
+
+BEGIN;
+
+DO $$
+DECLARE
+  legacy_constraint_definition text;
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Patch #187 refusé hors cerp_test (base actuelle : %)', current_database();
+  END IF;
+
+  IF to_regclass('public.contacts') IS NULL THEN
+    RAISE EXCEPTION 'Patch #187 refusé : table public.contacts absente';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM public.contacts
+     WHERE client_id IS NOT NULL
+       AND email IS NOT NULL
+       AND btrim(email) <> ''
+       AND archived_at IS NULL
+     GROUP BY client_id, lower(btrim(email))
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Patch #187 refusé : doublons de courriel actifs déjà présents dans un même client';
+  END IF;
+
+  SELECT pg_get_constraintdef(oid)
+    INTO legacy_constraint_definition
+    FROM pg_constraint
+   WHERE conrelid = 'public.contacts'::regclass
+     AND conname = 'contacts_email_key';
+
+  IF legacy_constraint_definition IS NOT NULL
+     AND legacy_constraint_definition <> 'UNIQUE (email)' THEN
+    RAISE EXCEPTION
+      'Patch #187 refusé : définition inattendue pour contacts_email_key : %',
+      legacy_constraint_definition;
+  END IF;
+END
+$$;
+
+ALTER TABLE public.contacts
+  DROP CONSTRAINT IF EXISTS contacts_email_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS contacts_client_email_active_key
+  ON public.contacts (client_id, lower(btrim(email)))
+  WHERE client_id IS NOT NULL
+    AND email IS NOT NULL
+    AND btrim(email) <> ''
+    AND archived_at IS NULL;
+
+COMMIT;

--- a/db/patches/support/20260727_contacts_email_scope_187.preflight.sql
+++ b/db/patches/support/20260727_contacts_email_scope_187.preflight.sql
@@ -1,0 +1,44 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Preflight #187 refusé hors cerp_test (base actuelle : %)', current_database();
+  END IF;
+
+  IF to_regclass('public.contacts') IS NULL THEN
+    RAISE EXCEPTION 'Preflight #187 refusé : table public.contacts absente';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM public.contacts
+     WHERE client_id IS NOT NULL
+       AND email IS NOT NULL
+       AND btrim(email) <> ''
+       AND archived_at IS NULL
+     GROUP BY client_id, lower(btrim(email))
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Preflight #187 refusé : doublons de courriel actifs dans un même client';
+  END IF;
+END
+$$;
+
+SELECT
+  current_database() AS database_name,
+  count(*) AS contacts_total,
+  count(*) FILTER (
+    WHERE client_id IS NOT NULL
+      AND email IS NOT NULL
+      AND btrim(email) <> ''
+      AND archived_at IS NULL
+  ) AS contacts_actifs_avec_courriel
+FROM public.contacts;
+
+SELECT
+  conname,
+  pg_get_constraintdef(oid) AS definition
+FROM pg_constraint
+WHERE conrelid = 'public.contacts'::regclass
+  AND conname = 'contacts_email_key';

--- a/db/patches/support/20260727_contacts_email_scope_187.rollback.sql
+++ b/db/patches/support/20260727_contacts_email_scope_187.rollback.sql
@@ -1,0 +1,7 @@
+-- À N'EXÉCUTER QUE SUR DÉCISION HUMAINE EXPLICITE.
+-- Après l'import de contacts partageant un courriel entre plusieurs clients,
+-- la contrainte globale historique ne peut plus être restaurée sans arbitrage
+-- métier et sans traitement de données.
+
+\echo 'Rollback automatique refusé : contrôler les courriels partagés et faire valider la procédure.'
+\quit 3

--- a/db/patches/support/20260727_contacts_email_scope_187.verify.sql
+++ b/db/patches/support/20260727_contacts_email_scope_187.verify.sql
@@ -1,0 +1,40 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Vérification #187 refusée hors cerp_test (base actuelle : %)', current_database();
+  END IF;
+END
+$$;
+
+SELECT
+  current_database() = 'cerp_test' AS is_test_database,
+  NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conrelid = 'public.contacts'::regclass
+       AND conname = 'contacts_email_key'
+  ) AS global_email_constraint_removed,
+  EXISTS (
+    SELECT 1
+      FROM pg_indexes
+     WHERE schemaname = 'public'
+       AND tablename = 'contacts'
+       AND indexname = 'contacts_client_email_active_key'
+       AND indexdef LIKE 'CREATE UNIQUE INDEX%'
+       AND indexdef LIKE '%client_id, lower(btrim((email)::text))%'
+       AND indexdef LIKE '%archived_at IS NULL%'
+  ) AS client_email_active_unique;
+
+SELECT count(*) AS same_client_active_email_duplicates
+FROM (
+  SELECT client_id, lower(btrim(email))
+    FROM public.contacts
+   WHERE client_id IS NOT NULL
+     AND email IS NOT NULL
+     AND btrim(email) <> ''
+     AND archived_at IS NULL
+   GROUP BY client_id, lower(btrim(email))
+  HAVING count(*) > 1
+) duplicates;

--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -28,6 +28,10 @@ Toutes les routes sont sous `/api/v1/import-assistant` et réservées aux rôles
   mappés sont écrits, sans listes vides implicites.
 - Contacts clients rattachés par le crosswalk du client parent, avec clé
   d’idempotence propre et validation obligatoire du prénom, nom et courriel.
+- Un même courriel peut appartenir à des contacts de clients différents
+  (adresse d’achats, de comptabilité ou de groupe partagée). L’unicité est
+  contrôlée sans tenir compte de la casse ni des espaces, par client actif ;
+  aucun courriel source ne doit être falsifié pour contourner un doublon.
 - Le rattachement conserve le contrat historique `clients.client_id` /
   `contacts.client_id` en `varchar(3)` ; seul `contacts.contact_id` est un UUID.
   La reprise idempotente ne doit donc jamais convertir l’identifiant client en
@@ -44,7 +48,10 @@ Patches :
 
 - `db/patches/20260726_import_assistant_167.sql` pour le socle ;
 - `db/patches/20260727_import_clients_enrichment_306.sql` pour
-  `CLIENT_ENRICHISSEMENT`, `CLIENT_CONTACT` et l’idempotence des contacts.
+  `CLIENT_ENRICHISSEMENT`, `CLIENT_CONTACT` et l’idempotence des contacts ;
+- `db/patches/20260727_contacts_email_scope_187.sql` pour remplacer, uniquement
+  dans `cerp_test`, l’unicité globale historique du courriel par une unicité
+  normalisée au sein d’un même client actif.
 
 Avant toute application, exécuter le preflight sur `cerp_test`, appliquer par le mécanisme de patches existant, puis lancer le script `verify`. Le rollback automatique est volontairement bloqué dès que des preuves ou correspondances peuvent exister.
 

--- a/src/__tests__/import-assistant.domain.test.ts
+++ b/src/__tests__/import-assistant.domain.test.ts
@@ -394,4 +394,18 @@ describe("Assistant d’import CLIPPER", () => {
     expect(patch).toContain("client_contact_create_idempotency");
     expect(patch).not.toMatch(/\bDROP\s+(TABLE|COLUMN|SCHEMA)\b/i);
   });
+
+  it("porte l'unicité du courriel de contact au niveau du client actif", () => {
+    const patch = fs.readFileSync(
+      path.resolve(process.cwd(), "db/patches/20260727_contacts_email_scope_187.sql"),
+      "utf8"
+    );
+
+    expect(patch).toContain("current_database() <> 'cerp_test'");
+    expect(patch).toContain("DROP CONSTRAINT IF EXISTS contacts_email_key");
+    expect(patch).toContain("CREATE UNIQUE INDEX IF NOT EXISTS contacts_client_email_active_key");
+    expect(patch).toContain("client_id, lower(btrim(email))");
+    expect(patch).toContain("archived_at IS NULL");
+    expect(patch).not.toMatch(/\b(UPDATE|DELETE|TRUNCATE)\b/i);
+  });
 });


### PR DESCRIPTION
## Correctif
- autorise un même email de contact pour plusieurs clients ;
- conserve l'unicité insensible à la casse au sein d'un client actif ;
- patch strictement verrouillé sur cerp_test pour cette validation.

## Validation
- preflight cerp_test : 123 contacts, aucun doublon intra-client ;
- 17 tests ciblés réussis ;
- build TypeScript réussi.

Closes #187