### PR TITLE
fix(contacts): autoriser les emails fonctionnels partagés

### DIFF
--- a/db/patches/20260727_contacts_shared_email_identity_190.sql
+++ b/db/patches/20260727_contacts_shared_email_identity_190.sql
@@ -1,0 +1,51 @@
+-- Issue #190 — une adresse fonctionnelle peut être partagée par plusieurs
+-- personnes distinctes d'un même client.
+-- Ce patch ne modifie aucune donnée métier. Il remplace l'unicité
+-- (client, courriel) par l'unicité de l'identité normalisée du contact actif.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Patch #190 refusé hors cerp_test (base actuelle : %)', current_database();
+  END IF;
+
+  IF to_regclass('public.contacts') IS NULL THEN
+    RAISE EXCEPTION 'Patch #190 refusé : table public.contacts absente';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM public.contacts
+     WHERE client_id IS NOT NULL
+       AND email IS NOT NULL
+       AND btrim(email) <> ''
+       AND archived_at IS NULL
+     GROUP BY
+       client_id,
+       lower(btrim(email)),
+       lower(btrim(coalesce(first_name, ''))),
+       lower(btrim(coalesce(last_name, '')))
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Patch #190 refusé : doublons exacts de contacts actifs déjà présents';
+  END IF;
+END
+$$;
+
+DROP INDEX IF EXISTS public.contacts_client_email_active_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS contacts_client_email_identity_active_key
+  ON public.contacts (
+    client_id,
+    lower(btrim(email)),
+    lower(btrim(coalesce(first_name, ''))),
+    lower(btrim(coalesce(last_name, '')))
+  )
+  WHERE client_id IS NOT NULL
+    AND email IS NOT NULL
+    AND btrim(email) <> ''
+    AND archived_at IS NULL;
+
+COMMIT;

--- a/db/patches/support/20260727_contacts_shared_email_identity_190.preflight.sql
+++ b/db/patches/support/20260727_contacts_shared_email_identity_190.preflight.sql
@@ -1,0 +1,63 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Preflight #190 refusé hors cerp_test (base actuelle : %)', current_database();
+  END IF;
+
+  IF to_regclass('public.contacts') IS NULL THEN
+    RAISE EXCEPTION 'Preflight #190 refusé : table public.contacts absente';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM public.contacts
+     WHERE client_id IS NOT NULL
+       AND email IS NOT NULL
+       AND btrim(email) <> ''
+       AND archived_at IS NULL
+     GROUP BY
+       client_id,
+       lower(btrim(email)),
+       lower(btrim(coalesce(first_name, ''))),
+       lower(btrim(coalesce(last_name, '')))
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Preflight #190 refusé : doublons exacts de contacts actifs';
+  END IF;
+END
+$$;
+
+SELECT
+  current_database() AS database_name,
+  count(*) AS contacts_total,
+  count(*) FILTER (
+    WHERE client_id IS NOT NULL
+      AND email IS NOT NULL
+      AND btrim(email) <> ''
+      AND archived_at IS NULL
+  ) AS contacts_actifs_avec_courriel
+FROM public.contacts;
+
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND tablename = 'contacts'
+  AND indexname IN (
+    'contacts_client_email_active_key',
+    'contacts_client_email_identity_active_key'
+  )
+ORDER BY indexname;
+
+SELECT count(*) AS same_client_shared_email_groups
+FROM (
+  SELECT client_id, lower(btrim(email))
+    FROM public.contacts
+   WHERE client_id IS NOT NULL
+     AND email IS NOT NULL
+     AND btrim(email) <> ''
+     AND archived_at IS NULL
+   GROUP BY client_id, lower(btrim(email))
+  HAVING count(*) > 1
+) shared;

--- a/db/patches/support/20260727_contacts_shared_email_identity_190.rollback.sql
+++ b/db/patches/support/20260727_contacts_shared_email_identity_190.rollback.sql
@@ -1,0 +1,35 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Rollback #190 refusé hors cerp_test (base actuelle : %)', current_database();
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM public.contacts
+     WHERE client_id IS NOT NULL
+       AND email IS NOT NULL
+       AND btrim(email) <> ''
+       AND archived_at IS NULL
+     GROUP BY client_id, lower(btrim(email))
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'Rollback #190 refusé : des personnes du même client partagent désormais un courriel';
+  END IF;
+END
+$$;
+
+DROP INDEX IF EXISTS public.contacts_client_email_identity_active_key;
+
+CREATE UNIQUE INDEX IF NOT EXISTS contacts_client_email_active_key
+  ON public.contacts (client_id, lower(btrim(email)))
+  WHERE client_id IS NOT NULL
+    AND email IS NOT NULL
+    AND btrim(email) <> ''
+    AND archived_at IS NULL;
+
+COMMIT;

--- a/db/patches/support/20260727_contacts_shared_email_identity_190.verify.sql
+++ b/db/patches/support/20260727_contacts_shared_email_identity_190.verify.sql
@@ -1,0 +1,69 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Vérification #190 refusée hors cerp_test (base actuelle : %)', current_database();
+  END IF;
+END
+$$;
+
+SELECT
+  current_database() = 'cerp_test' AS is_test_database,
+  NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conrelid = 'public.contacts'::regclass
+       AND conname = 'contacts_email_key'
+  ) AS global_email_constraint_removed,
+  NOT EXISTS (
+    SELECT 1
+      FROM pg_indexes
+     WHERE schemaname = 'public'
+       AND tablename = 'contacts'
+       AND indexname = 'contacts_client_email_active_key'
+  ) AS client_email_only_index_removed,
+  EXISTS (
+    SELECT 1
+      FROM pg_indexes
+     WHERE schemaname = 'public'
+       AND tablename = 'contacts'
+       AND indexname = 'contacts_client_email_identity_active_key'
+       AND indexdef LIKE 'CREATE UNIQUE INDEX%'
+       AND indexdef LIKE '%client_id, lower(btrim((email)::text))%'
+       AND indexdef LIKE '%lower(btrim((COALESCE(first_name%'
+       AND indexdef LIKE '%lower(btrim((COALESCE(last_name%'
+       AND indexdef LIKE '%archived_at IS NULL%'
+  ) AS contact_identity_active_unique;
+
+SELECT count(*) AS exact_active_contact_duplicates
+FROM (
+  SELECT
+    client_id,
+    lower(btrim(email)),
+    lower(btrim(coalesce(first_name, ''))),
+    lower(btrim(coalesce(last_name, '')))
+  FROM public.contacts
+  WHERE client_id IS NOT NULL
+    AND email IS NOT NULL
+    AND btrim(email) <> ''
+    AND archived_at IS NULL
+  GROUP BY
+    client_id,
+    lower(btrim(email)),
+    lower(btrim(coalesce(first_name, ''))),
+    lower(btrim(coalesce(last_name, '')))
+  HAVING count(*) > 1
+) duplicates;
+
+SELECT count(*) AS same_client_shared_email_groups
+FROM (
+  SELECT client_id, lower(btrim(email))
+    FROM public.contacts
+   WHERE client_id IS NOT NULL
+     AND email IS NOT NULL
+     AND btrim(email) <> ''
+     AND archived_at IS NULL
+   GROUP BY client_id, lower(btrim(email))
+  HAVING count(*) > 1
+) shared;

--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -28,10 +28,12 @@ Toutes les routes sont sous `/api/v1/import-assistant` et réservées aux rôles
   mappés sont écrits, sans listes vides implicites.
 - Contacts clients rattachés par le crosswalk du client parent, avec clé
   d’idempotence propre et validation obligatoire du prénom, nom et courriel.
-- Un même courriel peut appartenir à des contacts de clients différents
-  (adresse d’achats, de comptabilité ou de groupe partagée). L’unicité est
-  contrôlée sans tenir compte de la casse ni des espaces, par client actif ;
-  aucun courriel source ne doit être falsifié pour contourner un doublon.
+- Un même courriel peut appartenir à des contacts de clients différents ou à
+  plusieurs personnes distinctes d’un même client (adresse d’achats, de
+  comptabilité ou de groupe partagée). L’unicité est contrôlée sans tenir compte
+  de la casse ni des espaces sur le client, le courriel, le prénom et le nom du
+  contact actif ; aucun courriel source ne doit être falsifié pour contourner un
+  doublon.
 - Le rattachement conserve le contrat historique `clients.client_id` /
   `contacts.client_id` en `varchar(3)` ; seul `contacts.contact_id` est un UUID.
   La reprise idempotente ne doit donc jamais convertir l’identifiant client en
@@ -51,7 +53,10 @@ Patches :
   `CLIENT_ENRICHISSEMENT`, `CLIENT_CONTACT` et l’idempotence des contacts ;
 - `db/patches/20260727_contacts_email_scope_187.sql` pour remplacer, uniquement
   dans `cerp_test`, l’unicité globale historique du courriel par une unicité
-  normalisée au sein d’un même client actif.
+  normalisée au sein d’un même client actif ;
+- `db/patches/20260727_contacts_shared_email_identity_190.sql` pour affiner cette
+  règle, uniquement dans `cerp_test`, et autoriser des personnes distinctes
+  partageant une adresse fonctionnelle tout en bloquant le doublon exact actif.
 
 Avant toute application, exécuter le preflight sur `cerp_test`, appliquer par le mécanisme de patches existant, puis lancer le script `verify`. Le rollback automatique est volontairement bloqué dès que des preuves ou correspondances peuvent exister.
 

--- a/src/__tests__/import-assistant.domain.test.ts
+++ b/src/__tests__/import-assistant.domain.test.ts
@@ -408,4 +408,19 @@ describe("Assistant d’import CLIPPER", () => {
     expect(patch).toContain("archived_at IS NULL");
     expect(patch).not.toMatch(/\b(UPDATE|DELETE|TRUNCATE)\b/i);
   });
+
+  it("autorise un courriel fonctionnel partagé par des personnes distinctes du même client", () => {
+    const patch = fs.readFileSync(
+      path.resolve(process.cwd(), "db/patches/20260727_contacts_shared_email_identity_190.sql"),
+      "utf8"
+    );
+
+    expect(patch).toContain("current_database() <> 'cerp_test'");
+    expect(patch).toContain("DROP INDEX IF EXISTS public.contacts_client_email_active_key");
+    expect(patch).toContain("CREATE UNIQUE INDEX IF NOT EXISTS contacts_client_email_identity_active_key");
+    expect(patch).toContain("lower(btrim(coalesce(first_name, '')))");
+    expect(patch).toContain("lower(btrim(coalesce(last_name, '')))");
+    expect(patch).toContain("archived_at IS NULL");
+    expect(patch).not.toMatch(/\b(UPDATE|DELETE|TRUNCATE)\b/i);
+  });
 });


### PR DESCRIPTION
Closes #190

## Résultat
- autorise plusieurs personnes distinctes d'un même client avec la même adresse fonctionnelle ;
- conserve l'interdiction du doublon exact actif ;
- patch strictement limité à cerp_test ;
- ajoute preflight, vérification, rollback protégé, test et documentation.

## Validation
- 17 tests ciblés réussis ;
- build TypeScript réussi ;
- aucune donnée métier modifiée par le patch.