### PR TITLE
Import CLIPPER : activer le stock initial contrôlé

### DIFF
--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -24,6 +24,17 @@ Toutes les routes sont sous `/api/v1/import-assistant` et réservées aux rôles
 - SHA-256 du fichier et unicité du lot par source, domaine, empreinte et feuille.
 - Simulation par les schémas Zod existants.
 - Création par les services métier existants et codes générés par CERP.
+- Le stock d’ouverture exige un article déjà présent dans le crosswalk, un
+  article actif et géré en stock, ainsi qu’un magasin et un emplacement CERP
+  actifs, non ambigus, reliés au référentiel physique et autorisant les
+  entrées.
+- Chaque solde strictement positif crée puis comptabilise un mouvement
+  `ADJUSTMENT/IN` par article via le service stock normal. Le lot conserve la
+  date de cut-off, la provenance CLIPPER, la méthode de calcul et deux clés
+  d’idempotence distinctes pour la création et la comptabilisation.
+- Les soldes nuls ne sont pas importés. Les articles absents, inactifs, non
+  gérés en stock ou sans emplacement valide bloquent la simulation avant toute
+  écriture.
 - Enrichissement client par PATCH parcimonieux : seuls les champs réellement
   mappés sont écrits, sans listes vides implicites.
 - Contacts clients rattachés par le crosswalk du client parent, avec clé
@@ -65,10 +76,15 @@ Le patch est additif et n’importe aucune donnée métier.
 ## Ordre de reprise
 
 Les lots sont exécutés dans l’ordre : clients complets, contacts clients,
-fournisseurs, commandes fournisseurs, articles et matières achetés, machines et
-référentiels, puis pièces techniques. Une pièce technique ne doit pas être
-confirmée tant que ses clients, fournisseurs, matières et flux d’achat ne sont
-pas validés.
+fournisseurs, commandes fournisseurs, articles et matières achetés, stock
+d’ouverture, machines et référentiels, puis pièces techniques. Une pièce
+technique ne doit pas être confirmée tant que ses clients, fournisseurs,
+matières, flux d’achat et stocks de départ ne sont pas validés.
+
+Pour la reprise CLIPPER du 24 juillet 2026, le solde d’ouverture retenu est la
+somme chronologique `entrées + retours − sorties`. Les mouvements annulés sont
+ignorés. La colonne historique `ARTICLEM.COL_081` n’est pas un stock et ne doit
+jamais alimenter un mouvement d’ouverture.
 
 Le choix affiché par le frontend n’est jamais utilisé comme preuve. Le service
 API dédié à l’import doit disposer de son propre pool PostgreSQL vers

--- a/src/__tests__/import-assistant.domain.test.ts
+++ b/src/__tests__/import-assistant.domain.test.ts
@@ -439,12 +439,72 @@ describe("Assistant d’import CLIPPER", () => {
     ]));
   });
 
-  it("garde stock, BL et RH visibles mais impossibles à confirmer", () => {
-    const gated = IMPORT_CAPABILITIES.filter((capability) =>
-      ["STOCK_INITIAL", "BL_HISTORIQUE", "EMPLOYE"].includes(capability.entity_type)
+  it("normalise un stock d’ouverture positif avec un cut-off explicite", () => {
+    const mapping: ImportMapping = {
+      legacy_key_column: "ARTICLE",
+      columns: {
+        article_legacy_code: "ARTICLE",
+        quantity: "SOLDE",
+        magasin_code: "MAGASIN",
+        emplacement_code: "EMPLACEMENT",
+        cutoff_date: "CUT_OFF",
+      },
+      constants: {},
+      approved_decisions: ["DEC-05", "DEC-06", "DEC-15", "DEC-16"],
+      duplicate_strategy: "REVIEW",
+    };
+
+    const valid = normalizeImportRow(
+      "STOCK_INITIAL",
+      {
+        ARTICLE: "RO*303*ETIRE*22*1",
+        SOLDE: "738 000,00",
+        MAGASIN: "MAG-PRINCIPAL",
+        EMPLACEMENT: "STOCK-GENERAL",
+        CUT_OFF: "24/07/2026",
+      },
+      mapping
+    );
+    const blocked = normalizeImportRow(
+      "STOCK_INITIAL",
+      {
+        ARTICLE: "ARTICLE-VIDE",
+        SOLDE: "0",
+        MAGASIN: "MAG-PRINCIPAL",
+        EMPLACEMENT: "STOCK-GENERAL",
+        CUT_OFF: "2026-07-24",
+      },
+      mapping
     );
 
-    expect(gated).toHaveLength(3);
+    expect(valid.issues).toEqual([]);
+    expect(valid.normalized_data).toEqual({
+      article_legacy_code: "RO*303*ETIRE*22*1",
+      quantity: 738000,
+      magasin_code: "MAG-PRINCIPAL",
+      emplacement_code: "STOCK-GENERAL",
+      cutoff_date: "2026-07-24",
+    });
+    expect(blocked.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({ field: "quantity" }),
+    ]));
+  });
+
+  it("ouvre le stock initial mais garde BL et RH impossibles à confirmer", () => {
+    const stock = IMPORT_CAPABILITIES.find((capability) => capability.entity_type === "STOCK_INITIAL");
+    const gated = IMPORT_CAPABILITIES.filter((capability) =>
+      ["BL_HISTORIQUE", "EMPLOYE"].includes(capability.entity_type)
+    );
+
+    expect(stock?.confirm_enabled).toBe(true);
+    expect(stock?.fields.map((field) => field.key)).toEqual(expect.arrayContaining([
+      "article_legacy_code",
+      "quantity",
+      "magasin_code",
+      "emplacement_code",
+      "cutoff_date",
+    ]));
+    expect(gated).toHaveLength(2);
     expect(gated.every((capability) => !capability.confirm_enabled)).toBe(true);
     expect(gated.every((capability) => capability.unavailable_reason)).toBe(true);
   });

--- a/src/module/import-assistant/domain/import-capabilities.ts
+++ b/src/module/import-assistant/domain/import-capabilities.ts
@@ -206,6 +206,24 @@ const MACHINE_FIELDS: ImportTargetField[] = [
   commonOptional.notes,
 ];
 
+const STOCK_INITIAL_FIELDS: ImportTargetField[] = [
+  field("article_legacy_code", "Code article CLIPPER", "text", {
+    required: true,
+    hint: "L’article doit avoir été importé ou rapproché avant son stock d’ouverture",
+  }),
+  field("quantity", "Quantité d’ouverture", "number", {
+    required: true,
+    hint: "Solde strictement positif au cut-off ; les soldes nuls ne créent aucun mouvement",
+  }),
+  field("magasin_code", "Code magasin CERP", "text", { required: true }),
+  field("emplacement_code", "Code emplacement CERP", "text", { required: true }),
+  field("cutoff_date", "Date de cut-off", "date", { required: true }),
+  field("unite", "Unité CERP", "text", {
+    hint: "Laisser vide pour utiliser l’unité déjà définie sur l’article",
+  }),
+  field("notes", "Justification et provenance", "text", { sensitive: true }),
+];
+
 export const IMPORT_CAPABILITIES: ImportEntityCapability[] = [
   { entity_type: "CLIENT", label: "1A — Clients (création)", order: 10, confirm_enabled: true, unavailable_reason: null, fields: CLIENT_FIELDS, decisions: [DECISIONS["DEC-04"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
   { entity_type: "CLIENT_ENRICHISSEMENT", label: "1B — Clients (compléter les fiches)", order: 11, confirm_enabled: true, unavailable_reason: null, fields: CLIENT_ENRICHISSEMENT_FIELDS, decisions: [DECISIONS["DEC-04"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
@@ -214,7 +232,7 @@ export const IMPORT_CAPABILITIES: ImportEntityCapability[] = [
   { entity_type: "FOURNISSEUR_COMMANDE", label: "3 — Commandes fournisseurs ouvertes", order: 30, confirm_enabled: true, unavailable_reason: null, fields: FOURNISSEUR_COMMANDE_FIELDS, decisions: [DECISIONS["DEC-03"], DECISIONS["DEC-14"], DECISIONS["DEC-15"], DECISIONS["DEC-17"]] },
   { entity_type: "ARTICLE", label: "4 — Articles et matières achetés", order: 40, confirm_enabled: true, unavailable_reason: null, fields: ARTICLE_FIELDS, decisions: [DECISIONS["DEC-01"], DECISIONS["DEC-14"], DECISIONS["DEC-15"], DECISIONS["DEC-16"]] },
   { entity_type: "MACHINE", label: "5 — Machines CNC", order: 50, confirm_enabled: true, unavailable_reason: null, fields: MACHINE_FIELDS, decisions: [DECISIONS["DEC-07"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
-  { entity_type: "STOCK_INITIAL", label: "6 — Stock d’ouverture", order: 60, confirm_enabled: false, unavailable_reason: "Le stock doit passer par un inventaire ou des mouvements d’ouverture contrôlés ; les magasins, emplacements et le cut-off doivent être renseignés.", fields: [], decisions: [DECISIONS["DEC-05"], DECISIONS["DEC-06"], DECISIONS["DEC-15"], DECISIONS["DEC-16"]] },
+  { entity_type: "STOCK_INITIAL", label: "6 — Stock d’ouverture", order: 60, confirm_enabled: true, unavailable_reason: null, fields: STOCK_INITIAL_FIELDS, decisions: [DECISIONS["DEC-05"], DECISIONS["DEC-06"], DECISIONS["DEC-15"], DECISIONS["DEC-16"]] },
   { entity_type: "BL_HISTORIQUE", label: "7 — BL historiques", order: 70, confirm_enabled: false, unavailable_reason: "Le sort des BL ouverts et historiques doit être décidé avant toute écriture.", fields: [], decisions: [DECISIONS["DEC-13"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
   { entity_type: "EMPLOYE", label: "8 — Salariés", order: 80, confirm_enabled: false, unavailable_reason: "L’import RH reste fermé tant que le périmètre, les correspondances utilisateurs et la rétention ne sont pas documentés.", fields: [], decisions: [DECISIONS["DEC-09"], DECISIONS["DEC-12"], DECISIONS["DEC-15"]] },
   { entity_type: "PIECE_TECHNIQUE", label: "9 — Pièces techniques (dernière étape)", order: 90, confirm_enabled: true, unavailable_reason: null, fields: PIECE_FIELDS, decisions: [DECISIONS["DEC-02"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },

--- a/src/module/import-assistant/domain/import-normalization.ts
+++ b/src/module/import-assistant/domain/import-normalization.ts
@@ -51,6 +51,28 @@ const fournisseurCommandeImportSchema = createCommandeSchema.shape.body
   })
   .strict();
 
+const stockInitialImportSchema = z
+  .object({
+    article_legacy_code: z.string().trim().min(1, "Code article CLIPPER requis").max(200),
+    quantity: z.number().positive("La quantité d’ouverture doit être strictement positive").max(1_000_000_000_000),
+    magasin_code: z.string().trim().min(1, "Code magasin CERP requis").max(80),
+    emplacement_code: z.string().trim().min(1, "Code emplacement CERP requis").max(80),
+    cutoff_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date de cut-off attendue au format AAAA-MM-JJ"),
+    unite: z.string().trim().min(1).max(30).optional(),
+    notes: z.string().trim().min(1).max(2_000).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const parsed = new Date(`${value.cutoff_date}T00:00:00Z`);
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value.cutoff_date) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "La date de cut-off est invalide.",
+        path: ["cutoff_date"],
+      });
+    }
+  });
+
 function hasOwn(record: Record<string, unknown>, key: string) {
   return Object.prototype.hasOwnProperty.call(record, key);
 }
@@ -156,6 +178,8 @@ function entitySchema(entityType: ImportEntityType): { schema: ZodTypeAny; wrapp
       return { schema: createPieceTechniqueSchema, wrapped: true };
     case "MACHINE":
       return { schema: createMachineSchema, wrapped: true };
+    case "STOCK_INITIAL":
+      return { schema: stockInitialImportSchema, wrapped: false };
     default:
       return null;
   }

--- a/src/module/import-assistant/services/import-assistant.service.ts
+++ b/src/module/import-assistant/services/import-assistant.service.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import { resolveStockOpeningReferencesSVC } from "../../stock/services/stock.service";
 import { HttpError } from "../../../utils/httpError";
 import { getImportCapability, IMPORT_CAPABILITIES } from "../domain/import-capabilities";
 import { importRowDedupeKeys, normalizeImportRow, validateMapping } from "../domain/import-normalization";
@@ -189,6 +190,40 @@ export async function previewImportBatch(params: {
       legacy_keys: supplierLegacyKeys,
     })
     : new Map();
+  const stockArticleLegacyKeys = batch.entity_type === "STOCK_INITIAL"
+    ? normalized
+      .map((row) => row.result.normalized_data?.article_legacy_code)
+      .filter((value): value is string => typeof value === "string" && value.length > 0)
+    : [];
+  const stockArticleCrosswalk = stockArticleLegacyKeys.length > 0
+    ? await repo.repoFindCrosswalks({
+      source_system: batch.source_system,
+      entity_type: "ARTICLE",
+      legacy_keys: stockArticleLegacyKeys,
+    })
+    : new Map();
+  const stockOpeningReferences = batch.entity_type === "STOCK_INITIAL"
+    ? await resolveStockOpeningReferencesSVC(normalized.flatMap(({ stored, result }) => {
+      const data = result.normalized_data;
+      const articleLegacyCode = data?.article_legacy_code;
+      const magasinCode = data?.magasin_code;
+      const emplacementCode = data?.emplacement_code;
+      const article = typeof articleLegacyCode === "string"
+        ? stockArticleCrosswalk.get(articleLegacyCode)
+        : null;
+      if (
+        !article
+        || typeof magasinCode !== "string"
+        || typeof emplacementCode !== "string"
+      ) return [];
+      return [{
+        key: stored.id,
+        article_id: article.id,
+        magasin_code: magasinCode,
+        emplacement_code: emplacementCode,
+      }];
+    }))
+    : new Map();
   const dedupeEntity = batch.entity_type === "CLIENT_ENRICHISSEMENT"
     ? "CLIENT"
     : batch.entity_type;
@@ -315,6 +350,59 @@ export async function previewImportBatch(params: {
         issues: [],
         target_id: supplier.id,
         target_code: supplier.code,
+      };
+    }
+    if (batch.entity_type === "STOCK_INITIAL") {
+      const articleLegacyCode = result.normalized_data.article_legacy_code;
+      const article = typeof articleLegacyCode === "string"
+        ? stockArticleCrosswalk.get(articleLegacyCode)
+        : null;
+      if (!article) {
+        return {
+          id: stored.id,
+          legacy_key: result.legacy_key,
+          normalized_data: result.normalized_data,
+          status: "BLOCKED",
+          action: "SKIP",
+          issues: [{
+            code: "ARTICLE_CROSSWALK_MISSING",
+            message: "L’article CLIPPER doit être importé ou rapproché avant son stock d’ouverture.",
+            field: "article_legacy_code",
+          }],
+          target_id: null,
+          target_code: null,
+        };
+      }
+      const reference = stockOpeningReferences.get(stored.id);
+      if (!reference || reference.issue || !reference.magasin_id || !reference.emplacement_id) {
+        return {
+          id: stored.id,
+          legacy_key: result.legacy_key,
+          normalized_data: result.normalized_data,
+          status: "BLOCKED",
+          action: "SKIP",
+          issues: [{
+            code: reference?.issue?.code ?? "STOCK_REFERENCE_UNRESOLVED",
+            message: reference?.issue?.message ?? "Le magasin ou l’emplacement CERP n’a pas pu être validé.",
+            field: reference?.issue?.code.includes("MAGASIN")
+              ? "magasin_code"
+              : reference?.issue?.code.includes("EMPLACEMENT")
+                ? "emplacement_code"
+                : "article_legacy_code",
+          }],
+          target_id: null,
+          target_code: null,
+        };
+      }
+      return {
+        id: stored.id,
+        legacy_key: result.legacy_key,
+        normalized_data: result.normalized_data,
+        status: "VALID",
+        action: "CREATE",
+        issues: [],
+        target_id: article.id,
+        target_code: article.code,
       };
     }
     const duplicate = strongDedupe.get(result.legacy_key);

--- a/src/module/import-assistant/services/import-targets.service.ts
+++ b/src/module/import-assistant/services/import-targets.service.ts
@@ -19,8 +19,16 @@ import { createPieceTechniqueSVC } from "../../pieces-techniques/services/pieces
 import type { CreatePieceTechniqueBodyDTO } from "../../pieces-techniques/validators/pieces-techniques.validators";
 import { svcCreateMachine } from "../../production/services/production.service";
 import type { CreateMachineBodyDTO } from "../../production/validators/production.validators";
-import { createStockArticleSVC } from "../../stock/services/stock.service";
-import type { CreateArticleBodyDTO } from "../../stock/validators/stock.validators";
+import {
+  createStockArticleSVC,
+  createStockMovementSVC,
+  postStockMovementSVC,
+  resolveStockOpeningReferencesSVC,
+} from "../../stock/services/stock.service";
+import type {
+  CreateArticleBodyDTO,
+  CreateMovementBodyDTO,
+} from "../../stock/validators/stock.validators";
 import { HttpError } from "../../../utils/httpError";
 import type {
   ImportAuditContext,
@@ -131,6 +139,78 @@ export async function createImportTarget(params: {
         false
       );
       return { id: result.id, code: result.code };
+    }
+    case "STOCK_INITIAL": {
+      if (!params.parent_target_id) {
+        throw new HttpError(
+          409,
+          "IMPORT_ARTICLE_TARGET_MISSING",
+          "L’article CERP du stock d’ouverture est introuvable."
+        );
+      }
+      const data = params.normalized_data as {
+        article_legacy_code: string;
+        quantity: number;
+        magasin_code: string;
+        emplacement_code: string;
+        cutoff_date: string;
+        unite?: string;
+        notes?: string;
+      };
+      const references = await resolveStockOpeningReferencesSVC([{
+        key: "stock-opening",
+        article_id: params.parent_target_id,
+        magasin_code: data.magasin_code,
+        emplacement_code: data.emplacement_code,
+      }]);
+      const reference = references.get("stock-opening");
+      if (!reference || reference.issue || !reference.magasin_id || !reference.emplacement_id) {
+        throw new HttpError(
+          409,
+          reference?.issue?.code ?? "STOCK_REFERENCE_UNRESOLVED",
+          reference?.issue?.message ?? "Le magasin ou l’emplacement CERP n’a pas pu être validé."
+        );
+      }
+
+      const provenance = [
+        `Migration CLIPPER — stock d’ouverture au ${data.cutoff_date}.`,
+        "Solde reconstitué : entrées + retours − sorties ; mouvements annulés ignorés.",
+        `Article source : ${data.article_legacy_code}.`,
+        data.notes,
+      ].filter(Boolean).join(" ");
+      const movementBody: CreateMovementBodyDTO = {
+        movement_type: "ADJUSTMENT",
+        effective_at: `${data.cutoff_date}T23:59:59Z`,
+        source_document_type: "CLIPPER_STOCK_OPENING",
+        source_document_id: `${data.article_legacy_code}|${data.cutoff_date}`.slice(0, 120),
+        reason_code: "OPENING_BALANCE",
+        notes: provenance,
+        idempotency_key: `${params.idempotency_key}:create`,
+        lines: [{
+          article_id: params.parent_target_id,
+          qty: data.quantity,
+          ...(data.unite ? { unite: data.unite } : {}),
+          dst_magasin_id: reference.magasin_id,
+          dst_emplacement_id: reference.emplacement_id,
+          direction: "IN",
+          note: `Stock d’ouverture CLIPPER — ${data.cutoff_date}`,
+        }],
+      };
+      const draft = await createStockMovementSVC(movementBody, params.audit);
+      const posted = await postStockMovementSVC(
+        draft.movement.id,
+        {},
+        params.audit,
+        `${params.idempotency_key}:post`
+      );
+      if (!posted) {
+        throw new HttpError(
+          409,
+          "STOCK_OPENING_POST_FAILED",
+          "Le mouvement d’ouverture n’a pas pu être comptabilisé."
+        );
+      }
+      return { id: posted.movement.id, code: posted.movement.movement_no };
     }
     case "PIECE_TECHNIQUE": {
       const result = await createPieceTechniqueSVC(

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -109,6 +109,21 @@ export type AuditContext = {
   client_session_id: string | null;
 };
 
+export type StockOpeningReferenceInput = {
+  key: string;
+  article_id: string;
+  magasin_code: string;
+  emplacement_code: string;
+};
+
+export type StockOpeningReferenceResolution = {
+  key: string;
+  article_id: string;
+  magasin_id: string | null;
+  emplacement_id: number | null;
+  issue: { code: string; message: string } | null;
+};
+
 export type StockCommandType =
   | "MOVEMENT_CREATE"
   | "MOVEMENT_POST"
@@ -1774,6 +1789,127 @@ export async function getEmplacementMapping(
     location_type: row.location_type,
     restrictions: row.restrictions ?? {},
   };
+}
+
+export async function repoResolveStockOpeningReferences(
+  inputs: StockOpeningReferenceInput[]
+): Promise<Map<string, StockOpeningReferenceResolution>> {
+  if (inputs.length === 0) return new Map();
+
+  const result = await db.query<{
+    key: string;
+    article_id: string;
+    article_found: boolean;
+    article_active: boolean | null;
+    stock_managed: boolean | null;
+    magasin_id: string | null;
+    magasin_matches: number | string | null;
+    magasin_active: boolean | null;
+    emplacement_id: number | null;
+    emplacement_matches: number | string | null;
+    emplacement_active: boolean | null;
+    allow_inbound: boolean | null;
+    location_id: string | null;
+    warehouse_id: string | null;
+  }>(
+    `
+      WITH requested AS (
+        SELECT
+          item.key,
+          item.article_id::uuid AS article_id,
+          item.magasin_code,
+          item.emplacement_code
+        FROM jsonb_to_recordset($1::jsonb) AS item(
+          key text,
+          article_id text,
+          magasin_code text,
+          emplacement_code text
+        )
+      )
+      SELECT
+        requested.key,
+        requested.article_id::text AS article_id,
+        (article.id IS NOT NULL) AS article_found,
+        article.is_active AS article_active,
+        article.stock_managed,
+        magasin.id::text AS magasin_id,
+        COALESCE(magasin.matches, 0) AS magasin_matches,
+        magasin.is_active AS magasin_active,
+        emplacement.id::int AS emplacement_id,
+        COALESCE(emplacement.matches, 0) AS emplacement_matches,
+        emplacement.is_active AS emplacement_active,
+        emplacement.allow_inbound,
+        emplacement.location_id::text AS location_id,
+        location.warehouse_id::text AS warehouse_id
+      FROM requested
+      LEFT JOIN public.articles article ON article.id = requested.article_id
+      LEFT JOIN LATERAL (
+        SELECT
+          candidate.id,
+          COALESCE(candidate.is_active, candidate.actif, false) AS is_active,
+          count(*) OVER ()::int AS matches
+        FROM public.magasins candidate
+        WHERE upper(btrim(COALESCE(candidate.code, candidate.code_magasin))) =
+              upper(btrim(requested.magasin_code))
+        ORDER BY candidate.id
+        LIMIT 1
+      ) magasin ON true
+      LEFT JOIN LATERAL (
+        SELECT
+          candidate.id,
+          candidate.is_active,
+          candidate.allow_inbound,
+          candidate.location_id,
+          count(*) OVER ()::int AS matches
+        FROM public.emplacements candidate
+        WHERE candidate.magasin_id = magasin.id
+          AND upper(btrim(candidate.code)) = upper(btrim(requested.emplacement_code))
+        ORDER BY candidate.id
+        LIMIT 1
+      ) emplacement ON true
+      LEFT JOIN public.locations location ON location.id = emplacement.location_id
+      ORDER BY requested.key
+    `,
+    [JSON.stringify(inputs)]
+  );
+
+  return new Map(result.rows.map((row) => {
+    let issue: StockOpeningReferenceResolution["issue"] = null;
+    const magasinMatches = Number(row.magasin_matches ?? 0);
+    const emplacementMatches = Number(row.emplacement_matches ?? 0);
+
+    if (!row.article_found) {
+      issue = { code: "STOCK_ARTICLE_NOT_FOUND", message: "L’article CERP rapproché est introuvable." };
+    } else if (!row.article_active) {
+      issue = { code: "STOCK_ARTICLE_INACTIVE", message: "L’article CERP rapproché est inactif." };
+    } else if (!row.stock_managed) {
+      issue = { code: "STOCK_ARTICLE_NOT_MANAGED", message: "L’article CERP n’est pas géré en stock." };
+    } else if (magasinMatches === 0) {
+      issue = { code: "STOCK_MAGASIN_NOT_FOUND", message: "Le code magasin CERP est introuvable." };
+    } else if (magasinMatches > 1) {
+      issue = { code: "STOCK_MAGASIN_AMBIGUOUS", message: "Le code magasin CERP correspond à plusieurs magasins." };
+    } else if (!row.magasin_active) {
+      issue = { code: "STOCK_MAGASIN_INACTIVE", message: "Le magasin CERP est inactif." };
+    } else if (emplacementMatches === 0) {
+      issue = { code: "STOCK_EMPLACEMENT_NOT_FOUND", message: "Le code emplacement CERP est introuvable dans ce magasin." };
+    } else if (emplacementMatches > 1) {
+      issue = { code: "STOCK_EMPLACEMENT_AMBIGUOUS", message: "Le code emplacement CERP correspond à plusieurs emplacements." };
+    } else if (!row.emplacement_active) {
+      issue = { code: "STOCK_EMPLACEMENT_INACTIVE", message: "L’emplacement CERP est inactif." };
+    } else if (!row.allow_inbound) {
+      issue = { code: "STOCK_EMPLACEMENT_INBOUND_REFUSED", message: "L’emplacement CERP refuse les entrées de stock." };
+    } else if (!row.location_id || !row.warehouse_id) {
+      issue = { code: "STOCK_EMPLACEMENT_NOT_MAPPED", message: "L’emplacement CERP n’est pas relié au référentiel physique de stock." };
+    }
+
+    return [row.key, {
+      key: row.key,
+      article_id: row.article_id,
+      magasin_id: row.magasin_id,
+      emplacement_id: row.emplacement_id,
+      issue,
+    }];
+  }));
 }
 
 export async function ensureStockLevel(

--- a/src/module/stock/services/stock.service.ts
+++ b/src/module/stock/services/stock.service.ts
@@ -65,6 +65,10 @@ import type {
   UpdateMagasinBodyDTO,
 } from "../validators/stock.validators";
 import type { AuditContext } from "../repository/stock.repository";
+import type {
+  StockOpeningReferenceInput,
+  StockOpeningReferenceResolution,
+} from "../repository/stock.repository";
 import {
   repoCloseInventorySession,
   repoStartInventorySession,
@@ -118,6 +122,7 @@ import {
   repoUpdateArticle,
   repoArchiveArticle,
   repoReactivateArticle,
+  repoResolveStockOpeningReferences,
   repoListArticleVersions,
   repoListArticleWhereUsed,
   repoUpdateEmplacement,
@@ -129,6 +134,12 @@ import {
   repoDeactivateMagasin,
   repoActivateMagasin,
 } from "../repository/stock.repository";
+
+export async function resolveStockOpeningReferencesSVC(
+  inputs: StockOpeningReferenceInput[]
+): Promise<Map<string, StockOpeningReferenceResolution>> {
+  return repoResolveStockOpeningReferences(inputs);
+}
 
 export async function listStockInventorySessionsSVC(filters: ListInventorySessionsQueryDTO) {
   return repoListInventorySessions(filters);


### PR DESCRIPTION
Closes #195

## Changements

- ouvre le domaine `STOCK_INITIAL` dans l’assistant d’import `cerp_test` ;
- exige un article déjà rapproché, actif et géré en stock ;
- valide le magasin, l’emplacement, leur activation, leur rattachement physique et l’autorisation d’entrée ;
- crée puis comptabilise un mouvement `ADJUSTMENT/IN` idempotent par article via le service stock normal ;
- conserve le cut-off, la provenance CLIPPER et la méthode `E + R − S`, mouvements `A` ignorés ;
- bloque les quantités nulles, les références absentes et toute ambiguïté avant écriture ;
- documente explicitement que `ARTICLEM.COL_081` n’est pas un stock.

## Impact

Aucune migration de schéma et aucune écriture en production. Le flux reste verrouillé sur `cerp_test` par la garde existante de l’assistant.

## Validation

- `npm run build`
- 54 tests ciblés au vert : assistant d’import, commandes stock, disponibilité et validateurs stock
- `git diff --check`

## Summary by Sourcery

Enable controlled import of initial stock balances from CLIPPER via the import assistant, validating references and creating idempotent stock movements.

New Features:
- Add support in the import assistant for the STOCK_INITIAL domain, including schema, capability configuration, and normalization of stock opening rows.
- Introduce resolution of stock opening references (articles, magasins, emplacements) with validation of activity, stock management, uniqueness, and physical mapping.
- Create initial stock movements of type ADJUSTMENT/IN during import, preserving cut-off date, provenance, and idempotency.

Enhancements:
- Document the CLIPPER stock opening process, constraints, calculation method, and non-usage of ARTICLEM.COL_081.
- Extend tests to cover stock opening normalization, capability gating, and end-to-end behavior of the STOCK_INITIAL import flow.