### PR TITLE
fix(stock): preserve six-decimal import quantities

### DIFF
--- a/db/patches/20260727_stock_import_precision_198.sql
+++ b/db/patches/20260727_stock_import_precision_198.sql
@@ -1,0 +1,98 @@
+-- Issue #198 — preserve the canonical six-decimal stock quantity precision.
+-- cerp_test only. The repair is restricted to one-line CLIPPER opening
+-- movements whose line differs from the posted header by less than 0.0005,
+-- which is the maximum loss introduced by NUMERIC(18,3).
+
+BEGIN;
+
+DO $$
+DECLARE
+  current_scale integer;
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Patch #198 refused outside cerp_test (current database: %)', current_database();
+  END IF;
+
+  SELECT numeric_scale
+    INTO current_scale
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'stock_movement_lines'
+    AND column_name = 'qty';
+
+  IF current_scale IS NULL THEN
+    RAISE EXCEPTION 'Patch #198 refused: public.stock_movement_lines.qty is missing';
+  END IF;
+  IF current_scale NOT IN (3, 6) THEN
+    RAISE EXCEPTION 'Patch #198 refused: unexpected stock_movement_lines.qty scale %', current_scale;
+  END IF;
+END
+$$;
+
+ALTER TABLE public.stock_movement_lines
+  ALTER COLUMN qty TYPE numeric(18,6)
+  USING qty::numeric(18,6);
+
+-- The normal immutability trigger is retained for application traffic. It is
+-- disabled only inside this transaction for the bounded, audited repair below.
+ALTER TABLE public.stock_movement_lines
+  DISABLE TRIGGER trg_protect_posted_stock_movement_line;
+
+WITH opening_lines AS (
+  SELECT
+    l.id AS line_id,
+    l.movement_id,
+    l.qty AS old_line_qty,
+    m.qty AS posted_qty,
+    COALESCE(m.posted_by, m.updated_by, m.created_by, m.user_id) AS actor_user_id,
+    COUNT(*) OVER (PARTITION BY l.movement_id) AS lines_count
+  FROM public.stock_movement_lines l
+  JOIN public.stock_movements m ON m.id = l.movement_id
+  WHERE m.status = 'POSTED'
+    AND m.source_document_type = 'CLIPPER_STOCK_OPENING'
+),
+repaired AS (
+  UPDATE public.stock_movement_lines l
+  SET
+    qty = opening_lines.posted_qty,
+    updated_at = now(),
+    updated_by = opening_lines.actor_user_id
+  FROM opening_lines
+  WHERE l.id = opening_lines.line_id
+    AND opening_lines.lines_count = 1
+    AND opening_lines.old_line_qty IS DISTINCT FROM opening_lines.posted_qty
+    AND abs(opening_lines.old_line_qty - opening_lines.posted_qty) < 0.0005
+  RETURNING
+    opening_lines.movement_id,
+    opening_lines.old_line_qty,
+    opening_lines.posted_qty,
+    opening_lines.actor_user_id
+)
+INSERT INTO public.stock_movement_event_log (
+  id,
+  stock_movement_id,
+  event_type,
+  old_values,
+  new_values,
+  user_id,
+  created_by,
+  updated_by
+)
+SELECT
+  gen_random_uuid(),
+  movement_id,
+  'PRECISION_RECONCILED_198',
+  jsonb_build_object('line_qty', old_line_qty),
+  jsonb_build_object(
+    'line_qty', posted_qty,
+    'reason', 'Widen stock_movement_lines.qty from NUMERIC(18,3) to NUMERIC(18,6)'
+  ),
+  actor_user_id,
+  actor_user_id,
+  actor_user_id
+FROM repaired;
+
+ALTER TABLE public.stock_movement_lines
+  ENABLE TRIGGER trg_protect_posted_stock_movement_line;
+
+COMMIT;

--- a/db/patches/support/20260727_stock_import_precision_198.preflight.sql
+++ b/db/patches/support/20260727_stock_import_precision_198.preflight.sql
@@ -1,0 +1,67 @@
+\set ON_ERROR_STOP on
+
+DO $$
+DECLARE
+  current_scale integer;
+  unsafe_mismatches integer;
+  multi_line_openings integer;
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Preflight #198 refused outside cerp_test (current database: %)', current_database();
+  END IF;
+
+  SELECT numeric_scale
+    INTO current_scale
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'stock_movement_lines'
+    AND column_name = 'qty';
+
+  IF current_scale NOT IN (3, 6) THEN
+    RAISE EXCEPTION 'Preflight #198 refused: unexpected stock_movement_lines.qty scale %', current_scale;
+  END IF;
+
+  WITH opening_lines AS (
+    SELECT
+      l.movement_id,
+      l.qty AS line_qty,
+      m.qty AS posted_qty,
+      COUNT(*) OVER (PARTITION BY l.movement_id) AS lines_count
+    FROM public.stock_movement_lines l
+    JOIN public.stock_movements m ON m.id = l.movement_id
+    WHERE m.status = 'POSTED'
+      AND m.source_document_type = 'CLIPPER_STOCK_OPENING'
+  )
+  SELECT
+    COUNT(*) FILTER (
+      WHERE line_qty IS DISTINCT FROM posted_qty
+        AND abs(line_qty - posted_qty) >= 0.0005
+    ),
+    COUNT(DISTINCT movement_id) FILTER (WHERE lines_count <> 1)
+  INTO unsafe_mismatches, multi_line_openings
+  FROM opening_lines;
+
+  IF unsafe_mismatches > 0 THEN
+    RAISE EXCEPTION 'Preflight #198 refused: % opening line/header mismatches are not rounding residues', unsafe_mismatches;
+  END IF;
+  IF multi_line_openings > 0 THEN
+    RAISE EXCEPTION 'Preflight #198 refused: % CLIPPER opening movements contain multiple lines', multi_line_openings;
+  END IF;
+END
+$$;
+
+SELECT
+  c.numeric_precision,
+  c.numeric_scale,
+  COUNT(*) FILTER (
+    WHERE m.status = 'POSTED'
+      AND m.source_document_type = 'CLIPPER_STOCK_OPENING'
+      AND l.qty IS DISTINCT FROM m.qty
+  ) AS opening_mismatches_before
+FROM information_schema.columns c
+CROSS JOIN public.stock_movement_lines l
+JOIN public.stock_movements m ON m.id = l.movement_id
+WHERE c.table_schema = 'public'
+  AND c.table_name = 'stock_movement_lines'
+  AND c.column_name = 'qty'
+GROUP BY c.numeric_precision, c.numeric_scale;

--- a/db/patches/support/20260727_stock_import_precision_198.rollback.sql
+++ b/db/patches/support/20260727_stock_import_precision_198.rollback.sql
@@ -1,0 +1,86 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $$
+DECLARE
+  current_scale integer;
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Rollback #198 refused outside cerp_test (current database: %)', current_database();
+  END IF;
+
+  SELECT numeric_scale
+    INTO current_scale
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'stock_movement_lines'
+    AND column_name = 'qty';
+
+  IF current_scale <> 6 THEN
+    RAISE EXCEPTION 'Rollback #198 refused: expected scale 6, found %', current_scale;
+  END IF;
+END
+$$;
+
+ALTER TABLE public.stock_movement_lines
+  DISABLE TRIGGER trg_protect_posted_stock_movement_line;
+
+WITH latest_repair AS (
+  SELECT DISTINCT ON (stock_movement_id)
+    stock_movement_id,
+    (old_values ->> 'line_qty')::numeric(18,6) AS old_line_qty,
+    user_id
+  FROM public.stock_movement_event_log
+  WHERE event_type = 'PRECISION_RECONCILED_198'
+  ORDER BY stock_movement_id, created_at DESC, id DESC
+),
+restored AS (
+  UPDATE public.stock_movement_lines l
+  SET
+    qty = latest_repair.old_line_qty,
+    updated_at = now(),
+    updated_by = latest_repair.user_id
+  FROM latest_repair
+  WHERE l.movement_id = latest_repair.stock_movement_id
+  RETURNING l.movement_id, latest_repair.user_id
+)
+INSERT INTO public.stock_movement_event_log (
+  id,
+  stock_movement_id,
+  event_type,
+  new_values,
+  user_id,
+  created_by,
+  updated_by
+)
+SELECT
+  gen_random_uuid(),
+  movement_id,
+  'PRECISION_ROLLBACK_198',
+  jsonb_build_object('reason', 'Rollback issue #198'),
+  user_id,
+  user_id,
+  user_id
+FROM restored;
+
+ALTER TABLE public.stock_movement_lines
+  ENABLE TRIGGER trg_protect_posted_stock_movement_line;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.stock_movement_lines
+    WHERE qty <> round(qty, 3)
+  ) THEN
+    RAISE EXCEPTION 'Rollback #198 refused: six-decimal quantities exist outside the audited repair set';
+  END IF;
+END
+$$;
+
+ALTER TABLE public.stock_movement_lines
+  ALTER COLUMN qty TYPE numeric(18,3)
+  USING qty::numeric(18,3);
+
+COMMIT;

--- a/db/patches/support/20260727_stock_import_precision_198.verify.sql
+++ b/db/patches/support/20260727_stock_import_precision_198.verify.sql
@@ -1,0 +1,34 @@
+\set ON_ERROR_STOP on
+
+SELECT current_database() = 'cerp_test' AS is_test_database;
+
+SELECT
+  numeric_precision = 18 AS precision_is_18,
+  numeric_scale = 6 AS scale_is_6
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'stock_movement_lines'
+  AND column_name = 'qty';
+
+SELECT COUNT(*) = 0 AS opening_lines_match_posted_headers
+FROM public.stock_movement_lines l
+JOIN public.stock_movements m ON m.id = l.movement_id
+WHERE m.status = 'POSTED'
+  AND m.source_document_type = 'CLIPPER_STOCK_OPENING'
+  AND l.qty IS DISTINCT FROM m.qty;
+
+SELECT COUNT(*) = 0 AS opening_headers_match_stock_levels
+FROM public.stock_movements m
+JOIN public.stock_levels sl ON sl.id = m.stock_level_id
+WHERE m.status = 'POSTED'
+  AND m.source_document_type = 'CLIPPER_STOCK_OPENING'
+  AND sl.qty_total IS DISTINCT FROM m.qty;
+
+SELECT
+  COUNT(*) AS precision_repair_events,
+  COUNT(*) FILTER (
+    WHERE old_values ? 'line_qty'
+      AND new_values ? 'line_qty'
+  ) = COUNT(*) AS all_repairs_are_audited
+FROM public.stock_movement_event_log
+WHERE event_type = 'PRECISION_RECONCILED_198';

--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -32,6 +32,12 @@ Toutes les routes sont sous `/api/v1/import-assistant` et réservées aux rôles
   `ADJUSTMENT/IN` par article via le service stock normal. Le lot conserve la
   date de cut-off, la provenance CLIPPER, la méthode de calcul et deux clés
   d’idempotence distinctes pour la création et la comptabilisation.
+- Les quantités de mouvement, de ligne et de niveau de stock partagent une
+  précision canonique de six décimales. Le patch #198 élargit
+  `stock_movement_lines.qty` de `NUMERIC(18,3)` à `NUMERIC(18,6)` et réconcilie
+  uniquement les résidus d’arrondi inférieurs à `0,0005` des mouvements
+  d’ouverture CLIPPER à ligne unique. Chaque correction produit un événement
+  de stock auditable.
 - Les soldes nuls ne sont pas importés. Les articles absents, inactifs, non
   gérés en stock ou sans emplacement valide bloquent la simulation avant toute
   écriture.
@@ -68,6 +74,9 @@ Patches :
 - `db/patches/20260727_contacts_shared_email_identity_190.sql` pour affiner cette
   règle, uniquement dans `cerp_test`, et autoriser des personnes distinctes
   partageant une adresse fonctionnelle tout en bloquant le doublon exact actif.
+- `db/patches/20260727_stock_import_precision_198.sql` pour aligner, uniquement
+  dans `cerp_test`, la précision des lignes de mouvement sur le grand livre
+  stock à six décimales et réparer les seuls résidus d’arrondi prouvés.
 
 Avant toute application, exécuter le preflight sur `cerp_test`, appliquer par le mécanisme de patches existant, puis lancer le script `verify`. Le rollback automatique est volontairement bloqué dès que des preuves ou correspondances peuvent exister.
 

--- a/src/__tests__/stock-import-precision-198.migration-guards.test.ts
+++ b/src/__tests__/stock-import-precision-198.migration-guards.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const patch = readFileSync(
+  resolve(root, "db/patches/20260727_stock_import_precision_198.sql"),
+  "utf8"
+);
+const preflight = readFileSync(
+  resolve(root, "db/patches/support/20260727_stock_import_precision_198.preflight.sql"),
+  "utf8"
+);
+const verify = readFileSync(
+  resolve(root, "db/patches/support/20260727_stock_import_precision_198.verify.sql"),
+  "utf8"
+);
+const rollback = readFileSync(
+  resolve(root, "db/patches/support/20260727_stock_import_precision_198.rollback.sql"),
+  "utf8"
+);
+
+describe("stock opening precision migration #198", () => {
+  it("widens movement lines to the six-decimal stock ledger precision", () => {
+    expect(patch).toContain("ALTER COLUMN qty TYPE numeric(18,6)");
+    expect(patch).toContain("source_document_type = 'CLIPPER_STOCK_OPENING'");
+    expect(patch).toContain("abs(opening_lines.old_line_qty - opening_lines.posted_qty) < 0.0005");
+  });
+
+  it("keeps the posted-line repair bounded, transactional and auditable", () => {
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("current_database() <> 'cerp_test'");
+    expect(patch).toContain("DISABLE TRIGGER trg_protect_posted_stock_movement_line");
+    expect(patch).toContain("ENABLE TRIGGER trg_protect_posted_stock_movement_line");
+    expect(patch).toContain("PRECISION_RECONCILED_198");
+    expect(patch).toContain("COMMIT;");
+  });
+
+  it("blocks unsafe data and verifies line, header and level reconciliation", () => {
+    expect(preflight).toContain("abs(line_qty - posted_qty) >= 0.0005");
+    expect(preflight).toContain("lines_count <> 1");
+    expect(verify).toContain("opening_lines_match_posted_headers");
+    expect(verify).toContain("opening_headers_match_stock_levels");
+  });
+
+  it("provides a conservative test-only rollback", () => {
+    expect(rollback).toContain("current_database() <> 'cerp_test'");
+    expect(rollback).toContain("PRECISION_ROLLBACK_198");
+    expect(rollback).toContain("ALTER COLUMN qty TYPE numeric(18,3)");
+    expect(rollback).toContain("six-decimal quantities exist outside the audited repair set");
+  });
+});


### PR DESCRIPTION
## Summary
- align stock movement line quantities with the six-decimal stock ledger
- repair only proven CLIPPER opening rounding residues in cerp_test
- add preflight, verification, rollback, audit events, and migration guards

## Validation
- targeted Vitest: 4/4 passed
- TypeScript build passed
- cerp_test: 233/233 opening movements reconciled, 0 mismatches
- cerp_prod fingerprint unchanged

Closes #198

## Summary by Sourcery

Align stock movement line quantities with six-decimal stock ledger precision and add guarded, auditable migration scripts around the correction of CLIPPER opening rounding residues.

Enhancements:
- Add a migration patch to widen stock movement line quantity precision and reconcile proven rounding residues with full auditing and safety checks.

Deployment:
- Introduce preflight, verification, and rollback SQL scripts for the stock precision patch to safely manage data corrections in the test database.

Documentation:
- Document six-decimal stock quantity precision and the new test-only stock import patch in the import assistant guide.

Tests:
- Add migration guard tests to ensure the stock precision patch, preflight, verification, and rollback scripts remain bounded, test-only, and auditable.