### PR TITLE
release: publier import stock, RBAC multi-rôles et tour de contrôle des accès

### DIFF
--- a/db/patches/20260727_admin_access_tower_326.sql
+++ b/db/patches/20260727_admin_access_tower_326.sql
@@ -1,0 +1,190 @@
+-- Module « Tour de contrôle des accès » — socle serveur du filtrage module par compte.
+-- Issue frontend #326 ; issue backend #200.
+-- Migration ADDITIVE + IDEMPOTENTE uniquement (aucun DROP, aucun changement de type,
+-- aucune restriction posée par le patch : tout module naît débloqué).
+-- Le statut superadmin n'est accordé par AUCUNE API : uniquement par le seed gardé
+-- db/seeds/access-tower-superadmin-keenan.sql.
+-- Verify : db/patches/support/20260727_admin_access_tower_326.verify.sql
+-- Preflight : db/patches/support/20260727_admin_access_tower_326.preflight.sql
+-- Rollback : db/patches/support/20260727_admin_access_tower_326.rollback.sql
+
+BEGIN;
+
+-- ------------------------------------------------------------------ Marqueur de compte
+-- `is_superadmin` est un marqueur de compte, pas un rôle métier : il ne participe
+-- pas au RBAC #315 et ne peut donc pas être obtenu par une attribution de rôle.
+ALTER TABLE public.users
+  ADD COLUMN IF NOT EXISTS is_superadmin boolean NOT NULL DEFAULT false;
+
+-- ------------------------------------------------------------------ Catalogue de modules
+CREATE TABLE IF NOT EXISTS public.app_modules (
+  module_key text PRIMARY KEY,
+  label text NOT NULL,
+  description text NULL,
+  category text NOT NULL DEFAULT 'Autre',
+  api_prefixes text[] NOT NULL DEFAULT '{}',
+  nav_page_keys text[] NOT NULL DEFAULT '{}',
+  enabled_by_default boolean NOT NULL DEFAULT true,
+  is_protected boolean NOT NULL DEFAULT false,
+  sort_order integer NOT NULL DEFAULT 0,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- ------------------------------------------------------------------ Décisions explicites
+-- L'absence de ligne signifie « hérité du catalogue » : c'est la valeur par défaut,
+-- jamais un refus. Seule une décision prise à la main crée une ligne ici.
+CREATE TABLE IF NOT EXISTS public.app_module_user_access (
+  user_id integer NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  module_key text NOT NULL REFERENCES public.app_modules(module_key) ON UPDATE CASCADE ON DELETE CASCADE,
+  access text NOT NULL CHECK (access IN ('GRANTED', 'DENIED')),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  updated_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  PRIMARY KEY (user_id, module_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_module_user_access_module
+  ON public.app_module_user_access(module_key, user_id);
+
+-- ------------------------------------------------------------------ Journal append-only
+-- Aucune clé étrangère ici, volontairement : le trigger append-only interdit tout
+-- UPDATE, donc un `ON DELETE SET NULL` sur user_id ferait échouer la suppression du
+-- compte. Le journal doit survivre à la disparition de l'acteur comme de la cible.
+CREATE TABLE IF NOT EXISTS public.app_module_access_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id integer NULL,
+  module_key text NOT NULL,
+  event_type text NOT NULL CHECK (
+    event_type IN ('GRANTED', 'DENIED', 'INHERITED', 'DEFAULT_CHANGED', 'UNLOCK_ALL')
+  ),
+  previous_state text NULL,
+  next_state text NULL,
+  actor_user_id integer NULL,
+  source text NOT NULL DEFAULT 'admin',
+  occurred_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_app_module_access_events_recent
+  ON public.app_module_access_events(occurred_at DESC, id);
+CREATE INDEX IF NOT EXISTS idx_app_module_access_events_user
+  ON public.app_module_access_events(user_id, occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_app_module_access_events_module
+  ON public.app_module_access_events(module_key, occurred_at DESC);
+
+CREATE OR REPLACE FUNCTION public.fn_app_module_access_events_append_only()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'app_module_access_events is append-only'
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_app_module_access_events_append_only
+  ON public.app_module_access_events;
+CREATE TRIGGER trg_app_module_access_events_append_only
+BEFORE UPDATE OR DELETE ON public.app_module_access_events
+FOR EACH ROW EXECUTE FUNCTION public.fn_app_module_access_events_append_only();
+
+-- ------------------------------------------------------------------ Seed du catalogue
+-- Miroir exact de src/module/access-control/domain/module-catalog.ts.
+-- `enabled_by_default` et `is_active` sont ABSENTS du SET de conflit : une décision
+-- d'exploitation déjà prise ne doit jamais être écrasée par une réapplication.
+INSERT INTO public.app_modules (
+  module_key, label, description, category, api_prefixes, nav_page_keys, is_protected, sort_order
+) VALUES
+  ('clients', 'Clients', 'Comptes clients, contacts, adresses et conditions de règlement.', 'Commerce',
+   ARRAY['/clients', '/payment-modes', '/billers', '/banking-info'], ARRAY['clients'], false, 10),
+  ('devis', 'Devis', 'Chiffrage et cycle de vie des devis clients.', 'Commerce',
+   ARRAY['/devis'], ARRAY['devis'], false, 20),
+  ('commandes-clients', 'Commandes clients', 'Commandes fermes, cadres et internes, appels de livraison.', 'Commerce',
+   ARRAY['/commandes'], ARRAY['commandes'], false, 30),
+  ('livraisons', 'Livraisons', 'Préparation, expédition et bons de livraison.', 'Commerce',
+   ARRAY['/livraisons'], ARRAY['livraisons'], false, 40),
+  ('affaires', 'Affaires', 'Affaires commerciales et projets rattachés.', 'Commerce',
+   ARRAY['/affaires'], ARRAY['affaires'], false, 50),
+  ('facturation', 'Facturation', 'Factures, avoirs, règlements et tarification.', 'Commerce',
+   ARRAY['/factures', '/avoirs', '/paiements', '/tarification'], ARRAY['factures'], false, 60),
+  ('reporting-commercial', 'Reporting commercial', 'Indicateurs commerciaux et exports gouvernés.', 'Commerce',
+   ARRAY['/reporting'], ARRAY['reporting-commercial'], false, 70),
+  ('fournisseurs', 'Fournisseurs', 'Référentiel fournisseurs et écosystème achat.', 'Achats',
+   ARRAY['/fournisseurs'], ARRAY['fournisseurs'], false, 80),
+  ('commandes-fournisseurs', 'Commandes fournisseurs', 'Bons de commande fournisseurs et suivi des accusés.', 'Achats',
+   ARRAY['/commandes-fournisseurs'], ARRAY['commandes-fournisseurs'], false, 90),
+  ('pieces-techniques', 'Données techniques', 'Pièces techniques, versions, gammes et dossiers d’opération.', 'Production',
+   ARRAY['/pieces-techniques', '/piece-technique-versions', '/gammes', '/dossiers'],
+   ARRAY['pieces-techniques'], false, 100),
+  ('production', 'Production', 'Ordres de fabrication, planning, pointages et poste opérateur.', 'Production',
+   ARRAY['/production', '/planning', '/programmations'],
+   ARRAY['production-dashboard', 'machines-postes', 'production-planning', 'production-execution',
+         'atelier-station', 'production-pointages', 'ordres-fabrication'], false, 110),
+  ('qualite', 'Qualité', 'Plans de contrôle, non-conformités, réceptions et dérogations.', 'Qualité',
+   ARRAY['/qualite', '/receptions'],
+   ARRAY['qualite-center', 'qualite-controls', 'qualite-non-conformities', 'receptions'], false, 120),
+  ('metrologie', 'Métrologie', 'Parc de moyens de mesure, étalonnages et certificats.', 'Qualité',
+   ARRAY['/metrologie'], ARRAY['metrologie'], false, 130),
+  ('tracabilite', 'Traçabilité', 'Chaînage matière, généalogie des lots et dossiers as-built.', 'Qualité',
+   ARRAY['/traceability', '/asbuilt'], ARRAY['traceabilite'], false, 140),
+  ('stock', 'Stock', 'Articles, mouvements, emplacements et inventaires.', 'Stock',
+   ARRAY['/stock'],
+   ARRAY['stock-dashboard', 'stock-articles', 'stock-mouvements', 'stock-inventaires'], false, 150),
+  ('outillage', 'Outillage', 'Parc d’outils coupants et sorties atelier.', 'Stock',
+   ARRAY['/outils'], ARRAY['outils', 'outils-new', 'outils-retirer'], false, 160),
+  ('temps-deplacements', 'Temps & Déplacements', 'Pointages horaires et frais kilométriques.', 'Ressources humaines',
+   ARRAY['/time-clock'], ARRAY['td-*'], false, 170),
+  ('pilotage-projet', 'Pilotage projet', 'Project Office : lots, jalons, décisions et preuves.', 'Système',
+   ARRAY['/project-office'], ARRAY['po-*'], false, 180),
+  ('import-clipper', 'Migration CLIPPER', 'Assistant de reprise des données historiques CLIPPER.', 'Système',
+   ARRAY['/import-assistant'], ARRAY['import-assistant'], false, 190),
+  ('administration', 'Administration', 'Comptes, rôles, réglages ERP et tour de contrôle des accès.', 'Système',
+   ARRAY['/admin'], ARRAY['administration', 'erp-settings', 'acces'], true, 200)
+ON CONFLICT (module_key) DO UPDATE
+SET
+  label = EXCLUDED.label,
+  description = EXCLUDED.description,
+  category = EXCLUDED.category,
+  api_prefixes = EXCLUDED.api_prefixes,
+  nav_page_keys = EXCLUDED.nav_page_keys,
+  sort_order = EXCLUDED.sort_order,
+  updated_at = now();
+
+-- `is_protected` est une invariante de code, pas une préférence d'exploitation :
+-- on la réaffirme sans jamais toucher aux défauts choisis par l'administrateur.
+UPDATE public.app_modules
+SET is_protected = true, updated_at = now()
+WHERE module_key = 'administration'
+  AND is_protected IS DISTINCT FROM true;
+
+-- Un module protégé ne peut pas rester refusé : le patch efface les seules
+-- restrictions qui rendraient l'ERP inadministrable, et rien d'autre.
+DELETE FROM public.app_module_user_access a
+USING public.app_modules m
+WHERE m.module_key = a.module_key
+  AND m.is_protected
+  AND a.access = 'DENIED';
+
+-- ------------------------------------------------------------------ Droits applicatifs
+-- Les patches sont appliqués par le rôle système `postgres`, tandis que l'API tourne
+-- avec `cerp_app`. Sans grant explicite, le gate d'accès recevrait une erreur de
+-- permission sur chaque requête. `app_modules` n'est pas administrable par l'API :
+-- seul `enabled_by_default` est modifiable, jamais le catalogue lui-même.
+DO $grants$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT ON TABLE public.app_modules TO cerp_app;
+    GRANT UPDATE (enabled_by_default, updated_at) ON TABLE public.app_modules TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE, DELETE
+      ON TABLE public.app_module_user_access
+      TO cerp_app;
+    GRANT SELECT, INSERT
+      ON TABLE public.app_module_access_events
+      TO cerp_app;
+  ELSE
+    RAISE NOTICE 'role cerp_app absent — aucun grant appliqué';
+  END IF;
+END
+$grants$;
+
+COMMIT;

--- a/db/patches/20260727_stock_import_precision_198.sql
+++ b/db/patches/20260727_stock_import_precision_198.sql
@@ -1,0 +1,98 @@
+-- Issue #198 — preserve the canonical six-decimal stock quantity precision.
+-- cerp_test only. The repair is restricted to one-line CLIPPER opening
+-- movements whose line differs from the posted header by less than 0.0005,
+-- which is the maximum loss introduced by NUMERIC(18,3).
+
+BEGIN;
+
+DO $$
+DECLARE
+  current_scale integer;
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Patch #198 refused outside cerp_test (current database: %)', current_database();
+  END IF;
+
+  SELECT numeric_scale
+    INTO current_scale
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'stock_movement_lines'
+    AND column_name = 'qty';
+
+  IF current_scale IS NULL THEN
+    RAISE EXCEPTION 'Patch #198 refused: public.stock_movement_lines.qty is missing';
+  END IF;
+  IF current_scale NOT IN (3, 6) THEN
+    RAISE EXCEPTION 'Patch #198 refused: unexpected stock_movement_lines.qty scale %', current_scale;
+  END IF;
+END
+$$;
+
+ALTER TABLE public.stock_movement_lines
+  ALTER COLUMN qty TYPE numeric(18,6)
+  USING qty::numeric(18,6);
+
+-- The normal immutability trigger is retained for application traffic. It is
+-- disabled only inside this transaction for the bounded, audited repair below.
+ALTER TABLE public.stock_movement_lines
+  DISABLE TRIGGER trg_protect_posted_stock_movement_line;
+
+WITH opening_lines AS (
+  SELECT
+    l.id AS line_id,
+    l.movement_id,
+    l.qty AS old_line_qty,
+    m.qty AS posted_qty,
+    COALESCE(m.posted_by, m.updated_by, m.created_by, m.user_id) AS actor_user_id,
+    COUNT(*) OVER (PARTITION BY l.movement_id) AS lines_count
+  FROM public.stock_movement_lines l
+  JOIN public.stock_movements m ON m.id = l.movement_id
+  WHERE m.status = 'POSTED'
+    AND m.source_document_type = 'CLIPPER_STOCK_OPENING'
+),
+repaired AS (
+  UPDATE public.stock_movement_lines l
+  SET
+    qty = opening_lines.posted_qty,
+    updated_at = now(),
+    updated_by = opening_lines.actor_user_id
+  FROM opening_lines
+  WHERE l.id = opening_lines.line_id
+    AND opening_lines.lines_count = 1
+    AND opening_lines.old_line_qty IS DISTINCT FROM opening_lines.posted_qty
+    AND abs(opening_lines.old_line_qty - opening_lines.posted_qty) < 0.0005
+  RETURNING
+    opening_lines.movement_id,
+    opening_lines.old_line_qty,
+    opening_lines.posted_qty,
+    opening_lines.actor_user_id
+)
+INSERT INTO public.stock_movement_event_log (
+  id,
+  stock_movement_id,
+  event_type,
+  old_values,
+  new_values,
+  user_id,
+  created_by,
+  updated_by
+)
+SELECT
+  gen_random_uuid(),
+  movement_id,
+  'PRECISION_RECONCILED_198',
+  jsonb_build_object('line_qty', old_line_qty),
+  jsonb_build_object(
+    'line_qty', posted_qty,
+    'reason', 'Widen stock_movement_lines.qty from NUMERIC(18,3) to NUMERIC(18,6)'
+  ),
+  actor_user_id,
+  actor_user_id,
+  actor_user_id
+FROM repaired;
+
+ALTER TABLE public.stock_movement_lines
+  ENABLE TRIGGER trg_protect_posted_stock_movement_line;
+
+COMMIT;

--- a/db/patches/20260727_user_account_profile_optional_315.sql
+++ b/db/patches/20260727_user_account_profile_optional_315.sql
@@ -1,0 +1,22 @@
+-- Issue #315 — sépare la création d'un compte ERP de la complétude du dossier RH.
+-- Les contraintes UNIQUE restent en place : plusieurs valeurs NULL sont permises,
+-- mais deux vraies valeurs identiques restent interdites.
+
+BEGIN;
+
+ALTER TABLE public.users
+  ALTER COLUMN tel_no DROP NOT NULL,
+  ALTER COLUMN gender DROP NOT NULL,
+  ALTER COLUMN address DROP NOT NULL,
+  ALTER COLUMN lane DROP NOT NULL,
+  ALTER COLUMN house_no DROP NOT NULL,
+  ALTER COLUMN postcode DROP NOT NULL,
+  ALTER COLUMN date_of_birth DROP NOT NULL,
+  ALTER COLUMN social_security_number DROP NOT NULL;
+
+COMMENT ON COLUMN public.users.tel_no IS
+  'Optional during ERP account provisioning; complete with verified HR data later.';
+COMMENT ON COLUMN public.users.social_security_number IS
+  'Restricted HR identifier; never fabricate it for account provisioning.';
+
+COMMIT;

--- a/db/patches/20260727_user_multi_roles_315.sql
+++ b/db/patches/20260727_user_multi_roles_315.sql
@@ -123,4 +123,23 @@ WHERE NOT EXISTS (
     AND event.source = 'migration-315'
 );
 
+-- Les patches sont appliqués par le rôle système `postgres`, tandis que l'API
+-- s'exécute avec le rôle de moindre privilège `cerp_app`. PostgreSQL ne propage
+-- pas automatiquement les droits des tables existantes vers les nouvelles
+-- tables : accorder explicitement le minimum nécessaire évite un login 500
+-- après migration, sans rendre le journal append-only modifiable.
+DO $grants$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT ON TABLE public.app_roles TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE, DELETE
+      ON TABLE public.user_role_assignments
+      TO cerp_app;
+    GRANT SELECT, INSERT
+      ON TABLE public.user_role_assignment_events
+      TO cerp_app;
+  END IF;
+END
+$grants$;
+
 COMMIT;

--- a/db/patches/20260727_user_multi_roles_315.sql
+++ b/db/patches/20260727_user_multi_roles_315.sql
@@ -1,0 +1,126 @@
+-- Issue #315 — rôles multiples additifs pour un même compte CERP.
+-- `users.role` reste le rôle principal de compatibilité pendant la transition.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.app_roles (
+  role_key text PRIMARY KEY,
+  category text NOT NULL CHECK (category IN ('PRIMARY', 'ORGANIZATION')),
+  description text NOT NULL,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.user_role_assignments (
+  user_id integer NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  role_key text NOT NULL REFERENCES public.app_roles(role_key) ON UPDATE CASCADE,
+  assigned_at timestamptz NOT NULL DEFAULT now(),
+  assigned_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  PRIMARY KEY (user_id, role_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_role_assignments_role
+  ON public.user_role_assignments(role_key, user_id);
+
+CREATE TABLE IF NOT EXISTS public.user_role_assignment_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  role_key text NOT NULL,
+  event_type text NOT NULL CHECK (event_type IN ('ASSIGNED', 'REVOKED', 'MIGRATED')),
+  actor_user_id integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  source text NOT NULL DEFAULT 'admin',
+  occurred_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_role_assignment_events_user
+  ON public.user_role_assignment_events(user_id, occurred_at DESC);
+
+CREATE OR REPLACE FUNCTION public.fn_user_role_events_append_only()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'user_role_assignment_events is append-only'
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_user_role_events_append_only
+  ON public.user_role_assignment_events;
+CREATE TRIGGER trg_user_role_events_append_only
+BEFORE UPDATE OR DELETE ON public.user_role_assignment_events
+FOR EACH ROW EXECUTE FUNCTION public.fn_user_role_events_append_only();
+
+INSERT INTO public.app_roles (role_key, category, description)
+VALUES
+  ('Directeur', 'PRIMARY', 'Rôle principal de direction.'),
+  ('Employee', 'PRIMARY', 'Rôle principal salarié sans privilège implicite.'),
+  ('Administrateur Systeme et Reseau', 'PRIMARY', 'Administration technique CERP.'),
+  ('Responsable Qualité', 'PRIMARY', 'Responsabilité qualité principale.'),
+  ('Secretaire', 'PRIMARY', 'Secrétariat et assistance administrative.'),
+  ('Responsable Programmation', 'PRIMARY', 'Responsabilité programmation et données techniques.'),
+  ('Responsable RH', 'PRIMARY', 'Responsabilité ressources humaines.'),
+  ('Gérant', 'ORGANIZATION', 'Gérance de la société.'),
+  ('Commerce', 'ORGANIZATION', 'Commerce, clients, devis et commandes.'),
+  ('Achats', 'ORGANIZATION', 'Achats et fournisseurs.'),
+  ('RH-Financier', 'ORGANIZATION', 'Ressources humaines et pilotage financier.'),
+  ('Directeur Technique', 'ORGANIZATION', 'Direction technique de l’atelier.'),
+  ('Responsable Atelier-Production', 'ORGANIZATION', 'Supervision atelier et production.'),
+  ('Planning', 'ORGANIZATION', 'Pilotage du planning de production.'),
+  ('Planification', 'ORGANIZATION', 'Planification des opérations.'),
+  ('Préparateur commandes', 'ORGANIZATION', 'Préparation des commandes et expéditions.'),
+  ('Assistante polyvalente', 'ORGANIZATION', 'Assistance administrative polyvalente.'),
+  ('Assistante RH', 'ORGANIZATION', 'Assistance des ressources humaines.'),
+  ('Maintenance', 'ORGANIZATION', 'Maintenance du parc machine.'),
+  ('Responsable Agencement', 'ORGANIZATION', 'Responsabilité agencement.'),
+  ('Qualité', 'ORGANIZATION', 'Contrôle et décisions qualité.'),
+  ('Études-Méthodes', 'ORGANIZATION', 'Études, méthodes et données techniques.'),
+  ('Programmation', 'ORGANIZATION', 'Programmation d’usinage.'),
+  ('Fraisage', 'ORGANIZATION', 'Opérations de fraisage.'),
+  ('Livraison', 'ORGANIZATION', 'Livraison et expédition.'),
+  ('Préparation matière', 'ORGANIZATION', 'Préparation des matières.'),
+  ('Finitions', 'ORGANIZATION', 'Opérations de finition.'),
+  ('Gestion matière', 'ORGANIZATION', 'Gestion de la matière et du stock.'),
+  ('Responsable CAO', 'ORGANIZATION', 'Responsabilité conception assistée par ordinateur.'),
+  ('Responsable fabrication fraisage', 'ORGANIZATION', 'Supervision de la fabrication fraisage.'),
+  ('Tournage', 'ORGANIZATION', 'Opérations de tournage.'),
+  ('Responsable tournage', 'ORGANIZATION', 'Supervision de la fabrication tournage.'),
+  ('Opérateur atelier', 'ORGANIZATION', 'Exécution des opérations au poste atelier.')
+ON CONFLICT (role_key) DO UPDATE
+SET
+  category = EXCLUDED.category,
+  description = EXCLUDED.description,
+  is_active = true,
+  updated_at = now();
+
+INSERT INTO public.user_role_assignments (user_id, role_key)
+SELECT u.id, u.role
+FROM public.users u
+JOIN public.app_roles r ON r.role_key = u.role
+ON CONFLICT (user_id, role_key) DO NOTHING;
+
+INSERT INTO public.user_role_assignment_events (
+  user_id,
+  role_key,
+  event_type,
+  actor_user_id,
+  source
+)
+SELECT
+  ura.user_id,
+  ura.role_key,
+  'MIGRATED',
+  NULL,
+  'migration-315'
+FROM public.user_role_assignments ura
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.user_role_assignment_events event
+  WHERE event.user_id = ura.user_id
+    AND event.role_key = ura.role_key
+    AND event.event_type = 'MIGRATED'
+    AND event.source = 'migration-315'
+);
+
+COMMIT;

--- a/db/patches/support/20260727_admin_access_tower_326.preflight.sql
+++ b/db/patches/support/20260727_admin_access_tower_326.preflight.sql
@@ -1,0 +1,54 @@
+-- Lecture seule — prérequis de la tour de contrôle des accès #326 / back #200.
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
+    RAISE EXCEPTION 'Base inattendue pour #326 : %', current_database();
+  END IF;
+
+  IF to_regclass('public.users') IS NULL THEN
+    RAISE EXCEPTION 'Table prérequise public.users absente';
+  END IF;
+
+  IF to_regclass('public.erp_audit_logs') IS NULL THEN
+    RAISE EXCEPTION 'Table prérequise public.erp_audit_logs absente (audit des mutations)';
+  END IF;
+
+  -- Un objet homonyme préexistant d'une autre origine rendrait le patch trompeur :
+  -- CREATE TABLE IF NOT EXISTS le laisserait en place sans rien signaler.
+  IF to_regclass('public.app_modules') IS NOT NULL
+     AND NOT EXISTS (
+       SELECT 1
+       FROM information_schema.columns
+       WHERE table_schema = 'public'
+         AND table_name = 'app_modules'
+         AND column_name = 'enabled_by_default'
+     ) THEN
+    RAISE EXCEPTION 'public.app_modules existe déjà avec une forme incompatible';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'is_superadmin'
+      AND data_type <> 'boolean'
+  ) THEN
+    RAISE EXCEPTION 'public.users.is_superadmin existe déjà dans un type incompatible';
+  END IF;
+END $$;
+
+SELECT
+  current_database() AS database_name,
+  to_regclass('public.app_modules') IS NOT NULL AS app_modules_already_present,
+  to_regclass('public.app_module_user_access') IS NOT NULL AS user_access_already_present,
+  to_regclass('public.app_module_access_events') IS NOT NULL AS events_already_present,
+  EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'is_superadmin'
+  ) AS is_superadmin_already_present,
+  (SELECT COUNT(*)::int FROM public.users) AS user_count,
+  EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') AS runtime_role_present;

--- a/db/patches/support/20260727_admin_access_tower_326.rollback.sql
+++ b/db/patches/support/20260727_admin_access_tower_326.rollback.sql
@@ -1,0 +1,27 @@
+-- Rollback de la tour de contrôle des accès #326 / back #200.
+-- Ne touche AUCUNE ligne de public.users : seule la colonne ajoutée par le patch est
+-- retirée. Toute autre donnée de compte est hors du périmètre de ce rollback.
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
+    RAISE EXCEPTION 'Rollback #326 refusé hors cerp_test/cerp_prod (base actuelle : %)',
+      current_database();
+  END IF;
+END
+$$;
+
+DROP TRIGGER IF EXISTS trg_app_module_access_events_append_only
+  ON public.app_module_access_events;
+DROP FUNCTION IF EXISTS public.fn_app_module_access_events_append_only();
+DROP TABLE IF EXISTS public.app_module_access_events;
+DROP TABLE IF EXISTS public.app_module_user_access;
+DROP TABLE IF EXISTS public.app_modules;
+
+ALTER TABLE public.users
+  DROP COLUMN IF EXISTS is_superadmin;
+
+COMMIT;

--- a/db/patches/support/20260727_admin_access_tower_326.verify.sql
+++ b/db/patches/support/20260727_admin_access_tower_326.verify.sql
@@ -1,0 +1,66 @@
+-- Vérification post-application — tour de contrôle des accès #326 / back #200.
+\set ON_ERROR_STOP on
+
+SELECT
+  current_database() AS database_name,
+  to_regclass('public.app_modules') IS NOT NULL AS app_modules_exists,
+  to_regclass('public.app_module_user_access') IS NOT NULL AS user_access_exists,
+  to_regclass('public.app_module_access_events') IS NOT NULL AS events_exists,
+  EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'is_superadmin'
+      AND data_type = 'boolean'
+      AND is_nullable = 'NO'
+  ) AS is_superadmin_column_ok,
+  (SELECT COUNT(*)::int FROM public.app_modules) AS modules_total,
+  (SELECT COUNT(*)::int FROM public.app_modules WHERE is_active) AS modules_active,
+  (SELECT COUNT(*)::int FROM public.app_modules WHERE is_protected) AS modules_protected,
+  (
+    SELECT COUNT(*)::int
+    FROM public.app_modules
+    WHERE cardinality(api_prefixes) = 0
+  ) AS modules_without_api_prefix,
+  (SELECT COUNT(*)::int FROM public.users WHERE is_superadmin) AS superadmin_count,
+  (
+    SELECT COUNT(*)::int
+    FROM public.app_module_user_access a
+    JOIN public.app_modules m ON m.module_key = a.module_key
+    WHERE m.is_protected AND a.access = 'DENIED'
+  ) AS protected_module_denials,
+  EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'public.app_module_access_events'::regclass
+      AND tgname = 'trg_app_module_access_events_append_only'
+      AND NOT tgisinternal
+  ) AS events_append_only_trigger,
+  (
+    NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app')
+    OR (
+      has_table_privilege('cerp_app', 'public.app_modules', 'SELECT')
+      AND NOT has_table_privilege('cerp_app', 'public.app_modules', 'INSERT')
+      AND NOT has_table_privilege('cerp_app', 'public.app_modules', 'DELETE')
+      AND has_column_privilege('cerp_app', 'public.app_modules', 'enabled_by_default', 'UPDATE')
+      AND NOT has_column_privilege('cerp_app', 'public.app_modules', 'module_key', 'UPDATE')
+      AND has_table_privilege('cerp_app', 'public.app_module_user_access', 'SELECT,INSERT,UPDATE,DELETE')
+      AND has_table_privilege('cerp_app', 'public.app_module_access_events', 'SELECT,INSERT')
+      AND NOT has_table_privilege('cerp_app', 'public.app_module_access_events', 'UPDATE,DELETE')
+    )
+  ) AS application_privileges_ok;
+
+-- Le catalogue attendu doit être complet : toute clé manquante casserait le gate,
+-- qui résout le module par préfixe d'API avant d'interroger la base.
+SELECT array_agg(expected.module_key ORDER BY expected.module_key) AS missing_module_keys
+FROM (
+  VALUES
+    ('clients'), ('devis'), ('commandes-clients'), ('livraisons'), ('affaires'),
+    ('facturation'), ('reporting-commercial'), ('fournisseurs'), ('commandes-fournisseurs'),
+    ('pieces-techniques'), ('production'), ('qualite'), ('metrologie'), ('tracabilite'),
+    ('stock'), ('outillage'), ('temps-deplacements'), ('pilotage-projet'),
+    ('import-clipper'), ('administration')
+) AS expected(module_key)
+LEFT JOIN public.app_modules m ON m.module_key = expected.module_key
+WHERE m.module_key IS NULL;

--- a/db/patches/support/20260727_stock_import_precision_198.preflight.sql
+++ b/db/patches/support/20260727_stock_import_precision_198.preflight.sql
@@ -1,0 +1,67 @@
+\set ON_ERROR_STOP on
+
+DO $$
+DECLARE
+  current_scale integer;
+  unsafe_mismatches integer;
+  multi_line_openings integer;
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Preflight #198 refused outside cerp_test (current database: %)', current_database();
+  END IF;
+
+  SELECT numeric_scale
+    INTO current_scale
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'stock_movement_lines'
+    AND column_name = 'qty';
+
+  IF current_scale NOT IN (3, 6) THEN
+    RAISE EXCEPTION 'Preflight #198 refused: unexpected stock_movement_lines.qty scale %', current_scale;
+  END IF;
+
+  WITH opening_lines AS (
+    SELECT
+      l.movement_id,
+      l.qty AS line_qty,
+      m.qty AS posted_qty,
+      COUNT(*) OVER (PARTITION BY l.movement_id) AS lines_count
+    FROM public.stock_movement_lines l
+    JOIN public.stock_movements m ON m.id = l.movement_id
+    WHERE m.status = 'POSTED'
+      AND m.source_document_type = 'CLIPPER_STOCK_OPENING'
+  )
+  SELECT
+    COUNT(*) FILTER (
+      WHERE line_qty IS DISTINCT FROM posted_qty
+        AND abs(line_qty - posted_qty) >= 0.0005
+    ),
+    COUNT(DISTINCT movement_id) FILTER (WHERE lines_count <> 1)
+  INTO unsafe_mismatches, multi_line_openings
+  FROM opening_lines;
+
+  IF unsafe_mismatches > 0 THEN
+    RAISE EXCEPTION 'Preflight #198 refused: % opening line/header mismatches are not rounding residues', unsafe_mismatches;
+  END IF;
+  IF multi_line_openings > 0 THEN
+    RAISE EXCEPTION 'Preflight #198 refused: % CLIPPER opening movements contain multiple lines', multi_line_openings;
+  END IF;
+END
+$$;
+
+SELECT
+  c.numeric_precision,
+  c.numeric_scale,
+  COUNT(*) FILTER (
+    WHERE m.status = 'POSTED'
+      AND m.source_document_type = 'CLIPPER_STOCK_OPENING'
+      AND l.qty IS DISTINCT FROM m.qty
+  ) AS opening_mismatches_before
+FROM information_schema.columns c
+CROSS JOIN public.stock_movement_lines l
+JOIN public.stock_movements m ON m.id = l.movement_id
+WHERE c.table_schema = 'public'
+  AND c.table_name = 'stock_movement_lines'
+  AND c.column_name = 'qty'
+GROUP BY c.numeric_precision, c.numeric_scale;

--- a/db/patches/support/20260727_stock_import_precision_198.rollback.sql
+++ b/db/patches/support/20260727_stock_import_precision_198.rollback.sql
@@ -1,0 +1,86 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DO $$
+DECLARE
+  current_scale integer;
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Rollback #198 refused outside cerp_test (current database: %)', current_database();
+  END IF;
+
+  SELECT numeric_scale
+    INTO current_scale
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'stock_movement_lines'
+    AND column_name = 'qty';
+
+  IF current_scale <> 6 THEN
+    RAISE EXCEPTION 'Rollback #198 refused: expected scale 6, found %', current_scale;
+  END IF;
+END
+$$;
+
+ALTER TABLE public.stock_movement_lines
+  DISABLE TRIGGER trg_protect_posted_stock_movement_line;
+
+WITH latest_repair AS (
+  SELECT DISTINCT ON (stock_movement_id)
+    stock_movement_id,
+    (old_values ->> 'line_qty')::numeric(18,6) AS old_line_qty,
+    user_id
+  FROM public.stock_movement_event_log
+  WHERE event_type = 'PRECISION_RECONCILED_198'
+  ORDER BY stock_movement_id, created_at DESC, id DESC
+),
+restored AS (
+  UPDATE public.stock_movement_lines l
+  SET
+    qty = latest_repair.old_line_qty,
+    updated_at = now(),
+    updated_by = latest_repair.user_id
+  FROM latest_repair
+  WHERE l.movement_id = latest_repair.stock_movement_id
+  RETURNING l.movement_id, latest_repair.user_id
+)
+INSERT INTO public.stock_movement_event_log (
+  id,
+  stock_movement_id,
+  event_type,
+  new_values,
+  user_id,
+  created_by,
+  updated_by
+)
+SELECT
+  gen_random_uuid(),
+  movement_id,
+  'PRECISION_ROLLBACK_198',
+  jsonb_build_object('reason', 'Rollback issue #198'),
+  user_id,
+  user_id,
+  user_id
+FROM restored;
+
+ALTER TABLE public.stock_movement_lines
+  ENABLE TRIGGER trg_protect_posted_stock_movement_line;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.stock_movement_lines
+    WHERE qty <> round(qty, 3)
+  ) THEN
+    RAISE EXCEPTION 'Rollback #198 refused: six-decimal quantities exist outside the audited repair set';
+  END IF;
+END
+$$;
+
+ALTER TABLE public.stock_movement_lines
+  ALTER COLUMN qty TYPE numeric(18,3)
+  USING qty::numeric(18,3);
+
+COMMIT;

--- a/db/patches/support/20260727_stock_import_precision_198.verify.sql
+++ b/db/patches/support/20260727_stock_import_precision_198.verify.sql
@@ -1,0 +1,34 @@
+\set ON_ERROR_STOP on
+
+SELECT current_database() = 'cerp_test' AS is_test_database;
+
+SELECT
+  numeric_precision = 18 AS precision_is_18,
+  numeric_scale = 6 AS scale_is_6
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'stock_movement_lines'
+  AND column_name = 'qty';
+
+SELECT COUNT(*) = 0 AS opening_lines_match_posted_headers
+FROM public.stock_movement_lines l
+JOIN public.stock_movements m ON m.id = l.movement_id
+WHERE m.status = 'POSTED'
+  AND m.source_document_type = 'CLIPPER_STOCK_OPENING'
+  AND l.qty IS DISTINCT FROM m.qty;
+
+SELECT COUNT(*) = 0 AS opening_headers_match_stock_levels
+FROM public.stock_movements m
+JOIN public.stock_levels sl ON sl.id = m.stock_level_id
+WHERE m.status = 'POSTED'
+  AND m.source_document_type = 'CLIPPER_STOCK_OPENING'
+  AND sl.qty_total IS DISTINCT FROM m.qty;
+
+SELECT
+  COUNT(*) AS precision_repair_events,
+  COUNT(*) FILTER (
+    WHERE old_values ? 'line_qty'
+      AND new_values ? 'line_qty'
+  ) = COUNT(*) AS all_repairs_are_audited
+FROM public.stock_movement_event_log
+WHERE event_type = 'PRECISION_RECONCILED_198';

--- a/db/patches/support/20260727_user_account_profile_optional_315.rollback.sql
+++ b/db/patches/support/20260727_user_account_profile_optional_315.rollback.sql
@@ -1,0 +1,31 @@
+BEGIN;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.users
+    WHERE tel_no IS NULL
+       OR gender IS NULL
+       OR address IS NULL
+       OR lane IS NULL
+       OR house_no IS NULL
+       OR postcode IS NULL
+       OR date_of_birth IS NULL
+       OR social_security_number IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Cannot restore NOT NULL constraints while incomplete ERP profiles exist';
+  END IF;
+END $$;
+
+ALTER TABLE public.users
+  ALTER COLUMN tel_no SET NOT NULL,
+  ALTER COLUMN gender SET NOT NULL,
+  ALTER COLUMN address SET NOT NULL,
+  ALTER COLUMN lane SET NOT NULL,
+  ALTER COLUMN house_no SET NOT NULL,
+  ALTER COLUMN postcode SET NOT NULL,
+  ALTER COLUMN date_of_birth SET NOT NULL,
+  ALTER COLUMN social_security_number SET NOT NULL;
+
+COMMIT;

--- a/db/patches/support/20260727_user_account_profile_optional_315.verify.sql
+++ b/db/patches/support/20260727_user_account_profile_optional_315.verify.sql
@@ -1,0 +1,17 @@
+SELECT
+  column_name,
+  is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'users'
+  AND column_name IN (
+    'tel_no',
+    'gender',
+    'address',
+    'lane',
+    'house_no',
+    'postcode',
+    'date_of_birth',
+    'social_security_number'
+  )
+ORDER BY column_name;

--- a/db/patches/support/20260727_user_multi_roles_315.preflight.sql
+++ b/db/patches/support/20260727_user_multi_roles_315.preflight.sql
@@ -1,0 +1,63 @@
+-- Lecture seule — prérequis des patches comptes/RBAC #315.
+DO $$
+DECLARE
+  missing_columns text[];
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
+    RAISE EXCEPTION 'Unexpected database for #315: %', current_database();
+  END IF;
+
+  IF to_regclass('public.users') IS NULL THEN
+    RAISE EXCEPTION 'Missing prerequisite table public.users';
+  END IF;
+
+  SELECT array_agg(required.column_name ORDER BY required.column_name)
+  INTO missing_columns
+  FROM (
+    VALUES
+      ('id'),
+      ('role'),
+      ('tel_no'),
+      ('gender'),
+      ('address'),
+      ('lane'),
+      ('house_no'),
+      ('postcode'),
+      ('date_of_birth'),
+      ('social_security_number')
+  ) AS required(column_name)
+  LEFT JOIN information_schema.columns actual
+    ON actual.table_schema = 'public'
+   AND actual.table_name = 'users'
+   AND actual.column_name = required.column_name
+  WHERE actual.column_name IS NULL;
+
+  IF missing_columns IS NOT NULL THEN
+    RAISE EXCEPTION 'Missing public.users columns for #315: %', missing_columns;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.users
+    WHERE role IS NULL
+       OR role <> ALL (
+         ARRAY[
+           'Directeur',
+           'Employee',
+           'Administrateur Systeme et Reseau',
+           'Responsable Qualité',
+           'Secretaire',
+           'Responsable Programmation',
+           'Responsable RH'
+         ]::text[]
+       )
+  ) THEN
+    RAISE EXCEPTION 'Unknown or null users.role value blocks deterministic #315 backfill';
+  END IF;
+END $$;
+
+SELECT
+  current_database() AS database_name,
+  COUNT(*)::int AS user_count,
+  COUNT(DISTINCT role)::int AS distinct_primary_roles
+FROM public.users;

--- a/db/patches/support/20260727_user_multi_roles_315.rollback.sql
+++ b/db/patches/support/20260727_user_multi_roles_315.rollback.sql
@@ -1,0 +1,10 @@
+BEGIN;
+
+DROP TRIGGER IF EXISTS trg_user_role_events_append_only
+  ON public.user_role_assignment_events;
+DROP FUNCTION IF EXISTS public.fn_user_role_events_append_only();
+DROP TABLE IF EXISTS public.user_role_assignment_events;
+DROP TABLE IF EXISTS public.user_role_assignments;
+DROP TABLE IF EXISTS public.app_roles;
+
+COMMIT;

--- a/db/patches/support/20260727_user_multi_roles_315.verify.sql
+++ b/db/patches/support/20260727_user_multi_roles_315.verify.sql
@@ -1,0 +1,13 @@
+SELECT
+  to_regclass('public.app_roles') IS NOT NULL AS app_roles_exists,
+  to_regclass('public.user_role_assignments') IS NOT NULL AS assignments_exists,
+  to_regclass('public.user_role_assignment_events') IS NOT NULL AS events_exists,
+  (SELECT COUNT(*) FROM public.app_roles WHERE is_active) AS active_roles,
+  (
+    SELECT COUNT(*)
+    FROM public.users u
+    LEFT JOIN public.user_role_assignments ura
+      ON ura.user_id = u.id
+     AND ura.role_key = u.role
+    WHERE ura.user_id IS NULL
+  ) AS users_missing_primary_assignment;

--- a/db/patches/support/20260727_user_multi_roles_315.verify.sql
+++ b/db/patches/support/20260727_user_multi_roles_315.verify.sql
@@ -10,4 +10,13 @@ SELECT
       ON ura.user_id = u.id
      AND ura.role_key = u.role
     WHERE ura.user_id IS NULL
-  ) AS users_missing_primary_assignment;
+  ) AS users_missing_primary_assignment,
+  (
+    NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app')
+    OR (
+      has_table_privilege('cerp_app', 'public.app_roles', 'SELECT')
+      AND has_table_privilege('cerp_app', 'public.user_role_assignments', 'SELECT,INSERT,UPDATE,DELETE')
+      AND has_table_privilege('cerp_app', 'public.user_role_assignment_events', 'SELECT,INSERT')
+      AND NOT has_table_privilege('cerp_app', 'public.user_role_assignment_events', 'UPDATE,DELETE')
+    )
+  ) AS application_privileges_ok;

--- a/db/seeds/access-tower-superadmin-keenan.sql
+++ b/db/seeds/access-tower-superadmin-keenan.sql
@@ -1,0 +1,51 @@
+-- Accorde le statut superadmin au seul compte pilote nommé KEENAN.
+-- Ce statut n'est accordé par AUCUNE API : ce fichier est le seul chemin d'octroi.
+-- Le seed est idempotent et ne modifie aucune autre colonne du compte.
+--
+-- cerp_test :
+--   psql -d cerp_test -f db/seeds/access-tower-superadmin-keenan.sql
+--
+-- cerp_prod (uniquement après validation sur cerp_test et sauvegarde, en une session) :
+--   SET cerp.access_tower_superadmin_approved = 'KEENAN';
+--   \i db/seeds/access-tower-superadmin-keenan.sql
+
+DO $$
+DECLARE
+  v_user_id integer;
+  v_user_count integer;
+BEGIN
+  IF current_database() = 'cerp_prod'
+     AND current_setting('cerp.access_tower_superadmin_approved', true) IS DISTINCT FROM 'KEENAN' THEN
+    RAISE EXCEPTION 'INTERDIT : validation explicite KEENAN requise avant octroi superadmin sur cerp_prod';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'users'
+      AND column_name = 'is_superadmin'
+  ) THEN
+    RAISE EXCEPTION 'Colonne users.is_superadmin absente — appliquer d''abord db/patches/20260727_admin_access_tower_326.sql';
+  END IF;
+
+  -- Un homonyme rendrait l'octroi ambigu : on refuse plutôt que de choisir.
+  SELECT count(*), min(id)
+    INTO v_user_count, v_user_id
+    FROM public.users
+   WHERE upper(btrim(username)) = 'KEENAN';
+
+  IF v_user_count <> 1 THEN
+    RAISE EXCEPTION 'Compte superadmin KEENAN introuvable ou ambigu (% correspondances)', v_user_count;
+  END IF;
+
+  UPDATE public.users
+     SET is_superadmin = true
+   WHERE id = v_user_id
+     AND is_superadmin IS DISTINCT FROM true;
+END $$;
+
+SELECT id, username, is_superadmin
+FROM public.users
+WHERE is_superadmin
+ORDER BY id;

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -359,13 +359,25 @@ adresse, date de naissance et NIR restent `NULL` plutôt que d'être remplacés
 par des valeurs fictives. Les contraintes `UNIQUE` restent en place et
 s'appliquent dès qu'une valeur réelle est renseignée.
 
-Le patch est transactionnel et idempotent. Son script de vérification contrôle
-la présence des trois tables, le catalogue actif et l'absence de compte sans
-affectation de son rôle principal. Le rollback de support supprime uniquement
-les trois nouvelles tables ; il ne modifie aucune ligne de `users`.
+Le patch est transactionnel et idempotent. Il accorde explicitement au rôle
+applicatif de moindre privilège `cerp_app` la lecture du catalogue, la gestion
+des affectations et uniquement la lecture/ajout du journal append-only. Son
+script de vérification contrôle la présence des trois tables, le catalogue
+actif, l'absence de compte sans affectation de son rôle principal et ces
+privilèges applicatifs, y compris l'absence de droit `UPDATE`/`DELETE` sur le
+journal. Le rollback de support supprime uniquement les trois nouvelles
+tables ; il ne modifie aucune ligne de `users`.
 
 Ordre obligatoire : exécuter
 `support/20260727_user_multi_roles_315.preflight.sql`, appliquer les deux
 patches sur `cerp_test`, exécuter leurs vérifications, puis réaliser la recette
 des sessions mono-rôle et multi-rôles. Une validation humaine explicite reste
 obligatoire avant toute application sur `cerp_prod`.
+
+Validation d'exploitation du 2026-07-27 : sauvegarde `cerp_test` vérifiée,
+application des deux patches et recette des sessions multi-rôles sur l'API
+isolée ; sauvegarde `cerp_prod` vérifiée par catalogue et SHA-256 avant
+application identique. Les deux bases exposent 33 rôles actifs, aucun compte
+sans rôle principal et des privilèges applicatifs conformes. La recette a
+couvert 17 comptes provisionnés, 64 affectations et six profils d'accès
+représentatifs, sans modifier le compte administrateur existant.

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -343,3 +343,29 @@ Validation du 2026-07-27 : cycle complet avec rollback sur `cerp_test`,
 sauvegarde production vérifiée, trois contraintes validées sur `cerp_prod`,
 zéro référence invalide, toutes les clés étrangères publiques validées et
 empreintes des 302 tables métier inchangées.
+
+## Issue #315 - RBAC multi-rôles
+
+Le patch `20260727_user_multi_roles_315.sql` crée un catalogue de rôles
+applicatifs et les affectations plusieurs-à-plusieurs entre utilisateurs et
+rôles. Il conserve `users.role` comme rôle principal de compatibilité et
+reprend chaque compte existant dans `user_role_assignments`. Les attributions,
+révocations et reprises sont conservées dans le journal append-only
+`user_role_assignment_events`, avec l'acteur lorsqu'il est connu.
+
+Le patch préalable `20260727_user_account_profile_optional_315.sql` permet de
+créer le compte ERP avant de connaître les données RH sensibles. Téléphone,
+adresse, date de naissance et NIR restent `NULL` plutôt que d'être remplacés
+par des valeurs fictives. Les contraintes `UNIQUE` restent en place et
+s'appliquent dès qu'une valeur réelle est renseignée.
+
+Le patch est transactionnel et idempotent. Son script de vérification contrôle
+la présence des trois tables, le catalogue actif et l'absence de compte sans
+affectation de son rôle principal. Le rollback de support supprime uniquement
+les trois nouvelles tables ; il ne modifie aucune ligne de `users`.
+
+Ordre obligatoire : exécuter
+`support/20260727_user_multi_roles_315.preflight.sql`, appliquer les deux
+patches sur `cerp_test`, exécuter leurs vérifications, puis réaliser la recette
+des sessions mono-rôle et multi-rôles. Une validation humaine explicite reste
+obligatoire avant toute application sur `cerp_prod`.

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -381,3 +381,63 @@ application identique. Les deux bases exposent 33 rôles actifs, aucun compte
 sans rôle principal et des privilèges applicatifs conformes. La recette a
 couvert 17 comptes provisionnés, 64 affectations et six profils d'accès
 représentatifs, sans modifier le compte administrateur existant.
+
+## Issue #326 - Tour de contrôle des accès
+
+Le patch `20260727_admin_access_tower_326.sql` installe le socle du filtrage
+module par compte : la colonne marqueur `users.is_superadmin`, le catalogue
+`app_modules`, les décisions explicites `app_module_user_access` et le journal
+append-only `app_module_access_events`, protégé par le même mécanisme de trigger
+que `user_role_assignment_events` (#315).
+
+Le patch est transactionnel, idempotent et strictement additif. Il ne pose
+aucune restriction : les vingt modules du catalogue naissent avec
+`enabled_by_default = true`, et une restriction ne peut résulter que d'une
+décision explicite tracée. La réapplication met à jour le libellé, la
+description, la catégorie, les préfixes d'API, les clés de navigation et l'ordre
+d'affichage, mais **jamais** `enabled_by_default` ni `is_active` : une décision
+d'exploitation déjà prise ne doit pas être effacée par une migration. Seule
+exception assumée, le drapeau `is_protected` du module `administration` est
+réaffirmé, et les éventuelles restrictions posées sur un module protégé sont
+supprimées — c'est ce qui garantit qu'aucune décision ne peut rendre l'ERP
+inadministrable.
+
+Le journal ne porte volontairement aucune clé étrangère : le trigger append-only
+interdit tout `UPDATE`, donc un `ON DELETE SET NULL` sur `user_id` ferait échouer
+la suppression d'un compte. Le journal doit survivre à la disparition de l'acteur
+comme de la cible.
+
+Le patch accorde à `cerp_app` le strict nécessaire : lecture du catalogue et
+`UPDATE` limité aux seules colonnes `enabled_by_default` et `updated_at`, gestion
+complète des décisions utilisateur, lecture et ajout seulement sur le journal.
+Le script de vérification contrôle ces privilèges, y compris l'absence de droit
+`INSERT`/`DELETE` sur le catalogue, l'absence de droit `UPDATE` sur `module_key`
+et l'absence de droit `UPDATE`/`DELETE` sur le journal. Il vérifie aussi que les
+vingt clés de module attendues sont présentes : une clé manquante ferait
+silencieusement tomber le gate serveur en mode ouvert sur le module concerné.
+
+Le statut superadmin n'est accordé par **aucune API**. `is_superadmin` est exposé
+en lecture seule par `/admin/users` et `/admin/users/:id` ; le fournir dans le
+corps d'un `PATCH` est un rejet de validation, pas une ignorance silencieuse. Le
+seul chemin d'octroi est le seed gardé
+`db/seeds/access-tower-superadmin-keenan.sql`, qui refuse de s'exécuter sur
+`cerp_prod` sans `SET cerp.access_tower_superadmin_approved = 'KEENAN'`, refuse
+si la colonne n'existe pas encore, et refuse si le nom d'utilisateur ne
+correspond pas exactement à un compte unique.
+
+Ordre obligatoire : exécuter
+`support/20260727_admin_access_tower_326.preflight.sql`, appliquer le patch sur
+`cerp_test`, exécuter la vérification, appliquer le seed superadmin sur
+`cerp_test`, puis réaliser la recette navigateur de la tour de contrôle. Une
+validation humaine explicite reste obligatoire avant toute application sur
+`cerp_prod`. Le rollback de support supprime les trois tables, le trigger, sa
+fonction et la colonne ajoutée ; il ne modifie aucune ligne de `users`.
+
+Le socle serveur tolère l'absence de ce patch : une erreur PostgreSQL `42P01`
+fait passer le gate en mode ouvert avec un avertissement journalisé, et
+`/api/v1/auth/access-profile` répond `{ "is_superadmin": false, "modules": [] }`
+en 200. Briquer l'ERP entier serait pire que ne pas filtrer. Dès que
+l'infrastructure existe, la décision redevient fermée par défaut.
+
+État au 2026-07-27 : patch, scripts de support et seed **écrits et versionnés,
+appliqués sur aucune base**. Ni `cerp_test` ni `cerp_prod` n'ont été modifiés.

--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -32,6 +32,12 @@ Toutes les routes sont sous `/api/v1/import-assistant` et réservées aux rôles
   `ADJUSTMENT/IN` par article via le service stock normal. Le lot conserve la
   date de cut-off, la provenance CLIPPER, la méthode de calcul et deux clés
   d’idempotence distinctes pour la création et la comptabilisation.
+- Les quantités de mouvement, de ligne et de niveau de stock partagent une
+  précision canonique de six décimales. Le patch #198 élargit
+  `stock_movement_lines.qty` de `NUMERIC(18,3)` à `NUMERIC(18,6)` et réconcilie
+  uniquement les résidus d’arrondi inférieurs à `0,0005` des mouvements
+  d’ouverture CLIPPER à ligne unique. Chaque correction produit un événement
+  de stock auditable.
 - Les soldes nuls ne sont pas importés. Les articles absents, inactifs, non
   gérés en stock ou sans emplacement valide bloquent la simulation avant toute
   écriture.
@@ -68,6 +74,9 @@ Patches :
 - `db/patches/20260727_contacts_shared_email_identity_190.sql` pour affiner cette
   règle, uniquement dans `cerp_test`, et autoriser des personnes distinctes
   partageant une adresse fonctionnelle tout en bloquant le doublon exact actif.
+- `db/patches/20260727_stock_import_precision_198.sql` pour aligner, uniquement
+  dans `cerp_test`, la précision des lignes de mouvement sur le grand livre
+  stock à six décimales et réparer les seuls résidus d’arrondi prouvés.
 
 Avant toute application, exécuter le preflight sur `cerp_test`, appliquer par le mécanisme de patches existant, puis lancer le script `verify`. Le rollback automatique est volontairement bloqué dès que des preuves ou correspondances peuvent exister.
 

--- a/docs/import-assistant.md
+++ b/docs/import-assistant.md
@@ -24,6 +24,17 @@ Toutes les routes sont sous `/api/v1/import-assistant` et réservées aux rôles
 - SHA-256 du fichier et unicité du lot par source, domaine, empreinte et feuille.
 - Simulation par les schémas Zod existants.
 - Création par les services métier existants et codes générés par CERP.
+- Le stock d’ouverture exige un article déjà présent dans le crosswalk, un
+  article actif et géré en stock, ainsi qu’un magasin et un emplacement CERP
+  actifs, non ambigus, reliés au référentiel physique et autorisant les
+  entrées.
+- Chaque solde strictement positif crée puis comptabilise un mouvement
+  `ADJUSTMENT/IN` par article via le service stock normal. Le lot conserve la
+  date de cut-off, la provenance CLIPPER, la méthode de calcul et deux clés
+  d’idempotence distinctes pour la création et la comptabilisation.
+- Les soldes nuls ne sont pas importés. Les articles absents, inactifs, non
+  gérés en stock ou sans emplacement valide bloquent la simulation avant toute
+  écriture.
 - Enrichissement client par PATCH parcimonieux : seuls les champs réellement
   mappés sont écrits, sans listes vides implicites.
 - Contacts clients rattachés par le crosswalk du client parent, avec clé
@@ -65,10 +76,15 @@ Le patch est additif et n’importe aucune donnée métier.
 ## Ordre de reprise
 
 Les lots sont exécutés dans l’ordre : clients complets, contacts clients,
-fournisseurs, commandes fournisseurs, articles et matières achetés, machines et
-référentiels, puis pièces techniques. Une pièce technique ne doit pas être
-confirmée tant que ses clients, fournisseurs, matières et flux d’achat ne sont
-pas validés.
+fournisseurs, commandes fournisseurs, articles et matières achetés, stock
+d’ouverture, machines et référentiels, puis pièces techniques. Une pièce
+technique ne doit pas être confirmée tant que ses clients, fournisseurs,
+matières, flux d’achat et stocks de départ ne sont pas validés.
+
+Pour la reprise CLIPPER du 24 juillet 2026, le solde d’ouverture retenu est la
+somme chronologique `entrées + retours − sorties`. Les mouvements annulés sont
+ignorés. La colonne historique `ARTICLEM.COL_081` n’est pas un stock et ne doit
+jamais alimenter un mouvement d’ouverture.
 
 Le choix affiché par le frontend n’est jamais utilisé comme preuve. Le service
 API dédié à l’import doit disposer de son propre pool PostgreSQL vers

--- a/src/__tests__/access-control.gate.test.ts
+++ b/src/__tests__/access-control.gate.test.ts
@@ -1,0 +1,271 @@
+/**
+ * #326 / back #200 — gate d'accès module monté globalement dans v1.routes.ts.
+ * Le frontend masque, le backend refuse : ce fichier éprouve le refus réel, le
+ * passage du superadmin, l'immunité du module protégé, le fail-open documenté sur
+ * absence d'infrastructure (42P01) et le kill-switch d'exploitation.
+ */
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = { on: emitter.on.bind(emitter), query: mocks.poolQuery, connect: mocks.poolConnect };
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../module/auth/middlewares/auth.middleware")>();
+  return {
+    ...actual,
+    authenticateToken: (
+      req: { user?: unknown; headers: Record<string, unknown> },
+      res: { status: (n: number) => { json: (b: unknown) => void } },
+      next: () => void
+    ) => {
+      const role = typeof req.headers["x-test-role"] === "string" ? (req.headers["x-test-role"] as string) : "";
+      if (!role) {
+        res.status(401).json({ error: "Token manquant ou invalide" });
+        return;
+      }
+      req.user = { id: 9, username: "t", email: "t@t.t", role };
+      next();
+    },
+  };
+});
+
+// Seule la lecture du profil est simulée : la règle de décision, le cache et le
+// middleware restent les vrais.
+vi.mock("../module/access-control/repository/access-control.repository", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../module/access-control/repository/access-control.repository")>();
+  return { ...actual, repoResolveAccessProfile: vi.fn() };
+});
+
+import type { NextFunction, Request, Response } from "express";
+
+import app from "../config/app";
+import * as baseRepo from "../module/access-control/repository/access-control.repository";
+import { moduleAccessGate } from "../module/access-control/middlewares/module-access-gate";
+import { invalidateAccessCache } from "../module/access-control/services/access-control.service";
+
+const repo = vi.mocked(baseRepo);
+const USER_ID = 9;
+
+type FakeRes = Response & { statusCode: number; body: unknown };
+
+function fakeRes(): FakeRes {
+  const res = { statusCode: 0, body: null as unknown } as unknown as FakeRes;
+  (res as unknown as { status: (n: number) => unknown }).status = (n: number) => {
+    res.statusCode = n;
+    return res;
+  };
+  (res as unknown as { json: (b: unknown) => unknown }).json = (b: unknown) => {
+    res.body = b;
+    return res;
+  };
+  return res;
+}
+
+// `null` signifie explicitement « aucun utilisateur attaché », ce qu'un paramètre
+// optionnel ne permettrait pas de distinguer de l'absence d'argument.
+function fakeReq(path: string, user: { id: number } | null): Request {
+  return {
+    path,
+    originalUrl: `/api/v1${path}`,
+    method: "GET",
+    headers: {},
+    user: user ?? undefined,
+  } as unknown as Request;
+}
+
+function profileRow(overrides: {
+  module_key: string;
+  access?: "GRANTED" | "DENIED" | null;
+  enabled_by_default?: boolean;
+  is_active?: boolean;
+  is_superadmin?: boolean;
+}) {
+  return {
+    is_superadmin: overrides.is_superadmin ?? false,
+    module_key: overrides.module_key,
+    label: overrides.module_key,
+    nav_page_keys: [],
+    enabled_by_default: overrides.enabled_by_default ?? true,
+    is_protected: false,
+    is_active: overrides.is_active ?? true,
+    access: overrides.access ?? null,
+  };
+}
+
+async function run(path: string, user: { id: number } | null = { id: USER_ID }) {
+  const res = fakeRes();
+  const next = vi.fn() as unknown as NextFunction;
+  moduleAccessGate(fakeReq(path, user), res, next);
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  return { res, next: next as unknown as ReturnType<typeof vi.fn> };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  invalidateAccessCache();
+  delete process.env.CERP_MODULE_ACCESS_GATE_DISABLED;
+
+  mocks.poolQuery.mockResolvedValue({ rows: [] });
+  mocks.poolConnect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease });
+  mocks.clientQuery.mockResolvedValue({ rows: [] });
+  repo.repoResolveAccessProfile.mockResolvedValue([profileRow({ module_key: "clients" })]);
+});
+
+afterEach(() => {
+  delete process.env.CERP_MODULE_ACCESS_GATE_DISABLED;
+});
+
+describe("Gate d'accès module — passages sans interrogation de la base", () => {
+  it("laisse passer une surface d'infrastructure partagée sans résoudre aucun profil", async () => {
+    const { next } = await run("/users/4");
+    expect(next).toHaveBeenCalledOnce();
+    expect(repo.repoResolveAccessProfile).not.toHaveBeenCalled();
+  });
+
+  it("laisse passer le module protégé sans résoudre aucun profil", async () => {
+    const { res, next } = await run("/admin/users");
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(0);
+    expect(repo.repoResolveAccessProfile).not.toHaveBeenCalled();
+  });
+
+  it("laisse passer quand aucun utilisateur n'est attaché à la requête", async () => {
+    const { next } = await run("/clients/1", null);
+    expect(next).toHaveBeenCalledOnce();
+    expect(repo.repoResolveAccessProfile).not.toHaveBeenCalled();
+  });
+
+  it("kill-switch d'exploitation : le gate s'efface immédiatement", async () => {
+    process.env.CERP_MODULE_ACCESS_GATE_DISABLED = "1";
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "clients", access: "DENIED" }),
+    ]);
+    const { res, next } = await run("/clients/1");
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(0);
+    expect(repo.repoResolveAccessProfile).not.toHaveBeenCalled();
+  });
+});
+
+describe("Gate d'accès module — décisions", () => {
+  it("refus explicite ⇒ 403 sobre, sans jamais atteindre la route", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "clients", access: "DENIED" }),
+    ]);
+    const { res, next } = await run("/clients/1");
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "Accès interdit" });
+    expect(JSON.stringify(res.body)).not.toMatch(/module|superadmin|catalogue|interdit au module/i);
+  });
+
+  it("défaut catalogue désactivé ⇒ 403 sans override", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "clients", enabled_by_default: false }),
+    ]);
+    const { res } = await run("/clients/1");
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("module désactivé au catalogue ⇒ 403", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "clients", is_active: false }),
+    ]);
+    const { res } = await run("/clients/1");
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("le superadmin traverse tout, même un module explicitement refusé", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "clients", access: "DENIED", is_superadmin: true }),
+    ]);
+    const { res, next } = await run("/clients/1");
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(0);
+  });
+
+  it("le refus d'un module n'en refuse aucun autre", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "clients", access: "DENIED" }),
+      profileRow({ module_key: "stock" }),
+    ]);
+    expect((await run("/clients/1")).res.statusCode).toBe(403);
+    expect((await run("/stock/articles")).next).toHaveBeenCalledOnce();
+  });
+
+  it("« /production/station » est bien filtré par le module production", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "production", access: "DENIED" }),
+    ]);
+    const { res } = await run("/production/station/sessions");
+    expect(res.statusCode).toBe(403);
+  });
+
+  it("résout le profil une seule fois par compte grâce au cache", async () => {
+    await run("/clients/1");
+    await run("/clients/2");
+    expect(repo.repoResolveAccessProfile).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("Gate d'accès module — absence d'infrastructure", () => {
+  it("tables absentes (42P01) ⇒ fail-open documenté, jamais un ERP briqué", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue(null);
+    const { res, next } = await run("/clients/1");
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(0);
+  });
+
+  it("module absent du catalogue en base ⇒ fail-open, aucun refus fabriqué", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([profileRow({ module_key: "stock" })]);
+    const { res, next } = await run("/clients/1");
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(0);
+  });
+
+  it("erreur de base non liée à l'infrastructure ⇒ remontée à la chaîne d'erreurs", async () => {
+    const failure = new Error("connexion perdue");
+    repo.repoResolveAccessProfile.mockRejectedValue(failure);
+    const { res, next } = await run("/clients/1");
+    expect(res.statusCode).toBe(0);
+    expect(next).toHaveBeenCalledWith(failure);
+  });
+});
+
+describe("Gate d'accès module — application réelle", () => {
+  it("refuse 403 sur une route métier réelle, sans fuiter le motif", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "clients", access: "DENIED" }),
+    ]);
+
+    const res = await request(app).get("/api/v1/clients").set("x-test-role", "Directeur");
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ error: "Accès interdit" });
+    expect(JSON.stringify(res.body)).not.toMatch(/module|superadmin|catalogue/i);
+  });
+
+  it("n'ôte aucun garde existant : sans jeton, c'est toujours 401 avant le gate", async () => {
+    const res = await request(app).get("/api/v1/clients");
+    expect(res.status).toBe(401);
+    expect(repo.repoResolveAccessProfile).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/access-control.test.ts
+++ b/src/__tests__/access-control.test.ts
@@ -1,0 +1,577 @@
+/**
+ * #326 / back #200 — socle serveur de la tour de contrôle des accès.
+ *  1. Résolution chemin -> module : plus long préfixe, frontière de segment,
+ *     surfaces d'infrastructure jamais rattachées à un module.
+ *  2. Règles métier : module protégé jamais restreignable, compte superadmin
+ *     jamais restreignable, INHERIT = suppression de la ligne d'override.
+ *  3. Audit : la ligne erp_audit_logs est écrite dans la MÊME transaction.
+ *  4. Surface /admin/access : réservée au superadmin, 403 non bavard.
+ *  5. `is_superadmin` est exposé en lecture seule et rejeté en écriture.
+ */
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventEmitter } from "events";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+  txQuery: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = { on: emitter.on.bind(emitter), query: mocks.poolQuery, connect: mocks.poolConnect };
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+// authenticateToken simulé (401 sans en-tête de test) ; requireSuperadmin et
+// authorizeRole RÉELS — ce sont précisément les gardes que l'on veut éprouver.
+vi.mock("../module/auth/middlewares/auth.middleware", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../module/auth/middlewares/auth.middleware")>();
+  return {
+    ...actual,
+    authenticateToken: (
+      req: { user?: unknown; headers: Record<string, unknown> },
+      res: { status: (n: number) => { json: (b: unknown) => void } },
+      next: () => void
+    ) => {
+      const role = typeof req.headers["x-test-role"] === "string" ? (req.headers["x-test-role"] as string) : "";
+      if (!role) {
+        res.status(401).json({ error: "Token manquant ou invalide" });
+        return;
+      }
+      const rawId = req.headers["x-test-user-id"];
+      const id = typeof rawId === "string" ? Number(rawId) : 1;
+      req.user = { id, username: "t", email: "t@t.t", role };
+      next();
+    },
+  };
+});
+
+// Le dépôt est simulé pour éprouver les RÈGLES sans dépendre d'un dialecte SQL ;
+// `withTransaction` fournit une transaction factice observable.
+vi.mock("../module/access-control/repository/access-control.repository", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../module/access-control/repository/access-control.repository")>();
+  return {
+    ...actual,
+    withTransaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({ query: mocks.txQuery })
+    ),
+    repoResolveAccessProfile: vi.fn(),
+    repoIsSuperadmin: vi.fn(),
+    repoListCatalogModules: vi.fn(),
+    repoGetCatalogModule: vi.fn(),
+    repoListAccessUsers: vi.fn(),
+    repoGetAccessUser: vi.fn(),
+    repoListAccessOverrides: vi.fn(),
+    repoGetUserModuleAccess: vi.fn(),
+    repoSetModuleDefault: vi.fn(),
+    repoUpsertUserModuleAccess: vi.fn(),
+    repoDeleteUserModuleAccess: vi.fn(),
+    repoDeleteAllDenials: vi.fn(),
+    repoRestoreAllDefaults: vi.fn(),
+    repoInsertAccessEvent: vi.fn(),
+    repoListAccessEvents: vi.fn(),
+  };
+});
+
+import app from "../config/app";
+import * as baseRepo from "../module/access-control/repository/access-control.repository";
+import {
+  MODULE_CATALOG,
+  PROTECTED_MODULE_KEYS,
+  resolveModuleKeyForPath,
+} from "../module/access-control/domain/module-catalog";
+import * as service from "../module/access-control/services/access-control.service";
+
+const repo = vi.mocked(baseRepo);
+
+const SUPERADMIN_ID = 4;
+const OPERATEUR_ID = 9;
+
+const CATALOG_ROW = {
+  module_key: "clients",
+  label: "Clients",
+  description: null,
+  category: "Commerce",
+  api_prefixes: ["/clients"],
+  nav_page_keys: ["clients"],
+  enabled_by_default: true,
+  is_protected: false,
+  sort_order: 10,
+  is_active: true,
+};
+
+const PROTECTED_ROW = { ...CATALOG_ROW, module_key: "administration", label: "Administration", is_protected: true };
+
+const USER_ROW = {
+  id: OPERATEUR_ID,
+  username: "OPERATEUR",
+  name: "N",
+  surname: "P",
+  email: "op@croix-rousse-precision.fr",
+  role: "Employee",
+  roles: ["Employee"],
+  status: "Active",
+  is_superadmin: false,
+  last_login: null,
+};
+
+const SUPERADMIN_ROW = { ...USER_ROW, id: SUPERADMIN_ID, username: "KEENAN", is_superadmin: true };
+
+const AUDIT = {
+  user_id: SUPERADMIN_ID,
+  ip: null,
+  user_agent: null,
+  device_type: null,
+  os: null,
+  browser: null,
+  path: "/api/v1/admin/access",
+  client_session_id: null,
+};
+
+function txSql(): string[] {
+  return mocks.txQuery.mock.calls.map((call) => String(call[0]));
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  service.invalidateAccessCache();
+
+  mocks.poolQuery.mockResolvedValue({ rows: [] });
+  mocks.poolConnect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease });
+  mocks.clientQuery.mockResolvedValue({ rows: [] });
+  mocks.txQuery.mockResolvedValue({ rows: [{ id: "audit-1", created_at: "2026-07-27T00:00:00Z" }] });
+
+  repo.repoIsSuperadmin.mockResolvedValue(false);
+  repo.repoListCatalogModules.mockResolvedValue([CATALOG_ROW, PROTECTED_ROW]);
+  repo.repoListAccessUsers.mockResolvedValue([USER_ROW, SUPERADMIN_ROW]);
+  repo.repoListAccessOverrides.mockResolvedValue([]);
+  repo.repoGetCatalogModule.mockResolvedValue(CATALOG_ROW);
+  repo.repoGetAccessUser.mockResolvedValue(USER_ROW);
+  repo.repoGetUserModuleAccess.mockResolvedValue(null);
+  repo.repoDeleteAllDenials.mockResolvedValue([]);
+  repo.repoRestoreAllDefaults.mockResolvedValue([]);
+});
+
+describe("Catalogue de modules #326", () => {
+  it("expose 20 modules aux clés et préfixes uniques, dont un seul protégé", () => {
+    expect(MODULE_CATALOG).toHaveLength(20);
+    const keys = MODULE_CATALOG.map((entry) => entry.module_key);
+    expect(new Set(keys).size).toBe(20);
+
+    const prefixes = MODULE_CATALOG.flatMap((entry) => entry.api_prefixes);
+    expect(new Set(prefixes).size).toBe(prefixes.length);
+    expect(prefixes.every((prefix) => prefix.startsWith("/"))).toBe(true);
+    expect(PROTECTED_MODULE_KEYS).toEqual(["administration"]);
+  });
+
+  it("résout le module par le plus long préfixe, sur une frontière de segment", () => {
+    expect(resolveModuleKeyForPath("/production/station/of/42")).toBe("production");
+    expect(resolveModuleKeyForPath("/production")).toBe("production");
+    expect(resolveModuleKeyForPath("/clients/123/contacts")).toBe("clients");
+    // « /commandes » ne doit jamais capter « /commandes-fournisseurs ».
+    expect(resolveModuleKeyForPath("/commandes/17")).toBe("commandes-clients");
+    expect(resolveModuleKeyForPath("/commandes-fournisseurs/17")).toBe("commandes-fournisseurs");
+    expect(resolveModuleKeyForPath("/piece-technique-versions/9")).toBe("pieces-techniques");
+    expect(resolveModuleKeyForPath("/pieces-techniques/9")).toBe("pieces-techniques");
+  });
+
+  it("accepte une URL complète et ignore la query string", () => {
+    expect(resolveModuleKeyForPath("/api/v1/qualite/v2/plans?limit=10")).toBe("qualite");
+    expect(resolveModuleKeyForPath("/api/v1/admin/access/overview")).toBe("administration");
+    expect(resolveModuleKeyForPath("/stock/")).toBe("stock");
+  });
+
+  it("ne rattache aucune surface d'infrastructure partagée à un module", () => {
+    for (const path of [
+      "/auth/login",
+      "/audit-logs",
+      "/codes/formats",
+      "/notifications",
+      "/chat/threads",
+      "/users/4",
+      "/locks",
+      "/centre-frais",
+      "/pieces-families",
+      "/environment",
+    ]) {
+      expect(resolveModuleKeyForPath(path)).toBeNull();
+    }
+    expect(resolveModuleKeyForPath("")).toBeNull();
+    expect(resolveModuleKeyForPath(undefined)).toBeNull();
+  });
+});
+
+describe("Règles métier de la tour de contrôle", () => {
+  it("refuse 409 MODULE_PROTECTED de restreindre le module protégé", async () => {
+    repo.repoGetCatalogModule.mockResolvedValue(PROTECTED_ROW);
+
+    await expect(
+      service.setModuleDefault({ moduleKey: "administration", enabled: false, audit: AUDIT })
+    ).rejects.toMatchObject({ status: 409, code: "MODULE_PROTECTED" });
+
+    await expect(
+      service.setUserModuleAccess({
+        userId: OPERATEUR_ID,
+        moduleKey: "administration",
+        decision: "DENIED",
+        audit: AUDIT,
+      })
+    ).rejects.toMatchObject({ status: 409, code: "MODULE_PROTECTED" });
+
+    expect(repo.repoUpsertUserModuleAccess).not.toHaveBeenCalled();
+    expect(repo.repoSetModuleDefault).not.toHaveBeenCalled();
+  });
+
+  it("autorise en revanche un GRANTED explicite sur le module protégé", async () => {
+    repo.repoGetCatalogModule.mockResolvedValue(PROTECTED_ROW);
+    await service.setUserModuleAccess({
+      userId: OPERATEUR_ID,
+      moduleKey: "administration",
+      decision: "GRANTED",
+      audit: AUDIT,
+    });
+    expect(repo.repoUpsertUserModuleAccess).toHaveBeenCalledOnce();
+  });
+
+  it("refuse 409 SUPERADMIN_IMMUTABLE de refuser un module à un superadmin", async () => {
+    repo.repoGetAccessUser.mockResolvedValue(SUPERADMIN_ROW);
+    await expect(
+      service.setUserModuleAccess({
+        userId: SUPERADMIN_ID,
+        moduleKey: "clients",
+        decision: "DENIED",
+        audit: AUDIT,
+      })
+    ).rejects.toMatchObject({ status: 409, code: "SUPERADMIN_IMMUTABLE" });
+    expect(repo.repoUpsertUserModuleAccess).not.toHaveBeenCalled();
+  });
+
+  it("INHERIT supprime la ligne d'override et journalise INHERITED", async () => {
+    repo.repoGetUserModuleAccess.mockResolvedValue("DENIED");
+
+    await service.setUserModuleAccess({
+      userId: OPERATEUR_ID,
+      moduleKey: "clients",
+      decision: "INHERIT",
+      audit: AUDIT,
+    });
+
+    expect(repo.repoDeleteUserModuleAccess).toHaveBeenCalledWith(expect.anything(), {
+      userId: OPERATEUR_ID,
+      moduleKey: "clients",
+    });
+    expect(repo.repoUpsertUserModuleAccess).not.toHaveBeenCalled();
+    expect(repo.repoInsertAccessEvent).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ eventType: "INHERITED", previousState: "DENIED", nextState: "INHERIT" })
+    );
+  });
+
+  it("n'écrit rien quand la décision demandée est déjà l'état courant", async () => {
+    repo.repoGetUserModuleAccess.mockResolvedValue("DENIED");
+    await service.setUserModuleAccess({
+      userId: OPERATEUR_ID,
+      moduleKey: "clients",
+      decision: "DENIED",
+      audit: AUDIT,
+    });
+    expect(repo.repoUpsertUserModuleAccess).not.toHaveBeenCalled();
+    expect(repo.repoInsertAccessEvent).not.toHaveBeenCalled();
+    expect(txSql().join(" ")).not.toContain("erp_audit_logs");
+  });
+
+  it("écrit l'audit ERP dans la MÊME transaction que la mutation", async () => {
+    await service.setUserModuleAccess({
+      userId: OPERATEUR_ID,
+      moduleKey: "clients",
+      decision: "DENIED",
+      audit: AUDIT,
+    });
+
+    const auditInsert = mocks.txQuery.mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO erp_audit_logs")
+    );
+    expect(auditInsert).toBeDefined();
+    const values = auditInsert?.[1] as unknown[];
+    expect(values).toContain("ACCESS_USER_MODULE_SET");
+    expect(values).toContain("administration-acces");
+    expect(values).toContain("module_access");
+    expect(values).toContain(`${OPERATEUR_ID}:clients`);
+  });
+
+  it("le bulk applique chaque décision et journalise un seul ACCESS_USER_BULK_SET", async () => {
+    repo.repoGetCatalogModule.mockImplementation(async (moduleKey: string) =>
+      moduleKey === "administration" ? PROTECTED_ROW : { ...CATALOG_ROW, module_key: moduleKey }
+    );
+
+    await service.setUserModulesBulk({
+      userId: OPERATEUR_ID,
+      entries: [
+        { module_key: "clients", access: "DENIED" },
+        { module_key: "stock", access: "GRANTED" },
+      ],
+      audit: AUDIT,
+    });
+
+    expect(repo.repoUpsertUserModuleAccess).toHaveBeenCalledTimes(2);
+    const auditActions = mocks.txQuery.mock.calls
+      .filter((call) => String(call[0]).includes("INSERT INTO erp_audit_logs"))
+      .map((call) => (call[1] as unknown[])[2]);
+    expect(auditActions).toEqual(["ACCESS_USER_BULK_SET"]);
+  });
+
+  it("« tout débloquer » exige la confirmation exacte", async () => {
+    await expect(service.unlockAll({ confirm: "debloquer tout", audit: AUDIT })).rejects.toMatchObject({
+      status: 400,
+      code: "CONFIRMATION_REQUIRED",
+    });
+    expect(repo.repoDeleteAllDenials).not.toHaveBeenCalled();
+
+    repo.repoDeleteAllDenials.mockResolvedValue([{ user_id: OPERATEUR_ID, module_key: "clients" }]);
+    repo.repoRestoreAllDefaults.mockResolvedValue(["stock"]);
+    await service.unlockAll({ confirm: "DEBLOQUER TOUT", audit: AUDIT });
+
+    expect(repo.repoDeleteAllDenials).toHaveBeenCalledOnce();
+    expect(repo.repoRestoreAllDefaults).toHaveBeenCalledOnce();
+    expect(repo.repoInsertAccessEvent).toHaveBeenCalledTimes(2);
+  });
+
+  it("404 explicite sur un module ou un compte inconnu", async () => {
+    repo.repoGetCatalogModule.mockResolvedValue(null);
+    await expect(
+      service.setModuleDefault({ moduleKey: "inconnu", enabled: true, audit: AUDIT })
+    ).rejects.toMatchObject({ status: 404, code: "MODULE_NOT_FOUND" });
+
+    repo.repoGetAccessUser.mockResolvedValue(null);
+    await expect(
+      service.setUserModuleAccess({ userId: 999, moduleKey: "clients", decision: "DENIED", audit: AUDIT })
+    ).rejects.toMatchObject({ status: 404, code: "USER_NOT_FOUND" });
+  });
+});
+
+describe("Résolution du profil d'accès", () => {
+  const profileRows = (overrides: Partial<{ access: "GRANTED" | "DENIED"; enabled: boolean; superadmin: boolean }>) => [
+    {
+      is_superadmin: overrides.superadmin ?? false,
+      module_key: "clients",
+      label: "Clients",
+      nav_page_keys: ["clients"],
+      enabled_by_default: overrides.enabled ?? true,
+      is_protected: false,
+      is_active: true,
+      access: overrides.access ?? null,
+    },
+  ];
+
+  it("hérite du défaut catalogue quand aucun override n'existe", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue(profileRows({ enabled: false }));
+    const profile = await service.getAccessProfile(OPERATEUR_ID);
+    expect(profile.modules[0]).toMatchObject({ allowed: false, source: "DEFAULT" });
+  });
+
+  it("l'override explicite prime sur le défaut catalogue", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue(profileRows({ enabled: false, access: "GRANTED" }));
+    const profile = await service.getAccessProfile(OPERATEUR_ID);
+    expect(profile.modules[0]).toMatchObject({ allowed: true, source: "OVERRIDE" });
+  });
+
+  it("le superadmin traverse tout, même un module refusé explicitement", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue(
+      profileRows({ enabled: false, access: "DENIED", superadmin: true })
+    );
+    const profile = await service.getAccessProfile(SUPERADMIN_ID);
+    expect(profile.is_superadmin).toBe(true);
+    expect(profile.modules[0]).toMatchObject({ allowed: true, source: "SUPERADMIN" });
+  });
+
+  it("infrastructure absente (42P01) : profil vide en 200, jamais un refus", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue(null);
+    expect(await service.getAccessProfile(OPERATEUR_ID)).toEqual({ is_superadmin: false, modules: [] });
+  });
+
+  it("met le profil en cache et le relit après invalidation explicite", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue(profileRows({}));
+    await service.getAccessProfile(OPERATEUR_ID);
+    await service.getAccessProfile(OPERATEUR_ID);
+    expect(repo.repoResolveAccessProfile).toHaveBeenCalledTimes(1);
+
+    service.invalidateAccessCache(OPERATEUR_ID);
+    await service.getAccessProfile(OPERATEUR_ID);
+    expect(repo.repoResolveAccessProfile).toHaveBeenCalledTimes(2);
+  });
+
+  it("une mutation invalide le cache du compte visé", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue(profileRows({}));
+    await service.getAccessProfile(OPERATEUR_ID);
+    await service.setUserModuleAccess({
+      userId: OPERATEUR_ID,
+      moduleKey: "clients",
+      decision: "DENIED",
+      audit: AUDIT,
+    });
+    await service.getAccessProfile(OPERATEUR_ID);
+    expect(repo.repoResolveAccessProfile).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("Vue d'ensemble /admin/access/overview", () => {
+  it("assemble catalogue, comptes, matrice tri-état et compteurs", async () => {
+    repo.repoListAccessOverrides.mockResolvedValue([
+      { user_id: OPERATEUR_ID, module_key: "clients", access: "DENIED" },
+    ]);
+
+    const overview = await service.buildOverview();
+
+    expect(overview.summary).toMatchObject({
+      users_total: 2,
+      superadmins: 1,
+      modules_total: 2,
+      modules_restricted_by_default: 0,
+      active_restrictions: 1,
+    });
+    expect(overview.modules.find((m) => m.module_key === "clients")?.denied_count).toBe(1);
+
+    const cell = overview.matrix.find(
+      (entry) => entry.user_id === OPERATEUR_ID && entry.module_key === "clients"
+    );
+    expect(cell).toMatchObject({ access: "DENIED", effective: false, source: "OVERRIDE" });
+
+    // Hérité : la cellule ne porte AUCUN override, mais reste effectivement lisible.
+    const inherited = overview.matrix.find(
+      (entry) => entry.user_id === OPERATEUR_ID && entry.module_key === "administration"
+    );
+    expect(inherited).toMatchObject({ access: null, effective: true, source: "DEFAULT" });
+
+    // Le superadmin traverse tout, y compris le module refusé au reste.
+    const superadminCell = overview.matrix.find(
+      (entry) => entry.user_id === SUPERADMIN_ID && entry.module_key === "clients"
+    );
+    expect(superadminCell).toMatchObject({ effective: true, source: "SUPERADMIN" });
+    expect(overview.users.find((u) => u.id === OPERATEUR_ID)).toMatchObject({
+      denied_count: 1,
+      allowed_count: 1,
+    });
+  });
+});
+
+describe("Surface HTTP /admin/access", () => {
+  it("401 sans authentification", async () => {
+    const res = await request(app).get("/api/v1/admin/access/overview");
+    expect(res.status).toBe(401);
+  });
+
+  it("403 non bavard pour un compte non superadmin, même Directeur", async () => {
+    repo.repoIsSuperadmin.mockResolvedValue(false);
+    const res = await request(app)
+      .get("/api/v1/admin/access/overview")
+      .set("x-test-role", "Directeur")
+      .set("x-test-user-id", String(OPERATEUR_ID));
+
+    expect(res.status).toBe(403);
+    expect(JSON.stringify(res.body)).not.toMatch(/module|superadmin|catalog|acc[eè]s aux modules/i);
+    expect(res.body).toEqual({ error: "Accès interdit" });
+  });
+
+  it("403 fail-closed quand la résolution du statut superadmin échoue", async () => {
+    repo.repoIsSuperadmin.mockRejectedValue(new Error("connexion perdue"));
+    const res = await request(app)
+      .get("/api/v1/admin/access/overview")
+      .set("x-test-role", "Directeur")
+      .set("x-test-user-id", String(SUPERADMIN_ID));
+    expect(res.status).toBe(403);
+  });
+
+  it("200 pour le superadmin, avec l'enveloppe complète du contrat", async () => {
+    repo.repoIsSuperadmin.mockResolvedValue(true);
+    const res = await request(app)
+      .get("/api/v1/admin/access/overview")
+      .set("x-test-role", "Employee")
+      .set("x-test-user-id", String(SUPERADMIN_ID));
+
+    expect(res.status).toBe(200);
+    expect(Object.keys(res.body).sort()).toEqual(["matrix", "modules", "summary", "users"]);
+  });
+
+  it("409 MODULE_PROTECTED via l'API quand on tente de restreindre l'administration", async () => {
+    repo.repoIsSuperadmin.mockResolvedValue(true);
+    repo.repoGetCatalogModule.mockResolvedValue(PROTECTED_ROW);
+    const res = await request(app)
+      .put("/api/v1/admin/access/modules/administration/default")
+      .set("x-test-role", "Employee")
+      .set("x-test-user-id", String(SUPERADMIN_ID))
+      .send({ enabled_by_default: false });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ code: "MODULE_PROTECTED" });
+  });
+
+  it("400 CONFIRMATION_REQUIRED sur « tout débloquer » sans la phrase exacte", async () => {
+    repo.repoIsSuperadmin.mockResolvedValue(true);
+    const res = await request(app)
+      .post("/api/v1/admin/access/unlock-all")
+      .set("x-test-role", "Employee")
+      .set("x-test-user-id", String(SUPERADMIN_ID))
+      .send({ confirm: "oui" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "CONFIRMATION_REQUIRED" });
+  });
+
+  it("rejette une décision d'accès hors GRANTED/DENIED/INHERIT", async () => {
+    repo.repoIsSuperadmin.mockResolvedValue(true);
+    const res = await request(app)
+      .put(`/api/v1/admin/access/users/${OPERATEUR_ID}/modules/clients`)
+      .set("x-test-role", "Employee")
+      .set("x-test-user-id", String(SUPERADMIN_ID))
+      .send({ access: "PEUT-ETRE" });
+
+    expect(res.status).toBe(400);
+    expect(repo.repoUpsertUserModuleAccess).not.toHaveBeenCalled();
+  });
+});
+
+describe("Profil d'accès et exposition du marqueur superadmin", () => {
+  it("GET /auth/access-profile est ouvert à tout compte authentifié", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      {
+        is_superadmin: false,
+        module_key: "clients",
+        label: "Clients",
+        nav_page_keys: ["clients"],
+        enabled_by_default: true,
+        is_protected: false,
+        is_active: true,
+        access: null,
+      },
+    ]);
+
+    const res = await request(app)
+      .get("/api/v1/auth/access-profile")
+      .set("x-test-role", "Employee")
+      .set("x-test-user-id", String(OPERATEUR_ID));
+
+    expect(res.status).toBe(200);
+    expect(res.body.is_superadmin).toBe(false);
+    expect(res.body.modules[0]).toMatchObject({ module_key: "clients", allowed: true, source: "DEFAULT" });
+  });
+
+  it("PATCH /admin/users/:id refuse explicitement is_superadmin (aucune ignorance silencieuse)", async () => {
+    const res = await request(app)
+      .patch("/api/v1/admin/users/9")
+      .set("x-test-role", "Directeur")
+      .set("x-test-user-id", String(SUPERADMIN_ID))
+      .send({ is_superadmin: true });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ error: "VALIDATION_ERROR" });
+  });
+});

--- a/src/__tests__/affaires.routes.test.ts
+++ b/src/__tests__/affaires.routes.test.ts
@@ -52,6 +52,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app";
 
 beforeEach(() => {

--- a/src/__tests__/clients.routes.test.ts
+++ b/src/__tests__/clients.routes.test.ts
@@ -45,6 +45,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
     },
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app";
 
 beforeEach(() => {

--- a/src/__tests__/commande-ar.routes.test.ts
+++ b/src/__tests__/commande-ar.routes.test.ts
@@ -56,6 +56,13 @@ vi.mock("../module/commande-client/services/commande-ar.service", () => ({
   svcSendCommandeAr: mocks.sendAr,
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app";
 
 beforeEach(() => {

--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -64,6 +64,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
     },
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app";
 
 beforeEach(() => {

--- a/src/__tests__/devis.routes.test.ts
+++ b/src/__tests__/devis.routes.test.ts
@@ -63,6 +63,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app";
 
 /**

--- a/src/__tests__/fournisseurs.routes.test.ts
+++ b/src/__tests__/fournisseurs.routes.test.ts
@@ -42,6 +42,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app"
 
 beforeEach(() => {

--- a/src/__tests__/import-assistant.domain.test.ts
+++ b/src/__tests__/import-assistant.domain.test.ts
@@ -439,12 +439,72 @@ describe("Assistant d’import CLIPPER", () => {
     ]));
   });
 
-  it("garde stock, BL et RH visibles mais impossibles à confirmer", () => {
-    const gated = IMPORT_CAPABILITIES.filter((capability) =>
-      ["STOCK_INITIAL", "BL_HISTORIQUE", "EMPLOYE"].includes(capability.entity_type)
+  it("normalise un stock d’ouverture positif avec un cut-off explicite", () => {
+    const mapping: ImportMapping = {
+      legacy_key_column: "ARTICLE",
+      columns: {
+        article_legacy_code: "ARTICLE",
+        quantity: "SOLDE",
+        magasin_code: "MAGASIN",
+        emplacement_code: "EMPLACEMENT",
+        cutoff_date: "CUT_OFF",
+      },
+      constants: {},
+      approved_decisions: ["DEC-05", "DEC-06", "DEC-15", "DEC-16"],
+      duplicate_strategy: "REVIEW",
+    };
+
+    const valid = normalizeImportRow(
+      "STOCK_INITIAL",
+      {
+        ARTICLE: "RO*303*ETIRE*22*1",
+        SOLDE: "738 000,00",
+        MAGASIN: "MAG-PRINCIPAL",
+        EMPLACEMENT: "STOCK-GENERAL",
+        CUT_OFF: "24/07/2026",
+      },
+      mapping
+    );
+    const blocked = normalizeImportRow(
+      "STOCK_INITIAL",
+      {
+        ARTICLE: "ARTICLE-VIDE",
+        SOLDE: "0",
+        MAGASIN: "MAG-PRINCIPAL",
+        EMPLACEMENT: "STOCK-GENERAL",
+        CUT_OFF: "2026-07-24",
+      },
+      mapping
     );
 
-    expect(gated).toHaveLength(3);
+    expect(valid.issues).toEqual([]);
+    expect(valid.normalized_data).toEqual({
+      article_legacy_code: "RO*303*ETIRE*22*1",
+      quantity: 738000,
+      magasin_code: "MAG-PRINCIPAL",
+      emplacement_code: "STOCK-GENERAL",
+      cutoff_date: "2026-07-24",
+    });
+    expect(blocked.issues).toEqual(expect.arrayContaining([
+      expect.objectContaining({ field: "quantity" }),
+    ]));
+  });
+
+  it("ouvre le stock initial mais garde BL et RH impossibles à confirmer", () => {
+    const stock = IMPORT_CAPABILITIES.find((capability) => capability.entity_type === "STOCK_INITIAL");
+    const gated = IMPORT_CAPABILITIES.filter((capability) =>
+      ["BL_HISTORIQUE", "EMPLOYE"].includes(capability.entity_type)
+    );
+
+    expect(stock?.confirm_enabled).toBe(true);
+    expect(stock?.fields.map((field) => field.key)).toEqual(expect.arrayContaining([
+      "article_legacy_code",
+      "quantity",
+      "magasin_code",
+      "emplacement_code",
+      "cutoff_date",
+    ]));
+    expect(gated).toHaveLength(2);
     expect(gated.every((capability) => !capability.confirm_enabled)).toBe(true);
     expect(gated.every((capability) => capability.unavailable_reason)).toBe(true);
   });

--- a/src/__tests__/metrologie.routes.test.ts
+++ b/src/__tests__/metrologie.routes.test.ts
@@ -42,6 +42,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app"
 
 beforeEach(() => {

--- a/src/__tests__/multi-role-rbac.test.ts
+++ b/src/__tests__/multi-role-rbac.test.ts
@@ -1,0 +1,140 @@
+import type { NextFunction, Request, Response } from "express";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  authorizationRole,
+  effectiveRoleHasAny,
+  normalizeAssignedRoles,
+} from "../module/auth/domain/roles";
+import { authorizeRole } from "../module/auth/middlewares/auth.middleware";
+import { adminCreateUserSchema } from "../module/admin/validators/admin.validators";
+import { roleHasFinanceCapability } from "../module/facturation/domain/finance-policy";
+import { roleHasPlanningAccess } from "../module/planning/domain/planning-rbac";
+import { roleHasMachineCapability } from "../module/production/domain/machine-rbac";
+
+const validUserBody = {
+  username: "LAMBERT",
+  password: "Atelier1**",
+  name: "THOMASSONI",
+  surname: "Lambert",
+  email: "lambert@croix-rousse-precision.fr",
+  tel_no: "0600000001",
+  role: "Directeur",
+  roles: ["Directeur", "Commerce", "Achats"],
+  gender: "Male",
+  address: "Adresse provisoire",
+  lane: "Rue provisoire",
+  house_no: "1",
+  postcode: "69000",
+  country: "France",
+  date_of_birth: "1990-01-01",
+  status: "Active",
+  social_security_number: "100000000000001",
+};
+
+describe("RBAC multi-rôles #315", () => {
+  it("normalise les rôles sans doublon et conserve le rôle principal en premier", () => {
+    expect(normalizeAssignedRoles("Directeur", ["Commerce", "Directeur", "Achats"])).toEqual([
+      "Directeur",
+      "Commerce",
+      "Achats",
+    ]);
+    expect(authorizationRole("Directeur", ["Commerce", "Achats"])).toBe(
+      "Directeur | Commercial | Achat"
+    );
+  });
+
+  it("traduit explicitement les responsabilités sans escalade par intitulé", () => {
+    const effective = authorizationRole("Employee", [
+      "Directeur Technique",
+      "Planning",
+      "Maintenance",
+    ]);
+
+    expect(effective).toBe("Employee | Production | Atelier | Method | Planification | Maintenance");
+    expect(effectiveRoleHasAny(effective, ["Directeur"])).toBe(false);
+    expect(roleHasPlanningAccess(effective)).toBe(true);
+    expect(roleHasFinanceCapability(effective, "read")).toBe(false);
+  });
+
+  it("autorise une route lorsqu'un rôle complémentaire correspond", () => {
+    const middleware = authorizeRole("Responsable RH");
+    const req = {
+      user: {
+        id: 12,
+        username: "NIZIER",
+        email: "nizier@croix-rousse-precision.fr",
+        role: "Directeur | Responsable RH | Planning",
+        primary_role: "Directeur",
+        roles: ["Directeur", "Responsable RH", "Planning"],
+      },
+      headers: {},
+      method: "GET",
+      originalUrl: "/api/v1/temps-deplacements",
+    } as unknown as Request;
+    const status = vi.fn().mockReturnThis();
+    const json = vi.fn();
+    const res = { status, json } as unknown as Response;
+    const next = vi.fn() as NextFunction;
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it("refuse par défaut si aucun rôle attribué ne correspond", () => {
+    const middleware = authorizeRole("Responsable RH");
+    const req = {
+      user: {
+        id: 13,
+        username: "OPERATEUR",
+        email: "operateur@croix-rousse-precision.fr",
+        role: "Employee | Opérateur atelier",
+        primary_role: "Employee",
+        roles: ["Employee", "Opérateur atelier"],
+      },
+      headers: {},
+      method: "GET",
+      originalUrl: "/api/v1/temps-deplacements",
+    } as unknown as Request;
+    const json = vi.fn();
+    const status = vi.fn(() => ({ json }));
+    const res = { status } as unknown as Response;
+    const next = vi.fn() as NextFunction;
+
+    middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(403);
+  });
+
+  it("valide le rôle principal dans l'ensemble des rôles attribués", () => {
+    expect(adminCreateUserSchema.safeParse({ body: validUserBody }).success).toBe(true);
+    const invalid = adminCreateUserSchema.safeParse({
+      body: { ...validUserBody, roles: ["Commerce", "Achats"] },
+    });
+    expect(invalid.success).toBe(false);
+  });
+
+  it("autorise un compte ERP incomplet sans inventer de données RH", () => {
+    const accountOnly = {
+      ...validUserBody,
+      tel_no: null,
+      gender: null,
+      address: null,
+      lane: null,
+      house_no: null,
+      postcode: null,
+      date_of_birth: null,
+      social_security_number: null,
+    };
+    expect(adminCreateUserSchema.safeParse({ body: accountOnly }).success).toBe(true);
+  });
+
+  it("cumule les capacités des rôles fonctionnels historiques", () => {
+    expect(roleHasMachineCapability("Employee | Maintenance", "maintenance")).toBe(true);
+    expect(roleHasMachineCapability("Employee | Opérateur atelier", "archive")).toBe(false);
+    expect(roleHasFinanceCapability("Employee | Comptabilite", "validate")).toBe(true);
+  });
+});

--- a/src/__tests__/outils.routes.test.ts
+++ b/src/__tests__/outils.routes.test.ts
@@ -42,6 +42,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app"
 
 beforeEach(() => {

--- a/src/__tests__/planning.routes.test.ts
+++ b/src/__tests__/planning.routes.test.ts
@@ -49,6 +49,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
     },
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app";
 
 beforeEach(() => {

--- a/src/__tests__/production-execution-274.routes.test.ts
+++ b/src/__tests__/production-execution-274.routes.test.ts
@@ -58,6 +58,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
     },
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app";
 
 const BASE = "/api/v1/production/execution";

--- a/src/__tests__/production-machine-intelligence.routes.test.ts
+++ b/src/__tests__/production-machine-intelligence.routes.test.ts
@@ -49,6 +49,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
     },
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app";
 
 beforeEach(() => {

--- a/src/__tests__/qualite-360-228.routes.test.ts
+++ b/src/__tests__/qualite-360-228.routes.test.ts
@@ -57,6 +57,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
     },
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app";
 
 const BASE = "/api/v1/qualite/v2";

--- a/src/__tests__/qualite.routes.test.ts
+++ b/src/__tests__/qualite.routes.test.ts
@@ -42,6 +42,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app"
 
 beforeEach(() => {

--- a/src/__tests__/receptions.routes.test.ts
+++ b/src/__tests__/receptions.routes.test.ts
@@ -42,6 +42,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app"
 
 beforeEach(() => {

--- a/src/__tests__/stock-import-precision-198.migration-guards.test.ts
+++ b/src/__tests__/stock-import-precision-198.migration-guards.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const patch = readFileSync(
+  resolve(root, "db/patches/20260727_stock_import_precision_198.sql"),
+  "utf8"
+);
+const preflight = readFileSync(
+  resolve(root, "db/patches/support/20260727_stock_import_precision_198.preflight.sql"),
+  "utf8"
+);
+const verify = readFileSync(
+  resolve(root, "db/patches/support/20260727_stock_import_precision_198.verify.sql"),
+  "utf8"
+);
+const rollback = readFileSync(
+  resolve(root, "db/patches/support/20260727_stock_import_precision_198.rollback.sql"),
+  "utf8"
+);
+
+describe("stock opening precision migration #198", () => {
+  it("widens movement lines to the six-decimal stock ledger precision", () => {
+    expect(patch).toContain("ALTER COLUMN qty TYPE numeric(18,6)");
+    expect(patch).toContain("source_document_type = 'CLIPPER_STOCK_OPENING'");
+    expect(patch).toContain("abs(opening_lines.old_line_qty - opening_lines.posted_qty) < 0.0005");
+  });
+
+  it("keeps the posted-line repair bounded, transactional and auditable", () => {
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("current_database() <> 'cerp_test'");
+    expect(patch).toContain("DISABLE TRIGGER trg_protect_posted_stock_movement_line");
+    expect(patch).toContain("ENABLE TRIGGER trg_protect_posted_stock_movement_line");
+    expect(patch).toContain("PRECISION_RECONCILED_198");
+    expect(patch).toContain("COMMIT;");
+  });
+
+  it("blocks unsafe data and verifies line, header and level reconciliation", () => {
+    expect(preflight).toContain("abs(line_qty - posted_qty) >= 0.0005");
+    expect(preflight).toContain("lines_count <> 1");
+    expect(verify).toContain("opening_lines_match_posted_headers");
+    expect(verify).toContain("opening_headers_match_stock_levels");
+  });
+
+  it("provides a conservative test-only rollback", () => {
+    expect(rollback).toContain("current_database() <> 'cerp_test'");
+    expect(rollback).toContain("PRECISION_ROLLBACK_198");
+    expect(rollback).toContain("ALTER COLUMN qty TYPE numeric(18,3)");
+    expect(rollback).toContain("six-decimal quantities exist outside the audited repair set");
+  });
+});

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -49,6 +49,13 @@ vi.mock("../module/auth/middlewares/auth.middleware", () => ({
     },
 }));
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app";
 
 beforeEach(() => {

--- a/src/__tests__/traceability-asbuilt.routes.test.ts
+++ b/src/__tests__/traceability-asbuilt.routes.test.ts
@@ -128,6 +128,13 @@ vi.mock("../module/asbuilt/services/asbuilt.service", () => ({
   })),
 }))
 
+// Le gate d'accès module (#326) est monté globalement dans v1.routes.ts. Ce fichier
+// ne teste pas le filtrage par module : on le neutralise pour qu'il ne consomme pas
+// une réponse de `pool.query` destinée à la route sous test.
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
 import app from "../config/app"
 
 describe("🧪 Routes Traceabilite + As-built (/traceability, /asbuilt)", () => {

--- a/src/module/access-control/controllers/access-control.controller.ts
+++ b/src/module/access-control/controllers/access-control.controller.ts
@@ -1,0 +1,99 @@
+// src/module/access-control/controllers/access-control.controller.ts
+import type { Request, RequestHandler } from "express";
+
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { HttpError } from "../../../utils/httpError";
+import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import * as service from "../services/access-control.service";
+import type { AccessAuditContext } from "../types/access-control.types";
+import {
+  listAccessEventsQuerySchema,
+  setModuleDefaultSchema,
+  setUserModuleAccessSchema,
+  setUserModulesBulkSchema,
+  unlockAllSchema,
+} from "../validators/access-control.validators";
+
+export function buildAuditContext(req: Request): AccessAuditContext {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  const userAgent = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null;
+  const device = parseDevice(userAgent);
+  const clientSessionId =
+    typeof req.headers["x-client-session-id"] === "string"
+      ? req.headers["x-client-session-id"]
+      : typeof req.headers["x-session-id"] === "string"
+        ? req.headers["x-session-id"]
+        : null;
+  return {
+    user_id: user.id,
+    ip: getClientIp(req),
+    user_agent: userAgent,
+    device_type: device.device_type,
+    os: device.os,
+    browser: device.browser,
+    path: req.originalUrl ?? null,
+    client_session_id: clientSessionId,
+  };
+}
+
+// GET /auth/access-profile — accessible à TOUT compte authentifié : un opérateur
+// doit pouvoir charger sa propre navigation sans être administrateur.
+export const getAccessProfile: RequestHandler = asyncHandler(async (req, res) => {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  res.json(await service.getAccessProfile(user.id));
+});
+
+export const getOverview: RequestHandler = asyncHandler(async (_req, res) => {
+  res.json(await service.buildOverview());
+});
+
+export const putModuleDefault: RequestHandler = asyncHandler(async (req, res) => {
+  const dto = setModuleDefaultSchema.parse({ params: req.params, body: req.body });
+  const overview = await service.setModuleDefault({
+    moduleKey: dto.params.moduleKey,
+    enabled: dto.body.enabled_by_default,
+    audit: buildAuditContext(req),
+  });
+  res.json(overview);
+});
+
+export const putUserModuleAccess: RequestHandler = asyncHandler(async (req, res) => {
+  const dto = setUserModuleAccessSchema.parse({ params: req.params, body: req.body });
+  const overview = await service.setUserModuleAccess({
+    userId: Number(dto.params.userId),
+    moduleKey: dto.params.moduleKey,
+    decision: dto.body.access,
+    audit: buildAuditContext(req),
+  });
+  res.json(overview);
+});
+
+export const putUserModulesBulk: RequestHandler = asyncHandler(async (req, res) => {
+  const dto = setUserModulesBulkSchema.parse({ params: req.params, body: req.body });
+  const overview = await service.setUserModulesBulk({
+    userId: Number(dto.params.userId),
+    entries: dto.body.entries,
+    audit: buildAuditContext(req),
+  });
+  res.json(overview);
+});
+
+export const postUnlockAll: RequestHandler = asyncHandler(async (req, res) => {
+  const dto = unlockAllSchema.parse({ body: req.body });
+  const overview = await service.unlockAll({
+    confirm: dto.body.confirm,
+    audit: buildAuditContext(req),
+  });
+  res.json(overview);
+});
+
+export const getAccessEvents: RequestHandler = asyncHandler(async (req, res) => {
+  const query = listAccessEventsQuerySchema.parse(req.query);
+  res.json(await service.listAccessEvents(query));
+});

--- a/src/module/access-control/domain/module-catalog.ts
+++ b/src/module/access-control/domain/module-catalog.ts
@@ -1,0 +1,282 @@
+// Catalogue des modules ERP soumis au filtrage d'accès (#326 / back #200).
+// Miroir exact du seed db/patches/20260727_admin_access_tower_326.sql : la base fait
+// autorité sur les DÉCISIONS (défauts, overrides), le code fait autorité sur la
+// RÉSOLUTION chemin -> module, qui doit rester déterministe même base injoignable.
+
+export type ModuleCatalogEntry = {
+  module_key: string;
+  label: string;
+  description: string;
+  category: string;
+  api_prefixes: readonly string[];
+  nav_page_keys: readonly string[];
+  is_protected: boolean;
+  sort_order: number;
+};
+
+export const MODULE_CATALOG: readonly ModuleCatalogEntry[] = [
+  {
+    module_key: "clients",
+    label: "Clients",
+    description: "Comptes clients, contacts, adresses et conditions de règlement.",
+    category: "Commerce",
+    api_prefixes: ["/clients", "/payment-modes", "/billers", "/banking-info"],
+    nav_page_keys: ["clients"],
+    is_protected: false,
+    sort_order: 10,
+  },
+  {
+    module_key: "devis",
+    label: "Devis",
+    description: "Chiffrage et cycle de vie des devis clients.",
+    category: "Commerce",
+    api_prefixes: ["/devis"],
+    nav_page_keys: ["devis"],
+    is_protected: false,
+    sort_order: 20,
+  },
+  {
+    module_key: "commandes-clients",
+    label: "Commandes clients",
+    description: "Commandes fermes, cadres et internes, appels de livraison.",
+    category: "Commerce",
+    api_prefixes: ["/commandes"],
+    nav_page_keys: ["commandes"],
+    is_protected: false,
+    sort_order: 30,
+  },
+  {
+    module_key: "livraisons",
+    label: "Livraisons",
+    description: "Préparation, expédition et bons de livraison.",
+    category: "Commerce",
+    api_prefixes: ["/livraisons"],
+    nav_page_keys: ["livraisons"],
+    is_protected: false,
+    sort_order: 40,
+  },
+  {
+    module_key: "affaires",
+    label: "Affaires",
+    description: "Affaires commerciales et projets rattachés.",
+    category: "Commerce",
+    api_prefixes: ["/affaires"],
+    nav_page_keys: ["affaires"],
+    is_protected: false,
+    sort_order: 50,
+  },
+  {
+    module_key: "facturation",
+    label: "Facturation",
+    description: "Factures, avoirs, règlements et tarification.",
+    category: "Commerce",
+    api_prefixes: ["/factures", "/avoirs", "/paiements", "/tarification"],
+    nav_page_keys: ["factures"],
+    is_protected: false,
+    sort_order: 60,
+  },
+  {
+    module_key: "reporting-commercial",
+    label: "Reporting commercial",
+    description: "Indicateurs commerciaux et exports gouvernés.",
+    category: "Commerce",
+    api_prefixes: ["/reporting"],
+    nav_page_keys: ["reporting-commercial"],
+    is_protected: false,
+    sort_order: 70,
+  },
+  {
+    module_key: "fournisseurs",
+    label: "Fournisseurs",
+    description: "Référentiel fournisseurs et écosystème achat.",
+    category: "Achats",
+    api_prefixes: ["/fournisseurs"],
+    nav_page_keys: ["fournisseurs"],
+    is_protected: false,
+    sort_order: 80,
+  },
+  {
+    module_key: "commandes-fournisseurs",
+    label: "Commandes fournisseurs",
+    description: "Bons de commande fournisseurs et suivi des accusés.",
+    category: "Achats",
+    api_prefixes: ["/commandes-fournisseurs"],
+    nav_page_keys: ["commandes-fournisseurs"],
+    is_protected: false,
+    sort_order: 90,
+  },
+  {
+    module_key: "pieces-techniques",
+    label: "Données techniques",
+    description: "Pièces techniques, versions, gammes et dossiers d’opération.",
+    category: "Production",
+    api_prefixes: ["/pieces-techniques", "/piece-technique-versions", "/gammes", "/dossiers"],
+    nav_page_keys: ["pieces-techniques"],
+    is_protected: false,
+    sort_order: 100,
+  },
+  {
+    module_key: "production",
+    label: "Production",
+    description: "Ordres de fabrication, planning, pointages et poste opérateur.",
+    category: "Production",
+    api_prefixes: ["/production", "/planning", "/programmations"],
+    nav_page_keys: [
+      "production-dashboard",
+      "machines-postes",
+      "production-planning",
+      "production-execution",
+      "atelier-station",
+      "production-pointages",
+      "ordres-fabrication",
+    ],
+    is_protected: false,
+    sort_order: 110,
+  },
+  {
+    module_key: "qualite",
+    label: "Qualité",
+    description: "Plans de contrôle, non-conformités, réceptions et dérogations.",
+    category: "Qualité",
+    api_prefixes: ["/qualite", "/receptions"],
+    nav_page_keys: ["qualite-center", "qualite-controls", "qualite-non-conformities", "receptions"],
+    is_protected: false,
+    sort_order: 120,
+  },
+  {
+    module_key: "metrologie",
+    label: "Métrologie",
+    description: "Parc de moyens de mesure, étalonnages et certificats.",
+    category: "Qualité",
+    api_prefixes: ["/metrologie"],
+    nav_page_keys: ["metrologie"],
+    is_protected: false,
+    sort_order: 130,
+  },
+  {
+    module_key: "tracabilite",
+    label: "Traçabilité",
+    description: "Chaînage matière, généalogie des lots et dossiers as-built.",
+    category: "Qualité",
+    api_prefixes: ["/traceability", "/asbuilt"],
+    nav_page_keys: ["traceabilite"],
+    is_protected: false,
+    sort_order: 140,
+  },
+  {
+    module_key: "stock",
+    label: "Stock",
+    description: "Articles, mouvements, emplacements et inventaires.",
+    category: "Stock",
+    api_prefixes: ["/stock"],
+    nav_page_keys: ["stock-dashboard", "stock-articles", "stock-mouvements", "stock-inventaires"],
+    is_protected: false,
+    sort_order: 150,
+  },
+  {
+    module_key: "outillage",
+    label: "Outillage",
+    description: "Parc d’outils coupants et sorties atelier.",
+    category: "Stock",
+    api_prefixes: ["/outils"],
+    nav_page_keys: ["outils", "outils-new", "outils-retirer"],
+    is_protected: false,
+    sort_order: 160,
+  },
+  {
+    module_key: "temps-deplacements",
+    label: "Temps & Déplacements",
+    description: "Pointages horaires et frais kilométriques.",
+    category: "Ressources humaines",
+    api_prefixes: ["/time-clock"],
+    nav_page_keys: ["td-*"],
+    is_protected: false,
+    sort_order: 170,
+  },
+  {
+    module_key: "pilotage-projet",
+    label: "Pilotage projet",
+    description: "Project Office : lots, jalons, décisions et preuves.",
+    category: "Système",
+    api_prefixes: ["/project-office"],
+    nav_page_keys: ["po-*"],
+    is_protected: false,
+    sort_order: 180,
+  },
+  {
+    module_key: "import-clipper",
+    label: "Migration CLIPPER",
+    description: "Assistant de reprise des données historiques CLIPPER.",
+    category: "Système",
+    api_prefixes: ["/import-assistant"],
+    nav_page_keys: ["import-assistant"],
+    is_protected: false,
+    sort_order: 190,
+  },
+  {
+    module_key: "administration",
+    label: "Administration",
+    description: "Comptes, rôles, réglages ERP et tour de contrôle des accès.",
+    category: "Système",
+    api_prefixes: ["/admin"],
+    nav_page_keys: ["administration", "erp-settings", "acces"],
+    is_protected: true,
+    sort_order: 200,
+  },
+] as const;
+
+export const MODULE_KEYS: readonly string[] = MODULE_CATALOG.map((entry) => entry.module_key);
+
+export const PROTECTED_MODULE_KEYS: readonly string[] = MODULE_CATALOG.filter(
+  (entry) => entry.is_protected
+).map((entry) => entry.module_key);
+
+export function getModuleCatalogEntry(moduleKey: string): ModuleCatalogEntry | null {
+  return MODULE_CATALOG.find((entry) => entry.module_key === moduleKey) ?? null;
+}
+
+/**
+ * Un module protégé n'est jamais refusé par le gate. La réponse vient du catalogue
+ * de code et non de la base : c'est ce qui garantit qu'aucune décision, même
+ * erronée, ne puisse rendre l'ERP inadministrable.
+ */
+export function isProtectedModuleKey(moduleKey: string): boolean {
+  return PROTECTED_MODULE_KEYS.includes(moduleKey);
+}
+
+// Index préfixe -> module, trié du plus long au plus court : le gate doit choisir
+// « /commandes-fournisseurs » et jamais « /commandes » pour un bon de commande.
+const PREFIX_INDEX: ReadonlyArray<{ prefix: string; module_key: string }> = MODULE_CATALOG.flatMap(
+  (entry) => entry.api_prefixes.map((prefix) => ({ prefix, module_key: entry.module_key }))
+).sort((a, b) => b.prefix.length - a.prefix.length);
+
+const API_ROOT = "/api/v1";
+
+function normalizePath(path: string): string {
+  const withoutQuery = path.split("?")[0]?.split("#")[0] ?? "";
+  // Le gate est monté dans le routeur v1 (chemin relatif), mais la fonction doit
+  // rester utilisable avec une URL complète (tests, journalisation, outillage).
+  const withoutRoot = withoutQuery.startsWith(API_ROOT)
+    ? withoutQuery.slice(API_ROOT.length)
+    : withoutQuery;
+  const prefixed = withoutRoot.startsWith("/") ? withoutRoot : `/${withoutRoot}`;
+  return prefixed.length > 1 ? prefixed.replace(/\/+$/, "") : prefixed;
+}
+
+/**
+ * Résout la clé de module d'un chemin d'API. Le plus long préfixe gagne, et un
+ * préfixe ne correspond que sur une frontière de segment : « /commandes » ne doit
+ * jamais capter « /commandes-fournisseurs ». Retourne `null` pour les surfaces
+ * d'infrastructure partagée (/auth, /users, /codes, /notifications…), qui ne sont
+ * rattachées à aucun module et ne sont donc jamais filtrées.
+ */
+export function resolveModuleKeyForPath(path: string | null | undefined): string | null {
+  if (typeof path !== "string" || path.length === 0) return null;
+  const normalized = normalizePath(path);
+  for (const entry of PREFIX_INDEX) {
+    if (normalized === entry.prefix || normalized.startsWith(`${entry.prefix}/`)) {
+      return entry.module_key;
+    }
+  }
+  return null;
+}

--- a/src/module/access-control/middlewares/module-access-gate.ts
+++ b/src/module/access-control/middlewares/module-access-gate.ts
@@ -1,0 +1,113 @@
+import type { NextFunction, Request, Response } from "express";
+
+import { stripQueryFromUrl } from "../../../utils/logPath";
+import { isProtectedModuleKey, resolveModuleKeyForPath } from "../domain/module-catalog";
+import { resolveAccessProfile } from "../services/access-control.service";
+
+const KILL_SWITCH_ENV = "CERP_MODULE_ACCESS_GATE_DISABLED";
+
+function isGateDisabled(): boolean {
+  return process.env[KILL_SWITCH_ENV] === "1";
+}
+
+let killSwitchWarned = false;
+
+function warnKillSwitchOnce(): void {
+  if (killSwitchWarned) return;
+  killSwitchWarned = true;
+  console.warn(
+    JSON.stringify({
+      type: "module_access_gate_disabled",
+      reason: "kill_switch",
+      env: KILL_SWITCH_ENV,
+    })
+  );
+}
+
+if (isGateDisabled()) warnKillSwitchOnce();
+
+// Une base sans le patch #326 ne doit pas briquer l'ERP entier : on laisse passer
+// et on le dit, une seule fois par processus pour ne pas noyer les journaux.
+let infrastructureWarned = false;
+
+function warnMissingInfrastructure(reason: string, moduleKey: string | null): void {
+  if (infrastructureWarned) return;
+  infrastructureWarned = true;
+  console.warn(
+    JSON.stringify({
+      type: "module_access_gate_open",
+      reason,
+      module: moduleKey,
+    })
+  );
+}
+
+/**
+ * Gate d'accès module (#326) — monté globalement dans v1.routes.ts juste après
+ * `authenticateToken` et avant le premier module métier.
+ *
+ * Le chemin est résolu vers un module par le catalogue TypeScript (plus long
+ * préfixe, frontière de segment) ; seule la DÉCISION vient de la base. Surface
+ * hors catalogue, module protégé et superadmin passent sans aucune requête.
+ */
+export function moduleAccessGate(req: Request, res: Response, next: NextFunction): void {
+  if (isGateDisabled()) {
+    warnKillSwitchOnce();
+    next();
+    return;
+  }
+
+  const moduleKey = resolveModuleKeyForPath(req.path);
+  if (!moduleKey || isProtectedModuleKey(moduleKey)) {
+    next();
+    return;
+  }
+
+  const user = req.user;
+  if (!user || typeof user.id !== "number") {
+    // Le socle authenticateToken a déjà statué : rien à ajouter ici.
+    next();
+    return;
+  }
+
+  resolveAccessProfile(user.id)
+    .then((profile) => {
+      if (profile === null) {
+        warnMissingInfrastructure("access_tables_missing", moduleKey);
+        next();
+        return;
+      }
+      if (profile.is_superadmin) {
+        next();
+        return;
+      }
+
+      const decision = profile.modules.find((entry) => entry.module_key === moduleKey);
+      if (!decision) {
+        // Le module existe dans le code mais pas dans le catalogue de la base :
+        // même famille que l'absence de tables, on ne fabrique pas un refus.
+        warnMissingInfrastructure("module_absent_from_catalog", moduleKey);
+        next();
+        return;
+      }
+      if (decision.allowed) {
+        next();
+        return;
+      }
+
+      console.warn(
+        JSON.stringify({
+          type: "auth_forbidden",
+          module: moduleKey,
+          reason: "module_access_denied",
+          userId: user.id,
+          requestId: req.requestId ?? null,
+          method: req.method,
+          path: stripQueryFromUrl(req.originalUrl),
+        })
+      );
+      // Non bavard : aucune mention du module ni de l'existence d'un filtrage.
+      res.status(403).json({ error: "Accès interdit" });
+    })
+    .catch(next);
+}

--- a/src/module/access-control/middlewares/require-superadmin.ts
+++ b/src/module/access-control/middlewares/require-superadmin.ts
@@ -1,0 +1,42 @@
+import type { NextFunction, Request, Response } from "express";
+
+import { stripQueryFromUrl } from "../../../utils/logPath";
+import { isSuperadmin } from "../services/access-control.service";
+
+// Garde de la tour de contrôle des accès (#326) — monté en tête du routeur
+// /admin/access, APRÈS le socle authenticateToken. La décision vient de la base
+// (users.is_superadmin), jamais du JWT : révoquer le statut prend effet tout de suite.
+// Fail-closed : toute erreur de résolution refuse au lieu de laisser passer.
+export function requireSuperadmin(req: Request, res: Response, next: NextFunction): void {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") {
+    res.status(401).json({ error: "Utilisateur non authentifié" });
+    return;
+  }
+
+  const deny = (reason: string): void => {
+    console.warn(
+      JSON.stringify({
+        type: "auth_forbidden",
+        module: "access-control",
+        reason,
+        requestId: req.requestId ?? null,
+        method: req.method,
+        path: stripQueryFromUrl(req.originalUrl),
+        userId: user.id,
+      })
+    );
+    // Non bavard : ni le motif, ni l'existence de la surface ne sont révélés.
+    res.status(403).json({ error: "Accès interdit" });
+  };
+
+  isSuperadmin(user.id)
+    .then((ok) => {
+      if (ok) {
+        next();
+        return;
+      }
+      deny("not_superadmin");
+    })
+    .catch(() => deny("superadmin_resolution_failed"));
+}

--- a/src/module/access-control/repository/access-control.repository.ts
+++ b/src/module/access-control/repository/access-control.repository.ts
@@ -1,0 +1,424 @@
+// src/module/access-control/repository/access-control.repository.ts
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import type {
+  AccessEventRow,
+  AccessEventType,
+  AccessProfileRow,
+  ModuleAccessOverride,
+} from "../types/access-control.types";
+
+export type DbQueryer = Pick<PoolClient, "query">;
+
+export type CatalogModuleRow = {
+  module_key: string;
+  label: string;
+  description: string | null;
+  category: string;
+  api_prefixes: string[];
+  nav_page_keys: string[];
+  enabled_by_default: boolean;
+  is_protected: boolean;
+  sort_order: number;
+  is_active: boolean;
+};
+
+export type AccessUserRow = {
+  id: number;
+  username: string;
+  name: string | null;
+  surname: string | null;
+  email: string | null;
+  role: string;
+  roles: string[];
+  status: string | null;
+  is_superadmin: boolean;
+  last_login: string | null;
+};
+
+export type AccessOverrideRow = {
+  user_id: number;
+  module_key: string;
+  access: ModuleAccessOverride;
+};
+
+/**
+ * `42P01` (undefined_table) : le patch #326 n'est pas appliqué sur cette base.
+ * Le socle le traite comme une absence d'infrastructure, jamais comme un refus.
+ */
+export function isUndefinedTable(err: unknown): boolean {
+  return (err as { code?: unknown } | null)?.code === "42P01";
+}
+
+export async function withTransaction<T>(fn: (tx: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      // La transaction est déjà perdue : l'erreur d'origine prime.
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/**
+ * Une seule requête pour le profil complet d'un compte. Le départ depuis `users`
+ * garantit une ligne même quand le catalogue est vide : le marqueur superadmin
+ * reste lisible et le gate distingue « catalogue non peuplé » de « refus ».
+ * Retourne `null` si l'infrastructure d'accès est absente (42P01).
+ */
+export async function repoResolveAccessProfile(
+  userId: number,
+  tx?: DbQueryer
+): Promise<AccessProfileRow[] | null> {
+  const q = tx ?? pool;
+  try {
+    const { rows } = await q.query<AccessProfileRow>(
+      `
+        SELECT
+          COALESCE(u.is_superadmin, false) AS is_superadmin,
+          m.module_key,
+          m.label,
+          m.nav_page_keys,
+          m.enabled_by_default,
+          m.is_protected,
+          m.is_active,
+          a.access
+        FROM public.users u
+        LEFT JOIN public.app_modules m ON true
+        LEFT JOIN public.app_module_user_access a
+          ON a.user_id = u.id
+         AND a.module_key = m.module_key
+        WHERE u.id = $1
+        ORDER BY m.sort_order NULLS LAST, m.module_key NULLS LAST
+      `,
+      [userId]
+    );
+    return rows;
+  } catch (err) {
+    if (isUndefinedTable(err)) return null;
+    throw err;
+  }
+}
+
+export async function repoIsSuperadmin(userId: number, tx?: DbQueryer): Promise<boolean> {
+  const q = tx ?? pool;
+  const { rows } = await q.query<{ is_superadmin: boolean }>(
+    `SELECT COALESCE(is_superadmin, false) AS is_superadmin FROM public.users WHERE id = $1 LIMIT 1`,
+    [userId]
+  );
+  return rows[0]?.is_superadmin === true;
+}
+
+export async function repoListCatalogModules(tx?: DbQueryer): Promise<CatalogModuleRow[]> {
+  const q = tx ?? pool;
+  const { rows } = await q.query<CatalogModuleRow>(
+    `
+      SELECT
+        module_key,
+        label,
+        description,
+        category,
+        api_prefixes,
+        nav_page_keys,
+        enabled_by_default,
+        is_protected,
+        sort_order,
+        is_active
+      FROM public.app_modules
+      ORDER BY sort_order, module_key
+    `
+  );
+  return rows;
+}
+
+export async function repoGetCatalogModule(
+  moduleKey: string,
+  tx?: DbQueryer
+): Promise<CatalogModuleRow | null> {
+  const q = tx ?? pool;
+  const { rows } = await q.query<CatalogModuleRow>(
+    `
+      SELECT
+        module_key,
+        label,
+        description,
+        category,
+        api_prefixes,
+        nav_page_keys,
+        enabled_by_default,
+        is_protected,
+        sort_order,
+        is_active
+      FROM public.app_modules
+      WHERE module_key = $1
+      LIMIT 1
+    `,
+    [moduleKey]
+  );
+  return rows[0] ?? null;
+}
+
+export async function repoListAccessUsers(tx?: DbQueryer): Promise<AccessUserRow[]> {
+  const q = tx ?? pool;
+  const { rows } = await q.query<AccessUserRow>(
+    `
+      SELECT
+        u.id::int AS id,
+        u.username,
+        u.name,
+        u.surname,
+        u.email,
+        u.role,
+        COALESCE(
+          array_agg(ura.role_key ORDER BY (ura.role_key = u.role) DESC, ura.role_key)
+            FILTER (WHERE ura.role_key IS NOT NULL),
+          ARRAY[u.role]::text[]
+        ) AS roles,
+        u.status,
+        COALESCE(u.is_superadmin, false) AS is_superadmin,
+        u.last_login::text AS last_login
+      FROM public.users u
+      LEFT JOIN public.user_role_assignments ura ON ura.user_id = u.id
+      GROUP BY u.id
+      ORDER BY u.username
+    `
+  );
+  return rows;
+}
+
+export async function repoGetAccessUser(userId: number, tx?: DbQueryer): Promise<AccessUserRow | null> {
+  const q = tx ?? pool;
+  const { rows } = await q.query<AccessUserRow>(
+    `
+      SELECT
+        u.id::int AS id,
+        u.username,
+        u.name,
+        u.surname,
+        u.email,
+        u.role,
+        COALESCE(
+          (
+            SELECT array_agg(ura.role_key ORDER BY (ura.role_key = u.role) DESC, ura.role_key)
+            FROM public.user_role_assignments ura
+            WHERE ura.user_id = u.id
+          ),
+          ARRAY[u.role]::text[]
+        ) AS roles,
+        u.status,
+        COALESCE(u.is_superadmin, false) AS is_superadmin,
+        u.last_login::text AS last_login
+      FROM public.users u
+      WHERE u.id = $1
+      LIMIT 1
+    `,
+    [userId]
+  );
+  return rows[0] ?? null;
+}
+
+export async function repoListAccessOverrides(tx?: DbQueryer): Promise<AccessOverrideRow[]> {
+  const q = tx ?? pool;
+  const { rows } = await q.query<AccessOverrideRow>(
+    `
+      SELECT user_id::int AS user_id, module_key, access
+      FROM public.app_module_user_access
+      ORDER BY user_id, module_key
+    `
+  );
+  return rows;
+}
+
+export async function repoGetUserModuleAccess(
+  userId: number,
+  moduleKey: string,
+  tx?: DbQueryer
+): Promise<ModuleAccessOverride | null> {
+  const q = tx ?? pool;
+  const { rows } = await q.query<{ access: ModuleAccessOverride }>(
+    `
+      SELECT access
+      FROM public.app_module_user_access
+      WHERE user_id = $1 AND module_key = $2
+      LIMIT 1
+    `,
+    [userId, moduleKey]
+  );
+  return rows[0]?.access ?? null;
+}
+
+export async function repoSetModuleDefault(
+  tx: DbQueryer,
+  params: { moduleKey: string; enabled: boolean }
+): Promise<boolean> {
+  // `cerp_app` ne détient que UPDATE(enabled_by_default, updated_at) : le catalogue
+  // lui-même reste hors de portée de l'API.
+  const { rowCount } = await tx.query(
+    `
+      UPDATE public.app_modules
+      SET enabled_by_default = $2, updated_at = now()
+      WHERE module_key = $1
+    `,
+    [params.moduleKey, params.enabled]
+  );
+  return (rowCount ?? 0) > 0;
+}
+
+export async function repoUpsertUserModuleAccess(
+  tx: DbQueryer,
+  params: {
+    userId: number;
+    moduleKey: string;
+    access: ModuleAccessOverride;
+    updatedBy: number | null;
+  }
+): Promise<void> {
+  await tx.query(
+    `
+      INSERT INTO public.app_module_user_access (user_id, module_key, access, updated_at, updated_by)
+      VALUES ($1, $2, $3, now(), $4)
+      ON CONFLICT (user_id, module_key) DO UPDATE
+      SET access = EXCLUDED.access,
+          updated_at = now(),
+          updated_by = EXCLUDED.updated_by
+    `,
+    [params.userId, params.moduleKey, params.access, params.updatedBy]
+  );
+}
+
+export async function repoDeleteUserModuleAccess(
+  tx: DbQueryer,
+  params: { userId: number; moduleKey: string }
+): Promise<boolean> {
+  const { rowCount } = await tx.query(
+    `
+      DELETE FROM public.app_module_user_access
+      WHERE user_id = $1 AND module_key = $2
+    `,
+    [params.userId, params.moduleKey]
+  );
+  return (rowCount ?? 0) > 0;
+}
+
+export async function repoDeleteAllDenials(
+  tx: DbQueryer
+): Promise<Array<{ user_id: number; module_key: string }>> {
+  const { rows } = await tx.query<{ user_id: number; module_key: string }>(
+    `
+      DELETE FROM public.app_module_user_access
+      WHERE access = 'DENIED'
+      RETURNING user_id::int AS user_id, module_key
+    `
+  );
+  return rows;
+}
+
+export async function repoRestoreAllDefaults(tx: DbQueryer): Promise<string[]> {
+  const { rows } = await tx.query<{ module_key: string }>(
+    `
+      UPDATE public.app_modules
+      SET enabled_by_default = true, updated_at = now()
+      WHERE enabled_by_default IS DISTINCT FROM true
+      RETURNING module_key
+    `
+  );
+  return rows.map((row) => row.module_key);
+}
+
+export async function repoInsertAccessEvent(
+  tx: DbQueryer,
+  params: {
+    userId: number | null;
+    moduleKey: string;
+    eventType: AccessEventType;
+    previousState: string | null;
+    nextState: string | null;
+    actorUserId: number | null;
+    source?: string;
+  }
+): Promise<void> {
+  await tx.query(
+    `
+      INSERT INTO public.app_module_access_events (
+        user_id, module_key, event_type, previous_state, next_state, actor_user_id, source
+      ) VALUES ($1, $2, $3, $4, $5, $6, COALESCE($7, 'admin'))
+    `,
+    [
+      params.userId,
+      params.moduleKey,
+      params.eventType,
+      params.previousState,
+      params.nextState,
+      params.actorUserId,
+      params.source ?? null,
+    ]
+  );
+}
+
+export async function repoListAccessEvents(
+  filters: {
+    limit: number;
+    offset: number;
+    user_id?: number;
+    module_key?: string;
+  },
+  tx?: DbQueryer
+): Promise<{ items: AccessEventRow[]; total: number }> {
+  const q = tx ?? pool;
+  const where: string[] = [];
+  const values: unknown[] = [];
+  const push = (value: unknown) => {
+    values.push(value);
+    return `$${values.length}`;
+  };
+
+  if (typeof filters.user_id === "number") {
+    where.push(`e.user_id = ${push(filters.user_id)}`);
+  }
+  if (filters.module_key) {
+    where.push(`e.module_key = ${push(filters.module_key)}`);
+  }
+  const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+
+  const countRes = await q.query<{ total: number }>(
+    `SELECT COUNT(*)::int AS total FROM public.app_module_access_events e ${whereSql}`,
+    values
+  );
+
+  const dataRes = await q.query<AccessEventRow>(
+    `
+      SELECT
+        e.id::text AS id,
+        e.user_id::int AS user_id,
+        target.username AS username,
+        e.module_key,
+        e.event_type,
+        e.previous_state,
+        e.next_state,
+        e.actor_user_id::int AS actor_user_id,
+        actor.username AS actor_username,
+        e.source,
+        e.occurred_at::text AS occurred_at
+      FROM public.app_module_access_events e
+      LEFT JOIN public.users target ON target.id = e.user_id
+      LEFT JOIN public.users actor ON actor.id = e.actor_user_id
+      ${whereSql}
+      ORDER BY e.occurred_at DESC, e.id DESC
+      LIMIT $${values.length + 1}
+      OFFSET $${values.length + 2}
+    `,
+    [...values, filters.limit, filters.offset]
+  );
+
+  return { items: dataRes.rows, total: countRes.rows[0]?.total ?? 0 };
+}

--- a/src/module/access-control/routes/access-control.routes.ts
+++ b/src/module/access-control/routes/access-control.routes.ts
@@ -1,0 +1,21 @@
+// src/module/access-control/routes/access-control.routes.ts
+import { Router } from "express";
+
+import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import * as controller from "../controllers/access-control.controller";
+import { requireSuperadmin } from "../middlewares/require-superadmin";
+
+const router = Router();
+
+// Aucun `authorizeRole` ici : le statut superadmin n'est pas un rôle métier et ne
+// doit pas pouvoir être obtenu par une attribution de rôle depuis /admin/users.
+router.use(authenticateToken, requireSuperadmin);
+
+router.get("/overview", controller.getOverview);
+router.get("/events", controller.getAccessEvents);
+router.put("/modules/:moduleKey/default", controller.putModuleDefault);
+router.put("/users/:userId/modules/:moduleKey", controller.putUserModuleAccess);
+router.put("/users/:userId/modules", controller.putUserModulesBulk);
+router.post("/unlock-all", controller.postUnlockAll);
+
+export default router;

--- a/src/module/access-control/services/access-control.service.ts
+++ b/src/module/access-control/services/access-control.service.ts
@@ -1,0 +1,437 @@
+// src/module/access-control/services/access-control.service.ts
+import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import * as repo from "../repository/access-control.repository";
+import type { CatalogModuleRow, DbQueryer } from "../repository/access-control.repository";
+import type {
+  AccessAuditContext,
+  AccessOverview,
+  ModuleAccessDecision,
+  ModuleAccessOverride,
+  ModuleAccessSource,
+  OverviewMatrixCell,
+  ResolvedAccessProfile,
+  ResolvedModuleAccess,
+} from "../types/access-control.types";
+
+const AUDIT_PAGE_KEY = "administration-acces";
+const AUDIT_ENTITY_TYPE = "module_access";
+const UNLOCK_ALL_CONFIRMATION = "DEBLOQUER TOUT";
+
+/** Durée de vie du cache de résolution, en millisecondes. */
+export const ACCESS_CACHE_TTL_MS = 10_000;
+
+type CacheEntry = { expiresAt: number; profile: ResolvedAccessProfile };
+
+// Cache PROCESSUS : chaque instance API garde le sien. Une mutation invalide
+// immédiatement le sien ; les autres instances convergent au plus tard au bout du TTL.
+const profileCache = new Map<number, CacheEntry>();
+
+export function invalidateAccessCache(userId?: number): void {
+  if (typeof userId === "number") {
+    profileCache.delete(userId);
+    return;
+  }
+  profileCache.clear();
+}
+
+/** Décision d'accès pour une ligne de catalogue déjà résolue. */
+function decide(params: {
+  isSuperadmin: boolean;
+  isActive: boolean;
+  enabledByDefault: boolean;
+  override: ModuleAccessOverride | null;
+}): { allowed: boolean; source: ModuleAccessSource } {
+  if (params.isSuperadmin) return { allowed: true, source: "SUPERADMIN" };
+  if (!params.isActive) return { allowed: false, source: "DEFAULT" };
+  if (params.override) return { allowed: params.override === "GRANTED", source: "OVERRIDE" };
+  return { allowed: params.enabledByDefault, source: "DEFAULT" };
+}
+
+/**
+ * Profil d'accès d'un compte. `null` signifie « infrastructure d'accès absente »
+ * (42P01) : l'appelant décide alors de laisser passer, il ne reçoit pas un refus.
+ */
+export async function resolveAccessProfile(userId: number): Promise<ResolvedAccessProfile | null> {
+  const cached = profileCache.get(userId);
+  if (cached && cached.expiresAt > Date.now()) return cached.profile;
+
+  const rows = await repo.repoResolveAccessProfile(userId);
+  if (rows === null) return null;
+
+  const isSuperadmin = rows[0]?.is_superadmin === true;
+  const modules: ResolvedModuleAccess[] = [];
+  for (const row of rows) {
+    if (!row.module_key) continue;
+    const { allowed, source } = decide({
+      isSuperadmin,
+      isActive: row.is_active !== false,
+      enabledByDefault: row.enabled_by_default !== false,
+      override: row.access,
+    });
+    modules.push({
+      module_key: row.module_key,
+      label: row.label ?? row.module_key,
+      nav_page_keys: row.nav_page_keys ?? [],
+      allowed,
+      source,
+    });
+  }
+
+  const profile: ResolvedAccessProfile = { is_superadmin: isSuperadmin, modules };
+  profileCache.set(userId, { expiresAt: Date.now() + ACCESS_CACHE_TTL_MS, profile });
+  return profile;
+}
+
+/** Réponse de `GET /auth/access-profile`. Infrastructure absente ⇒ aucun filtrage. */
+export async function getAccessProfile(userId: number): Promise<ResolvedAccessProfile> {
+  const profile = await resolveAccessProfile(userId);
+  return profile ?? { is_superadmin: false, modules: [] };
+}
+
+export async function isSuperadmin(userId: number): Promise<boolean> {
+  return repo.repoIsSuperadmin(userId);
+}
+
+export async function buildOverview(tx?: DbQueryer): Promise<AccessOverview> {
+  const [modules, users, overrides] = await Promise.all([
+    repo.repoListCatalogModules(tx),
+    repo.repoListAccessUsers(tx),
+    repo.repoListAccessOverrides(tx),
+  ]);
+
+  const overrideByUser = new Map<number, Map<string, ModuleAccessOverride>>();
+  for (const row of overrides) {
+    let byModule = overrideByUser.get(row.user_id);
+    if (!byModule) {
+      byModule = new Map<string, ModuleAccessOverride>();
+      overrideByUser.set(row.user_id, byModule);
+    }
+    byModule.set(row.module_key, row.access);
+  }
+
+  const activeModules = modules.filter((module) => module.is_active);
+  const matrix: OverviewMatrixCell[] = [];
+  const userCounters = new Map<number, { denied: number; allowed: number }>();
+
+  for (const user of users) {
+    const byModule = overrideByUser.get(user.id);
+    const counters = { denied: 0, allowed: 0 };
+    for (const module of activeModules) {
+      const override = byModule?.get(module.module_key) ?? null;
+      const { allowed, source } = decide({
+        isSuperadmin: user.is_superadmin,
+        isActive: module.is_active,
+        enabledByDefault: module.enabled_by_default,
+        override,
+      });
+      matrix.push({ user_id: user.id, module_key: module.module_key, access: override, effective: allowed, source });
+      if (allowed) counters.allowed += 1;
+      if (override === "DENIED") counters.denied += 1;
+    }
+    userCounters.set(user.id, counters);
+  }
+
+  const deniedByModule = new Map<string, number>();
+  const grantedByModule = new Map<string, number>();
+  for (const row of overrides) {
+    const target = row.access === "DENIED" ? deniedByModule : grantedByModule;
+    target.set(row.module_key, (target.get(row.module_key) ?? 0) + 1);
+  }
+
+  return {
+    modules: modules.map((module) => ({
+      module_key: module.module_key,
+      label: module.label,
+      description: module.description,
+      category: module.category,
+      enabled_by_default: module.enabled_by_default,
+      is_protected: module.is_protected,
+      sort_order: module.sort_order,
+      denied_count: deniedByModule.get(module.module_key) ?? 0,
+      granted_count: grantedByModule.get(module.module_key) ?? 0,
+    })),
+    users: users.map((user) => ({
+      id: user.id,
+      username: user.username,
+      name: user.name,
+      surname: user.surname,
+      email: user.email,
+      role: user.role,
+      roles: user.roles,
+      status: user.status,
+      is_superadmin: user.is_superadmin,
+      last_login: user.last_login,
+      denied_count: userCounters.get(user.id)?.denied ?? 0,
+      allowed_count: userCounters.get(user.id)?.allowed ?? 0,
+    })),
+    matrix,
+    summary: {
+      users_total: users.length,
+      superadmins: users.filter((user) => user.is_superadmin).length,
+      modules_total: modules.length,
+      modules_restricted_by_default: modules.filter((module) => !module.enabled_by_default).length,
+      active_restrictions: overrides.filter((row) => row.access === "DENIED").length,
+    },
+  };
+}
+
+async function writeAuditLog(
+  tx: DbQueryer,
+  audit: AccessAuditContext,
+  entry: { action: string; entityId: string; details: Record<string, unknown> }
+): Promise<void> {
+  await repoInsertAuditLog({
+    user_id: audit.user_id,
+    body: {
+      event_type: "ACTION",
+      action: entry.action,
+      page_key: AUDIT_PAGE_KEY,
+      entity_type: AUDIT_ENTITY_TYPE,
+      entity_id: entry.entityId,
+      path: audit.path,
+      client_session_id: audit.client_session_id,
+      details: entry.details,
+    },
+    ip: audit.ip,
+    user_agent: audit.user_agent,
+    device_type: audit.device_type,
+    os: audit.os,
+    browser: audit.browser,
+    tx,
+  });
+}
+
+async function loadModuleOrThrow(tx: DbQueryer, moduleKey: string): Promise<CatalogModuleRow> {
+  const module = await repo.repoGetCatalogModule(moduleKey, tx);
+  if (!module) throw new HttpError(404, "MODULE_NOT_FOUND", "Module inconnu.");
+  return module;
+}
+
+export async function setModuleDefault(params: {
+  moduleKey: string;
+  enabled: boolean;
+  audit: AccessAuditContext;
+}): Promise<AccessOverview> {
+  const overview = await repo.withTransaction(async (tx) => {
+    const module = await loadModuleOrThrow(tx, params.moduleKey);
+    if (module.is_protected && !params.enabled) {
+      throw new HttpError(409, "MODULE_PROTECTED", "Ce module ne peut pas être restreint.");
+    }
+    if (module.enabled_by_default !== params.enabled) {
+      await repo.repoSetModuleDefault(tx, { moduleKey: module.module_key, enabled: params.enabled });
+      await repo.repoInsertAccessEvent(tx, {
+        userId: null,
+        moduleKey: module.module_key,
+        eventType: "DEFAULT_CHANGED",
+        previousState: module.enabled_by_default ? "ENABLED" : "DISABLED",
+        nextState: params.enabled ? "ENABLED" : "DISABLED",
+        actorUserId: params.audit.user_id,
+      });
+      await writeAuditLog(tx, params.audit, {
+        action: "ACCESS_MODULE_DEFAULT_SET",
+        entityId: module.module_key,
+        details: {
+          module_key: module.module_key,
+          previous_state: module.enabled_by_default,
+          next_state: params.enabled,
+        },
+      });
+    }
+    return buildOverview(tx);
+  });
+
+  // Un défaut catalogue change la résolution de TOUS les comptes sans override.
+  invalidateAccessCache();
+  return overview;
+}
+
+/** Applique une décision unitaire. Retourne `null` si l'état est déjà celui demandé. */
+async function applyUserModuleDecision(
+  tx: DbQueryer,
+  params: {
+    userId: number;
+    module: CatalogModuleRow;
+    decision: ModuleAccessDecision;
+    actorUserId: number;
+    targetIsSuperadmin: boolean;
+  }
+): Promise<{ previous: ModuleAccessOverride | null; next: ModuleAccessDecision } | null> {
+  if (params.decision === "DENIED") {
+    if (params.module.is_protected) {
+      throw new HttpError(409, "MODULE_PROTECTED", "Ce module ne peut pas être restreint.");
+    }
+    if (params.targetIsSuperadmin) {
+      throw new HttpError(409, "SUPERADMIN_IMMUTABLE", "Ce compte ne peut pas être restreint.");
+    }
+  }
+
+  const previous = await repo.repoGetUserModuleAccess(params.userId, params.module.module_key, tx);
+  if (params.decision === "INHERIT") {
+    if (previous === null) return null;
+    await repo.repoDeleteUserModuleAccess(tx, {
+      userId: params.userId,
+      moduleKey: params.module.module_key,
+    });
+  } else {
+    if (previous === params.decision) return null;
+    await repo.repoUpsertUserModuleAccess(tx, {
+      userId: params.userId,
+      moduleKey: params.module.module_key,
+      access: params.decision,
+      updatedBy: params.actorUserId,
+    });
+  }
+
+  await repo.repoInsertAccessEvent(tx, {
+    userId: params.userId,
+    moduleKey: params.module.module_key,
+    eventType: params.decision === "INHERIT" ? "INHERITED" : params.decision,
+    previousState: previous ?? "INHERIT",
+    nextState: params.decision,
+    actorUserId: params.actorUserId,
+  });
+
+  return { previous, next: params.decision };
+}
+
+async function loadTargetUser(tx: DbQueryer, userId: number) {
+  const user = await repo.repoGetAccessUser(userId, tx);
+  if (!user) throw new HttpError(404, "USER_NOT_FOUND", "Utilisateur inconnu.");
+  return user;
+}
+
+export async function setUserModuleAccess(params: {
+  userId: number;
+  moduleKey: string;
+  decision: ModuleAccessDecision;
+  audit: AccessAuditContext;
+}): Promise<AccessOverview> {
+  const overview = await repo.withTransaction(async (tx) => {
+    const user = await loadTargetUser(tx, params.userId);
+    const module = await loadModuleOrThrow(tx, params.moduleKey);
+    const change = await applyUserModuleDecision(tx, {
+      userId: user.id,
+      module,
+      decision: params.decision,
+      actorUserId: params.audit.user_id,
+      targetIsSuperadmin: user.is_superadmin,
+    });
+    if (change) {
+      await writeAuditLog(tx, params.audit, {
+        action: "ACCESS_USER_MODULE_SET",
+        entityId: `${user.id}:${module.module_key}`,
+        details: {
+          user_id: user.id,
+          username: user.username,
+          module_key: module.module_key,
+          previous_state: change.previous,
+          next_state: change.next,
+        },
+      });
+    }
+    return buildOverview(tx);
+  });
+
+  invalidateAccessCache(params.userId);
+  return overview;
+}
+
+export async function setUserModulesBulk(params: {
+  userId: number;
+  entries: ReadonlyArray<{ module_key: string; access: ModuleAccessDecision }>;
+  audit: AccessAuditContext;
+}): Promise<AccessOverview> {
+  const overview = await repo.withTransaction(async (tx) => {
+    const user = await loadTargetUser(tx, params.userId);
+    const applied: Array<{ module_key: string; previous_state: string | null; next_state: string }> = [];
+
+    for (const entry of params.entries) {
+      const module = await loadModuleOrThrow(tx, entry.module_key);
+      const change = await applyUserModuleDecision(tx, {
+        userId: user.id,
+        module,
+        decision: entry.access,
+        actorUserId: params.audit.user_id,
+        targetIsSuperadmin: user.is_superadmin,
+      });
+      if (change) {
+        applied.push({
+          module_key: module.module_key,
+          previous_state: change.previous,
+          next_state: change.next,
+        });
+      }
+    }
+
+    if (applied.length > 0) {
+      await writeAuditLog(tx, params.audit, {
+        action: "ACCESS_USER_BULK_SET",
+        entityId: String(user.id),
+        details: { user_id: user.id, username: user.username, changes: applied },
+      });
+    }
+    return buildOverview(tx);
+  });
+
+  invalidateAccessCache(params.userId);
+  return overview;
+}
+
+export async function unlockAll(params: {
+  confirm: string;
+  audit: AccessAuditContext;
+}): Promise<AccessOverview> {
+  if (params.confirm !== UNLOCK_ALL_CONFIRMATION) {
+    throw new HttpError(400, "CONFIRMATION_REQUIRED", "Confirmation exacte requise.");
+  }
+
+  const overview = await repo.withTransaction(async (tx) => {
+    const removed = await repo.repoDeleteAllDenials(tx);
+    const restored = await repo.repoRestoreAllDefaults(tx);
+
+    for (const row of removed) {
+      await repo.repoInsertAccessEvent(tx, {
+        userId: row.user_id,
+        moduleKey: row.module_key,
+        eventType: "UNLOCK_ALL",
+        previousState: "DENIED",
+        nextState: "INHERIT",
+        actorUserId: params.audit.user_id,
+      });
+    }
+    for (const moduleKey of restored) {
+      await repo.repoInsertAccessEvent(tx, {
+        userId: null,
+        moduleKey,
+        eventType: "UNLOCK_ALL",
+        previousState: "DISABLED",
+        nextState: "ENABLED",
+        actorUserId: params.audit.user_id,
+      });
+    }
+
+    await writeAuditLog(tx, params.audit, {
+      action: "ACCESS_UNLOCK_ALL",
+      entityId: "*",
+      details: {
+        removed_denials: removed.length,
+        restored_defaults: restored.length,
+        modules_restored: restored,
+      },
+    });
+    return buildOverview(tx);
+  });
+
+  invalidateAccessCache();
+  return overview;
+}
+
+export async function listAccessEvents(filters: {
+  limit: number;
+  offset: number;
+  user_id?: number;
+  module_key?: string;
+}) {
+  return repo.repoListAccessEvents(filters);
+}

--- a/src/module/access-control/types/access-control.types.ts
+++ b/src/module/access-control/types/access-control.types.ts
@@ -1,0 +1,113 @@
+// Types partagés de la tour de contrôle des accès (#326 / back #200).
+
+export type ModuleAccessOverride = "GRANTED" | "DENIED";
+export type ModuleAccessDecision = ModuleAccessOverride | "INHERIT";
+export type ModuleAccessSource = "SUPERADMIN" | "OVERRIDE" | "DEFAULT";
+
+export type AccessEventType =
+  | "GRANTED"
+  | "DENIED"
+  | "INHERITED"
+  | "DEFAULT_CHANGED"
+  | "UNLOCK_ALL";
+
+// Ligne brute de résolution : un module du catalogue vu depuis un compte donné.
+export type AccessProfileRow = {
+  is_superadmin: boolean;
+  module_key: string | null;
+  label: string | null;
+  nav_page_keys: string[] | null;
+  enabled_by_default: boolean | null;
+  is_protected: boolean | null;
+  is_active: boolean | null;
+  access: ModuleAccessOverride | null;
+};
+
+export type ResolvedModuleAccess = {
+  module_key: string;
+  label: string;
+  nav_page_keys: string[];
+  allowed: boolean;
+  source: ModuleAccessSource;
+};
+
+export type ResolvedAccessProfile = {
+  is_superadmin: boolean;
+  modules: ResolvedModuleAccess[];
+};
+
+export type OverviewModuleRow = {
+  module_key: string;
+  label: string;
+  description: string | null;
+  category: string;
+  enabled_by_default: boolean;
+  is_protected: boolean;
+  sort_order: number;
+  denied_count: number;
+  granted_count: number;
+};
+
+export type OverviewUserRow = {
+  id: number;
+  username: string;
+  name: string | null;
+  surname: string | null;
+  email: string | null;
+  role: string;
+  roles: string[];
+  status: string | null;
+  is_superadmin: boolean;
+  last_login: string | null;
+  denied_count: number;
+  allowed_count: number;
+};
+
+export type OverviewMatrixCell = {
+  user_id: number;
+  module_key: string;
+  access: ModuleAccessOverride | null;
+  effective: boolean;
+  source: ModuleAccessSource;
+};
+
+export type OverviewSummary = {
+  users_total: number;
+  superadmins: number;
+  modules_total: number;
+  modules_restricted_by_default: number;
+  active_restrictions: number;
+};
+
+export type AccessOverview = {
+  modules: OverviewModuleRow[];
+  users: OverviewUserRow[];
+  matrix: OverviewMatrixCell[];
+  summary: OverviewSummary;
+};
+
+export type AccessEventRow = {
+  id: string;
+  user_id: number | null;
+  username: string | null;
+  module_key: string;
+  event_type: AccessEventType;
+  previous_state: string | null;
+  next_state: string | null;
+  actor_user_id: number | null;
+  actor_username: string | null;
+  source: string;
+  occurred_at: string;
+};
+
+// Contexte d'audit ERP, même forme que les autres modules. Jamais de secret dedans.
+export type AccessAuditContext = {
+  user_id: number;
+  ip: string | null;
+  user_agent: string | null;
+  device_type: string | null;
+  os: string | null;
+  browser: string | null;
+  path: string | null;
+  client_session_id: string | null;
+};

--- a/src/module/access-control/validators/access-control.validators.ts
+++ b/src/module/access-control/validators/access-control.validators.ts
@@ -1,0 +1,69 @@
+// src/module/access-control/validators/access-control.validators.ts
+import { z } from "zod";
+
+const moduleKeyParam = z
+  .string({ required_error: "Clé de module requise", invalid_type_error: "Clé de module invalide" })
+  .trim()
+  .min(1, "Clé de module requise")
+  .max(64, "Clé de module invalide")
+  .regex(/^[a-z0-9-]+$/, "Clé de module invalide");
+
+const userIdParam = z
+  .string({ required_error: "ID utilisateur requis", invalid_type_error: "ID utilisateur invalide" })
+  .trim()
+  .regex(/^\d+$/, "ID utilisateur invalide");
+
+const accessDecision = z.enum(["GRANTED", "DENIED", "INHERIT"], {
+  errorMap: () => ({ message: "Décision d'accès invalide (GRANTED, DENIED ou INHERIT)" }),
+});
+
+export const setModuleDefaultSchema = z.object({
+  params: z.object({ moduleKey: moduleKeyParam }),
+  body: z
+    .object({
+      enabled_by_default: z.boolean({
+        required_error: "Valeur par défaut requise",
+        invalid_type_error: "Valeur par défaut invalide",
+      }),
+    })
+    .strict(),
+});
+export type SetModuleDefaultDTO = z.infer<typeof setModuleDefaultSchema>;
+
+export const setUserModuleAccessSchema = z.object({
+  params: z.object({ userId: userIdParam, moduleKey: moduleKeyParam }),
+  body: z.object({ access: accessDecision }).strict(),
+});
+export type SetUserModuleAccessDTO = z.infer<typeof setUserModuleAccessSchema>;
+
+export const setUserModulesBulkSchema = z.object({
+  params: z.object({ userId: userIdParam }),
+  body: z
+    .object({
+      entries: z
+        .array(z.object({ module_key: moduleKeyParam, access: accessDecision }).strict())
+        .min(1, "Au moins une décision est requise")
+        .max(100, "Trop de décisions dans un même envoi")
+        // Deux décisions contradictoires sur le même module rendraient le
+        // résultat dépendant de l'ordre : on refuse plutôt que d'arbitrer.
+        .refine(
+          (entries) => new Set(entries.map((entry) => entry.module_key)).size === entries.length,
+          "Un même module ne peut apparaître qu'une fois"
+        ),
+    })
+    .strict(),
+});
+export type SetUserModulesBulkDTO = z.infer<typeof setUserModulesBulkSchema>;
+
+export const unlockAllSchema = z.object({
+  body: z.object({ confirm: z.string({ required_error: "Confirmation requise" }) }).strict(),
+});
+export type UnlockAllDTO = z.infer<typeof unlockAllSchema>;
+
+export const listAccessEventsQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+  offset: z.coerce.number().int().min(0).optional().default(0),
+  user_id: z.coerce.number().int().positive().optional(),
+  module_key: moduleKeyParam.optional(),
+});
+export type ListAccessEventsQueryDTO = z.infer<typeof listAccessEventsQuerySchema>;

--- a/src/module/admin/controllers/admin.controller.ts
+++ b/src/module/admin/controllers/admin.controller.ts
@@ -15,6 +15,11 @@ export const listUsersAdmin: RequestHandler = asyncHandler(async (_req, res) => 
   res.json(rows);
 });
 
+export const listRolesAdmin: RequestHandler = asyncHandler(async (_req, res) => {
+  const rows = await adminService.listRoles();
+  res.json(rows);
+});
+
 export const listLoginLogsAdmin: RequestHandler = asyncHandler(async (req, res) => {
   const from = (req.query as { from?: unknown }).from;
   const to = (req.query as { to?: unknown }).to;
@@ -63,21 +68,23 @@ export const createUserAdmin: RequestHandler = asyncHandler(async (req, res) => 
     name: dto.body.name,
     surname: dto.body.surname,
     email: dto.body.email,
-    tel_no: dto.body.tel_no,
+    tel_no: dto.body.tel_no ?? null,
     role: dto.body.role,
-    gender: dto.body.gender,
-    address: dto.body.address,
-    lane: dto.body.lane,
-    house_no: dto.body.house_no,
-    postcode: dto.body.postcode,
+    roles: dto.body.roles,
+    assignedBy: req.user?.id ?? null,
+    gender: dto.body.gender ?? null,
+    address: dto.body.address ?? null,
+    lane: dto.body.lane ?? null,
+    house_no: dto.body.house_no ?? null,
+    postcode: dto.body.postcode ?? null,
     country: dto.body.country ?? "France",
     salary: dto.body.salary === undefined ? null : dto.body.salary,
-    date_of_birth: dto.body.date_of_birth,
+    date_of_birth: dto.body.date_of_birth ?? null,
     employment_date: dto.body.employment_date ?? null,
     employment_end_date: dto.body.employment_end_date ?? null,
     national_id: dto.body.national_id ?? null,
     status: dto.body.status ?? null,
-    social_security_number: dto.body.social_security_number,
+    social_security_number: dto.body.social_security_number ?? null,
   });
   res.status(201).json({ user });
 });
@@ -85,7 +92,7 @@ export const createUserAdmin: RequestHandler = asyncHandler(async (req, res) => 
 export const patchUserAdmin: RequestHandler = asyncHandler(async (req, res) => {
   const dto = adminUpdateUserSchema.parse({ params: req.params, body: req.body });
   const userId = Number(dto.params.id);
-  const user = await adminService.updateUserByAdmin(userId, dto.body);
+  const user = await adminService.updateUserByAdmin(userId, dto.body, req.user?.id ?? null);
   if (!user) throw new HttpError(404, "USER_NOT_FOUND", "User not found");
   res.json({ user });
 });

--- a/src/module/admin/repository/admin.repository.ts
+++ b/src/module/admin/repository/admin.repository.ts
@@ -1,16 +1,20 @@
 // src/module/admin/repository/admin.repository.ts
 import pool from "../../../config/database";
 import crypto from "node:crypto";
+import type { PoolClient } from "pg";
 
 import { HttpError } from "../../../utils/httpError";
+import { normalizeAssignedRoles } from "../../auth/domain/roles";
 
 export type AdminUserListRow = {
   id: number;
   username: string;
   email: string;
   role: string;
+  roles: string[];
   status: string | null;
   last_login: string | null;
+  profile_incomplete: boolean;
 };
 
 export type AdminUserDetailRow = {
@@ -19,16 +23,17 @@ export type AdminUserDetailRow = {
   name: string;
   surname: string;
   email: string;
-  tel_no: string;
+  tel_no: string | null;
   role: string;
-  gender: string;
-  address: string;
-  lane: string;
-  house_no: string;
-  postcode: string;
+  roles: string[];
+  gender: string | null;
+  address: string | null;
+  lane: string | null;
+  house_no: string | null;
+  postcode: string | null;
   country: string | null;
   salary: number | null;
-  date_of_birth: string;
+  date_of_birth: string | null;
   employment_date: string | null;
   employment_end_date: string | null;
   national_id: string | null;
@@ -36,7 +41,14 @@ export type AdminUserDetailRow = {
   last_login: string | null;
   status: string | null;
   created_at: string | null;
-  social_security_number: string;
+  social_security_number: string | null;
+  profile_incomplete: boolean;
+};
+
+export type AdminRoleRow = {
+  role_key: string;
+  category: "PRIMARY" | "ORGANIZATION";
+  description: string;
 };
 
 type PgErrorLike = { code?: unknown; constraint?: unknown };
@@ -54,18 +66,95 @@ function pgConstraint(err: unknown): string | null {
   return typeof v === "string" && v.trim() ? v.trim() : null;
 }
 
+async function replaceUserRoles(
+  client: PoolClient,
+  params: {
+    userId: number;
+    primaryRole: string;
+    roles: readonly string[];
+    assignedBy: number | null;
+  }
+): Promise<void> {
+  const roles = normalizeAssignedRoles(params.primaryRole, params.roles);
+  const existing = await client.query<{ role_key: string }>(
+    `SELECT role_key FROM public.user_role_assignments WHERE user_id = $1`,
+    [params.userId]
+  );
+  const previous = new Set(existing.rows.map((row) => row.role_key));
+  const next = new Set(roles);
+  const assigned = roles.filter((role) => !previous.has(role));
+  const revoked = [...previous].filter((role) => !next.has(role));
+
+  await client.query(
+    `
+      DELETE FROM public.user_role_assignments
+      WHERE user_id = $1
+        AND NOT (role_key = ANY($2::text[]))
+    `,
+    [params.userId, roles]
+  );
+  await client.query(
+    `
+      INSERT INTO public.user_role_assignments (user_id, role_key, assigned_by)
+      SELECT $1, role_key, $3
+      FROM unnest($2::text[]) AS assigned(role_key)
+      ON CONFLICT (user_id, role_key) DO UPDATE
+      SET assigned_by = COALESCE(EXCLUDED.assigned_by, public.user_role_assignments.assigned_by)
+    `,
+    [params.userId, roles, params.assignedBy]
+  );
+
+  if (assigned.length > 0) {
+    await client.query(
+      `
+        INSERT INTO public.user_role_assignment_events (
+          user_id, role_key, event_type, actor_user_id, source
+        )
+        SELECT $1, role_key, 'ASSIGNED', $3, 'admin-api'
+        FROM unnest($2::text[]) AS assigned_role(role_key)
+      `,
+      [params.userId, assigned, params.assignedBy]
+    );
+  }
+  if (revoked.length > 0) {
+    await client.query(
+      `
+        INSERT INTO public.user_role_assignment_events (
+          user_id, role_key, event_type, actor_user_id, source
+        )
+        SELECT $1, role_key, 'REVOKED', $3, 'admin-api'
+        FROM unnest($2::text[]) AS revoked_role(role_key)
+      `,
+      [params.userId, revoked, params.assignedBy]
+    );
+  }
+}
+
 export async function repoListUsers(): Promise<AdminUserListRow[]> {
   const { rows } = await pool.query<AdminUserListRow>(
     `
       SELECT
-        id::int AS id,
-        username,
-        email,
-        role,
-        status,
-        last_login::text AS last_login
-      FROM public.users
-      ORDER BY created_at DESC NULLS LAST, id DESC
+        u.id::int AS id,
+        u.username,
+        u.email,
+        u.role,
+        COALESCE(
+          array_agg(ura.role_key ORDER BY (ura.role_key = u.role) DESC, ura.role_key)
+            FILTER (WHERE ura.role_key IS NOT NULL),
+          ARRAY[u.role]::text[]
+        ) AS roles,
+        u.status,
+        u.last_login::text AS last_login,
+        (
+          u.tel_no IS NULL
+          OR u.address IS NULL
+          OR u.date_of_birth IS NULL
+          OR u.social_security_number IS NULL
+        ) AS profile_incomplete
+      FROM public.users u
+      LEFT JOIN public.user_role_assignments ura ON ura.user_id = u.id
+      GROUP BY u.id
+      ORDER BY u.created_at DESC NULLS LAST, u.id DESC
     `
   );
   return rows;
@@ -75,31 +164,45 @@ export async function repoGetUserById(userId: number): Promise<AdminUserDetailRo
   const { rows } = await pool.query<AdminUserDetailRow>(
     `
       SELECT
-        id::int AS id,
-        username,
-        name,
-        surname,
-        email,
-        tel_no,
-        role,
-        gender,
-        address,
-        lane,
-        house_no,
-        postcode,
-        country,
-        salary::float AS salary,
-        date_of_birth::text AS date_of_birth,
-        employment_date::text AS employment_date,
-        employment_end_date::text AS employment_end_date,
-        national_id,
-        profile_picture,
-        last_login::text AS last_login,
-        status,
-        created_at::text AS created_at,
-        social_security_number
-      FROM public.users
-      WHERE id = $1
+        u.id::int AS id,
+        u.username,
+        u.name,
+        u.surname,
+        u.email,
+        u.tel_no,
+        u.role,
+        COALESCE(
+          (
+            SELECT array_agg(ura.role_key ORDER BY (ura.role_key = u.role) DESC, ura.role_key)
+            FROM public.user_role_assignments ura
+            WHERE ura.user_id = u.id
+          ),
+          ARRAY[u.role]::text[]
+        ) AS roles,
+        u.gender,
+        u.address,
+        u.lane,
+        u.house_no,
+        u.postcode,
+        u.country,
+        u.salary::float AS salary,
+        u.date_of_birth::text AS date_of_birth,
+        u.employment_date::text AS employment_date,
+        u.employment_end_date::text AS employment_end_date,
+        u.national_id,
+        u.profile_picture,
+        u.last_login::text AS last_login,
+        u.status,
+        u.created_at::text AS created_at,
+        u.social_security_number,
+        (
+          u.tel_no IS NULL
+          OR u.address IS NULL
+          OR u.date_of_birth IS NULL
+          OR u.social_security_number IS NULL
+        ) AS profile_incomplete
+      FROM public.users u
+      WHERE u.id = $1
       LIMIT 1
     `,
     [userId]
@@ -113,24 +216,28 @@ export async function repoCreateUser(input: {
   name: string;
   surname: string;
   email: string;
-  tel_no: string;
+  tel_no: string | null;
   role: string;
-  gender: string;
-  address: string;
-  lane: string;
-  house_no: string;
-  postcode: string;
+  roles: string[];
+  assignedBy: number | null;
+  gender: string | null;
+  address: string | null;
+  lane: string | null;
+  house_no: string | null;
+  postcode: string | null;
   country: string | null;
   salary: number | null;
-  date_of_birth: string;
+  date_of_birth: string | null;
   employment_date: string | null;
   employment_end_date: string | null;
   national_id: string | null;
   status: string | null;
-  social_security_number: string;
+  social_security_number: string | null;
 }): Promise<AdminUserDetailRow> {
+  const client = await pool.connect();
   try {
-    const { rows } = await pool.query<AdminUserDetailRow>(
+    await client.query("BEGIN");
+    const { rows } = await client.query<{ id: number }>(
       `
         INSERT INTO public.users (
           username,
@@ -175,30 +282,7 @@ export async function repoCreateUser(input: {
           COALESCE(NULLIF($19, ''), 'Active'),
           $20
         )
-        RETURNING
-          id::int AS id,
-          username,
-          name,
-          surname,
-          email,
-          tel_no,
-          role,
-          gender,
-          address,
-          lane,
-          house_no,
-          postcode,
-          country,
-          salary::float AS salary,
-          date_of_birth::text AS date_of_birth,
-          employment_date::text AS employment_date,
-          employment_end_date::text AS employment_end_date,
-          national_id,
-          profile_picture,
-          last_login::text AS last_login,
-          status,
-          created_at::text AS created_at,
-          social_security_number
+        RETURNING id::int AS id
       `,
       [
         input.username,
@@ -226,8 +310,22 @@ export async function repoCreateUser(input: {
 
     const row = rows[0];
     if (!row) throw new Error("Failed to create user");
-    return row;
+    await replaceUserRoles(client, {
+      userId: row.id,
+      primaryRole: input.role,
+      roles: input.roles,
+      assignedBy: input.assignedBy,
+    });
+    await client.query("COMMIT");
+
+    const created = await repoGetUserById(row.id);
+    if (!created) throw new Error("Failed to reload created user");
+    return created;
   } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+    }
     if (isPgUniqueViolation(err)) {
       const constraint = pgConstraint(err);
       if (constraint === "users_username_key") throw new HttpError(409, "USERNAME_EXISTS", "Username already exists");
@@ -239,7 +337,21 @@ export async function repoCreateUser(input: {
       throw new HttpError(409, "DUPLICATE", "User already exists");
     }
     throw err;
+  } finally {
+    client.release();
   }
+}
+
+export async function repoListRoles(): Promise<AdminRoleRow[]> {
+  const { rows } = await pool.query<AdminRoleRow>(
+    `
+      SELECT role_key, category, description
+      FROM public.app_roles
+      WHERE is_active = true
+      ORDER BY category, role_key
+    `
+  );
+  return rows;
 }
 
 export async function repoUpdateUser(
@@ -249,21 +361,23 @@ export async function repoUpdateUser(
     name: string;
     surname: string;
     email: string;
-    tel_no: string;
+    tel_no: string | null;
     role: string;
-    gender: string;
-    address: string;
-    lane: string;
-    house_no: string;
-    postcode: string;
+    roles: string[];
+    assignedBy: number | null;
+    gender: string | null;
+    address: string | null;
+    lane: string | null;
+    house_no: string | null;
+    postcode: string | null;
     country: string | null;
     salary: number | null;
-    date_of_birth: string;
+    date_of_birth: string | null;
     employment_date: string | null;
     employment_end_date: string | null;
     national_id: string | null;
     status: string | null;
-    social_security_number: string;
+    social_security_number: string | null;
   }>
 ): Promise<AdminUserDetailRow | null> {
   const sets: string[] = [];
@@ -293,16 +407,49 @@ export async function repoUpdateUser(
   if (patch.status !== undefined) sets.push(`status = ${push(patch.status)}`);
   if (patch.social_security_number !== undefined) sets.push(`social_security_number = ${push(patch.social_security_number)}`);
 
-  if (!sets.length) return repoGetUserById(userId);
+  if (!sets.length && patch.roles === undefined) return repoGetUserById(userId);
 
-  const sql = `UPDATE public.users SET ${sets.join(", ")} WHERE id = ${push(userId)} RETURNING id::int AS id`;
-
+  const client = await pool.connect();
   try {
-    const res = await pool.query<{ id: number }>(sql, values);
-    const rowId = res.rows[0]?.id;
-    if (!rowId) return null;
-    return repoGetUserById(rowId);
+    await client.query("BEGIN");
+    const current = await client.query<{ role: string }>(
+      `SELECT role FROM public.users WHERE id = $1 FOR UPDATE`,
+      [userId]
+    );
+    const currentRole = current.rows[0]?.role;
+    if (!currentRole) {
+      await client.query("ROLLBACK");
+      return null;
+    }
+
+    if (sets.length) {
+      values.push(userId);
+      await client.query(
+        `UPDATE public.users SET ${sets.join(", ")} WHERE id = $${values.length}`,
+        values
+      );
+    }
+
+    if (patch.roles !== undefined || patch.role !== undefined) {
+      const existing = await client.query<{ role_key: string }>(
+        `SELECT role_key FROM public.user_role_assignments WHERE user_id = $1 ORDER BY role_key`,
+        [userId]
+      );
+      await replaceUserRoles(client, {
+        userId,
+        primaryRole: patch.role ?? currentRole,
+        roles: patch.roles ?? existing.rows.map((row) => row.role_key),
+        assignedBy: patch.assignedBy ?? null,
+      });
+    }
+
+    await client.query("COMMIT");
+    return repoGetUserById(userId);
   } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+    }
     if (isPgUniqueViolation(err)) {
       const constraint = pgConstraint(err);
       if (constraint === "users_username_key") throw new HttpError(409, "USERNAME_EXISTS", "Username already exists");
@@ -314,6 +461,8 @@ export async function repoUpdateUser(
       throw new HttpError(409, "DUPLICATE", "User already exists");
     }
     throw err;
+  } finally {
+    client.release();
   }
 }
 

--- a/src/module/admin/repository/admin.repository.ts
+++ b/src/module/admin/repository/admin.repository.ts
@@ -15,6 +15,9 @@ export type AdminUserListRow = {
   status: string | null;
   last_login: string | null;
   profile_incomplete: boolean;
+  // Marqueur de compte exposé en LECTURE SEULE : aucune route admin ne l'écrit,
+  // il ne s'obtient que par le seed SQL gardé de la tour de contrôle (#326).
+  is_superadmin: boolean;
 };
 
 export type AdminUserDetailRow = {
@@ -43,6 +46,7 @@ export type AdminUserDetailRow = {
   created_at: string | null;
   social_security_number: string | null;
   profile_incomplete: boolean;
+  is_superadmin: boolean;
 };
 
 export type AdminRoleRow = {
@@ -130,7 +134,26 @@ async function replaceUserRoles(
   }
 }
 
+/**
+ * `users.is_superadmin` arrive avec le patch #326. Le lire à part garde l'écran des
+ * comptes fonctionnel sur une base qui ne l'a pas encore (`42703`), plutôt que de
+ * transformer une migration en attente en erreur 500.
+ */
+async function readSuperadminIds(): Promise<Set<number>> {
+  try {
+    const { rows } = await pool.query<{ id: number }>(
+      `SELECT id::int AS id FROM public.users WHERE is_superadmin`
+    );
+    return new Set(rows.map((row) => row.id));
+  } catch (err) {
+    const code = (err as { code?: unknown } | null)?.code;
+    if (code === "42703" || code === "42P01") return new Set<number>();
+    throw err;
+  }
+}
+
 export async function repoListUsers(): Promise<AdminUserListRow[]> {
+  const superadminIds = await readSuperadminIds();
   const { rows } = await pool.query<AdminUserListRow>(
     `
       SELECT
@@ -157,10 +180,11 @@ export async function repoListUsers(): Promise<AdminUserListRow[]> {
       ORDER BY u.created_at DESC NULLS LAST, u.id DESC
     `
   );
-  return rows;
+  return rows.map((row) => ({ ...row, is_superadmin: superadminIds.has(row.id) }));
 }
 
 export async function repoGetUserById(userId: number): Promise<AdminUserDetailRow | null> {
+  const superadminIds = await readSuperadminIds();
   const { rows } = await pool.query<AdminUserDetailRow>(
     `
       SELECT
@@ -207,7 +231,8 @@ export async function repoGetUserById(userId: number): Promise<AdminUserDetailRo
     `,
     [userId]
   );
-  return rows[0] ?? null;
+  const row = rows[0];
+  return row ? { ...row, is_superadmin: superadminIds.has(row.id) } : null;
 }
 
 export async function repoCreateUser(input: {

--- a/src/module/admin/routes/admin.routes.ts
+++ b/src/module/admin/routes/admin.routes.ts
@@ -6,6 +6,7 @@ import {
   createUserAdmin,
   deleteUserAdmin,
   getUserAdmin,
+  listRolesAdmin,
   listUsersAdmin,
   listLoginLogsAdmin,
   resetUserPasswordAdmin,
@@ -19,6 +20,7 @@ router.use(authenticateToken);
 router.use(authorizeRole("Administrateur Systeme et Reseau", "Directeur"));
 
 router.get("/users", listUsersAdmin);
+router.get("/roles", listRolesAdmin);
 router.get("/users/:id", getUserAdmin);
 router.post("/users", createUserAdmin);
 router.patch("/users/:id", patchUserAdmin);

--- a/src/module/admin/services/admin.service.ts
+++ b/src/module/admin/services/admin.service.ts
@@ -8,6 +8,10 @@ export async function listUsers() {
   return adminRepo.repoListUsers();
 }
 
+export async function listRoles() {
+  return adminRepo.repoListRoles();
+}
+
 export async function getUser(userId: number) {
   return adminRepo.repoGetUserById(userId);
 }
@@ -18,21 +22,23 @@ export async function createUserByAdmin(input: {
   name: string;
   surname: string;
   email: string;
-  tel_no: string;
+  tel_no: string | null;
   role: string;
-  gender: string;
-  address: string;
-  lane: string;
-  house_no: string;
-  postcode: string;
+  roles: string[];
+  assignedBy: number | null;
+  gender: string | null;
+  address: string | null;
+  lane: string | null;
+  house_no: string | null;
+  postcode: string | null;
   country: string | null;
   salary: number | null;
-  date_of_birth: string;
+  date_of_birth: string | null;
   employment_date: string | null;
   employment_end_date: string | null;
   national_id: string | null;
   status: string | null;
-  social_security_number: string;
+  social_security_number: string | null;
 }) {
   const hash = await bcrypt.hash(input.password, 12);
   return adminRepo.repoCreateUser({
@@ -43,6 +49,8 @@ export async function createUserByAdmin(input: {
     email: input.email,
     tel_no: input.tel_no,
     role: input.role,
+    roles: input.roles,
+    assignedBy: input.assignedBy,
     gender: input.gender,
     address: input.address,
     lane: input.lane,
@@ -59,9 +67,16 @@ export async function createUserByAdmin(input: {
   });
 }
 
-export async function updateUserByAdmin(userId: number, patch: Record<string, unknown>) {
+export async function updateUserByAdmin(
+  userId: number,
+  patch: Record<string, unknown>,
+  assignedBy: number | null
+) {
   // Controller/validator ensures correct shape; keep narrow casting here.
-  return adminRepo.repoUpdateUser(userId, patch as Parameters<typeof adminRepo.repoUpdateUser>[1]);
+  return adminRepo.repoUpdateUser(userId, {
+    ...(patch as Parameters<typeof adminRepo.repoUpdateUser>[1]),
+    assignedBy,
+  });
 }
 
 export async function deleteUserByAdmin(userId: number) {

--- a/src/module/admin/validators/admin.validators.ts
+++ b/src/module/admin/validators/admin.validators.ts
@@ -1,6 +1,10 @@
 // src/module/admin/validators/admin.validators.ts
 import { z } from "zod";
 import { isoDate, strictEmail, trimString } from "../../auth/validators/_helpers";
+import {
+  ASSIGNABLE_USER_ROLES,
+  PRIMARY_USER_ROLES,
+} from "../../auth/domain/roles";
 
 const userIdParam = z
   .string({ required_error: "ID utilisateur requis", invalid_type_error: "ID utilisateur invalide" })
@@ -44,16 +48,25 @@ const userCoreObject = z
     name: trimString(2, "Nom requis (min 2 caractères)"),
     surname: trimString(2, "Prénom requis (min 2 caractères)"),
     email: strictEmail,
-    tel_no: phoneFR,
-    role: trimString(2, "Rôle requis"),
-    gender: z.enum(genders, { errorMap: () => ({ message: "Le genre doit être 'Male' ou 'Female'" }) }),
-    address: trimString(3, "Adresse requise"),
-    lane: trimString(2, "Rue requise"),
-    house_no: z.string({ required_error: "Numéro de voie requis" }).trim().min(1, "Numéro de voie requis"),
+    tel_no: phoneFR.optional().nullable(),
+    role: z.enum(PRIMARY_USER_ROLES, { errorMap: () => ({ message: "Rôle principal non autorisé" }) }),
+    roles: z
+      .array(z.enum(ASSIGNABLE_USER_ROLES))
+      .min(1, "Au moins un rôle est requis")
+      .max(20, "Trop de rôles attribués"),
+    gender: z
+      .enum(genders, { errorMap: () => ({ message: "Le genre doit être 'Male' ou 'Female'" }) })
+      .optional()
+      .nullable(),
+    address: trimString(3, "Adresse invalide (min 3 caractères)").optional().nullable(),
+    lane: trimString(2, "Rue invalide (min 2 caractères)").optional().nullable(),
+    house_no: z.string().trim().min(1, "Numéro de voie invalide").optional().nullable(),
     postcode: z
-      .string({ required_error: "Code postal requis" })
+      .string()
       .trim()
-      .regex(/^\d{5}$/, "Le code postal doit contenir 5 chiffres"),
+      .regex(/^\d{5}$/, "Le code postal doit contenir 5 chiffres")
+      .optional()
+      .nullable(),
     country: z.string().trim().min(1).optional().default("France"),
     salary: z
       .union([
@@ -64,22 +77,34 @@ const userCoreObject = z
         z.null(),
       ])
       .optional(),
-    date_of_birth: isoDate("Date de naissance").refine(
-      (v) => new Date(v) <= new Date(),
-      "La date de naissance ne peut pas être dans le futur"
-    ),
+    date_of_birth: isoDate("Date de naissance")
+      .refine((v) => new Date(v) <= new Date(), "La date de naissance ne peut pas être dans le futur")
+      .optional()
+      .nullable(),
     employment_date: isoDate("Date d'embauche").optional().nullable(),
     employment_end_date: isoDate("Date de fin d'emploi").optional().nullable(),
     national_id: z.string().trim().min(1).optional().nullable(),
     status: z.enum(statuses).optional(),
-    social_security_number: nir,
+    social_security_number: nir.optional().nullable(),
   })
   .strict();
 
 function refineEmploymentDates(
-  data: { employment_date?: string | null; employment_end_date?: string | null },
+  data: {
+    role?: string;
+    roles?: readonly string[];
+    employment_date?: string | null;
+    employment_end_date?: string | null;
+  },
   ctx: z.RefinementCtx
 ) {
+  if (data.role && data.roles && !data.roles.includes(data.role)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["roles"],
+      message: "Le rôle principal doit aussi figurer dans les rôles attribués",
+    });
+  }
   if (data.employment_date && data.employment_end_date) {
     const start = new Date(data.employment_date);
     const end = new Date(data.employment_end_date);

--- a/src/module/auth/controllers/user.controller.ts
+++ b/src/module/auth/controllers/user.controller.ts
@@ -3,6 +3,13 @@ import { RequestHandler } from 'express';
 export const getProfile: RequestHandler = (req, res) => {
   res.status(200).json({
     message: 'Profil utilisateur',
-    user: req.user,
+    user: req.user
+      ? {
+          ...req.user,
+          role: req.user.role,
+          primary_role: req.user.primary_role ?? req.user.role,
+          roles: req.user.roles ?? [req.user.primary_role ?? req.user.role],
+        }
+      : null,
   });
 };

--- a/src/module/auth/domain/roles.ts
+++ b/src/module/auth/domain/roles.ts
@@ -1,0 +1,142 @@
+export const PRIMARY_USER_ROLES = [
+  "Directeur",
+  "Employee",
+  "Administrateur Systeme et Reseau",
+  "Responsable Qualité",
+  "Secretaire",
+  "Responsable Programmation",
+  "Responsable RH",
+] as const;
+
+export const ORGANIZATION_USER_ROLES = [
+  "Gérant",
+  "Commerce",
+  "Achats",
+  "RH-Financier",
+  "Directeur Technique",
+  "Responsable Atelier-Production",
+  "Planning",
+  "Planification",
+  "Préparateur commandes",
+  "Assistante polyvalente",
+  "Assistante RH",
+  "Maintenance",
+  "Responsable Agencement",
+  "Qualité",
+  "Études-Méthodes",
+  "Programmation",
+  "Fraisage",
+  "Livraison",
+  "Préparation matière",
+  "Finitions",
+  "Gestion matière",
+  "Responsable CAO",
+  "Responsable fabrication fraisage",
+  "Tournage",
+  "Responsable tournage",
+  "Opérateur atelier",
+] as const;
+
+export const ASSIGNABLE_USER_ROLES = [
+  ...PRIMARY_USER_ROLES,
+  ...ORGANIZATION_USER_ROLES,
+] as const;
+
+export type PrimaryUserRole = (typeof PRIMARY_USER_ROLES)[number];
+export type AssignableUserRole = (typeof ASSIGNABLE_USER_ROLES)[number];
+
+/**
+ * Les intitulés d'organigramme ne sont jamais interprétés directement comme
+ * des privilèges. Chaque responsabilité est traduite ici vers des marqueurs
+ * techniques déjà compris par les politiques métier historiques.
+ *
+ * Exemple important : « Directeur Technique » donne accès à la production et
+ * aux méthodes, mais ne doit pas être confondu avec « Directeur » et ouvrir la
+ * finance ou l'administration.
+ */
+const AUTHORIZATION_ALIASES: Record<AssignableUserRole, readonly string[]> = {
+  Directeur: ["Directeur"],
+  Employee: ["Employee"],
+  "Administrateur Systeme et Reseau": ["Administrateur Systeme et Reseau"],
+  "Responsable Qualité": ["Responsable Qualité"],
+  Secretaire: ["Secretaire"],
+  "Responsable Programmation": ["Responsable Programmation"],
+  "Responsable RH": ["Responsable RH"],
+  Gérant: ["Directeur"],
+  Commerce: ["Commercial"],
+  Achats: ["Achat"],
+  "RH-Financier": ["Responsable RH", "Comptabilite"],
+  "Directeur Technique": ["Production", "Atelier", "Method"],
+  "Responsable Atelier-Production": ["Production", "Atelier"],
+  Planning: ["Planification"],
+  Planification: ["Planification"],
+  "Préparateur commandes": ["Logistique"],
+  "Assistante polyvalente": ["Secretaire"],
+  "Assistante RH": ["Responsable RH"],
+  Maintenance: ["Maintenance", "Atelier"],
+  "Responsable Agencement": ["Production", "Atelier"],
+  Qualité: ["Responsable Qualité"],
+  "Études-Méthodes": ["Method", "Responsable Programmation"],
+  Programmation: ["Responsable Programmation"],
+  Fraisage: ["Opérateur atelier"],
+  Livraison: ["Logistique"],
+  "Préparation matière": ["Stock", "Atelier"],
+  Finitions: ["Opérateur atelier"],
+  "Gestion matière": ["Stock", "Magasin"],
+  "Responsable CAO": ["Method"],
+  "Responsable fabrication fraisage": ["Production", "Atelier"],
+  Tournage: ["Opérateur atelier"],
+  "Responsable tournage": ["Production", "Atelier"],
+  "Opérateur atelier": ["Opérateur atelier"],
+};
+
+export function normalizeAssignedRoles(
+  primaryRole: string | null | undefined,
+  roles: readonly string[] | null | undefined
+): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+
+  for (const role of [primaryRole, ...(roles ?? [])]) {
+    const value = String(role ?? "").trim();
+    if (!value || seen.has(value)) continue;
+    seen.add(value);
+    normalized.push(value);
+  }
+
+  return normalized;
+}
+
+export function authorizationRole(
+  primaryRole: string | null | undefined,
+  roles: readonly string[] | null | undefined
+): string {
+  const aliases = normalizeAssignedRoles(primaryRole, roles).flatMap((role) => {
+    return AUTHORIZATION_ALIASES[role as AssignableUserRole] ?? [];
+  });
+  return [...new Set(aliases)].join(" | ");
+}
+
+export function effectiveRoleParts(role: string | null | undefined): string[] {
+  return String(role ?? "")
+    .split("|")
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+export function effectiveRoleHasAny(
+  role: string | null | undefined,
+  allowedRoles: readonly string[]
+): boolean {
+  const allowed = new Set(allowedRoles);
+  return effectiveRoleParts(role).some((part) => allowed.has(part));
+}
+
+export function hasAnyAssignedRole(
+  primaryRole: string | null | undefined,
+  assignedRoles: readonly string[] | null | undefined,
+  allowedRoles: readonly string[]
+): boolean {
+  const allowed = new Set(allowedRoles);
+  return normalizeAssignedRoles(primaryRole, assignedRoles).some((role) => allowed.has(role));
+}

--- a/src/module/auth/middlewares/auth.middleware.ts
+++ b/src/module/auth/middlewares/auth.middleware.ts
@@ -1,12 +1,15 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
 import jwt from 'jsonwebtoken';
 import { stripQueryFromUrl } from '../../../utils/logPath';
+import { hasAnyAssignedRole, normalizeAssignedRoles } from '../domain/roles';
 
 interface JwtPayload {
   id: number;
   username: string;
   email: string;
   role: string;
+  primary_role?: string;
+  roles?: string[];
 }
 
 // 🔧 Ajout de `req.user` pour tout Express
@@ -71,7 +74,9 @@ export const authorizeRole = (...roles: string[]) => {
         return;
       }
   
-      if (!roles.includes(req.user.role)) {
+      const primaryRole = req.user.primary_role ?? req.user.role;
+      const assignedRoles = normalizeAssignedRoles(primaryRole, req.user.roles);
+      if (!hasAnyAssignedRole(primaryRole, assignedRoles, roles)) {
         console.warn(
           JSON.stringify({
             type: "auth_forbidden",
@@ -80,7 +85,8 @@ export const authorizeRole = (...roles: string[]) => {
             method: req.method,
             path: stripQueryFromUrl(req.originalUrl),
             userId: req.user.id,
-            role: req.user.role,
+            role: primaryRole,
+            roles: assignedRoles,
             allowedRoles: roles,
           })
         );

--- a/src/module/auth/repository/auth.repository.ts
+++ b/src/module/auth/repository/auth.repository.ts
@@ -35,7 +35,20 @@ export const findUserByUsername = async (username: string) => {
   const client = await pool.connect();
   try {
     const result = await client.query(
-      'SELECT * FROM users WHERE username = $1 LIMIT 1',
+      `
+        SELECT
+          u.*,
+          COALESCE(
+            array_agg(ura.role_key ORDER BY (ura.role_key = u.role) DESC, ura.role_key)
+              FILTER (WHERE ura.role_key IS NOT NULL),
+            ARRAY[u.role]::text[]
+          ) AS roles
+        FROM public.users u
+        LEFT JOIN public.user_role_assignments ura ON ura.user_id = u.id
+        WHERE u.username = $1
+        GROUP BY u.id
+        LIMIT 1
+      `,
       [username]
     );
     return result.rows[0]; // undefined si pas trouvé

--- a/src/module/auth/routes/auth.routes.ts
+++ b/src/module/auth/routes/auth.routes.ts
@@ -6,6 +6,7 @@ import {
   } from '../middlewares/auth.middleware';
 import {asyncHandler} from '../../../utils/asyncHandler';
 import { getProfile } from '../controllers/user.controller';
+import { getAccessProfile } from '../../access-control/controllers/access-control.controller';
 
 const router: Router = Router();
 
@@ -19,6 +20,10 @@ router.get(
   authorizeRole('Administrateur Systeme et Reseau', 'Directeur'),
   getProfile
 );
-  
+
+// Profil d'accès module (#326) — volontairement SANS authorizeRole : chaque compte,
+// opérateur compris, doit pouvoir charger la navigation à laquelle il a droit.
+router.get('/access-profile', authenticateToken, getAccessProfile);
+
 
 export default router;

--- a/src/module/auth/services/auth.service.ts
+++ b/src/module/auth/services/auth.service.ts
@@ -20,6 +20,7 @@ import {
 
 import { sendPasswordResetEmail } from "./password-reset-email.service";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import { authorizationRole, normalizeAssignedRoles } from "../domain/roles";
 
 export const registerUser = async (data: CreateUserDTO) => {
   // 🔐 Hash du mot de passe
@@ -72,8 +73,17 @@ export const loginUser = async (
     throw new ApiError(401, "AUTH_INVALID", invalidMsg);
   }
 
+  const assignedRoles = normalizeAssignedRoles(user.role, user.roles);
+  const effectiveRole = authorizationRole(user.role, assignedRoles);
   const token = jwt.sign(
-    { id: user.id, username: user.username, email: user.email, role: user.role },
+    {
+      id: user.id,
+      username: user.username,
+      email: user.email,
+      role: effectiveRole,
+      primary_role: user.role,
+      roles: assignedRoles,
+    },
     process.env.JWT_SECRET as string,
     { expiresIn: "1d" }
   );
@@ -88,7 +98,14 @@ export const loginUser = async (
 
   return {
     token,
-    user: { id: user.id, username: user.username, email: user.email, role: user.role },
+    user: {
+      id: user.id,
+      username: user.username,
+      email: user.email,
+      role: effectiveRole,
+      primary_role: user.role,
+      roles: assignedRoles,
+    },
   };
 };
 

--- a/src/module/auth/validators/user.validator.ts
+++ b/src/module/auth/validators/user.validator.ts
@@ -1,15 +1,8 @@
 import { z } from "zod";
 import { isoDate, strictEmail, strongPassword, trimString } from "./_helpers";
+import { PRIMARY_USER_ROLES } from "../domain/roles";
 
-export const roles = [
-  "Directeur",
-  "Employee",
-  "Administrateur Systeme et Reseau",
-  "Responsable Qualité",
-  "Secretaire",
-  "Responsable Programmation",
-  "Responsable RH",
-] as const;
+export const roles = PRIMARY_USER_ROLES;
 
 const genders = ["Male", "Female"] as const;
 const statuses = ["Active", "Inactive", "Suspended"] as const;

--- a/src/module/client/client.permissions.ts
+++ b/src/module/client/client.permissions.ts
@@ -1,3 +1,5 @@
+import { effectiveRoleHasAny } from "../auth/domain/roles";
+
 /**
  * RBAC clients — rôles existants uniquement (contrainte users_role_check,
  * db/patches/20260710_hr_users_role_responsable_rh.sql). Deny by default :
@@ -19,7 +21,7 @@ export const CLIENT_WRITE_ROLES = [
 export const CLIENT_FINANCE_ROLES = CLIENT_WRITE_ROLES;
 
 export function canViewClientFinance(role: string | undefined | null): boolean {
-  return typeof role === "string" && (CLIENT_FINANCE_ROLES as readonly string[]).includes(role);
+  return effectiveRoleHasAny(role, CLIENT_FINANCE_ROLES);
 }
 
 /** Keep the last 4 characters visible: enough to recognise the account, useless to replay. */

--- a/src/module/facturation/domain/finance-policy.ts
+++ b/src/module/facturation/domain/finance-policy.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 
 import { HttpError } from "../../../utils/httpError";
+import { effectiveRoleHasAny } from "../../auth/domain/roles";
 
 export const FACTURE_WORKFLOW_STATUSES = [
   "DRAFT",
@@ -91,10 +92,8 @@ export function roleHasFinanceCapability(
   role: string | null | undefined,
   capability: FinanceCapability
 ): boolean {
-  if (typeof role !== "string" || !role.trim()) return false;
-  const normalizedRole = role.trim();
-  if (normalizedRole === ROLES.administrator) return true;
-  return CAPABILITY_ROLES[capability].has(normalizedRole);
+  if (effectiveRoleHasAny(role, [ROLES.administrator])) return true;
+  return effectiveRoleHasAny(role, [...CAPABILITY_ROLES[capability]]);
 }
 
 const FACTURE_TRANSITIONS: Readonly<Record<FactureWorkflowStatus, readonly FactureWorkflowStatus[]>> = {

--- a/src/module/import-assistant/domain/import-capabilities.ts
+++ b/src/module/import-assistant/domain/import-capabilities.ts
@@ -206,6 +206,24 @@ const MACHINE_FIELDS: ImportTargetField[] = [
   commonOptional.notes,
 ];
 
+const STOCK_INITIAL_FIELDS: ImportTargetField[] = [
+  field("article_legacy_code", "Code article CLIPPER", "text", {
+    required: true,
+    hint: "L’article doit avoir été importé ou rapproché avant son stock d’ouverture",
+  }),
+  field("quantity", "Quantité d’ouverture", "number", {
+    required: true,
+    hint: "Solde strictement positif au cut-off ; les soldes nuls ne créent aucun mouvement",
+  }),
+  field("magasin_code", "Code magasin CERP", "text", { required: true }),
+  field("emplacement_code", "Code emplacement CERP", "text", { required: true }),
+  field("cutoff_date", "Date de cut-off", "date", { required: true }),
+  field("unite", "Unité CERP", "text", {
+    hint: "Laisser vide pour utiliser l’unité déjà définie sur l’article",
+  }),
+  field("notes", "Justification et provenance", "text", { sensitive: true }),
+];
+
 export const IMPORT_CAPABILITIES: ImportEntityCapability[] = [
   { entity_type: "CLIENT", label: "1A — Clients (création)", order: 10, confirm_enabled: true, unavailable_reason: null, fields: CLIENT_FIELDS, decisions: [DECISIONS["DEC-04"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
   { entity_type: "CLIENT_ENRICHISSEMENT", label: "1B — Clients (compléter les fiches)", order: 11, confirm_enabled: true, unavailable_reason: null, fields: CLIENT_ENRICHISSEMENT_FIELDS, decisions: [DECISIONS["DEC-04"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
@@ -214,7 +232,7 @@ export const IMPORT_CAPABILITIES: ImportEntityCapability[] = [
   { entity_type: "FOURNISSEUR_COMMANDE", label: "3 — Commandes fournisseurs ouvertes", order: 30, confirm_enabled: true, unavailable_reason: null, fields: FOURNISSEUR_COMMANDE_FIELDS, decisions: [DECISIONS["DEC-03"], DECISIONS["DEC-14"], DECISIONS["DEC-15"], DECISIONS["DEC-17"]] },
   { entity_type: "ARTICLE", label: "4 — Articles et matières achetés", order: 40, confirm_enabled: true, unavailable_reason: null, fields: ARTICLE_FIELDS, decisions: [DECISIONS["DEC-01"], DECISIONS["DEC-14"], DECISIONS["DEC-15"], DECISIONS["DEC-16"]] },
   { entity_type: "MACHINE", label: "5 — Machines CNC", order: 50, confirm_enabled: true, unavailable_reason: null, fields: MACHINE_FIELDS, decisions: [DECISIONS["DEC-07"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
-  { entity_type: "STOCK_INITIAL", label: "6 — Stock d’ouverture", order: 60, confirm_enabled: false, unavailable_reason: "Le stock doit passer par un inventaire ou des mouvements d’ouverture contrôlés ; les magasins, emplacements et le cut-off doivent être renseignés.", fields: [], decisions: [DECISIONS["DEC-05"], DECISIONS["DEC-06"], DECISIONS["DEC-15"], DECISIONS["DEC-16"]] },
+  { entity_type: "STOCK_INITIAL", label: "6 — Stock d’ouverture", order: 60, confirm_enabled: true, unavailable_reason: null, fields: STOCK_INITIAL_FIELDS, decisions: [DECISIONS["DEC-05"], DECISIONS["DEC-06"], DECISIONS["DEC-15"], DECISIONS["DEC-16"]] },
   { entity_type: "BL_HISTORIQUE", label: "7 — BL historiques", order: 70, confirm_enabled: false, unavailable_reason: "Le sort des BL ouverts et historiques doit être décidé avant toute écriture.", fields: [], decisions: [DECISIONS["DEC-13"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },
   { entity_type: "EMPLOYE", label: "8 — Salariés", order: 80, confirm_enabled: false, unavailable_reason: "L’import RH reste fermé tant que le périmètre, les correspondances utilisateurs et la rétention ne sont pas documentés.", fields: [], decisions: [DECISIONS["DEC-09"], DECISIONS["DEC-12"], DECISIONS["DEC-15"]] },
   { entity_type: "PIECE_TECHNIQUE", label: "9 — Pièces techniques (dernière étape)", order: 90, confirm_enabled: true, unavailable_reason: null, fields: PIECE_FIELDS, decisions: [DECISIONS["DEC-02"], DECISIONS["DEC-14"], DECISIONS["DEC-15"]] },

--- a/src/module/import-assistant/domain/import-normalization.ts
+++ b/src/module/import-assistant/domain/import-normalization.ts
@@ -51,6 +51,28 @@ const fournisseurCommandeImportSchema = createCommandeSchema.shape.body
   })
   .strict();
 
+const stockInitialImportSchema = z
+  .object({
+    article_legacy_code: z.string().trim().min(1, "Code article CLIPPER requis").max(200),
+    quantity: z.number().positive("La quantité d’ouverture doit être strictement positive").max(1_000_000_000_000),
+    magasin_code: z.string().trim().min(1, "Code magasin CERP requis").max(80),
+    emplacement_code: z.string().trim().min(1, "Code emplacement CERP requis").max(80),
+    cutoff_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date de cut-off attendue au format AAAA-MM-JJ"),
+    unite: z.string().trim().min(1).max(30).optional(),
+    notes: z.string().trim().min(1).max(2_000).optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const parsed = new Date(`${value.cutoff_date}T00:00:00Z`);
+    if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value.cutoff_date) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "La date de cut-off est invalide.",
+        path: ["cutoff_date"],
+      });
+    }
+  });
+
 function hasOwn(record: Record<string, unknown>, key: string) {
   return Object.prototype.hasOwnProperty.call(record, key);
 }
@@ -156,6 +178,8 @@ function entitySchema(entityType: ImportEntityType): { schema: ZodTypeAny; wrapp
       return { schema: createPieceTechniqueSchema, wrapped: true };
     case "MACHINE":
       return { schema: createMachineSchema, wrapped: true };
+    case "STOCK_INITIAL":
+      return { schema: stockInitialImportSchema, wrapped: false };
     default:
       return null;
   }

--- a/src/module/import-assistant/services/import-assistant.service.ts
+++ b/src/module/import-assistant/services/import-assistant.service.ts
@@ -1,6 +1,7 @@
 import crypto from "node:crypto";
 
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import { resolveStockOpeningReferencesSVC } from "../../stock/services/stock.service";
 import { HttpError } from "../../../utils/httpError";
 import { getImportCapability, IMPORT_CAPABILITIES } from "../domain/import-capabilities";
 import { importRowDedupeKeys, normalizeImportRow, validateMapping } from "../domain/import-normalization";
@@ -189,6 +190,40 @@ export async function previewImportBatch(params: {
       legacy_keys: supplierLegacyKeys,
     })
     : new Map();
+  const stockArticleLegacyKeys = batch.entity_type === "STOCK_INITIAL"
+    ? normalized
+      .map((row) => row.result.normalized_data?.article_legacy_code)
+      .filter((value): value is string => typeof value === "string" && value.length > 0)
+    : [];
+  const stockArticleCrosswalk = stockArticleLegacyKeys.length > 0
+    ? await repo.repoFindCrosswalks({
+      source_system: batch.source_system,
+      entity_type: "ARTICLE",
+      legacy_keys: stockArticleLegacyKeys,
+    })
+    : new Map();
+  const stockOpeningReferences = batch.entity_type === "STOCK_INITIAL"
+    ? await resolveStockOpeningReferencesSVC(normalized.flatMap(({ stored, result }) => {
+      const data = result.normalized_data;
+      const articleLegacyCode = data?.article_legacy_code;
+      const magasinCode = data?.magasin_code;
+      const emplacementCode = data?.emplacement_code;
+      const article = typeof articleLegacyCode === "string"
+        ? stockArticleCrosswalk.get(articleLegacyCode)
+        : null;
+      if (
+        !article
+        || typeof magasinCode !== "string"
+        || typeof emplacementCode !== "string"
+      ) return [];
+      return [{
+        key: stored.id,
+        article_id: article.id,
+        magasin_code: magasinCode,
+        emplacement_code: emplacementCode,
+      }];
+    }))
+    : new Map();
   const dedupeEntity = batch.entity_type === "CLIENT_ENRICHISSEMENT"
     ? "CLIENT"
     : batch.entity_type;
@@ -315,6 +350,59 @@ export async function previewImportBatch(params: {
         issues: [],
         target_id: supplier.id,
         target_code: supplier.code,
+      };
+    }
+    if (batch.entity_type === "STOCK_INITIAL") {
+      const articleLegacyCode = result.normalized_data.article_legacy_code;
+      const article = typeof articleLegacyCode === "string"
+        ? stockArticleCrosswalk.get(articleLegacyCode)
+        : null;
+      if (!article) {
+        return {
+          id: stored.id,
+          legacy_key: result.legacy_key,
+          normalized_data: result.normalized_data,
+          status: "BLOCKED",
+          action: "SKIP",
+          issues: [{
+            code: "ARTICLE_CROSSWALK_MISSING",
+            message: "L’article CLIPPER doit être importé ou rapproché avant son stock d’ouverture.",
+            field: "article_legacy_code",
+          }],
+          target_id: null,
+          target_code: null,
+        };
+      }
+      const reference = stockOpeningReferences.get(stored.id);
+      if (!reference || reference.issue || !reference.magasin_id || !reference.emplacement_id) {
+        return {
+          id: stored.id,
+          legacy_key: result.legacy_key,
+          normalized_data: result.normalized_data,
+          status: "BLOCKED",
+          action: "SKIP",
+          issues: [{
+            code: reference?.issue?.code ?? "STOCK_REFERENCE_UNRESOLVED",
+            message: reference?.issue?.message ?? "Le magasin ou l’emplacement CERP n’a pas pu être validé.",
+            field: reference?.issue?.code.includes("MAGASIN")
+              ? "magasin_code"
+              : reference?.issue?.code.includes("EMPLACEMENT")
+                ? "emplacement_code"
+                : "article_legacy_code",
+          }],
+          target_id: null,
+          target_code: null,
+        };
+      }
+      return {
+        id: stored.id,
+        legacy_key: result.legacy_key,
+        normalized_data: result.normalized_data,
+        status: "VALID",
+        action: "CREATE",
+        issues: [],
+        target_id: article.id,
+        target_code: article.code,
       };
     }
     const duplicate = strongDedupe.get(result.legacy_key);

--- a/src/module/import-assistant/services/import-targets.service.ts
+++ b/src/module/import-assistant/services/import-targets.service.ts
@@ -19,8 +19,16 @@ import { createPieceTechniqueSVC } from "../../pieces-techniques/services/pieces
 import type { CreatePieceTechniqueBodyDTO } from "../../pieces-techniques/validators/pieces-techniques.validators";
 import { svcCreateMachine } from "../../production/services/production.service";
 import type { CreateMachineBodyDTO } from "../../production/validators/production.validators";
-import { createStockArticleSVC } from "../../stock/services/stock.service";
-import type { CreateArticleBodyDTO } from "../../stock/validators/stock.validators";
+import {
+  createStockArticleSVC,
+  createStockMovementSVC,
+  postStockMovementSVC,
+  resolveStockOpeningReferencesSVC,
+} from "../../stock/services/stock.service";
+import type {
+  CreateArticleBodyDTO,
+  CreateMovementBodyDTO,
+} from "../../stock/validators/stock.validators";
 import { HttpError } from "../../../utils/httpError";
 import type {
   ImportAuditContext,
@@ -131,6 +139,78 @@ export async function createImportTarget(params: {
         false
       );
       return { id: result.id, code: result.code };
+    }
+    case "STOCK_INITIAL": {
+      if (!params.parent_target_id) {
+        throw new HttpError(
+          409,
+          "IMPORT_ARTICLE_TARGET_MISSING",
+          "L’article CERP du stock d’ouverture est introuvable."
+        );
+      }
+      const data = params.normalized_data as {
+        article_legacy_code: string;
+        quantity: number;
+        magasin_code: string;
+        emplacement_code: string;
+        cutoff_date: string;
+        unite?: string;
+        notes?: string;
+      };
+      const references = await resolveStockOpeningReferencesSVC([{
+        key: "stock-opening",
+        article_id: params.parent_target_id,
+        magasin_code: data.magasin_code,
+        emplacement_code: data.emplacement_code,
+      }]);
+      const reference = references.get("stock-opening");
+      if (!reference || reference.issue || !reference.magasin_id || !reference.emplacement_id) {
+        throw new HttpError(
+          409,
+          reference?.issue?.code ?? "STOCK_REFERENCE_UNRESOLVED",
+          reference?.issue?.message ?? "Le magasin ou l’emplacement CERP n’a pas pu être validé."
+        );
+      }
+
+      const provenance = [
+        `Migration CLIPPER — stock d’ouverture au ${data.cutoff_date}.`,
+        "Solde reconstitué : entrées + retours − sorties ; mouvements annulés ignorés.",
+        `Article source : ${data.article_legacy_code}.`,
+        data.notes,
+      ].filter(Boolean).join(" ");
+      const movementBody: CreateMovementBodyDTO = {
+        movement_type: "ADJUSTMENT",
+        effective_at: `${data.cutoff_date}T23:59:59Z`,
+        source_document_type: "CLIPPER_STOCK_OPENING",
+        source_document_id: `${data.article_legacy_code}|${data.cutoff_date}`.slice(0, 120),
+        reason_code: "OPENING_BALANCE",
+        notes: provenance,
+        idempotency_key: `${params.idempotency_key}:create`,
+        lines: [{
+          article_id: params.parent_target_id,
+          qty: data.quantity,
+          ...(data.unite ? { unite: data.unite } : {}),
+          dst_magasin_id: reference.magasin_id,
+          dst_emplacement_id: reference.emplacement_id,
+          direction: "IN",
+          note: `Stock d’ouverture CLIPPER — ${data.cutoff_date}`,
+        }],
+      };
+      const draft = await createStockMovementSVC(movementBody, params.audit);
+      const posted = await postStockMovementSVC(
+        draft.movement.id,
+        {},
+        params.audit,
+        `${params.idempotency_key}:post`
+      );
+      if (!posted) {
+        throw new HttpError(
+          409,
+          "STOCK_OPENING_POST_FAILED",
+          "Le mouvement d’ouverture n’a pas pu être comptabilisé."
+        );
+      }
+      return { id: posted.movement.id, code: posted.movement.movement_no };
     }
     case "PIECE_TECHNIQUE": {
       const result = await createPieceTechniqueSVC(

--- a/src/module/planning/domain/planning-rbac.ts
+++ b/src/module/planning/domain/planning-rbac.ts
@@ -1,3 +1,5 @@
+import { effectiveRoleParts } from "../../auth/domain/roles";
+
 function normalizeRole(role: string | null | undefined): string {
   return String(role ?? "")
     .trim()
@@ -34,9 +36,9 @@ const FORCE_OVERLAP_ROLES = new Set([
 ]);
 
 export function roleHasPlanningAccess(role: string | null | undefined): boolean {
-  return PLANNING_ACCESS_ROLES.has(normalizeRole(role));
+  return effectiveRoleParts(role).some((part) => PLANNING_ACCESS_ROLES.has(normalizeRole(part)));
 }
 
 export function roleCanForcePlanningOverlap(role: string | null | undefined): boolean {
-  return FORCE_OVERLAP_ROLES.has(normalizeRole(role));
+  return effectiveRoleParts(role).some((part) => FORCE_OVERLAP_ROLES.has(normalizeRole(part)));
 }

--- a/src/module/production/repository/station.repository.ts
+++ b/src/module/production/repository/station.repository.ts
@@ -720,7 +720,19 @@ export async function repoFindSessionByToken(token: string): Promise<
 > {
   const { rows } = await pool.query(
     `SELECT ${SESSION_COLUMNS},
-            u.username, u.name, u.surname, u.role
+            u.username,
+            u.name,
+            u.surname,
+            concat_ws(
+              ' | ',
+              u.role,
+              (
+                SELECT string_agg(ura.role_key, ' | ' ORDER BY ura.role_key)
+                FROM public.user_role_assignments ura
+                WHERE ura.user_id = u.id
+                  AND ura.role_key <> u.role
+              )
+            ) AS role
        FROM public.operator_device_sessions s
        JOIN public.users u ON u.id = s.user_id
       WHERE s.session_token_hash = $1`,

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -109,6 +109,21 @@ export type AuditContext = {
   client_session_id: string | null;
 };
 
+export type StockOpeningReferenceInput = {
+  key: string;
+  article_id: string;
+  magasin_code: string;
+  emplacement_code: string;
+};
+
+export type StockOpeningReferenceResolution = {
+  key: string;
+  article_id: string;
+  magasin_id: string | null;
+  emplacement_id: number | null;
+  issue: { code: string; message: string } | null;
+};
+
 export type StockCommandType =
   | "MOVEMENT_CREATE"
   | "MOVEMENT_POST"
@@ -1774,6 +1789,127 @@ export async function getEmplacementMapping(
     location_type: row.location_type,
     restrictions: row.restrictions ?? {},
   };
+}
+
+export async function repoResolveStockOpeningReferences(
+  inputs: StockOpeningReferenceInput[]
+): Promise<Map<string, StockOpeningReferenceResolution>> {
+  if (inputs.length === 0) return new Map();
+
+  const result = await db.query<{
+    key: string;
+    article_id: string;
+    article_found: boolean;
+    article_active: boolean | null;
+    stock_managed: boolean | null;
+    magasin_id: string | null;
+    magasin_matches: number | string | null;
+    magasin_active: boolean | null;
+    emplacement_id: number | null;
+    emplacement_matches: number | string | null;
+    emplacement_active: boolean | null;
+    allow_inbound: boolean | null;
+    location_id: string | null;
+    warehouse_id: string | null;
+  }>(
+    `
+      WITH requested AS (
+        SELECT
+          item.key,
+          item.article_id::uuid AS article_id,
+          item.magasin_code,
+          item.emplacement_code
+        FROM jsonb_to_recordset($1::jsonb) AS item(
+          key text,
+          article_id text,
+          magasin_code text,
+          emplacement_code text
+        )
+      )
+      SELECT
+        requested.key,
+        requested.article_id::text AS article_id,
+        (article.id IS NOT NULL) AS article_found,
+        article.is_active AS article_active,
+        article.stock_managed,
+        magasin.id::text AS magasin_id,
+        COALESCE(magasin.matches, 0) AS magasin_matches,
+        magasin.is_active AS magasin_active,
+        emplacement.id::int AS emplacement_id,
+        COALESCE(emplacement.matches, 0) AS emplacement_matches,
+        emplacement.is_active AS emplacement_active,
+        emplacement.allow_inbound,
+        emplacement.location_id::text AS location_id,
+        location.warehouse_id::text AS warehouse_id
+      FROM requested
+      LEFT JOIN public.articles article ON article.id = requested.article_id
+      LEFT JOIN LATERAL (
+        SELECT
+          candidate.id,
+          COALESCE(candidate.is_active, candidate.actif, false) AS is_active,
+          count(*) OVER ()::int AS matches
+        FROM public.magasins candidate
+        WHERE upper(btrim(COALESCE(candidate.code, candidate.code_magasin))) =
+              upper(btrim(requested.magasin_code))
+        ORDER BY candidate.id
+        LIMIT 1
+      ) magasin ON true
+      LEFT JOIN LATERAL (
+        SELECT
+          candidate.id,
+          candidate.is_active,
+          candidate.allow_inbound,
+          candidate.location_id,
+          count(*) OVER ()::int AS matches
+        FROM public.emplacements candidate
+        WHERE candidate.magasin_id = magasin.id
+          AND upper(btrim(candidate.code)) = upper(btrim(requested.emplacement_code))
+        ORDER BY candidate.id
+        LIMIT 1
+      ) emplacement ON true
+      LEFT JOIN public.locations location ON location.id = emplacement.location_id
+      ORDER BY requested.key
+    `,
+    [JSON.stringify(inputs)]
+  );
+
+  return new Map(result.rows.map((row) => {
+    let issue: StockOpeningReferenceResolution["issue"] = null;
+    const magasinMatches = Number(row.magasin_matches ?? 0);
+    const emplacementMatches = Number(row.emplacement_matches ?? 0);
+
+    if (!row.article_found) {
+      issue = { code: "STOCK_ARTICLE_NOT_FOUND", message: "L’article CERP rapproché est introuvable." };
+    } else if (!row.article_active) {
+      issue = { code: "STOCK_ARTICLE_INACTIVE", message: "L’article CERP rapproché est inactif." };
+    } else if (!row.stock_managed) {
+      issue = { code: "STOCK_ARTICLE_NOT_MANAGED", message: "L’article CERP n’est pas géré en stock." };
+    } else if (magasinMatches === 0) {
+      issue = { code: "STOCK_MAGASIN_NOT_FOUND", message: "Le code magasin CERP est introuvable." };
+    } else if (magasinMatches > 1) {
+      issue = { code: "STOCK_MAGASIN_AMBIGUOUS", message: "Le code magasin CERP correspond à plusieurs magasins." };
+    } else if (!row.magasin_active) {
+      issue = { code: "STOCK_MAGASIN_INACTIVE", message: "Le magasin CERP est inactif." };
+    } else if (emplacementMatches === 0) {
+      issue = { code: "STOCK_EMPLACEMENT_NOT_FOUND", message: "Le code emplacement CERP est introuvable dans ce magasin." };
+    } else if (emplacementMatches > 1) {
+      issue = { code: "STOCK_EMPLACEMENT_AMBIGUOUS", message: "Le code emplacement CERP correspond à plusieurs emplacements." };
+    } else if (!row.emplacement_active) {
+      issue = { code: "STOCK_EMPLACEMENT_INACTIVE", message: "L’emplacement CERP est inactif." };
+    } else if (!row.allow_inbound) {
+      issue = { code: "STOCK_EMPLACEMENT_INBOUND_REFUSED", message: "L’emplacement CERP refuse les entrées de stock." };
+    } else if (!row.location_id || !row.warehouse_id) {
+      issue = { code: "STOCK_EMPLACEMENT_NOT_MAPPED", message: "L’emplacement CERP n’est pas relié au référentiel physique de stock." };
+    }
+
+    return [row.key, {
+      key: row.key,
+      article_id: row.article_id,
+      magasin_id: row.magasin_id,
+      emplacement_id: row.emplacement_id,
+      issue,
+    }];
+  }));
 }
 
 export async function ensureStockLevel(

--- a/src/module/stock/services/stock.service.ts
+++ b/src/module/stock/services/stock.service.ts
@@ -65,6 +65,10 @@ import type {
   UpdateMagasinBodyDTO,
 } from "../validators/stock.validators";
 import type { AuditContext } from "../repository/stock.repository";
+import type {
+  StockOpeningReferenceInput,
+  StockOpeningReferenceResolution,
+} from "../repository/stock.repository";
 import {
   repoCloseInventorySession,
   repoStartInventorySession,
@@ -118,6 +122,7 @@ import {
   repoUpdateArticle,
   repoArchiveArticle,
   repoReactivateArticle,
+  repoResolveStockOpeningReferences,
   repoListArticleVersions,
   repoListArticleWhereUsed,
   repoUpdateEmplacement,
@@ -129,6 +134,12 @@ import {
   repoDeactivateMagasin,
   repoActivateMagasin,
 } from "../repository/stock.repository";
+
+export async function resolveStockOpeningReferencesSVC(
+  inputs: StockOpeningReferenceInput[]
+): Promise<Map<string, StockOpeningReferenceResolution>> {
+  return repoResolveStockOpeningReferences(inputs);
+}
 
 export async function listStockInventorySessionsSVC(filters: ListInventorySessionsQueryDTO) {
   return repoListInventorySessions(filters);

--- a/src/module/stock/stock-article.permissions.ts
+++ b/src/module/stock/stock-article.permissions.ts
@@ -1,3 +1,5 @@
+import { effectiveRoleHasAny } from "../auth/domain/roles";
+
 export const ARTICLE_WRITE_ROLES = [
   "Directeur",
   "Administrateur Systeme et Reseau",
@@ -20,5 +22,5 @@ export const ARTICLE_COST_ROLES = [
 ] as const;
 
 export function canViewArticleCosts(role: string | null | undefined): boolean {
-  return typeof role === "string" && (ARTICLE_COST_ROLES as readonly string[]).includes(role);
+  return effectiveRoleHasAny(role, ARTICLE_COST_ROLES);
 }

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -49,6 +49,8 @@ import projectOfficeRoutes from "../module/project-office/routes/project-office.
 import gammesRoutes from "../module/gammes/routes/gammes.routes"
 import pieceTechniqueVersionsRoutes from "../module/gammes/routes/piece-technique-versions.routes"
 import importAssistantRoutes from "../module/import-assistant/routes/import-assistant.routes"
+import accessControlRoutes from "../module/access-control/routes/access-control.routes"
+import { moduleAccessGate } from "../module/access-control/middlewares/module-access-gate"
 const router = Router()
 
 // --- Routes publiques (avant authentification) ---
@@ -58,6 +60,11 @@ router.use("/auth", authRoutes)
 // définie APRÈS cette ligne exige un JWT valide. Les modules conservent en plus leurs
 // gardes authorizeRole plus fines. Tout nouveau module est protégé par défaut.
 router.use(authenticateToken)
+
+// 🔒 Tour de contrôle des accès (#326) : filtrage module par compte, monté avant tout
+// module métier pour qu'aucune surface future n'y échappe par oubli. Il n'ôte aucun
+// garde existant — les authorizeRole des modules s'appliquent toujours ensuite.
+router.use(moduleAccessGate)
 
 router.use("/outils", outilRoutes)
 router.use("/banking-info", bankingInfoRoutes)  
@@ -71,6 +78,9 @@ router.use("/pieces-techniques", piecesTechniquesRoutes)
 router.use("/piece-technique-versions", pieceTechniqueVersionsRoutes) // GPAO B2.2 — gammes par version
 router.use("/gammes", gammesRoutes)                                   // GPAO B2.2 — gammes + opérations
 router.use("/audit-logs", auditLogsRoutes)
+// Tour de contrôle des accès (#326) montée AVANT le routeur admin historique : elle
+// est gardée par le statut superadmin et ne doit pas hériter de son authorizeRole.
+router.use("/admin/access", accessControlRoutes);
 router.use("/admin", adminRoutes);
 router.use("/affaires", affaireRoutes);
 router.use("/devis", devisRoutes);


### PR DESCRIPTION
## Portée de la promotion dev → main

- import contrôlé du stock initial (#197) ;
- conservation des quantités à six décimales (#198) ;
- RBAC multi-rôles et journaux append-only ;
- tour de contrôle serveur, gate d’accès module et scripts SQL #326.

## Validation locale sur l’état promu

- `npm run test:run` : vert, 2 719 tests ;
- `npm run build` : vert.

## Déploiement coordonné

Déployer le backend avant ou avec le frontend. Le patch SQL est additif et le gate reste ouvert uniquement si son infrastructure est absente. Avant activation production : sauvegarde, preflight, patch, verify, seed KEENAN gardé, puis health checks.

Closes #197
Closes #198

## Summary by Sourcery

Introduce controlled initial stock import with six-decimal stock precision, implement multi-role RBAC with append-only role and module access journals, and add a server-side access control tower gating module access per user while exposing read-only superadmin status and new admin role management endpoints.

New Features:
- Enable CLIPPER initial stock import through the import assistant, resolving CERP articles, magasins and emplacements and creating audited stock opening movements via the standard stock services.
- Introduce per-module access control with a catalog of ERP modules, user-specific overrides, a global module access gate middleware, and a dedicated /admin/access supervision API protected by a superadmin flag.
- Support multiple roles per user with a roles catalog, many-to-many role assignments, and exposure of assigned/effective roles in authentication flows and admin user screens.

Bug Fixes:
- Align stock movement line quantity precision with the stock ledger at six decimals and reconcile bounded rounding residues from historical CLIPPER opening movements.
- Prevent ERP lockout by failing open when access-control infrastructure is absent and by making the administration module intrinsically non-restrictable.

Enhancements:
- Relax ERP user profile requirements so accounts can be provisioned without full HR data, while keeping uniqueness constraints on sensitive identifiers.
- Extend RBAC checks across finance, planning, client, article and machine domains to honor composite effective roles derived from multiple assigned responsibilities.
- Expose richer admin user metadata (multi-roles, profile completeness, read-only superadmin flag) and add listing of assignable roles via the admin API.
- Improve auth tokens and profile responses to carry primary and assigned roles, and adjust existing middleware and policies to operate on multi-part effective roles.

Documentation:
- Document the multi-role RBAC database patches and operational validation steps, the access control tower design and rollout order, and the controlled CLIPPER stock import process with precision considerations and recovery steps.

Tests:
- Add comprehensive tests for CLIPPER initial stock normalization and capabilities, the multi-role RBAC model and derived permissions, the module access gate behavior, and the access control tower APIs and migration guards.