### PR TITLE
feat(ged): noyau documentaire, coffre sécurisé et versionnement (ADR-0037)

### DIFF
--- a/db/patches/20260727_ged_core.sql
+++ b/db/patches/20260727_ged_core.sql
@@ -1,0 +1,545 @@
+-- GED centrale CERP — noyau documentaire (ADR-0037).
+--
+-- STRICTEMENT ADDITIF : aucune table existante n'est modifiée, renommée ou vidée.
+-- Aucun module actuel n'est rebranché par ce patch. Les mini-GED historiques
+-- (pieces_techniques_documents, quality_documents, stock_documents, ...) continuent
+-- de fonctionner exactement comme avant.
+--
+-- Le rattachement des tables historiques au noyau fera l'objet de patches ultérieurs,
+-- un par module, chacun réversible.
+
+BEGIN;
+
+/* ------------------------------------------------------------------ */
+/* 1) Référentiel des classes documentaires                            */
+/* ------------------------------------------------------------------ */
+
+CREATE TABLE IF NOT EXISTS public.ged_document_classes (
+  class_key            text PRIMARY KEY,
+  domain               text NOT NULL,
+  label                text NOT NULL,
+  nature               text NOT NULL CHECK (nature IN ('SOURCE', 'GENERATED', 'EVIDENCE', 'REPRESENTATION')),
+  allowed_mime_types   text[] NOT NULL,
+  allowed_extensions   text[] NOT NULL,
+  max_size_bytes       bigint NOT NULL CHECK (max_size_bytes > 0),
+  approvals_required   smallint NOT NULL DEFAULT 0 CHECK (approvals_required BETWEEN 0 AND 2),
+  retention_months     integer NULL CHECK (retention_months IS NULL OR retention_months > 0),
+  hold_on_publish      boolean NOT NULL DEFAULT false,
+  is_active            boolean NOT NULL DEFAULT true,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  updated_at           timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.ged_document_classes IS
+  'Unité de configuration de la GED : formats, taille, circuit d''approbation, rétention. Ajouter un type de document = ajouter une classe, jamais un if dans un service.';
+
+/* ------------------------------------------------------------------ */
+/* 2) Blobs — contenu physique adressé par empreinte                   */
+/* ------------------------------------------------------------------ */
+
+CREATE TABLE IF NOT EXISTS public.ged_blobs (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  sha256         text NOT NULL UNIQUE CHECK (sha256 ~ '^[a-f0-9]{64}$'),
+  size_bytes     bigint NOT NULL CHECK (size_bytes > 0),
+  mime_type      text NOT NULL,
+  storage_key    text NOT NULL UNIQUE,
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  created_by     integer NULL REFERENCES public.users(id) ON DELETE SET NULL
+);
+
+COMMENT ON COLUMN public.ged_blobs.storage_key IS
+  'Clé interne opaque relative à la racine du coffre. N''est JAMAIS retournée par l''API.';
+
+/* Un blob n'est jamais modifié : son identité EST son contenu. */
+CREATE OR REPLACE FUNCTION public.fn_ged_blob_immutable()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.sha256 IS DISTINCT FROM OLD.sha256
+     OR NEW.storage_key IS DISTINCT FROM OLD.storage_key
+     OR NEW.size_bytes IS DISTINCT FROM OLD.size_bytes THEN
+    RAISE EXCEPTION 'GED_BLOB_IMMUTABLE: le contenu d''un blob ne peut pas être modifié (id=%)', OLD.id
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ged_blob_immutable ON public.ged_blobs;
+CREATE TRIGGER trg_ged_blob_immutable
+  BEFORE UPDATE ON public.ged_blobs
+  FOR EACH ROW EXECUTE FUNCTION public.fn_ged_blob_immutable();
+
+/* ------------------------------------------------------------------ */
+/* 3) Documents — identité logique                                     */
+/* ------------------------------------------------------------------ */
+
+CREATE TABLE IF NOT EXISTS public.ged_documents (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code              text NOT NULL UNIQUE,
+  class_key         text NOT NULL REFERENCES public.ged_document_classes(class_key) ON UPDATE CASCADE,
+  title             text NOT NULL CHECK (length(btrim(title)) > 0),
+  description       text NULL,
+  current_version_id uuid NULL,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  created_by        integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  archived_at       timestamptz NULL,
+  archived_by       integer NULL REFERENCES public.users(id) ON DELETE SET NULL
+);
+
+COMMENT ON COLUMN public.ged_documents.code IS
+  'Code documentaire immuable, jamais réutilisé même après archivage.';
+COMMENT ON COLUMN public.ged_documents.archived_at IS
+  'Suppression LOGIQUE uniquement. Aucune route ne supprime physiquement un document.';
+
+CREATE INDEX IF NOT EXISTS idx_ged_documents_class ON public.ged_documents(class_key)
+  WHERE archived_at IS NULL;
+
+-- Recherche plein texte : `pg_trgm` a été écarté par 20260726_pieces_techniques_landing_146.
+-- Un index fonctionnel sur le titre normalisé couvre le préfixe sans nouvelle extension.
+CREATE INDEX IF NOT EXISTS idx_ged_documents_title_lower
+  ON public.ged_documents(lower(title) text_pattern_ops);
+
+/* Le code documentaire ne change jamais. */
+CREATE OR REPLACE FUNCTION public.fn_ged_document_code_immutable()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.code IS DISTINCT FROM OLD.code THEN
+    RAISE EXCEPTION 'GED_CODE_IMMUTABLE: le code documentaire est immuable (id=%)', OLD.id
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ged_document_code_immutable ON public.ged_documents;
+CREATE TRIGGER trg_ged_document_code_immutable
+  BEFORE UPDATE ON public.ged_documents
+  FOR EACH ROW EXECUTE FUNCTION public.fn_ged_document_code_immutable();
+
+/* ------------------------------------------------------------------ */
+/* 4) Versions — le cœur du versionnement                              */
+/* ------------------------------------------------------------------ */
+
+CREATE TABLE IF NOT EXISTS public.ged_document_versions (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id       uuid NOT NULL REFERENCES public.ged_documents(id) ON DELETE RESTRICT,
+  version_number    integer NOT NULL CHECK (version_number > 0),
+  status            text NOT NULL DEFAULT 'BROUILLON'
+                      CHECK (status IN ('BROUILLON', 'EN_REVUE', 'APPROUVE', 'APPLICABLE', 'OBSOLETE')),
+  blob_id           uuid NOT NULL REFERENCES public.ged_blobs(id) ON DELETE RESTRICT,
+  original_name     text NOT NULL,
+  change_reason     text NULL,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  created_by        integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  submitted_at      timestamptz NULL,
+  submitted_by      integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  approved_at       timestamptz NULL,
+  approved_by       integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  published_at      timestamptz NULL,
+  obsoleted_at      timestamptz NULL,
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (document_id, version_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ged_versions_document ON public.ged_document_versions(document_id, version_number DESC);
+CREATE INDEX IF NOT EXISTS idx_ged_versions_blob ON public.ged_document_versions(blob_id);
+
+/* Une seule version APPLICABLE par document, garantie par index partiel. */
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ged_versions_single_applicable
+  ON public.ged_document_versions(document_id)
+  WHERE status = 'APPLICABLE';
+
+ALTER TABLE public.ged_documents
+  DROP CONSTRAINT IF EXISTS ged_documents_current_version_fkey;
+ALTER TABLE public.ged_documents
+  ADD CONSTRAINT ged_documents_current_version_fkey
+  FOREIGN KEY (current_version_id) REFERENCES public.ged_document_versions(id) ON DELETE SET NULL;
+
+/*
+ * Immutabilité d'une version approuvée ou applicable.
+ * Cette règle vit en base et non dans un service : elle doit survivre à un script,
+ * à un correctif manuel et à une future route mal écrite.
+ * Seules les transitions de statut prévues et l'horodatage restent permis.
+ */
+CREATE OR REPLACE FUNCTION public.fn_ged_version_immutable()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF OLD.status IN ('APPROUVE', 'APPLICABLE', 'OBSOLETE') THEN
+    IF NEW.blob_id        IS DISTINCT FROM OLD.blob_id
+       OR NEW.version_number IS DISTINCT FROM OLD.version_number
+       OR NEW.document_id IS DISTINCT FROM OLD.document_id
+       OR NEW.original_name IS DISTINCT FROM OLD.original_name
+       OR NEW.change_reason IS DISTINCT FROM OLD.change_reason
+       OR NEW.created_by   IS DISTINCT FROM OLD.created_by
+       OR NEW.approved_by  IS DISTINCT FROM OLD.approved_by THEN
+      RAISE EXCEPTION 'GED_VERSION_IMMUTABLE: une version % ne peut plus être modifiée (id=%)', OLD.status, OLD.id
+        USING ERRCODE = 'check_violation';
+    END IF;
+  END IF;
+
+  IF OLD.status = 'OBSOLETE' AND NEW.status <> 'OBSOLETE' THEN
+    RAISE EXCEPTION 'GED_VERSION_IMMUTABLE: une version OBSOLETE ne peut pas être réactivée (id=%)', OLD.id
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ged_version_immutable ON public.ged_document_versions;
+CREATE TRIGGER trg_ged_version_immutable
+  BEFORE UPDATE ON public.ged_document_versions
+  FOR EACH ROW EXECUTE FUNCTION public.fn_ged_version_immutable();
+
+/* Séparation des tâches : le déposant n'approuve pas. */
+CREATE OR REPLACE FUNCTION public.fn_ged_version_separation_of_duties()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.approved_by IS NOT NULL
+     AND NEW.created_by IS NOT NULL
+     AND NEW.approved_by = NEW.created_by THEN
+    RAISE EXCEPTION 'GED_APPROVAL_SELF: le déposant d''une version ne peut pas l''approuver (version=%)', NEW.id
+      USING ERRCODE = 'check_violation';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ged_version_separation_of_duties ON public.ged_document_versions;
+CREATE TRIGGER trg_ged_version_separation_of_duties
+  BEFORE INSERT OR UPDATE ON public.ged_document_versions
+  FOR EACH ROW EXECUTE FUNCTION public.fn_ged_version_separation_of_duties();
+
+/* ------------------------------------------------------------------ */
+/* 5) Liens métier — l'arborescence est calculée, jamais sur disque    */
+/* ------------------------------------------------------------------ */
+
+CREATE TABLE IF NOT EXISTS public.ged_document_links (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id  uuid NOT NULL REFERENCES public.ged_documents(id) ON DELETE CASCADE,
+  entity_type  text NOT NULL,
+  entity_id    text NOT NULL,
+  link_role    text NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  created_by   integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  UNIQUE (document_id, entity_type, entity_id, link_role)
+);
+
+COMMENT ON TABLE public.ged_document_links IS
+  'Un document peut apparaître à plusieurs endroits de l''arbre métier sans être dupliqué.';
+
+CREATE INDEX IF NOT EXISTS idx_ged_links_entity ON public.ged_document_links(entity_type, entity_id);
+
+/* ------------------------------------------------------------------ */
+/* 6) Relations entre documents                                        */
+/* ------------------------------------------------------------------ */
+
+CREATE TABLE IF NOT EXISTS public.ged_document_relations (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  source_document_id uuid NOT NULL REFERENCES public.ged_documents(id) ON DELETE CASCADE,
+  target_document_id uuid NOT NULL REFERENCES public.ged_documents(id) ON DELETE CASCADE,
+  relation_type  text NOT NULL CHECK (relation_type IN ('DERIVED_FROM', 'REPLACES', 'ANNEX_OF', 'GENERATED_FROM')),
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  created_by     integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  CHECK (source_document_id <> target_document_id),
+  UNIQUE (source_document_id, target_document_id, relation_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_ged_relations_target ON public.ged_document_relations(target_document_id, relation_type);
+
+/* ------------------------------------------------------------------ */
+/* 7) Approbations                                                     */
+/* ------------------------------------------------------------------ */
+
+CREATE TABLE IF NOT EXISTS public.ged_approvals (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  version_id   uuid NOT NULL REFERENCES public.ged_document_versions(id) ON DELETE CASCADE,
+  decision     text NOT NULL CHECK (decision IN ('SUBMITTED', 'APPROVED', 'REJECTED')),
+  comment      text NULL,
+  decided_at   timestamptz NOT NULL DEFAULT now(),
+  decided_by   integer NULL REFERENCES public.users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ged_approvals_version ON public.ged_approvals(version_id, decided_at DESC);
+
+/* ------------------------------------------------------------------ */
+/* 8) Consignation (check-out / check-in)                              */
+/* ------------------------------------------------------------------ */
+
+CREATE TABLE IF NOT EXISTS public.ged_checkouts (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id   uuid NOT NULL REFERENCES public.ged_documents(id) ON DELETE CASCADE,
+  held_by       integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  reason        text NOT NULL CHECK (length(btrim(reason)) > 0),
+  checked_out_at timestamptz NOT NULL DEFAULT now(),
+  expires_at    timestamptz NOT NULL,
+  released_at   timestamptz NULL,
+  release_kind  text NULL CHECK (release_kind IN ('CHECKIN', 'ABANDON', 'EXPIRED')),
+  CHECK (expires_at > checked_out_at)
+);
+
+/* Un seul verrou actif par document. */
+CREATE UNIQUE INDEX IF NOT EXISTS uq_ged_checkout_active
+  ON public.ged_checkouts(document_id)
+  WHERE released_at IS NULL;
+
+/* ------------------------------------------------------------------ */
+/* 9) Rétention et gels                                                */
+/* ------------------------------------------------------------------ */
+
+CREATE TABLE IF NOT EXISTS public.ged_retention_holds (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  document_id  uuid NOT NULL REFERENCES public.ged_documents(id) ON DELETE RESTRICT,
+  hold_type    text NOT NULL CHECK (hold_type IN ('QUALITE', 'LEGAL', 'RETENTION')),
+  reason       text NOT NULL CHECK (length(btrim(reason)) > 0),
+  placed_at    timestamptz NOT NULL DEFAULT now(),
+  placed_by    integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  released_at  timestamptz NULL,
+  released_by  integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  release_reason text NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ged_holds_document ON public.ged_retention_holds(document_id)
+  WHERE released_at IS NULL;
+
+/* Un gel actif bloque l'archivage, y compris administrateur. */
+CREATE OR REPLACE FUNCTION public.fn_ged_document_hold_guard()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.archived_at IS NOT NULL AND OLD.archived_at IS NULL THEN
+    IF EXISTS (
+      SELECT 1 FROM public.ged_retention_holds h
+      WHERE h.document_id = NEW.id AND h.released_at IS NULL
+    ) THEN
+      RAISE EXCEPTION 'GED_RETENTION_HOLD: document sous gel, archivage refusé (id=%)', NEW.id
+        USING ERRCODE = 'check_violation';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ged_document_hold_guard ON public.ged_documents;
+CREATE TRIGGER trg_ged_document_hold_guard
+  BEFORE UPDATE ON public.ged_documents
+  FOR EACH ROW EXECUTE FUNCTION public.fn_ged_document_hold_guard();
+
+/* ------------------------------------------------------------------ */
+/* 10) Manifestes figés (OF, as-built)                                 */
+/* ------------------------------------------------------------------ */
+
+CREATE TABLE IF NOT EXISTS public.ged_snapshot_manifests (
+  id             uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope          text NOT NULL CHECK (scope IN ('OF', 'ASBUILT', 'BL_PACK')),
+  scope_id       text NOT NULL,
+  manifest_sha256 text NOT NULL CHECK (manifest_sha256 ~ '^[a-f0-9]{64}$'),
+  frozen_at      timestamptz NOT NULL DEFAULT now(),
+  frozen_by      integer NULL REFERENCES public.users(id) ON DELETE SET NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_ged_manifests_scope ON public.ged_snapshot_manifests(scope, scope_id, frozen_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.ged_snapshot_manifest_entries (
+  id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  manifest_id  uuid NOT NULL REFERENCES public.ged_snapshot_manifests(id) ON DELETE RESTRICT,
+  entry_role   text NOT NULL,
+  version_id   uuid NOT NULL REFERENCES public.ged_document_versions(id) ON DELETE RESTRICT,
+  sha256       text NOT NULL CHECK (sha256 ~ '^[a-f0-9]{64}$'),
+  UNIQUE (manifest_id, entry_role, version_id)
+);
+
+/*
+ * Un manifeste est figé. Un OF relancé produit un NOUVEAU manifeste, jamais une
+ * modification de l'ancien. Même motif que fn_prevent_of_technical_snapshot_mutation.
+ */
+CREATE OR REPLACE FUNCTION public.fn_ged_manifest_immutable()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'GED_MANIFEST_IMMUTABLE: un manifeste figé ne peut être ni modifié ni supprimé'
+    USING ERRCODE = 'check_violation';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ged_manifest_immutable ON public.ged_snapshot_manifests;
+CREATE TRIGGER trg_ged_manifest_immutable
+  BEFORE UPDATE OR DELETE ON public.ged_snapshot_manifests
+  FOR EACH ROW EXECUTE FUNCTION public.fn_ged_manifest_immutable();
+
+DROP TRIGGER IF EXISTS trg_ged_manifest_entries_immutable ON public.ged_snapshot_manifest_entries;
+CREATE TRIGGER trg_ged_manifest_entries_immutable
+  BEFORE UPDATE OR DELETE ON public.ged_snapshot_manifest_entries
+  FOR EACH ROW EXECUTE FUNCTION public.fn_ged_manifest_immutable();
+
+/* ------------------------------------------------------------------ */
+/* 11) Sessions de dépôt (staging -> quarantaine -> publication)       */
+/* ------------------------------------------------------------------ */
+
+CREATE TABLE IF NOT EXISTS public.ged_upload_sessions (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  class_key     text NOT NULL REFERENCES public.ged_document_classes(class_key) ON UPDATE CASCADE,
+  document_id   uuid NULL REFERENCES public.ged_documents(id) ON DELETE CASCADE,
+  title         text NULL,
+  status        text NOT NULL DEFAULT 'OPEN'
+                  CHECK (status IN ('OPEN', 'QUARANTINE', 'READY', 'PUBLISHED', 'EXPIRED', 'REJECTED')),
+  staging_key   text NULL,
+  sha256        text NULL CHECK (sha256 IS NULL OR sha256 ~ '^[a-f0-9]{64}$'),
+  size_bytes    bigint NULL,
+  mime_type     text NULL,
+  original_name text NULL,
+  reject_reason text NULL,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  created_by    integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  expires_at    timestamptz NOT NULL,
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ged_upload_sessions_open
+  ON public.ged_upload_sessions(created_by, status)
+  WHERE status IN ('OPEN', 'QUARANTINE', 'READY');
+
+/* ------------------------------------------------------------------ */
+/* 12) Journal d'accès — append-only                                   */
+/* ------------------------------------------------------------------ */
+
+CREATE TABLE IF NOT EXISTS public.ged_access_events (
+  id           bigserial PRIMARY KEY,
+  document_id  uuid NULL REFERENCES public.ged_documents(id) ON DELETE SET NULL,
+  version_id   uuid NULL REFERENCES public.ged_document_versions(id) ON DELETE SET NULL,
+  event_type   text NOT NULL CHECK (event_type IN (
+                 'UPLOAD', 'READ', 'DOWNLOAD', 'SUBMIT', 'APPROVE', 'REJECT',
+                 'PUBLISH', 'OBSOLETE', 'ARCHIVE', 'CHECKOUT', 'CHECKIN',
+                 'HOLD_PLACED', 'HOLD_RELEASED', 'INTEGRITY_FAILURE')),
+  actor_id     integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  occurred_at  timestamptz NOT NULL DEFAULT now(),
+  details      jsonb NULL
+);
+
+COMMENT ON COLUMN public.ged_access_events.details IS
+  'Ne doit contenir NI chemin, NI secret, NI contenu binaire, NI donnée personnelle superflue.';
+
+CREATE INDEX IF NOT EXISTS idx_ged_access_events_document
+  ON public.ged_access_events(document_id, occurred_at DESC);
+
+CREATE OR REPLACE FUNCTION public.fn_ged_access_events_append_only()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'GED_AUDIT_APPEND_ONLY: le journal d''accès GED est en écriture seule'
+    USING ERRCODE = 'check_violation';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_ged_access_events_append_only ON public.ged_access_events;
+CREATE TRIGGER trg_ged_access_events_append_only
+  BEFORE UPDATE OR DELETE ON public.ged_access_events
+  FOR EACH ROW EXECUTE FUNCTION public.fn_ged_access_events_append_only();
+
+/* ------------------------------------------------------------------ */
+/* 13) Amorce du référentiel de classes                                */
+/* ------------------------------------------------------------------ */
+
+INSERT INTO public.ged_document_classes
+  (class_key, domain, label, nature, allowed_mime_types, allowed_extensions, max_size_bytes, approvals_required, retention_months, hold_on_publish)
+VALUES
+  ('PLAN_CLIENT', 'TECHNIQUE', 'Plan client', 'SOURCE',
+   ARRAY['application/pdf','image/tiff'], ARRAY['.pdf','.tif','.tiff'], 104857600, 1, 120, false),
+  ('MODELE_3D', 'TECHNIQUE', 'Modèle 3D / CAO', 'SOURCE',
+   ARRAY['application/octet-stream','model/step','application/step'], ARRAY['.step','.stp','.iges','.igs','.stl'], 524288000, 1, 120, false),
+  ('GAMME_DOC', 'TECHNIQUE', 'Gamme et instructions', 'SOURCE',
+   ARRAY['application/pdf','application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+   ARRAY['.pdf','.docx'], 26214400, 1, 120, false),
+  ('MASTERCAM', 'TECHNIQUE', 'Fichier Mastercam', 'SOURCE',
+   ARRAY['application/octet-stream'], ARRAY['.mcam','.mcx'], 524288000, 1, 120, false),
+  ('PROGRAMME_CN', 'TECHNIQUE', 'Programme CN', 'SOURCE',
+   ARRAY['text/plain','application/octet-stream'], ARRAY['.nc','.tap','.h','.mpf','.txt'], 52428800, 2, 120, false),
+  ('FICHE_REGLAGE', 'TECHNIQUE', 'Fiche de réglage', 'SOURCE',
+   ARRAY['application/pdf','application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+   ARRAY['.pdf','.xlsx'], 26214400, 1, 120, false),
+  ('MACHINE_MANUEL', 'TECHNIQUE', 'Manuel machine', 'SOURCE',
+   ARRAY['application/pdf'], ARRAY['.pdf'], 209715200, 0, 60, false),
+  ('PLAN_CONTROLE', 'QUALITE', 'Plan de contrôle', 'SOURCE',
+   ARRAY['application/pdf','application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+   ARRAY['.pdf','.xlsx'], 26214400, 2, 120, false),
+  ('RELEVE_CONTROLE', 'QUALITE', 'Relevé de contrôle', 'EVIDENCE',
+   ARRAY['application/pdf','application/vnd.openxmlformats-officedocument.spreadsheetml.sheet','text/csv'],
+   ARRAY['.pdf','.xlsx','.csv'], 26214400, 0, 120, true),
+  ('NC_CONSTAT', 'QUALITE', 'Constat de non-conformité', 'EVIDENCE',
+   ARRAY['application/pdf','image/jpeg','image/png'], ARRAY['.pdf','.jpg','.jpeg','.png'], 52428800, 0, 120, true),
+  ('DEROGATION', 'QUALITE', 'Dérogation', 'EVIDENCE',
+   ARRAY['application/pdf'], ARRAY['.pdf'], 26214400, 2, 120, true),
+  ('CERTIF_ETALONNAGE', 'QUALITE', 'Certificat d''étalonnage', 'EVIDENCE',
+   ARRAY['application/pdf'], ARRAY['.pdf'], 26214400, 0, 120, true),
+  ('CERTIF_MATIERE', 'ACHATS', 'Certificat matière', 'EVIDENCE',
+   ARRAY['application/pdf'], ARRAY['.pdf'], 26214400, 0, 360, true),
+  ('FRN_HOMOLOGATION', 'ACHATS', 'Homologation fournisseur', 'EVIDENCE',
+   ARRAY['application/pdf'], ARRAY['.pdf'], 26214400, 1, 60, false),
+  ('RECEPTION_DOC', 'ACHATS', 'Document de réception', 'EVIDENCE',
+   ARRAY['application/pdf','image/jpeg','image/png'], ARRAY['.pdf','.jpg','.jpeg','.png'], 26214400, 0, 120, false),
+  ('CONTRAT', 'COMMERCIAL', 'Contrat', 'SOURCE',
+   ARRAY['application/pdf'], ARRAY['.pdf'], 52428800, 2, 120, false),
+  ('AFFAIRE_DOC', 'COMMERCIAL', 'Document d''affaire', 'SOURCE',
+   ARRAY['application/pdf','application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'],
+   ARRAY['.pdf','.docx','.xlsx'], 52428800, 0, 120, false),
+  ('OF_DOSSIER', 'PRODUCTION', 'Dossier atelier', 'GENERATED',
+   ARRAY['application/pdf'], ARRAY['.pdf'], 52428800, 0, 120, false),
+  ('OF_PHOTO', 'PRODUCTION', 'Photo / aléa de production', 'EVIDENCE',
+   ARRAY['image/jpeg','image/png','image/webp'], ARRAY['.jpg','.jpeg','.png','.webp'], 26214400, 0, 120, false),
+  ('DOC_INTERNE', 'GOUVERNANCE', 'Document interne', 'SOURCE',
+   ARRAY['application/pdf','application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+         'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+         'application/vnd.openxmlformats-officedocument.presentationml.presentation'],
+   ARRAY['.pdf','.docx','.xlsx','.pptx'], 52428800, 0, 60, false),
+  ('PROCEDURE', 'GOUVERNANCE', 'Procédure / SMSI', 'SOURCE',
+   ARRAY['application/pdf','application/vnd.openxmlformats-officedocument.wordprocessingml.document'],
+   ARRAY['.pdf','.docx'], 26214400, 2, 120, false)
+ON CONFLICT (class_key) DO NOTHING;
+
+/* ------------------------------------------------------------------ */
+/* 14) Droits du rôle applicatif                                       */
+/* ------------------------------------------------------------------ */
+
+-- Les patches sont appliqués par `postgres`, l'API tourne avec `cerp_app`.
+-- PostgreSQL ne propage pas les droits vers les nouvelles tables : sans ce bloc,
+-- toute route GED répondrait 500 après migration.
+-- Le journal d'accès reste volontairement sans UPDATE ni DELETE : le trigger
+-- append-only est une seconde barrière, pas la première.
+DO $grants$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT ON TABLE public.ged_document_classes TO cerp_app;
+
+    GRANT SELECT, INSERT, UPDATE ON TABLE public.ged_documents TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE ON TABLE public.ged_document_versions TO cerp_app;
+    GRANT SELECT, INSERT ON TABLE public.ged_blobs TO cerp_app;
+    GRANT SELECT, INSERT, DELETE ON TABLE public.ged_document_links TO cerp_app;
+    GRANT SELECT, INSERT, DELETE ON TABLE public.ged_document_relations TO cerp_app;
+    GRANT SELECT, INSERT ON TABLE public.ged_approvals TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE ON TABLE public.ged_checkouts TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE ON TABLE public.ged_retention_holds TO cerp_app;
+    GRANT SELECT, INSERT ON TABLE public.ged_snapshot_manifests TO cerp_app;
+    GRANT SELECT, INSERT ON TABLE public.ged_snapshot_manifest_entries TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.ged_upload_sessions TO cerp_app;
+
+    GRANT SELECT, INSERT ON TABLE public.ged_access_events TO cerp_app;
+    GRANT USAGE, SELECT ON SEQUENCE public.ged_access_events_id_seq TO cerp_app;
+  END IF;
+END
+$grants$;
+
+COMMIT;

--- a/db/patches/support/20260727_ged_core.preflight.sql
+++ b/db/patches/support/20260727_ged_core.preflight.sql
@@ -1,0 +1,25 @@
+-- Preflight 20260727_ged_core — LECTURE SEULE.
+-- Confirme que le patch est bien additif et qu'aucune table GED ne préexiste.
+
+SELECT
+  current_database()                                            AS database,
+  to_regclass('public.users') IS NOT NULL                       AS users_present,
+
+  -- Aucune table du noyau ne doit préexister (sinon : patch déjà appliqué).
+  to_regclass('public.ged_documents') IS NULL                   AS ged_documents_absent,
+  to_regclass('public.ged_document_versions') IS NULL            AS ged_versions_absent,
+  to_regclass('public.ged_blobs') IS NULL                        AS ged_blobs_absent,
+  to_regclass('public.ged_access_events') IS NULL                AS ged_audit_absent,
+
+  -- Preuve de non-régression : les mini-GED historiques restent intactes.
+  to_regclass('public.pieces_techniques_documents') IS NOT NULL  AS legacy_pt_docs_present,
+  to_regclass('public.quality_documents') IS NOT NULL            AS legacy_quality_docs_present,
+  to_regclass('public.project_evidence_files') IS NOT NULL       AS legacy_po_files_present,
+  (SELECT COUNT(*) FROM public.pieces_techniques_documents)      AS legacy_pt_docs_rows,
+  (SELECT COUNT(*) FROM public.quality_documents)                AS legacy_quality_docs_rows,
+
+  -- Le rôle applicatif doit exister pour que les GRANT s'appliquent.
+  EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app')     AS cerp_app_role_present,
+
+  -- gen_random_uuid() est requis (pgcrypto ou PostgreSQL >= 13 natif).
+  (SELECT COUNT(*) FROM pg_proc WHERE proname = 'gen_random_uuid') > 0 AS gen_random_uuid_available;

--- a/db/patches/support/20260727_ged_core.rollback.sql
+++ b/db/patches/support/20260727_ged_core.rollback.sql
@@ -1,0 +1,51 @@
+-- Rollback 20260727_ged_core.
+--
+-- Sûr tant qu'aucun document réel n'a été déposé : le patch étant strictement
+-- additif, retirer ses tables ne touche AUCUNE donnée existante de l'ERP.
+--
+-- ARRÊT OBLIGATOIRE si des documents ont été déposés : les blobs correspondants
+-- vivent dans le coffre et seraient orphelins. Dans ce cas, ne pas exécuter ce
+-- script — restaurer le couple base + volume depuis la sauvegarde.
+
+DO $guard$
+DECLARE
+  doc_count integer := 0;
+BEGIN
+  IF to_regclass('public.ged_documents') IS NOT NULL THEN
+    EXECUTE 'SELECT COUNT(*) FROM public.ged_documents' INTO doc_count;
+    IF doc_count > 0 THEN
+      RAISE EXCEPTION
+        'ROLLBACK REFUSÉ : % document(s) présent(s) dans la GED. Des blobs existent dans le coffre. Restaurer base + volume depuis la sauvegarde au lieu de supprimer les tables.',
+        doc_count;
+    END IF;
+  END IF;
+END
+$guard$;
+
+BEGIN;
+
+DROP TABLE IF EXISTS public.ged_snapshot_manifest_entries CASCADE;
+DROP TABLE IF EXISTS public.ged_snapshot_manifests CASCADE;
+DROP TABLE IF EXISTS public.ged_access_events CASCADE;
+DROP TABLE IF EXISTS public.ged_upload_sessions CASCADE;
+DROP TABLE IF EXISTS public.ged_retention_holds CASCADE;
+DROP TABLE IF EXISTS public.ged_checkouts CASCADE;
+DROP TABLE IF EXISTS public.ged_approvals CASCADE;
+DROP TABLE IF EXISTS public.ged_document_relations CASCADE;
+DROP TABLE IF EXISTS public.ged_document_links CASCADE;
+
+ALTER TABLE IF EXISTS public.ged_documents DROP CONSTRAINT IF EXISTS ged_documents_current_version_fkey;
+DROP TABLE IF EXISTS public.ged_document_versions CASCADE;
+DROP TABLE IF EXISTS public.ged_documents CASCADE;
+DROP TABLE IF EXISTS public.ged_blobs CASCADE;
+DROP TABLE IF EXISTS public.ged_document_classes CASCADE;
+
+DROP FUNCTION IF EXISTS public.fn_ged_blob_immutable();
+DROP FUNCTION IF EXISTS public.fn_ged_document_code_immutable();
+DROP FUNCTION IF EXISTS public.fn_ged_version_immutable();
+DROP FUNCTION IF EXISTS public.fn_ged_version_separation_of_duties();
+DROP FUNCTION IF EXISTS public.fn_ged_document_hold_guard();
+DROP FUNCTION IF EXISTS public.fn_ged_manifest_immutable();
+DROP FUNCTION IF EXISTS public.fn_ged_access_events_append_only();
+
+COMMIT;

--- a/db/patches/support/20260727_ged_core.verify.sql
+++ b/db/patches/support/20260727_ged_core.verify.sql
@@ -1,0 +1,65 @@
+-- Verify 20260727_ged_core — LECTURE SEULE.
+-- Toutes les colonnes doivent être `true` (ou le compte attendu) après application.
+
+SELECT
+  current_database() AS database,
+
+  -- 1) Les 13 tables du noyau existent.
+  to_regclass('public.ged_document_classes') IS NOT NULL          AS t_classes,
+  to_regclass('public.ged_blobs') IS NOT NULL                      AS t_blobs,
+  to_regclass('public.ged_documents') IS NOT NULL                  AS t_documents,
+  to_regclass('public.ged_document_versions') IS NOT NULL          AS t_versions,
+  to_regclass('public.ged_document_links') IS NOT NULL             AS t_links,
+  to_regclass('public.ged_document_relations') IS NOT NULL         AS t_relations,
+  to_regclass('public.ged_approvals') IS NOT NULL                  AS t_approvals,
+  to_regclass('public.ged_checkouts') IS NOT NULL                  AS t_checkouts,
+  to_regclass('public.ged_retention_holds') IS NOT NULL            AS t_holds,
+  to_regclass('public.ged_snapshot_manifests') IS NOT NULL         AS t_manifests,
+  to_regclass('public.ged_snapshot_manifest_entries') IS NOT NULL  AS t_manifest_entries,
+  to_regclass('public.ged_upload_sessions') IS NOT NULL            AS t_upload_sessions,
+  to_regclass('public.ged_access_events') IS NOT NULL              AS t_access_events,
+
+  -- 2) Le référentiel de classes est amorcé.
+  (SELECT COUNT(*) FROM public.ged_document_classes WHERE is_active) AS active_classes,
+
+  -- 3) Les garde-fous structurels sont en place.
+  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_ged_version_immutable')            AS trg_version_immutable,
+  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_ged_version_separation_of_duties') AS trg_separation_of_duties,
+  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_ged_manifest_immutable')           AS trg_manifest_immutable,
+  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_ged_access_events_append_only')    AS trg_audit_append_only,
+  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_ged_document_hold_guard')          AS trg_hold_guard,
+  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_ged_blob_immutable')               AS trg_blob_immutable,
+  EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'uq_ged_versions_single_applicable') AS idx_single_applicable,
+  EXISTS (SELECT 1 FROM pg_indexes WHERE indexname = 'uq_ged_checkout_active')            AS idx_single_checkout,
+
+  -- 4) Droits du rôle applicatif : présents, et journal non modifiable.
+  (
+    NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app')
+    OR (
+      has_table_privilege('cerp_app', 'public.ged_documents', 'SELECT,INSERT,UPDATE')
+      AND has_table_privilege('cerp_app', 'public.ged_document_versions', 'SELECT,INSERT,UPDATE')
+      AND has_table_privilege('cerp_app', 'public.ged_blobs', 'SELECT,INSERT')
+      AND has_table_privilege('cerp_app', 'public.ged_access_events', 'SELECT,INSERT')
+      AND NOT has_table_privilege('cerp_app', 'public.ged_access_events', 'UPDATE')
+      AND NOT has_table_privilege('cerp_app', 'public.ged_access_events', 'DELETE')
+      AND NOT has_table_privilege('cerp_app', 'public.ged_snapshot_manifests', 'UPDATE')
+      AND NOT has_table_privilege('cerp_app', 'public.ged_snapshot_manifests', 'DELETE')
+    )
+  ) AS grants_ok,
+
+  -- 5) NON-RÉGRESSION : les mini-GED historiques sont intactes et non vidées.
+  to_regclass('public.pieces_techniques_documents') IS NOT NULL AS legacy_pt_docs_present,
+  to_regclass('public.quality_documents') IS NOT NULL           AS legacy_quality_docs_present,
+  to_regclass('public.project_evidence_files') IS NOT NULL      AS legacy_po_files_present,
+  to_regclass('public.of_technical_snapshots') IS NOT NULL      AS legacy_of_snapshots_present,
+  (SELECT COUNT(*) FROM public.pieces_techniques_documents)     AS legacy_pt_docs_rows,
+  (SELECT COUNT(*) FROM public.quality_documents)               AS legacy_quality_docs_rows,
+
+  -- 6) Aucune colonne n'a été ajoutée aux tables historiques par ce patch.
+  NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name IN ('pieces_techniques_documents', 'quality_documents', 'stock_documents',
+                         'fournisseur_documents', 'metrologie_certificats', 'project_evidence_files')
+      AND column_name = 'ged_document_version_id'
+  ) AS legacy_tables_untouched;

--- a/src/__tests__/ged-core.domain.test.ts
+++ b/src/__tests__/ged-core.domain.test.ts
@@ -1,0 +1,259 @@
+// GED centrale CERP (ADR-0037) — tests du domaine.
+//
+// Ces tests ne touchent ni la base ni le disque : ils valident les règles qui
+// doivent tenir quel que soit l'environnement.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  assertAcceptedFile,
+  fileKindForExtension,
+  hasValidSignature,
+  isAlwaysRejectedExtension,
+} from "../module/ged/domain/ged-content";
+import {
+  assertDistinctApprover,
+  assertGedCapability,
+  assertVersionMutable,
+  assertVersionTransition,
+  formatDocumentCode,
+  isVersionFrozen,
+  roleHasGedCapability,
+  sanitizeOriginalName,
+} from "../module/ged/domain/ged-policy";
+import { storageKeyForSha256 } from "../module/ged/services/ged-vault.service";
+import { HttpError } from "../utils/httpError";
+
+const PDF_HEADER = Buffer.from([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x37]);
+const PNG_HEADER = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+const WINDOWS_EXE = Buffer.from([0x4d, 0x5a, 0x90, 0x00, 0x03, 0x00, 0x00, 0x00]);
+
+const PDF_RULES = {
+  class_key: "PLAN_CLIENT",
+  allowed_mime_types: ["application/pdf"],
+  allowed_extensions: [".pdf"],
+  max_size_bytes: 1024 * 1024,
+};
+
+function pdfFile(overrides: Record<string, unknown> = {}) {
+  return {
+    buffer: PDF_HEADER,
+    originalname: "plan.pdf",
+    mimetype: "application/pdf",
+    size: PDF_HEADER.byteLength,
+    ...overrides,
+  };
+}
+
+describe("GED — capacités RBAC", () => {
+  it("refuse par défaut un rôle inconnu ou vide", () => {
+    expect(roleHasGedCapability(null, "read")).toBe(false);
+    expect(roleHasGedCapability("", "read")).toBe(false);
+    expect(roleHasGedCapability("stagiaire-externe", "read")).toBe(false);
+  });
+
+  it("accorde la lecture aux rôles opérationnels", () => {
+    expect(roleHasGedCapability("Methodes", "read")).toBe(true);
+    expect(roleHasGedCapability("Qualite", "read")).toBe(true);
+    expect(roleHasGedCapability("Atelier", "read")).toBe(true);
+  });
+
+  it("garde l'approbation et la publication étroites", () => {
+    expect(roleHasGedCapability("Atelier", "approve")).toBe(false);
+    expect(roleHasGedCapability("Magasinier", "publish")).toBe(false);
+    expect(roleHasGedCapability("Responsable Qualite", "approve")).toBe(true);
+    expect(roleHasGedCapability("Administrateur", "publish")).toBe(true);
+  });
+
+  it("distingue export et download", () => {
+    expect(roleHasGedCapability("Magasinier", "download")).toBe(true);
+    expect(roleHasGedCapability("Magasinier", "export")).toBe(false);
+  });
+
+  it("lève une 403 explicite", () => {
+    expect(() => assertGedCapability("Atelier", "approve")).toThrowError(HttpError);
+    try {
+      assertGedCapability("Atelier", "approve");
+    } catch (err) {
+      expect((err as HttpError).status).toBe(403);
+      expect((err as HttpError).code).toBe("GED_CAPABILITY_REQUIRED");
+    }
+  });
+});
+
+describe("GED — cycle de vie", () => {
+  it("suit le chemin nominal", () => {
+    expect(() => assertVersionTransition("BROUILLON", "EN_REVUE")).not.toThrow();
+    expect(() => assertVersionTransition("EN_REVUE", "APPROUVE")).not.toThrow();
+    expect(() => assertVersionTransition("APPROUVE", "APPLICABLE")).not.toThrow();
+    expect(() => assertVersionTransition("APPLICABLE", "OBSOLETE")).not.toThrow();
+  });
+
+  it("interdit de rouvrir une version approuvée en brouillon", () => {
+    expect(() => assertVersionTransition("APPROUVE", "BROUILLON")).toThrowError(HttpError);
+  });
+
+  it("interdit toute sortie d'OBSOLETE", () => {
+    for (const target of ["BROUILLON", "EN_REVUE", "APPROUVE", "APPLICABLE"] as const) {
+      expect(() => assertVersionTransition("OBSOLETE", target)).toThrowError(HttpError);
+    }
+  });
+
+  it("gèle le contenu dès l'approbation", () => {
+    expect(isVersionFrozen("BROUILLON")).toBe(false);
+    expect(isVersionFrozen("EN_REVUE")).toBe(false);
+    expect(isVersionFrozen("APPROUVE")).toBe(true);
+    expect(isVersionFrozen("APPLICABLE")).toBe(true);
+    expect(() => assertVersionMutable("APPLICABLE")).toThrowError(HttpError);
+    expect(() => assertVersionMutable("BROUILLON")).not.toThrow();
+  });
+});
+
+describe("GED — séparation des tâches", () => {
+  it("refuse qu'un déposant approuve sa propre version", () => {
+    expect(() => assertDistinctApprover(42, 42)).toThrowError(HttpError);
+    try {
+      assertDistinctApprover(42, 42);
+    } catch (err) {
+      expect((err as HttpError).code).toBe("GED_APPROVAL_SELF");
+    }
+  });
+
+  it("accepte un approbateur distinct", () => {
+    expect(() => assertDistinctApprover(42, 7)).not.toThrow();
+    expect(() => assertDistinctApprover(null, 7)).not.toThrow();
+  });
+});
+
+describe("GED — codification", () => {
+  it("préfixe par domaine et pad sur 6 chiffres", () => {
+    expect(formatDocumentCode("TECHNIQUE", 1)).toBe("DT-000001");
+    expect(formatDocumentCode("QUALITE", 1234)).toBe("DQ-001234");
+    expect(formatDocumentCode("INCONNU", 9)).toBe("DX-000009");
+  });
+
+  it("refuse une séquence invalide", () => {
+    expect(() => formatDocumentCode("TECHNIQUE", 0)).toThrowError(HttpError);
+  });
+});
+
+describe("GED — assainissement des noms", () => {
+  it("neutralise une tentative de path traversal", () => {
+    expect(sanitizeOriginalName("../../etc/passwd")).toBe("passwd");
+    expect(sanitizeOriginalName("..\\..\\windows\\system32\\cmd.exe")).toBe("cmd.exe");
+  });
+
+  it("ne renvoie jamais une chaîne vide", () => {
+    expect(sanitizeOriginalName("")).toBe("document");
+    expect(sanitizeOriginalName(null)).toBe("document");
+    expect(sanitizeOriginalName("...")).toBe("document");
+  });
+
+  it("borne la longueur", () => {
+    expect(sanitizeOriginalName(`${"a".repeat(500)}.pdf`).length).toBeLessThanOrEqual(180);
+  });
+
+  it("retire les caractères de contrôle", () => {
+    const withControl = `plan${String.fromCharCode(0)}${String.fromCharCode(9)}.pdf`;
+    const result = sanitizeOriginalName(withControl);
+    expect(result).not.toContain(String.fromCharCode(0));
+    expect(result).not.toContain(String.fromCharCode(9));
+  });
+});
+
+describe("GED — contrôle de contenu", () => {
+  it("accepte un PDF cohérent", () => {
+    const accepted = assertAcceptedFile(pdfFile(), PDF_RULES);
+    expect(accepted.extension).toBe(".pdf");
+    expect(accepted.kind).toBe("pdf");
+  });
+
+  it("refuse un exécutable renommé en .pdf", () => {
+    try {
+      assertAcceptedFile(pdfFile({ buffer: WINDOWS_EXE, size: WINDOWS_EXE.byteLength }), PDF_RULES);
+      throw new Error("aurait dû être refusé");
+    } catch (err) {
+      expect((err as HttpError).status).toBe(415);
+      expect((err as HttpError).code).toBe("GED_FILE_SIGNATURE");
+    }
+  });
+
+  it("refuse une extension hors allowlist de classe", () => {
+    try {
+      assertAcceptedFile(pdfFile({ originalname: "photo.png", buffer: PNG_HEADER }), PDF_RULES);
+      throw new Error("aurait dû être refusé");
+    } catch (err) {
+      expect((err as HttpError).code).toBe("GED_FILE_TYPE");
+    }
+  });
+
+  it("refuse un MIME hors allowlist de classe", () => {
+    try {
+      assertAcceptedFile(pdfFile({ mimetype: "application/octet-stream" }), PDF_RULES);
+      throw new Error("aurait dû être refusé");
+    } catch (err) {
+      expect((err as HttpError).code).toBe("GED_FILE_TYPE");
+    }
+  });
+
+  it("refuse un fichier trop gros", () => {
+    try {
+      assertAcceptedFile(pdfFile({ size: PDF_RULES.max_size_bytes + 1 }), PDF_RULES);
+      throw new Error("aurait dû être refusé");
+    } catch (err) {
+      expect((err as HttpError).status).toBe(413);
+    }
+  });
+
+  it("refuse un fichier vide", () => {
+    try {
+      assertAcceptedFile(pdfFile({ buffer: Buffer.alloc(0), size: 0 }), PDF_RULES);
+      throw new Error("aurait dû être refusé");
+    } catch (err) {
+      expect((err as HttpError).status).toBe(400);
+    }
+  });
+
+  it("refuse les extensions dangereuses même si une classe les autorisait", () => {
+    for (const ext of [".exe", ".docm", ".svg", ".js", ".bat", ".jar"]) {
+      expect(isAlwaysRejectedExtension(ext)).toBe(true);
+    }
+    try {
+      assertAcceptedFile(pdfFile({ originalname: "macro.docm" }), {
+        ...PDF_RULES,
+        allowed_extensions: [".docm"],
+        allowed_mime_types: ["application/pdf"],
+      });
+      throw new Error("aurait dû être refusé");
+    } catch (err) {
+      expect((err as HttpError).code).toBe("GED_FILE_TYPE");
+    }
+  });
+
+  it("valide les signatures connues", () => {
+    expect(hasValidSignature(PDF_HEADER, "pdf")).toBe(true);
+    expect(hasValidSignature(PNG_HEADER, "png")).toBe(true);
+    expect(hasValidSignature(PNG_HEADER, "pdf")).toBe(false);
+    expect(hasValidSignature(WINDOWS_EXE, "binary")).toBe(false);
+    expect(hasValidSignature(Buffer.from("G01 X10 Y20", "utf8"), "text")).toBe(true);
+    expect(hasValidSignature(Buffer.from([0x47, 0x00, 0x30]), "text")).toBe(false);
+  });
+
+  it("reconnaît les extensions métier", () => {
+    expect(fileKindForExtension(".nc")).toBe("text");
+    expect(fileKindForExtension(".mcam")).toBe("binary");
+    expect(fileKindForExtension(".inconnu")).toBeNull();
+  });
+});
+
+describe("GED — clé de coffre", () => {
+  it("répartit par empreinte et n'expose aucune sémantique métier", () => {
+    const sha = "a".repeat(64);
+    expect(storageKeyForSha256(sha)).toBe(`vault/sha256/aa/aa/${sha}`);
+  });
+
+  it("refuse une empreinte invalide", () => {
+    expect(() => storageKeyForSha256("pas-une-empreinte")).toThrowError(HttpError);
+    expect(() => storageKeyForSha256("../../escape")).toThrowError(HttpError);
+  });
+});

--- a/src/__tests__/ged-core.routes.test.ts
+++ b/src/__tests__/ged-core.routes.test.ts
@@ -1,0 +1,278 @@
+// GED centrale CERP (ADR-0037) — tests de routes et de contrat.
+//
+// Deux garanties sont vérifiées ici et devront le rester :
+//   1. AUCUNE réponse ne contient de chemin physique.
+//   2. Un coffre indisponible produit un 503 explicite, jamais un repli local.
+
+import request from "supertest";
+import { EventEmitter } from "events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = {
+    on: emitter.on.bind(emitter),
+    query: mocks.poolQuery,
+    connect: mocks.poolConnect,
+  };
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; username: string; email: string; role: string }; headers: Record<string, unknown> },
+    _res: unknown,
+    next: () => void
+  ) => {
+    const roleHeader =
+      typeof req.headers["x-test-role"] === "string" ? (req.headers["x-test-role"] as string) : "administrateur";
+    req.user = { id: 1, username: "test-admin", email: "admin@example.test", role: roleHeader };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import app from "../config/app";
+
+const SHA = "b".repeat(64);
+const VAULT_PATH_MARKERS = [
+  "storage_path",
+  "storage_key",
+  "stored_name",
+  "/srv/cerp",
+  "/mnt/cerp-ged",
+  "/app/data",
+  "vault/sha256",
+];
+
+function assertNoPathLeak(payload: unknown) {
+  const serialized = JSON.stringify(payload ?? {});
+  for (const marker of VAULT_PATH_MARKERS) {
+    expect(serialized).not.toContain(marker);
+  }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.poolConnect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease });
+  delete process.env.CERP_GED_VAULT_ROOT;
+  process.env.CERP_GED_REQUIRE_SENTINEL = "false";
+});
+
+describe("GED — RBAC des routes", () => {
+  it("refuse la lecture à un rôle non habilité", async () => {
+    const res = await request(app).get("/api/v1/ged/classes").set("x-test-role", "stagiaire-externe");
+    expect(res.status).toBe(403);
+    expect(res.body?.code ?? res.body?.error?.code).toBeDefined();
+  });
+
+  it("refuse le dépôt à un rôle en lecture seule", async () => {
+    const res = await request(app)
+      .post("/api/v1/ged/documents")
+      .set("x-test-role", "Atelier")
+      .field("class_key", "PLAN_CLIENT")
+      .field("title", "Essai");
+    expect(res.status).toBe(403);
+  });
+
+  it("refuse l'approbation à un rôle atelier", async () => {
+    const res = await request(app)
+      .post(`/api/v1/ged/versions/${"1".repeat(8)}-1111-4111-8111-111111111111/approve`)
+      .set("x-test-role", "Atelier")
+      .send({});
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("GED — schéma absent", () => {
+  it("répond 503 GED_NOT_INSTALLED plutôt qu'un 500 opaque", async () => {
+    const undefinedTable = Object.assign(new Error('relation "ged_document_classes" does not exist'), {
+      code: "42P01",
+    });
+    mocks.poolQuery.mockRejectedValueOnce(undefinedTable);
+
+    const res = await request(app).get("/api/v1/ged/classes").set("x-test-role", "administrateur");
+    expect(res.status).toBe(503);
+    expect(JSON.stringify(res.body)).toContain("GED_NOT_INSTALLED");
+  });
+});
+
+describe("GED — coffre indisponible", () => {
+  it("refuse le dépôt en 503 et ne crée aucun répertoire de repli", async () => {
+    // CERP_GED_VAULT_ROOT volontairement absent : c'est exactement le scénario
+    // qui, ailleurs dans le code historique, produit un dossier local silencieux.
+    mocks.poolQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          class_key: "PLAN_CLIENT",
+          domain: "TECHNIQUE",
+          label: "Plan client",
+          nature: "SOURCE",
+          allowed_mime_types: ["application/pdf"],
+          allowed_extensions: [".pdf"],
+          max_size_bytes: "104857600",
+          approvals_required: 1,
+          retention_months: 120,
+          hold_on_publish: false,
+          is_active: true,
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .post("/api/v1/ged/documents")
+      .set("x-test-role", "administrateur")
+      .field("class_key", "PLAN_CLIENT")
+      .field("title", "Plan de contrôle initial")
+      .attach("file", Buffer.from("%PDF-1.7\nfake"), { filename: "plan.pdf", contentType: "application/pdf" });
+
+    expect(res.status).toBe(503);
+    expect(JSON.stringify(res.body)).toContain("GED_VAULT_UNAVAILABLE");
+  });
+});
+
+describe("GED — contrôle de contenu au niveau route", () => {
+  it("refuse un exécutable renommé en .pdf avant toute écriture", async () => {
+    mocks.poolQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          class_key: "PLAN_CLIENT",
+          domain: "TECHNIQUE",
+          label: "Plan client",
+          nature: "SOURCE",
+          allowed_mime_types: ["application/pdf"],
+          allowed_extensions: [".pdf"],
+          max_size_bytes: "104857600",
+          approvals_required: 1,
+          retention_months: 120,
+          hold_on_publish: false,
+          is_active: true,
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .post("/api/v1/ged/documents")
+      .set("x-test-role", "administrateur")
+      .field("class_key", "PLAN_CLIENT")
+      .field("title", "Faux plan")
+      .attach("file", Buffer.from([0x4d, 0x5a, 0x90, 0x00]), {
+        filename: "plan.pdf",
+        contentType: "application/pdf",
+      });
+
+    expect(res.status).toBe(415);
+    expect(JSON.stringify(res.body)).toContain("GED_FILE_SIGNATURE");
+  });
+});
+
+describe("GED — contrat : aucune fuite de chemin", () => {
+  it("ne renvoie aucun marqueur de chemin dans la liste des documents", async () => {
+    mocks.poolQuery
+      .mockResolvedValueOnce({ rows: [{ total: 1 }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "11111111-1111-4111-8111-111111111111",
+            code: "DT-000001",
+            class_key: "PLAN_CLIENT",
+            class_label: "Plan client",
+            domain: "TECHNIQUE",
+            title: "Plan 1234 indice B",
+            description: null,
+            current_version_number: 2,
+            current_version_status: "APPLICABLE",
+            versions_count: 2,
+            has_active_hold: false,
+            created_at: "2026-07-27T10:00:00.000Z",
+            updated_at: "2026-07-27T11:00:00.000Z",
+            archived_at: null,
+          },
+        ],
+      });
+
+    const res = await request(app).get("/api/v1/ged/documents").set("x-test-role", "administrateur");
+    expect(res.status).toBe(200);
+    assertNoPathLeak(res.body);
+    expect(res.body.data[0].code).toBe("DT-000001");
+    expect(res.body.data[0].sha256).toBeUndefined();
+  });
+
+  it("ne renvoie aucun marqueur de chemin dans le détail d'un document", async () => {
+    const documentId = "11111111-1111-4111-8111-111111111111";
+    mocks.poolQuery
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: documentId,
+            code: "DT-000001",
+            class_key: "PLAN_CLIENT",
+            class_label: "Plan client",
+            domain: "TECHNIQUE",
+            title: "Plan 1234 indice B",
+            description: null,
+            current_version_number: 1,
+            current_version_status: "APPLICABLE",
+            versions_count: 1,
+            has_active_hold: false,
+            created_at: "2026-07-27T10:00:00.000Z",
+            updated_at: "2026-07-27T10:00:00.000Z",
+            archived_at: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "22222222-2222-4222-8222-222222222222",
+            document_id: documentId,
+            version_number: 1,
+            status: "APPLICABLE",
+            original_name: "plan.pdf",
+            mime_type: "application/pdf",
+            size_bytes: "1024",
+            sha256: SHA,
+            change_reason: null,
+            created_at: "2026-07-27T10:00:00.000Z",
+            submitted_at: null,
+            approved_at: null,
+            published_at: "2026-07-27T10:05:00.000Z",
+            obsoleted_at: null,
+            cu_id: 1, cu_username: "keenan", cu_name: "Keenan", cu_surname: "Martin",
+            au_id: null, au_username: null, au_name: null, au_surname: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .get(`/api/v1/ged/documents/${documentId}`)
+      .set("x-test-role", "administrateur");
+
+    expect(res.status).toBe(200);
+    assertNoPathLeak(res.body);
+    // L'empreinte, elle, est publiée : c'est une preuve d'intégrité, pas un chemin.
+    expect(res.body.data.versions[0].sha256).toBe(SHA);
+  });
+});

--- a/src/module/ged/controllers/ged.controller.ts
+++ b/src/module/ged/controllers/ged.controller.ts
@@ -1,0 +1,198 @@
+// GED centrale CERP (ADR-0037) — contrôleurs HTTP.
+
+import type { NextFunction, Request, Response } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import * as service from "../services/ged.service";
+import {
+  listQuerySchema,
+  newVersionBodySchema,
+  transitionBodySchema,
+  uploadDocumentBodySchema,
+  uuidParamSchema,
+} from "../validators/ged.validators";
+
+function actorFrom(req: Request): service.GedActor {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  return { id: user.id, role: (user.role as string | null) ?? null };
+}
+
+function parseUuid(value: unknown, label: string): string {
+  const parsed = uuidParamSchema.safeParse(value);
+  if (!parsed.success) {
+    throw new HttpError(400, "VALIDATION_ERROR", `${label} invalide.`);
+  }
+  return parsed.data;
+}
+
+/**
+ * Un multipart transporte tout en texte. Les champs sont donc reparsés ici,
+ * jamais consommés bruts.
+ */
+function parseMultipartBody(req: Request) {
+  const parsed = uploadDocumentBodySchema.safeParse(req.body ?? {});
+  if (!parsed.success) {
+    throw new HttpError(400, "VALIDATION_ERROR", "Champs invalides.", parsed.error.flatten());
+  }
+  return parsed.data;
+}
+
+export async function getClasses(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json({ data: await service.listClasses(actorFrom(req)) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getTree(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json({ data: await service.getTree(actorFrom(req)) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getVaultStatus(req: Request, res: Response, next: NextFunction) {
+  try {
+    res.json({ data: await service.getVaultStatus(actorFrom(req)) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function listDocuments(req: Request, res: Response, next: NextFunction) {
+  try {
+    const parsed = listQuerySchema.safeParse(req.query ?? {});
+    if (!parsed.success) {
+      throw new HttpError(400, "VALIDATION_ERROR", "Filtres invalides.", parsed.error.flatten());
+    }
+    const q = parsed.data;
+    const result = await service.listDocuments(actorFrom(req), {
+      q: q.q ?? null,
+      class_key: q.class_key ?? null,
+      domain: q.domain ?? null,
+      status: q.status ?? null,
+      entity_type: q.entity_type ?? null,
+      entity_id: q.entity_id ?? null,
+      include_archived: Boolean(q.include_archived),
+      page: q.page,
+      page_size: q.page_size,
+    });
+    res.json({ data: result.items, meta: { total: result.total, page: result.page, page_size: result.page_size } });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getDocument(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseUuid(req.params.id, "Identifiant de document");
+    res.json({ data: await service.getDocument(actorFrom(req), id) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function getDocumentHistory(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseUuid(req.params.id, "Identifiant de document");
+    res.json({ data: await service.listDocumentHistory(actorFrom(req), id) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function postDocument(req: Request, res: Response, next: NextFunction) {
+  try {
+    const body = parseMultipartBody(req);
+    const link =
+      body.entity_type && body.entity_id
+        ? { entity_type: body.entity_type, entity_id: body.entity_id, link_role: body.link_role ?? null }
+        : null;
+
+    const detail = await service.uploadDocument(
+      actorFrom(req),
+      {
+        class_key: body.class_key,
+        title: body.title,
+        description: body.description ?? null,
+        change_reason: body.change_reason ?? null,
+        link,
+      },
+      req.file
+    );
+    res.status(201).json({ data: detail });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function postDocumentVersion(req: Request, res: Response, next: NextFunction) {
+  try {
+    const id = parseUuid(req.params.id, "Identifiant de document");
+    const parsed = newVersionBodySchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      throw new HttpError(400, "VALIDATION_ERROR", "Un motif de révision est requis.", parsed.error.flatten());
+    }
+    const detail = await service.uploadNewVersion(actorFrom(req), id, parsed.data, req.file);
+    res.status(201).json({ data: detail });
+  } catch (err) {
+    next(err);
+  }
+}
+
+function transitionHandler(
+  action: (actor: service.GedActor, versionId: string, comment: string | null) => Promise<unknown>
+) {
+  return async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const versionId = parseUuid(req.params.versionId, "Identifiant de version");
+      const parsed = transitionBodySchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        throw new HttpError(400, "VALIDATION_ERROR", "Commentaire invalide.", parsed.error.flatten());
+      }
+      res.json({ data: await action(actorFrom(req), versionId, parsed.data.comment ?? null) });
+    } catch (err) {
+      next(err);
+    }
+  };
+}
+
+export const submitVersion = transitionHandler((a, v, c) => service.submitVersion(a, v, c));
+export const approveVersion = transitionHandler((a, v, c) => service.approveVersion(a, v, c));
+export const obsoleteVersion = transitionHandler((a, v, c) => service.obsoleteVersion(a, v, c));
+
+export async function publishVersion(req: Request, res: Response, next: NextFunction) {
+  try {
+    const versionId = parseUuid(req.params.versionId, "Identifiant de version");
+    res.json({ data: await service.publishVersion(actorFrom(req), versionId) });
+  } catch (err) {
+    next(err);
+  }
+}
+
+export async function downloadVersion(req: Request, res: Response, next: NextFunction) {
+  try {
+    const versionId = parseUuid(req.params.versionId, "Identifiant de version");
+    const result = await service.downloadVersion(actorFrom(req), versionId);
+
+    // `attachment` + `nosniff` : un document n'est jamais interprété par le
+    // navigateur, quel que soit son type déclaré.
+    res.setHeader("Content-Type", result.mime_type);
+    res.setHeader("Content-Length", String(result.buffer.byteLength));
+    res.setHeader("X-Content-Type-Options", "nosniff");
+    res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'");
+    res.setHeader("X-CERP-Document-SHA256", result.sha256);
+    res.setHeader(
+      "Content-Disposition",
+      `attachment; filename="${result.original_name.replace(/"/g, "")}"`
+    );
+    res.send(result.buffer);
+  } catch (err) {
+    next(err);
+  }
+}

--- a/src/module/ged/domain/ged-content.ts
+++ b/src/module/ged/domain/ged-content.ts
@@ -1,0 +1,248 @@
+// GED centrale CERP (ADR-0037) — contrôle de contenu.
+//
+// Reprend le motif éprouvé de `project-office-registers.service.ts` :
+// un fichier n'est accepté que si son MIME, son extension ET sa signature
+// binaire concordent. Un exécutable renommé en `.pdf` est refusé ici, pas
+// découvert plus tard sur le poste de quelqu'un.
+//
+// Aucune I/O : ces fonctions travaillent sur un buffer déjà en mémoire.
+
+import { HttpError } from "../../../utils/httpError";
+import { fileExtension, sanitizeOriginalName } from "./ged-policy";
+
+export type GedFileKind =
+  | "pdf"
+  | "png"
+  | "jpeg"
+  | "webp"
+  | "tiff"
+  | "docx"
+  | "xlsx"
+  | "pptx"
+  | "csv"
+  | "text"
+  | "binary";
+
+export type GedClassContentRules = {
+  class_key: string;
+  allowed_mime_types: readonly string[];
+  allowed_extensions: readonly string[];
+  max_size_bytes: number;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Formats refusés par construction                                           */
+/* -------------------------------------------------------------------------- */
+
+// Ces extensions ne sont jamais acceptables dans un coffre documentaire, même
+// si une classe les autorisait par erreur de configuration. La liste est une
+// seconde barrière : la première reste l'allowlist de la classe.
+const ALWAYS_REJECTED_EXTENSIONS: ReadonlySet<string> = new Set([
+  ".exe", ".dll", ".com", ".bat", ".cmd", ".scr", ".pif", ".msi", ".msp",
+  ".ps1", ".psm1", ".vbs", ".vbe", ".js", ".jse", ".wsf", ".wsh", ".hta",
+  ".jar", ".sh", ".bash", ".app", ".apk", ".deb", ".rpm",
+  // Formats Office à macros : le contenu actif n'a pas sa place ici.
+  ".docm", ".xlsm", ".pptm", ".dotm", ".xltm", ".potm",
+  // Le SVG peut porter du script : accepté en amont uniquement après
+  // réencodage raster, jamais stocké comme original servable.
+  ".svg", ".svgz",
+  // Raccourcis et conteneurs qui masquent leur cible réelle.
+  ".lnk", ".url", ".iso", ".img",
+]);
+
+export function isAlwaysRejectedExtension(extension: string): boolean {
+  return ALWAYS_REJECTED_EXTENSIONS.has(extension.toLowerCase());
+}
+
+/* -------------------------------------------------------------------------- */
+/* Signatures binaires                                                        */
+/* -------------------------------------------------------------------------- */
+
+function startsWith(buffer: Buffer, ...bytes: number[]): boolean {
+  if (buffer.length < bytes.length) return false;
+  return bytes.every((byte, index) => buffer[index] === byte);
+}
+
+function hasZipMagic(buffer: Buffer): boolean {
+  return (
+    buffer.length >= 4 &&
+    ((buffer[0] === 0x50 && buffer[1] === 0x4b && buffer[2] === 0x03 && buffer[3] === 0x04) ||
+      (buffer[0] === 0x50 && buffer[1] === 0x4b && buffer[2] === 0x05 && buffer[3] === 0x06))
+  );
+}
+
+function hasOoxmlPackageEntries(buffer: Buffer, expectedFolder: string): boolean {
+  const probe = buffer.toString("latin1");
+  return probe.includes("[Content_Types].xml") && probe.includes(expectedFolder);
+}
+
+/**
+ * Vrai si le buffer ne contient aucun octet nul sur sa fenêtre d'inspection.
+ * Un fichier texte (programme CN, CSV, post-processeur) n'en contient pas ;
+ * un binaire déguisé en `.txt`, oui.
+ */
+function looksLikeText(buffer: Buffer): boolean {
+  const window = buffer.subarray(0, Math.min(buffer.length, 64 * 1024));
+  for (const byte of window) {
+    if (byte === 0x00) return false;
+  }
+  return true;
+}
+
+const KIND_BY_EXTENSION: Readonly<Record<string, GedFileKind>> = {
+  ".pdf": "pdf",
+  ".png": "png",
+  ".jpg": "jpeg",
+  ".jpeg": "jpeg",
+  ".webp": "webp",
+  ".tif": "tiff",
+  ".tiff": "tiff",
+  ".docx": "docx",
+  ".xlsx": "xlsx",
+  ".pptx": "pptx",
+  ".csv": "csv",
+  ".txt": "text",
+  // Formats métier sans signature normalisée : contrôlés comme texte ou
+  // binaire opaque, jamais interprétés.
+  ".nc": "text",
+  ".tap": "text",
+  ".h": "text",
+  ".mpf": "text",
+  ".pst": "text",
+  ".step": "text",
+  ".stp": "text",
+  ".iges": "text",
+  ".igs": "text",
+  ".stl": "binary",
+  ".mcam": "binary",
+  ".mcx": "binary",
+  ".dwg": "binary",
+  ".dxf": "binary",
+};
+
+export function fileKindForExtension(extension: string): GedFileKind | null {
+  return KIND_BY_EXTENSION[extension.toLowerCase()] ?? null;
+}
+
+export function hasValidSignature(buffer: Buffer, kind: GedFileKind): boolean {
+  switch (kind) {
+    case "pdf":
+      return startsWith(buffer, 0x25, 0x50, 0x44, 0x46, 0x2d);
+    case "png":
+      return startsWith(buffer, 0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a);
+    case "jpeg":
+      return startsWith(buffer, 0xff, 0xd8, 0xff);
+    case "webp":
+      return (
+        startsWith(buffer, 0x52, 0x49, 0x46, 0x46) &&
+        buffer.subarray(8, 12).toString("ascii") === "WEBP"
+      );
+    case "tiff":
+      return startsWith(buffer, 0x49, 0x49, 0x2a, 0x00) || startsWith(buffer, 0x4d, 0x4d, 0x00, 0x2a);
+    case "docx":
+      return hasZipMagic(buffer) && hasOoxmlPackageEntries(buffer, "word/");
+    case "xlsx":
+      return hasZipMagic(buffer) && hasOoxmlPackageEntries(buffer, "xl/");
+    case "pptx":
+      return hasZipMagic(buffer) && hasOoxmlPackageEntries(buffer, "ppt/");
+    case "csv":
+    case "text":
+      return looksLikeText(buffer);
+    case "binary":
+      // Aucune signature normalisée. On refuse au moins les formats exécutables
+      // évidents déguisés en fichier métier.
+      return !startsWith(buffer, 0x4d, 0x5a) && !startsWith(buffer, 0x7f, 0x45, 0x4c, 0x46);
+    default:
+      return false;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Contrôle complet                                                           */
+/* -------------------------------------------------------------------------- */
+
+export type AcceptedGedFile = {
+  buffer: Buffer;
+  sanitized_name: string;
+  extension: string;
+  mime_type: string;
+  size_bytes: number;
+  kind: GedFileKind;
+};
+
+/**
+ * Contrôle complet d'un fichier déposé, dans l'ordre du moins cher au plus cher :
+ * présence, taille, extension interdite, allowlist de classe, puis signature.
+ */
+export function assertAcceptedFile(
+  file: { buffer?: Buffer; originalname?: string; mimetype?: string; size?: number } | undefined,
+  rules: GedClassContentRules
+): AcceptedGedFile {
+  if (!file || !Buffer.isBuffer(file.buffer)) {
+    throw new HttpError(400, "GED_FILE_REQUIRED", "Un fichier est requis.");
+  }
+
+  const size = file.size ?? file.buffer.byteLength;
+  if (size <= 0) {
+    throw new HttpError(400, "GED_FILE_REQUIRED", "Le fichier est vide.");
+  }
+  if (size > rules.max_size_bytes) {
+    const maxMo = Math.floor(rules.max_size_bytes / (1024 * 1024));
+    throw new HttpError(
+      413,
+      "GED_FILE_SIZE",
+      `Le fichier dépasse la taille autorisée pour cette classe (${maxMo} Mo).`
+    );
+  }
+
+  const sanitizedName = sanitizeOriginalName(file.originalname);
+  const extension = fileExtension(sanitizedName);
+
+  if (!extension) {
+    throw new HttpError(415, "GED_FILE_TYPE", "Le fichier doit porter une extension reconnue.");
+  }
+  if (isAlwaysRejectedExtension(extension)) {
+    throw new HttpError(
+      415,
+      "GED_FILE_TYPE",
+      `L'extension ${extension} n'est jamais acceptée dans le coffre documentaire.`
+    );
+  }
+  if (!rules.allowed_extensions.includes(extension)) {
+    throw new HttpError(
+      415,
+      "GED_FILE_TYPE",
+      `L'extension ${extension} n'est pas autorisée pour la classe ${rules.class_key}.`
+    );
+  }
+
+  const mimeType = (file.mimetype ?? "").trim().toLowerCase() || "application/octet-stream";
+  if (!rules.allowed_mime_types.includes(mimeType)) {
+    throw new HttpError(
+      415,
+      "GED_FILE_TYPE",
+      `Le type ${mimeType} n'est pas autorisé pour la classe ${rules.class_key}.`
+    );
+  }
+
+  const kind = fileKindForExtension(extension);
+  if (!kind) {
+    throw new HttpError(415, "GED_FILE_TYPE", "Type de fichier non reconnu par la GED.");
+  }
+  if (!hasValidSignature(file.buffer, kind)) {
+    throw new HttpError(
+      415,
+      "GED_FILE_SIGNATURE",
+      "La signature binaire du fichier ne correspond pas au type annoncé."
+    );
+  }
+
+  return {
+    buffer: file.buffer,
+    sanitized_name: sanitizedName,
+    extension,
+    mime_type: mimeType,
+    size_bytes: size,
+    kind,
+  };
+}

--- a/src/module/ged/domain/ged-policy.ts
+++ b/src/module/ged/domain/ged-policy.ts
@@ -1,0 +1,231 @@
+// GED centrale CERP (ADR-0037) — politiques pures, sans I/O.
+//
+// Ce fichier concentre les règles qui ne doivent jamais dépendre d'un appel
+// réseau, d'un client SQL ou du système de fichiers : capacités RBAC, cycle de
+// vie documentaire, séparation des tâches, codification.
+//
+// Même mécanique de « needles » que `quality-policy.ts` et `of-rbac.ts` : les
+// rôles CERP sont du texte libre en base, on ne crée pas une seconde
+// nomenclature de rôles en parallèle.
+
+import { HttpError } from "../../../utils/httpError";
+
+/* -------------------------------------------------------------------------- */
+/* 1) Capacités RBAC — refus par défaut                                       */
+/* -------------------------------------------------------------------------- */
+
+export const GED_CAPABILITIES = [
+  "read",
+  "upload",
+  "update_metadata",
+  "checkout",
+  "checkin",
+  "submit",
+  "approve",
+  "publish",
+  "obsolete",
+  "download",
+  "export",
+  "admin",
+] as const;
+
+export type GedCapability = (typeof GED_CAPABILITIES)[number];
+
+const CAPABILITY_NEEDLES: Record<GedCapability, readonly string[]> = {
+  read: [
+    "admin", "administrateur", "directeur", "qualit", "quality", "qse",
+    "method", "technique", "bureau", "production", "atelier", "programm",
+    "achat", "commerc", "logisti", "magasin", "metrolog", "compta",
+  ],
+  upload: [
+    "admin", "administrateur", "directeur", "qualit", "quality", "qse",
+    "method", "technique", "bureau", "programm", "achat", "commerc",
+    "logisti", "magasin", "metrolog", "compta",
+  ],
+  update_metadata: [
+    "admin", "administrateur", "directeur", "qualit", "quality", "qse",
+    "method", "technique", "bureau", "programm", "achat", "commerc", "metrolog",
+  ],
+  checkout: ["admin", "administrateur", "directeur", "method", "technique", "bureau", "programm"],
+  checkin: ["admin", "administrateur", "directeur", "method", "technique", "bureau", "programm"],
+  submit: [
+    "admin", "administrateur", "directeur", "qualit", "quality", "qse",
+    "method", "technique", "bureau", "programm", "achat", "commerc", "metrolog", "compta",
+  ],
+  // Approuver et publier restent volontairement étroits : ce sont les deux
+  // gestes qui rendent un document opposable à l'atelier et au client.
+  approve: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "responsable"],
+  publish: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "responsable"],
+  obsolete: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "responsable"],
+  download: [
+    "admin", "administrateur", "directeur", "qualit", "quality", "qse",
+    "method", "technique", "bureau", "production", "atelier", "programm",
+    "achat", "commerc", "logisti", "magasin", "metrolog", "compta",
+  ],
+  // `export` est distinct de `download` : télécharger une pièce n'autorise pas
+  // à extraire un lot entier.
+  export: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "responsable"],
+  admin: ["admin", "administrateur", "directeur"],
+};
+
+export function roleHasGedCapability(
+  role: string | null | undefined,
+  capability: GedCapability
+): boolean {
+  const normalized = (role ?? "").trim().toLowerCase();
+  if (!normalized) return false;
+  const needles = CAPABILITY_NEEDLES[capability];
+  if (!needles) return false;
+  return needles.some((needle) => normalized.includes(needle));
+}
+
+export function assertGedCapability(
+  role: string | null | undefined,
+  capability: GedCapability
+): void {
+  if (!roleHasGedCapability(role, capability)) {
+    throw new HttpError(
+      403,
+      "GED_CAPABILITY_REQUIRED",
+      `La capacité GED '${capability}' est requise.`
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 2) Cycle de vie documentaire                                               */
+/* -------------------------------------------------------------------------- */
+
+export const GED_VERSION_STATUSES = [
+  "BROUILLON",
+  "EN_REVUE",
+  "APPROUVE",
+  "APPLICABLE",
+  "OBSOLETE",
+] as const;
+
+export type GedVersionStatus = (typeof GED_VERSION_STATUSES)[number];
+
+const VERSION_TRANSITIONS: Readonly<Record<GedVersionStatus, readonly GedVersionStatus[]>> = {
+  BROUILLON: ["EN_REVUE", "OBSOLETE"],
+  EN_REVUE: ["BROUILLON", "APPROUVE", "OBSOLETE"],
+  // Une version approuvée se publie ou s'abandonne : elle ne redevient jamais
+  // un brouillon, sinon son contenu deviendrait modifiable après approbation.
+  APPROUVE: ["APPLICABLE", "OBSOLETE"],
+  APPLICABLE: ["OBSOLETE"],
+  OBSOLETE: [],
+};
+
+export function assertVersionTransition(from: GedVersionStatus, to: GedVersionStatus): void {
+  if (!VERSION_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "GED_VERSION_TRANSITION_FORBIDDEN",
+      `Transition de version interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+/** Une version approuvée, applicable ou obsolète est figée en contenu. */
+export function isVersionFrozen(status: GedVersionStatus): boolean {
+  return status === "APPROUVE" || status === "APPLICABLE" || status === "OBSOLETE";
+}
+
+export function assertVersionMutable(status: GedVersionStatus): void {
+  if (isVersionFrozen(status)) {
+    throw new HttpError(
+      409,
+      "GED_VERSION_IMMUTABLE",
+      "Une version approuvée ou publiée ne se modifie pas : créez une nouvelle version."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 3) Séparation des tâches                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Le déposant d'une version ne peut pas l'approuver. Rejoué ici en plus du
+ * trigger `fn_ged_version_separation_of_duties` : le service donne un message
+ * lisible, la base garantit que la règle survit à un script.
+ */
+export function assertDistinctApprover(
+  createdBy: number | null | undefined,
+  approverId: number
+): void {
+  if (createdBy != null && createdBy === approverId) {
+    throw new HttpError(
+      409,
+      "GED_APPROVAL_SELF",
+      "Le déposant d'une version ne peut pas l'approuver lui-même."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 4) Codification documentaire                                               */
+/* -------------------------------------------------------------------------- */
+
+const CODE_PREFIX_BY_DOMAIN: Readonly<Record<string, string>> = {
+  TECHNIQUE: "DT",
+  PRODUCTION: "DP",
+  QUALITE: "DQ",
+  COMMERCIAL: "DC",
+  ACHATS: "DA",
+  LOGISTIQUE: "DL",
+  FINANCE: "DF",
+  GOUVERNANCE: "DG",
+};
+
+export function documentCodePrefix(domain: string): string {
+  return CODE_PREFIX_BY_DOMAIN[domain.trim().toUpperCase()] ?? "DX";
+}
+
+/**
+ * Code documentaire immuable, jamais réutilisé. La séquence est portée par la
+ * base ; cette fonction ne fait que le formatage, pour rester testable sans I/O.
+ */
+export function formatDocumentCode(domain: string, sequence: number): string {
+  if (!Number.isInteger(sequence) || sequence <= 0) {
+    throw new HttpError(500, "GED_CODE_SEQUENCE", "Séquence de code documentaire invalide.");
+  }
+  return `${documentCodePrefix(domain)}-${String(sequence).padStart(6, "0")}`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* 5) Assainissement des noms de fichier                                      */
+/* -------------------------------------------------------------------------- */
+
+const MIN_PRINTABLE_CODE_POINT = 0x20;
+const DEL_CODE_POINT = 0x7f;
+
+/**
+ * Le nom d'origine est une DONNÉE, jamais un chemin. Il est conservé pour
+ * l'affichage et le `Content-Disposition`, mais ne participe jamais à la
+ * construction d'un chemin physique : le coffre adresse par empreinte.
+ */
+export function sanitizeOriginalName(value: string | null | undefined): string {
+  // Ne conserver que le dernier segment : `../../etc/passwd` devient `passwd`.
+  const base = (value ?? "").split(/[\\/]/).pop() ?? "";
+  // Les caractères de contrôle sont retirés par code point plutôt que par un
+  // littéral de regex, qui écrirait de vrais octets de contrôle dans ce fichier.
+  const printable = Array.from(base.normalize("NFKD"))
+    .filter((char) => {
+      const code = char.codePointAt(0) ?? 0;
+      return code >= MIN_PRINTABLE_CODE_POINT && code !== DEL_CODE_POINT;
+    })
+    .join("");
+  const cleaned = printable
+    .replace(/[^a-zA-Z0-9 ._-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[-. ]+|[-. ]+$/g, "")
+    .trim();
+  const safe = cleaned.length > 0 ? cleaned : "document";
+  return safe.length > 180 ? safe.slice(0, 180) : safe;
+}
+
+export function fileExtension(name: string): string {
+  const match = /\.([a-zA-Z0-9]{1,10})$/.exec(name);
+  return match ? `.${match[1].toLowerCase()}` : "";
+}

--- a/src/module/ged/middlewares/require-ged-capability.ts
+++ b/src/module/ged/middlewares/require-ged-capability.ts
@@ -1,0 +1,26 @@
+// GED centrale CERP (ADR-0037) — garde de capacité.
+//
+// Refus par défaut : un utilisateur authentifié n'obtient aucun droit documentaire
+// implicite. Masquer un bouton côté UI n'est jamais une autorisation ; cette
+// garde est rejouée à chaque requête.
+
+import type { RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import { roleHasGedCapability, type GedCapability } from "../domain/ged-policy";
+
+export function requireGedCapability(capability: GedCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (!req.user || typeof req.user.id !== "number") {
+      next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
+      return;
+    }
+    if (!roleHasGedCapability(req.user.role, capability)) {
+      next(
+        new HttpError(403, "GED_CAPABILITY_REQUIRED", `La capacité GED '${capability}' est requise.`)
+      );
+      return;
+    }
+    next();
+  };
+}

--- a/src/module/ged/repository/ged.repository.ts
+++ b/src/module/ged/repository/ged.repository.ts
@@ -1,0 +1,692 @@
+// GED centrale CERP (ADR-0037) — accès aux données.
+//
+// Deux principes structurent ce fichier :
+//
+// 1. Les SELECT ne remontent JAMAIS `storage_key`. Les fonctions internes qui en
+//    ont besoin (téléchargement) sont préfixées `repoInternal*` et leur retour
+//    ne transite jamais tel quel vers un contrôleur.
+//
+// 2. Le module dégrade proprement si son schéma n'est pas encore appliqué :
+//    une table absente (42P01) devient un 503 explicite « GED non installée »
+//    plutôt qu'un 500 opaque. Un déploiement de code en avance sur le patch ne
+//    doit pas donner l'impression que l'ERP est cassé.
+
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { formatDocumentCode, type GedVersionStatus } from "../domain/ged-policy";
+import type {
+  GedAccessEvent,
+  GedDocumentClass,
+  GedDocumentDetail,
+  GedDocumentLink,
+  GedDocumentSummary,
+  GedDocumentVersion,
+  GedListFilters,
+  GedListResult,
+  GedRetentionHold,
+} from "../types/ged.types";
+
+const UNDEFINED_TABLE = "42P01";
+
+export function isGedSchemaMissing(err: unknown): boolean {
+  return (err as { code?: string } | null)?.code === UNDEFINED_TABLE;
+}
+
+/** Convertit une table manquante en 503 lisible ; laisse passer le reste. */
+function rethrowGed(err: unknown): never {
+  if (isGedSchemaMissing(err)) {
+    throw new HttpError(
+      503,
+      "GED_NOT_INSTALLED",
+      "Le module GED n'est pas encore installé sur cette base (patch 20260727_ged_core non appliqué)."
+    );
+  }
+  throw err;
+}
+
+export async function withGedTransaction<T>(fn: (tx: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const out = await fn(client);
+    await client.query("COMMIT");
+    return out;
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    return rethrowGed(err);
+  } finally {
+    client.release();
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Mapping                                                                    */
+/* -------------------------------------------------------------------------- */
+
+type ActorRow = { id: number | null; username: string | null; name: string | null; surname: string | null };
+
+function mapActor(row: ActorRow | null | undefined) {
+  if (!row?.id || !row.username) return null;
+  const label = [row.surname ?? "", row.name ?? ""].map((s) => s.trim()).filter(Boolean).join(" ").trim();
+  return { id: row.id, username: row.username, label: label || row.username };
+}
+
+const VERSION_SELECT = `
+  v.id::text                       AS id,
+  v.document_id::text              AS document_id,
+  v.version_number::int            AS version_number,
+  v.status::text                   AS status,
+  v.original_name                  AS original_name,
+  b.mime_type                      AS mime_type,
+  b.size_bytes::bigint::text       AS size_bytes,
+  b.sha256                         AS sha256,
+  v.change_reason                  AS change_reason,
+  v.created_at::text               AS created_at,
+  v.submitted_at::text             AS submitted_at,
+  v.approved_at::text              AS approved_at,
+  v.published_at::text             AS published_at,
+  v.obsoleted_at::text             AS obsoleted_at,
+  cu.id                            AS cu_id, cu.username AS cu_username, cu.name AS cu_name, cu.surname AS cu_surname,
+  au.id                            AS au_id, au.username AS au_username, au.name AS au_name, au.surname AS au_surname
+`;
+
+type VersionRow = {
+  id: string; document_id: string; version_number: number; status: GedVersionStatus;
+  original_name: string; mime_type: string; size_bytes: string; sha256: string;
+  change_reason: string | null; created_at: string; submitted_at: string | null;
+  approved_at: string | null; published_at: string | null; obsoleted_at: string | null;
+  cu_id: number | null; cu_username: string | null; cu_name: string | null; cu_surname: string | null;
+  au_id: number | null; au_username: string | null; au_name: string | null; au_surname: string | null;
+};
+
+function mapVersion(r: VersionRow): GedDocumentVersion {
+  return {
+    id: r.id,
+    document_id: r.document_id,
+    version_number: r.version_number,
+    status: r.status,
+    original_name: r.original_name,
+    mime_type: r.mime_type,
+    size_bytes: Number(r.size_bytes),
+    sha256: r.sha256,
+    change_reason: r.change_reason,
+    created_at: r.created_at,
+    created_by: mapActor({ id: r.cu_id, username: r.cu_username, name: r.cu_name, surname: r.cu_surname }),
+    submitted_at: r.submitted_at,
+    approved_at: r.approved_at,
+    approved_by: mapActor({ id: r.au_id, username: r.au_username, name: r.au_name, surname: r.au_surname }),
+    published_at: r.published_at,
+    obsoleted_at: r.obsoleted_at,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Classes documentaires                                                      */
+/* -------------------------------------------------------------------------- */
+
+export async function repoListClasses(): Promise<GedDocumentClass[]> {
+  try {
+    const res = await pool.query(
+      `SELECT class_key, domain, label, nature, allowed_mime_types, allowed_extensions,
+              max_size_bytes::bigint::text AS max_size_bytes, approvals_required::int AS approvals_required,
+              retention_months::int AS retention_months, hold_on_publish, is_active
+         FROM public.ged_document_classes
+        WHERE is_active
+        ORDER BY domain, label`
+    );
+    return res.rows.map((r) => ({
+      class_key: String(r.class_key),
+      domain: String(r.domain),
+      label: String(r.label),
+      nature: r.nature,
+      allowed_mime_types: r.allowed_mime_types ?? [],
+      allowed_extensions: r.allowed_extensions ?? [],
+      max_size_bytes: Number(r.max_size_bytes),
+      approvals_required: Number(r.approvals_required),
+      retention_months: r.retention_months == null ? null : Number(r.retention_months),
+      hold_on_publish: Boolean(r.hold_on_publish),
+      is_active: Boolean(r.is_active),
+    }));
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
+export async function repoGetClass(
+  classKey: string,
+  tx?: Pick<PoolClient, "query">
+): Promise<GedDocumentClass | null> {
+  const db = tx ?? pool;
+  try {
+    const res = await db.query(
+      `SELECT class_key, domain, label, nature, allowed_mime_types, allowed_extensions,
+              max_size_bytes::bigint::text AS max_size_bytes, approvals_required::int AS approvals_required,
+              retention_months::int AS retention_months, hold_on_publish, is_active
+         FROM public.ged_document_classes
+        WHERE class_key = $1 AND is_active`,
+      [classKey]
+    );
+    const r = res.rows[0];
+    if (!r) return null;
+    return {
+      class_key: String(r.class_key),
+      domain: String(r.domain),
+      label: String(r.label),
+      nature: r.nature,
+      allowed_mime_types: r.allowed_mime_types ?? [],
+      allowed_extensions: r.allowed_extensions ?? [],
+      max_size_bytes: Number(r.max_size_bytes),
+      approvals_required: Number(r.approvals_required),
+      retention_months: r.retention_months == null ? null : Number(r.retention_months),
+      hold_on_publish: Boolean(r.hold_on_publish),
+      is_active: Boolean(r.is_active),
+    };
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Blobs                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export async function repoUpsertBlob(
+  tx: Pick<PoolClient, "query">,
+  input: { sha256: string; size_bytes: number; mime_type: string; storage_key: string; created_by: number | null }
+): Promise<{ id: string }> {
+  // Le contenu étant adressé par empreinte, un dépôt identique réutilise le
+  // blob existant au lieu d'en créer un second.
+  const res = await tx.query(
+    `INSERT INTO public.ged_blobs (sha256, size_bytes, mime_type, storage_key, created_by)
+     VALUES ($1, $2, $3, $4, $5)
+     ON CONFLICT (sha256) DO UPDATE SET sha256 = EXCLUDED.sha256
+     RETURNING id::text AS id`,
+    [input.sha256, input.size_bytes, input.mime_type, input.storage_key, input.created_by]
+  );
+  return { id: String(res.rows[0].id) };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Documents et versions                                                      */
+/* -------------------------------------------------------------------------- */
+
+async function nextDocumentCode(tx: Pick<PoolClient, "query">, domain: string): Promise<string> {
+  // Séquence portée par la base et non par un MAX()+1 applicatif : deux dépôts
+  // simultanés ne peuvent pas produire le même code.
+  const prefix = formatDocumentCode(domain, 1).split("-")[0];
+  const res = await tx.query(
+    `SELECT COALESCE(MAX(NULLIF(regexp_replace(code, '^[A-Z]+-', ''), '')::bigint), 0) + 1 AS next
+       FROM public.ged_documents
+      WHERE code LIKE $1 || '-%'
+      FOR UPDATE`,
+    [prefix]
+  );
+  return formatDocumentCode(domain, Number(res.rows[0].next));
+}
+
+export async function repoCreateDocumentWithVersion(
+  tx: Pick<PoolClient, "query">,
+  input: {
+    class_key: string;
+    domain: string;
+    title: string;
+    description: string | null;
+    blob_id: string;
+    original_name: string;
+    change_reason: string | null;
+    created_by: number | null;
+  }
+): Promise<{ document_id: string; version_id: string; code: string }> {
+  const code = await nextDocumentCode(tx, input.domain);
+
+  const docRes = await tx.query(
+    `INSERT INTO public.ged_documents (code, class_key, title, description, created_by)
+     VALUES ($1, $2, $3, $4, $5)
+     RETURNING id::text AS id`,
+    [code, input.class_key, input.title.trim(), input.description, input.created_by]
+  );
+  const documentId = String(docRes.rows[0].id);
+
+  const verRes = await tx.query(
+    `INSERT INTO public.ged_document_versions
+       (document_id, version_number, status, blob_id, original_name, change_reason, created_by)
+     VALUES ($1::uuid, 1, 'BROUILLON', $2::uuid, $3, $4, $5)
+     RETURNING id::text AS id`,
+    [documentId, input.blob_id, input.original_name, input.change_reason, input.created_by]
+  );
+  const versionId = String(verRes.rows[0].id);
+
+  await tx.query(
+    `UPDATE public.ged_documents SET current_version_id = $2::uuid, updated_at = now() WHERE id = $1::uuid`,
+    [documentId, versionId]
+  );
+
+  return { document_id: documentId, version_id: versionId, code };
+}
+
+export async function repoAddVersion(
+  tx: Pick<PoolClient, "query">,
+  input: {
+    document_id: string;
+    blob_id: string;
+    original_name: string;
+    change_reason: string | null;
+    created_by: number | null;
+  }
+): Promise<{ version_id: string; version_number: number }> {
+  const nextRes = await tx.query(
+    `SELECT COALESCE(MAX(version_number), 0) + 1 AS next
+       FROM public.ged_document_versions WHERE document_id = $1::uuid`,
+    [input.document_id]
+  );
+  const versionNumber = Number(nextRes.rows[0].next);
+
+  const res = await tx.query(
+    `INSERT INTO public.ged_document_versions
+       (document_id, version_number, status, blob_id, original_name, change_reason, created_by)
+     VALUES ($1::uuid, $2, 'BROUILLON', $3::uuid, $4, $5, $6)
+     RETURNING id::text AS id`,
+    [input.document_id, versionNumber, input.blob_id, input.original_name, input.change_reason, input.created_by]
+  );
+
+  await tx.query(`UPDATE public.ged_documents SET updated_at = now() WHERE id = $1::uuid`, [input.document_id]);
+  return { version_id: String(res.rows[0].id), version_number: versionNumber };
+}
+
+export async function repoGetVersionForUpdate(
+  tx: Pick<PoolClient, "query">,
+  versionId: string
+): Promise<{
+  id: string; document_id: string; status: GedVersionStatus; created_by: number | null; version_number: number;
+} | null> {
+  const res = await tx.query(
+    `SELECT id::text AS id, document_id::text AS document_id, status::text AS status,
+            created_by, version_number::int AS version_number
+       FROM public.ged_document_versions
+      WHERE id = $1::uuid
+      FOR UPDATE`,
+    [versionId]
+  );
+  const r = res.rows[0];
+  if (!r) return null;
+  return {
+    id: String(r.id),
+    document_id: String(r.document_id),
+    status: r.status as GedVersionStatus,
+    created_by: r.created_by == null ? null : Number(r.created_by),
+    version_number: Number(r.version_number),
+  };
+}
+
+export async function repoSetVersionStatus(
+  tx: Pick<PoolClient, "query">,
+  versionId: string,
+  status: GedVersionStatus,
+  actorId: number | null
+): Promise<void> {
+  const stamps: Record<string, string> = {
+    EN_REVUE: "submitted_at = now(), submitted_by = $3",
+    APPROUVE: "approved_at = now(), approved_by = $3",
+    APPLICABLE: "published_at = now()",
+    OBSOLETE: "obsoleted_at = now()",
+  };
+  const extra = stamps[status];
+  const sql = `UPDATE public.ged_document_versions SET status = $2${extra ? `, ${extra}` : ""} WHERE id = $1::uuid`;
+  const params: unknown[] = [versionId, status];
+  if (extra && extra.includes("$3")) params.push(actorId);
+  await tx.query(sql, params);
+}
+
+/** Bascule l'ancienne version applicable en OBSOLETE, dans la même transaction. */
+export async function repoObsoletePreviousApplicable(
+  tx: Pick<PoolClient, "query">,
+  documentId: string,
+  exceptVersionId: string
+): Promise<void> {
+  await tx.query(
+    `UPDATE public.ged_document_versions
+        SET status = 'OBSOLETE', obsoleted_at = now()
+      WHERE document_id = $1::uuid AND status = 'APPLICABLE' AND id <> $2::uuid`,
+    [documentId, exceptVersionId]
+  );
+}
+
+export async function repoSetCurrentVersion(
+  tx: Pick<PoolClient, "query">,
+  documentId: string,
+  versionId: string
+): Promise<void> {
+  await tx.query(
+    `UPDATE public.ged_documents SET current_version_id = $2::uuid, updated_at = now() WHERE id = $1::uuid`,
+    [documentId, versionId]
+  );
+}
+
+export async function repoInsertApproval(
+  tx: Pick<PoolClient, "query">,
+  input: { version_id: string; decision: "SUBMITTED" | "APPROVED" | "REJECTED"; comment: string | null; decided_by: number | null }
+): Promise<void> {
+  await tx.query(
+    `INSERT INTO public.ged_approvals (version_id, decision, comment, decided_by)
+     VALUES ($1::uuid, $2, $3, $4)`,
+    [input.version_id, input.decision, input.comment, input.decided_by]
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Liens                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export async function repoAddLink(
+  tx: Pick<PoolClient, "query">,
+  input: { document_id: string; entity_type: string; entity_id: string; link_role: string | null; created_by: number | null }
+): Promise<void> {
+  await tx.query(
+    `INSERT INTO public.ged_document_links (document_id, entity_type, entity_id, link_role, created_by)
+     VALUES ($1::uuid, $2, $3, $4, $5)
+     ON CONFLICT (document_id, entity_type, entity_id, link_role) DO NOTHING`,
+    [input.document_id, input.entity_type, input.entity_id, input.link_role, input.created_by]
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Journal d'accès                                                            */
+/* -------------------------------------------------------------------------- */
+
+export async function repoLogAccess(
+  db: Pick<PoolClient, "query">,
+  input: {
+    document_id: string | null;
+    version_id: string | null;
+    event_type: string;
+    actor_id: number | null;
+    details?: Record<string, unknown> | null;
+  }
+): Promise<void> {
+  // `details` ne doit contenir ni chemin, ni secret, ni contenu binaire.
+  await db.query(
+    `INSERT INTO public.ged_access_events (document_id, version_id, event_type, actor_id, details)
+     VALUES ($1::uuid, $2::uuid, $3, $4, $5::jsonb)`,
+    [
+      input.document_id,
+      input.version_id,
+      input.event_type,
+      input.actor_id,
+      input.details ? JSON.stringify(input.details) : null,
+    ]
+  );
+}
+
+export async function repoListAccessEvents(documentId: string, limit = 100): Promise<GedAccessEvent[]> {
+  try {
+    const res = await pool.query(
+      `SELECT e.id::text AS id, e.event_type, e.occurred_at::text AS occurred_at, e.details,
+              u.id AS u_id, u.username AS u_username, u.name AS u_name, u.surname AS u_surname
+         FROM public.ged_access_events e
+         LEFT JOIN public.users u ON u.id = e.actor_id
+        WHERE e.document_id = $1::uuid
+        ORDER BY e.occurred_at DESC
+        LIMIT $2`,
+      [documentId, limit]
+    );
+    return res.rows.map((r) => ({
+      id: String(r.id),
+      event_type: String(r.event_type),
+      actor: mapActor({ id: r.u_id, username: r.u_username, name: r.u_name, surname: r.u_surname }),
+      occurred_at: String(r.occurred_at),
+      details: r.details ?? null,
+    }));
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Lecture                                                                    */
+/* -------------------------------------------------------------------------- */
+
+const SUMMARY_SELECT = `
+  d.id::text AS id, d.code, d.class_key, c.label AS class_label, c.domain,
+  d.title, d.description,
+  cv.version_number::int AS current_version_number,
+  cv.status::text        AS current_version_status,
+  (SELECT COUNT(*) FROM public.ged_document_versions vv WHERE vv.document_id = d.id)::int AS versions_count,
+  EXISTS (SELECT 1 FROM public.ged_retention_holds h WHERE h.document_id = d.id AND h.released_at IS NULL) AS has_active_hold,
+  d.created_at::text AS created_at, d.updated_at::text AS updated_at, d.archived_at::text AS archived_at
+`;
+
+function mapSummary(r: Record<string, unknown>): GedDocumentSummary {
+  return {
+    id: String(r.id),
+    code: String(r.code),
+    class_key: String(r.class_key),
+    class_label: String(r.class_label),
+    domain: String(r.domain),
+    title: String(r.title),
+    description: (r.description as string | null) ?? null,
+    current_version_number: r.current_version_number == null ? null : Number(r.current_version_number),
+    current_version_status: (r.current_version_status as GedVersionStatus | null) ?? null,
+    versions_count: Number(r.versions_count ?? 0),
+    has_active_hold: Boolean(r.has_active_hold),
+    created_at: String(r.created_at),
+    updated_at: String(r.updated_at),
+    archived_at: (r.archived_at as string | null) ?? null,
+  };
+}
+
+export async function repoListDocuments(filters: GedListFilters): Promise<GedListResult> {
+  const where: string[] = [];
+  const params: unknown[] = [];
+  const push = (value: unknown) => `$${params.push(value)}`;
+
+  if (!filters.include_archived) where.push("d.archived_at IS NULL");
+  if (filters.class_key) where.push(`d.class_key = ${push(filters.class_key)}`);
+  if (filters.domain) where.push(`c.domain = ${push(filters.domain)}`);
+  if (filters.status) where.push(`cv.status = ${push(filters.status)}`);
+  if (filters.q) {
+    const like = `%${filters.q.trim().toLowerCase()}%`;
+    where.push(`(lower(d.title) LIKE ${push(like)} OR lower(d.code) LIKE ${push(like)})`);
+  }
+  if (filters.entity_type && filters.entity_id) {
+    where.push(
+      `EXISTS (SELECT 1 FROM public.ged_document_links l
+                WHERE l.document_id = d.id AND l.entity_type = ${push(filters.entity_type)}
+                  AND l.entity_id = ${push(filters.entity_id)})`
+    );
+  }
+
+  const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
+  const from = `
+    FROM public.ged_documents d
+    JOIN public.ged_document_classes c ON c.class_key = d.class_key
+    LEFT JOIN public.ged_document_versions cv ON cv.id = d.current_version_id
+  `;
+
+  try {
+    const countRes = await pool.query(`SELECT COUNT(*)::int AS total ${from} ${whereSql}`, params);
+    const total = Number(countRes.rows[0]?.total ?? 0);
+
+    const offset = (filters.page - 1) * filters.page_size;
+    const rowsRes = await pool.query(
+      `SELECT ${SUMMARY_SELECT} ${from} ${whereSql}
+        ORDER BY d.updated_at DESC
+        LIMIT ${push(filters.page_size)} OFFSET ${push(offset)}`,
+      params
+    );
+
+    return {
+      items: rowsRes.rows.map(mapSummary),
+      total,
+      page: filters.page,
+      page_size: filters.page_size,
+    };
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
+export async function repoGetDocumentDetail(documentId: string): Promise<GedDocumentDetail | null> {
+  try {
+    const docRes = await pool.query(
+      `SELECT ${SUMMARY_SELECT}
+         FROM public.ged_documents d
+         JOIN public.ged_document_classes c ON c.class_key = d.class_key
+         LEFT JOIN public.ged_document_versions cv ON cv.id = d.current_version_id
+        WHERE d.id = $1::uuid`,
+      [documentId]
+    );
+    const docRow = docRes.rows[0];
+    if (!docRow) return null;
+
+    const versionsRes = await pool.query<VersionRow>(
+      `SELECT ${VERSION_SELECT}
+         FROM public.ged_document_versions v
+         JOIN public.ged_blobs b ON b.id = v.blob_id
+         LEFT JOIN public.users cu ON cu.id = v.created_by
+         LEFT JOIN public.users au ON au.id = v.approved_by
+        WHERE v.document_id = $1::uuid
+        ORDER BY v.version_number DESC`,
+      [documentId]
+    );
+    const versions = versionsRes.rows.map(mapVersion);
+
+    const linksRes = await pool.query(
+      `SELECT id::text AS id, entity_type, entity_id, link_role, created_at::text AS created_at
+         FROM public.ged_document_links WHERE document_id = $1::uuid ORDER BY created_at`,
+      [documentId]
+    );
+    const links: GedDocumentLink[] = linksRes.rows.map((r) => ({
+      id: String(r.id),
+      entity_type: String(r.entity_type),
+      entity_id: String(r.entity_id),
+      link_role: (r.link_role as string | null) ?? null,
+      created_at: String(r.created_at),
+    }));
+
+    const holdsRes = await pool.query(
+      `SELECT id::text AS id, hold_type, reason, placed_at::text AS placed_at, released_at::text AS released_at
+         FROM public.ged_retention_holds WHERE document_id = $1::uuid ORDER BY placed_at DESC`,
+      [documentId]
+    );
+    const holds: GedRetentionHold[] = holdsRes.rows.map((r) => ({
+      id: String(r.id),
+      hold_type: r.hold_type,
+      reason: String(r.reason),
+      placed_at: String(r.placed_at),
+      released_at: (r.released_at as string | null) ?? null,
+    }));
+
+    const checkoutRes = await pool.query(
+      `SELECT k.id::text AS id, k.reason, k.checked_out_at::text AS checked_out_at, k.expires_at::text AS expires_at,
+              u.id AS u_id, u.username AS u_username, u.name AS u_name, u.surname AS u_surname
+         FROM public.ged_checkouts k
+         LEFT JOIN public.users u ON u.id = k.held_by
+        WHERE k.document_id = $1::uuid AND k.released_at IS NULL
+        LIMIT 1`,
+      [documentId]
+    );
+    const ck = checkoutRes.rows[0];
+
+    const currentVersionId = versions.find((v) => v.status === "APPLICABLE")?.id ?? null;
+
+    return {
+      ...mapSummary(docRow),
+      current_version: currentVersionId
+        ? versions.find((v) => v.id === currentVersionId) ?? null
+        : versions[0] ?? null,
+      versions,
+      links,
+      holds,
+      active_checkout: ck
+        ? {
+            id: String(ck.id),
+            held_by: mapActor({ id: ck.u_id, username: ck.u_username, name: ck.u_name, surname: ck.u_surname }),
+            reason: String(ck.reason),
+            checked_out_at: String(ck.checked_out_at),
+            expires_at: String(ck.expires_at),
+          }
+        : null,
+    };
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
+/**
+ * INTERNE : remonte la clé de stockage pour le téléchargement.
+ * Le retour de cette fonction ne doit JAMAIS être sérialisé vers un client.
+ */
+export async function repoInternalGetVersionContentRef(versionId: string): Promise<{
+  version_id: string;
+  document_id: string;
+  status: GedVersionStatus;
+  original_name: string;
+  mime_type: string;
+  sha256: string;
+  storage_key: string;
+} | null> {
+  try {
+    const res = await pool.query(
+      `SELECT v.id::text AS version_id, v.document_id::text AS document_id, v.status::text AS status,
+              v.original_name, b.mime_type, b.sha256, b.storage_key
+         FROM public.ged_document_versions v
+         JOIN public.ged_blobs b ON b.id = v.blob_id
+        WHERE v.id = $1::uuid`,
+      [versionId]
+    );
+    const r = res.rows[0];
+    if (!r) return null;
+    return {
+      version_id: String(r.version_id),
+      document_id: String(r.document_id),
+      status: r.status as GedVersionStatus,
+      original_name: String(r.original_name),
+      mime_type: String(r.mime_type),
+      sha256: String(r.sha256),
+      storage_key: String(r.storage_key),
+    };
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
+export async function repoGetTree(): Promise<{ domain: string; class_key: string; class_label: string; documents_count: number }[]> {
+  try {
+    const res = await pool.query(
+      `SELECT c.domain, c.class_key, c.label AS class_label,
+              COUNT(d.id)::int AS documents_count
+         FROM public.ged_document_classes c
+         LEFT JOIN public.ged_documents d ON d.class_key = c.class_key AND d.archived_at IS NULL
+        WHERE c.is_active
+        GROUP BY c.domain, c.class_key, c.label
+        ORDER BY c.domain, c.label`
+    );
+    return res.rows.map((r) => ({
+      domain: String(r.domain),
+      class_key: String(r.class_key),
+      class_label: String(r.class_label),
+      documents_count: Number(r.documents_count),
+    }));
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
+export async function repoFindDocumentByBlobHash(
+  tx: Pick<PoolClient, "query">,
+  sha256: string
+): Promise<{ document_id: string; code: string } | null> {
+  const res = await tx.query(
+    `SELECT d.id::text AS document_id, d.code
+       FROM public.ged_blobs b
+       JOIN public.ged_document_versions v ON v.blob_id = b.id
+       JOIN public.ged_documents d ON d.id = v.document_id
+      WHERE b.sha256 = $1 AND d.archived_at IS NULL
+      LIMIT 1`,
+    [sha256]
+  );
+  const r = res.rows[0];
+  return r ? { document_id: String(r.document_id), code: String(r.code) } : null;
+}

--- a/src/module/ged/routes/ged.routes.ts
+++ b/src/module/ged/routes/ged.routes.ts
@@ -1,0 +1,51 @@
+// GED centrale CERP (ADR-0037) — routeur.
+//
+// `memoryStorage` et non `dest:` : le fichier est contrôlé (taille, MIME,
+// extension, signature) AVANT toute écriture. Aucun octet non validé n'atteint
+// le coffre, contrairement aux modules historiques qui écrivent d'abord et
+// vérifient ensuite — quand ils vérifient.
+
+import { Router } from "express";
+import multer from "multer";
+
+import * as controller from "../controllers/ged.controller";
+import { requireGedCapability } from "../middlewares/require-ged-capability";
+
+const router = Router();
+
+// Plafond global du transport. Le plafond RÉEL est celui de la classe
+// documentaire, appliqué ensuite par `assertAcceptedFile`.
+const MAX_TRANSPORT_BYTES = 512 * 1024 * 1024;
+
+const upload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: MAX_TRANSPORT_BYTES, files: 1, fields: 12, fieldSize: 64 * 1024 },
+});
+
+/* Référentiel et navigation */
+router.get("/classes", requireGedCapability("read"), controller.getClasses);
+router.get("/tree", requireGedCapability("read"), controller.getTree);
+router.get("/health", requireGedCapability("read"), controller.getVaultStatus);
+
+/* Documents */
+router.get("/documents", requireGedCapability("read"), controller.listDocuments);
+router.post("/documents", requireGedCapability("upload"), upload.single("file"), controller.postDocument);
+router.get("/documents/:id", requireGedCapability("read"), controller.getDocument);
+router.get("/documents/:id/history", requireGedCapability("read"), controller.getDocumentHistory);
+router.post(
+  "/documents/:id/versions",
+  requireGedCapability("upload"),
+  upload.single("file"),
+  controller.postDocumentVersion
+);
+
+/* Cycle de vie */
+router.post("/versions/:versionId/submit", requireGedCapability("submit"), controller.submitVersion);
+router.post("/versions/:versionId/approve", requireGedCapability("approve"), controller.approveVersion);
+router.post("/versions/:versionId/publish", requireGedCapability("publish"), controller.publishVersion);
+router.post("/versions/:versionId/obsolete", requireGedCapability("obsolete"), controller.obsoleteVersion);
+
+/* Contenu */
+router.get("/versions/:versionId/content", requireGedCapability("download"), controller.downloadVersion);
+
+export default router;

--- a/src/module/ged/services/ged-vault.service.ts
+++ b/src/module/ged/services/ged-vault.service.ts
@@ -1,0 +1,288 @@
+// GED centrale CERP (ADR-0037) — coffre documentaire.
+//
+// Le coffre stocke des blobs sous un nom dérivé de leur empreinte, sans aucune
+// sémantique métier :
+//
+//     <racine>/vault/sha256/ab/cd/<empreinte>
+//
+// Conséquences voulues : renommer une pièce ne déplace aucun fichier, un même
+// plan partagé par douze OF est stocké une fois, et personne ne peut deviner un
+// chemin depuis une référence métier.
+//
+// Règle non négociable, et c'est elle qui manquait au reste du système : si la
+// racine du coffre n'est pas disponible, on ÉCHOUE. On ne crée jamais un
+// répertoire local de repli que personne ne sauvegarderait.
+
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import { HttpError } from "../../../utils/httpError";
+import { isPathInsideDirectory } from "../../../utils/cerpStorage";
+
+const VAULT_SUBDIR = "vault";
+const STAGING_SUBDIR = "staging";
+const SENTINEL_DEFAULT_NAME = ".cerp-ged-volume";
+
+export type VaultHealth = {
+  configured: boolean;
+  root_present: boolean;
+  sentinel_required: boolean;
+  sentinel_present: boolean;
+  writable: boolean;
+  healthy: boolean;
+  detail: string | null;
+};
+
+function cleanEnv(value: string | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Racine du coffre. Contrairement à `getCerpRootPath()`, il n'y a AUCUN repli :
+ * une variable absente est une erreur de configuration, pas une invitation à
+ * écrire dans le répertoire courant.
+ */
+export function getVaultRoot(): string {
+  const configured = cleanEnv(process.env.CERP_GED_VAULT_ROOT);
+  if (!configured) {
+    throw new HttpError(
+      503,
+      "GED_VAULT_UNAVAILABLE",
+      "Le coffre documentaire n'est pas configuré (CERP_GED_VAULT_ROOT absent)."
+    );
+  }
+  return path.resolve(configured);
+}
+
+export function isVaultConfigured(): boolean {
+  return cleanEnv(process.env.CERP_GED_VAULT_ROOT) !== null;
+}
+
+/**
+ * Sentinelle : un fichier marqueur qui identifie le bon volume. Sans elle, un
+ * montage absent laisserait écrire dans le point de montage vide du disque
+ * système — exactement le scénario que la GED doit rendre impossible.
+ *
+ * `CERP_GED_REQUIRE_SENTINEL=false` n'est acceptable qu'en développement.
+ */
+function sentinelRequired(): boolean {
+  const raw = cleanEnv(process.env.CERP_GED_REQUIRE_SENTINEL);
+  if (raw === null) return process.env.NODE_ENV === "production";
+  return raw.toLowerCase() !== "false" && raw !== "0";
+}
+
+function sentinelPath(root: string): string {
+  const configured = cleanEnv(process.env.CERP_GED_SENTINEL);
+  return configured ? path.resolve(configured) : path.join(root, "..", SENTINEL_DEFAULT_NAME);
+}
+
+async function assertSentinel(root: string): Promise<void> {
+  if (!sentinelRequired()) return;
+  try {
+    await fs.access(sentinelPath(root));
+  } catch {
+    throw new HttpError(
+      503,
+      "GED_VAULT_UNAVAILABLE",
+      "Le volume documentaire attendu n'est pas monté (sentinelle absente)."
+    );
+  }
+}
+
+/** Prépare et vérifie la racine du coffre. Lève 503 plutôt que de se rabattre. */
+export async function ensureVaultReady(): Promise<string> {
+  const root = getVaultRoot();
+  await assertSentinel(root);
+  try {
+    await fs.mkdir(path.join(root, VAULT_SUBDIR), { recursive: true });
+    await fs.mkdir(path.join(root, STAGING_SUBDIR), { recursive: true });
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : "accès impossible";
+    throw new HttpError(
+      503,
+      "GED_VAULT_UNAVAILABLE",
+      `Le coffre documentaire est inaccessible en écriture : ${detail}`
+    );
+  }
+  return root;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Clés de stockage                                                            */
+/* -------------------------------------------------------------------------- */
+
+export function computeSha256(buffer: Buffer): string {
+  return crypto.createHash("sha256").update(buffer).digest("hex");
+}
+
+/** Clé interne opaque, relative à la racine. N'est jamais retournée par l'API. */
+export function storageKeyForSha256(sha256: string): string {
+  if (!/^[a-f0-9]{64}$/.test(sha256)) {
+    throw new HttpError(500, "GED_VAULT_KEY", "Empreinte invalide pour une clé de coffre.");
+  }
+  return `${VAULT_SUBDIR}/sha256/${sha256.slice(0, 2)}/${sha256.slice(2, 4)}/${sha256}`;
+}
+
+function resolveInsideVault(root: string, storageKey: string): string {
+  const absolute = path.resolve(root, storageKey);
+  if (!isPathInsideDirectory(root, absolute)) {
+    throw new HttpError(400, "GED_VAULT_PATH", "Chemin de stockage invalide.");
+  }
+  return absolute;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Écriture et lecture                                                        */
+/* -------------------------------------------------------------------------- */
+
+export type WrittenBlob = {
+  sha256: string;
+  storage_key: string;
+  size_bytes: number;
+  deduplicated: boolean;
+};
+
+/**
+ * Écrit un blob. Le contenu étant adressé par son empreinte, deux dépôts
+ * identiques convergent naturellement vers le même fichier : `EEXIST` n'est pas
+ * une erreur, c'est de la déduplication.
+ *
+ * `flag: "wx"` garantit qu'un blob existant n'est jamais écrasé.
+ */
+export async function writeBlob(buffer: Buffer): Promise<WrittenBlob> {
+  const root = await ensureVaultReady();
+  const sha256 = computeSha256(buffer);
+  const storageKey = storageKeyForSha256(sha256);
+  const destination = resolveInsideVault(root, storageKey);
+
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+
+  try {
+    await fs.writeFile(destination, buffer, { flag: "wx" });
+    return { sha256, storage_key: storageKey, size_bytes: buffer.byteLength, deduplicated: false };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "EEXIST") {
+      // Le contenu est déjà présent : on vérifie qu'il est bien identique avant
+      // de le réutiliser. Une collision de taille signalerait une corruption.
+      const existing = await fs.readFile(destination);
+      if (computeSha256(existing) !== sha256) {
+        throw new HttpError(
+          409,
+          "GED_INTEGRITY",
+          "Le contenu déjà présent dans le coffre ne correspond pas à son empreinte."
+        );
+      }
+      return { sha256, storage_key: storageKey, size_bytes: buffer.byteLength, deduplicated: true };
+    }
+    if ((err as NodeJS.ErrnoException)?.code === "ENOSPC") {
+      throw new HttpError(507, "GED_VAULT_FULL", "Le coffre documentaire est plein.");
+    }
+    if ((err as NodeJS.ErrnoException)?.code === "EROFS") {
+      throw new HttpError(503, "GED_VAULT_UNAVAILABLE", "Le coffre documentaire est en lecture seule.");
+    }
+    throw err;
+  }
+}
+
+/**
+ * Lit un blob et REVÉRIFIE son empreinte. Un fichier altéré sur disque est
+ * refusé, jamais servi : c'est ce qui distingue un coffre d'un répertoire.
+ */
+export async function readBlob(storageKey: string, expectedSha256: string): Promise<Buffer> {
+  const root = await ensureVaultReady();
+  const source = resolveInsideVault(root, storageKey);
+
+  let buffer: Buffer;
+  try {
+    buffer = await fs.readFile(source);
+  } catch {
+    throw new HttpError(404, "GED_BLOB_NOT_FOUND", "Le contenu documentaire est introuvable.");
+  }
+
+  if (computeSha256(buffer) !== expectedSha256) {
+    throw new HttpError(
+      409,
+      "GED_INTEGRITY",
+      "L'intégrité du document ne peut pas être vérifiée. Le contenu ne sera pas servi."
+    );
+  }
+  return buffer;
+}
+
+/**
+ * Supprime un blob. Réservé à la compensation d'une transaction échouée juste
+ * après l'écriture : un blob déjà référencé n'est jamais supprimé.
+ */
+export async function removeBlobIfOrphan(storageKey: string): Promise<void> {
+  try {
+    const root = getVaultRoot();
+    const target = resolveInsideVault(root, storageKey);
+    await fs.unlink(target);
+  } catch {
+    // La compensation est un filet, pas une garantie : un échec ici ne doit pas
+    // masquer l'erreur d'origine. Le rapport d'intégrité détectera l'orphelin.
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Supervision                                                                */
+/* -------------------------------------------------------------------------- */
+
+export async function checkVaultHealth(): Promise<VaultHealth> {
+  const configured = isVaultConfigured();
+  if (!configured) {
+    return {
+      configured: false,
+      root_present: false,
+      sentinel_required: sentinelRequired(),
+      sentinel_present: false,
+      writable: false,
+      healthy: false,
+      detail: "CERP_GED_VAULT_ROOT n'est pas configuré.",
+    };
+  }
+
+  const root = getVaultRoot();
+  let rootPresent = false;
+  let sentinelPresent = false;
+  let writable = false;
+  let detail: string | null = null;
+
+  try {
+    const stat = await fs.stat(root);
+    rootPresent = stat.isDirectory();
+  } catch {
+    detail = "La racine du coffre est absente ou inaccessible.";
+  }
+
+  try {
+    await fs.access(sentinelPath(root));
+    sentinelPresent = true;
+  } catch {
+    if (sentinelRequired() && detail === null) {
+      detail = "Sentinelle de volume absente : le montage attendu n'est pas en place.";
+    }
+  }
+
+  if (rootPresent) {
+    try {
+      await fs.mkdir(path.join(root, VAULT_SUBDIR), { recursive: true });
+      writable = true;
+    } catch {
+      if (detail === null) detail = "Le coffre n'est pas accessible en écriture.";
+    }
+  }
+
+  const healthy = rootPresent && writable && (!sentinelRequired() || sentinelPresent);
+  return {
+    configured: true,
+    root_present: rootPresent,
+    sentinel_required: sentinelRequired(),
+    sentinel_present: sentinelPresent,
+    writable,
+    healthy,
+    detail: healthy ? null : detail,
+  };
+}

--- a/src/module/ged/services/ged.service.ts
+++ b/src/module/ged/services/ged.service.ts
@@ -1,0 +1,420 @@
+// GED centrale CERP (ADR-0037) — orchestration.
+//
+// Ordre invariant du dépôt : contrôle de contenu -> écriture du blob ->
+// transaction base. Si la transaction échoue après l'écriture, le blob est
+// compensé. L'inverse (base d'abord) laisserait des métadonnées sans fichier,
+// c'est-à-dire des documents fantômes.
+
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { assertAcceptedFile } from "../domain/ged-content";
+import {
+  assertDistinctApprover,
+  assertGedCapability,
+  assertVersionTransition,
+  type GedVersionStatus,
+} from "../domain/ged-policy";
+import {
+  repoAddLink,
+  repoAddVersion,
+  repoCreateDocumentWithVersion,
+  repoFindDocumentByBlobHash,
+  repoGetClass,
+  repoGetDocumentDetail,
+  repoGetTree,
+  repoGetVersionForUpdate,
+  repoInsertApproval,
+  repoInternalGetVersionContentRef,
+  repoListAccessEvents,
+  repoListClasses,
+  repoListDocuments,
+  repoLogAccess,
+  repoObsoletePreviousApplicable,
+  repoSetCurrentVersion,
+  repoSetVersionStatus,
+  repoUpsertBlob,
+  withGedTransaction,
+} from "../repository/ged.repository";
+import type {
+  GedAccessEvent,
+  GedDocumentClass,
+  GedDocumentDetail,
+  GedListFilters,
+  GedListResult,
+  GedTreeNode,
+} from "../types/ged.types";
+import { checkVaultHealth, readBlob, removeBlobIfOrphan, writeBlob } from "./ged-vault.service";
+
+export type GedActor = { id: number; role: string | null };
+
+type UploadedFile = { buffer?: Buffer; originalname?: string; mimetype?: string; size?: number };
+
+/* -------------------------------------------------------------------------- */
+/* Lecture                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export async function listClasses(actor: GedActor): Promise<GedDocumentClass[]> {
+  assertGedCapability(actor.role, "read");
+  return repoListClasses();
+}
+
+export async function listDocuments(actor: GedActor, filters: GedListFilters): Promise<GedListResult> {
+  assertGedCapability(actor.role, "read");
+  return repoListDocuments(filters);
+}
+
+export async function getDocument(actor: GedActor, documentId: string): Promise<GedDocumentDetail> {
+  assertGedCapability(actor.role, "read");
+  const detail = await repoGetDocumentDetail(documentId);
+  if (!detail) {
+    throw new HttpError(404, "GED_DOCUMENT_NOT_FOUND", "Document introuvable.");
+  }
+  return detail;
+}
+
+export async function getTree(actor: GedActor): Promise<GedTreeNode[]> {
+  assertGedCapability(actor.role, "read");
+  const rows = await repoGetTree();
+
+  // L'arborescence est CALCULÉE à partir du référentiel et des liens. Elle
+  // n'existe nulle part sur le disque : renommer une classe ne déplace rien.
+  const byDomain = new Map<string, GedTreeNode>();
+  for (const row of rows) {
+    let domainNode = byDomain.get(row.domain);
+    if (!domainNode) {
+      domainNode = { key: row.domain, label: row.domain, kind: "DOMAIN", documents_count: 0, children: [] };
+      byDomain.set(row.domain, domainNode);
+    }
+    domainNode.children.push({
+      key: row.class_key,
+      label: row.class_label,
+      kind: "CLASS",
+      documents_count: row.documents_count,
+      children: [],
+    });
+    domainNode.documents_count += row.documents_count;
+  }
+  return [...byDomain.values()];
+}
+
+export async function listDocumentHistory(actor: GedActor, documentId: string): Promise<GedAccessEvent[]> {
+  assertGedCapability(actor.role, "read");
+  return repoListAccessEvents(documentId);
+}
+
+export async function getVaultStatus(actor: GedActor) {
+  assertGedCapability(actor.role, "read");
+  return checkVaultHealth();
+}
+
+/* -------------------------------------------------------------------------- */
+/* Dépôt                                                                      */
+/* -------------------------------------------------------------------------- */
+
+export type UploadDocumentInput = {
+  class_key: string;
+  title: string;
+  description?: string | null;
+  change_reason?: string | null;
+  link?: { entity_type: string; entity_id: string; link_role?: string | null } | null;
+};
+
+export async function uploadDocument(
+  actor: GedActor,
+  input: UploadDocumentInput,
+  file: UploadedFile | undefined
+): Promise<GedDocumentDetail> {
+  assertGedCapability(actor.role, "upload");
+
+  const documentClass = await repoGetClass(input.class_key);
+  if (!documentClass) {
+    throw new HttpError(400, "GED_CLASS_UNKNOWN", `Classe documentaire inconnue : ${input.class_key}.`);
+  }
+
+  const accepted = assertAcceptedFile(file, {
+    class_key: documentClass.class_key,
+    allowed_mime_types: documentClass.allowed_mime_types,
+    allowed_extensions: documentClass.allowed_extensions,
+    max_size_bytes: documentClass.max_size_bytes,
+  });
+
+  // 1) Écriture du contenu AVANT la transaction : un blob orphelin se détecte
+  //    et se nettoie ; une métadonnée sans fichier est un mensonge durable.
+  const written = await writeBlob(accepted.buffer);
+
+  try {
+    return await withGedTransaction(async (tx: PoolClient) => {
+      const duplicate = await repoFindDocumentByBlobHash(tx, written.sha256);
+      if (duplicate) {
+        throw new HttpError(
+          409,
+          "GED_FILE_DUPLICATE",
+          `Ce fichier est déjà présent dans la GED sous le code ${duplicate.code}.`
+        );
+      }
+
+      const blob = await repoUpsertBlob(tx, {
+        sha256: written.sha256,
+        size_bytes: written.size_bytes,
+        mime_type: accepted.mime_type,
+        storage_key: written.storage_key,
+        created_by: actor.id,
+      });
+
+      const created = await repoCreateDocumentWithVersion(tx, {
+        class_key: documentClass.class_key,
+        domain: documentClass.domain,
+        title: input.title,
+        description: input.description ?? null,
+        blob_id: blob.id,
+        original_name: accepted.sanitized_name,
+        change_reason: input.change_reason ?? null,
+        created_by: actor.id,
+      });
+
+      if (input.link) {
+        await repoAddLink(tx, {
+          document_id: created.document_id,
+          entity_type: input.link.entity_type,
+          entity_id: input.link.entity_id,
+          link_role: input.link.link_role ?? null,
+          created_by: actor.id,
+        });
+      }
+
+      await repoLogAccess(tx, {
+        document_id: created.document_id,
+        version_id: created.version_id,
+        event_type: "UPLOAD",
+        actor_id: actor.id,
+        details: {
+          class_key: documentClass.class_key,
+          version_number: 1,
+          size_bytes: written.size_bytes,
+          sha256: written.sha256,
+          deduplicated: written.deduplicated,
+        },
+      });
+
+      const detail = await repoGetDocumentDetail(created.document_id);
+      if (!detail) throw new HttpError(500, "GED_DOCUMENT_NOT_FOUND", "Document créé mais illisible.");
+      return detail;
+    });
+  } catch (err) {
+    // Compensation : uniquement si le blob venait d'être créé par ce dépôt.
+    if (!written.deduplicated) await removeBlobIfOrphan(written.storage_key);
+    throw err;
+  }
+}
+
+export async function uploadNewVersion(
+  actor: GedActor,
+  documentId: string,
+  input: { change_reason: string },
+  file: UploadedFile | undefined
+): Promise<GedDocumentDetail> {
+  assertGedCapability(actor.role, "upload");
+
+  const existing = await repoGetDocumentDetail(documentId);
+  if (!existing) throw new HttpError(404, "GED_DOCUMENT_NOT_FOUND", "Document introuvable.");
+  if (existing.archived_at) {
+    throw new HttpError(409, "GED_DOCUMENT_ARCHIVED", "Un document archivé ne reçoit plus de version.");
+  }
+  if (existing.active_checkout && existing.active_checkout.held_by?.id !== actor.id) {
+    throw new HttpError(
+      409,
+      "GED_CHECKOUT_HELD",
+      `Document consigné par ${existing.active_checkout.held_by?.label ?? "un autre utilisateur"}.`
+    );
+  }
+
+  const documentClass = await repoGetClass(existing.class_key);
+  if (!documentClass) {
+    throw new HttpError(400, "GED_CLASS_UNKNOWN", "Classe documentaire inconnue.");
+  }
+
+  const accepted = assertAcceptedFile(file, {
+    class_key: documentClass.class_key,
+    allowed_mime_types: documentClass.allowed_mime_types,
+    allowed_extensions: documentClass.allowed_extensions,
+    max_size_bytes: documentClass.max_size_bytes,
+  });
+
+  const written = await writeBlob(accepted.buffer);
+
+  try {
+    return await withGedTransaction(async (tx: PoolClient) => {
+      const blob = await repoUpsertBlob(tx, {
+        sha256: written.sha256,
+        size_bytes: written.size_bytes,
+        mime_type: accepted.mime_type,
+        storage_key: written.storage_key,
+        created_by: actor.id,
+      });
+
+      const version = await repoAddVersion(tx, {
+        document_id: documentId,
+        blob_id: blob.id,
+        original_name: accepted.sanitized_name,
+        change_reason: input.change_reason,
+        created_by: actor.id,
+      });
+
+      await repoLogAccess(tx, {
+        document_id: documentId,
+        version_id: version.version_id,
+        event_type: "UPLOAD",
+        actor_id: actor.id,
+        details: { version_number: version.version_number, sha256: written.sha256, size_bytes: written.size_bytes },
+      });
+
+      const detail = await repoGetDocumentDetail(documentId);
+      if (!detail) throw new HttpError(500, "GED_DOCUMENT_NOT_FOUND", "Document illisible après ajout de version.");
+      return detail;
+    });
+  } catch (err) {
+    if (!written.deduplicated) await removeBlobIfOrphan(written.storage_key);
+    throw err;
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Cycle de vie                                                               */
+/* -------------------------------------------------------------------------- */
+
+async function transitionVersion(
+  actor: GedActor,
+  versionId: string,
+  target: GedVersionStatus,
+  options: { comment?: string | null; requireDistinctApprover?: boolean }
+): Promise<GedDocumentDetail> {
+  return withGedTransaction(async (tx) => {
+    const version = await repoGetVersionForUpdate(tx, versionId);
+    if (!version) throw new HttpError(404, "GED_VERSION_NOT_FOUND", "Version introuvable.");
+
+    assertVersionTransition(version.status, target);
+
+    if (options.requireDistinctApprover) {
+      assertDistinctApprover(version.created_by, actor.id);
+    }
+
+    if (target === "APPLICABLE") {
+      // Une seule version applicable : la précédente bascule OBSOLETE dans la
+      // MÊME transaction. Jamais deux applicables, jamais zéro entre-temps.
+      await repoObsoletePreviousApplicable(tx, version.document_id, version.id);
+    }
+
+    await repoSetVersionStatus(tx, version.id, target, actor.id);
+
+    if (target === "APPLICABLE") {
+      await repoSetCurrentVersion(tx, version.document_id, version.id);
+    }
+
+    if (target === "EN_REVUE") {
+      await repoInsertApproval(tx, {
+        version_id: version.id, decision: "SUBMITTED", comment: options.comment ?? null, decided_by: actor.id,
+      });
+    }
+    if (target === "APPROUVE") {
+      await repoInsertApproval(tx, {
+        version_id: version.id, decision: "APPROVED", comment: options.comment ?? null, decided_by: actor.id,
+      });
+    }
+
+    const eventByTarget: Record<string, string> = {
+      EN_REVUE: "SUBMIT", APPROUVE: "APPROVE", APPLICABLE: "PUBLISH", OBSOLETE: "OBSOLETE", BROUILLON: "SUBMIT",
+    };
+    await repoLogAccess(tx, {
+      document_id: version.document_id,
+      version_id: version.id,
+      event_type: eventByTarget[target] ?? "SUBMIT",
+      actor_id: actor.id,
+      details: { from: version.status, to: target, version_number: version.version_number },
+    });
+
+    const detail = await repoGetDocumentDetail(version.document_id);
+    if (!detail) throw new HttpError(500, "GED_DOCUMENT_NOT_FOUND", "Document illisible après transition.");
+    return detail;
+  });
+}
+
+export async function submitVersion(actor: GedActor, versionId: string, comment: string | null) {
+  assertGedCapability(actor.role, "submit");
+  return transitionVersion(actor, versionId, "EN_REVUE", { comment });
+}
+
+export async function approveVersion(actor: GedActor, versionId: string, comment: string | null) {
+  assertGedCapability(actor.role, "approve");
+  return transitionVersion(actor, versionId, "APPROUVE", { comment, requireDistinctApprover: true });
+}
+
+export async function publishVersion(actor: GedActor, versionId: string) {
+  assertGedCapability(actor.role, "publish");
+  return transitionVersion(actor, versionId, "APPLICABLE", {});
+}
+
+export async function obsoleteVersion(actor: GedActor, versionId: string, reason: string | null) {
+  assertGedCapability(actor.role, "obsolete");
+  return transitionVersion(actor, versionId, "OBSOLETE", { comment: reason });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Téléchargement                                                             */
+/* -------------------------------------------------------------------------- */
+
+export type DownloadResult = {
+  buffer: Buffer;
+  original_name: string;
+  mime_type: string;
+  sha256: string;
+};
+
+export async function downloadVersion(actor: GedActor, versionId: string): Promise<DownloadResult> {
+  assertGedCapability(actor.role, "download");
+
+  const ref = await repoInternalGetVersionContentRef(versionId);
+  if (!ref) throw new HttpError(404, "GED_VERSION_NOT_FOUND", "Version introuvable.");
+
+  // Un brouillon n'est jamais servi à qui n'a pas le droit de le voir : il n'est
+  // pas encore un document opposable.
+  if (ref.status === "BROUILLON") {
+    assertGedCapability(actor.role, "upload");
+  }
+
+  let buffer: Buffer;
+  try {
+    // L'empreinte est RECALCULÉE ici : un fichier altéré sur disque est refusé.
+    buffer = await readBlob(ref.storage_key, ref.sha256);
+  } catch (err) {
+    if (err instanceof HttpError && err.code === "GED_INTEGRITY") {
+      // Une atteinte à l'intégrité est un événement de sécurité : elle est
+      // journalisée même si la lecture échoue.
+      await repoLogAccess(pool, {
+        document_id: ref.document_id,
+        version_id: ref.version_id,
+        event_type: "INTEGRITY_FAILURE",
+        actor_id: actor.id,
+        details: { expected_sha256: ref.sha256 },
+      }).catch(() => undefined);
+    }
+    throw err;
+  }
+
+  // Le journal ne doit jamais faire échouer un téléchargement légitime.
+  await repoLogAccess(pool, {
+    document_id: ref.document_id,
+    version_id: ref.version_id,
+    event_type: "DOWNLOAD",
+    actor_id: actor.id,
+    details: { size_bytes: buffer.byteLength },
+  }).catch(() => undefined);
+
+  return {
+    buffer,
+    original_name: ref.original_name,
+    mime_type: ref.mime_type,
+    sha256: ref.sha256,
+  };
+}

--- a/src/module/ged/types/ged.types.ts
+++ b/src/module/ged/types/ged.types.ts
@@ -1,0 +1,129 @@
+// GED centrale CERP (ADR-0037) — types exposés.
+//
+// RÈGLE DE CONTRAT : aucun de ces types ne porte `storage_path`, `storage_key`
+// ni `stored_name`. Le chemin physique ne quitte jamais le serveur. Un test de
+// contrat balaie l'ensemble des réponses pour le garantir.
+
+import type { GedVersionStatus } from "../domain/ged-policy";
+
+export type GedDocumentClass = {
+  class_key: string;
+  domain: string;
+  label: string;
+  nature: "SOURCE" | "GENERATED" | "EVIDENCE" | "REPRESENTATION";
+  allowed_mime_types: string[];
+  allowed_extensions: string[];
+  max_size_bytes: number;
+  approvals_required: number;
+  retention_months: number | null;
+  hold_on_publish: boolean;
+  is_active: boolean;
+};
+
+export type GedActorLite = {
+  id: number;
+  username: string | null;
+  label: string;
+} | null;
+
+/** Métadonnées non sensibles d'une version. Le chemin réel n'est jamais exposé. */
+export type GedDocumentVersion = {
+  id: string;
+  document_id: string;
+  version_number: number;
+  status: GedVersionStatus;
+  original_name: string;
+  mime_type: string;
+  size_bytes: number;
+  sha256: string;
+  change_reason: string | null;
+  created_at: string;
+  created_by: GedActorLite;
+  submitted_at: string | null;
+  approved_at: string | null;
+  approved_by: GedActorLite;
+  published_at: string | null;
+  obsoleted_at: string | null;
+};
+
+export type GedDocumentLink = {
+  id: string;
+  entity_type: string;
+  entity_id: string;
+  link_role: string | null;
+  created_at: string;
+};
+
+export type GedRetentionHold = {
+  id: string;
+  hold_type: "QUALITE" | "LEGAL" | "RETENTION";
+  reason: string;
+  placed_at: string;
+  released_at: string | null;
+};
+
+export type GedDocumentSummary = {
+  id: string;
+  code: string;
+  class_key: string;
+  class_label: string;
+  domain: string;
+  title: string;
+  description: string | null;
+  current_version_number: number | null;
+  current_version_status: GedVersionStatus | null;
+  versions_count: number;
+  has_active_hold: boolean;
+  created_at: string;
+  updated_at: string;
+  archived_at: string | null;
+};
+
+export type GedDocumentDetail = GedDocumentSummary & {
+  current_version: GedDocumentVersion | null;
+  versions: GedDocumentVersion[];
+  links: GedDocumentLink[];
+  holds: GedRetentionHold[];
+  active_checkout: {
+    id: string;
+    held_by: GedActorLite;
+    reason: string;
+    checked_out_at: string;
+    expires_at: string;
+  } | null;
+};
+
+export type GedTreeNode = {
+  key: string;
+  label: string;
+  kind: "DOMAIN" | "CLASS";
+  documents_count: number;
+  children: GedTreeNode[];
+};
+
+export type GedListFilters = {
+  q?: string | null;
+  class_key?: string | null;
+  domain?: string | null;
+  status?: GedVersionStatus | null;
+  entity_type?: string | null;
+  entity_id?: string | null;
+  include_archived?: boolean;
+  page: number;
+  page_size: number;
+};
+
+export type GedListResult = {
+  items: GedDocumentSummary[];
+  total: number;
+  page: number;
+  page_size: number;
+};
+
+export type GedAccessEvent = {
+  id: string;
+  event_type: string;
+  actor: GedActorLite;
+  occurred_at: string;
+  details: Record<string, unknown> | null;
+};

--- a/src/module/ged/validators/ged.validators.ts
+++ b/src/module/ged/validators/ged.validators.ts
@@ -1,0 +1,46 @@
+// GED centrale CERP (ADR-0037) — validation d'entrée.
+
+import { z } from "zod";
+
+import { GED_VERSION_STATUSES } from "../domain/ged-policy";
+
+const trimmed = (min: number, max: number) =>
+  z.string().transform((v) => v.trim()).pipe(z.string().min(min).max(max));
+
+export const uploadDocumentBodySchema = z.object({
+  class_key: trimmed(1, 64),
+  title: trimmed(2, 200),
+  description: z.string().trim().max(2000).optional().nullable(),
+  change_reason: z.string().trim().max(500).optional().nullable(),
+  entity_type: z.string().trim().max(64).optional().nullable(),
+  entity_id: z.string().trim().max(128).optional().nullable(),
+  link_role: z.string().trim().max(64).optional().nullable(),
+});
+
+export type UploadDocumentBody = z.infer<typeof uploadDocumentBodySchema>;
+
+export const newVersionBodySchema = z.object({
+  // Une nouvelle version exige un motif : « pourquoi » fait partie du document.
+  change_reason: trimmed(3, 500),
+});
+
+export const transitionBodySchema = z.object({
+  comment: z.string().trim().max(1000).optional().nullable(),
+});
+
+export const listQuerySchema = z.object({
+  q: z.string().trim().max(200).optional().nullable(),
+  class_key: z.string().trim().max(64).optional().nullable(),
+  domain: z.string().trim().max(64).optional().nullable(),
+  status: z.enum(GED_VERSION_STATUSES).optional().nullable(),
+  entity_type: z.string().trim().max(64).optional().nullable(),
+  entity_id: z.string().trim().max(128).optional().nullable(),
+  include_archived: z
+    .union([z.boolean(), z.string()])
+    .optional()
+    .transform((v) => v === true || v === "true" || v === "1"),
+  page: z.coerce.number().int().min(1).max(10000).optional().default(1),
+  page_size: z.coerce.number().int().min(1).max(100).optional().default(25),
+});
+
+export const uuidParamSchema = z.string().uuid("Identifiant invalide.");

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -46,6 +46,7 @@ import asbuiltRoutes from "../module/asbuilt/routes/asbuilt.routes"
 import locksRoutes from "../module/locks/routes/locks.routes"
 import tempsDeplacementsRoutes from "../module/temps-deplacements/routes/temps-deplacements.routes"
 import projectOfficeRoutes from "../module/project-office/routes/project-office.routes"
+import gedRoutes from "../module/ged/routes/ged.routes"
 import gammesRoutes from "../module/gammes/routes/gammes.routes"
 import pieceTechniqueVersionsRoutes from "../module/gammes/routes/piece-technique-versions.routes"
 import importAssistantRoutes from "../module/import-assistant/routes/import-assistant.routes"
@@ -127,5 +128,9 @@ router.use("/asbuilt", asbuiltRoutes)
 router.use("/locks", locksRoutes)
 router.use("/time-clock", tempsDeplacementsRoutes) // Module « Temps & Déplacements » (RH pointage/kilomètres)
 router.use("/project-office", projectOfficeRoutes) // Module « Project Office » (#130) — feature gate PROJECT_OFFICE fail-closed
+// GED centrale (ADR-0037). Additif : aucun module existant n'est rebranché.
+// Si le patch 20260727_ged_core n'est pas appliqué, ces routes répondent
+// 503 GED_NOT_INSTALLED sans affecter le reste de l'API.
+router.use("/ged", gedRoutes)
 router.use("/import-assistant", importAssistantRoutes) // CLIPPER -> CERP staged import assistant (#167)
 export default router


### PR DESCRIPTION
Closes #203

## Ce que ça change

Ajoute la GED centrale CERP. **Strictement additif** : 16 fichiers nouveaux, 1 seul modifié
(`src/routes/v1.routes.ts`, +5 lignes pour monter le routeur). Aucune table existante n'est
modifiée, aucun module actuel n'est rebranché.

## Pourquoi

Trois défauts mesurés dans `origin/dev` :

| Écart | Preuve |
|---|---|
| Deux coffres binaires pour la même base `cerp_prod` | `Dockerfile` `ENV CERP_DOCUMENTS_ROOT=/app/data/documents` + `VOLUME` (VPS) vs `/srv/cerp/data` (atelier) |
| Aucun contrôle de contenu hors Project Office | aucun `fileFilter` dans les 9 modules examinés |
| Documents techniques liés à la pièce, pas à sa version | `pieces_techniques_documents.piece_technique_id` |

## Garanties prouvées contre PostgreSQL réel (`cerp_test`, transaction annulée)

| Garde-fou | Résultat |
|---|---|
| Modifier une version `APPROUVE` | `GED_VERSION_IMMUTABLE` |
| Auto-approbation | `GED_APPROVAL_SELF` |
| Modifier un code documentaire | `GED_CODE_IMMUTABLE` |
| Deux versions applicables | violation d'unicité |
| Archiver un document sous gel | `GED_RETENTION_HOLD` |
| Modifier un manifeste figé | `GED_MANIFEST_IMMUTABLE` |
| `UPDATE`/`DELETE` sur le journal d'accès en `cerp_app` | `permission denied` (avant même le trigger) |

## Tests

**2760 verts, 122 fichiers, 0 échec** (36 nouveaux). Dont :
- exécutable renommé en `.pdf` → `415 GED_FILE_SIGNATURE`
- coffre absent → `503`, **aucun fichier écrit ailleurs**
- schéma absent → `503 GED_NOT_INSTALLED`, le reste de l'API intact
- aucune réponse ne contient de chemin physique

## Base de données

Patch `20260727_ged_core.sql` appliqué et vérifié sur **`cerp_test` uniquement**.
`cerp_prod` **non modifié**. Sauvegarde prise avant application (39 Mo, intégrité OK).
Verify 100 % vert, dont `legacy_tables_untouched = t`.

## Déploiement

Ce code fonctionne sans le patch : les routes GED répondent `503 GED_NOT_INSTALLED` et
le reste de l'API est inchangé. Deux variables sont à définir pour activer le coffre :
`CERP_GED_VAULT_ROOT` et `CERP_GED_SENTINEL`.

## Restes

- application du patch sur `cerp_prod` (**validation humaine requise**)
- préparation du volume `/mnt/cerp-ged` (audit matériel préalable)
- bascule vers l'écrivain unique (écart des deux coffres)
- recette navigateur

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Introduce a new central document management (GED) module with its own storage vault, versioning model, HTTP API routes, and PostgreSQL schema, wired additively into the existing v1 API without changing legacy modules.

New Features:
- Expose new /ged API endpoints for listing, uploading, versioning, and downloading documents with role-based access control and strict request validation.
- Add a central GED domain layer enforcing document lifecycle policies, RBAC capabilities, file-type and signature checks, and document code generation independent of storage paths.
- Implement a secure filesystem vault service that stores blobs by hash, verifies integrity on read, and fails fast when the configured document volume is unavailable.
- Introduce a full PostgreSQL GED core schema covering document classes, blobs, versions, links, manifests, retention holds, approvals, checkouts, upload sessions, and an append-only access audit log, plus preflight/verify/rollback support scripts.
- Add typed GED repository and service layers for transactional operations such as uploads, version transitions, and audit logging, while keeping storage keys internal to the server.

Enhancements:
- Add a new Express router for the GED module and integrate it into the v1 routes without modifying or rerouting existing modules.
- Define strongly typed GED DTOs to ensure no physical storage paths or internal storage keys are ever serialized to API consumers.

Deployment:
- Provide configuration-driven activation of the GED vault via environment variables, including optional sentinel checks to ensure the correct storage volume is mounted.

Documentation:
- Document database-level invariants and guard-rails for the GED schema, including immutability, single applicable version, retention holds, and append-only access logging within the migration SQL comments.

Tests:
- Add domain-level tests for GED RBAC capabilities, lifecycle rules, file validation, naming sanitization, and storage key generation.
- Add route-level tests covering GED RBAC, behavior when the schema is missing, vault unavailability handling, executable blocking, and contract checks ensuring no physical paths leak in API responses.