### PR TITLE
Release — Bibliothèque de finitions et résolution d'article de sous-traitance (#210)

### DIFF
--- a/db/patches/20260728_surface_finish_library_210.sql
+++ b/db/patches/20260728_surface_finish_library_210.sql
@@ -1,0 +1,703 @@
+-- 20260728_surface_finish_library_210.sql
+--
+-- Bibliothèque de finitions et génération d'articles de sous-traitance (#210 / web #339).
+-- ADR : crp-systems-web/docs/adr/ADR-0038-surface-finish-library.md
+--
+-- ADDITIF, IDEMPOTENT, NON DESTRUCTIF :
+--   - 6 nouvelles tables (référentiel administrable, finitions, révisions, documents,
+--     exigence d'opération, reçus d'idempotence) ;
+--   - colonnes NULLABLES ajoutées à `articles_traitement` (spécialisation existante,
+--     PK article_id) et à `pieces_techniques_achats` (liaison FK vers l'opération) ;
+--   - élargissement du whitelist de `fn_next_issued_code_value` au scope `FIN`.
+--   Aucune table existante n'est renommée, vidée, ni recodée. AUCUN BACKFILL :
+--   l'historique reste tel quel, un rapport de candidats est fourni séparément
+--   (db/patches/support/20260728_surface_finish_library_210.candidates.sql).
+--
+-- Pipeline db/patches (exécuté en tant que cerp_app). Cible : PostgreSQL 17.
+--   Preflight : db/patches/support/20260728_surface_finish_library_210.preflight.sql
+--   Verify    : db/patches/support/20260728_surface_finish_library_210.verify.sql
+--   Rollback  : db/patches/support/20260728_surface_finish_library_210.rollback.sql
+
+BEGIN;
+
+/* -------------------------------------------------------------------------- */
+/* 0) Pré-requis structurels                                                  */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF to_regclass('public.gammes') IS NULL THEN
+    RAISE EXCEPTION '#210: public.gammes is missing — apply 20260707_pieces_techniques_gpao_versions_gammes.sql first';
+  END IF;
+  IF to_regclass('public.articles_traitement') IS NULL THEN
+    RAISE EXCEPTION '#210: public.articles_traitement is missing — apply 20260319_articles_domain_subtypes.sql first';
+  END IF;
+  IF to_regprocedure('public.fn_next_issued_code_value(text)') IS NULL THEN
+    RAISE EXCEPTION '#210: public.fn_next_issued_code_value(text) is missing — apply 20260713_codification_versions_of_vsm.sql first';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 1) Codification : le scope FIN rejoint le whitelist                        */
+/* -------------------------------------------------------------------------- */
+-- Corps identique à 20260726_metrologie_360_229.sql, le whitelist gagne `FIN`.
+-- Aucun scope existant n'est retiré (MCH et MET restent, cf. régression 20260725).
+
+CREATE OR REPLACE FUNCTION public.fn_next_issued_code_value(p_scope text)
+RETURNS bigint
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+DECLARE
+  v_scope text := upper(btrim(COALESCE(p_scope, '')));
+BEGIN
+  IF v_scope !~ '^(CLI|FOU|MCH|MET|FIN|ART:[A-Z0-9]{1,48}|(DEV|CMD|AFF|OF|LOT|MVT|CQ|NC|CAPA|BL|FACT|BCF|PC|DER|MEX|MIA):[0-9]{4})$' THEN
+    RAISE EXCEPTION 'Unsupported business-code sequence scope: %', p_scope
+      USING ERRCODE = '22023';
+  END IF;
+  RETURN nextval('public.cerp_business_code_issue_seq'::regclass);
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_next_issued_code_value(text) IS
+  'Whitelisted, non-reusable business-code allocator backed by a native PostgreSQL sequence. Scopes: CLI, FOU, MCH, MET, FIN, ART:<FAMILY>, <PREFIX>:<YEAR>.';
+
+/* -------------------------------------------------------------------------- */
+/* 1bis) Fonctions utilitaires immuables (recherche et unités)                 */
+/* -------------------------------------------------------------------------- */
+-- `unaccent` n'est pas garanti installé sur toutes les bases CERP : on
+-- normalise avec `translate`, qui est natif, immuable et indexable.
+
+CREATE OR REPLACE FUNCTION public.surface_finish_norm(p_value text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+  SELECT lower(translate(
+    COALESCE(p_value, ''),
+    'ÀÁÂÃÄÅàáâãäåÈÉÊËèéêëÌÍÎÏìíîïÒÓÔÕÖØòóôõöøÙÚÛÜùúûüÇçÑñŸÿ',
+    'AAAAAAaaaaaaEEEEeeeeIIIIiiiiOOOOOOooooooUUUUuuuuCcNnYy'
+  ))
+$$;
+
+COMMENT ON FUNCTION public.surface_finish_norm(text) IS
+  '#210 — Normalisation de recherche (minuscules + accents neutralisés), sans dépendre de l''extension unaccent.';
+
+-- Conversion vers le micromètre, unité pivot des épaisseurs de revêtement.
+-- Miroir EXACT de `thicknessToMicrometers` côté TypeScript.
+CREATE OR REPLACE FUNCTION public.surface_finish_to_um(p_value numeric, p_unit text)
+RETURNS numeric
+LANGUAGE sql
+IMMUTABLE
+PARALLEL SAFE
+AS $$
+  SELECT CASE lower(btrim(COALESCE(p_unit, 'um')))
+    WHEN 'um'  THEN p_value
+    WHEN 'mm'  THEN p_value * 1000
+    WHEN 'cm'  THEN p_value * 10000
+    WHEN 'in'  THEN p_value * 25400
+    WHEN 'mil' THEN p_value * 25.4
+    ELSE NULL
+  END
+$$;
+
+COMMENT ON FUNCTION public.surface_finish_to_um(numeric, text) IS
+  '#210 — Épaisseur normalisée en micromètres. Miroir de thicknessToMicrometers (surface-finish-policy.ts).';
+
+/* -------------------------------------------------------------------------- */
+/* 2) Familles de finitions — référentiel ADMINISTRABLE (jamais un enum)      */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.surface_finish_families (
+  code            text PRIMARY KEY,
+  label           text NOT NULL,
+  description     text NULL,
+  sort_order      integer NOT NULL DEFAULT 100,
+  is_active       boolean NOT NULL DEFAULT true,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT surface_finish_families_code_not_blank CHECK (btrim(code) <> ''),
+  CONSTRAINT surface_finish_families_label_not_blank CHECK (btrim(label) <> '')
+);
+
+COMMENT ON TABLE public.surface_finish_families IS
+  '#210 — Familles de finitions administrables. Ajouter une famille est un acte de paramétrage, pas une migration.';
+
+-- Amorçage : familles couramment employées chez CRP. `ON CONFLICT DO NOTHING`
+-- pour ne jamais écraser un libellé ajusté par le métier après coup.
+INSERT INTO public.surface_finish_families (code, label, description, sort_order) VALUES
+  ('ANODISATION',        'Anodisation',                    'Oxydation anodique décorative ou protectrice de l''aluminium.', 10),
+  ('ANODISATION_DURE',   'Anodisation dure',               'Oxydation anodique dure, forte épaisseur et dureté.',           20),
+  ('PASSIVATION',        'Passivation',                    'Passivation des aciers inoxydables et alliages.',               30),
+  ('ZINGAGE',            'Zingage',                        'Revêtement électrolytique de zinc et alliages de zinc.',        40),
+  ('NICKELAGE_CHIMIQUE', 'Nickelage chimique',             'Dépôt autocatalytique de nickel-phosphore.',                    50),
+  ('CHROMAGE',           'Chromage',                       'Dépôt électrolytique de chrome, dur ou décoratif.',             60),
+  ('BRUNISSAGE',         'Brunissage',                     'Oxydation noire des aciers.',                                   70),
+  ('PHOSPHATATION',      'Phosphatation',                  'Conversion phosphatante, zinc ou manganèse.',                   80),
+  ('PEINTURE',           'Peinture',                       'Peinture liquide, primaire et finition.',                       90),
+  ('THERMOLAQUAGE',      'Thermolaquage',                  'Poudre polymérisée au four.',                                  100),
+  ('CATAPHORESE',        'Cataphorèse',                    'Électrodéposition cathodique.',                                110),
+  ('PREPARATION_SURFACE','Préparation / finition mécanique','Sablage, grenaillage, polissage, tribofinition, ébavurage.',   120),
+  ('AUTRE',              'Autre procédé validé',           'Procédé validé hors familles listées.',                        900)
+ON CONFLICT (code) DO NOTHING;
+
+/* -------------------------------------------------------------------------- */
+/* 3) Finitions — définition maître (identité)                                */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.surface_finishes (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code                text NOT NULL,
+  family_code         text NOT NULL,
+  procede             text NOT NULL,
+  designation_courte  text NOT NULL,
+  designation_longue  text NULL,
+  description         text NULL,
+  synonymes           text[] NOT NULL DEFAULT ARRAY[]::text[],
+  statut              text NOT NULL DEFAULT 'BROUILLON',
+  current_revision_id uuid NULL,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now(),
+  created_by          integer NULL,
+  updated_by          integer NULL,
+  CONSTRAINT surface_finishes_code_uq UNIQUE (code),
+  CONSTRAINT surface_finishes_code_format CHECK (code ~ '^FIN-[0-9]{6}$'),
+  CONSTRAINT surface_finishes_designation_not_blank CHECK (btrim(designation_courte) <> ''),
+  CONSTRAINT surface_finishes_procede_not_blank CHECK (btrim(procede) <> ''),
+  CONSTRAINT surface_finishes_statut_check CHECK (
+    statut IN ('BROUILLON','EN_VALIDATION','ACTIVE','SUSPENDUE','OBSOLETE','ARCHIVEE')
+  ),
+  CONSTRAINT surface_finishes_family_fk FOREIGN KEY (family_code)
+    REFERENCES public.surface_finish_families(code) ON DELETE RESTRICT
+);
+
+COMMENT ON TABLE public.surface_finishes IS
+  '#210 — Définition maître d''un procédé de finition. Le code FIN-NNNNNN est alloué par le serveur et immuable.';
+COMMENT ON COLUMN public.surface_finishes.synonymes IS
+  'Synonymes de recherche saisis par le métier (« alu noir », « OAD »…). Sert à la recherche, jamais à l''identité.';
+
+CREATE INDEX IF NOT EXISTS surface_finishes_family_idx ON public.surface_finishes (family_code);
+CREATE INDEX IF NOT EXISTS surface_finishes_statut_idx ON public.surface_finishes (statut);
+-- Index alignés sur les prédicats réels de la recherche (`surface_finish_norm`).
+CREATE INDEX IF NOT EXISTS surface_finishes_code_norm_idx
+  ON public.surface_finishes (public.surface_finish_norm(code));
+CREATE INDEX IF NOT EXISTS surface_finishes_designation_norm_idx
+  ON public.surface_finishes (public.surface_finish_norm(designation_courte));
+CREATE INDEX IF NOT EXISTS surface_finishes_procede_norm_idx
+  ON public.surface_finishes (public.surface_finish_norm(procede));
+CREATE INDEX IF NOT EXISTS surface_finishes_synonymes_gin_idx ON public.surface_finishes USING gin (synonymes);
+
+/* -------------------------------------------------------------------------- */
+/* 4) Révisions — la définition technique VERSIONNÉE                          */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.surface_finish_revisions (
+  id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  finish_id               uuid NOT NULL,
+  revision                integer NOT NULL,
+  statut                  text NOT NULL DEFAULT 'BROUILLON',
+
+  -- Référence normative : CERP stocke la RÉFÉRENCE et les paramètres validés
+  -- par CRP. Aucun contenu protégé de norme n'est recopié ici.
+  norme                   text NULL,
+  reference_client        text NULL,
+  classe                  text NULL,
+  substrat                text NULL,
+
+  epaisseur_min           numeric NULL,
+  epaisseur_nominale      numeric NULL,
+  epaisseur_max           numeric NULL,
+  epaisseur_unite         text NOT NULL DEFAULT 'um',
+
+  couleur                 text NULL,
+  teinte_ral              text NULL,
+  aspect                  text NULL,
+  brillance               text NULL,
+  rugosite                text NULL,
+  durete                  text NULL,
+  exigence_corrosion      text NULL,
+
+  pretraitement           text NULL,
+  posttraitement          text NULL,
+  zones_defaut            text[] NOT NULL DEFAULT ARRAY[]::text[],
+  regles_masquage         text[] NOT NULL DEFAULT ARRAY[]::text[],
+
+  criteres_acceptation    text NULL,
+  controles               text[] NOT NULL DEFAULT ARRAY[]::text[],
+  certificat_requis       boolean NOT NULL DEFAULT false,
+  certificat_type         text NULL,
+  conditionnement_retour  text NULL,
+  unite_achat             text NOT NULL DEFAULT 'PCE',
+
+  designation_template    text NULL,
+  commentaire_template    text NULL,
+  template_version        integer NOT NULL DEFAULT 1,
+
+  date_effet              date NULL,
+  approbateur_user_id     integer NULL,
+  approved_at             timestamptz NULL,
+
+  created_at              timestamptz NOT NULL DEFAULT now(),
+  updated_at              timestamptz NOT NULL DEFAULT now(),
+  created_by              integer NULL,
+  updated_by              integer NULL,
+
+  CONSTRAINT surface_finish_revisions_finish_fk FOREIGN KEY (finish_id)
+    REFERENCES public.surface_finishes(id) ON DELETE CASCADE,
+  CONSTRAINT surface_finish_revisions_finish_rev_uq UNIQUE (finish_id, revision),
+  CONSTRAINT surface_finish_revisions_revision_positive CHECK (revision >= 1),
+  CONSTRAINT surface_finish_revisions_statut_check CHECK (
+    statut IN ('BROUILLON','EN_VALIDATION','ACTIVE','SUSPENDUE','OBSOLETE','ARCHIVEE')
+  ),
+  CONSTRAINT surface_finish_revisions_unite_check CHECK (
+    epaisseur_unite IN ('um','mm','cm','in','mil')
+  ),
+  CONSTRAINT surface_finish_revisions_epaisseur_positive CHECK (
+    (epaisseur_min IS NULL OR epaisseur_min >= 0)
+    AND (epaisseur_nominale IS NULL OR epaisseur_nominale >= 0)
+    AND (epaisseur_max IS NULL OR epaisseur_max >= 0)
+  ),
+  CONSTRAINT surface_finish_revisions_epaisseur_coherente CHECK (
+    (epaisseur_min IS NULL OR epaisseur_max IS NULL OR epaisseur_min <= epaisseur_max)
+    AND (epaisseur_nominale IS NULL OR epaisseur_min IS NULL OR epaisseur_nominale >= epaisseur_min)
+    AND (epaisseur_nominale IS NULL OR epaisseur_max IS NULL OR epaisseur_nominale <= epaisseur_max)
+  ),
+  -- Un certificat exigé sans type est une exigence incomplète.
+  CONSTRAINT surface_finish_revisions_certificat_coherent CHECK (
+    certificat_requis = false OR btrim(COALESCE(certificat_type, '')) <> ''
+  ),
+  CONSTRAINT surface_finish_revisions_template_version_positive CHECK (template_version >= 1)
+);
+
+COMMENT ON TABLE public.surface_finish_revisions IS
+  '#210 — Révision versionnée d''une finition : c''est ELLE qui porte la définition technique opposable.';
+COMMENT ON COLUMN public.surface_finish_revisions.norme IS
+  'Référence de la norme ou spécification (ex. « ISO 7599 »). Le texte de la norme n''est jamais recopié.';
+
+CREATE INDEX IF NOT EXISTS surface_finish_revisions_finish_idx
+  ON public.surface_finish_revisions (finish_id);
+CREATE INDEX IF NOT EXISTS surface_finish_revisions_statut_idx
+  ON public.surface_finish_revisions (statut);
+CREATE INDEX IF NOT EXISTS surface_finish_revisions_norme_norm_idx
+  ON public.surface_finish_revisions (public.surface_finish_norm(norme));
+CREATE INDEX IF NOT EXISTS surface_finish_revisions_couleur_norm_idx
+  ON public.surface_finish_revisions (public.surface_finish_norm(couleur));
+CREATE INDEX IF NOT EXISTS surface_finish_revisions_ral_norm_idx
+  ON public.surface_finish_revisions (public.surface_finish_norm(teinte_ral));
+
+-- Une seule révision ACTIVE par finition : « la » révision applicable est non ambiguë.
+CREATE UNIQUE INDEX IF NOT EXISTS surface_finish_revisions_single_active_uq
+  ON public.surface_finish_revisions (finish_id)
+  WHERE statut = 'ACTIVE';
+
+-- Lien retour vers la révision courante (posé après création de la table cible).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'surface_finishes_current_revision_fk'
+      AND conrelid = 'public.surface_finishes'::regclass
+  ) THEN
+    ALTER TABLE public.surface_finishes
+      ADD CONSTRAINT surface_finishes_current_revision_fk
+      FOREIGN KEY (current_revision_id)
+      REFERENCES public.surface_finish_revisions(id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 5) Documents techniques d'une révision                                     */
+/* -------------------------------------------------------------------------- */
+-- Registre de RÉFÉRENCES documentaires. Le coffre est la GED centrale
+-- (ADR-0037) : aucun chemin de stockage n'est stocké ni exposé ici.
+
+CREATE TABLE IF NOT EXISTS public.surface_finish_revision_documents (
+  id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  revision_id         uuid NOT NULL,
+  libelle             text NOT NULL,
+  doc_type            text NOT NULL DEFAULT 'SPECIFICATION',
+  ged_document_id     uuid NULL,
+  reference_externe   text NULL,
+  sha256              text NULL,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  created_by          integer NULL,
+  CONSTRAINT surface_finish_revision_documents_revision_fk FOREIGN KEY (revision_id)
+    REFERENCES public.surface_finish_revisions(id) ON DELETE CASCADE,
+  CONSTRAINT surface_finish_revision_documents_libelle_not_blank CHECK (btrim(libelle) <> ''),
+  CONSTRAINT surface_finish_revision_documents_type_check CHECK (
+    doc_type IN ('SPECIFICATION','NORME','FICHE_TECHNIQUE','PLAN_MASQUAGE','CERTIFICAT_TYPE','AUTRE')
+  ),
+  -- Un document sans aucune ancre (ni GED, ni référence externe) n'est pas un document.
+  CONSTRAINT surface_finish_revision_documents_anchor_required CHECK (
+    ged_document_id IS NOT NULL OR btrim(COALESCE(reference_externe, '')) <> ''
+  ),
+  CONSTRAINT surface_finish_revision_documents_sha_format CHECK (
+    sha256 IS NULL OR sha256 ~ '^[0-9a-f]{64}$'
+  )
+);
+
+COMMENT ON TABLE public.surface_finish_revision_documents IS
+  '#210 — Références documentaires d''une révision. Le binaire vit dans la GED centrale ; aucun storage_path ici.';
+
+CREATE INDEX IF NOT EXISTS surface_finish_revision_documents_revision_idx
+  ON public.surface_finish_revision_documents (revision_id);
+
+/* -------------------------------------------------------------------------- */
+/* 6) Exigence de finition d'une opération de gamme                           */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.gamme_operation_finitions (
+  id                            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  gamme_id                      uuid NOT NULL,
+  gamme_operation_id            uuid NOT NULL,
+  piece_technique_version_id    uuid NOT NULL,
+  finish_revision_id            uuid NOT NULL,
+
+  perimetre                     text NOT NULL DEFAULT 'PIECE_ENTIERE',
+  zones                         text[] NOT NULL DEFAULT ARRAY[]::text[],
+  masquages                     text[] NOT NULL DEFAULT ARRAY[]::text[],
+
+  norme                         text NULL,
+  classe                        text NULL,
+  epaisseur_min                 numeric NULL,
+  epaisseur_nominale            numeric NULL,
+  epaisseur_max                 numeric NULL,
+  epaisseur_unite               text NOT NULL DEFAULT 'um',
+  couleur                       text NULL,
+  teinte_ral                    text NULL,
+  aspect                        text NULL,
+  rugosite                      text NULL,
+  durete                        text NULL,
+  exigence_corrosion            text NULL,
+  pretraitement                 text NULL,
+  posttraitement                text NULL,
+
+  controles                     text[] NOT NULL DEFAULT ARRAY[]::text[],
+  certificat_requis             boolean NOT NULL DEFAULT false,
+  certificat_type               text NULL,
+  conditionnement               text NULL,
+  unite_achat                   text NOT NULL DEFAULT 'PCE',
+  specification_client          text NULL,
+  specification_client_version  text NULL,
+  instructions                  text NULL,
+
+  spec_canonical                jsonb NOT NULL,
+  spec_fingerprint              text NOT NULL,
+
+  article_id                    uuid NULL,
+  achat_ligne_id                uuid NULL,
+
+  generated_designation         text NOT NULL,
+  generated_comment             text NOT NULL,
+  template_version              integer NOT NULL DEFAULT 1,
+  designation_override          text NULL,
+  comment_override              text NULL,
+  override_reason               text NULL,
+
+  created_at                    timestamptz NOT NULL DEFAULT now(),
+  updated_at                    timestamptz NOT NULL DEFAULT now(),
+  created_by                    integer NULL,
+  updated_by                    integer NULL,
+
+  CONSTRAINT gamme_operation_finitions_gamme_fk FOREIGN KEY (gamme_id)
+    REFERENCES public.gammes(id) ON DELETE CASCADE,
+  CONSTRAINT gamme_operation_finitions_operation_fk FOREIGN KEY (gamme_operation_id)
+    REFERENCES public.pieces_techniques_operations(id) ON DELETE CASCADE,
+  CONSTRAINT gamme_operation_finitions_version_fk FOREIGN KEY (piece_technique_version_id)
+    REFERENCES public.piece_technique_versions(id) ON DELETE CASCADE,
+  -- RESTRICT : une révision utilisée par une gamme ne disparaît jamais en silence.
+  CONSTRAINT gamme_operation_finitions_revision_fk FOREIGN KEY (finish_revision_id)
+    REFERENCES public.surface_finish_revisions(id) ON DELETE RESTRICT,
+  CONSTRAINT gamme_operation_finitions_article_fk FOREIGN KEY (article_id)
+    REFERENCES public.articles(id) ON DELETE RESTRICT,
+  CONSTRAINT gamme_operation_finitions_achat_fk FOREIGN KEY (achat_ligne_id)
+    REFERENCES public.pieces_techniques_achats(id) ON DELETE SET NULL,
+
+  -- Une opération porte AU PLUS une exigence de finition.
+  CONSTRAINT gamme_operation_finitions_operation_uq UNIQUE (gamme_operation_id),
+
+  CONSTRAINT gamme_operation_finitions_perimetre_check CHECK (
+    perimetre IN ('PIECE_ENTIERE','ZONES','AUTRE')
+  ),
+  CONSTRAINT gamme_operation_finitions_zones_coherentes CHECK (
+    perimetre <> 'ZONES' OR array_length(zones, 1) >= 1
+  ),
+  CONSTRAINT gamme_operation_finitions_unite_check CHECK (
+    epaisseur_unite IN ('um','mm','cm','in','mil')
+  ),
+  CONSTRAINT gamme_operation_finitions_epaisseur_coherente CHECK (
+    (epaisseur_min IS NULL OR epaisseur_max IS NULL OR epaisseur_min <= epaisseur_max)
+    AND (epaisseur_nominale IS NULL OR epaisseur_min IS NULL OR epaisseur_nominale >= epaisseur_min)
+    AND (epaisseur_nominale IS NULL OR epaisseur_max IS NULL OR epaisseur_nominale <= epaisseur_max)
+  ),
+  CONSTRAINT gamme_operation_finitions_fingerprint_format CHECK (
+    spec_fingerprint ~ '^[0-9a-f]{64}$'
+  ),
+  CONSTRAINT gamme_operation_finitions_override_reason CHECK (
+    (designation_override IS NULL AND comment_override IS NULL)
+    OR btrim(COALESCE(override_reason, '')) <> ''
+  )
+);
+
+COMMENT ON TABLE public.gamme_operation_finitions IS
+  '#210 — Exigence de finition d''une opération SOUS_TRAITANCE : liaison EXPLICITE gamme/opération/indice/révision + article résolu + ligne d''achat.';
+COMMENT ON COLUMN public.gamme_operation_finitions.spec_fingerprint IS
+  'SHA-256 de la spécification canonique. Fournisseur, prix, délai et MOQ en sont volontairement absents.';
+
+CREATE INDEX IF NOT EXISTS gamme_operation_finitions_gamme_idx
+  ON public.gamme_operation_finitions (gamme_id);
+CREATE INDEX IF NOT EXISTS gamme_operation_finitions_version_idx
+  ON public.gamme_operation_finitions (piece_technique_version_id);
+CREATE INDEX IF NOT EXISTS gamme_operation_finitions_revision_idx
+  ON public.gamme_operation_finitions (finish_revision_id);
+CREATE INDEX IF NOT EXISTS gamme_operation_finitions_article_idx
+  ON public.gamme_operation_finitions (article_id);
+CREATE INDEX IF NOT EXISTS gamme_operation_finitions_fingerprint_idx
+  ON public.gamme_operation_finitions (spec_fingerprint);
+
+/* -------------------------------------------------------------------------- */
+/* 7) Article de sous-traitance — EXTENSION de la spécialisation existante    */
+/* -------------------------------------------------------------------------- */
+-- On étend `articles_traitement` (PK article_id). Aucune table maître
+-- concurrente d'`articles` n'est créée.
+
+ALTER TABLE public.articles_traitement
+  ADD COLUMN IF NOT EXISTS piece_technique_id          uuid NULL,
+  ADD COLUMN IF NOT EXISTS piece_technique_version_id  uuid NULL,
+  ADD COLUMN IF NOT EXISTS finish_revision_id          uuid NULL,
+  ADD COLUMN IF NOT EXISTS spec_fingerprint            text NULL,
+  ADD COLUMN IF NOT EXISTS spec_canonical              jsonb NULL,
+  ADD COLUMN IF NOT EXISTS generated_designation       text NULL,
+  ADD COLUMN IF NOT EXISTS generated_comment           text NULL,
+  ADD COLUMN IF NOT EXISTS template_version            integer NULL,
+  ADD COLUMN IF NOT EXISTS origin                      text NULL,
+  ADD COLUMN IF NOT EXISTS superseded_at               timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS created_by                  integer NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'articles_traitement_piece_fk'
+      AND conrelid = 'public.articles_traitement'::regclass
+  ) THEN
+    ALTER TABLE public.articles_traitement
+      ADD CONSTRAINT articles_traitement_piece_fk
+      FOREIGN KEY (piece_technique_id) REFERENCES public.pieces_techniques(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'articles_traitement_version_fk'
+      AND conrelid = 'public.articles_traitement'::regclass
+  ) THEN
+    ALTER TABLE public.articles_traitement
+      ADD CONSTRAINT articles_traitement_version_fk
+      FOREIGN KEY (piece_technique_version_id) REFERENCES public.piece_technique_versions(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'articles_traitement_finish_revision_fk'
+      AND conrelid = 'public.articles_traitement'::regclass
+  ) THEN
+    ALTER TABLE public.articles_traitement
+      ADD CONSTRAINT articles_traitement_finish_revision_fk
+      FOREIGN KEY (finish_revision_id) REFERENCES public.surface_finish_revisions(id) ON DELETE RESTRICT;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'articles_traitement_origin_check'
+      AND conrelid = 'public.articles_traitement'::regclass
+  ) THEN
+    ALTER TABLE public.articles_traitement
+      ADD CONSTRAINT articles_traitement_origin_check
+      CHECK (origin IS NULL OR origin IN ('GAMME_FINITION','MANUEL','IMPORT'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'articles_traitement_fingerprint_format'
+      AND conrelid = 'public.articles_traitement'::regclass
+  ) THEN
+    ALTER TABLE public.articles_traitement
+      ADD CONSTRAINT articles_traitement_fingerprint_format
+      CHECK (spec_fingerprint IS NULL OR spec_fingerprint ~ '^[0-9a-f]{64}$');
+  END IF;
+
+  -- Une empreinte sans spécification (ou l'inverse) serait une identité orpheline.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'articles_traitement_spec_pair_check'
+      AND conrelid = 'public.articles_traitement'::regclass
+  ) THEN
+    ALTER TABLE public.articles_traitement
+      ADD CONSTRAINT articles_traitement_spec_pair_check
+      CHECK ((spec_fingerprint IS NULL) = (spec_canonical IS NULL));
+  END IF;
+END $$;
+
+-- ANTI-DOUBLON STRUCTUREL : une seule version COURANTE d'article par empreinte.
+-- Deux confirmations concurrentes ne peuvent pas créer deux articles.
+CREATE UNIQUE INDEX IF NOT EXISTS articles_traitement_fingerprint_current_uq
+  ON public.articles_traitement (spec_fingerprint)
+  WHERE spec_fingerprint IS NOT NULL AND superseded_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS articles_traitement_version_idx
+  ON public.articles_traitement (piece_technique_version_id)
+  WHERE piece_technique_version_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS articles_traitement_revision_idx
+  ON public.articles_traitement (finish_revision_id)
+  WHERE finish_revision_id IS NOT NULL;
+
+COMMENT ON COLUMN public.articles_traitement.spec_fingerprint IS
+  '#210 — Empreinte fonctionnelle de la prestation. Unique parmi les articles non remplacés.';
+COMMENT ON COLUMN public.articles_traitement.superseded_at IS
+  '#210 — Date à laquelle cette spécialisation a cédé sa place à une version plus récente. Aucune suppression.';
+
+/* -------------------------------------------------------------------------- */
+/* 8) Nomenclature d'achat — liaison par CLÉ ÉTRANGÈRE, plus par phase        */
+/* -------------------------------------------------------------------------- */
+
+ALTER TABLE public.pieces_techniques_achats
+  ADD COLUMN IF NOT EXISTS gamme_operation_id          uuid NULL,
+  ADD COLUMN IF NOT EXISTS gamme_id                    uuid NULL,
+  ADD COLUMN IF NOT EXISTS piece_technique_version_id  uuid NULL,
+  ADD COLUMN IF NOT EXISTS designation_snapshot        text NULL,
+  ADD COLUMN IF NOT EXISTS source                      text NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pt_achats_gamme_operation_fk'
+      AND conrelid = 'public.pieces_techniques_achats'::regclass
+  ) THEN
+    ALTER TABLE public.pieces_techniques_achats
+      ADD CONSTRAINT pt_achats_gamme_operation_fk
+      FOREIGN KEY (gamme_operation_id) REFERENCES public.pieces_techniques_operations(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pt_achats_gamme_fk'
+      AND conrelid = 'public.pieces_techniques_achats'::regclass
+  ) THEN
+    ALTER TABLE public.pieces_techniques_achats
+      ADD CONSTRAINT pt_achats_gamme_fk
+      FOREIGN KEY (gamme_id) REFERENCES public.gammes(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pt_achats_version_fk'
+      AND conrelid = 'public.pieces_techniques_achats'::regclass
+  ) THEN
+    ALTER TABLE public.pieces_techniques_achats
+      ADD CONSTRAINT pt_achats_version_fk
+      FOREIGN KEY (piece_technique_version_id) REFERENCES public.piece_technique_versions(id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'pt_achats_source_check'
+      AND conrelid = 'public.pieces_techniques_achats'::regclass
+  ) THEN
+    ALTER TABLE public.pieces_techniques_achats
+      ADD CONSTRAINT pt_achats_source_check
+      CHECK (source IS NULL OR source IN ('GAMME_FINITION','MANUEL','IMPORT'));
+  END IF;
+END $$;
+
+-- Une opération de gamme porte au plus UNE ligne d'achat de traitement.
+CREATE UNIQUE INDEX IF NOT EXISTS pt_achats_gamme_operation_traitement_uq
+  ON public.pieces_techniques_achats (gamme_operation_id)
+  WHERE gamme_operation_id IS NOT NULL AND type_achat = 'TRAITEMENT';
+
+CREATE INDEX IF NOT EXISTS pt_achats_gamme_idx
+  ON public.pieces_techniques_achats (gamme_id)
+  WHERE gamme_id IS NOT NULL;
+
+COMMENT ON COLUMN public.pieces_techniques_achats.gamme_operation_id IS
+  '#210 — Lien AUTORITAIRE vers l''opération source. Le champ `phase` reste informatif et ne porte plus aucun lien.';
+
+/* -------------------------------------------------------------------------- */
+/* 9) Reçus d'idempotence des commandes de finition                           */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.surface_finish_command_receipts (
+  idempotency_key text PRIMARY KEY,
+  command_type    text NOT NULL,
+  request_hash    text NOT NULL,
+  result          jsonb NOT NULL,
+  user_id         integer NULL,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT surface_finish_command_receipts_hash_format CHECK (request_hash ~ '^[0-9a-f]{64}$')
+);
+
+COMMENT ON TABLE public.surface_finish_command_receipts IS
+  '#210 — Reçus d''idempotence : même clé + même charge ⇒ même réponse ; même clé + charge différente ⇒ 409.';
+
+CREATE INDEX IF NOT EXISTS surface_finish_command_receipts_created_idx
+  ON public.surface_finish_command_receipts (created_at DESC);
+
+/* -------------------------------------------------------------------------- */
+/* 10) Immuabilité du code finition + updated_at                              */
+/* -------------------------------------------------------------------------- */
+
+CREATE OR REPLACE FUNCTION public.fn_protect_surface_finish_code_210()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.code IS DISTINCT FROM OLD.code THEN
+    RAISE EXCEPTION 'Le code d''une finition est immuable (% -> %)', OLD.code, NEW.code
+      USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_surface_finish_code_immutable ON public.surface_finishes;
+CREATE TRIGGER trg_surface_finish_code_immutable
+  BEFORE UPDATE ON public.surface_finishes
+  FOR EACH ROW EXECUTE FUNCTION public.fn_protect_surface_finish_code_210();
+
+DO $$
+BEGIN
+  IF to_regprocedure('public.tg_set_updated_at()') IS NOT NULL THEN
+    EXECUTE 'DROP TRIGGER IF EXISTS surface_finishes_set_updated_at ON public.surface_finishes';
+    EXECUTE 'CREATE TRIGGER surface_finishes_set_updated_at BEFORE UPDATE ON public.surface_finishes FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
+
+    EXECUTE 'DROP TRIGGER IF EXISTS surface_finish_revisions_set_updated_at ON public.surface_finish_revisions';
+    EXECUTE 'CREATE TRIGGER surface_finish_revisions_set_updated_at BEFORE UPDATE ON public.surface_finish_revisions FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
+
+    EXECUTE 'DROP TRIGGER IF EXISTS gamme_operation_finitions_set_updated_at ON public.gamme_operation_finitions';
+    EXECUTE 'CREATE TRIGGER gamme_operation_finitions_set_updated_at BEFORE UPDATE ON public.gamme_operation_finitions FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
+
+    EXECUTE 'DROP TRIGGER IF EXISTS surface_finish_families_set_updated_at ON public.surface_finish_families';
+    EXECUTE 'CREATE TRIGGER surface_finish_families_set_updated_at BEFORE UPDATE ON public.surface_finish_families FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 11) Droits du rôle applicatif                                              */
+/* -------------------------------------------------------------------------- */
+-- Les reçus d'idempotence sont append-only côté application : ni UPDATE ni DELETE.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON public.surface_finish_families TO cerp_app';
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE ON public.surface_finishes TO cerp_app';
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE ON public.surface_finish_revisions TO cerp_app';
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON public.surface_finish_revision_documents TO cerp_app';
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON public.gamme_operation_finitions TO cerp_app';
+    EXECUTE 'GRANT SELECT, INSERT ON public.surface_finish_command_receipts TO cerp_app';
+    EXECUTE 'REVOKE UPDATE, DELETE ON public.surface_finish_command_receipts FROM cerp_app';
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/support/20260728_surface_finish_library_210.candidates.sql
+++ b/db/patches/support/20260728_surface_finish_library_210.candidates.sql
@@ -1,0 +1,137 @@
+-- Rapport de reprise historique 20260728_surface_finish_library_210 — LECTURE SEULE.
+--
+-- ⚠️ AUCUN BACKFILL N'EST FAIT NI PROPOSÉ AUTOMATIQUEMENT.
+-- Ce script CLASSE les articles Traitement et les lignes d'achat existants pour
+-- qu'un humain décide, dossier par dossier. Il ne modifie rien, ne relie rien,
+-- ne recode rien, ne supprime rien.
+--
+-- Classement produit :
+--   EXACT_PROBABLE : la ligne d'achat TRAITEMENT désigne une seule opération
+--                    SOUS_TRAITANCE de la même pièce et le même numéro de phase.
+--   AMBIGU         : plusieurs opérations SOUS_TRAITANCE candidates, ou aucune
+--                    correspondance de phase fiable.
+--   INCOMPATIBLE   : la ligne porte un article qui n'est pas un article de
+--                    catégorie `traitement`.
+--   NON_LIE        : article Traitement sans aucune ligne d'achat, ou ligne sans
+--                    article — rien à rattacher sans décision métier.
+--
+-- Rappel : le numéro de phase N'EST PAS un lien. Un « EXACT_PROBABLE » reste une
+-- hypothèse à valider, jamais une reprise automatique.
+
+\echo '=== 1) Lignes d''achat TRAITEMENT : classement des candidats ==='
+
+WITH lignes AS (
+  SELECT
+    a.id                AS achat_id,
+    a.piece_technique_id,
+    a.phase,
+    a.article_id,
+    a.designation,
+    a.type_achat
+  FROM public.pieces_techniques_achats a
+  WHERE a.type_achat = 'TRAITEMENT'
+),
+candidats AS (
+  SELECT
+    l.achat_id,
+    l.piece_technique_id,
+    l.phase,
+    l.article_id,
+    l.designation,
+    COUNT(o.id) FILTER (WHERE o.type_operation = 'SOUS_TRAITANCE')                       AS ops_sous_traitance,
+    COUNT(o.id) FILTER (WHERE o.type_operation = 'SOUS_TRAITANCE' AND o.phase = l.phase) AS ops_meme_phase,
+    MIN(o.id::text) FILTER (WHERE o.type_operation = 'SOUS_TRAITANCE' AND o.phase = l.phase) AS operation_candidate
+  FROM lignes l
+  LEFT JOIN public.pieces_techniques_operations o
+    ON o.piece_technique_id = l.piece_technique_id
+  GROUP BY l.achat_id, l.piece_technique_id, l.phase, l.article_id, l.designation
+)
+SELECT
+  c.achat_id,
+  c.piece_technique_id,
+  c.phase,
+  c.article_id,
+  art.code                                   AS article_code,
+  art.article_category,
+  left(COALESCE(c.designation, ''), 60)      AS designation_extrait,
+  c.ops_sous_traitance,
+  c.ops_meme_phase,
+  c.operation_candidate,
+  CASE
+    WHEN c.article_id IS NOT NULL AND art.article_category IS DISTINCT FROM 'traitement' THEN 'INCOMPATIBLE'
+    WHEN c.article_id IS NULL                                                            THEN 'NON_LIE'
+    WHEN c.phase IS NULL                                                                 THEN 'AMBIGU'
+    WHEN c.ops_meme_phase = 1                                                            THEN 'EXACT_PROBABLE'
+    WHEN c.ops_meme_phase > 1                                                            THEN 'AMBIGU'
+    WHEN c.ops_sous_traitance = 0                                                        THEN 'NON_LIE'
+    ELSE 'AMBIGU'
+  END                                        AS classement
+FROM candidats c
+LEFT JOIN public.articles art ON art.id = c.article_id
+ORDER BY classement, c.piece_technique_id, c.phase NULLS LAST;
+
+\echo '=== 2) Synthèse par classement ==='
+
+WITH lignes AS (
+  SELECT a.id, a.piece_technique_id, a.phase, a.article_id
+  FROM public.pieces_techniques_achats a
+  WHERE a.type_achat = 'TRAITEMENT'
+),
+candidats AS (
+  SELECT
+    l.id,
+    l.article_id,
+    l.phase,
+    COUNT(o.id) FILTER (WHERE o.type_operation = 'SOUS_TRAITANCE')                       AS ops_sous_traitance,
+    COUNT(o.id) FILTER (WHERE o.type_operation = 'SOUS_TRAITANCE' AND o.phase = l.phase) AS ops_meme_phase
+  FROM lignes l
+  LEFT JOIN public.pieces_techniques_operations o ON o.piece_technique_id = l.piece_technique_id
+  GROUP BY l.id, l.article_id, l.phase
+)
+SELECT
+  CASE
+    WHEN c.article_id IS NOT NULL AND art.article_category IS DISTINCT FROM 'traitement' THEN 'INCOMPATIBLE'
+    WHEN c.article_id IS NULL                                                            THEN 'NON_LIE'
+    WHEN c.phase IS NULL                                                                 THEN 'AMBIGU'
+    WHEN c.ops_meme_phase = 1                                                            THEN 'EXACT_PROBABLE'
+    WHEN c.ops_meme_phase > 1                                                            THEN 'AMBIGU'
+    WHEN c.ops_sous_traitance = 0                                                        THEN 'NON_LIE'
+    ELSE 'AMBIGU'
+  END        AS classement,
+  COUNT(*)   AS lignes
+FROM candidats c
+LEFT JOIN public.articles art ON art.id = c.article_id
+GROUP BY 1
+ORDER BY 1;
+
+\echo '=== 3) Articles Traitement orphelins (aucune ligne d''achat) ==='
+
+SELECT
+  a.id            AS article_id,
+  a.code,
+  left(a.designation, 70) AS designation_extrait,
+  a.family_code,
+  a.is_active,
+  a.created_at
+FROM public.articles a
+WHERE a.article_category = 'traitement'
+  AND NOT EXISTS (
+    SELECT 1 FROM public.pieces_techniques_achats pa WHERE pa.article_id = a.id
+  )
+ORDER BY a.created_at;
+
+\echo '=== 4) Opérations SOUS_TRAITANCE sans exigence de finition ==='
+
+SELECT
+  o.id            AS operation_id,
+  o.gamme_id,
+  o.piece_technique_id,
+  o.phase,
+  left(o.designation, 70) AS designation_extrait
+FROM public.pieces_techniques_operations o
+WHERE o.type_operation = 'SOUS_TRAITANCE'
+  AND o.gamme_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM public.gamme_operation_finitions f WHERE f.gamme_operation_id = o.id
+  )
+ORDER BY o.piece_technique_id, o.phase NULLS LAST;

--- a/db/patches/support/20260728_surface_finish_library_210.preflight.sql
+++ b/db/patches/support/20260728_surface_finish_library_210.preflight.sql
@@ -1,0 +1,62 @@
+-- Preflight 20260728_surface_finish_library_210 — LECTURE SEULE.
+-- Confirme que le patch est bien additif, que ses pré-requis sont présents et
+-- qu'il n'écrase aucune structure existante.
+
+SELECT
+  current_database()                                                   AS database,
+
+  -- 1) Pré-requis GPAO / Articles / codification.
+  to_regclass('public.gammes') IS NOT NULL                             AS req_gammes,
+  to_regclass('public.piece_technique_versions') IS NOT NULL           AS req_versions,
+  to_regclass('public.pieces_techniques_operations') IS NOT NULL       AS req_operations,
+  to_regclass('public.pieces_techniques_achats') IS NOT NULL           AS req_achats,
+  to_regclass('public.articles') IS NOT NULL                           AS req_articles,
+  to_regclass('public.articles_traitement') IS NOT NULL                AS req_articles_traitement,
+  to_regclass('public.article_category_ref') IS NOT NULL               AS req_category_ref,
+  to_regprocedure('public.fn_next_issued_code_value(text)') IS NOT NULL AS req_code_allocator,
+  (SELECT COUNT(*) FROM pg_proc WHERE proname = 'gen_random_uuid') > 0 AS req_gen_random_uuid,
+
+  -- 2) La CAT cible existe déjà : le patch ne la crée pas.
+  EXISTS (SELECT 1 FROM public.article_category_ref WHERE code = 'traitement_surface')
+                                                                       AS cat_traitement_surface_present,
+
+  -- 3) Aucune table du chantier ne doit préexister (sinon : patch déjà appliqué).
+  to_regclass('public.surface_finish_families') IS NULL                AS t_families_absent,
+  to_regclass('public.surface_finishes') IS NULL                       AS t_finishes_absent,
+  to_regclass('public.surface_finish_revisions') IS NULL               AS t_revisions_absent,
+  to_regclass('public.surface_finish_revision_documents') IS NULL      AS t_documents_absent,
+  to_regclass('public.gamme_operation_finitions') IS NULL              AS t_operation_finish_absent,
+  to_regclass('public.surface_finish_command_receipts') IS NULL        AS t_receipts_absent,
+
+  -- 4) Les colonnes additives ne doivent pas préexister sous un autre sens.
+  NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'articles_traitement' AND column_name = 'spec_fingerprint'
+  )                                                                    AS col_fingerprint_absent,
+  NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'pieces_techniques_achats' AND column_name = 'gamme_operation_id'
+  )                                                                    AS col_achat_operation_absent,
+
+  -- 5) Volumétrie AVANT : preuve de non-régression comparable au verify.
+  (SELECT COUNT(*) FROM public.articles)                               AS articles_rows_before,
+  (SELECT COUNT(*) FROM public.articles_traitement)                    AS articles_traitement_rows_before,
+  (SELECT COUNT(*) FROM public.pieces_techniques_achats)               AS achats_rows_before,
+  (SELECT COUNT(*) FROM public.pieces_techniques_achats WHERE type_achat = 'TRAITEMENT')
+                                                                       AS achats_traitement_rows_before,
+  (SELECT COUNT(*) FROM public.pieces_techniques_operations WHERE type_operation = 'SOUS_TRAITANCE')
+                                                                       AS operations_sous_traitance_before,
+
+  -- 6) L'anti-doublon exigera une empreinte unique : aucune donnée ne doit s'y opposer
+  --    (le patch n'écrit aucune empreinte, ce compte doit donc rester à 0).
+  0                                                                    AS expected_existing_fingerprints,
+
+  -- 7) Le rôle applicatif doit exister pour que les GRANT s'appliquent.
+  EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app')           AS cerp_app_role_present,
+
+  -- 8) Le scope FIN ne doit PAS encore être accepté (preuve que l'élargissement sert).
+  NOT EXISTS (
+    SELECT 1 FROM pg_proc
+    WHERE proname = 'fn_next_issued_code_value'
+      AND prosrc LIKE '%FIN|%'
+  )                                                                    AS code_scope_fin_absent;

--- a/db/patches/support/20260728_surface_finish_library_210.rollback.sql
+++ b/db/patches/support/20260728_surface_finish_library_210.rollback.sql
@@ -1,0 +1,118 @@
+-- Rollback 20260728_surface_finish_library_210.
+--
+-- ⚠️ RÉALISTE, PAS MAGIQUE. Ce script annule la STRUCTURE ajoutée par le patch.
+-- Il DÉTRUIT les données saisies dans la bibliothèque de finitions et les
+-- exigences posées sur les gammes. Il ne restaure rien : la seule reprise
+-- possible après usage réel est une restauration de sauvegarde.
+--
+-- Conditions d'exécution acceptables :
+--   1. le patch vient d'être appliqué et AUCUNE finition n'a été saisie ;
+--   2. ou une sauvegarde vérifiée existe et la perte est assumée par écrit.
+--
+-- Le garde-fou ci-dessous refuse le rollback si des données métier existent.
+-- Pour passer outre en connaissance de cause : SET cerp.force_rollback = 'on';
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_finishes    bigint := 0;
+  v_links       bigint := 0;
+  v_articles    bigint := 0;
+  v_achats      bigint := 0;
+  v_force       text   := current_setting('cerp.force_rollback', true);
+BEGIN
+  IF to_regclass('public.surface_finishes') IS NOT NULL THEN
+    EXECUTE 'SELECT COUNT(*) FROM public.surface_finishes' INTO v_finishes;
+  END IF;
+  IF to_regclass('public.gamme_operation_finitions') IS NOT NULL THEN
+    EXECUTE 'SELECT COUNT(*) FROM public.gamme_operation_finitions' INTO v_links;
+  END IF;
+  IF to_regclass('public.articles_traitement') IS NOT NULL THEN
+    EXECUTE 'SELECT COUNT(*) FROM public.articles_traitement WHERE spec_fingerprint IS NOT NULL' INTO v_articles;
+  END IF;
+  IF to_regclass('public.pieces_techniques_achats') IS NOT NULL THEN
+    EXECUTE 'SELECT COUNT(*) FROM public.pieces_techniques_achats WHERE gamme_operation_id IS NOT NULL' INTO v_achats;
+  END IF;
+
+  IF (v_finishes + v_links + v_articles + v_achats) > 0 AND COALESCE(v_force, 'off') <> 'on' THEN
+    RAISE EXCEPTION
+      'Rollback refusé : % finition(s), % exigence(s), % article(s) tracé(s), % ligne(s) d''achat liée(s). Restaurez une sauvegarde ou posez SET cerp.force_rollback = ''on''.',
+      v_finishes, v_links, v_articles, v_achats
+      USING ERRCODE = '2F000';
+  END IF;
+END $$;
+
+-- 1) Liaisons ajoutées à la nomenclature d'achat (les lignes elles-mêmes restent).
+DROP INDEX IF EXISTS public.pt_achats_gamme_operation_traitement_uq;
+DROP INDEX IF EXISTS public.pt_achats_gamme_idx;
+ALTER TABLE public.pieces_techniques_achats
+  DROP CONSTRAINT IF EXISTS pt_achats_gamme_operation_fk,
+  DROP CONSTRAINT IF EXISTS pt_achats_gamme_fk,
+  DROP CONSTRAINT IF EXISTS pt_achats_version_fk,
+  DROP CONSTRAINT IF EXISTS pt_achats_source_check;
+ALTER TABLE public.pieces_techniques_achats
+  DROP COLUMN IF EXISTS gamme_operation_id,
+  DROP COLUMN IF EXISTS gamme_id,
+  DROP COLUMN IF EXISTS piece_technique_version_id,
+  DROP COLUMN IF EXISTS designation_snapshot,
+  DROP COLUMN IF EXISTS source;
+
+-- 2) Extension de la spécialisation article (les articles eux-mêmes restent).
+DROP INDEX IF EXISTS public.articles_traitement_fingerprint_current_uq;
+DROP INDEX IF EXISTS public.articles_traitement_version_idx;
+DROP INDEX IF EXISTS public.articles_traitement_revision_idx;
+ALTER TABLE public.articles_traitement
+  DROP CONSTRAINT IF EXISTS articles_traitement_piece_fk,
+  DROP CONSTRAINT IF EXISTS articles_traitement_version_fk,
+  DROP CONSTRAINT IF EXISTS articles_traitement_finish_revision_fk,
+  DROP CONSTRAINT IF EXISTS articles_traitement_origin_check,
+  DROP CONSTRAINT IF EXISTS articles_traitement_fingerprint_format,
+  DROP CONSTRAINT IF EXISTS articles_traitement_spec_pair_check;
+ALTER TABLE public.articles_traitement
+  DROP COLUMN IF EXISTS piece_technique_id,
+  DROP COLUMN IF EXISTS piece_technique_version_id,
+  DROP COLUMN IF EXISTS finish_revision_id,
+  DROP COLUMN IF EXISTS spec_fingerprint,
+  DROP COLUMN IF EXISTS spec_canonical,
+  DROP COLUMN IF EXISTS generated_designation,
+  DROP COLUMN IF EXISTS generated_comment,
+  DROP COLUMN IF EXISTS template_version,
+  DROP COLUMN IF EXISTS origin,
+  DROP COLUMN IF EXISTS superseded_at;
+-- `created_by` est laissé en place : d'autres chantiers pourraient l'avoir posé.
+
+-- 3) Tables du chantier (ordre inverse des dépendances).
+DROP TABLE IF EXISTS public.surface_finish_command_receipts;
+DROP TABLE IF EXISTS public.gamme_operation_finitions;
+DROP TABLE IF EXISTS public.surface_finish_revision_documents;
+ALTER TABLE IF EXISTS public.surface_finishes
+  DROP CONSTRAINT IF EXISTS surface_finishes_current_revision_fk;
+DROP TABLE IF EXISTS public.surface_finish_revisions;
+
+DROP TRIGGER IF EXISTS trg_surface_finish_code_immutable ON public.surface_finishes;
+DROP TABLE IF EXISTS public.surface_finishes;
+DROP TABLE IF EXISTS public.surface_finish_families;
+DROP FUNCTION IF EXISTS public.fn_protect_surface_finish_code_210();
+DROP FUNCTION IF EXISTS public.surface_finish_norm(text);
+DROP FUNCTION IF EXISTS public.surface_finish_to_um(numeric, text);
+
+-- 4) Codification : on RESTAURE le whitelist de 20260726_metrologie_360_229.
+--    Retirer `FIN` sans restaurer le reste casserait machines et métrologie.
+CREATE OR REPLACE FUNCTION public.fn_next_issued_code_value(p_scope text)
+RETURNS bigint
+LANGUAGE plpgsql
+VOLATILE
+AS $$
+DECLARE
+  v_scope text := upper(btrim(COALESCE(p_scope, '')));
+BEGIN
+  IF v_scope !~ '^(CLI|FOU|MCH|MET|ART:[A-Z0-9]{1,48}|(DEV|CMD|AFF|OF|LOT|MVT|CQ|NC|CAPA|BL|FACT|BCF|PC|DER|MEX|MIA):[0-9]{4})$' THEN
+    RAISE EXCEPTION 'Unsupported business-code sequence scope: %', p_scope
+      USING ERRCODE = '22023';
+  END IF;
+  RETURN nextval('public.cerp_business_code_issue_seq'::regclass);
+END;
+$$;
+
+COMMIT;

--- a/db/patches/support/20260728_surface_finish_library_210.verify.sql
+++ b/db/patches/support/20260728_surface_finish_library_210.verify.sql
@@ -1,0 +1,108 @@
+-- Verify 20260728_surface_finish_library_210 — LECTURE SEULE.
+-- Toutes les colonnes booléennes doivent être `true` après application.
+-- Les comptes sont à comparer au preflight : ils doivent être IDENTIQUES
+-- (le patch n'écrit aucune donnée métier, il n'y a aucun backfill).
+
+SELECT
+  current_database()                                                        AS database,
+
+  -- 1) Les 6 tables du chantier existent.
+  to_regclass('public.surface_finish_families') IS NOT NULL                 AS t_families,
+  to_regclass('public.surface_finishes') IS NOT NULL                        AS t_finishes,
+  to_regclass('public.surface_finish_revisions') IS NOT NULL                AS t_revisions,
+  to_regclass('public.surface_finish_revision_documents') IS NOT NULL       AS t_documents,
+  to_regclass('public.gamme_operation_finitions') IS NOT NULL               AS t_operation_finish,
+  to_regclass('public.surface_finish_command_receipts') IS NOT NULL         AS t_receipts,
+
+  -- 2) Le référentiel de familles est amorcé et administrable.
+  (SELECT COUNT(*) FROM public.surface_finish_families WHERE is_active)     AS active_families,
+
+  -- 3) Colonnes additives réellement posées.
+  EXISTS (SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='articles_traitement'
+            AND column_name='spec_fingerprint')                             AS col_at_fingerprint,
+  EXISTS (SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='articles_traitement'
+            AND column_name='spec_canonical')                               AS col_at_spec,
+  EXISTS (SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='articles_traitement'
+            AND column_name='superseded_at')                                AS col_at_superseded,
+  EXISTS (SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='pieces_techniques_achats'
+            AND column_name='gamme_operation_id')                           AS col_achat_operation,
+  EXISTS (SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='pieces_techniques_achats'
+            AND column_name='piece_technique_version_id')                   AS col_achat_version,
+
+  -- 4) Garde-fous structurels : anti-doublon, unicité, immuabilité.
+  EXISTS (SELECT 1 FROM pg_indexes
+          WHERE indexname = 'articles_traitement_fingerprint_current_uq')   AS idx_fingerprint_unique,
+  EXISTS (SELECT 1 FROM pg_indexes
+          WHERE indexname = 'pt_achats_gamme_operation_traitement_uq')      AS idx_achat_operation_unique,
+  EXISTS (SELECT 1 FROM pg_indexes
+          WHERE indexname = 'surface_finish_revisions_single_active_uq')    AS idx_single_active_revision,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname = 'gamme_operation_finitions_operation_uq')         AS uq_one_finish_per_operation,
+  EXISTS (SELECT 1 FROM pg_trigger
+          WHERE tgname = 'trg_surface_finish_code_immutable')               AS trg_code_immutable,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname = 'surface_finishes_code_format')                   AS chk_code_format,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname = 'surface_finish_revisions_epaisseur_coherente')   AS chk_thickness_range,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname = 'surface_finish_revisions_certificat_coherent')   AS chk_certificate_typed,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname = 'gamme_operation_finitions_zones_coherentes')     AS chk_zones_required,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname = 'articles_traitement_spec_pair_check')            AS chk_spec_pair,
+
+  -- 5) Liaisons par clé étrangère (jamais par le numéro de phase).
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname = 'pt_achats_gamme_operation_fk')                   AS fk_achat_operation,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname = 'gamme_operation_finitions_operation_fk')         AS fk_finish_operation,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname = 'gamme_operation_finitions_revision_fk')          AS fk_finish_revision,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname = 'gamme_operation_finitions_article_fk')           AS fk_finish_article,
+
+  -- 6) Le scope de codification FIN est accepté, et aucun scope existant n'a été
+  --    retiré (régression déjà vue en 20260725 : MCH avait disparu du whitelist).
+  --    Lecture du corps de la fonction — on ne CONSOMME pas la séquence ici.
+  EXISTS (SELECT 1 FROM pg_proc WHERE proname='fn_next_issued_code_value' AND prosrc LIKE '%FIN|%')  AS code_scope_fin,
+  EXISTS (SELECT 1 FROM pg_proc WHERE proname='fn_next_issued_code_value' AND prosrc LIKE '%MCH|%')  AS code_scope_mch_kept,
+  EXISTS (SELECT 1 FROM pg_proc WHERE proname='fn_next_issued_code_value' AND prosrc LIKE '%MET|%')  AS code_scope_met_kept,
+  EXISTS (SELECT 1 FROM pg_proc WHERE proname='fn_next_issued_code_value' AND prosrc LIKE '%MEX|MIA%') AS code_scope_metrology_kept,
+
+  -- 7) Droits : reçus d'idempotence non modifiables par l'application.
+  (
+    NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app')
+    OR (
+      has_table_privilege('cerp_app', 'public.surface_finishes', 'SELECT,INSERT,UPDATE')
+      AND has_table_privilege('cerp_app', 'public.surface_finish_revisions', 'SELECT,INSERT,UPDATE')
+      AND has_table_privilege('cerp_app', 'public.gamme_operation_finitions', 'SELECT,INSERT,UPDATE,DELETE')
+      AND has_table_privilege('cerp_app', 'public.surface_finish_command_receipts', 'SELECT,INSERT')
+      AND NOT has_table_privilege('cerp_app', 'public.surface_finish_command_receipts', 'UPDATE')
+      AND NOT has_table_privilege('cerp_app', 'public.surface_finish_command_receipts', 'DELETE')
+    )
+  )                                                                         AS grants_ok,
+
+  -- 8) NON-RÉGRESSION : aucun backfill, aucune donnée touchée.
+  (SELECT COUNT(*) FROM public.articles)                                    AS articles_rows_after,
+  (SELECT COUNT(*) FROM public.articles_traitement)                         AS articles_traitement_rows_after,
+  (SELECT COUNT(*) FROM public.pieces_techniques_achats)                    AS achats_rows_after,
+  (SELECT COUNT(*) FROM public.pieces_techniques_achats WHERE type_achat = 'TRAITEMENT')
+                                                                            AS achats_traitement_rows_after,
+  (SELECT COUNT(*) FROM public.articles_traitement WHERE spec_fingerprint IS NOT NULL)
+                                                                            AS backfilled_fingerprints,
+  (SELECT COUNT(*) FROM public.pieces_techniques_achats WHERE gamme_operation_id IS NOT NULL)
+                                                                            AS backfilled_achat_links,
+  (SELECT COUNT(*) FROM public.gamme_operation_finitions)                   AS finish_requirements_rows,
+
+  -- 9) L'enum du catalogue fournisseur n'a PAS été modifié par ce patch.
+  NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    JOIN pg_class t ON t.oid = c.conrelid
+    WHERE t.relname = 'fournisseur_catalogue'
+      AND pg_get_constraintdef(c.oid) ILIKE '%TRAITEMENT%'
+  )                                                                         AS supplier_catalogue_enum_untouched;

--- a/db/privileged/20260721_fix_app_table_ownership.sql
+++ b/db/privileged/20260721_fix_app_table_ownership.sql
@@ -13,11 +13,17 @@
 --   and non_conformity_dispositions.
 --
 -- FIX
---   Give ownership of every public application table back to cerp_app, EXCEPT the two
---   deliberately append-only tables (erp_audit_logs, hr_time_events) which MUST stay
---   postgres-owned with only SELECT,INSERT granted to cerp_app — a table owner bypasses
---   REVOKE and can DISABLE TRIGGER, so immutability requires ownership off the app role
---   (see 20260707_erp_audit_logs_append_only.sql, 20260709_hr_time_events_append_only.sql).
+--   Give ownership of every public application table back to cerp_app, EXCEPT the
+--   deliberately append-only tables (erp_audit_logs, hr_time_events,
+--   surface_finish_command_receipts) which MUST stay postgres-owned with only
+--   SELECT,INSERT granted to cerp_app — a table owner bypasses REVOKE and can
+--   DISABLE TRIGGER, so immutability requires ownership off the app role
+--   (see 20260707_erp_audit_logs_append_only.sql, 20260709_hr_time_events_append_only.sql,
+--   20260728_surface_finish_library_210.sql).
+--
+-- 2026-07-28 (#210) — `surface_finish_command_receipts` rejoint la liste : un reçu
+--   d'idempotence qui peut être réécrit ne prouve plus rien. Le rendre cerp_app-owned
+--   annulerait silencieusement le REVOKE UPDATE, DELETE posé par son patch.
 --
 -- PROPERTIES
 --   Idempotent. Non-destructive (no row is inserted/updated/deleted). Re-runnable.
@@ -34,7 +40,7 @@ BEGIN
   FOR r IN
     SELECT tablename FROM pg_tables
     WHERE schemaname = 'public' AND tableowner = 'postgres'
-      AND tablename NOT IN ('erp_audit_logs', 'hr_time_events')
+      AND tablename NOT IN ('erp_audit_logs', 'hr_time_events', 'surface_finish_command_receipts')
   LOOP
     EXECUTE format('ALTER TABLE public.%I OWNER TO cerp_app', r.tablename);
     RAISE NOTICE 'owner -> cerp_app: %', r.tablename;
@@ -56,13 +62,22 @@ END $$;
 DO $$
 DECLARE t text; v_seq text;
 BEGIN
-  FOREACH t IN ARRAY ARRAY['erp_audit_logs', 'hr_time_events'] LOOP
+  FOREACH t IN ARRAY ARRAY['erp_audit_logs', 'hr_time_events', 'surface_finish_command_receipts'] LOOP
     IF to_regclass('public.' || t) IS NOT NULL THEN
       EXECUTE format('ALTER TABLE public.%I OWNER TO postgres', t);
       EXECUTE format('REVOKE ALL ON public.%I FROM cerp_app', t);
       EXECUTE format('REVOKE UPDATE, DELETE, TRUNCATE ON public.%I FROM PUBLIC', t);
       EXECUTE format('GRANT SELECT, INSERT ON public.%I TO cerp_app', t);
-      SELECT pg_get_serial_sequence('public.' || t, 'id') INTO v_seq;
+      -- `pg_get_serial_sequence` LÈVE une erreur si la colonne n'existe pas, elle ne
+      -- renvoie pas NULL. Une table append-only sans colonne `id` (clé naturelle,
+      -- ex. surface_finish_command_receipts) faisait donc échouer TOUT le script.
+      v_seq := NULL;
+      IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_schema = 'public' AND table_name = t AND column_name = 'id'
+      ) THEN
+        SELECT pg_get_serial_sequence('public.' || t, 'id') INTO v_seq;
+      END IF;
       IF v_seq IS NOT NULL THEN
         EXECUTE format('ALTER SEQUENCE %s OWNER TO postgres', v_seq);
         EXECUTE format('GRANT USAGE, SELECT ON SEQUENCE %s TO cerp_app', v_seq);

--- a/src/__tests__/surface-finish-210.domain.test.ts
+++ b/src/__tests__/surface-finish-210.domain.test.ts
@@ -1,0 +1,979 @@
+// #210 — Politiques pures de la bibliothèque de finitions.
+//
+// Ce fichier est la garantie que l'anti-doublon, la génération de texte et le
+// cycle de vie ne dépendent d'aucune base : ils sont testés seuls, y compris
+// par propriétés et par matrice de spécifications.
+
+import { describe, expect, it } from "vitest";
+
+import { HttpError } from "../utils/httpError";
+import {
+  ARTICLE_DECISIONS,
+  assertArticleDecisionConsistent,
+  assertGammeEditable,
+  assertGeneratedTextOverrideAllowed,
+  assertNoIdempotencyConflict,
+  assertOperationBelongsToGamme,
+  assertOperationIsSubcontracting,
+  assertOptimisticVersion,
+  assertPreviewFresh,
+  assertRevisionContentMutable,
+  assertRevisionSelectable,
+  assertSurfaceFinishCapability,
+  assertSurfaceFinishTransition,
+  assertTemplateVariablesAllowed,
+  assertThicknessCoherent,
+  buildCanonicalFinishSpec,
+  buildGeneratedDesignation,
+  canonicalRal,
+  canonicalText,
+  canonicalToken,
+  canonicalTokenList,
+  computePreviewHash,
+  computeSpecFingerprint,
+  decideReceipt,
+  DEFAULT_COMMENT_TEMPLATE,
+  DESIGNATION_MAX_LENGTH,
+  diffCanonicalSpecs,
+  GENERATED_ARTICLE_TAXONOMY,
+  normalizeIdempotencyKey,
+  normalizeThicknessUnit,
+  PURCHASE_LINE_TYPE,
+  renderGeneratedComment,
+  requestHash,
+  roleHasSurfaceFinishCapability,
+  sanitizeTemplateValue,
+  SUPPLIER_CATALOGUE_CATEGORY,
+  SURFACE_FINISH_STATUSES,
+  surfaceFinishCapabilitiesFor,
+  thicknessToMicrometers,
+  truncateReadable,
+  type SurfaceFinishSpecInput,
+  type SurfaceFinishStatus,
+} from "../module/surface-finish/domain/surface-finish-policy";
+
+const VERSION_ID = "11111111-1111-4111-8111-111111111111";
+const REVISION_ID = "22222222-2222-4222-8222-222222222222";
+
+function baseSpecInput(overrides: Partial<SurfaceFinishSpecInput> = {}): SurfaceFinishSpecInput {
+  return {
+    piece_technique_version_id: VERSION_ID,
+    finish_revision_id: REVISION_ID,
+    norme: "ISO 7599",
+    classe: "AA20",
+    perimetre: "PIECE_ENTIERE",
+    zones: [],
+    masquages: [],
+    epaisseur_min: 15,
+    epaisseur_nominale: 20,
+    epaisseur_max: 25,
+    epaisseur_unite: "um",
+    couleur: "Noir",
+    teinte_ral: "RAL 9005",
+    aspect: "Mat",
+    rugosite: "Ra 1,6",
+    durete: "HV 400",
+    exigence_corrosion: "BS 240 h",
+    pretraitement: "Dégraissage alcalin",
+    posttraitement: "Colmatage",
+    controles: ["EPAISSEUR", "ASPECT"],
+    certificat_requis: true,
+    certificat_type: "3.1",
+    conditionnement: "Bac plastique cloisonné",
+    unite_achat: "PCE",
+    specification_client: null,
+    specification_client_version: null,
+    instructions: null,
+    ...overrides,
+  };
+}
+
+function fingerprintOf(overrides: Partial<SurfaceFinishSpecInput> = {}): string {
+  return computeSpecFingerprint(buildCanonicalFinishSpec(baseSpecInput(overrides)));
+}
+
+function expectHttpError(fn: () => unknown, status: number, code: string): void {
+  try {
+    fn();
+  } catch (err) {
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(status);
+    expect((err as HttpError).code).toBe(code);
+    return;
+  }
+  throw new Error(`Expected HttpError ${status} ${code} but nothing was thrown`);
+}
+
+/* -------------------------------------------------------------------------- */
+/* 1) Capacités RBAC — refus par défaut                                       */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 capacités", () => {
+  it("refuse tout à un rôle vide ou inconnu", () => {
+    for (const role of [null, undefined, "", "   ", "stagiaire", "visiteur"]) {
+      const caps = surfaceFinishCapabilitiesFor(role);
+      expect(Object.values(caps).every((value) => value === false)).toBe(true);
+    }
+  });
+
+  it("laisse lire les Achats mais ne leur laisse pas approuver une révision", () => {
+    expect(roleHasSurfaceFinishCapability("Responsable Achats", "library_read")).toBe(true);
+    expect(roleHasSurfaceFinishCapability("Responsable Achats", "library_approve")).toBe(false);
+    expect(roleHasSurfaceFinishCapability("Responsable Achats", "operation_configure")).toBe(false);
+  });
+
+  it("réserve force-create et override de texte généré à une habilitation dédiée", () => {
+    expect(roleHasSurfaceFinishCapability("Technicien Méthodes", "article_resolve")).toBe(true);
+    expect(roleHasSurfaceFinishCapability("Technicien Méthodes", "article_force_create")).toBe(false);
+    expect(roleHasSurfaceFinishCapability("Responsable Méthodes", "article_force_create")).toBe(true);
+    expect(roleHasSurfaceFinishCapability("Technicien Méthodes", "generated_text_override")).toBe(false);
+  });
+
+  it("lève un 403 explicite quand la capacité manque", () => {
+    expectHttpError(
+      () => assertSurfaceFinishCapability("Secretaire", "library_draft_create"),
+      403,
+      "SURFACE_FINISH_CAPABILITY_REQUIRED"
+    );
+  });
+
+  it("masque les coûts aux rôles qui n'ont pas à les voir", () => {
+    expect(roleHasSurfaceFinishCapability("Technicien Méthodes", "costs_read")).toBe(false);
+    expect(roleHasSurfaceFinishCapability("Responsable Achats", "costs_read")).toBe(true);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 2) Cycle de vie                                                            */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 cycle de vie des révisions", () => {
+  const allowed: Array<[SurfaceFinishStatus, SurfaceFinishStatus]> = [
+    ["BROUILLON", "EN_VALIDATION"],
+    ["BROUILLON", "ARCHIVEE"],
+    ["EN_VALIDATION", "ACTIVE"],
+    ["EN_VALIDATION", "BROUILLON"],
+    ["ACTIVE", "SUSPENDUE"],
+    ["ACTIVE", "OBSOLETE"],
+    ["SUSPENDUE", "ACTIVE"],
+    ["SUSPENDUE", "OBSOLETE"],
+    ["OBSOLETE", "ARCHIVEE"],
+  ];
+
+  it.each(allowed)("autorise %s -> %s", (from, to) => {
+    expect(() => assertSurfaceFinishTransition(from, to)).not.toThrow();
+  });
+
+  const forbidden: Array<[SurfaceFinishStatus, SurfaceFinishStatus]> = [
+    ["ACTIVE", "BROUILLON"],
+    ["ACTIVE", "EN_VALIDATION"],
+    ["ARCHIVEE", "ACTIVE"],
+    ["OBSOLETE", "ACTIVE"],
+    ["BROUILLON", "ACTIVE"],
+    ["SUSPENDUE", "BROUILLON"],
+  ];
+
+  it.each(forbidden)("interdit %s -> %s", (from, to) => {
+    expectHttpError(() => assertSurfaceFinishTransition(from, to), 409, "SURFACE_FINISH_TRANSITION_FORBIDDEN");
+  });
+
+  it("refuse une transition vers le même statut", () => {
+    expectHttpError(() => assertSurfaceFinishTransition("ACTIVE", "ACTIVE"), 409, "SURFACE_FINISH_TRANSITION_NOOP");
+  });
+
+  it("n'autorise que la révision ACTIVE sur une gamme", () => {
+    expect(() => assertRevisionSelectable("ACTIVE")).not.toThrow();
+    for (const status of SURFACE_FINISH_STATUSES.filter((value) => value !== "ACTIVE")) {
+      expectHttpError(() => assertRevisionSelectable(status), 409, "FINISH_REVISION_INACTIVE");
+    }
+  });
+
+  it("fige le contenu d'une révision publiée", () => {
+    expect(() => assertRevisionContentMutable("BROUILLON")).not.toThrow();
+    expect(() => assertRevisionContentMutable("EN_VALIDATION")).not.toThrow();
+    for (const status of ["ACTIVE", "SUSPENDUE", "OBSOLETE", "ARCHIVEE"] as SurfaceFinishStatus[]) {
+      expectHttpError(() => assertRevisionContentMutable(status), 409, "SURFACE_FINISH_REVISION_IMMUTABLE");
+    }
+  });
+});
+
+describe("#210 gardes de gamme et d'opération", () => {
+  it("n'accepte de modifier qu'une gamme brouillon ou en validation", () => {
+    expect(() => assertGammeEditable("BROUILLON")).not.toThrow();
+    expect(() => assertGammeEditable("EN_VALIDATION")).not.toThrow();
+    for (const statut of ["APPLICABLE", "OBSOLETE", "", null, undefined, "brouillon-ish"]) {
+      expectHttpError(() => assertGammeEditable(statut), 409, "GAMME_NOT_EDITABLE");
+    }
+  });
+
+  it("refuse une opération qui n'est pas de la sous-traitance", () => {
+    expect(() => assertOperationIsSubcontracting("SOUS_TRAITANCE")).not.toThrow();
+    expect(() => assertOperationIsSubcontracting("sous_traitance")).not.toThrow();
+    for (const type of ["TOURNAGE", "CONTROLE", "EMBALLAGE", null, ""]) {
+      expectHttpError(() => assertOperationIsSubcontracting(type), 422, "OPERATION_NOT_SUBCONTRACTING");
+    }
+  });
+
+  it("refuse une opération appartenant à une autre gamme", () => {
+    expect(() => assertOperationBelongsToGamme("g1", "g1")).not.toThrow();
+    expectHttpError(() => assertOperationBelongsToGamme("g2", "g1"), 409, "OPERATION_GAMME_MISMATCH");
+    expectHttpError(() => assertOperationBelongsToGamme(null, "g1"), 409, "OPERATION_GAMME_MISMATCH");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 3) Unités et normalisation                                                 */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 unités d'épaisseur", () => {
+  it.each([
+    ["um", "um"],
+    ["µm", "um"],
+    ["μm", "um"],
+    ["microns", "um"],
+    ["MM", "mm"],
+    ["Millimètres", "mm"],
+    ["cm", "cm"],
+    ["inch", "in"],
+    ["Pouce", "in"],
+    ["thou", "mil"],
+  ])("normalise %s en %s", (raw, expected) => {
+    expect(normalizeThicknessUnit(raw)).toBe(expected);
+  });
+
+  it("refuse une unité inconnue plutôt que de deviner", () => {
+    for (const unit of ["kg", "µ", "metre", "??"]) {
+      expectHttpError(() => normalizeThicknessUnit(unit), 422, "SURFACE_FINISH_THICKNESS_UNIT_INVALID");
+    }
+  });
+
+  it.each([
+    [20, "um", 20],
+    [0.02, "mm", 20],
+    [0.002, "cm", 20],
+    [1, "mil", 25.4],
+    [1, "in", 25400],
+  ])("convertit %s %s en %s µm", (value, unit, expected) => {
+    expect(thicknessToMicrometers(value, unit)).toBeCloseTo(expected, 4);
+  });
+
+  it("refuse une épaisseur négative ou non numérique", () => {
+    expectHttpError(() => thicknessToMicrometers(-1, "um"), 422, "SURFACE_FINISH_THICKNESS_INVALID");
+    expectHttpError(() => thicknessToMicrometers(Number.NaN, "um"), 422, "SURFACE_FINISH_THICKNESS_INVALID");
+  });
+
+  it("refuse un intervalle d'épaisseur incohérent", () => {
+    expectHttpError(
+      () => assertThicknessCoherent({ min_um: 30, nominal_um: null, max_um: 10 }),
+      422,
+      "SURFACE_FINISH_THICKNESS_RANGE_INVALID"
+    );
+    expectHttpError(
+      () => assertThicknessCoherent({ min_um: 10, nominal_um: 5, max_um: 30 }),
+      422,
+      "SURFACE_FINISH_THICKNESS_RANGE_INVALID"
+    );
+    expectHttpError(
+      () => assertThicknessCoherent({ min_um: 10, nominal_um: 40, max_um: 30 }),
+      422,
+      "SURFACE_FINISH_THICKNESS_RANGE_INVALID"
+    );
+    expect(() => assertThicknessCoherent({ min_um: null, nominal_um: null, max_um: null })).not.toThrow();
+  });
+});
+
+describe("#210 normalisation textuelle", () => {
+  it("traite chaîne vide et absence de valeur de façon identique", () => {
+    expect(canonicalText("")).toBeNull();
+    expect(canonicalText("   ")).toBeNull();
+    expect(canonicalText(null)).toBeNull();
+    expect(canonicalText(undefined)).toBeNull();
+  });
+
+  it("réduit les espaces sans perdre les accents lisibles", () => {
+    expect(canonicalText("  Anodisation   dure  ")).toBe("Anodisation dure");
+  });
+
+  it("neutralise casse et accents sur les identifiants fonctionnels", () => {
+    expect(canonicalToken("iso 7599")).toBe("ISO 7599");
+    expect(canonicalToken("Épaisseur")).toBe("EPAISSEUR");
+  });
+
+  it.each([
+    ["ral 9005", "RAL 9005"],
+    ["RAL9005", "RAL 9005"],
+    ["Ral-9005", "RAL 9005"],
+    ["  raL   9005 ", "RAL 9005"],
+  ])("canonise la teinte %s en %s", (raw, expected) => {
+    expect(canonicalRal(raw)).toBe(expected);
+  });
+
+  it("trie et dédoublonne les listes : l'ordre de saisie ne compte pas", () => {
+    expect(canonicalTokenList(["Filetage", "alésage", "Filetage", "", null])).toEqual(["ALESAGE", "FILETAGE"]);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 4) Empreinte — propriétés                                                  */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 empreinte anti-doublon", () => {
+  it("produit un SHA-256 hexadécimal stable", () => {
+    const first = fingerprintOf();
+    expect(first).toMatch(/^[0-9a-f]{64}$/);
+    expect(fingerprintOf()).toBe(first);
+  });
+
+  it("ignore l'ordre des clés de l'objet d'entrée", () => {
+    const reordered: SurfaceFinishSpecInput = {
+      instructions: null,
+      unite_achat: "PCE",
+      certificat_type: "3.1",
+      certificat_requis: true,
+      controles: ["EPAISSEUR", "ASPECT"],
+      posttraitement: "Colmatage",
+      pretraitement: "Dégraissage alcalin",
+      exigence_corrosion: "BS 240 h",
+      durete: "HV 400",
+      rugosite: "Ra 1,6",
+      aspect: "Mat",
+      teinte_ral: "RAL 9005",
+      couleur: "Noir",
+      epaisseur_unite: "um",
+      epaisseur_max: 25,
+      epaisseur_nominale: 20,
+      epaisseur_min: 15,
+      masquages: [],
+      zones: [],
+      perimetre: "PIECE_ENTIERE",
+      classe: "AA20",
+      norme: "ISO 7599",
+      finish_revision_id: REVISION_ID,
+      piece_technique_version_id: VERSION_ID,
+      conditionnement: "Bac plastique cloisonné",
+      specification_client: null,
+      specification_client_version: null,
+    };
+    expect(computeSpecFingerprint(buildCanonicalFinishSpec(reordered))).toBe(fingerprintOf());
+  });
+
+  it("ignore l'ordre des zones et des contrôles", () => {
+    const a = fingerprintOf({ perimetre: "ZONES", zones: ["Alésage", "Filetage"], controles: ["ASPECT", "EPAISSEUR"] });
+    const b = fingerprintOf({ perimetre: "ZONES", zones: ["Filetage", "Alésage"], controles: ["EPAISSEUR", "ASPECT"] });
+    expect(a).toBe(b);
+  });
+
+  it("rend équivalentes deux unités qui décrivent la même épaisseur", () => {
+    const micrometres = fingerprintOf({
+      epaisseur_min: 15,
+      epaisseur_nominale: 20,
+      epaisseur_max: 25,
+      epaisseur_unite: "um",
+    });
+    const millimetres = fingerprintOf({
+      epaisseur_min: 0.015,
+      epaisseur_nominale: 0.02,
+      epaisseur_max: 0.025,
+      epaisseur_unite: "mm",
+    });
+    expect(millimetres).toBe(micrometres);
+  });
+
+  it("rend équivalentes casse, accents et espaces d'un identifiant fonctionnel", () => {
+    expect(fingerprintOf({ norme: "  iso   7599 " })).toBe(fingerprintOf({ norme: "ISO 7599" }));
+    expect(fingerprintOf({ teinte_ral: "ral9005" })).toBe(fingerprintOf({ teinte_ral: "RAL 9005" }));
+  });
+
+  it("traite « champ absent » et « champ vide » comme la même chose", () => {
+    expect(fingerprintOf({ aspect: "" })).toBe(fingerprintOf({ aspect: null }));
+  });
+
+  it("ignore les zones quand le périmètre est la pièce entière", () => {
+    expect(fingerprintOf({ perimetre: "PIECE_ENTIERE", zones: ["Alésage"] })).toBe(
+      fingerprintOf({ perimetre: "PIECE_ENTIERE", zones: [] })
+    );
+  });
+
+  it("oublie le type de certificat quand aucun certificat n'est exigé", () => {
+    expect(fingerprintOf({ certificat_requis: false, certificat_type: "3.1" })).toBe(
+      fingerprintOf({ certificat_requis: false, certificat_type: null })
+    );
+  });
+
+  // Chaque champ d'identité DOIT changer l'empreinte : c'est la propriété qui
+  // empêche de fusionner deux prestations différentes.
+  const discriminating: Array<[string, Partial<SurfaceFinishSpecInput>]> = [
+    ["norme", { norme: "ISO 10074" }],
+    ["classe", { classe: "AA25" }],
+    ["périmètre", { perimetre: "ZONES", zones: ["Alésage"] }],
+    ["zones", { perimetre: "ZONES", zones: ["Filetage"] }],
+    ["masquages", { masquages: ["Taraudage M6"] }],
+    ["épaisseur min", { epaisseur_min: 10 }],
+    ["épaisseur nominale", { epaisseur_nominale: 22 }],
+    ["épaisseur max", { epaisseur_max: 30 }],
+    ["couleur", { couleur: "Gris" }],
+    ["teinte RAL", { teinte_ral: "RAL 7016" }],
+    ["aspect", { aspect: "Brillant" }],
+    ["rugosité", { rugosite: "Ra 0,8" }],
+    ["dureté", { durete: "HV 500" }],
+    ["corrosion", { exigence_corrosion: "BS 480 h" }],
+    ["prétraitement", { pretraitement: "Décapage acide" }],
+    ["post-traitement", { posttraitement: "Sans colmatage" }],
+    ["contrôles", { controles: ["EPAISSEUR"] }],
+    ["certificat requis", { certificat_requis: false }],
+    ["type de certificat", { certificat_type: "3.2" }],
+    ["conditionnement", { conditionnement: "Carton individuel" }],
+    ["unité d'achat", { unite_achat: "LOT" }],
+    ["spécification client", { specification_client: "SPEC-CLIENT-42" }],
+    ["version de spécification client", { specification_client_version: "B" }],
+    ["instructions", { instructions: "Protéger les portées de roulement." }],
+    ["révision de finition", { finish_revision_id: "33333333-3333-4333-8333-333333333333" }],
+    ["indice de pièce", { piece_technique_version_id: "44444444-4444-4444-8444-444444444444" }],
+  ];
+
+  it.each(discriminating)("distingue une différence de %s", (_label, patch) => {
+    expect(fingerprintOf(patch)).not.toBe(fingerprintOf());
+  });
+
+  it("matrice : 100+ spécifications valides produisent des empreintes toutes distinctes", () => {
+    const normes = ["ISO 7599", "ISO 10074", "ISO 4042", "ASTM B633", "NF A 91-450"];
+    const epaisseurs = [5, 12, 20, 25, 40];
+    const teintes = ["RAL 9005", "RAL 7016", "RAL 5010", null];
+    const perimetres = ["PIECE_ENTIERE", "ZONES"] as const;
+    const certificats: Array<[boolean, string | null]> = [
+      [true, "3.1"],
+      [false, null],
+    ];
+
+    const seen = new Map<string, string>();
+    let count = 0;
+    for (const norme of normes) {
+      for (const epaisseur of epaisseurs) {
+        for (const teinte of teintes) {
+          for (const perimetre of perimetres) {
+            for (const [requis, type] of certificats) {
+              const label = `${norme}|${epaisseur}|${teinte}|${perimetre}|${requis}`;
+              const fp = fingerprintOf({
+                norme,
+                epaisseur_min: epaisseur,
+                epaisseur_nominale: epaisseur,
+                epaisseur_max: epaisseur,
+                teinte_ral: teinte,
+                perimetre,
+                zones: perimetre === "ZONES" ? ["Alésage"] : [],
+                certificat_requis: requis,
+                certificat_type: type,
+              });
+              expect(fp).toMatch(/^[0-9a-f]{64}$/);
+              if (seen.has(fp)) {
+                throw new Error(`Collision d'empreinte entre « ${seen.get(fp)} » et « ${label} »`);
+              }
+              seen.set(fp, label);
+              count += 1;
+            }
+          }
+        }
+      }
+    }
+    expect(count).toBeGreaterThanOrEqual(100);
+    expect(seen.size).toBe(count);
+  });
+
+  it("matrice : chaque spécification est stable au ré-encodage (unité et ordre)", () => {
+    const cases = [
+      { epaisseur_unite: "mm", factor: 1 / 1000 },
+      { epaisseur_unite: "cm", factor: 1 / 10000 },
+      { epaisseur_unite: "mil", factor: 1 / 25.4 },
+    ];
+    for (const base of [8, 15, 20, 25, 30, 50, 80]) {
+      const reference = fingerprintOf({
+        epaisseur_min: base,
+        epaisseur_nominale: base,
+        epaisseur_max: base,
+        epaisseur_unite: "um",
+      });
+      for (const { epaisseur_unite, factor } of cases) {
+        const converted = fingerprintOf({
+          epaisseur_min: base * factor,
+          epaisseur_nominale: base * factor,
+          epaisseur_max: base * factor,
+          epaisseur_unite,
+        });
+        expect(converted).toBe(reference);
+      }
+    }
+  });
+
+  it("rejette une spécification invalide plutôt que de produire une empreinte", () => {
+    expectHttpError(
+      () => buildCanonicalFinishSpec(baseSpecInput({ epaisseur_min: 40, epaisseur_max: 10 })),
+      422,
+      "SURFACE_FINISH_THICKNESS_RANGE_INVALID"
+    );
+    expectHttpError(
+      () => buildCanonicalFinishSpec(baseSpecInput({ perimetre: "ZONES", zones: [] })),
+      422,
+      "SURFACE_FINISH_ZONES_REQUIRED"
+    );
+    expectHttpError(
+      () => buildCanonicalFinishSpec(baseSpecInput({ epaisseur_unite: "furlong" })),
+      422,
+      "SURFACE_FINISH_THICKNESS_UNIT_INVALID"
+    );
+  });
+
+  it("explique une différence champ par champ", () => {
+    const left = buildCanonicalFinishSpec(baseSpecInput());
+    const right = buildCanonicalFinishSpec(baseSpecInput({ teinte_ral: "RAL 7016", epaisseur_nominale: 22 }));
+    const diff = diffCanonicalSpecs(left, right);
+    const fields = diff.map((entry) => entry.field);
+    expect(fields).toContain("teinte_ral");
+    expect(fields).toContain("epaisseur_nominale_um");
+    expect(fields).not.toContain("schema_version");
+  });
+
+  it("n'accepte aucun champ commercial dans la spécification canonique", () => {
+    const spec = buildCanonicalFinishSpec(baseSpecInput());
+    const keys = Object.keys(spec);
+    for (const forbidden of ["fournisseur", "fournisseur_id", "prix", "devise", "moq", "delai", "quantite", "tarif"]) {
+      expect(keys.some((key) => key.includes(forbidden))).toBe(false);
+    }
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 5) Désignation générée                                                     */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 désignation générée", () => {
+  const ctx = {
+    code_piece: "CAP-100",
+    indice: "C",
+    finition_courte: "Anodisation noire",
+    teinte_ral: "RAL 9005",
+    couleur: "Noir",
+    epaisseur_nominale_um: 20,
+    epaisseur_min_um: 15,
+    classe: null,
+    perimetre: "PIECE_ENTIERE" as const,
+    zones: [] as string[],
+  };
+
+  it("respecte le modèle ST — {pièce} ind. {indice} — {finition}", () => {
+    expect(buildGeneratedDesignation({ ...ctx, teinte_ral: null, couleur: null, epaisseur_nominale_um: null, epaisseur_min_um: null }))
+      .toBe("ST — CAP-100 ind. C — Anodisation noire");
+  });
+
+  it("ajoute les qualificatifs discriminants disponibles", () => {
+    expect(buildGeneratedDesignation(ctx)).toBe("ST — CAP-100 ind. C — Anodisation noire RAL 9005 20 µm");
+  });
+
+  it("retombe sur l'épaisseur minimale quand la nominale manque", () => {
+    expect(buildGeneratedDesignation({ ...ctx, epaisseur_nominale_um: null })).toContain("15 µm");
+  });
+
+  it("mentionne la classe et les zones quand elles discriminent", () => {
+    const value = buildGeneratedDesignation({
+      ...ctx,
+      classe: "AA25",
+      perimetre: "ZONES",
+      zones: ["ALESAGE"],
+    });
+    expect(value).toContain("cl. AA25");
+    expect(value).toContain("zone ALESAGE");
+  });
+
+  it("ne contient jamais null, undefined, NaN ou un UUID", () => {
+    const variants = [
+      ctx,
+      { ...ctx, teinte_ral: null },
+      { ...ctx, couleur: null, teinte_ral: null },
+      { ...ctx, epaisseur_nominale_um: null, epaisseur_min_um: null },
+      { ...ctx, classe: "AA25", perimetre: "ZONES" as const, zones: ["A", "B"] },
+    ];
+    for (const variant of variants) {
+      const value = buildGeneratedDesignation(variant);
+      expect(value).not.toMatch(/null|undefined|NaN/i);
+      expect(value).not.toMatch(/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}/i);
+      expect(value.trim()).toBe(value);
+      expect(value).not.toMatch(/—\s*$/);
+    }
+  });
+
+  it("reste sous la limite du schéma Article", () => {
+    const value = buildGeneratedDesignation({
+      ...ctx,
+      finition_courte: "Anodisation dure décorative avec colmatage à chaud et contrôle renforcé ".repeat(4),
+    });
+    expect(value.length).toBeLessThanOrEqual(DESIGNATION_MAX_LENGTH);
+    expect(value.endsWith("…")).toBe(true);
+  });
+
+  it("refuse de générer sans contexte plutôt que d'écrire un trou", () => {
+    expectHttpError(
+      () => buildGeneratedDesignation({ ...ctx, code_piece: "" }),
+      422,
+      "SURFACE_FINISH_DESIGNATION_CONTEXT_INCOMPLETE"
+    );
+    expectHttpError(
+      () => buildGeneratedDesignation({ ...ctx, indice: "   " }),
+      422,
+      "SURFACE_FINISH_DESIGNATION_CONTEXT_INCOMPLETE"
+    );
+  });
+
+  it("tronque sans couper au milieu d'un mot quand c'est possible", () => {
+    expect(truncateReadable("Anodisation dure décorative", 20)).toBe("Anodisation dure…");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 6) Commentaire généré                                                      */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 commentaire généré", () => {
+  const values = {
+    gamme_code: "GAMME-SERIE",
+    code_piece: "CAP-100",
+    designation_piece: "Capot moteur",
+    indice: "C",
+    plan_reference: "PL-4521",
+    numero_operation: 40,
+    designation_operation: "Traitement de surface",
+    code_finition: "FIN-000012",
+    designation_finition: "Anodisation noire",
+    revision_finition: 2,
+    norme: "ISO 7599",
+    epaisseur: "20 µm (15 à 25 µm)",
+    teinte_aspect: "RAL 9005 / Mat",
+    perimetre: "Pièce entière",
+    zones_masquages: null,
+    certificat: "3.1",
+    controles: "EPAISSEUR, ASPECT",
+    conditionnement: "Bac plastique cloisonné",
+    instructions: null,
+  };
+
+  it("supprime proprement les lignes sans valeur", () => {
+    const rendered = renderGeneratedComment(DEFAULT_COMMENT_TEMPLATE, values);
+    expect(rendered.text).not.toMatch(/null|undefined/i);
+    expect(rendered.text).not.toMatch(/:\s*$/m);
+    expect(rendered.omitted_lines).toContain("Zones et masquages : {zones_masquages}");
+    expect(rendered.omitted_lines).toContain("Instructions complémentaires : {instructions}");
+    expect(rendered.text).toContain("Norme / spécification : ISO 7599");
+  });
+
+  it("ne laisse jamais une ligne réduite à son libellé", () => {
+    const rendered = renderGeneratedComment(DEFAULT_COMMENT_TEMPLATE, { code_piece: "CAP-100" });
+    for (const line of rendered.text.split("\n")) {
+      expect(line).not.toMatch(/^[^:]*:\s*$/);
+      expect(line.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  it("refuse une variable hors liste blanche", () => {
+    expectHttpError(
+      () => assertTemplateVariablesAllowed("Fournisseur : {fournisseur} — prix {prix}"),
+      422,
+      "SURFACE_FINISH_TEMPLATE_VARIABLE_FORBIDDEN"
+    );
+    expectHttpError(
+      () => renderGeneratedComment("Secret : {process_env}", values),
+      422,
+      "SURFACE_FINISH_TEMPLATE_VARIABLE_FORBIDDEN"
+    );
+  });
+
+  it("neutralise balises, accolades et injections de modèle dans les valeurs", () => {
+    const rendered = renderGeneratedComment("Pièce : {code_piece}", {
+      code_piece: "<script>alert(1)</script>{instructions}",
+    });
+    expect(rendered.text).not.toContain("<");
+    expect(rendered.text).not.toContain(">");
+    expect(rendered.text).not.toContain("{");
+    expect(rendered.text).not.toContain("}");
+  });
+
+  it("aplatit les retours à la ligne et les caractères de contrôle d'une valeur", () => {
+    expect(sanitizeTemplateValue("ligne1\nligne2")).toBe("ligne1 · ligne2");
+    expect(sanitizeTemplateValue("a bc")).toBe("a b c");
+    expect(sanitizeTemplateValue(null)).toBe("");
+    expect(sanitizeTemplateValue(["a", "", "b"])).toBe("a, b");
+  });
+
+  it("plafonne la longueur d'une valeur interpolée", () => {
+    const long = "x".repeat(2000);
+    expect(sanitizeTemplateValue(long, 100).length).toBeLessThanOrEqual(100);
+  });
+
+  it("conserve la version du modèle utilisée", () => {
+    const rendered = renderGeneratedComment(DEFAULT_COMMENT_TEMPLATE, values, 7);
+    expect(rendered.template_version).toBe(7);
+  });
+});
+
+describe("#210 override d'un texte généré", () => {
+  it("exige la capacité dédiée", () => {
+    expectHttpError(
+      () => assertGeneratedTextOverrideAllowed({ role: "Technicien Méthodes", reason: "Demande client formalisée" }),
+      403,
+      "SURFACE_FINISH_OVERRIDE_FORBIDDEN"
+    );
+  });
+
+  it("exige un motif écrit", () => {
+    expectHttpError(
+      () => assertGeneratedTextOverrideAllowed({ role: "Responsable Méthodes", reason: "court" }),
+      422,
+      "SURFACE_FINISH_OVERRIDE_REASON_REQUIRED"
+    );
+    expect(() =>
+      assertGeneratedTextOverrideAllowed({ role: "Responsable Méthodes", reason: "Exigence contractuelle client Airbus" })
+    ).not.toThrow();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 7) Décision de résolution                                                  */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 arbitrage de la décision d'article", () => {
+  const ARTICLE = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+
+  it("liste bien les trois décisions possibles", () => {
+    expect([...ARTICLE_DECISIONS]).toEqual(["REUSE", "CREATE", "FORCE_CREATE"]);
+  });
+
+  it("réutilise un article exact actif", () => {
+    expect(() =>
+      assertArticleDecisionConsistent({
+        decision: "REUSE",
+        state: { exactMatchArticleId: ARTICLE, exactMatchIsActive: true },
+        requestedArticleId: ARTICLE,
+        role: "Technicien Méthodes",
+        justification: null,
+      })
+    ).not.toThrow();
+  });
+
+  it("refuse une réutilisation quand l'article exact a changé", () => {
+    expectHttpError(
+      () =>
+        assertArticleDecisionConsistent({
+          decision: "REUSE",
+          state: { exactMatchArticleId: null, exactMatchIsActive: false },
+          requestedArticleId: ARTICLE,
+          role: "Technicien Méthodes",
+          justification: null,
+        }),
+      409,
+      "ARTICLE_EXACT_MATCH_CHANGED"
+    );
+    expectHttpError(
+      () =>
+        assertArticleDecisionConsistent({
+          decision: "REUSE",
+          state: { exactMatchArticleId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", exactMatchIsActive: true },
+          requestedArticleId: ARTICLE,
+          role: "Technicien Méthodes",
+          justification: null,
+        }),
+      409,
+      "ARTICLE_EXACT_MATCH_CHANGED"
+    );
+  });
+
+  it("refuse de réutiliser un article exact inactif", () => {
+    expectHttpError(
+      () =>
+        assertArticleDecisionConsistent({
+          decision: "REUSE",
+          state: { exactMatchArticleId: ARTICLE, exactMatchIsActive: false },
+          requestedArticleId: ARTICLE,
+          role: "Technicien Méthodes",
+          justification: null,
+        }),
+      422,
+      "ARTICLE_SPEC_CONFLICT"
+    );
+  });
+
+  it("refuse une création simple quand un article exact existe", () => {
+    expectHttpError(
+      () =>
+        assertArticleDecisionConsistent({
+          decision: "CREATE",
+          state: { exactMatchArticleId: ARTICLE, exactMatchIsActive: true },
+          requestedArticleId: null,
+          role: "Technicien Méthodes",
+          justification: null,
+        }),
+      409,
+      "ARTICLE_SPEC_CONFLICT"
+    );
+  });
+
+  it("autorise la création quand aucun article exact n'existe", () => {
+    expect(() =>
+      assertArticleDecisionConsistent({
+        decision: "CREATE",
+        state: { exactMatchArticleId: null, exactMatchIsActive: false },
+        requestedArticleId: null,
+        role: "Technicien Méthodes",
+        justification: null,
+      })
+    ).not.toThrow();
+  });
+
+  it("exige habilitation ET justification pour un article distinct", () => {
+    expectHttpError(
+      () =>
+        assertArticleDecisionConsistent({
+          decision: "FORCE_CREATE",
+          state: { exactMatchArticleId: ARTICLE, exactMatchIsActive: true },
+          requestedArticleId: null,
+          role: "Technicien Méthodes",
+          justification: "Le client impose une référence dédiée pour cette affaire",
+        }),
+      403,
+      "ARTICLE_FORCE_CREATE_FORBIDDEN"
+    );
+    expectHttpError(
+      () =>
+        assertArticleDecisionConsistent({
+          decision: "FORCE_CREATE",
+          state: { exactMatchArticleId: ARTICLE, exactMatchIsActive: true },
+          requestedArticleId: null,
+          role: "Responsable Méthodes",
+          justification: "trop court",
+        }),
+      422,
+      "ARTICLE_FORCE_CREATE_JUSTIFICATION_REQUIRED"
+    );
+    expect(() =>
+      assertArticleDecisionConsistent({
+        decision: "FORCE_CREATE",
+        state: { exactMatchArticleId: ARTICLE, exactMatchIsActive: true },
+        requestedArticleId: null,
+        role: "Responsable Méthodes",
+        justification: "Le client impose une référence dédiée pour cette affaire.",
+      })
+    ).not.toThrow();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 8) Aperçu, idempotence, verrou optimiste                                   */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 fraîcheur de l'aperçu", () => {
+  const base = {
+    gamme_id: "g",
+    operation_id: "o",
+    spec_fingerprint: "f",
+    exact_match_article_id: null,
+    designation: "ST — CAP-100 ind. C — Anodisation",
+    comment: "commentaire",
+    gamme_updated_at: "2026-07-28T08:00:00.000Z",
+    operation_updated_at: "2026-07-28T08:00:00.000Z",
+  };
+
+  it("change si l'article exact apparaît", () => {
+    const before = computePreviewHash(base);
+    const after = computePreviewHash({ ...base, exact_match_article_id: "art" });
+    expect(after).not.toBe(before);
+  });
+
+  it("change si la gamme ou l'opération bouge", () => {
+    const before = computePreviewHash(base);
+    expect(computePreviewHash({ ...base, gamme_updated_at: "2026-07-28T09:00:00.000Z" })).not.toBe(before);
+    expect(computePreviewHash({ ...base, operation_updated_at: "2026-07-28T09:00:00.000Z" })).not.toBe(before);
+  });
+
+  it("exige un aperçu et refuse un aperçu périmé", () => {
+    const current = computePreviewHash(base);
+    expectHttpError(() => assertPreviewFresh(null, current), 422, "PREVIEW_REQUIRED");
+    expectHttpError(() => assertPreviewFresh("   ", current), 422, "PREVIEW_REQUIRED");
+    expectHttpError(() => assertPreviewFresh("autre", current), 409, "PREVIEW_STALE");
+    expect(() => assertPreviewFresh(current, current)).not.toThrow();
+  });
+});
+
+describe("#210 idempotence", () => {
+  it("impose une clé de longueur raisonnable", () => {
+    expectHttpError(() => normalizeIdempotencyKey("court"), 400, "IDEMPOTENCY_KEY_INVALID");
+    expectHttpError(() => normalizeIdempotencyKey(null), 400, "IDEMPOTENCY_KEY_INVALID");
+    expectHttpError(() => normalizeIdempotencyKey("x".repeat(201)), 400, "IDEMPOTENCY_KEY_INVALID");
+    expect(normalizeIdempotencyKey("  abcdefgh  ")).toBe("abcdefgh");
+  });
+
+  it("rejoue une charge identique et refuse une charge différente", () => {
+    const hash = requestHash("surface_finish.confirm", { a: 1, b: [1, 2] });
+    expect(requestHash("surface_finish.confirm", { b: [1, 2], a: 1 })).toBe(hash);
+    expect(decideReceipt(null, hash)).toBe("NEW");
+    expect(decideReceipt(hash, hash)).toBe("REPLAY");
+    expect(decideReceipt("autre", hash)).toBe("CONFLICT");
+    expectHttpError(() => assertNoIdempotencyConflict("CONFLICT"), 409, "IDEMPOTENCY_CONFLICT");
+    expect(() => assertNoIdempotencyConflict("REPLAY")).not.toThrow();
+  });
+});
+
+describe("#210 verrou optimiste", () => {
+  it("exige expected_updated_at et détecte une modification concurrente", () => {
+    const now = "2026-07-28T08:00:00.000Z";
+    expectHttpError(
+      () => assertOptimisticVersion({ expectedUpdatedAt: null, currentUpdatedAt: now, label: "La gamme" }),
+      422,
+      "EXPECTED_VERSION_REQUIRED"
+    );
+    expectHttpError(
+      () => assertOptimisticVersion({ expectedUpdatedAt: "pas-une-date", currentUpdatedAt: now, label: "La gamme" }),
+      422,
+      "EXPECTED_VERSION_INVALID"
+    );
+    expectHttpError(
+      () =>
+        assertOptimisticVersion({
+          expectedUpdatedAt: "2026-07-28T07:00:00.000Z",
+          currentUpdatedAt: now,
+          label: "La gamme",
+        }),
+      409,
+      "CONCURRENT_MODIFICATION"
+    );
+    expect(() => assertOptimisticVersion({ expectedUpdatedAt: now, currentUpdatedAt: now, label: "La gamme" })).not.toThrow();
+  });
+
+  it("tolère les représentations équivalentes d'une même date", () => {
+    expect(() =>
+      assertOptimisticVersion({
+        expectedUpdatedAt: "2026-07-28T08:00:00.000Z",
+        currentUpdatedAt: new Date("2026-07-28T08:00:00.000Z"),
+        label: "La gamme",
+      })
+    ).not.toThrow();
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* 9) Taxonomie de l'article généré                                           */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 taxonomie CAT", () => {
+  it("fixe la CAT métier à traitement_surface, jamais un enum « CAT » inventé", () => {
+    expect(GENERATED_ARTICLE_TAXONOMY.article_categories).toEqual(["traitement_surface"]);
+    expect(GENERATED_ARTICLE_TAXONOMY.article_type).toBe("PURCHASED");
+    expect(GENERATED_ARTICLE_TAXONOMY.article_category).toBe("traitement");
+    expect(GENERATED_ARTICLE_TAXONOMY.default_family_code).toBe("TRT");
+  });
+
+  it("ne gère ni stock ni lot sur la prestation elle-même", () => {
+    expect(GENERATED_ARTICLE_TAXONOMY.stock_managed).toBe(false);
+    expect(GENERATED_ARTICLE_TAXONOMY.lot_tracking).toBe(false);
+  });
+
+  it("distingue la ligne d'achat pièce et la catégorie du catalogue fournisseur", () => {
+    expect(PURCHASE_LINE_TYPE).toBe("TRAITEMENT");
+    expect(SUPPLIER_CATALOGUE_CATEGORY).toBe("SOUS_TRAITANCE");
+  });
+});

--- a/src/__tests__/surface-finish-210.migration-guards.test.ts
+++ b/src/__tests__/surface-finish-210.migration-guards.test.ts
@@ -1,0 +1,251 @@
+// #210 — Garde-fous du patch « bibliothèque de finitions ».
+//
+// Ces tests lisent le SQL livré : ils empêchent qu'un patch cesse d'être
+// additif, qu'un backfill s'y glisse, ou qu'un garde-fou structurel disparaisse
+// à la faveur d'une retouche.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(resolve(root, relative), "utf8");
+
+// Un script « lecture seule » ne doit contenir aucune INSTRUCTION d'écriture.
+// On ancre en début de ligne : `SELECT,INSERT,UPDATE` dans has_table_privilege()
+// est un nom de privilège, pas une écriture.
+const READ_ONLY = /^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE|GRANT|REVOKE)\b/im;
+
+const patch = read("db/patches/20260728_surface_finish_library_210.sql");
+const preflight = read("db/patches/support/20260728_surface_finish_library_210.preflight.sql");
+const verify = read("db/patches/support/20260728_surface_finish_library_210.verify.sql");
+const rollback = read("db/patches/support/20260728_surface_finish_library_210.rollback.sql");
+const candidates = read("db/patches/support/20260728_surface_finish_library_210.candidates.sql");
+
+describe("#210 patch additif", () => {
+  it("est transactionnel", () => {
+    expect(patch.trimStart().startsWith("--")).toBe(true);
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("COMMIT;");
+  });
+
+  it("ne détruit ni ne réécrit aucune donnée existante", () => {
+    expect(patch).not.toMatch(/\bDROP\s+TABLE\b/i);
+    expect(patch).not.toMatch(/\bDROP\s+COLUMN\b/i);
+    expect(patch).not.toMatch(/\bTRUNCATE\b/i);
+    expect(patch).not.toMatch(/\bDELETE\s+FROM\b/i);
+    // Aucune donnée métier existante n'est réécrite : le seul UPDATE toléré
+    // serait un backfill, et il n'y en a pas.
+    expect(patch).not.toMatch(/\bUPDATE\s+public\.articles\b/i);
+    expect(patch).not.toMatch(/\bUPDATE\s+public\.articles_traitement\b/i);
+    expect(patch).not.toMatch(/\bUPDATE\s+public\.pieces_techniques_achats\b/i);
+    expect(patch).not.toMatch(/\bUPDATE\s+public\.pieces_techniques_operations\b/i);
+  });
+
+  it("n'effectue AUCUN backfill : pas de reprise par phase, désignation ou ILIKE", () => {
+    expect(patch).not.toMatch(/ILIKE/i);
+    expect(patch).not.toMatch(/INSERT INTO public\.gamme_operation_finitions/i);
+    // Le seul INSERT de données est l'amorçage du référentiel de familles.
+    const inserts = patch.match(/INSERT\s+INTO\s+public\.[a-z_]+/gi) ?? [];
+    expect(inserts).toEqual(["INSERT INTO public.surface_finish_families"]);
+    expect(patch).toContain("ON CONFLICT (code) DO NOTHING");
+  });
+
+  it("ajoute les colonnes en NULLABLE sur les tables existantes", () => {
+    for (const column of [
+      "spec_fingerprint",
+      "spec_canonical",
+      "finish_revision_id",
+      "generated_designation",
+      "superseded_at",
+    ]) {
+      expect(patch).toMatch(new RegExp(`ADD COLUMN IF NOT EXISTS\\s+${column}\\s+[a-z]+\\s+NULL`, "i"));
+    }
+    expect(patch).toMatch(/ADD COLUMN IF NOT EXISTS\s+gamme_operation_id\s+uuid NULL/i);
+  });
+
+  it("reste idempotent", () => {
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.surface_finishes");
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.surface_finish_revisions");
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.gamme_operation_finitions");
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.surface_finish_command_receipts");
+    const creates = patch.match(/CREATE TABLE(?! IF NOT EXISTS)/g) ?? [];
+    expect(creates).toEqual([]);
+    const indexes = patch.match(/CREATE (UNIQUE )?INDEX(?! IF NOT EXISTS)/g) ?? [];
+    expect(indexes).toEqual([]);
+  });
+});
+
+describe("#210 garde-fous structurels", () => {
+  it("impose une seule version courante d'article par empreinte", () => {
+    expect(patch).toContain("CREATE UNIQUE INDEX IF NOT EXISTS articles_traitement_fingerprint_current_uq");
+    expect(patch).toContain("WHERE spec_fingerprint IS NOT NULL AND superseded_at IS NULL");
+  });
+
+  it("lie la ligne d'achat à l'opération par clé étrangère et l'unicité", () => {
+    expect(patch).toContain("pt_achats_gamme_operation_fk");
+    expect(patch).toContain("FOREIGN KEY (gamme_operation_id) REFERENCES public.pieces_techniques_operations(id)");
+    expect(patch).toContain("CREATE UNIQUE INDEX IF NOT EXISTS pt_achats_gamme_operation_traitement_uq");
+    expect(patch).toContain("type_achat = 'TRAITEMENT'");
+  });
+
+  it("n'accepte qu'une exigence de finition par opération et une révision active par finition", () => {
+    expect(patch).toContain("CONSTRAINT gamme_operation_finitions_operation_uq UNIQUE (gamme_operation_id)");
+    expect(patch).toContain("CREATE UNIQUE INDEX IF NOT EXISTS surface_finish_revisions_single_active_uq");
+  });
+
+  it("rend le code de finition immuable et contraint son format", () => {
+    expect(patch).toContain("fn_protect_surface_finish_code_210");
+    expect(patch).toContain("trg_surface_finish_code_immutable");
+    expect(patch).toContain("code ~ '^FIN-[0-9]{6}$'");
+  });
+
+  it("contraint la cohérence métier en base, pas seulement en TypeScript", () => {
+    expect(patch).toContain("surface_finish_revisions_epaisseur_coherente");
+    expect(patch).toContain("surface_finish_revisions_certificat_coherent");
+    expect(patch).toContain("gamme_operation_finitions_zones_coherentes");
+    expect(patch).toContain("gamme_operation_finitions_fingerprint_format");
+    expect(patch).toContain("articles_traitement_spec_pair_check");
+    expect(patch).toContain("gamme_operation_finitions_override_reason");
+  });
+
+  it("empêche la disparition d'une révision utilisée par une gamme", () => {
+    expect(patch).toContain(
+      "CONSTRAINT gamme_operation_finitions_revision_fk FOREIGN KEY (finish_revision_id)\n    REFERENCES public.surface_finish_revisions(id) ON DELETE RESTRICT"
+    );
+  });
+
+  it("garde les familles administrables plutôt qu'enfermées dans un enum", () => {
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.surface_finish_families");
+    expect(patch).not.toMatch(/CHECK\s*\(\s*family_code\s+IN\s*\(/i);
+  });
+
+  it("ne stocke aucun chemin de fichier dans le registre documentaire", () => {
+    // Aucune COLONNE de chemin : le commentaire de table a le droit d'employer
+    // le mot pour dire précisément qu'il n'y en a pas.
+    expect(patch).not.toMatch(/^\s*storage_path\s/im);
+    expect(patch).not.toMatch(/^\s*(file_path|chemin|filepath)\s/im);
+    expect(patch).toContain("surface_finish_revision_documents_anchor_required");
+  });
+
+  it("rend les reçus d'idempotence non modifiables par l'application", () => {
+    expect(patch).toContain("GRANT SELECT, INSERT ON public.surface_finish_command_receipts TO cerp_app");
+    expect(patch).toContain("REVOKE UPDATE, DELETE ON public.surface_finish_command_receipts FROM cerp_app");
+  });
+});
+
+describe("#210 codification", () => {
+  it("ajoute le scope FIN sans retirer aucun scope existant", () => {
+    const match = patch.match(/v_scope !~ '(\^\([^']+\)\$)'/);
+    expect(match).not.toBeNull();
+    const regex = match![1];
+    for (const scope of ["CLI", "FOU", "MCH", "MET", "FIN", "BCF", "PC", "DER", "MEX", "MIA"]) {
+      expect(regex).toContain(scope);
+    }
+  });
+
+  it("restaure le whitelist précédent au rollback plutôt que de le laisser amputé", () => {
+    expect(rollback).toContain("CREATE OR REPLACE FUNCTION public.fn_next_issued_code_value");
+    const match = rollback.match(/v_scope !~ '(\^\([^']+\)\$)'/);
+    expect(match).not.toBeNull();
+    expect(match![1]).toContain("MCH");
+    expect(match![1]).toContain("MET");
+    expect(match![1]).not.toContain("FIN|");
+  });
+});
+
+describe("#210 fonctions utilitaires SQL", () => {
+  it("expose une normalisation de recherche sans dépendre de l'extension unaccent", () => {
+    expect(patch).toContain("CREATE OR REPLACE FUNCTION public.surface_finish_norm");
+    expect(patch).not.toMatch(/CREATE EXTENSION/i);
+    expect(patch).toContain("IMMUTABLE");
+  });
+
+  it("expose la conversion d'épaisseur, miroir du TypeScript", () => {
+    expect(patch).toContain("CREATE OR REPLACE FUNCTION public.surface_finish_to_um");
+    for (const factor of ["1000", "10000", "25400", "25.4"]) {
+      expect(patch).toContain(factor);
+    }
+  });
+
+  it("indexe ce que la recherche interroge réellement", () => {
+    expect(patch).toContain("public.surface_finish_norm(designation_courte)");
+    expect(patch).toContain("public.surface_finish_norm(norme)");
+    expect(patch).toContain("USING gin (synonymes)");
+  });
+});
+
+describe("#210 preflight", () => {
+  it("est en lecture seule", () => {
+    expect(preflight).not.toMatch(READ_ONLY);
+  });
+
+  it("vérifie les pré-requis et l'absence des tables du chantier", () => {
+    expect(preflight).toContain("req_code_allocator");
+    expect(preflight).toContain("cat_traitement_surface_present");
+    expect(preflight).toContain("t_finishes_absent");
+    expect(preflight).toContain("col_achat_operation_absent");
+    expect(preflight).toContain("articles_rows_before");
+  });
+});
+
+describe("#210 verify", () => {
+  it("est en lecture seule et ne consomme aucune séquence", () => {
+    expect(verify).not.toMatch(READ_ONLY);
+    expect(verify).not.toMatch(/SELECT public\.fn_next_issued_code_value\(/);
+  });
+
+  it("prouve l'absence de backfill", () => {
+    expect(verify).toContain("backfilled_fingerprints");
+    expect(verify).toContain("backfilled_achat_links");
+    expect(verify).toContain("articles_rows_after");
+  });
+
+  it("prouve que l'enum du catalogue fournisseur n'a pas bougé", () => {
+    expect(verify).toContain("supplier_catalogue_enum_untouched");
+  });
+
+  it("contrôle les garde-fous et les droits", () => {
+    expect(verify).toContain("idx_fingerprint_unique");
+    expect(verify).toContain("idx_achat_operation_unique");
+    expect(verify).toContain("trg_code_immutable");
+    expect(verify).toContain("grants_ok");
+  });
+});
+
+describe("#210 rollback réaliste", () => {
+  it("refuse de s'exécuter si des données métier existent", () => {
+    expect(rollback).toContain("Rollback refusé");
+    expect(rollback).toContain("cerp.force_rollback");
+    expect(rollback).toContain("ERRCODE = '2F000'");
+  });
+
+  it("dit explicitement qu'il détruit et ne restaure rien", () => {
+    expect(rollback).toMatch(/DÉTRUIT/);
+    expect(rollback).toMatch(/sauvegarde/i);
+  });
+
+  it("ne supprime ni les articles ni les lignes d'achat existantes", () => {
+    expect(rollback).not.toMatch(/DROP TABLE IF EXISTS public\.articles\b/i);
+    expect(rollback).not.toMatch(/DROP TABLE IF EXISTS public\.pieces_techniques_achats\b/i);
+    expect(rollback).not.toMatch(/DELETE FROM public\.articles\b/i);
+  });
+});
+
+describe("#210 rapport de reprise historique", () => {
+  it("est en lecture seule et ne relie rien automatiquement", () => {
+    expect(candidates).not.toMatch(READ_ONLY);
+    expect(candidates).toMatch(/AUCUN BACKFILL/);
+  });
+
+  it("classe les candidats en quatre familles explicites", () => {
+    for (const label of ["EXACT_PROBABLE", "AMBIGU", "INCOMPATIBLE", "NON_LIE"]) {
+      expect(candidates).toContain(label);
+    }
+  });
+
+  it("rappelle que le numéro de phase n'est pas un lien", () => {
+    expect(candidates).toMatch(/phase N'EST PAS un lien/);
+  });
+});

--- a/src/__tests__/surface-finish-210.routes.test.ts
+++ b/src/__tests__/surface-finish-210.routes.test.ts
@@ -1,0 +1,772 @@
+// Surface HTTP « Bibliothèque de finitions » (#210) : RBAC refusé par défaut,
+// aperçu strictement en lecture, confirmation atomique et idempotente, et
+// preuve qu'aucune commande fournisseur ni aucun mouvement de stock n'est créé.
+
+import request from "supertest";
+import { EventEmitter } from "events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+  currentRole: { value: "administrateur" as string | null },
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = {
+    on: emitter.on.bind(emitter),
+    query: mocks.poolQuery,
+    connect: mocks.poolConnect,
+  };
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; username: string; email: string; role: string } },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void
+  ) => {
+    if (mocks.currentRole.value === null) {
+      res.status(401).json({ error: "UNAUTHORIZED" });
+      return;
+    }
+    req.user = {
+      id: 42,
+      username: "tester",
+      email: "tester@example.test",
+      role: mocks.currentRole.value,
+    };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import app from "../config/app";
+
+const FIN_BASE = "/api/v1/finitions";
+const GAMME_ID = "11111111-1111-4111-8111-111111111111";
+const OPERATION_ID = "22222222-2222-4222-8222-222222222222";
+const REVISION_ID = "33333333-3333-4333-8333-333333333333";
+const VERSION_ID = "44444444-4444-4444-8444-444444444444";
+const PIECE_ID = "55555555-5555-4555-8555-555555555555";
+const FINISH_ID = "66666666-6666-4666-8666-666666666666";
+const ARTICLE_ID = "77777777-7777-4777-8777-777777777777";
+const LINE_ID = "88888888-8888-4888-8888-888888888888";
+const IDEMPOTENCY = "finition-confirm-key-0001";
+
+const OP_BASE = `/api/v1/gammes/${GAMME_ID}/operations/${OPERATION_ID}/finition`;
+
+type Row = Record<string, unknown>;
+
+const contextRow = (overrides: Row = {}): Row => ({
+  piece_technique_id: PIECE_ID,
+  code_piece: "CAP-100",
+  designation_piece: "Capot moteur",
+  piece_technique_version_id: VERSION_ID,
+  indice: "C",
+  plan_reference: "PL-4521",
+  gamme_id: GAMME_ID,
+  gamme_code: "GAMME-SERIE",
+  gamme_nom: "Gamme série",
+  gamme_statut: "BROUILLON",
+  gamme_updated_at: "2026-07-28T08:00:00.000Z",
+  operation_id: OPERATION_ID,
+  numero_operation: 40,
+  designation_operation: "Traitement de surface",
+  type_operation: "SOUS_TRAITANCE",
+  operation_updated_at: "2026-07-28T08:00:00.000Z",
+  operation_gamme_id: GAMME_ID,
+  ...overrides,
+});
+
+const revisionRow = (overrides: Row = {}): Row => ({
+  id: REVISION_ID,
+  finish_id: FINISH_ID,
+  revision: 2,
+  statut: "ACTIVE",
+  norme: "ISO 7599",
+  reference_client: null,
+  classe: "AA20",
+  substrat: "Aluminium",
+  epaisseur_min: 15,
+  epaisseur_nominale: 20,
+  epaisseur_max: 25,
+  epaisseur_unite: "um",
+  couleur: "Noir",
+  teinte_ral: "RAL 9005",
+  aspect: "Mat",
+  brillance: null,
+  rugosite: null,
+  durete: null,
+  exigence_corrosion: null,
+  pretraitement: "Dégraissage alcalin",
+  posttraitement: "Colmatage",
+  zones_defaut: [],
+  regles_masquage: [],
+  criteres_acceptation: "Aspect homogène, sans coulure",
+  controles: ["EPAISSEUR", "ASPECT"],
+  certificat_requis: true,
+  certificat_type: "3.1",
+  conditionnement_retour: "Bac plastique cloisonné",
+  unite_achat: "PCE",
+  designation_template: null,
+  commentaire_template: null,
+  template_version: 1,
+  date_effet: "2026-01-01",
+  approbateur_user_id: 7,
+  approved_at: "2026-01-02T09:00:00.000Z",
+  created_at: "2026-01-01T09:00:00.000Z",
+  updated_at: "2026-01-02T09:00:00.000Z",
+  finish_uuid: FINISH_ID,
+  finish_code: "FIN-000012",
+  finish_designation: "Anodisation noire",
+  finish_family: "ANODISATION",
+  finish_procede: "Anodisation sulfurique",
+  finish_statut: "ACTIVE",
+  ...overrides,
+});
+
+const requirementRow = (overrides: Row = {}): Row => ({
+  id: "99999999-9999-4999-8999-999999999999",
+  gamme_id: GAMME_ID,
+  gamme_operation_id: OPERATION_ID,
+  piece_technique_version_id: VERSION_ID,
+  finish_revision_id: REVISION_ID,
+  finish_id: FINISH_ID,
+  finish_code: "FIN-000012",
+  finish_designation: "Anodisation noire",
+  revision: 2,
+  revision_statut: "ACTIVE",
+  perimetre: "PIECE_ENTIERE",
+  zones: [],
+  masquages: [],
+  instructions: null,
+  spec_fingerprint: "a".repeat(64),
+  article_id: ARTICLE_ID,
+  article_code: "ART-TRT-000123",
+  article_designation: "ST — CAP-100 ind. C — Anodisation noire RAL 9005 20 µm cl. AA20",
+  achat_ligne_id: LINE_ID,
+  generated_designation: "ST — CAP-100 ind. C — Anodisation noire RAL 9005 20 µm cl. AA20",
+  generated_comment: "Sous-traitance issue de la gamme GAMME-SERIE.",
+  designation_override: null,
+  comment_override: null,
+  updated_at: "2026-07-28T08:05:00.000Z",
+  ...overrides,
+});
+
+/** Journal de toutes les requêtes vues : sert de preuve d'absence d'effet de bord. */
+let sqlLog: string[] = [];
+
+type Scenario = {
+  context?: Row;
+  revision?: Row;
+  exactMatch?: Row | null;
+  existingRequirement?: Row | null;
+  receipt?: { request_hash: string; result: unknown } | null;
+  failOnPurchaseLine?: boolean;
+};
+
+function installQueryRouter(scenario: Scenario = {}) {
+  const handler = async (sql: string): Promise<{ rows: Row[]; rowCount: number }> => {
+    sqlLog.push(sql);
+    const empty = { rows: [] as Row[], rowCount: 0 };
+    const one = (row: Row) => ({ rows: [row], rowCount: 1 });
+
+    if (/surface_finish_command_receipts/.test(sql) && /^\s*SELECT/i.test(sql)) {
+      return scenario.receipt ? one(scenario.receipt as Row) : empty;
+    }
+    if (/FROM public\.gammes g/.test(sql)) {
+      return one(scenario.context ?? contextRow());
+    }
+    if (/FROM public\.surface_finish_revisions r/.test(sql) && /JOIN public\.surface_finishes f/.test(sql)) {
+      return one(scenario.revision ?? revisionRow());
+    }
+    if (/FROM public\.articles_traitement t/.test(sql) && /spec_fingerprint = \$1/.test(sql)) {
+      return scenario.exactMatch ? one(scenario.exactMatch) : empty;
+    }
+    if (/FROM public\.articles_traitement t/.test(sql)) return empty; // near matches
+    if (/FROM public\.fournisseur_catalogue c/.test(sql)) return empty;
+    if (/FROM public\.gamme_operation_finitions fin/.test(sql)) {
+      return scenario.existingRequirement === null
+        ? empty
+        : one(scenario.existingRequirement ?? requirementRow());
+    }
+    if (/fn_next_issued_code_value/.test(sql)) return one({ v: "123" });
+    if (/INSERT INTO public\.articles\b/.test(sql)) return one({ id: ARTICLE_ID });
+    if (/INSERT INTO erp_audit_logs/.test(sql)) {
+      return one({ id: "audit-1", created_at: "2026-07-28T08:05:00.000Z" });
+    }
+    if (/INSERT INTO public\.pieces_techniques_achats/.test(sql)) {
+      if (scenario.failOnPurchaseLine) {
+        throw Object.assign(new Error("insert failed"), { code: "23502" });
+      }
+      return one({ id: LINE_ID, quantite: "1" });
+    }
+    if (/FROM public\.pieces_techniques_achats/.test(sql)) return empty;
+    return empty;
+  };
+
+  mocks.poolQuery.mockImplementation((sql: string) => handler(sql));
+  mocks.clientQuery.mockImplementation((sql: string) => handler(sql));
+  mocks.poolConnect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease });
+}
+
+async function fetchPreview(): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await request(app)
+    .post(`${OP_BASE}/preview`)
+    .send({ finish_revision_id: REVISION_ID, quantite: 1 });
+  return { status: res.status, body: res.body };
+}
+
+function confirmPayload(preview: Record<string, unknown>, overrides: Row = {}) {
+  return {
+    finish_revision_id: REVISION_ID,
+    quantite: 1,
+    decision: "CREATE",
+    preview_hash: preview.preview_hash,
+    spec_fingerprint: preview.spec_fingerprint,
+    expected_gamme_updated_at: "2026-07-28T08:00:00.000Z",
+    expected_operation_updated_at: "2026-07-28T08:00:00.000Z",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  sqlLog = [];
+  mocks.poolQuery.mockReset();
+  mocks.poolConnect.mockReset();
+  mocks.clientQuery.mockReset();
+  mocks.clientRelease.mockReset();
+  mocks.currentRole.value = "administrateur";
+  installQueryRouter();
+});
+
+/* -------------------------------------------------------------------------- */
+/* Authentification et RBAC                                                    */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 authentification et RBAC", () => {
+  it("refuse un appel non authentifié", async () => {
+    mocks.currentRole.value = null;
+    const res = await request(app).get(`${FIN_BASE}?page=1`);
+    expect(res.status).toBe(401);
+  });
+
+  it("refuse la lecture de la bibliothèque à un rôle sans capacité", async () => {
+    mocks.currentRole.value = "Secretaire";
+    const res = await request(app).get(`${FIN_BASE}?page=1`);
+    expect(res.status).toBe(403);
+    expect(res.body.code ?? res.body.error).toBeDefined();
+  });
+
+  it("laisse les Achats lire mais pas créer un brouillon de finition", async () => {
+    mocks.currentRole.value = "Responsable Achats";
+    const read = await request(app).get(`${FIN_BASE}?page=1&page_size=5`);
+    expect(read.status).toBe(200);
+
+    const write = await request(app)
+      .post(FIN_BASE)
+      .send({ family_code: "ANODISATION", procede: "Anodisation", designation_courte: "Anodisation noire" });
+    expect(write.status).toBe(403);
+  });
+
+  it("refuse la configuration d'opération à un rôle Production", async () => {
+    mocks.currentRole.value = "Operateur production";
+    const res = await request(app).delete(OP_BASE).send({ motif: "Erreur de saisie", expected_updated_at: "x" });
+    expect(res.status).toBe(403);
+  });
+
+  it("laisse les Achats prévisualiser sans pouvoir confirmer", async () => {
+    mocks.currentRole.value = "Responsable Achats";
+    const preview = await fetchPreview();
+    expect(preview.status).toBe(200);
+
+    const confirm = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview.body));
+    expect(confirm.status).toBe(403);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Validation                                                                  */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 validation d'entrée", () => {
+  it("refuse un identifiant de route non-UUID", async () => {
+    const res = await request(app)
+      .post(`/api/v1/gammes/not-a-uuid/operations/${OPERATION_ID}/finition/preview`)
+      .send({ finish_revision_id: REVISION_ID });
+    expect(res.status).toBe(422);
+  });
+
+  it("refuse une confirmation sans décision ni aperçu", async () => {
+    const res = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send({ finish_revision_id: REVISION_ID });
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("VALIDATION_ERROR");
+  });
+
+  it("refuse une page_size hors bornes", async () => {
+    const res = await request(app).get(`${FIN_BASE}?page_size=5000`);
+    expect(res.status).toBe(422);
+  });
+
+  it("refuse un document sans aucune ancre", async () => {
+    const res = await request(app)
+      .post(`${FIN_BASE}/revisions/${REVISION_ID}/documents`)
+      .send({ libelle: "Spécification client" });
+    expect(res.status).toBe(422);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Aperçu — lecture pure                                                       */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 aperçu", () => {
+  it("renvoie la spécification, l'empreinte et les textes générés côté serveur", async () => {
+    const { status, body } = await fetchPreview();
+    expect(status).toBe(200);
+    expect(body.spec_fingerprint).toMatch(/^[0-9a-f]{64}$/);
+    expect(body.preview_hash).toMatch(/^[0-9a-f]{64}$/);
+    expect(body.generated_designation).toBe("ST — CAP-100 ind. C — Anodisation noire RAL 9005 20 µm cl. AA20");
+    expect(String(body.generated_comment)).toContain("Norme / spécification : ISO 7599");
+    expect(String(body.generated_comment)).not.toMatch(/null|undefined/i);
+  });
+
+  // Régression : une valeur ABSENTE hérite de la révision ; une valeur
+  // explicitement `null` l'efface. Confondre les deux vidait la désignation.
+  it("hérite des valeurs de la révision quand l'opération ne les surcharge pas", async () => {
+    const { body } = await fetchPreview();
+    const spec = body.spec_canonical as Record<string, unknown>;
+    expect(spec.teinte_ral).toBe("RAL 9005");
+    expect(spec.norme).toBe("ISO 7599");
+    expect(spec.epaisseur_nominale_um).toBe(20);
+    expect(spec.controles).toEqual(["ASPECT", "EPAISSEUR"]);
+  });
+
+  it("efface une valeur héritée quand l'opération envoie explicitement null", async () => {
+    const res = await request(app)
+      .post(`${OP_BASE}/preview`)
+      .send({ finish_revision_id: REVISION_ID, overrides: { teinte_ral: null, couleur: null } });
+    expect(res.status).toBe(200);
+    const spec = res.body.spec_canonical as Record<string, unknown>;
+    expect(spec.teinte_ral).toBeNull();
+    expect(spec.couleur).toBeNull();
+    expect(res.body.generated_designation).toBe("ST — CAP-100 ind. C — Anodisation noire 20 µm cl. AA20");
+  });
+
+  it("annonce la classification CAT sans jamais inventer le code article", async () => {
+    const { body } = await fetchPreview();
+    const classification = body.classification as Record<string, unknown>;
+    expect(classification.article_type).toBe("PURCHASED");
+    expect(classification.article_category).toBe("traitement");
+    expect(classification.article_categories).toEqual(["traitement_surface"]);
+    expect(classification.stock_managed).toBe(false);
+    expect(classification.lot_tracking).toBe(false);
+    expect(String(classification.code_hint)).toContain("…");
+  });
+
+  it("N'ÉCRIT RIEN : aucune transaction, aucun INSERT, aucun UPDATE", async () => {
+    await fetchPreview();
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+    const mutating = sqlLog.filter((sql) => /\b(INSERT|UPDATE|DELETE|BEGIN|COMMIT)\b/i.test(sql));
+    expect(mutating).toEqual([]);
+  });
+
+  it("prévient quand la gamme n'est plus modifiable, sans refuser la lecture", async () => {
+    installQueryRouter({ context: contextRow({ gamme_statut: "APPLICABLE" }) });
+    const { status, body } = await fetchPreview();
+    expect(status).toBe(200);
+    const codes = (body.warnings as Array<{ code: string }>).map((w) => w.code);
+    expect(codes).toContain("GAMME_NOT_EDITABLE");
+    expect((body.context as Record<string, unknown>).gamme_editable).toBe(false);
+  });
+
+  it("prévient quand la révision n'est pas active", async () => {
+    installQueryRouter({ revision: revisionRow({ statut: "SUSPENDUE" }) });
+    const { body } = await fetchPreview();
+    const codes = (body.warnings as Array<{ code: string }>).map((w) => w.code);
+    expect(codes).toContain("FINISH_REVISION_INACTIVE");
+  });
+
+  it("propose la réutilisation quand un article exact actif existe", async () => {
+    const { body: first } = await fetchPreview();
+    installQueryRouter({
+      exactMatch: {
+        article_id: ARTICLE_ID,
+        code: "ART-TRT-000123",
+        designation: "ST — CAP-100 ind. C — Anodisation noire RAL 9005 20 µm cl. AA20",
+        is_active: true,
+        status: "VALIDE",
+        spec_fingerprint: first.spec_fingerprint,
+        spec_canonical: null,
+        finish_revision_id: REVISION_ID,
+        piece_technique_version_id: VERSION_ID,
+        created_at: "2026-05-01T10:00:00.000Z",
+      },
+    });
+    const { body } = await fetchPreview();
+    expect((body.exact_match as Record<string, unknown>).code).toBe("ART-TRT-000123");
+    expect(body.allowed_decisions).toContain("REUSE");
+    expect(body.allowed_decisions).not.toContain("CREATE");
+  });
+
+  it("refuse l'aperçu sur une opération qui n'est pas de la sous-traitance", async () => {
+    installQueryRouter({ context: contextRow({ type_operation: "TOURNAGE" }) });
+    const res = await fetchPreview();
+    expect(res.status).toBe(422);
+    expect(res.body.code).toBe("OPERATION_NOT_SUBCONTRACTING");
+  });
+
+  it("refuse l'aperçu sur une opération d'une autre gamme", async () => {
+    installQueryRouter({ context: contextRow({ operation_gamme_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa" }) });
+    const res = await fetchPreview();
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("OPERATION_GAMME_MISMATCH");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Confirmation                                                                */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 confirmation", () => {
+  it("exige une clé d'idempotence", async () => {
+    const { body: preview } = await fetchPreview();
+    const res = await request(app).post(`${OP_BASE}/confirm`).send(confirmPayload(preview));
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("IDEMPOTENCY_KEY_INVALID");
+  });
+
+  it("refuse un aperçu périmé", async () => {
+    const { body: preview } = await fetchPreview();
+    const res = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview, { preview_hash: "b".repeat(64) }));
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("PREVIEW_STALE");
+  });
+
+  it("refuse une empreinte qui ne correspond plus à la spécification recalculée", async () => {
+    const { body: preview } = await fetchPreview();
+    const res = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview, { spec_fingerprint: "c".repeat(64) }));
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("PREVIEW_STALE");
+  });
+
+  it("refuse une gamme non modifiable", async () => {
+    const { body: preview } = await fetchPreview();
+    installQueryRouter({ context: contextRow({ gamme_statut: "APPLICABLE" }) });
+    const res = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview));
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("GAMME_NOT_EDITABLE");
+  });
+
+  it("refuse une révision de finition inactive", async () => {
+    const { body: preview } = await fetchPreview();
+    installQueryRouter({ revision: revisionRow({ statut: "OBSOLETE" }) });
+    const res = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview));
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("FINISH_REVISION_INACTIVE");
+  });
+
+  it("refuse un verrou optimiste périmé sur la gamme", async () => {
+    const { body: preview } = await fetchPreview();
+    const res = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview, { expected_gamme_updated_at: "2026-07-01T00:00:00.000Z" }));
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("CONCURRENT_MODIFICATION");
+  });
+
+  it("crée l'article, l'exigence et la ligne d'achat en UNE transaction", async () => {
+    const { body: preview } = await fetchPreview();
+    sqlLog = [];
+    const res = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview));
+
+    expect(res.status).toBe(201);
+    expect(res.body.result).toBe("CREATED");
+    expect(res.body.article.article_categories).toEqual(["traitement_surface"]);
+    expect(res.body.article.stock_managed).toBe(false);
+    expect(res.body.purchase_line.type_achat).toBe("TRAITEMENT");
+
+    expect(sqlLog.filter((sql) => /^\s*BEGIN\s*$/i.test(sql))).toHaveLength(1);
+    expect(sqlLog.filter((sql) => /^\s*COMMIT\s*$/i.test(sql))).toHaveLength(1);
+    expect(sqlLog.some((sql) => /^\s*ROLLBACK\s*$/i.test(sql))).toBe(false);
+  });
+
+  it("lie la ligne d'achat à l'opération par clé étrangère, jamais par la seule phase", async () => {
+    const { body: preview } = await fetchPreview();
+    sqlLog = [];
+    await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview));
+
+    const insert = sqlLog.find((sql) => /INSERT INTO public\.pieces_techniques_achats/.test(sql));
+    expect(insert).toBeDefined();
+    expect(insert).toContain("gamme_operation_id");
+    expect(insert).toContain("piece_technique_version_id");
+    expect(insert).toContain("type_achat");
+  });
+
+  it("ne crée NI commande fournisseur, NI réception, NI mouvement de stock, NI règlement", async () => {
+    const { body: preview } = await fetchPreview();
+    sqlLog = [];
+    await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview));
+
+    const forbidden = [
+      /INSERT INTO public\.commande_fournisseur/i,
+      /INSERT INTO public\.commandes_fournisseurs/i,
+      /INSERT INTO public\.reception/i,
+      /INSERT INTO public\.stock_mouvements/i,
+      /INSERT INTO public\.stock_movements/i,
+      /INSERT INTO public\.paiements/i,
+      /INSERT INTO public\.fournisseur_catalogue/i,
+    ];
+    for (const pattern of forbidden) {
+      expect(sqlLog.some((sql) => pattern.test(sql))).toBe(false);
+    }
+  });
+
+  it("journalise la décision, l'empreinte et l'aperçu dans l'audit", async () => {
+    const { body: preview } = await fetchPreview();
+    sqlLog = [];
+    await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview));
+
+    const auditCalls = mocks.clientQuery.mock.calls.filter(([sql]) => /INSERT INTO erp_audit_logs/.test(String(sql)));
+    expect(auditCalls.length).toBeGreaterThan(0);
+    const detailsJson = JSON.stringify(auditCalls.map(([, params]) => params));
+    expect(detailsJson).toContain("finitions.operation.confirm");
+    expect(detailsJson).toContain(String(preview.spec_fingerprint));
+    expect(detailsJson).toContain(String(preview.preview_hash));
+  });
+
+  it("rejoue une clé d'idempotence identique sans rien réécrire", async () => {
+    const { body: preview } = await fetchPreview();
+    const payload = confirmPayload(preview);
+    const stored = { result: "CREATED", article: { id: ARTICLE_ID, code: "ART-TRT-000123" } };
+    installQueryRouter({
+      receipt: {
+        // Le hash stocké doit correspondre EXACTEMENT à la charge rejouée.
+        request_hash: "",
+        result: stored,
+      },
+    });
+
+    // Premier appel : reçu absent -> écriture.
+    const first = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(payload);
+    expect(first.status).toBe(201);
+
+    const receiptInsert = mocks.clientQuery.mock.calls.find(([sql]) =>
+      /INSERT INTO public\.surface_finish_command_receipts/.test(String(sql))
+    );
+    expect(receiptInsert).toBeDefined();
+    const storedHash = String((receiptInsert as unknown as [string, unknown[]])[1][2]);
+
+    // Second appel : le reçu existe avec le MÊME hash -> rejeu à l'identique.
+    // Même clé + même charge doit rendre la MÊME réponse, code HTTP compris.
+    installQueryRouter({ receipt: { request_hash: storedHash, result: stored } });
+    sqlLog = [];
+    const second = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(payload);
+    expect(second.status).toBe(first.status);
+    expect(second.body).toEqual(stored);
+    expect(sqlLog.some((sql) => /^\s*ROLLBACK\s*$/i.test(sql))).toBe(true);
+    expect(sqlLog.some((sql) => /INSERT INTO public\.articles\b/.test(sql))).toBe(false);
+  });
+
+  it("refuse la même clé avec une charge différente", async () => {
+    const { body: preview } = await fetchPreview();
+    installQueryRouter({ receipt: { request_hash: "d".repeat(64), result: {} } });
+    const res = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview));
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("IDEMPOTENCY_CONFLICT");
+  });
+
+  it("annule TOUT si la ligne d'achat échoue", async () => {
+    const { body: preview } = await fetchPreview();
+    installQueryRouter({ failOnPurchaseLine: true });
+    sqlLog = [];
+    const res = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview));
+
+    expect(res.status).toBeGreaterThanOrEqual(400);
+    expect(sqlLog.some((sql) => /^\s*ROLLBACK\s*$/i.test(sql))).toBe(true);
+    expect(sqlLog.some((sql) => /^\s*COMMIT\s*$/i.test(sql))).toBe(false);
+  });
+
+  it("traduit une collision d'unicité concurrente en conflit exploitable", async () => {
+    const { body: preview } = await fetchPreview();
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      sqlLog.push(sql);
+      if (/UPDATE public\.articles_traitement/.test(sql)) {
+        return Promise.reject(Object.assign(new Error("duplicate key"), { code: "23505" }));
+      }
+      if (/surface_finish_command_receipts/.test(sql) && /^\s*SELECT/i.test(sql)) {
+        return Promise.resolve({ rows: [], rowCount: 0 });
+      }
+      if (/FROM public\.gammes g/.test(sql)) return Promise.resolve({ rows: [contextRow()], rowCount: 1 });
+      if (/FROM public\.surface_finish_revisions r/.test(sql)) {
+        return Promise.resolve({ rows: [revisionRow()], rowCount: 1 });
+      }
+      if (/FROM public\.articles_traitement t/.test(sql)) return Promise.resolve({ rows: [], rowCount: 0 });
+      if (/fn_next_issued_code_value/.test(sql)) return Promise.resolve({ rows: [{ v: "123" }], rowCount: 1 });
+      if (/INSERT INTO public\.articles\b/.test(sql)) return Promise.resolve({ rows: [{ id: ARTICLE_ID }], rowCount: 1 });
+      if (/INSERT INTO erp_audit_logs/.test(sql)) {
+        return Promise.resolve({ rows: [{ id: "a", created_at: "x" }], rowCount: 1 });
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+
+    const res = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview));
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("ARTICLE_EXACT_MATCH_CHANGED");
+  });
+
+  it("refuse un article distinct sans habilitation dédiée", async () => {
+    mocks.currentRole.value = "Technicien Methodes";
+    const { body: preview } = await fetchPreview();
+    installQueryRouter({
+      exactMatch: {
+        article_id: ARTICLE_ID,
+        code: "ART-TRT-000123",
+        designation: "ST — CAP-100 ind. C",
+        is_active: true,
+        status: "VALIDE",
+        spec_fingerprint: preview.spec_fingerprint,
+        spec_canonical: null,
+        finish_revision_id: REVISION_ID,
+        piece_technique_version_id: VERSION_ID,
+        created_at: "2026-05-01T10:00:00.000Z",
+      },
+    });
+    const { body: refreshed } = await fetchPreview();
+    const res = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(
+        confirmPayload(refreshed, {
+          decision: "FORCE_CREATE",
+          justification: "Le client impose une référence dédiée pour cette affaire.",
+        })
+      );
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("ARTICLE_FORCE_CREATE_FORBIDDEN");
+  });
+
+  it("refuse une création simple quand un article exact existe déjà", async () => {
+    const { body: first } = await fetchPreview();
+    installQueryRouter({
+      exactMatch: {
+        article_id: ARTICLE_ID,
+        code: "ART-TRT-000123",
+        designation: "ST — CAP-100 ind. C",
+        is_active: true,
+        status: "VALIDE",
+        spec_fingerprint: first.spec_fingerprint,
+        spec_canonical: null,
+        finish_revision_id: REVISION_ID,
+        piece_technique_version_id: VERSION_ID,
+        created_at: "2026-05-01T10:00:00.000Z",
+      },
+    });
+    const { body: preview } = await fetchPreview();
+    const res = await request(app)
+      .post(`${OP_BASE}/confirm`)
+      .set("Idempotency-Key", IDEMPOTENCY)
+      .send(confirmPayload(preview, { decision: "CREATE" }));
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("ARTICLE_SPEC_CONFLICT");
+  });
+});
+
+/* -------------------------------------------------------------------------- */
+/* Retrait                                                                     */
+/* -------------------------------------------------------------------------- */
+
+describe("#210 retrait de l'exigence", () => {
+  it("détache la ligne d'achat sans supprimer l'article ni la ligne", async () => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      sqlLog.push(sql);
+      if (/FROM public\.gammes g/.test(sql)) return Promise.resolve({ rows: [contextRow()], rowCount: 1 });
+      if (/FROM public\.gamme_operation_finitions\s*\n?\s*WHERE gamme_operation_id/.test(sql) || /FOR UPDATE/.test(sql)) {
+        return Promise.resolve({
+          rows: [
+            {
+              id: "req-1",
+              updated_at: "2026-07-28T08:05:00.000Z",
+              article_id: ARTICLE_ID,
+              achat_ligne_id: LINE_ID,
+            },
+          ],
+          rowCount: 1,
+        });
+      }
+      if (/INSERT INTO erp_audit_logs/.test(sql)) {
+        return Promise.resolve({ rows: [{ id: "a", created_at: "x" }], rowCount: 1 });
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 });
+    });
+
+    const res = await request(app)
+      .delete(OP_BASE)
+      .send({ motif: "Finition déplacée sur une autre opération", expected_updated_at: "2026-07-28T08:05:00.000Z" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.detached).toBe(true);
+    expect(sqlLog.some((sql) => /DELETE FROM public\.articles/.test(sql))).toBe(false);
+    expect(sqlLog.some((sql) => /DELETE FROM public\.pieces_techniques_achats/.test(sql))).toBe(false);
+    expect(sqlLog.some((sql) => /DELETE FROM public\.gamme_operation_finitions/.test(sql))).toBe(true);
+  });
+});

--- a/src/module/access-control/domain/module-catalog.ts
+++ b/src/module/access-control/domain/module-catalog.ts
@@ -108,9 +108,11 @@ export const MODULE_CATALOG: readonly ModuleCatalogEntry[] = [
   {
     module_key: "pieces-techniques",
     label: "Données techniques",
-    description: "Pièces techniques, versions, gammes et dossiers d’opération.",
+    description: "Pièces techniques, versions, gammes, finitions et dossiers d’opération.",
     category: "Production",
-    api_prefixes: ["/pieces-techniques", "/piece-technique-versions", "/gammes", "/dossiers"],
+    // `/finitions` (#210) rejoint le module Données techniques : la bibliothèque
+    // de finitions est un référentiel Méthodes, pas un module d'accès distinct.
+    api_prefixes: ["/pieces-techniques", "/piece-technique-versions", "/gammes", "/finitions", "/dossiers"],
     nav_page_keys: ["pieces-techniques"],
     is_protected: false,
     sort_order: 100,

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -2732,6 +2732,146 @@ export async function repoGetArticlesKpis(): Promise<StockArticleKpis> {
   );
 }
 
+export type CreatedArticleSummary = {
+  id: string;
+  code: string;
+  article_type: "PIECE_TECHNIQUE" | "PURCHASED";
+  article_category: ArticleCategory;
+  article_categories: ArticleBusinessCategory[];
+  family_code: string;
+  stock_managed: boolean;
+  lot_tracking: boolean;
+};
+
+/**
+ * Création d'article DANS une transaction déjà ouverte par l'appelant.
+ *
+ * C'est le SEUL chemin de création d'article : `repoCreateArticle` s'appuie
+ * dessus, et les modules qui doivent créer un article à l'intérieur de leur
+ * propre commande transactionnelle (#210 — finitions) l'appellent directement
+ * au lieu de dupliquer la normalisation, la codification et les liaisons.
+ *
+ * L'appelant reste responsable du BEGIN/COMMIT/ROLLBACK et de l'idempotence.
+ */
+export async function repoCreateArticleTx(
+  client: PoolClient,
+  body: CreateArticleBodyDTO,
+  audit: AuditContext
+): Promise<CreatedArticleSummary> {
+  const normalized = await normalizeArticleState({
+    article_type: body.article_type,
+    article_category: body.article_category,
+    article_categories: body.article_categories,
+    family_code: body.family_code,
+    version_number: 1,
+    plan_index: 1,
+    status: body.status,
+    projet_id: body.projet_id ?? null,
+    piece_technique_id: body.piece_technique_id ?? null,
+    stock_managed: body.stock_managed,
+    lot_tracking: body.lot_tracking,
+    // The submitted code is non-authoritative. Keep legacy payloads compatible
+    // while the final ART-{FAMILY}-{SEQ6} value is allocated below.
+    code: "",
+    designation: body.designation,
+    client,
+  });
+  const generatedCode = await generateArticleBusinessCode(client, normalized.family_code);
+
+  if (normalized.piece_technique_id) {
+    await ensurePieceTechniqueExists(client, normalized.piece_technique_id);
+  }
+
+  const articleId = crypto.randomUUID();
+
+  const res = await client.query<{ id: string }>(
+    `
+      INSERT INTO public.articles (
+        id,
+        code, designation, designation_secondary, article_type, article_category, family_code, stock_managed, piece_technique_id, unite,
+        root_article_id, parent_article_id, version_number, plan_index, status, projet_id,
+        lot_tracking, is_sold, is_active, notes,
+        created_by, updated_by
+      )
+      VALUES ($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9::uuid,$10,$11::uuid,$12::uuid,$13,$14,$15,$16,$17,$18,$19,$20,$21,$21)
+      RETURNING id::text AS id
+    `,
+    [
+      articleId,
+      generatedCode,
+      body.designation,
+      body.designation_secondary ?? null,
+      normalized.article_type,
+      normalized.article_category,
+      normalized.family_code,
+      normalized.stock_managed,
+      normalized.piece_technique_id,
+      body.unite ?? null,
+      articleId,
+      null,
+      normalized.version_number,
+      normalized.plan_index,
+      normalized.status,
+      normalized.projet_id,
+      normalized.lot_tracking,
+      body.is_sold,
+      body.is_active,
+      body.notes ?? null,
+      audit.user_id,
+    ]
+  );
+
+  const id = res.rows[0]?.id;
+  if (!id) throw new Error("Failed to create article");
+  await syncArticleCategories(client, id, normalized.article_categories, audit.user_id);
+
+  await syncPieceTechniqueArticleLink(client, {
+    article_id: id,
+    previous_piece_technique_id: null,
+    next_piece_technique_id: normalized.piece_technique_id,
+  });
+
+  await syncArticleSubtypeDetails(client, {
+    article_id: id,
+    category: normalized.article_category,
+    family_code: normalized.family_code,
+    piece_technique_id: normalized.piece_technique_id,
+    article_matiere: body.article_matiere,
+  });
+  await syncArticleProcurementProfile(client, id, body.procurement, audit.user_id);
+
+  await insertAuditLog(client, audit, {
+    action: "stock.articles.create",
+    entity_type: "articles",
+    entity_id: id,
+    details: {
+      code: generatedCode,
+      designation: body.designation,
+      article_type: normalized.article_type,
+      article_category: normalized.article_category,
+      article_categories: normalized.article_categories,
+      family_code: normalized.family_code,
+      version_number: normalized.version_number,
+      plan_index: normalized.plan_index,
+      status: normalized.status,
+      projet_id: normalized.projet_id,
+      stock_managed: normalized.stock_managed,
+      is_sold: body.is_sold,
+    },
+  });
+
+  return {
+    id,
+    code: generatedCode,
+    article_type: normalized.article_type,
+    article_category: normalized.article_category,
+    article_categories: normalized.article_categories,
+    family_code: normalized.family_code,
+    stock_managed: normalized.stock_managed,
+    lot_tracking: normalized.lot_tracking,
+  };
+}
+
 export async function repoCreateArticle(
   body: CreateArticleBodyDTO,
   audit: AuditContext,
@@ -2763,87 +2903,8 @@ export async function repoCreateArticle(
       }
     }
 
-    const normalized = await normalizeArticleState({
-      article_type: body.article_type,
-      article_category: body.article_category,
-      article_categories: body.article_categories,
-      family_code: body.family_code,
-      version_number: 1,
-      plan_index: 1,
-      status: body.status,
-      projet_id: body.projet_id ?? null,
-      piece_technique_id: body.piece_technique_id ?? null,
-      stock_managed: body.stock_managed,
-      lot_tracking: body.lot_tracking,
-      // The submitted code is non-authoritative. Keep legacy payloads compatible
-      // while the final ART-{FAMILY}-{SEQ6} value is allocated below.
-      code: "",
-      designation: body.designation,
-      client,
-    });
-    const generatedCode = await generateArticleBusinessCode(client, normalized.family_code);
-
-    if (normalized.piece_technique_id) {
-      await ensurePieceTechniqueExists(client, normalized.piece_technique_id);
-    }
-
-    const articleId = crypto.randomUUID();
-
-    const res = await client.query<{ id: string }>(
-      `
-        INSERT INTO public.articles (
-          id,
-          code, designation, designation_secondary, article_type, article_category, family_code, stock_managed, piece_technique_id, unite,
-          root_article_id, parent_article_id, version_number, plan_index, status, projet_id,
-          lot_tracking, is_sold, is_active, notes,
-          created_by, updated_by
-        )
-        VALUES ($1::uuid,$2,$3,$4,$5,$6,$7,$8,$9::uuid,$10,$11::uuid,$12::uuid,$13,$14,$15,$16,$17,$18,$19,$20,$21,$21)
-        RETURNING id::text AS id
-      `,
-      [
-        articleId,
-        generatedCode,
-        body.designation,
-        body.designation_secondary ?? null,
-        normalized.article_type,
-        normalized.article_category,
-        normalized.family_code,
-        normalized.stock_managed,
-        normalized.piece_technique_id,
-        body.unite ?? null,
-        articleId,
-        null,
-        normalized.version_number,
-        normalized.plan_index,
-        normalized.status,
-        normalized.projet_id,
-        normalized.lot_tracking,
-        body.is_sold,
-        body.is_active,
-        body.notes ?? null,
-        audit.user_id,
-      ]
-    );
-
-    const id = res.rows[0]?.id;
-    if (!id) throw new Error("Failed to create article");
-    await syncArticleCategories(client, id, normalized.article_categories, audit.user_id);
-
-    await syncPieceTechniqueArticleLink(client, {
-      article_id: id,
-      previous_piece_technique_id: null,
-      next_piece_technique_id: normalized.piece_technique_id,
-    });
-
-    await syncArticleSubtypeDetails(client, {
-      article_id: id,
-      category: normalized.article_category,
-      family_code: normalized.family_code,
-      piece_technique_id: normalized.piece_technique_id,
-      article_matiere: body.article_matiere,
-    });
-    await syncArticleProcurementProfile(client, id, body.procurement, audit.user_id);
+    const created = await repoCreateArticleTx(client, body, audit);
+    const id = created.id;
 
     if (idempotencyKey) {
       await client.query(
@@ -2852,26 +2913,6 @@ export async function repoCreateArticle(
         [idempotencyKey, requestHash, id]
       );
     }
-
-    await insertAuditLog(client, audit, {
-      action: "stock.articles.create",
-      entity_type: "articles",
-      entity_id: id,
-      details: {
-        code: generatedCode,
-        designation: body.designation,
-        article_type: normalized.article_type,
-        article_category: normalized.article_category,
-        article_categories: normalized.article_categories,
-        family_code: normalized.family_code,
-        version_number: normalized.version_number,
-        plan_index: normalized.plan_index,
-        status: normalized.status,
-        projet_id: normalized.projet_id,
-        stock_managed: normalized.stock_managed,
-        is_sold: body.is_sold,
-      },
-    });
 
     await client.query("COMMIT");
 

--- a/src/module/surface-finish/controllers/surface-finish.controller.ts
+++ b/src/module/surface-finish/controllers/surface-finish.controller.ts
@@ -1,0 +1,247 @@
+// #210 — HTTP handlers de la bibliothèque de finitions et de la configuration
+// d'une opération de gamme. Le contrôleur ne décide de rien : il construit le
+// contexte d'audit depuis le TOKEN (jamais depuis le corps de la requête) et
+// délègue.
+
+import type { Request, RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import type { AuditContext } from "../../pieces-techniques/repository/pieces-techniques.repository";
+import {
+  attachRevisionDocumentSVC,
+  capabilitiesSVC,
+  confirmOperationFinishSVC,
+  createFinishDraftSVC,
+  createRevisionSVC,
+  detachOperationFinishSVC,
+  getFinishSVC,
+  getOperationFinishSVC,
+  listFinishesSVC,
+  listFinishFamiliesSVC,
+  listRevisionDocumentsSVC,
+  previewOperationFinishSVC,
+  revisionImpactSVC,
+  transitionRevisionSVC,
+  updateFinishDraftSVC,
+  updateRevisionSVC,
+  type Actor,
+} from "../services/surface-finish.service";
+import type { ListFinishesQueryDTO } from "../validators/surface-finish.validators";
+
+function requireUser(req: Request): { id: number; role: string | null } {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  return { id: user.id, role: typeof user.role === "string" ? user.role : null };
+}
+
+/** L'identité vient du jeton. Aucun champ libre du corps ne peut la remplacer. */
+function buildAuditContext(req: Request): AuditContext {
+  const user = requireUser(req);
+  const forwardedFor = req.headers["x-forwarded-for"];
+  const ipFromHeader = typeof forwardedFor === "string" ? forwardedFor.split(",")[0]?.trim() : null;
+  const ua = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null;
+  const pageKey = typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null;
+  const clientSessionId =
+    typeof req.headers["x-client-session-id"] === "string"
+      ? req.headers["x-client-session-id"]
+      : typeof req.headers["x-session-id"] === "string"
+        ? req.headers["x-session-id"]
+        : null;
+  return {
+    user_id: user.id,
+    ip: ipFromHeader ?? req.ip ?? null,
+    user_agent: ua,
+    device_type: null,
+    os: null,
+    browser: null,
+    path: req.originalUrl ?? null,
+    page_key: pageKey,
+    client_session_id: clientSessionId,
+  };
+}
+
+function actorOf(req: Request): Actor {
+  const user = requireUser(req);
+  return { user_id: user.id, role: user.role };
+}
+
+function routeParam(req: Request, name: string): string {
+  const value = req.params[name];
+  if (typeof value !== "string" || value.length === 0) {
+    throw new HttpError(400, "INVALID_ROUTE_PARAM", `Paramètre de route invalide : ${name}`);
+  }
+  return value;
+}
+
+function headerValue(req: Request, name: string): string | null {
+  const raw = req.headers[name];
+  if (typeof raw === "string") return raw;
+  if (Array.isArray(raw) && typeof raw[0] === "string") return raw[0];
+  return null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Bibliothèque                                                                */
+/* -------------------------------------------------------------------------- */
+
+export const listFinishFamilies: RequestHandler = async (_req, res, next) => {
+  try {
+    res.json(await listFinishFamiliesSVC());
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const listFinishes: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(await listFinishesSVC(req.query as unknown as ListFinishesQueryDTO));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const getFinish: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(await getFinishSVC(routeParam(req, "finishId")));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const createFinish: RequestHandler = async (req, res, next) => {
+  try {
+    const created = await createFinishDraftSVC(req.body, buildAuditContext(req));
+    res.status(201).json(created);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const updateFinish: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(await updateFinishDraftSVC(routeParam(req, "finishId"), req.body, buildAuditContext(req)));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const createRevision: RequestHandler = async (req, res, next) => {
+  try {
+    const created = await createRevisionSVC(routeParam(req, "finishId"), req.body, buildAuditContext(req));
+    res.status(201).json(created);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const updateRevision: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(await updateRevisionSVC(routeParam(req, "revisionId"), req.body, buildAuditContext(req)));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const transitionRevision: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(
+      await transitionRevisionSVC(routeParam(req, "revisionId"), req.body, buildAuditContext(req), actorOf(req))
+    );
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const revisionImpact: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(await revisionImpactSVC(routeParam(req, "revisionId")));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const listRevisionDocuments: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(await listRevisionDocumentsSVC(routeParam(req, "revisionId")));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const attachRevisionDocument: RequestHandler = async (req, res, next) => {
+  try {
+    const created = await attachRevisionDocumentSVC(routeParam(req, "revisionId"), req.body, buildAuditContext(req));
+    res.status(201).json(created);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const readCapabilities: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(capabilitiesSVC(actorOf(req)));
+  } catch (err) {
+    next(err);
+  }
+};
+
+/* -------------------------------------------------------------------------- */
+/* Configuration d'une opération de gamme                                      */
+/* -------------------------------------------------------------------------- */
+
+export const getOperationFinish: RequestHandler = async (req, res, next) => {
+  try {
+    const requirement = await getOperationFinishSVC(routeParam(req, "gammeId"), routeParam(req, "operationId"));
+    res.json(requirement);
+  } catch (err) {
+    next(err);
+  }
+};
+
+/** Aperçu : LECTURE PURE. Aucune écriture n'est déclenchée par cet appel. */
+export const previewOperationFinish: RequestHandler = async (req, res, next) => {
+  try {
+    const preview = await previewOperationFinishSVC(
+      routeParam(req, "gammeId"),
+      routeParam(req, "operationId"),
+      req.body,
+      actorOf(req)
+    );
+    res.json(preview);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const confirmOperationFinish: RequestHandler = async (req, res, next) => {
+  try {
+    const result = await confirmOperationFinishSVC(
+      routeParam(req, "gammeId"),
+      routeParam(req, "operationId"),
+      req.body,
+      buildAuditContext(req),
+      actorOf(req),
+      headerValue(req, "idempotency-key")
+    );
+    res.status(result.result === "CREATED" ? 201 : 200).json(result);
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const detachOperationFinish: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(
+      await detachOperationFinishSVC(
+        routeParam(req, "gammeId"),
+        routeParam(req, "operationId"),
+        req.body,
+        buildAuditContext(req)
+      )
+    );
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/module/surface-finish/domain/surface-finish-policy.ts
+++ b/src/module/surface-finish/domain/surface-finish-policy.ts
@@ -1,0 +1,1026 @@
+// Gouvernance « Bibliothèque de finitions » (#210 / web #339) — politiques pures, sans I/O.
+//
+// Ce fichier concentre tout ce qui ne doit dépendre ni d'un client SQL, ni du
+// réseau, ni du navigateur : capacités RBAC, cycles de vie, normalisation des
+// unités, spécification canonique, empreinte anti-doublon, idempotence et
+// verrou optimiste. Il est testable seul et fait autorité.
+//
+// Principe directeur (ADR-0038) : la FINITION décrit une exigence ; l'ARTICLE
+// est la prestation achetable qui en découle pour une pièce et un indice
+// donnés. Le fournisseur, le prix, le délai et le MOQ n'entrent JAMAIS dans
+// l'identité technique — ils appartiennent au catalogue fournisseur.
+
+import crypto from "node:crypto";
+
+import { HttpError } from "../../../utils/httpError";
+
+/* -------------------------------------------------------------------------- */
+/* 1) Capacités RBAC — refus par défaut                                       */
+/* -------------------------------------------------------------------------- */
+
+export const SURFACE_FINISH_CAPABILITIES = [
+  "library_read",
+  "library_draft_create",
+  "library_draft_write",
+  "library_submit",
+  "library_approve",
+  "library_retire",
+  "documents_read",
+  "documents_write",
+  "operation_configure",
+  "article_preview",
+  "article_resolve",
+  "article_force_create",
+  "generated_text_override",
+  "costs_read",
+  "supplier_qualification_manage",
+  "audit_read",
+] as const;
+
+export type SurfaceFinishCapability = (typeof SURFACE_FINISH_CAPABILITIES)[number];
+
+// Les rôles CERP sont du texte libre en base : on garde la mécanique par
+// « needles » déjà utilisée par `metrology-policy.ts` et `quality-policy.ts`
+// plutôt que d'inventer une table de rôles parallèle.
+//
+// Aucun rôle n'obtient de droit implicite. La bibliothèque est un référentiel
+// Méthodes/Qualité ; les Achats la LISENT sans pouvoir la réécrire.
+const CAPABILITY_NEEDLES: Record<SurfaceFinishCapability, readonly string[]> = {
+  library_read: [
+    "admin",
+    "administrateur",
+    "directeur",
+    "method",
+    "méthod",
+    "bureau",
+    "qualit",
+    "quality",
+    "qse",
+    "achat",
+    "approvision",
+    "production",
+    "atelier",
+  ],
+  library_draft_create: ["admin", "administrateur", "directeur", "method", "méthod", "bureau", "qualit", "quality", "qse"],
+  library_draft_write: ["admin", "administrateur", "directeur", "method", "méthod", "bureau", "qualit", "quality", "qse"],
+  library_submit: ["admin", "administrateur", "directeur", "method", "méthod", "bureau", "qualit", "quality", "qse"],
+  // Approuver une révision engage la conformité produit : jamais les Achats.
+  library_approve: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "method", "méthod"],
+  library_retire: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "method", "méthod"],
+  documents_read: [
+    "admin",
+    "administrateur",
+    "directeur",
+    "method",
+    "méthod",
+    "bureau",
+    "qualit",
+    "quality",
+    "qse",
+    "achat",
+    "approvision",
+  ],
+  documents_write: ["admin", "administrateur", "directeur", "method", "méthod", "bureau", "qualit", "quality", "qse"],
+  // Configurer une opération de gamme est un acte Méthodes.
+  operation_configure: ["admin", "administrateur", "directeur", "method", "méthod", "bureau"],
+  article_preview: ["admin", "administrateur", "directeur", "method", "méthod", "bureau", "achat", "approvision"],
+  article_resolve: ["admin", "administrateur", "directeur", "method", "méthod", "bureau"],
+  // Forcer un article distinct alors qu'un article exact existe : décision rare,
+  // justifiée, auditée. Réservée à l'encadrement Méthodes et à la direction.
+  article_force_create: ["admin", "administrateur", "directeur", "responsable method", "responsable méthod"],
+  generated_text_override: ["admin", "administrateur", "directeur", "responsable method", "responsable méthod"],
+  costs_read: ["admin", "administrateur", "directeur", "achat", "approvision", "compta", "finance", "controle de gestion"],
+  supplier_qualification_manage: ["admin", "administrateur", "directeur", "achat", "approvision", "qualit", "quality", "qse"],
+  audit_read: ["admin", "administrateur", "directeur", "qualit", "quality", "qse"],
+};
+
+export function roleHasSurfaceFinishCapability(
+  role: string | null | undefined,
+  capability: SurfaceFinishCapability
+): boolean {
+  const normalized = (role ?? "").trim().toLowerCase();
+  if (!normalized) return false;
+  const needles = CAPABILITY_NEEDLES[capability];
+  if (!needles) return false;
+  return needles.some((needle) => normalized.includes(needle));
+}
+
+export function assertSurfaceFinishCapability(
+  role: string | null | undefined,
+  capability: SurfaceFinishCapability
+): void {
+  if (!roleHasSurfaceFinishCapability(role, capability)) {
+    throw new HttpError(
+      403,
+      "SURFACE_FINISH_CAPABILITY_REQUIRED",
+      `La capacité Finitions '${capability}' est requise.`
+    );
+  }
+}
+
+export function surfaceFinishCapabilitiesFor(
+  role: string | null | undefined
+): Record<SurfaceFinishCapability, boolean> {
+  const out = {} as Record<SurfaceFinishCapability, boolean>;
+  for (const capability of SURFACE_FINISH_CAPABILITIES) {
+    out[capability] = roleHasSurfaceFinishCapability(role, capability);
+  }
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/* 2) Cycle de vie — finitions et révisions                                   */
+/* -------------------------------------------------------------------------- */
+
+export const SURFACE_FINISH_STATUSES = [
+  "BROUILLON",
+  "EN_VALIDATION",
+  "ACTIVE",
+  "SUSPENDUE",
+  "OBSOLETE",
+  "ARCHIVEE",
+] as const;
+export type SurfaceFinishStatus = (typeof SURFACE_FINISH_STATUSES)[number];
+
+const STATUS_TRANSITIONS: Readonly<Record<SurfaceFinishStatus, readonly SurfaceFinishStatus[]>> = {
+  BROUILLON: ["EN_VALIDATION", "ARCHIVEE"],
+  EN_VALIDATION: ["ACTIVE", "BROUILLON", "ARCHIVEE"],
+  // Une révision active ne redevient jamais un brouillon : on la suspend, on la
+  // rend obsolète, ou on publie une nouvelle révision.
+  ACTIVE: ["SUSPENDUE", "OBSOLETE"],
+  SUSPENDUE: ["ACTIVE", "OBSOLETE"],
+  OBSOLETE: ["ARCHIVEE"],
+  ARCHIVEE: [],
+};
+
+export function assertSurfaceFinishTransition(from: SurfaceFinishStatus, to: SurfaceFinishStatus): void {
+  if (from === to) {
+    throw new HttpError(
+      409,
+      "SURFACE_FINISH_TRANSITION_NOOP",
+      `La finition est déjà dans l'état ${from}.`
+    );
+  }
+  if (!STATUS_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "SURFACE_FINISH_TRANSITION_FORBIDDEN",
+      `Transition de finition interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+/** Seule une révision ACTIVE peut être posée sur une nouvelle gamme. */
+export function assertRevisionSelectable(status: SurfaceFinishStatus): void {
+  if (status !== "ACTIVE") {
+    throw new HttpError(
+      409,
+      "FINISH_REVISION_INACTIVE",
+      "Seule une révision de finition active peut être appliquée à une gamme."
+    );
+  }
+}
+
+/** Le contenu technique d'une révision publiée est figé : on crée une révision. */
+export function assertRevisionContentMutable(status: SurfaceFinishStatus): void {
+  if (status !== "BROUILLON" && status !== "EN_VALIDATION") {
+    throw new HttpError(
+      409,
+      "SURFACE_FINISH_REVISION_IMMUTABLE",
+      "Une révision publiée est figée : créez une nouvelle révision."
+    );
+  }
+}
+
+/** Les statuts qui restent lisibles dans l'historique mais ne se choisissent plus. */
+export function statusIsHistoricalOnly(status: SurfaceFinishStatus): boolean {
+  return status === "SUSPENDUE" || status === "OBSOLETE" || status === "ARCHIVEE";
+}
+
+/* -------------------------------------------------------------------------- */
+/* 3) Gammes — modifiabilité                                                  */
+/* -------------------------------------------------------------------------- */
+
+export const EDITABLE_GAMME_STATUSES = ["BROUILLON", "EN_VALIDATION"] as const;
+
+/**
+ * Une gamme APPLICABLE ou OBSOLETE n'est jamais modifiée silencieusement : la
+ * finition d'une gamme déjà applicable se remplace en créant une nouvelle
+ * gamme/version, pas en réécrivant l'historique.
+ */
+export function assertGammeEditable(statut: string | null | undefined): void {
+  const normalized = (statut ?? "").trim().toUpperCase();
+  if (!(EDITABLE_GAMME_STATUSES as readonly string[]).includes(normalized)) {
+    throw new HttpError(
+      409,
+      "GAMME_NOT_EDITABLE",
+      "Cette gamme n'est plus modifiable : créez une nouvelle gamme ou un nouvel indice."
+    );
+  }
+}
+
+export function assertOperationIsSubcontracting(typeOperation: string | null | undefined): void {
+  if ((typeOperation ?? "").trim().toUpperCase() !== "SOUS_TRAITANCE") {
+    throw new HttpError(
+      422,
+      "OPERATION_NOT_SUBCONTRACTING",
+      "Seule une opération de type Sous-traitance porte une finition."
+    );
+  }
+}
+
+export function assertOperationBelongsToGamme(operationGammeId: string | null | undefined, gammeId: string): void {
+  if (!operationGammeId || operationGammeId !== gammeId) {
+    throw new HttpError(
+      409,
+      "OPERATION_GAMME_MISMATCH",
+      "Cette opération n'appartient pas à la gamme indiquée."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 4) Normalisation des unités et des valeurs                                 */
+/* -------------------------------------------------------------------------- */
+
+export const THICKNESS_UNITS = ["um", "mm", "cm", "in", "mil"] as const;
+export type ThicknessUnit = (typeof THICKNESS_UNITS)[number];
+
+// Facteurs vers le micromètre, unité pivot des épaisseurs de revêtement.
+const THICKNESS_TO_MICROMETER: Record<ThicknessUnit, number> = {
+  um: 1,
+  mm: 1000,
+  cm: 10000,
+  in: 25400,
+  mil: 25.4,
+};
+
+const THICKNESS_ALIASES: Record<string, ThicknessUnit> = {
+  um: "um",
+  µm: "um",
+  μm: "um",
+  micron: "um",
+  microns: "um",
+  micrometre: "um",
+  micrometres: "um",
+  mm: "mm",
+  millimetre: "mm",
+  millimetres: "mm",
+  cm: "cm",
+  centimetre: "cm",
+  centimetres: "cm",
+  in: "in",
+  inch: "in",
+  inches: "in",
+  pouce: "in",
+  mil: "mil",
+  mils: "mil",
+  thou: "mil",
+};
+
+function stripDiacritics(value: string): string {
+  return value.normalize("NFD").replace(/\p{Diacritic}/gu, "");
+}
+
+export function normalizeThicknessUnit(value: string | null | undefined): ThicknessUnit {
+  const raw = stripDiacritics((value ?? "").trim().toLowerCase()).replace(/[.\s]/g, "");
+  const direct = THICKNESS_ALIASES[(value ?? "").trim().toLowerCase()] ?? THICKNESS_ALIASES[raw];
+  if (!direct) {
+    throw new HttpError(
+      422,
+      "SURFACE_FINISH_THICKNESS_UNIT_INVALID",
+      `Unité d'épaisseur inconnue : ${String(value ?? "")}.`
+    );
+  }
+  return direct;
+}
+
+/** Arrondi stable à 6 décimales : élimine le bruit binaire de la conversion. */
+function roundStable(value: number, decimals = 6): number {
+  const factor = 10 ** decimals;
+  const rounded = Math.round(value * factor) / factor;
+  // -0 et 0 doivent produire la même empreinte.
+  return Object.is(rounded, -0) ? 0 : rounded;
+}
+
+export function thicknessToMicrometers(value: number | null | undefined, unit: string | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  if (!Number.isFinite(value)) {
+    throw new HttpError(422, "SURFACE_FINISH_THICKNESS_INVALID", "Épaisseur non numérique.");
+  }
+  if (value < 0) {
+    throw new HttpError(422, "SURFACE_FINISH_THICKNESS_INVALID", "Une épaisseur ne peut pas être négative.");
+  }
+  return roundStable(value * THICKNESS_TO_MICROMETER[normalizeThicknessUnit(unit)], 4);
+}
+
+export type ThicknessRange = {
+  min_um: number | null;
+  nominal_um: number | null;
+  max_um: number | null;
+};
+
+export function assertThicknessCoherent(range: ThicknessRange): void {
+  const { min_um, nominal_um, max_um } = range;
+  if (min_um !== null && max_um !== null && min_um > max_um) {
+    throw new HttpError(
+      422,
+      "SURFACE_FINISH_THICKNESS_RANGE_INVALID",
+      "L'épaisseur minimale dépasse l'épaisseur maximale."
+    );
+  }
+  if (nominal_um !== null && min_um !== null && nominal_um < min_um) {
+    throw new HttpError(
+      422,
+      "SURFACE_FINISH_THICKNESS_RANGE_INVALID",
+      "L'épaisseur nominale est inférieure à l'épaisseur minimale."
+    );
+  }
+  if (nominal_um !== null && max_um !== null && nominal_um > max_um) {
+    throw new HttpError(
+      422,
+      "SURFACE_FINISH_THICKNESS_RANGE_INVALID",
+      "L'épaisseur nominale dépasse l'épaisseur maximale."
+    );
+  }
+}
+
+/**
+ * Texte canonique : accents conservés (le métier lit du français), casse et
+ * espaces normalisés. Une chaîne vide devient `null` pour que « champ absent »
+ * et « champ vide » produisent la MÊME empreinte.
+ */
+export function canonicalText(value: string | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const collapsed = String(value).replace(/\s+/g, " ").trim();
+  return collapsed === "" ? null : collapsed;
+}
+
+/** Identifiant fonctionnel : casse et accents neutralisés (norme, RAL, classe…). */
+export function canonicalToken(value: string | null | undefined): string | null {
+  const text = canonicalText(value);
+  if (text === null) return null;
+  return stripDiacritics(text).toUpperCase().replace(/\s+/g, " ");
+}
+
+/** Liste canonique : tokens normalisés, dédoublonnés, triés — l'ordre de saisie ne compte pas. */
+export function canonicalTokenList(values: readonly (string | null | undefined)[] | null | undefined): string[] {
+  if (!values) return [];
+  const set = new Set<string>();
+  for (const value of values) {
+    const token = canonicalToken(value);
+    if (token) set.add(token);
+  }
+  return [...set].sort((left, right) => left.localeCompare(right, "fr"));
+}
+
+export function canonicalNumber(value: number | null | undefined, decimals = 4): number | null {
+  if (value === null || value === undefined) return null;
+  if (!Number.isFinite(value)) {
+    throw new HttpError(422, "SURFACE_FINISH_NUMBER_INVALID", "Valeur numérique invalide.");
+  }
+  return roundStable(value, decimals);
+}
+
+/* -------------------------------------------------------------------------- */
+/* 5) Spécification canonique et empreinte                                    */
+/* -------------------------------------------------------------------------- */
+
+export const FINISH_SCOPES = ["PIECE_ENTIERE", "ZONES", "AUTRE"] as const;
+export type FinishScope = (typeof FINISH_SCOPES)[number];
+
+/** Entrée brute de la spécification, telle que résolue par le serveur. */
+export type SurfaceFinishSpecInput = {
+  piece_technique_version_id: string;
+  finish_revision_id: string;
+  norme: string | null;
+  classe: string | null;
+  perimetre: FinishScope;
+  zones: readonly string[] | null;
+  masquages: readonly string[] | null;
+  epaisseur_min: number | null;
+  epaisseur_nominale: number | null;
+  epaisseur_max: number | null;
+  epaisseur_unite: string | null;
+  couleur: string | null;
+  teinte_ral: string | null;
+  aspect: string | null;
+  rugosite: string | null;
+  durete: string | null;
+  exigence_corrosion: string | null;
+  pretraitement: string | null;
+  posttraitement: string | null;
+  controles: readonly string[] | null;
+  certificat_requis: boolean;
+  certificat_type: string | null;
+  conditionnement: string | null;
+  unite_achat: string | null;
+  specification_client: string | null;
+  specification_client_version: string | null;
+  instructions: string | null;
+};
+
+/**
+ * Spécification canonique — l'objet EXACT dont on prend l'empreinte.
+ *
+ * Sont volontairement absents : fournisseur, prix, devise, MOQ, multiple,
+ * délai, date de besoin, quantité commandée et tout commentaire commercial.
+ * Ces données appartiennent au catalogue fournisseur et à la commande, jamais
+ * à l'identité technique de la prestation.
+ *
+ * `instructions` EST retenu (écart assumé et documenté vis-à-vis d'une lecture
+ * minimale) : ce texte part chez le sous-traitant et figure dans le commentaire
+ * de l'article. L'exclure permettrait de réutiliser un article dont le
+ * commentaire contredirait l'opération qui le réutilise. L'inclure ne peut que
+ * créer des articles plus distincts, jamais en fusionner deux différents.
+ */
+export type CanonicalFinishSpec = {
+  schema_version: 1;
+  piece_technique_version_id: string;
+  finish_revision_id: string;
+  norme: string | null;
+  classe: string | null;
+  perimetre: FinishScope;
+  zones: string[];
+  masquages: string[];
+  epaisseur_min_um: number | null;
+  epaisseur_nominale_um: number | null;
+  epaisseur_max_um: number | null;
+  epaisseur_unite_canonique: "um";
+  couleur: string | null;
+  teinte_ral: string | null;
+  aspect: string | null;
+  rugosite: string | null;
+  durete: string | null;
+  exigence_corrosion: string | null;
+  pretraitement: string | null;
+  posttraitement: string | null;
+  controles: string[];
+  certificat_requis: boolean;
+  certificat_type: string | null;
+  conditionnement: string | null;
+  unite_achat: string;
+  specification_client: string | null;
+  specification_client_version: string | null;
+  instructions: string | null;
+};
+
+export const DEFAULT_PURCHASE_UNIT = "PCE";
+
+export function buildCanonicalFinishSpec(input: SurfaceFinishSpecInput): CanonicalFinishSpec {
+  const unite = normalizeThicknessUnit(input.epaisseur_unite ?? "um");
+  const range: ThicknessRange = {
+    min_um: thicknessToMicrometers(input.epaisseur_min, unite),
+    nominal_um: thicknessToMicrometers(input.epaisseur_nominale, unite),
+    max_um: thicknessToMicrometers(input.epaisseur_max, unite),
+  };
+  assertThicknessCoherent(range);
+
+  const perimetre = input.perimetre;
+  const zones = canonicalTokenList(input.zones);
+  if (perimetre === "ZONES" && zones.length === 0) {
+    throw new HttpError(
+      422,
+      "SURFACE_FINISH_ZONES_REQUIRED",
+      "Un périmètre « zones » exige au moins une zone traitée."
+    );
+  }
+
+  return {
+    schema_version: 1,
+    piece_technique_version_id: input.piece_technique_version_id,
+    finish_revision_id: input.finish_revision_id,
+    norme: canonicalToken(input.norme),
+    classe: canonicalToken(input.classe),
+    perimetre,
+    // Un périmètre « pièce entière » ignore les zones : deux saisies qui
+    // décrivent la même prestation doivent produire la même empreinte.
+    zones: perimetre === "PIECE_ENTIERE" ? [] : zones,
+    masquages: canonicalTokenList(input.masquages),
+    epaisseur_min_um: range.min_um,
+    epaisseur_nominale_um: range.nominal_um,
+    epaisseur_max_um: range.max_um,
+    epaisseur_unite_canonique: "um",
+    couleur: canonicalToken(input.couleur),
+    teinte_ral: canonicalRal(input.teinte_ral),
+    aspect: canonicalToken(input.aspect),
+    rugosite: canonicalToken(input.rugosite),
+    durete: canonicalToken(input.durete),
+    exigence_corrosion: canonicalToken(input.exigence_corrosion),
+    pretraitement: canonicalToken(input.pretraitement),
+    posttraitement: canonicalToken(input.posttraitement),
+    controles: canonicalTokenList(input.controles),
+    certificat_requis: Boolean(input.certificat_requis),
+    certificat_type: input.certificat_requis ? canonicalToken(input.certificat_type) : null,
+    conditionnement: canonicalToken(input.conditionnement),
+    unite_achat: canonicalToken(input.unite_achat) ?? DEFAULT_PURCHASE_UNIT,
+    specification_client: canonicalToken(input.specification_client),
+    specification_client_version: canonicalToken(input.specification_client_version),
+    instructions: canonicalText(input.instructions),
+  };
+}
+
+/** RAL canonique : « ral 9005 », « RAL9005 », « Ral-9005 » → « RAL 9005 ». */
+export function canonicalRal(value: string | null | undefined): string | null {
+  const token = canonicalToken(value);
+  if (token === null) return null;
+  const match = /^RAL[\s-]*([0-9]{4})$/.exec(token.replace(/\s+/g, " "));
+  return match ? `RAL ${match[1]}` : token;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([, child]) => child !== undefined)
+        .sort(([left], [right]) => (left < right ? -1 : left > right ? 1 : 0))
+        .map(([key, child]) => [key, canonicalize(child)])
+    );
+  }
+  return value;
+}
+
+export function canonicalJson(value: unknown): string {
+  return JSON.stringify(canonicalize(value));
+}
+
+export function sha256Hex(value: unknown): string {
+  return crypto.createHash("sha256").update(canonicalJson(value)).digest("hex");
+}
+
+/** Empreinte fonctionnelle de la prestation. Deux articles identiques ⇒ même valeur. */
+export function computeSpecFingerprint(spec: CanonicalFinishSpec): string {
+  return sha256Hex(spec);
+}
+
+/** Champs comparés pour expliquer une différence entre deux spécifications. */
+export function diffCanonicalSpecs(
+  left: CanonicalFinishSpec,
+  right: CanonicalFinishSpec
+): Array<{ field: keyof CanonicalFinishSpec; left: unknown; right: unknown }> {
+  const out: Array<{ field: keyof CanonicalFinishSpec; left: unknown; right: unknown }> = [];
+  const keys = Object.keys(left) as Array<keyof CanonicalFinishSpec>;
+  for (const key of keys) {
+    if (key === "schema_version") continue;
+    const a = canonicalJson(left[key]);
+    const b = canonicalJson(right[key]);
+    if (a !== b) out.push({ field: key, left: left[key], right: right[key] });
+  }
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/* 6) Génération de la désignation                                            */
+/* -------------------------------------------------------------------------- */
+
+// Le schéma Article limite la désignation ; on reste large sous la limite pour
+// que la troncature soit lisible plutôt que brutale.
+export const DESIGNATION_MAX_LENGTH = 180;
+export const COMMENT_MAX_LENGTH = 4000;
+export const GENERATION_TEMPLATE_VERSION = 1;
+
+export type DesignationContext = {
+  code_piece: string;
+  indice: string;
+  finition_courte: string;
+  teinte_ral: string | null;
+  couleur: string | null;
+  epaisseur_nominale_um: number | null;
+  epaisseur_min_um: number | null;
+  classe: string | null;
+  perimetre: FinishScope;
+  zones: readonly string[];
+};
+
+function formatMicrometers(value: number | null): string | null {
+  if (value === null) return null;
+  const rounded = Math.round(value * 100) / 100;
+  const text = Number.isInteger(rounded) ? String(rounded) : String(rounded).replace(".", ",");
+  return `${text} µm`;
+}
+
+/**
+ * `ST — {code_piece} ind. {indice} — {finition_courte}` enrichi des seuls
+ * qualificatifs DISCRIMINANTS réellement disponibles (teinte, épaisseur, classe,
+ * zone). Aucun `null`, aucun `undefined`, aucun UUID, aucun séparateur vide.
+ */
+export function buildGeneratedDesignation(ctx: DesignationContext): string {
+  const codePiece = canonicalText(ctx.code_piece);
+  const indice = canonicalText(ctx.indice);
+  const finition = canonicalText(ctx.finition_courte);
+  const missing: string[] = [];
+  if (!codePiece) missing.push("code_piece");
+  if (!indice) missing.push("indice");
+  if (!finition) missing.push("finition_courte");
+  if (missing.length > 0) {
+    throw new HttpError(
+      422,
+      "SURFACE_FINISH_DESIGNATION_CONTEXT_INCOMPLETE",
+      "Impossible de générer la désignation : contexte incomplet.",
+      { missing }
+    );
+  }
+
+  const qualifiers: string[] = [];
+  const teinte = canonicalRal(ctx.teinte_ral) ?? canonicalText(ctx.couleur);
+  if (teinte) qualifiers.push(teinte);
+  const epaisseur = formatMicrometers(ctx.epaisseur_nominale_um ?? ctx.epaisseur_min_um);
+  if (epaisseur) qualifiers.push(epaisseur);
+  const classe = canonicalText(ctx.classe);
+  if (classe) qualifiers.push(`cl. ${classe}`);
+  if (ctx.perimetre === "ZONES" && ctx.zones.length > 0) {
+    qualifiers.push(ctx.zones.length === 1 ? `zone ${ctx.zones[0]}` : `${ctx.zones.length} zones`);
+  }
+
+  const tail = qualifiers.length > 0 ? `${finition} ${qualifiers.join(" ")}` : (finition as string);
+  const full = `ST — ${codePiece} ind. ${indice} — ${tail}`;
+  return truncateReadable(full, DESIGNATION_MAX_LENGTH);
+}
+
+/** Troncature qui ne coupe jamais au milieu d'un mot si l'on peut l'éviter. */
+export function truncateReadable(value: string, max: number): string {
+  if (value.length <= max) return value;
+  const hard = value.slice(0, max - 1);
+  const lastSpace = hard.lastIndexOf(" ");
+  const base = lastSpace > max * 0.6 ? hard.slice(0, lastSpace) : hard;
+  return `${base.trimEnd()}…`;
+}
+
+/* -------------------------------------------------------------------------- */
+/* 7) Génération du commentaire technique                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Liste blanche EXHAUSTIVE des variables interpolables. Toute variable absente
+ * de cette liste fait échouer le rendu : un modèle ne peut pas exfiltrer un
+ * champ arbitraire, ni du contexte serveur.
+ */
+export const COMMENT_TEMPLATE_VARIABLES = [
+  "gamme_code",
+  "code_piece",
+  "designation_piece",
+  "indice",
+  "plan_reference",
+  "numero_operation",
+  "designation_operation",
+  "code_finition",
+  "designation_finition",
+  "revision_finition",
+  "norme",
+  "epaisseur",
+  "teinte_aspect",
+  "perimetre",
+  "zones_masquages",
+  "certificat",
+  "controles",
+  "conditionnement",
+  "instructions",
+] as const;
+export type CommentTemplateVariable = (typeof COMMENT_TEMPLATE_VARIABLES)[number];
+
+export const DEFAULT_COMMENT_TEMPLATE = [
+  "Sous-traitance issue de la gamme {gamme_code}.",
+  "Pièce : {code_piece} — {designation_piece}",
+  "Indice : {indice}",
+  "Plan : {plan_reference}",
+  "Opération : {numero_operation} — {designation_operation}",
+  "Finition : {code_finition} — {designation_finition}",
+  "Révision de finition : {revision_finition}",
+  "Norme / spécification : {norme}",
+  "Épaisseur : {epaisseur}",
+  "Teinte / aspect : {teinte_aspect}",
+  "Périmètre traité : {perimetre}",
+  "Zones et masquages : {zones_masquages}",
+  "Certificat requis : {certificat}",
+  "Contrôles requis : {controles}",
+  "Conditionnement retour : {conditionnement}",
+  "Instructions complémentaires : {instructions}",
+].join("\n");
+
+const TEMPLATE_TOKEN = /\{([a-z_]+)\}/g;
+
+export function assertTemplateVariablesAllowed(template: string): void {
+  const unknown = new Set<string>();
+  for (const match of template.matchAll(TEMPLATE_TOKEN)) {
+    const name = match[1];
+    if (!(COMMENT_TEMPLATE_VARIABLES as readonly string[]).includes(name)) unknown.add(name);
+  }
+  if (unknown.size > 0) {
+    throw new HttpError(
+      422,
+      "SURFACE_FINISH_TEMPLATE_VARIABLE_FORBIDDEN",
+      "Le modèle utilise une variable non autorisée.",
+      { forbidden: [...unknown].sort() }
+    );
+  }
+}
+
+/**
+ * Neutralise ce qui pourrait transformer une valeur métier en balise, en
+ * modèle imbriqué, ou en injection de ligne. On n'échappe pas « en HTML » :
+ * le commentaire est un texte, il ne doit contenir ni `<`, ni `>`, ni accolade,
+ * ni retour chariot non maîtrisé.
+ */
+export function sanitizeTemplateValue(value: unknown, maxLength = 400): string {
+  if (value === null || value === undefined) return "";
+  const raw = Array.isArray(value) ? value.filter(Boolean).join(", ") : String(value);
+  const cleaned = raw
+    // Caracteres de controle : jamais dans un texte metier.
+    .replace(/[\u0000-\u0009\u000B-\u001F\u007F]/g, " ")
+    .replace(/[<>{}]/g, " ")
+    .replace(/\r?\n/g, " · ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return cleaned.length > maxLength ? truncateReadable(cleaned, maxLength) : cleaned;
+}
+
+export type CommentRenderResult = {
+  text: string;
+  template_version: number;
+  omitted_lines: string[];
+};
+
+/**
+ * Rendu du commentaire : une ligne dont TOUTES les variables sont vides est
+ * supprimée proprement. Jamais de `null`, jamais de `undefined`, jamais un
+ * libellé suivi d'un séparateur vide.
+ */
+export function renderGeneratedComment(
+  template: string,
+  values: Partial<Record<CommentTemplateVariable, unknown>>,
+  templateVersion = GENERATION_TEMPLATE_VERSION
+): CommentRenderResult {
+  assertTemplateVariablesAllowed(template);
+
+  const omitted: string[] = [];
+  const lines: string[] = [];
+
+  for (const line of template.split("\n")) {
+    const tokens = [...line.matchAll(TEMPLATE_TOKEN)].map((match) => match[1] as CommentTemplateVariable);
+    if (tokens.length === 0) {
+      if (line.trim() !== "") lines.push(line.trim());
+      continue;
+    }
+    const rendered = line.replace(TEMPLATE_TOKEN, (_full, name: string) =>
+      sanitizeTemplateValue(values[name as CommentTemplateVariable])
+    );
+    const allEmpty = tokens.every((token) => sanitizeTemplateValue(values[token]) === "");
+    if (allEmpty) {
+      omitted.push(line.trim());
+      continue;
+    }
+    const collapsed = rendered.replace(/[ \t]+/g, " ").trim();
+    // Une ligne réduite à son libellé et son séparateur n'apporte rien.
+    if (collapsed === "" || /^[^:]*:\s*$/.test(collapsed) || /^[-—·,;]+$/.test(collapsed)) {
+      omitted.push(line.trim());
+      continue;
+    }
+    lines.push(collapsed);
+  }
+
+  const text = truncateReadable(lines.join("\n"), COMMENT_MAX_LENGTH);
+  return { text, template_version: templateVersion, omitted_lines: omitted };
+}
+
+/**
+ * Un override d'un texte généré exige une capacité dédiée ET un motif écrit.
+ * L'avant/après est journalisé par l'appelant.
+ */
+export function assertGeneratedTextOverrideAllowed(params: {
+  role: string | null | undefined;
+  reason: string | null | undefined;
+}): void {
+  if (!roleHasSurfaceFinishCapability(params.role, "generated_text_override")) {
+    throw new HttpError(
+      403,
+      "SURFACE_FINISH_OVERRIDE_FORBIDDEN",
+      "Modifier un texte généré exige la capacité 'generated_text_override'."
+    );
+  }
+  if ((params.reason ?? "").trim().length < 15) {
+    throw new HttpError(
+      422,
+      "SURFACE_FINISH_OVERRIDE_REASON_REQUIRED",
+      "Un texte généré ne se remplace qu'avec un motif d'au moins 15 caractères."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 8) Décision de résolution d'article                                        */
+/* -------------------------------------------------------------------------- */
+
+export const ARTICLE_DECISIONS = ["REUSE", "CREATE", "FORCE_CREATE"] as const;
+export type ArticleDecision = (typeof ARTICLE_DECISIONS)[number];
+
+export type ResolutionState = {
+  exactMatchArticleId: string | null;
+  exactMatchIsActive: boolean;
+};
+
+/**
+ * Arbitrage serveur de la décision demandée par l'interface. L'UI propose ;
+ * le serveur dispose. Aucune fusion n'est faite sur un nom : seule l'empreinte
+ * fait foi, et elle a été recalculée juste avant.
+ */
+export function assertArticleDecisionConsistent(params: {
+  decision: ArticleDecision;
+  state: ResolutionState;
+  requestedArticleId: string | null;
+  role: string | null | undefined;
+  justification: string | null;
+}): void {
+  const { decision, state, requestedArticleId } = params;
+
+  if (decision === "REUSE") {
+    if (!state.exactMatchArticleId) {
+      throw new HttpError(
+        409,
+        "ARTICLE_EXACT_MATCH_CHANGED",
+        "Aucun article exact ne correspond plus à cette spécification : rechargez l'aperçu."
+      );
+    }
+    if (!requestedArticleId || requestedArticleId !== state.exactMatchArticleId) {
+      throw new HttpError(
+        409,
+        "ARTICLE_EXACT_MATCH_CHANGED",
+        "L'article exact a changé depuis l'aperçu : rechargez avant de confirmer."
+      );
+    }
+    if (!state.exactMatchIsActive) {
+      throw new HttpError(
+        422,
+        "ARTICLE_SPEC_CONFLICT",
+        "L'article exact est inactif : réactivez-le ou créez un article distinct."
+      );
+    }
+    return;
+  }
+
+  if (decision === "CREATE") {
+    if (state.exactMatchArticleId) {
+      throw new HttpError(
+        409,
+        "ARTICLE_SPEC_CONFLICT",
+        "Un article exact existe déjà : réutilisez-le, ou demandez explicitement un article distinct."
+      );
+    }
+    return;
+  }
+
+  // FORCE_CREATE
+  if (!roleHasSurfaceFinishCapability(params.role, "article_force_create")) {
+    throw new HttpError(
+      403,
+      "ARTICLE_FORCE_CREATE_FORBIDDEN",
+      "Créer un article distinct alors qu'un article compatible existe exige une habilitation dédiée."
+    );
+  }
+  if ((params.justification ?? "").trim().length < 20) {
+    throw new HttpError(
+      422,
+      "ARTICLE_FORCE_CREATE_JUSTIFICATION_REQUIRED",
+      "Un article distinct exige une justification écrite d'au moins 20 caractères."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 9) Aperçu, idempotence et verrou optimiste                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Empreinte de l'aperçu : elle couvre le contexte ET le résultat proposé, pour
+ * qu'un changement d'article exact, de gamme ou de révision périme l'aperçu.
+ */
+export function computePreviewHash(params: {
+  gamme_id: string;
+  operation_id: string;
+  spec_fingerprint: string;
+  exact_match_article_id: string | null;
+  designation: string;
+  comment: string;
+  gamme_updated_at: string;
+  operation_updated_at: string | null;
+}): string {
+  return sha256Hex({
+    kind: "surface_finish_preview",
+    version: 1,
+    ...params,
+  });
+}
+
+export function assertPreviewFresh(expected: string | null | undefined, current: string): void {
+  const value = (expected ?? "").trim();
+  if (!value) {
+    throw new HttpError(
+      422,
+      "PREVIEW_REQUIRED",
+      "Un aperçu serveur est obligatoire avant de confirmer."
+    );
+  }
+  if (value !== current) {
+    throw new HttpError(
+      409,
+      "PREVIEW_STALE",
+      "L'aperçu n'est plus à jour : rechargez-le avant de confirmer."
+    );
+  }
+}
+
+export function normalizeIdempotencyKey(value: string | null | undefined): string {
+  const normalized = (value ?? "").trim();
+  if (normalized.length < 8 || normalized.length > 200) {
+    throw new HttpError(
+      400,
+      "IDEMPOTENCY_KEY_INVALID",
+      "Idempotency-Key doit contenir entre 8 et 200 caractères."
+    );
+  }
+  return normalized;
+}
+
+export function requestHash(commandType: string, payload: unknown): string {
+  return sha256Hex({ command_type: commandType, payload });
+}
+
+export function decideReceipt(
+  existingHash: string | null | undefined,
+  incomingHash: string
+): "NEW" | "REPLAY" | "CONFLICT" {
+  if (!existingHash) return "NEW";
+  return existingHash === incomingHash ? "REPLAY" : "CONFLICT";
+}
+
+export function assertNoIdempotencyConflict(decision: "NEW" | "REPLAY" | "CONFLICT"): void {
+  if (decision === "CONFLICT") {
+    throw new HttpError(
+      409,
+      "IDEMPOTENCY_CONFLICT",
+      "Cette clé d'idempotence a déjà servi pour une autre demande."
+    );
+  }
+}
+
+export function assertOptimisticVersion(params: {
+  expectedUpdatedAt: string | null | undefined;
+  currentUpdatedAt: string | Date;
+  label: string;
+}): void {
+  const expected = (params.expectedUpdatedAt ?? "").trim();
+  if (!expected) {
+    throw new HttpError(
+      422,
+      "EXPECTED_VERSION_REQUIRED",
+      `expected_updated_at est obligatoire pour modifier ${params.label}.`
+    );
+  }
+  const current =
+    params.currentUpdatedAt instanceof Date
+      ? params.currentUpdatedAt.toISOString()
+      : new Date(params.currentUpdatedAt).toISOString();
+  const parsed = new Date(expected);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new HttpError(422, "EXPECTED_VERSION_INVALID", "expected_updated_at est invalide.");
+  }
+  if (parsed.toISOString() !== current) {
+    throw new HttpError(
+      409,
+      "CONCURRENT_MODIFICATION",
+      `${params.label} a été modifié entre-temps : rechargez avant de confirmer.`
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* 10) Taxonomie de l'article généré — la CAT est une donnée, pas un enum     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Arbitrage CAT (#210) : la catégorie MÉTIER de l'article généré est
+ * `traitement_surface`. La catégorie technique reste `traitement` et le type
+ * reste `PURCHASED` : l'article représente une prestation approvisionnée.
+ *
+ * La CAT `sous_traitance` n'est PAS ajoutée : le multi-classement l'autoriserait
+ * (la catégorie primaire resterait `traitement`, cf. la table de priorité du
+ * module Stock), mais elle diluerait le filtre « Traitement de surface » des
+ * écrans Articles sans rien apporter. Décision documentée dans l'ADR-0038.
+ */
+export const GENERATED_ARTICLE_TAXONOMY = {
+  article_type: "PURCHASED",
+  article_category: "traitement",
+  article_categories: ["traitement_surface"],
+  default_family_code: "TRT",
+  stock_managed: false,
+  lot_tracking: false,
+} as const;
+
+export const PURCHASE_LINE_TYPE = "TRAITEMENT" as const;
+
+/**
+ * Catégorie de ligne du catalogue fournisseur. L'enum du catalogue accepte
+ * `SOUS_TRAITANCE` mais pas `TRAITEMENT` : on ne modifie pas cet enum ici, on
+ * documente le mapping et on l'expose pour que l'UI dise la vérité.
+ */
+export const SUPPLIER_CATALOGUE_CATEGORY = "SOUS_TRAITANCE" as const;

--- a/src/module/surface-finish/middlewares/surface-finish-authorization.middleware.ts
+++ b/src/module/surface-finish/middlewares/surface-finish-authorization.middleware.ts
@@ -1,0 +1,34 @@
+import type { RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import {
+  roleHasSurfaceFinishCapability,
+  type SurfaceFinishCapability,
+} from "../domain/surface-finish-policy";
+
+/**
+ * Garde de capacité Finitions (#210). Refus par défaut : un compte authentifié
+ * n'obtient aucun droit implicite. Masquer un bouton côté interface n'est jamais
+ * une autorisation — cette garde est rejouée à chaque requête, et le domaine la
+ * revérifie pour les règles qui dépendent de l'objet manipulé (force-create,
+ * override d'un texte généré).
+ */
+export function requireSurfaceFinishCapability(capability: SurfaceFinishCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (!req.user || typeof req.user.id !== "number") {
+      next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
+      return;
+    }
+    if (!roleHasSurfaceFinishCapability(req.user.role, capability)) {
+      next(
+        new HttpError(
+          403,
+          "SURFACE_FINISH_CAPABILITY_REQUIRED",
+          `La capacité Finitions '${capability}' est requise.`
+        )
+      );
+      return;
+    }
+    next();
+  };
+}

--- a/src/module/surface-finish/repository/surface-finish-library.repository.ts
+++ b/src/module/surface-finish/repository/surface-finish-library.repository.ts
@@ -1,0 +1,921 @@
+// #210 — Bibliothèque de finitions : lecture, recherche, brouillons, révisions,
+// transitions et documents. Toute écriture est transactionnelle et auditée.
+
+import type { PoolClient } from "pg";
+
+import db from "../../../config/database";
+import { generateSurfaceFinishCode } from "../../../shared/codes/code-generator.service";
+import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import type { AuditContext } from "../../pieces-techniques/repository/pieces-techniques.repository";
+import {
+  assertOptimisticVersion,
+  assertRevisionContentMutable,
+  assertSurfaceFinishTransition,
+  assertTemplateVariablesAllowed,
+  assertThicknessCoherent,
+  normalizeThicknessUnit,
+  thicknessToMicrometers,
+  type SurfaceFinishStatus,
+} from "../domain/surface-finish-policy";
+import type {
+  AttachDocumentBodyDTO,
+  CreateFinishBodyDTO,
+  ListFinishesQueryDTO,
+  RevisionPayloadDTO,
+  TransitionRevisionBodyDTO,
+  UpdateFinishBodyDTO,
+  UpdateRevisionBodyDTO,
+} from "../validators/surface-finish.validators";
+import type {
+  SurfaceFinishDetail,
+  SurfaceFinishDocument,
+  SurfaceFinishFamily,
+  SurfaceFinishListResult,
+  SurfaceFinishRevisionDetail,
+  SurfaceFinishRevisionSummary,
+  SurfaceFinishSummary,
+} from "../types/surface-finish.types";
+
+/* -------------------------------------------------------------------------- */
+/* Colonnes et projections                                                     */
+/* -------------------------------------------------------------------------- */
+
+/** Projection d'une révision. `alias` permet de la réutiliser en RETURNING. */
+export function revisionColumns(alias = "r"): string {
+  const p = alias ? `${alias}.` : "";
+  return `
+    ${p}id::text AS id,
+    ${p}finish_id::text AS finish_id,
+    ${p}revision,
+    ${p}statut,
+    ${p}norme,
+    ${p}reference_client,
+    ${p}classe,
+    ${p}substrat,
+    ${p}epaisseur_min::float8 AS epaisseur_min,
+    ${p}epaisseur_nominale::float8 AS epaisseur_nominale,
+    ${p}epaisseur_max::float8 AS epaisseur_max,
+    ${p}epaisseur_unite,
+    ${p}couleur,
+    ${p}teinte_ral,
+    ${p}aspect,
+    ${p}brillance,
+    ${p}rugosite,
+    ${p}durete,
+    ${p}exigence_corrosion,
+    ${p}pretraitement,
+    ${p}posttraitement,
+    ${p}zones_defaut,
+    ${p}regles_masquage,
+    ${p}criteres_acceptation,
+    ${p}controles,
+    ${p}certificat_requis,
+    ${p}certificat_type,
+    ${p}conditionnement_retour,
+    ${p}unite_achat,
+    ${p}designation_template,
+    ${p}commentaire_template,
+    ${p}template_version,
+    ${p}date_effet::text AS date_effet,
+    ${p}approbateur_user_id,
+    ${p}approved_at::text AS approved_at,
+    ${p}created_at::text AS created_at,
+    ${p}updated_at::text AS updated_at
+  `;
+}
+
+const FINISH_COLS = `
+  f.id::text AS id,
+  f.code,
+  f.family_code,
+  fam.label AS family_label,
+  f.procede,
+  f.designation_courte,
+  f.designation_longue,
+  f.description,
+  f.synonymes,
+  f.statut,
+  f.current_revision_id::text AS current_revision_id,
+  f.created_at::text AS created_at,
+  f.updated_at::text AS updated_at
+`;
+
+export type RevisionRow = {
+  id: string;
+  finish_id: string;
+  revision: number;
+  statut: SurfaceFinishStatus;
+  norme: string | null;
+  reference_client: string | null;
+  classe: string | null;
+  substrat: string | null;
+  epaisseur_min: number | null;
+  epaisseur_nominale: number | null;
+  epaisseur_max: number | null;
+  epaisseur_unite: string;
+  couleur: string | null;
+  teinte_ral: string | null;
+  aspect: string | null;
+  brillance: string | null;
+  rugosite: string | null;
+  durete: string | null;
+  exigence_corrosion: string | null;
+  pretraitement: string | null;
+  posttraitement: string | null;
+  zones_defaut: string[] | null;
+  regles_masquage: string[] | null;
+  criteres_acceptation: string | null;
+  controles: string[] | null;
+  certificat_requis: boolean;
+  certificat_type: string | null;
+  conditionnement_retour: string | null;
+  unite_achat: string;
+  designation_template: string | null;
+  commentaire_template: string | null;
+  template_version: number;
+  date_effet: string | null;
+  approbateur_user_id: number | null;
+  approved_at: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type FinishRow = {
+  id: string;
+  code: string;
+  family_code: string;
+  family_label: string | null;
+  procede: string;
+  designation_courte: string;
+  designation_longue: string | null;
+  description: string | null;
+  synonymes: string[] | null;
+  statut: SurfaceFinishStatus;
+  current_revision_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+export function mapRevision(row: RevisionRow): SurfaceFinishRevisionDetail {
+  return {
+    id: row.id,
+    finish_id: row.finish_id,
+    revision: row.revision,
+    statut: row.statut,
+    norme: row.norme,
+    reference_client: row.reference_client,
+    classe: row.classe,
+    substrat: row.substrat,
+    epaisseur_min: row.epaisseur_min,
+    epaisseur_nominale: row.epaisseur_nominale,
+    epaisseur_max: row.epaisseur_max,
+    epaisseur_unite: row.epaisseur_unite,
+    couleur: row.couleur,
+    teinte_ral: row.teinte_ral,
+    aspect: row.aspect,
+    brillance: row.brillance,
+    rugosite: row.rugosite,
+    durete: row.durete,
+    exigence_corrosion: row.exigence_corrosion,
+    pretraitement: row.pretraitement,
+    posttraitement: row.posttraitement,
+    zones_defaut: row.zones_defaut ?? [],
+    regles_masquage: row.regles_masquage ?? [],
+    criteres_acceptation: row.criteres_acceptation,
+    controles: row.controles ?? [],
+    certificat_requis: row.certificat_requis,
+    certificat_type: row.certificat_type,
+    conditionnement_retour: row.conditionnement_retour,
+    unite_achat: row.unite_achat,
+    designation_template: row.designation_template,
+    commentaire_template: row.commentaire_template,
+    template_version: row.template_version,
+    date_effet: row.date_effet,
+    approbateur_user_id: row.approbateur_user_id,
+    approved_at: row.approved_at,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export function toRevisionSummary(revision: SurfaceFinishRevisionDetail): SurfaceFinishRevisionSummary {
+  return {
+    id: revision.id,
+    revision: revision.revision,
+    statut: revision.statut,
+    norme: revision.norme,
+    classe: revision.classe,
+    epaisseur_min: revision.epaisseur_min,
+    epaisseur_nominale: revision.epaisseur_nominale,
+    epaisseur_max: revision.epaisseur_max,
+    epaisseur_unite: revision.epaisseur_unite,
+    couleur: revision.couleur,
+    teinte_ral: revision.teinte_ral,
+    aspect: revision.aspect,
+    certificat_requis: revision.certificat_requis,
+    date_effet: revision.date_effet,
+    updated_at: revision.updated_at,
+  };
+}
+
+export async function insertFinishAudit(
+  tx: Pick<PoolClient, "query">,
+  audit: AuditContext,
+  action: string,
+  entityType: string,
+  entityId: string,
+  details: Record<string, unknown> | null
+): Promise<void> {
+  await repoInsertAuditLog({
+    user_id: audit.user_id,
+    body: {
+      event_type: "ACTION",
+      action,
+      page_key: audit.page_key,
+      entity_type: entityType,
+      entity_id: entityId,
+      path: audit.path,
+      client_session_id: audit.client_session_id,
+      details,
+    },
+    ip: audit.ip,
+    user_agent: audit.user_agent,
+    device_type: audit.device_type,
+    os: audit.os,
+    browser: audit.browser,
+    tx,
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/* Familles                                                                    */
+/* -------------------------------------------------------------------------- */
+
+export async function repoListFinishFamilies(): Promise<SurfaceFinishFamily[]> {
+  const res = await db.query<SurfaceFinishFamily>(
+    `SELECT code, label, description, sort_order, is_active
+     FROM public.surface_finish_families
+     ORDER BY sort_order, label`
+  );
+  return res.rows;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Recherche                                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Recherche serveur bornée. Jamais de « charger toute la bibliothèque » : la
+ * pagination est obligatoire et plafonnée par le validateur.
+ *
+ * Recherche par code, désignation, famille, procédé, norme, couleur/teinte,
+ * épaisseur et synonyme. La norme et la couleur vivent sur la RÉVISION : la
+ * jointure latérale retient la révision active, sinon la plus récente.
+ */
+export async function repoListFinishes(filters: ListFinishesQueryDTO): Promise<SurfaceFinishListResult> {
+  const where: string[] = [];
+  const values: unknown[] = [];
+  const push = (value: unknown) => {
+    values.push(value);
+    return `$${values.length}`;
+  };
+
+  if (filters.only_selectable) {
+    // Depuis une gamme : uniquement ce qui est réellement applicable.
+    where.push(`f.statut = 'ACTIVE'`);
+    where.push(`rev.id IS NOT NULL AND rev.statut = 'ACTIVE'`);
+  } else if (filters.statut) {
+    where.push(`f.statut = ${push(filters.statut)}`);
+  }
+
+  if (filters.family_code) where.push(`f.family_code = ${push(filters.family_code)}`);
+  if (filters.procede) {
+    where.push(`public.surface_finish_norm(f.procede) LIKE public.surface_finish_norm(${push(`%${filters.procede}%`)})`);
+  }
+  if (filters.norme) {
+    where.push(`public.surface_finish_norm(rev.norme) LIKE public.surface_finish_norm(${push(`%${filters.norme}%`)})`);
+  }
+  if (filters.couleur) {
+    const needle = push(`%${filters.couleur}%`);
+    where.push(
+      `(public.surface_finish_norm(rev.couleur) LIKE public.surface_finish_norm(${needle})
+        OR public.surface_finish_norm(rev.teinte_ral) LIKE public.surface_finish_norm(${needle}))`
+    );
+  }
+  if (filters.epaisseur_um !== null && filters.epaisseur_um !== undefined) {
+    // Comparaison en micromètres : la révision peut être saisie dans une autre unité.
+    const target = push(filters.epaisseur_um);
+    where.push(`(
+      rev.id IS NOT NULL
+      AND ${target}::numeric >= COALESCE(public.surface_finish_to_um(rev.epaisseur_min::numeric, rev.epaisseur_unite), 0)
+      AND ${target}::numeric <= COALESCE(public.surface_finish_to_um(rev.epaisseur_max::numeric, rev.epaisseur_unite), 1e12)
+    )`);
+  }
+  if (filters.q) {
+    const needle = push(`%${filters.q}%`);
+    const exact = push(filters.q);
+    where.push(`(
+      public.surface_finish_norm(f.code) LIKE public.surface_finish_norm(${needle})
+      OR public.surface_finish_norm(f.designation_courte) LIKE public.surface_finish_norm(${needle})
+      OR public.surface_finish_norm(f.designation_longue) LIKE public.surface_finish_norm(${needle})
+      OR public.surface_finish_norm(f.procede) LIKE public.surface_finish_norm(${needle})
+      OR public.surface_finish_norm(f.family_code) LIKE public.surface_finish_norm(${needle})
+      OR public.surface_finish_norm(fam.label) LIKE public.surface_finish_norm(${needle})
+      OR public.surface_finish_norm(rev.norme) LIKE public.surface_finish_norm(${needle})
+      OR public.surface_finish_norm(rev.couleur) LIKE public.surface_finish_norm(${needle})
+      OR public.surface_finish_norm(rev.teinte_ral) LIKE public.surface_finish_norm(${needle})
+      OR EXISTS (
+        SELECT 1 FROM unnest(f.synonymes) AS s(value)
+        WHERE public.surface_finish_norm(s.value) LIKE public.surface_finish_norm(${needle})
+           OR public.surface_finish_norm(s.value) = public.surface_finish_norm(${exact})
+      )
+    )`);
+  }
+
+  const whereSql = where.length > 0 ? `WHERE ${where.join(" AND ")}` : "";
+
+  const baseFrom = `
+    FROM public.surface_finishes f
+    LEFT JOIN public.surface_finish_families fam ON fam.code = f.family_code
+    LEFT JOIN LATERAL (
+      SELECT ${revisionColumns("r")}
+      FROM public.surface_finish_revisions r
+      WHERE r.finish_id = f.id
+      ORDER BY (r.statut = 'ACTIVE') DESC, r.revision DESC
+      LIMIT 1
+    ) rev ON true
+    ${whereSql}
+  `;
+
+  const countRes = await db.query<{ total: number }>(`SELECT COUNT(*)::int AS total ${baseFrom}`, values);
+  const total = countRes.rows[0]?.total ?? 0;
+
+  const offset = (filters.page - 1) * filters.page_size;
+  const dataRes = await db.query<FinishRow & { rev_json: RevisionRow | null }>(
+    `SELECT ${FINISH_COLS}, CASE WHEN rev.id IS NULL THEN NULL ELSE to_jsonb(rev) END AS rev_json
+     ${baseFrom}
+     ORDER BY f.designation_courte, f.code
+     LIMIT $${values.length + 1} OFFSET $${values.length + 2}`,
+    [...values, filters.page_size, offset]
+  );
+
+  const items: SurfaceFinishSummary[] = dataRes.rows.map((row) => ({
+    id: row.id,
+    code: row.code,
+    family_code: row.family_code,
+    family_label: row.family_label,
+    procede: row.procede,
+    designation_courte: row.designation_courte,
+    designation_longue: row.designation_longue,
+    synonymes: row.synonymes ?? [],
+    statut: row.statut,
+    current_revision: row.rev_json ? toRevisionSummary(mapRevision(row.rev_json)) : null,
+    updated_at: row.updated_at,
+  }));
+
+  return { items, total, page: filters.page, page_size: filters.page_size };
+}
+
+export async function repoGetFinish(finishId: string): Promise<SurfaceFinishDetail | null> {
+  const res = await db.query<FinishRow>(
+    `SELECT ${FINISH_COLS}
+     FROM public.surface_finishes f
+     LEFT JOIN public.surface_finish_families fam ON fam.code = f.family_code
+     WHERE f.id = $1::uuid`,
+    [finishId]
+  );
+  const row = res.rows[0];
+  if (!row) return null;
+
+  const revisions = await db.query<RevisionRow>(
+    `SELECT ${revisionColumns("r")} FROM public.surface_finish_revisions r
+     WHERE r.finish_id = $1::uuid ORDER BY r.revision DESC`,
+    [finishId]
+  );
+  const mapped = revisions.rows.map(mapRevision);
+  const current =
+    mapped.find((rev) => rev.id === row.current_revision_id) ?? mapped.find((rev) => rev.statut === "ACTIVE") ?? null;
+
+  return {
+    id: row.id,
+    code: row.code,
+    family_code: row.family_code,
+    family_label: row.family_label,
+    procede: row.procede,
+    designation_courte: row.designation_courte,
+    designation_longue: row.designation_longue,
+    description: row.description,
+    synonymes: row.synonymes ?? [],
+    statut: row.statut,
+    current_revision: current ? toRevisionSummary(current) : null,
+    revisions: mapped,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Écriture — finitions                                                        */
+/* -------------------------------------------------------------------------- */
+
+export async function repoCreateFinishDraft(
+  body: CreateFinishBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishDetail> {
+  const client = await db.connect();
+  let finishId = "";
+  try {
+    await client.query("BEGIN");
+
+    const family = await client.query(
+      `SELECT 1 FROM public.surface_finish_families WHERE code = $1 AND is_active`,
+      [body.family_code]
+    );
+    if (family.rowCount === 0) {
+      throw new HttpError(422, "SURFACE_FINISH_FAMILY_UNKNOWN", "Famille de finition inconnue ou désactivée.");
+    }
+
+    // Le code visible est alloué par le SERVEUR, jamais proposé par l'interface.
+    const code = await generateSurfaceFinishCode(client);
+
+    const inserted = await client.query<{ id: string }>(
+      `INSERT INTO public.surface_finishes
+         (code, family_code, procede, designation_courte, designation_longue, description, synonymes, statut, created_by, updated_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,'BROUILLON',$8,$8)
+       RETURNING id::text AS id`,
+      [
+        code,
+        body.family_code,
+        body.procede,
+        body.designation_courte,
+        body.designation_longue,
+        body.description,
+        body.synonymes,
+        audit.user_id,
+      ]
+    );
+    finishId = inserted.rows[0].id;
+
+    // Toute finition naît avec sa révision 1 en brouillon : une finition sans
+    // révision ne veut rien dire techniquement.
+    const revision = await client.query<{ id: string }>(
+      `INSERT INTO public.surface_finish_revisions (finish_id, revision, statut, created_by, updated_by)
+       VALUES ($1::uuid, 1, 'BROUILLON', $2, $2)
+       RETURNING id::text AS id`,
+      [finishId, audit.user_id]
+    );
+
+    await client.query(`UPDATE public.surface_finishes SET current_revision_id = $2::uuid WHERE id = $1::uuid`, [
+      finishId,
+      revision.rows[0].id,
+    ]);
+
+    await insertFinishAudit(client, audit, "finitions.create", "surface_finish", finishId, {
+      code,
+      family_code: body.family_code,
+      procede: body.procede,
+    });
+
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  // Relecture APRÈS le commit : lire par le pool depuis une transaction ouverte
+  // ne verrait rien (leçon du chantier GED).
+  const out = await repoGetFinish(finishId);
+  if (!out) throw new Error("Failed to read created finish");
+  return out;
+}
+
+export async function repoUpdateFinishDraft(
+  finishId: string,
+  body: UpdateFinishBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishDetail> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const cur = await client.query<{ statut: SurfaceFinishStatus; updated_at: string }>(
+      `SELECT statut, updated_at::text AS updated_at FROM public.surface_finishes WHERE id = $1::uuid FOR UPDATE`,
+      [finishId]
+    );
+    const current = cur.rows[0];
+    if (!current) throw new HttpError(404, "NOT_FOUND", "Finition introuvable.");
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: current.updated_at,
+      label: "Cette finition",
+    });
+    if (current.statut === "ARCHIVEE") {
+      throw new HttpError(409, "SURFACE_FINISH_ARCHIVED", "Une finition archivée ne se modifie plus.");
+    }
+
+    if (body.family_code !== undefined) {
+      const family = await client.query(
+        `SELECT 1 FROM public.surface_finish_families WHERE code = $1 AND is_active`,
+        [body.family_code]
+      );
+      if (family.rowCount === 0) {
+        throw new HttpError(422, "SURFACE_FINISH_FAMILY_UNKNOWN", "Famille de finition inconnue ou désactivée.");
+      }
+    }
+
+    const sets: string[] = [];
+    const values: unknown[] = [];
+    const push = (col: string, value: unknown) => {
+      values.push(value);
+      sets.push(`${col} = $${values.length}`);
+    };
+    if (body.family_code !== undefined) push("family_code", body.family_code);
+    if (body.procede !== undefined) push("procede", body.procede);
+    if (body.designation_courte !== undefined) push("designation_courte", body.designation_courte);
+    if (body.designation_longue !== undefined) push("designation_longue", body.designation_longue);
+    if (body.description !== undefined) push("description", body.description);
+    if (body.synonymes !== undefined) push("synonymes", body.synonymes);
+    values.push(audit.user_id);
+    sets.push(`updated_by = $${values.length}`);
+    sets.push(`updated_at = now()`);
+    values.push(finishId);
+
+    await client.query(`UPDATE public.surface_finishes SET ${sets.join(", ")} WHERE id = $${values.length}::uuid`, values);
+    await insertFinishAudit(client, audit, "finitions.update", "surface_finish", finishId, {
+      changed: Object.keys(body).filter((key) => key !== "expected_updated_at"),
+    });
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  const out = await repoGetFinish(finishId);
+  if (!out) throw new HttpError(404, "NOT_FOUND", "Finition introuvable.");
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Écriture — révisions                                                        */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Ordre AUTORITAIRE des colonnes écrites d'une révision : la liste et les
+ * paramètres sont dérivés du MÊME tableau, il ne peut pas y avoir de décalage.
+ */
+const REVISION_WRITE_FIELDS = [
+  "norme",
+  "reference_client",
+  "classe",
+  "substrat",
+  "epaisseur_min",
+  "epaisseur_nominale",
+  "epaisseur_max",
+  "epaisseur_unite",
+  "couleur",
+  "teinte_ral",
+  "aspect",
+  "brillance",
+  "rugosite",
+  "durete",
+  "exigence_corrosion",
+  "pretraitement",
+  "posttraitement",
+  "zones_defaut",
+  "regles_masquage",
+  "criteres_acceptation",
+  "controles",
+  "certificat_requis",
+  "certificat_type",
+  "conditionnement_retour",
+  "unite_achat",
+  "designation_template",
+  "commentaire_template",
+  "date_effet",
+] as const;
+
+function revisionWriteValues(payload: RevisionPayloadDTO): unknown[] {
+  const map: Record<(typeof REVISION_WRITE_FIELDS)[number], unknown> = {
+    norme: payload.norme,
+    reference_client: payload.reference_client,
+    classe: payload.classe,
+    substrat: payload.substrat,
+    epaisseur_min: payload.epaisseur_min,
+    epaisseur_nominale: payload.epaisseur_nominale,
+    epaisseur_max: payload.epaisseur_max,
+    epaisseur_unite: payload.epaisseur_unite ?? "um",
+    couleur: payload.couleur,
+    teinte_ral: payload.teinte_ral,
+    aspect: payload.aspect,
+    brillance: payload.brillance,
+    rugosite: payload.rugosite,
+    durete: payload.durete,
+    exigence_corrosion: payload.exigence_corrosion,
+    pretraitement: payload.pretraitement,
+    posttraitement: payload.posttraitement,
+    zones_defaut: payload.zones_defaut,
+    regles_masquage: payload.regles_masquage,
+    criteres_acceptation: payload.criteres_acceptation ?? null,
+    controles: payload.controles,
+    certificat_requis: payload.certificat_requis ?? false,
+    certificat_type: payload.certificat_type,
+    conditionnement_retour: payload.conditionnement_retour,
+    unite_achat: payload.unite_achat ?? "PCE",
+    designation_template: payload.designation_template,
+    commentaire_template: payload.commentaire_template,
+    date_effet: payload.date_effet,
+  };
+  return REVISION_WRITE_FIELDS.map((field) => map[field]);
+}
+
+function assertRevisionPayloadCoherent(payload: RevisionPayloadDTO): void {
+  const unit = normalizeThicknessUnit(payload.epaisseur_unite ?? "um");
+  assertThicknessCoherent({
+    min_um: thicknessToMicrometers(payload.epaisseur_min, unit),
+    nominal_um: thicknessToMicrometers(payload.epaisseur_nominale, unit),
+    max_um: thicknessToMicrometers(payload.epaisseur_max, unit),
+  });
+  if (payload.certificat_requis && !payload.certificat_type) {
+    throw new HttpError(
+      422,
+      "SURFACE_FINISH_CERTIFICATE_TYPE_REQUIRED",
+      "Un certificat exigé sans type est une exigence incomplète."
+    );
+  }
+  if (payload.commentaire_template) assertTemplateVariablesAllowed(payload.commentaire_template);
+  if (payload.designation_template) assertTemplateVariablesAllowed(payload.designation_template);
+}
+
+/**
+ * Crée la révision suivante. Une modification technique majeure NE réécrit
+ * jamais une révision publiée : elle en crée une nouvelle, et la précédente
+ * reste lisible dans l'historique.
+ */
+export async function repoCreateRevision(
+  finishId: string,
+  payload: RevisionPayloadDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishRevisionDetail> {
+  assertRevisionPayloadCoherent(payload);
+
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    // Le verrou est posé sur la finition PARENTE : un agrégat ne supporte pas
+    // `FOR UPDATE`, et c'est bien la finition qui sérialise ses révisions.
+    const finish = await client.query<{ id: string; statut: SurfaceFinishStatus }>(
+      `SELECT id::text AS id, statut FROM public.surface_finishes WHERE id = $1::uuid FOR UPDATE`,
+      [finishId]
+    );
+    if (finish.rowCount === 0) throw new HttpError(404, "NOT_FOUND", "Finition introuvable.");
+    if (finish.rows[0].statut === "ARCHIVEE") {
+      throw new HttpError(409, "SURFACE_FINISH_ARCHIVED", "Une finition archivée n'accepte plus de révision.");
+    }
+
+    const next = await client.query<{ next_revision: number }>(
+      `SELECT COALESCE(MAX(revision), 0) + 1 AS next_revision
+       FROM public.surface_finish_revisions WHERE finish_id = $1::uuid`,
+      [finishId]
+    );
+    const nextRevision = next.rows[0]?.next_revision ?? 1;
+
+    const params = revisionWriteValues(payload);
+    const placeholders = params.map((_, index) => `$${index + 3}`).join(", ");
+    const inserted = await client.query<RevisionRow>(
+      `INSERT INTO public.surface_finish_revisions
+         (finish_id, revision, ${REVISION_WRITE_FIELDS.join(", ")}, statut, created_by, updated_by)
+       VALUES ($1::uuid, $2, ${placeholders}, 'BROUILLON', $${params.length + 3}, $${params.length + 3})
+       RETURNING ${revisionColumns("")}`,
+      [finishId, nextRevision, ...params, audit.user_id]
+    );
+
+    const row = inserted.rows[0];
+    await insertFinishAudit(client, audit, "finitions.revision.create", "surface_finish_revision", row.id, {
+      finish_id: finishId,
+      revision: nextRevision,
+    });
+    await client.query("COMMIT");
+    return mapRevision(row);
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoUpdateRevision(
+  revisionId: string,
+  body: UpdateRevisionBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishRevisionDetail> {
+  assertRevisionPayloadCoherent(body);
+
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const cur = await client.query<{ statut: SurfaceFinishStatus; updated_at: string; finish_id: string }>(
+      `SELECT statut, updated_at::text AS updated_at, finish_id::text AS finish_id
+       FROM public.surface_finish_revisions WHERE id = $1::uuid FOR UPDATE`,
+      [revisionId]
+    );
+    const current = cur.rows[0];
+    if (!current) throw new HttpError(404, "NOT_FOUND", "Révision introuvable.");
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: current.updated_at,
+      label: "Cette révision",
+    });
+    assertRevisionContentMutable(current.statut);
+
+    const params = revisionWriteValues(body);
+    const assignments = REVISION_WRITE_FIELDS.map((col, index) => `${col} = $${index + 2}`).join(", ");
+
+    const updated = await client.query<RevisionRow>(
+      `UPDATE public.surface_finish_revisions
+       SET ${assignments}, updated_by = $${params.length + 2}, updated_at = now()
+       WHERE id = $1::uuid
+       RETURNING ${revisionColumns("")}`,
+      [revisionId, ...params, audit.user_id]
+    );
+    const row = updated.rows[0];
+    await insertFinishAudit(client, audit, "finitions.revision.update", "surface_finish_revision", revisionId, {
+      finish_id: current.finish_id,
+    });
+    await client.query("COMMIT");
+    return mapRevision(row);
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+export type RevisionImpact = {
+  gammes: number;
+  articles: number;
+  operations: Array<{ gamme_id: string; operation_id: string; piece_code: string; indice: string }>;
+};
+
+/** Analyse d'impact AVANT suspension/obsolescence. Aucune action automatique. */
+export async function repoRevisionImpact(revisionId: string): Promise<RevisionImpact> {
+  const usage = await db.query<{ gamme_id: string; operation_id: string; piece_code: string; indice: string }>(
+    `SELECT
+       f.gamme_id::text           AS gamme_id,
+       f.gamme_operation_id::text AS operation_id,
+       pt.code_piece              AS piece_code,
+       ptv.indice                 AS indice
+     FROM public.gamme_operation_finitions f
+     JOIN public.piece_technique_versions ptv ON ptv.id = f.piece_technique_version_id
+     JOIN public.pieces_techniques pt ON pt.id = ptv.piece_technique_id
+     WHERE f.finish_revision_id = $1::uuid
+     ORDER BY pt.code_piece, ptv.indice
+     LIMIT 500`,
+    [revisionId]
+  );
+  const articles = await db.query<{ total: number }>(
+    `SELECT COUNT(*)::int AS total FROM public.articles_traitement WHERE finish_revision_id = $1::uuid`,
+    [revisionId]
+  );
+  return {
+    gammes: new Set(usage.rows.map((row) => row.gamme_id)).size,
+    articles: articles.rows[0]?.total ?? 0,
+    operations: usage.rows,
+  };
+}
+
+export async function repoTransitionRevision(
+  revisionId: string,
+  body: TransitionRevisionBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishRevisionDetail> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const cur = await client.query<{ statut: SurfaceFinishStatus; updated_at: string; finish_id: string }>(
+      `SELECT statut, updated_at::text AS updated_at, finish_id::text AS finish_id
+       FROM public.surface_finish_revisions WHERE id = $1::uuid FOR UPDATE`,
+      [revisionId]
+    );
+    const current = cur.rows[0];
+    if (!current) throw new HttpError(404, "NOT_FOUND", "Révision introuvable.");
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: current.updated_at,
+      label: "Cette révision",
+    });
+    assertSurfaceFinishTransition(current.statut, body.statut);
+
+    // Publier une révision rend obsolète celle qu'elle remplace : l'index
+    // partiel n'accepte qu'une seule révision ACTIVE par finition.
+    if (body.statut === "ACTIVE") {
+      await client.query(
+        `UPDATE public.surface_finish_revisions
+         SET statut = 'OBSOLETE', updated_at = now(), updated_by = $3
+         WHERE finish_id = $1::uuid AND statut = 'ACTIVE' AND id <> $2::uuid`,
+        [current.finish_id, revisionId, audit.user_id]
+      );
+    }
+
+    const approving = body.statut === "ACTIVE";
+    const updated = await client.query<RevisionRow>(
+      `UPDATE public.surface_finish_revisions
+       SET statut = $2,
+           approbateur_user_id = CASE WHEN $3::boolean THEN $4::integer ELSE approbateur_user_id END,
+           approved_at = CASE WHEN $3::boolean THEN now() ELSE approved_at END,
+           updated_by = $4::integer,
+           updated_at = now()
+       WHERE id = $1::uuid
+       RETURNING ${revisionColumns("")}`,
+      [revisionId, body.statut, approving, audit.user_id]
+    );
+
+    if (approving) {
+      await client.query(
+        `UPDATE public.surface_finishes
+         SET current_revision_id = $2::uuid,
+             statut = CASE WHEN statut IN ('BROUILLON','EN_VALIDATION') THEN 'ACTIVE' ELSE statut END,
+             updated_at = now(), updated_by = $3
+         WHERE id = $1::uuid`,
+        [current.finish_id, revisionId, audit.user_id]
+      );
+    }
+
+    await insertFinishAudit(client, audit, "finitions.revision.transition", "surface_finish_revision", revisionId, {
+      finish_id: current.finish_id,
+      from: current.statut,
+      to: body.statut,
+      motif: body.motif,
+    });
+
+    await client.query("COMMIT");
+    return mapRevision(updated.rows[0]);
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Documents                                                                   */
+/* -------------------------------------------------------------------------- */
+
+const DOCUMENT_COLS = `
+  id::text AS id, revision_id::text AS revision_id, libelle, doc_type,
+  ged_document_id::text AS ged_document_id, reference_externe, sha256,
+  created_at::text AS created_at
+`;
+
+export async function repoListRevisionDocuments(revisionId: string): Promise<SurfaceFinishDocument[]> {
+  const res = await db.query<SurfaceFinishDocument>(
+    `SELECT ${DOCUMENT_COLS}
+     FROM public.surface_finish_revision_documents
+     WHERE revision_id = $1::uuid
+     ORDER BY created_at`,
+    [revisionId]
+  );
+  return res.rows;
+}
+
+export async function repoAttachRevisionDocument(
+  revisionId: string,
+  body: AttachDocumentBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishDocument> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const rev = await client.query<{ statut: SurfaceFinishStatus }>(
+      `SELECT statut FROM public.surface_finish_revisions WHERE id = $1::uuid FOR UPDATE`,
+      [revisionId]
+    );
+    if (rev.rowCount === 0) throw new HttpError(404, "NOT_FOUND", "Révision introuvable.");
+    assertRevisionContentMutable(rev.rows[0].statut);
+
+    const inserted = await client.query<SurfaceFinishDocument>(
+      `INSERT INTO public.surface_finish_revision_documents
+         (revision_id, libelle, doc_type, ged_document_id, reference_externe, sha256, created_by)
+       VALUES ($1::uuid,$2,$3,$4::uuid,$5,$6,$7)
+       RETURNING ${DOCUMENT_COLS}`,
+      [revisionId, body.libelle, body.doc_type, body.ged_document_id, body.reference_externe, body.sha256, audit.user_id]
+    );
+    await insertFinishAudit(client, audit, "finitions.revision.document.attach", "surface_finish_revision", revisionId, {
+      libelle: body.libelle,
+      doc_type: body.doc_type,
+    });
+    await client.query("COMMIT");
+    return inserted.rows[0];
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}

--- a/src/module/surface-finish/repository/surface-finish-resolution.repository.ts
+++ b/src/module/surface-finish/repository/surface-finish-resolution.repository.ts
@@ -1,0 +1,1232 @@
+// #210 — Résolution d'article de sous-traitance depuis une opération de gamme.
+//
+// Deux commandes seulement :
+//   `repoPreviewOperationFinish`  — LECTURE PURE, aucune écriture, jamais.
+//   `repoConfirmOperationFinish`  — UNE transaction, tout ou rien.
+//
+// Le fournisseur, le prix, le délai et le MOQ ne participent jamais à
+// l'identité technique : ils sont lus pour information et rien d'autre.
+
+import type { PoolClient } from "pg";
+
+import db from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import type { AuditContext } from "../../pieces-techniques/repository/pieces-techniques.repository";
+import { repoCreateArticleTx } from "../../stock/repository/stock.repository";
+import type { CreateArticleBodyDTO } from "../../stock/validators/stock.validators";
+import {
+  assertArticleDecisionConsistent,
+  assertGammeEditable,
+  assertNoIdempotencyConflict,
+  assertOperationBelongsToGamme,
+  assertOperationIsSubcontracting,
+  assertOptimisticVersion,
+  assertPreviewFresh,
+  assertRevisionSelectable,
+  buildCanonicalFinishSpec,
+  buildGeneratedDesignation,
+  computePreviewHash,
+  computeSpecFingerprint,
+  DEFAULT_COMMENT_TEMPLATE,
+  decideReceipt,
+  diffCanonicalSpecs,
+  GENERATED_ARTICLE_TAXONOMY,
+  GENERATION_TEMPLATE_VERSION,
+  normalizeThicknessUnit,
+  PURCHASE_LINE_TYPE,
+  renderGeneratedComment,
+  requestHash,
+  roleHasSurfaceFinishCapability,
+  statusIsHistoricalOnly,
+  SUPPLIER_CATALOGUE_CATEGORY,
+  surfaceFinishCapabilitiesFor,
+  thicknessToMicrometers,
+  type ArticleDecision,
+  type CanonicalFinishSpec,
+  type FinishScope,
+  type SurfaceFinishStatus,
+} from "../domain/surface-finish-policy";
+import type {
+  ConfirmFinishBodyDTO,
+  DetachFinishBodyDTO,
+  OperationOverridesDTO,
+  PreviewFinishBodyDTO,
+} from "../validators/surface-finish.validators";
+import type {
+  ArticleMatch,
+  ArticleNearMatch,
+  ConfirmFinishResult,
+  OperationFinishContext,
+  OperationFinishRequirement,
+  PlannedArticleClassification,
+  PlannedPurchaseLine,
+  QualityRequirementPreview,
+  SupplierCandidate,
+  SurfaceFinishPreview,
+  SurfaceFinishRevisionDetail,
+} from "../types/surface-finish.types";
+import { insertFinishAudit, mapRevision, revisionColumns, type RevisionRow } from "./surface-finish-library.repository";
+
+type Queryer = Pick<PoolClient, "query">;
+
+/* -------------------------------------------------------------------------- */
+/* Contexte — lu côté serveur, jamais reconstruit depuis la requête           */
+/* -------------------------------------------------------------------------- */
+
+type ContextRow = {
+  piece_technique_id: string;
+  code_piece: string;
+  designation_piece: string;
+  piece_technique_version_id: string;
+  indice: string;
+  plan_reference: string | null;
+  gamme_id: string;
+  gamme_code: string | null;
+  gamme_nom: string | null;
+  gamme_statut: string;
+  gamme_updated_at: string;
+  operation_id: string;
+  numero_operation: number | null;
+  designation_operation: string;
+  type_operation: string | null;
+  operation_updated_at: string | null;
+  operation_gamme_id: string | null;
+};
+
+/**
+ * Anti-IDOR : la gamme, l'opération, la version et la pièce sont recoupées en
+ * UNE requête. Une opération d'une autre gamme, ou une gamme d'une autre
+ * version, ne peut pas franchir cette porte.
+ */
+async function loadContext(tx: Queryer, gammeId: string, operationId: string): Promise<OperationFinishContext> {
+  const res = await tx.query<ContextRow>(
+    `SELECT
+       pt.id::text                 AS piece_technique_id,
+       pt.code_piece               AS code_piece,
+       pt.designation              AS designation_piece,
+       ptv.id::text                AS piece_technique_version_id,
+       ptv.indice                  AS indice,
+       ptv.plan_reference          AS plan_reference,
+       g.id::text                  AS gamme_id,
+       g.code                      AS gamme_code,
+       g.nom                       AS gamme_nom,
+       g.statut                    AS gamme_statut,
+       g.updated_at::text          AS gamme_updated_at,
+       o.id::text                  AS operation_id,
+       o.phase                     AS numero_operation,
+       o.designation               AS designation_operation,
+       o.type_operation            AS type_operation,
+       o.updated_at::text          AS operation_updated_at,
+       o.gamme_id::text            AS operation_gamme_id
+     FROM public.gammes g
+     JOIN public.piece_technique_versions ptv ON ptv.id = g.piece_technique_version_id
+     JOIN public.pieces_techniques pt ON pt.id = ptv.piece_technique_id
+     JOIN public.pieces_techniques_operations o ON o.id = $2::uuid
+     WHERE g.id = $1::uuid`,
+    [gammeId, operationId]
+  );
+  const row = res.rows[0];
+  if (!row) throw new HttpError(404, "NOT_FOUND", "Gamme ou opération introuvable.");
+
+  assertOperationBelongsToGamme(row.operation_gamme_id, gammeId);
+  assertOperationIsSubcontracting(row.type_operation);
+
+  const editable = row.gamme_statut === "BROUILLON" || row.gamme_statut === "EN_VALIDATION";
+  return {
+    piece_technique_id: row.piece_technique_id,
+    code_piece: row.code_piece,
+    designation_piece: row.designation_piece,
+    piece_technique_version_id: row.piece_technique_version_id,
+    indice: row.indice,
+    plan_reference: row.plan_reference,
+    gamme_id: row.gamme_id,
+    gamme_code: row.gamme_code,
+    gamme_nom: row.gamme_nom,
+    gamme_statut: row.gamme_statut,
+    gamme_updated_at: row.gamme_updated_at,
+    gamme_editable: editable,
+    operation_id: row.operation_id,
+    numero_operation: row.numero_operation,
+    designation_operation: row.designation_operation,
+    type_operation: row.type_operation,
+    operation_updated_at: row.operation_updated_at,
+  };
+}
+
+async function loadRevision(tx: Queryer, revisionId: string) {
+  const res = await tx.query<
+    RevisionRow & {
+      finish_code: string;
+      finish_designation: string;
+      finish_family: string;
+      finish_procede: string;
+      finish_statut: SurfaceFinishStatus;
+      finish_uuid: string;
+    }
+  >(
+    `SELECT ${revisionColumns("r")},
+            f.id::text            AS finish_uuid,
+            f.code                AS finish_code,
+            f.designation_courte  AS finish_designation,
+            f.family_code         AS finish_family,
+            f.procede             AS finish_procede,
+            f.statut              AS finish_statut
+     FROM public.surface_finish_revisions r
+     JOIN public.surface_finishes f ON f.id = r.finish_id
+     WHERE r.id = $1::uuid`,
+    [revisionId]
+  );
+  const row = res.rows[0];
+  if (!row) throw new HttpError(404, "NOT_FOUND", "Révision de finition introuvable.");
+  return {
+    revision: mapRevision(row),
+    finish: {
+      id: row.finish_uuid,
+      code: row.finish_code,
+      designation_courte: row.finish_designation,
+      family_code: row.finish_family,
+      procede: row.finish_procede,
+      statut: row.finish_statut,
+    },
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Héritage révision → opération                                              */
+/* -------------------------------------------------------------------------- */
+
+/** `undefined` hérite ; `null` efface explicitement ; une valeur écrase. */
+function inherit<T>(override: T | null | undefined, base: T | null): T | null {
+  if (override === undefined) return base;
+  return override;
+}
+
+export type ResolvedSpecInput = {
+  perimetre: FinishScope;
+  zones: string[];
+  masquages: string[];
+  norme: string | null;
+  classe: string | null;
+  epaisseur_min: number | null;
+  epaisseur_nominale: number | null;
+  epaisseur_max: number | null;
+  epaisseur_unite: string;
+  couleur: string | null;
+  teinte_ral: string | null;
+  aspect: string | null;
+  rugosite: string | null;
+  durete: string | null;
+  exigence_corrosion: string | null;
+  pretraitement: string | null;
+  posttraitement: string | null;
+  controles: string[];
+  certificat_requis: boolean;
+  certificat_type: string | null;
+  conditionnement: string | null;
+  unite_achat: string;
+  specification_client: string | null;
+  specification_client_version: string | null;
+  instructions: string | null;
+};
+
+/**
+ * Fusionne la révision (valeurs héritées) et les écarts saisis sur l'opération.
+ * Les paramètres propres à l'opération ne modifient JAMAIS la définition maître.
+ */
+export function resolveOperationSpec(
+  revision: SurfaceFinishRevisionDetail,
+  overrides: OperationOverridesDTO
+): ResolvedSpecInput {
+  const perimetre = overrides.perimetre ?? "PIECE_ENTIERE";
+  const zones = overrides.zones.length > 0 ? overrides.zones : revision.zones_defaut;
+  const masquages = overrides.masquages.length > 0 ? overrides.masquages : revision.regles_masquage;
+  const controles = overrides.controles.length > 0 ? overrides.controles : revision.controles;
+  const certificatRequis = overrides.certificat_requis ?? revision.certificat_requis;
+
+  return {
+    perimetre,
+    zones: perimetre === "PIECE_ENTIERE" ? [] : zones,
+    masquages,
+    norme: inherit(overrides.norme, revision.norme),
+    classe: inherit(overrides.classe, revision.classe),
+    epaisseur_min: inherit(overrides.epaisseur_min, revision.epaisseur_min),
+    epaisseur_nominale: inherit(overrides.epaisseur_nominale, revision.epaisseur_nominale),
+    epaisseur_max: inherit(overrides.epaisseur_max, revision.epaisseur_max),
+    epaisseur_unite: overrides.epaisseur_unite ?? revision.epaisseur_unite ?? "um",
+    couleur: inherit(overrides.couleur, revision.couleur),
+    teinte_ral: inherit(overrides.teinte_ral, revision.teinte_ral),
+    aspect: inherit(overrides.aspect, revision.aspect),
+    rugosite: inherit(overrides.rugosite, revision.rugosite),
+    durete: inherit(overrides.durete, revision.durete),
+    exigence_corrosion: inherit(overrides.exigence_corrosion, revision.exigence_corrosion),
+    pretraitement: inherit(overrides.pretraitement, revision.pretraitement),
+    posttraitement: inherit(overrides.posttraitement, revision.posttraitement),
+    controles,
+    certificat_requis: certificatRequis,
+    certificat_type: certificatRequis ? inherit(overrides.certificat_type, revision.certificat_type) : null,
+    conditionnement: inherit(overrides.conditionnement, revision.conditionnement_retour),
+    unite_achat: overrides.unite_achat ?? revision.unite_achat ?? "PCE",
+    specification_client: overrides.specification_client ?? null,
+    specification_client_version: overrides.specification_client_version ?? null,
+    instructions: overrides.instructions ?? null,
+  };
+}
+
+function formatThicknessSentence(spec: CanonicalFinishSpec): string | null {
+  const fmt = (value: number | null) => {
+    if (value === null) return null;
+    const rounded = Math.round(value * 100) / 100;
+    return Number.isInteger(rounded) ? String(rounded) : String(rounded).replace(".", ",");
+  };
+  const min = fmt(spec.epaisseur_min_um);
+  const nom = fmt(spec.epaisseur_nominale_um);
+  const max = fmt(spec.epaisseur_max_um);
+  if (!min && !nom && !max) return null;
+  if (nom && (min || max)) return `${nom} µm (${min ?? "—"} à ${max ?? "—"} µm)`;
+  if (nom) return `${nom} µm`;
+  if (min && max) return `${min} à ${max} µm`;
+  return `${min ?? max} µm min.`;
+}
+
+function zoneSentence(spec: CanonicalFinishSpec): string | null {
+  const parts: string[] = [];
+  if (spec.zones.length > 0) parts.push(`zones : ${spec.zones.join(", ")}`);
+  if (spec.masquages.length > 0) parts.push(`masquage : ${spec.masquages.join(", ")}`);
+  return parts.length > 0 ? parts.join(" ; ") : null;
+}
+
+const SCOPE_LABELS: Record<FinishScope, string> = {
+  PIECE_ENTIERE: "Pièce entière",
+  ZONES: "Zones désignées",
+  AUTRE: "Périmètre particulier",
+};
+
+export type GenerationResult = {
+  designation: string;
+  comment: string;
+  omitted_lines: string[];
+  template_version: number;
+};
+
+/**
+ * Rendu serveur de la désignation et du commentaire. `includeInstructions`
+ * distingue le texte porté par l'ARTICLE (identité) de celui affiché sur
+ * l'exigence de l'opération : les deux restent conservés séparément.
+ */
+export function generateTexts(params: {
+  context: OperationFinishContext;
+  finish: { code: string; designation_courte: string };
+  revision: SurfaceFinishRevisionDetail;
+  spec: CanonicalFinishSpec;
+}): GenerationResult {
+  const { context, finish, revision, spec } = params;
+
+  const designation = buildGeneratedDesignation({
+    code_piece: context.code_piece,
+    indice: context.indice,
+    finition_courte: finish.designation_courte,
+    teinte_ral: spec.teinte_ral,
+    couleur: spec.couleur,
+    epaisseur_nominale_um: spec.epaisseur_nominale_um,
+    epaisseur_min_um: spec.epaisseur_min_um,
+    classe: spec.classe,
+    perimetre: spec.perimetre,
+    zones: spec.zones,
+  });
+
+  const template = revision.commentaire_template ?? DEFAULT_COMMENT_TEMPLATE;
+  const teinteAspect = [spec.teinte_ral ?? spec.couleur, spec.aspect].filter(Boolean).join(" / ") || null;
+
+  const rendered = renderGeneratedComment(
+    template,
+    {
+      gamme_code: context.gamme_code ?? context.gamme_nom,
+      code_piece: context.code_piece,
+      designation_piece: context.designation_piece,
+      indice: context.indice,
+      plan_reference: context.plan_reference,
+      numero_operation: context.numero_operation,
+      designation_operation: context.designation_operation,
+      code_finition: finish.code,
+      designation_finition: finish.designation_courte,
+      revision_finition: revision.revision,
+      norme: spec.norme,
+      epaisseur: formatThicknessSentence(spec),
+      teinte_aspect: teinteAspect,
+      perimetre: SCOPE_LABELS[spec.perimetre],
+      zones_masquages: zoneSentence(spec),
+      certificat: spec.certificat_requis ? (spec.certificat_type ?? "Oui") : null,
+      controles: spec.controles.length > 0 ? spec.controles.join(", ") : null,
+      conditionnement: spec.conditionnement,
+      instructions: spec.instructions,
+    },
+    revision.template_version ?? GENERATION_TEMPLATE_VERSION
+  );
+
+  return {
+    designation,
+    comment: rendered.text,
+    omitted_lines: rendered.omitted_lines,
+    template_version: rendered.template_version,
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Correspondances d'articles                                                 */
+/* -------------------------------------------------------------------------- */
+
+type ArticleMatchRow = {
+  article_id: string;
+  code: string;
+  designation: string;
+  is_active: boolean;
+  status: string | null;
+  spec_fingerprint: string | null;
+  spec_canonical: CanonicalFinishSpec | null;
+  finish_revision_id: string | null;
+  piece_technique_version_id: string | null;
+  created_at: string;
+};
+
+const ARTICLE_MATCH_COLS = `
+  a.id::text                       AS article_id,
+  a.code                           AS code,
+  a.designation                    AS designation,
+  a.is_active                      AS is_active,
+  a.status                         AS status,
+  t.spec_fingerprint               AS spec_fingerprint,
+  t.spec_canonical                 AS spec_canonical,
+  t.finish_revision_id::text       AS finish_revision_id,
+  t.piece_technique_version_id::text AS piece_technique_version_id,
+  a.created_at::text               AS created_at
+`;
+
+/**
+ * Correspondance EXACTE : par empreinte, et seulement par empreinte. Jamais par
+ * désignation, jamais par ILIKE, jamais par référence fournisseur.
+ */
+async function findExactMatch(tx: Queryer, fingerprint: string): Promise<ArticleMatchRow | null> {
+  const res = await tx.query<ArticleMatchRow>(
+    `SELECT ${ARTICLE_MATCH_COLS}
+     FROM public.articles_traitement t
+     JOIN public.articles a ON a.id = t.article_id
+     WHERE t.spec_fingerprint = $1 AND t.superseded_at IS NULL
+     LIMIT 1`,
+    [fingerprint]
+  );
+  return res.rows[0] ?? null;
+}
+
+/**
+ * Correspondances PROCHES : même pièce/indice ou même révision de finition,
+ * empreinte différente. Elles servent à COMPARER, jamais à réutiliser
+ * automatiquement.
+ */
+async function findNearMatches(
+  tx: Queryer,
+  params: { fingerprint: string; versionId: string; revisionId: string; spec: CanonicalFinishSpec }
+): Promise<ArticleNearMatch[]> {
+  const res = await tx.query<ArticleMatchRow>(
+    `SELECT ${ARTICLE_MATCH_COLS}
+     FROM public.articles_traitement t
+     JOIN public.articles a ON a.id = t.article_id
+     WHERE t.superseded_at IS NULL
+       AND t.spec_fingerprint IS NOT NULL
+       AND t.spec_fingerprint <> $1
+       AND (t.piece_technique_version_id = $2::uuid OR t.finish_revision_id = $3::uuid)
+     ORDER BY (t.piece_technique_version_id = $2::uuid) DESC, a.created_at DESC
+     LIMIT 5`,
+    [params.fingerprint, params.versionId, params.revisionId]
+  );
+
+  return res.rows.map((row) => ({
+    article_id: row.article_id,
+    code: row.code,
+    designation: row.designation,
+    is_active: row.is_active,
+    status: row.status,
+    spec_fingerprint: row.spec_fingerprint,
+    finish_revision_id: row.finish_revision_id,
+    piece_technique_version_id: row.piece_technique_version_id,
+    created_at: row.created_at,
+    differences: row.spec_canonical
+      ? diffCanonicalSpecs(row.spec_canonical, params.spec).map((entry) => ({
+          field: String(entry.field),
+          existing: entry.left,
+          proposed: entry.right,
+        }))
+      : [{ field: "spec_canonical", existing: null, proposed: params.spec }],
+  }));
+}
+
+function toArticleMatch(row: ArticleMatchRow | null): ArticleMatch | null {
+  if (!row) return null;
+  return {
+    article_id: row.article_id,
+    code: row.code,
+    designation: row.designation,
+    is_active: row.is_active,
+    status: row.status,
+    spec_fingerprint: row.spec_fingerprint,
+    finish_revision_id: row.finish_revision_id,
+    piece_technique_version_id: row.piece_technique_version_id,
+    created_at: row.created_at,
+  };
+}
+
+/**
+ * Fournisseurs candidats — INFORMATIF. La finition maître n'impose jamais un
+ * fournisseur ; le catalogue reste la source du prix, du MOQ et du délai, et
+ * aucune de ces données n'entre dans l'empreinte.
+ */
+async function findSupplierCandidates(tx: Queryer, articleId: string | null): Promise<SupplierCandidate[]> {
+  const res = await tx.query<SupplierCandidate>(
+    `SELECT DISTINCT
+       f.id::text    AS fournisseur_id,
+       f.nom         AS fournisseur_nom,
+       f.code        AS fournisseur_code,
+       c.type        AS categorie,
+       h.statut      AS statut_qualification
+     FROM public.fournisseur_catalogue c
+     JOIN public.fournisseurs f ON f.id = c.fournisseur_id
+     LEFT JOIN public.fournisseur_homologations h
+       ON h.fournisseur_id = f.id AND h.is_current = true
+     WHERE c.actif = true
+       AND f.actif = true
+       AND (c.type = $1 OR ($2::uuid IS NOT NULL AND c.article_id = $2::uuid))
+     ORDER BY f.nom
+     LIMIT 20`,
+    [SUPPLIER_CATALOGUE_CATEGORY, articleId]
+  );
+  return res.rows;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Aperçu — LECTURE PURE                                                      */
+/* -------------------------------------------------------------------------- */
+
+function buildClassification(): PlannedArticleClassification {
+  return {
+    article_type: GENERATED_ARTICLE_TAXONOMY.article_type,
+    article_category: GENERATED_ARTICLE_TAXONOMY.article_category,
+    article_categories: [...GENERATED_ARTICLE_TAXONOMY.article_categories],
+    cat_label: "Traitement de Surface",
+    family_code: GENERATED_ARTICLE_TAXONOMY.default_family_code,
+    stock_managed: GENERATED_ARTICLE_TAXONOMY.stock_managed,
+    lot_tracking: GENERATED_ARTICLE_TAXONOMY.lot_tracking,
+    // Le code réel est alloué par le serveur à la confirmation : on annonce le
+    // format, jamais une valeur qui pourrait ne pas être celle attribuée.
+    code_hint: `ART-${GENERATED_ARTICLE_TAXONOMY.default_family_code}-…`,
+  };
+}
+
+export async function repoPreviewOperationFinish(
+  gammeId: string,
+  operationId: string,
+  body: PreviewFinishBodyDTO,
+  actor: { user_id: number; role: string | null }
+): Promise<SurfaceFinishPreview> {
+  const context = await loadContext(db, gammeId, operationId);
+  const { revision, finish } = await loadRevision(db, body.finish_revision_id);
+
+  const resolved = resolveOperationSpec(revision, body.overrides);
+  const spec = buildCanonicalFinishSpec({
+    piece_technique_version_id: context.piece_technique_version_id,
+    finish_revision_id: revision.id,
+    ...resolved,
+  });
+  const fingerprint = computeSpecFingerprint(spec);
+  const texts = generateTexts({ context, finish, revision, spec });
+
+  const exactRow = await findExactMatch(db, fingerprint);
+  const nearMatches = await findNearMatches(db, {
+    fingerprint,
+    versionId: context.piece_technique_version_id,
+    revisionId: revision.id,
+    spec,
+  });
+  const suppliers = await findSupplierCandidates(db, exactRow?.article_id ?? null);
+
+  const existingLine = await db.query<{ id: string }>(
+    `SELECT id::text AS id FROM public.pieces_techniques_achats
+     WHERE gamme_operation_id = $1::uuid AND type_achat = $2`,
+    [operationId, PURCHASE_LINE_TYPE]
+  );
+
+  const warnings: Array<{ code: string; message: string }> = [];
+  if (!context.gamme_editable) {
+    warnings.push({
+      code: "GAMME_NOT_EDITABLE",
+      message: `Cette gamme est ${context.gamme_statut.toLowerCase()} : créez une nouvelle gamme ou un nouvel indice pour changer sa finition.`,
+    });
+  }
+  if (revision.statut !== "ACTIVE") {
+    warnings.push({
+      code: "FINISH_REVISION_INACTIVE",
+      message: `La révision ${revision.revision} est ${revision.statut.toLowerCase()} : elle ne peut pas être appliquée à une gamme.`,
+    });
+  }
+  if (statusIsHistoricalOnly(finish.statut)) {
+    warnings.push({
+      code: "FINISH_HISTORICAL",
+      message: "Cette finition n'est plus proposée au catalogue ; elle reste lisible dans l'historique.",
+    });
+  }
+  if (exactRow && !exactRow.is_active) {
+    warnings.push({
+      code: "ARTICLE_EXACT_MATCH_INACTIVE",
+      message: `L'article ${exactRow.code} correspond exactement mais il est inactif : réactivez-le ou créez un article distinct.`,
+    });
+  }
+  if (spec.certificat_requis && !spec.certificat_type) {
+    warnings.push({
+      code: "CERTIFICATE_TYPE_MISSING",
+      message: "Un certificat est exigé sans type précisé.",
+    });
+  }
+  if (suppliers.length === 0) {
+    warnings.push({
+      code: "NO_SUPPLIER_CANDIDATE",
+      message: "Aucun fournisseur de sous-traitance qualifié au catalogue : l'article restera à approvisionner.",
+    });
+  }
+
+  const capabilities = surfaceFinishCapabilitiesFor(actor.role);
+  const allowed: string[] = [];
+  if (exactRow) {
+    if (exactRow.is_active) allowed.push("REUSE");
+    if (capabilities.article_force_create) allowed.push("FORCE_CREATE");
+  } else if (capabilities.article_resolve) {
+    allowed.push("CREATE");
+  }
+
+  const previewHash = computePreviewHash({
+    gamme_id: context.gamme_id,
+    operation_id: context.operation_id,
+    spec_fingerprint: fingerprint,
+    exact_match_article_id: exactRow?.article_id ?? null,
+    designation: texts.designation,
+    comment: texts.comment,
+    gamme_updated_at: context.gamme_updated_at,
+    operation_updated_at: context.operation_updated_at,
+  });
+
+  const quality: QualityRequirementPreview = {
+    certificat_requis: spec.certificat_requis,
+    certificat_type: spec.certificat_type,
+    controles: spec.controles,
+    criteres_acceptation: revision.criteres_acceptation,
+    conditionnement: spec.conditionnement,
+  };
+
+  const purchaseLine: PlannedPurchaseLine = {
+    type_achat: PURCHASE_LINE_TYPE,
+    quantite: body.quantite,
+    unite: spec.unite_achat,
+    designation_snapshot: texts.designation,
+    gamme_operation_id: context.operation_id,
+    piece_technique_version_id: context.piece_technique_version_id,
+    existing_line_id: existingLine.rows[0]?.id ?? null,
+  };
+
+  return {
+    context,
+    finish,
+    revision,
+    spec_canonical: spec,
+    spec_fingerprint: fingerprint,
+    generated_designation: texts.designation,
+    generated_comment: texts.comment,
+    omitted_comment_lines: texts.omitted_lines,
+    template_version: texts.template_version,
+    classification: buildClassification(),
+    exact_match: toArticleMatch(exactRow),
+    near_matches: nearMatches,
+    purchase_line: purchaseLine,
+    suppliers,
+    quality,
+    warnings,
+    capabilities,
+    allowed_decisions: allowed,
+    preview_hash: previewHash,
+    generated_at: new Date().toISOString(),
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Exigence posée sur une opération                                           */
+/* -------------------------------------------------------------------------- */
+
+const REQUIREMENT_COLS = `
+  fin.id::text                        AS id,
+  fin.gamme_id::text                  AS gamme_id,
+  fin.gamme_operation_id::text        AS gamme_operation_id,
+  fin.piece_technique_version_id::text AS piece_technique_version_id,
+  fin.finish_revision_id::text        AS finish_revision_id,
+  sf.id::text                         AS finish_id,
+  sf.code                             AS finish_code,
+  sf.designation_courte               AS finish_designation,
+  r.revision                          AS revision,
+  r.statut                            AS revision_statut,
+  fin.perimetre                       AS perimetre,
+  fin.zones                           AS zones,
+  fin.masquages                       AS masquages,
+  fin.instructions                    AS instructions,
+  fin.spec_fingerprint                AS spec_fingerprint,
+  fin.article_id::text                AS article_id,
+  a.code                              AS article_code,
+  a.designation                       AS article_designation,
+  fin.achat_ligne_id::text            AS achat_ligne_id,
+  fin.generated_designation           AS generated_designation,
+  fin.generated_comment               AS generated_comment,
+  fin.designation_override            AS designation_override,
+  fin.comment_override                AS comment_override,
+  fin.updated_at::text                AS updated_at
+`;
+
+const REQUIREMENT_FROM = `
+  FROM public.gamme_operation_finitions fin
+  JOIN public.surface_finish_revisions r ON r.id = fin.finish_revision_id
+  JOIN public.surface_finishes sf ON sf.id = r.finish_id
+  LEFT JOIN public.articles a ON a.id = fin.article_id
+`;
+
+type RequirementRow = Omit<OperationFinishRequirement, "zones" | "masquages"> & {
+  zones: string[] | null;
+  masquages: string[] | null;
+};
+
+function mapRequirement(row: RequirementRow): OperationFinishRequirement {
+  return { ...row, zones: row.zones ?? [], masquages: row.masquages ?? [] };
+}
+
+export async function repoGetOperationFinish(
+  gammeId: string,
+  operationId: string
+): Promise<OperationFinishRequirement | null> {
+  const res = await db.query<RequirementRow>(
+    `SELECT ${REQUIREMENT_COLS} ${REQUIREMENT_FROM}
+     WHERE fin.gamme_id = $1::uuid AND fin.gamme_operation_id = $2::uuid`,
+    [gammeId, operationId]
+  );
+  const row = res.rows[0];
+  return row ? mapRequirement(row) : null;
+}
+
+async function readRequirement(tx: Queryer, operationId: string): Promise<OperationFinishRequirement | null> {
+  const res = await tx.query<RequirementRow>(
+    `SELECT ${REQUIREMENT_COLS} ${REQUIREMENT_FROM} WHERE fin.gamme_operation_id = $1::uuid`,
+    [operationId]
+  );
+  const row = res.rows[0];
+  return row ? mapRequirement(row) : null;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Confirmation — UNE transaction, tout ou rien                               */
+/* -------------------------------------------------------------------------- */
+
+function nextActions(articleId: string, pieceId: string, versionId: string) {
+  return [
+    { key: "article", label: "Ouvrir la fiche Article", href: `/stock/articles/${articleId}` },
+    { key: "achats", label: "Voir la ligne d'achat", href: `/pieces-techniques/${pieceId}?tab=achats&version=${versionId}` },
+    { key: "fournisseurs", label: "Ajouter un fournisseur", href: `/stock/articles/${articleId}?tab=fournisseurs` },
+    { key: "gamme", label: "Revenir à la gamme", href: `/pieces-techniques/${pieceId}?tab=gammes&version=${versionId}` },
+  ];
+}
+
+export async function repoConfirmOperationFinish(
+  gammeId: string,
+  operationId: string,
+  body: ConfirmFinishBodyDTO,
+  audit: AuditContext,
+  actor: { role: string | null },
+  idempotencyKey: string
+): Promise<ConfirmFinishResult> {
+  const commandType = "surface_finish.confirm";
+  const incomingHash = requestHash(commandType, { gammeId, operationId, body });
+
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+
+    /* 1) Idempotence — le reçu est verrouillé AVANT tout effet de bord. */
+    const receipt = await client.query<{ request_hash: string; result: ConfirmFinishResult }>(
+      `SELECT request_hash, result FROM public.surface_finish_command_receipts
+       WHERE idempotency_key = $1`,
+      [idempotencyKey]
+    );
+    const existing = receipt.rows[0];
+    const decisionKind = decideReceipt(existing?.request_hash, incomingHash);
+    assertNoIdempotencyConflict(decisionKind);
+    if (decisionKind === "REPLAY") {
+      await client.query("ROLLBACK");
+      return existing.result;
+    }
+
+    /* 2) Contexte, appartenance, type d'opération, modifiabilité. */
+    const context = await loadContext(client, gammeId, operationId);
+    assertGammeEditable(context.gamme_statut);
+
+    // Verrous : la gamme sérialise ses opérations, l'opération sérialise sa finition.
+    await client.query(`SELECT 1 FROM public.gammes WHERE id = $1::uuid FOR UPDATE`, [gammeId]);
+    await client.query(`SELECT 1 FROM public.pieces_techniques_operations WHERE id = $1::uuid FOR UPDATE`, [operationId]);
+
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_gamme_updated_at,
+      currentUpdatedAt: context.gamme_updated_at,
+      label: "Cette gamme",
+    });
+    if (context.operation_updated_at && body.expected_operation_updated_at) {
+      assertOptimisticVersion({
+        expectedUpdatedAt: body.expected_operation_updated_at,
+        currentUpdatedAt: context.operation_updated_at,
+        label: "Cette opération",
+      });
+    }
+
+    /* 3) Révision active obligatoire. */
+    const { revision, finish } = await loadRevision(client, body.finish_revision_id);
+    assertRevisionSelectable(revision.statut);
+
+    /* 4) Recalcul serveur de la spécification et de l'empreinte. */
+    const resolved = resolveOperationSpec(revision, body.overrides);
+    const spec = buildCanonicalFinishSpec({
+      piece_technique_version_id: context.piece_technique_version_id,
+      finish_revision_id: revision.id,
+      ...resolved,
+    });
+    const fingerprint = computeSpecFingerprint(spec);
+    if (fingerprint !== body.spec_fingerprint) {
+      throw new HttpError(
+        409,
+        "PREVIEW_STALE",
+        "La spécification a changé depuis l'aperçu : rechargez avant de confirmer."
+      );
+    }
+
+    const texts = generateTexts({ context, finish, revision, spec });
+
+    /* 5) Fraîcheur de l'aperçu — il couvre aussi l'article exact du moment. */
+    const exactRow = await findExactMatch(client, fingerprint);
+    const currentPreviewHash = computePreviewHash({
+      gamme_id: context.gamme_id,
+      operation_id: context.operation_id,
+      spec_fingerprint: fingerprint,
+      exact_match_article_id: exactRow?.article_id ?? null,
+      designation: texts.designation,
+      comment: texts.comment,
+      gamme_updated_at: context.gamme_updated_at,
+      operation_updated_at: context.operation_updated_at,
+    });
+    assertPreviewFresh(body.preview_hash, currentPreviewHash);
+
+    /* 6) Arbitrage de la décision. */
+    const decision: ArticleDecision = body.decision;
+    assertArticleDecisionConsistent({
+      decision,
+      state: {
+        exactMatchArticleId: exactRow?.article_id ?? null,
+        exactMatchIsActive: Boolean(exactRow?.is_active),
+      },
+      requestedArticleId: body.article_id,
+      role: actor.role,
+      justification: body.justification,
+    });
+
+    /* 7) Article : réutilisation ou création via le service Article canonique. */
+    let articleId: string;
+    let articleCode: string;
+    let articleDesignation: string;
+    let result: ConfirmFinishResult["result"];
+    let articleCategories: string[] = [...GENERATED_ARTICLE_TAXONOMY.article_categories];
+    let articleFamily: string = GENERATED_ARTICLE_TAXONOMY.default_family_code;
+
+    if (decision === "REUSE" && exactRow) {
+      articleId = exactRow.article_id;
+      articleCode = exactRow.code;
+      articleDesignation = exactRow.designation;
+      result = "REUSED";
+      const cats = await client.query<{ category_code: string }>(
+        `SELECT category_code FROM public.article_category_link WHERE article_id = $1::uuid ORDER BY is_primary DESC`,
+        [articleId]
+      );
+      articleCategories = cats.rows.map((row) => row.category_code);
+      const fam = await client.query<{ family_code: string }>(
+        `SELECT family_code FROM public.articles WHERE id = $1::uuid`,
+        [articleId]
+      );
+      articleFamily = fam.rows[0]?.family_code ?? articleFamily;
+    } else {
+      const created = await repoCreateArticleTx(
+        client,
+        {
+          designation: texts.designation,
+          designation_secondary: null,
+          article_type: GENERATED_ARTICLE_TAXONOMY.article_type,
+          article_category: GENERATED_ARTICLE_TAXONOMY.article_category,
+          article_categories: [...GENERATED_ARTICLE_TAXONOMY.article_categories],
+          family_code: GENERATED_ARTICLE_TAXONOMY.default_family_code,
+          // Une prestation ne se stocke pas : la pièce traitée et ses lots
+          // restent tracés par les domaines OF, sous-traitance et réception.
+          stock_managed: GENERATED_ARTICLE_TAXONOMY.stock_managed,
+          lot_tracking: GENERATED_ARTICLE_TAXONOMY.lot_tracking,
+          is_sold: false,
+          is_active: true,
+          unite: spec.unite_achat,
+          notes: texts.comment,
+          status: "VALIDE",
+          projet_id: null,
+          piece_technique_id: null,
+        } satisfies CreateArticleBodyDTO,
+        audit
+      );
+      articleId = created.id;
+      articleCode = created.code;
+      articleDesignation = texts.designation;
+      articleCategories = created.article_categories;
+      articleFamily = created.family_code;
+      result = "CREATED";
+
+      // La spécialisation porte l'identité technique. L'index partiel unique
+      // sur `spec_fingerprint` fait échouer ici une seconde création
+      // concurrente : c'est la base qui garantit l'unicité, pas la lecture.
+      await client.query(
+        `UPDATE public.articles_traitement
+         SET piece_technique_id = $2::uuid,
+             piece_technique_version_id = $3::uuid,
+             finish_revision_id = $4::uuid,
+             spec_fingerprint = $5,
+             spec_canonical = $6::jsonb,
+             generated_designation = $7,
+             generated_comment = $8,
+             template_version = $9,
+             origin = 'GAMME_FINITION',
+             created_by = COALESCE(created_by, $10),
+             updated_at = now()
+         WHERE article_id = $1::uuid`,
+        [
+          articleId,
+          context.piece_technique_id,
+          context.piece_technique_version_id,
+          revision.id,
+          fingerprint,
+          JSON.stringify(spec),
+          texts.designation,
+          texts.comment,
+          texts.template_version,
+          audit.user_id,
+        ]
+      );
+    }
+
+    /* 8) Exigence de finition — créée ou mise à jour, jamais dupliquée. */
+    const previous = await readRequirement(client, operationId);
+    if (previous && body.expected_finition_updated_at) {
+      assertOptimisticVersion({
+        expectedUpdatedAt: body.expected_finition_updated_at,
+        currentUpdatedAt: previous.updated_at,
+        label: "Cette exigence de finition",
+      });
+    }
+    if (previous && result === "REUSED" && previous.article_id === articleId) {
+      result = "LINKED";
+    }
+
+    const requirementValues = [
+      context.gamme_id,
+      context.operation_id,
+      context.piece_technique_version_id,
+      revision.id,
+      spec.perimetre,
+      spec.zones,
+      spec.masquages,
+      resolved.norme,
+      resolved.classe,
+      resolved.epaisseur_min,
+      resolved.epaisseur_nominale,
+      resolved.epaisseur_max,
+      normalizeThicknessUnit(resolved.epaisseur_unite),
+      resolved.couleur,
+      resolved.teinte_ral,
+      resolved.aspect,
+      resolved.rugosite,
+      resolved.durete,
+      resolved.exigence_corrosion,
+      resolved.pretraitement,
+      resolved.posttraitement,
+      spec.controles,
+      spec.certificat_requis,
+      spec.certificat_type,
+      resolved.conditionnement,
+      spec.unite_achat,
+      resolved.specification_client,
+      resolved.specification_client_version,
+      resolved.instructions,
+      JSON.stringify(spec),
+      fingerprint,
+      articleId,
+      texts.designation,
+      texts.comment,
+      texts.template_version,
+      audit.user_id,
+    ];
+
+    await client.query(
+      `INSERT INTO public.gamme_operation_finitions (
+         gamme_id, gamme_operation_id, piece_technique_version_id, finish_revision_id,
+         perimetre, zones, masquages,
+         norme, classe, epaisseur_min, epaisseur_nominale, epaisseur_max, epaisseur_unite,
+         couleur, teinte_ral, aspect, rugosite, durete, exigence_corrosion,
+         pretraitement, posttraitement,
+         controles, certificat_requis, certificat_type, conditionnement, unite_achat,
+         specification_client, specification_client_version, instructions,
+         spec_canonical, spec_fingerprint, article_id,
+         generated_designation, generated_comment, template_version,
+         created_by, updated_by
+       ) VALUES (
+         $1::uuid,$2::uuid,$3::uuid,$4::uuid,
+         $5,$6,$7,
+         $8,$9,$10,$11,$12,$13,
+         $14,$15,$16,$17,$18,$19,
+         $20,$21,
+         $22,$23,$24,$25,$26,
+         $27,$28,$29,
+         $30::jsonb,$31,$32::uuid,
+         $33,$34,$35,
+         $36,$36
+       )
+       ON CONFLICT (gamme_operation_id) DO UPDATE SET
+         gamme_id = EXCLUDED.gamme_id,
+         piece_technique_version_id = EXCLUDED.piece_technique_version_id,
+         finish_revision_id = EXCLUDED.finish_revision_id,
+         perimetre = EXCLUDED.perimetre,
+         zones = EXCLUDED.zones,
+         masquages = EXCLUDED.masquages,
+         norme = EXCLUDED.norme,
+         classe = EXCLUDED.classe,
+         epaisseur_min = EXCLUDED.epaisseur_min,
+         epaisseur_nominale = EXCLUDED.epaisseur_nominale,
+         epaisseur_max = EXCLUDED.epaisseur_max,
+         epaisseur_unite = EXCLUDED.epaisseur_unite,
+         couleur = EXCLUDED.couleur,
+         teinte_ral = EXCLUDED.teinte_ral,
+         aspect = EXCLUDED.aspect,
+         rugosite = EXCLUDED.rugosite,
+         durete = EXCLUDED.durete,
+         exigence_corrosion = EXCLUDED.exigence_corrosion,
+         pretraitement = EXCLUDED.pretraitement,
+         posttraitement = EXCLUDED.posttraitement,
+         controles = EXCLUDED.controles,
+         certificat_requis = EXCLUDED.certificat_requis,
+         certificat_type = EXCLUDED.certificat_type,
+         conditionnement = EXCLUDED.conditionnement,
+         unite_achat = EXCLUDED.unite_achat,
+         specification_client = EXCLUDED.specification_client,
+         specification_client_version = EXCLUDED.specification_client_version,
+         instructions = EXCLUDED.instructions,
+         spec_canonical = EXCLUDED.spec_canonical,
+         spec_fingerprint = EXCLUDED.spec_fingerprint,
+         article_id = EXCLUDED.article_id,
+         generated_designation = EXCLUDED.generated_designation,
+         generated_comment = EXCLUDED.generated_comment,
+         template_version = EXCLUDED.template_version,
+         updated_by = EXCLUDED.updated_by,
+         updated_at = now()`,
+      requirementValues
+    );
+
+    /* 9) Ligne de nomenclature d'achat — liée par FK, jamais par la phase. */
+    const lineRes = await client.query<{ id: string; quantite: string }>(
+      `INSERT INTO public.pieces_techniques_achats (
+         piece_technique_id, phase, article_id, quantite, unite_prix,
+         designation, designation_snapshot, type_achat,
+         gamme_operation_id, gamme_id, piece_technique_version_id, source
+       ) VALUES (
+         $1::uuid, $2, $3::uuid, $4, $5,
+         $6, $6, $7,
+         $8::uuid, $9::uuid, $10::uuid, 'GAMME_FINITION'
+       )
+       ON CONFLICT (gamme_operation_id) WHERE gamme_operation_id IS NOT NULL AND type_achat = 'TRAITEMENT'
+       DO UPDATE SET
+         article_id = EXCLUDED.article_id,
+         quantite = EXCLUDED.quantite,
+         unite_prix = EXCLUDED.unite_prix,
+         designation = EXCLUDED.designation,
+         designation_snapshot = EXCLUDED.designation_snapshot,
+         gamme_id = EXCLUDED.gamme_id,
+         piece_technique_version_id = EXCLUDED.piece_technique_version_id,
+         phase = EXCLUDED.phase,
+         updated_at = now()
+       RETURNING id::text AS id, quantite::text AS quantite`,
+      [
+        context.piece_technique_id,
+        context.numero_operation,
+        articleId,
+        body.quantite,
+        spec.unite_achat,
+        texts.designation,
+        PURCHASE_LINE_TYPE,
+        context.operation_id,
+        context.gamme_id,
+        context.piece_technique_version_id,
+      ]
+    );
+    const purchaseLineId = lineRes.rows[0].id;
+
+    await client.query(
+      `UPDATE public.gamme_operation_finitions SET achat_ligne_id = $2::uuid, updated_at = now()
+       WHERE gamme_operation_id = $1::uuid`,
+      [operationId, purchaseLineId]
+    );
+
+    /* 10) Audit append-only — la décision reste explicable des mois plus tard. */
+    await insertFinishAudit(client, audit, "finitions.operation.confirm", "gamme_operation_finition", operationId, {
+      gamme_id: context.gamme_id,
+      piece_technique_version_id: context.piece_technique_version_id,
+      finish_revision_id: revision.id,
+      finish_code: finish.code,
+      spec_fingerprint: fingerprint,
+      preview_hash: body.preview_hash,
+      decision,
+      result,
+      article_id: articleId,
+      article_code: articleCode,
+      exact_match_article_id: exactRow?.article_id ?? null,
+      justification: decision === "FORCE_CREATE" ? body.justification : null,
+      generated_designation: texts.designation,
+      template_version: texts.template_version,
+      achat_ligne_id: purchaseLineId,
+      idempotency_key: idempotencyKey,
+    });
+
+    const requirement = await readRequirement(client, operationId);
+    if (!requirement) throw new Error("Failed to read finish requirement after write");
+
+    const payload: ConfirmFinishResult = {
+      result,
+      article: {
+        id: articleId,
+        code: articleCode,
+        designation: articleDesignation,
+        article_type: GENERATED_ARTICLE_TAXONOMY.article_type,
+        article_category: GENERATED_ARTICLE_TAXONOMY.article_category,
+        article_categories: articleCategories,
+        family_code: articleFamily,
+        stock_managed: GENERATED_ARTICLE_TAXONOMY.stock_managed,
+        lot_tracking: GENERATED_ARTICLE_TAXONOMY.lot_tracking,
+      },
+      requirement,
+      purchase_line: {
+        id: purchaseLineId,
+        type_achat: PURCHASE_LINE_TYPE,
+        quantite: Number(lineRes.rows[0].quantite),
+        designation_snapshot: texts.designation,
+      },
+      next_actions: nextActions(articleId, context.piece_technique_id, context.piece_technique_version_id),
+    };
+
+    await client.query(
+      `INSERT INTO public.surface_finish_command_receipts (idempotency_key, command_type, request_hash, result, user_id)
+       VALUES ($1,$2,$3,$4::jsonb,$5)`,
+      [idempotencyKey, commandType, incomingHash, JSON.stringify(payload), audit.user_id]
+    );
+
+    await client.query("COMMIT");
+    return payload;
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    // Deux confirmations réellement concurrentes : la seconde perd la course sur
+    // l'index d'unicité. On la renvoie vers l'aperçu plutôt que vers un 500.
+    if ((err as { code?: string } | null)?.code === "23505") {
+      throw new HttpError(
+        409,
+        "ARTICLE_EXACT_MATCH_CHANGED",
+        "Un article portant cette empreinte vient d'être créé : rechargez l'aperçu pour le réutiliser."
+      );
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Retrait de l'exigence                                                      */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Retire l'exigence d'une opération. L'ARTICLE et la ligne d'achat ne sont
+ * jamais supprimés en silence : la ligne est détachée de l'opération et
+ * conservée, l'article reste au référentiel.
+ */
+export async function repoDetachOperationFinish(
+  gammeId: string,
+  operationId: string,
+  body: DetachFinishBodyDTO,
+  audit: AuditContext
+): Promise<{ detached: true }> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const context = await loadContext(client, gammeId, operationId);
+    assertGammeEditable(context.gamme_statut);
+
+    const current = await client.query<{ id: string; updated_at: string; article_id: string | null; achat_ligne_id: string | null }>(
+      `SELECT id::text AS id, updated_at::text AS updated_at, article_id::text AS article_id,
+              achat_ligne_id::text AS achat_ligne_id
+       FROM public.gamme_operation_finitions
+       WHERE gamme_operation_id = $1::uuid FOR UPDATE`,
+      [operationId]
+    );
+    const row = current.rows[0];
+    if (!row) throw new HttpError(404, "NOT_FOUND", "Aucune finition configurée sur cette opération.");
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: row.updated_at,
+      label: "Cette exigence de finition",
+    });
+
+    if (row.achat_ligne_id) {
+      await client.query(
+        `UPDATE public.pieces_techniques_achats
+         SET gamme_operation_id = NULL, source = 'MANUEL', updated_at = now()
+         WHERE id = $1::uuid`,
+        [row.achat_ligne_id]
+      );
+    }
+    await client.query(`DELETE FROM public.gamme_operation_finitions WHERE gamme_operation_id = $1::uuid`, [operationId]);
+
+    await insertFinishAudit(client, audit, "finitions.operation.detach", "gamme_operation_finition", operationId, {
+      gamme_id: gammeId,
+      motif: body.motif,
+      article_id: row.article_id,
+      achat_ligne_id: row.achat_ligne_id,
+      // L'article et la ligne d'achat SURVIVENT : rien n'est supprimé ici.
+      article_deleted: false,
+      purchase_line_deleted: false,
+    });
+
+    await client.query("COMMIT");
+    return { detached: true };
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/** Exposé pour les tests de politique : la capacité conditionne les décisions. */
+export function decisionsAllowedFor(role: string | null, hasExactMatch: boolean, exactIsActive: boolean): string[] {
+  const out: string[] = [];
+  if (hasExactMatch) {
+    if (exactIsActive) out.push("REUSE");
+    if (roleHasSurfaceFinishCapability(role, "article_force_create")) out.push("FORCE_CREATE");
+  } else if (roleHasSurfaceFinishCapability(role, "article_resolve")) {
+    out.push("CREATE");
+  }
+  return out;
+}
+
+export { thicknessToMicrometers };

--- a/src/module/surface-finish/routes/surface-finish-gamme.routes.ts
+++ b/src/module/surface-finish/routes/surface-finish-gamme.routes.ts
@@ -1,0 +1,62 @@
+// #210 — Configuration de la finition d'une opération de gamme.
+//
+// Monté sur /api/v1/gammes AVANT le routeur historique des gammes : ces routes
+// déclarent des capacités fines et ne doivent hériter d'aucun garde hérité.
+// Le routeur historique reste inchangé pour les écrans en production.
+
+import { Router } from "express";
+
+import {
+  confirmOperationFinish,
+  detachOperationFinish,
+  getOperationFinish,
+  previewOperationFinish,
+} from "../controllers/surface-finish.controller";
+import { requireSurfaceFinishCapability } from "../middlewares/surface-finish-authorization.middleware";
+import {
+  confirmFinishBodySchema,
+  detachFinishBodySchema,
+  operationFinishParamsSchema,
+  previewFinishBodySchema,
+  validate,
+} from "../validators/surface-finish.validators";
+
+const router = Router();
+
+const params = validate(operationFinishParamsSchema, "params");
+
+router.get(
+  "/:gammeId/operations/:operationId/finition",
+  requireSurfaceFinishCapability("library_read"),
+  params,
+  getOperationFinish
+);
+
+// Aperçu : lecture pure. Une capacité de prévisualisation suffit — les Achats
+// doivent pouvoir regarder sans pouvoir écrire.
+router.post(
+  "/:gammeId/operations/:operationId/finition/preview",
+  requireSurfaceFinishCapability("article_preview"),
+  params,
+  validate(previewFinishBodySchema),
+  previewOperationFinish
+);
+
+// Confirmation : commande transactionnelle, clé d'idempotence obligatoire.
+router.post(
+  "/:gammeId/operations/:operationId/finition/confirm",
+  requireSurfaceFinishCapability("article_resolve"),
+  params,
+  validate(confirmFinishBodySchema),
+  confirmOperationFinish
+);
+
+router.delete(
+  "/:gammeId/operations/:operationId/finition",
+  requireSurfaceFinishCapability("operation_configure"),
+  params,
+  validate(detachFinishBodySchema),
+  detachOperationFinish
+);
+
+export default router;

--- a/src/module/surface-finish/routes/surface-finish.routes.ts
+++ b/src/module/surface-finish/routes/surface-finish.routes.ts
@@ -1,0 +1,96 @@
+// #210 — Routeur bibliothèque de finitions, monté sur /api/v1/finitions.
+// Chaque route déclare sa capacité : refus par défaut, aucun droit implicite.
+
+import { Router } from "express";
+
+import {
+  attachRevisionDocument,
+  createFinish,
+  createRevision,
+  getFinish,
+  listFinishes,
+  listFinishFamilies,
+  listRevisionDocuments,
+  readCapabilities,
+  revisionImpact,
+  transitionRevision,
+  updateFinish,
+  updateRevision,
+} from "../controllers/surface-finish.controller";
+import { requireSurfaceFinishCapability } from "../middlewares/surface-finish-authorization.middleware";
+import {
+  attachDocumentBodySchema,
+  createFinishBodySchema,
+  createRevisionBodySchema,
+  listFinishesQuerySchema,
+  transitionRevisionBodySchema,
+  updateFinishBodySchema,
+  updateRevisionBodySchema,
+  validate,
+} from "../validators/surface-finish.validators";
+
+// `authenticateToken` est déjà appliqué globalement dans v1.routes.ts.
+const router = Router();
+
+router.get("/capabilities", readCapabilities);
+
+router.get("/familles", requireSurfaceFinishCapability("library_read"), listFinishFamilies);
+
+router.get(
+  "/",
+  requireSurfaceFinishCapability("library_read"),
+  validate(listFinishesQuerySchema, "query"),
+  listFinishes
+);
+
+router.post(
+  "/",
+  requireSurfaceFinishCapability("library_draft_create"),
+  validate(createFinishBodySchema),
+  createFinish
+);
+
+router.get("/:finishId", requireSurfaceFinishCapability("library_read"), getFinish);
+
+router.patch(
+  "/:finishId",
+  requireSurfaceFinishCapability("library_draft_write"),
+  validate(updateFinishBodySchema),
+  updateFinish
+);
+
+router.post(
+  "/:finishId/revisions",
+  requireSurfaceFinishCapability("library_draft_write"),
+  validate(createRevisionBodySchema),
+  createRevision
+);
+
+router.patch(
+  "/revisions/:revisionId",
+  requireSurfaceFinishCapability("library_draft_write"),
+  validate(updateRevisionBodySchema),
+  updateRevision
+);
+
+// La transition affine encore la capacité côté service (soumettre / approuver /
+// retirer ne sont pas le même acte).
+router.post(
+  "/revisions/:revisionId/transition",
+  requireSurfaceFinishCapability("library_read"),
+  validate(transitionRevisionBodySchema),
+  transitionRevision
+);
+
+router.get("/revisions/:revisionId/impact", requireSurfaceFinishCapability("library_read"), revisionImpact);
+
+router.get("/revisions/:revisionId/documents", requireSurfaceFinishCapability("documents_read"), listRevisionDocuments);
+
+router.post(
+  "/revisions/:revisionId/documents",
+  requireSurfaceFinishCapability("documents_write"),
+  validate(attachDocumentBodySchema),
+  attachRevisionDocument
+);
+
+export default router;

--- a/src/module/surface-finish/services/surface-finish.service.ts
+++ b/src/module/surface-finish/services/surface-finish.service.ts
@@ -1,0 +1,193 @@
+// #210 — Services de la bibliothèque de finitions. La couche service applique
+// les règles qui dépendent de l'ACTEUR (capacités fines, override d'un texte
+// généré) et délègue la persistance au repository.
+
+import { HttpError } from "../../../utils/httpError";
+import type { AuditContext } from "../../pieces-techniques/repository/pieces-techniques.repository";
+import {
+  assertSurfaceFinishCapability,
+  normalizeIdempotencyKey,
+  surfaceFinishCapabilitiesFor,
+  type SurfaceFinishCapability,
+} from "../domain/surface-finish-policy";
+import {
+  repoAttachRevisionDocument,
+  repoCreateFinishDraft,
+  repoCreateRevision,
+  repoGetFinish,
+  repoListFinishes,
+  repoListFinishFamilies,
+  repoListRevisionDocuments,
+  repoRevisionImpact,
+  repoTransitionRevision,
+  repoUpdateFinishDraft,
+  repoUpdateRevision,
+  type RevisionImpact,
+} from "../repository/surface-finish-library.repository";
+import {
+  repoConfirmOperationFinish,
+  repoDetachOperationFinish,
+  repoGetOperationFinish,
+  repoPreviewOperationFinish,
+} from "../repository/surface-finish-resolution.repository";
+import type {
+  AttachDocumentBodyDTO,
+  ConfirmFinishBodyDTO,
+  CreateFinishBodyDTO,
+  DetachFinishBodyDTO,
+  ListFinishesQueryDTO,
+  PreviewFinishBodyDTO,
+  RevisionPayloadDTO,
+  TransitionRevisionBodyDTO,
+  UpdateFinishBodyDTO,
+  UpdateRevisionBodyDTO,
+} from "../validators/surface-finish.validators";
+import type {
+  ConfirmFinishResult,
+  OperationFinishRequirement,
+  SurfaceFinishDetail,
+  SurfaceFinishDocument,
+  SurfaceFinishFamily,
+  SurfaceFinishListResult,
+  SurfaceFinishPreview,
+  SurfaceFinishRevisionDetail,
+} from "../types/surface-finish.types";
+
+export type Actor = { user_id: number; role: string | null };
+
+export async function listFinishFamiliesSVC(): Promise<SurfaceFinishFamily[]> {
+  return repoListFinishFamilies();
+}
+
+export async function listFinishesSVC(filters: ListFinishesQueryDTO): Promise<SurfaceFinishListResult> {
+  return repoListFinishes(filters);
+}
+
+export async function getFinishSVC(finishId: string): Promise<SurfaceFinishDetail> {
+  const finish = await repoGetFinish(finishId);
+  if (!finish) throw new HttpError(404, "NOT_FOUND", "Finition introuvable.");
+  return finish;
+}
+
+export async function createFinishDraftSVC(body: CreateFinishBodyDTO, audit: AuditContext): Promise<SurfaceFinishDetail> {
+  return repoCreateFinishDraft(body, audit);
+}
+
+export async function updateFinishDraftSVC(
+  finishId: string,
+  body: UpdateFinishBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishDetail> {
+  return repoUpdateFinishDraft(finishId, body, audit);
+}
+
+export async function createRevisionSVC(
+  finishId: string,
+  body: RevisionPayloadDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishRevisionDetail> {
+  return repoCreateRevision(finishId, body, audit);
+}
+
+export async function updateRevisionSVC(
+  revisionId: string,
+  body: UpdateRevisionBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishRevisionDetail> {
+  return repoUpdateRevision(revisionId, body, audit);
+}
+
+/**
+ * Transition de statut. Publier ou retirer exige des capacités DIFFÉRENTES :
+ * approuver engage la conformité produit, retirer engage l'atelier.
+ */
+export async function transitionRevisionSVC(
+  revisionId: string,
+  body: TransitionRevisionBodyDTO,
+  audit: AuditContext,
+  actor: Actor
+): Promise<SurfaceFinishRevisionDetail> {
+  const required: SurfaceFinishCapability =
+    body.statut === "ACTIVE"
+      ? "library_approve"
+      : body.statut === "EN_VALIDATION"
+        ? "library_submit"
+        : "library_retire";
+  assertSurfaceFinishCapability(actor.role, required);
+
+  // Retirer une révision utilisée n'est jamais un geste anodin : on exige un motif.
+  if (body.statut === "SUSPENDUE" || body.statut === "OBSOLETE" || body.statut === "ARCHIVEE") {
+    const impact = await repoRevisionImpact(revisionId);
+    if (impact.gammes > 0 && (body.motif ?? "").trim().length < 10) {
+      throw new HttpError(
+        422,
+        "SURFACE_FINISH_RETIRE_REASON_REQUIRED",
+        `Cette révision est utilisée par ${impact.gammes} gamme(s) : un motif d'au moins 10 caractères est requis.`,
+        { impact }
+      );
+    }
+  }
+
+  return repoTransitionRevision(revisionId, body, audit);
+}
+
+export async function revisionImpactSVC(revisionId: string): Promise<RevisionImpact> {
+  return repoRevisionImpact(revisionId);
+}
+
+export async function listRevisionDocumentsSVC(revisionId: string): Promise<SurfaceFinishDocument[]> {
+  return repoListRevisionDocuments(revisionId);
+}
+
+export async function attachRevisionDocumentSVC(
+  revisionId: string,
+  body: AttachDocumentBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishDocument> {
+  return repoAttachRevisionDocument(revisionId, body, audit);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Configuration d'opération                                                   */
+/* -------------------------------------------------------------------------- */
+
+export async function getOperationFinishSVC(
+  gammeId: string,
+  operationId: string
+): Promise<OperationFinishRequirement | null> {
+  return repoGetOperationFinish(gammeId, operationId);
+}
+
+export async function previewOperationFinishSVC(
+  gammeId: string,
+  operationId: string,
+  body: PreviewFinishBodyDTO,
+  actor: Actor
+): Promise<SurfaceFinishPreview> {
+  return repoPreviewOperationFinish(gammeId, operationId, body, actor);
+}
+
+export async function confirmOperationFinishSVC(
+  gammeId: string,
+  operationId: string,
+  body: ConfirmFinishBodyDTO,
+  audit: AuditContext,
+  actor: Actor,
+  rawIdempotencyKey: string | null | undefined
+): Promise<ConfirmFinishResult> {
+  const idempotencyKey = normalizeIdempotencyKey(rawIdempotencyKey);
+  return repoConfirmOperationFinish(gammeId, operationId, body, audit, actor, idempotencyKey);
+}
+
+export async function detachOperationFinishSVC(
+  gammeId: string,
+  operationId: string,
+  body: DetachFinishBodyDTO,
+  audit: AuditContext
+): Promise<{ detached: true }> {
+  return repoDetachOperationFinish(gammeId, operationId, body, audit);
+}
+
+export function capabilitiesSVC(actor: Actor) {
+  return surfaceFinishCapabilitiesFor(actor.role);
+}

--- a/src/module/surface-finish/types/surface-finish.types.ts
+++ b/src/module/surface-finish/types/surface-finish.types.ts
@@ -1,0 +1,253 @@
+// #210 — Contrats de sortie de la bibliothèque de finitions et de la résolution
+// d'article. Ce sont les formes que le frontend consomme ; elles ne fuient
+// jamais de chemin de stockage, ni de coût, ni d'identifiant interne inutile.
+
+import type {
+  CanonicalFinishSpec,
+  FinishScope,
+  SurfaceFinishCapability,
+  SurfaceFinishStatus,
+} from "../domain/surface-finish-policy";
+
+export type SurfaceFinishFamily = {
+  code: string;
+  label: string;
+  description: string | null;
+  sort_order: number;
+  is_active: boolean;
+};
+
+export type SurfaceFinishRevisionSummary = {
+  id: string;
+  revision: number;
+  statut: SurfaceFinishStatus;
+  norme: string | null;
+  classe: string | null;
+  epaisseur_min: number | null;
+  epaisseur_nominale: number | null;
+  epaisseur_max: number | null;
+  epaisseur_unite: string;
+  couleur: string | null;
+  teinte_ral: string | null;
+  aspect: string | null;
+  certificat_requis: boolean;
+  date_effet: string | null;
+  updated_at: string;
+};
+
+export type SurfaceFinishRevisionDetail = SurfaceFinishRevisionSummary & {
+  finish_id: string;
+  reference_client: string | null;
+  substrat: string | null;
+  brillance: string | null;
+  rugosite: string | null;
+  durete: string | null;
+  exigence_corrosion: string | null;
+  pretraitement: string | null;
+  posttraitement: string | null;
+  zones_defaut: string[];
+  regles_masquage: string[];
+  criteres_acceptation: string | null;
+  controles: string[];
+  certificat_type: string | null;
+  conditionnement_retour: string | null;
+  unite_achat: string;
+  designation_template: string | null;
+  commentaire_template: string | null;
+  template_version: number;
+  approbateur_user_id: number | null;
+  approved_at: string | null;
+  created_at: string;
+};
+
+export type SurfaceFinishSummary = {
+  id: string;
+  code: string;
+  family_code: string;
+  family_label: string | null;
+  procede: string;
+  designation_courte: string;
+  designation_longue: string | null;
+  synonymes: string[];
+  statut: SurfaceFinishStatus;
+  current_revision: SurfaceFinishRevisionSummary | null;
+  updated_at: string;
+};
+
+export type SurfaceFinishDetail = SurfaceFinishSummary & {
+  description: string | null;
+  created_at: string;
+  revisions: SurfaceFinishRevisionDetail[];
+};
+
+export type SurfaceFinishListResult = {
+  items: SurfaceFinishSummary[];
+  total: number;
+  page: number;
+  page_size: number;
+};
+
+export type SurfaceFinishDocument = {
+  id: string;
+  revision_id: string;
+  libelle: string;
+  doc_type: string;
+  ged_document_id: string | null;
+  reference_externe: string | null;
+  sha256: string | null;
+  created_at: string;
+};
+
+/** Contexte lu côté serveur : jamais reconstruit depuis le corps de la requête. */
+export type OperationFinishContext = {
+  piece_technique_id: string;
+  code_piece: string;
+  designation_piece: string;
+  piece_technique_version_id: string;
+  indice: string;
+  plan_reference: string | null;
+  gamme_id: string;
+  gamme_code: string | null;
+  gamme_nom: string | null;
+  gamme_statut: string;
+  gamme_updated_at: string;
+  gamme_editable: boolean;
+  operation_id: string;
+  numero_operation: number | null;
+  designation_operation: string;
+  type_operation: string | null;
+  operation_updated_at: string | null;
+};
+
+export type ArticleMatch = {
+  article_id: string;
+  code: string;
+  designation: string;
+  is_active: boolean;
+  status: string | null;
+  spec_fingerprint: string | null;
+  finish_revision_id: string | null;
+  piece_technique_version_id: string | null;
+  created_at: string;
+};
+
+export type ArticleNearMatch = ArticleMatch & {
+  differences: Array<{ field: string; existing: unknown; proposed: unknown }>;
+};
+
+export type PlannedArticleClassification = {
+  article_type: "PURCHASED";
+  article_category: "traitement";
+  article_categories: string[];
+  cat_label: string;
+  family_code: string;
+  stock_managed: boolean;
+  lot_tracking: boolean;
+  code_hint: string;
+};
+
+export type PlannedPurchaseLine = {
+  type_achat: "TRAITEMENT";
+  quantite: number;
+  unite: string;
+  designation_snapshot: string;
+  gamme_operation_id: string;
+  piece_technique_version_id: string;
+  existing_line_id: string | null;
+};
+
+export type SupplierCandidate = {
+  fournisseur_id: string;
+  fournisseur_nom: string;
+  fournisseur_code: string | null;
+  categorie: string | null;
+  statut_qualification: string | null;
+};
+
+export type QualityRequirementPreview = {
+  certificat_requis: boolean;
+  certificat_type: string | null;
+  controles: string[];
+  criteres_acceptation: string | null;
+  conditionnement: string | null;
+};
+
+export type SurfaceFinishPreview = {
+  context: OperationFinishContext;
+  finish: {
+    id: string;
+    code: string;
+    designation_courte: string;
+    family_code: string;
+    procede: string;
+    statut: SurfaceFinishStatus;
+  };
+  revision: SurfaceFinishRevisionDetail;
+  spec_canonical: CanonicalFinishSpec;
+  spec_fingerprint: string;
+  generated_designation: string;
+  generated_comment: string;
+  omitted_comment_lines: string[];
+  template_version: number;
+  classification: PlannedArticleClassification;
+  exact_match: ArticleMatch | null;
+  near_matches: ArticleNearMatch[];
+  purchase_line: PlannedPurchaseLine;
+  suppliers: SupplierCandidate[];
+  quality: QualityRequirementPreview;
+  warnings: Array<{ code: string; message: string }>;
+  capabilities: Record<SurfaceFinishCapability, boolean>;
+  allowed_decisions: string[];
+  preview_hash: string;
+  generated_at: string;
+};
+
+export type OperationFinishRequirement = {
+  id: string;
+  gamme_id: string;
+  gamme_operation_id: string;
+  piece_technique_version_id: string;
+  finish_revision_id: string;
+  finish_id: string;
+  finish_code: string;
+  finish_designation: string;
+  revision: number;
+  revision_statut: SurfaceFinishStatus;
+  perimetre: FinishScope;
+  zones: string[];
+  masquages: string[];
+  instructions: string | null;
+  spec_fingerprint: string;
+  article_id: string | null;
+  article_code: string | null;
+  article_designation: string | null;
+  achat_ligne_id: string | null;
+  generated_designation: string;
+  generated_comment: string;
+  designation_override: string | null;
+  comment_override: string | null;
+  updated_at: string;
+};
+
+export type ConfirmFinishResult = {
+  result: "CREATED" | "REUSED" | "LINKED";
+  article: {
+    id: string;
+    code: string;
+    designation: string;
+    article_type: string;
+    article_category: string;
+    article_categories: string[];
+    family_code: string;
+    stock_managed: boolean;
+    lot_tracking: boolean;
+  };
+  requirement: OperationFinishRequirement;
+  purchase_line: {
+    id: string;
+    type_achat: string;
+    quantite: number;
+    designation_snapshot: string | null;
+  };
+  next_actions: Array<{ key: string; label: string; href: string }>;
+};

--- a/src/module/surface-finish/validators/surface-finish.validators.ts
+++ b/src/module/surface-finish/validators/surface-finish.validators.ts
@@ -1,0 +1,341 @@
+// #210 — Validation d'entrée de la bibliothèque de finitions et de la résolution
+// d'article. Zod est la première ligne ; le domaine (`surface-finish-policy`) et
+// la base restent les lignes suivantes. Aucune de ces trois n'est optionnelle.
+
+import type { NextFunction, Request, Response } from "express";
+import { z } from "zod";
+
+import { HttpError } from "../../../utils/httpError";
+import {
+  ARTICLE_DECISIONS,
+  FINISH_SCOPES,
+  SURFACE_FINISH_STATUSES,
+  THICKNESS_UNITS,
+} from "../domain/surface-finish-policy";
+
+const uuid = z.string().uuid();
+const shortText = z.string().trim().min(1).max(200);
+const mediumText = z.string().trim().min(1).max(500);
+const longText = z.string().trim().max(4000);
+
+/** Une chaîne vide envoyée par un formulaire vaut « non renseigné », pas « chaîne vide ». */
+const optionalText = (max = 200) =>
+  z
+    .union([z.string(), z.null()])
+    .optional()
+    .transform((value) => {
+      if (value === null || value === undefined) return null;
+      const trimmed = value.trim();
+      return trimmed === "" ? null : trimmed;
+    })
+    .refine((value) => value === null || value.length <= max, {
+      message: `Ce champ ne peut pas dépasser ${max} caractères.`,
+    });
+
+const optionalNumber = z
+  .union([z.number(), z.string(), z.null()])
+  .optional()
+  .transform((value) => {
+    if (value === null || value === undefined) return null;
+    if (typeof value === "number") return Number.isFinite(value) ? value : null;
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const parsed = Number(trimmed.replace(",", "."));
+    return Number.isFinite(parsed) ? parsed : null;
+  })
+  .refine((value) => value === null || value >= 0, { message: "Une valeur négative n'est pas acceptée." });
+
+const tokenList = z
+  .array(z.string().trim().min(1).max(120))
+  .max(50, "50 entrées au maximum.")
+  .optional()
+  .transform((value) => value ?? []);
+
+/**
+ * Variante d'override : la distinction `undefined` (hériter de la révision) vs
+ * `null` (effacer explicitement) doit SURVIVRE à la validation. Un `optionalText`
+ * ordinaire écraserait l'absence en `null` et ferait disparaître les valeurs
+ * héritées de la finition.
+ */
+const overrideText = (max = 200) =>
+  z
+    .union([z.string(), z.null()])
+    .optional()
+    .transform((value) => {
+      if (value === undefined) return undefined;
+      if (value === null) return null;
+      const trimmed = value.trim();
+      return trimmed === "" ? null : trimmed;
+    })
+    .refine((value) => value === undefined || value === null || value.length <= max, {
+      message: `Ce champ ne peut pas dépasser ${max} caractères.`,
+    });
+
+const overrideNumber = z
+  .union([z.number(), z.string(), z.null()])
+  .optional()
+  .transform((value) => {
+    if (value === undefined) return undefined;
+    if (value === null) return null;
+    if (typeof value === "number") return Number.isFinite(value) ? value : null;
+    const trimmed = value.trim();
+    if (trimmed === "") return null;
+    const parsed = Number(trimmed.replace(",", "."));
+    return Number.isFinite(parsed) ? parsed : null;
+  })
+  .refine((value) => value === undefined || value === null || value >= 0, {
+    message: "Une valeur négative n'est pas acceptée.",
+  });
+
+export const thicknessUnitSchema = z.enum(THICKNESS_UNITS);
+export const finishScopeSchema = z.enum(FINISH_SCOPES);
+export const finishStatusSchema = z.enum(SURFACE_FINISH_STATUSES);
+export const articleDecisionSchema = z.enum(ARTICLE_DECISIONS);
+
+/* -------------------------------------------------------------------------- */
+/* Bibliothèque — recherche                                                    */
+/* -------------------------------------------------------------------------- */
+
+export const listFinishesQuerySchema = z.object({
+  q: optionalText(120),
+  family_code: optionalText(60),
+  procede: optionalText(120),
+  norme: optionalText(120),
+  couleur: optionalText(120),
+  epaisseur_um: optionalNumber,
+  statut: z
+    .union([finishStatusSchema, z.literal(""), z.null()])
+    .optional()
+    .transform((value) => (value ? (value as z.infer<typeof finishStatusSchema>) : null)),
+  // Par défaut la recherche depuis une gamme ne propose que du sélectionnable.
+  only_selectable: z
+    .union([z.boolean(), z.enum(["true", "false", "1", "0"])])
+    .optional()
+    .transform((value) => value === true || value === "true" || value === "1"),
+  page: z.coerce.number().int().min(1).max(10_000).optional().default(1),
+  page_size: z.coerce.number().int().min(1).max(50).optional().default(20),
+});
+export type ListFinishesQueryDTO = z.infer<typeof listFinishesQuerySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Bibliothèque — écriture                                                     */
+/* -------------------------------------------------------------------------- */
+
+export const createFinishBodySchema = z.object({
+  family_code: shortText,
+  procede: shortText,
+  designation_courte: shortText,
+  designation_longue: optionalText(300),
+  description: optionalText(2000),
+  synonymes: tokenList,
+});
+export type CreateFinishBodyDTO = z.infer<typeof createFinishBodySchema>;
+
+export const updateFinishBodySchema = z
+  .object({
+    family_code: shortText.optional(),
+    procede: shortText.optional(),
+    designation_courte: shortText.optional(),
+    designation_longue: optionalText(300),
+    description: optionalText(2000),
+    synonymes: tokenList,
+    expected_updated_at: z.string().min(1),
+  })
+  // `code` est délibérément absent : il est alloué par le serveur puis immuable.
+  .strict();
+export type UpdateFinishBodyDTO = z.infer<typeof updateFinishBodySchema>;
+
+export const revisionPayloadSchema = z.object({
+  norme: optionalText(200),
+  reference_client: optionalText(200),
+  classe: optionalText(120),
+  substrat: optionalText(200),
+
+  epaisseur_min: optionalNumber,
+  epaisseur_nominale: optionalNumber,
+  epaisseur_max: optionalNumber,
+  epaisseur_unite: thicknessUnitSchema.optional().default("um"),
+
+  couleur: optionalText(120),
+  teinte_ral: optionalText(60),
+  aspect: optionalText(120),
+  brillance: optionalText(120),
+  rugosite: optionalText(120),
+  durete: optionalText(120),
+  exigence_corrosion: optionalText(200),
+
+  pretraitement: optionalText(300),
+  posttraitement: optionalText(300),
+  zones_defaut: tokenList,
+  regles_masquage: tokenList,
+
+  criteres_acceptation: longText.optional().transform((value) => (value ? value : null)),
+  controles: tokenList,
+  certificat_requis: z.boolean().optional().default(false),
+  certificat_type: optionalText(120),
+  conditionnement_retour: optionalText(300),
+  unite_achat: optionalText(20),
+
+  designation_template: optionalText(400),
+  commentaire_template: z
+    .union([z.string(), z.null()])
+    .optional()
+    .transform((value) => {
+      if (value === null || value === undefined) return null;
+      const trimmed = value.trim();
+      return trimmed === "" ? null : trimmed;
+    })
+    .refine((value) => value === null || value.length <= 4000, {
+      message: "Le modèle de commentaire ne peut pas dépasser 4000 caractères.",
+    }),
+
+  date_effet: z
+    .union([z.string().regex(/^\d{4}-\d{2}-\d{2}$/), z.null()])
+    .optional()
+    .transform((value) => value ?? null),
+});
+export type RevisionPayloadDTO = z.infer<typeof revisionPayloadSchema>;
+
+export const createRevisionBodySchema = revisionPayloadSchema;
+
+export const updateRevisionBodySchema = revisionPayloadSchema.extend({
+  expected_updated_at: z.string().min(1),
+});
+export type UpdateRevisionBodyDTO = z.infer<typeof updateRevisionBodySchema>;
+
+export const transitionRevisionBodySchema = z.object({
+  statut: finishStatusSchema,
+  motif: optionalText(500),
+  expected_updated_at: z.string().min(1),
+});
+export type TransitionRevisionBodyDTO = z.infer<typeof transitionRevisionBodySchema>;
+
+export const attachDocumentBodySchema = z
+  .object({
+    libelle: mediumText,
+    doc_type: z
+      .enum(["SPECIFICATION", "NORME", "FICHE_TECHNIQUE", "PLAN_MASQUAGE", "CERTIFICAT_TYPE", "AUTRE"])
+      .optional()
+      .default("SPECIFICATION"),
+    ged_document_id: z.union([uuid, z.null()]).optional().transform((v) => v ?? null),
+    reference_externe: optionalText(300),
+    sha256: z
+      .union([z.string().regex(/^[0-9a-f]{64}$/), z.null()])
+      .optional()
+      .transform((v) => v ?? null),
+  })
+  .refine((body) => Boolean(body.ged_document_id) || Boolean(body.reference_externe), {
+    message: "Un document exige une ancre : identifiant GED ou référence externe.",
+    path: ["ged_document_id"],
+  });
+export type AttachDocumentBodyDTO = z.infer<typeof attachDocumentBodySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Configuration d'opération — aperçu et confirmation                          */
+/* -------------------------------------------------------------------------- */
+
+export const operationFinishParamsSchema = z.object({
+  gammeId: uuid,
+  operationId: uuid,
+});
+
+/** Overrides posés au niveau de l'opération. Chaque champ absent hérite de la révision. */
+export const operationOverridesSchema = z.object({
+  perimetre: finishScopeSchema.optional().default("PIECE_ENTIERE"),
+  zones: tokenList,
+  masquages: tokenList,
+  norme: overrideText(200),
+  classe: overrideText(120),
+  epaisseur_min: overrideNumber,
+  epaisseur_nominale: overrideNumber,
+  epaisseur_max: overrideNumber,
+  epaisseur_unite: thicknessUnitSchema.optional(),
+  couleur: overrideText(120),
+  teinte_ral: overrideText(60),
+  aspect: overrideText(120),
+  rugosite: overrideText(120),
+  durete: overrideText(120),
+  exigence_corrosion: overrideText(200),
+  pretraitement: overrideText(300),
+  posttraitement: overrideText(300),
+  controles: tokenList,
+  certificat_requis: z.boolean().optional(),
+  certificat_type: overrideText(120),
+  conditionnement: overrideText(300),
+  unite_achat: overrideText(20),
+  specification_client: overrideText(200),
+  specification_client_version: overrideText(60),
+  instructions: z
+    .union([z.string(), z.null()])
+    .optional()
+    .transform((value) => {
+      if (value === null || value === undefined) return null;
+      const trimmed = value.trim();
+      return trimmed === "" ? null : trimmed;
+    })
+    .refine((value) => value === null || value.length <= 2000, {
+      message: "Les instructions ne peuvent pas dépasser 2000 caractères.",
+    }),
+});
+export type OperationOverridesDTO = z.infer<typeof operationOverridesSchema>;
+
+export const previewFinishBodySchema = z.object({
+  finish_revision_id: uuid,
+  overrides: operationOverridesSchema.optional().default(operationOverridesSchema.parse({})),
+  quantite: z.coerce.number().positive().max(1_000_000).optional().default(1),
+});
+export type PreviewFinishBodyDTO = z.infer<typeof previewFinishBodySchema>;
+
+export const confirmFinishBodySchema = z.object({
+  finish_revision_id: uuid,
+  overrides: operationOverridesSchema.optional().default(operationOverridesSchema.parse({})),
+  quantite: z.coerce.number().positive().max(1_000_000).optional().default(1),
+  decision: articleDecisionSchema,
+  article_id: z.union([uuid, z.null()]).optional().transform((v) => v ?? null),
+  justification: optionalText(1000),
+  preview_hash: z.string().regex(/^[0-9a-f]{64}$/, "Aperçu invalide."),
+  spec_fingerprint: z.string().regex(/^[0-9a-f]{64}$/, "Empreinte invalide."),
+  expected_gamme_updated_at: z.string().min(1),
+  expected_operation_updated_at: z.union([z.string().min(1), z.null()]).optional().transform((v) => v ?? null),
+  expected_finition_updated_at: z.union([z.string().min(1), z.null()]).optional().transform((v) => v ?? null),
+});
+export type ConfirmFinishBodyDTO = z.infer<typeof confirmFinishBodySchema>;
+
+export const detachFinishBodySchema = z.object({
+  motif: mediumText,
+  expected_updated_at: z.string().min(1),
+});
+export type DetachFinishBodyDTO = z.infer<typeof detachFinishBodySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Middleware de validation                                                    */
+/* -------------------------------------------------------------------------- */
+
+type Target = "body" | "query" | "params";
+
+/**
+ * Valide et REMPLACE la section correspondante par la valeur normalisée : les
+ * couches suivantes ne voient jamais l'entrée brute.
+ */
+export function validate(schema: z.ZodTypeAny, target: Target = "body") {
+  return (req: Request, _res: Response, next: NextFunction): void => {
+    const source = target === "body" ? req.body : target === "query" ? req.query : req.params;
+    const parsed = schema.safeParse(source);
+    if (!parsed.success) {
+      next(
+        new HttpError(422, "VALIDATION_ERROR", "Données invalides.", {
+          issues: parsed.error.issues.map((issue) => ({
+            path: issue.path.join("."),
+            message: issue.message,
+            code: issue.code,
+          })),
+        })
+      );
+      return;
+    }
+    if (target === "body") req.body = parsed.data;
+    else if (target === "query") Object.assign(req.query as object, parsed.data);
+    else req.params = parsed.data as typeof req.params;
+    next();
+  };
+}

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -48,6 +48,8 @@ import tempsDeplacementsRoutes from "../module/temps-deplacements/routes/temps-d
 import projectOfficeRoutes from "../module/project-office/routes/project-office.routes"
 import gedRoutes from "../module/ged/routes/ged.routes"
 import gammesRoutes from "../module/gammes/routes/gammes.routes"
+import surfaceFinishRoutes from "../module/surface-finish/routes/surface-finish.routes"
+import surfaceFinishGammeRoutes from "../module/surface-finish/routes/surface-finish-gamme.routes"
 import pieceTechniqueVersionsRoutes from "../module/gammes/routes/piece-technique-versions.routes"
 import importAssistantRoutes from "../module/import-assistant/routes/import-assistant.routes"
 import accessControlRoutes from "../module/access-control/routes/access-control.routes"
@@ -77,7 +79,13 @@ router.use("/pieces-families", piecesfamiliesRoutes)
 router.use("/centre-frais", CFRoutes)     
 router.use("/pieces-techniques", piecesTechniquesRoutes)
 router.use("/piece-technique-versions", pieceTechniqueVersionsRoutes) // GPAO B2.2 — gammes par version
+// Bibliothèque de finitions (#210) : la configuration de la finition d'une
+// opération est montée AVANT le routeur historique des gammes pour déclarer ses
+// capacités fines sans hériter des gardes hérités. Le routeur historique reste
+// inchangé pour les écrans en production.
+router.use("/gammes", surfaceFinishGammeRoutes)
 router.use("/gammes", gammesRoutes)                                   // GPAO B2.2 — gammes + opérations
+router.use("/finitions", surfaceFinishRoutes)                         // #210 — bibliothèque de finitions
 router.use("/audit-logs", auditLogsRoutes)
 // Tour de contrôle des accès (#326) montée AVANT le routeur admin historique : elle
 // est gardée par le statut superadmin et ne doit pas hériter de son authorizeRole.

--- a/src/shared/codes/code-generator.service.ts
+++ b/src/shared/codes/code-generator.service.ts
@@ -203,6 +203,18 @@ export async function generateMetrologieImpactCode(
   return generateTransactionalBusinessCode(tx, { prefix: "MIA", date: params?.date, width: 5 });
 }
 
+/**
+ * #210 — Finition de surface : FIN-NNNNNN.
+ *
+ * Le code visible est alloué par le SERVEUR dans la transaction de création ;
+ * un code proposé par l'interface n'est jamais retenu, et le code attribué est
+ * ensuite immuable (trigger `fn_protect_surface_finish_code_210`).
+ */
+export async function generateSurfaceFinishCode(tx: DbQueryer): Promise<string> {
+  const seq = await nextCodeValue(tx, "FIN");
+  return `FIN-${pad(seq, 6)}`;
+}
+
 /** #172 — Bon de commande fournisseur : BCF-AAAA-NNNN, alloué en transaction, immuable. */
 export async function generateCommandeFournisseurCode(tx: DbQueryer, params?: { date?: Date }): Promise<string> {
   return generateTransactionalBusinessCode(tx, { prefix: "BCF", date: params?.date });

--- a/src/shared/codes/code-validator.ts
+++ b/src/shared/codes/code-validator.ts
@@ -54,6 +54,12 @@ export const CODE_FORMATS = {
     example: "ART-USI-000042",
     hintText: "Format attendu: ART-USI-000042",
   },
+  // #210 — Finition de surface : code alloué par le serveur, puis immuable.
+  surfaceFinish: {
+    regex: /^FIN-\d{6}$/,
+    example: "FIN-000042",
+    hintText: "Format attendu: FIN-000042",
+  },
   nonConformity: {
     regex: /^NC-\d{4}-\d{5}$/,
     example: "NC-2026-00001",


### PR DESCRIPTION
Release de `dev` vers `main`.

## Contenu

Un seul chantier : le socle serveur de la bibliothèque de finitions (#210), apparié au
frontend BigFootLime/crp-systems-web#339.

- `e86a2a6` — socle serveur : 6 tables, 2 fonctions SQL, domaine de politique pure, aperçu en
  lecture pure, confirmation atomique idempotente, RBAC 16 capacités, refactor de
  `repoCreateArticle` en `repoCreateArticleTx`.
- `cf26b6b` — correctif du fixer d'ownership partagé (`pg_get_serial_sequence()` lève sur
  colonne absente) + `surface_finish_command_receipts` classée append-only.

## Base de données — DÉJÀ EN PLACE AVANT CETTE RELEASE

Le patch `20260728_surface_finish_library_210` a été appliqué et vérifié sur **`cerp_test`
puis `cerp_prod`** le 2026-07-28, **avant** ce déploiement — c'est l'ordre voulu : le patch
est additif et inoffensif sans le code, l'inverse aurait fait tomber les routes en 500.

Sauvegarde `cerp_prod` prise avant écriture (`cerp_prod_20260728-215900.dump`, 50,5 Mo,
intégrité vérifiée). Verify 100 % vert sur les deux bases, volumétrie identique au preflight,
**aucun backfill**, enum du catalogue fournisseur non modifié, 13 scopes de codification
opérationnels sur `cerp_prod`.

## Tests

2954 verts (125 fichiers). `tsc` vert.

## Risque résiduel assumé

Aucune recette navigateur n'a été faite : les preuves sont des tests automatisés et des
contrôles SQL réels en transaction annulée, pas des captures d'écran. Les surfaces
existantes ne sont pas modifiées (routes historiques inchangées, patch strictement additif).

## Summary by Sourcery

Introduce a server-side surface finish library and subcontracting article resolution flow, with dedicated APIs, domain policies, and database schema, plus shared Article creation refactor and ownership fix.

New Features:
- Add full surface finish library domain (families, finishes, revisions, documents) and HTTP APIs for browsing and managing finishes.
- Add endpoints and services to configure, preview, confirm, and detach surface finish requirements on subcontracting operations, including idempotent confirmation and article resolution.
- Introduce server-allocated surface finish business codes (FIN-NNNNNN) and validation for their format.

Bug Fixes:
- Harden the ownership-fixing privileged script to skip sequences for tables without an id column and treat surface_finish_command_receipts as append-only postgres-owned.

Enhancements:
- Refactor article creation logic into a reusable transactional helper to support creation from complex domain workflows like surface finish resolution.
- Extend article treatment specialization and purchase BOM schema to carry canonical finish specs and link purchase lines directly to operations via foreign keys.
- Integrate surface finish routes into the existing v1 API and access-control module catalog so finishes appear under technical data with dedicated RBAC capabilities.
- Add comprehensive pure domain policies for surface finishes (RBAC, lifecycle, canonical spec, fingerprinting, text generation, idempotency, optimistic locking) with extensive unit tests, plus HTTP-level tests and migration guard tests.

Tests:
- Add extensive tests covering surface finish domain policies, HTTP routes, and migration constraints, ensuring idempotence, anti-duplication, and lack of side effects where expected.

Chores:
- Add the 20260728_surface_finish_library_210 additive database patch and support scripts (preflight, verify, rollback, candidates) to manage the surface finish library schema lifecycle.