### PR TITLE
release: facture et avoir sur la grammaire CERP (#216)

### DIFF
--- a/docs/facturation-document-cerp-216.md
+++ b/docs/facturation-document-cerp-216.md
@@ -1,0 +1,124 @@
+# Facture & avoir — pièces fiscales sur la grammaire CERP
+
+Issue `erp-crp-backend#216` ↔ `crp-systems-web#366` · Décision `ADR-0042`
+Applicable à : `src/module/facturation/services/finance-document-render.ts`,
+`finance-document.service.ts`, `avoir-document.service.ts`, `pdf.service.ts`
+
+## 1. Pourquoi ces documents restent au serveur
+
+La facture et l'avoir **font foi**. Elles sont conservées, leur contenu est encadré par la loi,
+et l'exemplaire émis est **immuable** — le service refuse de le régénérer. Un PDF rendu dans le
+navigateur ne peut pas être cet exemplaire : il n'a traversé aucun contrôle serveur, il dépend
+du poste et du bundle, et il pourrait différer de ce qui a été envoyé.
+
+C'est la même règle que pour le bon de livraison (ADR-0042, dépôt frontend).
+
+## 2. Un document, un rendu — pour trois chemins
+
+Trois services dessinaient ces pièces, chacun avec sa mise en page :
+
+| Chemin | Produisait |
+|---|---|
+| `pdf.service.ts` | Brouillons de facture **et** d'avoir |
+| `finance-document.service.ts` | Exemplaire légal immuable de la facture |
+| `avoir-document.service.ts` | Exemplaire légal immuable de l'avoir |
+
+Un client pouvait donc recevoir un brouillon puis une facture **d'aspect complètement
+différent** pour le même montant — couleurs, colonnes et structure changeaient.
+
+Le rendu vit désormais dans `finance-document-render.ts`, appelé par les trois. Les services ne
+s'occupent plus que de ce qui les regarde : écriture du fichier, empreinte SHA-256, journal.
+
+## 3. Les mentions obligatoires
+
+### Ce qui a été ajouté
+
+**Ventilation de la TVA par taux** — pour chaque taux appliqué, la base hors taxes et le
+montant de taxe. Elle est **entièrement dérivée des lignes** :
+
+- aucun montant n'est recalculé — si le référentiel fournit une taxe à `0.00` pour un taux à
+  20 %, le document affiche `0,00 €` ; il ne réapplique jamais un taux de son propre chef ;
+- les sommes se font en **centimes entiers** : `0.1 + 0.2` en virgule flottante donne
+  `0.30000000000000004`, ce qui se voit au centime sur une facture.
+
+**Identité fiscale des deux parties** — dénomination, adresse, SIRET, SIREN, RCS, n° de TVA
+intracommunautaire, capital. Lecture **défensive** de l'instantané, dont la forme appartient au
+référentiel : une mention absente **reste absente**, jamais remplacée par un substitut.
+
+L'instantané de l'émetteur ne retenait que `biller_id` et `biller_name` : la facture légale
+sortait donc sans adresse ni SIRET, alors que le rendu savait déjà les afficher. Il retient
+maintenant une **liste blanche** de champs d'identité fiscale, construite sur `to_jsonb(f)` —
+la table `factureur` est historique et sa forme exacte n'appartient pas à ce module. Le SQL
+remonte la ligne entière, le code filtre.
+
+**Un brouillon se dénonce comme tel** : statut « Brouillon », drapeau « Ne pas transmettre ».
+Imprimée, une facture non émise n'a aucune valeur fiscale.
+
+### Ce qui manque encore, faute de donnée
+
+Ces mentions ne sont **pas** imprimées parce que le référentiel ne les porte pas. Les inventer
+serait pire que les omettre :
+
+- **pénalités de retard** et **indemnité forfaitaire de recouvrement de 40 €**
+  (art. L441-10 / D441-5 du code de commerce) ;
+- **escompte** et conditions de règlement rédigées ;
+- **RCS**, **capital social**, **forme juridique** de l'émetteur — le rendu les affiche si les
+  colonnes existent et sont renseignées ; rien ne le garantit aujourd'hui.
+
+Elles relèvent d'un **paramétrage d'entité émettrice**, pas du rendu. À arbitrer.
+
+## 4. Format des montants
+
+Le référentiel fournit des chaînes à point décimal (`10465.20`) et le document les sortait
+telles quelles avec le code ISO — sur une facture française, et alors que les devis et
+commandes rendus dans le navigateur affichent déjà `10 465,20 €` pour la même entreprise.
+
+`money()` et `percent()` ne changent que les **séparateurs** : aucun chiffre n'est modifié, le
+signe négatif est conservé (un montant négatif devenu positif ferait mentir la pièce), et une
+chaîne qui n'est pas un nombre est rendue telle quelle plutôt que perdue.
+
+## 5. Deux corrections du socle
+
+**`notesSection`** — `section()` réserve 52 pt sous son titre pour ne pas l'orpheliner. Devant
+une note courte, cette réserve dépasse la hauteur réelle du bloc : une facture de deux lignes
+basculait sur une seconde page **pour 1,1 pt**. `notesSection` mesure le paragraphe avant de
+réserver.
+
+**`footerNote`** — la mention de traçabilité (`Instantané immuable <uuid>`) était écrite à la
+suite du contenu. Une note de 7 pt suffisait à ouvrir une page entière presque vide. Elle vit
+désormais dans la bande du pied de page, portée par **toutes** les pages — ce qui est aussi
+plus utile : une page détachée peut être rattachée à son exemplaire d'origine.
+
+## 6. Ce qui ne doit jamais figurer
+
+`ID: <uuid>` du client était imprimé sous la raison sociale, sur une pièce adressée au client.
+C'est la **quatrième** occurrence de ce défaut dans la série de documents CERP. Seule la raison
+sociale et l'identité fiscale sont imprimées.
+
+Le commentaire interne (`internal_comment`) reste dans l'ERP : seul le texte destiné au client
+est repris.
+
+## 7. Vérification
+
+```bash
+CERP_PDF_PREVIEW=1 npx vitest run src/module/facturation/services/finance-document-render.test.ts
+```
+
+**22 cas.** Le texte est relu **dans les flux de contenu décompressés**, décodés en WinAnsi —
+donc ce que le document affiche. Attention en relecture : WinAnsi **n'est pas** latin1 entre
+`0x80` et `0x9F`, où logent le tiret cadratin et l'apostrophe typographique.
+
+Couvre : facture émise à deux taux, brouillon, remise globale, 40 lignes paginées, émetteur à
+identité réduite, avoir avec motif et facture corrigée, absence d'échéances sur un avoir,
+absence de l'identifiant technique du client, accents et tiret cadratin, arithmétique de la
+ventilation TVA (regroupement, centimes, non-recalcul).
+
+Suite complète : **2989 tests verts sur 2990**. Le seul échec,
+`src/__tests__/surface-finish-210.migration-guards.test.ts`, est **antérieur** à ce chantier —
+vérifié en remisant les modifications et en relançant sur `origin/dev` seul.
+
+## 8. Limites
+
+- Aucune recette navigateur.
+- **Aucune migration de base**, aucun changement de contrat d'API.
+- Les mentions listées au § 3 restent absentes tant que le référentiel ne les porte pas.

--- a/src/module/facturation/services/avoir-document.service.ts
+++ b/src/module/facturation/services/avoir-document.service.ts
@@ -2,83 +2,21 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import PDFDocument from "pdfkit";
-
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import type {
   AvoirDocumentArtifact,
   AvoirDocumentSnapshot,
 } from "../repository/avoir-workflow.repository";
 
-function partyName(snapshot: Record<string, unknown>): string {
-  for (const key of ["company_name", "name", "raison_sociale"]) {
-    const value = snapshot[key];
-    if (typeof value === "string" && value.trim()) return value.trim();
-  }
-  return "Non renseigné";
-}
+import { renderFinanceDocument } from "./finance-document-render";
 
-async function render(snapshot: AvoirDocumentSnapshot): Promise<Buffer> {
-  const doc = new PDFDocument({ size: "A4", margin: 44, compress: true });
-  const chunks: Buffer[] = [];
-  doc.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
-
-  doc.info.Title = `Avoir ${snapshot.legal_number}`;
-  doc.font("Helvetica-Bold").fontSize(22).fillColor("#172033").text("AVOIR", { align: "right" });
-  doc.font("Helvetica").fontSize(10);
-  doc.text(`N° ${snapshot.legal_number}`, { align: "right" });
-  doc.text(`Date : ${snapshot.issue_date}`, { align: "right" });
-  doc.text(`Facture corrigée : ${snapshot.facture_number}`, { align: "right" });
-  doc.moveDown(1.5);
-  doc.font("Helvetica-Bold").text("Émetteur");
-  doc.font("Helvetica").text(partyName(snapshot.issuer_snapshot));
-  doc.moveDown(0.8);
-  doc.font("Helvetica-Bold").text("Client");
-  doc.font("Helvetica").text(partyName(snapshot.client_snapshot));
-  doc.moveDown(1);
-  doc.font("Helvetica-Bold").text(`Motif (${snapshot.reason_code})`);
-  doc.font("Helvetica").text(snapshot.reason);
-  doc.moveDown(1.2);
-
-  for (const line of snapshot.lines) {
-    if (doc.y > 700) doc.addPage();
-    doc.font("Helvetica-Bold").fontSize(9).text(line.designation, { continued: false });
-    doc
-      .font("Helvetica")
-      .text(
-        `${line.quantity_selected} × ${line.unit_price_ex_tax} ${snapshot.currency} HT — TVA ${line.tax_rate_percent} % — ${line.total_incl_tax} ${snapshot.currency} TTC`
-      );
-    doc.moveDown(0.5);
-  }
-
-  doc.moveDown(1);
-  doc.font("Helvetica").fontSize(10).text(`Total HT : ${snapshot.totals.total_ex_tax} ${snapshot.currency}`, {
-    align: "right",
-  });
-  doc.text(`TVA : ${snapshot.totals.total_tax} ${snapshot.currency}`, { align: "right" });
-  doc
-    .font("Helvetica-Bold")
-    .fontSize(12)
-    .text(`Total TTC : ${snapshot.totals.total_incl_tax} ${snapshot.currency}`, { align: "right" });
-  doc
-    .font("Helvetica")
-    .fontSize(7)
-    .fillColor("#667085")
-    .text(
-      `Document légal version 1 — instantané immuable ${snapshot.uuid}.`,
-      44,
-      doc.page.height - 48,
-      { width: 507, align: "center" }
-    );
-
-  doc.end();
-  await new Promise<void>((resolve, reject) => {
-    doc.once("end", resolve);
-    doc.once("error", reject);
-  });
-  return Buffer.concat(chunks);
-}
-
+/**
+ * Exemplaire legal immuable de l'avoir.
+ *
+ * Meme rendu que la facture (`finance-document-render.ts`). La version precedente n'avait pas
+ * de table : les lignes etaient ecrites en paragraphes libres, et la date d'emission sortait au
+ * format ISO brut sur un document adresse au client.
+ */
 export async function writeImmutableAvoirDocument(
   snapshot: AvoirDocumentSnapshot
 ): Promise<AvoirDocumentArtifact> {
@@ -86,8 +24,46 @@ export async function writeImmutableAvoirDocument(
   const safeNumber = snapshot.legal_number.replace(/[^a-zA-Z0-9_-]+/g, "_");
   const fileName = `Avoir_${safeNumber}_v1.pdf`;
   const filePath = path.join(ensureDocumentStoragePath(), `${documentId}.pdf`);
-  const pdf = await render(snapshot);
+
+  const pdf = await renderFinanceDocument({
+    kind: "AVOIR",
+    number: snapshot.legal_number,
+    draft: false,
+    issueDate: snapshot.issue_date,
+    currency: snapshot.currency,
+    issuer: snapshot.issuer_snapshot,
+    client: snapshot.client_snapshot,
+    // Un avoir credite : c'est la quantite retenue qui fait foi, pas celle facturee a l'origine.
+    lines: snapshot.lines.map((line) => ({
+      designation: line.designation,
+      codePiece: line.code_piece,
+      quantity: line.quantity_selected,
+      unit: line.unit,
+      unitPriceExTax: line.unit_price_ex_tax,
+      discountPercent: line.discount_percent,
+      taxRatePercent: line.tax_rate_percent,
+      totalExTax: line.total_ex_tax,
+      taxAmount: line.tax_amount,
+      totalInclTax: line.total_incl_tax,
+    })),
+    totals: {
+      subtotalExTax: snapshot.totals.subtotal_ex_tax,
+      globalDiscountPercent: snapshot.totals.global_discount_percent,
+      globalDiscountAmount: snapshot.totals.global_discount_amount,
+      totalExTax: snapshot.totals.total_ex_tax,
+      totalTax: snapshot.totals.total_tax,
+      totalInclTax: snapshot.totals.total_incl_tax,
+    },
+    dueDates: [],
+    correctedInvoice: snapshot.facture_number,
+    reasonCode: snapshot.reason_code,
+    reason: snapshot.reason,
+    snapshotUuid: snapshot.uuid,
+    draftReference: snapshot.draft_reference,
+  });
+
   await fs.writeFile(filePath, pdf, { flag: "wx" });
+
   return {
     documentId,
     fileName,

--- a/src/module/facturation/services/finance-document-render.test.ts
+++ b/src/module/facturation/services/finance-document-render.test.ts
@@ -1,0 +1,411 @@
+/**
+ * Rendu reel de la facture et de l'avoir.
+ *
+ * Ces documents sont **fiscaux** : leur contenu est encadre par la loi et l'exemplaire emis
+ * est immuable. Une regression n'est pas rattrapable sur les factures deja transmises.
+ *
+ * Le texte est relu dans les flux de contenu du PDF, decompresses et decodes en WinAnsi : on
+ * verifie ce que le document **affiche**, pas ce que le code croit avoir ecrit.
+ *
+ * `CERP_PDF_PREVIEW=1` ecrit les PDF dans `outputs/pdf-preview` pour inspection visuelle.
+ */
+
+import { mkdirSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { inflateSync } from "node:zlib";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  money,
+  percent,
+  renderFinanceDocument,
+  taxBreakdown,
+  partyLines,
+  type FinanceDocumentInput,
+  type FinanceDocumentLine,
+} from "./finance-document-render";
+
+const PREVIEW_ENABLED = process.env.CERP_PDF_PREVIEW === "1";
+const PREVIEW_DIR = process.env.CERP_PDF_PREVIEW_DIR ?? resolve(process.cwd(), "outputs", "pdf-preview");
+
+function keep(name: string, bytes: Buffer): void {
+  if (!PREVIEW_ENABLED) return;
+  mkdirSync(PREVIEW_DIR, { recursive: true });
+  writeFileSync(resolve(PREVIEW_DIR, `${name}.pdf`), bytes);
+}
+
+/** WinAnsi, pas latin1 : les deux divergent de 0x80 a 0x9F (tiret cadratin, apostrophe). */
+const WINANSI = new TextDecoder("windows-1252");
+
+function drawnPages(bytes: Buffer): string[] {
+  const decodeOperands = (operands: string): string =>
+    [...operands.matchAll(/<([0-9a-fA-F\s]*)>|\(((?:\\.|[^\\)])*)\)/g)]
+      .map((m) =>
+        m[1] !== undefined
+          ? WINANSI.decode(Buffer.from(m[1].replace(/\s+/g, ""), "hex"))
+          : m[2].replace(/\\([()\\])/g, "$1")
+      )
+      .join("");
+
+  const pages: string[] = [];
+  let cursor = 0;
+
+  for (;;) {
+    const start = bytes.indexOf("stream", cursor);
+    if (start < 0) break;
+    let from = start + "stream".length;
+    if (bytes[from] === 0x0d) from += 1;
+    if (bytes[from] === 0x0a) from += 1;
+    const end = bytes.indexOf("endstream", from);
+    if (end < 0) break;
+    cursor = end + "endstream".length;
+
+    let content: string;
+    try {
+      content = inflateSync(bytes.subarray(from, end)).toString("latin1");
+    } catch {
+      continue;
+    }
+    if (!content.includes("BT")) continue;
+
+    pages.push(
+      [
+        ...[...content.matchAll(/\[([^\]]*)\]\s*TJ/g)].map((m) => decodeOperands(m[1])),
+        ...[...content.matchAll(/(<[0-9a-fA-F\s]*>|\((?:\\.|[^\\)])*\))\s*Tj/g)].map((m) => decodeOperands(m[1])),
+      ].join("\n")
+    );
+  }
+
+  return pages;
+}
+
+function drawnText(bytes: Buffer): string {
+  return drawnPages(bytes).join("\n");
+}
+
+/** Identifiant technique du client : il ne doit apparaitre sur aucun document financier. */
+const CLIENT_UUID = "8f1c2b4e-7d3a-4f56-9c21-0ab5d6e7f890";
+
+const ISSUER = {
+  company_name: "CROIX ROUSSE PRECISION",
+  address_line_1: "12 rue de la Precision",
+  postal_code: "69004",
+  city: "LYON",
+  country: "France",
+  siret: "123 456 789 00012",
+  vat_number: "FR12345678900",
+};
+
+const CLIENT = {
+  client_id: CLIENT_UUID,
+  company_name: "ABB FRANCE",
+  siret: "987 654 321 00021",
+  vat_number: "FR98765432100",
+  billing_address: {
+    house_number: "12",
+    street: "ZA LA BOISSE",
+    postal_code: "01125",
+    city: "MONTLUEL CEDEX",
+    country: "France",
+  },
+};
+
+function ligne(overrides: Partial<FinanceDocumentLine> = {}): FinanceDocumentLine {
+  return {
+    designation: "Corps de vanne inox 316L — usinage complet, plan 4501-A indice C",
+    codePiece: "PT-4501-A",
+    quantity: "40",
+    unit: "pce",
+    unitPriceExTax: "182.40",
+    discountPercent: "0.00",
+    taxRatePercent: "20.00",
+    totalExTax: "7296.00",
+    taxAmount: "1459.20",
+    totalInclTax: "8755.20",
+    ...overrides,
+  };
+}
+
+const FACTURE: FinanceDocumentInput = {
+  kind: "FACTURE",
+  number: "FA-2026-0142",
+  draft: false,
+  issueDate: "2026-07-22",
+  currency: "EUR",
+  issuer: ISSUER,
+  client: CLIENT,
+  lines: [
+    ligne(),
+    ligne({
+      designation: "Bague de guidage bronze — tournage et rectification",
+      codePiece: "PT-4502-B",
+      quantity: "120",
+      unitPriceExTax: "27.80",
+      discountPercent: "5.00",
+      totalExTax: "3169.20",
+      taxAmount: "633.84",
+      totalInclTax: "3803.04",
+    }),
+  ],
+  totals: {
+    subtotalExTax: "10465.20",
+    globalDiscountPercent: "0.00",
+    globalDiscountAmount: "0.00",
+    totalExTax: "10465.20",
+    totalTax: "2093.04",
+    totalInclTax: "12558.24",
+  },
+  dueDates: [
+    { dueDate: "2026-08-21", label: "30 jours net", amount: "6279.12" },
+    { dueDate: "2026-09-20", label: "60 jours net", amount: "6279.12" },
+  ],
+  customerText: "Règlement par virement sur le compte habituel, en rappelant le numéro de facture.",
+  snapshotUuid: "3f6a1c88-2b4d-4a11-9d0e-5c7b2a9e4d31",
+  draftReference: "BRO-2026-0142",
+};
+
+const AVOIR: FinanceDocumentInput = {
+  ...FACTURE,
+  kind: "AVOIR",
+  number: "AV-2026-0007",
+  correctedInvoice: "FA-2026-0142",
+  reasonCode: "NON_CONFORME",
+  reason: "Pièces refusées au contrôle réception : cote hors tolérance sur le lot LOT-2026-0002.",
+  dueDates: [],
+  customerText: null,
+  lines: [ligne({ quantity: "4", totalExTax: "729.60", taxAmount: "145.92", totalInclTax: "875.52" })],
+  totals: {
+    subtotalExTax: "729.60",
+    globalDiscountPercent: "0.00",
+    globalDiscountAmount: "0.00",
+    totalExTax: "729.60",
+    totalTax: "145.92",
+    totalInclTax: "875.52",
+  },
+};
+
+describe("ventilation de la TVA", () => {
+  it("regroupe par taux et somme en centimes", () => {
+    // Mention obligatoire : base HT et montant de taxe pour chaque taux applique.
+    const taxes = taxBreakdown([
+      ligne({ taxRatePercent: "20.00", totalExTax: "100.00", taxAmount: "20.00" }),
+      ligne({ taxRatePercent: "20.00", totalExTax: "50.05", taxAmount: "10.01" }),
+      ligne({ taxRatePercent: "5.50", totalExTax: "10.10", taxAmount: "0.56" }),
+    ]);
+
+    expect(taxes).toEqual([
+      { ratePercent: "5.50", baseExTax: "10.10", taxAmount: "0.56" },
+      { ratePercent: "20.00", baseExTax: "150.05", taxAmount: "30.01" },
+    ]);
+  });
+
+  it("ne derive pas en virgule flottante sur des montants a un centime", () => {
+    // 0.1 + 0.2 en flottant donne 0.30000000000000004 : la somme se fait en centiers entiers.
+    const taxes = taxBreakdown([
+      ligne({ taxRatePercent: "20.00", totalExTax: "0.10", taxAmount: "0.02" }),
+      ligne({ taxRatePercent: "20.00", totalExTax: "0.20", taxAmount: "0.04" }),
+    ]);
+    expect(taxes[0].baseExTax).toBe("0.30");
+  });
+
+  it("ne recalcule jamais la taxe a partir du taux", () => {
+    // Le referentiel fait foi : si la taxe fournie est 0, le document affiche 0 — il ne
+    // reapplique pas 20 % de son propre chef.
+    const taxes = taxBreakdown([ligne({ taxRatePercent: "20.00", totalExTax: "100.00", taxAmount: "0.00" })]);
+    expect(taxes[0].taxAmount).toBe("0.00");
+  });
+});
+
+describe("format des montants", () => {
+  it("rend un montant a la francaise sans toucher aux chiffres", () => {
+    expect(money("10465.20", "EUR")).toBe("10 465,20 €");
+    expect(money("182.40", "EUR")).toBe("182,40 €");
+    expect(money("0.00", "EUR")).toBe("0,00 €");
+    expect(money("1234567.89", "EUR")).toBe("1 234 567,89 €");
+  });
+
+  it("conserve le signe d'un montant negatif", () => {
+    // Un montant negatif devenu positif ferait mentir la piece.
+    expect(money("-313.96", "EUR")).toBe("-313,96 €");
+  });
+
+  it("rend un pourcentage a la francaise", () => {
+    expect(percent("20.00")).toBe("20,00 %");
+    expect(percent("5.5")).toBe("5,5 %");
+  });
+
+  it("garde le code ISO pour une autre devise", () => {
+    expect(money("100.00", "USD")).toBe("100,00 USD");
+  });
+
+  it("ne perd pas une valeur qui n'est pas un nombre", () => {
+    expect(money("n/a", "EUR")).toBe("n/a €");
+  });
+});
+
+describe("identite des parties", () => {
+  it("imprime les mentions fiscales quand elles existent", () => {
+    const lines = partyLines(ISSUER);
+    expect(lines).toContain("SIRET 123 456 789 00012");
+    expect(lines).toContain("TVA FR12345678900");
+    expect(lines).toContain("CROIX ROUSSE PRECISION");
+  });
+
+  it("n'invente aucune mention absente", () => {
+    // Une identite reduite ne doit pas produire de « SIRET — » ni de ligne vide.
+    const lines = partyLines({ company_name: "ATELIER DU VAL DE SAONE" });
+    expect(lines).toEqual(["ATELIER DU VAL DE SAONE"]);
+  });
+
+  it("n'imprime jamais l'identifiant technique du client", () => {
+    expect(partyLines(CLIENT).join("\n")).not.toContain(CLIENT_UUID);
+  });
+});
+
+describe("facture — rendu reel", () => {
+  it("scenario 1 (facture emise, 2 taux) : une page, mentions portees", async () => {
+    const bytes = await renderFinanceDocument(FACTURE);
+    keep("60-facture-emise", bytes);
+
+    expect(bytes.byteLength).toBeGreaterThan(1000);
+    const pages = drawnPages(bytes);
+    expect(pages).toHaveLength(1);
+
+    const text = pages[0];
+    expect(text).toContain("FA-2026-0142");
+    expect(text).toContain("Page 1 / 1");
+    // Identite des deux parties, mentions fiscales comprises.
+    expect(text).toContain("CROIX ROUSSE PRECISION");
+    expect(text).toContain("SIRET 123 456 789 00012");
+    expect(text).toContain("ABB FRANCE");
+    expect(text).toContain("TVA FR98765432100");
+    // Ventilation de la TVA et totaux.
+    expect(text).toContain("RÉCAPITULATIF");
+      expect(text).toContain("MONTANT TVA");
+    expect(text).toContain("2 093,04 €");
+    // Echeances.
+    expect(text).toContain("21/08/2026");
+    expect(text).toContain("30 jours net");
+  }, 60_000);
+
+  it("n'imprime jamais l'identifiant technique du client", async () => {
+    // Regression : l'ancienne version ecrivait `ID: <uuid>` sous la raison sociale.
+    const bytes = await renderFinanceDocument(FACTURE);
+    expect(drawnText(bytes)).not.toContain(CLIENT_UUID);
+  }, 60_000);
+
+  it("scenario 2 (brouillon) : se denonce comme non transmissible", async () => {
+    // Un brouillon imprime n'a aucune valeur fiscale : il doit le dire lui-meme.
+    const bytes = await renderFinanceDocument({ ...FACTURE, draft: true, snapshotUuid: null });
+    keep("61-facture-brouillon", bytes);
+
+    const text = drawnText(bytes);
+    expect(text).toContain("Brouillon");
+    expect(text).toContain("NE PAS TRANSMETTRE");
+  }, 60_000);
+
+  it("scenario 3 (remise globale) : sous-total et remise apparaissent", async () => {
+    const bytes = await renderFinanceDocument({
+      ...FACTURE,
+      totals: { ...FACTURE.totals, globalDiscountPercent: "3.00", globalDiscountAmount: "313.96" },
+    });
+    keep("62-facture-remise", bytes);
+
+    const text = drawnText(bytes);
+    expect(text).toContain("Sous-total HT");
+    expect(text).toContain("Remise globale (3,00 %)");
+    // La remise est bien retranchee a l'affichage, jamais presentee en positif.
+    expect(text).toContain("- 313,96 €");
+  }, 60_000);
+
+  it("scenario 4 (40 lignes) : pagine et reemet l'en-tete de table", async () => {
+    const bytes = await renderFinanceDocument({
+      ...FACTURE,
+      lines: Array.from({ length: 40 }, (_, index) =>
+        ligne({ designation: `Composant usiné référence ${index + 1} — plan 46${index}-A indice B` })
+      ),
+    });
+    keep("63-facture-volume", bytes);
+
+    const pages = drawnPages(bytes);
+    expect(pages.length).toBeGreaterThan(1);
+    for (const page of pages) {
+      if (/PT-4501-A/.test(page)) expect(page).toContain("DÉSIGNATION");
+    }
+    pages.forEach((page, index) => {
+      expect(page).toContain(`Page ${index + 1} / ${pages.length}`);
+      if (index > 0) expect(page).toContain("FA-2026-0142");
+    });
+  }, 90_000);
+
+  it("scenario 5 (identite emetteur incomplete) : le document reste lisible", async () => {
+    // Le referentiel `factureur` est historique : rien ne garantit qu'il porte SIRET et TVA.
+    // Le document ne doit alors ni planter, ni afficher de mention vide.
+    const bytes = await renderFinanceDocument({
+      ...FACTURE,
+      issuer: { biller_name: "CROIX ROUSSE PRECISION" },
+      client: { company_name: "ATELIER DU VAL DE SAONE" },
+    });
+    keep("64-facture-emetteur-minimal", bytes);
+
+    const text = drawnText(bytes);
+    expect(text).toContain("CROIX ROUSSE PRECISION");
+    expect(text).toContain("ATELIER DU VAL DE SAONE");
+    // Aucune mention fiscale inventee, aucune etiquette laissee vide.
+    expect(text).not.toContain("SIRET ");
+    expect(text).not.toContain("TVA FR");
+    expect(drawnPages(bytes)).toHaveLength(1);
+  }, 60_000);
+
+  it("les accents et le tiret cadratin survivent a WinAnsi", async () => {
+    const bytes = await renderFinanceDocument(FACTURE);
+    const text = drawnText(bytes);
+    expect(text).toContain("DÉSIGNATION");
+    expect(text).toContain("Émetteur".toUpperCase());
+    expect(text).toContain("316L — usinage complet");
+  }, 60_000);
+});
+
+describe("avoir — rendu reel", () => {
+  it("scenario 6 (avoir emis) : facture corrigee et motif portes", async () => {
+    const bytes = await renderFinanceDocument(AVOIR);
+    keep("65-avoir-emis", bytes);
+
+    const pages = drawnPages(bytes);
+    expect(pages).toHaveLength(1);
+
+    const text = pages[0];
+    expect(text).toContain("AV-2026-0007");
+    expect(text).toContain("FA-2026-0142");
+    expect(text).toContain("NON_CONFORME");
+    expect(text).toContain("Total TTC à créditer");
+    expect(text).toContain("Page 1 / 1");
+  }, 60_000);
+
+  it("n'affiche pas d'echeances : un avoir ne se regle pas", async () => {
+    const bytes = await renderFinanceDocument(AVOIR);
+    expect(drawnText(bytes)).not.toContain("ÉCHÉANCES DE RÈGLEMENT");
+  }, 60_000);
+
+  it("n'imprime jamais l'identifiant technique du client", async () => {
+    const bytes = await renderFinanceDocument(AVOIR);
+    expect(drawnText(bytes)).not.toContain(CLIENT_UUID);
+  }, 60_000);
+});
+
+describe("facture et avoir partagent la meme grammaire", () => {
+  it("portent tous deux le pied de page pagine et le rappel d'identite", async () => {
+    const [facture, avoir] = await Promise.all([
+      renderFinanceDocument(FACTURE),
+      renderFinanceDocument(AVOIR),
+    ]);
+    for (const bytes of [facture, avoir]) {
+      const text = drawnText(bytes);
+      expect(text).toContain("CROIX ROUSSE PRECISION");
+      expect(text).toContain("Page 1 / 1");
+      expect(text).toContain("RÉCAPITULATIF");
+      expect(text).toContain("MONTANT TVA");
+    }
+  }, 90_000);
+});

--- a/src/module/facturation/services/finance-document-render.ts
+++ b/src/module/facturation/services/finance-document-render.ts
@@ -1,0 +1,454 @@
+import {
+  CONTENT_WIDTH,
+  renderCerpDocument,
+  type CerpAddressCard,
+  type CerpDocumentContext,
+  type CerpLineRow,
+} from "../../../shared/pdf/cerp-document";
+
+/**
+ * Rendu unique des documents financiers CERP : facture et avoir.
+ *
+ * Ces deux pieces sont **fiscales**. Elles ne sont pas seulement envoyees au client : elles
+ * font foi, sont conservees, et leur contenu est encadre par la loi. Le rendu est donc au
+ * serveur (ADR-0042), et il porte la grammaire CERP comme les autres documents sortants.
+ *
+ * Trois chemins produisaient auparavant ces documents avec trois mises en page differentes —
+ * dont deux pour la seule facture, l'une pour le brouillon et l'autre pour l'exemplaire legal
+ * immuable. Un client pouvait recevoir un brouillon puis une facture d'aspect completement
+ * different pour le meme montant.
+ */
+
+/** Partie d'un document financier : emetteur ou client, telle que figee dans l'instantane. */
+export type FinanceParty = Record<string, unknown>;
+
+export type FinanceTaxLine = {
+  ratePercent: string;
+  baseExTax: string;
+  taxAmount: string;
+};
+
+export type FinanceDocumentLine = {
+  designation: string;
+  codePiece: string | null;
+  quantity: string;
+  unit: string | null;
+  unitPriceExTax: string;
+  discountPercent: string;
+  taxRatePercent: string;
+  totalExTax: string;
+  taxAmount: string;
+  totalInclTax: string;
+};
+
+export type FinanceDocumentTotals = {
+  subtotalExTax: string;
+  globalDiscountPercent: string;
+  globalDiscountAmount: string;
+  totalExTax: string;
+  totalTax: string;
+  totalInclTax: string;
+};
+
+export type FinanceDocumentInput = {
+  kind: "FACTURE" | "AVOIR";
+  /** Numero legal, ou reference de brouillon si le document n'est pas encore emis. */
+  number: string;
+  /** `true` tant que le document n'est pas emis : il doit alors le dire. */
+  draft: boolean;
+  issueDate: string;
+  currency: string;
+  issuer: FinanceParty;
+  client: FinanceParty;
+  lines: FinanceDocumentLine[];
+  totals: FinanceDocumentTotals;
+  dueDates: Array<{ dueDate: string; label: string; amount: string }>;
+  /** Avoir : facture corrigee et motif. */
+  correctedInvoice?: string | null;
+  reasonCode?: string | null;
+  reason?: string | null;
+  /** Texte destine au client. Jamais le commentaire interne. */
+  customerText?: string | null;
+  /** Empreinte de l'instantane immuable, quand le document est emis. */
+  snapshotUuid?: string | null;
+  draftReference?: string | null;
+};
+
+function clean(value: unknown): string | null {
+  const s = typeof value === "string" ? value.trim() : typeof value === "number" ? String(value) : "";
+  return s ? s : null;
+}
+
+/** Premiere valeur non vide parmi plusieurs cles possibles. L'instantane est libre de forme. */
+function pick(source: FinanceParty, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = clean(source[key]);
+    if (value) return value;
+  }
+  return null;
+}
+
+export function formatDateFR(iso: string | null | undefined): string {
+  if (!iso) return "-";
+  const raw = String(iso);
+  const m = raw.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  if (m) return `${m[3]}/${m[2]}/${m[1]}`;
+  return raw;
+}
+
+/** Pourcentage a la francaise : `20,00 %`. Meme regle que `money` — aucun chiffre change. */
+export function percent(value: string): string {
+  const raw = String(value ?? "").trim();
+  if (!/^-?\d+(?:[.,]\d+)?$/.test(raw)) return `${raw} %`.trim();
+  return `${raw.replace(".", ",")} %`;
+}
+
+/**
+ * Montant au format francais : `10 465,20 €`.
+ *
+ * Le referentiel fournit des chaines a point decimal (`10465.20`) et le document les sortait
+ * telles quelles, avec le code ISO — sur une facture francaise, et alors que les documents
+ * rendus dans le navigateur affichent deja `10 465,20 €` pour la meme entreprise.
+ *
+ * **Aucun chiffre n'est modifie** : seuls les separateurs changent. Une chaine qui n'est pas un
+ * nombre est rendue telle quelle plutot que d'etre perdue.
+ */
+export function money(amount: string, currency: string): string {
+  const raw = String(amount ?? "").trim();
+  const symbol = currency === "EUR" ? "€" : currency;
+
+  const match = raw.match(/^(-?)(\d+)(?:[.,](\d+))?$/);
+  if (!match) return `${raw} ${symbol}`.trim();
+
+  const [, sign, whole, decimals] = match;
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+  return `${sign}${grouped}${decimals ? `,${decimals}` : ""} ${symbol}`;
+}
+
+/**
+ * Identite d'une partie, en lignes.
+ *
+ * Sur une facture, l'identite du vendeur et celle de l'acheteur sont des mentions
+ * **obligatoires** : denomination, adresse, SIRET, numero de TVA intracommunautaire. On lit
+ * l'instantane de facon defensive — sa forme appartient au referentiel — et on n'affiche que
+ * ce qui existe reellement. Une mention absente n'est jamais remplacee par un substitut.
+ */
+export function partyLines(party: FinanceParty): string[] {
+  const nested =
+    party.billing_address && typeof party.billing_address === "object"
+      ? (party.billing_address as FinanceParty)
+      : {};
+
+  const streetFromNested = [pick(nested, "house_number"), pick(nested, "street")].filter(Boolean).join(" ");
+  const cityLine = [
+    pick(party, "postal_code", "code_postal") ?? pick(nested, "postal_code"),
+    pick(party, "city", "ville") ?? pick(nested, "city"),
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const identity = [
+    pick(party, "company_name", "name", "raison_sociale", "biller_name"),
+    pick(party, "address_line_1", "address", "adresse") ?? (streetFromNested || null),
+    pick(party, "address_line_2", "adresse_complement") ?? pick(nested, "address_complement"),
+    cityLine || null,
+    pick(party, "country", "pays") ?? pick(nested, "country"),
+  ];
+
+  const legal = [
+    pick(party, "siret") ? `SIRET ${pick(party, "siret")}` : null,
+    pick(party, "siren") ? `SIREN ${pick(party, "siren")}` : null,
+    pick(party, "rcs") ? `RCS ${pick(party, "rcs")}` : null,
+    pick(party, "vat_number", "numero_tva", "tva_intracommunautaire")
+      ? `TVA ${pick(party, "vat_number", "numero_tva", "tva_intracommunautaire")}`
+      : null,
+    pick(party, "capital_social") ? `Capital ${pick(party, "capital_social")}` : null,
+  ];
+
+  return [...identity, ...legal].filter((line): line is string => Boolean(line));
+}
+
+/**
+ * Ventilation de la TVA par taux.
+ *
+ * Mention **obligatoire** sur une facture : pour chaque taux applique, la base hors taxes et
+ * le montant de taxe correspondant. Elle est entierement derivee des lignes — aucun montant
+ * n'est recalcule, les chaines viennent telles quelles du referentiel et sont sommees en
+ * centimes pour eviter toute derive en virgule flottante.
+ */
+export function taxBreakdown(lines: FinanceDocumentLine[]): FinanceTaxLine[] {
+  const toCents = (value: string): number => {
+    const n = Number.parseFloat(String(value).replace(/\s/g, "").replace(",", "."));
+    return Number.isFinite(n) ? Math.round(n * 100) : 0;
+  };
+  const fromCents = (cents: number): string => (cents / 100).toFixed(2);
+
+  const byRate = new Map<string, { base: number; tax: number }>();
+  for (const line of lines) {
+    const rate = clean(line.taxRatePercent) ?? "0";
+    const bucket = byRate.get(rate) ?? { base: 0, tax: 0 };
+    bucket.base += toCents(line.totalExTax);
+    bucket.tax += toCents(line.taxAmount);
+    byRate.set(rate, bucket);
+  }
+
+  return [...byRate.entries()]
+    .sort((a, b) => Number.parseFloat(a[0]) - Number.parseFloat(b[0]))
+    .map(([ratePercent, sums]) => ({
+      ratePercent,
+      baseExTax: fromCents(sums.base),
+      taxAmount: fromCents(sums.tax),
+    }));
+}
+
+/**
+ * Recapitulatif : ventilation de la TVA a gauche, totaux a droite.
+ *
+ * Les deux occupent la meme bande. Empiles, ils poussaient une facture de deux lignes sur une
+ * seconde page presque vide — et c'est aussi la disposition d'usage sur une facture.
+ */
+function summaryBlock(
+  ctx: CerpDocumentContext,
+  taxes: FinanceTaxLine[],
+  totals: Array<{ label: string; value: string; strong?: boolean }>,
+  currency: string
+): void {
+  const gap = 24;
+  const totalsWidth = 226;
+  const taxWidth = CONTENT_WIDTH - totalsWidth - gap;
+  const taxX = 38;
+  const totalsX = 38 + CONTENT_WIDTH - totalsWidth;
+
+  const taxHeight = 14 + Math.max(1, taxes.length) * 14;
+  const totalsHeight = totals.reduce((sum, row) => sum + (row.strong ? 18 : 15), 0);
+
+  ctx.y += 12;
+  ctx.ensureSpace(Math.max(taxHeight, totalsHeight) + 8);
+  const top = ctx.y;
+
+  // ── Ventilation de la TVA : mention obligatoire, base et taxe pour chaque taux applique.
+  const cols = [
+    { label: "Taux", w: taxWidth * 0.22, align: "left" as const },
+    { label: "Base HT", w: taxWidth * 0.39, align: "right" as const },
+    { label: "Montant TVA", w: taxWidth * 0.39, align: "right" as const },
+  ];
+  ctx.doc.font("Helvetica").fontSize(6.9).fillColor("#6E7681");
+  let colX = taxX;
+  for (const col of cols) {
+    ctx.text(col.label.toUpperCase(), colX, top, { width: col.w - 6, align: col.align, characterSpacing: 0.75 });
+    colX += col.w;
+  }
+
+  ctx.doc.save();
+  ctx.doc.lineWidth(0.8).strokeColor("#101418");
+  ctx.doc.moveTo(taxX, top + 11).lineTo(taxX + taxWidth, top + 11).stroke();
+  ctx.doc.restore();
+
+  let taxY = top + 16;
+  const rows = taxes.length ? taxes : null;
+  if (!rows) {
+    ctx.doc.font("Helvetica").fontSize(9.5).fillColor("#6E7681");
+    ctx.text("Aucune taxe applicable.", taxX, taxY, { width: taxWidth });
+    taxY += 14;
+  } else {
+    for (const tax of rows) {
+      const cells = [percent(tax.ratePercent), money(tax.baseExTax, currency), money(tax.taxAmount, currency)];
+      colX = taxX;
+      cells.forEach((cell, index) => {
+        ctx.doc
+          .font(index === 0 ? "Helvetica-Bold" : "Helvetica")
+          .fontSize(9)
+          .fillColor("#101418");
+        ctx.text(cell, colX, taxY, { width: cols[index].w - 6, align: cols[index].align });
+        colX += cols[index].w;
+      });
+      taxY += 14;
+    }
+  }
+
+  // ── Totaux.
+  let totalsY = top;
+  for (const row of totals) {
+    ctx.doc
+      .font(row.strong ? "Helvetica-Bold" : "Helvetica")
+      .fontSize(row.strong ? 11 : 9.5)
+      .fillColor("#101418");
+    if (row.strong) {
+      ctx.doc.save();
+      ctx.doc.lineWidth(0.8).strokeColor("#B90101");
+      ctx.doc.moveTo(totalsX, totalsY - 4).lineTo(totalsX + totalsWidth, totalsY - 4).stroke();
+      ctx.doc.restore();
+    }
+    ctx.text(row.label, totalsX, totalsY, { width: totalsWidth - 104 });
+    ctx.text(row.value, totalsX + totalsWidth - 104, totalsY, { width: 104, align: "right" });
+    totalsY += row.strong ? 18 : 15;
+  }
+
+  ctx.y = Math.max(taxY, totalsY);
+  ctx.doc.fillColor("#101418");
+}
+
+function partyCards(input: FinanceDocumentInput): CerpAddressCard[] {
+  return [
+    { caption: "Émetteur", lines: partyLines(input.issuer), accent: true, emptyLabel: "Non renseigné" },
+    {
+      caption: input.kind === "AVOIR" ? "Client crédité" : "Client facturé",
+      lines: partyLines(input.client),
+      emptyLabel: "Non renseigné",
+    },
+  ];
+}
+
+function documentLines(input: FinanceDocumentInput): CerpLineRow[] {
+  return input.lines.map((line) => {
+    const details = [
+      clean(line.codePiece),
+      clean(line.unit) ? `Unité : ${line.unit}` : null,
+      clean(line.discountPercent) && Number.parseFloat(line.discountPercent) !== 0
+        ? `Remise ${percent(line.discountPercent)}`
+        : null,
+    ].filter(Boolean);
+
+    return {
+      metaColumn: "designation",
+      meta: details.length ? details.join(" · ") : null,
+      cells: {
+        designation: line.designation,
+        quantite: clean(line.quantity) ?? "—",
+        pu: money(line.unitPriceExTax, input.currency),
+        tva: percent(line.taxRatePercent),
+        ht: money(line.totalExTax, input.currency),
+      },
+    };
+  });
+}
+
+/** Rattachement de l'exemplaire a l'instantane conserve, quand il existe. */
+function traceabilityNote(input: FinanceDocumentInput): string | null {
+  const parts = [
+    clean(input.snapshotUuid) ? `Instantané immuable ${input.snapshotUuid}` : null,
+    clean(input.draftReference) ? `Référence brouillon ${input.draftReference}` : null,
+  ].filter(Boolean);
+  return parts.length ? parts.join(" · ") : null;
+}
+
+export async function renderFinanceDocument(input: FinanceDocumentInput): Promise<Buffer> {
+  const isAvoir = input.kind === "AVOIR";
+  const documentType = isAvoir ? "Avoir" : "Facture";
+  const clientName = pick(input.client, "company_name", "name", "raison_sociale") ?? "Client";
+  const taxes = taxBreakdown(input.lines);
+
+  return renderCerpDocument(
+    {
+      documentType,
+      name: input.number,
+      code: formatDateFR(input.issueDate),
+      subtitle: clientName,
+      // Un brouillon doit se denoncer comme tel : sans cela, imprime, il passerait pour une
+      // piece emise — et une facture non emise n'a aucune valeur fiscale.
+      status: input.draft ? "Brouillon" : "Émis",
+      flag: input.draft ? "Ne pas transmettre" : null,
+      monogramName: clientName,
+      generatedAt: formatDateFR(input.issueDate),
+      generatedBy: null,
+      title: `${documentType} ${input.number}`,
+      subject: `${documentType} CERP`,
+      // Tracabilite de l'exemplaire, portee par toutes les pages : c'est ce qui permet de
+      // rattacher un PDF retrouve chez le client a l'instantane immuable conserve.
+      footerNote: traceabilityNote(input),
+      creationDate: new Date(`${input.issueDate.slice(0, 10)}T12:00:00.000Z`),
+    },
+    (ctx) => {
+      ctx.legalStrip(
+        isAvoir
+          ? [
+              { label: "Numéro d'avoir", value: input.number },
+              { label: "Date d'émission", value: formatDateFR(input.issueDate) },
+              { label: "Facture corrigée", value: clean(input.correctedInvoice) },
+              { label: "Devise", value: input.currency },
+            ]
+          : [
+              { label: "Numéro de facture", value: input.number },
+              { label: "Date d'émission", value: formatDateFR(input.issueDate) },
+              { label: "Échéance", value: input.dueDates.length ? formatDateFR(input.dueDates.at(-1)?.dueDate) : null },
+              { label: "Devise", value: input.currency },
+            ]
+      );
+
+      ctx.section("Parties", { cohesion: 90 });
+      ctx.addressCards(partyCards(input));
+
+      if (isAvoir && clean(input.reason)) {
+        ctx.notesSection(
+          "Motif",
+          clean(input.reasonCode) ? `${input.reasonCode} — ${input.reason}` : (input.reason as string)
+        );
+      }
+
+      ctx.section(isAvoir ? "Lignes créditées" : "Lignes facturées", { cohesion: 104 });
+      ctx.linesTable({
+        columns: [
+          { key: "designation", label: "Désignation", flex: 4.6 },
+          { key: "quantite", label: "Quantité", flex: 1.1, align: "right" },
+          { key: "pu", label: "PU HT", flex: 1.7, align: "right" },
+          { key: "tva", label: "TVA", flex: 0.9, align: "right" },
+          { key: "ht", label: "Total HT", flex: 1.7, align: "right" },
+        ],
+        rows: documentLines(input),
+        emptyLabel: isAvoir ? "Aucune ligne créditée." : "Aucune ligne facturée.",
+      });
+
+      const hasGlobalDiscount =
+        clean(input.totals.globalDiscountAmount) && Number.parseFloat(input.totals.globalDiscountAmount) !== 0;
+
+      ctx.section("Récapitulatif", { cohesion: 74 });
+      summaryBlock(
+        ctx,
+        taxes,
+        [
+          ...(hasGlobalDiscount
+            ? [
+                { label: "Sous-total HT", value: money(input.totals.subtotalExTax, input.currency) },
+                {
+                  label: `Remise globale (${percent(input.totals.globalDiscountPercent)})`,
+                  value: `- ${money(input.totals.globalDiscountAmount, input.currency)}`,
+                },
+              ]
+            : []),
+          { label: "Total HT", value: money(input.totals.totalExTax, input.currency) },
+          { label: "TVA", value: money(input.totals.totalTax, input.currency) },
+          {
+            label: isAvoir ? "Total TTC à créditer" : "Total TTC",
+            value: money(input.totals.totalInclTax, input.currency),
+            strong: true,
+          },
+        ],
+        input.currency
+      );
+
+      if (!isAvoir && input.dueDates.length) {
+        ctx.section("Échéances de règlement", { cohesion: 60 });
+        ctx.linesTable({
+          columns: [
+            { key: "date", label: "Échéance", flex: 1.6 },
+            { key: "label", label: "Libellé", flex: 4 },
+            { key: "montant", label: "Montant", flex: 2, align: "right" },
+          ],
+          rows: input.dueDates.map((due) => ({
+            metaColumn: "date",
+            cells: {
+              date: formatDateFR(due.dueDate),
+              label: clean(due.label) ?? "—",
+              montant: money(due.amount, input.currency),
+            },
+          })),
+          emptyLabel: "Aucune échéance.",
+        });
+      }
+
+      if (clean(input.customerText)) {
+        ctx.notesSection("Informations client", input.customerText as string);
+      }
+    }
+  );
+}

--- a/src/module/facturation/services/finance-document.service.ts
+++ b/src/module/facturation/services/finance-document.service.ts
@@ -2,253 +2,23 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 
-import PDFDocument from "pdfkit";
-
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import type {
   FinanceDocumentArtifact,
   FinanceDocumentSnapshot,
 } from "../repository/facture-workflow.repository";
 
-function textValue(source: Record<string, unknown>, ...keys: string[]): string | null {
-  for (const key of keys) {
-    const value = source[key];
-    if (typeof value === "string" && value.trim()) return value.trim();
-  }
-  return null;
-}
+import { renderFinanceDocument } from "./finance-document-render";
 
-function renderParty(
-  doc: PDFKit.PDFDocument,
-  title: string,
-  party: Record<string, unknown>
-): void {
-  doc.font("Helvetica-Bold").fontSize(10).fillColor("#172033").text(title);
-  doc.font("Helvetica").fontSize(9).fillColor("#172033");
-
-  const nestedAddress =
-    party.billing_address && typeof party.billing_address === "object"
-      ? (party.billing_address as Record<string, unknown>)
-      : {};
-  const addressLine = [
-    textValue(nestedAddress, "house_number"),
-    textValue(nestedAddress, "street"),
-  ]
-    .filter(Boolean)
-    .join(" ");
-  const lines = [
-    textValue(party, "company_name", "name", "raison_sociale"),
-    textValue(party, "address_line_1", "address", "adresse") || addressLine,
-    textValue(party, "address_line_2", "adresse_complement") ||
-      textValue(nestedAddress, "address_complement"),
-    [
-      textValue(party, "postal_code", "code_postal") ||
-        textValue(nestedAddress, "postal_code"),
-      textValue(party, "city", "ville") || textValue(nestedAddress, "city"),
-    ]
-      .filter(Boolean)
-      .join(" "),
-    textValue(party, "country", "pays") || textValue(nestedAddress, "country"),
-  ].filter((value): value is string => Boolean(value));
-
-  for (const line of lines) doc.text(line);
-
-  const siret = textValue(party, "siret");
-  const vat = textValue(party, "vat_number", "numero_tva", "tva_intracommunautaire");
-  if (siret) doc.text(`SIRET : ${siret}`);
-  if (vat) doc.text(`TVA : ${vat}`);
-}
-
-function formatDate(value: string): string {
-  const match = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  return match ? `${match[3]}/${match[2]}/${match[1]}` : value;
-}
-
-function renderSnapshot(doc: PDFKit.PDFDocument, snapshot: FinanceDocumentSnapshot): void {
-  doc.info.Title = `Facture ${snapshot.legal_number}`;
-  doc.info.Subject = "Facture émise depuis un instantané immuable";
-  doc.info.CreationDate = new Date(`${snapshot.issue_date}T12:00:00.000Z`);
-
-  doc
-    .font("Helvetica-Bold")
-    .fontSize(21)
-    .fillColor("#172033")
-    .text("FACTURE", { align: "right" });
-  doc.font("Helvetica").fontSize(10);
-  doc.text(`N° ${snapshot.legal_number}`, { align: "right" });
-  doc.text(`Émise le ${formatDate(snapshot.issue_date)}`, { align: "right" });
-  doc.text(`Référence brouillon ${snapshot.draft_reference}`, { align: "right" });
-
-  const partyY = Math.max(doc.y + 22, 105);
-  doc.save();
-  doc.rect(40, partyY, 250, 112).fillAndStroke("#f7f9fc", "#d8dee9");
-  doc.restore();
-  doc.x = 52;
-  doc.y = partyY + 12;
-  renderParty(doc, "Émetteur", snapshot.issuer_snapshot);
-
-  doc.save();
-  doc.rect(305, partyY, 250, 112).fillAndStroke("#ffffff", "#d8dee9");
-  doc.restore();
-  doc.x = 317;
-  doc.y = partyY + 12;
-  renderParty(doc, "Client facturé", snapshot.client_snapshot);
-
-  let y = partyY + 140;
-  const columns = {
-    designation: 218,
-    quantity: 55,
-    unitPrice: 72,
-    tax: 52,
-    total: 78,
-  };
-  const tableWidth = Object.values(columns).reduce((sum, value) => sum + value, 0);
-
-  const drawHeader = () => {
-    doc.save();
-    doc.rect(40, y, tableWidth, 22).fill("#172033");
-    doc.restore();
-    doc.font("Helvetica-Bold").fontSize(8).fillColor("#ffffff");
-    doc.text("Désignation", 46, y + 7, { width: columns.designation - 12 });
-    doc.text("Qté", 40 + columns.designation, y + 7, {
-      width: columns.quantity - 6,
-      align: "right",
-    });
-    doc.text("PU HT", 40 + columns.designation + columns.quantity, y + 7, {
-      width: columns.unitPrice - 6,
-      align: "right",
-    });
-    doc.text("TVA", 40 + columns.designation + columns.quantity + columns.unitPrice, y + 7, {
-      width: columns.tax - 6,
-      align: "right",
-    });
-    doc.text(
-      "Total TTC",
-      40 + columns.designation + columns.quantity + columns.unitPrice + columns.tax,
-      y + 7,
-      { width: columns.total - 6, align: "right" }
-    );
-    y += 22;
-  };
-
-  drawHeader();
-  for (const line of snapshot.lines) {
-    const rowHeight = Math.max(
-      25,
-      doc.heightOfString(line.designation, { width: columns.designation - 12 }) + 12
-    );
-    if (y + rowHeight > doc.page.height - 150) {
-      doc.addPage();
-      y = 45;
-      drawHeader();
-    }
-    doc.save();
-    doc.rect(40, y, tableWidth, rowHeight).fillAndStroke("#ffffff", "#e5e9f0");
-    doc.restore();
-    doc.font("Helvetica").fontSize(8).fillColor("#172033");
-    doc.text(line.designation, 46, y + 7, { width: columns.designation - 12 });
-    doc.text(line.quantity, 40 + columns.designation, y + 7, {
-      width: columns.quantity - 6,
-      align: "right",
-    });
-    doc.text(`${line.unit_price_ex_tax} ${snapshot.currency}`, 40 + columns.designation + columns.quantity, y + 7, {
-      width: columns.unitPrice - 6,
-      align: "right",
-    });
-    doc.text(`${line.tax_rate_percent} %`, 40 + columns.designation + columns.quantity + columns.unitPrice, y + 7, {
-      width: columns.tax - 6,
-      align: "right",
-    });
-    doc.text(
-      `${line.total_incl_tax} ${snapshot.currency}`,
-      40 + columns.designation + columns.quantity + columns.unitPrice + columns.tax,
-      y + 7,
-      { width: columns.total - 6, align: "right" }
-    );
-    y += rowHeight;
-  }
-
-  y += 16;
-  if (y > doc.page.height - 185) {
-    doc.addPage();
-    y = 55;
-  }
-  doc.font("Helvetica").fontSize(9).fillColor("#172033");
-  doc.text(`Sous-total HT : ${snapshot.totals.subtotal_ex_tax} ${snapshot.currency}`, 315, y, {
-    width: 240,
-    align: "right",
-  });
-  y += 15;
-  if (snapshot.totals.global_discount_amount !== "0.00") {
-    doc.text(
-      `Remise globale (${snapshot.totals.global_discount_percent} %) : -${snapshot.totals.global_discount_amount} ${snapshot.currency}`,
-      315,
-      y,
-      { width: 240, align: "right" }
-    );
-    y += 15;
-  }
-  doc.text(`Total HT : ${snapshot.totals.total_ex_tax} ${snapshot.currency}`, 315, y, {
-    width: 240,
-    align: "right",
-  });
-  y += 15;
-  doc.text(`TVA : ${snapshot.totals.total_tax} ${snapshot.currency}`, 315, y, {
-    width: 240,
-    align: "right",
-  });
-  y += 17;
-  doc.font("Helvetica-Bold").fontSize(12);
-  doc.text(`Total TTC : ${snapshot.totals.total_incl_tax} ${snapshot.currency}`, 315, y, {
-    width: 240,
-    align: "right",
-  });
-  y += 29;
-
-  doc.font("Helvetica-Bold").fontSize(9).text("Échéances", 40, y);
-  doc.font("Helvetica").fontSize(9);
-  y += 15;
-  for (const due of snapshot.due_dates) {
-    doc.text(
-      `${formatDate(due.due_date)} — ${due.label} — ${due.amount} ${snapshot.currency}`,
-      40,
-      y
-    );
-    y += 14;
-  }
-
-  if (snapshot.customer_text) {
-    y += 10;
-    doc.font("Helvetica-Bold").text("Informations client", 40, y);
-    y += 14;
-    doc.font("Helvetica").text(snapshot.customer_text, 40, y, { width: 515 });
-  }
-
-  doc
-    .font("Helvetica")
-    .fontSize(7)
-    .fillColor("#667085")
-    .text(
-      `Document légal version 1 — instantané immuable ${snapshot.uuid}.`,
-      40,
-      doc.page.height - 48,
-      { width: 515, align: "center" }
-    );
-}
-
-async function buildPdf(snapshot: FinanceDocumentSnapshot): Promise<Buffer> {
-  const doc = new PDFDocument({ size: "A4", margin: 40, compress: true });
-  const chunks: Buffer[] = [];
-  doc.on("data", (chunk) => chunks.push(Buffer.from(chunk)));
-  renderSnapshot(doc, snapshot);
-  doc.end();
-  await new Promise<void>((resolve, reject) => {
-    doc.once("end", resolve);
-    doc.once("error", reject);
-  });
-  return Buffer.concat(chunks);
-}
-
+/**
+ * Exemplaire legal immuable de la facture.
+ *
+ * Le rendu vit dans `finance-document-render.ts`, partage avec l'avoir et avec les brouillons :
+ * trois chemins dessinaient auparavant leur propre mise en page, dont deux pour la seule
+ * facture. Ce service ne s'occupe plus que de l'ecriture du fichier et de son empreinte.
+ *
+ * `flag: "wx"` est deliberé : un exemplaire legal ne s'ecrase jamais.
+ */
 export async function writeImmutableFactureDocument(
   snapshot: FinanceDocumentSnapshot
 ): Promise<FinanceDocumentArtifact> {
@@ -257,7 +27,46 @@ export async function writeImmutableFactureDocument(
   const fileName = `Facture_${safeNumber}_v1.pdf`;
   const storageRoot = ensureDocumentStoragePath();
   const filePath = path.join(storageRoot, `${documentId}.pdf`);
-  const pdf = await buildPdf(snapshot);
+
+  const pdf = await renderFinanceDocument({
+    kind: "FACTURE",
+    number: snapshot.legal_number,
+    draft: false,
+    issueDate: snapshot.issue_date,
+    currency: snapshot.currency,
+    issuer: snapshot.issuer_snapshot,
+    client: snapshot.client_snapshot,
+    lines: snapshot.lines.map((line) => ({
+      designation: line.designation,
+      codePiece: line.code_piece,
+      quantity: line.quantity,
+      unit: line.unit,
+      unitPriceExTax: line.unit_price_ex_tax,
+      discountPercent: line.discount_percent,
+      taxRatePercent: line.tax_rate_percent,
+      totalExTax: line.total_ex_tax,
+      taxAmount: line.tax_amount,
+      totalInclTax: line.total_incl_tax,
+    })),
+    totals: {
+      subtotalExTax: snapshot.totals.subtotal_ex_tax,
+      globalDiscountPercent: snapshot.totals.global_discount_percent,
+      globalDiscountAmount: snapshot.totals.global_discount_amount,
+      totalExTax: snapshot.totals.total_ex_tax,
+      totalTax: snapshot.totals.total_tax,
+      totalInclTax: snapshot.totals.total_incl_tax,
+    },
+    dueDates: snapshot.due_dates.map((due) => ({
+      dueDate: due.due_date,
+      label: due.label,
+      amount: due.amount,
+    })),
+    // `internal_comment` reste dans l'ERP : seul le texte destine au client est imprime.
+    customerText: snapshot.customer_text,
+    snapshotUuid: snapshot.uuid,
+    draftReference: snapshot.draft_reference,
+  });
+
   await fs.writeFile(filePath, pdf, { flag: "wx" });
 
   return {

--- a/src/module/facturation/services/pdf.service.ts
+++ b/src/module/facturation/services/pdf.service.ts
@@ -1,30 +1,30 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import crypto from "node:crypto";
-import PDFDocument from "pdfkit";
 import pool from "../../../config/database";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoGetAvoir } from "../repository/avoirs.repository";
 import { repoGetFacture } from "../repository/factures.repository";
 
-function formatCurrencyEUR(amount: number): string {
-  const n = Number.isFinite(amount) ? amount : 0;
-  return `${n.toFixed(2)} EUR`;
-}
+import { renderFinanceDocument, type FinanceDocumentLine, type FinanceParty } from "./finance-document-render";
 
-function formatDateFR(iso: string | null | undefined): string {
-  if (!iso) return "-";
-  const raw = String(iso);
-  const m = raw.match(/^(\d{4})-(\d{2})-(\d{2})/);
-  if (m) return `${m[3]}/${m[2]}/${m[1]}`;
+/**
+ * Facture et avoir a l'etat de **brouillon**.
+ *
+ * Le rendu vit dans `finance-document-render.ts`, partage avec les exemplaires legaux
+ * immuables : trois chemins dessinaient auparavant leur propre mise en page, dont deux pour la
+ * seule facture. Un client pouvait recevoir un brouillon et une facture d'aspect completement
+ * different pour le meme montant.
+ *
+ * Ces deux fonctions **refusent de s'executer sur un document emis** : l'exemplaire legal est
+ * ecrit une seule fois, par le workflow, et ne se regenere pas.
+ */
 
-  const d = new Date(raw);
-  if (Number.isNaN(d.getTime())) return raw;
-  const dd = String(d.getDate()).padStart(2, "0");
-  const mm = String(d.getMonth() + 1).padStart(2, "0");
-  const yyyy = d.getFullYear();
-  return `${dd}/${mm}/${yyyy}`;
+/** Montant du referentiel (nombre) vers la chaine a deux decimales attendue par le rendu. */
+function amount(value: number | null | undefined): string {
+  const n = typeof value === "number" && Number.isFinite(value) ? value : 0;
+  return n.toFixed(2);
 }
 
 async function ensureDocsDir(): Promise<string> {
@@ -33,86 +33,90 @@ async function ensureDocsDir(): Promise<string> {
   return uploadDir;
 }
 
-function renderTableHeader(doc: PDFKit.PDFDocument, x: number, y: number, widths: number[]) {
-  const [wDesc, wQty, wPu, wTva, wTotal] = widths;
-  doc.fontSize(9).fillColor("#111111").font("Helvetica-Bold");
-  doc.text("Designation", x, y, { width: wDesc });
-  doc.text("Qte", x + wDesc, y, { width: wQty, align: "right" });
-  doc.text("PU HT", x + wDesc + wQty, y, { width: wPu, align: "right" });
-  doc.text("TVA", x + wDesc + wQty + wPu, y, { width: wTva, align: "right" });
-  doc.text("Total TTC", x + wDesc + wQty + wPu + wTva, y, { width: wTotal, align: "right" });
-  doc.moveTo(x, y + 14).lineTo(x + widths.reduce((a, b) => a + b, 0), y + 14).strokeColor("#e5e7eb").stroke();
-  doc.font("Helvetica").fillColor("#111111");
-}
+/**
+ * Identite de l'emetteur, lue en base.
+ *
+ * `to_jsonb` remonte la ligne entiere et on ne retient qu'une **liste blanche** de champs
+ * d'identite fiscale : la table `factureur` est historique et sa forme exacte n'appartient pas
+ * a ce module. Un champ absent reste absent — aucune mention n'est inventee.
+ */
+const ISSUER_LEGAL_FIELDS = [
+  "company_name",
+  "biller_name",
+  "name",
+  "raison_sociale",
+  "address_line_1",
+  "address_line_2",
+  "address",
+  "adresse",
+  "adresse_complement",
+  "postal_code",
+  "code_postal",
+  "city",
+  "ville",
+  "country",
+  "pays",
+  "siret",
+  "siren",
+  "rcs",
+  "vat_number",
+  "numero_tva",
+  "tva_intracommunautaire",
+  "capital_social",
+] as const;
 
-function renderLines(
-  doc: PDFKit.PDFDocument,
-  lines: Array<{ designation: string; quantite: number; prix_unitaire_ht: number; taux_tva: number; total_ttc: number }>,
-  startY: number
-) {
-  const marginX = doc.page.margins.left;
-  const maxY = doc.page.height - doc.page.margins.bottom - 80;
-  const widths = [280, 45, 70, 45, 80];
-  let y = startY;
+async function getIssuerParty(): Promise<FinanceParty> {
+  const res = await pool.query<{ row: Record<string, unknown> }>(
+    `SELECT to_jsonb(f) AS row FROM factureur f ORDER BY f.biller_id ASC LIMIT 1`
+  );
+  const row = res.rows[0]?.row;
+  if (!row || typeof row !== "object") return {};
 
-  renderTableHeader(doc, marginX, y, widths);
-  y += 22;
-
-  doc.fontSize(9).fillColor("#111111");
-
-  for (const l of lines) {
-    const desc = l.designation ?? "";
-    const rowHeight = Math.max(14, doc.heightOfString(desc, { width: widths[0] }));
-    if (y + rowHeight > maxY) {
-      doc.addPage();
-      y = doc.page.margins.top;
-      renderTableHeader(doc, marginX, y, widths);
-      y += 22;
-    }
-
-    doc.text(desc, marginX, y, { width: widths[0] });
-    doc.text(String(l.quantite ?? 0), marginX + widths[0], y, { width: widths[1], align: "right" });
-    doc.text(formatCurrencyEUR(l.prix_unitaire_ht ?? 0), marginX + widths[0] + widths[1], y, {
-      width: widths[2],
-      align: "right",
-    });
-    doc.text(`${Number(l.taux_tva ?? 0).toFixed(0)}%`, marginX + widths[0] + widths[1] + widths[2], y, {
-      width: widths[3],
-      align: "right",
-    });
-    doc.text(formatCurrencyEUR(l.total_ttc ?? 0), marginX + widths[0] + widths[1] + widths[2] + widths[3], y, {
-      width: widths[4],
-      align: "right",
-    });
-
-    y += rowHeight + 6;
-    doc.moveTo(marginX, y).lineTo(marginX + widths.reduce((a, b) => a + b, 0), y).strokeColor("#f1f5f9").stroke();
-    y += 6;
+  const party: FinanceParty = {};
+  for (const key of ISSUER_LEGAL_FIELDS) {
+    if (row[key] !== undefined && row[key] !== null) party[key] = row[key];
   }
-
-  return y;
+  return party;
 }
 
-async function writePdfToFile(
-  filePath: string,
-  render: (doc: PDFKit.PDFDocument) => void
-): Promise<void> {
-  await fs.mkdir(path.dirname(filePath), { recursive: true });
+/**
+ * Identite du client telle que connue du referentiel de facturation.
+ *
+ * ⚠️ `client_id` est un identifiant technique : il n'entre pas dans la partie. L'ancienne
+ * version l'imprimait sous la raison sociale, sur un document adresse au client.
+ */
+function clientParty(client: { company_name?: string | null } | null | undefined): FinanceParty {
+  const name = typeof client?.company_name === "string" ? client.company_name.trim() : "";
+  return name ? { company_name: name } : {};
+}
 
-  const doc = new PDFDocument({ size: "A4", margin: 40 });
-  const chunks: Buffer[] = [];
-  doc.on("data", (c) => chunks.push(c as Buffer));
-
-  render(doc);
-  doc.end();
-
-  await new Promise<void>((resolve, reject) => {
-    doc.on("end", () => resolve());
-    doc.on("error", (err) => reject(err));
-  });
-
-  const buf = Buffer.concat(chunks);
-  await fs.writeFile(filePath, buf);
+function draftLines(
+  lignes: Array<{
+    designation: string;
+    code_piece: string | null;
+    quantite: number;
+    unite: string | null;
+    prix_unitaire_ht: number;
+    remise_ligne: number;
+    taux_tva: number;
+    total_ht: number;
+    total_ttc: number;
+  }>
+): FinanceDocumentLine[] {
+  return lignes.map((line) => ({
+    designation: line.designation,
+    codePiece: line.code_piece,
+    quantity: String(line.quantite ?? 0),
+    unit: line.unite,
+    unitPriceExTax: amount(line.prix_unitaire_ht),
+    discountPercent: amount(line.remise_ligne),
+    taxRatePercent: amount(line.taux_tva),
+    totalExTax: amount(line.total_ht),
+    // Le referentiel du brouillon ne stocke pas la taxe par ligne : elle se deduit des deux
+    // totaux deja calcules, sans jamais reappliquer un taux nous-memes.
+    taxAmount: amount((line.total_ttc ?? 0) - (line.total_ht ?? 0)),
+    totalInclTax: amount(line.total_ttc),
+  }));
 }
 
 export async function svcGenerateFacturePdf(factureId: number): Promise<{ document_id: string }> {
@@ -131,44 +135,30 @@ export async function svcGenerateFacturePdf(factureId: number): Promise<{ docume
   const fileName = `Facture_${detail.facture.numero}.pdf`;
   const filePath = path.join(docsDir, `${documentId}.pdf`);
 
-  await writePdfToFile(filePath, (doc) => {
-    const f = detail.facture;
-    const clientName = f.client?.company_name ?? f.client_id;
-
-    doc.font("Helvetica-Bold").fontSize(20).fillColor("#111111").text("FACTURE", { align: "right" });
-    doc.moveDown(0.5);
-    doc.font("Helvetica").fontSize(11).text(`Numero: ${f.numero}`, { align: "right" });
-    doc.text(`Date: ${formatDateFR(f.date_emission)}`, { align: "right" });
-    doc.text(`Echeance: ${formatDateFR(f.date_echeance)}`, { align: "right" });
-
-    doc.moveDown(1);
-    doc.font("Helvetica-Bold").fontSize(11).text("Client");
-    doc.font("Helvetica").fontSize(11).text(clientName);
-    doc.fillColor("#6b7280").fontSize(9).text(`ID: ${f.client_id}`);
-    doc.fillColor("#111111");
-
-    doc.moveDown(1);
-    const lines = detail.lignes.map((l) => ({
-      designation: l.designation,
-      quantite: l.quantite,
-      prix_unitaire_ht: l.prix_unitaire_ht,
-      taux_tva: l.taux_tva ?? 0,
-      total_ttc: l.total_ttc,
-    }));
-    const afterLinesY = renderLines(doc, lines, doc.y);
-
-    const boxY = Math.min(afterLinesY + 10, doc.page.height - doc.page.margins.bottom - 70);
-    doc.font("Helvetica-Bold").fontSize(11).text("Totaux", doc.page.margins.left, boxY);
-    doc.font("Helvetica").fontSize(11);
-    doc.text(`Total HT: ${formatCurrencyEUR(f.total_ht)}`, { align: "right" });
-    doc.text(`Total TTC: ${formatCurrencyEUR(f.total_ttc)}`, { align: "right" });
-
-    if (f.commentaires) {
-      doc.moveDown(1);
-      doc.font("Helvetica-Bold").fontSize(10).text("Notes");
-      doc.font("Helvetica").fontSize(10).text(String(f.commentaires));
-    }
+  const f = detail.facture;
+  const pdf = await renderFinanceDocument({
+    kind: "FACTURE",
+    number: f.numero,
+    draft: true,
+    issueDate: f.date_emission,
+    currency: "EUR",
+    issuer: await getIssuerParty(),
+    client: clientParty(f.client),
+    lines: draftLines(detail.lignes),
+    totals: {
+      subtotalExTax: amount(f.total_ht),
+      globalDiscountPercent: amount(f.remise_globale),
+      globalDiscountAmount: "0.00",
+      totalExTax: amount(f.total_ht),
+      totalTax: amount((f.total_ttc ?? 0) - (f.total_ht ?? 0)),
+      totalInclTax: amount(f.total_ttc),
+    },
+    dueDates: f.date_echeance ? [{ dueDate: f.date_echeance, label: "Échéance", amount: amount(f.total_ttc) }] : [],
+    customerText: f.commentaires,
+    draftReference: f.numero,
   });
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, pdf);
 
   const db = await pool.connect();
   try {
@@ -210,46 +200,31 @@ export async function svcGenerateAvoirPdf(avoirId: number): Promise<{ document_i
   const fileName = `Avoir_${detail.avoir.numero}.pdf`;
   const filePath = path.join(docsDir, `${documentId}.pdf`);
 
-  await writePdfToFile(filePath, (doc) => {
-    const a = detail.avoir;
-    const clientName = a.client?.company_name ?? a.client_id;
-
-    doc.font("Helvetica-Bold").fontSize(20).fillColor("#111111").text("AVOIR", { align: "right" });
-    doc.moveDown(0.5);
-    doc.font("Helvetica").fontSize(11).text(`Numero: ${a.numero}`, { align: "right" });
-    doc.text(`Date: ${formatDateFR(a.date_emission)}`, { align: "right" });
-    if (a.facture?.numero) {
-      doc.text(`Facture: ${a.facture.numero}`, { align: "right" });
-    }
-
-    doc.moveDown(1);
-    doc.font("Helvetica-Bold").fontSize(11).text("Client");
-    doc.font("Helvetica").fontSize(11).text(clientName);
-    doc.fillColor("#6b7280").fontSize(9).text(`ID: ${a.client_id}`);
-    doc.fillColor("#111111");
-
-    if (a.motif) {
-      doc.moveDown(0.5);
-      doc.font("Helvetica-Bold").fontSize(10).text("Motif");
-      doc.font("Helvetica").fontSize(10).text(String(a.motif));
-    }
-
-    doc.moveDown(1);
-    const lines = detail.lignes.map((l) => ({
-      designation: l.designation,
-      quantite: l.quantite,
-      prix_unitaire_ht: l.prix_unitaire_ht,
-      taux_tva: l.taux_tva ?? 0,
-      total_ttc: l.total_ttc,
-    }));
-    const afterLinesY = renderLines(doc, lines, doc.y);
-
-    const boxY = Math.min(afterLinesY + 10, doc.page.height - doc.page.margins.bottom - 70);
-    doc.font("Helvetica-Bold").fontSize(11).text("Totaux", doc.page.margins.left, boxY);
-    doc.font("Helvetica").fontSize(11);
-    doc.text(`Total HT: ${formatCurrencyEUR(a.total_ht)}`, { align: "right" });
-    doc.text(`Total TTC: ${formatCurrencyEUR(a.total_ttc)}`, { align: "right" });
+  const a = detail.avoir;
+  const pdf = await renderFinanceDocument({
+    kind: "AVOIR",
+    number: a.numero,
+    draft: true,
+    issueDate: a.date_emission,
+    currency: "EUR",
+    issuer: await getIssuerParty(),
+    client: clientParty(a.client),
+    lines: draftLines(detail.lignes),
+    totals: {
+      subtotalExTax: amount(a.total_ht),
+      globalDiscountPercent: "0.00",
+      globalDiscountAmount: "0.00",
+      totalExTax: amount(a.total_ht),
+      totalTax: amount((a.total_ttc ?? 0) - (a.total_ht ?? 0)),
+      totalInclTax: amount(a.total_ttc),
+    },
+    dueDates: [],
+    correctedInvoice: a.facture?.numero ?? null,
+    reason: a.motif,
+    draftReference: a.numero,
   });
+  await fs.mkdir(path.dirname(filePath), { recursive: true });
+  await fs.writeFile(filePath, pdf);
 
   const db = await pool.connect();
   try {

--- a/src/shared/pdf/cerp-document.ts
+++ b/src/shared/pdf/cerp-document.ts
@@ -109,6 +109,14 @@ export type CerpDocumentHeader = {
   monogramName?: string | null
   generatedAt: string
   generatedBy?: string | null
+  /**
+   * Mention de tracabilite portee par **toutes** les pages, juste au-dessus du pied de page.
+   *
+   * Elle vit dans la bande reservee au pied, jamais dans le flux : une note de 7 pt placee a
+   * la suite du contenu suffit a ouvrir une page entiere presque vide. Et sur un document
+   * detachable, une page isolee doit pouvoir etre rattachee a son exemplaire d'origine.
+   */
+  footerNote?: string | null
   /** Metadonnees PDF. */
   title: string
   subject: string
@@ -398,6 +406,22 @@ export class CerpDocumentContext {
     this.doc.fillColor(CERP_DOC_COLORS.ink)
   }
 
+  /**
+   * Titre de section suivi d'un paragraphe, la reserve de cohesion etant **mesuree sur le
+   * paragraphe** au lieu d'etre forfaitaire.
+   *
+   * `section()` reserve 52 pt par defaut pour ne pas orpheliner son titre. Devant une note
+   * courte, cette reserve depasse la hauteur reelle du bloc et provoque un saut de page
+   * injustifie — une facture de deux lignes basculait sur une seconde page pour 1,1 pt.
+   */
+  notesSection(title: string, text: string): void {
+    const inner = CONTENT_WIDTH - 26
+    this.doc.font("Helvetica").fontSize(9.2)
+    const height = this.doc.heightOfString(toPdfSafeText(text), { width: inner }) + 22
+    this.section(title, { cohesion: Math.min(height, 64) })
+    this.notes(text)
+  }
+
   /** Paragraphe sur fond gris, pour un texte long. */
   notes(text: string): void {
     const inner = CONTENT_WIDTH - 26
@@ -562,6 +586,13 @@ function drawRunningHead(doc: PDFKit.PDFDocument, header: CerpDocumentHeader): v
 
 function drawFooter(doc: PDFKit.PDFDocument, header: CerpDocumentHeader, pageNumber: number, totalPages: number): void {
   const y = PAGE_HEIGHT - 30
+
+  const note = header.footerNote && header.footerNote.trim() ? toPdfSafeText(header.footerNote.trim()) : null
+  if (note) {
+    doc.font("Helvetica").fontSize(6.5).fillColor(CERP_DOC_COLORS.steel)
+    const noteWidth = doc.widthOfString(note)
+    doc.text(note, MARGIN_X + (CONTENT_WIDTH - noteWidth) / 2, y - 17, { lineBreak: false })
+  }
 
   doc.save()
   doc.lineWidth(0.8).strokeColor(CERP_DOC_COLORS.hairline)


### PR DESCRIPTION
Release `dev` → `main`. Contenu : #217 (ferme #216).

Contrepartie frontend : BigFootLime/crp-systems-web#368 · Décision `ADR-0042`

## Contenu

La facture et l'avoir — **pièces fiscales**, dont l'exemplaire émis est immuable — passent sur la grammaire de document CERP.

Défauts fermés : trois services les dessinaient (dont **deux pour la seule facture**), aucune **ventilation de la TVA par taux**, aucune identité fiscale de l'émetteur sur la facture légale, `ID: <uuid>` du client imprimé sur une pièce adressée au client, montants en `182.40 EUR` sur une facture française, avoir sans table ni pagination.

## Ce qui reste absent, faute de donnée

**Non inventé** : pénalités de retard, indemnité forfaitaire de recouvrement de 40 €, escompte, RCS et capital social de l'émetteur. Ces mentions relèvent d'un **paramétrage d'entité émettrice** — à traiter séparément pour des factures pleinement conformes.

## Impact base de données

**Aucun.** Pas de patch SQL, pas de migration, pas de changement de contrat d'API. Rien à appliquer sur `cerp_test` ni `cerp_prod`.

## Vérification

2990 tests verts sur 2991 — l'échec restant (`surface-finish-210.migration-guards`) est **antérieur**, vérifié sur `origin/dev` seul.

## Après merge

⚠️ **Le merge ne déploie rien.** VPS backend **et backend de l'atelier** à redéployer à la main — c'est ce dernier qui sert `cerp_prod`.

## Limite

Aucune recette navigateur.

## Summary by Sourcery

Unify invoice and credit note PDF generation on the shared CERP document grammar, covering both drafts and immutable legal copies, and document the new behavior.

Enhancements:
- Refactor facture and avoir PDF services to delegate all layout rendering to a shared finance-document renderer using the CERP PDF framework.
- Add issuer and client identity handling from the billing reference, including a whitelist of legal fields, and remove client technical IDs from rendered documents.
- Introduce a unified tax breakdown and totals summary for financial documents, with French-style formatting for amounts and percentages.
- Enhance the shared CERP PDF component with footer traceability notes and a notesSection helper to reduce unnecessary page breaks.

Documentation:
- Add documentation explaining why invoice and credit note PDFs are rendered server-side with the CERP grammar, detailing mandatory mentions, formatting decisions, limitations, and verification steps.

Tests:
- Add integration-style tests that decode generated PDFs to verify rendered text, layout behavior, tax breakdown arithmetic, identity contents, and absence of client technical IDs.