### PR TITLE
test(finitions): normalize migration guard line endings

### DIFF
--- a/src/__tests__/surface-finish-210.migration-guards.test.ts
+++ b/src/__tests__/surface-finish-210.migration-guards.test.ts
@@ -10,7 +10,8 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const root = process.cwd();
-const read = (relative: string) => readFileSync(resolve(root, relative), "utf8");
+const read = (relative: string) =>
+  readFileSync(resolve(root, relative), "utf8").replace(/\r\n?/g, "\n");
 
 // Un script « lecture seule » ne doit contenir aucune INSTRUCTION d'écriture.
 // On ancre en début de ligne : `SELECT,INSERT,UPDATE` dans has_table_privilege()


### PR DESCRIPTION
## What changed

Normalize SQL fixture line endings when the #210 migration guard reads patch files.

## Why

On Windows with `core.autocrlf=true`, the SQL patch is materialized with CRLF while the only multiline assertion contains a literal LF. The foreign-key constraint is present and valid; the test failure was platform-specific.

## Impact

No runtime, SQL patch, schema, or business-data change. The migration guard now evaluates the canonical SQL content independently of checkout line endings.

## Validation

- `surface-finish-210.migration-guards.test.ts`: 31/31
- all migration guard files: 158/158
- `git diff --check`: clean

Closes #210

## Summary by Sourcery

Tests:
- Update migration guard test fixture reader to canonicalize line endings for consistent SQL assertions across platforms.