### PR TITLE
release: promote surface-finish migration guard fix

### DIFF
--- a/src/__tests__/surface-finish-210.migration-guards.test.ts
+++ b/src/__tests__/surface-finish-210.migration-guards.test.ts
@@ -10,7 +10,8 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const root = process.cwd();
-const read = (relative: string) => readFileSync(resolve(root, relative), "utf8");
+const read = (relative: string) =>
+  readFileSync(resolve(root, relative), "utf8").replace(/\r\n?/g, "\n");
 
 // Un script « lecture seule » ne doit contenir aucune INSTRUCTION d'écriture.
 // On ancre en début de ligne : `SELECT,INSERT,UPDATE` dans has_table_privilege()


### PR DESCRIPTION
## Release scope

Promote the Windows line-ending compatibility fix for the #210 surface-finish SQL migration guard from `dev` to `main`.

## Content delta

- 1 test file changed
- 2 insertions, 1 deletion
- no runtime code change
- no SQL patch or schema change

## Validation

- target migration guard: 31/31
- all backend migration guards: 158/158
- PR #219 merged cleanly into `dev`

Closes #210

## Summary by Sourcery

Bug Fixes:
- Fix surface-finish migration guard test to handle Windows-style line endings when reading fixtures.