### PR TITLE
fix(facturation): versionner les mentions légales des documents sortants

### DIFF
--- a/db/patches/20260729_finance_legal_mentions.sql
+++ b/db/patches/20260729_finance_legal_mentions.sql
@@ -1,0 +1,317 @@
+-- 20260729_finance_legal_mentions.sql
+--
+-- Mentions légales obligatoires de l'entité émettrice (code de commerce / CGI).
+-- Fait suite au rendu unique des pièces financières livré par #216.
+--
+-- CONSTAT À L'ORIGINE DU PATCH (relevé sur cerp_test ET cerp_prod le 2026-07-29) :
+--   - `public.factureur` ne porte AUCUNE colonne légale : ni SIRET, ni SIREN, ni RCS,
+--     ni numéro de TVA, ni capital social, ni forme juridique. Le code serveur
+--     (`ISSUER_LEGAL_FIELDS` dans facturation/services/pdf.service.ts) lisait donc des
+--     colonnes qui n'existent pas : `to_jsonb(f)` ne les renvoyait jamais et le bloc
+--     « Émetteur » du PDF ne portait aucune mention obligatoire.
+--   - `public.factureur` est VIDE sur les deux bases (0 ligne), tout comme
+--     `public.finance_billing_policies` et `public.facture`. Aucune facture n'a jamais été
+--     émise par ce chemin : il n'y a donc AUCUN exemplaire immuable à préserver.
+--
+-- ADDITIF, IDEMPOTENT, NON DESTRUCTIF :
+--   - 1 nouvelle table versionnée `finance_legal_mentions` ;
+--   - 1 fonction de lecture `fn_finance_issuer_snapshot(uuid, date)` ;
+--   - amorçage de l'entité émettrice CROIX ROUSSE PRECISION et de la version 1 de ses
+--     mentions, en `ON CONFLICT DO NOTHING` sur un UUID fixe.
+--   Aucune table existante n'est renommée, vidée, altérée ni recodée. Aucune colonne
+--   n'est ajoutée à `factureur` : les mentions vivent dans la table versionnée, qui est
+--   leur unique source de vérité.
+--
+-- POURQUOI UNE TABLE VERSIONNÉE PLUTÔT QUE DES COLONNES SUR `factureur` :
+--   un taux de pénalité, un capital ou une ville de RCS changent. Une facture émise doit
+--   porter les mentions **en vigueur à sa date d'émission**, et une facture déjà émise est
+--   immuable. Des colonnes sur `factureur` seraient réécrites en place et falsifieraient
+--   rétroactivement l'historique. Ici, une modification ouvre une nouvelle version : les
+--   instantanés déjà figés continuent de résoudre la leur.
+--
+-- Pipeline db/patches (exécuté en tant que cerp_app). Cible : PostgreSQL 17.
+--   Preflight : db/patches/support/20260729_finance_legal_mentions.preflight.sql
+--   Verify    : db/patches/support/20260729_finance_legal_mentions.verify.sql
+--   Rollback  : db/patches/support/20260729_finance_legal_mentions.rollback.sql
+
+BEGIN;
+
+/* -------------------------------------------------------------------------- */
+/* 0) Pré-requis structurels                                                  */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF to_regclass('public.factureur') IS NULL THEN
+    RAISE EXCEPTION '#legal-mentions: public.factureur is missing — historical table, restore the base schema first';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 1) Table versionnée des mentions légales                                   */
+/* -------------------------------------------------------------------------- */
+
+CREATE TABLE IF NOT EXISTS public.finance_legal_mentions (
+  mention_set_id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  biller_id                 uuid NOT NULL REFERENCES public.factureur(biller_id),
+  version                   integer NOT NULL,
+
+  -- Période de validité. `effective_to` NULL = version en vigueur.
+  effective_from            date NOT NULL,
+  effective_to              date,
+
+  -- ── Identité légale (art. R123-237 C. com.) ──────────────────────────────
+  legal_form                text,           -- « SARL », « SAS »… mention obligatoire
+  share_capital             numeric(14,2),  -- montant, jamais préformaté
+  share_capital_currency    char(3) NOT NULL DEFAULT 'EUR',
+  rcs_city                  text,           -- ville du greffe : « RCS <ville> <numéro> »
+  rcs_number                text,
+  siren                     text,
+  siret                     text,
+  vat_number                text,           -- TVA intracommunautaire
+  ape_code                  text,
+
+  -- ── Conditions de règlement ──────────────────────────────────────────────
+  -- Pénalités de retard : art. L441-10 C. com. Le taux est contractuel mais ne peut
+  -- être inférieur à 3× le taux d'intérêt légal ; la valeur n'est pas contrainte ici
+  -- car le plancher légal change chaque semestre.
+  late_penalty_rate         numeric(6,3),
+  late_penalty_basis        text,           -- 'ANNUEL' | 'MENSUEL'
+
+  -- Indemnité forfaitaire de recouvrement : art. D441-5 C. com., 40 € depuis 2013.
+  recovery_indemnity        numeric(10,2) NOT NULL DEFAULT 40.00,
+
+  -- Escompte pour paiement anticipé : mention obligatoire **même en son absence**.
+  -- Taux NULL ⇒ le document doit écrire qu'aucun escompte n'est accordé.
+  early_discount_rate       numeric(6,3),
+  early_discount_basis      text,           -- 'ANNUEL' | 'MENSUEL'
+
+  -- ── Régimes de TVA ───────────────────────────────────────────────────────
+  vat_on_receipts           boolean NOT NULL DEFAULT false,  -- « TVA acquittée sur les encaissements »
+  vat_exempt_293b           boolean NOT NULL DEFAULT false,  -- « TVA non applicable, art. 293 B du CGI »
+
+  -- ── Clauses ──────────────────────────────────────────────────────────────
+  retention_of_title        text,           -- réserve de propriété (loi du 12 mai 1980)
+  extra_mentions            text[] NOT NULL DEFAULT '{}',
+
+  created_at                timestamptz NOT NULL DEFAULT now(),
+  created_by                integer,
+
+  CONSTRAINT finance_legal_mentions_version_ck
+    CHECK (version >= 1),
+  CONSTRAINT finance_legal_mentions_dates_ck
+    CHECK (effective_to IS NULL OR effective_to > effective_from),
+  CONSTRAINT finance_legal_mentions_late_penalty_ck
+    CHECK (late_penalty_rate IS NULL OR late_penalty_rate > 0),
+  CONSTRAINT finance_legal_mentions_late_basis_ck
+    CHECK (late_penalty_basis IS NULL OR late_penalty_basis IN ('ANNUEL', 'MENSUEL')),
+  CONSTRAINT finance_legal_mentions_early_basis_ck
+    CHECK (early_discount_basis IS NULL OR early_discount_basis IN ('ANNUEL', 'MENSUEL')),
+  CONSTRAINT finance_legal_mentions_early_pair_ck
+    CHECK ((early_discount_rate IS NULL) = (early_discount_basis IS NULL)),
+  CONSTRAINT finance_legal_mentions_indemnity_ck
+    CHECK (recovery_indemnity >= 0),
+  -- Les deux régimes s'excluent : un redevable exonéré au titre du 293 B ne peut pas
+  -- acquitter la TVA sur ses encaissements.
+  CONSTRAINT finance_legal_mentions_vat_regime_ck
+    CHECK (NOT (vat_on_receipts AND vat_exempt_293b))
+);
+
+COMMENT ON TABLE public.finance_legal_mentions IS
+  'Mentions légales de l''entité émettrice, versionnées par période de validité. Une facture fige la version en vigueur à sa date d''émission ; les versions passées ne sont jamais réécrites.';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'finance_legal_mentions_biller_version_key'
+  ) THEN
+    ALTER TABLE public.finance_legal_mentions
+      ADD CONSTRAINT finance_legal_mentions_biller_version_key UNIQUE (biller_id, version);
+  END IF;
+END $$;
+
+-- Au plus une version ouverte par émetteur : sans cela, deux versions sans borne de fin
+-- rendraient la résolution à une date donnée non déterministe.
+CREATE UNIQUE INDEX IF NOT EXISTS finance_legal_mentions_one_open_idx
+  ON public.finance_legal_mentions (biller_id)
+  WHERE effective_to IS NULL;
+
+CREATE INDEX IF NOT EXISTS finance_legal_mentions_resolution_idx
+  ON public.finance_legal_mentions (biller_id, effective_from DESC);
+
+/* -------------------------------------------------------------------------- */
+/* 2) Résolution : instantané de l'émetteur à une date donnée                 */
+/* -------------------------------------------------------------------------- */
+-- Un seul point de vérité pour TOUS les documents sortants (facture, avoir, bon de
+-- livraison, pack COFC, accusé de réception). Sans cela, chaque module reconstruirait
+-- l'identité de l'émetteur à sa façon et les mentions divergeraient d'un document à
+-- l'autre — c'est exactement ce que #213 et #216 ont corrigé pour la mise en page.
+--
+-- Les montants et taux sortent en TEXTE : le rendu ne fait aucune arithmétique flottante
+-- sur une pièce fiscale, il met en forme des chaînes venues du référentiel.
+-- `jsonb_strip_nulls` garantit qu'une mention absente est absente de l'instantané, et
+-- non présente à NULL : le rendu n'affiche jamais de substitut à une mention manquante.
+
+CREATE OR REPLACE FUNCTION public.fn_finance_issuer_snapshot(p_biller_id uuid, p_at date)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT jsonb_strip_nulls(jsonb_build_object(
+    'biller_id',                 f.biller_id,
+    'company_name',              f.biller_name,
+    'address_line_1',            NULLIF(btrim(concat_ws(' ', f.house_number, f.street)), ''),
+    'postal_code',               f.postal_code,
+    'city',                      f.city,
+    'country',                   f.country,
+    'phone',                     f.phone,
+    'email',                     f.email,
+    'bank_name',                 f.default_bank_name,
+    'iban',                      f.default_iban,
+    'bic',                       f.default_bic,
+    'text_on_invoice',           f.text_on_invoice,
+
+    'legal_form',                m.legal_form,
+    'share_capital',             m.share_capital::text,
+    'share_capital_currency',    CASE WHEN m.share_capital IS NULL THEN NULL ELSE m.share_capital_currency END,
+    'rcs_city',                  m.rcs_city,
+    'rcs_number',                m.rcs_number,
+    'siren',                     m.siren,
+    'siret',                     m.siret,
+    'vat_number',                m.vat_number,
+    'ape_code',                  m.ape_code,
+
+    'late_penalty_rate',         m.late_penalty_rate::text,
+    'late_penalty_basis',        m.late_penalty_basis,
+    'recovery_indemnity',        CASE WHEN m.mention_set_id IS NULL THEN NULL ELSE m.recovery_indemnity::text END,
+    'early_discount_rate',       m.early_discount_rate::text,
+    'early_discount_basis',      m.early_discount_basis,
+
+    -- Booléens : seul `true` est porté. `false` disparaît avec strip_nulls, ce qui est
+    -- le comportement voulu — un régime non applicable n'est pas une mention.
+    'vat_on_receipts',           CASE WHEN m.vat_on_receipts   THEN true ELSE NULL END,
+    'vat_exempt_293b',           CASE WHEN m.vat_exempt_293b   THEN true ELSE NULL END,
+
+    'retention_of_title',        m.retention_of_title,
+    'extra_mentions',            CASE WHEN m.extra_mentions IS NULL OR cardinality(m.extra_mentions) = 0
+                                      THEN NULL ELSE to_jsonb(m.extra_mentions) END,
+
+    -- Traçabilité de la version figée : c'est ce qui permet de prouver, des années plus
+    -- tard, quelles mentions étaient applicables au moment de l'émission.
+    'legal_mentions_version',        m.version,
+    'legal_mentions_effective_from', m.effective_from::text
+  ))
+  FROM public.factureur f
+  LEFT JOIN public.finance_legal_mentions m
+         ON m.biller_id = f.biller_id
+        AND m.effective_from <= p_at
+        AND (m.effective_to IS NULL OR m.effective_to > p_at)
+  WHERE f.biller_id = p_biller_id;
+$$;
+
+COMMENT ON FUNCTION public.fn_finance_issuer_snapshot(uuid, date) IS
+  'Instantané complet de l''entité émettrice à une date donnée : identité opérationnelle (factureur) + mentions légales en vigueur (finance_legal_mentions). Destiné à être figé tel quel dans issuer_snapshot.';
+
+/* -------------------------------------------------------------------------- */
+/* 3) Amorçage de l'entité émettrice                                          */
+/* -------------------------------------------------------------------------- */
+-- `factureur` est vide sur les deux bases : sans cette ligne, `getIssuerParty()` renvoie
+-- {} (bloc « Émetteur » vide) et `issuerSnapshot()` lève 503 FINANCE_ISSUER_NOT_CONFIGURED
+-- à la première émission. L'UUID est fixe pour rendre l'amorçage rejouable.
+--
+-- Sources des valeurs :
+--   - annuaire-entreprises.data.gouv.fr / registre national des entreprises (INPI),
+--     SIREN 380569012, consulté le 2026-07-29 : dénomination, forme juridique
+--     (catégorie INSEE 5499 = SARL), capital 21 000,00 € fixe, TVA FR73 380 569 012,
+--     siège 530 rue de la Dombes, Les Échets, 01700 MIRIBEL, immatriculation 28/01/1991 ;
+--   - facture papier CERP n° 5256 du 24/07/2026 : taux de pénalité, taux d'escompte,
+--     clause de réserve de propriété, régime de TVA, coordonnées bancaires, téléphone.
+--
+-- Ville du RCS : Miribel est dans l'Ain (01), dont le ressort unique est le greffe du
+-- tribunal de commerce de Bourg-en-Bresse. La facture papier n'imprimait que le numéro,
+-- sans ville — la mention était donc incomplète au regard de l'art. R123-237.
+
+INSERT INTO public.factureur (
+  biller_id, biller_name, street, house_number, postal_code, city, country,
+  phone, default_bank_name, default_iban, default_bic
+)
+VALUES (
+  'b7c1e5a2-3f4d-4e8b-9a06-380569012000'::uuid,
+  'CROIX ROUSSE PRECISION',
+  'Rue de la Dombes',
+  '530',
+  '01700',
+  'MIRIBEL LES ECHETS',
+  'France',
+  '04 72 00 26 25',
+  'SG LYON CROIX-ROUSSE',
+  'FR76 3000 3024 9100 0200 0775 958',
+  'SOGEFRPP'
+)
+ON CONFLICT (biller_id) DO NOTHING;
+
+/* -------------------------------------------------------------------------- */
+/* 4) Version 1 des mentions légales                                          */
+/* -------------------------------------------------------------------------- */
+-- `effective_from` au 1er janvier 2026 : ces mentions sont celles que l'entreprise
+-- imprime aujourd'hui, et l'exercice en cours est la période la plus large que l'on
+-- puisse couvrir sans affirmer ce qui était en vigueur les années précédentes. Aucune
+-- facture n'existant en base, aucune pièce ne se retrouve hors période.
+--
+-- L'indemnité forfaitaire de 40 € est ajoutée ici alors qu'elle ne figurait PAS sur la
+-- facture papier : elle est obligatoire depuis le décret 2012-1115 (art. D441-5 C. com.)
+-- et son absence est sanctionnable. Ce n'est pas un choix de paramétrage.
+
+INSERT INTO public.finance_legal_mentions (
+  biller_id, version, effective_from, effective_to,
+  legal_form, share_capital, share_capital_currency,
+  rcs_city, rcs_number, siren, siret, vat_number,
+  late_penalty_rate, late_penalty_basis,
+  recovery_indemnity,
+  early_discount_rate, early_discount_basis,
+  vat_on_receipts, vat_exempt_293b,
+  retention_of_title
+)
+VALUES (
+  'b7c1e5a2-3f4d-4e8b-9a06-380569012000'::uuid,
+  1,
+  DATE '2026-01-01',
+  NULL,
+  'SARL',
+  21000.00,
+  'EUR',
+  'Bourg-en-Bresse',
+  '380 569 012',
+  '380 569 012',
+  '380 569 012 00020',
+  'FR73 380 569 012',
+  12.500,
+  'ANNUEL',
+  40.00,
+  1.500,
+  'MENSUEL',
+  true,
+  false,
+  'Nous nous réservons la propriété des marchandises jusqu''au paiement intégral du prix par l''acheteur. Notre droit de revendication porte aussi bien sur les marchandises que sur leur prix si elles ont déjà été revendues (loi du 12 mai 1980).'
+)
+ON CONFLICT (biller_id, version) DO NOTHING;
+
+/* -------------------------------------------------------------------------- */
+/* 5) Accès applicatif                                                        */
+/* -------------------------------------------------------------------------- */
+-- Le patch peut être appliqué par le rôle administratif `postgres` via psql (peer auth).
+-- Sans cette reprise d'ownership, `cerp_app` reçoit « permission denied for table … »
+-- (SQLSTATE 42501) et l'API répond 500 alors que le schéma est correct — régression
+-- constatée en production le 2026-07-21, cf. db/privileged/20260721_fix_app_table_ownership.sql.
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    EXECUTE 'ALTER TABLE public.finance_legal_mentions OWNER TO cerp_app';
+    EXECUTE 'ALTER FUNCTION public.fn_finance_issuer_snapshot(uuid, date) OWNER TO cerp_app';
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE ON public.finance_legal_mentions TO cerp_app';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.fn_finance_issuer_snapshot(uuid, date) TO cerp_app';
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/20260729_finance_legal_mentions_hardening_221.sql
+++ b/db/patches/20260729_finance_legal_mentions_hardening_221.sql
@@ -1,0 +1,156 @@
+-- 20260729_finance_legal_mentions_hardening_221.sql
+--
+-- Follow-up to 20260729_finance_legal_mentions.sql for issue #221.
+--
+-- The initial patch was already applied to cerp_test before review, so it remains immutable.
+-- This additive patch closes two integrity gaps without rewriting the seeded legal version:
+--   1. two closed legal versions could overlap and make date resolution ambiguous;
+--   2. the snapshot function did not explicitly choose the latest matching version.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.finance_legal_mentions') IS NULL THEN
+    RAISE EXCEPTION '#221: public.finance_legal_mentions is missing — apply 20260729_finance_legal_mentions.sql first';
+  END IF;
+END $$;
+
+-- Refuse to harden an already ambiguous history. No automatic correction is safe for fiscal
+-- reference data: an operator must decide which effective period is authoritative.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.finance_legal_mentions left_version
+    JOIN public.finance_legal_mentions right_version
+      ON right_version.biller_id = left_version.biller_id
+     AND right_version.mention_set_id > left_version.mention_set_id
+     AND daterange(
+           left_version.effective_from,
+           left_version.effective_to,
+           '[)'
+         ) && daterange(
+           right_version.effective_from,
+           right_version.effective_to,
+           '[)'
+         )
+  ) THEN
+    RAISE EXCEPTION '#221: overlapping finance_legal_mentions periods exist — manual Finance arbitration required';
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS finance_legal_mentions_effective_from_uidx
+  ON public.finance_legal_mentions (biller_id, effective_from);
+
+CREATE OR REPLACE FUNCTION public.tg_finance_legal_mentions_no_overlap()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Serialize period changes for one issuer. Without this transaction-level lock, two
+  -- concurrent inserts could both pass the overlap test before either becomes visible.
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended('finance_legal_mentions:' || NEW.biller_id::text, 0)
+  );
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.finance_legal_mentions existing
+    WHERE existing.biller_id = NEW.biller_id
+      AND existing.mention_set_id <> NEW.mention_set_id
+      AND daterange(
+            existing.effective_from,
+            existing.effective_to,
+            '[)'
+          ) && daterange(
+            NEW.effective_from,
+            NEW.effective_to,
+            '[)'
+          )
+  ) THEN
+    RAISE EXCEPTION USING
+      ERRCODE = '23P01',
+      MESSAGE = 'finance_legal_mentions periods must not overlap for one issuer';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS finance_legal_mentions_no_overlap_trg
+  ON public.finance_legal_mentions;
+CREATE TRIGGER finance_legal_mentions_no_overlap_trg
+BEFORE INSERT OR UPDATE OF biller_id, effective_from, effective_to
+ON public.finance_legal_mentions
+FOR EACH ROW
+EXECUTE FUNCTION public.tg_finance_legal_mentions_no_overlap();
+
+-- Deterministic resolution remains explicit even with the trigger. It protects reads if the
+-- table is restored from an old backup or temporarily loaded before constraints are checked.
+CREATE OR REPLACE FUNCTION public.fn_finance_issuer_snapshot(p_biller_id uuid, p_at date)
+RETURNS jsonb
+LANGUAGE sql
+STABLE
+AS $$
+  SELECT jsonb_strip_nulls(jsonb_build_object(
+    'biller_id',                 f.biller_id,
+    'company_name',              f.biller_name,
+    'address_line_1',            NULLIF(btrim(concat_ws(' ', f.house_number, f.street)), ''),
+    'postal_code',               f.postal_code,
+    'city',                      f.city,
+    'country',                   f.country,
+    'phone',                     f.phone,
+    'email',                     f.email,
+    'bank_name',                 f.default_bank_name,
+    'iban',                      f.default_iban,
+    'bic',                       f.default_bic,
+    'text_on_invoice',           f.text_on_invoice,
+
+    'legal_form',                m.legal_form,
+    'share_capital',             m.share_capital::text,
+    'share_capital_currency',    CASE WHEN m.share_capital IS NULL THEN NULL ELSE m.share_capital_currency END,
+    'rcs_city',                  m.rcs_city,
+    'rcs_number',                m.rcs_number,
+    'siren',                     m.siren,
+    'siret',                     m.siret,
+    'vat_number',                m.vat_number,
+    'ape_code',                  m.ape_code,
+
+    'late_penalty_rate',         m.late_penalty_rate::text,
+    'late_penalty_basis',        m.late_penalty_basis,
+    'recovery_indemnity',        CASE WHEN m.mention_set_id IS NULL THEN NULL ELSE m.recovery_indemnity::text END,
+    'early_discount_rate',       m.early_discount_rate::text,
+    'early_discount_basis',      m.early_discount_basis,
+    'vat_on_receipts',           CASE WHEN m.vat_on_receipts THEN true ELSE NULL END,
+    'vat_exempt_293b',           CASE WHEN m.vat_exempt_293b THEN true ELSE NULL END,
+    'retention_of_title',        m.retention_of_title,
+    'extra_mentions',            CASE WHEN m.extra_mentions IS NULL OR cardinality(m.extra_mentions) = 0
+                                      THEN NULL ELSE to_jsonb(m.extra_mentions) END,
+    'legal_mentions_version',        m.version,
+    'legal_mentions_effective_from', m.effective_from::text
+  ))
+  FROM public.factureur f
+  LEFT JOIN LATERAL (
+    SELECT resolved.*
+    FROM public.finance_legal_mentions resolved
+    WHERE resolved.biller_id = f.biller_id
+      AND resolved.effective_from <= p_at
+      AND (resolved.effective_to IS NULL OR resolved.effective_to > p_at)
+    ORDER BY resolved.effective_from DESC, resolved.version DESC
+    LIMIT 1
+  ) m ON TRUE
+  WHERE f.biller_id = p_biller_id;
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    EXECUTE 'ALTER FUNCTION public.tg_finance_legal_mentions_no_overlap() OWNER TO cerp_app';
+    EXECUTE 'ALTER FUNCTION public.fn_finance_issuer_snapshot(uuid, date) OWNER TO cerp_app';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.tg_finance_legal_mentions_no_overlap() TO cerp_app';
+    EXECUTE 'GRANT EXECUTE ON FUNCTION public.fn_finance_issuer_snapshot(uuid, date) TO cerp_app';
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/support/20260729_finance_legal_mentions.preflight.sql
+++ b/db/patches/support/20260729_finance_legal_mentions.preflight.sql
@@ -1,0 +1,97 @@
+-- 20260729_finance_legal_mentions.preflight.sql
+--
+-- LECTURE SEULE. Aucune écriture, aucun DDL. À exécuter avant le patch, sur cerp_test
+-- puis à nouveau avant toute décision concernant cerp_prod.
+--
+-- Ce que le préflight doit établir :
+--   1. sur quelle base on se trouve ;
+--   2. l'état réel de `factureur` — c'est de sa vacuité que vient le défaut ;
+--   3. qu'aucune facture ni aucun avoir n'a été émis (sinon leur instantané est immuable
+--      et l'amorçage devrait être rejoué autrement) ;
+--   4. que la table de mentions n'existe pas encore, ou dans quel état elle est.
+
+\echo '=== 0) Identité de la base ==='
+SELECT current_database() AS base, current_user AS role, version() AS serveur;
+
+\echo ''
+\echo '=== 1) Colonnes réellement présentes sur public.factureur ==='
+-- Attendu avant patch : aucune des colonnes légales lues par le serveur
+-- (siret, siren, rcs, vat_number, capital_social) n'existe.
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'public' AND table_name = 'factureur'
+ORDER BY ordinal_position;
+
+\echo ''
+\echo '=== 1bis) Colonnes légales attendues par le serveur : présentes ? ==='
+SELECT c.expected AS colonne_attendue_par_le_code,
+       (EXISTS (
+          SELECT 1 FROM information_schema.columns ic
+          WHERE ic.table_schema = 'public' AND ic.table_name = 'factureur'
+            AND ic.column_name = c.expected
+       )) AS presente
+FROM (VALUES ('siret'), ('siren'), ('rcs'), ('vat_number'), ('capital_social')) AS c(expected)
+ORDER BY 1;
+
+\echo ''
+\echo '=== 2) Volume de factureur (0 attendu : rien n''est configuré) ==='
+SELECT count(*) AS nb_factureurs FROM public.factureur;
+SELECT biller_id, biller_name, postal_code, city, country
+FROM public.factureur
+ORDER BY biller_name;
+
+\echo ''
+\echo '=== 3) Pièces déjà émises — un exemplaire émis est IMMUABLE ==='
+-- Si l'un de ces compteurs est non nul, STOP : il faut d'abord établir quelles mentions
+-- étaient en vigueur à leur date d'émission, et borner la version 1 en conséquence.
+-- Aucune pièce déjà émise ne doit être régénérée.
+SELECT
+  (SELECT count(*) FROM public.facture)                     AS nb_factures,
+  (SELECT count(*) FROM public.facture WHERE legal_number IS NOT NULL) AS nb_factures_emises,
+  (SELECT count(*) FROM public.finance_billing_policies)    AS nb_politiques,
+  (SELECT count(*) FROM public.finance_billing_policies WHERE active) AS nb_politiques_actives;
+
+\echo ''
+\echo '=== 3bis) Date d''émission la plus ancienne (borne basse de effective_from) ==='
+SELECT min(date_emission) AS plus_ancienne_emission,
+       max(date_emission) AS plus_recente_emission
+FROM public.facture;
+
+\echo ''
+\echo '=== 4) État de la cible du patch ==='
+SELECT
+  (to_regclass('public.finance_legal_mentions') IS NOT NULL)                     AS table_mentions_existe,
+  (to_regprocedure('public.fn_finance_issuer_snapshot(uuid, date)') IS NOT NULL) AS fonction_existe;
+
+\echo ''
+\echo '=== 4bis) Si la table existe déjà : versions enregistrées ==='
+DO $$
+DECLARE
+  v_overlaps integer;
+BEGIN
+  IF to_regclass('public.finance_legal_mentions') IS NOT NULL THEN
+    RAISE NOTICE 'finance_legal_mentions présente — contenu ci-dessous';
+    EXECUTE $query$
+      SELECT count(*)
+      FROM public.finance_legal_mentions left_version
+      JOIN public.finance_legal_mentions right_version
+        ON right_version.biller_id = left_version.biller_id
+       AND right_version.mention_set_id > left_version.mention_set_id
+       AND daterange(left_version.effective_from, left_version.effective_to, '[)')
+           && daterange(right_version.effective_from, right_version.effective_to, '[)')
+    $query$ INTO v_overlaps;
+    RAISE NOTICE 'Périodes de mentions qui se chevauchent : % (0 attendu)', v_overlaps;
+  ELSE
+    RAISE NOTICE 'finance_legal_mentions absente — création par le patch';
+  END IF;
+END $$;
+
+\echo ''
+\echo '=== 5) Registre des migrations ==='
+SELECT filename, applied_at
+FROM public.cerp_schema_migrations
+WHERE filename LIKE '%legal_mentions%' OR filename LIKE '%facturation%'
+ORDER BY filename;
+
+\echo ''
+\echo '=== PRÉFLIGHT TERMINÉ — aucune écriture effectuée ==='

--- a/db/patches/support/20260729_finance_legal_mentions.rollback.sql
+++ b/db/patches/support/20260729_finance_legal_mentions.rollback.sql
@@ -1,0 +1,55 @@
+-- 20260729_finance_legal_mentions.rollback.sql
+--
+-- RESTREINT À cerp_test. Refuse de s'exécuter ailleurs.
+--
+-- Le rollback refuse également de continuer dès qu'une pièce financière a figé un
+-- instantané d'émetteur : une facture émise est immuable, et retirer la table qui a
+-- produit ses mentions reviendrait à supprimer la preuve de ce qui était en vigueur au
+-- moment de l'émission. L'instantané lui-même reste intact dans `facture.issuer_snapshot`
+-- — il est autoportant, c'est tout l'intérêt d'un instantané — mais on ne détruit pas la
+-- source qui permet de l'auditer.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'ROLLBACK refusé : base « % », seul cerp_test est autorisé', current_database();
+  END IF;
+END $$;
+
+DO $$
+DECLARE
+  v_emises integer;
+BEGIN
+  SELECT count(*) INTO v_emises
+  FROM public.facture
+  WHERE legal_number IS NOT NULL OR issuer_snapshot IS NOT NULL;
+
+  IF v_emises > 0 THEN
+    RAISE EXCEPTION 'ROLLBACK refusé : % pièce(s) portent déjà un instantané d''émetteur', v_emises;
+  END IF;
+END $$;
+
+DROP TRIGGER IF EXISTS finance_legal_mentions_no_overlap_trg
+  ON public.finance_legal_mentions;
+DROP FUNCTION IF EXISTS public.tg_finance_legal_mentions_no_overlap();
+DROP FUNCTION IF EXISTS public.fn_finance_issuer_snapshot(uuid, date);
+DROP TABLE IF EXISTS public.finance_legal_mentions;
+
+-- L'entité émettrice amorcée n'est retirée que si rien ne la référence. `factureur` est
+-- référencée par clients, commande_client et devis : une suppression aveugle casserait
+-- ces liens.
+DELETE FROM public.factureur f
+WHERE f.biller_id = 'b7c1e5a2-3f4d-4e8b-9a06-380569012000'::uuid
+  AND NOT EXISTS (SELECT 1 FROM public.clients         c WHERE c.biller_id = f.biller_id)
+  AND NOT EXISTS (SELECT 1 FROM public.commande_client k WHERE k.biller_id = f.biller_id)
+  AND NOT EXISTS (SELECT 1 FROM public.devis           d WHERE d.biller_id = f.biller_id);
+
+DELETE FROM public.cerp_schema_migrations
+WHERE filename IN (
+  '20260729_finance_legal_mentions.sql',
+  '20260729_finance_legal_mentions_hardening_221.sql'
+);
+
+COMMIT;

--- a/db/patches/support/20260729_finance_legal_mentions.verify.sql
+++ b/db/patches/support/20260729_finance_legal_mentions.verify.sql
@@ -1,0 +1,247 @@
+-- 20260729_finance_legal_mentions.verify.sql
+--
+-- Vérification après application. Échoue bruyamment : une mention obligatoire absente
+-- d'une facture est sanctionnable, elle ne doit pas passer une vérification silencieuse.
+
+\echo '=== Base vérifiée ==='
+SELECT current_database() AS base;
+
+/* -------------------------------------------------------------------------- */
+/* 1) Structure                                                               */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF to_regclass('public.finance_legal_mentions') IS NULL THEN
+    RAISE EXCEPTION 'VERIFY: public.finance_legal_mentions est absente';
+  END IF;
+  IF to_regprocedure('public.fn_finance_issuer_snapshot(uuid, date)') IS NULL THEN
+    RAISE EXCEPTION 'VERIFY: public.fn_finance_issuer_snapshot(uuid, date) est absente';
+  END IF;
+  IF to_regprocedure('public.tg_finance_legal_mentions_no_overlap()') IS NULL THEN
+    RAISE EXCEPTION 'VERIFY: fonction de garde anti-chevauchement absente — appliquer le hardening #221';
+  END IF;
+END $$;
+
+\echo ''
+\echo '=== 1) Contraintes attendues ==='
+SELECT conname, pg_get_constraintdef(oid) AS definition
+FROM pg_constraint
+WHERE conrelid = 'public.finance_legal_mentions'::regclass
+ORDER BY conname;
+
+DO $$
+DECLARE
+  v_missing text;
+BEGIN
+  FOR v_missing IN
+    SELECT c.expected
+    FROM (VALUES
+      ('finance_legal_mentions_version_ck'),
+      ('finance_legal_mentions_dates_ck'),
+      ('finance_legal_mentions_late_penalty_ck'),
+      ('finance_legal_mentions_late_basis_ck'),
+      ('finance_legal_mentions_early_basis_ck'),
+      ('finance_legal_mentions_early_pair_ck'),
+      ('finance_legal_mentions_indemnity_ck'),
+      ('finance_legal_mentions_vat_regime_ck'),
+      ('finance_legal_mentions_biller_version_key')
+    ) AS c(expected)
+    WHERE NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conrelid = 'public.finance_legal_mentions'::regclass AND conname = c.expected
+    )
+  LOOP
+    RAISE EXCEPTION 'VERIFY: contrainte manquante %', v_missing;
+  END LOOP;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public' AND indexname = 'finance_legal_mentions_one_open_idx'
+  ) THEN
+    RAISE EXCEPTION 'VERIFY: index unique partiel finance_legal_mentions_one_open_idx manquant — deux versions ouvertes rendraient la résolution non déterministe';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND indexname = 'finance_legal_mentions_effective_from_uidx'
+  ) THEN
+    RAISE EXCEPTION 'VERIFY: index unique finance_legal_mentions_effective_from_uidx manquant';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger
+    WHERE tgrelid = 'public.finance_legal_mentions'::regclass
+      AND tgname = 'finance_legal_mentions_no_overlap_trg'
+      AND NOT tgisinternal
+      AND tgenabled <> 'D'
+  ) THEN
+    RAISE EXCEPTION 'VERIFY: trigger anti-chevauchement manquant ou désactivé';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM public.finance_legal_mentions left_version
+    JOIN public.finance_legal_mentions right_version
+      ON right_version.biller_id = left_version.biller_id
+     AND right_version.mention_set_id > left_version.mention_set_id
+     AND daterange(left_version.effective_from, left_version.effective_to, '[)')
+         && daterange(right_version.effective_from, right_version.effective_to, '[)')
+  ) THEN
+    RAISE EXCEPTION 'VERIFY: périodes de mentions qui se chevauchent';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 2) Amorçage                                                                */
+/* -------------------------------------------------------------------------- */
+
+\echo ''
+\echo '=== 2) Entité émettrice ==='
+SELECT biller_id, biller_name, house_number, street, postal_code, city, country, phone
+FROM public.factureur
+ORDER BY biller_name;
+
+DO $$
+DECLARE
+  v_nb integer;
+BEGIN
+  SELECT count(*) INTO v_nb FROM public.factureur;
+  IF v_nb = 0 THEN
+    RAISE EXCEPTION 'VERIFY: aucune entité émettrice — le bloc « Émetteur » des documents resterait vide';
+  END IF;
+END $$;
+
+\echo ''
+\echo '=== 3) Versions de mentions ==='
+SELECT version, effective_from, effective_to, legal_form, share_capital,
+       rcs_city, rcs_number, siret, vat_number,
+       late_penalty_rate, late_penalty_basis, recovery_indemnity,
+       early_discount_rate, early_discount_basis,
+       vat_on_receipts, vat_exempt_293b
+FROM public.finance_legal_mentions
+ORDER BY biller_id, version;
+
+DO $$
+DECLARE
+  v_open integer;
+BEGIN
+  SELECT count(*) INTO v_open
+  FROM public.finance_legal_mentions WHERE effective_to IS NULL;
+  IF v_open <> 1 THEN
+    RAISE EXCEPTION 'VERIFY: % version(s) en vigueur, 1 attendue', v_open;
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 3) Les cinq mentions obligatoires du ticket sont résolues                  */
+/* -------------------------------------------------------------------------- */
+
+\echo ''
+\echo '=== 4) Instantané résolu au 2026-07-29 ==='
+SELECT jsonb_pretty(public.fn_finance_issuer_snapshot(
+  (SELECT biller_id FROM public.factureur ORDER BY biller_name LIMIT 1),
+  DATE '2026-07-29'
+)) AS instantane;
+
+DO $$
+DECLARE
+  v_snap    jsonb;
+  v_biller  uuid;
+  v_missing text;
+BEGIN
+  SELECT biller_id INTO v_biller FROM public.factureur ORDER BY biller_name LIMIT 1;
+  v_snap := public.fn_finance_issuer_snapshot(v_biller, DATE '2026-07-29');
+
+  IF v_snap IS NULL THEN
+    RAISE EXCEPTION 'VERIFY: la fonction ne résout aucun instantané pour %', v_biller;
+  END IF;
+
+  -- 1. Pénalités de retard — art. L441-10 C. com.
+  -- 2. Indemnité forfaitaire de recouvrement — art. D441-5 C. com.
+  -- 3. Escompte (taux, ou absence explicite côté rendu)
+  -- 4. Identité : RCS + ville, capital social, forme juridique
+  FOR v_missing IN
+    SELECT k.key
+    FROM (VALUES
+      ('late_penalty_rate'), ('late_penalty_basis'),
+      ('recovery_indemnity'),
+      ('legal_form'), ('share_capital'), ('share_capital_currency'),
+      ('rcs_city'), ('rcs_number'),
+      ('siren'), ('siret'), ('vat_number'),
+      ('company_name'), ('legal_mentions_version')
+    ) AS k(key)
+    WHERE NOT (v_snap ? k.key)
+  LOOP
+    RAISE EXCEPTION 'VERIFY: mention obligatoire absente de l''instantané : %', v_missing;
+  END LOOP;
+
+  -- L'indemnité forfaitaire est de 40 € par facture impayée (montant fixé par décret).
+  IF (v_snap ->> 'recovery_indemnity')::numeric <> 40.00 THEN
+    RAISE EXCEPTION 'VERIFY: indemnité forfaitaire = % €, 40.00 attendus (art. D441-5)',
+      v_snap ->> 'recovery_indemnity';
+  END IF;
+
+  -- Un instantané ne doit jamais porter d'identifiant technique client ni de clé nulle.
+  IF v_snap ? 'client_id' THEN
+    RAISE EXCEPTION 'VERIFY: l''instantané émetteur porte un client_id';
+  END IF;
+
+  RAISE NOTICE 'VERIFY: instantané complet — version % en vigueur depuis %',
+    v_snap ->> 'legal_mentions_version', v_snap ->> 'legal_mentions_effective_from';
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 4) Le versionnement fait bien son travail                                  */
+/* -------------------------------------------------------------------------- */
+-- Une date antérieure à la première version doit rendre l'identité opérationnelle SANS
+-- mentions : le rendu affichera alors ce qu'il a, et rien d'inventé. C'est le
+-- comportement voulu, et c'est ce qui protège l'historique d'une réécriture.
+
+DO $$
+DECLARE
+  v_snap   jsonb;
+  v_biller uuid;
+BEGIN
+  SELECT biller_id INTO v_biller FROM public.factureur ORDER BY biller_name LIMIT 1;
+  v_snap := public.fn_finance_issuer_snapshot(v_biller, DATE '2020-01-01');
+
+  IF v_snap ? 'late_penalty_rate' THEN
+    RAISE EXCEPTION 'VERIFY: des mentions sont résolues hors de leur période de validité';
+  END IF;
+  IF NOT (v_snap ? 'company_name') THEN
+    RAISE EXCEPTION 'VERIFY: identité opérationnelle perdue hors période de mentions';
+  END IF;
+
+  RAISE NOTICE 'VERIFY: résolution hors période correcte — identité sans mentions';
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 5) Accès applicatif                                                        */
+/* -------------------------------------------------------------------------- */
+
+\echo ''
+\echo '=== 5) Ownership et privilèges runtime ==='
+SELECT tablename, tableowner
+FROM pg_tables
+WHERE schemaname = 'public' AND tablename = 'finance_legal_mentions';
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    IF NOT has_table_privilege('cerp_app', 'public.finance_legal_mentions', 'SELECT') THEN
+      RAISE EXCEPTION 'VERIFY: cerp_app ne peut pas lire finance_legal_mentions (SQLSTATE 42501 en runtime → API 500)';
+    END IF;
+    IF NOT has_function_privilege('cerp_app', 'public.fn_finance_issuer_snapshot(uuid, date)', 'EXECUTE') THEN
+      RAISE EXCEPTION 'VERIFY: cerp_app ne peut pas exécuter fn_finance_issuer_snapshot';
+    END IF;
+    RAISE NOTICE 'VERIFY: accès runtime cerp_app confirmé';
+  ELSE
+    RAISE NOTICE 'VERIFY: rôle cerp_app absent de cette base — contrôle d''accès ignoré';
+  END IF;
+END $$;
+
+\echo ''
+\echo '=== VERIFY TERMINÉ SANS ERREUR ==='

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -441,3 +441,68 @@ l'infrastructure existe, la décision redevient fermée par défaut.
 
 État au 2026-07-27 : patch, scripts de support et seed **écrits et versionnés,
 appliqués sur aucune base**. Ni `cerp_test` ni `cerp_prod` n'ont été modifiés.
+
+## Mentions légales obligatoires de l'entité émettrice
+
+Le patch `20260729_finance_legal_mentions.sql` fait suite au rendu unique des pièces
+financières (#216). Il crée la table versionnée `finance_legal_mentions` et la fonction de
+résolution `fn_finance_issuer_snapshot(biller_id, date)`, puis amorce l'entité émettrice.
+Le correctif additif `20260729_finance_legal_mentions_hardening_221.sql` interdit les
+chevauchements de périodes, sérialise les écritures concurrentes par émetteur et rend la
+résolution explicitement déterministe. Le patch initial avait déjà été appliqué sur
+`cerp_test` avant la revue #221 ; conformément à la règle d'immutabilité des patches
+exécutés, il n'a pas été modifié.
+
+Constat relevé le 2026-07-29 sur `cerp_test` **et** `cerp_prod` :
+
+- `public.factureur` ne porte **aucune** colonne légale — ni `siret`, ni `siren`, ni `rcs`,
+  ni `vat_number`, ni `capital_social`. Le serveur filtrait pourtant `to_jsonb(factureur)`
+  sur exactement cette liste (`ISSUER_LEGAL_FIELDS`) : le filtre ne retenait jamais rien et
+  aucune mention obligatoire n'était imprimée ;
+- `public.factureur` est **vide** sur les deux bases, comme `finance_billing_policies` et
+  `facture`. Aucune facture n'a jamais été émise par ce chemin, donc **aucun exemplaire
+  immuable à préserver**.
+
+Le versionnement n'est pas décoratif : une facture émise porte les mentions **en vigueur à
+sa date d'émission** et ne se régénère jamais. Des colonnes posées sur `factureur` seraient
+réécrites en place et falsifieraient rétroactivement l'historique ; une nouvelle version
+laisse les instantanés déjà figés résoudre la leur. Un index unique partiel garantit au plus
+une version ouverte par émetteur, sans quoi la résolution à une date donnée ne serait pas
+déterministe.
+
+Valeurs amorcées pour CROIX ROUSSE PRECISION, et leur source :
+
+- registre national des entreprises (INPI) via `annuaire-entreprises.data.gouv.fr`, SIREN
+  380569012, consulté le 2026-07-29 : forme juridique SARL (catégorie INSEE 5499), capital
+  21 000,00 € fixe, TVA `FR73 380 569 012`, siège 530 rue de la Dombes, Les Échets,
+  01700 Miribel, immatriculation du 28/01/1991 ;
+- facture papier CERP n° 5256 du 24/07/2026 : pénalités 12,50 % annuel, escompte 1,50 %
+  mensuel, réserve de propriété, TVA acquittée sur les encaissements, coordonnées bancaires.
+
+Deux numéros de TVA figurent sur cette facture papier. Les deux clés de contrôle sont
+valides mais portent sur des SIREN différents : seul `FR73 380 569 012` est cohérent avec le
+SIRET `380 569 012 00020`. `FR40 800 163 065` est celui du client, pas de l'émetteur.
+
+Deux mentions ont été **ajoutées** parce qu'elles manquaient à la facture papier et sont
+obligatoires : l'indemnité forfaitaire de recouvrement de 40 € (art. D441-5, décret
+2012-1115) et la ville du RCS — Miribel relève de l'Ain, dont le ressort unique est le
+greffe de Bourg-en-Bresse. « RCS : 380569012 » sans ville est incomplet au regard de
+l'art. R123-237.
+
+`effective_from` est fixé au 1er janvier 2026 : c'est la période la plus large que l'on
+puisse couvrir sans affirmer ce qui était en vigueur les années précédentes. Aucune facture
+n'existant en base, aucune pièce ne se retrouve hors période.
+
+Ordre obligatoire : exécuter `support/20260729_finance_legal_mentions.preflight.sql`,
+appliquer les deux patches dans l'ordre sur `cerp_test`, exécuter la vérification. Le
+rollback est restreint à `cerp_test` et refuse de s'exécuter dès qu'une pièce porte un
+instantané d'émetteur. Une validation humaine explicite reste obligatoire avant toute
+application sur `cerp_prod`.
+
+Validation du 2026-07-29 : sauvegarde `cerp_prod_20260729-110843.dump` (50 642 473 o)
+vérifiée avant toute écriture ; préflight en lecture seule confirmant 0 factureur,
+0 politique et 0 facture ; patch appliqué et enregistré dans `cerp_schema_migrations`
+(SHA-256 `814dcc7dbb51dd13eb3ce2a3656ce729716b8d7e7f66ac473d31e79e0e461a4d`) ; vérification
+complète réussie — 11 contraintes, une seule version en vigueur, instantané portant les
+treize clés obligatoires, résolution hors période rendant l'identité **sans** mentions, et
+`finance_legal_mentions` possédée par `cerp_app`. **`cerp_prod` n'a pas été modifiée.**

--- a/docs/mentions-legales-documents-sortants.md
+++ b/docs/mentions-legales-documents-sortants.md
@@ -1,0 +1,151 @@
+# Mentions légales des documents sortants
+
+Toute pièce commerciale émise par CERP porte désormais l'identité légale de son émetteur et
+ses mentions obligatoires : facture, avoir, bon de livraison, certificat de conformité et
+accusé de réception de commande.
+
+Fait suite au rendu unique des pièces financières (#216) et du bon de livraison (#213).
+
+## Le défaut
+
+Le rendu était prêt à afficher SIRET, SIREN, RCS, numéro de TVA et capital social — il ne
+les inventait simplement pas. Trois constats, relevés le 2026-07-29 :
+
+1. **`public.factureur` ne porte aucune colonne légale.** Le serveur lisait
+   `to_jsonb(factureur)` puis filtrait sur une liste blanche contenant `siret`, `siren`,
+   `rcs`, `vat_number` et `capital_social`. Aucune de ces colonnes n'existe : le filtre ne
+   retenait jamais rien.
+2. **`public.factureur` est vide** sur `cerp_test` comme sur `cerp_prod`. Le bloc
+   « Émetteur » sortait « Non renseigné », et l'émission aurait levé
+   `503 FINANCE_ISSUER_NOT_CONFIGURED` dès la première facture.
+3. **L'instantané ne figeait que `biller_id` et `biller_name`.** Même alimenté, il n'aurait
+   rien porté d'opposable.
+
+Le bon de livraison et le pack COFC lisaient `biller_name` seul ; l'accusé de réception ne
+lisait rien du tout. Chaque module avait sa propre idée de l'émetteur.
+
+## Ce que la loi exige
+
+| Mention | Fondement | Champ |
+|---|---|---|
+| Forme juridique, capital social | art. R123-237 C. com. | `legal_form`, `share_capital` |
+| RCS **et ville d'immatriculation** | art. R123-237 C. com. | `rcs_city`, `rcs_number` |
+| SIREN / SIRET | art. R123-237 C. com. | `siren`, `siret` |
+| N° de TVA intracommunautaire | art. 242 nonies A ann. II CGI | `vat_number` |
+| Pénalités de retard | art. L441-10 C. com. | `late_penalty_rate`, `late_penalty_basis` |
+| Indemnité forfaitaire de recouvrement (40 €) | art. D441-5 C. com. | `recovery_indemnity` |
+| Escompte, **même en son absence** | art. L441-9 C. com. | `early_discount_rate` |
+| « TVA non applicable, art. 293 B du CGI » | art. 293 B CGI | `vat_exempt_293b` |
+| « TVA acquittée sur les encaissements » | art. 269-2 CGI | `vat_on_receipts` |
+| Réserve de propriété | loi du 12 mai 1980 | `retention_of_title` |
+
+## Où vit la donnée
+
+`public.finance_legal_mentions`, **versionnée par période de validité**, et non des colonnes
+sur `factureur`.
+
+Un taux de pénalité, un capital ou une ville de RCS changent. Une facture émise doit porter
+les mentions en vigueur **à sa date d'émission**, et elle est immuable. Des colonnes sur
+`factureur` seraient réécrites en place et falsifieraient rétroactivement l'historique. Ici,
+une modification ouvre une nouvelle version : les instantanés déjà figés continuent de
+résoudre la leur.
+
+`fn_finance_issuer_snapshot(biller_id, date)` résout identité opérationnelle et mentions
+applicables en un seul objet JSON, destiné à être figé tel quel. C'est le **seul** point de
+vérité, partagé par tous les documents.
+
+Le patch additif
+`20260729_finance_legal_mentions_hardening_221.sql` interdit en outre tout chevauchement
+de périodes pour un même émetteur, y compris en cas d'écritures concurrentes, et rend le
+choix de la version applicable explicitement déterministe. Le premier patch avait déjà été
+appliqué sur `cerp_test` au moment de cette revue : il n'a donc pas été réécrit.
+
+Les montants et taux sortent en **texte** : le rendu met en forme, il ne calcule pas.
+`jsonb_strip_nulls` garantit qu'une mention absente est absente de l'instantané, et non
+présente à `NULL` — le rendu n'affiche jamais de substitut à une mention manquante.
+
+## Quand les mentions sont figées
+
+À l'**émission**, pas à la création du brouillon. Un brouillon peut vivre des semaines ; si
+un taux change entre-temps, la facture doit porter ce qui est en vigueur le jour où elle est
+émise. `svcIssueFacture` et `svcIssueAvoir` re-résolvent donc l'instantané à `issueDate`,
+l'écrivent dans le document **et** le réenregistrent sur la ligne : sans cela,
+`facture.issuer_snapshot` et le PDF émis diraient deux choses différentes de la même pièce.
+
+Un avoir résout ses propres mentions à sa date d'émission plutôt que d'hériter de celles de
+la facture corrigée : c'est lui-même une pièce fiscale.
+
+Facture et avoir refusent désormais l'émission avant toute consommation d'un numéro légal
+si la version applicable ou l'une des mentions obligatoires manque. La ligne métier conserve
+ensuite le même `issuer_snapshot` que l'instantané immuable et le PDF.
+
+## Où les mentions apparaissent
+
+Dans la **bande de pied**, sur toutes les pages — jamais dans le flux du contenu.
+
+C'est la disposition de la facture papier de l'entreprise : le bloc « Émetteur » en tête
+porte l'adresse et le téléphone, le pied porte capital, RCS, SIRET et TVA. Trois raisons :
+
+- placées à la suite du contenu, elles poussaient un bon de livraison de deux lignes sur une
+  seconde page qui ne portait qu'elles — le cadre de réception occupe déjà le bas de page ;
+- une mention obligatoire ne doit jamais coûter une page ;
+- répétée à chaque page, elle reste opposable sur une page détachée.
+
+La hauteur de la bande est **mesurée** sur le texte réel, jamais forfaitaire : une clause de
+réserve de propriété longue chevaucherait sinon la dernière ligne du contenu, et une mention
+illisible est une mention absente.
+
+Deux pièges de pdfkit sont traités dans `shared/pdf/cerp-document.ts` :
+
+- pdfkit **ouvre une page** dès qu'un texte susceptible de revenir à la ligne dépasse
+  `maxY()`. Un pied vit par définition sous la marge basse : la marge est donc suspendue le
+  temps de le dessiner. Sans cela, chaque document gagnait une page vide.
+- pdfkit **justifie en positionnant les mots** au lieu d'écrire les espaces. Le texte extrait
+  revenait collé (« Pénalitésderetard:12,5% »). Les mentions sont donc rendues fer à gauche :
+  une mention légale doit rester lisible par une machine — copier-coller, indexation,
+  contrôle automatisé.
+
+## Conséquence sur la pagination
+
+La bande coûte de la hauteur de contenu à chaque page. Un document déjà au bord gagne une
+page. Le gabarit `FACTURE` des tests était à moins de 10 pt de la limite **avant** ce
+changement : sa seule ligne d'identité légale suffit à le faire paginer. C'est le contenu qui
+remplit la page, pas les mentions — mais l'effet est visible et assumé.
+
+## Périmètre
+
+| Document | Identité légale | Mentions | Rendu |
+|---|---|---|---|
+| Facture | ✅ | ✅ + RIB | grammaire CERP |
+| Avoir | ✅ | ✅ sans RIB — un avoir ne se règle pas | grammaire CERP |
+| Bon de livraison | ✅ | ✅ | grammaire CERP |
+| Certificat de conformité | ✅ | ✅ | grammaire CERP |
+| Accusé de réception de commande | ✅ | ✅ | grammaire CERP |
+
+L'accusé de réception a rejoint `renderCerpDocument` pendant la revue #221 : le référentiel
+est résolu à la date de génération de l'artefact, la table est paginée par le socle et le
+pied répète les mentions sur chaque page comme les autres documents.
+
+Devis, commande et bon de commande sont rendus dans le navigateur (ADR-0039/0040) : ils
+relèvent du dépôt `crp-systems-web` et ne sont pas couverts ici.
+
+## Tolérance à l'absence de patch
+
+Tant que `20260729_finance_legal_mentions.sql` n'est pas appliqué, la fonction n'existe pas
+(`42883`) et `readIssuerParty` retombe sur l'identité opérationnelle seule pour les
+documents non fiscaux et les aperçus. L'émission d'une facture ou d'un avoir, elle, échoue
+explicitement : un exemplaire fiscal immuable sans mentions ne doit jamais être créé.
+
+## Vérification
+
+`src/module/facturation/services/finance-document-render.test.ts` — 42 cas, dont 20 ajoutés
+pour les mentions. `src/module/livraisons/services/pack-pdf.service.test.ts` — 18 cas.
+
+Le texte est relu dans les **flux de contenu décompressés** du PDF, décodés en WinAnsi : on
+vérifie ce que le document affiche, pas ce que le code croit avoir écrit. Sont couverts la
+présence de chaque mention obligatoire, l'absence de mention inventée quand le référentiel
+est muet, l'énoncé explicite de l'absence d'escompte, la franchise 293 B, la répétition sur
+chaque page, l'extractibilité du texte, et le fait que l'instantané figé prime sur le
+paramétrage courant.
+
+`CERP_PDF_PREVIEW=1` écrit les PDF dans `outputs/pdf-preview` pour inspection visuelle.

--- a/src/__tests__/finance-legal-mentions-221.migration-guards.test.ts
+++ b/src/__tests__/finance-legal-mentions-221.migration-guards.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+const repositoryRoot = resolve(__dirname, '..', '..');
+
+function readRepositoryFile(relativePath: string): string {
+  return readFileSync(resolve(repositoryRoot, relativePath), 'utf8');
+}
+
+describe('finance legal mentions migration guards (#221)', () => {
+  const initialPatch = readRepositoryFile(
+    'db/patches/20260729_finance_legal_mentions.sql'
+  );
+  const hardeningPatch = readRepositoryFile(
+    'db/patches/20260729_finance_legal_mentions_hardening_221.sql'
+  );
+  const preflight = readRepositoryFile(
+    'db/patches/support/20260729_finance_legal_mentions.preflight.sql'
+  );
+  const verification = readRepositoryFile(
+    'db/patches/support/20260729_finance_legal_mentions.verify.sql'
+  );
+  const rollback = readRepositoryFile(
+    'db/patches/support/20260729_finance_legal_mentions.rollback.sql'
+  );
+
+  it('keeps both patches transactional and avoids destructive table operations', () => {
+    for (const patch of [initialPatch, hardeningPatch]) {
+      expect(patch).toMatch(/\bBEGIN\s*;/i);
+      expect(patch).toMatch(/\bCOMMIT\s*;/i);
+      expect(patch).not.toMatch(/\bDROP\s+TABLE\b/i);
+      expect(patch).not.toMatch(/\bTRUNCATE\b/i);
+    }
+  });
+
+  it('prevents overlapping legal versions and resolves one deterministic version', () => {
+    expect(hardeningPatch).toMatch(/pg_advisory_xact_lock/i);
+    expect(hardeningPatch).toMatch(/daterange\s*\(/i);
+    expect(hardeningPatch).toMatch(
+      /CREATE\s+TRIGGER\s+finance_legal_mentions_no_overlap_trg/i
+    );
+    expect(hardeningPatch).toMatch(/LEFT\s+JOIN\s+LATERAL/i);
+    expect(hardeningPatch).toMatch(
+      /ORDER\s+BY\s+resolved\.effective_from\s+DESC,\s*resolved\.version\s+DESC/i
+    );
+    expect(hardeningPatch).toMatch(/LIMIT\s+1/i);
+  });
+
+  it('keeps the preflight read-only', () => {
+    expect(preflight).not.toMatch(
+      /^\s*(INSERT|UPDATE|DELETE|TRUNCATE|ALTER|DROP|CREATE|GRANT|REVOKE)\b/im
+    );
+  });
+
+  it('verifies the overlap guard and the absence of ambiguous periods', () => {
+    expect(verification).toMatch(
+      /tg_finance_legal_mentions_no_overlap/i
+    );
+    expect(verification).toMatch(
+      /finance_legal_mentions_no_overlap_trg/i
+    );
+    expect(verification).toMatch(/overlap/i);
+    expect(verification).toMatch(/périodes de mentions qui se chevauchent/i);
+  });
+
+  it('restricts rollback to cerp_test and refuses snapshotted documents', () => {
+    expect(rollback).toMatch(/current_database\(\)\s*<>\s*'cerp_test'/i);
+    expect(rollback).toMatch(
+      /legal_number\s+IS\s+NOT\s+NULL\s+OR\s+issuer_snapshot\s+IS\s+NOT\s+NULL/i
+    );
+    expect(rollback).toMatch(
+      /DROP\s+TRIGGER\s+IF\s+EXISTS\s+finance_legal_mentions_no_overlap_trg/i
+    );
+  });
+});

--- a/src/module/commande-client/services/commande-ar.service.test.ts
+++ b/src/module/commande-client/services/commande-ar.service.test.ts
@@ -1,0 +1,144 @@
+import { inflateSync } from "node:zlib";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../config/database", () => ({
+  default: { connect: vi.fn() },
+}));
+vi.mock("../../../shared/realtime/realtime.service", () => ({
+  emitAppNotificationCreated: vi.fn(),
+  emitEntityChanged: vi.fn(),
+}));
+vi.mock("../../../shared/email/resend.service", () => ({
+  sendTransactionalEmail: vi.fn(),
+}));
+vi.mock("../../../shared/documents/issuer-identity.repository", () => ({
+  readIssuerParty: vi.fn(),
+}));
+vi.mock("../repository/commande-ar.repository", () => ({
+  buildCommandeArRecipientSuggestions: vi.fn(),
+  repoCreateCommandeArDraft: vi.fn(),
+  repoFinalizeCommandeArSend: vi.fn(),
+  repoGetCommandeArDraft: vi.fn(),
+  repoLoadCommandeArGenerationData: vi.fn(),
+  repoMarkCommandeArFailed: vi.fn(),
+}));
+
+import { buildCommandeArPdfBuffer } from "./commande-ar.service";
+
+const WINANSI = new TextDecoder("windows-1252");
+
+function drawnPages(bytes: Buffer): string[] {
+  const decodeOperands = (operands: string): string =>
+    [...operands.matchAll(/<([0-9a-fA-F\s]*)>|\(((?:\\.|[^\\)])*)\)/g)]
+      .map((match) =>
+        match[1] !== undefined
+          ? WINANSI.decode(Buffer.from(match[1].replace(/\s+/g, ""), "hex"))
+          : match[2].replace(/\\([()\\])/g, "$1")
+      )
+      .join("");
+
+  const pages: string[] = [];
+  let cursor = 0;
+  for (;;) {
+    const start = bytes.indexOf("stream", cursor);
+    if (start < 0) break;
+    let from = start + "stream".length;
+    if (bytes[from] === 0x0d) from += 1;
+    if (bytes[from] === 0x0a) from += 1;
+    const end = bytes.indexOf("endstream", from);
+    if (end < 0) break;
+    cursor = end + "endstream".length;
+
+    let content: string;
+    try {
+      content = inflateSync(bytes.subarray(from, end)).toString("latin1");
+    } catch {
+      continue;
+    }
+    if (!content.includes("BT")) continue;
+    pages.push(
+      [
+        ...[...content.matchAll(/\[([^\]]*)\]\s*TJ/g)].map((match) =>
+          decodeOperands(match[1])
+        ),
+        ...[
+          ...content.matchAll(
+            /(<[0-9a-fA-F\s]*>|\((?:\\.|[^\\)])*\))\s*Tj/g
+          ),
+        ].map((match) => decodeOperands(match[1])),
+      ].join("\n")
+    );
+  }
+  return pages;
+}
+
+const ISSUER = {
+  company_name: "CROIX ROUSSE PRECISION",
+  legal_form: "SARL",
+  share_capital: "21000.00",
+  share_capital_currency: "EUR",
+  rcs_city: "Bourg-en-Bresse",
+  rcs_number: "380 569 012",
+  siret: "380 569 012 00020",
+  vat_number: "FR73 380 569 012",
+  late_penalty_rate: "12.500",
+  late_penalty_basis: "ANNUEL",
+  recovery_indemnity: "40.00",
+  early_discount_rate: "1.500",
+  early_discount_basis: "MENSUEL",
+  vat_on_receipts: true,
+  retention_of_title: "Propriété réservée jusqu'au paiement intégral.",
+  legal_mentions_version: 1,
+};
+
+describe("accusé de réception — mentions légales", () => {
+  it("uses the CERP document footer and repeats legal mentions on every page", async () => {
+    const bytes = await buildCommandeArPdfBuffer({
+      draftNumber: "CC-2026-0042",
+      companyName: "ABB FRANCE",
+      dateCommande: "2026-07-20",
+      generatedAt: new Date("2026-07-29T10:00:00.000Z"),
+      statut: "PLANIFIEE",
+      totalHt: 12_000,
+      totalTtc: 14_400,
+      commentaire: "Merci de vérifier les délais confirmés.",
+      clientEmail: "achats@example.test",
+      clientPhone: "01 23 45 67 89",
+      billAddress: {
+        name: "ABB FRANCE",
+        street: "Rue de la Commande",
+        house_number: "12",
+        postal_code: "69000",
+        city: "LYON",
+        country: "France",
+      },
+      deliveryAddress: {
+        name: "ABB FRANCE — Réception",
+        street: "Rue de la Livraison",
+        house_number: "4",
+        postal_code: "69000",
+        city: "LYON",
+        country: "France",
+      },
+      lines: Array.from({ length: 45 }, (_, index) => ({
+        designation: `Pièce usinée ${index + 1}`,
+        code_piece: `PT-${String(index + 1).padStart(4, "0")}`,
+        quantite: 2,
+        unite: "pce",
+        prix_unitaire_ht: 100,
+        taux_tva: 20,
+        total_ttc: 240,
+      })),
+      issuer: ISSUER,
+    });
+
+    const pages = drawnPages(bytes);
+    expect(pages.length).toBeGreaterThan(1);
+    for (const page of pages) {
+      expect(page).toContain("SIRET 380 569 012 00020");
+      expect(page).toContain("Pénalités de retard : 12,5 % l'an");
+      expect(page).toContain("Indemnité forfaitaire");
+    }
+  }, 90_000);
+});

--- a/src/module/commande-client/services/commande-ar.service.ts
+++ b/src/module/commande-client/services/commande-ar.service.ts
@@ -1,4 +1,3 @@
-import PDFDocument from "pdfkit";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -6,6 +5,13 @@ import { HttpError } from "../../../utils/httpError";
 import { getDocumentStoragePath } from "../../../utils/cerpStorage";
 import { emitAppNotificationCreated, emitEntityChanged } from "../../../shared/realtime/realtime.service";
 import { sendTransactionalEmail, type ResendSendResult } from "../../../shared/email/resend.service";
+import { readIssuerParty } from "../../../shared/documents/issuer-identity.repository";
+import {
+  CONTENT_WIDTH,
+  renderCerpDocument,
+  type CerpLineRow,
+} from "../../../shared/pdf/cerp-document";
+import { issuerIdentityLine, issuerLegalMentions, type LegalParty } from "../../../shared/pdf/legal-mentions";
 import type {
   CommandeArDraft,
   CommandeArRecipientSuggestion,
@@ -101,10 +107,11 @@ function isResendSendError(result: Extract<ResendSendResult, { ok: false }>): re
   return "error" in result;
 }
 
-async function buildPdfBuffer(params: {
+export async function buildCommandeArPdfBuffer(params: {
   draftNumber: string;
   companyName: string | null;
   dateCommande: string;
+  generatedAt: Date;
   statut: string | null;
   totalHt: number;
   totalTtc: number;
@@ -122,77 +129,101 @@ async function buildPdfBuffer(params: {
     taux_tva: number | null;
     total_ttc: number;
   }>;
+  /**
+   * Instantane de l'emetteur : identite legale et mentions obligatoires.
+   *
+   * L'accuse de reception est un document commercial envoye au client par courriel : il
+   * doit porter l'identite legale de son emetteur au meme titre que la facture et le bon de
+   * livraison (art. R123-237 C. com.). Il ne portait aucune mention.
+   */
+  issuer: LegalParty;
 }): Promise<Buffer> {
-  return new Promise<Buffer>((resolve, reject) => {
-    const doc = new PDFDocument({ size: "A4", margin: 40 });
-    const chunks: Buffer[] = [];
-    doc.on("data", (chunk) => chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)));
-    doc.on("end", () => resolve(Buffer.concat(chunks)));
-    doc.on("error", reject);
+  const clientName = params.companyName?.trim() || "Client";
+  const rows: CerpLineRow[] = params.lines.map((line) => ({
+    cells: {
+      designation: line.designation,
+      code_piece: line.code_piece ?? "—",
+      quantite: String(line.quantite),
+      unite: line.unite ?? "—",
+      prix_unitaire_ht: formatCurrencyEUR(line.prix_unitaire_ht),
+      taux_tva: `${line.taux_tva ?? 0} %`,
+      total_ttc: formatCurrencyEUR(line.total_ttc),
+    },
+    metaColumn: "designation",
+  }));
 
-    doc.fontSize(20).text("Accuse de reception", { align: "left" });
-    doc.moveDown(0.5);
-    doc.fontSize(11).fillColor("#475569").text(`Commande ${params.draftNumber}`);
-    doc.text(`Date commande: ${formatDateFR(params.dateCommande)}`);
-    doc.text(`Statut: ${params.statut ?? "PLANIFIEE"}`);
-    doc.fillColor("black");
-    doc.moveDown();
+  return renderCerpDocument(
+    {
+      documentType: "Accusé de réception",
+      name: clientName,
+      code: params.draftNumber,
+      subtitle: `Commande ${params.draftNumber}`,
+      status: params.statut ?? "PLANIFIEE",
+      monogramName: clientName,
+      generatedAt: formatDateFR(params.generatedAt.toISOString()),
+      title: `Accusé de réception ${params.draftNumber}`,
+      subject: "Accusé de réception de commande CERP",
+      legalIdentity: issuerIdentityLine(params.issuer),
+      legalMentions: issuerLegalMentions(params.issuer),
+      creationDate: params.generatedAt,
+    },
+    (ctx) => {
+      ctx.legalStrip([
+        { label: "Commande", value: params.draftNumber },
+        { label: "Date commande", value: formatDateFR(params.dateCommande) },
+        { label: "Statut", value: params.statut ?? "PLANIFIEE" },
+        { label: "Total TTC", value: formatCurrencyEUR(params.totalTtc) },
+      ]);
 
-    doc.fontSize(13).text("Client");
-    doc.fontSize(10);
-    doc.text(params.companyName ?? "-");
-    doc.text(`Email: ${params.clientEmail ?? "-"}`);
-    doc.text(`Telephone: ${params.clientPhone ?? "-"}`);
-    doc.moveDown();
+      ctx.section("Client et adresses", { cohesion: 100 });
+      ctx.addressCards([
+        {
+          caption: "Facturation",
+          lines: addressLines(params.billAddress),
+          accent: true,
+        },
+        {
+          caption: "Livraison",
+          lines: addressLines(params.deliveryAddress),
+        },
+      ]);
 
-    doc.fontSize(13).text("Adresse de facturation");
-    doc.fontSize(10);
-    for (const line of addressLines(params.billAddress)) doc.text(line);
-    doc.moveDown(0.5);
-    doc.fontSize(13).text("Adresse de livraison");
-    doc.fontSize(10);
-    for (const line of addressLines(params.deliveryAddress)) doc.text(line);
-    doc.moveDown();
+      ctx.section("Contact", { cohesion: 36 });
+      const half = CONTENT_WIDTH / 2 - 8;
+      const emailBottom = ctx.field("Email", params.clientEmail, 38, half);
+      const phoneBottom = ctx.field("Téléphone", params.clientPhone, 38 + half + 16, half);
+      ctx.y = Math.max(emailBottom, phoneBottom);
 
-    doc.fontSize(13).text("Lignes");
-    doc.moveDown(0.5);
-    doc.fontSize(9).fillColor("#475569");
-    doc.text("Designation", 40, doc.y, { width: 230 });
-    doc.text("Qte", 275, doc.y, { width: 40, align: "right" });
-    doc.text("PU HT", 320, doc.y, { width: 80, align: "right" });
-    doc.text("TVA", 405, doc.y, { width: 50, align: "right" });
-    doc.text("Total TTC", 460, doc.y, { width: 95, align: "right" });
-    doc.moveDown(0.4);
-    doc.fillColor("black");
-    doc.moveTo(40, doc.y).lineTo(555, doc.y).strokeColor("#cbd5e1").stroke();
-    doc.moveDown(0.4);
+      ctx.section("Lignes de commande", { cohesion: 84 });
+      ctx.linesTable({
+        columns: [
+          { key: "designation", label: "Désignation", flex: 4.5 },
+          { key: "code_piece", label: "Code pièce", flex: 1.8 },
+          { key: "quantite", label: "Qté", flex: 1, align: "right" },
+          { key: "unite", label: "Unité", flex: 1 },
+          { key: "prix_unitaire_ht", label: "PU HT", flex: 1.8, align: "right" },
+          { key: "taux_tva", label: "TVA", flex: 1.2, align: "right" },
+          { key: "total_ttc", label: "Total TTC", flex: 2, align: "right" },
+        ],
+        rows,
+        emptyLabel: "Aucune ligne sur cette commande.",
+      });
 
-    for (const line of params.lines) {
-      const startY = doc.y;
-      doc.fontSize(10).fillColor("black");
-      doc.text(line.designation, 40, startY, { width: 230 });
-      if (line.code_piece) {
-        doc.fontSize(8).fillColor("#64748b").text(line.code_piece, 40, doc.y, { width: 230 });
+      ctx.section("Totaux", { cohesion: 32 });
+      const totalHtBottom = ctx.field("Total HT", formatCurrencyEUR(params.totalHt), 38, half);
+      const totalTtcBottom = ctx.field(
+        "Total TTC",
+        formatCurrencyEUR(params.totalTtc),
+        38 + half + 16,
+        half
+      );
+      ctx.y = Math.max(totalHtBottom, totalTtcBottom);
+
+      if (params.commentaire?.trim()) {
+        ctx.notesSection("Notes", params.commentaire.trim());
       }
-      doc.fontSize(10).fillColor("black");
-      doc.text(String(line.quantite), 275, startY, { width: 40, align: "right" });
-      doc.text(formatCurrencyEUR(line.prix_unitaire_ht), 320, startY, { width: 80, align: "right" });
-      doc.text(`${line.taux_tva ?? 0}%`, 405, startY, { width: 50, align: "right" });
-      doc.text(formatCurrencyEUR(line.total_ttc), 460, startY, { width: 95, align: "right" });
-      doc.moveDown(0.8);
     }
-
-    doc.moveDown();
-    doc.fontSize(11).text(`Total HT: ${formatCurrencyEUR(params.totalHt)}`, { align: "right" });
-    doc.text(`Total TTC: ${formatCurrencyEUR(params.totalTtc)}`, { align: "right" });
-    if (params.commentaire?.trim()) {
-      doc.moveDown();
-      doc.fontSize(11).text("Notes");
-      doc.fontSize(10).text(params.commentaire.trim());
-    }
-
-    doc.end();
-  });
+  );
 }
 
 export async function svcGenerateCommandeAr(params: {
@@ -213,10 +244,17 @@ export async function svcGenerateCommandeAr(params: {
       companyName: data.header.client_company_name,
     });
 
-    const pdfBuffer = await buildPdfBuffer({
+    const generatedAt = new Date();
+    // An acknowledgement is fixed by the generated PDF. It carries the legal version in
+    // force when that artifact is created, not the possibly much older order date.
+    const issuer = await readIssuerParty({ at: generatedAt.toISOString().slice(0, 10) });
+
+    const pdfBuffer = await buildCommandeArPdfBuffer({
+      issuer,
       draftNumber: data.header.numero,
       companyName: data.header.client_company_name,
       dateCommande: data.header.date_commande,
+      generatedAt,
       statut: data.header.statut,
       totalHt: data.header.total_ht,
       totalTtc: data.header.total_ttc,

--- a/src/module/facturation/repository/avoir-workflow.repository.ts
+++ b/src/module/facturation/repository/avoir-workflow.repository.ts
@@ -34,6 +34,7 @@ import {
   insertGlobalFinanceAudit,
   newCorrelationId,
   nextLegacyId,
+  requireFinanceIssuerSnapshotAt,
   saveFinanceReceipt,
 } from "./workflow.repository.shared";
 
@@ -773,6 +774,14 @@ export async function repoIssueAvoir(params: {
       );
     }
     const issueDate = new Date().toISOString().slice(0, 10);
+    // An avoir is itself a fiscal document. Resolve and validate its own legal version before
+    // consuming a legal sequence value; inheriting the corrected invoice's older mentions
+    // would rewrite the issue-date truth.
+    const issuerAtIssue = await requireFinanceIssuerSnapshotAt(
+      client,
+      avoir.legal_entity_code,
+      issueDate
+    );
     const legal = await allocateLegalNumber({
       client,
       documentType: "AVOIR",
@@ -789,7 +798,7 @@ export async function repoIssueAvoir(params: {
       facture_number: preview.facture_number,
       currency: preview.currency,
       client_snapshot: avoir.client_snapshot,
-      issuer_snapshot: avoir.issuer_snapshot,
+      issuer_snapshot: issuerAtIssue,
       reason_code: preview.reason_code,
       reason: preview.reason,
       lines: preview.lines,
@@ -822,6 +831,7 @@ export async function repoIssueAvoir(params: {
             issued_by = $6,
             immutable_snapshot = $7::jsonb,
             document_checksum_sha256 = $8,
+            issuer_snapshot = $9::jsonb,
             row_version = row_version + 1,
             updated_at = now()
         WHERE id = $1
@@ -836,6 +846,7 @@ export async function repoIssueAvoir(params: {
         params.actor.userId,
         JSON.stringify(snapshot),
         artifact.checksumSha256,
+        JSON.stringify(issuerAtIssue),
       ]
     );
     await client.query(

--- a/src/module/facturation/repository/facture-workflow.repository.ts
+++ b/src/module/facturation/repository/facture-workflow.repository.ts
@@ -36,8 +36,10 @@ import {
   insertFinanceEvent,
   insertFinanceOutbox,
   insertGlobalFinanceAudit,
+  issuerSnapshotAt,
   newCorrelationId,
   nextLegacyId,
+  requireFinanceIssuerSnapshotAt,
   saveFinanceReceipt,
 } from "./workflow.repository.shared";
 
@@ -503,29 +505,32 @@ async function clientSnapshot(queryer: DbQueryer, clientId: string): Promise<Rec
   return snapshot as Record<string, unknown>;
 }
 
-async function issuerSnapshot(queryer: DbQueryer, entityCode: string): Promise<Record<string, unknown>> {
-  const result = await queryer.query<Record<string, unknown>>(
-    `
-      SELECT jsonb_build_object(
-        'entity_code', $1::text,
-        'biller_id', f.biller_id,
-        'biller_name', f.biller_name
-      ) AS snapshot
-      FROM public.factureur f
-      WHERE f.biller_id::text = $1
-      LIMIT 1
-    `,
-    [entityCode]
-  );
-  const snapshot = result.rows[0]?.snapshot;
-  if (!snapshot || typeof snapshot !== "object") {
+/**
+ * Instantane de l'entite emettrice, mentions legales **en vigueur a la date donnee**.
+ *
+ * L'ancienne version ne figeait que `biller_id` et `biller_name`. Le document sortant ne
+ * pouvait donc porter ni SIRET, ni RCS, ni numero de TVA, ni capital, ni taux de penalite —
+ * toutes mentions obligatoires. `fn_finance_issuer_snapshot` resout l'identite complete et
+ * la version de mentions applicable a `at`, et le resultat est fige tel quel : c'est lui qui
+ * fera foi si la facture est contestee dans cinq ans.
+ *
+ * `at` est la date **d'emission**, pas la date du jour. Les deux different des qu'un
+ * brouillon est emis un autre jour que celui ou il a ete cree.
+ */
+async function issuerSnapshot(
+  queryer: DbQueryer,
+  entityCode: string,
+  at: string
+): Promise<Record<string, unknown>> {
+  const snapshot = await issuerSnapshotAt(queryer, entityCode, at);
+  if (!snapshot) {
     throw new HttpError(
       503,
       "FINANCE_ISSUER_NOT_CONFIGURED",
       "L'entité émettrice de la politique Finance est introuvable."
     );
   }
-  return snapshot as Record<string, unknown>;
+  return snapshot;
 }
 
 function ensurePreviewUsable(preview: FacturePreview, expectedHash: string): void {
@@ -575,7 +580,10 @@ export async function repoCreateFactureDraft(params: {
     const year = new Date().getUTCFullYear();
     const draftReference = `DFT-${year}-${String(factureId).padStart(6, "0")}`;
     const clientData = await clientSnapshot(client, params.input.client_id);
-    const issuerData = await issuerSnapshot(client, policy.legal_entity_code);
+    // Brouillon : les mentions du jour. Elles seront **re-resolues a l'emission**, seul
+    // moment ou la loi les fige (cf. svcIssueFacture).
+    const draftDate = new Date().toISOString().slice(0, 10);
+    const issuerData = await issuerSnapshot(client, policy.legal_entity_code, draftDate);
     const commandeIds = [...new Set(sources.map((row) => row.commande_id).filter(Boolean))];
     const affaireIds = [...new Set(sources.map((row) => row.affaire_id).filter(Boolean))];
     const dueDate = [...params.input.due_dates].sort((a, b) => a.due_date.localeCompare(b.due_date)).at(-1);
@@ -1112,6 +1120,13 @@ export async function repoIssueFacture(params: {
     }
     assertFactureTransition(facture.statut, "ISSUED");
     const issueDate = new Date().toISOString().slice(0, 10);
+    // Fail before consuming a legal sequence value: an immutable fiscal document must never
+    // be issued without the complete legal version applicable on its issue date.
+    const issuerAtIssue = await requireFinanceIssuerSnapshotAt(
+      client,
+      facture.legal_entity_code,
+      issueDate
+    );
     const legal = await allocateLegalNumber({
       client,
       documentType: "FACTURE",
@@ -1123,6 +1138,9 @@ export async function repoIssueFacture(params: {
       label: due.label,
       amount: due.amount,
     }));
+    // Les mentions legales sont figees **a l'emission**, pas a la creation du brouillon.
+    // Un brouillon peut vivre des semaines ; si le taux de penalite ou le capital change
+    // entre-temps, la facture doit porter ce qui est en vigueur le jour ou elle est emise.
     const snapshot: FinanceDocumentSnapshot = {
       document_type: "FACTURE",
       uuid: facture.uuid,
@@ -1132,7 +1150,7 @@ export async function repoIssueFacture(params: {
       due_dates: dueDates,
       currency: facture.currency,
       client_snapshot: facture.client_snapshot,
-      issuer_snapshot: facture.issuer_snapshot,
+      issuer_snapshot: issuerAtIssue,
       lines: preview.lines,
       totals: preview.totals,
       internal_comment: facture.commentaires,
@@ -1165,6 +1183,7 @@ export async function repoIssueFacture(params: {
             issued_by = $6,
             immutable_snapshot = $7::jsonb,
             document_checksum_sha256 = $8,
+            issuer_snapshot = $9::jsonb,
             row_version = row_version + 1,
             updated_at = now()
         WHERE id = $1
@@ -1179,6 +1198,10 @@ export async function repoIssueFacture(params: {
         params.actor.userId,
         JSON.stringify(snapshot),
         artifact.checksumSha256,
+        // La ligne conserve les mentions reellement imprimees, et non celles du brouillon :
+        // sans cela, `facture.issuer_snapshot` et le PDF emis diraient deux choses
+        // differentes sur la meme piece.
+        JSON.stringify(issuerAtIssue),
       ]
     );
     await client.query(

--- a/src/module/facturation/repository/workflow.repository.shared.test.ts
+++ b/src/module/facturation/repository/workflow.repository.shared.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { HttpError } from "../../../utils/httpError";
+import {
+  type DbQueryer,
+  requireFinanceIssuerSnapshotAt,
+} from "./workflow.repository.shared";
+
+const COMPLETE_ISSUER = {
+  entity_code: "b7c1e5a2-3f4d-4e8b-9a06-380569012000",
+  company_name: "CROIX ROUSSE PRECISION",
+  legal_mentions_version: 1,
+  legal_form: "SARL",
+  share_capital: "21000.00",
+  share_capital_currency: "EUR",
+  rcs_city: "Bourg-en-Bresse",
+  rcs_number: "380 569 012",
+  siret: "380 569 012 00020",
+  vat_number: "FR73 380 569 012",
+  late_penalty_rate: "12.500",
+  late_penalty_basis: "ANNUEL",
+  recovery_indemnity: "40.00",
+};
+
+function queryerReturning(snapshot: Record<string, unknown> | null): DbQueryer {
+  return {
+    query: vi.fn().mockResolvedValue({ rows: snapshot ? [{ snapshot }] : [] }),
+  } as unknown as DbQueryer;
+}
+
+describe("requireFinanceIssuerSnapshotAt", () => {
+  it("returns the complete legal snapshot used by the immutable document", async () => {
+    await expect(
+      requireFinanceIssuerSnapshotAt(
+        queryerReturning(COMPLETE_ISSUER),
+        COMPLETE_ISSUER.entity_code,
+        "2026-07-29"
+      )
+    ).resolves.toEqual(COMPLETE_ISSUER);
+  });
+
+  it("fails explicitly when the legal entity does not exist", async () => {
+    const error = await requireFinanceIssuerSnapshotAt(
+      queryerReturning(null),
+      COMPLETE_ISSUER.entity_code,
+      "2026-07-29"
+    ).catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error).toMatchObject({
+      status: 503,
+      code: "FINANCE_ISSUER_NOT_CONFIGURED",
+    });
+  });
+
+  it("fails before issuance when a mandatory legal field is missing", async () => {
+    const { recovery_indemnity: _missing, ...incomplete } = COMPLETE_ISSUER;
+    const error = await requireFinanceIssuerSnapshotAt(
+      queryerReturning(incomplete),
+      COMPLETE_ISSUER.entity_code,
+      "2026-07-29"
+    ).catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error).toMatchObject({
+      status: 503,
+      code: "FINANCE_LEGAL_MENTIONS_NOT_CONFIGURED",
+      details: { missing: ["recovery_indemnity"] },
+    });
+  });
+});

--- a/src/module/facturation/repository/workflow.repository.shared.ts
+++ b/src/module/facturation/repository/workflow.repository.shared.ts
@@ -277,6 +277,93 @@ export async function allocateLegalNumber(params: {
   return { legalNumber, periodKey, sequenceValue };
 }
 
+/**
+ * Instantane de l'entite emettrice, mentions legales **en vigueur a la date donnee**.
+ *
+ * Partage par la facture et l'avoir : les deux sont des pieces fiscales et doivent porter
+ * exactement les memes mentions obligatoires, resolues selon la meme regle.
+ *
+ * La date est celle de l'**emission** du document, jamais « aujourd'hui » : c'est elle qui
+ * determine quelle version de `finance_legal_mentions` fait foi. Le resultat est destine a
+ * etre fige tel quel dans `issuer_snapshot`, qui devient alors autoportant — un document
+ * retrouve dans dix ans se relit sans la base.
+ *
+ * Renvoie `null` quand l'entite est inconnue ; l'appelant decide si c'est une erreur.
+ */
+export async function issuerSnapshotAt(
+  queryer: DbQueryer,
+  entityCode: string,
+  at: string
+): Promise<Record<string, unknown> | null> {
+  const result = await queryer.query<{ snapshot: Record<string, unknown> | null }>(
+    `
+      SELECT COALESCE(public.fn_finance_issuer_snapshot(f.biller_id, $2::date), '{}'::jsonb)
+             || jsonb_build_object('entity_code', $1::text) AS snapshot
+      FROM public.factureur f
+      WHERE f.biller_id::text = $1
+      LIMIT 1
+    `,
+    [entityCode, at]
+  );
+  const snapshot = result.rows[0]?.snapshot;
+  return snapshot && typeof snapshot === "object" ? (snapshot as Record<string, unknown>) : null;
+}
+
+const REQUIRED_FINANCE_LEGAL_MENTION_KEYS = [
+  "company_name",
+  "legal_mentions_version",
+  "legal_form",
+  "share_capital",
+  "share_capital_currency",
+  "rcs_city",
+  "rcs_number",
+  "siret",
+  "vat_number",
+  "late_penalty_rate",
+  "late_penalty_basis",
+  "recovery_indemnity",
+] as const;
+
+function hasSnapshotValue(snapshot: Record<string, unknown>, key: string): boolean {
+  const value = snapshot[key];
+  return value !== null && value !== undefined && (typeof value !== "string" || value.trim().length > 0);
+}
+
+/**
+ * Resolve the issuer snapshot required to issue a fiscal document.
+ *
+ * Drafts may remain readable while the legal reference data is being deployed. Issuance is
+ * different: a missing legal version or mandatory field must fail before a legal number is
+ * allocated, otherwise the server would knowingly create a non-compliant immutable document.
+ */
+export async function requireFinanceIssuerSnapshotAt(
+  queryer: DbQueryer,
+  entityCode: string,
+  at: string
+): Promise<Record<string, unknown>> {
+  const snapshot = await issuerSnapshotAt(queryer, entityCode, at);
+  if (!snapshot) {
+    throw new HttpError(
+      503,
+      "FINANCE_ISSUER_NOT_CONFIGURED",
+      "L'entité émettrice de la politique Finance est introuvable."
+    );
+  }
+
+  const missing = REQUIRED_FINANCE_LEGAL_MENTION_KEYS.filter(
+    (key) => !hasSnapshotValue(snapshot, key)
+  );
+  if (missing.length) {
+    throw new HttpError(
+      503,
+      "FINANCE_LEGAL_MENTIONS_NOT_CONFIGURED",
+      "Les mentions légales obligatoires de l'entité émettrice ne sont pas configurées pour la date d'émission.",
+      { missing }
+    );
+  }
+  return snapshot;
+}
+
 export function newCorrelationId(): string {
   return crypto.randomUUID();
 }

--- a/src/module/facturation/services/finance-document-render.test.ts
+++ b/src/module/facturation/services/finance-document-render.test.ts
@@ -16,6 +16,8 @@ import { inflateSync } from "node:zlib";
 
 import { describe, expect, it } from "vitest";
 
+import { issuerIdentityLine, issuerLegalMentions } from "../../../shared/pdf/legal-mentions";
+
 import {
   money,
   percent,
@@ -408,4 +410,266 @@ describe("facture et avoir partagent la meme grammaire", () => {
       expect(text).toContain("MONTANT TVA");
     }
   }, 90_000);
+});
+
+/**
+ * Mentions legales obligatoires de l'emetteur.
+ *
+ * Le referentiel ne les portait pas : `factureur` n'a aucune colonne legale et etait vide
+ * sur les deux bases. Elles viennent desormais de `finance_legal_mentions`, versionnee, et
+ * sont figees dans l'instantane a la date d'emission.
+ *
+ * Elles sont verifiees **dans le texte reellement dessine**, pas sur l'objet d'entree : une
+ * mention presente dans l'instantane mais absente du PDF est juridiquement absente.
+ */
+
+/** Instantane complet, tel que le renvoie `fn_finance_issuer_snapshot`. */
+const ISSUER_MENTIONS = {
+  company_name: "CROIX ROUSSE PRECISION",
+  address_line_1: "530 Rue de la Dombes",
+  postal_code: "01700",
+  city: "MIRIBEL LES ECHETS",
+  country: "France",
+  phone: "04 72 00 26 25",
+  legal_form: "SARL",
+  share_capital: "21000.00",
+  share_capital_currency: "EUR",
+  rcs_city: "Bourg-en-Bresse",
+  rcs_number: "380 569 012",
+  siren: "380 569 012",
+  siret: "380 569 012 00020",
+  vat_number: "FR73 380 569 012",
+  late_penalty_rate: "12.500",
+  late_penalty_basis: "ANNUEL",
+  recovery_indemnity: "40.00",
+  early_discount_rate: "1.500",
+  early_discount_basis: "MENSUEL",
+  vat_on_receipts: true,
+  retention_of_title:
+    "Nous nous réservons la propriété des marchandises jusqu'au paiement intégral du prix par l'acheteur.",
+  iban: "FR76 3000 3024 9100 0200 0775 958",
+  bic: "SOGEFRPP",
+  bank_name: "SG LYON CROIX-ROUSSE",
+  legal_mentions_version: 1,
+  legal_mentions_effective_from: "2026-01-01",
+};
+
+const FACTURE_MENTIONS: FinanceDocumentInput = { ...FACTURE, issuer: ISSUER_MENTIONS };
+
+describe("identite legale de l'emetteur", () => {
+  it("compose la ligne portee par le pied de page", () => {
+    // Art. R123-237 C. com. : forme juridique, capital, RCS **et ville**, SIRET, TVA.
+    expect(issuerIdentityLine(ISSUER_MENTIONS)).toBe(
+      "SARL au capital de 21 000,00 € · RCS Bourg-en-Bresse 380 569 012 · " +
+        "SIRET 380 569 012 00020 · TVA FR73 380 569 012"
+    );
+  });
+
+  it("n'invente pas la ville du RCS quand elle manque", () => {
+    // La facture papier imprimait « RCS : 380569012 », sans ville : la mention etait
+    // incomplete. On ne la complete pas d'office — on affiche ce qu'on a.
+    const line = issuerIdentityLine({ ...ISSUER_MENTIONS, rcs_city: undefined });
+    expect(line).toContain("RCS 380 569 012");
+    expect(line).not.toContain("Bourg-en-Bresse");
+  });
+
+  it("prefere le SIRET au SIREN, qu'il contient deja", () => {
+    const line = issuerIdentityLine(ISSUER_MENTIONS) as string;
+    expect(line).toContain("SIRET 380 569 012 00020");
+    expect(line).not.toContain("SIREN");
+  });
+
+  it("ne rend aucune ligne quand rien n'est parametre", () => {
+    expect(issuerIdentityLine({})).toBeNull();
+    expect(issuerIdentityLine({ company_name: "CROIX ROUSSE PRECISION" })).toBeNull();
+  });
+
+  it("degrade proprement sur une identite partielle", () => {
+    // Une forme juridique sans capital reste une mention valable ; on ne tait pas tout
+    // parce qu'une piece manque.
+    expect(issuerIdentityLine({ legal_form: "SARL" })).toBe("SARL");
+    expect(issuerIdentityLine({ share_capital: "21000.00" })).toBe("Capital social 21 000,00 €");
+  });
+
+  it("n'est plus repetee dans la carte « Émetteur »", () => {
+    // L'identite legale vit dans le pied, sur toutes les pages. La reprendre dans la carte
+    // la ferait figurer deux fois sur la meme page.
+    const lines = partyLines(ISSUER_MENTIONS, { identifiers: false });
+    expect(lines).toContain("CROIX ROUSSE PRECISION");
+    expect(lines).toContain("Tél. 04 72 00 26 25");
+    expect(lines.join("\n")).not.toContain("SIRET");
+    expect(lines.join("\n")).not.toContain("TVA");
+  });
+});
+
+describe("mentions de reglement", () => {
+  it("porte les cinq mentions obligatoires", () => {
+    const mentions = issuerLegalMentions(ISSUER_MENTIONS).join("\n");
+    expect(mentions).toContain("Pénalités de retard : 12,5 % l'an");
+    expect(mentions).toContain("art. L441-10 du code de commerce");
+    expect(mentions).toContain("Indemnité forfaitaire pour frais de recouvrement : 40,00 € par facture");
+    expect(mentions).toContain("art. D441-5 du code de commerce");
+    expect(mentions).toContain("Escompte pour paiement anticipé : 1,5 % par mois");
+    expect(mentions).toContain("TVA acquittée sur les encaissements");
+    expect(mentions).toContain("Réserve de propriété : Nous nous réservons la propriété");
+  });
+
+  it("dit explicitement qu'aucun escompte n'est accordé", () => {
+    // L'escompte est une mention obligatoire **meme en son absence** (art. L441-9). Un taux
+    // vide ne doit pas se traduire par un silence.
+    const mentions = issuerLegalMentions({
+      ...ISSUER_MENTIONS,
+      early_discount_rate: undefined,
+      early_discount_basis: undefined,
+    }).join("\n");
+    expect(mentions).toContain("Escompte pour paiement anticipé : aucun escompte n'est accordé");
+  });
+
+  it("ne parle pas d'escompte quand aucune version de mentions n'est résolue", () => {
+    // Hors periode de validite, on ne sait rien : ecrire « aucun escompte » serait une
+    // affirmation inventee, pas une mention.
+    const mentions = issuerLegalMentions({ company_name: "CROIX ROUSSE PRECISION" });
+    expect(mentions).toEqual([]);
+  });
+
+  it("porte la franchise en base quand elle s'applique", () => {
+    const mentions = issuerLegalMentions({
+      ...ISSUER_MENTIONS,
+      vat_on_receipts: undefined,
+      vat_exempt_293b: true,
+    }).join("\n");
+    expect(mentions).toContain("TVA non applicable, article 293 B du code général des impôts");
+    expect(mentions).not.toContain("TVA acquittée sur les encaissements");
+  });
+
+  it("supprime les zéros décimaux inutiles d'un taux", () => {
+    // `numeric(6,3)` stocke `12.500` : la precision de stockage n'a pas a transparaitre.
+    const mentions = issuerLegalMentions({ ...ISSUER_MENTIONS, late_penalty_rate: "12.000" }).join("\n");
+    expect(mentions).toContain("Pénalités de retard : 12 % l'an");
+  });
+
+  it("reprend les mentions libres additionnelles", () => {
+    const mentions = issuerLegalMentions({
+      ...ISSUER_MENTIONS,
+      extra_mentions: ["Membre d'une association agréée, le règlement par chèque est accepté."],
+    });
+    expect(mentions.at(-1)).toBe("Membre d'une association agréée, le règlement par chèque est accepté.");
+  });
+});
+
+/** Texte dessine, espaces normalises : un retour a la ligne coupe les chaines longues. */
+function flat(bytes: Buffer): string {
+  return drawnText(bytes).replace(/\s+/g, " ");
+}
+
+describe("mentions legales — rendu reel", () => {
+  it("scenario 7 (facture avec mentions) : toutes portees", async () => {
+    const bytes = await renderFinanceDocument(FACTURE_MENTIONS);
+    keep("66-facture-mentions-legales", bytes);
+
+    const text = flat(bytes);
+    expect(text).toContain("SARL au capital de 21 000,00 €");
+    expect(text).toContain("RCS Bourg-en-Bresse 380 569 012");
+    expect(text).toContain("SIRET 380 569 012 00020");
+    expect(text).toContain("TVA FR73 380 569 012");
+    expect(text).toContain("Pénalités de retard : 12,5 % l'an");
+    expect(text).toContain("Indemnité forfaitaire pour frais de recouvrement : 40,00 € par facture");
+    expect(text).toContain("Escompte pour paiement anticipé : 1,5 % par mois");
+    expect(text).toContain("TVA acquittée sur les encaissements");
+    expect(text).toContain("Nous nous réservons la propriété des marchandises");
+  }, 60_000);
+
+  it("scenario 8 (facture courte) : les mentions tiennent sans ouvrir de page", async () => {
+    // Les mentions vivent dans la bande de pied, pas dans le flux : sur un document qui a
+    // de la place, elles ne coutent aucune page. Sur un document deja au bord — comme le
+    // gabarit `FACTURE`, a moins de 10 pt de la limite avant meme ce changement — la
+    // seconde page vient du contenu, pas des mentions.
+    const bytes = await renderFinanceDocument({
+      ...FACTURE_MENTIONS,
+      lines: [ligne()],
+      dueDates: [{ dueDate: "2026-08-21", label: "30 jours net", amount: "8755.20" }],
+      customerText: null,
+    });
+    keep("69-facture-mentions-courte", bytes);
+
+    expect(drawnPages(bytes)).toHaveLength(1);
+    const text = flat(bytes);
+    expect(text).toContain("SARL au capital de 21 000,00 €");
+    expect(text).toContain("Pénalités de retard : 12,5 % l'an");
+    expect(text).toContain("Nous nous réservons la propriété des marchandises");
+  }, 60_000);
+
+  it("porte les coordonnées de règlement, qui permettent au client de payer", async () => {
+    const text = flat(await renderFinanceDocument(FACTURE_MENTIONS));
+    expect(text).toContain("RIB : FR76 3000 3024 9100 0200 0775 958");
+    expect(text).toContain("BIC : SOGEFRPP");
+  }, 60_000);
+
+  it("n'affiche pas de coordonnées bancaires sur un avoir", async () => {
+    // Un avoir ne se regle pas : y afficher un RIB serait une invitation a payer.
+    const text = drawnText(await renderFinanceDocument({ ...AVOIR, issuer: ISSUER_MENTIONS }));
+    expect(text).not.toContain("FR76 3000 3024 9100 0200 0775 958");
+    // Les mentions obligatoires, elles, restent : un avoir est une piece fiscale.
+    expect(text).toContain("SIRET 380 569 012 00020");
+    expect(text).toContain("Pénalités de retard : 12,5 % l'an");
+  }, 60_000);
+
+  it("répète identité et mentions sur chacune des pages", async () => {
+    // Une page detachee doit rester rattachable a son emetteur et rester opposable.
+    const bytes = await renderFinanceDocument({
+      ...FACTURE_MENTIONS,
+      lines: Array.from({ length: 40 }, (_, index) =>
+        ligne({ designation: `Composant usiné référence ${index + 1} — plan 46${index}-A indice B` })
+      ),
+    });
+    keep("67-facture-mentions-volume", bytes);
+
+    const pages = drawnPages(bytes);
+    expect(pages.length).toBeGreaterThan(1);
+    for (const page of pages) {
+      expect(page).toContain("SIRET 380 569 012 00020");
+      expect(page).toContain("Pénalités de retard : 12,5 % l'an");
+      expect(page).toContain("Indemnité forfaitaire");
+    }
+  }, 90_000);
+
+  it("le texte des mentions reste extractible du PDF", async () => {
+    // Les mentions sont rendues fer a gauche et non justifiees : pdfkit justifie en
+    // positionnant les mots, ce qui fait ressortir « Penalitesderetard:12,5% » a
+    // l'extraction. Une mention legale doit rester lisible par une machine.
+    const text = drawnText(await renderFinanceDocument(FACTURE_MENTIONS));
+    expect(text).toContain("Pénalités de retard : 12,5 % l'an, exigibles de plein droit");
+    expect(text).not.toMatch(/Pénalitésderetard/);
+  }, 60_000);
+
+  it("l'instantané fige fait foi, pas le paramétrage courant", async () => {
+    // Une facture emise porte les mentions **en vigueur a son emission**. Rendue depuis un
+    // instantane ancien, elle doit afficher l'ancien taux — sinon le versionnement ne sert
+    // a rien et l'historique se retrouve reecrit.
+    const bytes = await renderFinanceDocument({
+      ...FACTURE_MENTIONS,
+      issuer: { ...ISSUER_MENTIONS, late_penalty_rate: "9.750", legal_mentions_version: 0 },
+    });
+    const text = drawnText(bytes);
+    expect(text).toContain("Pénalités de retard : 9,75 % l'an");
+    expect(text).not.toContain("12,5 %");
+  }, 60_000);
+
+  it("n'invente aucune mention quand le référentiel n'en porte pas", async () => {
+    // Etat d'avant le patch : ni identite legale, ni mentions. Le document doit rester
+    // lisible et muet, jamais approximatif.
+    const bytes = await renderFinanceDocument({
+      ...FACTURE,
+      issuer: { company_name: "CROIX ROUSSE PRECISION" },
+    });
+    keep("68-facture-sans-mentions", bytes);
+
+    const text = drawnText(bytes);
+    expect(text).toContain("CROIX ROUSSE PRECISION");
+    expect(text).not.toContain("Pénalités de retard");
+    expect(text).not.toContain("Indemnité forfaitaire");
+    expect(text).not.toContain("Escompte");
+    expect(text).not.toContain("au capital de");
+    expect(drawnPages(bytes)).toHaveLength(1);
+  }, 60_000);
 });

--- a/src/module/facturation/services/finance-document-render.ts
+++ b/src/module/facturation/services/finance-document-render.ts
@@ -5,6 +5,12 @@ import {
   type CerpDocumentContext,
   type CerpLineRow,
 } from "../../../shared/pdf/cerp-document";
+import { formatDateFR, money, percent } from "../../../shared/pdf/format-fr";
+import { issuerIdentityLine, issuerLegalMentions, issuerPaymentDetails } from "../../../shared/pdf/legal-mentions";
+
+// Reexportes : la mise en forme francaise est desormais partagee avec le bon de livraison
+// et l'accuse de reception, qui portent les memes mentions legales.
+export { formatDateFR, money, percent };
 
 /**
  * Rendu unique des documents financiers CERP : facture et avoir.
@@ -88,43 +94,6 @@ function pick(source: FinanceParty, ...keys: string[]): string | null {
   return null;
 }
 
-export function formatDateFR(iso: string | null | undefined): string {
-  if (!iso) return "-";
-  const raw = String(iso);
-  const m = raw.match(/^(\d{4})-(\d{2})-(\d{2})/);
-  if (m) return `${m[3]}/${m[2]}/${m[1]}`;
-  return raw;
-}
-
-/** Pourcentage a la francaise : `20,00 %`. Meme regle que `money` — aucun chiffre change. */
-export function percent(value: string): string {
-  const raw = String(value ?? "").trim();
-  if (!/^-?\d+(?:[.,]\d+)?$/.test(raw)) return `${raw} %`.trim();
-  return `${raw.replace(".", ",")} %`;
-}
-
-/**
- * Montant au format francais : `10 465,20 €`.
- *
- * Le referentiel fournit des chaines a point decimal (`10465.20`) et le document les sortait
- * telles quelles, avec le code ISO — sur une facture francaise, et alors que les documents
- * rendus dans le navigateur affichent deja `10 465,20 €` pour la meme entreprise.
- *
- * **Aucun chiffre n'est modifie** : seuls les separateurs changent. Une chaine qui n'est pas un
- * nombre est rendue telle quelle plutot que d'etre perdue.
- */
-export function money(amount: string, currency: string): string {
-  const raw = String(amount ?? "").trim();
-  const symbol = currency === "EUR" ? "€" : currency;
-
-  const match = raw.match(/^(-?)(\d+)(?:[.,](\d+))?$/);
-  if (!match) return `${raw} ${symbol}`.trim();
-
-  const [, sign, whole, decimals] = match;
-  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, " ");
-  return `${sign}${grouped}${decimals ? `,${decimals}` : ""} ${symbol}`;
-}
-
 /**
  * Identite d'une partie, en lignes.
  *
@@ -132,8 +101,20 @@ export function money(amount: string, currency: string): string {
  * **obligatoires** : denomination, adresse, SIRET, numero de TVA intracommunautaire. On lit
  * l'instantane de facon defensive — sa forme appartient au referentiel — et on n'affiche que
  * ce qui existe reellement. Une mention absente n'est jamais remplacee par un substitut.
+ *
+ * ## Emetteur et client ne portent pas leur identite au meme endroit
+ *
+ * L'acheteur n'a qu'un seul emplacement sur le document : sa carte. Ses identifiants y
+ * figurent donc.
+ *
+ * Le vendeur, lui, porte son identite legale dans le **pied de page**, sur toutes les pages
+ * — forme juridique, capital, RCS et ville, SIRET, TVA. C'est la disposition de la facture
+ * papier de l'entreprise, et c'est la seule qui garantisse la mention sur une page detachee.
+ * La repeter dans la carte « Emetteur » la ferait apparaitre deux fois sur la meme page.
+ * D'ou `identifiers: false` pour l'emetteur, pose par `partyCards()`.
  */
-export function partyLines(party: FinanceParty): string[] {
+export function partyLines(party: FinanceParty, options: { identifiers?: boolean } = {}): string[] {
+  const withIdentifiers = options.identifiers ?? true;
   const nested =
     party.billing_address && typeof party.billing_address === "object"
       ? (party.billing_address as FinanceParty)
@@ -147,23 +128,31 @@ export function partyLines(party: FinanceParty): string[] {
     .filter(Boolean)
     .join(" ");
 
+  const phone = pick(party, "phone", "telephone");
   const identity = [
     pick(party, "company_name", "name", "raison_sociale", "biller_name"),
     pick(party, "address_line_1", "address", "adresse") ?? (streetFromNested || null),
     pick(party, "address_line_2", "adresse_complement") ?? pick(nested, "address_complement"),
     cityLine || null,
     pick(party, "country", "pays") ?? pick(nested, "country"),
+    phone ? `Tél. ${phone}` : null,
   ];
 
-  const legal = [
-    pick(party, "siret") ? `SIRET ${pick(party, "siret")}` : null,
-    pick(party, "siren") ? `SIREN ${pick(party, "siren")}` : null,
-    pick(party, "rcs") ? `RCS ${pick(party, "rcs")}` : null,
-    pick(party, "vat_number", "numero_tva", "tva_intracommunautaire")
-      ? `TVA ${pick(party, "vat_number", "numero_tva", "tva_intracommunautaire")}`
-      : null,
-    pick(party, "capital_social") ? `Capital ${pick(party, "capital_social")}` : null,
-  ];
+  const legal = withIdentifiers
+    ? [
+        pick(party, "siret") ? `SIRET ${pick(party, "siret")}` : null,
+        pick(party, "siren") ? `SIREN ${pick(party, "siren")}` : null,
+        pick(party, "rcs_number", "rcs")
+          ? pick(party, "rcs_city")
+            ? `RCS ${pick(party, "rcs_city")} ${pick(party, "rcs_number", "rcs")}`
+            : `RCS ${pick(party, "rcs_number", "rcs")}`
+          : null,
+        pick(party, "vat_number", "numero_tva", "tva_intracommunautaire")
+          ? `TVA ${pick(party, "vat_number", "numero_tva", "tva_intracommunautaire")}`
+          : null,
+        pick(party, "capital_social") ? `Capital ${pick(party, "capital_social")}` : null,
+      ]
+    : [];
 
   return [...identity, ...legal].filter((line): line is string => Boolean(line));
 }
@@ -290,7 +279,13 @@ function summaryBlock(
 
 function partyCards(input: FinanceDocumentInput): CerpAddressCard[] {
   return [
-    { caption: "Émetteur", lines: partyLines(input.issuer), accent: true, emptyLabel: "Non renseigné" },
+    {
+      caption: "Émetteur",
+      // Les identifiants legaux de l'emetteur sont dans le pied, sur toutes les pages.
+      lines: partyLines(input.issuer, { identifiers: false }),
+      accent: true,
+      emptyLabel: "Non renseigné",
+    },
     {
       caption: input.kind === "AVOIR" ? "Client crédité" : "Client facturé",
       lines: partyLines(input.client),
@@ -356,6 +351,23 @@ export async function renderFinanceDocument(input: FinanceDocumentInput): Promis
       // Tracabilite de l'exemplaire, portee par toutes les pages : c'est ce qui permet de
       // rattacher un PDF retrouve chez le client a l'instantane immuable conserve.
       footerNote: traceabilityNote(input),
+      // Identite legale de l'emetteur : mention obligatoire, portee par toutes les pages.
+      // Elle est lue dans l'instantane fige, donc elle reflete ce qui etait en vigueur a
+      // l'emission — pas ce qui est parametre aujourd'hui.
+      legalIdentity: issuerIdentityLine(input.issuer),
+      // Penalites de retard, indemnite forfaitaire de recouvrement, escompte, regime de TVA
+      // et reserve de propriete. Dans la bande de pied, comme sur la facture papier : elles
+      // ne doivent jamais couter une page au contenu.
+      //
+      // Les coordonnees bancaires ferment la bande. Ce n'est pas une mention obligatoire,
+      // mais c'est ce qui permet au client de payer, et un avoir ne se regle pas — y
+      // afficher un RIB serait une invitation a payer. En section titree dans le flux,
+      // elles coutaient 54 pt et faisaient basculer une facture de deux lignes sur une
+      // seconde page ; ici, une ligne suffit.
+      legalMentions: [
+        ...issuerLegalMentions(input.issuer),
+        ...(isAvoir ? [] : [issuerPaymentDetails(input.issuer)].filter((line): line is string => Boolean(line))),
+      ],
       creationDate: new Date(`${input.issueDate.slice(0, 10)}T12:00:00.000Z`),
     },
     (ctx) => {
@@ -449,6 +461,7 @@ export async function renderFinanceDocument(input: FinanceDocumentInput): Promis
       if (clean(input.customerText)) {
         ctx.notesSection("Informations client", input.customerText as string);
       }
+
     }
   );
 }

--- a/src/module/facturation/services/pdf.service.ts
+++ b/src/module/facturation/services/pdf.service.ts
@@ -7,6 +7,8 @@ import { HttpError } from "../../../utils/httpError";
 import { repoGetAvoir } from "../repository/avoirs.repository";
 import { repoGetFacture } from "../repository/factures.repository";
 
+import { readIssuerParty } from "../../../shared/documents/issuer-identity.repository";
+
 import { renderFinanceDocument, type FinanceDocumentLine, type FinanceParty } from "./finance-document-render";
 
 /**
@@ -34,49 +36,19 @@ async function ensureDocsDir(): Promise<string> {
 }
 
 /**
- * Identite de l'emetteur, lue en base.
+ * Identite de l'emetteur, mentions legales comprises.
  *
- * `to_jsonb` remonte la ligne entiere et on ne retient qu'une **liste blanche** de champs
- * d'identite fiscale : la table `factureur` est historique et sa forme exacte n'appartient pas
- * a ce module. Un champ absent reste absent — aucune mention n'est inventee.
+ * L'ancienne version lisait `to_jsonb(factureur)` et filtrait sur une liste blanche
+ * comprenant `siret`, `siren`, `rcs`, `vat_number` et `capital_social`. **Aucune de ces
+ * colonnes n'existe** dans `factureur` : le filtre ne retenait donc jamais la moindre
+ * mention legale, et la table etait de surcroit vide sur les deux bases. Le bloc
+ * « Emetteur » sortait vide et aucune mention obligatoire n'etait imprimee.
+ *
+ * La lecture passe desormais par `readIssuerParty()`, qui joint la table versionnee des
+ * mentions et resout celles **en vigueur a la date d'emission** du document.
  */
-const ISSUER_LEGAL_FIELDS = [
-  "company_name",
-  "biller_name",
-  "name",
-  "raison_sociale",
-  "address_line_1",
-  "address_line_2",
-  "address",
-  "adresse",
-  "adresse_complement",
-  "postal_code",
-  "code_postal",
-  "city",
-  "ville",
-  "country",
-  "pays",
-  "siret",
-  "siren",
-  "rcs",
-  "vat_number",
-  "numero_tva",
-  "tva_intracommunautaire",
-  "capital_social",
-] as const;
-
-async function getIssuerParty(): Promise<FinanceParty> {
-  const res = await pool.query<{ row: Record<string, unknown> }>(
-    `SELECT to_jsonb(f) AS row FROM factureur f ORDER BY f.biller_id ASC LIMIT 1`
-  );
-  const row = res.rows[0]?.row;
-  if (!row || typeof row !== "object") return {};
-
-  const party: FinanceParty = {};
-  for (const key of ISSUER_LEGAL_FIELDS) {
-    if (row[key] !== undefined && row[key] !== null) party[key] = row[key];
-  }
-  return party;
+async function getIssuerParty(issueDate: string | null): Promise<FinanceParty> {
+  return readIssuerParty({ at: issueDate }) as Promise<FinanceParty>;
 }
 
 /**
@@ -142,7 +114,7 @@ export async function svcGenerateFacturePdf(factureId: number): Promise<{ docume
     draft: true,
     issueDate: f.date_emission,
     currency: "EUR",
-    issuer: await getIssuerParty(),
+    issuer: await getIssuerParty(f.date_emission),
     client: clientParty(f.client),
     lines: draftLines(detail.lignes),
     totals: {
@@ -207,7 +179,7 @@ export async function svcGenerateAvoirPdf(avoirId: number): Promise<{ document_i
     draft: true,
     issueDate: a.date_emission,
     currency: "EUR",
-    issuer: await getIssuerParty(),
+    issuer: await getIssuerParty(a.date_emission),
     client: clientParty(a.client),
     lines: draftLines(detail.lignes),
     totals: {

--- a/src/module/livraisons/services/bon-livraison-document.ts
+++ b/src/module/livraisons/services/bon-livraison-document.ts
@@ -1,4 +1,5 @@
 import { renderCerpDocument, type CerpAddressCard, type CerpLineRow } from "../../../shared/pdf/cerp-document"
+import { issuerIdentityLine, issuerLegalMentions, type LegalParty } from "../../../shared/pdf/legal-mentions"
 
 import type { BonLivraisonHeader, BonLivraisonLigne, BonLivraisonLigneAllocation } from "../types/livraisons.types"
 
@@ -20,6 +21,14 @@ export type BonLivraisonDocumentInput = {
   version: number
   /** Raison sociale de l'emetteur, lue en base. */
   company: string | null
+  /**
+   * Instantane de l'emetteur : identite legale et mentions obligatoires.
+   *
+   * Un bon de livraison est un document commercial : il doit porter l'identite legale de
+   * celui qui l'emet (art. R123-237 C. com.), au meme titre qu'une facture. Il ne portait
+   * jusqu'ici qu'une raison sociale.
+   */
+  issuer?: LegalParty
 }
 
 export function formatDateFR(iso: string | null | undefined): string {
@@ -83,6 +92,7 @@ export function addressLines(label: string | null | undefined): string[] | null 
 
 export async function renderBonLivraisonDocument(input: BonLivraisonDocumentInput): Promise<Buffer> {
   const { header: bl, company, version } = input
+  const issuer = input.issuer ?? {}
   const clientName = clean(bl.client.company_name) ?? "Client"
 
   // Le referentiel expose l'identifiant technique du client ; il n'a rien a faire sur un
@@ -125,6 +135,11 @@ export async function renderBonLivraisonDocument(input: BonLivraisonDocumentInpu
       generatedBy: null,
       title: `Bon de livraison ${bl.numero}`,
       subject: "Bon de livraison CERP",
+      legalIdentity: issuerIdentityLine(issuer),
+      // La reserve de propriete a ici sa portee la plus forte : c'est a la livraison que se
+      // joue le transfert de possession, et la clause n'a d'effet que si l'acheteur en a eu
+      // connaissance au plus tard a ce moment-la.
+      legalMentions: issuerLegalMentions(issuer),
       creationDate: toUtcMidnightFromIso(bl.date_expedition ?? bl.date_creation),
     },
     (ctx) => {

--- a/src/module/livraisons/services/pack-pdf.service.test.ts
+++ b/src/module/livraisons/services/pack-pdf.service.test.ts
@@ -15,9 +15,43 @@ import { inflateSync } from "node:zlib"
 
 import { describe, expect, it, vi } from "vitest"
 
-// Le service lit la raison sociale de l'emetteur en base : la seule dependance a isoler.
+/**
+ * Instantane de l'emetteur, tel que le renvoie `fn_finance_issuer_snapshot`.
+ *
+ * Le service ne lit plus la seule raison sociale : un bon de livraison est un document
+ * commercial et doit porter l'identite legale de son emetteur (art. R123-237 C. com.).
+ * `vi.hoisted` est indispensable — `vi.mock` est remonte au-dessus des declarations.
+ */
+const ISSUER = vi.hoisted(() => ({
+  company_name: "CROIX ROUSSE PRECISION",
+  address_line_1: "530 Rue de la Dombes",
+  postal_code: "01700",
+  city: "MIRIBEL LES ECHETS",
+  country: "France",
+  phone: "04 72 00 26 25",
+  legal_form: "SARL",
+  share_capital: "21000.00",
+  share_capital_currency: "EUR",
+  rcs_city: "Bourg-en-Bresse",
+  rcs_number: "380 569 012",
+  siren: "380 569 012",
+  siret: "380 569 012 00020",
+  vat_number: "FR73 380 569 012",
+  late_penalty_rate: "12.500",
+  late_penalty_basis: "ANNUEL",
+  recovery_indemnity: "40.00",
+  early_discount_rate: "1.500",
+  early_discount_basis: "MENSUEL",
+  vat_on_receipts: true,
+  retention_of_title:
+    "Nous nous réservons la propriété des marchandises jusqu'au paiement intégral du prix par l'acheteur.",
+  legal_mentions_version: 1,
+  legal_mentions_effective_from: "2026-01-01",
+}))
+
+// Le service lit l'instantane de l'emetteur en base : la seule dependance a isoler.
 vi.mock("../../../config/database", () => ({
-  default: { query: vi.fn().mockResolvedValue({ rows: [{ biller_name: "CROIX ROUSSE PRECISION" }] }) },
+  default: { query: vi.fn().mockResolvedValue({ rows: [{ party: ISSUER }] }) },
 }))
 
 import { renderBonLivraisonDocument } from "./bon-livraison-document"
@@ -332,9 +366,65 @@ describe("bon de livraison PDF — rendu reel", () => {
       lignes: p.lignes,
       version: 1,
       company: "CROIX ROUSSE PRECISION",
+      issuer: ISSUER,
     })
     expect(viaSimple.equals(viaPack)).toBe(true)
   }, 60_000)
+
+  it("porte l'identite legale et les mentions obligatoires de l'emetteur", async () => {
+    // Un bon de livraison est un document commercial : il doit porter l'identite legale de
+    // son emetteur au meme titre qu'une facture. Il ne portait qu'une raison sociale.
+    const bytes = await svcRenderPackBonLivraisonPdf({ preview: preview(), version: 1 })
+    keep("57-bl-mentions-legales", bytes)
+
+    const text = drawnText(bytes)
+    expect(text).toContain("SARL au capital de 21 000,00 €")
+    expect(text).toContain("RCS Bourg-en-Bresse 380 569 012")
+    expect(text).toContain("SIRET 380 569 012 00020")
+    expect(text).toContain("TVA FR73 380 569 012")
+    expect(text).toContain("Pénalités de retard : 12,5 % l'an")
+    expect(text).toContain("40,00 € par facture")
+    expect(text).toContain("Escompte pour paiement anticipé : 1,5 % par mois")
+    // La reserve de propriete a sa portee la plus forte au moment de la livraison.
+    expect(text).toContain("Nous nous réservons la propriété des marchandises")
+  }, 60_000)
+
+  it("les mentions ne coutent aucune page et ne repoussent pas le cadre de réception", async () => {
+    // Les mentions vivent dans la bande de pied, pas dans le flux : placees a la suite du
+    // contenu, elles poussaient ce bon de deux lignes sur une seconde page qui ne portait
+    // qu'elles. Le cadre de reception reste entier sur la premiere page.
+    const bytes = await svcRenderPackBonLivraisonPdf({ preview: preview(), version: 1 })
+    expect(countPages(bytes)).toBe(1)
+
+    const pages = drawnPages(bytes)
+    expect(pages).toHaveLength(1)
+    expect(pages[0]).toContain("RÉCEPTION")
+    expect(pages[0]).toContain("Pénalités de retard")
+  }, 60_000)
+
+  it("répète l'identité légale et les mentions sur chaque page", async () => {
+    // Une page detachee doit rester rattachable a son emetteur et rester opposable : la
+    // mention obligatoire figure donc sur toutes les pages, pas seulement la derniere.
+    const p = preview()
+    const bytes = await svcRenderPackBonLivraisonPdf({
+      preview: {
+        ...p,
+        lignes: Array.from({ length: 40 }, (_, index) => ({
+          ...p.lignes[0]!,
+          ordre: index + 1,
+          designation: `Composant usiné référence ${index + 1} — plan 46${index}-A indice B`,
+        })),
+      },
+      version: 1,
+    })
+
+    const pages = drawnPages(bytes)
+    expect(pages.length).toBeGreaterThan(1)
+    for (const page of pages) {
+      expect(page).toContain("SIRET 380 569 012 00020")
+      expect(page).toContain("Pénalités de retard")
+    }
+  }, 90_000)
 
   it("scenario 4 (aucune ligne) : le document le dit au lieu d'afficher une table vide", async () => {
     const p = preview()

--- a/src/module/livraisons/services/pack-pdf.service.ts
+++ b/src/module/livraisons/services/pack-pdf.service.ts
@@ -1,5 +1,6 @@
-import pool from "../../../config/database"
+import { readIssuerParty } from "../../../shared/documents/issuer-identity.repository"
 import { CONTENT_WIDTH, renderCerpDocument, type CerpLineRow } from "../../../shared/pdf/cerp-document"
+import { issuerIdentityLine, issuerLegalMentions, pickMention } from "../../../shared/pdf/legal-mentions"
 
 import { clean, formatDateFR, lotCodesOf, renderBonLivraisonDocument, toUtcMidnightFromIso } from "./bon-livraison-document"
 
@@ -17,11 +18,8 @@ import type { LivraisonPackPreview } from "../types/pack.types"
  * donnee opposable, et aucun vocabulaire interne.
  */
 
-async function getCompanyHeader(): Promise<string | null> {
-  const res = await pool.query<{ biller_name: string }>(`SELECT biller_name FROM factureur ORDER BY biller_id ASC LIMIT 1`)
-  const name = res.rows[0]?.biller_name
-  return typeof name === "string" && name.trim() ? name.trim() : null
-}
+// L'emetteur n'est plus reduit a sa raison sociale : ces documents partent chez le client,
+// ils doivent porter l'identite legale complete (art. R123-237 C. com.).
 
 /**
  * Vocabulaire interne des mouvements de stock, traduit pour un lecteur externe.
@@ -54,11 +52,14 @@ function labelOf(dictionary: Record<string, string>, code: string | null | undef
 }
 
 export async function svcRenderPackBonLivraisonPdf(args: { preview: LivraisonPackPreview; version: number }): Promise<Buffer> {
+  const bl = args.preview.bon_livraison
+  const issuer = await readIssuerParty({ at: bl.date_expedition ?? bl.date_creation })
   return renderBonLivraisonDocument({
-    header: args.preview.bon_livraison,
+    header: bl,
     lignes: args.preview.lignes,
     version: args.version,
-    company: await getCompanyHeader(),
+    company: pickMention(issuer, "company_name"),
+    issuer,
   })
 }
 
@@ -69,9 +70,10 @@ export async function svcRenderPackCofcPdf(args: {
   commentairePack: string | null
   includeDocuments: boolean
 }): Promise<Buffer> {
-  const company = await getCompanyHeader()
   const p = args.preview
   const bl = p.bon_livraison
+  const issuer = await readIssuerParty({ at: bl.date_expedition ?? bl.date_creation })
+  const company = pickMention(issuer, "company_name")
   const clientName = clean(bl.client.company_name) ?? "Client"
 
   const rows: CerpLineRow[] = p.lignes.map((line) => {
@@ -100,6 +102,8 @@ export async function svcRenderPackCofcPdf(args: {
       generatedBy: clean(args.signataireLabel),
       title: `Certificat de conformité ${bl.numero}`,
       subject: "Certificat de conformité CERP",
+      legalIdentity: issuerIdentityLine(issuer),
+      legalMentions: issuerLegalMentions(issuer),
       creationDate: toUtcMidnightFromIso(bl.date_expedition ?? bl.date_creation),
     },
     (ctx) => {

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -5,6 +5,8 @@ import crypto from "node:crypto"
 import pool from "../../../config/database"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
+import { readIssuerParty } from "../../../shared/documents/issuer-identity.repository"
+import { pickMention } from "../../../shared/pdf/legal-mentions"
 import { repoGetLivraisonDetail, repoGetDocumentName } from "../repository/livraisons.repository"
 
 import { renderBonLivraisonDocument } from "./bon-livraison-document"
@@ -24,13 +26,8 @@ async function ensureDocsDir(): Promise<string> {
   return uploadDir
 }
 
-async function getCompanyHeader(): Promise<string | null> {
-  const res = await pool.query<{ biller_name: string }>(
-    `SELECT biller_name FROM factureur ORDER BY biller_id ASC LIMIT 1`
-  )
-  const name = res.rows[0]?.biller_name
-  return typeof name === "string" && name.trim() ? name.trim() : null
-}
+// L'emetteur n'est plus reduit a sa raison sociale : `readIssuerParty` remonte aussi son
+// identite legale et ses mentions obligatoires, que le bon de livraison doit porter.
 
 export async function svcGetLatestLivraisonPdfDocument(id: string): Promise<{ document_id: string; version: number } | null> {
   const res = await pool.query<{ document_id: string; version: number }>(
@@ -64,11 +61,15 @@ export async function svcGenerateLivraisonPdf(bonLivraisonId: string, userId: nu
   const fileName = `Bon_livraison_${detail.bon_livraison.numero}.pdf`
   const filePath = path.join(docsDir, `${documentId}.pdf`)
 
+  const issuer = await readIssuerParty({
+    at: detail.bon_livraison.date_expedition ?? detail.bon_livraison.date_creation,
+  })
   const pdfBytes = await renderBonLivraisonDocument({
     header: detail.bon_livraison,
     lignes: detail.lignes,
     version,
-    company: await getCompanyHeader(),
+    company: pickMention(issuer, "company_name"),
+    issuer,
   })
   await fs.mkdir(path.dirname(filePath), { recursive: true })
   await fs.writeFile(filePath, pdfBytes)

--- a/src/shared/documents/issuer-identity.repository.ts
+++ b/src/shared/documents/issuer-identity.repository.ts
@@ -1,0 +1,98 @@
+import pool from "../../config/database"
+
+import type { LegalParty } from "../pdf/legal-mentions"
+
+/**
+ * Lecture de l'identite de l'entite emettrice et de ses mentions legales en vigueur.
+ *
+ * **Un seul point d'entree pour tous les documents sortants** — facture, avoir, bon de
+ * livraison, pack COFC, accuse de reception. Chaque module reconstruisait auparavant sa
+ * propre idee de l'emetteur : `livraisons` lisait `biller_name` seul, `facturation` lisait
+ * une liste blanche de colonnes qui **n'existent pas** dans `factureur`. Les documents
+ * divergeaient donc sur l'identite de celui qui les emet.
+ *
+ * ## Le contrat de date
+ *
+ * `fn_finance_issuer_snapshot(biller_id, date)` resout les mentions **en vigueur a la date
+ * demandee**. Cette date n'est pas « aujourd'hui » : c'est la date d'emission du document.
+ * Une facture emise en janvier doit porter les mentions de janvier, meme regeneree — sauf
+ * qu'une facture emise ne se regenere jamais, precisement parce que son instantane est fige.
+ *
+ * ## Tolerance a l'absence de patch
+ *
+ * Tant que `20260729_finance_legal_mentions.sql` n'est pas applique, la fonction n'existe
+ * pas (SQLSTATE `42883`) : on retombe alors sur l'identite operationnelle seule plutot que
+ * de faire echouer la generation. Un document sans mentions reste un document ; une
+ * generation qui leve laisse l'utilisateur sans rien.
+ */
+
+/** Code SQLSTATE : fonction inexistante. */
+const UNDEFINED_FUNCTION = "42883"
+/** Code SQLSTATE : table inexistante. */
+const UNDEFINED_TABLE = "42P01"
+
+function isMissingObject(error: unknown): boolean {
+  const code = (error as { code?: string } | null)?.code
+  return code === UNDEFINED_FUNCTION || code === UNDEFINED_TABLE
+}
+
+/** Identite operationnelle seule, quand la table de mentions n'est pas encore en place. */
+async function fallbackIssuerParty(billerId: string | null): Promise<LegalParty> {
+  const result = await pool.query<{ party: LegalParty }>(
+    `
+      SELECT jsonb_strip_nulls(jsonb_build_object(
+        'biller_id',      f.biller_id,
+        'company_name',   f.biller_name,
+        'address_line_1', NULLIF(btrim(concat_ws(' ', f.house_number, f.street)), ''),
+        'postal_code',    f.postal_code,
+        'city',           f.city,
+        'country',        f.country,
+        'phone',          f.phone,
+        'email',          f.email,
+        'bank_name',      f.default_bank_name,
+        'iban',           f.default_iban,
+        'bic',            f.default_bic
+      )) AS party
+      FROM public.factureur f
+      WHERE ($1::uuid IS NULL OR f.biller_id = $1::uuid)
+      ORDER BY f.biller_id ASC
+      LIMIT 1
+    `,
+    [billerId]
+  )
+  return result.rows[0]?.party ?? {}
+}
+
+/**
+ * Instantane complet de l'emetteur a une date donnee.
+ *
+ * `billerId` a `null` prend le premier emetteur enregistre : c'est le comportement
+ * historique de `getIssuerParty()` et `getCompanyHeader()`, conserve tant que le
+ * referentiel ne porte qu'une entite. La politique Finance, elle, designe explicitement son
+ * entite legale et doit passer son identifiant.
+ *
+ * Renvoie `{}` quand aucun emetteur n'est configure. Le rendu affiche alors « Non
+ * renseigne » plutot que d'inventer une identite.
+ */
+export async function readIssuerParty(options: { billerId?: string | null; at?: string | null } = {}): Promise<LegalParty> {
+  const billerId = options.billerId ?? null
+  // La date d'emission gouverne la version de mentions ; a defaut, la date du jour.
+  const at = options.at ? String(options.at).slice(0, 10) : null
+
+  try {
+    const result = await pool.query<{ party: LegalParty | null }>(
+      `
+        SELECT public.fn_finance_issuer_snapshot(f.biller_id, COALESCE($2::date, CURRENT_DATE)) AS party
+        FROM public.factureur f
+        WHERE ($1::uuid IS NULL OR f.biller_id = $1::uuid)
+        ORDER BY f.biller_id ASC
+        LIMIT 1
+      `,
+      [billerId, at]
+    )
+    return result.rows[0]?.party ?? {}
+  } catch (error) {
+    if (!isMissingObject(error)) throw error
+    return fallbackIssuerParty(billerId)
+  }
+}

--- a/src/shared/pdf/cerp-document.ts
+++ b/src/shared/pdf/cerp-document.ts
@@ -32,12 +32,93 @@ const MARGIN_TOP = 34
 /** Bande reservee au pied de page fixe. */
 const MARGIN_BOTTOM = 54
 
+/**
+ * Geometrie du pied de page, mesuree pour un document donne.
+ *
+ * ## Pourquoi les mentions vivent dans le pied et non dans le flux
+ *
+ * Placees a la suite du contenu, elles poussaient un bon de livraison de deux lignes sur une
+ * seconde page qui ne portait qu'elles : le cadre de reception occupe deja le bas de la
+ * page. Une mention obligatoire ne doit jamais couter une page, et elle a d'autant plus de
+ * valeur qu'elle figure sur **chaque** page — une page detachee reste opposable.
+ *
+ * C'est aussi la disposition de la facture papier de l'entreprise : penalites, escompte et
+ * reserve de propriete en petit corps au-dessus du filet, identite legale en dessous.
+ *
+ * ## Reserve
+ *
+ * La bande n'a pas de hauteur fixe : elle est **mesuree** sur le texte reel. Une reserve
+ * forfaitaire ferait chevaucher les mentions et la derniere ligne du contenu des que la
+ * clause de reserve de propriete depasse une ligne — et une mention illisible est une
+ * mention absente.
+ */
+type FooterGeometry = {
+  reserve: number
+  identity: string | null
+  mentions: string | null
+  mentionsHeight: number
+  mentionsY: number
+  noteY: number
+}
+
+function measureFooter(header: CerpDocumentHeader): FooterGeometry {
+  const identity = header.legalIdentity && header.legalIdentity.trim() ? toPdfSafeText(header.legalIdentity.trim()) : null
+  const usable = (header.legalMentions ?? []).map((line) => line.trim()).filter(Boolean)
+  // Les mentions sont fondues en un seul paragraphe separe par des points medians : sur une
+  // bande de pied, un paragraphe par mention gaspillerait la moitie de la hauteur en
+  // interlignes.
+  const mentions = usable.length ? toPdfSafeText(usable.join("  ·  ")) : null
+
+  if (!identity && !mentions) {
+    // Aucun contenu legal : on conserve exactement la geometrie anterieure.
+    return {
+      reserve: MARGIN_BOTTOM,
+      identity: null,
+      mentions: null,
+      mentionsHeight: 0,
+      mentionsY: 0,
+      noteY: FOOTER_BASELINE - 17,
+    }
+  }
+
+  let mentionsHeight = 0
+  if (mentions) {
+    // Instance jetable : `heightOfString` ne depend que de la police, du corps et de la
+    // largeur, et le document reel doit connaitre sa marge basse des sa construction.
+    const ruler = new PDFDocument({ size: "A4" })
+    ruler.font("Helvetica").fontSize(LEGAL_MENTIONS_SIZE)
+    mentionsHeight = ruler.heightOfString(mentions, { width: CONTENT_WIDTH, lineGap: 0.3 })
+    ruler.end()
+  }
+
+  // Interlignes serres : chaque point rendu a la bande est un point rendu au contenu, et
+  // ces trois elements sont du petit corps qui n'a pas besoin de respirer.
+  const identityY = FOOTER_BASELINE - 16
+  const mentionsY = identityY - 2 - mentionsHeight
+  const noteY = (mentions ? mentionsY : identityY) - 8
+  const contentBottom = (header.footerNote && header.footerNote.trim() ? noteY : mentionsY) - 5
+
+  return {
+    reserve: Math.max(MARGIN_BOTTOM, PAGE_HEIGHT - contentBottom),
+    identity,
+    mentions,
+    mentionsHeight,
+    mentionsY,
+    noteY,
+  }
+}
+
 const PAGE_WIDTH = 595.28
 const PAGE_HEIGHT = 841.89
 export const CONTENT_WIDTH = PAGE_WIDTH - MARGIN_X * 2
 
 const BODY_SIZE = 9.5
 const LOGO_WIDTH = 148
+
+/** Ligne de base du pied : « CROIX ROUSSE PRECISION — Genere le … — Page X / Y ». */
+const FOOTER_BASELINE = PAGE_HEIGHT - 30
+const LEGAL_IDENTITY_SIZE = 6.2
+const LEGAL_MENTIONS_SIZE = 5.8
 
 /**
  * Caracteres absents de WinAnsi, seul encodage des polices standard PDF.
@@ -117,6 +198,30 @@ export type CerpDocumentHeader = {
    * detachable, une page isolee doit pouvoir etre rattachee a son exemplaire d'origine.
    */
   footerNote?: string | null
+  /**
+   * Identite legale de l'emetteur, portee par **toutes** les pages : forme juridique,
+   * capital social, RCS et ville d'immatriculation, SIRET, numero de TVA.
+   *
+   * Mention **obligatoire** (art. R123-237 C. com.) sur tout document commercial — facture,
+   * avoir, bon de livraison, accuse de reception. Elle vit dans le pied et non dans le flux,
+   * comme sur la facture papier de l'entreprise : le bloc « Emetteur » en tete porte
+   * l'adresse, le pied porte l'identite legale.
+   *
+   * Construite par `issuerIdentityLine()` (`shared/pdf/legal-mentions.ts`) a partir de
+   * l'instantane fige — jamais recomposee par un appelant.
+   */
+  legalIdentity?: string | null
+  /**
+   * Mentions legales de reglement et clauses, portees par **toutes** les pages.
+   *
+   * Penalites de retard (art. L441-10 C. com.), indemnite forfaitaire de recouvrement
+   * (art. D441-5), escompte (art. L441-9, obligatoire meme en son absence), regime de TVA
+   * et reserve de propriete.
+   *
+   * Construites par `issuerLegalMentions()` a partir de l'instantane fige. Elles vivent dans
+   * la bande de pied et non dans le flux : voir `measureFooter`.
+   */
+  legalMentions?: string[] | null
   /** Metadonnees PDF. */
   title: string
   subject: string
@@ -153,10 +258,13 @@ export type CerpAddressCard = {
 export class CerpDocumentContext {
   readonly doc: PDFKit.PDFDocument
   private cursor: number
+  /** Bande reservee au pied, variable selon les mentions qu'il porte. */
+  private readonly reserve: number
 
-  constructor(doc: PDFKit.PDFDocument, startY: number) {
+  constructor(doc: PDFKit.PDFDocument, startY: number, reserve: number = MARGIN_BOTTOM) {
     this.doc = doc
     this.cursor = startY
+    this.reserve = reserve
   }
 
   get y(): number {
@@ -168,7 +276,7 @@ export class CerpDocumentContext {
   }
 
   private get bottomLimit(): number {
-    return PAGE_HEIGHT - MARGIN_BOTTOM
+    return PAGE_HEIGHT - this.reserve
   }
 
   /** Ouvre une page si `height` ne tient pas dans ce qui reste. */
@@ -370,7 +478,7 @@ export class CerpDocumentContext {
         rowHeight += 1 + this.doc.heightOfString(toPdfSafeText(row.meta), { width: metaWidth })
       }
 
-      if (this.cursor + rowHeight + 12 > PAGE_HEIGHT - MARGIN_BOTTOM) {
+      if (this.cursor + rowHeight + 12 > this.bottomLimit) {
         this.doc.addPage()
         this.cursor = MARGIN_TOP
         drawHead()
@@ -482,6 +590,7 @@ export class CerpDocumentContext {
     this.cursor += height
     this.doc.fillColor(CERP_DOC_COLORS.ink)
   }
+
 }
 
 function drawMasthead(doc: PDFKit.PDFDocument, header: CerpDocumentHeader): number {
@@ -584,14 +693,55 @@ function drawRunningHead(doc: PDFKit.PDFDocument, header: CerpDocumentHeader): v
   doc.fillColor(CERP_DOC_COLORS.ink)
 }
 
-function drawFooter(doc: PDFKit.PDFDocument, header: CerpDocumentHeader, pageNumber: number, totalPages: number): void {
-  const y = PAGE_HEIGHT - 30
+function drawFooter(
+  doc: PDFKit.PDFDocument,
+  header: CerpDocumentHeader,
+  geometry: FooterGeometry,
+  pageNumber: number,
+  totalPages: number
+): void {
+  const y = FOOTER_BASELINE
+
+  // Le pied vit **sous** la marge basse : c'est sa raison d'etre. pdfkit, lui, ouvre une
+  // page des qu'un texte susceptible de revenir a la ligne depasse `maxY()` — un bloc de
+  // mentions de trois lignes suffisait a ajouter une page vide a chaque document. Les
+  // lignes uniques y echappent via `lineBreak: false` ; un paragraphe justifie, non. On
+  // suspend donc la marge le temps de dessiner le pied, puis on la retablit.
+  const savedBottomMargin = doc.page.margins.bottom
+  doc.page.margins.bottom = 0
+
+  // Mentions de reglement et clauses, au-dessus de l'identite legale.
+  if (geometry.mentions) {
+    doc.font("Helvetica").fontSize(LEGAL_MENTIONS_SIZE).fillColor(CERP_DOC_COLORS.steel)
+    // Fer a gauche, jamais justifie : pdfkit justifie en **positionnant** les mots plutot
+    // qu'en ecrivant les espaces, et le texte extrait du PDF revient alors colle
+    // (« Penalitesderetard:12,5% »). Une mention legale doit rester lisible par une
+    // machine — copier-coller, indexation, controle automatise.
+    doc.text(geometry.mentions, MARGIN_X, geometry.mentionsY, {
+      width: CONTENT_WIDTH,
+      lineGap: 0.3,
+    })
+  }
+
+  // Identite legale : mention obligatoire, placee au plus pres du filet de pied et repetee
+  // sur chaque page.
+  if (geometry.identity) {
+    doc.font("Helvetica").fontSize(LEGAL_IDENTITY_SIZE).fillColor(CERP_DOC_COLORS.graphite)
+    const legalWidth = doc.widthOfString(geometry.identity)
+    // Une identite trop longue pour une ligne est laissee au retour a la ligne plutot que
+    // rognee : une mention obligatoire tronquee ne vaut pas mieux qu'une mention absente.
+    if (legalWidth <= CONTENT_WIDTH) {
+      doc.text(geometry.identity, MARGIN_X + (CONTENT_WIDTH - legalWidth) / 2, y - 17, { lineBreak: false })
+    } else {
+      doc.text(geometry.identity, MARGIN_X, y - 17, { width: CONTENT_WIDTH, align: "center" })
+    }
+  }
 
   const note = header.footerNote && header.footerNote.trim() ? toPdfSafeText(header.footerNote.trim()) : null
   if (note) {
     doc.font("Helvetica").fontSize(6.5).fillColor(CERP_DOC_COLORS.steel)
     const noteWidth = doc.widthOfString(note)
-    doc.text(note, MARGIN_X + (CONTENT_WIDTH - noteWidth) / 2, y - 17, { lineBreak: false })
+    doc.text(note, MARGIN_X + (CONTENT_WIDTH - noteWidth) / 2, geometry.noteY, { lineBreak: false })
   }
 
   doc.save()
@@ -613,6 +763,7 @@ function drawFooter(doc: PDFKit.PDFDocument, header: CerpDocumentHeader, pageNum
   const pageWidth = doc.widthOfString(page)
   doc.text(page, MARGIN_X + CONTENT_WIDTH - pageWidth, y, { lineBreak: false })
 
+  doc.page.margins.bottom = savedBottomMargin
   doc.fillColor(CERP_DOC_COLORS.ink)
 }
 
@@ -626,10 +777,11 @@ export async function renderCerpDocument(
   header: CerpDocumentHeader,
   render: (ctx: CerpDocumentContext) => void
 ): Promise<Buffer> {
+  const geometry = measureFooter(header)
   const doc = new PDFDocument({
     size: "A4",
     bufferPages: true,
-    margins: { top: MARGIN_TOP, bottom: MARGIN_BOTTOM, left: MARGIN_X, right: MARGIN_X },
+    margins: { top: MARGIN_TOP, bottom: geometry.reserve, left: MARGIN_X, right: MARGIN_X },
     info: {
       Title: toPdfSafeText(header.title),
       Author: "Croix Rousse Precision",
@@ -646,13 +798,13 @@ export async function renderCerpDocument(
   const afterMasthead = drawMasthead(doc, header)
   const afterIdentity = drawIdentity(doc, header, afterMasthead)
 
-  render(new CerpDocumentContext(doc, afterIdentity))
+  render(new CerpDocumentContext(doc, afterIdentity, geometry.reserve))
 
   const range = doc.bufferedPageRange()
   for (let index = 0; index < range.count; index += 1) {
     doc.switchToPage(range.start + index)
     if (index > 0) drawRunningHead(doc, header)
-    drawFooter(doc, header, index + 1, range.count)
+    drawFooter(doc, header, geometry, index + 1, range.count)
   }
 
   doc.end()

--- a/src/shared/pdf/format-fr.ts
+++ b/src/shared/pdf/format-fr.ts
@@ -1,0 +1,60 @@
+/**
+ * Mise en forme francaise des nombres, taux et dates pour les documents sortants.
+ *
+ * Extrait de `facturation/services/finance-document-render.ts` (#216) pour etre partage :
+ * les mentions legales de l'emetteur portent un capital social et des taux, et elles
+ * s'impriment aussi sur le bon de livraison et l'accuse de reception, qui ne peuvent pas
+ * dependre du module facturation.
+ *
+ * **Aucun chiffre n'est modifie** : seuls les separateurs changent.
+ */
+
+/** Date ISO en date francaise : `22/07/2026`. */
+export function formatDateFR(iso: string | null | undefined): string {
+  if (!iso) return "-"
+  const raw = String(iso)
+  const m = raw.match(/^(\d{4})-(\d{2})-(\d{2})/)
+  if (m) return `${m[3]}/${m[2]}/${m[1]}`
+  return raw
+}
+
+/** Pourcentage a la francaise : `20,00 %`. Meme regle que `money` — aucun chiffre change. */
+export function percent(value: string): string {
+  const raw = String(value ?? "").trim()
+  if (!/^-?\d+(?:[.,]\d+)?$/.test(raw)) return `${raw} %`.trim()
+  return `${raw.replace(".", ",")} %`
+}
+
+/**
+ * Montant au format francais : `10 465,20 €`.
+ *
+ * Le referentiel fournit des chaines a point decimal (`10465.20`) et le document les sortait
+ * telles quelles, avec le code ISO — sur une facture francaise, et alors que les documents
+ * rendus dans le navigateur affichent deja `10 465,20 €` pour la meme entreprise.
+ *
+ * Une chaine qui n'est pas un nombre est rendue telle quelle plutot que d'etre perdue.
+ */
+export function money(amount: string, currency: string): string {
+  const raw = String(amount ?? "").trim()
+  const symbol = currency === "EUR" ? "€" : currency
+
+  const match = raw.match(/^(-?)(\d+)(?:[.,](\d+))?$/)
+  if (!match) return `${raw} ${symbol}`.trim()
+
+  const [, sign, whole, decimals] = match
+  const grouped = whole.replace(/\B(?=(\d{3})+(?!\d))/g, " ")
+  return `${sign}${grouped}${decimals ? `,${decimals}` : ""} ${symbol}`
+}
+
+/**
+ * Taux debarrasse de ses zeros decimaux inutiles : `12.500` devient `12,5 %`.
+ *
+ * Un taux de penalite s'ecrit `12,5 %`, pas `12,500 %` : la precision de stockage
+ * (numeric(6,3)) n'a pas a transparaitre sur une mention legale.
+ */
+export function rate(value: string | null | undefined): string | null {
+  const raw = String(value ?? "").trim()
+  if (!/^-?\d+(?:[.,]\d+)?$/.test(raw)) return raw ? percent(raw) : null
+  const trimmed = raw.replace(",", ".").replace(/\.(\d*?)0+$/, ".$1").replace(/\.$/, "")
+  return percent(trimmed)
+}

--- a/src/shared/pdf/legal-mentions.ts
+++ b/src/shared/pdf/legal-mentions.ts
@@ -1,0 +1,202 @@
+import { money, rate } from "./format-fr"
+
+/**
+ * Mentions legales de l'entite emettrice, communes a **tous** les documents sortants.
+ *
+ * Ce module ne vit pas dans `module/facturation` a dessein : les memes mentions doivent
+ * figurer sur la facture, l'avoir, le bon de livraison, le pack COFC et l'accuse de
+ * reception. Une seule redaction, un seul endroit — sinon les documents divergent, ce qui
+ * est exactement le defaut que #213 et #216 ont corrige pour la mise en page.
+ *
+ * ## Ce que le referentiel ne portait pas
+ *
+ * `public.factureur` est une table historique : elle ne possede **aucune** colonne legale
+ * (ni SIRET, ni SIREN, ni RCS, ni numero de TVA, ni capital, ni forme juridique) et elle
+ * etait vide sur `cerp_test` comme sur `cerp_prod`. Le rendu etait donc pret a afficher des
+ * mentions qui n'existaient nulle part. Le patch `20260729_finance_legal_mentions.sql`
+ * cree la table versionnee `finance_legal_mentions` et la fonction de resolution
+ * `fn_finance_issuer_snapshot(biller_id, date)`.
+ *
+ * ## Pourquoi une lecture defensive
+ *
+ * L'instantane est libre de forme et **immuable** : un document emis il y a deux ans porte
+ * la forme d'instantane de l'epoque. On lit donc plusieurs cles possibles et **on n'affiche
+ * que ce qui existe reellement**. Une mention absente n'est jamais remplacee par un
+ * substitut, un tiret ou une etiquette vide : sur une piece fiscale, une mention inventee
+ * est pire qu'une mention manquante.
+ */
+
+/** Instantane d'une partie, tel que fige dans le document. Forme libre, volontairement. */
+export type LegalParty = Record<string, unknown>
+
+function clean(value: unknown): string | null {
+  const s = typeof value === "string" ? value.trim() : typeof value === "number" ? String(value) : ""
+  return s ? s : null
+}
+
+/** Premiere valeur non vide parmi plusieurs cles possibles. */
+export function pickMention(source: LegalParty, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = clean(source[key])
+    if (value) return value
+  }
+  return null
+}
+
+function flag(source: LegalParty, key: string): boolean {
+  return source[key] === true || source[key] === "true"
+}
+
+/** Une version de mentions a-t-elle ete resolue pour ce document ? */
+function hasMentionSet(party: LegalParty): boolean {
+  return pickMention(party, "legal_mentions_version") !== null
+}
+
+/**
+ * Capital social mis en forme, avec sa devise.
+ *
+ * Stocke en `numeric(14,2)` et transporte en texte : le rendu met en forme, il ne calcule
+ * pas. `21000.00` devient `21 000,00 €`.
+ */
+export function shareCapital(party: LegalParty): string | null {
+  const amount = pickMention(party, "share_capital", "capital_social")
+  if (!amount) return null
+  const currency = pickMention(party, "share_capital_currency") ?? "EUR"
+  return money(amount, currency)
+}
+
+/**
+ * Ligne d'identite legale, portee par **toutes les pages** de **tous** les documents.
+ *
+ * C'est la disposition de la facture papier de l'entreprise : le bloc « Emetteur » en tete
+ * porte l'adresse et le telephone, le pied porte capital, RCS, SIRET et numero de TVA. La
+ * repeter a chaque page garantit qu'une page detachee reste rattachable a son emetteur.
+ *
+ * Mentions couvertes : art. R123-237 du code de commerce (forme juridique, capital, RCS et
+ * ville d'immatriculation, SIREN/SIRET) et art. 242 nonies A de l'annexe II au CGI
+ * (numero de TVA intracommunautaire).
+ */
+export function issuerIdentityLine(party: LegalParty): string | null {
+  const form = pickMention(party, "legal_form", "forme_juridique")
+  const capital = shareCapital(party)
+  const rcsNumber = pickMention(party, "rcs_number", "rcs")
+  const rcsCity = pickMention(party, "rcs_city")
+  const siret = pickMention(party, "siret")
+  const siren = pickMention(party, "siren")
+  const vat = pickMention(party, "vat_number", "numero_tva", "tva_intracommunautaire")
+  const ape = pickMention(party, "ape_code", "code_ape", "naf")
+
+  const identity =
+    form && capital ? `${form} au capital de ${capital}` : form ? form : capital ? `Capital social ${capital}` : null
+
+  // « RCS <ville> <numero> » : sans la ville, la mention est incomplete au regard de
+  // R123-237 — c'est precisement ce qui manquait sur la facture papier.
+  const rcs = rcsNumber ? (rcsCity ? `RCS ${rcsCity} ${rcsNumber}` : `RCS ${rcsNumber}`) : null
+
+  const segments = [
+    identity,
+    rcs,
+    siret ? `SIRET ${siret}` : siren ? `SIREN ${siren}` : null,
+    vat ? `TVA ${vat}` : null,
+    ape ? `APE ${ape}` : null,
+  ].filter((segment): segment is string => Boolean(segment))
+
+  return segments.length ? segments.join(" · ") : null
+}
+
+/** `12.500` + `ANNUEL` devient `12,5 % l'an`. */
+function rateWithBasis(value: string | null, basis: string | null): string | null {
+  const formatted = rate(value)
+  if (!formatted) return null
+  const normalized = (basis ?? "").toUpperCase()
+  if (normalized === "MENSUEL") return `${formatted} par mois`
+  if (normalized === "ANNUEL") return `${formatted} l'an`
+  return formatted
+}
+
+/**
+ * Mentions de reglement et clauses, en fin de document.
+ *
+ * Chaque entree est un paragraphe autonome. L'ordre suit celui du code de commerce :
+ * penalites, indemnite forfaitaire, escompte, puis regime de TVA et clauses.
+ *
+ * Rien n'est emis sans donnee correspondante, a une exception assumee : **l'escompte est
+ * une mention obligatoire meme en son absence** (art. L441-9). Quand une version de
+ * mentions est resolue mais qu'aucun taux n'est parametre, le document ecrit donc
+ * explicitement qu'aucun escompte n'est accorde. Si aucune version n'est resolue, on
+ * n'ecrit rien : on ne sait pas, et on ne le devine pas.
+ */
+export function issuerLegalMentions(party: LegalParty): string[] {
+  const mentions: string[] = []
+
+  // 1. Penalites de retard — art. L441-10 du code de commerce.
+  const penalty = rateWithBasis(
+    pickMention(party, "late_penalty_rate", "taux_penalites_retard"),
+    pickMention(party, "late_penalty_basis")
+  )
+  if (penalty) {
+    mentions.push(
+      `Pénalités de retard : ${penalty}, exigibles de plein droit le jour suivant la date de règlement, ` +
+        `sans rappel préalable (art. L441-10 du code de commerce).`
+    )
+  }
+
+  // 2. Indemnite forfaitaire de recouvrement — art. D441-5, 40 € depuis le decret 2012-1115.
+  const indemnity = pickMention(party, "recovery_indemnity", "indemnite_recouvrement")
+  if (indemnity) {
+    mentions.push(
+      `Indemnité forfaitaire pour frais de recouvrement : ${money(indemnity, "EUR")} par facture ` +
+        `(art. D441-5 du code de commerce), sans préjudice d'une indemnisation complémentaire sur justificatifs.`
+    )
+  }
+
+  // 3. Escompte — obligatoire meme en son absence.
+  const discount = rateWithBasis(
+    pickMention(party, "early_discount_rate", "taux_escompte"),
+    pickMention(party, "early_discount_basis")
+  )
+  if (discount) {
+    mentions.push(`Escompte pour paiement anticipé : ${discount}.`)
+  } else if (hasMentionSet(party)) {
+    mentions.push(`Escompte pour paiement anticipé : aucun escompte n'est accordé.`)
+  }
+
+  // 4. Regimes de TVA.
+  if (flag(party, "vat_exempt_293b")) {
+    mentions.push(`TVA non applicable, article 293 B du code général des impôts.`)
+  }
+  if (flag(party, "vat_on_receipts")) {
+    mentions.push(`TVA acquittée sur les encaissements.`)
+  }
+
+  // 5. Reserve de propriete — loi du 12 mai 1980, reprise telle qu'elle est parametree.
+  const retention = pickMention(party, "retention_of_title", "reserve_propriete")
+  if (retention) {
+    mentions.push(`Réserve de propriété : ${retention}`)
+  }
+
+  // 6. Mentions libres additionnelles, dans l'ordre du parametrage.
+  const extras = party.extra_mentions
+  if (Array.isArray(extras)) {
+    for (const extra of extras) {
+      const text = clean(extra)
+      if (text) mentions.push(text)
+    }
+  }
+
+  return mentions
+}
+
+/**
+ * Coordonnees de reglement, quand elles sont parametrees.
+ *
+ * Ce n'est pas une mention obligatoire, mais c'est ce que porte la facture papier de
+ * l'entreprise et c'est ce qui permet au client de payer.
+ */
+export function issuerPaymentDetails(party: LegalParty): string | null {
+  const iban = pickMention(party, "iban", "default_iban")
+  if (!iban) return null
+  const bic = pickMention(party, "bic", "default_bic")
+  const bank = pickMention(party, "bank_name", "default_bank_name")
+  return [`RIB : ${iban}`, bic ? `BIC : ${bic}` : null, bank].filter(Boolean).join(" · ")
+}


### PR DESCRIPTION
Closes #221

## Résultat
- centralise l’identité émettrice et les mentions légales versionnées ;
- fige l’instantané lors de l’émission d’une facture ou d’un avoir, avant l’allocation du numéro légal ;
- ajoute les mentions aux factures, avoirs, accusés de réception, bons de livraison et COFC, avec répétition sur chaque page PDF ;
- bloque l’émission fiscale si la configuration obligatoire est incomplète ;
- ajoute les patchs SQL, le préflight, la vérification et le rollback restreint à `cerp_test` ;
- empêche les périodes de mentions qui se chevauchent et rend leur résolution déterministe.

## Validation locale
- `npm run build` : OK
- `npm run test:run` : OK (suite backend complète)
- `git diff --check` : OK

## Déploiement prévu après fusion
- application et vérification sur `cerp_test` puis `cerp_prod`, avec sauvegarde préalable ;
- déploiement des backends atelier et public ;
- contrôles de santé et de commit déployé.

## Summary by Sourcery

Introduce versioned legal mentions for the issuing entity and ensure all outgoing commercial documents carry the correct, date-resolved legal identity and mandatory mentions at emission time.

New Features:
- Add a versioned finance_legal_mentions table and snapshot function to resolve the issuer’s legal identity and mentions as of a given date.
- Extend the shared PDF infrastructure to support legal identity and legal mentions in a repeated footer strip across all pages of CERP documents.
- Add legal identity and mentions to delivery notes, COFC certificates, invoices, credit notes, and order acknowledgements, with centralised issuer resolution.

Bug Fixes:
- Block fiscal document issuance when the issuer’s mandatory legal configuration or applicable legal version is missing, preventing non-compliant immutable documents.
- Prevent overlapping legal mention periods per issuer and enforce deterministic resolution of the applicable version for a given date.

Enhancements:
- Refactor issuer identity rendering into a shared legal-mentions module with French formatting, reused by finance, delivery, and order modules.
- Adjust CERP PDF layout to measure footer height dynamically so legal mentions do not add blank pages or push business content, while keeping text extractible from PDFs.
- Update finance workflows so invoice and credit-note snapshots freeze the issuer’s legal state at emission time rather than draft creation, and persist that snapshot consistently.
- Introduce a shared repository to read issuer identity and legal mentions, replacing ad hoc factureur lookups in facturation and livraisons modules.

Build:
- Add finance_legal_mentions database patches plus supporting preflight, verification, and constrained rollback scripts for controlled deployment.

Deployment:
- Prepare migration and verification workflow for deploying the finance_legal_mentions schema and hardening to cerp_test and cerp_prod, with explicit safeguards around existing data and snapshots.

Documentation:
- Document the legal requirements and design for issuer legal mentions on outgoing documents, including storage, versioning, and pagination behaviour.
- Extend database patch documentation with the finance_legal_mentions migration, hardening rules, and operational preflight/verify/rollback steps.

Tests:
- Add extensive PDF-level tests to verify presence, absence, and repetition of legal mentions and issuer identity on finance, delivery, COFC, and order acknowledgement documents.
- Add migration guard tests and workflow tests to enforce non-overlapping legal mention periods and mandatory issuer snapshot validation before fiscal issuance.