### PR TITLE
release: déployer le correctif des droits d’action RBAC

### DIFF
--- a/src/__tests__/multi-role-rbac.test.ts
+++ b/src/__tests__/multi-role-rbac.test.ts
@@ -11,6 +11,13 @@ import { adminCreateUserSchema } from "../module/admin/validators/admin.validato
 import { roleHasFinanceCapability } from "../module/facturation/domain/finance-policy";
 import { roleHasPlanningAccess } from "../module/planning/domain/planning-rbac";
 import { roleHasMachineCapability } from "../module/production/domain/machine-rbac";
+import { ARTICLE_WRITE_ROLES } from "../module/stock/stock-article.permissions";
+import { canApprovePieceTechniqueVersion } from "../module/pieces-techniques/domain/pieces-techniques-rbac";
+import { canLaunchInternalOrder } from "../module/commande-client/domain/commande-client-rbac";
+import {
+  CLIENT_FINANCE_ROLES,
+  CLIENT_WRITE_ROLES,
+} from "../module/client/client.permissions";
 
 const validUserBody = {
   username: "LAMBERT",
@@ -83,6 +90,58 @@ describe("RBAC multi-rôles #315", () => {
     expect(status).not.toHaveBeenCalled();
   });
 
+  it("applique les alias explicites aux gardes de rôle exactes", () => {
+    const middleware = authorizeRole("Secretaire");
+    const req = {
+      user: {
+        id: 14,
+        username: "ASSISTANCE",
+        email: "assistance@example.invalid",
+        role: "Employee | Secretaire",
+        primary_role: "Employee",
+        roles: ["Employee", "Assistante polyvalente"],
+      },
+      headers: {},
+      method: "POST",
+      originalUrl: "/api/v1/clients",
+    } as unknown as Request;
+    const status = vi.fn().mockReturnThis();
+    const json = vi.fn();
+    const res = { status, json } as unknown as Response;
+    const next = vi.fn() as NextFunction;
+
+    middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledOnce();
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it("n'escalade jamais Directeur Technique vers le rôle global Directeur", () => {
+    const middleware = authorizeRole("Directeur");
+    const req = {
+      user: {
+        id: 15,
+        username: "DIRECTION_TECHNIQUE",
+        email: "direction-technique@example.invalid",
+        role: "Employee | Production | Atelier | Method",
+        primary_role: "Employee",
+        roles: ["Employee", "Directeur Technique"],
+      },
+      headers: {},
+      method: "GET",
+      originalUrl: "/api/v1/admin/users",
+    } as unknown as Request;
+    const json = vi.fn();
+    const status = vi.fn(() => ({ json }));
+    const res = { status } as unknown as Response;
+    const next = vi.fn() as NextFunction;
+
+    middleware(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(403);
+  });
+
   it("refuse par défaut si aucun rôle attribué ne correspond", () => {
     const middleware = authorizeRole("Responsable RH");
     const req = {
@@ -136,5 +195,28 @@ describe("RBAC multi-rôles #315", () => {
     expect(roleHasMachineCapability("Employee | Maintenance", "maintenance")).toBe(true);
     expect(roleHasMachineCapability("Employee | Opérateur atelier", "archive")).toBe(false);
     expect(roleHasFinanceCapability("Employee | Comptabilite", "validate")).toBe(true);
+  });
+
+  it("débloque les actions critiques pour les responsabilités organisationnelles prévues", () => {
+    const materialManagerRole = authorizationRole("Employee", ["Gestion matière"]);
+    const methodsRole = authorizationRole("Employee", ["Études-Méthodes"]);
+    const technicalDirectorRole = authorizationRole("Employee", ["Directeur Technique"]);
+    const commercialRole = authorizationRole("Employee", ["Commerce"]);
+    const financeRole = authorizationRole("Employee", ["RH-Financier"]);
+
+    expect(effectiveRoleHasAny(materialManagerRole, ARTICLE_WRITE_ROLES)).toBe(true);
+    expect(canApprovePieceTechniqueVersion(methodsRole)).toBe(true);
+    expect(canLaunchInternalOrder(technicalDirectorRole)).toBe(true);
+    expect(effectiveRoleHasAny(commercialRole, CLIENT_WRITE_ROLES)).toBe(true);
+    expect(effectiveRoleHasAny(commercialRole, CLIENT_FINANCE_ROLES)).toBe(false);
+    expect(effectiveRoleHasAny(financeRole, CLIENT_FINANCE_ROLES)).toBe(true);
+  });
+
+  it("maintient le refus sur les actions sensibles pour un opérateur sans responsabilité", () => {
+    const operatorRole = authorizationRole("Employee", ["Opérateur atelier"]);
+
+    expect(effectiveRoleHasAny(operatorRole, ARTICLE_WRITE_ROLES)).toBe(false);
+    expect(canApprovePieceTechniqueVersion(operatorRole)).toBe(false);
+    expect(canLaunchInternalOrder(operatorRole)).toBe(false);
   });
 });

--- a/src/__tests__/pieces-techniques.routes.test.ts
+++ b/src/__tests__/pieces-techniques.routes.test.ts
@@ -34,8 +34,16 @@ vi.mock("../utils/checkNetworkDrive", () => ({
 }));
 
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
-  authenticateToken: (req: { user?: { id: number; role: string } }, _res: unknown, next: () => void) => {
-    req.user = { id: 1, role: "Administrateur Systeme et Reseau" };
+  authenticateToken: (
+    req: { user?: { id: number; role: string }; headers?: Record<string, string | string[] | undefined> },
+    _res: unknown,
+    next: () => void
+  ) => {
+    const requestedRole = req.headers?.["x-test-role"];
+    req.user = {
+      id: 1,
+      role: typeof requestedRole === "string" ? requestedRole : "Administrateur Systeme et Reseau",
+    };
     next();
   },
   authorizeRole:
@@ -67,6 +75,35 @@ beforeEach(() => {
 });
 
 describe("/api/v1/pieces-techniques", () => {
+  it.each([
+    "Employee | Method",
+    "Employee | Responsable Programmation",
+  ])("lets an authorized multi-role marker reach technical-version approval (%s)", async (role) => {
+    const pieceId = "11111111-1111-4111-8111-111111111111";
+    const versionId = "22222222-2222-4222-8222-222222222222";
+
+    const res = await request(app)
+      .patch(`/api/v1/pieces-techniques/${pieceId}/versions/${versionId}/status`)
+      .set("x-test-role", role)
+      .send({ next_statut: "APPLICABLE" });
+
+    expect(res.status).toBe(404);
+    expect(res.body).toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("keeps technical-version approval closed to an unprivileged operator", async () => {
+    const pieceId = "11111111-1111-4111-8111-111111111111";
+    const versionId = "22222222-2222-4222-8222-222222222222";
+
+    const res = await request(app)
+      .patch(`/api/v1/pieces-techniques/${pieceId}/versions/${versionId}/status`)
+      .set("x-test-role", "Employee | Opérateur atelier")
+      .send({ next_statut: "APPLICABLE" });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: "PIECE_VERSION_APPROVAL_FORBIDDEN" });
+  });
+
   it("rejects a manufactured child relation that would create a fabrication cycle", async () => {
     const parentId = "11111111-1111-4111-8111-111111111111";
     const childId = "22222222-2222-4222-8222-222222222222";

--- a/src/module/auth/middlewares/auth.middleware.ts
+++ b/src/module/auth/middlewares/auth.middleware.ts
@@ -1,7 +1,11 @@
 import { Request, Response, NextFunction, RequestHandler } from 'express';
 import jwt from 'jsonwebtoken';
 import { stripQueryFromUrl } from '../../../utils/logPath';
-import { hasAnyAssignedRole, normalizeAssignedRoles } from '../domain/roles';
+import {
+  effectiveRoleHasAny,
+  hasAnyAssignedRole,
+  normalizeAssignedRoles,
+} from '../domain/roles';
 
 interface JwtPayload {
   id: number;
@@ -76,7 +80,13 @@ export const authorizeRole = (...roles: string[]) => {
   
       const primaryRole = req.user.primary_role ?? req.user.role;
       const assignedRoles = normalizeAssignedRoles(primaryRole, req.user.roles);
-      if (!hasAnyAssignedRole(primaryRole, assignedRoles, roles)) {
+      // Multi-role sessions expose both the raw assignments and the explicit
+      // authorization aliases in `role`. Exact guards must understand both:
+      // e.g. `Assistante polyvalente` is deliberately aliased to `Secretaire`,
+      // while `Directeur Technique` is not aliased to the global `Directeur`.
+      const hasAssignedMatch = hasAnyAssignedRole(primaryRole, assignedRoles, roles);
+      const hasEffectiveMatch = effectiveRoleHasAny(req.user.role, roles);
+      if (!hasAssignedMatch && !hasEffectiveMatch) {
         console.warn(
           JSON.stringify({
             type: "auth_forbidden",

--- a/src/module/client/client.permissions.ts
+++ b/src/module/client/client.permissions.ts
@@ -11,6 +11,7 @@ export const CLIENT_WRITE_ROLES = [
   "Directeur",
   "Administrateur Systeme et Reseau",
   "Secretaire",
+  "Commercial",
 ] as const;
 
 /**
@@ -18,7 +19,12 @@ export const CLIENT_WRITE_ROLES = [
  * IBAN/BIC = critique, masqué par défaut, complet uniquement pour compta/admin.
  * Faute de rôle comptabilité dédié, ce sont les rôles de gestion clients.
  */
-export const CLIENT_FINANCE_ROLES = CLIENT_WRITE_ROLES;
+export const CLIENT_FINANCE_ROLES = [
+  "Directeur",
+  "Administrateur Systeme et Reseau",
+  "Secretaire",
+  "Comptabilite",
+] as const;
 
 export function canViewClientFinance(role: string | undefined | null): boolean {
   return effectiveRoleHasAny(role, CLIENT_FINANCE_ROLES);

--- a/src/module/commande-client/domain/commande-client-rbac.ts
+++ b/src/module/commande-client/domain/commande-client-rbac.ts
@@ -1,0 +1,19 @@
+import { effectiveRoleHasAny } from "../../auth/domain/roles";
+
+export const INTERNAL_ORDER_LAUNCH_ROLES = [
+  "Directeur",
+  "Administrateur Systeme et Reseau",
+  "Production",
+  "Responsable Programmation",
+  // Historical signed sessions and test fixtures kept during the multi-role
+  // transition. Exact matching preserves their previous scope without
+  // reintroducing substring-based role inference.
+  "Directeur industriel",
+  "Responsable Production",
+  "Responsable Atelier",
+  "Chef Atelier",
+] as const;
+
+export function canLaunchInternalOrder(role: string | null | undefined): boolean {
+  return effectiveRoleHasAny(role, INTERNAL_ORDER_LAUNCH_ROLES);
+}

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -40,6 +40,7 @@ import {
   createRecursiveOrdresFabrication,
   type GeneratedOfRef,
 } from "../../production/domain/of-generation";
+import { canLaunchInternalOrder } from "../domain/commande-client-rbac";
 
 function normalizeStoredPath(filePath: string) {
   const rel = path.isAbsolute(filePath) ? path.relative(process.cwd(), filePath) : filePath;
@@ -64,18 +65,6 @@ function coerceOrderType(value: unknown): CreateCommandeInput["order_type"] {
     if (v === "FERME" || v === "CADRE" || v === "INTERNE") return v as CreateCommandeInput["order_type"];
   }
   return "FERME";
-}
-
-function canLaunchInternalOrder(role: string | null | undefined): boolean {
-  if (!role) return false;
-  const normalized = role.trim().toLowerCase();
-  if (normalized.includes("admin") || normalized.includes("administrateur") || normalized.includes("directeur")) {
-    return true;
-  }
-  const isManager = normalized.includes("responsable") || normalized.includes("chef");
-  const isProduction =
-    normalized.includes("production") || normalized.includes("atelier") || normalized.includes("programmation");
-  return isManager && isProduction;
 }
 
 function sortColumn(sortBy: ListCommandesQueryDTO["sortBy"]) {

--- a/src/module/fournisseurs/routes/fournisseurs.routes.ts
+++ b/src/module/fournisseurs/routes/fournisseurs.routes.ts
@@ -37,7 +37,7 @@ import {
 
 // RBAC capability tiers (validated with the business). Reads are open to any
 // authenticated internal user; writes and sensitive actions are role-gated.
-const WRITE: string[] = ["Directeur", "Administrateur Systeme et Reseau", "Secretaire", "Responsable Programmation", "Responsable Qualité"]
+const WRITE: string[] = ["Directeur", "Administrateur Systeme et Reseau", "Secretaire", "Responsable Programmation", "Responsable Qualité", "Achat"]
 const QUALIF: string[] = ["Directeur", "Administrateur Systeme et Reseau", "Responsable Qualité"]
 const ARCHIVE: string[] = ["Directeur", "Administrateur Systeme et Reseau"]
 

--- a/src/module/pieces-techniques/domain/pieces-techniques-rbac.ts
+++ b/src/module/pieces-techniques/domain/pieces-techniques-rbac.ts
@@ -1,0 +1,21 @@
+import { effectiveRoleHasAny } from "../../auth/domain/roles";
+
+/**
+ * Releasing a technical definition is distinct from deleting one.
+ *
+ * The former belongs to Direction, Methods and Quality responsibilities; the
+ * latter remains restricted to the historical administrator guard.
+ */
+export const PIECE_TECHNIQUE_VERSION_APPROVAL_ROLES = [
+  "Directeur",
+  "Administrateur Systeme et Reseau",
+  "Responsable Programmation",
+  "Responsable Qualité",
+  "Method",
+] as const;
+
+export function canApprovePieceTechniqueVersion(
+  role: string | null | undefined
+): boolean {
+  return effectiveRoleHasAny(role, PIECE_TECHNIQUE_VERSION_APPROVAL_ROLES);
+}

--- a/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
+++ b/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
@@ -75,6 +75,7 @@ import {
   versionIdParamSchema,
   versionStatusSchema,
 } from "../validators/versions.validators"
+import { canApprovePieceTechniqueVersion } from "../domain/pieces-techniques-rbac"
 
 const router = Router()
 
@@ -87,6 +88,14 @@ function isAdminRole(role: string | undefined): boolean {
 const requireAdmin: RequestHandler = (req, _res, next) => {
   if (!isAdminRole(req.user?.role)) {
     next(new HttpError(403, "FORBIDDEN", "Admin role required"))
+    return
+  }
+  next()
+}
+
+const requireVersionApproval: RequestHandler = (req, _res, next) => {
+  if (!canApprovePieceTechniqueVersion(req.user?.role)) {
+    next(new HttpError(403, "PIECE_VERSION_APPROVAL_FORBIDDEN", "Technical definition approval role required"))
     return
   }
   next()
@@ -126,7 +135,7 @@ router.post("/:id/create-or-link-article-fabrique", validate(idParamSchema), cre
 router.get("/:id/versions", validate(idParamSchema), listVersions)
 router.post("/:id/versions", validate(idParamSchema), validate(createVersionSchema), createVersion)
 router.patch("/:id/versions/:versionId", validate(versionIdParamSchema), validate(updateVersionSchema), updateVersion)
-router.patch("/:id/versions/:versionId/status", requireAdmin, validate(versionIdParamSchema), validate(versionStatusSchema), updateVersionStatus)
+router.patch("/:id/versions/:versionId/status", requireVersionApproval, validate(versionIdParamSchema), validate(versionStatusSchema), updateVersionStatus)
 router.post("/:id/versions/:versionId/create-next", validate(versionIdParamSchema), validate(createNextVersionSchema), createNextVersion)
 
 router.post("/:id/nomenclature", validate(idParamSchema), validate(addBomLineSchema), addBomLine)

--- a/src/module/stock/stock-article.permissions.ts
+++ b/src/module/stock/stock-article.permissions.ts
@@ -6,6 +6,13 @@ export const ARTICLE_WRITE_ROLES = [
   "Secretaire",
   "Responsable Programmation",
   "Responsable Qualité",
+  // Explicit authorization aliases emitted for organization responsibilities.
+  // They keep article master-data writes available to Methods, Purchasing and
+  // Material Management without granting a global administrator role.
+  "Method",
+  "Achat",
+  "Stock",
+  "Magasin",
 ] as const;
 
 export const ARTICLE_ARCHIVE_ROLES = [
@@ -19,6 +26,8 @@ export const ARTICLE_COST_ROLES = [
   "Directeur",
   "Administrateur Systeme et Reseau",
   "Secretaire",
+  "Achat",
+  "Comptabilite",
 ] as const;
 
 export function canViewArticleCosts(role: string | null | undefined): boolean {


### PR DESCRIPTION
## Objet

Promeut dans `main` le correctif urgent des droits d’action RBAC déjà validé et fusionné dans `dev` via #228.

## Contenu de la promotion

La comparaison `main...dev` contient uniquement les 10 fichiers du correctif #225 : garde multi-rôle, politiques Articles, Clients, Fournisseurs, Pièces techniques et Commandes internes, ainsi que leurs tests.

## Validation

- suite backend complète : OK
- build TypeScript : OK
- tests RBAC multi-rôle : 11 OK
- tests commandes : 20 OK
- tests routes pièces techniques : 4 OK
- revue Sourcery : succès
- aucun workflow GitHub Actions ni Dependabot ajouté

Closes #225

## Summary by Sourcery

Adjust RBAC enforcement to correctly handle multi-role sessions and explicit authorization aliases for critical business actions.

Bug Fixes:
- Ensure authorizeRole considers both assigned roles and effective role aliases to avoid unintended blocking or escalation.
- Restrict technical-definition version approval to a dedicated responsibility set instead of the generic admin guard.
- Gate internal production orders on an explicit list of production and management roles instead of substring-based role inference.
- Clarify client finance access by separating financial roles from broader client write permissions, preventing commercial-only roles from seeing sensitive data.
- Extend article, client, and supplier write/cost permissions to the intended Methods, Purchasing, Stock, and Commercial responsibilities while keeping operators excluded from sensitive actions.

Enhancements:
- Introduce dedicated RBAC modules for internal order launch and technical-definition approval to centralize role policies.
- Update multi-role and route tests to cover new RBAC rules and ensure correct behavior for privileged and unprivileged roles.