### PR TITLE
feat(finitions): ajouter favoris, archivage, historique et similarité

### DIFF
--- a/db/patches/20260729_surface_finish_library_admin_226.sql
+++ b/db/patches/20260729_surface_finish_library_admin_226.sql
@@ -1,0 +1,165 @@
+-- 20260729_surface_finish_library_admin_226.sql
+--
+-- Administration de la bibliothèque de finitions (#226 / web #374).
+-- Complète 20260728_surface_finish_library_210.sql, ne le remplace pas.
+-- ADR : crp-systems-web/docs/adr/ADR-0038-surface-finish-library.md
+--
+-- ADDITIF, IDEMPOTENT, NON DESTRUCTIF :
+--   - 1 nouvelle table (`surface_finish_favorites`, préférence personnelle) ;
+--   - 3 colonnes NULLABLES d'archivage sur `surface_finishes`, nommées comme
+--     celles d'`articles` (archived_at / archived_by / archive_reason) pour que
+--     les deux référentiels s'archivent avec le même vocabulaire ;
+--   - 1 index unique PARTIEL qui rend le doublon strict impossible.
+--   Aucune table existante n'est renommée, vidée ni recodée. AUCUN BACKFILL.
+--
+-- Pas d'index trigramme ici, délibérément. `pg_trgm` est installé sur les deux
+-- bases et `similarity()` fonctionne SANS index ; la bibliothèque compte
+-- quelques centaines de lignes au plus et `articles` est la table la plus
+-- écrite de l'ERP. Un GIN trigramme se paierait à chaque écriture pour un gain
+-- nul à cette volumétrie. À reconsidérer au-delà de ~50 000 articles.
+--
+-- Pipeline db/patches (exécuté en tant que cerp_app). Cible : PostgreSQL 17.
+--   Preflight : db/patches/support/20260729_surface_finish_library_admin_226.preflight.sql
+--   Verify    : db/patches/support/20260729_surface_finish_library_admin_226.verify.sql
+--   Rollback  : db/patches/support/20260729_surface_finish_library_admin_226.rollback.sql
+
+BEGIN;
+
+/* -------------------------------------------------------------------------- */
+/* 0) Pré-requis structurels                                                  */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF to_regclass('public.surface_finishes') IS NULL THEN
+    RAISE EXCEPTION '#226: public.surface_finishes is missing — apply 20260728_surface_finish_library_210.sql first';
+  END IF;
+  IF to_regclass('public.users') IS NULL THEN
+    RAISE EXCEPTION '#226: public.users is missing';
+  END IF;
+  IF to_regprocedure('public.surface_finish_norm(text)') IS NULL THEN
+    RAISE EXCEPTION '#226: public.surface_finish_norm(text) is missing — apply 20260728_surface_finish_library_210.sql first';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 1) Favoris — préférence PERSONNELLE, jamais une donnée métier              */
+/* -------------------------------------------------------------------------- */
+-- Un favori n'engage rien : il n'entre dans aucune spécification, aucune
+-- empreinte, aucun document opposable. Il est donc supprimable sans réserve
+-- (contrairement aux exigences de gamme), et disparaît avec son utilisateur.
+
+CREATE TABLE IF NOT EXISTS public.surface_finish_favorites (
+  user_id     integer     NOT NULL,
+  finish_id   uuid        NOT NULL,
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT surface_finish_favorites_pk PRIMARY KEY (user_id, finish_id),
+  CONSTRAINT surface_finish_favorites_user_fk FOREIGN KEY (user_id)
+    REFERENCES public.users(id) ON DELETE CASCADE,
+  CONSTRAINT surface_finish_favorites_finish_fk FOREIGN KEY (finish_id)
+    REFERENCES public.surface_finishes(id) ON DELETE CASCADE
+);
+
+COMMENT ON TABLE public.surface_finish_favorites IS
+  '#226 — Favoris de bibliothèque, par utilisateur. Préférence d''affichage : n''entre dans aucune spécification ni empreinte.';
+
+-- La liste « mes favoris » se lit par utilisateur ; la PK (user_id, finish_id)
+-- la sert déjà. L'index inverse sert le compteur « combien de personnes ont
+-- mis cette finition en favori » et la purge par finition.
+CREATE INDEX IF NOT EXISTS surface_finish_favorites_finish_idx
+  ON public.surface_finish_favorites (finish_id);
+
+/* -------------------------------------------------------------------------- */
+/* 2) Archivage d'une finition                                                */
+/* -------------------------------------------------------------------------- */
+-- `surface_finishes.statut` acceptait déjà 'ARCHIVEE' et 'SUSPENDUE' par CHECK,
+-- mais AUCUN code n'y menait : seule l'approbation d'une révision écrivait
+-- 'ACTIVE'. On ajoute la traçabilité qui manquait pour que sortir une finition
+-- du référentiel soit un acte daté, signé et motivé — pas un simple UPDATE.
+
+ALTER TABLE public.surface_finishes
+  ADD COLUMN IF NOT EXISTS archived_at        timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS archived_by        integer     NULL,
+  ADD COLUMN IF NOT EXISTS archive_reason     text        NULL,
+  ADD COLUMN IF NOT EXISTS statut_changed_at  timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS statut_changed_by  integer     NULL;
+
+COMMENT ON COLUMN public.surface_finishes.archive_reason IS
+  '#226 — Motif d''archivage. Obligatoire côté service : une finition sort du référentiel avec une raison écrite.';
+
+-- Cohérence : archivée ⇔ horodatée et motivée. Écrite en NOT VALID puis
+-- validée, pour ne jamais bloquer sur un historique qu'on n'a pas relu — ici
+-- les deux bases sont à 0 finition, la validation passe donc à coup sûr, mais
+-- la forme reste la bonne si le patch est rejoué sur une base peuplée.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'surface_finishes_archive_coherent'
+      AND conrelid = 'public.surface_finishes'::regclass
+  ) THEN
+    ALTER TABLE public.surface_finishes
+      ADD CONSTRAINT surface_finishes_archive_coherent CHECK (
+        (statut <> 'ARCHIVEE')
+        OR (archived_at IS NOT NULL AND btrim(COALESCE(archive_reason, '')) <> '')
+      ) NOT VALID;
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'surface_finishes_archive_coherent'
+      AND conrelid = 'public.surface_finishes'::regclass
+      AND NOT convalidated
+  ) THEN
+    BEGIN
+      ALTER TABLE public.surface_finishes VALIDATE CONSTRAINT surface_finishes_archive_coherent;
+    EXCEPTION WHEN check_violation THEN
+      -- Base peuplée d'archives antérieures sans motif : la contrainte reste
+      -- NOT VALID (elle protège les écritures futures) et le verify le signale.
+      RAISE NOTICE '#226: surface_finishes_archive_coherent laissée NOT VALID — des lignes ARCHIVEE sans motif existent.';
+    END;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS surface_finishes_archived_at_idx
+  ON public.surface_finishes (archived_at)
+  WHERE archived_at IS NOT NULL;
+
+/* -------------------------------------------------------------------------- */
+/* 3) Anti-doublon du RÉFÉRENTIEL                                             */
+/* -------------------------------------------------------------------------- */
+-- ADR-0038 tient l'unicité des ARTICLES par `spec_fingerprint`. Rien ne tenait
+-- celle des FINITIONS : `surface_finishes_code_uq` porte sur un code alloué par
+-- le serveur, donc jamais en collision. Dix « anodisation noire » pouvaient
+-- coexister dans la même famille.
+--
+-- L'identité retenue est le triplet (famille, procédé, désignation courte)
+-- NORMALISÉ — accents et casse neutralisés par `surface_finish_norm`, déjà
+-- utilisée par la recherche. Ni la description, ni les synonymes, ni la
+-- désignation longue n'entrent dans l'identité : ce sont des aides de
+-- recherche, deux rédacteurs les écrivent différemment pour la même chose.
+--
+-- L'index est PARTIEL sur `statut <> 'ARCHIVEE'` : archiver une finition libère
+-- son identité, ce qui permet de la remplacer sans détruire l'historique. Deux
+-- créations concurrentes ne peuvent pas passer : la seconde lève 23505, que le
+-- service traduit en 409 exploitable.
+--
+-- La détection de doublon APPROCHANT (« anodisation noire » vs « anodisation
+-- noire mate ») reste un service consultatif : la base ne peut pas arbitrer une
+-- ressemblance, seul le métier le peut.
+
+CREATE UNIQUE INDEX IF NOT EXISTS surface_finishes_identity_uq
+  ON public.surface_finishes (
+    family_code,
+    public.surface_finish_norm(procede),
+    public.surface_finish_norm(designation_courte)
+  )
+  WHERE statut <> 'ARCHIVEE';
+
+COMMENT ON INDEX public.surface_finishes_identity_uq IS
+  '#226 — Doublon strict impossible : même famille + même procédé + même désignation normalisée, hors archives.';
+
+COMMIT;

--- a/db/patches/support/20260729_surface_finish_library_admin_226.preflight.sql
+++ b/db/patches/support/20260729_surface_finish_library_admin_226.preflight.sql
@@ -1,0 +1,61 @@
+-- Preflight 20260729_surface_finish_library_admin_226 — LECTURE SEULE.
+-- Confirme que les pré-requis sont là, que rien du patch ne préexiste, et
+-- surtout que l'index d'identité PEUT être créé sans conflit.
+
+SELECT
+  current_database()                                                        AS database,
+
+  -- 1) Pré-requis : le socle #210 doit être en place.
+  to_regclass('public.surface_finishes') IS NOT NULL                        AS req_finishes,
+  to_regclass('public.surface_finish_revisions') IS NOT NULL                AS req_revisions,
+  to_regclass('public.users') IS NOT NULL                                   AS req_users,
+  to_regprocedure('public.surface_finish_norm(text)') IS NOT NULL           AS req_norm_fn,
+
+  -- 2) Rien du patch ne doit préexister (sinon : déjà appliqué).
+  to_regclass('public.surface_finish_favorites') IS NULL                    AS t_favorites_absent,
+  NOT EXISTS (SELECT 1 FROM information_schema.columns
+              WHERE table_schema='public' AND table_name='surface_finishes'
+                AND column_name='archived_at')                              AS col_archived_at_absent,
+  NOT EXISTS (SELECT 1 FROM pg_indexes
+              WHERE indexname='surface_finishes_identity_uq')               AS idx_identity_absent,
+
+  -- 3) LE point de rupture possible. L'index unique partiel échouerait si des
+  --    doublons stricts existaient déjà. On les compte AVANT d'écrire.
+  --    Attendu : 0. Si > 0, NE PAS APPLIQUER : il faut d'abord arbitrer avec
+  --    le métier lesquels archiver (la requête 4 les liste).
+  (SELECT COUNT(*) FROM (
+     SELECT 1
+     FROM public.surface_finishes
+     WHERE statut <> 'ARCHIVEE'
+     GROUP BY family_code,
+              public.surface_finish_norm(procede),
+              public.surface_finish_norm(designation_courte)
+     HAVING COUNT(*) > 1
+   ) d)                                                                     AS identity_conflicts,
+
+  -- 4) Lignes déjà ARCHIVEE. Avant ce patch la colonne `archive_reason`
+  --    n'existe pas : toute ligne ARCHIVEE est donc SANS motif et laisserait
+  --    `surface_finishes_archive_coherent` en NOT VALID. Attendu : 0 (aucun
+  --    chemin d'archivage n'existait). Ne pas référencer `archive_reason` ici,
+  --    un preflight s'exécute AVANT le patch.
+  (SELECT COUNT(*) FROM public.surface_finishes WHERE statut = 'ARCHIVEE')  AS archived_rows_without_reason,
+
+  -- 5) Volumétrie AVANT : à comparer au verify, doit être IDENTIQUE.
+  (SELECT COUNT(*) FROM public.surface_finishes)                            AS finishes_rows_before,
+  (SELECT COUNT(*) FROM public.surface_finish_revisions)                    AS revisions_rows_before,
+  (SELECT COUNT(*) FROM public.surface_finish_families)                     AS families_rows_before,
+  (SELECT COUNT(*) FROM public.gamme_operation_finitions)                   AS requirements_rows_before,
+  (SELECT COUNT(*) FROM public.articles)                                    AS articles_rows_before;
+
+-- Détail des conflits d'identité éventuels (vide = feu vert).
+SELECT
+  family_code,
+  public.surface_finish_norm(procede)            AS procede_norm,
+  public.surface_finish_norm(designation_courte) AS designation_norm,
+  COUNT(*)                                       AS occurrences,
+  array_agg(code ORDER BY created_at)            AS codes
+FROM public.surface_finishes
+WHERE statut <> 'ARCHIVEE'
+GROUP BY 1, 2, 3
+HAVING COUNT(*) > 1
+ORDER BY occurrences DESC, 1, 2, 3;

--- a/db/patches/support/20260729_surface_finish_library_admin_226.rollback.sql
+++ b/db/patches/support/20260729_surface_finish_library_admin_226.rollback.sql
@@ -1,0 +1,47 @@
+-- Rollback 20260729_surface_finish_library_admin_226.
+--
+-- ⚠️ DESTRUCTIF : `surface_finish_favorites` est SUPPRIMÉE avec son contenu.
+-- Les favoris sont une préférence d'affichage, jamais une donnée opposable :
+-- les perdre ne casse aucune traçabilité industrielle. C'est précisément
+-- pourquoi ce rollback est acceptable — il ne le serait pas pour une exigence
+-- de gamme ou un article.
+--
+-- Les colonnes d'archivage sont retirées elles aussi. Si des finitions ont été
+-- archivées entre-temps, leur MOTIF disparaît alors que leur statut 'ARCHIVEE'
+-- reste : relire d'abord la requête de contrôle en fin de fichier.
+--
+-- À n'exécuter qu'avec autorisation humaine explicite, sauvegarde faite.
+
+BEGIN;
+
+-- 1) Anti-doublon du référentiel.
+DROP INDEX IF EXISTS public.surface_finishes_identity_uq;
+
+-- 2) Archivage. La contrainte part avant les colonnes qu'elle référence.
+ALTER TABLE public.surface_finishes
+  DROP CONSTRAINT IF EXISTS surface_finishes_archive_coherent;
+
+DROP INDEX IF EXISTS public.surface_finishes_archived_at_idx;
+
+ALTER TABLE public.surface_finishes
+  DROP COLUMN IF EXISTS archived_at,
+  DROP COLUMN IF EXISTS archived_by,
+  DROP COLUMN IF EXISTS archive_reason,
+  DROP COLUMN IF EXISTS statut_changed_at,
+  DROP COLUMN IF EXISTS statut_changed_by;
+
+-- 3) Favoris.
+DROP TABLE IF EXISTS public.surface_finish_favorites;
+
+COMMIT;
+
+-- Contrôle post-rollback : tout doit être `false` / absent.
+-- SELECT
+--   to_regclass('public.surface_finish_favorites') IS NULL          AS favorites_dropped,
+--   NOT EXISTS (SELECT 1 FROM pg_indexes
+--               WHERE indexname='surface_finishes_identity_uq')     AS identity_idx_dropped,
+--   NOT EXISTS (SELECT 1 FROM information_schema.columns
+--               WHERE table_schema='public' AND table_name='surface_finishes'
+--                 AND column_name='archived_at')                    AS archive_cols_dropped,
+--   (SELECT COUNT(*) FROM public.surface_finishes
+--    WHERE statut = 'ARCHIVEE')                                     AS orphan_archived_finishes;

--- a/db/patches/support/20260729_surface_finish_library_admin_226.verify.sql
+++ b/db/patches/support/20260729_surface_finish_library_admin_226.verify.sql
@@ -1,0 +1,80 @@
+-- Verify 20260729_surface_finish_library_admin_226 — LECTURE SEULE.
+-- Toutes les colonnes booléennes doivent être `true`.
+-- Les comptes doivent être IDENTIQUES au preflight : aucun backfill.
+
+SELECT
+  current_database()                                                        AS database,
+
+  -- 1) Table des favoris et ses garde-fous.
+  to_regclass('public.surface_finish_favorites') IS NOT NULL                AS t_favorites,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname='surface_finish_favorites_pk'
+            AND conrelid='public.surface_finish_favorites'::regclass)       AS fav_pk,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname='surface_finish_favorites_user_fk'
+            AND conrelid='public.surface_finish_favorites'::regclass
+            AND confdeltype = 'c')                                          AS fav_user_fk_cascade,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname='surface_finish_favorites_finish_fk'
+            AND conrelid='public.surface_finish_favorites'::regclass
+            AND confdeltype = 'c')                                          AS fav_finish_fk_cascade,
+  EXISTS (SELECT 1 FROM pg_indexes
+          WHERE indexname='surface_finish_favorites_finish_idx')            AS fav_reverse_idx,
+
+  -- 2) Colonnes d'archivage réellement posées, et NULLABLES (additif).
+  EXISTS (SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='surface_finishes'
+            AND column_name='archived_at' AND is_nullable='YES')            AS col_archived_at,
+  EXISTS (SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='surface_finishes'
+            AND column_name='archived_by' AND is_nullable='YES')            AS col_archived_by,
+  EXISTS (SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='surface_finishes'
+            AND column_name='archive_reason' AND is_nullable='YES')         AS col_archive_reason,
+  EXISTS (SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='surface_finishes'
+            AND column_name='statut_changed_at')                            AS col_statut_changed_at,
+  EXISTS (SELECT 1 FROM information_schema.columns
+          WHERE table_schema='public' AND table_name='surface_finishes'
+            AND column_name='statut_changed_by')                            AS col_statut_changed_by,
+
+  -- 3) Cohérence d'archivage présente ET validée.
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname='surface_finishes_archive_coherent'
+            AND conrelid='public.surface_finishes'::regclass)               AS chk_archive_present,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname='surface_finishes_archive_coherent'
+            AND conrelid='public.surface_finishes'::regclass
+            AND convalidated)                                               AS chk_archive_validated,
+
+  -- 4) Anti-doublon du référentiel : index unique ET partiel.
+  EXISTS (SELECT 1 FROM pg_indexes
+          WHERE indexname='surface_finishes_identity_uq')                   AS idx_identity,
+  (SELECT indisunique FROM pg_index
+   WHERE indexrelid='public.surface_finishes_identity_uq'::regclass)        AS idx_identity_is_unique,
+  (SELECT pg_get_expr(indpred, indrelid) IS NOT NULL FROM pg_index
+   WHERE indexrelid='public.surface_finishes_identity_uq'::regclass)        AS idx_identity_is_partial,
+  EXISTS (SELECT 1 FROM pg_indexes
+          WHERE indexname='surface_finishes_archived_at_idx')               AS idx_archived_at,
+
+  -- 5) Le socle #210 est intact : rien n'a été retiré.
+  EXISTS (SELECT 1 FROM pg_indexes
+          WHERE indexname='surface_finish_revisions_single_active_uq')      AS idx_210_single_active_intact,
+  EXISTS (SELECT 1 FROM pg_indexes
+          WHERE indexname='articles_traitement_fingerprint_current_uq')     AS idx_210_fingerprint_intact,
+  EXISTS (SELECT 1 FROM pg_constraint
+          WHERE conname='surface_finishes_code_uq')                         AS uq_210_code_intact,
+
+  -- 6) Volumétrie APRÈS : doit égaler le preflight.
+  (SELECT COUNT(*) FROM public.surface_finishes)                            AS finishes_rows_after,
+  (SELECT COUNT(*) FROM public.surface_finish_revisions)                    AS revisions_rows_after,
+  (SELECT COUNT(*) FROM public.surface_finish_families)                     AS families_rows_after,
+  (SELECT COUNT(*) FROM public.gamme_operation_finitions)                   AS requirements_rows_after,
+  (SELECT COUNT(*) FROM public.articles)                                    AS articles_rows_after,
+  (SELECT COUNT(*) FROM public.surface_finish_favorites)                    AS favorites_rows;
+
+-- 7) Ownership : les nouvelles tables doivent appartenir à cerp_app, sinon
+--    l'API tombera en 42501 → 500 (leçon prod du 2026-07-21).
+SELECT tablename, tableowner
+FROM pg_tables
+WHERE schemaname = 'public' AND tablename = 'surface_finish_favorites';

--- a/src/__tests__/surface-finish-226.admin.test.ts
+++ b/src/__tests__/surface-finish-226.admin.test.ts
@@ -1,0 +1,558 @@
+// Administration de la bibliothèque (#226) : contrôle des doublons, favoris,
+// archivage et historique.
+//
+// Ce que ces tests prouvent, et qui n'était couvert nulle part :
+//   - le doublon strict est refusé par la BASE, et traduit en 409 lisible ;
+//   - un favori est PERSONNEL et idempotent (double-clic = pas de 409) ;
+//   - archiver exige `library_retire`, un motif écrit, et refuse tant qu'une
+//     gamme modifiable utilise la finition ;
+//   - l'historique exige `audit_read` et n'invente jamais d'évènement ;
+//   - `/similaires` est déclarée AVANT `/:finishId` (régression de routage).
+
+import request from "supertest";
+import { EventEmitter } from "events";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+  currentRole: { value: "administrateur" as string | null },
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = {
+    on: emitter.on.bind(emitter),
+    query: mocks.poolQuery,
+    connect: mocks.poolConnect,
+  };
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; username: string; email: string; role: string } },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void
+  ) => {
+    if (mocks.currentRole.value === null) {
+      res.status(401).json({ error: "UNAUTHORIZED" });
+      return;
+    }
+    req.user = { id: 42, username: "tester", email: "tester@example.test", role: mocks.currentRole.value };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import app from "../config/app";
+
+const FIN_BASE = "/api/v1/finitions";
+const FINISH_ID = "66666666-6666-4666-8666-666666666666";
+const OTHER_FINISH_ID = "99999999-9999-4999-8999-999999999999";
+const GAMME_ID = "11111111-1111-4111-8111-111111111111";
+
+type Row = Record<string, unknown>;
+const rows = (list: Row[]) => ({ rows: list, rowCount: list.length });
+const empty = () => rows([]);
+
+const finishRow = (overrides: Row = {}): Row => ({
+  id: FINISH_ID,
+  code: "FIN-000001",
+  family_code: "ANODISATION",
+  family_label: "Anodisation",
+  procede: "Anodisation sulfurique",
+  designation_courte: "Anodisation noire 20 µm",
+  designation_longue: null,
+  description: null,
+  synonymes: ["alu noir"],
+  statut: "ACTIVE",
+  current_revision_id: null,
+  created_at: "2026-07-01T08:00:00.000Z",
+  updated_at: "2026-07-20T08:00:00.000Z",
+  archived_at: null,
+  archive_reason: null,
+  favori: false,
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.currentRole.value = "administrateur";
+  mocks.poolConnect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease });
+});
+
+/* -------------------------------------------------------------------------- */
+
+describe("#226 routage", () => {
+  it("expose /finitions/similaires sans le confondre avec une finition", async () => {
+    // Si `/:finishId` gagnait, la requête partirait en `repoGetFinish` et
+    // renverrait 404 (ou 400 sur l'UUID) au lieu d'une liste.
+    // `mockResolvedValue` et non `…Once` : la toute première requête du fichier
+    // peut consommer un appel d'initialisation du pool.
+    mocks.poolQuery.mockResolvedValue(empty());
+
+    const res = await request(app)
+      .get(`${FIN_BASE}/similaires`)
+      .query({ designation_courte: "anodisation noire", family_code: "ANODISATION" });
+
+    expect(res.status).toBe(200);
+    expect(Array.isArray(res.body)).toBe(true);
+  });
+
+  it("expose /stock/articles/similaires sans le confondre avec un article", async () => {
+    mocks.poolQuery.mockResolvedValueOnce(empty());
+
+    const res = await request(app).get("/api/v1/stock/articles/similaires").query({ designation: "vis chc m6" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ items: [], total: 0 });
+  });
+});
+
+describe("#226 contrôle des doublons", () => {
+  it("classe un triplet identique en IDENTIQUE et l'explique", async () => {
+    mocks.poolQuery.mockResolvedValueOnce(
+      rows([
+        {
+          ...finishRow(),
+          score: "0.98",
+          exact_identity: true,
+          same_family: true,
+          synonym_hit: false,
+          norme_hit: false,
+          couleur_hit: false,
+          epaisseur_hit: false,
+          rev_json: null,
+        },
+      ])
+    );
+
+    const res = await request(app).get(`${FIN_BASE}/similaires`).query({
+      designation_courte: "Anodisation noire 20 µm",
+      procede: "Anodisation sulfurique",
+      family_code: "ANODISATION",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+    expect(res.body[0].level).toBe("IDENTIQUE");
+    expect(res.body[0].reasons).toContain("Même famille, même procédé, même désignation");
+  });
+
+  it("écarte un candidat dont le score reste sous le plancher", async () => {
+    // Le SQL a pu le retenir via un synonyme ; la politique tranche et
+    // l'écarte, pour ne pas noyer l'écran de faux voisins.
+    mocks.poolQuery.mockResolvedValueOnce(
+      rows([
+        {
+          ...finishRow({ designation_courte: "Zingage blanc" }),
+          score: "0.05",
+          exact_identity: false,
+          same_family: false,
+          synonym_hit: false,
+          norme_hit: false,
+          couleur_hit: false,
+          epaisseur_hit: false,
+          rev_json: null,
+        },
+      ])
+    );
+
+    const res = await request(app).get(`${FIN_BASE}/similaires`).query({ designation_courte: "anodisation noire" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("n'interroge pas la base quand il n'y a rien à comparer", async () => {
+    const res = await request(app).get(`${FIN_BASE}/similaires`).query({ family_code: "ANODISATION" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+  });
+
+  it("traduit la violation d'unicité de la base en 409 exploitable", async () => {
+    // C'est l'index `surface_finishes_identity_uq` qui parle ici, pas le code.
+    mocks.clientQuery.mockImplementation((sql: unknown) => {
+      const text = String(sql);
+      if (text.includes("surface_finish_families")) return Promise.resolve(rows([{ ok: 1 }]));
+      // Le code FIN-NNNNNN est alloué par le générateur autoritaire avant
+      // l'INSERT : sans cette réponse, le test échouerait AVANT le doublon.
+      if (text.includes("fn_next_issued_code_value")) return Promise.resolve(rows([{ v: "1" }]));
+      if (text.includes("INSERT INTO public.surface_finishes")) {
+        return Promise.reject(Object.assign(new Error("duplicate key"), { code: "23505" }));
+      }
+      return Promise.resolve(empty());
+    });
+    mocks.poolQuery.mockResolvedValue(rows([{ v: "1" }]));
+
+    const res = await request(app).post(FIN_BASE).send({
+      family_code: "ANODISATION",
+      procede: "Anodisation sulfurique",
+      designation_courte: "Anodisation noire 20 µm",
+    });
+
+    expect(res.status).toBe(409);
+  });
+});
+
+describe("#226 favoris", () => {
+  it("pose un favori pour l'utilisateur du jeton", async () => {
+    mocks.poolQuery
+      .mockResolvedValueOnce(rows([{ ok: 1 }])) // la finition existe
+      .mockResolvedValueOnce(empty()); // INSERT ... ON CONFLICT DO NOTHING
+
+    const res = await request(app).post(`${FIN_BASE}/${FINISH_ID}/favori`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ finish_id: FINISH_ID, favori: true });
+
+    const insert = mocks.poolQuery.mock.calls[1];
+    expect(String(insert[0])).toContain("ON CONFLICT (user_id, finish_id) DO NOTHING");
+    // L'identité vient du jeton (42), jamais du corps de la requête.
+    expect(insert[1]).toEqual([42, FINISH_ID]);
+  });
+
+  it("reste idempotent : reposer le même favori ne produit pas d'erreur", async () => {
+    mocks.poolQuery.mockResolvedValue(rows([{ ok: 1 }]));
+
+    const first = await request(app).post(`${FIN_BASE}/${FINISH_ID}/favori`);
+    const second = await request(app).post(`${FIN_BASE}/${FINISH_ID}/favori`);
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(second.body.favori).toBe(true);
+  });
+
+  it("retirer un favori absent n'est pas une erreur", async () => {
+    mocks.poolQuery.mockResolvedValueOnce(rows([{ ok: 1 }])).mockResolvedValueOnce(empty());
+
+    const res = await request(app).delete(`${FIN_BASE}/${FINISH_ID}/favori`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.favori).toBe(false);
+  });
+
+  it("404 sur une finition inexistante plutôt qu'un favori fantôme", async () => {
+    mocks.poolQuery.mockResolvedValueOnce(empty());
+
+    const res = await request(app).post(`${FIN_BASE}/${FINISH_ID}/favori`);
+
+    expect(res.status).toBe(404);
+  });
+
+  it("laisse la production poser un favori : lire suffit, écrire n'est pas requis", async () => {
+    mocks.currentRole.value = "production";
+    mocks.poolQuery.mockResolvedValueOnce(rows([{ ok: 1 }])).mockResolvedValueOnce(empty());
+
+    const res = await request(app).post(`${FIN_BASE}/${FINISH_ID}/favori`);
+
+    expect(res.status).toBe(200);
+  });
+});
+
+describe("#226 archivage", () => {
+  const archiveBody = {
+    motif: "Remplacée par la révision 25 µm",
+    expected_updated_at: "2026-07-20T08:00:00.000Z",
+  };
+
+  it("refuse l'archivage sans la capacité library_retire", async () => {
+    mocks.currentRole.value = "achats";
+
+    const res = await request(app).post(`${FIN_BASE}/${FINISH_ID}/archive`).send(archiveBody);
+
+    expect(res.status).toBe(403);
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
+  it("refuse un motif trop court : sortir du référentiel s'explique", async () => {
+    const res = await request(app)
+      .post(`${FIN_BASE}/${FINISH_ID}/archive`)
+      .send({ motif: "obsolète", expected_updated_at: "2026-07-20T08:00:00.000Z" });
+
+    // 422 : le `validate` du module rend une entité non traitable, pas un 400.
+    expect(res.status).toBe(422);
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
+  it("refuse d'archiver une finition utilisée par une gamme encore modifiable", async () => {
+    mocks.clientQuery.mockImplementation((sql: unknown) => {
+      const text = String(sql);
+      if (text.startsWith("BEGIN") || text.startsWith("ROLLBACK")) return Promise.resolve(empty());
+      if (text.includes("FROM public.surface_finishes WHERE id")) {
+        return Promise.resolve(
+          rows([{ id: FINISH_ID, statut: "ACTIVE", updated_at: "2026-07-20T08:00:00.000Z", code: "FIN-000001" }])
+        );
+      }
+      if (text.includes("gamme_operation_finitions")) {
+        return Promise.resolve(
+          rows([{ gamme_id: GAMME_ID, piece_code: "CAP-100", indice: "C", gamme_statut: "BROUILLON" }])
+        );
+      }
+      return Promise.resolve(empty());
+    });
+
+    const res = await request(app).post(`${FIN_BASE}/${FINISH_ID}/archive`).send(archiveBody);
+
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error).toBe("SURFACE_FINISH_IN_USE");
+    // Rien n'a été écrit.
+    const wrote = mocks.clientQuery.mock.calls.some((call) =>
+      String(call[0]).includes("SET statut = 'ARCHIVEE'")
+    );
+    expect(wrote).toBe(false);
+  });
+
+  it("refuse d'archiver deux fois", async () => {
+    mocks.clientQuery.mockImplementation((sql: unknown) => {
+      const text = String(sql);
+      if (text.includes("FROM public.surface_finishes WHERE id")) {
+        return Promise.resolve(
+          rows([{ id: FINISH_ID, statut: "ARCHIVEE", updated_at: "2026-07-20T08:00:00.000Z", code: "FIN-000001" }])
+        );
+      }
+      return Promise.resolve(empty());
+    });
+
+    const res = await request(app).post(`${FIN_BASE}/${FINISH_ID}/archive`).send(archiveBody);
+
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error).toBe("SURFACE_FINISH_ALREADY_ARCHIVED");
+  });
+
+  it("refuse d'archiver sur une version périmée (verrou optimiste)", async () => {
+    mocks.clientQuery.mockImplementation((sql: unknown) => {
+      const text = String(sql);
+      if (text.includes("FROM public.surface_finishes WHERE id")) {
+        return Promise.resolve(
+          rows([{ id: FINISH_ID, statut: "ACTIVE", updated_at: "2026-07-28T12:00:00.000Z", code: "FIN-000001" }])
+        );
+      }
+      return Promise.resolve(empty());
+    });
+
+    const res = await request(app).post(`${FIN_BASE}/${FINISH_ID}/archive`).send(archiveBody);
+
+    expect(res.status).toBe(409);
+  });
+
+  it("archive avec motif, journalise, et ne touche à aucune gamme", async () => {
+    mocks.clientQuery.mockImplementation((sql: unknown) => {
+      const text = String(sql);
+      if (text.includes("FROM public.surface_finishes WHERE id")) {
+        return Promise.resolve(
+          rows([{ id: FINISH_ID, statut: "ACTIVE", updated_at: "2026-07-20T08:00:00.000Z", code: "FIN-000001" }])
+        );
+      }
+      return Promise.resolve(empty());
+    });
+    // Relecture après commit.
+    mocks.poolQuery
+      .mockResolvedValueOnce(rows([finishRow({ statut: "ARCHIVEE", archived_at: "2026-07-29T10:00:00.000Z" })]))
+      .mockResolvedValueOnce(empty());
+
+    const res = await request(app).post(`${FIN_BASE}/${FINISH_ID}/archive`).send(archiveBody);
+
+    expect(res.status).toBe(200);
+    expect(res.body.statut).toBe("ARCHIVEE");
+
+    const sqlSeen = mocks.clientQuery.mock.calls.map((call) => String(call[0]));
+    expect(sqlSeen.some((sql) => sql.includes("SET statut = 'ARCHIVEE'"))).toBe(true);
+    expect(sqlSeen.some((sql) => sql.includes("COMMIT"))).toBe(true);
+    // Aucune exigence de gamme, aucun article, aucune ligne d'achat n'est touché.
+    expect(sqlSeen.some((sql) => /DELETE FROM public\.gamme_operation_finitions/.test(sql))).toBe(false);
+    expect(sqlSeen.some((sql) => /UPDATE public\.articles\b/.test(sql))).toBe(false);
+  });
+
+  it("réactive en recalculant le statut depuis les révisions", async () => {
+    mocks.clientQuery.mockImplementation((sql: unknown) => {
+      const text = String(sql);
+      if (text.includes("FROM public.surface_finishes WHERE id")) {
+        return Promise.resolve(
+          rows([{ id: FINISH_ID, statut: "ARCHIVEE", updated_at: "2026-07-20T08:00:00.000Z", code: "FIN-000001" }])
+        );
+      }
+      // Aucune révision ACTIVE → retour en BROUILLON, pas en ACTIVE.
+      if (text.includes("statut = 'ACTIVE' LIMIT 1")) return Promise.resolve(empty());
+      return Promise.resolve(empty());
+    });
+    mocks.poolQuery.mockResolvedValueOnce(rows([finishRow({ statut: "BROUILLON" })])).mockResolvedValueOnce(empty());
+
+    const res = await request(app)
+      .post(`${FIN_BASE}/${FINISH_ID}/reactivate`)
+      .send({ motif: "Reprise du procédé chez un nouveau sous-traitant", expected_updated_at: "2026-07-20T08:00:00.000Z" });
+
+    expect(res.status).toBe(200);
+    const update = mocks.clientQuery.mock.calls.find((call) => String(call[0]).includes("archived_at = NULL"));
+    expect(update).toBeDefined();
+    expect(update?.[1]).toContain("BROUILLON");
+  });
+
+  it("refuse la réactivation si l'identité a été reprise entre-temps", async () => {
+    mocks.clientQuery.mockImplementation((sql: unknown) => {
+      const text = String(sql);
+      if (text.includes("FROM public.surface_finishes WHERE id")) {
+        return Promise.resolve(
+          rows([{ id: FINISH_ID, statut: "ARCHIVEE", updated_at: "2026-07-20T08:00:00.000Z", code: "FIN-000001" }])
+        );
+      }
+      if (text.includes("archived_at = NULL")) {
+        return Promise.reject(Object.assign(new Error("duplicate key"), { code: "23505" }));
+      }
+      return Promise.resolve(empty());
+    });
+
+    const res = await request(app)
+      .post(`${FIN_BASE}/${FINISH_ID}/reactivate`)
+      .send({ motif: "Reprise du procédé historique", expected_updated_at: "2026-07-20T08:00:00.000Z" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error).toBe("SURFACE_FINISH_IDENTITY_TAKEN");
+  });
+});
+
+describe("#226 historique", () => {
+  it("exige audit_read", async () => {
+    mocks.currentRole.value = "achats";
+
+    const res = await request(app).get(`${FIN_BASE}/${FINISH_ID}/historique`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("renvoie une liste vide sans inventer d'évènement", async () => {
+    mocks.poolQuery
+      .mockResolvedValueOnce(rows([{ ok: 1 }])) // la finition existe
+      .mockResolvedValueOnce(empty()); // aucun log
+
+    const res = await request(app).get(`${FIN_BASE}/${FINISH_ID}/historique`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("rend l'identifiant bigint en nombre et n'expose pas l'e-mail", async () => {
+    mocks.poolQuery.mockResolvedValueOnce(rows([{ ok: 1 }])).mockResolvedValueOnce(
+      rows([
+        {
+          id: "9007199254740000",
+          created_at: "2026-07-29T09:00:00.000Z",
+          action: "finitions.archive",
+          entity_type: "surface_finish",
+          entity_id: FINISH_ID,
+          user_id: 42,
+          user_label: "Jean Méthodes",
+          details: { motif: "Remplacée" },
+        },
+      ])
+    );
+
+    const res = await request(app).get(`${FIN_BASE}/${FINISH_ID}/historique`);
+
+    expect(res.status).toBe(200);
+    expect(typeof res.body[0].id).toBe("number");
+    expect(res.body[0].user_label).toBe("Jean Méthodes");
+    expect(JSON.stringify(res.body)).not.toContain("@");
+  });
+
+  it("404 sur une finition inexistante", async () => {
+    mocks.poolQuery.mockResolvedValueOnce(empty());
+
+    const res = await request(app).get(`${FIN_BASE}/${OTHER_FINISH_ID}/historique`);
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("#226 recherche de bibliothèque", () => {
+  it("exclut les archives par défaut et joint le favori sur l'utilisateur du jeton", async () => {
+    mocks.poolQuery.mockResolvedValueOnce(rows([{ total: 0 }])).mockResolvedValueOnce(empty());
+
+    const res = await request(app).get(FIN_BASE);
+
+    expect(res.status).toBe(200);
+    const countSql = String(mocks.poolQuery.mock.calls[0][0]);
+    expect(countSql).toContain("f.statut <> 'ARCHIVEE'");
+    expect(countSql).toContain("surface_finish_favorites");
+    expect(mocks.poolQuery.mock.calls[0][1]).toContain(42);
+  });
+
+  it("montre les archives quand on les demande explicitement", async () => {
+    mocks.poolQuery.mockResolvedValueOnce(rows([{ total: 0 }])).mockResolvedValueOnce(empty());
+
+    await request(app).get(FIN_BASE).query({ include_archived: "true" });
+
+    expect(String(mocks.poolQuery.mock.calls[0][0])).not.toContain("f.statut <> 'ARCHIVEE'");
+  });
+
+  it("filtre sur mes favoris seulement", async () => {
+    mocks.poolQuery.mockResolvedValueOnce(rows([{ total: 0 }])).mockResolvedValueOnce(empty());
+
+    await request(app).get(FIN_BASE).query({ only_favorites: "true" });
+
+    expect(String(mocks.poolQuery.mock.calls[0][0])).toContain("fav.user_id IS NOT NULL");
+  });
+});
+
+describe("#226 articles similaires", () => {
+  it("ignore totalement le stock : « manquant » = absent du référentiel", async () => {
+    mocks.poolQuery.mockResolvedValueOnce(empty());
+
+    await request(app).get("/api/v1/stock/articles/similaires").query({ designation: "vis chc m6" });
+
+    const sql = String(mocks.poolQuery.mock.calls[0][0]);
+    expect(sql).not.toMatch(/stock_balance|qty_available|quantite/i);
+  });
+
+  it("remonte un article archivé et dit qu'il faut le réactiver, pas le recréer", async () => {
+    mocks.poolQuery.mockResolvedValueOnce(
+      rows([
+        {
+          id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+          code: "ART-ACHATP-000312",
+          designation: "VIS CHC M6X20 INOX A2",
+          designation_secondary: null,
+          article_category: "achat",
+          article_categories: ["achat_revente"],
+          family_code: "ACHATP",
+          piece_technique_id: null,
+          piece_code: null,
+          status: "VALIDE",
+          is_active: false,
+          archived_at: "2026-05-02T08:00:00.000Z",
+          score: "0.71",
+          exact_designation: false,
+          same_category: true,
+          same_family: false,
+          same_piece: false,
+        },
+      ])
+    );
+
+    const res = await request(app).get("/api/v1/stock/articles/similaires").query({ designation: "vis chc m6x20" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.items[0].level).toBe("TRES_PROCHE");
+    expect(res.body.items[0].reasons).toContain("Archivé — à réactiver plutôt qu'à recréer");
+  });
+
+  it("refuse une désignation trop courte plutôt que de renvoyer le référentiel", async () => {
+    const res = await request(app).get("/api/v1/stock/articles/similaires").query({ designation: "v" });
+
+    expect(res.status).toBe(400);
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/module/stock/controllers/stock.controller.ts
+++ b/src/module/stock/controllers/stock.controller.ts
@@ -24,6 +24,7 @@ import {
   listAnalyticsQuerySchema,
   listInventorySessionsQuerySchema,
   listArticlesQuerySchema,
+  similarArticlesQuerySchema,
   listArticleFamiliesQuerySchema,
   listMatiereEtatsQuerySchema,
   listMatiereNuancesQuerySchema,
@@ -118,6 +119,7 @@ import {
   getStockMovementSVC,
   listStockArticleDocumentsSVC,
   listStockArticlesSVC,
+  findSimilarStockArticlesSVC,
   listStockBalancesSVC,
   listStockEmplacementsSVC,
   listStockLotsSVC,
@@ -326,6 +328,25 @@ export const listStockArticles: RequestHandler = async (req, res, next) => {
     }
     const out = await listStockArticlesSVC(parsed.data);
     res.json(out);
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * #226 — « Existe-t-il déjà un article comme celui-ci ? » posée AVANT création.
+ * Lecture pure : `requireStockCapability("read")` suffit, et aucune écriture
+ * n'est émise.
+ */
+export const listSimilarStockArticles: RequestHandler = async (req, res, next) => {
+  try {
+    const parsed = similarArticlesQuerySchema.safeParse(req.query);
+    if (!parsed.success) {
+      res.status(400).json({ error: parsed.error.issues?.[0]?.message ?? "Invalid query" });
+      return;
+    }
+    const items = await findSimilarStockArticlesSVC(parsed.data);
+    res.json({ items, total: items.length });
   } catch (err) {
     next(err);
   }

--- a/src/module/stock/repository/stock-article-similarity.repository.ts
+++ b/src/module/stock/repository/stock-article-similarity.repository.ts
@@ -1,0 +1,152 @@
+// #226 — Détection d'articles similaires avant création.
+//
+// Objectif : qu'on ne crée plus « VIS CHC M6 » quand « VIS CHC M6X20 INOX A2 »
+// existe déjà. Purement CONSULTATIF — cette recherche ne crée rien, ne verrouille
+// rien, et ne bloque aucune création. La barrière dure reste l'unicité du code
+// article et, pour les prestations de traitement, `spec_fingerprint`.
+//
+// « Article manquant » = ABSENT DU RÉFÉRENTIEL. Ni la quantité en stock, ni la
+// disponibilité n'entrent ici : un article à zéro existe, il ne se recrée pas.
+
+import db from "../../../config/database";
+import type { SimilarArticlesQueryDTO } from "../validators/stock.validators";
+
+export type SimilarArticleMatch = {
+  id: string;
+  code: string;
+  designation: string;
+  designation_secondary: string | null;
+  article_category: string;
+  article_categories: string[];
+  family_code: string | null;
+  piece_technique_id: string | null;
+  piece_code: string | null;
+  status: string | null;
+  is_active: boolean;
+  archived_at: string | null;
+  score: number;
+  level: "IDENTIQUE" | "TRES_PROCHE" | "PROCHE";
+  reasons: string[];
+};
+
+/** Aligné sur `SIMILARITY_FLOOR` du module Finitions : même notion, même seuil. */
+const SIMILARITY_FLOOR = 0.34;
+const VERY_CLOSE_FLOOR = 0.62;
+
+type Row = {
+  id: string;
+  code: string;
+  designation: string;
+  designation_secondary: string | null;
+  article_category: string;
+  article_categories: string[] | null;
+  family_code: string | null;
+  piece_technique_id: string | null;
+  piece_code: string | null;
+  status: string | null;
+  is_active: boolean;
+  archived_at: string | null;
+  score: string | number;
+  exact_designation: boolean;
+  same_category: boolean;
+  same_family: boolean;
+  same_piece: boolean;
+};
+
+export async function repoFindSimilarArticles(query: SimilarArticlesQueryDTO): Promise<SimilarArticleMatch[]> {
+  const res = await db.query<Row>(
+    `WITH candidat AS (
+       SELECT
+         a.id, a.code, a.designation, a.designation_secondary,
+         a.article_category, a.family_code, a.piece_technique_id,
+         a.status, a.is_active, a.archived_at,
+         -- La désignation secondaire compte : c'est souvent là qu'est écrit le
+         -- vrai libellé fournisseur. On garde le meilleur des deux.
+         GREATEST(
+           similarity(lower(public.unaccent(a.designation)), lower(public.unaccent($1))),
+           COALESCE(similarity(lower(public.unaccent(a.designation_secondary)), lower(public.unaccent($1))), 0)
+         ) AS base_score,
+         (lower(public.unaccent(btrim(a.designation))) = lower(public.unaccent(btrim($1)))) AS exact_designation,
+         ($2::text IS NOT NULL AND a.article_category = $2::text) AS same_category,
+         ($3::text IS NOT NULL AND a.family_code = $3::text) AS same_family,
+         ($4::uuid IS NOT NULL AND a.piece_technique_id = $4::uuid) AS same_piece
+       FROM public.articles a
+       WHERE ($5::text IS NULL OR EXISTS (
+                SELECT 1 FROM public.article_category_link acl
+                WHERE acl.article_id = a.id AND acl.category_code = $5::text
+              ))
+     )
+     SELECT
+       c.id::text AS id, c.code, c.designation, c.designation_secondary,
+       c.article_category, c.family_code,
+       c.piece_technique_id::text AS piece_technique_id,
+       pt.code_piece AS piece_code,
+       c.status, c.is_active, c.archived_at::text AS archived_at,
+       c.exact_designation, c.same_category, c.same_family, c.same_piece,
+       COALESCE(acl.categories, ARRAY[]::text[]) AS article_categories,
+       LEAST(
+         1.0,
+         c.base_score
+         + CASE WHEN c.same_category THEN 0.10 ELSE 0 END
+         + CASE WHEN c.same_family   THEN 0.10 ELSE 0 END
+         -- Deux articles sur la MÊME pièce technique sont presque toujours le
+         -- même besoin exprimé deux fois : c'est le signal le plus fort.
+         + CASE WHEN c.same_piece    THEN 0.30 ELSE 0 END
+       )::numeric AS score
+     FROM candidat c
+     LEFT JOIN public.pieces_techniques pt ON pt.id = c.piece_technique_id
+     LEFT JOIN LATERAL (
+       SELECT array_agg(l.category_code ORDER BY l.is_primary DESC, l.category_code) AS categories
+       FROM public.article_category_link l
+       WHERE l.article_id = c.id
+     ) acl ON true
+     WHERE c.exact_designation OR c.base_score >= $6::real
+     ORDER BY c.exact_designation DESC, score DESC, c.designation
+     LIMIT $7`,
+    [
+      query.designation,
+      query.article_category ?? null,
+      query.family_code ?? null,
+      query.piece_technique_id ?? null,
+      query.business_category ?? null,
+      SIMILARITY_FLOOR,
+      query.limit,
+    ]
+  );
+
+  return res.rows.map((row) => {
+    const score = typeof row.score === "string" ? Number(row.score) : row.score;
+    const level: SimilarArticleMatch["level"] = row.exact_designation
+      ? "IDENTIQUE"
+      : score >= VERY_CLOSE_FLOOR
+        ? "TRES_PROCHE"
+        : "PROCHE";
+
+    const reasons: string[] = [];
+    if (row.exact_designation) reasons.push("Désignation identique");
+    if (row.same_piece) reasons.push("Même pièce technique");
+    if (row.same_category) reasons.push("Même catégorie");
+    if (row.same_family) reasons.push("Même famille");
+    // Un article archivé ou désactivé se réactive ; il ne se recrée pas.
+    if (row.archived_at) reasons.push("Archivé — à réactiver plutôt qu'à recréer");
+    else if (!row.is_active) reasons.push("Inactif — à réactiver plutôt qu'à recréer");
+
+    return {
+      id: row.id,
+      code: row.code,
+      designation: row.designation,
+      designation_secondary: row.designation_secondary,
+      article_category: row.article_category,
+      article_categories: row.article_categories ?? [],
+      family_code: row.family_code,
+      piece_technique_id: row.piece_technique_id,
+      piece_code: row.piece_code,
+      status: row.status,
+      is_active: row.is_active,
+      archived_at: row.archived_at,
+      score: Math.round(score * 1000) / 1000,
+      level,
+      reasons,
+    };
+  });
+}

--- a/src/module/stock/routes/stock.routes.ts
+++ b/src/module/stock/routes/stock.routes.ts
@@ -46,6 +46,7 @@ import {
   listStockInventorySessions,
   listStockArticleDocuments,
   listStockArticles,
+  listSimilarStockArticles,
   listStockBalances,
   listStockEmplacements,
   listStockLots,
@@ -126,6 +127,9 @@ router.post("/matiere-sous-etats", requireArticleWrite, createStockMatiereSousEt
 router.get("/articles", requireStockCapability("read"), listStockArticles);
 router.get("/articles/kpis", requireStockCapability("read"), getStockArticlesKpis);
 router.get("/articles/code-preview", requireStockCapability("read"), previewStockArticleCode);
+// #226 — Déclarée AVANT `/articles/:id` : sans cela, « similaires » serait lu
+// comme un identifiant d'article.
+router.get("/articles/similaires", requireStockCapability("read"), listSimilarStockArticles);
 router.post("/articles", requireArticleWrite, createStockArticle);
 router.get("/articles/:id", requireStockCapability("read"), getStockArticle);
 router.patch("/articles/:id", requireArticleWrite, updateStockArticle);

--- a/src/module/stock/services/stock.service.ts
+++ b/src/module/stock/services/stock.service.ts
@@ -40,6 +40,7 @@ import type {
   ListAnalyticsQueryDTO,
   ListInventorySessionsQueryDTO,
   ListArticlesQueryDTO,
+  SimilarArticlesQueryDTO,
   ListArticleVersionsQueryDTO,
   ListArticleWhereUsedQueryDTO,
   ListArticleFamiliesQueryDTO,
@@ -134,6 +135,10 @@ import {
   repoDeactivateMagasin,
   repoActivateMagasin,
 } from "../repository/stock.repository";
+import {
+  repoFindSimilarArticles,
+  type SimilarArticleMatch,
+} from "../repository/stock-article-similarity.repository";
 
 export async function resolveStockOpeningReferencesSVC(
   inputs: StockOpeningReferenceInput[]
@@ -208,6 +213,11 @@ export async function closeStockInventorySessionSVC(
 
 export async function listStockArticlesSVC(filters: ListArticlesQueryDTO) {
   return repoListArticles(filters);
+}
+
+/** #226 — Consultatif : ne crée rien, ne verrouille rien, ne bloque rien. */
+export async function findSimilarStockArticlesSVC(query: SimilarArticlesQueryDTO): Promise<SimilarArticleMatch[]> {
+  return repoFindSimilarArticles(query);
 }
 
 export async function getStockArticleSVC(id: string, includeCosts = false): Promise<StockArticleDetail | null> {

--- a/src/module/stock/validators/stock.validators.ts
+++ b/src/module/stock/validators/stock.validators.ts
@@ -97,6 +97,28 @@ export const listArticlesQuerySchema = z.object({
 
 export type ListArticlesQueryDTO = z.infer<typeof listArticlesQuerySchema>;
 
+/**
+ * #226 — Détection d'articles similaires AVANT création.
+ *
+ * « Article manquant » veut dire ABSENT DU RÉFÉRENTIEL, jamais « stock à zéro » :
+ * cette recherche ignore donc totalement les quantités et interroge la seule
+ * table `articles`. Les articles archivés ou inactifs SONT retournés — « il
+ * existe déjà mais il a été archivé » est précisément ce qu'il faut savoir
+ * avant d'en créer un second.
+ */
+export const similarArticlesQuerySchema = z
+  .object({
+    designation: z.string().trim().min(2, "Deux caractères au minimum.").max(300),
+    article_category: articleCategorySchema.optional(),
+    /** CAT métier (`article_category_link`), plus fine que la catégorie primaire. */
+    business_category: z.string().trim().min(1).max(60).optional(),
+    family_code: z.string().trim().min(1).max(40).optional(),
+    piece_technique_id: z.string().uuid().optional(),
+    limit: z.coerce.number().int().min(1).max(20).optional().default(8),
+  })
+  .strict();
+export type SimilarArticlesQueryDTO = z.infer<typeof similarArticlesQuerySchema>;
+
 export const listArticleFamiliesQuerySchema = z.object({
   category: articleCategorySchema.optional(),
 });

--- a/src/module/surface-finish/controllers/surface-finish.controller.ts
+++ b/src/module/surface-finish/controllers/surface-finish.controller.ts
@@ -8,25 +8,34 @@ import type { Request, RequestHandler } from "express";
 import { HttpError } from "../../../utils/httpError";
 import type { AuditContext } from "../../pieces-techniques/repository/pieces-techniques.repository";
 import {
+  archiveFinishSVC,
   attachRevisionDocumentSVC,
   capabilitiesSVC,
   confirmOperationFinishSVC,
   createFinishDraftSVC,
   createRevisionSVC,
   detachOperationFinishSVC,
+  findSimilarFinishesSVC,
   getFinishSVC,
   getOperationFinishSVC,
   listFinishesSVC,
   listFinishFamiliesSVC,
+  listFinishHistorySVC,
   listRevisionDocumentsSVC,
   previewOperationFinishSVC,
+  reactivateFinishSVC,
   revisionImpactSVC,
+  setFinishFavoriteSVC,
   transitionRevisionSVC,
   updateFinishDraftSVC,
   updateRevisionSVC,
   type Actor,
 } from "../services/surface-finish.service";
-import type { ListFinishesQueryDTO } from "../validators/surface-finish.validators";
+import type {
+  FinishHistoryQueryDTO,
+  ListFinishesQueryDTO,
+  SimilarFinishesQueryDTO,
+} from "../validators/surface-finish.validators";
 
 function requireUser(req: Request): { id: number; role: string | null } {
   const user = req.user;
@@ -96,7 +105,8 @@ export const listFinishFamilies: RequestHandler = async (_req, res, next) => {
 
 export const listFinishes: RequestHandler = async (req, res, next) => {
   try {
-    res.json(await listFinishesSVC(req.query as unknown as ListFinishesQueryDTO));
+    // L'identité du lecteur vient du jeton : c'est elle qui décide de `favori`.
+    res.json(await listFinishesSVC(req.query as unknown as ListFinishesQueryDTO, requireUser(req).id));
   } catch (err) {
     next(err);
   }
@@ -104,7 +114,65 @@ export const listFinishes: RequestHandler = async (req, res, next) => {
 
 export const getFinish: RequestHandler = async (req, res, next) => {
   try {
-    res.json(await getFinishSVC(routeParam(req, "finishId")));
+    res.json(await getFinishSVC(routeParam(req, "finishId"), requireUser(req).id));
+  } catch (err) {
+    next(err);
+  }
+};
+
+/* -------------------------------------------------------------------------- */
+/* #226 — Doublons, favoris, archivage, historique                            */
+/* -------------------------------------------------------------------------- */
+
+export const listSimilarFinishes: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(await findSimilarFinishesSVC(req.query as unknown as SimilarFinishesQueryDTO));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const addFinishFavorite: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(await setFinishFavoriteSVC(routeParam(req, "finishId"), actorOf(req), true));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const removeFinishFavorite: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(await setFinishFavoriteSVC(routeParam(req, "finishId"), actorOf(req), false));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const archiveFinish: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(await archiveFinishSVC(routeParam(req, "finishId"), req.body, actorOf(req), buildAuditContext(req)));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const reactivateFinish: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(await reactivateFinishSVC(routeParam(req, "finishId"), req.body, actorOf(req), buildAuditContext(req)));
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const listFinishHistory: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(
+      await listFinishHistorySVC(
+        routeParam(req, "finishId"),
+        req.query as unknown as FinishHistoryQueryDTO,
+        actorOf(req)
+      )
+    );
   } catch (err) {
     next(err);
   }

--- a/src/module/surface-finish/domain/surface-finish-policy.ts
+++ b/src/module/surface-finish/domain/surface-finish-policy.ts
@@ -198,6 +198,76 @@ export function statusIsHistoricalOnly(status: SurfaceFinishStatus): boolean {
 }
 
 /* -------------------------------------------------------------------------- */
+/* 2 bis) Archivage d'une FINITION (#226)                                     */
+/* -------------------------------------------------------------------------- */
+//
+// `STATUS_TRANSITIONS` ci-dessus gouverne les RÉVISIONS. Archiver la finition
+// elle-même est un autre acte : on sort une entrée du référentiel sans toucher
+// à ce que les gammes ont déjà figé. Les deux ne se confondent pas.
+
+/** Une finition déjà archivée ne se réarchive pas ; le motif est obligatoire. */
+export function assertFinishArchivable(status: SurfaceFinishStatus): void {
+  if (status === "ARCHIVEE") {
+    throw new HttpError(409, "SURFACE_FINISH_ALREADY_ARCHIVED", "Cette finition est déjà archivée.");
+  }
+}
+
+export function assertFinishReactivable(status: SurfaceFinishStatus): void {
+  if (status !== "ARCHIVEE") {
+    throw new HttpError(
+      409,
+      "SURFACE_FINISH_NOT_ARCHIVED",
+      "Cette finition n'est pas archivée : il n'y a rien à réactiver."
+    );
+  }
+}
+
+/**
+ * Statut retrouvé en sortie d'archive. On ne restaure PAS le statut d'avant :
+ * il n'a pas été conservé et le déduire d'une colonne effacée serait une
+ * invention. On le recalcule depuis la seule chose qui fasse foi — les
+ * révisions existantes.
+ */
+export function statusAfterReactivation(hasActiveRevision: boolean): SurfaceFinishStatus {
+  return hasActiveRevision ? "ACTIVE" : "BROUILLON";
+}
+
+/* -------------------------------------------------------------------------- */
+/* 2 ter) Similarité — contrôle des doublons du RÉFÉRENTIEL (#226)            */
+/* -------------------------------------------------------------------------- */
+//
+// La base interdit le doublon STRICT (index `surface_finishes_identity_uq` :
+// même famille + même procédé + même désignation, normalisés). Elle ne peut pas
+// arbitrer « anodisation noire » contre « anodisation noire mate » : seul le
+// métier le peut. D'où un service CONSULTATIF, jamais bloquant.
+
+export const SIMILARITY_LEVELS = ["IDENTIQUE", "TRES_PROCHE", "PROCHE"] as const;
+export type SimilarityLevel = (typeof SIMILARITY_LEVELS)[number];
+
+/** En deçà, deux libellés n'ont plus rien à voir : ne pas encombrer l'écran. */
+export const SIMILARITY_FLOOR = 0.34;
+const VERY_CLOSE_FLOOR = 0.62;
+
+/**
+ * `exactIdentity` vient de la base (le triplet normalisé), pas du score : deux
+ * libellés identiques à la casse près SONT le même, quel que soit le trigramme.
+ */
+export function classifySimilarity(score: number, exactIdentity: boolean): SimilarityLevel | null {
+  if (exactIdentity) return "IDENTIQUE";
+  if (!Number.isFinite(score) || score < SIMILARITY_FLOOR) return null;
+  return score >= VERY_CLOSE_FLOOR ? "TRES_PROCHE" : "PROCHE";
+}
+
+export const SIMILARITY_LEVEL_LABELS: Record<SimilarityLevel, string> = {
+  IDENTIQUE: "Doublon : cette finition existe déjà",
+  TRES_PROCHE: "Très proche — vérifiez avant de créer",
+  PROCHE: "Proche — peut-être la même prestation",
+};
+
+/** Motif d'archivage : assez long pour dire pourquoi, pas un simple « ok ». */
+export const ARCHIVE_REASON_MIN_LENGTH = 10;
+
+/* -------------------------------------------------------------------------- */
 /* 3) Gammes — modifiabilité                                                  */
 /* -------------------------------------------------------------------------- */
 

--- a/src/module/surface-finish/repository/surface-finish-admin.repository.ts
+++ b/src/module/surface-finish/repository/surface-finish-admin.repository.ts
@@ -1,0 +1,496 @@
+// #226 — Administration de la bibliothèque : favoris, archivage, historique et
+// contrôle des doublons.
+//
+// Séparé de `surface-finish-library.repository.ts` (déjà 900 lignes) parce que
+// ce sont d'autres actes : la lecture/écriture d'une définition technique d'un
+// côté, la gestion du référentiel de l'autre.
+
+import db from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import type { AuditContext } from "../../pieces-techniques/repository/pieces-techniques.repository";
+import {
+  assertFinishArchivable,
+  assertFinishReactivable,
+  assertOptimisticVersion,
+  classifySimilarity,
+  SIMILARITY_FLOOR,
+  statusAfterReactivation,
+  type SurfaceFinishStatus,
+} from "../domain/surface-finish-policy";
+import type {
+  ArchiveFinishBodyDTO,
+  FinishHistoryQueryDTO,
+  ReactivateFinishBodyDTO,
+  SimilarFinishesQueryDTO,
+} from "../validators/surface-finish.validators";
+import type {
+  SurfaceFinishDetail,
+  SurfaceFinishHistoryEntry,
+  SurfaceFinishSimilarMatch,
+} from "../types/surface-finish.types";
+import {
+  insertFinishAudit,
+  mapRevision,
+  repoGetFinish,
+  revisionColumns,
+  toRevisionSummary,
+  type RevisionRow,
+} from "./surface-finish-library.repository";
+
+/* -------------------------------------------------------------------------- */
+/* Favoris                                                                     */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Poser/retirer un favori est idempotent par construction : `ON CONFLICT DO
+ * NOTHING` et un `DELETE` qui ne trouve rien ne sont pas des erreurs. Un
+ * double-clic sur l'étoile ne doit jamais produire un 409.
+ *
+ * Pas d'audit ici, délibérément : un favori n'engage rien et journaliser chaque
+ * clic d'étoile noierait `erp_audit_logs`, qui sert à retracer des actes
+ * opposables.
+ */
+export async function repoSetFinishFavorite(
+  finishId: string,
+  userId: number,
+  favorite: boolean
+): Promise<{ finish_id: string; favori: boolean }> {
+  const exists = await db.query(`SELECT 1 FROM public.surface_finishes WHERE id = $1::uuid`, [finishId]);
+  if (exists.rowCount === 0) throw new HttpError(404, "NOT_FOUND", "Finition introuvable.");
+
+  if (favorite) {
+    await db.query(
+      `INSERT INTO public.surface_finish_favorites (user_id, finish_id)
+       VALUES ($1::integer, $2::uuid)
+       ON CONFLICT (user_id, finish_id) DO NOTHING`,
+      [userId, finishId]
+    );
+  } else {
+    await db.query(`DELETE FROM public.surface_finish_favorites WHERE user_id = $1::integer AND finish_id = $2::uuid`, [
+      userId,
+      finishId,
+    ]);
+  }
+
+  return { finish_id: finishId, favori: favorite };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Archivage                                                                   */
+/* -------------------------------------------------------------------------- */
+
+type FinishLockRow = { id: string; statut: SurfaceFinishStatus; updated_at: string; code: string };
+
+/**
+ * Archiver une finition la sort du référentiel SANS toucher à ce que les gammes
+ * ont déjà figé : une exigence de gamme conserve sa `finish_revision_id` et un
+ * article validé garde sa spécification. C'est tout l'intérêt du modèle
+ * versionné d'ADR-0038 — archiver n'est pas réécrire l'histoire.
+ *
+ * En revanche on REFUSE d'archiver une finition encore utilisée par une gamme
+ * modifiable : là, l'archivage serait subi par quelqu'un qui est en train de
+ * travailler dessus. Les gammes APPLICABLE, elles, n'empêchent rien : elles
+ * sont figées et leur exigence reste lisible.
+ */
+export async function repoArchiveFinish(
+  finishId: string,
+  body: ArchiveFinishBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishDetail> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+
+    const cur = await client.query<FinishLockRow>(
+      `SELECT id::text AS id, statut, updated_at::text AS updated_at, code
+       FROM public.surface_finishes WHERE id = $1::uuid FOR UPDATE`,
+      [finishId]
+    );
+    const current = cur.rows[0];
+    if (!current) throw new HttpError(404, "NOT_FOUND", "Finition introuvable.");
+
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: current.updated_at,
+      label: "Cette finition",
+    });
+    assertFinishArchivable(current.statut);
+
+    const blocking = await client.query<{ gamme_id: string; piece_code: string; indice: string; gamme_statut: string }>(
+      `SELECT DISTINCT
+         gof.gamme_id::text AS gamme_id,
+         COALESCE(pt.code_piece, '?') AS piece_code,
+         COALESCE(ptv.indice, '?')    AS indice,
+         g.statut                     AS gamme_statut
+       FROM public.gamme_operation_finitions gof
+       JOIN public.surface_finish_revisions sfr ON sfr.id = gof.finish_revision_id
+       JOIN public.gammes g ON g.id = gof.gamme_id
+       LEFT JOIN public.piece_technique_versions ptv ON ptv.id = gof.piece_technique_version_id
+       LEFT JOIN public.pieces_techniques pt ON pt.id = ptv.piece_technique_id
+       WHERE sfr.finish_id = $1::uuid
+         AND g.statut IN ('BROUILLON','EN_VALIDATION')
+       LIMIT 20`,
+      [finishId]
+    );
+
+    if (blocking.rowCount && blocking.rowCount > 0) {
+      throw new HttpError(
+        409,
+        "SURFACE_FINISH_IN_USE",
+        `Cette finition est utilisée par ${blocking.rowCount} gamme(s) encore modifiable(s). Retirez-la de ces gammes avant de l'archiver.`,
+        { gammes: blocking.rows }
+      );
+    }
+
+    await client.query(
+      `UPDATE public.surface_finishes
+       SET statut = 'ARCHIVEE',
+           archived_at = now(),
+           archived_by = $2::integer,
+           archive_reason = $3,
+           statut_changed_at = now(),
+           statut_changed_by = $2::integer,
+           updated_at = now(),
+           updated_by = $2::integer
+       WHERE id = $1::uuid`,
+      [finishId, audit.user_id, body.motif]
+    );
+
+    await insertFinishAudit(client, audit, "finitions.archive", "surface_finish", finishId, {
+      code: current.code,
+      from: current.statut,
+      to: "ARCHIVEE",
+      motif: body.motif,
+    });
+
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  // Relecture APRÈS le commit (leçon GED : lire par le pool depuis une
+  // transaction ouverte ne verrait rien).
+  const out = await repoGetFinish(finishId, audit.user_id);
+  if (!out) throw new Error("Failed to read archived finish");
+  return out;
+}
+
+/**
+ * Sortir d'archive. Le statut n'est pas « restauré » : il est RECALCULÉ depuis
+ * les révisions, seule chose qui fasse foi. La désarchivage peut échouer en
+ * `23505` si une autre finition a repris l'identité libérée entre-temps — c'est
+ * le comportement voulu, traduit en 409 lisible.
+ */
+export async function repoReactivateFinish(
+  finishId: string,
+  body: ReactivateFinishBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishDetail> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+
+    const cur = await client.query<FinishLockRow>(
+      `SELECT id::text AS id, statut, updated_at::text AS updated_at, code
+       FROM public.surface_finishes WHERE id = $1::uuid FOR UPDATE`,
+      [finishId]
+    );
+    const current = cur.rows[0];
+    if (!current) throw new HttpError(404, "NOT_FOUND", "Finition introuvable.");
+
+    assertOptimisticVersion({
+      expectedUpdatedAt: body.expected_updated_at,
+      currentUpdatedAt: current.updated_at,
+      label: "Cette finition",
+    });
+    assertFinishReactivable(current.statut);
+
+    const active = await client.query(
+      `SELECT 1 FROM public.surface_finish_revisions WHERE finish_id = $1::uuid AND statut = 'ACTIVE' LIMIT 1`,
+      [finishId]
+    );
+    const nextStatus = statusAfterReactivation((active.rowCount ?? 0) > 0);
+
+    try {
+      await client.query(
+        `UPDATE public.surface_finishes
+         SET statut = $2,
+             archived_at = NULL,
+             archived_by = NULL,
+             archive_reason = NULL,
+             statut_changed_at = now(),
+             statut_changed_by = $3::integer,
+             updated_at = now(),
+             updated_by = $3::integer
+         WHERE id = $1::uuid`,
+        [finishId, nextStatus, audit.user_id]
+      );
+    } catch (err) {
+      if (typeof err === "object" && err !== null && (err as { code?: string }).code === "23505") {
+        throw new HttpError(
+          409,
+          "SURFACE_FINISH_IDENTITY_TAKEN",
+          "Une autre finition active porte désormais la même famille, le même procédé et la même désignation. Renommez-la avant de sortir celle-ci d'archive."
+        );
+      }
+      throw err;
+    }
+
+    await insertFinishAudit(client, audit, "finitions.reactivate", "surface_finish", finishId, {
+      code: current.code,
+      from: "ARCHIVEE",
+      to: nextStatus,
+      motif: body.motif,
+    });
+
+    await client.query("COMMIT");
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  const out = await repoGetFinish(finishId, audit.user_id);
+  if (!out) throw new Error("Failed to read reactivated finish");
+  return out;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Historique                                                                  */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * L'historique est LU depuis `erp_audit_logs`, jamais reconstitué à partir des
+ * `updated_at` : une reconstitution inventerait des évènements qui n'ont pas eu
+ * lieu. Une finition sans trace affiche une liste vide — c'est une information,
+ * pas un bug.
+ *
+ * La finition ET ses révisions sont couvertes : l'utilisateur veut « ce qui est
+ * arrivé à cette finition », pas « ce qui est arrivé à cette ligne de table ».
+ */
+export async function repoListFinishHistory(
+  finishId: string,
+  query: FinishHistoryQueryDTO
+): Promise<SurfaceFinishHistoryEntry[]> {
+  const exists = await db.query(`SELECT 1 FROM public.surface_finishes WHERE id = $1::uuid`, [finishId]);
+  if (exists.rowCount === 0) throw new HttpError(404, "NOT_FOUND", "Finition introuvable.");
+
+  const values: unknown[] = [finishId];
+  let beforeSql = "";
+  if (query.before_id !== undefined) {
+    values.push(query.before_id);
+    beforeSql = `AND l.id < $${values.length}`;
+  }
+  values.push(query.limit);
+
+  const res = await db.query<{
+    id: string;
+    created_at: string;
+    action: string;
+    entity_type: string;
+    entity_id: string;
+    user_id: number | null;
+    user_label: string | null;
+    details: Record<string, unknown> | null;
+  }>(
+    `SELECT
+       l.id::text AS id,
+       l.created_at::text AS created_at,
+       l.action,
+       l.entity_type,
+       l.entity_id,
+       l.user_id,
+       -- Nom d'usage seulement. L'e-mail n'a rien à faire dans un historique
+       -- affiché à l'écran (RGPD : minimisation).
+       COALESCE(NULLIF(btrim(u.name), ''), u.username) AS user_label,
+       l.details
+     FROM public.erp_audit_logs l
+     LEFT JOIN public.users u ON u.id = l.user_id
+     WHERE (
+        (l.entity_type = 'surface_finish' AND l.entity_id = $1::text)
+        OR (l.entity_type IN ('surface_finish_revision', 'surface_finish_document')
+            AND l.entity_id IN (
+              SELECT r.id::text FROM public.surface_finish_revisions r WHERE r.finish_id = $1::uuid
+            ))
+        OR (l.entity_type = 'surface_finish_revision'
+            AND l.details ->> 'finish_id' = $1::text)
+     )
+     ${beforeSql}
+     ORDER BY l.id DESC
+     LIMIT $${values.length}`,
+    values
+  );
+
+  // `erp_audit_logs.id` est un bigint : le driver le rend en chaîne. Le
+  // convertir ici évite un identifiant qui « saute » côté navigateur.
+  return res.rows.map((row) => ({
+    id: Number(row.id),
+    created_at: row.created_at,
+    action: row.action,
+    entity_type: row.entity_type,
+    entity_id: row.entity_id,
+    user_id: row.user_id,
+    user_label: row.user_label,
+    details: row.details,
+  }));
+}
+
+/* -------------------------------------------------------------------------- */
+/* Contrôle des doublons                                                       */
+/* -------------------------------------------------------------------------- */
+
+type SimilarRow = {
+  id: string;
+  code: string;
+  family_code: string;
+  family_label: string | null;
+  procede: string;
+  designation_courte: string;
+  designation_longue: string | null;
+  synonymes: string[] | null;
+  statut: SurfaceFinishStatus;
+  score: string | number;
+  exact_identity: boolean;
+  same_family: boolean;
+  synonym_hit: boolean;
+  norme_hit: boolean;
+  couleur_hit: boolean;
+  epaisseur_hit: boolean;
+  rev_json: RevisionRow | null;
+};
+
+/**
+ * Cherche les finitions proches d'une saisie en cours. CONSULTATIF : ne bloque
+ * jamais, ne crée rien. L'index unique `surface_finishes_identity_uq` reste la
+ * seule barrière dure.
+ *
+ * Le score combine la désignation et le procédé via `similarity()` (pg_trgm,
+ * qui fonctionne sans index à cette volumétrie — cf. patch #226), et retient
+ * le meilleur des deux plutôt que leur moyenne : « anodisation noire » et
+ * « anodisation dure noire » se ressemblent par la désignation même quand les
+ * procédés diffèrent, et il faut le montrer.
+ *
+ * Les archives SONT incluses : « cette finition existe déjà mais elle a été
+ * archivée en mars pour telle raison » est exactement ce qu'il faut savoir
+ * avant d'en recréer une.
+ */
+export async function repoFindSimilarFinishes(query: SimilarFinishesQueryDTO): Promise<SurfaceFinishSimilarMatch[]> {
+  const designation = query.designation_courte ?? "";
+  const procede = query.procede ?? "";
+
+  // Sans désignation ni procédé ni synonyme, il n'y a rien à comparer : une
+  // recherche vide renverrait la bibliothèque entière classée au hasard.
+  if (designation.trim() === "" && procede.trim() === "" && query.synonymes.length === 0) return [];
+
+  const res = await db.query<SimilarRow>(
+    `WITH candidat AS (
+       SELECT
+         f.id, f.code, f.family_code, f.procede, f.designation_courte,
+         f.designation_longue, f.synonymes, f.statut,
+         fam.label AS family_label,
+         GREATEST(
+           similarity(public.surface_finish_norm(f.designation_courte), public.surface_finish_norm($1)),
+           similarity(public.surface_finish_norm(f.procede), public.surface_finish_norm($2))
+         ) AS base_score,
+         (
+           $3::text IS NOT NULL
+           AND f.family_code = $3::text
+           AND public.surface_finish_norm(f.procede) = public.surface_finish_norm($2)
+           AND public.surface_finish_norm(f.designation_courte) = public.surface_finish_norm($1)
+         ) AS exact_identity,
+         ($3::text IS NOT NULL AND f.family_code = $3::text) AS same_family,
+         EXISTS (
+           SELECT 1 FROM unnest(f.synonymes) AS s(value)
+           JOIN unnest($4::text[]) AS q(value) ON true
+           WHERE public.surface_finish_norm(s.value) = public.surface_finish_norm(q.value)
+              OR public.surface_finish_norm(s.value) = public.surface_finish_norm($1)
+         ) AS synonym_hit
+       FROM public.surface_finishes f
+       LEFT JOIN public.surface_finish_families fam ON fam.code = f.family_code
+       WHERE ($5::uuid IS NULL OR f.id <> $5::uuid)
+     )
+     SELECT
+       c.id::text AS id, c.code, c.family_code, c.family_label, c.procede,
+       c.designation_courte, c.designation_longue, c.synonymes, c.statut,
+       c.exact_identity, c.same_family, c.synonym_hit,
+       -- Appartenir à la même famille rapproche réellement deux entrées ; un
+       -- synonyme commun est un aveu de doublon. Le score reste plafonné à 1.
+       LEAST(
+         1.0,
+         c.base_score
+         + CASE WHEN c.same_family THEN 0.15 ELSE 0 END
+         + CASE WHEN c.synonym_hit THEN 0.25 ELSE 0 END
+       )::numeric AS score,
+       ($6::text IS NOT NULL AND public.surface_finish_norm(rev.norme) = public.surface_finish_norm($6)) AS norme_hit,
+       ($7::text IS NOT NULL AND (
+          public.surface_finish_norm(rev.couleur)   = public.surface_finish_norm($7)
+          OR public.surface_finish_norm(rev.teinte_ral) = public.surface_finish_norm($7)
+       )) AS couleur_hit,
+       ($8::numeric IS NOT NULL AND rev.id IS NOT NULL AND
+          $8::numeric BETWEEN COALESCE(public.surface_finish_to_um(rev.epaisseur_min::numeric, rev.epaisseur_unite), 0)
+                          AND COALESCE(public.surface_finish_to_um(rev.epaisseur_max::numeric, rev.epaisseur_unite), 1e12)
+       ) AS epaisseur_hit,
+       CASE WHEN rev.id IS NULL THEN NULL ELSE to_jsonb(rev) END AS rev_json
+     FROM candidat c
+     LEFT JOIN LATERAL (
+       SELECT ${revisionColumns("r")}
+       FROM public.surface_finish_revisions r
+       WHERE r.finish_id = c.id
+       ORDER BY (r.statut = 'ACTIVE') DESC, r.revision DESC
+       LIMIT 1
+     ) rev ON true
+     WHERE c.exact_identity OR c.synonym_hit OR c.base_score >= $9::real
+     ORDER BY c.exact_identity DESC, score DESC, c.designation_courte
+     LIMIT $10`,
+    [
+      designation,
+      procede,
+      query.family_code,
+      query.synonymes,
+      query.exclude_finish_id,
+      query.norme,
+      query.couleur,
+      query.epaisseur_um,
+      SIMILARITY_FLOOR,
+      query.limit,
+    ]
+  );
+
+  const out: SurfaceFinishSimilarMatch[] = [];
+  for (const row of res.rows) {
+    const score = typeof row.score === "string" ? Number(row.score) : row.score;
+    const level = classifySimilarity(score, row.exact_identity === true);
+    // `classifySimilarity` peut écarter ce que le SQL a laissé passer (un
+    // synonyme commun sur un libellé sans rapport) : la politique tranche.
+    if (!level) continue;
+
+    const reasons: string[] = [];
+    if (row.exact_identity) reasons.push("Même famille, même procédé, même désignation");
+    if (row.synonym_hit) reasons.push("Synonyme en commun");
+    if (row.same_family && !row.exact_identity) reasons.push("Même famille");
+    if (row.norme_hit) reasons.push("Même norme");
+    if (row.couleur_hit) reasons.push("Même couleur");
+    if (row.epaisseur_hit) reasons.push("Épaisseur compatible");
+
+    out.push({
+      id: row.id,
+      code: row.code,
+      family_code: row.family_code,
+      family_label: row.family_label,
+      procede: row.procede,
+      designation_courte: row.designation_courte,
+      designation_longue: row.designation_longue,
+      synonymes: row.synonymes ?? [],
+      statut: row.statut,
+      score: Math.round(score * 1000) / 1000,
+      level,
+      reasons,
+      current_revision: row.rev_json ? toRevisionSummary(mapRevision(row.rev_json)) : null,
+    });
+  }
+  return out;
+}

--- a/src/module/surface-finish/repository/surface-finish-library.repository.ts
+++ b/src/module/surface-finish/repository/surface-finish-library.repository.ts
@@ -98,7 +98,9 @@ const FINISH_COLS = `
   f.statut,
   f.current_revision_id::text AS current_revision_id,
   f.created_at::text AS created_at,
-  f.updated_at::text AS updated_at
+  f.updated_at::text AS updated_at,
+  f.archived_at::text AS archived_at,
+  f.archive_reason
 `;
 
 export type RevisionRow = {
@@ -155,6 +157,8 @@ type FinishRow = {
   current_revision_id: string | null;
   created_at: string;
   updated_at: string;
+  archived_at: string | null;
+  archive_reason: string | null;
 };
 
 export function mapRevision(row: RevisionRow): SurfaceFinishRevisionDetail {
@@ -273,7 +277,10 @@ export async function repoListFinishFamilies(): Promise<SurfaceFinishFamily[]> {
  * épaisseur et synonyme. La norme et la couleur vivent sur la RÉVISION : la
  * jointure latérale retient la révision active, sinon la plus récente.
  */
-export async function repoListFinishes(filters: ListFinishesQueryDTO): Promise<SurfaceFinishListResult> {
+export async function repoListFinishes(
+  filters: ListFinishesQueryDTO,
+  viewerUserId: number
+): Promise<SurfaceFinishListResult> {
   const where: string[] = [];
   const values: unknown[] = [];
   const push = (value: unknown) => {
@@ -281,13 +288,23 @@ export async function repoListFinishes(filters: ListFinishesQueryDTO): Promise<S
     return `$${values.length}`;
   };
 
+  // #226 — Le favori est PERSONNEL : il est joint sur l'utilisateur qui
+  // interroge, jamais agrégé. Poussé en premier pour que `$1` soit stable.
+  const viewer = push(viewerUserId);
+
   if (filters.only_selectable) {
     // Depuis une gamme : uniquement ce qui est réellement applicable.
     where.push(`f.statut = 'ACTIVE'`);
     where.push(`rev.id IS NOT NULL AND rev.statut = 'ACTIVE'`);
   } else if (filters.statut) {
     where.push(`f.statut = ${push(filters.statut)}`);
+  } else if (!filters.include_archived) {
+    // #226 — Les archives ne remontent que si on les demande explicitement,
+    // OU si l'utilisateur filtre justement sur le statut ARCHIVEE ci-dessus.
+    where.push(`f.statut <> 'ARCHIVEE'`);
   }
+
+  if (filters.only_favorites) where.push(`fav.user_id IS NOT NULL`);
 
   if (filters.family_code) where.push(`f.family_code = ${push(filters.family_code)}`);
   if (filters.procede) {
@@ -338,6 +355,8 @@ export async function repoListFinishes(filters: ListFinishesQueryDTO): Promise<S
   const baseFrom = `
     FROM public.surface_finishes f
     LEFT JOIN public.surface_finish_families fam ON fam.code = f.family_code
+    LEFT JOIN public.surface_finish_favorites fav
+      ON fav.finish_id = f.id AND fav.user_id = ${viewer}::integer
     LEFT JOIN LATERAL (
       SELECT ${revisionColumns("r")}
       FROM public.surface_finish_revisions r
@@ -352,10 +371,12 @@ export async function repoListFinishes(filters: ListFinishesQueryDTO): Promise<S
   const total = countRes.rows[0]?.total ?? 0;
 
   const offset = (filters.page - 1) * filters.page_size;
-  const dataRes = await db.query<FinishRow & { rev_json: RevisionRow | null }>(
-    `SELECT ${FINISH_COLS}, CASE WHEN rev.id IS NULL THEN NULL ELSE to_jsonb(rev) END AS rev_json
+  const dataRes = await db.query<FinishRow & { rev_json: RevisionRow | null; favori: boolean }>(
+    `SELECT ${FINISH_COLS},
+            (fav.user_id IS NOT NULL) AS favori,
+            CASE WHEN rev.id IS NULL THEN NULL ELSE to_jsonb(rev) END AS rev_json
      ${baseFrom}
-     ORDER BY f.designation_courte, f.code
+     ORDER BY (fav.user_id IS NOT NULL) DESC, f.designation_courte, f.code
      LIMIT $${values.length + 1} OFFSET $${values.length + 2}`,
     [...values, filters.page_size, offset]
   );
@@ -372,18 +393,31 @@ export async function repoListFinishes(filters: ListFinishesQueryDTO): Promise<S
     statut: row.statut,
     current_revision: row.rev_json ? toRevisionSummary(mapRevision(row.rev_json)) : null,
     updated_at: row.updated_at,
+    favori: row.favori === true,
+    archived_at: row.archived_at,
+    archive_reason: row.archive_reason,
   }));
 
   return { items, total, page: filters.page, page_size: filters.page_size };
 }
 
-export async function repoGetFinish(finishId: string): Promise<SurfaceFinishDetail | null> {
-  const res = await db.query<FinishRow>(
-    `SELECT ${FINISH_COLS}
+/**
+ * `viewerUserId` peut être `null` pour les relectures internes (après écriture)
+ * qui n'ont pas de lecteur : le favori vaut alors `false` et n'est jamais
+ * renvoyé au mauvais utilisateur.
+ */
+export async function repoGetFinish(
+  finishId: string,
+  viewerUserId: number | null = null
+): Promise<SurfaceFinishDetail | null> {
+  const res = await db.query<FinishRow & { favori: boolean }>(
+    `SELECT ${FINISH_COLS}, (fav.user_id IS NOT NULL) AS favori
      FROM public.surface_finishes f
      LEFT JOIN public.surface_finish_families fam ON fam.code = f.family_code
+     LEFT JOIN public.surface_finish_favorites fav
+       ON fav.finish_id = f.id AND fav.user_id = $2::integer
      WHERE f.id = $1::uuid`,
-    [finishId]
+    [finishId, viewerUserId]
   );
   const row = res.rows[0];
   if (!row) return null;
@@ -412,6 +446,9 @@ export async function repoGetFinish(finishId: string): Promise<SurfaceFinishDeta
     revisions: mapped,
     created_at: row.created_at,
     updated_at: row.updated_at,
+    favori: row.favori === true,
+    archived_at: row.archived_at,
+    archive_reason: row.archive_reason,
   };
 }
 
@@ -480,6 +517,17 @@ export async function repoCreateFinishDraft(
     await client.query("COMMIT");
   } catch (err) {
     await client.query("ROLLBACK").catch(() => {});
+    // #226 — `surface_finishes_identity_uq` (même famille + même procédé +
+    // même désignation normalisée, hors archives) rend le doublon strict
+    // impossible EN BASE. Sans cette traduction, deux créations concurrentes
+    // rendraient un 500 illisible au lieu d'un conflit exploitable.
+    if (typeof err === "object" && err !== null && (err as { code?: string }).code === "23505") {
+      throw new HttpError(
+        409,
+        "SURFACE_FINISH_DUPLICATE",
+        "Une finition active porte déjà cette famille, ce procédé et cette désignation. Ouvrez-la, ou changez la désignation."
+      );
+    }
     throw err;
   } finally {
     client.release();
@@ -487,7 +535,7 @@ export async function repoCreateFinishDraft(
 
   // Relecture APRÈS le commit : lire par le pool depuis une transaction ouverte
   // ne verrait rien (leçon du chantier GED).
-  const out = await repoGetFinish(finishId);
+  const out = await repoGetFinish(finishId, audit.user_id);
   if (!out) throw new Error("Failed to read created finish");
   return out;
 }
@@ -549,12 +597,21 @@ export async function repoUpdateFinishDraft(
     await client.query("COMMIT");
   } catch (err) {
     await client.query("ROLLBACK").catch(() => {});
+    // Renommer une finition peut la faire entrer en collision avec une autre :
+    // même index, même traduction que pour la création.
+    if (typeof err === "object" && err !== null && (err as { code?: string }).code === "23505") {
+      throw new HttpError(
+        409,
+        "SURFACE_FINISH_DUPLICATE",
+        "Une autre finition active porte déjà cette famille, ce procédé et cette désignation."
+      );
+    }
     throw err;
   } finally {
     client.release();
   }
 
-  const out = await repoGetFinish(finishId);
+  const out = await repoGetFinish(finishId, audit.user_id);
   if (!out) throw new HttpError(404, "NOT_FOUND", "Finition introuvable.");
   return out;
 }

--- a/src/module/surface-finish/routes/surface-finish.routes.ts
+++ b/src/module/surface-finish/routes/surface-finish.routes.ts
@@ -4,14 +4,20 @@
 import { Router } from "express";
 
 import {
+  addFinishFavorite,
+  archiveFinish,
   attachRevisionDocument,
   createFinish,
   createRevision,
   getFinish,
   listFinishes,
   listFinishFamilies,
+  listFinishHistory,
   listRevisionDocuments,
+  listSimilarFinishes,
+  reactivateFinish,
   readCapabilities,
+  removeFinishFavorite,
   revisionImpact,
   transitionRevision,
   updateFinish,
@@ -19,10 +25,14 @@ import {
 } from "../controllers/surface-finish.controller";
 import { requireSurfaceFinishCapability } from "../middlewares/surface-finish-authorization.middleware";
 import {
+  archiveFinishBodySchema,
   attachDocumentBodySchema,
   createFinishBodySchema,
   createRevisionBodySchema,
+  finishHistoryQuerySchema,
   listFinishesQuerySchema,
+  reactivateFinishBodySchema,
+  similarFinishesQuerySchema,
   transitionRevisionBodySchema,
   updateFinishBodySchema,
   updateRevisionBodySchema,
@@ -35,6 +45,16 @@ const router = Router();
 router.get("/capabilities", readCapabilities);
 
 router.get("/familles", requireSurfaceFinishCapability("library_read"), listFinishFamilies);
+
+// #226 — Contrôle des doublons. DÉCLARÉ AVANT `/:finishId` : les deux motifs
+// n'ont qu'un segment, et Express retient le premier inscrit — placé après,
+// cette route serait lue comme une finition d'identifiant « similaires ».
+router.get(
+  "/similaires",
+  requireSurfaceFinishCapability("library_read"),
+  validate(similarFinishesQuerySchema, "query"),
+  listSimilarFinishes
+);
 
 router.get(
   "/",
@@ -57,6 +77,35 @@ router.patch(
   requireSurfaceFinishCapability("library_draft_write"),
   validate(updateFinishBodySchema),
   updateFinish
+);
+
+// #226 — Favori : préférence personnelle, `library_read` suffit. Exiger un
+// droit d'écriture sur le référentiel pour poser une étoile priverait les
+// Achats et la production d'un confort qui n'engage rien.
+router.post("/:finishId/favori", requireSurfaceFinishCapability("library_read"), addFinishFavorite);
+router.delete("/:finishId/favori", requireSurfaceFinishCapability("library_read"), removeFinishFavorite);
+
+// #226 — Archivage. `library_retire` était déclarée depuis #210 sans qu'aucune
+// route ne l'impose : c'est ici qu'elle prend enfin son sens.
+router.post(
+  "/:finishId/archive",
+  requireSurfaceFinishCapability("library_retire"),
+  validate(archiveFinishBodySchema),
+  archiveFinish
+);
+router.post(
+  "/:finishId/reactivate",
+  requireSurfaceFinishCapability("library_retire"),
+  validate(reactivateFinishBodySchema),
+  reactivateFinish
+);
+
+// #226 — Historique : lecture d'audit, capacité dédiée.
+router.get(
+  "/:finishId/historique",
+  requireSurfaceFinishCapability("audit_read"),
+  validate(finishHistoryQuerySchema, "query"),
+  listFinishHistory
 );
 
 router.post(

--- a/src/module/surface-finish/services/surface-finish.service.ts
+++ b/src/module/surface-finish/services/surface-finish.service.ts
@@ -25,19 +25,30 @@ import {
   type RevisionImpact,
 } from "../repository/surface-finish-library.repository";
 import {
+  repoArchiveFinish,
+  repoFindSimilarFinishes,
+  repoListFinishHistory,
+  repoReactivateFinish,
+  repoSetFinishFavorite,
+} from "../repository/surface-finish-admin.repository";
+import {
   repoConfirmOperationFinish,
   repoDetachOperationFinish,
   repoGetOperationFinish,
   repoPreviewOperationFinish,
 } from "../repository/surface-finish-resolution.repository";
 import type {
+  ArchiveFinishBodyDTO,
   AttachDocumentBodyDTO,
   ConfirmFinishBodyDTO,
   CreateFinishBodyDTO,
   DetachFinishBodyDTO,
+  FinishHistoryQueryDTO,
   ListFinishesQueryDTO,
   PreviewFinishBodyDTO,
+  ReactivateFinishBodyDTO,
   RevisionPayloadDTO,
+  SimilarFinishesQueryDTO,
   TransitionRevisionBodyDTO,
   UpdateFinishBodyDTO,
   UpdateRevisionBodyDTO,
@@ -48,9 +59,11 @@ import type {
   SurfaceFinishDetail,
   SurfaceFinishDocument,
   SurfaceFinishFamily,
+  SurfaceFinishHistoryEntry,
   SurfaceFinishListResult,
   SurfaceFinishPreview,
   SurfaceFinishRevisionDetail,
+  SurfaceFinishSimilarMatch,
 } from "../types/surface-finish.types";
 
 export type Actor = { user_id: number; role: string | null };
@@ -59,14 +72,67 @@ export async function listFinishFamiliesSVC(): Promise<SurfaceFinishFamily[]> {
   return repoListFinishFamilies();
 }
 
-export async function listFinishesSVC(filters: ListFinishesQueryDTO): Promise<SurfaceFinishListResult> {
-  return repoListFinishes(filters);
+export async function listFinishesSVC(
+  filters: ListFinishesQueryDTO,
+  viewerUserId: number
+): Promise<SurfaceFinishListResult> {
+  return repoListFinishes(filters, viewerUserId);
 }
 
-export async function getFinishSVC(finishId: string): Promise<SurfaceFinishDetail> {
-  const finish = await repoGetFinish(finishId);
+export async function getFinishSVC(finishId: string, viewerUserId: number): Promise<SurfaceFinishDetail> {
+  const finish = await repoGetFinish(finishId, viewerUserId);
   if (!finish) throw new HttpError(404, "NOT_FOUND", "Finition introuvable.");
   return finish;
+}
+
+/* -------------------------------------------------------------------------- */
+/* #226 — Doublons, favoris, archivage, historique                            */
+/* -------------------------------------------------------------------------- */
+
+export async function findSimilarFinishesSVC(query: SimilarFinishesQueryDTO): Promise<SurfaceFinishSimilarMatch[]> {
+  return repoFindSimilarFinishes(query);
+}
+
+/** Un favori est personnel : l'identité vient du jeton, jamais du corps. */
+export async function setFinishFavoriteSVC(
+  finishId: string,
+  actor: Actor,
+  favorite: boolean
+): Promise<{ finish_id: string; favori: boolean }> {
+  return repoSetFinishFavorite(finishId, actor.user_id, favorite);
+}
+
+/**
+ * Archiver et réactiver exigent `library_retire` — une capacité déclarée depuis
+ * #210 mais que rien n'avait encore imposée, faute de chemin d'archivage.
+ */
+export async function archiveFinishSVC(
+  finishId: string,
+  body: ArchiveFinishBodyDTO,
+  actor: Actor,
+  audit: AuditContext
+): Promise<SurfaceFinishDetail> {
+  assertSurfaceFinishCapability(actor.role, "library_retire");
+  return repoArchiveFinish(finishId, body, audit);
+}
+
+export async function reactivateFinishSVC(
+  finishId: string,
+  body: ReactivateFinishBodyDTO,
+  actor: Actor,
+  audit: AuditContext
+): Promise<SurfaceFinishDetail> {
+  assertSurfaceFinishCapability(actor.role, "library_retire");
+  return repoReactivateFinish(finishId, body, audit);
+}
+
+export async function listFinishHistorySVC(
+  finishId: string,
+  query: FinishHistoryQueryDTO,
+  actor: Actor
+): Promise<SurfaceFinishHistoryEntry[]> {
+  assertSurfaceFinishCapability(actor.role, "audit_read");
+  return repoListFinishHistory(finishId, query);
 }
 
 export async function createFinishDraftSVC(body: CreateFinishBodyDTO, audit: AuditContext): Promise<SurfaceFinishDetail> {

--- a/src/module/surface-finish/types/surface-finish.types.ts
+++ b/src/module/surface-finish/types/surface-finish.types.ts
@@ -5,6 +5,7 @@
 import type {
   CanonicalFinishSpec,
   FinishScope,
+  SimilarityLevel,
   SurfaceFinishCapability,
   SurfaceFinishStatus,
 } from "../domain/surface-finish-policy";
@@ -72,12 +73,46 @@ export type SurfaceFinishSummary = {
   statut: SurfaceFinishStatus;
   current_revision: SurfaceFinishRevisionSummary | null;
   updated_at: string;
+  /** #226 — Favori de l'utilisateur qui interroge, jamais un favori partagé. */
+  favori: boolean;
+  archived_at: string | null;
+  archive_reason: string | null;
 };
 
 export type SurfaceFinishDetail = SurfaceFinishSummary & {
   description: string | null;
   created_at: string;
   revisions: SurfaceFinishRevisionDetail[];
+};
+
+/* #226 — Contrôle des doublons du référentiel. */
+export type SurfaceFinishSimilarMatch = {
+  id: string;
+  code: string;
+  family_code: string;
+  family_label: string | null;
+  procede: string;
+  designation_courte: string;
+  designation_longue: string | null;
+  synonymes: string[];
+  statut: SurfaceFinishStatus;
+  score: number;
+  level: SimilarityLevel;
+  /** Ce qui a déclenché le rapprochement, pour que l'écran puisse l'expliquer. */
+  reasons: string[];
+  current_revision: SurfaceFinishRevisionSummary | null;
+};
+
+/* #226 — Historique lu depuis erp_audit_logs, jamais reconstitué. */
+export type SurfaceFinishHistoryEntry = {
+  id: number;
+  created_at: string;
+  action: string;
+  entity_type: string;
+  entity_id: string;
+  user_id: number | null;
+  user_label: string | null;
+  details: Record<string, unknown> | null;
 };
 
 export type SurfaceFinishListResult = {

--- a/src/module/surface-finish/validators/surface-finish.validators.ts
+++ b/src/module/surface-finish/validators/surface-finish.validators.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import { HttpError } from "../../../utils/httpError";
 import {
+  ARCHIVE_REASON_MIN_LENGTH,
   ARTICLE_DECISIONS,
   FINISH_SCOPES,
   SURFACE_FINISH_STATUSES,
@@ -112,10 +113,93 @@ export const listFinishesQuerySchema = z.object({
     .union([z.boolean(), z.enum(["true", "false", "1", "0"])])
     .optional()
     .transform((value) => value === true || value === "true" || value === "1"),
+  // #226 — Mes favoris. Personnel : jamais partagé entre utilisateurs.
+  only_favorites: z
+    .union([z.boolean(), z.enum(["true", "false", "1", "0"])])
+    .optional()
+    .transform((value) => value === true || value === "true" || value === "1"),
+  /**
+   * #226 — Les archives sont EXCLUES par défaut. Une bibliothèque qui montre
+   * ses archives sans qu'on les demande redevient illisible en un an.
+   */
+  include_archived: z
+    .union([z.boolean(), z.enum(["true", "false", "1", "0"])])
+    .optional()
+    .transform((value) => value === true || value === "true" || value === "1"),
   page: z.coerce.number().int().min(1).max(10_000).optional().default(1),
   page_size: z.coerce.number().int().min(1).max(50).optional().default(20),
 });
 export type ListFinishesQueryDTO = z.infer<typeof listFinishesQuerySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Bibliothèque — contrôle des doublons (#226)                                 */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Recherche de finitions proches AVANT création. Les mêmes champs que la
+ * création, tous facultatifs : on interroge en cours de frappe, pas une fois le
+ * formulaire complet.
+ */
+export const similarFinishesQuerySchema = z.object({
+  family_code: optionalText(60),
+  procede: optionalText(200),
+  designation_courte: optionalText(200),
+  synonymes: z
+    .union([z.string(), z.array(z.string())])
+    .optional()
+    .transform((value) => {
+      if (value === undefined) return [] as string[];
+      const list = Array.isArray(value) ? value : value.split(",");
+      return list.map((item) => item.trim()).filter((item) => item !== "").slice(0, 50);
+    }),
+  norme: optionalText(200),
+  couleur: optionalText(120),
+  epaisseur_um: optionalNumber,
+  // Une modification exclut la finition en cours de sa propre liste de doublons.
+  exclude_finish_id: z.union([uuid, z.literal(""), z.null()]).optional().transform((v) => (v ? v : null)),
+  limit: z.coerce.number().int().min(1).max(20).optional().default(8),
+});
+export type SimilarFinishesQueryDTO = z.infer<typeof similarFinishesQuerySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Bibliothèque — archivage (#226)                                             */
+/* -------------------------------------------------------------------------- */
+
+export const archiveFinishBodySchema = z
+  .object({
+    // Sortir une entrée du référentiel se motive par écrit : c'est ce motif que
+    // relira, dans deux ans, celui qui se demandera où est passée la finition.
+    motif: z
+      .string()
+      .trim()
+      .min(ARCHIVE_REASON_MIN_LENGTH, `Le motif doit faire au moins ${ARCHIVE_REASON_MIN_LENGTH} caractères.`)
+      .max(1000),
+    expected_updated_at: z.string().min(1),
+  })
+  .strict();
+export type ArchiveFinishBodyDTO = z.infer<typeof archiveFinishBodySchema>;
+
+export const reactivateFinishBodySchema = z
+  .object({
+    motif: z
+      .string()
+      .trim()
+      .min(ARCHIVE_REASON_MIN_LENGTH, `Le motif doit faire au moins ${ARCHIVE_REASON_MIN_LENGTH} caractères.`)
+      .max(1000),
+    expected_updated_at: z.string().min(1),
+  })
+  .strict();
+export type ReactivateFinishBodyDTO = z.infer<typeof reactivateFinishBodySchema>;
+
+/* -------------------------------------------------------------------------- */
+/* Bibliothèque — historique (#226)                                            */
+/* -------------------------------------------------------------------------- */
+
+export const finishHistoryQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(200).optional().default(50),
+  before_id: z.coerce.number().int().min(1).optional(),
+});
+export type FinishHistoryQueryDTO = z.infer<typeof finishHistoryQuerySchema>;
 
 /* -------------------------------------------------------------------------- */
 /* Bibliothèque — écriture                                                     */


### PR DESCRIPTION
## Ce qui change
- ajoute les API de favoris, archivage/réactivation, historique et similarité des finitions
- ajoute la recherche d’articles similaires
- complète le contrôle des doublons et les réponses 409
- ajoute le patch SQL additif/idempotent `20260729_surface_finish_library_admin_226` avec preflight, verify et rollback

## Pourquoi
La bibliothèque versionnée était déployée mais vide et ne disposait d’aucun chemin d’administration. Le patch ajoute uniquement les préférences de favoris, la traçabilité d’archivage et l’unicité métier stricte.

## Validation locale
- 3 133 tests backend verts
- build/typecheck TypeScript vert avec les dépendances verrouillées
- patch déjà vérifié sur `cerp_test`; application production séparée et explicitement autorisée

Closes #226

## Summary by Sourcery

Add administration features for the surface finish library and article catalog, including favorites, archiving with history, and duplicate detection APIs.

New Features:
- Expose APIs to manage personal favorites on surface finishes and persist them in a dedicated table.
- Add endpoints to archive and reactivate surface finishes with mandatory reasons and role-based permissions.
- Introduce similarity search APIs for surface finishes and stock articles to detect potential duplicates before creation.
- Provide history endpoints to read audit logs for surface finishes, including revisions and documents.

Bug Fixes:
- Translate database uniqueness violations on surface finishes into HTTP 409 conflict responses instead of generic errors.

Enhancements:
- Extend surface finish listing to handle personal favorites, archived records visibility, and optimistic ordering.
- Enrich surface finish domain policy with archiving rules and similarity classification levels.
- Tighten duplicate control for surface finishes via a partial unique index on normalized identity fields.

Build:
- Add an additive, idempotent database patch with preflight, verify, and rollback scripts for surface finish library administration and similarity support.

Documentation:
- Add in-SQL comments and constraints documentation explaining the archival model, favorites semantics, and duplicate identity rules.

Tests:
- Add comprehensive tests covering routing precedence, duplicate handling, favorites behavior, archiving constraints, history access, and similarity search for finishes and articles.