### PR TITLE
release: snapshot OF complet et qualification du parc machine (#233)

### DIFF
--- a/db/patches/20260729_methodes_gamme_referentials.sql
+++ b/db/patches/20260729_methodes_gamme_referentials.sql
@@ -1,7 +1,7 @@
 -- 20260729_methodes_gamme_referentials.sql
 --
 -- Méthodes : familles machine, centres de frais tarifés, parc machine et éditeur de gamme.
--- ADR : crp-systems-web/docs/adr/ADR-0044-methodes-referentiels-gamme.md
+-- ADR : crp-systems-web/docs/adr/ADR-0046-methodes-referentiels-gamme.md
 -- Audit préalable : crp-systems-web/docs/architecture/methodes-gamme-audit-2026-07-29.md
 --
 -- ADDITIF, IDEMPOTENT, NON DESTRUCTIF :

--- a/db/patches/20260729_methodes_machine_qualification_233.sql
+++ b/db/patches/20260729_methodes_machine_qualification_233.sql
@@ -1,0 +1,196 @@
+-- 20260729_methodes_machine_qualification_233.sql
+--
+-- Méthodes — qualification traçable du parc machine (#233 / crp-systems-web#384).
+-- ADR : crp-systems-web/docs/adr/ADR-0046-methodes-referentiels-gamme.md
+--
+-- COMPLÉMENT de 20260729_methodes_gamme_referentials.sql, qui a créé les
+-- référentiels et les colonnes `machines.machine_family_code` / `machines.cf_id`
+-- SANS aucun backfill. Ce patch n'affecte toujours AUCUNE famille : il crée
+-- seulement le JOURNAL qui rend l'affectation traçable et réversible.
+--
+-- ADDITIF, IDEMPOTENT, NON DESTRUCTIF :
+--   - 1 nouvelle table (`production_machine_qualifications`) ;
+--   - 1 index unique conditionnel rejoué (phases de gamme) ;
+--   - AUCUN UPDATE, AUCUN DELETE, AUCUN DROP sur des données existantes.
+--
+-- POURQUOI UN JOURNAL PLUTÔT QU'UNE SIMPLE COLONNE : affecter une machine à une
+-- famille change le calcul de coût des gammes futures et l'exigence de numéro de
+-- programme. Une valeur seule ne dit ni qui, ni quand, ni pourquoi. Le journal
+-- porte l'ancienne ET la nouvelle valeur, donc l'affectation reste réversible
+-- sans reconstitution.
+--
+-- Pipeline db/patches (exécuté en tant que `cerp_app`). Cible : PostgreSQL 17.
+--   Preflight : db/patches/support/20260729_methodes_machine_qualification_233.preflight.sql
+--   Verify    : db/patches/support/20260729_methodes_machine_qualification_233.verify.sql
+--   Rollback  : db/patches/support/20260729_methodes_machine_qualification_233.rollback.sql
+-- Si le patch est appliqué via `sudo -u postgres psql`, exécuter ensuite
+-- db/privileged/20260721_fix_app_table_ownership.sql : sinon `cerp_app` obtient
+-- 42501 puis l'API renvoie 500 alors que le schéma est correct.
+
+BEGIN;
+
+/* -------------------------------------------------------------------------- */
+/* 0) Pré-requis structurels                                                  */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF to_regclass('public.production_machine_families') IS NULL THEN
+    RAISE EXCEPTION 'methodes: production_machine_families absent — appliquer 20260729_methodes_gamme_referentials.sql';
+  END IF;
+  IF to_regclass('public.machines') IS NULL THEN
+    RAISE EXCEPTION 'methodes: public.machines est absent';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'machines' AND column_name = 'machine_family_code'
+  ) THEN
+    RAISE EXCEPTION 'methodes: machines.machine_family_code absent — appliquer 20260729_methodes_gamme_referentials.sql';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 1) Journal de qualification du parc machine                                */
+/* -------------------------------------------------------------------------- */
+-- Une ligne = une décision humaine de qualification. `motif` est OBLIGATOIRE :
+-- une affectation sans justification écrite est exactement ce que l'audit
+-- reproche aux référentiels hérités.
+--
+-- PAS de clé étrangère vers `production_machine_families` sur les codes
+-- conservés : le journal est une preuve. Une famille désactivée ou renommée ne
+-- doit ni bloquer l'écriture, ni effacer ce qui a été décidé.
+
+CREATE TABLE IF NOT EXISTS public.production_machine_qualifications (
+  id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  machine_id           uuid NOT NULL,
+  -- État AVANT décision.
+  previous_family_code text,
+  previous_cf_id       uuid,
+  previous_valid_from  date,
+  previous_valid_to    date,
+  -- État APRÈS décision.
+  new_family_code      text,
+  new_cf_id            uuid,
+  new_valid_from       date,
+  new_valid_to         date,
+  motif                text NOT NULL,
+  created_at           timestamp with time zone NOT NULL DEFAULT now(),
+  created_by           integer
+);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'machine_qualifications_machine_fkey'
+      AND conrelid = 'public.production_machine_qualifications'::regclass
+  ) THEN
+    ALTER TABLE public.production_machine_qualifications
+      ADD CONSTRAINT machine_qualifications_machine_fkey
+      FOREIGN KEY (machine_id) REFERENCES public.machines (id) ON DELETE CASCADE;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'machine_qualifications_created_by_fkey'
+      AND conrelid = 'public.production_machine_qualifications'::regclass
+  ) THEN
+    ALTER TABLE public.production_machine_qualifications
+      ADD CONSTRAINT machine_qualifications_created_by_fkey
+      FOREIGN KEY (created_by) REFERENCES public.users (id) ON DELETE SET NULL;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'machine_qualifications_motif_ck'
+      AND conrelid = 'public.production_machine_qualifications'::regclass
+  ) THEN
+    ALTER TABLE public.production_machine_qualifications
+      ADD CONSTRAINT machine_qualifications_motif_ck CHECK (btrim(motif) <> '');
+  END IF;
+  -- Une ligne de journal qui ne change rien n'est pas une décision.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'machine_qualifications_change_ck'
+      AND conrelid = 'public.production_machine_qualifications'::regclass
+  ) THEN
+    ALTER TABLE public.production_machine_qualifications
+      ADD CONSTRAINT machine_qualifications_change_ck
+      CHECK (
+        previous_family_code IS DISTINCT FROM new_family_code
+        OR previous_cf_id      IS DISTINCT FROM new_cf_id
+        OR previous_valid_from IS DISTINCT FROM new_valid_from
+        OR previous_valid_to   IS DISTINCT FROM new_valid_to
+      );
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'machine_qualifications_validity_ck'
+      AND conrelid = 'public.production_machine_qualifications'::regclass
+  ) THEN
+    ALTER TABLE public.production_machine_qualifications
+      ADD CONSTRAINT machine_qualifications_validity_ck
+      CHECK (new_valid_from IS NULL OR new_valid_to IS NULL OR new_valid_to >= new_valid_from);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS machine_qualifications_machine_idx
+  ON public.production_machine_qualifications (machine_id, created_at DESC);
+
+/* -------------------------------------------------------------------------- */
+/* 2) Anti-collision des phases — nouvelle tentative                          */
+/* -------------------------------------------------------------------------- */
+-- Le patch précédent n'a pas pu créer cet index sur une base portant déjà deux
+-- opérations à la même phase dans une même gamme (constaté sur `cerp_test`).
+-- La garde est rejouée : dès que le doublon est renuméroté côté métier, une
+-- réapplication crée l'index. Aucune donnée n'est modifiée ici.
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class WHERE relname = 'pt_operations_gamme_phase_uidx' AND relkind = 'i'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM public.pieces_techniques_operations
+    WHERE gamme_id IS NOT NULL
+    GROUP BY gamme_id, phase HAVING count(*) > 1
+  ) THEN
+    CREATE UNIQUE INDEX pt_operations_gamme_phase_uidx
+      ON public.pieces_techniques_operations (gamme_id, phase)
+      WHERE gamme_id IS NOT NULL;
+  ELSIF NOT EXISTS (
+    SELECT 1 FROM pg_class WHERE relname = 'pt_operations_gamme_phase_uidx' AND relkind = 'i'
+  ) THEN
+    RAISE NOTICE 'methodes: index (gamme_id, phase) NON créé — doublons de phase à renuméroter, voir le verify.';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 3) Catalogue d'accès (#326) — la page « Parc machine » rejoint le module    */
+/* -------------------------------------------------------------------------- */
+-- Mise à jour ciblée d'une ligne de CATALOGUE (pas de donnée métier), pour que
+-- la base reste le miroir de `module-catalog.ts`. Sans cette page key, l'entrée
+-- de navigation disparaîtrait de tout compte dont le profil d'accès est filtré.
+-- `access_modules` n'existe pas encore sur toutes les bases : la garde évite un
+-- échec de patch là où le module d'accès n'est pas déployé.
+
+DO $$
+BEGIN
+  IF to_regclass('public.access_modules') IS NOT NULL THEN
+    UPDATE public.access_modules
+    SET nav_page_keys = array_append(nav_page_keys, 'methodes-parc-machines'),
+        updated_at    = now()
+    WHERE module_key = 'pieces-techniques'
+      AND NOT ('methodes-parc-machines' = ANY (nav_page_keys));
+  ELSE
+    RAISE NOTICE 'methodes: access_modules absent — catalogue d''accès non applicable sur cette base.';
+  END IF;
+END $$;
+
+/* -------------------------------------------------------------------------- */
+/* 4) Documentation embarquée                                                 */
+/* -------------------------------------------------------------------------- */
+
+COMMENT ON TABLE public.production_machine_qualifications IS
+  'Journal des décisions de qualification machine (famille, centre de frais, validité). Ancienne et nouvelle valeur conservées : l''affectation reste réversible et auditable.';
+COMMENT ON COLUMN public.production_machine_qualifications.motif IS
+  'Justification écrite obligatoire de la décision. Une affectation sans motif n''est pas acceptée.';
+
+COMMIT;

--- a/db/patches/support/20260729_methodes_machine_qualification_233.preflight.sql
+++ b/db/patches/support/20260729_methodes_machine_qualification_233.preflight.sql
@@ -1,0 +1,28 @@
+-- Preflight LECTURE SEULE de 20260729_methodes_machine_qualification_233.sql.
+-- Aucune écriture. À exécuter avant le patch, sur cerp_test puis sur cerp_prod.
+
+\echo '== 1. Cible et pré-requis =='
+SELECT current_database()                                            AS database,
+       to_regclass('public.production_machine_families') IS NOT NULL AS prereq_familles,
+       to_regclass('public.machines')                    IS NOT NULL AS prereq_machines,
+       to_regclass('public.production_machine_qualifications') IS NOT NULL AS deja_applique;
+
+\echo '== 2. Parc machine — ce que le patch NE touche PAS =='
+SELECT count(*)                                            AS machines_actives,
+       count(*) FILTER (WHERE machine_family_code IS NULL) AS sans_famille,
+       count(*) FILTER (WHERE cf_id IS NULL)               AS sans_centre_de_frais
+  FROM public.machines
+ WHERE archived_at IS NULL;
+
+\echo '== 3. Doublons de phase bloquant l''index unique (gamme_id, phase) =='
+SELECT gamme_id::text AS gamme_id, phase, count(*) AS operations
+  FROM public.pieces_techniques_operations
+ WHERE gamme_id IS NOT NULL
+ GROUP BY gamme_id, phase
+HAVING count(*) > 1
+ ORDER BY gamme_id, phase;
+
+\echo '== 4. Index unique deja present ? =='
+SELECT EXISTS (
+  SELECT 1 FROM pg_class WHERE relname = 'pt_operations_gamme_phase_uidx' AND relkind = 'i'
+) AS idx_gamme_phase_unique;

--- a/db/patches/support/20260729_methodes_machine_qualification_233.rollback.sql
+++ b/db/patches/support/20260729_methodes_machine_qualification_233.rollback.sql
@@ -1,0 +1,26 @@
+-- Rollback de 20260729_methodes_machine_qualification_233.sql.
+--
+-- ATTENTION : `DROP TABLE production_machine_qualifications` DÉTRUIT l'historique
+-- des décisions de qualification. Ce n'est pas une opération d'hygiène — c'est la
+-- perte d'une preuve d'audit. À n'exécuter que sur décision humaine explicite, et
+-- après export du contenu (requête fournie ci-dessous).
+--
+-- Le rollback ne dé-qualifie AUCUNE machine : `machines.machine_family_code` et
+-- `machines.cf_id` appartiennent au patch précédent et restent en place. Les
+-- affectations déjà décidées survivent donc au retrait du journal.
+
+-- 1) Export préalable — à exécuter et à conserver AVANT le DROP.
+-- \copy (SELECT * FROM public.production_machine_qualifications ORDER BY created_at)
+--   TO '/tmp/machine_qualifications_export.csv' WITH CSV HEADER
+
+BEGIN;
+
+DROP INDEX IF EXISTS public.machine_qualifications_machine_idx;
+DROP TABLE IF EXISTS public.production_machine_qualifications;
+
+-- L'index unique (gamme_id, phase) n'est PAS retiré : il protège les données de
+-- gamme et n'est pas propre à ce patch (il était déjà tenté par
+-- 20260729_methodes_gamme_referentials.sql). Pour le retirer explicitement :
+--   DROP INDEX IF EXISTS public.pt_operations_gamme_phase_uidx;
+
+COMMIT;

--- a/db/patches/support/20260729_methodes_machine_qualification_233.verify.sql
+++ b/db/patches/support/20260729_methodes_machine_qualification_233.verify.sql
@@ -1,0 +1,46 @@
+-- Verify LECTURE SEULE de 20260729_methodes_machine_qualification_233.sql.
+-- Toutes les colonnes booléennes doivent valoir `t`, SAUF `idx_gamme_phase_unique`
+-- qui reste `f` tant qu'une gamme porte deux opérations à la même phase.
+
+\echo '== Contrôles structurels =='
+SELECT
+  current_database() AS database,
+  to_regclass('public.production_machine_qualifications') IS NOT NULL AS table_journal,
+  EXISTS (SELECT 1 FROM pg_constraint
+           WHERE conname = 'machine_qualifications_machine_fkey')     AS fk_machine,
+  EXISTS (SELECT 1 FROM pg_constraint
+           WHERE conname = 'machine_qualifications_motif_ck')         AS ck_motif_obligatoire,
+  EXISTS (SELECT 1 FROM pg_constraint
+           WHERE conname = 'machine_qualifications_change_ck')        AS ck_changement_reel,
+  EXISTS (SELECT 1 FROM pg_constraint
+           WHERE conname = 'machine_qualifications_validity_ck')      AS ck_validite,
+  EXISTS (SELECT 1 FROM pg_class
+           WHERE relname = 'machine_qualifications_machine_idx')      AS idx_journal,
+  EXISTS (SELECT 1 FROM pg_class
+           WHERE relname = 'pt_operations_gamme_phase_uidx' AND relkind = 'i') AS idx_gamme_phase_unique,
+  -- Le patch ne qualifie AUCUNE machine : ces deux compteurs doivent être
+  -- identiques avant et après application.
+  (SELECT count(*) FROM public.machines WHERE archived_at IS NULL)    AS machines_actives,
+  (SELECT count(*) FROM public.machines
+    WHERE archived_at IS NULL AND machine_family_code IS NOT NULL)    AS machines_qualifiees,
+  (SELECT count(*) FROM public.production_machine_qualifications)     AS decisions_journalisees,
+  (SELECT relowner::regrole::text FROM pg_class
+    WHERE relname = 'production_machine_qualifications')              AS owner_journal;
+
+\echo '== Doublons de phase restants (doit etre vide pour que l''index existe) =='
+SELECT gamme_id::text AS gamme_id, phase, count(*) AS operations
+  FROM public.pieces_techniques_operations
+ WHERE gamme_id IS NOT NULL
+ GROUP BY gamme_id, phase
+HAVING count(*) > 1
+ ORDER BY gamme_id, phase;
+
+\echo '== Parc machine : etat de qualification =='
+SELECT m.code,
+       COALESCE(m.machine_family_code, 'A QUALIFIER') AS famille,
+       COALESCE(cf.code, '-')                        AS centre_de_frais,
+       m.status::text                                AS statut
+  FROM public.machines m
+  LEFT JOIN public.centres_frais cf ON cf.id = m.cf_id
+ WHERE m.archived_at IS NULL
+ ORDER BY m.code;

--- a/src/__tests__/machine-qualification-233.test.ts
+++ b/src/__tests__/machine-qualification-233.test.ts
@@ -1,0 +1,115 @@
+// Qualification du parc machine (#233 / crp-systems-web#384).
+//
+// Ce que ces tests protègent :
+//   - « à qualifier » reste une valeur ASSUMÉE (`null`), pas un oubli toléré ;
+//   - une qualification sans motif écrit n'existe pas ;
+//   - le verrou optimiste est obligatoire (deux Méthodes sur la même machine) ;
+//   - qualifier est un droit d'écriture du référentiel, pas un droit de lecture.
+
+import { describe, expect, it } from "vitest"
+
+import {
+  listMachinesQualificationQuerySchema,
+  machineIdParamSchema,
+  previewMachineQualificationQuerySchema,
+  qualifyMachineSchema,
+} from "../module/methodes/validators/methodes.validators"
+import { methodesCapabilitiesFor, roleHasMethodesCapability } from "../module/methodes/domain/methodes-policy"
+
+const MACHINE_ID = "33333333-3333-3333-3333-333333333333"
+const CF_ID = "44444444-4444-4444-4444-444444444444"
+const BASE = {
+  machine_family_code: "F",
+  cf_id: CF_ID,
+  motif: "Centre d'usinage CN, confirmé par les Méthodes le 29/07/2026.",
+  expected_updated_at: "2026-07-29T10:00:00.000Z",
+}
+
+describe("Qualification machine — contrat d'entrée", () => {
+  it("accepte une qualification complète", () => {
+    const parsed = qualifyMachineSchema.safeParse(BASE)
+    expect(parsed.success).toBe(true)
+    if (parsed.success) {
+      expect(parsed.data.machine_family_code).toBe("F")
+      // Validité non fournie = pas de borne, pas une borne à aujourd'hui.
+      expect(parsed.data.valid_from).toBeNull()
+      expect(parsed.data.valid_to).toBeNull()
+    }
+  })
+
+  it("accepte explicitement « à qualifier » : famille et centre de frais à null", () => {
+    // Dé-qualifier est une décision légitime (machine reclassée, erreur corrigée).
+    // Elle passe par le même chemin audité, motif compris.
+    const parsed = qualifyMachineSchema.safeParse({ ...BASE, machine_family_code: null, cf_id: null })
+    expect(parsed.success).toBe(true)
+  })
+
+  it("refuse une qualification sans motif ou avec un motif vide", () => {
+    expect(qualifyMachineSchema.safeParse({ ...BASE, motif: undefined }).success).toBe(false)
+    expect(qualifyMachineSchema.safeParse({ ...BASE, motif: "   " }).success).toBe(false)
+    expect(qualifyMachineSchema.safeParse({ ...BASE, motif: "ok" }).success).toBe(false)
+  })
+
+  it("exige le verrou optimiste : deux Méthodes ne se écrasent pas en silence", () => {
+    expect(qualifyMachineSchema.safeParse({ ...BASE, expected_updated_at: undefined }).success).toBe(false)
+    expect(qualifyMachineSchema.safeParse({ ...BASE, expected_updated_at: "" }).success).toBe(false)
+  })
+
+  it("normalise le code de famille et refuse un code fantaisiste", () => {
+    const parsed = qualifyMachineSchema.safeParse({ ...BASE, machine_family_code: " ttrad " })
+    expect(parsed.success && parsed.data.machine_family_code).toBe("TTRAD")
+    expect(qualifyMachineSchema.safeParse({ ...BASE, machine_family_code: "F raisage" }).success).toBe(false)
+  })
+
+  it("refuse une date de validité hors format AAAA-MM-JJ", () => {
+    expect(qualifyMachineSchema.safeParse({ ...BASE, valid_from: "2026-01-01" }).success).toBe(true)
+    expect(qualifyMachineSchema.safeParse({ ...BASE, valid_from: "01/01/2026" }).success).toBe(false)
+  })
+
+  it("refuse un identifiant de machine qui n'est pas un UUID", () => {
+    expect(machineIdParamSchema.safeParse({ machineId: MACHINE_ID }).success).toBe(true)
+    expect(machineIdParamSchema.safeParse({ machineId: "MCH-000193" }).success).toBe(false)
+  })
+})
+
+describe("Qualification machine — parcours de lecture", () => {
+  it("le filtre « à qualifier » est explicite et vaut false par défaut", () => {
+    const parsed = listMachinesQualificationQuerySchema.safeParse({})
+    expect(parsed.success && parsed.data.only_unqualified).toBe(false)
+    expect(parsed.success && parsed.data.include_archived).toBe(false)
+
+    const filtered = listMachinesQualificationQuerySchema.safeParse({ only_unqualified: "true" })
+    expect(filtered.success && filtered.data.only_unqualified).toBe(true)
+  })
+
+  it("l'aperçu d'impact accepte une famille candidate, ou aucune", () => {
+    expect(previewMachineQualificationQuerySchema.safeParse({}).success).toBe(true)
+    const parsed = previewMachineQualificationQuerySchema.safeParse({ machine_family_code: "t" })
+    expect(parsed.success && parsed.data.machine_family_code).toBe("T")
+  })
+})
+
+describe("Qualification machine — droits", () => {
+  it("lire le parc suffit en lecture de référentiel ; le qualifier exige l'écriture", () => {
+    // Un opérateur atelier consulte le parc mais ne le requalifie pas.
+    expect(roleHasMethodesCapability("Atelier", "referentiel_read")).toBe(true)
+    expect(roleHasMethodesCapability("Atelier", "referentiel_write")).toBe(false)
+
+    // Les Méthodes et la Programmation qualifient.
+    expect(roleHasMethodesCapability("Method", "referentiel_write")).toBe(true)
+    expect(roleHasMethodesCapability("Responsable Programmation", "referentiel_write")).toBe(true)
+  })
+
+  it("qualifier ne donne aucun droit sur les taux horaires", () => {
+    // Séparation voulue : les Méthodes classent le parc, la gestion fixe les prix.
+    const methodes = methodesCapabilitiesFor("Method")
+    expect(methodes.referentiel_write).toBe(true)
+    expect(methodes.tarif_write).toBe(false)
+  })
+
+  it("un rôle inconnu ou vide ne qualifie rien", () => {
+    expect(roleHasMethodesCapability(null, "referentiel_write")).toBe(false)
+    expect(roleHasMethodesCapability("", "referentiel_write")).toBe(false)
+    expect(roleHasMethodesCapability("Stagiaire", "referentiel_write")).toBe(false)
+  })
+})

--- a/src/__tests__/of-snapshot-methodes-233.test.ts
+++ b/src/__tests__/of-snapshot-methodes-233.test.ts
@@ -1,0 +1,182 @@
+// Snapshot d'OF — ce que le lancement fige réellement (#233 / crp-systems-web#384).
+//
+// Le SQL de `copyPieceOperationsToOf` n'est pas testable « à l'unité » sans base ;
+// ce qui EST testable, et ce qui a réellement cassé, c'est :
+//   1. la LISTE des colonnes figées — une colonne oubliée = une preuve perdue ;
+//   2. l'ACCORD ARITHMÉTIQUE entre le SQL de l'OF et `computeOperationTimes`,
+//      la formule autoritaire de la gamme.
+// Le point 2 est vérifié en rejouant la formule SQL en JavaScript sur des jeux
+// de valeurs qui font justement diverger l'ancienne implémentation.
+
+import { describe, expect, it } from "vitest"
+
+import { computeOperationTimes } from "../module/methodes/domain/methodes-policy"
+import { copyPieceOperationsToOf, loadApplicableTechnicalSnapshot } from "../module/production/domain/of-generation"
+
+/** Capture le SQL sans toucher à une base. */
+function makeSqlSpy(rows: unknown[] = []) {
+  const statements: string[] = []
+  return {
+    statements,
+    tx: {
+      query: async (sql: string) => {
+        statements.push(sql)
+        return { rows, rowCount: rows.length } as never
+      },
+    },
+  }
+}
+
+const round = (value: number, decimals: number) => {
+  const factor = 10 ** decimals
+  return Math.round(value * factor) / factor
+}
+
+/** Transcription exacte du SQL de `copyPieceOperationsToOf`. */
+function sqlPlannedTimes(tp: number, tfUnit: number, qte: number, coef: number) {
+  const tempsFabrication = round(tfUnit * qte * coef, 4)
+  return { temps_fabrication_planned: tempsFabrication, temps_total_planned: round(tp + tempsFabrication, 3) }
+}
+
+/** Ancienne implémentation, conservée comme témoin de non-régression. */
+function legacyPlannedTotal(tp: number, tfUnit: number, qte: number, coef: number) {
+  return round((tp + tfUnit * qte) * coef, 3)
+}
+
+describe("Snapshot OF — colonnes figées", () => {
+  it("recopie famille, machine, programme, centre de frais et tarif retenu", async () => {
+    const spy = makeSqlSpy()
+    await copyPieceOperationsToOf(spy.tx, {
+      of_id: 1,
+      piece_technique_id: "11111111-1111-1111-1111-111111111111",
+      gamme_id: "22222222-2222-2222-2222-222222222222",
+    })
+    const sql = spy.statements.join("\n")
+
+    for (const column of [
+      "machine_family_code",
+      "numero_programme",
+      "cf_code_snapshot",
+      "cf_rate_id",
+      "hourly_rate_source",
+      "hourly_rate_effective_at",
+      "temps_fabrication_planned",
+    ]) {
+      expect(sql, `colonne ${column} absente du snapshot`).toContain(column)
+    }
+  })
+
+  it("ne perd plus la machine choisie en gamme", async () => {
+    const spy = makeSqlSpy()
+    await copyPieceOperationsToOf(spy.tx, {
+      of_id: 1,
+      piece_technique_id: "11111111-1111-1111-1111-111111111111",
+      gamme_id: null,
+    })
+    const sql = spy.statements.join("\n")
+    // La régression exacte : `NULL::uuid AS machine_id`.
+    expect(sql).not.toMatch(/NULL::uuid\s+AS\s+machine_id/)
+    expect(sql).toContain("pto.machine_id")
+  })
+
+  it("recopie le code lisible du centre de frais, pas seulement son identifiant", async () => {
+    const spy = makeSqlSpy()
+    await copyPieceOperationsToOf(spy.tx, {
+      of_id: 1,
+      piece_technique_id: "11111111-1111-1111-1111-111111111111",
+      gamme_id: null,
+    })
+    const sql = spy.statements.join("\n")
+    // Sans cette jointure, archiver un centre de frais rendrait le snapshot illisible.
+    expect(sql).toContain("LEFT JOIN public.centres_frais cf ON cf.id = pto.cf_id")
+    expect(sql).toContain("cf.code AS cf_code_snapshot")
+  })
+})
+
+describe("Snapshot OF — accord des temps avec la gamme", () => {
+  const cases = [
+    { tp: 0, tf: 0, qte: 1, coef: 1 },
+    { tp: 0.5, tf: 0.02, qte: 1, coef: 1 },
+    { tp: 2, tf: 0.1, qte: 1, coef: 1 },
+    // Les cas qui font diverger l'ancienne formule : coef ≠ 1 ET tp ≠ 0.
+    { tp: 2, tf: 0.1, qte: 1, coef: 1.2 },
+    { tp: 1.5, tf: 0.25, qte: 10, coef: 0.8 },
+    { tp: 0.75, tf: 0.033, qte: 250, coef: 1.05 },
+  ]
+
+  it("le SQL de l'OF donne exactement le temps calculé par la gamme", () => {
+    for (const { tp, tf, qte, coef } of cases) {
+      const gamme = computeOperationTimes({
+        temps_preparation: tp,
+        temps_unitaire: tf,
+        quantite_base: qte,
+        coefficient: coef,
+      })
+      const of = sqlPlannedTimes(tp, tf, qte, coef)
+      expect(of.temps_fabrication_planned, `temps_fabrication pour ${JSON.stringify({ tp, tf, qte, coef })}`).toBe(
+        gamme.temps_fabrication,
+      )
+      // `temps_total_planned` est stocké en numeric(12,3) : on compare à 3 décimales.
+      expect(of.temps_total_planned, `temps_final pour ${JSON.stringify({ tp, tf, qte, coef })}`).toBe(
+        round(gamme.temps_final, 3),
+      )
+    }
+  })
+
+  it("l'ancienne formule divergeait bien dès que coef ≠ 1 et tp ≠ 0", () => {
+    // Sans ce témoin, la correction pourrait être annulée sans que rien n'échoue.
+    const divergent = { tp: 2, tf: 0.1, qte: 1, coef: 1.2 }
+    const gamme = computeOperationTimes({
+      temps_preparation: divergent.tp,
+      temps_unitaire: divergent.tf,
+      quantite_base: divergent.qte,
+      coefficient: divergent.coef,
+    })
+    expect(legacyPlannedTotal(divergent.tp, divergent.tf, divergent.qte, divergent.coef)).not.toBe(
+      round(gamme.temps_final, 3),
+    )
+
+    // …et restait juste quand coef = 1 : la correction ne réécrit pas l'histoire
+    // des OF lancés sans coefficient.
+    const neutre = { tp: 2, tf: 0.1, qte: 3, coef: 1 }
+    const gammeNeutre = computeOperationTimes({
+      temps_preparation: neutre.tp,
+      temps_unitaire: neutre.tf,
+      quantite_base: neutre.qte,
+      coefficient: neutre.coef,
+    })
+    expect(legacyPlannedTotal(neutre.tp, neutre.tf, neutre.qte, neutre.coef)).toBe(round(gammeNeutre.temps_final, 3))
+  })
+
+  it("la quantité de base n'est jamais multipliée deux fois", () => {
+    // `qte` est la quantité de BASE de la gamme. Le SQL ne doit pas la
+    // remultiplier par la quantité lancée de l'OF.
+    const base = sqlPlannedTimes(1, 0.5, 4, 1)
+    expect(base.temps_fabrication_planned).toBe(2) // 0.5 × 4 × 1, pas 0.5 × 4 × 4.
+    expect(base.temps_total_planned).toBe(3)
+  })
+})
+
+describe("Snapshot JSON — preuve figée lisible", () => {
+  it("embarque référentiels en clair, programme, unité de temps et coûts", async () => {
+    const spy = makeSqlSpy([{ version_id: "v", gamme_id: "g", version_interne: 1, snapshot: { ok: true } }])
+    await loadApplicableTechnicalSnapshot(spy.tx, "11111111-1111-1111-1111-111111111111")
+    const sql = spy.statements.join("\n")
+
+    for (const key of [
+      "'machine_family_code'",
+      "'machine_family_libelle'",
+      "'machine_code'",
+      "'numero_programme'",
+      "'cf_code'",
+      "'cf_rate_id'",
+      "'taux_horaire_source'",
+      "'unite_temps', 'HEURES_DECIMALES'",
+      "'temps_fabrication'",
+      "'cout_mo'",
+      "'ordre'",
+    ]) {
+      expect(sql, `clé ${key} absente du snapshot JSON`).toContain(key)
+    }
+  })
+})

--- a/src/module/access-control/domain/module-catalog.ts
+++ b/src/module/access-control/domain/module-catalog.ts
@@ -122,9 +122,10 @@ export const MODULE_CATALOG: readonly ModuleCatalogEntry[] = [
       "/dossiers",
       "/methodes",
     ],
-    // `methodes-centres-frais` est une page de CE module : sans elle dans la
-    // liste, l'entrée de navigation disparaîtrait pour tout compte filtré.
-    nav_page_keys: ["pieces-techniques", "methodes-centres-frais"],
+    // `methodes-centres-frais` et `methodes-parc-machines` sont des pages de CE
+    // module : sans elles dans la liste, leurs entrées de navigation
+    // disparaîtraient pour tout compte filtré.
+    nav_page_keys: ["pieces-techniques", "methodes-centres-frais", "methodes-parc-machines"],
     is_protected: false,
     sort_order: 100,
   },

--- a/src/module/methodes/controllers/methodes.controller.ts
+++ b/src/module/methodes/controllers/methodes.controller.ts
@@ -9,10 +9,14 @@ import {
   createCostCenterSVC,
   createMachineFamilySVC,
   getCostCenterSVC,
+  getMachineQualificationSVC,
   listCostCenterRatesSVC,
   listCostCentersSVC,
   listMachineFamiliesSVC,
   listMachineOptionsSVC,
+  listMachinesForQualificationSVC,
+  previewMachineQualificationSVC,
+  qualifyMachineSVC,
   updateCostCenterSVC,
   updateMachineFamilySVC,
 } from "../services/methodes.service";
@@ -24,6 +28,9 @@ import {
   listCostCentersQuerySchema,
   listFamiliesQuerySchema,
   listMachineOptionsQuerySchema,
+  listMachinesQualificationQuerySchema,
+  previewMachineQualificationQuerySchema,
+  qualifyMachineSchema,
   updateCostCenterSchema,
   updateFamilySchema,
   validatedQuery,
@@ -185,6 +192,70 @@ export const listMachineOptions: RequestHandler = async (req, res, next) => {
         include_unselectable: query.include_unselectable,
       })
     );
+  } catch (error) {
+    next(error);
+  }
+};
+
+/* -------------------------------------------------------------------------- */
+/* Qualification du parc machine (#233)                                       */
+/* -------------------------------------------------------------------------- */
+
+export const listMachinesForQualification: RequestHandler = async (req, res, next) => {
+  try {
+    const query = validatedQuery<ReturnType<(typeof listMachinesQualificationQuerySchema)["parse"]>>(req);
+    res.json(
+      await listMachinesForQualificationSVC({
+        search: query.search ?? null,
+        only_unqualified: query.only_unqualified,
+        include_archived: query.include_archived,
+      })
+    );
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getMachineQualification: RequestHandler = async (req, res, next) => {
+  try {
+    const out = await getMachineQualificationSVC(req.params.machineId);
+    if (!out) throw new HttpError(404, "NOT_FOUND", "Machine introuvable");
+    res.json(out);
+  } catch (error) {
+    next(error);
+  }
+};
+
+/** Aperçu d'impact : lecture seule, appelée avant de confirmer une décision. */
+export const previewMachineQualification: RequestHandler = async (req, res, next) => {
+  try {
+    const query = validatedQuery<ReturnType<(typeof previewMachineQualificationQuerySchema)["parse"]>>(req);
+    const out = await previewMachineQualificationSVC(req.params.machineId, query.machine_family_code ?? null);
+    if (!out) throw new HttpError(404, "NOT_FOUND", "Machine introuvable");
+    res.json(out);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const qualifyMachine: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildMethodesAuditContext(req);
+    const body = qualifyMachineSchema.parse(req.body);
+    const out = await qualifyMachineSVC(
+      req.params.machineId,
+      {
+        machine_family_code: body.machine_family_code,
+        cf_id: body.cf_id,
+        valid_from: body.valid_from ?? null,
+        valid_to: body.valid_to ?? null,
+        motif: body.motif,
+        expected_updated_at: body.expected_updated_at,
+      },
+      audit
+    );
+    if (!out) throw new HttpError(404, "NOT_FOUND", "Machine introuvable");
+    res.json(out);
   } catch (error) {
     next(error);
   }

--- a/src/module/methodes/repository/machine-qualification.repository.ts
+++ b/src/module/methodes/repository/machine-qualification.repository.ts
@@ -1,0 +1,494 @@
+// Qualification du parc machine (#233 / crp-systems-web#384).
+//
+// Qualifier une machine = lui donner sa FAMILLE (T, F, TTRAD, FTRAD, DECOUPE…),
+// son CENTRE DE FRAIS et sa période de validité. Les trois objets restent
+// distincts : la famille classe, le centre de frais valorise, la machine
+// exécute.
+//
+// RIEN N'EST DÉDUIT. Ni du code machine, ni du libellé, ni du champ `type`
+// (MILLING/TURNING ne distingue pas une CN d'une conventionnelle). Une machine
+// non qualifiée reste `null` et l'interface le dit — ADR-0020 « ne pas déduire
+// depuis le code machine ».
+//
+// CHAQUE DÉCISION EST JOURNALISÉE avec son état précédent et son motif : une
+// affectation qui change le coût des gammes futures doit pouvoir être relue et
+// défaite sans reconstitution.
+
+import type { PoolClient } from "pg";
+
+import db from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import { assertCostCenterSelectable, assertFamilySelectable, assertOptimisticVersion } from "../domain/methodes-policy";
+import type { AuditContext } from "../types/methodes.types";
+
+/* -------------------------------------------------------------------------- */
+/* Contrats                                                                   */
+/* -------------------------------------------------------------------------- */
+
+export type MachineQualificationEntryDTO = {
+  id: string;
+  previous_family_code: string | null;
+  previous_cf_id: string | null;
+  previous_cf_code: string | null;
+  previous_valid_from: string | null;
+  previous_valid_to: string | null;
+  new_family_code: string | null;
+  new_cf_id: string | null;
+  new_cf_code: string | null;
+  new_valid_from: string | null;
+  new_valid_to: string | null;
+  motif: string;
+  created_at: string;
+  created_by: number | null;
+  created_by_nom: string | null;
+};
+
+/**
+ * Ce qu'une requalification touche RÉELLEMENT. `of_operations_figees` est
+ * volontairement séparé : ces lignes sont des snapshots d'OF lancés, elles ne
+ * bougeront pas — les compter rassure au lieu d'inquiéter.
+ */
+export type MachineQualificationImpactDTO = {
+  operations_gammes_modifiables: number;
+  operations_gammes_publiees: number;
+  gammes_publiees_concernees: number;
+  of_operations_figees: number;
+  /** `true` si la nouvelle famille contredit une opération de gamme publiée. */
+  conflit_famille_gamme_publiee: boolean;
+};
+
+export type MachineQualificationDTO = {
+  id: string;
+  code: string;
+  name: string;
+  display_name: string | null;
+  legacy_alias: string | null;
+  type: string | null;
+  brand: string | null;
+  model: string | null;
+  status: string;
+  is_available: boolean;
+  location: string | null;
+  workshop_zone: string | null;
+  archived_at: string | null;
+  updated_at: string;
+  machine_family_code: string | null;
+  machine_family_libelle: string | null;
+  cf_id: string | null;
+  cf_code: string | null;
+  cf_designation: string | null;
+  valid_from: string | null;
+  valid_to: string | null;
+  /** `true` tant que la famille n'est pas renseignée : « À qualifier ». */
+  a_qualifier: boolean;
+  impact: MachineQualificationImpactDTO;
+  historique: MachineQualificationEntryDTO[];
+};
+
+export type QualifyMachineInput = {
+  machine_family_code: string | null;
+  cf_id: string | null;
+  valid_from: string | null;
+  valid_to: string | null;
+  motif: string;
+  expected_updated_at: string;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Lecture                                                                    */
+/* -------------------------------------------------------------------------- */
+
+const MACHINE_COLS = `
+  m.id::text AS id, m.code, m.name, m.display_name, m.legacy_alias,
+  m.type::text AS type, m.brand, m.model, m.status::text AS status, m.is_available,
+  m.location, m.workshop_zone, m.archived_at::text AS archived_at,
+  m.updated_at::text AS updated_at,
+  m.machine_family_code, fam.libelle AS machine_family_libelle,
+  m.cf_id::text AS cf_id, cf.code AS cf_code, cf.designation AS cf_designation,
+  m.valid_from::text AS valid_from, m.valid_to::text AS valid_to
+`;
+
+const MACHINE_FROM = `
+  FROM public.machines m
+  LEFT JOIN public.production_machine_families fam ON fam.code = m.machine_family_code
+  LEFT JOIN public.centres_frais cf ON cf.id = m.cf_id
+`;
+
+/**
+ * Impact d'une requalification. `candidateFamily` vaut `undefined` en lecture
+ * simple : on ne signale un conflit que lorsqu'une nouvelle famille est proposée.
+ */
+async function loadImpact(
+  tx: Pick<PoolClient, "query">,
+  machineId: string,
+  candidateFamily?: string | null
+): Promise<MachineQualificationImpactDTO> {
+  const res = await tx.query<{
+    operations_gammes_modifiables: string;
+    operations_gammes_publiees: string;
+    gammes_publiees_concernees: string;
+    of_operations_figees: string;
+    conflit: boolean;
+  }>(
+    `
+      SELECT
+        count(*) FILTER (WHERE g.statut IN ('BROUILLON', 'EN_VALIDATION'))            AS operations_gammes_modifiables,
+        count(*) FILTER (WHERE g.statut = 'APPLICABLE')                                AS operations_gammes_publiees,
+        count(DISTINCT g.id) FILTER (WHERE g.statut = 'APPLICABLE')                    AS gammes_publiees_concernees,
+        (SELECT count(*) FROM public.of_operations WHERE machine_id = $1::uuid)        AS of_operations_figees,
+        COALESCE(bool_or(
+          g.statut = 'APPLICABLE'
+          AND op.machine_family_code IS NOT NULL
+          AND op.machine_family_code IS DISTINCT FROM $2::text
+        ), false)                                                                      AS conflit
+      FROM public.pieces_techniques_operations op
+      JOIN public.gammes g ON g.id = op.gamme_id
+     WHERE op.machine_id = $1::uuid
+    `,
+    [machineId, candidateFamily ?? null]
+  );
+  const row = res.rows[0];
+  return {
+    operations_gammes_modifiables: Number(row?.operations_gammes_modifiables ?? 0),
+    operations_gammes_publiees: Number(row?.operations_gammes_publiees ?? 0),
+    gammes_publiees_concernees: Number(row?.gammes_publiees_concernees ?? 0),
+    of_operations_figees: Number(row?.of_operations_figees ?? 0),
+    conflit_famille_gamme_publiee: candidateFamily === undefined ? false : Boolean(row?.conflit),
+  };
+}
+
+async function loadHistory(
+  tx: Pick<PoolClient, "query">,
+  machineId: string
+): Promise<MachineQualificationEntryDTO[]> {
+  const res = await tx.query(
+    `
+      SELECT q.id::text AS id,
+             q.previous_family_code, q.previous_cf_id::text AS previous_cf_id,
+             prev_cf.code AS previous_cf_code,
+             q.previous_valid_from::text AS previous_valid_from,
+             q.previous_valid_to::text   AS previous_valid_to,
+             q.new_family_code, q.new_cf_id::text AS new_cf_id,
+             new_cf.code AS new_cf_code,
+             q.new_valid_from::text AS new_valid_from,
+             q.new_valid_to::text   AS new_valid_to,
+             q.motif, q.created_at::text AS created_at, q.created_by,
+             NULLIF(btrim(COALESCE(u.name, '') || ' ' || COALESCE(u.surname, '')), '') AS created_by_nom
+        FROM public.production_machine_qualifications q
+        LEFT JOIN public.centres_frais prev_cf ON prev_cf.id = q.previous_cf_id
+        LEFT JOIN public.centres_frais new_cf  ON new_cf.id  = q.new_cf_id
+        LEFT JOIN public.users u ON u.id = q.created_by
+       WHERE q.machine_id = $1::uuid
+       ORDER BY q.created_at DESC, q.id DESC
+       LIMIT 200
+    `,
+    [machineId]
+  );
+  return res.rows.map((row) => ({
+    id: String(row.id),
+    previous_family_code: (row.previous_family_code as string | null) ?? null,
+    previous_cf_id: (row.previous_cf_id as string | null) ?? null,
+    previous_cf_code: (row.previous_cf_code as string | null) ?? null,
+    previous_valid_from: (row.previous_valid_from as string | null) ?? null,
+    previous_valid_to: (row.previous_valid_to as string | null) ?? null,
+    new_family_code: (row.new_family_code as string | null) ?? null,
+    new_cf_id: (row.new_cf_id as string | null) ?? null,
+    new_cf_code: (row.new_cf_code as string | null) ?? null,
+    new_valid_from: (row.new_valid_from as string | null) ?? null,
+    new_valid_to: (row.new_valid_to as string | null) ?? null,
+    motif: String(row.motif),
+    created_at: String(row.created_at),
+    created_by: row.created_by === null || row.created_by === undefined ? null : Number(row.created_by),
+    created_by_nom: (row.created_by_nom as string | null) ?? null,
+  }));
+}
+
+function mapMachine(
+  row: Record<string, unknown>,
+  impact: MachineQualificationImpactDTO,
+  historique: MachineQualificationEntryDTO[]
+): MachineQualificationDTO {
+  const familyCode = (row.machine_family_code as string | null) ?? null;
+  return {
+    id: String(row.id),
+    code: String(row.code),
+    name: String(row.name),
+    display_name: (row.display_name as string | null) ?? null,
+    legacy_alias: (row.legacy_alias as string | null) ?? null,
+    type: (row.type as string | null) ?? null,
+    brand: (row.brand as string | null) ?? null,
+    model: (row.model as string | null) ?? null,
+    status: String(row.status),
+    is_available: Boolean(row.is_available),
+    location: (row.location as string | null) ?? null,
+    workshop_zone: (row.workshop_zone as string | null) ?? null,
+    archived_at: (row.archived_at as string | null) ?? null,
+    updated_at: String(row.updated_at),
+    machine_family_code: familyCode,
+    machine_family_libelle: (row.machine_family_libelle as string | null) ?? null,
+    cf_id: (row.cf_id as string | null) ?? null,
+    cf_code: (row.cf_code as string | null) ?? null,
+    cf_designation: (row.cf_designation as string | null) ?? null,
+    valid_from: (row.valid_from as string | null) ?? null,
+    valid_to: (row.valid_to as string | null) ?? null,
+    a_qualifier: familyCode === null,
+    impact,
+    historique,
+  };
+}
+
+/** Parc machine complet vu par les Méthodes : qualifiées et à qualifier. */
+export async function repoListMachinesForQualification(params: {
+  search: string | null;
+  only_unqualified: boolean;
+  include_archived: boolean;
+}): Promise<MachineQualificationDTO[]> {
+  const res = await db.query(
+    `SELECT ${MACHINE_COLS},
+            (SELECT count(*) FROM public.production_machine_qualifications q WHERE q.machine_id = m.id)
+              AS historique_count
+     ${MACHINE_FROM}
+      WHERE ($1::text IS NULL
+             OR m.code ILIKE '%' || $1 || '%'
+             OR m.name ILIKE '%' || $1 || '%'
+             OR COALESCE(m.display_name, '') ILIKE '%' || $1 || '%'
+             OR COALESCE(m.brand, '') ILIKE '%' || $1 || '%'
+             OR COALESCE(m.model, '') ILIKE '%' || $1 || '%')
+        AND ($2::boolean IS NOT TRUE OR m.machine_family_code IS NULL)
+        AND ($3::boolean OR m.archived_at IS NULL)
+      ORDER BY (m.machine_family_code IS NOT NULL), m.code`,
+    [params.search, params.only_unqualified, params.include_archived]
+  );
+  // Une liste ne charge ni l'impact ni l'historique complet : le détail les
+  // fournit. Les compteurs à zéro ici ne sont donc PAS une affirmation d'absence.
+  const empty: MachineQualificationImpactDTO = {
+    operations_gammes_modifiables: 0,
+    operations_gammes_publiees: 0,
+    gammes_publiees_concernees: 0,
+    of_operations_figees: 0,
+    conflit_famille_gamme_publiee: false,
+  };
+  return res.rows.map((row) => mapMachine(row, empty, []));
+}
+
+export async function repoGetMachineQualification(machineId: string): Promise<MachineQualificationDTO | null> {
+  const res = await db.query(`SELECT ${MACHINE_COLS} ${MACHINE_FROM} WHERE m.id = $1::uuid`, [machineId]);
+  const row = res.rows[0];
+  if (!row) return null;
+  const [impact, historique] = await Promise.all([loadImpact(db, machineId), loadHistory(db, machineId)]);
+  return mapMachine(row, impact, historique);
+}
+
+/** Aperçu d'impact AVANT décision. Lecture seule, aucune écriture. */
+export async function repoPreviewMachineQualification(
+  machineId: string,
+  candidateFamily: string | null
+): Promise<MachineQualificationImpactDTO | null> {
+  const exists = await db.query(`SELECT 1 FROM public.machines WHERE id = $1::uuid`, [machineId]);
+  if (exists.rowCount === 0) return null;
+  return loadImpact(db, machineId, candidateFamily);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Écriture                                                                   */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Qualifie une machine. Transaction unique : verrou sur la machine, contrôle du
+ * référentiel, journal, mise à jour, audit. Si le journal échoue, la machine
+ * n'est pas modifiée — une qualification sans trace n'existe pas.
+ *
+ * Les OPÉRATIONS DÉJÀ SAISIES ne sont jamais réécrites : une gamme publiée garde
+ * la famille qu'elle portait. Seules les saisies futures voient la nouvelle
+ * qualification.
+ */
+export async function repoQualifyMachine(
+  machineId: string,
+  input: QualifyMachineInput,
+  audit: AuditContext
+): Promise<MachineQualificationDTO | null> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+
+    const currentRes = await client.query<{
+      updated_at: string;
+      code: string;
+      machine_family_code: string | null;
+      cf_id: string | null;
+      valid_from: string | null;
+      valid_to: string | null;
+      archived_at: string | null;
+    }>(
+      `SELECT updated_at::text AS updated_at, code, machine_family_code, cf_id::text AS cf_id,
+              valid_from::text AS valid_from, valid_to::text AS valid_to, archived_at::text AS archived_at
+         FROM public.machines WHERE id = $1::uuid FOR UPDATE`,
+      [machineId]
+    );
+    const current = currentRes.rows[0];
+    if (!current) {
+      await client.query("ROLLBACK").catch(() => {});
+      return null;
+    }
+    if (current.archived_at) {
+      throw new HttpError(
+        422,
+        "MACHINE_ARCHIVED",
+        `La machine ${current.code} est archivée : elle ne se requalifie plus. Réactivez-la d'abord.`
+      );
+    }
+
+    assertOptimisticVersion({
+      expectedUpdatedAt: input.expected_updated_at,
+      currentUpdatedAt: current.updated_at,
+      label: `la machine ${current.code}`,
+    });
+
+    // Famille : doit exister ET être active. `null` = « à qualifier » assumé.
+    if (input.machine_family_code !== null) {
+      const familyRes = await client.query<{
+        code: string;
+        libelle: string;
+        programme_requis: boolean;
+        actif: boolean;
+      }>(
+        `SELECT code, libelle, programme_requis, actif
+           FROM public.production_machine_families WHERE code = $1`,
+        [input.machine_family_code]
+      );
+      assertFamilySelectable(familyRes.rows[0] ?? null, input.machine_family_code);
+    }
+
+    // Centre de frais : doit exister ET être actif.
+    if (input.cf_id !== null) {
+      const cfRes = await client.query(
+        `SELECT id::text AS id, code, designation, statut, devise, machine_family_code,
+                designation_auto, designation_modele
+           FROM public.centres_frais WHERE id = $1::uuid`,
+        [input.cf_id]
+      );
+      const cf = cfRes.rows[0];
+      assertCostCenterSelectable(
+        cf
+          ? {
+              id: String(cf.id),
+              code: String(cf.code),
+              designation: String(cf.designation),
+              statut: String(cf.statut),
+              devise: String(cf.devise),
+              machine_family_code: (cf.machine_family_code as string | null) ?? null,
+              designation_auto: Boolean(cf.designation_auto),
+              designation_modele: (cf.designation_modele as string | null) ?? null,
+            }
+          : null,
+        input.cf_id
+      );
+      // Un centre de frais rattaché à une AUTRE famille produirait un coût
+      // incohérent avec le classement de la machine : on refuse au lieu de
+      // laisser passer une contradiction silencieuse.
+      const cfFamily = (cf?.machine_family_code as string | null) ?? null;
+      if (cfFamily !== null && input.machine_family_code !== null && cfFamily !== input.machine_family_code) {
+        throw new HttpError(
+          422,
+          "COST_CENTER_FAMILY_MISMATCH",
+          `Le centre de frais ${String(cf?.code)} est rattaché à la famille ${cfFamily}, pas à ${input.machine_family_code}.`,
+          { cf_family_code: cfFamily, machine_family_code: input.machine_family_code }
+        );
+      }
+    }
+
+    if (input.valid_from && input.valid_to && input.valid_to < input.valid_from) {
+      throw new HttpError(422, "MACHINE_VALIDITY_INVALID", "La fin de validité précède le début de validité.");
+    }
+
+    const unchanged =
+      current.machine_family_code === input.machine_family_code &&
+      current.cf_id === input.cf_id &&
+      current.valid_from === input.valid_from &&
+      current.valid_to === input.valid_to;
+    if (unchanged) {
+      throw new HttpError(
+        409,
+        "MACHINE_QUALIFICATION_UNCHANGED",
+        "Aucun changement : la machine porte déjà cette qualification."
+      );
+    }
+
+    // Journal AVANT mise à jour : l'état précédent est encore lisible.
+    await client.query(
+      `INSERT INTO public.production_machine_qualifications
+         (machine_id, previous_family_code, previous_cf_id, previous_valid_from, previous_valid_to,
+          new_family_code, new_cf_id, new_valid_from, new_valid_to, motif, created_by)
+       VALUES ($1::uuid,$2,$3::uuid,$4::date,$5::date,$6,$7::uuid,$8::date,$9::date,$10,$11)`,
+      [
+        machineId,
+        current.machine_family_code,
+        current.cf_id,
+        current.valid_from,
+        current.valid_to,
+        input.machine_family_code,
+        input.cf_id,
+        input.valid_from,
+        input.valid_to,
+        input.motif.trim(),
+        audit.user_id,
+      ]
+    );
+
+    await client.query(
+      `UPDATE public.machines
+          SET machine_family_code = $2,
+              cf_id               = $3::uuid,
+              valid_from          = $4::date,
+              valid_to            = $5::date,
+              updated_by          = $6,
+              updated_at          = now()
+        WHERE id = $1::uuid`,
+      [machineId, input.machine_family_code, input.cf_id, input.valid_from, input.valid_to, audit.user_id]
+    );
+
+    await repoInsertAuditLog({
+      user_id: audit.user_id,
+      body: {
+        event_type: "ACTION",
+        action: "methodes.machine.qualify",
+        page_key: audit.page_key,
+        entity_type: "machine",
+        entity_id: machineId,
+        path: audit.path,
+        client_session_id: audit.client_session_id,
+        details: {
+          code: current.code,
+          avant: {
+            machine_family_code: current.machine_family_code,
+            cf_id: current.cf_id,
+            valid_from: current.valid_from,
+            valid_to: current.valid_to,
+          },
+          apres: {
+            machine_family_code: input.machine_family_code,
+            cf_id: input.cf_id,
+            valid_from: input.valid_from,
+            valid_to: input.valid_to,
+          },
+          motif: input.motif.trim(),
+        },
+      },
+      ip: audit.ip,
+      user_agent: audit.user_agent,
+      device_type: audit.device_type,
+      os: audit.os,
+      browser: audit.browser,
+      tx: client,
+    });
+
+    await client.query("COMMIT");
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => {});
+    throw error;
+  } finally {
+    client.release();
+  }
+  return repoGetMachineQualification(machineId);
+}

--- a/src/module/methodes/routes/methodes.routes.ts
+++ b/src/module/methodes/routes/methodes.routes.ts
@@ -11,10 +11,14 @@ import {
   createCostCenter,
   createMachineFamily,
   getCostCenter,
+  getMachineQualification,
   listCostCenterRates,
   listCostCenters,
   listMachineFamilies,
   listMachineOptions,
+  listMachinesForQualification,
+  previewMachineQualification,
+  qualifyMachine,
   readMethodesCapabilities,
   updateCostCenter,
   updateMachineFamily,
@@ -26,6 +30,9 @@ import {
   listCostCentersQuerySchema,
   listFamiliesQuerySchema,
   listMachineOptionsQuerySchema,
+  listMachinesQualificationQuerySchema,
+  machineIdParamSchema,
+  previewMachineQualificationQuerySchema,
   validate,
 } from "../validators/methodes.validators";
 
@@ -89,6 +96,39 @@ router.get(
   requireMethodesCapability("referentiel_read"),
   validate(listMachineOptionsQuerySchema, "query"),
   listMachineOptions
+);
+
+/* Qualification du parc machine (#233).
+ * Déclaré APRÈS `/machines` et sur des chemins distincts : `/machines/parc` ne
+ * peut pas être capturé comme un identifiant puisqu'il n'est pas un UUID, mais
+ * l'ordre reste explicite pour qui relira ce fichier.
+ * LIRE le parc relève du référentiel ; le QUALIFIER est un acte Méthodes
+ * (`referentiel_write`), au même titre que créer une famille. */
+router.get(
+  "/machines/parc",
+  requireMethodesCapability("referentiel_read"),
+  validate(listMachinesQualificationQuerySchema, "query"),
+  listMachinesForQualification
+);
+router.get(
+  "/machines/:machineId/qualification",
+  requireMethodesCapability("referentiel_read"),
+  validate(machineIdParamSchema, "params"),
+  getMachineQualification
+);
+// Aperçu d'impact AVANT décision : lecture seule, jamais d'écriture.
+router.get(
+  "/machines/:machineId/qualification/impact",
+  requireMethodesCapability("referentiel_read"),
+  validate(machineIdParamSchema, "params"),
+  validate(previewMachineQualificationQuerySchema, "query"),
+  previewMachineQualification
+);
+router.patch(
+  "/machines/:machineId/qualification",
+  requireMethodesCapability("referentiel_write"),
+  validate(machineIdParamSchema, "params"),
+  qualifyMachine
 );
 
 export default router;

--- a/src/module/methodes/services/methodes.service.ts
+++ b/src/module/methodes/services/methodes.service.ts
@@ -23,6 +23,15 @@ import {
   type UpdateCostCenterInput,
   type UpdateMachineFamilyInput,
 } from "../repository/methodes.repository";
+import {
+  repoGetMachineQualification,
+  repoListMachinesForQualification,
+  repoPreviewMachineQualification,
+  repoQualifyMachine,
+  type MachineQualificationDTO,
+  type MachineQualificationImpactDTO,
+  type QualifyMachineInput,
+} from "../repository/machine-qualification.repository";
 import type {
   AuditContext,
   CostCenterDTO,
@@ -99,4 +108,39 @@ export async function addCostCenterRateSVC(
 export async function listMachineOptionsSVC(params: ListMachineOptionsParams): Promise<MachineOptionDTO[]> {
   await assertFamilyUsable(params.machine_family_code);
   return repoListMachineOptions(params);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Qualification du parc machine (#233)                                       */
+/* -------------------------------------------------------------------------- */
+
+export const listMachinesForQualificationSVC = (params: {
+  search: string | null;
+  only_unqualified: boolean;
+  include_archived: boolean;
+}): Promise<MachineQualificationDTO[]> => repoListMachinesForQualification(params);
+
+export const getMachineQualificationSVC = (machineId: string): Promise<MachineQualificationDTO | null> =>
+  repoGetMachineQualification(machineId);
+
+export async function previewMachineQualificationSVC(
+  machineId: string,
+  candidateFamily: string | null
+): Promise<MachineQualificationImpactDTO | null> {
+  await assertFamilyUsable(candidateFamily);
+  return repoPreviewMachineQualification(machineId, candidateFamily);
+}
+
+/**
+ * La famille est revalidée ICI en plus du repository : le service voit le
+ * référentiel complet (libellé, `programme_requis`) et rend un refus lisible
+ * avant même d'ouvrir une transaction.
+ */
+export async function qualifyMachineSVC(
+  machineId: string,
+  input: QualifyMachineInput,
+  audit: AuditContext
+): Promise<MachineQualificationDTO | null> {
+  await assertFamilyUsable(input.machine_family_code);
+  return repoQualifyMachine(machineId, input, audit);
 }

--- a/src/module/methodes/validators/methodes.validators.ts
+++ b/src/module/methodes/validators/methodes.validators.ts
@@ -135,6 +135,35 @@ export const listMachineOptionsQuerySchema = z.object({
   include_unselectable: booleanish.optional().default(true),
 });
 
+export const machineIdParamSchema = z.object({ machineId: uuid });
+
+export const listMachinesQualificationQuerySchema = z.object({
+  search: z.string().trim().min(1).max(120).optional(),
+  /** `true` = seulement les machines dont la famille n'est pas renseignée. */
+  only_unqualified: booleanish.optional().default(false),
+  include_archived: booleanish.optional().default(false),
+});
+
+export const previewMachineQualificationQuerySchema = z.object({
+  machine_family_code: familyCode.optional(),
+});
+
+/**
+ * Qualification d'une machine. `machine_family_code` et `cf_id` acceptent
+ * explicitement `null` : « à qualifier » est une valeur assumée, pas un oubli.
+ * Le `motif` est obligatoire — une affectation qui change le coût des gammes
+ * futures se justifie par écrit.
+ */
+export const qualifyMachineSchema = z.object({
+  machine_family_code: familyCode.nullable(),
+  cf_id: uuid.nullable(),
+  valid_from: isoDate.nullable().optional().default(null),
+  valid_to: isoDate.nullable().optional().default(null),
+  motif: z.string().trim().min(5, "Le motif de la qualification est obligatoire (au moins 5 caractères)").max(1000),
+  expected_updated_at: z.string().trim().min(1, "expected_updated_at est obligatoire"),
+});
+export type QualifyMachineBodyDTO = z.infer<typeof qualifyMachineSchema>;
+
 /* -------------------------------------------------------------------------- */
 /* Fragments partagés avec le module Gammes                                   */
 /* -------------------------------------------------------------------------- */

--- a/src/module/production/domain/of-generation.ts
+++ b/src/module/production/domain/of-generation.ts
@@ -193,6 +193,32 @@ export async function allocateOrdreFabricationId(tx: Queryable): Promise<number>
   return toInt(idRes.rows[0]?.of_id, "ordres_fabrication.id");
 }
 
+/**
+ * Recopie les opérations de la gamme applicable dans l'OF (#384).
+ *
+ * SNAPSHOT, PAS RÉFÉRENCE. Chaque valeur de gamme est FIGÉE dans la ligne d'OF :
+ * famille machine, machine, numéro de programme, centre de frais (id ET code
+ * lisible), tarif retenu (`cf_rate_id`), provenance et date d'effet du taux.
+ * Le code du centre de frais est recopié en clair (`cf_code_snapshot`) pour que
+ * l'archivage ultérieur d'un centre n'efface pas la trace.
+ *
+ * LE TAUX N'EST PAS RÉSOLU À NOUVEAU AU LANCEMENT : on recopie celui que la
+ * gamme porte déjà (gelé à la saisie depuis `production_cost_center_rates`).
+ * Re-résoudre ferait diverger le coût de l'OF de la gamme publiée que les
+ * Méthodes ont validée, sans que personne ne l'ait décidé. Un tarif posé APRÈS
+ * le lancement ne touche donc rien — c'est l'invariant demandé.
+ *
+ * FORMULE ALIGNÉE SUR `methodes-policy.computeOperationTimes` :
+ *   temps_fabrication = tf_unit × qte × coef
+ *   temps_final       = tp + temps_fabrication
+ * L'implémentation précédente calculait `(tp + tf_unit × qte) × coef`, ce qui
+ * appliquait le coefficient AUSSI au temps de préparation : l'OF affichait alors
+ * un temps différent de la gamme dès que `coef ≠ 1` et `tp ≠ 0`.
+ *
+ * `qte` est la QUANTITÉ DE BASE de la gamme, jamais la quantité de l'OF : la
+ * multiplication par la quantité lancée appartient au calcul de charge, pas au
+ * temps unitaire figé. Aucune double multiplication ici.
+ */
 export async function copyPieceOperationsToOf(tx: Queryable, params: {
   of_id: number;
   piece_technique_id: string;
@@ -205,13 +231,20 @@ export async function copyPieceOperationsToOf(tx: Queryable, params: {
         phase,
         designation,
         cf_id,
+        cf_code_snapshot,
+        cf_rate_id,
         poste_id,
         machine_id,
+        machine_family_code,
+        numero_programme,
         hourly_rate_applied,
+        hourly_rate_source,
+        hourly_rate_effective_at,
         tp,
         tf_unit,
         qte,
         coef,
+        temps_fabrication_planned,
         temps_total_planned,
         status,
         notes,
@@ -222,18 +255,31 @@ export async function copyPieceOperationsToOf(tx: Queryable, params: {
         pto.phase,
         pto.designation,
         pto.cf_id,
+        cf.code AS cf_code_snapshot,
+        pto.cf_rate_id,
         NULL::uuid AS poste_id,
-        NULL::uuid AS machine_id,
+        pto.machine_id,
+        pto.machine_family_code,
+        pto.numero_programme,
         COALESCE(pto.taux_horaire, 0)::numeric(12,2) AS hourly_rate_applied,
+        pto.taux_horaire_source AS hourly_rate_source,
+        pto.taux_horaire_effective_at AS hourly_rate_effective_at,
         COALESCE(pto.tp, 0)::numeric(12,3) AS tp,
         COALESCE(pto.tf_unit, 0)::numeric(12,3) AS tf_unit,
         COALESCE(pto.qte, 1)::numeric(12,3) AS qte,
         COALESCE(pto.coef, 1)::numeric(10,3) AS coef,
-        ROUND((COALESCE(pto.tp,0) + COALESCE(pto.tf_unit,0) * COALESCE(pto.qte,1)) * COALESCE(pto.coef,1), 3)::numeric(12,3) AS temps_total_planned,
+        ROUND(COALESCE(pto.tf_unit,0) * COALESCE(pto.qte,1) * COALESCE(pto.coef,1), 4)::numeric(12,4)
+          AS temps_fabrication_planned,
+        ROUND(
+          COALESCE(pto.tp,0)
+          + ROUND(COALESCE(pto.tf_unit,0) * COALESCE(pto.qte,1) * COALESCE(pto.coef,1), 4),
+          3
+        )::numeric(12,3) AS temps_total_planned,
         'TODO'::of_operation_status AS status,
         pto.designation_2 AS notes,
         pto.id AS source_piece_operation_id
       FROM public.pieces_techniques_operations pto
+      LEFT JOIN public.centres_frais cf ON cf.id = pto.cf_id
       WHERE pto.piece_technique_id = $2::uuid
         AND (pto.gamme_id = $3::uuid OR ($3::uuid IS NULL AND pto.gamme_id IS NULL))
       ORDER BY pto.phase ASC, pto.id ASC
@@ -316,14 +362,43 @@ export async function loadApplicableTechnicalSnapshot(
           'code_metier', v.code_metier,
           'date_effet', v.date_effet
         ),
-        'gamme', CASE WHEN g.id IS NULL THEN NULL ELSE jsonb_build_object('id', g.id::text, 'code', g.code, 'designation', g.designation) END,
+        'gamme', CASE WHEN g.id IS NULL THEN NULL ELSE jsonb_build_object(
+          'id', g.id::text, 'nom', g.nom, 'code', g.code, 'designation', g.designation,
+          'statut', g.statut, 'is_current', g.is_current, 'updated_at', g.updated_at
+        ) END,
+        -- Preuve figée d'une opération (#384). Les référentiels sont recopiés en
+        -- CLAIR (code famille, code et libellé du centre de frais, code et nom
+        -- machine) : renommer ou archiver un référentiel plus tard ne doit pas
+        -- rendre le snapshot illisible. La clé unite_temps est explicite pour
+        -- qu'un lecteur futur n'ait pas à deviner l'unité (heures décimales).
         'operations', COALESCE((
           SELECT jsonb_agg(jsonb_build_object(
-            'id', op.id::text, 'phase', op.phase, 'designation', op.designation,
-            'cf_id', op.cf_id::text, 'taux_horaire', op.taux_horaire,
-            'tp', op.tp, 'tf_unit', op.tf_unit, 'qte', op.qte, 'coef', op.coef
+            'id', op.id::text, 'phase', op.phase, 'ordre', op.ordre,
+            'designation', op.designation, 'type_operation', op.type_operation,
+            'machine_family_code', op.machine_family_code,
+            'machine_family_libelle', fam.libelle,
+            'machine_id', op.machine_id::text,
+            'machine_code', mac.code,
+            'machine_nom', COALESCE(mac.display_name, mac.name),
+            'numero_programme', op.numero_programme,
+            'cf_id', op.cf_id::text,
+            'cf_code', ccf.code,
+            'cf_designation', ccf.designation,
+            'cf_rate_id', op.cf_rate_id::text,
+            'taux_horaire', op.taux_horaire,
+            'taux_horaire_source', op.taux_horaire_source,
+            'taux_horaire_effective_at', op.taux_horaire_effective_at,
+            'devise', COALESCE(ccf.devise, 'EUR'),
+            'unite_temps', 'HEURES_DECIMALES',
+            'tp', op.tp, 'tf_unit', op.tf_unit, 'qte', op.qte, 'coef', op.coef,
+            'temps_fabrication', op.temps_fabrication, 'temps_total', op.temps_total,
+            'cout_mo', op.cout_mo,
+            'consignes', op.consignes
           ) ORDER BY op.phase, op.id)
           FROM public.pieces_techniques_operations op
+          LEFT JOIN public.production_machine_families fam ON fam.code = op.machine_family_code
+          LEFT JOIN public.machines mac ON mac.id = op.machine_id
+          LEFT JOIN public.centres_frais ccf ON ccf.id = op.cf_id
           WHERE op.piece_technique_id = pt.id
             AND (op.gamme_id = g.id OR (g.id IS NULL AND op.gamme_id IS NULL))
         ), '[]'::jsonb),


### PR DESCRIPTION
Promotion de `dev` vers `main` : snapshot d'OF complet et qualification traçable du parc machine.

Contenu : BigFootLime/erp-crp-backend#234 (closes #233).

- Snapshot d'OF : 7 colonnes de gamme désormais figées, `machine_id` conservé, formule de temps alignée sur `computeOperationTimes`, snapshot JSON hashé enrichi en clair.
- Qualification machine : `GET /methodes/machines/parc`, `GET|PATCH /methodes/machines/:id/qualification`, `GET …/impact`, journal `production_machine_qualifications`.
- Aucun backfill de famille machine.

Base de données déjà appliquée et vérifiée sur `cerp_test` **et** `cerp_prod`, migrations enregistrées.

⚠️ Merger ne déploie plus. Après merge, redéployer à la main le VPS Coolify et le backend atelier, sinon les nouvelles routes répondront 404 alors que la base est prête.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Snapshot ordre de fabrication operations now fully freeze relevant routing and costing data and align planned time calculations with the authoritative méthodes policy, and introduce a traceable machine qualification workflow and journal across API, services, database, access control, and tests.

New Features:
- Expose machine park qualification endpoints for listing machines, reading qualification, previewing impact, and applying qualifications with audit context.
- Add machine qualification DTOs, repository, and service layer to read, preview, and persist machine qualifications with impact analysis and audit logging.
- Introduce qualification journal table for machines with constraints, indexes, and supporting preflight/verify/rollback scripts to keep machine-family and cost-center changes auditable and reversible.
- Include OF snapshot JSON enrichment with explicit machine, family, cost center, program, timing, and costing fields for long-term readable traceability.

Bug Fixes:
- Correct OF planned time calculation to match computeOperationTimes by separating fabrication and total times without applying the coefficient to preparation time.
- Ensure OF snapshots retain the selected machine and human-readable cost center code so later archival or renaming does not break traceability.

Enhancements:
- Extend OF operation copy to freeze additional routing and costing attributes such as machine family, program number, rate metadata, and planned fabrication time.
- Update méthodes module validators and capabilities to support machine qualification workflows, including explicit optimistic locking and required justification.
- Adjust module catalog and access module configuration to register the new machine park page key for filtered navigation.

Build:
- Reference updated ADR for méthodes referentials in database patch comments to reflect current design documentation.

Deployment:
- Add database patch for machine qualification journal and related index/catalog updates, plus supporting preflight, verify, and rollback scripts for controlled rollout.

Tests:
- Add OF snapshot tests to guard the set of frozen columns and arithmetic agreement between OF SQL and méthodes time computation formula.
- Add machine qualification tests covering validation contracts, query filters, capability separation between read and write, and role-based access to qualification actions.