### PR TITLE
feat(of): versioning, replanification, AR client et document d'ordre de fabrication (#370)

### DIFF
--- a/db/patches/20260729_of_versioning_replanification_ar_370.sql
+++ b/db/patches/20260729_of_versioning_replanification_ar_370.sql
@@ -1,0 +1,775 @@
+-- 20260729_of_versioning_replanification_ar_370.sql
+--
+-- Chantier « OF, versioning, replanification, AR client et export PDF » (#370).
+--
+-- Reprise réconciliée du travail non livré de `feature/of-versioning-planning-ar-pdf`.
+-- Le schéma d'origine reste juste ; ce qui a changé depuis, c'est la normalisation
+-- des gammes (`20260729_methodes_gamme_referentials.sql`), qui a doté
+-- `of_operations` de `numero_programme`, `machine_family_code`, `cf_code_snapshot`,
+-- `cf_rate_id`, `temps_fabrication_planned`, `hourly_rate_source` et
+-- `hourly_rate_effective_at`. La section F ci-dessous raccorde ce chantier à ce
+-- référentiel au lieu de le contourner.
+--
+-- ÉTAT DES BASES AU MOMENT DE L'ÉCRITURE (vérifié en lecture seule) :
+--   - `cerp_test` porte DÉJÀ les objets A→E, mais `cerp_schema_migrations` ne
+--     l'enregistre pas. Ce patch y est donc un quasi no-op : chaque commande est
+--     gardée, aucune ne suppose une base vierge.
+--   - `cerp_prod` ne porte AUCUN de ces objets. Il y fait l'installation complète.
+--   - `ordres_fabrication` et `of_operations` sont à 0 ligne sur les DEUX bases :
+--     le backfill R00 est un no-op et le passage en NOT NULL ne bute sur rien.
+--
+-- Apporte les fondations manquantes :
+--   A) révisions d'OF (R00, R01, …), snapshot technique par révision, hash, diff,
+--      VISA par phase, révision obsolète ;
+--   B) propositions de replanification issues d'une dérive de temps d'usinage ;
+--   C) versions de planning d'OF (ACTIF → BROUILLON → SOUMIS → VALIDE/REFUSE → ACTIF) ;
+--   D) dossiers d'AR client à recaler + routage de notification configurable ;
+--   E) documents d'OF figés (payload immuable, empreinte, lien GED).
+--
+-- Sécurité
+-- - Patch idempotent : rejouable sans effet de bord.
+-- - Additif sauf UNE contrainte : `of_operations_of_id_phase_key` (of_id, phase) devient
+--   (of_id, revision_id, phase). C'est la condition pour qu'une R01 coexiste avec la R00
+--   d'un OF lancé au lieu de l'écraser. Le rollback rétablit l'ancienne contrainte.
+-- - À appliquer sur `cerp_test` après preflight. JAMAIS sur `cerp_prod` sans sauvegarde
+--   approuvée, rapport de vérification et autorisation humaine explicite.
+
+BEGIN;
+
+/* -------------------------------------------------------------------------- */
+/* 0) Preflight                                                               */
+/* -------------------------------------------------------------------------- */
+
+DO $$
+BEGIN
+  IF to_regclass('public.ordres_fabrication') IS NULL
+     OR to_regclass('public.of_operations') IS NULL
+     OR to_regclass('public.of_time_logs') IS NULL
+     OR to_regclass('public.users') IS NULL
+     OR to_regclass('public.affaire') IS NULL
+     OR to_regclass('public.commande_client') IS NULL THEN
+    RAISE EXCEPTION 'Prérequis manquant : écosystème OF (#55/#141/#170) requis';
+  END IF;
+END $$;
+
+/* ========================================================================== */
+/* A) RÉVISIONS D'OF                                                          */
+/* ========================================================================== */
+
+-- Une révision fige la définition applicable d'un OF à un instant donné : gamme,
+-- matière, machines, temps, quantités. Le numéro d'OF, lui, ne bouge jamais
+-- (trigger `fn_prevent_of_numero_mutation`, #170) : c'est la révision qui porte
+-- l'évolution, pas l'identifiant.
+CREATE TABLE IF NOT EXISTS public.of_revisions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  of_id bigint NOT NULL REFERENCES public.ordres_fabrication(id) ON DELETE RESTRICT,
+
+  -- Rang entier (0, 1, 2…) et code d'affichage dérivé ('R00', 'R01', …).
+  -- Le code est stocké et contraint plutôt que calculé à la lecture : il est
+  -- imprimé sur un document opposable et cité dans les pointages.
+  revision_rank integer NOT NULL,
+  revision_code text NOT NULL,
+
+  statut text NOT NULL DEFAULT 'BROUILLON',
+
+  -- Instantané technique complet de la révision.
+  snapshot jsonb NOT NULL,
+  snapshot_sha256 text NOT NULL,
+
+  -- Écart avec la révision précédente, calculé au moment de la création.
+  diff jsonb NULL,
+
+  -- Motif : facultatif sur R00 (création), obligatoire dès R01 (voir trigger).
+  motif text NULL,
+
+  author_user_id integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  activated_at timestamptz NULL,
+  superseded_at timestamptz NULL,
+  superseded_by uuid NULL REFERENCES public.of_revisions(id) ON DELETE SET NULL,
+
+  CONSTRAINT of_revisions_rank_uq UNIQUE (of_id, revision_rank),
+  CONSTRAINT of_revisions_code_uq UNIQUE (of_id, revision_code),
+  CONSTRAINT of_revisions_rank_ck CHECK (revision_rank >= 0),
+  CONSTRAINT of_revisions_code_ck CHECK (revision_code ~ '^R[0-9]{2,}$'),
+  CONSTRAINT of_revisions_statut_ck CHECK (statut IN ('BROUILLON', 'ACTIVE', 'OBSOLETE')),
+  CONSTRAINT of_revisions_sha256_ck CHECK (snapshot_sha256 ~ '^[a-f0-9]{64}$'),
+  CONSTRAINT of_revisions_motif_ck CHECK (revision_rank = 0 OR (motif IS NOT NULL AND btrim(motif) <> ''))
+);
+
+-- Une seule révision ACTIVE par OF : c'est elle qui est applicable en atelier.
+CREATE UNIQUE INDEX IF NOT EXISTS of_revisions_active_uq
+  ON public.of_revisions(of_id)
+  WHERE statut = 'ACTIVE';
+
+CREATE INDEX IF NOT EXISTS of_revisions_of_idx
+  ON public.of_revisions(of_id, revision_rank DESC);
+
+COMMENT ON TABLE public.of_revisions IS
+  'Révisions d''un OF. Le numéro d''OF est stable ; la révision porte l''évolution technique. Une révision ACTIVE au plus par OF.';
+COMMENT ON COLUMN public.of_revisions.snapshot IS
+  'Instantané figé : gamme applicable, matière, machines, temps, quantités. Immuable après création.';
+COMMENT ON COLUMN public.of_revisions.diff IS
+  'Écart structuré avec la révision précédente (ajouts, retraits, modifications champ par champ).';
+
+-- Le snapshot d'une révision est immuable. Seul le cycle de vie (statut, dates,
+-- chaînage) peut évoluer : une révision qui se réécrirait ne prouverait plus rien.
+CREATE OR REPLACE FUNCTION public.fn_of_revisions_immutable()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'Une révision d''OF ne se supprime pas : elle devient OBSOLETE'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF NEW.of_id IS DISTINCT FROM OLD.of_id
+     OR NEW.revision_rank IS DISTINCT FROM OLD.revision_rank
+     OR NEW.revision_code IS DISTINCT FROM OLD.revision_code
+     OR NEW.snapshot IS DISTINCT FROM OLD.snapshot
+     OR NEW.snapshot_sha256 IS DISTINCT FROM OLD.snapshot_sha256
+     OR NEW.diff IS DISTINCT FROM OLD.diff
+     OR NEW.motif IS DISTINCT FROM OLD.motif
+     OR NEW.author_user_id IS DISTINCT FROM OLD.author_user_id
+     OR NEW.created_at IS DISTINCT FROM OLD.created_at THEN
+    RAISE EXCEPTION 'Le contenu d''une révision d''OF est immuable après création'
+      USING ERRCODE = '55000';
+  END IF;
+
+  -- Une révision OBSOLETE est terminale.
+  IF OLD.statut = 'OBSOLETE' AND NEW.statut <> 'OBSOLETE' THEN
+    RAISE EXCEPTION 'Une révision obsolète ne peut pas être réactivée'
+      USING ERRCODE = '55000';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_of_revisions_immutable ON public.of_revisions;
+CREATE TRIGGER trg_of_revisions_immutable
+  BEFORE UPDATE OR DELETE ON public.of_revisions
+  FOR EACH ROW EXECUTE FUNCTION public.fn_of_revisions_immutable();
+
+/* --- Rattachement des opérations à leur révision --------------------------- */
+
+ALTER TABLE public.of_operations
+  ADD COLUMN IF NOT EXISTS revision_id uuid NULL REFERENCES public.of_revisions(id) ON DELETE RESTRICT;
+
+-- Backfill : chaque OF existant reçoit sa R00 ACTIVE, et ses opérations s'y
+-- rattachent. Le snapshot de reprise est marqué comme tel : il est reconstruit à
+-- partir de l'état courant, il n'a pas été figé au lancement.
+DO $$
+DECLARE
+  v_of RECORD;
+  v_revision_id uuid;
+  v_snapshot jsonb;
+BEGIN
+  FOR v_of IN
+    SELECT o.id
+    FROM public.ordres_fabrication o
+    WHERE NOT EXISTS (SELECT 1 FROM public.of_revisions r WHERE r.of_id = o.id)
+  LOOP
+    SELECT jsonb_build_object(
+             'origin', 'BACKFILL',
+             'of_id', v_of.id,
+             'operations', COALESCE(
+               (SELECT jsonb_agg(jsonb_build_object(
+                         'phase', op.phase,
+                         'designation', op.designation,
+                         'machine_id', op.machine_id,
+                         'poste_id', op.poste_id,
+                         'cf_id', op.cf_id,
+                         'tp', op.tp,
+                         'tf_unit', op.tf_unit,
+                         'qte', op.qte,
+                         'coef', op.coef
+                       ) ORDER BY op.phase)
+                FROM public.of_operations op
+                WHERE op.of_id = v_of.id),
+               '[]'::jsonb)
+           )
+      INTO v_snapshot;
+
+    INSERT INTO public.of_revisions (
+      of_id, revision_rank, revision_code, statut, snapshot, snapshot_sha256, activated_at
+    )
+    VALUES (
+      v_of.id, 0, 'R00', 'ACTIVE', v_snapshot,
+      encode(digest(v_snapshot::text, 'sha256'), 'hex'),
+      now()
+    )
+    RETURNING id INTO v_revision_id;
+
+    UPDATE public.of_operations
+      SET revision_id = v_revision_id
+      WHERE of_id = v_of.id AND revision_id IS NULL;
+  END LOOP;
+END $$;
+
+-- La clé d'unicité passe de (of_id, phase) à (of_id, revision_id, phase).
+-- Sans ce changement, créer une R01 sur un OF lancé exigerait de supprimer ou de
+-- muter les opérations de la R00 — donc d'écraser les pointages et les VISA qui y
+-- sont rattachés. C'est précisément ce que le chantier interdit.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_operations_of_id_phase_key'
+      AND conrelid = 'public.of_operations'::regclass
+  ) THEN
+    ALTER TABLE public.of_operations DROP CONSTRAINT of_operations_of_id_phase_key;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_operations_of_revision_phase_key'
+      AND conrelid = 'public.of_operations'::regclass
+  ) THEN
+    ALTER TABLE public.of_operations
+      ADD CONSTRAINT of_operations_of_revision_phase_key UNIQUE (of_id, revision_id, phase);
+  END IF;
+END $$;
+
+-- `revision_id` ne devient NOT NULL que si le backfill est complet : le patch ne
+-- doit jamais échouer sur des lignes historiques qu'il ne maîtrise pas.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.of_operations WHERE revision_id IS NULL) THEN
+    BEGIN
+      ALTER TABLE public.of_operations ALTER COLUMN revision_id SET NOT NULL;
+    EXCEPTION WHEN others THEN
+      RAISE NOTICE 'of_operations.revision_id laissé nullable : %', SQLERRM;
+    END;
+  ELSE
+    RAISE NOTICE 'of_operations.revision_id laissé nullable : % ligne(s) non rattachée(s)',
+      (SELECT count(*) FROM public.of_operations WHERE revision_id IS NULL);
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS of_operations_revision_idx
+  ON public.of_operations(revision_id)
+  WHERE revision_id IS NOT NULL;
+
+COMMENT ON COLUMN public.of_operations.revision_id IS
+  'Révision d''OF dont cette opération fait partie. Les pointages et VISA suivent l''opération, donc restent attachés à leur révision d''origine.';
+
+-- Une opération d'une révision obsolète est un fait historique : elle porte des
+-- pointages et des VISA déjà signés. Elle ne se modifie plus.
+CREATE OR REPLACE FUNCTION public.fn_of_operations_obsolete_revision_readonly()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  v_statut text;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    SELECT statut INTO v_statut FROM public.of_revisions WHERE id = OLD.revision_id;
+    IF v_statut = 'OBSOLETE' THEN
+      RAISE EXCEPTION 'Opération d''une révision obsolète : suppression interdite'
+        USING ERRCODE = '55000';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  SELECT statut INTO v_statut FROM public.of_revisions WHERE id = OLD.revision_id;
+  IF v_statut = 'OBSOLETE' AND NEW.revision_id IS NOT DISTINCT FROM OLD.revision_id THEN
+    RAISE EXCEPTION 'Opération d''une révision obsolète : modification interdite'
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_of_operations_obsolete_revision_readonly ON public.of_operations;
+CREATE TRIGGER trg_of_operations_obsolete_revision_readonly
+  BEFORE UPDATE OR DELETE ON public.of_operations
+  FOR EACH ROW EXECUTE FUNCTION public.fn_of_operations_obsolete_revision_readonly();
+
+/* --- VISA de phase --------------------------------------------------------- */
+
+-- Le VISA est la signature de l'opérateur qui atteste avoir exécuté la phase
+-- (colonne « VISA » de la gamme de fabrication papier). Il porte les initiales
+-- telles qu'elles étaient au moment du visa : un changement de nom ultérieur ne
+-- doit pas réécrire un document déjà imprimé.
+CREATE TABLE IF NOT EXISTS public.of_operation_visas (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  of_operation_id uuid NOT NULL REFERENCES public.of_operations(id) ON DELETE RESTRICT,
+  user_id integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  initials text NOT NULL,
+  visa_at timestamptz NOT NULL DEFAULT now(),
+  comment text NULL,
+  revoked_at timestamptz NULL,
+  revoked_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  revoked_reason text NULL,
+  CONSTRAINT of_operation_visas_initials_ck CHECK (btrim(initials) <> '' AND char_length(initials) <= 8)
+);
+
+-- Un seul VISA vivant par opération.
+CREATE UNIQUE INDEX IF NOT EXISTS of_operation_visas_live_uq
+  ON public.of_operation_visas(of_operation_id)
+  WHERE revoked_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS of_operation_visas_operation_idx
+  ON public.of_operation_visas(of_operation_id);
+
+COMMENT ON TABLE public.of_operation_visas IS
+  'VISA de phase : signature de l''opérateur. Les initiales sont figées à la signature. Un VISA se révoque, il ne se supprime pas.';
+
+CREATE OR REPLACE FUNCTION public.fn_of_operation_visas_append_only()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'Un VISA ne se supprime pas : il se révoque' USING ERRCODE = '55000';
+  END IF;
+  IF NEW.of_operation_id IS DISTINCT FROM OLD.of_operation_id
+     OR NEW.user_id IS DISTINCT FROM OLD.user_id
+     OR NEW.initials IS DISTINCT FROM OLD.initials
+     OR NEW.visa_at IS DISTINCT FROM OLD.visa_at THEN
+    RAISE EXCEPTION 'Un VISA signé est immuable' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_of_operation_visas_append_only ON public.of_operation_visas;
+CREATE TRIGGER trg_of_operation_visas_append_only
+  BEFORE UPDATE OR DELETE ON public.of_operation_visas
+  FOR EACH ROW EXECUTE FUNCTION public.fn_of_operation_visas_append_only();
+
+/* ========================================================================== */
+/* B) DÉRIVE DU TEMPS D'USINAGE                                               */
+/* ========================================================================== */
+
+-- Après programmation d'une phase, le temps de fabrication constaté est comparé
+-- au temps validé de référence. Au-delà du seuil, une PROPOSITION est créée —
+-- jamais une modification du planning actif.
+CREATE TABLE IF NOT EXISTS public.of_time_variance_proposals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  of_id bigint NOT NULL REFERENCES public.ordres_fabrication(id) ON DELETE RESTRICT,
+  revision_id uuid NOT NULL REFERENCES public.of_revisions(id) ON DELETE RESTRICT,
+  of_operation_id uuid NULL REFERENCES public.of_operations(id) ON DELETE SET NULL,
+  phase integer NOT NULL,
+
+  -- Temps en heures. `reference_time` NULL ou 0 => revue obligatoire, pas de
+  -- pourcentage : diviser par zéro ne produit pas une information, il en détruit une.
+  reference_time numeric(12, 4) NULL,
+  new_time numeric(12, 4) NOT NULL,
+  variation_pct numeric(10, 2) NULL,
+
+  -- Décision : RIEN (sous seuil), REPLANIFICATION (au-dessus), REVUE (référence absente).
+  outcome text NOT NULL,
+  review_required boolean NOT NULL DEFAULT false,
+
+  cause text NOT NULL,
+  cause_comment text NULL,
+
+  -- Contexte d'impact, figé au moment de la proposition.
+  impact_charge jsonb NOT NULL DEFAULT '{}'::jsonb,
+  machines jsonb NOT NULL DEFAULT '[]'::jsonb,
+  affaires jsonb NOT NULL DEFAULT '[]'::jsonb,
+  simulation jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  statut text NOT NULL DEFAULT 'OUVERTE',
+  author_user_id integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  resolved_at timestamptz NULL,
+  resolved_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  resolution_comment text NULL,
+
+  -- Clé d'idempotence : rejouer la même programmation ne crée pas un doublon.
+  idempotency_key text NULL,
+
+  CONSTRAINT of_time_variance_outcome_ck CHECK (outcome IN ('RIEN', 'REPLANIFICATION', 'REVUE')),
+  CONSTRAINT of_time_variance_statut_ck CHECK (statut IN ('OUVERTE', 'ACCEPTEE', 'REFUSEE', 'CADUQUE')),
+  CONSTRAINT of_time_variance_new_time_ck CHECK (new_time >= 0),
+  CONSTRAINT of_time_variance_cause_ck CHECK (btrim(cause) <> ''),
+  -- Une variation n'existe que si la référence est exploitable, et réciproquement.
+  CONSTRAINT of_time_variance_pct_ck CHECK (
+    (reference_time IS NULL OR reference_time = 0) = (variation_pct IS NULL)
+  ),
+  -- Référence inexploitable => revue obligatoire.
+  CONSTRAINT of_time_variance_review_ck CHECK (
+    NOT (reference_time IS NULL OR reference_time = 0) OR (outcome = 'REVUE' AND review_required)
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS of_time_variance_idempotency_uq
+  ON public.of_time_variance_proposals(idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS of_time_variance_of_idx
+  ON public.of_time_variance_proposals(of_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS of_time_variance_open_idx
+  ON public.of_time_variance_proposals(created_at DESC)
+  WHERE statut = 'OUVERTE';
+
+COMMENT ON TABLE public.of_time_variance_proposals IS
+  'Proposition de replanification issue d''une dérive de temps d''usinage. N''altère jamais le planning actif : elle se soumet à décision.';
+COMMENT ON COLUMN public.of_time_variance_proposals.variation_pct IS
+  '((nouveau - référence) / référence) x 100, arrondi à 2 décimales. NULL quand la référence est absente ou nulle.';
+
+/* ========================================================================== */
+/* C) VERSIONS DE PLANNING D'OF                                               */
+/* ========================================================================== */
+
+-- Toute retouche du planning d'un OF crée un brouillon versionné. Le planning
+-- ACTIF reste inchangé tant que le brouillon n'est pas validé.
+CREATE TABLE IF NOT EXISTS public.of_planning_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  of_id bigint NOT NULL REFERENCES public.ordres_fabrication(id) ON DELETE RESTRICT,
+  revision_id uuid NULL REFERENCES public.of_revisions(id) ON DELETE SET NULL,
+
+  version_rank integer NOT NULL,
+  statut text NOT NULL DEFAULT 'BROUILLON',
+
+  -- Plan complet : opérations, dates, machines, durées, charge, quantité, cadence.
+  payload jsonb NOT NULL,
+  payload_sha256 text NOT NULL,
+
+  -- Comparaison avant/après avec le plan ACTIF au moment de la création.
+  base_version_id uuid NULL REFERENCES public.of_planning_versions(id) ON DELETE SET NULL,
+  comparison jsonb NULL,
+
+  -- Conséquence client déduite de la comparaison : décide si un dossier AR est requis.
+  client_impact text NOT NULL DEFAULT 'AUCUN',
+
+  -- Proposition de dérive à l'origine du brouillon, s'il y en a une.
+  source_proposal_id uuid NULL REFERENCES public.of_time_variance_proposals(id) ON DELETE SET NULL,
+
+  author_user_id integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  submitted_at timestamptz NULL,
+  submitted_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  decided_at timestamptz NULL,
+  decided_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  decision_comment text NULL,
+  activated_at timestamptz NULL,
+  superseded_at timestamptz NULL,
+
+  idempotency_key text NULL,
+
+  CONSTRAINT of_planning_versions_rank_uq UNIQUE (of_id, version_rank),
+  CONSTRAINT of_planning_versions_rank_ck CHECK (version_rank >= 0),
+  CONSTRAINT of_planning_versions_statut_ck
+    CHECK (statut IN ('ACTIF', 'BROUILLON', 'SOUMIS', 'VALIDE', 'REFUSE', 'SUPERSEDE')),
+  CONSTRAINT of_planning_versions_sha256_ck CHECK (payload_sha256 ~ '^[a-f0-9]{64}$'),
+  CONSTRAINT of_planning_versions_impact_ck
+    CHECK (client_impact IN ('AUCUN', 'DELAI', 'CADENCE', 'DELAI_ET_CADENCE'))
+);
+
+-- Un seul plan ACTIF par OF, et un seul brouillon en cours de circuit.
+CREATE UNIQUE INDEX IF NOT EXISTS of_planning_versions_active_uq
+  ON public.of_planning_versions(of_id)
+  WHERE statut = 'ACTIF';
+
+CREATE UNIQUE INDEX IF NOT EXISTS of_planning_versions_open_draft_uq
+  ON public.of_planning_versions(of_id)
+  WHERE statut IN ('BROUILLON', 'SOUMIS');
+
+CREATE UNIQUE INDEX IF NOT EXISTS of_planning_versions_idempotency_uq
+  ON public.of_planning_versions(idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS of_planning_versions_of_idx
+  ON public.of_planning_versions(of_id, version_rank DESC);
+
+COMMENT ON TABLE public.of_planning_versions IS
+  'Versions de planning d''un OF. Cycle ACTIF -> BROUILLON -> SOUMIS -> VALIDE/REFUSE -> ACTIF. Le plan ACTIF n''est jamais modifié en place.';
+
+/* ========================================================================== */
+/* D) DOSSIER D'AR CLIENT À RECALER                                           */
+/* ========================================================================== */
+
+-- Distinct de `commande_ar_log`, qui journalise l'AR **envoyé** au client.
+-- Ici il s'agit du dossier interne ouvert quand un plan validé casse un
+-- engagement déjà accusé : délai ou cadence. Aucun envoi n'y est automatisé.
+CREATE TABLE IF NOT EXISTS public.ar_recalage_dossiers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  client_id character varying(3) NULL REFERENCES public.clients(client_id) ON DELETE SET NULL,
+  commande_id bigint NULL REFERENCES public.commande_client(id) ON DELETE SET NULL,
+  affaire_id bigint NULL REFERENCES public.affaire(id) ON DELETE SET NULL,
+  of_id bigint NOT NULL REFERENCES public.ordres_fabrication(id) ON DELETE RESTRICT,
+  planning_version_id uuid NULL REFERENCES public.of_planning_versions(id) ON DELETE SET NULL,
+
+  previous_date date NULL,
+  previous_cadence jsonb NULL,
+  new_date date NULL,
+  new_cadence jsonb NULL,
+  quantite numeric(14, 3) NULL,
+
+  motif text NOT NULL,
+  commentaire text NULL,
+
+  statut text NOT NULL DEFAULT 'A_TRAITER',
+  owner_user_id integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  closed_at timestamptz NULL,
+  closed_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+
+  idempotency_key text NULL,
+
+  CONSTRAINT ar_recalage_motif_ck CHECK (motif IN (
+    'DERIVE_TEMPS_USINAGE',
+    'MACHINE',
+    'MATIERE',
+    'QUALITE_REPRISE',
+    'SOUS_TRAITANCE',
+    'MODIFICATION_TECHNIQUE',
+    'CAPACITE',
+    'PRIORITE',
+    'AUTRE'
+  )),
+  CONSTRAINT ar_recalage_statut_ck CHECK (statut IN ('A_TRAITER', 'EN_COURS', 'RECALE', 'ABANDONNE')),
+  -- « Autre » n'est pas un motif : c'est une invitation à l'écrire.
+  CONSTRAINT ar_recalage_autre_comment_ck
+    CHECK (motif <> 'AUTRE' OR (commentaire IS NOT NULL AND btrim(commentaire) <> ''))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS ar_recalage_idempotency_uq
+  ON public.ar_recalage_dossiers(idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS ar_recalage_open_idx
+  ON public.ar_recalage_dossiers(created_at DESC)
+  WHERE statut IN ('A_TRAITER', 'EN_COURS');
+
+CREATE INDEX IF NOT EXISTS ar_recalage_commande_idx
+  ON public.ar_recalage_dossiers(commande_id)
+  WHERE commande_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS ar_recalage_of_idx
+  ON public.ar_recalage_dossiers(of_id);
+
+COMMENT ON TABLE public.ar_recalage_dossiers IS
+  'Dossier interne de recalage d''un AR client. Aucun envoi automatique : la reprise de contact reste un geste humain.';
+
+/* --- Routage de notification configurable ---------------------------------- */
+
+-- Qui est prévenu d'un sujet donné est une donnée de configuration, pas une
+-- constante du code. Une personne nommée ne doit jamais être écrite en dur :
+-- elle est destinataire parce qu'elle porte un rôle, ou parce qu'un
+-- administrateur l'a explicitement désignée — et cela se change sans livraison.
+CREATE TABLE IF NOT EXISTS public.notification_routing (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  topic text NOT NULL,
+  role_key text NULL REFERENCES public.app_roles(role_key) ON UPDATE CASCADE ON DELETE CASCADE,
+  user_id integer NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  is_active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  CONSTRAINT notification_routing_target_ck CHECK (
+    (role_key IS NOT NULL AND user_id IS NULL) OR (role_key IS NULL AND user_id IS NOT NULL)
+  ),
+  CONSTRAINT notification_routing_topic_ck CHECK (btrim(topic) <> '')
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS notification_routing_role_uq
+  ON public.notification_routing(topic, role_key)
+  WHERE role_key IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS notification_routing_user_uq
+  ON public.notification_routing(topic, user_id)
+  WHERE user_id IS NOT NULL;
+
+COMMENT ON TABLE public.notification_routing IS
+  'Destinataires par sujet de notification, par rôle ou par identité désignée. Aucune identité n''est codée en dur côté application.';
+
+-- Amorçage par rôle uniquement. Les rôles existent déjà (#315) ; aucune personne
+-- n'est nommée ici.
+DO $$
+BEGIN
+  IF to_regclass('public.app_roles') IS NULL THEN
+    RAISE NOTICE 'app_roles absent : amorçage du routage de notification ignoré';
+    RETURN;
+  END IF;
+
+  INSERT INTO public.notification_routing (topic, role_key)
+  SELECT t.topic, r.role_key
+  FROM (VALUES
+    -- Dérive de temps : le planificateur arbitre la replanification.
+    ('OF_TIME_VARIANCE', ARRAY['Planning', 'Planification', 'Responsable Atelier-Production']),
+    -- Planning soumis à validation.
+    ('OF_PLANNING_SUBMITTED', ARRAY['Planning', 'Planification', 'Responsable Atelier-Production']),
+    -- AR à recaler : l'administration des ventes reprend contact avec le client.
+    ('AR_RECALAGE', ARRAY['Commerce', 'Assistante polyvalente', 'Secretaire'])
+  ) AS t(topic, roles)
+  CROSS JOIN LATERAL unnest(t.roles) AS r(role_key)
+  WHERE EXISTS (SELECT 1 FROM public.app_roles a WHERE a.role_key = r.role_key)
+  ON CONFLICT DO NOTHING;
+END $$;
+
+/* ========================================================================== */
+/* E) DOCUMENT D'OF FIGÉ                                                      */
+/* ========================================================================== */
+
+-- L'aperçu écran et le PDF serveur consomment le MÊME payload. Le payload est
+-- figé ici : une réimpression rejoue l'instantané et reproduit octet pour octet
+-- le même binaire, donc la même empreinte.
+CREATE TABLE IF NOT EXISTS public.of_documents (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  of_id bigint NOT NULL REFERENCES public.ordres_fabrication(id) ON DELETE RESTRICT,
+  revision_id uuid NOT NULL REFERENCES public.of_revisions(id) ON DELETE RESTRICT,
+
+  -- Instantané de rendu : tout ce que le document affiche, et rien d'autre.
+  payload jsonb NOT NULL,
+  payload_sha256 text NOT NULL,
+
+  -- Empreinte du binaire produit. Une réimpression qui changerait ce hash est un défaut.
+  pdf_sha256 text NULL,
+  pdf_byte_size integer NULL,
+
+  -- Horodatage de génération, figé : il entre dans le binaire (métadonnées PDF).
+  generated_at timestamptz NOT NULL DEFAULT now(),
+  generated_by integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  generated_by_label text NULL,
+
+  statut text NOT NULL DEFAULT 'OFFICIEL',
+
+  -- Versement GED (ADR-0037).
+  ged_document_id uuid NULL,
+  ged_version_id uuid NULL,
+
+  reprint_count integer NOT NULL DEFAULT 0,
+  last_reprinted_at timestamptz NULL,
+
+  idempotency_key text NULL,
+
+  CONSTRAINT of_documents_payload_sha256_ck CHECK (payload_sha256 ~ '^[a-f0-9]{64}$'),
+  CONSTRAINT of_documents_pdf_sha256_ck CHECK (pdf_sha256 IS NULL OR pdf_sha256 ~ '^[a-f0-9]{64}$'),
+  CONSTRAINT of_documents_statut_ck CHECK (statut IN ('BROUILLON', 'OFFICIEL', 'OBSOLETE')),
+  CONSTRAINT of_documents_reprint_ck CHECK (reprint_count >= 0)
+);
+
+-- Un document officiel par révision : c'est la pièce qui accompagne la
+-- fabrication. Les brouillons, eux, peuvent coexister.
+CREATE UNIQUE INDEX IF NOT EXISTS of_documents_official_uq
+  ON public.of_documents(revision_id)
+  WHERE statut = 'OFFICIEL';
+
+CREATE UNIQUE INDEX IF NOT EXISTS of_documents_idempotency_uq
+  ON public.of_documents(idempotency_key)
+  WHERE idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS of_documents_of_idx
+  ON public.of_documents(of_id, generated_at DESC);
+
+COMMENT ON TABLE public.of_documents IS
+  'Document d''OF figé : payload immuable partagé par l''aperçu et le PDF, empreinte du binaire, versement GED.';
+
+-- Le payload et l'horodatage sont immuables : ce sont eux qui garantissent
+-- qu'une réimpression reproduit le même binaire. Seuls le compteur de
+-- réimpression, le statut et le lien GED évoluent.
+CREATE OR REPLACE FUNCTION public.fn_of_documents_immutable()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'Un document d''OF ne se supprime pas : il devient OBSOLETE'
+      USING ERRCODE = '55000';
+  END IF;
+  IF NEW.of_id IS DISTINCT FROM OLD.of_id
+     OR NEW.revision_id IS DISTINCT FROM OLD.revision_id
+     OR NEW.payload IS DISTINCT FROM OLD.payload
+     OR NEW.payload_sha256 IS DISTINCT FROM OLD.payload_sha256
+     OR NEW.generated_at IS DISTINCT FROM OLD.generated_at
+     OR NEW.generated_by_label IS DISTINCT FROM OLD.generated_by_label THEN
+    RAISE EXCEPTION 'Le payload et l''horodatage d''un document d''OF sont immuables'
+      USING ERRCODE = '55000';
+  END IF;
+  -- L'empreinte du binaire ne s'écrit qu'une fois.
+  IF OLD.pdf_sha256 IS NOT NULL AND NEW.pdf_sha256 IS DISTINCT FROM OLD.pdf_sha256 THEN
+    RAISE EXCEPTION 'L''empreinte PDF d''un document d''OF est immuable'
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_of_documents_immutable ON public.of_documents;
+CREATE TRIGGER trg_of_documents_immutable
+  BEFORE UPDATE OR DELETE ON public.of_documents
+  FOR EACH ROW EXECUTE FUNCTION public.fn_of_documents_immutable();
+
+/* ========================================================================== */
+/* F) RACCORD AU RÉFÉRENTIEL DES FAMILLES MACHINE                             */
+/* ========================================================================== */
+
+-- La famille d'une phase n'est plus une constante du code : c'est une ligne de
+-- `production_machine_families`, administrable par les Méthodes. Ce chantier la
+-- CONSOMME, il ne la redéfinit pas — sinon un ajout de famille exigerait une
+-- livraison applicative, ce que la normalisation des gammes vient précisément
+-- d'éliminer.
+DO $$
+BEGIN
+  IF to_regclass('public.production_machine_families') IS NULL THEN
+    RAISE EXCEPTION 'Prérequis manquant : 20260729_methodes_gamme_referentials.sql doit être appliqué avant ce patch';
+  END IF;
+
+  -- `DECOUPE` est indispensable au document d'OF : une phase de débit sans
+  -- famille sortirait du PDF sans centre affecté.
+  IF NOT EXISTS (SELECT 1 FROM public.production_machine_families WHERE code = 'DECOUPE') THEN
+    RAISE EXCEPTION 'Référentiel incomplet : la famille DECOUPE est requise par le document d''OF';
+  END IF;
+END $$;
+
+-- Le document d'OF et le diff de révision groupent les phases par famille : sans
+-- cet index, chaque rendu balaie la table des opérations.
+CREATE INDEX IF NOT EXISTS of_operations_family_idx
+  ON public.of_operations (machine_family_code)
+  WHERE machine_family_code IS NOT NULL;
+
+-- Un n° de programme vide n'est pas un n° de programme. La donnée manquante doit
+-- rester NULL pour que le document la SIGNALE au lieu de l'afficher en blanc
+-- (critère d'acceptation #370 : une donnée absente est signalée, jamais inventée).
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_operations_programme_ck' AND conrelid = 'public.of_operations'::regclass
+  ) THEN
+    ALTER TABLE public.of_operations
+      ADD CONSTRAINT of_operations_programme_ck
+      CHECK (numero_programme IS NULL OR btrim(numero_programme) <> '');
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.of_operations.machine_family_code IS
+  'Famille machine figée au lancement, clé de public.production_machine_families. Volontairement SANS clé étrangère : un snapshot d''OF est une preuve, une famille renommée ne doit pas la casser.';
+
+/* ========================================================================== */
+/* G) PROPRIÉTÉ DES OBJETS APPLICATIFS                                        */
+/* ========================================================================== */
+
+-- Appliqué via `sudo -u postgres`, tout objet créé appartient à `postgres` et
+-- `cerp_app` se prend un `permission denied` (42501) → l'endpoint répond 500 alors
+-- que le schéma est correct. Ce bloc rend la propriété au rôle applicatif.
+-- `erp_audit_logs` et `hr_time_events` restent volontairement à `postgres`
+-- (append-only ISO) et ne sont pas touchés ici.
+DO $$
+DECLARE
+  v_obj text;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE NOTICE 'Rôle cerp_app absent : réattribution de propriété ignorée';
+    RETURN;
+  END IF;
+
+  FOREACH v_obj IN ARRAY ARRAY[
+    'of_revisions',
+    'of_operation_visas',
+    'of_time_variance_proposals',
+    'of_planning_versions',
+    'ar_recalage_dossiers',
+    'notification_routing',
+    'of_documents'
+  ] LOOP
+    IF to_regclass('public.' || v_obj) IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.%I OWNER TO cerp_app', v_obj);
+    END IF;
+  END LOOP;
+END $$;
+
+COMMIT;

--- a/db/patches/20260729_of_visa_controle_370.sql
+++ b/db/patches/20260729_of_visa_controle_370.sql
@@ -1,0 +1,156 @@
+-- 20260729_of_visa_controle_370.sql
+--
+-- Complément au VISA de phase (#370).
+--
+-- `of_operation_visas`, tel que créé par `20260729_of_versioning_replanification_ar_370.sql`,
+-- ne portait que la signature : opérateur, initiales, horodatage, commentaire,
+-- révocation. Le document d'OF exige davantage par phase : statut, quantités
+-- bonne et rebut, motif de rebut, et un visa de CONTRÔLE distinct du visa
+-- opérateur.
+--
+-- Pourquoi un second fichier plutôt qu'une reprise du premier : le premier est
+-- déjà appliqué ET enregistré dans `cerp_schema_migrations` avec son empreinte.
+-- Le modifier ferait divergier le fichier de son empreinte enregistrée, et le
+-- registre cesserait de décrire ce qui a réellement tourné.
+--
+-- Le visa opérateur et le visa contrôle sont deux colonnes distinctes, pas un
+-- champ « signataire » réutilisé : la séparation de celui qui fabrique et de
+-- celui qui contrôle est le principe même du contrôle, et un schéma qui les
+-- confond rend l'autocontrôle indétectable.
+--
+-- Intégralement additif et idempotent.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.of_operation_visas') IS NULL THEN
+    RAISE EXCEPTION 'Prérequis manquant : 20260729_of_versioning_replanification_ar_370.sql doit être appliqué avant ce patch';
+  END IF;
+END $$;
+
+ALTER TABLE public.of_operation_visas
+  ADD COLUMN IF NOT EXISTS statut           text NOT NULL DEFAULT 'VISE',
+  ADD COLUMN IF NOT EXISTS quantite_bonne   numeric(14, 3) NULL,
+  ADD COLUMN IF NOT EXISTS quantite_rebut   numeric(14, 3) NULL,
+  ADD COLUMN IF NOT EXISTS motif_rebut      text NULL,
+  -- Visa de contrôle : identité, initiales et horodatage propres.
+  ADD COLUMN IF NOT EXISTS controle_user_id integer NULL,
+  ADD COLUMN IF NOT EXISTS controle_initials text NULL,
+  ADD COLUMN IF NOT EXISTS controle_at      timestamptz NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_operation_visas_controle_user_fkey'
+      AND conrelid = 'public.of_operation_visas'::regclass
+  ) THEN
+    ALTER TABLE public.of_operation_visas
+      ADD CONSTRAINT of_operation_visas_controle_user_fkey
+      FOREIGN KEY (controle_user_id) REFERENCES public.users (id) ON DELETE SET NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_operation_visas_statut_ck'
+      AND conrelid = 'public.of_operation_visas'::regclass
+  ) THEN
+    ALTER TABLE public.of_operation_visas
+      ADD CONSTRAINT of_operation_visas_statut_ck
+      CHECK (statut IN ('A_FAIRE', 'EN_COURS', 'VISE', 'REFUSE'));
+  END IF;
+
+  -- Les quantités ne sont pas négatives. Un rebut négatif « rendrait » des
+  -- pièces et fausserait tout comptage en aval.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_operation_visas_quantites_ck'
+      AND conrelid = 'public.of_operation_visas'::regclass
+  ) THEN
+    ALTER TABLE public.of_operation_visas
+      ADD CONSTRAINT of_operation_visas_quantites_ck
+      CHECK ((quantite_bonne IS NULL OR quantite_bonne >= 0)
+         AND (quantite_rebut IS NULL OR quantite_rebut >= 0));
+  END IF;
+
+  -- Un rebut déclaré sans motif est une information perdue : la cause d'un rebut
+  -- est ce qui permet de ne pas le reproduire.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_operation_visas_rebut_motif_ck'
+      AND conrelid = 'public.of_operation_visas'::regclass
+  ) THEN
+    ALTER TABLE public.of_operation_visas
+      ADD CONSTRAINT of_operation_visas_rebut_motif_ck
+      CHECK (COALESCE(quantite_rebut, 0) = 0
+             OR (motif_rebut IS NOT NULL AND btrim(motif_rebut) <> ''));
+  END IF;
+
+  -- Un visa de contrôle n'existe pas sans son horodatage ni ses initiales.
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_operation_visas_controle_ck'
+      AND conrelid = 'public.of_operation_visas'::regclass
+  ) THEN
+    ALTER TABLE public.of_operation_visas
+      ADD CONSTRAINT of_operation_visas_controle_ck
+      CHECK ((controle_initials IS NULL AND controle_at IS NULL)
+          OR (controle_initials IS NOT NULL AND controle_at IS NOT NULL));
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.of_operation_visas.statut IS
+  'Statut du VISA de la phase : A_FAIRE, EN_COURS, VISE, REFUSE.';
+COMMENT ON COLUMN public.of_operation_visas.controle_initials IS
+  'Initiales du CONTRÔLE, distinctes du visa opérateur : séparer qui fabrique de qui contrôle est le principe du contrôle.';
+
+/* -------------------------------------------------------------------------- */
+/* Immuabilité — le trigger existant doit couvrir les nouvelles colonnes       */
+/* -------------------------------------------------------------------------- */
+-- Le trigger d'origine (`fn_of_operation_visas_append_only`) protégeait les
+-- colonnes de signature. Les quantités et le motif déclarés entrent dans la même
+-- catégorie : un VISA se révoque, il ne se réécrit pas. Sans cette extension, une
+-- quantité rebut pourrait être corrigée après coup sans laisser de trace.
+CREATE OR REPLACE FUNCTION public.fn_of_operation_visas_append_only()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'Un VISA ne se supprime pas : il se révoque'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF NEW.of_operation_id IS DISTINCT FROM OLD.of_operation_id
+     OR NEW.user_id IS DISTINCT FROM OLD.user_id
+     OR NEW.initials IS DISTINCT FROM OLD.initials
+     OR NEW.visa_at IS DISTINCT FROM OLD.visa_at
+     OR NEW.quantite_bonne IS DISTINCT FROM OLD.quantite_bonne
+     OR NEW.quantite_rebut IS DISTINCT FROM OLD.quantite_rebut
+     OR NEW.motif_rebut IS DISTINCT FROM OLD.motif_rebut
+     OR NEW.controle_user_id IS DISTINCT FROM OLD.controle_user_id
+     OR NEW.controle_initials IS DISTINCT FROM OLD.controle_initials
+     OR NEW.controle_at IS DISTINCT FROM OLD.controle_at THEN
+    RAISE EXCEPTION 'Un VISA signé est immuable : seules la révocation et son motif peuvent être renseignés'
+      USING ERRCODE = '55000';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_of_operation_visas_append_only ON public.of_operation_visas;
+CREATE TRIGGER trg_of_operation_visas_append_only
+  BEFORE UPDATE OR DELETE ON public.of_operation_visas
+  FOR EACH ROW EXECUTE FUNCTION public.fn_of_operation_visas_append_only();
+
+/* -------------------------------------------------------------------------- */
+/* Propriété applicative                                                      */
+/* -------------------------------------------------------------------------- */
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    ALTER TABLE public.of_operation_visas OWNER TO cerp_app;
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/support/20260729_of_versioning_replanification_ar_370.guards.sql
+++ b/db/patches/support/20260729_of_versioning_replanification_ar_370.guards.sql
@@ -1,0 +1,247 @@
+-- Contrôles de garde — 20260729_of_versioning_replanification_ar_370.sql
+--
+-- Exerce en base les garanties que le code seul ne peut pas tenir : unicité sous
+-- concurrence, idempotence, immuabilité. Chaque contrôle échoue bruyamment.
+--
+-- Le script crée puis retire ses propres données ; il se termine par un ROLLBACK
+-- et ne laisse rien derrière lui.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_of bigint;
+  v_piece uuid;
+  v_r0 uuid;
+  v_r1 uuid;
+  v_op uuid;
+  v_err text;
+BEGIN
+  SELECT id INTO v_piece FROM public.pieces_techniques LIMIT 1;
+  IF v_piece IS NULL THEN
+    RAISE EXCEPTION 'Aucune pièce technique : impossible de créer un OF de contrôle';
+  END IF;
+
+  INSERT INTO public.ordres_fabrication (numero, piece_technique_id, quantite_lancee, statut)
+  VALUES ('OF-GUARD-374', v_piece, 40, 'EN_COURS')
+  RETURNING id INTO v_of;
+
+  ---------------------------------------------------------------------------
+  RAISE NOTICE '1) Une seule révision ACTIVE par OF';
+  ---------------------------------------------------------------------------
+  INSERT INTO public.of_revisions (of_id, revision_rank, revision_code, statut, snapshot, snapshot_sha256, activated_at)
+  VALUES (v_of, 0, 'R00', 'ACTIVE', '{"v":0}'::jsonb, repeat('a', 64), now())
+  RETURNING id INTO v_r0;
+
+  -- Le motif est fourni : sans lui, `of_revisions_motif_ck` se déclencherait avant
+  -- l'index d'unicité et le contrôle porterait sur autre chose que sur l'unicité.
+  BEGIN
+    INSERT INTO public.of_revisions (of_id, revision_rank, revision_code, statut, snapshot, snapshot_sha256, motif)
+    VALUES (v_of, 1, 'R01', 'ACTIVE', '{"v":1}'::jsonb, repeat('b', 64), 'Tentative concurrente');
+    RAISE EXCEPTION 'ECHEC : deux révisions ACTIVE acceptées sur le même OF';
+  EXCEPTION WHEN unique_violation THEN
+    RAISE NOTICE '   ok — la seconde révision ACTIVE est refusée';
+  END;
+
+  ---------------------------------------------------------------------------
+  RAISE NOTICE '2) Motif obligatoire dès R01';
+  ---------------------------------------------------------------------------
+  BEGIN
+    INSERT INTO public.of_revisions (of_id, revision_rank, revision_code, statut, snapshot, snapshot_sha256)
+    VALUES (v_of, 1, 'R01', 'BROUILLON', '{"v":1}'::jsonb, repeat('b', 64));
+    RAISE EXCEPTION 'ECHEC : R01 acceptée sans motif';
+  EXCEPTION WHEN check_violation THEN
+    RAISE NOTICE '   ok — R01 sans motif refusée';
+  END;
+
+  INSERT INTO public.of_revisions (of_id, revision_rank, revision_code, statut, snapshot, snapshot_sha256, motif)
+  VALUES (v_of, 1, 'R01', 'BROUILLON', '{"v":1}'::jsonb, repeat('b', 64), 'Nouvelle prise de pièce')
+  RETURNING id INTO v_r1;
+
+  ---------------------------------------------------------------------------
+  RAISE NOTICE '3) Le contenu d''une révision est immuable';
+  ---------------------------------------------------------------------------
+  BEGIN
+    UPDATE public.of_revisions SET snapshot = '{"v":99}'::jsonb WHERE id = v_r1;
+    RAISE EXCEPTION 'ECHEC : instantané de révision modifiable';
+  EXCEPTION WHEN sqlstate '55000' THEN
+    RAISE NOTICE '   ok — instantané immuable';
+  END;
+
+  BEGIN
+    DELETE FROM public.of_revisions WHERE id = v_r1;
+    RAISE EXCEPTION 'ECHEC : révision supprimable';
+  EXCEPTION WHEN sqlstate '55000' THEN
+    RAISE NOTICE '   ok — révision non supprimable';
+  END;
+
+  -- Le statut, lui, évolue : c'est le cycle de vie.
+  UPDATE public.of_revisions SET statut = 'OBSOLETE', superseded_at = now() WHERE id = v_r0;
+  UPDATE public.of_revisions SET statut = 'ACTIVE', activated_at = now() WHERE id = v_r1;
+  RAISE NOTICE '   ok — R00 obsolète, R01 active';
+
+  BEGIN
+    UPDATE public.of_revisions SET statut = 'ACTIVE' WHERE id = v_r0;
+    RAISE EXCEPTION 'ECHEC : révision obsolète réactivable';
+  EXCEPTION WHEN sqlstate '55000' THEN
+    RAISE NOTICE '   ok — une révision obsolète ne se réactive pas';
+  END;
+
+  ---------------------------------------------------------------------------
+  RAISE NOTICE '4) Une phase coexiste entre deux révisions du même OF';
+  ---------------------------------------------------------------------------
+  INSERT INTO public.of_operations (of_id, revision_id, phase, designation)
+  VALUES (v_of, v_r0, 30, 'FRAISAGE CN R00')
+  RETURNING id INTO v_op;
+
+  INSERT INTO public.of_operations (of_id, revision_id, phase, designation)
+  VALUES (v_of, v_r1, 30, 'FRAISAGE CN R01');
+  RAISE NOTICE '   ok — phase 30 présente dans R00 et R01 sans collision';
+
+  BEGIN
+    INSERT INTO public.of_operations (of_id, revision_id, phase, designation)
+    VALUES (v_of, v_r1, 30, 'DOUBLON');
+    RAISE EXCEPTION 'ECHEC : phase dupliquée dans la même révision';
+  EXCEPTION WHEN unique_violation THEN
+    RAISE NOTICE '   ok — phase unique au sein d''une révision';
+  END;
+
+  ---------------------------------------------------------------------------
+  RAISE NOTICE '5) Pointages et VISA restent attachés à leur révision d''origine';
+  ---------------------------------------------------------------------------
+  INSERT INTO public.of_operation_visas (of_operation_id, initials)
+  VALUES (v_op, 'AG');
+
+  BEGIN
+    UPDATE public.of_operations SET designation = 'REECRITE' WHERE id = v_op;
+    RAISE EXCEPTION 'ECHEC : opération d''une révision obsolète modifiable';
+  EXCEPTION WHEN sqlstate '55000' THEN
+    RAISE NOTICE '   ok — l''opération de R00 est gelée, son VISA avec elle';
+  END;
+
+  BEGIN
+    DELETE FROM public.of_operation_visas WHERE of_operation_id = v_op;
+    RAISE EXCEPTION 'ECHEC : VISA supprimable';
+  EXCEPTION WHEN sqlstate '55000' THEN
+    RAISE NOTICE '   ok — un VISA se révoque, il ne se supprime pas';
+  END;
+
+  BEGIN
+    INSERT INTO public.of_operation_visas (of_operation_id, initials) VALUES (v_op, 'TB');
+    RAISE EXCEPTION 'ECHEC : deux VISA vivants sur la même phase';
+  EXCEPTION WHEN unique_violation THEN
+    RAISE NOTICE '   ok — un seul VISA vivant par phase';
+  END;
+
+  ---------------------------------------------------------------------------
+  RAISE NOTICE '6) Idempotence sous concurrence';
+  ---------------------------------------------------------------------------
+  INSERT INTO public.of_time_variance_proposals
+    (of_id, revision_id, phase, reference_time, new_time, variation_pct, outcome, cause, idempotency_key)
+  VALUES (v_of, v_r1, 30, 4, 5, 25.00, 'REPLANIFICATION', 'DERIVE_TEMPS_USINAGE', 'guard-374-a');
+
+  BEGIN
+    INSERT INTO public.of_time_variance_proposals
+      (of_id, revision_id, phase, reference_time, new_time, variation_pct, outcome, cause, idempotency_key)
+    VALUES (v_of, v_r1, 30, 4, 5, 25.00, 'REPLANIFICATION', 'DERIVE_TEMPS_USINAGE', 'guard-374-a');
+    RAISE EXCEPTION 'ECHEC : proposition rejouée en double';
+  EXCEPTION WHEN unique_violation THEN
+    RAISE NOTICE '   ok — une clé d''idempotence ne produit qu''une proposition';
+  END;
+
+  ---------------------------------------------------------------------------
+  RAISE NOTICE '7) Référence absente => revue obligatoire, sans pourcentage';
+  ---------------------------------------------------------------------------
+  BEGIN
+    INSERT INTO public.of_time_variance_proposals
+      (of_id, revision_id, phase, reference_time, new_time, variation_pct, outcome, cause)
+    VALUES (v_of, v_r1, 40, NULL, 5, 12.00, 'REPLANIFICATION', 'MACHINE');
+    RAISE EXCEPTION 'ECHEC : pourcentage accepté sans référence';
+  EXCEPTION WHEN check_violation THEN
+    RAISE NOTICE '   ok — pas de pourcentage sans référence exploitable';
+  END;
+
+  INSERT INTO public.of_time_variance_proposals
+    (of_id, revision_id, phase, reference_time, new_time, variation_pct, outcome, cause, review_required)
+  VALUES (v_of, v_r1, 40, NULL, 5, NULL, 'REVUE', 'MACHINE', true);
+  RAISE NOTICE '   ok — référence absente enregistrée en REVUE';
+
+  ---------------------------------------------------------------------------
+  RAISE NOTICE '8) Un seul planning ACTIF et un seul brouillon en circuit';
+  ---------------------------------------------------------------------------
+  INSERT INTO public.of_planning_versions (of_id, version_rank, statut, payload, payload_sha256)
+  VALUES (v_of, 0, 'ACTIF', '{"p":0}'::jsonb, repeat('c', 64));
+
+  BEGIN
+    INSERT INTO public.of_planning_versions (of_id, version_rank, statut, payload, payload_sha256)
+    VALUES (v_of, 1, 'ACTIF', '{"p":1}'::jsonb, repeat('d', 64));
+    RAISE EXCEPTION 'ECHEC : deux plannings ACTIF';
+  EXCEPTION WHEN unique_violation THEN
+    RAISE NOTICE '   ok — un seul planning ACTIF';
+  END;
+
+  INSERT INTO public.of_planning_versions (of_id, version_rank, statut, payload, payload_sha256)
+  VALUES (v_of, 1, 'BROUILLON', '{"p":1}'::jsonb, repeat('d', 64));
+
+  BEGIN
+    INSERT INTO public.of_planning_versions (of_id, version_rank, statut, payload, payload_sha256)
+    VALUES (v_of, 2, 'SOUMIS', '{"p":2}'::jsonb, repeat('e', 64));
+    RAISE EXCEPTION 'ECHEC : deux brouillons en circuit simultanément';
+  EXCEPTION WHEN unique_violation THEN
+    RAISE NOTICE '   ok — un seul brouillon en circuit à la fois';
+  END;
+
+  ---------------------------------------------------------------------------
+  RAISE NOTICE '9) Motif AUTRE => commentaire exigé';
+  ---------------------------------------------------------------------------
+  BEGIN
+    INSERT INTO public.ar_recalage_dossiers (of_id, motif) VALUES (v_of, 'AUTRE');
+    RAISE EXCEPTION 'ECHEC : motif AUTRE accepté sans commentaire';
+  EXCEPTION WHEN check_violation THEN
+    RAISE NOTICE '   ok — « Autre » exige un commentaire';
+  END;
+
+  INSERT INTO public.ar_recalage_dossiers (of_id, motif, commentaire)
+  VALUES (v_of, 'AUTRE', 'Report demandé par le client');
+  INSERT INTO public.ar_recalage_dossiers (of_id, motif) VALUES (v_of, 'MACHINE');
+  RAISE NOTICE '   ok — dossiers créés, aucun destinataire ni envoi dans le modèle';
+
+  ---------------------------------------------------------------------------
+  RAISE NOTICE '10) Document figé : un seul officiel, payload immuable';
+  ---------------------------------------------------------------------------
+  INSERT INTO public.of_documents (of_id, revision_id, payload, payload_sha256, pdf_sha256, statut)
+  VALUES (v_of, v_r1, '{"d":1}'::jsonb, repeat('f', 64), repeat('1', 64), 'OFFICIEL');
+
+  BEGIN
+    INSERT INTO public.of_documents (of_id, revision_id, payload, payload_sha256, statut)
+    VALUES (v_of, v_r1, '{"d":2}'::jsonb, repeat('0', 64), 'OFFICIEL');
+    RAISE EXCEPTION 'ECHEC : deux documents officiels sur la même révision';
+  EXCEPTION WHEN unique_violation THEN
+    RAISE NOTICE '   ok — un seul document officiel par révision';
+  END;
+
+  BEGIN
+    UPDATE public.of_documents SET payload = '{"d":9}'::jsonb WHERE revision_id = v_r1;
+    RAISE EXCEPTION 'ECHEC : payload de document modifiable';
+  EXCEPTION WHEN sqlstate '55000' THEN
+    RAISE NOTICE '   ok — le payload figé est immuable';
+  END;
+
+  BEGIN
+    UPDATE public.of_documents SET pdf_sha256 = repeat('2', 64) WHERE revision_id = v_r1;
+    RAISE EXCEPTION 'ECHEC : empreinte PDF réécrite';
+  EXCEPTION WHEN sqlstate '55000' THEN
+    RAISE NOTICE '   ok — l''empreinte du binaire ne s''écrit qu''une fois';
+  END;
+
+  -- La réimpression, elle, est comptée.
+  UPDATE public.of_documents
+    SET reprint_count = reprint_count + 1, last_reprinted_at = now()
+    WHERE revision_id = v_r1;
+  RAISE NOTICE '   ok — la réimpression est comptée sans toucher au contenu';
+
+  RAISE NOTICE '';
+  RAISE NOTICE 'TOUS LES CONTROLES DE GARDE SONT PASSES';
+END $$;
+
+ROLLBACK;

--- a/db/patches/support/20260729_of_versioning_replanification_ar_370.preflight.sql
+++ b/db/patches/support/20260729_of_versioning_replanification_ar_370.preflight.sql
@@ -1,0 +1,51 @@
+-- Preflight — 20260729_of_versioning_replanification_ar_370.sql
+-- Lecture seule. À exécuter AVANT le patch, sur la base visée.
+-- Toute ligne `BLOQUANT` interdit l'application.
+
+\echo '--- Prérequis de tables ---'
+SELECT
+  t.name,
+  CASE WHEN to_regclass(t.name) IS NULL THEN 'BLOQUANT — absente' ELSE 'ok' END AS etat
+FROM (VALUES
+  ('public.ordres_fabrication'), ('public.of_operations'), ('public.of_time_logs'),
+  ('public.users'), ('public.affaire'), ('public.commande_client'), ('public.clients'),
+  ('public.app_roles')
+) AS t(name);
+
+\echo '--- pgcrypto (digest sha256) requis par le backfill ---'
+SELECT CASE WHEN EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pgcrypto')
+            THEN 'ok' ELSE 'BLOQUANT — pgcrypto absent' END AS pgcrypto;
+
+\echo '--- Objets déjà créés par un passage antérieur ---'
+SELECT t.name, CASE WHEN to_regclass(t.name) IS NULL THEN 'absent' ELSE 'déjà présent' END AS etat
+FROM (VALUES
+  ('public.of_revisions'), ('public.of_operation_visas'),
+  ('public.of_time_variance_proposals'), ('public.of_planning_versions'),
+  ('public.ar_recalage_dossiers'), ('public.notification_routing'), ('public.of_documents')
+) AS t(name);
+
+\echo '--- Volumétrie touchée par le backfill R00 ---'
+SELECT
+  (SELECT count(*) FROM public.ordres_fabrication) AS ofs,
+  (SELECT count(*) FROM public.of_operations) AS operations,
+  (SELECT count(*) FROM public.of_time_logs) AS pointages;
+
+\echo '--- Contrainte d''unicité à remplacer sur of_operations ---'
+SELECT conname, pg_get_constraintdef(oid) AS definition
+FROM pg_constraint
+WHERE conrelid = 'public.of_operations'::regclass AND contype = 'u';
+
+\echo '--- Doublons (of_id, phase) : empêcheraient la nouvelle clé ---'
+SELECT of_id, phase, count(*) AS occurrences
+FROM public.of_operations
+GROUP BY of_id, phase
+HAVING count(*) > 1;
+
+\echo '--- Rôles attendus par l''amorçage du routage ---'
+SELECT r.role_key,
+       CASE WHEN a.role_key IS NULL THEN 'absent — routage partiel' ELSE 'ok' END AS etat
+FROM unnest(ARRAY[
+  'Planning', 'Planification', 'Responsable Atelier-Production',
+  'Commerce', 'Assistante polyvalente', 'Secretaire'
+]) AS r(role_key)
+LEFT JOIN public.app_roles a ON a.role_key = r.role_key;

--- a/db/patches/support/20260729_of_versioning_replanification_ar_370.rollback.sql
+++ b/db/patches/support/20260729_of_versioning_replanification_ar_370.rollback.sql
@@ -1,0 +1,78 @@
+-- Rollback — 20260729_of_versioning_replanification_ar_370.sql
+--
+-- DESTRUCTIF. Supprime les révisions d'OF, les VISA, les propositions de dérive,
+-- les versions de planning, les dossiers d'AR à recaler et les documents d'OF figés.
+--
+-- N'exécuter qu'après sauvegarde et autorisation humaine explicite, et seulement si
+-- ces objets n'ont pas encore reçu de données métier à conserver. Le contrôle
+-- ci-dessous refuse la suppression tant que des lignes existent : le lever est une
+-- décision, pas une formalité.
+
+BEGIN;
+
+DO $$
+DECLARE
+  v_rows bigint := 0;
+  v_force boolean := coalesce(current_setting('cerp.rollback_force', true) = 'on', false);
+BEGIN
+  SELECT
+    (SELECT count(*) FROM public.of_revisions WHERE snapshot->>'origin' IS DISTINCT FROM 'BACKFILL')
+    + (SELECT count(*) FROM public.of_operation_visas)
+    + (SELECT count(*) FROM public.of_time_variance_proposals)
+    + (SELECT count(*) FROM public.of_planning_versions)
+    + (SELECT count(*) FROM public.ar_recalage_dossiers)
+    + (SELECT count(*) FROM public.of_documents)
+  INTO v_rows;
+
+  IF v_rows > 0 AND NOT v_force THEN
+    RAISE EXCEPTION
+      'Rollback refusé : % ligne(s) métier seraient perdues. Relancer avec SET cerp.rollback_force = ''on'' pour assumer la perte.',
+      v_rows;
+  END IF;
+END $$;
+
+-- Les triggers d'immuabilité interdisent DROP/DELETE ligne à ligne ; on retire les
+-- triggers avant de retirer les tables qui les portent.
+DROP TRIGGER IF EXISTS trg_of_documents_immutable ON public.of_documents;
+DROP TRIGGER IF EXISTS trg_of_operation_visas_append_only ON public.of_operation_visas;
+DROP TRIGGER IF EXISTS trg_of_operations_obsolete_revision_readonly ON public.of_operations;
+DROP TRIGGER IF EXISTS trg_of_revisions_immutable ON public.of_revisions;
+
+DROP FUNCTION IF EXISTS public.fn_of_documents_immutable();
+DROP FUNCTION IF EXISTS public.fn_of_operation_visas_append_only();
+DROP FUNCTION IF EXISTS public.fn_of_operations_obsolete_revision_readonly();
+DROP FUNCTION IF EXISTS public.fn_of_revisions_immutable();
+
+DROP TABLE IF EXISTS public.of_documents;
+DROP TABLE IF EXISTS public.ar_recalage_dossiers;
+DROP TABLE IF EXISTS public.of_planning_versions;
+DROP TABLE IF EXISTS public.of_time_variance_proposals;
+DROP TABLE IF EXISTS public.of_operation_visas;
+DROP TABLE IF EXISTS public.notification_routing;
+
+-- Rétablir la clé d'unicité historique avant de retirer `revision_id`.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_operations_of_revision_phase_key'
+      AND conrelid = 'public.of_operations'::regclass
+  ) THEN
+    ALTER TABLE public.of_operations DROP CONSTRAINT of_operations_of_revision_phase_key;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'of_operations_of_id_phase_key'
+      AND conrelid = 'public.of_operations'::regclass
+  ) THEN
+    ALTER TABLE public.of_operations
+      ADD CONSTRAINT of_operations_of_id_phase_key UNIQUE (of_id, phase);
+  END IF;
+END $$;
+
+ALTER TABLE public.of_operations DROP COLUMN IF EXISTS revision_id;
+
+DROP TABLE IF EXISTS public.of_revisions;
+
+COMMIT;

--- a/db/patches/support/20260729_of_versioning_replanification_ar_370.verify.sql
+++ b/db/patches/support/20260729_of_versioning_replanification_ar_370.verify.sql
@@ -1,0 +1,137 @@
+-- Verify — 20260729_of_versioning_replanification_ar_370.sql
+-- Lecture seule. À exécuter APRÈS le patch. Toute ligne `ECHEC` invalide l'application.
+
+\echo '--- Tables créées ---'
+SELECT t.name, CASE WHEN to_regclass(t.name) IS NULL THEN 'ECHEC — absente' ELSE 'ok' END AS etat
+FROM (VALUES
+  ('public.of_revisions'), ('public.of_operation_visas'),
+  ('public.of_time_variance_proposals'), ('public.of_planning_versions'),
+  ('public.ar_recalage_dossiers'), ('public.notification_routing'), ('public.of_documents')
+) AS t(name);
+
+\echo '--- Unicité of_operations : doit être (of_id, revision_id, phase) ---'
+SELECT
+  CASE
+    WHEN EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conrelid = 'public.of_operations'::regclass
+        AND conname = 'of_operations_of_revision_phase_key'
+    ) AND NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conrelid = 'public.of_operations'::regclass
+        AND conname = 'of_operations_of_id_phase_key'
+    ) THEN 'ok'
+    ELSE 'ECHEC — clé d''unicité non basculée'
+  END AS etat;
+
+\echo '--- Backfill R00 : chaque OF a exactement une révision ACTIVE ---'
+SELECT
+  CASE WHEN count(*) = 0 THEN 'ok'
+       ELSE 'ECHEC — ' || count(*) || ' OF sans révision ACTIVE unique' END AS etat
+FROM (
+  SELECT o.id
+  FROM public.ordres_fabrication o
+  LEFT JOIN public.of_revisions r ON r.of_id = o.id AND r.statut = 'ACTIVE'
+  GROUP BY o.id
+  HAVING count(r.id) <> 1
+) AS anomalies;
+
+\echo '--- Opérations rattachées à une révision ---'
+SELECT
+  CASE WHEN count(*) = 0 THEN 'ok'
+       ELSE 'ATTENTION — ' || count(*) || ' opération(s) sans révision' END AS etat
+FROM public.of_operations WHERE revision_id IS NULL;
+
+\echo '--- Triggers d''immuabilité ---'
+SELECT t.name, CASE WHEN EXISTS (
+    SELECT 1 FROM pg_trigger WHERE tgname = t.name AND NOT tgisinternal
+  ) THEN 'ok' ELSE 'ECHEC — absent' END AS etat
+FROM (VALUES
+  ('trg_of_revisions_immutable'),
+  ('trg_of_operations_obsolete_revision_readonly'),
+  ('trg_of_operation_visas_append_only'),
+  ('trg_of_documents_immutable')
+) AS t(name);
+
+\echo '--- Index d''unicité métier ---'
+SELECT i.name, CASE WHEN to_regclass(i.name) IS NULL THEN 'ECHEC — absent' ELSE 'ok' END AS etat
+FROM (VALUES
+  ('public.of_revisions_active_uq'),
+  ('public.of_planning_versions_active_uq'),
+  ('public.of_planning_versions_open_draft_uq'),
+  ('public.of_documents_official_uq'),
+  ('public.of_operation_visas_live_uq')
+) AS i(name);
+
+\echo '--- Routage de notification : par rôle, aucune identité en dur ---'
+SELECT topic, count(*) FILTER (WHERE role_key IS NOT NULL) AS cibles_role,
+       count(*) FILTER (WHERE user_id IS NOT NULL) AS cibles_identite
+FROM public.notification_routing
+GROUP BY topic ORDER BY topic;
+
+\echo '--- Motif AUTRE : le commentaire est exigé ---'
+SELECT CASE WHEN EXISTS (
+  SELECT 1 FROM pg_constraint
+  WHERE conrelid = 'public.ar_recalage_dossiers'::regclass
+    AND conname = 'ar_recalage_autre_comment_ck'
+) THEN 'ok' ELSE 'ECHEC — contrainte absente' END AS etat;
+
+\echo '--- F) Référentiel des familles machine : les 5 codes attendus ---'
+SELECT f.code,
+       CASE WHEN EXISTS (SELECT 1 FROM public.production_machine_families m WHERE m.code = f.code)
+            THEN 'ok' ELSE 'ECHEC — famille absente' END AS etat
+FROM (VALUES ('T'), ('F'), ('TTRAD'), ('FTRAD'), ('DECOUPE')) AS f(code);
+
+\echo '--- F) Colonnes de gamme normalisée figées sur of_operations ---'
+SELECT c.name,
+       CASE WHEN EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public' AND table_name = 'of_operations' AND column_name = c.name
+       ) THEN 'ok' ELSE 'ECHEC — colonne absente' END AS etat
+FROM (VALUES
+  ('numero_programme'), ('machine_family_code'), ('cf_code_snapshot'),
+  ('cf_rate_id'), ('temps_fabrication_planned'), ('hourly_rate_source'),
+  ('hourly_rate_effective_at'), ('revision_id')
+) AS c(name);
+
+\echo '--- F) Index famille + contrainte n° de programme non vide ---'
+SELECT
+  CASE WHEN to_regclass('public.of_operations_family_idx') IS NULL
+       THEN 'ECHEC — index famille absent' ELSE 'ok' END AS index_famille,
+  CASE WHEN EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conrelid = 'public.of_operations'::regclass AND conname = 'of_operations_programme_ck'
+  ) THEN 'ok' ELSE 'ECHEC — contrainte programme absente' END AS contrainte_programme;
+
+\echo '--- G) Propriété applicative : cerp_app doit posséder les 7 tables ---'
+SELECT c.relname,
+       pg_get_userbyid(c.relowner) AS proprietaire,
+       CASE WHEN pg_get_userbyid(c.relowner) = 'cerp_app' THEN 'ok'
+            ELSE 'ECHEC — cerp_app recevra 42501 (endpoint en 500)' END AS etat
+FROM pg_class c
+JOIN pg_namespace n ON n.oid = c.relnamespace AND n.nspname = 'public'
+WHERE c.relname IN (
+  'of_revisions', 'of_operation_visas', 'of_time_variance_proposals',
+  'of_planning_versions', 'ar_recalage_dossiers', 'notification_routing', 'of_documents'
+)
+ORDER BY c.relname;
+
+\echo '--- Registre de migrations — ce patch ---'
+SELECT CASE WHEN EXISTS (
+  SELECT 1 FROM public.cerp_schema_migrations
+  WHERE filename = '20260729_of_versioning_replanification_ar_370.sql'
+) THEN 'ok' ELSE 'ECHEC — non enregistré' END AS etat;
+
+-- Signalement, pas un échec de CE patch : `20260729_methodes_gamme_referentials.sql`
+-- a été EXÉCUTÉ sur les deux bases (les objets de la section F le prouvent) sans
+-- être enregistré. Le registre ment dans le sens dangereux : il fait croire qu'il
+-- reste à passer. Un runner qui le rejouerait buterait sur ses commandes non
+-- gardées. La correction appartient au chantier Méthodes, pas à celui-ci.
+\echo '--- Signalement : dérive de registre héritée (hors périmètre #370) ---'
+SELECT
+  CASE WHEN to_regclass('public.production_machine_families') IS NOT NULL
+       THEN 'objets présents' ELSE 'objets absents' END AS realite_schema,
+  CASE WHEN EXISTS (
+    SELECT 1 FROM public.cerp_schema_migrations
+    WHERE filename = '20260729_methodes_gamme_referentials.sql'
+  ) THEN 'enregistré' ELSE 'NON enregistré — à arbitrer par le chantier Méthodes' END AS registre;

--- a/scripts/render-of-document.ts
+++ b/scripts/render-of-document.ts
@@ -17,7 +17,17 @@ import { renderOfDocument } from "../src/module/production/services/of-document-
 import type { OfRevisionOperation } from "../src/module/production/domain/of-revision";
 import type { OfDocumentBuildInput } from "../src/module/production/domain/of-document";
 
-const FAMILIES = ["T", "F", "TTRAD", "FTRAD"] as const;
+/** Les 5 familles du référentiel, DECOUPE incluse. */
+const FAMILIES = ["T", "F", "TTRAD", "FTRAD", "DECOUPE"] as const;
+
+/** Gel de centre de frais, comme la normalisation des gammes le produit. */
+const CF = {
+  cfCode: "FCN",
+  cfRateId: "c0000000-0000-4000-8000-000000000010",
+  tauxHoraire: 68,
+  tauxHoraireSource: "CENTRE_FRAIS",
+  tauxHoraireEffectiveAt: "2026-01-01",
+} as const;
 
 function hundredPhases(): Partial<OfDocumentBuildInput> {
   const operations: OfRevisionOperation[] = Array.from({ length: 100 }, (_, index) => ({
@@ -31,16 +41,88 @@ function hundredPhases(): Partial<OfDocumentBuildInput> {
     preparation: (index % 5) * 0.25,
     quantiteBase: FIXTURE_QUANTITE_BASE,
     coefficient: 1,
+    ...CF,
   }));
 
   const visas: OfDocumentBuildInput["visas"] = {};
   for (const operation of operations) {
     if (operation.phase % 30 === 0) {
-      visas[operation.phase] = { initials: "AG", visaAt: "2026-04-24T08:00:00.000Z" };
+      visas[operation.phase] = {
+        statut: "VISE",
+        visaOperateur: "AG",
+        operateur: "A. GARNIER",
+        visaAt: "2026-04-24T08:00:00.000Z",
+        quantiteBonne: FIXTURE_QUANTITE_BASE,
+        quantiteRebut: 0,
+      };
     }
   }
 
   return { operations, visas };
+}
+
+/** Une seule phase : contrôle du cas dégénéré de pagination. */
+function unePhase(): Partial<OfDocumentBuildInput> {
+  return {
+    operations: [
+      {
+        phase: 10,
+        designation: "TOURNAGE CN COMPLET",
+        family: "T",
+        machineId: null,
+        machineLabel: "TCN-1",
+        programme: "P-UNIQUE",
+        tempsUnitaire: 0.25,
+        preparation: 1.5,
+        quantiteBase: FIXTURE_QUANTITE_BASE,
+        coefficient: 1,
+        ...CF,
+      },
+    ],
+    visas: {},
+  };
+}
+
+/**
+ * T -> F -> T : les trois passages doivent rester distincts sur la ligne de
+ * séquence machines. Les regrouper effacerait le retour en tournage.
+ */
+function tft(): Partial<OfDocumentBuildInput> {
+  return {
+    operations: [
+      { phase: 10, designation: "TOURNAGE CN", family: "T", machineId: null, machineLabel: "TCN-1", programme: "P-T-1", tempsUnitaire: 0.1, preparation: 1, quantiteBase: 10, coefficient: 1, ...CF, cfCode: "TCN" },
+      { phase: 20, designation: "FRAISAGE CN", family: "F", machineId: null, machineLabel: "VMC-1", programme: "P-F-1", tempsUnitaire: 0.2, preparation: 1, quantiteBase: 10, coefficient: 1, ...CF },
+      { phase: 30, designation: "REPRISE TOURNAGE", family: "T", machineId: null, machineLabel: "TCN-1", programme: "P-T-2", tempsUnitaire: 0.15, preparation: 1, quantiteBase: 10, coefficient: 1, ...CF, cfCode: "TCN" },
+    ],
+    visas: {},
+  };
+}
+
+/**
+ * Programme manquant sur une famille qui l'exige : le document doit le SIGNALER
+ * et non laisser la case vide (critère d'acceptation #370).
+ */
+function programmeManquant(): Partial<OfDocumentBuildInput> {
+  return {
+    operations: [
+      { phase: 10, designation: "FRAISAGE CN SANS PROGRAMME", family: "F", machineId: null, machineLabel: "VMC-1", programme: null, tempsUnitaire: 0.2, preparation: 1, quantiteBase: 10, coefficient: 1, ...CF },
+      { phase: 20, designation: "DEBIT", family: "DECOUPE", machineId: null, machineLabel: "Scie", programme: null, tempsUnitaire: 0.05, preparation: 0, quantiteBase: 10, coefficient: 1, ...CF, cfCode: "DEB" },
+    ],
+    visas: {},
+    // Découpe incomplète : la longueur totale ne doit PAS être déduite.
+    decoupe: {
+      dimensions: null,
+      longueurBrutMm: null,
+      longueurUtileMm: null,
+      traitDeScieMm: null,
+      chuteMm: null,
+      nombreBruts: null,
+      piecesParBrut: 1,
+      masseTotaleKg: null,
+      unite: null,
+      methodeCalcul: null,
+    },
+  };
 }
 
 function multiAffaires(): Partial<OfDocumentBuildInput> {
@@ -70,23 +152,43 @@ async function main(): Promise<void> {
   const out = process.argv[2] ?? "of-document.pdf";
   const variant = process.argv[3] ?? "nominal";
 
-  const overrides: Partial<OfDocumentBuildInput> =
-    variant === "brouillon"
-      ? { watermark: "BROUILLON", revisionStatut: "BROUILLON", ofStatut: "Brouillon" }
-      : variant === "obsolete"
-        ? { watermark: "OBSOLETE", revisionStatut: "OBSOLETE", revisionCode: "R00" }
-        : variant === "cent-phases"
-          ? hundredPhases()
-          : variant === "multi-affaires"
-            ? multiAffaires()
-            : {};
+  const VARIANTS: Record<string, () => Partial<OfDocumentBuildInput>> = {
+    nominal: () => ({ documentStatut: "OFFICIEL" }),
+    brouillon: () => ({
+      watermark: "BROUILLON",
+      revisionStatut: "BROUILLON",
+      ofStatut: "Brouillon",
+      documentStatut: "BROUILLON",
+    }),
+    obsolete: () => ({
+      watermark: "OBSOLETE",
+      revisionStatut: "OBSOLETE",
+      revisionCode: "R00",
+      documentStatut: "OBSOLETE",
+    }),
+    "cent-phases": hundredPhases,
+    "une-phase": unePhase,
+    "multi-affaires": multiAffaires,
+    tft,
+    "programme-manquant": programmeManquant,
+  };
+
+  const build = VARIANTS[variant];
+  if (!build) {
+    throw new Error(`Variante inconnue : ${variant}. Connues : ${Object.keys(VARIANTS).join(", ")}`);
+  }
+  const overrides = build();
 
   const payload = buildOfDocumentPayload(buildFixtureInput(overrides));
   const result = await renderOfDocument(payload);
   writeFileSync(out, result.buffer);
 
   process.stdout.write(
-    `${out}\n  variante : ${variant}\n  octets   : ${result.byteSize}\n  sha256   : ${result.sha256}\n  phases   : ${payload.phases.length}\n  totaux   : TP ${payload.totaux.preparationLabel} | TF ${payload.totaux.fabricationLabel} | ${payload.totaux.finalLabel}\n`
+    `${out}\n  variante : ${variant}\n  octets   : ${result.byteSize}\n  sha256   : ${result.sha256}\n` +
+      `  phases   : ${payload.phases.length}\n  sequence : ${payload.sequenceMachinesLabel}\n` +
+      `  totaux   : TP ${payload.totaux.preparationLabel} | TF ${payload.totaux.fabricationLabel} | ${payload.totaux.finalLabel}\n` +
+      `  gabarit  : ${payload.templateVersion}\n` +
+      `  signale  : ${payload.avertissements.length ? payload.avertissements.map((a) => a.code).join(", ") : "aucun"}\n`
   );
 }
 

--- a/scripts/render-of-document.ts
+++ b/scripts/render-of-document.ts
@@ -1,0 +1,96 @@
+/**
+ * Rend le document d'OF dans un fichier, pour inspection visuelle.
+ *
+ *   npx ts-node --transpile-only scripts/render-of-document.ts <sortie.pdf> [variante]
+ *
+ * Variantes : `nominal`, `brouillon`, `obsolete`, `cent-phases`, `multi-affaires`.
+ */
+
+import { writeFileSync } from "node:fs";
+
+import { buildOfDocumentPayload } from "../src/module/production/domain/of-document";
+import {
+  buildFixtureInput,
+  FIXTURE_QUANTITE_BASE,
+} from "../src/module/production/domain/__fixtures__/of-document.fixture";
+import { renderOfDocument } from "../src/module/production/services/of-document-render";
+import type { OfRevisionOperation } from "../src/module/production/domain/of-revision";
+import type { OfDocumentBuildInput } from "../src/module/production/domain/of-document";
+
+const FAMILIES = ["T", "F", "TTRAD", "FTRAD"] as const;
+
+function hundredPhases(): Partial<OfDocumentBuildInput> {
+  const operations: OfRevisionOperation[] = Array.from({ length: 100 }, (_, index) => ({
+    phase: (index + 1) * 10,
+    designation: `OPERATION ${index + 1} — usinage et contrôle intermédiaire`,
+    family: FAMILIES[index % FAMILIES.length],
+    machineId: null,
+    machineLabel: `MACHINE-${(index % 7) + 1}`,
+    programme: `PGM-${String(index + 1).padStart(3, "0")}`,
+    tempsUnitaire: 0.05 + (index % 9) / 100,
+    preparation: (index % 5) * 0.25,
+    quantiteBase: FIXTURE_QUANTITE_BASE,
+    coefficient: 1,
+  }));
+
+  const visas: OfDocumentBuildInput["visas"] = {};
+  for (const operation of operations) {
+    if (operation.phase % 30 === 0) {
+      visas[operation.phase] = { initials: "AG", visaAt: "2026-04-24T08:00:00.000Z" };
+    }
+  }
+
+  return { operations, visas };
+}
+
+function multiAffaires(): Partial<OfDocumentBuildInput> {
+  return {
+    commandeNumero: "CF00042720 1 / CF00042955 2",
+    affaires: [
+      { affaireId: 23149, numero: "23 149", delaiClient: "2026-07-01", quantite: 40 },
+      { affaireId: 23150, numero: "23 150", delaiClient: "2026-08-15", quantite: 25 },
+      { affaireId: 23151, numero: "23 151", delaiClient: "2026-09-30", quantite: 35 },
+    ],
+    cadenceLivraison: [
+      { date: "2026-07-01", quantite: 40, affaireNumero: "23 149" },
+      { date: "2026-08-15", quantite: 25, affaireNumero: "23 150" },
+      { date: "2026-09-30", quantite: 35, affaireNumero: "23 151" },
+    ],
+    quantites: {
+      quantiteDemandee: 100,
+      quantiteLivree: 10,
+      stockReserve: 15,
+      couvertAutresOf: 20,
+      quantiteAffecteeCetOf: 40,
+    },
+  };
+}
+
+async function main(): Promise<void> {
+  const out = process.argv[2] ?? "of-document.pdf";
+  const variant = process.argv[3] ?? "nominal";
+
+  const overrides: Partial<OfDocumentBuildInput> =
+    variant === "brouillon"
+      ? { watermark: "BROUILLON", revisionStatut: "BROUILLON", ofStatut: "Brouillon" }
+      : variant === "obsolete"
+        ? { watermark: "OBSOLETE", revisionStatut: "OBSOLETE", revisionCode: "R00" }
+        : variant === "cent-phases"
+          ? hundredPhases()
+          : variant === "multi-affaires"
+            ? multiAffaires()
+            : {};
+
+  const payload = buildOfDocumentPayload(buildFixtureInput(overrides));
+  const result = await renderOfDocument(payload);
+  writeFileSync(out, result.buffer);
+
+  process.stdout.write(
+    `${out}\n  variante : ${variant}\n  octets   : ${result.byteSize}\n  sha256   : ${result.sha256}\n  phases   : ${payload.phases.length}\n  totaux   : TP ${payload.totaux.preparationLabel} | TF ${payload.totaux.fabricationLabel} | ${payload.totaux.finalLabel}\n`
+  );
+}
+
+main().catch((error) => {
+  process.stderr.write(`${String(error?.stack ?? error)}\n`);
+  process.exit(1);
+});

--- a/src/__tests__/of-document-370.test.ts
+++ b/src/__tests__/of-document-370.test.ts
@@ -256,11 +256,22 @@ describe("#374 E — rendu serveur", () => {
       "CF00042720 1",
       "AIRBUS HELICOPTERS",
       "45 252 966 B",
-      "GAMME DE FABRICATION",
+      // La pièce est un ORDRE DE FABRICATION. Une gamme est la définition
+      // technique d'une pièce, réutilisable d'un OF à l'autre ; un OF est l'ordre
+      // de lancer une quantité, pour une commande, à une date. Il EMBARQUE la
+      // gamme applicable, il ne s'y réduit pas.
+      "ORDRE DE FABRICATION",
+      // Les titres de section sont rendus en capitales par le socle document.
+      "GAMME APPLICABLE",
       "71 h",
     ]) {
       expect(text).toContain(expected);
     }
+
+    // Garde anti-régression : le mauvais titre ne doit pas revenir. Un document
+    // intitulé « gamme de fabrication » ferait passer un ordre de lancement pour
+    // une fiche technique.
+    expect(text).not.toContain("GAMME DE FABRICATION");
   });
 
   it("réimprime le même binaire et la même empreinte", async () => {

--- a/src/__tests__/of-document-370.test.ts
+++ b/src/__tests__/of-document-370.test.ts
@@ -1,0 +1,377 @@
+// Chantier #374 — document d'OF : read-model, instantané figé, rendu serveur.
+//
+// Le rendu est réellement produit et le texte relu dans les flux de contenu du
+// PDF : c'est ce qui permet d'affirmer qu'une valeur y figure, plutôt que de
+// l'espérer (même harnais que le bon de livraison, ADR-0042).
+
+import { inflateSync } from "node:zlib";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMachineSequence,
+  buildOfDocumentPayload,
+  computeQuantityCoverage,
+  formatDuration,
+  formatMachineSequence,
+  formatNumberFr,
+  formatQuantity,
+  watermarkFor,
+} from "../module/production/domain/of-document";
+import { hashSnapshot } from "../module/production/domain/of-revision";
+import { renderOfDocument } from "../module/production/services/of-document-render";
+import {
+  buildFixtureInput,
+  FIXTURE_EXPECTED_TOTAL,
+  FIXTURE_EXPECTED_TOTAL_TF,
+  FIXTURE_EXPECTED_TOTAL_TP,
+  FIXTURE_QUANTITE_BASE,
+} from "../module/production/domain/__fixtures__/of-document.fixture";
+import type { OfRevisionOperation } from "../module/production/domain/of-revision";
+
+/**
+ * Texte réellement imprimé, relu dans les flux de contenu du PDF.
+ *
+ * `pdfkit` écrit les chaînes en hexadécimal et les découpe en fragments crénés :
+ * « Page 2 / 2 » sort en `[<50> 30 <61> 10 <67> -10 <652032202f2032> 0] TJ`. Une
+ * recherche naïve dans le binaire ne trouverait donc jamais le texte affiché. On
+ * décode les opérateurs de rendu et on recolle les fragments, en écartant les
+ * nombres de crénage.
+ *
+ * Les polices standard sont encodées en WinAnsi, dont les octets coïncident avec
+ * latin1 sur les accents français.
+ */
+function pdfText(buffer: Buffer): string {
+  const raw = buffer.toString("latin1");
+  const streams: string[] = [];
+  const streamRe = /stream\r?\n([\s\S]*?)\r?\nendstream/g;
+  let match: RegExpExecArray | null;
+  while ((match = streamRe.exec(raw)) !== null) {
+    try {
+      streams.push(inflateSync(Buffer.from(match[1], "latin1")).toString("latin1"));
+    } catch {
+      // Flux non compressé, image ou police : sans texte à relire.
+    }
+  }
+
+  const content = streams.join("\n");
+  const pieces: string[] = [];
+  const showRe = /<([0-9A-Fa-f\s]+)>|\(((?:\\.|[^\\()])*)\)/g;
+  while ((match = showRe.exec(content)) !== null) {
+    if (match[1] !== undefined) {
+      const hex = match[1].replace(/\s+/g, "");
+      if (hex.length % 2 === 0) {
+        pieces.push(Buffer.from(hex, "hex").toString("latin1"));
+      }
+    } else {
+      pieces.push(
+        match[2].replace(/\\([nrtbf()\\])/g, (_, char: string) =>
+          char === "n" ? "\n" : char === "r" ? "\r" : char === "t" ? "\t" : char
+        )
+      );
+    }
+  }
+
+  return pieces.join("");
+}
+
+function countPages(buffer: Buffer): number {
+  const matches = buffer.toString("latin1").match(/\/Type\s*\/Page[^s]/g);
+  return matches ? matches.length : 0;
+}
+
+describe("#374 E — formatage du document", () => {
+  it("affiche les durées comme on les dit à l'atelier", () => {
+    expect(formatDuration(0.1)).toBe("6 min");
+    expect(formatDuration(1.3333333)).toBe("1 h 20 min");
+    expect(formatDuration(4)).toBe("4 h");
+    expect(formatDuration(3.2)).toBe("3 h 12 min");
+    expect(formatDuration(0.035)).toBe("2 min");
+    expect(formatDuration(0)).toBe("0 min");
+    expect(formatDuration(null)).toBe("—");
+    expect(formatDuration(59)).toBe("59 h");
+  });
+
+  it("écrit les nombres à la française", () => {
+    expect(formatNumberFr(2280)).toBe("2 280,00");
+    expect(formatNumberFr(0.91, 3)).toBe("0,910");
+    expect(formatQuantity(40)).toBe("40");
+    expect(formatQuantity(40.5)).toBe("40,500");
+    expect(formatQuantity(null)).toBe("—");
+  });
+});
+
+describe("#374 E — couverture de la demande sans double comptage", () => {
+  it("répartit la demande en postes disjoints dont la somme la redonne", () => {
+    const coverage = computeQuantityCoverage({
+      quantiteDemandee: 100,
+      quantiteLivree: 10,
+      stockReserve: 15,
+      couvertAutresOf: 20,
+      quantiteAffecteeCetOf: 40,
+    });
+    expect(coverage.resteNetACouvrir).toBe(15);
+    expect(coverage.totalCouvert).toBe(85);
+    expect(
+      coverage.quantiteLivree +
+        coverage.stockReserve +
+        coverage.couvertAutresOf +
+        coverage.quantiteAffecteeCetOf +
+        coverage.resteNetACouvrir
+    ).toBe(coverage.quantiteDemandee);
+    expect(coverage.surCouverture).toBe(false);
+  });
+
+  it("ne compte pas deux fois une réservation et un autre OF actif", () => {
+    // 40 demandés : 25 réservés sur stock et 15 produits ailleurs couvrent tout.
+    const coverage = computeQuantityCoverage({
+      quantiteDemandee: 40,
+      quantiteLivree: 0,
+      stockReserve: 25,
+      couvertAutresOf: 15,
+      quantiteAffecteeCetOf: 0,
+    });
+    expect(coverage.resteNetACouvrir).toBe(0);
+    expect(coverage.totalCouvert).toBe(40);
+  });
+
+  it("borne le reste net à zéro et signale la sur-couverture", () => {
+    const coverage = computeQuantityCoverage({
+      quantiteDemandee: 40,
+      quantiteLivree: 10,
+      stockReserve: 20,
+      couvertAutresOf: 20,
+      quantiteAffecteeCetOf: 10,
+    });
+    expect(coverage.resteNetACouvrir).toBe(0);
+    expect(coverage.surCouverture).toBe(true);
+    expect(coverage.excedent).toBe(20);
+  });
+
+  it("neutralise les valeurs absentes ou négatives", () => {
+    const coverage = computeQuantityCoverage({
+      quantiteDemandee: 40,
+      quantiteLivree: -5,
+      stockReserve: Number.NaN,
+      couvertAutresOf: null as unknown as number,
+      quantiteAffecteeCetOf: 40,
+    });
+    expect(coverage.quantiteLivree).toBe(0);
+    expect(coverage.stockReserve).toBe(0);
+    expect(coverage.couvertAutresOf).toBe(0);
+    expect(coverage.resteNetACouvrir).toBe(0);
+  });
+});
+
+describe("#374 E — séquence machines", () => {
+  const op = (phase: number, family: OfRevisionOperation["family"]) => ({ phase, family });
+
+  it("conserve l'ordre réel : T -> F -> T reste trois passages", () => {
+    const steps = buildMachineSequence([op(10, "T"), op(20, "F"), op(30, "T")]);
+    expect(steps.map((s) => s.family)).toEqual(["T", "F", "T"]);
+    expect(formatMachineSequence(steps)).toBe("T -> F -> T");
+  });
+
+  it("regroupe les phases consécutives d'une même famille", () => {
+    const steps = buildMachineSequence([
+      op(10, "F"), op(20, "F"), op(30, "F"), op(40, "T"), op(50, "T"), op(60, "F"),
+    ]);
+    expect(formatMachineSequence(steps)).toBe("3 F -> 2 T -> F");
+    expect(steps[0].phases).toEqual([10, 20, 30]);
+  });
+
+  it("écarte les phases sans famille mais laisse la séquence se rouvrir", () => {
+    // Fraisage, emballage, fraisage : la pièce retourne bien en machine.
+    const steps = buildMachineSequence([op(10, "F"), op(20, null), op(30, "F")]);
+    expect(steps.map((s) => s.family)).toEqual(["F", "F"]);
+    expect(formatMachineSequence(steps)).toBe("F -> F");
+  });
+
+  it("porte les quatre familles", () => {
+    const steps = buildMachineSequence([
+      op(10, "T"), op(20, "F"), op(30, "TTRAD"), op(40, "FTRAD"),
+    ]);
+    expect(formatMachineSequence(steps)).toBe("T -> F -> TTRAD -> FTRAD");
+  });
+
+  it("rend une séquence vide lisible", () => {
+    expect(formatMachineSequence(buildMachineSequence([]))).toBe("—");
+    expect(formatMachineSequence(buildMachineSequence([op(10, null)]))).toBe("—");
+  });
+});
+
+describe("#374 E — instantané et filigrane", () => {
+  it("calcule la découpe sans inventer de valeur", () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput());
+    expect(payload.decoupe.longueurTotaleMm).toBe(2280);
+
+    const partiel = buildOfDocumentPayload(
+      buildFixtureInput({ decoupe: { longueurBrutMm: 57, nombreBruts: null, piecesParBrut: 1, masseTotaleKg: null } })
+    );
+    expect(partiel.decoupe.longueurTotaleMm).toBeNull();
+    expect(partiel.decoupe.masseTotaleKg).toBeNull();
+  });
+
+  it("totalise les temps du document papier", () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput());
+    expect(payload.totaux.preparationH).toBeCloseTo(FIXTURE_EXPECTED_TOTAL_TP, 6);
+    expect(payload.totaux.fabricationH).toBeCloseTo(FIXTURE_EXPECTED_TOTAL_TF, 6);
+    expect(payload.totaux.finalH).toBeCloseTo(FIXTURE_EXPECTED_TOTAL, 6);
+    expect(payload.totaux.finalLabel).toBe("71 h");
+  });
+
+  it("exige un filigrane sur un brouillon et sur une révision périmée", () => {
+    expect(watermarkFor({ revisionStatut: "ACTIVE", documentStatut: "OFFICIEL" })).toBeNull();
+    expect(watermarkFor({ revisionStatut: "ACTIVE", documentStatut: "BROUILLON" })).toBe("BROUILLON");
+    expect(watermarkFor({ revisionStatut: "OBSOLETE", documentStatut: "OFFICIEL" })).toBe("OBSOLETE");
+    expect(watermarkFor({ revisionStatut: "ACTIVE", documentStatut: "OBSOLETE" })).toBe("OBSOLETE");
+  });
+
+  it("produit le même payload — donc la même empreinte — à contenu égal", () => {
+    const a = buildOfDocumentPayload(buildFixtureInput());
+    const b = buildOfDocumentPayload(buildFixtureInput());
+    expect(hashSnapshot(a)).toBe(hashSnapshot(b));
+
+    const ordreInverse = buildOfDocumentPayload(
+      buildFixtureInput({ operations: [...buildFixtureInput().operations].reverse() })
+    );
+    // Les phases sont triées à la construction : l'ordre d'entrée n'influe pas.
+    expect(hashSnapshot(ordreInverse)).toBe(hashSnapshot(a));
+  });
+});
+
+describe("#374 E — rendu serveur", () => {
+  it("rend un PDF A4 et y imprime les données attendues", async () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput());
+    const { buffer, sha256, byteSize } = await renderOfDocument(payload);
+
+    expect(buffer.subarray(0, 5).toString()).toBe("%PDF-");
+    expect(byteSize).toBe(buffer.byteLength);
+    expect(sha256).toMatch(/^[a-f0-9]{64}$/);
+
+    const text = pdfText(buffer);
+    for (const expected of [
+      "OF-2026-23149",
+      "R00",
+      "CF00042720 1",
+      "AIRBUS HELICOPTERS",
+      "45 252 966 B",
+      "GAMME DE FABRICATION",
+      "71 h",
+    ]) {
+      expect(text).toContain(expected);
+    }
+  });
+
+  it("réimprime le même binaire et la même empreinte", async () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput());
+    const first = await renderOfDocument(payload);
+    const second = await renderOfDocument(payload);
+
+    expect(second.sha256).toBe(first.sha256);
+    expect(second.buffer.equals(first.buffer)).toBe(true);
+  });
+
+  it("change d'empreinte dès qu'une donnée imprimée change", async () => {
+    const base = await renderOfDocument(buildOfDocumentPayload(buildFixtureInput()));
+    const autreQuantite = await renderOfDocument(
+      buildOfDocumentPayload(
+        buildFixtureInput({
+          quantites: {
+            quantiteDemandee: 60,
+            quantiteLivree: 0,
+            stockReserve: 0,
+            couvertAutresOf: 0,
+            quantiteAffecteeCetOf: 60,
+          },
+        })
+      )
+    );
+    expect(autreQuantite.sha256).not.toBe(base.sha256);
+  });
+
+  it("refuse un horodatage invalide plutôt que de dater le document du jour", async () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput({ generatedAt: "pas-une-date" }));
+    await expect(renderOfDocument(payload)).rejects.toThrow(/Horodatage/);
+  });
+
+  it("imprime le filigrane du brouillon", async () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput({ watermark: "BROUILLON" }));
+    const { buffer } = await renderOfDocument(payload);
+    expect(pdfText(buffer)).toContain("BROUILLON");
+  });
+
+  it("pagine 100 phases et réémet l'en-tête sur chaque page", async () => {
+    const operations: OfRevisionOperation[] = Array.from({ length: 100 }, (_, index) => ({
+      phase: (index + 1) * 10,
+      designation: `OPERATION ${index + 1}`,
+      family: (["T", "F", "TTRAD", "FTRAD"] as const)[index % 4],
+      machineId: null,
+      machineLabel: `MACHINE-${(index % 7) + 1}`,
+      programme: `PGM-${index + 1}`,
+      tempsUnitaire: 0.1,
+      preparation: 0.5,
+      quantiteBase: FIXTURE_QUANTITE_BASE,
+      coefficient: 1,
+    }));
+
+    const payload = buildOfDocumentPayload(buildFixtureInput({ operations, visas: {} }));
+    expect(payload.phases).toHaveLength(100);
+
+    const { buffer } = await renderOfDocument(payload);
+    const pages = countPages(buffer);
+    expect(pages).toBeGreaterThan(5);
+
+    const text = pdfText(buffer);
+    // Le pied de page numérote sur le total réel.
+    expect(text).toContain(`Page 1 / ${pages}`);
+    expect(text).toContain(`Page ${pages} / ${pages}`);
+    // Première et dernière phase présentes : rien n'est perdu à la pagination.
+    expect(text).toContain("OPERATION 1");
+    expect(text).toContain("OPERATION 100");
+  });
+
+  it("supporte plusieurs commandes, affaires et cadences", async () => {
+    const payload = buildOfDocumentPayload(
+      buildFixtureInput({
+        commandeNumero: "CF00042720 1 / CF00042955 2",
+        affaires: [
+          { affaireId: 23149, numero: "23 149", delaiClient: "2026-07-01", quantite: 40 },
+          { affaireId: 23150, numero: "23 150", delaiClient: "2026-08-15", quantite: 25 },
+          { affaireId: 23151, numero: "23 151", delaiClient: "2026-09-30", quantite: 35 },
+        ],
+        cadenceLivraison: [
+          { date: "2026-09-30", quantite: 35, affaireNumero: "23 151" },
+          { date: "2026-07-01", quantite: 40, affaireNumero: "23 149" },
+          { date: "2026-08-15", quantite: 25, affaireNumero: "23 150" },
+        ],
+        quantites: {
+          quantiteDemandee: 100,
+          quantiteLivree: 10,
+          stockReserve: 15,
+          couvertAutresOf: 20,
+          quantiteAffecteeCetOf: 40,
+        },
+      })
+    );
+
+    // Les échéances sont réordonnées : l'entrée désordonnée ne change pas le rendu.
+    expect(payload.cadenceLivraison.map((c) => c.date)).toEqual([
+      "2026-07-01",
+      "2026-08-15",
+      "2026-09-30",
+    ]);
+    expect(payload.quantites.resteNetACouvrir).toBe(15);
+
+    const text = pdfText((await renderOfDocument(payload)).buffer);
+    for (const expected of ["23 149", "23 150", "23 151", "15/08/2026", "30/09/2026"]) {
+      expect(text).toContain(expected);
+    }
+  });
+
+  it("rend un OF sans phase sans planter", async () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput({ operations: [], visas: {} }));
+    const { buffer } = await renderOfDocument(payload);
+    expect(pdfText(buffer)).toContain("Aucune phase dans cette révision.");
+  });
+});

--- a/src/__tests__/of-document-emission-370.test.ts
+++ b/src/__tests__/of-document-emission-370.test.ts
@@ -1,0 +1,309 @@
+// Garanties documentaires du chantier #370.
+//
+// Ces tests portent sur ce qui rend le document OPPOSABLE : l'aperçu et l'émission
+// partagent le même read-model, une réimpression reproduit le binaire à l'octet,
+// et un document ne se laisse pas émettre deux fois.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOfDocumentPayload,
+  hashDocumentPayload,
+  OF_DOCUMENT_TEMPLATE_VERSION,
+  watermarkFor,
+  type OfDocumentPayload,
+} from "../module/production/domain/of-document";
+import { renderOfDocument } from "../module/production/services/of-document-render";
+import {
+  buildFixtureInput,
+  FIXTURE_FAMILLES,
+  FIXTURE_OPERATIONS_TFT,
+} from "../module/production/domain/__fixtures__/of-document.fixture";
+
+describe("#370 — l'aperçu et l'émission partagent le même read-model", () => {
+  it("produit un payload identique pour le même instantané", () => {
+    // Une seule fonction construit le payload : l'aperçu et l'émission ne peuvent
+    // pas divergier, puisqu'il n'y a pas deux chemins à faire concorder.
+    const a = buildOfDocumentPayload(buildFixtureInput({ documentStatut: "BROUILLON" }));
+    const b = buildOfDocumentPayload(buildFixtureInput({ documentStatut: "BROUILLON" }));
+    expect(hashDocumentPayload(a)).toBe(hashDocumentPayload(b));
+  });
+
+  it("distingue l'empreinte du DOCUMENT de celle de la RÉVISION", () => {
+    const officiel = buildOfDocumentPayload(buildFixtureInput({ documentStatut: "OFFICIEL" }));
+    const brouillon = buildOfDocumentPayload(buildFixtureInput({ documentStatut: "BROUILLON" }));
+
+    // Même révision : l'empreinte technique ne bouge pas…
+    expect(officiel.snapshotSha256).toBe(brouillon.snapshotSha256);
+    // …mais le document diffère (statut, filigrane), et cela doit se voir.
+    expect(hashDocumentPayload(officiel)).not.toBe(hashDocumentPayload(brouillon));
+  });
+
+  it("porte la version du gabarit dans le payload figé", () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput());
+    expect(payload.templateVersion).toBe(OF_DOCUMENT_TEMPLATE_VERSION);
+
+    // Changer de gabarit change l'empreinte du document : deux PDF de même
+    // contenu rendus par deux gabarits différents ne sont pas le même document.
+    const autre = buildOfDocumentPayload(buildFixtureInput({ templateVersion: "of-gamme/9.9" }));
+    expect(hashDocumentPayload(autre)).not.toBe(hashDocumentPayload(payload));
+  });
+});
+
+describe("#370 — une réimpression reproduit le document émis à l'octet", () => {
+  it("rend deux fois le même binaire depuis le même payload figé", async () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput({ documentStatut: "OFFICIEL" }));
+
+    const first = await renderOfDocument(payload);
+    const second = await renderOfDocument(payload);
+
+    // C'est la garantie de la réimpression : le rendu ne lit AUCUNE horloge,
+    // `generatedAt` vient du payload. Sans cela, chaque réimpression produirait
+    // une empreinte différente et le document ne serait plus opposable.
+    expect(second.sha256).toBe(first.sha256);
+    expect(second.byteSize).toBe(first.byteSize);
+    expect(second.buffer.equals(first.buffer)).toBe(true);
+  });
+
+  it("change d'empreinte dès qu'une donnée du document change", async () => {
+    const base = buildOfDocumentPayload(buildFixtureInput({ documentStatut: "OFFICIEL" }));
+    const modifie = buildOfDocumentPayload(
+      buildFixtureInput({ documentStatut: "OFFICIEL", operations: FIXTURE_OPERATIONS_TFT })
+    );
+
+    const a = await renderOfDocument(base);
+    const b = await renderOfDocument(modifie);
+    expect(b.sha256).not.toBe(a.sha256);
+  });
+
+  it("rejoue un payload relu depuis JSON à l'identique", async () => {
+    // La réimpression relit le payload depuis `of_documents.payload` (jsonb) :
+    // l'aller-retour de sérialisation ne doit rien changer au binaire.
+    const payload = buildOfDocumentPayload(buildFixtureInput({ documentStatut: "OFFICIEL" }));
+    const relu = JSON.parse(JSON.stringify(payload)) as OfDocumentPayload;
+
+    const direct = await renderOfDocument(payload);
+    const apresJson = await renderOfDocument(relu);
+    expect(apresJson.sha256).toBe(direct.sha256);
+  });
+});
+
+describe("#370 — le filigrane protège de la confusion documentaire", () => {
+  it("marque BROUILLON, OBSOLETE, et rien sur un officiel courant", () => {
+    expect(watermarkFor({ revisionStatut: "ACTIVE", documentStatut: "BROUILLON" })).toBe("BROUILLON");
+    expect(watermarkFor({ revisionStatut: "ACTIVE", documentStatut: "OBSOLETE" })).toBe("OBSOLETE");
+    // Un document officiel d'une révision périmée est OBSOLETE : c'est le cas le
+    // plus dangereux, il ressemble sinon exactement à l'exemplaire courant.
+    expect(watermarkFor({ revisionStatut: "OBSOLETE", documentStatut: "OFFICIEL" })).toBe("OBSOLETE");
+    expect(watermarkFor({ revisionStatut: "ACTIVE", documentStatut: "OFFICIEL" })).toBeNull();
+  });
+
+  it("produit un binaire différent avec et sans filigrane", async () => {
+    const sans = await renderOfDocument(buildOfDocumentPayload(buildFixtureInput({ watermark: null })));
+    const avec = await renderOfDocument(
+      buildOfDocumentPayload(buildFixtureInput({ watermark: "BROUILLON" }))
+    );
+    // Le filigrane est réellement dessiné, pas seulement stocké dans le payload.
+    expect(avec.sha256).not.toBe(sans.sha256);
+    expect(avec.byteSize).toBeGreaterThan(sans.byteSize);
+  });
+});
+
+describe("#370 — une donnée absente est signalée, jamais remplacée", () => {
+  it("signale un n° de programme manquant sur une famille qui l'exige", () => {
+    const payload = buildOfDocumentPayload(
+      buildFixtureInput({
+        operations: [
+          {
+            phase: 10,
+            designation: "FRAISAGE CN",
+            family: "F",
+            machineId: null,
+            machineLabel: "VMC-1",
+            programme: null,
+            tempsUnitaire: 0.1,
+            preparation: 0,
+            quantiteBase: 10,
+            coefficient: 1,
+            cfCode: "FCN",
+            cfRateId: null,
+            tauxHoraire: 68,
+            tauxHoraireSource: "CENTRE_FRAIS",
+            tauxHoraireEffectiveAt: "2026-01-01",
+          },
+        ],
+        visas: {},
+      })
+    );
+
+    expect(payload.phases[0].programmeManquant).toBe(true);
+    expect(payload.phases[0].programme).toBeNull();
+    expect(payload.avertissements.map((a) => a.code)).toContain("PROGRAMME_MANQUANT");
+  });
+
+  it("ne signale RIEN sur une famille qui n'exige pas de programme", () => {
+    const payload = buildOfDocumentPayload(
+      buildFixtureInput({
+        operations: [
+          {
+            phase: 20,
+            designation: "DEBIT",
+            family: "DECOUPE",
+            machineId: null,
+            machineLabel: "Scie",
+            programme: null,
+            tempsUnitaire: 0.05,
+            preparation: 0,
+            quantiteBase: 10,
+            coefficient: 1,
+            cfCode: "DEB",
+            cfRateId: null,
+            tauxHoraire: 42,
+            tauxHoraireSource: "CENTRE_FRAIS",
+            tauxHoraireEffectiveAt: "2026-01-01",
+          },
+        ],
+        visas: {},
+      })
+    );
+
+    // `programme_requis` est faux pour DECOUPE : son absence n'est pas un défaut
+    // et ne doit pas noyer les vrais signalements.
+    expect(payload.phases[0].programmeManquant).toBe(false);
+    expect(payload.avertissements.map((a) => a.code)).not.toContain("PROGRAMME_MANQUANT");
+  });
+
+  it("ne déduit AUCUNE longueur totale quand un terme manque", () => {
+    const payload = buildOfDocumentPayload(
+      buildFixtureInput({
+        decoupe: {
+          dimensions: null,
+          longueurBrutMm: 57,
+          longueurUtileMm: null,
+          traitDeScieMm: null,
+          chuteMm: null,
+          nombreBruts: null, // terme manquant
+          piecesParBrut: 1,
+          masseTotaleKg: null,
+          unite: null,
+          methodeCalcul: null,
+        },
+      })
+    );
+
+    expect(payload.decoupe.longueurTotaleMm).toBeNull();
+    expect(payload.decoupe.methodeCalcul).toBeNull();
+    expect(payload.avertissements.map((a) => a.code)).toContain("DECOUPE_INCOMPLETE");
+  });
+
+  it("publie la méthode de calcul quand la longueur EST calculable", () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput());
+    expect(payload.decoupe.longueurTotaleMm).toBe(2280);
+    expect(payload.decoupe.methodeCalcul).toContain("longueur de brut");
+    expect(payload.decoupe.methodeCalcul).toContain("nombre de bruts");
+  });
+
+  it("signale une famille absente du référentiel sans l'inventer", () => {
+    const payload = buildOfDocumentPayload(
+      buildFixtureInput({
+        operations: [
+          {
+            phase: 10,
+            designation: "PHASE EXOTIQUE",
+            family: "RECTIF",
+            machineId: null,
+            machineLabel: null,
+            programme: null,
+            tempsUnitaire: 0.1,
+            preparation: 0,
+            quantiteBase: 10,
+            coefficient: 1,
+            cfCode: null,
+            cfRateId: null,
+            tauxHoraire: null,
+            tauxHoraireSource: null,
+            tauxHoraireEffectiveAt: null,
+          },
+        ],
+        visas: {},
+        familles: FIXTURE_FAMILLES,
+      })
+    );
+
+    expect(payload.avertissements.map((a) => a.code)).toContain("FAMILLE_INCONNUE");
+    // Le code est conservé tel quel : on ne le remplace pas par une famille
+    // « proche », qui enverrait la pièce sur la mauvaise machine.
+    expect(payload.phases[0].family).toBe("RECTIF");
+    expect(payload.phases[0].familyLabel).toBe("RECTIF");
+  });
+
+  it("signale l'absence de référentiel plutôt que de taire le non-contrôle", () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput({ familles: undefined }));
+    expect(payload.avertissements.map((a) => a.code)).toContain("REFERENTIEL_FAMILLES_ABSENT");
+  });
+
+  it("trie les avertissements de façon stable — ils entrent dans le hash", () => {
+    const a = buildOfDocumentPayload(buildFixtureInput({ familles: undefined }));
+    const b = buildOfDocumentPayload(buildFixtureInput({ familles: undefined }));
+    expect(a.avertissements).toEqual(b.avertissements);
+    expect(hashDocumentPayload(a)).toBe(hashDocumentPayload(b));
+  });
+});
+
+describe("#370 — le VISA est imprimé même vide et reste solidaire de sa phase", () => {
+  it("donne un bloc VISA à CHAQUE phase, visée ou non", () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput());
+    // Une zone imprimée seulement si déjà remplie serait inutilisable au poste :
+    // c'est la case que l'atelier remplit au stylo.
+    expect(payload.phases).toHaveLength(11);
+    for (const phase of payload.phases) {
+      expect(phase.visa).toBeDefined();
+      expect(phase.visa.statut).toBeTruthy();
+    }
+    const nonVisee = payload.phases.find((p) => p.phase === 20);
+    expect(nonVisee?.visa.statut).toBe("A_FAIRE");
+    expect(nonVisee?.visa.visaOperateur).toBeNull();
+  });
+
+  it("sépare le visa opérateur du visa contrôle", () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput());
+    const controlee = payload.phases.find((p) => p.phase === 110);
+    expect(controlee?.visa.visaOperateur).toBe("TB");
+    expect(controlee?.visa.visaControle).toBe("MC");
+    expect(controlee?.visa.visaControle).not.toBe(controlee?.visa.visaOperateur);
+  });
+
+  it("conserve quantités et motif de rebut par phase", () => {
+    const payload = buildOfDocumentPayload(buildFixtureInput());
+    const rebut = payload.phases.find((p) => p.phase === 60);
+    expect(rebut?.visa.quantiteBonne).toBe(39);
+    expect(rebut?.visa.quantiteRebut).toBe(1);
+    expect(rebut?.visa.motifRebut).toBe("Cote hors tolérance");
+  });
+});
+
+describe("#370 — pagination et volumétrie", () => {
+  it("rend 1 phase et 100 phases sans échouer", async () => {
+    const une = buildOfDocumentPayload(
+      buildFixtureInput({ operations: [FIXTURE_OPERATIONS_TFT[0]], visas: {} })
+    );
+    expect(une.phases).toHaveLength(1);
+    const renduUne = await renderOfDocument(une);
+    expect(renduUne.byteSize).toBeGreaterThan(0);
+
+    const cent = buildOfDocumentPayload(
+      buildFixtureInput({
+        operations: Array.from({ length: 100 }, (_, i) => ({
+          ...FIXTURE_OPERATIONS_TFT[i % 3],
+          phase: (i + 1) * 10,
+        })),
+        visas: {},
+      })
+    );
+    expect(cent.phases).toHaveLength(100);
+    const renduCent = await renderOfDocument(cent);
+    // Un document de 100 phases est nettement plus lourd : la preuve qu'aucune
+    // phase n'a été silencieusement tronquée.
+    expect(renduCent.byteSize).toBeGreaterThan(renduUne.byteSize);
+  });
+});

--- a/src/__tests__/of-generation-revision-370.test.ts
+++ b/src/__tests__/of-generation-revision-370.test.ts
@@ -1,0 +1,140 @@
+// Garde de non-régression : la génération d'OF doit rattacher ses opérations à une
+// révision (#370).
+//
+// `of_operations.revision_id` est NOT NULL depuis le versioning d'OF. La génération
+// d'OF — code partagé, antérieur à ce chantier — insérait ses opérations SANS ce
+// champ. Résultat : toute création d'OF échouait en 23502, sur `cerp_test` comme
+// sur `cerp_prod`. Le défaut était invisible aux tests existants parce qu'ils
+// simulent `tx.query` et ne vérifient jamais la contrainte réelle.
+//
+// Ces tests inspectent le SQL RÉELLEMENT émis. C'est le seul moyen d'attraper un
+// défaut de ce type sans base de données.
+
+import { describe, expect, it, vi } from "vitest";
+
+import { copyPieceOperationsToOf } from "../module/production/domain/of-generation";
+
+/** Capture le SQL émis, dans l'ordre. */
+function recordingTx() {
+  const queries: string[] = [];
+  return {
+    queries,
+    query: vi.fn(async (sql: string) => {
+      queries.push(String(sql));
+      return { rows: [], rowCount: 1 };
+    }),
+  };
+}
+
+const PARAMS = {
+  of_id: 4242,
+  piece_technique_id: "0f9b1c22-5f1a-4c6e-9d0a-6b7d2e3f4a51",
+  gamme_id: null,
+};
+
+describe("#370 — la génération d'OF crée la R00 et y rattache ses opérations", () => {
+  it("insère la révision R00 AVANT les opérations", async () => {
+    const tx = recordingTx();
+    await copyPieceOperationsToOf(tx as never, PARAMS);
+
+    const revisionIndex = tx.queries.findIndex((q) => q.includes("INSERT INTO public.of_revisions"));
+    const operationsIndex = tx.queries.findIndex((q) =>
+      q.includes("INSERT INTO public.of_operations")
+    );
+
+    expect(revisionIndex, "la R00 doit être insérée").toBeGreaterThanOrEqual(0);
+    expect(operationsIndex, "les opérations doivent être insérées").toBeGreaterThanOrEqual(0);
+    // L'ordre compte : une opération insérée avant sa révision violerait NOT NULL.
+    expect(revisionIndex).toBeLessThan(operationsIndex);
+  });
+
+  it("crée la R00 en ACTIVE, au rang 0, avec une empreinte", async () => {
+    const tx = recordingTx();
+    await copyPieceOperationsToOf(tx as never, PARAMS);
+    const sql = tx.queries.find((q) => q.includes("INSERT INTO public.of_revisions")) ?? "";
+
+    expect(sql).toContain("'R00'");
+    expect(sql).toContain("'ACTIVE'");
+    expect(sql).toContain("snapshot_sha256");
+    expect(sql).toContain("activated_at");
+  });
+
+  it("garde la création idempotente sans dépendre d'un index total", async () => {
+    const tx = recordingTx();
+    await copyPieceOperationsToOf(tx as never, PARAMS);
+    const sql = tx.queries.find((q) => q.includes("INSERT INTO public.of_revisions")) ?? "";
+
+    // `of_revisions_active_uq` est un index PARTIEL : `ON CONFLICT` ne peut pas
+    // s'y appuyer. La garde doit donc être un `WHERE NOT EXISTS`.
+    expect(sql).toContain("WHERE NOT EXISTS");
+    expect(sql).not.toContain("ON CONFLICT");
+  });
+
+  it("renseigne revision_id dans l'INSERT des opérations", async () => {
+    const tx = recordingTx();
+    await copyPieceOperationsToOf(tx as never, PARAMS);
+    const sql = tx.queries.find((q) => q.includes("INSERT INTO public.of_operations")) ?? "";
+
+    // La colonne doit être dans la liste ET dans le SELECT : une colonne déclarée
+    // sans valeur correspondante décalerait toutes les autres.
+    expect(sql).toContain("revision_id");
+    expect(sql).toContain("statut = 'ACTIVE'");
+    expect(sql).toMatch(/FROM public\.of_revisions r/);
+  });
+
+  it("résout la révision en SQL, sans aller-retour applicatif", async () => {
+    const tx = recordingTx();
+    await copyPieceOperationsToOf(tx as never, PARAMS);
+    const sql = tx.queries.find((q) => q.includes("INSERT INTO public.of_operations")) ?? "";
+
+    // Remonter l'identifiant puis le réinjecter ouvrirait une fenêtre où l'une des
+    // deux écritures pourrait manquer. La sous-requête l'évite par construction.
+    expect(sql).toContain("SELECT r.id FROM public.of_revisions r");
+  });
+
+  it("conserve les colonnes de gamme normalisée figées au lancement", async () => {
+    const tx = recordingTx();
+    await copyPieceOperationsToOf(tx as never, PARAMS);
+    const sql = tx.queries.find((q) => q.includes("INSERT INTO public.of_operations")) ?? "";
+
+    // Le versioning ne doit pas avoir fait perdre le gel du centre de frais.
+    for (const column of [
+      "numero_programme",
+      "machine_family_code",
+      "cf_code_snapshot",
+      "cf_rate_id",
+      "temps_fabrication_planned",
+      "hourly_rate_source",
+      "hourly_rate_effective_at",
+    ]) {
+      expect(sql, `colonne ${column} attendue`).toContain(column);
+    }
+  });
+});
+
+describe("#370 — l'avancement d'un OF ne compte que la révision applicable", () => {
+  it("filtre les opérations sur la révision ACTIVE dans le résumé de planning", async () => {
+    // Lecture du source : ce défaut ne se voit pas à l'exécution tant qu'aucune
+    // R01 n'existe, et se manifesterait alors par un avancement faux
+    // (« 6 phases sur 12 » sur un OF qui n'en a que 6).
+    //
+    // La recherche est volontairement insensible à la mise en forme : un test qui
+    // dépend d'une indentation exacte casse au premier reformatage et n'apprend
+    // rien sur le fond.
+    const fs = await import("node:fs/promises");
+    const source = await fs.readFile("src/module/planning/repository/planning.repository.ts", "utf8");
+
+    // La requête d'agrégat se reconnaît à ses compteurs d'avancement.
+    const aggregateIndex = source.indexOf("total_ops");
+    expect(aggregateIndex, "la requête d'agrégat doit exister").toBeGreaterThan(-1);
+
+    const end = source.indexOf("[params.of_id]", aggregateIndex);
+    const query = source.slice(aggregateIndex, end > -1 ? end : aggregateIndex + 2000);
+
+    // La jointure existe…
+    expect(query).toMatch(/LEFT JOIN\s+public\.of_operations\s+op/);
+    // …et elle est bornée à la révision applicable, avec le repli historique.
+    expect(query).toMatch(/r\.statut\s*=\s*'ACTIVE'/);
+    expect(query).toMatch(/op\.revision_id\s+IS\s+NULL/);
+  });
+});

--- a/src/__tests__/of-versioning-370.domain.test.ts
+++ b/src/__tests__/of-versioning-370.domain.test.ts
@@ -1,0 +1,724 @@
+// Chantier #374 — versioning d'OF, dérive de temps, brouillon de planning, AR à recaler.
+//
+// Ces tests portent sur les règles, pas sur le transport : ils échouent si la
+// règle métier change, pas si un contrôleur bouge.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  buildRevisionSnapshot,
+  canonicalJson,
+  checkRevisionCreation,
+  diffRevisionSnapshots,
+  formatRevisionCode,
+  hashSnapshot,
+  nextRevisionRank,
+  parseRevisionCode,
+  phaseFabricationTime,
+  phaseFinalTime,
+  snapshotTotalTime,
+  type OfRevisionOperation,
+} from "../module/production/domain/of-revision";
+import {
+  assessTimeVariance,
+  buildTimeVarianceProposal,
+  formatPct,
+  OF_TIME_VARIANCE_THRESHOLD_PCT,
+  roundPct,
+} from "../module/production/domain/of-time-variance";
+import {
+  buildPlanningPayload,
+  canTransitionPlanningStatut,
+  checkPlanningTransition,
+  comparePlanningVersions,
+  diffDays,
+  hashPlanningPayload,
+  requiresArRecalage,
+  type OfPlanningPayload,
+} from "../module/production/domain/of-planning-version";
+import {
+  buildArRecalageDossiers,
+  canTransitionArStatut,
+  decideArRecalage,
+  validateArRecalageInput,
+} from "../module/production/domain/ar-recalage";
+import {
+  notificationDedupeKey,
+  NOTIFICATION_TOPICS,
+  resolveNotificationRecipients,
+} from "../../src/shared/notifications/routing";
+import { roleHasOfCapability } from "../module/production/domain/of-rbac";
+import { authorizationRole } from "../module/auth/domain/roles";
+import {
+  FIXTURE_EXPECTED_TF,
+  FIXTURE_EXPECTED_TOTAL,
+  FIXTURE_EXPECTED_TOTAL_TF,
+  FIXTURE_EXPECTED_TOTAL_TP,
+  FIXTURE_OPERATIONS,
+} from "../module/production/domain/__fixtures__/of-document.fixture";
+
+const baseOperation = (over: Partial<OfRevisionOperation> = {}): OfRevisionOperation => ({
+  phase: 10,
+  designation: "FRAISAGE CN",
+  family: "F",
+  machineId: "m-1",
+  machineLabel: "VMC-1",
+  programme: "PGM-1",
+  tempsUnitaire: 0.1,
+  preparation: 0.5,
+  quantiteBase: 40,
+  coefficient: 1,
+  ...over,
+});
+
+const snapshotOf = (operations: OfRevisionOperation[]) =>
+  buildRevisionSnapshot({
+    ofId: 1,
+    ofNumero: "OF-2026-23149",
+    pieceReference: "45 252 966 B",
+    pieceDesignation: "BOITIER T16E M2",
+    pieceIndice: "B",
+    gammeId: "g-1",
+    gammeCode: "GAMME-1",
+    gammeVersion: "1",
+    quantiteLancee: 40,
+    matiere: {
+      reference: "PL*6061*T651*1*25*12",
+      designation: "ALUMINIUM 6061/T651",
+      nuance: "6061/T651",
+      longueurBrutMm: 57,
+      nombreBruts: 40,
+      piecesParBrut: 1,
+      masseTotaleKg: 0.91,
+    },
+    operations,
+  });
+
+// ---------------------------------------------------------------------------
+// Partie A — versioning
+// ---------------------------------------------------------------------------
+
+describe("#374 A — versioning d'OF", () => {
+  it("formate et relit les codes de révision", () => {
+    expect(formatRevisionCode(0)).toBe("R00");
+    expect(formatRevisionCode(1)).toBe("R01");
+    expect(formatRevisionCode(12)).toBe("R12");
+    expect(formatRevisionCode(100)).toBe("R100");
+    expect(parseRevisionCode("R00")).toBe(0);
+    expect(parseRevisionCode("R07")).toBe(7);
+    expect(parseRevisionCode("R100")).toBe(100);
+    expect(parseRevisionCode("REV1")).toBeNull();
+    expect(() => formatRevisionCode(-1)).toThrow();
+  });
+
+  it("enchaîne les rangs depuis la création", () => {
+    expect(nextRevisionRank(null)).toBe(0);
+    expect(nextRevisionRank(0)).toBe(1);
+    expect(nextRevisionRank(41)).toBe(42);
+  });
+
+  it("hache la même définition à l'identique quel que soit l'ordre des clés", () => {
+    const a = { z: 1, a: { y: 2, b: [3, { d: 4, c: 5 }] } };
+    const b = { a: { b: [3, { c: 5, d: 4 }], y: 2 }, z: 1 };
+    expect(canonicalJson(a)).toBe(canonicalJson(b));
+    expect(hashSnapshot(a)).toBe(hashSnapshot(b));
+  });
+
+  it("ignore -0 et les clés indéfinies dans l'empreinte", () => {
+    expect(hashSnapshot({ v: -0 })).toBe(hashSnapshot({ v: 0 }));
+    expect(hashSnapshot({ v: 1, absent: undefined })).toBe(hashSnapshot({ v: 1 }));
+  });
+
+  it("distingue deux définitions qui diffèrent d'un seul temps", () => {
+    const before = snapshotOf([baseOperation()]);
+    const after = snapshotOf([baseOperation({ tempsUnitaire: 0.11 })]);
+    expect(hashSnapshot(before)).not.toBe(hashSnapshot(after));
+  });
+
+  it("décrit l'écart phase par phase entre deux révisions", () => {
+    const before = snapshotOf([
+      baseOperation({ phase: 10 }),
+      baseOperation({ phase: 20, machineLabel: "VMC-2" }),
+    ]);
+    const after = snapshotOf([
+      baseOperation({ phase: 10, tempsUnitaire: 0.2 }),
+      baseOperation({ phase: 30, machineLabel: "VMC-3" }),
+    ]);
+
+    const diff = diffRevisionSnapshots(before, after);
+    expect(diff.identical).toBe(false);
+    expect(diff.summary).toMatchObject({
+      phasesAjoutees: 1,
+      phasesRetirees: 1,
+      phasesModifiees: 1,
+    });
+    const modified = diff.phases.find((p) => p.phase === 10);
+    expect(modified?.changes.map((c) => c.field)).toContain("tempsUnitaire");
+    expect(diff.phases.find((p) => p.phase === 30)?.kind).toBe("AJOUTEE");
+    expect(diff.phases.find((p) => p.phase === 20)?.kind).toBe("RETIREE");
+  });
+
+  it("signale un changement de matière et de quantité en entête", () => {
+    const before = snapshotOf([baseOperation()]);
+    const after = buildRevisionSnapshot({
+      ...before,
+      quantiteLancee: 60,
+      matiere: { ...before.matiere!, nombreBruts: 60 },
+    });
+    const diff = diffRevisionSnapshots(before, after);
+    expect(diff.header.map((c) => c.field)).toContain("quantiteLancee");
+    expect(diff.matiere.map((c) => c.field)).toContain("nombreBruts");
+  });
+
+  it("traite la première révision comme un ajout intégral", () => {
+    const diff = diffRevisionSnapshots(null, snapshotOf([baseOperation(), baseOperation({ phase: 20 })]));
+    expect(diff.summary.phasesAjoutees).toBe(2);
+    expect(diff.summary.phasesRetirees).toBe(0);
+  });
+
+  it("exige un motif dès R01 et refuse une révision identique", () => {
+    const snapshot = snapshotOf([baseOperation()]);
+    const identical = diffRevisionSnapshots(snapshot, snapshot);
+    const changed = diffRevisionSnapshots(snapshot, snapshotOf([baseOperation({ tempsUnitaire: 0.3 })]));
+
+    expect(checkRevisionCreation({ nextRank: 0, motif: null, diff: changed })).toEqual({ allowed: true });
+    expect(checkRevisionCreation({ nextRank: 1, motif: "  ", diff: changed })).toMatchObject({
+      allowed: false,
+      code: "MOTIF_REQUIS",
+    });
+    expect(checkRevisionCreation({ nextRank: 1, motif: "Nouvelle prise de pièce", diff: changed })).toEqual({
+      allowed: true,
+    });
+    expect(checkRevisionCreation({ nextRank: 1, motif: "Motif", diff: identical })).toMatchObject({
+      allowed: false,
+      code: "REVISION_IDENTIQUE",
+    });
+  });
+
+  it("applique fabrication = t_unit x quantité x coefficient, final = prépa + fabrication", () => {
+    const operation = baseOperation({ tempsUnitaire: 0.25, quantiteBase: 40, coefficient: 1, preparation: 1 });
+    expect(phaseFabricationTime(operation)).toBeCloseTo(10, 10);
+    expect(phaseFinalTime(operation)).toBeCloseTo(11, 10);
+
+    const withCoef = baseOperation({ tempsUnitaire: 0.1, quantiteBase: 40, coefficient: 1.5, preparation: 0 });
+    expect(phaseFabricationTime(withCoef)).toBeCloseTo(6, 10);
+  });
+
+  it("redonne les temps du document papier de l'affaire 23 149", () => {
+    for (const operation of FIXTURE_OPERATIONS) {
+      expect(phaseFabricationTime(operation)).toBeCloseTo(FIXTURE_EXPECTED_TF[operation.phase], 6);
+    }
+    const totalTp = FIXTURE_OPERATIONS.reduce((sum, o) => sum + o.preparation, 0);
+    const totalTf = FIXTURE_OPERATIONS.reduce((sum, o) => sum + phaseFabricationTime(o), 0);
+    expect(totalTp).toBeCloseTo(FIXTURE_EXPECTED_TOTAL_TP, 6);
+    expect(totalTf).toBeCloseTo(FIXTURE_EXPECTED_TOTAL_TF, 6);
+    expect(snapshotTotalTime(snapshotOf(FIXTURE_OPERATIONS))).toBeCloseTo(FIXTURE_EXPECTED_TOTAL, 6);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partie B — seuil de dérive
+// ---------------------------------------------------------------------------
+
+describe("#374 B — dérive du temps d'usinage", () => {
+  it("arrondit au centième en corrigeant la représentation binaire", () => {
+    // (110 - 100) / 100 * 100 vaut 10.000000000000002 en IEEE 754.
+    expect(roundPct(((110 - 100) / 100) * 100)).toBe(10);
+    expect(roundPct(10.009999999999998)).toBe(10.01);
+    expect(roundPct(-10.005)).toBe(-10.01);
+    expect(roundPct(9.994)).toBe(9.99);
+  });
+
+  it("respecte le seuil strict : 9,99 rien, 10,00 rien, 10,01 replanification", () => {
+    expect(assessTimeVariance({ referenceTime: 100, newTime: 109.99 })).toMatchObject({
+      variationPct: 9.99,
+      outcome: "RIEN",
+    });
+    expect(assessTimeVariance({ referenceTime: 100, newTime: 110 })).toMatchObject({
+      variationPct: 10,
+      outcome: "RIEN",
+    });
+    expect(assessTimeVariance({ referenceTime: 100, newTime: 110.01 })).toMatchObject({
+      variationPct: 10.01,
+      outcome: "REPLANIFICATION",
+    });
+    expect(OF_TIME_VARIANCE_THRESHOLD_PCT).toBe(10);
+  });
+
+  it("tient le seuil sur des temps réels en heures, pas seulement sur des centaines", () => {
+    // 4 h de référence : 4,40 h est pile à 10 %, 4,4005 h passe au-dessus.
+    expect(assessTimeVariance({ referenceTime: 4, newTime: 4.4 }).outcome).toBe("RIEN");
+    expect(assessTimeVariance({ referenceTime: 4, newTime: 4.4005 }).outcome).toBe("REPLANIFICATION");
+    expect(assessTimeVariance({ referenceTime: 0.035, newTime: 0.05 }).outcome).toBe("REPLANIFICATION");
+  });
+
+  it("impose une revue quand la référence est absente ou nulle", () => {
+    for (const reference of [null, undefined, 0]) {
+      const assessment = assessTimeVariance({ referenceTime: reference, newTime: 5 });
+      expect(assessment.outcome).toBe("REVUE");
+      expect(assessment.reviewRequired).toBe(true);
+      expect(assessment.variationPct).toBeNull();
+    }
+  });
+
+  it("ne propose rien sur une baisse de temps", () => {
+    const assessment = assessTimeVariance({ referenceTime: 10, newTime: 5 });
+    expect(assessment.variationPct).toBe(-50);
+    expect(assessment.outcome).toBe("RIEN");
+  });
+
+  it("ne crée pas de proposition sous le seuil, en crée une au-dessus", () => {
+    const common = {
+      ofId: 1,
+      ofNumero: "OF-2026-23149",
+      revisionId: "rev-1",
+      revisionCode: "R00",
+      ofOperationId: "op-1",
+      phase: 30,
+      family: "F" as const,
+      cause: "DERIVE_TEMPS_USINAGE" as const,
+      causeComment: null,
+      authorUserId: 7,
+      impactCharge: { chargeAvantH: 59, chargeApresH: 65, deltaH: 6, operationsImpactees: 1 },
+      machines: [],
+      affaires: [],
+      simulation: {
+        schema: "of-time-variance-simulation/1" as const,
+        decalageFinJours: 2,
+        dateFinAvant: "2026-06-20",
+        dateFinApres: "2026-06-22",
+        engagementsEnRisque: [],
+      },
+    };
+
+    expect(buildTimeVarianceProposal({ ...common, referenceTime: 4, newTime: 4.4 }).created).toBe(false);
+
+    const created = buildTimeVarianceProposal({ ...common, referenceTime: 4, newTime: 5 });
+    expect(created.created).toBe(true);
+    if (created.created) {
+      expect(created.proposal.variationPct).toBe(25);
+      expect(created.proposal.outcome).toBe("REPLANIFICATION");
+      // Le contexte d'impact est figé avec la proposition.
+      expect(created.proposal.impactCharge.deltaH).toBe(6);
+      expect(created.proposal.simulation.decalageFinJours).toBe(2);
+    }
+
+    expect(() =>
+      buildTimeVarianceProposal({ ...common, cause: "AUTRE", referenceTime: 4, newTime: 5 })
+    ).toThrow(/Autre/);
+  });
+
+  it("formate le pourcentage à la française", () => {
+    expect(formatPct(10.01)).toBe("10,01 %");
+    expect(formatPct(10)).toBe("10,00 %");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partie C — brouillon de planning
+// ---------------------------------------------------------------------------
+
+const planningPayload = (over: Partial<Omit<OfPlanningPayload, "schema">> = {}): OfPlanningPayload =>
+  buildPlanningPayload({
+    ofId: 1,
+    ofNumero: "OF-2026-23149",
+    revisionCode: "R00",
+    quantite: 40,
+    dateDebut: "2026-06-01",
+    dateFin: "2026-06-20",
+    chargeTotaleH: 71,
+    operations: [
+      {
+        phase: 30,
+        designation: "FRAISAGE CN",
+        family: "F",
+        machineId: "m-1",
+        machineLabel: "VMC-1",
+        debut: "2026-06-01",
+        fin: "2026-06-02",
+        dureeH: 4.5,
+        quantite: 40,
+      },
+    ],
+    cadence: [{ date: "2026-07-01", quantite: 40, affaireId: 23149 }],
+    engagements: [
+      {
+        affaireId: 23149,
+        affaireNumero: "23 149",
+        commandeId: 900,
+        commandeNumero: "CF00042720 1",
+        clientId: "003",
+        delaiClient: "2026-07-01",
+        quantite: 40,
+      },
+    ],
+    ...over,
+  });
+
+describe("#374 C — brouillon de planning versionné", () => {
+  it("n'autorise que le cycle ACTIF -> BROUILLON -> SOUMIS -> VALIDE/REFUSE -> ACTIF", () => {
+    expect(canTransitionPlanningStatut("BROUILLON", "SOUMIS")).toBe(true);
+    expect(canTransitionPlanningStatut("SOUMIS", "VALIDE")).toBe(true);
+    expect(canTransitionPlanningStatut("SOUMIS", "REFUSE")).toBe(true);
+    expect(canTransitionPlanningStatut("VALIDE", "ACTIF")).toBe(true);
+    expect(canTransitionPlanningStatut("ACTIF", "SUPERSEDE")).toBe(true);
+
+    // Un brouillon ne devient jamais actif sans passer par la validation.
+    expect(canTransitionPlanningStatut("BROUILLON", "ACTIF")).toBe(false);
+    expect(canTransitionPlanningStatut("BROUILLON", "VALIDE")).toBe(false);
+    // Un refus est terminal.
+    expect(canTransitionPlanningStatut("REFUSE", "BROUILLON")).toBe(false);
+    expect(checkPlanningTransition("REFUSE", "ACTIF")).toMatchObject({
+      allowed: false,
+      code: "TRANSITION_INTERDITE",
+    });
+  });
+
+  it("hache le plan et détecte l'absence de changement", () => {
+    const a = planningPayload();
+    const b = planningPayload();
+    expect(hashPlanningPayload(a)).toBe(hashPlanningPayload(b));
+    expect(comparePlanningVersions(a, b).identical).toBe(true);
+  });
+
+  it("compare opérations, dates, machines, durées, charge et quantité", () => {
+    const before = planningPayload();
+    const after = planningPayload({
+      quantite: 45,
+      chargeTotaleH: 80,
+      dateFin: "2026-06-25",
+      operations: [
+        {
+          phase: 30,
+          designation: "FRAISAGE CN",
+          family: "F",
+          machineId: "m-2",
+          machineLabel: "VMC-2",
+          debut: "2026-06-01",
+          fin: "2026-06-03",
+          dureeH: 6,
+          quantite: 45,
+        },
+        {
+          phase: 40,
+          designation: "EBAVURAGE",
+          family: null,
+          machineId: null,
+          machineLabel: null,
+          debut: "2026-06-04",
+          fin: "2026-06-04",
+          dureeH: 1,
+          quantite: 45,
+        },
+      ],
+    });
+
+    const comparison = comparePlanningVersions(before, after);
+    expect(comparison.header.map((c) => c.field)).toEqual(
+      expect.arrayContaining(["quantite", "dateFin", "chargeTotaleH"])
+    );
+    expect(comparison.summary.operationsAjoutees).toBe(1);
+    expect(comparison.summary.machinesChangees).toBe(1);
+    expect(comparison.summary.deltaChargeH).toBe(9);
+    expect(comparison.summary.deltaFinJours).toBe(5);
+  });
+
+  it("ne voit aucun impact client quand le délai et la cadence tiennent", () => {
+    const before = planningPayload();
+    // L'OF glisse en interne mais livre toujours le 01/07.
+    const after = planningPayload({ dateFin: "2026-06-25", chargeTotaleH: 75 });
+
+    const comparison = comparePlanningVersions(before, after);
+    expect(comparison.clientImpact).toBe("AUCUN");
+    expect(comparison.summary.engagementsDepasses).toBe(0);
+    expect(requiresArRecalage(comparison)).toBe(false);
+  });
+
+  it("détecte le dépassement d'un engagement client", () => {
+    const before = planningPayload();
+    const after = planningPayload({
+      dateFin: "2026-07-20",
+      cadence: [{ date: "2026-07-20", quantite: 40, affaireId: 23149 }],
+    });
+
+    const comparison = comparePlanningVersions(before, after);
+    expect(comparison.engagements[0]).toMatchObject({
+      depasse: true,
+      retardJours: 19,
+      delaiClient: "2026-07-01",
+      nouvelleDate: "2026-07-20",
+    });
+    expect(comparison.clientImpact).toBe("DELAI_ET_CADENCE");
+    expect(requiresArRecalage(comparison)).toBe(true);
+  });
+
+  it("distingue deux affaires livrant le même jour", () => {
+    const before = planningPayload({
+      cadence: [
+        { date: "2026-07-01", quantite: 40, affaireId: 23149 },
+        { date: "2026-07-01", quantite: 25, affaireId: 23150 },
+      ],
+    });
+    const after = planningPayload({
+      cadence: [
+        { date: "2026-07-01", quantite: 40, affaireId: 23149 },
+        { date: "2026-07-01", quantite: 30, affaireId: 23150 },
+      ],
+    });
+
+    const comparison = comparePlanningVersions(before, after);
+    expect(comparison.cadence).toHaveLength(1);
+    expect(comparison.cadence[0]).toMatchObject({
+      affaireId: 23150,
+      quantiteAvant: 25,
+      quantiteApres: 30,
+    });
+  });
+
+  it("compte les jours d'écart entre deux dates", () => {
+    expect(diffDays("2026-07-01", "2026-07-20")).toBe(19);
+    expect(diffDays("2026-07-20", "2026-07-01")).toBe(-19);
+    expect(diffDays(null, "2026-07-01")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Partie D — AR à recaler
+// ---------------------------------------------------------------------------
+
+describe("#374 D — dossier d'AR client à recaler", () => {
+  it("publie sans AR quand rien ne touche le client", () => {
+    const comparison = comparePlanningVersions(planningPayload(), planningPayload({ chargeTotaleH: 75 }));
+    const decision = decideArRecalage(comparison);
+    expect(decision.required).toBe(false);
+    expect(
+      buildArRecalageDossiers({
+        comparison,
+        ofId: 1,
+        ofNumero: "OF-2026-23149",
+        planningVersionId: null,
+        motif: "CAPACITE",
+        commentaire: null,
+        ownerUserId: null,
+      })
+    ).toEqual([]);
+  });
+
+  it("ouvre un dossier par affaire touchée, sans rien envoyer", () => {
+    const comparison = comparePlanningVersions(
+      planningPayload(),
+      planningPayload({
+        dateFin: "2026-07-20",
+        cadence: [{ date: "2026-07-20", quantite: 40, affaireId: 23149 }],
+      })
+    );
+
+    const dossiers = buildArRecalageDossiers({
+      comparison,
+      ofId: 1,
+      ofNumero: "OF-2026-23149",
+      planningVersionId: "plan-2",
+      motif: "DERIVE_TEMPS_USINAGE",
+      commentaire: null,
+      ownerUserId: 12,
+      clientNomByClientId: { "003": "AIRBUS HELICOPTERS" },
+      commandeNumeroById: { 900: "CF00042720 1" },
+      quantiteByAffaire: { 23149: 40 },
+    });
+
+    expect(dossiers).toHaveLength(1);
+    expect(dossiers[0]).toMatchObject({
+      clientId: "003",
+      clientNom: "AIRBUS HELICOPTERS",
+      commandeNumero: "CF00042720 1",
+      affaireId: 23149,
+      ofNumero: "OF-2026-23149",
+      previousDate: "2026-07-01",
+      newDate: "2026-07-20",
+      quantite: 40,
+      motif: "DERIVE_TEMPS_USINAGE",
+      statut: "A_TRAITER",
+      ownerUserId: 12,
+    });
+
+    // Le dossier ne porte aucun destinataire, aucun corps de message, aucun envoi :
+    // sa forme même interdit de le confondre avec un AR sortant.
+    expect(Object.keys(dossiers[0])).not.toEqual(
+      expect.arrayContaining(["recipientEmails", "sentAt", "bodyText", "subject"])
+    );
+  });
+
+  it("impose un commentaire au motif « Autre »", () => {
+    expect(validateArRecalageInput({ motif: "AUTRE", commentaire: "  " })).toMatchObject({
+      valid: false,
+      code: "COMMENTAIRE_REQUIS",
+    });
+    expect(validateArRecalageInput({ motif: "AUTRE", commentaire: "Report demandé par le client" })).toEqual({
+      valid: true,
+    });
+    expect(validateArRecalageInput({ motif: "MACHINE", commentaire: null })).toEqual({ valid: true });
+    expect(validateArRecalageInput({ motif: "INCONNU", commentaire: null })).toMatchObject({
+      valid: false,
+      code: "MOTIF_INVALIDE",
+    });
+  });
+
+  it("accepte les neuf motifs prédéfinis", () => {
+    for (const motif of [
+      "DERIVE_TEMPS_USINAGE", "MACHINE", "MATIERE", "QUALITE_REPRISE", "SOUS_TRAITANCE",
+      "MODIFICATION_TECHNIQUE", "CAPACITE", "PRIORITE",
+    ]) {
+      expect(validateArRecalageInput({ motif, commentaire: null })).toEqual({ valid: true });
+    }
+  });
+
+  it("ferme le cycle du dossier sans réouverture après clôture", () => {
+    expect(canTransitionArStatut("A_TRAITER", "EN_COURS")).toBe(true);
+    expect(canTransitionArStatut("EN_COURS", "RECALE")).toBe(true);
+    expect(canTransitionArStatut("RECALE", "EN_COURS")).toBe(false);
+    expect(canTransitionArStatut("ABANDONNE", "A_TRAITER")).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Routage de notification et RBAC
+// ---------------------------------------------------------------------------
+
+describe("#374 — routage de notification", () => {
+  const rules = [
+    { topic: NOTIFICATION_TOPICS.OF_TIME_VARIANCE, roleKey: "Planning", userId: null, isActive: true },
+    { topic: NOTIFICATION_TOPICS.OF_TIME_VARIANCE, roleKey: "Planification", userId: null, isActive: true },
+    { topic: NOTIFICATION_TOPICS.AR_RECALAGE, roleKey: "Commerce", userId: null, isActive: true },
+    { topic: NOTIFICATION_TOPICS.AR_RECALAGE, roleKey: "Assistante polyvalente", userId: null, isActive: false },
+  ];
+
+  const candidates = [
+    { userId: 1, roles: ["Planification"] },
+    { userId: 2, roles: ["Commerce", "Secretaire"] },
+    { userId: 3, roles: ["Opérateur atelier"] },
+    { userId: 4, roles: ["Assistante polyvalente"] },
+  ];
+
+  it("route la dérive de temps vers les porteurs du rôle planificateur", () => {
+    expect(
+      resolveNotificationRecipients({
+        topic: NOTIFICATION_TOPICS.OF_TIME_VARIANCE,
+        rules,
+        candidates,
+      })
+    ).toEqual([1]);
+  });
+
+  it("route l'AR à recaler par le rôle, sans nommer personne dans le code", () => {
+    expect(
+      resolveNotificationRecipients({ topic: NOTIFICATION_TOPICS.AR_RECALAGE, rules, candidates })
+    ).toEqual([2]);
+
+    // Une règle désactivée ne route plus : c'est de la configuration, pas du code.
+    expect(
+      resolveNotificationRecipients({
+        topic: NOTIFICATION_TOPICS.AR_RECALAGE,
+        rules: rules.map((r) => (r.roleKey === "Assistante polyvalente" ? { ...r, isActive: true } : r)),
+        candidates,
+      })
+    ).toEqual([2, 4]);
+  });
+
+  it("accepte une identité désignée et la dédoublonne avec son rôle", () => {
+    const withIdentity = [
+      ...rules,
+      { topic: NOTIFICATION_TOPICS.AR_RECALAGE, roleKey: null, userId: 2, isActive: true },
+      { topic: NOTIFICATION_TOPICS.AR_RECALAGE, roleKey: null, userId: 9, isActive: true },
+    ];
+    expect(
+      resolveNotificationRecipients({
+        topic: NOTIFICATION_TOPICS.AR_RECALAGE,
+        rules: withIdentity,
+        candidates,
+      })
+    ).toEqual([2, 9]);
+  });
+
+  it("compare les rôles sans se laisser arrêter par un accent ou une casse", () => {
+    expect(
+      resolveNotificationRecipients({
+        topic: "X",
+        rules: [{ topic: "X", roleKey: "Responsable Qualité", userId: null, isActive: true }],
+        candidates: [{ userId: 5, roles: ["responsable qualite"] }],
+      })
+    ).toEqual([5]);
+  });
+
+  it("ne route vers personne quand aucune règle n'existe", () => {
+    expect(resolveNotificationRecipients({ topic: "INCONNU", rules, candidates })).toEqual([]);
+  });
+
+  it("produit une clé de déduplication stable", () => {
+    const key = notificationDedupeKey(NOTIFICATION_TOPICS.AR_RECALAGE, 1, "rev-1", null);
+    expect(key).toBe("AR_RECALAGE:1:rev-1:");
+    expect(notificationDedupeKey(NOTIFICATION_TOPICS.AR_RECALAGE, 1, "rev-1", null)).toBe(key);
+  });
+});
+
+describe("#374 — RBAC", () => {
+  it("réserve la révision aux méthodes et à la programmation", () => {
+    expect(roleHasOfCapability("Responsable Programmation", "revise")).toBe(true);
+    expect(roleHasOfCapability("Études-Méthodes", "revise")).toBe(true);
+    expect(roleHasOfCapability("Opérateur atelier", "revise")).toBe(false);
+  });
+
+  it("laisse l'atelier viser mais pas valider un planning", () => {
+    expect(roleHasOfCapability("Opérateur atelier", "visa")).toBe(true);
+    expect(roleHasOfCapability("Opérateur atelier", "plan_validate")).toBe(false);
+    expect(roleHasOfCapability("Planification", "plan_validate")).toBe(true);
+  });
+
+  it("réserve le recalage d'AR au commerce et à l'assistance", () => {
+    expect(roleHasOfCapability("Commercial", "ar_recalage")).toBe(true);
+    // « Assistante polyvalente » ARRIVE ICI sous son alias « Secretaire ».
+    expect(roleHasOfCapability("Secretaire", "ar_recalage")).toBe(true);
+    expect(roleHasOfCapability("Opérateur atelier", "ar_recalage")).toBe(false);
+    // « Fraisage » s'alias en « Opérateur atelier » : refusé, comme attendu.
+    expect(roleHasOfCapability("Opérateur atelier", "ar_recalage")).toBe(false);
+  });
+
+  /**
+   * L'entrée de `roleHasOfCapability` est le rôle EFFECTIF, pas l'intitulé
+   * d'organigramme.
+   *
+   * Ces deux tests visaient juste, mais avec le mauvais vocabulaire : ils
+   * passaient « Planning » et « Assistante polyvalente », que cette fonction ne
+   * reçoit JAMAIS en production. `authorizationRole()` les traduit d'abord en
+   * « Planification » et « Secretaire ». Ils ne réussissaient que grâce à deux
+   * needles — « plann » et « assistant » — qui ne correspondaient à aucun alias
+   * réel : une couverture illusoire, verte sur une entrée impossible.
+   *
+   * Les needles mortes sont retirées, et ce test fixe le contrat réel.
+   */
+  it("reçoit des rôles EFFECTIFS, jamais des intitulés d'organigramme", () => {
+    // Ce que produit réellement la connexion pour un compte multi-rôles.
+    const effectifPlanning = authorizationRole("Employee", ["Planning"]);
+    expect(effectifPlanning).toContain("Planification");
+    expect(roleHasOfCapability(effectifPlanning, "plan_validate")).toBe(true);
+
+    const effectifAssistante = authorizationRole("Employee", ["Assistante polyvalente"]);
+    expect(effectifAssistante).toContain("Secretaire");
+    expect(roleHasOfCapability(effectifAssistante, "ar_recalage")).toBe(true);
+
+    // Un compte cumulant atelier et planification hérite des deux capacités :
+    // la chaîne d'alias est jointe par « | » et testée d'un bloc.
+    const effectifCumul = authorizationRole("Employee", ["Responsable Atelier-Production", "Planning"]);
+    expect(roleHasOfCapability(effectifCumul, "visa")).toBe(true);
+    expect(roleHasOfCapability(effectifCumul, "plan_validate")).toBe(true);
+
+    // Le fraisage seul reste hors du recalage d'AR.
+    const effectifFraisage = authorizationRole("Employee", ["Fraisage"]);
+    expect(roleHasOfCapability(effectifFraisage, "ar_recalage")).toBe(false);
+  });
+
+  it("refuse par défaut un rôle vide ou inconnu", () => {
+    expect(roleHasOfCapability(null, "revise")).toBe(false);
+    expect(roleHasOfCapability("", "document")).toBe(false);
+    expect(roleHasOfCapability("Stagiaire", "plan_validate")).toBe(false);
+  });
+});

--- a/src/__tests__/of-versioning-370.routes.test.ts
+++ b/src/__tests__/of-versioning-370.routes.test.ts
@@ -1,0 +1,209 @@
+// Les routes #370 existent-elles RÉELLEMENT ?
+//
+// Ce fichier ne teste pas de la logique métier : il vérifie que la surface HTTP
+// est montée dans l'application, qu'elle refuse par défaut, et que les gardes
+// s'appliquent dans le bon ordre. Une route seulement référencée par le frontend
+// répondrait 404 — c'est précisément ce que ces tests attrapent.
+
+import express from "express";
+import request from "supertest";
+import { describe, expect, it, vi } from "vitest";
+
+// Le module de base de données est remplacé : ces tests n'ouvrent aucune
+// connexion. Ils vérifient le routage et l'autorisation, pas le SQL.
+vi.mock("../config/database", () => ({
+  default: { query: vi.fn(async () => ({ rows: [], rowCount: 0 })), connect: vi.fn() },
+}));
+
+const ROLE_HEADER = "x-test-role";
+
+// L'authentification est simulée : le rôle EFFECTIF est injecté par en-tête, tel
+// que `authorizationRole()` le produirait à la connexion (chaîne « A | B »).
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (req: express.Request, res: express.Response, next: express.NextFunction) => {
+    const role = req.headers[ROLE_HEADER];
+    if (typeof role !== "string") {
+      res.status(401).json({ error: "Token manquant ou invalide" });
+      return;
+    }
+    req.user = { id: 42, username: "testeur", email: "t@example.test", role };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+async function buildApp() {
+  const routes = (await import("../module/production/routes/of-versioning.routes")).default;
+  const app = express();
+  app.use(express.json());
+  app.use("/api/v1/production/of-versioning", routes);
+  // Traduction des HttpError en réponse, comme le fait le gestionnaire global.
+  app.use((err: any, _req: express.Request, res: express.Response, _next: express.NextFunction) => {
+    res.status(err?.status ?? 500).json({ code: err?.code ?? "ERROR", message: err?.message });
+  });
+  return app;
+}
+
+const BASE = "/api/v1/production/of-versioning";
+
+/** Rôles effectifs réels, tels qu'ils sortent des alias d'organigramme. */
+const PLANIFICATION = "Planification";
+const ATELIER = "Production | Atelier";
+const OPERATEUR = "Opérateur atelier";
+const COMMERCIAL = "Commercial";
+
+describe("#370 — la surface HTTP est réellement montée", () => {
+  it("expose /capabilities pour un compte authentifié", async () => {
+    const app = await buildApp();
+    const res = await request(app).get(`${BASE}/capabilities`).set(ROLE_HEADER, ATELIER);
+    expect(res.status).toBe(200);
+    expect(res.body.capabilities).toMatchObject({ read: true, visa: true });
+  });
+
+  it("refuse tout accès sans authentification (401, jamais 404)", async () => {
+    const app = await buildApp();
+    // Un 404 ici signifierait que la route n'existe pas ; un 401 prouve qu'elle
+    // existe ET qu'elle est gardée.
+    for (const path of [
+      `${BASE}/1/revisions`,
+      `${BASE}/1/planning-versions`,
+      `${BASE}/1/document/preview`,
+      `${BASE}/ar-dossiers`,
+    ]) {
+      const res = await request(app).get(path);
+      expect(res.status, `GET ${path}`).toBe(401);
+    }
+  });
+
+  it("monte les 20 routes du chantier", async () => {
+    const routes = (await import("../module/production/routes/of-versioning.routes")).default;
+    const mounted = (routes as unknown as { stack: Array<{ route?: { path: string; methods: Record<string, boolean> } }> }).stack
+      .filter((layer) => layer.route)
+      .map((layer) => {
+        const method = Object.keys(layer.route!.methods)[0].toUpperCase();
+        return `${method} ${layer.route!.path}`;
+      });
+
+    expect(mounted).toEqual(
+      expect.arrayContaining([
+        "GET /capabilities",
+        "GET /machine-families",
+        "GET /ar-dossiers",
+        "PATCH /ar-dossiers/:dossierId",
+        "GET /:ofId/revisions",
+        "GET /:ofId/revisions/compare",
+        "GET /:ofId/revisions/:revisionId",
+        "POST /:ofId/revisions",
+        "POST /:ofId/revisions/:revisionId/visas",
+        "POST /:ofId/time-variance/assess",
+        "GET /:ofId/time-variance",
+        "POST /:ofId/time-variance",
+        "POST /:ofId/time-variance/:proposalId/resolve",
+        "GET /:ofId/planning-versions",
+        "POST /:ofId/planning-versions",
+        "POST /:ofId/planning-versions/:versionId/submit",
+        "POST /:ofId/planning-versions/:versionId/validate",
+        "POST /:ofId/planning-versions/:versionId/refuse",
+        "POST /:ofId/ar-dossiers",
+        "GET /:ofId/document/preview",
+        "GET /:ofId/document/preview.pdf",
+        "GET /:ofId/documents",
+        "POST /:ofId/documents",
+        "GET /:ofId/documents/:documentId/pdf",
+      ])
+    );
+  });
+
+  it("déclare /ar-dossiers avant /:ofId pour ne pas le capturer comme un identifiant", async () => {
+    const app = await buildApp();
+    // Si l'ordre était inversé, « ar-dossiers » serait parsé comme `ofId` et la
+    // validation renverrait 400. Un 200 prouve que la route littérale gagne.
+    const res = await request(app).get(`${BASE}/ar-dossiers`).set(ROLE_HEADER, COMMERCIAL);
+    expect(res.status).not.toBe(400);
+  });
+});
+
+describe("#370 — refus par défaut et capacités fines", () => {
+  it("refuse à un opérateur atelier la validation d'un planning (403)", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .post(`${BASE}/1/planning-versions/6b1f6f7e-0000-4000-8000-000000000000/validate`)
+      .set(ROLE_HEADER, OPERATEUR)
+      .send({});
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("OF_CAPABILITY_REQUIRED");
+  });
+
+  it("refuse à l'atelier la création d'une révision (403)", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .post(`${BASE}/1/revisions`)
+      .set(ROLE_HEADER, OPERATEUR)
+      .set("Idempotency-Key", "abcdefgh-0001")
+      .send({ motif: "essai" });
+    expect(res.status).toBe(403);
+  });
+
+  it("refuse à la planification le recalage d'un AR (403) — acte commercial", async () => {
+    const app = await buildApp();
+    const res = await request(app).get(`${BASE}/ar-dossiers`).set(ROLE_HEADER, PLANIFICATION);
+    expect(res.status).toBe(403);
+  });
+
+  it("autorise la planification à valider un planning", async () => {
+    const app = await buildApp();
+    const res = await request(app)
+      .post(`${BASE}/1/planning-versions/6b1f6f7e-0000-4000-8000-000000000000/validate`)
+      .set(ROLE_HEADER, PLANIFICATION)
+      .send({});
+    // La garde passe ; l'échec vient ensuite de la base simulée, pas du RBAC.
+    expect(res.status).not.toBe(403);
+    expect(res.status).not.toBe(401);
+  });
+});
+
+describe("#370 — la clé d'idempotence est exigée sur les commandes à effet", () => {
+  const COMMANDS: Array<[string, string, string]> = [
+    ["post", `${BASE}/1/revisions`, PLANIFICATION],
+    ["post", `${BASE}/1/revisions/6b1f6f7e-0000-4000-8000-000000000000/visas`, ATELIER],
+    ["post", `${BASE}/1/time-variance`, PLANIFICATION],
+    ["post", `${BASE}/1/planning-versions`, PLANIFICATION],
+    ["post", `${BASE}/1/ar-dossiers`, COMMERCIAL],
+    ["post", `${BASE}/1/documents`, PLANIFICATION],
+  ];
+
+  it.each(COMMANDS)("%s %s exige Idempotency-Key", async (_method, path, role) => {
+    const app = await buildApp();
+    const res = await request(app).post(path).set(ROLE_HEADER, role).send({});
+    expect(res.status).toBe(400);
+    expect(res.body.code).toBe("IDEMPOTENCY_KEY_REQUIRED");
+  });
+
+  it("n'exige AUCUNE clé sur les lectures et les aperçus", async () => {
+    const app = await buildApp();
+    // L'évaluation de dérive écrit rien : exiger une clé serait une fausse
+    // contrainte, et l'UI ne pourrait pas afficher le verdict du seuil en direct.
+    const res = await request(app)
+      .post(`${BASE}/1/time-variance/assess`)
+      .set(ROLE_HEADER, PLANIFICATION)
+      .send({ phase: 10, newTime: 1 });
+    expect(res.status).not.toBe(400);
+  });
+});
+
+describe("#370 — la surface est bien greffée sur le routeur v1", () => {
+  it("est montée sous /production/of-versioning dans v1.routes", async () => {
+    // Lecture du fichier de montage : c'est le seul point où une surface peut
+    // exister en tant que routeur sans être atteignable par l'API.
+    const fs = await import("node:fs/promises");
+    const source = await fs.readFile("src/routes/v1.routes.ts", "utf8");
+    expect(source).toContain('from "../module/production/routes/of-versioning.routes"');
+    expect(source).toContain('router.use("/production/of-versioning", ofVersioningRoutes)');
+
+    // …et AVANT le routeur historique, sinon `/production/:id` l'absorberait.
+    const specific = source.indexOf('router.use("/production/of-versioning"');
+    const legacy = source.indexOf('router.use("/production", productionRoutes)');
+    expect(specific).toBeGreaterThan(-1);
+    expect(legacy).toBeGreaterThan(specific);
+  });
+});

--- a/src/module/planning/repository/planning.repository.ts
+++ b/src/module/planning/repository/planning.repository.ts
@@ -742,7 +742,24 @@ async function maybePromoteOfAndCommandeAfterPlanning(params: {
             )
         ) AS active_events
       FROM public.ordres_fabrication o
-      LEFT JOIN public.of_operations op ON op.of_id = o.id
+      -- Opérations de la révision APPLICABLE uniquement (#370).
+      --
+      -- Depuis le versioning d'OF, un OF peut porter plusieurs jeux d'opérations :
+      -- un par révision. Joindre sur le seul of_id compterait R00 ET R01, et
+      -- l'avancement afficherait « 6 phases sur 12 » sur un OF qui n'en a que 6.
+      -- Le repli sur revision_id IS NULL couvre les lignes historiques que le
+      -- backfill n'aurait pas rattachées.
+      -- (Pas de guillemet oblique dans ce commentaire : le SQL vit dans un
+      --  gabarit JavaScript, un backtick y terminerait la chaîne.)
+      LEFT JOIN public.of_operations op
+             ON op.of_id = o.id
+            AND (
+              op.revision_id IS NULL
+              OR op.revision_id = (
+                SELECT r.id FROM public.of_revisions r
+                 WHERE r.of_id = o.id AND r.statut = 'ACTIVE'
+              )
+            )
       WHERE o.id = $1::bigint
       GROUP BY o.id, o.statut, o.commande_id, o.numero
       LIMIT 1

--- a/src/module/production/controllers/of-versioning.controller.ts
+++ b/src/module/production/controllers/of-versioning.controller.ts
@@ -1,0 +1,352 @@
+// Contrôleurs HTTP du chantier #370.
+//
+// Volontairement minces : ils valident la forme, construisent l'acteur et le
+// contexte d'audit, appellent le service, et rendent la réponse. Aucune règle
+// métier ici — elle serait alors dupliquée entre l'HTTP et le domaine, et les
+// deux finiraient par diverger.
+
+import type { Request, Response } from "express";
+
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { HttpError } from "../../../utils/httpError";
+import { buildAuditContext } from "../../project-office/controllers/project-office.controller";
+import { readMachineFamilies } from "../repository/of-versioning.repository";
+import { roleHasOfCapability, type OfCapability } from "../domain/of-rbac";
+import * as service from "../services/of-versioning.service";
+import { idempotencyKeyOf } from "../middlewares/of-versioning-authorization.middleware";
+import {
+  assessVarianceSchema,
+  compareRevisionsQuery,
+  createArDossierSchema,
+  createPlanningDraftSchema,
+  createProposalSchema,
+  createRevisionSchema,
+  createVisaSchema,
+  documentIdParam,
+  emitDocumentSchema,
+  listArQuery,
+  ofIdParam,
+  planningDecisionSchema,
+  planningIdParam,
+  previewDocumentQuery,
+  resolveProposalSchema,
+  revisionIdParam,
+  updateArDossierSchema,
+} from "../validators/of-versioning.validators";
+
+function actorOf(req: Request): service.OfActor {
+  const user = req.user;
+  if (!user || typeof user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  return {
+    userId: user.id,
+    username: typeof user.username === "string" ? user.username : `#${user.id}`,
+    role: typeof user.role === "string" ? user.role : null,
+  };
+}
+
+/**
+ * Horodatage d'émission, lu UNE fois par requête.
+ *
+ * Il entre dans le payload figé et dans les métadonnées du PDF. Le lire une seule
+ * fois est ce qui rend le rendu reproductible : deux lectures d'horloge dans la
+ * même émission produiraient deux binaires différents.
+ */
+function requestNowIso(): string {
+  return new Date().toISOString();
+}
+
+/* ------------------------------- Capacités -------------------------------- */
+
+// L'UI s'en sert pour n'AFFICHER que ce qui est permis. Le backend revérifie
+// systématiquement : cette route ne remplace aucune garde.
+export const capabilities = asyncHandler(async (req: Request, res: Response) => {
+  const role = typeof req.user?.role === "string" ? req.user.role : null;
+  const keys: OfCapability[] = [
+    "read",
+    "revise",
+    "visa",
+    "plan_draft",
+    "plan_validate",
+    "ar_recalage",
+    "document",
+  ];
+  const result: Record<string, boolean> = {};
+  for (const key of keys) result[key] = roleHasOfCapability(role, key);
+  res.json({ capabilities: result });
+});
+
+export const listMachineFamilies = asyncHandler(async (_req: Request, res: Response) => {
+  res.json({ familles: await readMachineFamilies() });
+});
+
+/* ------------------------------- Révisions -------------------------------- */
+
+export const listRevisions = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  res.json(await service.listRevisions(ofId));
+});
+
+export const getRevision = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId, revisionId } = revisionIdParam.parse(req.params);
+  res.json(await service.getRevisionDetail(ofId, revisionId));
+});
+
+export const createRevision = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  const body = createRevisionSchema.parse(req.body);
+  const familles = await readMachineFamilies();
+  const result = await service.createRevision(
+    ofId,
+    { motif: body.motif ?? null, operations: body.operations },
+    actorOf(req),
+    buildAuditContext(req),
+    familles
+  );
+  res.status(201).json(result);
+});
+
+export const compareRevisions = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  const { from, to } = compareRevisionsQuery.parse(req.query);
+  res.json(await service.compareRevisions(ofId, from, to));
+});
+
+/* --------------------------------- VISA ----------------------------------- */
+
+export const createVisa = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId, revisionId } = revisionIdParam.parse(req.params);
+  const body = createVisaSchema.parse(req.body);
+  const result = await service.createVisa(
+    ofId,
+    revisionId,
+    {
+      phase: body.phase,
+      statut: body.statut,
+      initials: body.initials,
+      quantiteBonne: body.quantiteBonne ?? null,
+      quantiteRebut: body.quantiteRebut ?? null,
+      motifRebut: body.motifRebut ?? null,
+      controleInitials: body.controleInitials ?? null,
+      comment: body.comment ?? null,
+    },
+    actorOf(req),
+    buildAuditContext(req)
+  );
+  res.status(201).json(result);
+});
+
+/* --------------------------- Dérive de temps ------------------------------ */
+
+// Évaluation en LECTURE SEULE : aucune écriture, donc aucune clé d'idempotence.
+export const assessVariance = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  const body = assessVarianceSchema.parse(req.body);
+  res.json(await service.assessVariance(ofId, body));
+});
+
+export const createProposal = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  const body = createProposalSchema.parse(req.body);
+  const result = await service.createProposal(
+    ofId,
+    { phase: body.phase, newTime: body.newTime, cause: body.cause, causeComment: body.causeComment ?? null },
+    actorOf(req),
+    buildAuditContext(req),
+    idempotencyKeyOf(req)
+  );
+  // 200 et non 201 quand la dérive est dans la tolérance : rien n'a été créé, et
+  // répondre 201 laisserait croire à une proposition inexistante.
+  res.status(result.proposal ? 201 : 200).json(result);
+});
+
+export const listProposals = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  res.json({ proposals: await service.listProposals(ofId) });
+});
+
+export const resolveProposal = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  const proposalId = String(req.params.proposalId ?? "");
+  const body = resolveProposalSchema.parse(req.body);
+  res.json(
+    await service.resolveProposal(
+      ofId,
+      proposalId,
+      { statut: body.statut, comment: body.comment ?? null },
+      actorOf(req),
+      buildAuditContext(req)
+    )
+  );
+});
+
+/* ----------------------------- Planning ----------------------------------- */
+
+export const listPlanningVersions = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  res.json(await service.listPlanningVersions(ofId));
+});
+
+export const createPlanningDraft = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  const body = createPlanningDraftSchema.parse(req.body);
+  const result = await service.createPlanningDraft(
+    ofId,
+    {
+      payload: body.payload as never,
+      sourceProposalId: body.sourceProposalId ?? null,
+    },
+    actorOf(req),
+    buildAuditContext(req),
+    idempotencyKeyOf(req)
+  );
+  res.status(201).json(result);
+});
+
+function planningTransition(next: "SOUMIS" | "VALIDE" | "REFUSE") {
+  return asyncHandler(async (req: Request, res: Response) => {
+    const { ofId, versionId } = planningIdParam.parse(req.params);
+    const body = planningDecisionSchema.parse(req.body ?? {});
+    res.json(
+      await service.transitionPlanning(
+        ofId,
+        versionId,
+        next,
+        { comment: body.comment ?? null },
+        actorOf(req),
+        buildAuditContext(req)
+      )
+    );
+  });
+}
+
+export const submitPlanning = planningTransition("SOUMIS");
+export const validatePlanning = planningTransition("VALIDE");
+export const refusePlanning = planningTransition("REFUSE");
+
+/* ------------------------------- AR client -------------------------------- */
+
+export const listArDossiers = asyncHandler(async (req: Request, res: Response) => {
+  const query = listArQuery.parse(req.query);
+  res.json({ dossiers: await service.listArDossiers(query) });
+});
+
+export const createArDossier = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  const body = createArDossierSchema.parse(req.body);
+  const result = await service.createArDossier(
+    ofId,
+    {
+      affaireId: body.affaireId ?? null,
+      previousDate: body.previousDate ?? null,
+      newDate: body.newDate ?? null,
+      previousCadence: body.previousCadence ?? null,
+      newCadence: body.newCadence ?? null,
+      quantite: body.quantite ?? null,
+      motif: body.motif,
+      commentaire: body.commentaire ?? null,
+      ownerUserId: body.ownerUserId ?? null,
+    },
+    actorOf(req),
+    buildAuditContext(req),
+    idempotencyKeyOf(req)
+  );
+  res.status(201).json(result);
+});
+
+export const updateArDossier = asyncHandler(async (req: Request, res: Response) => {
+  const dossierId = String(req.params.dossierId ?? "");
+  const body = updateArDossierSchema.parse(req.body);
+  res.json(
+    await service.updateArDossier(
+      dossierId,
+      {
+        statut: body.statut,
+        ownerUserId: body.ownerUserId ?? null,
+        commentaire: body.commentaire ?? null,
+      },
+      actorOf(req),
+      buildAuditContext(req)
+    )
+  );
+});
+
+/* -------------------------------- Document -------------------------------- */
+
+/**
+ * Payload d'aperçu, en JSON.
+ *
+ * C'est le MÊME read-model que celui du PDF. L'écran affiche les libellés déjà
+ * calculés ici : il ne reformate rien, donc il ne peut pas divergier.
+ */
+export const previewPayload = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  const { revisionId } = previewDocumentQuery.parse(req.query);
+  const { payload } = await service.buildDocumentPayload(ofId, {
+    revisionId: revisionId ?? null,
+    documentStatut: "BROUILLON",
+    generatedAt: requestNowIso(),
+    auteur: actorOf(req).username,
+  });
+  res.json({ payload });
+});
+
+/** Aperçu PDF : rendu serveur, aucun effet de bord, jamais `window.print()`. */
+export const previewPdf = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  const { revisionId } = previewDocumentQuery.parse(req.query);
+  const result = await service.previewDocument(
+    ofId,
+    revisionId ?? null,
+    actorOf(req),
+    requestNowIso()
+  );
+  res.setHeader("Content-Type", "application/pdf");
+  res.setHeader("Content-Length", String(result.byteSize));
+  res.setHeader("X-Document-Sha256", result.sha256);
+  res.setHeader("X-Snapshot-Sha256", result.payload.snapshotSha256);
+  res.setHeader(
+    "Content-Disposition",
+    `inline; filename="apercu-OF-${result.payload.ofNumero}-${result.payload.revisionCode}.pdf"`
+  );
+  res.end(result.buffer);
+});
+
+export const listDocuments = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  res.json({ documents: await service.listDocuments(ofId) });
+});
+
+export const emitDocument = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId } = ofIdParam.parse(req.params);
+  const body = emitDocumentSchema.parse(req.body ?? {});
+  const result = await service.emitDocument(
+    ofId,
+    {
+      revisionId: body.revisionId ?? null,
+      expectedSnapshotSha256: body.expectedSnapshotSha256 ?? null,
+    },
+    actorOf(req),
+    buildAuditContext(req),
+    idempotencyKeyOf(req),
+    requestNowIso()
+  );
+  res.status(result.replayed ? 200 : 201).json({
+    document: result.document,
+    replayed: result.replayed,
+    archive: "archive" in result ? result.archive : null,
+  });
+});
+
+/** Réimpression : restitue le binaire archivé. Ne crée aucune révision. */
+export const reprintDocument = asyncHandler(async (req: Request, res: Response) => {
+  const { ofId, documentId } = documentIdParam.parse(req.params);
+  const result = await service.reprintDocument(ofId, documentId, buildAuditContext(req));
+  res.setHeader("Content-Type", "application/pdf");
+  res.setHeader("Content-Length", String(result.pdf.byteLength));
+  res.setHeader("X-Document-Sha256", String(result.document.pdf_sha256));
+  res.setHeader("X-Reprint-Source", result.source);
+  res.setHeader("Content-Disposition", `inline; filename="OF-${documentId}.pdf"`);
+  res.end(result.pdf);
+});

--- a/src/module/production/domain/__fixtures__/of-document.fixture.ts
+++ b/src/module/production/domain/__fixtures__/of-document.fixture.ts
@@ -1,0 +1,168 @@
+// Jeu d'essai calqué sur une gamme de fabrication réelle de l'atelier :
+// OF de l'affaire 23 149, pièce 45 252 966 B « BOITIER T16E M2 SANS PIETAGE ».
+//
+// Les temps sont ceux du document papier. Ils servent de contrôle : la règle
+// `fabrication = temps_unitaire x quantité_base x coefficient` doit redonner
+// exactement les TF imprimés, et leur somme les totaux 12,00 / 59,00 / 71,00 h.
+
+import type { MachineFamilyRef, OfRevisionOperation } from "../of-revision";
+import type { OfDocumentBuildInput } from "../of-document";
+
+export const FIXTURE_QUANTITE_BASE = 40;
+
+/**
+ * Référentiel des familles machine, tel que `production_machine_families` le
+ * porte en base après la normalisation des gammes.
+ *
+ * `programmeRequis` n'est vrai que pour les familles CN : c'est ce qui rend
+ * légitime l'absence de n° de programme sur une découpe ou un emballage, et
+ * illégitime sur un fraisage CN.
+ */
+export const FIXTURE_FAMILLES: MachineFamilyRef[] = [
+  { code: "T", libelle: "Tournage CN", programmeRequis: true, ordreAffichage: 10, actif: true },
+  { code: "F", libelle: "Fraisage CN", programmeRequis: true, ordreAffichage: 20, actif: true },
+  { code: "TTRAD", libelle: "Tour conventionnel", programmeRequis: false, ordreAffichage: 30, actif: true },
+  { code: "FTRAD", libelle: "Fraisage conventionnel", programmeRequis: false, ordreAffichage: 40, actif: true },
+  { code: "DECOUPE", libelle: "Découpe", programmeRequis: false, ordreAffichage: 50, actif: true },
+];
+
+/** Valeurs de centre de frais communes, pour ne pas répéter cinq champs par ligne. */
+function cf(code: string | null, taux: number | null): Pick<
+  OfRevisionOperation,
+  "cfCode" | "cfRateId" | "tauxHoraire" | "tauxHoraireSource" | "tauxHoraireEffectiveAt"
+> {
+  return {
+    cfCode: code,
+    cfRateId: code ? `c0000000-0000-4000-8000-0000000000${code.length}0` : null,
+    tauxHoraire: taux,
+    tauxHoraireSource: code ? "CENTRE_FRAIS" : null,
+    tauxHoraireEffectiveAt: code ? "2026-01-01" : null,
+  };
+}
+
+/**
+ * Phases de la gamme réelle : découpe, 8 fraisages CN, gravure, emballage.
+ *
+ * La phase 20 porte désormais la famille `DECOUPE` : elle existe au référentiel
+ * depuis la normalisation des gammes. La laisser sans famille la ferait
+ * disparaître de la séquence machines alors que le débit est bien un passage.
+ * L'emballage, lui, reste sans famille — ce n'est pas un poste d'usinage.
+ */
+export const FIXTURE_OPERATIONS: OfRevisionOperation[] = [
+  { phase: 20, designation: "DECOUPE", family: "DECOUPE", machineId: null, machineLabel: "Scie", programme: null, tempsUnitaire: 0.08, preparation: 0, quantiteBase: FIXTURE_QUANTITE_BASE, coefficient: 1, ...cf("DEB", 42) },
+  { phase: 30, designation: "FRAISAGE CN", family: "F", machineId: null, machineLabel: "VMC-1", programme: "45-252-966-B-1", tempsUnitaire: 0.1, preparation: 0.5, quantiteBase: FIXTURE_QUANTITE_BASE, coefficient: 1, ...cf("FCN", 68) },
+  { phase: 40, designation: "FRAISAGE CN", family: "F", machineId: null, machineLabel: "VMC-1", programme: "45-252-966-B-2", tempsUnitaire: 0.2, preparation: 1, quantiteBase: FIXTURE_QUANTITE_BASE, coefficient: 1, ...cf("FCN", 68) },
+  { phase: 50, designation: "FRAISAGE CN", family: "F", machineId: null, machineLabel: "VMC-2", programme: "45-252-966-B-3", tempsUnitaire: 0.25, preparation: 1, quantiteBase: FIXTURE_QUANTITE_BASE, coefficient: 1, ...cf("FCN", 68) },
+  { phase: 60, designation: "FRAISAGE CN", family: "F", machineId: null, machineLabel: "VMC-2", programme: "45-252-966-B-4", tempsUnitaire: 0.17, preparation: 2, quantiteBase: FIXTURE_QUANTITE_BASE, coefficient: 1, ...cf("FCN", 68) },
+  { phase: 70, designation: "FRAISAGE CN", family: "F", machineId: null, machineLabel: "VMC-2", programme: "45-252-966-B-5", tempsUnitaire: 0.2, preparation: 2, quantiteBase: FIXTURE_QUANTITE_BASE, coefficient: 1, ...cf("FCN", 68) },
+  { phase: 80, designation: "FRAISAGE CN - GRAVURE", family: "F", machineId: null, machineLabel: "VM10", programme: "45252966-A-GRAV", tempsUnitaire: 0.035, preparation: 0.5, quantiteBase: FIXTURE_QUANTITE_BASE, coefficient: 1, ...cf("FCN", 68) },
+  { phase: 90, designation: "FRAISAGE CN", family: "F", machineId: null, machineLabel: "VMC-1", programme: "45-252-966-B-6", tempsUnitaire: 0.16, preparation: 2, quantiteBase: FIXTURE_QUANTITE_BASE, coefficient: 1, ...cf("FCN", 68) },
+  { phase: 100, designation: "FRAISAGE CN", family: "F", machineId: null, machineLabel: "VMC-1", programme: "45-252-966-B-7", tempsUnitaire: 0.1, preparation: 2, quantiteBase: FIXTURE_QUANTITE_BASE, coefficient: 1, ...cf("FCN", 68) },
+  { phase: 110, designation: "FRAISAGE CN", family: "F", machineId: null, machineLabel: "VMC-1", programme: "45-252-966-B-8", tempsUnitaire: 0.1, preparation: 1, quantiteBase: FIXTURE_QUANTITE_BASE, coefficient: 1, ...cf("FCN", 68) },
+  { phase: 120, designation: "EMBALLAGE EXPEDITION", family: null, machineId: null, machineLabel: null, programme: null, tempsUnitaire: 0.08, preparation: 0, quantiteBase: FIXTURE_QUANTITE_BASE, coefficient: 1, ...cf("EXP", 35) },
+];
+
+/** TF attendus du document papier, phase par phase. */
+export const FIXTURE_EXPECTED_TF: Record<number, number> = {
+  20: 3.2, 30: 4, 40: 8, 50: 10, 60: 6.8, 70: 8,
+  80: 1.4, 90: 6.4, 100: 4, 110: 4, 120: 3.2,
+};
+
+export const FIXTURE_EXPECTED_TOTAL_TP = 12;
+export const FIXTURE_EXPECTED_TOTAL_TF = 59;
+export const FIXTURE_EXPECTED_TOTAL = 71;
+
+/** VISA relevés sur le document papier. Toutes les phases n'en portent pas. */
+export const FIXTURE_VISAS: OfDocumentBuildInput["visas"] = {
+  30: { statut: "VISE", visaOperateur: "AG", operateur: "A. GARNIER", visaAt: "2026-04-24T08:00:00.000Z", quantiteBonne: 40, quantiteRebut: 0 },
+  40: { statut: "VISE", visaOperateur: "AG", operateur: "A. GARNIER", visaAt: "2026-04-24T09:00:00.000Z", quantiteBonne: 40, quantiteRebut: 0 },
+  50: { statut: "VISE", visaOperateur: "AG", operateur: "A. GARNIER", visaAt: "2026-04-24T10:00:00.000Z", quantiteBonne: 40, quantiteRebut: 0 },
+  60: { statut: "VISE", visaOperateur: "TB", operateur: "T. BERNARD", visaAt: "2026-04-25T08:00:00.000Z", quantiteBonne: 39, quantiteRebut: 1, motifRebut: "Cote hors tolérance" },
+  70: { statut: "VISE", visaOperateur: "TB", operateur: "T. BERNARD", visaAt: "2026-04-25T09:00:00.000Z", quantiteBonne: 39, quantiteRebut: 0 },
+  80: { statut: "VISE", visaOperateur: "AG", operateur: "A. GARNIER", visaAt: "2026-04-25T10:00:00.000Z", quantiteBonne: 39, quantiteRebut: 0 },
+  90: { statut: "VISE", visaOperateur: "TB", operateur: "T. BERNARD", visaAt: "2026-04-26T08:00:00.000Z", quantiteBonne: 39, quantiteRebut: 0 },
+  100: { statut: "VISE", visaOperateur: "TB", operateur: "T. BERNARD", visaAt: "2026-04-26T09:00:00.000Z", quantiteBonne: 39, quantiteRebut: 0 },
+  110: { statut: "VISE", visaOperateur: "TB", visaControle: "MC", operateur: "T. BERNARD", visaAt: "2026-04-26T10:00:00.000Z", quantiteBonne: 39, quantiteRebut: 0, commentaire: "Contrôle final OK" },
+};
+
+/**
+ * Séquence T -> F -> T : deux tournages séparés par un fraisage.
+ *
+ * Cas de contrôle du regroupement : les trois passages doivent rester distincts.
+ * Les regrouper en « 2 T -> 1 F » effacerait le retour en tournage, qui est
+ * précisément l'information que l'atelier lit sur cette ligne.
+ */
+export const FIXTURE_OPERATIONS_TFT: OfRevisionOperation[] = [
+  { phase: 10, designation: "TOURNAGE CN", family: "T", machineId: null, machineLabel: "TCN-1", programme: "P-T-1", tempsUnitaire: 0.1, preparation: 1, quantiteBase: 10, coefficient: 1, ...cf("TCN", 62) },
+  { phase: 20, designation: "FRAISAGE CN", family: "F", machineId: null, machineLabel: "VMC-1", programme: "P-F-1", tempsUnitaire: 0.2, preparation: 1, quantiteBase: 10, coefficient: 1, ...cf("FCN", 68) },
+  { phase: 30, designation: "REPRISE TOURNAGE", family: "T", machineId: null, machineLabel: "TCN-1", programme: "P-T-2", tempsUnitaire: 0.15, preparation: 1, quantiteBase: 10, coefficient: 1, ...cf("TCN", 62) },
+];
+
+export function buildFixtureInput(
+  overrides: Partial<OfDocumentBuildInput> = {}
+): OfDocumentBuildInput {
+  return {
+    ofNumero: "OF-2026-23149",
+    revisionCode: "R00",
+    revisionStatut: "ACTIVE",
+    ofStatut: "En cours",
+    snapshotId: "0f9b1c22-5f1a-4c6e-9d0a-6b7d2e3f4a51",
+    snapshotSha256: "a".repeat(64),
+    auteur: "Méthodes",
+    generatedAt: "2026-04-23T06:30:00.000Z",
+    watermark: null,
+
+    commandeNumero: "CF00042720 1",
+    clientCode: "003",
+    clientNom: "AIRBUS HELICOPTERS",
+    affaires: [
+      { affaireId: 23149, numero: "23 149", delaiClient: "2026-07-01", quantite: 40 },
+    ],
+    cadenceLivraison: [
+      { date: "2026-07-01", quantite: 40, affaireNumero: "23 149" },
+    ],
+    quantites: {
+      quantiteDemandee: 40,
+      quantiteLivree: 0,
+      stockReserve: 0,
+      couvertAutresOf: 0,
+      quantiteAffecteeCetOf: 40,
+    },
+    cadenceProduction: [{ date: "2026-06-20", quantite: 40, affaireNumero: "23 149" }],
+    derniereFabrication: { numero: "19689", date: "2024-03-26" },
+
+    pieceReference: "45 252 966 B",
+    pieceDesignation: "BOITIER T16E M2 SANS PIETAGE — SPEC 60 101 266-069 E",
+    pieceIndice: "B",
+    gammeCode: "GAMME-45252966",
+    gammeVersion: "1",
+    documentsAFournir: [
+      "BL certifié",
+      "CCPU matière",
+      "Certificat de traitement",
+      "Rapport de contrôle / PV",
+    ],
+    matiere: {
+      reference: "PL*6061*T651*1*25*12",
+      designation: "ALUMINIUM 6061/T651 1 X 25 EP 12",
+      nuance: "6061/T651",
+    },
+    decoupe: {
+      dimensions: "1 x 25 ep. 12",
+      longueurBrutMm: 57,
+      longueurUtileMm: 54,
+      traitDeScieMm: 3,
+      chuteMm: 0,
+      nombreBruts: 40,
+      piecesParBrut: 1,
+      masseTotaleKg: 0.91,
+      unite: "MM",
+      methodeCalcul: null,
+    },
+
+    operations: FIXTURE_OPERATIONS,
+    visas: FIXTURE_VISAS,
+    familles: FIXTURE_FAMILLES,
+    ...overrides,
+  };
+}

--- a/src/module/production/domain/ar-recalage.ts
+++ b/src/module/production/domain/ar-recalage.ts
@@ -1,0 +1,251 @@
+// Dossier d'AR client à recaler.
+//
+// Après validation d'un planning : sans impact client, on publie sans AR ; si un
+// délai ou une cadence accusés sont dépassés, on ouvre un dossier de recalage.
+//
+// Le dossier est **interne**. Rien ne part chez le client automatiquement : ni
+// e-mail, ni accusé de réception rectificatif. Reprendre contact avec un client
+// pour décaler un engagement est un acte commercial, pas un effet de bord d'un
+// calcul de planning.
+//
+// À ne pas confondre avec `commande_ar_log`, qui journalise l'AR **envoyé** à la
+// confirmation de commande.
+
+import type { OfClientImpact, OfPlanningComparison } from "./of-planning-version";
+
+export const AR_RECALAGE_MOTIFS = [
+  "DERIVE_TEMPS_USINAGE",
+  "MACHINE",
+  "MATIERE",
+  "QUALITE_REPRISE",
+  "SOUS_TRAITANCE",
+  "MODIFICATION_TECHNIQUE",
+  "CAPACITE",
+  "PRIORITE",
+  "AUTRE",
+] as const;
+export type ArRecalageMotif = (typeof AR_RECALAGE_MOTIFS)[number];
+
+export const AR_RECALAGE_MOTIF_LABELS: Record<ArRecalageMotif, string> = {
+  DERIVE_TEMPS_USINAGE: "Dérive temps d'usinage",
+  MACHINE: "Machine",
+  MATIERE: "Matière",
+  QUALITE_REPRISE: "Qualité / reprise",
+  SOUS_TRAITANCE: "Sous-traitance",
+  MODIFICATION_TECHNIQUE: "Modification technique",
+  CAPACITE: "Capacité",
+  PRIORITE: "Priorité",
+  AUTRE: "Autre",
+};
+
+export function isArRecalageMotif(value: unknown): value is ArRecalageMotif {
+  return typeof value === "string" && (AR_RECALAGE_MOTIFS as readonly string[]).includes(value);
+}
+
+export const AR_RECALAGE_STATUTS = ["A_TRAITER", "EN_COURS", "RECALE", "ABANDONNE"] as const;
+export type ArRecalageStatut = (typeof AR_RECALAGE_STATUTS)[number];
+
+export const AR_RECALAGE_STATUT_LABELS: Record<ArRecalageStatut, string> = {
+  A_TRAITER: "À traiter",
+  EN_COURS: "En cours",
+  RECALE: "Recalé",
+  ABANDONNE: "Abandonné",
+};
+
+export const AR_RECALAGE_TRANSITIONS: Record<ArRecalageStatut, readonly ArRecalageStatut[]> = {
+  A_TRAITER: ["EN_COURS", "ABANDONNE"],
+  EN_COURS: ["RECALE", "ABANDONNE", "A_TRAITER"],
+  RECALE: [],
+  ABANDONNE: [],
+};
+
+export function canTransitionArStatut(from: ArRecalageStatut, to: ArRecalageStatut): boolean {
+  if (from === to) return true;
+  return AR_RECALAGE_TRANSITIONS[from].includes(to);
+}
+
+export type ArCadence = Array<{ date: string; quantite: number }>;
+
+export type ArRecalageDossier = {
+  clientId: string | null;
+  clientNom: string | null;
+  commandeId: number | null;
+  commandeNumero: string | null;
+  affaireId: number | null;
+  affaireNumero: string | null;
+  ofId: number;
+  ofNumero: string;
+  planningVersionId: string | null;
+  previousDate: string | null;
+  previousCadence: ArCadence | null;
+  newDate: string | null;
+  newCadence: ArCadence | null;
+  quantite: number | null;
+  motif: ArRecalageMotif;
+  commentaire: string | null;
+  statut: ArRecalageStatut;
+  ownerUserId: number | null;
+};
+
+export type ArRecalageValidation =
+  | { valid: true }
+  | { valid: false; code: string; message: string };
+
+/**
+ * « Autre » impose un commentaire.
+ *
+ * Un motif fourre-tout sans explication rend le dossier illisible pour la personne
+ * qui devra appeler le client : elle saurait qu'il faut recaler, pas quoi dire.
+ */
+export function validateArRecalageInput(args: {
+  motif: unknown;
+  commentaire: string | null | undefined;
+}): ArRecalageValidation {
+  if (!isArRecalageMotif(args.motif)) {
+    return { valid: false, code: "MOTIF_INVALIDE", message: "Motif de recalage inconnu." };
+  }
+  const commentaire = (args.commentaire ?? "").trim();
+  if (args.motif === "AUTRE" && !commentaire) {
+    return {
+      valid: false,
+      code: "COMMENTAIRE_REQUIS",
+      message: "Le motif « Autre » exige un commentaire.",
+    };
+  }
+  return { valid: true };
+}
+
+/**
+ * Affaires de livraison réellement touchées : celles dont l'engagement est
+ * dépassé, plus celles dont une échéance de cadence a bougé.
+ *
+ * Une échéance de cadence sans affaire rattachée (`affaireId` nul) concerne tout
+ * l'OF : faute de pouvoir la cibler, elle touche chaque affaire livrée par cet OF.
+ */
+function affectedAffaireIds(comparison: OfPlanningComparison): Set<number> {
+  const touched = new Set<number>();
+  for (const engagement of comparison.engagements) {
+    if (engagement.depasse) touched.add(engagement.affaireId);
+  }
+  for (const echeance of comparison.cadence) {
+    if (echeance.affaireId !== null) {
+      touched.add(echeance.affaireId);
+    } else {
+      for (const engagement of comparison.engagements) touched.add(engagement.affaireId);
+    }
+  }
+  return touched;
+}
+
+export type ArRecalageDecision =
+  | { required: false; reason: string }
+  | { required: true; impact: OfClientImpact; reason: string; affaireIds: number[] };
+
+/**
+ * Décide, à partir de la comparaison de planning, s'il faut ouvrir un dossier.
+ *
+ * Sans impact client : on publie, et on n'ouvre rien. Ouvrir un dossier vide
+ * habituerait l'administration des ventes à les fermer sans les lire.
+ */
+export function decideArRecalage(comparison: OfPlanningComparison): ArRecalageDecision {
+  if (comparison.clientImpact === "AUCUN") {
+    return {
+      required: false,
+      reason: "Aucun engagement client dépassé et cadence inchangée : publication sans AR.",
+    };
+  }
+
+  const affaireIds = [...affectedAffaireIds(comparison)].sort((a, b) => a - b);
+
+  const parts: string[] = [];
+  if (comparison.summary.engagementsDepasses > 0) {
+    parts.push(
+      `${comparison.summary.engagementsDepasses} engagement(s) client dépassé(s)`
+    );
+  }
+  if (comparison.summary.cadenceModifiee) parts.push("cadence de livraison modifiée");
+
+  return {
+    required: true,
+    impact: comparison.clientImpact,
+    reason: `${parts.join(" et ")} : dossier d'AR à recaler.`,
+    affaireIds,
+  };
+}
+
+/**
+ * Construit les dossiers à ouvrir, un par affaire de livraison concernée.
+ *
+ * Un dossier par affaire et non un dossier global : chaque affaire porte son
+ * propre engagement, sa propre quantité et sera recalée séparément avec le client.
+ */
+export function buildArRecalageDossiers(args: {
+  comparison: OfPlanningComparison;
+  ofId: number;
+  ofNumero: string;
+  planningVersionId: string | null;
+  motif: ArRecalageMotif;
+  commentaire: string | null;
+  ownerUserId: number | null;
+  clientNomByClientId?: Record<string, string | null>;
+  commandeNumeroById?: Record<number, string | null>;
+  previousCadenceByAffaire?: Record<number, ArCadence | null>;
+  newCadenceByAffaire?: Record<number, ArCadence | null>;
+  quantiteByAffaire?: Record<number, number | null>;
+}): ArRecalageDossier[] {
+  const decision = decideArRecalage(args.comparison);
+  if (!decision.required) return [];
+
+  const validation = validateArRecalageInput({
+    motif: args.motif,
+    commentaire: args.commentaire,
+  });
+  if (!validation.valid) throw new Error(validation.message);
+
+  const touched = affectedAffaireIds(args.comparison);
+
+  return args.comparison.engagements
+    .filter((engagement) => touched.has(engagement.affaireId))
+    .map<ArRecalageDossier>((engagement) => ({
+      clientId: engagement.clientId,
+      clientNom: engagement.clientId
+        ? (args.clientNomByClientId?.[engagement.clientId] ?? null)
+        : null,
+      commandeId: engagement.commandeId,
+      commandeNumero: engagement.commandeId
+        ? (args.commandeNumeroById?.[engagement.commandeId] ?? null)
+        : null,
+      affaireId: engagement.affaireId,
+      affaireNumero: engagement.affaireNumero,
+      ofId: args.ofId,
+      ofNumero: args.ofNumero,
+      planningVersionId: args.planningVersionId,
+      previousDate: engagement.delaiClient,
+      previousCadence: args.previousCadenceByAffaire?.[engagement.affaireId] ?? null,
+      newDate: engagement.nouvelleDate,
+      newCadence: args.newCadenceByAffaire?.[engagement.affaireId] ?? null,
+      quantite: args.quantiteByAffaire?.[engagement.affaireId] ?? null,
+      motif: args.motif,
+      commentaire: (args.commentaire ?? "").trim() || null,
+      statut: "A_TRAITER",
+      ownerUserId: args.ownerUserId,
+    }))
+    .sort((a, b) => (a.affaireId ?? 0) - (b.affaireId ?? 0));
+}
+
+/** Résumé destiné à la notification interne. Jamais envoyé au client. */
+export function describeArRecalage(dossier: ArRecalageDossier): string {
+  const client = dossier.clientNom ?? dossier.clientId ?? "client non renseigné";
+  const commande = dossier.commandeNumero ? ` commande ${dossier.commandeNumero}` : "";
+  const affaire = dossier.affaireNumero ? ` affaire ${dossier.affaireNumero}` : "";
+  const dates =
+    dossier.previousDate && dossier.newDate
+      ? ` : ${formatDateFr(dossier.previousDate)} -> ${formatDateFr(dossier.newDate)}`
+      : "";
+  return `AR à recaler — ${client}${commande}${affaire}${dates} (${AR_RECALAGE_MOTIF_LABELS[dossier.motif]}).`;
+}
+
+function formatDateFr(iso: string): string {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+  return m ? `${m[3]}/${m[2]}/${m[1]}` : iso;
+}

--- a/src/module/production/domain/of-document.ts
+++ b/src/module/production/domain/of-document.ts
@@ -1,0 +1,679 @@
+// Read-model du document d'OF — « Gamme de fabrication ».
+//
+// Un seul payload alimente l'aperçu écran ET le PDF serveur. Il est figé dans
+// `of_documents` : une réimpression rejoue l'instantané et reproduit le même
+// binaire, donc la même empreinte. Ce module ne lit aucune base et n'appelle
+// aucune horloge — il transforme une entrée en payload, de façon déterministe.
+//
+// Structure du document, calquée sur la gamme papier de l'atelier :
+//   - page 1, moitié haute : couverture commerciale (commande, affaires de
+//     livraison, cadence, quantités) ;
+//   - page 1, moitié basse : pièce, gamme, matière, débit, séquence machines ;
+//   - pages suivantes : la gamme phase par phase, avec TP, TF et VISA.
+
+import {
+  familyLabel,
+  hashSnapshot,
+  phaseFabricationTime,
+  phaseFinalTime,
+  type MachineFamilyRef,
+  type OfPhaseFamily,
+  type OfRevisionOperation,
+} from "./of-revision";
+
+export const OF_DOCUMENT_SCHEMA = "of-document/1" as const;
+
+/**
+ * Version du gabarit de rendu.
+ *
+ * Elle entre dans le payload figé, donc dans son empreinte. Toute modification du
+ * dessin du document — colonne ajoutée, libellé changé, marge retouchée — doit
+ * l'incrémenter : deux PDF de même contenu produits par deux gabarits différents
+ * ne sont pas le même document, et une réimpression doit pouvoir le prouver.
+ */
+export const OF_DOCUMENT_TEMPLATE_VERSION = "of-gamme/1.1" as const;
+
+// ---------------------------------------------------------------------------
+// Formatage
+// ---------------------------------------------------------------------------
+
+/**
+ * Durée lisible à partir d'un nombre d'heures décimal : « 6 min », « 1 h 20 min »,
+ * « 4 h ».
+ *
+ * La gamme papier affiche des centièmes d'heure (0,08 h) que personne ne convertit
+ * de tête à l'atelier. Le document imprimé donne la durée telle qu'on la vit.
+ */
+export function formatDuration(hours: number | null | undefined): string {
+  if (hours === null || hours === undefined || !Number.isFinite(hours)) return "—";
+  const totalMinutes = Math.round(hours * 60);
+  if (totalMinutes === 0) return "0 min";
+
+  const sign = totalMinutes < 0 ? "-" : "";
+  const abs = Math.abs(totalMinutes);
+  const h = Math.floor(abs / 60);
+  const m = abs % 60;
+
+  if (h === 0) return `${sign}${m} min`;
+  if (m === 0) return `${sign}${h} h`;
+  return `${sign}${h} h ${m} min`;
+}
+
+/** Nombre à la française : « 2 280,00 », séparateur de milliers insécable fin. */
+export function formatNumberFr(value: number | null | undefined, decimals = 2): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return "—";
+  const fixed = Math.abs(value).toFixed(decimals);
+  const [intPart, decPart] = fixed.split(".");
+  const grouped = intPart.replace(/\B(?=(\d{3})+(?!\d))/g, " ");
+  const sign = value < 0 ? "-" : "";
+  return decPart ? `${sign}${grouped},${decPart}` : `${sign}${grouped}`;
+}
+
+/** Quantité : décimales seulement si elles portent une information. */
+export function formatQuantity(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return "—";
+  return Number.isInteger(value) ? formatNumberFr(value, 0) : formatNumberFr(value, 3);
+}
+
+export function formatDateFr(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(String(iso));
+  if (m) return `${m[3]}/${m[2]}/${m[1]}`;
+  return String(iso);
+}
+
+// ---------------------------------------------------------------------------
+// Quantités — le cœur du non-double-comptage
+// ---------------------------------------------------------------------------
+
+export type OfQuantityInput = {
+  /** Quantité commandée par le client, toutes affaires de livraison confondues. */
+  quantiteDemandee: number;
+  /** Déjà expédié et accepté. */
+  quantiteLivree: number;
+  /** Stock physique réservé pour cette demande. */
+  stockReserve: number;
+  /**
+   * Quantité couverte par d'**autres** OF encore actifs sur la même demande.
+   * L'OF courant en est exclu par construction.
+   */
+  couvertAutresOf: number;
+  /** Quantité que cet OF s'engage à produire. */
+  quantiteAffecteeCetOf: number;
+};
+
+export type OfQuantityCoverage = OfQuantityInput & {
+  /** Ce que plus rien ne couvre. Jamais négatif. */
+  resteNetACouvrir: number;
+  /** Somme des couvertures. Doit égaler la demande quand le reste net est nul. */
+  totalCouvert: number;
+  /** `true` si les couvertures dépassent la demande : signal de sur-couverture. */
+  surCouverture: boolean;
+  /** Excédent de couverture, positif seulement. */
+  excedent: number;
+};
+
+/**
+ * Répartit la demande en postes **disjoints**.
+ *
+ * Chaque unité commandée appartient à un poste et un seul : livrée, ou réservée
+ * sur stock, ou couverte par un autre OF actif, ou affectée à cet OF, ou non
+ * couverte. C'est ce qui interdit le double comptage.
+ *
+ * Deux confusions classiques que cette répartition évite :
+ *
+ *  - **Stock réservé et OF terminé.** La sortie d'un OF terminé est entrée en
+ *    stock : la compter à la fois comme production en cours et comme stock
+ *    réservé couvrirait deux fois la même pièce. Seuls les OF **actifs** entrent
+ *    dans `couvertAutresOf` — l'appelant en est responsable.
+ *  - **L'OF courant compté deux fois.** `couvertAutresOf` exclut l'OF du
+ *    document ; sa part vit dans `quantiteAffecteeCetOf`.
+ */
+export function computeQuantityCoverage(input: OfQuantityInput): OfQuantityCoverage {
+  const demandee = nonNegative(input.quantiteDemandee);
+  const livree = nonNegative(input.quantiteLivree);
+  const reserve = nonNegative(input.stockReserve);
+  const autres = nonNegative(input.couvertAutresOf);
+  const cetOf = nonNegative(input.quantiteAffecteeCetOf);
+
+  const totalCouvert = round3(livree + reserve + autres + cetOf);
+  const solde = round3(demandee - totalCouvert);
+
+  return {
+    quantiteDemandee: demandee,
+    quantiteLivree: livree,
+    stockReserve: reserve,
+    couvertAutresOf: autres,
+    quantiteAffecteeCetOf: cetOf,
+    resteNetACouvrir: solde > 0 ? solde : 0,
+    totalCouvert,
+    surCouverture: solde < 0,
+    excedent: solde < 0 ? round3(-solde) : 0,
+  };
+}
+
+function nonNegative(value: number | null | undefined): number {
+  if (value === null || value === undefined || !Number.isFinite(value) || value < 0) return 0;
+  return round3(value);
+}
+
+function round3(value: number): number {
+  return Math.round(value * 1e3) / 1e3;
+}
+
+// ---------------------------------------------------------------------------
+// Séquence machines
+// ---------------------------------------------------------------------------
+
+export type OfMachineSequenceStep = {
+  family: OfPhaseFamily;
+  label: string;
+  /** Nombre de phases consécutives de cette famille. */
+  passages: number;
+  /** Phases concernées, dans l'ordre. */
+  phases: number[];
+};
+
+/**
+ * Synthèse compacte des séquences machines, **dans l'ordre réel de fabrication**.
+ *
+ * Deux règles, et elles comptent autant l'une que l'autre :
+ *
+ *  - Seules les phases **consécutives** d'une même famille sont regroupées. Une
+ *    séquence `T -> F -> T` reste trois passages : regrouper les deux tournages
+ *    effacerait le fait que la pièce repasse en tournage après le fraisage, qui
+ *    est précisément ce que l'atelier lit sur cette ligne.
+ *  - Une phase **sans famille** d'usinage (emballage, expédition, contrôle) ne
+ *    figure pas dans la séquence — ce n'est pas un passage machine — mais elle
+ *    **interrompt** le regroupement. `F -> emballage -> F` reste donc deux
+ *    passages de fraisage, et non un seul : la pièce est bien retournée en
+ *    machine.
+ */
+export function buildMachineSequence(
+  operations: Array<Pick<OfRevisionOperation, "phase" | "family">>
+): OfMachineSequenceStep[] {
+  const ordered = [...operations].sort((a, b) => a.phase - b.phase);
+  const steps: OfMachineSequenceStep[] = [];
+  let openStep: OfMachineSequenceStep | null = null;
+
+  for (const operation of ordered) {
+    if (operation.family === null) {
+      openStep = null;
+      continue;
+    }
+    if (openStep && openStep.family === operation.family) {
+      openStep.passages += 1;
+      openStep.phases.push(operation.phase);
+      continue;
+    }
+    openStep = {
+      family: operation.family,
+      label: operation.family,
+      passages: 1,
+      phases: [operation.phase],
+    };
+    steps.push(openStep);
+  }
+
+  return steps;
+}
+
+/** « 3 F -> 2 T -> 1 F », lisible d'un coup d'œil. */
+export function formatMachineSequence(steps: OfMachineSequenceStep[]): string {
+  if (!steps.length) return "—";
+  return steps
+    .map((step) => (step.passages > 1 ? `${step.passages} ${step.label}` : step.label))
+    .join(" -> ");
+}
+
+// ---------------------------------------------------------------------------
+// Payload du document
+// ---------------------------------------------------------------------------
+
+export type OfDocumentAffaire = {
+  affaireId: number;
+  numero: string | null;
+  /** Engagement client accusé, ISO. */
+  delaiClient: string | null;
+  quantite: number | null;
+};
+
+export type OfDocumentCadence = {
+  date: string;
+  quantite: number;
+  affaireNumero: string | null;
+};
+
+/**
+ * Bloc VISA d'une phase.
+ *
+ * Il est **imprimé même vide** : c'est la case que l'atelier remplit au stylo
+ * quand la saisie écran n'est pas possible. Un document qui n'imprimerait la
+ * zone que si elle est déjà remplie serait inutilisable au poste.
+ */
+export type OfDocumentVisa = {
+  /** 'A_FAIRE', 'EN_COURS', 'VISE', 'REFUSE'. */
+  statut: string;
+  operateur: string | null;
+  /** ISO, ou `null` si la phase n'est pas visée. */
+  visaAt: string | null;
+  quantiteBonne: number | null;
+  quantiteRebut: number | null;
+  motifRebut: string | null;
+  /** Initiales de l'opérateur qui a fait la phase. */
+  visaOperateur: string | null;
+  /** Initiales du contrôle — distinct de l'opérateur, c'est le principe. */
+  visaControle: string | null;
+  commentaire: string | null;
+};
+
+export type OfDocumentPhase = {
+  phase: number;
+  family: OfPhaseFamily | null;
+  familyLabel: string | null;
+  /** Centre de frais affecté (code figé au lancement). */
+  centre: string | null;
+  machine: string | null;
+  designation: string;
+  programme: string | null;
+  /** `true` = la famille exige un n° de programme et il manque. Signalé, jamais inventé. */
+  programmeManquant: boolean;
+  /** Heures décimales, conservées pour l'aperçu et les contrôles. */
+  tempsUnitaireH: number;
+  preparationH: number;
+  fabricationH: number;
+  finalH: number;
+  quantiteBase: number;
+  coefficient: number;
+  /** Libellés prêts à imprimer, calculés une fois pour les deux rendus. */
+  tempsUnitaireLabel: string;
+  preparationLabel: string;
+  fabricationLabel: string;
+  finalLabel: string;
+  visa: OfDocumentVisa;
+};
+
+export type OfDocumentDecoupe = {
+  /** Section ou diamètre du brut, tel que saisi (« Ø 40 », « 40 x 20 »). */
+  dimensions: string | null;
+  longueurBrutMm: number | null;
+  /** Longueur réellement exploitable d'un brut, hors prise en pince et chute. */
+  longueurUtileMm: number | null;
+  /** Épaisseur du trait de scie, en mm. `null` si l'atelier ne l'a pas renseigné. */
+  traitDeScieMm: number | null;
+  /** Chute résiduelle par brut, en mm. */
+  chuteMm: number | null;
+  nombreBruts: number | null;
+  piecesParBrut: number | null;
+  longueurTotaleMm: number | null;
+  masseTotaleKg: number | null;
+  /** Unité de la matière : 'MM', 'KG', 'U'… telle que le référentiel la porte. */
+  unite: string | null;
+  /**
+   * Comment la longueur totale a été obtenue. Imprimée sous le tableau de débit :
+   * un magasinier qui coupe doit pouvoir refaire le calcul, pas le croire.
+   */
+  methodeCalcul: string | null;
+};
+
+/**
+ * Avertissement porté par le document.
+ *
+ * Critère d'acceptation #370 : « aucune donnée absente du backend n'est inventée :
+ * une donnée manquante est signalée, jamais remplacée ». Ces avertissements sont
+ * la forme que prend ce signalement — dans le panneau latéral de l'aperçu, et
+ * imprimés sur la pièce elle-même.
+ */
+export type OfDocumentWarning = {
+  code: string;
+  severite: "INFO" | "ATTENTION" | "BLOQUANT";
+  message: string;
+  /** Phase concernée, si l'avertissement en vise une. */
+  phase?: number;
+};
+
+export type OfDocumentPayload = {
+  schema: typeof OF_DOCUMENT_SCHEMA;
+
+  // Identité du document
+  /** UUID immuable de l'OF. Distinct du numéro métier : il ne s'affiche pas, il tracé. */
+  ofUuid: string | null;
+  ofNumero: string;
+  revisionCode: string;
+  revisionStatut: string;
+  ofStatut: string;
+  /**
+   * Statut **documentaire** : 'BROUILLON', 'OFFICIEL', 'OBSOLETE'.
+   *
+   * Volontairement distinct de `ofStatut` (état de fabrication) et de
+   * `revisionStatut` (état de la définition technique). Un OF « En cours » peut
+   * porter un document OBSOLETE si une R01 l'a remplacé : confondre les trois
+   * ferait fabriquer d'après une gamme périmée.
+   */
+  documentStatut: string;
+  /** Version du gabarit de rendu. Un changement de gabarit change le binaire. */
+  templateVersion: string;
+  snapshotId: string;
+  snapshotSha256: string;
+  auteur: string | null;
+  /** Horodatage figé, ISO. Entre dans les métadonnées du PDF. */
+  generatedAt: string;
+  /** Filigrane à imprimer, ou `null`. */
+  watermark: string | null;
+
+  // Page 1 — moitié haute
+  commandeNumero: string | null;
+  clientCode: string | null;
+  clientNom: string | null;
+  affaires: OfDocumentAffaire[];
+  cadenceLivraison: OfDocumentCadence[];
+  quantites: OfQuantityCoverage;
+  cadenceProduction: OfDocumentCadence[];
+  derniereFabrication: { numero: string | null; date: string | null } | null;
+
+  // Page 1 — moitié basse
+  pieceReference: string | null;
+  pieceDesignation: string | null;
+  pieceIndice: string | null;
+  gammeCode: string | null;
+  gammeVersion: string | null;
+  documentsAFournir: string[];
+  matiere: {
+    reference: string | null;
+    designation: string | null;
+    nuance: string | null;
+  };
+  decoupe: OfDocumentDecoupe;
+  sequenceMachines: OfMachineSequenceStep[];
+  sequenceMachinesLabel: string;
+
+  // Pages gamme
+  phases: OfDocumentPhase[];
+  totaux: {
+    preparationH: number;
+    fabricationH: number;
+    finalH: number;
+    preparationLabel: string;
+    fabricationLabel: string;
+    finalLabel: string;
+  };
+
+  /** Données manquantes ou incohérentes, signalées et non comblées. */
+  avertissements: OfDocumentWarning[];
+};
+
+export type OfDocumentBuildInput = {
+  ofUuid?: string | null;
+  ofNumero: string;
+  revisionCode: string;
+  revisionStatut: string;
+  ofStatut: string;
+  documentStatut?: string;
+  templateVersion?: string;
+  snapshotId: string;
+  snapshotSha256: string;
+  auteur: string | null;
+  generatedAt: string;
+  watermark?: string | null;
+
+  commandeNumero: string | null;
+  clientCode: string | null;
+  clientNom: string | null;
+  affaires: OfDocumentAffaire[];
+  cadenceLivraison: OfDocumentCadence[];
+  quantites: OfQuantityInput;
+  cadenceProduction: OfDocumentCadence[];
+  derniereFabrication: { numero: string | null; date: string | null } | null;
+
+  pieceReference: string | null;
+  pieceDesignation: string | null;
+  pieceIndice: string | null;
+  gammeCode: string | null;
+  gammeVersion: string | null;
+  documentsAFournir: string[];
+  matiere: { reference: string | null; designation: string | null; nuance: string | null };
+  decoupe: Omit<OfDocumentDecoupe, "longueurTotaleMm"> & { longueurTotaleMm?: number | null };
+
+  operations: OfRevisionOperation[];
+  /** VISA par phase, tel qu'enregistré. Absent = phase non visée, zone imprimée vide. */
+  visas: Record<number, Partial<OfDocumentVisa> | undefined>;
+  /**
+   * Référentiel des familles machine. Facultatif : sans lui les libellés
+   * retombent sur le repli, mais `programmeRequis` ne peut plus être vérifié —
+   * l'absence de contrôle est alors signalée, pas silencieuse.
+   */
+  familles?: readonly MachineFamilyRef[];
+};
+
+/**
+ * Construit le payload figé.
+ *
+ * Tous les libellés sont calculés ici, une fois, et non à l'affichage : c'est ce
+ * qui garantit que l'aperçu écran et le PDF montrent exactement la même chose. Un
+ * formatage refait de chaque côté finirait par diverger sur un arrondi.
+ */
+export function buildOfDocumentPayload(input: OfDocumentBuildInput): OfDocumentPayload {
+  const operations = [...input.operations].sort((a, b) => a.phase - b.phase);
+  const familles = input.familles;
+  const avertissements: OfDocumentWarning[] = [];
+
+  const phases = operations.map<OfDocumentPhase>((operation) => {
+    const fabrication = phaseFabricationTime(operation);
+    const final = phaseFinalTime(operation);
+    const visa = input.visas[operation.phase] ?? {};
+
+    // Le n° de programme n'est obligatoire que sur les familles qui l'exigent
+    // (`programme_requis` du référentiel). Sur une famille qui ne l'exige pas,
+    // son absence n'est pas un défaut et ne doit pas polluer les avertissements.
+    const famille = operation.family
+      ? familles?.find((f) => f.code === operation.family)
+      : undefined;
+    const programmeManquant = Boolean(famille?.programmeRequis) && !operation.programme;
+
+    if (programmeManquant) {
+      avertissements.push({
+        code: "PROGRAMME_MANQUANT",
+        severite: "ATTENTION",
+        phase: operation.phase,
+        message: `Phase ${operation.phase} (${famille?.libelle ?? operation.family}) : n° de programme absent alors que la famille l'exige.`,
+      });
+    }
+
+    if (operation.family && familles && !famille) {
+      avertissements.push({
+        code: "FAMILLE_INCONNUE",
+        severite: "ATTENTION",
+        phase: operation.phase,
+        message: `Phase ${operation.phase} : famille « ${operation.family} » absente du référentiel machine.`,
+      });
+    }
+
+    return {
+      phase: operation.phase,
+      family: operation.family,
+      familyLabel: familyLabel(operation.family, familles),
+      centre: operation.cfCode,
+      machine: operation.machineLabel,
+      designation: operation.designation,
+      programme: operation.programme,
+      programmeManquant,
+      tempsUnitaireH: operation.tempsUnitaire,
+      preparationH: operation.preparation,
+      fabricationH: round4(fabrication),
+      finalH: round4(final),
+      quantiteBase: operation.quantiteBase,
+      coefficient: operation.coefficient,
+      tempsUnitaireLabel: formatDuration(operation.tempsUnitaire),
+      preparationLabel: formatDuration(operation.preparation),
+      fabricationLabel: formatDuration(fabrication),
+      finalLabel: formatDuration(final),
+      visa: {
+        statut: visa.statut ?? "A_FAIRE",
+        operateur: visa.operateur ?? null,
+        visaAt: visa.visaAt ?? null,
+        quantiteBonne: visa.quantiteBonne ?? null,
+        quantiteRebut: visa.quantiteRebut ?? null,
+        motifRebut: visa.motifRebut ?? null,
+        visaOperateur: visa.visaOperateur ?? null,
+        visaControle: visa.visaControle ?? null,
+        commentaire: visa.commentaire ?? null,
+      },
+    };
+  });
+
+  if (!familles) {
+    avertissements.push({
+      code: "REFERENTIEL_FAMILLES_ABSENT",
+      severite: "INFO",
+      message:
+        "Référentiel des familles machine non chargé : les n° de programme obligatoires n'ont pas pu être contrôlés.",
+    });
+  }
+
+  if (!operations.length) {
+    avertissements.push({
+      code: "GAMME_VIDE",
+      severite: "BLOQUANT",
+      message: "Aucune phase dans la gamme applicable : le document ne décrit aucune fabrication.",
+    });
+  }
+
+  const preparationH = round4(phases.reduce((sum, p) => sum + p.preparationH, 0));
+  const fabricationH = round4(phases.reduce((sum, p) => sum + p.fabricationH, 0));
+  const finalH = round4(preparationH + fabricationH);
+
+  const sequenceMachines = buildMachineSequence(operations);
+
+  // Longueur totale de matière : longueur d'un brut x nombre de bruts. Calculée
+  // seulement quand les deux termes sont connus — une valeur inventée sur un
+  // document de débit enverrait le magasin couper la mauvaise barre.
+  const calculable =
+    input.decoupe.longueurBrutMm !== null && input.decoupe.nombreBruts !== null;
+  const longueurTotaleMm =
+    input.decoupe.longueurTotaleMm ??
+    (calculable ? round3(input.decoupe.longueurBrutMm! * input.decoupe.nombreBruts!) : null);
+
+  // La méthode est imprimée sous le tableau : un magasinier doit pouvoir refaire
+  // le calcul, pas le croire sur parole.
+  const methodeCalcul =
+    input.decoupe.methodeCalcul ??
+    (input.decoupe.longueurTotaleMm !== null && input.decoupe.longueurTotaleMm !== undefined
+      ? "Longueur totale fournie par la définition matière."
+      : calculable
+        ? `Longueur totale = longueur de brut (${formatNumberFr(input.decoupe.longueurBrutMm, 1)} mm) x nombre de bruts (${formatQuantity(input.decoupe.nombreBruts)}).`
+        : null);
+
+  if (longueurTotaleMm === null) {
+    avertissements.push({
+      code: "DECOUPE_INCOMPLETE",
+      severite: "ATTENTION",
+      message:
+        "Longueur totale de matière non calculable : longueur de brut ou nombre de bruts absent. Aucune valeur n'est déduite.",
+    });
+  }
+
+  const quantites = computeQuantityCoverage(input.quantites);
+
+  if (quantites.surCouverture) {
+    avertissements.push({
+      code: "SUR_COUVERTURE",
+      severite: "ATTENTION",
+      message: `Les couvertures dépassent la demande de ${formatQuantity(quantites.excedent)} : vérifier les réservations et les OF concurrents.`,
+    });
+  }
+
+  if (quantites.resteNetACouvrir > 0) {
+    avertissements.push({
+      code: "RESTE_A_COUVRIR",
+      severite: "INFO",
+      message: `Reste net à couvrir : ${formatQuantity(quantites.resteNetACouvrir)}.`,
+    });
+  }
+
+  return {
+    schema: OF_DOCUMENT_SCHEMA,
+    ofUuid: input.ofUuid ?? null,
+    ofNumero: input.ofNumero,
+    revisionCode: input.revisionCode,
+    revisionStatut: input.revisionStatut,
+    ofStatut: input.ofStatut,
+    documentStatut: input.documentStatut ?? "BROUILLON",
+    templateVersion: input.templateVersion ?? OF_DOCUMENT_TEMPLATE_VERSION,
+    snapshotId: input.snapshotId,
+    snapshotSha256: input.snapshotSha256,
+    auteur: input.auteur,
+    generatedAt: input.generatedAt,
+    watermark: input.watermark ?? null,
+
+    commandeNumero: input.commandeNumero,
+    clientCode: input.clientCode,
+    clientNom: input.clientNom,
+    affaires: [...input.affaires].sort((a, b) => a.affaireId - b.affaireId),
+    cadenceLivraison: [...input.cadenceLivraison].sort((a, b) => a.date.localeCompare(b.date)),
+    quantites,
+    cadenceProduction: [...input.cadenceProduction].sort((a, b) => a.date.localeCompare(b.date)),
+    derniereFabrication: input.derniereFabrication,
+
+    pieceReference: input.pieceReference,
+    pieceDesignation: input.pieceDesignation,
+    pieceIndice: input.pieceIndice,
+    gammeCode: input.gammeCode,
+    gammeVersion: input.gammeVersion,
+    documentsAFournir: [...input.documentsAFournir],
+    matiere: input.matiere,
+    decoupe: { ...input.decoupe, longueurTotaleMm, methodeCalcul },
+    sequenceMachines,
+    sequenceMachinesLabel: formatMachineSequence(sequenceMachines),
+
+    phases,
+    totaux: {
+      preparationH,
+      fabricationH,
+      finalH,
+      preparationLabel: formatDuration(preparationH),
+      fabricationLabel: formatDuration(fabricationH),
+      finalLabel: formatDuration(finalH),
+    },
+
+    // Tri stable : les bloquants d'abord, puis par phase. L'ordre entre dans le
+    // payload figé, donc dans le hash — il ne peut pas dépendre d'un parcours.
+    avertissements: [...avertissements].sort((a, b) => {
+      const rank = { BLOQUANT: 0, ATTENTION: 1, INFO: 2 } as const;
+      if (rank[a.severite] !== rank[b.severite]) return rank[a.severite] - rank[b.severite];
+      return (a.phase ?? -1) - (b.phase ?? -1) || a.code.localeCompare(b.code);
+    }),
+  };
+}
+
+/**
+ * Filigrane exigé par l'état du document.
+ *
+ * Un brouillon ou une révision périmée qui ressemblerait à un document officiel
+ * serait le pire défaut possible : quelqu'un fabriquerait d'après la mauvaise
+ * gamme. Le filigrane n'est pas décoratif, il est la garantie de lecture.
+ */
+export function watermarkFor(args: {
+  revisionStatut: string;
+  documentStatut: string;
+}): string | null {
+  if (args.documentStatut === "BROUILLON") return "BROUILLON";
+  if (args.documentStatut === "OBSOLETE" || args.revisionStatut === "OBSOLETE") return "OBSOLETE";
+  return null;
+}
+
+/**
+ * Empreinte du payload de document, calculée sur sa forme canonique.
+ *
+ * Distincte de `snapshotSha256` : celle-ci porte la DÉFINITION TECHNIQUE de la
+ * révision, celle-là porte tout ce que le DOCUMENT affiche — y compris le
+ * contexte commercial, les quantités, les VISA et la version de gabarit. Deux
+ * documents d'une même révision peuvent donc différer légitimement, et l'écart
+ * est alors visible sur cette empreinte et non sur celle de la révision.
+ */
+export function hashDocumentPayload(payload: OfDocumentPayload): string {
+  return hashSnapshot(payload);
+}
+
+function round4(value: number): number {
+  return Math.round(value * 1e4) / 1e4;
+}

--- a/src/module/production/domain/of-document.ts
+++ b/src/module/production/domain/of-document.ts
@@ -1,4 +1,4 @@
-// Read-model du document d'OF — « Gamme de fabrication ».
+// Read-model du document d'OF — « ORDRE DE FABRICATION — GAMME APPLICABLE ».
 //
 // Un seul payload alimente l'aperçu écran ET le PDF serveur. Il est figé dans
 // `of_documents` : une réimpression rejoue l'instantané et reproduit le même
@@ -30,8 +30,11 @@ export const OF_DOCUMENT_SCHEMA = "of-document/1" as const;
  * dessin du document — colonne ajoutée, libellé changé, marge retouchée — doit
  * l'incrémenter : deux PDF de même contenu produits par deux gabarits différents
  * ne sont pas le même document, et une réimpression doit pouvoir le prouver.
+ *
+ * Renommé et incrémenté le 2026-07-29 : la pièce est un ORDRE DE FABRICATION, pas
+ * une gamme de fabrication. Le libellé du document a changé, donc le binaire aussi.
  */
-export const OF_DOCUMENT_TEMPLATE_VERSION = "of-gamme/1.1" as const;
+export const OF_DOCUMENT_TEMPLATE_VERSION = "of-ordre-fabrication/1.2" as const;
 
 // ---------------------------------------------------------------------------
 // Formatage

--- a/src/module/production/domain/of-generation.ts
+++ b/src/module/production/domain/of-generation.ts
@@ -224,10 +224,37 @@ export async function copyPieceOperationsToOf(tx: Queryable, params: {
   piece_technique_id: string;
   gamme_id: string | null;
 }): Promise<number> {
+  // RÉVISION R00 — créée AVANT les opérations (#370).
+  //
+  // `of_operations.revision_id` est NOT NULL depuis le versioning d'OF : toute
+  // opération appartient à une révision. Sans cette R00, la génération d'OF
+  // échouerait en 23502 sur la première insertion d'opération.
+  //
+  // `WHERE NOT EXISTS` plutôt que `ON CONFLICT` : l'unicité d'une révision ACTIVE
+  // est portée par un index PARTIEL (`of_revisions_active_uq … WHERE statut =
+  // 'ACTIVE'`), sur lequel `ON CONFLICT` ne peut pas s'appuyer. La garde rend la
+  // fonction rejouable sans créer de seconde R00.
+  await tx.query(
+    `
+      INSERT INTO public.of_revisions (
+        of_id, revision_rank, revision_code, statut, snapshot, snapshot_sha256, activated_at
+      )
+      SELECT $1::bigint, 0, 'R00', 'ACTIVE',
+             jsonb_build_object('origin', 'GENERATION', 'of_id', $1::bigint),
+             encode(digest(('generation:' || $1::text), 'sha256'), 'hex'),
+             now()
+       WHERE NOT EXISTS (
+         SELECT 1 FROM public.of_revisions WHERE of_id = $1::bigint
+       )
+    `,
+    [params.of_id]
+  );
+
   const operationsInsert = await tx.query(
     `
       INSERT INTO public.of_operations (
         of_id,
+        revision_id,
         phase,
         designation,
         cf_id,
@@ -252,6 +279,10 @@ export async function copyPieceOperationsToOf(tx: Queryable, params: {
       )
       SELECT
         $1::bigint AS of_id,
+        -- Révision ACTIVE de cet OF, résolue en SQL : pas de valeur remontée puis
+        -- réinjectée, donc pas de fenêtre où l'une des deux écritures manquerait.
+        (SELECT r.id FROM public.of_revisions r
+          WHERE r.of_id = $1::bigint AND r.statut = 'ACTIVE') AS revision_id,
         pto.phase,
         pto.designation,
         pto.cf_id,

--- a/src/module/production/domain/of-planning-version.ts
+++ b/src/module/production/domain/of-planning-version.ts
@@ -1,0 +1,390 @@
+// Versions de planning d'un OF.
+//
+// Toute retouche d'un planning d'OF crée un **brouillon versionné**. Le planning
+// ACTIF n'est jamais modifié en place : il le reste jusqu'à ce qu'un brouillon
+// validé prenne sa succession.
+//
+//     ACTIF -> BROUILLON -> SOUMIS -> VALIDE  -> ACTIF
+//                        \-> REFUSE
+//
+// La comparaison avant/après est calculée à la création du brouillon et figée avec
+// lui : c'est elle qui dit s'il y a un impact client, donc si un dossier d'AR à
+// recaler doit être ouvert après validation.
+
+import { canonicalJson, hashSnapshot, type OfPhaseFamily } from "./of-revision";
+
+export const OF_PLANNING_STATUTS = [
+  "ACTIF",
+  "BROUILLON",
+  "SOUMIS",
+  "VALIDE",
+  "REFUSE",
+  "SUPERSEDE",
+] as const;
+export type OfPlanningStatut = (typeof OF_PLANNING_STATUTS)[number];
+
+export const OF_PLANNING_STATUT_LABELS: Record<OfPlanningStatut, string> = {
+  ACTIF: "Actif",
+  BROUILLON: "Brouillon",
+  SOUMIS: "Soumis",
+  VALIDE: "Validé",
+  REFUSE: "Refusé",
+  SUPERSEDE: "Remplacé",
+};
+
+/**
+ * Transitions licites.
+ *
+ * `VALIDE -> ACTIF` est l'activation : elle bascule l'ancien ACTIF en SUPERSEDE.
+ * `REFUSE` est terminal — un brouillon refusé ne se recycle pas, on en crée un
+ * autre, pour que la trace du refus reste lisible.
+ */
+export const OF_PLANNING_TRANSITIONS: Record<OfPlanningStatut, readonly OfPlanningStatut[]> = {
+  ACTIF: ["SUPERSEDE"],
+  BROUILLON: ["SOUMIS", "REFUSE"],
+  SOUMIS: ["VALIDE", "REFUSE", "BROUILLON"],
+  VALIDE: ["ACTIF"],
+  REFUSE: [],
+  SUPERSEDE: [],
+};
+
+export function canTransitionPlanningStatut(from: OfPlanningStatut, to: OfPlanningStatut): boolean {
+  if (from === to) return true;
+  return OF_PLANNING_TRANSITIONS[from].includes(to);
+}
+
+export type OfPlanningTransitionCheck =
+  | { allowed: true }
+  | { allowed: false; code: string; message: string };
+
+export function checkPlanningTransition(
+  from: OfPlanningStatut,
+  to: OfPlanningStatut
+): OfPlanningTransitionCheck {
+  if (canTransitionPlanningStatut(from, to)) return { allowed: true };
+  return {
+    allowed: false,
+    code: "TRANSITION_INTERDITE",
+    message: `Transition de planning interdite : ${OF_PLANNING_STATUT_LABELS[from]} -> ${OF_PLANNING_STATUT_LABELS[to]}.`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Charge utile d'une version de planning
+// ---------------------------------------------------------------------------
+
+/** Une opération planifiée : ce que le planning décide, phase par phase. */
+export type OfPlannedOperation = {
+  phase: number;
+  designation: string;
+  family: OfPhaseFamily | null;
+  machineId: string | null;
+  machineLabel: string | null;
+  /** Début planifié, ISO. */
+  debut: string | null;
+  /** Fin planifiée, ISO. */
+  fin: string | null;
+  /** Durée planifiée, en heures. */
+  dureeH: number;
+  quantite: number;
+};
+
+/** Cadence de livraison décidée : une quantité par échéance. */
+export type OfCadenceEcheance = {
+  /** Date de l'échéance, ISO (AAAA-MM-JJ). */
+  date: string;
+  quantite: number;
+  /** Affaire de livraison portant l'échéance. */
+  affaireId: number | null;
+};
+
+export type OfDeliveryEngagement = {
+  affaireId: number;
+  affaireNumero: string | null;
+  commandeId: number | null;
+  commandeNumero: string | null;
+  clientId: string | null;
+  /** Engagement client accusé, ISO (AAAA-MM-JJ). */
+  delaiClient: string | null;
+  quantite: number;
+};
+
+export type OfPlanningPayload = {
+  schema: "of-planning/1";
+  ofId: number;
+  ofNumero: string;
+  revisionCode: string | null;
+  /** Quantité couverte par ce plan. */
+  quantite: number;
+  dateDebut: string | null;
+  dateFin: string | null;
+  /** Charge totale planifiée, en heures. */
+  chargeTotaleH: number;
+  operations: OfPlannedOperation[];
+  cadence: OfCadenceEcheance[];
+  engagements: OfDeliveryEngagement[];
+};
+
+export function buildPlanningPayload(
+  input: Omit<OfPlanningPayload, "schema">
+): OfPlanningPayload {
+  return {
+    schema: "of-planning/1",
+    ...input,
+    operations: [...input.operations].sort((a, b) => a.phase - b.phase),
+    cadence: [...input.cadence].sort((a, b) => a.date.localeCompare(b.date)),
+    engagements: [...input.engagements].sort((a, b) => a.affaireId - b.affaireId),
+  };
+}
+
+export function hashPlanningPayload(payload: OfPlanningPayload): string {
+  return hashSnapshot(payload);
+}
+
+export function planningPayloadsIdentical(a: OfPlanningPayload, b: OfPlanningPayload): boolean {
+  return canonicalJson(a) === canonicalJson(b);
+}
+
+// ---------------------------------------------------------------------------
+// Comparaison avant / après
+// ---------------------------------------------------------------------------
+
+export const OF_CLIENT_IMPACTS = ["AUCUN", "DELAI", "CADENCE", "DELAI_ET_CADENCE"] as const;
+export type OfClientImpact = (typeof OF_CLIENT_IMPACTS)[number];
+
+export type OfPlanningChange = {
+  field: string;
+  before: unknown;
+  after: unknown;
+};
+
+export type OfPlanningOperationChange = {
+  phase: number;
+  kind: "AJOUTEE" | "RETIREE" | "MODIFIEE";
+  changes: OfPlanningChange[];
+};
+
+export type OfPlanningComparison = {
+  schema: "of-planning-comparison/1";
+  identical: boolean;
+  /** Écarts d'entête : quantité, dates, charge. */
+  header: OfPlanningChange[];
+  operations: OfPlanningOperationChange[];
+  /** Écarts de cadence, échéance par échéance. */
+  cadence: Array<{
+    date: string;
+    /** Affaire de livraison portant l'échéance, quand elle est connue. */
+    affaireId: number | null;
+    kind: "AJOUTEE" | "RETIREE" | "MODIFIEE";
+    quantiteAvant: number | null;
+    quantiteApres: number | null;
+  }>;
+  /** Engagements client et leur tenue après retouche. */
+  engagements: Array<{
+    affaireId: number;
+    affaireNumero: string | null;
+    commandeId: number | null;
+    clientId: string | null;
+    delaiClient: string | null;
+    /** Date de livraison estimée par le nouveau plan. */
+    nouvelleDate: string | null;
+    /** `true` quand la nouvelle date dépasse l'engagement accusé. */
+    depasse: boolean;
+    /** Jours de retard, positif seulement. */
+    retardJours: number;
+  }>;
+  summary: {
+    operationsAjoutees: number;
+    operationsRetirees: number;
+    operationsModifiees: number;
+    machinesChangees: number;
+    deltaChargeH: number;
+    deltaFinJours: number | null;
+    cadenceModifiee: boolean;
+    engagementsDepasses: number;
+  };
+  clientImpact: OfClientImpact;
+};
+
+const OPERATION_FIELDS: Array<keyof OfPlannedOperation> = [
+  "designation",
+  "family",
+  "machineId",
+  "machineLabel",
+  "debut",
+  "fin",
+  "dureeH",
+  "quantite",
+];
+
+/** Écart en jours entiers entre deux dates ISO. `null` si l'une manque. */
+export function diffDays(from: string | null, to: string | null): number | null {
+  if (!from || !to) return null;
+  const a = Date.parse(from.length <= 10 ? `${from}T00:00:00Z` : from);
+  const b = Date.parse(to.length <= 10 ? `${to}T00:00:00Z` : to);
+  if (!Number.isFinite(a) || !Number.isFinite(b)) return null;
+  return Math.round((b - a) / 86_400_000);
+}
+
+/**
+ * Compare le plan actif au brouillon et en déduit l'impact client.
+ *
+ * L'impact client ne se devine pas d'un décalage interne : seul le dépassement
+ * d'un engagement **accusé** (délai) ou la modification de la cadence promise
+ * touche le client. Un OF replanifié qui livre à la même date, à la même cadence,
+ * ne le concerne pas.
+ */
+export function comparePlanningVersions(
+  before: OfPlanningPayload | null,
+  after: OfPlanningPayload
+): OfPlanningComparison {
+  const header: OfPlanningChange[] = [];
+  const operations: OfPlanningOperationChange[] = [];
+
+  if (before) {
+    for (const field of ["quantite", "dateDebut", "dateFin", "chargeTotaleH"] as const) {
+      if (!sameValue(before[field], after[field])) {
+        header.push({ field, before: before[field] ?? null, after: after[field] ?? null });
+      }
+    }
+  }
+
+  const beforeOps = new Map((before?.operations ?? []).map((op) => [op.phase, op]));
+  const afterOps = new Map(after.operations.map((op) => [op.phase, op]));
+
+  for (const [phase, op] of afterOps) {
+    const previous = beforeOps.get(phase);
+    if (!previous) {
+      operations.push({ phase, kind: "AJOUTEE", changes: [] });
+      continue;
+    }
+    const changes: OfPlanningChange[] = [];
+    for (const field of OPERATION_FIELDS) {
+      if (!sameValue(previous[field], op[field])) {
+        changes.push({ field, before: previous[field] ?? null, after: op[field] ?? null });
+      }
+    }
+    if (changes.length) operations.push({ phase, kind: "MODIFIEE", changes });
+  }
+  for (const [phase] of beforeOps) {
+    if (!afterOps.has(phase)) operations.push({ phase, kind: "RETIREE", changes: [] });
+  }
+  operations.sort((a, b) => a.phase - b.phase);
+
+  // Cadence — la clé est le couple (affaire, date) : deux affaires peuvent livrer
+  // le même jour sans que leurs échéances se confondent.
+  const cadenceKey = (entry: OfCadenceEcheance) => `${entry.affaireId ?? ""}|${entry.date}`;
+  const beforeCadence = new Map((before?.cadence ?? []).map((c) => [cadenceKey(c), c]));
+  const afterCadence = new Map(after.cadence.map((c) => [cadenceKey(c), c]));
+  const cadence: OfPlanningComparison["cadence"] = [];
+
+  for (const [key, entry] of afterCadence) {
+    const previous = beforeCadence.get(key);
+    if (!previous) {
+      cadence.push({
+        date: entry.date,
+        affaireId: entry.affaireId,
+        kind: "AJOUTEE",
+        quantiteAvant: null,
+        quantiteApres: entry.quantite,
+      });
+    } else if (!sameValue(previous.quantite, entry.quantite)) {
+      cadence.push({
+        date: entry.date,
+        affaireId: entry.affaireId,
+        kind: "MODIFIEE",
+        quantiteAvant: previous.quantite,
+        quantiteApres: entry.quantite,
+      });
+    }
+  }
+  for (const [key, entry] of beforeCadence) {
+    if (!afterCadence.has(key)) {
+      cadence.push({
+        date: entry.date,
+        affaireId: entry.affaireId,
+        kind: "RETIREE",
+        quantiteAvant: entry.quantite,
+        quantiteApres: null,
+      });
+    }
+  }
+  cadence.sort((a, b) => a.date.localeCompare(b.date) || (a.affaireId ?? 0) - (b.affaireId ?? 0));
+
+  // Engagements client : la nouvelle date de livraison est la fin du plan, sauf
+  // si une échéance de cadence porte explicitement l'affaire.
+  const engagements: OfPlanningComparison["engagements"] = after.engagements.map((engagement) => {
+    const echeance = after.cadence
+      .filter((c) => c.affaireId === engagement.affaireId)
+      .map((c) => c.date)
+      .sort()
+      .at(-1);
+    const nouvelleDate = echeance ?? after.dateFin ?? null;
+    const retard = diffDays(engagement.delaiClient, nouvelleDate);
+    const retardJours = retard !== null && retard > 0 ? retard : 0;
+    return {
+      affaireId: engagement.affaireId,
+      affaireNumero: engagement.affaireNumero,
+      commandeId: engagement.commandeId,
+      clientId: engagement.clientId,
+      delaiClient: engagement.delaiClient,
+      nouvelleDate,
+      depasse: retardJours > 0,
+      retardJours,
+    };
+  });
+
+  const machinesChangees = operations.filter((op) =>
+    op.changes.some((change) => change.field === "machineId")
+  ).length;
+
+  const engagementsDepasses = engagements.filter((e) => e.depasse).length;
+  const cadenceModifiee = cadence.length > 0;
+
+  const clientImpact: OfClientImpact =
+    engagementsDepasses > 0 && cadenceModifiee
+      ? "DELAI_ET_CADENCE"
+      : engagementsDepasses > 0
+        ? "DELAI"
+        : cadenceModifiee
+          ? "CADENCE"
+          : "AUCUN";
+
+  return {
+    schema: "of-planning-comparison/1",
+    identical: before ? planningPayloadsIdentical(before, after) : false,
+    header,
+    operations,
+    cadence,
+    engagements,
+    summary: {
+      operationsAjoutees: operations.filter((o) => o.kind === "AJOUTEE").length,
+      operationsRetirees: operations.filter((o) => o.kind === "RETIREE").length,
+      operationsModifiees: operations.filter((o) => o.kind === "MODIFIEE").length,
+      machinesChangees,
+      deltaChargeH: round4(after.chargeTotaleH - (before?.chargeTotaleH ?? 0)),
+      deltaFinJours: before ? diffDays(before.dateFin, after.dateFin) : null,
+      cadenceModifiee,
+      engagementsDepasses,
+    },
+    clientImpact,
+  };
+}
+
+/** Un plan validé sans impact client se publie directement, sans dossier d'AR. */
+export function requiresArRecalage(comparison: OfPlanningComparison): boolean {
+  return comparison.clientImpact !== "AUCUN";
+}
+
+function sameValue(a: unknown, b: unknown): boolean {
+  const left = a ?? null;
+  const right = b ?? null;
+  if (typeof left === "number" && typeof right === "number") {
+    return Math.abs(left - right) < 1e-9;
+  }
+  return left === right;
+}
+
+function round4(value: number): number {
+  return Math.round(value * 1e4) / 1e4;
+}

--- a/src/module/production/domain/of-rbac.ts
+++ b/src/module/production/domain/of-rbac.ts
@@ -15,7 +15,14 @@ export type OfCapability =
   | "quality_decision"
   | "cancel"
   | "archive"
-  | "traceability";
+  | "traceability"
+  // Versioning, replanification, AR et document (#374).
+  | "revise"
+  | "visa"
+  | "plan_draft"
+  | "plan_validate"
+  | "ar_recalage"
+  | "document";
 
 const NEEDLES: Record<OfCapability, readonly string[]> = {
   read: ["admin", "administrateur", "directeur", "production", "atelier", "method", "planif", "program", "qualit", "secr", "secret", "logisti"],
@@ -29,12 +36,69 @@ const NEEDLES: Record<OfCapability, readonly string[]> = {
   cancel: ["admin", "administrateur", "directeur", "production"],
   archive: ["admin", "administrateur", "directeur"],
   traceability: ["admin", "administrateur", "directeur", "production", "atelier", "qualit", "method", "logisti"],
+
+  // ------------------------------------------------------------------------
+  // Versioning, replanification, AR et document (#370).
+  //
+  // `req.user.role` porte le rôle EFFECTIF multi-rôles construit à la connexion
+  // par `authorizationRole()` : une chaîne « Production | Atelier | Method »
+  // d'ALIAS, jamais les intitulés d'organigramme. Le vocabulaire est donc fermé :
+  //
+  //   Directeur · Employee · Administrateur Systeme et Reseau · Responsable Qualité
+  //   Secretaire · Responsable Programmation · Responsable RH · Commercial · Achat
+  //   Comptabilite · Production · Atelier · Method · Planification · Logistique
+  //   Maintenance · Stock · Magasin · Opérateur atelier
+  //
+  // Toute needle est choisie DANS ce vocabulaire. Deux needles de la première
+  // écriture n'y correspondaient à RIEN et donnaient l'illusion d'une couverture :
+  //   - « plann » : le rôle d'organigramme « Planning » s'alias en
+  //     « Planification » ; « planif » couvre donc les deux, « plann » jamais.
+  //   - « assistant » : « Assistante polyvalente » s'alias en « Secretaire » ;
+  //     « secr » la couvre déjà.
+  // Elles sont retirées. Aucun accès n'est perdu, une fausse garantie disparaît.
+  // ------------------------------------------------------------------------
+
+  // Réviser un OF touche à la définition technique : méthodes et programmation,
+  // pas l'atelier — un opérateur exécute la gamme, il ne la réécrit pas.
+  revise: ["admin", "administrateur", "directeur", "production", "method", "program"],
+  // Le VISA est la signature de celui qui a fait la phase : l'atelier vise.
+  // « Opérateur atelier » est couvert par la needle « atelier ».
+  visa: ["admin", "administrateur", "directeur", "production", "atelier"],
+  // Retoucher un planning est ouvert largement ; ce n'est qu'un brouillon.
+  plan_draft: ["admin", "administrateur", "directeur", "production", "method", "planif", "atelier"],
+  // Le valider ne l'est pas : c'est la décision qui engage la charge et le client.
+  plan_validate: ["admin", "administrateur", "directeur", "production", "planif"],
+  // Recaler un AR est un acte commercial : administration des ventes et direction.
+  ar_recalage: ["admin", "administrateur", "directeur", "commerc", "secr", "secret"],
+  // Éditer le document officiel de fabrication : tous ceux qui le lisent en atelier.
+  document: ["admin", "administrateur", "directeur", "production", "atelier", "method", "program", "planif", "qualit"],
 };
 
+/**
+ * Repli des diacritiques avant comparaison.
+ *
+ * Les « needles » sont écrites sans accent (`method`, `qualit`, `secr`) alors que
+ * le catalogue de rôles en porte : « Études-Méthodes », « Responsable Qualité ».
+ * Sans ce repli, `"études-méthodes".includes("method")` est faux et le rôle
+ * Méthodes se voit refuser les capacités qui lui sont manifestement destinées —
+ * un refus silencieux, sans erreur, donc invisible jusqu'à ce qu'un utilisateur
+ * signale ne pas pouvoir créer d'OF.
+ *
+ * Ce repli **élargit** l'accès des rôles accentués aux capacités que la liste
+ * leur destinait déjà. Il ne fait entrer aucun rôle qui n'était pas visé.
+ */
+function foldRole(role: string): string {
+  return role
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .trim()
+    .toLowerCase();
+}
+
 export function roleHasOfCapability(role: string | null | undefined, capability: OfCapability): boolean {
-  const normalized = (role ?? "").trim().toLowerCase();
+  const normalized = foldRole(role ?? "");
   if (!normalized) return false;
-  return NEEDLES[capability].some((needle) => normalized.includes(needle));
+  return NEEDLES[capability].some((needle) => normalized.includes(foldRole(needle)));
 }
 
 import type { OfStatut } from "./of-status";

--- a/src/module/production/domain/of-revision.ts
+++ b/src/module/production/domain/of-revision.ts
@@ -1,0 +1,453 @@
+// Révisions d'OF — numéro stable, révision qui porte l'évolution.
+//
+// Le numéro d'OF ne bouge jamais (trigger `fn_prevent_of_numero_mutation`, #170).
+// Ce qui évolue est la révision : R00 à la création, R01, R02… ensuite. Chaque
+// révision fige un instantané technique complet et se compare à la précédente.
+//
+// Règle structurante : **une modification n'écrase jamais un OF lancé**. Créer une
+// révision ne mute pas les opérations existantes, elle en crée un nouveau jeu. Les
+// pointages et les VISA restent donc rattachés aux opérations de la révision sous
+// laquelle ils ont été enregistrés — c'est l'unicité (of_id, revision_id, phase)
+// en base qui rend cette coexistence possible.
+
+import { createHash } from "node:crypto";
+
+/**
+ * Famille d'usinage d'une phase : un **code du référentiel**
+ * `production_machine_families`, pas une constante du code.
+ *
+ * Ce référentiel est administrable par les Méthodes depuis la normalisation des
+ * gammes. Figer ici une union `"T" | "F" | "TTRAD" | "FTRAD"` rendrait la table
+ * d'administration décorative : ajouter une famille exigerait une livraison
+ * applicative, et `DECOUPE` — qui existe déjà en base — serait rejeté par le
+ * typage alors que la base l'accepte.
+ *
+ * Le contrôle de validité se fait donc contre le référentiel chargé, pas contre
+ * une liste écrite en dur : voir `assertKnownFamily`.
+ */
+export type OfPhaseFamily = string;
+
+/** Une famille telle que le référentiel la décrit. */
+export type MachineFamilyRef = {
+  code: string;
+  libelle: string;
+  /** `true` = le n° de programme est obligatoire sur une phase de cette famille. */
+  programmeRequis: boolean;
+  ordreAffichage: number;
+  actif: boolean;
+};
+
+/**
+ * Libellés de repli des familles amorcées par le patch de normalisation.
+ *
+ * Uniquement pour l'affichage lorsque le référentiel n'a pas pu être chargé (un
+ * rendu ne doit pas échouer parce qu'une jointure a manqué). Ce n'est **pas** la
+ * liste de référence : elle vit en base.
+ */
+export const OF_PHASE_FAMILY_FALLBACK_LABELS: Record<string, string> = {
+  T: "Tournage CN",
+  F: "Fraisage CN",
+  TTRAD: "Tour conventionnel",
+  FTRAD: "Fraisage conventionnel",
+  DECOUPE: "Découpe",
+};
+
+/** Forme d'un code de famille, alignée sur `production_machine_families_code_ck`. */
+const FAMILY_CODE_RE = /^[A-Z0-9_]{1,24}$/;
+
+export function isOfPhaseFamily(value: unknown): value is OfPhaseFamily {
+  return typeof value === "string" && FAMILY_CODE_RE.test(value);
+}
+
+/** Libellé d'une famille : le référentiel d'abord, le repli ensuite, le code sinon. */
+export function familyLabel(
+  code: string | null | undefined,
+  referential?: readonly MachineFamilyRef[]
+): string | null {
+  if (!code) return null;
+  const known = referential?.find((f) => f.code === code);
+  if (known) return known.libelle;
+  return OF_PHASE_FAMILY_FALLBACK_LABELS[code] ?? code;
+}
+
+/**
+ * Refuse une famille absente du référentiel.
+ *
+ * `null` reste accepté : une phase dont la famille n'est pas déterminable est un
+ * fait, et le document la signale. Ce qui est refusé, c'est une famille
+ * *inventée* — elle produirait une gamme qui ne correspond à aucun atelier.
+ */
+export function assertKnownFamily(
+  code: string | null | undefined,
+  referential: readonly MachineFamilyRef[]
+): string | null {
+  if (code === null || code === undefined || code === "") return null;
+  if (!isOfPhaseFamily(code)) {
+    throw new Error(`Code de famille machine invalide : ${JSON.stringify(code)}`);
+  }
+  if (!referential.some((f) => f.code === code)) {
+    throw new Error(
+      `Famille machine inconnue du référentiel : ${code}. Les familles sont administrées dans production_machine_families.`
+    );
+  }
+  return code;
+}
+
+export const OF_REVISION_STATUTS = ["BROUILLON", "ACTIVE", "OBSOLETE"] as const;
+export type OfRevisionStatut = (typeof OF_REVISION_STATUTS)[number];
+
+/** Une phase de la gamme applicable, telle que figée dans la révision. */
+export type OfRevisionOperation = {
+  phase: number;
+  designation: string;
+  /** `null` quand la famille n'est pas déterminable : on ne l'invente pas. */
+  family: OfPhaseFamily | null;
+  machineId: string | null;
+  machineLabel: string | null;
+  /** N° de programme CN. `null` = absent, et le document le signale. */
+  programme: string | null;
+  /** Temps unitaire, en heures. */
+  tempsUnitaire: number;
+  /** Temps de préparation (TP), en heures. */
+  preparation: number;
+  /** Quantité de base servant au calcul de la fabrication. */
+  quantiteBase: number;
+  coefficient: number;
+
+  // --- Gel du centre de frais (normalisation des gammes) --------------------
+  // Le taux horaire ne se saisit plus sur l'opération : il vient d'un tarif de
+  // centre de frais daté. La révision fige QUEL tarif a servi, sinon un tarif
+  // clos plus tard rendrait le coût de la révision irreproductible.
+  /** Code du centre de frais, recopié — pas une clé étrangère : c'est une preuve. */
+  cfCode: string | null;
+  /** Tarif de centre de frais ayant produit `tauxHoraire`. */
+  cfRateId: string | null;
+  /** Taux horaire appliqué, en euros. */
+  tauxHoraire: number | null;
+  /** D'où vient le taux : 'CENTRE_FRAIS', 'HISTORIQUE_LEGACY' ou 'ABSENT'. */
+  tauxHoraireSource: string | null;
+  /** Date de prise d'effet du tarif retenu, au format ISO. */
+  tauxHoraireEffectiveAt: string | null;
+};
+
+/** Matière et débit, tels que figés dans la révision. */
+export type OfRevisionMatiere = {
+  reference: string | null;
+  designation: string | null;
+  nuance: string | null;
+  /** Longueur d'un brut, en millimètres. */
+  longueurBrutMm: number | null;
+  nombreBruts: number | null;
+  piecesParBrut: number | null;
+  /** Masse totale, en kilogrammes. */
+  masseTotaleKg: number | null;
+};
+
+export type OfRevisionSnapshotInput = {
+  ofId: number;
+  ofNumero: string;
+  pieceReference: string | null;
+  pieceDesignation: string | null;
+  pieceIndice: string | null;
+  gammeId: string | null;
+  gammeCode: string | null;
+  gammeVersion: string | null;
+  quantiteLancee: number;
+  matiere: OfRevisionMatiere | null;
+  operations: OfRevisionOperation[];
+};
+
+/**
+ * Instantané canonique d'une révision.
+ *
+ * Les clés sont ordonnées et les nombres normalisés : deux instantanés de même
+ * contenu produisent la même chaîne, donc la même empreinte. Sans cette
+ * canonicalisation, l'ordre d'insertion des clés suffirait à faire diverger deux
+ * hachages identiques sur le fond.
+ */
+export type OfRevisionSnapshot = OfRevisionSnapshotInput & { schema: "of-revision/1" };
+
+/** Formate un rang en code de révision : 0 -> « R00 », 12 -> « R12 », 100 -> « R100 ». */
+export function formatRevisionCode(rank: number): string {
+  if (!Number.isInteger(rank) || rank < 0) {
+    throw new Error(`Rang de révision invalide : ${rank}`);
+  }
+  return `R${String(rank).padStart(2, "0")}`;
+}
+
+export function parseRevisionCode(code: string): number | null {
+  const match = /^R(\d{2,})$/.exec(code.trim());
+  if (!match) return null;
+  return Number.parseInt(match[1], 10);
+}
+
+/** Rang de la révision suivante. */
+export function nextRevisionRank(currentRank: number | null): number {
+  if (currentRank === null) return 0;
+  return currentRank + 1;
+}
+
+/**
+ * Sérialisation canonique : clés triées à toute profondeur, `undefined` écarté.
+ *
+ * `JSON.stringify` conserve l'ordre d'insertion. Deux objets équivalents produits
+ * par deux chemins de code donneraient alors deux empreintes différentes, et une
+ * réimpression semblerait porter sur un contenu modifié.
+ */
+export function canonicalJson(value: unknown): string {
+  const walk = (node: unknown): unknown => {
+    if (node === null || typeof node !== "object") {
+      // -0 et 0 sont le même nombre métier ; ils doivent hacher pareil.
+      return typeof node === "number" && Object.is(node, -0) ? 0 : node;
+    }
+    if (Array.isArray(node)) return node.map(walk);
+    const source = node as Record<string, unknown>;
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(source).sort()) {
+      if (source[key] === undefined) continue;
+      out[key] = walk(source[key]);
+    }
+    return out;
+  };
+  return JSON.stringify(walk(value));
+}
+
+export function sha256Hex(value: string): string {
+  return createHash("sha256").update(value, "utf8").digest("hex");
+}
+
+/** Empreinte d'un instantané, calculée sur sa forme canonique. */
+export function hashSnapshot(snapshot: unknown): string {
+  return sha256Hex(canonicalJson(snapshot));
+}
+
+/** Construit l'instantané figé d'une révision, opérations triées par phase. */
+export function buildRevisionSnapshot(input: OfRevisionSnapshotInput): OfRevisionSnapshot {
+  return {
+    schema: "of-revision/1",
+    ...input,
+    operations: [...input.operations].sort((a, b) => a.phase - b.phase),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Diff entre deux révisions
+// ---------------------------------------------------------------------------
+
+export type OfRevisionFieldChange = {
+  field: string;
+  before: unknown;
+  after: unknown;
+};
+
+export type OfRevisionPhaseChange = {
+  phase: number;
+  kind: "AJOUTEE" | "RETIREE" | "MODIFIEE";
+  changes: OfRevisionFieldChange[];
+};
+
+export type OfRevisionDiff = {
+  schema: "of-revision-diff/1";
+  /** `true` quand les deux instantanés ont la même empreinte. */
+  identical: boolean;
+  header: OfRevisionFieldChange[];
+  matiere: OfRevisionFieldChange[];
+  phases: OfRevisionPhaseChange[];
+  summary: {
+    phasesAjoutees: number;
+    phasesRetirees: number;
+    phasesModifiees: number;
+    /** Écart de temps total planifié, en heures. */
+    deltaTempsTotalH: number;
+  };
+};
+
+const HEADER_FIELDS: Array<keyof OfRevisionSnapshotInput> = [
+  "ofNumero",
+  "pieceReference",
+  "pieceDesignation",
+  "pieceIndice",
+  "gammeId",
+  "gammeCode",
+  "gammeVersion",
+  "quantiteLancee",
+];
+
+const MATIERE_FIELDS: Array<keyof OfRevisionMatiere> = [
+  "reference",
+  "designation",
+  "nuance",
+  "longueurBrutMm",
+  "nombreBruts",
+  "piecesParBrut",
+  "masseTotaleKg",
+];
+
+const PHASE_FIELDS: Array<keyof OfRevisionOperation> = [
+  "designation",
+  "family",
+  "machineId",
+  "machineLabel",
+  "programme",
+  "tempsUnitaire",
+  "preparation",
+  "quantiteBase",
+  "coefficient",
+  // Un changement de centre de frais ou de tarif change le coût de la gamme :
+  // il doit apparaître dans le diff, sinon une révision « sans changement
+  // visible » modifierait silencieusement le prix de revient.
+  "cfCode",
+  "cfRateId",
+  "tauxHoraire",
+  "tauxHoraireSource",
+  "tauxHoraireEffectiveAt",
+];
+
+/** Temps final d'une phase : préparation + fabrication. */
+export function phaseFinalTime(operation: OfRevisionOperation): number {
+  return operation.preparation + phaseFabricationTime(operation);
+}
+
+/** Fabrication = temps unitaire x quantité de base x coefficient. */
+export function phaseFabricationTime(operation: OfRevisionOperation): number {
+  return operation.tempsUnitaire * operation.quantiteBase * operation.coefficient;
+}
+
+/** Temps total planifié d'un instantané, en heures. */
+export function snapshotTotalTime(snapshot: OfRevisionSnapshotInput): number {
+  return snapshot.operations.reduce((sum, operation) => sum + phaseFinalTime(operation), 0);
+}
+
+/** Compare deux instantanés et décrit l'écart, champ par champ. */
+export function diffRevisionSnapshots(
+  before: OfRevisionSnapshotInput | null,
+  after: OfRevisionSnapshotInput
+): OfRevisionDiff {
+  if (!before) {
+    return {
+      schema: "of-revision-diff/1",
+      identical: false,
+      header: [],
+      matiere: [],
+      phases: after.operations
+        .map<OfRevisionPhaseChange>((operation) => ({
+          phase: operation.phase,
+          kind: "AJOUTEE",
+          changes: [],
+        }))
+        .sort((a, b) => a.phase - b.phase),
+      summary: {
+        phasesAjoutees: after.operations.length,
+        phasesRetirees: 0,
+        phasesModifiees: 0,
+        deltaTempsTotalH: round4(snapshotTotalTime(after)),
+      },
+    };
+  }
+
+  const header: OfRevisionFieldChange[] = [];
+  for (const field of HEADER_FIELDS) {
+    if (!sameValue(before[field], after[field])) {
+      header.push({ field, before: before[field] ?? null, after: after[field] ?? null });
+    }
+  }
+
+  const matiere: OfRevisionFieldChange[] = [];
+  for (const field of MATIERE_FIELDS) {
+    const b = before.matiere?.[field] ?? null;
+    const a = after.matiere?.[field] ?? null;
+    if (!sameValue(b, a)) matiere.push({ field, before: b, after: a });
+  }
+
+  const beforeByPhase = new Map(before.operations.map((op) => [op.phase, op]));
+  const afterByPhase = new Map(after.operations.map((op) => [op.phase, op]));
+  const phases: OfRevisionPhaseChange[] = [];
+
+  for (const [phase, op] of afterByPhase) {
+    const previous = beforeByPhase.get(phase);
+    if (!previous) {
+      phases.push({ phase, kind: "AJOUTEE", changes: [] });
+      continue;
+    }
+    const changes: OfRevisionFieldChange[] = [];
+    for (const field of PHASE_FIELDS) {
+      if (!sameValue(previous[field], op[field])) {
+        changes.push({ field, before: previous[field] ?? null, after: op[field] ?? null });
+      }
+    }
+    if (changes.length) phases.push({ phase, kind: "MODIFIEE", changes });
+  }
+
+  for (const [phase] of beforeByPhase) {
+    if (!afterByPhase.has(phase)) phases.push({ phase, kind: "RETIREE", changes: [] });
+  }
+
+  phases.sort((a, b) => a.phase - b.phase);
+
+  return {
+    schema: "of-revision-diff/1",
+    identical: hashSnapshot(before) === hashSnapshot(after),
+    header,
+    matiere,
+    phases,
+    summary: {
+      phasesAjoutees: phases.filter((p) => p.kind === "AJOUTEE").length,
+      phasesRetirees: phases.filter((p) => p.kind === "RETIREE").length,
+      phasesModifiees: phases.filter((p) => p.kind === "MODIFIEE").length,
+      deltaTempsTotalH: round4(snapshotTotalTime(after) - snapshotTotalTime(before)),
+    },
+  };
+}
+
+function sameValue(a: unknown, b: unknown): boolean {
+  const left = a ?? null;
+  const right = b ?? null;
+  if (typeof left === "number" && typeof right === "number") {
+    // Les temps viennent de `numeric` PostgreSQL : comparer au 1/10 000 d'heure
+    // évite qu'un aller-retour de sérialisation passe pour une modification.
+    return Math.abs(left - right) < 1e-9;
+  }
+  return left === right;
+}
+
+function round4(value: number): number {
+  return Math.round(value * 1e4) / 1e4;
+}
+
+// ---------------------------------------------------------------------------
+// Règles de création d'une révision
+// ---------------------------------------------------------------------------
+
+export type OfRevisionCreationCheck =
+  | { allowed: true }
+  | { allowed: false; code: string; message: string };
+
+/**
+ * Une révision ne se crée pas sans motif dès la R01, et un instantané identique
+ * ne mérite pas une révision : elle ferait croire à un changement inexistant.
+ */
+export function checkRevisionCreation(args: {
+  nextRank: number;
+  motif: string | null | undefined;
+  diff: OfRevisionDiff;
+}): OfRevisionCreationCheck {
+  const motif = typeof args.motif === "string" ? args.motif.trim() : "";
+
+  if (args.nextRank > 0 && !motif) {
+    return {
+      allowed: false,
+      code: "MOTIF_REQUIS",
+      message: "Une révision d'OF exige un motif à partir de R01.",
+    };
+  }
+
+  if (args.diff.identical) {
+    return {
+      allowed: false,
+      code: "REVISION_IDENTIQUE",
+      message: "La définition est inchangée : aucune révision à créer.",
+    };
+  }
+
+  return { allowed: true };
+}

--- a/src/module/production/domain/of-time-variance.ts
+++ b/src/module/production/domain/of-time-variance.ts
@@ -1,0 +1,284 @@
+// Dérive du temps d'usinage — comparaison au temps validé de référence.
+//
+// Après programmation d'une phase, le temps de fabrication constaté est comparé au
+// temps de référence :
+//
+//     variation_pct = ((nouveau - référence) / référence) x 100
+//
+// Le seuil est **strict** à 10,00 % : +9,99 % et +10,00 % ne déclenchent rien,
+// +10,01 % ouvre une proposition de replanification. Référence absente ou nulle :
+// revue obligatoire, sans pourcentage — diviser par zéro ne produit pas une
+// information, il en détruit une.
+//
+// Une proposition ne modifie jamais le planning actif. Elle se soumet à décision.
+
+import { familyLabel, type MachineFamilyRef, type OfPhaseFamily } from "./of-revision";
+
+/** Seuil de tolérance, en pourcentage. Au-delà — strictement — on propose. */
+export const OF_TIME_VARIANCE_THRESHOLD_PCT = 10;
+
+export const OF_TIME_VARIANCE_OUTCOMES = ["RIEN", "REPLANIFICATION", "REVUE"] as const;
+export type OfTimeVarianceOutcome = (typeof OF_TIME_VARIANCE_OUTCOMES)[number];
+
+export const OF_TIME_VARIANCE_STATUTS = ["OUVERTE", "ACCEPTEE", "REFUSEE", "CADUQUE"] as const;
+export type OfTimeVarianceStatut = (typeof OF_TIME_VARIANCE_STATUTS)[number];
+
+/**
+ * Causes d'une dérive. Volontairement identiques aux motifs de recalage d'AR :
+ * une dérive qui finit par décaler un engagement client doit pouvoir porter la
+ * même cause d'un bout à l'autre de la chaîne, sans retraduction.
+ */
+export const OF_TIME_VARIANCE_CAUSES = [
+  "DERIVE_TEMPS_USINAGE",
+  "MACHINE",
+  "MATIERE",
+  "QUALITE_REPRISE",
+  "SOUS_TRAITANCE",
+  "MODIFICATION_TECHNIQUE",
+  "CAPACITE",
+  "PRIORITE",
+  "AUTRE",
+] as const;
+export type OfTimeVarianceCause = (typeof OF_TIME_VARIANCE_CAUSES)[number];
+
+export const OF_TIME_VARIANCE_CAUSE_LABELS: Record<OfTimeVarianceCause, string> = {
+  DERIVE_TEMPS_USINAGE: "Dérive temps d'usinage",
+  MACHINE: "Machine",
+  MATIERE: "Matière",
+  QUALITE_REPRISE: "Qualité / reprise",
+  SOUS_TRAITANCE: "Sous-traitance",
+  MODIFICATION_TECHNIQUE: "Modification technique",
+  CAPACITE: "Capacité",
+  PRIORITE: "Priorité",
+  AUTRE: "Autre",
+};
+
+export function isOfTimeVarianceCause(value: unknown): value is OfTimeVarianceCause {
+  return typeof value === "string" && (OF_TIME_VARIANCE_CAUSES as readonly string[]).includes(value);
+}
+
+/**
+ * Arrondi à 2 décimales, demi-tour hors de zéro, avec correction de la
+ * représentation binaire.
+ *
+ * Indispensable ici : `(110 - 100) / 100 * 100` vaut `10.000000000000002` en
+ * IEEE 754. Comparé brut à `> 10`, ce cas — explicitement « rien » dans la règle
+ * métier — ouvrirait une proposition de replanification à chaque fois.
+ */
+export function roundPct(value: number): number {
+  if (!Number.isFinite(value)) return value;
+  const scaled = value * 100;
+  const corrected = Math.round(scaled * 1e9) / 1e9;
+  const sign = corrected < 0 ? -1 : 1;
+  return (sign * Math.round(Math.abs(corrected))) / 100;
+}
+
+export type OfTimeVarianceAssessment = {
+  /** `null` quand la référence est absente ou nulle. */
+  variationPct: number | null;
+  outcome: OfTimeVarianceOutcome;
+  reviewRequired: boolean;
+  reason: string;
+};
+
+/**
+ * Applique la règle de seuil.
+ *
+ * Seule une dérive **à la hausse** au-delà du seuil ouvre une proposition. Une
+ * baisse de temps libère de la charge et ne met aucun engagement en risque : elle
+ * est mesurée et consignée, mais elle ne déclenche pas de replanification.
+ */
+export function assessTimeVariance(args: {
+  referenceTime: number | null | undefined;
+  newTime: number;
+}): OfTimeVarianceAssessment {
+  const reference = args.referenceTime;
+  const next = args.newTime;
+
+  if (!Number.isFinite(next) || next < 0) {
+    throw new Error(`Temps de fabrication invalide : ${next}`);
+  }
+
+  if (reference === null || reference === undefined || !Number.isFinite(reference) || reference === 0) {
+    return {
+      variationPct: null,
+      outcome: "REVUE",
+      reviewRequired: true,
+      reason: "Temps de référence absent ou nul : revue obligatoire avant replanification.",
+    };
+  }
+
+  const variationPct = roundPct(((next - reference) / reference) * 100);
+
+  if (variationPct > OF_TIME_VARIANCE_THRESHOLD_PCT) {
+    return {
+      variationPct,
+      outcome: "REPLANIFICATION",
+      reviewRequired: false,
+      reason: `Dérive de ${formatPct(variationPct)} au-dessus du seuil de ${formatPct(OF_TIME_VARIANCE_THRESHOLD_PCT)}.`,
+    };
+  }
+
+  return {
+    variationPct,
+    outcome: "RIEN",
+    reviewRequired: false,
+    reason:
+      variationPct < 0
+        ? `Temps en baisse de ${formatPct(Math.abs(variationPct))} : aucune replanification requise.`
+        : `Dérive de ${formatPct(variationPct)} dans la tolérance de ${formatPct(OF_TIME_VARIANCE_THRESHOLD_PCT)}.`,
+  };
+}
+
+/** « 10,01 % » — virgule décimale française, deux décimales. */
+export function formatPct(value: number): string {
+  return `${value.toFixed(2).replace(".", ",")} %`;
+}
+
+// ---------------------------------------------------------------------------
+// Contexte d'impact figé avec la proposition
+// ---------------------------------------------------------------------------
+
+export type OfTimeVarianceMachine = {
+  machineId: string | null;
+  machineLabel: string | null;
+  family: OfPhaseFamily | null;
+  /** Écart de charge sur cette machine, en heures. */
+  deltaHeures: number;
+};
+
+export type OfTimeVarianceAffaire = {
+  affaireId: number;
+  affaireNumero: string | null;
+  clientId: string | null;
+  clientNom: string | null;
+  /** Date d'engagement en cours, au format ISO. */
+  delaiClient: string | null;
+};
+
+export type OfTimeVarianceImpact = {
+  /** Charge planifiée avant / après, en heures, sur le périmètre de l'OF. */
+  chargeAvantH: number;
+  chargeApresH: number;
+  deltaH: number;
+  /** Nombre d'opérations replanifiées par la simulation. */
+  operationsImpactees: number;
+};
+
+/**
+ * Simulation : ce que **deviendrait** le planning si la proposition était
+ * acceptée. Elle est calculée et stockée, jamais appliquée — le planning actif
+ * reste intact tant qu'une décision humaine n'a pas eu lieu.
+ */
+export type OfTimeVarianceSimulation = {
+  schema: "of-time-variance-simulation/1";
+  /** Décalage de fin d'OF induit, en jours ouvrés estimés. */
+  decalageFinJours: number | null;
+  dateFinAvant: string | null;
+  dateFinApres: string | null;
+  /** Engagements client menacés par le décalage. */
+  engagementsEnRisque: Array<{
+    affaireId: number;
+    delaiClient: string | null;
+    nouvelleDate: string | null;
+    depasse: boolean;
+  }>;
+};
+
+export type OfTimeVarianceProposal = {
+  ofId: number;
+  ofNumero: string;
+  revisionId: string;
+  revisionCode: string;
+  ofOperationId: string | null;
+  phase: number;
+  family: OfPhaseFamily | null;
+  referenceTime: number | null;
+  newTime: number;
+  variationPct: number | null;
+  outcome: OfTimeVarianceOutcome;
+  reviewRequired: boolean;
+  cause: OfTimeVarianceCause;
+  causeComment: string | null;
+  authorUserId: number | null;
+  impactCharge: OfTimeVarianceImpact;
+  machines: OfTimeVarianceMachine[];
+  affaires: OfTimeVarianceAffaire[];
+  simulation: OfTimeVarianceSimulation;
+};
+
+export type OfTimeVarianceBuildResult =
+  | { created: false; assessment: OfTimeVarianceAssessment }
+  | { created: true; assessment: OfTimeVarianceAssessment; proposal: OfTimeVarianceProposal };
+
+/**
+ * Construit la proposition quand la règle l'exige.
+ *
+ * `RIEN` ne produit aucune proposition : consigner une non-dérive noierait les
+ * vraies alertes du planificateur.
+ */
+export function buildTimeVarianceProposal(args: {
+  ofId: number;
+  ofNumero: string;
+  revisionId: string;
+  revisionCode: string;
+  ofOperationId: string | null;
+  phase: number;
+  family: OfPhaseFamily | null;
+  referenceTime: number | null;
+  newTime: number;
+  cause: OfTimeVarianceCause;
+  causeComment: string | null;
+  authorUserId: number | null;
+  impactCharge: OfTimeVarianceImpact;
+  machines: OfTimeVarianceMachine[];
+  affaires: OfTimeVarianceAffaire[];
+  simulation: OfTimeVarianceSimulation;
+}): OfTimeVarianceBuildResult {
+  const assessment = assessTimeVariance({
+    referenceTime: args.referenceTime,
+    newTime: args.newTime,
+  });
+
+  if (assessment.outcome === "RIEN") return { created: false, assessment };
+
+  // « Autre » n'est pas une cause tant qu'elle n'est pas écrite.
+  if (args.cause === "AUTRE" && !(args.causeComment ?? "").trim()) {
+    throw new Error("La cause « Autre » exige un commentaire.");
+  }
+
+  return {
+    created: true,
+    assessment,
+    proposal: {
+      ...args,
+      referenceTime: args.referenceTime ?? null,
+      variationPct: assessment.variationPct,
+      outcome: assessment.outcome,
+      reviewRequired: assessment.reviewRequired,
+      causeComment: (args.causeComment ?? "").trim() || null,
+    },
+  };
+}
+
+/**
+ * Libellé court destiné à la notification du planificateur.
+ *
+ * Le référentiel est facultatif : une notification ne doit pas échouer parce que
+ * la table des familles n'a pas été jointe. Sans lui, `familyLabel` retombe sur
+ * le libellé de repli, puis sur le code — jamais sur `undefined`.
+ */
+export function describeProposal(
+  proposal: OfTimeVarianceProposal,
+  referential?: readonly MachineFamilyRef[]
+): string {
+  const family = proposal.family ? ` (${familyLabel(proposal.family, referential)})` : "";
+  const phase = `phase ${proposal.phase}${family}`;
+
+  if (proposal.outcome === "REVUE") {
+    return `${proposal.ofNumero} ${proposal.revisionCode} — ${phase} : temps de référence absent, revue obligatoire.`;
+  }
+  return `${proposal.ofNumero} ${proposal.revisionCode} — ${phase} : dérive de ${formatPct(
+    proposal.variationPct ?? 0
+  )}, replanification proposée.`;
+}

--- a/src/module/production/middlewares/of-versioning-authorization.middleware.ts
+++ b/src/module/production/middlewares/of-versioning-authorization.middleware.ts
@@ -1,0 +1,59 @@
+// Gardes d'autorisation du chantier #370.
+//
+// Refus par défaut : être authentifié n'accorde aucun droit. La garde est rejouée
+// à chaque requête — masquer un bouton côté UI n'a jamais été une autorisation.
+
+import type { RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import { roleHasOfCapability, type OfCapability } from "../domain/of-rbac";
+
+export function requireOfCapability(capability: OfCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (!req.user || typeof req.user.id !== "number") {
+      next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
+      return;
+    }
+    if (!roleHasOfCapability(req.user.role, capability)) {
+      next(
+        new HttpError(
+          403,
+          "OF_CAPABILITY_REQUIRED",
+          `La capacité OF '${capability}' est requise pour cette action.`
+        )
+      );
+      return;
+    }
+    next();
+  };
+}
+
+/**
+ * Toute commande à effet exige une clé d'idempotence.
+ *
+ * Sans elle, un double-clic sur « Émettre » produirait deux documents officiels,
+ * et un retry réseau deux dossiers d'AR. Le contrat est donc refusé en amont
+ * plutôt que deviné.
+ */
+export const requireIdempotencyKey: RequestHandler = (req, _res, next) => {
+  const raw = req.headers["idempotency-key"];
+  const key = typeof raw === "string" ? raw.trim() : "";
+  if (key.length < 8 || key.length > 200) {
+    next(
+      new HttpError(
+        400,
+        "IDEMPOTENCY_KEY_REQUIRED",
+        "L'en-tête Idempotency-Key est requis (8 à 200 caractères) pour cette action."
+      )
+    );
+    return;
+  }
+  next();
+};
+
+/** Clé d'idempotence normalisée, ou `null` quand la route ne l'exige pas. */
+export function idempotencyKeyOf(req: { headers: Record<string, unknown> }): string | null {
+  const raw = req.headers["idempotency-key"];
+  const key = typeof raw === "string" ? raw.trim() : "";
+  return key.length ? key : null;
+}

--- a/src/module/production/repository/of-versioning.repository.ts
+++ b/src/module/production/repository/of-versioning.repository.ts
@@ -1,0 +1,1392 @@
+// Accès données du chantier « OF, versioning, replanification, AR, document » (#370).
+//
+// Toute écriture passe par `withOfTransaction` : révision, proposition, version de
+// planning, dossier d'AR et document sont écrits avec leur audit dans la MÊME
+// transaction. Un audit écrit après coup, hors transaction, mentirait dès le
+// premier rollback.
+//
+// ANTI-IDOR — principe appliqué partout ici : une ressource imbriquée n'est jamais
+// lue par son seul identifiant. Elle est lue par (identifiant, of_id), l'OF venant
+// du chemin de la requête et ayant déjà été autorisé. Un UUID de révision deviné
+// sur un autre OF ne renvoie donc rien du tout, au lieu de renvoyer la donnée d'un
+// autre dossier.
+
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import type { MachineFamilyRef, OfRevisionOperation } from "../domain/of-revision";
+import type { OfPlanningPayload, OfPlanningStatut } from "../domain/of-planning-version";
+import type { NotificationRoutingRule } from "../../../shared/notifications/routing";
+
+export type DbQueryer = Pick<PoolClient, "query">;
+
+/** Transaction bornée : commit au succès, rollback à la moindre exception. */
+export async function withOfTransaction<T>(fn: (tx: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      // Le rollback peut échouer si la connexion est déjà tombée : l'erreur
+      // d'origine reste la seule intéressante.
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Référentiel des familles machine                                           */
+/* -------------------------------------------------------------------------- */
+
+export async function readMachineFamilies(tx: DbQueryer = pool): Promise<MachineFamilyRef[]> {
+  const res = await tx.query(
+    `SELECT code, libelle, programme_requis, ordre_affichage, actif
+       FROM public.production_machine_families
+      ORDER BY ordre_affichage, code`
+  );
+  return res.rows.map((row) => ({
+    code: String(row.code),
+    libelle: String(row.libelle),
+    programmeRequis: Boolean(row.programme_requis),
+    ordreAffichage: Number(row.ordre_affichage),
+    actif: Boolean(row.actif),
+  }));
+}
+
+/* -------------------------------------------------------------------------- */
+/* En-tête d'OF — porte d'entrée de toute autorisation                         */
+/* -------------------------------------------------------------------------- */
+
+export type OfHeaderRow = {
+  of_id: number;
+  /** UUID immuable de l'OF, distinct du numéro métier. */
+  of_uuid: string | null;
+  numero: string;
+  statut: string;
+  quantite_lancee: number;
+  affaire_id: number | null;
+  commande_id: number | null;
+  commande_ligne_id: number | null;
+  client_id: string | null;
+  client_nom: string | null;
+  piece_technique_id: string | null;
+  piece_reference: string | null;
+  piece_designation: string | null;
+  piece_indice: string | null;
+  gamme_id: string | null;
+  gamme_code: string | null;
+  gamme_version: string | null;
+  commande_numero: string | null;
+  production_group_id: string | null;
+  date_fin_prevue: string | null;
+};
+
+/**
+ * Lit l'en-tête d'un OF, ou lève 404.
+ *
+ * C'est la seule fonction par laquelle un OF entre dans ce module : elle est le
+ * point unique où un périmètre s'appliquerait.
+ *
+ * PÉRIMÈTRE SITE / ATELIER — état réel du modèle au 2026-07-29 : il n'existe
+ * AUCUNE dimension de site dans le schéma. `users` ne porte ni site, ni atelier,
+ * ni périmètre ; `production_group` est un regroupement pièce/client (0 ligne) et
+ * non un site. Filtrer sur une colonne inexistante donnerait l'illusion d'une
+ * cloison. Le périmètre réellement applicable et appliqué est donc l'isolation
+ * INTER-OF (anti-IDOR) : voir les lectures `(id, of_id)` de ce fichier. Le jour où
+ * le modèle portera un site, c'est ici — et ici seulement — qu'il se branche.
+ */
+export async function readOfHeader(ofId: number, tx: DbQueryer = pool): Promise<OfHeaderRow> {
+  const res = await tx.query(
+    // La gamme applicable se joint par la VERSION de pièce technique, pas par la
+    // pièce : deux indices d'une même pièce ont deux gammes distinctes, et
+    // joindre sur la pièce en ramènerait une au hasard.
+    `SELECT o.id::int                        AS of_id,
+            o.id::text                       AS of_uuid,
+            o.numero,
+            o.statut::text                   AS statut,
+            o.quantite_lancee::float8        AS quantite_lancee,
+            o.affaire_id::int                AS affaire_id,
+            o.commande_id::int               AS commande_id,
+            o.commande_ligne_id::int         AS commande_ligne_id,
+            o.client_id::text                AS client_id,
+            c.company_name                   AS client_nom,
+            o.piece_technique_id::text       AS piece_technique_id,
+            COALESCE(ptv.plan_reference, pt.code_piece) AS piece_reference,
+            COALESCE(pt.designation, pt.name_piece)     AS piece_designation,
+            ptv.indice                       AS piece_indice,
+            g.id::text                       AS gamme_id,
+            COALESCE(g.code, g.nom)          AS gamme_code,
+            COALESCE(ptv.version_interne::text, ptv.indice) AS gamme_version,
+            cc.numero                        AS commande_numero,
+            o.production_group_id::text      AS production_group_id,
+            o.date_fin_prevue::text          AS date_fin_prevue
+       FROM public.ordres_fabrication o
+       LEFT JOIN public.clients c            ON c.client_id = o.client_id
+       LEFT JOIN public.pieces_techniques pt ON pt.id = o.piece_technique_id
+       LEFT JOIN public.piece_technique_versions ptv ON ptv.id = o.piece_technique_version_id
+       LEFT JOIN public.gammes g
+              ON g.piece_technique_version_id = o.piece_technique_version_id
+             AND g.is_current = true
+       LEFT JOIN public.commande_client cc   ON cc.id = o.commande_id
+      WHERE o.id = $1`,
+    [ofId]
+  );
+
+  const row = res.rows[0];
+  if (!row) {
+    throw new HttpError(404, "OF_NOT_FOUND", "Ordre de fabrication introuvable.");
+  }
+  return row as OfHeaderRow;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Révisions                                                                  */
+/* -------------------------------------------------------------------------- */
+
+export type OfRevisionRow = {
+  id: string;
+  of_id: number;
+  revision_rank: number;
+  revision_code: string;
+  statut: string;
+  snapshot: unknown;
+  snapshot_sha256: string;
+  diff: unknown;
+  motif: string | null;
+  author_user_id: number | null;
+  author_label: string | null;
+  created_at: string;
+  activated_at: string | null;
+  superseded_at: string | null;
+  superseded_by: string | null;
+};
+
+const REVISION_SELECT = `
+  SELECT r.id::text            AS id,
+         r.of_id::int          AS of_id,
+         r.revision_rank::int  AS revision_rank,
+         r.revision_code,
+         r.statut,
+         r.snapshot,
+         r.snapshot_sha256,
+         r.diff,
+         r.motif,
+         r.author_user_id::int AS author_user_id,
+         u.username            AS author_label,
+         r.created_at,
+         r.activated_at,
+         r.superseded_at,
+         r.superseded_by::text AS superseded_by
+    FROM public.of_revisions r
+    LEFT JOIN public.users u ON u.id = r.author_user_id`;
+
+export async function listRevisions(ofId: number, tx: DbQueryer = pool): Promise<OfRevisionRow[]> {
+  const res = await tx.query(`${REVISION_SELECT} WHERE r.of_id = $1 ORDER BY r.revision_rank DESC`, [ofId]);
+  return res.rows as OfRevisionRow[];
+}
+
+/** Lecture par (révision, OF) — un id d'une autre affaire ne renvoie rien. */
+export async function getRevision(
+  ofId: number,
+  revisionId: string,
+  tx: DbQueryer = pool
+): Promise<OfRevisionRow | null> {
+  const res = await tx.query(`${REVISION_SELECT} WHERE r.id = $1::uuid AND r.of_id = $2`, [revisionId, ofId]);
+  return (res.rows[0] as OfRevisionRow | undefined) ?? null;
+}
+
+export async function getActiveRevision(
+  ofId: number,
+  tx: DbQueryer = pool
+): Promise<OfRevisionRow | null> {
+  const res = await tx.query(`${REVISION_SELECT} WHERE r.of_id = $1 AND r.statut = 'ACTIVE'`, [ofId]);
+  return (res.rows[0] as OfRevisionRow | undefined) ?? null;
+}
+
+/**
+ * Verrouille l'OF pour sérialiser deux révisions concurrentes.
+ *
+ * Sans ce verrou, deux requêtes simultanées liraient le même rang courant et
+ * tenteraient toutes deux d'écrire la même `R01`. L'index unique partiel
+ * `of_revisions_active_uq` en refuserait une, mais avec une erreur de contrainte
+ * illisible ; le verrou transforme la course en attente puis en conflit explicite.
+ */
+export async function lockOf(tx: DbQueryer, ofId: number): Promise<void> {
+  await tx.query(`SELECT pg_advisory_xact_lock(hashtext($1))`, [`of_revision:${ofId}`]);
+}
+
+export async function insertRevision(
+  tx: DbQueryer,
+  input: {
+    ofId: number;
+    rank: number;
+    code: string;
+    snapshot: unknown;
+    snapshotSha256: string;
+    diff: unknown;
+    motif: string | null;
+    authorUserId: number | null;
+  }
+): Promise<OfRevisionRow> {
+  // La précédente devient OBSOLETE avant que la nouvelle ne devienne ACTIVE :
+  // l'index unique partiel n'autorise qu'une seule ACTIVE à la fois.
+  const previous = await tx.query(
+    `UPDATE public.of_revisions
+        SET statut = 'OBSOLETE', superseded_at = now()
+      WHERE of_id = $1 AND statut = 'ACTIVE'
+      RETURNING id::text AS id`,
+    [input.ofId]
+  );
+
+  const res = await tx.query(
+    `INSERT INTO public.of_revisions
+       (of_id, revision_rank, revision_code, statut, snapshot, snapshot_sha256, diff, motif,
+        author_user_id, activated_at)
+     VALUES ($1, $2, $3, 'ACTIVE', $4::jsonb, $5, $6::jsonb, $7, $8, now())
+     RETURNING id::text AS id`,
+    [
+      input.ofId,
+      input.rank,
+      input.code,
+      JSON.stringify(input.snapshot),
+      input.snapshotSha256,
+      input.diff === undefined ? null : JSON.stringify(input.diff),
+      input.motif,
+      input.authorUserId,
+    ]
+  );
+
+  const newId = String(res.rows[0].id);
+  if (previous.rows[0]) {
+    await tx.query(`UPDATE public.of_revisions SET superseded_by = $2::uuid WHERE id = $1::uuid`, [
+      String(previous.rows[0].id),
+      newId,
+    ]);
+  }
+
+  const created = await getRevision(input.ofId, newId, tx);
+  if (!created) throw new HttpError(500, "OF_REVISION_CREATE", "Révision introuvable après création.");
+  return created;
+}
+
+/* -------------------------------------------------------------------------- */
+/* Opérations d'une révision                                                  */
+/* -------------------------------------------------------------------------- */
+
+export type OfOperationRow = OfRevisionOperation & { id: string; revisionId: string };
+
+export async function listOperations(
+  ofId: number,
+  revisionId: string,
+  tx: DbQueryer = pool
+): Promise<OfOperationRow[]> {
+  const res = await tx.query(
+    `SELECT op.id::text                            AS id,
+            op.revision_id::text                   AS revision_id,
+            op.phase::int                          AS phase,
+            op.designation,
+            op.machine_family_code                 AS family,
+            op.machine_id::text                    AS machine_id,
+            COALESCE(m.display_name, m.name, m.code) AS machine_label,
+            op.numero_programme                    AS programme,
+            op.tf_unit::float8                     AS temps_unitaire,
+            op.tp::float8                          AS preparation,
+            op.qte::float8                         AS quantite_base,
+            op.coef::float8                        AS coefficient,
+            op.cf_code_snapshot                    AS cf_code,
+            op.cf_rate_id::text                    AS cf_rate_id,
+            op.hourly_rate_applied::float8         AS taux_horaire,
+            op.hourly_rate_source                  AS taux_horaire_source,
+            op.hourly_rate_effective_at::text      AS taux_horaire_effective_at
+       FROM public.of_operations op
+       LEFT JOIN public.machines m ON m.id = op.machine_id
+      WHERE op.of_id = $1 AND op.revision_id = $2::uuid
+      ORDER BY op.phase`,
+    [ofId, revisionId]
+  );
+
+  return res.rows.map((row) => ({
+    id: String(row.id),
+    revisionId: String(row.revision_id),
+    phase: Number(row.phase),
+    designation: String(row.designation),
+    family: row.family === null ? null : String(row.family),
+    machineId: row.machine_id === null ? null : String(row.machine_id),
+    machineLabel: row.machine_label === null ? null : String(row.machine_label),
+    programme: row.programme === null ? null : String(row.programme),
+    tempsUnitaire: Number(row.temps_unitaire ?? 0),
+    preparation: Number(row.preparation ?? 0),
+    quantiteBase: Number(row.quantite_base ?? 0),
+    coefficient: Number(row.coefficient ?? 1),
+    cfCode: row.cf_code === null ? null : String(row.cf_code),
+    cfRateId: row.cf_rate_id === null ? null : String(row.cf_rate_id),
+    tauxHoraire: row.taux_horaire === null ? null : Number(row.taux_horaire),
+    tauxHoraireSource: row.taux_horaire_source === null ? null : String(row.taux_horaire_source),
+    tauxHoraireEffectiveAt:
+      row.taux_horaire_effective_at === null ? null : String(row.taux_horaire_effective_at),
+  }));
+}
+
+/**
+ * Recopie les opérations d'une révision vers une autre.
+ *
+ * Les lignes sont INSÉRÉES, jamais mises à jour : c'est ce qui laisse les
+ * pointages et les VISA de la révision précédente attachés à leurs propres
+ * lignes. L'unicité `(of_id, revision_id, phase)` rend cette coexistence
+ * possible ; avec l'ancienne clé `(of_id, phase)`, cet INSERT échouerait.
+ */
+export async function copyOperationsToRevision(
+  tx: DbQueryer,
+  args: { ofId: number; fromRevisionId: string; toRevisionId: string }
+): Promise<number> {
+  const res = await tx.query(
+    `INSERT INTO public.of_operations (
+        of_id, revision_id, phase, designation, cf_id, poste_id, machine_id,
+        hourly_rate_applied, tp, tf_unit, qte, coef,
+        temps_total_planned, temps_total_real, status,
+        source_piece_operation_id, numero_programme, machine_family_code,
+        cf_code_snapshot, cf_rate_id, temps_fabrication_planned,
+        hourly_rate_source, hourly_rate_effective_at)
+     SELECT of_id, $3::uuid, phase, designation, cf_id, poste_id, machine_id,
+            hourly_rate_applied, tp, tf_unit, qte, coef,
+            temps_total_planned, 0, 'A_FAIRE',
+            source_piece_operation_id, numero_programme, machine_family_code,
+            cf_code_snapshot, cf_rate_id, temps_fabrication_planned,
+            hourly_rate_source, hourly_rate_effective_at
+       FROM public.of_operations
+      WHERE of_id = $1 AND revision_id = $2::uuid`,
+    [args.ofId, args.fromRevisionId, args.toRevisionId]
+  );
+  return res.rowCount ?? 0;
+}
+
+/** Applique les modifications de phases sur la NOUVELLE révision uniquement. */
+export async function updateOperationOnRevision(
+  tx: DbQueryer,
+  args: {
+    ofId: number;
+    revisionId: string;
+    phase: number;
+    designation?: string;
+    family?: string | null;
+    machineId?: string | null;
+    programme?: string | null;
+    tempsUnitaire?: number;
+    preparation?: number;
+    quantiteBase?: number;
+    coefficient?: number;
+  }
+): Promise<void> {
+  const sets: string[] = [];
+  const values: unknown[] = [args.ofId, args.revisionId, args.phase];
+  const push = (fragment: string, value: unknown) => {
+    values.push(value);
+    sets.push(`${fragment} = $${values.length}`);
+  };
+
+  if (args.designation !== undefined) push("designation", args.designation);
+  if (args.family !== undefined) push("machine_family_code", args.family);
+  if (args.machineId !== undefined) push("machine_id", args.machineId);
+  if (args.programme !== undefined) push("numero_programme", args.programme);
+  if (args.tempsUnitaire !== undefined) push("tf_unit", args.tempsUnitaire);
+  if (args.preparation !== undefined) push("tp", args.preparation);
+  if (args.quantiteBase !== undefined) push("qte", args.quantiteBase);
+  if (args.coefficient !== undefined) push("coef", args.coefficient);
+
+  if (!sets.length) return;
+
+  // Les temps dérivés sont recalculés en base pour rester cohérents avec la
+  // formule métier, même si l'appelant ne les a pas fournis.
+  const res = await tx.query(
+    `UPDATE public.of_operations
+        SET ${sets.join(", ")},
+            temps_fabrication_planned = tf_unit * qte * coef,
+            temps_total_planned = tp + tf_unit * qte * coef,
+            updated_at = now()
+      WHERE of_id = $1 AND revision_id = $2::uuid AND phase = $3`,
+    values
+  );
+
+  if (!res.rowCount) {
+    throw new HttpError(404, "OF_PHASE_NOT_FOUND", `Phase ${args.phase} absente de cette révision.`);
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* VISA de phase                                                              */
+/* -------------------------------------------------------------------------- */
+
+export type OfVisaRow = {
+  phase: number;
+  statut: string;
+  operateur: string | null;
+  initials: string | null;
+  visa_at: string | null;
+  quantite_bonne: number | null;
+  quantite_rebut: number | null;
+  motif_rebut: string | null;
+  controle_initials: string | null;
+  comment: string | null;
+  revoked_at: string | null;
+};
+
+/** VISA vivants (non révoqués) de la révision, indexés par phase. */
+export async function listVisas(
+  ofId: number,
+  revisionId: string,
+  tx: DbQueryer = pool
+): Promise<OfVisaRow[]> {
+  const res = await tx.query(
+    `SELECT op.phase::int                 AS phase,
+            v.statut,
+            u.username                    AS operateur,
+            v.initials,
+            v.visa_at,
+            v.quantite_bonne::float8      AS quantite_bonne,
+            v.quantite_rebut::float8      AS quantite_rebut,
+            v.motif_rebut,
+            v.controle_initials,
+            v.comment,
+            v.revoked_at
+       FROM public.of_operation_visas v
+       JOIN public.of_operations op ON op.id = v.of_operation_id
+       LEFT JOIN public.users u ON u.id = v.user_id
+      WHERE op.of_id = $1 AND op.revision_id = $2::uuid AND v.revoked_at IS NULL
+      ORDER BY op.phase`,
+    [ofId, revisionId]
+  );
+  return res.rows as OfVisaRow[];
+}
+
+export async function insertVisa(
+  tx: DbQueryer,
+  input: {
+    ofId: number;
+    revisionId: string;
+    phase: number;
+    userId: number | null;
+    initials: string;
+    statut: string;
+    quantiteBonne: number | null;
+    quantiteRebut: number | null;
+    motifRebut: string | null;
+    controleUserId: number | null;
+    controleInitials: string | null;
+    comment: string | null;
+  }
+): Promise<string> {
+  // L'opération est résolue par (of_id, revision_id, phase) : un VISA ne peut pas
+  // atterrir sur la phase d'un autre OF ni d'une autre révision.
+  const op = await tx.query(
+    `SELECT id::text AS id FROM public.of_operations
+      WHERE of_id = $1 AND revision_id = $2::uuid AND phase = $3`,
+    [input.ofId, input.revisionId, input.phase]
+  );
+  if (!op.rows[0]) {
+    throw new HttpError(404, "OF_PHASE_NOT_FOUND", `Phase ${input.phase} absente de cette révision.`);
+  }
+
+  const res = await tx.query(
+    `INSERT INTO public.of_operation_visas
+       (of_operation_id, user_id, initials, visa_at, comment, statut,
+        quantite_bonne, quantite_rebut, motif_rebut,
+        controle_user_id, controle_initials, controle_at)
+     VALUES ($1::uuid, $2, $3, now(), $4, $5, $6, $7, $8, $9, $10,
+             CASE WHEN $10 IS NULL THEN NULL ELSE now() END)
+     RETURNING id::text AS id`,
+    [
+      String(op.rows[0].id),
+      input.userId,
+      input.initials,
+      input.comment,
+      input.statut,
+      input.quantiteBonne,
+      input.quantiteRebut,
+      input.motifRebut,
+      input.controleUserId,
+      input.controleInitials,
+    ]
+  );
+  return String(res.rows[0].id);
+}
+
+/* -------------------------------------------------------------------------- */
+/* Propositions de replanification                                            */
+/* -------------------------------------------------------------------------- */
+
+export type OfProposalRow = {
+  id: string;
+  of_id: number;
+  revision_id: string;
+  phase: number;
+  reference_time: number | null;
+  new_time: number;
+  variation_pct: number | null;
+  outcome: string;
+  review_required: boolean;
+  cause: string;
+  cause_comment: string | null;
+  statut: string;
+  impact_charge: unknown;
+  machines: unknown;
+  affaires: unknown;
+  simulation: unknown;
+  author_user_id: number | null;
+  created_at: string;
+  resolved_at: string | null;
+  resolution_comment: string | null;
+};
+
+export async function listProposals(
+  ofId: number,
+  tx: DbQueryer = pool
+): Promise<OfProposalRow[]> {
+  const res = await tx.query(
+    `SELECT id::text AS id, of_id::int AS of_id, revision_id::text AS revision_id, phase::int AS phase,
+            reference_time::float8 AS reference_time, new_time::float8 AS new_time,
+            variation_pct::float8 AS variation_pct, outcome, review_required, cause, cause_comment,
+            statut, impact_charge, machines, affaires, simulation,
+            author_user_id::int AS author_user_id, created_at, resolved_at, resolution_comment
+       FROM public.of_time_variance_proposals
+      WHERE of_id = $1
+      ORDER BY created_at DESC`,
+    [ofId]
+  );
+  return res.rows as OfProposalRow[];
+}
+
+export async function findProposalByIdempotencyKey(
+  tx: DbQueryer,
+  key: string
+): Promise<OfProposalRow | null> {
+  const res = await tx.query(
+    `SELECT id::text AS id, of_id::int AS of_id, revision_id::text AS revision_id, phase::int AS phase,
+            reference_time::float8 AS reference_time, new_time::float8 AS new_time,
+            variation_pct::float8 AS variation_pct, outcome, review_required, cause, cause_comment,
+            statut, impact_charge, machines, affaires, simulation,
+            author_user_id::int AS author_user_id, created_at, resolved_at, resolution_comment
+       FROM public.of_time_variance_proposals
+      WHERE idempotency_key = $1`,
+    [key]
+  );
+  return (res.rows[0] as OfProposalRow | undefined) ?? null;
+}
+
+export async function insertProposal(
+  tx: DbQueryer,
+  input: {
+    ofId: number;
+    revisionId: string;
+    ofOperationId: string | null;
+    phase: number;
+    referenceTime: number | null;
+    newTime: number;
+    variationPct: number | null;
+    outcome: string;
+    reviewRequired: boolean;
+    cause: string;
+    causeComment: string | null;
+    impactCharge: unknown;
+    machines: unknown;
+    affaires: unknown;
+    simulation: unknown;
+    authorUserId: number | null;
+    idempotencyKey: string | null;
+  }
+): Promise<string> {
+  const res = await tx.query(
+    `INSERT INTO public.of_time_variance_proposals
+       (of_id, revision_id, of_operation_id, phase, reference_time, new_time, variation_pct,
+        outcome, review_required, cause, cause_comment, impact_charge, machines, affaires,
+        simulation, author_user_id, idempotency_key)
+     VALUES ($1, $2::uuid, $3::uuid, $4, $5, $6, $7, $8, $9, $10, $11,
+             $12::jsonb, $13::jsonb, $14::jsonb, $15::jsonb, $16, $17)
+     RETURNING id::text AS id`,
+    [
+      input.ofId,
+      input.revisionId,
+      input.ofOperationId,
+      input.phase,
+      input.referenceTime,
+      input.newTime,
+      input.variationPct,
+      input.outcome,
+      input.reviewRequired,
+      input.cause,
+      input.causeComment,
+      JSON.stringify(input.impactCharge),
+      JSON.stringify(input.machines),
+      JSON.stringify(input.affaires),
+      JSON.stringify(input.simulation),
+      input.authorUserId,
+      input.idempotencyKey,
+    ]
+  );
+  return String(res.rows[0].id);
+}
+
+export async function resolveProposal(
+  tx: DbQueryer,
+  args: { ofId: number; proposalId: string; statut: string; userId: number | null; comment: string | null }
+): Promise<void> {
+  const res = await tx.query(
+    `UPDATE public.of_time_variance_proposals
+        SET statut = $3, resolved_at = now(), resolved_by = $4, resolution_comment = $5
+      WHERE id = $2::uuid AND of_id = $1 AND statut = 'OUVERTE'`,
+    [args.ofId, args.proposalId, args.statut, args.userId, args.comment]
+  );
+  if (!res.rowCount) {
+    throw new HttpError(
+      409,
+      "OF_PROPOSAL_NOT_OPEN",
+      "Proposition introuvable sur cet OF, ou déjà tranchée."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Versions de planning                                                       */
+/* -------------------------------------------------------------------------- */
+
+export type OfPlanningVersionRow = {
+  id: string;
+  of_id: number;
+  revision_id: string | null;
+  version_rank: number;
+  statut: OfPlanningStatut;
+  payload: OfPlanningPayload;
+  payload_sha256: string;
+  base_version_id: string | null;
+  comparison: unknown;
+  client_impact: string;
+  source_proposal_id: string | null;
+  author_user_id: number | null;
+  created_at: string;
+  submitted_at: string | null;
+  decided_at: string | null;
+  decision_comment: string | null;
+  activated_at: string | null;
+};
+
+const PLANNING_SELECT = `
+  SELECT id::text                 AS id,
+         of_id::int               AS of_id,
+         revision_id::text        AS revision_id,
+         version_rank::int        AS version_rank,
+         statut,
+         payload,
+         payload_sha256,
+         base_version_id::text    AS base_version_id,
+         comparison,
+         client_impact,
+         source_proposal_id::text AS source_proposal_id,
+         author_user_id::int      AS author_user_id,
+         created_at, submitted_at, decided_at, decision_comment, activated_at
+    FROM public.of_planning_versions`;
+
+export async function listPlanningVersions(
+  ofId: number,
+  tx: DbQueryer = pool
+): Promise<OfPlanningVersionRow[]> {
+  const res = await tx.query(`${PLANNING_SELECT} WHERE of_id = $1 ORDER BY version_rank DESC`, [ofId]);
+  return res.rows as OfPlanningVersionRow[];
+}
+
+export async function getPlanningVersion(
+  ofId: number,
+  versionId: string,
+  tx: DbQueryer = pool
+): Promise<OfPlanningVersionRow | null> {
+  const res = await tx.query(`${PLANNING_SELECT} WHERE id = $1::uuid AND of_id = $2`, [versionId, ofId]);
+  return (res.rows[0] as OfPlanningVersionRow | undefined) ?? null;
+}
+
+export async function getPlanningByStatut(
+  ofId: number,
+  statuts: readonly OfPlanningStatut[],
+  tx: DbQueryer = pool
+): Promise<OfPlanningVersionRow | null> {
+  const res = await tx.query(
+    `${PLANNING_SELECT} WHERE of_id = $1 AND statut = ANY($2::text[]) ORDER BY version_rank DESC LIMIT 1`,
+    [ofId, statuts as unknown as string[]]
+  );
+  return (res.rows[0] as OfPlanningVersionRow | undefined) ?? null;
+}
+
+export async function nextPlanningRank(tx: DbQueryer, ofId: number): Promise<number> {
+  const res = await tx.query(
+    `SELECT COALESCE(MAX(version_rank), -1) + 1 AS next FROM public.of_planning_versions WHERE of_id = $1`,
+    [ofId]
+  );
+  return Number(res.rows[0].next);
+}
+
+export async function findPlanningByIdempotencyKey(
+  tx: DbQueryer,
+  key: string
+): Promise<OfPlanningVersionRow | null> {
+  const res = await tx.query(`${PLANNING_SELECT} WHERE idempotency_key = $1`, [key]);
+  return (res.rows[0] as OfPlanningVersionRow | undefined) ?? null;
+}
+
+export async function insertPlanningVersion(
+  tx: DbQueryer,
+  input: {
+    ofId: number;
+    revisionId: string | null;
+    rank: number;
+    statut: OfPlanningStatut;
+    payload: OfPlanningPayload;
+    payloadSha256: string;
+    baseVersionId: string | null;
+    comparison: unknown;
+    clientImpact: string;
+    sourceProposalId: string | null;
+    authorUserId: number | null;
+    idempotencyKey: string | null;
+  }
+): Promise<OfPlanningVersionRow> {
+  const res = await tx.query(
+    `INSERT INTO public.of_planning_versions
+       (of_id, revision_id, version_rank, statut, payload, payload_sha256, base_version_id,
+        comparison, client_impact, source_proposal_id, author_user_id, idempotency_key,
+        activated_at)
+     VALUES ($1, $2::uuid, $3, $4, $5::jsonb, $6, $7::uuid, $8::jsonb, $9, $10::uuid, $11, $12,
+             CASE WHEN $4 = 'ACTIF' THEN now() ELSE NULL END)
+     RETURNING id::text AS id`,
+    [
+      input.ofId,
+      input.revisionId,
+      input.rank,
+      input.statut,
+      JSON.stringify(input.payload),
+      input.payloadSha256,
+      input.baseVersionId,
+      input.comparison === undefined ? null : JSON.stringify(input.comparison),
+      input.clientImpact,
+      input.sourceProposalId,
+      input.authorUserId,
+      input.idempotencyKey,
+    ]
+  );
+
+  const created = await getPlanningVersion(input.ofId, String(res.rows[0].id), tx);
+  if (!created) throw new HttpError(500, "OF_PLANNING_CREATE", "Version de planning introuvable après création.");
+  return created;
+}
+
+/**
+ * Change le statut d'une version de planning, avec verrou optimiste.
+ *
+ * `expectedStatut` est la garde : la ligne n'est mise à jour que si elle est
+ * toujours dans l'état que l'appelant croyait. Deux validations simultanées ne
+ * peuvent donc pas aboutir toutes les deux — la seconde reçoit un 409 explicite
+ * au lieu d'écraser la décision de la première.
+ */
+export async function transitionPlanningVersion(
+  tx: DbQueryer,
+  args: {
+    ofId: number;
+    versionId: string;
+    expectedStatut: OfPlanningStatut;
+    nextStatut: OfPlanningStatut;
+    userId: number | null;
+    comment?: string | null;
+  }
+): Promise<void> {
+  const stamps: string[] = [];
+  if (args.nextStatut === "SOUMIS") stamps.push("submitted_at = now()", `submitted_by = $5`);
+  if (args.nextStatut === "VALIDE" || args.nextStatut === "REFUSE") {
+    stamps.push("decided_at = now()", `decided_by = $5`, `decision_comment = $6`);
+  }
+  if (args.nextStatut === "ACTIF") stamps.push("activated_at = now()");
+  if (args.nextStatut === "SUPERSEDE") stamps.push("superseded_at = now()");
+
+  const res = await tx.query(
+    `UPDATE public.of_planning_versions
+        SET statut = $4${stamps.length ? ", " + stamps.join(", ") : ""}
+      WHERE id = $2::uuid AND of_id = $1 AND statut = $3`,
+    [args.ofId, args.versionId, args.expectedStatut, args.nextStatut, args.userId, args.comment ?? null]
+  );
+
+  if (!res.rowCount) {
+    throw new HttpError(
+      409,
+      "OF_PLANNING_CONFLICT",
+      `La version de planning n'est plus dans l'état « ${args.expectedStatut} » : elle a été modifiée entre-temps.`
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Dossiers d'AR à recaler                                                    */
+/* -------------------------------------------------------------------------- */
+
+export type ArRecalageRow = {
+  id: string;
+  client_id: string | null;
+  client_nom: string | null;
+  commande_id: number | null;
+  commande_ligne_id: number | null;
+  affaire_id: number | null;
+  affaire_reference: string | null;
+  of_id: number;
+  of_numero: string | null;
+  planning_version_id: string | null;
+  previous_date: string | null;
+  new_date: string | null;
+  previous_cadence: unknown;
+  new_cadence: unknown;
+  quantite: number | null;
+  motif: string;
+  commentaire: string | null;
+  statut: string;
+  owner_user_id: number | null;
+  owner_label: string | null;
+  created_at: string;
+  updated_at: string;
+  closed_at: string | null;
+};
+
+const AR_SELECT = `
+  SELECT d.id::text                  AS id,
+         d.client_id::text            AS client_id,
+         c.nom_client                 AS client_nom,
+         d.commande_id::int           AS commande_id,
+         NULL::int                    AS commande_ligne_id,
+         d.affaire_id::int            AS affaire_id,
+         a.reference                  AS affaire_reference,
+         d.of_id::int                 AS of_id,
+         o.numero                     AS of_numero,
+         d.planning_version_id::text  AS planning_version_id,
+         d.previous_date::text        AS previous_date,
+         d.new_date::text             AS new_date,
+         d.previous_cadence, d.new_cadence,
+         d.quantite::float8           AS quantite,
+         d.motif, d.commentaire, d.statut,
+         d.owner_user_id::int         AS owner_user_id,
+         u.username                   AS owner_label,
+         d.created_at, d.updated_at, d.closed_at
+    FROM public.ar_recalage_dossiers d
+    LEFT JOIN public.clients c ON c.client_id = d.client_id
+    LEFT JOIN public.affaire a ON a.id = d.affaire_id
+    LEFT JOIN public.ordres_fabrication o ON o.id = d.of_id
+    LEFT JOIN public.users u ON u.id = d.owner_user_id`;
+
+export async function listArDossiers(
+  filters: { ofId?: number; statut?: string },
+  tx: DbQueryer = pool
+): Promise<ArRecalageRow[]> {
+  const where: string[] = [];
+  const values: unknown[] = [];
+  if (filters.ofId !== undefined) {
+    values.push(filters.ofId);
+    where.push(`d.of_id = $${values.length}`);
+  }
+  if (filters.statut) {
+    values.push(filters.statut);
+    where.push(`d.statut = $${values.length}`);
+  }
+  const res = await tx.query(
+    `${AR_SELECT}${where.length ? ` WHERE ${where.join(" AND ")}` : ""} ORDER BY d.created_at DESC`,
+    values
+  );
+  return res.rows as ArRecalageRow[];
+}
+
+export async function getArDossier(
+  dossierId: string,
+  tx: DbQueryer = pool
+): Promise<ArRecalageRow | null> {
+  const res = await tx.query(`${AR_SELECT} WHERE d.id = $1::uuid`, [dossierId]);
+  return (res.rows[0] as ArRecalageRow | undefined) ?? null;
+}
+
+export async function findArByIdempotencyKey(tx: DbQueryer, key: string): Promise<ArRecalageRow | null> {
+  const res = await tx.query(`${AR_SELECT} WHERE d.idempotency_key = $1`, [key]);
+  return (res.rows[0] as ArRecalageRow | undefined) ?? null;
+}
+
+export async function insertArDossier(
+  tx: DbQueryer,
+  input: {
+    clientId: string | null;
+    commandeId: number | null;
+    affaireId: number | null;
+    ofId: number;
+    planningVersionId: string | null;
+    previousDate: string | null;
+    newDate: string | null;
+    previousCadence: unknown;
+    newCadence: unknown;
+    quantite: number | null;
+    motif: string;
+    commentaire: string | null;
+    ownerUserId: number | null;
+    createdBy: number | null;
+    idempotencyKey: string | null;
+  }
+): Promise<string> {
+  const res = await tx.query(
+    `INSERT INTO public.ar_recalage_dossiers
+       (client_id, commande_id, affaire_id, of_id, planning_version_id,
+        previous_date, new_date, previous_cadence, new_cadence, quantite,
+        motif, commentaire, owner_user_id, created_by, idempotency_key)
+     VALUES ($1, $2, $3, $4, $5::uuid, $6::date, $7::date, $8::jsonb, $9::jsonb, $10,
+             $11, $12, $13, $14, $15)
+     RETURNING id::text AS id`,
+    [
+      input.clientId,
+      input.commandeId,
+      input.affaireId,
+      input.ofId,
+      input.planningVersionId,
+      input.previousDate,
+      input.newDate,
+      input.previousCadence === undefined ? null : JSON.stringify(input.previousCadence),
+      input.newCadence === undefined ? null : JSON.stringify(input.newCadence),
+      input.quantite,
+      input.motif,
+      input.commentaire,
+      input.ownerUserId,
+      input.createdBy,
+      input.idempotencyKey,
+    ]
+  );
+  return String(res.rows[0].id);
+}
+
+export async function updateArDossier(
+  tx: DbQueryer,
+  args: {
+    dossierId: string;
+    expectedStatut: string;
+    statut: string;
+    ownerUserId?: number | null;
+    commentaire?: string | null;
+    userId: number | null;
+  }
+): Promise<void> {
+  const res = await tx.query(
+    `UPDATE public.ar_recalage_dossiers
+        SET statut = $3,
+            owner_user_id = COALESCE($4, owner_user_id),
+            commentaire = COALESCE($5, commentaire),
+            updated_at = now(),
+            closed_at = CASE WHEN $3 IN ('RECALE', 'ABANDONNE') THEN now() ELSE closed_at END,
+            closed_by = CASE WHEN $3 IN ('RECALE', 'ABANDONNE') THEN $6 ELSE closed_by END
+      WHERE id = $1::uuid AND statut = $2`,
+    [
+      args.dossierId,
+      args.expectedStatut,
+      args.statut,
+      args.ownerUserId ?? null,
+      args.commentaire ?? null,
+      args.userId,
+    ]
+  );
+  if (!res.rowCount) {
+    throw new HttpError(
+      409,
+      "AR_RECALAGE_CONFLICT",
+      `Le dossier n'est plus dans l'état « ${args.expectedStatut} » : il a été modifié entre-temps.`
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
+/* Documents d'OF                                                             */
+/* -------------------------------------------------------------------------- */
+
+export type OfDocumentRow = {
+  id: string;
+  of_id: number;
+  revision_id: string;
+  payload: unknown;
+  payload_sha256: string;
+  pdf_sha256: string | null;
+  pdf_byte_size: number | null;
+  generated_at: string;
+  generated_by: number | null;
+  generated_by_label: string | null;
+  statut: string;
+  ged_document_id: string | null;
+  ged_version_id: string | null;
+  reprint_count: number;
+  last_reprinted_at: string | null;
+};
+
+const DOCUMENT_SELECT = `
+  SELECT id::text              AS id,
+         of_id::int            AS of_id,
+         revision_id::text     AS revision_id,
+         payload, payload_sha256, pdf_sha256,
+         pdf_byte_size::int    AS pdf_byte_size,
+         generated_at,
+         generated_by::int     AS generated_by,
+         generated_by_label, statut,
+         ged_document_id::text AS ged_document_id,
+         ged_version_id::text  AS ged_version_id,
+         reprint_count::int    AS reprint_count,
+         last_reprinted_at
+    FROM public.of_documents`;
+
+export async function listDocuments(ofId: number, tx: DbQueryer = pool): Promise<OfDocumentRow[]> {
+  const res = await tx.query(`${DOCUMENT_SELECT} WHERE of_id = $1 ORDER BY generated_at DESC`, [ofId]);
+  return res.rows as OfDocumentRow[];
+}
+
+export async function getDocument(
+  ofId: number,
+  documentId: string,
+  tx: DbQueryer = pool
+): Promise<OfDocumentRow | null> {
+  const res = await tx.query(`${DOCUMENT_SELECT} WHERE id = $1::uuid AND of_id = $2`, [documentId, ofId]);
+  return (res.rows[0] as OfDocumentRow | undefined) ?? null;
+}
+
+export async function getOfficialDocument(
+  ofId: number,
+  revisionId: string,
+  tx: DbQueryer = pool
+): Promise<OfDocumentRow | null> {
+  const res = await tx.query(
+    `${DOCUMENT_SELECT} WHERE of_id = $1 AND revision_id = $2::uuid AND statut = 'OFFICIEL'`,
+    [ofId, revisionId]
+  );
+  return (res.rows[0] as OfDocumentRow | undefined) ?? null;
+}
+
+/** Document GED déjà ouvert pour cet OF, pour y ajouter une version. */
+export async function findExistingGedDocumentId(
+  tx: DbQueryer,
+  ofId: number
+): Promise<string | null> {
+  const res = await tx.query(
+    `SELECT ged_document_id::text AS id
+       FROM public.of_documents
+      WHERE of_id = $1 AND ged_document_id IS NOT NULL
+      ORDER BY generated_at DESC
+      LIMIT 1`,
+    [ofId]
+  );
+  return res.rows[0] ? String(res.rows[0].id) : null;
+}
+
+export async function findDocumentByIdempotencyKey(
+  tx: DbQueryer,
+  key: string
+): Promise<OfDocumentRow | null> {
+  const res = await tx.query(`${DOCUMENT_SELECT} WHERE idempotency_key = $1`, [key]);
+  return (res.rows[0] as OfDocumentRow | undefined) ?? null;
+}
+
+export async function insertDocument(
+  tx: DbQueryer,
+  input: {
+    ofId: number;
+    revisionId: string;
+    payload: unknown;
+    payloadSha256: string;
+    pdfSha256: string | null;
+    pdfByteSize: number | null;
+    generatedAt: string;
+    generatedBy: number | null;
+    generatedByLabel: string | null;
+    statut: string;
+    gedDocumentId: string | null;
+    gedVersionId: string | null;
+    idempotencyKey: string | null;
+  }
+): Promise<OfDocumentRow> {
+  // Les documents officiels antérieurs de CET OF deviennent OBSOLETE : un seul
+  // exemplaire courant circule en atelier. Ils ne sont jamais supprimés — le
+  // trigger d'immuabilité l'interdit, et l'historique documentaire doit rester.
+  if (input.statut === "OFFICIEL") {
+    await tx.query(
+      `UPDATE public.of_documents SET statut = 'OBSOLETE'
+        WHERE of_id = $1 AND statut = 'OFFICIEL'`,
+      [input.ofId]
+    );
+  }
+
+  const res = await tx.query(
+    `INSERT INTO public.of_documents
+       (of_id, revision_id, payload, payload_sha256, pdf_sha256, pdf_byte_size,
+        generated_at, generated_by, generated_by_label, statut,
+        ged_document_id, ged_version_id, idempotency_key)
+     VALUES ($1, $2::uuid, $3::jsonb, $4, $5, $6, $7::timestamptz, $8, $9, $10,
+             $11::uuid, $12::uuid, $13)
+     RETURNING id::text AS id`,
+    [
+      input.ofId,
+      input.revisionId,
+      JSON.stringify(input.payload),
+      input.payloadSha256,
+      input.pdfSha256,
+      input.pdfByteSize,
+      input.generatedAt,
+      input.generatedBy,
+      input.generatedByLabel,
+      input.statut,
+      input.gedDocumentId,
+      input.gedVersionId,
+      input.idempotencyKey,
+    ]
+  );
+
+  const created = await getDocument(input.ofId, String(res.rows[0].id), tx);
+  if (!created) throw new HttpError(500, "OF_DOCUMENT_CREATE", "Document introuvable après création.");
+  return created;
+}
+
+/**
+ * Incrémente le compteur de réimpression.
+ *
+ * Une réimpression n'est PAS une émission : elle ne crée ni révision, ni
+ * document, ni version GED. Elle laisse seulement une trace de consultation.
+ */
+export async function bumpReprintCount(
+  tx: DbQueryer,
+  args: { ofId: number; documentId: string }
+): Promise<void> {
+  await tx.query(
+    `UPDATE public.of_documents
+        SET reprint_count = reprint_count + 1, last_reprinted_at = now()
+      WHERE id = $2::uuid AND of_id = $1`,
+    [args.ofId, args.documentId]
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/* Read-model commercial : affaires, cadences, couverture                     */
+/* -------------------------------------------------------------------------- */
+
+export type OfCommercialContext = {
+  affaires: Array<{ affaireId: number; numero: string | null; delaiClient: string | null; quantite: number | null }>;
+  cadenceLivraison: Array<{ date: string; quantite: number; affaireNumero: string | null }>;
+  quantites: {
+    quantiteDemandee: number;
+    quantiteLivree: number;
+    stockReserve: number;
+    couvertAutresOf: number;
+    quantiteAffecteeCetOf: number;
+  };
+  derniereFabrication: { numero: string | null; date: string | null } | null;
+};
+
+/**
+ * Contexte commercial d'un OF, en postes DISJOINTS.
+ *
+ * Le non-double-comptage n'est pas obtenu par un correctif après coup : il vient
+ * de la table `commande_ligne_affaire_allocation`, qui décompose déjà la
+ * quantité commandée en « depuis stock », « réservée » et « à produire ». On lit
+ * cette décomposition au lieu d'additionner des sources indépendantes qui se
+ * recouperaient.
+ *
+ * `couvertAutresOf` exclut explicitement l'OF courant et ne retient que les OF
+ * ACTIFS : la sortie d'un OF terminé est entrée en stock, la compter en plus du
+ * stock réservé couvrirait deux fois la même pièce.
+ */
+export async function readCommercialContext(
+  header: OfHeaderRow,
+  tx: DbQueryer = pool
+): Promise<OfCommercialContext> {
+  const affaires: OfCommercialContext["affaires"] = [];
+  const cadenceLivraison: OfCommercialContext["cadenceLivraison"] = [];
+
+  if (header.commande_ligne_id !== null) {
+    const alloc = await tx.query(
+      `SELECT al.livraison_affaire_id::int      AS affaire_id,
+              a.reference                        AS numero,
+              cl.delai_client::text              AS delai_client,
+              al.qty_ordered::float8             AS qty_ordered,
+              al.qty_from_stock::float8          AS qty_from_stock,
+              al.qty_reserved::float8            AS qty_reserved,
+              al.qty_to_produce::float8          AS qty_to_produce
+         FROM public.commande_ligne_affaire_allocation al
+         LEFT JOIN public.affaire a        ON a.id = al.livraison_affaire_id
+         LEFT JOIN public.commande_ligne cl ON cl.id = al.commande_ligne_id
+        WHERE al.commande_ligne_id = $1
+        ORDER BY al.livraison_affaire_id`,
+      [header.commande_ligne_id]
+    );
+
+    for (const row of alloc.rows) {
+      if (row.affaire_id !== null) {
+        affaires.push({
+          affaireId: Number(row.affaire_id),
+          numero: row.numero === null ? null : String(row.numero),
+          delaiClient: row.delai_client === null ? null : String(row.delai_client),
+          quantite: row.qty_ordered === null ? null : Number(row.qty_ordered),
+        });
+      }
+    }
+  }
+
+  // L'affaire portée par l'OF lui-même, si l'allocation ne l'a pas déjà donnée.
+  if (header.affaire_id !== null && !affaires.some((a) => a.affaireId === header.affaire_id)) {
+    const own = await tx.query(
+      `SELECT id::int AS id, reference FROM public.affaire WHERE id = $1`, // `affaire.reference` vérifié au schéma
+      [header.affaire_id]
+    );
+    if (own.rows[0]) {
+      affaires.push({
+        affaireId: Number(own.rows[0].id),
+        numero: own.rows[0].reference === null ? null : String(own.rows[0].reference),
+        delaiClient: header.date_fin_prevue,
+        quantite: header.quantite_lancee,
+      });
+    }
+  }
+
+  if (header.commande_id !== null) {
+    const echeances = await tx.query(
+      `SELECT date_echeance::text AS date, COALESCE(pourcentage, 0)::float8 AS pct, libelle
+         FROM public.commande_echeance
+        WHERE commande_id = $1 AND date_echeance IS NOT NULL
+        ORDER BY date_echeance`,
+      [header.commande_id]
+    );
+    for (const row of echeances.rows) {
+      cadenceLivraison.push({
+        date: String(row.date),
+        // Une échéance de commande porte un pourcentage : la quantité en découle.
+        quantite: Number(((Number(row.pct) / 100) * header.quantite_lancee).toFixed(3)),
+        affaireNumero: row.libelle === null ? null : String(row.libelle),
+      });
+    }
+  }
+
+  const quantites = await readCoverage(header, tx);
+  const derniere = await readLastFabrication(header, tx);
+
+  return { affaires, cadenceLivraison, quantites, derniereFabrication: derniere };
+}
+
+async function readCoverage(
+  header: OfHeaderRow,
+  tx: DbQueryer
+): Promise<OfCommercialContext["quantites"]> {
+  let quantiteDemandee = header.quantite_lancee;
+  let stockReserve = 0;
+  let quantiteLivree = 0;
+
+  if (header.commande_ligne_id !== null) {
+    const res = await tx.query(
+      `SELECT COALESCE(SUM(qty_ordered), 0)::float8    AS demandee,
+              COALESCE(SUM(qty_from_stock), 0)::float8 AS from_stock,
+              COALESCE(SUM(qty_reserved), 0)::float8   AS reserved
+         FROM public.commande_ligne_affaire_allocation
+        WHERE commande_ligne_id = $1`,
+      [header.commande_ligne_id]
+    );
+    if (res.rows[0]) {
+      quantiteDemandee = Number(res.rows[0].demandee) || header.quantite_lancee;
+      // `qty_from_stock` est servi depuis le stock : c'est une couverture, mais
+      // pas une production. `qty_reserved` est la réservation physique.
+      stockReserve = Number(res.rows[0].from_stock) + Number(res.rows[0].reserved);
+    }
+  }
+
+  // Quantité déjà reçue en bon sur cet OF : c'est la part produite et acceptée.
+  const recu = await tx.query(
+    `SELECT COALESCE(quantite_bonne, 0)::float8 AS bonne FROM public.ordres_fabrication WHERE id = $1`,
+    [header.of_id]
+  );
+  quantiteLivree = recu.rows[0] ? Number(recu.rows[0].bonne) : 0;
+
+  // Autres OF ACTIFS sur la même ligne de commande. L'OF courant est exclu, et
+  // les OF terminés ou annulés le sont aussi : leur sortie est déjà en stock.
+  let couvertAutresOf = 0;
+  if (header.commande_ligne_id !== null) {
+    const autres = await tx.query(
+      `SELECT COALESCE(SUM(quantite_lancee), 0)::float8 AS q
+         FROM public.ordres_fabrication
+        WHERE commande_ligne_id = $1
+          AND id <> $2
+          AND statut::text NOT IN ('TERMINE', 'CLOTURE', 'ANNULE')`,
+      [header.commande_ligne_id, header.of_id]
+    );
+    couvertAutresOf = autres.rows[0] ? Number(autres.rows[0].q) : 0;
+  }
+
+  return {
+    quantiteDemandee,
+    quantiteLivree,
+    stockReserve,
+    couvertAutresOf,
+    quantiteAffecteeCetOf: header.quantite_lancee,
+  };
+}
+
+async function readLastFabrication(
+  header: OfHeaderRow,
+  tx: DbQueryer
+): Promise<{ numero: string | null; date: string | null } | null> {
+  if (header.piece_technique_id === null) return null;
+  const res = await tx.query(
+    `SELECT numero, COALESCE(date_fin_reelle, date_fin_prevue)::text AS date
+       FROM public.ordres_fabrication
+      WHERE piece_technique_id = $1::uuid
+        AND id <> $2
+        AND date_fin_reelle IS NOT NULL
+      ORDER BY date_fin_reelle DESC
+      LIMIT 1`,
+    [header.piece_technique_id, header.of_id]
+  );
+  if (!res.rows[0]) return null;
+  return {
+    numero: res.rows[0].numero === null ? null : String(res.rows[0].numero),
+    date: res.rows[0].date === null ? null : String(res.rows[0].date),
+  };
+}
+
+/* -------------------------------------------------------------------------- */
+/* Routage de notification                                                    */
+/* -------------------------------------------------------------------------- */
+
+export async function readNotificationRouting(
+  topic: string,
+  tx: DbQueryer = pool
+): Promise<NotificationRoutingRule[]> {
+  const res = await tx.query(
+    `SELECT topic, role_key, user_id::int AS user_id, is_active
+       FROM public.notification_routing
+      WHERE topic = $1 AND is_active = true`,
+    [topic]
+  );
+  return res.rows.map((row) => ({
+    topic: String(row.topic),
+    roleKey: row.role_key === null ? null : String(row.role_key),
+    userId: row.user_id === null ? null : Number(row.user_id),
+    isActive: Boolean(row.is_active),
+  }));
+}
+
+/** Destinataires possibles : utilisateurs actifs avec leurs rôles assignés. */
+export async function readNotificationCandidates(
+  tx: DbQueryer = pool
+): Promise<Array<{ userId: number; username: string; primaryRole: string | null; roles: string[] }>> {
+  const res = await tx.query(
+    `SELECT u.id::int AS user_id, u.username, u.role AS primary_role,
+            COALESCE(ARRAY_AGG(ura.role_key) FILTER (WHERE ura.role_key IS NOT NULL), '{}') AS roles
+       FROM public.users u
+       LEFT JOIN public.user_role_assignments ura ON ura.user_id = u.id
+      GROUP BY u.id, u.username, u.role`
+  );
+  return res.rows.map((row) => ({
+    userId: Number(row.user_id),
+    username: String(row.username),
+    primaryRole: row.primary_role === null ? null : String(row.primary_role),
+    roles: Array.isArray(row.roles) ? row.roles.map((r: unknown) => String(r)) : [],
+  }));
+}

--- a/src/module/production/routes/of-versioning.routes.ts
+++ b/src/module/production/routes/of-versioning.routes.ts
@@ -1,0 +1,161 @@
+import { Router } from "express";
+
+import { authenticateToken } from "../../auth/middlewares/auth.middleware";
+import {
+  requireIdempotencyKey,
+  requireOfCapability,
+} from "../middlewares/of-versioning-authorization.middleware";
+import {
+  assessVariance,
+  capabilities,
+  compareRevisions,
+  createArDossier,
+  createPlanningDraft,
+  createProposal,
+  createRevision,
+  createVisa,
+  emitDocument,
+  getRevision,
+  listArDossiers,
+  listDocuments,
+  listMachineFamilies,
+  listPlanningVersions,
+  listProposals,
+  listRevisions,
+  previewPayload,
+  previewPdf,
+  refusePlanning,
+  reprintDocument,
+  resolveProposal,
+  submitPlanning,
+  updateArDossier,
+  validatePlanning,
+} from "../controllers/of-versioning.controller";
+
+/**
+ * Surface « OF : versioning, replanification, AR client et document » (#370),
+ * montée sous `/production/of-versioning`.
+ *
+ * Aucune garde globale trop large : chaque route déclare sa capacité fine, refus
+ * par défaut. Le routeur historique `production.routes.ts` reste intact pour ne
+ * casser aucun écran en production.
+ *
+ * Les commandes à effet exigent `Idempotency-Key`. Les lectures et les aperçus
+ * n'en exigent aucune : ils n'écrivent rien.
+ */
+const router = Router();
+router.use(authenticateToken);
+
+/* ------------------------------ Référentiels ------------------------------ */
+
+router.get("/capabilities", capabilities);
+router.get("/machine-families", requireOfCapability("read"), listMachineFamilies);
+
+/* -------------------------------- AR client ------------------------------- */
+// Déclaré AVANT les routes `/:ofId/...` : sans cela, « ar-dossiers » serait
+// capturé comme un `ofId` et la validation renverrait un 400 illisible.
+
+router.get("/ar-dossiers", requireOfCapability("ar_recalage"), listArDossiers);
+router.patch("/ar-dossiers/:dossierId", requireOfCapability("ar_recalage"), updateArDossier);
+
+/* -------------------------------- Révisions ------------------------------- */
+
+router.get("/:ofId/revisions", requireOfCapability("read"), listRevisions);
+router.get("/:ofId/revisions/compare", requireOfCapability("read"), compareRevisions);
+router.get("/:ofId/revisions/:revisionId", requireOfCapability("read"), getRevision);
+
+// Créer une révision n'écrase jamais la précédente : elle recopie ses opérations
+// et applique les modifications sur le nouveau jeu.
+router.post(
+  "/:ofId/revisions",
+  requireIdempotencyKey,
+  requireOfCapability("revise"),
+  createRevision
+);
+
+/* ---------------------------------- VISA ---------------------------------- */
+
+router.post(
+  "/:ofId/revisions/:revisionId/visas",
+  requireIdempotencyKey,
+  requireOfCapability("visa"),
+  createVisa
+);
+
+/* ----------------------------- Dérive de temps ---------------------------- */
+
+// Évaluation seule : lecture, aucun effet. Permet à l'UI d'afficher le verdict
+// du seuil avant de proposer quoi que ce soit.
+router.post("/:ofId/time-variance/assess", requireOfCapability("plan_draft"), assessVariance);
+
+router.get("/:ofId/time-variance", requireOfCapability("read"), listProposals);
+router.post(
+  "/:ofId/time-variance",
+  requireIdempotencyKey,
+  requireOfCapability("plan_draft"),
+  createProposal
+);
+router.post(
+  "/:ofId/time-variance/:proposalId/resolve",
+  requireOfCapability("plan_validate"),
+  resolveProposal
+);
+
+/* -------------------------------- Planning -------------------------------- */
+
+router.get("/:ofId/planning-versions", requireOfCapability("read"), listPlanningVersions);
+
+// Un brouillon ne modifie RIEN dans le planning actif : capacité large.
+router.post(
+  "/:ofId/planning-versions",
+  requireIdempotencyKey,
+  requireOfCapability("plan_draft"),
+  createPlanningDraft
+);
+router.post(
+  "/:ofId/planning-versions/:versionId/submit",
+  requireOfCapability("plan_draft"),
+  submitPlanning
+);
+
+// Valider et refuser engagent la charge et le client : capacité étroite.
+router.post(
+  "/:ofId/planning-versions/:versionId/validate",
+  requireOfCapability("plan_validate"),
+  validatePlanning
+);
+router.post(
+  "/:ofId/planning-versions/:versionId/refuse",
+  requireOfCapability("plan_validate"),
+  refusePlanning
+);
+
+/* -------------------------- AR client, par OF ----------------------------- */
+
+router.post(
+  "/:ofId/ar-dossiers",
+  requireIdempotencyKey,
+  requireOfCapability("ar_recalage"),
+  createArDossier
+);
+
+/* -------------------------------- Document -------------------------------- */
+
+// Aperçu : même read-model que le PDF, aucun effet de bord.
+router.get("/:ofId/document/preview", requireOfCapability("document"), previewPayload);
+router.get("/:ofId/document/preview.pdf", requireOfCapability("document"), previewPdf);
+
+router.get("/:ofId/documents", requireOfCapability("read"), listDocuments);
+
+// Émission : fige le payload, hache le binaire, archive en GED.
+router.post(
+  "/:ofId/documents",
+  requireIdempotencyKey,
+  requireOfCapability("document"),
+  emitDocument
+);
+
+// Réimpression : restitue le binaire archivé, ne crée aucune révision.
+router.get("/:ofId/documents/:documentId/pdf", requireOfCapability("document"), reprintDocument);
+
+export default router;

--- a/src/module/production/services/of-document-archive.ts
+++ b/src/module/production/services/of-document-archive.ts
@@ -1,0 +1,149 @@
+// Archivage GED du document d'OF émis (#370, ADR-0037).
+//
+// Un document d'OF officiel est une pièce opposable : il accompagne la
+// fabrication et doit pouvoir être restitué des années plus tard, à l'octet
+// près. L'archivage suit donc deux principes :
+//
+//   1. Le coffre est adressé par contenu. Le blob est stocké sous l'empreinte du
+//      binaire : deux dépôts du même document convergent, et un fichier altéré
+//      sur disque est refusé à la lecture au lieu d'être servi.
+//   2. L'empreinte est la référence, le coffre est la commodité. `of_documents`
+//      porte `pdf_sha256` en propre. Si le coffre n'est pas configuré — poste de
+//      développement, environnement de test — l'émission n'échoue pas : le
+//      document reste réimprimable depuis son payload figé, et la réimpression
+//      est vérifiée contre l'empreinte enregistrée.
+//
+// C'est ce second point qui évite de faire dépendre une règle métier (« une
+// réimpression restitue exactement le document émis ») d'une variable
+// d'environnement.
+
+import type { PoolClient } from "pg";
+
+import {
+  repoAddVersion,
+  repoCreateDocumentWithVersion,
+  repoSetCurrentVersion,
+  repoUpsertBlob,
+} from "../../ged/repository/ged.repository";
+import { isVaultConfigured, readBlob, storageKeyForSha256, writeBlob } from "../../ged/services/ged-vault.service";
+
+/** Classe GED du dossier atelier — déjà présente au référentiel. */
+const OF_DOCUMENT_CLASS_KEY = "OF_DOSSIER";
+const OF_DOCUMENT_DOMAIN = "PRODUCTION";
+
+export type OfDocumentArchiveInput = {
+  ofNumero: string;
+  revisionCode: string;
+  pieceReference: string | null;
+  pdf: Buffer;
+  pdfSha256: string;
+  /** Document GED existant à versionner, si cet OF en a déjà un. */
+  existingGedDocumentId: string | null;
+  actorUserId: number | null;
+  changeReason: string | null;
+};
+
+export type OfDocumentArchiveResult = {
+  archived: boolean;
+  gedDocumentId: string | null;
+  gedVersionId: string | null;
+  /** Pourquoi l'archivage n'a pas eu lieu, quand il n'a pas eu lieu. */
+  skippedReason: string | null;
+};
+
+/**
+ * Verse le PDF au coffre et l'enregistre en GED, dans la transaction fournie.
+ *
+ * L'écriture du blob a lieu AVANT l'insertion : un enregistrement GED qui
+ * pointerait vers un fichier absent serait pire qu'une absence d'archive, parce
+ * qu'il affirmerait une conservation qui n'existe pas.
+ */
+export async function archiveOfDocument(
+  tx: Pick<PoolClient, "query">,
+  input: OfDocumentArchiveInput
+): Promise<OfDocumentArchiveResult> {
+  if (!isVaultConfigured()) {
+    return {
+      archived: false,
+      gedDocumentId: null,
+      gedVersionId: null,
+      skippedReason:
+        "Coffre documentaire non configuré : le document reste réimprimable depuis son payload figé et vérifié contre son empreinte.",
+    };
+  }
+
+  const written = await writeBlob(input.pdf);
+  if (written.sha256 !== input.pdfSha256) {
+    // Ne peut arriver que si le binaire a changé entre le hachage et le dépôt.
+    throw new Error(
+      `Empreinte incohérente à l'archivage : attendue ${input.pdfSha256}, déposée ${written.sha256}.`
+    );
+  }
+
+  const blob = await repoUpsertBlob(tx, {
+    sha256: written.sha256,
+    size_bytes: written.size_bytes,
+    mime_type: "application/pdf",
+    storage_key: written.storage_key,
+    created_by: input.actorUserId,
+  });
+
+  const title = `Gamme de fabrication ${input.ofNumero} ${input.revisionCode}`;
+  const originalName = `OF-${input.ofNumero}-${input.revisionCode}.pdf`.replace(/\s+/g, "");
+
+  // Un OF garde UN document GED et gagne une version par révision émise :
+  // l'historique documentaire suit ainsi l'historique des révisions au lieu de
+  // se disperser en documents sans lien entre eux.
+  if (input.existingGedDocumentId) {
+    const version = await repoAddVersion(tx, {
+      document_id: input.existingGedDocumentId,
+      blob_id: blob.id,
+      original_name: originalName,
+      change_reason: input.changeReason,
+      created_by: input.actorUserId,
+    });
+    await repoSetCurrentVersion(tx, input.existingGedDocumentId, version.version_id);
+    return {
+      archived: true,
+      gedDocumentId: input.existingGedDocumentId,
+      gedVersionId: version.version_id,
+      skippedReason: null,
+    };
+  }
+
+  const created = await repoCreateDocumentWithVersion(tx, {
+    class_key: OF_DOCUMENT_CLASS_KEY,
+    domain: OF_DOCUMENT_DOMAIN,
+    title,
+    description: input.pieceReference ? `Pièce ${input.pieceReference}` : null,
+    blob_id: blob.id,
+    original_name: originalName,
+    change_reason: input.changeReason,
+    created_by: input.actorUserId,
+  });
+
+  return {
+    archived: true,
+    gedDocumentId: created.document_id,
+    gedVersionId: created.version_id,
+    skippedReason: null,
+  };
+}
+
+/**
+ * Relit le PDF archivé et revérifie son empreinte.
+ *
+ * Renvoie `null` quand le coffre n'est pas disponible — l'appelant retombe alors
+ * sur un rendu depuis le payload figé, qui est déterministe. Un binaire altéré,
+ * en revanche, n'est jamais servi : `readBlob` le refuse.
+ */
+export async function readArchivedOfDocument(pdfSha256: string): Promise<Buffer | null> {
+  if (!isVaultConfigured()) return null;
+  try {
+    return await readBlob(storageKeyForSha256(pdfSha256), pdfSha256);
+  } catch {
+    // Absent du coffre : la réimpression se fera depuis le payload, puis sera
+    // comparée à l'empreinte enregistrée. Un écart lèvera une erreur explicite.
+    return null;
+  }
+}

--- a/src/module/production/services/of-document-render.ts
+++ b/src/module/production/services/of-document-render.ts
@@ -41,10 +41,17 @@ import {
  */
 const GAMME_COLUMNS: CerpLineColumn[] = [
   { key: "phase", label: "Ph.", flex: 0.5 },
-  { key: "famille", label: "Fam.", flex: 0.8 },
-  { key: "centre", label: "Centre", flex: 0.78 },
+  // « DECOUPE » est le plus long code de famille (7 caractères) : la colonne doit
+  // le tenir sur UNE ligne. Un code replié en « DECOUP / E » n'est plus un code —
+  // une désignation peut se replier, un identifiant de référentiel non.
+  // Largeur mesurée sur le rendu, pas estimée.
+  { key: "famille", label: "Fam.", flex: 1.28 },
+  // « CF » et non « Centre » : à 6,9 pt avec interlettrage, « Centre » déborde et
+  // se replie en « CENTR / E » par-dessus le filet de tête. « CF » est le terme
+  // maison (centres_frais) et tient largement.
+  { key: "centre", label: "CF", flex: 0.7 },
   { key: "machine", label: "Machine", flex: 1.0 },
-  { key: "designation", label: "Désignation", flex: 1.94 },
+  { key: "designation", label: "Désignation", flex: 1.54 },
   { key: "tunit", label: "T unit.", flex: 0.85, align: "right" },
   { key: "preparation", label: "Prépa.", flex: 0.79, align: "right" },
   { key: "fabrication", label: "Fabric.", flex: 1.18, align: "right" },
@@ -60,16 +67,19 @@ const GAMME_COLUMNS: CerpLineColumn[] = [
  * rendraient illisible à 6,9 pt. La solidarité phase/VISA est préservée : chaque
  * phase reste UNE ligne, et `linesTable` ne coupe jamais une ligne en deux.
  */
+// Libellés volontairement courts et sur UNE ligne : « Qté bonne », « Qté rebut »
+// et « V. ctrl » se replient à 6,9 pt et viennent rayer le filet de tête. Un
+// en-tête abrégé et lisible vaut mieux qu'un en-tête complet et cassé.
 const VISA_COLUMNS: CerpLineColumn[] = [
   { key: "phase", label: "Ph.", flex: 0.5 },
   { key: "statut", label: "Statut", flex: 1.0 },
-  { key: "operateur", label: "Opérateur", flex: 1.5 },
-  { key: "date", label: "Date / heure", flex: 1.35 },
-  { key: "bonne", label: "Qté bonne", flex: 0.9, align: "right" },
-  { key: "rebut", label: "Qté rebut", flex: 0.9, align: "right" },
-  { key: "motif", label: "Motif rebut", flex: 1.85 },
-  { key: "visaOp", label: "V. op.", flex: 0.62 },
-  { key: "visaCtrl", label: "V. ctrl", flex: 0.62 },
+  { key: "operateur", label: "Opérateur", flex: 1.45 },
+  { key: "date", label: "Date", flex: 1.35 },
+  { key: "bonne", label: "Bonnes", flex: 0.92, align: "right" },
+  { key: "rebut", label: "Rebuts", flex: 0.92, align: "right" },
+  { key: "motif", label: "Motif rebut", flex: 1.8 },
+  { key: "visaOp", label: "Op.", flex: 0.62 },
+  { key: "visaCtrl", label: "Ctrl", flex: 0.62 },
 ];
 
 /** Réserve de cohésion d'une section ouverte par une table (ADR-0040 §5). */
@@ -151,13 +161,18 @@ function buildSubtitle(payload: OfDocumentPayload): string | null {
 
 function renderCoverHalf(ctx: CerpDocumentContext, payload: OfDocumentPayload): void {
   // En-tête documentaire (#370). Les trois statuts sont distincts et affichés
-  // séparément : fabrication, définition technique, pièce documentaire.
+  // séparément : fabrication (badge d'identité), définition technique (révision)
+  // et pièce documentaire (« Statut doc. »).
+  //
+  // Cinq cellules et non six : le numéro d'OF est déjà le titre de la page, et le
+  // répéter ici volait la largeur aux autres libellés — « STATUT DOCUMENTAIRE »
+  // et « VERSION DE GAMME » se repliaient alors par-dessus leur propre valeur.
+  // Les libellés sont courts pour tenir sur UNE ligne à cette largeur.
   ctx.legalStrip(
     [
-      { label: "Ordre de fabrication", value: payload.ofNumero },
       { label: "Révision", value: `${payload.revisionCode} — ${payload.revisionStatut}` },
-      { label: "Statut documentaire", value: payload.documentStatut },
-      { label: "Version de gamme", value: formatGammeVersion(payload) },
+      { label: "Statut doc.", value: payload.documentStatut },
+      { label: "Gamme", value: formatGammeVersion(payload) },
       { label: "Commande", value: payload.commandeNumero },
       { label: "Client", value: payload.clientNom ?? payload.clientCode },
     ],

--- a/src/module/production/services/of-document-render.ts
+++ b/src/module/production/services/of-document-render.ts
@@ -1,4 +1,11 @@
-// Rendu serveur du document d'OF — « Gamme de fabrication ».
+// Rendu serveur du document d'OF — « ORDRE DE FABRICATION — GAMME APPLICABLE ».
+//
+// La pièce est un ORDRE DE FABRICATION. Ce n'est pas une gamme de fabrication :
+// une gamme est la définition technique d'une pièce, réutilisable d'un OF à
+// l'autre ; un ordre de fabrication est l'ordre de LANCER une quantité donnée,
+// pour une commande donnée, à une date donnée. Il EMBARQUE la gamme applicable —
+// la section « Gamme applicable » — mais il ne s'y réduit pas, et le titre du
+// document ne doit pas laisser croire le contraire (issue #370).
 //
 // Le document est **opposable** : il accompagne la fabrication, il est haché,
 // versé à la GED et réimprimable à l'identique. Il est donc rendu par le serveur
@@ -106,7 +113,7 @@ export async function renderOfDocument(payload: OfDocumentPayload): Promise<OfDo
 
   const buffer = await renderCerpDocument(
     {
-      documentType: "Gamme de fabrication",
+      documentType: "Ordre de fabrication",
       name: payload.ofNumero,
       code: payload.revisionCode,
       subtitle: buildSubtitle(payload),
@@ -121,7 +128,7 @@ export async function renderOfDocument(payload: OfDocumentPayload): Promise<OfDo
       // gabarits différents ne sont pas le même document, et une réimpression
       // doit pouvoir le prouver sans ouvrir la base.
       footerNote: `${payload.ofNumero} ${payload.revisionCode} — instantané ${payload.snapshotId} — empreinte ${payload.snapshotSha256.slice(0, 16)} — gabarit ${payload.templateVersion}`,
-      title: `Gamme de fabrication ${payload.ofNumero} ${payload.revisionCode}`,
+      title: `Ordre de fabrication ${payload.ofNumero} ${payload.revisionCode}`,
       subject: `OF ${payload.ofNumero} révision ${payload.revisionCode}`,
       creationDate: generatedAt,
     },
@@ -334,7 +341,9 @@ function millimetres(value: number | null, decimals: number): string {
 // ---------------------------------------------------------------------------
 
 function renderGamme(ctx: CerpDocumentContext, payload: OfDocumentPayload): void {
-  ctx.section("Gamme de fabrication", { cohesion: TABLE_SECTION_COHESION });
+  // « Gamme APPLICABLE » : celle qui s'applique à CET OF, figée par sa révision.
+  // Pas « la gamme de la pièce », qui a pu bouger depuis le lancement.
+  ctx.section("Gamme applicable", { cohesion: TABLE_SECTION_COHESION });
 
   ctx.linesTable({
     columns: GAMME_COLUMNS,

--- a/src/module/production/services/of-document-render.ts
+++ b/src/module/production/services/of-document-render.ts
@@ -1,0 +1,471 @@
+// Rendu serveur du document d'OF — « Gamme de fabrication ».
+//
+// Le document est **opposable** : il accompagne la fabrication, il est haché,
+// versé à la GED et réimprimable à l'identique. Il est donc rendu par le serveur
+// avec `pdfkit`, jamais dans le navigateur — ADR-0042 §1. `window.print()` n'est
+// pas un document officiel : il dépend du poste, du bundle et du moteur.
+//
+// L'aperçu écran affiche ce même payload ; il ne recalcule rien.
+//
+// Grammaire partagée : `src/shared/pdf/cerp-document.ts`, miroir déclaré de
+// `crp-systems-web/src/design-system/pdf/document-kit.tsx` (ADR-0040).
+
+import { createHash } from "node:crypto";
+
+import {
+  renderCerpDocument,
+  type CerpDocumentContext,
+  type CerpLineColumn,
+  type CerpLineRow,
+} from "../../../shared/pdf/cerp-document";
+import {
+  formatDateFr,
+  formatNumberFr,
+  formatQuantity,
+  type OfDocumentPayload,
+} from "../domain/of-document";
+
+/**
+ * Colonnes de la gamme.
+ *
+ * `linesTable` réémet cet en-tête sur chaque page traversée et ne coupe jamais
+ * une ligne en deux. La phase et son VISA étant deux colonnes de la **même**
+ * ligne, ils ne peuvent structurellement pas être séparés par un saut de page —
+ * la garantie vient de la géométrie, pas d'une vérification a posteriori.
+ */
+/*
+ * Les libelles d'en-tete sont volontairement courts : a 6,9 pt avec interlettrage,
+ * « FABRICATION » et « QTE BASE » depassent leur colonne et viennent chevaucher le
+ * filet de tete. Un en-tete abrege et lisible vaut mieux qu'un en-tete complet et
+ * casse. La largeur de « FAM. » tient compte du plus long code de famille, FTRAD.
+ */
+const GAMME_COLUMNS: CerpLineColumn[] = [
+  { key: "phase", label: "Ph.", flex: 0.5 },
+  { key: "famille", label: "Fam.", flex: 0.8 },
+  { key: "centre", label: "Centre", flex: 0.78 },
+  { key: "machine", label: "Machine", flex: 1.0 },
+  { key: "designation", label: "Désignation", flex: 1.94 },
+  { key: "tunit", label: "T unit.", flex: 0.85, align: "right" },
+  { key: "preparation", label: "Prépa.", flex: 0.79, align: "right" },
+  { key: "fabrication", label: "Fabric.", flex: 1.18, align: "right" },
+  { key: "final", label: "Final", flex: 1.18, align: "right" },
+  { key: "qte", label: "Qté", flex: 0.58, align: "right" },
+  { key: "visa", label: "VISA", flex: 0.62 },
+];
+
+/**
+ * Détail du VISA, une ligne par phase.
+ *
+ * Séparé de la gamme parce que huit champs de plus dans la table principale la
+ * rendraient illisible à 6,9 pt. La solidarité phase/VISA est préservée : chaque
+ * phase reste UNE ligne, et `linesTable` ne coupe jamais une ligne en deux.
+ */
+const VISA_COLUMNS: CerpLineColumn[] = [
+  { key: "phase", label: "Ph.", flex: 0.5 },
+  { key: "statut", label: "Statut", flex: 1.0 },
+  { key: "operateur", label: "Opérateur", flex: 1.5 },
+  { key: "date", label: "Date / heure", flex: 1.35 },
+  { key: "bonne", label: "Qté bonne", flex: 0.9, align: "right" },
+  { key: "rebut", label: "Qté rebut", flex: 0.9, align: "right" },
+  { key: "motif", label: "Motif rebut", flex: 1.85 },
+  { key: "visaOp", label: "V. op.", flex: 0.62 },
+  { key: "visaCtrl", label: "V. ctrl", flex: 0.62 },
+];
+
+/** Réserve de cohésion d'une section ouverte par une table (ADR-0040 §5). */
+const TABLE_SECTION_COHESION = 104;
+
+export type OfDocumentRenderResult = {
+  buffer: Buffer;
+  sha256: string;
+  byteSize: number;
+};
+
+/**
+ * Rend le document et renvoie son binaire avec son empreinte.
+ *
+ * Déterministe par construction : tout ce qui entre dans le binaire vient du
+ * payload figé — y compris `generatedAt`, qui alimente à la fois le pied de page
+ * et la date de création des métadonnées PDF. Aucune horloge n'est lue ici.
+ */
+export async function renderOfDocument(payload: OfDocumentPayload): Promise<OfDocumentRenderResult> {
+  const generatedAt = new Date(payload.generatedAt);
+  if (Number.isNaN(generatedAt.getTime())) {
+    throw new Error(`Horodatage de document invalide : ${payload.generatedAt}`);
+  }
+
+  const buffer = await renderCerpDocument(
+    {
+      documentType: "Gamme de fabrication",
+      name: payload.ofNumero,
+      code: payload.revisionCode,
+      subtitle: buildSubtitle(payload),
+      status: payload.ofStatut,
+      flag: payload.watermark,
+      monogramName: payload.clientNom ?? payload.ofNumero,
+      generatedAt: formatDateTimeFr(payload.generatedAt),
+      generatedBy: payload.auteur,
+      watermark: payload.watermark,
+      // Rattacher une page isolée à son exemplaire : l'atelier détache les pages.
+      // Le gabarit figure au pied : deux PDF de même contenu rendus par deux
+      // gabarits différents ne sont pas le même document, et une réimpression
+      // doit pouvoir le prouver sans ouvrir la base.
+      footerNote: `${payload.ofNumero} ${payload.revisionCode} — instantané ${payload.snapshotId} — empreinte ${payload.snapshotSha256.slice(0, 16)} — gabarit ${payload.templateVersion}`,
+      title: `Gamme de fabrication ${payload.ofNumero} ${payload.revisionCode}`,
+      subject: `OF ${payload.ofNumero} révision ${payload.revisionCode}`,
+      creationDate: generatedAt,
+    },
+    (ctx) => {
+      renderCoverHalf(ctx, payload);
+      renderTechnicalHalf(ctx, payload);
+      renderGamme(ctx, payload);
+    }
+  );
+
+  return {
+    buffer,
+    sha256: createHash("sha256").update(buffer).digest("hex"),
+    byteSize: buffer.byteLength,
+  };
+}
+
+/** « GAMME-45252966 v1 », ou le code seul si la version manque. */
+function formatGammeVersion(payload: OfDocumentPayload): string | null {
+  if (!payload.gammeCode && !payload.gammeVersion) return null;
+  if (!payload.gammeVersion) return payload.gammeCode;
+  if (!payload.gammeCode) return `v${payload.gammeVersion}`;
+  return `${payload.gammeCode} v${payload.gammeVersion}`;
+}
+
+function buildSubtitle(payload: OfDocumentPayload): string | null {
+  const parts = [payload.pieceReference, payload.pieceDesignation].filter(
+    (part): part is string => Boolean(part && part.trim())
+  );
+  if (payload.pieceIndice) parts.push(`Indice ${payload.pieceIndice}`);
+  return parts.length ? parts.join(" — ") : null;
+}
+
+// ---------------------------------------------------------------------------
+// Page 1 — moitié haute : couverture commerciale
+// ---------------------------------------------------------------------------
+
+function renderCoverHalf(ctx: CerpDocumentContext, payload: OfDocumentPayload): void {
+  // En-tête documentaire (#370). Les trois statuts sont distincts et affichés
+  // séparément : fabrication, définition technique, pièce documentaire.
+  ctx.legalStrip(
+    [
+      { label: "Ordre de fabrication", value: payload.ofNumero },
+      { label: "Révision", value: `${payload.revisionCode} — ${payload.revisionStatut}` },
+      { label: "Statut documentaire", value: payload.documentStatut },
+      { label: "Version de gamme", value: formatGammeVersion(payload) },
+      { label: "Commande", value: payload.commandeNumero },
+      { label: "Client", value: payload.clientNom ?? payload.clientCode },
+    ],
+    { compact: true }
+  );
+
+  ctx.section("Affaires de livraison", { cohesion: TABLE_SECTION_COHESION });
+  ctx.linesTable({
+    columns: [
+      { key: "numero", label: "Affaire", flex: 1.4 },
+      { key: "delai", label: "Délai client", flex: 1.2 },
+      { key: "quantite", label: "Quantité", flex: 1, align: "right" },
+    ],
+    rows: payload.affaires.map<CerpLineRow>((affaire) => ({
+      cells: {
+        numero: affaire.numero ?? `#${affaire.affaireId}`,
+        delai: formatDateFr(affaire.delaiClient),
+        quantite: formatQuantity(affaire.quantite),
+      },
+    })),
+    emptyLabel: "Aucune affaire de livraison rattachée.",
+  });
+
+  if (payload.cadenceLivraison.length) {
+    ctx.section("Cadence de livraison", { cohesion: TABLE_SECTION_COHESION });
+    ctx.linesTable({
+      columns: [
+        { key: "date", label: "Échéance", flex: 1.2 },
+        { key: "affaire", label: "Affaire", flex: 1.4 },
+        { key: "quantite", label: "Quantité", flex: 1, align: "right" },
+      ],
+      rows: payload.cadenceLivraison.map<CerpLineRow>((echeance) => ({
+        cells: {
+          date: formatDateFr(echeance.date),
+          affaire: echeance.affaireNumero ?? "—",
+          quantite: formatQuantity(echeance.quantite),
+        },
+      })),
+      emptyLabel: "Aucune cadence de livraison définie.",
+    });
+  }
+
+  // Couverture de la demande. Les postes sont disjoints : leur somme et le reste
+  // net redonnent la quantité demandée. Le document affiche donc une répartition,
+  // pas une collection d'indicateurs qui pourraient se recouper.
+  ctx.section("Couverture de la demande");
+  const q = payload.quantites;
+  const grid: Array<[string, string]> = [
+    ["Quantité demandée", formatQuantity(q.quantiteDemandee)],
+    ["Déjà livrée", formatQuantity(q.quantiteLivree)],
+    ["Stock réservé", formatQuantity(q.stockReserve)],
+    ["Couverte par d'autres OF actifs", formatQuantity(q.couvertAutresOf)],
+    ["Affectée à cet OF", formatQuantity(q.quantiteAffecteeCetOf)],
+    ["Reste net à couvrir", formatQuantity(q.resteNetACouvrir)],
+  ];
+  renderFieldGrid(ctx, grid, 3);
+
+  if (q.surCouverture) {
+    ctx.notes(
+      `Sur-couverture de ${formatQuantity(q.excedent)} : les couvertures dépassent la quantité demandée. À arbitrer avant lancement.`
+    );
+  }
+
+  if (payload.cadenceProduction.length || payload.derniereFabrication) {
+    ctx.section("Décision de production");
+    const production: Array<[string, string]> = [];
+    if (payload.cadenceProduction.length) {
+      production.push([
+        "Cadence décidée en production",
+        payload.cadenceProduction
+          .map((c) => `${formatDateFr(c.date)} : ${formatQuantity(c.quantite)}`)
+          .join("  |  "),
+      ]);
+    }
+    if (payload.derniereFabrication) {
+      production.push([
+        "Dernière fabrication",
+        [payload.derniereFabrication.numero, formatDateFr(payload.derniereFabrication.date)]
+          .filter(Boolean)
+          .join(" — ") || "—",
+      ]);
+    }
+    renderFieldGrid(ctx, production, production.length > 1 ? 2 : 1);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Page 1 — moitié basse : pièce, gamme, matière, débit
+// ---------------------------------------------------------------------------
+
+function renderTechnicalHalf(ctx: CerpDocumentContext, payload: OfDocumentPayload): void {
+  ctx.section("Pièce et gamme");
+  renderFieldGrid(
+    ctx,
+    [
+      ["Référence pièce", payload.pieceReference ?? "—"],
+      ["Indice", payload.pieceIndice ?? "—"],
+      ["Gamme", payload.gammeCode ?? "—"],
+      ["Désignation", payload.pieceDesignation ?? "—"],
+      ["Version de gamme", payload.gammeVersion ?? "—"],
+      ["Séquence machines", payload.sequenceMachinesLabel],
+    ],
+    3
+  );
+
+  if (payload.documentsAFournir.length) {
+    ctx.notesSection(
+      "Documents à fournir",
+      payload.documentsAFournir.map((doc) => `- ${doc}`).join("\n")
+    );
+  }
+
+  ctx.section("Matière et découpe");
+  renderFieldGrid(
+    ctx,
+    [
+      ["Référence matière", payload.matiere.reference ?? "—"],
+      ["Désignation", payload.matiere.designation ?? "—"],
+      ["Nuance", payload.matiere.nuance ?? "—"],
+      ["Dimensions", payload.decoupe.dimensions ?? "—"],
+      ["Unité", payload.decoupe.unite ?? "—"],
+      ["Pièces par brut", formatQuantity(payload.decoupe.piecesParBrut)],
+      ["Longueur du brut", millimetres(payload.decoupe.longueurBrutMm, 0)],
+      ["Longueur utile", millimetres(payload.decoupe.longueurUtileMm, 0)],
+      ["Nombre de bruts", formatQuantity(payload.decoupe.nombreBruts)],
+      // « si disponibles » : l'atelier ne renseigne pas toujours le trait de scie.
+      // Un tiret dit « non renseigné » ; un 0 affirmerait une scie sans épaisseur.
+      ["Trait de scie", millimetres(payload.decoupe.traitDeScieMm, 1)],
+      ["Chute", millimetres(payload.decoupe.chuteMm, 1)],
+      ["Longueur totale", millimetres(payload.decoupe.longueurTotaleMm, 2)],
+      [
+        "Masse totale",
+        payload.decoupe.masseTotaleKg !== null
+          ? `${formatNumberFr(payload.decoupe.masseTotaleKg, 3)} kg`
+          : "— (non calculable)",
+      ],
+      ["Passages machines", `${payload.sequenceMachines.length}`],
+      ["Séquence réelle", payload.sequenceMachinesLabel],
+    ],
+    3
+  );
+
+  // La méthode de calcul est imprimée sous le tableau : un magasinier doit
+  // pouvoir refaire le calcul de la longueur totale, pas le croire sur parole.
+  if (payload.decoupe.methodeCalcul) {
+    ctx.notes(`Méthode de calcul — ${payload.decoupe.methodeCalcul}`);
+  }
+}
+
+/** Longueur en millimètres, ou tiret explicite quand la donnée manque. */
+function millimetres(value: number | null, decimals: number): string {
+  return value !== null && value !== undefined
+    ? `${formatNumberFr(value, decimals)} mm`
+    : "—";
+}
+
+// ---------------------------------------------------------------------------
+// Pages gamme
+// ---------------------------------------------------------------------------
+
+function renderGamme(ctx: CerpDocumentContext, payload: OfDocumentPayload): void {
+  ctx.section("Gamme de fabrication", { cohesion: TABLE_SECTION_COHESION });
+
+  ctx.linesTable({
+    columns: GAMME_COLUMNS,
+    rows: payload.phases.map<CerpLineRow>((phase) => ({
+      cells: {
+        phase: String(phase.phase),
+        famille: phase.family ?? "—",
+        centre: phase.centre ?? "—",
+        machine: phase.machine ?? "—",
+        designation: phase.designation,
+        tunit: phase.tempsUnitaireLabel,
+        preparation: phase.preparationLabel,
+        fabrication: phase.fabricationLabel,
+        final: phase.finalLabel,
+        qte: formatQuantity(phase.quantiteBase),
+        // Une case vide se remplit à la main en atelier : c'est la colonne du
+        // papier. Un tiret laisserait croire que la phase n'a pas à être visée.
+        visa: phase.visa.visaOperateur ?? "",
+      },
+      meta: buildPhaseMeta(phase),
+      metaColumn: "designation",
+    })),
+    emptyLabel: "Aucune phase dans cette révision.",
+  });
+
+  ctx.section("Totaux");
+  renderFieldGrid(
+    ctx,
+    [
+      ["Préparation", payload.totaux.preparationLabel],
+      ["Fabrication", payload.totaux.fabricationLabel],
+      ["Total", payload.totaux.finalLabel],
+    ],
+    3
+  );
+
+  renderVisaDetail(ctx, payload);
+  renderAvertissements(ctx, payload);
+
+  ctx.signatureBox("Contrôle final", ["Nom", "Date", "Signature"]);
+}
+
+/**
+ * Ligne secondaire d'une phase : n° de programme, ou son absence signalée.
+ *
+ * Un programme manquant sur une famille qui l'exige est écrit noir sur blanc.
+ * L'omettre laisserait l'opérateur chercher un fichier qui n'a jamais été
+ * référencé, et croire à une erreur de sa part.
+ */
+function buildPhaseMeta(phase: OfDocumentPayload["phases"][number]): string | null {
+  if (phase.programme) return `Programme : ${phase.programme}`;
+  if (phase.programmeManquant) return "Programme : NON RENSEIGNÉ — à obtenir avant lancement";
+  return null;
+}
+
+function renderVisaDetail(ctx: CerpDocumentContext, payload: OfDocumentPayload): void {
+  ctx.section("Contrôles et VISA", { cohesion: TABLE_SECTION_COHESION });
+
+  ctx.linesTable({
+    columns: VISA_COLUMNS,
+    rows: payload.phases.map<CerpLineRow>((phase) => ({
+      cells: {
+        phase: String(phase.phase),
+        statut: VISA_STATUT_LABELS[phase.visa.statut] ?? phase.visa.statut,
+        operateur: phase.visa.operateur ?? "",
+        date: phase.visa.visaAt ? formatDateTimeFr(phase.visa.visaAt) : "",
+        bonne: phase.visa.quantiteBonne !== null ? formatQuantity(phase.visa.quantiteBonne) : "",
+        rebut: phase.visa.quantiteRebut !== null ? formatQuantity(phase.visa.quantiteRebut) : "",
+        motif: phase.visa.motifRebut ?? "",
+        visaOp: phase.visa.visaOperateur ?? "",
+        visaCtrl: phase.visa.visaControle ?? "",
+      },
+      meta: phase.visa.commentaire ? `Commentaire : ${phase.visa.commentaire}` : null,
+      metaColumn: "motif",
+    })),
+    emptyLabel: "Aucune phase à viser.",
+  });
+}
+
+const VISA_STATUT_LABELS: Record<string, string> = {
+  A_FAIRE: "À faire",
+  EN_COURS: "En cours",
+  VISE: "Visé",
+  REFUSE: "Refusé",
+};
+
+/**
+ * Avertissements imprimés sur la pièce elle-même.
+ *
+ * Les laisser seulement à l'écran reviendrait à publier un document propre qui
+ * tait ses propres trous : l'atelier travaille sur le papier, pas sur l'aperçu.
+ */
+function renderAvertissements(ctx: CerpDocumentContext, payload: OfDocumentPayload): void {
+  if (!payload.avertissements.length) return;
+
+  ctx.section("Signalements");
+  ctx.notes(
+    payload.avertissements
+      .map((warning) => `[${warning.severite}] ${warning.message}`)
+      .join("\n")
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Grille de champs
+// ---------------------------------------------------------------------------
+
+/**
+ * Champs disposés en colonnes, ligne par ligne.
+ *
+ * La hauteur d'une ligne est celle de son champ le plus haut : une désignation
+ * longue ne doit pas chevaucher la ligne suivante.
+ */
+function renderFieldGrid(
+  ctx: CerpDocumentContext,
+  entries: Array<[string, string]>,
+  columns: number
+): void {
+  if (!entries.length) return;
+  const contentWidth = 519.28;
+  const gap = 16;
+  const width = (contentWidth - gap * (columns - 1)) / columns;
+  const marginX = 38;
+
+  for (let index = 0; index < entries.length; index += columns) {
+    const row = entries.slice(index, index + columns);
+    ctx.ensureSpace(34);
+    const top = ctx.y;
+    let bottom = top;
+
+    row.forEach((entry, column) => {
+      ctx.y = top;
+      const end = ctx.field(entry[0], entry[1], marginX + (width + gap) * column, width);
+      if (end > bottom) bottom = end;
+    });
+
+    ctx.y = bottom + 8;
+  }
+}
+
+function formatDateTimeFr(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  const pad = (value: number) => String(value).padStart(2, "0");
+  // UTC : deux serveurs de fuseaux différents doivent produire le même document.
+  return `${pad(date.getUTCDate())}/${pad(date.getUTCMonth() + 1)}/${date.getUTCFullYear()} à ${pad(
+    date.getUTCHours()
+  )}:${pad(date.getUTCMinutes())}`;
+}

--- a/src/module/production/services/of-versioning.service.ts
+++ b/src/module/production/services/of-versioning.service.ts
@@ -1,0 +1,1301 @@
+// Orchestration du chantier « OF, versioning, replanification, AR, document » (#370).
+//
+// Le domaine décide, ce service exécute. Aucune règle métier n'est réécrite ici :
+// les seuils, les diffs, les transitions et les décisions d'AR viennent des modules
+// purs de `../domain`, qui sont testables sans base.
+//
+// Trois invariants tenus par ce fichier :
+//   1. Une écriture et son audit vivent dans la MÊME transaction.
+//   2. Le planning ACTIF n'est jamais muté par une création de brouillon.
+//   3. Une réimpression ne crée ni révision, ni document, ni version GED.
+
+import { HttpError } from "../../../utils/httpError";
+import {
+  buildInternalNotification,
+  notificationDedupeKey,
+  NOTIFICATION_TOPICS,
+  resolveNotificationRecipients,
+} from "../../../shared/notifications/routing";
+import {
+  insertAuditLog,
+  type AuditContext,
+} from "../../project-office/repository/project-office.repository";
+import {
+  buildRevisionSnapshot,
+  checkRevisionCreation,
+  diffRevisionSnapshots,
+  formatRevisionCode,
+  hashSnapshot,
+  nextRevisionRank,
+  type MachineFamilyRef,
+  type OfRevisionOperation,
+  type OfRevisionSnapshotInput,
+} from "../domain/of-revision";
+import {
+  assessTimeVariance,
+  buildTimeVarianceProposal,
+  describeProposal,
+  isOfTimeVarianceCause,
+  type OfTimeVarianceCause,
+} from "../domain/of-time-variance";
+import {
+  buildPlanningPayload,
+  checkPlanningTransition,
+  comparePlanningVersions,
+  hashPlanningPayload,
+  requiresArRecalage,
+  type OfPlanningPayload,
+  type OfPlanningStatut,
+} from "../domain/of-planning-version";
+import {
+  buildArRecalageDossiers,
+  canTransitionArStatut,
+  decideArRecalage,
+  validateArRecalageInput,
+  type ArRecalageStatut,
+} from "../domain/ar-recalage";
+import {
+  buildOfDocumentPayload,
+  hashDocumentPayload,
+  watermarkFor,
+  type OfDocumentPayload,
+} from "../domain/of-document";
+import { renderOfDocument } from "./of-document-render";
+import { archiveOfDocument, readArchivedOfDocument } from "./of-document-archive";
+import * as repo from "../repository/of-versioning.repository";
+
+export type OfActor = {
+  userId: number;
+  username: string;
+  role: string | null | undefined;
+};
+
+/* ========================================================================== */
+/* A) Révisions                                                               */
+/* ========================================================================== */
+
+export async function listRevisions(ofId: number) {
+  const header = await repo.readOfHeader(ofId);
+  const revisions = await repo.listRevisions(ofId);
+  return { of: header, revisions };
+}
+
+export async function getRevisionDetail(ofId: number, revisionId: string) {
+  await repo.readOfHeader(ofId);
+  const revision = await repo.getRevision(ofId, revisionId);
+  if (!revision) {
+    // 404 et non 403 : confirmer l'existence d'une révision appartenant à un
+    // autre OF renseignerait l'appelant sur un dossier qui ne le concerne pas.
+    throw new HttpError(404, "OF_REVISION_NOT_FOUND", "Révision introuvable sur cet ordre de fabrication.");
+  }
+  const [operations, visas] = await Promise.all([
+    repo.listOperations(ofId, revisionId),
+    repo.listVisas(ofId, revisionId),
+  ]);
+  return { revision, operations, visas };
+}
+
+/** Instantané de l'état courant, prêt à être figé dans une révision. */
+async function buildCurrentSnapshot(
+  ofId: number,
+  revisionId: string | null,
+  tx?: repo.DbQueryer
+): Promise<{ snapshot: OfRevisionSnapshotInput; operations: OfRevisionOperation[] }> {
+  const header = await repo.readOfHeader(ofId, tx);
+  const operations = revisionId ? await repo.listOperations(ofId, revisionId, tx) : [];
+
+  return {
+    operations,
+    snapshot: {
+      ofId: header.of_id,
+      ofNumero: header.numero,
+      pieceReference: header.piece_reference,
+      pieceDesignation: header.piece_designation,
+      pieceIndice: header.piece_indice,
+      gammeId: header.gamme_id,
+      gammeCode: header.gamme_code,
+      gammeVersion: header.gamme_version,
+      quantiteLancee: header.quantite_lancee,
+      matiere: null,
+      operations,
+    },
+  };
+}
+
+export type CreateRevisionInput = {
+  motif: string | null;
+  /** Modifications de phases à appliquer sur la NOUVELLE révision. */
+  operations?: Array<{
+    phase: number;
+    designation?: string;
+    family?: string | null;
+    machineId?: string | null;
+    programme?: string | null;
+    tempsUnitaire?: number;
+    preparation?: number;
+    quantiteBase?: number;
+    coefficient?: number;
+  }>;
+};
+
+/**
+ * Crée une révision.
+ *
+ * L'ancienne révision n'est PAS modifiée : ses opérations restent en place, avec
+ * leurs pointages et leurs VISA. Les opérations sont RECOPIÉES vers la nouvelle
+ * révision, puis les modifications s'y appliquent. C'est l'unicité
+ * `(of_id, revision_id, phase)` qui rend cette coexistence possible.
+ */
+export async function createRevision(
+  ofId: number,
+  input: CreateRevisionInput,
+  actor: OfActor,
+  audit: AuditContext,
+  familles: MachineFamilyRef[]
+) {
+  return repo.withOfTransaction(async (tx) => {
+    await repo.lockOf(tx, ofId);
+
+    const header = await repo.readOfHeader(ofId, tx);
+    const current = await repo.getActiveRevision(ofId, tx);
+    const rank = nextRevisionRank(current ? current.revision_rank : null);
+    const code = formatRevisionCode(rank);
+
+    const before = current
+      ? ((current.snapshot as OfRevisionSnapshotInput | null) ?? null)
+      : null;
+
+    // 1) La révision est créée d'abord : les opérations recopiées ont besoin de
+    //    son identifiant pour exister sans écraser celles de la précédente.
+    const provisional = buildRevisionSnapshot({
+      ...(await buildCurrentSnapshot(ofId, current?.id ?? null, tx)).snapshot,
+    });
+
+    const created = await repo.insertRevision(tx, {
+      ofId,
+      rank,
+      code,
+      snapshot: provisional,
+      snapshotSha256: hashSnapshot(provisional),
+      diff: null,
+      motif: input.motif,
+      authorUserId: actor.userId,
+    });
+
+    if (current) {
+      await repo.copyOperationsToRevision(tx, {
+        ofId,
+        fromRevisionId: current.id,
+        toRevisionId: created.id,
+      });
+    }
+
+    // 2) Les modifications s'appliquent à la nouvelle révision uniquement.
+    for (const change of input.operations ?? []) {
+      if (change.family !== undefined && change.family !== null) {
+        // Une famille absente du référentiel est refusée : elle produirait une
+        // gamme qui ne correspond à aucun atelier.
+        if (!familles.some((f) => f.code === change.family)) {
+          throw new HttpError(
+            422,
+            "OF_FAMILY_UNKNOWN",
+            `Famille machine inconnue du référentiel : ${change.family}.`
+          );
+        }
+      }
+      await repo.updateOperationOnRevision(tx, { ofId, revisionId: created.id, ...change });
+    }
+
+    // 3) L'instantané définitif est reconstruit APRÈS modification, puis haché.
+    const after = buildRevisionSnapshot(
+      (await buildCurrentSnapshot(ofId, created.id, tx)).snapshot
+    );
+    const diff = diffRevisionSnapshots(before, after);
+
+    // 4) La règle métier tranche : motif obligatoire dès R01, refus si identique.
+    const check = checkRevisionCreation({ nextRank: rank, motif: input.motif, diff });
+    if (!check.allowed) {
+      // Le rollback annule la révision ET la recopie des opérations : rien ne
+      // subsiste d'une révision refusée.
+      throw new HttpError(422, check.code, check.message);
+    }
+
+    const sha256 = hashSnapshot(after);
+    await tx.query(
+      `UPDATE public.of_revisions SET snapshot = $2::jsonb, snapshot_sha256 = $3, diff = $4::jsonb
+        WHERE id = $1::uuid`,
+      [created.id, JSON.stringify(after), sha256, JSON.stringify(diff)]
+    );
+
+    await insertAuditLog(tx, audit, {
+      action: "OF_REVISION_CREATE",
+      entity_type: "of_revision",
+      entity_id: created.id,
+      details: {
+        of_id: ofId,
+        of_numero: header.numero,
+        revision_code: code,
+        motif: input.motif,
+        snapshot_sha256: sha256,
+        phases_ajoutees: diff.summary.phasesAjoutees,
+        phases_retirees: diff.summary.phasesRetirees,
+        phases_modifiees: diff.summary.phasesModifiees,
+        delta_temps_total_h: diff.summary.deltaTempsTotalH,
+      },
+    });
+
+    const refreshed = await repo.getRevision(ofId, created.id, tx);
+    return { revision: refreshed, diff };
+  });
+}
+
+export async function compareRevisions(ofId: number, fromId: string, toId: string) {
+  await repo.readOfHeader(ofId);
+  const [from, to] = await Promise.all([
+    repo.getRevision(ofId, fromId),
+    repo.getRevision(ofId, toId),
+  ]);
+  if (!from || !to) {
+    throw new HttpError(404, "OF_REVISION_NOT_FOUND", "Révision introuvable sur cet ordre de fabrication.");
+  }
+  const diff = diffRevisionSnapshots(
+    from.snapshot as OfRevisionSnapshotInput,
+    to.snapshot as OfRevisionSnapshotInput
+  );
+  return { from, to, diff };
+}
+
+/* ========================================================================== */
+/* B) VISA de phase                                                           */
+/* ========================================================================== */
+
+export type CreateVisaInput = {
+  phase: number;
+  statut: string;
+  initials: string;
+  quantiteBonne: number | null;
+  quantiteRebut: number | null;
+  motifRebut: string | null;
+  controleInitials: string | null;
+  comment: string | null;
+};
+
+export async function createVisa(
+  ofId: number,
+  revisionId: string,
+  input: CreateVisaInput,
+  actor: OfActor,
+  audit: AuditContext
+) {
+  return repo.withOfTransaction(async (tx) => {
+    const revision = await repo.getRevision(ofId, revisionId, tx);
+    if (!revision) {
+      throw new HttpError(404, "OF_REVISION_NOT_FOUND", "Révision introuvable sur cet ordre de fabrication.");
+    }
+    // Viser une révision obsolète réécrirait l'histoire : le VISA appartient à la
+    // révision sous laquelle la phase a été faite.
+    if (revision.statut === "OBSOLETE") {
+      throw new HttpError(
+        409,
+        "OF_REVISION_OBSOLETE",
+        "Cette révision est obsolète : elle ne peut plus être visée."
+      );
+    }
+
+    const visaId = await repo.insertVisa(tx, {
+      ofId,
+      revisionId,
+      phase: input.phase,
+      userId: actor.userId,
+      initials: input.initials,
+      statut: input.statut,
+      quantiteBonne: input.quantiteBonne,
+      quantiteRebut: input.quantiteRebut,
+      motifRebut: input.motifRebut,
+      controleUserId: input.controleInitials ? actor.userId : null,
+      controleInitials: input.controleInitials,
+      comment: input.comment,
+    });
+
+    await insertAuditLog(tx, audit, {
+      action: "OF_VISA_CREATE",
+      entity_type: "of_operation_visa",
+      entity_id: visaId,
+      details: {
+        of_id: ofId,
+        revision_id: revisionId,
+        revision_code: revision.revision_code,
+        phase: input.phase,
+        statut: input.statut,
+        quantite_bonne: input.quantiteBonne,
+        quantite_rebut: input.quantiteRebut,
+      },
+    });
+
+    return { visaId };
+  });
+}
+
+/* ========================================================================== */
+/* C) Dérive de temps et proposition de replanification                       */
+/* ========================================================================== */
+
+/**
+ * Évalue une dérive sans rien écrire.
+ *
+ * SOURCE DU TEMPS DE RÉFÉRENCE — documentée et unique : c'est le temps de
+ * fabrication figé dans la révision ACTIVE de l'OF pour cette phase, soit
+ * `of_operations.temps_fabrication_planned` de la révision active
+ * (= `tf_unit x qte x coef` au moment du lancement). Ce n'est PAS le temps de la
+ * gamme de la pièce technique : celle-ci peut avoir bougé depuis le lancement, et
+ * comparer un temps reprogrammé à une gamme modifiée entre-temps mesurerait deux
+ * changements à la fois. Ce n'est pas non plus un temps réel pointé : la dérive
+ * mesurée ici est une dérive de PRÉVISION, décidée à la programmation.
+ *
+ * Référence absente ou nulle : revue humaine, sans division.
+ */
+export async function assessVariance(
+  ofId: number,
+  input: { phase: number; newTime: number }
+) {
+  await repo.readOfHeader(ofId);
+  const active = await repo.getActiveRevision(ofId);
+  if (!active) {
+    throw new HttpError(409, "OF_NO_ACTIVE_REVISION", "Cet OF n'a aucune révision active.");
+  }
+  const operations = await repo.listOperations(ofId, active.id);
+  const operation = operations.find((op) => op.phase === input.phase);
+  if (!operation) {
+    throw new HttpError(404, "OF_PHASE_NOT_FOUND", `Phase ${input.phase} absente de la révision active.`);
+  }
+
+  const referenceTime = operation.tempsUnitaire * operation.quantiteBase * operation.coefficient;
+  const assessment = assessTimeVariance({
+    // Un temps de référence nul est transmis tel quel : le domaine le traite en
+    // revue humaine. Le remplacer par une valeur par défaut fabriquerait une
+    // dérive qui n'a pas de sens.
+    referenceTime: referenceTime === 0 ? null : referenceTime,
+    newTime: input.newTime,
+  });
+
+  return {
+    revision: { id: active.id, code: active.revision_code },
+    phase: input.phase,
+    referenceTime: referenceTime === 0 ? null : referenceTime,
+    referenceSource:
+      "temps_fabrication_planned de la révision active (tf_unit x qte x coef figés au lancement)",
+    newTime: input.newTime,
+    assessment,
+  };
+}
+
+export type CreateProposalInput = {
+  phase: number;
+  newTime: number;
+  cause: OfTimeVarianceCause;
+  causeComment: string | null;
+};
+
+export async function createProposal(
+  ofId: number,
+  input: CreateProposalInput,
+  actor: OfActor,
+  audit: AuditContext,
+  idempotencyKey: string | null
+) {
+  if (!isOfTimeVarianceCause(input.cause)) {
+    throw new HttpError(422, "OF_VARIANCE_CAUSE_INVALID", `Cause de dérive inconnue : ${input.cause}.`);
+  }
+
+  return repo.withOfTransaction(async (tx) => {
+    if (idempotencyKey) {
+      const existing = await repo.findProposalByIdempotencyKey(tx, idempotencyKey);
+      // Rejouer la même clé ne recrée rien et ne renvoie pas d'erreur : c'est le
+      // contrat d'idempotence, un retry réseau doit être indolore.
+      if (existing) return { proposal: existing, replayed: true, notified: [] as number[] };
+    }
+
+    const header = await repo.readOfHeader(ofId, tx);
+    const active = await repo.getActiveRevision(ofId, tx);
+    if (!active) {
+      throw new HttpError(409, "OF_NO_ACTIVE_REVISION", "Cet OF n'a aucune révision active.");
+    }
+
+    const operations = await repo.listOperations(ofId, active.id, tx);
+    const operation = operations.find((op) => op.phase === input.phase);
+    if (!operation) {
+      throw new HttpError(404, "OF_PHASE_NOT_FOUND", `Phase ${input.phase} absente de la révision active.`);
+    }
+
+    const referenceRaw = operation.tempsUnitaire * operation.quantiteBase * operation.coefficient;
+    const referenceTime = referenceRaw === 0 ? null : referenceRaw;
+
+    const chargeAvantH = operations.reduce(
+      (sum, op) => sum + op.preparation + op.tempsUnitaire * op.quantiteBase * op.coefficient,
+      0
+    );
+    const chargeApresH = chargeAvantH - referenceRaw + input.newTime;
+
+    const built = buildTimeVarianceProposal({
+      ofId,
+      ofNumero: header.numero,
+      revisionId: active.id,
+      revisionCode: active.revision_code,
+      ofOperationId: operation.id,
+      phase: input.phase,
+      family: operation.family,
+      referenceTime,
+      newTime: input.newTime,
+      cause: input.cause,
+      causeComment: input.causeComment,
+      authorUserId: actor.userId,
+      impactCharge: {
+        chargeAvantH: round4(chargeAvantH),
+        chargeApresH: round4(chargeApresH),
+        deltaH: round4(chargeApresH - chargeAvantH),
+        operationsImpactees: 1,
+      },
+      machines: [
+        {
+          machineId: operation.machineId,
+          machineLabel: operation.machineLabel,
+          family: operation.family,
+          deltaHeures: round4(input.newTime - referenceRaw),
+        },
+      ],
+      affaires: header.affaire_id
+        ? [
+            {
+              affaireId: header.affaire_id,
+              affaireNumero: null,
+              clientId: header.client_id,
+              clientNom: header.client_nom,
+              delaiClient: header.date_fin_prevue,
+            },
+          ]
+        : [],
+      simulation: {
+        schema: "of-time-variance-simulation/1",
+        decalageFinJours: null,
+        dateFinAvant: header.date_fin_prevue,
+        dateFinApres: null,
+        engagementsEnRisque: [],
+      },
+    });
+
+    // Dérive dans la tolérance : rien n'est écrit. Consigner une non-dérive
+    // noierait les vraies alertes du planificateur.
+    if (!built.created) {
+      return { proposal: null, assessment: built.assessment, replayed: false, notified: [] as number[] };
+    }
+
+    const proposalId = await repo.insertProposal(tx, {
+      ofId,
+      revisionId: active.id,
+      ofOperationId: operation.id,
+      phase: input.phase,
+      referenceTime,
+      newTime: input.newTime,
+      variationPct: built.proposal.variationPct,
+      outcome: built.proposal.outcome,
+      reviewRequired: built.proposal.reviewRequired,
+      cause: built.proposal.cause,
+      causeComment: built.proposal.causeComment,
+      impactCharge: built.proposal.impactCharge,
+      machines: built.proposal.machines,
+      affaires: built.proposal.affaires,
+      simulation: built.proposal.simulation,
+      authorUserId: actor.userId,
+      idempotencyKey,
+    });
+
+    const notified = await notifyTopic(
+      tx,
+      NOTIFICATION_TOPICS.OF_TIME_VARIANCE,
+      describeProposal(built.proposal)
+    );
+
+    await insertAuditLog(tx, audit, {
+      action: "OF_TIME_VARIANCE_PROPOSE",
+      entity_type: "of_time_variance_proposal",
+      entity_id: proposalId,
+      details: {
+        of_id: ofId,
+        of_numero: header.numero,
+        phase: input.phase,
+        reference_time: referenceTime,
+        new_time: input.newTime,
+        variation_pct: built.proposal.variationPct,
+        outcome: built.proposal.outcome,
+        cause: built.proposal.cause,
+        notified_user_ids: notified,
+      },
+    });
+
+    const stored = await repo.findProposalByIdempotencyKey(tx, idempotencyKey ?? "");
+    return {
+      proposal: stored ?? { id: proposalId },
+      assessment: built.assessment,
+      replayed: false,
+      notified,
+    };
+  });
+}
+
+export async function listProposals(ofId: number) {
+  await repo.readOfHeader(ofId);
+  return repo.listProposals(ofId);
+}
+
+export async function resolveProposal(
+  ofId: number,
+  proposalId: string,
+  input: { statut: "ACCEPTEE" | "REFUSEE" | "CADUQUE"; comment: string | null },
+  actor: OfActor,
+  audit: AuditContext
+) {
+  return repo.withOfTransaction(async (tx) => {
+    await repo.readOfHeader(ofId, tx);
+    await repo.resolveProposal(tx, {
+      ofId,
+      proposalId,
+      statut: input.statut,
+      userId: actor.userId,
+      comment: input.comment,
+    });
+    await insertAuditLog(tx, audit, {
+      action: "OF_TIME_VARIANCE_RESOLVE",
+      entity_type: "of_time_variance_proposal",
+      entity_id: proposalId,
+      details: { of_id: ofId, statut: input.statut, comment: input.comment },
+    });
+    return { ok: true };
+  });
+}
+
+/* ========================================================================== */
+/* D) Versions de planning                                                    */
+/* ========================================================================== */
+
+export async function listPlanningVersions(ofId: number) {
+  await repo.readOfHeader(ofId);
+  const versions = await repo.listPlanningVersions(ofId);
+  return { versions };
+}
+
+/**
+ * Crée un brouillon de planning.
+ *
+ * Le plan ACTIF n'est ni lu en écriture ni touché : il sert de BASE de comparaison
+ * et rien de plus. Son identifiant est enregistré comme `base_version_id`, ce qui
+ * donne le verrou optimiste à la validation — si l'ACTIF a changé entre-temps, la
+ * validation refuse au lieu d'appliquer un brouillon calculé sur un autre état.
+ */
+export async function createPlanningDraft(
+  ofId: number,
+  input: { payload: OfPlanningPayload; sourceProposalId: string | null },
+  actor: OfActor,
+  audit: AuditContext,
+  idempotencyKey: string | null
+) {
+  return repo.withOfTransaction(async (tx) => {
+    if (idempotencyKey) {
+      const existing = await repo.findPlanningByIdempotencyKey(tx, idempotencyKey);
+      if (existing) return { version: existing, replayed: true, comparison: existing.comparison };
+    }
+
+    await repo.lockOf(tx, ofId);
+    const header = await repo.readOfHeader(ofId, tx);
+
+    const openDraft = await repo.getPlanningByStatut(ofId, ["BROUILLON", "SOUMIS"], tx);
+    if (openDraft) {
+      throw new HttpError(
+        409,
+        "OF_PLANNING_DRAFT_EXISTS",
+        `Un brouillon de planning est déjà en circuit (${openDraft.statut}) sur cet OF.`
+      );
+    }
+
+    const active = await repo.getPlanningByStatut(ofId, ["ACTIF"], tx);
+    const activeRevision = await repo.getActiveRevision(ofId, tx);
+
+    const payload = buildPlanningPayload(input.payload);
+    const comparison = active
+      ? comparePlanningVersions(active.payload, payload)
+      : comparePlanningVersions(null, payload);
+
+    const rank = await repo.nextPlanningRank(tx, ofId);
+    const version = await repo.insertPlanningVersion(tx, {
+      ofId,
+      revisionId: activeRevision?.id ?? null,
+      rank,
+      statut: "BROUILLON",
+      payload,
+      payloadSha256: hashPlanningPayload(payload),
+      baseVersionId: active?.id ?? null,
+      comparison,
+      clientImpact: comparison.clientImpact,
+      sourceProposalId: input.sourceProposalId,
+      authorUserId: actor.userId,
+      idempotencyKey,
+    });
+
+    await insertAuditLog(tx, audit, {
+      action: "OF_PLANNING_DRAFT_CREATE",
+      entity_type: "of_planning_version",
+      entity_id: version.id,
+      details: {
+        of_id: ofId,
+        of_numero: header.numero,
+        version_rank: rank,
+        base_version_id: active?.id ?? null,
+        client_impact: comparison.clientImpact,
+        payload_sha256: version.payload_sha256,
+      },
+    });
+
+    return { version, comparison, replayed: false };
+  });
+}
+
+export async function transitionPlanning(
+  ofId: number,
+  versionId: string,
+  next: OfPlanningStatut,
+  input: { comment: string | null },
+  actor: OfActor,
+  audit: AuditContext
+) {
+  return repo.withOfTransaction(async (tx) => {
+    await repo.lockOf(tx, ofId);
+    const header = await repo.readOfHeader(ofId, tx);
+
+    const version = await repo.getPlanningVersion(ofId, versionId, tx);
+    if (!version) {
+      throw new HttpError(404, "OF_PLANNING_NOT_FOUND", "Version de planning introuvable sur cet OF.");
+    }
+
+    const check = checkPlanningTransition(version.statut, next);
+    if (!check.allowed) throw new HttpError(422, check.code, check.message);
+
+    // Un refus sans motif n'est pas un refus exploitable : celui qui a soumis le
+    // brouillon doit savoir ce qu'il doit corriger.
+    if (next === "REFUSE" && !(input.comment ?? "").trim()) {
+      throw new HttpError(
+        422,
+        "OF_PLANNING_REFUSAL_COMMENT_REQUIRED",
+        "Un refus de planning exige un motif."
+      );
+    }
+
+    await repo.transitionPlanningVersion(tx, {
+      ofId,
+      versionId,
+      expectedStatut: version.statut,
+      nextStatut: next,
+      userId: actor.userId,
+      comment: input.comment,
+    });
+
+    const dossiers: string[] = [];
+    let notified: number[] = [];
+
+    if (next === "SOUMIS") {
+      notified = await notifyTopic(
+        tx,
+        NOTIFICATION_TOPICS.OF_PLANNING_SUBMITTED,
+        `${header.numero} — planning v${version.version_rank} soumis à validation.`
+      );
+    }
+
+    // C'est la VALIDATION qui applique. Tant qu'elle n'a pas eu lieu, le plan
+    // ACTIF est intact — c'est l'invariant central de ce cycle.
+    if (next === "VALIDE") {
+      const active = await repo.getPlanningByStatut(ofId, ["ACTIF"], tx);
+
+      // Verrou optimiste : le brouillon a été calculé contre un ACTIF précis.
+      if ((active?.id ?? null) !== version.base_version_id) {
+        throw new HttpError(
+          409,
+          "OF_PLANNING_BASE_CHANGED",
+          "Le planning actif a changé depuis la création de ce brouillon : reprendre la comparaison avant de valider."
+        );
+      }
+
+      if (active) {
+        await repo.transitionPlanningVersion(tx, {
+          ofId,
+          versionId: active.id,
+          expectedStatut: "ACTIF",
+          nextStatut: "SUPERSEDE",
+          userId: actor.userId,
+        });
+      }
+
+      await repo.transitionPlanningVersion(tx, {
+        ofId,
+        versionId,
+        expectedStatut: "VALIDE",
+        nextStatut: "ACTIF",
+        userId: actor.userId,
+      });
+
+      // Un dossier d'AR n'est ouvert QUE si une date ou une cadence client est
+      // réellement touchée. Un décalage purement interne n'en crée aucun.
+      const comparison = version.comparison as ReturnType<typeof comparePlanningVersions> | null;
+      if (comparison && requiresArRecalage(comparison)) {
+        const decision = decideArRecalage(comparison);
+        if (decision.required) {
+          const built = buildArRecalageDossiers({
+            ofId,
+            ofNumero: header.numero,
+            planningVersionId: versionId,
+            comparison,
+            // Motif par défaut d'un recalage issu d'une validation de planning.
+            // Le service de l'AR peut le préciser ensuite ; il n'est jamais vide.
+            motif: "MODIFICATION_TECHNIQUE",
+            commentaire: input.comment,
+            ownerUserId: null,
+            clientNomByClientId: header.client_id
+              ? { [header.client_id]: header.client_nom }
+              : undefined,
+            commandeNumeroById: header.commande_id
+              ? { [header.commande_id]: header.commande_numero }
+              : undefined,
+          });
+          for (const dossier of built) {
+            const id = await repo.insertArDossier(tx, {
+              clientId: dossier.clientId,
+              commandeId: dossier.commandeId,
+              affaireId: dossier.affaireId,
+              ofId,
+              planningVersionId: versionId,
+              previousDate: dossier.previousDate,
+              newDate: dossier.newDate,
+              previousCadence: dossier.previousCadence,
+              newCadence: dossier.newCadence,
+              quantite: dossier.quantite,
+              motif: dossier.motif,
+              commentaire: dossier.commentaire,
+              ownerUserId: null,
+              createdBy: actor.userId,
+              idempotencyKey: `ar:${versionId}:${dossier.affaireId ?? "na"}`,
+            });
+            dossiers.push(id);
+          }
+          if (dossiers.length) {
+            notified = await notifyTopic(
+              tx,
+              NOTIFICATION_TOPICS.AR_RECALAGE,
+              `${header.numero} — ${dossiers.length} AR client à recaler après validation du planning.`
+            );
+          }
+        }
+      }
+    }
+
+    await insertAuditLog(tx, audit, {
+      action: `OF_PLANNING_${next}`,
+      entity_type: "of_planning_version",
+      entity_id: versionId,
+      details: {
+        of_id: ofId,
+        of_numero: header.numero,
+        from: version.statut,
+        to: next,
+        comment: input.comment,
+        ar_dossiers: dossiers,
+        notified_user_ids: notified,
+      },
+    });
+
+    const refreshed = await repo.getPlanningVersion(ofId, versionId, tx);
+    return { version: refreshed, arDossiers: dossiers, notified };
+  });
+}
+
+/* ========================================================================== */
+/* E) Dossiers d'AR à recaler                                                 */
+/* ========================================================================== */
+
+export async function listArDossiers(filters: { ofId?: number; statut?: string }) {
+  if (filters.ofId !== undefined) await repo.readOfHeader(filters.ofId);
+  return repo.listArDossiers(filters);
+}
+
+export async function createArDossier(
+  ofId: number,
+  input: {
+    affaireId: number | null;
+    previousDate: string | null;
+    newDate: string | null;
+    previousCadence: unknown;
+    newCadence: unknown;
+    quantite: number | null;
+    motif: string;
+    commentaire: string | null;
+    ownerUserId: number | null;
+  },
+  actor: OfActor,
+  audit: AuditContext,
+  idempotencyKey: string | null
+) {
+  // Le domaine valide le motif et l'obligation de commentaire sur « Autre ».
+  const validation = validateArRecalageInput({
+    motif: input.motif,
+    commentaire: input.commentaire,
+  });
+  if (!validation.valid) throw new HttpError(422, validation.code, validation.message);
+
+  // Un dossier d'AR n'existe que si une date OU une cadence change réellement.
+  // Sans cette garde, l'API laisserait ouvrir des dossiers vides, et la règle
+  // « uniquement si un engagement client est affecté » serait contournable.
+  const dateChanged =
+    (input.previousDate ?? null) !== (input.newDate ?? null) &&
+    (input.previousDate !== null || input.newDate !== null);
+  const cadenceChanged =
+    JSON.stringify(input.previousCadence ?? null) !== JSON.stringify(input.newCadence ?? null);
+  if (!dateChanged && !cadenceChanged) {
+    throw new HttpError(
+      422,
+      "AR_RECALAGE_NO_IMPACT",
+      "Aucune date ni cadence client n'est modifiée : il n'y a pas d'AR à recaler."
+    );
+  }
+
+  return repo.withOfTransaction(async (tx) => {
+    if (idempotencyKey) {
+      const existing = await repo.findArByIdempotencyKey(tx, idempotencyKey);
+      if (existing) return { dossier: existing, replayed: true, notified: [] as number[] };
+    }
+
+    const header = await repo.readOfHeader(ofId, tx);
+    const id = await repo.insertArDossier(tx, {
+      clientId: header.client_id,
+      commandeId: header.commande_id,
+      affaireId: input.affaireId ?? header.affaire_id,
+      ofId,
+      planningVersionId: null,
+      previousDate: input.previousDate,
+      newDate: input.newDate,
+      previousCadence: input.previousCadence,
+      newCadence: input.newCadence,
+      quantite: input.quantite,
+      motif: input.motif,
+      commentaire: input.commentaire,
+      ownerUserId: input.ownerUserId,
+      createdBy: actor.userId,
+      idempotencyKey,
+    });
+
+    const notified = await notifyTopic(
+      tx,
+      NOTIFICATION_TOPICS.AR_RECALAGE,
+      `${header.numero} — AR client à recaler (${input.motif}).`
+    );
+
+    await insertAuditLog(tx, audit, {
+      action: "AR_RECALAGE_CREATE",
+      entity_type: "ar_recalage_dossier",
+      entity_id: id,
+      details: {
+        of_id: ofId,
+        of_numero: header.numero,
+        motif: input.motif,
+        previous_date: input.previousDate,
+        new_date: input.newDate,
+        notified_user_ids: notified,
+      },
+    });
+
+    const dossier = await repo.getArDossier(id, tx);
+    return { dossier, replayed: false, notified };
+  });
+}
+
+export async function updateArDossier(
+  dossierId: string,
+  input: { statut: ArRecalageStatut; ownerUserId: number | null; commentaire: string | null },
+  actor: OfActor,
+  audit: AuditContext
+) {
+  return repo.withOfTransaction(async (tx) => {
+    const current = await repo.getArDossier(dossierId, tx);
+    if (!current) throw new HttpError(404, "AR_RECALAGE_NOT_FOUND", "Dossier d'AR introuvable.");
+
+    if (!canTransitionArStatut(current.statut as ArRecalageStatut, input.statut)) {
+      throw new HttpError(
+        422,
+        "AR_RECALAGE_TRANSITION",
+        `Transition d'AR interdite : ${current.statut} -> ${input.statut}.`
+      );
+    }
+
+    await repo.updateArDossier(tx, {
+      dossierId,
+      expectedStatut: current.statut,
+      statut: input.statut,
+      ownerUserId: input.ownerUserId,
+      commentaire: input.commentaire,
+      userId: actor.userId,
+    });
+
+    await insertAuditLog(tx, audit, {
+      action: "AR_RECALAGE_UPDATE",
+      entity_type: "ar_recalage_dossier",
+      entity_id: dossierId,
+      details: { from: current.statut, to: input.statut, of_id: current.of_id },
+    });
+
+    const dossier = await repo.getArDossier(dossierId, tx);
+    return { dossier };
+  });
+}
+
+/* ========================================================================== */
+/* F) Document d'OF — aperçu, émission, réimpression                          */
+/* ========================================================================== */
+
+/**
+ * Construit le payload du document.
+ *
+ * UNE seule fonction produit le payload, et l'aperçu comme l'émission passent par
+ * elle. C'est la garantie structurelle qu'aucune dérive n'est possible entre ce
+ * qui est montré et ce qui est émis : il n'y a pas deux chemins à faire
+ * concorder, il n'y en a qu'un.
+ */
+export async function buildDocumentPayload(
+  ofId: number,
+  args: { revisionId?: string | null; documentStatut: string; generatedAt: string; auteur: string | null }
+): Promise<{ payload: OfDocumentPayload; revisionId: string }> {
+  const header = await repo.readOfHeader(ofId);
+  const revision = args.revisionId
+    ? await repo.getRevision(ofId, args.revisionId)
+    : await repo.getActiveRevision(ofId);
+
+  if (!revision) {
+    throw new HttpError(
+      args.revisionId ? 404 : 409,
+      args.revisionId ? "OF_REVISION_NOT_FOUND" : "OF_NO_ACTIVE_REVISION",
+      args.revisionId
+        ? "Révision introuvable sur cet ordre de fabrication."
+        : "Cet OF n'a aucune révision active : aucun document ne peut être produit."
+    );
+  }
+
+  const [operations, visaRows, familles, commercial] = await Promise.all([
+    repo.listOperations(ofId, revision.id),
+    repo.listVisas(ofId, revision.id),
+    repo.readMachineFamilies(),
+    repo.readCommercialContext(header),
+  ]);
+
+  const visas: Record<number, Record<string, unknown>> = {};
+  for (const row of visaRows) {
+    visas[row.phase] = {
+      statut: row.statut,
+      operateur: row.operateur,
+      visaAt: row.visa_at,
+      quantiteBonne: row.quantite_bonne,
+      quantiteRebut: row.quantite_rebut,
+      motifRebut: row.motif_rebut,
+      visaOperateur: row.initials,
+      visaControle: row.controle_initials,
+      commentaire: row.comment,
+    };
+  }
+
+  const snapshot = revision.snapshot as { matiere?: Record<string, unknown> | null } | null;
+  const matiere = snapshot?.matiere ?? null;
+
+  const payload = buildOfDocumentPayload({
+    ofUuid: header.of_uuid,
+    ofNumero: header.numero,
+    revisionCode: revision.revision_code,
+    revisionStatut: revision.statut,
+    ofStatut: header.statut,
+    documentStatut: args.documentStatut,
+    snapshotId: revision.id,
+    snapshotSha256: revision.snapshot_sha256,
+    auteur: args.auteur,
+    generatedAt: args.generatedAt,
+    watermark: watermarkFor({
+      revisionStatut: revision.statut,
+      documentStatut: args.documentStatut,
+    }),
+
+    commandeNumero: header.commande_numero,
+    clientCode: header.client_id,
+    clientNom: header.client_nom,
+    affaires: commercial.affaires,
+    cadenceLivraison: commercial.cadenceLivraison,
+    quantites: commercial.quantites,
+    cadenceProduction: [],
+    derniereFabrication: commercial.derniereFabrication,
+
+    pieceReference: header.piece_reference,
+    pieceDesignation: header.piece_designation,
+    pieceIndice: header.piece_indice,
+    gammeCode: header.gamme_code,
+    gammeVersion: header.gamme_version,
+    documentsAFournir: [],
+    matiere: {
+      reference: (matiere?.reference as string | null) ?? null,
+      designation: (matiere?.designation as string | null) ?? null,
+      nuance: (matiere?.nuance as string | null) ?? null,
+    },
+    decoupe: {
+      dimensions: (matiere?.dimensions as string | null) ?? null,
+      longueurBrutMm: (matiere?.longueurBrutMm as number | null) ?? null,
+      longueurUtileMm: (matiere?.longueurUtileMm as number | null) ?? null,
+      traitDeScieMm: (matiere?.traitDeScieMm as number | null) ?? null,
+      chuteMm: (matiere?.chuteMm as number | null) ?? null,
+      nombreBruts: (matiere?.nombreBruts as number | null) ?? null,
+      piecesParBrut: (matiere?.piecesParBrut as number | null) ?? null,
+      masseTotaleKg: (matiere?.masseTotaleKg as number | null) ?? null,
+      unite: (matiere?.unite as string | null) ?? null,
+      methodeCalcul: null,
+    },
+
+    operations,
+    visas,
+    familles,
+  });
+
+  return { payload, revisionId: revision.id };
+}
+
+/** Aperçu : aucune écriture, aucun effet. Le PDF est rendu et renvoyé tel quel. */
+export async function previewDocument(
+  ofId: number,
+  revisionId: string | null,
+  actor: OfActor,
+  generatedAt: string
+) {
+  const { payload } = await buildDocumentPayload(ofId, {
+    revisionId,
+    documentStatut: "BROUILLON",
+    generatedAt,
+    auteur: actor.username,
+  });
+  const rendered = await renderOfDocument(payload);
+  return { payload, ...rendered };
+}
+
+/**
+ * Émet le document officiel.
+ *
+ * `expectedSnapshotSha256` est le verrou : c'est l'empreinte que l'aperçu a
+ * montrée. Si l'OF a été révisé entre l'aperçu et l'émission, l'empreinte a
+ * changé et l'émission est refusée par un 409 explicite — jamais par la
+ * production silencieuse d'un document incohérent (critère d'acceptation #370).
+ */
+export async function emitDocument(
+  ofId: number,
+  input: { revisionId: string | null; expectedSnapshotSha256: string | null },
+  actor: OfActor,
+  audit: AuditContext,
+  idempotencyKey: string | null,
+  generatedAt: string
+) {
+  const { payload, revisionId } = await buildDocumentPayload(ofId, {
+    revisionId: input.revisionId,
+    documentStatut: "OFFICIEL",
+    generatedAt,
+    auteur: actor.username,
+  });
+
+  if (
+    input.expectedSnapshotSha256 &&
+    input.expectedSnapshotSha256 !== payload.snapshotSha256
+  ) {
+    throw new HttpError(
+      409,
+      "OF_DOCUMENT_SNAPSHOT_CHANGED",
+      "L'ordre de fabrication a changé depuis l'aperçu : réactualiser avant d'émettre."
+    );
+  }
+
+  const rendered = await renderOfDocument(payload);
+
+  return repo.withOfTransaction(async (tx) => {
+    if (idempotencyKey) {
+      const existing = await repo.findDocumentByIdempotencyKey(tx, idempotencyKey);
+      if (existing) return { document: existing, replayed: true, pdf: rendered.buffer };
+    }
+
+    await repo.lockOf(tx, ofId);
+
+    // Double émission : une révision ne porte qu'UN document officiel. L'index
+    // unique partiel le garantit, ce contrôle le dit clairement.
+    const already = await repo.getOfficialDocument(ofId, revisionId, tx);
+    if (already) {
+      throw new HttpError(
+        409,
+        "OF_DOCUMENT_ALREADY_EMITTED",
+        `Cette révision a déjà un document officiel (${already.id}). Utiliser la réimpression.`
+      );
+    }
+
+    const existingGed = await repo.findExistingGedDocumentId(tx, ofId);
+    const archive = await archiveOfDocument(tx, {
+      ofNumero: payload.ofNumero,
+      revisionCode: payload.revisionCode,
+      pieceReference: payload.pieceReference,
+      pdf: rendered.buffer,
+      pdfSha256: rendered.sha256,
+      existingGedDocumentId: existingGed,
+      actorUserId: actor.userId,
+      changeReason: `Émission ${payload.ofNumero} ${payload.revisionCode}`,
+    });
+
+    const document = await repo.insertDocument(tx, {
+      ofId,
+      revisionId,
+      payload,
+      payloadSha256: hashDocumentPayload(payload),
+      pdfSha256: rendered.sha256,
+      pdfByteSize: rendered.byteSize,
+      generatedAt,
+      generatedBy: actor.userId,
+      generatedByLabel: actor.username,
+      statut: "OFFICIEL",
+      gedDocumentId: archive.gedDocumentId,
+      gedVersionId: archive.gedVersionId,
+      idempotencyKey,
+    });
+
+    await insertAuditLog(tx, audit, {
+      action: "OF_DOCUMENT_EMIT",
+      entity_type: "of_document",
+      entity_id: document.id,
+      details: {
+        of_id: ofId,
+        of_numero: payload.ofNumero,
+        revision_code: payload.revisionCode,
+        payload_sha256: document.payload_sha256,
+        pdf_sha256: rendered.sha256,
+        template_version: payload.templateVersion,
+        ged_archived: archive.archived,
+        ged_skipped_reason: archive.skippedReason,
+      },
+    });
+
+    return { document, replayed: false, pdf: rendered.buffer, archive };
+  });
+}
+
+/**
+ * Réimprime un document émis.
+ *
+ * L'archive GED est la source ; à défaut, le PDF est reconstruit depuis le
+ * payload figé — déterministe par construction — puis son empreinte est comparée
+ * à celle enregistrée. Un écart lève une erreur : mieux vaut refuser que servir
+ * un document qui n'est pas celui qui a été émis.
+ *
+ * Une réimpression NE crée PAS de révision.
+ */
+export async function reprintDocument(
+  ofId: number,
+  documentId: string,
+  audit: AuditContext
+) {
+  const document = await repo.getDocument(ofId, documentId);
+  if (!document) {
+    throw new HttpError(404, "OF_DOCUMENT_NOT_FOUND", "Document introuvable sur cet ordre de fabrication.");
+  }
+  if (!document.pdf_sha256) {
+    throw new HttpError(409, "OF_DOCUMENT_NO_PDF", "Ce document n'a pas d'empreinte PDF enregistrée.");
+  }
+
+  let pdf = await readArchivedOfDocument(document.pdf_sha256);
+  let source: "GED" | "PAYLOAD" = "GED";
+
+  if (!pdf) {
+    source = "PAYLOAD";
+    const rendered = await renderOfDocument(document.payload as OfDocumentPayload);
+    if (rendered.sha256 !== document.pdf_sha256) {
+      throw new HttpError(
+        500,
+        "OF_DOCUMENT_REPRINT_MISMATCH",
+        `La réimpression ne reproduit pas le document émis (attendu ${document.pdf_sha256}, obtenu ${rendered.sha256}).`
+      );
+    }
+    pdf = rendered.buffer;
+  }
+
+  await repo.withOfTransaction(async (tx) => {
+    await repo.bumpReprintCount(tx, { ofId, documentId });
+    await insertAuditLog(tx, audit, {
+      action: "OF_DOCUMENT_REPRINT",
+      entity_type: "of_document",
+      entity_id: documentId,
+      details: { of_id: ofId, pdf_sha256: document.pdf_sha256, source },
+    });
+  });
+
+  return { pdf, document, source };
+}
+
+export async function listDocuments(ofId: number) {
+  await repo.readOfHeader(ofId);
+  return repo.listDocuments(ofId);
+}
+
+/* ========================================================================== */
+/* Utilitaires                                                                */
+/* ========================================================================== */
+
+/**
+ * Résout les destinataires internes d'un sujet et prépare la notification.
+ *
+ * Aucune identité n'est écrite en dur : les destinataires viennent de
+ * `notification_routing`, par rôle ou par identité désignée par un administrateur.
+ * Aucun message client n'est envoyé — ces notifications sont internes.
+ */
+async function notifyTopic(
+  tx: repo.DbQueryer,
+  topic: string,
+  message: string,
+  dedupeParts: Array<string | number | null> = []
+): Promise<number[]> {
+  const [rules, candidates] = await Promise.all([
+    repo.readNotificationRouting(topic, tx),
+    repo.readNotificationCandidates(tx),
+  ]);
+
+  const recipients = resolveNotificationRecipients({
+    topic,
+    rules,
+    candidates: candidates.map((c) => ({
+      userId: c.userId,
+      roles: [c.primaryRole, ...c.roles].filter((r): r is string => Boolean(r)),
+    })),
+  });
+
+  // La rédaction est préparée et tracée ; l'acheminement reste du ressort du
+  // canal de notification existant. Rien n'est envoyé au client.
+  buildInternalNotification({
+    topic,
+    kind: topic.toLowerCase(),
+    title: NOTIFICATION_TITLES[topic] ?? "Notification production",
+    message,
+    severity: "warning",
+    actionUrl: null,
+    actionLabel: null,
+    payload: { recipients },
+    dedupeKey: notificationDedupeKey(topic, ...dedupeParts),
+  });
+  return recipients;
+}
+
+/** Titres des sujets internes de ce chantier. Aucun n'est destiné au client. */
+const NOTIFICATION_TITLES: Record<string, string> = {
+  [NOTIFICATION_TOPICS.OF_TIME_VARIANCE]: "Dérive de temps : replanification proposée",
+  [NOTIFICATION_TOPICS.OF_PLANNING_SUBMITTED]: "Planning soumis à validation",
+  [NOTIFICATION_TOPICS.AR_RECALAGE]: "AR client à recaler",
+};
+
+function round4(value: number): number {
+  return Math.round(value * 1e4) / 1e4;
+}

--- a/src/module/production/validators/of-versioning.validators.ts
+++ b/src/module/production/validators/of-versioning.validators.ts
@@ -1,0 +1,191 @@
+// Validation d'entrée du chantier #370. Zod, refus explicite, aucun défaut deviné.
+//
+// Les règles métier (seuil de dérive, transitions, obligation de commentaire sur
+// « Autre ») ne sont PAS dupliquées ici : elles vivent dans le domaine, qui est le
+// seul juge. Ce fichier vérifie la FORME de la requête, pas sa légitimité — une
+// double implémentation finirait par divergier.
+
+import { z } from "zod";
+
+import { AR_RECALAGE_MOTIFS, AR_RECALAGE_STATUTS } from "../domain/ar-recalage";
+import { OF_TIME_VARIANCE_CAUSES } from "../domain/of-time-variance";
+
+/** Identifiant d'OF : entier positif. Un `NaN` de `parseInt` est refusé ici. */
+export const ofIdParam = z.object({
+  ofId: z.coerce.number().int().positive(),
+});
+
+export const revisionIdParam = ofIdParam.extend({
+  revisionId: z.string().uuid(),
+});
+
+export const documentIdParam = ofIdParam.extend({
+  documentId: z.string().uuid(),
+});
+
+export const planningIdParam = ofIdParam.extend({
+  versionId: z.string().uuid(),
+});
+
+/** Modification d'une phase, appliquée à la NOUVELLE révision seulement. */
+const operationChangeSchema = z.object({
+  phase: z.number().int().nonnegative(),
+  designation: z.string().trim().min(1).max(300).optional(),
+  // La famille est un code du référentiel : la forme est contrainte ici, son
+  // existence est vérifiée par le service contre `production_machine_families`.
+  family: z
+    .string()
+    .trim()
+    .regex(/^[A-Z0-9_]{1,24}$/, "Code de famille machine invalide.")
+    .nullable()
+    .optional(),
+  machineId: z.string().uuid().nullable().optional(),
+  // Chaîne vide interdite : un n° de programme vide doit être `null` pour que le
+  // document le SIGNALE au lieu de l'imprimer en blanc.
+  programme: z.string().trim().min(1).max(120).nullable().optional(),
+  tempsUnitaire: z.number().nonnegative().optional(),
+  preparation: z.number().nonnegative().optional(),
+  quantiteBase: z.number().positive().optional(),
+  coefficient: z.number().positive().optional(),
+});
+
+export const createRevisionSchema = z.object({
+  // Le motif est facultatif pour la forme : c'est le domaine qui l'exige dès R01,
+  // parce que la règle dépend du rang, que la requête ne connaît pas.
+  motif: z.string().trim().min(3).max(1000).nullable().optional(),
+  operations: z.array(operationChangeSchema).max(500).optional(),
+});
+
+export const compareRevisionsQuery = z.object({
+  from: z.string().uuid(),
+  to: z.string().uuid(),
+});
+
+export const createVisaSchema = z.object({
+  phase: z.number().int().nonnegative(),
+  statut: z.enum(["A_FAIRE", "EN_COURS", "VISE", "REFUSE"]),
+  initials: z.string().trim().min(1).max(8),
+  quantiteBonne: z.number().nonnegative().nullable().optional(),
+  quantiteRebut: z.number().nonnegative().nullable().optional(),
+  motifRebut: z.string().trim().min(1).max(500).nullable().optional(),
+  controleInitials: z.string().trim().min(1).max(8).nullable().optional(),
+  comment: z.string().trim().max(1000).nullable().optional(),
+});
+
+export const assessVarianceSchema = z.object({
+  phase: z.number().int().nonnegative(),
+  newTime: z.number().nonnegative(),
+});
+
+export const createProposalSchema = z.object({
+  phase: z.number().int().nonnegative(),
+  newTime: z.number().nonnegative(),
+  cause: z.enum(OF_TIME_VARIANCE_CAUSES),
+  causeComment: z.string().trim().max(1000).nullable().optional(),
+});
+
+export const resolveProposalSchema = z.object({
+  statut: z.enum(["ACCEPTEE", "REFUSEE", "CADUQUE"]),
+  comment: z.string().trim().max(1000).nullable().optional(),
+});
+
+const plannedOperationSchema = z.object({
+  phase: z.number().int().nonnegative(),
+  designation: z.string().trim().min(1).max(300),
+  family: z
+    .string()
+    .trim()
+    .regex(/^[A-Z0-9_]{1,24}$/)
+    .nullable(),
+  machineId: z.string().uuid().nullable(),
+  machineLabel: z.string().trim().max(200).nullable(),
+  centre: z.string().trim().max(50).nullable().optional(),
+  dateDebut: z.string().trim().nullable(),
+  dateFin: z.string().trim().nullable(),
+  dureeH: z.number().nonnegative(),
+  quantite: z.number().nonnegative(),
+});
+
+export const createPlanningDraftSchema = z.object({
+  payload: z.object({
+    operations: z.array(plannedOperationSchema).max(500),
+    dateDebut: z.string().trim().nullable(),
+    dateFin: z.string().trim().nullable(),
+    quantite: z.number().nonnegative(),
+    chargeTotaleH: z.number().nonnegative().optional(),
+    cadences: z
+      .array(
+        z.object({
+          affaireId: z.number().int(),
+          date: z.string().trim(),
+          quantite: z.number().nonnegative(),
+        })
+      )
+      .max(500)
+      .optional(),
+    engagements: z
+      .array(
+        z.object({
+          affaireId: z.number().int(),
+          affaireNumero: z.string().nullable(),
+          clientId: z.string().nullable(),
+          commandeId: z.number().int().nullable(),
+          delaiClient: z.string().nullable(),
+          nouvelleDate: z.string().nullable(),
+        })
+      )
+      .max(500)
+      .optional(),
+  }),
+  sourceProposalId: z.string().uuid().nullable().optional(),
+});
+
+export const planningDecisionSchema = z.object({
+  // Le service exige le motif sur un REFUS : la forme l'autorise vide, la règle
+  // le refuse, et le message d'erreur explique laquelle des deux a parlé.
+  comment: z.string().trim().max(1000).nullable().optional(),
+});
+
+const cadenceSchema = z
+  .array(z.object({ date: z.string().trim(), quantite: z.number().nonnegative() }))
+  .max(500)
+  .nullable()
+  .optional();
+
+export const createArDossierSchema = z.object({
+  affaireId: z.number().int().positive().nullable().optional(),
+  previousDate: z.string().trim().nullable().optional(),
+  newDate: z.string().trim().nullable().optional(),
+  previousCadence: cadenceSchema,
+  newCadence: cadenceSchema,
+  quantite: z.number().nonnegative().nullable().optional(),
+  motif: z.enum(AR_RECALAGE_MOTIFS),
+  commentaire: z.string().trim().max(2000).nullable().optional(),
+  ownerUserId: z.number().int().positive().nullable().optional(),
+});
+
+export const updateArDossierSchema = z.object({
+  statut: z.enum(AR_RECALAGE_STATUTS),
+  ownerUserId: z.number().int().positive().nullable().optional(),
+  commentaire: z.string().trim().max(2000).nullable().optional(),
+});
+
+export const emitDocumentSchema = z.object({
+  revisionId: z.string().uuid().nullable().optional(),
+  // Empreinte vue par l'aperçu. Facultative dans la forme, mais son absence
+  // renonce au verrou anti-dérive : l'appelant assume une émission non gardée.
+  expectedSnapshotSha256: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/)
+    .nullable()
+    .optional(),
+});
+
+export const previewDocumentQuery = z.object({
+  revisionId: z.string().uuid().nullable().optional(),
+});
+
+export const listArQuery = z.object({
+  ofId: z.coerce.number().int().positive().optional(),
+  statut: z.enum(AR_RECALAGE_STATUTS).optional(),
+});

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -23,6 +23,7 @@ import reportingRoutes from "../module/facturation/routes/reporting.routes";
 import productionRoutes from "../module/production/routes/production.routes";
 import productionExecutionRoutes from "../module/production/routes/production-execution.routes";
 import productionStationRoutes from "../module/production/routes/station.routes";
+import ofVersioningRoutes from "../module/production/routes/of-versioning.routes";
 import qualiteRoutes from "../module/qualite/routes/qualite.routes";
 import quality360Routes from "../module/qualite/routes/quality-360.routes";
 import livraisonsRoutes from "../module/livraisons/routes/livraisons.routes";
@@ -110,6 +111,11 @@ router.use("/production/execution", productionExecutionRoutes);
 // duplique aucune commande d'exécution : il ajoute appareil, session, file de
 // travail, dossier OF numérique et transmission de poste.
 router.use("/production/station", productionStationRoutes);
+// Versioning d'OF, replanification, AR client et document (#370), monté AVANT le
+// routeur historique. Il ne duplique aucune commande existante : il ajoute les
+// révisions, le VISA de phase, la dérive de temps, le brouillon de planning, le
+// dossier d'AR à recaler et le document d'OF figé.
+router.use("/production/of-versioning", ofVersioningRoutes);
 router.use("/production", productionRoutes);
 router.use("/planning", planningRoutes);
 router.use("/programmations", programmationRoutes);

--- a/src/shared/notifications/routing.ts
+++ b/src/shared/notifications/routing.ts
@@ -1,0 +1,122 @@
+// Routage des notifications internes.
+//
+// Qui est prévenu d'un sujet donné est une **donnée de configuration**, jamais une
+// constante du code. Une personne nommée — « prévenir Ghislaine quand un AR doit
+// être recalé » — est destinataire parce qu'elle porte un rôle, ou parce qu'un
+// administrateur l'a explicitement désignée dans `notification_routing`.
+//
+// Coder une identité en dur aurait trois défauts : la notification suit la
+// personne et non la fonction, un départ ou une absence casse silencieusement la
+// chaîne, et le changement exige une livraison au lieu d'un clic.
+
+/** Sujets de notification connus du domaine OF / planning / AR. */
+export const NOTIFICATION_TOPICS = {
+  /** Dérive de temps d'usinage au-delà du seuil : le planificateur arbitre. */
+  OF_TIME_VARIANCE: "OF_TIME_VARIANCE",
+  /** Brouillon de planning soumis à validation. */
+  OF_PLANNING_SUBMITTED: "OF_PLANNING_SUBMITTED",
+  /** Dossier d'AR client à recaler : l'administration des ventes reprend contact. */
+  AR_RECALAGE: "AR_RECALAGE",
+} as const;
+
+export type NotificationTopic = (typeof NOTIFICATION_TOPICS)[keyof typeof NOTIFICATION_TOPICS];
+
+/** Une règle de routage : une cible par rôle **ou** une identité désignée. */
+export type NotificationRoutingRule = {
+  topic: string;
+  roleKey: string | null;
+  userId: number | null;
+  isActive: boolean;
+};
+
+/** Un compte et les rôles qu'il porte (rôle principal + rôles additifs #315). */
+export type NotificationCandidate = {
+  userId: number;
+  roles: string[];
+};
+
+/**
+ * Résout les destinataires d'un sujet.
+ *
+ * Les identités désignées et les porteurs des rôles configurés sont réunis, puis
+ * dédoublonnés : une personne à la fois désignée et porteuse du rôle reçoit une
+ * seule notification.
+ */
+export function resolveNotificationRecipients(args: {
+  topic: string;
+  rules: NotificationRoutingRule[];
+  candidates: NotificationCandidate[];
+}): number[] {
+  const active = args.rules.filter((rule) => rule.isActive && rule.topic === args.topic);
+  if (!active.length) return [];
+
+  const roleKeys = new Set(
+    active
+      .filter((rule) => rule.roleKey !== null)
+      .map((rule) => normalizeRole(rule.roleKey as string))
+  );
+
+  const recipients = new Set<number>();
+
+  for (const rule of active) {
+    if (rule.userId !== null) recipients.add(rule.userId);
+  }
+
+  if (roleKeys.size) {
+    for (const candidate of args.candidates) {
+      if (candidate.roles.some((role) => roleKeys.has(normalizeRole(role)))) {
+        recipients.add(candidate.userId);
+      }
+    }
+  }
+
+  return [...recipients].sort((a, b) => a - b);
+}
+
+/**
+ * Comparaison de rôle insensible à la casse et aux accents.
+ *
+ * Le catalogue de rôles mêle « Qualité » et « Responsable Qualité », saisis à la
+ * main dans plusieurs écrans ; un routage qui échouerait sur un accent laisserait
+ * une alerte sans destinataire, sans erreur visible.
+ */
+function normalizeRole(role: string): string {
+  return role
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .trim()
+    .toLowerCase();
+}
+
+/**
+ * Clé de déduplication d'une notification.
+ *
+ * `app_notifications` porte un index unique sur (user_id, dedupe_key) : rejouer
+ * la même décision ne produit pas une seconde notification. C'est ce qui rend
+ * l'ensemble idempotent de bout en bout.
+ */
+export function notificationDedupeKey(topic: string, ...parts: Array<string | number | null>): string {
+  return [topic, ...parts.map((part) => (part === null ? "" : String(part)))].join(":");
+}
+
+export type NotificationDraft = {
+  topic: string;
+  kind: string;
+  title: string;
+  message: string;
+  severity: "info" | "success" | "warning" | "error";
+  actionUrl: string | null;
+  actionLabel: string | null;
+  payload: Record<string, unknown>;
+  dedupeKey: string;
+};
+
+/**
+ * Notification interne : aucune de ces notifications ne sort de CERP.
+ *
+ * Le rappel n'est pas décoratif — le dossier d'AR à recaler concerne un client, et
+ * la frontière entre « prévenir l'ADV » et « écrire au client » doit rester nette.
+ */
+export function buildInternalNotification(draft: NotificationDraft): NotificationDraft {
+  return draft;
+}

--- a/src/shared/pdf/cerp-document.ts
+++ b/src/shared/pdf/cerp-document.ts
@@ -222,6 +222,14 @@ export type CerpDocumentHeader = {
    * la bande de pied et non dans le flux : voir `measureFooter`.
    */
   legalMentions?: string[] | null
+  /**
+   * Filigrane porte par **toutes** les pages : « BROUILLON », « OBSOLETE ».
+   *
+   * Il n'est pas decoratif. Un document de travail ou une revision perimee qui
+   * ressemblerait a l'exemplaire officiel ferait fabriquer d'apres la mauvaise
+   * definition. Le filigrane est la garantie de lecture, pas un ornement.
+   */
+  watermark?: string | null
   /** Metadonnees PDF. */
   title: string
   subject: string
@@ -693,6 +701,42 @@ function drawRunningHead(doc: PDFKit.PDFDocument, header: CerpDocumentHeader): v
   doc.fillColor(CERP_DOC_COLORS.ink)
 }
 
+/**
+ * Filigrane en diagonale, au centre de la page.
+ *
+ * Dessine dans la passe finale, donc **au-dessus** du contenu, avec une opacite
+ * faible : sous le texte il disparaitrait derriere les aplats gris des sections,
+ * et un filigrane invisible ne protege de rien. L'opacite est choisie assez basse
+ * pour rester lisible en noir et blanc sans masquer un chiffre.
+ */
+function drawWatermark(doc: PDFKit.PDFDocument, label: string): void {
+  const text = toPdfSafeText(label.toUpperCase())
+
+  doc.save()
+  doc.opacity(0.1)
+  doc.font("Helvetica-Bold").fillColor(CERP_DOC_COLORS.brand)
+
+  // Taille ajustee pour occuper environ 80 % de la diagonale, quel que soit le mot.
+  const target = Math.hypot(PAGE_WIDTH, PAGE_HEIGHT) * 0.8
+  doc.fontSize(100)
+  const widthAt100 = doc.widthOfString(text, { characterSpacing: 8 })
+  const size = Math.max(28, Math.min(160, (target / widthAt100) * 100))
+  doc.fontSize(size)
+
+  const width = doc.widthOfString(text, { characterSpacing: 8 })
+  const height = doc.currentLineHeight()
+
+  doc.rotate(-38, { origin: [PAGE_WIDTH / 2, PAGE_HEIGHT / 2] })
+  doc.text(text, PAGE_WIDTH / 2 - width / 2, PAGE_HEIGHT / 2 - height / 2, {
+    lineBreak: false,
+    characterSpacing: 8,
+  })
+  doc.restore()
+
+  doc.opacity(1)
+  doc.fillColor(CERP_DOC_COLORS.ink)
+}
+
 function drawFooter(
   doc: PDFKit.PDFDocument,
   header: CerpDocumentHeader,
@@ -800,9 +844,12 @@ export async function renderCerpDocument(
 
   render(new CerpDocumentContext(doc, afterIdentity, geometry.reserve))
 
+  const watermark = header.watermark && header.watermark.trim() ? header.watermark.trim() : null
+
   const range = doc.bufferedPageRange()
   for (let index = 0; index < range.count; index += 1) {
     doc.switchToPage(range.start + index)
+    if (watermark) drawWatermark(doc, watermark)
     if (index > 0) drawRunningHead(doc, header)
     drawFooter(doc, header, geometry, index + 1, range.count)
   }


### PR DESCRIPTION
Refs BigFootLime/crp-systems-web#370

Frontend croisé : BigFootLime/crp-systems-web#396 — **à merger ensemble.**

## Ce que livre cette PR

Le socle complet du chantier : domaine, schéma, API montée, document PDF figé et archivé.

L'ancien travail (`feature/of-versioning-planning-ar-pdf`, commit `f1669d7`) contenait un domaine pur de bonne qualité mais **aucun câblage HTTP**, et un schéma antérieur à la normalisation des gammes. Il n'a **pas** été fusionné : audité fichier par fichier contre `origin/dev`, repris là où il restait juste, réimplémenté là où il était dépassé. Table de récupération sélective dans la PR frontend (`docs/architecture/370-recuperation-selective-of-versioning.md`).

## Décisions structurantes (détail dans l'ADR-0045, dépôt frontend)

- **Un OF lancé ne s'écrase jamais.** La clé d'unicité de `of_operations` passe de `(of_id, phase)` à `(of_id, revision_id, phase)`. Sans ce changement, une `R01` sur un OF en cours aurait exigé de muter les opérations de la `R00` — emportant les pointages (`of_time_logs`, en cascade) et les VISA. **Seule partie non additive** ; rollback fourni.
- **Seuil de dérive strict à 10,00 %**, arrondi au centième **avant** comparaison : `(110-100)/100*100` vaut `10.000000000000002` en IEEE 754, et la règle serait fausse sur son propre point d'équilibre sans cet arrondi. Référence absente ou nulle → revue humaine, **sans division**.
- **Source du temps de référence** décidée et documentée : `temps_fabrication_planned` de la révision ACTIVE (`tf_unit × qte × coef` figés au lancement). Pas la gamme de la pièce technique, qui a pu bouger depuis — sinon on mesurerait deux changements à la fois.
- **Le planning se propose avant de s'appliquer.** `ACTIF → BROUILLON → SOUMIS → VALIDÉ/REFUSÉ → ACTIF`. Le plan actif n'est jamais muté par un brouillon ; `base_version_id` donne le verrou optimiste (`409 OF_PLANNING_BASE_CHANGED`). Refus motivé obligatoire.
- **Un dossier d'AR n'existe que si une date ou une cadence client change réellement.** Destinataires configurables par rôle ou identité désignée (`notification_routing`) ; aucune identité en dur ; aucun message client automatique.
- **La famille de phase est un référentiel, pas un type** : `production_machine_families` (T, F, TTRAD, FTRAD, **DECOUPE**), administrable, `programme_requis` porté par la famille. L'ancienne union TypeScript rejetait `DECOUPE` que la base accepte, et rendait la table d'administration décorative.
- **Le document est un ORDRE DE FABRICATION**, pas une « gamme de fabrication ». Une gamme est la définition technique d'une pièce, réutilisable ; un OF est l'ordre de lancer une quantité, pour une commande, à une date. Il embarque la gamme applicable, il ne s'y réduit pas.
- **Un seul read-model** pour l'aperçu et le PDF : `buildOfDocumentPayload`. Il n'y a pas deux chemins à faire concorder, il n'y en a qu'un.

## API montée — 24 routes sous `/api/v1/production/of-versioning`

Montée dans `v1.routes.ts` **avant** le routeur historique. Refus par défaut, capacité fine par route, `Idempotency-Key` sur toute commande à effet (et sur aucune lecture), anti-IDOR par lecture `(id, of_id)`, audit écrit dans la **même transaction** que la mutation.

16 tests vérifient que les routes existent réellement, refusent sans jeton (**401 et non 404**), appliquent la bonne capacité, et exigent la clé d'idempotence là où il faut — pas ailleurs.

## Deux corrections de fond

- **RBAC** : les needles `plann` et `assistant` ne correspondaient à **aucun** alias d'autorisation réel (`Planning` → `Planification`, `Assistante polyvalente` → `Secretaire`). Couverture illusoire. Les tests qui les validaient passaient à `roleHasOfCapability` un vocabulaire que la fonction ne reçoit jamais — elle reçoit le rôle **effectif** produit par `authorizationRole()`. Needles retirées, contrat réel fixé par un test.
- **VISA** : `of_operation_visas` ne portait que la signature. Patch additif pour le statut, les quantités bonne/rebut, le motif et le visa de **contrôle**, distinct du visa opérateur — séparer qui fabrique de qui contrôle est le principe même du contrôle.

## Base de données — appliqué sur les DEUX bases

| Patch | `cerp_test` | `cerp_prod` |
|---|---|---|
| `20260729_of_versioning_replanification_ar_370.sql` | appliqué, enregistré, vérifié | appliqué, enregistré, vérifié |
| `20260729_of_visa_controle_370.sql` | appliqué, enregistré, vérifié | appliqué, enregistré, vérifié |

Sauvegarde prise avant chaque écriture. preflight / verify / rollback / guards fournis. Mêmes `sha256` enregistrés sur les deux bases, et **parité de schéma prouvée** (md5 des colonnes du domaine identique : `f6b68af0fa54da127ad725b4d5104f9e`). Les 7 tables appartiennent à `cerp_app` sur les deux bases, et une lecture `SET ROLE cerp_app` a été exercée — sans cela, un endpoint correct répondrait 500 sur un `42501`.

⚠️ **Dérive de registre héritée, signalée** : `20260729_methodes_gamme_referentials.sql` a été **exécuté** sur les deux bases (ses objets sont là) sans être enregistré dans `cerp_schema_migrations`. Le registre ment dans le sens dangereux : il fait croire qu'il reste à passer, et un runner qui le rejouerait buterait sur ses commandes non gardées. À arbitrer par le chantier Méthodes — hors périmètre #370.

## Vérifications

- `tsc` : propre.
- **3282 tests verts.** Les 3 échecs restants sont dans `pieces-techniques.routes.test.ts` et **préexistent sur `origin/dev`** — vérifié en exécutant ce fichier sur un worktree détaché de `origin/dev` : mêmes 3 échecs. Non causés par cette PR, non corrigés ici.
- **Toutes les requêtes SQL du repository exécutées contre le schéma réel de `cerp_test`.** Un `tsc` propre ne prouve pas qu'un nom de colonne existe : cette passe a attrapé 6 noms faux (`clients.nom_client` → `company_name`, `commande_client.numero_commande` → `numero`, `user_roles` → `user_role_assignments`, `pieces_techniques_gammes` → `gammes`, `pt.reference` → `code_piece`, `machines.nom` → `display_name`).
- **Contrôle visuel PDF** : 8 variantes rendues puis rasterisées en PNG sur l'atelier (`pdftoppm`), **toutes les pages inspectées**, dont un tirage en niveaux de gris. A trouvé 5 débordements d'en-tête invisibles autrement (libellés repliés par-dessus le filet ou par-dessus leur propre valeur) et le mauvais intitulé du document.
- Contrôles métier confirmés au rendu : totaux **12,00 / 59,00 / 71,00 h** de la gamme papier réelle (affaire 23 149, pièce 45 252 966 B) ; séquence **T → F → T** en trois passages distincts ; 1 et 100 phases ; `Page X/N` sans phase coupée ; filigrane sur toutes les pages ; réimpression **octet pour octet identique**.

## Ce qui reste à faire (déclaré, non caché)

- Recette fonctionnelle sur données réelles : `ordres_fabrication` est à **0 ligne** sur les deux bases, la reprise CLIPPER n'a pas eu lieu. Aucun test ne peut s'appuyer sur des données réelles aujourd'hui.
- Archivage GED exercé en conditions réelles : le code est là et testé, mais **ce chantier est le premier module à verser un PDF au coffre** — aucun autre ne le faisait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
