### PR TITLE
fix(ged): sécuriser le RBAC par classe et le périmètre parent (#236)

### DIFF
--- a/db/patches/20260729_ged_scope_security_236.sql
+++ b/db/patches/20260729_ged_scope_security_236.sql
@@ -1,0 +1,241 @@
+-- GED #236 - permissions par classe et refus par défaut.
+--
+-- Additif uniquement. Ce patch ne modifie ni document, ni version, ni blob.
+-- Il remplace la détection applicative par sous-chaîne par un référentiel SQL
+-- explicite (rôle attribué, classe, capacité).
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.ged_class_capabilities (
+  class_key   text NOT NULL
+    REFERENCES public.ged_document_classes(class_key) ON UPDATE CASCADE ON DELETE CASCADE,
+  role_key    text NOT NULL CHECK (length(btrim(role_key)) > 0),
+  capability  text NOT NULL CHECK (capability IN (
+    'read', 'upload', 'update_metadata', 'checkout', 'checkin', 'submit',
+    'approve', 'publish', 'obsolete', 'download', 'export', 'admin'
+  )),
+  created_at  timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (class_key, role_key, capability)
+);
+
+COMMENT ON TABLE public.ged_class_capabilities IS
+  'Permissions GED explicites par rôle réellement attribué et classe documentaire. Absence de ligne = refus.';
+
+CREATE INDEX IF NOT EXISTS idx_ged_class_capabilities_role
+  ON public.ged_class_capabilities(role_key, capability, class_key);
+
+-- Administration technique : le rôle admin implique toutes les capacités,
+-- mais reste borné à chaque classe. Une future classe RH pourra donc ne pas
+-- recevoir cette ligne.
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, 'Administrateur Systeme et Reseau', 'admin'
+  FROM public.ged_document_classes c
+ WHERE c.is_active
+ON CONFLICT DO NOTHING;
+
+-- Direction : consultation et export, sans droit implicite de validation.
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (VALUES ('Directeur'), ('Gérant')) AS r(role_key)
+ CROSS JOIN (VALUES ('read'), ('download'), ('export')) AS p(capability)
+ WHERE c.is_active
+ON CONFLICT DO NOTHING;
+
+-- Technique / Méthodes.
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (
+   VALUES
+     ('Directeur Technique'),
+     ('Responsable Programmation'),
+     ('Programmation'),
+     ('Études-Méthodes'),
+     ('Responsable CAO')
+ ) AS r(role_key)
+ CROSS JOIN (
+   VALUES
+     ('read'), ('upload'), ('update_metadata'), ('checkout'), ('checkin'),
+     ('submit'), ('download'), ('export')
+ ) AS p(capability)
+ WHERE c.domain = 'TECHNIQUE' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (VALUES ('Directeur Technique'), ('Responsable Programmation')) AS r(role_key)
+ CROSS JOIN (VALUES ('approve'), ('publish'), ('obsolete')) AS p(capability)
+ WHERE c.domain = 'TECHNIQUE' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (
+   VALUES
+     ('Responsable Qualité'),
+     ('Qualité'),
+     ('Responsable Atelier-Production'),
+     ('Responsable fabrication fraisage'),
+     ('Responsable tournage')
+ ) AS r(role_key)
+ CROSS JOIN (VALUES ('read'), ('download')) AS p(capability)
+ WHERE c.domain = 'TECHNIQUE' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+-- Production : les opérateurs ne parcourent pas la technique. Ils peuvent
+-- uniquement déposer les preuves de production prévues par leur classe.
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (
+   VALUES
+     ('Directeur Technique'),
+     ('Responsable Atelier-Production'),
+     ('Responsable fabrication fraisage'),
+     ('Responsable tournage')
+ ) AS r(role_key)
+ CROSS JOIN (
+   VALUES
+     ('read'), ('upload'), ('update_metadata'), ('submit'),
+     ('download'), ('export')
+ ) AS p(capability)
+ WHERE c.domain = 'PRODUCTION' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (
+   VALUES
+     ('Opérateur atelier'),
+     ('Fraisage'),
+     ('Finitions'),
+     ('Tournage')
+ ) AS r(role_key)
+ CROSS JOIN (VALUES ('read'), ('upload'), ('download')) AS p(capability)
+ WHERE c.class_key = 'OF_PHOTO' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (VALUES ('Responsable Qualité'), ('Qualité')) AS r(role_key)
+ CROSS JOIN (VALUES ('read'), ('download')) AS p(capability)
+ WHERE c.domain = 'PRODUCTION' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+-- Qualité.
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (VALUES ('Responsable Qualité'), ('Qualité')) AS r(role_key)
+ CROSS JOIN (
+   VALUES
+     ('read'), ('upload'), ('update_metadata'), ('submit'), ('approve'),
+     ('publish'), ('obsolete'), ('download'), ('export')
+ ) AS p(capability)
+ WHERE c.domain = 'QUALITE' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (
+   VALUES
+     ('Directeur Technique'),
+     ('Études-Méthodes'),
+     ('Achats'),
+     ('Maintenance')
+ ) AS r(role_key)
+ CROSS JOIN (VALUES ('read'), ('download')) AS p(capability)
+ WHERE c.domain = 'QUALITE' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+-- Commercial.
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (
+   VALUES
+     ('Commerce'),
+     ('Secretaire'),
+     ('Assistante polyvalente')
+ ) AS r(role_key)
+ CROSS JOIN (
+   VALUES ('read'), ('upload'), ('update_metadata'), ('submit'), ('download'), ('export')
+ ) AS p(capability)
+ WHERE c.domain = 'COMMERCIAL' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+-- Achats, réception et certificats.
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, 'Achats', p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (
+   VALUES
+     ('read'), ('upload'), ('update_metadata'), ('submit'),
+     ('approve'), ('publish'), ('download'), ('export')
+ ) AS p(capability)
+ WHERE c.domain = 'ACHATS' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (
+   VALUES
+     ('Préparateur commandes'),
+     ('Préparation matière'),
+     ('Gestion matière'),
+     ('Livraison')
+ ) AS r(role_key)
+ CROSS JOIN (VALUES ('read'), ('upload'), ('download')) AS p(capability)
+ WHERE c.class_key IN ('RECEPTION_DOC', 'CERTIF_MATIERE') AND c.is_active
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (VALUES ('Responsable Qualité'), ('Qualité')) AS r(role_key)
+ CROSS JOIN (VALUES ('read'), ('download')) AS p(capability)
+ WHERE c.domain = 'ACHATS' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+-- Gouvernance et procédures.
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (VALUES ('Responsable Qualité'), ('Qualité')) AS r(role_key)
+ CROSS JOIN (
+   VALUES
+     ('read'), ('upload'), ('update_metadata'), ('submit'), ('approve'),
+     ('publish'), ('obsolete'), ('download'), ('export')
+ ) AS p(capability)
+ WHERE c.domain = 'GOUVERNANCE' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+INSERT INTO public.ged_class_capabilities (class_key, role_key, capability)
+SELECT c.class_key, r.role_key, p.capability
+  FROM public.ged_document_classes c
+ CROSS JOIN (
+   VALUES
+     ('Directeur Technique'),
+     ('Études-Méthodes'),
+     ('Responsable Programmation')
+ ) AS r(role_key)
+ CROSS JOIN (VALUES ('read'), ('download')) AS p(capability)
+ WHERE c.domain = 'GOUVERNANCE' AND c.is_active
+ON CONFLICT DO NOTHING;
+
+DO $grants$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT ON TABLE public.ged_class_capabilities TO cerp_app;
+  END IF;
+END
+$grants$;
+
+COMMIT;

--- a/db/patches/support/20260729_ged_scope_security_236.preflight.sql
+++ b/db/patches/support/20260729_ged_scope_security_236.preflight.sql
@@ -1,0 +1,22 @@
+\set ON_ERROR_STOP on
+
+DO $preflight$
+BEGIN
+  IF to_regclass('public.ged_document_classes') IS NULL THEN
+    RAISE EXCEPTION '#236: public.ged_document_classes absente - appliquer 20260727_ged_core.sql';
+  END IF;
+
+  IF to_regclass('public.ged_documents') IS NULL
+     OR to_regclass('public.ged_document_links') IS NULL
+     OR to_regclass('public.ged_document_versions') IS NULL
+     OR to_regclass('public.ged_access_events') IS NULL THEN
+    RAISE EXCEPTION '#236: noyau GED incomplet';
+  END IF;
+
+  IF to_regclass('public.piece_technique_versions') IS NULL THEN
+    RAISE EXCEPTION '#236: parent PIECE_TECHNIQUE_VERSION indisponible';
+  END IF;
+END
+$preflight$;
+
+SELECT 'GED_SCOPE_SECURITY_236_PREFLIGHT_OK' AS result;

--- a/db/patches/support/20260729_ged_scope_security_236.rollback.sql
+++ b/db/patches/support/20260729_ged_scope_security_236.rollback.sql
@@ -1,0 +1,9 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+DROP TABLE IF EXISTS public.ged_class_capabilities;
+
+COMMIT;
+
+SELECT 'GED_SCOPE_SECURITY_236_ROLLBACK_OK' AS result;

--- a/db/patches/support/20260729_ged_scope_security_236.verify.sql
+++ b/db/patches/support/20260729_ged_scope_security_236.verify.sql
@@ -1,0 +1,53 @@
+\set ON_ERROR_STOP on
+
+DO $verify$
+DECLARE
+  missing_read_count integer;
+  missing_admin_count integer;
+  invalid_count integer;
+BEGIN
+  IF to_regclass('public.ged_class_capabilities') IS NULL THEN
+    RAISE EXCEPTION '#236: public.ged_class_capabilities absente';
+  END IF;
+
+  SELECT COUNT(*) INTO missing_read_count
+    FROM public.ged_document_classes c
+   WHERE c.is_active
+     AND NOT EXISTS (
+       SELECT 1 FROM public.ged_class_capabilities p
+        WHERE p.class_key = c.class_key
+          AND p.capability IN ('read', 'admin')
+     );
+  IF missing_read_count <> 0 THEN
+    RAISE EXCEPTION '#236: % classe(s) active(s) sans lecture autorisée', missing_read_count;
+  END IF;
+
+  SELECT COUNT(*) INTO missing_admin_count
+    FROM public.ged_document_classes c
+   WHERE c.is_active
+     AND NOT EXISTS (
+       SELECT 1 FROM public.ged_class_capabilities p
+        WHERE p.class_key = c.class_key
+          AND p.role_key = 'Administrateur Systeme et Reseau'
+          AND p.capability = 'admin'
+     );
+  IF missing_admin_count <> 0 THEN
+    RAISE EXCEPTION '#236: % classe(s) active(s) sans administration explicite', missing_admin_count;
+  END IF;
+
+  SELECT COUNT(*) INTO invalid_count
+    FROM public.ged_class_capabilities
+   WHERE role_key <> btrim(role_key)
+      OR role_key = '';
+  IF invalid_count <> 0 THEN
+    RAISE EXCEPTION '#236: % permission(s) avec rôle non canonique', invalid_count;
+  END IF;
+END
+$verify$;
+
+SELECT class_key, COUNT(*) AS permissions_count
+  FROM public.ged_class_capabilities
+ GROUP BY class_key
+ ORDER BY class_key;
+
+SELECT 'GED_SCOPE_SECURITY_236_VERIFY_OK' AS result;

--- a/src/__tests__/ged-core.domain.test.ts
+++ b/src/__tests__/ged-core.domain.test.ts
@@ -13,12 +13,12 @@ import {
 } from "../module/ged/domain/ged-content";
 import {
   assertDistinctApprover,
-  assertGedCapability,
+  assertGedCapabilityGranted,
   assertVersionMutable,
   assertVersionTransition,
   formatDocumentCode,
+  gedRoleKeys,
   isVersionFrozen,
-  roleHasGedCapability,
   sanitizeOriginalName,
 } from "../module/ged/domain/ged-policy";
 import { storageKeyForSha256 } from "../module/ged/services/ged-vault.service";
@@ -46,38 +46,36 @@ function pdfFile(overrides: Record<string, unknown> = {}) {
 }
 
 describe("GED — capacités RBAC", () => {
-  it("refuse par défaut un rôle inconnu ou vide", () => {
-    expect(roleHasGedCapability(null, "read")).toBe(false);
-    expect(roleHasGedCapability("", "read")).toBe(false);
-    expect(roleHasGedCapability("stagiaire-externe", "read")).toBe(false);
+  it("refuse par défaut l'absence de rôle attribué", () => {
+    expect(gedRoleKeys(null)).toEqual([]);
+    expect(gedRoleKeys({ role: "" })).toEqual([]);
   });
 
-  it("accorde la lecture aux rôles opérationnels", () => {
-    expect(roleHasGedCapability("Methodes", "read")).toBe(true);
-    expect(roleHasGedCapability("Qualite", "read")).toBe(true);
-    expect(roleHasGedCapability("Atelier", "read")).toBe(true);
+  it("conserve uniquement les rôles exacts réellement attribués", () => {
+    expect(
+      gedRoleKeys({
+        role: "Production | Atelier | Method",
+        primary_role: "Directeur Technique",
+        roles: ["Directeur Technique", "Études-Méthodes"],
+      })
+    ).toEqual(["Directeur Technique", "Études-Méthodes"]);
   });
 
-  it("garde l'approbation et la publication étroites", () => {
-    expect(roleHasGedCapability("Atelier", "approve")).toBe(false);
-    expect(roleHasGedCapability("Magasinier", "publish")).toBe(false);
-    expect(roleHasGedCapability("Responsable Qualite", "approve")).toBe(true);
-    expect(roleHasGedCapability("Administrateur", "publish")).toBe(true);
+  it("ne découpe pas une chaîne effective sans rôle principal", () => {
+    expect(gedRoleKeys({ role: "Production | Atelier | Method" })).toEqual([
+      "Production | Atelier | Method",
+    ]);
   });
 
-  it("distingue export et download", () => {
-    expect(roleHasGedCapability("Magasinier", "download")).toBe(true);
-    expect(roleHasGedCapability("Magasinier", "export")).toBe(false);
-  });
-
-  it("lève une 403 explicite", () => {
-    expect(() => assertGedCapability("Atelier", "approve")).toThrowError(HttpError);
+  it("lève une 403 explicite quand la base refuse la capacité", () => {
+    expect(() => assertGedCapabilityGranted(false, "approve")).toThrowError(HttpError);
     try {
-      assertGedCapability("Atelier", "approve");
+      assertGedCapabilityGranted(false, "approve");
     } catch (err) {
       expect((err as HttpError).status).toBe(403);
       expect((err as HttpError).code).toBe("GED_CAPABILITY_REQUIRED");
     }
+    expect(() => assertGedCapabilityGranted(true, "approve")).not.toThrow();
   });
 });
 

--- a/src/__tests__/ged-core.routes.test.ts
+++ b/src/__tests__/ged-core.routes.test.ts
@@ -1,11 +1,6 @@
-// GED centrale CERP (ADR-0037) — tests de routes et de contrat.
-//
-// Deux garanties sont vérifiées ici et devront le rester :
-//   1. AUCUNE réponse ne contient de chemin physique.
-//   2. Un coffre indisponible produit un 503 explicite, jamais un repli local.
+import { EventEmitter } from "events";
 
 import request from "supertest";
-import { EventEmitter } from "events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
@@ -13,6 +8,9 @@ const mocks = vi.hoisted(() => ({
   poolConnect: vi.fn(),
   clientQuery: vi.fn(),
   clientRelease: vi.fn(),
+  targetExists: true,
+  linkedDocument: true,
+  readBlob: vi.fn(),
 }));
 
 vi.mock("pg", () => {
@@ -35,13 +33,36 @@ vi.mock("../utils/checkNetworkDrive", () => ({
 
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authenticateToken: (
-    req: { user?: { id: number; username: string; email: string; role: string }; headers: Record<string, unknown> },
+    req: {
+      user?: {
+        id: number;
+        username: string;
+        email: string;
+        role: string;
+        primary_role: string;
+        roles: string[];
+      };
+      headers: Record<string, unknown>;
+    },
     _res: unknown,
     next: () => void
   ) => {
-    const roleHeader =
-      typeof req.headers["x-test-role"] === "string" ? (req.headers["x-test-role"] as string) : "administrateur";
-    req.user = { id: 1, username: "test-admin", email: "admin@example.test", role: roleHeader };
+    if (req.headers["x-test-unauthenticated"] === "true") {
+      next();
+      return;
+    }
+    const role =
+      typeof req.headers["x-test-role"] === "string"
+        ? (req.headers["x-test-role"] as string)
+        : "Administrateur Systeme et Reseau";
+    req.user = {
+      id: 1,
+      username: "test-user",
+      email: "user@example.test",
+      role,
+      primary_role: role,
+      roles: [role],
+    };
     next();
   },
   authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
@@ -51,9 +72,247 @@ vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
   moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
 }));
 
+vi.mock("../module/ged/services/ged-vault.service", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../module/ged/services/ged-vault.service")>();
+  return {
+    ...actual,
+    readBlob: mocks.readBlob,
+  };
+});
+
 import app from "../config/app";
 
+const DOCUMENT_ID = "11111111-1111-4111-8111-111111111111";
+const VERSION_ID = "22222222-2222-4222-8222-222222222222";
+const PARENT_ID = "33333333-3333-4333-8333-333333333333";
+const OTHER_PARENT_ID = "44444444-4444-4444-8444-444444444444";
 const SHA = "b".repeat(64);
+
+const CLASS_ROW = {
+  class_key: "PLAN_CLIENT",
+  domain: "TECHNIQUE",
+  label: "Plan client",
+  nature: "SOURCE",
+  allowed_mime_types: ["application/pdf"],
+  allowed_extensions: [".pdf"],
+  max_size_bytes: "104857600",
+  approvals_required: 1,
+  retention_months: 120,
+  hold_on_publish: false,
+  is_active: true,
+};
+
+const DOCUMENT_ROW = {
+  id: DOCUMENT_ID,
+  code: "DT-000001",
+  class_key: "PLAN_CLIENT",
+  class_label: "Plan client",
+  domain: "TECHNIQUE",
+  title: "Plan 1234 indice B",
+  description: null,
+  current_version_number: 1,
+  current_version_status: "APPLICABLE",
+  versions_count: 1,
+  has_active_hold: false,
+  created_at: "2026-07-27T10:00:00.000Z",
+  updated_at: "2026-07-27T10:00:00.000Z",
+  archived_at: null,
+  access_scope_entity_type: "PIECE_TECHNIQUE_VERSION",
+  access_scope_entity_id: PARENT_ID,
+};
+
+const VERSION_ROW = {
+  id: VERSION_ID,
+  document_id: DOCUMENT_ID,
+  version_number: 1,
+  status: "APPLICABLE",
+  original_name: "plan.pdf",
+  mime_type: "application/pdf",
+  size_bytes: "1024",
+  sha256: SHA,
+  change_reason: null,
+  created_at: "2026-07-27T10:00:00.000Z",
+  submitted_at: null,
+  approved_at: null,
+  published_at: "2026-07-27T10:05:00.000Z",
+  obsoleted_at: null,
+  cu_id: 1,
+  cu_username: "keenan",
+  cu_name: "Keenan",
+  cu_surname: "Martin",
+  au_id: null,
+  au_username: null,
+  au_name: null,
+  au_surname: null,
+};
+
+const CAPABILITIES = new Set([
+  "read",
+  "upload",
+  "update_metadata",
+  "checkout",
+  "checkin",
+  "submit",
+  "approve",
+  "publish",
+  "obsolete",
+  "download",
+  "export",
+  "admin",
+]);
+
+function roleKeysFrom(params: unknown[]): string[] {
+  return (params.find((value) => Array.isArray(value)) as string[] | undefined) ?? [];
+}
+
+function capabilityFrom(params: unknown[]): string {
+  return (
+    (params.find(
+      (value) => typeof value === "string" && CAPABILITIES.has(value)
+    ) as string | undefined) ?? "read"
+  );
+}
+
+function hasAnyCapability(roleKeys: string[], capability: string): boolean {
+  if (roleKeys.includes("Administrateur Systeme et Reseau")) return true;
+  if (roleKeys.includes("stagiaire-externe")) return false;
+  if (roleKeys.includes("Directeur")) {
+    return ["read", "download", "export"].includes(capability);
+  }
+  if (roleKeys.includes("Études-Méthodes")) {
+    return [
+      "read",
+      "upload",
+      "update_metadata",
+      "checkout",
+      "checkin",
+      "submit",
+      "download",
+      "export",
+    ].includes(capability);
+  }
+  if (roleKeys.includes("Responsable Qualité")) {
+    return true;
+  }
+  if (roleKeys.includes("Responsable Atelier-Production")) {
+    return ["read", "upload", "download"].includes(capability);
+  }
+  return false;
+}
+
+function canReadTechnicalTarget(roleKeys: string[]): boolean {
+  return (
+    roleKeys.includes("Administrateur Systeme et Reseau") ||
+    roleKeys.includes("Études-Méthodes")
+  );
+}
+
+function scopeMatches(params: unknown[]): boolean {
+  if (!mocks.linkedDocument) return true;
+  const roleKeys = roleKeysFrom(params);
+  if (roleKeys.includes("Administrateur Systeme et Reseau")) return true;
+  return params.includes("PIECE_TECHNIQUE_VERSION") && params.includes(PARENT_ID);
+}
+
+function defaultQuery(sqlInput: unknown, paramsInput?: unknown[]) {
+  const sql = String(sqlInput);
+  const params = paramsInput ?? [];
+  const roleKeys = roleKeysFrom(params);
+  const capability = capabilityFrom(params);
+
+  if (sql.includes("INSERT INTO public.ged_access_events")) {
+    return { rows: [] };
+  }
+  if (sql.includes("public.piece_technique_versions") && sql.includes("AS found")) {
+    return { rows: [{ found: mocks.targetExists }] };
+  }
+  if (sql.includes("ged_class_capabilities") && sql.includes("AS granted")) {
+    return { rows: [{ granted: hasAnyCapability(roleKeys, capability) }] };
+  }
+  if (
+    sql.includes("FROM public.ged_class_capabilities cap") &&
+    sql.includes("AS granted")
+  ) {
+    return { rows: [{ granted: hasAnyCapability(roleKeys, capability) }] };
+  }
+  if (
+    sql.includes("FROM public.ged_document_classes c") &&
+    sql.includes("ORDER BY c.domain")
+  ) {
+    return { rows: hasAnyCapability(roleKeys, capability) ? [CLASS_ROW] : [] };
+  }
+  if (
+    sql.includes("FROM public.ged_document_classes") &&
+    sql.includes("WHERE class_key = $1")
+  ) {
+    return { rows: [CLASS_ROW] };
+  }
+  if (sql.includes("SELECT COUNT(*)::int AS total")) {
+    return { rows: [{ total: canReadTechnicalTarget(roleKeys) ? 1 : 0 }] };
+  }
+  if (sql.includes("SELECT") && sql.includes("AS access_scope_entity_type")) {
+    if (sql.includes("WHERE d.id = $1::uuid")) {
+      return {
+        rows:
+          params[0] === DOCUMENT_ID &&
+          canReadTechnicalTarget(roleKeys) &&
+          scopeMatches(params)
+            ? [DOCUMENT_ROW]
+            : [],
+      };
+    }
+    return { rows: canReadTechnicalTarget(roleKeys) ? [DOCUMENT_ROW] : [] };
+  }
+  if (sql.includes("b.storage_key")) {
+    return {
+      rows:
+        canReadTechnicalTarget(roleKeys) && scopeMatches(params)
+          ? [
+              {
+                version_id: VERSION_ID,
+                document_id: DOCUMENT_ID,
+                class_key: "PLAN_CLIENT",
+                status: "APPLICABLE",
+                original_name: "plan.pdf",
+                mime_type: "application/pdf",
+                sha256: SHA,
+                storage_key: `vault/sha256/bb/bb/${SHA}`,
+              },
+            ]
+          : [],
+    };
+  }
+  if (sql.includes("FROM public.ged_document_versions v") && sql.includes("b.mime_type")) {
+    return { rows: [VERSION_ROW] };
+  }
+  if (sql.includes("FROM public.ged_document_links")) {
+    return {
+      rows: mocks.linkedDocument
+        ? [
+            {
+              id: "55555555-5555-4555-8555-555555555555",
+              entity_type: "PIECE_TECHNIQUE_VERSION",
+              entity_id: PARENT_ID,
+              link_role: "PLAN",
+              created_at: "2026-07-27T10:00:00.000Z",
+            },
+          ]
+        : [],
+    };
+  }
+  if (
+    sql.includes("FROM public.ged_retention_holds") ||
+    sql.includes("FROM public.ged_checkouts")
+  ) {
+    return { rows: [] };
+  }
+  if (sql.includes("FROM public.ged_access_events e")) {
+    return { rows: [] };
+  }
+  return { rows: [] };
+}
+
 const VAULT_PATH_MARKERS = [
   "storage_path",
   "storage_key",
@@ -73,206 +332,232 @@ function assertNoPathLeak(payload: unknown) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mocks.poolConnect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease });
+  mocks.targetExists = true;
+  mocks.linkedDocument = true;
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+  mocks.poolQuery.mockImplementation(defaultQuery);
+  mocks.readBlob.mockResolvedValue(Buffer.from("%PDF-1.7\nsecure"));
   delete process.env.CERP_GED_VAULT_ROOT;
   process.env.CERP_GED_REQUIRE_SENTINEL = "false";
 });
 
-describe("GED — RBAC des routes", () => {
-  it("refuse la lecture à un rôle non habilité", async () => {
-    const res = await request(app).get("/api/v1/ged/classes").set("x-test-role", "stagiaire-externe");
-    expect(res.status).toBe(403);
-    expect(res.body?.code ?? res.body?.error?.code).toBeDefined();
+describe("GED — authentification et RBAC par classe", () => {
+  it("refuse une requête sans utilisateur authentifié", async () => {
+    const res = await request(app)
+      .get("/api/v1/ged/classes")
+      .set("x-test-unauthenticated", "true");
+    expect(res.status).toBe(401);
   });
 
-  it("refuse le dépôt à un rôle en lecture seule", async () => {
+  it("refuse par défaut un rôle inconnu", async () => {
+    const res = await request(app)
+      .get("/api/v1/ged/classes")
+      .set("x-test-role", "stagiaire-externe");
+    expect(res.status).toBe(403);
+    expect(JSON.stringify(res.body)).toContain("GED_CAPABILITY_REQUIRED");
+  });
+
+  it("ne confond pas lecture et dépôt", async () => {
     const res = await request(app)
       .post("/api/v1/ged/documents")
-      .set("x-test-role", "Atelier")
+      .set("x-test-role", "Directeur")
       .field("class_key", "PLAN_CLIENT")
       .field("title", "Essai");
     expect(res.status).toBe(403);
   });
 
-  it("refuse l'approbation à un rôle atelier", async () => {
+  it("renvoie 404 pour une classe cible hors périmètre d'un rôle pourtant habilité ailleurs", async () => {
     const res = await request(app)
-      .post(`/api/v1/ged/versions/${"1".repeat(8)}-1111-4111-8111-111111111111/approve`)
-      .set("x-test-role", "Atelier")
-      .send({});
-    expect(res.status).toBe(403);
+      .get(`/api/v1/ged/documents/${DOCUMENT_ID}`)
+      .set("x-test-role", "Responsable Qualité")
+      .query({ entity_type: "PIECE_TECHNIQUE_VERSION", entity_id: PARENT_ID });
+    expect(res.status).toBe(404);
+    expect(JSON.stringify(res.body)).toContain("GED_DOCUMENT_NOT_FOUND");
   });
 });
 
-describe("GED — schéma absent", () => {
-  it("répond 503 GED_NOT_INSTALLED plutôt qu'un 500 opaque", async () => {
-    const undefinedTable = Object.assign(new Error('relation "ged_document_classes" does not exist'), {
-      code: "42P01",
+describe("GED — contrôle parent/cible et anti-IDOR", () => {
+  it("refuse un UUID lié présenté sans son parent", async () => {
+    const res = await request(app)
+      .get(`/api/v1/ged/documents/${DOCUMENT_ID}`)
+      .set("x-test-role", "Études-Méthodes");
+    expect(res.status).toBe(404);
+  });
+
+  it("refuse le document valide avec un parent différent", async () => {
+    const res = await request(app)
+      .get(`/api/v1/ged/documents/${DOCUMENT_ID}`)
+      .set("x-test-role", "Études-Méthodes")
+      .query({
+        entity_type: "PIECE_TECHNIQUE_VERSION",
+        entity_id: OTHER_PARENT_ID,
+      });
+    expect(res.status).toBe(404);
+  });
+
+  it("refuse un identifiant de document deviné même avec un parent valide", async () => {
+    const guessedId = "99999999-9999-4999-8999-999999999999";
+    const res = await request(app)
+      .get(`/api/v1/ged/documents/${guessedId}`)
+      .set("x-test-role", "Études-Méthodes")
+      .query({
+        entity_type: "PIECE_TECHNIQUE_VERSION",
+        entity_id: PARENT_ID,
+      });
+    expect(res.status).toBe(404);
+    expect(JSON.stringify(res.body)).toContain("GED_DOCUMENT_NOT_FOUND");
+  });
+
+  it("refuse un périmètre partiel ou un type de parent non supporté", async () => {
+    const partial = await request(app)
+      .get(`/api/v1/ged/documents/${DOCUMENT_ID}`)
+      .set("x-test-role", "Études-Méthodes")
+      .query({ entity_type: "PIECE_TECHNIQUE_VERSION" });
+    expect(partial.status).toBe(400);
+
+    const unsupported = await request(app)
+      .get(`/api/v1/ged/documents/${DOCUMENT_ID}`)
+      .set("x-test-role", "Études-Méthodes")
+      .query({ entity_type: "COMMANDE_CLIENT", entity_id: PARENT_ID });
+    expect(unsupported.status).toBe(400);
+  });
+
+  it("autorise le couple parent/cible exact et journalise READ", async () => {
+    const res = await request(app)
+      .get(`/api/v1/ged/documents/${DOCUMENT_ID}`)
+      .set("x-test-role", "Études-Méthodes")
+      .query({
+        entity_type: "PIECE_TECHNIQUE_VERSION",
+        entity_id: PARENT_ID,
+      });
+    expect(res.status).toBe(200);
+    assertNoPathLeak(res.body);
+    expect(res.body.data.access_scope).toEqual({
+      entity_type: "PIECE_TECHNIQUE_VERSION",
+      entity_id: PARENT_ID,
     });
+
+    const auditCall = mocks.poolQuery.mock.calls.find(([sql]) =>
+      String(sql).includes("INSERT INTO public.ged_access_events")
+    );
+    expect(auditCall).toBeDefined();
+    expect(auditCall?.[1]?.[2]).toBe("READ");
+    assertNoPathLeak(auditCall?.[1]);
+  });
+
+  it("refuse un rattachement vers un parent inexistant avant toute écriture", async () => {
+    mocks.targetExists = false;
+    const res = await request(app)
+      .post("/api/v1/ged/documents")
+      .set("x-test-role", "Études-Méthodes")
+      .field("class_key", "PLAN_CLIENT")
+      .field("title", "Plan orphelin")
+      .field("entity_type", "PIECE_TECHNIQUE_VERSION")
+      .field("entity_id", OTHER_PARENT_ID)
+      .attach("file", Buffer.from("%PDF-1.7\nfake"), {
+        filename: "plan.pdf",
+        contentType: "application/pdf",
+      });
+    expect(res.status).toBe(404);
+    expect(JSON.stringify(res.body)).toContain("GED_LINK_TARGET_NOT_FOUND");
+  });
+});
+
+describe("GED — validation, disponibilité et contrat", () => {
+  it("répond 503 lorsque les tables de sécurité GED sont absentes", async () => {
+    const undefinedTable = Object.assign(
+      new Error('relation "ged_class_capabilities" does not exist'),
+      { code: "42P01" }
+    );
     mocks.poolQuery.mockRejectedValueOnce(undefinedTable);
 
-    const res = await request(app).get("/api/v1/ged/classes").set("x-test-role", "administrateur");
+    const res = await request(app).get("/api/v1/ged/classes");
     expect(res.status).toBe(503);
     expect(JSON.stringify(res.body)).toContain("GED_NOT_INSTALLED");
   });
-});
 
-describe("GED — coffre indisponible", () => {
-  it("refuse le dépôt en 503 et ne crée aucun répertoire de repli", async () => {
-    // CERP_GED_VAULT_ROOT volontairement absent : c'est exactement le scénario
-    // qui, ailleurs dans le code historique, produit un dossier local silencieux.
-    mocks.poolQuery.mockResolvedValueOnce({
-      rows: [
-        {
-          class_key: "PLAN_CLIENT",
-          domain: "TECHNIQUE",
-          label: "Plan client",
-          nature: "SOURCE",
-          allowed_mime_types: ["application/pdf"],
-          allowed_extensions: [".pdf"],
-          max_size_bytes: "104857600",
-          approvals_required: 1,
-          retention_months: 120,
-          hold_on_publish: false,
-          is_active: true,
-        },
-      ],
-    });
-
+  it("refuse le dépôt en 503 quand le coffre est indisponible", async () => {
     const res = await request(app)
       .post("/api/v1/ged/documents")
-      .set("x-test-role", "administrateur")
       .field("class_key", "PLAN_CLIENT")
-      .field("title", "Plan de contrôle initial")
-      .attach("file", Buffer.from("%PDF-1.7\nfake"), { filename: "plan.pdf", contentType: "application/pdf" });
-
+      .field("title", "Plan initial")
+      .attach("file", Buffer.from("%PDF-1.7\nfake"), {
+        filename: "plan.pdf",
+        contentType: "application/pdf",
+      });
     expect(res.status).toBe(503);
     expect(JSON.stringify(res.body)).toContain("GED_VAULT_UNAVAILABLE");
   });
-});
 
-describe("GED — contrôle de contenu au niveau route", () => {
-  it("refuse un exécutable renommé en .pdf avant toute écriture", async () => {
-    mocks.poolQuery.mockResolvedValueOnce({
-      rows: [
-        {
-          class_key: "PLAN_CLIENT",
-          domain: "TECHNIQUE",
-          label: "Plan client",
-          nature: "SOURCE",
-          allowed_mime_types: ["application/pdf"],
-          allowed_extensions: [".pdf"],
-          max_size_bytes: "104857600",
-          approvals_required: 1,
-          retention_months: 120,
-          hold_on_publish: false,
-          is_active: true,
-        },
-      ],
-    });
-
+  it("refuse un exécutable renommé en PDF avant toute écriture", async () => {
     const res = await request(app)
       .post("/api/v1/ged/documents")
-      .set("x-test-role", "administrateur")
       .field("class_key", "PLAN_CLIENT")
       .field("title", "Faux plan")
       .attach("file", Buffer.from([0x4d, 0x5a, 0x90, 0x00]), {
         filename: "plan.pdf",
         contentType: "application/pdf",
       });
-
     expect(res.status).toBe(415);
     expect(JSON.stringify(res.body)).toContain("GED_FILE_SIGNATURE");
   });
-});
 
-describe("GED — contrat : aucune fuite de chemin", () => {
-  it("ne renvoie aucun marqueur de chemin dans la liste des documents", async () => {
-    mocks.poolQuery
-      .mockResolvedValueOnce({ rows: [{ total: 1 }] })
-      .mockResolvedValueOnce({
-        rows: [
-          {
-            id: "11111111-1111-4111-8111-111111111111",
-            code: "DT-000001",
-            class_key: "PLAN_CLIENT",
-            class_label: "Plan client",
-            domain: "TECHNIQUE",
-            title: "Plan 1234 indice B",
-            description: null,
-            current_version_number: 2,
-            current_version_status: "APPLICABLE",
-            versions_count: 2,
-            has_active_hold: false,
-            created_at: "2026-07-27T10:00:00.000Z",
-            updated_at: "2026-07-27T11:00:00.000Z",
-            archived_at: null,
-          },
-        ],
-      });
-
-    const res = await request(app).get("/api/v1/ged/documents").set("x-test-role", "administrateur");
+  it("ne renvoie aucun chemin physique dans la recherche", async () => {
+    const res = await request(app).get("/api/v1/ged/documents");
     expect(res.status).toBe(200);
     assertNoPathLeak(res.body);
     expect(res.body.data[0].code).toBe("DT-000001");
     expect(res.body.data[0].sha256).toBeUndefined();
   });
 
-  it("ne renvoie aucun marqueur de chemin dans le détail d'un document", async () => {
-    const documentId = "11111111-1111-4111-8111-111111111111";
-    mocks.poolQuery
-      .mockResolvedValueOnce({
-        rows: [
-          {
-            id: documentId,
-            code: "DT-000001",
-            class_key: "PLAN_CLIENT",
-            class_label: "Plan client",
-            domain: "TECHNIQUE",
-            title: "Plan 1234 indice B",
-            description: null,
-            current_version_number: 1,
-            current_version_status: "APPLICABLE",
-            versions_count: 1,
-            has_active_hold: false,
-            created_at: "2026-07-27T10:00:00.000Z",
-            updated_at: "2026-07-27T10:00:00.000Z",
-            archived_at: null,
-          },
-        ],
-      })
-      .mockResolvedValueOnce({
-        rows: [
-          {
-            id: "22222222-2222-4222-8222-222222222222",
-            document_id: documentId,
-            version_number: 1,
-            status: "APPLICABLE",
-            original_name: "plan.pdf",
-            mime_type: "application/pdf",
-            size_bytes: "1024",
-            sha256: SHA,
-            change_reason: null,
-            created_at: "2026-07-27T10:00:00.000Z",
-            submitted_at: null,
-            approved_at: null,
-            published_at: "2026-07-27T10:05:00.000Z",
-            obsoleted_at: null,
-            cu_id: 1, cu_username: "keenan", cu_name: "Keenan", cu_surname: "Martin",
-            au_id: null, au_username: null, au_name: null, au_surname: null,
-          },
-        ],
-      })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
-
+  it("télécharge par la route authentifiée, avec périmètre exact et audit obligatoire", async () => {
     const res = await request(app)
-      .get(`/api/v1/ged/documents/${documentId}`)
-      .set("x-test-role", "administrateur");
+      .get(`/api/v1/ged/versions/${VERSION_ID}/content`)
+      .set("x-test-role", "Études-Méthodes")
+      .query({
+        entity_type: "PIECE_TECHNIQUE_VERSION",
+        entity_id: PARENT_ID,
+      });
 
     expect(res.status).toBe(200);
+    expect(res.headers["content-disposition"]).toContain("attachment");
+    expect(res.headers["x-content-type-options"]).toBe("nosniff");
+    expect(mocks.readBlob).toHaveBeenCalledWith(`vault/sha256/bb/bb/${SHA}`, SHA);
+
+    const auditCall = mocks.poolQuery.mock.calls.find(
+      ([sql, params]) =>
+        String(sql).includes("INSERT INTO public.ged_access_events") &&
+        Array.isArray(params) &&
+        params[2] === "DOWNLOAD"
+    );
+    expect(auditCall).toBeDefined();
+    assertNoPathLeak(auditCall?.[1]);
+  });
+
+  it("refuse de servir un fichier si la trace DOWNLOAD ne peut pas être écrite", async () => {
+    mocks.poolQuery.mockImplementation((sql, params) => {
+      if (
+        String(sql).includes("INSERT INTO public.ged_access_events") &&
+        Array.isArray(params) &&
+        params[2] === "DOWNLOAD"
+      ) {
+        return Promise.reject(new Error("audit indisponible"));
+      }
+      return defaultQuery(sql, params);
+    });
+
+    const res = await request(app)
+      .get(`/api/v1/ged/versions/${VERSION_ID}/content`)
+      .set("x-test-role", "Études-Méthodes")
+      .query({
+        entity_type: "PIECE_TECHNIQUE_VERSION",
+        entity_id: PARENT_ID,
+      });
+
+    expect(res.status).toBe(500);
     assertNoPathLeak(res.body);
-    // L'empreinte, elle, est publiée : c'est une preuve d'intégrité, pas un chemin.
-    expect(res.body.data.versions[0].sha256).toBe(SHA);
   });
 });

--- a/src/module/ged/controllers/ged.controller.ts
+++ b/src/module/ged/controllers/ged.controller.ts
@@ -3,8 +3,11 @@
 import type { NextFunction, Request, Response } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { gedRoleKeys } from "../domain/ged-policy";
 import * as service from "../services/ged.service";
+import type { GedAccessScope } from "../types/ged.types";
 import {
+  accessScopeQuerySchema,
   listQuerySchema,
   newVersionBodySchema,
   transitionBodySchema,
@@ -17,7 +20,7 @@ function actorFrom(req: Request): service.GedActor {
   if (!user || typeof user.id !== "number") {
     throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
   }
-  return { id: user.id, role: (user.role as string | null) ?? null };
+  return { id: user.id, role_keys: gedRoleKeys(user) };
 }
 
 function parseUuid(value: unknown, label: string): string {
@@ -38,6 +41,28 @@ function parseMultipartBody(req: Request) {
     throw new HttpError(400, "VALIDATION_ERROR", "Champs invalides.", parsed.error.flatten());
   }
   return parsed.data;
+}
+
+function scopeFrom(value: {
+  entity_type?: string | null;
+  entity_id?: string | null;
+}): GedAccessScope | null {
+  return value.entity_type && value.entity_id
+    ? { entity_type: value.entity_type, entity_id: value.entity_id }
+    : null;
+}
+
+function parseAccessScope(req: Request): GedAccessScope | null {
+  const parsed = accessScopeQuerySchema.safeParse(req.query ?? {});
+  if (!parsed.success) {
+    throw new HttpError(
+      400,
+      "VALIDATION_ERROR",
+      "Périmètre documentaire invalide.",
+      parsed.error.flatten()
+    );
+  }
+  return scopeFrom(parsed.data);
 }
 
 export async function getClasses(req: Request, res: Response, next: NextFunction) {
@@ -91,7 +116,7 @@ export async function listDocuments(req: Request, res: Response, next: NextFunct
 export async function getDocument(req: Request, res: Response, next: NextFunction) {
   try {
     const id = parseUuid(req.params.id, "Identifiant de document");
-    res.json({ data: await service.getDocument(actorFrom(req), id) });
+    res.json({ data: await service.getDocument(actorFrom(req), id, parseAccessScope(req)) });
   } catch (err) {
     next(err);
   }
@@ -100,7 +125,9 @@ export async function getDocument(req: Request, res: Response, next: NextFunctio
 export async function getDocumentHistory(req: Request, res: Response, next: NextFunction) {
   try {
     const id = parseUuid(req.params.id, "Identifiant de document");
-    res.json({ data: await service.listDocumentHistory(actorFrom(req), id) });
+    res.json({
+      data: await service.listDocumentHistory(actorFrom(req), id, parseAccessScope(req)),
+    });
   } catch (err) {
     next(err);
   }
@@ -138,7 +165,13 @@ export async function postDocumentVersion(req: Request, res: Response, next: Nex
     if (!parsed.success) {
       throw new HttpError(400, "VALIDATION_ERROR", "Un motif de révision est requis.", parsed.error.flatten());
     }
-    const detail = await service.uploadNewVersion(actorFrom(req), id, parsed.data, req.file);
+    const detail = await service.uploadNewVersion(
+      actorFrom(req),
+      id,
+      { change_reason: parsed.data.change_reason },
+      req.file,
+      scopeFrom(parsed.data)
+    );
     res.status(201).json({ data: detail });
   } catch (err) {
     next(err);
@@ -146,7 +179,12 @@ export async function postDocumentVersion(req: Request, res: Response, next: Nex
 }
 
 function transitionHandler(
-  action: (actor: service.GedActor, versionId: string, comment: string | null) => Promise<unknown>
+  action: (
+    actor: service.GedActor,
+    versionId: string,
+    comment: string | null,
+    scope: GedAccessScope | null
+  ) => Promise<unknown>
 ) {
   return async (req: Request, res: Response, next: NextFunction) => {
     try {
@@ -155,21 +193,39 @@ function transitionHandler(
       if (!parsed.success) {
         throw new HttpError(400, "VALIDATION_ERROR", "Commentaire invalide.", parsed.error.flatten());
       }
-      res.json({ data: await action(actorFrom(req), versionId, parsed.data.comment ?? null) });
+      res.json({
+        data: await action(
+          actorFrom(req),
+          versionId,
+          parsed.data.comment ?? null,
+          scopeFrom(parsed.data)
+        ),
+      });
     } catch (err) {
       next(err);
     }
   };
 }
 
-export const submitVersion = transitionHandler((a, v, c) => service.submitVersion(a, v, c));
-export const approveVersion = transitionHandler((a, v, c) => service.approveVersion(a, v, c));
-export const obsoleteVersion = transitionHandler((a, v, c) => service.obsoleteVersion(a, v, c));
+export const submitVersion = transitionHandler((a, v, c, s) => service.submitVersion(a, v, c, s));
+export const approveVersion = transitionHandler((a, v, c, s) => service.approveVersion(a, v, c, s));
+export const obsoleteVersion = transitionHandler((a, v, c, s) => service.obsoleteVersion(a, v, c, s));
 
 export async function publishVersion(req: Request, res: Response, next: NextFunction) {
   try {
     const versionId = parseUuid(req.params.versionId, "Identifiant de version");
-    res.json({ data: await service.publishVersion(actorFrom(req), versionId) });
+    const parsed = transitionBodySchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      throw new HttpError(
+        400,
+        "VALIDATION_ERROR",
+        "Périmètre documentaire invalide.",
+        parsed.error.flatten()
+      );
+    }
+    res.json({
+      data: await service.publishVersion(actorFrom(req), versionId, scopeFrom(parsed.data)),
+    });
   } catch (err) {
     next(err);
   }
@@ -178,7 +234,11 @@ export async function publishVersion(req: Request, res: Response, next: NextFunc
 export async function downloadVersion(req: Request, res: Response, next: NextFunction) {
   try {
     const versionId = parseUuid(req.params.versionId, "Identifiant de version");
-    const result = await service.downloadVersion(actorFrom(req), versionId);
+    const result = await service.downloadVersion(
+      actorFrom(req),
+      versionId,
+      parseAccessScope(req)
+    );
 
     // `attachment` + `nosniff` : un document n'est jamais interprété par le
     // navigateur, quel que soit son type déclaré.

--- a/src/module/ged/domain/ged-policy.ts
+++ b/src/module/ged/domain/ged-policy.ts
@@ -1,18 +1,5 @@
-// GED centrale CERP (ADR-0037) — politiques pures, sans I/O.
-//
-// Ce fichier concentre les règles qui ne doivent jamais dépendre d'un appel
-// réseau, d'un client SQL ou du système de fichiers : capacités RBAC, cycle de
-// vie documentaire, séparation des tâches, codification.
-//
-// Même mécanique de « needles » que `quality-policy.ts` et `of-rbac.ts` : les
-// rôles CERP sont du texte libre en base, on ne crée pas une seconde
-// nomenclature de rôles en parallèle.
-
 import { HttpError } from "../../../utils/httpError";
-
-/* -------------------------------------------------------------------------- */
-/* 1) Capacités RBAC — refus par défaut                                       */
-/* -------------------------------------------------------------------------- */
+import { normalizeAssignedRoles } from "../../auth/domain/roles";
 
 export const GED_CAPABILITIES = [
   "read",
@@ -31,59 +18,26 @@ export const GED_CAPABILITIES = [
 
 export type GedCapability = (typeof GED_CAPABILITIES)[number];
 
-const CAPABILITY_NEEDLES: Record<GedCapability, readonly string[]> = {
-  read: [
-    "admin", "administrateur", "directeur", "qualit", "quality", "qse",
-    "method", "technique", "bureau", "production", "atelier", "programm",
-    "achat", "commerc", "logisti", "magasin", "metrolog", "compta",
-  ],
-  upload: [
-    "admin", "administrateur", "directeur", "qualit", "quality", "qse",
-    "method", "technique", "bureau", "programm", "achat", "commerc",
-    "logisti", "magasin", "metrolog", "compta",
-  ],
-  update_metadata: [
-    "admin", "administrateur", "directeur", "qualit", "quality", "qse",
-    "method", "technique", "bureau", "programm", "achat", "commerc", "metrolog",
-  ],
-  checkout: ["admin", "administrateur", "directeur", "method", "technique", "bureau", "programm"],
-  checkin: ["admin", "administrateur", "directeur", "method", "technique", "bureau", "programm"],
-  submit: [
-    "admin", "administrateur", "directeur", "qualit", "quality", "qse",
-    "method", "technique", "bureau", "programm", "achat", "commerc", "metrolog", "compta",
-  ],
-  // Approuver et publier restent volontairement étroits : ce sont les deux
-  // gestes qui rendent un document opposable à l'atelier et au client.
-  approve: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "responsable"],
-  publish: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "responsable"],
-  obsolete: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "responsable"],
-  download: [
-    "admin", "administrateur", "directeur", "qualit", "quality", "qse",
-    "method", "technique", "bureau", "production", "atelier", "programm",
-    "achat", "commerc", "logisti", "magasin", "metrolog", "compta",
-  ],
-  // `export` est distinct de `download` : télécharger une pièce n'autorise pas
-  // à extraire un lot entier.
-  export: ["admin", "administrateur", "directeur", "qualit", "quality", "qse", "responsable"],
-  admin: ["admin", "administrateur", "directeur"],
+export type GedRoleBearer = {
+  role?: string | null;
+  primary_role?: string | null;
+  roles?: readonly string[] | null;
 };
 
-export function roleHasGedCapability(
-  role: string | null | undefined,
-  capability: GedCapability
-): boolean {
-  const normalized = (role ?? "").trim().toLowerCase();
-  if (!normalized) return false;
-  const needles = CAPABILITY_NEEDLES[capability];
-  if (!needles) return false;
-  return needles.some((needle) => normalized.includes(needle));
+/**
+ * Retourne les rôles réellement attribués. La chaîne effective séparée par
+ * `|` n'est jamais interprétée par sous-chaîne.
+ */
+export function gedRoleKeys(user: GedRoleBearer | null | undefined): string[] {
+  if (!user) return [];
+  return normalizeAssignedRoles(user.primary_role ?? user.role, user.roles);
 }
 
-export function assertGedCapability(
-  role: string | null | undefined,
+export function assertGedCapabilityGranted(
+  granted: boolean,
   capability: GedCapability
 ): void {
-  if (!roleHasGedCapability(role, capability)) {
+  if (!granted) {
     throw new HttpError(
       403,
       "GED_CAPABILITY_REQUIRED",
@@ -91,10 +45,6 @@ export function assertGedCapability(
     );
   }
 }
-
-/* -------------------------------------------------------------------------- */
-/* 2) Cycle de vie documentaire                                               */
-/* -------------------------------------------------------------------------- */
 
 export const GED_VERSION_STATUSES = [
   "BROUILLON",
@@ -109,8 +59,6 @@ export type GedVersionStatus = (typeof GED_VERSION_STATUSES)[number];
 const VERSION_TRANSITIONS: Readonly<Record<GedVersionStatus, readonly GedVersionStatus[]>> = {
   BROUILLON: ["EN_REVUE", "OBSOLETE"],
   EN_REVUE: ["BROUILLON", "APPROUVE", "OBSOLETE"],
-  // Une version approuvée se publie ou s'abandonne : elle ne redevient jamais
-  // un brouillon, sinon son contenu deviendrait modifiable après approbation.
   APPROUVE: ["APPLICABLE", "OBSOLETE"],
   APPLICABLE: ["OBSOLETE"],
   OBSOLETE: [],
@@ -141,15 +89,6 @@ export function assertVersionMutable(status: GedVersionStatus): void {
   }
 }
 
-/* -------------------------------------------------------------------------- */
-/* 3) Séparation des tâches                                                   */
-/* -------------------------------------------------------------------------- */
-
-/**
- * Le déposant d'une version ne peut pas l'approuver. Rejoué ici en plus du
- * trigger `fn_ged_version_separation_of_duties` : le service donne un message
- * lisible, la base garantit que la règle survit à un script.
- */
 export function assertDistinctApprover(
   createdBy: number | null | undefined,
   approverId: number
@@ -162,10 +101,6 @@ export function assertDistinctApprover(
     );
   }
 }
-
-/* -------------------------------------------------------------------------- */
-/* 4) Codification documentaire                                               */
-/* -------------------------------------------------------------------------- */
 
 const CODE_PREFIX_BY_DOMAIN: Readonly<Record<string, string>> = {
   TECHNIQUE: "DT",
@@ -182,10 +117,6 @@ export function documentCodePrefix(domain: string): string {
   return CODE_PREFIX_BY_DOMAIN[domain.trim().toUpperCase()] ?? "DX";
 }
 
-/**
- * Code documentaire immuable, jamais réutilisé. La séquence est portée par la
- * base ; cette fonction ne fait que le formatage, pour rester testable sans I/O.
- */
 export function formatDocumentCode(domain: string, sequence: number): string {
   if (!Number.isInteger(sequence) || sequence <= 0) {
     throw new HttpError(500, "GED_CODE_SEQUENCE", "Séquence de code documentaire invalide.");
@@ -193,23 +124,15 @@ export function formatDocumentCode(domain: string, sequence: number): string {
   return `${documentCodePrefix(domain)}-${String(sequence).padStart(6, "0")}`;
 }
 
-/* -------------------------------------------------------------------------- */
-/* 5) Assainissement des noms de fichier                                      */
-/* -------------------------------------------------------------------------- */
-
 const MIN_PRINTABLE_CODE_POINT = 0x20;
 const DEL_CODE_POINT = 0x7f;
 
 /**
- * Le nom d'origine est une DONNÉE, jamais un chemin. Il est conservé pour
- * l'affichage et le `Content-Disposition`, mais ne participe jamais à la
- * construction d'un chemin physique : le coffre adresse par empreinte.
+ * Le nom d'origine est une donnée d'affichage et ne participe jamais à la
+ * construction du chemin physique dans le coffre.
  */
 export function sanitizeOriginalName(value: string | null | undefined): string {
-  // Ne conserver que le dernier segment : `../../etc/passwd` devient `passwd`.
   const base = (value ?? "").split(/[\\/]/).pop() ?? "";
-  // Les caractères de contrôle sont retirés par code point plutôt que par un
-  // littéral de regex, qui écrirait de vrais octets de contrôle dans ce fichier.
   const printable = Array.from(base.normalize("NFKD"))
     .filter((char) => {
       const code = char.codePointAt(0) ?? 0;

--- a/src/module/ged/middlewares/require-ged-capability.ts
+++ b/src/module/ged/middlewares/require-ged-capability.ts
@@ -7,7 +7,8 @@
 import type { RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
-import { roleHasGedCapability, type GedCapability } from "../domain/ged-policy";
+import { gedRoleKeys, type GedCapability } from "../domain/ged-policy";
+import { repoActorHasAnyCapability } from "../repository/ged.repository";
 
 export function requireGedCapability(capability: GedCapability): RequestHandler {
   return (req, _res, next) => {
@@ -15,12 +16,21 @@ export function requireGedCapability(capability: GedCapability): RequestHandler 
       next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
       return;
     }
-    if (!roleHasGedCapability(req.user.role, capability)) {
-      next(
-        new HttpError(403, "GED_CAPABILITY_REQUIRED", `La capacité GED '${capability}' est requise.`)
-      );
-      return;
-    }
-    next();
+    const roleKeys = gedRoleKeys(req.user);
+    void repoActorHasAnyCapability(roleKeys, capability)
+      .then((granted) => {
+        if (!granted) {
+          next(
+            new HttpError(
+              403,
+              "GED_CAPABILITY_REQUIRED",
+              `La capacité GED '${capability}' est requise.`
+            )
+          );
+          return;
+        }
+        next();
+      })
+      .catch(next);
   };
 }

--- a/src/module/ged/repository/ged.repository.ts
+++ b/src/module/ged/repository/ged.repository.ts
@@ -15,8 +15,13 @@ import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
-import { formatDocumentCode, type GedVersionStatus } from "../domain/ged-policy";
+import {
+  formatDocumentCode,
+  type GedCapability,
+  type GedVersionStatus,
+} from "../domain/ged-policy";
 import type {
+  GedAccessScope,
   GedAccessEvent,
   GedDocumentClass,
   GedDocumentDetail,
@@ -30,6 +35,52 @@ import type {
 
 const UNDEFINED_TABLE = "42P01";
 
+export type GedAuthorization = {
+  role_keys: readonly string[];
+  capability: GedCapability;
+  scope?: GedAccessScope | null;
+};
+
+function classCapabilityPredicate(
+  classExpression: string,
+  roleKeysParameter: string,
+  capabilityParameter: string
+): string {
+  return `EXISTS (
+    SELECT 1
+      FROM public.ged_class_capabilities cap
+     WHERE cap.class_key = ${classExpression}
+       AND cap.role_key = ANY(${roleKeysParameter}::text[])
+       AND cap.capability IN (${capabilityParameter}, 'admin')
+  )`;
+}
+
+function documentScopePredicate(
+  documentExpression: string,
+  classExpression: string,
+  roleKeysParameter: string,
+  scopeTypeParameter: string,
+  scopeIdParameter: string
+): string {
+  return `(
+    ${classCapabilityPredicate(classExpression, roleKeysParameter, "'admin'")}
+    OR NOT EXISTS (
+      SELECT 1 FROM public.ged_document_links scope_any
+       WHERE scope_any.document_id = ${documentExpression}
+    )
+    OR (
+      ${scopeTypeParameter}::text IS NOT NULL
+      AND ${scopeIdParameter}::text IS NOT NULL
+      AND EXISTS (
+        SELECT 1 FROM public.ged_document_links scope_match
+         WHERE scope_match.document_id = ${documentExpression}
+           AND scope_match.entity_type = ${scopeTypeParameter}
+           AND scope_match.entity_id = ${scopeIdParameter}
+      )
+    )
+  )`;
+}
+
 export function isGedSchemaMissing(err: unknown): boolean {
   return (err as { code?: string } | null)?.code === UNDEFINED_TABLE;
 }
@@ -40,7 +91,7 @@ function rethrowGed(err: unknown): never {
     throw new HttpError(
       503,
       "GED_NOT_INSTALLED",
-      "Le module GED n'est pas encore installé sur cette base (patch 20260727_ged_core non appliqué)."
+      "Le module GED n'est pas complètement installé sur cette base (patches GED requis)."
     );
   }
   throw err;
@@ -126,15 +177,62 @@ function mapVersion(r: VersionRow): GedDocumentVersion {
 /* Classes documentaires                                                      */
 /* -------------------------------------------------------------------------- */
 
-export async function repoListClasses(): Promise<GedDocumentClass[]> {
+export async function repoActorHasAnyCapability(
+  roleKeys: readonly string[],
+  capability: GedCapability
+): Promise<boolean> {
+  if (roleKeys.length === 0) return false;
   try {
     const res = await pool.query(
-      `SELECT class_key, domain, label, nature, allowed_mime_types, allowed_extensions,
-              max_size_bytes::bigint::text AS max_size_bytes, approvals_required::int AS approvals_required,
-              retention_months::int AS retention_months, hold_on_publish, is_active
-         FROM public.ged_document_classes
-        WHERE is_active
-        ORDER BY domain, label`
+      `SELECT EXISTS (
+         SELECT 1
+           FROM public.ged_class_capabilities cap
+          WHERE cap.role_key = ANY($1::text[])
+            AND cap.capability IN ($2, 'admin')
+       ) AS granted`,
+      [roleKeys, capability]
+    );
+    return Boolean(res.rows[0]?.granted);
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
+export async function repoActorHasClassCapability(
+  classKey: string,
+  roleKeys: readonly string[],
+  capability: GedCapability,
+  tx?: Pick<PoolClient, "query">
+): Promise<boolean> {
+  if (roleKeys.length === 0) return false;
+  const db = tx ?? pool;
+  try {
+    const res = await db.query(
+      `SELECT ${classCapabilityPredicate("$1", "$2", "$3")} AS granted`,
+      [classKey, roleKeys, capability]
+    );
+    return Boolean(res.rows[0]?.granted);
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
+export async function repoListClasses(
+  roleKeys: readonly string[],
+  capability: GedCapability = "read"
+): Promise<GedDocumentClass[]> {
+  try {
+    const res = await pool.query(
+      `SELECT c.class_key, c.domain, c.label, c.nature, c.allowed_mime_types, c.allowed_extensions,
+              c.max_size_bytes::bigint::text AS max_size_bytes,
+              c.approvals_required::int AS approvals_required,
+              c.retention_months::int AS retention_months,
+              c.hold_on_publish, c.is_active
+         FROM public.ged_document_classes c
+        WHERE c.is_active
+          AND ${classCapabilityPredicate("c.class_key", "$1", "$2")}
+        ORDER BY c.domain, c.label`,
+      [roleKeys, capability]
     );
     return res.rows.map((r) => ({
       class_key: String(r.class_key),
@@ -186,6 +284,22 @@ export async function repoGetClass(
   } catch (err) {
     return rethrowGed(err);
   }
+}
+
+export async function repoGetClassForActor(
+  classKey: string,
+  authorization: GedAuthorization,
+  tx?: Pick<PoolClient, "query">
+): Promise<GedDocumentClass | null> {
+  if (authorization.role_keys.length === 0) return null;
+  const granted = await repoActorHasClassCapability(
+    classKey,
+    authorization.role_keys,
+    authorization.capability,
+    tx
+  );
+  if (!granted) return null;
+  return repoGetClass(classKey, tx);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -318,17 +432,27 @@ export async function repoAddVersion(
 
 export async function repoGetVersionForUpdate(
   tx: Pick<PoolClient, "query">,
-  versionId: string
+  versionId: string,
+  authorization: GedAuthorization
 ): Promise<{
   id: string; document_id: string; status: GedVersionStatus; created_by: number | null; version_number: number;
 } | null> {
   const res = await tx.query(
-    `SELECT id::text AS id, document_id::text AS document_id, status::text AS status,
-            created_by, version_number::int AS version_number
-       FROM public.ged_document_versions
-      WHERE id = $1::uuid
+    `SELECT v.id::text AS id, v.document_id::text AS document_id, v.status::text AS status,
+            v.created_by, v.version_number::int AS version_number
+       FROM public.ged_document_versions v
+       JOIN public.ged_documents d ON d.id = v.document_id
+      WHERE v.id = $1::uuid
+        AND ${classCapabilityPredicate("d.class_key", "$2", "$3")}
+        AND ${documentScopePredicate("d.id", "d.class_key", "$2", "$4", "$5")}
       FOR UPDATE`,
-    [versionId]
+    [
+      versionId,
+      authorization.role_keys,
+      authorization.capability,
+      authorization.scope?.entity_type ?? null,
+      authorization.scope?.entity_id ?? null,
+    ]
   );
   const r = res.rows[0];
   if (!r) return null;
@@ -412,6 +536,28 @@ export async function repoAddLink(
   );
 }
 
+export async function repoLinkTargetExists(
+  entityType: string,
+  entityId: string,
+  tx?: Pick<PoolClient, "query">
+): Promise<boolean> {
+  const db = tx ?? pool;
+  try {
+    if (entityType !== "PIECE_TECHNIQUE_VERSION") return false;
+    const res = await db.query(
+      `SELECT EXISTS (
+         SELECT 1
+           FROM public.piece_technique_versions v
+          WHERE v.id = $1::uuid
+       ) AS found`,
+      [entityId]
+    );
+    return Boolean(res.rows[0]?.found);
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
 /* -------------------------------------------------------------------------- */
 /* Journal d'accès                                                            */
 /* -------------------------------------------------------------------------- */
@@ -440,17 +586,31 @@ export async function repoLogAccess(
   );
 }
 
-export async function repoListAccessEvents(documentId: string, limit = 100): Promise<GedAccessEvent[]> {
+export async function repoListAccessEvents(
+  documentId: string,
+  authorization: GedAuthorization,
+  limit = 100
+): Promise<GedAccessEvent[]> {
   try {
     const res = await pool.query(
       `SELECT e.id::text AS id, e.event_type, e.occurred_at::text AS occurred_at, e.details,
               u.id AS u_id, u.username AS u_username, u.name AS u_name, u.surname AS u_surname
          FROM public.ged_access_events e
+         JOIN public.ged_documents d ON d.id = e.document_id
          LEFT JOIN public.users u ON u.id = e.actor_id
         WHERE e.document_id = $1::uuid
+          AND ${classCapabilityPredicate("d.class_key", "$2", "$3")}
+          AND ${documentScopePredicate("d.id", "d.class_key", "$2", "$4", "$5")}
         ORDER BY e.occurred_at DESC
-        LIMIT $2`,
-      [documentId, limit]
+        LIMIT $6`,
+      [
+        documentId,
+        authorization.role_keys,
+        authorization.capability,
+        authorization.scope?.entity_type ?? null,
+        authorization.scope?.entity_id ?? null,
+        limit,
+      ]
     );
     return res.rows.map((r) => ({
       id: String(r.id),
@@ -475,7 +635,9 @@ const SUMMARY_SELECT = `
   cv.status::text        AS current_version_status,
   (SELECT COUNT(*) FROM public.ged_document_versions vv WHERE vv.document_id = d.id)::int AS versions_count,
   EXISTS (SELECT 1 FROM public.ged_retention_holds h WHERE h.document_id = d.id AND h.released_at IS NULL) AS has_active_hold,
-  d.created_at::text AS created_at, d.updated_at::text AS updated_at, d.archived_at::text AS archived_at
+  d.created_at::text AS created_at, d.updated_at::text AS updated_at, d.archived_at::text AS archived_at,
+  scope.entity_type AS access_scope_entity_type,
+  scope.entity_id AS access_scope_entity_id
 `;
 
 function mapSummary(r: Record<string, unknown>): GedDocumentSummary {
@@ -494,13 +656,29 @@ function mapSummary(r: Record<string, unknown>): GedDocumentSummary {
     created_at: String(r.created_at),
     updated_at: String(r.updated_at),
     archived_at: (r.archived_at as string | null) ?? null,
+    access_scope:
+      r.access_scope_entity_type && r.access_scope_entity_id
+        ? {
+            entity_type: String(r.access_scope_entity_type),
+            entity_id: String(r.access_scope_entity_id),
+          }
+        : null,
   };
 }
 
-export async function repoListDocuments(filters: GedListFilters): Promise<GedListResult> {
+export async function repoListDocuments(
+  filters: GedListFilters,
+  authorization: GedAuthorization
+): Promise<GedListResult> {
   const where: string[] = [];
   const params: unknown[] = [];
   const push = (value: unknown) => `$${params.push(value)}`;
+
+  const roleKeysParameter = push(authorization.role_keys);
+  const capabilityParameter = push(authorization.capability);
+  let preferredScopeTypeParameter = "NULL";
+  let preferredScopeIdParameter = "NULL";
+  where.push(classCapabilityPredicate("d.class_key", roleKeysParameter, capabilityParameter));
 
   if (!filters.include_archived) where.push("d.archived_at IS NULL");
   if (filters.class_key) where.push(`d.class_key = ${push(filters.class_key)}`);
@@ -511,10 +689,12 @@ export async function repoListDocuments(filters: GedListFilters): Promise<GedLis
     where.push(`(lower(d.title) LIKE ${push(like)} OR lower(d.code) LIKE ${push(like)})`);
   }
   if (filters.entity_type && filters.entity_id) {
+    preferredScopeTypeParameter = push(filters.entity_type);
+    preferredScopeIdParameter = push(filters.entity_id);
     where.push(
       `EXISTS (SELECT 1 FROM public.ged_document_links l
-                WHERE l.document_id = d.id AND l.entity_type = ${push(filters.entity_type)}
-                  AND l.entity_id = ${push(filters.entity_id)})`
+                WHERE l.document_id = d.id AND l.entity_type = ${preferredScopeTypeParameter}
+                  AND l.entity_id = ${preferredScopeIdParameter})`
     );
   }
 
@@ -523,6 +703,17 @@ export async function repoListDocuments(filters: GedListFilters): Promise<GedLis
     FROM public.ged_documents d
     JOIN public.ged_document_classes c ON c.class_key = d.class_key
     LEFT JOIN public.ged_document_versions cv ON cv.id = d.current_version_id
+    LEFT JOIN LATERAL (
+      SELECT l.entity_type, l.entity_id
+        FROM public.ged_document_links l
+       WHERE l.document_id = d.id
+       ORDER BY
+         (l.entity_type = ${preferredScopeTypeParameter}::text
+          AND l.entity_id = ${preferredScopeIdParameter}::text) DESC,
+         l.created_at,
+         l.id
+       LIMIT 1
+    ) scope ON true
   `;
 
   try {
@@ -548,15 +739,36 @@ export async function repoListDocuments(filters: GedListFilters): Promise<GedLis
   }
 }
 
-export async function repoGetDocumentDetail(documentId: string): Promise<GedDocumentDetail | null> {
+export async function repoGetDocumentDetail(
+  documentId: string,
+  authorization: GedAuthorization
+): Promise<GedDocumentDetail | null> {
   try {
     const docRes = await pool.query(
       `SELECT ${SUMMARY_SELECT}
          FROM public.ged_documents d
          JOIN public.ged_document_classes c ON c.class_key = d.class_key
          LEFT JOIN public.ged_document_versions cv ON cv.id = d.current_version_id
-        WHERE d.id = $1::uuid`,
-      [documentId]
+         LEFT JOIN LATERAL (
+           SELECT l.entity_type, l.entity_id
+             FROM public.ged_document_links l
+            WHERE l.document_id = d.id
+            ORDER BY
+              (l.entity_type = $4::text AND l.entity_id = $5::text) DESC,
+              l.created_at,
+              l.id
+            LIMIT 1
+         ) scope ON true
+        WHERE d.id = $1::uuid
+          AND ${classCapabilityPredicate("d.class_key", "$2", "$3")}
+          AND ${documentScopePredicate("d.id", "d.class_key", "$2", "$4", "$5")}`,
+      [
+        documentId,
+        authorization.role_keys,
+        authorization.capability,
+        authorization.scope?.entity_type ?? null,
+        authorization.scope?.entity_id ?? null,
+      ]
     );
     const docRow = docRes.rows[0];
     if (!docRow) return null;
@@ -639,9 +851,13 @@ export async function repoGetDocumentDetail(documentId: string): Promise<GedDocu
  * INTERNE : remonte la clé de stockage pour le téléchargement.
  * Le retour de cette fonction ne doit JAMAIS être sérialisé vers un client.
  */
-export async function repoInternalGetVersionContentRef(versionId: string): Promise<{
+export async function repoInternalGetVersionContentRef(
+  versionId: string,
+  authorization: GedAuthorization
+): Promise<{
   version_id: string;
   document_id: string;
+  class_key: string;
   status: GedVersionStatus;
   original_name: string;
   mime_type: string;
@@ -651,17 +867,27 @@ export async function repoInternalGetVersionContentRef(versionId: string): Promi
   try {
     const res = await pool.query(
       `SELECT v.id::text AS version_id, v.document_id::text AS document_id, v.status::text AS status,
-              v.original_name, b.mime_type, b.sha256, b.storage_key
+              d.class_key, v.original_name, b.mime_type, b.sha256, b.storage_key
          FROM public.ged_document_versions v
+         JOIN public.ged_documents d ON d.id = v.document_id
          JOIN public.ged_blobs b ON b.id = v.blob_id
-        WHERE v.id = $1::uuid`,
-      [versionId]
+        WHERE v.id = $1::uuid
+          AND ${classCapabilityPredicate("d.class_key", "$2", "$3")}
+          AND ${documentScopePredicate("d.id", "d.class_key", "$2", "$4", "$5")}`,
+      [
+        versionId,
+        authorization.role_keys,
+        authorization.capability,
+        authorization.scope?.entity_type ?? null,
+        authorization.scope?.entity_id ?? null,
+      ]
     );
     const r = res.rows[0];
     if (!r) return null;
     return {
       version_id: String(r.version_id),
       document_id: String(r.document_id),
+      class_key: String(r.class_key),
       status: r.status as GedVersionStatus,
       original_name: String(r.original_name),
       mime_type: String(r.mime_type),
@@ -673,7 +899,9 @@ export async function repoInternalGetVersionContentRef(versionId: string): Promi
   }
 }
 
-export async function repoGetTree(): Promise<{ domain: string; class_key: string; class_label: string; documents_count: number }[]> {
+export async function repoGetTree(
+  authorization: GedAuthorization
+): Promise<{ domain: string; class_key: string; class_label: string; documents_count: number }[]> {
   try {
     const res = await pool.query(
       `SELECT c.domain, c.class_key, c.label AS class_label,
@@ -681,8 +909,10 @@ export async function repoGetTree(): Promise<{ domain: string; class_key: string
          FROM public.ged_document_classes c
          LEFT JOIN public.ged_documents d ON d.class_key = c.class_key AND d.archived_at IS NULL
         WHERE c.is_active
+          AND ${classCapabilityPredicate("c.class_key", "$1", "$2")}
         GROUP BY c.domain, c.class_key, c.label
-        ORDER BY c.domain, c.label`
+        ORDER BY c.domain, c.label`,
+      [authorization.role_keys, authorization.capability]
     );
     return res.rows.map((r) => ({
       domain: String(r.domain),
@@ -698,9 +928,9 @@ export async function repoGetTree(): Promise<{ domain: string; class_key: string
 export async function repoFindDocumentByBlobHash(
   tx: Pick<PoolClient, "query">,
   sha256: string
-): Promise<{ document_id: string; code: string } | null> {
+): Promise<boolean> {
   const res = await tx.query(
-    `SELECT d.id::text AS document_id, d.code
+    `SELECT 1
        FROM public.ged_blobs b
        JOIN public.ged_document_versions v ON v.blob_id = b.id
        JOIN public.ged_documents d ON d.id = v.document_id
@@ -708,6 +938,5 @@ export async function repoFindDocumentByBlobHash(
       LIMIT 1`,
     [sha256]
   );
-  const r = res.rows[0];
-  return r ? { document_id: String(r.document_id), code: String(r.code) } : null;
+  return Boolean(res.rows[0]);
 }

--- a/src/module/ged/services/ged.service.ts
+++ b/src/module/ged/services/ged.service.ts
@@ -12,16 +12,19 @@ import { HttpError } from "../../../utils/httpError";
 import { assertAcceptedFile } from "../domain/ged-content";
 import {
   assertDistinctApprover,
-  assertGedCapability,
+  assertGedCapabilityGranted,
   assertVersionTransition,
+  type GedCapability,
   type GedVersionStatus,
 } from "../domain/ged-policy";
 import {
   repoAddLink,
   repoAddVersion,
+  repoActorHasAnyCapability,
+  repoActorHasClassCapability,
   repoCreateDocumentWithVersion,
   repoFindDocumentByBlobHash,
-  repoGetClass,
+  repoGetClassForActor,
   repoGetDocumentDetail,
   repoGetTree,
   repoGetVersionForUpdate,
@@ -30,6 +33,7 @@ import {
   repoListAccessEvents,
   repoListClasses,
   repoListDocuments,
+  repoLinkTargetExists,
   repoLogAccess,
   repoObsoletePreviousApplicable,
   repoSetCurrentVersion,
@@ -38,6 +42,7 @@ import {
   withGedTransaction,
 } from "../repository/ged.repository";
 import type {
+  GedAccessScope,
   GedAccessEvent,
   GedDocumentClass,
   GedDocumentDetail,
@@ -47,7 +52,7 @@ import type {
 } from "../types/ged.types";
 import { checkVaultHealth, readBlob, removeBlobIfOrphan, writeBlob } from "./ged-vault.service";
 
-export type GedActor = { id: number; role: string | null };
+export type GedActor = { id: number; role_keys: string[] };
 
 type UploadedFile = { buffer?: Buffer; originalname?: string; mimetype?: string; size?: number };
 
@@ -58,8 +63,31 @@ type UploadedFile = { buffer?: Buffer; originalname?: string; mimetype?: string;
  * transaction encore ouverte, il ne verrait rien de ce qu'elle vient d'écrire.
  * Défaut constaté au premier dépôt réel le 2026-07-28.
  */
-async function readDetailOrFail(documentId: string): Promise<GedDocumentDetail> {
-  const detail = await repoGetDocumentDetail(documentId);
+function authorization(
+  actor: GedActor,
+  capability: GedCapability,
+  scope: GedAccessScope | null = null
+) {
+  return { role_keys: actor.role_keys, capability, scope };
+}
+
+async function assertAnyCapability(actor: GedActor, capability: GedCapability): Promise<void> {
+  assertGedCapabilityGranted(
+    await repoActorHasAnyCapability(actor.role_keys, capability),
+    capability
+  );
+}
+
+async function readDetailOrFail(
+  actor: GedActor,
+  documentId: string,
+  capability: GedCapability,
+  scope: GedAccessScope | null = null
+): Promise<GedDocumentDetail> {
+  const detail = await repoGetDocumentDetail(
+    documentId,
+    authorization(actor, capability, scope)
+  );
   if (!detail) {
     throw new HttpError(500, "GED_DOCUMENT_NOT_FOUND", "Document enregistré mais illisible.");
   }
@@ -71,27 +99,40 @@ async function readDetailOrFail(documentId: string): Promise<GedDocumentDetail> 
 /* -------------------------------------------------------------------------- */
 
 export async function listClasses(actor: GedActor): Promise<GedDocumentClass[]> {
-  assertGedCapability(actor.role, "read");
-  return repoListClasses();
+  await assertAnyCapability(actor, "read");
+  return repoListClasses(actor.role_keys, "read");
 }
 
 export async function listDocuments(actor: GedActor, filters: GedListFilters): Promise<GedListResult> {
-  assertGedCapability(actor.role, "read");
-  return repoListDocuments(filters);
+  await assertAnyCapability(actor, "read");
+  return repoListDocuments(filters, authorization(actor, "read"));
 }
 
-export async function getDocument(actor: GedActor, documentId: string): Promise<GedDocumentDetail> {
-  assertGedCapability(actor.role, "read");
-  const detail = await repoGetDocumentDetail(documentId);
+export async function getDocument(
+  actor: GedActor,
+  documentId: string,
+  scope: GedAccessScope | null = null
+): Promise<GedDocumentDetail> {
+  const detail = await repoGetDocumentDetail(
+    documentId,
+    authorization(actor, "read", scope)
+  );
   if (!detail) {
     throw new HttpError(404, "GED_DOCUMENT_NOT_FOUND", "Document introuvable.");
   }
+  await repoLogAccess(pool, {
+    document_id: documentId,
+    version_id: detail.current_version?.id ?? null,
+    event_type: "READ",
+    actor_id: actor.id,
+    details: { surface: "DOCUMENT_DETAIL" },
+  });
   return detail;
 }
 
 export async function getTree(actor: GedActor): Promise<GedTreeNode[]> {
-  assertGedCapability(actor.role, "read");
-  const rows = await repoGetTree();
+  await assertAnyCapability(actor, "read");
+  const rows = await repoGetTree(authorization(actor, "read"));
 
   // L'arborescence est CALCULÉE à partir du référentiel et des liens. Elle
   // n'existe nulle part sur le disque : renommer une classe ne déplace rien.
@@ -114,13 +155,23 @@ export async function getTree(actor: GedActor): Promise<GedTreeNode[]> {
   return [...byDomain.values()];
 }
 
-export async function listDocumentHistory(actor: GedActor, documentId: string): Promise<GedAccessEvent[]> {
-  assertGedCapability(actor.role, "read");
-  return repoListAccessEvents(documentId);
+export async function listDocumentHistory(
+  actor: GedActor,
+  documentId: string,
+  scope: GedAccessScope | null = null
+): Promise<GedAccessEvent[]> {
+  const detail = await repoGetDocumentDetail(
+    documentId,
+    authorization(actor, "read", scope)
+  );
+  if (!detail) {
+    throw new HttpError(404, "GED_DOCUMENT_NOT_FOUND", "Document introuvable.");
+  }
+  return repoListAccessEvents(documentId, authorization(actor, "read", scope));
 }
 
 export async function getVaultStatus(actor: GedActor) {
-  assertGedCapability(actor.role, "read");
+  await assertAnyCapability(actor, "read");
   return checkVaultHealth();
 }
 
@@ -141,11 +192,23 @@ export async function uploadDocument(
   input: UploadDocumentInput,
   file: UploadedFile | undefined
 ): Promise<GedDocumentDetail> {
-  assertGedCapability(actor.role, "upload");
-
-  const documentClass = await repoGetClass(input.class_key);
+  const documentClass = await repoGetClassForActor(
+    input.class_key,
+    authorization(actor, "upload")
+  );
   if (!documentClass) {
-    throw new HttpError(400, "GED_CLASS_UNKNOWN", `Classe documentaire inconnue : ${input.class_key}.`);
+    throw new HttpError(
+      403,
+      "GED_CAPABILITY_REQUIRED",
+      "Dépôt interdit pour cette classe documentaire."
+    );
+  }
+
+  if (
+    input.link &&
+    !(await repoLinkTargetExists(input.link.entity_type, input.link.entity_id))
+  ) {
+    throw new HttpError(404, "GED_LINK_TARGET_NOT_FOUND", "Parent documentaire introuvable.");
   }
 
   const accepted = assertAcceptedFile(file, {
@@ -167,7 +230,7 @@ export async function uploadDocument(
         throw new HttpError(
           409,
           "GED_FILE_DUPLICATE",
-          `Ce fichier est déjà présent dans la GED sous le code ${duplicate.code}.`
+          "Ce fichier est déjà présent dans la GED."
         );
       }
 
@@ -224,18 +287,20 @@ export async function uploadDocument(
 
   // Relecture APRÈS le commit : `repoGetDocumentDetail` ouvre sa propre
   // connexion et ne verrait rien d'une transaction encore ouverte.
-  return readDetailOrFail(documentId);
+  return readDetailOrFail(actor, documentId, "upload", input.link ?? null);
 }
 
 export async function uploadNewVersion(
   actor: GedActor,
   documentId: string,
   input: { change_reason: string },
-  file: UploadedFile | undefined
+  file: UploadedFile | undefined,
+  scope: GedAccessScope | null = null
 ): Promise<GedDocumentDetail> {
-  assertGedCapability(actor.role, "upload");
-
-  const existing = await repoGetDocumentDetail(documentId);
+  const existing = await repoGetDocumentDetail(
+    documentId,
+    authorization(actor, "upload", scope)
+  );
   if (!existing) throw new HttpError(404, "GED_DOCUMENT_NOT_FOUND", "Document introuvable.");
   if (existing.archived_at) {
     throw new HttpError(409, "GED_DOCUMENT_ARCHIVED", "Un document archivé ne reçoit plus de version.");
@@ -248,7 +313,10 @@ export async function uploadNewVersion(
     );
   }
 
-  const documentClass = await repoGetClass(existing.class_key);
+  const documentClass = await repoGetClassForActor(
+    existing.class_key,
+    authorization(actor, "upload")
+  );
   if (!documentClass) {
     throw new HttpError(400, "GED_CLASS_UNKNOWN", "Classe documentaire inconnue.");
   }
@@ -295,7 +363,7 @@ export async function uploadNewVersion(
   }
 
   // Relecture APRÈS le commit, pour la même raison que dans `uploadDocument`.
-  return readDetailOrFail(documentId);
+  return readDetailOrFail(actor, documentId, "upload", scope);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -306,10 +374,19 @@ async function transitionVersion(
   actor: GedActor,
   versionId: string,
   target: GedVersionStatus,
-  options: { comment?: string | null; requireDistinctApprover?: boolean }
+  capability: GedCapability,
+  options: {
+    comment?: string | null;
+    requireDistinctApprover?: boolean;
+    scope?: GedAccessScope | null;
+  }
 ): Promise<GedDocumentDetail> {
   const documentId = await withGedTransaction(async (tx) => {
-    const version = await repoGetVersionForUpdate(tx, versionId);
+    const version = await repoGetVersionForUpdate(
+      tx,
+      versionId,
+      authorization(actor, capability, options.scope ?? null)
+    );
     if (!version) throw new HttpError(404, "GED_VERSION_NOT_FOUND", "Version introuvable.");
 
     assertVersionTransition(version.status, target);
@@ -356,27 +433,49 @@ async function transitionVersion(
   });
 
   // Relecture APRÈS le commit, pour la même raison que dans `uploadDocument`.
-  return readDetailOrFail(documentId);
+  return readDetailOrFail(actor, documentId, capability, options.scope ?? null);
 }
 
-export async function submitVersion(actor: GedActor, versionId: string, comment: string | null) {
-  assertGedCapability(actor.role, "submit");
-  return transitionVersion(actor, versionId, "EN_REVUE", { comment });
+export async function submitVersion(
+  actor: GedActor,
+  versionId: string,
+  comment: string | null,
+  scope: GedAccessScope | null = null
+) {
+  return transitionVersion(actor, versionId, "EN_REVUE", "submit", { comment, scope });
 }
 
-export async function approveVersion(actor: GedActor, versionId: string, comment: string | null) {
-  assertGedCapability(actor.role, "approve");
-  return transitionVersion(actor, versionId, "APPROUVE", { comment, requireDistinctApprover: true });
+export async function approveVersion(
+  actor: GedActor,
+  versionId: string,
+  comment: string | null,
+  scope: GedAccessScope | null = null
+) {
+  return transitionVersion(actor, versionId, "APPROUVE", "approve", {
+    comment,
+    requireDistinctApprover: true,
+    scope,
+  });
 }
 
-export async function publishVersion(actor: GedActor, versionId: string) {
-  assertGedCapability(actor.role, "publish");
-  return transitionVersion(actor, versionId, "APPLICABLE", {});
+export async function publishVersion(
+  actor: GedActor,
+  versionId: string,
+  scope: GedAccessScope | null = null
+) {
+  return transitionVersion(actor, versionId, "APPLICABLE", "publish", { scope });
 }
 
-export async function obsoleteVersion(actor: GedActor, versionId: string, reason: string | null) {
-  assertGedCapability(actor.role, "obsolete");
-  return transitionVersion(actor, versionId, "OBSOLETE", { comment: reason });
+export async function obsoleteVersion(
+  actor: GedActor,
+  versionId: string,
+  reason: string | null,
+  scope: GedAccessScope | null = null
+) {
+  return transitionVersion(actor, versionId, "OBSOLETE", "obsolete", {
+    comment: reason,
+    scope,
+  });
 }
 
 /* -------------------------------------------------------------------------- */
@@ -390,16 +489,28 @@ export type DownloadResult = {
   sha256: string;
 };
 
-export async function downloadVersion(actor: GedActor, versionId: string): Promise<DownloadResult> {
-  assertGedCapability(actor.role, "download");
-
-  const ref = await repoInternalGetVersionContentRef(versionId);
+export async function downloadVersion(
+  actor: GedActor,
+  versionId: string,
+  scope: GedAccessScope | null = null
+): Promise<DownloadResult> {
+  const ref = await repoInternalGetVersionContentRef(
+    versionId,
+    authorization(actor, "download", scope)
+  );
   if (!ref) throw new HttpError(404, "GED_VERSION_NOT_FOUND", "Version introuvable.");
 
   // Un brouillon n'est jamais servi à qui n'a pas le droit de le voir : il n'est
   // pas encore un document opposable.
   if (ref.status === "BROUILLON") {
-    assertGedCapability(actor.role, "upload");
+    const canUpload = await repoActorHasClassCapability(
+      ref.class_key,
+      actor.role_keys,
+      "upload"
+    );
+    if (!canUpload) {
+      throw new HttpError(404, "GED_VERSION_NOT_FOUND", "Version introuvable.");
+    }
   }
 
   let buffer: Buffer;
@@ -421,14 +532,15 @@ export async function downloadVersion(actor: GedActor, versionId: string): Promi
     throw err;
   }
 
-  // Le journal ne doit jamais faire échouer un téléchargement légitime.
+  // Un téléchargement non audité n'est pas un téléchargement légitime : on
+  // écrit la trace avant d'envoyer le contenu au contrôleur.
   await repoLogAccess(pool, {
     document_id: ref.document_id,
     version_id: ref.version_id,
     event_type: "DOWNLOAD",
     actor_id: actor.id,
     details: { size_bytes: buffer.byteLength },
-  }).catch(() => undefined);
+  });
 
   return {
     buffer,

--- a/src/module/ged/types/ged.types.ts
+++ b/src/module/ged/types/ged.types.ts
@@ -54,6 +54,11 @@ export type GedDocumentLink = {
   created_at: string;
 };
 
+export type GedAccessScope = {
+  entity_type: string;
+  entity_id: string;
+};
+
 export type GedRetentionHold = {
   id: string;
   hold_type: "QUALITE" | "LEGAL" | "RETENTION";
@@ -77,6 +82,7 @@ export type GedDocumentSummary = {
   created_at: string;
   updated_at: string;
   archived_at: string | null;
+  access_scope: GedAccessScope | null;
 };
 
 export type GedDocumentDetail = GedDocumentSummary & {

--- a/src/module/ged/validators/ged.validators.ts
+++ b/src/module/ged/validators/ged.validators.ts
@@ -1,5 +1,3 @@
-// GED centrale CERP (ADR-0037) — validation d'entrée.
-
 import { z } from "zod";
 
 import { GED_VERSION_STATUSES } from "../domain/ged-policy";
@@ -7,40 +5,71 @@ import { GED_VERSION_STATUSES } from "../domain/ged-policy";
 const trimmed = (min: number, max: number) =>
   z.string().transform((v) => v.trim()).pipe(z.string().min(min).max(max));
 
-export const uploadDocumentBodySchema = z.object({
-  class_key: trimmed(1, 64),
-  title: trimmed(2, 200),
-  description: z.string().trim().max(2000).optional().nullable(),
-  change_reason: z.string().trim().max(500).optional().nullable(),
-  entity_type: z.string().trim().max(64).optional().nullable(),
-  entity_id: z.string().trim().max(128).optional().nullable(),
-  link_role: z.string().trim().max(64).optional().nullable(),
-});
+export const GED_LINK_ENTITY_TYPES = ["PIECE_TECHNIQUE_VERSION"] as const;
+
+const accessScopeFields = {
+  entity_type: z.enum(GED_LINK_ENTITY_TYPES).optional().nullable(),
+  entity_id: z.string().uuid("Identifiant de parent invalide.").optional().nullable(),
+};
+
+function requireCompleteScope(
+  value: { entity_type?: string | null; entity_id?: string | null },
+  ctx: z.RefinementCtx
+) {
+  if (Boolean(value.entity_type) !== Boolean(value.entity_id)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Le type et l'identifiant du parent doivent être fournis ensemble.",
+      path: value.entity_type ? ["entity_id"] : ["entity_type"],
+    });
+  }
+}
+
+export const uploadDocumentBodySchema = z
+  .object({
+    class_key: trimmed(1, 64),
+    title: trimmed(2, 200),
+    description: z.string().trim().max(2000).optional().nullable(),
+    change_reason: z.string().trim().max(500).optional().nullable(),
+    ...accessScopeFields,
+    link_role: z.string().trim().max(64).optional().nullable(),
+  })
+  .superRefine(requireCompleteScope);
 
 export type UploadDocumentBody = z.infer<typeof uploadDocumentBodySchema>;
 
-export const newVersionBodySchema = z.object({
-  // Une nouvelle version exige un motif : « pourquoi » fait partie du document.
-  change_reason: trimmed(3, 500),
-});
+export const newVersionBodySchema = z
+  .object({
+    change_reason: trimmed(3, 500),
+    ...accessScopeFields,
+  })
+  .superRefine(requireCompleteScope);
 
-export const transitionBodySchema = z.object({
-  comment: z.string().trim().max(1000).optional().nullable(),
-});
+export const transitionBodySchema = z
+  .object({
+    comment: z.string().trim().max(1000).optional().nullable(),
+    ...accessScopeFields,
+  })
+  .superRefine(requireCompleteScope);
 
-export const listQuerySchema = z.object({
-  q: z.string().trim().max(200).optional().nullable(),
-  class_key: z.string().trim().max(64).optional().nullable(),
-  domain: z.string().trim().max(64).optional().nullable(),
-  status: z.enum(GED_VERSION_STATUSES).optional().nullable(),
-  entity_type: z.string().trim().max(64).optional().nullable(),
-  entity_id: z.string().trim().max(128).optional().nullable(),
-  include_archived: z
-    .union([z.boolean(), z.string()])
-    .optional()
-    .transform((v) => v === true || v === "true" || v === "1"),
-  page: z.coerce.number().int().min(1).max(10000).optional().default(1),
-  page_size: z.coerce.number().int().min(1).max(100).optional().default(25),
-});
+export const listQuerySchema = z
+  .object({
+    q: z.string().trim().max(200).optional().nullable(),
+    class_key: z.string().trim().max(64).optional().nullable(),
+    domain: z.string().trim().max(64).optional().nullable(),
+    status: z.enum(GED_VERSION_STATUSES).optional().nullable(),
+    ...accessScopeFields,
+    include_archived: z
+      .union([z.boolean(), z.string()])
+      .optional()
+      .transform((v) => v === true || v === "true" || v === "1"),
+    page: z.coerce.number().int().min(1).max(10000).optional().default(1),
+    page_size: z.coerce.number().int().min(1).max(100).optional().default(25),
+  })
+  .superRefine(requireCompleteScope);
+
+export const accessScopeQuerySchema = z
+  .object(accessScopeFields)
+  .superRefine(requireCompleteScope);
 
 export const uuidParamSchema = z.string().uuid("Identifiant invalide.");


### PR DESCRIPTION
Closes #236

## Résultat

- remplace le RBAC GED par sous-chaîne par des capacités explicites par classe et rôle réellement attribué ;
- applique le refus par défaut et sépare lecture, dépôt, validation, publication et téléchargement ;
- impose le couple parent/cible `PIECE_TECHNIQUE_VERSION` sur les accès directs liés ;
- renvoie `404` pour un identifiant deviné, un parent absent ou un autre périmètre ;
- vérifie l’existence du parent avant toute écriture ;
- rend les traces `READ` et `DOWNLOAD` obligatoires avant de répondre ;
- ne sérialise aucun chemin physique du coffre ;
- ajoute le patch SQL additif `20260729_ged_scope_security_236.sql` avec preflight, vérification et rollback.

## Validation

- build TypeScript : vert ;
- GED : 45 tests verts ;
- tests des changements arrivés sur `dev` pendant le travail : verts ;
- suite backend complète : 3 209 tests verts, 3 échecs préexistants et hors périmètre dans `pieces-techniques.routes.test.ts` (aucun fichier Pièces techniques modifié par cette PR).

## Déploiement

Le patch n’a été appliqué à aucune base. Ordre requis après validation humaine : preflight puis patch puis verify sur `cerp_test`; production et recette d’envoi authentifié restent des étapes séparées soumises à validation humaine explicite.

## Contamination

Audit des chemins et du diff : uniquement GED/tests/patches GED. Aucun changement de la commande #376 n’est présent.

## Summary by Sourcery

Enforce class- and role-based GED permissions with default-deny, scoped parent access, and stricter auditing and validation, backed by a new SQL capabilities table.

New Features:
- Introduce explicit per-class GED capabilities resolved from user role assignments instead of substring-based RBAC.
- Add support for document access scopes tied to parent entities (e.g. PIECE_TECHNIQUE_VERSION) across listing, detail, history, transitions, and downloads.
- Expose authenticated, scope-aware GED download and history endpoints that log READ and DOWNLOAD events before responding.

Bug Fixes:
- Prevent access to GED documents and blobs via guessed identifiers or mismatched parent scopes, returning 404 instead of leaking existence.
- Ensure GED responds with GED_NOT_INSTALLED when core or security tables are missing, and GED_VAULT_UNAVAILABLE when the vault is unreachable.
- Block uploads of executable content disguised as PDFs before any write, and require existing parents before linking documents.

Enhancements:
- Refine GED role handling to use normalized assigned roles and database-validated capabilities, removing substring matching logic.
- Augment GED document summaries with access scope metadata and enforce capability checks for class listing, trees, histories, and transitions.
- Tighten download semantics by forbidding unaudited downloads and hiding drafts from actors without upload rights, while preserving path secrecy.

Build:
- Add additive SQL patch 20260729_ged_scope_security_236.sql with preflight, verification, and rollback scripts to provision and validate the new ged_class_capabilities table.

Tests:
- Extend GED route and domain tests to cover authentication requirements, per-class RBAC, parent/child scope enforcement, vault availability, content validation, and audit logging behavior.