### PR TITLE
release: ouvrir la vente en commande client a toutes les categories d'article (#395)

### DIFF
--- a/src/__tests__/article-categories-commande-selectable-395.test.ts
+++ b/src/__tests__/article-categories-commande-selectable-395.test.ts
@@ -1,0 +1,65 @@
+// #395 — Référentiel des catégories d'article : ce qui est VENDABLE en commande client.
+//
+// Ce référentiel est un contrat, pas une préférence d'affichage : le frontend l'utilise à la
+// fois pour proposer les catégories à la création depuis une commande et pour filtrer la
+// recherche d'article des lignes. Un `false` posé ici ferme les deux portes d'un coup.
+import { beforeAll, describe, expect, it } from "vitest";
+
+import {
+  commandeClientSelectableCategoryCodes,
+  repoListArticleCategories,
+} from "../module/stock/repository/stock.repository";
+import type { StockArticleCategoryOption } from "../module/stock/types/stock.types";
+
+describe("#395 — catégories vendables en commande client", () => {
+  let options: StockArticleCategoryOption[] = [];
+
+  beforeAll(async () => {
+    options = await repoListArticleCategories();
+  });
+
+  it("expose les six catégories métier du référentiel", () => {
+    expect(options.map((option) => option.code).sort()).toEqual(
+      [
+        "achat_revente",
+        "achat_transforme",
+        "matiere_premiere",
+        "piece_finie_fabriquee",
+        "sous_traitance",
+        "traitement_surface",
+      ].sort()
+    );
+  });
+
+  it("rend TOUTES les catégories vendables (élargissement #395)", () => {
+    // Régression : seule `piece_finie_fabriquee` l'était, ce qui rendait la création d'article
+    // depuis une commande inutilisable pour un achat, une sous-traitance ou un traitement.
+    const notSellable = options.filter((option) => !option.commande_client_selectable);
+    expect(notSellable.map((option) => option.code)).toEqual([]);
+  });
+
+  it("n'exige un dossier technique QUE pour une pièce finie fabriquée", () => {
+    // L'élargissement de la vente ne doit pas propager l'obligation de dossier technique :
+    // c'est lui qui produit les OF, et seule une pièce fabriquée en a un.
+    const requiring = options.filter((option) => option.piece_technique_required).map((option) => option.code);
+    expect(requiring).toEqual(["piece_finie_fabriquee"]);
+  });
+
+  it("dérive la liste des codes vendables depuis le référentiel, sans liste parallèle", () => {
+    const derived = commandeClientSelectableCategoryCodes();
+    const expected = options.filter((option) => option.commande_client_selectable).map((option) => option.code);
+    expect(derived).toEqual(expected);
+    expect(derived.length).toBeGreaterThan(0);
+  });
+
+  it("conserve un segment de code et un comportement stock pour chaque catégorie", () => {
+    for (const option of options) {
+      expect(option.code_segment, `segment manquant pour ${option.code}`).toMatch(/^[A-Z]{2,5}$/);
+      expect(typeof option.stock_managed_default, `stock_managed_default pour ${option.code}`).toBe("boolean");
+    }
+    // Les services ne sont pas inventoriés : le référentiel doit continuer à le dire.
+    const byCode = new Map(options.map((option) => [option.code, option]));
+    expect(byCode.get("traitement_surface")?.stock_managed_default).toBe(false);
+    expect(byCode.get("sous_traitance")?.stock_managed_default).toBe(false);
+  });
+});

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -255,6 +255,24 @@ const ARTICLE_PRIMARY_CATEGORY_OPTIONS: Array<{ code: ArticleCategory }> = [
   { code: "achat" },
 ];
 
+/**
+ * Référentiel des catégories métier d'article.
+ *
+ * `commande_client_selectable` (#395) — élargi à TOUTES les catégories.
+ *
+ * Il ne valait `true` que pour `piece_finie_fabriquee`, ce qui rendait la création d'article
+ * depuis une commande client inutilisable pour tout le reste : un composant revendu, un
+ * achat transformé, une sous-traitance refacturée, un traitement de surface facturé à la
+ * ligne ou une matière cédée au client sont tous des choses que CRP vend réellement, et
+ * toutes finissaient par un contournement (créer l'article ailleurs, puis revenir).
+ *
+ * Ce drapeau reste le SEUL levier pour restreindre à nouveau : il pilote à la fois les
+ * catégories proposées à la création depuis une commande et le filtre de recherche des
+ * lignes de commande. Le repasser à `false` suffit, sans toucher au frontend.
+ *
+ * `piece_technique_required` n'est PAS élargi : seule une pièce finie fabriquée exige un
+ * dossier technique — c'est lui qui produit les OF.
+ */
 const ARTICLE_CATEGORY_OPTIONS: StockArticleCategoryOption[] = [
   {
     code: "piece_finie_fabriquee",
@@ -270,7 +288,7 @@ const ARTICLE_CATEGORY_OPTIONS: StockArticleCategoryOption[] = [
     code_segment: "MP",
     stock_managed_default: true,
     piece_technique_required: false,
-    commande_client_selectable: false,
+    commande_client_selectable: true,
   },
   {
     code: "traitement_surface",
@@ -278,7 +296,7 @@ const ARTICLE_CATEGORY_OPTIONS: StockArticleCategoryOption[] = [
     code_segment: "TRT",
     stock_managed_default: false,
     piece_technique_required: false,
-    commande_client_selectable: false,
+    commande_client_selectable: true,
   },
   {
     code: "achat_revente",
@@ -286,7 +304,7 @@ const ARTICLE_CATEGORY_OPTIONS: StockArticleCategoryOption[] = [
     code_segment: "ACH",
     stock_managed_default: true,
     piece_technique_required: false,
-    commande_client_selectable: false,
+    commande_client_selectable: true,
   },
   {
     code: "achat_transforme",
@@ -294,7 +312,7 @@ const ARTICLE_CATEGORY_OPTIONS: StockArticleCategoryOption[] = [
     code_segment: "AHT",
     stock_managed_default: true,
     piece_technique_required: false,
-    commande_client_selectable: false,
+    commande_client_selectable: true,
   },
   {
     code: "sous_traitance",
@@ -302,9 +320,14 @@ const ARTICLE_CATEGORY_OPTIONS: StockArticleCategoryOption[] = [
     code_segment: "STA",
     stock_managed_default: false,
     piece_technique_required: false,
-    commande_client_selectable: false,
+    commande_client_selectable: true,
   },
 ];
+
+/** Codes métier vendables en commande client, dérivés du référentiel ci-dessus. */
+export function commandeClientSelectableCategoryCodes(): string[] {
+  return ARTICLE_CATEGORY_OPTIONS.filter((option) => option.commande_client_selectable).map((option) => option.code);
+}
 
 const BUSINESS_TO_PRIMARY_CATEGORY: Record<ArticleBusinessCategory, ArticleCategory> = {
   piece_finie_fabriquee: "fabrique",
@@ -2542,6 +2565,34 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
   if (filters.is_active !== undefined) where.push(`a.is_active = ${push(filters.is_active)}`);
   if (filters.lot_tracking !== undefined) where.push(`a.lot_tracking = ${push(filters.lot_tracking)}`);
   if (filters.stock_managed !== undefined) where.push(`a.stock_managed = ${push(filters.stock_managed)}`);
+
+  /**
+   * #395 — Filtre « vendable en commande client », dérivé du référentiel.
+   *
+   * Un article est retenu si sa catégorie primaire OU l'une de ses catégories métier liées est
+   * vendable. Le jeu de codes vient de `ARTICLE_CATEGORY_OPTIONS` : élargir ou restreindre la
+   * vente se fait à cet endroit unique, et la recherche de ligne suit sans redéploiement du
+   * frontend.
+   */
+  if (filters.commande_client_selectable !== undefined) {
+    const sellable = commandeClientSelectableCategoryCodes();
+    if (sellable.length === 0) {
+      // Référentiel entièrement fermé : ne rien proposer plutôt que tout proposer.
+      where.push(filters.commande_client_selectable ? "FALSE" : "TRUE");
+    } else {
+      const p = push(sellable);
+      const predicate = `(
+        ${normalizedBusinessCategorySql("a.article_category")} = ANY(${p}::text[])
+        OR EXISTS (
+          SELECT 1
+          FROM public.article_category_link acls
+          WHERE acls.article_id = a.id
+            AND acls.category_code = ANY(${p}::text[])
+        )
+      )`;
+      where.push(filters.commande_client_selectable ? predicate : `NOT ${predicate}`);
+    }
+  }
 
   const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
   const orderBy = articleSortColumn(filters.sortBy);

--- a/src/module/stock/validators/stock.validators.ts
+++ b/src/module/stock/validators/stock.validators.ts
@@ -89,6 +89,19 @@ export const listArticlesQuerySchema = z.object({
   is_active: z.preprocess(parseBoolean, z.boolean().optional()),
   lot_tracking: z.preprocess(parseBoolean, z.boolean().optional()),
   stock_managed: z.preprocess(parseBoolean, z.boolean().optional()),
+  /**
+   * #395 — Ne renvoyer que les articles VENDABLES en commande client.
+   *
+   * `article_category` n'accepte qu'UNE catégorie : il ne peut donc pas exprimer « les cinq
+   * catégories vendables ». Ce drapeau délègue la question au référentiel
+   * (`commande_client_selectable`), qui reste ainsi le seul endroit à modifier pour élargir
+   * ou restreindre — écran de création ET recherche de ligne suivent ensemble.
+   *
+   * ATTENTION : ce schéma est `.strict()`. Un frontend qui envoie ce paramètre à un backend
+   * qui ne le connaît pas encore reçoit un 400, pas un filtre ignoré. Les deux dépôts se
+   * déploient donc ensemble, backend d'abord.
+   */
+  commande_client_selectable: z.preprocess(parseBoolean, z.boolean().optional()),
   page: z.coerce.number().int().min(1).optional().default(1),
   pageSize: z.coerce.number().int().min(1).max(200).optional().default(20),
   sortBy: z.enum(["updated_at", "created_at", "code", "designation"]).optional().default("updated_at"),


### PR DESCRIPTION
Promotion de `dev` vers `main` pour #395.

## Contenu — exactement 3 fichiers

- `src/module/stock/repository/stock.repository.ts` — les six categories metier passent a `commande_client_selectable: true` ; nouveau filtre de liste derive du referentiel
- `src/module/stock/validators/stock.validators.ts` — parametre `commande_client_selectable` sur `GET /stock/articles`
- `src/__tests__/article-categories-commande-selectable-395.test.ts` — 5 tests

`piece_technique_required` reste reserve a `piece_finie_fabriquee`.

## Migration

**Aucune.** Le referentiel est une constante applicative, pas une table. Rien a appliquer sur `cerp_test` ni `cerp_prod`.

## Deploiement

Ce backend doit etre deploye **avant ou avec** `crp-systems-web` #400. `listArticlesQuerySchema` est `.strict()` : un frontend seul recevrait un 400 sur le nouveau parametre.

## Tests

146 fichiers / 3 347 tests, **3 344 verts**.

Les 3 echecs (`pieces-techniques.routes.test.ts`, approbation d'indice technique / RBAC) **preexistent sur `main` et `dev`** : verifie sur un worktree propre a `aae7f43` sans aucune modification. Ils ne viennent pas de cette release et sont deja presents en production aujourd'hui.

Refs BigFootLime/crp-systems-web#395

## Summary by Sourcery

Open client-order article creation and search to all business categories while keeping technical dossier requirements restricted to finished manufactured parts.

New Features:
- Add a query flag on article listing to filter articles that are sellable in client orders based on the central category reference.

Enhancements:
- Mark all business article categories as selectable for client orders in the stock category reference and derive sellable category codes from this reference to avoid parallel lists.

Tests:
- Add tests covering the expanded set of client-order-sellable categories, the technical dossier requirement constraint, and the derivation and integrity of the category reference.