### PR TITLE
Correction Article : classification métier autoritaire

### DIFF
--- a/docs/articles-master-data-164.md
+++ b/docs/articles-master-data-164.md
@@ -98,3 +98,17 @@ Validation du 29 juillet 2026 sur `cerp_test` :
 
 La migration de production reste une décision humaine distincte. Le patch n'a
 pas été appliqué à `cerp_prod`.
+
+## Classification primaire et validations conditionnelles (#401)
+
+`articles.article_category` reste la classification primaire explicite et
+autoritaire. `article_categories` décrit les usages métier secondaires mais ne
+peut plus reclasser silencieusement un Article selon un ordre de priorité.
+
+- une PF exige une PT et utilise la famille technique interne `PT` ;
+- une PT est interdite sur les catégories achat, matière et traitement ;
+- `article_matiere` est accepté uniquement pour une matière ;
+- un PATCH matière qui ne renvoie pas `article_matiere` conserve les détails
+  existants au lieu de les effacer ;
+- les contrôles sont répétés côté serveur : le masquage d’un champ frontend ne
+  constitue jamais une validation métier.

--- a/src/__tests__/article-category-primary-401.test.ts
+++ b/src/__tests__/article-category-primary-401.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("pg", () => ({
+  Pool: class {
+    on = vi.fn();
+    query = vi.fn();
+    connect = vi.fn();
+  },
+}));
+
+vi.mock("dotenv", () => ({ default: { config: vi.fn() } }));
+
+import {
+  normalizeArticleCategorySelection,
+  syncArticleSubtypeDetails,
+} from "../module/stock/repository/stock.repository";
+import { createArticleSchema, updateArticleSchema } from "../module/stock/validators/stock.validators";
+
+const PT_ID = "11111111-1111-4111-8111-111111111111";
+
+const validCases = [
+  {
+    label: "PF fabriquée",
+    body: {
+      designation: "Pièce fabriquée",
+      article_category: "fabrique" as const,
+      article_categories: ["piece_finie_fabriquee" as const],
+      family_code: "PT",
+      piece_technique_id: PT_ID,
+    },
+  },
+  {
+    label: "matière première",
+    body: {
+      designation: "Rond acier",
+      article_category: "matiere" as const,
+      article_categories: ["matiere_premiere" as const],
+      family_code: "RO",
+      article_matiere: {},
+    },
+  },
+  {
+    label: "traitement de surface",
+    body: {
+      designation: "Anodisation noire",
+      article_category: "traitement" as const,
+      article_categories: ["traitement_surface" as const],
+      family_code: "TRT",
+    },
+  },
+  {
+    label: "achat-revente",
+    body: {
+      designation: "Vis standard",
+      article_category: "achat" as const,
+      article_categories: ["achat_revente" as const],
+      family_code: "ACH",
+    },
+  },
+  {
+    label: "achat-transformé",
+    body: {
+      designation: "Brut transformé",
+      article_category: "achat" as const,
+      article_categories: ["achat_transforme" as const],
+      family_code: "ACH",
+    },
+  },
+  {
+    label: "sous-traitance",
+    body: {
+      designation: "Usinage sous-traité",
+      article_category: "achat" as const,
+      article_categories: ["sous_traitance" as const],
+      family_code: "ACH",
+    },
+  },
+];
+
+describe("#401 catégorie primaire Article", () => {
+  it.each(validCases)("accepte la création $label sans champ d'une autre catégorie", ({ body }) => {
+    expect(createArticleSchema.safeParse({ body }).success).toBe(true);
+  });
+
+  it("conserve la catégorie primaire explicite malgré des usages secondaires contradictoires", () => {
+    const selection = normalizeArticleCategorySelection("achat", [
+      "piece_finie_fabriquee",
+      "matiere_premiere",
+      "sous_traitance",
+    ]);
+
+    expect(selection.article_category).toBe("achat");
+    expect(selection.article_categories).toEqual([
+      "achat_revente",
+      "piece_finie_fabriquee",
+      "matiere_premiere",
+      "sous_traitance",
+    ]);
+  });
+
+  it("place le code métier associé à la catégorie primaire en première position", () => {
+    expect(normalizeArticleCategorySelection("traitement", ["achat_revente"]).article_categories).toEqual([
+      "traitement_surface",
+      "achat_revente",
+    ]);
+    expect(normalizeArticleCategorySelection("matiere", ["achat_transforme"]).article_categories).toEqual([
+      "matiere_premiere",
+      "achat_transforme",
+    ]);
+  });
+
+  it("interdit une PT hors PF et exige une PT pour une PF", () => {
+    expect(createArticleSchema.safeParse({
+      body: { ...validCases[2].body, piece_technique_id: PT_ID },
+    }).success).toBe(false);
+    expect(createArticleSchema.safeParse({
+      body: { designation: "PF incomplète", article_category: "fabrique", family_code: "PT" },
+    }).success).toBe(false);
+  });
+
+  it("interdit les détails matière hors matière, y compris lors d'une mise à jour explicitement catégorisée", () => {
+    expect(createArticleSchema.safeParse({
+      body: { ...validCases[3].body, article_matiere: {} },
+    }).success).toBe(false);
+    expect(updateArticleSchema.safeParse({
+      body: { expected_row_version: 1, article_category: "achat", article_matiere: {} },
+    }).success).toBe(false);
+  });
+
+  it("autorise un PATCH matière sans article_matiere afin de préserver les détails existants", () => {
+    expect(updateArticleSchema.safeParse({
+      body: { expected_row_version: 1, designation: "Rond acier corrigé" },
+    }).success).toBe(true);
+  });
+
+  it("préserve les détails matière lorsque le PATCH ne fournit pas article_matiere", async () => {
+    const queries: string[] = [];
+    const client = {
+      query: async (sql: string) => {
+        queries.push(sql);
+        if (sql.includes("information_schema.columns")) return { rows: [{ present: true }] };
+        return { rows: [] };
+      },
+    } as Parameters<typeof syncArticleSubtypeDetails>[0];
+
+    await syncArticleSubtypeDetails(client, {
+      article_id: PT_ID,
+      category: "matiere",
+      family_code: "RO",
+      piece_technique_id: null,
+    });
+
+    expect(queries.some((sql) => sql.includes("DELETE FROM public.articles_matiere"))).toBe(false);
+    const materialUpsert = queries.find((sql) => sql.includes("INSERT INTO public.articles_matiere"));
+    const materialUpsertText = materialUpsert ?? "";
+    expect(materialUpsertText).toContain("SET family_code = EXCLUDED.family_code");
+    expect(materialUpsertText).not.toContain("longueur_mm = EXCLUDED.longueur_mm");
+  });
+});

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -329,15 +329,6 @@ export function commandeClientSelectableCategoryCodes(): string[] {
   return ARTICLE_CATEGORY_OPTIONS.filter((option) => option.commande_client_selectable).map((option) => option.code);
 }
 
-const BUSINESS_TO_PRIMARY_CATEGORY: Record<ArticleBusinessCategory, ArticleCategory> = {
-  piece_finie_fabriquee: "fabrique",
-  matiere_premiere: "matiere",
-  traitement_surface: "traitement",
-  achat_revente: "achat",
-  achat_transforme: "achat",
-  sous_traitance: "achat",
-};
-
 type UploadedDocument = Express.Multer.File;
 
 function isPgUniqueViolation(err: unknown): boolean {
@@ -489,7 +480,7 @@ function normalizeArticleWorkflowStatus(value: string | null | undefined): "EN_D
   return normalized === "EN_DEVIS" ? "EN_DEVIS" : "VALIDE";
 }
 
-function normalizeArticleCategories(
+export function normalizeArticleCategories(
   requested: string[] | null | undefined,
   primaryCategory: ArticleCategory
 ): ArticleBusinessCategory[] {
@@ -515,11 +506,18 @@ function normalizeArticleCategories(
   return out;
 }
 
-function derivePrimaryCategoryFromBusinessCategories(categories: ArticleBusinessCategory[]): ArticleCategory {
-  if (categories.some((value) => BUSINESS_TO_PRIMARY_CATEGORY[value] === "fabrique")) return "fabrique";
-  if (categories.some((value) => BUSINESS_TO_PRIMARY_CATEGORY[value] === "matiere")) return "matiere";
-  if (categories.some((value) => BUSINESS_TO_PRIMARY_CATEGORY[value] === "traitement")) return "traitement";
-  return "achat";
+/**
+ * Keeps the primary category explicit and deterministic while allowing the
+ * category link table to hold secondary business uses.
+ */
+export function normalizeArticleCategorySelection(
+  primaryCategory: ArticleCategory,
+  requestedCategories: string[] | null | undefined
+): { article_category: ArticleCategory; article_categories: ArticleBusinessCategory[] } {
+  return {
+    article_category: primaryCategory,
+    article_categories: normalizeArticleCategories(requestedCategories, primaryCategory),
+  };
 }
 
 function expectedFabricatedArticleCodeFromPlan(planReference: string, planIndex: number): string {
@@ -642,8 +640,16 @@ async function normalizeArticleState(args: {
     return toBusinessArticleCategory(args.article_category, "achat");
   })();
   const requestedPrimaryCategory = toBusinessArticleCategory(args.article_category, categoryFromType);
-  const article_categories = normalizeArticleCategories(args.article_categories, requestedPrimaryCategory);
-  const article_category = derivePrimaryCategoryFromBusinessCategories(article_categories);
+  const categorySelection = normalizeArticleCategorySelection(requestedPrimaryCategory, args.article_categories);
+  /**
+   * `article_category` is the authoritative primary classification. Business
+   * categories are secondary uses and must never silently reclassify an
+   * Article just because one of them maps to another primary category.
+   *
+   * normalizeArticleCategories keeps the matching business category at index
+   * zero, which syncArticleCategories persists with is_primary = true.
+   */
+  const { article_category, article_categories } = categorySelection;
   const article_type = inferArticleType(article_category);
   const piece_technique_id = article_category === "fabrique" ? args.piece_technique_id : null;
   const requestedFamilyCode = normalizeFamilyCode(args.family_code, defaultFamilyCodeForCategory(article_category));
@@ -1324,7 +1330,7 @@ async function ensureArticleFamilyEntry(
   );
 }
 
-async function syncArticleSubtypeDetails(
+export async function syncArticleSubtypeDetails(
   client: Pick<PoolClient, "query">,
   args: {
     article_id: string;
@@ -3181,6 +3187,14 @@ export async function repoUpdateArticle(
       designation: patch.designation ?? current.designation,
       client,
     });
+
+    if (patch.article_matiere && normalized.article_category !== "matiere") {
+      throw new HttpError(
+        400,
+        "INVALID_ARTICLE",
+        "article_matiere is only allowed for article_category=matiere"
+      );
+    }
 
     if (current.stock_managed && !normalized.stock_managed) {
       await ensureArticleCanDisableStockManagement(client, id);


### PR DESCRIPTION
Closes #401. Classification Article autoritaire côté serveur, validation matière et couverture de régression.

## Summary by Sourcery

Enforce article_category as the authoritative primary classification and align server-side validation and persistence with this model.

New Features:
- Expose helpers for normalizing article categories and syncing subtype details for reuse in validation and tests.

Bug Fixes:
- Prevent secondary business categories from silently reclassifying an Article to a different primary category.
- Reject article_matiere payloads on non-matiere articles during updates.

Enhancements:
- Ensure the primary business category code is stored first in article_categories to reflect the explicit primary classification.
- Preserve existing material details when PATCH requests for material articles omit article_matiere instead of deleting them.

Documentation:
- Document the authoritative role of the primary article_category, category-specific constraints, and server-side validations related to #401.

Tests:
- Add regression tests covering primary vs secondary category behavior, category-specific PT and matière constraints, and PATCH semantics for material details.