### PR TITLE
Pièces techniques : applicabilité et archivage robustes

### DIFF
--- a/db/patches/20260730_piece_technique_pf_internal_family_404.sql
+++ b/db/patches/20260730_piece_technique_pf_internal_family_404.sql
@@ -1,0 +1,23 @@
+-- #404 — famille interne des pièces techniques fabriquées.
+-- Additif, idempotent, sans réécriture des pièces historiques.
+-- La colonne pieces_techniques.famille_id reste NOT NULL ; les nouvelles PT
+-- reçoivent la famille référentielle PF côté serveur.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.pieces_families') IS NULL THEN
+    RAISE EXCEPTION 'Pré-requis absent: public.pieces_families';
+  END IF;
+END $$;
+
+INSERT INTO public.pieces_families (code, designation)
+SELECT 'PF', 'Pièce fabriquée (interne)'
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.pieces_families
+  WHERE upper(btrim(code)) = 'PF'
+);
+
+COMMIT;

--- a/db/patches/support/20260730_piece_technique_pf_internal_family_404.preflight.sql
+++ b/db/patches/support/20260730_piece_technique_pf_internal_family_404.preflight.sql
@@ -1,0 +1,9 @@
+-- #404 — lecture seule avant application.
+SELECT current_database() AS database, current_user AS role, now() AS checked_at;
+
+SELECT to_regclass('public.pieces_families') IS NOT NULL AS pieces_families_present;
+
+SELECT id::text, code, designation, type_famille, section
+FROM public.pieces_families
+WHERE upper(btrim(code)) = 'PF'
+ORDER BY created_at ASC, id ASC;

--- a/db/patches/support/20260730_piece_technique_pf_internal_family_404.verify.sql
+++ b/db/patches/support/20260730_piece_technique_pf_internal_family_404.verify.sql
@@ -1,0 +1,8 @@
+-- #404 — lecture seule après application.
+SELECT count(*) = 1 AS one_internal_pf_family
+FROM public.pieces_families
+WHERE upper(btrim(code)) = 'PF';
+
+SELECT id::text, code, designation, type_famille, section
+FROM public.pieces_families
+WHERE upper(btrim(code)) = 'PF';

--- a/src/__tests__/pieces-techniques-versions.test.ts
+++ b/src/__tests__/pieces-techniques-versions.test.ts
@@ -5,6 +5,7 @@ import {
   createVersionSchema,
   versionStatusSchema,
 } from "../module/pieces-techniques/validators/versions.validators"
+import { createPieceTechniqueSchema } from "../module/pieces-techniques/validators/pieces-techniques.validators"
 
 // GPAO B2.1 — règles de cycle de vie des versions.
 // (La règle "une seule APPLICABLE" est en plus garantie par l'index unique partiel DB
@@ -61,8 +62,29 @@ describe("Versions — validators", () => {
     expect(versionStatusSchema.safeParse({ body: { next_statut: "WRONG" } }).success).toBe(false)
   })
 
+  it("valide la publication avec une date SQL et refuse un datetime qui ferait échouer la transaction", () => {
+    expect(versionStatusSchema.safeParse({ body: { next_statut: "APPLICABLE", date_application: "2026-07-30" } }).success).toBe(true)
+    expect(versionStatusSchema.safeParse({ body: { next_statut: "APPLICABLE", date_application: "2026-07-30T10:00:00.000Z" } }).success).toBe(false)
+    expect(versionStatusSchema.safeParse({ body: { next_statut: "APPLICABLE", date_application: "2026-02-30" } }).success).toBe(false)
+  })
+
   it("create-next exige aussi un indice", () => {
     expect(createNextVersionSchema.safeParse({ body: { indice: "B", type_changement: "EVOLUTION" } }).success).toBe(true)
     expect(createNextVersionSchema.safeParse({ body: {} }).success).toBe(false)
+  })
+})
+
+describe("Pièce technique — famille interne PF", () => {
+  it("accepte la création sans famille : le serveur attribue la famille interne", () => {
+    const parsed = createPieceTechniqueSchema.safeParse({
+      body: {
+        client_id: "045",
+        name_piece: "Carter",
+        designation: "Carter aluminium",
+        plan_reference: "10233",
+        indice_externe: "A",
+      },
+    })
+    expect(parsed.success).toBe(true)
   })
 })

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -1637,6 +1637,31 @@ async function lookupClientCompanyName(tx: Pick<PoolClient, "query">, clientId: 
   return typeof name === "string" && name.trim().length > 0 ? name.trim() : null;
 }
 
+/**
+ * La contrainte historique `pieces_techniques.famille_id NOT NULL` est conservée.
+ * Une PT créée par le nouveau parcours reçoit néanmoins une famille interne,
+ * stable et non exposée comme un choix métier : `PF` (pièce fabriquée).
+ */
+async function resolveInternalFabricatedFamilyId(tx: Pick<PoolClient, "query">): Promise<string> {
+  const result = await tx.query<{ id: string }>(
+    `SELECT id::text AS id
+       FROM public.pieces_families
+      WHERE upper(btrim(code)) = 'PF'
+      ORDER BY created_at ASC, id ASC
+      LIMIT 1
+      FOR SHARE`
+  );
+  const familyId = result.rows[0]?.id;
+  if (!familyId) {
+    throw new HttpError(
+      503,
+      "PIECE_TECHNIQUE_INTERNAL_FAMILY_MISSING",
+      "La famille interne PF est absente. Appliquez le patch de référentiel avant de créer une pièce technique."
+    );
+  }
+  return familyId;
+}
+
 export async function repoCreatePieceTechnique(
   body: CreatePieceTechniqueBodyDTO & {
     statut: PieceTechniqueStatut;
@@ -1648,6 +1673,9 @@ export async function repoCreatePieceTechnique(
   idempotencyKey?: string | null
 ): Promise<PieceTechnique> {
   const client = await db.connect();
+  // Conserve le hash historique : une clé déjà consommée avant #404 doit
+  // continuer à rejouer la même pièce, même si son ancien payload portait une
+  // famille choisie dans l'interface.
   const requestHash = crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex");
   try {
     await client.query("BEGIN");
@@ -1670,6 +1698,11 @@ export async function repoCreatePieceTechnique(
         return existing;
       }
     }
+
+    // Ne jamais réutiliser une famille envoyée par le navigateur : la famille
+    // d'une PT est un invariant serveur. Cette résolution arrive après le
+    // rejeu d'idempotence pour préserver les créations historiques.
+    const internalFamilyId = await resolveInternalFabricatedFamilyId(client);
 
     const actorUserId = audit.user_id;
     const createdBy = actorUserId;
@@ -1747,7 +1780,7 @@ export async function repoCreatePieceTechnique(
       clientIdForInsert,
       createdBy,
       updatedBy,
-      body.famille_id,
+      internalFamilyId,
       body.name_piece,
       generatedCode,
       body.designation,
@@ -2216,13 +2249,27 @@ export async function repoDeletePieceTechnique(id: string, audit: AuditContext):
       return false;
     }
 
+    const archivedCode = base.code_piece.startsWith("ARCH-") ? base.code_piece : `ARCH-${base.code_piece}`;
+    const collision = await client.query<{ id: string }>(
+      `SELECT id::text AS id
+         FROM pieces_techniques
+        WHERE code_piece = $2
+          AND id <> $1::uuid
+        LIMIT 1
+        FOR KEY SHARE`,
+      [id, archivedCode]
+    );
+    if (collision.rows[0]) {
+      throw new HttpError(409, "ARCHIVE_CODE_CONFLICT", "Le code archivé existe déjà ; la pièce n'a pas été supprimée.");
+    }
+
     const upd = await client.query(
       `
         UPDATE pieces_techniques
-        SET deleted_at = now(), deleted_by = $2, updated_at = now(), updated_by = $2
+        SET code_piece = $3, deleted_at = now(), deleted_by = $2, updated_at = now(), updated_by = $2
         WHERE id = $1::uuid AND deleted_at IS NULL
       `,
-      [id, audit.user_id]
+      [id, audit.user_id, archivedCode]
     );
     if ((upd.rowCount ?? 0) === 0) {
       await client.query("ROLLBACK");
@@ -2235,6 +2282,7 @@ export async function repoDeletePieceTechnique(id: string, audit: AuditContext):
       entity_id: id,
       details: {
         code_piece: base.code_piece,
+        archived_code_piece: archivedCode,
         designation: base.designation,
       },
     });

--- a/src/module/pieces-techniques/validators/pieces-techniques.validators.ts
+++ b/src/module/pieces-techniques/validators/pieces-techniques.validators.ts
@@ -186,7 +186,10 @@ export const createPieceTechniqueSchema = z.object({
     client_id: z.string().trim().min(1).max(3).optional().nullable(),
     code_client: z.string().trim().min(1).max(80).optional().nullable(),
     client_name: z.string().trim().min(1).max(200).optional().nullable(),
-    famille_id: uuid,
+    // Une pièce technique est par définition une pièce fabriquée. La famille
+    // technique interne est imposée par le serveur : le client ne doit plus la
+    // choisir, tout en restant tolérant aux anciens formulaires qui l'envoient.
+    famille_id: uuid.optional(),
     name_piece: z.string().trim().min(1, "Nom de pièce requis"),
     // Kept only to return a clear compatibility error to legacy callers.  It is
     // never accepted as the source of a final business code.

--- a/src/module/pieces-techniques/validators/versions.validators.ts
+++ b/src/module/pieces-techniques/validators/versions.validators.ts
@@ -39,7 +39,20 @@ export type UpdateVersionBodyDTO = z.infer<typeof updateVersionSchema>["body"]
 export const versionStatusSchema = z.object({
   body: z.object({
     next_statut: versionStatutSchema,
-    date_application: z.string().min(1).optional().nullable(),
+    // Empêche qu'une valeur d'interface non SQL (ex. datetime ISO) atteigne le
+    // cast `::date` de la transaction de publication et se transforme en 500.
+    date_application: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Date d'application attendue au format YYYY-MM-DD")
+      .refine(
+        (value) => {
+          const parsed = new Date(`${value}T00:00:00.000Z`)
+          return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value
+        },
+        "Date d'application invalide"
+      )
+      .optional()
+      .nullable(),
     commentaire_validation: z.string().max(2000).optional().nullable(),
     expected_updated_at: z.string().min(1).optional(),
   }),


### PR DESCRIPTION
Implements BigFootLime/crp-systems-web#404. Validation de date, famille PF interne, archivage ARCH et scripts SQL contrôlés.

## Summary by Sourcery

Enforce server-controlled internal PF family for technical parts, harden version applicability date validation, and make technical part deletion use collision-safe ARCH code archiving backed by SQL patches.

New Features:
- Assign a non-exposed internal PF family to all newly created technical parts on the server side.
- Archive deleted technical parts by prefixing their code with ARCH- while preventing code collisions.

Bug Fixes:
- Validate version applicability dates as real YYYY-MM-DD SQL dates to avoid runtime errors from invalid or datetime values.

Enhancements:
- Relax client validation to allow creating technical parts without specifying a family, keeping backward compatibility with legacy payloads.
- Include archived code information in deletion audit logs for better traceability.

Build:
- Add an idempotent database patch to ensure the presence of the internal PF family in pieces_families.

Tests:
- Extend validator tests to cover strict applicability date validation and family-less technical part creation under the new PF internal family rule.

Chores:
- Add preflight and verification SQL scripts to safely roll out and confirm the PF internal family patch.