### PR TITLE
Tour d’accès : catalogue granulaire des nouveaux modules

### DIFF
--- a/db/patches/20260730_repair_module_catalog_visibility_402.sql
+++ b/db/patches/20260730_repair_module_catalog_visibility_402.sql
@@ -1,0 +1,175 @@
+-- Réparation ciblée du catalogue de visibilité des modules (#402).
+--
+-- Contexte : les comptes ordinaires sont filtrés par public.app_modules, alors
+-- qu'un superadministrateur le contourne. Des pages réellement livrées étaient
+-- absentes ou incomplètes dans le catalogue persistant, donc invisibles pour les
+-- utilisateurs non superadmin.
+--
+-- ADDITIF, IDEMPOTENT, SANS DONNÉE MÉTIER :
+--   - sépare Finitions, Centres de frais et Parc machine afin que la Tour
+--     d'accès puisse les attribuer individuellement ;
+--   - crée ou aligne le module de GED ;
+--   - ne modifie jamais ces réglages sur les modules existants ; les nouveaux
+--     modules héritent du bloc technique historique à leur première création ;
+--   - ne remplace jamais les décisions nominatives existantes.
+--
+-- Prérequis : 20260727_admin_access_tower_326.sql.
+-- Préflight : db/patches/support/20260730_repair_module_catalog_visibility_402.preflight.sql
+-- Verify    : db/patches/support/20260730_repair_module_catalog_visibility_402.verify.sql
+--
+-- Le rollout du pilote Project Office reste une politique distincte, gouvernée
+-- par son feature flag et ses contrôles propres : ce patch ne le modifie pas.
+
+BEGIN;
+
+DO $catalog_guard$
+BEGIN
+  IF to_regclass('public.app_modules') IS NULL THEN
+    RAISE EXCEPTION
+      'catalogue #402 : public.app_modules absent — appliquer 20260727_admin_access_tower_326.sql d''abord';
+  END IF;
+END
+$catalog_guard$;
+
+-- La pièce technique reste son propre module. Les trois espaces livrés autour
+-- d'elle deviennent sélectionnables indépendamment dans la Tour d'accès.
+-- On retire seulement les anciens rattachements de navigation/API : les décisions
+-- d'exploitation restent dans les colonnes dédiées et dans les overrides ci-dessous.
+UPDATE public.app_modules
+SET
+  label = 'Données techniques',
+  description = 'Pièces techniques, versions, gammes et dossiers d’opération.',
+  api_prefixes = ARRAY['/pieces-techniques', '/piece-technique-versions', '/gammes', '/dossiers'],
+  nav_page_keys = ARRAY['pieces-techniques'],
+  sort_order = 100,
+  updated_at = now()
+WHERE module_key = 'pieces-techniques';
+
+-- A la première application, les nouveaux modules héritent du défaut et de
+-- l'activation du bloc technique historique. Cela évite de modifier d'un coup
+-- l'accès effectif des comptes. Les réapplications n'écrasent jamais les choix
+-- propres déjà posés sur les nouveaux modules.
+INSERT INTO public.app_modules (
+  module_key, label, description, category, api_prefixes, nav_page_keys,
+  enabled_by_default, is_active, is_protected, sort_order
+)
+SELECT
+  'finitions',
+  'Bibliothèque de finitions',
+  'Référentiel contrôlé des traitements et finitions de surface.',
+  'Production',
+  ARRAY['/finitions'],
+  ARRAY['finitions'],
+  technical.enabled_by_default,
+  technical.is_active,
+  false,
+  101
+FROM public.app_modules AS technical
+WHERE technical.module_key = 'pieces-techniques'
+ON CONFLICT (module_key) DO UPDATE
+SET label = EXCLUDED.label,
+    description = EXCLUDED.description,
+    category = EXCLUDED.category,
+    api_prefixes = EXCLUDED.api_prefixes,
+    nav_page_keys = EXCLUDED.nav_page_keys,
+    is_protected = false,
+    sort_order = EXCLUDED.sort_order,
+    updated_at = now();
+
+INSERT INTO public.app_modules (
+  module_key, label, description, category, api_prefixes, nav_page_keys,
+  enabled_by_default, is_active, is_protected, sort_order
+)
+SELECT
+  'methodes-centres-frais',
+  'Méthodes — Centres de frais',
+  'Centres de frais, tarifs versionnés et référentiel associé.',
+  'Production',
+  ARRAY['/methodes/centres-frais', '/centre-frais'],
+  ARRAY['methodes-centres-frais'],
+  technical.enabled_by_default,
+  technical.is_active,
+  false,
+  102
+FROM public.app_modules AS technical
+WHERE technical.module_key = 'pieces-techniques'
+ON CONFLICT (module_key) DO UPDATE
+SET label = EXCLUDED.label,
+    description = EXCLUDED.description,
+    category = EXCLUDED.category,
+    api_prefixes = EXCLUDED.api_prefixes,
+    nav_page_keys = EXCLUDED.nav_page_keys,
+    is_protected = false,
+    sort_order = EXCLUDED.sort_order,
+    updated_at = now();
+
+INSERT INTO public.app_modules (
+  module_key, label, description, category, api_prefixes, nav_page_keys,
+  enabled_by_default, is_active, is_protected, sort_order
+)
+SELECT
+  'methodes-parc-machines',
+  'Méthodes — Parc machine',
+  'Qualification du parc machine et familles de machines.',
+  'Production',
+  ARRAY['/methodes/machines', '/methodes/familles-machine'],
+  ARRAY['methodes-parc-machines'],
+  technical.enabled_by_default,
+  technical.is_active,
+  false,
+  103
+FROM public.app_modules AS technical
+WHERE technical.module_key = 'pieces-techniques'
+ON CONFLICT (module_key) DO UPDATE
+SET label = EXCLUDED.label,
+    description = EXCLUDED.description,
+    category = EXCLUDED.category,
+    api_prefixes = EXCLUDED.api_prefixes,
+    nav_page_keys = EXCLUDED.nav_page_keys,
+    is_protected = false,
+    sort_order = EXCLUDED.sort_order,
+    updated_at = now();
+
+-- Un override historique de Données techniques couvre logiquement les trois
+-- sous-espaces avant leur séparation. On le recopie uniquement s'il n'existe pas
+-- déjà de décision dédiée : les arbitrages plus fins restent prioritaires.
+INSERT INTO public.app_module_user_access (user_id, module_key, access, updated_at, updated_by)
+SELECT legacy.user_id, target.module_key, legacy.access, legacy.updated_at, legacy.updated_by
+FROM public.app_module_user_access AS legacy
+CROSS JOIN (VALUES ('finitions'), ('methodes-centres-frais'), ('methodes-parc-machines')) AS target(module_key)
+WHERE legacy.module_key = 'pieces-techniques'
+ON CONFLICT (user_id, module_key) DO NOTHING;
+
+-- GED est un module autonome : son catalogue peut être actualisé sans remettre
+-- à zéro les choix effectués en exploitation (default, activation et overrides).
+INSERT INTO public.app_modules (
+  module_key,
+  label,
+  description,
+  category,
+  api_prefixes,
+  nav_page_keys,
+  is_protected,
+  sort_order
+) VALUES (
+  'ged',
+  'Gestion documentaire',
+  'Documents contrôlés, versions, classes documentaires et validations.',
+  'Système',
+  ARRAY['/ged'],
+  ARRAY['ged'],
+  false,
+  195
+)
+ON CONFLICT (module_key) DO UPDATE
+SET
+  label = EXCLUDED.label,
+  description = EXCLUDED.description,
+  category = EXCLUDED.category,
+  api_prefixes = EXCLUDED.api_prefixes,
+  nav_page_keys = EXCLUDED.nav_page_keys,
+  is_protected = false,
+  sort_order = EXCLUDED.sort_order,
+  updated_at = now();
+
+COMMIT;

--- a/db/patches/support/20260730_repair_module_catalog_visibility_402.preflight.sql
+++ b/db/patches/support/20260730_repair_module_catalog_visibility_402.preflight.sql
@@ -1,0 +1,70 @@
+-- Préflight non destructif — réparation catalogue de visibilité #402.
+\set ON_ERROR_STOP on
+
+DO $preflight$
+DECLARE
+  technical_module_count integer;
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
+    RAISE EXCEPTION 'catalogue #402 refusé hors cerp_test/cerp_prod (base actuelle : %)', current_database();
+  END IF;
+
+  IF to_regclass('public.app_modules') IS NULL THEN
+    RAISE EXCEPTION
+      'catalogue #402 : public.app_modules absent — appliquer 20260727_admin_access_tower_326.sql d''abord';
+  END IF;
+
+  IF to_regclass('public.app_module_user_access') IS NULL THEN
+    RAISE EXCEPTION
+      'catalogue #402 : public.app_module_user_access absent — appliquer 20260727_admin_access_tower_326.sql d''abord';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'app_modules'
+      AND column_name IN (
+        'module_key', 'label', 'description', 'category', 'api_prefixes',
+        'nav_page_keys', 'enabled_by_default', 'is_active', 'is_protected',
+        'sort_order', 'updated_at'
+      )
+    GROUP BY table_schema, table_name
+    HAVING count(*) = 11
+  ) THEN
+    RAISE EXCEPTION 'catalogue #402 : public.app_modules a une forme incompatible';
+  END IF;
+
+  SELECT count(*)::integer
+  INTO technical_module_count
+  FROM public.app_modules
+  WHERE module_key = 'pieces-techniques';
+
+  IF technical_module_count <> 1 THEN
+    RAISE EXCEPTION
+      'catalogue #402 : le module source pieces-techniques doit exister exactement une fois (trouvé : %)',
+      technical_module_count;
+  END IF;
+END
+$preflight$;
+
+SELECT
+  current_database() AS database_name,
+  (SELECT enabled_by_default FROM public.app_modules WHERE module_key = 'pieces-techniques')
+    AS technical_data_enabled_by_default_before,
+  (SELECT is_active FROM public.app_modules WHERE module_key = 'pieces-techniques')
+    AS technical_data_is_active_before,
+  (SELECT enabled_by_default FROM public.app_modules WHERE module_key = 'finitions')
+    AS finitions_enabled_by_default_before,
+  (SELECT enabled_by_default FROM public.app_modules WHERE module_key = 'methodes-centres-frais')
+    AS cost_centers_enabled_by_default_before,
+  (SELECT enabled_by_default FROM public.app_modules WHERE module_key = 'methodes-parc-machines')
+    AS machine_park_enabled_by_default_before,
+  (SELECT enabled_by_default FROM public.app_modules WHERE module_key = 'ged')
+    AS ged_enabled_by_default_before,
+  (SELECT is_active FROM public.app_modules WHERE module_key = 'ged')
+    AS ged_is_active_before,
+  (SELECT count(*)::int FROM public.app_module_user_access WHERE module_key IN (
+    'pieces-techniques', 'finitions', 'methodes-centres-frais', 'methodes-parc-machines', 'ged'
+  ))
+    AS preserved_named_overrides_count;

--- a/db/patches/support/20260730_repair_module_catalog_visibility_402.verify.sql
+++ b/db/patches/support/20260730_repair_module_catalog_visibility_402.verify.sql
@@ -1,0 +1,61 @@
+-- Vérification post-application — réparation catalogue de visibilité #402.
+\set ON_ERROR_STOP on
+
+DO $verify_guard$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
+    RAISE EXCEPTION 'catalogue #402 refusé hors cerp_test/cerp_prod (base actuelle : %)', current_database();
+  END IF;
+END
+$verify_guard$;
+
+SELECT
+  current_database() AS database_name,
+  EXISTS (SELECT 1 FROM public.app_modules
+    WHERE module_key = 'pieces-techniques'
+      AND api_prefixes = ARRAY['/pieces-techniques', '/piece-technique-versions', '/gammes', '/dossiers']
+      AND nav_page_keys = ARRAY['pieces-techniques']
+  ) AS pieces_techniques_catalog_complete,
+  EXISTS (SELECT 1 FROM public.app_modules
+    WHERE module_key = 'finitions'
+      AND api_prefixes = ARRAY['/finitions']
+      AND nav_page_keys = ARRAY['finitions']
+      AND is_protected = false
+  ) AS finitions_catalog_complete,
+  EXISTS (SELECT 1 FROM public.app_modules
+    WHERE module_key = 'methodes-centres-frais'
+      AND api_prefixes = ARRAY['/methodes/centres-frais', '/centre-frais']
+      AND nav_page_keys = ARRAY['methodes-centres-frais']
+      AND is_protected = false
+  ) AS cost_centers_catalog_complete,
+  EXISTS (SELECT 1 FROM public.app_modules
+    WHERE module_key = 'methodes-parc-machines'
+      AND api_prefixes = ARRAY['/methodes/machines', '/methodes/familles-machine']
+      AND nav_page_keys = ARRAY['methodes-parc-machines']
+      AND is_protected = false
+  ) AS machine_park_catalog_complete,
+  EXISTS (
+    SELECT 1 FROM public.app_modules
+    WHERE module_key = 'ged'
+      AND '/ged' = ANY (api_prefixes)
+      AND 'ged' = ANY (nav_page_keys)
+      AND is_protected = false
+  ) AS ged_catalog_complete,
+  (
+    SELECT count(*)::int
+    FROM public.app_module_user_access
+    WHERE module_key IN (
+      'pieces-techniques', 'finitions', 'methodes-centres-frais', 'methodes-parc-machines', 'ged'
+    )
+  ) AS named_overrides_after;
+
+-- Contrôle d'hygiène : aucun tableau de catalogue ne doit introduire de doublon.
+SELECT
+  module_key,
+  cardinality(api_prefixes) AS api_prefixes_count,
+  (SELECT count(DISTINCT value) FROM unnest(api_prefixes) AS value) AS api_prefixes_distinct,
+  cardinality(nav_page_keys) AS nav_page_keys_count,
+  (SELECT count(DISTINCT value) FROM unnest(nav_page_keys) AS value) AS nav_page_keys_distinct
+FROM public.app_modules
+WHERE module_key IN ('pieces-techniques', 'finitions', 'methodes-centres-frais', 'methodes-parc-machines', 'ged')
+ORDER BY module_key;

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -466,6 +466,29 @@ l'infrastructure existe, la décision redevient fermée par défaut.
 État au 2026-07-27 : patch, scripts de support et seed **écrits et versionnés,
 appliqués sur aucune base**. Ni `cerp_test` ni `cerp_prod` n'ont été modifiés.
 
+## Issue #402 - Granularité des modules récents dans la Tour d'accès
+
+Le patch `20260730_repair_module_catalog_visibility_402.sql` fait apparaître
+séparément dans la matrice d'habilitation : **Pièces techniques**,
+**Bibliothèque de finitions**, **Méthodes — Centres de frais**, **Méthodes — Parc
+machine** et **Gestion documentaire**. Les nouveaux espaces sont ainsi réglables
+compte par compte, sans donner accès à toute la rubrique Données techniques.
+
+Le patch est transactionnel et idempotent. Les nouveaux modules héritent une seule
+fois de l'état actif et du défaut historique de `pieces-techniques`; il ne réécrit
+jamais ensuite leurs paramètres d'exploitation. Les overrides existants sur les
+nouvelles clés sont conservés, et un override historique de `pieces-techniques`
+est recopié vers les trois sous-espaces seulement lorsqu'aucun réglage dédié ne le
+remplace. Aucun droit métier, donnée industrielle ou compte utilisateur n'est créé.
+
+Ordre de recette : préflight #402, sauvegarde et application sur `cerp_test`,
+verify #402, contrôle navigateur de la Tour d'accès avec un compte non superadmin,
+puis seulement le même enchaînement sur `cerp_prod` après validation humaine. Les
+scripts de préflight et de vérification refusent toute autre base. Le backend qui
+porte le nouveau catalogue doit être redémarré dans la même fenêtre que le patch :
+le résolveur de routes est volontairement côté code et ne doit pas cohabiter avec
+la version de catalogue précédente.
+
 ## Mentions légales obligatoires de l'entité émettrice
 
 Le patch `20260729_finance_legal_mentions.sql` fait suite au rendu unique des pièces

--- a/docs/module-access-catalog.md
+++ b/docs/module-access-catalog.md
@@ -1,0 +1,39 @@
+# Catalogue de visibilité des modules
+
+Le contrôle de visibilité par compte repose sur `public.app_modules` et
+`public.app_module_user_access`. Il ne remplace pas les autorisations métier :
+les routes concernées gardent leurs contrôles RBAC propres.
+
+## Réparation #402
+
+Le patch `20260730_repair_module_catalog_visibility_402.sql` remet le catalogue
+persistant en cohérence avec le catalogue TypeScript :
+
+- les espaces **Pièces techniques**, **Bibliothèque de finitions**,
+  **Méthodes — Centres de frais** et **Méthodes — Parc machine** sont quatre
+  modules séparés dans la matrice. Un administrateur peut donc attribuer ou
+  refuser chacun d'eux indépendamment ;
+- la **Gestion documentaire** (`/ged`) devient un module distinct, actif par
+  défaut lorsqu'il est créé et non protégé ;
+- les choix déjà réalisés en exploitation (`enabled_by_default`, `is_active` et
+  les overrides nominatives) sont préservés. Au premier découpage, les trois
+  nouveaux modules Méthodes/Finitions héritent du défaut et de l'état actif de
+  `pieces-techniques`; un override nominatif historique est recopié seulement
+  si aucun override plus précis n'existe déjà.
+
+Les routes partagées de diagnostic de Méthodes restent hors de ce découpage ;
+elles ne donnent ni lecture métier ni droit d'écriture. Les routes de chaque
+espace, et leurs capacités métier propres, restent contrôlées par le backend.
+
+## Ordre de livraison
+
+Le catalogue TypeScript résout aussi les routes API. Le déploiement backend et
+le patch SQL doivent donc être appliqués dans une même fenêtre de maintenance :
+ne laissez jamais une version de code antérieure tourner entre le découpage SQL
+et le redémarrage de l'API. La recette démarre sur `cerp_test`, puis passe sur
+`cerp_prod` après sauvegarde et validation explicite.
+
+Le préflight et le verify se trouvent dans `db/patches/support/`. Ils doivent
+être exécutés sur `cerp_test` avant toute décision de déploiement. Le patch ne
+modifie aucune donnée métier, aucun compte et aucun flag du pilote Project
+Office ; son rollout utilisateur reste une décision séparée et contrôlée.

--- a/src/__tests__/access-control.gate.test.ts
+++ b/src/__tests__/access-control.gate.test.ts
@@ -219,6 +219,29 @@ describe("Gate d'accès module — décisions", () => {
     expect(res.statusCode).toBe(403);
   });
 
+  it("la GED est filtrée par son module dédié pour les comptes non superadmin", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "ged", access: "DENIED" }),
+    ]);
+    const { res, next } = await run("/ged/documents");
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "Accès interdit" });
+  });
+
+  it("applique des décisions distinctes aux nouveaux modules techniques", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "finitions", access: "DENIED" }),
+      profileRow({ module_key: "methodes-centres-frais" }),
+      profileRow({ module_key: "methodes-parc-machines", access: "DENIED" }),
+    ]);
+
+    expect((await run("/finitions/search")).res.statusCode).toBe(403);
+    expect((await run("/methodes/centres-frais")).next).toHaveBeenCalledOnce();
+    expect((await run("/methodes/machines/parc")).res.statusCode).toBe(403);
+  });
+
   it("résout le profil une seule fois par compte grâce au cache", async () => {
     await run("/clients/1");
     await run("/clients/2");

--- a/src/__tests__/access-control.test.ts
+++ b/src/__tests__/access-control.test.ts
@@ -162,10 +162,10 @@ beforeEach(() => {
 });
 
 describe("Catalogue de modules #326", () => {
-  it("expose 20 modules aux clés et préfixes uniques, dont un seul protégé", () => {
-    expect(MODULE_CATALOG).toHaveLength(20);
+  it("expose 24 modules aux clés et préfixes uniques, dont un seul protégé", () => {
+    expect(MODULE_CATALOG).toHaveLength(24);
     const keys = MODULE_CATALOG.map((entry) => entry.module_key);
-    expect(new Set(keys).size).toBe(20);
+    expect(new Set(keys).size).toBe(24);
 
     const prefixes = MODULE_CATALOG.flatMap((entry) => entry.api_prefixes);
     expect(new Set(prefixes).size).toBe(prefixes.length);
@@ -182,6 +182,30 @@ describe("Catalogue de modules #326", () => {
     expect(resolveModuleKeyForPath("/commandes-fournisseurs/17")).toBe("commandes-fournisseurs");
     expect(resolveModuleKeyForPath("/piece-technique-versions/9")).toBe("pieces-techniques");
     expect(resolveModuleKeyForPath("/pieces-techniques/9")).toBe("pieces-techniques");
+    expect(resolveModuleKeyForPath("/finitions/9")).toBe("finitions");
+    expect(resolveModuleKeyForPath("/methodes/centres-frais/9")).toBe("methodes-centres-frais");
+    expect(resolveModuleKeyForPath("/methodes/machines/9")).toBe("methodes-parc-machines");
+    expect(resolveModuleKeyForPath("/methodes/familles-machine/9")).toBe("methodes-parc-machines");
+    expect(resolveModuleKeyForPath("/centre-frais/9")).toBe("methodes-centres-frais");
+    expect(resolveModuleKeyForPath("/ged/documents")).toBe("ged");
+  });
+
+  it("rend les nouveaux espaces sélectionnables séparément dans la tour d'accès", () => {
+    const technicalData = MODULE_CATALOG.find((entry) => entry.module_key === "pieces-techniques");
+    const finitions = MODULE_CATALOG.find((entry) => entry.module_key === "finitions");
+    const costCenters = MODULE_CATALOG.find((entry) => entry.module_key === "methodes-centres-frais");
+    const machines = MODULE_CATALOG.find((entry) => entry.module_key === "methodes-parc-machines");
+    const ged = MODULE_CATALOG.find((entry) => entry.module_key === "ged");
+
+    expect(technicalData?.nav_page_keys).toEqual(["pieces-techniques"]);
+    expect(finitions).toMatchObject({ nav_page_keys: ["finitions"], api_prefixes: ["/finitions"] });
+    expect(costCenters).toMatchObject({ nav_page_keys: ["methodes-centres-frais"] });
+    expect(machines).toMatchObject({ nav_page_keys: ["methodes-parc-machines"] });
+    expect(ged).toMatchObject({
+      is_protected: false,
+      api_prefixes: ["/ged"],
+      nav_page_keys: ["ged"],
+    });
   });
 
   it("accepte une URL complète et ignore la query string", () => {
@@ -199,7 +223,6 @@ describe("Catalogue de modules #326", () => {
       "/chat/threads",
       "/users/4",
       "/locks",
-      "/centre-frais",
       "/pieces-families",
       "/environment",
     ]) {

--- a/src/__tests__/module-catalog-visibility-402.migration-guards.test.ts
+++ b/src/__tests__/module-catalog-visibility-402.migration-guards.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const patch = readFileSync(
+  resolve(root, "db/patches/20260730_repair_module_catalog_visibility_402.sql"),
+  "utf8"
+);
+const preflight = readFileSync(
+  resolve(root, "db/patches/support/20260730_repair_module_catalog_visibility_402.preflight.sql"),
+  "utf8"
+);
+const verify = readFileSync(
+  resolve(root, "db/patches/support/20260730_repair_module_catalog_visibility_402.verify.sql"),
+  "utf8"
+);
+
+describe("#402 catalogue de visibilité des modules", () => {
+  it("est transactionnel et ne réécrit ni les choix d'exploitation ni les overrides", () => {
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("COMMIT;");
+    expect(patch).not.toMatch(/\benabled_by_default\s*=/i);
+    expect(patch).not.toMatch(/\bis_active\s*=/i);
+    expect(patch).toMatch(/\bINSERT\s+INTO\s+public\.app_module_user_access/i);
+    expect(patch).toContain("ON CONFLICT (user_id, module_key) DO NOTHING");
+    expect(patch).not.toMatch(/\bUPDATE\s+public\.app_module_user_access/i);
+    expect(patch).not.toMatch(/\bDELETE\s+FROM\s+public\.app_module_user_access/i);
+  });
+
+  it("corrige le vrai catalogue app_modules, sans revenir aux anciennes migrations access_modules", () => {
+    expect(patch).toContain("public.app_modules");
+    expect(patch).not.toContain("public.access_modules");
+    expect(patch).toContain("'/finitions'");
+    expect(patch).toContain("'methodes-centres-frais'");
+    expect(patch).toContain("'methodes-parc-machines'");
+  });
+
+  it("déclare une GED autonome, non protégée, sans modifier Project Office", () => {
+    expect(patch).toContain("'ged'");
+    expect(patch).toContain("ARRAY['/ged']");
+    expect(patch).toContain("is_protected = false");
+    expect(patch).toContain("Project Office");
+    expect(patch).not.toMatch(/PROJECT_OFFICE\s*=/);
+  });
+
+  it("fournit un préflight et un verify non destructifs, bornés aux bases CERP", () => {
+    for (const script of [preflight, verify]) {
+      expect(script).toContain("\\set ON_ERROR_STOP on");
+      expect(script).toContain("current_database() NOT IN ('cerp_test', 'cerp_prod')");
+      expect(script).not.toMatch(/\bINSERT\s+INTO\b/i);
+      expect(script).not.toMatch(/\bUPDATE\s+public\./i);
+      expect(script).not.toMatch(/\bDELETE\s+FROM\b/i);
+      expect(script).not.toMatch(/\bDROP\s+/i);
+    }
+    expect(preflight).toContain("technical_module_count <> 1");
+    expect(preflight).toContain("module_key = 'pieces-techniques'");
+  });
+});

--- a/src/module/access-control/domain/module-catalog.ts
+++ b/src/module/access-control/domain/module-catalog.ts
@@ -108,26 +108,47 @@ export const MODULE_CATALOG: readonly ModuleCatalogEntry[] = [
   {
     module_key: "pieces-techniques",
     label: "Données techniques",
-    description: "Pièces techniques, versions, gammes, finitions et dossiers d’opération.",
+    description: "Pièces techniques, versions, gammes et dossiers d’opération.",
     category: "Production",
-    // `/finitions` (#210) rejoint le module Données techniques : la bibliothèque
-    // de finitions est un référentiel Méthodes, pas un module d'accès distinct.
-    // Idem `/methodes` : familles machine, centres de frais tarifés et sélecteur
-    // de machines sont les référentiels de la gamme, pas un module à part.
     api_prefixes: [
       "/pieces-techniques",
       "/piece-technique-versions",
       "/gammes",
-      "/finitions",
       "/dossiers",
-      "/methodes",
     ],
-    // `methodes-centres-frais` et `methodes-parc-machines` sont des pages de CE
-    // module : sans elles dans la liste, leurs entrées de navigation
-    // disparaîtraient pour tout compte filtré.
-    nav_page_keys: ["pieces-techniques", "methodes-centres-frais", "methodes-parc-machines"],
+    nav_page_keys: ["pieces-techniques"],
     is_protected: false,
     sort_order: 100,
+  },
+  {
+    module_key: "finitions",
+    label: "Bibliothèque de finitions",
+    description: "Référentiel contrôlé des traitements et finitions de surface.",
+    category: "Production",
+    api_prefixes: ["/finitions"],
+    nav_page_keys: ["finitions"],
+    is_protected: false,
+    sort_order: 101,
+  },
+  {
+    module_key: "methodes-centres-frais",
+    label: "Méthodes — Centres de frais",
+    description: "Centres de frais, tarifs versionnés et référentiel associé.",
+    category: "Production",
+    api_prefixes: ["/methodes/centres-frais", "/centre-frais"],
+    nav_page_keys: ["methodes-centres-frais"],
+    is_protected: false,
+    sort_order: 102,
+  },
+  {
+    module_key: "methodes-parc-machines",
+    label: "Méthodes — Parc machine",
+    description: "Qualification du parc machine et familles de machines.",
+    category: "Production",
+    api_prefixes: ["/methodes/machines", "/methodes/familles-machine"],
+    nav_page_keys: ["methodes-parc-machines"],
+    is_protected: false,
+    sort_order: 103,
   },
   {
     module_key: "production",
@@ -226,6 +247,16 @@ export const MODULE_CATALOG: readonly ModuleCatalogEntry[] = [
     nav_page_keys: ["import-assistant"],
     is_protected: false,
     sort_order: 190,
+  },
+  {
+    module_key: "ged",
+    label: "Gestion documentaire",
+    description: "Documents contrôlés, versions, classes documentaires et validations.",
+    category: "Système",
+    api_prefixes: ["/ged"],
+    nav_page_keys: ["ged"],
+    is_protected: false,
+    sort_order: 195,
   },
   {
     module_key: "administration",


### PR DESCRIPTION
Implements BigFootLime/crp-systems-web#402. Catalogue RBAC granulaire, héritage prudent des droits et patch SQL contrôlé.

## Summary by Sourcery

Separate recently delivered technical and GED spaces into distinct modules in the access catalog so their visibility can be controlled independently per account, and align the persistent database catalog with the TypeScript catalog under guarded, idempotent SQL migrations.

New Features:
- Introduce dedicated modules for Finitions, Méthodes — Centres de frais, Méthodes — Parc machines, and Gestion documentaire in the module catalog, each with its own API prefixes and navigation entries.
- Expose these new spaces as individually selectable entries in the access tower matrix rather than grouping them under technical data.

Bug Fixes:
- Ensure non‑superadmin accounts can see and be filtered by all delivered pages by repairing missing or incomplete entries in the persistent module visibility catalog.
- Align route resolution so GED and the new technical spaces are correctly mapped to their module keys for access-control decisions.

Enhancements:
- Update module catalog tests to cover the expanded set of modules, unique keys/prefixes, and distinct visibility decisions for the new spaces.
- Add migration guard tests to enforce that the SQL patch is transactional, non-destructive, and targets the app_modules catalog instead of legacy access_modules.
- Document the module visibility catalog and the #402 repair, including operational constraints and rollout ordering between backend deployment and SQL patch application.

Deployment:
- Introduce a controlled, transactional, and idempotent SQL patch plus preflight and verify scripts to safely update the persistent module catalog in cerp_test and cerp_prod, without altering business data or existing per-user overrides.

Documentation:
- Add dedicated documentation describing the module visibility catalog, the #402 repair, and the required deployment sequence and safety guarantees.
- Update database patch notes to describe the granular module separation and the guarded rollout process for the new modules.

Tests:
- Extend access-control and gate tests to validate module resolution and per-module decisions for the new technical modules and GED.
- Add preflight/verify SQL scripts and corresponding tests to guard the #402 catalog repair, constrain it to production/test databases, and confirm catalog completeness and override preservation.