### PR TITLE
Finitions : commentaires automatiques par famille

### DIFF
--- a/db/patches/20260730_surface_finish_family_comment_244.sql
+++ b/db/patches/20260730_surface_finish_family_comment_244.sql
@@ -1,0 +1,26 @@
+-- #244 -- Commentaire automatique parametre au niveau de la famille de finition.
+-- Additif et idempotent : ne modifie ni les codes FIN/ART, ni les revisions existantes.
+
+BEGIN;
+
+ALTER TABLE public.surface_finish_families
+  ADD COLUMN IF NOT EXISTS commentaire_template text NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'surface_finish_families_commentaire_template_length_check'
+      AND conrelid = 'public.surface_finish_families'::regclass
+  ) THEN
+    ALTER TABLE public.surface_finish_families
+      ADD CONSTRAINT surface_finish_families_commentaire_template_length_check
+      CHECK (commentaire_template IS NULL OR char_length(commentaire_template) <= 4000);
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.surface_finish_families.commentaire_template IS
+  '#244 -- Phrase ou modele commun ajoute au commentaire genere de chaque article de traitement de cette famille.';
+
+COMMIT;

--- a/db/patches/support/20260730_surface_finish_family_comment_244.preflight.sql
+++ b/db/patches/support/20260730_surface_finish_family_comment_244.preflight.sql
@@ -1,0 +1,12 @@
+-- #244 preflight -- lecture seule, a executer avant la migration.
+\set ON_ERROR_STOP on
+
+SELECT
+  current_database() AS database_name,
+  to_regclass('public.surface_finish_families') IS NOT NULL AS families_table_exists,
+  EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'surface_finish_families'
+      AND column_name = 'commentaire_template'
+  ) AS comment_column_already_exists;

--- a/db/patches/support/20260730_surface_finish_family_comment_244.verify.sql
+++ b/db/patches/support/20260730_surface_finish_family_comment_244.verify.sql
@@ -1,0 +1,18 @@
+-- #244 verify -- lecture seule, a executer apres la migration.
+\set ON_ERROR_STOP on
+
+SELECT
+  current_database() AS database_name,
+  EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'surface_finish_families'
+      AND column_name = 'commentaire_template'
+  ) AS comment_column_exists,
+  EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'surface_finish_families_commentaire_template_length_check'
+      AND conrelid = 'public.surface_finish_families'::regclass
+  ) AS length_check_exists,
+  COUNT(*) FILTER (WHERE commentaire_template IS NOT NULL) AS configured_families
+FROM public.surface_finish_families;

--- a/docs/surface-finish-family-comment-244.md
+++ b/docs/surface-finish-family-comment-244.md
@@ -1,0 +1,23 @@
+# #244 — Commentaire automatique par famille de finition
+
+## Objectif
+
+Une famille de finition peut désormais porter un `commentaire_template`. Il est
+ajouté par le serveur avant le modèle de commentaire de la révision lors de
+l'aperçu et de la confirmation d'un article de traitement.
+
+## Contrat
+
+- `POST /api/v1/finitions/familles` exige `library_draft_write`.
+- Charge : `code`, `label`, `description?`, `commentaire_template?`, `sort_order?`.
+- Le commentaire accepte la même liste blanche de variables que les modèles de
+  révision ; le serveur refuse toute variable inconnue.
+- Le code article demeure `ART-TRT-NNNNNN` et le code finition `FIN-NNNNNN`.
+- Une finition et sa révision restent brouillon jusqu'à leur validation : ce
+  paramétrage n'affaiblit aucune règle Qualité.
+
+## Migration
+
+`db/patches/20260730_surface_finish_family_comment_244.sql` est additive,
+idempotente et non exécutée. Les scripts `preflight` et `verify` associés sont
+en lecture seule.

--- a/src/__tests__/surface-finish-244.family-comment.test.ts
+++ b/src/__tests__/surface-finish-244.family-comment.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(resolve(root, relative), "utf8").replace(/\r\n?/g, "\n");
+
+const patch = read("db/patches/20260730_surface_finish_family_comment_244.sql");
+const preflight = read("db/patches/support/20260730_surface_finish_family_comment_244.preflight.sql");
+const verify = read("db/patches/support/20260730_surface_finish_family_comment_244.verify.sql");
+const library = read("src/module/surface-finish/repository/surface-finish-library.repository.ts");
+const resolution = read("src/module/surface-finish/repository/surface-finish-resolution.repository.ts");
+const routes = read("src/module/surface-finish/routes/surface-finish.routes.ts");
+
+describe("#244 commentaire de famille de finition", () => {
+  it("est additif, transactionnel et ne modifie aucun article existant", () => {
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("COMMIT;");
+    expect(patch).toMatch(/ADD COLUMN IF NOT EXISTS\s+commentaire_template\s+text NULL/i);
+    expect(patch).not.toMatch(/\bUPDATE\b|\bDELETE\b|\bINSERT\b/i);
+  });
+
+  it("borne le modèle et livre les contrôles de migration lecture seule", () => {
+    expect(patch).toContain("surface_finish_families_commentaire_template_length_check");
+    expect(patch).toContain("char_length(commentaire_template) <= 4000");
+    expect(preflight).toContain("\\set ON_ERROR_STOP on");
+    expect(verify).toContain("\\set ON_ERROR_STOP on");
+    expect(preflight).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/im);
+    expect(verify).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/im);
+    expect(verify).toContain("comment_column_exists");
+    expect(verify).toMatch(/configured_families\s*\nFROM public\.surface_finish_families;/);
+  });
+
+  it("compose le commentaire de famille dans le même rendu pour aperçu et confirmation", () => {
+    expect(resolution).toContain("fam.commentaire_template AS family_commentaire_template");
+    expect(resolution).toContain("LEFT JOIN public.surface_finish_families fam");
+    expect(resolution).toContain("[familyTemplate, revisionTemplate].filter(Boolean).join");
+    expect(routes).toContain('router.post(\n  "/familles",');
+    expect(routes).toContain('requireSurfaceFinishCapability("library_draft_write")');
+  });
+
+  it("crée la famille et sa trace d'audit dans une seule transaction", () => {
+    expect(library).toContain('await client.query("BEGIN")');
+    expect(library).toContain('await insertFinishAudit(client, audit, "finitions.family.create"');
+    expect(library).toContain('await client.query("COMMIT")');
+    expect(library).toContain('await client.query("ROLLBACK").catch');
+  });
+});

--- a/src/module/surface-finish/controllers/surface-finish.controller.ts
+++ b/src/module/surface-finish/controllers/surface-finish.controller.ts
@@ -12,6 +12,7 @@ import {
   attachRevisionDocumentSVC,
   capabilitiesSVC,
   confirmOperationFinishSVC,
+  createFinishFamilySVC,
   createFinishDraftSVC,
   createRevisionSVC,
   detachOperationFinishSVC,
@@ -100,6 +101,14 @@ function headerValue(req: Request, name: string): string | null {
 export const listFinishFamilies: RequestHandler = async (_req, res, next) => {
   try {
     res.json(await listFinishFamiliesSVC());
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const createFinishFamily: RequestHandler = async (req, res, next) => {
+  try {
+    res.status(201).json(await createFinishFamilySVC(req.body, buildAuditContext(req)));
   } catch (err) {
     next(err);
   }

--- a/src/module/surface-finish/repository/surface-finish-library.repository.ts
+++ b/src/module/surface-finish/repository/surface-finish-library.repository.ts
@@ -20,6 +20,7 @@ import {
 } from "../domain/surface-finish-policy";
 import type {
   AttachDocumentBodyDTO,
+  CreateFinishFamilyBodyDTO,
   CreateFinishBodyDTO,
   ListFinishesQueryDTO,
   RevisionPayloadDTO,
@@ -258,11 +259,46 @@ export async function insertFinishAudit(
 
 export async function repoListFinishFamilies(): Promise<SurfaceFinishFamily[]> {
   const res = await db.query<SurfaceFinishFamily>(
-    `SELECT code, label, description, sort_order, is_active
+    `SELECT code, label, description, commentaire_template, sort_order, is_active
      FROM public.surface_finish_families
      ORDER BY sort_order, label`
   );
   return res.rows;
+}
+
+/** Family parameterization is auditable and separate from a finish draft. */
+export async function repoCreateFinishFamily(
+  body: CreateFinishFamilyBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishFamily> {
+  assertTemplateVariablesAllowed(body.commentaire_template ?? "");
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const res = await client.query<SurfaceFinishFamily>(
+      `INSERT INTO public.surface_finish_families
+         (code, label, description, commentaire_template, sort_order, is_active)
+       VALUES ($1, $2, $3, $4, $5, true)
+       RETURNING code, label, description, commentaire_template, sort_order, is_active`,
+      [body.code, body.label, body.description, body.commentaire_template, body.sort_order]
+    );
+    const family = res.rows[0];
+    await insertFinishAudit(client, audit, "finitions.family.create", "surface_finish_family", family.code, {
+      code: family.code,
+      label: family.label,
+      has_commentaire_template: Boolean(family.commentaire_template),
+    });
+    await client.query("COMMIT");
+    return family;
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    if (typeof err === "object" && err !== null && (err as { code?: string }).code === "23505") {
+      throw new HttpError(409, "SURFACE_FINISH_FAMILY_DUPLICATE", "Une famille de finition porte dÃ©jÃ  ce code.");
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/module/surface-finish/repository/surface-finish-resolution.repository.ts
+++ b/src/module/surface-finish/repository/surface-finish-resolution.repository.ts
@@ -163,6 +163,7 @@ async function loadRevision(tx: Queryer, revisionId: string) {
       finish_designation: string;
       finish_family: string;
       finish_procede: string;
+      family_commentaire_template: string | null;
       finish_statut: SurfaceFinishStatus;
       finish_uuid: string;
     }
@@ -173,9 +174,11 @@ async function loadRevision(tx: Queryer, revisionId: string) {
             f.designation_courte  AS finish_designation,
             f.family_code         AS finish_family,
             f.procede             AS finish_procede,
+            fam.commentaire_template AS family_commentaire_template,
             f.statut              AS finish_statut
      FROM public.surface_finish_revisions r
      JOIN public.surface_finishes f ON f.id = r.finish_id
+     LEFT JOIN public.surface_finish_families fam ON fam.code = f.family_code
      WHERE r.id = $1::uuid`,
     [revisionId]
   );
@@ -188,6 +191,7 @@ async function loadRevision(tx: Queryer, revisionId: string) {
       code: row.finish_code,
       designation_courte: row.finish_designation,
       family_code: row.finish_family,
+      family_commentaire_template: row.family_commentaire_template,
       procede: row.finish_procede,
       statut: row.finish_statut,
     },
@@ -318,7 +322,7 @@ export type GenerationResult = {
  */
 export function generateTexts(params: {
   context: OperationFinishContext;
-  finish: { code: string; designation_courte: string };
+  finish: { code: string; designation_courte: string; family_commentaire_template?: string | null };
   revision: SurfaceFinishRevisionDetail;
   spec: CanonicalFinishSpec;
 }): GenerationResult {
@@ -337,7 +341,9 @@ export function generateTexts(params: {
     zones: spec.zones,
   });
 
-  const template = revision.commentaire_template ?? DEFAULT_COMMENT_TEMPLATE;
+  const familyTemplate = params.finish.family_commentaire_template?.trim() ?? "";
+  const revisionTemplate = revision.commentaire_template ?? DEFAULT_COMMENT_TEMPLATE;
+  const template = [familyTemplate, revisionTemplate].filter(Boolean).join("\n");
   const teinteAspect = [spec.teinte_ral ?? spec.couleur, spec.aspect].filter(Boolean).join(" / ") || null;
 
   const rendered = renderGeneratedComment(

--- a/src/module/surface-finish/routes/surface-finish.routes.ts
+++ b/src/module/surface-finish/routes/surface-finish.routes.ts
@@ -8,6 +8,7 @@ import {
   archiveFinish,
   attachRevisionDocument,
   createFinish,
+  createFinishFamily,
   createRevision,
   getFinish,
   listFinishes,
@@ -30,6 +31,7 @@ import {
   archiveFinishBodySchema,
   attachDocumentBodySchema,
   createFinishBodySchema,
+  createFinishFamilyBodySchema,
   createRevisionBodySchema,
   finishHistoryQuerySchema,
   listFinishesQuerySchema,
@@ -49,6 +51,12 @@ const router = Router();
 router.get("/capabilities", readCapabilities);
 
 router.get("/familles", requireSurfaceFinishCapability("library_read"), listFinishFamilies);
+router.post(
+  "/familles",
+  requireSurfaceFinishCapability("library_draft_write"),
+  validate(createFinishFamilyBodySchema),
+  createFinishFamily
+);
 
 // #226 — Contrôle des doublons. DÉCLARÉ AVANT `/:finishId` : les deux motifs
 // n'ont qu'un segment, et Express retient le premier inscrit — placé après,

--- a/src/module/surface-finish/services/surface-finish.service.ts
+++ b/src/module/surface-finish/services/surface-finish.service.ts
@@ -13,6 +13,7 @@ import {
 import {
   repoAttachRevisionDocument,
   repoCreateFinishDraft,
+  repoCreateFinishFamily,
   repoCreateRevision,
   repoGetFinish,
   repoListFinishes,
@@ -42,6 +43,7 @@ import {
 import type {
   ArchiveFinishBodyDTO,
   AttachDocumentBodyDTO,
+  CreateFinishFamilyBodyDTO,
   ConfirmFinishBodyDTO,
   CreateFinishBodyDTO,
   DetachFinishBodyDTO,
@@ -75,6 +77,13 @@ export type Actor = { user_id: number; role: string | null };
 
 export async function listFinishFamiliesSVC(): Promise<SurfaceFinishFamily[]> {
   return repoListFinishFamilies();
+}
+
+export async function createFinishFamilySVC(
+  body: CreateFinishFamilyBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishFamily> {
+  return repoCreateFinishFamily(body, audit);
 }
 
 export async function listFinishesSVC(

--- a/src/module/surface-finish/types/surface-finish.types.ts
+++ b/src/module/surface-finish/types/surface-finish.types.ts
@@ -14,6 +14,7 @@ export type SurfaceFinishFamily = {
   code: string;
   label: string;
   description: string | null;
+  commentaire_template: string | null;
   sort_order: number;
   is_active: boolean;
 };

--- a/src/module/surface-finish/validators/surface-finish.validators.ts
+++ b/src/module/surface-finish/validators/surface-finish.validators.ts
@@ -131,6 +131,23 @@ export const listFinishesQuerySchema = z.object({
 });
 export type ListFinishesQueryDTO = z.infer<typeof listFinishesQuerySchema>;
 
+const familyCode = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .min(2)
+  .max(60)
+  .regex(/^[A-Z0-9_]+$/, "Le code famille accepte uniquement A-Z, 0-9 et _.");
+
+export const createFinishFamilyBodySchema = z.object({
+  code: familyCode,
+  label: shortText,
+  description: optionalText(2000),
+  commentaire_template: optionalText(4000),
+  sort_order: z.coerce.number().int().min(0).max(10_000).optional().default(100),
+});
+export type CreateFinishFamilyBodyDTO = z.infer<typeof createFinishFamilyBodySchema>;
+
 /* -------------------------------------------------------------------------- */
 /* Bibliothèque — contrôle des doublons (#226)                                 */
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
Closes #244. Ajoute le commentaire modèle de famille, la création auditée et la composition serveur des textes Article.

## Summary by Sourcery

Introduce family-level comment templates for surface finishes and ensure they are applied server-side when generating article comments, while keeping the change additive and auditable.

New Features:
- Allow creation of surface finish families with an optional commentaire_template via a dedicated POST endpoint secured by library_draft_write.
- Include family commentaire_template in server-side composition of generated article comments for preview and confirmation.

Enhancements:
- Make surface finish family parameterization auditable with a dedicated audit entry on creation.
- Extend finish family listing and types to expose the family commentaire_template field.

Build:
- Add database migration and supporting preflight/verify scripts to introduce the commentaire_template column and its length constraint on surface_finish_families.

Documentation:
- Add documentation describing the new family-level commentaire_template, API contract, and migration behavior for surface finish families.

Tests:
- Add regression tests validating the migration scripts, comment composition behavior, API route wiring, and transactional creation with auditing of finish families.