### PR TITLE
Tests Article : cibler l’upsert matière exact

### DIFF
--- a/src/__tests__/article-category-primary-401.test.ts
+++ b/src/__tests__/article-category-primary-401.test.ts
@@ -151,7 +151,9 @@ describe("#401 catégorie primaire Article", () => {
     });
 
     expect(queries.some((sql) => sql.includes("DELETE FROM public.articles_matiere"))).toBe(false);
-    const materialUpsert = queries.find((sql) => sql.includes("INSERT INTO public.articles_matiere"));
+    const materialUpsert = queries.find((sql) =>
+      /INSERT INTO public\.articles_matiere\s*\(/.test(sql)
+    );
     const materialUpsertText = materialUpsert ?? "";
     expect(materialUpsertText).toContain("SET family_code = EXCLUDED.family_code");
     expect(materialUpsertText).not.toContain("longueur_mm = EXCLUDED.longueur_mm");


### PR DESCRIPTION
Refs BigFootLime/crp-systems-web#401. Corrige uniquement le sélecteur SQL du test intégré, sans changement métier.

## Summary by Sourcery

Tests:
- Update the SQL query matcher in the article category primary test to target the precise articles_matiere INSERT statement.