### PR TITLE
Release CERP : Articles, PT, finitions et Tour d’accès

### DIFF
--- a/db/patches/20260730_piece_technique_pf_internal_family_404.sql
+++ b/db/patches/20260730_piece_technique_pf_internal_family_404.sql
@@ -1,0 +1,23 @@
+-- #404 — famille interne des pièces techniques fabriquées.
+-- Additif, idempotent, sans réécriture des pièces historiques.
+-- La colonne pieces_techniques.famille_id reste NOT NULL ; les nouvelles PT
+-- reçoivent la famille référentielle PF côté serveur.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.pieces_families') IS NULL THEN
+    RAISE EXCEPTION 'Pré-requis absent: public.pieces_families';
+  END IF;
+END $$;
+
+INSERT INTO public.pieces_families (code, designation)
+SELECT 'PF', 'Pièce fabriquée (interne)'
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM public.pieces_families
+  WHERE upper(btrim(code)) = 'PF'
+);
+
+COMMIT;

--- a/db/patches/20260730_repair_module_catalog_visibility_402.sql
+++ b/db/patches/20260730_repair_module_catalog_visibility_402.sql
@@ -1,0 +1,175 @@
+-- Réparation ciblée du catalogue de visibilité des modules (#402).
+--
+-- Contexte : les comptes ordinaires sont filtrés par public.app_modules, alors
+-- qu'un superadministrateur le contourne. Des pages réellement livrées étaient
+-- absentes ou incomplètes dans le catalogue persistant, donc invisibles pour les
+-- utilisateurs non superadmin.
+--
+-- ADDITIF, IDEMPOTENT, SANS DONNÉE MÉTIER :
+--   - sépare Finitions, Centres de frais et Parc machine afin que la Tour
+--     d'accès puisse les attribuer individuellement ;
+--   - crée ou aligne le module de GED ;
+--   - ne modifie jamais ces réglages sur les modules existants ; les nouveaux
+--     modules héritent du bloc technique historique à leur première création ;
+--   - ne remplace jamais les décisions nominatives existantes.
+--
+-- Prérequis : 20260727_admin_access_tower_326.sql.
+-- Préflight : db/patches/support/20260730_repair_module_catalog_visibility_402.preflight.sql
+-- Verify    : db/patches/support/20260730_repair_module_catalog_visibility_402.verify.sql
+--
+-- Le rollout du pilote Project Office reste une politique distincte, gouvernée
+-- par son feature flag et ses contrôles propres : ce patch ne le modifie pas.
+
+BEGIN;
+
+DO $catalog_guard$
+BEGIN
+  IF to_regclass('public.app_modules') IS NULL THEN
+    RAISE EXCEPTION
+      'catalogue #402 : public.app_modules absent — appliquer 20260727_admin_access_tower_326.sql d''abord';
+  END IF;
+END
+$catalog_guard$;
+
+-- La pièce technique reste son propre module. Les trois espaces livrés autour
+-- d'elle deviennent sélectionnables indépendamment dans la Tour d'accès.
+-- On retire seulement les anciens rattachements de navigation/API : les décisions
+-- d'exploitation restent dans les colonnes dédiées et dans les overrides ci-dessous.
+UPDATE public.app_modules
+SET
+  label = 'Données techniques',
+  description = 'Pièces techniques, versions, gammes et dossiers d’opération.',
+  api_prefixes = ARRAY['/pieces-techniques', '/piece-technique-versions', '/gammes', '/dossiers'],
+  nav_page_keys = ARRAY['pieces-techniques'],
+  sort_order = 100,
+  updated_at = now()
+WHERE module_key = 'pieces-techniques';
+
+-- A la première application, les nouveaux modules héritent du défaut et de
+-- l'activation du bloc technique historique. Cela évite de modifier d'un coup
+-- l'accès effectif des comptes. Les réapplications n'écrasent jamais les choix
+-- propres déjà posés sur les nouveaux modules.
+INSERT INTO public.app_modules (
+  module_key, label, description, category, api_prefixes, nav_page_keys,
+  enabled_by_default, is_active, is_protected, sort_order
+)
+SELECT
+  'finitions',
+  'Bibliothèque de finitions',
+  'Référentiel contrôlé des traitements et finitions de surface.',
+  'Production',
+  ARRAY['/finitions'],
+  ARRAY['finitions'],
+  technical.enabled_by_default,
+  technical.is_active,
+  false,
+  101
+FROM public.app_modules AS technical
+WHERE technical.module_key = 'pieces-techniques'
+ON CONFLICT (module_key) DO UPDATE
+SET label = EXCLUDED.label,
+    description = EXCLUDED.description,
+    category = EXCLUDED.category,
+    api_prefixes = EXCLUDED.api_prefixes,
+    nav_page_keys = EXCLUDED.nav_page_keys,
+    is_protected = false,
+    sort_order = EXCLUDED.sort_order,
+    updated_at = now();
+
+INSERT INTO public.app_modules (
+  module_key, label, description, category, api_prefixes, nav_page_keys,
+  enabled_by_default, is_active, is_protected, sort_order
+)
+SELECT
+  'methodes-centres-frais',
+  'Méthodes — Centres de frais',
+  'Centres de frais, tarifs versionnés et référentiel associé.',
+  'Production',
+  ARRAY['/methodes/centres-frais', '/centre-frais'],
+  ARRAY['methodes-centres-frais'],
+  technical.enabled_by_default,
+  technical.is_active,
+  false,
+  102
+FROM public.app_modules AS technical
+WHERE technical.module_key = 'pieces-techniques'
+ON CONFLICT (module_key) DO UPDATE
+SET label = EXCLUDED.label,
+    description = EXCLUDED.description,
+    category = EXCLUDED.category,
+    api_prefixes = EXCLUDED.api_prefixes,
+    nav_page_keys = EXCLUDED.nav_page_keys,
+    is_protected = false,
+    sort_order = EXCLUDED.sort_order,
+    updated_at = now();
+
+INSERT INTO public.app_modules (
+  module_key, label, description, category, api_prefixes, nav_page_keys,
+  enabled_by_default, is_active, is_protected, sort_order
+)
+SELECT
+  'methodes-parc-machines',
+  'Méthodes — Parc machine',
+  'Qualification du parc machine et familles de machines.',
+  'Production',
+  ARRAY['/methodes/machines', '/methodes/familles-machine'],
+  ARRAY['methodes-parc-machines'],
+  technical.enabled_by_default,
+  technical.is_active,
+  false,
+  103
+FROM public.app_modules AS technical
+WHERE technical.module_key = 'pieces-techniques'
+ON CONFLICT (module_key) DO UPDATE
+SET label = EXCLUDED.label,
+    description = EXCLUDED.description,
+    category = EXCLUDED.category,
+    api_prefixes = EXCLUDED.api_prefixes,
+    nav_page_keys = EXCLUDED.nav_page_keys,
+    is_protected = false,
+    sort_order = EXCLUDED.sort_order,
+    updated_at = now();
+
+-- Un override historique de Données techniques couvre logiquement les trois
+-- sous-espaces avant leur séparation. On le recopie uniquement s'il n'existe pas
+-- déjà de décision dédiée : les arbitrages plus fins restent prioritaires.
+INSERT INTO public.app_module_user_access (user_id, module_key, access, updated_at, updated_by)
+SELECT legacy.user_id, target.module_key, legacy.access, legacy.updated_at, legacy.updated_by
+FROM public.app_module_user_access AS legacy
+CROSS JOIN (VALUES ('finitions'), ('methodes-centres-frais'), ('methodes-parc-machines')) AS target(module_key)
+WHERE legacy.module_key = 'pieces-techniques'
+ON CONFLICT (user_id, module_key) DO NOTHING;
+
+-- GED est un module autonome : son catalogue peut être actualisé sans remettre
+-- à zéro les choix effectués en exploitation (default, activation et overrides).
+INSERT INTO public.app_modules (
+  module_key,
+  label,
+  description,
+  category,
+  api_prefixes,
+  nav_page_keys,
+  is_protected,
+  sort_order
+) VALUES (
+  'ged',
+  'Gestion documentaire',
+  'Documents contrôlés, versions, classes documentaires et validations.',
+  'Système',
+  ARRAY['/ged'],
+  ARRAY['ged'],
+  false,
+  195
+)
+ON CONFLICT (module_key) DO UPDATE
+SET
+  label = EXCLUDED.label,
+  description = EXCLUDED.description,
+  category = EXCLUDED.category,
+  api_prefixes = EXCLUDED.api_prefixes,
+  nav_page_keys = EXCLUDED.nav_page_keys,
+  is_protected = false,
+  sort_order = EXCLUDED.sort_order,
+  updated_at = now();
+
+COMMIT;

--- a/db/patches/20260730_surface_finish_family_comment_244.sql
+++ b/db/patches/20260730_surface_finish_family_comment_244.sql
@@ -1,0 +1,26 @@
+-- #244 -- Commentaire automatique parametre au niveau de la famille de finition.
+-- Additif et idempotent : ne modifie ni les codes FIN/ART, ni les revisions existantes.
+
+BEGIN;
+
+ALTER TABLE public.surface_finish_families
+  ADD COLUMN IF NOT EXISTS commentaire_template text NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'surface_finish_families_commentaire_template_length_check'
+      AND conrelid = 'public.surface_finish_families'::regclass
+  ) THEN
+    ALTER TABLE public.surface_finish_families
+      ADD CONSTRAINT surface_finish_families_commentaire_template_length_check
+      CHECK (commentaire_template IS NULL OR char_length(commentaire_template) <= 4000);
+  END IF;
+END $$;
+
+COMMENT ON COLUMN public.surface_finish_families.commentaire_template IS
+  '#244 -- Phrase ou modele commun ajoute au commentaire genere de chaque article de traitement de cette famille.';
+
+COMMIT;

--- a/db/patches/support/20260730_piece_technique_pf_internal_family_404.preflight.sql
+++ b/db/patches/support/20260730_piece_technique_pf_internal_family_404.preflight.sql
@@ -1,0 +1,9 @@
+-- #404 — lecture seule avant application.
+SELECT current_database() AS database, current_user AS role, now() AS checked_at;
+
+SELECT to_regclass('public.pieces_families') IS NOT NULL AS pieces_families_present;
+
+SELECT id::text, code, designation, type_famille, section
+FROM public.pieces_families
+WHERE upper(btrim(code)) = 'PF'
+ORDER BY created_at ASC, id ASC;

--- a/db/patches/support/20260730_piece_technique_pf_internal_family_404.verify.sql
+++ b/db/patches/support/20260730_piece_technique_pf_internal_family_404.verify.sql
@@ -1,0 +1,8 @@
+-- #404 — lecture seule après application.
+SELECT count(*) = 1 AS one_internal_pf_family
+FROM public.pieces_families
+WHERE upper(btrim(code)) = 'PF';
+
+SELECT id::text, code, designation, type_famille, section
+FROM public.pieces_families
+WHERE upper(btrim(code)) = 'PF';

--- a/db/patches/support/20260730_repair_module_catalog_visibility_402.preflight.sql
+++ b/db/patches/support/20260730_repair_module_catalog_visibility_402.preflight.sql
@@ -1,0 +1,70 @@
+-- Préflight non destructif — réparation catalogue de visibilité #402.
+\set ON_ERROR_STOP on
+
+DO $preflight$
+DECLARE
+  technical_module_count integer;
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
+    RAISE EXCEPTION 'catalogue #402 refusé hors cerp_test/cerp_prod (base actuelle : %)', current_database();
+  END IF;
+
+  IF to_regclass('public.app_modules') IS NULL THEN
+    RAISE EXCEPTION
+      'catalogue #402 : public.app_modules absent — appliquer 20260727_admin_access_tower_326.sql d''abord';
+  END IF;
+
+  IF to_regclass('public.app_module_user_access') IS NULL THEN
+    RAISE EXCEPTION
+      'catalogue #402 : public.app_module_user_access absent — appliquer 20260727_admin_access_tower_326.sql d''abord';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'app_modules'
+      AND column_name IN (
+        'module_key', 'label', 'description', 'category', 'api_prefixes',
+        'nav_page_keys', 'enabled_by_default', 'is_active', 'is_protected',
+        'sort_order', 'updated_at'
+      )
+    GROUP BY table_schema, table_name
+    HAVING count(*) = 11
+  ) THEN
+    RAISE EXCEPTION 'catalogue #402 : public.app_modules a une forme incompatible';
+  END IF;
+
+  SELECT count(*)::integer
+  INTO technical_module_count
+  FROM public.app_modules
+  WHERE module_key = 'pieces-techniques';
+
+  IF technical_module_count <> 1 THEN
+    RAISE EXCEPTION
+      'catalogue #402 : le module source pieces-techniques doit exister exactement une fois (trouvé : %)',
+      technical_module_count;
+  END IF;
+END
+$preflight$;
+
+SELECT
+  current_database() AS database_name,
+  (SELECT enabled_by_default FROM public.app_modules WHERE module_key = 'pieces-techniques')
+    AS technical_data_enabled_by_default_before,
+  (SELECT is_active FROM public.app_modules WHERE module_key = 'pieces-techniques')
+    AS technical_data_is_active_before,
+  (SELECT enabled_by_default FROM public.app_modules WHERE module_key = 'finitions')
+    AS finitions_enabled_by_default_before,
+  (SELECT enabled_by_default FROM public.app_modules WHERE module_key = 'methodes-centres-frais')
+    AS cost_centers_enabled_by_default_before,
+  (SELECT enabled_by_default FROM public.app_modules WHERE module_key = 'methodes-parc-machines')
+    AS machine_park_enabled_by_default_before,
+  (SELECT enabled_by_default FROM public.app_modules WHERE module_key = 'ged')
+    AS ged_enabled_by_default_before,
+  (SELECT is_active FROM public.app_modules WHERE module_key = 'ged')
+    AS ged_is_active_before,
+  (SELECT count(*)::int FROM public.app_module_user_access WHERE module_key IN (
+    'pieces-techniques', 'finitions', 'methodes-centres-frais', 'methodes-parc-machines', 'ged'
+  ))
+    AS preserved_named_overrides_count;

--- a/db/patches/support/20260730_repair_module_catalog_visibility_402.verify.sql
+++ b/db/patches/support/20260730_repair_module_catalog_visibility_402.verify.sql
@@ -1,0 +1,61 @@
+-- Vérification post-application — réparation catalogue de visibilité #402.
+\set ON_ERROR_STOP on
+
+DO $verify_guard$
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
+    RAISE EXCEPTION 'catalogue #402 refusé hors cerp_test/cerp_prod (base actuelle : %)', current_database();
+  END IF;
+END
+$verify_guard$;
+
+SELECT
+  current_database() AS database_name,
+  EXISTS (SELECT 1 FROM public.app_modules
+    WHERE module_key = 'pieces-techniques'
+      AND api_prefixes = ARRAY['/pieces-techniques', '/piece-technique-versions', '/gammes', '/dossiers']
+      AND nav_page_keys = ARRAY['pieces-techniques']
+  ) AS pieces_techniques_catalog_complete,
+  EXISTS (SELECT 1 FROM public.app_modules
+    WHERE module_key = 'finitions'
+      AND api_prefixes = ARRAY['/finitions']
+      AND nav_page_keys = ARRAY['finitions']
+      AND is_protected = false
+  ) AS finitions_catalog_complete,
+  EXISTS (SELECT 1 FROM public.app_modules
+    WHERE module_key = 'methodes-centres-frais'
+      AND api_prefixes = ARRAY['/methodes/centres-frais', '/centre-frais']
+      AND nav_page_keys = ARRAY['methodes-centres-frais']
+      AND is_protected = false
+  ) AS cost_centers_catalog_complete,
+  EXISTS (SELECT 1 FROM public.app_modules
+    WHERE module_key = 'methodes-parc-machines'
+      AND api_prefixes = ARRAY['/methodes/machines', '/methodes/familles-machine']
+      AND nav_page_keys = ARRAY['methodes-parc-machines']
+      AND is_protected = false
+  ) AS machine_park_catalog_complete,
+  EXISTS (
+    SELECT 1 FROM public.app_modules
+    WHERE module_key = 'ged'
+      AND '/ged' = ANY (api_prefixes)
+      AND 'ged' = ANY (nav_page_keys)
+      AND is_protected = false
+  ) AS ged_catalog_complete,
+  (
+    SELECT count(*)::int
+    FROM public.app_module_user_access
+    WHERE module_key IN (
+      'pieces-techniques', 'finitions', 'methodes-centres-frais', 'methodes-parc-machines', 'ged'
+    )
+  ) AS named_overrides_after;
+
+-- Contrôle d'hygiène : aucun tableau de catalogue ne doit introduire de doublon.
+SELECT
+  module_key,
+  cardinality(api_prefixes) AS api_prefixes_count,
+  (SELECT count(DISTINCT value) FROM unnest(api_prefixes) AS value) AS api_prefixes_distinct,
+  cardinality(nav_page_keys) AS nav_page_keys_count,
+  (SELECT count(DISTINCT value) FROM unnest(nav_page_keys) AS value) AS nav_page_keys_distinct
+FROM public.app_modules
+WHERE module_key IN ('pieces-techniques', 'finitions', 'methodes-centres-frais', 'methodes-parc-machines', 'ged')
+ORDER BY module_key;

--- a/db/patches/support/20260730_surface_finish_family_comment_244.preflight.sql
+++ b/db/patches/support/20260730_surface_finish_family_comment_244.preflight.sql
@@ -1,0 +1,12 @@
+-- #244 preflight -- lecture seule, a executer avant la migration.
+\set ON_ERROR_STOP on
+
+SELECT
+  current_database() AS database_name,
+  to_regclass('public.surface_finish_families') IS NOT NULL AS families_table_exists,
+  EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'surface_finish_families'
+      AND column_name = 'commentaire_template'
+  ) AS comment_column_already_exists;

--- a/db/patches/support/20260730_surface_finish_family_comment_244.verify.sql
+++ b/db/patches/support/20260730_surface_finish_family_comment_244.verify.sql
@@ -1,0 +1,18 @@
+-- #244 verify -- lecture seule, a executer apres la migration.
+\set ON_ERROR_STOP on
+
+SELECT
+  current_database() AS database_name,
+  EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'surface_finish_families'
+      AND column_name = 'commentaire_template'
+  ) AS comment_column_exists,
+  EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'surface_finish_families_commentaire_template_length_check'
+      AND conrelid = 'public.surface_finish_families'::regclass
+  ) AS length_check_exists,
+  COUNT(*) FILTER (WHERE commentaire_template IS NOT NULL) AS configured_families
+FROM public.surface_finish_families;

--- a/docs/articles-master-data-164.md
+++ b/docs/articles-master-data-164.md
@@ -98,3 +98,17 @@ Validation du 29 juillet 2026 sur `cerp_test` :
 
 La migration de production reste une décision humaine distincte. Le patch n'a
 pas été appliqué à `cerp_prod`.
+
+## Classification primaire et validations conditionnelles (#401)
+
+`articles.article_category` reste la classification primaire explicite et
+autoritaire. `article_categories` décrit les usages métier secondaires mais ne
+peut plus reclasser silencieusement un Article selon un ordre de priorité.
+
+- une PF exige une PT et utilise la famille technique interne `PT` ;
+- une PT est interdite sur les catégories achat, matière et traitement ;
+- `article_matiere` est accepté uniquement pour une matière ;
+- un PATCH matière qui ne renvoie pas `article_matiere` conserve les détails
+  existants au lieu de les effacer ;
+- les contrôles sont répétés côté serveur : le masquage d’un champ frontend ne
+  constitue jamais une validation métier.

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -466,6 +466,29 @@ l'infrastructure existe, la décision redevient fermée par défaut.
 État au 2026-07-27 : patch, scripts de support et seed **écrits et versionnés,
 appliqués sur aucune base**. Ni `cerp_test` ni `cerp_prod` n'ont été modifiés.
 
+## Issue #402 - Granularité des modules récents dans la Tour d'accès
+
+Le patch `20260730_repair_module_catalog_visibility_402.sql` fait apparaître
+séparément dans la matrice d'habilitation : **Pièces techniques**,
+**Bibliothèque de finitions**, **Méthodes — Centres de frais**, **Méthodes — Parc
+machine** et **Gestion documentaire**. Les nouveaux espaces sont ainsi réglables
+compte par compte, sans donner accès à toute la rubrique Données techniques.
+
+Le patch est transactionnel et idempotent. Les nouveaux modules héritent une seule
+fois de l'état actif et du défaut historique de `pieces-techniques`; il ne réécrit
+jamais ensuite leurs paramètres d'exploitation. Les overrides existants sur les
+nouvelles clés sont conservés, et un override historique de `pieces-techniques`
+est recopié vers les trois sous-espaces seulement lorsqu'aucun réglage dédié ne le
+remplace. Aucun droit métier, donnée industrielle ou compte utilisateur n'est créé.
+
+Ordre de recette : préflight #402, sauvegarde et application sur `cerp_test`,
+verify #402, contrôle navigateur de la Tour d'accès avec un compte non superadmin,
+puis seulement le même enchaînement sur `cerp_prod` après validation humaine. Les
+scripts de préflight et de vérification refusent toute autre base. Le backend qui
+porte le nouveau catalogue doit être redémarré dans la même fenêtre que le patch :
+le résolveur de routes est volontairement côté code et ne doit pas cohabiter avec
+la version de catalogue précédente.
+
 ## Mentions légales obligatoires de l'entité émettrice
 
 Le patch `20260729_finance_legal_mentions.sql` fait suite au rendu unique des pièces

--- a/docs/module-access-catalog.md
+++ b/docs/module-access-catalog.md
@@ -1,0 +1,39 @@
+# Catalogue de visibilité des modules
+
+Le contrôle de visibilité par compte repose sur `public.app_modules` et
+`public.app_module_user_access`. Il ne remplace pas les autorisations métier :
+les routes concernées gardent leurs contrôles RBAC propres.
+
+## Réparation #402
+
+Le patch `20260730_repair_module_catalog_visibility_402.sql` remet le catalogue
+persistant en cohérence avec le catalogue TypeScript :
+
+- les espaces **Pièces techniques**, **Bibliothèque de finitions**,
+  **Méthodes — Centres de frais** et **Méthodes — Parc machine** sont quatre
+  modules séparés dans la matrice. Un administrateur peut donc attribuer ou
+  refuser chacun d'eux indépendamment ;
+- la **Gestion documentaire** (`/ged`) devient un module distinct, actif par
+  défaut lorsqu'il est créé et non protégé ;
+- les choix déjà réalisés en exploitation (`enabled_by_default`, `is_active` et
+  les overrides nominatives) sont préservés. Au premier découpage, les trois
+  nouveaux modules Méthodes/Finitions héritent du défaut et de l'état actif de
+  `pieces-techniques`; un override nominatif historique est recopié seulement
+  si aucun override plus précis n'existe déjà.
+
+Les routes partagées de diagnostic de Méthodes restent hors de ce découpage ;
+elles ne donnent ni lecture métier ni droit d'écriture. Les routes de chaque
+espace, et leurs capacités métier propres, restent contrôlées par le backend.
+
+## Ordre de livraison
+
+Le catalogue TypeScript résout aussi les routes API. Le déploiement backend et
+le patch SQL doivent donc être appliqués dans une même fenêtre de maintenance :
+ne laissez jamais une version de code antérieure tourner entre le découpage SQL
+et le redémarrage de l'API. La recette démarre sur `cerp_test`, puis passe sur
+`cerp_prod` après sauvegarde et validation explicite.
+
+Le préflight et le verify se trouvent dans `db/patches/support/`. Ils doivent
+être exécutés sur `cerp_test` avant toute décision de déploiement. Le patch ne
+modifie aucune donnée métier, aucun compte et aucun flag du pilote Project
+Office ; son rollout utilisateur reste une décision séparée et contrôlée.

--- a/docs/surface-finish-family-comment-244.md
+++ b/docs/surface-finish-family-comment-244.md
@@ -1,0 +1,23 @@
+# #244 — Commentaire automatique par famille de finition
+
+## Objectif
+
+Une famille de finition peut désormais porter un `commentaire_template`. Il est
+ajouté par le serveur avant le modèle de commentaire de la révision lors de
+l'aperçu et de la confirmation d'un article de traitement.
+
+## Contrat
+
+- `POST /api/v1/finitions/familles` exige `library_draft_write`.
+- Charge : `code`, `label`, `description?`, `commentaire_template?`, `sort_order?`.
+- Le commentaire accepte la même liste blanche de variables que les modèles de
+  révision ; le serveur refuse toute variable inconnue.
+- Le code article demeure `ART-TRT-NNNNNN` et le code finition `FIN-NNNNNN`.
+- Une finition et sa révision restent brouillon jusqu'à leur validation : ce
+  paramétrage n'affaiblit aucune règle Qualité.
+
+## Migration
+
+`db/patches/20260730_surface_finish_family_comment_244.sql` est additive,
+idempotente et non exécutée. Les scripts `preflight` et `verify` associés sont
+en lecture seule.

--- a/src/__tests__/access-control.gate.test.ts
+++ b/src/__tests__/access-control.gate.test.ts
@@ -219,6 +219,29 @@ describe("Gate d'accès module — décisions", () => {
     expect(res.statusCode).toBe(403);
   });
 
+  it("la GED est filtrée par son module dédié pour les comptes non superadmin", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "ged", access: "DENIED" }),
+    ]);
+    const { res, next } = await run("/ged/documents");
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "Accès interdit" });
+  });
+
+  it("applique des décisions distinctes aux nouveaux modules techniques", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "finitions", access: "DENIED" }),
+      profileRow({ module_key: "methodes-centres-frais" }),
+      profileRow({ module_key: "methodes-parc-machines", access: "DENIED" }),
+    ]);
+
+    expect((await run("/finitions/search")).res.statusCode).toBe(403);
+    expect((await run("/methodes/centres-frais")).next).toHaveBeenCalledOnce();
+    expect((await run("/methodes/machines/parc")).res.statusCode).toBe(403);
+  });
+
   it("résout le profil une seule fois par compte grâce au cache", async () => {
     await run("/clients/1");
     await run("/clients/2");

--- a/src/__tests__/access-control.test.ts
+++ b/src/__tests__/access-control.test.ts
@@ -162,10 +162,10 @@ beforeEach(() => {
 });
 
 describe("Catalogue de modules #326", () => {
-  it("expose 20 modules aux clés et préfixes uniques, dont un seul protégé", () => {
-    expect(MODULE_CATALOG).toHaveLength(20);
+  it("expose 24 modules aux clés et préfixes uniques, dont un seul protégé", () => {
+    expect(MODULE_CATALOG).toHaveLength(24);
     const keys = MODULE_CATALOG.map((entry) => entry.module_key);
-    expect(new Set(keys).size).toBe(20);
+    expect(new Set(keys).size).toBe(24);
 
     const prefixes = MODULE_CATALOG.flatMap((entry) => entry.api_prefixes);
     expect(new Set(prefixes).size).toBe(prefixes.length);
@@ -182,6 +182,30 @@ describe("Catalogue de modules #326", () => {
     expect(resolveModuleKeyForPath("/commandes-fournisseurs/17")).toBe("commandes-fournisseurs");
     expect(resolveModuleKeyForPath("/piece-technique-versions/9")).toBe("pieces-techniques");
     expect(resolveModuleKeyForPath("/pieces-techniques/9")).toBe("pieces-techniques");
+    expect(resolveModuleKeyForPath("/finitions/9")).toBe("finitions");
+    expect(resolveModuleKeyForPath("/methodes/centres-frais/9")).toBe("methodes-centres-frais");
+    expect(resolveModuleKeyForPath("/methodes/machines/9")).toBe("methodes-parc-machines");
+    expect(resolveModuleKeyForPath("/methodes/familles-machine/9")).toBe("methodes-parc-machines");
+    expect(resolveModuleKeyForPath("/centre-frais/9")).toBe("methodes-centres-frais");
+    expect(resolveModuleKeyForPath("/ged/documents")).toBe("ged");
+  });
+
+  it("rend les nouveaux espaces sélectionnables séparément dans la tour d'accès", () => {
+    const technicalData = MODULE_CATALOG.find((entry) => entry.module_key === "pieces-techniques");
+    const finitions = MODULE_CATALOG.find((entry) => entry.module_key === "finitions");
+    const costCenters = MODULE_CATALOG.find((entry) => entry.module_key === "methodes-centres-frais");
+    const machines = MODULE_CATALOG.find((entry) => entry.module_key === "methodes-parc-machines");
+    const ged = MODULE_CATALOG.find((entry) => entry.module_key === "ged");
+
+    expect(technicalData?.nav_page_keys).toEqual(["pieces-techniques"]);
+    expect(finitions).toMatchObject({ nav_page_keys: ["finitions"], api_prefixes: ["/finitions"] });
+    expect(costCenters).toMatchObject({ nav_page_keys: ["methodes-centres-frais"] });
+    expect(machines).toMatchObject({ nav_page_keys: ["methodes-parc-machines"] });
+    expect(ged).toMatchObject({
+      is_protected: false,
+      api_prefixes: ["/ged"],
+      nav_page_keys: ["ged"],
+    });
   });
 
   it("accepte une URL complète et ignore la query string", () => {
@@ -199,7 +223,6 @@ describe("Catalogue de modules #326", () => {
       "/chat/threads",
       "/users/4",
       "/locks",
-      "/centre-frais",
       "/pieces-families",
       "/environment",
     ]) {

--- a/src/__tests__/article-category-primary-401.test.ts
+++ b/src/__tests__/article-category-primary-401.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("pg", () => ({
+  Pool: class {
+    on = vi.fn();
+    query = vi.fn();
+    connect = vi.fn();
+  },
+}));
+
+vi.mock("dotenv", () => ({ default: { config: vi.fn() } }));
+
+import {
+  normalizeArticleCategorySelection,
+  syncArticleSubtypeDetails,
+} from "../module/stock/repository/stock.repository";
+import { createArticleSchema, updateArticleSchema } from "../module/stock/validators/stock.validators";
+
+const PT_ID = "11111111-1111-4111-8111-111111111111";
+
+const validCases = [
+  {
+    label: "PF fabriquée",
+    body: {
+      designation: "Pièce fabriquée",
+      article_category: "fabrique" as const,
+      article_categories: ["piece_finie_fabriquee" as const],
+      family_code: "PT",
+      piece_technique_id: PT_ID,
+    },
+  },
+  {
+    label: "matière première",
+    body: {
+      designation: "Rond acier",
+      article_category: "matiere" as const,
+      article_categories: ["matiere_premiere" as const],
+      family_code: "RO",
+      article_matiere: {},
+    },
+  },
+  {
+    label: "traitement de surface",
+    body: {
+      designation: "Anodisation noire",
+      article_category: "traitement" as const,
+      article_categories: ["traitement_surface" as const],
+      family_code: "TRT",
+    },
+  },
+  {
+    label: "achat-revente",
+    body: {
+      designation: "Vis standard",
+      article_category: "achat" as const,
+      article_categories: ["achat_revente" as const],
+      family_code: "ACH",
+    },
+  },
+  {
+    label: "achat-transformé",
+    body: {
+      designation: "Brut transformé",
+      article_category: "achat" as const,
+      article_categories: ["achat_transforme" as const],
+      family_code: "ACH",
+    },
+  },
+  {
+    label: "sous-traitance",
+    body: {
+      designation: "Usinage sous-traité",
+      article_category: "achat" as const,
+      article_categories: ["sous_traitance" as const],
+      family_code: "ACH",
+    },
+  },
+];
+
+describe("#401 catégorie primaire Article", () => {
+  it.each(validCases)("accepte la création $label sans champ d'une autre catégorie", ({ body }) => {
+    expect(createArticleSchema.safeParse({ body }).success).toBe(true);
+  });
+
+  it("conserve la catégorie primaire explicite malgré des usages secondaires contradictoires", () => {
+    const selection = normalizeArticleCategorySelection("achat", [
+      "piece_finie_fabriquee",
+      "matiere_premiere",
+      "sous_traitance",
+    ]);
+
+    expect(selection.article_category).toBe("achat");
+    expect(selection.article_categories).toEqual([
+      "achat_revente",
+      "piece_finie_fabriquee",
+      "matiere_premiere",
+      "sous_traitance",
+    ]);
+  });
+
+  it("place le code métier associé à la catégorie primaire en première position", () => {
+    expect(normalizeArticleCategorySelection("traitement", ["achat_revente"]).article_categories).toEqual([
+      "traitement_surface",
+      "achat_revente",
+    ]);
+    expect(normalizeArticleCategorySelection("matiere", ["achat_transforme"]).article_categories).toEqual([
+      "matiere_premiere",
+      "achat_transforme",
+    ]);
+  });
+
+  it("interdit une PT hors PF et exige une PT pour une PF", () => {
+    expect(createArticleSchema.safeParse({
+      body: { ...validCases[2].body, piece_technique_id: PT_ID },
+    }).success).toBe(false);
+    expect(createArticleSchema.safeParse({
+      body: { designation: "PF incomplète", article_category: "fabrique", family_code: "PT" },
+    }).success).toBe(false);
+  });
+
+  it("interdit les détails matière hors matière, y compris lors d'une mise à jour explicitement catégorisée", () => {
+    expect(createArticleSchema.safeParse({
+      body: { ...validCases[3].body, article_matiere: {} },
+    }).success).toBe(false);
+    expect(updateArticleSchema.safeParse({
+      body: { expected_row_version: 1, article_category: "achat", article_matiere: {} },
+    }).success).toBe(false);
+  });
+
+  it("autorise un PATCH matière sans article_matiere afin de préserver les détails existants", () => {
+    expect(updateArticleSchema.safeParse({
+      body: { expected_row_version: 1, designation: "Rond acier corrigé" },
+    }).success).toBe(true);
+  });
+
+  it("préserve les détails matière lorsque le PATCH ne fournit pas article_matiere", async () => {
+    const queries: string[] = [];
+    const client = {
+      query: async (sql: string) => {
+        queries.push(sql);
+        if (sql.includes("information_schema.columns")) return { rows: [{ present: true }] };
+        return { rows: [] };
+      },
+    } as Parameters<typeof syncArticleSubtypeDetails>[0];
+
+    await syncArticleSubtypeDetails(client, {
+      article_id: PT_ID,
+      category: "matiere",
+      family_code: "RO",
+      piece_technique_id: null,
+    });
+
+    expect(queries.some((sql) => sql.includes("DELETE FROM public.articles_matiere"))).toBe(false);
+    const materialUpsert = queries.find((sql) => sql.includes("INSERT INTO public.articles_matiere"));
+    const materialUpsertText = materialUpsert ?? "";
+    expect(materialUpsertText).toContain("SET family_code = EXCLUDED.family_code");
+    expect(materialUpsertText).not.toContain("longueur_mm = EXCLUDED.longueur_mm");
+  });
+});

--- a/src/__tests__/article-category-primary-401.test.ts
+++ b/src/__tests__/article-category-primary-401.test.ts
@@ -151,7 +151,9 @@ describe("#401 catégorie primaire Article", () => {
     });
 
     expect(queries.some((sql) => sql.includes("DELETE FROM public.articles_matiere"))).toBe(false);
-    const materialUpsert = queries.find((sql) => sql.includes("INSERT INTO public.articles_matiere"));
+    const materialUpsert = queries.find((sql) =>
+      /INSERT INTO public\.articles_matiere\s*\(/.test(sql)
+    );
     const materialUpsertText = materialUpsert ?? "";
     expect(materialUpsertText).toContain("SET family_code = EXCLUDED.family_code");
     expect(materialUpsertText).not.toContain("longueur_mm = EXCLUDED.longueur_mm");

--- a/src/__tests__/module-catalog-visibility-402.migration-guards.test.ts
+++ b/src/__tests__/module-catalog-visibility-402.migration-guards.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const patch = readFileSync(
+  resolve(root, "db/patches/20260730_repair_module_catalog_visibility_402.sql"),
+  "utf8"
+);
+const preflight = readFileSync(
+  resolve(root, "db/patches/support/20260730_repair_module_catalog_visibility_402.preflight.sql"),
+  "utf8"
+);
+const verify = readFileSync(
+  resolve(root, "db/patches/support/20260730_repair_module_catalog_visibility_402.verify.sql"),
+  "utf8"
+);
+
+describe("#402 catalogue de visibilité des modules", () => {
+  it("est transactionnel et ne réécrit ni les choix d'exploitation ni les overrides", () => {
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("COMMIT;");
+    expect(patch).not.toMatch(/\benabled_by_default\s*=/i);
+    expect(patch).not.toMatch(/\bis_active\s*=/i);
+    expect(patch).toMatch(/\bINSERT\s+INTO\s+public\.app_module_user_access/i);
+    expect(patch).toContain("ON CONFLICT (user_id, module_key) DO NOTHING");
+    expect(patch).not.toMatch(/\bUPDATE\s+public\.app_module_user_access/i);
+    expect(patch).not.toMatch(/\bDELETE\s+FROM\s+public\.app_module_user_access/i);
+  });
+
+  it("corrige le vrai catalogue app_modules, sans revenir aux anciennes migrations access_modules", () => {
+    expect(patch).toContain("public.app_modules");
+    expect(patch).not.toContain("public.access_modules");
+    expect(patch).toContain("'/finitions'");
+    expect(patch).toContain("'methodes-centres-frais'");
+    expect(patch).toContain("'methodes-parc-machines'");
+  });
+
+  it("déclare une GED autonome, non protégée, sans modifier Project Office", () => {
+    expect(patch).toContain("'ged'");
+    expect(patch).toContain("ARRAY['/ged']");
+    expect(patch).toContain("is_protected = false");
+    expect(patch).toContain("Project Office");
+    expect(patch).not.toMatch(/PROJECT_OFFICE\s*=/);
+  });
+
+  it("fournit un préflight et un verify non destructifs, bornés aux bases CERP", () => {
+    for (const script of [preflight, verify]) {
+      expect(script).toContain("\\set ON_ERROR_STOP on");
+      expect(script).toContain("current_database() NOT IN ('cerp_test', 'cerp_prod')");
+      expect(script).not.toMatch(/\bINSERT\s+INTO\b/i);
+      expect(script).not.toMatch(/\bUPDATE\s+public\./i);
+      expect(script).not.toMatch(/\bDELETE\s+FROM\b/i);
+      expect(script).not.toMatch(/\bDROP\s+/i);
+    }
+    expect(preflight).toContain("technical_module_count <> 1");
+    expect(preflight).toContain("module_key = 'pieces-techniques'");
+  });
+});

--- a/src/__tests__/pieces-techniques-versions.test.ts
+++ b/src/__tests__/pieces-techniques-versions.test.ts
@@ -5,6 +5,7 @@ import {
   createVersionSchema,
   versionStatusSchema,
 } from "../module/pieces-techniques/validators/versions.validators"
+import { createPieceTechniqueSchema } from "../module/pieces-techniques/validators/pieces-techniques.validators"
 
 // GPAO B2.1 — règles de cycle de vie des versions.
 // (La règle "une seule APPLICABLE" est en plus garantie par l'index unique partiel DB
@@ -61,8 +62,29 @@ describe("Versions — validators", () => {
     expect(versionStatusSchema.safeParse({ body: { next_statut: "WRONG" } }).success).toBe(false)
   })
 
+  it("valide la publication avec une date SQL et refuse un datetime qui ferait échouer la transaction", () => {
+    expect(versionStatusSchema.safeParse({ body: { next_statut: "APPLICABLE", date_application: "2026-07-30" } }).success).toBe(true)
+    expect(versionStatusSchema.safeParse({ body: { next_statut: "APPLICABLE", date_application: "2026-07-30T10:00:00.000Z" } }).success).toBe(false)
+    expect(versionStatusSchema.safeParse({ body: { next_statut: "APPLICABLE", date_application: "2026-02-30" } }).success).toBe(false)
+  })
+
   it("create-next exige aussi un indice", () => {
     expect(createNextVersionSchema.safeParse({ body: { indice: "B", type_changement: "EVOLUTION" } }).success).toBe(true)
     expect(createNextVersionSchema.safeParse({ body: {} }).success).toBe(false)
+  })
+})
+
+describe("Pièce technique — famille interne PF", () => {
+  it("accepte la création sans famille : le serveur attribue la famille interne", () => {
+    const parsed = createPieceTechniqueSchema.safeParse({
+      body: {
+        client_id: "045",
+        name_piece: "Carter",
+        designation: "Carter aluminium",
+        plan_reference: "10233",
+        indice_externe: "A",
+      },
+    })
+    expect(parsed.success).toBe(true)
   })
 })

--- a/src/__tests__/surface-finish-244.family-comment.test.ts
+++ b/src/__tests__/surface-finish-244.family-comment.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const read = (relative: string) => readFileSync(resolve(root, relative), "utf8").replace(/\r\n?/g, "\n");
+
+const patch = read("db/patches/20260730_surface_finish_family_comment_244.sql");
+const preflight = read("db/patches/support/20260730_surface_finish_family_comment_244.preflight.sql");
+const verify = read("db/patches/support/20260730_surface_finish_family_comment_244.verify.sql");
+const library = read("src/module/surface-finish/repository/surface-finish-library.repository.ts");
+const resolution = read("src/module/surface-finish/repository/surface-finish-resolution.repository.ts");
+const routes = read("src/module/surface-finish/routes/surface-finish.routes.ts");
+
+describe("#244 commentaire de famille de finition", () => {
+  it("est additif, transactionnel et ne modifie aucun article existant", () => {
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("COMMIT;");
+    expect(patch).toMatch(/ADD COLUMN IF NOT EXISTS\s+commentaire_template\s+text NULL/i);
+    expect(patch).not.toMatch(/\bUPDATE\b|\bDELETE\b|\bINSERT\b/i);
+  });
+
+  it("borne le modèle et livre les contrôles de migration lecture seule", () => {
+    expect(patch).toContain("surface_finish_families_commentaire_template_length_check");
+    expect(patch).toContain("char_length(commentaire_template) <= 4000");
+    expect(preflight).toContain("\\set ON_ERROR_STOP on");
+    expect(verify).toContain("\\set ON_ERROR_STOP on");
+    expect(preflight).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/im);
+    expect(verify).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/im);
+    expect(verify).toContain("comment_column_exists");
+    expect(verify).toMatch(/configured_families\s*\nFROM public\.surface_finish_families;/);
+  });
+
+  it("compose le commentaire de famille dans le même rendu pour aperçu et confirmation", () => {
+    expect(resolution).toContain("fam.commentaire_template AS family_commentaire_template");
+    expect(resolution).toContain("LEFT JOIN public.surface_finish_families fam");
+    expect(resolution).toContain("[familyTemplate, revisionTemplate].filter(Boolean).join");
+    expect(routes).toContain('router.post(\n  "/familles",');
+    expect(routes).toContain('requireSurfaceFinishCapability("library_draft_write")');
+  });
+
+  it("crée la famille et sa trace d'audit dans une seule transaction", () => {
+    expect(library).toContain('await client.query("BEGIN")');
+    expect(library).toContain('await insertFinishAudit(client, audit, "finitions.family.create"');
+    expect(library).toContain('await client.query("COMMIT")');
+    expect(library).toContain('await client.query("ROLLBACK").catch');
+  });
+});

--- a/src/module/access-control/domain/module-catalog.ts
+++ b/src/module/access-control/domain/module-catalog.ts
@@ -108,26 +108,47 @@ export const MODULE_CATALOG: readonly ModuleCatalogEntry[] = [
   {
     module_key: "pieces-techniques",
     label: "Données techniques",
-    description: "Pièces techniques, versions, gammes, finitions et dossiers d’opération.",
+    description: "Pièces techniques, versions, gammes et dossiers d’opération.",
     category: "Production",
-    // `/finitions` (#210) rejoint le module Données techniques : la bibliothèque
-    // de finitions est un référentiel Méthodes, pas un module d'accès distinct.
-    // Idem `/methodes` : familles machine, centres de frais tarifés et sélecteur
-    // de machines sont les référentiels de la gamme, pas un module à part.
     api_prefixes: [
       "/pieces-techniques",
       "/piece-technique-versions",
       "/gammes",
-      "/finitions",
       "/dossiers",
-      "/methodes",
     ],
-    // `methodes-centres-frais` et `methodes-parc-machines` sont des pages de CE
-    // module : sans elles dans la liste, leurs entrées de navigation
-    // disparaîtraient pour tout compte filtré.
-    nav_page_keys: ["pieces-techniques", "methodes-centres-frais", "methodes-parc-machines"],
+    nav_page_keys: ["pieces-techniques"],
     is_protected: false,
     sort_order: 100,
+  },
+  {
+    module_key: "finitions",
+    label: "Bibliothèque de finitions",
+    description: "Référentiel contrôlé des traitements et finitions de surface.",
+    category: "Production",
+    api_prefixes: ["/finitions"],
+    nav_page_keys: ["finitions"],
+    is_protected: false,
+    sort_order: 101,
+  },
+  {
+    module_key: "methodes-centres-frais",
+    label: "Méthodes — Centres de frais",
+    description: "Centres de frais, tarifs versionnés et référentiel associé.",
+    category: "Production",
+    api_prefixes: ["/methodes/centres-frais", "/centre-frais"],
+    nav_page_keys: ["methodes-centres-frais"],
+    is_protected: false,
+    sort_order: 102,
+  },
+  {
+    module_key: "methodes-parc-machines",
+    label: "Méthodes — Parc machine",
+    description: "Qualification du parc machine et familles de machines.",
+    category: "Production",
+    api_prefixes: ["/methodes/machines", "/methodes/familles-machine"],
+    nav_page_keys: ["methodes-parc-machines"],
+    is_protected: false,
+    sort_order: 103,
   },
   {
     module_key: "production",
@@ -226,6 +247,16 @@ export const MODULE_CATALOG: readonly ModuleCatalogEntry[] = [
     nav_page_keys: ["import-assistant"],
     is_protected: false,
     sort_order: 190,
+  },
+  {
+    module_key: "ged",
+    label: "Gestion documentaire",
+    description: "Documents contrôlés, versions, classes documentaires et validations.",
+    category: "Système",
+    api_prefixes: ["/ged"],
+    nav_page_keys: ["ged"],
+    is_protected: false,
+    sort_order: 195,
   },
   {
     module_key: "administration",

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -1637,6 +1637,31 @@ async function lookupClientCompanyName(tx: Pick<PoolClient, "query">, clientId: 
   return typeof name === "string" && name.trim().length > 0 ? name.trim() : null;
 }
 
+/**
+ * La contrainte historique `pieces_techniques.famille_id NOT NULL` est conservée.
+ * Une PT créée par le nouveau parcours reçoit néanmoins une famille interne,
+ * stable et non exposée comme un choix métier : `PF` (pièce fabriquée).
+ */
+async function resolveInternalFabricatedFamilyId(tx: Pick<PoolClient, "query">): Promise<string> {
+  const result = await tx.query<{ id: string }>(
+    `SELECT id::text AS id
+       FROM public.pieces_families
+      WHERE upper(btrim(code)) = 'PF'
+      ORDER BY created_at ASC, id ASC
+      LIMIT 1
+      FOR SHARE`
+  );
+  const familyId = result.rows[0]?.id;
+  if (!familyId) {
+    throw new HttpError(
+      503,
+      "PIECE_TECHNIQUE_INTERNAL_FAMILY_MISSING",
+      "La famille interne PF est absente. Appliquez le patch de référentiel avant de créer une pièce technique."
+    );
+  }
+  return familyId;
+}
+
 export async function repoCreatePieceTechnique(
   body: CreatePieceTechniqueBodyDTO & {
     statut: PieceTechniqueStatut;
@@ -1648,6 +1673,9 @@ export async function repoCreatePieceTechnique(
   idempotencyKey?: string | null
 ): Promise<PieceTechnique> {
   const client = await db.connect();
+  // Conserve le hash historique : une clé déjà consommée avant #404 doit
+  // continuer à rejouer la même pièce, même si son ancien payload portait une
+  // famille choisie dans l'interface.
   const requestHash = crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex");
   try {
     await client.query("BEGIN");
@@ -1670,6 +1698,11 @@ export async function repoCreatePieceTechnique(
         return existing;
       }
     }
+
+    // Ne jamais réutiliser une famille envoyée par le navigateur : la famille
+    // d'une PT est un invariant serveur. Cette résolution arrive après le
+    // rejeu d'idempotence pour préserver les créations historiques.
+    const internalFamilyId = await resolveInternalFabricatedFamilyId(client);
 
     const actorUserId = audit.user_id;
     const createdBy = actorUserId;
@@ -1747,7 +1780,7 @@ export async function repoCreatePieceTechnique(
       clientIdForInsert,
       createdBy,
       updatedBy,
-      body.famille_id,
+      internalFamilyId,
       body.name_piece,
       generatedCode,
       body.designation,
@@ -2216,13 +2249,27 @@ export async function repoDeletePieceTechnique(id: string, audit: AuditContext):
       return false;
     }
 
+    const archivedCode = base.code_piece.startsWith("ARCH-") ? base.code_piece : `ARCH-${base.code_piece}`;
+    const collision = await client.query<{ id: string }>(
+      `SELECT id::text AS id
+         FROM pieces_techniques
+        WHERE code_piece = $2
+          AND id <> $1::uuid
+        LIMIT 1
+        FOR KEY SHARE`,
+      [id, archivedCode]
+    );
+    if (collision.rows[0]) {
+      throw new HttpError(409, "ARCHIVE_CODE_CONFLICT", "Le code archivé existe déjà ; la pièce n'a pas été supprimée.");
+    }
+
     const upd = await client.query(
       `
         UPDATE pieces_techniques
-        SET deleted_at = now(), deleted_by = $2, updated_at = now(), updated_by = $2
+        SET code_piece = $3, deleted_at = now(), deleted_by = $2, updated_at = now(), updated_by = $2
         WHERE id = $1::uuid AND deleted_at IS NULL
       `,
-      [id, audit.user_id]
+      [id, audit.user_id, archivedCode]
     );
     if ((upd.rowCount ?? 0) === 0) {
       await client.query("ROLLBACK");
@@ -2235,6 +2282,7 @@ export async function repoDeletePieceTechnique(id: string, audit: AuditContext):
       entity_id: id,
       details: {
         code_piece: base.code_piece,
+        archived_code_piece: archivedCode,
         designation: base.designation,
       },
     });

--- a/src/module/pieces-techniques/validators/pieces-techniques.validators.ts
+++ b/src/module/pieces-techniques/validators/pieces-techniques.validators.ts
@@ -186,7 +186,10 @@ export const createPieceTechniqueSchema = z.object({
     client_id: z.string().trim().min(1).max(3).optional().nullable(),
     code_client: z.string().trim().min(1).max(80).optional().nullable(),
     client_name: z.string().trim().min(1).max(200).optional().nullable(),
-    famille_id: uuid,
+    // Une pièce technique est par définition une pièce fabriquée. La famille
+    // technique interne est imposée par le serveur : le client ne doit plus la
+    // choisir, tout en restant tolérant aux anciens formulaires qui l'envoient.
+    famille_id: uuid.optional(),
     name_piece: z.string().trim().min(1, "Nom de pièce requis"),
     // Kept only to return a clear compatibility error to legacy callers.  It is
     // never accepted as the source of a final business code.

--- a/src/module/pieces-techniques/validators/versions.validators.ts
+++ b/src/module/pieces-techniques/validators/versions.validators.ts
@@ -39,7 +39,20 @@ export type UpdateVersionBodyDTO = z.infer<typeof updateVersionSchema>["body"]
 export const versionStatusSchema = z.object({
   body: z.object({
     next_statut: versionStatutSchema,
-    date_application: z.string().min(1).optional().nullable(),
+    // Empêche qu'une valeur d'interface non SQL (ex. datetime ISO) atteigne le
+    // cast `::date` de la transaction de publication et se transforme en 500.
+    date_application: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/, "Date d'application attendue au format YYYY-MM-DD")
+      .refine(
+        (value) => {
+          const parsed = new Date(`${value}T00:00:00.000Z`)
+          return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value
+        },
+        "Date d'application invalide"
+      )
+      .optional()
+      .nullable(),
     commentaire_validation: z.string().max(2000).optional().nullable(),
     expected_updated_at: z.string().min(1).optional(),
   }),

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -329,15 +329,6 @@ export function commandeClientSelectableCategoryCodes(): string[] {
   return ARTICLE_CATEGORY_OPTIONS.filter((option) => option.commande_client_selectable).map((option) => option.code);
 }
 
-const BUSINESS_TO_PRIMARY_CATEGORY: Record<ArticleBusinessCategory, ArticleCategory> = {
-  piece_finie_fabriquee: "fabrique",
-  matiere_premiere: "matiere",
-  traitement_surface: "traitement",
-  achat_revente: "achat",
-  achat_transforme: "achat",
-  sous_traitance: "achat",
-};
-
 type UploadedDocument = Express.Multer.File;
 
 function isPgUniqueViolation(err: unknown): boolean {
@@ -489,7 +480,7 @@ function normalizeArticleWorkflowStatus(value: string | null | undefined): "EN_D
   return normalized === "EN_DEVIS" ? "EN_DEVIS" : "VALIDE";
 }
 
-function normalizeArticleCategories(
+export function normalizeArticleCategories(
   requested: string[] | null | undefined,
   primaryCategory: ArticleCategory
 ): ArticleBusinessCategory[] {
@@ -515,11 +506,18 @@ function normalizeArticleCategories(
   return out;
 }
 
-function derivePrimaryCategoryFromBusinessCategories(categories: ArticleBusinessCategory[]): ArticleCategory {
-  if (categories.some((value) => BUSINESS_TO_PRIMARY_CATEGORY[value] === "fabrique")) return "fabrique";
-  if (categories.some((value) => BUSINESS_TO_PRIMARY_CATEGORY[value] === "matiere")) return "matiere";
-  if (categories.some((value) => BUSINESS_TO_PRIMARY_CATEGORY[value] === "traitement")) return "traitement";
-  return "achat";
+/**
+ * Keeps the primary category explicit and deterministic while allowing the
+ * category link table to hold secondary business uses.
+ */
+export function normalizeArticleCategorySelection(
+  primaryCategory: ArticleCategory,
+  requestedCategories: string[] | null | undefined
+): { article_category: ArticleCategory; article_categories: ArticleBusinessCategory[] } {
+  return {
+    article_category: primaryCategory,
+    article_categories: normalizeArticleCategories(requestedCategories, primaryCategory),
+  };
 }
 
 function expectedFabricatedArticleCodeFromPlan(planReference: string, planIndex: number): string {
@@ -642,8 +640,16 @@ async function normalizeArticleState(args: {
     return toBusinessArticleCategory(args.article_category, "achat");
   })();
   const requestedPrimaryCategory = toBusinessArticleCategory(args.article_category, categoryFromType);
-  const article_categories = normalizeArticleCategories(args.article_categories, requestedPrimaryCategory);
-  const article_category = derivePrimaryCategoryFromBusinessCategories(article_categories);
+  const categorySelection = normalizeArticleCategorySelection(requestedPrimaryCategory, args.article_categories);
+  /**
+   * `article_category` is the authoritative primary classification. Business
+   * categories are secondary uses and must never silently reclassify an
+   * Article just because one of them maps to another primary category.
+   *
+   * normalizeArticleCategories keeps the matching business category at index
+   * zero, which syncArticleCategories persists with is_primary = true.
+   */
+  const { article_category, article_categories } = categorySelection;
   const article_type = inferArticleType(article_category);
   const piece_technique_id = article_category === "fabrique" ? args.piece_technique_id : null;
   const requestedFamilyCode = normalizeFamilyCode(args.family_code, defaultFamilyCodeForCategory(article_category));
@@ -1324,7 +1330,7 @@ async function ensureArticleFamilyEntry(
   );
 }
 
-async function syncArticleSubtypeDetails(
+export async function syncArticleSubtypeDetails(
   client: Pick<PoolClient, "query">,
   args: {
     article_id: string;
@@ -3181,6 +3187,14 @@ export async function repoUpdateArticle(
       designation: patch.designation ?? current.designation,
       client,
     });
+
+    if (patch.article_matiere && normalized.article_category !== "matiere") {
+      throw new HttpError(
+        400,
+        "INVALID_ARTICLE",
+        "article_matiere is only allowed for article_category=matiere"
+      );
+    }
 
     if (current.stock_managed && !normalized.stock_managed) {
       await ensureArticleCanDisableStockManagement(client, id);

--- a/src/module/surface-finish/controllers/surface-finish.controller.ts
+++ b/src/module/surface-finish/controllers/surface-finish.controller.ts
@@ -12,6 +12,7 @@ import {
   attachRevisionDocumentSVC,
   capabilitiesSVC,
   confirmOperationFinishSVC,
+  createFinishFamilySVC,
   createFinishDraftSVC,
   createRevisionSVC,
   detachOperationFinishSVC,
@@ -100,6 +101,14 @@ function headerValue(req: Request, name: string): string | null {
 export const listFinishFamilies: RequestHandler = async (_req, res, next) => {
   try {
     res.json(await listFinishFamiliesSVC());
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const createFinishFamily: RequestHandler = async (req, res, next) => {
+  try {
+    res.status(201).json(await createFinishFamilySVC(req.body, buildAuditContext(req)));
   } catch (err) {
     next(err);
   }

--- a/src/module/surface-finish/repository/surface-finish-library.repository.ts
+++ b/src/module/surface-finish/repository/surface-finish-library.repository.ts
@@ -20,6 +20,7 @@ import {
 } from "../domain/surface-finish-policy";
 import type {
   AttachDocumentBodyDTO,
+  CreateFinishFamilyBodyDTO,
   CreateFinishBodyDTO,
   ListFinishesQueryDTO,
   RevisionPayloadDTO,
@@ -258,11 +259,46 @@ export async function insertFinishAudit(
 
 export async function repoListFinishFamilies(): Promise<SurfaceFinishFamily[]> {
   const res = await db.query<SurfaceFinishFamily>(
-    `SELECT code, label, description, sort_order, is_active
+    `SELECT code, label, description, commentaire_template, sort_order, is_active
      FROM public.surface_finish_families
      ORDER BY sort_order, label`
   );
   return res.rows;
+}
+
+/** Family parameterization is auditable and separate from a finish draft. */
+export async function repoCreateFinishFamily(
+  body: CreateFinishFamilyBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishFamily> {
+  assertTemplateVariablesAllowed(body.commentaire_template ?? "");
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const res = await client.query<SurfaceFinishFamily>(
+      `INSERT INTO public.surface_finish_families
+         (code, label, description, commentaire_template, sort_order, is_active)
+       VALUES ($1, $2, $3, $4, $5, true)
+       RETURNING code, label, description, commentaire_template, sort_order, is_active`,
+      [body.code, body.label, body.description, body.commentaire_template, body.sort_order]
+    );
+    const family = res.rows[0];
+    await insertFinishAudit(client, audit, "finitions.family.create", "surface_finish_family", family.code, {
+      code: family.code,
+      label: family.label,
+      has_commentaire_template: Boolean(family.commentaire_template),
+    });
+    await client.query("COMMIT");
+    return family;
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    if (typeof err === "object" && err !== null && (err as { code?: string }).code === "23505") {
+      throw new HttpError(409, "SURFACE_FINISH_FAMILY_DUPLICATE", "Une famille de finition porte dÃ©jÃ  ce code.");
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/module/surface-finish/repository/surface-finish-resolution.repository.ts
+++ b/src/module/surface-finish/repository/surface-finish-resolution.repository.ts
@@ -163,6 +163,7 @@ async function loadRevision(tx: Queryer, revisionId: string) {
       finish_designation: string;
       finish_family: string;
       finish_procede: string;
+      family_commentaire_template: string | null;
       finish_statut: SurfaceFinishStatus;
       finish_uuid: string;
     }
@@ -173,9 +174,11 @@ async function loadRevision(tx: Queryer, revisionId: string) {
             f.designation_courte  AS finish_designation,
             f.family_code         AS finish_family,
             f.procede             AS finish_procede,
+            fam.commentaire_template AS family_commentaire_template,
             f.statut              AS finish_statut
      FROM public.surface_finish_revisions r
      JOIN public.surface_finishes f ON f.id = r.finish_id
+     LEFT JOIN public.surface_finish_families fam ON fam.code = f.family_code
      WHERE r.id = $1::uuid`,
     [revisionId]
   );
@@ -188,6 +191,7 @@ async function loadRevision(tx: Queryer, revisionId: string) {
       code: row.finish_code,
       designation_courte: row.finish_designation,
       family_code: row.finish_family,
+      family_commentaire_template: row.family_commentaire_template,
       procede: row.finish_procede,
       statut: row.finish_statut,
     },
@@ -318,7 +322,7 @@ export type GenerationResult = {
  */
 export function generateTexts(params: {
   context: OperationFinishContext;
-  finish: { code: string; designation_courte: string };
+  finish: { code: string; designation_courte: string; family_commentaire_template?: string | null };
   revision: SurfaceFinishRevisionDetail;
   spec: CanonicalFinishSpec;
 }): GenerationResult {
@@ -337,7 +341,9 @@ export function generateTexts(params: {
     zones: spec.zones,
   });
 
-  const template = revision.commentaire_template ?? DEFAULT_COMMENT_TEMPLATE;
+  const familyTemplate = params.finish.family_commentaire_template?.trim() ?? "";
+  const revisionTemplate = revision.commentaire_template ?? DEFAULT_COMMENT_TEMPLATE;
+  const template = [familyTemplate, revisionTemplate].filter(Boolean).join("\n");
   const teinteAspect = [spec.teinte_ral ?? spec.couleur, spec.aspect].filter(Boolean).join(" / ") || null;
 
   const rendered = renderGeneratedComment(

--- a/src/module/surface-finish/routes/surface-finish.routes.ts
+++ b/src/module/surface-finish/routes/surface-finish.routes.ts
@@ -8,6 +8,7 @@ import {
   archiveFinish,
   attachRevisionDocument,
   createFinish,
+  createFinishFamily,
   createRevision,
   getFinish,
   listFinishes,
@@ -30,6 +31,7 @@ import {
   archiveFinishBodySchema,
   attachDocumentBodySchema,
   createFinishBodySchema,
+  createFinishFamilyBodySchema,
   createRevisionBodySchema,
   finishHistoryQuerySchema,
   listFinishesQuerySchema,
@@ -49,6 +51,12 @@ const router = Router();
 router.get("/capabilities", readCapabilities);
 
 router.get("/familles", requireSurfaceFinishCapability("library_read"), listFinishFamilies);
+router.post(
+  "/familles",
+  requireSurfaceFinishCapability("library_draft_write"),
+  validate(createFinishFamilyBodySchema),
+  createFinishFamily
+);
 
 // #226 — Contrôle des doublons. DÉCLARÉ AVANT `/:finishId` : les deux motifs
 // n'ont qu'un segment, et Express retient le premier inscrit — placé après,

--- a/src/module/surface-finish/services/surface-finish.service.ts
+++ b/src/module/surface-finish/services/surface-finish.service.ts
@@ -13,6 +13,7 @@ import {
 import {
   repoAttachRevisionDocument,
   repoCreateFinishDraft,
+  repoCreateFinishFamily,
   repoCreateRevision,
   repoGetFinish,
   repoListFinishes,
@@ -42,6 +43,7 @@ import {
 import type {
   ArchiveFinishBodyDTO,
   AttachDocumentBodyDTO,
+  CreateFinishFamilyBodyDTO,
   ConfirmFinishBodyDTO,
   CreateFinishBodyDTO,
   DetachFinishBodyDTO,
@@ -75,6 +77,13 @@ export type Actor = { user_id: number; role: string | null };
 
 export async function listFinishFamiliesSVC(): Promise<SurfaceFinishFamily[]> {
   return repoListFinishFamilies();
+}
+
+export async function createFinishFamilySVC(
+  body: CreateFinishFamilyBodyDTO,
+  audit: AuditContext
+): Promise<SurfaceFinishFamily> {
+  return repoCreateFinishFamily(body, audit);
 }
 
 export async function listFinishesSVC(

--- a/src/module/surface-finish/types/surface-finish.types.ts
+++ b/src/module/surface-finish/types/surface-finish.types.ts
@@ -14,6 +14,7 @@ export type SurfaceFinishFamily = {
   code: string;
   label: string;
   description: string | null;
+  commentaire_template: string | null;
   sort_order: number;
   is_active: boolean;
 };

--- a/src/module/surface-finish/validators/surface-finish.validators.ts
+++ b/src/module/surface-finish/validators/surface-finish.validators.ts
@@ -131,6 +131,23 @@ export const listFinishesQuerySchema = z.object({
 });
 export type ListFinishesQueryDTO = z.infer<typeof listFinishesQuerySchema>;
 
+const familyCode = z
+  .string()
+  .trim()
+  .toUpperCase()
+  .min(2)
+  .max(60)
+  .regex(/^[A-Z0-9_]+$/, "Le code famille accepte uniquement A-Z, 0-9 et _.");
+
+export const createFinishFamilyBodySchema = z.object({
+  code: familyCode,
+  label: shortText,
+  description: optionalText(2000),
+  commentaire_template: optionalText(4000),
+  sort_order: z.coerce.number().int().min(0).max(10_000).optional().default(100),
+});
+export type CreateFinishFamilyBodyDTO = z.infer<typeof createFinishFamilyBodySchema>;
+
 /* -------------------------------------------------------------------------- */
 /* Bibliothèque — contrôle des doublons (#226)                                 */
 /* -------------------------------------------------------------------------- */


### PR DESCRIPTION
Intègre les PR #245 à #249 après build TypeScript et 77 tests ciblés verts.

## Summary by Sourcery

Separate and harden technical master data flows for articles, pieces techniques, surface finishes, and access-control modules, including new PF family handling, GED and methods sub-modules visibility, and database patches to align catalog and comments.

New Features:
- Introduce an internal, non-user-selectable fabricated family PF for pieces techniques, while keeping idempotent creation semantics and archiving deleted pieces with collision-safe codes.
- Expose new dedicated modules for Finitions, Méthodes — Centres de frais, Méthodes — Parc machine, and GED in the access-control catalog and tour d’accès, with independent navigation and visibility.
- Add support for creating and auditing surface finish families with optional shared commentaire templates applied across generated treatment comments.
- Document and ship SQL patches and operational guides for module catalog repair, surface finish family comments, and internal PF family creation.

Bug Fixes:
- Validate version publication dates strictly as SQL YYYY-MM-DD values to avoid runtime errors during status change transactions.
- Ensure article_matiere details are only accepted and updated for articles with primary category matière, preserving existing material details when omitted in updates.
- Prevent archived pieces techniques from reusing existing codes by prefixing and verifying ARCH- codes before deletion.

Enhancements:
- Make article_category the explicit primary classification and treat article_categories as secondary business uses via a deterministic normalization helper, avoiding implicit reclassification.
- Export and reuse helpers for article category selection and subtype details syncing to support stronger validations and tests.
- Allow pieces techniques creation requests to omit famille_id, treating it as server-enforced invariant while remaining compatible with legacy payloads.
- Enrich surface finish revision resolution to combine family-level and revision-level commentaire templates for consistent preview and confirmation texts.
- Refine module catalog tests and gate logic to ensure new technical and GED modules are individually controllable for non-superadmin accounts.

Documentation:
- Add dedicated documentation for the module access catalog and its repair process, including rollout sequencing and separation of technical spaces and GED.
- Extend articles master data documentation to clarify primary classification rules, PF/PT requirements, matière-only constraints, and server-side enforcement.
- Document the new surface finish family comment feature, including API contract, variable whitelist, and non-impact on existing quality rules.
- Update database patches documentation to describe the #402 module catalog repair behavior and operational steps for preflight, application, and verification.

Tests:
- Add comprehensive tests around article primary category behavior, PF/PT constraints, matière-only validations, and preservation of material details on partial updates.
- Extend access-control catalog and gate tests to cover new modules, route resolution, visibility counts, and distinct decisions in the tour d’accès.
- Introduce migration guard tests verifying that module catalog and surface finish patches are transactional, additive, idempotent, and limited to CERP environments.
- Add tests for pieces techniques validators to accept family-less creation and for version status validators to enforce valid SQL date formats for application.
- Add tests ensuring surface finish family comments are wired through patches, repositories, routes, and rendering logic without altering existing finishes.