### PR TITLE
test(articles): verrouiller le contrat article_matiere

### DIFF
--- a/src/__tests__/article-category-primary-401.test.ts
+++ b/src/__tests__/article-category-primary-401.test.ts
@@ -118,6 +118,13 @@ describe("#401 catégorie primaire Article", () => {
     }).success).toBe(false);
   });
 
+  it("accepte une PF sans article_matiere mais refuse explicitement article_matiere=null", () => {
+    expect(createArticleSchema.safeParse({ body: validCases[0].body }).success).toBe(true);
+    expect(createArticleSchema.safeParse({
+      body: { ...validCases[0].body, article_matiere: null },
+    }).success).toBe(false);
+  });
+
   it("interdit les détails matière hors matière, y compris lors d'une mise à jour explicitement catégorisée", () => {
     expect(createArticleSchema.safeParse({
       body: { ...validCases[3].body, article_matiere: {} },


### PR DESCRIPTION
## Contrat verrouillé

Ajoute une régression ciblée confirmant qu’une pièce fabriquée est valide lorsque `article_matiere` est absent, et que `article_matiere: null` reste explicitement refusé.

Le runtime backend ne change pas : cette PR documente et protège le contrat auquel le frontend doit se conformer.

## Validation

- 13 tests ciblés passés
- build TypeScript passé

Référence : BigFootLime/crp-systems-web#401

## Summary by Sourcery

Tests:
- Add a regression test ensuring manufactured articles remain valid without article_matiere while explicitly rejecting article_matiere: null.