### PR TITLE
release: verrouiller le contrat article_matiere

### DIFF
--- a/src/__tests__/article-category-primary-401.test.ts
+++ b/src/__tests__/article-category-primary-401.test.ts
@@ -118,6 +118,13 @@ describe("#401 catégorie primaire Article", () => {
     }).success).toBe(false);
   });
 
+  it("accepte une PF sans article_matiere mais refuse explicitement article_matiere=null", () => {
+    expect(createArticleSchema.safeParse({ body: validCases[0].body }).success).toBe(true);
+    expect(createArticleSchema.safeParse({
+      body: { ...validCases[0].body, article_matiere: null },
+    }).success).toBe(false);
+  });
+
   it("interdit les détails matière hors matière, y compris lors d'une mise à jour explicitement catégorisée", () => {
     expect(createArticleSchema.safeParse({
       body: { ...validCases[3].body, article_matiere: {} },


### PR DESCRIPTION
## Livraison

Livre le test de contrat confirmant qu’une PF sans `article_matiere` est valide et que la valeur explicite `null` reste refusée.

Aucun changement de schéma ni migration SQL.

## Validation

- 13 tests ciblés passés
- build TypeScript passé
- PR d’intégration : #251

Référence : BigFootLime/crp-systems-web#401

## Summary by Sourcery

Tests:
- Add a test ensuring a PF without article_matiere is accepted while an explicit article_matiere: null is rejected.