### PR TITLE
release: pièces techniques sans famille (#413)

### DIFF
--- a/db/patches/20260730_piece_technique_family_nullable_413.sql
+++ b/db/patches/20260730_piece_technique_family_nullable_413.sql
@@ -1,0 +1,17 @@
+-- #413 — une pièce technique / pièce fabriquée ne porte pas de famille métier.
+-- Migration additive et idempotente : les liens historiques sont conservés,
+-- seules les nouvelles PT peuvent désormais enregistrer famille_id = NULL.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.pieces_techniques') IS NULL THEN
+    RAISE EXCEPTION 'Pré-requis absent: public.pieces_techniques';
+  END IF;
+END $$;
+
+ALTER TABLE public.pieces_techniques
+  ALTER COLUMN famille_id DROP NOT NULL;
+
+COMMIT;

--- a/db/patches/support/20260730_piece_technique_family_nullable_413.preflight.sql
+++ b/db/patches/support/20260730_piece_technique_family_nullable_413.preflight.sql
@@ -1,0 +1,27 @@
+-- #413 — lecture seule avant application.
+SELECT current_database() AS database, current_user AS role, now() AS checked_at;
+
+DO $$
+BEGIN
+  IF to_regclass('public.pieces_techniques') IS NULL THEN
+    RAISE EXCEPTION 'Pré-vol #413 impossible : public.pieces_techniques est absente';
+  END IF;
+END
+$$;
+
+SELECT
+  table_schema,
+  table_name,
+  column_name,
+  is_nullable,
+  data_type
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'pieces_techniques'
+  AND column_name = 'famille_id';
+
+SELECT
+  count(*) AS total_pieces_techniques,
+  count(*) FILTER (WHERE famille_id IS NULL) AS sans_famille,
+  count(*) FILTER (WHERE famille_id IS NOT NULL) AS avec_famille
+FROM public.pieces_techniques;

--- a/db/patches/support/20260730_piece_technique_family_nullable_413.rollback.sql
+++ b/db/patches/support/20260730_piece_technique_family_nullable_413.rollback.sql
@@ -1,0 +1,21 @@
+-- #413 — rollback contrôlé.
+-- Refuse de rétablir NOT NULL si des PT sans famille ont déjà été créées.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.pieces_techniques
+    WHERE famille_id IS NULL
+  ) THEN
+    RAISE EXCEPTION
+      'Rollback #413 impossible: des pièces techniques sans famille existent';
+  END IF;
+END $$;
+
+ALTER TABLE public.pieces_techniques
+  ALTER COLUMN famille_id SET NOT NULL;
+
+COMMIT;

--- a/db/patches/support/20260730_piece_technique_family_nullable_413.verify.sql
+++ b/db/patches/support/20260730_piece_technique_family_nullable_413.verify.sql
@@ -1,0 +1,23 @@
+-- #413 — lecture seule après application.
+SELECT
+  is_nullable = 'YES' AS famille_id_nullable,
+  data_type
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'pieces_techniques'
+  AND column_name = 'famille_id';
+
+SELECT
+  count(*) AS total_pieces_techniques,
+  count(*) FILTER (WHERE famille_id IS NULL) AS sans_famille,
+  count(*) FILTER (WHERE famille_id IS NOT NULL) AS historiques_avec_famille
+FROM public.pieces_techniques;
+
+SELECT
+  EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conrelid = 'public.pieces_techniques'::regclass
+      AND contype = 'f'
+      AND pg_get_constraintdef(oid) ILIKE '%famille_id%'
+  ) AS foreign_key_preserved;

--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -514,6 +514,7 @@ describe("/api/v1/commandes", () => {
 
     expect(pieceCreateCalls.length).toBe(1);
     expect(articleCreateCalls.length).toBe(1);
+    expect(pieceCreateCalls[0]?.[1]).not.toContain("33333333-3333-3333-3333-333333333333");
   });
 
   it("PATCH /api/v1/commandes/:id works and replaces lignes", async () => {

--- a/src/__tests__/import-assistant.domain.test.ts
+++ b/src/__tests__/import-assistant.domain.test.ts
@@ -313,6 +313,14 @@ describe("Assistant d’import CLIPPER", () => {
     expect(articles).toBeLessThan(pieces);
   });
 
+  it("does not require a family for technical-piece imports", () => {
+    const pieceCapability = IMPORT_CAPABILITIES.find((item) => item.entity_type === "PIECE_TECHNIQUE");
+    const family = pieceCapability?.fields.find((item) => item.key === "famille_id");
+
+    expect(family?.required).not.toBe(true);
+    expect(family?.label).toMatch(/ignorée/i);
+  });
+
   it("marque l’adresse fournisseur importée comme adresse principale", () => {
     const mapping: ImportMapping = {
       legacy_key_column: "CODE",

--- a/src/__tests__/piece-technique-family-nullable-413.migration.test.ts
+++ b/src/__tests__/piece-technique-family-nullable-413.migration.test.ts
@@ -1,0 +1,64 @@
+import fs from "node:fs"
+import path from "node:path"
+
+import { describe, expect, it } from "vitest"
+
+const PATCH_DIR = path.resolve(__dirname, "../../db/patches")
+const SUPPORT_DIR = path.join(PATCH_DIR, "support")
+const PATCH = path.join(PATCH_DIR, "20260730_piece_technique_family_nullable_413.sql")
+const PREFLIGHT = path.join(SUPPORT_DIR, "20260730_piece_technique_family_nullable_413.preflight.sql")
+const VERIFY = path.join(SUPPORT_DIR, "20260730_piece_technique_family_nullable_413.verify.sql")
+const ROLLBACK = path.join(SUPPORT_DIR, "20260730_piece_technique_family_nullable_413.rollback.sql")
+
+function executable(source: string): string {
+  return source
+    .split("\n")
+    .filter((line) => !line.trimStart().startsWith("--"))
+    .join("\n")
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+}
+
+describe("#413 — famille PT nullable", () => {
+  it("ne modifie aucune donnée historique et retire uniquement NOT NULL", () => {
+    const sql = executable(fs.readFileSync(PATCH, "utf8"))
+    expect(sql).toMatch(/ALTER TABLE public\.pieces_techniques[\s\S]*ALTER COLUMN famille_id DROP NOT NULL/i)
+    expect(sql).not.toMatch(/\b(INSERT|UPDATE|DELETE|TRUNCATE)\b/i)
+    expect(sql.trimStart().startsWith("BEGIN;")).toBe(true)
+    expect(sql.trimEnd().endsWith("COMMIT;")).toBe(true)
+  })
+
+  it("fournit les contrôles preflight, verify et rollback", () => {
+    for (const file of [PREFLIGHT, VERIFY, ROLLBACK]) {
+      expect(fs.existsSync(file)).toBe(true)
+    }
+    expect(executable(fs.readFileSync(PREFLIGHT, "utf8"))).not.toMatch(
+      /\b(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP)\b/i
+    )
+    expect(fs.readFileSync(PREFLIGHT, "utf8")).toMatch(/to_regclass\('public\.pieces_techniques'\)/i)
+    expect(executable(fs.readFileSync(VERIFY, "utf8"))).not.toMatch(
+      /\b(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP)\b/i
+    )
+  })
+
+  it("refuse un rollback dès qu'une PT sans famille existe", () => {
+    const rollback = fs.readFileSync(ROLLBACK, "utf8")
+    expect(rollback).toMatch(/WHERE famille_id IS NULL/i)
+    expect(rollback).toMatch(/RAISE EXCEPTION/i)
+    expect(rollback).toMatch(/ALTER COLUMN famille_id SET NOT NULL/i)
+  })
+  it("preserves historical families and neutralizes new PT flows", () => {
+    const repository = fs.readFileSync(
+      path.resolve(__dirname, "../module/pieces-techniques/repository/pieces-techniques.repository.ts"),
+      "utf8"
+    )
+    const promotion = fs.readFileSync(
+      path.resolve(__dirname, "../module/commande-client/repository/commande-client.repository.ts"),
+      "utf8"
+    )
+
+    expect(repository).not.toMatch(/if \(patch\.famille_id !== undefined\) sets\.push\("famille_id = NULL"\)/)
+    expect(repository).toMatch(/A duplicate is a new PT:[\s\S]*?null,/)
+    expect(promotion).not.toMatch(/maybeFamilleId/)
+    expect(promotion).toMatch(/famille_id,[\s\S]*?NULL,/)
+  })
+})

--- a/src/__tests__/pieces-techniques-versions.test.ts
+++ b/src/__tests__/pieces-techniques-versions.test.ts
@@ -5,7 +5,10 @@ import {
   createVersionSchema,
   versionStatusSchema,
 } from "../module/pieces-techniques/validators/versions.validators"
-import { createPieceTechniqueSchema } from "../module/pieces-techniques/validators/pieces-techniques.validators"
+import {
+  createPieceTechniqueSchema,
+  updatePieceTechniqueSchema,
+} from "../module/pieces-techniques/validators/pieces-techniques.validators"
 
 // GPAO B2.1 — règles de cycle de vie des versions.
 // (La règle "une seule APPLICABLE" est en plus garantie par l'index unique partiel DB
@@ -74,17 +77,35 @@ describe("Versions — validators", () => {
   })
 })
 
-describe("Pièce technique — famille interne PF", () => {
-  it("accepte la création sans famille : le serveur attribue la famille interne", () => {
+describe("Pièce technique — aucune famille métier (#413)", () => {
+  const validBody = {
+    client_id: "045",
+    name_piece: "Carter",
+    designation: "Carter aluminium",
+    plan_reference: "10233",
+    indice_externe: "A",
+  }
+
+  it("accepte la création sans famille", () => {
     const parsed = createPieceTechniqueSchema.safeParse({
-      body: {
-        client_id: "045",
-        name_piece: "Carter",
-        designation: "Carter aluminium",
-        plan_reference: "10233",
-        indice_externe: "A",
-      },
+      body: validBody,
     })
     expect(parsed.success).toBe(true)
+    if (parsed.success) expect(parsed.data.body.famille_id).toBeUndefined()
+  })
+
+  it("tolère le null et l'UUID des anciens clients sans les rendre obligatoires", () => {
+    expect(createPieceTechniqueSchema.safeParse({
+      body: { ...validBody, famille_id: null },
+    }).success).toBe(true)
+    expect(createPieceTechniqueSchema.safeParse({
+      body: { ...validBody, famille_id: "33333333-3333-4333-8333-333333333333" },
+    }).success).toBe(true)
+  })
+  it("accepts the legacy family field on PATCH without making it required", () => {
+    expect(updatePieceTechniqueSchema.safeParse({
+      body: { famille_id: "33333333-3333-4333-8333-333333333333" },
+    }).success).toBe(true)
+    expect(updatePieceTechniqueSchema.safeParse({ body: { famille_id: null } }).success).toBe(true)
   })
 })

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -473,7 +473,6 @@ async function ensureOfficialPieceFromPreparatory(
 
   if (!officialPieceId) {
     const payload = asRecord(dossier.payload);
-    const maybeFamilleId = typeof payload.famille_id === "string" ? payload.famille_id : null;
     const maybeClientId = typeof payload.client_id === "string" ? payload.client_id : null;
     const maybeCodeClient = typeof payload.code_client === "string" ? payload.code_client : null;
     const maybeClientName = typeof payload.client_name === "string" ? payload.client_name : null;
@@ -517,25 +516,24 @@ async function ensureOfficialPieceFromPreparatory(
           $2,
           NULL,
           NULL,
-          $3::uuid,
+          NULL,
+          $3,
           $4,
           $5,
           $6,
           $7,
-          $8,
           'ACTIVE',
           0,
           NULL,
           NULL,
+          $8,
           $9,
-          $10,
           false
         )
       `,
       [
         officialPieceId,
         maybeClientId,
-        maybeFamilleId,
         maybeNamePiece,
         dossier.code_piece,
         dossier.designation,

--- a/src/module/import-assistant/domain/import-capabilities.ts
+++ b/src/module/import-assistant/domain/import-capabilities.ts
@@ -174,7 +174,11 @@ const ARTICLE_FIELDS: ImportTargetField[] = [
 
 const PIECE_FIELDS: ImportTargetField[] = [
   field("client_id", "Code client CERP", "text", { required: true }),
-  field("famille_id", "Famille de pièce CERP", "uuid", { required: true }),
+  // #413 — Kept solely to accept historical CLIPPER files. It is optional and
+  // ignored when the technical piece is persisted.
+  field("famille_id", "Famille de pièce historique (ignorée)", "uuid", {
+    hint: "Optionnel pour les imports hérités ; cette valeur n'est pas appliquée à la pièce technique.",
+  }),
   field("name_piece", "Nom de pièce", "text", { required: true }),
   field("designation", "Désignation", "text", { required: true }),
   field("designation_2", "Désignation secondaire", "text"),

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -146,7 +146,7 @@ type PieceTechniqueCoreRow = {
   client_id: string | null;
   created_by: number | null;
   updated_by: number | null;
-  famille_id: string;
+  famille_id: string | null;
   name_piece: string;
   code_piece: string;
   designation: string;
@@ -1637,31 +1637,6 @@ async function lookupClientCompanyName(tx: Pick<PoolClient, "query">, clientId: 
   return typeof name === "string" && name.trim().length > 0 ? name.trim() : null;
 }
 
-/**
- * La contrainte historique `pieces_techniques.famille_id NOT NULL` est conservée.
- * Une PT créée par le nouveau parcours reçoit néanmoins une famille interne,
- * stable et non exposée comme un choix métier : `PF` (pièce fabriquée).
- */
-async function resolveInternalFabricatedFamilyId(tx: Pick<PoolClient, "query">): Promise<string> {
-  const result = await tx.query<{ id: string }>(
-    `SELECT id::text AS id
-       FROM public.pieces_families
-      WHERE upper(btrim(code)) = 'PF'
-      ORDER BY created_at ASC, id ASC
-      LIMIT 1
-      FOR SHARE`
-  );
-  const familyId = result.rows[0]?.id;
-  if (!familyId) {
-    throw new HttpError(
-      503,
-      "PIECE_TECHNIQUE_INTERNAL_FAMILY_MISSING",
-      "La famille interne PF est absente. Appliquez le patch de référentiel avant de créer une pièce technique."
-    );
-  }
-  return familyId;
-}
-
 export async function repoCreatePieceTechnique(
   body: CreatePieceTechniqueBodyDTO & {
     statut: PieceTechniqueStatut;
@@ -1698,11 +1673,6 @@ export async function repoCreatePieceTechnique(
         return existing;
       }
     }
-
-    // Ne jamais réutiliser une famille envoyée par le navigateur : la famille
-    // d'une PT est un invariant serveur. Cette résolution arrive après le
-    // rejeu d'idempotence pour préserver les créations historiques.
-    const internalFamilyId = await resolveInternalFabricatedFamilyId(client);
 
     const actorUserId = audit.user_id;
     const createdBy = actorUserId;
@@ -1780,7 +1750,7 @@ export async function repoCreatePieceTechnique(
       clientIdForInsert,
       createdBy,
       updatedBy,
-      internalFamilyId,
+      null,
       body.name_piece,
       generatedCode,
       body.designation,
@@ -2166,7 +2136,9 @@ export async function repoUpdatePieceTechnique(
   if (patch.version_number !== undefined) sets.push(`version_number = ${push(patch.version_number)}::int`);
   if (patch.code_client !== undefined) sets.push(`code_client = ${push(patch.code_client)}`);
   if (patch.client_name !== undefined) sets.push(`client_name = ${push(patch.client_name)}`);
-  if (patch.famille_id !== undefined) sets.push(`famille_id = ${push(patch.famille_id)}::uuid`);
+  // #413 — Compatibility input only: an old client may still send `famille_id`,
+  // but a PATCH must never erase an historical family assignment. New PTs are
+  // created without a family (see the creation path).
   if (patch.name_piece !== undefined) sets.push(`name_piece = ${push(patch.name_piece)}`);
   if (patch.designation !== undefined) sets.push(`designation = ${push(patch.designation)}`);
   if (patch.designation_2 !== undefined) sets.push(`designation_2 = ${push(patch.designation_2)}`);
@@ -2532,7 +2504,8 @@ export async function repoDuplicatePieceTechnique(id: string, userId: number | n
             o.client_id,
             userId,
             userId,
-            o.famille_id,
+            // A duplicate is a new PT: do not propagate the historical family.
+            null,
             o.name_piece,
             code,
             o.designation,

--- a/src/module/pieces-techniques/types/pieces-techniques.types.ts
+++ b/src/module/pieces-techniques/types/pieces-techniques.types.ts
@@ -164,7 +164,7 @@ export type PieceTechnique = {
   created_by: number | null
   updated_by: number | null
 
-  famille_id: string
+  famille_id: string | null
   name_piece: string
   code_piece: string
   designation: string
@@ -198,7 +198,7 @@ export type CreatePieceTechniqueInput = {
   created_by?: number | null
   updated_by?: number | null
 
-  famille_id: string
+  famille_id?: string | null
   name_piece: string
   code_piece: string
   designation: string

--- a/src/module/pieces-techniques/validators/pieces-techniques.validators.ts
+++ b/src/module/pieces-techniques/validators/pieces-techniques.validators.ts
@@ -186,10 +186,9 @@ export const createPieceTechniqueSchema = z.object({
     client_id: z.string().trim().min(1).max(3).optional().nullable(),
     code_client: z.string().trim().min(1).max(80).optional().nullable(),
     client_name: z.string().trim().min(1).max(200).optional().nullable(),
-    // Une pièce technique est par définition une pièce fabriquée. La famille
-    // technique interne est imposée par le serveur : le client ne doit plus la
-    // choisir, tout en restant tolérant aux anciens formulaires qui l'envoient.
-    famille_id: uuid.optional(),
+    // #413 — Une pièce technique n'a pas de famille à saisir. Le champ reste
+    // toléré à l'entrée pour les anciens clients, mais le repository l'ignore.
+    famille_id: uuid.optional().nullable(),
     name_piece: z.string().trim().min(1, "Nom de pièce requis"),
     // Kept only to return a clear compatibility error to legacy callers.  It is
     // never accepted as the source of a final business code.
@@ -244,7 +243,9 @@ export const updatePieceTechniqueSchema = z.object({
     client_id: z.string().trim().min(1).max(3).optional().nullable(),
     code_client: z.string().trim().min(1).max(80).optional().nullable(),
     client_name: z.string().trim().min(1).max(200).optional().nullable(),
-    famille_id: uuid.optional(),
+    // Compatibilité de transport uniquement : toute valeur reçue est neutralisée
+    // par le repository afin qu'une PT ne porte plus de famille métier.
+    famille_id: uuid.optional().nullable(),
     name_piece: z.string().trim().min(1).optional(),
     designation: z.string().trim().min(1).optional(),
     designation_2: z.string().optional().nullable(),


### PR DESCRIPTION
Release contrôlée de dev vers main pour #413.

Contenu vérifié : uniquement la persistance PT sans famille, les compatibilités héritées, la migration additive nullable et ses garde-fous.

Validation locale : 57 tests ciblés et build TypeScript. Les 3 échecs de la suite globale concernent les attentes RBAC du test pieces-techniques.routes, inchangées par ce diff et déjà présentes sur la base.

## Summary by Sourcery

Make technical piece families optional and neutralize new flows so pieces can be created without a business family while preserving historical data and enabling a controlled nullable migration.

New Features:
- Allow creation and update of technical pieces without requiring a famille_id and treat the field as optional, legacy-only input.
- Relax CLIPPER import capabilities so technical-piece imports no longer require a family while still accepting legacy files.

Enhancements:
- Adjust repositories and type definitions so newly created and duplicated technical pieces are persisted without a family and legacy famille_id values are ignored.
- Add targeted tests to validate validator behavior, import capabilities, repository promotion logic, and the controlled nullable migration behavior for famille_id.

Deployment:
- Add SQL migration and support scripts to drop the NOT NULL constraint on pieces_techniques.famille_id while preserving foreign keys and enforcing safe rollback conditions.

Tests:
- Introduce migration tests ensuring the famille_id column on pieces_techniques becomes nullable via an additive, guarded patch with preflight, verify, and rollback scripts.
- Extend domain and route tests to assert that famille_id is optional for imports and no historical family IDs are propagated in new technical-piece creations and duplications.