### PR TITLE
fix(methodes): validate Express route parameters (#170)

### DIFF
--- a/src/__tests__/gamme-operations.validators.test.ts
+++ b/src/__tests__/gamme-operations.validators.test.ts
@@ -13,6 +13,8 @@ import {
   createFamilySchema,
   listMachineOptionsQuerySchema,
 } from "../module/methodes/validators/methodes.validators"
+import { requiredRouteParam } from "../module/methodes/controllers/methodes.controller"
+import { HttpError } from "../utils/httpError"
 
 describe("Opération de gamme — contrat d'entrée", () => {
   it("accepte le type DECOUPE sans retirer les types existants", () => {
@@ -75,6 +77,20 @@ describe("Opération de gamme — contrat d'entrée", () => {
 })
 
 describe("Référentiels Méthodes — contrat d'entrée", () => {
+  it("refuse les paramètres de route absents, multiples ou vides", () => {
+    const req = (params: Record<string, string | string[] | undefined>) => ({ params }) as never
+
+    expect(requiredRouteParam(req({ cfId: "  123  " }), "cfId")).toBe("  123  ")
+    for (const params of [{}, { cfId: ["123", "456"] }, { cfId: "   " }]) {
+      expect(() => requiredRouteParam(req(params), "cfId")).toThrow(HttpError)
+      try {
+        requiredRouteParam(req(params), "cfId")
+      } catch (error) {
+        expect(error).toMatchObject({ status: 400, code: "INVALID_ROUTE_PARAM" })
+      }
+    }
+  })
+
   it("impose un code de famille en majuscules sans espace", () => {
     const ok = createFamilySchema.safeParse({ code: "rectif cn", libelle: "Rectification" })
     expect(ok.success).toBe(false)

--- a/src/module/methodes/controllers/methodes.controller.ts
+++ b/src/module/methodes/controllers/methodes.controller.ts
@@ -60,6 +60,19 @@ export function buildMethodesAuditContext(req: Request): AuditContext {
   };
 }
 
+/**
+ * Express route parameters are typed as `string | string[]`. Route validators
+ * protect normal HTTP requests, but controllers must keep the same boundary
+ * when they are called by tests or by future route wiring.
+ */
+export function requiredRouteParam(req: Request, name: string): string {
+  const value = req.params[name];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new HttpError(400, "INVALID_ROUTE_PARAM", `Paramètre de route invalide : ${name}`);
+  }
+  return value;
+}
+
 /* -------------------------------------------------------------------------- */
 /* Capacités                                                                  */
 /* -------------------------------------------------------------------------- */
@@ -100,7 +113,7 @@ export const updateMachineFamily: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildMethodesAuditContext(req);
     const body = updateFamilySchema.parse(req.body);
-    const out = await updateMachineFamilySVC(String(req.params.code).toUpperCase(), body, audit);
+    const out = await updateMachineFamilySVC(requiredRouteParam(req, "code").toUpperCase(), body, audit);
     if (!out) throw new HttpError(404, "NOT_FOUND", "Famille machine introuvable");
     res.json(out);
   } catch (error) {
@@ -130,7 +143,7 @@ export const listCostCenters: RequestHandler = async (req, res, next) => {
 
 export const getCostCenter: RequestHandler = async (req, res, next) => {
   try {
-    const out = await getCostCenterSVC(req.params.cfId);
+    const out = await getCostCenterSVC(requiredRouteParam(req, "cfId"));
     if (!out) throw new HttpError(404, "NOT_FOUND", "Centre de frais introuvable");
     res.json(out);
   } catch (error) {
@@ -152,7 +165,7 @@ export const updateCostCenter: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildMethodesAuditContext(req);
     const body = updateCostCenterSchema.parse(req.body);
-    const out = await updateCostCenterSVC(req.params.cfId, body, audit);
+    const out = await updateCostCenterSVC(requiredRouteParam(req, "cfId"), body, audit);
     if (!out) throw new HttpError(404, "NOT_FOUND", "Centre de frais introuvable");
     res.json(out);
   } catch (error) {
@@ -162,7 +175,7 @@ export const updateCostCenter: RequestHandler = async (req, res, next) => {
 
 export const listCostCenterRates: RequestHandler = async (req, res, next) => {
   try {
-    res.json(await listCostCenterRatesSVC(req.params.cfId));
+    res.json(await listCostCenterRatesSVC(requiredRouteParam(req, "cfId")));
   } catch (error) {
     next(error);
   }
@@ -172,7 +185,7 @@ export const addCostCenterRate: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildMethodesAuditContext(req);
     const body = addCostCenterRateSchema.parse(req.body);
-    res.status(201).json(await addCostCenterRateSVC(req.params.cfId, body, audit));
+    res.status(201).json(await addCostCenterRateSVC(requiredRouteParam(req, "cfId"), body, audit));
   } catch (error) {
     next(error);
   }
@@ -218,7 +231,7 @@ export const listMachinesForQualification: RequestHandler = async (req, res, nex
 
 export const getMachineQualification: RequestHandler = async (req, res, next) => {
   try {
-    const out = await getMachineQualificationSVC(req.params.machineId);
+    const out = await getMachineQualificationSVC(requiredRouteParam(req, "machineId"));
     if (!out) throw new HttpError(404, "NOT_FOUND", "Machine introuvable");
     res.json(out);
   } catch (error) {
@@ -230,7 +243,10 @@ export const getMachineQualification: RequestHandler = async (req, res, next) =>
 export const previewMachineQualification: RequestHandler = async (req, res, next) => {
   try {
     const query = validatedQuery<ReturnType<(typeof previewMachineQualificationQuerySchema)["parse"]>>(req);
-    const out = await previewMachineQualificationSVC(req.params.machineId, query.machine_family_code ?? null);
+    const out = await previewMachineQualificationSVC(
+      requiredRouteParam(req, "machineId"),
+      query.machine_family_code ?? null
+    );
     if (!out) throw new HttpError(404, "NOT_FOUND", "Machine introuvable");
     res.json(out);
   } catch (error) {
@@ -243,7 +259,7 @@ export const qualifyMachine: RequestHandler = async (req, res, next) => {
     const audit = buildMethodesAuditContext(req);
     const body = qualifyMachineSchema.parse(req.body);
     const out = await qualifyMachineSVC(
-      req.params.machineId,
+      requiredRouteParam(req, "machineId"),
       {
         machine_family_code: body.machine_family_code,
         cf_id: body.cf_id,


### PR DESCRIPTION
Closes #170

## Correction
- normalise les paramètres Express string | string[]`n- refuse les paramètres absents, vides ou multiples avec HTTP 400
- couvre les huit routes Méthodes concernées

## Vérification
- tests ciblés : 14/14
- build TypeScript : réussi

## Summary by Sourcery

Validate and normalize Express route parameters for Méthodes controllers to reject invalid inputs with HTTP 400 and ensure consistent handling across affected routes.

Bug Fixes:
- Prevent Méthodes routes from accepting missing, empty, or multi-valued Express route parameters by enforcing a required single string value.

Enhancements:
- Introduce a shared helper for accessing required Express route parameters to standardize controller boundaries.

Tests:
- Add tests covering route parameter validation behavior for Méthodes referential endpoints, including rejection of invalid parameter shapes.