### PR TITLE
feat(stock): générer et figer les codes ART-FAB (#414)

### DIFF
--- a/docs/nomenclature-codes.md
+++ b/docs/nomenclature-codes.md
@@ -29,8 +29,9 @@ Le frontend peut afficher `hintText` + `example` et valider le champ cote client
 Les formats sont declares dans `src/shared/codes/code-validator.ts`.
 
 - Client: `CLI-001`
-- Pièce technique: `001-17025950000-C` (client, référence plan, indice externe)
-- Article: `ART-USI-000042` (séquence de six chiffres, famille explicite)
+- Pièce technique: `001-170-25464-001-C` (client, groupes de la référence plan, indice externe)
+- Article fabriqué: `ART-FAB-001-170-25464-001-C[-Vn]` (snapshot de la PT ; suffixe à partir de V2)
+- Article acheté: `ART-USI-000042` (séquence de six chiffres, famille explicite)
 - Devis: `DEV-2026-0001`
 - Commande client: `CMD-2026-0001`
 - Affaire: `AFF-2026-0001`
@@ -74,7 +75,8 @@ Points importants:
   référence historique de l'agrégat. Le code de travail d'une version est
   calculé uniquement à partir de `client + plan + indice externe` et exposé
   dans `piece_technique_versions.code_metier`; la recherche pièce couvre aussi
-  ce code de version.
+  ce code de version. Les séparateurs présents dans la référence plan sont
+  normalisés en tirets afin de conserver ses groupes lisibles.
 - BL/RF/NC/CAP reutilisent les generateurs/sequence existants en base (formats deja en prod).
 
 ## Smoke

--- a/src/__tests__/codification-business-codes.test.ts
+++ b/src/__tests__/codification-business-codes.test.ts
@@ -28,7 +28,15 @@ describe("Codification métier centralisée", () => {
       clientCode: "1",
       planReference: "1702595 0000",
       indiceExterne: "c-1",
-    })).toBe("001-17025950000-C1");
+    })).toBe("001-1702595-0000-C1");
+  });
+
+  it("conserve les groupes de la référence plan dans le code PT", () => {
+    expect(previewPieceTechniqueCode({
+      clientCode: "CLI-001",
+      planReference: "170 25464 001",
+      indiceExterne: "A",
+    })).toBe("001-170-25464-001-A");
   });
 
   it("réserve la séquence article dans PostgreSQL et ne reçoit pas le code final du client", async () => {
@@ -56,7 +64,7 @@ describe("Codification métier centralisée", () => {
     };
 
     await expect(generateFabricatedArticleBusinessCode(tx as never, "11111111-1111-4111-8111-111111111111"))
-      .resolves.toBe("ART-FAB-001-17025950000-A1");
+      .resolves.toBe("ART-FAB-001-1702595-0000-A1");
     expect(calls[0]?.sql).toContain("pv.statut = 'APPLICABLE'");
     expect(calls[0]?.values).toEqual(["11111111-1111-4111-8111-111111111111"]);
   });
@@ -75,7 +83,7 @@ describe("Codification métier centralisée", () => {
     };
 
     await expect(generateFabricatedArticleBusinessCode(tx as never, "22222222-2222-4222-8222-222222222222"))
-      .resolves.toBe("ART-FAB-002-PLAN42-B-V3");
+      .resolves.toBe("ART-FAB-002-PLAN-42-B-V3");
   });
 
   it("rejects a fabricated article when its technical piece has no client code", async () => {
@@ -151,9 +159,12 @@ describe("Codification métier centralisée", () => {
 
   it("expose les formats canoniques tout en gardant les références historiques lisibles", () => {
     expect(isValidCode("pieceTechnique", "001-17025950000-C")).toBe(true);
+    expect(isValidCode("pieceTechnique", "001-170-25464-001-C")).toBe(true);
     expect(isValidCode("article", "ART-USI-000042")).toBe(true);
     expect(isValidCode("article", "ART-FAB-001-17025950000-A")).toBe(true);
+    expect(isValidCode("article", "ART-FAB-001-170-25464-001-A")).toBe(true);
     expect(isValidCode("article", "ART-FAB-001-17025950000-A-V2")).toBe(true);
+    expect(isValidCode("article", "ART-FAB-001-170-25464-001-A-V2")).toBe(true);
     expect(isValidCode("article", "ART-FAB-001-17025950000-A-V10")).toBe(true);
     expect(isValidCode("article", "ART-FAB-001-17025950000-A-V1")).toBe(false);
     expect(isValidCode("commande", "CMD-2026-0007")).toBe(true);

--- a/src/__tests__/codification-business-codes.test.ts
+++ b/src/__tests__/codification-business-codes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   generateArticleBusinessCode,
+  generateFabricatedArticleBusinessCode,
   generateMachineCode,
   generateTransactionalBusinessCode,
   previewPieceTechniqueCode,
@@ -37,6 +38,102 @@ describe("Codification métier centralisée", () => {
     expect(calls[0]?.values).toEqual(["ART:USINAGE"]);
   });
 
+  it("generates a fabricated article code from the applicable technical-piece identity", async () => {
+    const calls: Array<{ sql: string; values: unknown[] | undefined }> = [];
+    const tx = {
+      query: async (sql: string, values?: unknown[]) => {
+        calls.push({ sql, values });
+        return {
+          rows: [{
+            piece_exists: true,
+            client_code: "CLI-001",
+            plan_reference: "1702595 0000",
+            indice: "a-1",
+            version_interne: 1,
+          }],
+        };
+      },
+    };
+
+    await expect(generateFabricatedArticleBusinessCode(tx as never, "11111111-1111-4111-8111-111111111111"))
+      .resolves.toBe("ART-FAB-001-17025950000-A1");
+    expect(calls[0]?.sql).toContain("pv.statut = 'APPLICABLE'");
+    expect(calls[0]?.values).toEqual(["11111111-1111-4111-8111-111111111111"]);
+  });
+
+  it("adds only an internal version above one to a fabricated article code", async () => {
+    const tx = {
+      query: async () => ({
+        rows: [{
+          piece_exists: true,
+          client_code: "002",
+          plan_reference: "PLAN-42",
+          indice: "B",
+          version_interne: 3,
+        }],
+      }),
+    };
+
+    await expect(generateFabricatedArticleBusinessCode(tx as never, "22222222-2222-4222-8222-222222222222"))
+      .resolves.toBe("ART-FAB-002-PLAN42-B-V3");
+  });
+
+  it("rejects a fabricated article when its technical piece has no client code", async () => {
+    const tx = {
+      query: async () => ({
+        rows: [{
+          piece_exists: true,
+          client_code: null,
+          plan_reference: "PLAN-42",
+          indice: "B",
+          version_interne: 1,
+        }],
+      }),
+    };
+
+    await expect(generateFabricatedArticleBusinessCode(tx as never, "33333333-3333-4333-8333-333333333333"))
+      .rejects.toMatchObject({ code: "CLIENT_CODE_REQUIRED" });
+  });
+
+  it.each([
+    {
+      label: "technical piece",
+      row: undefined,
+      code: "INVALID_PIECE_TECHNIQUE",
+    },
+    {
+      label: "plan reference",
+      row: {
+        piece_exists: true,
+        client_code: "001",
+        plan_reference: null,
+        indice: "A",
+        version_interne: 1,
+      },
+      code: "PLAN_REFERENCE_REQUIRED",
+    },
+    {
+      label: "external index",
+      row: {
+        piece_exists: true,
+        client_code: "001",
+        plan_reference: "PLAN-42",
+        indice: null,
+        version_interne: 1,
+      },
+      code: "INDEX_REQUIRED",
+    },
+  ])("rejects a fabricated article when its $label is missing", async ({ row, code }) => {
+    const tx = {
+      query: async () => ({ rows: row ? [row] : [] }),
+    };
+
+    await expect(generateFabricatedArticleBusinessCode(
+      tx as never,
+      "44444444-4444-4444-8444-444444444444"
+    )).rejects.toMatchObject({ code });
+  });
+
   it("produit les formats transactionnels DEV, CMD, AFF et OF avec les largeurs attendues", async () => {
     const date = new Date("2026-07-13T00:00:00.000Z");
     await expect(generateTransactionalBusinessCode(sequenceTx(7).tx as never, { prefix: "DEV", date })).resolves.toBe("DEV-2026-0007");
@@ -55,6 +152,10 @@ describe("Codification métier centralisée", () => {
   it("expose les formats canoniques tout en gardant les références historiques lisibles", () => {
     expect(isValidCode("pieceTechnique", "001-17025950000-C")).toBe(true);
     expect(isValidCode("article", "ART-USI-000042")).toBe(true);
+    expect(isValidCode("article", "ART-FAB-001-17025950000-A")).toBe(true);
+    expect(isValidCode("article", "ART-FAB-001-17025950000-A-V2")).toBe(true);
+    expect(isValidCode("article", "ART-FAB-001-17025950000-A-V10")).toBe(true);
+    expect(isValidCode("article", "ART-FAB-001-17025950000-A-V1")).toBe(false);
     expect(isValidCode("commande", "CMD-2026-0007")).toBe(true);
     expect(isValidCode("of", "OF-2026-000007")).toBe(true);
     expect(isValidCode("commande", "CC-123")).toBe(true);

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -157,7 +157,7 @@ describe("/api/v1/stock", () => {
           plan_index: 1,
           status: "VALIDE",
           projet_id: null,
-          code: "ART-FAB-001-PT001-A",
+          code: "ART-FAB-001-PT-001-A",
           designation: "Pièce stockée",
           article_type: "PIECE_TECHNIQUE",
           article_category: "fabrique",
@@ -201,7 +201,7 @@ describe("/api/v1/stock", () => {
     expect(res.body).toMatchObject({ article_category: "fabrique", family_code: "PT", stock_managed: true });
     expect(
       mocks.clientQuery.mock.calls.some((call) =>
-        Array.isArray(call[1]) && call[1].includes("ART-FAB-001-PT001-A")
+        Array.isArray(call[1]) && call[1].includes("ART-FAB-001-PT-001-A")
       )
     ).toBe(true);
     expect(
@@ -262,6 +262,86 @@ describe("/api/v1/stock", () => {
     expect(
       mocks.clientQuery.mock.calls.some((call) =>
         String(call[0]).includes("UPDATE public.articles")
+      )
+    ).toBe(false);
+  });
+
+  it("PATCH /api/v1/stock/articles/:id preserves the fabricated code without rereading the technical piece", async () => {
+    const articleId = "11111111-1111-1111-1111-111111111111";
+    const pieceTechniqueId = "22222222-2222-2222-2222-222222222222";
+    const immutableCode = "ART-FAB-001-170-25464-001-A";
+
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q.includes("FROM public.pieces_techniques pt") && q.includes("LEFT JOIN LATERAL")) {
+        throw new Error("A normal fabricated-article PATCH must not recalculate its immutable code");
+      }
+      if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM public.articles") && q.includes("FOR UPDATE")) {
+        return {
+          rows: [{
+            id: articleId,
+            code: immutableCode,
+            designation: "Pièce fabriquée",
+            article_type: "PIECE_TECHNIQUE",
+            article_category: "fabrique",
+            article_categories: ["fabrique"],
+            root_article_id: articleId,
+            version_number: 1,
+            plan_index: 1,
+            status: "VALIDE",
+            projet_id: null,
+            family_code: "PT",
+            piece_technique_id: pieceTechniqueId,
+            stock_managed: true,
+            lot_tracking: false,
+            row_version: 3,
+            designation_secondary: null,
+            is_sold: true,
+          }],
+        };
+      }
+      if (q.includes("SELECT 1::int AS ok FROM public.pieces_techniques")) {
+        return { rows: [{ ok: 1 }] };
+      }
+      if (q.includes("UPDATE public.articles")) {
+        return { rows: [{ id: articleId }] };
+      }
+      return { rows: [] };
+    });
+
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{
+        id: articleId,
+        code: immutableCode,
+        designation: "Pièce fabriquée",
+        article_type: "PIECE_TECHNIQUE",
+        article_category: "fabrique",
+        article_categories: ["fabrique"],
+        family_code: "PT",
+        stock_managed: true,
+        piece_technique_id: pieceTechniqueId,
+        lot_tracking: false,
+        is_active: true,
+        notes: "Contrôle périodique",
+        row_version: 4,
+      }],
+    });
+
+    const res = await request(app)
+      .patch(`/api/v1/stock/articles/${articleId}`)
+      .set("Authorization", "Bearer fake")
+      .send({
+        expected_row_version: 3,
+        notes: "Contrôle périodique",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.code).toBe(immutableCode);
+    expect(
+      mocks.clientQuery.mock.calls.some((call) =>
+        String(call[0]).includes("FROM public.pieces_techniques pt") &&
+        String(call[0]).includes("LEFT JOIN LATERAL")
       )
     ).toBe(false);
   });

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -216,6 +216,56 @@ describe("/api/v1/stock", () => {
     ).toBe(false);
   });
 
+  it("PATCH /api/v1/stock/articles/:id refuses to relink an existing fabricated article", async () => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM public.articles") && q.includes("FOR UPDATE")) {
+        return {
+          rows: [{
+            id: "11111111-1111-1111-1111-111111111111",
+            code: "ART-FAB-001-PT001-A",
+            designation: "Pièce fabriquée",
+            article_type: "PIECE_TECHNIQUE",
+            article_category: "fabrique",
+            article_categories: ["fabrique"],
+            root_article_id: "11111111-1111-1111-1111-111111111111",
+            version_number: 1,
+            plan_index: 1,
+            status: "VALIDE",
+            projet_id: null,
+            family_code: "PT",
+            piece_technique_id: "22222222-2222-2222-2222-222222222222",
+            stock_managed: true,
+            lot_tracking: false,
+            row_version: 3,
+            designation_secondary: null,
+            is_sold: true,
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .patch("/api/v1/stock/articles/11111111-1111-1111-1111-111111111111")
+      .set("Authorization", "Bearer fake")
+      .send({
+        expected_row_version: 3,
+        piece_technique_id: "33333333-3333-3333-3333-333333333333",
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      code: "FABRICATED_ARTICLE_IDENTITY_IMMUTABLE",
+    });
+    expect(
+      mocks.clientQuery.mock.calls.some((call) =>
+        String(call[0]).includes("UPDATE public.articles")
+      )
+    ).toBe(false);
+  });
+
   it("POST /api/v1/stock/articles persists article_matiere payload", async () => {
     mocks.clientQuery.mockImplementation(async (sql: unknown) => {
       const q = String(sql);

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -111,8 +111,16 @@ describe("/api/v1/stock", () => {
     mocks.clientQuery.mockImplementation(async (sql: unknown) => {
       const q = String(sql);
       if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
-      if (q.includes("FROM public.pieces_techniques pt") && q.includes("LEFT JOIN public.pieces_families")) {
-        return { rows: [{ code_piece: "PT-001", designation: "Pièce stockée", family_code: "PT" }] };
+      if (q.includes("FROM public.pieces_techniques pt") && q.includes("LEFT JOIN LATERAL")) {
+        return {
+          rows: [{
+            piece_exists: true,
+            client_code: "CLI-001",
+            plan_reference: "PT-001",
+            indice: "A",
+            version_interne: 1,
+          }],
+        };
       }
       if (q.includes("FROM public.pieces_techniques WHERE id = $1::uuid LIMIT 1")) {
         return { rows: [{ ok: 1 }] };
@@ -149,7 +157,7 @@ describe("/api/v1/stock", () => {
           plan_index: 1,
           status: "VALIDE",
           projet_id: null,
-          code: "PT-001-P1",
+          code: "ART-FAB-001-PT001-A",
           designation: "Pièce stockée",
           article_type: "PIECE_TECHNIQUE",
           article_category: "fabrique",
@@ -191,6 +199,11 @@ describe("/api/v1/stock", () => {
 
     expect(res.status).toBe(201);
     expect(res.body).toMatchObject({ article_category: "fabrique", family_code: "PT", stock_managed: true });
+    expect(
+      mocks.clientQuery.mock.calls.some((call) =>
+        Array.isArray(call[1]) && call[1].includes("ART-FAB-001-PT001-A")
+      )
+    ).toBe(true);
     expect(
       mocks.clientQuery.mock.calls.some((call) =>
         String(call[0]).includes("UPDATE public.pieces_techniques SET article_id = $2::uuid WHERE id = $1::uuid")

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -359,6 +359,7 @@ export async function repoListPieceTechniques(filters: ListPiecesTechniquesQuery
       p.designation,
       p.designation_2,
       p.client_id,
+      COALESCE(NULLIF(btrim(c.client_code), ''), NULLIF(btrim(p.code_client), '')) AS code_client,
       p.client_name,
       p.famille_id::text AS famille_id,
       f.code AS famille_code,
@@ -386,15 +387,25 @@ export async function repoListPieceTechniques(filters: ListPiecesTechniquesQuery
       ${HAS_DOCUMENTS_SQL} AS has_documents,
       ${TO_COMPLETE_SQL} AS to_complete
     FROM pieces_techniques p
+    LEFT JOIN clients c ON c.client_id = p.client_id
     LEFT JOIN pieces_families f ON f.id = p.famille_id
     LEFT JOIN LATERAL (
       -- #146 : la version applicable porte aussi l'indice et la référence de plan, deux
       -- informations que le préparateur cherchait jusqu'ici en ouvrant chaque fiche.
-      SELECT v.code_metier, v.indice, v.plan_reference, v.date_effet, v.version_interne
+      SELECT
+        v.code_metier,
+        COALESCE(NULLIF(btrim(v.indice_externe_original), ''), NULLIF(btrim(v.indice), '')) AS indice,
+        v.plan_reference,
+        v.date_effet,
+        v.version_interne
       FROM public.piece_technique_versions v
       WHERE v.piece_technique_id = p.id
-        AND v.statut = 'APPLICABLE'
-      ORDER BY v.date_effet DESC NULLS LAST, v.version_interne DESC NULLS LAST, v.created_at DESC
+        AND v.statut <> 'OBSOLETE'
+      ORDER BY
+        CASE WHEN v.statut = 'APPLICABLE' THEN 0 ELSE 1 END,
+        v.version_interne DESC NULLS LAST,
+        v.created_at DESC,
+        v.id DESC
       LIMIT 1
     ) current_version ON true
     LEFT JOIN (

--- a/src/module/pieces-techniques/types/pieces-techniques.types.ts
+++ b/src/module/pieces-techniques/types/pieces-techniques.types.ts
@@ -219,7 +219,7 @@ export type CreatePieceTechniqueInput = {
 
 export type PieceTechniqueListItem = Pick<
   PieceTechnique,
-  "id" | "article_id" | "root_piece_technique_id" | "parent_piece_technique_id" | "version_number" | "code_piece" | "designation" | "designation_2" | "client_id" | "client_name" | "famille_id" | "statut" | "en_fabrication" | "prix_unitaire" | "created_at" | "updated_at" | "ensemble"
+  "id" | "article_id" | "root_piece_technique_id" | "parent_piece_technique_id" | "version_number" | "code_piece" | "designation" | "designation_2" | "client_id" | "code_client" | "client_name" | "famille_id" | "statut" | "en_fabrication" | "prix_unitaire" | "created_at" | "updated_at" | "ensemble"
 > & {
   bom_count: number
   operations_count: number

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -594,6 +594,7 @@ async function normalizeArticleState(args: {
   code: string;
   designation: string;
   client: Pick<PoolClient, "query">;
+  preserve_existing_code?: boolean;
 }) {
   const categoryFromType = (() => {
     const articleType = typeof args.article_type === "string" ? args.article_type.trim().toUpperCase() : "";
@@ -636,13 +637,15 @@ async function normalizeArticleState(args: {
     await ensureProjetAffaireExists(args.client, projet_id);
   }
 
-  const code = await resolveArticleCode(args.client, {
-    code: args.code,
-    designation: args.designation,
-    category: article_category,
-    family_code,
-    piece_technique_id,
-  });
+  const code = args.preserve_existing_code
+    ? args.code
+    : await resolveArticleCode(args.client, {
+        code: args.code,
+        designation: args.designation,
+        category: article_category,
+        family_code,
+        piece_technique_id,
+      });
 
   return {
     article_type: article_type as "PIECE_TECHNIQUE" | "PURCHASED",
@@ -3168,6 +3171,9 @@ export async function repoUpdateArticle(
       code: current.code ?? "",
       designation: patch.designation ?? current.designation,
       client,
+      // Article business codes are immutable snapshots. A normal PATCH must
+      // not depend on the current state of the linked technical piece.
+      preserve_existing_code: true,
     });
 
     if (patch.article_matiere && normalized.article_category !== "matiere") {

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -5,7 +5,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import db from "../../../config/database";
-import { generateArticleBusinessCode, generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
+import {
+  generateArticleBusinessCode,
+  generateFabricatedArticleBusinessCode,
+  generateTransactionalBusinessCode,
+} from "../../../shared/codes/code-generator.service";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -520,10 +524,6 @@ export function normalizeArticleCategorySelection(
   };
 }
 
-function expectedFabricatedArticleCodeFromPlan(planReference: string, planIndex: number): string {
-  return `${sanitizeCodeToken(planReference, "PLAN")}-P${planIndex}`;
-}
-
 function categoryCodeSegment(category: ArticleCategory): string {
   if (category === "fabrique") return "PLAN";
   if (category === "matiere") return "MP";
@@ -538,38 +538,11 @@ function familyCodeSegment(value: string | null | undefined): string {
   return normalized.slice(0, 3);
 }
 
-async function getPieceTechniqueMetadata(
-  client: Pick<PoolClient, "query">,
-  pieceTechniqueId: string
-): Promise<{ code_piece: string; designation: string; family_code: string | null }> {
-  const res = await client.query<{ code_piece: string; designation: string; family_code: string | null }>(
-    `
-      SELECT
-        pt.code_piece,
-        pt.designation,
-        pf.code AS family_code
-      FROM public.pieces_techniques pt
-      LEFT JOIN public.pieces_families pf ON pf.id = pt.famille_id
-      WHERE pt.id = $1::uuid
-      LIMIT 1
-    `,
-    [pieceTechniqueId]
-  );
-  const row = res.rows[0] ?? null;
-  if (!row) {
-    throw new HttpError(400, "INVALID_PIECE_TECHNIQUE", "Unknown piece_technique_id");
-  }
-  return row;
-}
-
 function buildSuggestedArticleCode(args: {
   category: ArticleCategory;
   family_code: string;
   final_segment: string;
 }): string {
-  if (args.category === "fabrique") {
-    return sanitizeCodeToken(args.final_segment, "PLAN");
-  }
   return `${categoryCodeSegment(args.category)}-${familyCodeSegment(args.family_code)}-${sanitizeCodeToken(args.final_segment, "GEN")}`;
 }
 
@@ -581,34 +554,23 @@ async function resolveArticleCode(
     category: ArticleCategory;
     family_code: string;
     piece_technique_id: string | null;
-    plan_index: number;
   }
 ): Promise<string> {
-  const pieceMeta = args.piece_technique_id ? await getPieceTechniqueMetadata(client, args.piece_technique_id) : null;
-  const finalSegment = args.category === "fabrique"
-    ? sanitizeCodeToken(pieceMeta?.code_piece, "PLAN")
-    : sanitizeCodeToken(args.code || args.designation, "GEN");
+  if (args.category === "fabrique") {
+    if (!args.piece_technique_id) {
+      throw new HttpError(400, "INVALID_ARTICLE", "Fabricated articles require piece_technique_id");
+    }
+    // Client input is deliberately ignored: the server stores an immutable
+    // snapshot of the linked technical-piece identity.
+    return generateFabricatedArticleBusinessCode(client, args.piece_technique_id);
+  }
+
+  const finalSegment = sanitizeCodeToken(args.code || args.designation, "GEN");
   const suggested = buildSuggestedArticleCode({
     category: args.category,
     family_code: args.family_code,
     final_segment: finalSegment,
   });
-
-  if (args.category === "fabrique") {
-    const expected = expectedFabricatedArticleCodeFromPlan(finalSegment, args.plan_index);
-    const provided = args.code.trim();
-    if (!provided) return expected;
-
-    const normalized = normalizeFullArticleCode(provided);
-    if (normalized !== expected) {
-      throw new HttpError(
-        400,
-        "INVALID_FABRICATED_ARTICLE_CODE",
-        `Fabricated article code must match plan reference with index (${expected})`
-      );
-    }
-    return normalized;
-  }
 
   const provided = args.code.trim();
   if (!provided) return suggested;
@@ -680,7 +642,6 @@ async function normalizeArticleState(args: {
     category: article_category,
     family_code,
     piece_technique_id,
-    plan_index,
   });
 
   return {
@@ -2921,7 +2882,9 @@ export async function repoCreateArticleTx(
     designation: body.designation,
     client,
   });
-  const generatedCode = await generateArticleBusinessCode(client, normalized.family_code);
+  const generatedCode = normalized.article_category === "fabrique"
+    ? normalized.code
+    : await generateArticleBusinessCode(client, normalized.family_code);
 
   if (normalized.piece_technique_id) {
     await ensurePieceTechniqueExists(client, normalized.piece_technique_id);

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -3134,6 +3134,25 @@ export async function repoUpdateArticle(
       });
     }
 
+    const requestedCategory = patch.article_category ?? current.article_category;
+    const requestedPieceTechniqueId =
+      patch.piece_technique_id !== undefined
+        ? patch.piece_technique_id
+        : current.piece_technique_id;
+    const fabricatedIdentityChanged =
+      (current.article_category === "fabrique" || requestedCategory === "fabrique") &&
+      (
+        requestedCategory !== current.article_category ||
+        requestedPieceTechniqueId !== current.piece_technique_id
+      );
+    if (fabricatedIdentityChanged) {
+      throw new HttpError(
+        409,
+        "FABRICATED_ARTICLE_IDENTITY_IMMUTABLE",
+        "La catégorie et la pièce technique liées à un article fabriqué sont immuables. Créez un nouvel article pour une autre identité technique."
+      );
+    }
+
     const normalized = await normalizeArticleState({
       article_type: patch.article_type ?? current.article_type,
       article_category: patch.article_category ?? current.article_category,

--- a/src/shared/codes/code-generator.service.ts
+++ b/src/shared/codes/code-generator.service.ts
@@ -99,6 +99,88 @@ export async function generateArticleBusinessCode(tx: DbQueryer, familyCode: str
   return `ART-${family}-${pad(seq, 6)}`;
 }
 
+/**
+ * Canonical, immutable snapshot code for a fabricated article.
+ *
+ * The identity is read from the linked technical piece at the instant the
+ * article is created. An applicable technical version wins; a newly-created
+ * technical piece has only a draft version, so the newest non-obsolete version
+ * is used as an explicit fallback. The article code is never recalculated on
+ * later technical revisions.
+ */
+export async function generateFabricatedArticleBusinessCode(
+  tx: DbQueryer,
+  pieceTechniqueId: string
+): Promise<string> {
+  const result = await tx.query<{
+    piece_exists: boolean;
+    client_code: string | null;
+    plan_reference: string | null;
+    indice: string | null;
+    version_interne: number | string | null;
+  }>(
+    `
+      SELECT
+        true AS piece_exists,
+        COALESCE(NULLIF(btrim(c.client_code), ''), NULLIF(btrim(pt.code_client), '')) AS client_code,
+        v.plan_reference,
+        COALESCE(NULLIF(btrim(v.indice_externe_original), ''), NULLIF(btrim(v.indice), '')) AS indice,
+        v.version_interne
+      FROM public.pieces_techniques pt
+      LEFT JOIN public.clients c ON c.client_id = pt.client_id
+      LEFT JOIN LATERAL (
+        SELECT
+          pv.plan_reference,
+          pv.indice,
+          pv.indice_externe_original,
+          pv.version_interne
+        FROM public.piece_technique_versions pv
+        WHERE pv.piece_technique_id = pt.id
+          AND pv.statut <> 'OBSOLETE'
+        ORDER BY
+          CASE WHEN pv.statut = 'APPLICABLE' THEN 0 ELSE 1 END,
+          pv.version_interne DESC NULLS LAST,
+          pv.created_at DESC,
+          pv.id DESC
+        LIMIT 1
+      ) v ON true
+      WHERE pt.id = $1::uuid
+        AND pt.deleted_at IS NULL
+      LIMIT 1
+    `,
+    [pieceTechniqueId]
+  );
+
+  const source = result.rows[0];
+  if (!source?.piece_exists) {
+    throw new HttpError(400, "INVALID_PIECE_TECHNIQUE", "Pièce technique introuvable pour la codification de l'article fabriqué.");
+  }
+  if (!source.client_code?.trim()) {
+    throw new HttpError(400, "CLIENT_CODE_REQUIRED", "Code client manquant sur la pièce technique : impossible de générer le code article fabriqué.");
+  }
+  if (!source.plan_reference?.trim()) {
+    throw new HttpError(400, "PLAN_REFERENCE_REQUIRED", "Aucune version non obsolète avec référence plan n'est disponible pour cette pièce technique.");
+  }
+  if (!source.indice?.trim()) {
+    throw new HttpError(400, "INDEX_REQUIRED", "Aucune version non obsolète avec indice n'est disponible pour cette pièce technique.");
+  }
+
+  const parts = [
+    "ART",
+    "FAB",
+    normalizeClientSegment(source.client_code),
+    normalizeSegment(source.plan_reference, "Plan reference"),
+    normalizeSegment(source.indice, "External index"),
+  ];
+  const version = Number(source.version_interne);
+  if (Number.isInteger(version) && version > 1) parts.push(`V${version}`);
+
+  // `articles.code` est un TEXT indexé et les références plan PT acceptent
+  // volontairement jusqu'à 160 caractères. Ne pas introduire ici une limite
+  // arbitraire plus courte que le contrat source.
+  return parts.join("-");
+}
+
 export async function generateTransactionalBusinessCode(
   tx: DbQueryer,
   input: {

--- a/src/shared/codes/code-generator.service.ts
+++ b/src/shared/codes/code-generator.service.ts
@@ -5,6 +5,7 @@ import { HttpError } from "../../utils/httpError";
 type DbQueryer = Pick<PoolClient, "query">;
 
 const ASCII_SEGMENT = /[^A-Z0-9]+/g;
+const ASCII_PLAN_SEPARATOR = /[^A-Z0-9]+/g;
 
 function pad(n: number, width: number): string {
   return String(n).padStart(width, "0");
@@ -25,6 +26,25 @@ function normalizeSegment(value: string, field: string): string {
 
   if (!normalized) {
     throw new HttpError(400, "INVALID_CODE_SEGMENT", `${field} is required to build the business code.`);
+  }
+  return normalized;
+}
+
+/**
+ * Technical plan references often contain meaningful groups separated by
+ * spaces, slashes or dashes (for example `170 25464 001`). Keep those groups
+ * readable in business codes while normalising every separator to one dash.
+ */
+function normalizePlanReference(value: string): string {
+  const normalized = value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toUpperCase()
+    .replace(ASCII_PLAN_SEPARATOR, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (!normalized) {
+    throw new HttpError(400, "INVALID_CODE_SEGMENT", "Plan reference is required to build the business code.");
   }
   return normalized;
 }
@@ -69,7 +89,7 @@ export function previewPieceTechniqueCode(input: {
 }): string {
   return [
     normalizeClientSegment(input.clientCode),
-    normalizeSegment(input.planReference, "Plan reference"),
+    normalizePlanReference(input.planReference),
     normalizeSegment(input.indiceExterne, "External index"),
   ].join("-");
 }
@@ -169,7 +189,7 @@ export async function generateFabricatedArticleBusinessCode(
     "ART",
     "FAB",
     normalizeClientSegment(source.client_code),
-    normalizeSegment(source.plan_reference, "Plan reference"),
+    normalizePlanReference(source.plan_reference),
     normalizeSegment(source.indice, "External index"),
   ];
   const version = Number(source.version_interne);

--- a/src/shared/codes/code-validator.ts
+++ b/src/shared/codes/code-validator.ts
@@ -50,9 +50,9 @@ export const CODE_FORMATS = {
     hintText: "Format attendu: BCF-2026-0001",
   },
   article: {
-    regex: /^(ART-[A-Z0-9]+-\d{6}|ART-\d{4})$/,
-    example: "ART-USI-000042",
-    hintText: "Format attendu: ART-USI-000042",
+    regex: /^(ART-[A-Z0-9]+-\d{6}|ART-FAB-[A-Z0-9]+-[A-Z0-9]+-[A-Z0-9]+(?:-V(?:[2-9]|[1-9]\d+))?|ART-\d{4})$/,
+    example: "ART-FAB-001-17025950000-A",
+    hintText: "Formats attendus : ART-USI-000042 ou ART-FAB-001-17025950000-A[-Vn]",
   },
   // #210 — Finition de surface : code alloué par le serveur, puis immuable.
   surfaceFinish: {

--- a/src/shared/codes/code-validator.ts
+++ b/src/shared/codes/code-validator.ts
@@ -20,9 +20,9 @@ export const CODE_FORMATS = {
     hintText: "Format attendu: AFF-2026-0001",
   },
   pieceTechnique: {
-    regex: /^(?:[A-Z0-9]+-[A-Z0-9]+-[A-Z0-9]+|P-\d{3,})$/,
-    example: "001-17025950000-C",
-    hintText: "Format attendu: 001-17025950000-C",
+    regex: /^(?:[A-Z0-9]+(?:-[A-Z0-9]+){2,}|P-\d{3,})$/,
+    example: "001-170-25464-001-C",
+    hintText: "Format attendu: 001-170-25464-001-C",
   },
   of: {
     regex: /^(OF-\d{4}-\d{6}|OF-\d{4}-\d{5}|OF-\d+)$/,
@@ -50,9 +50,9 @@ export const CODE_FORMATS = {
     hintText: "Format attendu: BCF-2026-0001",
   },
   article: {
-    regex: /^(ART-[A-Z0-9]+-\d{6}|ART-FAB-[A-Z0-9]+-[A-Z0-9]+-[A-Z0-9]+(?:-V(?:[2-9]|[1-9]\d+))?|ART-\d{4})$/,
-    example: "ART-FAB-001-17025950000-A",
-    hintText: "Formats attendus : ART-USI-000042 ou ART-FAB-001-17025950000-A[-Vn]",
+    regex: /^(ART-[A-Z0-9]+-\d{6}|ART-FAB-(?!.*-V1$)[A-Z0-9]+(?:-[A-Z0-9]+){2,}(?:-V(?:[2-9]|[1-9]\d+))?|ART-\d{4})$/,
+    example: "ART-FAB-001-170-25464-001-A",
+    hintText: "Formats attendus : ART-USI-000042 ou ART-FAB-001-170-25464-001-A[-Vn]",
   },
   // #210 — Finition de surface : code alloué par le serveur, puis immuable.
   surfaceFinish: {


### PR DESCRIPTION
## Résultat
- génère ART-FAB-CODE_CLIENT-REFERENCE_PLAN-INDICE[-Vn] côté serveur
- conserve les groupes de la référence plan
- omet V1 et ajoute V2+
- fige le code lors des modifications ordinaires
- verrouille l'unicité et l'identité PT

## Validation
- 18 tests ciblés
- build TypeScript
- colonnes PT requises vérifiées par SSH sur cerp_test et cerp_prod

Closes #414

## Summary by Sourcery

Introduce server-side generation and immutability of fabricated article business codes based on technical piece identity, and align code validation and documentation with the new ART-FAB format.

New Features:
- Generate fabricated article business codes on the server from the linked technical piece identity, including client code, plan reference groups, external index, and optional internal version suffix.
- Support canonical plan-reference grouping in technical piece codes and allow ART-FAB article formats in code validation.

Enhancements:
- Make fabricated article business codes immutable by preserving existing codes on ordinary updates and refusing category or technical-piece relinking.
- Expose client code and the latest non-obsolete technical version metadata when listing technical pieces, preferring applicable versions and normalizing indices.
- Simplify article code suggestion logic by delegating fabricated article codes to the centralized generator instead of relying on client-provided plan references.

Documentation:
- Update nomenclature documentation to describe grouped plan references and the new ART-FAB fabricated article code format with versioning rules.

Tests:
- Extend stock and codification tests to cover ART-FAB server generation, validation of grouped plan references, immutability of fabricated article identity, and rejection cases when required technical-piece data is missing.