### PR TITLE
fix(clients): filtrer exactement les codes client (#256)

### DIFF
--- a/src/__tests__/clients.routes.test.ts
+++ b/src/__tests__/clients.routes.test.ts
@@ -133,6 +133,30 @@ describe("/api/v1/clients", () => {
     });
   });
 
+  it.each([
+    ["1", "CLI-001"],
+    ["001", "CLI-001"],
+    ["CLI-001", "CLI-001"],
+  ])("GET /api/v1/clients uses an exact normalized code lookup for %s", async (q, expectedCode) => {
+    const res = await request(app).get("/api/v1/clients").query({ q });
+
+    expect(res.status).toBe(200);
+    expect(mocks.poolQuery).toHaveBeenCalledOnce();
+    const [sql, values] = mocks.poolQuery.mock.calls[0] as [string, [string, number, string | null]];
+    expect(values).toEqual([q, 2000, expectedCode]);
+    expect(sql).toContain("WHEN $3::text IS NOT NULL THEN");
+    expect(sql).toContain("REGEXP_REPLACE");
+  });
+
+  it("GET /api/v1/clients keeps generic text search for a non-code query", async () => {
+    const res = await request(app).get("/api/v1/clients").query({ q: "CLAYENS", limit: "25" });
+
+    expect(res.status).toBe(200);
+    const [sql, values] = mocks.poolQuery.mock.calls[0] as [string, [string, number, string | null]];
+    expect(values).toEqual(["CLAYENS", 25, null]);
+    expect(sql).toContain("c.siret ILIKE replace('%' || $1 || '%',' ','')");
+  });
+
   it("GET /api/v1/clients/:id returns client.client_code in detail payload", async () => {
     mocks.poolQuery
       .mockResolvedValueOnce({

--- a/src/module/client/services/client.service.ts
+++ b/src/module/client/services/client.service.ts
@@ -95,7 +95,21 @@ export async function updateClientLogoPath(id: string, logoPath: string): Promis
 }
 
 
+/**
+ * A short numeric search is a client-code lookup, not a broad text search.
+ * Without this distinction, entering "001" also matched SIRETs and made the
+ * client selector unreliable. The stored legacy code may be "001", "CLI-001"
+ * or "CLI 001"; all three forms are normalized by the SQL predicate below.
+ */
+function exactClientCodeQuery(q: string): string | null {
+  const match = q.trim().match(/^(?:CLI[-\s]?)?(\d{1,3})$/i);
+  if (!match) return null;
+
+  return `CLI-${match[1].padStart(3, "0")}`;
+}
+
 export async function listClients(q = "", limit = 25): Promise<ClientRow[]> {
+  const codeQuery = exactClientCodeQuery(q);
   const sql = `
   SELECT
     c.client_id::text,
@@ -194,17 +208,34 @@ export async function listClients(q = "", limit = 25): Promise<ClientRow[]> {
 
     WHERE
       $1 = '' OR (
-        c.company_name ILIKE '%' || $1 || '%'
-        OR COALESCE(
-          NULLIF(btrim(to_jsonb(c)->>'client_code'), ''),
-          NULLIF(btrim(to_jsonb(c)->>'code_client'), '')
-        ) ILIKE '%' || $1 || '%'
-        OR c.email ILIKE '%' || $1 || '%'
-        OR c.siret ILIKE replace('%' || $1 || '%',' ','')
-        OR c.vat_number ILIKE '%' || $1 || '%'
-      OR af.city ILIKE '%' || $1 || '%'
-      OR al.city ILIKE '%' || $1 || '%'
-    )
+        CASE
+          WHEN $3::text IS NOT NULL THEN
+            'CLI-' || LPAD(
+              REGEXP_REPLACE(
+                COALESCE(
+                  NULLIF(btrim(to_jsonb(c)->>'client_code'), ''),
+                  NULLIF(btrim(to_jsonb(c)->>'code_client'), '')
+                ),
+                '^CLI[- ]?',
+                '',
+                'i'
+              ),
+              3,
+              '0'
+            ) = $3
+          ELSE
+            c.company_name ILIKE '%' || $1 || '%'
+            OR COALESCE(
+              NULLIF(btrim(to_jsonb(c)->>'client_code'), ''),
+              NULLIF(btrim(to_jsonb(c)->>'code_client'), '')
+            ) ILIKE '%' || $1 || '%'
+            OR c.email ILIKE '%' || $1 || '%'
+            OR c.siret ILIKE replace('%' || $1 || '%',' ','')
+            OR c.vat_number ILIKE '%' || $1 || '%'
+            OR af.city ILIKE '%' || $1 || '%'
+            OR al.city ILIKE '%' || $1 || '%'
+        END
+      )
 
   GROUP BY
     c.client_id, af.bill_address_id, al.delivery_address_id, ib.bank_info_id, ct.contact_id
@@ -213,7 +244,7 @@ export async function listClients(q = "", limit = 25): Promise<ClientRow[]> {
   LIMIT $2
 `;
 
-  const { rows } = await pool.query<ClientRow>(sql, [q, limit]);
+  const { rows } = await pool.query<ClientRow>(sql, [q, limit, codeQuery]);
   return rows;
 }
 // createClient (MAX+1 sur client_id) et updateClientPrimaryContact (sans


### PR DESCRIPTION
## Résultat
- 1, 001 et CLI-001 ciblent uniquement CLI-001
- les SIRET, emails et villes ne créent plus de faux positifs pour une recherche code
- la recherche générique par nom reste inchangée

## Validation
- 6 tests ciblés
- build TypeScript
- contrôle du diff

Closes #256

## Summary by Sourcery

Ensure client search treats short numeric inputs as exact client code lookups while preserving existing generic text search behavior.

New Features:
- Support normalized exact client code lookup (e.g., 1, 001, CLI-001 all target CLI-001) in the client listing API.

Bug Fixes:
- Prevent SIRET, email, VAT number, and city fields from matching when a query is intended as a client code search.

Tests:
- Add tests covering exact normalized client code queries and the fallback to generic text search for non-code queries.