### PR TITLE
fix(pt): restaurer la validation des versions par Méthodes (#259)

### DIFF
--- a/src/__tests__/piece-technique-rbac-227.test.ts
+++ b/src/__tests__/piece-technique-rbac-227.test.ts
@@ -46,6 +46,12 @@ describe("#227 — validation d'un indice : le défaut « accès refusé » est 
     expect(canValidatePieceTechnique(user("Employee", ["Livraison"]))).toBe(false);
   });
 
+  it("reconnaît les marqueurs effectifs Méthodes sans ouvrir les rôles atelier", () => {
+    expect(canValidatePieceTechnique(user("Employee | Method"))).toBe(true);
+    expect(canValidatePieceTechnique(user("Employee | Responsable Programmation"))).toBe(true);
+    expect(canValidatePieceTechnique(user("Employee | Opérateur atelier"))).toBe(false);
+  });
+
   it("aucune autorisation par sous-chaîne : un rôle inventé contenant « admin » est refusé", () => {
     expect(canValidatePieceTechnique(user("Stagiaire admin"))).toBe(false);
     expect(canValidatePieceTechnique(user("admin"))).toBe(false);

--- a/src/module/pieces-techniques/pieces-techniques.permissions.ts
+++ b/src/module/pieces-techniques/pieces-techniques.permissions.ts
@@ -27,7 +27,7 @@
 
 import type { Request } from "express";
 
-import { hasAnyAssignedRole } from "../auth/domain/roles";
+import { effectiveRoleHasAny, hasAnyAssignedRole } from "../auth/domain/roles";
 
 /**
  * Rédaction du dossier technique : créer/modifier une pièce, sa nomenclature, sa gamme,
@@ -42,6 +42,7 @@ export const PIECE_TECHNIQUE_WRITE_ROLES = [
   "Programmation",
   "Études-Méthodes",
   "Responsable CAO",
+  "Method",
   "Responsable Qualité",
   "Qualité",
 ] as const;
@@ -61,6 +62,7 @@ export const PIECE_TECHNIQUE_VALIDATE_ROLES = [
   "Qualité",
   "Responsable Programmation",
   "Études-Méthodes",
+  "Method",
 ] as const;
 
 /**
@@ -93,7 +95,10 @@ function allows(user: RoleBearer | null | undefined, allowed: readonly string[])
   if (!user) return false;
   // Comparaison exacte sur les rôles assignés, jamais une sous-chaîne :
   // un rôle inconnu est refusé, point.
-  return hasAnyAssignedRole(user.role, user.roles, allowed);
+  return (
+    hasAnyAssignedRole(user.role, user.roles, allowed) ||
+    effectiveRoleHasAny(user.role, allowed)
+  );
 }
 
 export const canWritePieceTechnique = (user: RoleBearer | null | undefined): boolean =>

--- a/src/module/pieces-techniques/repository/pieces-techniques-landing.test.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques-landing.test.ts
@@ -285,10 +285,12 @@ describe("colonnes de complétude", () => {
     }
   });
 
-  it("ne retient qu'une seule version applicable, la plus récente en date d'effet", async () => {
+  it("privilégie la version applicable puis la version interne la plus récente", async () => {
     await repoListPieceTechniques(parse({}));
     const dataSql = captured()[1].text;
-    expect(dataSql).toContain("ORDER BY v.date_effet DESC NULLS LAST");
+    expect(dataSql).toContain("CASE WHEN v.statut = 'APPLICABLE' THEN 0 ELSE 1 END");
+    expect(dataSql).toContain("v.version_interne DESC NULLS LAST");
+    expect(dataSql).toContain("v.id DESC");
     expect(dataSql).toContain("LIMIT 1");
   });
 

--- a/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
+++ b/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
@@ -1,13 +1,14 @@
 // src/module/pieces-techniques/routes/pieces-techniques.routes.ts
-import { Router } from "express"
+import { Router, type RequestHandler } from "express"
 import multer from "multer"
 
 import { authenticateToken, authorizeRole } from "../../auth/middlewares/auth.middleware"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
+import { HttpError } from "../../../utils/httpError"
 import {
+  canValidatePieceTechnique,
   PIECE_DOCUMENT_POLICY_ROLES,
   PIECE_TECHNIQUE_DELETE_ROLES,
-  PIECE_TECHNIQUE_VALIDATE_ROLES,
 } from "../pieces-techniques.permissions"
 import {
   abandonPieceDraft,
@@ -115,9 +116,21 @@ const router = Router()
 // refusé » à la validation d'un indice), acceptait tout futur rôle contenant « admin »,
 // et ignorait le multi-rôles #315. Les listes vivent dans pieces-techniques.permissions.ts
 // et sont comparées aux rôles réellement assignés.
-const requireValidateRole = authorizeRole(...PIECE_TECHNIQUE_VALIDATE_ROLES)
 const requireDeleteRole = authorizeRole(...PIECE_TECHNIQUE_DELETE_ROLES)
 const requireDocumentPolicyRole = authorizeRole(...PIECE_DOCUMENT_POLICY_ROLES)
+const requireVersionApproval: RequestHandler = (req, _res, next) => {
+  if (!canValidatePieceTechnique(req.user)) {
+    next(
+      new HttpError(
+        403,
+        "PIECE_VERSION_APPROVAL_FORBIDDEN",
+        "Technical definition approval role required"
+      )
+    )
+    return
+  }
+  next()
+}
 
 const docsBaseDir = ensureDocumentStoragePath("pieces-techniques")
 
@@ -183,7 +196,7 @@ router.post("/:id/create-or-link-article-fabrique", validate(idParamSchema), cre
 router.get("/:id/versions", validate(idParamSchema), listVersions)
 router.post("/:id/versions", validate(idParamSchema), validate(createVersionSchema), createVersion)
 router.patch("/:id/versions/:versionId", validate(versionIdParamSchema), validate(updateVersionSchema), updateVersion)
-router.patch("/:id/versions/:versionId/status", requireValidateRole, validate(versionIdParamSchema), validate(versionStatusSchema), updateVersionStatus)
+router.patch("/:id/versions/:versionId/status", requireVersionApproval, validate(versionIdParamSchema), validate(versionStatusSchema), updateVersionStatus)
 router.post("/:id/versions/:versionId/create-next", validate(versionIdParamSchema), validate(createNextVersionSchema), createNextVersion)
 
 router.post("/:id/nomenclature", validate(idParamSchema), validate(addBomLineSchema), addBomLine)


### PR DESCRIPTION
## Résultat
- autorise les marqueurs effectifs Method et Responsable Programmation
- conserve un refus par défaut pour les opérateurs
- renvoie le code stable PIECE_VERSION_APPROVAL_FORBIDDEN
- aligne le test de sélection de version PT sur APPLICABLE puis version interne

## Validation
- 60 tests PT ciblés
- suite backend complète
- build TypeScript
- revue sécurité RBAC indépendante

Closes #259

## Summary by Sourcery

Restore and tighten version approval for technical pieces by enforcing dedicated approval logic and role markers while aligning version selection ordering with business rules.

Bug Fixes:
- Ensure version status updates for technical pieces are blocked by default unless the user has an explicit approval role or effective Method/Responsable Programmation marker.
- Prevent workshop operator roles and arbitrary role substrings from inadvertently granting version approval permissions.

Enhancements:
- Extend technical piece write/validate permissions to recognize effective Method and Responsable Programmation markers via the role domain helpers.
- Refine technical piece version selection to prioritize applicable versions first, then the most recent internal version and ID for completeness views.

Tests:
- Add RBAC tests covering effective Method and Responsable Programmation markers and ensuring operators remain denied.
- Update repository tests to assert the new ordering criteria for preferred technical piece versions.