### PR TITLE
release: PT sans famille, ART-FAB et recherche client exacte

### DIFF
--- a/docs/nomenclature-codes.md
+++ b/docs/nomenclature-codes.md
@@ -29,8 +29,9 @@ Le frontend peut afficher `hintText` + `example` et valider le champ cote client
 Les formats sont declares dans `src/shared/codes/code-validator.ts`.
 
 - Client: `CLI-001`
-- Pièce technique: `001-17025950000-C` (client, référence plan, indice externe)
-- Article: `ART-USI-000042` (séquence de six chiffres, famille explicite)
+- Pièce technique: `001-170-25464-001-C` (client, groupes de la référence plan, indice externe)
+- Article fabriqué: `ART-FAB-001-170-25464-001-C[-Vn]` (snapshot de la PT ; suffixe à partir de V2)
+- Article acheté: `ART-USI-000042` (séquence de six chiffres, famille explicite)
 - Devis: `DEV-2026-0001`
 - Commande client: `CMD-2026-0001`
 - Affaire: `AFF-2026-0001`
@@ -74,7 +75,8 @@ Points importants:
   référence historique de l'agrégat. Le code de travail d'une version est
   calculé uniquement à partir de `client + plan + indice externe` et exposé
   dans `piece_technique_versions.code_metier`; la recherche pièce couvre aussi
-  ce code de version.
+  ce code de version. Les séparateurs présents dans la référence plan sont
+  normalisés en tirets afin de conserver ses groupes lisibles.
 - BL/RF/NC/CAP reutilisent les generateurs/sequence existants en base (formats deja en prod).
 
 ## Smoke

--- a/src/__tests__/clients.routes.test.ts
+++ b/src/__tests__/clients.routes.test.ts
@@ -133,6 +133,30 @@ describe("/api/v1/clients", () => {
     });
   });
 
+  it.each([
+    ["1", "CLI-001"],
+    ["001", "CLI-001"],
+    ["CLI-001", "CLI-001"],
+  ])("GET /api/v1/clients uses an exact normalized code lookup for %s", async (q, expectedCode) => {
+    const res = await request(app).get("/api/v1/clients").query({ q });
+
+    expect(res.status).toBe(200);
+    expect(mocks.poolQuery).toHaveBeenCalledOnce();
+    const [sql, values] = mocks.poolQuery.mock.calls[0] as [string, [string, number, string | null]];
+    expect(values).toEqual([q, 2000, expectedCode]);
+    expect(sql).toContain("WHEN $3::text IS NOT NULL THEN");
+    expect(sql).toContain("REGEXP_REPLACE");
+  });
+
+  it("GET /api/v1/clients keeps generic text search for a non-code query", async () => {
+    const res = await request(app).get("/api/v1/clients").query({ q: "CLAYENS", limit: "25" });
+
+    expect(res.status).toBe(200);
+    const [sql, values] = mocks.poolQuery.mock.calls[0] as [string, [string, number, string | null]];
+    expect(values).toEqual(["CLAYENS", 25, null]);
+    expect(sql).toContain("c.siret ILIKE replace('%' || $1 || '%',' ','')");
+  });
+
   it("GET /api/v1/clients/:id returns client.client_code in detail payload", async () => {
     mocks.poolQuery
       .mockResolvedValueOnce({

--- a/src/__tests__/codification-business-codes.test.ts
+++ b/src/__tests__/codification-business-codes.test.ts
@@ -28,7 +28,15 @@ describe("Codification métier centralisée", () => {
       clientCode: "1",
       planReference: "1702595 0000",
       indiceExterne: "c-1",
-    })).toBe("001-17025950000-C1");
+    })).toBe("001-1702595-0000-C1");
+  });
+
+  it("conserve les groupes de la référence plan dans le code PT", () => {
+    expect(previewPieceTechniqueCode({
+      clientCode: "CLI-001",
+      planReference: "170 25464 001",
+      indiceExterne: "A",
+    })).toBe("001-170-25464-001-A");
   });
 
   it("réserve la séquence article dans PostgreSQL et ne reçoit pas le code final du client", async () => {
@@ -56,7 +64,7 @@ describe("Codification métier centralisée", () => {
     };
 
     await expect(generateFabricatedArticleBusinessCode(tx as never, "11111111-1111-4111-8111-111111111111"))
-      .resolves.toBe("ART-FAB-001-17025950000-A1");
+      .resolves.toBe("ART-FAB-001-1702595-0000-A1");
     expect(calls[0]?.sql).toContain("pv.statut = 'APPLICABLE'");
     expect(calls[0]?.values).toEqual(["11111111-1111-4111-8111-111111111111"]);
   });
@@ -75,7 +83,7 @@ describe("Codification métier centralisée", () => {
     };
 
     await expect(generateFabricatedArticleBusinessCode(tx as never, "22222222-2222-4222-8222-222222222222"))
-      .resolves.toBe("ART-FAB-002-PLAN42-B-V3");
+      .resolves.toBe("ART-FAB-002-PLAN-42-B-V3");
   });
 
   it("rejects a fabricated article when its technical piece has no client code", async () => {
@@ -151,9 +159,12 @@ describe("Codification métier centralisée", () => {
 
   it("expose les formats canoniques tout en gardant les références historiques lisibles", () => {
     expect(isValidCode("pieceTechnique", "001-17025950000-C")).toBe(true);
+    expect(isValidCode("pieceTechnique", "001-170-25464-001-C")).toBe(true);
     expect(isValidCode("article", "ART-USI-000042")).toBe(true);
     expect(isValidCode("article", "ART-FAB-001-17025950000-A")).toBe(true);
+    expect(isValidCode("article", "ART-FAB-001-170-25464-001-A")).toBe(true);
     expect(isValidCode("article", "ART-FAB-001-17025950000-A-V2")).toBe(true);
+    expect(isValidCode("article", "ART-FAB-001-170-25464-001-A-V2")).toBe(true);
     expect(isValidCode("article", "ART-FAB-001-17025950000-A-V10")).toBe(true);
     expect(isValidCode("article", "ART-FAB-001-17025950000-A-V1")).toBe(false);
     expect(isValidCode("commande", "CMD-2026-0007")).toBe(true);

--- a/src/__tests__/codification-business-codes.test.ts
+++ b/src/__tests__/codification-business-codes.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   generateArticleBusinessCode,
+  generateFabricatedArticleBusinessCode,
   generateMachineCode,
   generateTransactionalBusinessCode,
   previewPieceTechniqueCode,
@@ -37,6 +38,102 @@ describe("Codification métier centralisée", () => {
     expect(calls[0]?.values).toEqual(["ART:USINAGE"]);
   });
 
+  it("generates a fabricated article code from the applicable technical-piece identity", async () => {
+    const calls: Array<{ sql: string; values: unknown[] | undefined }> = [];
+    const tx = {
+      query: async (sql: string, values?: unknown[]) => {
+        calls.push({ sql, values });
+        return {
+          rows: [{
+            piece_exists: true,
+            client_code: "CLI-001",
+            plan_reference: "1702595 0000",
+            indice: "a-1",
+            version_interne: 1,
+          }],
+        };
+      },
+    };
+
+    await expect(generateFabricatedArticleBusinessCode(tx as never, "11111111-1111-4111-8111-111111111111"))
+      .resolves.toBe("ART-FAB-001-17025950000-A1");
+    expect(calls[0]?.sql).toContain("pv.statut = 'APPLICABLE'");
+    expect(calls[0]?.values).toEqual(["11111111-1111-4111-8111-111111111111"]);
+  });
+
+  it("adds only an internal version above one to a fabricated article code", async () => {
+    const tx = {
+      query: async () => ({
+        rows: [{
+          piece_exists: true,
+          client_code: "002",
+          plan_reference: "PLAN-42",
+          indice: "B",
+          version_interne: 3,
+        }],
+      }),
+    };
+
+    await expect(generateFabricatedArticleBusinessCode(tx as never, "22222222-2222-4222-8222-222222222222"))
+      .resolves.toBe("ART-FAB-002-PLAN42-B-V3");
+  });
+
+  it("rejects a fabricated article when its technical piece has no client code", async () => {
+    const tx = {
+      query: async () => ({
+        rows: [{
+          piece_exists: true,
+          client_code: null,
+          plan_reference: "PLAN-42",
+          indice: "B",
+          version_interne: 1,
+        }],
+      }),
+    };
+
+    await expect(generateFabricatedArticleBusinessCode(tx as never, "33333333-3333-4333-8333-333333333333"))
+      .rejects.toMatchObject({ code: "CLIENT_CODE_REQUIRED" });
+  });
+
+  it.each([
+    {
+      label: "technical piece",
+      row: undefined,
+      code: "INVALID_PIECE_TECHNIQUE",
+    },
+    {
+      label: "plan reference",
+      row: {
+        piece_exists: true,
+        client_code: "001",
+        plan_reference: null,
+        indice: "A",
+        version_interne: 1,
+      },
+      code: "PLAN_REFERENCE_REQUIRED",
+    },
+    {
+      label: "external index",
+      row: {
+        piece_exists: true,
+        client_code: "001",
+        plan_reference: "PLAN-42",
+        indice: null,
+        version_interne: 1,
+      },
+      code: "INDEX_REQUIRED",
+    },
+  ])("rejects a fabricated article when its $label is missing", async ({ row, code }) => {
+    const tx = {
+      query: async () => ({ rows: row ? [row] : [] }),
+    };
+
+    await expect(generateFabricatedArticleBusinessCode(
+      tx as never,
+      "44444444-4444-4444-8444-444444444444"
+    )).rejects.toMatchObject({ code });
+  });
+
   it("produit les formats transactionnels DEV, CMD, AFF et OF avec les largeurs attendues", async () => {
     const date = new Date("2026-07-13T00:00:00.000Z");
     await expect(generateTransactionalBusinessCode(sequenceTx(7).tx as never, { prefix: "DEV", date })).resolves.toBe("DEV-2026-0007");
@@ -55,6 +152,10 @@ describe("Codification métier centralisée", () => {
   it("expose les formats canoniques tout en gardant les références historiques lisibles", () => {
     expect(isValidCode("pieceTechnique", "001-17025950000-C")).toBe(true);
     expect(isValidCode("article", "ART-USI-000042")).toBe(true);
+    expect(isValidCode("article", "ART-FAB-001-17025950000-A")).toBe(true);
+    expect(isValidCode("article", "ART-FAB-001-17025950000-A-V2")).toBe(true);
+    expect(isValidCode("article", "ART-FAB-001-17025950000-A-V10")).toBe(true);
+    expect(isValidCode("article", "ART-FAB-001-17025950000-A-V1")).toBe(false);
     expect(isValidCode("commande", "CMD-2026-0007")).toBe(true);
     expect(isValidCode("of", "OF-2026-000007")).toBe(true);
     expect(isValidCode("commande", "CC-123")).toBe(true);

--- a/src/__tests__/gamme-operations.validators.test.ts
+++ b/src/__tests__/gamme-operations.validators.test.ts
@@ -13,6 +13,8 @@ import {
   createFamilySchema,
   listMachineOptionsQuerySchema,
 } from "../module/methodes/validators/methodes.validators"
+import { requiredRouteParam } from "../module/methodes/controllers/methodes.controller"
+import { HttpError } from "../utils/httpError"
 
 describe("Opération de gamme — contrat d'entrée", () => {
   it("accepte le type DECOUPE sans retirer les types existants", () => {
@@ -75,6 +77,20 @@ describe("Opération de gamme — contrat d'entrée", () => {
 })
 
 describe("Référentiels Méthodes — contrat d'entrée", () => {
+  it("refuse les paramètres de route absents, multiples ou vides", () => {
+    const req = (params: Record<string, string | string[] | undefined>) => ({ params }) as never
+
+    expect(requiredRouteParam(req({ cfId: "  123  " }), "cfId")).toBe("  123  ")
+    for (const params of [{}, { cfId: ["123", "456"] }, { cfId: "   " }]) {
+      expect(() => requiredRouteParam(req(params), "cfId")).toThrow(HttpError)
+      try {
+        requiredRouteParam(req(params), "cfId")
+      } catch (error) {
+        expect(error).toMatchObject({ status: 400, code: "INVALID_ROUTE_PARAM" })
+      }
+    }
+  })
+
   it("impose un code de famille en majuscules sans espace", () => {
     const ok = createFamilySchema.safeParse({ code: "rectif cn", libelle: "Rectification" })
     expect(ok.success).toBe(false)

--- a/src/__tests__/piece-technique-rbac-227.test.ts
+++ b/src/__tests__/piece-technique-rbac-227.test.ts
@@ -46,6 +46,12 @@ describe("#227 — validation d'un indice : le défaut « accès refusé » est 
     expect(canValidatePieceTechnique(user("Employee", ["Livraison"]))).toBe(false);
   });
 
+  it("reconnaît les marqueurs effectifs Méthodes sans ouvrir les rôles atelier", () => {
+    expect(canValidatePieceTechnique(user("Employee | Method"))).toBe(true);
+    expect(canValidatePieceTechnique(user("Employee | Responsable Programmation"))).toBe(true);
+    expect(canValidatePieceTechnique(user("Employee | Opérateur atelier"))).toBe(false);
+  });
+
   it("aucune autorisation par sous-chaîne : un rôle inventé contenant « admin » est refusé", () => {
     expect(canValidatePieceTechnique(user("Stagiaire admin"))).toBe(false);
     expect(canValidatePieceTechnique(user("admin"))).toBe(false);

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -157,7 +157,7 @@ describe("/api/v1/stock", () => {
           plan_index: 1,
           status: "VALIDE",
           projet_id: null,
-          code: "ART-FAB-001-PT001-A",
+          code: "ART-FAB-001-PT-001-A",
           designation: "Pièce stockée",
           article_type: "PIECE_TECHNIQUE",
           article_category: "fabrique",
@@ -201,7 +201,7 @@ describe("/api/v1/stock", () => {
     expect(res.body).toMatchObject({ article_category: "fabrique", family_code: "PT", stock_managed: true });
     expect(
       mocks.clientQuery.mock.calls.some((call) =>
-        Array.isArray(call[1]) && call[1].includes("ART-FAB-001-PT001-A")
+        Array.isArray(call[1]) && call[1].includes("ART-FAB-001-PT-001-A")
       )
     ).toBe(true);
     expect(
@@ -262,6 +262,86 @@ describe("/api/v1/stock", () => {
     expect(
       mocks.clientQuery.mock.calls.some((call) =>
         String(call[0]).includes("UPDATE public.articles")
+      )
+    ).toBe(false);
+  });
+
+  it("PATCH /api/v1/stock/articles/:id preserves the fabricated code without rereading the technical piece", async () => {
+    const articleId = "11111111-1111-1111-1111-111111111111";
+    const pieceTechniqueId = "22222222-2222-2222-2222-222222222222";
+    const immutableCode = "ART-FAB-001-170-25464-001-A";
+
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q.includes("FROM public.pieces_techniques pt") && q.includes("LEFT JOIN LATERAL")) {
+        throw new Error("A normal fabricated-article PATCH must not recalculate its immutable code");
+      }
+      if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM public.articles") && q.includes("FOR UPDATE")) {
+        return {
+          rows: [{
+            id: articleId,
+            code: immutableCode,
+            designation: "Pièce fabriquée",
+            article_type: "PIECE_TECHNIQUE",
+            article_category: "fabrique",
+            article_categories: ["fabrique"],
+            root_article_id: articleId,
+            version_number: 1,
+            plan_index: 1,
+            status: "VALIDE",
+            projet_id: null,
+            family_code: "PT",
+            piece_technique_id: pieceTechniqueId,
+            stock_managed: true,
+            lot_tracking: false,
+            row_version: 3,
+            designation_secondary: null,
+            is_sold: true,
+          }],
+        };
+      }
+      if (q.includes("SELECT 1::int AS ok FROM public.pieces_techniques")) {
+        return { rows: [{ ok: 1 }] };
+      }
+      if (q.includes("UPDATE public.articles")) {
+        return { rows: [{ id: articleId }] };
+      }
+      return { rows: [] };
+    });
+
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{
+        id: articleId,
+        code: immutableCode,
+        designation: "Pièce fabriquée",
+        article_type: "PIECE_TECHNIQUE",
+        article_category: "fabrique",
+        article_categories: ["fabrique"],
+        family_code: "PT",
+        stock_managed: true,
+        piece_technique_id: pieceTechniqueId,
+        lot_tracking: false,
+        is_active: true,
+        notes: "Contrôle périodique",
+        row_version: 4,
+      }],
+    });
+
+    const res = await request(app)
+      .patch(`/api/v1/stock/articles/${articleId}`)
+      .set("Authorization", "Bearer fake")
+      .send({
+        expected_row_version: 3,
+        notes: "Contrôle périodique",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.code).toBe(immutableCode);
+    expect(
+      mocks.clientQuery.mock.calls.some((call) =>
+        String(call[0]).includes("FROM public.pieces_techniques pt") &&
+        String(call[0]).includes("LEFT JOIN LATERAL")
       )
     ).toBe(false);
   });

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -216,6 +216,56 @@ describe("/api/v1/stock", () => {
     ).toBe(false);
   });
 
+  it("PATCH /api/v1/stock/articles/:id refuses to relink an existing fabricated article", async () => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM public.articles") && q.includes("FOR UPDATE")) {
+        return {
+          rows: [{
+            id: "11111111-1111-1111-1111-111111111111",
+            code: "ART-FAB-001-PT001-A",
+            designation: "Pièce fabriquée",
+            article_type: "PIECE_TECHNIQUE",
+            article_category: "fabrique",
+            article_categories: ["fabrique"],
+            root_article_id: "11111111-1111-1111-1111-111111111111",
+            version_number: 1,
+            plan_index: 1,
+            status: "VALIDE",
+            projet_id: null,
+            family_code: "PT",
+            piece_technique_id: "22222222-2222-2222-2222-222222222222",
+            stock_managed: true,
+            lot_tracking: false,
+            row_version: 3,
+            designation_secondary: null,
+            is_sold: true,
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .patch("/api/v1/stock/articles/11111111-1111-1111-1111-111111111111")
+      .set("Authorization", "Bearer fake")
+      .send({
+        expected_row_version: 3,
+        piece_technique_id: "33333333-3333-3333-3333-333333333333",
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({
+      code: "FABRICATED_ARTICLE_IDENTITY_IMMUTABLE",
+    });
+    expect(
+      mocks.clientQuery.mock.calls.some((call) =>
+        String(call[0]).includes("UPDATE public.articles")
+      )
+    ).toBe(false);
+  });
+
   it("POST /api/v1/stock/articles persists article_matiere payload", async () => {
     mocks.clientQuery.mockImplementation(async (sql: unknown) => {
       const q = String(sql);

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -111,8 +111,16 @@ describe("/api/v1/stock", () => {
     mocks.clientQuery.mockImplementation(async (sql: unknown) => {
       const q = String(sql);
       if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
-      if (q.includes("FROM public.pieces_techniques pt") && q.includes("LEFT JOIN public.pieces_families")) {
-        return { rows: [{ code_piece: "PT-001", designation: "Pièce stockée", family_code: "PT" }] };
+      if (q.includes("FROM public.pieces_techniques pt") && q.includes("LEFT JOIN LATERAL")) {
+        return {
+          rows: [{
+            piece_exists: true,
+            client_code: "CLI-001",
+            plan_reference: "PT-001",
+            indice: "A",
+            version_interne: 1,
+          }],
+        };
       }
       if (q.includes("FROM public.pieces_techniques WHERE id = $1::uuid LIMIT 1")) {
         return { rows: [{ ok: 1 }] };
@@ -149,7 +157,7 @@ describe("/api/v1/stock", () => {
           plan_index: 1,
           status: "VALIDE",
           projet_id: null,
-          code: "PT-001-P1",
+          code: "ART-FAB-001-PT001-A",
           designation: "Pièce stockée",
           article_type: "PIECE_TECHNIQUE",
           article_category: "fabrique",
@@ -191,6 +199,11 @@ describe("/api/v1/stock", () => {
 
     expect(res.status).toBe(201);
     expect(res.body).toMatchObject({ article_category: "fabrique", family_code: "PT", stock_managed: true });
+    expect(
+      mocks.clientQuery.mock.calls.some((call) =>
+        Array.isArray(call[1]) && call[1].includes("ART-FAB-001-PT001-A")
+      )
+    ).toBe(true);
     expect(
       mocks.clientQuery.mock.calls.some((call) =>
         String(call[0]).includes("UPDATE public.pieces_techniques SET article_id = $2::uuid WHERE id = $1::uuid")

--- a/src/module/client/services/client.service.ts
+++ b/src/module/client/services/client.service.ts
@@ -95,7 +95,21 @@ export async function updateClientLogoPath(id: string, logoPath: string): Promis
 }
 
 
+/**
+ * A short numeric search is a client-code lookup, not a broad text search.
+ * Without this distinction, entering "001" also matched SIRETs and made the
+ * client selector unreliable. The stored legacy code may be "001", "CLI-001"
+ * or "CLI 001"; all three forms are normalized by the SQL predicate below.
+ */
+function exactClientCodeQuery(q: string): string | null {
+  const match = q.trim().match(/^(?:CLI[-\s]?)?(\d{1,3})$/i);
+  if (!match) return null;
+
+  return `CLI-${match[1].padStart(3, "0")}`;
+}
+
 export async function listClients(q = "", limit = 25): Promise<ClientRow[]> {
+  const codeQuery = exactClientCodeQuery(q);
   const sql = `
   SELECT
     c.client_id::text,
@@ -194,17 +208,34 @@ export async function listClients(q = "", limit = 25): Promise<ClientRow[]> {
 
     WHERE
       $1 = '' OR (
-        c.company_name ILIKE '%' || $1 || '%'
-        OR COALESCE(
-          NULLIF(btrim(to_jsonb(c)->>'client_code'), ''),
-          NULLIF(btrim(to_jsonb(c)->>'code_client'), '')
-        ) ILIKE '%' || $1 || '%'
-        OR c.email ILIKE '%' || $1 || '%'
-        OR c.siret ILIKE replace('%' || $1 || '%',' ','')
-        OR c.vat_number ILIKE '%' || $1 || '%'
-      OR af.city ILIKE '%' || $1 || '%'
-      OR al.city ILIKE '%' || $1 || '%'
-    )
+        CASE
+          WHEN $3::text IS NOT NULL THEN
+            'CLI-' || LPAD(
+              REGEXP_REPLACE(
+                COALESCE(
+                  NULLIF(btrim(to_jsonb(c)->>'client_code'), ''),
+                  NULLIF(btrim(to_jsonb(c)->>'code_client'), '')
+                ),
+                '^CLI[- ]?',
+                '',
+                'i'
+              ),
+              3,
+              '0'
+            ) = $3
+          ELSE
+            c.company_name ILIKE '%' || $1 || '%'
+            OR COALESCE(
+              NULLIF(btrim(to_jsonb(c)->>'client_code'), ''),
+              NULLIF(btrim(to_jsonb(c)->>'code_client'), '')
+            ) ILIKE '%' || $1 || '%'
+            OR c.email ILIKE '%' || $1 || '%'
+            OR c.siret ILIKE replace('%' || $1 || '%',' ','')
+            OR c.vat_number ILIKE '%' || $1 || '%'
+            OR af.city ILIKE '%' || $1 || '%'
+            OR al.city ILIKE '%' || $1 || '%'
+        END
+      )
 
   GROUP BY
     c.client_id, af.bill_address_id, al.delivery_address_id, ib.bank_info_id, ct.contact_id
@@ -213,7 +244,7 @@ export async function listClients(q = "", limit = 25): Promise<ClientRow[]> {
   LIMIT $2
 `;
 
-  const { rows } = await pool.query<ClientRow>(sql, [q, limit]);
+  const { rows } = await pool.query<ClientRow>(sql, [q, limit, codeQuery]);
   return rows;
 }
 // createClient (MAX+1 sur client_id) et updateClientPrimaryContact (sans

--- a/src/module/methodes/controllers/methodes.controller.ts
+++ b/src/module/methodes/controllers/methodes.controller.ts
@@ -60,6 +60,19 @@ export function buildMethodesAuditContext(req: Request): AuditContext {
   };
 }
 
+/**
+ * Express route parameters are typed as `string | string[]`. Route validators
+ * protect normal HTTP requests, but controllers must keep the same boundary
+ * when they are called by tests or by future route wiring.
+ */
+export function requiredRouteParam(req: Request, name: string): string {
+  const value = req.params[name];
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new HttpError(400, "INVALID_ROUTE_PARAM", `Paramètre de route invalide : ${name}`);
+  }
+  return value;
+}
+
 /* -------------------------------------------------------------------------- */
 /* Capacités                                                                  */
 /* -------------------------------------------------------------------------- */
@@ -100,7 +113,7 @@ export const updateMachineFamily: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildMethodesAuditContext(req);
     const body = updateFamilySchema.parse(req.body);
-    const out = await updateMachineFamilySVC(String(req.params.code).toUpperCase(), body, audit);
+    const out = await updateMachineFamilySVC(requiredRouteParam(req, "code").toUpperCase(), body, audit);
     if (!out) throw new HttpError(404, "NOT_FOUND", "Famille machine introuvable");
     res.json(out);
   } catch (error) {
@@ -130,7 +143,7 @@ export const listCostCenters: RequestHandler = async (req, res, next) => {
 
 export const getCostCenter: RequestHandler = async (req, res, next) => {
   try {
-    const out = await getCostCenterSVC(req.params.cfId);
+    const out = await getCostCenterSVC(requiredRouteParam(req, "cfId"));
     if (!out) throw new HttpError(404, "NOT_FOUND", "Centre de frais introuvable");
     res.json(out);
   } catch (error) {
@@ -152,7 +165,7 @@ export const updateCostCenter: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildMethodesAuditContext(req);
     const body = updateCostCenterSchema.parse(req.body);
-    const out = await updateCostCenterSVC(req.params.cfId, body, audit);
+    const out = await updateCostCenterSVC(requiredRouteParam(req, "cfId"), body, audit);
     if (!out) throw new HttpError(404, "NOT_FOUND", "Centre de frais introuvable");
     res.json(out);
   } catch (error) {
@@ -162,7 +175,7 @@ export const updateCostCenter: RequestHandler = async (req, res, next) => {
 
 export const listCostCenterRates: RequestHandler = async (req, res, next) => {
   try {
-    res.json(await listCostCenterRatesSVC(req.params.cfId));
+    res.json(await listCostCenterRatesSVC(requiredRouteParam(req, "cfId")));
   } catch (error) {
     next(error);
   }
@@ -172,7 +185,7 @@ export const addCostCenterRate: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildMethodesAuditContext(req);
     const body = addCostCenterRateSchema.parse(req.body);
-    res.status(201).json(await addCostCenterRateSVC(req.params.cfId, body, audit));
+    res.status(201).json(await addCostCenterRateSVC(requiredRouteParam(req, "cfId"), body, audit));
   } catch (error) {
     next(error);
   }
@@ -218,7 +231,7 @@ export const listMachinesForQualification: RequestHandler = async (req, res, nex
 
 export const getMachineQualification: RequestHandler = async (req, res, next) => {
   try {
-    const out = await getMachineQualificationSVC(req.params.machineId);
+    const out = await getMachineQualificationSVC(requiredRouteParam(req, "machineId"));
     if (!out) throw new HttpError(404, "NOT_FOUND", "Machine introuvable");
     res.json(out);
   } catch (error) {
@@ -230,7 +243,10 @@ export const getMachineQualification: RequestHandler = async (req, res, next) =>
 export const previewMachineQualification: RequestHandler = async (req, res, next) => {
   try {
     const query = validatedQuery<ReturnType<(typeof previewMachineQualificationQuerySchema)["parse"]>>(req);
-    const out = await previewMachineQualificationSVC(req.params.machineId, query.machine_family_code ?? null);
+    const out = await previewMachineQualificationSVC(
+      requiredRouteParam(req, "machineId"),
+      query.machine_family_code ?? null
+    );
     if (!out) throw new HttpError(404, "NOT_FOUND", "Machine introuvable");
     res.json(out);
   } catch (error) {
@@ -243,7 +259,7 @@ export const qualifyMachine: RequestHandler = async (req, res, next) => {
     const audit = buildMethodesAuditContext(req);
     const body = qualifyMachineSchema.parse(req.body);
     const out = await qualifyMachineSVC(
-      req.params.machineId,
+      requiredRouteParam(req, "machineId"),
       {
         machine_family_code: body.machine_family_code,
         cf_id: body.cf_id,

--- a/src/module/pieces-techniques/pieces-techniques.permissions.ts
+++ b/src/module/pieces-techniques/pieces-techniques.permissions.ts
@@ -27,7 +27,7 @@
 
 import type { Request } from "express";
 
-import { hasAnyAssignedRole } from "../auth/domain/roles";
+import { effectiveRoleHasAny, hasAnyAssignedRole } from "../auth/domain/roles";
 
 /**
  * Rédaction du dossier technique : créer/modifier une pièce, sa nomenclature, sa gamme,
@@ -42,6 +42,7 @@ export const PIECE_TECHNIQUE_WRITE_ROLES = [
   "Programmation",
   "Études-Méthodes",
   "Responsable CAO",
+  "Method",
   "Responsable Qualité",
   "Qualité",
 ] as const;
@@ -61,6 +62,7 @@ export const PIECE_TECHNIQUE_VALIDATE_ROLES = [
   "Qualité",
   "Responsable Programmation",
   "Études-Méthodes",
+  "Method",
 ] as const;
 
 /**
@@ -93,7 +95,10 @@ function allows(user: RoleBearer | null | undefined, allowed: readonly string[])
   if (!user) return false;
   // Comparaison exacte sur les rôles assignés, jamais une sous-chaîne :
   // un rôle inconnu est refusé, point.
-  return hasAnyAssignedRole(user.role, user.roles, allowed);
+  return (
+    hasAnyAssignedRole(user.role, user.roles, allowed) ||
+    effectiveRoleHasAny(user.role, allowed)
+  );
 }
 
 export const canWritePieceTechnique = (user: RoleBearer | null | undefined): boolean =>

--- a/src/module/pieces-techniques/repository/pieces-techniques-landing.test.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques-landing.test.ts
@@ -285,10 +285,12 @@ describe("colonnes de complétude", () => {
     }
   });
 
-  it("ne retient qu'une seule version applicable, la plus récente en date d'effet", async () => {
+  it("privilégie la version applicable puis la version interne la plus récente", async () => {
     await repoListPieceTechniques(parse({}));
     const dataSql = captured()[1].text;
-    expect(dataSql).toContain("ORDER BY v.date_effet DESC NULLS LAST");
+    expect(dataSql).toContain("CASE WHEN v.statut = 'APPLICABLE' THEN 0 ELSE 1 END");
+    expect(dataSql).toContain("v.version_interne DESC NULLS LAST");
+    expect(dataSql).toContain("v.id DESC");
     expect(dataSql).toContain("LIMIT 1");
   });
 

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -359,6 +359,7 @@ export async function repoListPieceTechniques(filters: ListPiecesTechniquesQuery
       p.designation,
       p.designation_2,
       p.client_id,
+      COALESCE(NULLIF(btrim(c.client_code), ''), NULLIF(btrim(p.code_client), '')) AS code_client,
       p.client_name,
       p.famille_id::text AS famille_id,
       f.code AS famille_code,
@@ -386,15 +387,25 @@ export async function repoListPieceTechniques(filters: ListPiecesTechniquesQuery
       ${HAS_DOCUMENTS_SQL} AS has_documents,
       ${TO_COMPLETE_SQL} AS to_complete
     FROM pieces_techniques p
+    LEFT JOIN clients c ON c.client_id = p.client_id
     LEFT JOIN pieces_families f ON f.id = p.famille_id
     LEFT JOIN LATERAL (
       -- #146 : la version applicable porte aussi l'indice et la référence de plan, deux
       -- informations que le préparateur cherchait jusqu'ici en ouvrant chaque fiche.
-      SELECT v.code_metier, v.indice, v.plan_reference, v.date_effet, v.version_interne
+      SELECT
+        v.code_metier,
+        COALESCE(NULLIF(btrim(v.indice_externe_original), ''), NULLIF(btrim(v.indice), '')) AS indice,
+        v.plan_reference,
+        v.date_effet,
+        v.version_interne
       FROM public.piece_technique_versions v
       WHERE v.piece_technique_id = p.id
-        AND v.statut = 'APPLICABLE'
-      ORDER BY v.date_effet DESC NULLS LAST, v.version_interne DESC NULLS LAST, v.created_at DESC
+        AND v.statut <> 'OBSOLETE'
+      ORDER BY
+        CASE WHEN v.statut = 'APPLICABLE' THEN 0 ELSE 1 END,
+        v.version_interne DESC NULLS LAST,
+        v.created_at DESC,
+        v.id DESC
       LIMIT 1
     ) current_version ON true
     LEFT JOIN (

--- a/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
+++ b/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
@@ -1,13 +1,14 @@
 // src/module/pieces-techniques/routes/pieces-techniques.routes.ts
-import { Router } from "express"
+import { Router, type RequestHandler } from "express"
 import multer from "multer"
 
 import { authenticateToken, authorizeRole } from "../../auth/middlewares/auth.middleware"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
+import { HttpError } from "../../../utils/httpError"
 import {
+  canValidatePieceTechnique,
   PIECE_DOCUMENT_POLICY_ROLES,
   PIECE_TECHNIQUE_DELETE_ROLES,
-  PIECE_TECHNIQUE_VALIDATE_ROLES,
 } from "../pieces-techniques.permissions"
 import {
   abandonPieceDraft,
@@ -115,9 +116,21 @@ const router = Router()
 // refusé » à la validation d'un indice), acceptait tout futur rôle contenant « admin »,
 // et ignorait le multi-rôles #315. Les listes vivent dans pieces-techniques.permissions.ts
 // et sont comparées aux rôles réellement assignés.
-const requireValidateRole = authorizeRole(...PIECE_TECHNIQUE_VALIDATE_ROLES)
 const requireDeleteRole = authorizeRole(...PIECE_TECHNIQUE_DELETE_ROLES)
 const requireDocumentPolicyRole = authorizeRole(...PIECE_DOCUMENT_POLICY_ROLES)
+const requireVersionApproval: RequestHandler = (req, _res, next) => {
+  if (!canValidatePieceTechnique(req.user)) {
+    next(
+      new HttpError(
+        403,
+        "PIECE_VERSION_APPROVAL_FORBIDDEN",
+        "Technical definition approval role required"
+      )
+    )
+    return
+  }
+  next()
+}
 
 const docsBaseDir = ensureDocumentStoragePath("pieces-techniques")
 
@@ -183,7 +196,7 @@ router.post("/:id/create-or-link-article-fabrique", validate(idParamSchema), cre
 router.get("/:id/versions", validate(idParamSchema), listVersions)
 router.post("/:id/versions", validate(idParamSchema), validate(createVersionSchema), createVersion)
 router.patch("/:id/versions/:versionId", validate(versionIdParamSchema), validate(updateVersionSchema), updateVersion)
-router.patch("/:id/versions/:versionId/status", requireValidateRole, validate(versionIdParamSchema), validate(versionStatusSchema), updateVersionStatus)
+router.patch("/:id/versions/:versionId/status", requireVersionApproval, validate(versionIdParamSchema), validate(versionStatusSchema), updateVersionStatus)
 router.post("/:id/versions/:versionId/create-next", validate(versionIdParamSchema), validate(createNextVersionSchema), createNextVersion)
 
 router.post("/:id/nomenclature", validate(idParamSchema), validate(addBomLineSchema), addBomLine)

--- a/src/module/pieces-techniques/types/pieces-techniques.types.ts
+++ b/src/module/pieces-techniques/types/pieces-techniques.types.ts
@@ -219,7 +219,7 @@ export type CreatePieceTechniqueInput = {
 
 export type PieceTechniqueListItem = Pick<
   PieceTechnique,
-  "id" | "article_id" | "root_piece_technique_id" | "parent_piece_technique_id" | "version_number" | "code_piece" | "designation" | "designation_2" | "client_id" | "client_name" | "famille_id" | "statut" | "en_fabrication" | "prix_unitaire" | "created_at" | "updated_at" | "ensemble"
+  "id" | "article_id" | "root_piece_technique_id" | "parent_piece_technique_id" | "version_number" | "code_piece" | "designation" | "designation_2" | "client_id" | "code_client" | "client_name" | "famille_id" | "statut" | "en_fabrication" | "prix_unitaire" | "created_at" | "updated_at" | "ensemble"
 > & {
   bom_count: number
   operations_count: number

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -594,6 +594,7 @@ async function normalizeArticleState(args: {
   code: string;
   designation: string;
   client: Pick<PoolClient, "query">;
+  preserve_existing_code?: boolean;
 }) {
   const categoryFromType = (() => {
     const articleType = typeof args.article_type === "string" ? args.article_type.trim().toUpperCase() : "";
@@ -636,13 +637,15 @@ async function normalizeArticleState(args: {
     await ensureProjetAffaireExists(args.client, projet_id);
   }
 
-  const code = await resolveArticleCode(args.client, {
-    code: args.code,
-    designation: args.designation,
-    category: article_category,
-    family_code,
-    piece_technique_id,
-  });
+  const code = args.preserve_existing_code
+    ? args.code
+    : await resolveArticleCode(args.client, {
+        code: args.code,
+        designation: args.designation,
+        category: article_category,
+        family_code,
+        piece_technique_id,
+      });
 
   return {
     article_type: article_type as "PIECE_TECHNIQUE" | "PURCHASED",
@@ -3168,6 +3171,9 @@ export async function repoUpdateArticle(
       code: current.code ?? "",
       designation: patch.designation ?? current.designation,
       client,
+      // Article business codes are immutable snapshots. A normal PATCH must
+      // not depend on the current state of the linked technical piece.
+      preserve_existing_code: true,
     });
 
     if (patch.article_matiere && normalized.article_category !== "matiere") {

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -5,7 +5,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import db from "../../../config/database";
-import { generateArticleBusinessCode, generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
+import {
+  generateArticleBusinessCode,
+  generateFabricatedArticleBusinessCode,
+  generateTransactionalBusinessCode,
+} from "../../../shared/codes/code-generator.service";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -520,10 +524,6 @@ export function normalizeArticleCategorySelection(
   };
 }
 
-function expectedFabricatedArticleCodeFromPlan(planReference: string, planIndex: number): string {
-  return `${sanitizeCodeToken(planReference, "PLAN")}-P${planIndex}`;
-}
-
 function categoryCodeSegment(category: ArticleCategory): string {
   if (category === "fabrique") return "PLAN";
   if (category === "matiere") return "MP";
@@ -538,38 +538,11 @@ function familyCodeSegment(value: string | null | undefined): string {
   return normalized.slice(0, 3);
 }
 
-async function getPieceTechniqueMetadata(
-  client: Pick<PoolClient, "query">,
-  pieceTechniqueId: string
-): Promise<{ code_piece: string; designation: string; family_code: string | null }> {
-  const res = await client.query<{ code_piece: string; designation: string; family_code: string | null }>(
-    `
-      SELECT
-        pt.code_piece,
-        pt.designation,
-        pf.code AS family_code
-      FROM public.pieces_techniques pt
-      LEFT JOIN public.pieces_families pf ON pf.id = pt.famille_id
-      WHERE pt.id = $1::uuid
-      LIMIT 1
-    `,
-    [pieceTechniqueId]
-  );
-  const row = res.rows[0] ?? null;
-  if (!row) {
-    throw new HttpError(400, "INVALID_PIECE_TECHNIQUE", "Unknown piece_technique_id");
-  }
-  return row;
-}
-
 function buildSuggestedArticleCode(args: {
   category: ArticleCategory;
   family_code: string;
   final_segment: string;
 }): string {
-  if (args.category === "fabrique") {
-    return sanitizeCodeToken(args.final_segment, "PLAN");
-  }
   return `${categoryCodeSegment(args.category)}-${familyCodeSegment(args.family_code)}-${sanitizeCodeToken(args.final_segment, "GEN")}`;
 }
 
@@ -581,34 +554,23 @@ async function resolveArticleCode(
     category: ArticleCategory;
     family_code: string;
     piece_technique_id: string | null;
-    plan_index: number;
   }
 ): Promise<string> {
-  const pieceMeta = args.piece_technique_id ? await getPieceTechniqueMetadata(client, args.piece_technique_id) : null;
-  const finalSegment = args.category === "fabrique"
-    ? sanitizeCodeToken(pieceMeta?.code_piece, "PLAN")
-    : sanitizeCodeToken(args.code || args.designation, "GEN");
+  if (args.category === "fabrique") {
+    if (!args.piece_technique_id) {
+      throw new HttpError(400, "INVALID_ARTICLE", "Fabricated articles require piece_technique_id");
+    }
+    // Client input is deliberately ignored: the server stores an immutable
+    // snapshot of the linked technical-piece identity.
+    return generateFabricatedArticleBusinessCode(client, args.piece_technique_id);
+  }
+
+  const finalSegment = sanitizeCodeToken(args.code || args.designation, "GEN");
   const suggested = buildSuggestedArticleCode({
     category: args.category,
     family_code: args.family_code,
     final_segment: finalSegment,
   });
-
-  if (args.category === "fabrique") {
-    const expected = expectedFabricatedArticleCodeFromPlan(finalSegment, args.plan_index);
-    const provided = args.code.trim();
-    if (!provided) return expected;
-
-    const normalized = normalizeFullArticleCode(provided);
-    if (normalized !== expected) {
-      throw new HttpError(
-        400,
-        "INVALID_FABRICATED_ARTICLE_CODE",
-        `Fabricated article code must match plan reference with index (${expected})`
-      );
-    }
-    return normalized;
-  }
 
   const provided = args.code.trim();
   if (!provided) return suggested;
@@ -680,7 +642,6 @@ async function normalizeArticleState(args: {
     category: article_category,
     family_code,
     piece_technique_id,
-    plan_index,
   });
 
   return {
@@ -2921,7 +2882,9 @@ export async function repoCreateArticleTx(
     designation: body.designation,
     client,
   });
-  const generatedCode = await generateArticleBusinessCode(client, normalized.family_code);
+  const generatedCode = normalized.article_category === "fabrique"
+    ? normalized.code
+    : await generateArticleBusinessCode(client, normalized.family_code);
 
   if (normalized.piece_technique_id) {
     await ensurePieceTechniqueExists(client, normalized.piece_technique_id);

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -3134,6 +3134,25 @@ export async function repoUpdateArticle(
       });
     }
 
+    const requestedCategory = patch.article_category ?? current.article_category;
+    const requestedPieceTechniqueId =
+      patch.piece_technique_id !== undefined
+        ? patch.piece_technique_id
+        : current.piece_technique_id;
+    const fabricatedIdentityChanged =
+      (current.article_category === "fabrique" || requestedCategory === "fabrique") &&
+      (
+        requestedCategory !== current.article_category ||
+        requestedPieceTechniqueId !== current.piece_technique_id
+      );
+    if (fabricatedIdentityChanged) {
+      throw new HttpError(
+        409,
+        "FABRICATED_ARTICLE_IDENTITY_IMMUTABLE",
+        "La catégorie et la pièce technique liées à un article fabriqué sont immuables. Créez un nouvel article pour une autre identité technique."
+      );
+    }
+
     const normalized = await normalizeArticleState({
       article_type: patch.article_type ?? current.article_type,
       article_category: patch.article_category ?? current.article_category,

--- a/src/shared/codes/code-generator.service.ts
+++ b/src/shared/codes/code-generator.service.ts
@@ -99,6 +99,88 @@ export async function generateArticleBusinessCode(tx: DbQueryer, familyCode: str
   return `ART-${family}-${pad(seq, 6)}`;
 }
 
+/**
+ * Canonical, immutable snapshot code for a fabricated article.
+ *
+ * The identity is read from the linked technical piece at the instant the
+ * article is created. An applicable technical version wins; a newly-created
+ * technical piece has only a draft version, so the newest non-obsolete version
+ * is used as an explicit fallback. The article code is never recalculated on
+ * later technical revisions.
+ */
+export async function generateFabricatedArticleBusinessCode(
+  tx: DbQueryer,
+  pieceTechniqueId: string
+): Promise<string> {
+  const result = await tx.query<{
+    piece_exists: boolean;
+    client_code: string | null;
+    plan_reference: string | null;
+    indice: string | null;
+    version_interne: number | string | null;
+  }>(
+    `
+      SELECT
+        true AS piece_exists,
+        COALESCE(NULLIF(btrim(c.client_code), ''), NULLIF(btrim(pt.code_client), '')) AS client_code,
+        v.plan_reference,
+        COALESCE(NULLIF(btrim(v.indice_externe_original), ''), NULLIF(btrim(v.indice), '')) AS indice,
+        v.version_interne
+      FROM public.pieces_techniques pt
+      LEFT JOIN public.clients c ON c.client_id = pt.client_id
+      LEFT JOIN LATERAL (
+        SELECT
+          pv.plan_reference,
+          pv.indice,
+          pv.indice_externe_original,
+          pv.version_interne
+        FROM public.piece_technique_versions pv
+        WHERE pv.piece_technique_id = pt.id
+          AND pv.statut <> 'OBSOLETE'
+        ORDER BY
+          CASE WHEN pv.statut = 'APPLICABLE' THEN 0 ELSE 1 END,
+          pv.version_interne DESC NULLS LAST,
+          pv.created_at DESC,
+          pv.id DESC
+        LIMIT 1
+      ) v ON true
+      WHERE pt.id = $1::uuid
+        AND pt.deleted_at IS NULL
+      LIMIT 1
+    `,
+    [pieceTechniqueId]
+  );
+
+  const source = result.rows[0];
+  if (!source?.piece_exists) {
+    throw new HttpError(400, "INVALID_PIECE_TECHNIQUE", "Pièce technique introuvable pour la codification de l'article fabriqué.");
+  }
+  if (!source.client_code?.trim()) {
+    throw new HttpError(400, "CLIENT_CODE_REQUIRED", "Code client manquant sur la pièce technique : impossible de générer le code article fabriqué.");
+  }
+  if (!source.plan_reference?.trim()) {
+    throw new HttpError(400, "PLAN_REFERENCE_REQUIRED", "Aucune version non obsolète avec référence plan n'est disponible pour cette pièce technique.");
+  }
+  if (!source.indice?.trim()) {
+    throw new HttpError(400, "INDEX_REQUIRED", "Aucune version non obsolète avec indice n'est disponible pour cette pièce technique.");
+  }
+
+  const parts = [
+    "ART",
+    "FAB",
+    normalizeClientSegment(source.client_code),
+    normalizeSegment(source.plan_reference, "Plan reference"),
+    normalizeSegment(source.indice, "External index"),
+  ];
+  const version = Number(source.version_interne);
+  if (Number.isInteger(version) && version > 1) parts.push(`V${version}`);
+
+  // `articles.code` est un TEXT indexé et les références plan PT acceptent
+  // volontairement jusqu'à 160 caractères. Ne pas introduire ici une limite
+  // arbitraire plus courte que le contrat source.
+  return parts.join("-");
+}
+
 export async function generateTransactionalBusinessCode(
   tx: DbQueryer,
   input: {

--- a/src/shared/codes/code-generator.service.ts
+++ b/src/shared/codes/code-generator.service.ts
@@ -5,6 +5,7 @@ import { HttpError } from "../../utils/httpError";
 type DbQueryer = Pick<PoolClient, "query">;
 
 const ASCII_SEGMENT = /[^A-Z0-9]+/g;
+const ASCII_PLAN_SEPARATOR = /[^A-Z0-9]+/g;
 
 function pad(n: number, width: number): string {
   return String(n).padStart(width, "0");
@@ -25,6 +26,25 @@ function normalizeSegment(value: string, field: string): string {
 
   if (!normalized) {
     throw new HttpError(400, "INVALID_CODE_SEGMENT", `${field} is required to build the business code.`);
+  }
+  return normalized;
+}
+
+/**
+ * Technical plan references often contain meaningful groups separated by
+ * spaces, slashes or dashes (for example `170 25464 001`). Keep those groups
+ * readable in business codes while normalising every separator to one dash.
+ */
+function normalizePlanReference(value: string): string {
+  const normalized = value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toUpperCase()
+    .replace(ASCII_PLAN_SEPARATOR, "-")
+    .replace(/^-+|-+$/g, "");
+
+  if (!normalized) {
+    throw new HttpError(400, "INVALID_CODE_SEGMENT", "Plan reference is required to build the business code.");
   }
   return normalized;
 }
@@ -69,7 +89,7 @@ export function previewPieceTechniqueCode(input: {
 }): string {
   return [
     normalizeClientSegment(input.clientCode),
-    normalizeSegment(input.planReference, "Plan reference"),
+    normalizePlanReference(input.planReference),
     normalizeSegment(input.indiceExterne, "External index"),
   ].join("-");
 }
@@ -169,7 +189,7 @@ export async function generateFabricatedArticleBusinessCode(
     "ART",
     "FAB",
     normalizeClientSegment(source.client_code),
-    normalizeSegment(source.plan_reference, "Plan reference"),
+    normalizePlanReference(source.plan_reference),
     normalizeSegment(source.indice, "External index"),
   ];
   const version = Number(source.version_interne);

--- a/src/shared/codes/code-validator.ts
+++ b/src/shared/codes/code-validator.ts
@@ -50,9 +50,9 @@ export const CODE_FORMATS = {
     hintText: "Format attendu: BCF-2026-0001",
   },
   article: {
-    regex: /^(ART-[A-Z0-9]+-\d{6}|ART-\d{4})$/,
-    example: "ART-USI-000042",
-    hintText: "Format attendu: ART-USI-000042",
+    regex: /^(ART-[A-Z0-9]+-\d{6}|ART-FAB-[A-Z0-9]+-[A-Z0-9]+-[A-Z0-9]+(?:-V(?:[2-9]|[1-9]\d+))?|ART-\d{4})$/,
+    example: "ART-FAB-001-17025950000-A",
+    hintText: "Formats attendus : ART-USI-000042 ou ART-FAB-001-17025950000-A[-Vn]",
   },
   // #210 — Finition de surface : code alloué par le serveur, puis immuable.
   surfaceFinish: {

--- a/src/shared/codes/code-validator.ts
+++ b/src/shared/codes/code-validator.ts
@@ -20,9 +20,9 @@ export const CODE_FORMATS = {
     hintText: "Format attendu: AFF-2026-0001",
   },
   pieceTechnique: {
-    regex: /^(?:[A-Z0-9]+-[A-Z0-9]+-[A-Z0-9]+|P-\d{3,})$/,
-    example: "001-17025950000-C",
-    hintText: "Format attendu: 001-17025950000-C",
+    regex: /^(?:[A-Z0-9]+(?:-[A-Z0-9]+){2,}|P-\d{3,})$/,
+    example: "001-170-25464-001-C",
+    hintText: "Format attendu: 001-170-25464-001-C",
   },
   of: {
     regex: /^(OF-\d{4}-\d{6}|OF-\d{4}-\d{5}|OF-\d+)$/,
@@ -50,9 +50,9 @@ export const CODE_FORMATS = {
     hintText: "Format attendu: BCF-2026-0001",
   },
   article: {
-    regex: /^(ART-[A-Z0-9]+-\d{6}|ART-FAB-[A-Z0-9]+-[A-Z0-9]+-[A-Z0-9]+(?:-V(?:[2-9]|[1-9]\d+))?|ART-\d{4})$/,
-    example: "ART-FAB-001-17025950000-A",
-    hintText: "Formats attendus : ART-USI-000042 ou ART-FAB-001-17025950000-A[-Vn]",
+    regex: /^(ART-[A-Z0-9]+-\d{6}|ART-FAB-(?!.*-V1$)[A-Z0-9]+(?:-[A-Z0-9]+){2,}(?:-V(?:[2-9]|[1-9]\d+))?|ART-\d{4})$/,
+    example: "ART-FAB-001-170-25464-001-A",
+    hintText: "Formats attendus : ART-USI-000042 ou ART-FAB-001-170-25464-001-A[-Vn]",
   },
   // #210 — Finition de surface : code alloué par le serveur, puis immuable.
   surfaceFinish: {


### PR DESCRIPTION
## Contenu
- PT sans famille obligatoire
- génération immuable ART-FAB-CODE_CLIENT-REFERENCE_PLAN-INDICE[-Vn]
- recherche exacte 1 / 001 / CLI-001
- validation de version PT restaurée pour Méthodes
- build méthodes corrigé

## Validation
- suite backend complète
- tests ciblés PT, stock, clients et codification
- build TypeScript
- préflight schéma cerp_test / cerp_prod par SSH

Issues #170 #413 #414 #256 #259

## Summary by Sourcery

Enforce immutable, plan-based business codes for fabricated articles, tighten client code and plan reference normalization, and restore robust Méthodes route validation and PT version approval authorization.

New Features:
- Introduce a canonical fabricated article business code derived from the applicable technical piece identity, including optional internal version suffixes.
- Support grouped plan references in technical piece codes and expose client plan/index information consistently in PT listings.
- Add exact client code lookup semantics so short numeric queries resolve reliably to normalized CLI-xxx codes.

Bug Fixes:
- Prevent PATCH operations from changing the identity (category or linked technical piece) of fabricated articles, preserving their immutable business codes.
- Restore strict validation of Méthodes route parameters to reject missing, empty or multi-valued IDs.
- Fix PT version approval permissions by basing authorization on effective Méthodes roles instead of brittle string matches.

Enhancements:
- Refine code validation rules to accept new PT and fabricated article formats while disallowing invalid version suffixes like V1.
- Improve selection of the current PT version by preferring applicable status and latest internal version, with deterministic ordering.
- Normalize plan reference separators in business codes to keep reference groups readable across formats.

Documentation:
- Update nomenclature documentation to describe grouped plan-reference formats and the immutable fabricated article code pattern with versioning semantics.

Tests:
- Extend stock, codification, client, Méthodes, PT RBAC and PT listing tests to cover fabricated article immutability, new code formats, exact client searches, route param validation and version selection behavior.