### PR TITLE
release: account-based ERP access

### DIFF
--- a/db/patches/20260730_account_module_access_262.sql
+++ b/db/patches/20260730_account_module_access_262.sql
@@ -1,0 +1,83 @@
+-- Autorisation CERP pilotée uniquement par compte et par module (#262 / frontend #422).
+--
+-- Etat cible :
+--   * tous les modules actifs et ouverts par défaut ;
+--   * aucune restriction historique au moment du basculement ;
+--   * seules les futures lignes DENIED ferment un module pour un compte ;
+--   * KEENAN est l'unique superadministrateur de la Tour de contrôle.
+--
+-- Les rôles métier restent des données descriptives et d'affectation. Ils ne
+-- décident plus de la visibilité ni des capacités d'action dans un module.
+--
+-- Préflight : db/patches/support/20260730_account_module_access_262.preflight.sql
+-- Verify    : db/patches/support/20260730_account_module_access_262.verify.sql
+
+BEGIN;
+
+DO $guard$
+DECLARE
+  keenan_count integer;
+BEGIN
+  IF to_regclass('public.users') IS NULL
+     OR to_regclass('public.app_modules') IS NULL
+     OR to_regclass('public.app_module_user_access') IS NULL
+     OR to_regclass('public.app_module_access_events') IS NULL THEN
+    RAISE EXCEPTION 'access #262 : infrastructure de contrôle des accès incomplète';
+  END IF;
+
+  SELECT count(*)::integer
+  INTO keenan_count
+  FROM public.users
+  WHERE upper(trim(username)) = 'KEENAN';
+
+  IF keenan_count <> 1 THEN
+    RAISE EXCEPTION
+      'access #262 : exactement un compte KEENAN attendu, trouvé %',
+      keenan_count;
+  END IF;
+END
+$guard$;
+
+-- Le privilège de redistribution des accès appartient à un compte unique.
+UPDATE public.users
+SET is_superadmin = (upper(trim(username)) = 'KEENAN')
+WHERE is_superadmin IS DISTINCT FROM (upper(trim(username)) = 'KEENAN');
+
+-- Le défaut global n'est plus une décision d'exploitation : le catalogue est
+-- toujours actif et ouvert. La fermeture se fait exclusivement par compte.
+UPDATE public.app_modules
+SET enabled_by_default = true,
+    is_active = true,
+    updated_at = now()
+WHERE enabled_by_default IS DISTINCT FROM true
+   OR is_active IS DISTINCT FROM true;
+
+-- Conserver une preuve append-only avant de remettre tous les comptes à zéro.
+INSERT INTO public.app_module_access_events (
+  user_id,
+  module_key,
+  event_type,
+  previous_state,
+  next_state,
+  actor_user_id,
+  source
+)
+SELECT
+  access.user_id,
+  access.module_key,
+  'UNLOCK_ALL',
+  access.access,
+  'INHERIT',
+  keenan.id,
+  'migration_262_account_default_allow'
+FROM public.app_module_user_access AS access
+CROSS JOIN LATERAL (
+  SELECT id
+  FROM public.users
+  WHERE upper(trim(username)) = 'KEENAN'
+  LIMIT 1
+) AS keenan;
+
+DELETE FROM public.app_module_user_access;
+
+COMMIT;

--- a/db/patches/support/20260730_account_module_access_262.preflight.sql
+++ b/db/patches/support/20260730_account_module_access_262.preflight.sql
@@ -1,0 +1,25 @@
+\set ON_ERROR_STOP on
+
+SELECT
+  to_regclass('public.users') AS users_table,
+  to_regclass('public.app_modules') AS modules_table,
+  to_regclass('public.app_module_user_access') AS overrides_table,
+  to_regclass('public.app_module_access_events') AS events_table;
+
+SELECT
+  count(*) FILTER (WHERE upper(trim(username)) = 'KEENAN') AS keenan_accounts,
+  count(*) FILTER (WHERE COALESCE(is_superadmin, false)) AS current_superadmins,
+  count(*) AS users_total
+FROM public.users;
+
+SELECT
+  count(*) AS modules_total,
+  count(*) FILTER (WHERE NOT enabled_by_default) AS closed_by_default,
+  count(*) FILTER (WHERE NOT is_active) AS inactive_modules
+FROM public.app_modules;
+
+SELECT
+  count(*) AS overrides_total,
+  count(*) FILTER (WHERE access = 'DENIED') AS denied_total,
+  count(*) FILTER (WHERE access = 'GRANTED') AS granted_total
+FROM public.app_module_user_access;

--- a/db/patches/support/20260730_account_module_access_262.verify.sql
+++ b/db/patches/support/20260730_account_module_access_262.verify.sql
@@ -1,0 +1,55 @@
+\set ON_ERROR_STOP on
+
+DO $verify$
+DECLARE
+  invalid_superadmins integer;
+  keenan_superadmins integer;
+  closed_modules integer;
+  overrides_count integer;
+BEGIN
+  SELECT count(*)::integer
+  INTO invalid_superadmins
+  FROM public.users
+  WHERE COALESCE(is_superadmin, false)
+    AND upper(trim(username)) <> 'KEENAN';
+
+  SELECT count(*)::integer
+  INTO keenan_superadmins
+  FROM public.users
+  WHERE upper(trim(username)) = 'KEENAN'
+    AND COALESCE(is_superadmin, false);
+
+  SELECT count(*)::integer
+  INTO closed_modules
+  FROM public.app_modules
+  WHERE NOT enabled_by_default OR NOT is_active;
+
+  SELECT count(*)::integer
+  INTO overrides_count
+  FROM public.app_module_user_access;
+
+  IF invalid_superadmins <> 0 THEN
+    RAISE EXCEPTION 'access #262 verify : % superadmin(s) autre(s) que KEENAN', invalid_superadmins;
+  END IF;
+  IF keenan_superadmins <> 1 THEN
+    RAISE EXCEPTION 'access #262 verify : KEENAN superadmin attendu une fois, trouvé %', keenan_superadmins;
+  END IF;
+  IF closed_modules <> 0 THEN
+    RAISE EXCEPTION 'access #262 verify : % module(s) fermé(s) ou inactif(s)', closed_modules;
+  END IF;
+  IF overrides_count <> 0 THEN
+    RAISE EXCEPTION 'access #262 verify : % override(s) résiduel(s)', overrides_count;
+  END IF;
+END
+$verify$;
+
+SELECT
+  u.id,
+  u.username,
+  u.is_superadmin,
+  count(m.module_key)::integer AS modules_visibles_par_defaut
+FROM public.users AS u
+CROSS JOIN public.app_modules AS m
+WHERE m.is_active
+GROUP BY u.id, u.username, u.is_superadmin
+ORDER BY u.username;

--- a/docs/module-access-catalog.md
+++ b/docs/module-access-catalog.md
@@ -1,8 +1,32 @@
 # Catalogue de visibilité des modules
 
-Le contrôle de visibilité par compte repose sur `public.app_modules` et
-`public.app_module_user_access`. Il ne remplace pas les autorisations métier :
-les routes concernées gardent leurs contrôles RBAC propres.
+Le contrôle d'accès par compte repose sur `public.app_modules` et
+`public.app_module_user_access`.
+
+## Politique autoritaire #262
+
+Depuis le 30 juillet 2026, les rôles sont descriptifs et ne portent plus
+d'autorisation :
+
+- tout module actif est ouvert par défaut à tout compte authentifié ;
+- seule une ligne `DENIED` pour un couple compte × module ferme l'accès ;
+- `INHERIT` signifie ouvert et supprime l'override ;
+- un ancien `GRANTED` est normalisé en `INHERIT` ;
+- le défaut global ne peut plus être fermé ;
+- les capacités historiques basées sur le rôle sont traversées après
+  autorisation du module ;
+- les invariants métier qui ne dépendent pas du rôle restent appliqués ;
+- les API `/admin/access` sont réservées au statut `is_superadmin`, attribué
+  uniquement au compte KEENAN.
+
+Le middleware global porte la décision autorisée dans un contexte asynchrone
+jusqu'aux politiques profondes. L'identité, le rôle descriptif et les données
+d'audit ne sont pas modifiés. Un `DENIED` est refusé avant la route.
+
+Le patch `20260730_account_module_access_262.sql` ouvre et active le catalogue,
+journalise les anciens overrides avant de les retirer et garantit l'unicité du
+superadmin KEENAN. Préflight et vérification sont obligatoires sur `cerp_test`
+avant `cerp_prod`.
 
 ## Réparation #402
 

--- a/src/__tests__/access-control.gate.test.ts
+++ b/src/__tests__/access-control.gate.test.ts
@@ -139,11 +139,11 @@ describe("Gate d'accès module — passages sans interrogation de la base", () =
     expect(repo.repoResolveAccessProfile).not.toHaveBeenCalled();
   });
 
-  it("laisse passer le module protégé sans résoudre aucun profil", async () => {
+  it("laisse passer le module protégé après résolution du compte", async () => {
     const { res, next } = await run("/admin/users");
     expect(next).toHaveBeenCalledOnce();
     expect(res.statusCode).toBe(0);
-    expect(repo.repoResolveAccessProfile).not.toHaveBeenCalled();
+    expect(repo.repoResolveAccessProfile).toHaveBeenCalledOnce();
   });
 
   it("laisse passer quand aucun utilisateur n'est attaché à la requête", async () => {
@@ -177,12 +177,13 @@ describe("Gate d'accès module — décisions", () => {
     expect(JSON.stringify(res.body)).not.toMatch(/module|superadmin|catalogue|interdit au module/i);
   });
 
-  it("défaut catalogue désactivé ⇒ 403 sans override", async () => {
+  it("un ancien défaut catalogue désactivé n'a plus aucun effet", async () => {
     repo.repoResolveAccessProfile.mockResolvedValue([
       profileRow({ module_key: "clients", enabled_by_default: false }),
     ]);
-    const { res } = await run("/clients/1");
-    expect(res.statusCode).toBe(403);
+    const { res, next } = await run("/clients/1");
+    expect(next).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(0);
   });
 
   it("module désactivé au catalogue ⇒ 403", async () => {

--- a/src/__tests__/access-control.test.ts
+++ b/src/__tests__/access-control.test.ts
@@ -214,10 +214,10 @@ describe("Catalogue de modules #326", () => {
     expect(resolveModuleKeyForPath("/stock/")).toBe("stock");
   });
 
-  it("ne rattache aucune surface d'infrastructure partagée à un module", () => {
+  it("rattache les journaux à Administration et laisse les autres surfaces partagées hors catalogue", () => {
+    expect(resolveModuleKeyForPath("/audit-logs")).toBe("administration");
     for (const path of [
       "/auth/login",
-      "/audit-logs",
       "/codes/formats",
       "/notifications",
       "/chat/threads",
@@ -234,12 +234,12 @@ describe("Catalogue de modules #326", () => {
 });
 
 describe("Règles métier de la tour de contrôle", () => {
-  it("refuse 409 MODULE_PROTECTED de restreindre le module protégé", async () => {
+  it("refuse tout défaut global fermé et protège le module administration", async () => {
     repo.repoGetCatalogModule.mockResolvedValue(PROTECTED_ROW);
 
     await expect(
       service.setModuleDefault({ moduleKey: "administration", enabled: false, audit: AUDIT })
-    ).rejects.toMatchObject({ status: 409, code: "MODULE_PROTECTED" });
+    ).rejects.toMatchObject({ status: 409, code: "ACCOUNT_ONLY_ACCESS_POLICY" });
 
     await expect(
       service.setUserModuleAccess({
@@ -254,7 +254,7 @@ describe("Règles métier de la tour de contrôle", () => {
     expect(repo.repoSetModuleDefault).not.toHaveBeenCalled();
   });
 
-  it("autorise en revanche un GRANTED explicite sur le module protégé", async () => {
+  it("normalise un ancien GRANTED explicite en ouverture par défaut", async () => {
     repo.repoGetCatalogModule.mockResolvedValue(PROTECTED_ROW);
     await service.setUserModuleAccess({
       userId: OPERATEUR_ID,
@@ -262,7 +262,7 @@ describe("Règles métier de la tour de contrôle", () => {
       decision: "GRANTED",
       audit: AUDIT,
     });
-    expect(repo.repoUpsertUserModuleAccess).toHaveBeenCalledOnce();
+    expect(repo.repoUpsertUserModuleAccess).not.toHaveBeenCalled();
   });
 
   it("refuse 409 SUPERADMIN_IMMUTABLE de refuser un module à un superadmin", async () => {
@@ -345,7 +345,7 @@ describe("Règles métier de la tour de contrôle", () => {
       audit: AUDIT,
     });
 
-    expect(repo.repoUpsertUserModuleAccess).toHaveBeenCalledTimes(2);
+    expect(repo.repoUpsertUserModuleAccess).toHaveBeenCalledTimes(1);
     const auditActions = mocks.txQuery.mock.calls
       .filter((call) => String(call[0]).includes("INSERT INTO erp_audit_logs"))
       .map((call) => (call[1] as unknown[])[2]);
@@ -395,10 +395,10 @@ describe("Résolution du profil d'accès", () => {
     },
   ];
 
-  it("hérite du défaut catalogue quand aucun override n'existe", async () => {
+  it("reste ouvert même si une ancienne valeur catalogue vaut false", async () => {
     repo.repoResolveAccessProfile.mockResolvedValue(profileRows({ enabled: false }));
     const profile = await service.getAccessProfile(OPERATEUR_ID);
-    expect(profile.modules[0]).toMatchObject({ allowed: false, source: "DEFAULT" });
+    expect(profile.modules[0]).toMatchObject({ allowed: true, source: "DEFAULT" });
   });
 
   it("l'override explicite prime sur le défaut catalogue", async () => {
@@ -524,7 +524,7 @@ describe("Surface HTTP /admin/access", () => {
     expect(Object.keys(res.body).sort()).toEqual(["matrix", "modules", "summary", "users"]);
   });
 
-  it("409 MODULE_PROTECTED via l'API quand on tente de restreindre l'administration", async () => {
+  it("409 ACCOUNT_ONLY_ACCESS_POLICY via l'API pour toute fermeture globale", async () => {
     repo.repoIsSuperadmin.mockResolvedValue(true);
     repo.repoGetCatalogModule.mockResolvedValue(PROTECTED_ROW);
     const res = await request(app)
@@ -534,7 +534,7 @@ describe("Surface HTTP /admin/access", () => {
       .send({ enabled_by_default: false });
 
     expect(res.status).toBe(409);
-    expect(res.body).toMatchObject({ code: "MODULE_PROTECTED" });
+    expect(res.body).toMatchObject({ code: "ACCOUNT_ONLY_ACCESS_POLICY" });
   });
 
   it("400 CONFIRMATION_REQUIRED sur « tout débloquer » sans la phrase exacte", async () => {

--- a/src/__tests__/production-execution-274.domain.test.ts
+++ b/src/__tests__/production-execution-274.domain.test.ts
@@ -158,10 +158,10 @@ describe("#274 séparation des tâches", () => {
     ).not.toThrow();
   });
 
-  it("exempte la direction, qui n'a personne au-dessus d'elle", () => {
+  it("n'exempte aucun rôle de la séparation auteur/validateur", () => {
     expect(() =>
       assertSeparationOfDuties({ actorUserId: 1, ownerUserId: 1, actorRole: ADMIN })
-    ).not.toThrow();
+    ).toThrowError(/propre auteur/i);
   });
 });
 

--- a/src/module/access-control/context/account-module-access.context.ts
+++ b/src/module/access-control/context/account-module-access.context.ts
@@ -1,0 +1,31 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export type AccountModuleAccessContext = {
+  userId: number;
+  moduleKey: string;
+};
+
+const accountModuleAccessStorage = new AsyncLocalStorage<AccountModuleAccessContext>();
+
+/**
+ * Runs the complete Express request chain with the account/module decision
+ * resolved by the global gate.
+ *
+ * Legacy policies still receive a role string in deep service and repository
+ * calls. This context lets them stop using the role as an authorization source
+ * without mutating the authenticated identity or weakening the superadmin guard.
+ */
+export function runWithAccountModuleAccess(
+  context: AccountModuleAccessContext,
+  callback: () => void
+): void {
+  accountModuleAccessStorage.run(context, callback);
+}
+
+export function hasGrantedAccountModuleAccess(): boolean {
+  return accountModuleAccessStorage.getStore() !== undefined;
+}
+
+export function getAccountModuleAccessContext(): AccountModuleAccessContext | undefined {
+  return accountModuleAccessStorage.getStore();
+}

--- a/src/module/access-control/domain/module-catalog.ts
+++ b/src/module/access-control/domain/module-catalog.ts
@@ -263,7 +263,7 @@ export const MODULE_CATALOG: readonly ModuleCatalogEntry[] = [
     label: "Administration",
     description: "Comptes, rôles, réglages ERP et tour de contrôle des accès.",
     category: "Système",
-    api_prefixes: ["/admin"],
+    api_prefixes: ["/admin", "/audit-logs"],
     nav_page_keys: ["administration", "erp-settings", "acces"],
     is_protected: true,
     sort_order: 200,

--- a/src/module/access-control/middlewares/module-access-gate.ts
+++ b/src/module/access-control/middlewares/module-access-gate.ts
@@ -1,7 +1,8 @@
 import type { NextFunction, Request, Response } from "express";
 
 import { stripQueryFromUrl } from "../../../utils/logPath";
-import { isProtectedModuleKey, resolveModuleKeyForPath } from "../domain/module-catalog";
+import { runWithAccountModuleAccess } from "../context/account-module-access.context";
+import { resolveModuleKeyForPath } from "../domain/module-catalog";
 import { resolveAccessProfile } from "../services/access-control.service";
 
 const KILL_SWITCH_ENV = "CERP_MODULE_ACCESS_GATE_DISABLED";
@@ -48,7 +49,9 @@ function warnMissingInfrastructure(reason: string, moduleKey: string | null): vo
  *
  * Le chemin est résolu vers un module par le catalogue TypeScript (plus long
  * préfixe, frontière de segment) ; seule la DÉCISION vient de la base. Surface
- * hors catalogue, module protégé et superadmin passent sans aucune requête.
+ * hors catalogue passe sans aucune requête. Les modules protégés sont résolus
+ * comme les autres afin d'installer le contexte de capacités ; ils restent
+ * toujours ouverts et non restreignables.
  */
 export function moduleAccessGate(req: Request, res: Response, next: NextFunction): void {
   if (isGateDisabled()) {
@@ -58,7 +61,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
   }
 
   const moduleKey = resolveModuleKeyForPath(req.path);
-  if (!moduleKey || isProtectedModuleKey(moduleKey)) {
+  if (!moduleKey) {
     next();
     return;
   }
@@ -78,7 +81,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
         return;
       }
       if (profile.is_superadmin) {
-        next();
+        runWithAccountModuleAccess({ userId: user.id, moduleKey }, next);
         return;
       }
 
@@ -91,7 +94,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
         return;
       }
       if (decision.allowed) {
-        next();
+        runWithAccountModuleAccess({ userId: user.id, moduleKey }, next);
         return;
       }
 

--- a/src/module/access-control/services/access-control.service.ts
+++ b/src/module/access-control/services/access-control.service.ts
@@ -39,13 +39,14 @@ export function invalidateAccessCache(userId?: number): void {
 function decide(params: {
   isSuperadmin: boolean;
   isActive: boolean;
-  enabledByDefault: boolean;
+  isProtected: boolean;
   override: ModuleAccessOverride | null;
 }): { allowed: boolean; source: ModuleAccessSource } {
   if (params.isSuperadmin) return { allowed: true, source: "SUPERADMIN" };
+  if (params.isProtected) return { allowed: true, source: "DEFAULT" };
   if (!params.isActive) return { allowed: false, source: "DEFAULT" };
-  if (params.override) return { allowed: params.override === "GRANTED", source: "OVERRIDE" };
-  return { allowed: params.enabledByDefault, source: "DEFAULT" };
+  if (params.override === "DENIED") return { allowed: false, source: "OVERRIDE" };
+  return { allowed: true, source: params.override === "GRANTED" ? "OVERRIDE" : "DEFAULT" };
 }
 
 /**
@@ -66,7 +67,7 @@ export async function resolveAccessProfile(userId: number): Promise<ResolvedAcce
     const { allowed, source } = decide({
       isSuperadmin,
       isActive: row.is_active !== false,
-      enabledByDefault: row.enabled_by_default !== false,
+      isProtected: row.is_protected === true,
       override: row.access,
     });
     modules.push({
@@ -122,7 +123,7 @@ export async function buildOverview(tx?: DbQueryer): Promise<AccessOverview> {
       const { allowed, source } = decide({
         isSuperadmin: user.is_superadmin,
         isActive: module.is_active,
-        enabledByDefault: module.enabled_by_default,
+        isProtected: module.is_protected,
         override,
       });
       matrix.push({ user_id: user.id, module_key: module.module_key, access: override, effective: allowed, source });
@@ -213,6 +214,13 @@ export async function setModuleDefault(params: {
   enabled: boolean;
   audit: AccessAuditContext;
 }): Promise<AccessOverview> {
+  if (!params.enabled) {
+    throw new HttpError(
+      409,
+      "ACCOUNT_ONLY_ACCESS_POLICY",
+      "Le défaut global est toujours ouvert. Restreignez un compte sur un module."
+    );
+  }
   const overview = await repo.withTransaction(async (tx) => {
     const module = await loadModuleOrThrow(tx, params.moduleKey);
     if (module.is_protected && !params.enabled) {
@@ -257,7 +265,10 @@ async function applyUserModuleDecision(
     targetIsSuperadmin: boolean;
   }
 ): Promise<{ previous: ModuleAccessOverride | null; next: ModuleAccessDecision } | null> {
-  if (params.decision === "DENIED") {
+  const decision: ModuleAccessDecision =
+    params.decision === "GRANTED" ? "INHERIT" : params.decision;
+
+  if (decision === "DENIED") {
     if (params.module.is_protected) {
       throw new HttpError(409, "MODULE_PROTECTED", "Ce module ne peut pas être restreint.");
     }
@@ -267,18 +278,18 @@ async function applyUserModuleDecision(
   }
 
   const previous = await repo.repoGetUserModuleAccess(params.userId, params.module.module_key, tx);
-  if (params.decision === "INHERIT") {
+  if (decision === "INHERIT") {
     if (previous === null) return null;
     await repo.repoDeleteUserModuleAccess(tx, {
       userId: params.userId,
       moduleKey: params.module.module_key,
     });
   } else {
-    if (previous === params.decision) return null;
+    if (previous === decision) return null;
     await repo.repoUpsertUserModuleAccess(tx, {
       userId: params.userId,
       moduleKey: params.module.module_key,
-      access: params.decision,
+      access: decision,
       updatedBy: params.actorUserId,
     });
   }
@@ -286,13 +297,13 @@ async function applyUserModuleDecision(
   await repo.repoInsertAccessEvent(tx, {
     userId: params.userId,
     moduleKey: params.module.module_key,
-    eventType: params.decision === "INHERIT" ? "INHERITED" : params.decision,
+    eventType: decision === "INHERIT" ? "INHERITED" : decision,
     previousState: previous ?? "INHERIT",
-    nextState: params.decision,
+    nextState: decision,
     actorUserId: params.actorUserId,
   });
 
-  return { previous, next: params.decision };
+  return { previous, next: decision };
 }
 
 async function loadTargetUser(tx: DbQueryer, userId: number) {

--- a/src/module/affaire/domain/affaire-rbac.ts
+++ b/src/module/affaire/domain/affaire-rbac.ts
@@ -47,6 +47,7 @@ const CAPABILITY_ROLE_NEEDLES: Record<AffaireCapability, readonly string[]> = {
 };
 
 export function roleHasAffaireCapability(role: string | null | undefined, capability: AffaireCapability): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   if (!role) return false;
   const normalized = role.trim().toLowerCase();
   if (!normalized) return false;
@@ -66,3 +67,4 @@ export function capabilityForTransition(kind: AffaireTransitionKind): AffaireCap
       return "transition";
   }
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/audit-logs/controllers/audit-logs.controller.ts
+++ b/src/module/audit-logs/controllers/audit-logs.controller.ts
@@ -3,8 +3,10 @@ import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 import * as service from "../services/audit-logs.service";
 import { createAuditLogBodySchema, listAuditLogsQuerySchema } from "../validators/audit-logs.validators";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 
 function isAdminRole(role: string | undefined): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   if (!role) return false;
   const r = role.trim().toLowerCase();
   return r.includes("admin") || r.includes("administrateur");
@@ -41,7 +43,6 @@ export const listAuditLogs: RequestHandler = async (req, res, next) => {
     const user = req.user;
     if (!user || typeof user.id !== "number") throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
     if (!isAdminRole(user.role)) throw new HttpError(403, "FORBIDDEN", "Admin role required");
-
     const filters = listAuditLogsQuerySchema.parse(req.query);
     const out = await service.svcListAuditLogs(filters);
     res.json(out);

--- a/src/module/auth/middlewares/auth.middleware.ts
+++ b/src/module/auth/middlewares/auth.middleware.ts
@@ -1,11 +1,12 @@
-import { Request, Response, NextFunction, RequestHandler } from 'express';
-import jwt from 'jsonwebtoken';
-import { stripQueryFromUrl } from '../../../utils/logPath';
+import { Request, Response, NextFunction, RequestHandler } from "express";
+import jwt from "jsonwebtoken";
+import { stripQueryFromUrl } from "../../../utils/logPath";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import {
   effectiveRoleHasAny,
   hasAnyAssignedRole,
   normalizeAssignedRoles,
-} from '../domain/roles';
+} from "../domain/roles";
 
 interface JwtPayload {
   id: number;
@@ -16,7 +17,6 @@ interface JwtPayload {
   roles?: string[];
 }
 
-// 🔧 Ajout de `req.user` pour tout Express
 declare global {
   namespace Express {
     interface Request {
@@ -25,7 +25,6 @@ declare global {
   }
 }
 
-// 🔐 Vérifie le token JWT
 export const authenticateToken: RequestHandler = (req, res, next) => {
   const authHeader = req.headers.authorization;
   const ctx = {
@@ -34,14 +33,14 @@ export const authenticateToken: RequestHandler = (req, res, next) => {
     method: req.method,
     path: stripQueryFromUrl(req.originalUrl),
   };
- 
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
     console.warn(JSON.stringify({ type: "auth_fail", reason: "missing_bearer", ...ctx }));
-    res.status(401).json({ error: 'Token manquant ou invalide' });
+    res.status(401).json({ error: "Token manquant ou invalide" });
     return;
   }
 
-  const token = authHeader.split(' ')[1];
+  const token = authHeader.split(" ")[1];
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET as string) as JwtPayload;
@@ -56,57 +55,62 @@ export const authenticateToken: RequestHandler = (req, res, next) => {
         ...ctx,
       })
     );
-    res.status(401).json({ error: 'Token invalide ou expiré' });
+    res.status(401).json({ error: "Token invalide ou expiré" });
   }
 };
 
-// 🎯 Vérifie que l'utilisateur a un rôle autorisé
+/**
+ * Compatibility wrapper kept for existing routes.
+ *
+ * Roles are descriptive metadata only. Authenticated business access is
+ * resolved per account and per module by moduleAccessGate. The Access Control
+ * Tower does not use this wrapper: requireSuperadmin checks the database
+ * account flag independently.
+ */
 export const authorizeRole = (...roles: string[]) => {
-    return (req: Request, res: Response, next: NextFunction): void => {
-      if (!req.user) {
-        console.warn(
-          JSON.stringify({
-            type: "auth_fail",
-            reason: "missing_user",
-            requestId: req.requestId ?? null,
-            origin: req.headers.origin ?? null,
-            method: req.method,
-            path: stripQueryFromUrl(req.originalUrl),
-          })
-        );
-        res.status(401).json({ error: 'Utilisateur non authentifié' });
-        return;
-      }
-  
-      const primaryRole = req.user.primary_role ?? req.user.role;
-      const assignedRoles = normalizeAssignedRoles(primaryRole, req.user.roles);
-      // Multi-role sessions expose both the raw assignments and the explicit
-      // authorization aliases in `role`. Exact guards must understand both:
-      // e.g. `Assistante polyvalente` is deliberately aliased to `Secretaire`,
-      // while `Directeur Technique` is not aliased to the global `Directeur`.
-      const hasAssignedMatch = hasAnyAssignedRole(primaryRole, assignedRoles, roles);
-      const hasEffectiveMatch = effectiveRoleHasAny(req.user.role, roles);
-      if (!hasAssignedMatch && !hasEffectiveMatch) {
-        console.warn(
-          JSON.stringify({
-            type: "auth_forbidden",
-            requestId: req.requestId ?? null,
-            origin: req.headers.origin ?? null,
-            method: req.method,
-            path: stripQueryFromUrl(req.originalUrl),
-            userId: req.user.id,
-            role: primaryRole,
-            roles: assignedRoles,
-            allowedRoles: roles,
-          })
-        );
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!req.user) {
+      console.warn(
+        JSON.stringify({
+          type: "auth_fail",
+          reason: "missing_user",
+          requestId: req.requestId ?? null,
+          origin: req.headers.origin ?? null,
+          method: req.method,
+          path: stripQueryFromUrl(req.originalUrl),
+        })
+      );
+      res.status(401).json({ error: "Utilisateur non authentifié" });
+      return;
+    }
 
-       res.status(403).json({ error: 'Accès interdit' });
-
-        return;
-      }
-  
+    if (hasGrantedAccountModuleAccess()) {
       next();
-    };
+      return;
+    }
+
+    const primaryRole = req.user.primary_role ?? req.user.role;
+    const assignedRoles = normalizeAssignedRoles(primaryRole, req.user.roles);
+    const hasAssignedMatch = hasAnyAssignedRole(primaryRole, assignedRoles, roles);
+    const hasEffectiveMatch = effectiveRoleHasAny(req.user.role, roles);
+    if (!hasAssignedMatch && !hasEffectiveMatch) {
+      console.warn(
+        JSON.stringify({
+          type: "auth_forbidden",
+          requestId: req.requestId ?? null,
+          origin: req.headers.origin ?? null,
+          method: req.method,
+          path: stripQueryFromUrl(req.originalUrl),
+          userId: req.user.id,
+          role: primaryRole,
+          roles: assignedRoles,
+          allowedRoles: roles,
+        })
+      );
+      res.status(403).json({ error: "Accès interdit" });
+      return;
+    }
+
+    next();
   };
-  
+};

--- a/src/module/client/client.permissions.ts
+++ b/src/module/client/client.permissions.ts
@@ -1,4 +1,5 @@
 import { effectiveRoleHasAny } from "../auth/domain/roles";
+import { hasGrantedAccountModuleAccess } from "../access-control/context/account-module-access.context";
 
 /**
  * RBAC clients — rôles existants uniquement (contrainte users_role_check,
@@ -27,6 +28,7 @@ export const CLIENT_FINANCE_ROLES = [
 ] as const;
 
 export function canViewClientFinance(role: string | undefined | null): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   return effectiveRoleHasAny(role, CLIENT_FINANCE_ROLES);
 }
 

--- a/src/module/commande-client/domain/commande-client-rbac.ts
+++ b/src/module/commande-client/domain/commande-client-rbac.ts
@@ -1,4 +1,5 @@
 import { effectiveRoleHasAny } from "../../auth/domain/roles";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 
 export const INTERNAL_ORDER_LAUNCH_ROLES = [
   "Directeur",
@@ -15,5 +16,6 @@ export const INTERNAL_ORDER_LAUNCH_ROLES = [
 ] as const;
 
 export function canLaunchInternalOrder(role: string | null | undefined): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   return effectiveRoleHasAny(role, INTERNAL_ORDER_LAUNCH_ROLES);
 }

--- a/src/module/commande-client/routes/commande-client.routes.ts
+++ b/src/module/commande-client/routes/commande-client.routes.ts
@@ -2,6 +2,7 @@ import type { RequestHandler } from "express"
 import { Router } from "express"
 import multer from "multer"
 
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context"
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
 import { HttpError } from "../../../utils/httpError"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
@@ -97,6 +98,10 @@ function isOfficeSupportRole(role: string | undefined): boolean {
 }
 
 const requireOfficeSupportOrAdmin: RequestHandler = (req, _res, next) => {
+  if (hasGrantedAccountModuleAccess()) {
+    next()
+    return
+  }
   const role = req.user?.role
   if (!isAdminRole(role) && !isOfficeSupportRole(role)) {
     next(new HttpError(403, "FORBIDDEN", "Secretary or accounting role required"))

--- a/src/module/commande-fournisseur/domain/commande-fournisseur-rbac.ts
+++ b/src/module/commande-fournisseur/domain/commande-fournisseur-rbac.ts
@@ -59,6 +59,7 @@ export function roleHasCommandeFournisseurCapability(
   role: string | null | undefined,
   capability: CommandeFournisseurCapability
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   if (!role) return false;
   const normalized = role.trim().toLowerCase();
   if (!normalized) return false;
@@ -90,3 +91,4 @@ export function capabilityForTransition(
       return "cancel";
   }
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/devis/domain/devis-rbac.ts
+++ b/src/module/devis/domain/devis-rbac.ts
@@ -53,6 +53,7 @@ const CAPABILITY_ROLE_NEEDLES: Record<DevisCapability, readonly string[]> = {
 };
 
 export function roleHasDevisCapability(role: string | null | undefined, capability: DevisCapability): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   if (!role) return false;
   const normalized = role.trim().toLowerCase();
   if (!normalized) return false;
@@ -79,3 +80,4 @@ export const DEVIS_TRANSITION_CAPABILITIES: readonly DevisCapability[] = [
   "cancel",
   "update_draft",
 ];
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/facturation/domain/finance-policy.ts
+++ b/src/module/facturation/domain/finance-policy.ts
@@ -92,6 +92,7 @@ export function roleHasFinanceCapability(
   role: string | null | undefined,
   capability: FinanceCapability
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   if (effectiveRoleHasAny(role, [ROLES.administrator])) return true;
   return effectiveRoleHasAny(role, [...CAPABILITY_ROLES[capability]]);
 }
@@ -217,3 +218,4 @@ export function paymentStatusFromAllocation(params: {
   if (params.allocatedCents < params.paymentCents) return "PARTIALLY_ALLOCATED";
   return "ALLOCATED";
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/ged/domain/ged-policy.ts
+++ b/src/module/ged/domain/ged-policy.ts
@@ -72,6 +72,7 @@ export function roleHasGedCapability(
   role: string | null | undefined,
   capability: GedCapability
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const normalized = (role ?? "").trim().toLowerCase();
   if (!normalized) return false;
   const needles = CAPABILITY_NEEDLES[capability];
@@ -229,3 +230,4 @@ export function fileExtension(name: string): string {
   const match = /\.([a-zA-Z0-9]{1,10})$/.exec(name);
   return match ? `.${match[1].toLowerCase()}` : "";
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/livraisons/domain/livraisons-rbac.ts
+++ b/src/module/livraisons/domain/livraisons-rbac.ts
@@ -30,7 +30,9 @@ export function roleHasLivraisonCapability(
   role: string | null | undefined,
   capability: LivraisonCapability
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true
   const normalized = (role ?? "").trim().toLowerCase()
   if (!normalized) return false
   return NEEDLES[capability].some((needle) => normalized.includes(needle))
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context"

--- a/src/module/methodes/domain/methodes-policy.ts
+++ b/src/module/methodes/domain/methodes-policy.ts
@@ -93,6 +93,7 @@ export function roleHasMethodesCapability(
   role: string | null | undefined,
   capability: MethodesCapability
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const normalized = (role ?? "").trim().toLowerCase();
   if (!normalized) return false;
   const needles = CAPABILITY_NEEDLES[capability];
@@ -746,3 +747,4 @@ export function assertOptimisticVersion(params: {
     );
   }
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/metrologie/domain/metrology-policy.ts
+++ b/src/module/metrologie/domain/metrology-policy.ts
@@ -116,6 +116,7 @@ export function roleHasMetrologyCapability(
   role: string | null | undefined,
   capability: MetrologyCapability
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const normalized = (role ?? "").trim().toLowerCase();
   if (!normalized) return false;
   const needles = CAPABILITY_NEEDLES[capability];
@@ -691,3 +692,4 @@ export function assertOptimisticVersion(params: {
     );
   }
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/pieces-techniques/domain/pieces-techniques-rbac.ts
+++ b/src/module/pieces-techniques/domain/pieces-techniques-rbac.ts
@@ -1,4 +1,5 @@
 import { effectiveRoleHasAny } from "../../auth/domain/roles";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 
 /**
  * Releasing a technical definition is distinct from deleting one.
@@ -17,5 +18,6 @@ export const PIECE_TECHNIQUE_VERSION_APPROVAL_ROLES = [
 export function canApprovePieceTechniqueVersion(
   role: string | null | undefined
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   return effectiveRoleHasAny(role, PIECE_TECHNIQUE_VERSION_APPROVAL_ROLES);
 }

--- a/src/module/pieces-techniques/pieces-techniques.permissions.ts
+++ b/src/module/pieces-techniques/pieces-techniques.permissions.ts
@@ -27,6 +27,7 @@
 
 import type { Request } from "express";
 
+import { hasGrantedAccountModuleAccess } from "../access-control/context/account-module-access.context";
 import { effectiveRoleHasAny, hasAnyAssignedRole } from "../auth/domain/roles";
 
 /**
@@ -93,6 +94,7 @@ type RoleBearer = Pick<NonNullable<Request["user"]>, "role"> & { roles?: string[
 
 function allows(user: RoleBearer | null | undefined, allowed: readonly string[]): boolean {
   if (!user) return false;
+  if (hasGrantedAccountModuleAccess()) return true;
   // Comparaison exacte sur les rôles assignés, jamais une sous-chaîne :
   // un rôle inconnu est refusé, point.
   return (

--- a/src/module/planning/domain/planning-rbac.ts
+++ b/src/module/planning/domain/planning-rbac.ts
@@ -36,9 +36,12 @@ const FORCE_OVERLAP_ROLES = new Set([
 ]);
 
 export function roleHasPlanningAccess(role: string | null | undefined): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   return effectiveRoleParts(role).some((part) => PLANNING_ACCESS_ROLES.has(normalizeRole(part)));
 }
 
 export function roleCanForcePlanningOverlap(role: string | null | undefined): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   return effectiveRoleParts(role).some((part) => FORCE_OVERLAP_ROLES.has(normalizeRole(part)));
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/production/domain/machine-rbac.ts
+++ b/src/module/production/domain/machine-rbac.ts
@@ -24,7 +24,9 @@ const NEEDLES: Record<MachineCapability, readonly string[]> = {
 };
 
 export function roleHasMachineCapability(role: string | null | undefined, capability: MachineCapability): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const normalized = (role ?? "").trim().toLowerCase();
   if (!normalized) return false;
   return NEEDLES[capability].some((needle) => normalized.includes(needle));
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/production/domain/of-rbac.ts
+++ b/src/module/production/domain/of-rbac.ts
@@ -96,6 +96,7 @@ function foldRole(role: string): string {
 }
 
 export function roleHasOfCapability(role: string | null | undefined, capability: OfCapability): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const normalized = foldRole(role ?? "");
   if (!normalized) return false;
   return NEEDLES[capability].some((needle) => normalized.includes(foldRole(needle)));
@@ -118,3 +119,4 @@ export function capabilityForOfTransition(_from: OfStatut, to: OfStatut): OfCapa
       return "edit_prelaunch";
   }
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/production/domain/production-execution.ts
+++ b/src/module/production/domain/production-execution.ts
@@ -14,6 +14,7 @@
 import crypto from "node:crypto";
 
 import { HttpError } from "../../../utils/httpError";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 
 /* -------------------------------------------------------------------------- */
 /* 1) Capacités RBAC — refus par défaut                                       */
@@ -91,6 +92,7 @@ export function roleHasProductionExecutionCapability(
   role: string | null | undefined,
   capability: ProductionExecutionCapability
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const normalized = (role ?? "").trim().toLowerCase();
   if (!normalized) return false;
   const needles = CAPABILITY_NEEDLES[capability];
@@ -200,9 +202,6 @@ export function assertSeparationOfDuties(params: {
   actorRole: string | null | undefined;
 }): void {
   if (params.actorUserId !== params.ownerUserId) return;
-  const normalized = (params.actorRole ?? "").trim().toLowerCase();
-  const exempt = ["admin", "administrateur", "directeur"].some((needle) => normalized.includes(needle));
-  if (exempt) return;
   throw new HttpError(
     409,
     "PRODUCTION_EXECUTION_SELF_VALIDATION_FORBIDDEN",

--- a/src/module/production/domain/station.ts
+++ b/src/module/production/domain/station.ts
@@ -111,6 +111,7 @@ export function roleHasStationCapability(
   role: string | null | undefined,
   capability: StationCapability
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const normalized = (role ?? "").trim().toLowerCase();
   if (!normalized) return false;
   const needles = CAPABILITY_NEEDLES[capability];
@@ -1039,3 +1040,4 @@ export function sanitizeAuditDetail(detail: Record<string, unknown>): Record<str
   }
   return out;
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/production/routes/production.routes.ts
+++ b/src/module/production/routes/production.routes.ts
@@ -1,6 +1,7 @@
 import { Router, type RequestHandler } from "express";
 import multer from "multer";
 
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { upload } from "../../../middlewares/upload";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
@@ -93,6 +94,10 @@ function isProductionRole(role: string | undefined): boolean {
 }
 
 const requireAdmin: RequestHandler = (req, _res, next) => {
+  if (hasGrantedAccountModuleAccess()) {
+    next();
+    return;
+  }
   if (!isAdminRole(req.user?.role)) {
     next(new HttpError(403, "FORBIDDEN", "Admin role required"));
     return;
@@ -101,6 +106,10 @@ const requireAdmin: RequestHandler = (req, _res, next) => {
 };
 
 const requireProductionOrAdmin: RequestHandler = (req, _res, next) => {
+  if (hasGrantedAccountModuleAccess()) {
+    next();
+    return;
+  }
   const role = req.user?.role;
   if (!isAdminRole(role) && !isProductionRole(role)) {
     next(new HttpError(403, "FORBIDDEN", "Production, atelier, secretariat or admin role required"));

--- a/src/module/programmation/routes/programmation.routes.ts
+++ b/src/module/programmation/routes/programmation.routes.ts
@@ -1,4 +1,5 @@
 import { Router, type RequestHandler } from "express";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { HttpError } from "../../../utils/httpError";
 import { healthProgrammations, listProgrammations } from "../controllers/programmation.controller";
@@ -16,6 +17,10 @@ function isProductionRole(role: string | undefined): boolean {
 }
 
 const requireProductionOrAdmin: RequestHandler = (req, _res, next) => {
+  if (hasGrantedAccountModuleAccess()) {
+    next();
+    return;
+  }
   const role = req.user?.role;
   if (!isAdminRole(role) && !isProductionRole(role)) {
     next(new HttpError(403, "FORBIDDEN", "Production, atelier, secretariat or admin role required"));

--- a/src/module/project-office/controllers/project-office.controller.ts
+++ b/src/module/project-office/controllers/project-office.controller.ts
@@ -1,6 +1,7 @@
 import type { Request, Response } from "express";
 import { asyncHandler } from "../../../utils/asyncHandler";
 import { HttpError } from "../../../utils/httpError";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import type { AuditContext } from "../repository/project-office.repository";
 import { hasProjectOfficeAccess } from "../services/project-office-access.service";
 
@@ -54,6 +55,6 @@ export function buildAuditContext(req: Request): AuditContext {
 // répond { project_office: false } au lieu de 403 pour piloter l'affichage de la nav.
 export const getAccess = asyncHandler(async (req: Request, res: Response) => {
   const user = requireUser(req);
-  const ok = await hasProjectOfficeAccess(user.id);
+  const ok = hasGrantedAccountModuleAccess() || await hasProjectOfficeAccess(user.id);
   res.json({ project_office: ok });
 });

--- a/src/module/project-office/middlewares/require-project-office-access.ts
+++ b/src/module/project-office/middlewares/require-project-office-access.ts
@@ -1,4 +1,5 @@
 import type { NextFunction, Request, Response } from "express";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { hasProjectOfficeAccess } from "../services/project-office-access.service";
 
 // Gate du module Project Office (#130) — monté en tête du routeur /project-office,
@@ -8,6 +9,10 @@ export function requireProjectOfficeAccess(req: Request, res: Response, next: Ne
   const user = req.user;
   if (!user || typeof user.id !== "number") {
     res.status(401).json({ error: "Utilisateur non authentifié" });
+    return;
+  }
+  if (hasGrantedAccountModuleAccess()) {
+    next();
     return;
   }
   hasProjectOfficeAccess(user.id)

--- a/src/module/project-office/repository/project-office.repository.ts
+++ b/src/module/project-office/repository/project-office.repository.ts
@@ -1,5 +1,6 @@
 import type { PoolClient } from "pg";
 import pool from "../../../config/database";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import type {
@@ -170,6 +171,7 @@ export async function repoGetProjectAccess(
   if (Number(row.owner_id) === userId) effective = "OWNER";
   else if (row.member_role) effective = row.member_role;
   else if (row.visibility === "INTERNAL") effective = "VIEWER";
+  if (!effective && hasGrantedAccountModuleAccess()) effective = "MANAGER";
   if (!effective) return null; // PRIVATE/PILOT non-membre ⇒ invisible (404 contrôlé, pas de fuite)
   return { project_id: row.id, visibility: row.visibility, owner_id: Number(row.owner_id), effective_role: effective };
 }
@@ -180,7 +182,9 @@ export async function repoListProjects(
   q: DbQueryer = pool
 ): Promise<{ items: ProjectRow[]; total: number }> {
   const conds: string[] = [
-    `(p.owner_id = $1 OR p.visibility = 'INTERNAL' OR EXISTS (
+    hasGrantedAccountModuleAccess()
+      ? "TRUE"
+      : `(p.owner_id = $1 OR p.visibility = 'INTERNAL' OR EXISTS (
         SELECT 1 FROM public.project_members m WHERE m.project_id = p.id AND m.user_id = $1))`,
   ];
   const params: unknown[] = [userId];

--- a/src/module/project-office/services/project-office-access.service.ts
+++ b/src/module/project-office/services/project-office-access.service.ts
@@ -1,4 +1,5 @@
 import { HttpError } from "../../../utils/httpError";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import {
   PROJECT_OFFICE_FLAG_KEY,
   repoGetProjectAccess,
@@ -8,6 +9,7 @@ import type { Actor, PoMemberRole, ProjectAccess } from "../types/project-office
 
 // Accès au module : feature flag fail-closed (flag absent/OFF ⇒ false), override par utilisateur.
 export async function hasProjectOfficeAccess(userId: number): Promise<boolean> {
+  if (hasGrantedAccountModuleAccess()) return true;
   return repoResolveFeatureAccess(PROJECT_OFFICE_FLAG_KEY, userId);
 }
 
@@ -21,10 +23,12 @@ const WRITE_ROLES: PoMemberRole[] = ["OWNER", "MANAGER", "CONTRIBUTOR"];
 const MANAGE_ROLES: PoMemberRole[] = ["OWNER", "MANAGER"];
 
 export function canWrite(access: ProjectAccess): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   return access.effective_role !== null && WRITE_ROLES.includes(access.effective_role);
 }
 
 export function canManage(access: ProjectAccess): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   return access.effective_role !== null && MANAGE_ROLES.includes(access.effective_role);
 }
 

--- a/src/module/qualite/domain/quality-policy.ts
+++ b/src/module/qualite/domain/quality-policy.ts
@@ -74,6 +74,7 @@ export function roleHasQualityCapability(
   role: string | null | undefined,
   capability: QualityCapability
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const normalized = (role ?? "").trim().toLowerCase();
   if (!normalized) return false;
   const needles = CAPABILITY_NEEDLES[capability];
@@ -525,3 +526,4 @@ export function assertOptimisticVersion(params: {
     );
   }
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/qualite/routes/qualite.routes.ts
+++ b/src/module/qualite/routes/qualite.routes.ts
@@ -1,6 +1,7 @@
 import { Router, type RequestHandler } from "express";
 import multer from "multer";
 
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
@@ -52,6 +53,10 @@ function isQualityRole(role: string | undefined): boolean {
 }
 
 const requireQualityOrAdmin: RequestHandler = (req, _res, next) => {
+  if (hasGrantedAccountModuleAccess()) {
+    next();
+    return;
+  }
   const role = req.user?.role;
   if (!isAdminRole(role) && !isQualityRole(role)) {
     next(new HttpError(403, "FORBIDDEN", "Quality role required"));

--- a/src/module/stock/domain/stock-rbac.ts
+++ b/src/module/stock/domain/stock-rbac.ts
@@ -63,7 +63,9 @@ export function roleHasStockCapability(
   role: string | null | undefined,
   capability: StockCapability
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const normalized = (role ?? "").trim().toLowerCase();
   if (!normalized) return false;
   return NEEDLES[capability].some((needle) => normalized.includes(needle));
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/stock/stock-article.permissions.ts
+++ b/src/module/stock/stock-article.permissions.ts
@@ -1,4 +1,5 @@
 import { effectiveRoleHasAny } from "../auth/domain/roles";
+import { hasGrantedAccountModuleAccess } from "../access-control/context/account-module-access.context";
 
 export const ARTICLE_WRITE_ROLES = [
   "Directeur",
@@ -41,5 +42,6 @@ export const ARTICLE_COST_ROLES = [
 ] as const;
 
 export function canViewArticleCosts(role: string | null | undefined): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   return effectiveRoleHasAny(role, ARTICLE_COST_ROLES);
 }

--- a/src/module/surface-finish/domain/surface-finish-policy.ts
+++ b/src/module/surface-finish/domain/surface-finish-policy.ts
@@ -98,6 +98,7 @@ export function roleHasSurfaceFinishCapability(
   role: string | null | undefined,
   capability: SurfaceFinishCapability
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const normalized = (role ?? "").trim().toLowerCase();
   if (!normalized) return false;
   const needles = CAPABILITY_NEEDLES[capability];
@@ -1094,3 +1095,4 @@ export const PURCHASE_LINE_TYPE = "TRAITEMENT" as const;
  * documente le mapping et on l'expose pour que l'UI dise la vérité.
  */
 export const SUPPLIER_CATALOGUE_CATEGORY = "SOUS_TRAITANCE" as const;
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/temps-deplacements/controllers/temps-deplacements.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements.controller.ts
@@ -2,6 +2,7 @@ import type { Request, Response } from "express";
 import { asyncHandler } from "../../../utils/asyncHandler";
 import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import type { AuditContext } from "../repository/temps-deplacements.repository";
 import * as repo from "../repository/temps-deplacements.repository";
 import * as svc from "../services/temps-deplacements.service";
@@ -52,6 +53,7 @@ export function requireUser(req: Request): { id: number; role: string } {
 
 // RBAC lecture d'un employé : soi-même, OU son manager, OU un rôle RH/Direction/Admin.
 export function isHrPrivileged(role: string): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const r = role.toLowerCase();
   return r.includes("rh") || r.includes("directeur") || r.includes("direction") || r.includes("administrateur");
 }

--- a/src/module/temps-deplacements/services/temps-deplacements-corrections.service.ts
+++ b/src/module/temps-deplacements/services/temps-deplacements-corrections.service.ts
@@ -1,4 +1,5 @@
 import { HttpError } from "../../../utils/httpError";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import {
   repoCreateAdjustment,
   repoDecideAdjustment,
@@ -28,6 +29,7 @@ export type Actor = { id: number; role: string };
 
 // Miroir de isHrPrivileged du contrôleur T2 (rôle RH/Direction/Admin). Pur ⇒ testable directement.
 export function isHrPrivileged(role: string): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const r = role.toLowerCase();
   return r.includes("rh") || r.includes("directeur") || r.includes("direction") || r.includes("administrateur");
 }

--- a/src/module/traceability/domain/traceability-policy.ts
+++ b/src/module/traceability/domain/traceability-policy.ts
@@ -191,6 +191,7 @@ export function roleHasTraceabilityCapability(
   role: string | null | undefined,
   capability: TraceabilityCapability
 ): boolean {
+  if (hasGrantedAccountModuleAccess()) return true;
   const normalized = (role ?? "").trim().toLowerCase();
   if (!normalized) return false;
   const needles = CAPABILITY_NEEDLES[capability];
@@ -334,3 +335,4 @@ export function clampSearchLimit(value: number | undefined): number {
   }
   return Math.max(1, Math.min(TRACEABILITY_LIMITS.SEARCH_MAX_LIMIT, Math.trunc(value)));
 }
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";


### PR DESCRIPTION
Release of #263 after cerp_test migration and verification.

- sole authorization source: account x module
- explicit DENIED only
- KEENAN remains sole Access Control Tower administrator
- full backend suite passed
- cerp_test post-migration verification passed

## Summary by Sourcery

Switch ERP access control to an account×module-based policy with modules open by default and superadmin restricted to KEENAN, preserving roles as descriptive metadata only.

New Features:
- Introduce an async context to propagate granted account×module access decisions through the request chain so legacy RBAC policies can treat module authorization as already resolved.

Enhancements:
- Update the module access gate and service logic so protected modules stay always open, only explicit per-account DENIED entries can restrict access, and historical GRANTED overrides normalize to inheritance.
- Relax numerous RBAC checks across functional domains to defer to the global account×module authorization, while keeping business invariants like separation of duties intact.
- Extend the module catalog to attach audit-log surfaces to the Administration module and ensure superadmin-only access APIs enforce the new account-only access policy.

Build:
- Add preflight, migration, and verification SQL patches to enforce a single KEENAN superadmin, open all active modules by default, and clear historical per-account overrides in a controlled way.

Deployment:
- Enforce production rollout via mandatory cerp_test preflight and verification scripts before applying the access-control migration to cerp_prod.

Documentation:
- Document the new authoritative account×module access policy, deprecation of role-based authorization, and the migration/verification workflow in the module access catalog and SQL patch notes.

Tests:
- Adapt access-control and gate tests to the new default-open behavior, protected-module handling, GRANTED normalization, and updated error codes for global access configuration.
- Strengthen production separation-of-duties tests to reflect that no role is exempt from the self-validation guard.