### PR TITLE
fix(access): supprimer les derniers refus hérités des rôles

### DIFF
--- a/docs/module-access-catalog.md
+++ b/docs/module-access-catalog.md
@@ -22,6 +22,11 @@ d'autorisation :
 Le middleware global porte la décision autorisée dans un contexte asynchrone
 jusqu'aux politiques profondes. L'identité, le rôle descriptif et les données
 d'audit ne sont pas modifiés. Un `DENIED` est refusé avant la route.
+L'identifiant du compte est normalisé lorsqu'un ancien jeton JWT le fournit
+sous forme de chaîne numérique, afin que la décision nominative reste
+autoritaire. Le kill-switch d'exploitation désactive uniquement les refus
+nominatifs : il conserve ce contexte d'autorisation et ne réactive donc jamais
+les anciens refus fondés sur le rôle.
 
 Le patch `20260730_account_module_access_262.sql` ouvre et active le catalogue,
 journalise les anciens overrides avant de les retirer et garantit l'unicité du

--- a/src/__tests__/access-control.gate.test.ts
+++ b/src/__tests__/access-control.gate.test.ts
@@ -25,6 +25,16 @@ vi.mock("../utils/checkNetworkDrive", () => ({
   checkNetworkDrive: vi.fn(() => Promise.resolve()),
 }));
 
+vi.mock("../module/production/controllers/pointages.controller", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../module/production/controllers/pointages.controller")>();
+  return {
+    ...actual,
+    pointagesKpis: (_req: unknown, res: { json: (body: unknown) => void }) =>
+      res.json({ ok: true }),
+  };
+});
+
 vi.mock("../module/auth/middlewares/auth.middleware", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../module/auth/middlewares/auth.middleware")>();
   return {
@@ -57,6 +67,7 @@ import type { NextFunction, Request, Response } from "express";
 
 import app from "../config/app";
 import * as baseRepo from "../module/access-control/repository/access-control.repository";
+import { hasGrantedAccountModuleAccess } from "../module/access-control/context/account-module-access.context";
 import { moduleAccessGate } from "../module/access-control/middlewares/module-access-gate";
 import { invalidateAccessCache } from "../module/access-control/services/access-control.service";
 
@@ -80,7 +91,7 @@ function fakeRes(): FakeRes {
 
 // `null` signifie explicitement « aucun utilisateur attaché », ce qu'un paramètre
 // optionnel ne permettrait pas de distinguer de l'absence d'argument.
-function fakeReq(path: string, user: { id: number } | null): Request {
+function fakeReq(path: string, user: { id: number | string } | null): Request {
   return {
     path,
     originalUrl: `/api/v1${path}`,
@@ -109,12 +120,15 @@ function profileRow(overrides: {
   };
 }
 
-async function run(path: string, user: { id: number } | null = { id: USER_ID }) {
+async function run(path: string, user: { id: number | string } | null = { id: USER_ID }) {
   const res = fakeRes();
-  const next = vi.fn() as unknown as NextFunction;
+  let accountPolicyInstalled = false;
+  const next = vi.fn(() => {
+    accountPolicyInstalled = hasGrantedAccountModuleAccess();
+  }) as unknown as NextFunction;
   moduleAccessGate(fakeReq(path, user), res, next);
   await new Promise((resolve) => setTimeout(resolve, 0));
-  return { res, next: next as unknown as ReturnType<typeof vi.fn> };
+  return { res, next: next as unknown as ReturnType<typeof vi.fn>, accountPolicyInstalled };
 }
 
 beforeEach(() => {
@@ -157,10 +171,11 @@ describe("Gate d'accès module — passages sans interrogation de la base", () =
     repo.repoResolveAccessProfile.mockResolvedValue([
       profileRow({ module_key: "clients", access: "DENIED" }),
     ]);
-    const { res, next } = await run("/clients/1");
+    const { res, next, accountPolicyInstalled } = await run("/clients/1");
     expect(next).toHaveBeenCalledOnce();
     expect(res.statusCode).toBe(0);
     expect(repo.repoResolveAccessProfile).not.toHaveBeenCalled();
+    expect(accountPolicyInstalled).toBe(true);
   });
 });
 
@@ -201,6 +216,20 @@ describe("Gate d'accès module — décisions", () => {
     const { res, next } = await run("/clients/1");
     expect(next).toHaveBeenCalledOnce();
     expect(res.statusCode).toBe(0);
+  });
+
+  it("normalise un identifiant de compte numérique issu du JWT", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "production" }),
+    ]);
+
+    const { next, accountPolicyInstalled } = await run("/production/pointages/kpis", {
+      id: "21",
+    });
+
+    expect(repo.repoResolveAccessProfile).toHaveBeenCalledWith(21);
+    expect(next).toHaveBeenCalledOnce();
+    expect(accountPolicyInstalled).toBe(true);
   });
 
   it("le refus d'un module n'en refuse aucun autre", async () => {
@@ -275,6 +304,19 @@ describe("Gate d'accès module — absence d'infrastructure", () => {
 });
 
 describe("Gate d'accès module — application réelle", () => {
+  it("ouvre les KPI de pointage à un compte authentifié sans rôle production", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "production" }),
+    ]);
+
+    const res = await request(app)
+      .get("/api/v1/production/pointages/kpis?date_from=2026-07-30&date_to=2026-07-30")
+      .set("x-test-role", "Employee");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
   it("refuse 403 sur une route métier réelle, sans fuiter le motif", async () => {
     repo.repoResolveAccessProfile.mockResolvedValue([
       profileRow({ module_key: "clients", access: "DENIED" }),

--- a/src/module/access-control/middlewares/module-access-gate.ts
+++ b/src/module/access-control/middlewares/module-access-gate.ts
@@ -11,6 +11,17 @@ function isGateDisabled(): boolean {
   return process.env[KILL_SWITCH_ENV] === "1";
 }
 
+function normalizeUserId(value: unknown): number | null {
+  if (typeof value === "number" && Number.isSafeInteger(value) && value > 0) {
+    return value;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+  }
+  return null;
+}
+
 let killSwitchWarned = false;
 
 function warnKillSwitchOnce(): void {
@@ -54,26 +65,28 @@ function warnMissingInfrastructure(reason: string, moduleKey: string | null): vo
  * toujours ouverts et non restreignables.
  */
 export function moduleAccessGate(req: Request, res: Response, next: NextFunction): void {
-  if (isGateDisabled()) {
-    warnKillSwitchOnce();
-    next();
-    return;
-  }
-
   const moduleKey = resolveModuleKeyForPath(req.path);
   if (!moduleKey) {
     next();
     return;
   }
 
-  const user = req.user;
-  if (!user || typeof user.id !== "number") {
+  const userId = normalizeUserId(req.user?.id);
+  if (userId === null) {
     // Le socle authenticateToken a déjà statué : rien à ajouter ici.
     next();
     return;
   }
 
-  resolveAccessProfile(user.id)
+  if (isGateDisabled()) {
+    warnKillSwitchOnce();
+    // Le kill-switch désactive seulement les refus nominatifs. Il ne doit
+    // jamais réactiver les anciens refus par rôle dans la suite de la requête.
+    runWithAccountModuleAccess({ userId, moduleKey }, next);
+    return;
+  }
+
+  resolveAccessProfile(userId)
     .then((profile) => {
       if (profile === null) {
         warnMissingInfrastructure("access_tables_missing", moduleKey);
@@ -81,7 +94,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
         return;
       }
       if (profile.is_superadmin) {
-        runWithAccountModuleAccess({ userId: user.id, moduleKey }, next);
+        runWithAccountModuleAccess({ userId, moduleKey }, next);
         return;
       }
 
@@ -94,7 +107,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
         return;
       }
       if (decision.allowed) {
-        runWithAccountModuleAccess({ userId: user.id, moduleKey }, next);
+        runWithAccountModuleAccess({ userId, moduleKey }, next);
         return;
       }
 
@@ -103,7 +116,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
           type: "auth_forbidden",
           module: moduleKey,
           reason: "module_access_denied",
-          userId: user.id,
+          userId,
           requestId: req.requestId ?? null,
           method: req.method,
           path: stripQueryFromUrl(req.originalUrl),


### PR DESCRIPTION
Closes #265

- conserve le contexte d'accès nominatif lorsque le kill-switch est actif
- normalise les identifiants numériques issus des anciens JWT
- couvre le KPI de pointage avec un compte sans rôle Production
- documente l'autorité exclusive des accès par compte

Validation : suite backend complète et build TypeScript.

## Summary by Sourcery

Preserve nominative module access decisions while the kill-switch is active and ensure account-based access remains authoritative over legacy role-based refusals.

Bug Fixes:
- Normalize numeric account identifiers coming from legacy JWTs so access profiles are resolved with a consistent user ID type.
- Maintain the account-module access context even when the module-access kill-switch is enabled, preventing regression to role-based refusals.

Enhancements:
- Expose production pointing KPIs to authenticated accounts without a Production role when nominative access allows it.
- Extend module access gate logging and decision flow to operate on normalized account identifiers instead of raw request user IDs.

Documentation:
- Clarify in the access catalog that account IDs from legacy JWTs are normalized and that the kill-switch only disables nominative refusals while preserving account-based authority.

Tests:
- Add tests covering numeric-string JWT user IDs, kill-switch behavior preserving account access context, and KPI access for non-Production-role accounts.