### PR TITLE
fix(access): éliminer les derniers retours aux rôles

### DIFF
--- a/docs/module-access-catalog.md
+++ b/docs/module-access-catalog.md
@@ -22,6 +22,12 @@ d'autorisation :
 Le middleware global porte la décision autorisée dans un contexte asynchrone
 jusqu'aux politiques profondes. L'identité, le rôle descriptif et les données
 d'audit ne sont pas modifiés. Un `DENIED` est refusé avant la route.
+Ce contexte est ouvert dès l'entrée dans `/api/v1`, puis marqué comme accordé
+par le gate : il reste ainsi disponible dans les routeurs imbriqués, les
+middlewares asynchrones et les services profonds. Les surfaces partagées
+authentifiées qui ne correspondent à aucun module (par exemple les réponses de
+capacités UI) reçoivent également ce contexte ; elles ne recréent jamais une
+autorisation par rôle.
 L'identifiant du compte est normalisé lorsqu'un ancien jeton JWT le fournit
 sous forme de chaîne numérique, afin que la décision nominative reste
 autoritaire. Le kill-switch d'exploitation désactive uniquement les refus

--- a/src/__tests__/access-control.gate.test.ts
+++ b/src/__tests__/access-control.gate.test.ts
@@ -35,6 +35,16 @@ vi.mock("../module/production/controllers/pointages.controller", async (importOr
   };
 });
 
+vi.mock("../module/metrologie/controllers/metrology-360.controller", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../module/metrologie/controllers/metrology-360.controller")>();
+  return {
+    ...actual,
+    center: (_req: unknown, res: { json: (body: unknown) => void }) =>
+      res.json({ ok: true }),
+  };
+});
+
 vi.mock("../module/auth/middlewares/auth.middleware", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../module/auth/middlewares/auth.middleware")>();
   return {
@@ -148,9 +158,10 @@ afterEach(() => {
 
 describe("Gate d'accès module — passages sans interrogation de la base", () => {
   it("laisse passer une surface d'infrastructure partagée sans résoudre aucun profil", async () => {
-    const { next } = await run("/users/4");
+    const { next, accountPolicyInstalled } = await run("/users/4");
     expect(next).toHaveBeenCalledOnce();
     expect(repo.repoResolveAccessProfile).not.toHaveBeenCalled();
+    expect(accountPolicyInstalled).toBe(true);
   });
 
   it("laisse passer le module protégé après résolution du compte", async () => {
@@ -304,6 +315,20 @@ describe("Gate d'accès module — absence d'infrastructure", () => {
 });
 
 describe("Gate d'accès module — application réelle", () => {
+  it("ouvre les capacités partagées Méthodes sans revenir au rôle", async () => {
+    const res = await request(app)
+      .get("/api/v1/methodes/capabilities")
+      .set("x-test-role", "Employee");
+
+    expect(res.status).toBe(200);
+    expect(res.body.capabilities).toMatchObject({
+      referentiel_read: true,
+      referentiel_write: true,
+      tarif_read: true,
+      tarif_write: true,
+    });
+  });
+
   it("ouvre les KPI de pointage à un compte authentifié sans rôle production", async () => {
     repo.repoResolveAccessProfile.mockResolvedValue([
       profileRow({ module_key: "production" }),
@@ -311,6 +336,19 @@ describe("Gate d'accès module — application réelle", () => {
 
     const res = await request(app)
       .get("/api/v1/production/pointages/kpis?date_from=2026-07-30&date_to=2026-07-30")
+      .set("x-test-role", "Employee");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("ouvre Métrologie 360 à un compte autorisé sans rôle Métrologie", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "metrologie" }),
+    ]);
+
+    const res = await request(app)
+      .get("/api/v1/metrologie/v2/center?horizon_days=30")
       .set("x-test-role", "Employee");
 
     expect(res.status).toBe(200);

--- a/src/module/access-control/context/account-module-access.context.ts
+++ b/src/module/access-control/context/account-module-access.context.ts
@@ -1,11 +1,24 @@
 import { AsyncLocalStorage } from "node:async_hooks";
 
 export type AccountModuleAccessContext = {
-  userId: number;
-  moduleKey: string;
+  userId: number | null;
+  moduleKey: string | null;
+  granted: boolean;
 };
 
 const accountModuleAccessStorage = new AsyncLocalStorage<AccountModuleAccessContext>();
+
+/**
+ * Installe le contexte dès l'entrée dans le routeur v1. La décision est
+ * complétée ensuite par le gate. Ce cycle de vie englobe toute la chaîne
+ * Express, y compris les routeurs imbriqués et leurs middlewares asynchrones.
+ */
+export function runWithAccountModuleAccessScope(callback: () => void): void {
+  accountModuleAccessStorage.run(
+    { userId: null, moduleKey: null, granted: false },
+    callback
+  );
+}
 
 /**
  * Runs the complete Express request chain with the account/module decision
@@ -16,14 +29,22 @@ const accountModuleAccessStorage = new AsyncLocalStorage<AccountModuleAccessCont
  * without mutating the authenticated identity or weakening the superadmin guard.
  */
 export function runWithAccountModuleAccess(
-  context: AccountModuleAccessContext,
+  context: Pick<AccountModuleAccessContext, "userId" | "moduleKey">,
   callback: () => void
 ): void {
-  accountModuleAccessStorage.run(context, callback);
+  const existing = accountModuleAccessStorage.getStore();
+  if (existing) {
+    existing.userId = context.userId;
+    existing.moduleKey = context.moduleKey;
+    existing.granted = true;
+    callback();
+    return;
+  }
+  accountModuleAccessStorage.run({ ...context, granted: true }, callback);
 }
 
 export function hasGrantedAccountModuleAccess(): boolean {
-  return accountModuleAccessStorage.getStore() !== undefined;
+  return accountModuleAccessStorage.getStore()?.granted === true;
 }
 
 export function getAccountModuleAccessContext(): AccountModuleAccessContext | undefined {

--- a/src/module/access-control/middlewares/module-access-gate.ts
+++ b/src/module/access-control/middlewares/module-access-gate.ts
@@ -65,16 +65,20 @@ function warnMissingInfrastructure(reason: string, moduleKey: string | null): vo
  * toujours ouverts et non restreignables.
  */
 export function moduleAccessGate(req: Request, res: Response, next: NextFunction): void {
-  const moduleKey = resolveModuleKeyForPath(req.path);
-  if (!moduleKey) {
-    next();
-    return;
-  }
-
   const userId = normalizeUserId(req.user?.id);
   if (userId === null) {
     // Le socle authenticateToken a déjà statué : rien à ajouter ici.
     next();
+    return;
+  }
+
+  const moduleKey =
+    resolveModuleKeyForPath(req.originalUrl) ??
+    resolveModuleKeyForPath(req.path);
+  if (!moduleKey) {
+    // Les surfaces partagées authentifiées (utilisateurs, codes,
+    // notifications, capabilities…) ne sont pas restrictibles par module.
+    runWithAccountModuleAccess({ userId, moduleKey: "shared" }, next);
     return;
   }
 

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -56,19 +56,22 @@ import methodesRoutes from "../module/methodes/routes/methodes.routes"
 import importAssistantRoutes from "../module/import-assistant/routes/import-assistant.routes"
 import accessControlRoutes from "../module/access-control/routes/access-control.routes"
 import { moduleAccessGate } from "../module/access-control/middlewares/module-access-gate"
+import { runWithAccountModuleAccessScope } from "../module/access-control/context/account-module-access.context"
 const router = Router()
+
+router.use((_req, _res, next) => runWithAccountModuleAccessScope(next))
 
 // --- Routes publiques (avant authentification) ---
 router.use("/auth", authRoutes)
 
-// 🔒 Socle default-deny (ISO/IEC 27001 A.5.15 / A.8.3) : toute route sous /api/v1
-// définie APRÈS cette ligne exige un JWT valide. Les modules conservent en plus leurs
-// gardes authorizeRole plus fines. Tout nouveau module est protégé par défaut.
+// 🔒 Socle d'authentification : toute route sous /api/v1 définie APRÈS cette
+// ligne exige un JWT valide. Les rôles restent descriptifs ; l'autorisation
+// métier est portée par le compte et le module au middleware suivant.
 router.use(authenticateToken)
 
 // 🔒 Tour de contrôle des accès (#326) : filtrage module par compte, monté avant tout
-// module métier pour qu'aucune surface future n'y échappe par oubli. Il n'ôte aucun
-// garde existant — les authorizeRole des modules s'appliquent toujours ensuite.
+// module métier pour qu'aucune surface future n'y échappe par oubli. Une fois le
+// module autorisé, les anciens gardes de rôle deviennent de simples compatibilités.
 router.use(moduleAccessGate)
 
 router.use("/outils", outilRoutes)


### PR DESCRIPTION
Closes #268

- installe le contexte d'accès nominatif dès l'entrée dans l'API v1
- conserve la décision à travers les routeurs imbriqués et middlewares asynchrones
- ouvre les surfaces partagées authentifiées sans recalcul par rôle
- couvre Métrologie 360, les capacités Méthodes et les KPI Production avec un compte Employee

Validation : suite backend complète et build TypeScript verts.

## Summary by Sourcery

Install and propagate an account-based module access context across the v1 API so shared authenticated surfaces and nested middleware can rely on nominative access instead of role-based checks.

New Features:
- Expose shared authenticated capabilities in the Méthodes module to Employee accounts without requiring legacy role-based authorization.
- Allow Employee accounts to access Metrology 360 and production KPI endpoints when authorized at the account/module level rather than via roles.

Enhancements:
- Introduce a top-level v1 router scope that initializes the account/module access context before authentication and module gating.
- Extend the account/module access context to track whether access has been granted and reuse an existing context across nested Express middleware and routers.
- Treat non-module shared authenticated routes as covered by the module access context with a synthetic shared module key, avoiding per-route role recalculation.
- Update documentation to describe the new lifecycle of the module access context and the handling of shared authenticated surfaces.

Tests:
- Add integration tests covering Méthodes shared capabilities, Metrology 360, and production KPI access for Employee accounts under the new context-based gate.
- Augment access gate tests to assert that shared authenticated infrastructure routes install the account module access context without resolving profiles.