### PR TITLE
fix(access): conserver l’autorisation dans les handlers différés

### DIFF
--- a/src/__tests__/access-control.gate.test.ts
+++ b/src/__tests__/access-control.gate.test.ts
@@ -45,6 +45,16 @@ vi.mock("../module/metrologie/controllers/metrology-360.controller", async (impo
   };
 });
 
+vi.mock("../module/qualite/controllers/qualite.controller", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../module/qualite/controllers/qualite.controller")>();
+  return {
+    ...actual,
+    qualiteDashboard: (_req: unknown, res: { json: (body: unknown) => void }) =>
+      res.json({ ok: true }),
+  };
+});
+
 vi.mock("../module/auth/middlewares/auth.middleware", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../module/auth/middlewares/auth.middleware")>();
   return {
@@ -349,6 +359,19 @@ describe("Gate d'accès module — application réelle", () => {
 
     const res = await request(app)
       .get("/api/v1/metrologie/v2/center?horizon_days=30")
+      .set("x-test-role", "Employee");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("ouvre le dashboard Qualité à un compte autorisé sans rôle Qualité", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "qualite" }),
+    ]);
+
+    const res = await request(app)
+      .get("/api/v1/qualite/dashboard?today=2026-07-31")
       .set("x-test-role", "Employee");
 
     expect(res.status).toBe(200);

--- a/src/module/access-control/context/account-module-access.context.ts
+++ b/src/module/access-control/context/account-module-access.context.ts
@@ -14,10 +14,12 @@ const accountModuleAccessStorage = new AsyncLocalStorage<AccountModuleAccessCont
  * Express, y compris les routeurs imbriqués et leurs middlewares asynchrones.
  */
 export function runWithAccountModuleAccessScope(callback: () => void): void {
-  accountModuleAccessStorage.run(
-    { userId: null, moduleKey: null, granted: false },
-    callback
-  );
+  accountModuleAccessStorage.enterWith({
+    userId: null,
+    moduleKey: null,
+    granted: false,
+  });
+  callback();
 }
 
 /**
@@ -40,7 +42,8 @@ export function runWithAccountModuleAccess(
     callback();
     return;
   }
-  accountModuleAccessStorage.run({ ...context, granted: true }, callback);
+  accountModuleAccessStorage.enterWith({ ...context, granted: true });
+  callback();
 }
 
 export function hasGrantedAccountModuleAccess(): boolean {


### PR DESCRIPTION
Refs #268

Correctif de durcissement après recette réelle CLEMENT : la décision nominative reste attachée à l'exécution asynchrone de la requête, y compris après la reprise d'un routeur imbriqué. Ajoute la régression HTTP exacte du dashboard Qualité.

## Summary by Sourcery

Preserve account module access authorization across deferred and nested request handlers and add a regression test for Qualité dashboard access behavior.

Bug Fixes:
- Ensure account module access authorization context is preserved across asynchronous handlers and nested routers by adjusting AsyncLocalStorage usage.

Tests:
- Add regression test for Qualité dashboard HTTP access to verify authorized accounts without the Qualité role can reach the endpoint.