### PR TITLE
fix(access): preuve nominative portée par chaque requête ERP

### DIFF
--- a/docs/module-access-catalog.md
+++ b/docs/module-access-catalog.md
@@ -28,6 +28,10 @@ middlewares asynchrones et les services profonds. Les surfaces partagées
 authentifiées qui ne correspondent à aucun module (par exemple les réponses de
 capacités UI) reçoivent également ce contexte ; elles ne recréent jamais une
 autorisation par rôle.
+La décision est aussi inscrite sur l'objet `Request` Express. Les gardes HTTP
+lisent cette preuve en priorité : des appels parallèles du dashboard ne peuvent
+donc ni perdre ni échanger leur autorisation asynchrone. L'AsyncLocalStorage
+reste utilisé par les règles profondes qui ne reçoivent pas la requête.
 L'identifiant du compte est normalisé lorsqu'un ancien jeton JWT le fournit
 sous forme de chaîne numérique, afin que la décision nominative reste
 autoritaire. Le kill-switch d'exploitation désactive uniquement les refus

--- a/src/module/access-control/context/account-module-access.context.ts
+++ b/src/module/access-control/context/account-module-access.context.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import type { Request } from "express";
 
 export type AccountModuleAccessContext = {
   userId: number | null;
@@ -8,18 +9,24 @@ export type AccountModuleAccessContext = {
 
 const accountModuleAccessStorage = new AsyncLocalStorage<AccountModuleAccessContext>();
 
+declare global {
+  namespace Express {
+    interface Request {
+      accountModuleAccess?: AccountModuleAccessContext;
+    }
+  }
+}
+
 /**
  * Installe le contexte dès l'entrée dans le routeur v1. La décision est
  * complétée ensuite par le gate. Ce cycle de vie englobe toute la chaîne
  * Express, y compris les routeurs imbriqués et leurs middlewares asynchrones.
  */
 export function runWithAccountModuleAccessScope(callback: () => void): void {
-  accountModuleAccessStorage.enterWith({
-    userId: null,
-    moduleKey: null,
-    granted: false,
-  });
-  callback();
+  accountModuleAccessStorage.run(
+    { userId: null, moduleKey: null, granted: false },
+    callback
+  );
 }
 
 /**
@@ -42,8 +49,20 @@ export function runWithAccountModuleAccess(
     callback();
     return;
   }
-  accountModuleAccessStorage.enterWith({ ...context, granted: true });
-  callback();
+  accountModuleAccessStorage.run({ ...context, granted: true }, callback);
+}
+
+export function grantAccountModuleAccessToRequest(
+  req: Request,
+  context: Pick<AccountModuleAccessContext, "userId" | "moduleKey">,
+  callback: () => void
+): void {
+  req.accountModuleAccess = { ...context, granted: true };
+  runWithAccountModuleAccess(context, callback);
+}
+
+export function requestHasGrantedAccountModuleAccess(req: Request): boolean {
+  return req.accountModuleAccess?.granted === true;
 }
 
 export function hasGrantedAccountModuleAccess(): boolean {

--- a/src/module/access-control/middlewares/module-access-gate.ts
+++ b/src/module/access-control/middlewares/module-access-gate.ts
@@ -1,7 +1,7 @@
 import type { NextFunction, Request, Response } from "express";
 
 import { stripQueryFromUrl } from "../../../utils/logPath";
-import { runWithAccountModuleAccess } from "../context/account-module-access.context";
+import { grantAccountModuleAccessToRequest } from "../context/account-module-access.context";
 import { resolveModuleKeyForPath } from "../domain/module-catalog";
 import { resolveAccessProfile } from "../services/access-control.service";
 
@@ -78,7 +78,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
   if (!moduleKey) {
     // Les surfaces partagées authentifiées (utilisateurs, codes,
     // notifications, capabilities…) ne sont pas restrictibles par module.
-    runWithAccountModuleAccess({ userId, moduleKey: "shared" }, next);
+    grantAccountModuleAccessToRequest(req, { userId, moduleKey: "shared" }, next);
     return;
   }
 
@@ -86,7 +86,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
     warnKillSwitchOnce();
     // Le kill-switch désactive seulement les refus nominatifs. Il ne doit
     // jamais réactiver les anciens refus par rôle dans la suite de la requête.
-    runWithAccountModuleAccess({ userId, moduleKey }, next);
+    grantAccountModuleAccessToRequest(req, { userId, moduleKey }, next);
     return;
   }
 
@@ -98,7 +98,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
         return;
       }
       if (profile.is_superadmin) {
-        runWithAccountModuleAccess({ userId, moduleKey }, next);
+        grantAccountModuleAccessToRequest(req, { userId, moduleKey }, next);
         return;
       }
 
@@ -111,7 +111,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
         return;
       }
       if (decision.allowed) {
-        runWithAccountModuleAccess({ userId, moduleKey }, next);
+        grantAccountModuleAccessToRequest(req, { userId, moduleKey }, next);
         return;
       }
 

--- a/src/module/affaire/routes/affaire.routes.ts
+++ b/src/module/affaire/routes/affaire.routes.ts
@@ -1,4 +1,5 @@
 import { Router, type RequestHandler } from "express";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { HttpError } from "../../../utils/httpError";
 import { roleHasAffaireCapability, type AffaireCapability } from "../domain/affaire-rbac";
@@ -19,7 +20,10 @@ const router = Router();
 // Refus par défaut : chaque route exige une capacité distincte, vérifiée côté serveur.
 function requireAffaireCapability(capability: AffaireCapability): RequestHandler {
   return (req, _res, next) => {
-    if (roleHasAffaireCapability(req.user?.role, capability)) {
+  if (
+    requestHasGrantedAccountModuleAccess(req) ||
+    roleHasAffaireCapability(req.user?.role, capability)
+  ) {
       next();
       return;
     }
@@ -35,7 +39,10 @@ const requireAffaireTransitionCapability: RequestHandler = (req, _res, next) => 
   let capability: AffaireCapability = "transition";
   if (to === "CLOTUREE") capability = "close";
   else if (to === "ANNULEE") capability = "archive";
-  if (roleHasAffaireCapability(role, capability)) {
+  if (
+    requestHasGrantedAccountModuleAccess(req) ||
+    roleHasAffaireCapability(role, capability)
+  ) {
     next();
     return;
   }

--- a/src/module/audit-logs/controllers/audit-logs.controller.ts
+++ b/src/module/audit-logs/controllers/audit-logs.controller.ts
@@ -3,7 +3,10 @@ import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 import * as service from "../services/audit-logs.service";
 import { createAuditLogBodySchema, listAuditLogsQuerySchema } from "../validators/audit-logs.validators";
-import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import {
+  hasGrantedAccountModuleAccess,
+  requestHasGrantedAccountModuleAccess,
+} from "../../access-control/context/account-module-access.context";
 
 function isAdminRole(role: string | undefined): boolean {
   if (hasGrantedAccountModuleAccess()) return true;
@@ -42,7 +45,12 @@ export const listAuditLogs: RequestHandler = async (req, res, next) => {
   try {
     const user = req.user;
     if (!user || typeof user.id !== "number") throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
-    if (!isAdminRole(user.role)) throw new HttpError(403, "FORBIDDEN", "Admin role required");
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !isAdminRole(user.role)
+    ) {
+      throw new HttpError(403, "FORBIDDEN", "Admin role required");
+    }
     const filters = listAuditLogsQuerySchema.parse(req.query);
     const out = await service.svcListAuditLogs(filters);
     res.json(out);

--- a/src/module/auth/middlewares/auth.middleware.ts
+++ b/src/module/auth/middlewares/auth.middleware.ts
@@ -1,7 +1,10 @@
 import { Request, Response, NextFunction, RequestHandler } from "express";
 import jwt from "jsonwebtoken";
 import { stripQueryFromUrl } from "../../../utils/logPath";
-import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import {
+  hasGrantedAccountModuleAccess,
+  requestHasGrantedAccountModuleAccess,
+} from "../../access-control/context/account-module-access.context";
 import {
   effectiveRoleHasAny,
   hasAnyAssignedRole,
@@ -84,7 +87,10 @@ export const authorizeRole = (...roles: string[]) => {
       return;
     }
 
-    if (hasGrantedAccountModuleAccess()) {
+    if (
+      requestHasGrantedAccountModuleAccess(req) ||
+      hasGrantedAccountModuleAccess()
+    ) {
       next();
       return;
     }

--- a/src/module/commande-client/routes/commande-client.routes.ts
+++ b/src/module/commande-client/routes/commande-client.routes.ts
@@ -2,7 +2,10 @@ import type { RequestHandler } from "express"
 import { Router } from "express"
 import multer from "multer"
 
-import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context"
+import {
+  hasGrantedAccountModuleAccess,
+  requestHasGrantedAccountModuleAccess,
+} from "../../access-control/context/account-module-access.context"
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
 import { HttpError } from "../../../utils/httpError"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
@@ -98,7 +101,10 @@ function isOfficeSupportRole(role: string | undefined): boolean {
 }
 
 const requireOfficeSupportOrAdmin: RequestHandler = (req, _res, next) => {
-  if (hasGrantedAccountModuleAccess()) {
+  if (
+    requestHasGrantedAccountModuleAccess(req) ||
+    hasGrantedAccountModuleAccess()
+  ) {
     next()
     return
   }

--- a/src/module/commande-fournisseur/controllers/commande-fournisseur.controller.ts
+++ b/src/module/commande-fournisseur/controllers/commande-fournisseur.controller.ts
@@ -1,4 +1,5 @@
 import type { Request, RequestHandler } from "express";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 
 import { HttpError } from "../../../utils/httpError";
 import { roleHasCommandeFournisseurCapability } from "../domain/commande-fournisseur-rbac";
@@ -73,7 +74,10 @@ function buildAuditContext(req: Request): AuditContext {
 }
 
 function includePricesFor(req: Request): boolean {
-  return roleHasCommandeFournisseurCapability(req.user?.role, "prices");
+  return (
+    requestHasGrantedAccountModuleAccess(req) ||
+    roleHasCommandeFournisseurCapability(req.user?.role, "prices")
+  );
 }
 
 /** Clé d'idempotence : header standard prioritaire, sinon champ body. */
@@ -267,7 +271,9 @@ export const resyncReceptions: RequestHandler = async (req, res, next) => {
   try {
     const { params } = commandeIdParamSchema.parse({ params: req.params });
     const audit = buildAuditContext(req);
-    const allowOver = roleHasCommandeFournisseurCapability(req.user?.role, "over_receipt");
+    const allowOver =
+      requestHasGrantedAccountModuleAccess(req) ||
+      roleHasCommandeFournisseurCapability(req.user?.role, "over_receipt");
     res.json(await resyncReceptionsSVC(params.id, audit, allowOver));
   } catch (err) {
     next(err);

--- a/src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts
+++ b/src/module/commande-fournisseur/routes/commande-fournisseur.routes.ts
@@ -1,4 +1,5 @@
 import { Router, type RequestHandler } from "express";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 
 import { HttpError } from "../../../utils/httpError";
 import {
@@ -35,7 +36,10 @@ import {
  */
 function requireCapability(capability: CommandeFournisseurCapability): RequestHandler {
   return (req, _res, next) => {
-    if (!roleHasCommandeFournisseurCapability(req.user?.role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasCommandeFournisseurCapability(req.user?.role, capability)
+    ) {
       next(new HttpError(403, "FORBIDDEN", "Votre rôle ne permet pas cette action sur les commandes fournisseurs."));
       return;
     }

--- a/src/module/devis/routes/devis.routes.ts
+++ b/src/module/devis/routes/devis.routes.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from "express";
 import { Router } from "express";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import multer from "multer";
 import { z } from "zod";
 import { HttpError } from "../../../utils/httpError";
@@ -73,7 +74,10 @@ const parseMultipartData = (schema: z.ZodTypeAny): RequestHandler => {
  */
 function requireCapability(capability: DevisCapability): RequestHandler {
   return (req, _res, next) => {
-    if (!roleHasDevisCapability(req.user?.role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasDevisCapability(req.user?.role, capability)
+    ) {
       next(new HttpError(403, "FORBIDDEN", "Votre rôle ne permet pas cette action sur les devis."));
       return;
     }

--- a/src/module/facturation/middlewares/finance-authorization.middleware.ts
+++ b/src/module/facturation/middlewares/finance-authorization.middleware.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import {
   roleHasFinanceCapability,
   type FinanceCapability,
@@ -12,7 +13,10 @@ export function requireFinanceCapability(capability: FinanceCapability): Request
       next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
       return;
     }
-    if (!roleHasFinanceCapability(req.user.role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasFinanceCapability(req.user.role, capability)
+    ) {
       next(
         new HttpError(
           403,

--- a/src/module/ged/middlewares/require-ged-capability.ts
+++ b/src/module/ged/middlewares/require-ged-capability.ts
@@ -7,6 +7,7 @@
 import type { RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { roleHasGedCapability, type GedCapability } from "../domain/ged-policy";
 
 export function requireGedCapability(capability: GedCapability): RequestHandler {
@@ -15,7 +16,10 @@ export function requireGedCapability(capability: GedCapability): RequestHandler 
       next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
       return;
     }
-    if (!roleHasGedCapability(req.user.role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasGedCapability(req.user.role, capability)
+    ) {
       next(
         new HttpError(403, "GED_CAPABILITY_REQUIRED", `La capacité GED '${capability}' est requise.`)
       );

--- a/src/module/livraisons/routes/livraisons.routes.ts
+++ b/src/module/livraisons/routes/livraisons.routes.ts
@@ -1,4 +1,5 @@
 import { Router, type RequestHandler } from "express"
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import multer from "multer"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
@@ -54,7 +55,10 @@ router.use(authenticateToken)
 
 const requireLivraisonCapability = (capability: LivraisonCapability): RequestHandler =>
   (req, _res, next) => {
-    if (!roleHasLivraisonCapability(req.user?.role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasLivraisonCapability(req.user?.role, capability)
+    ) {
       next(
         new HttpError(
           403,

--- a/src/module/methodes/controllers/methodes.controller.ts
+++ b/src/module/methodes/controllers/methodes.controller.ts
@@ -3,7 +3,11 @@
 import type { Request, RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
-import { methodesCapabilitiesFor } from "../domain/methodes-policy";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import {
+  METHODES_CAPABILITIES,
+  methodesCapabilitiesFor,
+} from "../domain/methodes-policy";
 import {
   addCostCenterRateSVC,
   createCostCenterSVC,
@@ -80,6 +84,14 @@ export function requiredRouteParam(req: Request, name: string): string {
 export const readMethodesCapabilities: RequestHandler = (req, res, next) => {
   try {
     if (!req.user) throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+    if (requestHasGrantedAccountModuleAccess(req)) {
+      res.json({
+        capabilities: Object.fromEntries(
+          METHODES_CAPABILITIES.map((capability) => [capability, true])
+        ),
+      });
+      return;
+    }
     res.json({ capabilities: methodesCapabilitiesFor(req.user.role) });
   } catch (error) {
     next(error);

--- a/src/module/methodes/middlewares/methodes-authorization.middleware.ts
+++ b/src/module/methodes/middlewares/methodes-authorization.middleware.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { roleHasMethodesCapability, type MethodesCapability } from "../domain/methodes-policy";
 
 /**
@@ -15,7 +16,10 @@ export function requireMethodesCapability(capability: MethodesCapability): Reque
       next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
       return;
     }
-    if (!roleHasMethodesCapability(req.user.role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasMethodesCapability(req.user.role, capability)
+    ) {
       next(new HttpError(403, "METHODES_CAPABILITY_REQUIRED", `La capacité Méthodes '${capability}' est requise.`));
       return;
     }

--- a/src/module/metrologie/middlewares/metrology-authorization.middleware.ts
+++ b/src/module/metrologie/middlewares/metrology-authorization.middleware.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { roleHasMetrologyCapability, type MetrologyCapability } from "../domain/metrology-policy";
 
 /**
@@ -15,7 +16,10 @@ export function requireMetrologyCapability(capability: MetrologyCapability): Req
       next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
       return;
     }
-    if (!roleHasMetrologyCapability(req.user.role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasMetrologyCapability(req.user.role, capability)
+    ) {
       next(
         new HttpError(
           403,

--- a/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
+++ b/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
@@ -1,5 +1,6 @@
 // src/module/pieces-techniques/routes/pieces-techniques.routes.ts
 import { Router, type RequestHandler } from "express"
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import multer from "multer"
 
 import { authenticateToken, authorizeRole } from "../../auth/middlewares/auth.middleware"
@@ -119,7 +120,10 @@ const router = Router()
 const requireDeleteRole = authorizeRole(...PIECE_TECHNIQUE_DELETE_ROLES)
 const requireDocumentPolicyRole = authorizeRole(...PIECE_DOCUMENT_POLICY_ROLES)
 const requireVersionApproval: RequestHandler = (req, _res, next) => {
-  if (!canValidatePieceTechnique(req.user)) {
+  if (
+    !requestHasGrantedAccountModuleAccess(req) &&
+    !canValidatePieceTechnique(req.user)
+  ) {
     next(
       new HttpError(
         403,

--- a/src/module/planning/routes/planning.routes.ts
+++ b/src/module/planning/routes/planning.routes.ts
@@ -1,4 +1,5 @@
 import { Router, type RequestHandler } from "express";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import multer from "multer";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
@@ -22,7 +23,10 @@ import {
 
 const requireProductionOrAdmin: RequestHandler = (req, _res, next) => {
   const role = req.user?.role;
-  if (!roleHasPlanningAccess(role)) {
+  if (
+    !requestHasGrantedAccountModuleAccess(req) &&
+    !roleHasPlanningAccess(role)
+  ) {
     next(new HttpError(403, "FORBIDDEN", "Production, atelier, secretariat or admin role required"));
     return;
   }

--- a/src/module/production/controllers/production.controller.ts
+++ b/src/module/production/controllers/production.controller.ts
@@ -1,4 +1,5 @@
 import type { Request } from "express";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { asyncHandler } from "../../../utils/asyncHandler";
 import { HttpError } from "../../../utils/httpError";
 import { emitEntityChanged } from "../../../shared/realtime/realtime.service";
@@ -57,8 +58,21 @@ import {
   svcUpdatePoste,
 } from "../services/production.service";
 import { svcGetMachineIntelligence } from "../services/machine-intelligence.service";
-import { roleHasMachineCapability } from "../domain/machine-rbac";
+import {
+  roleHasMachineCapability,
+  type MachineCapability,
+} from "../domain/machine-rbac";
 import { roleHasOfCapability } from "../domain/of-rbac";
+
+function requestHasMachineCapability(
+  req: Request,
+  capability: MachineCapability
+): boolean {
+  return (
+    requestHasGrantedAccountModuleAccess(req) ||
+    roleHasMachineCapability(req.user?.role, capability)
+  );
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -170,7 +184,7 @@ function redactMachineCosts<T extends object>(value: T) {
 export const listMachines = asyncHandler(async (req, res) => {
   const query = listMachinesQuerySchema.parse(req.query);
   const out = await svcListMachines(query);
-  res.json(roleHasMachineCapability(req.user?.role, "costs") ? out : { ...out, items: out.items.map(redactMachineCosts) });
+  res.json(requestHasMachineCapability(req, "costs") ? out : { ...out, items: out.items.map(redactMachineCosts) });
 });
 
 export const getMachine = asyncHandler(async (req, res) => {
@@ -182,7 +196,7 @@ export const getMachine = asyncHandler(async (req, res) => {
   }
   const intelligence = await svcGetMachineIntelligence(id);
   const detail = { ...out, ...(intelligence ?? {}) };
-  res.json(roleHasMachineCapability(req.user?.role, "costs") ? detail : redactMachineCosts(detail));
+  res.json(requestHasMachineCapability(req, "costs") ? detail : redactMachineCosts(detail));
 });
 
 export const createMachine = asyncHandler(async (req, res) => {
@@ -190,7 +204,7 @@ export const createMachine = asyncHandler(async (req, res) => {
   const raw = parseBody(req);
   const body = createMachineSchema.parse({ body: raw }).body;
   assertMachineRateProvenance(body);
-  if (hasMachineCostMutation(body) && !roleHasMachineCapability(req.user?.role, "costs")) {
+  if (hasMachineCostMutation(body) && !requestHasMachineCapability(req, "costs")) {
     throw new HttpError(403, "MACHINE_COST_FORBIDDEN", "Machine cost capability required.");
   }
   const file = (req as Request & { file?: unknown }).file;
@@ -198,7 +212,7 @@ export const createMachine = asyncHandler(async (req, res) => {
   const idempotencyKey = typeof req.headers["idempotency-key"] === "string" ? req.headers["idempotency-key"].trim() : null;
   if (idempotencyKey && (idempotencyKey.length < 8 || idempotencyKey.length > 200)) throw new HttpError(400, "INVALID_IDEMPOTENCY_KEY", "Idempotency-Key must contain 8 to 200 characters.");
   const out = await svcCreateMachine({ body, image_path: imagePath, idempotency_key: idempotencyKey, audit });
-  res.status(201).json(roleHasMachineCapability(req.user?.role, "costs") ? out : redactMachineCosts(out));
+  res.status(201).json(requestHasMachineCapability(req, "costs") ? out : redactMachineCosts(out));
 });
 
 export const createMachineOnboarding = asyncHandler(async (req, res) => {
@@ -206,7 +220,7 @@ export const createMachineOnboarding = asyncHandler(async (req, res) => {
   const raw = parseBody(req);
   const body = createMachineOnboardingSchema.parse({ body: raw }).body;
   assertMachineRateProvenance(body.machine);
-  if (hasMachineCostMutation(body.machine) && !roleHasMachineCapability(req.user?.role, "costs")) {
+  if (hasMachineCostMutation(body.machine) && !requestHasMachineCapability(req, "costs")) {
     throw new HttpError(403, "MACHINE_COST_FORBIDDEN", "Machine cost capability required.");
   }
   const file = (req as Request & { file?: unknown }).file;
@@ -214,7 +228,7 @@ export const createMachineOnboarding = asyncHandler(async (req, res) => {
   const idempotencyKey = typeof req.headers["idempotency-key"] === "string" ? req.headers["idempotency-key"].trim() : null;
   if (!idempotencyKey || idempotencyKey.length < 8 || idempotencyKey.length > 200) throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "A stable Idempotency-Key containing 8 to 200 characters is required.");
   const out = await svcCreateMachineOnboarding({ body, image_path: imagePath, idempotency_key: idempotencyKey, audit });
-  res.status(201).json(roleHasMachineCapability(req.user?.role, "costs") ? out : redactMachineCosts(out));
+  res.status(201).json(requestHasMachineCapability(req, "costs") ? out : redactMachineCosts(out));
 });
 
 export const updateMachine = asyncHandler(async (req, res) => {
@@ -223,7 +237,7 @@ export const updateMachine = asyncHandler(async (req, res) => {
   const raw = parseBody(req);
   const patch = updateMachineSchema.parse({ body: raw }).body;
   assertMachineRateProvenance(patch);
-  if (hasMachineCostMutation(patch) && !roleHasMachineCapability(req.user?.role, "costs")) {
+  if (hasMachineCostMutation(patch) && !requestHasMachineCapability(req, "costs")) {
     throw new HttpError(403, "MACHINE_COST_FORBIDDEN", "Machine cost capability required.");
   }
   const file = (req as Request & { file?: unknown }).file;
@@ -233,7 +247,7 @@ export const updateMachine = asyncHandler(async (req, res) => {
     res.status(404).json({ error: "Not found" });
     return;
   }
-  res.status(200).json(roleHasMachineCapability(req.user?.role, "costs") ? out : redactMachineCosts(out));
+  res.status(200).json(requestHasMachineCapability(req, "costs") ? out : redactMachineCosts(out));
 });
 
 export const updateMachineOnboarding = asyncHandler(async (req, res) => {
@@ -242,10 +256,10 @@ export const updateMachineOnboarding = asyncHandler(async (req, res) => {
   const raw = parseBody(req);
   const body = updateMachineOnboardingSchema.parse({ body: raw }).body;
   assertMachineRateProvenance(body.machine);
-  if (hasMachineCostMutation(body.machine) && !roleHasMachineCapability(req.user?.role, "costs")) {
+  if (hasMachineCostMutation(body.machine) && !requestHasMachineCapability(req, "costs")) {
     throw new HttpError(403, "MACHINE_COST_FORBIDDEN", "Machine cost capability required.");
   }
-  if (body.update_shared_model && !roleHasMachineCapability(req.user?.role, "model_update")) {
+  if (body.update_shared_model && !requestHasMachineCapability(req, "model_update")) {
     throw new HttpError(403, "MACHINE_MODEL_UPDATE_FORBIDDEN", "Shared machine model update capability required.");
   }
   const file = (req as Request & { file?: unknown }).file;
@@ -255,7 +269,7 @@ export const updateMachineOnboarding = asyncHandler(async (req, res) => {
     res.status(404).json({ error: "Not found" });
     return;
   }
-  res.status(200).json(roleHasMachineCapability(req.user?.role, "costs") ? out : redactMachineCosts(out));
+  res.status(200).json(requestHasMachineCapability(req, "costs") ? out : redactMachineCosts(out));
 });
 
 export const archiveMachine = asyncHandler(async (req, res) => {
@@ -473,7 +487,9 @@ async function withGenerationDependencyGuard<T>(fn: () => Promise<T>): Promise<T
 export const getOfReceiptContext = asyncHandler(async (req, res) => {
   const { id } = ofIdParamSchema.parse({ params: req.params }).params;
   const out = await svcGetOfReceiptContext({ of_id: id });
-  const canDecideQuality = roleHasOfCapability(req.user?.role, "quality_decision");
+    const canDecideQuality =
+      requestHasGrantedAccountModuleAccess(req) ||
+      roleHasOfCapability(req.user?.role, "quality_decision");
   res.json({
     ...out,
     permissions: {
@@ -493,7 +509,11 @@ export const createOfReceipt = asyncHandler(async (req, res) => {
   if (!idempotencyKey || idempotencyKey.length < 8 || idempotencyKey.length > 200) {
     throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "Une cle Idempotency-Key stable de 8 a 200 caracteres est requise.");
   }
-  if (body.quality_status !== "QUARANTAINE" && !roleHasOfCapability(req.user?.role, "quality_decision")) {
+    if (
+      body.quality_status !== "QUARANTAINE" &&
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasOfCapability(req.user?.role, "quality_decision")
+    ) {
     throw new HttpError(
       403,
       "OF_QUALITY_DECISION_FORBIDDEN",

--- a/src/module/production/middlewares/of-versioning-authorization.middleware.ts
+++ b/src/module/production/middlewares/of-versioning-authorization.middleware.ts
@@ -6,6 +6,7 @@
 import type { RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { roleHasOfCapability, type OfCapability } from "../domain/of-rbac";
 
 export function requireOfCapability(capability: OfCapability): RequestHandler {
@@ -14,7 +15,10 @@ export function requireOfCapability(capability: OfCapability): RequestHandler {
       next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
       return;
     }
-    if (!roleHasOfCapability(req.user.role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasOfCapability(req.user.role, capability)
+    ) {
       next(
         new HttpError(
           403,

--- a/src/module/production/middlewares/production-execution-authorization.middleware.ts
+++ b/src/module/production/middlewares/production-execution-authorization.middleware.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import {
   roleHasProductionExecutionCapability,
   type ProductionExecutionCapability,
@@ -19,7 +20,10 @@ export function requireProductionExecutionCapability(
       next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
       return;
     }
-    if (!roleHasProductionExecutionCapability(req.user.role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasProductionExecutionCapability(req.user.role, capability)
+    ) {
       next(
         new HttpError(
           403,

--- a/src/module/production/middlewares/station-authorization.middleware.ts
+++ b/src/module/production/middlewares/station-authorization.middleware.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler, Request, Response } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import {
   evaluateSession,
   roleHasStationCapability,
@@ -273,7 +274,10 @@ export function requireStationCapability(capability: StationCapability): Request
       next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
       return;
     }
-    if (!roleHasStationCapability(role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasStationCapability(role, capability)
+    ) {
       void repoStationAudit({
         event_type: "AUTHORIZATION_DENIED",
         outcome: "DENIED",

--- a/src/module/production/routes/production.routes.ts
+++ b/src/module/production/routes/production.routes.ts
@@ -1,7 +1,10 @@
 import { Router, type RequestHandler } from "express";
 import multer from "multer";
 
-import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import {
+  hasGrantedAccountModuleAccess,
+  requestHasGrantedAccountModuleAccess,
+} from "../../access-control/context/account-module-access.context";
 import { upload } from "../../../middlewares/upload";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
@@ -94,7 +97,10 @@ function isProductionRole(role: string | undefined): boolean {
 }
 
 const requireAdmin: RequestHandler = (req, _res, next) => {
-  if (hasGrantedAccountModuleAccess()) {
+  if (
+    requestHasGrantedAccountModuleAccess(req) ||
+    hasGrantedAccountModuleAccess()
+  ) {
     next();
     return;
   }
@@ -106,7 +112,10 @@ const requireAdmin: RequestHandler = (req, _res, next) => {
 };
 
 const requireProductionOrAdmin: RequestHandler = (req, _res, next) => {
-  if (hasGrantedAccountModuleAccess()) {
+  if (
+    requestHasGrantedAccountModuleAccess(req) ||
+    hasGrantedAccountModuleAccess()
+  ) {
     next();
     return;
   }
@@ -119,7 +128,10 @@ const requireProductionOrAdmin: RequestHandler = (req, _res, next) => {
 };
 
 const requireMachineCapability = (capability: MachineCapability): RequestHandler => (req, _res, next) => {
-  if (!roleHasMachineCapability(req.user?.role, capability)) {
+  if (
+    !requestHasGrantedAccountModuleAccess(req) &&
+    !roleHasMachineCapability(req.user?.role, capability)
+  ) {
     next(new HttpError(403, "MACHINE_FORBIDDEN", `Machine capability required: ${capability}`));
     return;
   }
@@ -130,7 +142,10 @@ const requireMachineCapability = (capability: MachineCapability): RequestHandler
 // capacité explicite (la granularité fine transition/édition se rejoue au
 // repository qui connaît le statut courant).
 const requireOfCapability = (capability: OfCapability): RequestHandler => (req, _res, next) => {
-  if (!roleHasOfCapability(req.user?.role, capability)) {
+  if (
+    !requestHasGrantedAccountModuleAccess(req) &&
+    !roleHasOfCapability(req.user?.role, capability)
+  ) {
     next(new HttpError(403, "OF_FORBIDDEN", `OF capability required: ${capability}`));
     return;
   }
@@ -138,6 +153,10 @@ const requireOfCapability = (capability: OfCapability): RequestHandler => (req, 
 };
 
 const requireAnyOfCapability = (capabilities: readonly OfCapability[]): RequestHandler => (req, _res, next) => {
+  if (requestHasGrantedAccountModuleAccess(req)) {
+    next();
+    return;
+  }
   if (!capabilities.some((capability) => roleHasOfCapability(req.user?.role, capability))) {
     next(new HttpError(403, "OF_FORBIDDEN", `OF capability required: ${capabilities.join("|")}`));
     return;

--- a/src/module/programmation/routes/programmation.routes.ts
+++ b/src/module/programmation/routes/programmation.routes.ts
@@ -1,5 +1,8 @@
 import { Router, type RequestHandler } from "express";
-import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import {
+  hasGrantedAccountModuleAccess,
+  requestHasGrantedAccountModuleAccess,
+} from "../../access-control/context/account-module-access.context";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { HttpError } from "../../../utils/httpError";
 import { healthProgrammations, listProgrammations } from "../controllers/programmation.controller";
@@ -17,7 +20,10 @@ function isProductionRole(role: string | undefined): boolean {
 }
 
 const requireProductionOrAdmin: RequestHandler = (req, _res, next) => {
-  if (hasGrantedAccountModuleAccess()) {
+  if (
+    requestHasGrantedAccountModuleAccess(req) ||
+    hasGrantedAccountModuleAccess()
+  ) {
     next();
     return;
   }

--- a/src/module/qualite/middlewares/quality-authorization.middleware.ts
+++ b/src/module/qualite/middlewares/quality-authorization.middleware.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { roleHasQualityCapability, type QualityCapability } from "../domain/quality-policy";
 
 /**
@@ -14,7 +15,10 @@ export function requireQualityCapability(capability: QualityCapability): Request
       next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
       return;
     }
-    if (!roleHasQualityCapability(req.user.role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasQualityCapability(req.user.role, capability)
+    ) {
       next(
         new HttpError(
           403,

--- a/src/module/qualite/routes/qualite.routes.ts
+++ b/src/module/qualite/routes/qualite.routes.ts
@@ -1,7 +1,10 @@
 import { Router, type RequestHandler } from "express";
 import multer from "multer";
 
-import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import {
+  hasGrantedAccountModuleAccess,
+  requestHasGrantedAccountModuleAccess,
+} from "../../access-control/context/account-module-access.context";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
@@ -53,7 +56,10 @@ function isQualityRole(role: string | undefined): boolean {
 }
 
 const requireQualityOrAdmin: RequestHandler = (req, _res, next) => {
-  if (hasGrantedAccountModuleAccess()) {
+  if (
+    requestHasGrantedAccountModuleAccess(req) ||
+    hasGrantedAccountModuleAccess()
+  ) {
     next();
     return;
   }

--- a/src/module/stock/controllers/stock.controller.ts
+++ b/src/module/stock/controllers/stock.controller.ts
@@ -1,4 +1,5 @@
 import type { Request, RequestHandler, Response } from "express";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import fs from "node:fs/promises";
 
 import { previewArticleCode } from "../../../shared/codes/code-generator.service";
@@ -1090,6 +1091,7 @@ export const postStockMovement: RequestHandler = async (req, res, next) => {
     const body: PostMovementBodyDTO = postMovementSchema.parse({ body: req.body }).body;
     if (
       body.negative_stock_override &&
+      !requestHasGrantedAccountModuleAccess(req) &&
       !roleHasStockCapability(req.user?.role, "negative_stock_override")
     ) {
       throw new HttpError(

--- a/src/module/stock/routes/stock.routes.ts
+++ b/src/module/stock/routes/stock.routes.ts
@@ -1,4 +1,5 @@
 import { Router, type RequestHandler } from "express";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import multer from "multer";
 
 import { authenticateToken, authorizeRole } from "../../auth/middlewares/auth.middleware";
@@ -111,7 +112,10 @@ const requireArticleApprove = authorizeRole(...ARTICLE_APPROVE_ROLES);
 const requireArticleDocumentWrite = authorizeRole(...ARTICLE_DOCUMENT_WRITE_ROLES);
 
 const requireStockCapability = (capability: StockCapability): RequestHandler => (req, _res, next) => {
-  if (!roleHasStockCapability(req.user?.role, capability)) {
+  if (
+    !requestHasGrantedAccountModuleAccess(req) &&
+    !roleHasStockCapability(req.user?.role, capability)
+  ) {
     next(new HttpError(403, "STOCK_FORBIDDEN", `Stock capability required: ${capability}`));
     return;
   }

--- a/src/module/surface-finish/middlewares/surface-finish-authorization.middleware.ts
+++ b/src/module/surface-finish/middlewares/surface-finish-authorization.middleware.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import {
   roleHasSurfaceFinishCapability,
   type SurfaceFinishCapability,
@@ -19,7 +20,10 @@ export function requireSurfaceFinishCapability(capability: SurfaceFinishCapabili
       next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
       return;
     }
-    if (!roleHasSurfaceFinishCapability(req.user.role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasSurfaceFinishCapability(req.user.role, capability)
+    ) {
       next(
         new HttpError(
           403,

--- a/src/module/traceability/middlewares/traceability-authorization.middleware.ts
+++ b/src/module/traceability/middlewares/traceability-authorization.middleware.ts
@@ -1,6 +1,7 @@
 import type { RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import {
   roleHasTraceabilityCapability,
   type TraceabilityCapability,
@@ -21,7 +22,10 @@ export function requireTraceabilityCapability(capability: TraceabilityCapability
       next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
       return;
     }
-    if (!roleHasTraceabilityCapability(req.user.role, capability)) {
+    if (
+      !requestHasGrantedAccountModuleAccess(req) &&
+      !roleHasTraceabilityCapability(req.user.role, capability)
+    ) {
       next(
         new HttpError(
           403,


### PR DESCRIPTION
Refs #268

Correction définitive validée contre le cas réel CLEMENT :
- preuve d'autorisation attachée à Request, sans dépendre de la concurrence AsyncLocalStorage
- gardes HTTP Commerce, Production, Qualité, Métrologie, Stock, Méthodes, GED, Finitions et Traçabilité alignés
- capacités Méthodes ouvertes pour un compte autorisé, donc création centre de frais activée
- DENIED nominatif toujours refusé avant les routes

Suite backend complète et build TypeScript verts.

## Summary by Sourcery

Persist and leverage nominative module-access decisions per Express request to harden ERP authorization and align HTTP guards across domains.

New Features:
- Expose module access decisions on the Express Request object and helper to detect per-request granted access.
- Allow Methods module to present full capabilities for an account with granted module access, enabling cost center creation flows.

Bug Fixes:
- Ensure module-level granted access is honored consistently across production, quality, stock, finance, metrology, GED, traceability, planning, deliveries, purchasing, sales, audit logs and station guards, preventing denial when a nominative access is already granted.
- Fix race conditions and cross-request leakage risks by preferring per-request authorization proof over AsyncLocalStorage in HTTP guards.
- Honor granted module access for machine cost and model update operations and OF quality decisions in production controllers.

Enhancements:
- Refine access-control context lifecycle by using AsyncLocalStorage.run and combining it with per-request storage for deep services and middlewares.
- Centralize machine capability checks through a helper that merges role-based and module-access authorization.
- Update module access documentation to describe the new per-request proof and its interaction with AsyncLocalStorage.