### PR TITLE
fix(articles): générer la matière côté serveur et réviser les gammes figées

### DIFF
--- a/db/patches/20260731_gamme_revision_lineage.sql
+++ b/db/patches/20260731_gamme_revision_lineage.sql
@@ -1,0 +1,64 @@
+-- #433 — Révision d'une gamme APPLICABLE : filiation et idempotence.
+--
+-- Une gamme applicable est immuable : les OF lancés et l'historique s'appuient
+-- dessus. Pour ajouter une opération, on prépare une RÉVISION — un nouveau
+-- brouillon dupliqué depuis la gamme figée. Deux informations manquaient pour
+-- que cette opération soit sûre :
+--
+--   · `source_gamme_id` — de quelle gamme la révision est issue, pour l'audit
+--     et pour l'écran (« révision de la gamme X ») ;
+--   · `revision_idempotency_key` — un double clic, un rejeu après coupure ou un
+--     retour arrière du navigateur doivent rendre LA MÊME révision, pas une
+--     deuxième gamme en double.
+--
+-- Migration ADDITIVE et idempotente : aucune colonne existante n'est touchée,
+-- aucune donnée n'est réécrite. Les gammes historiques gardent
+-- `source_gamme_id = NULL`, ce qui signifie simplement « créée directement ».
+--
+-- NON EXÉCUTÉE : à appliquer sur cerp_test d'abord, jamais automatiquement sur
+-- cerp_prod (preflight / verify / rollback dans db/patches/support).
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.gammes') IS NULL THEN
+    RAISE EXCEPTION 'Pré-requis absent: public.gammes';
+  END IF;
+END $$;
+
+ALTER TABLE public.gammes
+  ADD COLUMN IF NOT EXISTS source_gamme_id uuid NULL,
+  ADD COLUMN IF NOT EXISTS revision_idempotency_key text NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'gammes_source_gamme_id_fkey'
+      AND conrelid = 'public.gammes'::regclass
+  ) THEN
+    ALTER TABLE public.gammes
+      ADD CONSTRAINT gammes_source_gamme_id_fkey
+      FOREIGN KEY (source_gamme_id) REFERENCES public.gammes (id) ON DELETE SET NULL;
+  END IF;
+END $$;
+
+-- Une clé d'idempotence ne vaut que pour la gamme source : deux gammes
+-- différentes peuvent recevoir la même clé sans conflit, une même gamme ne peut
+-- produire qu'une révision par clé.
+CREATE UNIQUE INDEX IF NOT EXISTS gammes_revision_idempotency_uidx
+  ON public.gammes (source_gamme_id, revision_idempotency_key)
+  WHERE revision_idempotency_key IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS gammes_source_gamme_id_idx
+  ON public.gammes (source_gamme_id)
+  WHERE source_gamme_id IS NOT NULL;
+
+COMMENT ON COLUMN public.gammes.source_gamme_id IS
+  '#433 — gamme dont celle-ci est la révision. NULL = gamme créée directement.';
+COMMENT ON COLUMN public.gammes.revision_idempotency_key IS
+  '#433 — clé d''idempotence du rejeu de « Préparer une révision ». Unique par gamme source.';
+
+COMMIT;

--- a/db/patches/support/20260731_gamme_revision_lineage.preflight.sql
+++ b/db/patches/support/20260731_gamme_revision_lineage.preflight.sql
@@ -1,0 +1,28 @@
+-- Preflight #433 — révision de gamme. LECTURE SEULE.
+-- À exécuter avant le patch, sur cerp_test puis (après validation humaine) cerp_prod.
+
+\echo '--- Table cible ---'
+SELECT to_regclass('public.gammes') AS gammes_table;
+
+\echo '--- Colonnes déjà présentes (attendu: 0 ligne avant application) ---'
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'gammes'
+  AND column_name IN ('source_gamme_id', 'revision_idempotency_key')
+ORDER BY column_name;
+
+\echo '--- Index/contraintes homonymes (attendu: 0 ligne) ---'
+SELECT indexname FROM pg_indexes
+WHERE schemaname = 'public'
+  AND indexname IN ('gammes_revision_idempotency_uidx', 'gammes_source_gamme_id_idx');
+SELECT conname FROM pg_constraint
+WHERE conrelid = 'public.gammes'::regclass AND conname = 'gammes_source_gamme_id_fkey';
+
+\echo '--- Volumétrie (le patch n''écrit aucune donnée) ---'
+SELECT count(*) AS gammes_total,
+       count(*) FILTER (WHERE statut = 'APPLICABLE') AS gammes_applicables,
+       count(*) FILTER (WHERE statut = 'BROUILLON') AS gammes_brouillon
+FROM public.gammes;
+
+\echo '--- Sauvegarde: vérifier qu''un dump récent existe AVANT d''appliquer ---'

--- a/db/patches/support/20260731_gamme_revision_lineage.rollback.sql
+++ b/db/patches/support/20260731_gamme_revision_lineage.rollback.sql
@@ -1,0 +1,25 @@
+-- Rollback #433 — révision de gamme.
+--
+-- ⚠️ Ce rollback SUPPRIME la filiation et les clés d'idempotence enregistrées
+-- depuis l'application du patch. Les gammes elles-mêmes, leurs opérations, les
+-- OF et les snapshots ne sont pas touchés : seules deux colonnes additives
+-- disparaissent.
+--
+-- Vérifier AVANT d'exécuter :
+--   SELECT count(*) FROM public.gammes WHERE source_gamme_id IS NOT NULL;
+-- Si le compte est > 0, la traçabilité « révision de » sera perdue. Exiger une
+-- décision humaine explicite dans ce cas.
+
+BEGIN;
+
+DROP INDEX IF EXISTS public.gammes_revision_idempotency_uidx;
+DROP INDEX IF EXISTS public.gammes_source_gamme_id_idx;
+
+ALTER TABLE public.gammes
+  DROP CONSTRAINT IF EXISTS gammes_source_gamme_id_fkey;
+
+ALTER TABLE public.gammes
+  DROP COLUMN IF EXISTS revision_idempotency_key,
+  DROP COLUMN IF EXISTS source_gamme_id;
+
+COMMIT;

--- a/db/patches/support/20260731_gamme_revision_lineage.verify.sql
+++ b/db/patches/support/20260731_gamme_revision_lineage.verify.sql
@@ -1,0 +1,32 @@
+-- Verify #433 — révision de gamme. LECTURE SEULE, à exécuter APRÈS le patch.
+-- Attendu : 2 colonnes, 1 contrainte FK, 2 index, et AUCUNE donnée modifiée.
+
+\echo '--- Colonnes (attendu: 2 lignes, nullables) ---'
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND table_name = 'gammes'
+  AND column_name IN ('source_gamme_id', 'revision_idempotency_key')
+ORDER BY column_name;
+
+\echo '--- Contrainte de filiation (attendu: 1 ligne) ---'
+SELECT conname, pg_get_constraintdef(oid) AS definition
+FROM pg_constraint
+WHERE conrelid = 'public.gammes'::regclass AND conname = 'gammes_source_gamme_id_fkey';
+
+\echo '--- Index (attendu: 2 lignes) ---'
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND indexname IN ('gammes_revision_idempotency_uidx', 'gammes_source_gamme_id_idx')
+ORDER BY indexname;
+
+\echo '--- Aucune donnée écrite par le patch (attendu: 0) ---'
+SELECT count(*) AS gammes_avec_filiation
+FROM public.gammes
+WHERE source_gamme_id IS NOT NULL OR revision_idempotency_key IS NOT NULL;
+
+\echo '--- Les gammes existantes sont intactes ---'
+SELECT count(*) AS gammes_total,
+       count(*) FILTER (WHERE statut = 'APPLICABLE') AS gammes_applicables
+FROM public.gammes;

--- a/src/__tests__/gamme-revision-433.controller.test.ts
+++ b/src/__tests__/gamme-revision-433.controller.test.ts
@@ -1,0 +1,93 @@
+import type { NextFunction, Request, Response } from "express"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  createRevision: vi.fn(),
+}))
+
+vi.mock("../module/gammes/services/gammes.service", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../module/gammes/services/gammes.service")>()),
+  createGammeRevisionSVC: mocks.createRevision,
+}))
+
+import { createGammeRevision } from "../module/gammes/controllers/gammes.controller"
+
+const GAMME_ID = "11111111-1111-4111-8111-111111111111"
+
+function requestWith(idempotencyKey?: string): Request {
+  return {
+    body: {},
+    params: { gammeId: GAMME_ID },
+    headers: idempotencyKey ? { "idempotency-key": idempotencyKey } : {},
+    user: { id: 42, username: "methodes", role: "Directeur" },
+    ip: "127.0.0.1",
+    originalUrl: `/api/v1/gammes/${GAMME_ID}/revisions`,
+  } as unknown as Request
+}
+
+function responseRecorder() {
+  const response = {
+    status: vi.fn(),
+    json: vi.fn(),
+  }
+  response.status.mockReturnValue(response)
+  return response as unknown as Response
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe("#433 — contrat HTTP de préparation d'une révision", () => {
+  it.each([undefined, "short", "x".repeat(201)])(
+    "refuse une Idempotency-Key absente ou hors bornes (%s)",
+    async (key) => {
+      const next = vi.fn() as NextFunction
+      await createGammeRevision(requestWith(key), responseRecorder(), next)
+
+      expect(next).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: 400,
+          code: "IDEMPOTENCY_KEY_REQUIRED",
+        }),
+      )
+      expect(mocks.createRevision).not.toHaveBeenCalled()
+    },
+  )
+
+  it("transmet une clé valide et rend 201 à la première création", async () => {
+    const response = responseRecorder()
+    const next = vi.fn() as NextFunction
+    mocks.createRevision.mockResolvedValue({
+      gamme: { id: "22222222-2222-4222-8222-222222222222" },
+      operations_copied: 2,
+      replayed: false,
+    })
+
+    await createGammeRevision(requestWith("revision-key-433"), response, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(mocks.createRevision).toHaveBeenCalledWith(
+      GAMME_ID,
+      {},
+      expect.objectContaining({ user_id: 42 }),
+      "revision-key-433",
+    )
+    expect(response.status).toHaveBeenCalledWith(201)
+  })
+
+  it("rend 200 pour le rejeu de la même clé", async () => {
+    const response = responseRecorder()
+    const next = vi.fn() as NextFunction
+    mocks.createRevision.mockResolvedValue({
+      gamme: { id: "22222222-2222-4222-8222-222222222222" },
+      operations_copied: 2,
+      replayed: true,
+    })
+
+    await createGammeRevision(requestWith("revision-key-433"), response, next)
+
+    expect(next).not.toHaveBeenCalled()
+    expect(response.status).toHaveBeenCalledWith(200)
+  })
+})

--- a/src/__tests__/gamme-revision-433.repository.test.ts
+++ b/src/__tests__/gamme-revision-433.repository.test.ts
@@ -1,0 +1,242 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  poolConnect: vi.fn(),
+  poolQuery: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+  insertAudit: vi.fn(),
+}))
+
+vi.mock("../config/database", () => ({
+  default: {
+    connect: mocks.poolConnect,
+    query: mocks.poolQuery,
+  },
+}))
+
+vi.mock("../module/audit-logs/repository/audit-logs.repository", () => ({
+  repoInsertAuditLog: mocks.insertAudit,
+}))
+
+import { repoCreateGammeRevision } from "../module/gammes/repository/gammes.repository"
+
+const SOURCE_ID = "11111111-1111-4111-8111-111111111111"
+const VERSION_ID = "22222222-2222-4222-8222-222222222222"
+const REVISION_ID = "33333333-3333-4333-8333-333333333333"
+const SOURCE_OPERATION_ID = "44444444-4444-4444-8444-444444444444"
+const REVISION_OPERATION_ID = "55555555-5555-4555-8555-555555555555"
+
+const audit = {
+  user_id: 42,
+  ip: "127.0.0.1",
+  user_agent: "vitest",
+  device_type: null,
+  os: null,
+  browser: null,
+  path: `/api/v1/gammes/${SOURCE_ID}/revisions`,
+  page_key: "pieces-techniques",
+  client_session_id: "test-session",
+}
+
+const source = {
+  id: SOURCE_ID,
+  piece_technique_version_id: VERSION_ID,
+  nom: "Gamme applicable",
+  code: "GAM-001",
+  designation: "Gamme série",
+  commentaire: null,
+  statut: "APPLICABLE",
+  updated_at: "2026-07-31T10:00:00.000Z",
+}
+
+const revision = {
+  id: REVISION_ID,
+  piece_technique_version_id: VERSION_ID,
+  nom: "045-PLAN-A — Gamme 2",
+  code: "GAM-001",
+  designation: "Gamme série",
+  commentaire: null,
+  statut: "BROUILLON",
+  is_current: false,
+  created_at: "2026-07-31T10:01:00.000Z",
+  updated_at: "2026-07-31T10:01:00.000Z",
+  created_by: 42,
+  updated_by: 42,
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  })
+  mocks.poolQuery.mockResolvedValue({ rows: [], rowCount: 0 })
+  mocks.insertAudit.mockResolvedValue(undefined)
+})
+
+describe("#433 — duplication transactionnelle d'une gamme figée", () => {
+  it("refuse une base qui ne porte pas le patch de filiation", async () => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (String(sql).includes("information_schema.columns")) {
+        return Promise.resolve({ rows: [{ present: false }], rowCount: 1 })
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 })
+    })
+
+    await expect(
+      repoCreateGammeRevision(SOURCE_ID, {}, audit, "revision-key-433"),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "GAMME_REVISION_SCHEMA_UPGRADE_REQUIRED",
+    })
+
+    expect(mocks.clientQuery).toHaveBeenCalledWith("BEGIN")
+    expect(mocks.clientQuery).toHaveBeenCalledWith("ROLLBACK")
+    expect(mocks.clientRelease).toHaveBeenCalledTimes(1)
+  })
+
+  it("refuse de réviser un brouillon pour ne pas contourner son parcours d'édition", async () => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      const text = String(sql)
+      if (text.includes("information_schema.columns")) {
+        return Promise.resolve({ rows: [{ present: true }], rowCount: 1 })
+      }
+      if (text.includes("FROM public.gammes WHERE id = $1 FOR UPDATE")) {
+        return Promise.resolve({ rows: [{ ...source, statut: "BROUILLON" }], rowCount: 1 })
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 })
+    })
+
+    await expect(
+      repoCreateGammeRevision(SOURCE_ID, {}, audit, "revision-key-433"),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "GAMME_REVISION_SOURCE_NOT_FROZEN",
+    })
+
+    expect(
+      mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO public.gammes")),
+    ).toBe(false)
+  })
+
+  it("copie l'entête, les opérations et leurs finitions avant un unique COMMIT", async () => {
+    mocks.clientQuery.mockImplementation((sql: string, params?: unknown[]) => {
+      const text = String(sql)
+      if (text === "BEGIN" || text === "COMMIT" || text === "ROLLBACK") {
+        return Promise.resolve({ rows: [], rowCount: 0 })
+      }
+      if (text.includes("information_schema.columns") && params?.[0] === "gammes") {
+        return Promise.resolve({ rows: [{ present: true }], rowCount: 1 })
+      }
+      if (text.includes("FROM public.gammes WHERE id = $1 FOR UPDATE")) {
+        return Promise.resolve({ rows: [source], rowCount: 1 })
+      }
+      if (text.includes("WHERE source_gamme_id = $1 AND revision_idempotency_key = $2")) {
+        return Promise.resolve({ rows: [], rowCount: 0 })
+      }
+      if (text.includes("FROM public.piece_technique_versions v")) {
+        return Promise.resolve({
+          rows: [{ code_piece: "045-PLAN", designation: "Pièce", indice: "A", existing: "1" }],
+          rowCount: 1,
+        })
+      }
+      if (text.includes("INSERT INTO public.gammes")) {
+        return Promise.resolve({ rows: [revision], rowCount: 1 })
+      }
+      if (
+        text.includes("information_schema.columns") &&
+        params?.[0] === "pieces_techniques_operations"
+      ) {
+        return Promise.resolve({
+          rows: [
+            { column_name: "ordre" },
+            { column_name: "phase" },
+            { column_name: "designation" },
+            { column_name: "type_operation" },
+          ],
+          rowCount: 4,
+        })
+      }
+      if (text.includes("WITH copied AS")) {
+        return Promise.resolve({
+          rows: [{ old_id: SOURCE_OPERATION_ID, new_id: REVISION_OPERATION_ID }],
+          rowCount: 1,
+        })
+      }
+      if (text.includes("to_regclass('public.gamme_operation_finitions')")) {
+        return Promise.resolve({ rows: [{ present: true }], rowCount: 1 })
+      }
+      if (
+        text.includes("information_schema.columns") &&
+        params?.[0] === "gamme_operation_finitions"
+      ) {
+        return Promise.resolve({
+          rows: [
+            { column_name: "piece_technique_version_id" },
+            { column_name: "finish_revision_id" },
+            { column_name: "spec_canonical" },
+            { column_name: "spec_fingerprint" },
+            { column_name: "generated_designation" },
+            { column_name: "generated_comment" },
+          ],
+          rowCount: 6,
+        })
+      }
+      if (text.includes("INSERT INTO public.gamme_operation_finitions")) {
+        return Promise.resolve({ rows: [], rowCount: 1 })
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 })
+    })
+
+    const result = await repoCreateGammeRevision(
+      SOURCE_ID,
+      { expected_updated_at: source.updated_at },
+      audit,
+      "revision-key-433",
+    )
+
+    expect(result).toEqual({ gamme: revision, operations_copied: 1, replayed: false })
+    const statements = mocks.clientQuery.mock.calls.map(([sql]) => String(sql))
+    expect(statements.some((sql) => sql.includes("INSERT INTO public.gammes"))).toBe(true)
+    expect(statements.some((sql) => sql.includes("WITH copied AS"))).toBe(true)
+    expect(
+      statements.some((sql) => sql.includes("INSERT INTO public.gamme_operation_finitions")),
+    ).toBe(true)
+    expect(statements.filter((sql) => sql === "COMMIT")).toHaveLength(1)
+    expect(statements.some((sql) => /^UPDATE public\.gammes/m.test(sql))).toBe(false)
+    expect(mocks.insertAudit).toHaveBeenCalledTimes(1)
+  })
+
+  it("rejoue la même clé sans créer une seconde gamme", async () => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      const text = String(sql)
+      if (text.includes("information_schema.columns")) {
+        return Promise.resolve({ rows: [{ present: true }], rowCount: 1 })
+      }
+      if (text.includes("FROM public.gammes WHERE id = $1 FOR UPDATE")) {
+        return Promise.resolve({ rows: [source], rowCount: 1 })
+      }
+      if (text.includes("WHERE source_gamme_id = $1 AND revision_idempotency_key = $2")) {
+        return Promise.resolve({ rows: [revision], rowCount: 1 })
+      }
+      if (text.includes("count(*)::text AS total")) {
+        return Promise.resolve({ rows: [{ total: "3" }], rowCount: 1 })
+      }
+      return Promise.resolve({ rows: [], rowCount: 0 })
+    })
+
+    const result = await repoCreateGammeRevision(
+      SOURCE_ID,
+      {},
+      audit,
+      "revision-key-433",
+    )
+
+    expect(result).toEqual({ gamme: revision, operations_copied: 3, replayed: true })
+    expect(
+      mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO public.gammes")),
+    ).toBe(false)
+    expect(mocks.clientQuery).toHaveBeenCalledWith("COMMIT")
+  })
+})

--- a/src/__tests__/gammes.test.ts
+++ b/src/__tests__/gammes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest"
 import {
   addGammeOperationSchema,
   createGammeSchema,
+  createGammeRevisionSchema,
   gammeStatutSchema,
   operationTypeSchema,
   reorderOperationsSchema,
@@ -33,6 +34,15 @@ describe("Gammes — validators", () => {
   it("update partiel + expected_updated_at", () => {
     expect(updateGammeSchema.safeParse({ body: { is_current: true, expected_updated_at: "2026-07-08" } }).success).toBe(true)
     expect(updateGammeSchema.safeParse({ body: {} }).success).toBe(true)
+  })
+
+  it("borne le corps d'une révision au verrou optimiste et au nom", () => {
+    expect(
+      createGammeRevisionSchema.safeParse({
+        body: { expected_updated_at: "2026-07-31T10:00:00.000Z", nom: "Révision B" },
+      }).success,
+    ).toBe(true)
+    expect(createGammeRevisionSchema.safeParse({ body: { statut: "BROUILLON" } }).success).toBe(false)
   })
 })
 

--- a/src/__tests__/material-article-code-164.test.ts
+++ b/src/__tests__/material-article-code-164.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertMaterialPreviewFresh,
+  buildMaterialArticleCode,
+  buildMaterialDimensionsSegment,
+  computeMaterialCodePreviewHash,
+  isSpecialMaterialProfile,
+  normalizeMaterialProfile,
+  MATERIAL_PROFILE_CODES,
+} from "../shared/codes/material-article-code";
+import { createArticleSchema, previewMaterialArticleCodeSchema } from "../module/stock/validators/stock.validators";
+
+/**
+ * #164 — La référence matière est produite par le SERVEUR.
+ *
+ * Ces tests figent la règle : aperçu et création appellent la même fonction,
+ * aucune valeur n'est inventée quand une donnée manque, et un profil inconnu
+ * est refusé au lieu de produire une référence illisible.
+ */
+describe("Référence matière — profils", () => {
+  it("expose exactement les sept profils du besoin", () => {
+    expect([...MATERIAL_PROFILE_CODES]).toEqual(["PL", "RO", "U", "FOND", "TUBE", "PROFIL", "BRUTCL"]);
+  });
+
+  it("ramène les orthographes historiques au code canonique", () => {
+    expect(normalizeMaterialProfile("plat")).toBe("PL");
+    expect(normalizeMaterialProfile("TÔLE")).toBe("PL");
+    expect(normalizeMaterialProfile("Rond")).toBe("RO");
+    expect(normalizeMaterialProfile("brut-client")).toBe("BRUTCL");
+    expect(normalizeMaterialProfile("FONDERIE")).toBe("FOND");
+  });
+
+  it("refuse un profil inconnu plutôt que d'inventer un code", () => {
+    expect(() => normalizeMaterialProfile("XYZ")).toThrowError(/Profil matière inconnu/);
+    expect(() => normalizeMaterialProfile("")).toThrowError(/Profil matière inconnu/);
+  });
+
+  it("classe FOND, PROFIL et BRUTCL comme profils sans géométrie identifiante", () => {
+    expect(isSpecialMaterialProfile("FOND")).toBe(true);
+    expect(isSpecialMaterialProfile("PROFIL")).toBe(true);
+    expect(isSpecialMaterialProfile("BRUTCL")).toBe(true);
+    expect(isSpecialMaterialProfile("PL")).toBe(false);
+  });
+});
+
+describe("Référence matière — segment dimensionnel", () => {
+  it("ordonne les cotes par profil", () => {
+    expect(
+      buildMaterialDimensionsSegment("PL", { largeur_mm: 100, epaisseur_mm: 10, longueur_brut_mm: 3000 })
+    ).toBe("100x10x3000");
+    expect(buildMaterialDimensionsSegment("RO", { diametre_mm: 20, longueur_brut_mm: 3000 })).toBe("20x3000");
+    expect(
+      buildMaterialDimensionsSegment("TUBE", { diametre_mm: 30, epaisseur_mm: 2, longueur_coupe_mm: 1000 })
+    ).toBe("30x2x1000");
+    expect(
+      buildMaterialDimensionsSegment("U", { largeur_mm: 50, hauteur_mm: 40, epaisseur_mm: 5 })
+    ).toBe("50x40x5");
+  });
+
+  it("omet une cote absente au lieu de la combler", () => {
+    expect(buildMaterialDimensionsSegment("PL", { largeur_mm: 100 })).toBe("100");
+    expect(buildMaterialDimensionsSegment("PL", {})).toBeNull();
+    expect(buildMaterialDimensionsSegment("RO", { diametre_mm: 0 })).toBeNull();
+  });
+
+  it("exclut la longueur d'une barre à découper : elle varie d'une réception à l'autre", () => {
+    expect(
+      buildMaterialDimensionsSegment("RO", {
+        diametre_mm: 20,
+        barre_a_decouper: true,
+        longueur_barre_source_mm: 6000,
+        longueur_brut_mm: 6000,
+      })
+    ).toBe("20");
+  });
+
+  it("n'attribue aucune dimension aux profils particuliers", () => {
+    expect(buildMaterialDimensionsSegment("FOND", { largeur_mm: 10 })).toBeNull();
+    expect(buildMaterialDimensionsSegment("BRUTCL", { largeur_mm: 10 })).toBeNull();
+  });
+});
+
+describe("Référence matière — code et désignation canonique", () => {
+  it("construit la référence d'un plat complet", () => {
+    const out = buildMaterialArticleCode({
+      profile: "PL",
+      nuance_code: "S235",
+      etat_code: "BRUT",
+      dimensions: { largeur_mm: 100, epaisseur_mm: 10, longueur_brut_mm: 3000 },
+    });
+    expect(out.code).toBe("MP-PL-S235-BRUT-100x10x3000");
+    expect(out.designation).toBe("PLAT/TOLE S235 BRUT 100x10x3000 mm");
+  });
+
+  it("insère le sous-état quand il est choisi", () => {
+    const out = buildMaterialArticleCode({
+      profile: "RO",
+      nuance_code: "316L",
+      etat_code: "RECT",
+      sous_etat_code: "H9",
+      dimensions: { diametre_mm: 20, longueur_brut_mm: 3000 },
+    });
+    expect(out.code).toBe("MP-RO-316L-RECT-H9-20x3000");
+  });
+
+  it("accepte une matière sans aucune cote : le code reste lisible, sans segment inventé", () => {
+    const out = buildMaterialArticleCode({ profile: "PL", nuance_code: "S235", etat_code: "BRUT" });
+    expect(out.code).toBe("MP-PL-S235-BRUT");
+    expect(out.dimensions_segment).toBeNull();
+  });
+
+  it("normalise les séparateurs sans écraser les groupes métier", () => {
+    const out = buildMaterialArticleCode({
+      profile: "PL",
+      nuance_code: "s 235 jr",
+      etat_code: "brut/lamine",
+      dimensions: { largeur_mm: 100, epaisseur_mm: 10 },
+    });
+    expect(out.code).toBe("MP-PL-S-235-JR-BRUT-LAMINE-100x10");
+  });
+
+  it("exige nuance et état pour un profil géométrique", () => {
+    expect(() => buildMaterialArticleCode({ profile: "PL", etat_code: "BRUT" })).toThrowError(/nuance/i);
+    expect(() => buildMaterialArticleCode({ profile: "PL", nuance_code: "S235" })).toThrowError(/état/i);
+  });
+
+  it("exige une référence métier pour FOND et PROFIL", () => {
+    expect(() => buildMaterialArticleCode({ profile: "FOND" })).toThrowError(/référence métier/i);
+    expect(buildMaterialArticleCode({ profile: "FOND", reference_suffix: "CARTER-12" }).code).toBe(
+      "MP-FOND-CARTER-12"
+    );
+    expect(buildMaterialArticleCode({ profile: "PROFIL", reference_suffix: "omega 45" }).code).toBe(
+      "MP-PROFIL-OMEGA-45"
+    );
+  });
+
+  it("exige le code client ET la référence pour un brut client", () => {
+    expect(() => buildMaterialArticleCode({ profile: "BRUTCL", reference_suffix: "AX12" })).toThrowError(
+      /code du client propriétaire/i
+    );
+    const out = buildMaterialArticleCode({
+      profile: "BRUTCL",
+      client_code: "CLI-042",
+      reference_suffix: "AX12",
+    });
+    expect(out.code).toBe("MP-BRUTCL-CLI-042-AX12");
+    expect(out.designation).toBe("BRUT CLIENT CLI-042 AX12");
+  });
+});
+
+describe("Référence matière — empreinte d'aperçu", () => {
+  const input = {
+    profile: "PL" as const,
+    nuance_code: "S235",
+    etat_code: "BRUT",
+    dimensions: { largeur_mm: 100, epaisseur_mm: 10, longueur_brut_mm: 3000 },
+  };
+
+  it("est stable pour une configuration identique", () => {
+    const result = buildMaterialArticleCode(input);
+    const a = computeMaterialCodePreviewHash({ input, code: result.code, designation: result.designation });
+    const b = computeMaterialCodePreviewHash({ input, code: result.code, designation: result.designation });
+    expect(a).toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("change dès qu'une cote change", () => {
+    const first = buildMaterialArticleCode(input);
+    const second = buildMaterialArticleCode({ ...input, dimensions: { ...input.dimensions, largeur_mm: 120 } });
+    expect(
+      computeMaterialCodePreviewHash({ input, code: first.code, designation: first.designation })
+    ).not.toBe(
+      computeMaterialCodePreviewHash({
+        input: { ...input, dimensions: { ...input.dimensions, largeur_mm: 120 } },
+        code: second.code,
+        designation: second.designation,
+      })
+    );
+  });
+
+  it("refuse une confirmation dont l'aperçu est périmé, tolère un client qui n'en envoie pas", () => {
+    expect(() => assertMaterialPreviewFresh(undefined, "a".repeat(64))).not.toThrow();
+    expect(() => assertMaterialPreviewFresh("", "a".repeat(64))).not.toThrow();
+    expect(() => assertMaterialPreviewFresh("b".repeat(64), "a".repeat(64))).toThrowError(/plus à jour/);
+  });
+});
+
+describe("Contrat HTTP", () => {
+  it("accepte une matière SANS désignation : le serveur produit la forme canonique", () => {
+    const parsed = createArticleSchema.safeParse({
+      body: {
+        article_category: "matiere",
+        family_code: "PL",
+        article_matiere: { nuance_id: 1, etat_id: 2, largeur_mm: 100, epaisseur_mm: 10 },
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("continue d'exiger une désignation hors matière", () => {
+    const parsed = createArticleSchema.safeParse({
+      body: { article_category: "achat", family_code: "ACH" },
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("refuse une empreinte d'aperçu matière sur une autre catégorie", () => {
+    const parsed = createArticleSchema.safeParse({
+      body: {
+        designation: "Écrou",
+        article_category: "achat",
+        family_code: "ACH",
+        material_code_preview_hash: "a".repeat(64),
+      },
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it("accepte la configuration matière complète pour l'aperçu", () => {
+    const parsed = previewMaterialArticleCodeSchema.safeParse({
+      body: {
+        family_code: "BRUTCL",
+        client_proprietaire_id: "042",
+        reference_suffix: "AX12",
+      },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it("refuse un champ inconnu dans l'aperçu (schéma strict)", () => {
+    const parsed = previewMaterialArticleCodeSchema.safeParse({
+      body: { family_code: "PL", code: "MP-PL-FORGE" },
+    });
+    expect(parsed.success).toBe(false);
+  });
+});

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -363,6 +363,11 @@ describe("/api/v1/stock", () => {
       if (q.includes("INSERT INTO public.articles_matiere")) {
         return { rows: [] };
       }
+      // #164 — La référence matière est DÉRIVÉE par le serveur : il relit
+      // lui-même les codes du référentiel, le navigateur n'envoie que des ids.
+      if (q.includes("FROM public.stock_nuances")) return { rows: [{ code: "ALU" }] };
+      if (q.includes("FROM public.stock_etats")) return { rows: [{ code: "ETAT" }] };
+      if (q.includes("FROM public.stock_sous_etats")) return { rows: [] };
       return { rows: [] };
     });
 
@@ -443,6 +448,18 @@ describe("/api/v1/stock", () => {
     expect(
       mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO public.articles_matiere"))
     ).toBe(true);
+
+    // #164 — Le code enregistré est DÉRIVÉ de la configuration matière, pas
+    // séquencé : aucun `ART-<FAMILLE>-<SEQ6>` n'est alloué pour une matière.
+    const insertArticle = mocks.clientQuery.mock.calls.find((call) =>
+      String(call[0]).includes("INSERT INTO public.articles (")
+    );
+    expect(insertArticle).toBeDefined();
+    const insertedCode = (insertArticle?.[1] as unknown[])?.[1];
+    expect(insertedCode).toBe("MP-PL-ALU-ETAT-50x10x1000");
+    expect(
+      mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("public.fn_next_issued_code_value"))
+    ).toBe(false);
   });
 
   it("POST /api/v1/stock/movements rejects missing lot for lot-tracked article", async () => {

--- a/src/module/gammes/controllers/gammes.controller.ts
+++ b/src/module/gammes/controllers/gammes.controller.ts
@@ -97,16 +97,23 @@ export const updateGamme: RequestHandler = async (req, res, next) => {
 /**
  * #433 — Préparer une révision d'une gamme figée.
  *
- * `Idempotency-Key` est FACULTATIVE mais fortement recommandée : sans elle, un
- * double clic crée deux brouillons. L'écran en fournit une, stable tant que
- * l'utilisateur reste sur la même gamme.
+ * `Idempotency-Key` est OBLIGATOIRE : l'API ne doit pas dépendre du seul
+ * comportement de l'écran pour garantir qu'un double clic ou un rejeu après
+ * coupure ne crée pas deux brouillons.
  */
 export const createGammeRevision: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = createGammeRevisionSchema.parse({ body: req.body }).body
     const rawKey = req.headers["idempotency-key"]
-    const idempotencyKey = typeof rawKey === "string" && rawKey.trim() ? rawKey.trim().slice(0, 200) : null
+    const idempotencyKey = typeof rawKey === "string" ? rawKey.trim() : ""
+    if (idempotencyKey.length < 8 || idempotencyKey.length > 200) {
+      throw new HttpError(
+        400,
+        "IDEMPOTENCY_KEY_REQUIRED",
+        "Une clé Idempotency-Key stable de 8 à 200 caractères est obligatoire."
+      )
+    }
     const out = await createGammeRevisionSVC(routeParam(req, "gammeId"), body, audit, idempotencyKey)
     res.status(out.replayed ? 200 : 201).json(out)
   } catch (err) {

--- a/src/module/gammes/controllers/gammes.controller.ts
+++ b/src/module/gammes/controllers/gammes.controller.ts
@@ -6,6 +6,7 @@ import type { AuditContext } from "../../pieces-techniques/repository/pieces-tec
 import {
   addGammeOperationSchema,
   createGammeSchema,
+  createGammeRevisionSchema,
   deleteGammeOperationSchema,
   publishGammeSchema,
   reorderOperationsSchema,
@@ -15,6 +16,7 @@ import {
 import {
   addGammeOperationSVC,
   createGammeSVC,
+  createGammeRevisionSVC,
   deleteGammeOperationSVC,
   gammePublicationReadinessSVC,
   listGammeOperationsSVC,
@@ -87,6 +89,26 @@ export const updateGamme: RequestHandler = async (req, res, next) => {
     const out = await updateGammeSVC(routeParam(req, "gammeId"), body, audit)
     if (!out) throw new HttpError(404, "NOT_FOUND", "Gamme introuvable")
     res.json(out)
+  } catch (err) {
+    next(err)
+  }
+}
+
+/**
+ * #433 — Préparer une révision d'une gamme figée.
+ *
+ * `Idempotency-Key` est FACULTATIVE mais fortement recommandée : sans elle, un
+ * double clic crée deux brouillons. L'écran en fournit une, stable tant que
+ * l'utilisateur reste sur la même gamme.
+ */
+export const createGammeRevision: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req)
+    const body = createGammeRevisionSchema.parse({ body: req.body }).body
+    const rawKey = req.headers["idempotency-key"]
+    const idempotencyKey = typeof rawKey === "string" && rawKey.trim() ? rawKey.trim().slice(0, 200) : null
+    const out = await createGammeRevisionSVC(routeParam(req, "gammeId"), body, audit, idempotencyKey)
+    res.status(out.replayed ? 200 : 201).json(out)
   } catch (err) {
     next(err)
   }

--- a/src/module/gammes/repository/gammes.repository.ts
+++ b/src/module/gammes/repository/gammes.repository.ts
@@ -267,6 +267,14 @@ export async function repoCreateGammeRevision(
       throw new HttpError(404, "NOT_FOUND", "Gamme introuvable")
     }
 
+    if (source.statut !== "APPLICABLE" && source.statut !== "OBSOLETE") {
+      throw new HttpError(
+        409,
+        "GAMME_REVISION_SOURCE_NOT_FROZEN",
+        "Seule une gamme figée (applicable ou obsolète) peut être préparée en révision."
+      )
+    }
+
     // Verrou optimiste : la gamme affichée doit être celle qu'on duplique.
     if (body.expected_updated_at && body.expected_updated_at !== source.updated_at) {
       throw new HttpError(409, "CONCURRENT_MODIFICATION", "La gamme a été modifiée entre-temps")

--- a/src/module/gammes/repository/gammes.repository.ts
+++ b/src/module/gammes/repository/gammes.repository.ts
@@ -158,6 +158,237 @@ export async function repoCreateGamme(versionId: string, body: CreateGammeBodyDT
   }
 }
 
+/* -------------------------------------------------------------------------- */
+/* #433 — Préparer une RÉVISION d'une gamme figée                             */
+/* -------------------------------------------------------------------------- */
+
+async function columnExists(
+  tx: Pick<PoolClient, "query">,
+  table: string,
+  column: string
+): Promise<boolean> {
+  const res = await tx.query<{ present: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM information_schema.columns
+       WHERE table_schema = 'public' AND table_name = $1 AND column_name = $2
+     ) AS present`,
+    [table, column]
+  )
+  return Boolean(res.rows[0]?.present)
+}
+
+/**
+ * Colonnes à recopier d'une ligne à l'autre : tout SAUF l'identité et les
+ * traces d'écriture, qui doivent être neuves.
+ *
+ * La liste est lue dans le catalogue plutôt qu'écrite en dur : une colonne
+ * ajoutée plus tard aux opérations (un référentiel Méthodes, un temps, un lien
+ * de finition) est reprise automatiquement. Une liste figée aurait perdu cette
+ * donnée en silence, ce qui est exactement ce qu'une révision ne doit pas faire.
+ */
+async function copyableColumns(
+  tx: Pick<PoolClient, "query">,
+  table: string,
+  excluded: string[]
+): Promise<string[]> {
+  const res = await tx.query<{ column_name: string }>(
+    `SELECT column_name
+       FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = $1
+        AND is_generated = 'NEVER'
+        AND column_name <> ALL($2::text[])
+      ORDER BY ordinal_position`,
+    [table, excluded]
+  )
+  return res.rows.map((row) => row.column_name)
+}
+
+export type GammeRevisionResult = { gamme: GammeRow; operations_copied: number; replayed: boolean }
+
+/**
+ * Duplique une gamme et ses opérations dans un NOUVEAU BROUILLON.
+ *
+ * Pourquoi ce point d'entrée existe
+ * ---------------------------------
+ * Une gamme `APPLICABLE` est volontairement immuable : les OF lancés et les
+ * snapshots historiques s'appuient dessus. « Ajouter une opération » y est donc
+ * grisé — sans issue. Cette opération donne la suite : repartir de la définition
+ * figée dans un brouillon modifiable.
+ *
+ * Garanties
+ * ---------
+ * · atomique — une seule transaction, entête + opérations + liens de finition ;
+ * · fidèle — phases, ordre, référentiels, temps et taux gelés sont recopiés ;
+ * · non destructive — la gamme source n'est PAS touchée, la gamme courante non
+ *   plus (le brouillon n'est jamais `is_current`) ;
+ * · idempotente — la même `Idempotency-Key` rend la même révision ;
+ * · auditée.
+ */
+export async function repoCreateGammeRevision(
+  gammeId: string,
+  body: { expected_updated_at?: string | null; nom?: string | null },
+  audit: AuditContext,
+  idempotencyKey?: string | null
+): Promise<GammeRevisionResult> {
+  const client = await db.connect()
+  try {
+    await client.query("BEGIN")
+
+    const lineageReady =
+      (await columnExists(client, "gammes", "source_gamme_id"))
+      && (await columnExists(client, "gammes", "revision_idempotency_key"))
+    if (!lineageReady) {
+      throw new HttpError(
+        503,
+        "GAMME_REVISION_SCHEMA_UPGRADE_REQUIRED",
+        "Le patch additif 20260731_gamme_revision_lineage doit être appliqué sur cet environnement avant de préparer une révision de gamme."
+      )
+    }
+
+    const sourceRes = await client.query<{
+      id: string
+      piece_technique_version_id: string
+      nom: string | null
+      code: string | null
+      designation: string | null
+      commentaire: string | null
+      statut: GammeStatutDTO
+      updated_at: string
+    }>(
+      `SELECT id::text AS id, piece_technique_version_id::text AS piece_technique_version_id,
+              nom, code, designation, commentaire, statut, updated_at::text AS updated_at
+         FROM public.gammes WHERE id = $1 FOR UPDATE`,
+      [gammeId]
+    )
+    const source = sourceRes.rows[0]
+    if (!source) {
+      await client.query("ROLLBACK").catch(() => {})
+      throw new HttpError(404, "NOT_FOUND", "Gamme introuvable")
+    }
+
+    // Verrou optimiste : la gamme affichée doit être celle qu'on duplique.
+    if (body.expected_updated_at && body.expected_updated_at !== source.updated_at) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "La gamme a été modifiée entre-temps")
+    }
+
+    // Rejeu : la même clé sur la même gamme source rend la révision déjà créée.
+    if (idempotencyKey) {
+      const replay = await client.query<GammeRow>(
+        `SELECT ${GAMME_COLS} FROM public.gammes
+          WHERE source_gamme_id = $1 AND revision_idempotency_key = $2
+          LIMIT 1`,
+        [gammeId, idempotencyKey]
+      )
+      const existing = replay.rows[0]
+      if (existing) {
+        const counted = await client.query<{ total: string }>(
+          `SELECT count(*)::text AS total FROM public.pieces_techniques_operations WHERE gamme_id = $1`,
+          [existing.id]
+        )
+        await client.query("COMMIT")
+        return { gamme: existing, operations_copied: Number(counted.rows[0]?.total ?? "0"), replayed: true }
+      }
+    }
+
+    const naming = await readGammeNamingContext(client, source.piece_technique_version_id)
+    const nom = resolveGammeName(body.nom ?? null, naming)
+
+    // La révision naît BROUILLON et jamais courante : tant qu'elle n'est pas
+    // publiée, la production continue de suivre la gamme applicable.
+    const createdRes = await client.query<GammeRow>(
+      `INSERT INTO public.gammes
+        (piece_technique_version_id, nom, code, designation, commentaire, statut, is_current,
+         source_gamme_id, revision_idempotency_key, created_by, updated_by)
+       VALUES ($1,$2,$3,$4,$5,'BROUILLON',false,$6,$7,$8,$8)
+       RETURNING ${GAMME_COLS}`,
+      [
+        source.piece_technique_version_id,
+        nom,
+        source.code,
+        source.designation,
+        source.commentaire,
+        gammeId,
+        idempotencyKey ?? null,
+        audit.user_id,
+      ]
+    )
+    const created = createdRes.rows[0]
+
+    const opColumns = await copyableColumns(client, "pieces_techniques_operations", [
+      "id",
+      "gamme_id",
+      "created_at",
+      "updated_at",
+      "created_by",
+      "updated_by",
+    ])
+    const opColumnList = opColumns.map((c) => `"${c}"`).join(", ")
+    const copiedOps = await client.query<{ new_id: string; old_id: string }>(
+      `WITH copied AS (
+         INSERT INTO public.pieces_techniques_operations
+           (gamme_id, ${opColumnList}, created_by, updated_by)
+         SELECT $2::uuid, ${opColumns.map((c) => `o."${c}"`).join(", ")}, $3, $3
+           FROM public.pieces_techniques_operations o
+          WHERE o.gamme_id = $1
+          ORDER BY o.ordre ASC, o.phase ASC, o.created_at ASC
+         RETURNING id::text AS new_id, ordre, phase
+       )
+       SELECT c.new_id,
+              (SELECT o.id::text
+                 FROM public.pieces_techniques_operations o
+                WHERE o.gamme_id = $1 AND o.ordre = c.ordre AND o.phase IS NOT DISTINCT FROM c.phase
+                LIMIT 1) AS old_id
+         FROM copied c`,
+      [gammeId, created.id, audit.user_id]
+    )
+
+    // Liens de finition : chaque ligne suit SON opération dupliquée. Une
+    // finition orpheline serait pire qu'absente.
+    const finitionsTable = await client.query<{ present: boolean }>(
+      `SELECT to_regclass('public.gamme_operation_finitions') IS NOT NULL AS present`
+    )
+    if (finitionsTable.rows[0]?.present) {
+      const finitionColumns = await copyableColumns(client, "gamme_operation_finitions", [
+        "id",
+        "gamme_id",
+        "gamme_operation_id",
+        "created_at",
+        "updated_at",
+        "created_by",
+        "updated_by",
+      ])
+      const finitionList = finitionColumns.map((c) => `"${c}"`).join(", ")
+      for (const pair of copiedOps.rows) {
+        if (!pair.old_id) continue
+        await client.query(
+          `INSERT INTO public.gamme_operation_finitions
+             (gamme_id, gamme_operation_id, ${finitionList}, created_by, updated_by)
+           SELECT $2::uuid, $3::uuid, ${finitionColumns.map((c) => `f."${c}"`).join(", ")}, $4, $4
+             FROM public.gamme_operation_finitions f
+            WHERE f.gamme_operation_id = $1::uuid`,
+          [pair.old_id, created.id, pair.new_id, audit.user_id]
+        )
+      }
+    }
+
+    await insertAudit(client, audit, "gammes.revision.create", "gamme", created.id, {
+      source_gamme_id: gammeId,
+      source_statut: source.statut,
+      piece_technique_version_id: source.piece_technique_version_id,
+      operations_copied: copiedOps.rowCount ?? 0,
+    })
+
+    await client.query("COMMIT")
+    return { gamme: created, operations_copied: copiedOps.rowCount ?? 0, replayed: false }
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {})
+    throw e
+  } finally {
+    client.release()
+  }
+}
+
 export async function repoUpdateGamme(gammeId: string, body: UpdateGammeBodyDTO, audit: AuditContext): Promise<GammeRow | null> {
   const client = await db.connect()
   try {

--- a/src/module/gammes/routes/gammes.routes.ts
+++ b/src/module/gammes/routes/gammes.routes.ts
@@ -8,6 +8,7 @@ import { authenticateToken } from "../../auth/middlewares/auth.middleware"
 import { requireMethodesCapability } from "../../methodes/middlewares/methodes-authorization.middleware"
 import {
   addGammeOperation,
+  createGammeRevision,
   deleteGammeOperation,
   listGammeOperations,
   nextGammeOperationPhase,
@@ -19,6 +20,7 @@ import {
 } from "../controllers/gammes.controller"
 import {
   addGammeOperationSchema,
+  createGammeRevisionSchema,
   deleteGammeOperationSchema,
   gammeIdParamSchema,
   nextPhaseQuerySchema,
@@ -34,6 +36,21 @@ const router = Router()
 router.use(authenticateToken)
 
 router.patch("/:gammeId", validate(gammeIdParamSchema), validate(updateGammeSchema), updateGamme)
+
+/**
+ * #433 — Révision d'une gamme figée.
+ *
+ * Écrire une gamme applicable reste INTERDIT ; en préparer une révision est une
+ * écriture Méthodes ordinaire, soumise à la même capacité que l'ajout d'une
+ * opération — c'est bien ce que l'utilisateur veut faire au bout du parcours.
+ */
+router.post(
+  "/:gammeId/revisions",
+  requireMethodesCapability("gamme_operation_write"),
+  validate(gammeIdParamSchema),
+  validate(createGammeRevisionSchema),
+  createGammeRevision
+)
 
 /* Opérations. */
 router.get(

--- a/src/module/gammes/services/gammes.service.ts
+++ b/src/module/gammes/services/gammes.service.ts
@@ -14,11 +14,13 @@ import {
 } from "../repository/gamme-operations.repository"
 import {
   repoCreateGamme,
+  repoCreateGammeRevision,
   repoListGammesByVersion,
   repoUpdateGamme,
 } from "../repository/gammes.repository"
 import type {
   CreateGammeBodyDTO,
+  CreateGammeRevisionBodyDTO,
   UpdateGammeBodyDTO,
 } from "../validators/gammes.validators"
 
@@ -27,6 +29,13 @@ export const createGammeSVC = (versionId: string, body: CreateGammeBodyDTO, audi
   repoCreateGamme(versionId, body, audit)
 export const updateGammeSVC = (gammeId: string, body: UpdateGammeBodyDTO, audit: AuditContext) =>
   repoUpdateGamme(gammeId, body, audit)
+/** #433 — duplique une gamme figée dans un brouillon modifiable, en une transaction. */
+export const createGammeRevisionSVC = (
+  gammeId: string,
+  body: CreateGammeRevisionBodyDTO,
+  audit: AuditContext,
+  idempotencyKey?: string | null
+) => repoCreateGammeRevision(gammeId, body, audit, idempotencyKey)
 
 export const listGammeOperationsSVC = (gammeId: string) => repoListGammeOperations(gammeId)
 export const nextPhaseSVC = (gammeId: string, afterOperationId: string | null) =>

--- a/src/module/gammes/validators/gammes.validators.ts
+++ b/src/module/gammes/validators/gammes.validators.ts
@@ -46,6 +46,23 @@ export const updateGammeSchema = z.object({
 })
 export type UpdateGammeBodyDTO = z.infer<typeof updateGammeSchema>["body"]
 
+/**
+ * #433 — Préparer une révision d'une gamme figée.
+ *
+ * Le corps ne décrit PAS le contenu de la nouvelle gamme : celui-ci est
+ * intégralement dupliqué depuis la source. Il ne porte que le verrou optimiste
+ * et, éventuellement, un intitulé choisi — sinon le serveur nomme la révision.
+ */
+export const createGammeRevisionSchema = z.object({
+  body: z
+    .object({
+      expected_updated_at: z.string().min(1).optional(),
+      nom: z.string().trim().min(1, "Nom de gamme vide").max(200).optional().nullable(),
+    })
+    .strict(),
+})
+export type CreateGammeRevisionBodyDTO = z.infer<typeof createGammeRevisionSchema>["body"]
+
 // Opération de gamme. Noms métier mappés aux colonnes DB : numero_operation→phase,
 // temps_preparation→tp, temps_cycle→tf_unit.
 //

--- a/src/module/stock/controllers/stock.controller.ts
+++ b/src/module/stock/controllers/stock.controller.ts
@@ -29,6 +29,7 @@ import {
   listArticleFamiliesQuerySchema,
   listMatiereEtatsQuerySchema,
   listMatiereNuancesQuerySchema,
+  previewMaterialArticleCodeSchema,
   listMatiereSousEtatsQuerySchema,
   listBalancesQuerySchema,
   listEmplacementsQuerySchema,
@@ -55,6 +56,7 @@ import {
   type CreateArticleFamilyBodyDTO,
   type CreateMatiereEtatBodyDTO,
   type CreateMatiereNuanceBodyDTO,
+  type PreviewMaterialArticleCodeBodyDTO,
   type CreateMatiereSousEtatBodyDTO,
   type CreateEmplacementBodyDTO,
   type CreateLotBodyDTO,
@@ -113,6 +115,7 @@ import {
   listStockArticleFamiliesSVC,
   listStockMatiereEtatsSVC,
   listStockMatiereNuancesSVC,
+  previewMaterialArticleCodeSVC,
   listStockMatiereSousEtatsSVC,
   getStockLotSVC,
   getStockLotGenealogySVC,
@@ -425,6 +428,23 @@ export const listStockArticleFamilies: RequestHandler = async (req, res, next) =
     }
     const out = await listStockArticleFamiliesSVC(parsed.data);
     res.json({ items: out, total: out.length });
+  } catch (err) {
+    next(err);
+  }
+};
+
+/**
+ * #164 — Aperçu SERVEUR de la référence matière.
+ *
+ * POST parce que la configuration matière est un objet, pas une chaîne de
+ * requête. La réponse porte `authoritative: true` : contrairement à
+ * `/articles/code-preview`, cette valeur EST celle qui sera enregistrée.
+ */
+export const previewMaterialArticleCode: RequestHandler = async (req, res, next) => {
+  try {
+    const body: PreviewMaterialArticleCodeBodyDTO = previewMaterialArticleCodeSchema.parse({ body: req.body }).body;
+    const out = await previewMaterialArticleCodeSVC(body);
+    res.json({ ...out, authoritative: true, source: "server-generator" });
   } catch (err) {
     next(err);
   }

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -10,6 +10,16 @@ import {
   generateFabricatedArticleBusinessCode,
   generateTransactionalBusinessCode,
 } from "../../../shared/codes/code-generator.service";
+import {
+  assertMaterialPreviewFresh,
+  buildMaterialArticleCode,
+  computeMaterialCodePreviewHash,
+  isSpecialMaterialProfile,
+  normalizeMaterialProfile,
+  type MaterialCodeInput,
+  type MaterialCodeResult,
+  type MaterialProfileCode,
+} from "../../../shared/codes/material-article-code";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -579,6 +589,109 @@ async function resolveArticleCode(
   return normalized;
 }
 
+/* -------------------------------------------------------------------------- */
+/* Référence MATIÈRE PREMIÈRE — résolution des segments puis génération        */
+/* -------------------------------------------------------------------------- */
+
+export type MaterialCodeRequest = {
+  family_code: string;
+  nuance_id?: number | null;
+  etat_id?: number | null;
+  sous_etat_id?: number | null;
+  client_proprietaire_id?: string | null;
+  reference_suffix?: string | null;
+  dimensions?: MaterialCodeInput["dimensions"];
+};
+
+async function referentialCode(
+  client: Pick<PoolClient, "query">,
+  args: { table: "stock_nuances" | "stock_etats" | "stock_sous_etats"; id: number; label: string }
+): Promise<string> {
+  const res = await client.query<{ code: string | null }>(
+    `SELECT code FROM public.${args.table} WHERE id = $1::bigint LIMIT 1`,
+    [args.id]
+  );
+  const code = (res.rows[0]?.code ?? "").trim();
+  if (!code) {
+    throw new HttpError(400, "INVALID_MATERIAL_REFERENTIAL", `${args.label} introuvable (id ${args.id}).`);
+  }
+  return code;
+}
+
+/**
+ * Résout, EN BASE, les codes qui composent une référence matière.
+ *
+ * Le navigateur n'envoie que des identifiants : c'est le serveur qui lit le
+ * code de la nuance, de l'état, du sous-état et du client propriétaire. Une
+ * interface qui enverrait un libellé fantaisiste ne peut donc pas influencer la
+ * référence produite.
+ */
+export async function resolveMaterialCodeInput(
+  client: Pick<PoolClient, "query">,
+  request: MaterialCodeRequest
+): Promise<MaterialCodeInput> {
+  const profile: MaterialProfileCode = normalizeMaterialProfile(request.family_code);
+  const special = isSpecialMaterialProfile(profile);
+
+  const nuanceId = typeof request.nuance_id === "number" && Number.isFinite(request.nuance_id) ? Math.trunc(request.nuance_id) : null;
+  const etatId = typeof request.etat_id === "number" && Number.isFinite(request.etat_id) ? Math.trunc(request.etat_id) : null;
+  const sousEtatId =
+    typeof request.sous_etat_id === "number" && Number.isFinite(request.sous_etat_id) ? Math.trunc(request.sous_etat_id) : null;
+
+  const nuanceCode = !special && nuanceId ? await referentialCode(client, { table: "stock_nuances", id: nuanceId, label: "Nuance" }) : null;
+  const etatCode = !special && etatId ? await referentialCode(client, { table: "stock_etats", id: etatId, label: "État" }) : null;
+  const sousEtatCode = !special && sousEtatId
+    ? await referentialCode(client, { table: "stock_sous_etats", id: sousEtatId, label: "Sous-état" })
+    : null;
+
+  let clientCode: string | null = null;
+  if (profile === "BRUTCL") {
+    const clientId = (request.client_proprietaire_id ?? "").trim();
+    if (!clientId) {
+      throw new HttpError(
+        400,
+        "MATERIAL_CLIENT_CODE_REQUIRED",
+        "Un brut client exige le client propriétaire pour construire sa référence."
+      );
+    }
+    const res = await client.query<{ client_code: string | null }>(
+      `SELECT client_code FROM public.clients WHERE client_id = $1 LIMIT 1`,
+      [clientId]
+    );
+    if (res.rowCount === 0) {
+      throw new HttpError(400, "INVALID_CLIENT", `Client propriétaire inconnu : ${clientId}.`);
+    }
+    // Le code client est la forme lisible ; l'identifiant reste la valeur de
+    // secours pour un client historique sans code attribué.
+    clientCode = (res.rows[0]?.client_code ?? "").trim() || clientId;
+  }
+
+  return {
+    profile,
+    nuance_code: nuanceCode,
+    etat_code: etatCode,
+    sous_etat_code: sousEtatCode,
+    client_code: clientCode,
+    reference_suffix: request.reference_suffix ?? null,
+    dimensions: request.dimensions ?? null,
+  };
+}
+
+export type MaterialCodePreview = MaterialCodeResult & { preview_hash: string };
+
+/**
+ * Aperçu serveur de la référence matière. C'est LA MÊME fonction que la
+ * création : les deux ne peuvent pas diverger.
+ */
+export async function repoPreviewMaterialArticleCode(request: MaterialCodeRequest): Promise<MaterialCodePreview> {
+  const input = await resolveMaterialCodeInput(db, request);
+  const result = buildMaterialArticleCode(input);
+  return {
+    ...result,
+    preview_hash: computeMaterialCodePreviewHash({ input, code: result.code, designation: result.designation }),
+  };
+}
+
 async function normalizeArticleState(args: {
   article_type: string | null | undefined;
   article_category: string | null | undefined;
@@ -1056,7 +1169,7 @@ export async function repoListMatiereEtats(filters: ListMatiereEtatsQueryDTO = {
   const res = await db.query<{
     id: number;
     code: string;
-    designation: string;
+    designation: string | null;
     unite_achat: number;
     is_active: boolean;
     nuance_ids: number[];
@@ -1084,7 +1197,9 @@ export async function repoListMatiereEtats(filters: ListMatiereEtatsQueryDTO = {
   return res.rows.map((row) => ({
     id: row.id,
     code: row.code,
-    designation: row.designation,
+    // Une désignation vide en base est présentée comme absente : l'écran affiche
+    // alors le code, il n'affiche pas « CODE — ».
+    designation: row.designation && row.designation.trim() ? row.designation : null,
     unite_achat: typeof row.unite_achat === "number" ? row.unite_achat : Number(row.unite_achat) || 3020,
     is_active: row.is_active,
     nuance_ids: Array.isArray(row.nuance_ids) ? row.nuance_ids.filter((v) => typeof v === "number") : [],
@@ -1093,7 +1208,9 @@ export async function repoListMatiereEtats(filters: ListMatiereEtatsQueryDTO = {
 
 export async function repoCreateMatiereEtat(body: CreateMatiereEtatBodyDTO, audit: AuditContext): Promise<StockMatiereEtat> {
   const code = normalizeStockReferentialCode(body.code, "Etat");
-  const designation = body.designation.trim();
+  // La colonne historique `stock_etats.designation` est NOT NULL : une
+  // désignation absente est stockée vide et ressort `null` côté API.
+  const designation = body.designation?.trim() || "";
   const unite_achat = typeof body.unite_achat === "number" && Number.isFinite(body.unite_achat) ? Math.trunc(body.unite_achat) : 3020;
   const is_active = body.is_active;
   const nuance_ids = uniqPositiveInts(body.nuance_ids);
@@ -1143,7 +1260,7 @@ export async function repoCreateMatiereEtat(body: CreateMatiereEtatBodyDTO, audi
         entity_id: String(etatId),
         path: audit.path,
         client_session_id: audit.client_session_id,
-        details: { code, designation, unite_achat, is_active, nuance_ids },
+        details: { code, designation: designation || null, unite_achat, is_active, nuance_ids },
       },
       ip: audit.ip,
       user_agent: audit.user_agent,
@@ -1158,7 +1275,7 @@ export async function repoCreateMatiereEtat(body: CreateMatiereEtatBodyDTO, audi
     return {
       id: etatId,
       code,
-      designation,
+      designation: designation || null,
       unite_achat,
       is_active,
       nuance_ids,
@@ -2882,12 +2999,49 @@ export async function repoCreateArticleTx(
     // The submitted code is non-authoritative. Keep legacy payloads compatible
     // while the final ART-{FAMILY}-{SEQ6} value is allocated below.
     code: "",
-    designation: body.designation,
+    designation: body.designation ?? "",
     client,
   });
+  /**
+   * Matière première : la référence est DÉRIVÉE de la configuration matière,
+   * jamais séquencée. Deux matières identiques doivent porter la même
+   * référence — c'est ce qui rend le doublon détectable au lieu d'être créé en
+   * silence sous deux numéros différents.
+   *
+   * La désignation suit la même source : si l'écran n'en propose pas (une MP
+   * n'a plus de champ Désignation), le serveur produit la forme canonique.
+   * `articles.designation` n'est jamais rendue nullable pour arranger l'UI.
+   */
+  const material = normalized.article_category === "matiere"
+    ? await (async () => {
+        const input = await resolveMaterialCodeInput(client, {
+          family_code: normalized.family_code,
+          nuance_id: body.article_matiere?.nuance_id ?? null,
+          etat_id: body.article_matiere?.etat_id ?? null,
+          sous_etat_id: body.article_matiere?.sous_etat_id ?? null,
+          client_proprietaire_id: body.article_matiere?.client_proprietaire_id ?? null,
+          reference_suffix: body.article_matiere?.reference_suffix ?? null,
+          dimensions: body.article_matiere ?? null,
+        });
+        const result = buildMaterialArticleCode(input);
+        assertMaterialPreviewFresh(
+          body.material_code_preview_hash,
+          computeMaterialCodePreviewHash({ input, code: result.code, designation: result.designation })
+        );
+        return result;
+      })()
+    : null;
+
   const generatedCode = normalized.article_category === "fabrique"
     ? normalized.code
-    : await generateArticleBusinessCode(client, normalized.family_code);
+    : material
+      ? material.code
+      : await generateArticleBusinessCode(client, normalized.family_code);
+
+  const designation = (body.designation ?? "").trim() || material?.designation || "";
+  if (!designation) {
+    throw new HttpError(400, "INVALID_ARTICLE", "La désignation de l'article est obligatoire.");
+  }
 
   if (normalized.piece_technique_id) {
     await ensurePieceTechniqueExists(client, normalized.piece_technique_id);
@@ -2910,7 +3064,7 @@ export async function repoCreateArticleTx(
     [
       articleId,
       generatedCode,
-      body.designation,
+      designation,
       body.designation_secondary ?? null,
       normalized.article_type,
       normalized.article_category,
@@ -2957,7 +3111,7 @@ export async function repoCreateArticleTx(
     entity_id: id,
     details: {
       code: generatedCode,
-      designation: body.designation,
+      designation,
       article_type: normalized.article_type,
       article_category: normalized.article_category,
       article_categories: normalized.article_categories,
@@ -3050,11 +3204,56 @@ export async function repoCreateArticle(
       }
     }
     if (isPgUniqueViolation(err)) {
+      /**
+       * Matière : deux configurations identiques produisent volontairement la
+       * MÊME référence. La collision n'est donc pas un incident technique, c'est
+       * l'article qui existe déjà — on le dit, avec de quoi agir, au lieu
+       * d'inventer un suffixe qui créerait un doublon silencieux.
+       */
+      if (body.article_category === "matiere") {
+        const existing = await repoFindArticleByMaterialConfiguration(body);
+        throw new HttpError(
+          409,
+          "DUPLICATE_MATERIAL_ARTICLE",
+          existing
+            ? `Cette matière existe déjà sous la référence ${existing.code}. Réutilisez-la, ou précisez la configuration (dimensions, sous-état) pour créer une matière distincte.`
+            : "Cette référence matière existe déjà. Précisez la configuration pour créer une matière distincte."
+        );
+      }
       throw new HttpError(409, "DUPLICATE", "Article code already exists");
     }
     throw err;
   } finally {
     client.release();
+  }
+}
+
+/**
+ * Retrouve l'article matière qui occupe déjà la référence calculée, pour
+ * pouvoir le nommer dans le message d'erreur. Toute défaillance de cette
+ * lecture d'agrément reste silencieuse : elle ne doit jamais masquer le 409.
+ */
+async function repoFindArticleByMaterialConfiguration(
+  body: CreateArticleBodyDTO
+): Promise<{ id: string; code: string } | null> {
+  try {
+    const input = await resolveMaterialCodeInput(db, {
+      family_code: body.family_code,
+      nuance_id: body.article_matiere?.nuance_id ?? null,
+      etat_id: body.article_matiere?.etat_id ?? null,
+      sous_etat_id: body.article_matiere?.sous_etat_id ?? null,
+      client_proprietaire_id: body.article_matiere?.client_proprietaire_id ?? null,
+      reference_suffix: body.article_matiere?.reference_suffix ?? null,
+      dimensions: body.article_matiere ?? null,
+    });
+    const { code } = buildMaterialArticleCode(input);
+    const res = await db.query<{ id: string; code: string }>(
+      `SELECT id::text AS id, code FROM public.articles WHERE code = $1 LIMIT 1`,
+      [code]
+    );
+    return res.rows[0] ?? null;
+  } catch {
+    return null;
   }
 }
 

--- a/src/module/stock/routes/stock.routes.ts
+++ b/src/module/stock/routes/stock.routes.ts
@@ -16,6 +16,7 @@ import {
   createStockInventorySession,
   createStockArticle,
   previewStockArticleCode,
+  previewMaterialArticleCode,
   createStockArticleFamily,
   createStockMatiereEtat,
   createStockMatiereNuance,
@@ -135,6 +136,8 @@ router.post("/matiere-sous-etats", requireArticleWrite, createStockMatiereSousEt
 router.get("/articles", requireStockCapability("read"), listStockArticles);
 router.get("/articles/kpis", requireStockCapability("read"), getStockArticlesKpis);
 router.get("/articles/code-preview", requireStockCapability("read"), previewStockArticleCode);
+// #164 — Aperçu AUTORITAIRE de la référence matière : même générateur que la création.
+router.post("/articles/material-code-preview", requireStockCapability("read"), previewMaterialArticleCode);
 router.get("/articles/export.csv", requireStockCapability("read"), exportStockArticles);
 // #226 — Déclarée AVANT `/articles/:id` : sans cela, « similaires » serait lu
 // comme un identifiant d'article.

--- a/src/module/stock/services/stock.service.ts
+++ b/src/module/stock/services/stock.service.ts
@@ -30,6 +30,7 @@ import type {
   CreateArticleFamilyBodyDTO,
   CreateMatiereEtatBodyDTO,
   CreateMatiereNuanceBodyDTO,
+  PreviewMaterialArticleCodeBodyDTO,
   CreateMatiereSousEtatBodyDTO,
   CreateEmplacementBodyDTO,
   CreateLotBodyDTO,
@@ -97,6 +98,7 @@ import {
   repoGetArticle,
   repoListArticleCategories,
   repoListArticleFamilies,
+  repoPreviewMaterialArticleCode,
   repoListMatiereEtats,
   repoListMatiereNuances,
   repoListMatiereSousEtats,
@@ -257,6 +259,35 @@ export async function listStockArticleFamiliesSVC(filters: ListArticleFamiliesQu
 
 export async function listStockMatiereNuancesSVC(filters: ListMatiereNuancesQueryDTO): Promise<StockMatiereNuance[]> {
   return repoListMatiereNuances(filters);
+}
+
+/**
+ * #164 — Aperçu de la référence matière.
+ *
+ * Le même générateur sert l'aperçu et la création : ce que l'écran affiche est
+ * ce que la base recevra, ou la création est refusée.
+ */
+export async function previewMaterialArticleCodeSVC(body: PreviewMaterialArticleCodeBodyDTO) {
+  return repoPreviewMaterialArticleCode({
+    family_code: body.family_code,
+    nuance_id: body.nuance_id ?? null,
+    etat_id: body.etat_id ?? null,
+    sous_etat_id: body.sous_etat_id ?? null,
+    client_proprietaire_id: body.client_proprietaire_id ?? null,
+    reference_suffix: body.reference_suffix ?? null,
+    dimensions: {
+      barre_a_decouper: body.barre_a_decouper ?? false,
+      longueur_barre_source_mm: body.longueur_barre_source_mm ?? null,
+      longueur_coupe_mm: body.longueur_coupe_mm ?? null,
+      longueur_brut_mm: body.longueur_brut_mm ?? null,
+      longueur_mm: body.longueur_mm ?? null,
+      largeur_mm: body.largeur_mm ?? null,
+      hauteur_mm: body.hauteur_mm ?? null,
+      epaisseur_mm: body.epaisseur_mm ?? null,
+      diametre_mm: body.diametre_mm ?? null,
+      largeur_plat_mm: body.largeur_plat_mm ?? null,
+    },
+  });
 }
 
 export async function createStockMatiereNuanceSVC(body: CreateMatiereNuanceBodyDTO, audit: AuditContext): Promise<StockMatiereNuance> {

--- a/src/module/stock/types/stock.types.ts
+++ b/src/module/stock/types/stock.types.ts
@@ -44,7 +44,8 @@ export type StockMatiereNuance = {
 export type StockMatiereEtat = {
   id: number;
   code: string;
-  designation: string;
+  /** #164 — Facultative. `null` quand l'état n'est connu que par son code. */
+  designation: string | null;
   unite_achat: number;
   is_active: boolean;
   nuance_ids: number[];

--- a/src/module/stock/validators/stock.validators.ts
+++ b/src/module/stock/validators/stock.validators.ts
@@ -176,7 +176,16 @@ export const createMatiereEtatSchema = z.object({
   body: z
     .object({
       code: z.string().trim().min(1).max(40),
-      designation: z.string().trim().min(1).max(160),
+      /**
+       * #164 — La désignation d'un état est FACULTATIVE, comme celle d'une
+       * nuance. Un état d'approvisionnement est souvent connu par son seul code
+       * atelier (`BRUT`, `RECT`) ; exiger une phrase poussait à saisir un
+       * doublon du code. Le code sert de libellé de secours à l'affichage.
+       */
+      designation: z
+        .union([z.string().trim().max(160), z.null()])
+        .optional()
+        .transform((value) => (value && value.length > 0 ? value : null)),
       unite_achat: optionalPositiveInt,
       nuance_ids: z.array(positiveInt).optional().default([]),
       is_active: z.boolean().optional().default(true),
@@ -204,6 +213,38 @@ export const createMatiereSousEtatSchema = z.object({
 });
 export type CreateMatiereSousEtatBodyDTO = z.infer<typeof createMatiereSousEtatSchema>["body"];
 
+/**
+ * #164 — Aperçu SERVEUR de la référence matière.
+ *
+ * Le corps reprend exactement la configuration matière du formulaire. Le
+ * serveur relit lui-même les codes de nuance, d'état, de sous-état et du client
+ * propriétaire : aucun libellé fourni par le navigateur n'entre dans la
+ * référence.
+ */
+export const previewMaterialArticleCodeSchema = z.object({
+  body: z
+    .object({
+      family_code: z.string().trim().min(1).max(40),
+      nuance_id: nullablePositiveInt.optional(),
+      etat_id: nullablePositiveInt.optional(),
+      sous_etat_id: nullablePositiveInt.optional(),
+      client_proprietaire_id: z.string().trim().regex(/^[0-9]{3}$/).optional().nullable(),
+      reference_suffix: z.string().trim().min(1).max(60).optional().nullable(),
+      barre_a_decouper: z.boolean().optional().default(false),
+      longueur_barre_source_mm: nullablePositiveInt.optional(),
+      longueur_coupe_mm: nullablePositiveInt.optional(),
+      longueur_brut_mm: nullablePositiveInt.optional(),
+      longueur_mm: nullablePositiveInt.optional(),
+      largeur_mm: nullablePositiveInt.optional(),
+      hauteur_mm: nullablePositiveInt.optional(),
+      epaisseur_mm: nullablePositiveInt.optional(),
+      diametre_mm: nullablePositiveInt.optional(),
+      largeur_plat_mm: nullablePositiveInt.optional(),
+    })
+    .strict(),
+});
+export type PreviewMaterialArticleCodeBodyDTO = z.infer<typeof previewMaterialArticleCodeSchema>["body"];
+
 export const createArticleFamilySchema = z.object({
   body: z
     .object({
@@ -221,6 +262,12 @@ const articleMatiereSchema = z
     etat_id: nullablePositiveInt.optional(),
     sous_etat_id: nullablePositiveInt.optional(),
     client_proprietaire_id: z.string().trim().regex(/^[0-9]{3}$/).optional().nullable(),
+    /**
+     * Suffixe métier des profils qu'aucune géométrie n'identifie
+     * (`FOND`, `PROFIL`, `BRUTCL`). Il entre dans la référence calculée par le
+     * serveur ; ce n'est pas un code libre, seulement un segment normalisé.
+     */
+    reference_suffix: z.string().trim().min(1).max(60).optional().nullable(),
     barre_a_decouper: z.boolean().optional().default(false),
     longueur_barre_source_mm: nullablePositiveInt.optional(),
     longueur_coupe_mm: nullablePositiveInt.optional(),
@@ -263,8 +310,20 @@ const articleProcurementSchema = z
 export const createArticleSchema = z.object({
   body: z
     .object({
-      designation: z.string().trim().min(1).max(400),
+      /**
+       * Facultative pour une MATIÈRE uniquement : l'écran n'expose plus de champ
+       * Désignation et le serveur produit la forme canonique depuis la
+       * configuration matière. Elle reste exigée partout ailleurs (superRefine).
+       */
+      designation: z.string().trim().min(1).max(400).optional(),
       designation_secondary: z.string().trim().min(1).max(400).optional().nullable(),
+      /**
+       * Empreinte de l'aperçu de référence matière. Facultative — un client qui
+       * ne l'envoie pas garde le comportement précédent — mais si elle est
+       * fournie et périmée, la création est refusée (409) plutôt que de produire
+       * une référence différente de celle affichée.
+       */
+      material_code_preview_hash: z.string().regex(/^[0-9a-f]{64}$/, "Aperçu matière invalide.").optional(),
       article_type: articleTypeSchema.optional(),
       article_category: articleCategorySchema,
       article_categories: z.array(articleBusinessCategorySchema).min(1).max(8).optional(),
@@ -283,6 +342,20 @@ export const createArticleSchema = z.object({
     })
     .strict()
     .superRefine((body, ctx) => {
+      if (body.article_category !== "matiere" && !body.designation) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "La désignation de l'article est obligatoire.",
+          path: ["designation"],
+        });
+      }
+      if (body.material_code_preview_hash && body.article_category !== "matiere") {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "material_code_preview_hash n'existe que pour une matière première.",
+          path: ["material_code_preview_hash"],
+        });
+      }
       if (body.article_category === "fabrique") {
         if (!body.piece_technique_id) {
           ctx.addIssue({ code: z.ZodIssueCode.custom, message: "piece_technique_id is required for fabricated articles", path: ["piece_technique_id"] });

--- a/src/shared/codes/material-article-code.ts
+++ b/src/shared/codes/material-article-code.ts
@@ -1,0 +1,354 @@
+import crypto from "crypto";
+
+import { HttpError } from "../../utils/httpError";
+
+/**
+ * Codification MATIÈRE PREMIÈRE — générateur autoritaire unique.
+ *
+ * Pourquoi ce fichier existe
+ * --------------------------
+ * Jusqu'ici trois règles concurrentes cohabitaient pour une même matière :
+ *   1. le dialogue frontend calculait `PL-S235-BRUT-100x10x3000` et l'affichait ;
+ *   2. `apiCreateStockArticle` supprimait ce code du payload ;
+ *   3. le serveur allouait finalement `ART-<FAMILLE>-<SEQ6>`.
+ * L'aperçu montré à l'utilisateur n'avait donc AUCUN rapport avec le code créé.
+ *
+ * Ce module est désormais la seule règle. Il est appelé par l'aperçu ET par la
+ * création : les deux ne peuvent plus diverger puisqu'ils exécutent la même
+ * fonction pure sur les mêmes données résolues en base.
+ *
+ * Invariants
+ * ----------
+ * · aucun code proposé par le navigateur n'est retenu ;
+ * · aucune valeur n'est inventée : un segment absent est ABSENT, jamais `XXX` ;
+ * · les séparateurs métier `-` et `x` sont conservés (lisibilité atelier) ;
+ * · le résultat est déterministe, donc rejouable et testable hors base.
+ */
+
+/** Segment de tête, aligné sur `code_segment` du référentiel des catégories. */
+export const MATERIAL_CODE_PREFIX = "MP";
+
+export type MaterialProfileCode = "PL" | "RO" | "U" | "FOND" | "TUBE" | "PROFIL" | "BRUTCL";
+
+export const MATERIAL_PROFILE_CODES: readonly MaterialProfileCode[] = [
+  "PL",
+  "RO",
+  "U",
+  "FOND",
+  "TUBE",
+  "PROFIL",
+  "BRUTCL",
+] as const;
+
+/** Libellés métier utilisés pour la désignation canonique. */
+const MATERIAL_PROFILE_LABELS: Record<MaterialProfileCode, string> = {
+  PL: "PLAT/TOLE",
+  RO: "ROND",
+  U: "U",
+  FOND: "ACHAT FONDERIE",
+  TUBE: "TUBE",
+  PROFIL: "PROFILS DIVERS",
+  BRUTCL: "BRUT CLIENT",
+};
+
+/**
+ * Alias historiques rencontrés en base et dans les anciens écrans. Ils sont
+ * ramenés au code canonique AVANT toute génération : deux orthographes ne
+ * doivent jamais produire deux codes différents pour la même matière.
+ */
+const MATERIAL_PROFILE_ALIASES: Record<string, MaterialProfileCode> = {
+  PL: "PL",
+  PLAT: "PL",
+  PLATTOLE: "PL",
+  TOLE: "PL",
+  RO: "RO",
+  ROND: "RO",
+  U: "U",
+  FOND: "FOND",
+  FONDERI: "FOND",
+  FONDERIE: "FOND",
+  ACHATFONDERIE: "FOND",
+  TUBE: "TUBE",
+  TU: "TUBE",
+  PROFIL: "PROFIL",
+  PROFI: "PROFIL",
+  PR: "PROFIL",
+  PROFILSDIVERS: "PROFIL",
+  BRUTCL: "BRUTCL",
+  BRUTCLIENT: "BRUTCL",
+};
+
+/** Profils dont la référence repose sur un suffixe métier, pas sur une géométrie. */
+const SPECIAL_PROFILES: ReadonlySet<MaterialProfileCode> = new Set<MaterialProfileCode>([
+  "FOND",
+  "PROFIL",
+  "BRUTCL",
+]);
+
+export function isSpecialMaterialProfile(profile: MaterialProfileCode): boolean {
+  return SPECIAL_PROFILES.has(profile);
+}
+
+function stripDiacritics(value: string): string {
+  return value.normalize("NFD").replace(/\p{Diacritic}/gu, "");
+}
+
+/** Segment d'identité : majuscules ASCII, séparateurs internes ramenés à `-`. */
+function normalizeSegment(value: string | null | undefined): string {
+  if (typeof value !== "string") return "";
+  return stripDiacritics(value)
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+}
+
+/** Clé de comparaison d'un profil : lettres et chiffres uniquement. */
+function profileLookupKey(value: string): string {
+  return stripDiacritics(value).toUpperCase().replace(/[^A-Z0-9]+/g, "");
+}
+
+/**
+ * Ramène un code famille/profil au code canonique. Une valeur inconnue est
+ * refusée : générer une référence matière à partir d'un profil non reconnu
+ * produirait un code que personne ne sait relire.
+ */
+export function normalizeMaterialProfile(value: string | null | undefined): MaterialProfileCode {
+  const key = profileLookupKey(typeof value === "string" ? value : "");
+  const canonical = MATERIAL_PROFILE_ALIASES[key];
+  if (!canonical) {
+    throw new HttpError(
+      400,
+      "INVALID_MATERIAL_PROFILE",
+      `Profil matière inconnu : ${value ?? "(vide)"}. Profils acceptés : ${MATERIAL_PROFILE_CODES.join(", ")}.`
+    );
+  }
+  return canonical;
+}
+
+export function isMaterialProfileCode(value: string | null | undefined): boolean {
+  const key = profileLookupKey(typeof value === "string" ? value : "");
+  return Boolean(MATERIAL_PROFILE_ALIASES[key]);
+}
+
+export type MaterialDimensions = {
+  barre_a_decouper?: boolean | null;
+  longueur_barre_source_mm?: number | null;
+  longueur_coupe_mm?: number | null;
+  longueur_brut_mm?: number | null;
+  longueur_mm?: number | null;
+  largeur_mm?: number | null;
+  hauteur_mm?: number | null;
+  epaisseur_mm?: number | null;
+  diametre_mm?: number | null;
+  largeur_plat_mm?: number | null;
+};
+
+export type MaterialCodeInput = {
+  profile: MaterialProfileCode;
+  /** Code du référentiel `stock_nuances`, résolu en base. */
+  nuance_code?: string | null;
+  /** Code du référentiel `stock_etats`, résolu en base. */
+  etat_code?: string | null;
+  /** Code du référentiel `stock_sous_etats`, résolu en base. */
+  sous_etat_code?: string | null;
+  /** Code client propriétaire (`clients.client_code`) pour un brut client. */
+  client_code?: string | null;
+  /** Suffixe métier saisi pour FOND / PROFIL / BRUTCL. */
+  reference_suffix?: string | null;
+  dimensions?: MaterialDimensions | null;
+};
+
+export type MaterialCodeResult = {
+  code: string;
+  designation: string;
+  /** Segments retenus, dans l'ordre, pour expliquer la référence à l'écran. */
+  segments: string[];
+  /** Segment dimensionnel isolé (`100x10x3000`) ou `null` si aucune cote fournie. */
+  dimensions_segment: string | null;
+};
+
+function toPositiveInt(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const n = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(n)) return null;
+  const i = Math.trunc(n);
+  return i > 0 ? i : null;
+}
+
+/**
+ * Longueur retenue dans la référence.
+ *
+ * Une barre à découper n'a pas de longueur d'article : sa longueur source est
+ * une donnée d'approvisionnement qui varie d'une réception à l'autre. L'inclure
+ * créerait un article différent par barre reçue.
+ */
+function codeLength(dims: MaterialDimensions): number | null {
+  if (dims.barre_a_decouper) return null;
+  return toPositiveInt(dims.longueur_brut_mm ?? dims.longueur_coupe_mm ?? dims.longueur_mm);
+}
+
+/**
+ * Cotes retenues par profil, dans l'ordre de lecture atelier.
+ * Une cote absente est simplement omise ; rien n'est comblé.
+ */
+export function buildMaterialDimensionsSegment(
+  profile: MaterialProfileCode,
+  dimensions: MaterialDimensions | null | undefined
+): string | null {
+  if (isSpecialMaterialProfile(profile)) return null;
+  const dims = dimensions ?? {};
+
+  const longueur = codeLength(dims);
+  const largeur = toPositiveInt(dims.largeur_mm);
+  const hauteur = toPositiveInt(dims.hauteur_mm);
+  const epaisseur = toPositiveInt(dims.epaisseur_mm);
+  const diametre = toPositiveInt(dims.diametre_mm);
+
+  const ordered: Array<number | null> = (() => {
+    switch (profile) {
+      case "PL":
+        return [largeur, epaisseur, longueur];
+      case "RO":
+        return [diametre, longueur];
+      case "TUBE":
+        return [diametre, epaisseur, longueur];
+      case "U":
+        return [largeur, hauteur, epaisseur, longueur];
+      default:
+        return [longueur];
+    }
+  })();
+
+  const parts = ordered.filter((value): value is number => typeof value === "number");
+  return parts.length ? parts.join("x") : null;
+}
+
+/**
+ * Construit la référence matière et sa désignation canonique.
+ *
+ * Contrat des profils particuliers :
+ * · `FOND` et `PROFIL` — la géométrie n'identifie rien, un suffixe métier est exigé ;
+ * · `BRUTCL` — la propriété client fait partie de l'identité : code client ET suffixe.
+ */
+export function buildMaterialArticleCode(input: MaterialCodeInput): MaterialCodeResult {
+  const profile = input.profile;
+
+  if (isSpecialMaterialProfile(profile)) {
+    const suffix = normalizeSegment(input.reference_suffix);
+    if (!suffix) {
+      throw new HttpError(
+        400,
+        "MATERIAL_REFERENCE_SUFFIX_REQUIRED",
+        `Le profil ${MATERIAL_PROFILE_LABELS[profile]} exige une référence métier : aucune dimension ne l'identifie.`
+      );
+    }
+
+    const clientSegment = profile === "BRUTCL" ? normalizeSegment(input.client_code) : "";
+    if (profile === "BRUTCL" && !clientSegment) {
+      throw new HttpError(
+        400,
+        "MATERIAL_CLIENT_CODE_REQUIRED",
+        "Un brut client exige le code du client propriétaire pour construire sa référence."
+      );
+    }
+
+    const segments = [MATERIAL_CODE_PREFIX, profile, ...(clientSegment ? [clientSegment] : []), suffix];
+    const designation = [MATERIAL_PROFILE_LABELS[profile], clientSegment || null, suffix]
+      .filter((value): value is string => Boolean(value))
+      .join(" ");
+
+    return { code: segments.join("-"), designation, segments, dimensions_segment: null };
+  }
+
+  const nuance = normalizeSegment(input.nuance_code);
+  if (!nuance) {
+    throw new HttpError(
+      400,
+      "MATERIAL_NUANCE_REQUIRED",
+      "La nuance est obligatoire pour construire la référence matière."
+    );
+  }
+  const etat = normalizeSegment(input.etat_code);
+  if (!etat) {
+    throw new HttpError(
+      400,
+      "MATERIAL_ETAT_REQUIRED",
+      "L'état est obligatoire pour construire la référence matière."
+    );
+  }
+  const sousEtat = normalizeSegment(input.sous_etat_code);
+  const dimensionsSegment = buildMaterialDimensionsSegment(profile, input.dimensions);
+
+  const segments = [
+    MATERIAL_CODE_PREFIX,
+    profile,
+    nuance,
+    etat,
+    ...(sousEtat ? [sousEtat] : []),
+    ...(dimensionsSegment ? [dimensionsSegment] : []),
+  ];
+
+  const designation = [
+    MATERIAL_PROFILE_LABELS[profile],
+    nuance,
+    etat,
+    sousEtat || null,
+    dimensionsSegment ? `${dimensionsSegment} mm` : null,
+  ]
+    .filter((value): value is string => Boolean(value))
+    .join(" ");
+
+  return { code: segments.join("-"), designation, segments, dimensions_segment: dimensionsSegment };
+}
+
+/**
+ * Empreinte de l'aperçu matière, sur le MÊME motif que la bibliothèque de
+ * finitions : elle couvre l'entrée résolue et le code proposé. Le navigateur la
+ * renvoie à la création ; si le référentiel a bougé entre-temps, la confirmation
+ * est refusée au lieu de créer une référence différente de celle affichée.
+ */
+export function computeMaterialCodePreviewHash(params: {
+  input: MaterialCodeInput;
+  code: string;
+  designation: string;
+}): string {
+  const dims = params.input.dimensions ?? {};
+  const canonical = {
+    kind: "material_article_code_preview",
+    version: 1,
+    profile: params.input.profile,
+    nuance_code: normalizeSegment(params.input.nuance_code) || null,
+    etat_code: normalizeSegment(params.input.etat_code) || null,
+    sous_etat_code: normalizeSegment(params.input.sous_etat_code) || null,
+    client_code: normalizeSegment(params.input.client_code) || null,
+    reference_suffix: normalizeSegment(params.input.reference_suffix) || null,
+    dimensions: {
+      barre_a_decouper: Boolean(dims.barre_a_decouper),
+      longueur_barre_source_mm: toPositiveInt(dims.longueur_barre_source_mm),
+      longueur_coupe_mm: toPositiveInt(dims.longueur_coupe_mm),
+      longueur_brut_mm: toPositiveInt(dims.longueur_brut_mm),
+      longueur_mm: toPositiveInt(dims.longueur_mm),
+      largeur_mm: toPositiveInt(dims.largeur_mm),
+      hauteur_mm: toPositiveInt(dims.hauteur_mm),
+      epaisseur_mm: toPositiveInt(dims.epaisseur_mm),
+      diametre_mm: toPositiveInt(dims.diametre_mm),
+      largeur_plat_mm: toPositiveInt(dims.largeur_plat_mm),
+    },
+    code: params.code,
+    designation: params.designation,
+  };
+  return crypto.createHash("sha256").update(JSON.stringify(canonical)).digest("hex");
+}
+
+export function assertMaterialPreviewFresh(expected: string | null | undefined, current: string): void {
+  const value = (expected ?? "").trim();
+  if (!value) return; // L'aperçu reste facultatif : un client historique n'est pas cassé.
+  if (value !== current) {
+    throw new HttpError(
+      409,
+      "MATERIAL_CODE_PREVIEW_STALE",
+      "La référence matière affichée n'est plus à jour : rechargez l'aperçu avant de créer l'article."
+    );
+  }
+}


### PR DESCRIPTION
## Ce qui change

- ajoute le générateur autoritaire de référence Matière première utilisé par l’aperçu et la création ;
- rend la désignation d’état facultative et produit une désignation matière canonique ;
- refuse explicitement les collisions de configuration matière ;
- ajoute `POST /gammes/:gammeId/revisions` avec duplication transactionnelle de l’entête, des opérations et des finitions ;
- exige une `Idempotency-Key` de 8 à 200 caractères, refuse la révision d’une gamme encore modifiable et conserve le verrou optimiste ;
- prépare le patch additif `20260731_gamme_revision_lineage.sql` avec preflight, verify et rollback.

## Validation locale

- build TypeScript : vert
- Vitest : 3 433 tests / 153 fichiers, tous verts
- tests dédiés #433 : transaction, absence de schéma, source modifiable, rejeu idempotent et contrat HTTP

## Déploiement

Le backend doit être livré avant le frontend `crp-systems-web#435`. Le patch reste à appliquer et vérifier sur `cerp_test`, puis sur `cerp_prod` uniquement dans la fenêtre explicitement autorisée.

Références : BigFootLime/crp-systems-web#431, #433 et #434.

## Summary by Sourcery

Introduce server-authoritative material code generation and canonical designations, and add an idempotent revision workflow for frozen gammes backed by an additive schema patch.

New Features:
- Provide a server-side generator for material article codes and designations, shared between preview and creation endpoints.
- Expose a POST /articles/material-code-preview API that returns an authoritative material reference preview based on the configured material profile and dimensions.
- Add a POST /gammes/:gammeId/revisions API to duplicate a frozen gamme and its operations into a new draft revision using an idempotency key.

Bug Fixes:
- Prevent silent creation of duplicate material articles by treating configuration collisions as a domain error and surfacing the existing article reference.
- Ensure article creation for materials fails if the designation cannot be derived or provided, avoiding empty or inconsistent labels.

Enhancements:
- Make the matière état designation optional in the API while storing empty strings in the legacy NOT NULL column and exposing null when absent.
- Derive material article references from referential codes and configuration instead of generic sequential codes, keeping frontend-provided codes non-authoritative.
- Enforce optimistic locking and idempotent behaviour when preparing gamme revisions, including replay support for repeated keys without duplicating drafts.

Deployment:
- Introduce an additive database patch to track gamme revision lineage and idempotency keys, with supporting preflight, verify, and rollback scripts for controlled rollout.

Documentation:
- Add SQL preflight, verify, and rollback scripts documenting and controlling deployment of the gamme revision lineage patch.

Tests:
- Add unit and route tests capturing the server-side material code generation rules, preview fingerprint behaviour, and HTTP contract for material articles.
- Add repository and controller tests for gamme revision creation, covering schema precondition checks, frozen-source constraints, transactional duplication, and idempotent replay behaviour.