### PR TITLE
fix(db): livrer la compatibilité magasins #446

### DIFF
--- a/db/patches/20260731_stock_old_new_446.sql
+++ b/db/patches/20260731_stock_old_new_446.sql
@@ -122,8 +122,10 @@ BEGIN
   END IF;
 END $$;
 
--- Four fixed functional stores. Physical locations/rays are created through the
--- normal magasin/emplacement APIs or the historical import endpoint.
+-- Four fixed functional stores. HYPERBOX2 keeps both the current (`code`,
+-- `name`, `is_active`) and legacy (`code_magasin`, `libelle`, `actif`) magasin
+-- fields as NOT NULL. Seed both representations so the historical schema and
+-- current stock APIs see the same functional stores.
 INSERT INTO public.warehouses (code, name, stock_scope)
 VALUES
   ('OLD-PF', 'Base old - Produits finis', 'OLD'),
@@ -132,8 +134,12 @@ VALUES
   ('NEW-MP', 'Base new - Matieres premieres', 'NEW')
 ON CONFLICT (code) DO UPDATE SET stock_scope = EXCLUDED.stock_scope;
 
-INSERT INTO public.magasins (id, code, name, stock_scope, warehouse_id, is_active)
-SELECT gen_random_uuid(), seed.code, seed.name, seed.stock_scope, w.id, true
+INSERT INTO public.magasins (
+  id, code, code_magasin, name, libelle, stock_scope, warehouse_id, is_active, actif
+)
+SELECT
+  gen_random_uuid(), seed.code, seed.code, seed.name, seed.name,
+  seed.stock_scope, w.id, true, true
 FROM (VALUES
   ('OLD-PF', 'Base old - Produits finis', 'OLD'),
   ('OLD-MP', 'Base old - Matieres premieres', 'OLD'),
@@ -142,9 +148,13 @@ FROM (VALUES
 ) AS seed(code, name, stock_scope)
 JOIN public.warehouses w ON w.code = seed.code
 ON CONFLICT (code) DO UPDATE
-SET stock_scope = EXCLUDED.stock_scope,
+SET code_magasin = EXCLUDED.code_magasin,
+    name = EXCLUDED.name,
+    libelle = EXCLUDED.libelle,
+    stock_scope = EXCLUDED.stock_scope,
     warehouse_id = EXCLUDED.warehouse_id,
     is_active = true,
+    actif = true,
     updated_at = now();
 
 COMMIT;

--- a/db/patches/support/20260731_stock_old_new_446.preflight.sql
+++ b/db/patches/support/20260731_stock_old_new_446.preflight.sql
@@ -24,6 +24,7 @@ DO $$
 DECLARE
   v_magasin_id_type text;
   v_emplacement_magasin_id_type text;
+  v_required_magasin_columns integer;
 BEGIN
   IF to_regclass('public.warehouses') IS NULL
      OR to_regclass('public.magasins') IS NULL
@@ -57,6 +58,20 @@ BEGIN
       v_emplacement_magasin_id_type;
   END IF;
 
+  SELECT count(*) INTO v_required_magasin_columns
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'magasins'
+    AND (
+      (column_name IN ('code_magasin', 'libelle')
+       AND data_type = 'character varying' AND is_nullable = 'NO')
+      OR (column_name = 'actif' AND data_type = 'boolean')
+    );
+  IF v_required_magasin_columns <> 3 THEN
+    RAISE EXCEPTION
+      '#446 preflight requires NOT NULL magasins.code_magasin/libelle varchar and magasins.actif boolean';
+  END IF;
+
   IF (SELECT count(*) FROM public.article_category_ref WHERE code = 'achat_transforme') <> 1 THEN
     RAISE EXCEPTION '#446 preflight requires exactly one achat_transforme category';
   END IF;
@@ -66,7 +81,7 @@ SELECT table_name, column_name, data_type
 FROM information_schema.columns
 WHERE table_schema = 'public'
   AND (
-    (table_name = 'magasins' AND column_name = 'id')
+    (table_name = 'magasins' AND column_name IN ('id', 'code', 'code_magasin', 'name', 'libelle', 'is_active', 'actif'))
     OR (table_name = 'emplacements' AND column_name = 'magasin_id')
     OR (table_name = 'lots' AND column_name = 'id')
     OR (table_name = 'article_category_ref' AND column_name IN ('code', 'label'))
@@ -89,7 +104,11 @@ ORDER BY code;
 
 SELECT
   code,
-  name
+  code_magasin,
+  name,
+  libelle,
+  is_active,
+  actif
 FROM public.magasins
 WHERE code IN ('OLD-PF', 'OLD-MP', 'NEW-PF', 'NEW-MP')
 ORDER BY code;

--- a/db/patches/support/20260731_stock_old_new_446.rollback.sql
+++ b/db/patches/support/20260731_stock_old_new_446.rollback.sql
@@ -44,7 +44,8 @@ BEGIN
 END $$;
 
 DELETE FROM public.magasins
-WHERE code IN ('OLD-PF', 'OLD-MP', 'NEW-PF', 'NEW-MP');
+WHERE code IN ('OLD-PF', 'OLD-MP', 'NEW-PF', 'NEW-MP')
+   OR code_magasin IN ('OLD-PF', 'OLD-MP', 'NEW-PF', 'NEW-MP');
 
 DELETE FROM public.warehouses
 WHERE code IN ('OLD-PF', 'OLD-MP', 'NEW-PF', 'NEW-MP');

--- a/db/patches/support/20260731_stock_old_new_446.verify.sql
+++ b/db/patches/support/20260731_stock_old_new_446.verify.sql
@@ -8,6 +8,7 @@ SELECT current_database() AS database_name, current_user AS database_user, now()
 DO $$
 DECLARE
   v_fixed_store_count integer;
+  v_required_magasin_columns integer;
 BEGIN
   IF to_regclass('public.stock_lot_trace_references') IS NULL
      OR to_regclass('public.stock_trace_code_446_seq') IS NULL THEN
@@ -41,6 +42,19 @@ BEGIN
     RAISE EXCEPTION '#446 verify failed: achat_transforme must be labelled Fourniture Client';
   END IF;
 
+  SELECT count(*) INTO v_required_magasin_columns
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'magasins'
+    AND (
+      (column_name IN ('code_magasin', 'libelle')
+       AND data_type = 'character varying' AND is_nullable = 'NO')
+      OR (column_name = 'actif' AND data_type = 'boolean')
+    );
+  IF v_required_magasin_columns <> 3 THEN
+    RAISE EXCEPTION '#446 verify failed: required legacy magasin columns are missing or incompatible';
+  END IF;
+
   IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'warehouses_stock_scope_446_ck')
      OR NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'magasins_stock_scope_446_ck')
      OR NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'lots_origin_stock_scope_446_ck')
@@ -52,15 +66,22 @@ BEGIN
   SELECT count(*) INTO v_fixed_store_count
   FROM (
     VALUES
-      ('OLD-PF', 'OLD'), ('OLD-MP', 'OLD'), ('NEW-PF', 'NEW'), ('NEW-MP', 'NEW')
-  ) AS expected(code, stock_scope)
+      ('OLD-PF', 'Base old - Produits finis', 'OLD'),
+      ('OLD-MP', 'Base old - Matieres premieres', 'OLD'),
+      ('NEW-PF', 'Base new - Produits finis', 'NEW'),
+      ('NEW-MP', 'Base new - Matieres premieres', 'NEW')
+  ) AS expected(code, name, stock_scope)
   JOIN public.warehouses warehouse
     ON warehouse.code = expected.code AND warehouse.stock_scope = expected.stock_scope
   JOIN public.magasins magasin
-    ON magasin.code = expected.code
+   ON magasin.code = expected.code
+   AND magasin.code_magasin = expected.code
+   AND magasin.name = expected.name
+   AND magasin.libelle = expected.name
    AND magasin.stock_scope = expected.stock_scope
    AND magasin.warehouse_id = warehouse.id
-   AND magasin.is_active;
+   AND magasin.is_active
+   AND magasin.actif;
 
   IF v_fixed_store_count <> 4 THEN
     RAISE EXCEPTION '#446 verify failed: expected four aligned OLD/NEW warehouses and magasins, found %', v_fixed_store_count;
@@ -111,18 +132,28 @@ ORDER BY indexname;
 
 SELECT
   expected.code,
+  expected.name,
   expected.stock_scope,
   warehouse.id AS warehouse_id,
   magasin.id AS magasin_id,
-  magasin.is_active
+  magasin.code_magasin,
+  magasin.libelle,
+  magasin.is_active,
+  magasin.actif
 FROM (
   VALUES
-    ('OLD-PF', 'OLD'), ('OLD-MP', 'OLD'), ('NEW-PF', 'NEW'), ('NEW-MP', 'NEW')
-) AS expected(code, stock_scope)
+    ('OLD-PF', 'Base old - Produits finis', 'OLD'),
+    ('OLD-MP', 'Base old - Matieres premieres', 'OLD'),
+    ('NEW-PF', 'Base new - Produits finis', 'NEW'),
+    ('NEW-MP', 'Base new - Matieres premieres', 'NEW')
+) AS expected(code, name, stock_scope)
 JOIN public.warehouses warehouse
   ON warehouse.code = expected.code
 JOIN public.magasins magasin
   ON magasin.code = expected.code
+ AND magasin.code_magasin = expected.code
+ AND magasin.name = expected.name
+ AND magasin.libelle = expected.name
 ORDER BY expected.code;
 
 SELECT

--- a/src/__tests__/stock-old-new-446.migration-guards.test.ts
+++ b/src/__tests__/stock-old-new-446.migration-guards.test.ts
@@ -44,6 +44,9 @@ describe("#446 stock OLD/NEW migration guards", () => {
     }
     expect(migration.match(/\('(?:OLD|NEW)-(?:PF|MP)'/g)).toHaveLength(8);
     expect(migration).toMatch(/CHECK \(stock_scope IN \('OLD', 'NEW'\)\)/i);
+    expect(migration).toMatch(/code_magasin, name, libelle, stock_scope, warehouse_id, is_active, actif/i);
+    expect(migration).toMatch(/seed\.code, seed\.code, seed\.name, seed\.name/i);
+    expect(migration).toMatch(/actif = true/i);
   });
 
   it("verrouille la trace a six chiffres et son QR associe", () => {
@@ -71,6 +74,7 @@ describe("#446 stock OLD/NEW migration guards", () => {
     expect(preflight).toMatch(/BEGIN TRANSACTION READ ONLY;/i);
     expect(preflight).toMatch(/COMMIT;/i);
     expect(preflight).toMatch(/UUID magasins\.id\/emplacements\.magasin_id/i);
+    expect(preflight).toMatch(/magasins\.code_magasin\/libelle varchar and magasins\.actif boolean/i);
     expect(preflight).toMatch(/article_category_ref/i);
     expect(preflight).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/im);
   });
@@ -80,6 +84,8 @@ describe("#446 stock OLD/NEW migration guards", () => {
     expect(verify).toMatch(/stock_lot_trace_references/i);
     expect(verify).toMatch(/stock_trace_code_446_seq/i);
     expect(verify).toMatch(/v_fixed_store_count <> 4/i);
+    expect(verify).toMatch(/magasin\.code_magasin = expected\.code/i);
+    expect(verify).toMatch(/magasin\.actif/i);
     expect(verify).toMatch(/has_table_privilege\('cerp_app'/i);
     expect(verify).toMatch(/has_sequence_privilege\('cerp_app'/i);
     expect(verify).not.toMatch(/^\s*(INSERT|UPDATE|DELETE|ALTER|CREATE|DROP|TRUNCATE)\b/im);
@@ -91,6 +97,7 @@ describe("#446 stock OLD/NEW migration guards", () => {
     expect(rollback).toMatch(/stock_trace_code IS NOT NULL/i);
     expect(rollback).toMatch(/stock_movement_lines/i);
     expect(rollback).toMatch(/rollback refused/i);
+    expect(rollback).toMatch(/OR code_magasin IN/i);
     expect(rollback).toMatch(/DROP TABLE IF EXISTS public\.stock_lot_trace_references/i);
   });
 });


### PR DESCRIPTION
## Correctif de livraison #446

Intègre dans `main` la compatibilité de la migration OLD/NEW avec le schéma historique réel de HYPERBOX2 (`code_magasin`, `libelle`, `actif`).

## Validation

- suite backend complète : 3452 tests verts ;
- `cerp_test` : migration + vérification vertes ;
- seconde exécution sur `cerp_test` verte (idempotence) ;
- aucun changement #446 n'a encore été appliqué à `cerp_prod`.

## Summary by Sourcery

Align the #446 stock OLD/NEW migration with the legacy HYPERBOX2 magasin schema and ensure safe, reversible deployment.

Bug Fixes:
- Ensure OLD/NEW functional stores are visible and consistent across both current and legacy magasin representations.

Enhancements:
- Add preflight and verify guards that validate required legacy magasin columns and alignment between warehouses and magasins.
- Seed magasins with both current and historical identification fields so legacy and current stock flows share the same functional stores.
- Extend rollback logic to remove functional stores by both current and legacy magasin codes.

Tests:
- Strengthen migration guard tests to cover legacy magasin fields, preflight column constraints, verify alignment checks, and rollback protections.