### PR TITLE
fix(stock): exposer la route positions OLD/NEW (#446)

### DIFF
--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -71,6 +71,20 @@ beforeEach(() => {
 });
 
 describe("/api/v1/stock", () => {
+  it("GET /api/v1/stock/positions exposes the consolidated OLD/NEW read model", async () => {
+    mocks.poolQuery
+      .mockResolvedValueOnce({ rows: [{ total: 0 }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await request(app)
+      .get("/api/v1/stock/positions?scope=OLD&page=1&pageSize=50&sortBy=article_code&sortDir=asc")
+      .set("Authorization", "Bearer fake");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ items: [], total: 0 });
+    expect(mocks.poolQuery).toHaveBeenCalledTimes(2);
+  });
+
   it("GET /api/v1/stock/analytics returns analytics payload", async () => {
     mocks.poolQuery
       .mockResolvedValueOnce({ rows: [{ articles_count: 12, stock_managed_articles: 9, qty_on_hand: 120, qty_available: 100, qty_reserved: 20 }] })

--- a/src/module/stock/routes/stock.routes.ts
+++ b/src/module/stock/routes/stock.routes.ts
@@ -126,6 +126,7 @@ const requireStockCapability = (capability: StockCapability): RequestHandler => 
 };
 
 router.get("/analytics", requireStockCapability("read"), getStockAnalytics);
+router.get("/positions", requireStockCapability("read"), listConsolidatedInventory);
 router.get("/inventory", requireStockCapability("read"), listConsolidatedInventory);
 router.post("/historical-imports", requireStockCapability("movement_create"), createHistoricalImport);
 router.get("/article-categories", requireStockCapability("read"), listStockArticleCategories);


### PR DESCRIPTION
## Correctif runtime #446

Expose le même read model consolidé OLD/NEW sur un chemin neuf `/api/v1/stock/positions`, tout en conservant `/inventory` pour compatibilité.

Le nouveau chemin évite définitivement la réponse 404 retenue sur l'ancien endpoint pendant le déploiement désynchronisé.

## Validation

- test route réel Supertest : 200 sur `/stock/positions` ;
- fichier stock routes : 9/9 tests verts ;
- build TypeScript : vert ;
- `git diff --check` : vert.

## Summary by Sourcery

Expose the consolidated stock positions read model on a new /api/v1/stock/positions endpoint while keeping the legacy inventory endpoint for compatibility.

New Features:
- Add /api/v1/stock/positions route that serves the consolidated OLD/NEW inventory read model.

Tests:
- Add Supertest coverage ensuring /api/v1/stock/positions returns the expected consolidated payload and status.