### PR TITLE
Fiabiliser le fulfillment commande jusqu'à la facture

### DIFF
--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -73,6 +73,21 @@ and `/var/backups/cerp/cerp_prod_20260731-234848.dump` (50,866,662 bytes).
 Preflight, apply and read-only verification passed on both databases;
 `cerp_test` was then reapplied successfully to confirm idempotence.
 
+### Comportement applicatif après patch
+
+Cette section ne décrit pas une nouvelle migration. Après le contrôle `OLD` puis
+`NEW`, une commande entièrement couverte réserve le stock et prépare le BL sans
+OF ni Planning. En cas de manque, le stock disponible est réservé et seuls les
+manquants génèrent des OF ; la quantité proposée peut être majorée pour une
+reconstitution volontaire de stock. Lors de la préparation du BL, une réservation
+active provenant du lancement est transférée à la ligne de BL au lieu d'être
+dupliquée. L'expédition crée la sortie de stock et synchronise la commande vers
+`LIVRE`; l'état `FACTURE` ne peut suivre que l'émission Finance explicite.
+
+Les paramètres légaux et la politique d'émission Finance restent à valider par
+Finance/Juridique. Les recettes frontend et le déploiement applicatif restent à
+compléter séparément.
+
 ## Issue #164 - Règles Articles / matière / Stock restantes
 
 `20260729_articles_164_remaining_rules.sql` ajoute les sept profils matière

--- a/docs/http/facturation-227.md
+++ b/docs/http/facturation-227.md
@@ -69,3 +69,20 @@ Le patch `db/patches/20260725_facturation_payments_227.sql` ne crée aucune
 politique ni séquence active. Finance et Juridique doivent valider puis
 configurer ces lignes sur `cerp_test` avant toute recette d'émission. Aucune
 migration n'a été exécutée pendant l'implémentation.
+
+### Configuration administrée
+
+- `GET /factures/configuration?year=YYYY` expose uniquement l'état de
+  préparation : émetteurs, complétude des mentions légales, politique active,
+  séquences et bloqueurs. Les coordonnées bancaires ne sont jamais retournées.
+- `POST /factures/configuration/activate` crée atomiquement une politique et sa
+  séquence `FACTURE` obligatoire, avec une séquence `AVOIR` optionnelle.
+- `POST /factures/configuration/sequences` ajoute une séquence annuelle
+  manquante à l'émetteur de la politique active.
+
+Ces mutations exigent `settings_manage` et `confirm: true`, verrouillent la
+configuration, écrivent l'audit global et restent create-only : aucun numéro,
+préfixe, compteur ou historique existant n'est réinitialisé. Les chevauchements
+de politique, les scopes de séquence déjà présents et les mentions légales
+incomplètes sont refusés. L'écran d'administration rend ce paramétrage
+possible ; il ne vaut ni validation Finance/Juridique ni activation implicite.

--- a/docs/http/facturation-configuration.http
+++ b/docs/http/facturation-configuration.http
@@ -1,0 +1,35 @@
+### Finance configuration readiness (Director / Administrator)
+GET {{baseUrl}}/api/v1/factures/configuration?year=2026
+Authorization: Bearer {{token}}
+
+### Activate a new Finance policy and legal sequences
+# This command only creates records. Existing policies and sequence scopes are never overwritten.
+POST {{baseUrl}}/api/v1/factures/configuration/activate
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "confirm": true,
+  "legal_entity_code": "00000000-0000-0000-0000-000000000000",
+  "policy_version": "finance-2026-v1",
+  "effective_from": "2026-01-01",
+  "effective_to": null,
+  "eligible_delivery_statuses": ["SHIPPED", "DELIVERED"],
+  "require_distinct_issuer": true,
+  "sequences": {
+    "facture": { "year": 2026, "prefix": "FAC-2026-", "next_value": 1, "padding": 6 },
+    "avoir": { "year": 2026, "prefix": "AVO-2026-", "next_value": 1, "padding": 6 }
+  }
+}
+
+### Add a new year or optional AVOIR sequence to the current policy issuer
+POST {{baseUrl}}/api/v1/factures/configuration/sequences
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+{
+  "confirm": true,
+  "sequences": {
+    "avoir": { "year": 2027, "prefix": "AVO-2027-", "next_value": 1, "padding": 6 }
+  }
+}

--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -596,6 +596,7 @@ describe("/api/v1/commandes", () => {
 
     mocks.clientQuery
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ exists: true }] }) // linked OF invariant
       .mockResolvedValueOnce({ rows: [{ id: "123" }] }) // exists
       .mockResolvedValueOnce({ rows: [{ nouveau_statut: "ENREGISTREE" }] }) // last
       .mockResolvedValueOnce({ rows: [{ id: "10" }] }) // insert historique
@@ -613,6 +614,31 @@ describe("/api/v1/commandes", () => {
     const insertCall = mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("INSERT INTO commande_historique"));
     expect(insertCall).toBeTruthy();
     expect(insertCall?.[1]).toEqual([123, 1, "ENREGISTREE", "PLANIFIEE", "ok"]);
+  });
+
+  it("POST /api/v1/commandes/:id/status refuses planning statuses without an OF", async () => {
+    process.env.JWT_SECRET = "test-secret";
+    const token = jwt.sign(
+      { id: 1, username: "test", email: "test@example.com", role: "admin" },
+      process.env.JWT_SECRET,
+      { expiresIn: "1h" }
+    );
+
+    mocks.clientQuery
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [{ exists: false }] }) // linked OF invariant
+      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+
+    const res = await request(app)
+      .post("/api/v1/commandes/123/status")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ nouveau_statut: "ATTENTE_PLANNING", commentaire: "force" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ code: "PLANNING_REQUIRES_OF" });
+    expect(
+      mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO commande_historique"))
+    ).toBe(false);
   });
 
   it("GET /api/v1/commandes/:id/workflow returns checkpoints and available actions", async () => {
@@ -790,6 +816,81 @@ describe("/api/v1/commandes", () => {
     );
     expect(statusHistoryCall?.[1]).toEqual([123, 1, "ATTENTE_TECHNIQUE", "ATTENTE_STOCK", "ok technique"]);
     expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO ordres_fabrication"))).toBe(false);
+  });
+
+  it("POST /api/v1/commandes/:id/workflow/actions refuses to complete launch without stock allocation or OF generation", async () => {
+    const res = await request(app)
+      .post("/api/v1/commandes/123/workflow/actions")
+      .send({ action: "mark_of_ready" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ code: "COMMAND_LAUNCH_REQUIRED" });
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "/api/v1/commandes/123/generate-affaires/confirm",
+    "/api/v1/commandes/123/affaires/generate",
+  ])("POST %s rejects the removed legacy launch path", async (path) => {
+    const res = await request(app).post(path).send({ strategy: "AUTO" });
+
+    expect(res.status).toBe(410);
+    expect(res.body).toMatchObject({ code: "LEGACY_COMMAND_LAUNCH_REMOVED" });
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["mark_delivered", "DELIVERY_NOT_COMPLETE"],
+    ["mark_invoiced", "INVOICE_NOT_COMPLETE"],
+  ])("refuses workflow action %s without its real fulfillment artifact", async (action, code) => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM commande_client cc")) {
+        return { rows: [{ id: "123", numero: "CC-123", client_id: "001", raw_statut: "PRET_LIVRAISON" }] };
+      }
+      if (q.includes("WITH shipped_by_line AS")) {
+        return {
+          rows: [{
+            has_lines: true,
+            has_ready_delivery: true,
+            fully_shipped: false,
+            fully_invoiced: false,
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post("/api/v1/commandes/123/workflow/actions")
+      .send({ action });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ code });
+    expect(mocks.clientQuery).toHaveBeenCalledWith("ROLLBACK");
+  });
+
+  it("POST /api/v1/commandes/:id/workflow/actions refuses planning validation without an OF", async () => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM commande_client cc")) {
+        return { rows: [{ id: "123", numero: "CC-123", client_id: "001", raw_statut: "ATTENTE_PLANNING" }] };
+      }
+      if (q.includes("FROM public.ordres_fabrication")) {
+        return { rows: [{ exists: false }] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post("/api/v1/commandes/123/workflow/actions")
+      .send({ action: "validate_planning" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ code: "PLANNING_REQUIRES_OF" });
+    expect(mocks.clientQuery).toHaveBeenCalledWith("ROLLBACK");
   });
 
   it("PATCH /api/v1/commandes/:id/workflow/checkpoints/:checkpointCode clears assignment and resumes blocked status", async () => {
@@ -1207,7 +1308,7 @@ describe("/api/v1/commandes", () => {
     expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(false);
   });
 
-  it("POST /api/v1/commandes/:id/generate-affaires creates LIVRAISON even when no stock is available", async () => {
+  it("POST /api/v1/commandes/:id/generate-affaires recovers planning and reuses its existing delivery affair", async () => {
     process.env.JWT_SECRET = "test-secret";
     const token = jwt.sign(
       { id: 1, username: "test", email: "test@example.com", role: "admin" },
@@ -1229,13 +1330,16 @@ describe("/api/v1/commandes", () => {
 
       // Customer-command generation is intentionally gated by the completed stock check.
       if (q.includes("FROM commande_client cc") && q.includes("LEFT JOIN LATERAL")) {
-        return { rows: [{ id: "123", numero: "CC-123", client_id: "001", raw_statut: "ATTENTE_OF" }] };
+        return { rows: [{ id: "123", numero: "CC-123", client_id: "001", raw_statut: "ATTENTE_PLANNING" }] };
       }
       if (q.includes("INSERT INTO public.commande_client_workflow_checkpoint")) return { rows: [] };
       if (q.includes("FROM public.commande_client_workflow_checkpoint") && q.includes("checkpoint_code IN ('stock_check', 'of_generation')")) {
-        return { rows: [{ checkpoint_code: "stock_check", status: "done" }, { checkpoint_code: "of_generation", status: "active" }] };
+        return { rows: [{ checkpoint_code: "stock_check", status: "done" }, { checkpoint_code: "of_generation", status: "done" }] };
       }
-      if (q.includes("SELECT EXISTS(SELECT 1 FROM public.commande_to_affaire")) return { rows: [{ exists: false }] };
+      if (q.includes("SELECT EXISTS(SELECT 1 FROM public.commande_to_affaire")) return { rows: [{ exists: true }] };
+      if (q.includes("EXISTS(SELECT 1 FROM public.ordres_fabrication") && q.includes("EXISTS(SELECT 1 FROM public.bon_livraison")) {
+        return { rows: [{ has_of: false, has_delivery: false }] };
+      }
       if (q.includes("SELECT id::int AS id, numero, client_id") && q.includes("FROM commande_client")) {
         return { rows: [{ id: 123, numero: "CC-123", client_id: "001" }] };
       }
@@ -1261,7 +1365,7 @@ describe("/api/v1/commandes", () => {
       }
 
       if (q.includes("FROM commande_to_affaire") && q.includes("WHERE commande_id")) {
-        return { rows: [] };
+        return { rows: [{ affaire_id: 7, role: "LIVRAISON" }] };
       }
 
       if (q.includes("FROM public.erp_settings") && String(p0) === "stock.default_shipping_location") {
@@ -1278,7 +1382,7 @@ describe("/api/v1/commandes", () => {
             {
               commande_ligne_id: 1,
               code_piece: "P1",
-              qty_ordered: 1,
+              qty_ordered: 2,
               article_id: ARTICLE_ID,
               piece_technique_id: PIECE_ID,
             },
@@ -1286,9 +1390,13 @@ describe("/api/v1/commandes", () => {
         };
       }
 
-      // No stock available -> should create the livraison affaire and OF.
-      if (q.includes("FROM public.stock_levels") && q.includes("GROUP BY sl.article_id")) {
-        return { rows: [{ article_id: ARTICLE_ID, qty_available: 0 }] };
+      // One OLD/NEW unit is already covered by a legacy grouped-delivery reservation.
+      if (q.includes("GROUP BY availability.article_id") && q.includes("warehouse.stock_scope")) {
+        return { rows: [{ article_id: ARTICLE_ID, stock_scope: "OLD", qty_available: 1 }] };
+      }
+
+      if (q.includes("FROM public.stock_reservations reservation") && q.includes("JOIN public.commande_ligne line")) {
+        return { rows: [{ id: "99999999-9999-4999-8999-999999999999", commande_ligne_id: 1, qty_reserved: 1 }] };
       }
 
       if (q.includes("nextval('public.affaire_id_seq')")) {
@@ -1360,6 +1468,7 @@ describe("/api/v1/commandes", () => {
       .post("/api/v1/commandes/123/generate-affaires")
       .set("Authorization", `Bearer ${token}`)
       .send({
+        decision: "SHIP_ALL_TOGETHER",
         // The shortage is 1; launching 3 is a deliberate stock build-up.
         lines: [{ commande_ligne_id: 1, qty_ship_now: 0, qty_to_produce: 3 }],
       });
@@ -1368,8 +1477,23 @@ describe("/api/v1/commandes", () => {
     expect(res.body).toMatchObject({
       affaire_ids: [7],
       livraison_affaire_id: 7,
+      warnings: ["RECOVERED_PLANNING_WITHOUT_OF_OR_DELIVERY"],
     });
     expect(ofInsertCalls.some((params) => params.includes(3))).toBe(true);
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO affaire"))).toBe(false);
+    expect(
+      mocks.clientQuery.mock.calls.some(
+        (call) =>
+          String(call[0]).includes("checkpoint_code IN ('of_generation', 'planning_validation')") &&
+          JSON.stringify(call[1] ?? []).includes("planning_without_of_or_delivery")
+      )
+    ).toBe(true);
+    expect(mocks.clientQuery.mock.calls.some((call) =>
+      String(call[0]).includes("UPDATE public.stock_levels") && String(call[0]).includes("qty_reserved = qty_reserved +")
+    )).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some((call) =>
+      String(call[0]).includes("FROM public.stock_reservations reservation") && String(call[0]).includes("JOIN public.commande_ligne line")
+    )).toBe(true);
   });
 
   it("POST /api/v1/commandes/:id/generate-affaires creates recursive OF tree for manufactured sub-pieces", async () => {

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -44,6 +44,12 @@ import {
 } from "../../production/domain/of-generation";
 import { canLaunchInternalOrder } from "../domain/commande-client-rbac";
 import {
+  assertCommandeFullyInvoiced,
+  assertCommandeFullyShipped,
+  assertCommandeHasActiveOf,
+  assertCommandeHasPreparedDelivery,
+} from "./commande-fulfillment.repository";
+import {
   allocateCommandeStockOldThenNew,
   type CommandeStockAvailability,
 } from "../domain/stock-scope-allocation";
@@ -758,6 +764,7 @@ async function listGeneratedOfRefs(db: Queryable, commandeId: number): Promise<G
       FROM public.ordres_fabrication
       WHERE commande_id = $1
         AND generation_batch_id IS NOT NULL
+        AND statut::text <> 'ANNULE'
       ORDER BY generation_level ASC, id ASC
     `,
     [commandeId]
@@ -1030,6 +1037,16 @@ async function loadCommandeWorkflowHeader(tx: Queryable, commandeId: number): Pr
   return res.rows[0] ?? null;
 }
 
+const COMMANDE_STATUSES_REQUIRING_OF = new Set([
+  "ATTENTE_PLANNING",
+  "PLANNING_VALIDE",
+  "AR_PRET",
+  "AR_ENVOYE",
+  "EN_PRODUCTION",
+  "PRODUCTION_TERMINEE",
+  "CONTROLE_QUALITE",
+]);
+
 export async function repoEnsureCommandeWorkflowStatus(params: {
   tx: Queryable;
   commande_id: number;
@@ -1284,6 +1301,14 @@ async function advanceCustomerOrderWorkflowAfterLaunch(params: {
       commentaire: "Stock réservé et OF du manquant générés",
       user_id: params.user_id,
     });
+  }
+
+  if (!params.bon_livraison_id) {
+    throw new HttpError(
+      409,
+      "PREPARED_DELIVERY_REQUIRED",
+      "La commande couverte par le stock doit posséder un bon de livraison préparé."
+    );
   }
 
   await params.tx.query(
@@ -1838,6 +1863,13 @@ export async function repoRunCommandeWorkflowAction(
   if (userId === null) throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
   const action = getCommandeWorkflowAction(body.action);
   if (!action) throw new HttpError(400, "UNKNOWN_WORKFLOW_ACTION", "Unknown workflow action");
+  if (action.key === "mark_of_ready") {
+    throw new HttpError(
+      409,
+      "COMMAND_LAUNCH_REQUIRED",
+      "Utilisez Vérifier le stock et lancer : cette étape doit réserver OLD/NEW, préparer le BL ou créer les OF du manquant."
+    );
+  }
 
   const runsStockAnalysis = action.key === "check_stock";
 
@@ -1850,6 +1882,9 @@ export async function repoRunCommandeWorkflowAction(
       await client.query("ROLLBACK");
       return null;
     }
+    if (action.key === "validate_planning") await assertCommandeHasActiveOf(client, commandeId);
+    if (action.key === "mark_delivered") await assertCommandeFullyShipped(client, commandeId);
+    if (action.key === "mark_invoiced") await assertCommandeFullyInvoiced(client, commandeId);
     await ensureCommandeWorkflowCheckpoints(client, commandeId, header.statut);
 
     const checkpointRes = await client.query<{ status: string; responsible_role: string }>(
@@ -3059,6 +3094,20 @@ export async function repoUpdateCommandeStatus(
       throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
     }
 
+    const normalizedTargetStatus = normalizeCommandeWorkflowStatus(nouveau_statut);
+    if (normalizedTargetStatus && COMMANDE_STATUSES_REQUIRING_OF.has(normalizedTargetStatus)) {
+      await assertCommandeHasActiveOf(client, commandeId);
+    }
+    if (normalizedTargetStatus === "PRET_LIVRAISON") {
+      await assertCommandeHasPreparedDelivery(client, commandeId);
+    }
+    if (normalizedTargetStatus === "LIVRE") {
+      await assertCommandeFullyShipped(client, commandeId);
+    }
+    if (normalizedTargetStatus === "FACTURE" || normalizedTargetStatus === "ARCHIVE") {
+      await assertCommandeFullyInvoiced(client, commandeId);
+    }
+
     const out = await repoEnsureCommandeWorkflowStatus({
       tx: client,
       commande_id: commandeId,
@@ -3229,6 +3278,7 @@ export async function repoAnalyzeCommandeStock(id: string, audit: AuditContext) 
 export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAffairesV3BodyDTO, audit: AuditContext) {
   const commandeId = toInt(id, "commande_id");
   const client = await pool.connect();
+  let recoveredInvalidPlanningState = false;
   try {
     await client.query("BEGIN");
 
@@ -3303,12 +3353,67 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         [commandeId]
       );
       const ofGenerationStatus = statusByCheckpoint.get("of_generation");
+      const stockCheckDone = statusByCheckpoint.get("stock_check") === "done";
+      const hasExistingLaunch = existingLaunch.rows[0]?.exists === true;
+
+      if (
+        stockCheckDone &&
+        ofGenerationStatus === "done" &&
+        workflowHeader.statut === "ATTENTE_PLANNING"
+      ) {
+        const artifacts = await client.query<{ has_of: boolean; has_delivery: boolean }>(
+          `
+            SELECT
+              EXISTS(
+                SELECT 1
+                FROM public.ordres_fabrication
+                WHERE commande_id = $1
+                  AND statut::text <> 'ANNULE'
+              ) AS has_of,
+              EXISTS(
+                SELECT 1
+                FROM public.bon_livraison
+                WHERE commande_id = $1
+                  AND statut <> 'CANCELLED'
+              ) AS has_delivery
+          `,
+          [commandeId]
+        );
+        const artifactState = artifacts.rows[0] ?? { has_of: false, has_delivery: false };
+        recoveredInvalidPlanningState = !artifactState.has_of && !artifactState.has_delivery;
+
+        if (recoveredInvalidPlanningState) {
+          await client.query(
+            `
+              UPDATE public.commande_client_workflow_checkpoint
+              SET
+                status = CASE
+                  WHEN checkpoint_code = 'of_generation' THEN 'active'
+                  WHEN checkpoint_code = 'planning_validation' THEN 'pending'
+                  ELSE status
+                END,
+                completed_at = CASE WHEN checkpoint_code = 'of_generation' THEN NULL ELSE completed_at END,
+                completed_by = CASE WHEN checkpoint_code = 'of_generation' THEN NULL ELSE completed_by END,
+                metadata = COALESCE(metadata, '{}'::jsonb) || $2::jsonb,
+                updated_at = now()
+              WHERE commande_id = $1
+                AND checkpoint_code IN ('of_generation', 'planning_validation')
+            `,
+            [
+              commandeId,
+              JSON.stringify({ recovery_reason: "planning_without_of_or_delivery" }),
+            ]
+          );
+        }
+      }
+
       const launchAllowed =
-        statusByCheckpoint.get("stock_check") === "done" &&
+        stockCheckDone &&
         (
           ofGenerationStatus === "active" ||
+          recoveredInvalidPlanningState ||
           ((ofGenerationStatus === "done" || ofGenerationStatus === "skipped") &&
-            existingLaunch.rows[0]?.exists === true)
+            hasExistingLaunch)
         );
       if (!launchAllowed) {
         throw new HttpError(
@@ -3359,7 +3464,15 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
     const existingMappings = await listCommandeToAffaireMappings(client, commandeId);
     const existingLivraisons = existingMappings.filter((r) => r.role === "LIVRAISON");
 
-    if (existingMappings.length > 0) {
+    if (recoveredInvalidPlanningState && existingMappings.length > 0 && existingLivraisons.length === 0) {
+      throw new HttpError(
+        409,
+        "COMMANDE_AFFAIRE_MAPPING_INVALID",
+        "La commande possède une affaire liée sans rôle LIVRAISON. Corrigez ce lien avant de relancer."
+      );
+    }
+
+    if (existingMappings.length > 0 && !recoveredInvalidPlanningState) {
       if (orderType === "INTERNE" && existingLivraisons.length === 0) {
         throw new HttpError(
           409,
@@ -3523,7 +3636,8 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       overrides.set(l.commande_ligne_id, Number(l.qty_ship_now));
     }
 
-    const reservedByLine = new Map<number, number>();
+    const stockCoveredByLine = new Map<number, number>();
+    const immediateDeliveryByLine = new Map<number, number>();
     for (const line of stockAnalysis.lines) {
       const maxShip = Number(line.available_used_qty);
       const override = overrides.has(line.commande_ligne_id)
@@ -3559,24 +3673,30 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
           `La livraison et la production doivent couvrir la quantité demandée pour la ligne ${line.commande_ligne_id}.`
         );
       }
-      reservedByLine.set(line.commande_ligne_id, qtyToDeliverNow);
+      stockCoveredByLine.set(line.commande_ligne_id, maxShip);
+      immediateDeliveryByLine.set(line.commande_ligne_id, qtyToDeliverNow);
     }
 
-    const livraisonAffaireIds: number[] = [];
-    const livraisonAffaireId = await createAffaire(client, {
-      commande_id: commandeId,
-      devis_id: commande.devis_id ? toNullableInt(commande.devis_id, "commande.devis_id") : null,
-      client_id: clientId,
-    });
-    await insertCommandeToAffaireMapping(client, {
-      commande_id: commandeId,
-      affaire_id: livraisonAffaireId,
-      role: "LIVRAISON",
-      commentaire: "Generated from commande",
-    });
-    livraisonAffaireIds.push(livraisonAffaireId);
+    const livraisonAffaireIds: number[] = recoveredInvalidPlanningState
+      ? existingLivraisons.map((mapping) => mapping.affaire_id)
+      : [];
 
-    for (let i = 1; i < requestedLivraisonCount; i += 1) {
+    if (livraisonAffaireIds.length === 0) {
+      const createdId = await createAffaire(client, {
+        commande_id: commandeId,
+        devis_id: commande.devis_id ? toNullableInt(commande.devis_id, "commande.devis_id") : null,
+        client_id: clientId,
+      });
+      await insertCommandeToAffaireMapping(client, {
+        commande_id: commandeId,
+        affaire_id: createdId,
+        role: "LIVRAISON",
+        commentaire: "Generated from commande",
+      });
+      livraisonAffaireIds.push(createdId);
+    }
+
+    for (let i = livraisonAffaireIds.length; i < requestedLivraisonCount; i += 1) {
       const extraId = await createAffaire(client, {
         commande_id: commandeId,
         devis_id: commande.devis_id ? toNullableInt(commande.devis_id, "commande.devis_id") : null,
@@ -3589,6 +3709,11 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         commentaire: `Split delivery (${i + 1}/${requestedLivraisonCount})`,
       });
       livraisonAffaireIds.push(extraId);
+    }
+
+    const livraisonAffaireId = livraisonAffaireIds[0];
+    if (!livraisonAffaireId) {
+      throw new HttpError(500, "LIVRAISON_AFFAIRE_REQUIRED", "Aucune affaire de livraison n'a pu être préparée.");
     }
 
     const planLines: CommandeAllocationPlanLine[] = analysis.lines.map((l) => ({
@@ -3614,20 +3739,38 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       livraison_affaire_id: livraisonAffaireId,
       allocation_mode: allocationMode,
       reserve_stock: false,
-      reserved_qty_by_line: orderType !== "INTERNE" ? reservedByLine : null,
+      reserved_qty_by_line: orderType !== "INTERNE" ? stockCoveredByLine : null,
       lines: planLines,
     });
 
+    const holdsStockForGroupedDelivery =
+      orderType !== "INTERNE" && needsProduction && decision === "SHIP_ALL_TOGETHER";
     const preparedDelivery =
-      orderType !== "INTERNE"
+      orderType !== "INTERNE" && !holdsStockForGroupedDelivery
         ? await createPreparedLivraisonForStock(client, {
             commande_id: commandeId,
             user_id: audit.user_id,
             analysis_lines: stockAnalysis.lines,
-            quantities_by_line: reservedByLine,
+            quantities_by_line: immediateDeliveryByLine,
           })
         : null;
-    const reservationsCreated = preparedDelivery?.reservation_ids ?? [];
+    const reservationsCreated = holdsStockForGroupedDelivery
+      ? (
+          (recoveredInvalidPlanningState
+            ? await reuseRecoveredCommandeStockReservations(client, {
+                commande_id: commandeId,
+                quantities_by_line: stockCoveredByLine,
+              })
+            : null) ??
+          await reserveCommandeStockForLaterDelivery(client, {
+            commande_id: commandeId,
+            livraison_affaire_id: livraisonAffaireId,
+            user_id: audit.user_id,
+            analysis_lines: stockAnalysis.lines,
+            quantities_by_line: stockCoveredByLine,
+          })
+        )
+      : preparedDelivery?.reservation_ids ?? [];
     const bonLivraisonId = preparedDelivery?.bon_livraison_id ?? null;
 
     const generatedOfs: GeneratedOfRef[] = [];
@@ -3710,6 +3853,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         bon_livraison_id: bonLivraisonId,
         reservations_created: reservationsCreated.length,
         of_created: ofIds.length,
+        recovered_invalid_planning_state: recoveredInvalidPlanningState,
       },
       user_id: audit.user_id,
     });
@@ -3727,6 +3871,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
         bon_livraison_id: bonLivraisonId,
         reservations_created: reservationsCreated,
         of_ids: ofIds,
+        recovered_invalid_planning_state: recoveredInvalidPlanningState,
       },
     });
 
@@ -3763,7 +3908,7 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       generation_mode: orderType === "INTERNE" ? "INTERNAL_ORDER" : "CUSTOMER_ORDER",
       idempotent_replay: false,
       workflow_status: workflowStatus,
-      warnings: [],
+      warnings: recoveredInvalidPlanningState ? ["RECOVERED_PLANNING_WITHOUT_OF_OR_DELIVERY"] : [],
     };
   } catch (e) {
     await client.query("ROLLBACK");
@@ -4028,7 +4173,7 @@ async function loadScopedAvailableQtyByArticle(
 
 type StockAvailabilityStatus = "FULL" | "PARTIAL" | "NONE";
 
-type CommandeStockAnalysisLine = {
+export type CommandeStockAnalysisLine = {
   commande_ligne_id: number;
   code_piece: string | null;
   article_id: string | null;
@@ -4322,6 +4467,205 @@ async function createPreparedLivraisonForStock(
     bon_livraison_id: livraison.id,
     reservation_ids: reservations.rows.map((reservation) => reservation.id),
   };
+}
+
+export async function reserveCommandeStockForLaterDelivery(
+  db: PoolClient,
+  params: {
+    commande_id: number;
+    livraison_affaire_id: number;
+    user_id: number;
+    analysis_lines: CommandeStockAnalysisLine[];
+    quantities_by_line: ReadonlyMap<number, number>;
+  }
+): Promise<string[]> {
+  const positiveQuantities = new Map(
+    [...params.quantities_by_line.entries()].filter(([, quantity]) => Number(quantity) > 1e-9)
+  );
+  if (positiveQuantities.size === 0) return [];
+
+  const articleIds = Array.from(
+    new Set(
+      params.analysis_lines
+        .filter((line) => positiveQuantities.has(line.commande_ligne_id))
+        .map((line) => line.article_id)
+        .filter((articleId): articleId is string => Boolean(articleId))
+    )
+  );
+  const candidates = await loadScopedDeliveryStockCandidates(db, articleIds);
+  const allocations = planDeliveryAllocations(params.analysis_lines, positiveQuantities, candidates);
+  const reservationIds: string[] = [];
+
+  for (const allocation of allocations) {
+    const stockLevel = await db.query<{
+      qty_total: number;
+      qty_reserved: number;
+      qty_depreciated: number;
+    }>(
+      `
+        SELECT
+          qty_total::float8 AS qty_total,
+          qty_reserved::float8 AS qty_reserved,
+          qty_depreciated::float8 AS qty_depreciated
+        FROM public.stock_levels
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
+      [allocation.stock_level_id]
+    );
+    const level = stockLevel.rows[0] ?? null;
+    const available = level
+      ? Number(level.qty_total) - Number(level.qty_reserved) - Number(level.qty_depreciated)
+      : 0;
+    if (!level || available + 1e-9 < allocation.quantity) {
+      throw new HttpError(
+        409,
+        "STOCK_POSITION_NOT_RESERVABLE",
+        `Le stock OLD/NEW de la ligne ${allocation.commande_ligne_id} a changé. Relancez l'analyse.`
+      );
+    }
+
+    if (allocation.stock_batch_id) {
+      const stockBatch = await db.query<{ qty_total: number; qty_reserved: number }>(
+        `
+          SELECT qty_total::float8 AS qty_total, qty_reserved::float8 AS qty_reserved
+          FROM public.stock_batches
+          WHERE id = $1::uuid
+          FOR UPDATE
+        `,
+        [allocation.stock_batch_id]
+      );
+      const batch = stockBatch.rows[0] ?? null;
+      const batchAvailable = batch
+        ? Number(batch.qty_total) - Number(batch.qty_reserved)
+        : 0;
+      if (!batch || batchAvailable + 1e-9 < allocation.quantity) {
+        throw new HttpError(
+          409,
+          "STOCK_BATCH_NOT_RESERVABLE",
+          `Le lot OLD/NEW de la ligne ${allocation.commande_ligne_id} a changé. Relancez l'analyse.`
+        );
+      }
+    }
+
+    await db.query(
+      `
+        UPDATE public.stock_levels
+        SET qty_reserved = qty_reserved + $2,
+            updated_at = now(),
+            updated_by = $3
+        WHERE id = $1::uuid
+      `,
+      [allocation.stock_level_id, allocation.quantity, params.user_id]
+    );
+    if (allocation.stock_batch_id) {
+      await db.query(
+        `UPDATE public.stock_batches SET qty_reserved = qty_reserved + $2 WHERE id = $1::uuid`,
+        [allocation.stock_batch_id, allocation.quantity]
+      );
+    }
+
+    const reservation = await db.query<{ id: string }>(
+      `
+        INSERT INTO public.stock_reservations (
+          article_id, location_id, qty_reserved, source_type, source_id,
+          commande_ligne_id, affaire_id, status, lot_id, stock_batch_id,
+          reason, created_by, updated_by
+        ) VALUES (
+          $1::uuid,$2::uuid,$3,'COMMANDE_LIGNE',$4,$4::bigint,$5::bigint,
+          'ACTIVE',$6::uuid,$7::uuid,$8,$9,$9
+        )
+        ON CONFLICT (source_type, source_id, article_id, location_id, lot_id)
+          WHERE status = 'ACTIVE' AND lot_id IS NOT NULL
+        DO UPDATE SET
+          qty_reserved = public.stock_reservations.qty_reserved + EXCLUDED.qty_reserved,
+          affaire_id = COALESCE(public.stock_reservations.affaire_id, EXCLUDED.affaire_id),
+          updated_at = now(),
+          updated_by = EXCLUDED.updated_by
+        RETURNING id::text AS id
+      `,
+      [
+        allocation.article_id,
+        allocation.location_id,
+        allocation.quantity,
+        String(allocation.commande_ligne_id),
+        params.livraison_affaire_id,
+        allocation.lot_id,
+        allocation.stock_batch_id,
+        "Réservée dès le lancement pour une livraison groupée",
+        params.user_id,
+      ]
+    );
+    const reservationId = reservation.rows[0]?.id;
+    if (!reservationId) throw new Error("Failed to reserve order stock for later delivery");
+    reservationIds.push(reservationId);
+  }
+
+  return reservationIds;
+}
+
+/**
+ * A legacy command can be marked `ATTENTE_PLANNING` without a BL or OF while still
+ * carrying active grouped-delivery reservations. Re-running the launcher must not
+ * add those quantities a second time. We only reuse an exact, locked coverage; any
+ * partial or unexpected reservation is left untouched and requires a manual repair.
+ */
+export async function reuseRecoveredCommandeStockReservations(
+  db: PoolClient,
+  params: {
+    commande_id: number;
+    quantities_by_line: ReadonlyMap<number, number>;
+  }
+): Promise<string[] | null> {
+  const expected = new Map(
+    [...params.quantities_by_line.entries()].filter(([, quantity]) => Number(quantity) > 1e-9)
+  );
+
+  const reservations = await db.query<{
+    id: string;
+    commande_ligne_id: number;
+    qty_reserved: number;
+  }>(
+    `
+      SELECT reservation.id::text AS id,
+             reservation.commande_ligne_id::bigint::int AS commande_ligne_id,
+             reservation.qty_reserved::float8 AS qty_reserved
+      FROM public.stock_reservations reservation
+      JOIN public.commande_ligne line
+        ON line.id = reservation.commande_ligne_id
+       AND line.commande_id = $1
+      WHERE reservation.source_type = 'COMMANDE_LIGNE'
+        AND reservation.source_id = reservation.commande_ligne_id::text
+        AND reservation.status = 'ACTIVE'
+      ORDER BY reservation.commande_ligne_id, reservation.created_at, reservation.id
+      FOR UPDATE
+    `,
+    [params.commande_id]
+  );
+  if (reservations.rows.length === 0) return expected.size === 0 ? [] : null;
+
+  const covered = new Map<number, number>();
+  for (const reservation of reservations.rows) {
+    covered.set(
+      reservation.commande_ligne_id,
+      (covered.get(reservation.commande_ligne_id) ?? 0) + Number(reservation.qty_reserved)
+    );
+  }
+  const mismatch =
+    [...expected.entries()].some(([lineId, quantity]) =>
+      Math.abs((covered.get(lineId) ?? 0) - Number(quantity)) > 1e-9
+    ) ||
+    [...covered.entries()].some(
+      ([lineId, quantity]) => !expected.has(lineId) || !Number.isFinite(quantity) || quantity <= 0
+    );
+  if (mismatch) {
+    throw new HttpError(
+      409,
+      "RECOVERED_RESERVATION_COVERAGE_MISMATCH",
+      "La reprise a trouvé des réservations OLD/NEW partielles ou incohérentes. Elles n'ont pas été modifiées ; corrigez-les avant de relancer."
+    );
+  }
+  return reservations.rows.map((reservation) => reservation.id);
 }
 
 async function computeCommandeAllocationPlan(db: PoolClient, commandeId: number): Promise<CommandeAllocationPlan> {

--- a/src/module/commande-client/repository/commande-fulfillment.repository.test.ts
+++ b/src/module/commande-client/repository/commande-fulfillment.repository.test.ts
@@ -1,0 +1,122 @@
+import type { PoolClient } from "pg";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  assertCommandeFullyInvoiced,
+  assertCommandeFullyShipped,
+  assertCommandeHasActiveOf,
+  syncCommandeAfterInvoiceIssue,
+  syncCommandeAfterShipment,
+} from "./commande-fulfillment.repository";
+
+function queryable(
+  implementation: (sql: string, values?: unknown[]) => Promise<{ rows: unknown[] }>
+) {
+  return {
+    query: vi.fn((sql: string, values?: unknown[]) => implementation(sql, values)),
+  } as unknown as Pick<PoolClient, "query">;
+}
+
+const completeState = {
+  has_lines: true,
+  has_ready_delivery: true,
+  fully_shipped: true,
+  fully_invoiced: true,
+};
+
+describe("commande fulfillment invariants", () => {
+  it("ignores cancelled OF when validating planning", async () => {
+    const tx = queryable(async (sql) => {
+      expect(sql).toContain("statut::text <> 'ANNULE'");
+      return { rows: [{ exists: false }] };
+    });
+
+    await expect(assertCommandeHasActiveOf(tx, 12)).rejects.toMatchObject({
+      code: "PLANNING_REQUIRES_OF",
+    });
+  });
+
+  it("requires every ordered quantity to be shipped and invoiced", async () => {
+    const tx = queryable(async () => ({
+      rows: [{
+        has_lines: true,
+        has_ready_delivery: true,
+        fully_shipped: false,
+        fully_invoiced: false,
+      }],
+    }));
+
+    await expect(assertCommandeFullyShipped(tx, 12)).rejects.toMatchObject({
+      code: "DELIVERY_NOT_COMPLETE",
+    });
+    await expect(assertCommandeFullyInvoiced(tx, 12)).rejects.toMatchObject({
+      code: "INVOICE_NOT_COMPLETE",
+    });
+  });
+
+  it("advances delivery only from PRET_LIVRAISON", async () => {
+    const tx = queryable(async (sql) => {
+      if (sql.includes("WITH shipped_by_line AS")) return { rows: [completeState] };
+      if (sql.includes("SELECT statut, order_type")) {
+        return { rows: [{ statut: "PRET_LIVRAISON", order_type: "STANDARD" }] };
+      }
+      return { rows: [] };
+    });
+
+    await expect(syncCommandeAfterShipment(tx, 12, 7)).resolves.toEqual({
+      advanced: true,
+      status: "LIVRE",
+    });
+    expect(tx.query).toHaveBeenCalledWith(
+      expect.stringContaining("SET statut = 'LIVRE'"),
+      [12]
+    );
+    expect(tx.query).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO public.commande_historique"),
+      [
+        12,
+        7,
+        "PRET_LIVRAISON",
+        "LIVRE",
+        expect.stringContaining("sortie de stock complète"),
+      ]
+    );
+  });
+
+  it("rolls back the semantic shortcut when a complete shipment happens too early", async () => {
+    const tx = queryable(async (sql) => {
+      if (sql.includes("WITH shipped_by_line AS")) return { rows: [completeState] };
+      if (sql.includes("SELECT statut, order_type")) {
+        return { rows: [{ statut: "ATTENTE_PLANNING", order_type: "STANDARD" }] };
+      }
+      return { rows: [] };
+    });
+
+    await expect(syncCommandeAfterShipment(tx, 12, 7)).rejects.toMatchObject({
+      code: "COMMAND_NOT_READY_FOR_DELIVERY",
+    });
+    expect(tx.query).not.toHaveBeenCalledWith(
+      expect.stringContaining("SET statut = 'LIVRE'"),
+      expect.anything()
+    );
+  });
+
+  it("advances invoicing only after the delivered command is fully covered", async () => {
+    const tx = queryable(async (sql) => {
+      if (sql.includes("WITH shipped_by_line AS")) return { rows: [completeState] };
+      if (sql.includes("SELECT statut FROM public.commande_client")) {
+        return { rows: [{ statut: "LIVRE" }] };
+      }
+      return { rows: [] };
+    });
+
+    await expect(syncCommandeAfterInvoiceIssue(tx, 12, 9)).resolves.toEqual({
+      advanced: true,
+      status: "FACTURE",
+    });
+    expect(tx.query).toHaveBeenCalledWith(
+      expect.stringContaining("SET statut = 'FACTURE'"),
+      [12]
+    );
+  });
+});

--- a/src/module/commande-client/repository/commande-fulfillment.repository.ts
+++ b/src/module/commande-client/repository/commande-fulfillment.repository.ts
@@ -1,0 +1,348 @@
+import type { PoolClient } from "pg";
+
+import { HttpError } from "../../../utils/httpError";
+
+type Queryable = Pick<PoolClient, "query">;
+
+type FulfillmentState = {
+  has_lines: boolean;
+  has_ready_delivery: boolean;
+  fully_shipped: boolean;
+  fully_invoiced: boolean;
+};
+
+const INVOICE_LEDGER_STATUSES = ["ISSUED", "PARTIALLY_PAID", "PAID"] as const;
+
+async function loadCommandeFulfillmentState(
+  tx: Queryable,
+  commandeId: number
+): Promise<FulfillmentState> {
+  const result = await tx.query<FulfillmentState>(
+    `
+      WITH shipped_by_line AS (
+        SELECT
+          delivery_line.commande_ligne_id,
+          COALESCE(SUM(delivery_line.quantite), 0)::numeric AS quantity
+        FROM public.bon_livraison_ligne delivery_line
+        JOIN public.bon_livraison delivery
+          ON delivery.id = delivery_line.bon_livraison_id
+        WHERE delivery.commande_id = $1
+          AND delivery.statut IN ('SHIPPED', 'DELIVERED')
+          AND delivery_line.commande_ligne_id IS NOT NULL
+        GROUP BY delivery_line.commande_ligne_id
+      ),
+      invoiced_by_delivery_line AS (
+        SELECT
+          source.source_line_id,
+          COALESCE(SUM(source.quantity_consumed), 0)::numeric AS quantity
+        FROM public.facture_source_allocations source
+        JOIN public.facture invoice ON invoice.id = source.facture_id
+        WHERE source.source_type = 'DELIVERY_LINE'
+          AND source.allocation_status = 'CONSUMED'
+          AND invoice.statut = ANY($2::text[])
+        GROUP BY source.source_line_id
+      )
+      SELECT
+        EXISTS(
+          SELECT 1
+          FROM public.commande_ligne line
+          WHERE line.commande_id = $1
+        ) AS has_lines,
+        EXISTS(
+          SELECT 1
+          FROM public.bon_livraison delivery
+          WHERE delivery.commande_id = $1
+            AND delivery.statut IN ('READY', 'SHIPPED', 'DELIVERED')
+        ) AS has_ready_delivery,
+        NOT EXISTS(
+          SELECT 1
+          FROM public.commande_ligne line
+          LEFT JOIN shipped_by_line shipped ON shipped.commande_ligne_id = line.id
+          WHERE line.commande_id = $1
+            AND COALESCE(shipped.quantity, 0) + 0.000000001 < line.quantite
+        ) AS fully_shipped,
+        NOT EXISTS(
+          SELECT 1
+          FROM public.bon_livraison_ligne delivery_line
+          JOIN public.bon_livraison delivery
+            ON delivery.id = delivery_line.bon_livraison_id
+          LEFT JOIN invoiced_by_delivery_line invoiced
+            ON invoiced.source_line_id = delivery_line.id::text
+          WHERE delivery.commande_id = $1
+            AND delivery.statut IN ('SHIPPED', 'DELIVERED')
+            AND COALESCE(invoiced.quantity, 0) + 0.000000001 < delivery_line.quantite
+        ) AS fully_invoiced
+    `,
+    [commandeId, [...INVOICE_LEDGER_STATUSES]]
+  );
+
+  const state = result.rows[0] ?? {
+    has_lines: false,
+    has_ready_delivery: false,
+    fully_shipped: false,
+    fully_invoiced: false,
+  };
+  return {
+    ...state,
+    fully_shipped: state.has_lines && state.fully_shipped,
+    fully_invoiced: state.has_lines && state.fully_shipped && state.fully_invoiced,
+  };
+}
+
+export async function assertCommandeHasActiveOf(tx: Queryable, commandeId: number): Promise<void> {
+  const linkedOf = await tx.query<{ exists: boolean }>(
+    `
+      SELECT EXISTS(
+        SELECT 1
+        FROM public.ordres_fabrication
+        WHERE commande_id = $1
+          AND statut::text <> 'ANNULE'
+      ) AS exists
+    `,
+    [commandeId]
+  );
+  if (linkedOf.rows[0]?.exists !== true) {
+    throw new HttpError(
+      409,
+      "PLANNING_REQUIRES_OF",
+      "Aucun OF actif n'est lié à cette commande. Relancez le contrôle OLD/NEW et la génération avant de valider le planning."
+    );
+  }
+}
+
+export async function assertCommandeHasPreparedDelivery(
+  tx: Queryable,
+  commandeId: number
+): Promise<void> {
+  const state = await loadCommandeFulfillmentState(tx, commandeId);
+  if (!state.has_ready_delivery) {
+    throw new HttpError(
+      409,
+      "DELIVERY_PREPARATION_REQUIRED",
+      "Aucun bon de livraison prêt n'est lié à cette commande. Préparez le BL et ses réservations avant ce changement de statut."
+    );
+  }
+}
+
+export async function assertCommandeFullyShipped(
+  tx: Queryable,
+  commandeId: number
+): Promise<void> {
+  const state = await loadCommandeFulfillmentState(tx, commandeId);
+  if (!state.fully_shipped) {
+    throw new HttpError(
+      409,
+      "DELIVERY_NOT_COMPLETE",
+      "La commande ne peut pas être déclarée livrée : toutes les quantités doivent d'abord sortir du stock via un BL expédié."
+    );
+  }
+}
+
+export async function assertCommandeFullyInvoiced(
+  tx: Queryable,
+  commandeId: number
+): Promise<void> {
+  const state = await loadCommandeFulfillmentState(tx, commandeId);
+  if (!state.fully_invoiced) {
+    throw new HttpError(
+      409,
+      "INVOICE_NOT_COMPLETE",
+      "La commande ne peut pas être déclarée facturée : toutes les lignes expédiées doivent être couvertes par une facture émise."
+    );
+  }
+}
+
+async function insertAutomaticHistory(params: {
+  tx: Queryable;
+  commande_id: number;
+  user_id: number;
+  old_status: string;
+  new_status: "LIVRE" | "FACTURE";
+  comment: string;
+}): Promise<void> {
+  if (params.old_status === params.new_status) return;
+  await params.tx.query(
+    `
+      INSERT INTO public.commande_historique (
+        commande_id, user_id, ancien_statut, nouveau_statut, commentaire
+      ) VALUES ($1,$2,$3,$4,$5)
+    `,
+    [
+      params.commande_id,
+      params.user_id,
+      params.old_status,
+      params.new_status,
+      params.comment,
+    ]
+  );
+}
+
+export async function syncCommandeAfterShipment(
+  tx: Queryable,
+  commandeId: number,
+  userId: number
+): Promise<{ advanced: boolean; status: string | null }> {
+  const state = await loadCommandeFulfillmentState(tx, commandeId);
+  if (!state.fully_shipped) return { advanced: false, status: null };
+
+  const header = await tx.query<{ statut: string; order_type: string | null }>(
+    `
+      SELECT statut, order_type
+      FROM public.commande_client
+      WHERE id = $1
+      FOR UPDATE
+    `,
+    [commandeId]
+  );
+  const current = header.rows[0] ?? null;
+  if (!current) return { advanced: false, status: null };
+  if (["FACTURE", "ARCHIVE"].includes(current.statut)) {
+    return { advanced: false, status: current.statut };
+  }
+  if (!["PRET_LIVRAISON", "LIVRE"].includes(current.statut)) {
+    throw new HttpError(
+      409,
+      "COMMAND_NOT_READY_FOR_DELIVERY",
+      "L'expédition complète est bloquée tant que le workflow commande n'a pas atteint Prêt pour livraison."
+    );
+  }
+
+  await tx.query(
+    `
+      UPDATE public.commande_client
+      SET statut = 'LIVRE', updated_at = now()
+      WHERE id = $1
+    `,
+    [commandeId]
+  );
+  await insertAutomaticHistory({
+    tx,
+    commande_id: commandeId,
+    user_id: userId,
+    old_status: current.statut,
+    new_status: "LIVRE",
+    comment: "Statut synchronisé automatiquement après sortie de stock complète et expédition du BL",
+  });
+
+  const internalOrder = String(current.order_type ?? "").toUpperCase() === "INTERNE";
+  await tx.query(
+    `
+      UPDATE public.commande_client_workflow_checkpoint
+      SET
+        status = CASE
+          WHEN checkpoint_code = 'delivery' THEN 'done'
+          WHEN checkpoint_code = 'invoicing' THEN $2
+          WHEN checkpoint_code = 'archive' AND $2 = 'skipped' THEN 'active'
+          ELSE status
+        END,
+        completed_at = CASE
+          WHEN checkpoint_code = 'delivery' THEN COALESCE(completed_at, now())
+          WHEN checkpoint_code = 'invoicing' AND $2 = 'skipped' THEN COALESCE(completed_at, now())
+          ELSE completed_at
+        END,
+        completed_by = CASE
+          WHEN checkpoint_code = 'delivery' THEN COALESCE(completed_by, $3)
+          WHEN checkpoint_code = 'invoicing' AND $2 = 'skipped' THEN COALESCE(completed_by, $3)
+          ELSE completed_by
+        END,
+        metadata = COALESCE(metadata, '{}'::jsonb) || $4::jsonb,
+        updated_at = now()
+      WHERE commande_id = $1
+        AND checkpoint_code IN ('delivery', 'invoicing', 'archive')
+    `,
+    [
+      commandeId,
+      internalOrder ? "skipped" : "active",
+      userId,
+      JSON.stringify({ synchronized_from: "delivery_shipped" }),
+    ]
+  );
+  return { advanced: true, status: "LIVRE" };
+}
+
+export async function syncCommandeAfterInvoiceIssue(
+  tx: Queryable,
+  commandeId: number,
+  userId: number
+): Promise<{ advanced: boolean; status: string | null }> {
+  const state = await loadCommandeFulfillmentState(tx, commandeId);
+  if (!state.fully_invoiced) return { advanced: false, status: null };
+
+  const header = await tx.query<{ statut: string }>(
+    `SELECT statut FROM public.commande_client WHERE id = $1 FOR UPDATE`,
+    [commandeId]
+  );
+  const current = header.rows[0] ?? null;
+  if (!current) return { advanced: false, status: null };
+  if (current.statut === "ARCHIVE") return { advanced: false, status: current.statut };
+  if (!["LIVRE", "FACTURE"].includes(current.statut)) {
+    throw new HttpError(
+      409,
+      "COMMAND_NOT_READY_FOR_INVOICE",
+      "L'émission finale est bloquée tant que la commande n'est pas entièrement livrée."
+    );
+  }
+
+  await tx.query(
+    `UPDATE public.commande_client SET statut = 'FACTURE', updated_at = now() WHERE id = $1`,
+    [commandeId]
+  );
+  await insertAutomaticHistory({
+    tx,
+    commande_id: commandeId,
+    user_id: userId,
+    old_status: current.statut,
+    new_status: "FACTURE",
+    comment: "Statut synchronisé automatiquement après émission complète de la facture",
+  });
+  await tx.query(
+    `
+      UPDATE public.commande_client_workflow_checkpoint
+      SET
+        status = CASE
+          WHEN checkpoint_code = 'invoicing' THEN 'done'
+          WHEN checkpoint_code = 'archive' THEN 'active'
+          ELSE status
+        END,
+        completed_at = CASE
+          WHEN checkpoint_code = 'invoicing' THEN COALESCE(completed_at, now())
+          WHEN checkpoint_code = 'archive' THEN NULL
+          ELSE completed_at
+        END,
+        completed_by = CASE
+          WHEN checkpoint_code = 'invoicing' THEN COALESCE(completed_by, $2)
+          WHEN checkpoint_code = 'archive' THEN NULL
+          ELSE completed_by
+        END,
+        metadata = COALESCE(metadata, '{}'::jsonb) || $3::jsonb,
+        updated_at = now()
+      WHERE commande_id = $1
+        AND checkpoint_code IN ('invoicing', 'archive')
+    `,
+    [commandeId, userId, JSON.stringify({ synchronized_from: "invoice_issued" })]
+  );
+  return { advanced: true, status: "FACTURE" };
+}
+
+export async function listIssuedInvoiceCommandeIds(
+  tx: Queryable,
+  factureId: number
+): Promise<number[]> {
+  const result = await tx.query<{ commande_id: number }>(
+    `
+      SELECT DISTINCT delivery.commande_id::int AS commande_id
+      FROM public.facture_source_allocations source
+      JOIN public.bon_livraison_ligne delivery_line
+        ON source.source_type = 'DELIVERY_LINE'
+       AND source.source_line_id = delivery_line.id::text
+      JOIN public.bon_livraison delivery
+        ON delivery.id = delivery_line.bon_livraison_id
+      WHERE source.facture_id = $1
+        AND source.allocation_status = 'CONSUMED'
+        AND delivery.commande_id IS NOT NULL
+      ORDER BY delivery.commande_id
+    `,
+    [factureId]
+  );
+  return result.rows.map((row) => Number(row.commande_id)).filter(Number.isInteger);
+}

--- a/src/module/commande-client/repository/commande-stock-reservation.repository.test.ts
+++ b/src/module/commande-client/repository/commande-stock-reservation.repository.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  reserveCommandeStockForLaterDelivery,
+  reuseRecoveredCommandeStockReservations,
+  type CommandeStockAnalysisLine,
+} from "./commande-client.repository";
+
+const ids = {
+  article: "11111111-1111-1111-1111-111111111111",
+  location: "22222222-2222-2222-2222-222222222222",
+  level: "33333333-3333-3333-3333-333333333333",
+  lot: "44444444-4444-4444-8444-444444444444",
+  magasin: "55555555-5555-5555-8555-555555555555",
+};
+
+const line: CommandeStockAnalysisLine = {
+  commande_ligne_id: 1,
+  code_piece: "P-1",
+  article_id: ids.article,
+  article_code: "ART-1",
+  article_designation: "Article test",
+  piece_technique_id: null,
+  piece_code: null,
+  piece_designation: null,
+  requested_qty: 10,
+  old_available_qty: 4,
+  old_used_qty: 4,
+  new_available_qty: 0,
+  new_used_qty: 0,
+  available_qty: 4,
+  available_used_qty: 4,
+  shortage_qty: 6,
+  proposed_production_qty: 6,
+  status: "PARTIAL",
+};
+
+describe("reserveCommandeStockForLaterDelivery", () => {
+  it("reserves exactly the four OLD/NEW units for SHIP_ALL_TOGETHER without creating a BL", async () => {
+    const query = vi.fn(async (sql: unknown, _params?: unknown[]) => {
+      const text = String(sql);
+      if (text.includes("FROM public.v_stock_availability_225 availability")) {
+        return {
+          rows: [{
+            article_id: ids.article,
+            stock_scope: "OLD",
+            stock_level_id: ids.level,
+            stock_batch_id: null,
+            location_id: ids.location,
+            lot_id: ids.lot,
+            magasin_id: ids.magasin,
+            emplacement_id: 1,
+            qty_available: 4,
+          }],
+        };
+      }
+      if (text.includes("FROM public.stock_levels") && text.includes("FOR UPDATE")) {
+        return { rows: [{ qty_total: 4, qty_reserved: 0, qty_depreciated: 0 }] };
+      }
+      if (text.includes("INSERT INTO public.stock_reservations")) {
+        return { rows: [{ id: "66666666-6666-6666-8666-666666666666" }] };
+      }
+      return { rows: [] };
+    });
+
+    await expect(
+      reserveCommandeStockForLaterDelivery({ query } as never, {
+        commande_id: 123,
+        livraison_affaire_id: 7,
+        user_id: 9,
+        analysis_lines: [line],
+        quantities_by_line: new Map([[1, 4]]),
+      })
+    ).resolves.toEqual(["66666666-6666-6666-8666-666666666666"]);
+
+    const levelUpdate = query.mock.calls.find(([sql]) => String(sql).includes("UPDATE public.stock_levels"));
+    const reservationInsert = query.mock.calls.find(([sql]) => String(sql).includes("INSERT INTO public.stock_reservations"));
+    expect(levelUpdate?.[1]).toEqual([ids.level, 4, 9]);
+    expect(reservationInsert?.[1]).toEqual(expect.arrayContaining([ids.article, ids.location, 4, "1", 7, ids.lot]));
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO bon_livraison"))).toBe(false);
+  });
+});
+
+describe("reuseRecoveredCommandeStockReservations", () => {
+  it("reuses an exact locked coverage for the whole command", async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [
+        { id: "77777777-7777-4777-8777-777777777777", commande_ligne_id: 1, qty_reserved: 4 },
+      ],
+    });
+
+    await expect(
+      reuseRecoveredCommandeStockReservations({ query } as never, {
+        commande_id: 123,
+        quantities_by_line: new Map([[1, 4]]),
+      })
+    ).resolves.toEqual(["77777777-7777-4777-8777-777777777777"]);
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("JOIN public.commande_ligne line"),
+      [123]
+    );
+    expect(String(query.mock.calls[0]?.[0])).toContain("FOR UPDATE");
+  });
+
+  it("rejects an unexpected reservation instead of silently keeping excess stock reserved", async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [
+        { id: "77777777-7777-4777-8777-777777777777", commande_ligne_id: 1, qty_reserved: 4 },
+        { id: "88888888-8888-4888-8888-888888888888", commande_ligne_id: 2, qty_reserved: 1 },
+      ],
+    });
+
+    await expect(
+      reuseRecoveredCommandeStockReservations({ query } as never, {
+        commande_id: 123,
+        quantities_by_line: new Map([[1, 4]]),
+      })
+    ).rejects.toMatchObject({ code: "RECOVERED_RESERVATION_COVERAGE_MISMATCH", status: 409 });
+  });
+
+  it("accepts an empty expected coverage only when the command has no active reservation", async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [] });
+
+    await expect(
+      reuseRecoveredCommandeStockReservations({ query } as never, {
+        commande_id: 123,
+        quantities_by_line: new Map(),
+      })
+    ).resolves.toEqual([]);
+  });
+});

--- a/src/module/commande-client/routes/commande-client.routes.ts
+++ b/src/module/commande-client/routes/commande-client.routes.ts
@@ -18,9 +18,7 @@ import {
   deleteCommande,
   duplicateCommande,
   generateAffairesFromOrder,
-  confirmGenerateAffaires,
   previewAffairesFromCommande,
-  generateAffairesFromCommande,
   getCadreRelease,
   getCommande,
   getCommandeDocumentFile,
@@ -43,8 +41,6 @@ import {
 } from "../validators/commande-ar.validators"
 import {
   createCommandeBodySchema,
-  confirmGenerateAffairesSchema,
-  generateAffairesSchema,
   generateAffairesV3Schema,
   commandeWorkflowCheckpointCodeParamSchema,
   documentIdParamSchema,
@@ -114,6 +110,16 @@ const requireOfficeSupportOrAdmin: RequestHandler = (req, _res, next) => {
     return
   }
   next()
+}
+
+const rejectLegacyCommandeLaunch: RequestHandler = (_req, _res, next) => {
+  next(
+    new HttpError(
+      410,
+      "LEGACY_COMMAND_LAUNCH_REMOVED",
+      "Cet ancien lancement de commande est désactivé. Utilisez Vérifier le stock et lancer."
+    )
+  )
 }
 
 // POST /api/v1/commandes  (multipart: data + documents[])
@@ -200,13 +206,13 @@ router.post("/:id/analyze-stock", authenticateToken, validate(idParamSchema), an
 router.post("/:id/generate-affaires", authenticateToken, validate(generateAffairesV3Schema), generateAffairesFromOrder)
 
 // POST /api/v1/commandes/:id/generate-affaires/confirm
-router.post("/:id/generate-affaires/confirm", authenticateToken, validate(confirmGenerateAffairesSchema), confirmGenerateAffaires)
+router.post("/:id/generate-affaires/confirm", authenticateToken, rejectLegacyCommandeLaunch)
 
 // POST /api/v1/commandes/:id/affaires/preview
 router.post("/:id/affaires/preview", authenticateToken, validate(idParamSchema), previewAffairesFromCommande)
 
 // POST /api/v1/commandes/:id/affaires/generate
-router.post("/:id/affaires/generate", authenticateToken, validate(generateAffairesSchema), generateAffairesFromCommande)
+router.post("/:id/affaires/generate", authenticateToken, rejectLegacyCommandeLaunch)
 
 // POST /api/v1/commandes/:id/duplicate
 router.post("/:id/duplicate", validate(idParamSchema), duplicateCommande)

--- a/src/module/commande-client/workflow/commande-client-workflow.definition.ts
+++ b/src/module/commande-client/workflow/commande-client-workflow.definition.ts
@@ -129,7 +129,7 @@ export const COMMANDE_WORKFLOW_CHECKPOINTS: CommandeWorkflowCheckpointDefinition
     sort_order: 50,
     status_when_done: "ATTENTE_PLANNING",
     action_key: "mark_of_ready",
-    action_label: "Lancement pret",
+    action_label: "Vérifier le stock et lancer",
   },
   {
     code: "planning_validation",

--- a/src/module/facturation/controllers/finance-configuration.controller.ts
+++ b/src/module/facturation/controllers/finance-configuration.controller.ts
@@ -1,0 +1,43 @@
+import type { Request, RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import type { FinanceActorContext } from "../repository/workflow.repository.shared";
+import {
+  svcActivateFinanceConfiguration,
+  svcCreateFinanceSequences,
+  svcGetFinanceConfigurationReadiness,
+} from "../services/finance-configuration.service";
+import {
+  activateFinanceConfigurationBodySchema,
+  createFinanceSequencesBodySchema,
+  financeConfigurationReadinessQuerySchema,
+} from "../validators/finance-configuration.validators";
+
+function actorFromRequest(req: Request): FinanceActorContext {
+  const userId = req.user?.id;
+  if (!Number.isInteger(userId) || !userId || userId <= 0) {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  return { userId, requestId: req.requestId ?? "missing-request-id", path: req.originalUrl.split("?")[0] ?? req.path };
+}
+
+export const getFinanceConfigurationReadiness: RequestHandler = async (req, res, next) => {
+  try {
+    actorFromRequest(req);
+    res.json(await svcGetFinanceConfigurationReadiness(financeConfigurationReadinessQuerySchema.parse(req.query)));
+  } catch (error) { next(error); }
+};
+
+export const activateFinanceConfiguration: RequestHandler = async (req, res, next) => {
+  try {
+    const input = activateFinanceConfigurationBodySchema.parse(req.body);
+    res.status(201).json(await svcActivateFinanceConfiguration({ input, actor: actorFromRequest(req) }));
+  } catch (error) { next(error); }
+};
+
+export const createFinanceSequences: RequestHandler = async (req, res, next) => {
+  try {
+    const input = createFinanceSequencesBodySchema.parse(req.body);
+    res.status(201).json(await svcCreateFinanceSequences({ input, actor: actorFromRequest(req) }));
+  } catch (error) { next(error); }
+};

--- a/src/module/facturation/repository/facture-workflow.repository.ts
+++ b/src/module/facturation/repository/facture-workflow.repository.ts
@@ -3,6 +3,10 @@ import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
 import {
+  listIssuedInvoiceCommandeIds,
+  syncCommandeAfterInvoiceIssue,
+} from "../../commande-client/repository/commande-fulfillment.repository";
+import {
   assertFactureTransition,
   assertSeparationOfDuties,
   financePreviewHash,
@@ -1287,6 +1291,10 @@ export async function repoIssueFacture(params: {
         correlation_id: correlationId,
       },
     });
+    const commandeIds = await listIssuedInvoiceCommandeIds(client, facture.id);
+    for (const commandeId of commandeIds) {
+      await syncCommandeAfterInvoiceIssue(client, commandeId, params.actor.userId);
+    }
     await saveFinanceReceipt({
       client,
       actor: params.actor,

--- a/src/module/facturation/repository/factures.repository.ts
+++ b/src/module/facturation/repository/factures.repository.ts
@@ -93,6 +93,24 @@ function buildListWhere(filters: ListFacturesQueryDTO, includeClientInSearch: bo
     where.push(`f.client_id = ${p}`);
   }
 
+  if (filters.commande_id) {
+    const p = push(filters.commande_id);
+    where.push(`(
+      f.commande_id = ${p}::bigint
+      OR EXISTS (
+        SELECT 1
+        FROM public.facture_source_allocations source
+        JOIN public.bon_livraison_ligne delivery_line
+          ON source.source_type = 'DELIVERY_LINE'
+         AND source.source_line_id = delivery_line.id::text
+        JOIN public.bon_livraison delivery
+          ON delivery.id = delivery_line.bon_livraison_id
+        WHERE source.facture_id = f.id
+          AND delivery.commande_id = ${p}::bigint
+      )
+    )`);
+  }
+
   if (filters.statut && filters.statut.trim().length > 0) {
     const p = push(filters.statut.trim());
     where.push(`f.statut = ${p}`);
@@ -153,6 +171,7 @@ export async function repoListFactures(filters: ListFacturesQueryDTO): Promise<P
       f.id::text AS id,
       f.numero,
       f.client_id,
+      f.commande_id::bigint::int AS commande_id,
       f.date_emission::text AS date_emission,
       f.date_echeance::text AS date_echeance,
       f.total_ht::float8 AS total_ht,

--- a/src/module/facturation/repository/finance-configuration.repository.test.ts
+++ b/src/module/facturation/repository/finance-configuration.repository.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+  release: vi.fn(),
+  connect: vi.fn(),
+  audit: vi.fn(),
+  requireSnapshot: vi.fn(),
+}));
+
+vi.mock("../../../config/database", () => ({
+  default: { connect: mocks.connect, query: vi.fn() },
+}));
+vi.mock("./workflow.repository.shared", () => ({
+  insertGlobalFinanceAudit: mocks.audit,
+  issuerSnapshotAt: vi.fn(),
+  requireFinanceIssuerSnapshotAt: mocks.requireSnapshot,
+}));
+
+import {
+  repoActivateFinanceConfiguration,
+  repoCreateFinanceSequences,
+} from "./finance-configuration.repository";
+
+const input = {
+  confirm: true as const,
+  legal_entity_code: "b7c1e5a2-3f4d-4e8b-9a06-380569012000",
+  policy_version: "finance-2026-v1",
+  effective_from: "2026-01-01",
+  effective_to: null,
+  eligible_delivery_statuses: ["SHIPPED", "DELIVERED"] as ("SHIPPED" | "DELIVERED")[],
+  require_distinct_issuer: true,
+  sequences: { facture: { year: 2026, prefix: "FAC-2026-", next_value: 1, padding: 6 } },
+};
+const actor = { userId: 7, requestId: "request-id", path: "/api/v1/factures/configuration/activate" };
+const sequenceInput = {
+  confirm: true as const,
+  sequences: { avoir: { year: 2027, prefix: "AVO-2027-", next_value: 1, padding: 6 } },
+};
+
+beforeEach(() => {
+  mocks.query.mockReset(); mocks.release.mockReset(); mocks.connect.mockReset(); mocks.audit.mockReset(); mocks.requireSnapshot.mockReset();
+  mocks.connect.mockResolvedValue({ query: mocks.query, release: mocks.release });
+  mocks.requireSnapshot.mockResolvedValue({ company_name: "Issuer" });
+});
+
+describe("repoActivateFinanceConfiguration", () => {
+  it("creates the policy and sequence atomically and records a global audit", async () => {
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // advisory lock
+      .mockResolvedValueOnce({ rows: [{ biller_id: input.legal_entity_code }] })
+      .mockResolvedValueOnce({ rows: [] }) // version
+      .mockResolvedValueOnce({ rows: [] }) // overlap
+      .mockResolvedValueOnce({ rows: [] }) // sequence scope
+      .mockResolvedValueOnce({ rows: [{ id: "policy-id" }] })
+      .mockResolvedValueOnce({ rows: [] }) // sequence insert
+      .mockResolvedValueOnce({ rows: [] }); // commit
+
+    await expect(repoActivateFinanceConfiguration({ input, actor })).resolves.toMatchObject({ id: "policy-id", active: true });
+    expect(mocks.audit).toHaveBeenCalledWith(expect.objectContaining({ entityId: "policy-id", actor }));
+    expect(mocks.query).toHaveBeenLastCalledWith("COMMIT");
+    expect(mocks.release).toHaveBeenCalledOnce();
+  });
+
+  it("rolls back and never audits when an active policy overlaps", async () => {
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ biller_id: input.legal_entity_code }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "other-policy" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(repoActivateFinanceConfiguration({ input, actor })).rejects.toMatchObject({ code: "FINANCE_BILLING_POLICY_OVERLAP" });
+    expect(mocks.audit).not.toHaveBeenCalled();
+    expect(mocks.query).toHaveBeenLastCalledWith("ROLLBACK");
+  });
+
+  it("rolls back if the legal sequence scope already exists", async () => {
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ biller_id: input.legal_entity_code }] })
+      .mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "existing-sequence" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(repoActivateFinanceConfiguration({ input, actor })).rejects.toMatchObject({ code: "FINANCE_LEGAL_SEQUENCE_SCOPE_EXISTS" });
+    expect(mocks.audit).not.toHaveBeenCalled();
+    expect(mocks.query).toHaveBeenLastCalledWith("ROLLBACK");
+  });
+});
+
+describe("repoCreateFinanceSequences", () => {
+  it("creates missing scopes atomically and records a global audit", async () => {
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // advisory lock
+      .mockResolvedValueOnce({ rows: [{ legal_entity_code: input.legal_entity_code, policy_version: input.policy_version }] })
+      .mockResolvedValueOnce({ rows: [] }) // scope
+      .mockResolvedValueOnce({ rows: [] }) // insert
+      .mockResolvedValueOnce({ rows: [] }); // commit
+
+    await expect(repoCreateFinanceSequences({ input: sequenceInput, actor })).resolves.toMatchObject({
+      legal_entity_code: input.legal_entity_code,
+      sequences: [{ document_type: "AVOIR", year: 2027, active: true }],
+    });
+    expect(mocks.audit).toHaveBeenCalledWith(expect.objectContaining({
+      action: "facturation.configuration.sequences_created",
+      entityId: input.legal_entity_code,
+    }));
+    expect(mocks.query).toHaveBeenLastCalledWith("COMMIT");
+  });
+
+  it("rolls back without auditing when a requested scope already exists", async () => {
+    mocks.query
+      .mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ legal_entity_code: input.legal_entity_code, policy_version: input.policy_version }] })
+      .mockResolvedValueOnce({ rows: [{ id: "existing-sequence" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(repoCreateFinanceSequences({ input: sequenceInput, actor })).rejects.toMatchObject({
+      code: "FINANCE_LEGAL_SEQUENCE_SCOPE_EXISTS",
+    });
+    expect(mocks.audit).not.toHaveBeenCalled();
+    expect(mocks.query).toHaveBeenLastCalledWith("ROLLBACK");
+  });
+});

--- a/src/module/facturation/repository/finance-configuration.repository.ts
+++ b/src/module/facturation/repository/finance-configuration.repository.ts
@@ -1,0 +1,275 @@
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import {
+  insertGlobalFinanceAudit,
+  issuerSnapshotAt,
+  requireFinanceIssuerSnapshotAt,
+  type FinanceActorContext,
+} from "./workflow.repository.shared";
+import type {
+  ActivateFinanceConfigurationBodyDTO,
+  CreateFinanceSequencesBodyDTO,
+  FinanceConfigurationReadinessQueryDTO,
+} from "../validators/finance-configuration.validators";
+
+const REQUIRED_LEGAL_KEYS = [
+  "company_name",
+  "legal_mentions_version",
+  "legal_form",
+  "share_capital",
+  "share_capital_currency",
+  "rcs_city",
+  "rcs_number",
+  "siret",
+  "vat_number",
+  "late_penalty_rate",
+  "late_penalty_basis",
+  "recovery_indemnity",
+] as const;
+
+type BillerRow = {
+  biller_id: string;
+  biller_name: string;
+  bank_details_complete: boolean;
+};
+
+function missingLegalKeys(snapshot: Record<string, unknown> | null): string[] {
+  if (!snapshot) return [...REQUIRED_LEGAL_KEYS];
+  return REQUIRED_LEGAL_KEYS.filter((key) => {
+    const value = snapshot[key];
+    return value === null || value === undefined || (typeof value === "string" && !value.trim());
+  });
+}
+
+function sequenceInputRows(input: ActivateFinanceConfigurationBodyDTO) {
+  return [
+    { document_type: "FACTURE" as const, ...input.sequences.facture },
+    ...(input.sequences.avoir ? [{ document_type: "AVOIR" as const, ...input.sequences.avoir }] : []),
+  ];
+}
+
+function isMissingSchemaError(error: unknown): boolean {
+  return typeof error === "object" && error !== null && "code" in error &&
+    ["42P01", "42883"].includes(String((error as { code?: unknown }).code));
+}
+
+export async function repoGetFinanceConfigurationReadiness(
+  query: FinanceConfigurationReadinessQueryDTO
+) {
+  const periodKey = String(query.year ?? new Date().getUTCFullYear());
+  const [billers, policy, sequences] = await Promise.all([
+    pool.query<BillerRow>(
+      `
+        SELECT biller_id::text AS biller_id, biller_name,
+          (NULLIF(trim(COALESCE(default_bank_name, '')), '') IS NOT NULL
+           AND NULLIF(trim(COALESCE(default_iban, '')), '') IS NOT NULL
+           AND NULLIF(trim(COALESCE(default_bic, '')), '') IS NOT NULL) AS bank_details_complete
+        FROM public.factureur
+        ORDER BY biller_name, biller_id
+      `
+    ),
+    pool.query(
+      `SELECT policy_version, legal_entity_code, eligible_delivery_statuses, require_distinct_issuer,
+              effective_from::text AS effective_from, effective_to::text AS effective_to
+       FROM public.finance_billing_policies
+       WHERE active = TRUE AND effective_from <= CURRENT_DATE
+         AND (effective_to IS NULL OR effective_to >= CURRENT_DATE)
+       ORDER BY effective_from DESC, created_at DESC LIMIT 1`
+    ),
+    pool.query(
+      `SELECT document_type, entity_code, period_key, prefix, next_value::text AS next_value,
+              padding, active
+       FROM public.finance_legal_sequences
+       WHERE period_key = $1 AND document_type IN ('FACTURE', 'AVOIR')
+       ORDER BY entity_code, document_type`,
+      [periodKey]
+    ),
+  ]);
+
+  let legalFunctionAvailable = true;
+  const issuers = await Promise.all(
+    billers.rows.map(async (biller) => {
+      let snapshot: Record<string, unknown> | null = null;
+      try {
+        snapshot = await issuerSnapshotAt(pool, biller.biller_id, `${periodKey}-01-01`);
+      } catch (error) {
+        if (!isMissingSchemaError(error)) throw error;
+        legalFunctionAvailable = false;
+      }
+      const missing_legal_fields = missingLegalKeys(snapshot);
+      return {
+        legal_entity_code: biller.biller_id,
+        name: biller.biller_name,
+        bank_details_complete: biller.bank_details_complete,
+        legal_snapshot_complete: missing_legal_fields.length === 0,
+        missing_legal_fields,
+      };
+    })
+  );
+
+  const activePolicy = policy.rows[0] ?? null;
+  const blockers: Array<{ code: string; message: string }> = [];
+  const warnings: Array<{ code: string; message: string }> = [];
+  if (!issuers.length) blockers.push({ code: "FINANCE_ISSUER_NOT_CONFIGURED", message: "Aucun émetteur Finance n'est configuré." });
+  if (!legalFunctionAvailable) blockers.push({ code: "FINANCE_LEGAL_MENTIONS_NOT_CONFIGURED", message: "Le référentiel des mentions légales Finance est indisponible." });
+  if (!activePolicy && issuers.some((issuer) => !issuer.legal_snapshot_complete)) warnings.push({ code: "FINANCE_LEGAL_MENTIONS_NOT_CONFIGURED", message: "Un ou plusieurs émetteurs ont des mentions légales obligatoires incomplètes." });
+  if (issuers.some((issuer) => !issuer.bank_details_complete)) warnings.push({ code: "FINANCE_ISSUER_BANK_DETAILS_INCOMPLETE", message: "Au moins un émetteur ne possède pas toutes ses coordonnées bancaires." });
+  if (!activePolicy) blockers.push({ code: "FINANCE_BILLING_POLICY_NOT_CONFIGURED", message: "Aucune politique de facturation active n'est applicable aujourd'hui." });
+  if (activePolicy) {
+    const activeIssuer = issuers.find((issuer) => issuer.legal_entity_code === activePolicy.legal_entity_code);
+    if (!activeIssuer?.legal_snapshot_complete) blockers.push({ code: "FINANCE_LEGAL_MENTIONS_NOT_CONFIGURED", message: "Les mentions légales de l'émetteur sélectionné par la politique active sont incomplètes." });
+  }
+  if (activePolicy && !sequences.rows.some((sequence) => sequence.document_type === "FACTURE" && sequence.entity_code === activePolicy.legal_entity_code && sequence.active)) {
+    blockers.push({ code: "FINANCE_LEGAL_SEQUENCE_NOT_CONFIGURED", message: "La séquence FACTURE active de l'émetteur sélectionné est absente pour cette année." });
+  }
+  if (activePolicy && !sequences.rows.some((sequence) => sequence.document_type === "AVOIR" && sequence.entity_code === activePolicy.legal_entity_code && sequence.active)) {
+    warnings.push({ code: "FINANCE_AVOIR_SEQUENCE_NOT_CONFIGURED", message: "La séquence AVOIR est optionnelle mais absente pour cette année." });
+  }
+  return {
+    current_year: Number(periodKey),
+    issuers,
+    active_policy: activePolicy,
+    sequences: sequences.rows,
+    readiness: { ready: blockers.length === 0, blockers, warnings },
+  };
+}
+
+async function assertIssuerExists(client: PoolClient, legalEntityCode: string): Promise<void> {
+  const issuer = await client.query(
+    "SELECT biller_id FROM public.factureur WHERE biller_id::text = $1 FOR KEY SHARE",
+    [legalEntityCode]
+  );
+  if (!issuer.rows[0]) throw new HttpError(409, "FINANCE_ISSUER_NOT_CONFIGURED", "L'émetteur légal sélectionné est introuvable.");
+}
+
+export async function repoActivateFinanceConfiguration(params: {
+  input: ActivateFinanceConfigurationBodyDTO;
+  actor: FinanceActorContext;
+}) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    // Serializes all activations so no active date range can appear between check and insert.
+    await client.query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", ["finance:billing-policy:activation"]);
+    await assertIssuerExists(client, params.input.legal_entity_code);
+    await requireFinanceIssuerSnapshotAt(client, params.input.legal_entity_code, params.input.effective_from);
+
+    const duplicateVersion = await client.query(
+      "SELECT id FROM public.finance_billing_policies WHERE policy_version = $1 FOR UPDATE",
+      [params.input.policy_version]
+    );
+    if (duplicateVersion.rows[0]) throw new HttpError(409, "FINANCE_POLICY_VERSION_EXISTS", "Cette version de politique existe déjà.");
+    const overlap = await client.query(
+      `SELECT id FROM public.finance_billing_policies
+       WHERE active = TRUE
+         AND effective_from <= COALESCE($1::date, 'infinity'::date)
+         AND COALESCE(effective_to, 'infinity'::date) >= $2::date
+       FOR UPDATE`,
+      [params.input.effective_to ?? null, params.input.effective_from]
+    );
+    if (overlap.rows[0]) throw new HttpError(409, "FINANCE_BILLING_POLICY_OVERLAP", "Une politique Finance active couvre déjà cette période.");
+
+    const sequenceRows = sequenceInputRows(params.input);
+    for (const sequence of sequenceRows) {
+      const existing = await client.query(
+        `SELECT id FROM public.finance_legal_sequences
+         WHERE document_type = $1 AND entity_code = $2 AND period_key = $3 FOR UPDATE`,
+        [sequence.document_type, params.input.legal_entity_code, String(sequence.year)]
+      );
+      if (existing.rows[0]) {
+        throw new HttpError(409, "FINANCE_LEGAL_SEQUENCE_SCOPE_EXISTS", `La séquence ${sequence.document_type} existe déjà pour ce périmètre.`);
+      }
+    }
+
+    const createdPolicy = await client.query<{ id: string }>(
+      `INSERT INTO public.finance_billing_policies (
+         policy_version, legal_entity_code, eligible_delivery_statuses, require_distinct_issuer,
+         active, effective_from, effective_to, created_by
+       ) VALUES ($1,$2,$3::text[],$4,TRUE,$5::date,$6::date,$7) RETURNING id::text AS id`,
+      [params.input.policy_version, params.input.legal_entity_code, params.input.eligible_delivery_statuses,
+        params.input.require_distinct_issuer, params.input.effective_from, params.input.effective_to ?? null, params.actor.userId]
+    );
+    const policyId = createdPolicy.rows[0]?.id;
+    if (!policyId) throw new Error("Finance billing policy creation failed");
+    for (const sequence of sequenceRows) {
+      await client.query(
+        `INSERT INTO public.finance_legal_sequences
+          (document_type, entity_code, period_key, prefix, next_value, padding, active)
+         VALUES ($1,$2,$3,$4,$5,$6,TRUE)`,
+        [sequence.document_type, params.input.legal_entity_code, String(sequence.year), sequence.prefix,
+          sequence.next_value, sequence.padding]
+      );
+    }
+    await insertGlobalFinanceAudit({
+      client, actor: params.actor, action: "facturation.configuration.activated",
+      entityType: "finance_billing_policy", entityId: policyId,
+      details: {
+        policy_version: params.input.policy_version,
+        legal_entity_code: params.input.legal_entity_code,
+        effective_from: params.input.effective_from,
+        effective_to: params.input.effective_to ?? null,
+        eligible_delivery_statuses: params.input.eligible_delivery_statuses,
+        require_distinct_issuer: params.input.require_distinct_issuer,
+        sequences: sequenceRows.map((sequence) => ({ document_type: sequence.document_type, year: sequence.year, prefix: sequence.prefix, next_value: sequence.next_value, padding: sequence.padding })),
+      },
+    });
+    await client.query("COMMIT");
+    return { id: policyId, policy_version: params.input.policy_version, legal_entity_code: params.input.legal_entity_code, active: true, sequences: sequenceRows.map(({ document_type, year }) => ({ document_type, year, active: true })) };
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoCreateFinanceSequences(params: {
+  input: CreateFinanceSequencesBodyDTO;
+  actor: FinanceActorContext;
+}) {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", ["finance:legal-sequence:creation"]);
+    const policy = await client.query<{ legal_entity_code: string; policy_version: string }>(
+      `SELECT legal_entity_code, policy_version FROM public.finance_billing_policies
+       WHERE active = TRUE AND effective_from <= CURRENT_DATE
+         AND (effective_to IS NULL OR effective_to >= CURRENT_DATE)
+       ORDER BY effective_from DESC, created_at DESC LIMIT 1 FOR UPDATE`
+    );
+    const activePolicy = policy.rows[0];
+    if (!activePolicy) throw new HttpError(409, "FINANCE_BILLING_POLICY_NOT_CONFIGURED", "Une politique Finance active est requise pour créer une séquence.");
+    const rows = [
+      ...(params.input.sequences.facture ? [{ document_type: "FACTURE" as const, ...params.input.sequences.facture }] : []),
+      ...(params.input.sequences.avoir ? [{ document_type: "AVOIR" as const, ...params.input.sequences.avoir }] : []),
+    ];
+    for (const sequence of rows) {
+      const existing = await client.query(
+        `SELECT id FROM public.finance_legal_sequences
+         WHERE document_type = $1 AND entity_code = $2 AND period_key = $3 FOR UPDATE`,
+        [sequence.document_type, activePolicy.legal_entity_code, String(sequence.year)]
+      );
+      if (existing.rows[0]) throw new HttpError(409, "FINANCE_LEGAL_SEQUENCE_SCOPE_EXISTS", `La séquence ${sequence.document_type} existe déjà pour ce périmètre.`);
+    }
+    for (const sequence of rows) {
+      await client.query(
+        `INSERT INTO public.finance_legal_sequences
+          (document_type, entity_code, period_key, prefix, next_value, padding, active)
+         VALUES ($1,$2,$3,$4,$5,$6,TRUE)`,
+        [sequence.document_type, activePolicy.legal_entity_code, String(sequence.year), sequence.prefix, sequence.next_value, sequence.padding]
+      );
+    }
+    await insertGlobalFinanceAudit({
+      client, actor: params.actor, action: "facturation.configuration.sequences_created",
+      entityType: "finance_legal_sequence", entityId: activePolicy.legal_entity_code,
+      details: { policy_version: activePolicy.policy_version, sequences: rows.map((row) => ({ document_type: row.document_type, year: row.year, prefix: row.prefix, next_value: row.next_value, padding: row.padding })) },
+    });
+    await client.query("COMMIT");
+    return { legal_entity_code: activePolicy.legal_entity_code, sequences: rows.map(({ document_type, year }) => ({ document_type, year, active: true })) };
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally { client.release(); }
+}

--- a/src/module/facturation/routes/factures.routes.ts
+++ b/src/module/facturation/routes/factures.routes.ts
@@ -17,6 +17,11 @@ import {
   validateFactureWorkflow,
 } from "../controllers/facture-workflow.controller";
 import { requireFinanceCapability } from "../middlewares/finance-authorization.middleware";
+import {
+  activateFinanceConfiguration,
+  createFinanceSequences,
+  getFinanceConfigurationReadiness,
+} from "../controllers/finance-configuration.controller";
 
 const router = Router();
 
@@ -38,6 +43,23 @@ router.post(
   validateFactureWorkflow
 );
 router.post("/workflow/:id/issue", requireFinanceCapability("issue"), issueFactureWorkflow);
+
+// Must precede `/:id`: configuration is a Finance settings resource, not a legacy invoice id.
+router.get(
+  "/configuration",
+  requireFinanceCapability("settings_manage"),
+  getFinanceConfigurationReadiness
+);
+router.post(
+  "/configuration/activate",
+  requireFinanceCapability("settings_manage"),
+  activateFinanceConfiguration
+);
+router.post(
+  "/configuration/sequences",
+  requireFinanceCapability("settings_manage"),
+  createFinanceSequences
+);
 
 router.get("/", requireFinanceCapability("read"), listFactures);
 router.get("/:id", requireFinanceCapability("read"), getFacture);

--- a/src/module/facturation/services/finance-configuration.service.ts
+++ b/src/module/facturation/services/finance-configuration.service.ts
@@ -1,0 +1,24 @@
+import {
+  repoActivateFinanceConfiguration,
+  repoCreateFinanceSequences,
+  repoGetFinanceConfigurationReadiness,
+} from "../repository/finance-configuration.repository";
+import type { FinanceActorContext } from "../repository/workflow.repository.shared";
+import type {
+  ActivateFinanceConfigurationBodyDTO,
+  CreateFinanceSequencesBodyDTO,
+  FinanceConfigurationReadinessQueryDTO,
+} from "../validators/finance-configuration.validators";
+
+export const svcGetFinanceConfigurationReadiness = (query: FinanceConfigurationReadinessQueryDTO) =>
+  repoGetFinanceConfigurationReadiness(query);
+
+export const svcActivateFinanceConfiguration = (params: {
+  input: ActivateFinanceConfigurationBodyDTO;
+  actor: FinanceActorContext;
+}) => repoActivateFinanceConfiguration(params);
+
+export const svcCreateFinanceSequences = (params: {
+  input: CreateFinanceSequencesBodyDTO;
+  actor: FinanceActorContext;
+}) => repoCreateFinanceSequences(params);

--- a/src/module/facturation/types/factures.types.ts
+++ b/src/module/facturation/types/factures.types.ts
@@ -70,6 +70,7 @@ export type FactureListItem = {
   id: number;
   numero: string;
   client_id: string;
+  commande_id: number | null;
   date_emission: string;
   date_echeance: string | null;
   total_ht: number;

--- a/src/module/facturation/validators/factures.validators.ts
+++ b/src/module/facturation/validators/factures.validators.ts
@@ -19,6 +19,7 @@ export const factureIdParamsSchema = z.object({
 export const listFacturesQuerySchema = z.object({
   q: z.string().optional(),
   client_id: z.string().optional(),
+  commande_id: z.coerce.number().int().positive().optional(),
   statut: z.string().optional(),
   from: isoDate.optional(),
   to: isoDate.optional(),

--- a/src/module/facturation/validators/finance-configuration.validators.test.ts
+++ b/src/module/facturation/validators/finance-configuration.validators.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { activateFinanceConfigurationBodySchema } from "./finance-configuration.validators";
+
+const validCommand = {
+  confirm: true,
+  legal_entity_code: "b7c1e5a2-3f4d-4e8b-9a06-380569012000",
+  policy_version: "finance-2026-v1",
+  effective_from: "2026-01-01",
+  effective_to: null,
+  eligible_delivery_statuses: ["SHIPPED", "DELIVERED"],
+  require_distinct_issuer: true,
+  sequences: {
+    facture: { year: 2026, prefix: "FAC-2026-", next_value: 1, padding: 6 },
+  },
+};
+
+describe("activateFinanceConfigurationBodySchema", () => {
+  it("accepts a confirmed command with the mandatory FACTURE sequence", () => {
+    expect(activateFinanceConfigurationBodySchema.parse(validCommand)).toMatchObject(validCommand);
+  });
+
+  it("refuses a command that has not been explicitly confirmed", () => {
+    expect(activateFinanceConfigurationBodySchema.safeParse({ ...validCommand, confirm: false }).success).toBe(false);
+  });
+
+  it("refuses statuses outside SHIPPED and DELIVERED", () => {
+    expect(activateFinanceConfigurationBodySchema.safeParse({
+      ...validCommand,
+      eligible_delivery_statuses: ["PREPARED"],
+    }).success).toBe(false);
+  });
+
+  it("refuses a sequence reset or unsafe next value", () => {
+    expect(activateFinanceConfigurationBodySchema.safeParse({
+      ...validCommand,
+      sequences: { facture: { ...validCommand.sequences.facture, next_value: 0 } },
+    }).success).toBe(false);
+  });
+
+  it("refuses spaces and control characters in policy versions and prefixes", () => {
+    expect(activateFinanceConfigurationBodySchema.safeParse({ ...validCommand, policy_version: "finance 2026" }).success).toBe(false);
+    expect(activateFinanceConfigurationBodySchema.safeParse({
+      ...validCommand,
+      sequences: { facture: { ...validCommand.sequences.facture, prefix: "FAC 2026" } },
+    }).success).toBe(false);
+  });
+});

--- a/src/module/facturation/validators/finance-configuration.validators.ts
+++ b/src/module/facturation/validators/finance-configuration.validators.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date attendue au format YYYY-MM-DD");
+const year = z.coerce.number().int().min(2000).max(2200);
+const safeIdentifier = (label: string, min: number, max: number) =>
+  z.string().trim().min(min).max(max).regex(/^[A-Za-z0-9._/-]+$/, `${label} ne peut contenir que lettres, chiffres, ., _, / et -.`);
+
+const sequenceSchema = z
+  .object({
+    year,
+    prefix: safeIdentifier("Le préfixe", 1, 60),
+    next_value: z.coerce.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+    padding: z.coerce.number().int().min(1).max(12),
+  })
+  .strict();
+
+export const financeConfigurationReadinessQuerySchema = z
+  .object({ year: year.optional() })
+  .strict();
+
+export type FinanceConfigurationReadinessQueryDTO = z.infer<
+  typeof financeConfigurationReadinessQuerySchema
+>;
+
+export const activateFinanceConfigurationBodySchema = z
+  .object({
+    confirm: z.literal(true),
+    legal_entity_code: z.string().uuid(),
+    policy_version: safeIdentifier("La version de politique", 3, 80),
+    effective_from: isoDate,
+    effective_to: isoDate.optional().nullable(),
+    eligible_delivery_statuses: z
+      .array(z.enum(["SHIPPED", "DELIVERED"]))
+      .min(1)
+      .max(2)
+      .refine((values) => new Set(values).size === values.length, "Statuts dupliqués interdits."),
+    // Historical column name retained: this controls creator/validator separation of duties.
+    require_distinct_issuer: z.boolean().default(true),
+    sequences: z
+      .object({
+        facture: sequenceSchema,
+        avoir: sequenceSchema.optional(),
+      })
+      .strict(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (value.effective_to && value.effective_to < value.effective_from) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["effective_to"],
+        message: "La date de fin doit être postérieure ou égale à la date de début.",
+      });
+    }
+  });
+
+export type ActivateFinanceConfigurationBodyDTO = z.infer<
+  typeof activateFinanceConfigurationBodySchema
+>;
+
+export const createFinanceSequencesBodySchema = z
+  .object({
+    confirm: z.literal(true),
+    sequences: z.object({ facture: sequenceSchema.optional(), avoir: sequenceSchema.optional() }).strict(),
+  })
+  .strict()
+  .superRefine((value, context) => {
+    if (!value.sequences.facture && !value.sequences.avoir) {
+      context.addIssue({ code: z.ZodIssueCode.custom, path: ["sequences"], message: "Au moins une séquence est requise." });
+    }
+  });
+
+export type CreateFinanceSequencesBodyDTO = z.infer<typeof createFinanceSequencesBodySchema>;

--- a/src/module/livraisons/repository/livraisons-shipment.repository.test.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.test.ts
@@ -1,0 +1,193 @@
+import type { PoolClient } from "pg";
+import { describe, expect, it, vi } from "vitest";
+
+import { prepareLivraisonInTransaction } from "./livraisons-shipment.repository";
+import { attachActiveCommandeReservationsToLivraison } from "./livraisons.repository";
+
+describe("prepareLivraisonInTransaction", () => {
+  it("reuses an active production reservation without reserving stock twice", async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("FROM public.bon_livraison\n")) {
+        return {
+          rows: [{
+            id: "44444444-4444-4444-8444-444444444444",
+            numero: "BL-00000001",
+            statut: "DRAFT",
+            row_version: 1,
+            commande_id: "12",
+            affaire_id: "7",
+          }],
+        };
+      }
+      if (sql.includes("remainder.quantite_commandee::float8")) {
+        return {
+          rows: [{
+            id: "55555555-5555-4555-8555-555555555555",
+            ordre: 1,
+            quantite: 2,
+            commande_ligne_id: 91,
+            quantite_commandee: 2,
+            quantite_expediee: 0,
+            quantite_restante: 2,
+          }],
+        };
+      }
+      if (sql.includes("FROM public.bon_livraison_ligne_allocations allocation")) {
+        return {
+          rows: [{
+            id: "66666666-6666-4666-8666-666666666666",
+            bon_livraison_ligne_id: "55555555-5555-4555-8555-555555555555",
+            line_order: 1,
+            line_quantity: 2,
+            article_id: "11111111-1111-4111-8111-111111111111",
+            lot_id: "22222222-2222-4222-8222-222222222222",
+            lot_article_id: "11111111-1111-4111-8111-111111111111",
+            lot_status: "LIBERE",
+            magasin_id: "33333333-3333-4333-8333-333333333333",
+            emplacement_id: 4,
+            location_id: "77777777-7777-4777-8777-777777777777",
+            stock_level_id: "88888888-8888-4888-8888-888888888888",
+            stock_batch_id: "99999999-9999-4999-8999-999999999999",
+            reservation_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            reservation_status: "ACTIVE",
+            reservation_quantity: 2,
+            stock_movement_line_id: null,
+            quantite: 2,
+            unite: "u",
+            qty_on_hand: 2,
+            qty_reserved: 2,
+            qty_depreciated: 0,
+          }],
+        };
+      }
+      if (sql.includes("FROM public.bon_livraison_pack_versions")) return { rows: [] };
+      return { rows: [] };
+    });
+    const client = { query } as unknown as PoolClient;
+
+    await expect(
+      prepareLivraisonInTransaction(
+        client,
+        "44444444-4444-4444-8444-444444444444",
+        7
+      )
+    ).resolves.toBeUndefined();
+
+    expect(
+      query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO public.stock_reservations"))
+    ).toBe(false);
+    expect(
+      query.mock.calls.some(([sql]) =>
+        String(sql).includes("SET qty_reserved = qty_reserved +"))
+    ).toBe(false);
+    expect(
+      query.mock.calls.some(([sql]) =>
+        String(sql).includes("source_type = 'BON_LIVRAISON_LIGNE'"))
+    ).toBe(true);
+    expect(
+      query.mock.calls.some(([sql]) =>
+        String(sql).includes("SET statut = 'READY'"))
+    ).toBe(true);
+  });
+});
+
+describe("attachActiveCommandeReservationsToLivraison", () => {
+  it("transfers a produced order-line reservation to the delivery allocation", async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("reservation.source_type = 'COMMANDE_LIGNE'")) {
+        return {
+          rows: [{
+            line_id: "55555555-5555-4555-8555-555555555555",
+            commande_ligne_id: 91,
+            line_quantity: 2,
+            affaire_id: 7,
+            reservation_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+            reservation_quantity: 2,
+            article_id: "11111111-1111-4111-8111-111111111111",
+            lot_id: "22222222-2222-4222-8222-222222222222",
+            location_id: "77777777-7777-4777-8777-777777777777",
+            stock_level_id: "88888888-8888-4888-8888-888888888888",
+            stock_batch_id: "99999999-9999-4999-8999-999999999999",
+            magasin_id: "33333333-3333-4333-8333-333333333333",
+            emplacement_id: 4,
+            unite: "u",
+          }],
+        };
+      }
+      if (sql.includes("SELECT NOT EXISTS(")) return { rows: [{ complete: true }] };
+      return { rows: [] };
+    });
+    const client = { query } as unknown as PoolClient;
+
+    await expect(
+      attachActiveCommandeReservationsToLivraison(
+        client,
+        "44444444-4444-4444-8444-444444444444",
+        7
+      )
+    ).resolves.toEqual({ attached: 1, fullyAllocated: true });
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("source_type = 'BON_LIVRAISON_LIGNE'"),
+      [
+        "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "55555555-5555-4555-8555-555555555555",
+        7,
+        "44444444-4444-4444-8444-444444444444",
+        7,
+      ]
+    );
+    expect(
+      query.mock.calls.some(([sql]) =>
+        String(sql).includes("INSERT INTO public.bon_livraison_ligne_allocations"))
+    ).toBe(true);
+    expect(
+      query.mock.calls.some(([sql]) =>
+        String(sql).includes("UPDATE public.stock_levels"))
+    ).toBe(false);
+  });
+
+  it("never allocates the same order reservation to duplicate delivery lines", async () => {
+    const sharedReservation = {
+      commande_ligne_id: 91,
+      line_quantity: 2,
+      affaire_id: 7,
+      reservation_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      reservation_quantity: 2,
+      article_id: "11111111-1111-4111-8111-111111111111",
+      lot_id: "22222222-2222-4222-8222-222222222222",
+      location_id: "77777777-7777-4777-8777-777777777777",
+      stock_level_id: "88888888-8888-4888-8888-888888888888",
+      stock_batch_id: "99999999-9999-4999-8999-999999999999",
+      magasin_id: "33333333-3333-4333-8333-333333333333",
+      emplacement_id: 4,
+      unite: "u",
+    };
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("reservation.source_type = 'COMMANDE_LIGNE'")) {
+        return {
+          rows: [
+            { ...sharedReservation, line_id: "55555555-5555-4555-8555-555555555555" },
+            { ...sharedReservation, line_id: "66666666-6666-4666-8666-666666666666" },
+          ],
+        };
+      }
+      if (sql.includes("SELECT NOT EXISTS(")) return { rows: [{ complete: false }] };
+      return { rows: [] };
+    });
+    const client = { query } as unknown as PoolClient;
+
+    await expect(
+      attachActiveCommandeReservationsToLivraison(
+        client,
+        "44444444-4444-4444-8444-444444444444",
+        7
+      )
+    ).resolves.toEqual({ attached: 1, fullyAllocated: false });
+
+    const allocationInserts = query.mock.calls.filter(([sql]) =>
+      String(sql).includes("INSERT INTO public.bon_livraison_ligne_allocations")
+    );
+    expect(allocationInserts).toHaveLength(1);
+  });
+});

--- a/src/module/livraisons/repository/livraisons-shipment.repository.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.ts
@@ -4,6 +4,7 @@ import type { PoolClient } from "pg"
 import pool from "../../../config/database"
 import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
+import { syncCommandeAfterShipment } from "../../commande-client/repository/commande-fulfillment.repository"
 import { hashStockCommand, normalizeIdempotencyKey } from "../../stock/domain/stock-command"
 import {
   assertStockConsumptionAllowed,
@@ -544,9 +545,13 @@ export async function prepareLivraisonInTransaction(
     header: { ...snapshot.header, statut: "READY" },
     allocations: snapshot.allocations.map((allocation) => ({
       ...allocation,
-      reservation_id: crypto.randomUUID(),
-      reservation_status: "ACTIVE",
-      reservation_quantity: allocation.quantite,
+      reservation_id: allocation.reservation_id ?? crypto.randomUUID(),
+      reservation_status: allocation.reservation_id
+        ? allocation.reservation_status
+        : "ACTIVE",
+      reservation_quantity: allocation.reservation_id
+        ? allocation.reservation_quantity
+        : allocation.quantite,
     })),
   })
   const relevantBlockers = draftPreview.blockers.filter(
@@ -563,7 +568,11 @@ export async function prepareLivraisonInTransaction(
     )
   }
 
-  const groups = buildGroups(snapshot.allocations)
+  const allocationsToReserve = snapshot.allocations.filter(
+    (allocation) =>
+      !allocation.reservation_id || allocation.reservation_status !== "ACTIVE"
+  )
+  const groups = buildGroups(allocationsToReserve)
   const targets: StockLockTarget[] = groups.map((group) => ({
     stock_level_id: group.stock_level_id,
     stock_batch_id: group.stock_batch_id,
@@ -665,6 +674,30 @@ export async function prepareLivraisonInTransaction(
 
   await client.query(
     `
+      UPDATE public.stock_reservations reservation
+      SET source_type = 'BON_LIVRAISON_LIGNE',
+          source_id = allocation.bon_livraison_ligne_id::text,
+          commande_ligne_id = line.commande_ligne_id,
+          bon_livraison_ligne_id = allocation.bon_livraison_ligne_id,
+          affaire_id = delivery.affaire_id,
+          reason = 'Préparation du bon de livraison ' || delivery.numero,
+          correlation_id = COALESCE(reservation.correlation_id, $2::uuid),
+          updated_at = now(),
+          updated_by = $3
+      FROM public.bon_livraison_ligne_allocations allocation
+      JOIN public.bon_livraison_ligne line
+        ON line.id = allocation.bon_livraison_ligne_id
+      JOIN public.bon_livraison delivery
+        ON delivery.id = line.bon_livraison_id
+      WHERE delivery.id = $1::uuid
+        AND allocation.reservation_id = reservation.id
+        AND reservation.status = 'ACTIVE'
+    `,
+    [bonLivraisonId, correlationId, userId]
+  )
+
+  await client.query(
+    `
       UPDATE public.bon_livraison
       SET statut = 'READY',
           updated_at = now(),
@@ -681,6 +714,7 @@ export async function prepareLivraisonInTransaction(
     new_values: {
       statut: "READY",
       reservations_count: snapshot.allocations.length,
+      reservations_reused: snapshot.allocations.length - allocationsToReserve.length,
       correlation_id: correlationId,
     },
   })
@@ -1133,6 +1167,13 @@ export async function repoShipLivraison(
       browser: null,
       tx: client,
     })
+
+    const commandeId = snapshot.header.commande_id === null
+      ? null
+      : Number(snapshot.header.commande_id)
+    if (commandeId !== null && Number.isInteger(commandeId)) {
+      await syncCommandeAfterShipment(client, commandeId, userId)
+    }
 
     const result: BonLivraisonShipResult = {
       id: bonLivraisonId,

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -401,6 +401,11 @@ function buildListWhere(filters: ListLivraisonsQueryDTO): ListWhere {
     where.push(`bl.client_id = ${p}`)
   }
 
+  if (filters.commande_id) {
+    const p = push(filters.commande_id)
+    where.push(`bl.commande_id = ${p}::bigint`)
+  }
+
   if (filters.statut) {
     const p = push(filters.statut)
     where.push(`bl.statut = ${p}`)
@@ -2280,6 +2285,211 @@ export async function repoUpdateLivraisonStatus(
   } finally {
     db.release()
   }
+
+}
+
+export async function attachActiveCommandeReservationsToLivraison(
+  db: PoolClient,
+  bonLivraisonId: string,
+  userId: number
+): Promise<{ attached: number; fullyAllocated: boolean }> {
+  const reservations = await db.query<{
+    line_id: string
+    commande_ligne_id: number
+    line_quantity: number
+    affaire_id: number | null
+    reservation_id: string
+    reservation_quantity: number
+    article_id: string
+    lot_id: string | null
+    location_id: string
+    stock_level_id: string
+    stock_batch_id: string | null
+    magasin_id: string | null
+    emplacement_id: number | null
+    unite: string | null
+  }>(
+    `
+      SELECT
+        delivery_line.id::text AS line_id,
+        delivery_line.commande_ligne_id::bigint::int AS commande_ligne_id,
+        delivery_line.quantite::float8 AS line_quantity,
+        delivery.affaire_id::bigint::int AS affaire_id,
+        reservation.id::text AS reservation_id,
+        reservation.qty_reserved::float8 AS reservation_quantity,
+        reservation.article_id::text AS article_id,
+        reservation.lot_id::text AS lot_id,
+        reservation.location_id::text AS location_id,
+        level.id::text AS stock_level_id,
+        reservation.stock_batch_id::text AS stock_batch_id,
+        location_map.magasin_id::text AS magasin_id,
+        location_map.emplacement_id::bigint::int AS emplacement_id,
+        article.unite
+      FROM public.bon_livraison_ligne delivery_line
+      JOIN public.bon_livraison delivery
+        ON delivery.id = delivery_line.bon_livraison_id
+      JOIN public.stock_reservations reservation
+        ON reservation.commande_ligne_id = delivery_line.commande_ligne_id
+       AND reservation.source_type = 'COMMANDE_LIGNE'
+       AND reservation.status = 'ACTIVE'
+      JOIN public.stock_levels level
+        ON level.article_id = reservation.article_id
+       AND level.location_id = reservation.location_id
+      JOIN public.articles article ON article.id = reservation.article_id
+      LEFT JOIN LATERAL (
+        SELECT
+          emplacement.magasin_id,
+          emplacement.id AS emplacement_id
+        FROM public.emplacements emplacement
+        WHERE emplacement.location_id = reservation.location_id
+        ORDER BY emplacement.id
+        LIMIT 1
+      ) location_map ON TRUE
+      WHERE delivery.id = $1::uuid
+        AND delivery_line.commande_ligne_id IS NOT NULL
+      ORDER BY delivery_line.ordre, reservation.created_at, reservation.id
+      FOR UPDATE OF delivery_line, reservation, level
+    `,
+    [bonLivraisonId]
+  )
+
+  const remainingByLine = new Map<string, number>()
+  const consumedReservationIds = new Set<string>()
+  let attached = 0
+  for (const reservation of reservations.rows) {
+    // A reservation can appear more than once if a malformed BL contains
+    // duplicate lines for the same order line. Never allocate the same locked
+    // reservation snapshot twice; leave the duplicate line visibly uncovered.
+    if (consumedReservationIds.has(reservation.reservation_id)) continue
+    consumedReservationIds.add(reservation.reservation_id)
+    const remaining = remainingByLine.has(reservation.line_id)
+      ? Number(remainingByLine.get(reservation.line_id))
+      : Number(reservation.line_quantity)
+    if (remaining <= 1e-9) continue
+    if (!reservation.magasin_id || reservation.emplacement_id === null) {
+      throw new HttpError(
+        409,
+        "RESERVED_STOCK_LOCATION_INVALID",
+        "L'emplacement du stock réservé ne peut pas être rattaché au bon de livraison."
+      )
+    }
+
+    const quantity = Math.min(remaining, Number(reservation.reservation_quantity))
+    if (quantity <= 1e-9) continue
+    let reservationId = reservation.reservation_id
+
+    if (quantity + 1e-9 < Number(reservation.reservation_quantity)) {
+      await db.query(
+        `
+          UPDATE public.stock_reservations
+          SET qty_reserved = qty_reserved - $2,
+              row_version = row_version + 1,
+              updated_at = now(),
+              updated_by = $3
+          WHERE id = $1::uuid
+            AND status = 'ACTIVE'
+        `,
+        [reservation.reservation_id, quantity, userId]
+      )
+      const split = await db.query<{ id: string }>(
+        `
+          INSERT INTO public.stock_reservations (
+            article_id, location_id, qty_reserved, source_type, source_id, status,
+            lot_id, stock_batch_id, correlation_id, commande_ligne_id, of_id,
+            bon_livraison_ligne_id, affaire_id, reason, created_by, updated_by
+          )
+          SELECT
+            article_id, location_id, $2, 'BON_LIVRAISON_LIGNE', $3, 'ACTIVE',
+            lot_id, stock_batch_id, correlation_id, commande_ligne_id, of_id,
+            $3::uuid, $4::bigint, 'Affectée au bon de livraison ' || $5, $6, $6
+          FROM public.stock_reservations
+          WHERE id = $1::uuid
+          RETURNING id::text AS id
+        `,
+        [
+          reservation.reservation_id,
+          quantity,
+          reservation.line_id,
+          reservation.affaire_id,
+          bonLivraisonId,
+          userId,
+        ]
+      )
+      reservationId = split.rows[0]?.id ?? ""
+      if (!reservationId) throw new Error("Failed to split the order-line stock reservation")
+    } else {
+      await db.query(
+        `
+          UPDATE public.stock_reservations
+          SET source_type = 'BON_LIVRAISON_LIGNE',
+              source_id = $2,
+              bon_livraison_ligne_id = $2::uuid,
+              affaire_id = $3::bigint,
+              reason = 'Affectée au bon de livraison ' || $4,
+              row_version = row_version + 1,
+              updated_at = now(),
+              updated_by = $5
+          WHERE id = $1::uuid
+            AND status = 'ACTIVE'
+        `,
+        [
+          reservation.reservation_id,
+          reservation.line_id,
+          reservation.affaire_id,
+          bonLivraisonId,
+          userId,
+        ]
+      )
+    }
+
+    await db.query(
+      `
+        INSERT INTO public.bon_livraison_ligne_allocations (
+          bon_livraison_ligne_id, article_id, lot_id, magasin_id,
+          emplacement_id, location_id, stock_level_id, stock_batch_id,
+          reservation_id, stock_movement_line_id, quantite, unite,
+          created_by, updated_by
+        ) VALUES (
+          $1::uuid,$2::uuid,$3::uuid,$4::uuid,$5::bigint,$6::uuid,$7::uuid,$8::uuid,
+          $9::uuid,NULL,$10,$11,$12,$12
+        )
+      `,
+      [
+        reservation.line_id,
+        reservation.article_id,
+        reservation.lot_id,
+        reservation.magasin_id,
+        reservation.emplacement_id,
+        reservation.location_id,
+        reservation.stock_level_id,
+        reservation.stock_batch_id,
+        reservationId,
+        quantity,
+        reservation.unite,
+        userId,
+      ]
+    )
+    remainingByLine.set(reservation.line_id, remaining - quantity)
+    attached += 1
+  }
+
+  const coverage = await db.query<{ complete: boolean }>(
+    `
+      SELECT NOT EXISTS(
+        SELECT 1
+        FROM public.bon_livraison_ligne line
+        LEFT JOIN LATERAL (
+          SELECT COALESCE(SUM(allocation.quantite), 0)::numeric AS quantity
+          FROM public.bon_livraison_ligne_allocations allocation
+          WHERE allocation.bon_livraison_ligne_id = line.id
+        ) allocated ON TRUE
+        WHERE line.bon_livraison_id = $1::uuid
+          AND ABS(line.quantite - COALESCE(allocated.quantity, 0)) > 0.000000001
+      ) AS complete
+    `,
+    [bonLivraisonId]
+  )
+  return { attached, fullyAllocated: coverage.rows[0]?.complete === true }
 }
 
 export async function repoCreateLivraisonFromCommande(
@@ -2425,11 +2635,27 @@ export async function repoCreateLivraisonFromCommande(
 
     await insertLines(db, id, outLines, userId)
 
+    const transferredReservations = await attachActiveCommandeReservationsToLivraison(
+      db,
+      id,
+      userId
+    )
+    if (transferredReservations.fullyAllocated) {
+      await prepareLivraisonInTransaction(db, id, userId)
+    }
+
     await insertEvent(db, {
       bon_livraison_id: id,
       event_type: "CREATED_FROM_COMMANDE",
       user_id: userId,
-      new_values: { id, numero, commande_id: cmd.id, commande_numero: cmd.numero },
+      new_values: {
+        id,
+        numero,
+        commande_id: cmd.id,
+        commande_numero: cmd.numero,
+        reservations_transferred: transferredReservations.attached,
+        prepared: transferredReservations.fullyAllocated,
+      },
     })
 
     if (ownsTransaction) await db.query("COMMIT")

--- a/src/module/livraisons/validators/livraisons.validators.ts
+++ b/src/module/livraisons/validators/livraisons.validators.ts
@@ -36,6 +36,7 @@ export const listLivraisonsQuerySchema = z
   .object({
     q: z.string().trim().min(1).max(120).optional(),
     client_id: z.string().trim().min(1).optional(),
+    commande_id: z.coerce.number().int().positive().optional(),
     statut: bonLivraisonStatutSchema.optional(),
     from: isoDate.optional(),
     to: isoDate.optional(),

--- a/src/module/production/repository/production-receipts.repository.test.ts
+++ b/src/module/production/repository/production-receipts.repository.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { reserveProducedQtyForCommandeLine } from "./production-receipts.repository";
+
+const ids = {
+  article: "11111111-1111-1111-1111-111111111111",
+  location: "22222222-2222-2222-2222-222222222222",
+  level: "33333333-3333-3333-3333-333333333333",
+  batch: "44444444-4444-4444-4444-444444444444",
+  lot: "55555555-5555-5555-5555-555555555555",
+};
+
+function transactionClient(params: { activeCommandeReservation: number; plannedBlQty: number }) {
+  const query = vi.fn(async (sql: unknown, _queryParams?: unknown[]) => {
+    const text = String(sql);
+    if (text.includes("FROM public.commande_ligne") && text.includes("FOR UPDATE")) {
+      return { rows: [{ quantite: 10, article_id: ids.article }] };
+    }
+    if (text.includes("source_type = 'COMMANDE_LIGNE'") && text.includes("SUM(qty_reserved)")) {
+      return { rows: [{ qty_reserved: params.activeCommandeReservation }] };
+    }
+    if (text.includes("FROM public.bon_livraison_ligne line") && text.includes("delivery.statut <> 'CANCELLED'")) {
+      return { rows: [{ qty_planned: params.plannedBlQty }] };
+    }
+    if (text.includes("FROM public.stock_levels") && text.includes("FOR UPDATE")) {
+      return { rows: [{ qty_total: 20, qty_reserved: 0 }] };
+    }
+    if (text.includes("FROM public.stock_batches") && text.includes("FOR UPDATE")) {
+      return { rows: [{ qty_total: 20, qty_reserved: 0 }] };
+    }
+    if (text.includes("SELECT id::text AS id") && text.includes("stock_batch_id")) return { rows: [] };
+    if (text.includes("INSERT INTO public.stock_reservations")) return { rows: [{ id: "66666666-6666-6666-6666-666666666666" }] };
+    return { rows: [] };
+  });
+  return { query };
+}
+
+async function reserve(client: { query: ReturnType<typeof vi.fn> }, qty_ok: number) {
+  return reserveProducedQtyForCommandeLine(client as never, {
+    commande_ligne_id: 10,
+    article_id: ids.article,
+    location_id: ids.location,
+    stock_level_id: ids.level,
+    stock_batch_id: ids.batch,
+    lot_id: ids.lot,
+    qty_ok,
+    actor_user_id: 7,
+  });
+}
+
+describe("reserveProducedQtyForCommandeLine", () => {
+  it("SHIP_AVAILABLE_NOW: excludes both the prepared BL quantity and active command reservations", async () => {
+    const client = transactionClient({ activeCommandeReservation: 0, plannedBlQty: 5 });
+
+    await expect(reserve(client, 7)).resolves.toMatchObject({ qty_reserved: 5 });
+
+    const levelUpdate = client.query.mock.calls.find(([sql]) => String(sql).includes("UPDATE public.stock_levels"));
+    const reservationInsert = client.query.mock.calls.find(([sql]) => String(sql).includes("INSERT INTO public.stock_reservations"));
+    expect(levelUpdate?.[1]).toEqual([ids.level, 5, 7]);
+    expect(reservationInsert?.[1]).toEqual(expect.arrayContaining([5, "10"]));
+  });
+
+  it("SHIP_ALL_TOGETHER: keeps the stock reservation and reserves only the production remainder", async () => {
+    const client = transactionClient({ activeCommandeReservation: 5, plannedBlQty: 0 });
+
+    await expect(reserve(client, 7)).resolves.toMatchObject({ qty_reserved: 5 });
+
+    const levelUpdate = client.query.mock.calls.find(([sql]) => String(sql).includes("UPDATE public.stock_levels"));
+    expect(levelUpdate?.[1]).toEqual([ids.level, 5, 7]);
+  });
+});

--- a/src/module/production/repository/production-receipts.repository.ts
+++ b/src/module/production/repository/production-receipts.repository.ts
@@ -171,7 +171,7 @@ async function resolveArticleForPieceTechnique(client: Pick<PoolClient, "query">
   return row;
 }
 
-async function reserveProducedQtyForCommandeLine(
+export async function reserveProducedQtyForCommandeLine(
   client: Pick<PoolClient, "query">,
   args: {
     commande_ligne_id: number;
@@ -214,9 +214,21 @@ async function reserveProducedQtyForCommandeLine(
     [String(args.commande_ligne_id)]
   );
 
+  const plannedDeliveryRes = await client.query<{ qty_planned: number }>(
+    `
+      SELECT COALESCE(SUM(line.quantite), 0)::float8 AS qty_planned
+      FROM public.bon_livraison_ligne line
+      JOIN public.bon_livraison delivery ON delivery.id = line.bon_livraison_id
+      WHERE line.commande_ligne_id = $1::bigint
+        AND delivery.statut <> 'CANCELLED'
+    `,
+    [args.commande_ligne_id]
+  );
+
   const orderedQty = Number(line.quantite);
   const alreadyReserved = Number(currentReservedRes.rows[0]?.qty_reserved ?? 0);
-  const remainingToReserve = Math.max(0, orderedQty - alreadyReserved);
+  const alreadyPlannedForDelivery = Number(plannedDeliveryRes.rows[0]?.qty_planned ?? 0);
+  const remainingToReserve = Math.max(0, orderedQty - alreadyReserved - alreadyPlannedForDelivery);
   const qtyToReserve = Math.min(args.qty_ok, remainingToReserve);
   if (qtyToReserve <= 0) return null;
 


### PR DESCRIPTION
## Objectif

Garantir les invariants métier entre commande client, stock OLD/NEW, OF, BL, sortie réelle de stock et facture émise.

## Changements

- réserve le stock disponible et ne génère des OF que pour les manquants ;
- autorise une quantité lancée supérieure au manque pour constituer du stock libre ;
- interdit les transitions planning/livraison/facturation sans preuve métier ;
- transfère les réservations de commande vers les allocations BL sans double comptage ;
- poste un mouvement OUT à l'expédition et consomme les réservations ;
- calcule la réception de production sans réserver la surproduction ;
- synchronise la commande vers LIVRÉ puis FACTURÉ uniquement sur couverture complète ;
- ajoute une configuration Finance auditée pour politique et séquences annuelles ;
- sécurise la récupération des réservations historiques avec verrouillage et contrôles fail-closed.

## Impact

Les statuts de commande reflètent désormais les faits réels : OF actif si fabrication, BL expédié pour la livraison et facture émise pour la facturation.

## Validation

- suite backend complète : passée
- tests ciblés commandes/réservations/BL/production/facturation : passés
- build TypeScript : passé
- contrôle `git diff --check` : passé

## Summary by Sourcery

Enforce end‑to‑end fulfillment invariants between customer orders, production, delivery notes and invoicing, and introduce audited Finance configuration for legal billing policies and annual sequences.

New Features:
- Add fulfillment invariants that synchronize customer order statuses with actual shipment and invoicing artifacts.
- Introduce Finance configuration endpoints and storage for billing policies and legal numbering sequences, with audited, confirmation‑gated activation flows.
- Support filtering deliveries and invoices by linked customer order ID in list APIs.

Bug Fixes:
- Prevent double reservation of OLD/NEW stock by reusing existing grouped‑delivery reservations when relaunching legacy orders.
- Ensure produced quantities reserved for an order line exclude amounts already planned on delivery notes, avoiding over‑reservation.
- Recover invalid planning states where orders were marked waiting for planning without BL or OF, and repair checkpoints without duplicating artifacts.

Enhancements:
- Tighten workflow transitions so planning validation, delivery, and invoicing actions require corresponding OF, prepared BL, complete shipment or complete invoicing coverage.
- Automatically advance customer order workflow to LIVRE on full shipment and to FACTURE on complete invoice coverage, while enforcing readiness constraints.
- Reuse active production reservations when preparing deliveries instead of creating new ones, and attach them to BL allocations with correlation tracking.
- Rename the command launch checkpoint label to clarify its combined stock check and launch responsibilities.
- Extend invoice list items and search to surface the linked customer order for traceability.

Documentation:
- Document the new Finance configuration API and its guarded, non‑destructive behavior for billing policies and sequences.
- Update database patch notes to describe the post‑patch application behavior for stock reservation, BL preparation, shipment and invoice‑driven order status changes.

Tests:
- Add unit and route tests covering fulfillment invariants, legacy launch rejection, stock reservation reuse, delivery allocation attachment, production reservation behavior, and Finance configuration validation and repository logic.