### PR TITLE
release: publication technique guidée (#461)

### DIFF
--- a/docs/codification-versions-vsm-api.md
+++ b/docs/codification-versions-vsm-api.md
@@ -33,9 +33,22 @@ légaux de facture restent au format `FT-…`; le mouvement de stock conserve so
 - `GET /api/v1/pieces-techniques/code-preview` : aperçu non réservant.
 - `POST /api/v1/pieces-techniques/:id/versions/:versionId/create-next` : clone la définition courante
   (champs de version, opérations, gamme et nomenclature) dans une nouvelle version modifiable.
+- `POST /api/v1/pieces-techniques/:id/versions/:versionId/publish` : publication guidée atomique.
+  Un brouillon passe par la validation puis devient Applicable dans la même transaction ; une version
+  déjà en validation devient Applicable et un rejeu sur l'indice déjà Applicable est idempotent. Le
+  déclassement de l'ancien indice et le gel des exigences documentaires font partie de la transaction.
+  `expected_updated_at` protège des modifications concurrentes. `date_effet: null`, envoyé
+  explicitement, rend immédiatement effective une version Applicable dont l'effet était différé.
 - Une version `APPLICABLE` ou `OBSOLETE` est immuable et une seule version peut être applicable par pièce.
+- Une date d'effet future est refusée avant tout déclassement avec
+  `422 VERSION_EFFECTIVE_DATE_FUTURE`. Une version obsolète est refusée avec
+  `409 VERSION_NOT_PUBLISHABLE`.
 - `POST /api/v1/production/ofs` exige une version applicable et enregistre son snapshot JSON et son
   empreinte SHA-256. Les OF enfants générés récursivement possèdent leur propre snapshot.
+- Quand aucune version utilisable n'existe, `VERSION_NOT_APPLICABLE` expose dans `details`
+  `piece_technique_id`, `code_piece`, `designation` et les versions candidates (`id`, `indice`,
+  `statut`, `date_effet`, `effective_now`). Le frontend peut ainsi guider vers le dossier exact sans
+  deviner la pièce à partir d'une recherche.
 - Une mise à jour d'OF ne peut pas remplacer sa version, son snapshot, sa date ou son empreinte.
 
 ## Fichiers Project Office

--- a/src/__tests__/of-snapshot-methodes-233.test.ts
+++ b/src/__tests__/of-snapshot-methodes-233.test.ts
@@ -180,3 +180,33 @@ describe("Snapshot JSON — preuve figée lisible", () => {
     }
   })
 })
+
+describe("Snapshot OF — diagnostic version non applicable", () => {
+  it("retourne la pièce et les versions exploitables par l'interface", async () => {
+    let call = 0
+    const tx = {
+      query: async () => {
+        call += 1
+        if (call === 1) return { rows: [] } as never
+        return {
+          rows: [{
+            piece_technique_id: "11111111-1111-1111-1111-111111111111",
+            code_piece: "PT-001",
+            designation: "Pièce test",
+            versions: [{ id: "v1", indice: "A", statut: "EN_VALIDATION", date_effet: null, effective_now: false }],
+          }],
+        } as never
+      },
+    }
+
+    await expect(loadApplicableTechnicalSnapshot(tx, "11111111-1111-1111-1111-111111111111")).rejects.toMatchObject({
+      status: 422,
+      code: "VERSION_NOT_APPLICABLE",
+      details: {
+        piece_technique_id: "11111111-1111-1111-1111-111111111111",
+        code_piece: "PT-001",
+        versions: [{ indice: "A", statut: "EN_VALIDATION", effective_now: false }],
+      },
+    })
+  })
+})

--- a/src/__tests__/pieces-techniques-versions.test.ts
+++ b/src/__tests__/pieces-techniques-versions.test.ts
@@ -4,6 +4,7 @@ import {
   createNextVersionSchema,
   createVersionSchema,
   versionStatusSchema,
+  publishVersionSchema,
 } from "../module/pieces-techniques/validators/versions.validators"
 import {
   createPieceTechniqueSchema,
@@ -69,6 +70,15 @@ describe("Versions — validators", () => {
     expect(versionStatusSchema.safeParse({ body: { next_statut: "APPLICABLE", date_application: "2026-07-30" } }).success).toBe(true)
     expect(versionStatusSchema.safeParse({ body: { next_statut: "APPLICABLE", date_application: "2026-07-30T10:00:00.000Z" } }).success).toBe(false)
     expect(versionStatusSchema.safeParse({ body: { next_statut: "APPLICABLE", date_application: "2026-02-30" } }).success).toBe(false)
+  })
+
+  it("accepte le contrat minimal du bouton Valider et appliquer", () => {
+    expect(publishVersionSchema.safeParse({ body: {} }).success).toBe(true)
+    expect(publishVersionSchema.safeParse({ body: { date_application: "2026-07-30" } }).success).toBe(true)
+    expect(publishVersionSchema.safeParse({ body: { date_effet: "2026-08-01" } }).success).toBe(true)
+    expect(publishVersionSchema.safeParse({ body: { date_effet: null } }).success).toBe(true)
+    expect(publishVersionSchema.safeParse({ body: { date_effet: "2026-02-30" } }).success).toBe(false)
+    expect(publishVersionSchema.safeParse({ body: { date_application: "2026-07-30T10:00:00.000Z" } }).success).toBe(false)
   })
 
   it("create-next exige aussi un indice", () => {

--- a/src/__tests__/pieces-techniques.routes.test.ts
+++ b/src/__tests__/pieces-techniques.routes.test.ts
@@ -104,6 +104,112 @@ describe("/api/v1/pieces-techniques", () => {
     expect(res.body).toMatchObject({ code: "PIECE_VERSION_APPROVAL_FORBIDDEN" });
   });
 
+  it("keeps guided version publication closed to an unprivileged operator", async () => {
+    const pieceId = "11111111-1111-4111-8111-111111111111";
+    const versionId = "22222222-2222-4222-8222-222222222222";
+
+    const res = await request(app)
+      .post(`/api/v1/pieces-techniques/${pieceId}/versions/${versionId}/publish`)
+      .set("x-test-role", "Employee | Opérateur atelier")
+      .send({});
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: "PIECE_VERSION_APPROVAL_FORBIDDEN" });
+  });
+
+  it("accepts an already applicable version without a second state change", async () => {
+    const pieceId = "11111111-1111-4111-8111-111111111111";
+    const versionId = "22222222-2222-4222-8222-222222222222";
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query === "BEGIN" || query === "COMMIT" || query === "ROLLBACK") return { rows: [] };
+      if (query.includes("FROM public.piece_technique_versions") && query.includes("FOR UPDATE")) {
+        return { rows: [{ id: versionId, piece_technique_id: pieceId, statut: "APPLICABLE", updated_at: "2026-08-01T10:00:00.000Z" }] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/pieces-techniques/${pieceId}/versions/${versionId}/publish`)
+      .send({ expected_updated_at: "2026-08-01T10:00:00.000Z" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ id: versionId, statut: "APPLICABLE" });
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("SET statut = 'EN_VALIDATION'"))).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("SET statut = 'OBSOLETE'"))).toBe(false);
+  });
+
+  it("updates date_effet on an applicable version so OF generation can resume", async () => {
+    const pieceId = "11111111-1111-4111-8111-111111111111";
+    const versionId = "22222222-2222-4222-8222-222222222222";
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query === "BEGIN" || query === "COMMIT" || query === "ROLLBACK") return { rows: [] };
+      if (query.includes("FROM public.piece_technique_versions") && query.includes("FOR UPDATE")) {
+        return { rows: [{ id: versionId, piece_technique_id: pieceId, statut: "APPLICABLE", updated_at: "2026-08-01T10:00:00.000Z", date_effet: "2026-09-01" }] };
+      }
+      if (query.includes("SET date_effet = $2::date")) {
+        return { rows: [{ id: versionId, piece_technique_id: pieceId, statut: "APPLICABLE", date_effet: "2026-08-01" }] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/pieces-techniques/${pieceId}/versions/${versionId}/publish`)
+      .send({ date_effet: "2026-08-01" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ statut: "APPLICABLE", date_effet: "2026-08-01" });
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("SET date_effet = $2::date"))).toBe(true);
+  });
+
+  it("refuses a future effective date before it can replace the current applicable version", async () => {
+    const pieceId = "11111111-1111-4111-8111-111111111111";
+    const versionId = "22222222-2222-4222-8222-222222222222";
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query === "BEGIN" || query === "COMMIT" || query === "ROLLBACK") return { rows: [] };
+      if (query.includes("FROM public.piece_technique_versions") && query.includes("FOR UPDATE")) {
+        return { rows: [{ id: versionId, piece_technique_id: pieceId, statut: "EN_VALIDATION", updated_at: "2026-08-01T10:00:00.000Z", date_effet: "2099-01-01" }] };
+      }
+      if (query.includes("$1::date > CURRENT_DATE")) return { rows: [{ is_future: true }] };
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/pieces-techniques/${pieceId}/versions/${versionId}/publish`)
+      .send({});
+
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({ code: "VERSION_EFFECTIVE_DATE_FUTURE", details: { date_effet: "2099-01-01" } });
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("SET statut = 'OBSOLETE'"))).toBe(false);
+  });
+
+  it("applies the same future-date guard to the legacy status endpoint", async () => {
+    const pieceId = "11111111-1111-4111-8111-111111111111";
+    const versionId = "22222222-2222-4222-8222-222222222222";
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{ statut: "EN_VALIDATION", updated_at: "2026-08-01T10:00:00.000Z", date_effet: "2099-01-01" }],
+    });
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query === "BEGIN" || query === "COMMIT" || query === "ROLLBACK") return { rows: [] };
+      if (query.includes("piece_technique_versions")) {
+        return { rows: [{ statut: "EN_VALIDATION", updated_at: "2026-08-01T10:00:00.000Z", date_effet: "2099-01-01" }] };
+      }
+      if (query.includes("$1::date > CURRENT_DATE")) return { rows: [{ is_future: true }] };
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .patch(`/api/v1/pieces-techniques/${pieceId}/versions/${versionId}/status`)
+      .send({ next_statut: "APPLICABLE" });
+
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({ code: "VERSION_EFFECTIVE_DATE_FUTURE" });
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("SET statut = 'OBSOLETE'"))).toBe(false);
+  });
+
   it("rejects a manufactured child relation that would create a fabrication cycle", async () => {
     const parentId = "11111111-1111-4111-8111-111111111111";
     const childId = "22222222-2222-4222-8222-222222222222";

--- a/src/module/pieces-techniques/controllers/versions.controller.ts
+++ b/src/module/pieces-techniques/controllers/versions.controller.ts
@@ -7,6 +7,7 @@ import {
   createNextVersionSchema,
   createVersionSchema,
   updateVersionSchema,
+  publishVersionSchema,
   versionStatusSchema,
 } from "../validators/versions.validators"
 import {
@@ -15,6 +16,7 @@ import {
   listVersionsSVC,
   updateVersionSVC,
   updateVersionStatusSVC,
+  publishVersionSVC,
 } from "../services/versions.service"
 
 function buildAuditContext(req: Request): AuditContext {
@@ -93,6 +95,23 @@ export const updateVersionStatus: RequestHandler = async (req, res, next) => {
     const audit = buildAuditContext(req)
     const body = versionStatusSchema.parse({ body: req.body }).body
     const out = await updateVersionStatusSVC(
+      routeParam(req, "id"),
+      routeParam(req, "versionId"),
+      body,
+      audit
+    )
+    if (!out) throw new HttpError(404, "NOT_FOUND", "Version introuvable")
+    res.json(out)
+  } catch (err) {
+    next(err)
+  }
+}
+
+export const publishVersion: RequestHandler = async (req, res, next) => {
+  try {
+    const audit = buildAuditContext(req)
+    const body = publishVersionSchema.parse({ body: req.body }).body
+    const out = await publishVersionSVC(
       routeParam(req, "id"),
       routeParam(req, "versionId"),
       body,

--- a/src/module/pieces-techniques/repository/versions.repository.ts
+++ b/src/module/pieces-techniques/repository/versions.repository.ts
@@ -89,6 +89,25 @@ async function assertPieceExists(tx: Pick<PoolClient, "query">, pieceId: string)
   if (res.rowCount === 0) throw new HttpError(404, "NOT_FOUND", "Pièce technique introuvable")
 }
 
+async function assertVersionEffectiveToday(
+  tx: Pick<PoolClient, "query">,
+  dateEffet: string | null
+): Promise<void> {
+  if (!dateEffet) return
+  const result = await tx.query<{ is_future: boolean }>(
+    `SELECT $1::date > CURRENT_DATE AS is_future`,
+    [dateEffet]
+  )
+  if (result.rows[0]?.is_future) {
+    throw new HttpError(
+      422,
+      "VERSION_EFFECTIVE_DATE_FUTURE",
+      "La date d'effet de la version est dans le futur : choisissez aujourd'hui ou une date antérieure pour lancer un OF.",
+      { date_effet: dateEffet }
+    )
+  }
+}
+
 export type PieceTechniqueVersionCloneResult = PieceTechniqueVersionRow & {
   copied: {
     current_gamme: boolean
@@ -282,8 +301,8 @@ export async function repoUpdateVersionStatus(
   const client = await db.connect()
   try {
     await client.query("BEGIN")
-    const cur = await client.query<{ statut: VersionStatutDTO; updated_at: string }>(
-      `SELECT statut, updated_at::text AS updated_at FROM public.piece_technique_versions
+    const cur = await client.query<{ statut: VersionStatutDTO; updated_at: string; date_effet: string | null }>(
+      `SELECT statut, updated_at::text AS updated_at, date_effet::text AS date_effet FROM public.piece_technique_versions
        WHERE id = $1 AND piece_technique_id = $2 FOR UPDATE`,
       [versionId, pieceTechniqueId]
     )
@@ -294,6 +313,10 @@ export async function repoUpdateVersionStatus(
     }
     if (extra.expected_updated_at && extra.expected_updated_at !== current.updated_at) {
       throw new HttpError(409, "CONCURRENT_MODIFICATION", "La version a été modifiée entre-temps")
+    }
+
+    if (toStatut === "APPLICABLE") {
+      await assertVersionEffectiveToday(client, current.date_effet)
     }
 
     // Passe APPLICABLE : déclasser l'ancienne APPLICABLE d'abord (respecte l'index unique partiel).
@@ -340,6 +363,138 @@ export async function repoUpdateVersionStatus(
       piece_technique_id: pieceTechniqueId,
       from: current.statut,
       to: toStatut,
+      document_requirements_frozen: frozen ? !frozen.already_frozen : false,
+      document_requirements_count: frozen?.frozen_count ?? null,
+    })
+    await client.query("COMMIT")
+    return row
+  } catch (e) {
+    await client.query("ROLLBACK").catch(() => {})
+    throw e
+  } finally {
+    client.release()
+  }
+}
+
+/**
+ * Publication guidée d'un indice dans une transaction unique. La transition
+ * intermédiaire EN_VALIDATION est conservée dans la règle métier, sans
+ * exposer au client un état partiellement publié si le gel documentaire
+ * échoue ensuite.
+ */
+export async function repoPublishVersion(
+  pieceTechniqueId: string,
+  versionId: string,
+  extra: {
+    date_application: string | null;
+    date_effet?: string | null;
+    commentaire_validation: string | null;
+    expected_updated_at?: string;
+  },
+  audit: AuditContext
+): Promise<PieceTechniqueVersionRow | null> {
+  const client = await db.connect()
+  try {
+    await client.query("BEGIN")
+    const cur = await client.query<PieceTechniqueVersionRow>(
+      `SELECT ${VERSION_COLUMNS}
+         FROM public.piece_technique_versions
+        WHERE id = $1 AND piece_technique_id = $2
+        FOR UPDATE`,
+      [versionId, pieceTechniqueId]
+    )
+    const current = cur.rows[0] ?? null
+    if (!current) {
+      await client.query("ROLLBACK").catch(() => {})
+      return null
+    }
+    if (extra.expected_updated_at && extra.expected_updated_at !== current.updated_at) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "La version a été modifiée entre-temps")
+    }
+
+    if (current.statut === "OBSOLETE") {
+      throw new HttpError(409, "VERSION_NOT_PUBLISHABLE", "Une version obsolète ne peut pas redevenir applicable — créez un nouvel indice")
+    }
+    const targetDateEffet = extra.date_effet !== undefined ? extra.date_effet : current.date_effet
+    await assertVersionEffectiveToday(client, targetDateEffet)
+    if (current.statut === "APPLICABLE") {
+      // Une ancienne publication peut avoir une date d'effet future : elle est
+      // alors Applicable dans le dossier mais inutilisable par le moteur OF.
+      // Le parcours guidé peut la rendre effective sans changer d'indice.
+      if (extra.date_effet !== undefined) {
+        const updated = await client.query<PieceTechniqueVersionRow>(
+          `UPDATE public.piece_technique_versions
+              SET date_effet = $2::date, updated_at = now(), updated_by = $3
+            WHERE id = $1
+            RETURNING ${VERSION_COLUMNS}`,
+          [versionId, extra.date_effet, audit.user_id]
+        )
+        const row = updated.rows[0]
+        if (!row) throw new Error("Impossible de mettre à jour la date d'effet de la version technique")
+        await insertAudit(client, audit, "pieces-techniques.version.publish", versionId, {
+          piece_technique_id: pieceTechniqueId,
+          from: "APPLICABLE",
+          to: "APPLICABLE",
+          date_effet_updated: true,
+          date_effet: extra.date_effet,
+        })
+        await client.query("COMMIT")
+        return row
+      }
+      await client.query("COMMIT")
+      return current
+    }
+
+    if (current.statut === "BROUILLON") {
+      await client.query(
+        `UPDATE public.piece_technique_versions
+            SET statut = 'EN_VALIDATION', is_current = false, updated_at = now(), updated_by = $2
+          WHERE id = $1`,
+        [versionId, audit.user_id]
+      )
+    }
+
+    // Déclasser l'ancienne applicable avant de promouvoir la nouvelle afin de
+    // respecter l'index unique partiel, y compris sous concurrence.
+    await client.query(
+      `UPDATE public.piece_technique_versions
+          SET statut = 'OBSOLETE', is_current = false, updated_at = now(), updated_by = $3
+        WHERE piece_technique_id = $1 AND statut = 'APPLICABLE' AND id <> $2`,
+      [pieceTechniqueId, versionId, audit.user_id]
+    )
+    const published = await client.query<PieceTechniqueVersionRow>(
+      `UPDATE public.piece_technique_versions SET
+         statut = 'APPLICABLE',
+         is_current = true,
+         valide_par = $2,
+         date_validation = now(),
+         date_application = COALESCE($3::date, date_application, CURRENT_DATE),
+         commentaire_validation = COALESCE($4, commentaire_validation),
+         date_effet = CASE WHEN $5::boolean THEN $6::date ELSE date_effet END,
+         updated_at = now(), updated_by = $2
+       WHERE id = $1
+       RETURNING ${VERSION_COLUMNS}`,
+      [
+        versionId,
+        audit.user_id,
+        extra.date_application,
+        extra.commentaire_validation,
+        extra.date_effet !== undefined,
+        extra.date_effet ?? null,
+      ]
+    )
+    const row = published.rows[0]
+    if (!row) throw new Error("Impossible de publier la version technique")
+
+    const frozen = await freezePieceVersionRequirements(client, {
+      pieceTechniqueId,
+      versionId,
+      userId: audit.user_id,
+    })
+    await insertAudit(client, audit, "pieces-techniques.version.publish", versionId, {
+      piece_technique_id: pieceTechniqueId,
+      from: current.statut,
+      to: "APPLICABLE",
       document_requirements_frozen: frozen ? !frozen.already_frozen : false,
       document_requirements_count: frozen?.frozen_count ?? null,
     })

--- a/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
+++ b/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
@@ -100,6 +100,7 @@ import {
   listVersions,
   updateVersion,
   updateVersionStatus,
+  publishVersion,
 } from "../controllers/versions.controller"
 import { createOrLinkArticleFabrique, getPieceArticlePrincipal } from "../controllers/piece-article.controller"
 import {
@@ -108,6 +109,7 @@ import {
   updateVersionSchema,
   versionIdParamSchema,
   versionStatusSchema,
+  publishVersionSchema,
 } from "../validators/versions.validators"
 
 const router = Router()
@@ -201,6 +203,7 @@ router.get("/:id/versions", validate(idParamSchema), listVersions)
 router.post("/:id/versions", validate(idParamSchema), validate(createVersionSchema), createVersion)
 router.patch("/:id/versions/:versionId", validate(versionIdParamSchema), validate(updateVersionSchema), updateVersion)
 router.patch("/:id/versions/:versionId/status", requireVersionApproval, validate(versionIdParamSchema), validate(versionStatusSchema), updateVersionStatus)
+router.post("/:id/versions/:versionId/publish", requireVersionApproval, validate(versionIdParamSchema), validate(publishVersionSchema), publishVersion)
 router.post("/:id/versions/:versionId/create-next", validate(versionIdParamSchema), validate(createNextVersionSchema), createNextVersion)
 
 router.post("/:id/nomenclature", validate(idParamSchema), validate(addBomLineSchema), addBomLine)

--- a/src/module/pieces-techniques/services/versions.service.ts
+++ b/src/module/pieces-techniques/services/versions.service.ts
@@ -7,6 +7,7 @@ import {
   repoCreateVersion,
   repoGetVersion,
   repoListVersions,
+  repoPublishVersion,
   repoUpdateVersion,
   repoUpdateVersionStatus,
 } from "../repository/versions.repository"
@@ -15,6 +16,7 @@ import type {
   CreateVersionBodyDTO,
   UpdateVersionBodyDTO,
   VersionStatusBodyDTO,
+  PublishVersionBodyDTO,
   VersionStatutDTO,
 } from "../validators/versions.validators"
 
@@ -65,6 +67,23 @@ export async function updateVersionStatusSVC(
     audit
   )
 }
+
+export const publishVersionSVC = (
+  pieceTechniqueId: string,
+  versionId: string,
+  body: PublishVersionBodyDTO,
+  audit: AuditContext
+) => repoPublishVersion(
+  pieceTechniqueId,
+  versionId,
+  {
+    date_application: body.date_application ?? null,
+    date_effet: body.date_effet,
+    commentaire_validation: body.commentaire_validation ?? null,
+    expected_updated_at: body.expected_updated_at,
+  },
+  audit
+)
 
 export const createNextVersionSVC = (
   pieceTechniqueId: string,

--- a/src/module/pieces-techniques/validators/versions.validators.ts
+++ b/src/module/pieces-techniques/validators/versions.validators.ts
@@ -7,6 +7,17 @@ const uuid = z.string().uuid()
 export const versionStatutSchema = z.enum(["BROUILLON", "EN_VALIDATION", "APPLICABLE", "OBSOLETE"])
 export type VersionStatutDTO = z.infer<typeof versionStatutSchema>
 
+const sqlDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "Date attendue au format YYYY-MM-DD")
+  .refine(
+    (value) => {
+      const parsed = new Date(`${value}T00:00:00.000Z`)
+      return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value
+    },
+    "Date invalide"
+  )
+
 export const typeChangementSchema = z.enum(["EVOLUTION", "MODIFICATION"])
 export type TypeChangementDTO = z.infer<typeof typeChangementSchema>
 
@@ -41,23 +52,28 @@ export const versionStatusSchema = z.object({
     next_statut: versionStatutSchema,
     // Empêche qu'une valeur d'interface non SQL (ex. datetime ISO) atteigne le
     // cast `::date` de la transaction de publication et se transforme en 500.
-    date_application: z
-      .string()
-      .regex(/^\d{4}-\d{2}-\d{2}$/, "Date d'application attendue au format YYYY-MM-DD")
-      .refine(
-        (value) => {
-          const parsed = new Date(`${value}T00:00:00.000Z`)
-          return !Number.isNaN(parsed.getTime()) && parsed.toISOString().slice(0, 10) === value
-        },
-        "Date d'application invalide"
-      )
-      .optional()
-      .nullable(),
+    date_application: sqlDateSchema.optional().nullable(),
     commentaire_validation: z.string().max(2000).optional().nullable(),
     expected_updated_at: z.string().min(1).optional(),
   }),
 })
 export type VersionStatusBodyDTO = z.infer<typeof versionStatusSchema>["body"]
+
+// Parcours guidé : le serveur passe lui-même BROUILLON → EN_VALIDATION →
+// APPLICABLE dans une seule transaction. Les champs restent volontairement les
+// mêmes que pour la transition unitaire afin que l'UI n'ait pas deux contrats.
+export const publishVersionSchema = z.object({
+  body: z.object({
+    date_application: versionStatusSchema.shape.body.shape.date_application,
+    // `undefined` = conserver la date configurée, `null` = rendre applicable
+    // immédiatement. Ce champ est aussi autorisé sur une version déjà
+    // Applicable pour corriger une date future qui bloquait les OF.
+    date_effet: sqlDateSchema.optional().nullable(),
+    commentaire_validation: z.string().max(2000).optional().nullable(),
+    expected_updated_at: z.string().min(1).optional(),
+  }),
+})
+export type PublishVersionBodyDTO = z.infer<typeof publishVersionSchema>["body"]
 
 // "Nouvel indice / nouvelle évolution / nouvelle modification" (remplace le duplicate cassé).
 export const createNextVersionSchema = z.object({ body: versionCoreBody })

--- a/src/module/production/domain/of-generation.ts
+++ b/src/module/production/domain/of-generation.ts
@@ -329,6 +329,52 @@ export type ApplicableTechnicalSnapshot = {
   sha256: string;
 };
 
+type VersionNotApplicableDetails = {
+  piece_technique_id: string;
+  code_piece: string;
+  designation: string;
+  versions: Array<{
+    id: string;
+    indice: string;
+    statut: string;
+    date_effet: string | null;
+    effective_now: boolean;
+  }>;
+};
+
+async function loadVersionNotApplicableDetails(
+  tx: Queryable,
+  pieceTechniqueId: string
+): Promise<VersionNotApplicableDetails | null> {
+  const result = await tx.query<VersionNotApplicableDetails>(
+    `
+      SELECT pt.id::text AS piece_technique_id,
+             pt.code_piece,
+             pt.designation,
+             COALESCE(
+               jsonb_agg(
+                 jsonb_build_object(
+                   'id', v.id::text,
+                   'indice', v.indice,
+                   'statut', v.statut,
+                   'date_effet', v.date_effet,
+                   'effective_now', v.statut = 'APPLICABLE'
+                     AND (v.date_effet IS NULL OR v.date_effet <= CURRENT_DATE)
+                 )
+                 ORDER BY v.date_effet DESC NULLS LAST, v.version_interne DESC NULLS LAST, v.created_at DESC
+               ) FILTER (WHERE v.id IS NOT NULL),
+               '[]'::jsonb
+             ) AS versions
+        FROM public.pieces_techniques pt
+        LEFT JOIN public.piece_technique_versions v ON v.piece_technique_id = pt.id
+       WHERE pt.id = $1::uuid
+       GROUP BY pt.id, pt.code_piece, pt.designation
+    `,
+    [pieceTechniqueId]
+  );
+  return result.rows[0] ?? null;
+}
+
 /**
  * Sélectionne la version applicable (ou valide une version épinglée) DANS la
  * transaction de génération, puis fige toutes les données de fabrication dans
@@ -366,10 +412,12 @@ export async function loadApplicableTechnicalSnapshot(
   );
   const version = versionRes.rows[0] ?? null;
   if (!version) {
+    const details = await loadVersionNotApplicableDetails(tx, pieceTechniqueId);
     throw new HttpError(
       422,
       "VERSION_NOT_APPLICABLE",
-      `La pièce technique ${pieceTechniqueId} ne possède pas de version applicable pour générer un OF.`
+      `La pièce technique ${pieceTechniqueId} ne possède pas de version applicable pour générer un OF.`,
+      details ?? { piece_technique_id: pieceTechniqueId, code_piece: null, designation: null, versions: [] }
     );
   }
   if (pinned && version.version_id !== pinned) {


### PR DESCRIPTION
Promotion de dev vers main après suite complète, build et boot contrôlé. Inclut la publication atomique et le diagnostic VERSION_NOT_APPLICABLE structuré. Référence BigFootLime/crp-systems-web#461.

## Summary by Sourcery

Introduce guided, atomic publication flow for technical piece versions, tighten date validation around effective dates, and enrich OF generation errors with structured diagnostics about non-applicable versions.

New Features:
- Add a guided publish endpoint that transitions versions through validation to applicable in a single atomic transaction, including concurrent modification protection and optional effective date updates.
- Expose structured details with VERSION_NOT_APPLICABLE errors so clients can understand which piece and candidate versions prevented OF generation.

Bug Fixes:
- Prevent publishing or status changes when a version’s effective date is in the future, returning a VERSION_EFFECTIVE_DATE_FUTURE error instead of leaving OF generation blocked or data inconsistent.

Enhancements:
- Reuse a shared SQL date validator for publication and status change payloads to avoid invalid formats reaching database casts.
- Allow correcting the effective date on already applicable versions so OF generation can resume without changing indices.

Documentation:
- Update codification and API documentation to describe the guided publish endpoint, future-date guards, and the enriched VERSION_NOT_APPLICABLE diagnostics.

Tests:
- Add route, validator, and domain tests covering guided publication behavior, permission enforcement, effective date updates and guards, and the structured VERSION_NOT_APPLICABLE error payload.