### PR TITLE
fix: corriger la publication guidée des versions techniques (#461)

### DIFF
--- a/db/patches/20260801_piece_version_guided_publish_trigger.sql
+++ b/db/patches/20260801_piece_version_guided_publish_trigger.sql
@@ -1,0 +1,66 @@
+-- #461 — Publication guidée d'une version technique.
+--
+-- Les versions APPLICABLE restent immuables. La seule nouvelle exception est
+-- une accélération explicite d'une date d'effet encore future vers aujourd'hui
+-- (ou NULL, qui signifie effet immédiat dans le moteur OF). Aucun contenu
+-- technique, statut ou instantané documentaire ne peut être modifié par cette
+-- exception. L'action HTTP correspondante est protégée par RBAC et auditée.
+--
+-- Le gel documentaire des nouvelles publications est désormais réalisé AVANT
+-- la promotion par le repository ; il n'a donc besoin d'aucune exception ici.
+-- Patch idempotent : CREATE OR REPLACE conserve le trigger existant.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.piece_technique_versions') IS NULL THEN
+    RAISE EXCEPTION 'Pré-requis absent: public.piece_technique_versions';
+  END IF;
+END $$;
+
+CREATE OR REPLACE FUNCTION public.fn_prevent_validated_piece_version_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' AND OLD.statut IN ('APPLICABLE', 'OBSOLETE') THEN
+    RAISE EXCEPTION 'Validated technical versions are retained for traceability'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.statut IN ('APPLICABLE', 'OBSOLETE') THEN
+    -- Déclassement historique déjà autorisé : seule la mécanique de statut
+    -- change, le contenu technique reste identique.
+    IF OLD.statut = 'APPLICABLE'
+       AND NEW.statut = 'OBSOLETE'
+       AND (to_jsonb(NEW) - ARRAY['statut', 'is_current', 'updated_at', 'updated_by'])
+           IS NOT DISTINCT FROM (to_jsonb(OLD) - ARRAY['statut', 'is_current', 'updated_at', 'updated_by']) THEN
+      RETURN NEW;
+    END IF;
+
+    -- Une version planifiée dans le futur peut être avancée à effet immédiat.
+    -- L'exception est volontairement à sens unique : impossible de reporter
+    -- une version déjà effective ou de toucher à un autre champ validé.
+    IF OLD.statut = 'APPLICABLE'
+       AND NEW.statut = 'APPLICABLE'
+       AND OLD.date_effet IS NOT NULL
+       AND OLD.date_effet > CURRENT_DATE
+       AND (NEW.date_effet IS NULL OR NEW.date_effet <= CURRENT_DATE)
+       AND NEW.updated_by IS NOT NULL
+       AND (to_jsonb(NEW) - ARRAY['date_effet', 'updated_at', 'updated_by'])
+           IS NOT DISTINCT FROM (to_jsonb(OLD) - ARRAY['date_effet', 'updated_at', 'updated_by']) THEN
+      RETURN NEW;
+    END IF;
+
+    RAISE EXCEPTION 'Validated technical versions are immutable; create a new version instead'
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_prevent_validated_piece_version_mutation() IS
+  '#461 — protège les versions validées ; autorise seulement déclassement et avance contrôlée d’une date d’effet future.';
+
+COMMIT;

--- a/db/patches/support/20260801_piece_version_guided_publish_trigger.rollback.sql
+++ b/db/patches/support/20260801_piece_version_guided_publish_trigger.rollback.sql
@@ -1,0 +1,35 @@
+-- Rollback #461 — restaure la politique d'immuabilité stricte du patch
+-- 20260713. Aucun enregistrement métier n'est supprimé ou réécrit.
+--
+-- Après rollback, une version APPLICABLE à date d'effet future devra être
+-- remplacée par un nouvel indice pour devenir immédiatement effective.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.fn_prevent_validated_piece_version_mutation()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' AND OLD.statut IN ('APPLICABLE', 'OBSOLETE') THEN
+    RAISE EXCEPTION 'Validated technical versions are retained for traceability'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.statut IN ('APPLICABLE', 'OBSOLETE') THEN
+    IF OLD.statut = 'APPLICABLE'
+       AND NEW.statut = 'OBSOLETE'
+       AND (to_jsonb(NEW) - ARRAY['statut', 'is_current', 'updated_at', 'updated_by'])
+           IS NOT DISTINCT FROM (to_jsonb(OLD) - ARRAY['statut', 'is_current', 'updated_at', 'updated_by']) THEN
+      RETURN NEW;
+    END IF;
+    RAISE EXCEPTION 'Validated technical versions are immutable; create a new version instead'
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_prevent_validated_piece_version_mutation() IS NULL;
+
+COMMIT;

--- a/db/patches/support/20260801_piece_version_guided_publish_trigger.verify.sql
+++ b/db/patches/support/20260801_piece_version_guided_publish_trigger.verify.sql
@@ -1,0 +1,28 @@
+-- Verify #461 — lecture seule, à exécuter après le patch.
+
+\echo '--- Fonction d’immuabilité (attendu: 1 ligne, 3 contrôles true) ---'
+WITH fn AS (
+  SELECT pg_get_functiondef(p.oid) AS definition
+  FROM pg_proc p
+  JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public'
+    AND p.proname = 'fn_prevent_validated_piece_version_mutation'
+)
+SELECT
+  definition LIKE '%Validated technical versions are immutable%' AS immutabilite_conservee,
+  definition LIKE '%OLD.date_effet > CURRENT_DATE%' AS ancienne_date_future_requise,
+  definition LIKE '%NEW.date_effet IS NULL OR NEW.date_effet <= CURRENT_DATE%' AS effet_immediat_uniquement
+FROM fn;
+
+\echo '--- Trigger raccordé (attendu: 1 ligne) ---'
+SELECT t.tgname, pg_get_triggerdef(t.oid) AS definition
+FROM pg_trigger t
+WHERE t.tgrelid = 'public.piece_technique_versions'::regclass
+  AND t.tgname = 'trg_prevent_validated_piece_version_mutation'
+  AND NOT t.tgisinternal;
+
+\echo '--- Contrôle de données non mutées par le patch ---'
+SELECT
+  count(*) FILTER (WHERE statut = 'APPLICABLE') AS versions_applicables,
+  count(*) FILTER (WHERE statut = 'OBSOLETE') AS versions_obsoletes
+FROM public.piece_technique_versions;

--- a/docs/codification-versions-vsm-api.md
+++ b/docs/codification-versions-vsm-api.md
@@ -37,12 +37,16 @@ légaux de facture restent au format `FT-…`; le mouvement de stock conserve so
   Un brouillon passe par la validation puis devient Applicable dans la même transaction ; une version
   déjà en validation devient Applicable et un rejeu sur l'indice déjà Applicable est idempotent. Le
   déclassement de l'ancien indice et le gel des exigences documentaires font partie de la transaction.
+  Le gel est exécuté avant la promotion finale afin que le trigger d'immuabilité ne voie jamais une
+  modification tardive d'un indice déjà Applicable ; un échec ultérieur annule toujours l'ensemble.
   `expected_updated_at` protège des modifications concurrentes. `date_effet: null`, envoyé
   explicitement, rend immédiatement effective une version Applicable dont l'effet était différé.
 - Une version `APPLICABLE` ou `OBSOLETE` est immuable et une seule version peut être applicable par pièce.
 - Une date d'effet future est refusée avant tout déclassement avec
   `422 VERSION_EFFECTIVE_DATE_FUTURE`. Une version obsolète est refusée avec
   `409 VERSION_NOT_PUBLISHABLE`.
+- Le patch `20260801_piece_version_guided_publish_trigger.sql` conserve l'immuabilité du contenu validé
+  et autorise uniquement l'avance auditée d'une date d'effet encore future vers un effet immédiat.
 - `POST /api/v1/production/ofs` exige une version applicable et enregistre son snapshot JSON et son
   empreinte SHA-256. Les OF enfants générés récursivement possèdent leur propre snapshot.
 - Quand aucune version utilisable n'existe, `VERSION_NOT_APPLICABLE` expose dans `details`

--- a/src/__tests__/piece-version-publish-trigger-461.test.ts
+++ b/src/__tests__/piece-version-publish-trigger-461.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const root = process.cwd();
+const patch = readFileSync(
+  resolve(root, "db/patches/20260801_piece_version_guided_publish_trigger.sql"),
+  "utf8"
+);
+const verify = readFileSync(
+  resolve(root, "db/patches/support/20260801_piece_version_guided_publish_trigger.verify.sql"),
+  "utf8"
+);
+const rollback = readFileSync(
+  resolve(root, "db/patches/support/20260801_piece_version_guided_publish_trigger.rollback.sql"),
+  "utf8"
+);
+
+describe("#461 guided technical-version publication migration guards", () => {
+  it("keeps validated technical content immutable", () => {
+    expect(patch).toContain("Validated technical versions are retained for traceability");
+    expect(patch).toContain("Validated technical versions are immutable; create a new version instead");
+    expect(patch).toContain("OLD.statut = 'APPLICABLE'");
+    expect(patch).toContain("NEW.statut = 'OBSOLETE'");
+  });
+
+  it("only permits advancing a still-future effective date", () => {
+    expect(patch).toContain("OLD.date_effet > CURRENT_DATE");
+    expect(patch).toContain("NEW.date_effet IS NULL OR NEW.date_effet <= CURRENT_DATE");
+    expect(patch).toContain("NEW.updated_by IS NOT NULL");
+    expect(patch).toContain("ARRAY['date_effet', 'updated_at', 'updated_by']");
+    expect(patch).not.toContain("document_requirements_frozen_at', 'updated_at'");
+  });
+
+  it("is transactional and does not rewrite business data", () => {
+    expect(patch).toContain("BEGIN;");
+    expect(patch).toContain("COMMIT;");
+    expect(patch).not.toMatch(/\bUPDATE\s+public\.piece_technique_versions\b/i);
+    expect(patch).not.toMatch(/\bDELETE\s+FROM\b/i);
+    expect(patch).not.toMatch(/\bTRUNCATE\b/i);
+  });
+
+  it("ships read-only verification and a non-destructive rollback", () => {
+    expect(verify).toContain("pg_get_functiondef");
+    expect(verify).toContain("trg_prevent_validated_piece_version_mutation");
+    expect(rollback).toContain("CREATE OR REPLACE FUNCTION public.fn_prevent_validated_piece_version_mutation");
+    expect(rollback).not.toMatch(/\bUPDATE\s+public\.piece_technique_versions\b/i);
+    expect(rollback).not.toMatch(/\bDELETE\s+FROM\b/i);
+  });
+});

--- a/src/__tests__/pieces-techniques.routes.test.ts
+++ b/src/__tests__/pieces-techniques.routes.test.ts
@@ -163,6 +163,134 @@ describe("/api/v1/pieces-techniques", () => {
     expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("SET date_effet = $2::date"))).toBe(true);
   });
 
+  it("freezes document requirements before guided publication makes the version immutable", async () => {
+    const pieceId = "11111111-1111-4111-8111-111111111111";
+    const versionId = "22222222-2222-4222-8222-222222222222";
+    const currentVersion = {
+      id: versionId,
+      piece_technique_id: pieceId,
+      indice: "A",
+      statut: "EN_VALIDATION",
+      updated_at: "2026-08-01T10:00:00.000Z",
+      date_effet: null,
+    };
+
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query === "BEGIN" || query === "COMMIT" || query === "ROLLBACK") return { rows: [] };
+      if (query.includes("indice_externe_original") && query.includes("FOR UPDATE")) {
+        return { rows: [currentVersion] };
+      }
+      if (query.includes("to_regclass('public.piece_document_types')")) return { rows: [{ ready: true }] };
+      if (query.includes("FROM public.pieces_techniques p")) {
+        return {
+          rows: [{
+            piece_technique_id: pieceId,
+            code_piece: "PT-001",
+            designation: "Pièce test",
+            client_id: null,
+            client_name: null,
+            piece_critique: false,
+            piece_critique_motif: null,
+            document_policy: "NONE",
+            selected: [],
+            current_version_id: versionId,
+            current_version_indice: "A",
+            current_version_statut: "EN_VALIDATION",
+            frozen_at: null,
+            frozen_policy: null,
+          }],
+        };
+      }
+      if (query.includes("FROM public.pieces_techniques_documents")) return { rows: [] };
+      if (query.includes("FROM public.piece_document_types")) return { rows: [] };
+      if (query.includes("SELECT document_requirements_frozen_at::text AS frozen_at")) {
+        return { rows: [{ frozen_at: null }] };
+      }
+      if (query.includes("statut = 'APPLICABLE',") && query.includes("RETURNING")) {
+        return { rows: [{ ...currentVersion, statut: "APPLICABLE", is_current: true }] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(`/api/v1/pieces-techniques/${pieceId}/versions/${versionId}/publish`)
+      .send({ expected_updated_at: currentVersion.updated_at });
+
+    expect(res.status).toBe(200);
+    const queries = mocks.clientQuery.mock.calls.map((call) => String(call[0]));
+    const freezeIndex = queries.findIndex((query) => query.includes("SET document_requirements_frozen_at = now()"));
+    const demoteIndex = queries.findIndex((query) => query.includes("SET statut = 'OBSOLETE'"));
+    const promoteIndex = queries.findIndex((query) => query.includes("statut = 'APPLICABLE',") && query.includes("RETURNING"));
+    expect(freezeIndex).toBeGreaterThan(-1);
+    expect(demoteIndex).toBeGreaterThan(freezeIndex);
+    expect(promoteIndex).toBeGreaterThan(demoteIndex);
+  });
+
+  it("freezes document requirements before the legacy status endpoint promotes a version", async () => {
+    const pieceId = "11111111-1111-4111-8111-111111111111";
+    const versionId = "22222222-2222-4222-8222-222222222222";
+    const currentVersion = {
+      id: versionId,
+      piece_technique_id: pieceId,
+      indice: "A",
+      statut: "EN_VALIDATION",
+      updated_at: "2026-08-01T10:00:00.000Z",
+      date_effet: null,
+    };
+    mocks.poolQuery.mockResolvedValue({ rows: [currentVersion] });
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query === "BEGIN" || query === "COMMIT" || query === "ROLLBACK") return { rows: [] };
+      if (query.includes("indice_externe_original") && query.includes("FOR UPDATE")) {
+        return { rows: [currentVersion] };
+      }
+      if (query.includes("to_regclass('public.piece_document_types')")) return { rows: [{ ready: true }] };
+      if (query.includes("FROM public.pieces_techniques p")) {
+        return {
+          rows: [{
+            piece_technique_id: pieceId,
+            code_piece: "PT-001",
+            designation: "Pièce test",
+            client_id: null,
+            client_name: null,
+            piece_critique: false,
+            piece_critique_motif: null,
+            document_policy: "NONE",
+            selected: [],
+            current_version_id: versionId,
+            current_version_indice: "A",
+            current_version_statut: "EN_VALIDATION",
+            frozen_at: null,
+            frozen_policy: null,
+          }],
+        };
+      }
+      if (query.includes("FROM public.pieces_techniques_documents")) return { rows: [] };
+      if (query.includes("FROM public.piece_document_types")) return { rows: [] };
+      if (query.includes("SELECT document_requirements_frozen_at::text AS frozen_at")) {
+        return { rows: [{ frozen_at: null }] };
+      }
+      if (query.includes("statut = $2") && query.includes("RETURNING")) {
+        return { rows: [{ ...currentVersion, statut: "APPLICABLE", is_current: true }] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .patch(`/api/v1/pieces-techniques/${pieceId}/versions/${versionId}/status`)
+      .send({ next_statut: "APPLICABLE", expected_updated_at: currentVersion.updated_at });
+
+    expect(res.status).toBe(200);
+    const queries = mocks.clientQuery.mock.calls.map((call) => String(call[0]));
+    const freezeIndex = queries.findIndex((query) => query.includes("SET document_requirements_frozen_at = now()"));
+    const demoteIndex = queries.findIndex((query) => query.includes("SET statut = 'OBSOLETE'"));
+    const promoteIndex = queries.findIndex((query) => query.includes("statut = $2") && query.includes("RETURNING"));
+    expect(freezeIndex).toBeGreaterThan(-1);
+    expect(demoteIndex).toBeGreaterThan(freezeIndex);
+    expect(promoteIndex).toBeGreaterThan(demoteIndex);
+  });
+
   it("refuses a future effective date before it can replace the current applicable version", async () => {
     const pieceId = "11111111-1111-4111-8111-111111111111";
     const versionId = "22222222-2222-4222-8222-222222222222";

--- a/src/module/pieces-techniques/repository/versions.repository.ts
+++ b/src/module/pieces-techniques/repository/versions.repository.ts
@@ -301,8 +301,8 @@ export async function repoUpdateVersionStatus(
   const client = await db.connect()
   try {
     await client.query("BEGIN")
-    const cur = await client.query<{ statut: VersionStatutDTO; updated_at: string; date_effet: string | null }>(
-      `SELECT statut, updated_at::text AS updated_at, date_effet::text AS date_effet FROM public.piece_technique_versions
+    const cur = await client.query<PieceTechniqueVersionRow>(
+      `SELECT ${VERSION_COLUMNS} FROM public.piece_technique_versions
        WHERE id = $1 AND piece_technique_id = $2 FOR UPDATE`,
       [versionId, pieceTechniqueId]
     )
@@ -315,8 +315,28 @@ export async function repoUpdateVersionStatus(
       throw new HttpError(409, "CONCURRENT_MODIFICATION", "La version a été modifiée entre-temps")
     }
 
+    // Les statuts validés sont immuables. Une répétition du même ordre est donc
+    // idempotente et ne doit pas émettre un UPDATE que le trigger refuserait.
+    if (current.statut === toStatut && (current.statut === "APPLICABLE" || current.statut === "OBSOLETE")) {
+      await client.query("COMMIT")
+      return current
+    }
+
     if (toStatut === "APPLICABLE") {
       await assertVersionEffectiveToday(client, current.date_effet)
+    }
+
+    // #227 — geler les exigences AVANT de rendre l'indice immuable. Le trigger
+    // PostgreSQL interdit toute modification fonctionnelle d'une version déjà
+    // APPLICABLE ; un gel exécuté après la promotion fait échouer la transaction.
+    // Le gel reste atomique : une promotion ultérieure en échec l'annule aussi.
+    let frozen: Awaited<ReturnType<typeof freezePieceVersionRequirements>> = null
+    if (toStatut === "APPLICABLE" && current.statut !== "APPLICABLE") {
+      frozen = await freezePieceVersionRequirements(client, {
+        pieceTechniqueId,
+        versionId,
+        userId: audit.user_id,
+      })
     }
 
     // Passe APPLICABLE : déclasser l'ancienne APPLICABLE d'abord (respecte l'index unique partiel).
@@ -344,20 +364,6 @@ export async function repoUpdateVersionStatus(
       [versionId, toStatut, isCurrent, extra.valide_par ?? audit.user_id, extra.date_application ?? null, extra.commentaire_validation ?? null, audit.user_id]
     )
     const row = res.rows[0]
-
-    // #227 — GEL des exigences documentaires au moment où l'indice devient applicable.
-    // Dans la MÊME transaction que la publication : une version publiée sans son
-    // instantané serait une version dont on ne saurait plus ce qu'elle exigeait.
-    // Idempotent côté service : un indice déjà gelé n'est jamais réécrit, donc une
-    // modification ultérieure de la politique du client ne remonte pas dans l'histoire.
-    let frozen: Awaited<ReturnType<typeof freezePieceVersionRequirements>> = null
-    if (toStatut === "APPLICABLE") {
-      frozen = await freezePieceVersionRequirements(client, {
-        pieceTechniqueId,
-        versionId,
-        userId: audit.user_id,
-      })
-    }
 
     await insertAudit(client, audit, "pieces-techniques.version.status", versionId, {
       piece_technique_id: pieceTechniqueId,
@@ -454,6 +460,14 @@ export async function repoPublishVersion(
       )
     }
 
+    // Le gel doit précéder la promotion finale : une version APPLICABLE est
+    // immuable au niveau PostgreSQL. L'ordre inverse déclenchait SQLSTATE 55000.
+    const frozen = await freezePieceVersionRequirements(client, {
+      pieceTechniqueId,
+      versionId,
+      userId: audit.user_id,
+    })
+
     // Déclasser l'ancienne applicable avant de promouvoir la nouvelle afin de
     // respecter l'index unique partiel, y compris sous concurrence.
     await client.query(
@@ -486,11 +500,6 @@ export async function repoPublishVersion(
     const row = published.rows[0]
     if (!row) throw new Error("Impossible de publier la version technique")
 
-    const frozen = await freezePieceVersionRequirements(client, {
-      pieceTechniqueId,
-      versionId,
-      userId: audit.user_id,
-    })
     await insertAudit(client, audit, "pieces-techniques.version.publish", versionId, {
       piece_technique_id: pieceTechniqueId,
       from: current.statut,


### PR DESCRIPTION
## Pourquoi

La recette réelle sur CERP_TEST a révélé une erreur PostgreSQL `55000` : le backend promouvait d’abord la version en `APPLICABLE`, puis tentait de figer ses exigences documentaires. Le trigger d’immuabilité bloquait alors ce second UPDATE.

## Correctif

- gèle les exigences documentaires avant la promotion, dans la même transaction ;
- applique le même ordre sûr à l’endpoint historique de statut ;
- rend les répétitions sur un statut validé idempotentes ;
- ajoute un patch SQL borné pour avancer uniquement une date d’effet encore future vers un effet immédiat ;
- fournit verify et rollback ;
- ajoute les tests de régression d’ordre SQL et les gardes de migration.

## Validation

- tests ciblés : 15/15 verts ;
- suite Vitest complète : verte ;
- build TypeScript : vert ;
- `git diff --check` : vert.

Issue liée : BigFootLime/crp-systems-web#461

## Summary by Sourcery

Ensure guided publication of technical versions freezes document requirements before promotion and preserves immutability rules for validated content.

Bug Fixes:
- Correct guided publication and legacy status updates so document requirements are frozen before making a version immutable, avoiding PostgreSQL 55000 errors.

Enhancements:
- Make repeated status updates toward already validated versions idempotent to avoid unnecessary writes.
- Extend the immutability trigger to allow only audited advancement of a still-future effective date to immediate effect while keeping validated content unchanged.
- Clarify documentation around guided publication, immutability, and the new effective-date advancement exception.

Deployment:
- Add a PostgreSQL patch, verification, and rollback scripts to enforce immutability of validated technical versions while permitting controlled advancement of future effective dates.

Tests:
- Add regression tests to verify SQL operation order for guided publication and legacy status updates, including freezing, demotion, and promotion sequence.
- Introduce migration guard tests for the new immutability trigger patch, including its transactional behavior, allowed exceptions, and rollback/verify scripts.