### PR TITLE
fix: secure gamme/version UUID route params

### DIFF
--- a/docs/route-param-hardening-170.md
+++ b/docs/route-param-hardening-170.md
@@ -12,11 +12,12 @@ garantie n’était pas reflétée dans les contrôleurs.
 
 ## Correction
 
-Chaque contrôleur extrait désormais le paramètre nommé avec une vérification
-défensive :
+Les contrôleurs Gammes et Versions utilisent désormais le helper partagé
+`parseUuidRouteParam`. Les schémas Zod de leurs routes réutilisent la même
+fabrique `uuidRouteParam` :
 
-- seule une chaîne non vide est acceptée ;
-- une valeur absente, vide ou multiple produit une erreur HTTP 400
+- seule une chaîne représentant un UUID valide est acceptée ;
+- une valeur absente, multiple ou non UUID produit une erreur HTTP 400
   `INVALID_ROUTE_PARAM` ;
 - les services continuent de recevoir exactement une chaîne ;
 - aucune règle métier, route ou donnée n’est modifiée.
@@ -24,5 +25,6 @@ défensive :
 ## Validation
 
 - compilation TypeScript complète ;
-- tests `gammes.test.ts` ;
-- tests `pieces-techniques-versions.test.ts`.
+- tests unitaires du helper (valide, absent, tableau, UUID invalide) ;
+- tests routes/contrôleurs Gammes et Versions (400, 404, appels nominaux,
+  création, mise à jour et réordonnancement).

--- a/src/__tests__/gammes-versions.routes.test.ts
+++ b/src/__tests__/gammes-versions.routes.test.ts
@@ -1,0 +1,215 @@
+import express from "express"
+import request from "supertest"
+import { afterAll, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  listGammesByVersion: vi.fn(),
+  createGamme: vi.fn(),
+  updateGamme: vi.fn(),
+  createGammeRevision: vi.fn(),
+  listGammeOperations: vi.fn(),
+  addGammeOperation: vi.fn(),
+  updateGammeOperation: vi.fn(),
+  deleteGammeOperation: vi.fn(),
+  nextPhase: vi.fn(),
+  reorderGammeOperations: vi.fn(),
+  gammePublicationReadiness: vi.fn(),
+  publishGamme: vi.fn(),
+  listVersions: vi.fn(),
+  createVersion: vi.fn(),
+  updateVersion: vi.fn(),
+  updateVersionStatus: vi.fn(),
+  publishVersion: vi.fn(),
+  createNextVersion: vi.fn(),
+}))
+
+vi.mock("../module/gammes/services/gammes.service", () => ({
+  listGammesByVersionSVC: mocks.listGammesByVersion,
+  createGammeSVC: mocks.createGamme,
+  updateGammeSVC: mocks.updateGamme,
+  createGammeRevisionSVC: mocks.createGammeRevision,
+  listGammeOperationsSVC: mocks.listGammeOperations,
+  addGammeOperationSVC: mocks.addGammeOperation,
+  updateGammeOperationSVC: mocks.updateGammeOperation,
+  deleteGammeOperationSVC: mocks.deleteGammeOperation,
+  nextPhaseSVC: mocks.nextPhase,
+  reorderGammeOperationsSVC: mocks.reorderGammeOperations,
+  gammePublicationReadinessSVC: mocks.gammePublicationReadiness,
+  publishGammeSVC: mocks.publishGamme,
+}))
+
+vi.mock("../module/pieces-techniques/services/versions.service", () => ({
+  listVersionsSVC: mocks.listVersions,
+  createVersionSVC: mocks.createVersion,
+  updateVersionSVC: mocks.updateVersion,
+  updateVersionStatusSVC: mocks.updateVersionStatus,
+  publishVersionSVC: mocks.publishVersion,
+  createNextVersionSVC: mocks.createNextVersion,
+}))
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (req: { user?: Record<string, unknown> }, _res: unknown, next: () => void) => {
+    req.user = {
+      id: 1,
+      username: "test-admin",
+      email: "admin@example.test",
+      role: "Administrateur Systeme et Reseau",
+    }
+    next()
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}))
+
+vi.mock("../module/methodes/middlewares/methodes-authorization.middleware", () => ({
+  requireMethodesCapability: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}))
+
+vi.mock("../utils/cerpStorage", () => ({
+  ensureDocumentStoragePath: () => process.cwd(),
+}))
+
+import gammesRoutes from "../module/gammes/routes/gammes.routes"
+import pieceTechniqueVersionsRoutes from "../module/gammes/routes/piece-technique-versions.routes"
+import piecesTechniquesRoutes from "../module/pieces-techniques/routes/pieces-techniques.routes"
+import { validationErrorMiddleware } from "../module/auth/middlewares/validationError.middleware"
+import { errorHandler } from "../middlewares/errorHandler"
+
+const PIECE_ID = "11111111-1111-4111-8111-111111111111"
+const VERSION_ID = "22222222-2222-4222-8222-222222222222"
+const GAMME_ID = "33333333-3333-4333-8333-333333333333"
+const OPERATION_ID = "44444444-4444-4444-8444-444444444444"
+
+const app = express()
+app.use(express.json())
+app.use("/piece-technique-versions", pieceTechniqueVersionsRoutes)
+app.use("/gammes", gammesRoutes)
+app.use("/pieces-techniques", piecesTechniquesRoutes)
+app.use(validationErrorMiddleware)
+app.use(errorHandler)
+
+const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.listGammesByVersion.mockResolvedValue([])
+  mocks.createGamme.mockResolvedValue({ id: GAMME_ID })
+  mocks.updateGamme.mockResolvedValue({ id: GAMME_ID })
+  mocks.listGammeOperations.mockResolvedValue([])
+  mocks.addGammeOperation.mockResolvedValue({ id: OPERATION_ID })
+  mocks.reorderGammeOperations.mockResolvedValue([{ id: OPERATION_ID }])
+  mocks.listVersions.mockResolvedValue([])
+  mocks.createVersion.mockResolvedValue({ id: VERSION_ID })
+  mocks.updateVersion.mockResolvedValue({ id: VERSION_ID })
+  mocks.updateVersionStatus.mockResolvedValue({ id: VERSION_ID, statut: "EN_VALIDATION" })
+  mocks.createNextVersion.mockResolvedValue({ id: VERSION_ID })
+})
+
+afterAll(() => {
+  consoleError.mockRestore()
+})
+
+describe("Routes/contrôleurs gammes et versions", () => {
+  it.each([
+    ["/piece-technique-versions/not-a-uuid/gammes", "versionId"],
+    ["/gammes/not-a-uuid/operations", "gammeId"],
+    ["/pieces-techniques/not-a-uuid/versions", "id"],
+  ])("renvoie 400 avant le service pour %s", async (path, paramName) => {
+    const response = await request(app).get(path)
+
+    expect(response.status).toBe(400)
+    expect(response.body).toMatchObject({ error: "VALIDATION_ERROR" })
+    expect(response.body.errors).toEqual(
+      expect.arrayContaining([expect.objectContaining({ message: expect.stringContaining(paramName) })])
+    )
+  })
+
+  it("préserve les six appels nominaux gamme, dont création et réordonnancement", async () => {
+    expect((await request(app).get(`/piece-technique-versions/${VERSION_ID}/gammes`)).status).toBe(200)
+    expect(
+      (await request(app).post(`/piece-technique-versions/${VERSION_ID}/gammes`).send({ nom: "Gamme principale" })).status
+    ).toBe(201)
+    expect((await request(app).patch(`/gammes/${GAMME_ID}`).send({ commentaire: "Mise à jour" })).status).toBe(200)
+    expect((await request(app).get(`/gammes/${GAMME_ID}/operations`)).status).toBe(200)
+    expect((await request(app).post(`/gammes/${GAMME_ID}/operations`).send({ designation: "Tournage" })).status).toBe(201)
+    expect(
+      (await request(app).patch(`/gammes/${GAMME_ID}/operations/reorder`).send({ order: [OPERATION_ID] })).status
+    ).toBe(200)
+
+    expect(mocks.listGammesByVersion).toHaveBeenCalledWith(VERSION_ID)
+    expect(mocks.createGamme).toHaveBeenCalledWith(
+      VERSION_ID,
+      expect.objectContaining({ nom: "Gamme principale", statut: "BROUILLON", is_current: false }),
+      expect.objectContaining({ user_id: 1 })
+    )
+    expect(mocks.updateGamme).toHaveBeenCalledWith(
+      GAMME_ID,
+      expect.objectContaining({ commentaire: "Mise à jour" }),
+      expect.objectContaining({ user_id: 1 })
+    )
+    expect(mocks.listGammeOperations).toHaveBeenCalledWith(GAMME_ID)
+    expect(mocks.addGammeOperation).toHaveBeenCalledWith(
+      GAMME_ID,
+      expect.objectContaining({ designation: "Tournage" }),
+      expect.objectContaining({ user_id: 1 })
+    )
+    expect(mocks.reorderGammeOperations).toHaveBeenCalledWith(
+      GAMME_ID,
+      [OPERATION_ID],
+      expect.objectContaining({ user_id: 1 })
+    )
+  })
+
+  it("préserve les cinq appels nominaux version", async () => {
+    expect((await request(app).get(`/pieces-techniques/${PIECE_ID}/versions`)).status).toBe(200)
+    expect((await request(app).post(`/pieces-techniques/${PIECE_ID}/versions`).send({ indice: "A" })).status).toBe(201)
+    expect(
+      (await request(app).patch(`/pieces-techniques/${PIECE_ID}/versions/${VERSION_ID}`).send({ commentaire_revision: "R1" })).status
+    ).toBe(200)
+    expect(
+      (await request(app).patch(`/pieces-techniques/${PIECE_ID}/versions/${VERSION_ID}/status`).send({ next_statut: "EN_VALIDATION" })).status
+    ).toBe(200)
+    expect(
+      (await request(app).post(`/pieces-techniques/${PIECE_ID}/versions/${VERSION_ID}/create-next`).send({ indice: "B" })).status
+    ).toBe(201)
+
+    expect(mocks.listVersions).toHaveBeenCalledWith(PIECE_ID)
+    expect(mocks.createVersion).toHaveBeenCalledWith(
+      PIECE_ID,
+      expect.objectContaining({ indice: "A" }),
+      expect.objectContaining({ user_id: 1 })
+    )
+    expect(mocks.updateVersion).toHaveBeenCalledWith(
+      PIECE_ID,
+      VERSION_ID,
+      expect.objectContaining({ commentaire_revision: "R1" }),
+      expect.objectContaining({ user_id: 1 })
+    )
+    expect(mocks.updateVersionStatus).toHaveBeenCalledWith(
+      PIECE_ID,
+      VERSION_ID,
+      expect.objectContaining({ next_statut: "EN_VALIDATION" }),
+      expect.objectContaining({ user_id: 1 })
+    )
+    expect(mocks.createNextVersion).toHaveBeenCalledWith(
+      PIECE_ID,
+      VERSION_ID,
+      expect.objectContaining({ indice: "B" }),
+      expect.objectContaining({ user_id: 1 })
+    )
+  })
+
+  it("conserve les 404 métier des mises à jour introuvables", async () => {
+    mocks.updateGamme.mockResolvedValueOnce(null)
+    mocks.updateVersion.mockResolvedValueOnce(null)
+
+    const gamme = await request(app).patch(`/gammes/${GAMME_ID}`).send({ commentaire: "Absent" })
+    const version = await request(app)
+      .patch(`/pieces-techniques/${PIECE_ID}/versions/${VERSION_ID}`)
+      .send({ commentaire_revision: "Absent" })
+
+    expect(gamme.status).toBe(404)
+    expect(gamme.body).toMatchObject({ code: "NOT_FOUND", message: "Gamme introuvable" })
+    expect(version.status).toBe(404)
+    expect(version.body).toMatchObject({ code: "NOT_FOUND", message: "Version introuvable" })
+  })
+})

--- a/src/__tests__/route-params.test.ts
+++ b/src/__tests__/route-params.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest"
+
+import { gammeIdParamSchema, operationIdParamSchema, versionIdParamSchema as gammeVersionIdParamSchema } from "../module/gammes/validators/gammes.validators"
+import { idParamSchema } from "../module/pieces-techniques/validators/pieces-techniques.validators"
+import { versionIdParamSchema } from "../module/pieces-techniques/validators/versions.validators"
+import { HttpError } from "../utils/httpError"
+import { parseUuidRouteParam } from "../utils/routeParams"
+
+const PIECE_ID = "11111111-1111-4111-8111-111111111111"
+const VERSION_ID = "22222222-2222-4222-8222-222222222222"
+const GAMME_ID = "33333333-3333-4333-8333-333333333333"
+const OPERATION_ID = "44444444-4444-4444-8444-444444444444"
+
+describe("Paramètres de route UUID", () => {
+  it("retourne uniquement une chaîne UUID validée", () => {
+    expect(parseUuidRouteParam({ versionId: VERSION_ID }, "versionId")).toBe(VERSION_ID)
+  })
+
+  it.each([
+    ["absent", {}],
+    ["multiple", { versionId: [VERSION_ID, VERSION_ID] }],
+    ["non UUID", { versionId: "version-A" }],
+  ])("refuse un paramètre %s avec une erreur 400 actionnable", (_label, params) => {
+    expect.assertions(4)
+    try {
+      parseUuidRouteParam(params, "versionId")
+    } catch (error) {
+      if (!(error instanceof Error)) throw error
+      expect(error).toBeInstanceOf(HttpError)
+      expect(error).toMatchObject({ status: 400, code: "INVALID_ROUTE_PARAM" })
+      expect(error.message).toContain("versionId")
+      expect(error.message).toMatch(/requis|une seule fois|UUID valide/)
+    }
+  })
+
+  it("conserve les schémas de paramètres des routes gamme/version strictement UUID", () => {
+    expect(gammeVersionIdParamSchema.safeParse({ params: { versionId: VERSION_ID } }).success).toBe(true)
+    expect(gammeIdParamSchema.safeParse({ params: { gammeId: GAMME_ID } }).success).toBe(true)
+    expect(operationIdParamSchema.safeParse({ params: { gammeId: GAMME_ID, operationId: OPERATION_ID } }).success).toBe(true)
+    expect(idParamSchema.safeParse({ params: { id: PIECE_ID } }).success).toBe(true)
+    expect(versionIdParamSchema.safeParse({ params: { id: PIECE_ID, versionId: VERSION_ID } }).success).toBe(true)
+
+    expect(gammeIdParamSchema.safeParse({ params: { gammeId: [GAMME_ID] } }).success).toBe(false)
+    expect(versionIdParamSchema.safeParse({ params: { id: PIECE_ID, versionId: "A" } }).success).toBe(false)
+  })
+})

--- a/src/module/gammes/controllers/gammes.controller.ts
+++ b/src/module/gammes/controllers/gammes.controller.ts
@@ -2,6 +2,7 @@
 // GPAO B2.2 — HTTP handlers gammes + opérations de gamme.
 import type { Request, RequestHandler } from "express"
 import { HttpError } from "../../../utils/httpError"
+import { parseUuidRouteParam } from "../../../utils/routeParams"
 import type { AuditContext } from "../../pieces-techniques/repository/pieces-techniques.repository"
 import {
   addGammeOperationSchema,
@@ -54,17 +55,9 @@ function buildAuditContext(req: Request): AuditContext {
   }
 }
 
-function routeParam(req: Request, name: string): string {
-  const value = req.params[name]
-  if (typeof value !== "string" || value.length === 0) {
-    throw new HttpError(400, "INVALID_ROUTE_PARAM", `Paramètre de route invalide : ${name}`)
-  }
-  return value
-}
-
 export const listGammesByVersion: RequestHandler = async (req, res, next) => {
   try {
-    const items = await listGammesByVersionSVC(routeParam(req, "versionId"))
+    const items = await listGammesByVersionSVC(parseUuidRouteParam(req.params, "versionId"))
     res.json(items)
   } catch (err) {
     next(err)
@@ -75,7 +68,7 @@ export const createGamme: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = createGammeSchema.parse({ body: req.body }).body
-    const out = await createGammeSVC(routeParam(req, "versionId"), body, audit)
+    const out = await createGammeSVC(parseUuidRouteParam(req.params, "versionId"), body, audit)
     res.status(201).json(out)
   } catch (err) {
     next(err)
@@ -86,7 +79,7 @@ export const updateGamme: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = updateGammeSchema.parse({ body: req.body }).body
-    const out = await updateGammeSVC(routeParam(req, "gammeId"), body, audit)
+    const out = await updateGammeSVC(parseUuidRouteParam(req.params, "gammeId"), body, audit)
     if (!out) throw new HttpError(404, "NOT_FOUND", "Gamme introuvable")
     res.json(out)
   } catch (err) {
@@ -114,7 +107,7 @@ export const createGammeRevision: RequestHandler = async (req, res, next) => {
         "Une clé Idempotency-Key stable de 8 à 200 caractères est obligatoire."
       )
     }
-    const out = await createGammeRevisionSVC(routeParam(req, "gammeId"), body, audit, idempotencyKey)
+    const out = await createGammeRevisionSVC(parseUuidRouteParam(req.params, "gammeId"), body, audit, idempotencyKey)
     res.status(out.replayed ? 200 : 201).json(out)
   } catch (err) {
     next(err)
@@ -123,7 +116,7 @@ export const createGammeRevision: RequestHandler = async (req, res, next) => {
 
 export const listGammeOperations: RequestHandler = async (req, res, next) => {
   try {
-    const items = await listGammeOperationsSVC(routeParam(req, "gammeId"))
+    const items = await listGammeOperationsSVC(parseUuidRouteParam(req.params, "gammeId"))
     res.json(items)
   } catch (err) {
     next(err)
@@ -134,7 +127,7 @@ export const addGammeOperation: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = addGammeOperationSchema.parse({ body: req.body }).body
-    const out = await addGammeOperationSVC(routeParam(req, "gammeId"), body, audit)
+    const out = await addGammeOperationSVC(parseUuidRouteParam(req.params, "gammeId"), body, audit)
     res.status(201).json(out)
   } catch (err) {
     next(err)
@@ -146,8 +139,8 @@ export const updateGammeOperation: RequestHandler = async (req, res, next) => {
     const audit = buildAuditContext(req)
     const body = updateGammeOperationSchema.parse({ body: req.body }).body
     const out = await updateGammeOperationSVC(
-      routeParam(req, "gammeId"),
-      routeParam(req, "operationId"),
+      parseUuidRouteParam(req.params, "gammeId"),
+      parseUuidRouteParam(req.params, "operationId"),
       body,
       audit
     )
@@ -162,8 +155,8 @@ export const deleteGammeOperation: RequestHandler = async (req, res, next) => {
     const audit = buildAuditContext(req)
     const body = deleteGammeOperationSchema.parse({ body: req.body }).body
     await deleteGammeOperationSVC(
-      routeParam(req, "gammeId"),
-      routeParam(req, "operationId"),
+      parseUuidRouteParam(req.params, "gammeId"),
+      parseUuidRouteParam(req.params, "operationId"),
       body.expected_updated_at,
       audit
     )
@@ -181,7 +174,7 @@ export const deleteGammeOperation: RequestHandler = async (req, res, next) => {
 export const nextGammeOperationPhase: RequestHandler = async (req, res, next) => {
   try {
     const after = typeof req.query.after_operation_id === "string" ? req.query.after_operation_id : null
-    res.json(await nextPhaseSVC(routeParam(req, "gammeId"), after))
+    res.json(await nextPhaseSVC(parseUuidRouteParam(req.params, "gammeId"), after))
   } catch (err) {
     next(err)
   }
@@ -191,7 +184,7 @@ export const reorderGammeOperations: RequestHandler = async (req, res, next) => 
   try {
     const audit = buildAuditContext(req)
     const body = reorderOperationsSchema.parse({ body: req.body }).body
-    const out = await reorderGammeOperationsSVC(routeParam(req, "gammeId"), body.order, audit)
+    const out = await reorderGammeOperationsSVC(parseUuidRouteParam(req.params, "gammeId"), body.order, audit)
     res.json(out)
   } catch (err) {
     next(err)
@@ -200,7 +193,7 @@ export const reorderGammeOperations: RequestHandler = async (req, res, next) => 
 
 export const readGammePublicationReadiness: RequestHandler = async (req, res, next) => {
   try {
-    res.json(await gammePublicationReadinessSVC(routeParam(req, "gammeId")))
+    res.json(await gammePublicationReadinessSVC(parseUuidRouteParam(req.params, "gammeId")))
   } catch (err) {
     next(err)
   }
@@ -210,7 +203,7 @@ export const publishGamme: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = publishGammeSchema.parse({ body: req.body }).body
-    res.json(await publishGammeSVC(routeParam(req, "gammeId"), body.expected_updated_at, audit))
+    res.json(await publishGammeSVC(parseUuidRouteParam(req.params, "gammeId"), body.expected_updated_at, audit))
   } catch (err) {
     next(err)
   }

--- a/src/module/gammes/validators/gammes.validators.ts
+++ b/src/module/gammes/validators/gammes.validators.ts
@@ -2,6 +2,7 @@
 // GPAO B2.2 — validators des gammes + opérations de gamme.
 import type { RequestHandler } from "express"
 import { z } from "zod"
+import { uuidRouteParam } from "../../../utils/routeParams"
 
 const uuid = z.string().uuid()
 
@@ -23,8 +24,8 @@ export const operationTypeSchema = z.enum([
 ])
 export type OperationTypeDTO = z.infer<typeof operationTypeSchema>
 
-export const versionIdParamSchema = z.object({ params: z.object({ versionId: uuid }) })
-export const gammeIdParamSchema = z.object({ params: z.object({ gammeId: uuid }) })
+export const versionIdParamSchema = z.object({ params: z.object({ versionId: uuidRouteParam("versionId") }) })
+export const gammeIdParamSchema = z.object({ params: z.object({ gammeId: uuidRouteParam("gammeId") }) })
 
 const gammeCore = z.object({
   // #227 — le nom devient OPTIONNEL : le serveur le calcule depuis la pièce et l'indice
@@ -131,7 +132,9 @@ export const deleteGammeOperationSchema = z.object({
   body: z.object({ expected_updated_at: z.string().trim().min(1, "expected_updated_at est obligatoire") }),
 })
 
-export const operationIdParamSchema = z.object({ params: z.object({ gammeId: uuid, operationId: uuid }) })
+export const operationIdParamSchema = z.object({
+  params: z.object({ gammeId: uuidRouteParam("gammeId"), operationId: uuidRouteParam("operationId") }),
+})
 
 export const nextPhaseQuerySchema = z.object({
   query: z.object({ after_operation_id: uuid.optional() }),

--- a/src/module/pieces-techniques/controllers/versions.controller.ts
+++ b/src/module/pieces-techniques/controllers/versions.controller.ts
@@ -2,6 +2,7 @@
 // GPAO B2.1 — HTTP handlers des versions/indices.
 import type { Request, RequestHandler } from "express"
 import { HttpError } from "../../../utils/httpError"
+import { parseUuidRouteParam } from "../../../utils/routeParams"
 import type { AuditContext } from "../repository/pieces-techniques.repository"
 import {
   createNextVersionSchema,
@@ -45,17 +46,9 @@ function buildAuditContext(req: Request): AuditContext {
   }
 }
 
-function routeParam(req: Request, name: string): string {
-  const value = req.params[name]
-  if (typeof value !== "string" || value.length === 0) {
-    throw new HttpError(400, "INVALID_ROUTE_PARAM", `Paramètre de route invalide : ${name}`)
-  }
-  return value
-}
-
 export const listVersions: RequestHandler = async (req, res, next) => {
   try {
-    const items = await listVersionsSVC(routeParam(req, "id"))
+    const items = await listVersionsSVC(parseUuidRouteParam(req.params, "id"))
     res.json(items)
   } catch (err) {
     next(err)
@@ -66,7 +59,7 @@ export const createVersion: RequestHandler = async (req, res, next) => {
   try {
     const audit = buildAuditContext(req)
     const body = createVersionSchema.parse({ body: req.body }).body
-    const out = await createVersionSVC(routeParam(req, "id"), body, audit)
+    const out = await createVersionSVC(parseUuidRouteParam(req.params, "id"), body, audit)
     res.status(201).json(out)
   } catch (err) {
     next(err)
@@ -78,8 +71,8 @@ export const updateVersion: RequestHandler = async (req, res, next) => {
     const audit = buildAuditContext(req)
     const body = updateVersionSchema.parse({ body: req.body }).body
     const out = await updateVersionSVC(
-      routeParam(req, "id"),
-      routeParam(req, "versionId"),
+      parseUuidRouteParam(req.params, "id"),
+      parseUuidRouteParam(req.params, "versionId"),
       body,
       audit
     )
@@ -95,8 +88,8 @@ export const updateVersionStatus: RequestHandler = async (req, res, next) => {
     const audit = buildAuditContext(req)
     const body = versionStatusSchema.parse({ body: req.body }).body
     const out = await updateVersionStatusSVC(
-      routeParam(req, "id"),
-      routeParam(req, "versionId"),
+      parseUuidRouteParam(req.params, "id"),
+      parseUuidRouteParam(req.params, "versionId"),
       body,
       audit
     )
@@ -112,8 +105,8 @@ export const publishVersion: RequestHandler = async (req, res, next) => {
     const audit = buildAuditContext(req)
     const body = publishVersionSchema.parse({ body: req.body }).body
     const out = await publishVersionSVC(
-      routeParam(req, "id"),
-      routeParam(req, "versionId"),
+      parseUuidRouteParam(req.params, "id"),
+      parseUuidRouteParam(req.params, "versionId"),
       body,
       audit
     )
@@ -129,8 +122,8 @@ export const createNextVersion: RequestHandler = async (req, res, next) => {
     const audit = buildAuditContext(req)
     const body = createNextVersionSchema.parse({ body: req.body }).body
     const out = await createNextVersionSVC(
-      routeParam(req, "id"),
-      routeParam(req, "versionId"),
+      parseUuidRouteParam(req.params, "id"),
+      parseUuidRouteParam(req.params, "versionId"),
       body,
       audit
     )

--- a/src/module/pieces-techniques/validators/pieces-techniques.validators.ts
+++ b/src/module/pieces-techniques/validators/pieces-techniques.validators.ts
@@ -1,6 +1,7 @@
 // src/module/pieces-techniques/validators/pieces-techniques.validators.ts
 import type { RequestHandler } from "express"
 import { z } from "zod"
+import { uuidRouteParam } from "../../../utils/routeParams"
 
 const uuid = z.string().uuid()
 
@@ -14,7 +15,7 @@ export const pieceTechniqueStatutSchema = z.enum([
 export type PieceTechniqueStatutDTO = z.infer<typeof pieceTechniqueStatutSchema>
 
 export const idParamSchema = z.object({
-  params: z.object({ id: uuid }),
+  params: z.object({ id: uuidRouteParam("id") }),
 })
 
 export const bomLineIdParamSchema = z.object({

--- a/src/module/pieces-techniques/validators/versions.validators.ts
+++ b/src/module/pieces-techniques/validators/versions.validators.ts
@@ -1,6 +1,7 @@
 // src/module/pieces-techniques/validators/versions.validators.ts
 // GPAO B2.1 — validators des versions/indices d'une pièce technique.
 import { z } from "zod"
+import { uuidRouteParam } from "../../../utils/routeParams"
 
 const uuid = z.string().uuid()
 
@@ -22,7 +23,7 @@ export const typeChangementSchema = z.enum(["EVOLUTION", "MODIFICATION"])
 export type TypeChangementDTO = z.infer<typeof typeChangementSchema>
 
 export const versionIdParamSchema = z.object({
-  params: z.object({ id: uuid, versionId: uuid }),
+  params: z.object({ id: uuidRouteParam("id"), versionId: uuidRouteParam("versionId") }),
 })
 
 const versionCoreBody = z.object({

--- a/src/utils/routeParams.ts
+++ b/src/utils/routeParams.ts
@@ -1,0 +1,28 @@
+import { z } from "zod"
+
+import { HttpError } from "./httpError"
+
+export function uuidRouteParam(name: string) {
+  return z
+    .string({
+      required_error: `Le paramètre de route "${name}" est requis`,
+      invalid_type_error: `Le paramètre de route "${name}" doit être fourni une seule fois sous forme de chaîne`,
+    })
+    .uuid(`Le paramètre de route "${name}" doit être un UUID valide`)
+}
+
+/**
+ * Narrows the Express 5 route-param union only after runtime UUID validation.
+ * Missing params and wildcard arrays are rejected before reaching services.
+ */
+export function parseUuidRouteParam(params: Readonly<Record<string, unknown>>, name: string): string {
+  const parsed = uuidRouteParam(name).safeParse(params[name])
+  if (!parsed.success) {
+    throw new HttpError(
+      400,
+      "INVALID_ROUTE_PARAM",
+      parsed.error.issues[0]?.message ?? `Le paramètre de route "${name}" est invalide`
+    )
+  }
+  return parsed.data
+}


### PR DESCRIPTION
## Résumé
- centralise le narrowing des paramètres Express via validation UUID Zod
- rejette paramètres absents, multiples ou non UUID avec HTTP 400 actionnable
- préserve les signatures services/repositories, l’audit et les 404 métier
- couvre les appels nominaux gamme/version, création, mise à jour et réordonnancement

## Validation
- `npm run build`
- `npx tsc -p tsconfig.json`
- `npm run test:run -- --reporter=basic` — 164 fichiers, 3508 tests
- compilation vérifiée avec `@types/express-serve-static-core@5.1.3` installée sans modification du manifeste

## Summary by Sourcery

Harden UUID route parameter handling for gamme and version endpoints using centralized validation, ensuring invalid or ambiguous params fail fast with actionable 400 errors while preserving existing business behaviours.

Bug Fixes:
- Reject missing, duplicated or non-UUID route parameters for gamme and version routes with consistent HTTP 400 INVALID_ROUTE_PARAM responses.

Enhancements:
- Introduce shared uuidRouteParam/parseUuidRouteParam helpers and wire them into controllers and Zod validators for gamme and version resources.
- Add tests covering UUID route parameter validation, nominal gamme/version flows and preservation of 404 business errors.
- Update documentation to describe the new UUID-based route parameter validation and associated test coverage.

Tests:
- Add integration-style tests for gamme and version routes/controllers to assert 400 validation errors, nominal success paths and unchanged 404 behaviour.
- Add unit tests for the shared UUID route parameter helper and the updated Zod parameter schemas.