### PR TITLE
fix(access): versionner le contrat du profil

### DIFF
--- a/docs/module-access-catalog.md
+++ b/docs/module-access-catalog.md
@@ -43,6 +43,27 @@ journalise les anciens overrides avant de les retirer et garantit l'unicité du
 superadmin KEENAN. Préflight et vérification sont obligatoires sur `cerp_test`
 avant `cerp_prod`.
 
+## Contrat `access-profile` v1
+
+`GET /api/v1/auth/access-profile` exige un JWT valide et répond pour tout compte
+authentifié. La réponse canonique contient `contract_version: 1`,
+`cache_ttl_seconds`, `is_superadmin` et la liste `modules`. Chaque module porte
+`module_key`, `label`, `nav_page_keys`, `allowed` et `source`. Le frontend peut
+masquer une entrée à partir de ce profil, mais cette visibilité ne remplace
+jamais le gate serveur : un accès direct explicitement refusé reste un `403`.
+
+Le cache serveur converge au plus tard dans le délai annoncé par
+`cache_ttl_seconds` et les mutations locales l'invalident immédiatement. Pendant
+un déploiement progressif, un frontend récent accepte l'ancienne réponse sans
+métadonnées et utilise dix secondes par défaut ; un frontend ancien ignore les
+deux champs additifs.
+
+Ordre de déploiement : backend, tests `401/403/200` sur `cerp_test`, puis
+frontend. Le rollback applicatif consiste à remettre le frontend précédent puis
+le backend précédent ; aucun rollback SQL n'est requis pour ces deux champs de
+réponse additifs. Les restrictions en base et leurs journaux ne sont jamais
+supprimés par ce rollback.
+
 ## Réparation #402
 
 Le patch `20260730_repair_module_catalog_visibility_402.sql` remet le catalogue

--- a/src/__tests__/access-control.test.ts
+++ b/src/__tests__/access-control.test.ts
@@ -418,7 +418,12 @@ describe("Résolution du profil d'accès", () => {
 
   it("infrastructure absente (42P01) : profil vide en 200, jamais un refus", async () => {
     repo.repoResolveAccessProfile.mockResolvedValue(null);
-    expect(await service.getAccessProfile(OPERATEUR_ID)).toEqual({ is_superadmin: false, modules: [] });
+    expect(await service.getAccessProfile(OPERATEUR_ID)).toEqual({
+      contract_version: 1,
+      cache_ttl_seconds: 10,
+      is_superadmin: false,
+      modules: [],
+    });
   });
 
   it("met le profil en cache et le relit après invalidation explicite", async () => {
@@ -563,6 +568,13 @@ describe("Surface HTTP /admin/access", () => {
 });
 
 describe("Profil d'accès et exposition du marqueur superadmin", () => {
+  it("GET /auth/access-profile refuse 401 sans authentification", async () => {
+    const res = await request(app).get("/api/v1/auth/access-profile");
+
+    expect(res.status).toBe(401);
+    expect(repo.repoResolveAccessProfile).not.toHaveBeenCalled();
+  });
+
   it("GET /auth/access-profile est ouvert à tout compte authentifié", async () => {
     repo.repoResolveAccessProfile.mockResolvedValue([
       {
@@ -583,6 +595,7 @@ describe("Profil d'accès et exposition du marqueur superadmin", () => {
       .set("x-test-user-id", String(OPERATEUR_ID));
 
     expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ contract_version: 1, cache_ttl_seconds: 10 });
     expect(res.body.is_superadmin).toBe(false);
     expect(res.body.modules[0]).toMatchObject({ module_key: "clients", allowed: true, source: "DEFAULT" });
   });

--- a/src/__tests__/multi-role-rbac.test.ts
+++ b/src/__tests__/multi-role-rbac.test.ts
@@ -176,6 +176,20 @@ describe("RBAC multi-rôles #315", () => {
     expect(invalid.success).toBe(false);
   });
 
+  it("refuse les rôles inconnus au lieu de fabriquer une autorisation", () => {
+    expect(
+      adminCreateUserSchema.safeParse({
+        body: { ...validUserBody, role: "Directeur Technique Inconnu" },
+      }).success
+    ).toBe(false);
+    expect(
+      adminCreateUserSchema.safeParse({
+        body: { ...validUserBody, roles: ["Directeur", "Role-Inconnu"] },
+      }).success
+    ).toBe(false);
+    expect(authorizationRole("Role-Inconnu", ["Role-Inconnu"])).toBe("");
+  });
+
   it("autorise un compte ERP incomplet sans inventer de données RH", () => {
     const accountOnly = {
       ...validUserBody,

--- a/src/module/access-control/services/access-control.service.ts
+++ b/src/module/access-control/services/access-control.service.ts
@@ -5,6 +5,7 @@ import * as repo from "../repository/access-control.repository";
 import type { CatalogModuleRow, DbQueryer } from "../repository/access-control.repository";
 import type {
   AccessAuditContext,
+  AccessProfileResponse,
   AccessOverview,
   ModuleAccessDecision,
   ModuleAccessOverride,
@@ -20,6 +21,7 @@ const UNLOCK_ALL_CONFIRMATION = "DEBLOQUER TOUT";
 
 /** Durée de vie du cache de résolution, en millisecondes. */
 export const ACCESS_CACHE_TTL_MS = 10_000;
+export const ACCESS_PROFILE_CONTRACT_VERSION = 1 as const;
 
 type CacheEntry = { expiresAt: number; profile: ResolvedAccessProfile };
 
@@ -84,10 +86,14 @@ export async function resolveAccessProfile(userId: number): Promise<ResolvedAcce
   return profile;
 }
 
-/** Réponse de `GET /auth/access-profile`. Infrastructure absente ⇒ aucun filtrage. */
-export async function getAccessProfile(userId: number): Promise<ResolvedAccessProfile> {
+/** Réponse versionnée de `GET /auth/access-profile`. Infrastructure absente ⇒ aucun filtrage. */
+export async function getAccessProfile(userId: number): Promise<AccessProfileResponse> {
   const profile = await resolveAccessProfile(userId);
-  return profile ?? { is_superadmin: false, modules: [] };
+  return {
+    contract_version: ACCESS_PROFILE_CONTRACT_VERSION,
+    cache_ttl_seconds: ACCESS_CACHE_TTL_MS / 1000,
+    ...(profile ?? { is_superadmin: false, modules: [] }),
+  };
 }
 
 export async function isSuperadmin(userId: number): Promise<boolean> {

--- a/src/module/access-control/types/access-control.types.ts
+++ b/src/module/access-control/types/access-control.types.ts
@@ -36,6 +36,11 @@ export type ResolvedAccessProfile = {
   modules: ResolvedModuleAccess[];
 };
 
+export type AccessProfileResponse = ResolvedAccessProfile & {
+  contract_version: 1;
+  cache_ttl_seconds: number;
+};
+
 export type OverviewModuleRow = {
   module_key: string;
   label: string;


### PR DESCRIPTION
## Résultat

`GET /api/v1/auth/access-profile` publie un contrat v1 explicite avec son TTL de cache, tout en conservant le backend comme autorité pour les accès directs. Les rôles inconnus restent refusés sans rapprochement approximatif.

## Cause racine

Le endpoint, les profils module/compte, le multi-rôle exact et les gates 401/403 existaient déjà sur `dev`. Il manquait un marqueur de version/TTL au contrat et des preuves explicites pour le profil non authentifié et les rôles inconnus.

## Changements

- ajoute `contract_version: 1` et `cache_ttl_seconds` au contrat ;
- dérive le TTL publié de la politique de cache existante ;
- conserve le profil fail-safe quand l’infrastructure d’accès est absente ;
- ajoute la preuve 401 du profil et les assertions de contrat ;
- prouve le refus exact des rôles primaires/secondaires inconnus ;
- documente autorité serveur, cohérence du cache, compatibilité progressive, déploiement et rollback.

## Validation

- `pnpm test:run` — suite complète verte
- `pnpm build` — vert
- tests ciblés après rebase — 4 fichiers, 67 tests verts
- matrice couverte : profil 401/200 ; surface admin 401/403/200 ; route métier directe 401/403/200 selon décision

## Déploiement / rollback

1. Déployer ce backend en premier.
2. Vérifier le contrat v1 et la matrice 401/403/200 sur `cerp_test`.
3. Déployer le frontend consommateur.
4. Rollback : frontend puis backend. Aucun changement SQL ni donnée à supprimer.

Refs BigFootLime/crp-systems-web#326
Refs #200

## Summary by Sourcery

Version the access profile API response with an explicit contract marker and cache TTL while keeping fail-safe behavior when access infrastructure is unavailable.

New Features:
- Expose `contract_version` and `cache_ttl_seconds` in the `GET /api/v1/auth/access-profile` response to define a versioned client-facing contract.

Bug Fixes:
- Ensure unknown primary and secondary roles are rejected instead of accidentally granting authorization.

Enhancements:
- Wrap resolved access profiles in a typed `AccessProfileResponse` that consistently includes contract version and TTL metadata.
- Clarify and extend documentation for the `access-profile` v1 contract, cache convergence, server authority, and deployment/rollback order.

Documentation:
- Document the `access-profile` v1 HTTP contract, including response shape, caching semantics, and progressive deployment/rollback strategy.

Tests:
- Add tests asserting the new contract fields in `access-profile` responses, 401 behavior for unauthenticated access, fail-safe empty profile when infrastructure is missing, and strict rejection of unknown roles.