### PR TITLE
fix(devis): accepter les champs de préparation facultatifs

### DIFF
--- a/docs/devis-workflow-167.md
+++ b/docs/devis-workflow-167.md
@@ -138,3 +138,16 @@ Cas particulier : l'audit de conversion est écrit après COMMIT du moteur comma
 `support/`). Appliqué sur **cerp_test** le 2026-07-22 (backup pris, verify vert,
 ownership `cerp_app` réassigné). **cerp_prod NON modifié** — application prod
 uniquement après validation humaine explicite.
+
+## 11. Champs de préparation facultatifs (#470)
+
+Le contrat d'entrée d'une ligne de devis distingue désormais la préparation
+explicite de ses valeurs par défaut :
+
+- propriété absente, `null`, objet vide ou chaînes uniquement blanches : aucune
+  préparation explicite ; le validateur normalise la propriété vers l'absence ;
+- objet renseigné : les chaînes sont tronquées et les valeurs non blanches sont
+  conservées ; les identifiants facultatifs acceptent l'absence ou `null` ;
+- le frontend complète un objet partiel avec les mêmes valeurs préparatoires
+  historiques avant l'appel API. Les prix, totaux, statuts et permissions ne
+  sont pas modifiés par ce contrat.

--- a/src/__tests__/devis.routes.test.ts
+++ b/src/__tests__/devis.routes.test.ts
@@ -753,6 +753,33 @@ describe("/api/v1/devis", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it("POST /api/v1/devis refuse un dossier préparatoire orphelin sans écriture", async () => {
+    const payload = {
+      client_id: "001",
+      user_id: 1,
+      lignes: [{
+        description: "Line",
+        quantite: 1,
+        prix_unitaire_ht: 100,
+        dossier_technique_piece_devis: {
+          code_piece: "DOS-42",
+          designation: "Dossier orphelin",
+        },
+      }],
+    };
+
+    const res = await request(app)
+      .post("/api/v1/devis")
+      .field("data", JSON.stringify(payload));
+
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "article_devis est requis lorsqu'un dossier_technique_piece_devis est fourni",
+    });
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
   it("PATCH /api/v1/devis/:id supports multipart update (replace lignes)", async () => {
     state.updateCurrent = {
       id: "7",

--- a/src/module/devis/repository/devis.repository.ts
+++ b/src/module/devis/repository/devis.repository.ts
@@ -861,7 +861,16 @@ type InsertedDevisLine = {
 async function insertDevisPreparatoryEntities(client: PoolClient, devisId: number, lines: InsertedDevisLine[]) {
   for (const line of lines) {
     const source = line.input;
-    if (!source.article_devis) continue;
+    if (!source.article_devis) {
+      if (source.dossier_technique_piece_devis) {
+        throw new HttpError(
+          422,
+          "DEVIS_DOSSIER_REQUIRES_ARTICLE",
+          "Un dossier technique de devis doit être rattaché à un article-devis."
+        );
+      }
+      continue;
+    }
 
     const a = source.article_devis;
     const articleDevisId = a.id ?? crypto.randomUUID();

--- a/src/module/devis/repository/devis.repository.ts
+++ b/src/module/devis/repository/devis.repository.ts
@@ -116,8 +116,8 @@ type DossierDevisRow = Omit<DossierTechniquePieceDevis, "devis_id" | "version_nu
 
 type DevisLineWithPreparatoryInput = CreateDevisBodyDTO["lignes"][number] & {
   article_devis?: {
-    id?: string;
-    root_article_devis_id?: string;
+    id?: string | null;
+    root_article_devis_id?: string | null;
     parent_article_devis_id?: string | null;
     version_number?: number;
     code: string;
@@ -130,8 +130,8 @@ type DevisLineWithPreparatoryInput = CreateDevisBodyDTO["lignes"][number] & {
     source_official_article_id?: string | null;
   };
   dossier_technique_piece_devis?: {
-    id?: string;
-    root_dossier_devis_id?: string;
+    id?: string | null;
+    root_dossier_devis_id?: string | null;
     parent_dossier_devis_id?: string | null;
     version_number?: number;
     code_piece: string;

--- a/src/module/devis/validators/devis.validators.test.ts
+++ b/src/module/devis/validators/devis.validators.test.ts
@@ -255,6 +255,34 @@ describe("#167 — matrice de payloads createDevisBodySchema", () => {
       designation: "Dossier spécial",
     });
   });
+
+  it("ne supprime pas silencieusement un plan_index non par défaut", () => {
+    const parsed = createDevisBodySchema.safeParse(withLigne({
+      article_devis: { plan_index: 2 },
+    }));
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.error.issues.some((issue) =>
+      issue.path.join(".") === "lignes.0.article_devis.code"
+    )).toBe(true);
+  });
+
+  it("refuse un dossier technique sans article-devis au lieu de le perdre", () => {
+    const parsed = createDevisBodySchema.safeParse(withLigne({
+      dossier_technique_piece_devis: {
+        code_piece: "DOS-42",
+        designation: "Dossier orphelin",
+      },
+    }));
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.error.issues).toContainEqual(expect.objectContaining({
+      path: ["lignes", 0, "article_devis"],
+      message: "article_devis est requis lorsqu'un dossier_technique_piece_devis est fourni",
+    }));
+  });
 });
 
 describe("#167 — updateDevisBodySchema (verrou optimiste additif)", () => {

--- a/src/module/devis/validators/devis.validators.test.ts
+++ b/src/module/devis/validators/devis.validators.test.ts
@@ -203,6 +203,58 @@ describe("#167 — matrice de payloads createDevisBodySchema", () => {
       expect(parsed.data.lignes[0]).toMatchObject({ quantite: 1, taux_tva: 20, remise_ligne: 0 });
     }
   });
+
+  it.each([
+    ["absentes", {}],
+    ["null", { article_devis: null, dossier_technique_piece_devis: null }],
+    [
+      "vides",
+      {
+        article_devis: { code: " ", designation: "", primary_category: "", family_code: "", plan_index: 1 },
+        dossier_technique_piece_devis: { code_piece: " ", designation: "", payload: {} },
+      },
+    ],
+  ])("accepte les données de préparation %s sur un devis minimal", (_label, preparation) => {
+    const parsed = createDevisBodySchema.safeParse(withLigne(preparation));
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.lignes[0].article_devis).toBeUndefined();
+    expect(parsed.data.lignes[0].dossier_technique_piece_devis).toBeUndefined();
+  });
+
+  it("préserve les valeurs de préparation non vides et accepte leurs identifiants null", () => {
+    const parsed = createDevisBodySchema.safeParse(withLigne({
+      article_devis: {
+        id: null,
+        root_article_devis_id: null,
+        code: "  ART-42  ",
+        designation: "  Pièce spéciale  ",
+        primary_category: "piece_finie_fabriquee",
+        article_categories: ["piece_finie_fabriquee"],
+        family_code: "PT",
+      },
+      dossier_technique_piece_devis: {
+        id: null,
+        root_dossier_devis_id: null,
+        code_piece: "  DOS-42  ",
+        designation: "  Dossier spécial  ",
+      },
+    }));
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.lignes[0].article_devis).toMatchObject({
+      id: null,
+      code: "ART-42",
+      designation: "Pièce spéciale",
+    });
+    expect(parsed.data.lignes[0].dossier_technique_piece_devis).toMatchObject({
+      id: null,
+      code_piece: "DOS-42",
+      designation: "Dossier spécial",
+    });
+  });
 });
 
 describe("#167 — updateDevisBodySchema (verrou optimiste additif)", () => {

--- a/src/module/devis/validators/devis.validators.ts
+++ b/src/module/devis/validators/devis.validators.ts
@@ -17,6 +17,43 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function hasPreparationValue(value: unknown) {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (isRecord(value)) return Object.keys(value).length > 0;
+  return true;
+}
+
+function emptyPreparationToUndefined(value: unknown, meaningfulFields: readonly string[]) {
+  if (value === null || value === undefined) return undefined;
+  if (!isRecord(value)) return value;
+  return meaningfulFields.some((field) => hasPreparationValue(value[field])) ? value : undefined;
+}
+
+const articlePreparationFields = [
+  "id",
+  "root_article_devis_id",
+  "parent_article_devis_id",
+  "code",
+  "designation",
+  "primary_category",
+  "article_categories",
+  "family_code",
+  "projet_id",
+  "source_official_article_id",
+] as const;
+
+const dossierPreparationFields = [
+  "id",
+  "root_dossier_devis_id",
+  "parent_dossier_devis_id",
+  "code_piece",
+  "designation",
+  "source_official_piece_technique_id",
+  "payload",
+] as const;
+
 export const devisIdParamsSchema = z.object({
   id: z.coerce.number().int().positive(),
 });
@@ -94,10 +131,11 @@ z.object({
   prix_unitaire_ht: z.coerce.number().min(0),
   remise_ligne: z.coerce.number().min(0).max(100).optional().default(0),
   taux_tva: z.coerce.number().min(0).max(100).optional().default(20),
-  article_devis: z
-    .object({
-      id: z.string().uuid().optional(),
-      root_article_devis_id: z.string().uuid().optional(),
+  article_devis: z.preprocess(
+    (value) => emptyPreparationToUndefined(value, articlePreparationFields),
+    z.object({
+      id: z.string().uuid().optional().nullable(),
+      root_article_devis_id: z.string().uuid().optional().nullable(),
       parent_article_devis_id: z.string().uuid().optional().nullable(),
       version_number: z.coerce.number().int().positive().optional(),
       code: z.string().trim().min(1),
@@ -108,20 +146,21 @@ z.object({
       plan_index: z.coerce.number().int().positive().optional().default(1),
       projet_id: z.coerce.number().int().positive().optional().nullable(),
       source_official_article_id: z.string().uuid().optional().nullable(),
-    })
-    .optional(),
-  dossier_technique_piece_devis: z
-    .object({
-      id: z.string().uuid().optional(),
-      root_dossier_devis_id: z.string().uuid().optional(),
+    }).optional()
+  ),
+  dossier_technique_piece_devis: z.preprocess(
+    (value) => emptyPreparationToUndefined(value, dossierPreparationFields),
+    z.object({
+      id: z.string().uuid().optional().nullable(),
+      root_dossier_devis_id: z.string().uuid().optional().nullable(),
       parent_dossier_devis_id: z.string().uuid().optional().nullable(),
       version_number: z.coerce.number().int().positive().optional(),
       code_piece: z.string().trim().min(1),
       designation: z.string().trim().min(1),
       source_official_piece_technique_id: z.string().uuid().optional().nullable(),
       payload: z.record(z.string(), z.unknown()).optional().default({}),
-    })
-    .optional(),
+    }).optional()
+  ),
 }));
 
 export const createDevisBodySchema = z.object({

--- a/src/module/devis/validators/devis.validators.ts
+++ b/src/module/devis/validators/devis.validators.ts
@@ -31,6 +31,15 @@ function emptyPreparationToUndefined(value: unknown, meaningfulFields: readonly 
   return meaningfulFields.some((field) => hasPreparationValue(value[field])) ? value : undefined;
 }
 
+function emptyArticlePreparationToUndefined(value: unknown) {
+  const preparation = emptyPreparationToUndefined(value, articlePreparationFields);
+  if (preparation !== undefined || !isRecord(value)) return preparation;
+
+  const planIndex = value.plan_index;
+  if (!hasPreparationValue(planIndex) || Number(planIndex) === 1) return undefined;
+  return value;
+}
+
 const articlePreparationFields = [
   "id",
   "root_article_devis_id",
@@ -132,7 +141,7 @@ z.object({
   remise_ligne: z.coerce.number().min(0).max(100).optional().default(0),
   taux_tva: z.coerce.number().min(0).max(100).optional().default(20),
   article_devis: z.preprocess(
-    (value) => emptyPreparationToUndefined(value, articlePreparationFields),
+    emptyArticlePreparationToUndefined,
     z.object({
       id: z.string().uuid().optional().nullable(),
       root_article_devis_id: z.string().uuid().optional().nullable(),
@@ -161,6 +170,14 @@ z.object({
       payload: z.record(z.string(), z.unknown()).optional().default({}),
     }).optional()
   ),
+}).superRefine((line, context) => {
+  if (line.dossier_technique_piece_devis && !line.article_devis) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["article_devis"],
+      message: "article_devis est requis lorsqu'un dossier_technique_piece_devis est fourni",
+    });
+  }
 }));
 
 export const createDevisBodySchema = z.object({


### PR DESCRIPTION
## Résumé
- normalise une préparation absente, null, vide ou uniquement blanche vers l'absence
- accepte null pour les identifiants préparatoires facultatifs
- conserve et tronque les valeurs non blanches
- documente le contrat sans modifier prix, totaux, permissions ni schéma SQL

## Vérifications
- `npm run test:run -- src/module/devis/validators/devis.validators.test.ts` (133 tests)
- `npm run build`

Lié à BigFootLime/crp-systems-web#470

## Summary by Sourcery

Normalize optional preparatory data on devis lines and clarify the input contract for preparation fields without impacting pricing or permissions.

New Features:
- Support null values for optional preparatory identifiers on devis line preparation objects.
- Treat absent, null, empty, or whitespace-only preparation payloads as no explicit preparation on devis lines.

Bug Fixes:
- Ensure devis line validators correctly ignore empty preparatory objects while preserving non-empty values.

Enhancements:
- Trim and preserve non-blank preparatory string fields for article and dossier technique data on devis lines.
- Align repository type definitions with the updated contract allowing nullable preparatory identifiers.

Documentation:
- Document the behaviour of optional preparation fields in the devis workflow, including normalization rules and frontend expectations.

Tests:
- Add validator tests covering empty, null, and non-empty preparatory data and nullable identifiers on devis lines.