### PR TITLE
release: promote audit wave 2 to main

### DIFF
--- a/db/patches/20260804_finance_settlement_state_469.sql
+++ b/db/patches/20260804_finance_settlement_state_469.sql
@@ -11,9 +11,26 @@ BEGIN
     WHERE COALESCE((
       SELECT SUM(pa.amount_ttc) FROM public.paiement_allocations pa WHERE pa.facture_id = f.id
     ), 0) + COALESCE((
+      SELECT SUM(p.montant)
+      FROM public.paiement p
+      WHERE p.facture_id = f.id
+        AND NOT EXISTS (
+          SELECT 1 FROM public.paiement_allocations existing_pa
+          WHERE existing_pa.paiement_id = p.id
+        )
+    ), 0) + COALESCE((
       SELECT SUM(asa.amount_ttc)
       FROM public.avoir_source_allocations asa
       WHERE asa.facture_id = f.id AND asa.allocation_status = 'CONSUMED'
+    ), 0) + COALESCE((
+      SELECT SUM(a.total_ttc)
+      FROM public.avoir a
+      WHERE a.facture_id = f.id
+        AND a.statut IN ('ISSUED','emis','emise','envoyee')
+        AND NOT EXISTS (
+          SELECT 1 FROM public.avoir_source_allocations existing_asa
+          WHERE existing_asa.avoir_id = a.id
+        )
     ), 0) > f.total_ttc
   ) THEN
     RAISE EXCEPTION '#469 migration refused: an invoice is already over-allocated';
@@ -52,9 +69,28 @@ FROM (
         WHERE pa.facture_id = invoice.id
       ), 0)
       + COALESCE((
+        SELECT SUM(p.montant)
+        FROM public.paiement p
+        WHERE p.facture_id = invoice.id
+          AND NOT EXISTS (
+            SELECT 1 FROM public.paiement_allocations existing_pa
+            WHERE existing_pa.paiement_id = p.id
+          )
+      ), 0)
+      + COALESCE((
         SELECT SUM(asa.amount_ttc)
         FROM public.avoir_source_allocations asa
         WHERE asa.facture_id = invoice.id AND asa.allocation_status = 'CONSUMED'
+      ), 0)
+      + COALESCE((
+        SELECT SUM(a.total_ttc)
+        FROM public.avoir a
+        WHERE a.facture_id = invoice.id
+          AND a.statut IN ('ISSUED','emis','emise','envoyee')
+          AND NOT EXISTS (
+            SELECT 1 FROM public.avoir_source_allocations existing_asa
+            WHERE existing_asa.avoir_id = a.id
+          )
       ), 0)
     )::numeric(18,2) AS settled_ttc
   FROM public.facture invoice
@@ -69,6 +105,11 @@ ALTER TABLE public.facture
   ALTER COLUMN settlement_status SET DEFAULT 'UNPAID',
   ALTER COLUMN settlement_status SET NOT NULL;
 
+-- Recreate the two NOT VALID compatibility constraints so a safely replayed patch
+-- also repairs an earlier #469 draft definition.
+ALTER TABLE public.facture DROP CONSTRAINT IF EXISTS facture_statut_469_ck;
+ALTER TABLE public.avoir DROP CONSTRAINT IF EXISTS avoir_statut_469_ck;
+
 DO $$
 BEGIN
   IF NOT EXISTS (
@@ -76,9 +117,13 @@ BEGIN
     WHERE conname = 'facture_statut_469_ck'
       AND conrelid = 'public.facture'::regclass
   ) THEN
-    -- NOT VALID preserves arbitrary historical values while rejecting every new one.
+    -- NOT VALID preserves rows outside the known vocabulary. Known historical values
+    -- remain updateable; arbitrary future values are still rejected.
     ALTER TABLE public.facture ADD CONSTRAINT facture_statut_469_ck CHECK (
-      statut IN ('DRAFT','PENDING_VALIDATION','APPROVED','ISSUED','PARTIALLY_PAID','PAID','CANCELLED')
+      statut IN (
+        'DRAFT','PENDING_VALIDATION','APPROVED','ISSUED','PARTIALLY_PAID','PAID','CANCELLED',
+        'brouillon','emis','emise','envoyee','partielle','payee','annule','annulee'
+      )
     ) NOT VALID;
   END IF;
   IF NOT EXISTS (
@@ -105,7 +150,10 @@ BEGIN
       AND conrelid = 'public.avoir'::regclass
   ) THEN
     ALTER TABLE public.avoir ADD CONSTRAINT avoir_statut_469_ck CHECK (
-      statut IN ('DRAFT','PENDING_VALIDATION','APPROVED','ISSUED','CANCELLED')
+      statut IN (
+        'DRAFT','PENDING_VALIDATION','APPROVED','ISSUED','CANCELLED',
+        'brouillon','emis','emise','envoyee','annule','annulee'
+      )
     ) NOT VALID;
   END IF;
 END $$;
@@ -129,14 +177,18 @@ BEGIN
   IF TG_TABLE_NAME = 'facture'
      AND OLD.document_status = 'ISSUED'
      AND NEW.document_status = 'ISSUED'
-     AND OLD.statut IN ('ISSUED', 'PARTIALLY_PAID', 'PAID')
+     AND OLD.statut IN (
+       'ISSUED', 'PARTIALLY_PAID', 'PAID',
+       'emise', 'envoyee', 'partielle', 'payee', 'emis'
+     )
      AND NEW.statut = CASE
        WHEN NEW.settlement_status = 'UNPAID' THEN 'ISSUED'
        ELSE NEW.settlement_status
      END
      AND NEW.row_version = OLD.row_version + 1
+     AND current_setting('cerp.finance_settlement_correlation_id', true) IS NOT NULL
      AND current_setting('cerp.finance_settlement_correlation_id', true)
-         IS NOT DISTINCT FROM NEW.correlation_id::text
+         = NEW.correlation_id::text
      AND (to_jsonb(NEW)
           - 'statut' - 'document_status' - 'settlement_status'
           - 'row_version' - 'correlation_id' - 'updated_at')
@@ -163,6 +215,6 @@ $$;
 COMMENT ON COLUMN public.facture.document_status IS
   'Authoritative document lifecycle. ISSUED remains immutable after legal emission.';
 COMMENT ON COLUMN public.facture.settlement_status IS
-  'Derived only from consumed payment and credit allocations: UNPAID, PARTIALLY_PAID, PAID.';
+  'Derived from modern allocations plus non-duplicated direct legacy evidence: UNPAID, PARTIALLY_PAID, PAID.';
 
 COMMIT;

--- a/db/patches/20260804_finance_settlement_state_469.sql
+++ b/db/patches/20260804_finance_settlement_state_469.sql
@@ -566,10 +566,53 @@ BEGIN
 END;
 $$;
 
+-- Rebind every trigger that depends on a function replaced by this patch. This
+-- makes a replay repair missing or misbound #227 triggers instead of silently
+-- installing new function bodies that never execute.
+DROP TRIGGER IF EXISTS trg_protect_facture_ligne_227 ON public.facture_ligne;
+CREATE TRIGGER trg_protect_facture_ligne_227
+BEFORE INSERT OR UPDATE OR DELETE ON public.facture_ligne
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+
+DROP TRIGGER IF EXISTS trg_protect_avoir_ligne_227 ON public.avoir_ligne;
+CREATE TRIGGER trg_protect_avoir_ligne_227
+BEFORE INSERT OR UPDATE OR DELETE ON public.avoir_ligne
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+
+DROP TRIGGER IF EXISTS trg_protect_facture_source_227 ON public.facture_source_allocations;
+CREATE TRIGGER trg_protect_facture_source_227
+BEFORE INSERT OR UPDATE OR DELETE ON public.facture_source_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+
+DROP TRIGGER IF EXISTS trg_protect_facture_echeance_227 ON public.facture_echeance;
+CREATE TRIGGER trg_protect_facture_echeance_227
+BEFORE INSERT OR UPDATE OR DELETE ON public.facture_echeance
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+
+DROP TRIGGER IF EXISTS trg_protect_avoir_source_227 ON public.avoir_source_allocations;
+CREATE TRIGGER trg_protect_avoir_source_227
+BEFORE INSERT OR UPDATE OR DELETE ON public.avoir_source_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+
+DROP TRIGGER IF EXISTS trg_validate_facture_source_allocation_227 ON public.facture_source_allocations;
+CREATE TRIGGER trg_validate_facture_source_allocation_227
+BEFORE INSERT ON public.facture_source_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_validate_facturation_allocation_227();
+
+DROP TRIGGER IF EXISTS trg_validate_paiement_allocation_227 ON public.paiement_allocations;
+CREATE TRIGGER trg_validate_paiement_allocation_227
+BEFORE INSERT ON public.paiement_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_validate_facturation_allocation_227();
+
 DROP TRIGGER IF EXISTS trg_validate_avoir_allocation_227 ON public.avoir_source_allocations;
 CREATE TRIGGER trg_validate_avoir_allocation_227
 BEFORE INSERT OR UPDATE ON public.avoir_source_allocations
 FOR EACH ROW EXECUTE FUNCTION public.fn_validate_facturation_allocation_227();
+
+DROP TRIGGER IF EXISTS trg_protect_paiement_227 ON public.paiement;
+CREATE TRIGGER trg_protect_paiement_227
+BEFORE UPDATE OR DELETE ON public.paiement
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_paiement_227();
 
 COMMENT ON COLUMN public.facture.document_status IS
   'Authoritative document lifecycle. ISSUED remains immutable after legal emission.';

--- a/db/patches/20260804_finance_settlement_state_469.sql
+++ b/db/patches/20260804_finance_settlement_state_469.sql
@@ -9,11 +9,20 @@ BEGIN
     SELECT 1
     FROM public.facture f
     WHERE COALESCE((
-      SELECT SUM(pa.amount_ttc) FROM public.paiement_allocations pa WHERE pa.facture_id = f.id
+      SELECT SUM(pa.amount_ttc)
+      FROM public.paiement_allocations pa
+      JOIN public.paiement allocated_payment ON allocated_payment.id = pa.paiement_id
+      WHERE pa.facture_id = f.id
+        AND allocated_payment.status NOT IN ('REJECTED','REVERSED')
+        AND allocated_payment.workflow_status <> 'REVERSED'
+        AND allocated_payment.reversal_of_id IS NULL
     ), 0) + COALESCE((
       SELECT SUM(p.montant)
       FROM public.paiement p
       WHERE p.facture_id = f.id
+        AND p.status NOT IN ('REJECTED','REVERSED')
+        AND p.workflow_status <> 'REVERSED'
+        AND p.reversal_of_id IS NULL
         AND NOT EXISTS (
           SELECT 1 FROM public.paiement_allocations existing_pa
           WHERE existing_pa.paiement_id = p.id
@@ -35,6 +44,23 @@ BEGIN
   ) THEN
     RAISE EXCEPTION '#469 migration refused: an invoice is already over-allocated';
   END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM public.paiement p
+    WHERE p.facture_id IS NOT NULL
+      AND NOT (
+        p.uuid IS NOT NULL
+        AND p.code IS NOT NULL
+        AND p.correlation_id IS NOT NULL
+        AND p.idempotency_key IS NOT NULL
+        AND p.request_hash IS NOT NULL
+      )
+      AND EXISTS (
+        SELECT 1 FROM public.paiement_allocations pa WHERE pa.paiement_id = p.id
+      )
+  ) THEN
+    RAISE EXCEPTION '#469 migration refused: direct legacy payment evidence was already converted to allocations';
+  END IF;
 END $$;
 
 ALTER TABLE public.facture
@@ -55,8 +81,6 @@ SET document_status = CASE
     settlement_status = CASE
       WHEN balance.settled_ttc >= f.total_ttc AND f.total_ttc > 0 THEN 'PAID'
       WHEN balance.settled_ttc > 0 THEN 'PARTIALLY_PAID'
-      WHEN f.statut = 'PAID' OR lower(f.statut) = 'payee' THEN 'PAID'
-      WHEN f.statut = 'PARTIALLY_PAID' OR lower(f.statut) = 'partielle' THEN 'PARTIALLY_PAID'
       ELSE 'UNPAID'
     END
 FROM (
@@ -66,12 +90,19 @@ FROM (
       COALESCE((
         SELECT SUM(pa.amount_ttc)
         FROM public.paiement_allocations pa
+        JOIN public.paiement allocated_payment ON allocated_payment.id = pa.paiement_id
         WHERE pa.facture_id = invoice.id
+          AND allocated_payment.status NOT IN ('REJECTED','REVERSED')
+          AND allocated_payment.workflow_status <> 'REVERSED'
+          AND allocated_payment.reversal_of_id IS NULL
       ), 0)
       + COALESCE((
         SELECT SUM(p.montant)
         FROM public.paiement p
         WHERE p.facture_id = invoice.id
+          AND p.status NOT IN ('REJECTED','REVERSED')
+          AND p.workflow_status <> 'REVERSED'
+          AND p.reversal_of_id IS NULL
           AND NOT EXISTS (
             SELECT 1 FROM public.paiement_allocations existing_pa
             WHERE existing_pa.paiement_id = p.id
@@ -211,6 +242,334 @@ BEGIN
   RETURN NEW;
 END;
 $$;
+
+CREATE OR REPLACE FUNCTION public.fn_protect_facturation_child_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  parent_status text;
+  parent_document_status text;
+BEGIN
+  IF TG_TABLE_NAME IN ('facture_ligne', 'facture_source_allocations', 'facture_echeance') THEN
+    IF TG_OP = 'DELETE' THEN
+      SELECT statut, document_status
+      INTO parent_status, parent_document_status
+      FROM public.facture
+      WHERE id = OLD.facture_id;
+    ELSE
+      SELECT statut, document_status
+      INTO parent_status, parent_document_status
+      FROM public.facture
+      WHERE id = NEW.facture_id;
+    END IF;
+  ELSIF TG_TABLE_NAME = 'avoir_ligne' THEN
+    IF TG_OP = 'DELETE' THEN
+      SELECT statut INTO parent_status FROM public.avoir WHERE id = OLD.avoir_id;
+    ELSE
+      SELECT statut INTO parent_status FROM public.avoir WHERE id = NEW.avoir_id;
+    END IF;
+  ELSIF TG_TABLE_NAME = 'avoir_source_allocations' THEN
+    IF TG_OP = 'DELETE' THEN
+      SELECT statut INTO parent_status FROM public.avoir WHERE id = OLD.avoir_id;
+    ELSE
+      SELECT statut INTO parent_status FROM public.avoir WHERE id = NEW.avoir_id;
+    END IF;
+  END IF;
+
+  IF TG_TABLE_NAME = 'facture_echeance' AND TG_OP = 'UPDATE' THEN
+    IF (parent_document_status = 'ISSUED' OR parent_status IN (
+          'ISSUED', 'PARTIALLY_PAID', 'PAID',
+          'emis', 'emise', 'envoyee', 'partielle', 'payee'
+        ))
+       AND NEW.amount_allocated >= OLD.amount_allocated
+       AND NEW.amount_allocated <= NEW.amount_due
+       AND NEW.status = CASE
+         WHEN NEW.amount_allocated >= NEW.amount_due THEN 'PAID'
+         WHEN NEW.amount_allocated > 0 THEN 'PARTIALLY_PAID'
+         ELSE OLD.status
+       END
+       AND (to_jsonb(NEW) - 'amount_allocated' - 'status')
+           IS NOT DISTINCT FROM
+           (to_jsonb(OLD) - 'amount_allocated' - 'status') THEN
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  IF parent_document_status = 'ISSUED' OR parent_status IN (
+    'ISSUED', 'PARTIALLY_PAID', 'PAID', 'CANCELLED',
+    'emise', 'envoyee', 'partielle', 'payee', 'annulee', 'emis', 'annule'
+  ) THEN
+    RAISE EXCEPTION 'children of issued or cancelled finance evidence are immutable' USING ERRCODE = '55000';
+  END IF;
+
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_validate_facturation_allocation_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  payment_amount numeric(18,2);
+  payment_facture_id bigint;
+  payment_is_net boolean;
+  payment_is_modern boolean;
+  allocated_amount numeric(18,2);
+  invoice_amount numeric(18,2);
+  invoice_allocated numeric(18,2);
+  credit_amount numeric(18,2);
+  credit_allocated numeric(18,2);
+  delivery_qty numeric(18,3);
+  sourced_qty numeric(18,3);
+  source_client text;
+  target_client text;
+  incoming_invoice_credit numeric(18,2);
+BEGIN
+  IF TG_TABLE_NAME = 'paiement_allocations' THEN
+    SELECT
+      montant::numeric(18,2),
+      facture_id,
+      status NOT IN ('REJECTED','REVERSED')
+        AND workflow_status <> 'REVERSED'
+        AND reversal_of_id IS NULL,
+      uuid IS NOT NULL
+        AND code IS NOT NULL
+        AND correlation_id IS NOT NULL
+        AND idempotency_key IS NOT NULL
+        AND request_hash IS NOT NULL
+    INTO payment_amount, payment_facture_id, payment_is_net, payment_is_modern
+    FROM public.paiement
+    WHERE id = NEW.paiement_id
+    FOR UPDATE;
+
+    SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2)
+    INTO allocated_amount
+    FROM public.paiement_allocations
+    WHERE paiement_id = NEW.paiement_id;
+
+    IF payment_facture_id IS NOT NULL
+       AND allocated_amount = 0
+       AND NOT COALESCE(payment_is_modern, FALSE) THEN
+      RAISE EXCEPTION 'direct legacy payment evidence cannot be converted to allocations' USING ERRCODE = '55000';
+    END IF;
+    IF payment_amount IS NULL
+       OR NOT COALESCE(payment_is_net, FALSE)
+       OR allocated_amount + NEW.amount_ttc > payment_amount THEN
+      RAISE EXCEPTION 'payment allocations exceed recorded net payment' USING ERRCODE = '23514';
+    END IF;
+
+    SELECT total_ttc::numeric(18,2)
+    INTO invoice_amount
+    FROM public.facture
+    WHERE id = NEW.facture_id
+    FOR UPDATE;
+
+    SELECT (
+      COALESCE((
+        SELECT SUM(pa.amount_ttc)
+        FROM public.paiement_allocations pa
+        JOIN public.paiement allocated_payment ON allocated_payment.id = pa.paiement_id
+        WHERE pa.facture_id = NEW.facture_id
+          AND allocated_payment.status NOT IN ('REJECTED','REVERSED')
+          AND allocated_payment.workflow_status <> 'REVERSED'
+          AND allocated_payment.reversal_of_id IS NULL
+      ), 0)
+      + COALESCE((
+        SELECT SUM(p.montant)
+        FROM public.paiement p
+        WHERE p.facture_id = NEW.facture_id
+          AND p.id <> NEW.paiement_id
+          AND p.status NOT IN ('REJECTED','REVERSED')
+          AND p.workflow_status <> 'REVERSED'
+          AND p.reversal_of_id IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM public.paiement_allocations existing_pa
+            WHERE existing_pa.paiement_id = p.id
+          )
+      ), 0)
+      + COALESCE((
+        SELECT SUM(asa.amount_ttc)
+        FROM public.avoir_source_allocations asa
+        WHERE asa.facture_id = NEW.facture_id
+          AND asa.allocation_status = 'CONSUMED'
+      ), 0)
+      + COALESCE((
+        SELECT SUM(a.total_ttc)
+        FROM public.avoir a
+        WHERE a.facture_id = NEW.facture_id
+          AND a.statut IN ('ISSUED','emis','emise','envoyee')
+          AND NOT EXISTS (
+            SELECT 1 FROM public.avoir_source_allocations existing_asa
+            WHERE existing_asa.avoir_id = a.id
+          )
+      ), 0)
+    )::numeric(18,2)
+    INTO invoice_allocated;
+
+    IF invoice_amount IS NULL OR invoice_allocated + NEW.amount_ttc > invoice_amount THEN
+      RAISE EXCEPTION 'payment and credit allocations exceed invoice total' USING ERRCODE = '23514';
+    END IF;
+  ELSIF TG_TABLE_NAME = 'avoir_source_allocations' THEN
+    SELECT total_ttc::numeric(18,2), client_id
+    INTO credit_amount, source_client
+    FROM public.avoir
+    WHERE id = NEW.avoir_id
+    FOR UPDATE;
+
+    SELECT total_ttc::numeric(18,2), client_id
+    INTO invoice_amount, target_client
+    FROM public.facture
+    WHERE id = NEW.facture_id
+    FOR UPDATE;
+
+    SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2)
+    INTO credit_allocated
+    FROM public.avoir_source_allocations
+    WHERE avoir_id = NEW.avoir_id
+      AND id IS DISTINCT FROM NEW.id;
+
+    IF source_client IS DISTINCT FROM target_client
+       OR credit_amount IS NULL
+       OR credit_allocated + NEW.amount_ttc > credit_amount THEN
+      RAISE EXCEPTION 'credit allocation has a client mismatch or exceeds the credit note' USING ERRCODE = '23514';
+    END IF;
+
+    incoming_invoice_credit := CASE
+      WHEN NEW.allocation_status = 'CONSUMED' THEN NEW.amount_ttc
+      ELSE 0
+    END;
+
+    SELECT (
+      COALESCE((
+        SELECT SUM(pa.amount_ttc)
+        FROM public.paiement_allocations pa
+        JOIN public.paiement allocated_payment ON allocated_payment.id = pa.paiement_id
+        WHERE pa.facture_id = NEW.facture_id
+          AND allocated_payment.status NOT IN ('REJECTED','REVERSED')
+          AND allocated_payment.workflow_status <> 'REVERSED'
+          AND allocated_payment.reversal_of_id IS NULL
+      ), 0)
+      + COALESCE((
+        SELECT SUM(p.montant)
+        FROM public.paiement p
+        WHERE p.facture_id = NEW.facture_id
+          AND p.status NOT IN ('REJECTED','REVERSED')
+          AND p.workflow_status <> 'REVERSED'
+          AND p.reversal_of_id IS NULL
+          AND NOT EXISTS (
+            SELECT 1 FROM public.paiement_allocations existing_pa
+            WHERE existing_pa.paiement_id = p.id
+          )
+      ), 0)
+      + COALESCE((
+        SELECT SUM(asa.amount_ttc)
+        FROM public.avoir_source_allocations asa
+        WHERE asa.facture_id = NEW.facture_id
+          AND asa.allocation_status = 'CONSUMED'
+          AND asa.id IS DISTINCT FROM NEW.id
+      ), 0)
+      + COALESCE((
+        SELECT SUM(a.total_ttc)
+        FROM public.avoir a
+        WHERE a.facture_id = NEW.facture_id
+          AND a.statut IN ('ISSUED','emis','emise','envoyee')
+          AND NOT EXISTS (
+            SELECT 1 FROM public.avoir_source_allocations existing_asa
+            WHERE existing_asa.avoir_id = a.id
+          )
+      ), 0)
+    )::numeric(18,2)
+    INTO invoice_allocated;
+
+    IF invoice_amount IS NULL
+       OR invoice_allocated + incoming_invoice_credit > invoice_amount THEN
+      RAISE EXCEPTION 'payment and credit allocations exceed invoice total' USING ERRCODE = '23514';
+    END IF;
+  ELSIF TG_TABLE_NAME = 'facture_source_allocations' THEN
+    SELECT bll.quantite::numeric(18,3), bl.client_id, f.client_id
+    INTO delivery_qty, source_client, target_client
+    FROM public.bon_livraison_ligne bll
+    JOIN public.bon_livraison bl ON bl.id = bll.bon_livraison_id
+    JOIN public.facture f ON f.id = NEW.facture_id
+    WHERE NEW.source_type = 'DELIVERY_LINE' AND bll.id::text = NEW.source_line_id
+    FOR UPDATE OF bll, bl, f;
+    SELECT COALESCE(SUM(quantity_selected), 0)::numeric(18,3) INTO sourced_qty
+    FROM public.facture_source_allocations
+    WHERE source_type = 'DELIVERY_LINE' AND source_line_id = NEW.source_line_id
+      AND allocation_status IN ('DRAFT','CONSUMED');
+    IF delivery_qty IS NULL OR source_client IS DISTINCT FROM target_client OR sourced_qty + NEW.quantity_selected > delivery_qty THEN
+      RAISE EXCEPTION 'invoice source allocations have a client mismatch or exceed delivered quantity' USING ERRCODE = '23514';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_protect_paiement_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  has_allocations boolean;
+BEGIN
+  SELECT EXISTS (
+    SELECT 1 FROM public.paiement_allocations WHERE paiement_id = OLD.id
+  ) INTO has_allocations;
+
+  IF OLD.uuid IS NULL AND (OLD.facture_id IS NOT NULL OR has_allocations) THEN
+    IF TG_OP = 'DELETE' THEN
+      RAISE EXCEPTION 'direct legacy payment evidence cannot be deleted' USING ERRCODE = '55000';
+    END IF;
+    IF NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.uuid IS DISTINCT FROM OLD.uuid
+       OR NEW.code IS DISTINCT FROM OLD.code
+       OR NEW.client_id IS DISTINCT FROM OLD.client_id
+       OR NEW.facture_id IS DISTINCT FROM OLD.facture_id
+       OR NEW.montant IS DISTINCT FROM OLD.montant
+       OR NEW.currency IS DISTINCT FROM OLD.currency
+       OR NEW.date_paiement IS DISTINCT FROM OLD.date_paiement
+       OR NEW.value_date IS DISTINCT FROM OLD.value_date
+       OR NEW.booking_date IS DISTINCT FROM OLD.booking_date
+       OR NEW.mode IS DISTINCT FROM OLD.mode
+       OR NEW.reference IS DISTINCT FROM OLD.reference
+       OR NEW.commentaire IS DISTINCT FROM OLD.commentaire
+       OR NEW.proof_document_id IS DISTINCT FROM OLD.proof_document_id
+       OR NEW.created_by IS DISTINCT FROM OLD.created_by
+       OR NEW.status IS DISTINCT FROM OLD.status
+       OR NEW.workflow_status IS DISTINCT FROM OLD.workflow_status
+       OR NEW.reversal_of_id IS DISTINCT FROM OLD.reversal_of_id THEN
+      RAISE EXCEPTION 'direct legacy payment evidence is immutable' USING ERRCODE = '55000';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF OLD.uuid IS NULL THEN
+    RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+  END IF;
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'recorded payment evidence cannot be deleted' USING ERRCODE = '55000';
+  END IF;
+  IF NEW.id IS DISTINCT FROM OLD.id
+     OR NEW.uuid IS DISTINCT FROM OLD.uuid
+     OR NEW.code IS DISTINCT FROM OLD.code
+     OR NEW.client_id IS DISTINCT FROM OLD.client_id
+     OR NEW.facture_id IS DISTINCT FROM OLD.facture_id
+     OR NEW.montant IS DISTINCT FROM OLD.montant
+     OR NEW.currency IS DISTINCT FROM OLD.currency
+     OR NEW.date_paiement IS DISTINCT FROM OLD.date_paiement
+     OR NEW.value_date IS DISTINCT FROM OLD.value_date
+     OR NEW.booking_date IS DISTINCT FROM OLD.booking_date
+     OR NEW.mode IS DISTINCT FROM OLD.mode
+     OR NEW.reference IS DISTINCT FROM OLD.reference
+     OR NEW.commentaire IS DISTINCT FROM OLD.commentaire
+     OR NEW.proof_document_id IS DISTINCT FROM OLD.proof_document_id
+     OR NEW.created_by IS DISTINCT FROM OLD.created_by THEN
+    RAISE EXCEPTION 'recorded payment identity and amount are immutable' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_validate_avoir_allocation_227 ON public.avoir_source_allocations;
+CREATE TRIGGER trg_validate_avoir_allocation_227
+BEFORE INSERT OR UPDATE ON public.avoir_source_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_validate_facturation_allocation_227();
 
 COMMENT ON COLUMN public.facture.document_status IS
   'Authoritative document lifecycle. ISSUED remains immutable after legal emission.';

--- a/db/patches/20260804_finance_settlement_state_469.sql
+++ b/db/patches/20260804_finance_settlement_state_469.sql
@@ -1,0 +1,168 @@
+-- Issue #469 / BUG-CERP-0007
+-- Separate the immutable document lifecycle from the derived settlement state.
+-- `statut` remains a backwards-compatible projection for existing consumers.
+BEGIN;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM public.facture f
+    WHERE COALESCE((
+      SELECT SUM(pa.amount_ttc) FROM public.paiement_allocations pa WHERE pa.facture_id = f.id
+    ), 0) + COALESCE((
+      SELECT SUM(asa.amount_ttc)
+      FROM public.avoir_source_allocations asa
+      WHERE asa.facture_id = f.id AND asa.allocation_status = 'CONSUMED'
+    ), 0) > f.total_ttc
+  ) THEN
+    RAISE EXCEPTION '#469 migration refused: an invoice is already over-allocated';
+  END IF;
+END $$;
+
+ALTER TABLE public.facture
+  ADD COLUMN IF NOT EXISTS document_status text,
+  ADD COLUMN IF NOT EXISTS settlement_status text;
+
+-- Backfill only the new derived columns. Historical `statut` values are never rewritten.
+ALTER TABLE public.facture DISABLE TRIGGER trg_protect_facture_immutable_227;
+UPDATE public.facture f
+SET document_status = CASE
+      WHEN f.statut IN ('DRAFT', 'PENDING_VALIDATION', 'APPROVED', 'CANCELLED') THEN f.statut
+      WHEN f.statut IN ('ISSUED', 'PARTIALLY_PAID', 'PAID') THEN 'ISSUED'
+      WHEN lower(f.statut) = 'brouillon' THEN 'DRAFT'
+      WHEN lower(f.statut) IN ('emis', 'emise', 'envoyee', 'partielle', 'payee') THEN 'ISSUED'
+      WHEN lower(f.statut) IN ('annule', 'annulee') THEN 'CANCELLED'
+      ELSE 'LEGACY'
+    END,
+    settlement_status = CASE
+      WHEN balance.settled_ttc >= f.total_ttc AND f.total_ttc > 0 THEN 'PAID'
+      WHEN balance.settled_ttc > 0 THEN 'PARTIALLY_PAID'
+      WHEN f.statut = 'PAID' OR lower(f.statut) = 'payee' THEN 'PAID'
+      WHEN f.statut = 'PARTIALLY_PAID' OR lower(f.statut) = 'partielle' THEN 'PARTIALLY_PAID'
+      ELSE 'UNPAID'
+    END
+FROM (
+  SELECT
+    invoice.id,
+    (
+      COALESCE((
+        SELECT SUM(pa.amount_ttc)
+        FROM public.paiement_allocations pa
+        WHERE pa.facture_id = invoice.id
+      ), 0)
+      + COALESCE((
+        SELECT SUM(asa.amount_ttc)
+        FROM public.avoir_source_allocations asa
+        WHERE asa.facture_id = invoice.id AND asa.allocation_status = 'CONSUMED'
+      ), 0)
+    )::numeric(18,2) AS settled_ttc
+  FROM public.facture invoice
+) balance
+WHERE balance.id = f.id
+  AND (f.document_status IS NULL OR f.settlement_status IS NULL);
+ALTER TABLE public.facture ENABLE TRIGGER trg_protect_facture_immutable_227;
+
+ALTER TABLE public.facture
+  ALTER COLUMN document_status SET DEFAULT 'DRAFT',
+  ALTER COLUMN document_status SET NOT NULL,
+  ALTER COLUMN settlement_status SET DEFAULT 'UNPAID',
+  ALTER COLUMN settlement_status SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'facture_statut_469_ck'
+      AND conrelid = 'public.facture'::regclass
+  ) THEN
+    -- NOT VALID preserves arbitrary historical values while rejecting every new one.
+    ALTER TABLE public.facture ADD CONSTRAINT facture_statut_469_ck CHECK (
+      statut IN ('DRAFT','PENDING_VALIDATION','APPROVED','ISSUED','PARTIALLY_PAID','PAID','CANCELLED')
+    ) NOT VALID;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'facture_document_status_469_ck'
+      AND conrelid = 'public.facture'::regclass
+  ) THEN
+    ALTER TABLE public.facture ADD CONSTRAINT facture_document_status_469_ck CHECK (
+      document_status IN ('DRAFT','PENDING_VALIDATION','APPROVED','ISSUED','CANCELLED','LEGACY')
+    );
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'facture_settlement_status_469_ck'
+      AND conrelid = 'public.facture'::regclass
+  ) THEN
+    ALTER TABLE public.facture ADD CONSTRAINT facture_settlement_status_469_ck CHECK (
+      settlement_status IN ('UNPAID','PARTIALLY_PAID','PAID')
+    );
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'avoir_statut_469_ck'
+      AND conrelid = 'public.avoir'::regclass
+  ) THEN
+    ALTER TABLE public.avoir ADD CONSTRAINT avoir_statut_469_ck CHECK (
+      statut IN ('DRAFT','PENDING_VALIDATION','APPROVED','ISSUED','CANCELLED')
+    ) NOT VALID;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS facture_document_settlement_469_idx
+  ON public.facture(document_status, settlement_status, issued_at DESC);
+
+CREATE OR REPLACE FUNCTION public.fn_protect_facturation_immutable_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.statut IN (
+      'ISSUED', 'PARTIALLY_PAID', 'PAID', 'CANCELLED',
+      'emise', 'envoyee', 'partielle', 'payee', 'annulee', 'emis', 'annule'
+    ) THEN
+      RAISE EXCEPTION 'issued or cancelled finance evidence cannot be deleted' USING ERRCODE = '55000';
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  IF TG_TABLE_NAME = 'facture'
+     AND OLD.document_status = 'ISSUED'
+     AND NEW.document_status = 'ISSUED'
+     AND OLD.statut IN ('ISSUED', 'PARTIALLY_PAID', 'PAID')
+     AND NEW.statut = CASE
+       WHEN NEW.settlement_status = 'UNPAID' THEN 'ISSUED'
+       ELSE NEW.settlement_status
+     END
+     AND NEW.row_version = OLD.row_version + 1
+     AND current_setting('cerp.finance_settlement_correlation_id', true)
+         IS NOT DISTINCT FROM NEW.correlation_id::text
+     AND (to_jsonb(NEW)
+          - 'statut' - 'document_status' - 'settlement_status'
+          - 'row_version' - 'correlation_id' - 'updated_at')
+         IS NOT DISTINCT FROM
+         (to_jsonb(OLD)
+          - 'statut' - 'document_status' - 'settlement_status'
+          - 'row_version' - 'correlation_id' - 'updated_at') THEN
+    RETURN NEW;
+  END IF;
+
+  IF OLD.statut IN (
+    'ISSUED', 'PARTIALLY_PAID', 'PAID', 'CANCELLED',
+    'emise', 'envoyee', 'partielle', 'payee', 'annulee', 'emis', 'annule'
+  ) THEN
+    RAISE EXCEPTION 'issued or cancelled finance evidence is immutable' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.statut = 'DRAFT' AND NEW.statut = 'CANCELLED' THEN
+    RAISE EXCEPTION 'draft finance evidence must not be cancelled as legal evidence' USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON COLUMN public.facture.document_status IS
+  'Authoritative document lifecycle. ISSUED remains immutable after legal emission.';
+COMMENT ON COLUMN public.facture.settlement_status IS
+  'Derived only from consumed payment and credit allocations: UNPAID, PARTIALLY_PAID, PAID.';
+
+COMMIT;

--- a/db/patches/support/20260804_finance_settlement_state_469.preflight.sql
+++ b/db/patches/support/20260804_finance_settlement_state_469.preflight.sql
@@ -19,11 +19,20 @@ BEGIN
     SELECT 1
     FROM public.facture f
     WHERE COALESCE((
-      SELECT SUM(pa.amount_ttc) FROM public.paiement_allocations pa WHERE pa.facture_id = f.id
+      SELECT SUM(pa.amount_ttc)
+      FROM public.paiement_allocations pa
+      JOIN public.paiement allocated_payment ON allocated_payment.id = pa.paiement_id
+      WHERE pa.facture_id = f.id
+        AND allocated_payment.status NOT IN ('REJECTED','REVERSED')
+        AND allocated_payment.workflow_status <> 'REVERSED'
+        AND allocated_payment.reversal_of_id IS NULL
     ), 0) + COALESCE((
       SELECT SUM(p.montant)
       FROM public.paiement p
       WHERE p.facture_id = f.id
+        AND p.status NOT IN ('REJECTED','REVERSED')
+        AND p.workflow_status <> 'REVERSED'
+        AND p.reversal_of_id IS NULL
         AND NOT EXISTS (
           SELECT 1 FROM public.paiement_allocations existing_pa
           WHERE existing_pa.paiement_id = p.id
@@ -44,6 +53,23 @@ BEGIN
     ), 0) > f.total_ttc
   ) THEN
     RAISE EXCEPTION '#469 preflight refused: an invoice is already over-allocated';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM public.paiement p
+    WHERE p.facture_id IS NOT NULL
+      AND NOT (
+        p.uuid IS NOT NULL
+        AND p.code IS NOT NULL
+        AND p.correlation_id IS NOT NULL
+        AND p.idempotency_key IS NOT NULL
+        AND p.request_hash IS NOT NULL
+      )
+      AND EXISTS (
+        SELECT 1 FROM public.paiement_allocations pa WHERE pa.paiement_id = p.id
+      )
+  ) THEN
+    RAISE EXCEPTION '#469 preflight refused: direct legacy payment evidence was already converted to allocations';
   END IF;
 END $$;
 

--- a/db/patches/support/20260804_finance_settlement_state_469.preflight.sql
+++ b/db/patches/support/20260804_finance_settlement_state_469.preflight.sql
@@ -16,6 +16,35 @@ BEGIN
     RAISE EXCEPTION 'Issue #227 immutable invoice trigger is missing';
   END IF;
   IF EXISTS (
+    WITH expected(trigger_name, table_name, function_name, trigger_type) AS (
+      VALUES
+        ('trg_protect_facture_ligne_227', 'facture_ligne', 'fn_protect_facturation_child_227', 31),
+        ('trg_protect_avoir_ligne_227', 'avoir_ligne', 'fn_protect_facturation_child_227', 31),
+        ('trg_protect_facture_source_227', 'facture_source_allocations', 'fn_protect_facturation_child_227', 31),
+        ('trg_protect_facture_echeance_227', 'facture_echeance', 'fn_protect_facturation_child_227', 31),
+        ('trg_protect_avoir_source_227', 'avoir_source_allocations', 'fn_protect_facturation_child_227', 31),
+        ('trg_validate_facture_source_allocation_227', 'facture_source_allocations', 'fn_validate_facturation_allocation_227', 7),
+        ('trg_validate_paiement_allocation_227', 'paiement_allocations', 'fn_validate_facturation_allocation_227', 7),
+        ('trg_validate_avoir_allocation_227', 'avoir_source_allocations', 'fn_validate_facturation_allocation_227', 7),
+        ('trg_protect_paiement_227', 'paiement', 'fn_protect_paiement_227', 27)
+    )
+    SELECT 1
+    FROM expected e
+    LEFT JOIN pg_trigger t
+      ON t.tgname = e.trigger_name
+     AND t.tgrelid = to_regclass('public.' || e.table_name)
+    LEFT JOIN pg_proc p ON p.oid = t.tgfoid
+    LEFT JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE t.oid IS NULL
+       OR t.tgisinternal
+       OR t.tgenabled IS DISTINCT FROM 'O'
+       OR t.tgtype <> e.trigger_type
+       OR p.proname IS DISTINCT FROM e.function_name
+       OR n.nspname IS DISTINCT FROM 'public'
+  ) THEN
+    RAISE EXCEPTION 'Issue #227 Finance trigger bindings are missing, disabled, or misconfigured';
+  END IF;
+  IF EXISTS (
     SELECT 1
     FROM public.facture f
     WHERE COALESCE((

--- a/db/patches/support/20260804_finance_settlement_state_469.preflight.sql
+++ b/db/patches/support/20260804_finance_settlement_state_469.preflight.sql
@@ -21,9 +21,26 @@ BEGIN
     WHERE COALESCE((
       SELECT SUM(pa.amount_ttc) FROM public.paiement_allocations pa WHERE pa.facture_id = f.id
     ), 0) + COALESCE((
+      SELECT SUM(p.montant)
+      FROM public.paiement p
+      WHERE p.facture_id = f.id
+        AND NOT EXISTS (
+          SELECT 1 FROM public.paiement_allocations existing_pa
+          WHERE existing_pa.paiement_id = p.id
+        )
+    ), 0) + COALESCE((
       SELECT SUM(asa.amount_ttc)
       FROM public.avoir_source_allocations asa
       WHERE asa.facture_id = f.id AND asa.allocation_status = 'CONSUMED'
+    ), 0) + COALESCE((
+      SELECT SUM(a.total_ttc)
+      FROM public.avoir a
+      WHERE a.facture_id = f.id
+        AND a.statut IN ('ISSUED','emis','emise','envoyee')
+        AND NOT EXISTS (
+          SELECT 1 FROM public.avoir_source_allocations existing_asa
+          WHERE existing_asa.avoir_id = a.id
+        )
     ), 0) > f.total_ttc
   ) THEN
     RAISE EXCEPTION '#469 preflight refused: an invoice is already over-allocated';

--- a/db/patches/support/20260804_finance_settlement_state_469.preflight.sql
+++ b/db/patches/support/20260804_finance_settlement_state_469.preflight.sql
@@ -1,0 +1,38 @@
+-- Read-only preflight for issue #469. Run only against the explicitly selected database.
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#469 preflight is restricted to cerp_test';
+  END IF;
+  IF to_regclass('public.facture') IS NULL
+     OR to_regclass('public.paiement_allocations') IS NULL
+     OR to_regclass('public.avoir_source_allocations') IS NULL THEN
+    RAISE EXCEPTION 'Issue #227 Finance schema is required before #469';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgname = 'trg_protect_facture_immutable_227' AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'Issue #227 immutable invoice trigger is missing';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM public.facture f
+    WHERE COALESCE((
+      SELECT SUM(pa.amount_ttc) FROM public.paiement_allocations pa WHERE pa.facture_id = f.id
+    ), 0) + COALESCE((
+      SELECT SUM(asa.amount_ttc)
+      FROM public.avoir_source_allocations asa
+      WHERE asa.facture_id = f.id AND asa.allocation_status = 'CONSUMED'
+    ), 0) > f.total_ttc
+  ) THEN
+    RAISE EXCEPTION '#469 preflight refused: an invoice is already over-allocated';
+  END IF;
+END $$;
+
+SELECT
+  COUNT(*) FILTER (WHERE statut IS NULL OR btrim(statut) = '') AS blank_statuses,
+  COUNT(*) FILTER (WHERE statut NOT IN (
+    'DRAFT','PENDING_VALIDATION','APPROVED','ISSUED','PARTIALLY_PAID','PAID','CANCELLED'
+  )) AS historical_noncanonical_statuses
+FROM public.facture;

--- a/db/patches/support/20260804_finance_settlement_state_469.rollback.sql
+++ b/db/patches/support/20260804_finance_settlement_state_469.rollback.sql
@@ -1,10 +1,23 @@
 -- Roll back the #469 schema contract. Derived columns are removed; historical rows are untouched.
+--
+-- Controlled production procedure (never run from application startup):
+--   1. stop/drain Finance writes;
+--   2. deploy the previous application version (it tolerates the additive columns);
+--   3. in this same psql session set both explicit acknowledgements below;
+--   4. run this script, verify COMMIT, then reopen Finance writes.
+--
+--   SET cerp.finance_469_application_rolled_back = 'YES';
+--   SET cerp.finance_469_rollback_authorized = 'YES';
 BEGIN;
 
 DO $$
 BEGIN
-  IF current_database() <> 'cerp_test' THEN
-    RAISE EXCEPTION '#469 rollback is restricted to cerp_test';
+  IF current_database() <> 'cerp_test'
+     AND (
+       COALESCE(current_setting('cerp.finance_469_application_rolled_back', true), '') <> 'YES'
+       OR COALESCE(current_setting('cerp.finance_469_rollback_authorized', true), '') <> 'YES'
+     ) THEN
+    RAISE EXCEPTION '#469 rollback outside cerp_test requires an app rollback and two explicit session acknowledgements';
   END IF;
 END $$;
 

--- a/db/patches/support/20260804_finance_settlement_state_469.rollback.sql
+++ b/db/patches/support/20260804_finance_settlement_state_469.rollback.sql
@@ -52,6 +52,154 @@ BEGIN
 END;
 $$;
 
+-- Restore the exact corrected #227 child policy shipped by patch #275.
+CREATE OR REPLACE FUNCTION public.fn_protect_facturation_child_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  parent_status text;
+BEGIN
+  IF TG_TABLE_NAME IN ('facture_ligne', 'facture_source_allocations', 'facture_echeance') THEN
+    IF TG_OP = 'DELETE' THEN
+      SELECT statut INTO parent_status FROM public.facture WHERE id = OLD.facture_id;
+    ELSE
+      SELECT statut INTO parent_status FROM public.facture WHERE id = NEW.facture_id;
+    END IF;
+  ELSIF TG_TABLE_NAME = 'avoir_ligne' THEN
+    IF TG_OP = 'DELETE' THEN
+      SELECT statut INTO parent_status FROM public.avoir WHERE id = OLD.avoir_id;
+    ELSE
+      SELECT statut INTO parent_status FROM public.avoir WHERE id = NEW.avoir_id;
+    END IF;
+  ELSIF TG_TABLE_NAME = 'avoir_source_allocations' THEN
+    IF TG_OP = 'DELETE' THEN
+      SELECT statut INTO parent_status FROM public.avoir WHERE id = OLD.avoir_id;
+    ELSE
+      SELECT statut INTO parent_status FROM public.avoir WHERE id = NEW.avoir_id;
+    END IF;
+  END IF;
+
+  IF TG_TABLE_NAME = 'facture_echeance' AND TG_OP = 'UPDATE' THEN
+    IF parent_status IN ('ISSUED', 'PARTIALLY_PAID', 'PAID')
+       AND NEW.facture_id = OLD.facture_id
+       AND NEW.due_date = OLD.due_date
+       AND NEW.label = OLD.label
+       AND NEW.amount_due = OLD.amount_due
+       AND NEW.created_by = OLD.created_by
+       AND NEW.amount_allocated >= OLD.amount_allocated THEN
+      RETURN NEW;
+    END IF;
+  END IF;
+
+  IF parent_status IN (
+    'ISSUED', 'PARTIALLY_PAID', 'PAID', 'CANCELLED',
+    'emise', 'envoyee', 'partielle', 'payee', 'annulee', 'emis', 'annule'
+  ) THEN
+    RAISE EXCEPTION 'children of issued or cancelled finance evidence are immutable' USING ERRCODE = '55000';
+  END IF;
+
+  RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+END;
+$$;
+
+-- Restore the exact #227 allocation validator and INSERT-only trigger contract.
+CREATE OR REPLACE FUNCTION public.fn_validate_facturation_allocation_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+DECLARE
+  payment_amount numeric(18,2);
+  allocated_amount numeric(18,2);
+  invoice_amount numeric(18,2);
+  invoice_allocated numeric(18,2);
+  credit_amount numeric(18,2);
+  credit_allocated numeric(18,2);
+  delivery_qty numeric(18,3);
+  sourced_qty numeric(18,3);
+  source_client text;
+  target_client text;
+BEGIN
+  IF TG_TABLE_NAME = 'paiement_allocations' THEN
+    SELECT montant::numeric(18,2) INTO payment_amount FROM public.paiement WHERE id = NEW.paiement_id FOR UPDATE;
+    SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2) INTO allocated_amount
+    FROM public.paiement_allocations WHERE paiement_id = NEW.paiement_id;
+    IF payment_amount IS NULL OR allocated_amount + NEW.amount_ttc > payment_amount THEN
+      RAISE EXCEPTION 'payment allocations exceed recorded payment' USING ERRCODE = '23514';
+    END IF;
+    SELECT total_ttc::numeric(18,2) INTO invoice_amount FROM public.facture WHERE id = NEW.facture_id FOR UPDATE;
+    SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2) INTO invoice_allocated
+    FROM public.paiement_allocations WHERE facture_id = NEW.facture_id;
+    SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2) INTO credit_allocated
+    FROM public.avoir_source_allocations WHERE facture_id = NEW.facture_id;
+    IF invoice_amount IS NULL OR invoice_allocated + credit_allocated + NEW.amount_ttc > invoice_amount THEN
+      RAISE EXCEPTION 'payment and credit allocations exceed invoice total' USING ERRCODE = '23514';
+    END IF;
+  ELSIF TG_TABLE_NAME = 'avoir_source_allocations' THEN
+    SELECT a.total_ttc::numeric(18,2), a.client_id, f.client_id
+    INTO credit_amount, source_client, target_client
+    FROM public.avoir a JOIN public.facture f ON f.id = NEW.facture_id
+    WHERE a.id = NEW.avoir_id FOR UPDATE;
+    SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2) INTO credit_allocated
+    FROM public.avoir_source_allocations WHERE avoir_id = NEW.avoir_id;
+    IF source_client IS DISTINCT FROM target_client OR credit_amount IS NULL OR credit_allocated + NEW.amount_ttc > credit_amount THEN
+      RAISE EXCEPTION 'credit allocation has a client mismatch or exceeds the credit note' USING ERRCODE = '23514';
+    END IF;
+    SELECT total_ttc::numeric(18,2) INTO invoice_amount FROM public.facture WHERE id = NEW.facture_id FOR UPDATE;
+    SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2) INTO invoice_allocated
+    FROM public.paiement_allocations WHERE facture_id = NEW.facture_id;
+    IF invoice_amount IS NULL OR invoice_allocated + credit_allocated + NEW.amount_ttc > invoice_amount THEN
+      RAISE EXCEPTION 'payment and credit allocations exceed invoice total' USING ERRCODE = '23514';
+    END IF;
+  ELSIF TG_TABLE_NAME = 'facture_source_allocations' THEN
+    SELECT bll.quantite::numeric(18,3), bl.client_id, f.client_id
+    INTO delivery_qty, source_client, target_client
+    FROM public.bon_livraison_ligne bll
+    JOIN public.bon_livraison bl ON bl.id = bll.bon_livraison_id
+    JOIN public.facture f ON f.id = NEW.facture_id
+    WHERE NEW.source_type = 'DELIVERY_LINE' AND bll.id::text = NEW.source_line_id
+    FOR UPDATE OF bll, bl, f;
+    SELECT COALESCE(SUM(quantity_selected), 0)::numeric(18,3) INTO sourced_qty
+    FROM public.facture_source_allocations
+    WHERE source_type = 'DELIVERY_LINE' AND source_line_id = NEW.source_line_id
+      AND allocation_status IN ('DRAFT','CONSUMED');
+    IF delivery_qty IS NULL OR source_client IS DISTINCT FROM target_client OR sourced_qty + NEW.quantity_selected > delivery_qty THEN
+      RAISE EXCEPTION 'invoice source allocations have a client mismatch or exceed delivered quantity' USING ERRCODE = '23514';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.fn_protect_paiement_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF OLD.uuid IS NULL THEN
+    RETURN CASE WHEN TG_OP = 'DELETE' THEN OLD ELSE NEW END;
+  END IF;
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'recorded payment evidence cannot be deleted' USING ERRCODE = '55000';
+  END IF;
+  IF NEW.uuid IS DISTINCT FROM OLD.uuid
+     OR NEW.code IS DISTINCT FROM OLD.code
+     OR NEW.client_id IS DISTINCT FROM OLD.client_id
+     OR NEW.facture_id IS DISTINCT FROM OLD.facture_id
+     OR NEW.montant IS DISTINCT FROM OLD.montant
+     OR NEW.currency IS DISTINCT FROM OLD.currency
+     OR NEW.date_paiement IS DISTINCT FROM OLD.date_paiement
+     OR NEW.value_date IS DISTINCT FROM OLD.value_date
+     OR NEW.booking_date IS DISTINCT FROM OLD.booking_date
+     OR NEW.mode IS DISTINCT FROM OLD.mode
+     OR NEW.reference IS DISTINCT FROM OLD.reference
+     OR NEW.commentaire IS DISTINCT FROM OLD.commentaire
+     OR NEW.proof_document_id IS DISTINCT FROM OLD.proof_document_id
+     OR NEW.created_by IS DISTINCT FROM OLD.created_by THEN
+    RAISE EXCEPTION 'recorded payment identity and amount are immutable' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_validate_avoir_allocation_227 ON public.avoir_source_allocations;
+CREATE TRIGGER trg_validate_avoir_allocation_227 BEFORE INSERT ON public.avoir_source_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_validate_facturation_allocation_227();
+
 ALTER TABLE public.facture
   DROP COLUMN IF EXISTS settlement_status,
   DROP COLUMN IF EXISTS document_status;

--- a/db/patches/support/20260804_finance_settlement_state_469.rollback.sql
+++ b/db/patches/support/20260804_finance_settlement_state_469.rollback.sql
@@ -196,9 +196,35 @@ BEGIN
 END;
 $$;
 
+-- Restore every original #227 binding for the three restored function bodies.
+DROP TRIGGER IF EXISTS trg_protect_facture_ligne_227 ON public.facture_ligne;
+CREATE TRIGGER trg_protect_facture_ligne_227 BEFORE INSERT OR UPDATE OR DELETE ON public.facture_ligne
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+DROP TRIGGER IF EXISTS trg_protect_avoir_ligne_227 ON public.avoir_ligne;
+CREATE TRIGGER trg_protect_avoir_ligne_227 BEFORE INSERT OR UPDATE OR DELETE ON public.avoir_ligne
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+DROP TRIGGER IF EXISTS trg_protect_facture_source_227 ON public.facture_source_allocations;
+CREATE TRIGGER trg_protect_facture_source_227 BEFORE INSERT OR UPDATE OR DELETE ON public.facture_source_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+DROP TRIGGER IF EXISTS trg_protect_facture_echeance_227 ON public.facture_echeance;
+CREATE TRIGGER trg_protect_facture_echeance_227 BEFORE INSERT OR UPDATE OR DELETE ON public.facture_echeance
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+DROP TRIGGER IF EXISTS trg_protect_avoir_source_227 ON public.avoir_source_allocations;
+CREATE TRIGGER trg_protect_avoir_source_227 BEFORE INSERT OR UPDATE OR DELETE ON public.avoir_source_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_facturation_child_227();
+
+DROP TRIGGER IF EXISTS trg_validate_facture_source_allocation_227 ON public.facture_source_allocations;
+CREATE TRIGGER trg_validate_facture_source_allocation_227 BEFORE INSERT ON public.facture_source_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_validate_facturation_allocation_227();
+DROP TRIGGER IF EXISTS trg_validate_paiement_allocation_227 ON public.paiement_allocations;
+CREATE TRIGGER trg_validate_paiement_allocation_227 BEFORE INSERT ON public.paiement_allocations
+FOR EACH ROW EXECUTE FUNCTION public.fn_validate_facturation_allocation_227();
 DROP TRIGGER IF EXISTS trg_validate_avoir_allocation_227 ON public.avoir_source_allocations;
 CREATE TRIGGER trg_validate_avoir_allocation_227 BEFORE INSERT ON public.avoir_source_allocations
 FOR EACH ROW EXECUTE FUNCTION public.fn_validate_facturation_allocation_227();
+DROP TRIGGER IF EXISTS trg_protect_paiement_227 ON public.paiement;
+CREATE TRIGGER trg_protect_paiement_227 BEFORE UPDATE OR DELETE ON public.paiement
+FOR EACH ROW EXECUTE FUNCTION public.fn_protect_paiement_227();
 
 ALTER TABLE public.facture
   DROP COLUMN IF EXISTS settlement_status,

--- a/db/patches/support/20260804_finance_settlement_state_469.rollback.sql
+++ b/db/patches/support/20260804_finance_settlement_state_469.rollback.sql
@@ -1,0 +1,46 @@
+-- Roll back the #469 schema contract. Derived columns are removed; historical rows are untouched.
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#469 rollback is restricted to cerp_test';
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS public.facture_document_settlement_469_idx;
+ALTER TABLE public.facture DROP CONSTRAINT IF EXISTS facture_statut_469_ck;
+ALTER TABLE public.facture DROP CONSTRAINT IF EXISTS facture_document_status_469_ck;
+ALTER TABLE public.facture DROP CONSTRAINT IF EXISTS facture_settlement_status_469_ck;
+ALTER TABLE public.avoir DROP CONSTRAINT IF EXISTS avoir_statut_469_ck;
+
+CREATE OR REPLACE FUNCTION public.fn_protect_facturation_immutable_227()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF OLD.statut IN (
+      'ISSUED', 'PARTIALLY_PAID', 'PAID', 'CANCELLED',
+      'emise', 'envoyee', 'partielle', 'payee', 'annulee', 'emis', 'annule'
+    ) THEN
+      RAISE EXCEPTION 'issued or cancelled finance evidence cannot be deleted' USING ERRCODE = '55000';
+    END IF;
+    RETURN OLD;
+  END IF;
+  IF OLD.statut IN (
+    'ISSUED', 'PARTIALLY_PAID', 'PAID', 'CANCELLED',
+    'emise', 'envoyee', 'partielle', 'payee', 'annulee', 'emis', 'annule'
+  ) THEN
+    RAISE EXCEPTION 'issued or cancelled finance evidence is immutable' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.statut = 'DRAFT' AND NEW.statut = 'CANCELLED' THEN
+    RAISE EXCEPTION 'draft finance evidence must not be cancelled as legal evidence' USING ERRCODE = '23514';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+ALTER TABLE public.facture
+  DROP COLUMN IF EXISTS settlement_status,
+  DROP COLUMN IF EXISTS document_status;
+
+COMMIT;

--- a/db/patches/support/20260804_finance_settlement_state_469.verify.sql
+++ b/db/patches/support/20260804_finance_settlement_state_469.verify.sql
@@ -22,11 +22,20 @@ BEGIN
     SELECT 1
     FROM public.facture f
     WHERE COALESCE((
-      SELECT SUM(pa.amount_ttc) FROM public.paiement_allocations pa WHERE pa.facture_id = f.id
+      SELECT SUM(pa.amount_ttc)
+      FROM public.paiement_allocations pa
+      JOIN public.paiement allocated_payment ON allocated_payment.id = pa.paiement_id
+      WHERE pa.facture_id = f.id
+        AND allocated_payment.status NOT IN ('REJECTED','REVERSED')
+        AND allocated_payment.workflow_status <> 'REVERSED'
+        AND allocated_payment.reversal_of_id IS NULL
     ), 0) + COALESCE((
       SELECT SUM(p.montant)
       FROM public.paiement p
       WHERE p.facture_id = f.id
+        AND p.status NOT IN ('REJECTED','REVERSED')
+        AND p.workflow_status <> 'REVERSED'
+        AND p.reversal_of_id IS NULL
         AND NOT EXISTS (
           SELECT 1 FROM public.paiement_allocations existing_pa
           WHERE existing_pa.paiement_id = p.id
@@ -50,15 +59,41 @@ BEGIN
   END IF;
   IF EXISTS (
     SELECT 1
+    FROM public.paiement p
+    WHERE p.facture_id IS NOT NULL
+      AND NOT (
+        p.uuid IS NOT NULL
+        AND p.code IS NOT NULL
+        AND p.correlation_id IS NOT NULL
+        AND p.idempotency_key IS NOT NULL
+        AND p.request_hash IS NOT NULL
+      )
+      AND EXISTS (
+        SELECT 1 FROM public.paiement_allocations pa WHERE pa.paiement_id = p.id
+      )
+  ) THEN
+    RAISE EXCEPTION 'Direct legacy payment evidence was converted to allocations';
+  END IF;
+  IF EXISTS (
+    SELECT 1
     FROM public.facture f
     CROSS JOIN LATERAL (
       SELECT (
         COALESCE((
-          SELECT SUM(pa.amount_ttc) FROM public.paiement_allocations pa WHERE pa.facture_id = f.id
+          SELECT SUM(pa.amount_ttc)
+          FROM public.paiement_allocations pa
+          JOIN public.paiement allocated_payment ON allocated_payment.id = pa.paiement_id
+          WHERE pa.facture_id = f.id
+            AND allocated_payment.status NOT IN ('REJECTED','REVERSED')
+            AND allocated_payment.workflow_status <> 'REVERSED'
+            AND allocated_payment.reversal_of_id IS NULL
         ), 0) + COALESCE((
           SELECT SUM(p.montant)
           FROM public.paiement p
           WHERE p.facture_id = f.id
+            AND p.status NOT IN ('REJECTED','REVERSED')
+            AND p.workflow_status <> 'REVERSED'
+            AND p.reversal_of_id IS NULL
             AND NOT EXISTS (
               SELECT 1 FROM public.paiement_allocations existing_pa
               WHERE existing_pa.paiement_id = p.id
@@ -82,8 +117,6 @@ BEGIN
     WHERE f.settlement_status <> CASE
       WHEN balance.settled_ttc >= f.total_ttc AND f.total_ttc > 0 THEN 'PAID'
       WHEN balance.settled_ttc > 0 THEN 'PARTIALLY_PAID'
-      WHEN f.statut = 'PAID' OR lower(f.statut) = 'payee' THEN 'PAID'
-      WHEN f.statut = 'PARTIALLY_PAID' OR lower(f.statut) = 'partielle' THEN 'PARTIALLY_PAID'
       ELSE 'UNPAID'
     END
   ) THEN
@@ -131,6 +164,52 @@ BEGIN
       AND pg_get_constraintdef(c.oid) LIKE '%annulee%'
   ) THEN
     RAISE EXCEPTION 'avoir_statut_469_ck is missing, validated unexpectedly, or incomplete';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'fn_validate_facturation_allocation_227'
+      AND pg_get_functiondef(p.oid) LIKE '%direct legacy payment evidence cannot be converted to allocations%'
+      AND pg_get_functiondef(p.oid) LIKE '%allocation_status = ''CONSUMED''%'
+      AND pg_get_functiondef(p.oid) LIKE '%allocated_payment.status NOT IN (''REJECTED'',''REVERSED'')%'
+      AND pg_get_functiondef(p.oid) LIKE '%p.id <> NEW.paiement_id%'
+  ) THEN
+    RAISE EXCEPTION '#469 allocation validator is missing or incomplete';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'fn_protect_paiement_227'
+      AND pg_get_functiondef(p.oid) LIKE '%direct legacy payment evidence cannot be deleted%'
+      AND pg_get_functiondef(p.oid) LIKE '%NEW.status IS DISTINCT FROM OLD.status%'
+      AND pg_get_functiondef(p.oid) LIKE '%NEW.reversal_of_id IS DISTINCT FROM OLD.reversal_of_id%'
+  ) THEN
+    RAISE EXCEPTION '#469 legacy payment protection is missing or incomplete';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE n.nspname = 'public'
+      AND p.proname = 'fn_protect_facturation_child_227'
+      AND pg_get_functiondef(p.oid) LIKE '%parent_document_status = ''ISSUED''%'
+      AND pg_get_functiondef(p.oid) LIKE '%to_jsonb(NEW) - ''amount_allocated'' - ''status''%'
+  ) THEN
+    RAISE EXCEPTION '#469 issued due-date protection is missing or incomplete';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_trigger t
+    WHERE t.tgname = 'trg_validate_avoir_allocation_227'
+      AND t.tgrelid = 'public.avoir_source_allocations'::regclass
+      AND NOT t.tgisinternal
+      AND pg_get_triggerdef(t.oid) LIKE '%BEFORE INSERT OR UPDATE%'
+  ) THEN
+    RAISE EXCEPTION '#469 consumed-credit transition validator trigger is missing or incomplete';
   END IF;
 END $$;
 

--- a/db/patches/support/20260804_finance_settlement_state_469.verify.sql
+++ b/db/patches/support/20260804_finance_settlement_state_469.verify.sql
@@ -201,15 +201,34 @@ BEGIN
   ) THEN
     RAISE EXCEPTION '#469 issued due-date protection is missing or incomplete';
   END IF;
-  IF NOT EXISTS (
+  IF EXISTS (
+    WITH expected(trigger_name, table_name, function_name, trigger_type) AS (
+      VALUES
+        ('trg_protect_facture_ligne_227', 'facture_ligne', 'fn_protect_facturation_child_227', 31),
+        ('trg_protect_avoir_ligne_227', 'avoir_ligne', 'fn_protect_facturation_child_227', 31),
+        ('trg_protect_facture_source_227', 'facture_source_allocations', 'fn_protect_facturation_child_227', 31),
+        ('trg_protect_facture_echeance_227', 'facture_echeance', 'fn_protect_facturation_child_227', 31),
+        ('trg_protect_avoir_source_227', 'avoir_source_allocations', 'fn_protect_facturation_child_227', 31),
+        ('trg_validate_facture_source_allocation_227', 'facture_source_allocations', 'fn_validate_facturation_allocation_227', 7),
+        ('trg_validate_paiement_allocation_227', 'paiement_allocations', 'fn_validate_facturation_allocation_227', 7),
+        ('trg_validate_avoir_allocation_227', 'avoir_source_allocations', 'fn_validate_facturation_allocation_227', 23),
+        ('trg_protect_paiement_227', 'paiement', 'fn_protect_paiement_227', 27)
+    )
     SELECT 1
-    FROM pg_trigger t
-    WHERE t.tgname = 'trg_validate_avoir_allocation_227'
-      AND t.tgrelid = 'public.avoir_source_allocations'::regclass
-      AND NOT t.tgisinternal
-      AND pg_get_triggerdef(t.oid) LIKE '%BEFORE INSERT OR UPDATE%'
+    FROM expected e
+    LEFT JOIN pg_trigger t
+      ON t.tgname = e.trigger_name
+     AND t.tgrelid = to_regclass('public.' || e.table_name)
+    LEFT JOIN pg_proc p ON p.oid = t.tgfoid
+    LEFT JOIN pg_namespace n ON n.oid = p.pronamespace
+    WHERE t.oid IS NULL
+       OR t.tgisinternal
+       OR t.tgenabled IS DISTINCT FROM 'O'
+       OR t.tgtype <> e.trigger_type
+       OR p.proname IS DISTINCT FROM e.function_name
+       OR n.nspname IS DISTINCT FROM 'public'
   ) THEN
-    RAISE EXCEPTION '#469 consumed-credit transition validator trigger is missing or incomplete';
+    RAISE EXCEPTION '#469 Finance trigger bindings are missing, disabled, or misconfigured';
   END IF;
 END $$;
 

--- a/db/patches/support/20260804_finance_settlement_state_469.verify.sql
+++ b/db/patches/support/20260804_finance_settlement_state_469.verify.sql
@@ -12,7 +12,9 @@ BEGIN
   END IF;
   IF EXISTS (
     SELECT 1 FROM public.facture
-    WHERE statut IN ('ISSUED','PARTIALLY_PAID','PAID') AND document_status <> 'ISSUED'
+    WHERE statut IN (
+      'ISSUED','PARTIALLY_PAID','PAID','emis','emise','envoyee','partielle','payee'
+    ) AND document_status <> 'ISSUED'
   ) THEN
     RAISE EXCEPTION 'Canonical issued invoice lifecycle backfill is inconsistent';
   END IF;
@@ -22,12 +24,113 @@ BEGIN
     WHERE COALESCE((
       SELECT SUM(pa.amount_ttc) FROM public.paiement_allocations pa WHERE pa.facture_id = f.id
     ), 0) + COALESCE((
+      SELECT SUM(p.montant)
+      FROM public.paiement p
+      WHERE p.facture_id = f.id
+        AND NOT EXISTS (
+          SELECT 1 FROM public.paiement_allocations existing_pa
+          WHERE existing_pa.paiement_id = p.id
+        )
+    ), 0) + COALESCE((
       SELECT SUM(asa.amount_ttc)
       FROM public.avoir_source_allocations asa
       WHERE asa.facture_id = f.id AND asa.allocation_status = 'CONSUMED'
+    ), 0) + COALESCE((
+      SELECT SUM(a.total_ttc)
+      FROM public.avoir a
+      WHERE a.facture_id = f.id
+        AND a.statut IN ('ISSUED','emis','emise','envoyee')
+        AND NOT EXISTS (
+          SELECT 1 FROM public.avoir_source_allocations existing_asa
+          WHERE existing_asa.avoir_id = a.id
+        )
     ), 0) > f.total_ttc
   ) THEN
     RAISE EXCEPTION 'Invoice allocation cap verification failed';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM public.facture f
+    CROSS JOIN LATERAL (
+      SELECT (
+        COALESCE((
+          SELECT SUM(pa.amount_ttc) FROM public.paiement_allocations pa WHERE pa.facture_id = f.id
+        ), 0) + COALESCE((
+          SELECT SUM(p.montant)
+          FROM public.paiement p
+          WHERE p.facture_id = f.id
+            AND NOT EXISTS (
+              SELECT 1 FROM public.paiement_allocations existing_pa
+              WHERE existing_pa.paiement_id = p.id
+            )
+        ), 0) + COALESCE((
+          SELECT SUM(asa.amount_ttc)
+          FROM public.avoir_source_allocations asa
+          WHERE asa.facture_id = f.id AND asa.allocation_status = 'CONSUMED'
+        ), 0) + COALESCE((
+          SELECT SUM(a.total_ttc)
+          FROM public.avoir a
+          WHERE a.facture_id = f.id
+            AND a.statut IN ('ISSUED','emis','emise','envoyee')
+            AND NOT EXISTS (
+              SELECT 1 FROM public.avoir_source_allocations existing_asa
+              WHERE existing_asa.avoir_id = a.id
+            )
+        ), 0)
+      )::numeric(18,2) AS settled_ttc
+    ) balance
+    WHERE f.settlement_status <> CASE
+      WHEN balance.settled_ttc >= f.total_ttc AND f.total_ttc > 0 THEN 'PAID'
+      WHEN balance.settled_ttc > 0 THEN 'PARTIALLY_PAID'
+      WHEN f.statut = 'PAID' OR lower(f.statut) = 'payee' THEN 'PAID'
+      WHEN f.statut = 'PARTIALLY_PAID' OR lower(f.statut) = 'partielle' THEN 'PARTIALLY_PAID'
+      ELSE 'UNPAID'
+    END
+  ) THEN
+    RAISE EXCEPTION 'Invoice settlement derivation verification failed';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    WHERE c.conname = 'facture_statut_469_ck'
+      AND c.conrelid = 'public.facture'::regclass
+      AND c.convalidated = FALSE
+      AND pg_get_constraintdef(c.oid) LIKE '%brouillon%'
+      AND pg_get_constraintdef(c.oid) LIKE '%partielle%'
+      AND pg_get_constraintdef(c.oid) LIKE '%annulee%'
+  ) THEN
+    RAISE EXCEPTION 'facture_statut_469_ck is missing, validated unexpectedly, or incomplete';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    WHERE c.conname = 'facture_document_status_469_ck'
+      AND c.conrelid = 'public.facture'::regclass
+      AND c.convalidated = TRUE
+      AND pg_get_constraintdef(c.oid) LIKE '%LEGACY%'
+      AND pg_get_constraintdef(c.oid) LIKE '%ISSUED%'
+  ) THEN
+    RAISE EXCEPTION 'facture_document_status_469_ck is missing, unvalidated, or incomplete';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    WHERE c.conname = 'facture_settlement_status_469_ck'
+      AND c.conrelid = 'public.facture'::regclass
+      AND c.convalidated = TRUE
+      AND pg_get_constraintdef(c.oid) LIKE '%UNPAID%'
+      AND pg_get_constraintdef(c.oid) LIKE '%PARTIALLY_PAID%'
+      AND pg_get_constraintdef(c.oid) LIKE '%PAID%'
+  ) THEN
+    RAISE EXCEPTION 'facture_settlement_status_469_ck is missing, unvalidated, or incomplete';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint c
+    WHERE c.conname = 'avoir_statut_469_ck'
+      AND c.conrelid = 'public.avoir'::regclass
+      AND c.convalidated = FALSE
+      AND pg_get_constraintdef(c.oid) LIKE '%brouillon%'
+      AND pg_get_constraintdef(c.oid) LIKE '%envoyee%'
+      AND pg_get_constraintdef(c.oid) LIKE '%annulee%'
+  ) THEN
+    RAISE EXCEPTION 'avoir_statut_469_ck is missing, validated unexpectedly, or incomplete';
   END IF;
 END $$;
 

--- a/db/patches/support/20260804_finance_settlement_state_469.verify.sql
+++ b/db/patches/support/20260804_finance_settlement_state_469.verify.sql
@@ -1,0 +1,48 @@
+-- Read-only verification for issue #469.
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION '#469 verification is restricted to cerp_test';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.facture
+    WHERE document_status IS NULL OR settlement_status IS NULL
+  ) THEN
+    RAISE EXCEPTION 'Invoice document/settlement backfill is incomplete';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.facture
+    WHERE statut IN ('ISSUED','PARTIALLY_PAID','PAID') AND document_status <> 'ISSUED'
+  ) THEN
+    RAISE EXCEPTION 'Canonical issued invoice lifecycle backfill is inconsistent';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM public.facture f
+    WHERE COALESCE((
+      SELECT SUM(pa.amount_ttc) FROM public.paiement_allocations pa WHERE pa.facture_id = f.id
+    ), 0) + COALESCE((
+      SELECT SUM(asa.amount_ttc)
+      FROM public.avoir_source_allocations asa
+      WHERE asa.facture_id = f.id AND asa.allocation_status = 'CONSUMED'
+    ), 0) > f.total_ttc
+  ) THEN
+    RAISE EXCEPTION 'Invoice allocation cap verification failed';
+  END IF;
+END $$;
+
+SELECT conname, convalidated
+FROM pg_constraint
+WHERE conrelid IN ('public.facture'::regclass, 'public.avoir'::regclass)
+  AND conname IN (
+    'facture_statut_469_ck',
+    'facture_document_status_469_ck',
+    'facture_settlement_status_469_ck',
+    'avoir_statut_469_ck'
+  )
+ORDER BY conname;
+
+SELECT document_status, settlement_status, statut, COUNT(*) AS invoice_count
+FROM public.facture
+GROUP BY document_status, settlement_status, statut
+ORDER BY document_status, settlement_status, statut;

--- a/docs/devis-workflow-167.md
+++ b/docs/devis-workflow-167.md
@@ -138,3 +138,16 @@ Cas particulier : l'audit de conversion est écrit après COMMIT du moteur comma
 `support/`). Appliqué sur **cerp_test** le 2026-07-22 (backup pris, verify vert,
 ownership `cerp_app` réassigné). **cerp_prod NON modifié** — application prod
 uniquement après validation humaine explicite.
+
+## 11. Champs de préparation facultatifs (#470)
+
+Le contrat d'entrée d'une ligne de devis distingue désormais la préparation
+explicite de ses valeurs par défaut :
+
+- propriété absente, `null`, objet vide ou chaînes uniquement blanches : aucune
+  préparation explicite ; le validateur normalise la propriété vers l'absence ;
+- objet renseigné : les chaînes sont tronquées et les valeurs non blanches sont
+  conservées ; les identifiants facultatifs acceptent l'absence ou `null` ;
+- le frontend complète un objet partiel avec les mêmes valeurs préparatoires
+  historiques avant l'appel API. Les prix, totaux, statuts et permissions ne
+  sont pas modifiés par ce contrat.

--- a/docs/http/facturation-227.md
+++ b/docs/http/facturation-227.md
@@ -43,6 +43,8 @@ codifié et son explication sont obligatoires.
 
 ## Paiement
 
+- `GET /paiements`
+- `GET /paiements/:id`
 - `POST /paiements/workflow/register`
 - `POST /paiements/workflow/:id/allocations`
 
@@ -50,6 +52,12 @@ Les montants sont des chaînes décimales exactes. L'enregistrement accepte zér
 ou plusieurs allocations `FACTURE`/`ECHEANCE`; chaque allocation contrôle le
 client, la devise, le disponible du paiement et le solde de la cible dans la
 même transaction. Un paiement enregistré est immuable et ne se supprime pas.
+
+Le filtre `GET /paiements?unallocated=true` retient tout règlement net dont le
+disponible (`montant − allocations`) est strictement positif, y compris une affectation
+partielle. Les règlements rejetés/extournés et les rattachements directs hérités sans
+allocation en sont exclus. Pour ces derniers, les lectures liste/détail projettent le
+statut `ALLOCATED` sans modifier leur statut brut historique en base.
 
 ## Garanties transactionnelles
 

--- a/docs/reporting-commercial-360-275.md
+++ b/docs/reporting-commercial-360-275.md
@@ -104,6 +104,13 @@ Un règlement compte comme encaissement net s'il n'est ni rejeté (`REJECTED`), 
 (`reversal_of_id IS NOT NULL`). Cette règle est neutre quelle que soit la convention
 d'extourne retenue plus tard.
 
+Le disponible d'une source de règlement vaut `MAX(montant − allocations, 0)`. Il reste
+donc positif pour un règlement partiellement affecté et alimente à la fois le KPI, son
+drill-down et la file `/paiements?unallocated=true`. Un rattachement direct hérité
+(`facture_id` renseigné sans allocation) constitue une affectation économique complète :
+son disponible vaut zéro et les lectures liste/détail projettent `status = ALLOCATED`, sans
+réécrire le statut brut conservé comme preuve historique.
+
 ### Encours à `as_of` — la règle centrale
 ```
 solde(facture) = total_ttc

--- a/src/__tests__/devis.routes.test.ts
+++ b/src/__tests__/devis.routes.test.ts
@@ -753,6 +753,33 @@ describe("/api/v1/devis", () => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it("POST /api/v1/devis refuse un dossier préparatoire orphelin sans écriture", async () => {
+    const payload = {
+      client_id: "001",
+      user_id: 1,
+      lignes: [{
+        description: "Line",
+        quantite: 1,
+        prix_unitaire_ht: 100,
+        dossier_technique_piece_devis: {
+          code_piece: "DOS-42",
+          designation: "Dossier orphelin",
+        },
+      }],
+    };
+
+    const res = await request(app)
+      .post("/api/v1/devis")
+      .field("data", JSON.stringify(payload));
+
+    expect(res.status).toBe(422);
+    expect(res.body).toMatchObject({
+      code: "VALIDATION_ERROR",
+      message: "article_devis est requis lorsqu'un dossier_technique_piece_devis est fourni",
+    });
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
   it("PATCH /api/v1/devis/:id supports multipart update (replace lignes)", async () => {
     state.updateCurrent = {
       id: "7",

--- a/src/__tests__/facturation-469.migration-guards.test.ts
+++ b/src/__tests__/facturation-469.migration-guards.test.ts
@@ -54,6 +54,99 @@ function normalizedSql(source: string): string {
     .trim();
 }
 
+const replacedFunctionTriggerBindings = [
+  {
+    name: "trg_protect_facture_ligne_227",
+    table: "facture_ligne",
+    functionName: "fn_protect_facturation_child_227",
+    forwardEvents: "INSERT OR UPDATE OR DELETE",
+    forwardType: 31,
+    rollbackEvents: "INSERT OR UPDATE OR DELETE",
+    rollbackType: 31,
+  },
+  {
+    name: "trg_protect_avoir_ligne_227",
+    table: "avoir_ligne",
+    functionName: "fn_protect_facturation_child_227",
+    forwardEvents: "INSERT OR UPDATE OR DELETE",
+    forwardType: 31,
+    rollbackEvents: "INSERT OR UPDATE OR DELETE",
+    rollbackType: 31,
+  },
+  {
+    name: "trg_protect_facture_source_227",
+    table: "facture_source_allocations",
+    functionName: "fn_protect_facturation_child_227",
+    forwardEvents: "INSERT OR UPDATE OR DELETE",
+    forwardType: 31,
+    rollbackEvents: "INSERT OR UPDATE OR DELETE",
+    rollbackType: 31,
+  },
+  {
+    name: "trg_protect_facture_echeance_227",
+    table: "facture_echeance",
+    functionName: "fn_protect_facturation_child_227",
+    forwardEvents: "INSERT OR UPDATE OR DELETE",
+    forwardType: 31,
+    rollbackEvents: "INSERT OR UPDATE OR DELETE",
+    rollbackType: 31,
+  },
+  {
+    name: "trg_protect_avoir_source_227",
+    table: "avoir_source_allocations",
+    functionName: "fn_protect_facturation_child_227",
+    forwardEvents: "INSERT OR UPDATE OR DELETE",
+    forwardType: 31,
+    rollbackEvents: "INSERT OR UPDATE OR DELETE",
+    rollbackType: 31,
+  },
+  {
+    name: "trg_validate_facture_source_allocation_227",
+    table: "facture_source_allocations",
+    functionName: "fn_validate_facturation_allocation_227",
+    forwardEvents: "INSERT",
+    forwardType: 7,
+    rollbackEvents: "INSERT",
+    rollbackType: 7,
+  },
+  {
+    name: "trg_validate_paiement_allocation_227",
+    table: "paiement_allocations",
+    functionName: "fn_validate_facturation_allocation_227",
+    forwardEvents: "INSERT",
+    forwardType: 7,
+    rollbackEvents: "INSERT",
+    rollbackType: 7,
+  },
+  {
+    name: "trg_validate_avoir_allocation_227",
+    table: "avoir_source_allocations",
+    functionName: "fn_validate_facturation_allocation_227",
+    forwardEvents: "INSERT OR UPDATE",
+    forwardType: 23,
+    rollbackEvents: "INSERT",
+    rollbackType: 7,
+  },
+  {
+    name: "trg_protect_paiement_227",
+    table: "paiement",
+    functionName: "fn_protect_paiement_227",
+    forwardEvents: "UPDATE OR DELETE",
+    forwardType: 27,
+    rollbackEvents: "UPDATE OR DELETE",
+    rollbackType: 27,
+  },
+] as const;
+
+function triggerBindingPattern(binding: typeof replacedFunctionTriggerBindings[number], rollback = false) {
+  const events = rollback ? binding.rollbackEvents : binding.forwardEvents;
+  return new RegExp(
+    `DROP TRIGGER IF EXISTS ${binding.name} ON public\\.${binding.table};` +
+      `[\\s\\S]*?CREATE TRIGGER ${binding.name}\\s+BEFORE ${events} ON public\\.${binding.table}` +
+      `\\s+FOR EACH ROW EXECUTE FUNCTION public\\.${binding.functionName}\\(\\);`
+  );
+}
+
 describe("#469 settlement-state guards", () => {
   it("preserves historical statuses and constrains future writes", () => {
     expect(patch).toContain("Historical `statut` values are never rewritten");
@@ -137,6 +230,30 @@ describe("#469 settlement-state guards", () => {
     expect(patch).toContain("WHEN NEW.allocation_status = 'CONSUMED' THEN NEW.amount_ttc");
   });
 
+  it("rebinds every trigger that depends on a replaced #227 function", () => {
+    const preflight = supportScripts[0];
+    const verify = supportScripts[1];
+    const rollback = supportScripts[2];
+
+    for (const binding of replacedFunctionTriggerBindings) {
+      expect(patch).toMatch(triggerBindingPattern(binding));
+      expect(rollback).toMatch(triggerBindingPattern(binding, true));
+      expect(preflight).toContain(
+        `('${binding.name}', '${binding.table}', '${binding.functionName}', ${binding.rollbackType})`
+      );
+      expect(verify).toContain(
+        `('${binding.name}', '${binding.table}', '${binding.functionName}', ${binding.forwardType})`
+      );
+    }
+
+    for (const script of [preflight, verify]) {
+      expect(script).toContain("t.tgenabled IS DISTINCT FROM 'O'");
+      expect(script).toContain("t.tgtype <> e.trigger_type");
+      expect(script).toContain("p.proname IS DISTINCT FROM e.function_name");
+      expect(script).toContain("n.nspname IS DISTINCT FROM 'public'");
+    }
+  });
+
   it("allows only monotone due-date settlement updates on issued legacy invoices", () => {
     expect(patch).toContain("CREATE OR REPLACE FUNCTION public.fn_protect_facturation_child_227()");
     expect(patch).toContain("parent_document_status = 'ISSUED'");
@@ -162,7 +279,7 @@ describe("#469 settlement-state guards", () => {
     );
     expect(rollback).not.toContain("direct legacy payment evidence cannot be deleted");
     expect(verify).toContain("pg_get_functiondef");
-    expect(verify).toContain("pg_get_triggerdef");
+    expect(verify).toContain("LEFT JOIN pg_trigger t");
   });
 
   it("restores the prior #227 function and trigger contracts on rollback", () => {

--- a/src/__tests__/facturation-469.migration-guards.test.ts
+++ b/src/__tests__/facturation-469.migration-guards.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+import { repoRoot } from "./helpers/repo-paths";
+
+const patch = readFileSync(
+  resolve(repoRoot, "db/patches/20260804_finance_settlement_state_469.sql"),
+  "utf8"
+);
+const supportScripts = ["preflight", "verify", "rollback"].map((suffix) =>
+  readFileSync(
+    resolve(repoRoot, `db/patches/support/20260804_finance_settlement_state_469.${suffix}.sql`),
+    "utf8"
+  )
+);
+const repository = readFileSync(
+  resolve(repoRoot, "src/module/facturation/repository/payment-workflow.repository.ts"),
+  "utf8"
+);
+
+describe("#469 settlement-state guards", () => {
+  it("preserves historical statuses and constrains future writes", () => {
+    expect(patch).toContain("Historical `statut` values are never rewritten");
+    expect(patch).toContain("facture_statut_469_ck");
+    expect(patch).toContain("avoir_statut_469_ck");
+    expect(patch).toMatch(/facture_statut_469_ck[\s\S]*NOT VALID/);
+    expect(patch).not.toMatch(/UPDATE\s+public\.facture\s+SET\s+statut/i);
+  });
+
+  it("separates document and settlement state behind the immutable trigger", () => {
+    expect(patch).toContain("document_status");
+    expect(patch).toContain("settlement_status");
+    expect(patch).toContain("cerp.finance_settlement_correlation_id");
+    expect(patch).toContain("NEW.row_version = OLD.row_version + 1");
+  });
+
+  it("derives invoice state inside payment transactions and records evidence", () => {
+    expect(repository).toContain("refreshInvoiceSettlementStates");
+    expect(repository).toContain("FACTURE_SETTLEMENT_DERIVED");
+    expect(repository).toContain("FINANCE-SETTLEMENT-469");
+    expect(repository).toContain("FOR UPDATE");
+    expect(repository).toContain("BEGIN");
+    expect(repository).toContain("ROLLBACK");
+  });
+
+  it("restricts all database recipes to cerp_test", () => {
+    for (const script of supportScripts) {
+      expect(script).toContain("current_database() <> 'cerp_test'");
+    }
+  });
+});

--- a/src/__tests__/facturation-469.migration-guards.test.ts
+++ b/src/__tests__/facturation-469.migration-guards.test.ts
@@ -30,6 +30,29 @@ const factureRepository = readFileSync(
   resolve(repoRoot, "src/module/facturation/repository/factures.repository.ts"),
   "utf8"
 );
+const original227Patch = readFileSync(
+  resolve(repoRoot, "db/patches/20260725_facturation_payments_227.sql"),
+  "utf8"
+);
+const correctedChild227Patch = readFileSync(
+  resolve(repoRoot, "db/patches/20260726_fix_facturation_child_trigger_227.sql"),
+  "utf8"
+);
+
+function sqlFunction(source: string, name: string): string {
+  const start = source.indexOf(`CREATE OR REPLACE FUNCTION public.${name}()`);
+  if (start < 0) throw new Error(`Missing SQL function ${name}`);
+  const end = source.indexOf("$$;", start);
+  if (end < 0) throw new Error(`Unterminated SQL function ${name}`);
+  return source.slice(start, end + 3);
+}
+
+function normalizedSql(source: string): string {
+  return source
+    .replace(/--.*$/gm, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
 
 describe("#469 settlement-state guards", () => {
   it("preserves historical statuses and constrains future writes", () => {
@@ -39,6 +62,20 @@ describe("#469 settlement-state guards", () => {
     expect(patch).toMatch(/facture_statut_469_ck[\s\S]*NOT VALID/);
     expect(patch).toContain("'brouillon','emis','emise','envoyee','partielle','payee','annule','annulee'");
     expect(patch).not.toMatch(/UPDATE\s+public\.facture\s+SET\s+statut/i);
+  });
+
+  it("never derives settlement from legacy raw status without monetary evidence", () => {
+    const settlementBackfill = patch.slice(
+      patch.indexOf("settlement_status = CASE"),
+      patch.indexOf("FROM (", patch.indexOf("settlement_status = CASE"))
+    );
+    expect(settlementBackfill).toContain("WHEN balance.settled_ttc > 0 THEN 'PARTIALLY_PAID'");
+    expect(settlementBackfill).toContain("ELSE 'UNPAID'");
+    expect(settlementBackfill).not.toContain("payee");
+    expect(settlementBackfill).not.toContain("partielle");
+    expect(supportScripts[1]).not.toMatch(
+      /WHEN\s+(?:f\.)?statut\s*=\s*'(?:PAID|PARTIALLY_PAID)'\s+OR/i
+    );
   });
 
   it("separates document and settlement state behind the immutable trigger", () => {
@@ -74,6 +111,40 @@ describe("#469 settlement-state guards", () => {
     expect(repository).toContain("legacy_direct_credit_ttc");
   });
 
+  it("uses the same net-payment predicate in migration, verification and reads", () => {
+    for (const source of [patch, supportScripts[0], supportScripts[1], repository, factureRepository]) {
+      expect(source).toContain("status NOT IN ('REJECTED','REVERSED')");
+      expect(source).toContain("workflow_status <> 'REVERSED'");
+      expect(source).toContain("reversal_of_id IS NULL");
+    }
+    expect(repository).toContain(
+      "JOIN public.paiement allocated_payment ON allocated_payment.id = pa.paiement_id"
+    );
+  });
+
+  it("hardens database allocation caps and direct legacy payment evidence", () => {
+    expect(patch).toContain("CREATE OR REPLACE FUNCTION public.fn_validate_facturation_allocation_227()");
+    expect(patch).toContain("direct legacy payment evidence cannot be converted to allocations");
+    expect(patch).toContain("p.id <> NEW.paiement_id");
+    expect(patch).toContain("asa.allocation_status = 'CONSUMED'");
+    expect(patch).toMatch(
+      /CREATE TRIGGER trg_validate_avoir_allocation_227\s+BEFORE INSERT OR UPDATE/i
+    );
+    expect(patch).toContain("direct legacy payment evidence cannot be deleted");
+    expect(patch).toContain("NEW.status IS DISTINCT FROM OLD.status");
+    expect(patch).toContain("NEW.reversal_of_id IS DISTINCT FROM OLD.reversal_of_id");
+    expect(patch).toContain("incoming_invoice_credit := CASE");
+    expect(patch).toContain("WHEN NEW.allocation_status = 'CONSUMED' THEN NEW.amount_ttc");
+  });
+
+  it("allows only monotone due-date settlement updates on issued legacy invoices", () => {
+    expect(patch).toContain("CREATE OR REPLACE FUNCTION public.fn_protect_facturation_child_227()");
+    expect(patch).toContain("parent_document_status = 'ISSUED'");
+    expect(patch).toContain("NEW.amount_allocated >= OLD.amount_allocated");
+    expect(patch).toContain("NEW.amount_allocated <= NEW.amount_due");
+    expect(patch).toContain("to_jsonb(NEW) - 'amount_allocated' - 'status'");
+  });
+
   it("asserts constraint definitions and protects a controlled non-test rollback", () => {
     const verify = supportScripts[1];
     const rollback = supportScripts[2];
@@ -83,6 +154,40 @@ describe("#469 settlement-state guards", () => {
     expect(rollback).toContain("cerp.finance_469_application_rolled_back");
     expect(rollback).toContain("cerp.finance_469_rollback_authorized");
     expect(rollback).toContain("current_database() <> 'cerp_test'");
+    expect(rollback).toContain("CREATE OR REPLACE FUNCTION public.fn_validate_facturation_allocation_227()");
+    expect(rollback).toContain("CREATE OR REPLACE FUNCTION public.fn_protect_paiement_227()");
+    expect(rollback).toContain("CREATE OR REPLACE FUNCTION public.fn_protect_facturation_child_227()");
+    expect(rollback).toMatch(
+      /CREATE TRIGGER trg_validate_avoir_allocation_227 BEFORE INSERT ON public\.avoir_source_allocations/i
+    );
+    expect(rollback).not.toContain("direct legacy payment evidence cannot be deleted");
+    expect(verify).toContain("pg_get_functiondef");
+    expect(verify).toContain("pg_get_triggerdef");
+  });
+
+  it("restores the prior #227 function and trigger contracts on rollback", () => {
+    const rollback = supportScripts[2];
+    expect(normalizedSql(sqlFunction(
+      rollback,
+      "fn_validate_facturation_allocation_227"
+    ))).toBe(normalizedSql(sqlFunction(
+      original227Patch,
+      "fn_validate_facturation_allocation_227"
+    )));
+    expect(normalizedSql(sqlFunction(
+      rollback,
+      "fn_protect_paiement_227"
+    ))).toBe(normalizedSql(sqlFunction(
+      original227Patch,
+      "fn_protect_paiement_227"
+    )));
+    expect(normalizedSql(sqlFunction(
+      rollback,
+      "fn_protect_facturation_child_227"
+    ))).toBe(normalizedSql(sqlFunction(
+      correctedChild227Patch,
+      "fn_protect_facturation_child_227"
+    )));
   });
 
   it("keeps invoice lines independent from payment aliases", () => {

--- a/src/__tests__/facturation-469.migration-guards.test.ts
+++ b/src/__tests__/facturation-469.migration-guards.test.ts
@@ -15,7 +15,19 @@ const supportScripts = ["preflight", "verify", "rollback"].map((suffix) =>
   )
 );
 const repository = readFileSync(
+  resolve(repoRoot, "src/module/facturation/repository/invoice-settlement.repository.ts"),
+  "utf8"
+);
+const paymentRepository = readFileSync(
   resolve(repoRoot, "src/module/facturation/repository/payment-workflow.repository.ts"),
+  "utf8"
+);
+const creditRepository = readFileSync(
+  resolve(repoRoot, "src/module/facturation/repository/avoir-workflow.repository.ts"),
+  "utf8"
+);
+const factureRepository = readFileSync(
+  resolve(repoRoot, "src/module/facturation/repository/factures.repository.ts"),
   "utf8"
 );
 
@@ -25,6 +37,7 @@ describe("#469 settlement-state guards", () => {
     expect(patch).toContain("facture_statut_469_ck");
     expect(patch).toContain("avoir_statut_469_ck");
     expect(patch).toMatch(/facture_statut_469_ck[\s\S]*NOT VALID/);
+    expect(patch).toContain("'brouillon','emis','emise','envoyee','partielle','payee','annule','annulee'");
     expect(patch).not.toMatch(/UPDATE\s+public\.facture\s+SET\s+statut/i);
   });
 
@@ -32,7 +45,14 @@ describe("#469 settlement-state guards", () => {
     expect(patch).toContain("document_status");
     expect(patch).toContain("settlement_status");
     expect(patch).toContain("cerp.finance_settlement_correlation_id");
+    expect(patch).toMatch(
+      /current_setting\('cerp\.finance_settlement_correlation_id', true\) IS NOT NULL/
+    );
+    expect(patch).toMatch(
+      /current_setting\('cerp\.finance_settlement_correlation_id', true\)\s*= NEW\.correlation_id::text/
+    );
     expect(patch).toContain("NEW.row_version = OLD.row_version + 1");
+    expect(patch).toContain("'emise', 'envoyee', 'partielle', 'payee', 'emis'");
   });
 
   it("derives invoice state inside payment transactions and records evidence", () => {
@@ -40,13 +60,37 @@ describe("#469 settlement-state guards", () => {
     expect(repository).toContain("FACTURE_SETTLEMENT_DERIVED");
     expect(repository).toContain("FINANCE-SETTLEMENT-469");
     expect(repository).toContain("FOR UPDATE");
-    expect(repository).toContain("BEGIN");
-    expect(repository).toContain("ROLLBACK");
+    expect(paymentRepository).toContain("BEGIN");
+    expect(paymentRepository).toContain("ROLLBACK");
+    expect(creditRepository).toContain("refreshInvoiceSettlementStates");
   });
 
-  it("restricts all database recipes to cerp_test", () => {
-    for (const script of supportScripts) {
-      expect(script).toContain("current_database() <> 'cerp_test'");
+  it("uses the legacy direct-evidence fallback without double counting", () => {
+    for (const script of [patch, supportScripts[0], supportScripts[1]]) {
+      expect(script).toContain("existing_pa.paiement_id = p.id");
+      expect(script).toContain("existing_asa.avoir_id = a.id");
     }
+    expect(repository).toContain("legacy_direct_payment_ttc");
+    expect(repository).toContain("legacy_direct_credit_ttc");
+  });
+
+  it("asserts constraint definitions and protects a controlled non-test rollback", () => {
+    const verify = supportScripts[1];
+    const rollback = supportScripts[2];
+    expect(verify).toContain("pg_get_constraintdef");
+    expect(verify).toContain("convalidated = FALSE");
+    expect(verify).toContain("convalidated = TRUE");
+    expect(rollback).toContain("cerp.finance_469_application_rolled_back");
+    expect(rollback).toContain("cerp.finance_469_rollback_authorized");
+    expect(rollback).toContain("current_database() <> 'cerp_test'");
+  });
+
+  it("keeps invoice lines independent from payment aliases", () => {
+    const lineQuery = factureRepository.slice(
+      factureRepository.indexOf("const lignes: FactureLine[]"),
+      factureRepository.indexOf("const documents: FactureDocument[]")
+    );
+    expect(lineQuery).not.toContain("paiement.id");
+    expect(lineQuery).toContain("facture_id::text AS facture_id");
   });
 });

--- a/src/__tests__/reporting-360-275.sql.test.ts
+++ b/src/__tests__/reporting-360-275.sql.test.ts
@@ -133,6 +133,23 @@ describe("#275 encours — stricte antériorité à la date d'arrêté", () => {
     expect(sql).toContain("NOT EXISTS (SELECT 1 FROM avoir_source_allocations asa2");
   });
 
+  it("compte le solde d'un règlement partiellement affecté dans le KPI non affecté", async () => {
+    captured.length = 0;
+    await repoReceivables(CTX);
+    const sql = allSql();
+    expect(sql).toContain("p.montant::numeric(18,2) - (CASE");
+    expect(sql).toContain("SELECT SUM(pa.amount_ttc)");
+    expect(sql).toContain("SUM(available)");
+  });
+
+  it("neutralise dans ce KPI la preuve directe héritée, économiquement déjà affectée", async () => {
+    captured.length = 0;
+    await repoReceivables(CTX);
+    const sql = allSql();
+    expect(sql).toMatch(/WHEN p\.facture_id IS NOT NULL[\s\S]*NOT EXISTS[\s\S]*THEN p\.montant::numeric\(18,2\)/);
+    expect(sql).toContain("p.status NOT IN ('REJECTED', 'REVERSED')");
+  });
+
   it("agrège en NUMERIC et jamais en float8", async () => {
     captured.length = 0;
     await repoReceivables(CTX);
@@ -458,10 +475,39 @@ describe("#275 drill-down", () => {
     expect(allSql()).toContain("cl.delai_client IS NOT NULL AND cl.delai_client <");
   });
 
-  it("un scope « non affecté » filtre réellement côté serveur", async () => {
+  it("un scope « non affecté » filtre le solde disponible et conserve les paiements partiels", async () => {
     captured.length = 0;
     await repoDrilldown(CTX, "payments", "unallocated");
-    expect(allSql()).toContain("p.facture_id IS NULL");
+    const sql = allSql();
+    expect(sql).toContain("AS allocated_amount");
+    expect(sql).toContain("AS available_amount");
+    expect(sql).toContain("WHERE pr.available_amount > 0::numeric");
+    expect(sql).toContain("SELECT SUM(pa.amount_ttc)");
+    expect(sql).not.toContain("p.facture_id IS NULL");
+  });
+
+  it("projette le direct legacy en ALLOCATED et l'exclut du drill-down non affecté", async () => {
+    captured.length = 0;
+    await repoDrilldown(CTX, "payments", "unallocated");
+    const sql = allSql();
+    expect(sql).toContain("p.facture_id IS NOT NULL");
+    expect(sql).toContain("FROM paiement_allocations pa2");
+    expect(sql).toContain("THEN 'ALLOCATED'");
+    expect(sql).toContain("pr.projected_status AS status");
+    expect(sql).toContain("p.status NOT IN ('REJECTED', 'REVERSED')");
+  });
+
+  it("expose les montants total, affecté et disponible dans le drill-down", async () => {
+    captured.length = 0;
+    mocks.poolQuery.mockImplementation((sql: string, values: unknown[] = []) => {
+      captured.push({ sql, values });
+      return Promise.resolve({
+        rows: [{ id: "9", montant: "100.00", allocated_amount: "60.00", available_amount: "40.00", total_rows: 1 }],
+      });
+    });
+
+    const result = await repoDrilldown(CTX, "payments", "unallocated");
+    expect(result.rows[0]).toMatchObject({ montant: 100, allocated_amount: 60, available_amount: 40 });
   });
 });
 

--- a/src/module/devis/repository/devis.repository.ts
+++ b/src/module/devis/repository/devis.repository.ts
@@ -861,7 +861,16 @@ type InsertedDevisLine = {
 async function insertDevisPreparatoryEntities(client: PoolClient, devisId: number, lines: InsertedDevisLine[]) {
   for (const line of lines) {
     const source = line.input;
-    if (!source.article_devis) continue;
+    if (!source.article_devis) {
+      if (source.dossier_technique_piece_devis) {
+        throw new HttpError(
+          422,
+          "DEVIS_DOSSIER_REQUIRES_ARTICLE",
+          "Un dossier technique de devis doit être rattaché à un article-devis."
+        );
+      }
+      continue;
+    }
 
     const a = source.article_devis;
     const articleDevisId = a.id ?? crypto.randomUUID();

--- a/src/module/devis/repository/devis.repository.ts
+++ b/src/module/devis/repository/devis.repository.ts
@@ -116,8 +116,8 @@ type DossierDevisRow = Omit<DossierTechniquePieceDevis, "devis_id" | "version_nu
 
 type DevisLineWithPreparatoryInput = CreateDevisBodyDTO["lignes"][number] & {
   article_devis?: {
-    id?: string;
-    root_article_devis_id?: string;
+    id?: string | null;
+    root_article_devis_id?: string | null;
     parent_article_devis_id?: string | null;
     version_number?: number;
     code: string;
@@ -130,8 +130,8 @@ type DevisLineWithPreparatoryInput = CreateDevisBodyDTO["lignes"][number] & {
     source_official_article_id?: string | null;
   };
   dossier_technique_piece_devis?: {
-    id?: string;
-    root_dossier_devis_id?: string;
+    id?: string | null;
+    root_dossier_devis_id?: string | null;
     parent_dossier_devis_id?: string | null;
     version_number?: number;
     code_piece: string;

--- a/src/module/devis/validators/devis.validators.test.ts
+++ b/src/module/devis/validators/devis.validators.test.ts
@@ -255,6 +255,34 @@ describe("#167 — matrice de payloads createDevisBodySchema", () => {
       designation: "Dossier spécial",
     });
   });
+
+  it("ne supprime pas silencieusement un plan_index non par défaut", () => {
+    const parsed = createDevisBodySchema.safeParse(withLigne({
+      article_devis: { plan_index: 2 },
+    }));
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.error.issues.some((issue) =>
+      issue.path.join(".") === "lignes.0.article_devis.code"
+    )).toBe(true);
+  });
+
+  it("refuse un dossier technique sans article-devis au lieu de le perdre", () => {
+    const parsed = createDevisBodySchema.safeParse(withLigne({
+      dossier_technique_piece_devis: {
+        code_piece: "DOS-42",
+        designation: "Dossier orphelin",
+      },
+    }));
+
+    expect(parsed.success).toBe(false);
+    if (parsed.success) return;
+    expect(parsed.error.issues).toContainEqual(expect.objectContaining({
+      path: ["lignes", 0, "article_devis"],
+      message: "article_devis est requis lorsqu'un dossier_technique_piece_devis est fourni",
+    }));
+  });
 });
 
 describe("#167 — updateDevisBodySchema (verrou optimiste additif)", () => {

--- a/src/module/devis/validators/devis.validators.test.ts
+++ b/src/module/devis/validators/devis.validators.test.ts
@@ -203,6 +203,58 @@ describe("#167 — matrice de payloads createDevisBodySchema", () => {
       expect(parsed.data.lignes[0]).toMatchObject({ quantite: 1, taux_tva: 20, remise_ligne: 0 });
     }
   });
+
+  it.each([
+    ["absentes", {}],
+    ["null", { article_devis: null, dossier_technique_piece_devis: null }],
+    [
+      "vides",
+      {
+        article_devis: { code: " ", designation: "", primary_category: "", family_code: "", plan_index: 1 },
+        dossier_technique_piece_devis: { code_piece: " ", designation: "", payload: {} },
+      },
+    ],
+  ])("accepte les données de préparation %s sur un devis minimal", (_label, preparation) => {
+    const parsed = createDevisBodySchema.safeParse(withLigne(preparation));
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.lignes[0].article_devis).toBeUndefined();
+    expect(parsed.data.lignes[0].dossier_technique_piece_devis).toBeUndefined();
+  });
+
+  it("préserve les valeurs de préparation non vides et accepte leurs identifiants null", () => {
+    const parsed = createDevisBodySchema.safeParse(withLigne({
+      article_devis: {
+        id: null,
+        root_article_devis_id: null,
+        code: "  ART-42  ",
+        designation: "  Pièce spéciale  ",
+        primary_category: "piece_finie_fabriquee",
+        article_categories: ["piece_finie_fabriquee"],
+        family_code: "PT",
+      },
+      dossier_technique_piece_devis: {
+        id: null,
+        root_dossier_devis_id: null,
+        code_piece: "  DOS-42  ",
+        designation: "  Dossier spécial  ",
+      },
+    }));
+
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(parsed.data.lignes[0].article_devis).toMatchObject({
+      id: null,
+      code: "ART-42",
+      designation: "Pièce spéciale",
+    });
+    expect(parsed.data.lignes[0].dossier_technique_piece_devis).toMatchObject({
+      id: null,
+      code_piece: "DOS-42",
+      designation: "Dossier spécial",
+    });
+  });
 });
 
 describe("#167 — updateDevisBodySchema (verrou optimiste additif)", () => {

--- a/src/module/devis/validators/devis.validators.ts
+++ b/src/module/devis/validators/devis.validators.ts
@@ -17,6 +17,43 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
+function hasPreparationValue(value: unknown) {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  if (isRecord(value)) return Object.keys(value).length > 0;
+  return true;
+}
+
+function emptyPreparationToUndefined(value: unknown, meaningfulFields: readonly string[]) {
+  if (value === null || value === undefined) return undefined;
+  if (!isRecord(value)) return value;
+  return meaningfulFields.some((field) => hasPreparationValue(value[field])) ? value : undefined;
+}
+
+const articlePreparationFields = [
+  "id",
+  "root_article_devis_id",
+  "parent_article_devis_id",
+  "code",
+  "designation",
+  "primary_category",
+  "article_categories",
+  "family_code",
+  "projet_id",
+  "source_official_article_id",
+] as const;
+
+const dossierPreparationFields = [
+  "id",
+  "root_dossier_devis_id",
+  "parent_dossier_devis_id",
+  "code_piece",
+  "designation",
+  "source_official_piece_technique_id",
+  "payload",
+] as const;
+
 export const devisIdParamsSchema = z.object({
   id: z.coerce.number().int().positive(),
 });
@@ -94,10 +131,11 @@ z.object({
   prix_unitaire_ht: z.coerce.number().min(0),
   remise_ligne: z.coerce.number().min(0).max(100).optional().default(0),
   taux_tva: z.coerce.number().min(0).max(100).optional().default(20),
-  article_devis: z
-    .object({
-      id: z.string().uuid().optional(),
-      root_article_devis_id: z.string().uuid().optional(),
+  article_devis: z.preprocess(
+    (value) => emptyPreparationToUndefined(value, articlePreparationFields),
+    z.object({
+      id: z.string().uuid().optional().nullable(),
+      root_article_devis_id: z.string().uuid().optional().nullable(),
       parent_article_devis_id: z.string().uuid().optional().nullable(),
       version_number: z.coerce.number().int().positive().optional(),
       code: z.string().trim().min(1),
@@ -108,20 +146,21 @@ z.object({
       plan_index: z.coerce.number().int().positive().optional().default(1),
       projet_id: z.coerce.number().int().positive().optional().nullable(),
       source_official_article_id: z.string().uuid().optional().nullable(),
-    })
-    .optional(),
-  dossier_technique_piece_devis: z
-    .object({
-      id: z.string().uuid().optional(),
-      root_dossier_devis_id: z.string().uuid().optional(),
+    }).optional()
+  ),
+  dossier_technique_piece_devis: z.preprocess(
+    (value) => emptyPreparationToUndefined(value, dossierPreparationFields),
+    z.object({
+      id: z.string().uuid().optional().nullable(),
+      root_dossier_devis_id: z.string().uuid().optional().nullable(),
       parent_dossier_devis_id: z.string().uuid().optional().nullable(),
       version_number: z.coerce.number().int().positive().optional(),
       code_piece: z.string().trim().min(1),
       designation: z.string().trim().min(1),
       source_official_piece_technique_id: z.string().uuid().optional().nullable(),
       payload: z.record(z.string(), z.unknown()).optional().default({}),
-    })
-    .optional(),
+    }).optional()
+  ),
 }));
 
 export const createDevisBodySchema = z.object({

--- a/src/module/devis/validators/devis.validators.ts
+++ b/src/module/devis/validators/devis.validators.ts
@@ -31,6 +31,15 @@ function emptyPreparationToUndefined(value: unknown, meaningfulFields: readonly 
   return meaningfulFields.some((field) => hasPreparationValue(value[field])) ? value : undefined;
 }
 
+function emptyArticlePreparationToUndefined(value: unknown) {
+  const preparation = emptyPreparationToUndefined(value, articlePreparationFields);
+  if (preparation !== undefined || !isRecord(value)) return preparation;
+
+  const planIndex = value.plan_index;
+  if (!hasPreparationValue(planIndex) || Number(planIndex) === 1) return undefined;
+  return value;
+}
+
 const articlePreparationFields = [
   "id",
   "root_article_devis_id",
@@ -132,7 +141,7 @@ z.object({
   remise_ligne: z.coerce.number().min(0).max(100).optional().default(0),
   taux_tva: z.coerce.number().min(0).max(100).optional().default(20),
   article_devis: z.preprocess(
-    (value) => emptyPreparationToUndefined(value, articlePreparationFields),
+    emptyArticlePreparationToUndefined,
     z.object({
       id: z.string().uuid().optional().nullable(),
       root_article_devis_id: z.string().uuid().optional().nullable(),
@@ -161,6 +170,14 @@ z.object({
       payload: z.record(z.string(), z.unknown()).optional().default({}),
     }).optional()
   ),
+}).superRefine((line, context) => {
+  if (line.dossier_technique_piece_devis && !line.article_devis) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["article_devis"],
+      message: "article_devis est requis lorsqu'un dossier_technique_piece_devis est fourni",
+    });
+  }
 }));
 
 export const createDevisBodySchema = z.object({

--- a/src/module/facturation/domain/finance-policy.test.ts
+++ b/src/module/facturation/domain/finance-policy.test.ts
@@ -131,6 +131,17 @@ describe("issue #227 — idempotence et soldes", () => {
     expect(FACTURE_LIST_FILTER_STATUSES).not.toContain("custom" as never);
   });
 
+  it.each(["partielle", "payee"])(
+    "conserve %s comme preuve documentaire sans inventer de règlement",
+    (legacyStatus) => {
+      expect(isInvoiceIssuedForSettlement({ documentStatus: "ISSUED", legacyStatus })).toBe(true);
+      expect(invoiceSettlementStatusFromBalance({
+        totalCents: 10_000n,
+        settledCents: 0n,
+      })).toBe("UNPAID");
+    }
+  );
+
   it("stabilise le hash malgré l'ordre des propriétés", () => {
     expect(financeRequestHash("PAYMENT_REGISTER", { b: 2, a: 1 })).toBe(
       financeRequestHash("PAYMENT_REGISTER", { a: 1, b: 2 })

--- a/src/module/facturation/domain/finance-policy.test.ts
+++ b/src/module/facturation/domain/finance-policy.test.ts
@@ -6,6 +6,7 @@ import {
   assertFactureTransition,
   decideReceipt,
   financeRequestHash,
+  invoiceSettlementStatusFromBalance,
   invoiceStatusFromBalance,
   paymentStatusFromAllocation,
   roleHasFinanceCapability,
@@ -140,6 +141,15 @@ describe("issue #227 — idempotence et soldes", () => {
     [10_000n, 10_000n, "PAID"],
   ] as const)("statut facture %s/%s", (totalCents, settledCents, expected) => {
     expect(invoiceStatusFromBalance({ totalCents, settledCents })).toBe(expected);
+  });
+
+  it.each([
+    [10_000n, 0n, "UNPAID"],
+    [10_000n, 1n, "PARTIALLY_PAID"],
+    [10_000n, 9_999n, "PARTIALLY_PAID"],
+    [10_000n, 10_000n, "PAID"],
+  ] as const)("état de règlement facture %s/%s", (totalCents, settledCents, expected) => {
+    expect(invoiceSettlementStatusFromBalance({ totalCents, settledCents })).toBe(expected);
   });
 
   it.each([

--- a/src/module/facturation/domain/finance-policy.test.ts
+++ b/src/module/facturation/domain/finance-policy.test.ts
@@ -2,12 +2,14 @@ import { describe, expect, it } from "vitest";
 
 import { HttpError } from "../../../utils/httpError";
 import {
+  FACTURE_LIST_FILTER_STATUSES,
   assertAvoirTransition,
   assertFactureTransition,
   decideReceipt,
   financeRequestHash,
   invoiceSettlementStatusFromBalance,
   invoiceStatusFromBalance,
+  isInvoiceIssuedForSettlement,
   paymentStatusFromAllocation,
   roleHasFinanceCapability,
 } from "./finance-policy";
@@ -120,6 +122,15 @@ describe("issue #227 — RBAC fail-closed", () => {
 });
 
 describe("issue #227 — idempotence et soldes", () => {
+  it("reconnaît les factures historiques émises sans élargir le vocabulaire arbitrairement", () => {
+    for (const legacyStatus of ["emis", "emise", "envoyee", "partielle", "payee"]) {
+      expect(isInvoiceIssuedForSettlement({ documentStatus: "ISSUED", legacyStatus })).toBe(true);
+      expect(FACTURE_LIST_FILTER_STATUSES).toContain(legacyStatus);
+    }
+    expect(isInvoiceIssuedForSettlement({ documentStatus: "LEGACY", legacyStatus: "custom" })).toBe(false);
+    expect(FACTURE_LIST_FILTER_STATUSES).not.toContain("custom" as never);
+  });
+
   it("stabilise le hash malgré l'ordre des propriétés", () => {
     expect(financeRequestHash("PAYMENT_REGISTER", { b: 2, a: 1 })).toBe(
       financeRequestHash("PAYMENT_REGISTER", { a: 1, b: 2 })

--- a/src/module/facturation/domain/finance-policy.ts
+++ b/src/module/facturation/domain/finance-policy.ts
@@ -33,6 +33,42 @@ export const FACTURE_SETTLEMENT_STATUSES = [
 
 export type FactureSettlementStatus = (typeof FACTURE_SETTLEMENT_STATUSES)[number];
 
+/** Statuts réellement présents avant le workflow #227 et encore supportés en lecture. */
+export const FACTURE_LEGACY_STATUSES = [
+  "brouillon",
+  "emis",
+  "emise",
+  "envoyee",
+  "partielle",
+  "payee",
+  "annule",
+  "annulee",
+] as const;
+
+export const FACTURE_LEGACY_ISSUED_STATUSES = [
+  "emis",
+  "emise",
+  "envoyee",
+  "partielle",
+  "payee",
+] as const;
+
+export const FACTURE_LIST_FILTER_STATUSES = [
+  ...FACTURE_WORKFLOW_STATUSES,
+  "LEGACY",
+  ...FACTURE_LEGACY_STATUSES,
+] as const;
+
+export function isInvoiceIssuedForSettlement(params: {
+  documentStatus: string | null | undefined;
+  legacyStatus: string | null | undefined;
+}): boolean {
+  if (params.documentStatus === "ISSUED") return true;
+  return (FACTURE_LEGACY_ISSUED_STATUSES as readonly string[]).includes(
+    (params.legacyStatus ?? "").trim()
+  );
+}
+
 export const AVOIR_WORKFLOW_STATUSES = [
   "DRAFT",
   "PENDING_VALIDATION",

--- a/src/module/facturation/domain/finance-policy.ts
+++ b/src/module/facturation/domain/finance-policy.ts
@@ -15,6 +15,24 @@ export const FACTURE_WORKFLOW_STATUSES = [
 
 export type FactureWorkflowStatus = (typeof FACTURE_WORKFLOW_STATUSES)[number];
 
+export const FACTURE_DOCUMENT_STATUSES = [
+  "DRAFT",
+  "PENDING_VALIDATION",
+  "APPROVED",
+  "ISSUED",
+  "CANCELLED",
+] as const;
+
+export type FactureDocumentStatus = (typeof FACTURE_DOCUMENT_STATUSES)[number];
+
+export const FACTURE_SETTLEMENT_STATUSES = [
+  "UNPAID",
+  "PARTIALLY_PAID",
+  "PAID",
+] as const;
+
+export type FactureSettlementStatus = (typeof FACTURE_SETTLEMENT_STATUSES)[number];
+
 export const AVOIR_WORKFLOW_STATUSES = [
   "DRAFT",
   "PENDING_VALIDATION",
@@ -205,7 +223,16 @@ export function invoiceStatusFromBalance(params: {
   totalCents: bigint;
   settledCents: bigint;
 }): "ISSUED" | "PARTIALLY_PAID" | "PAID" {
-  if (params.settledCents <= 0n) return "ISSUED";
+  const settlementStatus = invoiceSettlementStatusFromBalance(params);
+  if (settlementStatus === "UNPAID") return "ISSUED";
+  return settlementStatus;
+}
+
+export function invoiceSettlementStatusFromBalance(params: {
+  totalCents: bigint;
+  settledCents: bigint;
+}): FactureSettlementStatus {
+  if (params.settledCents <= 0n) return "UNPAID";
   if (params.settledCents < params.totalCents) return "PARTIALLY_PAID";
   return "PAID";
 }

--- a/src/module/facturation/domain/reporting-metrics.ts
+++ b/src/module/facturation/domain/reporting-metrics.ts
@@ -717,8 +717,9 @@ const CATALOG: MetricDefinition[] = [
     family: "encaissement",
     label: "Règlements non affectés TTC",
     definition:
-      "Part encaissée à la date d'arrêté qui n'est rattachée à aucune facture : montant du règlement − allocations ≤ as_of.",
-    formula: "SUM(paiement.montant − Σ paiement_allocations ≤ as_of) WHERE date_paiement ≤ as_of",
+      "Part nette encore affectable à la date d'arrêté : montant du règlement − allocations ≤ as_of. Un rattachement direct hérité sans allocation vaut affectation complète.",
+    formula:
+      "SUM(MAX(paiement.montant − affecté_économique ≤ as_of, 0)) WHERE date_paiement ≤ as_of AND règlement net",
     sources: ["paiement.montant", "paiement_allocations.amount_ttc"],
     grain: "Un règlement.",
     date_field: "paiement.date_paiement ≤ as_of",
@@ -736,6 +737,7 @@ const CATALOG: MetricDefinition[] = [
     availability: "available",
     limitations: [
       "Ce montant ne doit jamais être soustrait de l'encours global : ce serait supposer un lettrage qui n'existe pas.",
+      "Une preuve directe héritée (facture_id renseigné sans allocation) est projetée ALLOCATED et contribue zéro au disponible.",
     ],
   },
   {

--- a/src/module/facturation/middlewares/finance-authorization.middleware.test.ts
+++ b/src/module/facturation/middlewares/finance-authorization.middleware.test.ts
@@ -1,0 +1,57 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+import { describe, expect, it } from "vitest";
+
+import {
+  requireFinanceCapability,
+  requirePaymentAllocationCapabilityForInlineAllocations,
+} from "./finance-authorization.middleware";
+
+const authorizePaymentRegistration: RequestHandler[] = [
+  requireFinanceCapability("payment_register"),
+  requirePaymentAllocationCapabilityForInlineAllocations,
+];
+
+function authorizationError(role: string, body: unknown): unknown {
+  const req = {
+    body,
+    user: { id: 7, username: "finance-test", email: "finance@test.invalid", role },
+  } as Request;
+  const res = {} as Response;
+  let error: unknown;
+
+  const run = (index: number): void => {
+    const handler = authorizePaymentRegistration[index];
+    if (!handler) return;
+    handler(req, res, ((nextError?: unknown) => {
+      if (nextError) {
+        error = nextError;
+        return;
+      }
+      run(index + 1);
+    }) as NextFunction);
+  };
+
+  run(0);
+  return error;
+}
+
+describe("#469 inline payment allocation authorization", () => {
+  it("refuse à une secrétaire l'enregistrement qui alloue dans la même commande", () => {
+    expect(authorizationError("Secretaire", {
+      allocations: [{ target_type: "FACTURE", target_id: "42", amount: "10.00" }],
+    })).toEqual(expect.objectContaining({
+      status: 403,
+      code: "FINANCE_CAPABILITY_REQUIRED",
+    }));
+  });
+
+  it("conserve l'enregistrement sans allocation pour une secrétaire", () => {
+    expect(authorizationError("Secretaire", { allocations: [] })).toBeUndefined();
+  });
+
+  it("autorise un comptable à enregistrer et allouer dans la même commande", () => {
+    expect(authorizationError("Comptable", {
+      allocations: [{ target_type: "FACTURE", target_id: "42", amount: "10.00" }],
+    })).toBeUndefined();
+  });
+});

--- a/src/module/facturation/middlewares/finance-authorization.middleware.ts
+++ b/src/module/facturation/middlewares/finance-authorization.middleware.ts
@@ -1,4 +1,4 @@
-import type { RequestHandler } from "express";
+import type { Request, RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
 import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
@@ -29,3 +29,22 @@ export function requireFinanceCapability(capability: FinanceCapability): Request
     next();
   };
 }
+
+export function requireFinanceCapabilityWhen(
+  capability: FinanceCapability,
+  isRequired: (req: Request) => boolean
+): RequestHandler {
+  const requireCapability = requireFinanceCapability(capability);
+  return (req, res, next) => {
+    if (!isRequired(req)) {
+      next();
+      return;
+    }
+    requireCapability(req, res, next);
+  };
+}
+
+export const requirePaymentAllocationCapabilityForInlineAllocations = requireFinanceCapabilityWhen(
+  "payment_allocate",
+  (req) => Array.isArray(req.body?.allocations) && req.body.allocations.length > 0
+);

--- a/src/module/facturation/repository/avoir-workflow.repository.ts
+++ b/src/module/facturation/repository/avoir-workflow.repository.ts
@@ -7,11 +7,13 @@ import {
   assertAvoirTransition,
   assertSeparationOfDuties,
   financePreviewHash,
+  isInvoiceIssuedForSettlement,
   type AvoirWorkflowStatus,
 } from "../domain/finance-policy";
 import {
   computeExactDocumentTotals,
   computeExactLineTotals,
+  moneyToCents,
   parseDecimal,
 } from "../domain/decimal-money";
 import type {
@@ -37,11 +39,18 @@ import {
   requireFinanceIssuerSnapshotAt,
   saveFinanceReceipt,
 } from "./workflow.repository.shared";
+import {
+  assertInvoiceCreditWithinBalance,
+  assertInvoiceIssued,
+  lockInvoiceSettlement,
+  refreshInvoiceSettlementStates,
+} from "./invoice-settlement.repository";
 
 type AvoirSourceRow = {
   facture_id: string;
   facture_number: string;
   facture_status: string;
+  facture_document_status: string | null;
   client_id: string;
   currency: string;
   client_snapshot: Record<string, unknown>;
@@ -105,6 +114,7 @@ async function loadAvoirSources(
         f.id::text AS facture_id,
         f.numero AS facture_number,
         f.statut AS facture_status,
+        f.document_status AS facture_document_status,
         f.client_id,
         COALESCE(f.currency, 'EUR') AS currency,
         COALESCE(f.client_snapshot, '{}'::jsonb) AS client_snapshot,
@@ -145,7 +155,10 @@ async function buildAvoirPreview(
     throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture ou lignes de facture introuvables.");
   }
   const header = rows[0]!;
-  if (!["ISSUED", "PARTIALLY_PAID", "PAID"].includes(header.facture_status)) {
+  if (!isInvoiceIssuedForSettlement({
+    documentStatus: header.facture_document_status,
+    legacyStatus: header.facture_status,
+  })) {
     throw new HttpError(
       409,
       "AVOIR_FACTURE_NOT_ISSUED",
@@ -268,7 +281,10 @@ export async function repoListAvoirEligibleLines(factureId: number): Promise<{
     throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture ou lignes introuvables.");
   }
   const header = rows[0]!;
-  if (!["ISSUED", "PARTIALLY_PAID", "PAID"].includes(header.facture_status)) {
+  if (!isInvoiceIssuedForSettlement({
+    documentStatus: header.facture_document_status,
+    legacyStatus: header.facture_status,
+  })) {
     throw new HttpError(409, "AVOIR_FACTURE_NOT_ISSUED", "La facture n'est pas émise.");
   }
   return {
@@ -747,6 +763,13 @@ export async function repoIssueAvoir(params: {
     ) {
       throw new HttpError(409, "AVOIR_PREVIEW_CHANGED", "L'aperçu de l'avoir a changé.");
     }
+    const invoiceBeforeCredit = await lockInvoiceSettlement(client, preview.facture_id);
+    if (!invoiceBeforeCredit) {
+      throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
+    }
+    assertInvoiceIssued(invoiceBeforeCredit);
+    const creditCents = moneyToCents(preview.totals.total_incl_tax, "Montant de l'avoir");
+    assertInvoiceCreditWithinBalance(invoiceBeforeCredit, creditCents);
     const policy = await client.query<{ policy_version: string; require_distinct_issuer: boolean }>(
       `
         SELECT policy_version, require_distinct_issuer
@@ -818,6 +841,13 @@ export async function repoIssueAvoir(params: {
       `,
       [params.avoirId, params.actor.userId]
     );
+    await refreshInvoiceSettlementStates({
+      client,
+      factureIds: [preview.facture_id],
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
+    });
     const updated = await client.query<{ row_version: number }>(
       `
         UPDATE public.avoir

--- a/src/module/facturation/repository/facture-workflow.repository.ts
+++ b/src/module/facturation/repository/facture-workflow.repository.ts
@@ -905,6 +905,7 @@ async function transitionFacture(params: {
       `
         UPDATE public.facture
         SET statut = $2,
+            document_status = $2,
             validation_requested_at = CASE WHEN $2 = 'PENDING_VALIDATION' THEN now() ELSE validation_requested_at END,
             validation_requested_by = CASE WHEN $2 = 'PENDING_VALIDATION' THEN $3 ELSE validation_requested_by END,
             row_version = row_version + 1,
@@ -1007,6 +1008,7 @@ export async function repoValidateFacture(params: {
       `
         UPDATE public.facture
         SET statut = $2,
+            document_status = $2,
             approved_at = CASE WHEN $2 = 'APPROVED' THEN now() ELSE NULL END,
             approved_by = CASE WHEN $2 = 'APPROVED' THEN $3 ELSE NULL END,
             validation_reason = $4,
@@ -1183,6 +1185,8 @@ export async function repoIssueFacture(params: {
             legal_sequence_value = $4,
             date_emission = $5::date,
             statut = 'ISSUED',
+            document_status = 'ISSUED',
+            settlement_status = 'UNPAID',
             issued_at = now(),
             issued_by = $6,
             immutable_snapshot = $7::jsonb,

--- a/src/module/facturation/repository/factures.repository.test.ts
+++ b/src/module/facturation/repository/factures.repository.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+
+import { listFacturesQuerySchema } from "../validators/factures.validators";
+import { buildListWhere } from "./factures.repository";
+
+describe("#469 invoice list historical filters", () => {
+  it("filters unknown historical rows through document_status=LEGACY", () => {
+    const filters = listFacturesQuerySchema.parse({ statut: "LEGACY" });
+    expect(buildListWhere(filters, false)).toEqual({
+      whereSql: "WHERE f.document_status = 'LEGACY'",
+      values: [],
+    });
+  });
+
+  it("filters a supported historical value through the untouched legacy projection", () => {
+    const filters = listFacturesQuerySchema.parse({ statut: "emise" });
+    const built = buildListWhere(filters, false);
+    expect(built.whereSql).toBe("WHERE f.statut = $1");
+    expect(built.values).toEqual(["emise"]);
+  });
+
+  it.each(["DRAFT", "CANCELLED"] as const)(
+    "filters canonical %s rows through document_status",
+    (status) => {
+      const filters = listFacturesQuerySchema.parse({ statut: status });
+      const built = buildListWhere(filters, false);
+      expect(built.whereSql).toBe("WHERE f.document_status = $1");
+      expect(built.values).toEqual([status]);
+    }
+  );
+});

--- a/src/module/facturation/repository/factures.repository.ts
+++ b/src/module/facturation/repository/factures.repository.ts
@@ -70,6 +70,15 @@ function sortDirection(sortDir: ListFacturesQueryDTO["sortDir"]) {
   return sortDir === "asc" ? "ASC" : "DESC";
 }
 
+function factureProjectedStatusSql(alias = "f") {
+  return `CASE
+    WHEN ${alias}.document_status = 'ISSUED' AND ${alias}.settlement_status = 'UNPAID' THEN 'ISSUED'
+    WHEN ${alias}.document_status = 'ISSUED' THEN ${alias}.settlement_status
+    WHEN ${alias}.document_status = 'LEGACY' THEN ${alias}.statut
+    ELSE ${alias}.document_status
+  END`;
+}
+
 type ListWhere = { whereSql: string; values: unknown[] };
 function buildListWhere(filters: ListFacturesQueryDTO, includeClientInSearch: boolean): ListWhere {
   const where: string[] = [];
@@ -112,8 +121,16 @@ function buildListWhere(filters: ListFacturesQueryDTO, includeClientInSearch: bo
   }
 
   if (filters.statut && filters.statut.trim().length > 0) {
-    const p = push(filters.statut.trim());
-    where.push(`f.statut = ${p}`);
+    const status = filters.statut.trim();
+    if (status === "PARTIALLY_PAID" || status === "PAID") {
+      const p = push(status);
+      where.push(`f.document_status = 'ISSUED' AND f.settlement_status = ${p}`);
+    } else if (status === "ISSUED") {
+      where.push(`f.document_status = 'ISSUED' AND f.settlement_status = 'UNPAID'`);
+    } else {
+      const p = push(status);
+      where.push(`f.document_status = ${p}`);
+    }
   }
 
   if (filters.from) {
@@ -177,7 +194,9 @@ export async function repoListFactures(filters: ListFacturesQueryDTO): Promise<P
       f.total_ht::float8 AS total_ht,
       f.total_ttc::float8 AS total_ttc,
       f.updated_at::text AS updated_at,
-      f.statut,
+      ${factureProjectedStatusSql("f")} AS statut,
+      f.document_status,
+      f.settlement_status,
       ${clientSelectSql},
       pay.total_paye_ttc,
       av.total_avoirs_ttc,
@@ -185,15 +204,39 @@ export async function repoListFactures(filters: ListFacturesQueryDTO): Promise<P
     FROM facture f
     ${joinClientSql}
     LEFT JOIN LATERAL (
-      SELECT COALESCE(SUM(p.montant), 0)::float8 AS total_paye_ttc
-      FROM paiement p
-      WHERE p.facture_id = f.id
+      SELECT (
+        COALESCE((
+          SELECT SUM(pa.amount_ttc)
+          FROM paiement_allocations pa
+          WHERE pa.facture_id = f.id
+        ), 0)
+        + COALESCE((
+          SELECT SUM(p.montant)
+          FROM paiement p
+          WHERE p.facture_id = f.id
+            AND NOT EXISTS (
+              SELECT 1 FROM paiement_allocations pa WHERE pa.paiement_id = p.id
+            )
+        ), 0)
+      )::float8 AS total_paye_ttc
     ) pay ON TRUE
     LEFT JOIN LATERAL (
-      SELECT COALESCE(SUM(a.total_ttc), 0)::float8 AS total_avoirs_ttc
-      FROM avoir a
-      WHERE a.facture_id = f.id
-        AND COALESCE(a.statut, '') <> 'brouillon'
+      SELECT (
+        COALESCE((
+          SELECT SUM(asa.amount_ttc)
+          FROM avoir_source_allocations asa
+          WHERE asa.facture_id = f.id AND asa.allocation_status = 'CONSUMED'
+        ), 0)
+        + COALESCE((
+          SELECT SUM(a.total_ttc)
+          FROM avoir a
+          WHERE a.facture_id = f.id
+            AND a.statut IN ('ISSUED','emis','emise','envoyee')
+            AND NOT EXISTS (
+              SELECT 1 FROM avoir_source_allocations asa WHERE asa.avoir_id = a.id
+            )
+        ), 0)
+      )::float8 AS total_avoirs_ttc
     ) av ON TRUE
     ${whereSql}
     ORDER BY ${orderBy} ${orderDir}
@@ -256,7 +299,9 @@ export async function repoGetFacture(id: number, includeValue: string): Promise<
       f.affaire_id::text AS affaire_id,
       f.date_emission::text AS date_emission,
       f.date_echeance::text AS date_echeance,
-      f.statut,
+      ${factureProjectedStatusSql("f")} AS statut,
+      f.document_status,
+      f.settlement_status,
       f.remise_globale::float8 AS remise_globale,
       f.total_ht::float8 AS total_ht,
       f.total_ttc::float8 AS total_ttc,
@@ -270,15 +315,39 @@ export async function repoGetFacture(id: number, includeValue: string): Promise<
     FROM facture f
     ${joinClientSql}
     LEFT JOIN LATERAL (
-      SELECT COALESCE(SUM(p.montant), 0)::float8 AS total_paye_ttc
-      FROM paiement p
-      WHERE p.facture_id = f.id
+      SELECT (
+        COALESCE((
+          SELECT SUM(pa.amount_ttc)
+          FROM paiement_allocations pa
+          WHERE pa.facture_id = f.id
+        ), 0)
+        + COALESCE((
+          SELECT SUM(p.montant)
+          FROM paiement p
+          WHERE p.facture_id = f.id
+            AND NOT EXISTS (
+              SELECT 1 FROM paiement_allocations pa WHERE pa.paiement_id = p.id
+            )
+        ), 0)
+      )::float8 AS total_paye_ttc
     ) pay ON TRUE
     LEFT JOIN LATERAL (
-      SELECT COALESCE(SUM(a.total_ttc), 0)::float8 AS total_avoirs_ttc
-      FROM avoir a
-      WHERE a.facture_id = f.id
-        AND COALESCE(a.statut, '') <> 'brouillon'
+      SELECT (
+        COALESCE((
+          SELECT SUM(asa.amount_ttc)
+          FROM avoir_source_allocations asa
+          WHERE asa.facture_id = f.id AND asa.allocation_status = 'CONSUMED'
+        ), 0)
+        + COALESCE((
+          SELECT SUM(a.total_ttc)
+          FROM avoir a
+          WHERE a.facture_id = f.id
+            AND a.statut IN ('ISSUED','emis','emise','envoyee')
+            AND NOT EXISTS (
+              SELECT 1 FROM avoir_source_allocations asa WHERE asa.avoir_id = a.id
+            )
+        ), 0)
+      )::float8 AS total_avoirs_ttc
     ) av ON TRUE
     WHERE f.id = $1
   `;
@@ -312,7 +381,13 @@ export async function repoGetFacture(id: number, includeValue: string): Promise<
           `
           SELECT
             id::text AS id,
-            facture_id::text AS facture_id,
+            CASE
+              WHEN EXISTS (
+                SELECT 1 FROM paiement_allocations target
+                WHERE target.paiement_id = paiement.id AND target.facture_id = $1
+              ) THEN $1::text
+              ELSE facture_id::text
+            END AS facture_id,
             ordre,
             designation,
             code_piece,
@@ -392,6 +467,11 @@ export async function repoGetFacture(id: number, includeValue: string): Promise<
             updated_at::text AS updated_at
           FROM paiement
           WHERE facture_id = $1
+             OR EXISTS (
+               SELECT 1
+               FROM paiement_allocations pa
+               WHERE pa.paiement_id = paiement.id AND pa.facture_id = $1
+             )
           ORDER BY date_paiement DESC, id DESC
           `,
           [id]

--- a/src/module/facturation/repository/factures.repository.ts
+++ b/src/module/facturation/repository/factures.repository.ts
@@ -80,6 +80,12 @@ function factureProjectedStatusSql(alias = "f") {
   END`;
 }
 
+function netPaymentSql(alias: string): string {
+  return `${alias}.status NOT IN ('REJECTED','REVERSED')
+    AND ${alias}.workflow_status <> 'REVERSED'
+    AND ${alias}.reversal_of_id IS NULL`;
+}
+
 type ListWhere = { whereSql: string; values: unknown[] };
 export function buildListWhere(filters: ListFacturesQueryDTO, includeClientInSearch: boolean): ListWhere {
   const where: string[] = [];
@@ -214,12 +220,15 @@ export async function repoListFactures(filters: ListFacturesQueryDTO): Promise<P
         COALESCE((
           SELECT SUM(pa.amount_ttc)
           FROM paiement_allocations pa
+          JOIN paiement allocated_payment ON allocated_payment.id = pa.paiement_id
           WHERE pa.facture_id = f.id
+            AND ${netPaymentSql("allocated_payment")}
         ), 0)
         + COALESCE((
           SELECT SUM(p.montant)
           FROM paiement p
           WHERE p.facture_id = f.id
+            AND ${netPaymentSql("p")}
             AND NOT EXISTS (
               SELECT 1 FROM paiement_allocations pa WHERE pa.paiement_id = p.id
             )
@@ -325,12 +334,15 @@ export async function repoGetFacture(id: number, includeValue: string): Promise<
         COALESCE((
           SELECT SUM(pa.amount_ttc)
           FROM paiement_allocations pa
+          JOIN paiement allocated_payment ON allocated_payment.id = pa.paiement_id
           WHERE pa.facture_id = f.id
+            AND ${netPaymentSql("allocated_payment")}
         ), 0)
         + COALESCE((
           SELECT SUM(p.montant)
           FROM paiement p
           WHERE p.facture_id = f.id
+            AND ${netPaymentSql("p")}
             AND NOT EXISTS (
               SELECT 1 FROM paiement_allocations pa WHERE pa.paiement_id = p.id
             )

--- a/src/module/facturation/repository/factures.repository.ts
+++ b/src/module/facturation/repository/factures.repository.ts
@@ -1,6 +1,7 @@
 import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
+import { FACTURE_LEGACY_STATUSES } from "../domain/finance-policy";
 import { computeDocumentTotals, computeLineTotals } from "../lib/totals";
 import type { ClientLite, DocumentClient } from "../types/shared.types";
 import type {
@@ -80,7 +81,7 @@ function factureProjectedStatusSql(alias = "f") {
 }
 
 type ListWhere = { whereSql: string; values: unknown[] };
-function buildListWhere(filters: ListFacturesQueryDTO, includeClientInSearch: boolean): ListWhere {
+export function buildListWhere(filters: ListFacturesQueryDTO, includeClientInSearch: boolean): ListWhere {
   const where: string[] = [];
   const values: unknown[] = [];
   const push = (v: unknown) => {
@@ -127,6 +128,11 @@ function buildListWhere(filters: ListFacturesQueryDTO, includeClientInSearch: bo
       where.push(`f.document_status = 'ISSUED' AND f.settlement_status = ${p}`);
     } else if (status === "ISSUED") {
       where.push(`f.document_status = 'ISSUED' AND f.settlement_status = 'UNPAID'`);
+    } else if (status === "LEGACY") {
+      where.push(`f.document_status = 'LEGACY'`);
+    } else if ((FACTURE_LEGACY_STATUSES as readonly string[]).includes(status)) {
+      const p = push(status);
+      where.push(`f.statut = ${p}`);
     } else {
       const p = push(status);
       where.push(`f.document_status = ${p}`);
@@ -381,13 +387,7 @@ export async function repoGetFacture(id: number, includeValue: string): Promise<
           `
           SELECT
             id::text AS id,
-            CASE
-              WHEN EXISTS (
-                SELECT 1 FROM paiement_allocations target
-                WHERE target.paiement_id = paiement.id AND target.facture_id = $1
-              ) THEN $1::text
-              ELSE facture_id::text
-            END AS facture_id,
+            facture_id::text AS facture_id,
             ordre,
             designation,
             code_piece,
@@ -456,7 +456,15 @@ export async function repoGetFacture(id: number, includeValue: string): Promise<
           `
           SELECT
             id::text AS id,
-            facture_id::text AS facture_id,
+            CASE
+              WHEN EXISTS (
+                SELECT 1
+                FROM paiement_allocations target
+                WHERE target.paiement_id = paiement.id
+                  AND target.facture_id = $1
+              ) THEN $1::text
+              ELSE facture_id::text
+            END AS facture_id,
             client_id,
             date_paiement::text AS date_paiement,
             montant::float8 AS montant,

--- a/src/module/facturation/repository/invoice-settlement.repository.test.ts
+++ b/src/module/facturation/repository/invoice-settlement.repository.test.ts
@@ -1,0 +1,104 @@
+import type { PoolClient } from "pg";
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  assertInvoiceCreditWithinBalance,
+  lockInvoiceSettlement,
+  refreshInvoiceSettlementStates,
+} from "./invoice-settlement.repository";
+
+function invoiceRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 42,
+    uuid: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    client_id: "001",
+    currency: "EUR",
+    statut: "emise",
+    document_status: "ISSUED",
+    settlement_status: "UNPAID",
+    total_ttc: "100.00",
+    allocated_payment_ttc: "20.00",
+    legacy_direct_payment_ttc: "30.00",
+    consumed_credit_ttc: "10.00",
+    legacy_direct_credit_ttc: "5.00",
+    ...overrides,
+  };
+}
+
+describe("#469 invoice settlement repository", () => {
+  it("additionne allocations modernes et preuves directes historiques sans changer de source", async () => {
+    const query = vi.fn(async (_sqlValue: unknown) => ({ rows: [invoiceRow()], rowCount: 1 }));
+    const invoice = await lockInvoiceSettlement(
+      { query } as unknown as Pick<PoolClient, "query">,
+      42
+    );
+
+    expect(invoice?.settledCents).toBe(6_500n);
+    expect(invoice?.settledAmount).toBe("65.00");
+    const sql = String(query.mock.calls[0]?.[0]);
+    expect(sql).toContain("legacy_direct_payment_ttc");
+    expect(sql).toContain("legacy_direct_credit_ttc");
+    expect(sql.match(/NOT EXISTS/g)).toHaveLength(2);
+  });
+
+  it("refuse un avoir qui dépasserait le solde économique unifié", async () => {
+    const query = vi.fn(async () => ({
+      rows: [invoiceRow({
+        allocated_payment_ttc: "20.00",
+        legacy_direct_payment_ttc: "70.00",
+        consumed_credit_ttc: "0.00",
+        legacy_direct_credit_ttc: "0.00",
+      })],
+      rowCount: 1,
+    }));
+    const invoice = await lockInvoiceSettlement(
+      { query } as unknown as Pick<PoolClient, "query">,
+      42
+    );
+
+    expect(() => assertInvoiceCreditWithinBalance(invoice!, 1_100n)).toThrowError(
+      expect.objectContaining({
+        status: 409,
+        code: "AVOIR_INVOICE_BALANCE_EXCEEDED",
+      })
+    );
+  });
+
+  it("projette et audite une facture historique émise avec la même transaction", async () => {
+    const calls: Array<{ sql: string; values: unknown[] | undefined }> = [];
+    const query = vi.fn(async (sqlValue: unknown, values?: unknown[]) => {
+      const sql = String(sqlValue);
+      calls.push({ sql, values });
+      if (sql.includes("FROM public.facture f")) {
+        return {
+          rows: [invoiceRow({
+            allocated_payment_ttc: "0.00",
+            legacy_direct_payment_ttc: "25.00",
+            consumed_credit_ttc: "0.00",
+            legacy_direct_credit_ttc: "0.00",
+          })],
+          rowCount: 1,
+        };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+
+    await refreshInvoiceSettlementStates({
+      client: { query } as unknown as PoolClient,
+      factureIds: [42],
+      actor: { userId: 7, requestId: "req-469", path: "/facturation/avoirs/1/issue" },
+      correlationId: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+      idempotencyKey: "idempotency-469",
+    });
+
+    const update = calls.find((call) => call.sql.includes("UPDATE public.facture"));
+    expect(update?.values).toEqual([
+      42,
+      "PARTIALLY_PAID",
+      "PARTIALLY_PAID",
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    ]);
+    expect(calls.some((call) => call.sql.includes("public.finance_event_log"))).toBe(true);
+    expect(calls.some((call) => call.sql.includes("INSERT INTO erp_audit_logs"))).toBe(true);
+  });
+});

--- a/src/module/facturation/repository/invoice-settlement.repository.test.ts
+++ b/src/module/facturation/repository/invoice-settlement.repository.test.ts
@@ -35,10 +35,39 @@ describe("#469 invoice settlement repository", () => {
 
     expect(invoice?.settledCents).toBe(6_500n);
     expect(invoice?.settledAmount).toBe("65.00");
-    const sql = String(query.mock.calls[0]?.[0]);
-    expect(sql).toContain("legacy_direct_payment_ttc");
-    expect(sql).toContain("legacy_direct_credit_ttc");
-    expect(sql.match(/NOT EXISTS/g)).toHaveLength(2);
+    const lockSql = String(query.mock.calls[0]?.[0]);
+    const evidenceSql = String(query.mock.calls[1]?.[0]);
+    expect(lockSql).toContain("FOR UPDATE");
+    expect(lockSql).not.toContain("paiement_allocations");
+    expect(lockSql).not.toContain("avoir_source_allocations");
+    expect(evidenceSql).not.toContain("FOR UPDATE");
+    expect(evidenceSql).toContain("legacy_direct_payment_ttc");
+    expect(evidenceSql).toContain("legacy_direct_credit_ttc");
+    expect(evidenceSql.match(/NOT EXISTS/g)).toHaveLength(2);
+    expect(evidenceSql).toContain("allocated_payment.status NOT IN ('REJECTED','REVERSED')");
+    expect(evidenceSql).toContain("allocated_payment.workflow_status <> 'REVERSED'");
+    expect(evidenceSql).toContain("allocated_payment.reversal_of_id IS NULL");
+    expect(evidenceSql).toContain("p.status NOT IN ('REJECTED','REVERSED')");
+  });
+
+  it("libère le solde après exclusion des paiements rejetés ou inversés", async () => {
+    const query = vi.fn(async () => ({
+      rows: [invoiceRow({
+        allocated_payment_ttc: "0.00",
+        legacy_direct_payment_ttc: "0.00",
+        consumed_credit_ttc: "0.00",
+        legacy_direct_credit_ttc: "0.00",
+      })],
+      rowCount: 1,
+    }));
+
+    const invoice = await lockInvoiceSettlement(
+      { query } as unknown as Pick<PoolClient, "query">,
+      42
+    );
+
+    expect(invoice?.settledCents).toBe(0n);
+    expect(() => assertInvoiceCreditWithinBalance(invoice!, 10_000n)).not.toThrow();
   });
 
   it("refuse un avoir qui dépasserait le solde économique unifié", async () => {

--- a/src/module/facturation/repository/invoice-settlement.repository.ts
+++ b/src/module/facturation/repository/invoice-settlement.repository.ts
@@ -1,0 +1,235 @@
+import type { PoolClient } from "pg";
+
+import { HttpError } from "../../../utils/httpError";
+import {
+  invoiceSettlementStatusFromBalance,
+  isInvoiceIssuedForSettlement,
+} from "../domain/finance-policy";
+import { formatDecimal, moneyToCents } from "../domain/decimal-money";
+import {
+  insertFinanceEvent,
+  insertGlobalFinanceAudit,
+  type FinanceActorContext,
+} from "./workflow.repository.shared";
+
+type InvoiceSettlementRow = {
+  id: number;
+  uuid: string | null;
+  client_id: string;
+  currency: string;
+  statut: string;
+  document_status: string | null;
+  settlement_status: string | null;
+  total_ttc: string;
+  allocated_payment_ttc: string;
+  legacy_direct_payment_ttc: string;
+  consumed_credit_ttc: string;
+  legacy_direct_credit_ttc: string;
+};
+
+export type LockedInvoiceSettlement = {
+  id: number;
+  uuid: string | null;
+  clientId: string;
+  currency: string;
+  status: string;
+  documentStatus: string | null;
+  settlementStatus: string | null;
+  totalCents: bigint;
+  settledCents: bigint;
+  settledAmount: string;
+};
+
+/**
+ * Source de vérité du solde #469.
+ *
+ * Les allocations #227 sont prioritaires. Le lien direct historique n'est pris en
+ * compte que lorsqu'aucune allocation n'existe pour la pièce concernée, ce qui
+ * conserve l'évidence pré-#227 sans jamais la compter deux fois.
+ */
+export async function lockInvoiceSettlement(
+  client: Pick<PoolClient, "query">,
+  factureId: number
+): Promise<LockedInvoiceSettlement | null> {
+  const result = await client.query<InvoiceSettlementRow>(
+    `
+      SELECT
+        f.id,
+        f.uuid::text AS uuid,
+        f.client_id,
+        COALESCE(f.currency, 'EUR') AS currency,
+        f.statut,
+        f.document_status,
+        f.settlement_status,
+        f.total_ttc::numeric(18,2)::text AS total_ttc,
+        COALESCE((
+          SELECT SUM(pa.amount_ttc)
+          FROM public.paiement_allocations pa
+          WHERE pa.facture_id = f.id
+        ), 0)::numeric(18,2)::text AS allocated_payment_ttc,
+        COALESCE((
+          SELECT SUM(p.montant)
+          FROM public.paiement p
+          WHERE p.facture_id = f.id
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.paiement_allocations existing_payment_allocation
+              WHERE existing_payment_allocation.paiement_id = p.id
+            )
+        ), 0)::numeric(18,2)::text AS legacy_direct_payment_ttc,
+        COALESCE((
+          SELECT SUM(asa.amount_ttc)
+          FROM public.avoir_source_allocations asa
+          WHERE asa.facture_id = f.id
+            AND asa.allocation_status = 'CONSUMED'
+        ), 0)::numeric(18,2)::text AS consumed_credit_ttc,
+        COALESCE((
+          SELECT SUM(a.total_ttc)
+          FROM public.avoir a
+          WHERE a.facture_id = f.id
+            AND a.statut IN ('ISSUED','emis','emise','envoyee')
+            AND NOT EXISTS (
+              SELECT 1
+              FROM public.avoir_source_allocations existing_credit_allocation
+              WHERE existing_credit_allocation.avoir_id = a.id
+            )
+        ), 0)::numeric(18,2)::text AS legacy_direct_credit_ttc
+      FROM public.facture f
+      WHERE f.id = $1
+      FOR UPDATE
+    `,
+    [factureId]
+  );
+  const row = result.rows[0];
+  if (!row) return null;
+  const settledCents =
+    moneyToCents(row.allocated_payment_ttc, "Paiements alloués") +
+    moneyToCents(row.legacy_direct_payment_ttc, "Paiements historiques") +
+    moneyToCents(row.consumed_credit_ttc, "Avoirs consommés") +
+    moneyToCents(row.legacy_direct_credit_ttc, "Avoirs historiques");
+  return {
+    id: row.id,
+    uuid: row.uuid,
+    clientId: row.client_id,
+    currency: row.currency,
+    status: row.statut,
+    documentStatus: row.document_status,
+    settlementStatus: row.settlement_status,
+    totalCents: moneyToCents(row.total_ttc, "Total facture"),
+    settledCents,
+    settledAmount: formatDecimal(settledCents, 2),
+  };
+}
+
+export function assertInvoiceIssued(invoice: LockedInvoiceSettlement): void {
+  if (
+    !isInvoiceIssuedForSettlement({
+      documentStatus: invoice.documentStatus,
+      legacyStatus: invoice.status,
+    })
+  ) {
+    throw new HttpError(
+      409,
+      "PAYMENT_FACTURE_NOT_ISSUED",
+      "Un règlement ne peut être affecté qu'à une facture émise."
+    );
+  }
+}
+
+export function assertInvoiceCreditWithinBalance(
+  invoice: LockedInvoiceSettlement,
+  creditCents: bigint
+): void {
+  if (invoice.settledCents + creditCents > invoice.totalCents) {
+    throw new HttpError(
+      409,
+      "AVOIR_INVOICE_BALANCE_EXCEEDED",
+      "L'avoir dépasse le solde encore réglable de la facture."
+    );
+  }
+}
+
+export async function refreshInvoiceSettlementStates(params: {
+  client: PoolClient;
+  factureIds: readonly number[];
+  actor: FinanceActorContext;
+  correlationId: string;
+  idempotencyKey: string;
+}): Promise<void> {
+  const factureIds = [...new Set(params.factureIds)].sort((left, right) => left - right);
+  let correlationConfigured = false;
+
+  for (const factureId of factureIds) {
+    const invoice = await lockInvoiceSettlement(params.client, factureId);
+    if (!invoice) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
+    assertInvoiceIssued(invoice);
+    const settlementStatus = invoiceSettlementStatusFromBalance({
+      totalCents: invoice.totalCents,
+      settledCents: invoice.settledCents,
+    });
+    const projectedStatus = settlementStatus === "UNPAID" ? "ISSUED" : settlementStatus;
+    if (
+      invoice.status === projectedStatus &&
+      invoice.documentStatus === "ISSUED" &&
+      invoice.settlementStatus === settlementStatus
+    ) {
+      continue;
+    }
+
+    if (!correlationConfigured) {
+      await params.client.query(
+        `SELECT set_config('cerp.finance_settlement_correlation_id', $1, true)`,
+        [params.correlationId]
+      );
+      correlationConfigured = true;
+    }
+    await params.client.query(
+      `
+        UPDATE public.facture
+        SET statut = $2,
+            document_status = 'ISSUED',
+            settlement_status = $3,
+            row_version = row_version + 1,
+            correlation_id = $4::uuid,
+            updated_at = now()
+        WHERE id = $1
+      `,
+      [factureId, projectedStatus, settlementStatus, params.correlationId]
+    );
+    const aggregateId = invoice.uuid ?? String(factureId);
+    await insertFinanceEvent({
+      client: params.client,
+      aggregateType: "FACTURE",
+      aggregateId,
+      eventType: "FACTURE_SETTLEMENT_DERIVED",
+      oldValues: {
+        status: invoice.status,
+        settlement_status: invoice.settlementStatus,
+      },
+      newValues: {
+        status: projectedStatus,
+        settlement_status: settlementStatus,
+        settled_amount: invoice.settledAmount,
+        total_amount: formatDecimal(invoice.totalCents, 2),
+      },
+      actor: params.actor,
+      correlationId: params.correlationId,
+      idempotencyKey: params.idempotencyKey,
+      ruleCode: "FINANCE-SETTLEMENT-469",
+    });
+    await insertGlobalFinanceAudit({
+      client: params.client,
+      actor: params.actor,
+      action: "facturation.facture_settlement_derived",
+      entityType: "facture",
+      entityId: aggregateId,
+      details: {
+        from: invoice.settlementStatus,
+        to: settlementStatus,
+        settled_amount: invoice.settledAmount,
+        total_amount: formatDecimal(invoice.totalCents, 2),
+        correlation_id: params.correlationId,
+      },
+    });
+  }
+}

--- a/src/module/facturation/repository/invoice-settlement.repository.ts
+++ b/src/module/facturation/repository/invoice-settlement.repository.ts
@@ -12,7 +12,7 @@ import {
   type FinanceActorContext,
 } from "./workflow.repository.shared";
 
-type InvoiceSettlementRow = {
+type InvoiceSettlementHeaderRow = {
   id: number;
   uuid: string | null;
   client_id: string;
@@ -21,6 +21,9 @@ type InvoiceSettlementRow = {
   document_status: string | null;
   settlement_status: string | null;
   total_ttc: string;
+};
+
+type InvoiceSettlementEvidenceRow = {
   allocated_payment_ttc: string;
   legacy_direct_payment_ttc: string;
   consumed_credit_ttc: string;
@@ -51,7 +54,10 @@ export async function lockInvoiceSettlement(
   client: Pick<PoolClient, "query">,
   factureId: number
 ): Promise<LockedInvoiceSettlement | null> {
-  const result = await client.query<InvoiceSettlementRow>(
+  // Le verrou est volontairement une requête dédiée. Sous READ COMMITTED, si
+  // elle attend un autre writer, la requête d'agrégats suivante obtient un
+  // nouveau snapshot après l'acquisition du verrou.
+  const headerResult = await client.query<InvoiceSettlementHeaderRow>(
     `
       SELECT
         f.id,
@@ -61,16 +67,35 @@ export async function lockInvoiceSettlement(
         f.statut,
         f.document_status,
         f.settlement_status,
-        f.total_ttc::numeric(18,2)::text AS total_ttc,
+        f.total_ttc::numeric(18,2)::text AS total_ttc
+      FROM public.facture f
+      WHERE f.id = $1
+      FOR UPDATE
+    `,
+    [factureId]
+  );
+  const header = headerResult.rows[0];
+  if (!header) return null;
+
+  const evidenceResult = await client.query<InvoiceSettlementEvidenceRow>(
+    `
+      SELECT
         COALESCE((
           SELECT SUM(pa.amount_ttc)
           FROM public.paiement_allocations pa
+          JOIN public.paiement allocated_payment ON allocated_payment.id = pa.paiement_id
           WHERE pa.facture_id = f.id
+            AND allocated_payment.status NOT IN ('REJECTED','REVERSED')
+            AND allocated_payment.workflow_status <> 'REVERSED'
+            AND allocated_payment.reversal_of_id IS NULL
         ), 0)::numeric(18,2)::text AS allocated_payment_ttc,
         COALESCE((
           SELECT SUM(p.montant)
           FROM public.paiement p
           WHERE p.facture_id = f.id
+            AND p.status NOT IN ('REJECTED','REVERSED')
+            AND p.workflow_status <> 'REVERSED'
+            AND p.reversal_of_id IS NULL
             AND NOT EXISTS (
               SELECT 1
               FROM public.paiement_allocations existing_payment_allocation
@@ -96,26 +121,25 @@ export async function lockInvoiceSettlement(
         ), 0)::numeric(18,2)::text AS legacy_direct_credit_ttc
       FROM public.facture f
       WHERE f.id = $1
-      FOR UPDATE
     `,
     [factureId]
   );
-  const row = result.rows[0];
-  if (!row) return null;
+  const evidence = evidenceResult.rows[0];
+  if (!evidence) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
   const settledCents =
-    moneyToCents(row.allocated_payment_ttc, "Paiements alloués") +
-    moneyToCents(row.legacy_direct_payment_ttc, "Paiements historiques") +
-    moneyToCents(row.consumed_credit_ttc, "Avoirs consommés") +
-    moneyToCents(row.legacy_direct_credit_ttc, "Avoirs historiques");
+    moneyToCents(evidence.allocated_payment_ttc, "Paiements alloués") +
+    moneyToCents(evidence.legacy_direct_payment_ttc, "Paiements historiques") +
+    moneyToCents(evidence.consumed_credit_ttc, "Avoirs consommés") +
+    moneyToCents(evidence.legacy_direct_credit_ttc, "Avoirs historiques");
   return {
-    id: row.id,
-    uuid: row.uuid,
-    clientId: row.client_id,
-    currency: row.currency,
-    status: row.statut,
-    documentStatus: row.document_status,
-    settlementStatus: row.settlement_status,
-    totalCents: moneyToCents(row.total_ttc, "Total facture"),
+    id: header.id,
+    uuid: header.uuid,
+    clientId: header.client_id,
+    currency: header.currency,
+    status: header.statut,
+    documentStatus: header.document_status,
+    settlementStatus: header.settlement_status,
+    totalCents: moneyToCents(header.total_ttc, "Total facture"),
     settledCents,
     settledAmount: formatDecimal(settledCents, 2),
   };

--- a/src/module/facturation/repository/paiements.repository.test.ts
+++ b/src/module/facturation/repository/paiements.repository.test.ts
@@ -52,8 +52,21 @@ describe("repoListPaiements — visibilite des reglements non affectes", () => {
     await repoListPaiements({ ...baseFilters });
 
     const [, dataSql] = capturedSql();
-    expect(dataSql.text).toContain("p.status");
+    expect(dataSql.text).toContain("THEN 'ALLOCATED'");
+    expect(dataSql.text).toContain("AS status");
     expect(dataSql.text).toContain("p.workflow_status");
+  });
+
+  it("projette le rattachement direct hérité en ALLOCATED sans réécrire la preuve brute", async () => {
+    query.mockResolvedValueOnce({ rows: [{ total: 0 }] }).mockResolvedValueOnce({ rows: [] });
+
+    await repoListPaiements({ ...baseFilters });
+
+    const [, dataSql] = capturedSql();
+    expect(dataSql.text).toContain("p.facture_id IS NOT NULL");
+    expect(dataSql.text).toContain("NOT EXISTS");
+    expect(dataSql.text).toContain("FROM paiement_allocations pa2");
+    expect(dataSql.text).toContain("THEN 'ALLOCATED'");
   });
 
   it("renvoie facture_id null et facture null sans lever, pour un reglement non affecte", async () => {
@@ -121,11 +134,12 @@ describe("repoListPaiements — visibilite des reglements non affectes", () => {
     await repoListPaiements({ ...baseFilters, status: "UNALLOCATED" });
 
     const [countSql] = capturedSql();
-    expect(countSql.text).toContain("p.status =");
+    expect(countSql.text).toContain("THEN 'ALLOCATED'");
+    expect(countSql.text).toMatch(/END\s*=\s*\$\d+/);
     expect(countSql.values).toContain("UNALLOCATED");
   });
 
-  it("expose un raccourci `unallocated` qui filtre sur l'absence de facture", async () => {
+  it("filtre `unallocated` sur le solde disponible, donc conserve les paiements partiels", async () => {
     query
       .mockResolvedValueOnce({ rows: [{ total: 0 }] })
       .mockResolvedValueOnce({ rows: [] });
@@ -133,7 +147,23 @@ describe("repoListPaiements — visibilite des reglements non affectes", () => {
     await repoListPaiements({ ...baseFilters, unallocated: true });
 
     const [countSql] = capturedSql();
-    expect(countSql.text).toContain("p.facture_id IS NULL");
+    expect(countSql.text).toContain("GREATEST(");
+    expect(countSql.text).toContain("p.montant::numeric(18,2)");
+    expect(countSql.text).toContain("SELECT SUM(pa.amount_ttc)");
+    expect(countSql.text).toContain("> 0::numeric");
+    expect(countSql.text).not.toContain("p.facture_id IS NULL");
+  });
+
+  it("écarte de la file les rejets, extournes et rattachements directs hérités", async () => {
+    query.mockResolvedValueOnce({ rows: [{ total: 0 }] }).mockResolvedValueOnce({ rows: [] });
+
+    await repoListPaiements({ ...baseFilters, unallocated: true });
+
+    const [countSql] = capturedSql();
+    expect(countSql.text).toContain("p.status NOT IN ('REJECTED', 'REVERSED')");
+    expect(countSql.text).toContain("p.workflow_status <> 'REVERSED'");
+    expect(countSql.text).toContain("p.reversal_of_id IS NULL");
+    expect(countSql.text).toMatch(/WHEN p\.facture_id IS NOT NULL[\s\S]*THEN p\.montant::numeric\(18,2\)/);
   });
 });
 
@@ -170,5 +200,17 @@ describe("repoGetPaiement — lecture d'un reglement non affecte", () => {
     expect(paiement?.facture_id).toBeNull();
     expect(paiement?.status).toBe("UNALLOCATED");
     expect(capturedSql()[0].text).toContain("LEFT JOIN facture");
+  });
+
+  it("projette aussi le statut ALLOCATED sur le détail direct hérité", async () => {
+    query.mockResolvedValueOnce({ rows: [] });
+
+    await repoGetPaiement(7, "");
+
+    const sql = capturedSql()[0].text;
+    expect(sql).toContain("p.facture_id IS NOT NULL");
+    expect(sql).toContain("FROM paiement_allocations pa2");
+    expect(sql).toContain("THEN 'ALLOCATED'");
+    expect(sql).toContain("AS status");
   });
 });

--- a/src/module/facturation/repository/paiements.repository.ts
+++ b/src/module/facturation/repository/paiements.repository.ts
@@ -3,6 +3,7 @@ import { HttpError } from "../../../utils/httpError";
 import type { ClientLite } from "../types/shared.types";
 import type { Paginated, Paiement, PaiementListItem } from "../types/paiements.types";
 import type { CreatePaiementBodyDTO, ListPaiementsQueryDTO, UpdatePaiementBodyDTO } from "../validators/paiements.validators";
+import { paiementAvailableAmountExpression, paiementProjectedStatusExpression } from "./reporting-sql";
 
 function toInt(value: unknown, label = "id"): number {
   if (typeof value === "number" && Number.isInteger(value)) return value;
@@ -80,11 +81,11 @@ function buildListWhere(filters: ListPaiementsQueryDTO, includeClientInSearch: b
   // « reglements a affecter » sans calcul cote interface.
   if (filters.status && filters.status.trim().length > 0) {
     const p = push(filters.status.trim());
-    where.push(`p.status = ${p}`);
+    where.push(`${paiementProjectedStatusExpression("p")} = ${p}`);
   }
 
   if (filters.unallocated === true) {
-    where.push(`p.facture_id IS NULL`);
+    where.push(`(${paiementAvailableAmountExpression("p")}) > 0::numeric`);
   }
 
   if (filters.from) {
@@ -162,7 +163,7 @@ export async function repoListPaiements(filters: ListPaiementsQueryDTO): Promise
       p.montant::float8 AS montant,
       p.mode,
       p.reference,
-      p.status,
+      ${paiementProjectedStatusExpression("p")} AS status,
       p.workflow_status,
       p.updated_at::text AS updated_at,
       ${clientSelectSql},
@@ -234,7 +235,7 @@ export async function repoGetPaiement(id: number, includeValue: string): Promise
       p.mode,
       p.reference,
       p.commentaire,
-      p.status,
+      ${paiementProjectedStatusExpression("p")} AS status,
       p.workflow_status,
       p.created_at::text AS created_at,
       p.updated_at::text AS updated_at,

--- a/src/module/facturation/repository/payment-workflow.legacy-direct.test.ts
+++ b/src/module/facturation/repository/payment-workflow.legacy-direct.test.ts
@@ -1,0 +1,109 @@
+import type { PoolClient } from "pg";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  poolConnect: vi.fn(),
+}));
+
+vi.mock("../../../config/database", () => ({
+  default: { connect: mocks.poolConnect },
+}));
+
+import { lockInvoiceSettlement } from "./invoice-settlement.repository";
+import { repoAllocatePayment } from "./payment-workflow.repository";
+
+describe("#469 direct legacy payment immutability", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["sa facture d'origine", "1"],
+    ["une autre facture", "2"],
+  ])("refuse toute allocation vers %s avant insertion", async (_label, targetId) => {
+    const sqlCalls: string[] = [];
+    const query = vi.fn(async (sqlValue: unknown) => {
+      const sql = String(sqlValue);
+      sqlCalls.push(sql);
+      if (sql === "BEGIN" || sql === "ROLLBACK") return { rows: [], rowCount: 0 };
+      if (sql.includes("pg_advisory_xact_lock")) return { rows: [], rowCount: 1 };
+      if (sql.includes("FROM public.finance_command_receipts")) {
+        return { rows: [], rowCount: 0 };
+      }
+      if (sql.includes("FROM public.paiement") && sql.includes("FOR UPDATE")) {
+        return {
+          rows: [{
+            id: 7,
+            uuid: "77777777-7777-4777-8777-777777777777",
+            code: "PAY-LEGACY-7",
+            facture_id: 1,
+            client_id: "001",
+            montant: "100.00",
+            currency: "EUR",
+            status: "UNALLOCATED",
+            row_version: 1,
+          }],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes("FROM public.paiement_allocations")) {
+        return {
+          rows: [{ amount: "0.00", allocation_count: 0 }],
+          rowCount: 1,
+        };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+    const release = vi.fn();
+    mocks.poolConnect.mockResolvedValue({ query, release });
+
+    await expect(repoAllocatePayment({
+      paymentId: 7,
+      input: {
+        expected_version: 1,
+        allocations: [{ target_type: "FACTURE", target_id: targetId, amount: "20.00" }],
+      },
+      actor: { userId: 9, requestId: "req-legacy-469", path: "/payments/7/allocate" },
+      idempotencyKey: `legacy-direct-${targetId}-immutable`,
+    })).rejects.toMatchObject({
+      status: 409,
+      code: "PAYMENT_LEGACY_DIRECT_IMMUTABLE",
+    });
+
+    expect(sqlCalls).toContain("ROLLBACK");
+    expect(sqlCalls.some((sql) => sql.includes("INSERT INTO public.paiement_allocations"))).toBe(false);
+    expect(sqlCalls.some((sql) => sql.includes("FROM public.facture f"))).toBe(false);
+    expect(release).toHaveBeenCalledOnce();
+  });
+
+  it("conserve les 100 EUR comme solde réglé de la facture d'origine", async () => {
+    const query = vi.fn(async (_sqlValue: unknown) => ({
+      rows: [{
+        id: 1,
+        uuid: null,
+        client_id: "001",
+        currency: "EUR",
+        statut: "emise",
+        document_status: "LEGACY",
+        settlement_status: "PAID",
+        total_ttc: "100.00",
+        allocated_payment_ttc: "0.00",
+        legacy_direct_payment_ttc: "100.00",
+        consumed_credit_ttc: "0.00",
+        legacy_direct_credit_ttc: "0.00",
+      }],
+      rowCount: 1,
+    }));
+
+    const invoice = await lockInvoiceSettlement(
+      { query } as unknown as Pick<PoolClient, "query">,
+      1
+    );
+
+    expect(invoice?.settledCents).toBe(10_000n);
+    expect(invoice?.settledAmount).toBe("100.00");
+    expect(String(query.mock.calls[1]?.[0])).toContain(
+      "existing_payment_allocation.paiement_id = p.id"
+    );
+  });
+});

--- a/src/module/facturation/repository/payment-workflow.repository.test.ts
+++ b/src/module/facturation/repository/payment-workflow.repository.test.ts
@@ -14,7 +14,7 @@ describe("#469 payment allocation lock ordering", () => {
           rowCount: 1,
         };
       }
-      if (sql.includes("FROM public.facture f")) {
+      if (sql.includes("FROM public.facture f") && sql.includes("FOR UPDATE")) {
         const factureId = Number(values?.[0]);
         lockOrder.push(`facture:${factureId}`);
         return {
@@ -27,6 +27,17 @@ describe("#469 payment allocation lock ordering", () => {
             document_status: "ISSUED",
             settlement_status: "UNPAID",
             total_ttc: "100.00",
+            allocated_payment_ttc: "0.00",
+            legacy_direct_payment_ttc: "0.00",
+            consumed_credit_ttc: "0.00",
+            legacy_direct_credit_ttc: "0.00",
+          }],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes("FROM public.facture f")) {
+        return {
+          rows: [{
             allocated_payment_ttc: "0.00",
             legacy_direct_payment_ttc: "0.00",
             consumed_credit_ttc: "0.00",
@@ -73,7 +84,7 @@ describe("#469 payment allocation lock ordering", () => {
   it("includes a direct pre-#227 payment in the invoice balance cap", async () => {
     const query = vi.fn(async (sqlValue: unknown) => {
       const sql = String(sqlValue);
-      if (sql.includes("FROM public.facture f")) {
+      if (sql.includes("FROM public.facture f") && sql.includes("FOR UPDATE")) {
         return {
           rows: [{
             id: 1,
@@ -84,6 +95,17 @@ describe("#469 payment allocation lock ordering", () => {
             document_status: "LEGACY",
             settlement_status: "UNPAID",
             total_ttc: "100.00",
+            allocated_payment_ttc: "0.00",
+            legacy_direct_payment_ttc: "90.00",
+            consumed_credit_ttc: "0.00",
+            legacy_direct_credit_ttc: "0.00",
+          }],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes("FROM public.facture f")) {
+        return {
+          rows: [{
             allocated_payment_ttc: "0.00",
             legacy_direct_payment_ttc: "90.00",
             consumed_credit_ttc: "0.00",
@@ -105,5 +127,51 @@ describe("#469 payment allocation lock ordering", () => {
       status: 409,
       code: "PAYMENT_INVOICE_BALANCE_EXCEEDED",
     });
+  });
+
+  it("autorise un paiement de remplacement après exclusion des preuves rejetées ou inversées", async () => {
+    const evidenceSql: string[] = [];
+    const query = vi.fn(async (sqlValue: unknown) => {
+      const sql = String(sqlValue);
+      if (sql.includes("FROM public.facture f") && sql.includes("FOR UPDATE")) {
+        return {
+          rows: [{
+            id: 1,
+            uuid: null,
+            client_id: "001",
+            currency: "EUR",
+            statut: "ISSUED",
+            document_status: "ISSUED",
+            settlement_status: "UNPAID",
+            total_ttc: "100.00",
+          }],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes("FROM public.facture f")) {
+        evidenceSql.push(sql);
+        return {
+          rows: [{
+            allocated_payment_ttc: "0.00",
+            legacy_direct_payment_ttc: "0.00",
+            consumed_credit_ttc: "0.00",
+            legacy_direct_credit_ttc: "0.00",
+          }],
+          rowCount: 1,
+        };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    await expect(resolveAndValidateAllocations({
+      client: { query } as unknown as PoolClient,
+      clientId: "001",
+      currency: "EUR",
+      paymentAvailableCents: 10_000n,
+      allocations: [{ target_type: "FACTURE", target_id: "1", amount: "100.00" }],
+    })).resolves.toHaveLength(1);
+
+    expect(evidenceSql[0]).toContain("allocated_payment.status NOT IN ('REJECTED','REVERSED')");
+    expect(evidenceSql[0]).toContain("p.status NOT IN ('REJECTED','REVERSED')");
   });
 });

--- a/src/module/facturation/repository/payment-workflow.repository.test.ts
+++ b/src/module/facturation/repository/payment-workflow.repository.test.ts
@@ -1,0 +1,109 @@
+import type { PoolClient } from "pg";
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveAndValidateAllocations } from "./payment-workflow.repository";
+
+describe("#469 payment allocation lock ordering", () => {
+  it("verrouille toutes les factures par id croissant avant les échéances", async () => {
+    const lockOrder: string[] = [];
+    const query = vi.fn(async (sqlValue: unknown, values?: unknown[]) => {
+      const sql = String(sqlValue);
+      if (sql.includes("FROM public.facture_echeance") && !sql.includes("amount_due")) {
+        return {
+          rows: [{ id: "11111111-1111-4111-8111-111111111111", facture_id: 1 }],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes("FROM public.facture f")) {
+        const factureId = Number(values?.[0]);
+        lockOrder.push(`facture:${factureId}`);
+        return {
+          rows: [{
+            id: factureId,
+            uuid: null,
+            client_id: "001",
+            currency: "EUR",
+            statut: "ISSUED",
+            document_status: "ISSUED",
+            settlement_status: "UNPAID",
+            total_ttc: "100.00",
+            allocated_payment_ttc: "0.00",
+            legacy_direct_payment_ttc: "0.00",
+            consumed_credit_ttc: "0.00",
+            legacy_direct_credit_ttc: "0.00",
+          }],
+          rowCount: 1,
+        };
+      }
+      if (sql.includes("FROM public.facture_echeance") && sql.includes("amount_due")) {
+        lockOrder.push("echeance:1");
+        return {
+          rows: [{
+            id: "11111111-1111-4111-8111-111111111111",
+            facture_id: 1,
+            amount_due: "100.00",
+            amount_allocated: "0.00",
+            status: "OPEN",
+          }],
+          rowCount: 1,
+        };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    const resolved = await resolveAndValidateAllocations({
+      client: { query } as unknown as PoolClient,
+      clientId: "001",
+      currency: "EUR",
+      paymentAvailableCents: 2_000n,
+      allocations: [
+        { target_type: "FACTURE", target_id: "2", amount: "10.00" },
+        {
+          target_type: "ECHEANCE",
+          target_id: "11111111-1111-4111-8111-111111111111",
+          amount: "10.00",
+        },
+      ],
+    });
+
+    expect(resolved).toHaveLength(2);
+    expect(lockOrder).toEqual(["facture:1", "facture:2", "echeance:1"]);
+  });
+
+  it("includes a direct pre-#227 payment in the invoice balance cap", async () => {
+    const query = vi.fn(async (sqlValue: unknown) => {
+      const sql = String(sqlValue);
+      if (sql.includes("FROM public.facture f")) {
+        return {
+          rows: [{
+            id: 1,
+            uuid: null,
+            client_id: "001",
+            currency: "EUR",
+            statut: "emise",
+            document_status: "LEGACY",
+            settlement_status: "UNPAID",
+            total_ttc: "100.00",
+            allocated_payment_ttc: "0.00",
+            legacy_direct_payment_ttc: "90.00",
+            consumed_credit_ttc: "0.00",
+            legacy_direct_credit_ttc: "0.00",
+          }],
+          rowCount: 1,
+        };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    await expect(resolveAndValidateAllocations({
+      client: { query } as unknown as PoolClient,
+      clientId: "001",
+      currency: "EUR",
+      paymentAvailableCents: 1_100n,
+      allocations: [{ target_type: "FACTURE", target_id: "1", amount: "11.00" }],
+    })).rejects.toMatchObject({
+      status: 409,
+      code: "PAYMENT_INVOICE_BALANCE_EXCEEDED",
+    });
+  });
+});

--- a/src/module/facturation/repository/payment-workflow.repository.ts
+++ b/src/module/facturation/repository/payment-workflow.repository.ts
@@ -4,6 +4,7 @@ import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
 import {
+  invoiceSettlementStatusFromBalance,
   paymentStatusFromAllocation,
   type PaymentStatus,
 } from "../domain/finance-policy";
@@ -83,6 +84,7 @@ async function resolveAndValidateAllocations(params: {
 }): Promise<ResolvedAllocation[]> {
   const uniqueTargets = new Set<string>();
   const resolved: ResolvedAllocation[] = [];
+  const requestedByInvoice = new Map<number, bigint>();
   let requestedCents = 0n;
 
   const sorted = [...params.allocations].sort((left, right) =>
@@ -212,13 +214,15 @@ async function resolveAndValidateAllocations(params: {
     const invoiceAvailableCents =
       moneyToCents(invoice.total_ttc, "Total facture") -
       moneyToCents(invoice.settled_ttc, "Total réglé");
-    if (amountCents > invoiceAvailableCents) {
+    const alreadyRequestedForInvoice = requestedByInvoice.get(factureId) ?? 0n;
+    if (alreadyRequestedForInvoice + amountCents > invoiceAvailableCents) {
       throw new HttpError(
         409,
         "PAYMENT_INVOICE_BALANCE_EXCEEDED",
         "L'allocation dépasse le solde de la facture."
       );
     }
+    requestedByInvoice.set(factureId, alreadyRequestedForInvoice + amountCents);
     resolved.push({
       targetType: allocation.target_type,
       targetId: allocation.target_id,
@@ -278,6 +282,129 @@ async function insertAllocations(params: {
         [allocation.dueDateId, allocation.amount]
       );
     }
+  }
+}
+
+async function refreshInvoiceSettlementStates(params: {
+  client: PoolClient;
+  allocations: readonly ResolvedAllocation[];
+  actor: FinanceActorContext;
+  correlationId: string;
+  idempotencyKey: string;
+}): Promise<void> {
+  const factureIds = [...new Set(params.allocations.map((allocation) => allocation.factureId))]
+    .sort((left, right) => left - right);
+
+  for (const factureId of factureIds) {
+    const result = await params.client.query<{
+      uuid: string | null;
+      statut: string;
+      document_status: string;
+      settlement_status: string;
+      total_ttc: string;
+      settled_ttc: string;
+    }>(
+      `
+        SELECT
+          f.uuid::text AS uuid,
+          f.statut,
+          f.document_status,
+          f.settlement_status,
+          f.total_ttc::numeric(18,2)::text AS total_ttc,
+          (
+            COALESCE((
+              SELECT SUM(pa.amount_ttc)
+              FROM public.paiement_allocations pa
+              WHERE pa.facture_id = f.id
+            ), 0)
+            +
+            COALESCE((
+              SELECT SUM(asa.amount_ttc)
+              FROM public.avoir_source_allocations asa
+              WHERE asa.facture_id = f.id
+                AND asa.allocation_status = 'CONSUMED'
+            ), 0)
+          )::numeric(18,2)::text AS settled_ttc
+        FROM public.facture f
+        WHERE f.id = $1
+        FOR UPDATE
+      `,
+      [factureId]
+    );
+    const invoice = result.rows[0];
+    if (!invoice) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
+    if (invoice.document_status !== "ISSUED") {
+      throw new HttpError(
+        409,
+        "PAYMENT_FACTURE_NOT_ISSUED",
+        "Un paiement ne peut être alloué qu'à une facture émise."
+      );
+    }
+    const settlementStatus = invoiceSettlementStatusFromBalance({
+      totalCents: moneyToCents(invoice.total_ttc, "Total facture"),
+      settledCents: moneyToCents(invoice.settled_ttc, "Total réglé"),
+    });
+    const projectedStatus = settlementStatus === "UNPAID" ? "ISSUED" : settlementStatus;
+    if (
+      invoice.statut === projectedStatus &&
+      invoice.settlement_status === settlementStatus
+    ) {
+      continue;
+    }
+
+    // The immutable-evidence trigger accepts only this correlation-bound settlement projection.
+    await params.client.query(
+      `SELECT set_config('cerp.finance_settlement_correlation_id', $1, true)`,
+      [params.correlationId]
+    );
+    await params.client.query(
+      `
+        UPDATE public.facture
+        SET statut = $2,
+            document_status = 'ISSUED',
+            settlement_status = $3,
+            row_version = row_version + 1,
+            correlation_id = $4::uuid,
+            updated_at = now()
+        WHERE id = $1
+      `,
+      [factureId, projectedStatus, settlementStatus, params.correlationId]
+    );
+    const aggregateId = invoice.uuid ?? String(factureId);
+    await insertFinanceEvent({
+      client: params.client,
+      aggregateType: "FACTURE",
+      aggregateId,
+      eventType: "FACTURE_SETTLEMENT_DERIVED",
+      oldValues: {
+        status: invoice.statut,
+        settlement_status: invoice.settlement_status,
+      },
+      newValues: {
+        status: projectedStatus,
+        settlement_status: settlementStatus,
+        settled_amount: invoice.settled_ttc,
+        total_amount: invoice.total_ttc,
+      },
+      actor: params.actor,
+      correlationId: params.correlationId,
+      idempotencyKey: params.idempotencyKey,
+      ruleCode: "FINANCE-SETTLEMENT-469",
+    });
+    await insertGlobalFinanceAudit({
+      client: params.client,
+      actor: params.actor,
+      action: "facturation.facture_settlement_derived",
+      entityType: "facture",
+      entityId: aggregateId,
+      details: {
+        from: invoice.settlement_status,
+        to: settlementStatus,
+        settled_amount: invoice.settled_ttc,
+        total_amount: invoice.total_ttc,
+        correlation_id: params.correlationId,
+      },
+    });
   }
 }
 
@@ -389,6 +516,13 @@ export async function repoRegisterPayment(params: {
       actor: params.actor,
       correlationId,
       allocations,
+    });
+    await refreshInvoiceSettlementStates({
+      client,
+      allocations,
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
     });
     const allocatedCents = allocations.reduce(
       (sum, allocation) => sum + moneyToCents(allocation.amount, "Montant alloué"),
@@ -529,6 +663,13 @@ export async function repoAllocatePayment(params: {
       actor: params.actor,
       correlationId,
       allocations,
+    });
+    await refreshInvoiceSettlementStates({
+      client,
+      allocations,
+      actor: params.actor,
+      correlationId,
+      idempotencyKey: receipt.idempotencyKey,
     });
     const newlyAllocated = allocations.reduce(
       (sum, allocation) => sum + moneyToCents(allocation.amount, "Montant alloué"),

--- a/src/module/facturation/repository/payment-workflow.repository.ts
+++ b/src/module/facturation/repository/payment-workflow.repository.ts
@@ -4,7 +4,6 @@ import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
 import {
-  invoiceSettlementStatusFromBalance,
   paymentStatusFromAllocation,
   type PaymentStatus,
 } from "../domain/finance-policy";
@@ -24,6 +23,12 @@ import {
   nextLegacyId,
   saveFinanceReceipt,
 } from "./workflow.repository.shared";
+import {
+  assertInvoiceIssued,
+  lockInvoiceSettlement,
+  refreshInvoiceSettlementStates,
+  type LockedInvoiceSettlement,
+} from "./invoice-settlement.repository";
 
 type LockedPayment = {
   id: number;
@@ -74,16 +79,25 @@ type ResolvedAllocation = {
   amount: string;
 };
 
-async function resolveAndValidateAllocations(params: {
+type AllocationCandidate = ResolvedAllocation & { amountCents: bigint };
+
+type LockedDueDate = {
+  id: string;
+  facture_id: number;
+  amount_due: string;
+  amount_allocated: string;
+  status: string;
+};
+
+export async function resolveAndValidateAllocations(params: {
   client: PoolClient;
   clientId: string;
   currency: string;
-  paymentId: number;
   paymentAvailableCents: bigint;
   allocations: readonly AllocationInput[];
 }): Promise<ResolvedAllocation[]> {
   const uniqueTargets = new Set<string>();
-  const resolved: ResolvedAllocation[] = [];
+  const candidates: AllocationCandidate[] = [];
   const requestedByInvoice = new Map<number, bigint>();
   let requestedCents = 0n;
 
@@ -111,24 +125,15 @@ async function resolveAndValidateAllocations(params: {
 
     let factureId: number;
     let dueDateId: string | null = null;
-    let dueAvailableCents: bigint | null = null;
     if (allocation.target_type === "ECHEANCE") {
       const due = await params.client.query<{
         id: string;
         facture_id: number;
-        amount_due: string;
-        amount_allocated: string;
-        status: string;
       }>(
         `
-          SELECT
-            id::text AS id, facture_id,
-            amount_due::numeric(18,2)::text AS amount_due,
-            amount_allocated::numeric(18,2)::text AS amount_allocated,
-            status
+          SELECT id::text AS id, facture_id
           FROM public.facture_echeance
           WHERE id = $1::uuid
-          FOR UPDATE
         `,
         [allocation.target_id]
       );
@@ -138,16 +143,6 @@ async function resolveAndValidateAllocations(params: {
       }
       factureId = row.facture_id;
       dueDateId = row.id;
-      dueAvailableCents =
-        moneyToCents(row.amount_due, "Échéance") -
-        moneyToCents(row.amount_allocated, "Échéance allouée");
-      if (row.status === "CANCELLED" || amountCents > dueAvailableCents) {
-        throw new HttpError(
-          409,
-          "PAYMENT_DUE_DATE_EXCEEDED",
-          "L'allocation dépasse le solde de l'échéance."
-        );
-      }
     } else {
       if (!/^\d+$/.test(allocation.target_id)) {
         throw new HttpError(422, "PAYMENT_FACTURE_ID_INVALID", "Identifiant facture invalide.");
@@ -155,49 +150,26 @@ async function resolveAndValidateAllocations(params: {
       factureId = Number.parseInt(allocation.target_id, 10);
     }
 
-    const facture = await params.client.query<{
-      client_id: string;
-      currency: string;
-      statut: string;
-      total_ttc: string;
-      settled_ttc: string;
-    }>(
-      `
-        SELECT
-          f.client_id,
-          COALESCE(f.currency, 'EUR') AS currency,
-          f.statut,
-          f.total_ttc::numeric(18,2)::text AS total_ttc,
-          (
-            COALESCE((
-              SELECT SUM(pa.amount_ttc)
-              FROM public.paiement_allocations pa
-              WHERE pa.facture_id = f.id
-            ), 0)
-            +
-            COALESCE((
-              SELECT SUM(asa.amount_ttc)
-              FROM public.avoir_source_allocations asa
-              WHERE asa.facture_id = f.id
-                AND asa.allocation_status = 'CONSUMED'
-            ), 0)
-          )::numeric(18,2)::text AS settled_ttc
-        FROM public.facture f
-        WHERE f.id = $1
-        FOR UPDATE
-      `,
-      [factureId]
-    );
-    const invoice = facture.rows[0];
+    candidates.push({
+      targetType: allocation.target_type,
+      targetId: allocation.target_id,
+      factureId,
+      dueDateId,
+      amount: allocation.amount,
+      amountCents,
+    });
+  }
+
+  // Tous les verrous facture sont acquis dans le même ordre global, avant les
+  // échéances. Un mélange FACTURE + ECHEANCE ne peut donc plus inverser l'ordre.
+  const invoices = new Map<number, LockedInvoiceSettlement>();
+  const factureIds = [...new Set(candidates.map((candidate) => candidate.factureId))]
+    .sort((left, right) => left - right);
+  for (const factureId of factureIds) {
+    const invoice = await lockInvoiceSettlement(params.client, factureId);
     if (!invoice) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
-    if (!["ISSUED", "PARTIALLY_PAID", "PAID"].includes(invoice.statut)) {
-      throw new HttpError(
-        409,
-        "PAYMENT_FACTURE_NOT_ISSUED",
-        "Un paiement ne peut être alloué qu'à une facture émise."
-      );
-    }
-    if (invoice.client_id !== params.clientId) {
+    assertInvoiceIssued(invoice);
+    if (invoice.clientId !== params.clientId) {
       throw new HttpError(
         422,
         "PAYMENT_CLIENT_MISMATCH",
@@ -211,25 +183,67 @@ async function resolveAndValidateAllocations(params: {
         "Le paiement et la facture doivent avoir la même devise."
       );
     }
-    const invoiceAvailableCents =
-      moneyToCents(invoice.total_ttc, "Total facture") -
-      moneyToCents(invoice.settled_ttc, "Total réglé");
-    const alreadyRequestedForInvoice = requestedByInvoice.get(factureId) ?? 0n;
-    if (alreadyRequestedForInvoice + amountCents > invoiceAvailableCents) {
+    invoices.set(factureId, invoice);
+  }
+
+  const dueDates = new Map<string, LockedDueDate>();
+  const dueCandidates = candidates
+    .filter((candidate): candidate is AllocationCandidate & { dueDateId: string } =>
+      candidate.dueDateId !== null
+    )
+    .sort((left, right) =>
+      left.factureId - right.factureId || left.dueDateId.localeCompare(right.dueDateId)
+    );
+  for (const candidate of dueCandidates) {
+    const due = await params.client.query<LockedDueDate>(
+      `
+        SELECT
+          id::text AS id, facture_id,
+          amount_due::numeric(18,2)::text AS amount_due,
+          amount_allocated::numeric(18,2)::text AS amount_allocated,
+          status
+        FROM public.facture_echeance
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
+      [candidate.dueDateId]
+    );
+    const row = due.rows[0];
+    if (!row) throw new HttpError(404, "PAYMENT_DUE_DATE_NOT_FOUND", "Échéance introuvable.");
+    if (row.facture_id !== candidate.factureId) {
+      throw new HttpError(409, "PAYMENT_DUE_DATE_CHANGED", "L'échéance a changé; réessayez.");
+    }
+    dueDates.set(candidate.dueDateId, row);
+  }
+
+  for (const candidate of candidates) {
+    const invoice = invoices.get(candidate.factureId)!;
+    if (candidate.dueDateId) {
+      const due = dueDates.get(candidate.dueDateId)!;
+      const dueAvailableCents =
+        moneyToCents(due.amount_due, "Échéance") -
+        moneyToCents(due.amount_allocated, "Échéance allouée");
+      if (due.status === "CANCELLED" || candidate.amountCents > dueAvailableCents) {
+        throw new HttpError(
+          409,
+          "PAYMENT_DUE_DATE_EXCEEDED",
+          "L'allocation dépasse le solde de l'échéance."
+        );
+      }
+    }
+    const invoiceAvailableCents = invoice.totalCents - invoice.settledCents;
+    const alreadyRequestedForInvoice = requestedByInvoice.get(candidate.factureId) ?? 0n;
+    if (alreadyRequestedForInvoice + candidate.amountCents > invoiceAvailableCents) {
       throw new HttpError(
         409,
         "PAYMENT_INVOICE_BALANCE_EXCEEDED",
         "L'allocation dépasse le solde de la facture."
       );
     }
-    requestedByInvoice.set(factureId, alreadyRequestedForInvoice + amountCents);
-    resolved.push({
-      targetType: allocation.target_type,
-      targetId: allocation.target_id,
-      factureId,
-      dueDateId,
-      amount: allocation.amount,
-    });
+    requestedByInvoice.set(
+      candidate.factureId,
+      alreadyRequestedForInvoice + candidate.amountCents
+    );
   }
 
   if (requestedCents > params.paymentAvailableCents) {
@@ -239,7 +253,7 @@ async function resolveAndValidateAllocations(params: {
       "Les allocations dépassent le montant disponible du paiement."
     );
   }
-  return resolved;
+  return candidates.map(({ amountCents: _amountCents, ...candidate }) => candidate);
 }
 
 async function insertAllocations(params: {
@@ -282,129 +296,6 @@ async function insertAllocations(params: {
         [allocation.dueDateId, allocation.amount]
       );
     }
-  }
-}
-
-async function refreshInvoiceSettlementStates(params: {
-  client: PoolClient;
-  allocations: readonly ResolvedAllocation[];
-  actor: FinanceActorContext;
-  correlationId: string;
-  idempotencyKey: string;
-}): Promise<void> {
-  const factureIds = [...new Set(params.allocations.map((allocation) => allocation.factureId))]
-    .sort((left, right) => left - right);
-
-  for (const factureId of factureIds) {
-    const result = await params.client.query<{
-      uuid: string | null;
-      statut: string;
-      document_status: string;
-      settlement_status: string;
-      total_ttc: string;
-      settled_ttc: string;
-    }>(
-      `
-        SELECT
-          f.uuid::text AS uuid,
-          f.statut,
-          f.document_status,
-          f.settlement_status,
-          f.total_ttc::numeric(18,2)::text AS total_ttc,
-          (
-            COALESCE((
-              SELECT SUM(pa.amount_ttc)
-              FROM public.paiement_allocations pa
-              WHERE pa.facture_id = f.id
-            ), 0)
-            +
-            COALESCE((
-              SELECT SUM(asa.amount_ttc)
-              FROM public.avoir_source_allocations asa
-              WHERE asa.facture_id = f.id
-                AND asa.allocation_status = 'CONSUMED'
-            ), 0)
-          )::numeric(18,2)::text AS settled_ttc
-        FROM public.facture f
-        WHERE f.id = $1
-        FOR UPDATE
-      `,
-      [factureId]
-    );
-    const invoice = result.rows[0];
-    if (!invoice) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
-    if (invoice.document_status !== "ISSUED") {
-      throw new HttpError(
-        409,
-        "PAYMENT_FACTURE_NOT_ISSUED",
-        "Un paiement ne peut être alloué qu'à une facture émise."
-      );
-    }
-    const settlementStatus = invoiceSettlementStatusFromBalance({
-      totalCents: moneyToCents(invoice.total_ttc, "Total facture"),
-      settledCents: moneyToCents(invoice.settled_ttc, "Total réglé"),
-    });
-    const projectedStatus = settlementStatus === "UNPAID" ? "ISSUED" : settlementStatus;
-    if (
-      invoice.statut === projectedStatus &&
-      invoice.settlement_status === settlementStatus
-    ) {
-      continue;
-    }
-
-    // The immutable-evidence trigger accepts only this correlation-bound settlement projection.
-    await params.client.query(
-      `SELECT set_config('cerp.finance_settlement_correlation_id', $1, true)`,
-      [params.correlationId]
-    );
-    await params.client.query(
-      `
-        UPDATE public.facture
-        SET statut = $2,
-            document_status = 'ISSUED',
-            settlement_status = $3,
-            row_version = row_version + 1,
-            correlation_id = $4::uuid,
-            updated_at = now()
-        WHERE id = $1
-      `,
-      [factureId, projectedStatus, settlementStatus, params.correlationId]
-    );
-    const aggregateId = invoice.uuid ?? String(factureId);
-    await insertFinanceEvent({
-      client: params.client,
-      aggregateType: "FACTURE",
-      aggregateId,
-      eventType: "FACTURE_SETTLEMENT_DERIVED",
-      oldValues: {
-        status: invoice.statut,
-        settlement_status: invoice.settlement_status,
-      },
-      newValues: {
-        status: projectedStatus,
-        settlement_status: settlementStatus,
-        settled_amount: invoice.settled_ttc,
-        total_amount: invoice.total_ttc,
-      },
-      actor: params.actor,
-      correlationId: params.correlationId,
-      idempotencyKey: params.idempotencyKey,
-      ruleCode: "FINANCE-SETTLEMENT-469",
-    });
-    await insertGlobalFinanceAudit({
-      client: params.client,
-      actor: params.actor,
-      action: "facturation.facture_settlement_derived",
-      entityType: "facture",
-      entityId: aggregateId,
-      details: {
-        from: invoice.settlement_status,
-        to: settlementStatus,
-        settled_amount: invoice.settled_ttc,
-        total_amount: invoice.total_ttc,
-        correlation_id: params.correlationId,
-      },
-    });
   }
 }
 
@@ -470,7 +361,6 @@ export async function repoRegisterPayment(params: {
       client,
       clientId: params.input.client_id,
       currency: params.input.currency,
-      paymentId: id,
       paymentAvailableCents: amountCents,
       allocations: params.input.allocations,
     });
@@ -519,7 +409,7 @@ export async function repoRegisterPayment(params: {
     });
     await refreshInvoiceSettlementStates({
       client,
-      allocations,
+      factureIds: allocations.map((allocation) => allocation.factureId),
       actor: params.actor,
       correlationId,
       idempotencyKey: receipt.idempotencyKey,
@@ -652,7 +542,6 @@ export async function repoAllocatePayment(params: {
       client,
       clientId: payment.client_id,
       currency: payment.currency,
-      paymentId: payment.id,
       paymentAvailableCents: amountCents - alreadyAllocated,
       allocations: params.input.allocations,
     });
@@ -666,7 +555,7 @@ export async function repoAllocatePayment(params: {
     });
     await refreshInvoiceSettlementStates({
       client,
-      allocations,
+      factureIds: allocations.map((allocation) => allocation.factureId),
       actor: params.actor,
       correlationId,
       idempotencyKey: receipt.idempotencyKey,

--- a/src/module/facturation/repository/payment-workflow.repository.ts
+++ b/src/module/facturation/repository/payment-workflow.repository.ts
@@ -34,6 +34,7 @@ type LockedPayment = {
   id: number;
   uuid: string;
   code: string;
+  facture_id: number | null;
   client_id: string;
   montant: string;
   currency: string;
@@ -47,7 +48,7 @@ async function lockPayment(client: PoolClient, paymentId: number): Promise<Locke
   const result = await client.query<LockedPayment>(
     `
       SELECT
-        id, uuid::text AS uuid, code, client_id,
+        id, uuid::text AS uuid, code, facture_id, client_id,
         montant::numeric(18,2)::text AS montant,
         currency, status, row_version
       FROM public.paiement
@@ -59,16 +60,24 @@ async function lockPayment(client: PoolClient, paymentId: number): Promise<Locke
   return result.rows[0] ?? null;
 }
 
-async function allocatedPaymentCents(client: PoolClient, paymentId: number): Promise<bigint> {
-  const result = await client.query<{ amount: string }>(
+async function allocatedPaymentEvidence(
+  client: PoolClient,
+  paymentId: number
+): Promise<{ allocatedCents: bigint; allocationCount: number }> {
+  const result = await client.query<{ amount: string; allocation_count: number }>(
     `
-      SELECT COALESCE(SUM(amount_ttc), 0)::numeric(18,2)::text AS amount
+      SELECT
+        COALESCE(SUM(amount_ttc), 0)::numeric(18,2)::text AS amount,
+        COUNT(*)::int AS allocation_count
       FROM public.paiement_allocations
       WHERE paiement_id = $1
     `,
     [paymentId]
   );
-  return moneyToCents(result.rows[0]?.amount ?? "0.00", "Montant alloué");
+  return {
+    allocatedCents: moneyToCents(result.rows[0]?.amount ?? "0.00", "Montant alloué"),
+    allocationCount: result.rows[0]?.allocation_count ?? 0,
+  };
 }
 
 type ResolvedAllocation = {
@@ -435,6 +444,7 @@ export async function repoRegisterPayment(params: {
       id,
       uuid,
       code,
+      facture_id: firstFactureId,
       client_id: params.input.client_id,
       montant: params.input.amount,
       currency: params.input.currency,
@@ -537,7 +547,18 @@ export async function repoAllocatePayment(params: {
       throw new HttpError(409, "CONCURRENT_MODIFICATION", "Le paiement a changé.");
     }
     const amountCents = moneyToCents(payment.montant, "Montant du paiement");
-    const alreadyAllocated = await allocatedPaymentCents(client, payment.id);
+    const paymentEvidence = await allocatedPaymentEvidence(client, payment.id);
+    // Un lien facture direct sans allocation est la preuve complète pré-#227.
+    // Le rendre partiellement alloué supprimerait le fallback de la facture
+    // historique et réécrirait son solde économique sans preuve de migration.
+    if (payment.facture_id !== null && paymentEvidence.allocationCount === 0) {
+      throw new HttpError(
+        409,
+        "PAYMENT_LEGACY_DIRECT_IMMUTABLE",
+        "Ce paiement historique est déjà intégralement affecté à sa facture d'origine."
+      );
+    }
+    const alreadyAllocated = paymentEvidence.allocatedCents;
     const allocations = await resolveAndValidateAllocations({
       client,
       clientId: payment.client_id,

--- a/src/module/facturation/repository/reporting-sql.ts
+++ b/src/module/facturation/repository/reporting-sql.ts
@@ -155,6 +155,80 @@ export function paiementNetPredicate(p: Params, alias = "p"): string {
         AND ${alias}.reversal_of_id IS NULL`;
 }
 
+type PaiementAvailabilityOptions = {
+  /** Expression SQL de date incluse, par exemple `$1::date`. Sans valeur, toutes les allocations comptent. */
+  allocationAsOfDateSql?: string;
+};
+
+function paiementNetReadPredicate(alias: string): string {
+  const excluded = PAIEMENT_EXCLUDED_STATUSES.map((status) => `'${status}'`).join(", ");
+  return `${alias}.status NOT IN (${excluded})
+        AND ${alias}.workflow_status <> 'REVERSED'
+        AND ${alias}.reversal_of_id IS NULL`;
+}
+
+function paiementDirectLegacyPredicate(alias: string): string {
+  return `${alias}.facture_id IS NOT NULL
+        AND NOT EXISTS (
+          SELECT 1 FROM paiement_allocations pa2
+          WHERE pa2.paiement_id = ${alias}.id
+        )`;
+}
+
+/**
+ * Montant économiquement affecté d'une source de règlement.
+ *
+ * Le rattachement direct hérité constitue une preuve d'affectation complète quand
+ * aucune ligne d'allocation moderne n'existe. Il ne doit donc jamais réapparaître
+ * dans une file « à affecter », même si son statut brut historique vaut UNALLOCATED.
+ */
+export function paiementAllocatedAmountExpression(
+  alias = "p",
+  options: PaiementAvailabilityOptions = {}
+): string {
+  const cutoff = options.allocationAsOfDateSql
+    ? `AND ${parisDate("pa.created_at")} <= ${options.allocationAsOfDateSql}`
+    : "";
+  return `CASE
+        WHEN ${paiementDirectLegacyPredicate(alias)}
+          THEN ${alias}.montant::numeric(18,2)
+        ELSE COALESCE((
+          SELECT SUM(pa.amount_ttc)
+          FROM paiement_allocations pa
+          WHERE pa.paiement_id = ${alias}.id
+            ${cutoff}
+        ), 0)::numeric(18,2)
+      END`;
+}
+
+/** Solde encore affectable : règlement net − montant économiquement affecté. */
+export function paiementAvailableAmountExpression(
+  alias = "p",
+  options: PaiementAvailabilityOptions = {}
+): string {
+  return `CASE
+        WHEN ${paiementNetReadPredicate(alias)}
+          THEN GREATEST(
+            ${alias}.montant::numeric(18,2) - (${paiementAllocatedAmountExpression(alias, options)}),
+            0::numeric
+          )
+        ELSE 0::numeric
+      END`;
+}
+
+/**
+ * Vue de lecture compatible : la preuve directe héritée est affichée ALLOCATED,
+ * sans modifier le statut brut conservé en base.
+ */
+export function paiementProjectedStatusExpression(alias = "p"): string {
+  return `CASE
+        WHEN ${paiementNetReadPredicate(alias)}
+          AND ${paiementDirectLegacyPredicate(alias)}
+          THEN 'ALLOCATED'
+        ELSE ${alias}.status
+      END`;
+}
+
 /**
  * CTE `settled` : montants réellement imputés à chaque facture À LA DATE D'ARRÊTÉ.
  *

--- a/src/module/facturation/repository/reporting-v2.repository.ts
+++ b/src/module/facturation/repository/reporting-v2.repository.ts
@@ -30,7 +30,10 @@ import {
   ledgerFactureCte,
   lineValueExpression,
   money,
+  paiementAllocatedAmountExpression,
+  paiementAvailableAmountExpression,
   paiementNetPredicate,
+  paiementProjectedStatusExpression,
   ratio,
   settledCte,
   shippedLinesCte,
@@ -924,21 +927,9 @@ async function repoUnallocated(
 
   const res = await pool.query(
     `WITH pay AS (
-       SELECT p.montant::numeric(18,2) AS montant,
-              (
-                COALESCE((
-                  SELECT SUM(pa.amount_ttc) FROM paiement_allocations pa
-                  WHERE pa.paiement_id = p.id
-                    AND (pa.created_at AT TIME ZONE 'Europe/Paris')::date <= ${asOf}::date
-                ), 0)
-                -- Rattachement direct hérité : un règlement lié à une facture sans
-                -- ligne de lettrage est affecté, pas en attente d'affectation.
-                + CASE
-                    WHEN p.facture_id IS NOT NULL
-                      AND NOT EXISTS (SELECT 1 FROM paiement_allocations pa2 WHERE pa2.paiement_id = p.id)
-                    THEN p.montant ELSE 0
-                  END
-              )::numeric(18,2) AS allocated
+       SELECT ${paiementAvailableAmountExpression("p", {
+         allocationAsOfDateSql: `${asOf}::date`,
+       })}::numeric(18,2) AS available
        FROM paiement p
        WHERE p.date_paiement <= ${asOf}::date AND ${net} ${clientPay}
      ),
@@ -955,7 +946,7 @@ async function repoUnallocated(
          AND a.facture_id IS NULL ${clientCred}
      )
      SELECT
-       COALESCE((SELECT SUM(GREATEST(montant - allocated, 0)) FROM pay), 0)::numeric(18,2)::text  AS payments_ttc,
+       COALESCE((SELECT SUM(available) FROM pay), 0)::numeric(18,2)::text AS payments_ttc,
        COALESCE((SELECT SUM(GREATEST(montant - allocated, 0)) FROM cred), 0)::numeric(18,2)::text AS credits_ttc`,
     p.values
   );
@@ -1516,29 +1507,38 @@ async function drilldownPayments(ctx: ReportingContext, scope: string): Promise<
   const net = paiementNetPredicate(p, "p");
   const from = p.push(ctx.period.from);
   const to = p.push(ctx.period.to);
+  const asOf = p.push(ctx.asOf);
   const clientFilter = ctx.clientId ? `AND p.client_id = ${p.push(ctx.clientId)}` : "";
   const limit = p.push(ctx.limit);
-  const unallocatedFilter =
-    scope === "unallocated"
-      ? `AND p.facture_id IS NULL AND NOT EXISTS (SELECT 1 FROM paiement_allocations pa WHERE pa.paiement_id = p.id)`
-      : "";
+  const allocationOptions = { allocationAsOfDateSql: `${asOf}::date` };
+  const unallocatedFilter = scope === "unallocated" ? "WHERE pr.available_amount > 0::numeric" : "";
 
   const res = await pool.query(
-    `SELECT p.id::text AS id, p.code, p.client_id, c.company_name,
-            p.date_paiement::text AS date_paiement,
-            p.montant::numeric(18,2)::text AS montant,
-            p.mode, p.status, p.workflow_status, p.currency,
-            p.facture_id::text AS facture_id,
+    `WITH payment_read AS (
+       SELECT p.*,
+              ${paiementAllocatedAmountExpression("p", allocationOptions)}::numeric(18,2) AS allocated_amount,
+              ${paiementAvailableAmountExpression("p", allocationOptions)}::numeric(18,2) AS available_amount,
+              ${paiementProjectedStatusExpression("p")} AS projected_status
+       FROM paiement p
+       WHERE p.date_paiement BETWEEN ${from}::date AND ${to}::date
+         AND ${net} ${clientFilter}
+     )
+     SELECT pr.id::text AS id, pr.code, pr.client_id, c.company_name,
+            pr.date_paiement::text AS date_paiement,
+            pr.montant::numeric(18,2)::text AS montant,
+            pr.allocated_amount::text AS allocated_amount,
+            pr.available_amount::text AS available_amount,
+            pr.mode, pr.projected_status AS status, pr.workflow_status, pr.currency,
+            pr.facture_id::text AS facture_id,
             COUNT(*) OVER ()::int AS total_rows
-     FROM paiement p
-     LEFT JOIN clients c ON c.client_id = p.client_id
-     WHERE p.date_paiement BETWEEN ${from}::date AND ${to}::date
-       AND ${net} ${clientFilter} ${unallocatedFilter}
-     ORDER BY p.date_paiement DESC, p.id DESC
+     FROM payment_read pr
+     LEFT JOIN clients c ON c.client_id = pr.client_id
+     ${unallocatedFilter}
+     ORDER BY pr.date_paiement DESC, pr.id DESC
      LIMIT ${limit}`,
     p.values
   );
-  return buildDrilldown("payments", scope, res.rows, ["montant"]);
+  return buildDrilldown("payments", scope, res.rows, ["montant", "allocated_amount", "available_amount"]);
 }
 
 function buildDrilldown(

--- a/src/module/facturation/repository/reporting.repository.ts
+++ b/src/module/facturation/repository/reporting.repository.ts
@@ -33,6 +33,7 @@ import {
   creditedCte,
   ledgerFactureCte,
   money,
+  paiementAvailableAmountExpression,
   paiementNetPredicate,
   settledCte,
 } from "./reporting-sql";
@@ -302,22 +303,9 @@ export async function repoUnallocatedAtDate(
     WITH pay AS (
       SELECT
         p.id,
-        p.montant::numeric(18,2) AS montant,
-        (
-          COALESCE((
-            SELECT SUM(pa.amount_ttc)
-            FROM paiement_allocations pa
-            WHERE pa.paiement_id = p.id
-              AND (pa.created_at AT TIME ZONE 'Europe/Paris')::date <= ${asOfParam}::date
-          ), 0)
-          -- Rattachement direct hérité : un règlement lié à une facture sans ligne
-          -- de lettrage est affecté, pas en attente d'affectation.
-          + CASE
-              WHEN p.facture_id IS NOT NULL
-                AND NOT EXISTS (SELECT 1 FROM paiement_allocations pa2 WHERE pa2.paiement_id = p.id)
-              THEN p.montant ELSE 0
-            END
-        )::numeric(18,2) AS allocated
+        ${paiementAvailableAmountExpression("p", {
+          allocationAsOfDateSql: `${asOfParam}::date`,
+        })}::numeric(18,2) AS available
       FROM paiement p
       WHERE p.date_paiement <= ${asOfParam}::date
         AND ${net}
@@ -339,7 +327,7 @@ export async function repoUnallocatedAtDate(
         AND a.facture_id IS NULL
     )
     SELECT
-      COALESCE((SELECT SUM(GREATEST(montant - allocated, 0)) FROM pay), 0)::numeric(18,2)::text  AS payments_ttc,
+      COALESCE((SELECT SUM(available) FROM pay), 0)::numeric(18,2)::text AS payments_ttc,
       COALESCE((SELECT SUM(GREATEST(montant - allocated, 0)) FROM cred), 0)::numeric(18,2)::text AS credits_ttc
   `;
 

--- a/src/module/facturation/routes/paiements.routes.ts
+++ b/src/module/facturation/routes/paiements.routes.ts
@@ -6,7 +6,10 @@ import {
   listPaiements,
   updatePaiement,
 } from "../controllers/paiements.controller";
-import { requireFinanceCapability } from "../middlewares/finance-authorization.middleware";
+import {
+  requireFinanceCapability,
+  requirePaymentAllocationCapabilityForInlineAllocations,
+} from "../middlewares/finance-authorization.middleware";
 import {
   allocatePaymentWorkflow,
   registerPaymentWorkflow,
@@ -14,7 +17,12 @@ import {
 
 const router = Router();
 
-router.post("/workflow/register", requireFinanceCapability("payment_register"), registerPaymentWorkflow);
+router.post(
+  "/workflow/register",
+  requireFinanceCapability("payment_register"),
+  requirePaymentAllocationCapabilityForInlineAllocations,
+  registerPaymentWorkflow
+);
 router.post(
   "/workflow/:id/allocations",
   requireFinanceCapability("payment_allocate"),

--- a/src/module/facturation/types/factures.types.ts
+++ b/src/module/facturation/types/factures.types.ts
@@ -10,6 +10,8 @@ export type FactureHeader = {
   date_emission: string;
   date_echeance: string | null;
   statut: string;
+  document_status: string;
+  settlement_status: string;
   remise_globale: number;
   total_ht: number;
   total_ttc: number;
@@ -77,6 +79,8 @@ export type FactureListItem = {
   total_ttc: number;
   updated_at: string;
   statut: string;
+  document_status: string;
+  settlement_status: string;
   client?: ClientLite | null;
   total_paye_ttc?: number;
   total_avoirs_ttc?: number;

--- a/src/module/facturation/validators/avoirs.validators.ts
+++ b/src/module/facturation/validators/avoirs.validators.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 
 const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date (expected YYYY-MM-DD)");
+const avoirStatus = z.enum(["DRAFT", "PENDING_VALIDATION", "APPROVED", "ISSUED", "CANCELLED"]);
+const avoirDraftStatus = z.literal("DRAFT");
 
 function emptyStringToUndefined(value: unknown) {
   if (typeof value !== "string") return value;
@@ -20,7 +22,7 @@ export const listAvoirsQuerySchema = z.object({
   q: z.string().optional(),
   client_id: z.string().optional(),
   facture_id: z.coerce.number().int().positive().optional(),
-  statut: z.string().optional(),
+  statut: avoirStatus.optional(),
   from: isoDate.optional(),
   to: isoDate.optional(),
   page: z.coerce.number().int().min(1).optional().default(1),
@@ -67,7 +69,7 @@ export const createAvoirBodySchema = z.object({
   client_id: z.string().trim().min(1),
   facture_id: z.coerce.number().int().positive().optional().nullable(),
   date_emission: z.preprocess(emptyStringToUndefined, isoDate).optional(),
-  statut: z.preprocess(emptyStringToUndefined, z.string().trim().min(1).max(40)).optional().default("brouillon"),
+  statut: z.preprocess(emptyStringToUndefined, avoirDraftStatus).optional().default("DRAFT"),
   motif: z.preprocess(emptyStringToNull, z.string().trim().min(1)).optional().nullable(),
   lignes: z.array(avoirLineSchema).min(1),
 });
@@ -79,7 +81,7 @@ export const updateAvoirBodySchema = z.object({
   client_id: z.string().trim().min(1).optional(),
   facture_id: z.coerce.number().int().positive().optional().nullable(),
   date_emission: z.preprocess(emptyStringToUndefined, isoDate).optional(),
-  statut: z.preprocess(emptyStringToUndefined, z.string().trim().min(1).max(40)).optional(),
+  statut: z.preprocess(emptyStringToUndefined, avoirDraftStatus).optional(),
   motif: z.preprocess(emptyStringToNull, z.string().trim().min(1)).optional().nullable(),
   lignes: z.array(avoirLineSchema).min(1).optional(),
 });

--- a/src/module/facturation/validators/factures.validators.ts
+++ b/src/module/facturation/validators/factures.validators.ts
@@ -1,6 +1,16 @@
 import { z } from "zod";
 
 const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date (expected YYYY-MM-DD)");
+const factureStatus = z.enum([
+  "DRAFT",
+  "PENDING_VALIDATION",
+  "APPROVED",
+  "ISSUED",
+  "PARTIALLY_PAID",
+  "PAID",
+  "CANCELLED",
+]);
+const factureDraftStatus = z.literal("DRAFT");
 
 function emptyStringToUndefined(value: unknown) {
   if (typeof value !== "string") return value;
@@ -20,7 +30,7 @@ export const listFacturesQuerySchema = z.object({
   q: z.string().optional(),
   client_id: z.string().optional(),
   commande_id: z.coerce.number().int().positive().optional(),
-  statut: z.string().optional(),
+  statut: factureStatus.optional(),
   from: isoDate.optional(),
   to: isoDate.optional(),
   page: z.coerce.number().int().min(1).optional().default(1),
@@ -70,7 +80,7 @@ export const createFactureBodySchema = z.object({
   affaire_id: z.coerce.number().int().positive().optional().nullable(),
   date_emission: z.preprocess(emptyStringToUndefined, isoDate).optional(),
   date_echeance: z.preprocess(emptyStringToNull, isoDate).optional().nullable(),
-  statut: z.preprocess(emptyStringToUndefined, z.string().trim().min(1).max(40)).optional().default("brouillon"),
+  statut: z.preprocess(emptyStringToUndefined, factureDraftStatus).optional().default("DRAFT"),
   remise_globale: z.coerce.number().min(0).optional().default(0),
   commentaires: z.preprocess(emptyStringToNull, z.string().trim().min(1)).optional().nullable(),
   lignes: z.array(factureLineSchema).min(1),
@@ -86,7 +96,7 @@ export const updateFactureBodySchema = z.object({
   affaire_id: z.coerce.number().int().positive().optional().nullable(),
   date_emission: z.preprocess(emptyStringToUndefined, isoDate).optional(),
   date_echeance: z.preprocess(emptyStringToNull, isoDate).optional().nullable(),
-  statut: z.preprocess(emptyStringToUndefined, z.string().trim().min(1).max(40)).optional(),
+  statut: z.preprocess(emptyStringToUndefined, factureDraftStatus).optional(),
   remise_globale: z.coerce.number().min(0).optional(),
   commentaires: z.preprocess(emptyStringToNull, z.string().trim().min(1)).optional().nullable(),
   lignes: z.array(factureLineSchema).min(1).optional(),

--- a/src/module/facturation/validators/factures.validators.ts
+++ b/src/module/facturation/validators/factures.validators.ts
@@ -1,15 +1,8 @@
 import { z } from "zod";
+import { FACTURE_LIST_FILTER_STATUSES } from "../domain/finance-policy";
 
 const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Invalid date (expected YYYY-MM-DD)");
-const factureStatus = z.enum([
-  "DRAFT",
-  "PENDING_VALIDATION",
-  "APPROVED",
-  "ISSUED",
-  "PARTIALLY_PAID",
-  "PAID",
-  "CANCELLED",
-]);
+const factureStatus = z.enum(FACTURE_LIST_FILTER_STATUSES);
 const factureDraftStatus = z.literal("DRAFT");
 
 function emptyStringToUndefined(value: unknown) {

--- a/src/module/facturation/validators/finance-status.validators.test.ts
+++ b/src/module/facturation/validators/finance-status.validators.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
 import { createAvoirBodySchema, updateAvoirBodySchema } from "./avoirs.validators";
-import { createFactureBodySchema, updateFactureBodySchema } from "./factures.validators";
+import {
+  createFactureBodySchema,
+  listFacturesQuerySchema,
+  updateFactureBodySchema,
+} from "./factures.validators";
 
 const invoiceDraft = {
   client_id: "CLIENT-1",
@@ -13,6 +17,17 @@ const creditDraft = {
 };
 
 describe("#469 finance write status validation", () => {
+  it.each(["LEGACY", "emis", "emise", "envoyee", "partielle", "payee", "brouillon", "annulee"])(
+    "keeps historical invoice status %s filterable",
+    (statut) => {
+      expect(listFacturesQuerySchema.parse({ statut }).statut).toBe(statut);
+    }
+  );
+
+  it("rejects arbitrary invoice status filters", () => {
+    expect(listFacturesQuerySchema.safeParse({ statut: "arbitrary" }).success).toBe(false);
+  });
+
   it("defaults legacy create payloads to the canonical draft status", () => {
     expect(createFactureBodySchema.parse(invoiceDraft).statut).toBe("DRAFT");
     expect(createAvoirBodySchema.parse(creditDraft).statut).toBe("DRAFT");

--- a/src/module/facturation/validators/finance-status.validators.test.ts
+++ b/src/module/facturation/validators/finance-status.validators.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { createAvoirBodySchema, updateAvoirBodySchema } from "./avoirs.validators";
+import { createFactureBodySchema, updateFactureBodySchema } from "./factures.validators";
+
+const invoiceDraft = {
+  client_id: "CLIENT-1",
+  lignes: [{ designation: "Prestation", prix_unitaire_ht: "100.00" }],
+};
+const creditDraft = {
+  client_id: "CLIENT-1",
+  lignes: [{ designation: "Correction", prix_unitaire_ht: "10.00" }],
+};
+
+describe("#469 finance write status validation", () => {
+  it("defaults legacy create payloads to the canonical draft status", () => {
+    expect(createFactureBodySchema.parse(invoiceDraft).statut).toBe("DRAFT");
+    expect(createAvoirBodySchema.parse(creditDraft).statut).toBe("DRAFT");
+  });
+
+  it.each(["custom", "paid", "ISSUED", "PARTIALLY_PAID", "CANCELLED"])(
+    "rejects invoice status %s on generic writes",
+    (statut) => {
+      expect(createFactureBodySchema.safeParse({ ...invoiceDraft, statut }).success).toBe(false);
+      expect(updateFactureBodySchema.safeParse({ statut }).success).toBe(false);
+    }
+  );
+
+  it.each(["custom", "issued", "ISSUED", "CANCELLED"])(
+    "rejects credit-note status %s on generic writes",
+    (statut) => {
+      expect(createAvoirBodySchema.safeParse({ ...creditDraft, statut }).success).toBe(false);
+      expect(updateAvoirBodySchema.safeParse({ statut }).success).toBe(false);
+    }
+  );
+});


### PR DESCRIPTION
Promotion contrôlée de la vague GPT-5.6 n°2 : contrat devis facultatif et intégrité finance/règlements. Validation sur le commit dev exact : suite backend complète et build TypeScript verts ; frontend compagnon 206 fichiers / 1932 tests, typecheck et build web verts. La migration finance est livrée avec preflight/verify/rollback mais n’a pas été exécutée.

## Summary by Sourcery

Separate immutable invoice document lifecycle from derived settlement state, harden payment/credit allocation invariants, and make preparatory quote fields optional while preserving legacy finance evidence and reporting semantics.

New Features:
- Introduce invoice settlement repository and APIs to derive and persist invoice settlement status from unified payment and credit evidence.
- Add optional preparatory fields on devis lines that are normalized when empty and validated when dossiers are provided without articles.
- Expose projected payment and invoice statuses plus allocated/available amounts in reporting and drilldown APIs, including unallocated payment scopes.

Bug Fixes:
- Prevent legacy directly-linked payments from being reallocated or converted to modern allocations and ensure they remain fully settled on their original invoice.
- Ensure invoice and credit note creation/update only accept controlled workflow statuses, avoiding arbitrary or inconsistent state writes.
- Fix over-allocation risks by enforcing database-level caps that include both modern allocations and direct legacy evidence in invoice balance checks.

Enhancements:
- Refine invoice listing and detail queries to use document/settlement status fields, net payment predicates, and non-duplicated legacy evidence for paid and credited totals.
- Update finance authorization middleware so inline payment allocations during registration require the payment allocation capability while plain registrations remain allowed.
- Improve finance reporting metrics and SQL to compute economically available payment amounts, treat legacy direct links as allocated, and align KPI and drilldown behaviour.
- Extend tests across finance, reporting, devis, and middleware to cover settlement derivation, legacy behaviour, authorization, and migration guards.
- Document the optional preparatory contract for devis and the new finance settlement and reporting behaviour in HTTP and reporting docs.

Build:
- Add guarded SQL migration patch and preflight/verify/rollback support scripts to introduce document/settlement status columns, constraints, and triggers for invoices and payments.

Documentation:
- Update devis workflow documentation to describe optional preparatory fields and their normalization semantics.
- Extend finance HTTP and reporting documentation to explain new payment listing endpoints, unallocated filters, settlement status derivation, and legacy direct evidence handling.

Tests:
- Add migration guard tests ensuring #469 settlement-state patch, support scripts, and trigger bindings match the expected contracts and remain rollback-safe.
- Add repository tests for invoice settlement, payment allocation workflows, reporting queries, finance status validators, and factures list filters, including legacy scenarios.
- Extend route and validator tests for devis to enforce the relationship between article and dossier preparatory data and ensure invalid payloads are rejected early.