### PR TITLE
fix units article stock contract

### DIFF
--- a/db/patches/20260804_article_unit_stock_contract.sql
+++ b/db/patches/20260804_article_unit_stock_contract.sql
@@ -1,0 +1,44 @@
+-- #475 / BUG-CERP-0013 — Canonical article/stock unit contract.
+--
+-- `public.units.code` is the sole referential used by stock movements and is
+-- now also validated when an article is created or updated. Existing article
+-- values are never rewritten: this additive seed makes the already accepted
+-- linear unit `mm` resolvable by the stock ledger.
+--
+-- Idempotent. Run the companion preflight/verify scripts manually on cerp_test;
+-- do not run this patch against production as part of this change.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.units') IS NULL THEN
+    RAISE EXCEPTION '#475: public.units is required before adding the mm unit';
+  END IF;
+END $$;
+
+-- Keep whether this patch introduced `mm`: rollback must never delete a unit
+-- that predated the patch. This tiny marker is dropped by the guarded rollback.
+CREATE TABLE IF NOT EXISTS public.cerp_patch_20260804_unit_mm (
+  singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+  inserted_by_patch boolean NOT NULL
+);
+
+DO $$
+DECLARE introduced boolean;
+BEGIN
+  SELECT inserted_by_patch INTO introduced
+  FROM public.cerp_patch_20260804_unit_mm
+  WHERE singleton = true;
+
+  IF introduced IS NULL THEN
+    IF EXISTS (SELECT 1 FROM public.units WHERE code = 'mm') THEN
+      INSERT INTO public.cerp_patch_20260804_unit_mm (singleton, inserted_by_patch) VALUES (true, false);
+    ELSE
+      INSERT INTO public.units (code, label) VALUES ('mm', 'Millimètre');
+      INSERT INTO public.cerp_patch_20260804_unit_mm (singleton, inserted_by_patch) VALUES (true, true);
+    END IF;
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/20260804_article_unit_stock_contract.sql
+++ b/db/patches/20260804_article_unit_stock_contract.sql
@@ -1,44 +1,63 @@
 -- #475 / BUG-CERP-0013 — Canonical article/stock unit contract.
 --
--- `public.units.code` is the sole referential used by stock movements and is
--- now also validated when an article is created or updated. Existing article
--- values are never rewritten: this additive seed makes the already accepted
--- linear unit `mm` resolvable by the stock ledger.
+-- public.units remains the authoritative referential. The application maps
+-- historical piece aliases (PCE/PCS/PC, any case) to `u` and normalises other
+-- codes to lower case without converting quantities. Existing article values
+-- are intentionally left untouched and remain readable through that adapter.
 --
--- Idempotent. Run the companion preflight/verify scripts manually on cerp_test;
--- do not run this patch against production as part of this change.
+-- The canonical codes observed in article, stock and production contracts are
+-- seeded additively: u already comes from 20260223; this patch ensures mm, m
+-- and kg. It is idempotent and records exactly which rows it introduced so the
+-- companion rollback cannot delete pre-existing reference data.
 
 BEGIN;
 
 DO $$
 BEGIN
   IF to_regclass('public.units') IS NULL THEN
-    RAISE EXCEPTION '#475: public.units is required before adding the mm unit';
+    RAISE EXCEPTION '#475: public.units is required';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.units WHERE lower(code::text) = 'u') THEN
+    RAISE EXCEPTION '#475: canonical base unit u must be seeded by 20260223 first';
   END IF;
 END $$;
 
--- Keep whether this patch introduced `mm`: rollback must never delete a unit
--- that predated the patch. This tiny marker is dropped by the guarded rollback.
-CREATE TABLE IF NOT EXISTS public.cerp_patch_20260804_unit_mm (
-  singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+CREATE TABLE IF NOT EXISTS public.cerp_patch_20260804_stock_units (
+  code text PRIMARY KEY,
+  unit_id text NOT NULL,
   inserted_by_patch boolean NOT NULL
 );
 
 DO $$
-DECLARE introduced boolean;
+DECLARE seed record;
+        v_unit_id text;
 BEGIN
-  SELECT inserted_by_patch INTO introduced
-  FROM public.cerp_patch_20260804_unit_mm
-  WHERE singleton = true;
+  FOR seed IN
+    SELECT * FROM (VALUES
+      ('mm'::text, 'Millimètre'::text),
+      ('m'::text,  'Mètre'::text),
+      ('kg'::text, 'Kilogramme'::text)
+    ) AS seeded(code, label)
+  LOOP
+    IF NOT EXISTS (SELECT 1 FROM public.cerp_patch_20260804_stock_units WHERE code = seed.code) THEN
+      SELECT id::text INTO v_unit_id
+      FROM public.units
+      WHERE lower(code::text) = seed.code
+      LIMIT 1;
 
-  IF introduced IS NULL THEN
-    IF EXISTS (SELECT 1 FROM public.units WHERE code = 'mm') THEN
-      INSERT INTO public.cerp_patch_20260804_unit_mm (singleton, inserted_by_patch) VALUES (true, false);
-    ELSE
-      INSERT INTO public.units (code, label) VALUES ('mm', 'Millimètre');
-      INSERT INTO public.cerp_patch_20260804_unit_mm (singleton, inserted_by_patch) VALUES (true, true);
+      IF v_unit_id IS NOT NULL THEN
+        INSERT INTO public.cerp_patch_20260804_stock_units (code, unit_id, inserted_by_patch)
+        VALUES (seed.code, v_unit_id, false);
+      ELSE
+        INSERT INTO public.units (code, label)
+        VALUES (seed.code, seed.label)
+        RETURNING id::text INTO v_unit_id;
+
+        INSERT INTO public.cerp_patch_20260804_stock_units (code, unit_id, inserted_by_patch)
+        VALUES (seed.code, v_unit_id, true);
+      END IF;
     END IF;
-  END IF;
+  END LOOP;
 END $$;
 
 COMMIT;

--- a/db/patches/support/20260804_article_unit_stock_contract.preflight.sql
+++ b/db/patches/support/20260804_article_unit_stock_contract.preflight.sql
@@ -1,0 +1,21 @@
+-- #475 preflight (READ-ONLY). Run on cerp_test before the additive patch.
+
+\echo '=== #475 preflight — confirm the target is not production ==='
+SELECT current_database() AS database, current_user AS role, inet_server_addr() AS server_addr;
+
+\echo ''
+\echo '=== Required canonical referential (present must be true) ==='
+SELECT to_regclass('public.units') IS NOT NULL AS units_table_present;
+
+\echo ''
+\echo '=== Existing unit codes (mm may be absent before apply) ==='
+SELECT code, label FROM public.units WHERE code IN ('u', 'mm') ORDER BY code;
+
+\echo ''
+\echo '=== Existing article values that would remain unresolved (investigate before enforcing) ==='
+SELECT a.unite, count(*) AS articles
+FROM public.articles a
+LEFT JOIN public.units u ON u.code = a.unite
+WHERE a.unite IS NOT NULL AND btrim(a.unite) <> '' AND u.code IS NULL
+GROUP BY a.unite
+ORDER BY articles DESC, a.unite;

--- a/db/patches/support/20260804_article_unit_stock_contract.preflight.sql
+++ b/db/patches/support/20260804_article_unit_stock_contract.preflight.sql
@@ -3,19 +3,74 @@
 \echo '=== #475 preflight — confirm the target is not production ==='
 SELECT current_database() AS database, current_user AS role, inet_server_addr() AS server_addr;
 
-\echo ''
-\echo '=== Required canonical referential (present must be true) ==='
-SELECT to_regclass('public.units') IS NOT NULL AS units_table_present;
+SELECT (to_regclass('public.units') IS NULL)::text AS units_missing \gset
+\if :units_missing
+  \echo 'BLOCKING: public.units is missing. Apply the stock foundation patches first.'
+  \quit 3
+\endif
+
+SELECT (NOT EXISTS (SELECT 1 FROM public.units WHERE lower(code::text) = 'u'))::text AS base_unit_missing \gset
+\if :base_unit_missing
+  \echo 'BLOCKING: canonical base unit u is missing. Apply 20260223_seed_currencies_units.sql first.'
+  \quit 3
+\endif
 
 \echo ''
-\echo '=== Existing unit codes (mm may be absent before apply) ==='
-SELECT code, label FROM public.units WHERE code IN ('u', 'mm') ORDER BY code;
+\echo '=== Case-insensitive duplicate unit codes (expect 0 rows) ==='
+SELECT lower(code::text) AS canonical, count(*) AS matching_rows
+FROM public.units
+GROUP BY lower(code::text)
+HAVING count(*) > 1
+ORDER BY canonical;
+
+SELECT EXISTS (
+  SELECT 1 FROM public.units GROUP BY lower(code::text) HAVING count(*) > 1
+)::text AS has_case_duplicates \gset
+\if :has_case_duplicates
+  \echo 'BLOCKING: case-insensitive duplicate unit codes make resolution ambiguous. Reconcile them before applying this patch.'
+  \quit 3
+\endif
 
 \echo ''
-\echo '=== Existing article values that would remain unresolved (investigate before enforcing) ==='
-SELECT a.unite, count(*) AS articles
-FROM public.articles a
-LEFT JOIN public.units u ON u.code = a.unite
-WHERE a.unite IS NOT NULL AND btrim(a.unite) <> '' AND u.code IS NULL
-GROUP BY a.unite
-ORDER BY articles DESC, a.unite;
+\echo '=== Existing/planned canonical codes ==='
+SELECT code, label FROM public.units WHERE lower(code::text) IN ('u', 'mm', 'm', 'kg') ORDER BY code;
+
+\echo ''
+\echo '=== Existing article values unresolved after aliases + planned seeds ==='
+WITH normalized AS (
+  SELECT unite,
+    CASE
+      WHEN lower(btrim(unite)) IN ('pc','pce','pces','pcs','piece','pieces','pièce','pièces','unit','units','unite','unites','unité','unités') THEN 'u'
+      ELSE lower(btrim(unite))
+    END AS canonical
+  FROM public.articles
+  WHERE unite IS NOT NULL AND btrim(unite) <> ''
+), available AS (
+  SELECT lower(code::text) AS code FROM public.units
+  UNION SELECT unnest(ARRAY['u','mm','m','kg'])
+)
+SELECT n.unite, n.canonical, count(*) AS articles
+FROM normalized n
+LEFT JOIN available a ON a.code = n.canonical
+WHERE a.code IS NULL
+GROUP BY n.unite, n.canonical
+ORDER BY articles DESC, n.unite;
+
+WITH normalized AS (
+  SELECT CASE
+    WHEN lower(btrim(unite)) IN ('pc','pce','pces','pcs','piece','pieces','pièce','pièces','unit','units','unite','unites','unité','unités') THEN 'u'
+    ELSE lower(btrim(unite))
+  END AS canonical
+  FROM public.articles
+  WHERE unite IS NOT NULL AND btrim(unite) <> ''
+), available AS (
+  SELECT lower(code::text) AS code FROM public.units
+  UNION SELECT unnest(ARRAY['u','mm','m','kg'])
+)
+SELECT (count(*) > 0)::text AS has_unresolved
+FROM normalized n LEFT JOIN available a ON a.code = n.canonical
+WHERE a.code IS NULL \gset
+\if :has_unresolved
+  \echo 'BLOCKING: unresolved article units remain. Add an explicit alias or canonical seed; never guess a quantity conversion.'
+  \quit 3
+\endif

--- a/db/patches/support/20260804_article_unit_stock_contract.rollback.sql
+++ b/db/patches/support/20260804_article_unit_stock_contract.rollback.sql
@@ -1,38 +1,40 @@
 -- #475 guarded rollback. Manual only; never rewrites article or stock history.
--- It removes the seeded code only when no article or stock level references it.
+-- Removes only unit rows proven to have been introduced by this patch.
 
 BEGIN;
 
 DO $$
+DECLARE seeded record;
 BEGIN
   IF current_database() = 'cerp_prod' THEN
     RAISE EXCEPTION '#475 rollback is refused on cerp_prod';
   END IF;
 
-  IF NOT EXISTS (
-    SELECT 1 FROM public.cerp_patch_20260804_unit_mm WHERE singleton = true AND inserted_by_patch = true
-  ) THEN
-    RAISE NOTICE '#475 rollback: mm existed before this patch; nothing to remove.';
-    RETURN;
-  END IF;
+  FOR seeded IN
+    SELECT code, unit_id FROM public.cerp_patch_20260804_stock_units
+    WHERE inserted_by_patch = true
+  LOOP
+    IF EXISTS (
+      SELECT 1 FROM public.articles
+      WHERE lower(btrim(unite)) = seeded.code
+    ) THEN
+      RAISE EXCEPTION '#475 rollback refused: articles reference unit %', seeded.code;
+    END IF;
 
-  IF EXISTS (SELECT 1 FROM public.articles WHERE unite = 'mm') THEN
-    RAISE EXCEPTION '#475 rollback refused: articles still reference unit mm';
-  END IF;
+    IF EXISTS (
+      SELECT 1
+      FROM public.stock_levels sl
+      WHERE sl.unit_id::text = seeded.unit_id
+    ) THEN
+      RAISE EXCEPTION '#475 rollback refused: stock levels reference unit %', seeded.code;
+    END IF;
 
-  IF EXISTS (
-    SELECT 1
-    FROM public.stock_levels sl
-    JOIN public.units u ON u.id = sl.unit_id
-    WHERE u.code = 'mm'
-  ) THEN
-    RAISE EXCEPTION '#475 rollback refused: stock levels still reference unit mm';
-  END IF;
-
-  DELETE FROM public.units WHERE code = 'mm';
-  DELETE FROM public.cerp_patch_20260804_unit_mm WHERE singleton = true;
+    DELETE FROM public.units
+    WHERE id::text = seeded.unit_id
+      AND lower(code::text) = seeded.code;
+  END LOOP;
 END $$;
 
-DROP TABLE IF EXISTS public.cerp_patch_20260804_unit_mm;
+DROP TABLE IF EXISTS public.cerp_patch_20260804_stock_units;
 
 COMMIT;

--- a/db/patches/support/20260804_article_unit_stock_contract.rollback.sql
+++ b/db/patches/support/20260804_article_unit_stock_contract.rollback.sql
@@ -1,0 +1,38 @@
+-- #475 guarded rollback. Manual only; never rewrites article or stock history.
+-- It removes the seeded code only when no article or stock level references it.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_database() = 'cerp_prod' THEN
+    RAISE EXCEPTION '#475 rollback is refused on cerp_prod';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.cerp_patch_20260804_unit_mm WHERE singleton = true AND inserted_by_patch = true
+  ) THEN
+    RAISE NOTICE '#475 rollback: mm existed before this patch; nothing to remove.';
+    RETURN;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.articles WHERE unite = 'mm') THEN
+    RAISE EXCEPTION '#475 rollback refused: articles still reference unit mm';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.stock_levels sl
+    JOIN public.units u ON u.id = sl.unit_id
+    WHERE u.code = 'mm'
+  ) THEN
+    RAISE EXCEPTION '#475 rollback refused: stock levels still reference unit mm';
+  END IF;
+
+  DELETE FROM public.units WHERE code = 'mm';
+  DELETE FROM public.cerp_patch_20260804_unit_mm WHERE singleton = true;
+END $$;
+
+DROP TABLE IF EXISTS public.cerp_patch_20260804_unit_mm;
+
+COMMIT;

--- a/db/patches/support/20260804_article_unit_stock_contract.verify.sql
+++ b/db/patches/support/20260804_article_unit_stock_contract.verify.sql
@@ -1,19 +1,66 @@
 -- #475 verification (READ-ONLY). Run after applying the patch on cerp_test.
 
-\echo '=== #475 verify — mm must be present exactly once ==='
-SELECT code, label, count(*) OVER (PARTITION BY code) AS matching_rows
+\echo '=== #475 verify — canonical units (expect u, mm, m, kg) ==='
+SELECT lower(code::text) AS code, label, count(*) AS matching_rows
 FROM public.units
-WHERE code = 'mm';
+WHERE lower(code::text) IN ('u', 'mm', 'm', 'kg')
+GROUP BY lower(code::text), label
+ORDER BY code;
+
+SELECT (count(*) <> 4)::text AS canonical_seed_invalid
+FROM public.units WHERE lower(code::text) IN ('u', 'mm', 'm', 'kg') \gset
+\if :canonical_seed_invalid
+  \echo 'BLOCKING: canonical unit seeds are missing or duplicated case-insensitively.'
+  \quit 3
+\endif
 
 \echo ''
-\echo '=== Rollback marker (true means this patch inserted mm) ==='
-SELECT singleton, inserted_by_patch FROM public.cerp_patch_20260804_unit_mm;
+\echo '=== Rollback provenance ==='
+SELECT code, unit_id, inserted_by_patch FROM public.cerp_patch_20260804_stock_units ORDER BY code;
+
+SELECT (
+  count(*) <> 3
+  OR bool_or(u.id IS NULL)
+)::text AS rollback_provenance_invalid
+FROM public.cerp_patch_20260804_stock_units marker
+LEFT JOIN public.units u
+  ON u.id::text = marker.unit_id
+ AND lower(u.code::text) = marker.code \gset
+\if :rollback_provenance_invalid
+  \echo 'BLOCKING: rollback provenance is incomplete or no longer identifies the exact seeded rows.'
+  \quit 3
+\endif
 
 \echo ''
-\echo '=== Article values absent from the canonical referential (expect 0 rows) ==='
-SELECT a.unite, count(*) AS articles
-FROM public.articles a
-LEFT JOIN public.units u ON u.code = a.unite
-WHERE a.unite IS NOT NULL AND btrim(a.unite) <> '' AND u.code IS NULL
-GROUP BY a.unite
-ORDER BY articles DESC, a.unite;
+\echo '=== Article values unresolved through canonical aliases (expect 0 rows) ==='
+WITH normalized AS (
+  SELECT unite,
+    CASE
+      WHEN lower(btrim(unite)) IN ('pc','pce','pces','pcs','piece','pieces','pièce','pièces','unit','units','unite','unites','unité','unités') THEN 'u'
+      ELSE lower(btrim(unite))
+    END AS canonical
+  FROM public.articles
+  WHERE unite IS NOT NULL AND btrim(unite) <> ''
+)
+SELECT n.unite, n.canonical, count(*) AS articles
+FROM normalized n
+LEFT JOIN public.units u ON lower(u.code::text) = n.canonical
+WHERE u.code IS NULL
+GROUP BY n.unite, n.canonical
+ORDER BY articles DESC, n.unite;
+
+WITH normalized AS (
+  SELECT CASE
+    WHEN lower(btrim(unite)) IN ('pc','pce','pces','pcs','piece','pieces','pièce','pièces','unit','units','unite','unites','unité','unités') THEN 'u'
+    ELSE lower(btrim(unite))
+  END AS canonical
+  FROM public.articles
+  WHERE unite IS NOT NULL AND btrim(unite) <> ''
+)
+SELECT (count(*) > 0)::text AS has_unresolved
+FROM normalized n LEFT JOIN public.units u ON lower(u.code::text) = n.canonical
+WHERE u.code IS NULL \gset
+\if :has_unresolved
+  \echo 'BLOCKING: unresolved article units remain. Add an explicit alias or canonical seed before rollout.'
+  \quit 3
+\endif

--- a/db/patches/support/20260804_article_unit_stock_contract.verify.sql
+++ b/db/patches/support/20260804_article_unit_stock_contract.verify.sql
@@ -1,0 +1,19 @@
+-- #475 verification (READ-ONLY). Run after applying the patch on cerp_test.
+
+\echo '=== #475 verify — mm must be present exactly once ==='
+SELECT code, label, count(*) OVER (PARTITION BY code) AS matching_rows
+FROM public.units
+WHERE code = 'mm';
+
+\echo ''
+\echo '=== Rollback marker (true means this patch inserted mm) ==='
+SELECT singleton, inserted_by_patch FROM public.cerp_patch_20260804_unit_mm;
+
+\echo ''
+\echo '=== Article values absent from the canonical referential (expect 0 rows) ==='
+SELECT a.unite, count(*) AS articles
+FROM public.articles a
+LEFT JOIN public.units u ON u.code = a.unite
+WHERE a.unite IS NOT NULL AND btrim(a.unite) <> '' AND u.code IS NULL
+GROUP BY a.unite
+ORDER BY articles DESC, a.unite;

--- a/src/__tests__/article-unit-stock-contract.test.ts
+++ b/src/__tests__/article-unit-stock-contract.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertCanonicalArticleUnit,
+  resolveUnitIdForArticle,
+} from "../module/stock/repository/stock.repository";
+
+const ARTICLE_ID = "11111111-1111-4111-8111-111111111111";
+const MILLIMETRE_UNIT_ID = "22222222-2222-4222-8222-222222222222";
+
+describe("#475 article/stock unit contract", () => {
+  it("accepts the canonical mm article unit and resolves it for a nominal stock movement", async () => {
+    const queries: Array<{ sql: string; values: unknown[] | undefined }> = [];
+    const client = {
+      query: async (sql: string, values?: unknown[]) => {
+        queries.push({ sql, values });
+        if (sql.includes("SELECT code FROM public.units")) return { rows: [{ code: "mm" }] };
+        if (sql.includes("SELECT unite FROM public.articles")) return { rows: [{ unite: "mm" }] };
+        if (sql.includes("SELECT id::text AS id FROM public.units")) return { rows: [{ id: MILLIMETRE_UNIT_ID }] };
+        return { rows: [] };
+      },
+    };
+
+    await expect(assertCanonicalArticleUnit(client, "mm")).resolves.toBeUndefined();
+    await expect(resolveUnitIdForArticle(client, ARTICLE_ID, null)).resolves.toBe(MILLIMETRE_UNIT_ID);
+    expect(queries.some(({ values }) => values?.[0] === "mm")).toBe(true);
+  });
+
+  it("rejects an invalid article unit before the article is persisted", async () => {
+    const client = { query: async () => ({ rows: [] }) };
+
+    await expect(assertCanonicalArticleUnit(client, "banane")).rejects.toMatchObject({
+      status: 400,
+      code: "INVALID_ARTICLE_UNIT",
+      message: expect.stringContaining("banane"),
+    });
+  });
+});

--- a/src/__tests__/article-unit-stock-contract.test.ts
+++ b/src/__tests__/article-unit-stock-contract.test.ts
@@ -1,27 +1,57 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
   assertCanonicalArticleUnit,
+  repoCreateArticleTx,
   resolveUnitIdForArticle,
 } from "../module/stock/repository/stock.repository";
+import { canonicalizeStockUnitCode } from "../shared/stock-unit";
+import { createArticleSchema } from "../module/stock/validators/stock.validators";
 
 const ARTICLE_ID = "11111111-1111-4111-8111-111111111111";
 const MILLIMETRE_UNIT_ID = "22222222-2222-4222-8222-222222222222";
 
 describe("#475 article/stock unit contract", () => {
-  it("accepts the canonical mm article unit and resolves it for a nominal stock movement", async () => {
+  it.each([
+    ["PCE", "u"], ["pcs", "u"], ["PC", "u"], [" unite ", "u"], ["U", "u"], ["MM", "mm"], ["Kg", "kg"], ["M", "m"],
+  ])("canonicalizes the historical stock unit %s as %s", (input, expected) => {
+    expect(canonicalizeStockUnitCode(input)).toBe(expected);
+  });
+
+  it("creates a real article with canonical mm then resolves its unit for a stock movement", async () => {
     const queries: Array<{ sql: string; values: unknown[] | undefined }> = [];
+    let storedUnit: string | null = null;
     const client = {
       query: async (sql: string, values?: unknown[]) => {
         queries.push({ sql, values });
-        if (sql.includes("SELECT code FROM public.units")) return { rows: [{ code: "mm" }] };
-        if (sql.includes("SELECT unite FROM public.articles")) return { rows: [{ unite: "mm" }] };
-        if (sql.includes("SELECT id::text AS id FROM public.units")) return { rows: [{ id: MILLIMETRE_UNIT_ID }] };
+        if (sql.includes("FROM public.units")) return { rows: [{ id: MILLIMETRE_UNIT_ID }] };
+        if (sql.includes("fn_next_issued_code_value")) return { rows: [{ v: "42" }] };
+        if (sql.includes("INSERT INTO public.articles (")) {
+          storedUnit = (values?.[9] as string | null) ?? null;
+          return { rows: [{ id: ARTICLE_ID }] };
+        }
+        if (sql.includes("SELECT unite FROM public.articles")) return { rows: [{ unite: storedUnit }] };
         return { rows: [] };
       },
     };
 
-    await expect(assertCanonicalArticleUnit(client, "mm")).resolves.toBeUndefined();
+    const body = createArticleSchema.parse({ body: {
+      designation: "Tôle 2 mm",
+      article_category: "achat",
+      article_categories: ["achat_revente"],
+      family_code: "ACH",
+      unite: "MM",
+    } }).body;
+    const audit = {
+      user_id: 1, ip: null, user_agent: null, device_type: null, os: null,
+      browser: null, path: "/api/v1/stock/articles", page_key: "stock", client_session_id: null,
+    };
+
+    const created = await repoCreateArticleTx(client as never, body, audit);
+    expect(created.id).toBe(ARTICLE_ID);
+    expect(storedUnit).toBe("mm");
     await expect(resolveUnitIdForArticle(client, ARTICLE_ID, null)).resolves.toBe(MILLIMETRE_UNIT_ID);
     expect(queries.some(({ values }) => values?.[0] === "mm")).toBe(true);
   });
@@ -34,5 +64,29 @@ describe("#475 article/stock unit contract", () => {
       code: "INVALID_ARTICLE_UNIT",
       message: expect.stringContaining("banane"),
     });
+  });
+
+  it("keeps preflight, verification and exact-row rollback guards coherent", () => {
+    const patch = readFileSync(resolve("db/patches/20260804_article_unit_stock_contract.sql"), "utf8");
+    const preflight = readFileSync(resolve("db/patches/support/20260804_article_unit_stock_contract.preflight.sql"), "utf8");
+    const verify = readFileSync(resolve("db/patches/support/20260804_article_unit_stock_contract.verify.sql"), "utf8");
+    const rollback = readFileSync(resolve("db/patches/support/20260804_article_unit_stock_contract.rollback.sql"), "utf8");
+
+    expect(patch).toMatch(/\('mm'::text, 'Millimètre'::text\)/);
+    expect(patch).toMatch(/\('m'::text,\s+'Mètre'::text\)/);
+    expect(patch).toMatch(/\('kg'::text, 'Kilogramme'::text\)/);
+    expect(patch).toContain("unit_id text NOT NULL");
+    expect(patch).not.toMatch(/UPDATE\s+public\.articles/i);
+
+    for (const guard of [preflight, verify]) {
+      expect(guard).toContain("'pc','pce','pces','pcs'");
+      expect(guard).toContain("'unit','units','unite','unites','unité','unités'");
+      expect(guard).toContain("\\quit 3");
+      expect(guard).toContain("has_unresolved");
+    }
+
+    expect(rollback).toContain("current_database() = 'cerp_prod'");
+    expect(rollback).toContain("id::text = seeded.unit_id");
+    expect(rollback).not.toMatch(/DELETE\s+FROM\s+public\.articles/i);
   });
 });

--- a/src/__tests__/article-unit-stock-contract.test.ts
+++ b/src/__tests__/article-unit-stock-contract.test.ts
@@ -1,6 +1,42 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const routeDb = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => ({
+  Pool: vi.fn(() => ({
+    on: vi.fn(),
+    query: routeDb.poolQuery,
+    connect: routeDb.poolConnect,
+  })),
+}));
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; role: string } },
+    _res: unknown,
+    next: () => void
+  ) => {
+    req.user = { id: 1, role: "Administrateur Systeme et Reseau" };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
 
 import {
   assertCanonicalArticleUnit,
@@ -9,9 +45,27 @@ import {
 } from "../module/stock/repository/stock.repository";
 import { canonicalizeStockUnitCode } from "../shared/stock-unit";
 import { createArticleSchema } from "../module/stock/validators/stock.validators";
+import app from "../config/app";
 
 const ARTICLE_ID = "11111111-1111-4111-8111-111111111111";
 const MILLIMETRE_UNIT_ID = "22222222-2222-4222-8222-222222222222";
+const MAGASIN_ID = "33333333-3333-4333-8333-333333333333";
+const WAREHOUSE_ID = "44444444-4444-4444-8444-444444444444";
+const LOCATION_ID = "55555555-5555-4555-8555-555555555555";
+const STOCK_LEVEL_ID = "66666666-6666-4666-8666-666666666666";
+const MOVEMENT_ID = "77777777-7777-4777-8777-777777777777";
+const MOVEMENT_LINE_ID = "88888888-8888-4888-8888-888888888888";
+
+beforeEach(() => {
+  routeDb.poolQuery.mockReset();
+  routeDb.poolConnect.mockReset();
+  routeDb.clientQuery.mockReset();
+  routeDb.clientRelease.mockReset();
+  routeDb.poolConnect.mockResolvedValue({
+    query: routeDb.clientQuery,
+    release: routeDb.clientRelease,
+  });
+});
 
 describe("#475 article/stock unit contract", () => {
   it.each([
@@ -54,6 +108,294 @@ describe("#475 article/stock unit contract", () => {
     expect(storedUnit).toBe("mm");
     await expect(resolveUnitIdForArticle(client, ARTICLE_ID, null)).resolves.toBe(MILLIMETRE_UNIT_ID);
     expect(queries.some(({ values }) => values?.[0] === "mm")).toBe(true);
+  });
+
+  it("creates an article then a stock movement through the real HTTP/service/repository flow", async () => {
+    type QueryCall = { sql: string; values: unknown[] };
+    type ArticleState = {
+      id: string;
+      code: string;
+      designation: string;
+      article_type: string;
+      article_category: string;
+      article_categories: string[];
+      family_code: string;
+      stock_managed: boolean;
+      unite: string | null;
+      lot_tracking: boolean;
+      is_sold: boolean;
+      is_active: boolean;
+      status: string;
+    };
+
+    const state: {
+      queries: QueryCall[];
+      article: ArticleState | null;
+      stockLevel: {
+        id: string;
+        article_id: string;
+        unit_id: string;
+        warehouse_id: string;
+        location_id: string;
+      } | null;
+      movement: Record<string, unknown> | null;
+      movementLine: Record<string, unknown> | null;
+    } = {
+      queries: [],
+      article: null,
+      stockLevel: null,
+      movement: null,
+      movementLine: null,
+    };
+
+    const query = vi.fn(async (sql: unknown, rawValues?: unknown[]) => {
+      const text = String(sql);
+      const values = rawValues ?? [];
+      state.queries.push({ sql: text, values });
+
+      if (text === "BEGIN" || text === "COMMIT" || text === "ROLLBACK") return { rows: [], rowCount: 0 };
+      if (text.includes("pg_advisory_xact_lock")) return { rows: [], rowCount: 1 };
+      if (text.includes("FROM public.article_create_idempotence")) return { rows: [], rowCount: 0 };
+      if (text.includes("FROM public.stock_command_receipts")) return { rows: [], rowCount: 0 };
+      if (text.includes("FROM public.units")) {
+        return values[0] === "mm"
+          ? { rows: [{ id: MILLIMETRE_UNIT_ID }], rowCount: 1 }
+          : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("fn_next_issued_code_value")) return { rows: [{ v: "42" }], rowCount: 1 };
+      if (text.includes("INSERT INTO public.articles (")) {
+        state.article = {
+          id: String(values[0]),
+          code: String(values[1]),
+          designation: String(values[2]),
+          article_type: String(values[4]),
+          article_category: String(values[5]),
+          article_categories: ["achat_revente"],
+          family_code: String(values[6]),
+          stock_managed: Boolean(values[7]),
+          unite: values[9] == null ? null : String(values[9]),
+          lot_tracking: Boolean(values[16]),
+          is_sold: Boolean(values[17]),
+          is_active: Boolean(values[18]),
+          status: String(values[14]),
+        };
+        return { rows: [{ id: state.article.id }], rowCount: 1 };
+      }
+      if (text.includes("SELECT stock_managed, lot_tracking FROM public.articles")) {
+        return state.article
+          ? { rows: [{ stock_managed: state.article.stock_managed, lot_tracking: state.article.lot_tracking }], rowCount: 1 }
+          : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("SELECT unite FROM public.articles")) {
+        return state.article ? { rows: [{ unite: state.article.unite }], rowCount: 1 } : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("FROM public.emplacements e") && text.includes("JOIN public.magasins m")) {
+        return {
+          rows: [{
+            magasin_id: MAGASIN_ID,
+            location_id: LOCATION_ID,
+            warehouse_id: WAREHOUSE_ID,
+            emplacement_active: true,
+            magasin_active: true,
+            location_type: "STORAGE",
+            allow_inbound: true,
+            allow_outbound: true,
+            restrictions: {},
+          }],
+          rowCount: 1,
+        };
+      }
+      if (text.includes("INSERT INTO public.stock_levels (")) {
+        state.stockLevel = {
+          id: STOCK_LEVEL_ID,
+          article_id: String(values[0]),
+          unit_id: String(values[1]),
+          warehouse_id: String(values[2]),
+          location_id: String(values[3]),
+        };
+        return { rows: [], rowCount: 1 };
+      }
+      if (text.includes("FROM public.stock_levels") && text.includes("article_id = $1::uuid")) {
+        return state.stockLevel ? { rows: [state.stockLevel], rowCount: 1 } : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("SELECT nextval('public.stock_movement_no_seq')")) {
+        return { rows: [{ n: "7" }], rowCount: 1 };
+      }
+      if (text.includes("INSERT INTO public.stock_movements (")) {
+        state.movement = {
+          id: MOVEMENT_ID,
+          movement_no: values[0],
+          movement_type: values[1],
+          status: "DRAFT",
+          article_id: values[2],
+          stock_level_id: values[3],
+          stock_batch_id: values[4],
+          qty: values[5],
+          effective_at: values[6],
+          posted_at: null,
+          source_document_type: values[7],
+          source_document_id: values[8],
+          reason_code: values[9],
+          notes: values[10],
+          correlation_id: values[12],
+          reversal_of_id: null,
+          created_at: "2026-08-04T10:00:00.000Z",
+          updated_at: "2026-08-04T10:00:00.000Z",
+          created_by: values[13],
+          updated_by: values[13],
+          posted_by: null,
+        };
+        return { rows: [{ id: MOVEMENT_ID }], rowCount: 1 };
+      }
+      if (text.includes("INSERT INTO public.stock_movement_lines (")) {
+        state.movementLine = {
+          id: MOVEMENT_LINE_ID,
+          movement_id: values[0],
+          line_no: values[1],
+          article_id: values[2],
+          article_code: state.article?.code,
+          article_designation: state.article?.designation,
+          lot_id: values[3],
+          lot_code: null,
+          qty: values[4],
+          unite: values[5],
+          unit_cost: values[6],
+          currency: values[7],
+          src_magasin_id: values[8],
+          src_magasin_code: null,
+          src_magasin_name: null,
+          src_emplacement_id: values[9],
+          src_emplacement_code: null,
+          src_emplacement_name: null,
+          dst_magasin_id: values[10],
+          dst_magasin_code: "MAG-01",
+          dst_magasin_name: "Magasin principal",
+          dst_emplacement_id: values[11],
+          dst_emplacement_code: "RACK-01",
+          dst_emplacement_name: "Rack 01",
+          note: values[12],
+          direction: values[13],
+        };
+        return { rows: [], rowCount: 1 };
+      }
+      if (text.includes("FROM public.stock_movements") && text.includes("WHERE id = $1::uuid")) {
+        return state.movement ? { rows: [state.movement], rowCount: 1 } : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("FROM public.stock_movement_lines l")) {
+        return state.movementLine ? { rows: [state.movementLine], rowCount: 1 } : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("FROM public.stock_movement_documents md")) return { rows: [], rowCount: 0 };
+      if (text.includes("FROM public.stock_movement_event_log")) return { rows: [], rowCount: 0 };
+      if (text.includes("FROM public.articles a") && text.includes("WHERE a.id = $1::uuid")) {
+        if (!state.article) return { rows: [], rowCount: 0 };
+        return {
+          rows: [{
+            ...state.article,
+            root_article_id: state.article.id,
+            parent_article_id: null,
+            version_number: 1,
+            plan_index: 1,
+            projet_id: null,
+            piece_technique_id: null,
+            piece_code: null,
+            piece_designation: null,
+            row_version: 1,
+            archived_at: null,
+            archive_reason: null,
+            applicable_version: null,
+            notes: null,
+            article_matiere: null,
+            fourniture_client: null,
+            qty_available: 0,
+            qty_reserved: 0,
+            qty_total: 0,
+            locations_count: 0,
+            updated_at: "2026-08-04T10:00:00.000Z",
+            created_at: "2026-08-04T10:00:00.000Z",
+          }],
+          rowCount: 1,
+        };
+      }
+      if (text.includes("SELECT 1::int AS ok FROM public.articles")) {
+        return state.article ? { rows: [{ ok: 1 }], rowCount: 1 } : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("FROM public.article_procurement_profile")) return { rows: [], rowCount: 0 };
+      if (text.includes("FROM public.fournisseur_catalogue")) return { rows: [], rowCount: 0 };
+      if (text.includes("FROM public.article_documents")) return { rows: [], rowCount: 0 };
+
+      return { rows: [], rowCount: 0 };
+    });
+
+    routeDb.clientQuery.mockImplementation(query);
+    routeDb.poolQuery.mockImplementation(query);
+
+    const articleResponse = await request(app)
+      .post("/api/v1/stock/articles")
+      .set("Authorization", "Bearer fake")
+      .set("Idempotency-Key", "contract-article-mm-001")
+      .send({
+        designation: "Plaque 2 mm",
+        article_category: "achat",
+        article_categories: ["achat_revente"],
+        family_code: "ACH",
+        unite: "MM",
+      });
+
+    expect(articleResponse.status).toBe(201);
+    expect(articleResponse.body).toMatchObject({ id: state.article?.id, unite: "mm", stock_managed: true });
+    const movementQueryStart = state.queries.length;
+
+    const movementResponse = await request(app)
+      .post("/api/v1/stock/movements")
+      .set("Authorization", "Bearer fake")
+      .set("Idempotency-Key", "contract-movement-mm-001")
+      .send({
+        movement_type: "IN",
+        lines: [{
+          article_id: articleResponse.body.id,
+          qty: 5,
+          dst_magasin_id: MAGASIN_ID,
+          dst_emplacement_id: 1,
+        }],
+      });
+
+    expect(movementResponse.status).toBe(201);
+    expect(movementResponse.body).toMatchObject({
+      movement: {
+        id: MOVEMENT_ID,
+        article_id: articleResponse.body.id,
+        stock_level_id: STOCK_LEVEL_ID,
+        qty: 5,
+      },
+      lines: [{ movement_id: MOVEMENT_ID, article_id: articleResponse.body.id, qty: 5 }],
+    });
+    expect(state.stockLevel).toEqual({
+      id: STOCK_LEVEL_ID,
+      article_id: articleResponse.body.id,
+      unit_id: MILLIMETRE_UNIT_ID,
+      warehouse_id: WAREHOUSE_ID,
+      location_id: LOCATION_ID,
+    });
+    expect(state.movement).toMatchObject({
+      id: MOVEMENT_ID,
+      article_id: articleResponse.body.id,
+      stock_level_id: STOCK_LEVEL_ID,
+    });
+    expect(state.movementLine).toMatchObject({
+      movement_id: MOVEMENT_ID,
+      article_id: articleResponse.body.id,
+      dst_magasin_id: MAGASIN_ID,
+      dst_emplacement_id: 1,
+    });
+
+    const movementQueries = state.queries.slice(movementQueryStart);
+    expect(movementQueries).toEqual(expect.arrayContaining([
+      expect.objectContaining({ sql: expect.stringContaining("SELECT unite FROM public.articles"), values: [articleResponse.body.id] }),
+      expect.objectContaining({ sql: expect.stringContaining("FROM public.units"), values: ["mm"] }),
+      expect.objectContaining({ sql: expect.stringContaining("INSERT INTO public.stock_levels") }),
+      expect.objectContaining({ sql: expect.stringContaining("INSERT INTO public.stock_movements") }),
+      expect.objectContaining({ sql: expect.stringContaining("INSERT INTO public.stock_movement_lines") }),
+    ]));
   });
 
   it("rejects an invalid article unit before the article is persisted", async () => {

--- a/src/__tests__/stock-unit-resolvers.test.ts
+++ b/src/__tests__/stock-unit-resolvers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveUnitIdForArticle as resolveDeliveryUnit } from "../module/livraisons/repository/livraisons.repository";
+import { resolveUnitIdForArticle as resolveProductionUnit } from "../module/production/repository/production-receipts.repository";
+import { resolveUnitIdForArticle as resolveQualityUnit } from "../module/qualite/repository/qualite.repository";
+import { resolveUnitIdForArticle as resolveStockUnit } from "../module/stock/repository/stock.repository";
+
+const ARTICLE_ID = "11111111-1111-4111-8111-111111111111";
+const UNIT_ID = "22222222-2222-4222-8222-222222222222";
+
+type Resolution = string | { unit_id: string; unit_code: string };
+type Resolver = (db: never, articleId: string, preferred: null) => Promise<Resolution>;
+
+const resolvers: Array<[string, Resolver, number, string]> = [
+  ["stock", resolveStockUnit as Resolver, 400, "UNKNOWN_UNIT"],
+  ["production", resolveProductionUnit as Resolver, 422, "UNIT_NOT_FOUND"],
+  ["livraison", resolveDeliveryUnit as Resolver, 400, "UNKNOWN_UNIT"],
+  ["qualité", resolveQualityUnit as Resolver, 400, "UNKNOWN_UNIT"],
+];
+
+function databaseWithHistoricalArticle(unit: string) {
+  const query = vi.fn(async (sql: string, values?: unknown[]) => {
+    if (sql.includes("FROM public.articles")) return { rows: [{ unite: unit }], rowCount: 1 };
+    if (sql.includes("FROM public.units")) {
+      return values?.[0] === "banane"
+        ? { rows: [], rowCount: 0 }
+        : { rows: [{ id: UNIT_ID }], rowCount: 1 };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  return { db: { query } as never, query };
+}
+
+describe("#475 historical unit adapters across stock-producing modules", () => {
+  it.each(resolvers)("canonicalizes PCE/PC/MM in %s before resolving public.units", async (_name, resolver) => {
+    for (const [historical, canonical] of [["PCE", "u"], ["PC", "u"], ["MM", "mm"]] as const) {
+      const { db, query } = databaseWithHistoricalArticle(historical);
+      const resolution = await resolver(db, ARTICLE_ID, null);
+
+      expect(resolution).toEqual(
+        _name === "production" ? { unit_id: UNIT_ID, unit_code: canonical } : UNIT_ID
+      );
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining("FROM public.units"),
+        [canonical]
+      );
+    }
+  });
+
+  it.each(resolvers)("rejects an unresolved historical unit in %s", async (_name, resolver, status, code) => {
+    const { db } = databaseWithHistoricalArticle("BANANE");
+    await expect(resolver(db, ARTICLE_ID, null)).rejects.toMatchObject({ status, code });
+  });
+});

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   poolConnect: vi.fn(),
   clientQuery: vi.fn(),
   clientRelease: vi.fn(),
+  currentRole: { value: "Administrateur Systeme et Reseau" },
 }));
 
 vi.mock("pg", () => {
@@ -35,7 +36,7 @@ vi.mock("../utils/checkNetworkDrive", () => ({
 
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authenticateToken: (req: { user?: { id: number; role: string } }, _res: unknown, next: () => void) => {
-    req.user = { id: 1, role: "Administrateur Systeme et Reseau" };
+    req.user = { id: 1, role: mocks.currentRole.value };
     next();
   },
   authorizeRole:
@@ -63,6 +64,7 @@ beforeEach(() => {
   mocks.poolConnect.mockReset();
   mocks.clientQuery.mockReset();
   mocks.clientRelease.mockReset();
+  mocks.currentRole.value = "Administrateur Systeme et Reseau";
 
   mocks.poolConnect.mockResolvedValue({
     query: mocks.clientQuery,
@@ -71,6 +73,19 @@ beforeEach(() => {
 });
 
 describe("/api/v1/stock", () => {
+  it("GET /api/v1/stock/units returns the canonical referential behind stock read access", async () => {
+    mocks.poolQuery.mockResolvedValueOnce({ rows: [{ code: "PCE", label: "Pièce" }, { code: "u", label: "Unité" }, { code: "MM", label: "Millimètre" }] });
+
+    const allowed = await request(app).get("/api/v1/stock/units").set("Authorization", "Bearer fake");
+    expect(allowed.status).toBe(200);
+    expect(allowed.body.items).toEqual([{ code: "mm", label: "Millimètre" }, { code: "u", label: "Unité" }]);
+
+    mocks.currentRole.value = "Commercial";
+    const denied = await request(app).get("/api/v1/stock/units").set("Authorization", "Bearer fake");
+    expect(denied.status).toBe(403);
+    expect(denied.body.code).toBe("STOCK_FORBIDDEN");
+  });
+
   it("GET /api/v1/stock/positions exposes the consolidated OLD/NEW read model", async () => {
     mocks.poolQuery
       .mockResolvedValueOnce({ rows: [{ total: 0 }] })
@@ -358,6 +373,34 @@ describe("/api/v1/stock", () => {
         String(call[0]).includes("LEFT JOIN LATERAL")
       )
     ).toBe(false);
+  });
+
+  it("PATCH /api/v1/stock/articles/:id rejects an unknown unit before UPDATE", async () => {
+    const articleId = "11111111-1111-1111-1111-111111111111";
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM public.articles") && q.includes("FOR UPDATE")) {
+        return { rows: [{
+          id: articleId, code: "ART-ACH-000001", designation: "Vis", article_type: "APPROVISIONNE",
+          article_category: "achat", article_categories: ["achat_revente"], root_article_id: articleId,
+          version_number: 1, plan_index: 1, status: "VALIDE", projet_id: null, family_code: "ACH",
+          piece_technique_id: null, stock_managed: true, lot_tracking: false, row_version: 2,
+          designation_secondary: null, is_sold: true,
+        }] };
+      }
+      if (q.includes("FROM public.units")) return { rows: [] };
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .patch(`/api/v1/stock/articles/${articleId}`)
+      .set("Authorization", "Bearer fake")
+      .send({ expected_row_version: 2, unite: "banane" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "INVALID_ARTICLE_UNIT" });
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("UPDATE public.articles"))).toBe(false);
   });
 
   it("PATCH /api/v1/stock/articles/:id persists Fourniture Client fields and returns them", async () => {

--- a/src/__tests__/surface-finish-210.routes.test.ts
+++ b/src/__tests__/surface-finish-210.routes.test.ts
@@ -215,6 +215,7 @@ function installQueryRouter(scenario: Scenario = {}) {
         : one(scenario.existingRequirement ?? requirementRow());
     }
     if (/fn_next_issued_code_value/.test(sql)) return one({ v: "123" });
+    if (/FROM public\.units/.test(sql)) return one({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", code: "u" });
     if (/INSERT INTO public\.articles\b/.test(sql)) return one({ id: ARTICLE_ID });
     if (/INSERT INTO erp_audit_logs/.test(sql)) {
       return one({ id: "audit-1", created_at: "2026-07-28T08:05:00.000Z" });
@@ -789,6 +790,12 @@ describe("#210 confirmation", () => {
       }
       if (/FROM public\.articles_traitement t/.test(sql)) return Promise.resolve({ rows: [], rowCount: 0 });
       if (/fn_next_issued_code_value/.test(sql)) return Promise.resolve({ rows: [{ v: "123" }], rowCount: 1 });
+      if (/FROM public\.units/.test(sql)) {
+        return Promise.resolve({
+          rows: [{ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", code: "u" }],
+          rowCount: 1,
+        });
+      }
       if (/INSERT INTO public\.articles\b/.test(sql)) return Promise.resolve({ rows: [{ id: ARTICLE_ID }], rowCount: 1 });
       if (/INSERT INTO erp_audit_logs/.test(sql)) {
         return Promise.resolve({ rows: [{ id: "a", created_at: "x" }], rowCount: 1 });

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -4,6 +4,7 @@ import crypto from "node:crypto"
 import type { PoolClient } from "pg"
 
 import pool from "../../../config/database"
+import { canonicalizeStockUnitCode } from "../../../shared/stock-unit"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 
@@ -186,7 +187,7 @@ async function reserveStockMovementNo(db: Queryable): Promise<string> {
   return stockMovementNoFromSeq(n)
 }
 
-async function resolveUnitIdForArticle(
+export async function resolveUnitIdForArticle(
   db: Queryable,
   articleId: string,
   preferredUnitCode: string | null | undefined
@@ -198,9 +199,12 @@ async function resolveUnitIdForArticle(
     const a = await db.query<{ unite: string | null }>(`SELECT unite FROM public.articles WHERE id = $1::uuid`, [articleId])
     code = a.rows[0]?.unite?.trim() ? a.rows[0].unite.trim() : null
   }
-  if (!code) code = "u"
+  code = canonicalizeStockUnitCode(code) ?? "u"
 
-  const u = await db.query<{ id: string }>(`SELECT id::text AS id FROM public.units WHERE code = $1`, [code])
+  const u = await db.query<{ id: string }>(
+    `SELECT id::text AS id FROM public.units WHERE lower(code::text) = lower($1) LIMIT 1`,
+    [code]
+  )
   const unitId = u.rows[0]?.id
   if (!unitId) {
     throw new HttpError(400, "UNKNOWN_UNIT", `Unknown unit code: ${code}`)

--- a/src/module/production/repository/production-receipts.repository.ts
+++ b/src/module/production/repository/production-receipts.repository.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "crypto";
 
 import pool from "../../../config/database";
 import { generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
+import { canonicalizeStockUnitCode } from "../../../shared/stock-unit";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
@@ -354,7 +355,7 @@ export async function reserveProducedQtyForCommandeLine(
   return reservationId ? { reservation_id: reservationId, qty_reserved: qtyToReserve } : null;
 }
 
-async function resolveUnitIdForArticle(
+export async function resolveUnitIdForArticle(
   client: Pick<PoolClient, "query">,
   articleId: string,
   preferredUnitCode: string | null | undefined
@@ -370,12 +371,13 @@ async function resolveUnitIdForArticle(
     code = a.rows[0]?.unite?.trim() ? a.rows[0].unite!.trim() : null;
   }
 
+  code = canonicalizeStockUnitCode(code);
   if (!code) {
     throw new HttpError(422, "UNIT_REQUIRED", "Veuillez renseigner l'unite pour la mise en stock");
   }
 
   const u = await client.query<{ id: string }>(
-    `SELECT id::text AS id FROM public.units WHERE code = $1::citext LIMIT 1`,
+    `SELECT id::text AS id FROM public.units WHERE lower(code::text) = lower($1) LIMIT 1`,
     [code]
   );
   const unitId = u.rows[0]?.id;

--- a/src/module/qualite/repository/qualite.repository.ts
+++ b/src/module/qualite/repository/qualite.repository.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 
 import pool from "../../../config/database";
 import { generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
+import { canonicalizeStockUnitCode } from "../../../shared/stock-unit";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -2696,16 +2697,19 @@ async function reserveStockMovementNo(tx: DbQueryer): Promise<string> {
   return movementNoFromSeq(n);
 }
 
-async function resolveUnitIdForArticle(tx: DbQueryer, articleId: string, preferredUnitCode: string | null | undefined): Promise<string> {
+export async function resolveUnitIdForArticle(tx: DbQueryer, articleId: string, preferredUnitCode: string | null | undefined): Promise<string> {
   const preferred = preferredUnitCode?.trim() ? preferredUnitCode.trim() : null;
   let code: string | null = preferred;
   if (!code) {
     const a = await tx.query<{ unite: string | null }>(`SELECT unite FROM public.articles WHERE id = $1::uuid`, [articleId]);
     code = a.rows[0]?.unite?.trim() ? a.rows[0].unite.trim() : null;
   }
-  if (!code) code = "u";
+  code = canonicalizeStockUnitCode(code) ?? "u";
 
-  const u = await tx.query<{ id: string }>(`SELECT id::text AS id FROM public.units WHERE code = $1`, [code]);
+  const u = await tx.query<{ id: string }>(
+    `SELECT id::text AS id FROM public.units WHERE lower(code::text) = lower($1) LIMIT 1`,
+    [code]
+  );
   const unitId = u.rows[0]?.id;
   if (!unitId) {
     throw new HttpError(400, "UNKNOWN_UNIT", `Unknown unit code: ${code}`);

--- a/src/module/stock/controllers/stock.controller.ts
+++ b/src/module/stock/controllers/stock.controller.ts
@@ -116,6 +116,7 @@ import {
   getStockArticleSVC,
   getStockArticlesKpisSVC,
   listStockArticleCategoriesSVC,
+  listStockUnitsSVC,
   listStockArticleFamiliesSVC,
   listStockMatiereEtatsSVC,
   listStockMatiereNuancesSVC,
@@ -438,6 +439,15 @@ export const listSimilarStockArticles: RequestHandler = async (req, res, next) =
 export const listStockArticleCategories: RequestHandler = async (_req, res, next) => {
   try {
     const out = await listStockArticleCategoriesSVC();
+    res.json({ items: out, total: out.length });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const listStockUnits: RequestHandler = async (_req, res, next) => {
+  try {
+    const out = await listStockUnitsSVC();
     res.json({ items: out, total: out.length });
   } catch (err) {
     next(err);

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -833,6 +833,13 @@ export async function repoListArticleCategories(): Promise<StockArticleCategoryO
   return ARTICLE_CATEGORY_OPTIONS;
 }
 
+export async function repoListStockUnits(): Promise<Array<{ code: string; label: string }>> {
+  const res = await db.query<{ code: string; label: string }>(
+    `SELECT code, label FROM public.units ORDER BY code ASC`
+  );
+  return res.rows;
+}
+
 export async function repoListArticleFamilies(
   filters: ListArticleFamiliesQueryDTO = {}
 ): Promise<StockArticleFamily[]> {
@@ -1894,7 +1901,32 @@ function parseEffectiveAt(raw: string | null | undefined): Date {
   return dt;
 }
 
-async function resolveUnitIdForArticle(
+/**
+ * `public.units.code` is the single stock-unit referential. Articles retain
+ * their unit as a code so every creation/update must check that code before it
+ * can later be used by a stock movement.
+ */
+export async function assertCanonicalArticleUnit(
+  client: Pick<PoolClient, "query">,
+  unitCode: string | null | undefined
+): Promise<void> {
+  const code = unitCode?.trim() ? unitCode.trim() : null;
+  if (!code) return;
+
+  const unit = await client.query<{ code: string }>(
+    `SELECT code FROM public.units WHERE code = $1`,
+    [code]
+  );
+  if (!unit.rows[0]) {
+    throw new HttpError(
+      400,
+      "INVALID_ARTICLE_UNIT",
+      `L'unité article « ${code} » est inconnue. Choisissez un code du référentiel public.units.`
+    );
+  }
+}
+
+export async function resolveUnitIdForArticle(
   client: Pick<PoolClient, "query">,
   articleId: string,
   preferredUnitCode: string | null | undefined
@@ -3122,6 +3154,8 @@ export async function repoCreateArticleTx(
   body: CreateArticleBodyDTO,
   audit: AuditContext
 ): Promise<CreatedArticleSummary> {
+  await assertCanonicalArticleUnit(client, body.unite);
+
   const normalized = await normalizeArticleState({
     article_type: body.article_type,
     article_category: body.article_category,
@@ -3524,6 +3558,10 @@ export async function repoUpdateArticle(
 
     if (current.stock_managed && !normalized.stock_managed) {
       await ensureArticleCanDisableStockManagement(client, id);
+    }
+
+    if (patch.unite !== undefined) {
+      await assertCanonicalArticleUnit(client, patch.unite);
     }
 
     if (patch.designation !== undefined) sets.push(`designation = ${push(patch.designation)}`);

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -21,6 +21,7 @@ import {
   type MaterialCodeResult,
   type MaterialProfileCode,
 } from "../../../shared/codes/material-article-code";
+import { canonicalizeStockUnitCode } from "../../../shared/stock-unit";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -837,7 +838,16 @@ export async function repoListStockUnits(): Promise<Array<{ code: string; label:
   const res = await db.query<{ code: string; label: string }>(
     `SELECT code, label FROM public.units ORDER BY code ASC`
   );
-  return res.rows;
+  const canonical = new Map<string, { code: string; label: string }>();
+  for (const row of res.rows) {
+    const code = canonicalizeStockUnitCode(row.code);
+    if (!code) continue;
+    const current = canonical.get(code);
+    if (!current || row.code.trim().toLowerCase() === code) {
+      canonical.set(code, { code, label: row.label });
+    }
+  }
+  return [...canonical.values()].sort((a, b) => a.code.localeCompare(b.code, "fr"));
 }
 
 export async function repoListArticleFamilies(
@@ -1906,24 +1916,35 @@ function parseEffectiveAt(raw: string | null | undefined): Date {
  * their unit as a code so every creation/update must check that code before it
  * can later be used by a stock movement.
  */
+async function findCanonicalStockUnit(
+  client: Pick<PoolClient, "query">,
+  unitCode: string | null | undefined
+): Promise<{ id: string | null; code: string } | null> {
+  const code = canonicalizeStockUnitCode(unitCode);
+  if (!code) return null;
+  const unit = await client.query<{ id: string | null }>(
+    `SELECT id::text AS id FROM public.units WHERE lower(code::text) = lower($1) LIMIT 1`,
+    [code]
+  );
+  const row = unit.rows[0];
+  return row ? { id: row.id, code } : null;
+}
+
 export async function assertCanonicalArticleUnit(
   client: Pick<PoolClient, "query">,
   unitCode: string | null | undefined
-): Promise<void> {
-  const code = unitCode?.trim() ? unitCode.trim() : null;
-  if (!code) return;
-
-  const unit = await client.query<{ code: string }>(
-    `SELECT code FROM public.units WHERE code = $1`,
-    [code]
-  );
-  if (!unit.rows[0]) {
+): Promise<string | null> {
+  if (!canonicalizeStockUnitCode(unitCode)) return null;
+  const unit = await findCanonicalStockUnit(client, unitCode);
+  if (!unit) {
+    const submitted = unitCode?.trim() ?? "";
     throw new HttpError(
       400,
       "INVALID_ARTICLE_UNIT",
-      `L'unité article « ${code} » est inconnue. Choisissez un code du référentiel public.units.`
+      `L'unité article « ${submitted} » est inconnue. Choisissez un code du référentiel des unités de stock.`
     );
   }
+  return unit.code;
 }
 
 export async function resolveUnitIdForArticle(
@@ -1931,8 +1952,7 @@ export async function resolveUnitIdForArticle(
   articleId: string,
   preferredUnitCode: string | null | undefined
 ): Promise<string> {
-  const preferred = preferredUnitCode?.trim() ? preferredUnitCode.trim() : null;
-  let code: string | null = preferred;
+  let code: string | null = preferredUnitCode?.trim() ? preferredUnitCode.trim() : null;
 
   if (!code) {
     const a = await client.query<{ unite: string | null }>(
@@ -1944,8 +1964,8 @@ export async function resolveUnitIdForArticle(
 
   if (!code) code = "u";
 
-  const u = await client.query<{ id: string }>(`SELECT id::text AS id FROM public.units WHERE code = $1`, [code]);
-  const unitId = u.rows[0]?.id;
+  const unit = await findCanonicalStockUnit(client, code);
+  const unitId = unit?.id;
   if (!unitId) {
     throw new HttpError(400, "UNKNOWN_UNIT", `Unknown unit code: ${code}`);
   }
@@ -3154,7 +3174,7 @@ export async function repoCreateArticleTx(
   body: CreateArticleBodyDTO,
   audit: AuditContext
 ): Promise<CreatedArticleSummary> {
-  await assertCanonicalArticleUnit(client, body.unite);
+  const canonicalUnit = await assertCanonicalArticleUnit(client, body.unite);
 
   const normalized = await normalizeArticleState({
     article_type: body.article_type,
@@ -3243,7 +3263,7 @@ export async function repoCreateArticleTx(
       normalized.family_code,
       normalized.stock_managed,
       normalized.piece_technique_id,
-      body.unite ?? null,
+      canonicalUnit,
       articleId,
       null,
       normalized.version_number,
@@ -3560,9 +3580,9 @@ export async function repoUpdateArticle(
       await ensureArticleCanDisableStockManagement(client, id);
     }
 
-    if (patch.unite !== undefined) {
-      await assertCanonicalArticleUnit(client, patch.unite);
-    }
+    const canonicalUnit = patch.unite !== undefined
+      ? await assertCanonicalArticleUnit(client, patch.unite)
+      : undefined;
 
     if (patch.designation !== undefined) sets.push(`designation = ${push(patch.designation)}`);
     if (patch.designation_secondary !== undefined) sets.push(`designation_secondary = ${push(patch.designation_secondary)}`);
@@ -3575,7 +3595,7 @@ export async function repoUpdateArticle(
     sets.push(`family_code = ${push(normalized.family_code)}`);
     sets.push(`stock_managed = ${push(normalized.stock_managed)}`);
     sets.push(`piece_technique_id = ${push(normalized.piece_technique_id)}::uuid`);
-    if (patch.unite !== undefined) sets.push(`unite = ${push(patch.unite)}`);
+    if (patch.unite !== undefined) sets.push(`unite = ${push(canonicalUnit ?? null)}`);
     sets.push(`lot_tracking = ${push(normalized.lot_tracking)}`);
     if (patch.is_sold !== undefined) sets.push(`is_sold = ${push(patch.is_sold)}`);
     if (patch.notes !== undefined) sets.push(`notes = ${push(patch.notes)}`);

--- a/src/module/stock/routes/stock.routes.ts
+++ b/src/module/stock/routes/stock.routes.ts
@@ -37,6 +37,7 @@ import {
   getStockInventorySession,
   getStockArticle,
   listStockArticleCategories,
+  listStockUnits,
   listStockArticleFamilies,
   getStockArticlesKpis,
   getStockLot,
@@ -130,6 +131,7 @@ router.get("/positions", requireStockCapability("read"), listConsolidatedInvento
 router.get("/inventory", requireStockCapability("read"), listConsolidatedInventory);
 router.post("/historical-imports", requireStockCapability("movement_create"), createHistoricalImport);
 router.get("/article-categories", requireStockCapability("read"), listStockArticleCategories);
+router.get("/units", requireStockCapability("read"), listStockUnits);
 router.get("/article-families", requireStockCapability("read"), listStockArticleFamilies);
 router.post("/article-families", requireArticleWrite, createStockArticleFamily);
 router.get("/matiere-nuances", requireStockCapability("read"), listStockMatiereNuances);

--- a/src/module/stock/services/stock.service.ts
+++ b/src/module/stock/services/stock.service.ts
@@ -99,6 +99,7 @@ import {
   repoGetStockAnalytics,
   repoGetArticle,
   repoListArticleCategories,
+  repoListStockUnits,
   repoListArticleFamilies,
   repoPreviewMaterialArticleCode,
   repoListMatiereEtats,
@@ -255,6 +256,10 @@ export async function getStockArticlesKpisSVC(): Promise<StockArticleKpis> {
 
 export async function listStockArticleCategoriesSVC(): Promise<StockArticleCategoryOption[]> {
   return repoListArticleCategories();
+}
+
+export async function listStockUnitsSVC(): Promise<Array<{ code: string; label: string }>> {
+  return repoListStockUnits();
 }
 
 export async function listStockArticleFamiliesSVC(filters: ListArticleFamiliesQueryDTO): Promise<StockArticleFamily[]> {

--- a/src/shared/stock-unit.ts
+++ b/src/shared/stock-unit.ts
@@ -1,0 +1,29 @@
+/**
+ * Canonical stock-unit vocabulary observed in CERP's historical article,
+ * import, surface-finish and production contracts.
+ *
+ * This adapter only normalises spelling and case. It never converts a
+ * quantity between units.
+ */
+const STOCK_UNIT_ALIASES: Readonly<Record<string, string>> = {
+  pc: "u",
+  pce: "u",
+  pces: "u",
+  pcs: "u",
+  piece: "u",
+  pieces: "u",
+  pièce: "u",
+  pièces: "u",
+  unit: "u",
+  units: "u",
+  unite: "u",
+  unites: "u",
+  unité: "u",
+  unités: "u",
+};
+
+export function canonicalizeStockUnitCode(unitCode: string | null | undefined): string | null {
+  const token = unitCode?.trim().normalize("NFKC").toLocaleLowerCase("fr-FR") ?? "";
+  if (!token) return null;
+  return STOCK_UNIT_ALIASES[token] ?? token;
+}


### PR DESCRIPTION
Closes BigFootLime/crp-systems-web#475.

Canonical stock-unit adapter shared by stock, production receipts, deliveries and quality: explicit PCE/PC/PCS aliases map to u, while other codes are case-normalized with no dimensional conversion. Article create/update stores canonical codes; historical values remain readable by every stock-producing resolver. The additive patch seeds mm, m and kg with exact-row rollback provenance. Preflight and verify fail on missing base data, case-insensitive duplicates or unresolved article units.

The nominal contract test now uses the real HTTP -> controller -> service -> repository flow: it creates an article submitted as MM, creates an IN movement without an explicit line unit, and verifies article-unit resolution, stock-level persistence, movement persistence and movement-line persistence through a stateful PostgreSQL double.

Tests:
- `npm run test:run -- src/__tests__/article-unit-stock-contract.test.ts` — 12 passed.
- `npm run test:run -- src/__tests__/article-unit-stock-contract.test.ts src/__tests__/stock-unit-resolvers.test.ts src/__tests__/stock.routes.test.ts src/module/production/repository/production-receipts.repository.test.ts` — 4 files, 33 passed.
- `npx vitest run --config vitest.config.ts --reporter=dot --silent=passed-only` — 173 files, 3601 passed.
- `npm run build` — passed.

No migration or SQL was executed. No production or persistent database was accessed.