### PR TITLE
fix(pieces-techniques): rendre l’idempotence transactionnelle

### DIFF
--- a/src/__tests__/piece-technique-document-policy-227.routes.test.ts
+++ b/src/__tests__/piece-technique-document-policy-227.routes.test.ts
@@ -350,6 +350,125 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
 
     expect(res.status).toBe(409);
   });
+
+  it("#309 — arbitre deux créations concurrentes dans la transaction et renvoie la même pièce", async () => {
+    const idempotencyKey = "wizard-309-concurrent-01";
+    let earlyReadCount = 0;
+    let releaseEarlyReads: (() => void) | undefined;
+    const bothEarlyReads = new Promise<void>((resolve) => {
+      releaseEarlyReads = resolve;
+    });
+    let stored:
+      | { key: string; requestHash: string; pieceId: string; core: Record<string, unknown> }
+      | null = null;
+    const transactionQueries: string[][] = [];
+
+    // Force les DEUX contrôleurs à observer « aucune clé » avant de laisser les
+    // transactions avancer : c'est exactement la fenêtre de course de la régression.
+    mocks.poolQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query.includes("piece_technique_create_idempotence")) {
+        earlyReadCount += 1;
+        if (earlyReadCount <= 2) {
+          if (earlyReadCount === 2) releaseEarlyReads?.();
+          await bothEarlyReads;
+          return { rows: [], rowCount: 0 };
+        }
+        return {
+          rows: stored
+            ? [{ piece_technique_id: stored.pieceId, request_hash: stored.requestHash }]
+            : [],
+          rowCount: stored ? 1 : 0,
+        };
+      }
+      if (query.includes("FROM pieces_techniques p") && stored) {
+        return { rows: [stored.core], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    mocks.poolConnect.mockImplementation(async () => {
+      const queries: string[] = [];
+      transactionQueries.push(queries);
+      let localCore: Record<string, unknown> | null = null;
+      const query = vi.fn(async (sql: unknown, params?: unknown[]) => {
+        const statement = String(sql);
+        queries.push(statement);
+        if (statement === "BEGIN" || statement === "COMMIT" || statement === "ROLLBACK") {
+          return { rows: [], rowCount: 0 };
+        }
+        if (statement.includes("piece_technique_create_idempotence") && statement.includes("FOR UPDATE")) {
+          return { rows: [], rowCount: 0 };
+        }
+        if (statement.includes("SELECT client_code FROM public.clients")) {
+          return { rows: [{ client_code: "045" }], rowCount: 1 };
+        }
+        if (statement.includes("INSERT INTO pieces_techniques (")) {
+          const pieceId = String(params?.[0]);
+          localCore = {
+            id: pieceId,
+            article_id: null,
+            root_piece_technique_id: pieceId,
+            parent_piece_technique_id: null,
+            version_number: 1,
+            created_at: "2026-08-04T00:00:00.000Z",
+            updated_at: "2026-08-04T00:00:00.000Z",
+            client_id: "045",
+            created_by: 42,
+            updated_by: 42,
+            famille_id: null,
+            name_piece: "Carter",
+            code_piece: "045-10233-000",
+            designation: "Carter aluminium",
+            designation_2: null,
+            prix_unitaire: 0,
+            statut: "DRAFT",
+            en_fabrication: 0,
+            cycle: null,
+            cycle_fabrication: null,
+            code_client: null,
+            client_name: "ACME",
+            ensemble: false,
+          };
+          return { rows: [localCore], rowCount: 1 };
+        }
+        if (statement.includes("INSERT INTO pieces_techniques_historique")) {
+          return {
+            rows: [{ id: "history-1", date_action: "2026-08-04T00:00:00.000Z" }],
+            rowCount: 1,
+          };
+        }
+        if (statement.includes("INSERT INTO public.piece_technique_create_idempotence")) {
+          if (stored) throw Object.assign(new Error("duplicate key"), { code: "23505" });
+          stored = {
+            key: String(params?.[0]),
+            requestHash: String(params?.[1]),
+            pieceId: String(params?.[2]),
+            core: localCore ?? {},
+          };
+          return { rows: [], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+      return { query, release: vi.fn() };
+    });
+
+    const makeRequest = () =>
+      request(app)
+        .post("/api/v1/pieces-techniques")
+        .set("x-test-role", roleHeader("Directeur"))
+        .set("Idempotency-Key", idempotencyKey)
+        .send(body);
+
+    const [first, second] = await Promise.all([makeRequest(), makeRequest()]);
+
+    expect([first.status, second.status]).toEqual([201, 201]);
+    expect(first.body.id).toBe(second.body.id);
+    expect(stored?.key).toBe(idempotencyKey);
+    const flattened = transactionQueries.flat();
+    expect(flattened.filter((query) => query === "COMMIT")).toHaveLength(1);
+    expect(flattened.filter((query) => query === "ROLLBACK").length).toBeGreaterThanOrEqual(1);
+  });
 });
 
 describe("#227 — brouillons : strictement privés à leur auteur", () => {

--- a/src/__tests__/piece-technique-document-policy-227.routes.test.ts
+++ b/src/__tests__/piece-technique-document-policy-227.routes.test.ts
@@ -256,6 +256,56 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
     ensemble: false,
   };
 
+  const replayBom = {
+    id: "44444444-4444-4444-8444-444444444444",
+    child_piece_id: "55555555-5555-4555-8555-555555555555",
+    rang: 10,
+    quantite: 2,
+    repere: "R1",
+    designation: "Sous-ensemble",
+  };
+  const replayOperation = {
+    id: "66666666-6666-4666-8666-666666666666",
+    phase: 10,
+    designation: "Usinage",
+    designation_2: null,
+    cf_id: null,
+    prix: 0,
+    coef: 1,
+    tp: 1,
+    tf_unit: 2,
+    qte: 1,
+    taux_horaire: 50,
+    temps_total: 3,
+    cout_mo: 150,
+  };
+  const replayAchat = {
+    id: "77777777-7777-4777-8777-777777777777",
+    phase: 10,
+    type_achat: "MATIERE",
+    famille_piece_id: null,
+    nom: "Aluminium",
+    fournisseur_id: null,
+    fournisseur_nom: null,
+    fournisseur_code: null,
+    quantite: 1,
+    quantite_brut_mm: null,
+    longueur_mm: null,
+    coefficient_chute: null,
+    quantite_pieces: null,
+    prix_par_quantite: null,
+    tarif: null,
+    prix: 10,
+    unite_prix: "kg",
+    pu_achat: 10,
+    tva_achat: 20,
+    total_achat_ht: 10,
+    total_achat_ttc: 12,
+    designation: "Aluminium",
+    designation_2: null,
+    designation_3: null,
+  };
+
   it("rejette une clé d'idempotence malformée", async () => {
     const res = await request(app)
       .post("/api/v1/pieces-techniques")
@@ -284,7 +334,16 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
           rowCount: 1,
         });
       }
-      if (String(sql).includes("FROM pieces_techniques") || String(sql).includes("FROM public.pieces_techniques")) {
+      if (String(sql).includes("FROM pieces_techniques_nomenclature")) {
+        return Promise.resolve({ rows: [replayBom], rowCount: 1 });
+      }
+      if (String(sql).includes("FROM pieces_techniques_operations")) {
+        return Promise.resolve({ rows: [replayOperation], rowCount: 1 });
+      }
+      if (String(sql).includes("FROM pieces_techniques_achats")) {
+        return Promise.resolve({ rows: [replayAchat], rowCount: 1 });
+      }
+      if (String(sql).includes("FROM pieces_techniques p") || String(sql).includes("FROM public.pieces_techniques p")) {
         return Promise.resolve({
           rows: [
             {
@@ -327,6 +386,9 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
 
     expect(res.status).toBe(200);
     expect(res.body.id).toBe(PIECE_ID);
+    expect(res.body.bom).toEqual([expect.objectContaining({ id: replayBom.id })]);
+    expect(res.body.operations).toEqual([expect.objectContaining({ id: replayOperation.id })]);
+    expect(res.body.achats).toEqual([expect.objectContaining({ id: replayAchat.id })]);
     // Aucune connexion transactionnelle : la pièce n'a PAS été recréée.
     expect(mocks.poolConnect).not.toHaveBeenCalled();
   });
@@ -351,7 +413,18 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
     expect(res.status).toBe(409);
   });
 
-  it("#309 — arbitre deux créations concurrentes dans la transaction et renvoie la même pièce", async () => {
+  it.each([
+    {
+      caseName: "rejoue en 200 deux créations concurrentes identiques",
+      secondBody: body,
+      expectedCode: null,
+    },
+    {
+      caseName: "refuse en 409 deux créations concurrentes de payloads différents",
+      secondBody: { ...body, designation: "Carter aluminium révisé" },
+      expectedCode: "IDEMPOTENCY_KEY_REUSED",
+    },
+  ])("#309 — $caseName", async ({ secondBody, expectedCode }) => {
     const idempotencyKey = "wizard-309-concurrent-01";
     let earlyReadCount = 0;
     let releaseEarlyReads: (() => void) | undefined;
@@ -362,6 +435,8 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
       | { key: string; requestHash: string; pieceId: string; core: Record<string, unknown> }
       | null = null;
     const transactionQueries: string[][] = [];
+    const releases: ReturnType<typeof vi.fn>[] = [];
+    let advisoryTail = Promise.resolve();
 
     // Force les DEUX contrôleurs à observer « aucune clé » avant de laisser les
     // transactions avancer : c'est exactement la fenêtre de course de la régression.
@@ -384,6 +459,15 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
       if (query.includes("FROM pieces_techniques p") && stored) {
         return { rows: [stored.core], rowCount: 1 };
       }
+      if (query.includes("FROM pieces_techniques_nomenclature")) {
+        return { rows: [replayBom], rowCount: 1 };
+      }
+      if (query.includes("FROM pieces_techniques_operations")) {
+        return { rows: [replayOperation], rowCount: 1 };
+      }
+      if (query.includes("FROM pieces_techniques_achats")) {
+        return { rows: [replayAchat], rowCount: 1 };
+      }
       return { rows: [], rowCount: 0 };
     });
 
@@ -391,14 +475,34 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
       const queries: string[] = [];
       transactionQueries.push(queries);
       let localCore: Record<string, unknown> | null = null;
+      let releaseAdvisory: (() => void) | null = null;
       const query = vi.fn(async (sql: unknown, params?: unknown[]) => {
         const statement = String(sql);
         queries.push(statement);
-        if (statement === "BEGIN" || statement === "COMMIT" || statement === "ROLLBACK") {
+        if (statement === "BEGIN") {
+          return { rows: [], rowCount: 0 };
+        }
+        if (statement.includes("pg_advisory_xact_lock")) {
+          const previous = advisoryTail;
+          advisoryTail = new Promise<void>((resolve) => {
+            releaseAdvisory = resolve;
+          });
+          await previous;
+          return { rows: [{ pg_advisory_xact_lock: null }], rowCount: 1 };
+        }
+        if (statement === "COMMIT" || statement === "ROLLBACK") {
+          const release = releaseAdvisory;
+          releaseAdvisory = null;
+          release?.();
           return { rows: [], rowCount: 0 };
         }
         if (statement.includes("piece_technique_create_idempotence") && statement.includes("FOR UPDATE")) {
-          return { rows: [], rowCount: 0 };
+          return {
+            rows: stored
+              ? [{ piece_technique_id: stored.pieceId, request_hash: stored.requestHash }]
+              : [],
+            rowCount: stored ? 1 : 0,
+          };
         }
         if (statement.includes("SELECT client_code FROM public.clients")) {
           return { rows: [{ client_code: "045" }], rowCount: 1 };
@@ -417,9 +521,9 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
             created_by: 42,
             updated_by: 42,
             famille_id: null,
-            name_piece: "Carter",
+            name_piece: String(params?.[9]),
             code_piece: "045-10233-000",
-            designation: "Carter aluminium",
+            designation: String(params?.[11]),
             designation_2: null,
             prix_unitaire: 0,
             statut: "DRAFT",
@@ -439,7 +543,12 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
           };
         }
         if (statement.includes("INSERT INTO public.piece_technique_create_idempotence")) {
-          if (stored) throw Object.assign(new Error("duplicate key"), { code: "23505" });
+          if (stored) {
+            throw Object.assign(new Error("duplicate key"), {
+              code: "23505",
+              constraint: "piece_technique_create_idempotence_pkey",
+            });
+          }
           stored = {
             key: String(params?.[0]),
             requestHash: String(params?.[1]),
@@ -450,24 +559,39 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
         }
         return { rows: [], rowCount: 0 };
       });
-      return { query, release: vi.fn() };
+      const release = vi.fn();
+      releases.push(release);
+      return { query, release };
     });
 
-    const makeRequest = () =>
+    const makeRequest = (requestBody: typeof body) =>
       request(app)
         .post("/api/v1/pieces-techniques")
         .set("x-test-role", roleHeader("Directeur"))
         .set("Idempotency-Key", idempotencyKey)
-        .send(body);
+        .send(requestBody);
 
-    const [first, second] = await Promise.all([makeRequest(), makeRequest()]);
+    const [first, second] = await Promise.all([makeRequest(body), makeRequest(secondBody)]);
 
-    expect([first.status, second.status]).toEqual([201, 201]);
-    expect(first.body.id).toBe(second.body.id);
+    expect([first.status, second.status].sort()).toEqual(expectedCode ? [201, 409] : [200, 201]);
+    if (expectedCode) {
+      const conflict = [first, second].find((response) => response.status === 409);
+      expect(conflict?.body.code).toBe(expectedCode);
+      expect(conflict?.body.code).not.toBe("CODE_ALREADY_EXISTS");
+    } else {
+      expect(first.body.id).toBe(second.body.id);
+      const replay = [first, second].find((response) => response.status === 200);
+      expect(replay?.body.bom).toEqual([expect.objectContaining({ id: replayBom.id })]);
+      expect(replay?.body.operations).toEqual([expect.objectContaining({ id: replayOperation.id })]);
+      expect(replay?.body.achats).toEqual([expect.objectContaining({ id: replayAchat.id })]);
+    }
     expect(stored?.key).toBe(idempotencyKey);
     const flattened = transactionQueries.flat();
     expect(flattened.filter((query) => query === "COMMIT")).toHaveLength(1);
     expect(flattened.filter((query) => query === "ROLLBACK").length).toBeGreaterThanOrEqual(1);
+    expect(flattened.filter((query) => query.includes("INSERT INTO erp_audit_logs"))).toHaveLength(1);
+    expect(releases).toHaveLength(2);
+    releases.forEach((release) => expect(release).toHaveBeenCalledTimes(1));
   });
 });
 

--- a/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
+++ b/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
@@ -62,6 +62,7 @@ import {
   updatePieceTechniqueStatusSVC,
   createPieceTechniqueSVC,
   pieceTechniqueCreateCompatibleRequestHashes,
+  createPieceTechniqueWithReplaySVC,
   attachPieceTechniqueDocumentsSVC,
   downloadPieceTechniqueDocumentSVC,
   listPieceTechniqueDocumentsSVC,
@@ -163,8 +164,8 @@ export const createPieceTechnique: RequestHandler = async (req, res, next) => {
 
     // La clé entre dans LA MÊME transaction que l'insertion métier. Le pré-contrôle
     // ci-dessus optimise le rejeu séquentiel ; l'unicité en base tranche les courses.
-    const out = await createPieceTechniqueSVC(body, audit, idempotencyKey)
-    res.status(201).json(out)
+    const out = await createPieceTechniqueWithReplaySVC(body, audit, idempotencyKey)
+    res.status(out.replayed ? 200 : 201).json(out.piece)
   } catch (err) {
     next(err)
   }

--- a/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
+++ b/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
@@ -1,12 +1,8 @@
 // src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
 import type { Request, RequestHandler } from "express"
-import crypto from "node:crypto"
 import fs from "node:fs/promises"
 import db from "../../../config/database"
-import {
-  repoFindIdempotentPieceCreate,
-  repoRecordIdempotentPieceCreate,
-} from "../repository/create-drafts.repository"
+import { repoFindIdempotentPieceCreate } from "../repository/create-drafts.repository"
 import { generatePieceTechniqueBusinessCode } from "../../../shared/codes/code-generator.service"
 import { getDocumentStoragePath, isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
@@ -65,6 +61,7 @@ import {
   updatePieceTechniqueSVC,
   updatePieceTechniqueStatusSVC,
   createPieceTechniqueSVC,
+  pieceTechniqueCreateCompatibleRequestHashes,
   attachPieceTechniqueDocumentsSVC,
   downloadPieceTechniqueDocumentSVC,
   listPieceTechniqueDocumentsSVC,
@@ -145,12 +142,12 @@ export const createPieceTechnique: RequestHandler = async (req, res, next) => {
       return
     }
 
-    const requestHash = crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex")
+    const compatibleRequestHashes = new Set(pieceTechniqueCreateCompatibleRequestHashes(body))
     const replay = await repoFindIdempotentPieceCreate(idempotencyKey)
     if (replay) {
       // Même clé, charge différente : c'est une erreur d'appelant, pas un rejeu. On refuse
       // plutôt que de renvoyer une pièce qui ne correspond pas à ce qui vient d'être envoyé.
-      if (replay.request_hash !== requestHash) {
+      if (!compatibleRequestHashes.has(replay.request_hash)) {
         throw new HttpError(
           409,
           "IDEMPOTENCY_KEY_REUSED",
@@ -164,8 +161,9 @@ export const createPieceTechnique: RequestHandler = async (req, res, next) => {
       }
     }
 
-    const out = await createPieceTechniqueSVC(body, audit)
-    await repoRecordIdempotentPieceCreate(idempotencyKey, requestHash, out.id)
+    // La clé entre dans LA MÊME transaction que l'insertion métier. Le pré-contrôle
+    // ci-dessus optimise le rejeu séquentiel ; l'unicité en base tranche les courses.
+    const out = await createPieceTechniqueSVC(body, audit, idempotencyKey)
     res.status(201).json(out)
   } catch (err) {
     next(err)

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -1648,6 +1648,28 @@ async function lookupClientCompanyName(tx: Pick<PoolClient, "query">, clientId: 
   return typeof name === "string" && name.trim().length > 0 ? name.trim() : null;
 }
 
+export const PIECE_TECHNIQUE_IDEMPOTENCY_CONSTRAINT = "piece_technique_create_idempotence_pkey";
+
+export type RepoCreatePieceTechniqueResult = {
+  piece: PieceTechnique;
+  replayed: boolean;
+};
+
+function idempotencyKeyReusedError(): HttpError {
+  return new HttpError(
+    409,
+    "IDEMPOTENCY_KEY_REUSED",
+    "Cette clé d’idempotence a déjà servi avec une autre pièce technique."
+  );
+}
+
+function isIdempotencyKeyUniqueViolation(err: unknown): boolean {
+  const pg = err as { code?: unknown; constraint?: unknown } | null;
+  return pg?.code === "23505" && pg.constraint === PIECE_TECHNIQUE_IDEMPOTENCY_CONSTRAINT;
+}
+
+const CREATE_REPLAY_INCLUDES = new Set(["nomenclature", "operations", "achats"]);
+
 export async function repoCreatePieceTechnique(
   body: CreatePieceTechniqueBodyDTO & {
     statut: PieceTechniqueStatut;
@@ -1659,7 +1681,7 @@ export async function repoCreatePieceTechnique(
   idempotencyKey?: string | null,
   validatedRequestHash?: string,
   compatibleRequestHashes: readonly string[] = []
-): Promise<PieceTechnique> {
+): Promise<RepoCreatePieceTechniqueResult> {
   const client = await db.connect();
   // Conserve le hash historique : une clé déjà consommée avant #404 doit
   // continuer à rejouer la même pièce, même si son ancien payload portait une
@@ -1671,6 +1693,13 @@ export async function repoCreatePieceTechnique(
     await client.query("BEGIN");
 
     if (idempotencyKey) {
+      // Un SELECT FOR UPDATE ne verrouille aucune « ligne absente ». Le verrou consultatif
+      // transactionnel sérialise donc toutes les créations portant LA MÊME clé avant la
+      // première écriture métier. Le second appel peut alors décider replay/409 proprement.
+      await client.query(
+        "SELECT pg_advisory_xact_lock(hashtext('piece-technique-create'), hashtext($1))",
+        [idempotencyKey]
+      );
       const replay = await client.query<{ piece_technique_id: string; request_hash: string }>(
         `SELECT piece_technique_id::text AS piece_technique_id, request_hash
          FROM public.piece_technique_create_idempotence
@@ -1680,12 +1709,12 @@ export async function repoCreatePieceTechnique(
       );
       if (replay.rows[0]) {
         if (!acceptedRequestHashes.has(replay.rows[0].request_hash)) {
-          throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Cette clé d’idempotence a déjà servi avec une autre pièce technique.");
+          throw idempotencyKeyReusedError();
         }
         await client.query("ROLLBACK");
-        const existing = await repoGetPieceTechnique(replay.rows[0].piece_technique_id, new Set());
+        const existing = await repoGetPieceTechnique(replay.rows[0].piece_technique_id, CREATE_REPLAY_INCLUDES);
         if (!existing) throw new Error("Idempotent piece technique no longer exists");
-        return existing;
+        return { piece: existing, replayed: true };
       }
     }
 
@@ -1859,19 +1888,24 @@ export async function repoCreatePieceTechnique(
     }
 
     await client.query("COMMIT");
-    return piece;
+    return { piece, replayed: false };
   } catch (err) {
     await client.query("ROLLBACK");
-    const code = (err as { code?: unknown } | null)?.code;
-    if (idempotencyKey && code === "23505") {
+    if (idempotencyKey && isIdempotencyKeyUniqueViolation(err)) {
       const replay = await db.query<{ piece_technique_id: string; request_hash: string }>(
         `SELECT piece_technique_id::text AS piece_technique_id, request_hash
          FROM public.piece_technique_create_idempotence WHERE idempotency_key = $1`,
         [idempotencyKey]
       );
-      if (replay.rows[0] && acceptedRequestHashes.has(replay.rows[0].request_hash)) {
-        const existing = await repoGetPieceTechnique(replay.rows[0].piece_technique_id, new Set());
-        if (existing) return existing;
+      if (replay.rows[0]) {
+        if (!acceptedRequestHashes.has(replay.rows[0].request_hash)) {
+          throw idempotencyKeyReusedError();
+        }
+        const existing = await repoGetPieceTechnique(
+          replay.rows[0].piece_technique_id,
+          CREATE_REPLAY_INCLUDES
+        );
+        if (existing) return { piece: existing, replayed: true };
       }
     }
     throw err;

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -1656,13 +1656,17 @@ export async function repoCreatePieceTechnique(
     achats: (AddAchatBodyDTO & { total_achat_ht: number; total_achat_ttc: number })[];
   },
   audit: AuditContext,
-  idempotencyKey?: string | null
+  idempotencyKey?: string | null,
+  validatedRequestHash?: string,
+  compatibleRequestHashes: readonly string[] = []
 ): Promise<PieceTechnique> {
   const client = await db.connect();
   // Conserve le hash historique : une clé déjà consommée avant #404 doit
   // continuer à rejouer la même pièce, même si son ancien payload portait une
   // famille choisie dans l'interface.
-  const requestHash = crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex");
+  const requestHash =
+    validatedRequestHash ?? crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex");
+  const acceptedRequestHashes = new Set([requestHash, ...compatibleRequestHashes]);
   try {
     await client.query("BEGIN");
 
@@ -1675,7 +1679,7 @@ export async function repoCreatePieceTechnique(
         [idempotencyKey]
       );
       if (replay.rows[0]) {
-        if (replay.rows[0].request_hash !== requestHash) {
+        if (!acceptedRequestHashes.has(replay.rows[0].request_hash)) {
           throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Cette clé d’idempotence a déjà servi avec une autre pièce technique.");
         }
         await client.query("ROLLBACK");
@@ -1865,7 +1869,7 @@ export async function repoCreatePieceTechnique(
          FROM public.piece_technique_create_idempotence WHERE idempotency_key = $1`,
         [idempotencyKey]
       );
-      if (replay.rows[0]?.request_hash === requestHash) {
+      if (replay.rows[0] && acceptedRequestHashes.has(replay.rows[0].request_hash)) {
         const existing = await repoGetPieceTechnique(replay.rows[0].piece_technique_id, new Set());
         if (existing) return existing;
       }

--- a/src/module/pieces-techniques/services/pieces-techniques-create-idempotence.test.ts
+++ b/src/module/pieces-techniques/services/pieces-techniques-create-idempotence.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ create: vi.fn() }));
+
+vi.mock("../repository/pieces-techniques.repository", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../repository/pieces-techniques.repository")>()),
+  repoCreatePieceTechnique: (...args: unknown[]) => mocks.create(...args),
+}));
+
+import type { CreatePieceTechniqueBodyDTO } from "../validators/pieces-techniques.validators";
+import {
+  createPieceTechniqueSVC,
+  pieceTechniqueCreateCompatibleRequestHashes,
+  pieceTechniqueCreateRequestHash,
+} from "./pieces-techniques.service";
+
+const body = {
+  client_id: "045",
+  name_piece: "Carter",
+  designation: "Carter aluminium",
+  plan_reference: "10233",
+  indice_externe: "000",
+  sans_indice: false,
+  prix_unitaire: 0,
+  statut: "DRAFT",
+  ensemble: false,
+  bom: [],
+  operations: [],
+  achats: [],
+} satisfies CreatePieceTechniqueBodyDTO;
+
+const audit = {
+  user_id: 42,
+  ip: null,
+  user_agent: null,
+  device_type: null,
+  os: null,
+  browser: null,
+  path: "/api/v1/pieces-techniques",
+  page_key: "pieces-techniques",
+  client_session_id: null,
+};
+
+describe("#309 — service de création idempotente", () => {
+  beforeEach(() => {
+    mocks.create.mockReset();
+    mocks.create.mockResolvedValue({ id: "piece-1", code_piece: "045-10233-000" });
+  });
+
+  it("transmet la clé et le hash du DTO validé au repository transactionnel", async () => {
+    await createPieceTechniqueSVC(body, audit, "wizard-309-key-01");
+
+    expect(mocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({ designation: "Carter aluminium", operations: [], achats: [] }),
+      audit,
+      "wizard-309-key-01",
+      pieceTechniqueCreateRequestHash(body),
+      pieceTechniqueCreateCompatibleRequestHashes(body)
+    );
+  });
+
+  it("produit un autre hash lorsque le payload métier change", () => {
+    expect(pieceTechniqueCreateRequestHash({ ...body, designation: "Carter révisé" })).not.toBe(
+      pieceTechniqueCreateRequestHash(body)
+    );
+  });
+
+  it("accepte les empreintes historiques DTO validé et DTO enrichi", () => {
+    const hashes = pieceTechniqueCreateCompatibleRequestHashes(body);
+
+    expect(hashes).toContain(pieceTechniqueCreateRequestHash(body));
+    expect(new Set(hashes).size).toBe(2);
+  });
+});

--- a/src/module/pieces-techniques/services/pieces-techniques-create-idempotence.test.ts
+++ b/src/module/pieces-techniques/services/pieces-techniques-create-idempotence.test.ts
@@ -10,6 +10,7 @@ vi.mock("../repository/pieces-techniques.repository", async (importOriginal) => 
 import type { CreatePieceTechniqueBodyDTO } from "../validators/pieces-techniques.validators";
 import {
   createPieceTechniqueSVC,
+  createPieceTechniqueWithReplaySVC,
   pieceTechniqueCreateCompatibleRequestHashes,
   pieceTechniqueCreateRequestHash,
 } from "./pieces-techniques.service";
@@ -44,7 +45,10 @@ const audit = {
 describe("#309 — service de création idempotente", () => {
   beforeEach(() => {
     mocks.create.mockReset();
-    mocks.create.mockResolvedValue({ id: "piece-1", code_piece: "045-10233-000" });
+    mocks.create.mockResolvedValue({
+      piece: { id: "piece-1", code_piece: "045-10233-000" },
+      replayed: false,
+    });
   });
 
   it("transmet la clé et le hash du DTO validé au repository transactionnel", async () => {
@@ -70,5 +74,50 @@ describe("#309 — service de création idempotente", () => {
 
     expect(hashes).toContain(pieceTechniqueCreateRequestHash(body));
     expect(new Set(hashes).size).toBe(2);
+  });
+
+  it("préserve le flag de rejeu pour le contrôleur HTTP sans casser l'appel historique", async () => {
+    mocks.create.mockResolvedValueOnce({
+      piece: { id: "piece-1", code_piece: "045-10233-000", bom: [], operations: [], achats: [] },
+      replayed: true,
+    });
+
+    const httpResult = await createPieceTechniqueWithReplaySVC(body, audit, "wizard-309-key-01");
+    expect(httpResult).toMatchObject({ replayed: true, piece: { id: "piece-1" } });
+
+    mocks.create.mockResolvedValueOnce({
+      piece: { id: "piece-1", code_piece: "045-10233-000" },
+      replayed: false,
+    });
+    await expect(createPieceTechniqueSVC(body, audit, "wizard-309-key-02")).resolves.toMatchObject({
+      id: "piece-1",
+    });
+  });
+
+  it("ne transforme jamais la contrainte d'idempotence en CODE_ALREADY_EXISTS", async () => {
+    const idempotencyViolation = Object.assign(new Error("duplicate idempotency key"), {
+      code: "23505",
+      constraint: "piece_technique_create_idempotence_pkey",
+    });
+    mocks.create.mockRejectedValueOnce(idempotencyViolation);
+
+    await expect(
+      createPieceTechniqueWithReplaySVC(body, audit, "wizard-309-key-01")
+    ).rejects.toBe(idempotencyViolation);
+  });
+
+  it("continue à traduire une autre contrainte unique métier", async () => {
+    mocks.create.mockRejectedValueOnce(
+      Object.assign(new Error("duplicate code"), {
+        code: "23505",
+        constraint: "pieces_techniques_code_piece_key",
+        detail: "Key (code_piece)=(045-10233-000) already exists",
+      })
+    );
+
+    await expect(createPieceTechniqueWithReplaySVC(body, audit, "wizard-309-key-01")).rejects.toMatchObject({
+      status: 409,
+      code: "CODE_ALREADY_EXISTS",
+    });
   });
 });

--- a/src/module/pieces-techniques/services/pieces-techniques.service.ts
+++ b/src/module/pieces-techniques/services/pieces-techniques.service.ts
@@ -1,4 +1,5 @@
 // src/module/pieces-techniques/services/pieces-techniques.service.ts
+import crypto from "node:crypto";
 import { HttpError } from "../../../utils/httpError";
 import type { PieceTechniqueStatut } from "../types/pieces-techniques.types";
 import type {
@@ -96,6 +97,31 @@ export const getPieceTechniqueSVC = (id: string, includes: Set<string>) => repoG
 
 export const getPieceTechniqueFabricationTreeSVC = (id: string) => repoGetFabricationTree(id);
 
+/** Hash du DTO validé, commun au pré-contrôle HTTP et à la transaction de création. */
+export function pieceTechniqueCreateRequestHash(body: CreatePieceTechniqueBodyDTO): string {
+  return crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex");
+}
+
+/**
+ * Avant #309, le contrôleur stockait le hash du DTO validé mais l'assistant d'import
+ * passait directement par le repository, qui hashait le DTO enrichi. Les deux formes
+ * restent acceptées pour que les clés déjà émises continuent à rejouer leur pièce.
+ */
+export function pieceTechniqueCreateCompatibleRequestHashes(body: CreatePieceTechniqueBodyDTO): string[] {
+  const statut = body.statut ?? "DRAFT";
+  const enriched = {
+    ...body,
+    statut,
+    en_fabrication: statut === "IN_FABRICATION",
+    operations: (body.operations ?? []).map((operation) => ({ ...operation, ...computeOperation(operation) })),
+    achats: (body.achats ?? []).map((achat) => ({ ...achat, ...computeAchat(achat) })),
+  };
+  return [
+    pieceTechniqueCreateRequestHash(body),
+    crypto.createHash("sha256").update(JSON.stringify(enriched)).digest("hex"),
+  ];
+}
+
 export async function createPieceTechniqueSVC(
   body: CreatePieceTechniqueBodyDTO,
   audit: AuditContext,
@@ -123,7 +149,9 @@ export async function createPieceTechniqueSVC(
         achats,
       },
       audit,
-      idempotencyKey
+      idempotencyKey,
+      pieceTechniqueCreateRequestHash(body),
+      pieceTechniqueCreateCompatibleRequestHashes(body)
     );
   } catch (err: unknown) {
     // pg unique violation

--- a/src/module/pieces-techniques/services/pieces-techniques.service.ts
+++ b/src/module/pieces-techniques/services/pieces-techniques.service.ts
@@ -43,7 +43,9 @@ import {
   repoUpdatePieceTechnique,
   repoUpdatePieceTechniqueStatus,
   repoCreatePieceTechnique,
+  PIECE_TECHNIQUE_IDEMPOTENCY_CONSTRAINT,
   type AuditContext,
+  type RepoCreatePieceTechniqueResult,
 } from "../repository/pieces-techniques.repository";
 
 type UploadedDocument = Express.Multer.File;
@@ -127,6 +129,15 @@ export async function createPieceTechniqueSVC(
   audit: AuditContext,
   idempotencyKey?: string | null
 ) {
+  return (await createPieceTechniqueWithReplaySVC(body, audit, idempotencyKey)).piece;
+}
+
+/** Variante HTTP : conserve l'information 201 (création) / 200 (rejeu). */
+export async function createPieceTechniqueWithReplaySVC(
+  body: CreatePieceTechniqueBodyDTO,
+  audit: AuditContext,
+  idempotencyKey?: string | null
+): Promise<RepoCreatePieceTechniqueResult> {
   const statut = body.statut ?? "DRAFT";
   const enFabrication = statut === "IN_FABRICATION";
 
@@ -155,9 +166,9 @@ export async function createPieceTechniqueSVC(
     );
   } catch (err: unknown) {
     // pg unique violation
-    const code = (err as { code?: unknown } | null)?.code;
-    const detail = (err as { detail?: unknown } | null)?.detail;
-    if (code === "23505") {
+    const pg = err as { code?: unknown; constraint?: unknown; detail?: unknown } | null;
+    if (pg?.code === "23505" && pg.constraint !== PIECE_TECHNIQUE_IDEMPOTENCY_CONSTRAINT) {
+      const detail = pg.detail;
       const msg = typeof detail === "string" && detail.includes("code_piece") ? "Code de pièce déjà utilisé" : "Conflit de contrainte";
       throw new HttpError(409, "CODE_ALREADY_EXISTS", msg);
     }


### PR DESCRIPTION
## Pourquoi

Le contrôleur vérifiait la clé d’idempotence avant création, puis enregistrait cette clé après le commit métier. Deux requêtes simultanées pouvaient toutes deux observer une clé absente. Dans une course avec payloads différents, la contrainte `code_piece` pouvait en outre masquer la vraie erreur de réutilisation de clé. Enfin, un rejeu concurrent pouvait être renvoyé comme une création 201 et sans ses relations complètes.

## Ce qui change

- transmet la clé au repository afin que création métier, audit et reçu idempotent restent dans la même transaction
- sérialise une même clé par verrou consultatif transactionnel avant toute écriture métier
- retourne systématiquement `409 IDEMPOTENCY_KEY_REUSED` pour une même clé associée à un payload différent
- distingue précisément la contrainte primaire d’idempotence des autres violations `23505`
- conserve le pré-contrôle rapide et la compatibilité des empreintes historiques
- fait remonter le flag `replayed` du repository jusqu’au contrôleur sans changer le contrat du service utilisé en interne
- renvoie les rejeux séquentiels et concurrents en 200 avec nomenclature, opérations et achats complets
- teste les courses identiques et différentes, ainsi que commit, rollback, audit et libération des connexions

## Impact

Deux POST concurrents avec la même clé et le même payload produisent une seule pièce : un 201 et un replay 200 complet. Avec des payloads différents, une seule création est commitée et l’autre requête reçoit le conflit idempotent attendu, jamais `CODE_ALREADY_EXISTS`.

## Validation

- `vitest` ciblé : 2 fichiers, 32 tests passés
- `pnpm build` : passé
- tests isolés avec doubles PostgreSQL ; aucune base CERP ni environnement réel touché

Closes #309