### PR TITLE
release: promote CERP remediation wave 3

### DIFF
--- a/db/patches/20260804_article_unit_stock_contract.sql
+++ b/db/patches/20260804_article_unit_stock_contract.sql
@@ -1,0 +1,44 @@
+-- #475 / BUG-CERP-0013 — Canonical article/stock unit contract.
+--
+-- `public.units.code` is the sole referential used by stock movements and is
+-- now also validated when an article is created or updated. Existing article
+-- values are never rewritten: this additive seed makes the already accepted
+-- linear unit `mm` resolvable by the stock ledger.
+--
+-- Idempotent. Run the companion preflight/verify scripts manually on cerp_test;
+-- do not run this patch against production as part of this change.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.units') IS NULL THEN
+    RAISE EXCEPTION '#475: public.units is required before adding the mm unit';
+  END IF;
+END $$;
+
+-- Keep whether this patch introduced `mm`: rollback must never delete a unit
+-- that predated the patch. This tiny marker is dropped by the guarded rollback.
+CREATE TABLE IF NOT EXISTS public.cerp_patch_20260804_unit_mm (
+  singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+  inserted_by_patch boolean NOT NULL
+);
+
+DO $$
+DECLARE introduced boolean;
+BEGIN
+  SELECT inserted_by_patch INTO introduced
+  FROM public.cerp_patch_20260804_unit_mm
+  WHERE singleton = true;
+
+  IF introduced IS NULL THEN
+    IF EXISTS (SELECT 1 FROM public.units WHERE code = 'mm') THEN
+      INSERT INTO public.cerp_patch_20260804_unit_mm (singleton, inserted_by_patch) VALUES (true, false);
+    ELSE
+      INSERT INTO public.units (code, label) VALUES ('mm', 'Millimètre');
+      INSERT INTO public.cerp_patch_20260804_unit_mm (singleton, inserted_by_patch) VALUES (true, true);
+    END IF;
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/20260804_article_unit_stock_contract.sql
+++ b/db/patches/20260804_article_unit_stock_contract.sql
@@ -1,44 +1,63 @@
 -- #475 / BUG-CERP-0013 — Canonical article/stock unit contract.
 --
--- `public.units.code` is the sole referential used by stock movements and is
--- now also validated when an article is created or updated. Existing article
--- values are never rewritten: this additive seed makes the already accepted
--- linear unit `mm` resolvable by the stock ledger.
+-- public.units remains the authoritative referential. The application maps
+-- historical piece aliases (PCE/PCS/PC, any case) to `u` and normalises other
+-- codes to lower case without converting quantities. Existing article values
+-- are intentionally left untouched and remain readable through that adapter.
 --
--- Idempotent. Run the companion preflight/verify scripts manually on cerp_test;
--- do not run this patch against production as part of this change.
+-- The canonical codes observed in article, stock and production contracts are
+-- seeded additively: u already comes from 20260223; this patch ensures mm, m
+-- and kg. It is idempotent and records exactly which rows it introduced so the
+-- companion rollback cannot delete pre-existing reference data.
 
 BEGIN;
 
 DO $$
 BEGIN
   IF to_regclass('public.units') IS NULL THEN
-    RAISE EXCEPTION '#475: public.units is required before adding the mm unit';
+    RAISE EXCEPTION '#475: public.units is required';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM public.units WHERE lower(code::text) = 'u') THEN
+    RAISE EXCEPTION '#475: canonical base unit u must be seeded by 20260223 first';
   END IF;
 END $$;
 
--- Keep whether this patch introduced `mm`: rollback must never delete a unit
--- that predated the patch. This tiny marker is dropped by the guarded rollback.
-CREATE TABLE IF NOT EXISTS public.cerp_patch_20260804_unit_mm (
-  singleton boolean PRIMARY KEY DEFAULT true CHECK (singleton),
+CREATE TABLE IF NOT EXISTS public.cerp_patch_20260804_stock_units (
+  code text PRIMARY KEY,
+  unit_id text NOT NULL,
   inserted_by_patch boolean NOT NULL
 );
 
 DO $$
-DECLARE introduced boolean;
+DECLARE seed record;
+        v_unit_id text;
 BEGIN
-  SELECT inserted_by_patch INTO introduced
-  FROM public.cerp_patch_20260804_unit_mm
-  WHERE singleton = true;
+  FOR seed IN
+    SELECT * FROM (VALUES
+      ('mm'::text, 'Millimètre'::text),
+      ('m'::text,  'Mètre'::text),
+      ('kg'::text, 'Kilogramme'::text)
+    ) AS seeded(code, label)
+  LOOP
+    IF NOT EXISTS (SELECT 1 FROM public.cerp_patch_20260804_stock_units WHERE code = seed.code) THEN
+      SELECT id::text INTO v_unit_id
+      FROM public.units
+      WHERE lower(code::text) = seed.code
+      LIMIT 1;
 
-  IF introduced IS NULL THEN
-    IF EXISTS (SELECT 1 FROM public.units WHERE code = 'mm') THEN
-      INSERT INTO public.cerp_patch_20260804_unit_mm (singleton, inserted_by_patch) VALUES (true, false);
-    ELSE
-      INSERT INTO public.units (code, label) VALUES ('mm', 'Millimètre');
-      INSERT INTO public.cerp_patch_20260804_unit_mm (singleton, inserted_by_patch) VALUES (true, true);
+      IF v_unit_id IS NOT NULL THEN
+        INSERT INTO public.cerp_patch_20260804_stock_units (code, unit_id, inserted_by_patch)
+        VALUES (seed.code, v_unit_id, false);
+      ELSE
+        INSERT INTO public.units (code, label)
+        VALUES (seed.code, seed.label)
+        RETURNING id::text INTO v_unit_id;
+
+        INSERT INTO public.cerp_patch_20260804_stock_units (code, unit_id, inserted_by_patch)
+        VALUES (seed.code, v_unit_id, true);
+      END IF;
     END IF;
-  END IF;
+  END LOOP;
 END $$;
 
 COMMIT;

--- a/db/patches/support/20260804_article_unit_stock_contract.preflight.sql
+++ b/db/patches/support/20260804_article_unit_stock_contract.preflight.sql
@@ -1,0 +1,21 @@
+-- #475 preflight (READ-ONLY). Run on cerp_test before the additive patch.
+
+\echo '=== #475 preflight — confirm the target is not production ==='
+SELECT current_database() AS database, current_user AS role, inet_server_addr() AS server_addr;
+
+\echo ''
+\echo '=== Required canonical referential (present must be true) ==='
+SELECT to_regclass('public.units') IS NOT NULL AS units_table_present;
+
+\echo ''
+\echo '=== Existing unit codes (mm may be absent before apply) ==='
+SELECT code, label FROM public.units WHERE code IN ('u', 'mm') ORDER BY code;
+
+\echo ''
+\echo '=== Existing article values that would remain unresolved (investigate before enforcing) ==='
+SELECT a.unite, count(*) AS articles
+FROM public.articles a
+LEFT JOIN public.units u ON u.code = a.unite
+WHERE a.unite IS NOT NULL AND btrim(a.unite) <> '' AND u.code IS NULL
+GROUP BY a.unite
+ORDER BY articles DESC, a.unite;

--- a/db/patches/support/20260804_article_unit_stock_contract.preflight.sql
+++ b/db/patches/support/20260804_article_unit_stock_contract.preflight.sql
@@ -3,19 +3,74 @@
 \echo '=== #475 preflight — confirm the target is not production ==='
 SELECT current_database() AS database, current_user AS role, inet_server_addr() AS server_addr;
 
-\echo ''
-\echo '=== Required canonical referential (present must be true) ==='
-SELECT to_regclass('public.units') IS NOT NULL AS units_table_present;
+SELECT (to_regclass('public.units') IS NULL)::text AS units_missing \gset
+\if :units_missing
+  \echo 'BLOCKING: public.units is missing. Apply the stock foundation patches first.'
+  \quit 3
+\endif
+
+SELECT (NOT EXISTS (SELECT 1 FROM public.units WHERE lower(code::text) = 'u'))::text AS base_unit_missing \gset
+\if :base_unit_missing
+  \echo 'BLOCKING: canonical base unit u is missing. Apply 20260223_seed_currencies_units.sql first.'
+  \quit 3
+\endif
 
 \echo ''
-\echo '=== Existing unit codes (mm may be absent before apply) ==='
-SELECT code, label FROM public.units WHERE code IN ('u', 'mm') ORDER BY code;
+\echo '=== Case-insensitive duplicate unit codes (expect 0 rows) ==='
+SELECT lower(code::text) AS canonical, count(*) AS matching_rows
+FROM public.units
+GROUP BY lower(code::text)
+HAVING count(*) > 1
+ORDER BY canonical;
+
+SELECT EXISTS (
+  SELECT 1 FROM public.units GROUP BY lower(code::text) HAVING count(*) > 1
+)::text AS has_case_duplicates \gset
+\if :has_case_duplicates
+  \echo 'BLOCKING: case-insensitive duplicate unit codes make resolution ambiguous. Reconcile them before applying this patch.'
+  \quit 3
+\endif
 
 \echo ''
-\echo '=== Existing article values that would remain unresolved (investigate before enforcing) ==='
-SELECT a.unite, count(*) AS articles
-FROM public.articles a
-LEFT JOIN public.units u ON u.code = a.unite
-WHERE a.unite IS NOT NULL AND btrim(a.unite) <> '' AND u.code IS NULL
-GROUP BY a.unite
-ORDER BY articles DESC, a.unite;
+\echo '=== Existing/planned canonical codes ==='
+SELECT code, label FROM public.units WHERE lower(code::text) IN ('u', 'mm', 'm', 'kg') ORDER BY code;
+
+\echo ''
+\echo '=== Existing article values unresolved after aliases + planned seeds ==='
+WITH normalized AS (
+  SELECT unite,
+    CASE
+      WHEN lower(btrim(unite)) IN ('pc','pce','pces','pcs','piece','pieces','pièce','pièces','unit','units','unite','unites','unité','unités') THEN 'u'
+      ELSE lower(btrim(unite))
+    END AS canonical
+  FROM public.articles
+  WHERE unite IS NOT NULL AND btrim(unite) <> ''
+), available AS (
+  SELECT lower(code::text) AS code FROM public.units
+  UNION SELECT unnest(ARRAY['u','mm','m','kg'])
+)
+SELECT n.unite, n.canonical, count(*) AS articles
+FROM normalized n
+LEFT JOIN available a ON a.code = n.canonical
+WHERE a.code IS NULL
+GROUP BY n.unite, n.canonical
+ORDER BY articles DESC, n.unite;
+
+WITH normalized AS (
+  SELECT CASE
+    WHEN lower(btrim(unite)) IN ('pc','pce','pces','pcs','piece','pieces','pièce','pièces','unit','units','unite','unites','unité','unités') THEN 'u'
+    ELSE lower(btrim(unite))
+  END AS canonical
+  FROM public.articles
+  WHERE unite IS NOT NULL AND btrim(unite) <> ''
+), available AS (
+  SELECT lower(code::text) AS code FROM public.units
+  UNION SELECT unnest(ARRAY['u','mm','m','kg'])
+)
+SELECT (count(*) > 0)::text AS has_unresolved
+FROM normalized n LEFT JOIN available a ON a.code = n.canonical
+WHERE a.code IS NULL \gset
+\if :has_unresolved
+  \echo 'BLOCKING: unresolved article units remain. Add an explicit alias or canonical seed; never guess a quantity conversion.'
+  \quit 3
+\endif

--- a/db/patches/support/20260804_article_unit_stock_contract.rollback.sql
+++ b/db/patches/support/20260804_article_unit_stock_contract.rollback.sql
@@ -1,38 +1,40 @@
 -- #475 guarded rollback. Manual only; never rewrites article or stock history.
--- It removes the seeded code only when no article or stock level references it.
+-- Removes only unit rows proven to have been introduced by this patch.
 
 BEGIN;
 
 DO $$
+DECLARE seeded record;
 BEGIN
   IF current_database() = 'cerp_prod' THEN
     RAISE EXCEPTION '#475 rollback is refused on cerp_prod';
   END IF;
 
-  IF NOT EXISTS (
-    SELECT 1 FROM public.cerp_patch_20260804_unit_mm WHERE singleton = true AND inserted_by_patch = true
-  ) THEN
-    RAISE NOTICE '#475 rollback: mm existed before this patch; nothing to remove.';
-    RETURN;
-  END IF;
+  FOR seeded IN
+    SELECT code, unit_id FROM public.cerp_patch_20260804_stock_units
+    WHERE inserted_by_patch = true
+  LOOP
+    IF EXISTS (
+      SELECT 1 FROM public.articles
+      WHERE lower(btrim(unite)) = seeded.code
+    ) THEN
+      RAISE EXCEPTION '#475 rollback refused: articles reference unit %', seeded.code;
+    END IF;
 
-  IF EXISTS (SELECT 1 FROM public.articles WHERE unite = 'mm') THEN
-    RAISE EXCEPTION '#475 rollback refused: articles still reference unit mm';
-  END IF;
+    IF EXISTS (
+      SELECT 1
+      FROM public.stock_levels sl
+      WHERE sl.unit_id::text = seeded.unit_id
+    ) THEN
+      RAISE EXCEPTION '#475 rollback refused: stock levels reference unit %', seeded.code;
+    END IF;
 
-  IF EXISTS (
-    SELECT 1
-    FROM public.stock_levels sl
-    JOIN public.units u ON u.id = sl.unit_id
-    WHERE u.code = 'mm'
-  ) THEN
-    RAISE EXCEPTION '#475 rollback refused: stock levels still reference unit mm';
-  END IF;
-
-  DELETE FROM public.units WHERE code = 'mm';
-  DELETE FROM public.cerp_patch_20260804_unit_mm WHERE singleton = true;
+    DELETE FROM public.units
+    WHERE id::text = seeded.unit_id
+      AND lower(code::text) = seeded.code;
+  END LOOP;
 END $$;
 
-DROP TABLE IF EXISTS public.cerp_patch_20260804_unit_mm;
+DROP TABLE IF EXISTS public.cerp_patch_20260804_stock_units;
 
 COMMIT;

--- a/db/patches/support/20260804_article_unit_stock_contract.rollback.sql
+++ b/db/patches/support/20260804_article_unit_stock_contract.rollback.sql
@@ -1,0 +1,38 @@
+-- #475 guarded rollback. Manual only; never rewrites article or stock history.
+-- It removes the seeded code only when no article or stock level references it.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF current_database() = 'cerp_prod' THEN
+    RAISE EXCEPTION '#475 rollback is refused on cerp_prod';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM public.cerp_patch_20260804_unit_mm WHERE singleton = true AND inserted_by_patch = true
+  ) THEN
+    RAISE NOTICE '#475 rollback: mm existed before this patch; nothing to remove.';
+    RETURN;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.articles WHERE unite = 'mm') THEN
+    RAISE EXCEPTION '#475 rollback refused: articles still reference unit mm';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.stock_levels sl
+    JOIN public.units u ON u.id = sl.unit_id
+    WHERE u.code = 'mm'
+  ) THEN
+    RAISE EXCEPTION '#475 rollback refused: stock levels still reference unit mm';
+  END IF;
+
+  DELETE FROM public.units WHERE code = 'mm';
+  DELETE FROM public.cerp_patch_20260804_unit_mm WHERE singleton = true;
+END $$;
+
+DROP TABLE IF EXISTS public.cerp_patch_20260804_unit_mm;
+
+COMMIT;

--- a/db/patches/support/20260804_article_unit_stock_contract.verify.sql
+++ b/db/patches/support/20260804_article_unit_stock_contract.verify.sql
@@ -1,19 +1,66 @@
 -- #475 verification (READ-ONLY). Run after applying the patch on cerp_test.
 
-\echo '=== #475 verify — mm must be present exactly once ==='
-SELECT code, label, count(*) OVER (PARTITION BY code) AS matching_rows
+\echo '=== #475 verify — canonical units (expect u, mm, m, kg) ==='
+SELECT lower(code::text) AS code, label, count(*) AS matching_rows
 FROM public.units
-WHERE code = 'mm';
+WHERE lower(code::text) IN ('u', 'mm', 'm', 'kg')
+GROUP BY lower(code::text), label
+ORDER BY code;
+
+SELECT (count(*) <> 4)::text AS canonical_seed_invalid
+FROM public.units WHERE lower(code::text) IN ('u', 'mm', 'm', 'kg') \gset
+\if :canonical_seed_invalid
+  \echo 'BLOCKING: canonical unit seeds are missing or duplicated case-insensitively.'
+  \quit 3
+\endif
 
 \echo ''
-\echo '=== Rollback marker (true means this patch inserted mm) ==='
-SELECT singleton, inserted_by_patch FROM public.cerp_patch_20260804_unit_mm;
+\echo '=== Rollback provenance ==='
+SELECT code, unit_id, inserted_by_patch FROM public.cerp_patch_20260804_stock_units ORDER BY code;
+
+SELECT (
+  count(*) <> 3
+  OR bool_or(u.id IS NULL)
+)::text AS rollback_provenance_invalid
+FROM public.cerp_patch_20260804_stock_units marker
+LEFT JOIN public.units u
+  ON u.id::text = marker.unit_id
+ AND lower(u.code::text) = marker.code \gset
+\if :rollback_provenance_invalid
+  \echo 'BLOCKING: rollback provenance is incomplete or no longer identifies the exact seeded rows.'
+  \quit 3
+\endif
 
 \echo ''
-\echo '=== Article values absent from the canonical referential (expect 0 rows) ==='
-SELECT a.unite, count(*) AS articles
-FROM public.articles a
-LEFT JOIN public.units u ON u.code = a.unite
-WHERE a.unite IS NOT NULL AND btrim(a.unite) <> '' AND u.code IS NULL
-GROUP BY a.unite
-ORDER BY articles DESC, a.unite;
+\echo '=== Article values unresolved through canonical aliases (expect 0 rows) ==='
+WITH normalized AS (
+  SELECT unite,
+    CASE
+      WHEN lower(btrim(unite)) IN ('pc','pce','pces','pcs','piece','pieces','pièce','pièces','unit','units','unite','unites','unité','unités') THEN 'u'
+      ELSE lower(btrim(unite))
+    END AS canonical
+  FROM public.articles
+  WHERE unite IS NOT NULL AND btrim(unite) <> ''
+)
+SELECT n.unite, n.canonical, count(*) AS articles
+FROM normalized n
+LEFT JOIN public.units u ON lower(u.code::text) = n.canonical
+WHERE u.code IS NULL
+GROUP BY n.unite, n.canonical
+ORDER BY articles DESC, n.unite;
+
+WITH normalized AS (
+  SELECT CASE
+    WHEN lower(btrim(unite)) IN ('pc','pce','pces','pcs','piece','pieces','pièce','pièces','unit','units','unite','unites','unité','unités') THEN 'u'
+    ELSE lower(btrim(unite))
+  END AS canonical
+  FROM public.articles
+  WHERE unite IS NOT NULL AND btrim(unite) <> ''
+)
+SELECT (count(*) > 0)::text AS has_unresolved
+FROM normalized n LEFT JOIN public.units u ON lower(u.code::text) = n.canonical
+WHERE u.code IS NULL \gset
+\if :has_unresolved
+  \echo 'BLOCKING: unresolved article units remain. Add an explicit alias or canonical seed before rollout.'
+  \quit 3
+\endif

--- a/db/patches/support/20260804_article_unit_stock_contract.verify.sql
+++ b/db/patches/support/20260804_article_unit_stock_contract.verify.sql
@@ -1,0 +1,19 @@
+-- #475 verification (READ-ONLY). Run after applying the patch on cerp_test.
+
+\echo '=== #475 verify — mm must be present exactly once ==='
+SELECT code, label, count(*) OVER (PARTITION BY code) AS matching_rows
+FROM public.units
+WHERE code = 'mm';
+
+\echo ''
+\echo '=== Rollback marker (true means this patch inserted mm) ==='
+SELECT singleton, inserted_by_patch FROM public.cerp_patch_20260804_unit_mm;
+
+\echo ''
+\echo '=== Article values absent from the canonical referential (expect 0 rows) ==='
+SELECT a.unite, count(*) AS articles
+FROM public.articles a
+LEFT JOIN public.units u ON u.code = a.unite
+WHERE a.unite IS NOT NULL AND btrim(a.unite) <> '' AND u.code IS NULL
+GROUP BY a.unite
+ORDER BY articles DESC, a.unite;

--- a/src/__tests__/article-unit-stock-contract.test.ts
+++ b/src/__tests__/article-unit-stock-contract.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertCanonicalArticleUnit,
+  resolveUnitIdForArticle,
+} from "../module/stock/repository/stock.repository";
+
+const ARTICLE_ID = "11111111-1111-4111-8111-111111111111";
+const MILLIMETRE_UNIT_ID = "22222222-2222-4222-8222-222222222222";
+
+describe("#475 article/stock unit contract", () => {
+  it("accepts the canonical mm article unit and resolves it for a nominal stock movement", async () => {
+    const queries: Array<{ sql: string; values: unknown[] | undefined }> = [];
+    const client = {
+      query: async (sql: string, values?: unknown[]) => {
+        queries.push({ sql, values });
+        if (sql.includes("SELECT code FROM public.units")) return { rows: [{ code: "mm" }] };
+        if (sql.includes("SELECT unite FROM public.articles")) return { rows: [{ unite: "mm" }] };
+        if (sql.includes("SELECT id::text AS id FROM public.units")) return { rows: [{ id: MILLIMETRE_UNIT_ID }] };
+        return { rows: [] };
+      },
+    };
+
+    await expect(assertCanonicalArticleUnit(client, "mm")).resolves.toBeUndefined();
+    await expect(resolveUnitIdForArticle(client, ARTICLE_ID, null)).resolves.toBe(MILLIMETRE_UNIT_ID);
+    expect(queries.some(({ values }) => values?.[0] === "mm")).toBe(true);
+  });
+
+  it("rejects an invalid article unit before the article is persisted", async () => {
+    const client = { query: async () => ({ rows: [] }) };
+
+    await expect(assertCanonicalArticleUnit(client, "banane")).rejects.toMatchObject({
+      status: 400,
+      code: "INVALID_ARTICLE_UNIT",
+      message: expect.stringContaining("banane"),
+    });
+  });
+});

--- a/src/__tests__/article-unit-stock-contract.test.ts
+++ b/src/__tests__/article-unit-stock-contract.test.ts
@@ -1,27 +1,57 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 import {
   assertCanonicalArticleUnit,
+  repoCreateArticleTx,
   resolveUnitIdForArticle,
 } from "../module/stock/repository/stock.repository";
+import { canonicalizeStockUnitCode } from "../shared/stock-unit";
+import { createArticleSchema } from "../module/stock/validators/stock.validators";
 
 const ARTICLE_ID = "11111111-1111-4111-8111-111111111111";
 const MILLIMETRE_UNIT_ID = "22222222-2222-4222-8222-222222222222";
 
 describe("#475 article/stock unit contract", () => {
-  it("accepts the canonical mm article unit and resolves it for a nominal stock movement", async () => {
+  it.each([
+    ["PCE", "u"], ["pcs", "u"], ["PC", "u"], [" unite ", "u"], ["U", "u"], ["MM", "mm"], ["Kg", "kg"], ["M", "m"],
+  ])("canonicalizes the historical stock unit %s as %s", (input, expected) => {
+    expect(canonicalizeStockUnitCode(input)).toBe(expected);
+  });
+
+  it("creates a real article with canonical mm then resolves its unit for a stock movement", async () => {
     const queries: Array<{ sql: string; values: unknown[] | undefined }> = [];
+    let storedUnit: string | null = null;
     const client = {
       query: async (sql: string, values?: unknown[]) => {
         queries.push({ sql, values });
-        if (sql.includes("SELECT code FROM public.units")) return { rows: [{ code: "mm" }] };
-        if (sql.includes("SELECT unite FROM public.articles")) return { rows: [{ unite: "mm" }] };
-        if (sql.includes("SELECT id::text AS id FROM public.units")) return { rows: [{ id: MILLIMETRE_UNIT_ID }] };
+        if (sql.includes("FROM public.units")) return { rows: [{ id: MILLIMETRE_UNIT_ID }] };
+        if (sql.includes("fn_next_issued_code_value")) return { rows: [{ v: "42" }] };
+        if (sql.includes("INSERT INTO public.articles (")) {
+          storedUnit = (values?.[9] as string | null) ?? null;
+          return { rows: [{ id: ARTICLE_ID }] };
+        }
+        if (sql.includes("SELECT unite FROM public.articles")) return { rows: [{ unite: storedUnit }] };
         return { rows: [] };
       },
     };
 
-    await expect(assertCanonicalArticleUnit(client, "mm")).resolves.toBeUndefined();
+    const body = createArticleSchema.parse({ body: {
+      designation: "Tôle 2 mm",
+      article_category: "achat",
+      article_categories: ["achat_revente"],
+      family_code: "ACH",
+      unite: "MM",
+    } }).body;
+    const audit = {
+      user_id: 1, ip: null, user_agent: null, device_type: null, os: null,
+      browser: null, path: "/api/v1/stock/articles", page_key: "stock", client_session_id: null,
+    };
+
+    const created = await repoCreateArticleTx(client as never, body, audit);
+    expect(created.id).toBe(ARTICLE_ID);
+    expect(storedUnit).toBe("mm");
     await expect(resolveUnitIdForArticle(client, ARTICLE_ID, null)).resolves.toBe(MILLIMETRE_UNIT_ID);
     expect(queries.some(({ values }) => values?.[0] === "mm")).toBe(true);
   });
@@ -34,5 +64,29 @@ describe("#475 article/stock unit contract", () => {
       code: "INVALID_ARTICLE_UNIT",
       message: expect.stringContaining("banane"),
     });
+  });
+
+  it("keeps preflight, verification and exact-row rollback guards coherent", () => {
+    const patch = readFileSync(resolve("db/patches/20260804_article_unit_stock_contract.sql"), "utf8");
+    const preflight = readFileSync(resolve("db/patches/support/20260804_article_unit_stock_contract.preflight.sql"), "utf8");
+    const verify = readFileSync(resolve("db/patches/support/20260804_article_unit_stock_contract.verify.sql"), "utf8");
+    const rollback = readFileSync(resolve("db/patches/support/20260804_article_unit_stock_contract.rollback.sql"), "utf8");
+
+    expect(patch).toMatch(/\('mm'::text, 'Millimètre'::text\)/);
+    expect(patch).toMatch(/\('m'::text,\s+'Mètre'::text\)/);
+    expect(patch).toMatch(/\('kg'::text, 'Kilogramme'::text\)/);
+    expect(patch).toContain("unit_id text NOT NULL");
+    expect(patch).not.toMatch(/UPDATE\s+public\.articles/i);
+
+    for (const guard of [preflight, verify]) {
+      expect(guard).toContain("'pc','pce','pces','pcs'");
+      expect(guard).toContain("'unit','units','unite','unites','unité','unités'");
+      expect(guard).toContain("\\quit 3");
+      expect(guard).toContain("has_unresolved");
+    }
+
+    expect(rollback).toContain("current_database() = 'cerp_prod'");
+    expect(rollback).toContain("id::text = seeded.unit_id");
+    expect(rollback).not.toMatch(/DELETE\s+FROM\s+public\.articles/i);
   });
 });

--- a/src/__tests__/article-unit-stock-contract.test.ts
+++ b/src/__tests__/article-unit-stock-contract.test.ts
@@ -1,6 +1,42 @@
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { describe, expect, it } from "vitest";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const routeDb = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => ({
+  Pool: vi.fn(() => ({
+    on: vi.fn(),
+    query: routeDb.poolQuery,
+    connect: routeDb.poolConnect,
+  })),
+}));
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; role: string } },
+    _res: unknown,
+    next: () => void
+  ) => {
+    req.user = { id: 1, role: "Administrateur Systeme et Reseau" };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
 
 import {
   assertCanonicalArticleUnit,
@@ -9,9 +45,27 @@ import {
 } from "../module/stock/repository/stock.repository";
 import { canonicalizeStockUnitCode } from "../shared/stock-unit";
 import { createArticleSchema } from "../module/stock/validators/stock.validators";
+import app from "../config/app";
 
 const ARTICLE_ID = "11111111-1111-4111-8111-111111111111";
 const MILLIMETRE_UNIT_ID = "22222222-2222-4222-8222-222222222222";
+const MAGASIN_ID = "33333333-3333-4333-8333-333333333333";
+const WAREHOUSE_ID = "44444444-4444-4444-8444-444444444444";
+const LOCATION_ID = "55555555-5555-4555-8555-555555555555";
+const STOCK_LEVEL_ID = "66666666-6666-4666-8666-666666666666";
+const MOVEMENT_ID = "77777777-7777-4777-8777-777777777777";
+const MOVEMENT_LINE_ID = "88888888-8888-4888-8888-888888888888";
+
+beforeEach(() => {
+  routeDb.poolQuery.mockReset();
+  routeDb.poolConnect.mockReset();
+  routeDb.clientQuery.mockReset();
+  routeDb.clientRelease.mockReset();
+  routeDb.poolConnect.mockResolvedValue({
+    query: routeDb.clientQuery,
+    release: routeDb.clientRelease,
+  });
+});
 
 describe("#475 article/stock unit contract", () => {
   it.each([
@@ -54,6 +108,294 @@ describe("#475 article/stock unit contract", () => {
     expect(storedUnit).toBe("mm");
     await expect(resolveUnitIdForArticle(client, ARTICLE_ID, null)).resolves.toBe(MILLIMETRE_UNIT_ID);
     expect(queries.some(({ values }) => values?.[0] === "mm")).toBe(true);
+  });
+
+  it("creates an article then a stock movement through the real HTTP/service/repository flow", async () => {
+    type QueryCall = { sql: string; values: unknown[] };
+    type ArticleState = {
+      id: string;
+      code: string;
+      designation: string;
+      article_type: string;
+      article_category: string;
+      article_categories: string[];
+      family_code: string;
+      stock_managed: boolean;
+      unite: string | null;
+      lot_tracking: boolean;
+      is_sold: boolean;
+      is_active: boolean;
+      status: string;
+    };
+
+    const state: {
+      queries: QueryCall[];
+      article: ArticleState | null;
+      stockLevel: {
+        id: string;
+        article_id: string;
+        unit_id: string;
+        warehouse_id: string;
+        location_id: string;
+      } | null;
+      movement: Record<string, unknown> | null;
+      movementLine: Record<string, unknown> | null;
+    } = {
+      queries: [],
+      article: null,
+      stockLevel: null,
+      movement: null,
+      movementLine: null,
+    };
+
+    const query = vi.fn(async (sql: unknown, rawValues?: unknown[]) => {
+      const text = String(sql);
+      const values = rawValues ?? [];
+      state.queries.push({ sql: text, values });
+
+      if (text === "BEGIN" || text === "COMMIT" || text === "ROLLBACK") return { rows: [], rowCount: 0 };
+      if (text.includes("pg_advisory_xact_lock")) return { rows: [], rowCount: 1 };
+      if (text.includes("FROM public.article_create_idempotence")) return { rows: [], rowCount: 0 };
+      if (text.includes("FROM public.stock_command_receipts")) return { rows: [], rowCount: 0 };
+      if (text.includes("FROM public.units")) {
+        return values[0] === "mm"
+          ? { rows: [{ id: MILLIMETRE_UNIT_ID }], rowCount: 1 }
+          : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("fn_next_issued_code_value")) return { rows: [{ v: "42" }], rowCount: 1 };
+      if (text.includes("INSERT INTO public.articles (")) {
+        state.article = {
+          id: String(values[0]),
+          code: String(values[1]),
+          designation: String(values[2]),
+          article_type: String(values[4]),
+          article_category: String(values[5]),
+          article_categories: ["achat_revente"],
+          family_code: String(values[6]),
+          stock_managed: Boolean(values[7]),
+          unite: values[9] == null ? null : String(values[9]),
+          lot_tracking: Boolean(values[16]),
+          is_sold: Boolean(values[17]),
+          is_active: Boolean(values[18]),
+          status: String(values[14]),
+        };
+        return { rows: [{ id: state.article.id }], rowCount: 1 };
+      }
+      if (text.includes("SELECT stock_managed, lot_tracking FROM public.articles")) {
+        return state.article
+          ? { rows: [{ stock_managed: state.article.stock_managed, lot_tracking: state.article.lot_tracking }], rowCount: 1 }
+          : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("SELECT unite FROM public.articles")) {
+        return state.article ? { rows: [{ unite: state.article.unite }], rowCount: 1 } : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("FROM public.emplacements e") && text.includes("JOIN public.magasins m")) {
+        return {
+          rows: [{
+            magasin_id: MAGASIN_ID,
+            location_id: LOCATION_ID,
+            warehouse_id: WAREHOUSE_ID,
+            emplacement_active: true,
+            magasin_active: true,
+            location_type: "STORAGE",
+            allow_inbound: true,
+            allow_outbound: true,
+            restrictions: {},
+          }],
+          rowCount: 1,
+        };
+      }
+      if (text.includes("INSERT INTO public.stock_levels (")) {
+        state.stockLevel = {
+          id: STOCK_LEVEL_ID,
+          article_id: String(values[0]),
+          unit_id: String(values[1]),
+          warehouse_id: String(values[2]),
+          location_id: String(values[3]),
+        };
+        return { rows: [], rowCount: 1 };
+      }
+      if (text.includes("FROM public.stock_levels") && text.includes("article_id = $1::uuid")) {
+        return state.stockLevel ? { rows: [state.stockLevel], rowCount: 1 } : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("SELECT nextval('public.stock_movement_no_seq')")) {
+        return { rows: [{ n: "7" }], rowCount: 1 };
+      }
+      if (text.includes("INSERT INTO public.stock_movements (")) {
+        state.movement = {
+          id: MOVEMENT_ID,
+          movement_no: values[0],
+          movement_type: values[1],
+          status: "DRAFT",
+          article_id: values[2],
+          stock_level_id: values[3],
+          stock_batch_id: values[4],
+          qty: values[5],
+          effective_at: values[6],
+          posted_at: null,
+          source_document_type: values[7],
+          source_document_id: values[8],
+          reason_code: values[9],
+          notes: values[10],
+          correlation_id: values[12],
+          reversal_of_id: null,
+          created_at: "2026-08-04T10:00:00.000Z",
+          updated_at: "2026-08-04T10:00:00.000Z",
+          created_by: values[13],
+          updated_by: values[13],
+          posted_by: null,
+        };
+        return { rows: [{ id: MOVEMENT_ID }], rowCount: 1 };
+      }
+      if (text.includes("INSERT INTO public.stock_movement_lines (")) {
+        state.movementLine = {
+          id: MOVEMENT_LINE_ID,
+          movement_id: values[0],
+          line_no: values[1],
+          article_id: values[2],
+          article_code: state.article?.code,
+          article_designation: state.article?.designation,
+          lot_id: values[3],
+          lot_code: null,
+          qty: values[4],
+          unite: values[5],
+          unit_cost: values[6],
+          currency: values[7],
+          src_magasin_id: values[8],
+          src_magasin_code: null,
+          src_magasin_name: null,
+          src_emplacement_id: values[9],
+          src_emplacement_code: null,
+          src_emplacement_name: null,
+          dst_magasin_id: values[10],
+          dst_magasin_code: "MAG-01",
+          dst_magasin_name: "Magasin principal",
+          dst_emplacement_id: values[11],
+          dst_emplacement_code: "RACK-01",
+          dst_emplacement_name: "Rack 01",
+          note: values[12],
+          direction: values[13],
+        };
+        return { rows: [], rowCount: 1 };
+      }
+      if (text.includes("FROM public.stock_movements") && text.includes("WHERE id = $1::uuid")) {
+        return state.movement ? { rows: [state.movement], rowCount: 1 } : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("FROM public.stock_movement_lines l")) {
+        return state.movementLine ? { rows: [state.movementLine], rowCount: 1 } : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("FROM public.stock_movement_documents md")) return { rows: [], rowCount: 0 };
+      if (text.includes("FROM public.stock_movement_event_log")) return { rows: [], rowCount: 0 };
+      if (text.includes("FROM public.articles a") && text.includes("WHERE a.id = $1::uuid")) {
+        if (!state.article) return { rows: [], rowCount: 0 };
+        return {
+          rows: [{
+            ...state.article,
+            root_article_id: state.article.id,
+            parent_article_id: null,
+            version_number: 1,
+            plan_index: 1,
+            projet_id: null,
+            piece_technique_id: null,
+            piece_code: null,
+            piece_designation: null,
+            row_version: 1,
+            archived_at: null,
+            archive_reason: null,
+            applicable_version: null,
+            notes: null,
+            article_matiere: null,
+            fourniture_client: null,
+            qty_available: 0,
+            qty_reserved: 0,
+            qty_total: 0,
+            locations_count: 0,
+            updated_at: "2026-08-04T10:00:00.000Z",
+            created_at: "2026-08-04T10:00:00.000Z",
+          }],
+          rowCount: 1,
+        };
+      }
+      if (text.includes("SELECT 1::int AS ok FROM public.articles")) {
+        return state.article ? { rows: [{ ok: 1 }], rowCount: 1 } : { rows: [], rowCount: 0 };
+      }
+      if (text.includes("FROM public.article_procurement_profile")) return { rows: [], rowCount: 0 };
+      if (text.includes("FROM public.fournisseur_catalogue")) return { rows: [], rowCount: 0 };
+      if (text.includes("FROM public.article_documents")) return { rows: [], rowCount: 0 };
+
+      return { rows: [], rowCount: 0 };
+    });
+
+    routeDb.clientQuery.mockImplementation(query);
+    routeDb.poolQuery.mockImplementation(query);
+
+    const articleResponse = await request(app)
+      .post("/api/v1/stock/articles")
+      .set("Authorization", "Bearer fake")
+      .set("Idempotency-Key", "contract-article-mm-001")
+      .send({
+        designation: "Plaque 2 mm",
+        article_category: "achat",
+        article_categories: ["achat_revente"],
+        family_code: "ACH",
+        unite: "MM",
+      });
+
+    expect(articleResponse.status).toBe(201);
+    expect(articleResponse.body).toMatchObject({ id: state.article?.id, unite: "mm", stock_managed: true });
+    const movementQueryStart = state.queries.length;
+
+    const movementResponse = await request(app)
+      .post("/api/v1/stock/movements")
+      .set("Authorization", "Bearer fake")
+      .set("Idempotency-Key", "contract-movement-mm-001")
+      .send({
+        movement_type: "IN",
+        lines: [{
+          article_id: articleResponse.body.id,
+          qty: 5,
+          dst_magasin_id: MAGASIN_ID,
+          dst_emplacement_id: 1,
+        }],
+      });
+
+    expect(movementResponse.status).toBe(201);
+    expect(movementResponse.body).toMatchObject({
+      movement: {
+        id: MOVEMENT_ID,
+        article_id: articleResponse.body.id,
+        stock_level_id: STOCK_LEVEL_ID,
+        qty: 5,
+      },
+      lines: [{ movement_id: MOVEMENT_ID, article_id: articleResponse.body.id, qty: 5 }],
+    });
+    expect(state.stockLevel).toEqual({
+      id: STOCK_LEVEL_ID,
+      article_id: articleResponse.body.id,
+      unit_id: MILLIMETRE_UNIT_ID,
+      warehouse_id: WAREHOUSE_ID,
+      location_id: LOCATION_ID,
+    });
+    expect(state.movement).toMatchObject({
+      id: MOVEMENT_ID,
+      article_id: articleResponse.body.id,
+      stock_level_id: STOCK_LEVEL_ID,
+    });
+    expect(state.movementLine).toMatchObject({
+      movement_id: MOVEMENT_ID,
+      article_id: articleResponse.body.id,
+      dst_magasin_id: MAGASIN_ID,
+      dst_emplacement_id: 1,
+    });
+
+    const movementQueries = state.queries.slice(movementQueryStart);
+    expect(movementQueries).toEqual(expect.arrayContaining([
+      expect.objectContaining({ sql: expect.stringContaining("SELECT unite FROM public.articles"), values: [articleResponse.body.id] }),
+      expect.objectContaining({ sql: expect.stringContaining("FROM public.units"), values: ["mm"] }),
+      expect.objectContaining({ sql: expect.stringContaining("INSERT INTO public.stock_levels") }),
+      expect.objectContaining({ sql: expect.stringContaining("INSERT INTO public.stock_movements") }),
+      expect.objectContaining({ sql: expect.stringContaining("INSERT INTO public.stock_movement_lines") }),
+    ]));
   });
 
   it("rejects an invalid article unit before the article is persisted", async () => {

--- a/src/__tests__/piece-technique-document-policy-227.routes.test.ts
+++ b/src/__tests__/piece-technique-document-policy-227.routes.test.ts
@@ -350,6 +350,125 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
 
     expect(res.status).toBe(409);
   });
+
+  it("#309 — arbitre deux créations concurrentes dans la transaction et renvoie la même pièce", async () => {
+    const idempotencyKey = "wizard-309-concurrent-01";
+    let earlyReadCount = 0;
+    let releaseEarlyReads: (() => void) | undefined;
+    const bothEarlyReads = new Promise<void>((resolve) => {
+      releaseEarlyReads = resolve;
+    });
+    let stored:
+      | { key: string; requestHash: string; pieceId: string; core: Record<string, unknown> }
+      | null = null;
+    const transactionQueries: string[][] = [];
+
+    // Force les DEUX contrôleurs à observer « aucune clé » avant de laisser les
+    // transactions avancer : c'est exactement la fenêtre de course de la régression.
+    mocks.poolQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query.includes("piece_technique_create_idempotence")) {
+        earlyReadCount += 1;
+        if (earlyReadCount <= 2) {
+          if (earlyReadCount === 2) releaseEarlyReads?.();
+          await bothEarlyReads;
+          return { rows: [], rowCount: 0 };
+        }
+        return {
+          rows: stored
+            ? [{ piece_technique_id: stored.pieceId, request_hash: stored.requestHash }]
+            : [],
+          rowCount: stored ? 1 : 0,
+        };
+      }
+      if (query.includes("FROM pieces_techniques p") && stored) {
+        return { rows: [stored.core], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+
+    mocks.poolConnect.mockImplementation(async () => {
+      const queries: string[] = [];
+      transactionQueries.push(queries);
+      let localCore: Record<string, unknown> | null = null;
+      const query = vi.fn(async (sql: unknown, params?: unknown[]) => {
+        const statement = String(sql);
+        queries.push(statement);
+        if (statement === "BEGIN" || statement === "COMMIT" || statement === "ROLLBACK") {
+          return { rows: [], rowCount: 0 };
+        }
+        if (statement.includes("piece_technique_create_idempotence") && statement.includes("FOR UPDATE")) {
+          return { rows: [], rowCount: 0 };
+        }
+        if (statement.includes("SELECT client_code FROM public.clients")) {
+          return { rows: [{ client_code: "045" }], rowCount: 1 };
+        }
+        if (statement.includes("INSERT INTO pieces_techniques (")) {
+          const pieceId = String(params?.[0]);
+          localCore = {
+            id: pieceId,
+            article_id: null,
+            root_piece_technique_id: pieceId,
+            parent_piece_technique_id: null,
+            version_number: 1,
+            created_at: "2026-08-04T00:00:00.000Z",
+            updated_at: "2026-08-04T00:00:00.000Z",
+            client_id: "045",
+            created_by: 42,
+            updated_by: 42,
+            famille_id: null,
+            name_piece: "Carter",
+            code_piece: "045-10233-000",
+            designation: "Carter aluminium",
+            designation_2: null,
+            prix_unitaire: 0,
+            statut: "DRAFT",
+            en_fabrication: 0,
+            cycle: null,
+            cycle_fabrication: null,
+            code_client: null,
+            client_name: "ACME",
+            ensemble: false,
+          };
+          return { rows: [localCore], rowCount: 1 };
+        }
+        if (statement.includes("INSERT INTO pieces_techniques_historique")) {
+          return {
+            rows: [{ id: "history-1", date_action: "2026-08-04T00:00:00.000Z" }],
+            rowCount: 1,
+          };
+        }
+        if (statement.includes("INSERT INTO public.piece_technique_create_idempotence")) {
+          if (stored) throw Object.assign(new Error("duplicate key"), { code: "23505" });
+          stored = {
+            key: String(params?.[0]),
+            requestHash: String(params?.[1]),
+            pieceId: String(params?.[2]),
+            core: localCore ?? {},
+          };
+          return { rows: [], rowCount: 1 };
+        }
+        return { rows: [], rowCount: 0 };
+      });
+      return { query, release: vi.fn() };
+    });
+
+    const makeRequest = () =>
+      request(app)
+        .post("/api/v1/pieces-techniques")
+        .set("x-test-role", roleHeader("Directeur"))
+        .set("Idempotency-Key", idempotencyKey)
+        .send(body);
+
+    const [first, second] = await Promise.all([makeRequest(), makeRequest()]);
+
+    expect([first.status, second.status]).toEqual([201, 201]);
+    expect(first.body.id).toBe(second.body.id);
+    expect(stored?.key).toBe(idempotencyKey);
+    const flattened = transactionQueries.flat();
+    expect(flattened.filter((query) => query === "COMMIT")).toHaveLength(1);
+    expect(flattened.filter((query) => query === "ROLLBACK").length).toBeGreaterThanOrEqual(1);
+  });
 });
 
 describe("#227 — brouillons : strictement privés à leur auteur", () => {

--- a/src/__tests__/piece-technique-document-policy-227.routes.test.ts
+++ b/src/__tests__/piece-technique-document-policy-227.routes.test.ts
@@ -256,6 +256,56 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
     ensemble: false,
   };
 
+  const replayBom = {
+    id: "44444444-4444-4444-8444-444444444444",
+    child_piece_id: "55555555-5555-4555-8555-555555555555",
+    rang: 10,
+    quantite: 2,
+    repere: "R1",
+    designation: "Sous-ensemble",
+  };
+  const replayOperation = {
+    id: "66666666-6666-4666-8666-666666666666",
+    phase: 10,
+    designation: "Usinage",
+    designation_2: null,
+    cf_id: null,
+    prix: 0,
+    coef: 1,
+    tp: 1,
+    tf_unit: 2,
+    qte: 1,
+    taux_horaire: 50,
+    temps_total: 3,
+    cout_mo: 150,
+  };
+  const replayAchat = {
+    id: "77777777-7777-4777-8777-777777777777",
+    phase: 10,
+    type_achat: "MATIERE",
+    famille_piece_id: null,
+    nom: "Aluminium",
+    fournisseur_id: null,
+    fournisseur_nom: null,
+    fournisseur_code: null,
+    quantite: 1,
+    quantite_brut_mm: null,
+    longueur_mm: null,
+    coefficient_chute: null,
+    quantite_pieces: null,
+    prix_par_quantite: null,
+    tarif: null,
+    prix: 10,
+    unite_prix: "kg",
+    pu_achat: 10,
+    tva_achat: 20,
+    total_achat_ht: 10,
+    total_achat_ttc: 12,
+    designation: "Aluminium",
+    designation_2: null,
+    designation_3: null,
+  };
+
   it("rejette une clé d'idempotence malformée", async () => {
     const res = await request(app)
       .post("/api/v1/pieces-techniques")
@@ -284,7 +334,16 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
           rowCount: 1,
         });
       }
-      if (String(sql).includes("FROM pieces_techniques") || String(sql).includes("FROM public.pieces_techniques")) {
+      if (String(sql).includes("FROM pieces_techniques_nomenclature")) {
+        return Promise.resolve({ rows: [replayBom], rowCount: 1 });
+      }
+      if (String(sql).includes("FROM pieces_techniques_operations")) {
+        return Promise.resolve({ rows: [replayOperation], rowCount: 1 });
+      }
+      if (String(sql).includes("FROM pieces_techniques_achats")) {
+        return Promise.resolve({ rows: [replayAchat], rowCount: 1 });
+      }
+      if (String(sql).includes("FROM pieces_techniques p") || String(sql).includes("FROM public.pieces_techniques p")) {
         return Promise.resolve({
           rows: [
             {
@@ -327,6 +386,9 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
 
     expect(res.status).toBe(200);
     expect(res.body.id).toBe(PIECE_ID);
+    expect(res.body.bom).toEqual([expect.objectContaining({ id: replayBom.id })]);
+    expect(res.body.operations).toEqual([expect.objectContaining({ id: replayOperation.id })]);
+    expect(res.body.achats).toEqual([expect.objectContaining({ id: replayAchat.id })]);
     // Aucune connexion transactionnelle : la pièce n'a PAS été recréée.
     expect(mocks.poolConnect).not.toHaveBeenCalled();
   });
@@ -351,7 +413,18 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
     expect(res.status).toBe(409);
   });
 
-  it("#309 — arbitre deux créations concurrentes dans la transaction et renvoie la même pièce", async () => {
+  it.each([
+    {
+      caseName: "rejoue en 200 deux créations concurrentes identiques",
+      secondBody: body,
+      expectedCode: null,
+    },
+    {
+      caseName: "refuse en 409 deux créations concurrentes de payloads différents",
+      secondBody: { ...body, designation: "Carter aluminium révisé" },
+      expectedCode: "IDEMPOTENCY_KEY_REUSED",
+    },
+  ])("#309 — $caseName", async ({ secondBody, expectedCode }) => {
     const idempotencyKey = "wizard-309-concurrent-01";
     let earlyReadCount = 0;
     let releaseEarlyReads: (() => void) | undefined;
@@ -362,6 +435,8 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
       | { key: string; requestHash: string; pieceId: string; core: Record<string, unknown> }
       | null = null;
     const transactionQueries: string[][] = [];
+    const releases: ReturnType<typeof vi.fn>[] = [];
+    let advisoryTail = Promise.resolve();
 
     // Force les DEUX contrôleurs à observer « aucune clé » avant de laisser les
     // transactions avancer : c'est exactement la fenêtre de course de la régression.
@@ -384,6 +459,15 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
       if (query.includes("FROM pieces_techniques p") && stored) {
         return { rows: [stored.core], rowCount: 1 };
       }
+      if (query.includes("FROM pieces_techniques_nomenclature")) {
+        return { rows: [replayBom], rowCount: 1 };
+      }
+      if (query.includes("FROM pieces_techniques_operations")) {
+        return { rows: [replayOperation], rowCount: 1 };
+      }
+      if (query.includes("FROM pieces_techniques_achats")) {
+        return { rows: [replayAchat], rowCount: 1 };
+      }
       return { rows: [], rowCount: 0 };
     });
 
@@ -391,14 +475,34 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
       const queries: string[] = [];
       transactionQueries.push(queries);
       let localCore: Record<string, unknown> | null = null;
+      let releaseAdvisory: (() => void) | null = null;
       const query = vi.fn(async (sql: unknown, params?: unknown[]) => {
         const statement = String(sql);
         queries.push(statement);
-        if (statement === "BEGIN" || statement === "COMMIT" || statement === "ROLLBACK") {
+        if (statement === "BEGIN") {
+          return { rows: [], rowCount: 0 };
+        }
+        if (statement.includes("pg_advisory_xact_lock")) {
+          const previous = advisoryTail;
+          advisoryTail = new Promise<void>((resolve) => {
+            releaseAdvisory = resolve;
+          });
+          await previous;
+          return { rows: [{ pg_advisory_xact_lock: null }], rowCount: 1 };
+        }
+        if (statement === "COMMIT" || statement === "ROLLBACK") {
+          const release = releaseAdvisory;
+          releaseAdvisory = null;
+          release?.();
           return { rows: [], rowCount: 0 };
         }
         if (statement.includes("piece_technique_create_idempotence") && statement.includes("FOR UPDATE")) {
-          return { rows: [], rowCount: 0 };
+          return {
+            rows: stored
+              ? [{ piece_technique_id: stored.pieceId, request_hash: stored.requestHash }]
+              : [],
+            rowCount: stored ? 1 : 0,
+          };
         }
         if (statement.includes("SELECT client_code FROM public.clients")) {
           return { rows: [{ client_code: "045" }], rowCount: 1 };
@@ -417,9 +521,9 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
             created_by: 42,
             updated_by: 42,
             famille_id: null,
-            name_piece: "Carter",
+            name_piece: String(params?.[9]),
             code_piece: "045-10233-000",
-            designation: "Carter aluminium",
+            designation: String(params?.[11]),
             designation_2: null,
             prix_unitaire: 0,
             statut: "DRAFT",
@@ -439,7 +543,12 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
           };
         }
         if (statement.includes("INSERT INTO public.piece_technique_create_idempotence")) {
-          if (stored) throw Object.assign(new Error("duplicate key"), { code: "23505" });
+          if (stored) {
+            throw Object.assign(new Error("duplicate key"), {
+              code: "23505",
+              constraint: "piece_technique_create_idempotence_pkey",
+            });
+          }
           stored = {
             key: String(params?.[0]),
             requestHash: String(params?.[1]),
@@ -450,24 +559,39 @@ describe("#227 — idempotence de création : le double clic ne crée pas deux p
         }
         return { rows: [], rowCount: 0 };
       });
-      return { query, release: vi.fn() };
+      const release = vi.fn();
+      releases.push(release);
+      return { query, release };
     });
 
-    const makeRequest = () =>
+    const makeRequest = (requestBody: typeof body) =>
       request(app)
         .post("/api/v1/pieces-techniques")
         .set("x-test-role", roleHeader("Directeur"))
         .set("Idempotency-Key", idempotencyKey)
-        .send(body);
+        .send(requestBody);
 
-    const [first, second] = await Promise.all([makeRequest(), makeRequest()]);
+    const [first, second] = await Promise.all([makeRequest(body), makeRequest(secondBody)]);
 
-    expect([first.status, second.status]).toEqual([201, 201]);
-    expect(first.body.id).toBe(second.body.id);
+    expect([first.status, second.status].sort()).toEqual(expectedCode ? [201, 409] : [200, 201]);
+    if (expectedCode) {
+      const conflict = [first, second].find((response) => response.status === 409);
+      expect(conflict?.body.code).toBe(expectedCode);
+      expect(conflict?.body.code).not.toBe("CODE_ALREADY_EXISTS");
+    } else {
+      expect(first.body.id).toBe(second.body.id);
+      const replay = [first, second].find((response) => response.status === 200);
+      expect(replay?.body.bom).toEqual([expect.objectContaining({ id: replayBom.id })]);
+      expect(replay?.body.operations).toEqual([expect.objectContaining({ id: replayOperation.id })]);
+      expect(replay?.body.achats).toEqual([expect.objectContaining({ id: replayAchat.id })]);
+    }
     expect(stored?.key).toBe(idempotencyKey);
     const flattened = transactionQueries.flat();
     expect(flattened.filter((query) => query === "COMMIT")).toHaveLength(1);
     expect(flattened.filter((query) => query === "ROLLBACK").length).toBeGreaterThanOrEqual(1);
+    expect(flattened.filter((query) => query.includes("INSERT INTO erp_audit_logs"))).toHaveLength(1);
+    expect(releases).toHaveLength(2);
+    releases.forEach((release) => expect(release).toHaveBeenCalledTimes(1));
   });
 });
 

--- a/src/__tests__/stock-unit-resolvers.test.ts
+++ b/src/__tests__/stock-unit-resolvers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { resolveUnitIdForArticle as resolveDeliveryUnit } from "../module/livraisons/repository/livraisons.repository";
+import { resolveUnitIdForArticle as resolveProductionUnit } from "../module/production/repository/production-receipts.repository";
+import { resolveUnitIdForArticle as resolveQualityUnit } from "../module/qualite/repository/qualite.repository";
+import { resolveUnitIdForArticle as resolveStockUnit } from "../module/stock/repository/stock.repository";
+
+const ARTICLE_ID = "11111111-1111-4111-8111-111111111111";
+const UNIT_ID = "22222222-2222-4222-8222-222222222222";
+
+type Resolution = string | { unit_id: string; unit_code: string };
+type Resolver = (db: never, articleId: string, preferred: null) => Promise<Resolution>;
+
+const resolvers: Array<[string, Resolver, number, string]> = [
+  ["stock", resolveStockUnit as Resolver, 400, "UNKNOWN_UNIT"],
+  ["production", resolveProductionUnit as Resolver, 422, "UNIT_NOT_FOUND"],
+  ["livraison", resolveDeliveryUnit as Resolver, 400, "UNKNOWN_UNIT"],
+  ["qualité", resolveQualityUnit as Resolver, 400, "UNKNOWN_UNIT"],
+];
+
+function databaseWithHistoricalArticle(unit: string) {
+  const query = vi.fn(async (sql: string, values?: unknown[]) => {
+    if (sql.includes("FROM public.articles")) return { rows: [{ unite: unit }], rowCount: 1 };
+    if (sql.includes("FROM public.units")) {
+      return values?.[0] === "banane"
+        ? { rows: [], rowCount: 0 }
+        : { rows: [{ id: UNIT_ID }], rowCount: 1 };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  return { db: { query } as never, query };
+}
+
+describe("#475 historical unit adapters across stock-producing modules", () => {
+  it.each(resolvers)("canonicalizes PCE/PC/MM in %s before resolving public.units", async (_name, resolver) => {
+    for (const [historical, canonical] of [["PCE", "u"], ["PC", "u"], ["MM", "mm"]] as const) {
+      const { db, query } = databaseWithHistoricalArticle(historical);
+      const resolution = await resolver(db, ARTICLE_ID, null);
+
+      expect(resolution).toEqual(
+        _name === "production" ? { unit_id: UNIT_ID, unit_code: canonical } : UNIT_ID
+      );
+      expect(query).toHaveBeenCalledWith(
+        expect.stringContaining("FROM public.units"),
+        [canonical]
+      );
+    }
+  });
+
+  it.each(resolvers)("rejects an unresolved historical unit in %s", async (_name, resolver, status, code) => {
+    const { db } = databaseWithHistoricalArticle("BANANE");
+    await expect(resolver(db, ARTICLE_ID, null)).rejects.toMatchObject({ status, code });
+  });
+});

--- a/src/__tests__/stock.routes.test.ts
+++ b/src/__tests__/stock.routes.test.ts
@@ -7,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   poolConnect: vi.fn(),
   clientQuery: vi.fn(),
   clientRelease: vi.fn(),
+  currentRole: { value: "Administrateur Systeme et Reseau" },
 }));
 
 vi.mock("pg", () => {
@@ -35,7 +36,7 @@ vi.mock("../utils/checkNetworkDrive", () => ({
 
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authenticateToken: (req: { user?: { id: number; role: string } }, _res: unknown, next: () => void) => {
-    req.user = { id: 1, role: "Administrateur Systeme et Reseau" };
+    req.user = { id: 1, role: mocks.currentRole.value };
     next();
   },
   authorizeRole:
@@ -63,6 +64,7 @@ beforeEach(() => {
   mocks.poolConnect.mockReset();
   mocks.clientQuery.mockReset();
   mocks.clientRelease.mockReset();
+  mocks.currentRole.value = "Administrateur Systeme et Reseau";
 
   mocks.poolConnect.mockResolvedValue({
     query: mocks.clientQuery,
@@ -71,6 +73,19 @@ beforeEach(() => {
 });
 
 describe("/api/v1/stock", () => {
+  it("GET /api/v1/stock/units returns the canonical referential behind stock read access", async () => {
+    mocks.poolQuery.mockResolvedValueOnce({ rows: [{ code: "PCE", label: "Pièce" }, { code: "u", label: "Unité" }, { code: "MM", label: "Millimètre" }] });
+
+    const allowed = await request(app).get("/api/v1/stock/units").set("Authorization", "Bearer fake");
+    expect(allowed.status).toBe(200);
+    expect(allowed.body.items).toEqual([{ code: "mm", label: "Millimètre" }, { code: "u", label: "Unité" }]);
+
+    mocks.currentRole.value = "Commercial";
+    const denied = await request(app).get("/api/v1/stock/units").set("Authorization", "Bearer fake");
+    expect(denied.status).toBe(403);
+    expect(denied.body.code).toBe("STOCK_FORBIDDEN");
+  });
+
   it("GET /api/v1/stock/positions exposes the consolidated OLD/NEW read model", async () => {
     mocks.poolQuery
       .mockResolvedValueOnce({ rows: [{ total: 0 }] })
@@ -358,6 +373,34 @@ describe("/api/v1/stock", () => {
         String(call[0]).includes("LEFT JOIN LATERAL")
       )
     ).toBe(false);
+  });
+
+  it("PATCH /api/v1/stock/articles/:id rejects an unknown unit before UPDATE", async () => {
+    const articleId = "11111111-1111-1111-1111-111111111111";
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM public.articles") && q.includes("FOR UPDATE")) {
+        return { rows: [{
+          id: articleId, code: "ART-ACH-000001", designation: "Vis", article_type: "APPROVISIONNE",
+          article_category: "achat", article_categories: ["achat_revente"], root_article_id: articleId,
+          version_number: 1, plan_index: 1, status: "VALIDE", projet_id: null, family_code: "ACH",
+          piece_technique_id: null, stock_managed: true, lot_tracking: false, row_version: 2,
+          designation_secondary: null, is_sold: true,
+        }] };
+      }
+      if (q.includes("FROM public.units")) return { rows: [] };
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .patch(`/api/v1/stock/articles/${articleId}`)
+      .set("Authorization", "Bearer fake")
+      .send({ expected_row_version: 2, unite: "banane" });
+
+    expect(res.status).toBe(400);
+    expect(res.body).toMatchObject({ code: "INVALID_ARTICLE_UNIT" });
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("UPDATE public.articles"))).toBe(false);
   });
 
   it("PATCH /api/v1/stock/articles/:id persists Fourniture Client fields and returns them", async () => {

--- a/src/__tests__/surface-finish-210.routes.test.ts
+++ b/src/__tests__/surface-finish-210.routes.test.ts
@@ -215,6 +215,7 @@ function installQueryRouter(scenario: Scenario = {}) {
         : one(scenario.existingRequirement ?? requirementRow());
     }
     if (/fn_next_issued_code_value/.test(sql)) return one({ v: "123" });
+    if (/FROM public\.units/.test(sql)) return one({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", code: "u" });
     if (/INSERT INTO public\.articles\b/.test(sql)) return one({ id: ARTICLE_ID });
     if (/INSERT INTO erp_audit_logs/.test(sql)) {
       return one({ id: "audit-1", created_at: "2026-07-28T08:05:00.000Z" });
@@ -789,6 +790,12 @@ describe("#210 confirmation", () => {
       }
       if (/FROM public\.articles_traitement t/.test(sql)) return Promise.resolve({ rows: [], rowCount: 0 });
       if (/fn_next_issued_code_value/.test(sql)) return Promise.resolve({ rows: [{ v: "123" }], rowCount: 1 });
+      if (/FROM public\.units/.test(sql)) {
+        return Promise.resolve({
+          rows: [{ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", code: "u" }],
+          rowCount: 1,
+        });
+      }
       if (/INSERT INTO public\.articles\b/.test(sql)) return Promise.resolve({ rows: [{ id: ARTICLE_ID }], rowCount: 1 });
       if (/INSERT INTO erp_audit_logs/.test(sql)) {
         return Promise.resolve({ rows: [{ id: "a", created_at: "x" }], rowCount: 1 });

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -4,6 +4,7 @@ import crypto from "node:crypto"
 import type { PoolClient } from "pg"
 
 import pool from "../../../config/database"
+import { canonicalizeStockUnitCode } from "../../../shared/stock-unit"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 
@@ -186,7 +187,7 @@ async function reserveStockMovementNo(db: Queryable): Promise<string> {
   return stockMovementNoFromSeq(n)
 }
 
-async function resolveUnitIdForArticle(
+export async function resolveUnitIdForArticle(
   db: Queryable,
   articleId: string,
   preferredUnitCode: string | null | undefined
@@ -198,9 +199,12 @@ async function resolveUnitIdForArticle(
     const a = await db.query<{ unite: string | null }>(`SELECT unite FROM public.articles WHERE id = $1::uuid`, [articleId])
     code = a.rows[0]?.unite?.trim() ? a.rows[0].unite.trim() : null
   }
-  if (!code) code = "u"
+  code = canonicalizeStockUnitCode(code) ?? "u"
 
-  const u = await db.query<{ id: string }>(`SELECT id::text AS id FROM public.units WHERE code = $1`, [code])
+  const u = await db.query<{ id: string }>(
+    `SELECT id::text AS id FROM public.units WHERE lower(code::text) = lower($1) LIMIT 1`,
+    [code]
+  )
   const unitId = u.rows[0]?.id
   if (!unitId) {
     throw new HttpError(400, "UNKNOWN_UNIT", `Unknown unit code: ${code}`)

--- a/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
+++ b/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
@@ -62,6 +62,7 @@ import {
   updatePieceTechniqueStatusSVC,
   createPieceTechniqueSVC,
   pieceTechniqueCreateCompatibleRequestHashes,
+  createPieceTechniqueWithReplaySVC,
   attachPieceTechniqueDocumentsSVC,
   downloadPieceTechniqueDocumentSVC,
   listPieceTechniqueDocumentsSVC,
@@ -163,8 +164,8 @@ export const createPieceTechnique: RequestHandler = async (req, res, next) => {
 
     // La clé entre dans LA MÊME transaction que l'insertion métier. Le pré-contrôle
     // ci-dessus optimise le rejeu séquentiel ; l'unicité en base tranche les courses.
-    const out = await createPieceTechniqueSVC(body, audit, idempotencyKey)
-    res.status(201).json(out)
+    const out = await createPieceTechniqueWithReplaySVC(body, audit, idempotencyKey)
+    res.status(out.replayed ? 200 : 201).json(out.piece)
   } catch (err) {
     next(err)
   }

--- a/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
+++ b/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
@@ -1,12 +1,8 @@
 // src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
 import type { Request, RequestHandler } from "express"
-import crypto from "node:crypto"
 import fs from "node:fs/promises"
 import db from "../../../config/database"
-import {
-  repoFindIdempotentPieceCreate,
-  repoRecordIdempotentPieceCreate,
-} from "../repository/create-drafts.repository"
+import { repoFindIdempotentPieceCreate } from "../repository/create-drafts.repository"
 import { generatePieceTechniqueBusinessCode } from "../../../shared/codes/code-generator.service"
 import { getDocumentStoragePath, isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
@@ -65,6 +61,7 @@ import {
   updatePieceTechniqueSVC,
   updatePieceTechniqueStatusSVC,
   createPieceTechniqueSVC,
+  pieceTechniqueCreateCompatibleRequestHashes,
   attachPieceTechniqueDocumentsSVC,
   downloadPieceTechniqueDocumentSVC,
   listPieceTechniqueDocumentsSVC,
@@ -145,12 +142,12 @@ export const createPieceTechnique: RequestHandler = async (req, res, next) => {
       return
     }
 
-    const requestHash = crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex")
+    const compatibleRequestHashes = new Set(pieceTechniqueCreateCompatibleRequestHashes(body))
     const replay = await repoFindIdempotentPieceCreate(idempotencyKey)
     if (replay) {
       // Même clé, charge différente : c'est une erreur d'appelant, pas un rejeu. On refuse
       // plutôt que de renvoyer une pièce qui ne correspond pas à ce qui vient d'être envoyé.
-      if (replay.request_hash !== requestHash) {
+      if (!compatibleRequestHashes.has(replay.request_hash)) {
         throw new HttpError(
           409,
           "IDEMPOTENCY_KEY_REUSED",
@@ -164,8 +161,9 @@ export const createPieceTechnique: RequestHandler = async (req, res, next) => {
       }
     }
 
-    const out = await createPieceTechniqueSVC(body, audit)
-    await repoRecordIdempotentPieceCreate(idempotencyKey, requestHash, out.id)
+    // La clé entre dans LA MÊME transaction que l'insertion métier. Le pré-contrôle
+    // ci-dessus optimise le rejeu séquentiel ; l'unicité en base tranche les courses.
+    const out = await createPieceTechniqueSVC(body, audit, idempotencyKey)
     res.status(201).json(out)
   } catch (err) {
     next(err)

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -1648,6 +1648,28 @@ async function lookupClientCompanyName(tx: Pick<PoolClient, "query">, clientId: 
   return typeof name === "string" && name.trim().length > 0 ? name.trim() : null;
 }
 
+export const PIECE_TECHNIQUE_IDEMPOTENCY_CONSTRAINT = "piece_technique_create_idempotence_pkey";
+
+export type RepoCreatePieceTechniqueResult = {
+  piece: PieceTechnique;
+  replayed: boolean;
+};
+
+function idempotencyKeyReusedError(): HttpError {
+  return new HttpError(
+    409,
+    "IDEMPOTENCY_KEY_REUSED",
+    "Cette clé d’idempotence a déjà servi avec une autre pièce technique."
+  );
+}
+
+function isIdempotencyKeyUniqueViolation(err: unknown): boolean {
+  const pg = err as { code?: unknown; constraint?: unknown } | null;
+  return pg?.code === "23505" && pg.constraint === PIECE_TECHNIQUE_IDEMPOTENCY_CONSTRAINT;
+}
+
+const CREATE_REPLAY_INCLUDES = new Set(["nomenclature", "operations", "achats"]);
+
 export async function repoCreatePieceTechnique(
   body: CreatePieceTechniqueBodyDTO & {
     statut: PieceTechniqueStatut;
@@ -1659,7 +1681,7 @@ export async function repoCreatePieceTechnique(
   idempotencyKey?: string | null,
   validatedRequestHash?: string,
   compatibleRequestHashes: readonly string[] = []
-): Promise<PieceTechnique> {
+): Promise<RepoCreatePieceTechniqueResult> {
   const client = await db.connect();
   // Conserve le hash historique : une clé déjà consommée avant #404 doit
   // continuer à rejouer la même pièce, même si son ancien payload portait une
@@ -1671,6 +1693,13 @@ export async function repoCreatePieceTechnique(
     await client.query("BEGIN");
 
     if (idempotencyKey) {
+      // Un SELECT FOR UPDATE ne verrouille aucune « ligne absente ». Le verrou consultatif
+      // transactionnel sérialise donc toutes les créations portant LA MÊME clé avant la
+      // première écriture métier. Le second appel peut alors décider replay/409 proprement.
+      await client.query(
+        "SELECT pg_advisory_xact_lock(hashtext('piece-technique-create'), hashtext($1))",
+        [idempotencyKey]
+      );
       const replay = await client.query<{ piece_technique_id: string; request_hash: string }>(
         `SELECT piece_technique_id::text AS piece_technique_id, request_hash
          FROM public.piece_technique_create_idempotence
@@ -1680,12 +1709,12 @@ export async function repoCreatePieceTechnique(
       );
       if (replay.rows[0]) {
         if (!acceptedRequestHashes.has(replay.rows[0].request_hash)) {
-          throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Cette clé d’idempotence a déjà servi avec une autre pièce technique.");
+          throw idempotencyKeyReusedError();
         }
         await client.query("ROLLBACK");
-        const existing = await repoGetPieceTechnique(replay.rows[0].piece_technique_id, new Set());
+        const existing = await repoGetPieceTechnique(replay.rows[0].piece_technique_id, CREATE_REPLAY_INCLUDES);
         if (!existing) throw new Error("Idempotent piece technique no longer exists");
-        return existing;
+        return { piece: existing, replayed: true };
       }
     }
 
@@ -1859,19 +1888,24 @@ export async function repoCreatePieceTechnique(
     }
 
     await client.query("COMMIT");
-    return piece;
+    return { piece, replayed: false };
   } catch (err) {
     await client.query("ROLLBACK");
-    const code = (err as { code?: unknown } | null)?.code;
-    if (idempotencyKey && code === "23505") {
+    if (idempotencyKey && isIdempotencyKeyUniqueViolation(err)) {
       const replay = await db.query<{ piece_technique_id: string; request_hash: string }>(
         `SELECT piece_technique_id::text AS piece_technique_id, request_hash
          FROM public.piece_technique_create_idempotence WHERE idempotency_key = $1`,
         [idempotencyKey]
       );
-      if (replay.rows[0] && acceptedRequestHashes.has(replay.rows[0].request_hash)) {
-        const existing = await repoGetPieceTechnique(replay.rows[0].piece_technique_id, new Set());
-        if (existing) return existing;
+      if (replay.rows[0]) {
+        if (!acceptedRequestHashes.has(replay.rows[0].request_hash)) {
+          throw idempotencyKeyReusedError();
+        }
+        const existing = await repoGetPieceTechnique(
+          replay.rows[0].piece_technique_id,
+          CREATE_REPLAY_INCLUDES
+        );
+        if (existing) return { piece: existing, replayed: true };
       }
     }
     throw err;

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -1656,13 +1656,17 @@ export async function repoCreatePieceTechnique(
     achats: (AddAchatBodyDTO & { total_achat_ht: number; total_achat_ttc: number })[];
   },
   audit: AuditContext,
-  idempotencyKey?: string | null
+  idempotencyKey?: string | null,
+  validatedRequestHash?: string,
+  compatibleRequestHashes: readonly string[] = []
 ): Promise<PieceTechnique> {
   const client = await db.connect();
   // Conserve le hash historique : une clé déjà consommée avant #404 doit
   // continuer à rejouer la même pièce, même si son ancien payload portait une
   // famille choisie dans l'interface.
-  const requestHash = crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex");
+  const requestHash =
+    validatedRequestHash ?? crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex");
+  const acceptedRequestHashes = new Set([requestHash, ...compatibleRequestHashes]);
   try {
     await client.query("BEGIN");
 
@@ -1675,7 +1679,7 @@ export async function repoCreatePieceTechnique(
         [idempotencyKey]
       );
       if (replay.rows[0]) {
-        if (replay.rows[0].request_hash !== requestHash) {
+        if (!acceptedRequestHashes.has(replay.rows[0].request_hash)) {
           throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Cette clé d’idempotence a déjà servi avec une autre pièce technique.");
         }
         await client.query("ROLLBACK");
@@ -1865,7 +1869,7 @@ export async function repoCreatePieceTechnique(
          FROM public.piece_technique_create_idempotence WHERE idempotency_key = $1`,
         [idempotencyKey]
       );
-      if (replay.rows[0]?.request_hash === requestHash) {
+      if (replay.rows[0] && acceptedRequestHashes.has(replay.rows[0].request_hash)) {
         const existing = await repoGetPieceTechnique(replay.rows[0].piece_technique_id, new Set());
         if (existing) return existing;
       }

--- a/src/module/pieces-techniques/services/pieces-techniques-create-idempotence.test.ts
+++ b/src/module/pieces-techniques/services/pieces-techniques-create-idempotence.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ create: vi.fn() }));
+
+vi.mock("../repository/pieces-techniques.repository", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../repository/pieces-techniques.repository")>()),
+  repoCreatePieceTechnique: (...args: unknown[]) => mocks.create(...args),
+}));
+
+import type { CreatePieceTechniqueBodyDTO } from "../validators/pieces-techniques.validators";
+import {
+  createPieceTechniqueSVC,
+  pieceTechniqueCreateCompatibleRequestHashes,
+  pieceTechniqueCreateRequestHash,
+} from "./pieces-techniques.service";
+
+const body = {
+  client_id: "045",
+  name_piece: "Carter",
+  designation: "Carter aluminium",
+  plan_reference: "10233",
+  indice_externe: "000",
+  sans_indice: false,
+  prix_unitaire: 0,
+  statut: "DRAFT",
+  ensemble: false,
+  bom: [],
+  operations: [],
+  achats: [],
+} satisfies CreatePieceTechniqueBodyDTO;
+
+const audit = {
+  user_id: 42,
+  ip: null,
+  user_agent: null,
+  device_type: null,
+  os: null,
+  browser: null,
+  path: "/api/v1/pieces-techniques",
+  page_key: "pieces-techniques",
+  client_session_id: null,
+};
+
+describe("#309 — service de création idempotente", () => {
+  beforeEach(() => {
+    mocks.create.mockReset();
+    mocks.create.mockResolvedValue({ id: "piece-1", code_piece: "045-10233-000" });
+  });
+
+  it("transmet la clé et le hash du DTO validé au repository transactionnel", async () => {
+    await createPieceTechniqueSVC(body, audit, "wizard-309-key-01");
+
+    expect(mocks.create).toHaveBeenCalledWith(
+      expect.objectContaining({ designation: "Carter aluminium", operations: [], achats: [] }),
+      audit,
+      "wizard-309-key-01",
+      pieceTechniqueCreateRequestHash(body),
+      pieceTechniqueCreateCompatibleRequestHashes(body)
+    );
+  });
+
+  it("produit un autre hash lorsque le payload métier change", () => {
+    expect(pieceTechniqueCreateRequestHash({ ...body, designation: "Carter révisé" })).not.toBe(
+      pieceTechniqueCreateRequestHash(body)
+    );
+  });
+
+  it("accepte les empreintes historiques DTO validé et DTO enrichi", () => {
+    const hashes = pieceTechniqueCreateCompatibleRequestHashes(body);
+
+    expect(hashes).toContain(pieceTechniqueCreateRequestHash(body));
+    expect(new Set(hashes).size).toBe(2);
+  });
+});

--- a/src/module/pieces-techniques/services/pieces-techniques-create-idempotence.test.ts
+++ b/src/module/pieces-techniques/services/pieces-techniques-create-idempotence.test.ts
@@ -10,6 +10,7 @@ vi.mock("../repository/pieces-techniques.repository", async (importOriginal) => 
 import type { CreatePieceTechniqueBodyDTO } from "../validators/pieces-techniques.validators";
 import {
   createPieceTechniqueSVC,
+  createPieceTechniqueWithReplaySVC,
   pieceTechniqueCreateCompatibleRequestHashes,
   pieceTechniqueCreateRequestHash,
 } from "./pieces-techniques.service";
@@ -44,7 +45,10 @@ const audit = {
 describe("#309 — service de création idempotente", () => {
   beforeEach(() => {
     mocks.create.mockReset();
-    mocks.create.mockResolvedValue({ id: "piece-1", code_piece: "045-10233-000" });
+    mocks.create.mockResolvedValue({
+      piece: { id: "piece-1", code_piece: "045-10233-000" },
+      replayed: false,
+    });
   });
 
   it("transmet la clé et le hash du DTO validé au repository transactionnel", async () => {
@@ -70,5 +74,50 @@ describe("#309 — service de création idempotente", () => {
 
     expect(hashes).toContain(pieceTechniqueCreateRequestHash(body));
     expect(new Set(hashes).size).toBe(2);
+  });
+
+  it("préserve le flag de rejeu pour le contrôleur HTTP sans casser l'appel historique", async () => {
+    mocks.create.mockResolvedValueOnce({
+      piece: { id: "piece-1", code_piece: "045-10233-000", bom: [], operations: [], achats: [] },
+      replayed: true,
+    });
+
+    const httpResult = await createPieceTechniqueWithReplaySVC(body, audit, "wizard-309-key-01");
+    expect(httpResult).toMatchObject({ replayed: true, piece: { id: "piece-1" } });
+
+    mocks.create.mockResolvedValueOnce({
+      piece: { id: "piece-1", code_piece: "045-10233-000" },
+      replayed: false,
+    });
+    await expect(createPieceTechniqueSVC(body, audit, "wizard-309-key-02")).resolves.toMatchObject({
+      id: "piece-1",
+    });
+  });
+
+  it("ne transforme jamais la contrainte d'idempotence en CODE_ALREADY_EXISTS", async () => {
+    const idempotencyViolation = Object.assign(new Error("duplicate idempotency key"), {
+      code: "23505",
+      constraint: "piece_technique_create_idempotence_pkey",
+    });
+    mocks.create.mockRejectedValueOnce(idempotencyViolation);
+
+    await expect(
+      createPieceTechniqueWithReplaySVC(body, audit, "wizard-309-key-01")
+    ).rejects.toBe(idempotencyViolation);
+  });
+
+  it("continue à traduire une autre contrainte unique métier", async () => {
+    mocks.create.mockRejectedValueOnce(
+      Object.assign(new Error("duplicate code"), {
+        code: "23505",
+        constraint: "pieces_techniques_code_piece_key",
+        detail: "Key (code_piece)=(045-10233-000) already exists",
+      })
+    );
+
+    await expect(createPieceTechniqueWithReplaySVC(body, audit, "wizard-309-key-01")).rejects.toMatchObject({
+      status: 409,
+      code: "CODE_ALREADY_EXISTS",
+    });
   });
 });

--- a/src/module/pieces-techniques/services/pieces-techniques.service.ts
+++ b/src/module/pieces-techniques/services/pieces-techniques.service.ts
@@ -1,4 +1,5 @@
 // src/module/pieces-techniques/services/pieces-techniques.service.ts
+import crypto from "node:crypto";
 import { HttpError } from "../../../utils/httpError";
 import type { PieceTechniqueStatut } from "../types/pieces-techniques.types";
 import type {
@@ -96,6 +97,31 @@ export const getPieceTechniqueSVC = (id: string, includes: Set<string>) => repoG
 
 export const getPieceTechniqueFabricationTreeSVC = (id: string) => repoGetFabricationTree(id);
 
+/** Hash du DTO validé, commun au pré-contrôle HTTP et à la transaction de création. */
+export function pieceTechniqueCreateRequestHash(body: CreatePieceTechniqueBodyDTO): string {
+  return crypto.createHash("sha256").update(JSON.stringify(body)).digest("hex");
+}
+
+/**
+ * Avant #309, le contrôleur stockait le hash du DTO validé mais l'assistant d'import
+ * passait directement par le repository, qui hashait le DTO enrichi. Les deux formes
+ * restent acceptées pour que les clés déjà émises continuent à rejouer leur pièce.
+ */
+export function pieceTechniqueCreateCompatibleRequestHashes(body: CreatePieceTechniqueBodyDTO): string[] {
+  const statut = body.statut ?? "DRAFT";
+  const enriched = {
+    ...body,
+    statut,
+    en_fabrication: statut === "IN_FABRICATION",
+    operations: (body.operations ?? []).map((operation) => ({ ...operation, ...computeOperation(operation) })),
+    achats: (body.achats ?? []).map((achat) => ({ ...achat, ...computeAchat(achat) })),
+  };
+  return [
+    pieceTechniqueCreateRequestHash(body),
+    crypto.createHash("sha256").update(JSON.stringify(enriched)).digest("hex"),
+  ];
+}
+
 export async function createPieceTechniqueSVC(
   body: CreatePieceTechniqueBodyDTO,
   audit: AuditContext,
@@ -123,7 +149,9 @@ export async function createPieceTechniqueSVC(
         achats,
       },
       audit,
-      idempotencyKey
+      idempotencyKey,
+      pieceTechniqueCreateRequestHash(body),
+      pieceTechniqueCreateCompatibleRequestHashes(body)
     );
   } catch (err: unknown) {
     // pg unique violation

--- a/src/module/pieces-techniques/services/pieces-techniques.service.ts
+++ b/src/module/pieces-techniques/services/pieces-techniques.service.ts
@@ -43,7 +43,9 @@ import {
   repoUpdatePieceTechnique,
   repoUpdatePieceTechniqueStatus,
   repoCreatePieceTechnique,
+  PIECE_TECHNIQUE_IDEMPOTENCY_CONSTRAINT,
   type AuditContext,
+  type RepoCreatePieceTechniqueResult,
 } from "../repository/pieces-techniques.repository";
 
 type UploadedDocument = Express.Multer.File;
@@ -127,6 +129,15 @@ export async function createPieceTechniqueSVC(
   audit: AuditContext,
   idempotencyKey?: string | null
 ) {
+  return (await createPieceTechniqueWithReplaySVC(body, audit, idempotencyKey)).piece;
+}
+
+/** Variante HTTP : conserve l'information 201 (création) / 200 (rejeu). */
+export async function createPieceTechniqueWithReplaySVC(
+  body: CreatePieceTechniqueBodyDTO,
+  audit: AuditContext,
+  idempotencyKey?: string | null
+): Promise<RepoCreatePieceTechniqueResult> {
   const statut = body.statut ?? "DRAFT";
   const enFabrication = statut === "IN_FABRICATION";
 
@@ -155,9 +166,9 @@ export async function createPieceTechniqueSVC(
     );
   } catch (err: unknown) {
     // pg unique violation
-    const code = (err as { code?: unknown } | null)?.code;
-    const detail = (err as { detail?: unknown } | null)?.detail;
-    if (code === "23505") {
+    const pg = err as { code?: unknown; constraint?: unknown; detail?: unknown } | null;
+    if (pg?.code === "23505" && pg.constraint !== PIECE_TECHNIQUE_IDEMPOTENCY_CONSTRAINT) {
+      const detail = pg.detail;
       const msg = typeof detail === "string" && detail.includes("code_piece") ? "Code de pièce déjà utilisé" : "Conflit de contrainte";
       throw new HttpError(409, "CODE_ALREADY_EXISTS", msg);
     }

--- a/src/module/production/repository/production-receipts.repository.ts
+++ b/src/module/production/repository/production-receipts.repository.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from "crypto";
 
 import pool from "../../../config/database";
 import { generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
+import { canonicalizeStockUnitCode } from "../../../shared/stock-unit";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
@@ -354,7 +355,7 @@ export async function reserveProducedQtyForCommandeLine(
   return reservationId ? { reservation_id: reservationId, qty_reserved: qtyToReserve } : null;
 }
 
-async function resolveUnitIdForArticle(
+export async function resolveUnitIdForArticle(
   client: Pick<PoolClient, "query">,
   articleId: string,
   preferredUnitCode: string | null | undefined
@@ -370,12 +371,13 @@ async function resolveUnitIdForArticle(
     code = a.rows[0]?.unite?.trim() ? a.rows[0].unite!.trim() : null;
   }
 
+  code = canonicalizeStockUnitCode(code);
   if (!code) {
     throw new HttpError(422, "UNIT_REQUIRED", "Veuillez renseigner l'unite pour la mise en stock");
   }
 
   const u = await client.query<{ id: string }>(
-    `SELECT id::text AS id FROM public.units WHERE code = $1::citext LIMIT 1`,
+    `SELECT id::text AS id FROM public.units WHERE lower(code::text) = lower($1) LIMIT 1`,
     [code]
   );
   const unitId = u.rows[0]?.id;

--- a/src/module/qualite/repository/qualite.repository.ts
+++ b/src/module/qualite/repository/qualite.repository.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 
 import pool from "../../../config/database";
 import { generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
+import { canonicalizeStockUnitCode } from "../../../shared/stock-unit";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -2696,16 +2697,19 @@ async function reserveStockMovementNo(tx: DbQueryer): Promise<string> {
   return movementNoFromSeq(n);
 }
 
-async function resolveUnitIdForArticle(tx: DbQueryer, articleId: string, preferredUnitCode: string | null | undefined): Promise<string> {
+export async function resolveUnitIdForArticle(tx: DbQueryer, articleId: string, preferredUnitCode: string | null | undefined): Promise<string> {
   const preferred = preferredUnitCode?.trim() ? preferredUnitCode.trim() : null;
   let code: string | null = preferred;
   if (!code) {
     const a = await tx.query<{ unite: string | null }>(`SELECT unite FROM public.articles WHERE id = $1::uuid`, [articleId]);
     code = a.rows[0]?.unite?.trim() ? a.rows[0].unite.trim() : null;
   }
-  if (!code) code = "u";
+  code = canonicalizeStockUnitCode(code) ?? "u";
 
-  const u = await tx.query<{ id: string }>(`SELECT id::text AS id FROM public.units WHERE code = $1`, [code]);
+  const u = await tx.query<{ id: string }>(
+    `SELECT id::text AS id FROM public.units WHERE lower(code::text) = lower($1) LIMIT 1`,
+    [code]
+  );
   const unitId = u.rows[0]?.id;
   if (!unitId) {
     throw new HttpError(400, "UNKNOWN_UNIT", `Unknown unit code: ${code}`);

--- a/src/module/stock/controllers/stock.controller.ts
+++ b/src/module/stock/controllers/stock.controller.ts
@@ -116,6 +116,7 @@ import {
   getStockArticleSVC,
   getStockArticlesKpisSVC,
   listStockArticleCategoriesSVC,
+  listStockUnitsSVC,
   listStockArticleFamiliesSVC,
   listStockMatiereEtatsSVC,
   listStockMatiereNuancesSVC,
@@ -438,6 +439,15 @@ export const listSimilarStockArticles: RequestHandler = async (req, res, next) =
 export const listStockArticleCategories: RequestHandler = async (_req, res, next) => {
   try {
     const out = await listStockArticleCategoriesSVC();
+    res.json({ items: out, total: out.length });
+  } catch (err) {
+    next(err);
+  }
+};
+
+export const listStockUnits: RequestHandler = async (_req, res, next) => {
+  try {
+    const out = await listStockUnitsSVC();
     res.json({ items: out, total: out.length });
   } catch (err) {
     next(err);

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -833,6 +833,13 @@ export async function repoListArticleCategories(): Promise<StockArticleCategoryO
   return ARTICLE_CATEGORY_OPTIONS;
 }
 
+export async function repoListStockUnits(): Promise<Array<{ code: string; label: string }>> {
+  const res = await db.query<{ code: string; label: string }>(
+    `SELECT code, label FROM public.units ORDER BY code ASC`
+  );
+  return res.rows;
+}
+
 export async function repoListArticleFamilies(
   filters: ListArticleFamiliesQueryDTO = {}
 ): Promise<StockArticleFamily[]> {
@@ -1894,7 +1901,32 @@ function parseEffectiveAt(raw: string | null | undefined): Date {
   return dt;
 }
 
-async function resolveUnitIdForArticle(
+/**
+ * `public.units.code` is the single stock-unit referential. Articles retain
+ * their unit as a code so every creation/update must check that code before it
+ * can later be used by a stock movement.
+ */
+export async function assertCanonicalArticleUnit(
+  client: Pick<PoolClient, "query">,
+  unitCode: string | null | undefined
+): Promise<void> {
+  const code = unitCode?.trim() ? unitCode.trim() : null;
+  if (!code) return;
+
+  const unit = await client.query<{ code: string }>(
+    `SELECT code FROM public.units WHERE code = $1`,
+    [code]
+  );
+  if (!unit.rows[0]) {
+    throw new HttpError(
+      400,
+      "INVALID_ARTICLE_UNIT",
+      `L'unité article « ${code} » est inconnue. Choisissez un code du référentiel public.units.`
+    );
+  }
+}
+
+export async function resolveUnitIdForArticle(
   client: Pick<PoolClient, "query">,
   articleId: string,
   preferredUnitCode: string | null | undefined
@@ -3122,6 +3154,8 @@ export async function repoCreateArticleTx(
   body: CreateArticleBodyDTO,
   audit: AuditContext
 ): Promise<CreatedArticleSummary> {
+  await assertCanonicalArticleUnit(client, body.unite);
+
   const normalized = await normalizeArticleState({
     article_type: body.article_type,
     article_category: body.article_category,
@@ -3524,6 +3558,10 @@ export async function repoUpdateArticle(
 
     if (current.stock_managed && !normalized.stock_managed) {
       await ensureArticleCanDisableStockManagement(client, id);
+    }
+
+    if (patch.unite !== undefined) {
+      await assertCanonicalArticleUnit(client, patch.unite);
     }
 
     if (patch.designation !== undefined) sets.push(`designation = ${push(patch.designation)}`);

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -21,6 +21,7 @@ import {
   type MaterialCodeResult,
   type MaterialProfileCode,
 } from "../../../shared/codes/material-article-code";
+import { canonicalizeStockUnitCode } from "../../../shared/stock-unit";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -837,7 +838,16 @@ export async function repoListStockUnits(): Promise<Array<{ code: string; label:
   const res = await db.query<{ code: string; label: string }>(
     `SELECT code, label FROM public.units ORDER BY code ASC`
   );
-  return res.rows;
+  const canonical = new Map<string, { code: string; label: string }>();
+  for (const row of res.rows) {
+    const code = canonicalizeStockUnitCode(row.code);
+    if (!code) continue;
+    const current = canonical.get(code);
+    if (!current || row.code.trim().toLowerCase() === code) {
+      canonical.set(code, { code, label: row.label });
+    }
+  }
+  return [...canonical.values()].sort((a, b) => a.code.localeCompare(b.code, "fr"));
 }
 
 export async function repoListArticleFamilies(
@@ -1906,24 +1916,35 @@ function parseEffectiveAt(raw: string | null | undefined): Date {
  * their unit as a code so every creation/update must check that code before it
  * can later be used by a stock movement.
  */
+async function findCanonicalStockUnit(
+  client: Pick<PoolClient, "query">,
+  unitCode: string | null | undefined
+): Promise<{ id: string | null; code: string } | null> {
+  const code = canonicalizeStockUnitCode(unitCode);
+  if (!code) return null;
+  const unit = await client.query<{ id: string | null }>(
+    `SELECT id::text AS id FROM public.units WHERE lower(code::text) = lower($1) LIMIT 1`,
+    [code]
+  );
+  const row = unit.rows[0];
+  return row ? { id: row.id, code } : null;
+}
+
 export async function assertCanonicalArticleUnit(
   client: Pick<PoolClient, "query">,
   unitCode: string | null | undefined
-): Promise<void> {
-  const code = unitCode?.trim() ? unitCode.trim() : null;
-  if (!code) return;
-
-  const unit = await client.query<{ code: string }>(
-    `SELECT code FROM public.units WHERE code = $1`,
-    [code]
-  );
-  if (!unit.rows[0]) {
+): Promise<string | null> {
+  if (!canonicalizeStockUnitCode(unitCode)) return null;
+  const unit = await findCanonicalStockUnit(client, unitCode);
+  if (!unit) {
+    const submitted = unitCode?.trim() ?? "";
     throw new HttpError(
       400,
       "INVALID_ARTICLE_UNIT",
-      `L'unité article « ${code} » est inconnue. Choisissez un code du référentiel public.units.`
+      `L'unité article « ${submitted} » est inconnue. Choisissez un code du référentiel des unités de stock.`
     );
   }
+  return unit.code;
 }
 
 export async function resolveUnitIdForArticle(
@@ -1931,8 +1952,7 @@ export async function resolveUnitIdForArticle(
   articleId: string,
   preferredUnitCode: string | null | undefined
 ): Promise<string> {
-  const preferred = preferredUnitCode?.trim() ? preferredUnitCode.trim() : null;
-  let code: string | null = preferred;
+  let code: string | null = preferredUnitCode?.trim() ? preferredUnitCode.trim() : null;
 
   if (!code) {
     const a = await client.query<{ unite: string | null }>(
@@ -1944,8 +1964,8 @@ export async function resolveUnitIdForArticle(
 
   if (!code) code = "u";
 
-  const u = await client.query<{ id: string }>(`SELECT id::text AS id FROM public.units WHERE code = $1`, [code]);
-  const unitId = u.rows[0]?.id;
+  const unit = await findCanonicalStockUnit(client, code);
+  const unitId = unit?.id;
   if (!unitId) {
     throw new HttpError(400, "UNKNOWN_UNIT", `Unknown unit code: ${code}`);
   }
@@ -3154,7 +3174,7 @@ export async function repoCreateArticleTx(
   body: CreateArticleBodyDTO,
   audit: AuditContext
 ): Promise<CreatedArticleSummary> {
-  await assertCanonicalArticleUnit(client, body.unite);
+  const canonicalUnit = await assertCanonicalArticleUnit(client, body.unite);
 
   const normalized = await normalizeArticleState({
     article_type: body.article_type,
@@ -3243,7 +3263,7 @@ export async function repoCreateArticleTx(
       normalized.family_code,
       normalized.stock_managed,
       normalized.piece_technique_id,
-      body.unite ?? null,
+      canonicalUnit,
       articleId,
       null,
       normalized.version_number,
@@ -3560,9 +3580,9 @@ export async function repoUpdateArticle(
       await ensureArticleCanDisableStockManagement(client, id);
     }
 
-    if (patch.unite !== undefined) {
-      await assertCanonicalArticleUnit(client, patch.unite);
-    }
+    const canonicalUnit = patch.unite !== undefined
+      ? await assertCanonicalArticleUnit(client, patch.unite)
+      : undefined;
 
     if (patch.designation !== undefined) sets.push(`designation = ${push(patch.designation)}`);
     if (patch.designation_secondary !== undefined) sets.push(`designation_secondary = ${push(patch.designation_secondary)}`);
@@ -3575,7 +3595,7 @@ export async function repoUpdateArticle(
     sets.push(`family_code = ${push(normalized.family_code)}`);
     sets.push(`stock_managed = ${push(normalized.stock_managed)}`);
     sets.push(`piece_technique_id = ${push(normalized.piece_technique_id)}::uuid`);
-    if (patch.unite !== undefined) sets.push(`unite = ${push(patch.unite)}`);
+    if (patch.unite !== undefined) sets.push(`unite = ${push(canonicalUnit ?? null)}`);
     sets.push(`lot_tracking = ${push(normalized.lot_tracking)}`);
     if (patch.is_sold !== undefined) sets.push(`is_sold = ${push(patch.is_sold)}`);
     if (patch.notes !== undefined) sets.push(`notes = ${push(patch.notes)}`);

--- a/src/module/stock/routes/stock.routes.ts
+++ b/src/module/stock/routes/stock.routes.ts
@@ -37,6 +37,7 @@ import {
   getStockInventorySession,
   getStockArticle,
   listStockArticleCategories,
+  listStockUnits,
   listStockArticleFamilies,
   getStockArticlesKpis,
   getStockLot,
@@ -130,6 +131,7 @@ router.get("/positions", requireStockCapability("read"), listConsolidatedInvento
 router.get("/inventory", requireStockCapability("read"), listConsolidatedInventory);
 router.post("/historical-imports", requireStockCapability("movement_create"), createHistoricalImport);
 router.get("/article-categories", requireStockCapability("read"), listStockArticleCategories);
+router.get("/units", requireStockCapability("read"), listStockUnits);
 router.get("/article-families", requireStockCapability("read"), listStockArticleFamilies);
 router.post("/article-families", requireArticleWrite, createStockArticleFamily);
 router.get("/matiere-nuances", requireStockCapability("read"), listStockMatiereNuances);

--- a/src/module/stock/services/stock.service.ts
+++ b/src/module/stock/services/stock.service.ts
@@ -99,6 +99,7 @@ import {
   repoGetStockAnalytics,
   repoGetArticle,
   repoListArticleCategories,
+  repoListStockUnits,
   repoListArticleFamilies,
   repoPreviewMaterialArticleCode,
   repoListMatiereEtats,
@@ -255,6 +256,10 @@ export async function getStockArticlesKpisSVC(): Promise<StockArticleKpis> {
 
 export async function listStockArticleCategoriesSVC(): Promise<StockArticleCategoryOption[]> {
   return repoListArticleCategories();
+}
+
+export async function listStockUnitsSVC(): Promise<Array<{ code: string; label: string }>> {
+  return repoListStockUnits();
 }
 
 export async function listStockArticleFamiliesSVC(filters: ListArticleFamiliesQueryDTO): Promise<StockArticleFamily[]> {

--- a/src/shared/stock-unit.ts
+++ b/src/shared/stock-unit.ts
@@ -1,0 +1,29 @@
+/**
+ * Canonical stock-unit vocabulary observed in CERP's historical article,
+ * import, surface-finish and production contracts.
+ *
+ * This adapter only normalises spelling and case. It never converts a
+ * quantity between units.
+ */
+const STOCK_UNIT_ALIASES: Readonly<Record<string, string>> = {
+  pc: "u",
+  pce: "u",
+  pces: "u",
+  pcs: "u",
+  piece: "u",
+  pieces: "u",
+  pièce: "u",
+  pièces: "u",
+  unit: "u",
+  units: "u",
+  unite: "u",
+  unites: "u",
+  unité: "u",
+  unités: "u",
+};
+
+export function canonicalizeStockUnitCode(unitCode: string | null | undefined): string | null {
+  const token = unitCode?.trim().normalize("NFKC").toLocaleLowerCase("fr-FR") ?? "";
+  if (!token) return null;
+  return STOCK_UNIT_ALIASES[token] ?? token;
+}


### PR DESCRIPTION
## Résumé

Promotion de la vague 3 validée sur `dev` :

- fiabilisation de la création de pièce technique et idempotence backend ;
- contrat canonique des unités de stock ;
- tests de routes/services et scripts SQL documentés (aucun SQL exécuté pendant l’intégration).

## Validation

- suite complète backend : 174 fichiers / 3 609 tests réussis ;
- tests ciblés de la dernière correction : 104/104 ;
- build TypeScript strict réussi ;
- `main` vérifié ancêtre de `dev` avant promotion.

## Summary by Sourcery

Strengthen backend idempotent creation of technical parts and enforce a canonical stock-unit contract across article, stock, production, delivery, and quality modules.

Bug Fixes:
- Prevent race conditions when creating technical parts with idempotency keys by serializing concurrent requests and distinguishing key reuse from business code conflicts.
- Ensure stock movements consistently resolve units from articles using case-insensitive canonical codes and reject unknown units before persisting changes.

Enhancements:
- Replay technical part creations now returns full nomenclature, operations, and purchase data while preserving 200/201 semantics for HTTP clients.
- Introduce a shared stock-unit canonicalization helper and expose a canonical units referential via a secured stock API endpoint.
- Add guarded SQL patch, preflight, verification, and rollback scripts to seed and track canonical stock units without altering historical article data.

Tests:
- Add comprehensive route and service tests for technical part creation idempotence, including concurrent scenarios and replay behaviour.
- Add contract tests covering article unit creation, stock movements, and cross-module unit resolution adapters, plus role-based access tests for the stock units endpoint.