### PR TITLE
fix(stock): exposer les états terminaux de compensation

### DIFF
--- a/src/__tests__/stock-compensation-feedback.test.ts
+++ b/src/__tests__/stock-compensation-feedback.test.ts
@@ -1,0 +1,307 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const database = vi.hoisted(() => ({
+  query: vi.fn(),
+  connect: vi.fn(),
+}));
+
+vi.mock("../config/database", () => ({ default: database }));
+
+import { hashStockCommand } from "../module/stock/domain/stock-command";
+import {
+  beginStockCommand,
+  repoCompensateMovement,
+  repoPreviewMovementCompensation,
+  type AuditContext,
+} from "../module/stock/repository/stock.repository";
+
+const ORIGINAL_ID = "11111111-1111-4111-8111-111111111111";
+const COMPENSATION_ID = "22222222-2222-4222-8222-222222222222";
+const ARTICLE_ID = "33333333-3333-4333-8333-333333333333";
+const MAGASIN_ID = "44444444-4444-4444-8444-444444444444";
+const POSTED_AT = "2026-08-04T08:00:00.000Z";
+const BODY = {
+  reason: "Correction du comptage atelier",
+  expected_posted_at: POSTED_AT,
+};
+const AUDIT: AuditContext = {
+  user_id: 7,
+  ip: null,
+  user_agent: null,
+  device_type: null,
+  os: null,
+  browser: null,
+  path: "/api/v1/stock/movements/:id/compensate",
+  page_key: "stock-movement-detail",
+  client_session_id: null,
+};
+
+function movementRow(args: {
+  id?: string;
+  movementNo?: string;
+  status?: string;
+  postedAt?: string | null;
+  movementType?: string;
+} = {}) {
+  return {
+    id: args.id ?? ORIGINAL_ID,
+    movement_no: args.movementNo ?? "MVT-00042",
+    movement_type: args.movementType ?? "IN",
+    status: args.status ?? "POSTED",
+    article_id: ARTICLE_ID,
+    stock_level_id: null,
+    stock_batch_id: null,
+    qty: 5,
+    effective_at: "2026-08-04T07:55:00.000Z",
+    posted_at: args.postedAt === undefined ? POSTED_AT : args.postedAt,
+    source_document_type: "MANUAL",
+    source_document_id: null,
+    reason_code: "RECEIPT",
+    correlation_id: null,
+    reversal_of_id: args.id === COMPENSATION_ID ? ORIGINAL_ID : null,
+    notes: null,
+    created_at: "2026-08-04T07:50:00.000Z",
+    updated_at: "2026-08-04T08:00:00.000Z",
+    created_by: 7,
+    updated_by: 7,
+    posted_by: 7,
+  };
+}
+
+function movementLine(movementId = ORIGINAL_ID) {
+  return {
+    id: "55555555-5555-4555-8555-555555555555",
+    movement_id: movementId,
+    line_no: 1,
+    article_id: ARTICLE_ID,
+    article_code: "ART-001",
+    article_designation: "Article test",
+    lot_id: null,
+    lot_code: null,
+    qty: 5,
+    unite: "u",
+    unit_cost: null,
+    currency: null,
+    src_magasin_id: null,
+    src_magasin_code: null,
+    src_magasin_name: null,
+    src_emplacement_id: null,
+    src_emplacement_code: null,
+    src_emplacement_name: null,
+    dst_magasin_id: MAGASIN_ID,
+    dst_magasin_code: "MAG-01",
+    dst_magasin_name: "Magasin principal",
+    dst_emplacement_id: 1,
+    dst_emplacement_code: "RACK-01",
+    dst_emplacement_name: "Rack 01",
+    note: null,
+    direction: null,
+  };
+}
+
+function mockMovementQueries(args: {
+  originalPostedAt?: string | null;
+  existingCompensation?: { id: string; movement_no: string; status: string } | null;
+  requestedMovementId?: string;
+} = {}) {
+  database.query.mockImplementation(async (sql: unknown, values?: unknown[]) => {
+    const text = String(sql);
+    const requestedId = String(values?.[0] ?? args.requestedMovementId ?? ORIGINAL_ID);
+    if (text.includes("WHERE id = $1::uuid")) {
+      return {
+        rows: [
+          requestedId === COMPENSATION_ID
+            ? movementRow({
+                id: COMPENSATION_ID,
+                movementNo: "MVT-COMP-00042",
+                status: "DRAFT",
+                postedAt: null,
+                movementType: "OUT",
+              })
+            : movementRow({ postedAt: args.originalPostedAt }),
+        ],
+      };
+    }
+    if (text.includes("FROM public.stock_movement_lines l")) {
+      return { rows: [movementLine(requestedId)] };
+    }
+    if (text.includes("FROM public.stock_movement_documents md")) return { rows: [] };
+    if (text.includes("FROM public.stock_movement_event_log")) return { rows: [] };
+    if (text.includes("WHERE reversal_of_id = $1::uuid")) {
+      return { rows: args.existingCompensation ? [args.existingCompensation] : [] };
+    }
+    return { rows: [] };
+  });
+}
+
+beforeEach(() => {
+  database.query.mockReset();
+  database.connect.mockReset();
+});
+
+describe("BUG-CERP-0014 stock compensation feedback", () => {
+  it("returns an explicit, authoritative eligible terminal state", async () => {
+    mockMovementQueries();
+
+    const preview = await repoPreviewMovementCompensation(ORIGINAL_ID, BODY);
+
+    expect(preview).toMatchObject({
+      authoritative: true,
+      original_movement_id: ORIGINAL_ID,
+      outcome: "ELIGIBLE",
+      compensable: true,
+      blockers: [],
+      existing_compensation: null,
+      proposed_movement: {
+        movement_type: "OUT",
+        source_document_type: "STOCK_COMPENSATION",
+        source_document_id: ORIGINAL_ID,
+      },
+    });
+    expect(preview?.as_of).toEqual(expect.any(String));
+    expect(preview?.prerequisites.every((item) => item.satisfied)).toBe(true);
+  });
+
+  it("explains a missing posting timestamp in French without proposing a write", async () => {
+    mockMovementQueries({ originalPostedAt: null });
+
+    const preview = await repoPreviewMovementCompensation(ORIGINAL_ID, BODY);
+
+    expect(preview).toMatchObject({
+      outcome: "INELIGIBLE",
+      compensable: false,
+      proposed_movement: null,
+    });
+    expect(preview?.blockers).toContainEqual({
+      code: "POSTED_AT_MISSING",
+      message: expect.stringMatching(/date de comptabilisation est absente/i),
+    });
+    expect(preview?.prerequisites).toContainEqual(
+      expect.objectContaining({
+        code: "POSTED_AT_MISSING",
+        satisfied: false,
+      })
+    );
+  });
+
+  it("returns an existing compensation as a linkable terminal state", async () => {
+    const existingCompensation = {
+      id: COMPENSATION_ID,
+      movement_no: "MVT-COMP-00042",
+      status: "DRAFT",
+    };
+    mockMovementQueries({ existingCompensation });
+
+    const preview = await repoPreviewMovementCompensation(ORIGINAL_ID, BODY);
+
+    expect(preview).toMatchObject({
+      outcome: "ALREADY_COMPENSATED",
+      compensable: false,
+      existing_compensation: existingCompensation,
+      proposed_movement: null,
+    });
+    expect(preview?.blockers).toContainEqual({
+      code: "COMPENSATION_ALREADY_EXISTS",
+      message: expect.stringMatching(/ouvrez-la au lieu de créer un doublon/i),
+    });
+  });
+
+  it("replays a double action with the same intent key without creating another movement", async () => {
+    const requestHash = hashStockCommand("MOVEMENT_COMPENSATE", {
+      movement_id: ORIGINAL_ID,
+      ...BODY,
+    });
+    const clientQuery = vi.fn(async (sql: unknown) => {
+      const text = String(sql);
+      if (text.includes("FROM public.stock_command_receipts")) {
+        return {
+          rows: [
+            {
+              request_hash: requestHash,
+              resource_type: "stock_movement",
+              resource_id: COMPENSATION_ID,
+              result_payload: {
+                compensation_movement_id: COMPENSATION_ID,
+                reversal_of_id: ORIGINAL_ID,
+                status: "DRAFT",
+              },
+              correlation_id: "66666666-6666-4666-8666-666666666666",
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+    database.connect.mockResolvedValue({
+      query: clientQuery,
+      release: vi.fn(),
+    });
+    mockMovementQueries({ requestedMovementId: COMPENSATION_ID });
+
+    const replay = await repoCompensateMovement(
+      ORIGINAL_ID,
+      BODY,
+      AUDIT,
+      "stock-compensation-intent-00042"
+    );
+
+    expect(replay?.movement).toMatchObject({
+      id: COMPENSATION_ID,
+      movement_no: "MVT-COMP-00042",
+      status: "DRAFT",
+    });
+    expect(
+      clientQuery.mock.calls.some(([sql]) =>
+        String(sql).includes("INSERT INTO public.stock_command_receipts")
+      )
+    ).toBe(false);
+    expect(
+      database.query.mock.calls.some(([sql]) =>
+        String(sql).includes("WHERE reversal_of_id = $1::uuid")
+      )
+    ).toBe(false);
+  });
+
+  it("rejects the same intention key when the compensation payload changes", async () => {
+    const originalRequestHash = hashStockCommand("MOVEMENT_COMPENSATE", {
+      movement_id: ORIGINAL_ID,
+      ...BODY,
+    });
+    const query = vi.fn(async (sql: unknown) => {
+      const text = String(sql);
+      if (text.includes("FROM public.stock_command_receipts")) {
+        return {
+          rows: [
+            {
+              request_hash: originalRequestHash,
+              resource_type: "stock_movement",
+              resource_id: COMPENSATION_ID,
+              result_payload: {},
+              correlation_id: "66666666-6666-4666-8666-666666666666",
+            },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    await expect(
+      beginStockCommand(
+        { query } as never,
+        {
+          audit: AUDIT,
+          idempotency_key: "stock-compensation-intent-00042",
+          command_type: "MOVEMENT_COMPENSATE",
+          request_payload: {
+            movement_id: ORIGINAL_ID,
+            ...BODY,
+            reason: "Un autre motif ne doit pas partager la clé",
+          },
+        }
+      )
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "IDEMPOTENCY_KEY_REUSED",
+    });
+  });
+});

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -6244,43 +6244,108 @@ export async function repoPreviewMovement(
 function buildCompensatingMovementBody(
   detail: StockMovementDetail,
   body: CompensateMovementBodyDTO
-): { movement: CreateMovementBodyDTO | null; blockers: Array<{ code: string; message: string }> } {
+): {
+  movement: CreateMovementBodyDTO | null;
+  blockers: Array<{ code: string; message: string }>;
+  prerequisites: StockMovementCompensationPreview["prerequisites"];
+} {
   const blockers: Array<{ code: string; message: string }> = [];
-  if (detail.movement.status !== "POSTED") {
-    blockers.push({ code: "INVALID_STATUS", message: "Only POSTED movements can be compensated" });
-  }
-  if (!detail.movement.posted_at) {
-    blockers.push({ code: "POSTED_AT_MISSING", message: "Posted movement timestamp is missing" });
-  } else if (
-    new Date(detail.movement.posted_at).getTime() !== new Date(body.expected_posted_at).getTime()
-  ) {
-    blockers.push({
+  const prerequisites: StockMovementCompensationPreview["prerequisites"] = [];
+  const addPrerequisite = (args: {
+    code: string;
+    label: string;
+    satisfied: boolean;
+    successMessage: string;
+    failureMessage: string;
+  }) => {
+    const message = args.satisfied ? args.successMessage : args.failureMessage;
+    prerequisites.push({
+      code: args.code,
+      label: args.label,
+      satisfied: args.satisfied,
+      message,
+    });
+    if (!args.satisfied) blockers.push({ code: args.code, message });
+  };
+
+  addPrerequisite({
+    code: "INVALID_STATUS",
+    label: "Mouvement comptabilisé",
+    satisfied: detail.movement.status === "POSTED",
+    successMessage: "Le mouvement d'origine est comptabilisé et reste immuable.",
+    failureMessage:
+      "Le mouvement doit être comptabilisé (statut POSTED) avant de préparer une compensation.",
+  });
+
+  const hasPostedAt = Boolean(detail.movement.posted_at);
+  addPrerequisite({
+    code: "POSTED_AT_MISSING",
+    label: "Date de comptabilisation disponible",
+    satisfied: hasPostedAt,
+    successMessage: "La date de comptabilisation de l'écriture d'origine est disponible.",
+    failureMessage:
+      "La date de comptabilisation est absente. Rechargez le mouvement ou contactez le support Stock avant de continuer.",
+  });
+
+  if (detail.movement.posted_at) {
+    const postingTimestampMatches =
+      new Date(detail.movement.posted_at).getTime() ===
+      new Date(body.expected_posted_at).getTime();
+    addPrerequisite({
       code: "CONCURRENT_MODIFICATION",
-      message: "Movement posting timestamp no longer matches the preview",
+      label: "Aperçu à jour",
+      satisfied: postingTimestampMatches,
+      successMessage: "Le mouvement n'a pas changé depuis son chargement.",
+      failureMessage:
+        "Le mouvement a changé depuis son chargement. Rechargez la fiche puis relancez la prévisualisation.",
     });
   }
-  if (!detail.lines.length) {
-    blockers.push({ code: "MOVEMENT_LINES_MISSING", message: "Movement has no traceable lines" });
-  }
-  if (
-    detail.movement.movement_type === "SCRAP" ||
-    detail.movement.movement_type === "DEPRECIATE"
-  ) {
-    blockers.push({
-      code: "QUALITY_FLOW_REQUIRED",
-      message: "Scrap and depreciation reversals require a dedicated quality decision",
-    });
-  }
-  if (
-    detail.movement.movement_type === "RESERVE" ||
-    detail.movement.movement_type === "UNRESERVE"
-  ) {
-    blockers.push({
-      code: "RESERVATION_FLOW_REQUIRED",
-      message: "Reservation corrections must use the reservation lifecycle",
-    });
-  }
-  if (blockers.length) return { movement: null, blockers };
+
+  addPrerequisite({
+    code: "MOVEMENT_LINES_MISSING",
+    label: "Lignes de stock traçables",
+    satisfied: detail.lines.length > 0,
+    successMessage: "Les lignes de l'écriture d'origine sont traçables.",
+    failureMessage:
+      "Aucune ligne traçable n'est disponible. Vérifiez l'écriture d'origine avant de continuer.",
+  });
+
+  const movementType = detail.movement.movement_type;
+  const movementTypePrerequisite = (() => {
+    if (movementType === "SCRAP" || movementType === "DEPRECIATE") {
+      return {
+        code: "QUALITY_FLOW_REQUIRED",
+        failureMessage:
+          "Les rebuts et dépréciations se corrigent depuis le flux Qualité dédié.",
+      };
+    }
+    if (movementType === "RESERVE" || movementType === "UNRESERVE") {
+      return {
+        code: "RESERVATION_FLOW_REQUIRED",
+        failureMessage:
+          "Les réservations se corrigent depuis leur cycle de vie dédié.",
+      };
+    }
+    const supported = new Set(["IN", "OUT", "TRANSFER", "ADJUST", "ADJUSTMENT"]);
+    return supported.has(movementType)
+      ? null
+      : {
+          code: "MOVEMENT_NOT_COMPENSABLE",
+          failureMessage:
+            "Ce type de mouvement ne peut pas être compensé automatiquement. Contactez le responsable Stock.",
+        };
+  })();
+  addPrerequisite({
+    code: movementTypePrerequisite?.code ?? "MOVEMENT_TYPE_SUPPORTED",
+    label: "Type de mouvement pris en charge",
+    satisfied: movementTypePrerequisite === null,
+    successMessage: "Le type de mouvement peut produire un brouillon inverse.",
+    failureMessage:
+      movementTypePrerequisite?.failureMessage ??
+      "Ce type de mouvement ne peut pas être compensé automatiquement.",
+  });
+
+  if (blockers.length) return { movement: null, blockers, prerequisites };
 
   let reverseType: CreateMovementBodyDTO["movement_type"];
   switch (detail.movement.movement_type) {
@@ -6300,7 +6365,14 @@ function buildCompensatingMovementBody(
     default:
       return {
         movement: null,
-        blockers: [{ code: "MOVEMENT_NOT_COMPENSABLE", message: "Movement type cannot be compensated" }],
+        blockers: [
+          {
+            code: "MOVEMENT_NOT_COMPENSABLE",
+            message:
+              "Ce type de mouvement ne peut pas être compensé automatiquement. Contactez le responsable Stock.",
+          },
+        ],
+        prerequisites,
       };
   }
 
@@ -6365,6 +6437,7 @@ function buildCompensatingMovementBody(
 
   return {
     blockers,
+    prerequisites,
     movement: {
       movement_type: reverseType,
       effective_at: new Date().toISOString(),
@@ -6397,13 +6470,24 @@ export async function repoPreviewMovementCompensation(
     [id]
   );
   const built = buildCompensatingMovementBody(detail, body);
-  if (existing.rows[0]) {
+  const existingCompensation = existing.rows[0] ?? null;
+  const noExistingCompensation = !existingCompensation;
+  const existingMessage = existingCompensation
+    ? `La compensation ${existingCompensation.movement_no ?? existingCompensation.id} existe déjà au statut ${existingCompensation.status}. Ouvrez-la au lieu de créer un doublon.`
+    : "Aucune compensation active n'existe pour ce mouvement.";
+  built.prerequisites.push({
+    code: "COMPENSATION_ALREADY_EXISTS",
+    label: "Aucune compensation déjà active",
+    satisfied: noExistingCompensation,
+    message: existingMessage,
+  });
+  if (existingCompensation) {
     built.blockers.push({
       code: "COMPENSATION_ALREADY_EXISTS",
-      message: `A ${existing.rows[0].status} compensation already exists`,
+      message: existingMessage,
     });
   }
-  const proposed = built.movement
+  const proposed = built.blockers.length === 0 && built.movement
     ? {
         movement_type: built.movement.movement_type,
         source_document_type: "STOCK_COMPENSATION" as const,
@@ -6425,10 +6509,19 @@ export async function repoPreviewMovementCompensation(
     : null;
 
   return {
+    authoritative: true,
+    as_of: new Date().toISOString(),
     original_movement_id: id,
     original_movement_no: detail.movement.movement_no,
+    outcome: existingCompensation
+      ? "ALREADY_COMPENSATED"
+      : built.blockers.length === 0
+        ? "ELIGIBLE"
+        : "INELIGIBLE",
     compensable: built.blockers.length === 0,
     blockers: built.blockers,
+    prerequisites: built.prerequisites,
+    existing_compensation: existingCompensation,
     proposed_movement: proposed,
   };
 }
@@ -6466,7 +6559,7 @@ export async function repoCompensateMovement(
     if (!preview.compensable || !preview.proposed_movement) {
       const blocker = preview.blockers[0] ?? {
         code: "MOVEMENT_NOT_COMPENSABLE",
-        message: "Movement cannot be compensated",
+        message: "Le mouvement ne peut pas être compensé.",
       };
       throw new HttpError(409, blocker.code, blocker.message, { blockers: preview.blockers });
     }
@@ -6475,7 +6568,11 @@ export async function repoCompensateMovement(
     if (!detail) return null;
     const built = buildCompensatingMovementBody(detail, body);
     if (!built.movement) {
-      throw new HttpError(409, "MOVEMENT_NOT_COMPENSABLE", "Movement cannot be compensated");
+      throw new HttpError(
+        409,
+        "MOVEMENT_NOT_COMPENSABLE",
+        "Le mouvement ne peut pas être compensé."
+      );
     }
     const derivedKeyHash = hashStockCommand("MOVEMENT_COMPENSATION_CREATE_KEY", {
       actor_user_id: audit.user_id,

--- a/src/module/stock/types/stock.types.ts
+++ b/src/module/stock/types/stock.types.ts
@@ -475,10 +475,24 @@ export type StockMovementDetail = {
 };
 
 export type StockMovementCompensationPreview = {
+  authoritative: true;
+  as_of: string;
   original_movement_id: string;
   original_movement_no: string | null;
+  outcome: "ELIGIBLE" | "INELIGIBLE" | "ALREADY_COMPENSATED";
   compensable: boolean;
   blockers: Array<{ code: string; message: string }>;
+  prerequisites: Array<{
+    code: string;
+    label: string;
+    satisfied: boolean;
+    message: string;
+  }>;
+  existing_compensation: {
+    id: string;
+    movement_no: string | null;
+    status: string;
+  } | null;
   proposed_movement: {
     movement_type: StockMovementType;
     source_document_type: "STOCK_COMPENSATION";


### PR DESCRIPTION
## Résumé

- étend l'aperçu de compensation avec une réponse autoritaire et datée
- expose les états ELIGIBLE, INELIGIBLE et ALREADY_COMPENSATED, avec prérequis et bloqueurs actionnables en français
- échoue fermé : aucun mouvement proposé lorsqu'un bloqueur existe, et référence la compensation existante sans créer de doublon
- préserve le ledger, l'audit trail et les reçus d'idempotence existants

## Validation

- npm run test:run -- src/__tests__/stock-compensation-feedback.test.ts : 5 tests passés
- npm run build : passé
- npm run test:run : suite complète passée
- aucun SQL ni environnement de production utilisé

## Déploiement

Déployer ce contrat backend avant la PR frontend associée afin que les nouveaux états soient disponibles à l'interface.

Référence BigFootLime/crp-systems-web#483

## Summary by Sourcery

Extend stock movement compensation preview with explicit terminal outcomes and richer feedback while preserving existing idempotency and audit behavior.

New Features:
- Expose compensation preview outcome states (ELIGIBLE, INELIGIBLE, ALREADY_COMPENSATED) along with authoritative timestamp and existing compensation metadata.
- Provide structured, user-facing prerequisites and blockers in French to guide compensation eligibility and corrective actions.
- Ensure compensation previews no longer propose new movements when blockers are present or an existing compensation already exists.

Enhancements:
- Localize stock compensation error and guidance messages to French for consistency with the UI.
- Clarify supported and unsupported movement types for automatic compensation via explicit prerequisite feedback.

Tests:
- Add unit tests covering eligible, ineligible, and already-compensated preview outcomes, including French feedback messages.
- Add tests verifying replay of duplicate compensation requests via idempotency receipts without creating new movements.
- Add tests ensuring idempotency key reuse with a different payload is rejected with a conflict error.