### PR TITLE
fix(commandes): aligner l'éligibilité article

### DIFF
--- a/src/__tests__/article-categories-commande-selectable-395.test.ts
+++ b/src/__tests__/article-categories-commande-selectable-395.test.ts
@@ -1,8 +1,6 @@
-// #395 — Référentiel des catégories d'article : ce qui est VENDABLE en commande client.
-//
-// Ce référentiel est un contrat, pas une préférence d'affichage : le frontend l'utilise à la
-// fois pour proposer les catégories à la création depuis une commande et pour filtrer la
-// recherche d'article des lignes. Un `false` posé ici ferme les deux portes d'un coup.
+// #395 / BUG-CERP-0015 - referentiel des categories commandables.
+// Le filtre de recherche et la creation depuis une commande doivent rester fermes sur le
+// perimetre que le repository Commande sait valider et convertir sans ambiguite.
 import { beforeAll, describe, expect, it } from "vitest";
 
 import {
@@ -11,14 +9,14 @@ import {
 } from "../module/stock/repository/stock.repository";
 import type { StockArticleCategoryOption } from "../module/stock/types/stock.types";
 
-describe("#395 — catégories vendables en commande client", () => {
+describe("#395 / BUG-CERP-0015 - categories commandables", () => {
   let options: StockArticleCategoryOption[] = [];
 
   beforeAll(async () => {
     options = await repoListArticleCategories();
   });
 
-  it("expose les six catégories métier du référentiel", () => {
+  it("expose les six categories metier du referentiel", () => {
     expect(options.map((option) => option.code).sort()).toEqual(
       [
         "achat_revente",
@@ -31,33 +29,28 @@ describe("#395 — catégories vendables en commande client", () => {
     );
   });
 
-  it("rend TOUTES les catégories vendables (élargissement #395)", () => {
-    // Régression : seule `piece_finie_fabriquee` l'était, ce qui rendait la création d'article
-    // depuis une commande inutilisable pour un achat, une sous-traitance ou un traitement.
-    const notSellable = options.filter((option) => !option.commande_client_selectable);
-    expect(notSellable.map((option) => option.code)).toEqual([]);
+  it("n'expose que la piece finie fabriquee a la creation depuis une commande", () => {
+    const selectable = options.filter((option) => option.commande_client_selectable);
+    expect(selectable.map((option) => option.code)).toEqual(["piece_finie_fabriquee"]);
   });
 
-  it("n'exige un dossier technique QUE pour une pièce finie fabriquée", () => {
-    // L'élargissement de la vente ne doit pas propager l'obligation de dossier technique :
-    // c'est lui qui produit les OF, et seule une pièce fabriquée en a un.
+  it("n'exige un dossier technique que pour une piece finie fabriquee", () => {
     const requiring = options.filter((option) => option.piece_technique_required).map((option) => option.code);
     expect(requiring).toEqual(["piece_finie_fabriquee"]);
   });
 
-  it("dérive la liste des codes vendables depuis le référentiel, sans liste parallèle", () => {
+  it("derive les codes commandables depuis le referentiel, sans liste parallele", () => {
     const derived = commandeClientSelectableCategoryCodes();
     const expected = options.filter((option) => option.commande_client_selectable).map((option) => option.code);
     expect(derived).toEqual(expected);
-    expect(derived.length).toBeGreaterThan(0);
+    expect(derived).toEqual(["piece_finie_fabriquee"]);
   });
 
-  it("conserve un segment de code et un comportement stock pour chaque catégorie", () => {
+  it("conserve un segment de code et un comportement stock pour chaque categorie", () => {
     for (const option of options) {
       expect(option.code_segment, `segment manquant pour ${option.code}`).toMatch(/^[A-Z]{2,5}$/);
       expect(typeof option.stock_managed_default, `stock_managed_default pour ${option.code}`).toBe("boolean");
     }
-    // Les services ne sont pas inventoriés : le référentiel doit continuer à le dire.
     const byCode = new Map(options.map((option) => [option.code, option]));
     expect(byCode.get("traitement_surface")?.stock_managed_default).toBe(false);
     expect(byCode.get("sous_traitance")?.stock_managed_default).toBe(false);

--- a/src/__tests__/commande-article-eligibility-315.test.ts
+++ b/src/__tests__/commande-article-eligibility-315.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  commandeArticleEligibleSql,
+  commandeArticleEligibilityError,
+  commandeArticleIneligibilityCodeSql,
+  commandeArticleIneligibilityFromState,
+} from "../module/stock/domain/commande-article-eligibility";
+
+const BASE = {
+  is_active: true,
+  stock_managed: true,
+  article_category: "fabrique",
+  piece_technique_id: "11111111-1111-4111-8111-111111111111",
+};
+
+describe("BUG-CERP-0015 - predicat canonique d'eligibilite article", () => {
+  it("accepte la categorie primaire fabriquee et sa valeur historique", () => {
+    expect(commandeArticleIneligibilityFromState(BASE)).toBeNull();
+    expect(
+      commandeArticleIneligibilityFromState({ ...BASE, article_category: "PIECE_TECHNIQUE" })
+    ).toBeNull();
+  });
+
+  it("reste fail-closed pour une matiere ayant seulement une categorie secondaire fabriquee", () => {
+    expect(
+      commandeArticleIneligibilityFromState({ ...BASE, article_category: "matiere" })
+    ).toBe("ARTICLE_NOT_FABRICATED");
+
+    const sql = commandeArticleEligibleSql("a");
+    expect(sql).toContain("a.article_category IN ('fabrique', 'PIECE_TECHNIQUE')");
+    expect(sql).not.toContain("article_category_link");
+    expect(sql).not.toContain("piece_finie_fabriquee");
+  });
+
+  it.each([
+    [{ ...BASE, is_active: false }, "ARTICLE_INACTIVE"],
+    [{ ...BASE, stock_managed: false }, "ARTICLE_NOT_STOCK_MANAGED"],
+    [{ ...BASE, article_category: "achat" }, "ARTICLE_NOT_FABRICATED"],
+    [{ ...BASE, piece_technique_id: null }, "ARTICLE_PIECE_TECHNIQUE_REQUIRED"],
+  ] as const)("classe chaque refus avant toute creation de ligne", (article, expected) => {
+    expect(commandeArticleIneligibilityFromState(article)).toBe(expected);
+  });
+
+  it("garde le verdict et la raison SQL alignes", () => {
+    const eligibleSql = commandeArticleEligibleSql("a");
+    const reasonSql = commandeArticleIneligibilityCodeSql("a");
+    for (const fragment of [
+      "a.is_active",
+      "a.stock_managed",
+      "a.article_category IN ('fabrique', 'PIECE_TECHNIQUE')",
+      "a.piece_technique_id",
+    ]) {
+      expect(eligibleSql).toContain(fragment);
+      expect(reasonSql).toContain(fragment);
+    }
+  });
+
+  it("retourne une erreur actionnable rattachee a la bonne ligne", () => {
+    const error = commandeArticleEligibilityError({
+      code: "ARTICLE_NOT_FABRICATED",
+      articleId: "22222222-2222-4222-8222-222222222222",
+      articleCode: "MAT-01",
+      lineIndex: 2,
+    });
+
+    expect(error.status).toBe(409);
+    expect(error.code).toBe("ARTICLE_NOT_FABRICATED");
+    expect(error.message).toMatch(/MAT-01/);
+    expect(error.details).toMatchObject({
+      field: "lignes.2.article_id",
+      line_index: 2,
+      article_code: "MAT-01",
+    });
+  });
+});

--- a/src/__tests__/commande-article-eligibility.routes.test.ts
+++ b/src/__tests__/commande-article-eligibility.routes.test.ts
@@ -43,6 +43,8 @@ import app from "../config/app";
 
 const ARTICLE_ID = "11111111-1111-4111-8111-111111111111";
 const PIECE_ID = "22222222-2222-4222-8222-222222222222";
+const SOURCE_ARTICLE_DEVIS_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const SOURCE_DOSSIER_DEVIS_ID = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
 
 const payload = {
   numero: "CC-315",
@@ -80,7 +82,8 @@ function ineligibleArticleRow() {
 
 function expectCanonicalResolverQuery() {
   const resolveCall = mocks.clientQuery.mock.calls.find((call) =>
-    String(call[0]).includes("FROM public.articles a")
+    String(call[0]).includes("FROM public.articles a") &&
+    String(call[0]).includes("AS commande_client_eligible")
   );
   const sql = String(resolveCall?.[0]).replace(/\s+/g, " ");
   expect(sql).toContain("a.is_active = TRUE");
@@ -91,7 +94,7 @@ function expectCanonicalResolverQuery() {
 }
 
 function expectActionableRejection(res: Response) {
-  expect(res.status).toBe(409);
+  expect(res.status, JSON.stringify(res.body)).toBe(409);
   expect(res.body).toMatchObject({
     code: "ARTICLE_NOT_FABRICATED",
     details: {
@@ -107,6 +110,45 @@ function expectActionableRejection(res: Response) {
     mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO commande_ligne"))
   ).toBe(false);
   expectCanonicalResolverQuery();
+}
+
+function preparatoryBundleRow() {
+  return {
+    article_devis_id: SOURCE_ARTICLE_DEVIS_ID,
+    article_devis_devis_id: 7,
+    article_code: "ART-DV-315",
+    article_designation: "Article devis 315",
+    primary_category: "piece_finie_fabriquee",
+    article_categories: ["piece_finie_fabriquee"],
+    family_code: "PT",
+    plan_index: 1,
+    projet_id: null,
+    source_official_article_id: ARTICLE_ID,
+    dossier_devis_id: SOURCE_DOSSIER_DEVIS_ID,
+    dossier_devis_devis_id: 7,
+    dossier_code_piece: "DTP-315",
+    dossier_designation: "Dossier 315",
+    source_official_piece_technique_id: PIECE_ID,
+    dossier_payload: {},
+  };
+}
+
+function preparatoryPayload() {
+  return {
+    ...payload,
+    officialize_preparatory_data: true,
+    lignes: [
+      {
+        source_article_devis_id: SOURCE_ARTICLE_DEVIS_ID,
+        source_dossier_devis_id: SOURCE_DOSSIER_DEVIS_ID,
+        designation: "Ligne preparatoire",
+        code_piece: "DTP-315",
+        quantite: 1,
+        prix_unitaire_ht: 19.5,
+        delai_client: "2026-09-30",
+      },
+    ],
+  };
 }
 
 beforeEach(() => {
@@ -167,5 +209,176 @@ describe("BUG-CERP-0015 - validation serveur POST/PATCH commandes", () => {
       .field("data", JSON.stringify(payload));
 
     expectActionableRejection(res);
+  });
+
+  it("refuse en POST une promotion preparatoire existante mais ineligible", async () => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query.includes("nextval('public.commande_client_id_seq')")) return { rows: [{ id: "315" }] };
+      if (query.includes("public.fn_next_issued_code_value")) return { rows: [{ v: "1" }] };
+      if (query.includes("INSERT INTO commande_client")) return { rows: [{ id: "315" }] };
+      if (query.includes("FROM public.article_devis ad")) return { rows: [preparatoryBundleRow()] };
+      if (query.includes("FROM public.dossier_technique_piece_devis_promotion")) {
+        return { rows: [{ promoted_piece_technique_id: PIECE_ID }] };
+      }
+      if (query.includes("FROM public.article_devis_promotion")) {
+        return { rows: [{ promoted_article_id: ARTICLE_ID }] };
+      }
+      if (
+        query.includes("FROM public.articles a") &&
+        (query.includes("WHERE a.id = $1::uuid") || query.includes("AS commande_client_eligible"))
+      ) {
+        return { rows: [ineligibleArticleRow()] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post("/api/v1/commandes")
+      .field("data", JSON.stringify(preparatoryPayload()));
+
+    expectActionableRejection(res);
+  });
+
+  it("refuse en PATCH un nouvel article preparatoire sans dossier technique", async () => {
+    let promotedArticleId: string | null = null;
+    mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => {
+      const query = String(sql);
+      if (query.includes("FROM commande_client") && query.includes("FOR UPDATE")) {
+        return {
+          rows: [{
+            numero: "CC-315",
+            client_id: "001",
+            devis_id: null,
+            order_type: "FERME",
+            adresse_facturation_id: null,
+            cadre_start_date: null,
+            cadre_end_date: null,
+            dest_stock_magasin_id: null,
+            dest_stock_emplacement_id: null,
+            ar_sent_at: null,
+          }],
+        };
+      }
+      if (query.includes("UPDATE commande_client") && query.includes("RETURNING id")) {
+        return { rows: [{ id: "315" }] };
+      }
+      if (query.includes("FROM public.article_devis_promotion")) return { rows: [] };
+      if (query.includes("INSERT INTO public.articles (")) {
+        promotedArticleId = String(params?.[0] ?? "");
+        return { rows: [] };
+      }
+      if (
+        query.includes("FROM public.articles a") &&
+        (query.includes("WHERE a.id = $1::uuid") || query.includes("AS commande_client_eligible"))
+      ) {
+        const articleId = promotedArticleId ?? String(params?.[0] ?? "");
+        return {
+          rows: [{
+            article_id: articleId,
+            article_code: "ART-DV-NO-DTP",
+            article_designation: "Article devis sans DTP",
+            article_category: "fabrique",
+            family_code: "PT",
+            article_unite: "u",
+            piece_technique_id: null,
+            piece_code: null,
+            piece_designation: null,
+            stock_managed: true,
+            is_active: true,
+            commande_client_eligible: false,
+            commande_client_ineligibility_code: "ARTICLE_PIECE_TECHNIQUE_REQUIRED",
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const patchPayload = {
+      ...payload,
+      officialize_preparatory_data: true,
+      lignes: [{
+        designation: "Article devis sans DTP",
+        code_piece: "ART-DV-NO-DTP",
+        quantite: 1,
+        prix_unitaire_ht: 19.5,
+        delai_client: "2026-09-30",
+        article_devis_data: {
+          id: SOURCE_ARTICLE_DEVIS_ID,
+          devis_id: 7,
+          code: "ART-DV-NO-DTP",
+          designation: "Article devis sans DTP",
+          primary_category: "piece_finie_fabriquee",
+          article_categories: ["piece_finie_fabriquee"],
+          family_code: "PT",
+          plan_index: 1,
+          projet_id: null,
+          source_official_article_id: null,
+        },
+      }],
+    };
+
+    const res = await request(app)
+      .patch("/api/v1/commandes/315")
+      .field("data", JSON.stringify(patchPayload));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(409);
+    expect(res.body).toMatchObject({
+      code: "ARTICLE_PIECE_TECHNIQUE_REQUIRED",
+      details: {
+        field: "lignes.0.article_id",
+        line_index: 0,
+        article_id: promotedArticleId,
+        article_code: "ART-DV-NO-DTP",
+      },
+    });
+    expect(
+      mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO commande_ligne"))
+    ).toBe(false);
+    expectCanonicalResolverQuery();
+  });
+
+  it("accepte en POST une promotion preparatoire canoniquement eligible", async () => {
+    const eligible = {
+      ...ineligibleArticleRow(),
+      article_code: "ART-DV-ELIGIBLE",
+      article_designation: "Article devis eligible",
+      article_category: "fabrique",
+      family_code: "PT",
+      commande_client_eligible: true,
+      commande_client_ineligibility_code: null,
+    };
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query.includes("nextval('public.commande_client_id_seq')")) return { rows: [{ id: "315" }] };
+      if (query.includes("public.fn_next_issued_code_value")) return { rows: [{ v: "1" }] };
+      if (query.includes("INSERT INTO commande_client")) return { rows: [{ id: "315" }] };
+      if (query.includes("FROM public.article_devis ad")) return { rows: [preparatoryBundleRow()] };
+      if (query.includes("FROM public.dossier_technique_piece_devis_promotion")) {
+        return { rows: [{ promoted_piece_technique_id: PIECE_ID }] };
+      }
+      if (query.includes("FROM public.article_devis_promotion")) {
+        return { rows: [{ promoted_article_id: ARTICLE_ID }] };
+      }
+      if (
+        query.includes("FROM public.articles a") &&
+        (query.includes("WHERE a.id = $1::uuid") || query.includes("AS commande_client_eligible"))
+      ) {
+        return { rows: [eligible] };
+      }
+      if (query.includes("INSERT INTO commande_ligne")) return { rows: [{ id: "1" }] };
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post("/api/v1/commandes")
+      .field("data", JSON.stringify(preparatoryPayload()));
+
+    expect(res.status, JSON.stringify(res.body)).toBe(201);
+    expect(res.body).toMatchObject({ id: 315 });
+    expect(
+      mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO commande_ligne"))
+    ).toBe(true);
+    expectCanonicalResolverQuery();
   });
 });

--- a/src/__tests__/commande-article-eligibility.routes.test.ts
+++ b/src/__tests__/commande-article-eligibility.routes.test.ts
@@ -1,0 +1,171 @@
+import { EventEmitter } from "events";
+import request, { type Response } from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = {
+    on: emitter.on.bind(emitter),
+    query: mocks.poolQuery,
+    connect: mocks.poolConnect,
+  };
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({
+  checkNetworkDrive: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; role: string } },
+    _res: unknown,
+    next: () => void
+  ) => {
+    req.user = { id: 1, role: "Administrateur Systeme et Reseau" };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+
+import app from "../config/app";
+
+const ARTICLE_ID = "11111111-1111-4111-8111-111111111111";
+const PIECE_ID = "22222222-2222-4222-8222-222222222222";
+
+const payload = {
+  numero: "CC-315",
+  client_id: "001",
+  code_client: "PO-315",
+  date_commande: "2026-08-04",
+  lignes: [
+    {
+      article_id: ARTICLE_ID,
+      designation: "Ligne conservee",
+      quantite: 7,
+      prix_unitaire_ht: 19.5,
+      delai_client: "2026-09-30",
+    },
+  ],
+};
+
+function ineligibleArticleRow() {
+  return {
+    article_id: ARTICLE_ID,
+    article_code: "MAT-SECONDARY-PF",
+    article_designation: "Matiere multi-categorie",
+    article_category: "matiere",
+    family_code: "MAT",
+    article_unite: "kg",
+    piece_technique_id: PIECE_ID,
+    piece_code: "DTP-315",
+    piece_designation: "Dossier historique",
+    stock_managed: true,
+    is_active: true,
+    commande_client_eligible: false,
+    commande_client_ineligibility_code: "ARTICLE_NOT_FABRICATED",
+  };
+}
+
+function expectCanonicalResolverQuery() {
+  const resolveCall = mocks.clientQuery.mock.calls.find((call) =>
+    String(call[0]).includes("FROM public.articles a")
+  );
+  const sql = String(resolveCall?.[0]).replace(/\s+/g, " ");
+  expect(sql).toContain("a.is_active = TRUE");
+  expect(sql).toContain("a.stock_managed = TRUE");
+  expect(sql).toContain("a.article_category IN ('fabrique', 'PIECE_TECHNIQUE')");
+  expect(sql).toContain("a.piece_technique_id IS NOT NULL");
+  expect(sql).not.toContain("article_category_link");
+}
+
+function expectActionableRejection(res: Response) {
+  expect(res.status).toBe(409);
+  expect(res.body).toMatchObject({
+    code: "ARTICLE_NOT_FABRICATED",
+    details: {
+      field: "lignes.0.article_id",
+      line_index: 0,
+      article_id: ARTICLE_ID,
+      article_code: "MAT-SECONDARY-PF",
+    },
+  });
+  expect(res.body.message).toMatch(/MAT-SECONDARY-PF/);
+  expect(res.body.message).toMatch(/article fabriqu/i);
+  expect(
+    mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO commande_ligne"))
+  ).toBe(false);
+  expectCanonicalResolverQuery();
+}
+
+beforeEach(() => {
+  mocks.poolQuery.mockReset();
+  mocks.poolConnect.mockReset();
+  mocks.clientQuery.mockReset();
+  mocks.clientRelease.mockReset();
+  mocks.poolQuery.mockResolvedValue({ rows: [] });
+  mocks.clientQuery.mockResolvedValue({ rows: [] });
+  mocks.poolConnect.mockResolvedValue({
+    query: mocks.clientQuery,
+    release: mocks.clientRelease,
+  });
+});
+
+describe("BUG-CERP-0015 - validation serveur POST/PATCH commandes", () => {
+  it("refuse en POST une categorie primaire matiere meme avec secondaire fabriquee", async () => {
+    mocks.clientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "315" }] })
+      .mockResolvedValueOnce({ rows: [{ v: "1" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "315" }] })
+      .mockResolvedValueOnce({ rows: [ineligibleArticleRow()] });
+
+    const res = await request(app)
+      .post("/api/v1/commandes")
+      .field("data", JSON.stringify(payload));
+
+    expectActionableRejection(res);
+  });
+
+  it("applique le meme refus lors du remplacement des lignes en PATCH", async () => {
+    mocks.clientQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            numero: "CC-315",
+            client_id: "001",
+            devis_id: null,
+            order_type: "FERME",
+            adresse_facturation_id: null,
+            cadre_start_date: null,
+            cadre_end_date: null,
+            dest_stock_magasin_id: null,
+            dest_stock_emplacement_id: null,
+            ar_sent_at: null,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: "315" }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [ineligibleArticleRow()] });
+
+    const res = await request(app)
+      .patch("/api/v1/commandes/315")
+      .field("data", JSON.stringify(payload));
+
+    expectActionableRejection(res);
+  });
+});

--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -459,7 +459,7 @@ describe("/api/v1/commandes", () => {
         articlePromoted = true;
         return { rows: [] };
       }
-      if (q.includes("SELECT") && q.includes("FROM public.articles a") && q.includes("WHERE a.id = $1::uuid")) {
+      if (q.includes("SELECT") && q.includes("FROM public.articles a")) {
         return {
           rows: [
             {

--- a/src/__tests__/stock-commande-article-filter-315.test.ts
+++ b/src/__tests__/stock-commande-article-filter-315.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const queryMock = vi.hoisted(() => vi.fn());
+
+vi.mock("../config/database", () => ({
+  default: { query: queryMock },
+}));
+
+import { repoListArticles } from "../module/stock/repository/stock.repository";
+
+function normalized(sql: unknown): string {
+  return String(sql).replace(/\s+/g, " ").trim();
+}
+
+describe("BUG-CERP-0015 - filtre GET /stock/articles", () => {
+  beforeEach(() => {
+    queryMock.mockReset();
+    queryMock
+      .mockResolvedValueOnce({ rows: [{ total: 0 }] })
+      .mockResolvedValueOnce({ rows: [] });
+  });
+
+  it("applique le predicat canonique complet sans categorie secondaire", async () => {
+    await repoListArticles({ commande_client_selectable: true });
+
+    expect(queryMock).toHaveBeenCalledTimes(2);
+    for (const call of queryMock.mock.calls) {
+      const sql = normalized(call[0]);
+      expect(sql).toContain("a.is_active = TRUE");
+      expect(sql).toContain("a.stock_managed = TRUE");
+      expect(sql).toContain("a.article_category IN ('fabrique', 'PIECE_TECHNIQUE')");
+      expect(sql).toContain("a.piece_technique_id IS NOT NULL");
+      expect(sql).not.toContain("aclf.category_code");
+    }
+  });
+
+  it("inverse exactement le meme predicat pour selectable=false", async () => {
+    await repoListArticles({ commande_client_selectable: false });
+
+    const countSql = normalized(queryMock.mock.calls[0]?.[0]);
+    expect(countSql).toContain("IS NOT TRUE");
+    expect(countSql).toContain("a.article_category IN ('fabrique', 'PIECE_TECHNIQUE')");
+  });
+});

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -2816,7 +2816,20 @@ async function insertCommandeLignes(
       sourceDossierDevisId = bundle.source_dossier_devis_id;
 
       const officialPieceId = await ensureOfficialPieceFromPreparatory(client, bundle, options.commande_id_int);
-      resolved = await ensureOfficialArticleFromPreparatory(client, bundle, options.commande_id_int, officialPieceId);
+      const promoted = await ensureOfficialArticleFromPreparatory(
+        client,
+        bundle,
+        options.commande_id_int,
+        officialPieceId
+      );
+      // Une promotion ne vaut pas éligibilité Commande. Relire l'article officiel par le
+      // resolver canonique garantit le même prédicat et les mêmes erreurs structurées que
+      // pour une ligne non préparatoire (POST comme PATCH).
+      resolved = await resolveCommandeLineArticle(
+        client,
+        { ...l, article_id: promoted.article_id, code_piece: undefined },
+        lineIndex
+      );
     } else {
       resolved = await resolveCommandeLineArticle(client, l, lineIndex);
     }

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -53,6 +53,13 @@ import {
   allocateCommandeStockOldThenNew,
   type CommandeStockAvailability,
 } from "../domain/stock-scope-allocation";
+import {
+  commandeArticleEligibleSql,
+  commandeArticleEligibilityError,
+  commandeArticleIneligibilityFromState,
+  commandeArticleIneligibilityCodeSql,
+  type CommandeArticleIneligibilityCode,
+} from "../../stock/domain/commande-article-eligibility";
 
 function normalizeStoredPath(filePath: string) {
   const rel = path.isAbsolute(filePath) ? path.relative(process.cwd(), filePath) : filePath;
@@ -116,6 +123,8 @@ type CommandeLineArticleResolution = {
   piece_designation: string | null;
   stock_managed: boolean;
   is_active: boolean;
+  commande_client_eligible: boolean;
+  commande_client_ineligibility_code: CommandeArticleIneligibilityCode | null;
 };
 
 type AuditContext = {
@@ -194,13 +203,17 @@ async function insertCommandeEvent(db: Queryable, params: {
 
 async function resolveCommandeLineArticle(
   db: Queryable,
-  line: CreateCommandeInput["lignes"][number]
+  line: CreateCommandeInput["lignes"][number],
+  lineIndex: number
 ): Promise<CommandeLineArticleResolution> {
   const requestedArticleId = typeof line.article_id === "string" && line.article_id.trim() ? line.article_id.trim() : null;
   const requestedCode = typeof line.code_piece === "string" && line.code_piece.trim() ? line.code_piece.trim() : null;
 
   if (!requestedArticleId && !requestedCode) {
-    throw new HttpError(400, "ARTICLE_REQUIRED", "Each commande line must reference an article");
+    throw new HttpError(400, "ARTICLE_REQUIRED", "Chaque ligne doit référencer un article.", {
+      field: `lignes.${lineIndex}.article_id`,
+      line_index: lineIndex,
+    });
   }
 
   const res = await db.query<CommandeLineArticleResolution>(
@@ -216,7 +229,9 @@ async function resolveCommandeLineArticle(
         pt.code_piece AS piece_code,
         pt.designation AS piece_designation,
         a.stock_managed,
-        a.is_active
+        a.is_active,
+        ${commandeArticleEligibleSql("a")} AS commande_client_eligible,
+        ${commandeArticleIneligibilityCodeSql("a")} AS commande_client_ineligibility_code
       FROM public.articles a
       LEFT JOIN public.pieces_techniques pt ON pt.id = a.piece_technique_id
       WHERE ($1::uuid IS NOT NULL AND a.id = $1::uuid)
@@ -242,29 +257,28 @@ async function resolveCommandeLineArticle(
       400,
       "INVALID_ARTICLE",
       requestedCode
-        ? `Unknown article for reference ${requestedCode}`
-        : `Unknown article_id ${requestedArticleId}`
+        ? `Article inconnu pour la référence ${requestedCode}. Choisissez un article proposé par la recherche.`
+        : `Article inconnu ${requestedArticleId}. Choisissez un article proposé par la recherche.`,
+      {
+        field: `lignes.${lineIndex}.article_id`,
+        line_index: lineIndex,
+        article_id: requestedArticleId,
+        article_code: requestedCode,
+      }
     );
   }
 
-  if (!article.is_active) {
-    throw new HttpError(409, "ARTICLE_INACTIVE", `Article ${article.article_code} is inactive`);
-  }
-
-  if (!article.stock_managed) {
-    throw new HttpError(409, "ARTICLE_NOT_STOCK_MANAGED", `Article ${article.article_code} is not stock-managed`);
-  }
-
-  if (article.article_category !== "fabrique" && article.article_category !== "PIECE_TECHNIQUE") {
-    throw new HttpError(409, "ARTICLE_NOT_FABRICATED", `Article ${article.article_code} is not a fabricated article and cannot be sold in commande client`);
-  }
-
-  if (!article.piece_technique_id) {
-    throw new HttpError(
-      409,
-      "ARTICLE_PIECE_TECHNIQUE_REQUIRED",
-      `Article ${article.article_code} must be linked to a piece technique before it can be sold`
-    );
+  const ineligibilityCode =
+    article.commande_client_eligible === true
+      ? null
+      : article.commande_client_ineligibility_code ?? commandeArticleIneligibilityFromState(article);
+  if (ineligibilityCode) {
+    throw commandeArticleEligibilityError({
+      code: ineligibilityCode,
+      articleId: article.article_id,
+      articleCode: article.article_code,
+      lineIndex,
+    });
   }
 
   return article;
@@ -2479,7 +2493,7 @@ async function insertCommandeLignes(
 ) {
   if (!lignes.length) return;
 
-  for (const l of lignes) {
+  for (const [lineIndex, l] of lignes.entries()) {
     const hasPreparatory = lineHasPreparatorySource(l);
     if (hasPreparatory && !options.officialize_preparatory_data) {
       throw new HttpError(
@@ -2504,7 +2518,7 @@ async function insertCommandeLignes(
       const officialPieceId = await ensureOfficialPieceFromPreparatory(client, bundle, options.commande_id_int);
       resolved = await ensureOfficialArticleFromPreparatory(client, bundle, options.commande_id_int, officialPieceId);
     } else {
-      resolved = await resolveCommandeLineArticle(client, l);
+      resolved = await resolveCommandeLineArticle(client, l, lineIndex);
     }
 
     const designation = typeof l.designation === "string" && l.designation.trim().length > 0

--- a/src/module/stock/domain/commande-article-eligibility.ts
+++ b/src/module/stock/domain/commande-article-eligibility.ts
@@ -1,0 +1,104 @@
+import { HttpError } from "../../../utils/httpError";
+
+export type CommandeArticleIneligibilityCode =
+  | "ARTICLE_INACTIVE"
+  | "ARTICLE_NOT_STOCK_MANAGED"
+  | "ARTICLE_NOT_FABRICATED"
+  | "ARTICLE_PIECE_TECHNIQUE_REQUIRED";
+
+export type CommandeArticleEligibilityState = {
+  is_active: boolean;
+  stock_managed: boolean;
+  article_category: string;
+  piece_technique_id: string | null;
+};
+
+/** Miroir pur du predicat SQL, utile aux tests et aux doubles de repository. */
+export function commandeArticleIneligibilityFromState(
+  article: CommandeArticleEligibilityState
+): CommandeArticleIneligibilityCode | null {
+  if (!article.is_active) return "ARTICLE_INACTIVE";
+  if (!article.stock_managed) return "ARTICLE_NOT_STOCK_MANAGED";
+  if (article.article_category !== "fabrique" && article.article_category !== "PIECE_TECHNIQUE") {
+    return "ARTICLE_NOT_FABRICATED";
+  }
+  if (!article.piece_technique_id) return "ARTICLE_PIECE_TECHNIQUE_REQUIRED";
+  return null;
+}
+
+function safeArticleAlias(alias: string): string {
+  if (!/^[a-z_][a-z0-9_]*$/i.test(alias)) {
+    throw new Error(`Invalid SQL alias: ${alias}`);
+  }
+  return alias;
+}
+
+/**
+ * Catégorie fabriquée canonique d'une commande client.
+ *
+ * Les valeurs primaires historiques (`PIECE_TECHNIQUE`) restent reconnues. Une catégorie
+ * secondaire `piece_finie_fabriquee` ne transforme pas une catégorie primaire matière/achat :
+ * ce serait un élargissement métier que la validation Commande canonique n'autorisait pas.
+ */
+export function commandeArticleFabricatedSql(alias = "a"): string {
+  const article = safeArticleAlias(alias);
+  return `(${article}.article_category IN ('fabrique', 'PIECE_TECHNIQUE'))`;
+}
+
+/** Prédicat unique utilisé par le filtre Stock ET la validation POST/PATCH Commande. */
+export function commandeArticleEligibleSql(alias = "a"): string {
+  const article = safeArticleAlias(alias);
+  return `(
+    ${article}.is_active = TRUE
+    AND ${article}.stock_managed = TRUE
+    AND ${commandeArticleFabricatedSql(article)}
+    AND ${article}.piece_technique_id IS NOT NULL
+  )`;
+}
+
+/** Cause prioritaire, stable et actionnable du refus. */
+export function commandeArticleIneligibilityCodeSql(alias = "a"): string {
+  const article = safeArticleAlias(alias);
+  return `CASE
+    WHEN ${article}.is_active IS NOT TRUE THEN 'ARTICLE_INACTIVE'
+    WHEN ${article}.stock_managed IS NOT TRUE THEN 'ARTICLE_NOT_STOCK_MANAGED'
+    WHEN ${commandeArticleFabricatedSql(article)} IS NOT TRUE THEN 'ARTICLE_NOT_FABRICATED'
+    WHEN ${article}.piece_technique_id IS NULL THEN 'ARTICLE_PIECE_TECHNIQUE_REQUIRED'
+    ELSE NULL
+  END`;
+}
+
+export function commandeArticleEligibilityMessage(
+  code: CommandeArticleIneligibilityCode,
+  articleCode: string
+): string {
+  switch (code) {
+    case "ARTICLE_INACTIVE":
+      return `L'article ${articleCode} est inactif. Réactivez-le dans Stock ou choisissez un autre article.`;
+    case "ARTICLE_NOT_STOCK_MANAGED":
+      return `L'article ${articleCode} n'est pas géré en stock. Activez sa gestion de stock ou choisissez un autre article.`;
+    case "ARTICLE_NOT_FABRICATED":
+      return `L'article ${articleCode} n'est pas une pièce fabriquée éligible. Choisissez un article fabriqué.`;
+    case "ARTICLE_PIECE_TECHNIQUE_REQUIRED":
+      return `L'article ${articleCode} doit être relié à une pièce technique avant de pouvoir être commandé.`;
+  }
+}
+
+export function commandeArticleEligibilityError(params: {
+  code: CommandeArticleIneligibilityCode;
+  articleId: string;
+  articleCode: string;
+  lineIndex: number;
+}): HttpError {
+  return new HttpError(
+    409,
+    params.code,
+    commandeArticleEligibilityMessage(params.code, params.articleCode),
+    {
+      field: `lignes.${params.lineIndex}.article_id`,
+      line_index: params.lineIndex,
+      article_id: params.articleId,
+      article_code: params.articleCode,
+    }
+  );
+}

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -34,6 +34,10 @@ import {
   type StockLotQualityStatus,
 } from "../domain/stock-availability";
 import { hashStockCommand, normalizeIdempotencyKey } from "../domain/stock-command";
+import {
+  commandeArticleEligibleSql,
+  commandeArticleIneligibilityCodeSql,
+} from "../domain/commande-article-eligibility";
 import type {
   ArticleCategory,
   ArticleBusinessCategory,
@@ -278,20 +282,9 @@ const ARTICLE_PRIMARY_CATEGORY_OPTIONS: Array<{ code: ArticleCategory }> = [
 /**
  * Référentiel des catégories métier d'article.
  *
- * `commande_client_selectable` (#395) — élargi à TOUTES les catégories.
- *
- * Il ne valait `true` que pour `piece_finie_fabriquee`, ce qui rendait la création d'article
- * depuis une commande client inutilisable pour tout le reste : un composant revendu, un
- * achat transformé, une sous-traitance refacturée, un traitement de surface facturé à la
- * ligne ou une matière cédée au client sont tous des choses que CRP vend réellement, et
- * toutes finissaient par un contournement (créer l'article ailleurs, puis revenir).
- *
- * Ce drapeau reste le SEUL levier pour restreindre à nouveau : il pilote à la fois les
- * catégories proposées à la création depuis une commande et le filtre de recherche des
- * lignes de commande. Le repasser à `false` suffit, sans toucher au frontend.
- *
- * `piece_technique_required` n'est PAS élargi : seule une pièce finie fabriquée exige un
- * dossier technique — c'est lui qui produit les OF.
+ * `commande_client_selectable` décrit les catégories qu'un utilisateur peut créer depuis
+ * une commande. La sauvegarde Commande reste canonique : seule une pièce fabriquée, gérée
+ * en stock, active et reliée à une pièce technique est éligible (BUG-CERP-0015).
  */
 const ARTICLE_CATEGORY_OPTIONS: StockArticleCategoryOption[] = [
   {
@@ -308,7 +301,7 @@ const ARTICLE_CATEGORY_OPTIONS: StockArticleCategoryOption[] = [
     code_segment: "MP",
     stock_managed_default: true,
     piece_technique_required: false,
-    commande_client_selectable: true,
+    commande_client_selectable: false,
   },
   {
     code: "traitement_surface",
@@ -316,7 +309,7 @@ const ARTICLE_CATEGORY_OPTIONS: StockArticleCategoryOption[] = [
     code_segment: "TRT",
     stock_managed_default: false,
     piece_technique_required: false,
-    commande_client_selectable: true,
+    commande_client_selectable: false,
   },
   {
     code: "achat_revente",
@@ -324,7 +317,7 @@ const ARTICLE_CATEGORY_OPTIONS: StockArticleCategoryOption[] = [
     code_segment: "ACH",
     stock_managed_default: true,
     piece_technique_required: false,
-    commande_client_selectable: true,
+    commande_client_selectable: false,
   },
   {
     code: "achat_transforme",
@@ -332,7 +325,7 @@ const ARTICLE_CATEGORY_OPTIONS: StockArticleCategoryOption[] = [
     code_segment: "AHT",
     stock_managed_default: true,
     piece_technique_required: false,
-    commande_client_selectable: true,
+    commande_client_selectable: false,
   },
   {
     code: "sous_traitance",
@@ -340,7 +333,7 @@ const ARTICLE_CATEGORY_OPTIONS: StockArticleCategoryOption[] = [
     code_segment: "STA",
     stock_managed_default: false,
     piece_technique_required: false,
-    commande_client_selectable: true,
+    commande_client_selectable: false,
   },
 ];
 
@@ -2718,32 +2711,10 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
   if (filters.lot_tracking !== undefined) where.push(`a.lot_tracking = ${push(filters.lot_tracking)}`);
   if (filters.stock_managed !== undefined) where.push(`a.stock_managed = ${push(filters.stock_managed)}`);
 
-  /**
-   * #395 — Filtre « vendable en commande client », dérivé du référentiel.
-   *
-   * Un article est retenu si sa catégorie primaire OU l'une de ses catégories métier liées est
-   * vendable. Le jeu de codes vient de `ARTICLE_CATEGORY_OPTIONS` : élargir ou restreindre la
-   * vente se fait à cet endroit unique, et la recherche de ligne suit sans redéploiement du
-   * frontend.
-   */
+  /** BUG-CERP-0015 — même prédicat que POST/PATCH /commandes, fermé par défaut. */
   if (filters.commande_client_selectable !== undefined) {
-    const sellable = commandeClientSelectableCategoryCodes();
-    if (sellable.length === 0) {
-      // Référentiel entièrement fermé : ne rien proposer plutôt que tout proposer.
-      where.push(filters.commande_client_selectable ? "FALSE" : "TRUE");
-    } else {
-      const p = push(sellable);
-      const predicate = `(
-        ${normalizedBusinessCategorySql("a.article_category")} = ANY(${p}::text[])
-        OR EXISTS (
-          SELECT 1
-          FROM public.article_category_link acls
-          WHERE acls.article_id = a.id
-            AND acls.category_code = ANY(${p}::text[])
-        )
-      )`;
-      where.push(filters.commande_client_selectable ? predicate : `NOT ${predicate}`);
-    }
+    const predicate = commandeArticleEligibleSql("a");
+    where.push(filters.commande_client_selectable ? predicate : `(${predicate}) IS NOT TRUE`);
   }
 
   const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
@@ -2785,6 +2756,8 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
       a.lot_tracking,
       a.is_sold,
       a.is_active,
+      ${commandeArticleEligibleSql("a")} AS commande_client_eligible,
+      ${commandeArticleIneligibilityCodeSql("a")} AS commande_client_ineligibility_code,
       a.row_version::int AS row_version,
       a.archived_at::text AS archived_at,
       a.archive_reason,
@@ -2863,6 +2836,8 @@ export async function repoGetArticle(id: string, includeCosts = false): Promise<
          a.lot_tracking,
          a.is_sold,
          a.is_active,
+         ${commandeArticleEligibleSql("a")} AS commande_client_eligible,
+         ${commandeArticleIneligibilityCodeSql("a")} AS commande_client_ineligibility_code,
          a.row_version::int AS row_version,
          a.archived_at::text AS archived_at,
          a.archive_reason,

--- a/src/module/stock/types/stock.types.ts
+++ b/src/module/stock/types/stock.types.ts
@@ -1,3 +1,6 @@
+import type { CommandeArticleIneligibilityCode } from "../domain/commande-article-eligibility";
+export type { CommandeArticleIneligibilityCode } from "../domain/commande-article-eligibility";
+
 export type Paginated<T> = {
   items: T[];
   total: number;
@@ -172,6 +175,8 @@ export type StockArticleListItem = {
   lot_tracking: boolean;
   is_sold: boolean;
   is_active: boolean;
+  commande_client_eligible: boolean;
+  commande_client_ineligibility_code: CommandeArticleIneligibilityCode | null;
   row_version: number;
   archived_at: string | null;
   archive_reason: string | null;


### PR DESCRIPTION
Centralise le prédicat canonique d'éligibilité article entre la recherche Stock et les créations/mises à jour de commandes. Ajoute les motifs structurés 409 rattachés à la ligne et verrouille le référentiel de création sur les pièces fabriquées. Validation : suite complète pnpm test:run, tests ciblés 17/17 et build TypeScript verts. Closes #315

## Summary by Sourcery

Centralize and enforce a canonical article eligibility predicate shared between stock article search and commande creation/update, and expose eligibility metadata and actionable errors across the API.

Bug Fixes:
- Align server-side article eligibility validation for commande creation/update with stock search filtering using a shared canonical predicate.
- Return structured 409 errors with ineligibility codes and line-level context when commande lines reference non-eligible articles.
- Improve client error messages and field mapping when commande lines reference missing or invalid articles.

Enhancements:
- Restrict commande-origin article creation to fabricated, stock-managed, active articles linked to a piece technique via the category reference.
- Expose article commande eligibility flags and ineligibility codes in stock listing and detail APIs.
- Refine the article category reference so only fabricated finished pieces are selectable from commandes, keeping technical dossier requirements unchanged.

Tests:
- Add unit and integration tests covering the canonical article eligibility predicate, stock article filtering, and commande POST/PATCH rejection paths.
- Update article category selection tests to reflect the narrowed, commandable-only category scope.