### PR TITLE
fix: canonicaliser la machine d’état des commandes

### DIFF
--- a/contracts/commande-client-workflow.v1.json
+++ b/contracts/commande-client-workflow.v1.json
@@ -1,0 +1,426 @@
+{
+  "schema_version": "1.0.0",
+  "authority": "erp-crp-backend",
+  "statuses": [
+    "BROUILLON",
+    "EN_ANALYSE",
+    "ATTENTE_TECHNIQUE",
+    "ATTENTE_STOCK",
+    "ATTENTE_OF",
+    "ATTENTE_PLANNING",
+    "PLANNING_VALIDE",
+    "AR_PRET",
+    "AR_ENVOYE",
+    "EN_PRODUCTION",
+    "PRODUCTION_TERMINEE",
+    "CONTROLE_QUALITE",
+    "PRET_LIVRAISON",
+    "LIVRE",
+    "FACTURE",
+    "ARCHIVE",
+    "BLOQUE"
+  ],
+  "status_labels": {
+    "BROUILLON": "Brouillon",
+    "EN_ANALYSE": "En analyse",
+    "ATTENTE_TECHNIQUE": "Attente technique",
+    "ATTENTE_STOCK": "Attente contrôle stock",
+    "ATTENTE_OF": "Attente lancement",
+    "ATTENTE_PLANNING": "Attente planning",
+    "PLANNING_VALIDE": "Planning validé",
+    "AR_PRET": "AR prêt",
+    "AR_ENVOYE": "AR envoyé",
+    "EN_PRODUCTION": "En production",
+    "PRODUCTION_TERMINEE": "Production terminée",
+    "CONTROLE_QUALITE": "Contrôle qualité",
+    "PRET_LIVRAISON": "Prêt livraison",
+    "LIVRE": "Livré",
+    "FACTURE": "Facturé",
+    "ARCHIVE": "Archivé",
+    "BLOQUE": "Bloqué"
+  },
+  "status_order": {
+    "BROUILLON": 0,
+    "EN_ANALYSE": 1,
+    "ATTENTE_TECHNIQUE": 2,
+    "ATTENTE_STOCK": 3,
+    "ATTENTE_OF": 4,
+    "ATTENTE_PLANNING": 5,
+    "PLANNING_VALIDE": 6,
+    "AR_PRET": 7,
+    "AR_ENVOYE": 8,
+    "EN_PRODUCTION": 9,
+    "PRODUCTION_TERMINEE": 10,
+    "CONTROLE_QUALITE": 11,
+    "PRET_LIVRAISON": 12,
+    "LIVRE": 13,
+    "FACTURE": 14,
+    "ARCHIVE": 15,
+    "BLOQUE": 99
+  },
+  "checkpoint_statuses": [
+    "pending",
+    "active",
+    "blocked",
+    "done",
+    "skipped"
+  ],
+  "legacy_status_aliases": {
+    "ENREGISTREE": "EN_ANALYSE",
+    "PLANIFIEE": "PLANNING_VALIDE",
+    "AR_ENVOYEE": "AR_ENVOYE",
+    "LIVREE": "LIVRE"
+  },
+  "checkpoint_transitions": {
+    "BROUILLON": [
+      "EN_ANALYSE"
+    ],
+    "EN_ANALYSE": [
+      "ATTENTE_TECHNIQUE"
+    ],
+    "ATTENTE_TECHNIQUE": [
+      "ATTENTE_STOCK"
+    ],
+    "ATTENTE_STOCK": [
+      "ATTENTE_OF"
+    ],
+    "ATTENTE_OF": [],
+    "ATTENTE_PLANNING": [
+      "PLANNING_VALIDE"
+    ],
+    "PLANNING_VALIDE": [
+      "AR_PRET"
+    ],
+    "AR_PRET": [],
+    "AR_ENVOYE": [
+      "EN_PRODUCTION"
+    ],
+    "EN_PRODUCTION": [
+      "PRODUCTION_TERMINEE"
+    ],
+    "PRODUCTION_TERMINEE": [
+      "PRET_LIVRAISON"
+    ],
+    "CONTROLE_QUALITE": [
+      "PRET_LIVRAISON"
+    ],
+    "PRET_LIVRAISON": [
+      "LIVRE"
+    ],
+    "LIVRE": [
+      "FACTURE"
+    ],
+    "FACTURE": [
+      "ARCHIVE"
+    ],
+    "ARCHIVE": [],
+    "BLOQUE": []
+  },
+  "transition_rules": [
+    {
+      "from": "BROUILLON",
+      "to": "EN_ANALYSE",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "EN_ANALYSE",
+      "to": "ATTENTE_TECHNIQUE",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "ATTENTE_TECHNIQUE",
+      "to": "ATTENTE_STOCK",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "ATTENTE_STOCK",
+      "to": "ATTENTE_OF",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "ATTENTE_PLANNING",
+      "to": "PLANNING_VALIDE",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "PLANNING_VALIDE",
+      "to": "AR_PRET",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "AR_ENVOYE",
+      "to": "EN_PRODUCTION",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "EN_PRODUCTION",
+      "to": "PRODUCTION_TERMINEE",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "PRODUCTION_TERMINEE",
+      "to": "PRET_LIVRAISON",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "CONTROLE_QUALITE",
+      "to": "PRET_LIVRAISON",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "PRET_LIVRAISON",
+      "to": "LIVRE",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "LIVRE",
+      "to": "FACTURE",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "FACTURE",
+      "to": "ARCHIVE",
+      "cause": "checkpoint"
+    },
+    {
+      "from": "ATTENTE_OF",
+      "to": "ATTENTE_PLANNING",
+      "cause": "customer_order_launch"
+    },
+    {
+      "from": "ATTENTE_OF",
+      "to": "PRET_LIVRAISON",
+      "cause": "customer_order_launch"
+    },
+    {
+      "from": "ATTENTE_PLANNING",
+      "to": "PRET_LIVRAISON",
+      "cause": "customer_order_launch"
+    },
+    {
+      "from": "ATTENTE_TECHNIQUE",
+      "to": "ATTENTE_PLANNING",
+      "cause": "internal_order_launch"
+    },
+    {
+      "from": "ATTENTE_STOCK",
+      "to": "ATTENTE_PLANNING",
+      "cause": "internal_order_launch"
+    },
+    {
+      "from": "ATTENTE_OF",
+      "to": "ATTENTE_PLANNING",
+      "cause": "internal_order_launch"
+    },
+    {
+      "from": "ATTENTE_PLANNING",
+      "to": "PLANNING_VALIDE",
+      "cause": "internal_planning_validation"
+    },
+    {
+      "from": "PLANNING_VALIDE",
+      "to": "EN_PRODUCTION",
+      "cause": "internal_production_launch"
+    },
+    {
+      "from": "LIVRE",
+      "to": "ARCHIVE",
+      "cause": "internal_archive"
+    },
+    {
+      "from": "ATTENTE_PLANNING",
+      "to": "PLANNING_VALIDE",
+      "cause": "planning_sync"
+    },
+    {
+      "from": "AR_PRET",
+      "to": "AR_ENVOYE",
+      "cause": "ar_send"
+    },
+    {
+      "from": "PRET_LIVRAISON",
+      "to": "LIVRE",
+      "cause": "shipment_sync"
+    },
+    {
+      "from": "LIVRE",
+      "to": "FACTURE",
+      "cause": "invoice_sync"
+    }
+  ],
+  "transition_policies": {
+    "block": {
+      "from": "active checkpoint current status",
+      "to": "BLOQUE"
+    },
+    "resume": {
+      "from": "BLOQUE",
+      "to": "checkpoint metadata.previous_status_before_block"
+    },
+    "system_replays": {
+      "shipment_sync": [
+        "LIVRE",
+        "FACTURE",
+        "ARCHIVE"
+      ],
+      "invoice_sync": [
+        "FACTURE",
+        "ARCHIVE"
+      ],
+      "planning_sync": [
+        "PLANNING_VALIDE",
+        "AR_PRET",
+        "AR_ENVOYE",
+        "EN_PRODUCTION",
+        "PRODUCTION_TERMINEE",
+        "CONTROLE_QUALITE",
+        "PRET_LIVRAISON",
+        "LIVRE",
+        "FACTURE",
+        "ARCHIVE"
+      ]
+    }
+  },
+  "checkpoints": [
+    {
+      "code": "order_intake",
+      "label": "Saisie commande",
+      "description": "Commande client capturee, lignes et pieces client rattachees.",
+      "responsible_role": "secretariat",
+      "sort_order": 10,
+      "status_when_done": "EN_ANALYSE",
+      "action_key": "start_analysis",
+      "action_label": "Lancer analyse"
+    },
+    {
+      "code": "commercial_review",
+      "label": "Analyse administrative",
+      "description": "Client, conditions, delais et documents verifies avant passage technique.",
+      "responsible_role": "secretariat",
+      "sort_order": 20,
+      "status_when_done": "ATTENTE_TECHNIQUE",
+      "action_key": "request_technical_analysis",
+      "action_label": "Demander analyse technique"
+    },
+    {
+      "code": "technical_analysis",
+      "label": "Analyse technique",
+      "description": "Faisabilite, article, piece technique et gamme valides par les methodes, sans planification.",
+      "responsible_role": "technique",
+      "sort_order": 30,
+      "status_when_done": "ATTENTE_STOCK",
+      "action_key": "complete_technical_analysis",
+      "action_label": "Valider technique"
+    },
+    {
+      "code": "stock_check",
+      "label": "Controle du stock",
+      "description": "Disponibilite controlee dans la Base old puis dans la Base new avant toute proposition d'OF.",
+      "responsible_role": "technique",
+      "sort_order": 40,
+      "status_when_done": "ATTENTE_OF",
+      "action_key": "check_stock",
+      "action_label": "Controler le stock"
+    },
+    {
+      "code": "of_generation",
+      "label": "Lancement commande",
+      "description": "Affaires et allocations sont preparees depuis les lignes commande ; les OF ne sont crees que pour le manque de stock.",
+      "responsible_role": "technique",
+      "sort_order": 50,
+      "status_when_done": "ATTENTE_PLANNING",
+      "action_key": "mark_of_ready",
+      "action_label": "Vérifier le stock et lancer"
+    },
+    {
+      "code": "planning_validation",
+      "label": "Validation planning",
+      "description": "Charges, ressources, machines et jalons atelier confirmes.",
+      "responsible_role": "planning",
+      "sort_order": 60,
+      "status_when_done": "PLANNING_VALIDE",
+      "action_key": "validate_planning",
+      "action_label": "Valider planning"
+    },
+    {
+      "code": "ar_preparation",
+      "label": "Preparation AR",
+      "description": "Accuse de reception client pret avec delais et conditions confirmes.",
+      "responsible_role": "secretariat",
+      "sort_order": 70,
+      "status_when_done": "AR_PRET",
+      "action_key": "prepare_ar",
+      "action_label": "AR pret"
+    },
+    {
+      "code": "ar_sent",
+      "label": "Envoi AR",
+      "description": "AR envoye au client et trace dans le dossier commande.",
+      "responsible_role": "secretariat",
+      "sort_order": 80,
+      "status_when_done": "AR_ENVOYE",
+      "action_key": "mark_ar_sent",
+      "action_label": "Marquer AR envoye"
+    },
+    {
+      "code": "production_launch",
+      "label": "Production lancee",
+      "description": "Ordres de fabrication engages en atelier.",
+      "responsible_role": "production",
+      "sort_order": 90,
+      "status_when_done": "EN_PRODUCTION",
+      "action_key": "start_production",
+      "action_label": "Lancer production"
+    },
+    {
+      "code": "production_completion",
+      "label": "Production terminee",
+      "description": "Fabrication terminee et pieces disponibles pour controle.",
+      "responsible_role": "production",
+      "sort_order": 100,
+      "status_when_done": "PRODUCTION_TERMINEE",
+      "action_key": "complete_production",
+      "action_label": "Terminer production"
+    },
+    {
+      "code": "quality_control",
+      "label": "Controle qualite",
+      "description": "Controle final, non-conformites et liberation qualite traites.",
+      "responsible_role": "qualite",
+      "sort_order": 110,
+      "status_when_done": "PRET_LIVRAISON",
+      "action_key": "validate_quality",
+      "action_label": "Liberer livraison"
+    },
+    {
+      "code": "delivery",
+      "label": "Livraison",
+      "description": "Bon de livraison emis et expedition confirmee.",
+      "responsible_role": "logistique",
+      "sort_order": 120,
+      "status_when_done": "LIVRE",
+      "action_key": "mark_delivered",
+      "action_label": "Marquer livre"
+    },
+    {
+      "code": "invoicing",
+      "label": "Facturation",
+      "description": "Facture client creee et rattachee a la commande.",
+      "responsible_role": "comptabilite",
+      "sort_order": 130,
+      "status_when_done": "FACTURE",
+      "action_key": "mark_invoiced",
+      "action_label": "Marquer facture"
+    },
+    {
+      "code": "archive",
+      "label": "Archivage",
+      "description": "Dossier clos, trace et conserve selon les regles ERP.",
+      "responsible_role": "direction",
+      "sort_order": 140,
+      "status_when_done": "ARCHIVE",
+      "action_key": "archive",
+      "action_label": "Archiver"
+    }
+  ]
+}

--- a/db/patches/support/20260804_commande_workflow_canonical_314.preflight.sql
+++ b/db/patches/support/20260804_commande_workflow_canonical_314.preflight.sql
@@ -1,0 +1,267 @@
+-- Read-only preflight for issue #314 / GPT56-CERP-0005.
+-- This release does not add or mutate database schema. The append-only
+-- commande_historique remains the sole persisted command-status authority.
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $$
+BEGIN
+  IF to_regclass('public.commande_client') IS NULL
+     OR to_regclass('public.commande_historique') IS NULL
+     OR to_regclass('public.commande_client_workflow_checkpoint') IS NULL
+     OR to_regclass('public.commande_client_event_log') IS NULL THEN
+    RAISE EXCEPTION '#314 prerequisites are missing; apply the existing workflow patches first';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'commande_client'
+      AND column_name = 'statut'
+  ) THEN
+    RAISE EXCEPTION '#314 refuses a commande_client.statut projection; commande_historique is authoritative';
+  END IF;
+
+  IF EXISTS (
+    WITH latest AS (
+      SELECT DISTINCT ON (commande_id) commande_id, nouveau_statut
+      FROM public.commande_historique
+      ORDER BY commande_id, date_action DESC, id DESC
+    )
+    SELECT 1
+    FROM latest
+    WHERE nouveau_statut IS NOT NULL
+      AND nouveau_statut NOT IN (
+        'BROUILLON','EN_ANALYSE','ATTENTE_TECHNIQUE','ATTENTE_STOCK','ATTENTE_OF','ATTENTE_PLANNING',
+        'PLANNING_VALIDE','AR_PRET','AR_ENVOYE','EN_PRODUCTION','PRODUCTION_TERMINEE','CONTROLE_QUALITE',
+        'PRET_LIVRAISON','LIVRE','FACTURE','ARCHIVE','BLOQUE',
+        'ENREGISTREE','PLANIFIEE','AR_ENVOYEE','LIVREE'
+      )
+  ) THEN
+    RAISE EXCEPTION '#314 preflight refused: an unknown latest command status requires manual repair';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.commande_client_workflow_checkpoint
+    WHERE status NOT IN ('pending','active','blocked','done','skipped')
+  ) THEN
+    RAISE EXCEPTION '#314 preflight refused: an invalid checkpoint status exists';
+  END IF;
+
+  IF EXISTS (
+    SELECT commande_id, checkpoint_code
+    FROM public.commande_client_workflow_checkpoint
+    GROUP BY commande_id, checkpoint_code
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION '#314 preflight refused: duplicate command checkpoint codes exist';
+  END IF;
+
+  -- Compare every persisted checkpoint with the exact graph projection. This is
+  -- deliberately fail-closed: a future checkpoint already marked done, a
+  -- missing/extra checkpoint, or a bad internal/full-stock skip aborts deploy.
+  IF EXISTS (
+    WITH latest_raw AS (
+      SELECT DISTINCT ON (commande_id) commande_id, nouveau_statut
+      FROM public.commande_historique
+      ORDER BY commande_id, date_action DESC, id DESC
+    ), state AS (
+      SELECT
+        cc.id AS commande_id,
+        upper(COALESCE(cc.order_type, '')) AS order_type,
+        CASE COALESCE(l.nouveau_statut, 'BROUILLON')
+          WHEN 'ENREGISTREE' THEN 'EN_ANALYSE'
+          WHEN 'PLANIFIEE' THEN 'PLANNING_VALIDE'
+          WHEN 'AR_ENVOYEE' THEN 'AR_ENVOYE'
+          WHEN 'LIVREE' THEN 'LIVRE'
+          ELSE COALESCE(l.nouveau_statut, 'BROUILLON')
+        END AS canonical_status
+      FROM public.commande_client cc
+      LEFT JOIN latest_raw l ON l.commande_id = cc.id
+    ), effective_state AS (
+      SELECT s.*,
+        CASE
+          WHEN s.canonical_status <> 'BLOQUE' THEN s.canonical_status
+          ELSE (
+            SELECT cp.metadata->>'previous_status_before_block'
+            FROM public.commande_client_workflow_checkpoint cp
+            WHERE cp.commande_id = s.commande_id AND cp.status = 'blocked'
+            ORDER BY cp.id
+            LIMIT 1
+          )
+        END AS effective_status,
+        EXISTS (
+          SELECT 1
+          FROM public.commande_client_workflow_checkpoint cp
+          WHERE cp.commande_id = s.commande_id
+            AND cp.metadata->>'skip_reason' = 'commande_fully_reserved_from_stock'
+        ) AS full_stock_path
+      FROM state s
+    ), command_projection AS (
+      SELECT es.*,
+        CASE es.effective_status
+          WHEN 'BROUILLON' THEN 1 WHEN 'EN_ANALYSE' THEN 2
+          WHEN 'ATTENTE_TECHNIQUE' THEN 3 WHEN 'ATTENTE_STOCK' THEN 4
+          WHEN 'ATTENTE_OF' THEN 5 WHEN 'ATTENTE_PLANNING' THEN 6
+          WHEN 'PLANNING_VALIDE' THEN CASE WHEN es.order_type = 'INTERNE' THEN 9 ELSE 7 END
+          WHEN 'AR_PRET' THEN 8 WHEN 'AR_ENVOYE' THEN 9
+          WHEN 'EN_PRODUCTION' THEN 10
+          WHEN 'PRODUCTION_TERMINEE' THEN 11 WHEN 'CONTROLE_QUALITE' THEN 11
+          WHEN 'PRET_LIVRAISON' THEN 12 WHEN 'LIVRE' THEN CASE WHEN es.order_type = 'INTERNE' THEN 14 ELSE 13 END
+          WHEN 'FACTURE' THEN 14 WHEN 'ARCHIVE' THEN 15
+          ELSE NULL
+        END AS active_position,
+        es.order_type = 'INTERNE'
+          AND es.effective_status IN (
+            'ATTENTE_PLANNING','PLANNING_VALIDE','EN_PRODUCTION','PRODUCTION_TERMINEE',
+            'CONTROLE_QUALITE','PRET_LIVRAISON','LIVRE','ARCHIVE'
+          ) AS internal_path
+      FROM effective_state es
+    ), checkpoint_definition(checkpoint_code, checkpoint_position, sort_order) AS (
+      VALUES
+        ('order_intake',1,10), ('commercial_review',2,20), ('technical_analysis',3,30),
+        ('stock_check',4,40), ('of_generation',5,50), ('planning_validation',6,60),
+        ('ar_preparation',7,70), ('ar_sent',8,80), ('production_launch',9,90),
+        ('production_completion',10,100), ('quality_control',11,110), ('delivery',12,120),
+        ('invoicing',13,130), ('archive',14,140)
+    ), expected AS (
+      SELECT
+        p.commande_id,
+        d.checkpoint_code,
+        d.sort_order,
+        CASE
+          WHEN p.internal_path AND d.checkpoint_position IN (2,4,7,8,13) THEN 'skipped'
+          WHEN NOT p.internal_path AND p.full_stock_path AND d.checkpoint_position IN (5,6,7,8,9,10,11) THEN 'skipped'
+          WHEN d.checkpoint_position < p.active_position OR p.active_position = 15 THEN 'done'
+          WHEN d.checkpoint_position = p.active_position THEN
+            CASE WHEN p.canonical_status = 'BLOQUE' THEN 'blocked' ELSE 'active' END
+          ELSE 'pending'
+        END AS checkpoint_status
+      FROM command_projection p
+      CROSS JOIN checkpoint_definition d
+    ), anomaly AS (
+      SELECT COALESCE(e.commande_id, cp.commande_id) AS commande_id
+      FROM expected e
+      FULL OUTER JOIN public.commande_client_workflow_checkpoint cp
+        ON cp.commande_id = e.commande_id AND cp.checkpoint_code = e.checkpoint_code
+      WHERE e.commande_id IS NULL
+         OR cp.commande_id IS NULL
+         OR cp.status IS DISTINCT FROM e.checkpoint_status
+         OR cp.sort_order IS DISTINCT FROM e.sort_order
+    )
+    SELECT 1 FROM anomaly
+  ) THEN
+    RAISE EXCEPTION '#314 preflight refused: checkpoint graph is inconsistent with normalized history/order type';
+  END IF;
+END $$;
+
+WITH latest AS (
+  SELECT DISTINCT ON (commande_id) commande_id, nouveau_statut
+  FROM public.commande_historique
+  ORDER BY commande_id, date_action DESC, id DESC
+)
+SELECT
+  (SELECT COUNT(*) FROM public.commande_client cc LEFT JOIN latest l ON l.commande_id = cc.id WHERE l.commande_id IS NULL)
+    AS commandes_without_history_runtime_infers_brouillon,
+  COUNT(*) FILTER (WHERE nouveau_statut IN ('ENREGISTREE','PLANIFIEE','AR_ENVOYEE','LIVREE'))
+    AS latest_legacy_aliases_runtime_normalized,
+  COUNT(*) FILTER (WHERE nouveau_statut = 'BLOQUE') AS currently_blocked
+FROM latest;
+
+-- Diagnostic subset for operators. The complete graph check above has already
+-- failed closed before this report can be displayed.
+WITH latest_raw AS (
+  SELECT DISTINCT ON (commande_id) commande_id, nouveau_statut
+  FROM public.commande_historique
+  ORDER BY commande_id, date_action DESC, id DESC
+), state AS (
+  SELECT cc.id AS commande_id, cc.order_type,
+    CASE COALESCE(l.nouveau_statut, 'BROUILLON')
+      WHEN 'ENREGISTREE' THEN 'EN_ANALYSE'
+      WHEN 'PLANIFIEE' THEN 'PLANNING_VALIDE'
+      WHEN 'AR_ENVOYEE' THEN 'AR_ENVOYE'
+      WHEN 'LIVREE' THEN 'LIVRE'
+      ELSE COALESCE(l.nouveau_statut, 'BROUILLON')
+    END AS canonical_status
+  FROM public.commande_client cc
+  LEFT JOIN latest_raw l ON l.commande_id = cc.id
+), checkpoint_state AS (
+  SELECT commande_id,
+    COUNT(*) AS checkpoint_count,
+    COUNT(*) FILTER (WHERE status IN ('active','blocked')) AS controlling_count,
+    COUNT(*) FILTER (WHERE status = 'blocked') AS blocked_count,
+    COUNT(*) FILTER (
+      WHERE status = 'blocked'
+        AND metadata->>'previous_status_before_block' IN (
+          'BROUILLON','EN_ANALYSE','ATTENTE_TECHNIQUE','ATTENTE_STOCK','ATTENTE_OF','ATTENTE_PLANNING',
+          'PLANNING_VALIDE','AR_PRET','AR_ENVOYE','EN_PRODUCTION','PRODUCTION_TERMINEE','CONTROLE_QUALITE',
+          'PRET_LIVRAISON','LIVRE','FACTURE'
+        )
+    ) AS resumable_blocked_count,
+    MAX(checkpoint_code) FILTER (WHERE status = 'active') AS active_code
+  FROM public.commande_client_workflow_checkpoint
+  GROUP BY commande_id
+)
+SELECT
+  s.commande_id,
+  s.canonical_status,
+  cp.controlling_count,
+  cp.blocked_count,
+  cp.active_code,
+  CASE
+    WHEN s.canonical_status = 'BROUILLON' THEN 'order_intake'
+    WHEN s.canonical_status = 'EN_ANALYSE' THEN 'commercial_review'
+    WHEN s.canonical_status = 'ATTENTE_TECHNIQUE' THEN 'technical_analysis'
+    WHEN s.canonical_status = 'ATTENTE_STOCK' THEN 'stock_check'
+    WHEN s.canonical_status = 'ATTENTE_OF' THEN 'of_generation'
+    WHEN s.canonical_status = 'ATTENTE_PLANNING' THEN 'planning_validation'
+    WHEN s.canonical_status = 'PLANNING_VALIDE' AND upper(COALESCE(s.order_type, '')) = 'INTERNE' THEN 'production_launch'
+    WHEN s.canonical_status = 'PLANNING_VALIDE' THEN 'ar_preparation'
+    WHEN s.canonical_status = 'AR_PRET' THEN 'ar_sent'
+    WHEN s.canonical_status = 'AR_ENVOYE' THEN 'production_launch'
+    WHEN s.canonical_status = 'EN_PRODUCTION' THEN 'production_completion'
+    WHEN s.canonical_status IN ('PRODUCTION_TERMINEE','CONTROLE_QUALITE') THEN 'quality_control'
+    WHEN s.canonical_status = 'PRET_LIVRAISON' THEN 'delivery'
+    WHEN s.canonical_status = 'LIVRE' AND upper(COALESCE(s.order_type, '')) = 'INTERNE' THEN 'archive'
+    WHEN s.canonical_status = 'LIVRE' THEN 'invoicing'
+    WHEN s.canonical_status = 'FACTURE' THEN 'archive'
+    ELSE NULL
+  END AS expected_active_code
+FROM state s
+LEFT JOIN checkpoint_state cp ON cp.commande_id = s.commande_id
+WHERE COALESCE(cp.checkpoint_count, 0) = 0
+   OR cp.controlling_count > 1
+   OR (s.canonical_status = 'BLOQUE' AND (cp.blocked_count <> 1 OR cp.resumable_blocked_count <> 1))
+   OR (s.canonical_status <> 'BLOQUE' AND cp.blocked_count <> 0)
+   OR (
+     s.canonical_status NOT IN ('BLOQUE','ARCHIVE')
+     AND (
+       cp.controlling_count <> 1
+       OR cp.active_code IS DISTINCT FROM CASE
+         WHEN s.canonical_status = 'BROUILLON' THEN 'order_intake'
+         WHEN s.canonical_status = 'EN_ANALYSE' THEN 'commercial_review'
+         WHEN s.canonical_status = 'ATTENTE_TECHNIQUE' THEN 'technical_analysis'
+         WHEN s.canonical_status = 'ATTENTE_STOCK' THEN 'stock_check'
+         WHEN s.canonical_status = 'ATTENTE_OF' THEN 'of_generation'
+         WHEN s.canonical_status = 'ATTENTE_PLANNING' THEN 'planning_validation'
+         WHEN s.canonical_status = 'PLANNING_VALIDE' AND upper(COALESCE(s.order_type, '')) = 'INTERNE' THEN 'production_launch'
+         WHEN s.canonical_status = 'PLANNING_VALIDE' THEN 'ar_preparation'
+         WHEN s.canonical_status = 'AR_PRET' THEN 'ar_sent'
+         WHEN s.canonical_status = 'AR_ENVOYE' THEN 'production_launch'
+         WHEN s.canonical_status = 'EN_PRODUCTION' THEN 'production_completion'
+         WHEN s.canonical_status IN ('PRODUCTION_TERMINEE','CONTROLE_QUALITE') THEN 'quality_control'
+         WHEN s.canonical_status = 'PRET_LIVRAISON' THEN 'delivery'
+         WHEN s.canonical_status = 'LIVRE' AND upper(COALESCE(s.order_type, '')) = 'INTERNE' THEN 'archive'
+         WHEN s.canonical_status = 'LIVRE' THEN 'invoicing'
+         WHEN s.canonical_status = 'FACTURE' THEN 'archive'
+       END
+     )
+   )
+   OR (s.canonical_status = 'ARCHIVE' AND cp.controlling_count <> 0)
+ORDER BY s.commande_id
+LIMIT 100;
+
+ROLLBACK;

--- a/db/patches/support/20260804_commande_workflow_canonical_314.verify.sql
+++ b/db/patches/support/20260804_commande_workflow_canonical_314.verify.sql
@@ -1,0 +1,219 @@
+-- Read-only verification for issue #314 / GPT56-CERP-0005.
+-- Known historical aliases are accepted on read and projected below to their
+-- canonical runtime value. No history row is rewritten by this release.
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $$
+BEGIN
+  IF to_regclass('public.commande_client') IS NULL
+     OR to_regclass('public.commande_historique') IS NULL
+     OR to_regclass('public.commande_client_workflow_checkpoint') IS NULL
+     OR to_regclass('public.commande_client_event_log') IS NULL THEN
+    RAISE EXCEPTION '#314 verification failed: workflow prerequisites are missing';
+  END IF;
+
+  IF EXISTS (
+    SELECT commande_id, checkpoint_code
+    FROM public.commande_client_workflow_checkpoint
+    GROUP BY commande_id, checkpoint_code
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION '#314 verification failed: duplicate command checkpoint codes exist';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = 'commande_historique'
+      AND indexname = 'commande_historique_commande_last_idx'
+  ) THEN
+    RAISE EXCEPTION '#314 verification failed: latest-history lookup index is missing';
+  END IF;
+
+  IF EXISTS (
+    SELECT commande_id
+    FROM public.commande_client_workflow_checkpoint
+    WHERE status IN ('active','blocked')
+    GROUP BY commande_id
+    HAVING COUNT(*) > 1
+  ) THEN
+    RAISE EXCEPTION '#314 verification failed: a command has more than one active/blocked checkpoint';
+  END IF;
+
+  IF EXISTS (
+    WITH latest AS (
+      SELECT DISTINCT ON (commande_id) commande_id, nouveau_statut
+      FROM public.commande_historique
+      ORDER BY commande_id, date_action DESC, id DESC
+    )
+    SELECT 1
+    FROM latest l
+    LEFT JOIN public.commande_client_workflow_checkpoint cp
+      ON cp.commande_id = l.commande_id AND cp.status = 'blocked'
+    WHERE l.nouveau_statut = 'BLOQUE'
+    GROUP BY l.commande_id
+    HAVING COUNT(cp.id) <> 1
+       OR COUNT(cp.id) FILTER (
+         WHERE cp.metadata->>'previous_status_before_block' IN (
+           'BROUILLON','EN_ANALYSE','ATTENTE_TECHNIQUE','ATTENTE_STOCK','ATTENTE_OF','ATTENTE_PLANNING',
+           'PLANNING_VALIDE','AR_PRET','AR_ENVOYE','EN_PRODUCTION','PRODUCTION_TERMINEE','CONTROLE_QUALITE',
+           'PRET_LIVRAISON','LIVRE','FACTURE'
+         )
+       ) <> 1
+  ) THEN
+    RAISE EXCEPTION '#314 verification failed: BLOQUE history lacks one resumable blocked checkpoint';
+  END IF;
+
+  IF EXISTS (
+    WITH latest AS (
+      SELECT DISTINCT ON (commande_id) commande_id,
+        CASE nouveau_statut
+          WHEN 'ENREGISTREE' THEN 'EN_ANALYSE'
+          WHEN 'PLANIFIEE' THEN 'PLANNING_VALIDE'
+          WHEN 'AR_ENVOYEE' THEN 'AR_ENVOYE'
+          WHEN 'LIVREE' THEN 'LIVRE'
+          ELSE nouveau_statut
+        END AS canonical_status
+      FROM public.commande_historique
+      ORDER BY commande_id, date_action DESC, id DESC
+    )
+    SELECT 1
+    FROM latest l
+    JOIN public.commande_client_workflow_checkpoint cp ON cp.commande_id = l.commande_id
+    WHERE l.canonical_status <> 'BLOQUE' AND cp.status = 'blocked'
+  ) THEN
+    RAISE EXCEPTION '#314 verification failed: non-BLOQUE history has a blocked checkpoint';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.commande_client cc
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.commande_client_workflow_checkpoint cp
+      WHERE cp.commande_id = cc.id
+    )
+  ) THEN
+    RAISE EXCEPTION '#314 verification failed: a command has no seeded checkpoints';
+  END IF;
+
+  -- Validate the whole ordered graph, not only the controlling checkpoint.
+  -- This catches future checkpoints already done and enforces the two explicit
+  -- skip paths (INTERNE and fully-reserved-from-stock).
+  IF EXISTS (
+    WITH latest_raw AS (
+      SELECT DISTINCT ON (commande_id) commande_id, nouveau_statut
+      FROM public.commande_historique
+      ORDER BY commande_id, date_action DESC, id DESC
+    ), state AS (
+      SELECT cc.id AS commande_id, cc.order_type,
+        CASE COALESCE(l.nouveau_statut, 'BROUILLON')
+          WHEN 'ENREGISTREE' THEN 'EN_ANALYSE'
+          WHEN 'PLANIFIEE' THEN 'PLANNING_VALIDE'
+          WHEN 'AR_ENVOYEE' THEN 'AR_ENVOYE'
+          WHEN 'LIVREE' THEN 'LIVRE'
+          ELSE COALESCE(l.nouveau_statut, 'BROUILLON')
+        END AS canonical_status
+      FROM public.commande_client cc
+      LEFT JOIN latest_raw l ON l.commande_id = cc.id
+    ), effective_state AS (
+      SELECT s.*,
+        CASE
+          WHEN s.canonical_status <> 'BLOQUE' THEN s.canonical_status
+          ELSE (
+            SELECT cp.metadata->>'previous_status_before_block'
+            FROM public.commande_client_workflow_checkpoint cp
+            WHERE cp.commande_id = s.commande_id AND cp.status = 'blocked'
+            ORDER BY cp.id
+            LIMIT 1
+          )
+        END AS effective_status,
+        EXISTS (
+          SELECT 1
+          FROM public.commande_client_workflow_checkpoint cp
+          WHERE cp.commande_id = s.commande_id
+            AND cp.metadata->>'skip_reason' = 'commande_fully_reserved_from_stock'
+        ) AS full_stock_path
+      FROM state s
+    ), command_projection AS (
+      SELECT es.*,
+        CASE es.effective_status
+          WHEN 'BROUILLON' THEN 1 WHEN 'EN_ANALYSE' THEN 2
+          WHEN 'ATTENTE_TECHNIQUE' THEN 3 WHEN 'ATTENTE_STOCK' THEN 4
+          WHEN 'ATTENTE_OF' THEN 5 WHEN 'ATTENTE_PLANNING' THEN 6
+          WHEN 'PLANNING_VALIDE' THEN CASE WHEN upper(COALESCE(es.order_type, '')) = 'INTERNE' THEN 9 ELSE 7 END
+          WHEN 'AR_PRET' THEN 8 WHEN 'AR_ENVOYE' THEN 9
+          WHEN 'EN_PRODUCTION' THEN 10
+          WHEN 'PRODUCTION_TERMINEE' THEN 11 WHEN 'CONTROLE_QUALITE' THEN 11
+          WHEN 'PRET_LIVRAISON' THEN 12
+          WHEN 'LIVRE' THEN CASE WHEN upper(COALESCE(es.order_type, '')) = 'INTERNE' THEN 14 ELSE 13 END
+          WHEN 'FACTURE' THEN 14 WHEN 'ARCHIVE' THEN 15
+          ELSE NULL
+        END AS active_position,
+        upper(COALESCE(es.order_type, '')) = 'INTERNE'
+          AND es.effective_status IN (
+            'ATTENTE_PLANNING','PLANNING_VALIDE','EN_PRODUCTION','PRODUCTION_TERMINEE',
+            'CONTROLE_QUALITE','PRET_LIVRAISON','LIVRE','ARCHIVE'
+          ) AS internal_path
+      FROM effective_state es
+    ), checkpoint_definition(checkpoint_code, checkpoint_position, sort_order) AS (
+      VALUES
+        ('order_intake',1,10), ('commercial_review',2,20), ('technical_analysis',3,30),
+        ('stock_check',4,40), ('of_generation',5,50), ('planning_validation',6,60),
+        ('ar_preparation',7,70), ('ar_sent',8,80), ('production_launch',9,90),
+        ('production_completion',10,100), ('quality_control',11,110), ('delivery',12,120),
+        ('invoicing',13,130), ('archive',14,140)
+    ), expected AS (
+      SELECT
+        p.commande_id,
+        d.checkpoint_code,
+        d.sort_order,
+        CASE
+          WHEN p.internal_path AND d.checkpoint_position IN (2,4,7,8,13) THEN 'skipped'
+          WHEN NOT p.internal_path AND p.full_stock_path AND d.checkpoint_position IN (5,6,7,8,9,10,11) THEN 'skipped'
+          WHEN d.checkpoint_position < p.active_position OR p.active_position = 15 THEN 'done'
+          WHEN d.checkpoint_position = p.active_position THEN
+            CASE WHEN p.canonical_status = 'BLOQUE' THEN 'blocked' ELSE 'active' END
+          ELSE 'pending'
+        END AS checkpoint_status
+      FROM command_projection p
+      CROSS JOIN checkpoint_definition d
+    ), anomaly AS (
+      SELECT COALESCE(e.commande_id, cp.commande_id) AS commande_id
+      FROM expected e
+      FULL OUTER JOIN public.commande_client_workflow_checkpoint cp
+        ON cp.commande_id = e.commande_id AND cp.checkpoint_code = e.checkpoint_code
+      WHERE e.commande_id IS NULL
+         OR cp.commande_id IS NULL
+         OR cp.status IS DISTINCT FROM e.checkpoint_status
+         OR cp.sort_order IS DISTINCT FROM e.sort_order
+    )
+    SELECT 1 FROM anomaly
+  ) THEN
+    RAISE EXCEPTION '#314 verification failed: checkpoint graph is inconsistent with normalized history/order type';
+  END IF;
+END $$;
+
+WITH latest AS (
+  SELECT DISTINCT ON (commande_id) commande_id, nouveau_statut
+  FROM public.commande_historique
+  ORDER BY commande_id, date_action DESC, id DESC
+), normalized AS (
+  SELECT commande_id,
+    CASE nouveau_statut
+      WHEN 'ENREGISTREE' THEN 'EN_ANALYSE'
+      WHEN 'PLANIFIEE' THEN 'PLANNING_VALIDE'
+      WHEN 'AR_ENVOYEE' THEN 'AR_ENVOYE'
+      WHEN 'LIVREE' THEN 'LIVRE'
+      ELSE COALESCE(nouveau_statut, 'BROUILLON')
+    END AS canonical_status
+  FROM latest
+)
+SELECT canonical_status, COUNT(*) AS commandes
+FROM normalized
+GROUP BY canonical_status
+ORDER BY canonical_status;
+
+ROLLBACK;

--- a/docs/commande-client-workflow-canonique.md
+++ b/docs/commande-client-workflow-canonique.md
@@ -1,0 +1,50 @@
+# Machine d'état canonique des commandes client (#314)
+
+Le backend est l'autorité unique du contrat de workflow. Le statut persistant
+reste exclusivement l'historique append-only `commande_historique`; aucune
+colonne de projection `commande_client.statut` n'est créée ni utilisée.
+
+## Déploiement
+
+Aucune migration n'est requise par cette livraison. Les tables, contraintes et
+index nécessaires existent déjà via les patchs historiques du workflow et des
+checkpoints. Avant le déploiement applicatif, exécuter manuellement, sur la base
+explicitement ciblée, le script read-only
+`db/patches/support/20260804_commande_workflow_canonical_314.preflight.sql`.
+Après déploiement, exécuter de la même manière le script read-only
+`db/patches/support/20260804_commande_workflow_canonical_314.verify.sql`.
+Ces scripts ne sont pas chargés par `db:patches:up` et cette livraison ne les
+exécute pas automatiquement.
+
+Les dernières lignes utilisant les aliases historiques `ENREGISTREE`,
+`PLANIFIEE`, `AR_ENVOYEE` ou `LIVREE` restent lisibles et sont normalisées en
+mémoire. Une commande sans historique est lue comme `BROUILLON`; sa première
+écriture doit néanmoins suivre exactement l'arête canonique `BROUILLON` vers
+`EN_ANALYSE`. Un dernier statut inconnu est refusé avec un conflit explicite et
+doit être réparé manuellement après audit.
+
+## Retour arrière
+
+Le rollback est exclusivement applicatif puisqu'aucun DDL ni backfill n'est
+livré. Drainer les écritures de commande, redéployer ensemble les versions
+précédentes du backend et du frontend, puis rouvrir le trafic. Ne supprimer et
+ne réécrire aucune ligne de `commande_historique`, de checkpoint ou d'événement :
+les écritures canoniques produites par cette version restent valides et
+auditables par l'ancienne application. Si le rollback fait suite à une erreur,
+conserver les journaux et vérifier les commandes touchées avant reprise.
+
+Le preflight compare les 14 checkpoints de chaque commande à la projection
+attendue depuis l'historique normalisé et le `order_type`. Il échoue avant le
+rapport (`RAISE EXCEPTION`, avec `ON_ERROR_STOP`) en cas de checkpoint
+manquant/supplémentaire, statut ou ordre incohérent, futur checkpoint déjà
+terminé, blocage invalide, ou skip incorrect sur les parcours interne et
+entièrement couvert par le stock. Le SELECT final, limité à 100 commandes,
+reste uniquement un diagnostic opérateur lorsque le gate est vert.
+
+La réparation/backfill doit rester manuelle et contrôlée avant déploiement,
+conserver l'historique append-only, être revue commande par commande et disposer
+de sa propre sauvegarde/transaction et procédure de retour arrière ; aucun
+backfill automatique n'est fourni par cette livraison. Les commandes sans aucun
+checkpoint font également échouer le gate. Aucune anomalie n'est seulement
+listée : toute incohérence détectée interrompt le script et signifie
+explicitement `BLOCKED`.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "build": "tsc -p tsconfig.json",
+    "contract:generate": "npm run build && node scripts/generate-commande-workflow-contract.mjs",
     "start": "node dist/index.js",
     "db:patches:status": "node scripts/db-patches.js status",
     "db:patches:up": "node scripts/db-patches.js up",

--- a/scripts/generate-commande-workflow-contract.mjs
+++ b/scripts/generate-commande-workflow-contract.mjs
@@ -1,0 +1,20 @@
+import { mkdir, writeFile } from "node:fs/promises"
+import path from "node:path"
+import { createRequire } from "node:module"
+
+const require = createRequire(import.meta.url)
+const root = path.resolve(import.meta.dirname, "..")
+const definitionPath = path.join(
+  root,
+  "dist/module/commande-client/workflow/commande-client-workflow.definition.js",
+)
+const outputPath = path.join(root, "contracts/commande-client-workflow.v1.json")
+const { COMMANDE_WORKFLOW_CONTRACT } = require(definitionPath)
+
+if (COMMANDE_WORKFLOW_CONTRACT?.authority !== "erp-crp-backend") {
+  throw new Error("The compiled backend workflow contract is missing or has an unexpected authority.")
+}
+
+await mkdir(path.dirname(outputPath), { recursive: true })
+await writeFile(outputPath, `${JSON.stringify(COMMANDE_WORKFLOW_CONTRACT, null, 2)}\n`, "utf8")
+console.log(`Generated ${path.relative(root, outputPath)}`)

--- a/src/__tests__/commande-ar.routes.test.ts
+++ b/src/__tests__/commande-ar.routes.test.ts
@@ -1,6 +1,7 @@
 import request from "supertest";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EventEmitter } from "events";
+import { HttpError } from "../utils/httpError";
 
 const mocks = vi.hoisted(() => ({
   poolQuery: vi.fn(),
@@ -36,8 +37,16 @@ vi.mock("../utils/checkNetworkDrive", () => ({
 }));
 
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
-  authenticateToken: (req: { user?: { id: number; role: string } }, _res: unknown, next: () => void) => {
-    req.user = { id: 7, role: "Secretaire" };
+  authenticateToken: (
+    req: { user?: { id: number; role: string }; headers?: Record<string, string | string[] | undefined> },
+    _res: unknown,
+    next: () => void
+  ) => {
+    const requestedRole = req.headers?.["x-test-role"];
+    req.user = {
+      id: 7,
+      role: typeof requestedRole === "string" ? decodeURIComponent(requestedRole) : "Secretaire",
+    };
     next();
   },
   authorizeRole:
@@ -80,6 +89,48 @@ beforeEach(() => {
 });
 
 describe("/api/v1/commandes/:id/ar", () => {
+  it.each(["Employee", "Directeur Technique", "Responsable Qualité"])(
+    "delegates AR authorization for the exact identity %s to the checkpoint policy",
+    async (role) => {
+      const forbidden = new HttpError(403, "COMMAND_CHECKPOINT_FORBIDDEN", "forbidden");
+      mocks.generateAr.mockRejectedValueOnce(forbidden);
+      mocks.sendAr.mockRejectedValueOnce(forbidden);
+      const generate = await request(app)
+        .post("/api/v1/commandes/123/ar/generate")
+        .set("Authorization", "Bearer fake")
+        .set("x-test-role", encodeURIComponent(role))
+        .send({});
+
+      const send = await request(app)
+        .post("/api/v1/commandes/123/ar/send")
+        .set("Authorization", "Bearer fake")
+        .set("x-test-role", encodeURIComponent(role))
+        .send({
+          ar_id: "11111111-1111-1111-1111-111111111111",
+          recipient_emails: ["client@example.com"],
+          recipient_contact_ids: [],
+        });
+
+      expect(generate.status).toBe(403);
+      expect(send.status).toBe(403);
+      expect(mocks.generateAr).toHaveBeenCalledWith({ commande_id: 123, user_id: 7, user_role: role });
+      expect(mocks.sendAr).toHaveBeenCalledWith(expect.objectContaining({ user_id: 7, user_role: role }));
+    }
+  );
+
+  it("accepts an authorized role from the central multi-role representation", async () => {
+    mocks.generateAr.mockResolvedValue({ commande_id: 123, status: "GENERATED" });
+
+    const res = await request(app)
+      .post("/api/v1/commandes/123/ar/generate")
+      .set("Authorization", "Bearer fake")
+      .set("x-test-role", "Employee | Secretaire")
+      .send({});
+
+    expect(res.status).toBe(201);
+    expect(mocks.generateAr).toHaveBeenCalledWith({ commande_id: 123, user_id: 7, user_role: "Employee | Secretaire" });
+  });
+
   it("POST /generate returns generated AR draft", async () => {
     mocks.generateAr.mockResolvedValue({
       ar_id: "11111111-1111-1111-1111-111111111111",
@@ -102,7 +153,7 @@ describe("/api/v1/commandes/:id/ar", () => {
 
     expect(res.status).toBe(201);
     expect(res.body).toMatchObject({ commande_id: 123, status: "GENERATED" });
-    expect(mocks.generateAr).toHaveBeenCalledWith({ commande_id: 123, user_id: 7 });
+    expect(mocks.generateAr).toHaveBeenCalledWith({ commande_id: 123, user_id: 7, user_role: "Secretaire" });
   });
 
   it("POST /send returns AR send result", async () => {
@@ -110,7 +161,7 @@ describe("/api/v1/commandes/:id/ar", () => {
       ar_id: "11111111-1111-1111-1111-111111111111",
       commande_id: 123,
       document_id: "22222222-2222-2222-2222-222222222222",
-      status: "AR_ENVOYEE",
+      status: "AR_ENVOYE",
       sent_at: "2026-03-12T09:15:00.000Z",
       recipient_emails: ["client@example.com"],
       email_provider_id: "resend_123",
@@ -126,10 +177,11 @@ describe("/api/v1/commandes/:id/ar", () => {
       });
 
     expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({ status: "AR_ENVOYEE", commande_id: 123 });
+    expect(res.body).toMatchObject({ status: "AR_ENVOYE", commande_id: 123 });
     expect(mocks.sendAr).toHaveBeenCalledWith({
       commande_id: 123,
       user_id: 7,
+      user_role: "Secretaire",
       body: {
         ar_id: "11111111-1111-1111-1111-111111111111",
         recipient_emails: ["client@example.com"],

--- a/src/__tests__/commande-workflow-sql-guards.test.ts
+++ b/src/__tests__/commande-workflow-sql-guards.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const read = (name: string) =>
+  readFileSync(resolve("db/patches/support", name), "utf8").replace(/\r\n?/g, "\n");
+
+const preflight = read("20260804_commande_workflow_canonical_314.preflight.sql");
+const verify = read("20260804_commande_workflow_canonical_314.verify.sql");
+
+describe("#314 workflow SQL guards", () => {
+  it.each([
+    ["preflight", preflight],
+    ["verify", verify],
+  ])("keeps %s read-only and raises on a full-graph anomaly", (_label, sql) => {
+    expect(sql).toContain("BEGIN TRANSACTION READ ONLY;");
+    expect(sql).toContain("\\set ON_ERROR_STOP on");
+    expect(sql).toContain("FULL OUTER JOIN public.commande_client_workflow_checkpoint");
+    expect(sql).toContain("cp.status IS DISTINCT FROM e.checkpoint_status");
+    expect(sql).toContain("cp.sort_order IS DISTINCT FROM e.sort_order");
+    expect(sql).toMatch(/IF EXISTS \([\s\S]*SELECT 1 FROM anomaly[\s\S]*\) THEN\s+RAISE EXCEPTION/);
+    expect(sql).toContain("ROLLBACK;");
+    expect(sql).not.toMatch(/\b(?:INSERT|UPDATE|DELETE|TRUNCATE)\s+(?:INTO\s+|FROM\s+)?public\./i);
+  });
+
+  it.each([preflight, verify])("pins every canonical checkpoint and both skip paths", (sql) => {
+    for (const code of [
+      "order_intake", "commercial_review", "technical_analysis", "stock_check",
+      "of_generation", "planning_validation", "ar_preparation", "ar_sent",
+      "production_launch", "production_completion", "quality_control", "delivery",
+      "invoicing", "archive",
+    ]) {
+      expect(sql).toContain(`'${code}'`);
+    }
+
+    expect(sql).toContain("d.checkpoint_position IN (2,4,7,8,13)");
+    expect(sql).toContain("'commande_fully_reserved_from_stock'");
+    expect(sql).toContain("d.checkpoint_position IN (5,6,7,8,9,10,11)");
+    expect(sql).toContain("d.checkpoint_position < p.active_position");
+    expect(sql).toContain("ELSE 'pending'");
+  });
+});

--- a/src/__tests__/commande-workflow-state-machine.test.ts
+++ b/src/__tests__/commande-workflow-state-machine.test.ts
@@ -1,0 +1,272 @@
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it, vi } from "vitest"
+import {
+  COMMANDE_WORKFLOW_BLOCKABLE_STATUSES,
+  COMMANDE_WORKFLOW_CONTRACT,
+  COMMANDE_WORKFLOW_LEGACY_STATUS_ALIASES,
+  COMMANDE_WORKFLOW_STATUSES,
+  COMMANDE_WORKFLOW_TRANSITION_CAUSES,
+  COMMANDE_WORKFLOW_TRANSITIONS,
+  canCommandeWorkflowTransition,
+  isCanonicalCommandeWorkflowStatus,
+  normalizeCommandeWorkflowStatus,
+  type CommandeWorkflowStatus,
+} from "../module/commande-client/workflow/commande-client-workflow.definition"
+import { repoEnsureCommandeWorkflowStatus } from "../module/commande-client/repository/commande-client.repository"
+import { canActOnCommandeWorkflowCheckpoint } from "../module/commande-client/domain/commande-client-rbac"
+
+describe("commande workflow canonical state machine", () => {
+  it("accepts only the declared pair for every static cause/status combination", () => {
+    const staticCauses = COMMANDE_WORKFLOW_TRANSITION_CAUSES.filter(
+      (cause) => cause !== "block" && cause !== "resume",
+    )
+
+    for (const cause of staticCauses) {
+      for (const from of COMMANDE_WORKFLOW_STATUSES) {
+        for (const to of COMMANDE_WORKFLOW_STATUSES) {
+          const declared = from === to || COMMANDE_WORKFLOW_TRANSITIONS.some(
+            (rule) => rule.from === from && rule.to === to && rule.cause === cause,
+          )
+          expect(
+            canCommandeWorkflowTransition(from, to, cause),
+            `${cause}: ${from} -> ${to}`,
+          ).toBe(declared)
+        }
+      }
+    }
+  })
+
+  it("blocks only a non-terminal current status and resumes only the exact stored status", () => {
+    for (const from of COMMANDE_WORKFLOW_STATUSES) {
+      expect(canCommandeWorkflowTransition(from, "BLOQUE", "block"), from).toBe(
+        from === "BLOQUE" || COMMANDE_WORKFLOW_BLOCKABLE_STATUSES.includes(
+          from as Exclude<CommandeWorkflowStatus, "ARCHIVE" | "BLOQUE">,
+        ),
+      )
+    }
+
+    for (const resumeStatus of COMMANDE_WORKFLOW_BLOCKABLE_STATUSES) {
+      for (const target of COMMANDE_WORKFLOW_STATUSES) {
+        expect(
+          canCommandeWorkflowTransition("BLOQUE", target, "resume", { resume_status: resumeStatus }),
+          `resume ${resumeStatus}: BLOQUE -> ${target}`,
+        ).toBe(target === "BLOQUE" || target === resumeStatus)
+      }
+    }
+    expect(canCommandeWorkflowTransition("BLOQUE", "EN_ANALYSE", "resume")).toBe(false)
+    expect(COMMANDE_WORKFLOW_CONTRACT.checkpoint_transitions.BLOQUE).toEqual([])
+  })
+
+  it("preserves the audited business shortcuts and rejects the adjacent unauthorized jumps", () => {
+    expect(canCommandeWorkflowTransition("ATTENTE_OF", "ATTENTE_PLANNING", "customer_order_launch")).toBe(true)
+    expect(canCommandeWorkflowTransition("ATTENTE_OF", "PRET_LIVRAISON", "customer_order_launch")).toBe(true)
+    expect(canCommandeWorkflowTransition("ATTENTE_TECHNIQUE", "ATTENTE_PLANNING", "internal_order_launch")).toBe(true)
+    expect(canCommandeWorkflowTransition("ATTENTE_PLANNING", "AR_PRET", "checkpoint")).toBe(false)
+    expect(canCommandeWorkflowTransition("AR_PRET", "AR_ENVOYE", "ar_send")).toBe(true)
+    expect(canCommandeWorkflowTransition("PRODUCTION_TERMINEE", "PRET_LIVRAISON", "checkpoint")).toBe(true)
+    expect(canCommandeWorkflowTransition("ATTENTE_PLANNING", "PLANNING_VALIDE", "internal_planning_validation")).toBe(true)
+    expect(canCommandeWorkflowTransition("PLANNING_VALIDE", "EN_PRODUCTION", "internal_production_launch")).toBe(true)
+    expect(canCommandeWorkflowTransition("LIVRE", "ARCHIVE", "internal_archive")).toBe(true)
+
+    expect(canCommandeWorkflowTransition("ATTENTE_OF", "AR_PRET", "customer_order_launch")).toBe(false)
+    expect(canCommandeWorkflowTransition("ATTENTE_PLANNING", "PRET_LIVRAISON", "planning_sync")).toBe(false)
+    expect(canCommandeWorkflowTransition("LIVRE", "PRET_LIVRAISON", "checkpoint")).toBe(false)
+    expect(canCommandeWorkflowTransition("FACTURE", "LIVRE", "checkpoint")).toBe(false)
+    expect(COMMANDE_WORKFLOW_CONTRACT.checkpoint_transitions.ATTENTE_OF).toEqual([])
+    expect(COMMANDE_WORKFLOW_CONTRACT.checkpoint_transitions.ATTENTE_PLANNING).toEqual(["PLANNING_VALIDE"])
+  })
+
+  it("runs the canonical internal path without manufacturing AR or invoice states", async () => {
+    let currentStatus = "ATTENTE_PLANNING"
+    let historyId = 0
+    const writtenStatuses: string[] = []
+    const query = vi.fn(async (sql: unknown, values?: unknown[]) => {
+      const statement = String(sql)
+      if (statement.includes("FROM commande_client") && statement.includes("FOR UPDATE")) {
+        return { rows: [{ id: 123, numero: "CI-123", client_id: "001", order_type: "INTERNE" }] }
+      }
+      if (statement.includes("SELECT nouveau_statut")) return { rows: [{ nouveau_statut: currentStatus }] }
+      if (statement.includes("INSERT INTO commande_historique")) {
+        currentStatus = String(values?.[3])
+        writtenStatuses.push(currentStatus)
+        historyId += 1
+        return { rows: [{ id: String(historyId) }] }
+      }
+      return { rows: [] }
+    })
+    const tx = { query } as never
+    const steps = [
+      ["PLANNING_VALIDE", "internal_planning_validation"],
+      ["EN_PRODUCTION", "internal_production_launch"],
+      ["PRODUCTION_TERMINEE", "checkpoint"],
+      ["PRET_LIVRAISON", "checkpoint"],
+      ["LIVRE", "shipment_sync"],
+      ["ARCHIVE", "internal_archive"],
+    ] as const
+
+    for (const [target, cause] of steps) {
+      const result = await repoEnsureCommandeWorkflowStatus({
+        tx,
+        commande_id: 123,
+        nouveau_statut: target,
+        cause,
+        commentaire: `internal ${target}`,
+        user_id: 1,
+      })
+      expect(result.changed, `${cause} -> ${target}`).toBe(true)
+    }
+
+    expect(writtenStatuses).toEqual([
+      "PLANNING_VALIDE",
+      "EN_PRODUCTION",
+      "PRODUCTION_TERMINEE",
+      "PRET_LIVRAISON",
+      "LIVRE",
+      "ARCHIVE",
+    ])
+    expect(writtenStatuses).not.toContain("AR_PRET")
+    expect(writtenStatuses).not.toContain("AR_ENVOYE")
+    expect(writtenStatuses).not.toContain("FACTURE")
+
+    const standardTx = {
+      query: vi.fn(async (sql: unknown) => String(sql).includes("FROM commande_client")
+        ? { rows: [{ id: 456, numero: "CC-456", client_id: "001", order_type: "STANDARD" }] }
+        : { rows: [] }),
+    } as never
+    await expect(repoEnsureCommandeWorkflowStatus({
+      tx: standardTx,
+      commande_id: 456,
+      nouveau_statut: "EN_PRODUCTION",
+      cause: "internal_production_launch",
+      commentaire: null,
+      user_id: 1,
+    })).rejects.toMatchObject({ code: "INTERNAL_COMMAND_TRANSITION_REQUIRED", status: 409 })
+  })
+
+  it("keeps legacy aliases read-only while write targets remain canonical", () => {
+    for (const [legacy, canonical] of Object.entries(COMMANDE_WORKFLOW_LEGACY_STATUS_ALIASES)) {
+      expect(normalizeCommandeWorkflowStatus(legacy)).toBe(canonical)
+      expect(isCanonicalCommandeWorkflowStatus(legacy)).toBe(false)
+      expect(isCanonicalCommandeWorkflowStatus(canonical)).toBe(true)
+    }
+    expect(normalizeCommandeWorkflowStatus("unknown")).toBeNull()
+  })
+
+  it("keeps the committed JSON artifact byte-for-structure aligned with backend authority", () => {
+    const contractPath = path.resolve(process.cwd(), "contracts/commande-client-workflow.v1.json")
+    const generated = JSON.parse(fs.readFileSync(contractPath, "utf8"))
+    expect(generated).toEqual(COMMANDE_WORKFLOW_CONTRACT)
+    expect(generated.authority).toBe("erp-crp-backend")
+  })
+
+  it("repairs a legacy command without history only through the safe BROUILLON first step", async () => {
+    const query = vi.fn(async (sql: unknown) => {
+      const statement = String(sql)
+      if (statement.includes("FROM commande_client")) {
+        return { rows: [{ id: 123, numero: "CC-123", client_id: "001" }] }
+      }
+      if (statement.includes("SELECT nouveau_statut")) return { rows: [] }
+      if (statement.includes("INSERT INTO commande_historique")) return { rows: [{ id: "45" }] }
+      return { rows: [] }
+    })
+
+    const result = await repoEnsureCommandeWorkflowStatus({
+      tx: { query } as never,
+      commande_id: 123,
+      nouveau_statut: "EN_ANALYSE",
+      cause: "checkpoint",
+      commentaire: "first canonical checkpoint",
+      user_id: 1,
+    })
+
+    expect(result).toMatchObject({ changed: true, ancien_statut: null, nouveau_statut: "EN_ANALYSE" })
+    const historyCall = query.mock.calls.find(([sql]) => String(sql).includes("INSERT INTO commande_historique"))
+    expect(historyCall?.[1]).toEqual([123, 1, null, "EN_ANALYSE", "first canonical checkpoint"])
+
+    await expect(repoEnsureCommandeWorkflowStatus({
+      tx: { query } as never,
+      commande_id: 123,
+      nouveau_statut: "ATTENTE_STOCK",
+      cause: "checkpoint",
+      commentaire: "unsafe jump",
+      user_id: 1,
+    })).rejects.toMatchObject({ code: "ILLEGAL_COMMAND_STATUS_TRANSITION", status: 409 })
+  })
+
+  it("rejects legacy aliases and backward values as write targets", async () => {
+    const query = vi.fn(async (sql: unknown) => {
+      const statement = String(sql)
+      if (statement.includes("FROM commande_client")) {
+        return { rows: [{ id: 123, numero: "CC-123", client_id: "001" }] }
+      }
+      if (statement.includes("SELECT nouveau_statut")) return { rows: [{ nouveau_statut: "ATTENTE_STOCK" }] }
+      return { rows: [] }
+    })
+
+    await expect(repoEnsureCommandeWorkflowStatus({
+      tx: { query } as never,
+      commande_id: 123,
+      nouveau_statut: "PLANIFIEE" as CommandeWorkflowStatus,
+      cause: "planning_sync",
+      commentaire: null,
+      user_id: 1,
+    })).rejects.toMatchObject({ code: "INVALID_COMMAND_STATUS", status: 400 })
+
+    await expect(repoEnsureCommandeWorkflowStatus({
+      tx: { query } as never,
+      commande_id: 123,
+      nouveau_statut: "EN_ANALYSE",
+      cause: "checkpoint",
+      commentaire: null,
+      user_id: 1,
+    })).rejects.toMatchObject({ code: "ILLEGAL_COMMAND_STATUS_TRANSITION", status: 409 })
+  })
+
+  it.each([
+    ["secretariat", "Secretaire"],
+    ["technique", "Method"],
+    ["planning", "Planification"],
+    ["production", "Production"],
+    ["qualite", "Responsable Qualité"],
+    ["logistique", "Logistique"],
+    ["comptabilite", "Comptabilite"],
+    ["direction", "Directeur"],
+  ])("enforces server-side checkpoint ownership for %s", (responsibleRole, allowedRole) => {
+    expect(canActOnCommandeWorkflowCheckpoint({
+      user_id: 1,
+      user_role: allowedRole,
+      responsible_role: responsibleRole,
+    })).toBe(true)
+    expect(canActOnCommandeWorkflowCheckpoint({
+      user_id: 1,
+      user_role: "Employee",
+      responsible_role: responsibleRole,
+    })).toBe(false)
+    expect(canActOnCommandeWorkflowCheckpoint({
+      user_id: 1,
+      user_role: allowedRole,
+      responsible_role: responsibleRole,
+      assigned_user_id: 2,
+    })).toBe(allowedRole === "Directeur")
+    expect(canActOnCommandeWorkflowCheckpoint({
+      user_id: 1,
+      user_role: "Administrateur Systeme et Reseau",
+      responsible_role: responsibleRole,
+      assigned_user_id: 2,
+    })).toBe(true)
+  })
+
+  it("uses the checkpoint policy for both AR generation and sending", () => {
+    for (const role of ["Secretaire", "Commercial", "Comptabilite", "Directeur", "Administrateur Systeme et Reseau"]) {
+      expect(canActOnCommandeWorkflowCheckpoint({
+        user_id: 1,
+        user_role: role,
+        responsible_role: "secretariat",
+      }), role).toBe(true)
+    }
+    expect(canActOnCommandeWorkflowCheckpoint({ user_id: 1, user_role: "Employee | Secretaire", responsible_role: "secretariat" })).toBe(true)
+    expect(canActOnCommandeWorkflowCheckpoint({ user_id: 1, user_role: "Stagiaire admin", responsible_role: "secretariat" })).toBe(false)
+    expect(canActOnCommandeWorkflowCheckpoint({ user_id: 1, user_role: "Employee", responsible_role: "secretariat", assigned_user_id: 1 })).toBe(true)
+  })
+})

--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -157,6 +157,13 @@ describe("/api/v1/commandes", () => {
 
     expect(String(dataCall[0])).toContain("ORDER BY cc.numero ASC");
     expect(dataCall[1]).toEqual(["%ACME%", "001", "valide", "2026-02-01", "2026-02-28", 10, 200, 5, 5]);
+
+    const statusProjectionSql = `${String(countCall[0])}\n${String(dataCall[0])}`;
+    expect(statusProjectionSql).toContain("THEN 'EN_ANALYSE'");
+    expect(statusProjectionSql).toContain("THEN 'PLANNING_VALIDE'");
+    expect(statusProjectionSql).toContain("THEN 'AR_ENVOYE'");
+    expect(statusProjectionSql).toContain("THEN 'LIVRE'");
+    expect(statusProjectionSql).not.toMatch(/THEN '(ENREGISTREE|PLANIFIEE|AR_ENVOYEE|LIVREE)'/);
   });
 
   it("GET /api/v1/commandes/:id returns include structures", async () => {
@@ -586,59 +593,22 @@ describe("/api/v1/commandes", () => {
     expect(deleteLignesCall).toBeTruthy();
   });
 
-  it("POST /api/v1/commandes/:id/status writes historique", async () => {
+  it("POST /api/v1/commandes/:id/status is disabled in favor of checkpoint actions", async () => {
     process.env.JWT_SECRET = "test-secret";
     const token = jwt.sign(
       { id: 1, username: "test", email: "test@example.com", role: "admin" },
       process.env.JWT_SECRET,
       { expiresIn: "1h" }
     );
-
-    mocks.clientQuery
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [{ exists: true }] }) // linked OF invariant
-      .mockResolvedValueOnce({ rows: [{ id: "123" }] }) // exists
-      .mockResolvedValueOnce({ rows: [{ nouveau_statut: "ENREGISTREE" }] }) // last
-      .mockResolvedValueOnce({ rows: [{ id: "10" }] }) // insert historique
-      .mockResolvedValueOnce({ rows: [] }) // update commande
-      .mockResolvedValueOnce({ rows: [] }); // COMMIT
 
     const res = await request(app)
       .post("/api/v1/commandes/123/status")
       .set("Authorization", `Bearer ${token}`)
       .send({ nouveau_statut: "PLANIFIEE", commentaire: "ok" });
 
-    expect(res.status).toBe(200);
-    expect(res.body).toMatchObject({ ok: true, nouveau_statut: "PLANIFIEE" });
-
-    const insertCall = mocks.clientQuery.mock.calls.find((c) => String(c[0]).includes("INSERT INTO commande_historique"));
-    expect(insertCall).toBeTruthy();
-    expect(insertCall?.[1]).toEqual([123, 1, "ENREGISTREE", "PLANIFIEE", "ok"]);
-  });
-
-  it("POST /api/v1/commandes/:id/status refuses planning statuses without an OF", async () => {
-    process.env.JWT_SECRET = "test-secret";
-    const token = jwt.sign(
-      { id: 1, username: "test", email: "test@example.com", role: "admin" },
-      process.env.JWT_SECRET,
-      { expiresIn: "1h" }
-    );
-
-    mocks.clientQuery
-      .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [{ exists: false }] }) // linked OF invariant
-      .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
-
-    const res = await request(app)
-      .post("/api/v1/commandes/123/status")
-      .set("Authorization", `Bearer ${token}`)
-      .send({ nouveau_statut: "ATTENTE_PLANNING", commentaire: "force" });
-
-    expect(res.status).toBe(409);
-    expect(res.body).toMatchObject({ code: "PLANNING_REQUIRES_OF" });
-    expect(
-      mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO commande_historique"))
-    ).toBe(false);
+    expect(res.status).toBe(410);
+    expect(res.body).toMatchObject({ code: "DIRECT_COMMAND_STATUS_MUTATION_DISABLED" });
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
   });
 
   it("GET /api/v1/commandes/:id/workflow returns checkpoints and available actions", async () => {
@@ -705,6 +675,7 @@ describe("/api/v1/commandes", () => {
       commande_id: 123,
       numero: "CC-123",
       statut: "ATTENTE_TECHNIQUE",
+      can_act: true,
       current_checkpoint: {
         checkpoint_code: "technical_analysis",
         status: "active",
@@ -719,6 +690,71 @@ describe("/api/v1/commandes", () => {
       ],
     });
     expect(res.body.checkpoints).toHaveLength(2);
+
+    const commandLockIndex = mocks.clientQuery.mock.calls.findIndex(([sql]) =>
+      String(sql).includes("FROM commande_client cc") && String(sql).includes("FOR UPDATE")
+    );
+    const freshHistoryIndex = mocks.clientQuery.mock.calls.findIndex(([sql]) =>
+      String(sql).includes("st.nouveau_statut AS raw_statut")
+    );
+    expect(commandLockIndex).toBeGreaterThanOrEqual(0);
+    expect(freshHistoryIndex).toBeGreaterThan(commandLockIndex);
+    expect(String(mocks.clientQuery.mock.calls[freshHistoryIndex]?.[0])).not.toContain("FOR UPDATE OF cc");
+  });
+
+  it("computes workflow can_act from exact role, assignment and administrator override", async () => {
+    let assignedUserId: number | null = null;
+    const checkpoint = {
+      id: "77",
+      commande_id: "123",
+      checkpoint_code: "technical_analysis",
+      label: "Analyse technique",
+      sort_order: 30,
+      status: "active",
+      responsible_role: "technique",
+      assigned_user_id: null,
+      due_at: null,
+      completed_at: null,
+      completed_by: null,
+      blocked_reason: null,
+      notes: null,
+      action_key: "complete_technical_analysis",
+      action_label: "Valider technique",
+      metadata: {},
+      created_at: "2026-06-01T08:00:00.000Z",
+      updated_at: "2026-06-01T08:00:00.000Z",
+    };
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM commande_client cc")) {
+        return { rows: [{ id: "123", numero: "CC-123", client_id: "001", raw_statut: "ATTENTE_TECHNIQUE" }] };
+      }
+      if (q.includes("INSERT INTO public.commande_client_workflow_checkpoint")) return { rows: [] };
+      if (q.includes("FROM public.commande_client_workflow_checkpoint")) {
+        return { rows: [{ ...checkpoint, assigned_user_id: assignedUserId }] };
+      }
+      return { rows: [] };
+    });
+
+    const wrongRole = await request(app)
+      .get("/api/v1/commandes/123/workflow")
+      .set("x-test-role", "Employee");
+    expect(wrongRole.body).toMatchObject({ can_act: false, available_actions: [] });
+    expect(wrongRole.body.action_forbidden_reason).toContain("technique");
+
+    assignedUserId = 2;
+    const wrongAssignee = await request(app)
+      .get("/api/v1/commandes/123/workflow")
+      .set("x-test-role", "Method");
+    expect(wrongAssignee.body).toMatchObject({ can_act: false, available_actions: [] });
+    expect(wrongAssignee.body.action_forbidden_reason).toContain("autre utilisateur");
+
+    const admin = await request(app)
+      .get("/api/v1/commandes/123/workflow")
+      .set("x-test-role", "Administrateur Systeme et Reseau");
+    expect(admin.body).toMatchObject({ can_act: true });
+    expect(admin.body.available_actions).toHaveLength(1);
   });
 
   it("POST /api/v1/commandes/:id/workflow/actions advances the checkpoint workflow", async () => {
@@ -794,7 +830,7 @@ describe("/api/v1/commandes", () => {
     expect(res.status).toBe(200);
     expect(res.body.workflow).toMatchObject({
       commande_id: 123,
-      statut: "ATTENTE_TECHNIQUE",
+      statut: "ATTENTE_STOCK",
       current_checkpoint: {
         checkpoint_code: "stock_check",
         status: "active",
@@ -805,6 +841,7 @@ describe("/api/v1/commandes", () => {
         },
       ],
     });
+    expect(res.body.idempotent_replay).toBe(false);
 
     const completedCheckpointCall = mocks.clientQuery.mock.calls.find(
       (c) => String(c[0]).includes("SET status = 'done'") && String(c[0]).includes("public.commande_client_workflow_checkpoint")
@@ -818,6 +855,76 @@ describe("/api/v1/commandes", () => {
     expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO ordres_fabrication"))).toBe(false);
   });
 
+  it("replays an already completed workflow action without a second side effect", async () => {
+    const checkpointRows = [
+      {
+        id: "77",
+        commande_id: "123",
+        checkpoint_code: "technical_analysis",
+        label: "Analyse technique",
+        sort_order: 30,
+        status: "done",
+        responsible_role: "technique",
+        assigned_user_id: 12,
+        due_at: null,
+        completed_at: "2026-06-16T08:00:00.000Z",
+        completed_by: 1,
+        blocked_reason: null,
+        notes: "ok technique",
+        action_key: "complete_technical_analysis",
+        action_label: "Valider technique",
+        metadata: {},
+        created_at: "2026-06-01T08:00:00.000Z",
+        updated_at: "2026-06-16T08:00:00.000Z",
+      },
+      {
+        id: "78",
+        commande_id: "123",
+        checkpoint_code: "stock_check",
+        label: "Controle du stock",
+        sort_order: 40,
+        status: "active",
+        responsible_role: "technique",
+        assigned_user_id: null,
+        due_at: null,
+        completed_at: null,
+        completed_by: null,
+        blocked_reason: null,
+        notes: null,
+        action_key: "check_stock",
+        action_label: "Controler le stock",
+        metadata: {},
+        created_at: "2026-06-01T08:00:00.000Z",
+        updated_at: "2026-06-16T08:00:00.000Z",
+      },
+    ];
+
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query === "BEGIN" || query === "COMMIT" || query === "ROLLBACK") return { rows: [] };
+      if (query.includes("FROM commande_client cc")) {
+        return { rows: [{ id: "123", numero: "CC-123", client_id: "001", raw_statut: "ATTENTE_STOCK" }] };
+      }
+      if (query.includes("INSERT INTO public.commande_client_workflow_checkpoint")) return { rows: [] };
+      if (query.includes("SELECT status, responsible_role")) {
+        return { rows: [{ status: "done", responsible_role: "technique" }] };
+      }
+      if (query.includes("FROM public.commande_client_workflow_checkpoint")) return { rows: checkpointRows };
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post("/api/v1/commandes/123/workflow/actions")
+      .send({ action: "complete_technical_analysis", commentaire: "ok technique" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ idempotent_replay: true, workflow: { statut: "ATTENTE_STOCK" } });
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO commande_historique"))).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("commande_client_event_log"))).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("app_notification"))).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("SET status = 'done'"))).toBe(false);
+  });
+
   it("POST /api/v1/commandes/:id/workflow/actions refuses to complete launch without stock allocation or OF generation", async () => {
     const res = await request(app)
       .post("/api/v1/commandes/123/workflow/actions")
@@ -826,6 +933,17 @@ describe("/api/v1/commandes", () => {
     expect(res.status).toBe(409);
     expect(res.body).toMatchObject({ code: "COMMAND_LAUNCH_REQUIRED" });
     expect(mocks.poolConnect).not.toHaveBeenCalled();
+  });
+
+  it("refuses to simulate AR delivery through the generic checkpoint action", async () => {
+    const res = await request(app)
+      .post("/api/v1/commandes/123/workflow/actions")
+      .send({ action: "mark_ar_sent" });
+
+    expect(res.status).toBe(409);
+    expect(res.body).toMatchObject({ code: "COMMAND_AR_SEND_REQUIRED" });
+    expect(mocks.poolConnect).not.toHaveBeenCalled();
+    expect(mocks.clientQuery).not.toHaveBeenCalled();
   });
 
   it.each([
@@ -848,6 +966,10 @@ describe("/api/v1/commandes", () => {
       if (q === "BEGIN" || q === "ROLLBACK") return { rows: [] };
       if (q.includes("FROM commande_client cc")) {
         return { rows: [{ id: "123", numero: "CC-123", client_id: "001", raw_statut: "PRET_LIVRAISON" }] };
+      }
+      if (q.includes("INSERT INTO public.commande_client_workflow_checkpoint")) return { rows: [] };
+      if (q.includes("SELECT status, responsible_role")) {
+        return { rows: [{ status: "active", responsible_role: "logistique" }] };
       }
       if (q.includes("WITH shipped_by_line AS")) {
         return {
@@ -877,6 +999,10 @@ describe("/api/v1/commandes", () => {
       if (q === "BEGIN" || q === "ROLLBACK") return { rows: [] };
       if (q.includes("FROM commande_client cc")) {
         return { rows: [{ id: "123", numero: "CC-123", client_id: "001", raw_statut: "ATTENTE_PLANNING" }] };
+      }
+      if (q.includes("INSERT INTO public.commande_client_workflow_checkpoint")) return { rows: [] };
+      if (q.includes("SELECT status, responsible_role")) {
+        return { rows: [{ status: "active", responsible_role: "planning" }] };
       }
       if (q.includes("FROM public.ordres_fabrication")) {
         return { rows: [{ exists: false }] };
@@ -988,6 +1114,161 @@ describe("/api/v1/commandes", () => {
     expect(resumeStatusCall?.[1]).toEqual([123, 1, "BLOQUE", "ATTENTE_TECHNIQUE", "ok"]);
   });
 
+  it.each(["done", "skipped", "pending"])(
+    "PATCH checkpoint rejects direct progress status %s",
+    async (status) => {
+      const res = await request(app)
+        .patch("/api/v1/commandes/123/workflow/checkpoints/technical_analysis")
+        .send({ status });
+
+      expect(res.status).toBe(400);
+      expect(mocks.poolConnect).not.toHaveBeenCalled();
+    }
+  );
+
+  it("replays an identical blocked-checkpoint patch without duplicate history or notification", async () => {
+    const checkpointRow = {
+      id: "77",
+      commande_id: "123",
+      checkpoint_code: "technical_analysis",
+      label: "Analyse technique",
+      sort_order: 30,
+      status: "blocked",
+      responsible_role: "technique",
+      assigned_user_id: 12,
+      due_at: null,
+      completed_at: null,
+      completed_by: null,
+      blocked_reason: "Plan manquant",
+      notes: null,
+      action_key: "complete_technical_analysis",
+      action_label: "Valider technique",
+      metadata: { previous_status_before_block: "ATTENTE_TECHNIQUE" },
+      created_at: "2026-06-01T08:00:00.000Z",
+      updated_at: "2026-06-01T08:00:00.000Z",
+    };
+
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query === "BEGIN" || query === "COMMIT" || query === "ROLLBACK") return { rows: [] };
+      if (query.includes("FROM commande_client cc")) {
+        return { rows: [{ id: "123", numero: "CC-123", client_id: "001", raw_statut: "BLOQUE" }] };
+      }
+      if (query.includes("INSERT INTO public.commande_client_workflow_checkpoint")) return { rows: [] };
+      if (query.includes("FROM public.commande_client_workflow_checkpoint") && query.includes("FOR UPDATE")) {
+        return { rows: [checkpointRow] };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .patch("/api/v1/commandes/123/workflow/checkpoints/technical_analysis")
+      .send({ status: "blocked", blocked_reason: "Plan manquant" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({ idempotent_replay: true, checkpoint: { status: "blocked" } });
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("UPDATE public.commande_client_workflow_checkpoint"))).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO commande_historique"))).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("commande_client_event_log"))).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("app_notification"))).toBe(false);
+  });
+
+  it("notifies each real block episode with its own history-backed dedupe key", async () => {
+    let currentStatus = "ATTENTE_TECHNIQUE";
+    let nextHistoryId = 100;
+    let checkpoint = {
+      id: "77",
+      commande_id: "123",
+      checkpoint_code: "technical_analysis",
+      label: "Analyse technique",
+      sort_order: 30,
+      status: "active",
+      responsible_role: "technique",
+      assigned_user_id: null,
+      due_at: null,
+      completed_at: null,
+      completed_by: null,
+      blocked_reason: null,
+      notes: null,
+      action_key: "complete_technical_analysis",
+      action_label: "Valider technique",
+      metadata: {} as Record<string, unknown>,
+      created_at: "2026-06-01T08:00:00.000Z",
+      updated_at: "2026-06-01T08:00:00.000Z",
+    };
+    const notificationKeys: string[] = [];
+
+    mocks.clientQuery.mockImplementation(async (sql: unknown, values?: unknown[]) => {
+      const q = String(sql);
+      if (q === "BEGIN" || q === "COMMIT" || q === "ROLLBACK") return { rows: [] };
+      if (q.includes("FROM commande_client cc")) {
+        return { rows: [{ id: "123", numero: "CC-123", client_id: "001", raw_statut: currentStatus }] };
+      }
+      if (q.includes("INSERT INTO public.commande_client_workflow_checkpoint")) return { rows: [] };
+      if (q.includes("FROM public.commande_client_workflow_checkpoint") && q.includes("FOR UPDATE")) {
+        return { rows: [checkpoint] };
+      }
+      if (q.includes("UPDATE public.commande_client_workflow_checkpoint") && q.includes("RETURNING")) {
+        checkpoint = {
+          ...checkpoint,
+          status: String(values?.[2]),
+          assigned_user_id: (values?.[3] as number | null) ?? checkpoint.assigned_user_id,
+          due_at: (values?.[4] as string | null) ?? checkpoint.due_at,
+          blocked_reason: (values?.[6] as string | null) ?? null,
+          notes: (values?.[7] as string | null) ?? checkpoint.notes,
+          metadata: JSON.parse(String(values?.[8] ?? "{}")),
+        };
+        return { rows: [checkpoint] };
+      }
+      if (q.includes("SELECT id::int AS id, numero, client_id")) {
+        return { rows: [{ id: 123, numero: "CC-123", client_id: "001" }] };
+      }
+      if (q.includes("SELECT nouveau_statut")) return { rows: [{ nouveau_statut: currentStatus }] };
+      if (q.includes("INSERT INTO commande_historique")) {
+        currentStatus = String(values?.[3]);
+        nextHistoryId += 1;
+        return { rows: [{ id: String(nextHistoryId) }] };
+      }
+      if (q.includes("SELECT DISTINCT u.id::int AS id")) return { rows: [{ id: 9 }] };
+      if (q.includes("FROM public.app_notifications") && q.includes("dedupe_key")) return { rows: [] };
+      if (q.includes("INSERT INTO public.app_notifications")) {
+        notificationKeys.push(String(values?.[8]));
+        return {
+          rows: [{
+            id: String(notificationKeys.length),
+            user_id: 9,
+            kind: values?.[1],
+            title: values?.[2],
+            message: values?.[3],
+            severity: values?.[4],
+            action_url: values?.[5],
+            action_label: values?.[6],
+            payload: {},
+            created_at: "2026-08-04T08:00:00.000Z",
+            read_at: null,
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const blockOne = await request(app)
+      .patch("/api/v1/commandes/123/workflow/checkpoints/technical_analysis")
+      .send({ status: "blocked", blocked_reason: "Premier blocage" });
+    const resume = await request(app)
+      .patch("/api/v1/commandes/123/workflow/checkpoints/technical_analysis")
+      .send({ status: "active" });
+    const blockTwo = await request(app)
+      .patch("/api/v1/commandes/123/workflow/checkpoints/technical_analysis")
+      .send({ status: "blocked", blocked_reason: "Second blocage" });
+
+    expect([blockOne.status, resume.status, blockTwo.status]).toEqual([200, 200, 200]);
+    expect(notificationKeys).toEqual([
+      "commande:123:checkpoint:technical_analysis:blocked:101",
+      "commande:123:checkpoint:technical_analysis:blocked:103",
+    ]);
+  });
+
   it("POST /api/v1/commandes/:id/duplicate returns new id", async () => {
     const ARTICLE_ID = "11111111-1111-1111-1111-111111111111";
     const PIECE_ID = "22222222-2222-2222-2222-222222222222";
@@ -1087,6 +1368,19 @@ describe("/api/v1/commandes", () => {
       if (q.includes("FROM commande_client cc") && q.includes("LEFT JOIN LATERAL")) {
         return { rows: [{ id: "123", numero: "CC-123", client_id: "001", raw_statut: "ATTENTE_OF" }] };
       }
+      if (q.includes("FROM public.commande_client cc") && q.includes("dest_stock_magasin_id")) {
+        return {
+          rows: [{
+            id: 123,
+            numero: "CC-123",
+            client_id: "001",
+            order_type: "FERME",
+            raw_statut: "ATTENTE_OF",
+            dest_stock_magasin_id: null,
+            dest_stock_emplacement_id: null,
+          }],
+        };
+      }
       if (q.includes("INSERT INTO public.commande_client_workflow_checkpoint")) return { rows: [] };
       if (q.includes("FROM public.commande_client_workflow_checkpoint") && q.includes("checkpoint_code IN ('stock_check', 'of_generation')")) {
         return {
@@ -1099,6 +1393,9 @@ describe("/api/v1/commandes", () => {
       if (q.includes("SELECT EXISTS(SELECT 1 FROM public.commande_to_affaire")) return { rows: [{ exists: fullStockReplay }] };
       if (q.includes("SELECT id::int AS id, numero, client_id") && q.includes("FROM commande_client")) {
         return { rows: [{ id: 123, numero: "CC-123", client_id: "001" }] };
+      }
+      if (q.includes("SELECT nouveau_statut") && q.includes("FROM commande_historique")) {
+        return { rows: [{ nouveau_statut: "ATTENTE_OF" }] };
       }
       if (q.includes("SELECT id, numero, client_id FROM commande_client")) {
         return { rows: [{ id: 123, numero: "CC-123", client_id: "001" }] };
@@ -1343,6 +1640,9 @@ describe("/api/v1/commandes", () => {
       if (q.includes("SELECT id::int AS id, numero, client_id") && q.includes("FROM commande_client")) {
         return { rows: [{ id: 123, numero: "CC-123", client_id: "001" }] };
       }
+      if (q.includes("SELECT nouveau_statut") && q.includes("FROM commande_historique")) {
+        return { rows: [{ nouveau_statut: "ATTENTE_PLANNING" }] };
+      }
 
       if (q.includes("FROM commande_client") && q.includes("FOR UPDATE") && q.includes("order_type")) {
         return {
@@ -1531,6 +1831,9 @@ describe("/api/v1/commandes", () => {
       if (q.includes("SELECT EXISTS(SELECT 1 FROM public.commande_to_affaire")) return { rows: [{ exists: false }] };
       if (q.includes("SELECT id::int AS id, numero, client_id") && q.includes("FROM commande_client")) {
         return { rows: [{ id: 123, numero: "CC-123", client_id: "001" }] };
+      }
+      if (q.includes("SELECT nouveau_statut") && q.includes("FROM commande_historique")) {
+        return { rows: [{ nouveau_statut: "ATTENTE_OF" }] };
       }
 
       if (q.includes("FROM commande_client") && q.includes("FOR UPDATE") && q.includes("order_type")) {
@@ -1848,7 +2151,9 @@ describe("/api/v1/commandes", () => {
       if (q.includes("SELECT id::int AS id, numero, client_id") && q.includes("FROM commande_client")) {
         return { rows: [{ id: 123, numero: "CI-123", client_id: "001" }] };
       }
-      if (q.includes("SELECT nouveau_statut") && q.includes("FROM commande_historique")) return { rows: [] };
+      if (q.includes("SELECT nouveau_statut") && q.includes("FROM commande_historique")) {
+        return { rows: [{ nouveau_statut: "ATTENTE_TECHNIQUE" }] };
+      }
       if (q.includes("INSERT INTO commande_historique") && q.includes("RETURNING id::text AS id")) {
         return { rows: [{ id: "1" }] };
       }

--- a/src/__tests__/planning.routes.test.ts
+++ b/src/__tests__/planning.routes.test.ts
@@ -35,7 +35,7 @@ vi.mock("../utils/checkNetworkDrive", () => ({
 
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authenticateToken: (req: { user?: { id: number; role: string } }, _res: unknown, next: () => void) => {
-    req.user = { id: 1, role: "Atelier" };
+    req.user = { id: 1, role: "Production" };
     next();
   },
   authorizeRole:
@@ -309,6 +309,9 @@ describe("/api/v1/planning", () => {
           ],
         };
       }
+      if (q.includes("checkpoint_code = 'planning_validation'")) {
+        return { rows: [{ status: "active", responsible_role: "planning", assigned_user_id: null }] };
+      }
       if (q.includes("SELECT commande_id::text AS commande_id FROM public.ordres_fabrication")) {
         return { rows: [{ commande_id: null }] };
       }
@@ -487,11 +490,17 @@ describe("/api/v1/planning", () => {
           ],
         };
       }
+      if (q.includes("SELECT id::int AS id FROM public.commande_client") && q.includes("FOR UPDATE")) {
+        return { rows: [{ id: 123 }] };
+      }
+      if (q.includes("checkpoint_code = 'planning_validation'")) {
+        return { rows: [{ status: "active", responsible_role: "planning", assigned_user_id: null }] };
+      }
       if (q.includes("SELECT id::int AS id, numero, client_id") && q.includes("FROM commande_client")) {
         return { rows: [{ id: 123, numero: "CC-123", client_id: "001" }] };
       }
       if (q.includes("FROM commande_historique") && q.includes("LIMIT 1")) {
-        return { rows: [{ nouveau_statut: "ENREGISTREE" }] };
+        return { rows: [{ nouveau_statut: "ATTENTE_PLANNING" }] };
       }
       if (q.includes("INSERT INTO commande_historique")) {
         return { rows: [{ id: "11" }] };
@@ -546,7 +555,7 @@ describe("/api/v1/planning", () => {
 
     expect(res.status).toBe(201);
     expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO commande_historique"))).toBe(true);
-    expect(mocks.clientQuery.mock.calls.some((call) => String(call[0]).includes("INSERT INTO public.app_notifications"))).toBe(true);
+    expect(mocks.clientQuery.mock.calls.filter((call) => String(call[0]).includes("INSERT INTO public.app_notifications"))).toHaveLength(1);
   });
 
   it("POST /api/v1/planning/events rejects a blocked machine", async () => {

--- a/src/module/commande-client/controllers/commande-ar.controller.ts
+++ b/src/module/commande-client/controllers/commande-ar.controller.ts
@@ -13,7 +13,11 @@ function getUserId(req: Request): number {
 
 export const generateCommandeAr: RequestHandler = asyncHandler(async (req, res) => {
   const { id } = generateCommandeArSchema.parse({ params: req.params }).params;
-  const out = await svcGenerateCommandeAr({ commande_id: Number(id), user_id: getUserId(req) });
+  const out = await svcGenerateCommandeAr({
+    commande_id: Number(id),
+    user_id: getUserId(req),
+    user_role: req.user?.role,
+  });
   res.status(201).json(out);
 });
 
@@ -22,6 +26,7 @@ export const sendCommandeAr: RequestHandler = asyncHandler(async (req, res) => {
   const out = await svcSendCommandeAr({
     commande_id: Number(parsed.params.id),
     user_id: getUserId(req),
+    user_role: req.user?.role,
     body: parsed.body,
   });
   res.status(200).json(out);

--- a/src/module/commande-client/controllers/commande-client.controller.ts
+++ b/src/module/commande-client/controllers/commande-client.controller.ts
@@ -27,7 +27,6 @@ import {
   updateCadreReleaseStatusSVC,
   updateCommandeSVC,
   updateCommandeWorkflowCheckpointSVC,
-  updateCommandeStatusSVC,
   addCadreReleaseLineSVC,
   cancelCadreReleaseSVC,
 } from "../services/commande-client.service";
@@ -45,7 +44,6 @@ import {
   updateCadreReleaseBodySchema,
   updateCadreReleaseLineBodySchema,
   updateCommandeWorkflowCheckpointBodySchema,
-  updateCommandeStatusBodySchema,
   type CreateCommandeBodyDTO,
 } from "../validators/commande-client.validators";
 import type { UploadedDocument } from "../types/commande-client.types";
@@ -188,7 +186,9 @@ export const getCommande: RequestHandler = async (req, res, next) => {
 // GET /api/v1/commandes/:id/workflow
 export const getCommandeWorkflow: RequestHandler = async (req, res, next) => {
   try {
-    const out = await getCommandeWorkflowSVC(routeParam(req, "id"));
+    const userId = typeof req.user?.id === "number" ? req.user.id : null;
+    if (userId === null) throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
+    const out = await getCommandeWorkflowSVC(routeParam(req, "id"), userId, req.user?.role);
     if (!out) {
       res.status(404).json({ error: "Not found" });
       return;
@@ -212,7 +212,8 @@ export const updateCommandeWorkflowCheckpoint: RequestHandler = async (req, res,
       routeParam(req, "id"),
       routeParam(req, "checkpointCode"),
       parsed.data,
-      userId
+      userId,
+      typeof req.user?.role === "string" ? req.user.role : null
     );
     if (!out) {
       res.status(404).json({ error: "Not found" });
@@ -243,7 +244,7 @@ export const runCommandeWorkflowAction: RequestHandler = async (req, res, next) 
       res.status(404).json({ error: "Not found" });
       return;
     }
-    res.status(200).json({ ok: true, workflow: out });
+    res.status(200).json({ ok: true, workflow: out.workflow, idempotent_replay: out.idempotent_replay });
   } catch (err) {
     next(err);
   }
@@ -252,38 +253,18 @@ export const runCommandeWorkflowAction: RequestHandler = async (req, res, next) 
 // DELETE /api/v1/commandes/:id
 export const deleteCommande: RequestHandler = async (req, res, next) => {
   try {
-    const ok = await deleteCommandeSVC(routeParam(req, "id"));
+    const userId = req.user?.id;
+    if (typeof userId !== "number") throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
+    const ok = await deleteCommandeSVC(
+      routeParam(req, "id"),
+      userId,
+      typeof req.user?.role === "string" ? req.user.role : null
+    );
     if (!ok) {
       res.status(404).json({ error: "Not found" });
       return;
     }
     res.status(204).send();
-  } catch (err) {
-    next(err);
-  }
-};
-
-// POST /api/v1/commandes/:id/status
-export const updateCommandeStatus: RequestHandler = async (req, res, next) => {
-  try {
-    const parsed = updateCommandeStatusBodySchema.safeParse(req.body);
-    if (!parsed.success) {
-      res.status(400).json({ error: parsed.error.issues?.[0]?.message ?? "Invalid request" });
-      return;
-    }
-
-    const userId = typeof req.user?.id === "number" ? req.user.id : null;
-    const out = await updateCommandeStatusSVC(
-      routeParam(req, "id"),
-      parsed.data.nouveau_statut,
-      parsed.data.commentaire ?? null,
-      userId
-    );
-    if (!out) {
-      res.status(404).json({ error: "Not found" });
-      return;
-    }
-    res.status(200).json({ ok: true, ...out });
   } catch (err) {
     next(err);
   }

--- a/src/module/commande-client/domain/commande-client-rbac.ts
+++ b/src/module/commande-client/domain/commande-client-rbac.ts
@@ -1,5 +1,5 @@
 import { effectiveRoleHasAny } from "../../auth/domain/roles";
-import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import type { CommandeResponsibleRole } from "../workflow/commande-client-workflow.definition";
 
 export const INTERNAL_ORDER_LAUNCH_ROLES = [
   "Directeur",
@@ -16,6 +16,35 @@ export const INTERNAL_ORDER_LAUNCH_ROLES = [
 ] as const;
 
 export function canLaunchInternalOrder(role: string | null | undefined): boolean {
-  if (hasGrantedAccountModuleAccess()) return true;
   return effectiveRoleHasAny(role, INTERNAL_ORDER_LAUNCH_ROLES);
+}
+
+const WORKFLOW_OVERRIDE_ROLES = [
+  "Administrateur Systeme et Reseau",
+  "Directeur",
+] as const;
+
+const WORKFLOW_ROLES: Record<CommandeResponsibleRole, readonly string[]> = {
+  secretariat: ["Secretaire", "Commercial", "Comptabilite"],
+  technique: ["Method", "Responsable Programmation", "Production", "Responsable Production"],
+  planning: ["Planification", "Production", "Responsable Programmation", "Responsable Production"],
+  production: ["Production", "Atelier", "Opérateur atelier", "Responsable Production", "Responsable Atelier"],
+  qualite: ["Responsable Qualité", "Qualité"],
+  logistique: ["Logistique", "Stock", "Magasin"],
+  comptabilite: ["Comptabilite"],
+  direction: ["Directeur"],
+};
+
+export function canActOnCommandeWorkflowCheckpoint(params: {
+  user_id: number;
+  user_role: string | null | undefined;
+  responsible_role: string;
+  assigned_user_id?: number | null;
+}): boolean {
+  if (effectiveRoleHasAny(params.user_role, WORKFLOW_OVERRIDE_ROLES)) return true;
+  if (params.assigned_user_id !== null && params.assigned_user_id !== undefined) {
+    return params.assigned_user_id === params.user_id;
+  }
+  const allowed = WORKFLOW_ROLES[params.responsible_role as CommandeResponsibleRole];
+  return allowed ? effectiveRoleHasAny(params.user_role, allowed) : false;
 }

--- a/src/module/commande-client/repository/commande-ar.repository.test.ts
+++ b/src/module/commande-client/repository/commande-ar.repository.test.ts
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  poolQuery: vi.fn(),
+  clientQuery: vi.fn(),
+  release: vi.fn(),
+  ensureCheckpoints: vi.fn(),
+  applyMilestone: vi.fn(),
+}));
+
+vi.mock("../../../config/database", () => ({
+  default: { connect: mocks.connect, query: mocks.poolQuery },
+}));
+
+vi.mock("./commande-client.repository", () => ({
+  repoEnsureCommandeWorkflowCheckpoints: mocks.ensureCheckpoints,
+  repoApplyCommandeWorkflowMilestone: mocks.applyMilestone,
+}));
+
+import {
+  repoAbortCommandeArSendClaim,
+  repoAuthorizeCommandeArGeneration,
+  repoClaimCommandeArSend,
+  repoCreateCommandeArDraft,
+  repoMarkCommandeArFailed,
+} from "./commande-ar.repository";
+import { runWithAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+
+const draftRow = {
+  ar_id: "11111111-1111-4111-8111-111111111111",
+  commande_id: 123,
+  document_id: "22222222-2222-4222-8222-222222222222",
+  document_name: "AR-123.pdf",
+  subject: "AR commande 123",
+  body_text: null,
+  generated_at: "2026-08-04T08:00:00.000Z",
+  generated_by: 7,
+  status: "GENERATED",
+  sent_at: null,
+  recipient_emails: [],
+  email_provider_id: null,
+};
+
+function withCommandesModuleAccess<T>(operation: () => Promise<T>): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    runWithAccountModuleAccess({ userId: 7, moduleKey: "commandes" }, () => {
+      void operation().then(resolve, reject);
+    });
+  });
+}
+
+function mockClaimableDraft(assignedUserId: number | null) {
+  mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+    const q = String(sql);
+    if (q.includes("FROM public.commande_client cc")) return { rows: [{ raw_statut: "AR_PRET" }] };
+    if (q.includes("FROM public.commande_ar_log ar")) return { rows: [draftRow] };
+    if (q.includes("checkpoint_code = 'ar_sent'")) {
+      return { rows: [{ status: "active", responsible_role: "secretariat", assigned_user_id: assignedUserId }] };
+    }
+    return { rows: [] };
+  });
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockReset();
+  mocks.connect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.release });
+  mocks.ensureCheckpoints.mockResolvedValue(undefined);
+});
+
+describe("commande AR atomic send claim", () => {
+  it("revalide sous verrou et refuse un brouillon rendu avant un envoi concurrent", async () => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query.includes("SELECT id::int AS id FROM public.commande_client") && query.includes("FOR UPDATE")) {
+        return { rows: [{ id: 123 }] };
+      }
+      if (query.includes("st.nouveau_statut AS raw_statut")) {
+        return {
+          rows: [{
+            raw_statut: "AR_ENVOYE",
+            checkpoint_status: "done",
+            responsible_role: "secretariat",
+            assigned_user_id: null,
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    await expect(repoCreateCommandeArDraft({
+      commande_id: 123,
+      user_id: 7,
+      user_role: "Secretaire",
+      document_name: "AR-123.pdf",
+      pdf_buffer: Buffer.from("pdf"),
+      subject: "AR commande 123",
+      body_text: "Bonjour",
+      recipient_suggestions: [],
+    })).rejects.toMatchObject({ status: 409, code: "COMMAND_AR_GENERATION_NOT_ALLOWED" });
+
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO public.commande_ar_log"))).toBe(false);
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("AR_GENERATED"))).toBe(false);
+  });
+
+  it("lets an explicitly assigned non-secretariat user claim the AR send", async () => {
+    mockClaimableDraft(7);
+
+    const claim = await repoClaimCommandeArSend({
+      commande_id: 123,
+      ar_id: draftRow.ar_id,
+      user_id: 7,
+      user_role: "Employee",
+    });
+
+    expect(claim.kind).toBe("claimed");
+    if (claim.kind === "claimed") await repoAbortCommandeArSendClaim(claim);
+  });
+
+  it("does not let a module grant bypass the deep send role/assignment policy", async () => {
+    mockClaimableDraft(null);
+
+    await expect(withCommandesModuleAccess(() => repoClaimCommandeArSend({
+      commande_id: 123,
+      ar_id: draftRow.ar_id,
+      user_id: 7,
+      user_role: "Employee",
+    }))).rejects.toMatchObject({ status: 403, code: "COMMAND_CHECKPOINT_FORBIDDEN" });
+  });
+
+  it("authorizes before returning a SENT replay", async () => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q.includes("FROM public.commande_client cc")) return { rows: [{ raw_statut: "AR_ENVOYE" }] };
+      if (q.includes("FROM public.commande_ar_log ar")) {
+        return {
+          rows: [{
+            ...draftRow,
+            status: "SENT",
+            sent_at: "2026-08-04T08:05:00.000Z",
+            recipient_emails: ["persisted@example.test"],
+            email_provider_id: "provider-1",
+          }],
+        };
+      }
+      if (q.includes("checkpoint_code = 'ar_sent'")) {
+        return { rows: [{ status: "done", responsible_role: "secretariat", assigned_user_id: null }] };
+      }
+      return { rows: [] };
+    });
+
+    await expect(repoClaimCommandeArSend({
+      commande_id: 123,
+      ar_id: draftRow.ar_id,
+      user_id: 7,
+      user_role: "Employee",
+    })).rejects.toMatchObject({ status: 403, code: "COMMAND_CHECKPOINT_FORBIDDEN" });
+
+    expect(mocks.clientQuery).toHaveBeenCalledWith("ROLLBACK");
+    expect(mocks.release).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects an unknown technical AR status before the provider can be invoked", async () => {
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const q = String(sql);
+      if (q.includes("FROM public.commande_client cc")) return { rows: [{ raw_statut: "AR_PRET" }] };
+      if (q.includes("FROM public.commande_ar_log ar")) return { rows: [{ ...draftRow, status: "SENDING" }] };
+      return { rows: [] };
+    });
+
+    await expect(repoClaimCommandeArSend({
+      commande_id: 123,
+      ar_id: draftRow.ar_id,
+      user_id: 7,
+      user_role: "Secretaire",
+    })).rejects.toMatchObject({ status: 409, code: "COMMAND_AR_STATUS_INVALID" });
+    expect(mocks.ensureCheckpoints).not.toHaveBeenCalled();
+  });
+
+  it("never lets a failed request overwrite a concurrently SENT AR", async () => {
+    mocks.poolQuery.mockResolvedValue({ rows: [] });
+
+    await repoMarkCommandeArFailed({
+      commande_id: 123,
+      ar_id: draftRow.ar_id,
+      error_message: "provider timeout",
+    });
+
+    const [sql] = mocks.poolQuery.mock.calls[0];
+    expect(String(sql)).toContain("AND status <> 'SENT'");
+  });
+});
+
+describe("commande AR generation authorization", () => {
+  const accessRow = (assigned_user_id: number | null) => ({
+    raw_statut: "AR_PRET",
+    checkpoint_status: "active",
+    responsible_role: "secretariat",
+    assigned_user_id,
+  });
+
+  it("allows an assigned Employee before artifact generation", async () => {
+    const tx = { query: vi.fn().mockResolvedValue({ rows: [accessRow(7)] }) };
+    await expect(repoAuthorizeCommandeArGeneration({
+      tx: tx as never,
+      commande_id: 123,
+      user_id: 7,
+      user_role: "Employee",
+    })).resolves.toBeUndefined();
+  });
+
+  it("requires a business role even with module access and rejects an unassigned unauthorized role", async () => {
+    const grantedTx = { query: vi.fn().mockResolvedValue({ rows: [accessRow(null)] }) };
+    await expect(withCommandesModuleAccess(() => repoAuthorizeCommandeArGeneration({
+      tx: grantedTx as never,
+      commande_id: 123,
+      user_id: 7,
+      user_role: "Employee",
+    }))).rejects.toMatchObject({ status: 403, code: "COMMAND_CHECKPOINT_FORBIDDEN" });
+
+    const roleTx = { query: vi.fn().mockResolvedValue({ rows: [accessRow(null)] }) };
+    await expect(withCommandesModuleAccess(() => repoAuthorizeCommandeArGeneration({
+      tx: roleTx as never,
+      commande_id: 123,
+      user_id: 7,
+      user_role: "Secretaire",
+    }))).resolves.toBeUndefined();
+
+    const deniedTx = { query: vi.fn().mockResolvedValue({ rows: [accessRow(null)] }) };
+    await expect(repoAuthorizeCommandeArGeneration({
+      tx: deniedTx as never,
+      commande_id: 123,
+      user_id: 7,
+      user_role: "Employee",
+    })).rejects.toMatchObject({ status: 403, code: "COMMAND_CHECKPOINT_FORBIDDEN" });
+  });
+});

--- a/src/module/commande-client/repository/commande-ar.repository.ts
+++ b/src/module/commande-client/repository/commande-ar.repository.ts
@@ -6,7 +6,12 @@ import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { getDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
-import { repoEnsureCommandeWorkflowStatus } from "./commande-client.repository";
+import {
+  repoApplyCommandeWorkflowMilestone,
+  repoEnsureCommandeWorkflowCheckpoints,
+} from "./commande-client.repository";
+import { canActOnCommandeWorkflowCheckpoint } from "../domain/commande-client-rbac";
+import { normalizeCommandeWorkflowStatus } from "../workflow/commande-client-workflow.definition";
 import type { AppNotification } from "../../notifications/types/notifications.types";
 import type {
   CommandeArDraft,
@@ -86,6 +91,8 @@ export type CommandeArStoredDraft = {
   generated_by: number | null;
   status: "GENERATED" | "SENT" | "FAILED";
   sent_at: string | null;
+  recipient_emails: string[];
+  email_provider_id: string | null;
   preview_path: string;
 };
 
@@ -137,6 +144,94 @@ export function buildCommandeArRecipientSuggestions(data: CommandeArGenerationDa
   return out;
 }
 
+type CommandeArCheckpointAccess = {
+  status: string;
+  responsible_role: string;
+  assigned_user_id: number | null;
+};
+
+function assertCommandeArCheckpointAccess(params: {
+  checkpoint: CommandeArCheckpointAccess;
+  user_id: number;
+  user_role: string | null | undefined;
+}): void {
+  if (!canActOnCommandeWorkflowCheckpoint({
+    user_id: params.user_id,
+    user_role: params.user_role,
+    responsible_role: params.checkpoint.responsible_role,
+    assigned_user_id: params.checkpoint.assigned_user_id,
+  })) {
+    throw new HttpError(403, "COMMAND_CHECKPOINT_FORBIDDEN", "Ce checkpoint est attribué à un autre rôle ou utilisateur.");
+  }
+}
+
+export async function repoAuthorizeCommandeArGeneration(params: {
+  tx: DbQueryer;
+  commande_id: number;
+  user_id: number;
+  user_role: string | null | undefined;
+}): Promise<void> {
+  const access = await params.tx.query<{
+    raw_statut: string | null;
+    checkpoint_status: string | null;
+    responsible_role: string | null;
+    assigned_user_id: number | null;
+  }>(
+    `
+      SELECT
+        st.nouveau_statut AS raw_statut,
+        cp.status AS checkpoint_status,
+        cp.responsible_role,
+        cp.assigned_user_id::int AS assigned_user_id
+      FROM public.commande_client cc
+      LEFT JOIN LATERAL (
+        SELECT ch.nouveau_statut
+        FROM public.commande_historique ch
+        WHERE ch.commande_id = cc.id
+        ORDER BY ch.date_action DESC, ch.id DESC
+        LIMIT 1
+      ) st ON TRUE
+      LEFT JOIN public.commande_client_workflow_checkpoint cp
+        ON cp.commande_id = cc.id AND cp.checkpoint_code = 'ar_sent'
+      WHERE cc.id = $1::bigint
+      LIMIT 1
+    `,
+    [params.commande_id]
+  );
+  const row = access.rows[0];
+  if (!row) throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable");
+
+  const currentStatus = row.raw_statut === null ? "BROUILLON" : normalizeCommandeWorkflowStatus(row.raw_statut);
+  if (!currentStatus) {
+    throw new HttpError(
+      409,
+      "COMMAND_STATUS_HISTORY_INVALID",
+      `Le dernier statut enregistré (${row.raw_statut}) est inconnu. Réparez l'historique avant la génération de l'AR.`
+    );
+  }
+  if (!row.checkpoint_status || !row.responsible_role) {
+    throw new HttpError(409, "COMMAND_CHECKPOINT_MISSING", "Le checkpoint d'envoi de l'AR est absent.");
+  }
+
+  assertCommandeArCheckpointAccess({
+    checkpoint: {
+      status: row.checkpoint_status,
+      responsible_role: row.responsible_role,
+      assigned_user_id: row.assigned_user_id,
+    },
+    user_id: params.user_id,
+    user_role: params.user_role,
+  });
+
+  if (currentStatus !== "AR_PRET" || row.checkpoint_status !== "active") {
+    throw new HttpError(
+      409,
+      "COMMAND_AR_GENERATION_NOT_ALLOWED",
+      "L'AR ne peut être généré que lorsque son checkpoint d'envoi est actif."
+    );
+  }
+}
+
 export async function repoLoadCommandeArGenerationData(tx: DbQueryer, commandeId: number): Promise<CommandeArGenerationData | null> {
   type HeaderRow = Omit<CommandeArHeader, "commande_id"> & { commande_id: number };
   const headerRes = await tx.query<HeaderRow>(
@@ -144,7 +239,13 @@ export async function repoLoadCommandeArGenerationData(tx: DbQueryer, commandeId
       SELECT
         cc.id::int AS commande_id,
         cc.numero,
-        COALESCE(st.nouveau_statut, 'ENREGISTREE') AS statut,
+        CASE COALESCE(st.nouveau_statut, 'BROUILLON')
+          WHEN 'ENREGISTREE' THEN 'EN_ANALYSE'
+          WHEN 'PLANIFIEE' THEN 'PLANNING_VALIDE'
+          WHEN 'AR_ENVOYEE' THEN 'AR_ENVOYE'
+          WHEN 'LIVREE' THEN 'LIVRE'
+          ELSE COALESCE(st.nouveau_statut, 'BROUILLON')
+        END AS statut,
         cc.date_commande::text AS date_commande,
         cc.commentaire,
         cc.total_ht::float8 AS total_ht,
@@ -275,6 +376,7 @@ async function insertCommandeEvent(db: DbQueryer, params: {
 export async function repoCreateCommandeArDraft(params: {
   commande_id: number;
   user_id: number;
+  user_role: string | null | undefined;
   document_name: string;
   pdf_buffer: Buffer;
   subject: string;
@@ -296,6 +398,16 @@ export async function repoCreateCommandeArDraft(params: {
     if (!exists.rows[0]?.id) {
       throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable");
     }
+
+    // The PDF was rendered outside this transaction. Revalidate the status,
+    // active checkpoint and actor after acquiring the command lock so a send
+    // that committed in the meantime cannot be followed by a stale draft.
+    await repoAuthorizeCommandeArGeneration({
+      tx: client,
+      commande_id: params.commande_id,
+      user_id: params.user_id,
+      user_role: params.user_role,
+    });
 
     await fs.mkdir(path.dirname(filePath), { recursive: true });
     await fs.writeFile(filePath, params.pdf_buffer);
@@ -376,6 +488,8 @@ export async function repoCreateCommandeArDraft(params: {
       generated_by: row.generated_by,
       status: row.status,
       sent_at: row.sent_at,
+      recipient_emails: [],
+      email_provider_id: null,
       preview_path: `/commandes/${params.commande_id}/documents/${documentId}/file`,
     };
   } catch (err) {
@@ -395,6 +509,7 @@ export async function repoGetCommandeArDraft(params: {
   commande_id: number;
   ar_id: string;
   tx?: DbQueryer;
+  for_update?: boolean;
 }): Promise<CommandeArStoredDraft | null> {
   const db = params.tx ?? pool;
   const res = await db.query<{
@@ -408,6 +523,8 @@ export async function repoGetCommandeArDraft(params: {
     generated_by: number | null;
     status: "GENERATED" | "SENT" | "FAILED";
     sent_at: string | null;
+    recipient_emails: string[] | null;
+    email_provider_id: string | null;
   }>(
     `
       SELECT
@@ -420,12 +537,15 @@ export async function repoGetCommandeArDraft(params: {
         ar.generated_at::text AS generated_at,
         ar.generated_by,
         ar.status::text AS status,
-        ar.sent_at::text AS sent_at
+        ar.sent_at::text AS sent_at,
+        ar.recipient_emails,
+        ar.email_provider_id
       FROM public.commande_ar_log ar
       JOIN public.documents_clients dc ON dc.id = ar.document_id
       WHERE ar.commande_id = $1::bigint
         AND ar.id = $2::uuid
       LIMIT 1
+      ${params.for_update ? "FOR UPDATE OF ar" : ""}
     `,
     [params.commande_id, params.ar_id]
   );
@@ -444,6 +564,8 @@ export async function repoGetCommandeArDraft(params: {
     generated_by: row.generated_by,
     status: row.status,
     sent_at: row.sent_at,
+    recipient_emails: row.recipient_emails ?? [],
+    email_provider_id: row.email_provider_id,
     preview_path: `/commandes/${row.commande_id}/documents/${row.document_id}/file`,
   };
 }
@@ -452,19 +574,159 @@ export async function repoMarkCommandeArFailed(params: {
   commande_id: number;
   ar_id: string;
   error_message: string;
+  claim?: CommandeArSendClaim;
 }): Promise<void> {
-  await pool.query(
-    `
-      UPDATE public.commande_ar_log
-      SET status = 'FAILED', error_message = $3
-      WHERE commande_id = $1::bigint
-        AND id = $2::uuid
-    `,
-    [params.commande_id, params.ar_id, params.error_message]
-  );
+  const db = params.claim?.client ?? pool;
+  try {
+    await db.query(
+      `
+        UPDATE public.commande_ar_log
+        SET status = 'FAILED', error_message = $3
+        WHERE commande_id = $1::bigint
+          AND id = $2::uuid
+          AND status <> 'SENT'
+      `,
+      [params.commande_id, params.ar_id, params.error_message]
+    );
+    if (params.claim) await params.claim.client.query("COMMIT");
+  } catch (err) {
+    if (params.claim) await params.claim.client.query("ROLLBACK");
+    throw err;
+  } finally {
+    if (params.claim) params.claim.client.release();
+  }
+}
+
+export type CommandeArSendClaim = {
+  kind: "claimed";
+  client: PoolClient;
+  draft: CommandeArStoredDraft;
+};
+
+export type CommandeArSendClaimResult =
+  | CommandeArSendClaim
+  | { kind: "replay"; draft: CommandeArStoredDraft };
+
+export async function repoClaimCommandeArSend(params: {
+  commande_id: number;
+  ar_id: string;
+  user_id: number;
+  user_role: string | null | undefined;
+}): Promise<CommandeArSendClaimResult> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+
+    const header = await client.query<{ raw_statut: string | null }>(
+      `
+        SELECT st.nouveau_statut AS raw_statut
+        FROM public.commande_client cc
+        LEFT JOIN LATERAL (
+          SELECT ch.nouveau_statut
+          FROM public.commande_historique ch
+          WHERE ch.commande_id = cc.id
+          ORDER BY ch.date_action DESC, ch.id DESC
+          LIMIT 1
+        ) st ON TRUE
+        WHERE cc.id = $1::bigint
+        FOR UPDATE OF cc
+      `,
+      [params.commande_id]
+    );
+    if (!header.rows[0]) {
+      throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable");
+    }
+
+    const draft = await repoGetCommandeArDraft({
+      commande_id: params.commande_id,
+      ar_id: params.ar_id,
+      tx: client,
+      for_update: true,
+    });
+    if (!draft) {
+      throw new HttpError(404, "COMMANDE_AR_NOT_FOUND", "Accusé de réception introuvable");
+    }
+    if (!(new Set(["GENERATED", "FAILED", "SENT"])).has(draft.status)) {
+      throw new HttpError(
+        409,
+        "COMMAND_AR_STATUS_INVALID",
+        `Le statut technique de l'AR (${String(draft.status)}) ne permet pas son envoi.`
+      );
+    }
+
+    const rawStatus = header.rows[0].raw_statut;
+    const currentStatus = rawStatus === null ? "BROUILLON" : normalizeCommandeWorkflowStatus(rawStatus);
+    if (!currentStatus) {
+      throw new HttpError(
+        409,
+        "COMMAND_STATUS_HISTORY_INVALID",
+        `Le dernier statut enregistré (${rawStatus}) est inconnu. Réparez l'historique avant l'envoi de l'AR.`
+      );
+    }
+    await repoEnsureCommandeWorkflowCheckpoints(client, params.commande_id, currentStatus);
+    const checkpoint = await client.query<{
+      status: string;
+      responsible_role: string;
+      assigned_user_id: number | null;
+    }>(
+      `
+        SELECT status, responsible_role, assigned_user_id::int AS assigned_user_id
+        FROM public.commande_client_workflow_checkpoint
+        WHERE commande_id = $1::bigint
+          AND checkpoint_code = 'ar_sent'
+        FOR UPDATE
+      `,
+      [params.commande_id]
+    );
+    const activeCheckpoint = checkpoint.rows[0];
+    if (!activeCheckpoint) {
+      throw new HttpError(
+        409,
+        "COMMAND_CHECKPOINT_MISSING",
+        "Le checkpoint d'envoi de l'AR est absent. Rechargez le workflow de la commande."
+      );
+    }
+    assertCommandeArCheckpointAccess({ checkpoint: activeCheckpoint, user_id: params.user_id, user_role: params.user_role });
+    if (draft.status === "SENT") {
+      await client.query("COMMIT");
+      client.release();
+      return { kind: "replay", draft };
+    }
+    if (currentStatus !== "AR_PRET") {
+      throw new HttpError(
+        409,
+        "COMMAND_AR_SEND_NOT_ALLOWED",
+        `L'AR ne peut être envoyé que depuis le statut AR_PRET (statut courant: ${currentStatus}).`
+      );
+    }
+    if (activeCheckpoint.status !== "active") {
+      throw new HttpError(
+        409,
+        "COMMAND_CHECKPOINT_NOT_ACTIVE",
+        "Le checkpoint d'envoi de l'AR n'est pas actif. Rechargez le workflow de la commande."
+      );
+    }
+
+    // The open transaction and row locks are the send claim. A concurrent call
+    // waits here and observes SENT after commit, so it never invokes the provider.
+    return { kind: "claimed", client, draft };
+  } catch (err) {
+    await client.query("ROLLBACK");
+    client.release();
+    throw err;
+  }
+}
+
+export async function repoAbortCommandeArSendClaim(claim: CommandeArSendClaim): Promise<void> {
+  try {
+    await claim.client.query("ROLLBACK");
+  } finally {
+    claim.client.release();
+  }
 }
 
 export async function repoFinalizeCommandeArSend(params: {
+  claim: CommandeArSendClaim;
   commande_id: number;
   ar_id: string;
   sent_by: number;
@@ -473,15 +735,9 @@ export async function repoFinalizeCommandeArSend(params: {
   email_provider_id: string | null;
   commentaire: string | null;
 }): Promise<{ result: CommandeArSendResult; notifications: AppNotification[] }> {
-  const client = await pool.connect();
+  const client = params.claim.client;
+  const draft = params.claim.draft;
   try {
-    await client.query("BEGIN");
-
-    const draft = await repoGetCommandeArDraft({ commande_id: params.commande_id, ar_id: params.ar_id, tx: client });
-    if (!draft) {
-      throw new HttpError(404, "COMMANDE_AR_NOT_FOUND", "Accusé de réception introuvable");
-    }
-
     const updateRes = await client.query<{ sent_at: string }>(
       `
         UPDATE public.commande_ar_log
@@ -495,17 +751,24 @@ export async function repoFinalizeCommandeArSend(params: {
           error_message = NULL
         WHERE id = $1::uuid
           AND commande_id = $2::bigint
+          AND status IN ('GENERATED', 'FAILED')
         RETURNING sent_at::text AS sent_at
       `,
       [params.ar_id, params.commande_id, params.recipient_emails, params.recipient_contact_ids, params.sent_by, params.email_provider_id]
     );
+    if (!updateRes.rows[0]) {
+      throw new HttpError(409, "COMMAND_AR_SEND_CLAIM_LOST", "La réservation d'envoi de l'AR n'est plus valide.");
+    }
 
-    const statusOut = await repoEnsureCommandeWorkflowStatus({
+    const statusOut = await repoApplyCommandeWorkflowMilestone({
       tx: client,
       commande_id: params.commande_id,
-      nouveau_statut: "AR_ENVOYEE",
+      nouveau_statut: "AR_ENVOYE",
+      cause: "ar_send",
       commentaire: params.commentaire,
       user_id: params.sent_by,
+      completed_checkpoint_codes: ["ar_sent"],
+      active_checkpoint_code: "production_launch",
     });
 
     await insertCommandeEvent(client, {
@@ -527,7 +790,7 @@ export async function repoFinalizeCommandeArSend(params: {
         ar_id: draft.ar_id,
         commande_id: params.commande_id,
         document_id: draft.document_id,
-        status: "AR_ENVOYEE",
+        status: "AR_ENVOYE",
         sent_at: updateRes.rows[0]?.sent_at ?? new Date().toISOString(),
         recipient_emails: params.recipient_emails,
         email_provider_id: params.email_provider_id,

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import crypto from "node:crypto";
 import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
 import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
@@ -32,23 +33,29 @@ import {
   COMMANDE_CHECKPOINT_STATUSES,
   COMMANDE_WORKFLOW_CHECKPOINTS,
   COMMANDE_WORKFLOW_STATUS_ORDER,
+  canCommandeWorkflowTransition,
   getCommandeWorkflowAction,
   getCommandeWorkflowCheckpointDefinition,
+  isCanonicalCommandeWorkflowStatus,
   normalizeCommandeWorkflowStatus,
   type CommandeCheckpointStatus,
   type CommandeWorkflowStatus,
+  type CommandeWorkflowTransitionCause,
 } from "../workflow/commande-client-workflow.definition";
 import {
   createRecursiveOrdresFabrication,
   type GeneratedOfRef,
 } from "../../production/domain/of-generation";
-import { canLaunchInternalOrder } from "../domain/commande-client-rbac";
+import { canActOnCommandeWorkflowCheckpoint, canLaunchInternalOrder } from "../domain/commande-client-rbac";
 import {
   assertCommandeFullyInvoiced,
   assertCommandeFullyShipped,
   assertCommandeHasActiveOf,
   assertCommandeHasPreparedDelivery,
-} from "./commande-fulfillment.repository";
+  assertCommandeProductionCompleted,
+  assertCommandeProductionStarted,
+  assertCommandeQualityReleased,
+} from "./commande-fulfillment-guards.repository";
 import {
   allocateCommandeStockOldThenNew,
   type CommandeStockAvailability,
@@ -952,10 +959,10 @@ function normalizedCommandeStatusSql(rawExpr: string): string {
       WHEN ${rawExpr} = 'PLANIFIEE' THEN 'PLANNING_VALIDE'
       WHEN ${rawExpr} = 'AR_ENVOYEE' THEN 'AR_ENVOYE'
       WHEN ${rawExpr} = 'LIVREE' THEN 'LIVRE'
-      WHEN lower(${rawExpr}) IN ('brouillon','envoyée','envoyee','confirmée','confirmee') THEN 'ENREGISTREE'
-      WHEN lower(${rawExpr}) IN ('en préparation','en preparation','en production') THEN 'PLANIFIEE'
-      WHEN lower(${rawExpr}) IN ('partielle') THEN 'AR_ENVOYEE'
-      WHEN lower(${rawExpr}) IN ('livrée','livree','facturée','facturee','clôturée','cloturee') THEN 'LIVREE'
+      WHEN lower(${rawExpr}) IN ('brouillon','envoyée','envoyee','confirmée','confirmee') THEN 'EN_ANALYSE'
+      WHEN lower(${rawExpr}) IN ('en préparation','en preparation','en production') THEN 'PLANNING_VALIDE'
+      WHEN lower(${rawExpr}) IN ('partielle') THEN 'AR_ENVOYE'
+      WHEN lower(${rawExpr}) IN ('livrée','livree','facturée','facturee','clôturée','cloturee') THEN 'LIVRE'
       ELSE 'BROUILLON'
     END
   `;
@@ -1023,13 +1030,15 @@ async function loadCommandeWorkflowHeader(tx: Queryable, commandeId: number): Pr
   id: number;
   numero: string;
   client_id: string | null;
+  order_type: string | null;
 } | null> {
-  const res = await tx.query<{ id: number; numero: string; client_id: string | null }>(
+  const res = await tx.query<{ id: number; numero: string; client_id: string | null; order_type: string | null }>(
     `
-      SELECT id::int AS id, numero, client_id
+      SELECT id::int AS id, numero, client_id, order_type
       FROM commande_client
       WHERE id = $1
       LIMIT 1
+      FOR UPDATE
     `,
     [commandeId]
   );
@@ -1037,20 +1046,12 @@ async function loadCommandeWorkflowHeader(tx: Queryable, commandeId: number): Pr
   return res.rows[0] ?? null;
 }
 
-const COMMANDE_STATUSES_REQUIRING_OF = new Set([
-  "ATTENTE_PLANNING",
-  "PLANNING_VALIDE",
-  "AR_PRET",
-  "AR_ENVOYE",
-  "EN_PRODUCTION",
-  "PRODUCTION_TERMINEE",
-  "CONTROLE_QUALITE",
-]);
-
 export async function repoEnsureCommandeWorkflowStatus(params: {
   tx: Queryable;
   commande_id: number;
-  nouveau_statut: string;
+  nouveau_statut: CommandeWorkflowStatus;
+  cause: CommandeWorkflowTransitionCause;
+  resume_status?: CommandeWorkflowStatus | null;
   commentaire: string | null;
   user_id: number | null;
 }): Promise<{
@@ -1065,8 +1066,21 @@ export async function repoEnsureCommandeWorkflowStatus(params: {
     throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable");
   }
 
-  const nextRaw = params.nouveau_statut.trim();
-  const nextNormalized = normalizeCommandeWorkflowStatus(nextRaw);
+  if (!isCanonicalCommandeWorkflowStatus(params.nouveau_statut)) {
+    throw new HttpError(
+      400,
+      "INVALID_COMMAND_STATUS",
+      `Statut commande non canonique: ${String(params.nouveau_statut)}.`
+    );
+  }
+  const nextStatus = params.nouveau_statut;
+  if (params.cause.startsWith("internal_") && String(commande.order_type ?? "").toUpperCase() !== "INTERNE") {
+    throw new HttpError(
+      409,
+      "INTERNAL_COMMAND_TRANSITION_REQUIRED",
+      `La cause ${params.cause} est réservée aux commandes internes.`
+    );
+  }
 
   const last = await params.tx.query<{ nouveau_statut: string }>(
     `
@@ -1075,37 +1089,69 @@ export async function repoEnsureCommandeWorkflowStatus(params: {
       WHERE commande_id = $1
       ORDER BY date_action DESC, id DESC
       LIMIT 1
+      FOR UPDATE
     `,
     [params.commande_id]
   );
 
   const ancienStatut = last.rows[0]?.nouveau_statut ?? null;
-  const currentNormalized = normalizeCommandeWorkflowStatus(ancienStatut);
+  // Legacy rows without history have always been exposed as BROUILLON by the
+  // workflow reader. Keep that safe repair path, then apply the exact same
+  // transition rules as a newly-created command instead of accepting a jump.
+  const inferredFromMissingHistory = ancienStatut === null;
+  // commande_historique is the only persisted command-status authority; the
+  // base commande_client table intentionally has no workflow-status column.
+  const currentNormalized = inferredFromMissingHistory ? "BROUILLON" : normalizeCommandeWorkflowStatus(ancienStatut);
+  if (!currentNormalized) {
+    throw new HttpError(
+      409,
+      "COMMAND_STATUS_HISTORY_INVALID",
+      `Le dernier statut enregistré (${ancienStatut}) est inconnu. Réparez l'historique avant de poursuivre.`
+    );
+  }
 
-  if (ancienStatut && ancienStatut.trim().toUpperCase() === nextRaw.toUpperCase()) {
+  const isDownstreamSystemReplay =
+    (params.cause === "shipment_sync" && ["FACTURE", "ARCHIVE"].includes(currentNormalized)) ||
+    (params.cause === "invoice_sync" && currentNormalized === "ARCHIVE") ||
+    (params.cause === "planning_sync" && [
+      "AR_PRET",
+      "AR_ENVOYE",
+      "EN_PRODUCTION",
+      "PRODUCTION_TERMINEE",
+      "CONTROLE_QUALITE",
+      "PRET_LIVRAISON",
+      "LIVRE",
+      "FACTURE",
+      "ARCHIVE",
+    ].includes(currentNormalized));
+  if (isDownstreamSystemReplay) {
     return {
       changed: false,
       ancien_statut: ancienStatut,
-      nouveau_statut: ancienStatut,
+      nouveau_statut: currentNormalized,
       history_id: null,
       notifications: [],
     };
   }
 
-  if (
-    currentNormalized &&
-    nextNormalized &&
-    currentNormalized !== "BLOQUE" &&
-    nextNormalized !== "BLOQUE" &&
-    COMMANDE_WORKFLOW_STATUS_ORDER[nextNormalized] < COMMANDE_WORKFLOW_STATUS_ORDER[currentNormalized]
-  ) {
+  if (currentNormalized === nextStatus) {
     return {
       changed: false,
       ancien_statut: ancienStatut,
-      nouveau_statut: ancienStatut ?? nextRaw,
+      nouveau_statut: currentNormalized,
       history_id: null,
       notifications: [],
     };
+  }
+
+  if (!canCommandeWorkflowTransition(currentNormalized, nextStatus, params.cause, {
+    resume_status: params.resume_status,
+  })) {
+    throw new HttpError(
+      409,
+      "ILLEGAL_COMMAND_STATUS_TRANSITION",
+      `Transition commande interdite: ${currentNormalized} → ${nextStatus} (${params.cause}). Utilisez le checkpoint métier actif.`
+    );
   }
 
   const ins = await params.tx.query<{ id: string }>(
@@ -1114,11 +1160,11 @@ export async function repoEnsureCommandeWorkflowStatus(params: {
       VALUES ($1, $2, $3, $4, $5)
       RETURNING id::text AS id
     `,
-    [params.commande_id, params.user_id, ancienStatut, nextRaw, params.commentaire]
+    [params.commande_id, params.user_id, ancienStatut, nextStatus, params.commentaire]
   );
 
-  const marksPlanningValidated = nextNormalized === "PLANNING_VALIDE" || nextNormalized === "AR_PRET" || nextNormalized === "AR_ENVOYE";
-  const marksArSent = nextNormalized === "AR_ENVOYE";
+  const marksPlanningValidated = nextStatus === "PLANNING_VALIDE" || nextStatus === "AR_PRET" || nextStatus === "AR_ENVOYE";
+  const marksArSent = nextStatus === "AR_ENVOYE";
   await params.tx.query(
     `
       UPDATE commande_client
@@ -1152,20 +1198,30 @@ export async function repoEnsureCommandeWorkflowStatus(params: {
   await insertCommandeEvent(params.tx, {
     commande_id: params.commande_id,
     event_type: "STATUS_CHANGED",
-    old_values: { ancien_statut: ancienStatut },
-    new_values: { nouveau_statut: nextRaw },
+    old_values: {
+      ancien_statut: ancienStatut,
+      inferred_from_missing_history: inferredFromMissingHistory,
+    },
+    new_values: { nouveau_statut: nextStatus, cause: params.cause },
     user_id: params.user_id ?? null,
   });
 
   let notifications: AppNotification[] = [];
-  if (nextNormalized === "PLANNING_VALIDE") {
-    const recipientIds = await repoListUsersForCommandePlanningNotification(params.tx);
+  if (nextStatus === "PLANNING_VALIDE") {
+    const internalOrder = String(commande.order_type ?? "").toUpperCase() === "INTERNE";
+    const recipientIds = internalOrder
+      ? await listUsersForCommandeWorkflowRole(params.tx, "production")
+      : await repoListUsersForCommandePlanningNotification(params.tx);
     notifications = await repoCreateAppNotifications({
       tx: params.tx,
       user_ids: recipientIds,
-      kind: "commande.planning_valide",
-      title: `Commande ${commande.numero} planifiée`,
-      message: `La commande ${commande.numero} est maintenant planifiée. Un AR peut être envoyé au client.`,
+      kind: internalOrder ? "commande.workflow.handoff" : "commande.planning_valide",
+      title: internalOrder
+        ? `Production à lancer pour ${commande.numero}`
+        : `Commande ${commande.numero} planifiée`,
+      message: internalOrder
+        ? `Le planning interne de la commande ${commande.numero} est validé. La production peut être lancée.`
+        : `La commande ${commande.numero} est maintenant planifiée. Un AR peut être préparé.`,
       severity: "success",
       action_url: `/commandes/${params.commande_id}`,
       action_label: "Ouvrir",
@@ -1173,12 +1229,16 @@ export async function repoEnsureCommandeWorkflowStatus(params: {
         commande_id: params.commande_id,
         numero: commande.numero,
         client_id: commande.client_id,
+        checkpoint_code: internalOrder ? "production_launch" : "ar_preparation",
+        role: internalOrder ? "production" : "secretariat",
       },
-      dedupe_key: `commande:${params.commande_id}:planning_valide`,
+      dedupe_key: internalOrder
+        ? `commande:${params.commande_id}:checkpoint:production_launch:active`
+        : `commande:${params.commande_id}:planning_valide`,
     });
   }
 
-  if (nextNormalized === "AR_PRET") {
+  if (nextStatus === "AR_PRET") {
     const recipientIds = await repoListUsersForCommandePlanningNotification(params.tx);
     notifications = await repoCreateAppNotifications({
       tx: params.tx,
@@ -1201,10 +1261,72 @@ export async function repoEnsureCommandeWorkflowStatus(params: {
   return {
     changed: true,
     ancien_statut: ancienStatut,
-    nouveau_statut: nextRaw,
+    nouveau_statut: nextStatus,
     history_id: ins.rows[0]?.id ? toInt(ins.rows[0].id, "commande_historique.id") : null,
     notifications,
   };
+}
+
+export async function repoApplyCommandeWorkflowMilestone(params: {
+  tx: Queryable;
+  commande_id: number;
+  nouveau_statut: CommandeWorkflowStatus;
+  cause: CommandeWorkflowTransitionCause;
+  commentaire: string | null;
+  user_id: number | null;
+  completed_checkpoint_codes: readonly string[];
+  active_checkpoint_code: string | null;
+}) {
+  const transition = await repoEnsureCommandeWorkflowStatus({
+    tx: params.tx,
+    commande_id: params.commande_id,
+    nouveau_statut: params.nouveau_statut,
+    cause: params.cause,
+    commentaire: params.commentaire,
+    user_id: params.user_id,
+  });
+  if (!transition.changed) return transition;
+
+  await params.tx.query(
+    `
+      UPDATE public.commande_client_workflow_checkpoint
+      SET
+        status = CASE
+          WHEN checkpoint_code = ANY($2::text[]) THEN 'done'
+          WHEN checkpoint_code = $3::text AND status NOT IN ('done', 'skipped') THEN 'active'
+          ELSE status
+        END,
+        completed_at = CASE
+          WHEN checkpoint_code = ANY($2::text[]) THEN COALESCE(completed_at, now())
+          ELSE completed_at
+        END,
+        completed_by = CASE
+          WHEN checkpoint_code = ANY($2::text[]) THEN COALESCE(completed_by, $4::int)
+          ELSE completed_by
+        END,
+        blocked_reason = CASE WHEN checkpoint_code = $3::text THEN NULL ELSE blocked_reason END,
+        notes = CASE
+          WHEN checkpoint_code = ANY($2::text[]) THEN COALESCE($5, notes)
+          ELSE notes
+        END,
+        updated_at = now()
+      WHERE commande_id = $1
+        AND (checkpoint_code = ANY($2::text[]) OR checkpoint_code = $3::text)
+        AND (
+          (checkpoint_code = ANY($2::text[]) AND status <> 'done')
+          OR (checkpoint_code = $3::text AND status NOT IN ('active', 'done', 'skipped'))
+        )
+    `,
+    [
+      params.commande_id,
+      [...params.completed_checkpoint_codes],
+      params.active_checkpoint_code,
+      params.user_id,
+      params.commentaire,
+    ]
+  );
+
+  return transition;
 }
 
 async function advanceInternalOrderWorkflowAfterGeneration(params: {
@@ -1218,11 +1340,12 @@ async function advanceInternalOrderWorkflowAfterGeneration(params: {
     tx: params.tx,
     commande_id: params.commande_id,
     nouveau_statut: "ATTENTE_PLANNING",
+    cause: "internal_order_launch",
     commentaire: "Commande interne validee et lancee",
     user_id: params.user_id,
   });
 
-  await ensureCommandeWorkflowCheckpoints(params.tx, params.commande_id, "ATTENTE_PLANNING");
+  await repoEnsureCommandeWorkflowCheckpoints(params.tx, params.commande_id, "ATTENTE_PLANNING");
   await params.tx.query(
     `
       UPDATE public.commande_client_workflow_checkpoint
@@ -1298,6 +1421,7 @@ async function advanceCustomerOrderWorkflowAfterLaunch(params: {
       tx: params.tx,
       commande_id: params.commande_id,
       nouveau_statut: "ATTENTE_PLANNING",
+      cause: "customer_order_launch",
       commentaire: "Stock réservé et OF du manquant générés",
       user_id: params.user_id,
     });
@@ -1347,6 +1471,7 @@ async function advanceCustomerOrderWorkflowAfterLaunch(params: {
     tx: params.tx,
     commande_id: params.commande_id,
     nouveau_statut: "PRET_LIVRAISON",
+    cause: "customer_order_launch",
     commentaire: "Commande entièrement réservée, BL préparé sans OF",
     user_id: params.user_id,
   });
@@ -1356,6 +1481,7 @@ type CommandeWorkflowHeader = {
   id: number;
   numero: string;
   client_id: string | null;
+  order_type: string | null;
   statut: CommandeWorkflowStatus;
   raw_statut: string | null;
 };
@@ -1388,12 +1514,6 @@ function normalizeCheckpointStatus(value: unknown): CommandeCheckpointStatus {
   return checkpointStatusSet.has(status) ? (status as CommandeCheckpointStatus) : "pending";
 }
 
-function statusBeforeCheckpoint(checkpointCode: string): CommandeWorkflowStatus {
-  const index = COMMANDE_WORKFLOW_CHECKPOINTS.findIndex((checkpoint) => checkpoint.code === checkpointCode);
-  if (index <= 0) return "BROUILLON";
-  return COMMANDE_WORKFLOW_CHECKPOINTS[index - 1]?.status_when_done ?? "BROUILLON";
-}
-
 function mapWorkflowCheckpoint(row: WorkflowCheckpointRow) {
   return {
     ...row,
@@ -1417,11 +1537,31 @@ function checkpointSeedStatus(definitionStatus: CommandeWorkflowStatus, currentS
   return "pending" as CommandeCheckpointStatus;
 }
 
-async function loadCommandeWorkflowHeaderWithStatus(tx: Queryable, commandeId: number): Promise<CommandeWorkflowHeader | null> {
+async function loadCommandeWorkflowHeaderWithStatus(
+  tx: Queryable,
+  commandeId: number,
+  options: { forUpdate?: boolean } = {}
+): Promise<CommandeWorkflowHeader | null> {
+  if (options.forUpdate) {
+    const locked = await tx.query<{ id: string }>(
+      `
+        SELECT id::text AS id
+        FROM commande_client cc
+        WHERE cc.id = $1
+        FOR UPDATE
+      `,
+      [commandeId]
+    );
+    if (!locked.rows[0]) return null;
+  }
+
+  // When mutation was requested, this second statement runs only after the
+  // aggregate lock and therefore reads a fresh history snapshot.
   const res = await tx.query<{
     id: string;
     numero: string;
     client_id: string | null;
+    order_type: string | null;
     raw_statut: string | null;
   }>(
     `
@@ -1429,6 +1569,7 @@ async function loadCommandeWorkflowHeaderWithStatus(tx: Queryable, commandeId: n
         cc.id::text AS id,
         cc.numero,
         cc.client_id,
+        cc.order_type,
         st.nouveau_statut AS raw_statut
       FROM commande_client cc
       LEFT JOIN LATERAL (
@@ -1451,12 +1592,17 @@ async function loadCommandeWorkflowHeaderWithStatus(tx: Queryable, commandeId: n
     id: toInt(row.id, "commande.id"),
     numero: row.numero,
     client_id: row.client_id,
+    order_type: row.order_type,
     raw_statut: row.raw_statut,
     statut,
   };
 }
 
-async function ensureCommandeWorkflowCheckpoints(tx: Queryable, commandeId: number, currentStatus: CommandeWorkflowStatus) {
+export async function repoEnsureCommandeWorkflowCheckpoints(
+  tx: Queryable,
+  commandeId: number,
+  currentStatus: CommandeWorkflowStatus
+) {
   const activeAssigned = { value: false };
   for (const checkpoint of COMMANDE_WORKFLOW_CHECKPOINTS) {
     const status = checkpointSeedStatus(checkpoint.status_when_done, currentStatus, activeAssigned);
@@ -1529,12 +1675,27 @@ async function loadCommandeWorkflowCheckpoints(tx: Queryable, commandeId: number
   return rows.rows.map(mapWorkflowCheckpoint);
 }
 
-function buildWorkflowView(header: CommandeWorkflowHeader, checkpoints: ReturnType<typeof mapWorkflowCheckpoint>[]) {
+function buildWorkflowView(
+  header: CommandeWorkflowHeader,
+  checkpoints: ReturnType<typeof mapWorkflowCheckpoint>[],
+  viewer?: { user_id: number; user_role: string | null | undefined }
+) {
   const activeCheckpoint =
     checkpoints.find((checkpoint) => checkpoint.status === "active" || checkpoint.status === "blocked") ??
     checkpoints.find((checkpoint) => checkpoint.status === "pending") ??
     null;
   const action = activeCheckpoint?.action_key ? getCommandeWorkflowAction(activeCheckpoint.action_key) : null;
+  const canAct = Boolean(activeCheckpoint && viewer && canActOnCommandeWorkflowCheckpoint({
+    user_id: viewer.user_id,
+    user_role: viewer.user_role,
+    responsible_role: activeCheckpoint.responsible_role,
+    assigned_user_id: activeCheckpoint.assigned_user_id,
+  }));
+  const actionForbiddenReason = !activeCheckpoint || canAct
+    ? null
+    : activeCheckpoint.assigned_user_id !== null && activeCheckpoint.assigned_user_id !== viewer?.user_id
+      ? "Ce checkpoint est attribué à un autre utilisateur."
+      : `Action réservée au rôle ${activeCheckpoint.responsible_role}.`;
 
   return {
     commande_id: header.id,
@@ -1544,7 +1705,9 @@ function buildWorkflowView(header: CommandeWorkflowHeader, checkpoints: ReturnTy
     raw_statut: header.raw_statut,
     current_checkpoint: activeCheckpoint,
     checkpoints,
-    available_actions: action && activeCheckpoint
+    can_act: canAct,
+    action_forbidden_reason: actionForbiddenReason,
+    available_actions: action && activeCheckpoint?.status === "active" && canAct
       ? [{
           key: action.key,
           label: action.label,
@@ -1629,31 +1792,49 @@ async function activateNextCheckpoint(tx: Queryable, commandeId: number, nextChe
   if (!nextCheckpointCode) return;
   await tx.query(
     `
-      UPDATE public.commande_client_workflow_checkpoint
-      SET status = CASE WHEN status IN ('done','skipped') THEN status ELSE 'active' END,
-          blocked_reason = CASE WHEN status = 'blocked' THEN NULL ELSE blocked_reason END,
+      WITH requested AS (
+        SELECT sort_order
+        FROM public.commande_client_workflow_checkpoint
+        WHERE commande_id = $1 AND checkpoint_code = $2
+      ), next_eligible AS (
+        SELECT cp.id
+        FROM public.commande_client_workflow_checkpoint cp
+        CROSS JOIN requested r
+        WHERE cp.commande_id = $1
+          AND cp.sort_order >= r.sort_order
+          AND cp.status NOT IN ('done','skipped')
+        ORDER BY cp.sort_order ASC, cp.id ASC
+        LIMIT 1
+      )
+      UPDATE public.commande_client_workflow_checkpoint cp
+      SET status = 'active',
+          blocked_reason = NULL,
           updated_at = now()
-      WHERE commande_id = $1
-        AND checkpoint_code = $2
+      FROM next_eligible next
+      WHERE cp.id = next.id
     `,
     [commandeId, nextCheckpointCode]
   );
 }
 
-export async function repoGetCommandeWorkflow(id: string) {
+export async function repoGetCommandeWorkflow(
+  id: string,
+  userId: number,
+  userRole: string | null | undefined
+) {
   const commandeId = toInt(id, "commande_id");
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
-    const header = await loadCommandeWorkflowHeaderWithStatus(client, commandeId);
+    const header = await loadCommandeWorkflowHeaderWithStatus(client, commandeId, { forUpdate: true });
     if (!header) {
       await client.query("ROLLBACK");
       return null;
     }
-    await ensureCommandeWorkflowCheckpoints(client, commandeId, header.statut);
+    await repoEnsureCommandeWorkflowCheckpoints(client, commandeId, header.statut);
     const checkpoints = await loadCommandeWorkflowCheckpoints(client, commandeId);
     await client.query("COMMIT");
-    return buildWorkflowView(header, checkpoints);
+    return buildWorkflowView(header, checkpoints, { user_id: userId, user_role: userRole });
   } catch (e) {
     await client.query("ROLLBACK");
     throw e;
@@ -1666,7 +1847,8 @@ export async function repoUpdateCommandeWorkflowCheckpoint(
   id: string,
   checkpointCode: string,
   body: UpdateCommandeWorkflowCheckpointBodyDTO,
-  userId: number | null
+  userId: number | null,
+  userRole: string | null
 ) {
   const commandeId = toInt(id, "commande_id");
   if (userId === null) throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
@@ -1677,12 +1859,12 @@ export async function repoUpdateCommandeWorkflowCheckpoint(
   let notifications: AppNotification[] = [];
   try {
     await client.query("BEGIN");
-    const header = await loadCommandeWorkflowHeaderWithStatus(client, commandeId);
+    const header = await loadCommandeWorkflowHeaderWithStatus(client, commandeId, { forUpdate: true });
     if (!header) {
       await client.query("ROLLBACK");
       return null;
     }
-    await ensureCommandeWorkflowCheckpoints(client, commandeId, header.statut);
+    await repoEnsureCommandeWorkflowCheckpoints(client, commandeId, header.statut);
 
     const existing = await client.query<WorkflowCheckpointRow>(
       `
@@ -1713,25 +1895,92 @@ export async function repoUpdateCommandeWorkflowCheckpoint(
     );
     const before = existing.rows[0] ?? null;
     if (!before) throw new HttpError(404, "CHECKPOINT_NOT_FOUND", "Workflow checkpoint not found");
+    if (!canActOnCommandeWorkflowCheckpoint({
+      user_id: userId,
+      user_role: userRole,
+      responsible_role: before.responsible_role,
+      assigned_user_id: before.assigned_user_id,
+    })) {
+      throw new HttpError(403, "WORKFLOW_CHECKPOINT_FORBIDDEN", "This checkpoint is assigned to another role or user.");
+    }
 
-    const nextStatus = body.status ?? normalizeCheckpointStatus(before.status);
+    if (body.metadata && Object.prototype.hasOwnProperty.call(body.metadata, "previous_status_before_block")) {
+      throw new HttpError(
+        400,
+        "RESERVED_CHECKPOINT_METADATA",
+        "previous_status_before_block is managed by the workflow engine."
+      );
+    }
+
+    const beforeStatus = normalizeCheckpointStatus(before.status);
+    const nextStatus = body.status ?? beforeStatus;
+    const changesStatus = nextStatus !== beforeStatus;
+    const entersBlocked = beforeStatus === "active" && nextStatus === "blocked";
+    const resumesBlocked = beforeStatus === "blocked" && nextStatus === "active";
+    if (changesStatus && !entersBlocked && !resumesBlocked) {
+      throw new HttpError(
+        409,
+        "ILLEGAL_CHECKPOINT_STATUS_TRANSITION",
+        `Checkpoint transition forbidden: ${beforeStatus} -> ${nextStatus}. Run the active workflow action to advance.`
+      );
+    }
+    if (entersBlocked && !body.blocked_reason?.trim() && !body.notes?.trim()) {
+      throw new HttpError(400, "BLOCK_REASON_REQUIRED", "A reason is required to block the active checkpoint.");
+    }
+    if (entersBlocked && header.statut === "BLOQUE") {
+      throw new HttpError(409, "COMMAND_ALREADY_BLOCKED", "The command is already blocked by another checkpoint.");
+    }
+    if (resumesBlocked && header.statut !== "BLOQUE") {
+      throw new HttpError(409, "COMMAND_NOT_BLOCKED", "The command status is inconsistent with the blocked checkpoint.");
+    }
+
     const metadata = { ...(before.metadata ?? {}), ...(body.metadata ?? {}) };
-    const wasBlocked = normalizeCheckpointStatus(before.status) === "blocked";
     const hasAssignedUser = Object.prototype.hasOwnProperty.call(body, "assigned_user_id");
     const hasDueAt = Object.prototype.hasOwnProperty.call(body, "due_at");
     const hasNotes = Object.prototype.hasOwnProperty.call(body, "notes");
 
-    if (nextStatus === "blocked" && !wasBlocked) {
+    if (entersBlocked) {
       metadata.previous_status_before_block = header.statut;
     }
 
-    const resumeStatus =
-      nextStatus !== "blocked" && wasBlocked
-        ? normalizeCommandeWorkflowStatus(metadata.previous_status_before_block) ?? statusBeforeCheckpoint(definition.code)
-        : null;
+    const resumeStatus = resumesBlocked
+      ? normalizeCommandeWorkflowStatus(before.metadata?.previous_status_before_block)
+      : null;
+
+    if (resumesBlocked && (!resumeStatus || resumeStatus === "BLOQUE" || resumeStatus === "ARCHIVE")) {
+      throw new HttpError(
+        409,
+        "BLOCK_RESUME_STATUS_MISSING",
+        "The exact pre-block command status is missing from checkpoint metadata; repair it before resuming."
+      );
+    }
 
     if (resumeStatus) {
       delete metadata.previous_status_before_block;
+    }
+
+    const nextAssignedUser = hasAssignedUser ? body.assigned_user_id ?? null : before.assigned_user_id;
+    const nextDueAt = hasDueAt ? body.due_at ?? null : before.due_at;
+    const nextNotes = hasNotes ? body.notes ?? null : before.notes;
+    const nextBlockedReason = nextStatus === "blocked"
+      ? (Object.prototype.hasOwnProperty.call(body, "blocked_reason")
+          ? body.blocked_reason?.trim() || null
+          : before.blocked_reason)
+      : null;
+    const sameDueAt = nextDueAt === before.due_at || (
+      nextDueAt !== null && before.due_at !== null && Date.parse(nextDueAt) === Date.parse(before.due_at)
+    );
+    const isIdempotentReplay =
+      nextStatus === beforeStatus &&
+      nextAssignedUser === before.assigned_user_id &&
+      sameDueAt &&
+      nextNotes === before.notes &&
+      nextBlockedReason === before.blocked_reason &&
+      isDeepStrictEqual(metadata, before.metadata ?? {});
+
+    if (isIdempotentReplay) {
+      await client.query("COMMIT");
+      return { checkpoint: mapWorkflowCheckpoint(before), idempotent_replay: true };
     }
 
     const updated = await client.query<WorkflowCheckpointRow>(
@@ -1774,8 +2023,8 @@ export async function repoUpdateCommandeWorkflowCheckpoint(
         body.assigned_user_id ?? null,
         body.due_at ?? null,
         userId,
-        body.blocked_reason ?? null,
-        body.notes ?? null,
+        nextBlockedReason,
+        nextNotes,
         JSON.stringify(metadata),
         hasAssignedUser,
         hasDueAt,
@@ -1783,11 +2032,12 @@ export async function repoUpdateCommandeWorkflowCheckpoint(
       ]
     );
 
-    if (nextStatus === "blocked") {
-      await repoEnsureCommandeWorkflowStatus({
+    if (entersBlocked) {
+      const blockTransition = await repoEnsureCommandeWorkflowStatus({
         tx: client,
         commande_id: commandeId,
         nouveau_statut: "BLOQUE",
+        cause: "block",
         commentaire: body.blocked_reason ?? body.notes ?? `Checkpoint ${definition.code} blocked`,
         user_id: userId,
       });
@@ -1799,13 +2049,15 @@ export async function repoUpdateCommandeWorkflowCheckpoint(
         message: `Le checkpoint ${definition.label} est bloque.`,
         severity: "warning",
         checkpoint_code: definition.code,
-        dedupe_key: `commande:${commandeId}:checkpoint:${definition.code}:blocked`,
+        dedupe_key: `commande:${commandeId}:checkpoint:${definition.code}:blocked:${blockTransition.history_id ?? "unknown"}`,
       });
-    } else if (resumeStatus && header.statut === "BLOQUE") {
+    } else if (resumeStatus) {
       await repoEnsureCommandeWorkflowStatus({
         tx: client,
         commande_id: commandeId,
         nouveau_statut: resumeStatus,
+        cause: "resume",
+        resume_status: resumeStatus,
         commentaire: body.notes ?? `Checkpoint ${definition.code} resumed`,
         user_id: userId,
       });
@@ -1844,7 +2096,7 @@ export async function repoUpdateCommandeWorkflowCheckpoint(
       invalidateKeys: ["commandes:list", `commandes:detail:${commandeId}`, `commandes:workflow:${commandeId}`],
     });
 
-    return { checkpoint: mapWorkflowCheckpoint(updated.rows[0]) };
+    return { checkpoint: mapWorkflowCheckpoint(updated.rows[0]), idempotent_replay: false };
   } catch (e) {
     await client.query("ROLLBACK");
     throw e;
@@ -1870,6 +2122,13 @@ export async function repoRunCommandeWorkflowAction(
       "Utilisez Vérifier le stock et lancer : cette étape doit réserver OLD/NEW, préparer le BL ou créer les OF du manquant."
     );
   }
+  if (action.key === "mark_ar_sent") {
+    throw new HttpError(
+      409,
+      "COMMAND_AR_SEND_REQUIRED",
+      "Utilisez Envoyer l'AR : seul l'envoi client tracé peut valider ce checkpoint."
+    );
+  }
 
   const runsStockAnalysis = action.key === "check_stock";
 
@@ -1877,19 +2136,16 @@ export async function repoRunCommandeWorkflowAction(
   let notifications: AppNotification[] = [];
   try {
     await client.query("BEGIN");
-    const header = await loadCommandeWorkflowHeaderWithStatus(client, commandeId);
+    const header = await loadCommandeWorkflowHeaderWithStatus(client, commandeId, { forUpdate: true });
     if (!header) {
       await client.query("ROLLBACK");
       return null;
     }
-    if (action.key === "validate_planning") await assertCommandeHasActiveOf(client, commandeId);
-    if (action.key === "mark_delivered") await assertCommandeFullyShipped(client, commandeId);
-    if (action.key === "mark_invoiced") await assertCommandeFullyInvoiced(client, commandeId);
-    await ensureCommandeWorkflowCheckpoints(client, commandeId, header.statut);
+    await repoEnsureCommandeWorkflowCheckpoints(client, commandeId, header.statut);
 
-    const checkpointRes = await client.query<{ status: string; responsible_role: string }>(
+    const checkpointRes = await client.query<{ status: string; responsible_role: string; assigned_user_id: number | null }>(
       `
-        SELECT status, responsible_role
+        SELECT status, responsible_role, assigned_user_id::int AS assigned_user_id
         FROM public.commande_client_workflow_checkpoint
         WHERE commande_id = $1 AND checkpoint_code = $2
         FOR UPDATE
@@ -1898,8 +2154,24 @@ export async function repoRunCommandeWorkflowAction(
     );
     const checkpoint = checkpointRes.rows[0] ?? null;
     if (!checkpoint) throw new HttpError(404, "CHECKPOINT_NOT_FOUND", "Workflow checkpoint not found");
+    if (!canActOnCommandeWorkflowCheckpoint({
+      user_id: userId,
+      user_role: userRole,
+      responsible_role: checkpoint.responsible_role,
+      assigned_user_id: checkpoint.assigned_user_id,
+    })) {
+      throw new HttpError(403, "WORKFLOW_CHECKPOINT_FORBIDDEN", "This checkpoint is assigned to another role or user.");
+    }
     if (checkpoint.status === "blocked") {
       throw new HttpError(409, "CHECKPOINT_BLOCKED", "Resolve the blocker before running this workflow action");
+    }
+    if (checkpoint.status === "done") {
+      const checkpoints = await loadCommandeWorkflowCheckpoints(client, commandeId);
+      await client.query("COMMIT");
+      return {
+        workflow: buildWorkflowView(header, checkpoints, { user_id: userId, user_role: userRole }),
+        idempotent_replay: true,
+      };
     }
     if (checkpoint.status !== "active") {
       throw new HttpError(
@@ -1908,6 +2180,16 @@ export async function repoRunCommandeWorkflowAction(
         `L'étape ${action.checkpoint_code} n'est pas l'étape active de la commande.`
       );
     }
+
+    // Expensive/domain assertions are intentionally after the locked replay
+    // check: the second identical request must be a read-only success even if
+    // downstream state has already moved on.
+    if (action.key === "validate_planning") await assertCommandeHasActiveOf(client, commandeId);
+    if (action.key === "start_production") await assertCommandeProductionStarted(client, commandeId);
+    if (action.key === "complete_production") await assertCommandeProductionCompleted(client, commandeId);
+    if (action.key === "validate_quality") await assertCommandeQualityReleased(client, commandeId);
+    if (action.key === "mark_delivered") await assertCommandeFullyShipped(client, commandeId);
+    if (action.key === "mark_invoiced") await assertCommandeFullyInvoiced(client, commandeId);
 
     const stockAnalysisResult = runsStockAnalysis
       ? await analyzeCommandeStockTx(client, commandeId, {
@@ -1924,7 +2206,14 @@ export async function repoRunCommandeWorkflowAction(
         })
       : null;
 
-    const nextCheckpointCode = action.next_checkpoint_code;
+    const internalOrder = String(header.order_type ?? "").toUpperCase() === "INTERNE";
+    const nextCheckpointCode = internalOrder && action.key === "validate_planning"
+      ? "production_launch"
+      : action.next_checkpoint_code;
+    let transitionCause: CommandeWorkflowTransitionCause = "checkpoint";
+    if (internalOrder && action.key === "validate_planning") transitionCause = "internal_planning_validation";
+    if (internalOrder && action.key === "start_production") transitionCause = "internal_production_launch";
+    if (internalOrder && action.key === "archive") transitionCause = "internal_archive";
 
     await client.query(
       `
@@ -1963,12 +2252,16 @@ export async function repoRunCommandeWorkflowAction(
       tx: client,
       commande_id: commandeId,
       nouveau_statut: action.target_status,
+      cause: transitionCause,
       commentaire: body.commentaire ?? action.label,
       user_id: userId,
     });
     notifications = [...transition.notifications];
 
-    if (nextCheckpointCode) {
+    // A milestone notification already carries the handoff semantics for
+    // planning/AR transitions. Do not send a second differently-keyed handoff
+    // to overlapping recipients for the same state change.
+    if (nextCheckpointCode && transition.notifications.length === 0) {
       const nextDef = getCommandeWorkflowCheckpointDefinition(nextCheckpointCode);
       if (nextDef) {
         const roleNotifications = await notifyWorkflowRole(client, {
@@ -1998,6 +2291,13 @@ export async function repoRunCommandeWorkflowAction(
       user_id: userId,
     });
 
+    const checkpoints = await loadCommandeWorkflowCheckpoints(client, commandeId);
+    const workflow = buildWorkflowView(
+      { ...header, statut: action.target_status, raw_statut: action.target_status },
+      checkpoints,
+      { user_id: userId, user_role: userRole }
+    );
+
     await client.query("COMMIT");
 
     for (const notification of notifications) {
@@ -2013,7 +2313,7 @@ export async function repoRunCommandeWorkflowAction(
       invalidateKeys: ["commandes:list", `commandes:detail:${commandeId}`, `commandes:workflow:${commandeId}`],
     });
 
-    return repoGetCommandeWorkflow(id);
+    return { workflow, idempotent_replay: false };
   } catch (e) {
     await client.query("ROLLBACK");
     throw e;
@@ -2752,6 +3052,7 @@ export async function repoCreateCommande(input: CreateCommandeInput, documents: 
 
     const orderType = input.order_type ?? "FERME";
 
+    const initialWorkflowStatus: CommandeWorkflowStatus = "ATTENTE_TECHNIQUE";
     const insertSql = `
       INSERT INTO commande_client (
         id,
@@ -2830,8 +3131,7 @@ export async function repoCreateCommande(input: CreateCommandeInput, documents: 
     await insertCommandeEcheances(client, commandeId, input.echeances ?? []);
     await insertCommandeDocuments(client, commandeId, documents);
     await transitionLinkedDevisArticlesToValide(client, commandeIdInt, input.devis_id ?? null);
-    const initialWorkflowStatus: CommandeWorkflowStatus = "ATTENTE_TECHNIQUE";
-    await ensureCommandeWorkflowCheckpoints(client, commandeIdInt, initialWorkflowStatus);
+    await repoEnsureCommandeWorkflowCheckpoints(client, commandeIdInt, initialWorkflowStatus);
 
     await client.query(
       `
@@ -2857,6 +3157,7 @@ export async function repoCreateCommande(input: CreateCommandeInput, documents: 
         id: commandeIdInt,
         numero: numeroForInsert,
         client_id: input.client_id ?? null,
+        order_type: input.order_type ?? null,
         statut: initialWorkflowStatus,
         raw_statut: initialWorkflowStatus,
       },
@@ -2938,8 +3239,17 @@ export async function repoUpdateCommande(id: string, input: CreateCommandeInput,
       throw new HttpError(409, "COMMANDE_CODE_IMMUTABLE", "Le numéro de commande est attribué par le serveur et ne peut pas être modifié.");
     }
 
+    const existingOrderType = coerceOrderType(existing.order_type);
+    if (input.order_type !== undefined && input.order_type !== existingOrderType) {
+      throw new HttpError(
+        409,
+        "COMMANDE_ORDER_TYPE_IMMUTABLE",
+        "Le type de commande est immuable apres sa creation. Dupliquez la commande avec le type attendu."
+      );
+    }
+
     const numero = existing.numero;
-    const orderType = input.order_type ?? coerceOrderType(existing.order_type);
+    const orderType = existingOrderType;
 
     const clientIdForUpdate = hasOwn(input as object, "client_id") ? (input.client_id ?? null) : existing.client_id;
     const devisIdForUpdate = hasOwn(input as object, "devis_id") ? (input.devis_id ?? null) : toNullableInt(existing.devis_id, "devis_id");
@@ -3063,85 +3373,163 @@ export async function repoUpdateCommande(id: string, input: CreateCommandeInput,
   }
 }
 
-export async function repoDeleteCommande(id: string) {
-  const commandeId = toInt(id, "commande_id");
-  const before = await pool.query<{ ar_sent_at: string | null }>(
-    `SELECT ar_sent_at::text AS ar_sent_at FROM commande_client WHERE id = $1::bigint LIMIT 1`,
-    [commandeId]
-  );
-  const row = before.rows[0] ?? null;
-  if (!row) return false;
-  if (row.ar_sent_at) {
-    throw new HttpError(409, "COMMANDE_LOCKED_AFTER_AR", "Commande is locked after AR has been sent");
-  }
-
-  const { rowCount } = await pool.query(`DELETE FROM commande_client WHERE id = $1::bigint`, [commandeId]);
-  return (rowCount ?? 0) > 0;
-}
-
-export async function repoUpdateCommandeStatus(
+export async function repoDeleteCommande(
   id: string,
-  nouveau_statut: string,
-  commentaire: string | null,
-  userId: number | null
+  actor: { user_id: number; user_role: string | null }
 ) {
   const commandeId = toInt(id, "commande_id");
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
-
-    if (userId === null) {
-      throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
+    const lockedCommande = await client.query<{ order_type: string }>(
+      `
+        SELECT order_type
+        FROM public.commande_client
+        WHERE id = $1::bigint
+        FOR UPDATE
+      `,
+      [commandeId]
+    );
+    const lockedRow = lockedCommande.rows[0] ?? null;
+    if (!lockedRow) {
+      await client.query("ROLLBACK");
+      return false;
     }
 
-    const normalizedTargetStatus = normalizeCommandeWorkflowStatus(nouveau_statut);
-    if (normalizedTargetStatus && COMMANDE_STATUSES_REQUIRING_OF.has(normalizedTargetStatus)) {
-      await assertCommandeHasActiveOf(client, commandeId);
-    }
-    if (normalizedTargetStatus === "PRET_LIVRAISON") {
-      await assertCommandeHasPreparedDelivery(client, commandeId);
-    }
-    if (normalizedTargetStatus === "LIVRE") {
-      await assertCommandeFullyShipped(client, commandeId);
-    }
-    if (normalizedTargetStatus === "FACTURE" || normalizedTargetStatus === "ARCHIVE") {
-      await assertCommandeFullyInvoiced(client, commandeId);
+    // Evaluate retention only after the aggregate lock. Under READ COMMITTED this
+    // statement gets a fresh snapshot and sees workflow/artifacts committed while
+    // the command lock was being acquired.
+    const before = await client.query<{
+      raw_statut: string | null;
+      checkpoint_status: string | null;
+      responsible_role: string | null;
+      assigned_user_id: number | null;
+      initial_history_only: boolean;
+      initial_event_only: boolean;
+      has_business_artifacts: boolean;
+    }>(
+      `
+        SELECT
+          latest.nouveau_statut AS raw_statut,
+          cp.status AS checkpoint_status,
+          cp.responsible_role,
+          cp.assigned_user_id::int AS assigned_user_id,
+          (
+            SELECT COUNT(*) = 1
+              AND BOOL_AND(ch.ancien_statut IS NULL AND ch.nouveau_statut = 'ATTENTE_TECHNIQUE')
+            FROM public.commande_historique ch
+            WHERE ch.commande_id = cc.id
+          ) AS initial_history_only,
+          (
+            SELECT COUNT(*) = 1
+              AND BOOL_AND(ev.event_type = 'WORKFLOW_INITIALIZED')
+            FROM public.commande_client_event_log ev
+            WHERE ev.commande_id = cc.id
+          ) AS initial_event_only,
+          (
+            EXISTS (SELECT 1 FROM public.commande_to_affaire cta WHERE cta.commande_id = cc.id)
+            OR EXISTS (SELECT 1 FROM public.affaire business_case WHERE business_case.commande_id = cc.id)
+            OR EXISTS (
+              SELECT 1
+              FROM public.commande_ligne_affaire_allocation allocation
+              WHERE allocation.commande_id = cc.id
+            )
+            OR EXISTS (SELECT 1 FROM public.ordres_fabrication fabrication WHERE fabrication.commande_id = cc.id)
+            OR EXISTS (SELECT 1 FROM public.of_generation_batches batch WHERE batch.commande_id = cc.id)
+            OR EXISTS (SELECT 1 FROM public.bon_livraison delivery WHERE delivery.commande_id = cc.id)
+            OR EXISTS (SELECT 1 FROM public.commande_ar_log ar WHERE ar.commande_id = cc.id)
+            OR EXISTS (SELECT 1 FROM public.ar_recalage_dossiers recalage WHERE recalage.commande_id = cc.id)
+            OR EXISTS (SELECT 1 FROM public.facture invoice WHERE invoice.commande_id = cc.id)
+            OR EXISTS (
+              SELECT 1
+              FROM public.commande_cadre_release cadre_release
+              WHERE cadre_release.commande_cadre_id = cc.id
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM public.commande_fournisseur_ligne supplier_line
+              WHERE supplier_line.commande_client_id = cc.id
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM public.stock_reservations reservation
+              JOIN public.commande_ligne line ON line.id = reservation.commande_ligne_id
+              WHERE line.commande_id = cc.id
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM public.article_devis_promotion article_promotion
+              WHERE article_promotion.commande_id = cc.id
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM public.dossier_technique_piece_devis_promotion technical_promotion
+              WHERE technical_promotion.commande_id = cc.id
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM public.quick_commande_previews quick_preview
+              WHERE quick_preview.confirmed_commande_id = cc.id
+            )
+            OR EXISTS (
+              SELECT 1
+              FROM public.quick_commande_confirmations quick_confirmation
+              WHERE quick_confirmation.commande_id = cc.id
+            )
+          ) AS has_business_artifacts
+        FROM public.commande_client cc
+        LEFT JOIN LATERAL (
+          SELECT ch.nouveau_statut
+          FROM public.commande_historique ch
+          WHERE ch.commande_id = cc.id
+          ORDER BY ch.date_action DESC, ch.id DESC
+          LIMIT 1
+        ) latest ON TRUE
+        LEFT JOIN public.commande_client_workflow_checkpoint cp
+          ON cp.commande_id = cc.id
+         AND cp.checkpoint_code = 'technical_analysis'
+        WHERE cc.id = $1::bigint
+        LIMIT 1
+      `,
+      [commandeId]
+    );
+    const stateRow = before.rows[0] ?? null;
+    const row = stateRow ? { ...stateRow, order_type: lockedRow.order_type } : null;
+    if (!row) {
+      await client.query("ROLLBACK");
+      return false;
     }
 
-    const out = await repoEnsureCommandeWorkflowStatus({
-      tx: client,
-      commande_id: commandeId,
-      nouveau_statut,
-      commentaire,
-      user_id: userId,
-    });
+    const initialDeletableState =
+      row.order_type !== "INTERNE"
+      && normalizeCommandeWorkflowStatus(row.raw_statut) === "ATTENTE_TECHNIQUE"
+      && row.checkpoint_status === "active"
+      && row.responsible_role === "technique"
+      && row.initial_history_only
+      && row.initial_event_only
+      && !row.has_business_artifacts;
+    if (!initialDeletableState) {
+      throw new HttpError(
+        409,
+        "COMMANDE_DELETE_REQUIRES_ARCHIVE",
+        "Seule une commande client dans son état initial, sans historique métier ni artefact, peut être supprimée. Archivez-la sinon."
+      );
+    }
+    if (!canActOnCommandeWorkflowCheckpoint({
+      user_id: actor.user_id,
+      user_role: actor.user_role,
+      responsible_role: row.responsible_role ?? "",
+      assigned_user_id: row.assigned_user_id,
+    })) {
+      throw new HttpError(403, "WORKFLOW_CHECKPOINT_FORBIDDEN", "La suppression est attribuée à un autre rôle ou utilisateur.");
+    }
 
+    const deleted = await client.query(`DELETE FROM public.commande_client WHERE id = $1::bigint`, [commandeId]);
     await client.query("COMMIT");
-
-    for (const notification of out.notifications) {
-      emitAppNotificationCreated(notification.user_id, notification);
-    }
-    if (out.changed) {
-      emitEntityChanged({
-        entityType: "commande_client",
-        entityId: String(commandeId),
-        action: "status_changed",
-        module: "commandes",
-        at: new Date().toISOString(),
-        by: { id: userId ?? 0, name: userId ? `User #${userId}` : "System" },
-        invalidateKeys: ["commandes:list", `commandes:detail:${commandeId}`],
-      });
-    }
-
-    return {
-      id: out.history_id,
-      ancien_statut: out.ancien_statut,
-      nouveau_statut: out.nouveau_statut,
-      changed: out.changed,
-    };
-  } catch (e) {
+    return (deleted.rowCount ?? 0) > 0;
+  } catch (error) {
     await client.query("ROLLBACK");
-    throw e;
+    throw error;
   } finally {
     client.release();
   }
@@ -3333,10 +3721,15 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
     if (orderType !== "INTERNE") {
       const workflowHeader = await loadCommandeWorkflowHeaderWithStatus(client, commandeId);
       if (!workflowHeader) throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande not found");
-      await ensureCommandeWorkflowCheckpoints(client, commandeId, workflowHeader.statut);
-      const launchCheckpoints = await client.query<{ checkpoint_code: string; status: string }>(
+      await repoEnsureCommandeWorkflowCheckpoints(client, commandeId, workflowHeader.statut);
+      const launchCheckpoints = await client.query<{
+        checkpoint_code: string;
+        status: string;
+        responsible_role: string;
+        assigned_user_id: number | null;
+      }>(
         `
-          SELECT checkpoint_code, status
+          SELECT checkpoint_code, status, responsible_role, assigned_user_id::int AS assigned_user_id
           FROM public.commande_client_workflow_checkpoint
           WHERE commande_id = $1
             AND checkpoint_code IN ('stock_check', 'of_generation')
@@ -3355,6 +3748,24 @@ export async function repoGenerateAffairesFromOrder(id: string, body: GenerateAf
       const ofGenerationStatus = statusByCheckpoint.get("of_generation");
       const stockCheckDone = statusByCheckpoint.get("stock_check") === "done";
       const hasExistingLaunch = existingLaunch.rows[0]?.exists === true;
+      const launchCheckpoint = launchCheckpoints.rows.find(
+        (checkpoint) => checkpoint.checkpoint_code === "of_generation"
+      );
+      if (!launchCheckpoint) {
+        throw new HttpError(409, "COMMAND_CHECKPOINT_MISSING", "Le checkpoint de lancement est absent.");
+      }
+      if (!canActOnCommandeWorkflowCheckpoint({
+        user_id: audit.user_id,
+        user_role: audit.user_role,
+        responsible_role: launchCheckpoint.responsible_role,
+        assigned_user_id: launchCheckpoint.assigned_user_id,
+      })) {
+        throw new HttpError(
+          403,
+          "WORKFLOW_CHECKPOINT_FORBIDDEN",
+          "Le lancement est attribué à un autre rôle ou utilisateur."
+        );
+      }
 
       if (
         stockCheckDone &&
@@ -5132,6 +5543,7 @@ export async function repoDuplicateCommande(id: string) {
     if (!newId) throw new Error("Failed to allocate commande id");
     const newIdInt = toInt(newId, "commande_client.id");
     const newNumero = await generateCommandeCode(client, { client_code: original.code_client ?? original.client_id ?? "CMD" });
+    const initialWorkflowStatus: CommandeWorkflowStatus = "ATTENTE_TECHNIQUE";
 
     await client.query(
       `
@@ -5218,12 +5630,14 @@ export async function repoDuplicateCommande(id: string) {
       });
     }
 
+    await repoEnsureCommandeWorkflowCheckpoints(client, newIdInt, initialWorkflowStatus);
+
     await client.query(
       `
       INSERT INTO commande_historique (commande_id, user_id, ancien_statut, nouveau_statut, commentaire)
       VALUES ($1, $2, $3, $4, $5)
       `,
-      [newIdInt, null, null, "ENREGISTREE", `Duplicated from commande ${originalCommandeId}`]
+      [newIdInt, null, null, initialWorkflowStatus, `Duplicated from commande ${originalCommandeId}`]
     );
 
     await client.query("COMMIT");

--- a/src/module/commande-client/repository/commande-delete.repository.test.ts
+++ b/src/module/commande-client/repository/commande-delete.repository.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  clientQuery: vi.fn(),
+  release: vi.fn(),
+}));
+
+vi.mock("../../../config/database", () => ({
+  default: { connect: mocks.connect, query: vi.fn() },
+}));
+
+import { repoDeleteCommande } from "./commande-client.repository";
+
+const initialRow = {
+  order_type: "FERME",
+  raw_statut: "ATTENTE_TECHNIQUE",
+  checkpoint_status: "active",
+  responsible_role: "technique",
+  assigned_user_id: null,
+  initial_history_only: true,
+  initial_event_only: true,
+  has_business_artifacts: false,
+};
+
+function mockDeleteCandidate(overrides: Partial<typeof initialRow>) {
+  const row = { ...initialRow, ...overrides };
+  mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+    const query = String(sql);
+    if (query.includes("SELECT order_type") && query.includes("FROM public.commande_client") && query.includes("FOR UPDATE")) {
+      return { rows: [{ order_type: row.order_type }] };
+    }
+    if (query.includes("has_business_artifacts")) {
+      const { order_type: _orderType, ...stateRow } = row;
+      return { rows: [stateRow] };
+    }
+    if (query.includes("DELETE FROM public.commande_client")) return { rows: [], rowCount: 1 };
+    return { rows: [] };
+  });
+}
+
+beforeEach(() => {
+  mocks.connect.mockReset();
+  mocks.clientQuery.mockReset();
+  mocks.release.mockReset();
+  mocks.connect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.release });
+});
+
+describe("commande hard-delete retention guard", () => {
+  it.each([
+    ["une commande interne", { order_type: "INTERNE" }],
+    ["une commande en production", { raw_statut: "EN_PRODUCTION", initial_history_only: false, initial_event_only: false }],
+    ["une commande archivée", { raw_statut: "ARCHIVE", initial_history_only: false, initial_event_only: false }],
+    ["une commande portant un artefact métier", { has_business_artifacts: true }],
+  ])("refuse %s et ne lance aucun DELETE", async (_label, overrides) => {
+    mockDeleteCandidate(overrides);
+
+    await expect(repoDeleteCommande("123", { user_id: 7, user_role: "Production" }))
+      .rejects.toMatchObject({ status: 409, code: "COMMANDE_DELETE_REQUIRES_ARCHIVE" });
+
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("DELETE FROM public.commande_client"))).toBe(false);
+  });
+
+  it("verrouille la commande avant d'évaluer les artefacts de rétention", async () => {
+    mockDeleteCandidate({ has_business_artifacts: true });
+
+    await expect(repoDeleteCommande("123", { user_id: 7, user_role: "Production" }))
+      .rejects.toMatchObject({ status: 409, code: "COMMANDE_DELETE_REQUIRES_ARCHIVE" });
+
+    const commandLockIndex = mocks.clientQuery.mock.calls.findIndex(([sql]) =>
+      String(sql).includes("SELECT order_type") && String(sql).includes("FOR UPDATE")
+    );
+    const retentionIndex = mocks.clientQuery.mock.calls.findIndex(([sql]) =>
+      String(sql).includes("has_business_artifacts")
+    );
+    expect(commandLockIndex).toBeGreaterThanOrEqual(0);
+    expect(retentionIndex).toBeGreaterThan(commandLockIndex);
+
+    const guardSql = String(mocks.clientQuery.mock.calls[retentionIndex]?.[0] ?? "");
+    expect(guardSql).toContain("FROM public.facture invoice");
+    expect(guardSql).toContain("FROM public.commande_cadre_release cadre_release");
+    expect(guardSql).toContain("FROM public.commande_fournisseur_ligne supplier_line");
+    expect(guardSql).toContain("FROM public.commande_ligne_affaire_allocation allocation");
+    expect(guardSql).toContain("FROM public.stock_reservations reservation");
+    expect(guardSql).toContain("FROM public.article_devis_promotion article_promotion");
+    expect(guardSql).toContain("FROM public.quick_commande_confirmations quick_confirmation");
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("DELETE FROM public.commande_client"))).toBe(false);
+  });
+
+  it("refuse un rôle non propriétaire du checkpoint initial", async () => {
+    mockDeleteCandidate({});
+
+    await expect(repoDeleteCommande("123", { user_id: 7, user_role: "Commercial" }))
+      .rejects.toMatchObject({ status: 403, code: "WORKFLOW_CHECKPOINT_FORBIDDEN" });
+
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("DELETE FROM public.commande_client"))).toBe(false);
+  });
+
+  it("autorise le responsable technique uniquement sur l'état initial sans artefact", async () => {
+    mockDeleteCandidate({});
+
+    await expect(repoDeleteCommande("123", { user_id: 7, user_role: "Production" })).resolves.toBe(true);
+
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => String(sql).includes("DELETE FROM public.commande_client"))).toBe(true);
+  });
+});

--- a/src/module/commande-client/repository/commande-fulfillment-guards.repository.ts
+++ b/src/module/commande-client/repository/commande-fulfillment-guards.repository.ts
@@ -1,0 +1,199 @@
+import type { PoolClient } from "pg"
+
+import { HttpError } from "../../../utils/httpError"
+
+type Queryable = Pick<PoolClient, "query">
+
+export type FulfillmentState = {
+  has_lines: boolean
+  has_ready_delivery: boolean
+  fully_shipped: boolean
+  fully_invoiced: boolean
+}
+
+const INVOICE_LEDGER_STATUSES = ["ISSUED", "PARTIALLY_PAID", "PAID"] as const
+
+export async function loadCommandeFulfillmentState(tx: Queryable, commandeId: number): Promise<FulfillmentState> {
+  const result = await tx.query<FulfillmentState>(
+    `
+      WITH shipped_by_line AS (
+        SELECT delivery_line.commande_ligne_id, COALESCE(SUM(delivery_line.quantite), 0)::numeric AS quantity
+        FROM public.bon_livraison_ligne delivery_line
+        JOIN public.bon_livraison delivery ON delivery.id = delivery_line.bon_livraison_id
+        WHERE delivery.commande_id = $1
+          AND delivery.statut IN ('SHIPPED', 'DELIVERED')
+          AND delivery_line.commande_ligne_id IS NOT NULL
+        GROUP BY delivery_line.commande_ligne_id
+      ),
+      invoiced_by_delivery_line AS (
+        SELECT source.source_line_id, COALESCE(SUM(source.quantity_consumed), 0)::numeric AS quantity
+        FROM public.facture_source_allocations source
+        JOIN public.facture invoice ON invoice.id = source.facture_id
+        WHERE source.source_type = 'DELIVERY_LINE'
+          AND source.allocation_status = 'CONSUMED'
+          AND invoice.statut = ANY($2::text[])
+        GROUP BY source.source_line_id
+      )
+      SELECT
+        EXISTS(SELECT 1 FROM public.commande_ligne line WHERE line.commande_id = $1) AS has_lines,
+        EXISTS(
+          SELECT 1 FROM public.bon_livraison delivery
+          WHERE delivery.commande_id = $1 AND delivery.statut IN ('READY', 'SHIPPED', 'DELIVERED')
+        ) AS has_ready_delivery,
+        NOT EXISTS(
+          SELECT 1 FROM public.commande_ligne line
+          LEFT JOIN shipped_by_line shipped ON shipped.commande_ligne_id = line.id
+          WHERE line.commande_id = $1
+            AND COALESCE(shipped.quantity, 0) + 0.000000001 < line.quantite
+        ) AS fully_shipped,
+        NOT EXISTS(
+          SELECT 1 FROM public.bon_livraison_ligne delivery_line
+          JOIN public.bon_livraison delivery ON delivery.id = delivery_line.bon_livraison_id
+          LEFT JOIN invoiced_by_delivery_line invoiced ON invoiced.source_line_id = delivery_line.id::text
+          WHERE delivery.commande_id = $1
+            AND delivery.statut IN ('SHIPPED', 'DELIVERED')
+            AND COALESCE(invoiced.quantity, 0) + 0.000000001 < delivery_line.quantite
+        ) AS fully_invoiced
+    `,
+    [commandeId, [...INVOICE_LEDGER_STATUSES]],
+  )
+  const state = result.rows[0] ?? {
+    has_lines: false,
+    has_ready_delivery: false,
+    fully_shipped: false,
+    fully_invoiced: false,
+  }
+  return {
+    ...state,
+    fully_shipped: state.has_lines && state.fully_shipped,
+    fully_invoiced: state.has_lines && state.fully_shipped && state.fully_invoiced,
+  }
+}
+
+export async function assertCommandeHasActiveOf(tx: Queryable, commandeId: number): Promise<void> {
+  const linkedOf = await tx.query<{ exists: boolean }>(
+    `SELECT EXISTS(
+       SELECT 1 FROM public.ordres_fabrication
+       WHERE commande_id = $1 AND statut::text <> 'ANNULE'
+     ) AS exists`,
+    [commandeId],
+  )
+  if (linkedOf.rows[0]?.exists !== true) {
+    throw new HttpError(
+      409,
+      "PLANNING_REQUIRES_OF",
+      "Aucun OF actif n'est lié à cette commande. Relancez le contrôle OLD/NEW et la génération avant de valider le planning.",
+    )
+  }
+}
+
+export async function assertCommandeProductionStarted(tx: Queryable, commandeId: number): Promise<void> {
+  const result = await tx.query<{ total: number; not_started: number }>(
+    `
+      SELECT
+        COUNT(*) FILTER (WHERE statut::text <> 'ANNULE')::int AS total,
+        COUNT(*) FILTER (
+          WHERE statut::text <> 'ANNULE'
+            AND statut::text NOT IN ('EN_COURS','TERMINE','CLOTURE')
+        )::int AS not_started
+      FROM public.ordres_fabrication
+      WHERE commande_id = $1
+    `,
+    [commandeId]
+  )
+  const state = result.rows[0] ?? { total: 0, not_started: 0 }
+  if (state.total <= 0 || state.not_started > 0) {
+    throw new HttpError(409, "PRODUCTION_START_REQUIRED", "Lancez tous les OF actifs dans le module Production avant de synchroniser la commande.")
+  }
+}
+
+export async function assertCommandeProductionCompleted(tx: Queryable, commandeId: number): Promise<void> {
+  const result = await tx.query<{ total: number; incomplete: number }>(
+    `
+      SELECT
+        COUNT(*) FILTER (WHERE statut::text <> 'ANNULE')::int AS total,
+        COUNT(*) FILTER (
+          WHERE statut::text <> 'ANNULE'
+            AND statut::text NOT IN ('TERMINE','CLOTURE')
+        )::int AS incomplete
+      FROM public.ordres_fabrication
+      WHERE commande_id = $1
+    `,
+    [commandeId]
+  )
+  const state = result.rows[0] ?? { total: 0, incomplete: 0 }
+  if (state.total <= 0 || state.incomplete > 0) {
+    throw new HttpError(409, "PRODUCTION_NOT_COMPLETE", "Tous les OF actifs, y compris les OF enfants, doivent être terminés ou clôturés.")
+  }
+}
+
+export async function assertCommandeQualityReleased(tx: Queryable, commandeId: number): Promise<void> {
+  const result = await tx.query<{ total: number; unreleased: number; open_nc: number }>(
+    `
+      WITH active_of AS (
+        SELECT id, GREATEST(COALESCE(quantite_bonne, 0), 0)::numeric AS qty_required
+        FROM public.ordres_fabrication
+        WHERE commande_id = $1 AND statut::text <> 'ANNULE'
+      ), released AS (
+        SELECT object_id,
+          COALESCE(SUM(qty) FILTER (
+            WHERE decision IN ('FULL','PARTIAL') AND verdict IN ('CONFORME','PARTIEL')
+          ), 0)::numeric AS qty_released
+        FROM public.quality_release_decision
+        WHERE object_type = 'OF'
+          AND object_id IN (SELECT id::text FROM active_of)
+        GROUP BY object_id
+      )
+      SELECT
+        (SELECT COUNT(*)::int FROM active_of) AS total,
+        (SELECT COUNT(*)::int
+         FROM active_of target
+         LEFT JOIN released decision ON decision.object_id = target.id::text
+         WHERE decision.object_id IS NULL OR decision.qty_released + 0.000000001 < target.qty_required
+        ) AS unreleased,
+        (SELECT COUNT(*)::int
+         FROM public.non_conformity nc
+         WHERE nc.of_id IN (SELECT id FROM active_of)
+           AND nc.status::text NOT IN ('CLOSED','CANCELLED')
+        ) AS open_nc
+    `,
+    [commandeId]
+  )
+  const state = result.rows[0] ?? { total: 0, unreleased: 0, open_nc: 0 }
+  if (state.total <= 0 || state.unreleased > 0 || state.open_nc > 0) {
+    throw new HttpError(409, "QUALITY_RELEASE_REQUIRED", "Chaque OF actif doit être couvert par une décision de libération qualité et aucune non-conformité ne doit rester ouverte.")
+  }
+}
+
+export async function assertCommandeHasPreparedDelivery(tx: Queryable, commandeId: number): Promise<void> {
+  const state = await loadCommandeFulfillmentState(tx, commandeId)
+  if (!state.has_ready_delivery) {
+    throw new HttpError(
+      409,
+      "DELIVERY_PREPARATION_REQUIRED",
+      "Aucun bon de livraison prêt n'est lié à cette commande. Préparez le BL et ses réservations avant ce changement de statut.",
+    )
+  }
+}
+
+export async function assertCommandeFullyShipped(tx: Queryable, commandeId: number): Promise<void> {
+  const state = await loadCommandeFulfillmentState(tx, commandeId)
+  if (!state.fully_shipped) {
+    throw new HttpError(
+      409,
+      "DELIVERY_NOT_COMPLETE",
+      "La commande ne peut pas être déclarée livrée : toutes les quantités doivent d'abord sortir du stock via un BL expédié.",
+    )
+  }
+}
+
+export async function assertCommandeFullyInvoiced(tx: Queryable, commandeId: number): Promise<void> {
+  const state = await loadCommandeFulfillmentState(tx, commandeId)
+  if (!state.fully_invoiced) {
+    throw new HttpError(
+      409,
+      "INVOICE_NOT_COMPLETE",
+      "La commande ne peut pas être déclarée facturée : toutes les lignes expédiées doivent être couvertes par une facture émise.",
+    )
+  }
+}

--- a/src/module/commande-client/repository/commande-fulfillment.repository.test.ts
+++ b/src/module/commande-client/repository/commande-fulfillment.repository.test.ts
@@ -5,6 +5,9 @@ import {
   assertCommandeFullyInvoiced,
   assertCommandeFullyShipped,
   assertCommandeHasActiveOf,
+  assertCommandeProductionCompleted,
+  assertCommandeProductionStarted,
+  assertCommandeQualityReleased,
   syncCommandeAfterInvoiceIssue,
   syncCommandeAfterShipment,
 } from "./commande-fulfillment.repository";
@@ -12,9 +15,8 @@ import {
 function queryable(
   implementation: (sql: string, values?: unknown[]) => Promise<{ rows: unknown[] }>
 ) {
-  return {
-    query: vi.fn((sql: string, values?: unknown[]) => implementation(sql, values)),
-  } as unknown as Pick<PoolClient, "query">;
+  const query = vi.fn((sql: string, values?: unknown[]) => implementation(sql, values));
+  return { query } as { query: typeof query } & Pick<PoolClient, "query">;
 }
 
 const completeState = {
@@ -57,9 +59,12 @@ describe("commande fulfillment invariants", () => {
   it("advances delivery only from PRET_LIVRAISON", async () => {
     const tx = queryable(async (sql) => {
       if (sql.includes("WITH shipped_by_line AS")) return { rows: [completeState] };
-      if (sql.includes("SELECT statut, order_type")) {
-        return { rows: [{ statut: "PRET_LIVRAISON", order_type: "STANDARD" }] };
+      if (sql.includes("SELECT id::int AS id, numero, client_id")) {
+        return { rows: [{ id: 12, numero: "CC-12", client_id: "001" }] };
       }
+      if (sql.includes("SELECT nouveau_statut")) return { rows: [{ nouveau_statut: "PRET_LIVRAISON" }] };
+      if (sql.includes("INSERT INTO commande_historique")) return { rows: [{ id: "1" }] };
+      if (sql.includes("SELECT order_type")) return { rows: [{ order_type: "STANDARD" }] };
       return { rows: [] };
     });
 
@@ -68,11 +73,11 @@ describe("commande fulfillment invariants", () => {
       status: "LIVRE",
     });
     expect(tx.query).toHaveBeenCalledWith(
-      expect.stringContaining("SET statut = 'LIVRE'"),
-      [12]
+      expect.stringContaining("UPDATE commande_client"),
+      [12, false, 7, false]
     );
     expect(tx.query).toHaveBeenCalledWith(
-      expect.stringContaining("INSERT INTO public.commande_historique"),
+      expect.stringContaining("INSERT INTO commande_historique"),
       [
         12,
         7,
@@ -86,14 +91,15 @@ describe("commande fulfillment invariants", () => {
   it("rolls back the semantic shortcut when a complete shipment happens too early", async () => {
     const tx = queryable(async (sql) => {
       if (sql.includes("WITH shipped_by_line AS")) return { rows: [completeState] };
-      if (sql.includes("SELECT statut, order_type")) {
-        return { rows: [{ statut: "ATTENTE_PLANNING", order_type: "STANDARD" }] };
+      if (sql.includes("SELECT id::int AS id, numero, client_id")) {
+        return { rows: [{ id: 12, numero: "CC-12", client_id: "001" }] };
       }
+      if (sql.includes("SELECT nouveau_statut")) return { rows: [{ nouveau_statut: "ATTENTE_PLANNING" }] };
       return { rows: [] };
     });
 
     await expect(syncCommandeAfterShipment(tx, 12, 7)).rejects.toMatchObject({
-      code: "COMMAND_NOT_READY_FOR_DELIVERY",
+      code: "ILLEGAL_COMMAND_STATUS_TRANSITION",
     });
     expect(tx.query).not.toHaveBeenCalledWith(
       expect.stringContaining("SET statut = 'LIVRE'"),
@@ -104,9 +110,11 @@ describe("commande fulfillment invariants", () => {
   it("advances invoicing only after the delivered command is fully covered", async () => {
     const tx = queryable(async (sql) => {
       if (sql.includes("WITH shipped_by_line AS")) return { rows: [completeState] };
-      if (sql.includes("SELECT statut FROM public.commande_client")) {
-        return { rows: [{ statut: "LIVRE" }] };
+      if (sql.includes("SELECT id::int AS id, numero, client_id")) {
+        return { rows: [{ id: 12, numero: "CC-12", client_id: "001" }] };
       }
+      if (sql.includes("SELECT nouveau_statut")) return { rows: [{ nouveau_statut: "LIVRE" }] };
+      if (sql.includes("INSERT INTO commande_historique")) return { rows: [{ id: "2" }] };
       return { rows: [] };
     });
 
@@ -115,8 +123,118 @@ describe("commande fulfillment invariants", () => {
       status: "FACTURE",
     });
     expect(tx.query).toHaveBeenCalledWith(
-      expect.stringContaining("SET statut = 'FACTURE'"),
-      [12]
+      expect.stringContaining("UPDATE commande_client"),
+      [12, false, 9, false]
     );
+  });
+
+  it("refuse toute synchronisation de facture pour une commande interne sans écrire l'historique", async () => {
+    const tx = queryable(async (sql) => {
+      if (sql.includes("SELECT order_type") && sql.includes("FOR UPDATE")) {
+        return { rows: [{ order_type: "INTERNE" }] };
+      }
+      return { rows: [] };
+    });
+
+    await expect(syncCommandeAfterInvoiceIssue(tx, 12, 9)).rejects.toMatchObject({
+      status: 409,
+      code: "INTERNAL_ORDER_NOT_BILLABLE",
+    });
+    expect(tx.query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO commande_historique"))).toBe(false);
+    expect(tx.query.mock.calls.some(([sql]) => String(sql).includes("commande_client_event_log"))).toBe(false);
+  });
+
+  it("requires real multi-OF production state, while excluding cancelled OF", async () => {
+    const notStarted = queryable(async (sql) => {
+      expect(sql).toContain("statut::text NOT IN ('EN_COURS','TERMINE','CLOTURE')");
+      return { rows: [{ total: 2, not_started: 1 }] };
+    });
+    await expect(assertCommandeProductionStarted(notStarted, 12)).rejects.toMatchObject({
+      code: "PRODUCTION_START_REQUIRED",
+    });
+
+    const complete = queryable(async (sql) => {
+      expect(sql).toContain("statut::text <> 'ANNULE'");
+      return { rows: [{ total: 3, incomplete: 0 }] };
+    });
+    await expect(assertCommandeProductionCompleted(complete, 12)).resolves.toBeUndefined();
+
+    const childOpen = queryable(async () => ({ rows: [{ total: 3, incomplete: 1 }] }));
+    await expect(assertCommandeProductionCompleted(childOpen, 12)).rejects.toMatchObject({
+      code: "PRODUCTION_NOT_COMPLETE",
+    });
+  });
+
+  it("requires release-decision coverage and no open NC before quality completion", async () => {
+    const missingDecision = queryable(async (sql) => {
+      expect(sql).toContain("quality_release_decision");
+      expect(sql).toContain("public.non_conformity");
+      return { rows: [{ total: 2, unreleased: 1, open_nc: 0 }] };
+    });
+    await expect(assertCommandeQualityReleased(missingDecision, 12)).rejects.toMatchObject({
+      code: "QUALITY_RELEASE_REQUIRED",
+    });
+
+    const released = queryable(async () => ({ rows: [{ total: 2, unreleased: 0, open_nc: 0 }] }));
+    await expect(assertCommandeQualityReleased(released, 12)).resolves.toBeUndefined();
+  });
+
+  it("keeps append-only history authoritative through delivery, invoice and their replays", async () => {
+    let historyStatus = "PRET_LIVRAISON";
+    let historyWrites = 0;
+    let statusEvents = 0;
+    const tx = queryable(async (sql, values) => {
+      if (sql.includes("WITH shipped_by_line AS")) return { rows: [completeState] };
+      if (sql.includes("SELECT id::int AS id, numero, client_id")) {
+        return { rows: [{ id: 12, numero: "CC-12", client_id: "001" }] };
+      }
+      if (sql.includes("SELECT nouveau_statut")) return { rows: [{ nouveau_statut: historyStatus }] };
+      if (sql.includes("INSERT INTO commande_historique")) {
+        historyWrites += 1;
+        historyStatus = String(values?.[3]);
+        return { rows: [{ id: String(historyWrites) }] };
+      }
+      if (sql.includes("INSERT INTO public.commande_client_event_log")) {
+        statusEvents += 1;
+        return { rows: [] };
+      }
+      if (sql.includes("SELECT order_type")) return { rows: [{ order_type: "STANDARD" }] };
+      return { rows: [] };
+    });
+
+    await expect(syncCommandeAfterShipment(tx, 12, 7)).resolves.toEqual({ advanced: true, status: "LIVRE" });
+    expect(historyStatus).toBe("LIVRE");
+    await expect(syncCommandeAfterShipment(tx, 12, 7)).resolves.toEqual({ advanced: false, status: "LIVRE" });
+
+    await expect(syncCommandeAfterInvoiceIssue(tx, 12, 9)).resolves.toEqual({ advanced: true, status: "FACTURE" });
+    expect(historyStatus).toBe("FACTURE");
+    await expect(syncCommandeAfterInvoiceIssue(tx, 12, 9)).resolves.toEqual({ advanced: false, status: "FACTURE" });
+
+    expect(historyWrites).toBe(2);
+    expect(statusEvents).toBe(2);
+    expect(tx.query.mock.calls.some(([sql]) => /commande_client[\s\S]*statut/i.test(String(sql)))).toBe(false);
+  });
+
+  it.each([
+    ["shipment", "FACTURE"],
+    ["shipment", "ARCHIVE"],
+    ["invoice", "ARCHIVE"],
+  ])("treats downstream %s replay at %s as a side-effect-free success", async (kind, currentStatus) => {
+    const tx = queryable(async (sql) => {
+      if (sql.includes("WITH shipped_by_line AS")) return { rows: [completeState] };
+      if (sql.includes("SELECT id::int AS id, numero, client_id")) {
+        return { rows: [{ id: 12, numero: "CC-12", client_id: "001" }] };
+      }
+      if (sql.includes("SELECT nouveau_statut")) return { rows: [{ nouveau_statut: currentStatus }] };
+      return { rows: [] };
+    });
+
+    const result = kind === "shipment"
+      ? await syncCommandeAfterShipment(tx, 12, 7)
+      : await syncCommandeAfterInvoiceIssue(tx, 12, 9);
+    expect(result).toEqual({ advanced: false, status: currentStatus });
+    expect(tx.query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO commande_historique"))).toBe(false);
+    expect(tx.query.mock.calls.some(([sql]) => String(sql).includes("commande_client_event_log"))).toBe(false);
+    expect(tx.query.mock.calls.some(([sql]) => String(sql).includes("UPDATE public.commande_client_workflow_checkpoint"))).toBe(false);
   });
 });

--- a/src/module/commande-client/repository/commande-fulfillment.repository.ts
+++ b/src/module/commande-client/repository/commande-fulfillment.repository.ts
@@ -1,228 +1,49 @@
 import type { PoolClient } from "pg";
 
 import { HttpError } from "../../../utils/httpError";
+import { repoEnsureCommandeWorkflowStatus } from "./commande-client.repository";
+import { loadCommandeFulfillmentState } from "./commande-fulfillment-guards.repository";
+
+export {
+  assertCommandeFullyInvoiced,
+  assertCommandeFullyShipped,
+  assertCommandeHasActiveOf,
+  assertCommandeHasPreparedDelivery,
+  assertCommandeProductionCompleted,
+  assertCommandeProductionStarted,
+  assertCommandeQualityReleased,
+} from "./commande-fulfillment-guards.repository";
 
 type Queryable = Pick<PoolClient, "query">;
-
-type FulfillmentState = {
-  has_lines: boolean;
-  has_ready_delivery: boolean;
-  fully_shipped: boolean;
-  fully_invoiced: boolean;
-};
-
-const INVOICE_LEDGER_STATUSES = ["ISSUED", "PARTIALLY_PAID", "PAID"] as const;
-
-async function loadCommandeFulfillmentState(
-  tx: Queryable,
-  commandeId: number
-): Promise<FulfillmentState> {
-  const result = await tx.query<FulfillmentState>(
-    `
-      WITH shipped_by_line AS (
-        SELECT
-          delivery_line.commande_ligne_id,
-          COALESCE(SUM(delivery_line.quantite), 0)::numeric AS quantity
-        FROM public.bon_livraison_ligne delivery_line
-        JOIN public.bon_livraison delivery
-          ON delivery.id = delivery_line.bon_livraison_id
-        WHERE delivery.commande_id = $1
-          AND delivery.statut IN ('SHIPPED', 'DELIVERED')
-          AND delivery_line.commande_ligne_id IS NOT NULL
-        GROUP BY delivery_line.commande_ligne_id
-      ),
-      invoiced_by_delivery_line AS (
-        SELECT
-          source.source_line_id,
-          COALESCE(SUM(source.quantity_consumed), 0)::numeric AS quantity
-        FROM public.facture_source_allocations source
-        JOIN public.facture invoice ON invoice.id = source.facture_id
-        WHERE source.source_type = 'DELIVERY_LINE'
-          AND source.allocation_status = 'CONSUMED'
-          AND invoice.statut = ANY($2::text[])
-        GROUP BY source.source_line_id
-      )
-      SELECT
-        EXISTS(
-          SELECT 1
-          FROM public.commande_ligne line
-          WHERE line.commande_id = $1
-        ) AS has_lines,
-        EXISTS(
-          SELECT 1
-          FROM public.bon_livraison delivery
-          WHERE delivery.commande_id = $1
-            AND delivery.statut IN ('READY', 'SHIPPED', 'DELIVERED')
-        ) AS has_ready_delivery,
-        NOT EXISTS(
-          SELECT 1
-          FROM public.commande_ligne line
-          LEFT JOIN shipped_by_line shipped ON shipped.commande_ligne_id = line.id
-          WHERE line.commande_id = $1
-            AND COALESCE(shipped.quantity, 0) + 0.000000001 < line.quantite
-        ) AS fully_shipped,
-        NOT EXISTS(
-          SELECT 1
-          FROM public.bon_livraison_ligne delivery_line
-          JOIN public.bon_livraison delivery
-            ON delivery.id = delivery_line.bon_livraison_id
-          LEFT JOIN invoiced_by_delivery_line invoiced
-            ON invoiced.source_line_id = delivery_line.id::text
-          WHERE delivery.commande_id = $1
-            AND delivery.statut IN ('SHIPPED', 'DELIVERED')
-            AND COALESCE(invoiced.quantity, 0) + 0.000000001 < delivery_line.quantite
-        ) AS fully_invoiced
-    `,
-    [commandeId, [...INVOICE_LEDGER_STATUSES]]
-  );
-
-  const state = result.rows[0] ?? {
-    has_lines: false,
-    has_ready_delivery: false,
-    fully_shipped: false,
-    fully_invoiced: false,
-  };
-  return {
-    ...state,
-    fully_shipped: state.has_lines && state.fully_shipped,
-    fully_invoiced: state.has_lines && state.fully_shipped && state.fully_invoiced,
-  };
-}
-
-export async function assertCommandeHasActiveOf(tx: Queryable, commandeId: number): Promise<void> {
-  const linkedOf = await tx.query<{ exists: boolean }>(
-    `
-      SELECT EXISTS(
-        SELECT 1
-        FROM public.ordres_fabrication
-        WHERE commande_id = $1
-          AND statut::text <> 'ANNULE'
-      ) AS exists
-    `,
-    [commandeId]
-  );
-  if (linkedOf.rows[0]?.exists !== true) {
-    throw new HttpError(
-      409,
-      "PLANNING_REQUIRES_OF",
-      "Aucun OF actif n'est lié à cette commande. Relancez le contrôle OLD/NEW et la génération avant de valider le planning."
-    );
-  }
-}
-
-export async function assertCommandeHasPreparedDelivery(
-  tx: Queryable,
-  commandeId: number
-): Promise<void> {
-  const state = await loadCommandeFulfillmentState(tx, commandeId);
-  if (!state.has_ready_delivery) {
-    throw new HttpError(
-      409,
-      "DELIVERY_PREPARATION_REQUIRED",
-      "Aucun bon de livraison prêt n'est lié à cette commande. Préparez le BL et ses réservations avant ce changement de statut."
-    );
-  }
-}
-
-export async function assertCommandeFullyShipped(
-  tx: Queryable,
-  commandeId: number
-): Promise<void> {
-  const state = await loadCommandeFulfillmentState(tx, commandeId);
-  if (!state.fully_shipped) {
-    throw new HttpError(
-      409,
-      "DELIVERY_NOT_COMPLETE",
-      "La commande ne peut pas être déclarée livrée : toutes les quantités doivent d'abord sortir du stock via un BL expédié."
-    );
-  }
-}
-
-export async function assertCommandeFullyInvoiced(
-  tx: Queryable,
-  commandeId: number
-): Promise<void> {
-  const state = await loadCommandeFulfillmentState(tx, commandeId);
-  if (!state.fully_invoiced) {
-    throw new HttpError(
-      409,
-      "INVOICE_NOT_COMPLETE",
-      "La commande ne peut pas être déclarée facturée : toutes les lignes expédiées doivent être couvertes par une facture émise."
-    );
-  }
-}
-
-async function insertAutomaticHistory(params: {
-  tx: Queryable;
-  commande_id: number;
-  user_id: number;
-  old_status: string;
-  new_status: "LIVRE" | "FACTURE";
-  comment: string;
-}): Promise<void> {
-  if (params.old_status === params.new_status) return;
-  await params.tx.query(
-    `
-      INSERT INTO public.commande_historique (
-        commande_id, user_id, ancien_statut, nouveau_statut, commentaire
-      ) VALUES ($1,$2,$3,$4,$5)
-    `,
-    [
-      params.commande_id,
-      params.user_id,
-      params.old_status,
-      params.new_status,
-      params.comment,
-    ]
-  );
-}
 
 export async function syncCommandeAfterShipment(
   tx: Queryable,
   commandeId: number,
   userId: number
 ): Promise<{ advanced: boolean; status: string | null }> {
+  // Fulfillment callers lock their BL/facture first, then this command row.
+  // Keeping that order identical across shipment and invoice paths prevents
+  // deadlocks. The command lock serializes aggregate reads so two concurrent
+  // partial documents cannot both miss the other's just-committed completion.
+  const header = await tx.query<{ order_type: string | null }>(
+    `SELECT order_type FROM public.commande_client WHERE id = $1 FOR UPDATE`,
+    [commandeId]
+  );
   const state = await loadCommandeFulfillmentState(tx, commandeId);
   if (!state.fully_shipped) return { advanced: false, status: null };
 
-  const header = await tx.query<{ statut: string; order_type: string | null }>(
-    `
-      SELECT statut, order_type
-      FROM public.commande_client
-      WHERE id = $1
-      FOR UPDATE
-    `,
-    [commandeId]
-  );
-  const current = header.rows[0] ?? null;
-  if (!current) return { advanced: false, status: null };
-  if (["FACTURE", "ARCHIVE"].includes(current.statut)) {
-    return { advanced: false, status: current.statut };
-  }
-  if (!["PRET_LIVRAISON", "LIVRE"].includes(current.statut)) {
-    throw new HttpError(
-      409,
-      "COMMAND_NOT_READY_FOR_DELIVERY",
-      "L'expédition complète est bloquée tant que le workflow commande n'a pas atteint Prêt pour livraison."
-    );
-  }
-
-  await tx.query(
-    `
-      UPDATE public.commande_client
-      SET statut = 'LIVRE', updated_at = now()
-      WHERE id = $1
-    `,
-    [commandeId]
-  );
-  await insertAutomaticHistory({
+  const transition = await repoEnsureCommandeWorkflowStatus({
     tx,
     commande_id: commandeId,
+    nouveau_statut: "LIVRE",
+    cause: "shipment_sync",
+    commentaire: "Statut synchronisé automatiquement après sortie de stock complète et expédition du BL",
     user_id: userId,
-    old_status: current.statut,
-    new_status: "LIVRE",
-    comment: "Statut synchronisé automatiquement après sortie de stock complète et expédition du BL",
   });
+  if (!transition.changed) return { advanced: false, status: transition.nouveau_statut };
+
+  const current = header.rows[0] ?? null;
+  if (!current) return { advanced: false, status: null };
 
   const internalOrder = String(current.order_type ?? "").toUpperCase() === "INTERNE";
   await tx.query(
@@ -257,7 +78,7 @@ export async function syncCommandeAfterShipment(
       JSON.stringify({ synchronized_from: "delivery_shipped" }),
     ]
   );
-  return { advanced: true, status: "LIVRE" };
+  return { advanced: transition.changed, status: transition.nouveau_statut };
 }
 
 export async function syncCommandeAfterInvoiceIssue(
@@ -265,36 +86,25 @@ export async function syncCommandeAfterInvoiceIssue(
   commandeId: number,
   userId: number
 ): Promise<{ advanced: boolean; status: string | null }> {
+  const header = await tx.query<{ order_type: string | null }>(
+    `SELECT order_type FROM public.commande_client WHERE id = $1 FOR UPDATE`,
+    [commandeId]
+  );
+  if (String(header.rows[0]?.order_type ?? "").toUpperCase() === "INTERNE") {
+    throw new HttpError(409, "INTERNAL_ORDER_NOT_BILLABLE", "Une commande interne ne peut pas être facturée.");
+  }
   const state = await loadCommandeFulfillmentState(tx, commandeId);
   if (!state.fully_invoiced) return { advanced: false, status: null };
 
-  const header = await tx.query<{ statut: string }>(
-    `SELECT statut FROM public.commande_client WHERE id = $1 FOR UPDATE`,
-    [commandeId]
-  );
-  const current = header.rows[0] ?? null;
-  if (!current) return { advanced: false, status: null };
-  if (current.statut === "ARCHIVE") return { advanced: false, status: current.statut };
-  if (!["LIVRE", "FACTURE"].includes(current.statut)) {
-    throw new HttpError(
-      409,
-      "COMMAND_NOT_READY_FOR_INVOICE",
-      "L'émission finale est bloquée tant que la commande n'est pas entièrement livrée."
-    );
-  }
-
-  await tx.query(
-    `UPDATE public.commande_client SET statut = 'FACTURE', updated_at = now() WHERE id = $1`,
-    [commandeId]
-  );
-  await insertAutomaticHistory({
+  const transition = await repoEnsureCommandeWorkflowStatus({
     tx,
     commande_id: commandeId,
+    nouveau_statut: "FACTURE",
+    cause: "invoice_sync",
+    commentaire: "Statut synchronisé automatiquement après émission complète de la facture",
     user_id: userId,
-    old_status: current.statut,
-    new_status: "FACTURE",
-    comment: "Statut synchronisé automatiquement après émission complète de la facture",
   });
+  if (!transition.changed) return { advanced: false, status: transition.nouveau_statut };
   await tx.query(
     `
       UPDATE public.commande_client_workflow_checkpoint
@@ -321,7 +131,7 @@ export async function syncCommandeAfterInvoiceIssue(
     `,
     [commandeId, userId, JSON.stringify({ synchronized_from: "invoice_issued" })]
   );
-  return { advanced: true, status: "FACTURE" };
+  return { advanced: transition.changed, status: transition.nouveau_statut };
 }
 
 export async function listIssuedInvoiceCommandeIds(
@@ -337,9 +147,12 @@ export async function listIssuedInvoiceCommandeIds(
        AND source.source_line_id = delivery_line.id::text
       JOIN public.bon_livraison delivery
         ON delivery.id = delivery_line.bon_livraison_id
+      JOIN public.commande_client commande
+        ON commande.id = delivery.commande_id
       WHERE source.facture_id = $1
         AND source.allocation_status = 'CONSUMED'
         AND delivery.commande_id IS NOT NULL
+        AND upper(COALESCE(commande.order_type, '')) <> 'INTERNE'
       ORDER BY delivery.commande_id
     `,
     [factureId]

--- a/src/module/commande-client/repository/commande-update-order-type.repository.test.ts
+++ b/src/module/commande-client/repository/commande-update-order-type.repository.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  query: vi.fn(),
+  release: vi.fn(),
+}));
+
+vi.mock("../../../config/database", () => ({
+  default: { connect: mocks.connect, query: vi.fn() },
+}));
+
+import { repoUpdateCommande } from "./commande-client.repository";
+
+beforeEach(() => {
+  mocks.connect.mockReset();
+  mocks.query.mockReset();
+  mocks.release.mockReset();
+  mocks.connect.mockResolvedValue({ query: mocks.query, release: mocks.release });
+});
+
+describe("commande order type invariant", () => {
+  it("refuse le passage INTERNE vers FERME sous verrou, même sans AR", async () => {
+    mocks.query.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query.includes("FROM commande_client") && query.includes("FOR UPDATE")) {
+        return {
+          rows: [{
+            numero: "CI-123",
+            client_id: null,
+            devis_id: null,
+            order_type: "INTERNE",
+            adresse_facturation_id: null,
+            cadre_start_date: null,
+            cadre_end_date: null,
+            dest_stock_magasin_id: null,
+            dest_stock_emplacement_id: null,
+            ar_sent_at: null,
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    await expect(repoUpdateCommande("123", { order_type: "FERME" } as never, []))
+      .rejects.toMatchObject({ status: 409, code: "COMMANDE_ORDER_TYPE_IMMUTABLE" });
+
+    expect(mocks.query.mock.calls.some(([sql]) => /^\s*UPDATE commande_client/i.test(String(sql)))).toBe(false);
+    expect(mocks.query.mock.calls.some(([sql]) => /^\s*DELETE FROM commande_ligne/i.test(String(sql)))).toBe(false);
+  });
+});

--- a/src/module/commande-client/routes/commande-client.routes.ts
+++ b/src/module/commande-client/routes/commande-client.routes.ts
@@ -2,10 +2,6 @@ import type { RequestHandler } from "express"
 import { Router } from "express"
 import multer from "multer"
 
-import {
-  hasGrantedAccountModuleAccess,
-  requestHasGrantedAccountModuleAccess,
-} from "../../access-control/context/account-module-access.context"
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
 import { HttpError } from "../../../utils/httpError"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
@@ -32,7 +28,6 @@ import {
   updateCadreReleaseStatus,
   updateCommande,
   updateCommandeWorkflowCheckpoint,
-  updateCommandeStatus,
 } from "../controllers/commande-client.controller"
 import { generateCommandeAr, sendCommandeAr } from "../controllers/commande-ar.controller"
 import {
@@ -84,40 +79,22 @@ const parseCommandeBody: RequestHandler = (req, res, next) => {
 
 const router = Router()
 
-function isAdminRole(role: string | undefined): boolean {
-  if (!role) return false
-  const r = role.trim().toLowerCase()
-  return r.includes("admin") || r.includes("administrateur") || r.includes("directeur")
-}
-
-function isOfficeSupportRole(role: string | undefined): boolean {
-  if (!role) return false
-  const r = role.trim().toLowerCase()
-  return r.includes("secr") || r.includes("secret") || r.includes("compt")
-}
-
-const requireOfficeSupportOrAdmin: RequestHandler = (req, _res, next) => {
-  if (
-    requestHasGrantedAccountModuleAccess(req) ||
-    hasGrantedAccountModuleAccess()
-  ) {
-    next()
-    return
-  }
-  const role = req.user?.role
-  if (!isAdminRole(role) && !isOfficeSupportRole(role)) {
-    next(new HttpError(403, "FORBIDDEN", "Secretary or accounting role required"))
-    return
-  }
-  next()
-}
-
 const rejectLegacyCommandeLaunch: RequestHandler = (_req, _res, next) => {
   next(
     new HttpError(
       410,
       "LEGACY_COMMAND_LAUNCH_REMOVED",
       "Cet ancien lancement de commande est désactivé. Utilisez Vérifier le stock et lancer."
+    )
+  )
+}
+
+const rejectDirectCommandeStatusMutation: RequestHandler = (_req, _res, next) => {
+  next(
+    new HttpError(
+      410,
+      "DIRECT_COMMAND_STATUS_MUTATION_DISABLED",
+      "La modification directe du statut est désactivée. Utilisez l'action du checkpoint métier actif."
     )
   )
 }
@@ -191,13 +168,23 @@ router.patch("/:id", validate(idParamSchema), upload.array("documents[]"), parse
 router.delete("/:id", validate(idParamSchema), deleteCommande)
 
 // POST /api/v1/commandes/:id/status
-router.post("/:id/status", authenticateToken, validate(idParamSchema), updateCommandeStatus)
+router.post("/:id/status", authenticateToken, validate(idParamSchema), rejectDirectCommandeStatusMutation)
 
 // POST /api/v1/commandes/:id/ar/generate
-router.post("/:id/ar/generate", authenticateToken, validate(generateCommandeArSchema), generateCommandeAr)
+router.post(
+  "/:id/ar/generate",
+  authenticateToken,
+  validate(generateCommandeArSchema),
+  generateCommandeAr
+)
 
 // POST /api/v1/commandes/:id/ar/send
-router.post("/:id/ar/send", authenticateToken, validate(sendCommandeArSchema), sendCommandeAr)
+router.post(
+  "/:id/ar/send",
+  authenticateToken,
+  validate(sendCommandeArSchema),
+  sendCommandeAr
+)
 
 // POST /api/v1/commandes/:id/analyze-stock
 router.post("/:id/analyze-stock", authenticateToken, validate(idParamSchema), analyzeCommandeStock)

--- a/src/module/commande-client/services/commande-ar.service.test.ts
+++ b/src/module/commande-client/services/commande-ar.service.test.ts
@@ -2,6 +2,20 @@ import { inflateSync } from "node:zlib";
 
 import { describe, expect, it, vi } from "vitest";
 
+const mocks = vi.hoisted(() => ({
+  readFile: vi.fn(),
+  sendEmail: vi.fn(),
+  authorizeGeneration: vi.fn(),
+  abortClaim: vi.fn(),
+  claimSend: vi.fn(),
+  finalizeSend: vi.fn(),
+  markFailed: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  default: { readFile: mocks.readFile },
+}));
+
 vi.mock("../../../config/database", () => ({
   default: { connect: vi.fn() },
 }));
@@ -10,21 +24,24 @@ vi.mock("../../../shared/realtime/realtime.service", () => ({
   emitEntityChanged: vi.fn(),
 }));
 vi.mock("../../../shared/email/resend.service", () => ({
-  sendTransactionalEmail: vi.fn(),
+  sendTransactionalEmail: mocks.sendEmail,
 }));
 vi.mock("../../../shared/documents/issuer-identity.repository", () => ({
   readIssuerParty: vi.fn(),
 }));
 vi.mock("../repository/commande-ar.repository", () => ({
   buildCommandeArRecipientSuggestions: vi.fn(),
+  repoAbortCommandeArSendClaim: mocks.abortClaim,
+  repoAuthorizeCommandeArGeneration: mocks.authorizeGeneration,
+  repoClaimCommandeArSend: mocks.claimSend,
   repoCreateCommandeArDraft: vi.fn(),
-  repoFinalizeCommandeArSend: vi.fn(),
+  repoFinalizeCommandeArSend: mocks.finalizeSend,
   repoGetCommandeArDraft: vi.fn(),
   repoLoadCommandeArGenerationData: vi.fn(),
-  repoMarkCommandeArFailed: vi.fn(),
+  repoMarkCommandeArFailed: mocks.markFailed,
 }));
 
-import { buildCommandeArPdfBuffer } from "./commande-ar.service";
+import { buildCommandeArPdfBuffer, svcSendCommandeAr } from "./commande-ar.service";
 
 const WINANSI = new TextDecoder("windows-1252");
 
@@ -91,6 +108,87 @@ const ISSUER = {
   retention_of_title: "Propriété réservée jusqu'au paiement intégral.",
   legal_mentions_version: 1,
 };
+
+const SEND_BODY = {
+  ar_id: "11111111-1111-4111-8111-111111111111",
+  recipient_emails: ["new-request@example.test"],
+  recipient_contact_ids: [],
+};
+
+const GENERATED_DRAFT = {
+  ar_id: SEND_BODY.ar_id,
+  commande_id: 123,
+  document_id: "22222222-2222-4222-8222-222222222222",
+  document_name: "AR-123.pdf",
+  subject: "AR commande 123",
+  body_text: null,
+  generated_at: "2026-08-04T08:00:00.000Z",
+  generated_by: 7,
+  status: "GENERATED" as const,
+  sent_at: null,
+  recipient_emails: [],
+  email_provider_id: null,
+  preview_path: "/commandes/123/documents/22222222-2222-4222-8222-222222222222/file",
+};
+
+describe("envoi AR claimé avant effet externe", () => {
+  it.each([
+    [403, "COMMAND_CHECKPOINT_FORBIDDEN"],
+    [409, "COMMAND_AR_SEND_NOT_ALLOWED"],
+    [409, "COMMAND_AR_STATUS_INVALID"],
+  ])("does not call the email provider when the atomic claim rejects (%s %s)", async (status, code) => {
+    mocks.claimSend.mockRejectedValueOnce(Object.assign(new Error(code), { status, code }));
+
+    await expect(svcSendCommandeAr({
+      commande_id: 123,
+      user_id: 7,
+      user_role: "Secretaire",
+      body: SEND_BODY,
+    })).rejects.toMatchObject({ status, code });
+
+    expect(mocks.sendEmail).not.toHaveBeenCalled();
+  });
+
+  it("lets only the claimed concurrent request call the provider and returns the persisted SENT replay", async () => {
+    const claim = { kind: "claimed" as const, client: {} as never, draft: GENERATED_DRAFT };
+    const persistedReplay = {
+      ...GENERATED_DRAFT,
+      status: "SENT" as const,
+      sent_at: "2026-08-04T08:05:00.000Z",
+      recipient_emails: ["persisted@example.test"],
+      email_provider_id: "provider-persisted",
+    };
+    mocks.claimSend
+      .mockResolvedValueOnce(claim)
+      .mockResolvedValueOnce({ kind: "replay", draft: persistedReplay });
+    mocks.readFile.mockResolvedValueOnce(Buffer.from("pdf"));
+    mocks.sendEmail.mockResolvedValueOnce({ ok: true, id: "provider-first" });
+    mocks.finalizeSend.mockResolvedValueOnce({
+      result: {
+        ar_id: SEND_BODY.ar_id,
+        commande_id: 123,
+        document_id: GENERATED_DRAFT.document_id,
+        status: "AR_ENVOYE",
+        sent_at: "2026-08-04T08:05:00.000Z",
+        recipient_emails: SEND_BODY.recipient_emails,
+        email_provider_id: "provider-first",
+      },
+      notifications: [],
+    });
+
+    const [first, replay] = await Promise.all([
+      svcSendCommandeAr({ commande_id: 123, user_id: 7, user_role: "Secretaire", body: SEND_BODY }),
+      svcSendCommandeAr({ commande_id: 123, user_id: 7, user_role: "Secretaire", body: SEND_BODY }),
+    ]);
+
+    expect(mocks.sendEmail).toHaveBeenCalledTimes(1);
+    expect(first.email_provider_id).toBe("provider-first");
+    expect(replay).toMatchObject({
+      recipient_emails: ["persisted@example.test"],
+      email_provider_id: "provider-persisted",
+    });
+  });
+});
 
 describe("accusé de réception — mentions légales", () => {
   it("uses the CERP document footer and repeats legal mentions on every page", async () => {

--- a/src/module/commande-client/services/commande-ar.service.ts
+++ b/src/module/commande-client/services/commande-ar.service.ts
@@ -20,9 +20,11 @@ import type {
 import type { SendCommandeArBodyDTO } from "../validators/commande-ar.validators";
 import {
   buildCommandeArRecipientSuggestions,
+  repoAbortCommandeArSendClaim,
+  repoAuthorizeCommandeArGeneration,
+  repoClaimCommandeArSend,
   repoCreateCommandeArDraft,
   repoFinalizeCommandeArSend,
-  repoGetCommandeArDraft,
   repoLoadCommandeArGenerationData,
   repoMarkCommandeArFailed,
 } from "../repository/commande-ar.repository";
@@ -229,9 +231,16 @@ export async function buildCommandeArPdfBuffer(params: {
 export async function svcGenerateCommandeAr(params: {
   commande_id: number;
   user_id: number;
+  user_role: string | null | undefined;
 }): Promise<CommandeArDraft> {
   const client = await pool.connect();
   try {
+    await repoAuthorizeCommandeArGeneration({
+      tx: client,
+      commande_id: params.commande_id,
+      user_id: params.user_id,
+      user_role: params.user_role,
+    });
     const data = await repoLoadCommandeArGenerationData(client, params.commande_id);
     if (!data) {
       throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable");
@@ -285,6 +294,7 @@ export async function svcGenerateCommandeAr(params: {
     const draft = await repoCreateCommandeArDraft({
       commande_id: params.commande_id,
       user_id: params.user_id,
+      user_role: params.user_role,
       document_name: documentName,
       pdf_buffer: pdfBuffer,
       subject,
@@ -323,74 +333,100 @@ export async function svcGenerateCommandeAr(params: {
 export async function svcSendCommandeAr(params: {
   commande_id: number;
   user_id: number;
+  user_role: string | null | undefined;
   body: SendCommandeArBodyDTO;
 }): Promise<CommandeArSendResult> {
-  const draft = await repoGetCommandeArDraft({ commande_id: params.commande_id, ar_id: params.body.ar_id });
-  if (!draft) {
-    throw new HttpError(404, "COMMANDE_AR_NOT_FOUND", "Accusé de réception introuvable");
-  }
-
-  const filePath = path.resolve(getDocumentStoragePath(), `${draft.document_id}.pdf`);
-  const pdfBuffer = await fs.readFile(filePath);
-
-  const baseText = draft.body_text?.trim() || `Veuillez trouver ci-joint l'accuse de reception de la commande.`;
-  const customMessage = params.body.message?.trim() || null;
-  const fullText = customMessage ? `${baseText}\n\n${customMessage}` : baseText;
-
-  const emailResult = await sendTransactionalEmail({
-    to: params.body.recipient_emails,
-    subject: draft.subject,
-    text: fullText,
-    html: buildEmailHtml(baseText, customMessage),
-    idempotencyKey: `commande-ar:${params.body.ar_id}`,
-    attachments: [
-      {
-        filename: draft.document_name,
-        content: pdfBuffer,
-        contentType: "application/pdf",
-      },
-    ],
-  });
-
-  if (!emailResult.ok) {
-    let statusCode = 502;
-    let message = "Erreur d'envoi de l'email";
-    if ("skipped" in emailResult && emailResult.skipped === true) {
-      statusCode = 503;
-      message = "Email non configuré sur le serveur";
-    } else if (isResendSendError(emailResult)) {
-      message = emailResult.error;
-    }
-    await repoMarkCommandeArFailed({
-      commande_id: params.commande_id,
-      ar_id: params.body.ar_id,
-      error_message: message,
-    });
-    throw new HttpError(statusCode, "COMMANDE_AR_SEND_FAILED", message);
-  }
-
-  const finalized = await repoFinalizeCommandeArSend({
+  const claimResult = await repoClaimCommandeArSend({
     commande_id: params.commande_id,
     ar_id: params.body.ar_id,
-    sent_by: params.user_id,
-    recipient_emails: params.body.recipient_emails,
-    recipient_contact_ids: params.body.recipient_contact_ids,
-    email_provider_id: emailResult.id ?? null,
-    commentaire: `AR envoyé à ${params.body.recipient_emails.join(", ")}`,
+    user_id: params.user_id,
+    user_role: params.user_role,
   });
-
-  for (const notification of finalized.notifications) {
-    emitAppNotificationCreated(notification.user_id, notification);
+  if (claimResult.kind === "replay") {
+    return {
+      ar_id: claimResult.draft.ar_id,
+      commande_id: params.commande_id,
+      document_id: claimResult.draft.document_id,
+      status: "AR_ENVOYE",
+      sent_at: claimResult.draft.sent_at ?? new Date().toISOString(),
+      recipient_emails: claimResult.draft.recipient_emails,
+      email_provider_id: claimResult.draft.email_provider_id,
+    };
   }
-  emitEntityChanged({
-    entityType: "commande_client",
-    entityId: String(params.commande_id),
-    action: "status_changed",
-    module: "commandes",
-    at: new Date().toISOString(),
-    by: { id: params.user_id, name: `User #${params.user_id}` },
-    invalidateKeys: ["commandes:list", `commandes:detail:${params.commande_id}`],
-  });
 
-  return finalized.result;
+  const claim = claimResult;
+  const draft = claim.draft;
+  let claimOpen = true;
+  try {
+    const filePath = path.resolve(getDocumentStoragePath(), `${draft.document_id}.pdf`);
+    const pdfBuffer = await fs.readFile(filePath);
+
+    const baseText = draft.body_text?.trim() || `Veuillez trouver ci-joint l'accuse de reception de la commande.`;
+    const customMessage = params.body.message?.trim() || null;
+    const fullText = customMessage ? `${baseText}\n\n${customMessage}` : baseText;
+
+    const emailResult = await sendTransactionalEmail({
+      to: params.body.recipient_emails,
+      subject: draft.subject,
+      text: fullText,
+      html: buildEmailHtml(baseText, customMessage),
+      idempotencyKey: `commande-ar:${params.body.ar_id}`,
+      attachments: [
+        {
+          filename: draft.document_name,
+          content: pdfBuffer,
+          contentType: "application/pdf",
+        },
+      ],
+    });
+
+    if (!emailResult.ok) {
+      let statusCode = 502;
+      let message = "Erreur d'envoi de l'email";
+      if ("skipped" in emailResult && emailResult.skipped === true) {
+        statusCode = 503;
+        message = "Email non configuré sur le serveur";
+      } else if (isResendSendError(emailResult)) {
+        message = emailResult.error;
+      }
+      claimOpen = false;
+      await repoMarkCommandeArFailed({
+        commande_id: params.commande_id,
+        ar_id: params.body.ar_id,
+        error_message: message,
+        claim,
+      });
+      throw new HttpError(statusCode, "COMMANDE_AR_SEND_FAILED", message);
+    }
+
+    claimOpen = false;
+    const finalized = await repoFinalizeCommandeArSend({
+      claim,
+      commande_id: params.commande_id,
+      ar_id: params.body.ar_id,
+      sent_by: params.user_id,
+      recipient_emails: params.body.recipient_emails,
+      recipient_contact_ids: params.body.recipient_contact_ids,
+      email_provider_id: emailResult.id ?? null,
+      commentaire: `AR envoyé à ${params.body.recipient_emails.join(", ")}`,
+    });
+
+    for (const notification of finalized.notifications) {
+      emitAppNotificationCreated(notification.user_id, notification);
+    }
+    emitEntityChanged({
+      entityType: "commande_client",
+      entityId: String(params.commande_id),
+      action: "status_changed",
+      module: "commandes",
+      at: new Date().toISOString(),
+      by: { id: params.user_id, name: `User #${params.user_id}` },
+      invalidateKeys: ["commandes:list", `commandes:detail:${params.commande_id}`],
+    });
+
+    return finalized.result;
+  } catch (err) {
+    if (claimOpen) await repoAbortCommandeArSendClaim(claim);
+    throw err;
+  }
 }

--- a/src/module/commande-client/services/commande-client.service.ts
+++ b/src/module/commande-client/services/commande-client.service.ts
@@ -19,7 +19,6 @@ import {
   repoRunCommandeWorkflowAction,
   repoUpdateCommandeWorkflowCheckpoint,
   repoUpdateCommande,
-  repoUpdateCommandeStatus,
 } from "../repository/commande-client.repository";
 
 import {
@@ -69,14 +68,16 @@ export const listCommandesSVC = (filters: ListCommandesQueryDTO) => repoListComm
 
 export const getCommandeSVC = (id: string, includes: Set<string>) => repoGetCommande(id, includes);
 
-export const getCommandeWorkflowSVC = (id: string) => repoGetCommandeWorkflow(id);
+export const getCommandeWorkflowSVC = (id: string, userId: number, userRole: string | null | undefined) =>
+  repoGetCommandeWorkflow(id, userId, userRole);
 
 export const updateCommandeWorkflowCheckpointSVC = (
   id: string,
   checkpointCode: string,
   body: UpdateCommandeWorkflowCheckpointBodyDTO,
-  userId: number | null
-) => repoUpdateCommandeWorkflowCheckpoint(id, checkpointCode, body, userId);
+  userId: number | null,
+  userRole: string | null
+) => repoUpdateCommandeWorkflowCheckpoint(id, checkpointCode, body, userId, userRole);
 
 export const runCommandeWorkflowActionSVC = (
   id: string,
@@ -88,14 +89,8 @@ export const runCommandeWorkflowActionSVC = (
 export const getCommandeDocumentFileMetaSVC = (commandeId: string, docId: string) =>
   repoGetCommandeDocumentFileMeta(commandeId, docId);
 
-export const deleteCommandeSVC = (id: string) => repoDeleteCommande(id);
-
-export const updateCommandeStatusSVC = (
-  id: string,
-  nouveau_statut: string,
-  commentaire: string | null,
-  userId: number | null
-) => repoUpdateCommandeStatus(id, nouveau_statut, commentaire, userId);
+export const deleteCommandeSVC = (id: string, userId: number, userRole: string | null) =>
+  repoDeleteCommande(id, { user_id: userId, user_role: userRole });
 
 export const analyzeCommandeStockSVC = (id: string, audit: CommandesAuditContext) => repoAnalyzeCommandeStock(id, audit);
 

--- a/src/module/commande-client/types/commande-ar.types.ts
+++ b/src/module/commande-client/types/commande-ar.types.ts
@@ -25,7 +25,7 @@ export type CommandeArSendResult = {
   ar_id: string;
   commande_id: number;
   document_id: string;
-  status: "AR_ENVOYEE";
+  status: "AR_ENVOYE";
   sent_at: string;
   recipient_emails: string[];
   email_provider_id: string | null;

--- a/src/module/commande-client/validators/commande-client.validators.ts
+++ b/src/module/commande-client/validators/commande-client.validators.ts
@@ -224,38 +224,6 @@ z.object({
 
 export type CreateCommandeBodyDTO = z.infer<typeof createCommandeBodySchema>;
 
-export const commandeWorkflowStatusSchema = z.enum([
-  "BROUILLON",
-  "EN_ANALYSE",
-  "ATTENTE_TECHNIQUE",
-  "ATTENTE_STOCK",
-  "ATTENTE_OF",
-  "ATTENTE_PLANNING",
-  "PLANNING_VALIDE",
-  "AR_PRET",
-  "AR_ENVOYE",
-  "EN_PRODUCTION",
-  "PRODUCTION_TERMINEE",
-  "CONTROLE_QUALITE",
-  "PRET_LIVRAISON",
-  "LIVRE",
-  "FACTURE",
-  "ARCHIVE",
-  "BLOQUE",
-  "ENREGISTREE",
-  "PLANIFIEE",
-  "AR_ENVOYEE",
-  "LIVREE",
-]);
-export type CommandeWorkflowStatusDTO = z.infer<typeof commandeWorkflowStatusSchema>;
-
-export const updateCommandeStatusBodySchema = z.object({
-  nouveau_statut: commandeWorkflowStatusSchema,
-  commentaire: z.string().optional().nullable(),
-});
-
-export type UpdateCommandeStatusBodyDTO = z.infer<typeof updateCommandeStatusBodySchema>;
-
 export const commandeCheckpointStatusSchema = z.enum(COMMANDE_CHECKPOINT_STATUSES);
 
 export const commandeWorkflowCheckpointCodeParamSchema = z.object({
@@ -267,7 +235,9 @@ export const commandeWorkflowCheckpointCodeParamSchema = z.object({
 
 export const updateCommandeWorkflowCheckpointBodySchema = z
   .object({
-    status: commandeCheckpointStatusSchema.optional(),
+    // Workflow progress is owned by POST /workflow/actions. PATCH is limited
+    // to assignment metadata and the reversible active <-> blocked control.
+    status: z.enum(["active", "blocked"]).optional(),
     assigned_user_id: z.coerce.number().int().positive().optional().nullable(),
     due_at: z.string().datetime().optional().nullable(),
     blocked_reason: z.string().max(20000).optional().nullable(),

--- a/src/module/commande-client/workflow/commande-client-workflow.definition.ts
+++ b/src/module/commande-client/workflow/commande-client-workflow.definition.ts
@@ -20,6 +20,26 @@ export const COMMANDE_WORKFLOW_STATUSES = [
 
 export type CommandeWorkflowStatus = (typeof COMMANDE_WORKFLOW_STATUSES)[number];
 
+export const COMMANDE_WORKFLOW_STATUS_LABELS: Record<CommandeWorkflowStatus, string> = {
+  BROUILLON: "Brouillon",
+  EN_ANALYSE: "En analyse",
+  ATTENTE_TECHNIQUE: "Attente technique",
+  ATTENTE_STOCK: "Attente contrôle stock",
+  ATTENTE_OF: "Attente lancement",
+  ATTENTE_PLANNING: "Attente planning",
+  PLANNING_VALIDE: "Planning validé",
+  AR_PRET: "AR prêt",
+  AR_ENVOYE: "AR envoyé",
+  EN_PRODUCTION: "En production",
+  PRODUCTION_TERMINEE: "Production terminée",
+  CONTROLE_QUALITE: "Contrôle qualité",
+  PRET_LIVRAISON: "Prêt livraison",
+  LIVRE: "Livré",
+  FACTURE: "Facturé",
+  ARCHIVE: "Archivé",
+  BLOQUE: "Bloqué",
+};
+
 export const COMMANDE_WORKFLOW_STATUS_ORDER: Record<CommandeWorkflowStatus, number> = {
   BROUILLON: 0,
   EN_ANALYSE: 1,
@@ -40,12 +60,114 @@ export const COMMANDE_WORKFLOW_STATUS_ORDER: Record<CommandeWorkflowStatus, numb
   BLOQUE: 99,
 };
 
-const LEGACY_STATUS_ALIASES: Record<string, CommandeWorkflowStatus> = {
+export const COMMANDE_WORKFLOW_LEGACY_STATUS_ALIASES: Record<string, CommandeWorkflowStatus> = {
   ENREGISTREE: "EN_ANALYSE",
   PLANIFIEE: "PLANNING_VALIDE",
   AR_ENVOYEE: "AR_ENVOYE",
   LIVREE: "LIVRE",
 };
+
+export const COMMANDE_WORKFLOW_TRANSITION_CAUSES = [
+  "checkpoint",
+  "customer_order_launch",
+  "internal_order_launch",
+  "internal_planning_validation",
+  "internal_production_launch",
+  "internal_archive",
+  "planning_sync",
+  "ar_send",
+  "shipment_sync",
+  "invoice_sync",
+  "block",
+  "resume",
+] as const;
+
+export type CommandeWorkflowTransitionCause = (typeof COMMANDE_WORKFLOW_TRANSITION_CAUSES)[number];
+
+export type CommandeWorkflowTransitionRule = {
+  from: CommandeWorkflowStatus;
+  to: CommandeWorkflowStatus;
+  cause: CommandeWorkflowTransitionCause;
+};
+
+const CHECKPOINT_TRANSITIONS: CommandeWorkflowTransitionRule[] = [
+  { from: "BROUILLON", to: "EN_ANALYSE", cause: "checkpoint" },
+  { from: "EN_ANALYSE", to: "ATTENTE_TECHNIQUE", cause: "checkpoint" },
+  { from: "ATTENTE_TECHNIQUE", to: "ATTENTE_STOCK", cause: "checkpoint" },
+  { from: "ATTENTE_STOCK", to: "ATTENTE_OF", cause: "checkpoint" },
+  { from: "ATTENTE_PLANNING", to: "PLANNING_VALIDE", cause: "checkpoint" },
+  { from: "PLANNING_VALIDE", to: "AR_PRET", cause: "checkpoint" },
+  { from: "AR_ENVOYE", to: "EN_PRODUCTION", cause: "checkpoint" },
+  { from: "EN_PRODUCTION", to: "PRODUCTION_TERMINEE", cause: "checkpoint" },
+  // The quality checkpoint owns the release decision. CONTROLE_QUALITE remains
+  // readable for historical/integration data, while the UI action may release
+  // directly from PRODUCTION_TERMINEE once the quality artifact is complete.
+  { from: "PRODUCTION_TERMINEE", to: "PRET_LIVRAISON", cause: "checkpoint" },
+  { from: "CONTROLE_QUALITE", to: "PRET_LIVRAISON", cause: "checkpoint" },
+  { from: "PRET_LIVRAISON", to: "LIVRE", cause: "checkpoint" },
+  { from: "LIVRE", to: "FACTURE", cause: "checkpoint" },
+  { from: "FACTURE", to: "ARCHIVE", cause: "checkpoint" },
+];
+
+export const COMMANDE_WORKFLOW_BLOCKABLE_STATUSES = COMMANDE_WORKFLOW_STATUSES.filter(
+  (status): status is Exclude<CommandeWorkflowStatus, "ARCHIVE" | "BLOQUE"> => status !== "ARCHIVE" && status !== "BLOQUE"
+);
+
+export const COMMANDE_WORKFLOW_TRANSITIONS: readonly CommandeWorkflowTransitionRule[] = [
+  ...CHECKPOINT_TRANSITIONS,
+  { from: "ATTENTE_OF", to: "ATTENTE_PLANNING", cause: "customer_order_launch" },
+  { from: "ATTENTE_OF", to: "PRET_LIVRAISON", cause: "customer_order_launch" },
+  // A legacy invalid planning state can be recovered by reopening the launch
+  // checkpoint while its append-only status history remains ATTENTE_PLANNING.
+  { from: "ATTENTE_PLANNING", to: "PRET_LIVRAISON", cause: "customer_order_launch" },
+  { from: "ATTENTE_TECHNIQUE", to: "ATTENTE_PLANNING", cause: "internal_order_launch" },
+  // Commands saved by the former guided flow may already have completed one
+  // or both customer-only preparation checkpoints. Keep their launch
+  // recoverable under the same INTERNE-only cause.
+  { from: "ATTENTE_STOCK", to: "ATTENTE_PLANNING", cause: "internal_order_launch" },
+  { from: "ATTENTE_OF", to: "ATTENTE_PLANNING", cause: "internal_order_launch" },
+  { from: "ATTENTE_PLANNING", to: "PLANNING_VALIDE", cause: "internal_planning_validation" },
+  { from: "PLANNING_VALIDE", to: "EN_PRODUCTION", cause: "internal_production_launch" },
+  { from: "LIVRE", to: "ARCHIVE", cause: "internal_archive" },
+  { from: "ATTENTE_PLANNING", to: "PLANNING_VALIDE", cause: "planning_sync" },
+  { from: "AR_PRET", to: "AR_ENVOYE", cause: "ar_send" },
+  { from: "PRET_LIVRAISON", to: "LIVRE", cause: "shipment_sync" },
+  { from: "LIVRE", to: "FACTURE", cause: "invoice_sync" },
+];
+
+export type CommandeWorkflowTransitionContext = {
+  resume_status?: CommandeWorkflowStatus | null;
+};
+
+export function isCanonicalCommandeWorkflowStatus(value: unknown): value is CommandeWorkflowStatus {
+  return typeof value === "string" && (COMMANDE_WORKFLOW_STATUSES as readonly string[]).includes(value);
+}
+
+export function canCommandeWorkflowTransition(
+  from: CommandeWorkflowStatus,
+  to: CommandeWorkflowStatus,
+  cause: CommandeWorkflowTransitionCause,
+  context: CommandeWorkflowTransitionContext = {}
+): boolean {
+  if (from === to) return true;
+  if (cause === "block") {
+    return to === "BLOQUE" && (COMMANDE_WORKFLOW_BLOCKABLE_STATUSES as readonly string[]).includes(from);
+  }
+  if (cause === "resume") {
+    return from === "BLOQUE" && context.resume_status === to;
+  }
+  return COMMANDE_WORKFLOW_TRANSITIONS.some(
+    (transition) => transition.from === from && transition.to === to && transition.cause === cause
+  );
+}
+
+export function getAllowedCommandeWorkflowTransitions(from: CommandeWorkflowStatus): readonly CommandeWorkflowStatus[] {
+  return [...new Set(
+    COMMANDE_WORKFLOW_TRANSITIONS
+      .filter((transition) => transition.from === from && transition.cause === "checkpoint")
+      .map((transition) => transition.to)
+  )];
+}
 
 export function normalizeCommandeWorkflowStatus(value: unknown): CommandeWorkflowStatus | null {
   if (typeof value !== "string") return null;
@@ -53,7 +175,7 @@ export function normalizeCommandeWorkflowStatus(value: unknown): CommandeWorkflo
   if ((COMMANDE_WORKFLOW_STATUSES as readonly string[]).includes(normalized)) {
     return normalized as CommandeWorkflowStatus;
   }
-  return LEGACY_STATUS_ALIASES[normalized] ?? null;
+  return COMMANDE_WORKFLOW_LEGACY_STATUS_ALIASES[normalized] ?? null;
 }
 
 export const COMMANDE_CHECKPOINT_STATUSES = ["pending", "active", "blocked", "done", "skipped"] as const;
@@ -248,3 +370,44 @@ export function getCommandeWorkflowAction(key: string) {
   const normalized = key.trim();
   return COMMANDE_WORKFLOW_ACTIONS.find((action) => action.key === normalized) ?? null;
 }
+
+export const COMMANDE_WORKFLOW_CONTRACT = {
+  schema_version: "1.0.0",
+  authority: "erp-crp-backend",
+  statuses: COMMANDE_WORKFLOW_STATUSES,
+  status_labels: COMMANDE_WORKFLOW_STATUS_LABELS,
+  status_order: COMMANDE_WORKFLOW_STATUS_ORDER,
+  checkpoint_statuses: COMMANDE_CHECKPOINT_STATUSES,
+  legacy_status_aliases: COMMANDE_WORKFLOW_LEGACY_STATUS_ALIASES,
+  checkpoint_transitions: Object.fromEntries(
+    COMMANDE_WORKFLOW_STATUSES.map((status) => [status, getAllowedCommandeWorkflowTransitions(status)])
+  ) as Record<CommandeWorkflowStatus, readonly CommandeWorkflowStatus[]>,
+  transition_rules: COMMANDE_WORKFLOW_TRANSITIONS,
+  transition_policies: {
+    block: {
+      from: "active checkpoint current status",
+      to: "BLOQUE",
+    },
+    resume: {
+      from: "BLOQUE",
+      to: "checkpoint metadata.previous_status_before_block",
+    },
+    system_replays: {
+      shipment_sync: ["LIVRE", "FACTURE", "ARCHIVE"],
+      invoice_sync: ["FACTURE", "ARCHIVE"],
+      planning_sync: [
+        "PLANNING_VALIDE",
+        "AR_PRET",
+        "AR_ENVOYE",
+        "EN_PRODUCTION",
+        "PRODUCTION_TERMINEE",
+        "CONTROLE_QUALITE",
+        "PRET_LIVRAISON",
+        "LIVRE",
+        "FACTURE",
+        "ARCHIVE",
+      ],
+    },
+  },
+  checkpoints: COMMANDE_WORKFLOW_CHECKPOINTS,
+} as const;

--- a/src/module/facturation/repository/facture-internal-order.repository.test.ts
+++ b/src/module/facturation/repository/facture-internal-order.repository.test.ts
@@ -1,0 +1,131 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  connect: vi.fn(),
+  clientQuery: vi.fn(),
+  release: vi.fn(),
+}));
+
+vi.mock("../../../config/database", () => ({
+  default: { query: mocks.poolQuery, connect: mocks.connect },
+}));
+
+import {
+  repoCreateFactureDraft,
+  repoIssueFacture,
+  repoListEligibleFactureSources,
+  repoPreviewFacture,
+} from "./facture-workflow.repository";
+
+const previewInput = {
+  client_id: "C01",
+  currency: "EUR",
+  sources: [{
+    source_type: "DELIVERY_LINE" as const,
+    source_id: "11111111-1111-4111-8111-111111111111",
+    source_line_id: "22222222-2222-4222-8222-222222222222",
+    quantity: "1.000",
+  }],
+  global_discount_percent: "0",
+  due_dates: [{ due_date: "2026-09-03", label: "Échéance" }],
+  internal_comment: null,
+  customer_text: null,
+};
+
+const actor = { userId: 7, requestId: "request-1", path: "/factures" };
+
+beforeEach(() => {
+  mocks.poolQuery.mockReset();
+  mocks.connect.mockReset();
+  mocks.clientQuery.mockReset();
+  mocks.release.mockReset();
+  mocks.connect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.release });
+});
+
+describe("commande INTERNE non facturable", () => {
+  it("exclut systématiquement les BL internes de la liste des sources", async () => {
+    mocks.poolQuery.mockResolvedValue({ rows: [] });
+
+    await expect(repoListEligibleFactureSources({ page: 1, pageSize: 25 })).resolves.toEqual({
+      items: [], total: 0, policy_active: false,
+    });
+
+    const sourceQueries = mocks.poolQuery.mock.calls
+      .map(([sql]) => String(sql))
+      .filter((sql) => sql.includes("bon_livraison"));
+    expect(sourceQueries).toHaveLength(2);
+    expect(sourceQueries.every((sql) => sql.includes("COALESCE(upper(cc.order_type), '') <> 'INTERNE'"))).toBe(true);
+  });
+
+  it("rend une source interne introuvable en preview puis bloque la création sans écriture", async () => {
+    mocks.poolQuery.mockResolvedValue({ rows: [] });
+    const preview = await repoPreviewFacture(previewInput);
+    expect(preview.lines).toEqual([]);
+    expect(preview.blockers).toEqual(expect.arrayContaining([
+      expect.objectContaining({ code: "SOURCE_NOT_FOUND", source_line_id: previewInput.sources[0].source_line_id }),
+    ]));
+
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query.includes("FROM public.finance_command_receipts")) return { rows: [] };
+      return { rows: [] };
+    });
+    await expect(repoCreateFactureDraft({
+      input: { ...previewInput, preview_hash: preview.preview_hash },
+      actor,
+      idempotencyKey: "internal-order-create-001",
+    })).rejects.toMatchObject({ status: 422, code: "FACTURE_PREVIEW_BLOCKED" });
+
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => /^\s*INSERT INTO public\.facture\s*\(/.test(String(sql)))).toBe(false);
+  });
+
+  it("refuse l'émission d'un ancien brouillon directement relié à une commande interne", async () => {
+    const writeDocument = vi.fn();
+    mocks.clientQuery.mockImplementation(async (sql: unknown) => {
+      const query = String(sql);
+      if (query.includes("FROM public.finance_command_receipts")) return { rows: [] };
+      if (query.includes("FROM public.facture") && query.includes("FOR UPDATE")) {
+        return {
+          rows: [{
+            id: 41,
+            uuid: "33333333-3333-4333-8333-333333333333",
+            statut: "APPROVED",
+            row_version: 3,
+            preview_hash: "a".repeat(64),
+            created_by: 6,
+            approved_by: 8,
+            legal_entity_code: "CRP",
+            draft_reference: "DFT-41",
+            client_snapshot: {},
+            issuer_snapshot: {},
+            currency: "EUR",
+            commentaires: null,
+            customer_text: null,
+          }],
+        };
+      }
+      if (query.includes("upper(COALESCE(linked_commande.order_type, '')) = 'INTERNE'")) {
+        return { rows: [{ blocked: true }] };
+      }
+      return { rows: [] };
+    });
+
+    await expect(repoIssueFacture({
+      factureId: 41,
+      input: { expected_version: 3, preview_hash: "a".repeat(64), confirm: true },
+      actor,
+      idempotencyKey: "internal-order-issue-001",
+      writeDocument,
+    })).rejects.toMatchObject({ status: 409, code: "INTERNAL_ORDER_NOT_BILLABLE" });
+
+    expect(writeDocument).not.toHaveBeenCalled();
+    const internalGuardSql = String(mocks.clientQuery.mock.calls.find(([sql]) =>
+      String(sql).includes("upper(COALESCE(linked_commande.order_type, '')) = 'INTERNE'")
+    )?.[0] ?? "");
+    expect(internalGuardSql).toContain("FROM public.facture_source_allocations source");
+    expect(internalGuardSql).toContain("JOIN public.bon_livraison delivery");
+    expect(internalGuardSql).toContain("upper(COALESCE(commande.order_type, '')) = 'INTERNE'");
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => /^\s*(UPDATE|INSERT)\s/i.test(String(sql)))).toBe(false);
+  });
+});

--- a/src/module/facturation/repository/facture-workflow.repository.ts
+++ b/src/module/facturation/repository/facture-workflow.repository.ts
@@ -127,7 +127,10 @@ async function loadActiveBillingPolicy(queryer: DbQueryer): Promise<BillingPolic
 }
 
 function listWhere(filters: EligibleSourcesQueryDTO): { sql: string; values: unknown[] } {
-  const where = [`bl.statut IN ('SHIPPED','DELIVERED')`];
+  const where = [
+    `bl.statut IN ('SHIPPED','DELIVERED')`,
+    `COALESCE(upper(cc.order_type), '') <> 'INTERNE'`,
+  ];
   const values: unknown[] = [];
   const push = (value: unknown) => {
     values.push(value);
@@ -176,6 +179,7 @@ const DELIVERY_SOURCE_SELECT = `
   FROM public.bon_livraison_ligne bll
   JOIN public.bon_livraison bl ON bl.id = bll.bon_livraison_id
   JOIN public.clients c ON c.client_id = bl.client_id
+  LEFT JOIN public.commande_client cc ON cc.id = bl.commande_id
   LEFT JOIN public.commande_ligne cl ON cl.id = bll.commande_ligne_id
   LEFT JOIN LATERAL (
     SELECT COALESCE(SUM(source.quantity_consumed), 0) AS quantity
@@ -284,6 +288,7 @@ export async function repoListEligibleFactureSources(
       FROM public.bon_livraison_ligne bll
       JOIN public.bon_livraison bl ON bl.id = bll.bon_livraison_id
       JOIN public.clients c ON c.client_id = bl.client_id
+      LEFT JOIN public.commande_client cc ON cc.id = bl.commande_id
       ${sql}
     `,
     values
@@ -316,6 +321,7 @@ async function loadSelectedDeliverySources(
       ${DELIVERY_SOURCE_SELECT}
       WHERE bll.id = ANY($1::uuid[])
         AND bl.statut IN ('SHIPPED','DELIVERED')
+        AND COALESCE(upper(cc.order_type), '') <> 'INTERNE'
       ORDER BY bll.id
       ${lock ? "FOR UPDATE OF bll" : ""}
     `,
@@ -891,6 +897,7 @@ async function transitionFacture(params: {
     }
     const facture = await lockFacture(client, params.factureId);
     if (!facture) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
+    await repoAssertFactureHasNoInternalSource(client, params.factureId);
     if (facture.statut !== params.expectedStatus) {
       throw new HttpError(409, "FACTURE_STATUS_CONFLICT", "Le statut de la facture a changé.");
     }
@@ -964,6 +971,37 @@ async function transitionFacture(params: {
     throw error;
   } finally {
     client.release();
+  }
+}
+
+export async function repoAssertFactureHasNoInternalSource(
+  queryer: DbQueryer,
+  factureId: number
+): Promise<void> {
+  const internalSource = await queryer.query<{ blocked: boolean }>(
+    `
+      SELECT EXISTS (
+        SELECT 1
+        FROM public.facture facture
+        JOIN public.commande_client linked_commande ON linked_commande.id = facture.commande_id
+        WHERE facture.id = $1
+          AND upper(COALESCE(linked_commande.order_type, '')) = 'INTERNE'
+      ) OR EXISTS (
+        SELECT 1
+        FROM public.facture_source_allocations source
+        JOIN public.bon_livraison_ligne delivery_line
+          ON source.source_type = 'DELIVERY_LINE'
+         AND source.source_line_id = delivery_line.id::text
+        JOIN public.bon_livraison delivery ON delivery.id = delivery_line.bon_livraison_id
+        JOIN public.commande_client commande ON commande.id = delivery.commande_id
+        WHERE source.facture_id = $1
+          AND upper(COALESCE(commande.order_type, '')) = 'INTERNE'
+      ) AS blocked
+    `,
+    [factureId]
+  );
+  if (internalSource.rows[0]?.blocked === true) {
+    throw new HttpError(409, "INTERNAL_ORDER_NOT_BILLABLE", "Une commande interne ne peut pas être facturée.");
   }
 }
 
@@ -1096,6 +1134,7 @@ export async function repoIssueFacture(params: {
     }
     const facture = await lockFacture(client, params.factureId);
     if (!facture) throw new HttpError(404, "FACTURE_NOT_FOUND", "Facture introuvable.");
+    await repoAssertFactureHasNoInternalSource(client, params.factureId);
     if (facture.statut !== "APPROVED") {
       throw new HttpError(409, "FACTURE_NOT_APPROVED", "La facture doit être validée avant émission.");
     }

--- a/src/module/facturation/repository/factures-internal-order.repository.test.ts
+++ b/src/module/facturation/repository/factures-internal-order.repository.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  query: vi.fn(),
+  release: vi.fn(),
+}));
+
+vi.mock("../../../config/database", () => ({
+  default: { connect: mocks.connect, query: vi.fn() },
+}));
+
+import { repoCreateFacture, repoUpdateFacture } from "./factures.repository";
+
+beforeEach(() => {
+  mocks.connect.mockReset();
+  mocks.query.mockReset();
+  mocks.release.mockReset();
+  mocks.connect.mockResolvedValue({ query: mocks.query, release: mocks.release });
+});
+
+describe("legacy invoices cannot target internal orders", () => {
+  it("refuse la création avant séquence et INSERT", async () => {
+    mocks.query.mockImplementation(async (sql: unknown) => {
+      if (String(sql).includes("FROM public.commande_client")) return { rows: [{ order_type: "INTERNE" }] };
+      return { rows: [] };
+    });
+
+    await expect(repoCreateFacture({
+      client_id: "C01",
+      commande_id: 123,
+      statut: "DRAFT",
+      remise_globale: 0,
+      lignes: [{ designation: "Pièce", quantite: 1, prix_unitaire_ht: 10, remise_ligne: 0, taux_tva: 20 }],
+    })).rejects.toMatchObject({ status: 409, code: "INTERNAL_ORDER_NOT_BILLABLE" });
+
+    expect(mocks.query.mock.calls.some(([sql]) => String(sql).includes("nextval('public.facture_id_seq')"))).toBe(false);
+    expect(mocks.query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO facture"))).toBe(false);
+  });
+
+  it("verrouille d'abord la facture puis refuse le PATCH vers une commande interne avant toute modification", async () => {
+    mocks.query.mockImplementation(async (sql: unknown) => {
+      if (String(sql).includes("FROM facture") && String(sql).includes("FOR UPDATE")) {
+        return { rows: [{ id: "41", remise_globale: 0, statut: "DRAFT", commande_id: null }] };
+      }
+      if (String(sql).includes("FROM public.commande_client")) return { rows: [{ order_type: "INTERNE" }] };
+      return { rows: [] };
+    });
+
+    await expect(repoUpdateFacture(41, { commande_id: 123 }))
+      .rejects.toMatchObject({ status: 409, code: "INTERNAL_ORDER_NOT_BILLABLE" });
+
+    const invoiceLockIndex = mocks.query.mock.calls.findIndex(([sql]) =>
+      String(sql).includes("FROM facture") && String(sql).includes("FOR UPDATE")
+    );
+    const commandLockIndex = mocks.query.mock.calls.findIndex(([sql]) =>
+      String(sql).includes("FROM public.commande_client") && String(sql).includes("FOR SHARE")
+    );
+    expect(invoiceLockIndex).toBeGreaterThanOrEqual(0);
+    expect(commandLockIndex).toBeGreaterThan(invoiceLockIndex);
+    expect(mocks.query.mock.calls.some(([sql]) => /^\s*UPDATE facture/i.test(String(sql)))).toBe(false);
+  });
+});

--- a/src/module/facturation/repository/factures.repository.ts
+++ b/src/module/facturation/repository/factures.repository.ts
@@ -555,6 +555,18 @@ async function insertFactureLines(client: PoolClient, factureId: number, lignes:
   );
 }
 
+async function assertLegacyInvoiceCommandeBillable(client: PoolClient, commandeId: number): Promise<void> {
+  const commande = await client.query<{ order_type: string | null }>(
+    `SELECT order_type FROM public.commande_client WHERE id = $1::bigint FOR SHARE`,
+    [commandeId]
+  );
+  const row = commande.rows[0];
+  if (!row) throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable.");
+  if (String(row.order_type ?? "").toUpperCase() === "INTERNE") {
+    throw new HttpError(409, "INTERNAL_ORDER_NOT_BILLABLE", "Une commande interne ne peut pas être facturée.");
+  }
+}
+
 export async function repoCreateFacture(input: CreateFactureBodyDTO) {
   if (input.numero !== undefined) {
     throw new HttpError(400, "FACTURE_NUMERO_SERVER_MANAGED", "Le numéro légal de facture est attribué automatiquement.");
@@ -562,6 +574,10 @@ export async function repoCreateFacture(input: CreateFactureBodyDTO) {
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
+
+    if (input.commande_id !== undefined && input.commande_id !== null) {
+      await assertLegacyInvoiceCommandeBillable(client, input.commande_id);
+    }
 
     const seq = await client.query<{ id: string }>(`SELECT nextval('public.facture_id_seq')::bigint::text AS id`);
     const idRaw = seq.rows[0]?.id;
@@ -642,9 +658,14 @@ export async function repoUpdateFacture(id: number, input: UpdateFactureBodyDTO)
       id: string;
       remise_globale: number;
       statut: string;
+      commande_id: number | null;
     }>(
       `
-      SELECT id::text AS id, remise_globale::float8 AS remise_globale, statut
+      SELECT
+        id::text AS id,
+        remise_globale::float8 AS remise_globale,
+        statut,
+        commande_id::int AS commande_id
       FROM facture
       WHERE id = $1
       FOR UPDATE
@@ -656,6 +677,13 @@ export async function repoUpdateFacture(id: number, input: UpdateFactureBodyDTO)
       await client.query("ROLLBACK");
       return null;
     }
+    // Finance uses one global order: invoice first, then its linked command.
+    // This matches issue/validation flows and prevents a PATCH/issue deadlock.
+    const targetCommandeId = input.commande_id !== undefined ? input.commande_id : base.commande_id;
+    if (targetCommandeId !== null && targetCommandeId !== undefined) {
+      await assertLegacyInvoiceCommandeBillable(client, targetCommandeId);
+    }
+
     if (!["DRAFT", "brouillon"].includes(base.statut)) {
       throw new HttpError(
         409,

--- a/src/module/livraisons/repository/livraisons-shipment.repository.test.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.test.ts
@@ -2,7 +2,98 @@ import type { PoolClient } from "pg";
 import { describe, expect, it, vi } from "vitest";
 
 import { prepareLivraisonInTransaction } from "./livraisons-shipment.repository";
-import { attachActiveCommandeReservationsToLivraison } from "./livraisons.repository";
+import {
+  attachActiveCommandeReservationsToLivraison,
+  repoCreateLivraisonFromCommande,
+} from "./livraisons.repository";
+
+describe("internal order delivery gate", () => {
+  it("creates no BL artifact before the post-quality PRET_LIVRAISON milestone", async () => {
+    const query = vi.fn(async (sql: string, _values?: unknown[]) => {
+      if (sql.includes("FROM public.commande_client cc")) {
+        return {
+          rows: [{
+            id: 12,
+            numero: "CI-12",
+            client_id: null,
+            order_type: "INTERNE",
+            raw_statut: "PRODUCTION_TERMINEE",
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+    const tx = { query } as unknown as PoolClient;
+
+    await expect(repoCreateLivraisonFromCommande(12, 7, tx)).rejects.toMatchObject({
+      status: 409,
+      code: "INTERNAL_DELIVERY_QUALITY_RELEASE_REQUIRED",
+    });
+
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO bon_livraison"))).toBe(false);
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("bon_livraison_no_seq"))).toBe(false);
+  });
+
+  it("resolves the configured internal client and records the stock destination after quality", async () => {
+    const internalClientId = "CERP-INTERNE";
+    const warehouseId = "11111111-1111-4111-8111-111111111111";
+    const deliveryId = "22222222-2222-4222-8222-222222222222";
+    const query = vi.fn(async (sql: string, _values?: unknown[]) => {
+      if (sql.includes("FROM public.commande_client cc")) {
+        return {
+          rows: [{
+            id: 12,
+            numero: "CI-12",
+            client_id: null,
+            order_type: "INTERNE",
+            raw_statut: "PRET_LIVRAISON",
+            dest_stock_magasin_id: warehouseId,
+            dest_stock_emplacement_id: 42,
+          }],
+        };
+      }
+      if (sql.includes("commandes.internal_client_id")) return { rows: [{ value_text: internalClientId }] };
+      if (sql.includes("FROM pg_attribute")) return { rows: [{ ok: 1 }] };
+      if (sql.includes("FROM commande_to_affaire") || sql.includes("FROM public.commande_to_affaire")) {
+        return { rows: [{ affaire_id: 91 }] };
+      }
+      if (sql.includes("bon_livraison_no_seq")) return { rows: [{ n: "8" }] };
+      if (sql.includes("INSERT INTO bon_livraison (")) return { rows: [{ id: deliveryId }] };
+      if (sql.includes("v_bon_livraison_reliquats_226")) {
+        return {
+          rows: [{
+            id: 501,
+            designation: "Pièce interne",
+            code_piece: "INT-01",
+            quantite: 2,
+            unite: "u",
+            delai_client: null,
+          }],
+        };
+      }
+      if (sql.includes("FROM public.bon_livraison_ligne delivery_line")) return { rows: [] };
+      if (sql.includes("SELECT NOT EXISTS(")) return { rows: [{ complete: false }] };
+      return { rows: [] };
+    });
+    const tx = { query } as unknown as PoolClient;
+
+    await expect(repoCreateLivraisonFromCommande(12, 7, tx)).resolves.toEqual({ id: deliveryId });
+
+    const insert = query.mock.calls.find(([sql]) => String(sql).includes("INSERT INTO bon_livraison ("));
+    expect(insert?.[1]).toEqual([
+      "BL-00000008",
+      internalClientId,
+      12,
+      91,
+      null,
+      `Destination stock interne: magasin ${warehouseId}, emplacement 42`,
+      7,
+    ]);
+    const event = query.mock.calls.find(([sql]) => String(sql).includes("INSERT INTO bon_livraison_event_log"));
+    expect(String(event?.[1]?.[3])).toContain(`\"magasin_id\":\"${warehouseId}\"`);
+    expect(String(event?.[1]?.[3])).toContain("\"emplacement_id\":42");
+  });
+});
 
 describe("prepareLivraisonInTransaction", () => {
   it("reuses an active production reservation without reserving stock twice", async () => {

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -7,6 +7,7 @@ import pool from "../../../config/database"
 import { canonicalizeStockUnitCode } from "../../../shared/stock-unit"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
+import { normalizeCommandeWorkflowStatus } from "../../commande-client/workflow/commande-client-workflow.definition"
 
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
 import { isLivraisonTransitionAllowed } from "../domain/livraisons-policy"
@@ -2507,18 +2508,86 @@ export async function repoCreateLivraisonFromCommande(
   try {
     if (ownsTransaction) await db.query("BEGIN")
 
-    const cmdRes = await db.query<{ id: number; numero: string; client_id: string }>(
-      `SELECT id, numero, client_id FROM commande_client WHERE id = $1`,
+    const cmdRes = await db.query<{
+      id: number
+      numero: string
+      client_id: string | null
+      order_type: string | null
+      raw_statut: string | null
+      dest_stock_magasin_id: string | null
+      dest_stock_emplacement_id: number | null
+    }>(
+      `
+        SELECT
+          cc.id,
+          cc.numero,
+          cc.client_id,
+          cc.order_type,
+          cc.dest_stock_magasin_id::text AS dest_stock_magasin_id,
+          cc.dest_stock_emplacement_id::int AS dest_stock_emplacement_id,
+          st.nouveau_statut AS raw_statut
+        FROM public.commande_client cc
+        LEFT JOIN LATERAL (
+          SELECT ch.nouveau_statut
+          FROM public.commande_historique ch
+          WHERE ch.commande_id = cc.id
+          ORDER BY ch.date_action DESC, ch.id DESC
+          LIMIT 1
+        ) st ON TRUE
+        WHERE cc.id = $1
+        FOR UPDATE OF cc
+      `,
       [commandeId]
     )
     const cmd = cmdRes.rows[0] ?? null
     if (!cmd) throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande not found")
 
-    const clientRes = await db.query<{ delivery_address_id: string | null }>(
-      `SELECT delivery_address_id::text AS delivery_address_id FROM clients WHERE client_id = $1`,
-      [cmd.client_id]
-    )
-    const deliveryAddressId = clientRes.rows[0]?.delivery_address_id ?? null
+    const internalOrder = String(cmd.order_type ?? "").toUpperCase() === "INTERNE"
+    const currentStatus = cmd.raw_statut === null ? "BROUILLON" : normalizeCommandeWorkflowStatus(cmd.raw_statut)
+    if (!currentStatus) {
+      throw new HttpError(409, "COMMAND_STATUS_HISTORY_INVALID", "Le dernier statut de la commande est inconnu.")
+    }
+    if (internalOrder && currentStatus !== "PRET_LIVRAISON") {
+      throw new HttpError(
+        409,
+        "INTERNAL_DELIVERY_QUALITY_RELEASE_REQUIRED",
+        "Le BL interne ne peut être créé qu'après fabrication et libération qualité."
+      )
+    }
+    if (internalOrder && (!cmd.dest_stock_magasin_id || cmd.dest_stock_emplacement_id === null)) {
+      throw new HttpError(
+        409,
+        "INTERNAL_STOCK_DESTINATION_REQUIRED",
+        "La destination magasin/emplacement de la commande interne est obligatoire pour créer le BL."
+      )
+    }
+
+    let deliveryClientId = cmd.client_id
+    if (internalOrder && !deliveryClientId) {
+      const setting = await db.query<{ value_text: string | null }>(
+        `SELECT value_text FROM public.erp_settings WHERE key = 'commandes.internal_client_id' LIMIT 1`
+      )
+      deliveryClientId = setting.rows[0]?.value_text?.trim() || null
+    }
+    if (!deliveryClientId) {
+      throw new HttpError(
+        409,
+        internalOrder ? "INTERNAL_CLIENT_REQUIRED" : "COMMANDE_CLIENT_REQUIRED",
+        "Un client de livraison doit être configuré pour créer le BL."
+      )
+    }
+
+    let deliveryAddressId: string | null = null
+    if (!internalOrder) {
+      const clientRes = await db.query<{ delivery_address_id: string | null }>(
+        `SELECT delivery_address_id::text AS delivery_address_id FROM clients WHERE client_id = $1`,
+        [deliveryClientId]
+      )
+      deliveryAddressId = clientRes.rows[0]?.delivery_address_id ?? null
+    }
+    const internalDestination = internalOrder
+      ? `Destination stock interne: magasin ${cmd.dest_stock_magasin_id}, emplacement ${cmd.dest_stock_emplacement_id}`
+      : null
 
     const hasRoleColumn = await hasCommandeToAffaireRoleColumn(db)
     const affaireSql = hasRoleColumn
@@ -2558,14 +2627,15 @@ export async function repoCreateLivraisonFromCommande(
           commande_id,
           affaire_id,
           adresse_livraison_id,
+          commentaire_interne,
           statut,
           date_creation,
           created_by,
           updated_by
-        ) VALUES ($1,$2,$3,$4,$5::uuid,'DRAFT',CURRENT_DATE,$6,$6)
+        ) VALUES ($1,$2,$3,$4,$5::uuid,$6,'DRAFT',CURRENT_DATE,$7,$7)
         RETURNING id::text AS id
         `,
-        [numero, cmd.client_id, cmd.id, affaireId, deliveryAddressId, userId]
+        [numero, deliveryClientId, cmd.id, affaireId, deliveryAddressId, internalDestination, userId]
       )
 
       id = ins.rows[0]?.id ?? ""
@@ -2657,6 +2727,12 @@ export async function repoCreateLivraisonFromCommande(
         numero,
         commande_id: cmd.id,
         commande_numero: cmd.numero,
+        internal_stock_destination: internalOrder
+          ? {
+              magasin_id: cmd.dest_stock_magasin_id,
+              emplacement_id: cmd.dest_stock_emplacement_id,
+            }
+          : null,
         reservations_transferred: transferredReservations.attached,
         prepared: transferredReservations.fullyAllocated,
       },

--- a/src/module/planning/repository/planning-checkpoint-access.repository.test.ts
+++ b/src/module/planning/repository/planning-checkpoint-access.repository.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { repoAssertPlanningCheckpointAccess } from "./planning.repository";
+
+function queryer(checkpoint: { status: string; responsible_role: string; assigned_user_id: number | null }) {
+  return {
+    query: vi.fn().mockResolvedValue({ rows: [checkpoint] }),
+  };
+}
+
+describe("planning checkpoint deep authorization", () => {
+  it("refuse un secrétaire non assigné sans écrire l'historique", async () => {
+    const tx = queryer({ status: "active", responsible_role: "planning", assigned_user_id: null });
+
+    await expect(repoAssertPlanningCheckpointAccess({
+      tx: tx as never,
+      commande_id: 123,
+      user_id: 7,
+      user_role: "Secretaire",
+    })).rejects.toMatchObject({ status: 403, code: "WORKFLOW_CHECKPOINT_FORBIDDEN" });
+
+    expect(tx.query).toHaveBeenCalledTimes(2);
+    expect(String(tx.query.mock.calls[0]?.[0])).toContain("FROM public.commande_client");
+    expect(String(tx.query.mock.calls[0]?.[0])).toContain("FOR UPDATE");
+    expect(String(tx.query.mock.calls[1]?.[0])).toContain("commande_client_workflow_checkpoint");
+    expect(tx.query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO commande_historique"))).toBe(false);
+  });
+
+  it("refuse un employé assigné à un autre utilisateur", async () => {
+    const tx = queryer({ status: "active", responsible_role: "planning", assigned_user_id: 8 });
+
+    await expect(repoAssertPlanningCheckpointAccess({
+      tx: tx as never,
+      commande_id: 123,
+      user_id: 7,
+      user_role: "Employee",
+    })).rejects.toMatchObject({ status: 403, code: "WORKFLOW_CHECKPOINT_FORBIDDEN" });
+  });
+
+  it.each([
+    ["l'utilisateur assigné", "Employee", 7],
+    ["le rôle planning", "Planification", null],
+    ["l'administrateur", "Administrateur Systeme et Reseau", null],
+  ])("autorise %s", async (_label, role, assignedUserId) => {
+    const tx = queryer({ status: "active", responsible_role: "planning", assigned_user_id: assignedUserId });
+
+    await expect(repoAssertPlanningCheckpointAccess({
+      tx: tx as never,
+      commande_id: 123,
+      user_id: 7,
+      user_role: role,
+    })).resolves.toBeUndefined();
+  });
+});

--- a/src/module/planning/repository/planning.repository.ts
+++ b/src/module/planning/repository/planning.repository.ts
@@ -9,7 +9,8 @@ import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
-import { repoEnsureCommandeWorkflowStatus } from "../../commande-client/repository/commande-client.repository";
+import { repoApplyCommandeWorkflowMilestone } from "../../commande-client/repository/commande-client.repository";
+import { canActOnCommandeWorkflowCheckpoint } from "../../commande-client/domain/commande-client-rbac";
 import type { AppNotification } from "../../notifications/types/notifications.types";
 import { roleCanForcePlanningOverlap } from "../domain/planning-rbac";
 import type {
@@ -637,6 +638,7 @@ async function syncLinkedOfOperationFromPlanning(params: {
   tx: DbQueryer;
   of_operation_id: string;
   user_id: number;
+  user_role: string | null | undefined;
 }): Promise<{ of_id: number | null; notifications: AppNotification[] }> {
   const summary = await params.tx.query<{
     of_id: string;
@@ -704,6 +706,7 @@ async function syncLinkedOfOperationFromPlanning(params: {
     tx: params.tx,
     of_id: ofId,
     user_id: params.user_id,
+    user_role: params.user_role,
   });
 
   return { of_id: ofId, notifications };
@@ -713,6 +716,7 @@ async function maybePromoteOfAndCommandeAfterPlanning(params: {
   tx: DbQueryer;
   of_id: number;
   user_id: number;
+  user_role: string | null | undefined;
 }): Promise<AppNotification[]> {
   const statusRes = await params.tx.query<{
     statut: string;
@@ -722,12 +726,14 @@ async function maybePromoteOfAndCommandeAfterPlanning(params: {
     done_ops: number;
     running_ops: number;
     active_events: number;
+    order_type: string | null;
   }>(
     `
       SELECT
         o.statut::text AS statut,
         o.commande_id::text AS commande_id,
         o.numero,
+        cc.order_type,
         COUNT(op.id)::int AS total_ops,
         COUNT(op.id) FILTER (WHERE op.status = 'DONE'::of_operation_status)::int AS done_ops,
         COUNT(op.id) FILTER (WHERE op.status = 'RUNNING'::of_operation_status)::int AS running_ops,
@@ -760,8 +766,9 @@ async function maybePromoteOfAndCommandeAfterPlanning(params: {
                  WHERE r.of_id = o.id AND r.statut = 'ACTIVE'
               )
             )
+      LEFT JOIN public.commande_client cc ON cc.id = o.commande_id
       WHERE o.id = $1::bigint
-      GROUP BY o.id, o.statut, o.commande_id, o.numero
+      GROUP BY o.id, o.statut, o.commande_id, o.numero, cc.order_type
       LIMIT 1
     `,
     [params.of_id]
@@ -803,16 +810,69 @@ async function maybePromoteOfAndCommandeAfterPlanning(params: {
 
   const commandeId = toNullableInt(row.commande_id, "ordres_fabrication.commande_id");
   if (!commandeId || row.active_events <= 0) return [];
+  const internalOrder = String(row.order_type ?? "").toUpperCase() === "INTERNE";
 
-  const workflow = await repoEnsureCommandeWorkflowStatus({
+  await repoAssertPlanningCheckpointAccess({
     tx: params.tx,
     commande_id: commandeId,
-    nouveau_statut: "PLANIFIEE",
+    user_id: params.user_id,
+    user_role: params.user_role,
+  });
+
+  const workflow = await repoApplyCommandeWorkflowMilestone({
+    tx: params.tx,
+    commande_id: commandeId,
+    nouveau_statut: "PLANNING_VALIDE",
+    cause: internalOrder ? "internal_planning_validation" : "planning_sync",
     commentaire: `Commande automatiquement planifiée à partir de l'OF ${row.numero}`,
     user_id: params.user_id,
+    completed_checkpoint_codes: ["planning_validation"],
+    active_checkpoint_code: internalOrder ? "production_launch" : "ar_preparation",
   });
 
   return workflow.notifications;
+}
+
+export async function repoAssertPlanningCheckpointAccess(params: {
+  tx: DbQueryer;
+  commande_id: number;
+  user_id: number;
+  user_role: string | null | undefined;
+}): Promise<void> {
+  // Global workflow lock order is commande_client -> checkpoint. Keeping the
+  // same order as generic workflow actions prevents a command/checkpoint
+  // inversion when planning auto-promotion runs concurrently.
+  const commande = await params.tx.query<{ id: number }>(
+    `SELECT id::int AS id FROM public.commande_client WHERE id = $1::bigint FOR UPDATE`,
+    [params.commande_id]
+  );
+  if (!commande.rows[0]) throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable.");
+  const checkpoint = await params.tx.query<{
+    status: string;
+    responsible_role: string;
+    assigned_user_id: number | null;
+  }>(
+    `
+      SELECT status, responsible_role, assigned_user_id::int AS assigned_user_id
+      FROM public.commande_client_workflow_checkpoint
+      WHERE commande_id = $1::bigint AND checkpoint_code = 'planning_validation'
+      FOR UPDATE
+    `,
+    [params.commande_id]
+  );
+  const row = checkpoint.rows[0];
+  if (!row) throw new HttpError(409, "COMMAND_CHECKPOINT_MISSING", "Le checkpoint planning est absent.");
+  if (!canActOnCommandeWorkflowCheckpoint({
+    user_id: params.user_id,
+    user_role: params.user_role,
+    responsible_role: row.responsible_role,
+    assigned_user_id: row.assigned_user_id,
+  })) {
+    throw new HttpError(403, "WORKFLOW_CHECKPOINT_FORBIDDEN", "Le planning est attribué à un autre rôle ou utilisateur.");
+  }
+  if (row.status !== "active" && row.status !== "done") {
+    throw new HttpError(409, "CHECKPOINT_NOT_ACTIVE", "Le checkpoint planning n'est pas actif.");
+  }
 }
 
 async function loadCommandeIdForOf(tx: DbQueryer, ofId: number): Promise<number | null> {
@@ -888,6 +948,7 @@ export async function repoValidatePlanningForAr(params: {
       client_id: string | null;
       planning_validated_at: string | null;
       ar_sent_at: string | null;
+      order_type: string | null;
     };
 
     const candidatesRes = await client.query<CandidateRow>(
@@ -905,6 +966,7 @@ export async function repoValidatePlanningForAr(params: {
           cc.client_id::text AS client_id,
           cc.planning_validated_at::text AS planning_validated_at,
           cc.ar_sent_at::text AS ar_sent_at
+          ,cc.order_type
         FROM public.commande_client cc
         JOIN candidate_ids ci ON ci.commande_id = cc.id
         ORDER BY cc.numero ASC, cc.id ASC
@@ -942,10 +1004,11 @@ export async function repoValidatePlanningForAr(params: {
 
     const commentaire =
       params.body.commentaire?.trim() ||
-      "Planning valide depuis le planning atelier; AR pret pour preparation manuelle.";
+      "Planning validé depuis le planning atelier ; AR à préparer manuellement.";
 
     for (const row of candidates) {
       const commandeId = toInt(row.commande_id, "commande_client.id");
+      const internalOrder = String(row.order_type ?? "").toUpperCase() === "INTERNE";
       if (row.ar_sent_at) {
         skipped.push({
           commande_id: commandeId,
@@ -961,20 +1024,29 @@ export async function repoValidatePlanningForAr(params: {
           commande_id: commandeId,
           numero: row.numero,
           reason: "ALREADY_READY",
-          message: "Planning deja valide; AR pret.",
+          message: "Planning déjà validé ; AR à préparer.",
         });
         continue;
       }
 
       await client.query("SAVEPOINT planning_validate_commande");
       let transition;
+      await repoAssertPlanningCheckpointAccess({
+        tx: client,
+        commande_id: commandeId,
+        user_id: params.audit.user_id,
+        user_role: params.audit.role,
+      });
       try {
-        transition = await repoEnsureCommandeWorkflowStatus({
+        transition = await repoApplyCommandeWorkflowMilestone({
           tx: client,
           commande_id: commandeId,
-          nouveau_statut: "AR_PRET",
+          nouveau_statut: "PLANNING_VALIDE",
+          cause: internalOrder ? "internal_planning_validation" : "planning_sync",
           commentaire,
           user_id: params.audit.user_id,
+          completed_checkpoint_codes: ["planning_validation"],
+          active_checkpoint_code: internalOrder ? "production_launch" : "ar_preparation",
         });
       } catch (err) {
         await client.query("ROLLBACK TO SAVEPOINT planning_validate_commande");
@@ -992,33 +1064,6 @@ export async function repoValidatePlanningForAr(params: {
       await client.query("RELEASE SAVEPOINT planning_validate_commande");
       notifications.push(...transition.notifications);
 
-      await client.query(
-        `
-          UPDATE public.commande_client_workflow_checkpoint
-          SET
-            status = 'done',
-            completed_at = COALESCE(completed_at, now()),
-            completed_by = COALESCE(completed_by, $2::int),
-            notes = COALESCE($3, notes),
-            updated_at = now()
-          WHERE commande_id = $1
-            AND checkpoint_code IN ('planning_validation', 'ar_preparation')
-            AND status <> 'done'
-        `,
-        [commandeId, params.audit.user_id, commentaire]
-      );
-
-      await client.query(
-        `
-          UPDATE public.commande_client_workflow_checkpoint
-          SET status = 'active', updated_at = now()
-          WHERE commande_id = $1
-            AND checkpoint_code = 'ar_sent'
-            AND status = 'pending'
-        `,
-        [commandeId]
-      );
-
       const milestone = await client.query<{ planning_validated_at: string | null }>(
         `SELECT planning_validated_at::text AS planning_validated_at FROM public.commande_client WHERE id = $1::bigint LIMIT 1`,
         [commandeId]
@@ -1029,7 +1074,7 @@ export async function repoValidatePlanningForAr(params: {
         numero: row.numero,
         client_id: row.client_id,
         planning_validated_at: milestone.rows[0]?.planning_validated_at ?? row.planning_validated_at ?? null,
-        workflow_status: "AR_PRET",
+        workflow_status: "PLANNING_VALIDE",
       });
     }
 
@@ -1671,6 +1716,7 @@ export async function repoCreatePlanningEvent(params: {
         tx: client,
         of_operation_id: b.of_operation_id,
         user_id: params.audit.user_id,
+        user_role: params.audit.role,
       });
       synchronizedOfId = sync.of_id ?? synchronizedOfId;
       notifications = sync.notifications;
@@ -1679,6 +1725,7 @@ export async function repoCreatePlanningEvent(params: {
         tx: client,
         of_id: synchronizedOfId,
         user_id: params.audit.user_id,
+        user_role: params.audit.role,
       });
     }
 
@@ -1981,6 +2028,7 @@ export async function repoPatchPlanningEvent(params: {
         tx: client,
         of_operation_id: before.of_operation_id,
         user_id: params.audit.user_id,
+        user_role: params.audit.role,
       });
       synchronizedOfId = previousSync.of_id ?? synchronizedOfId;
     }
@@ -1990,6 +2038,7 @@ export async function repoPatchPlanningEvent(params: {
         tx: client,
         of_operation_id: nextOfOperationId,
         user_id: params.audit.user_id,
+        user_role: params.audit.role,
       });
       synchronizedOfId = sync.of_id ?? synchronizedOfId;
       notifications = sync.notifications;
@@ -1998,6 +2047,7 @@ export async function repoPatchPlanningEvent(params: {
         tx: client,
         of_id: synchronizedOfId,
         user_id: params.audit.user_id,
+        user_role: params.audit.role,
       });
     }
 
@@ -2116,6 +2166,7 @@ export async function repoArchivePlanningEvent(params: { id: string; audit: Audi
         tx: client,
         of_operation_id: before.of_operation_id,
         user_id: params.audit.user_id,
+        user_role: params.audit.role,
       });
       synchronizedOfId = sync.of_id ?? synchronizedOfId;
       notifications = sync.notifications;
@@ -2262,6 +2313,7 @@ export async function repoRestorePlanningEvent(params: {
         tx: client,
         of_operation_id: before.of_operation_id,
         user_id: params.audit.user_id,
+        user_role: params.audit.role,
       });
       synchronizedOfId = sync.of_id ?? synchronizedOfId;
       notifications = sync.notifications;

--- a/src/module/planning/types/planning.types.ts
+++ b/src/module/planning/types/planning.types.ts
@@ -112,7 +112,7 @@ export type PlanningValidationCommande = {
   numero: string;
   client_id: string | null;
   planning_validated_at: string | null;
-  workflow_status: "AR_PRET";
+  workflow_status: "PLANNING_VALIDE";
 };
 
 export type PlanningValidationSkippedCommande = {


### PR DESCRIPTION
## Résumé

- Définit un graphe canonique versionné pour le statut des commandes, avec causes, checkpoints, rôles et actions autorisées.
- Centralise les transitions dans l’endpoint workflow, avec idempotence, historique et refus explicite de l’ancien setter direct.
- Sécurise les parcours AR, planification, production, qualité, livraison et facturation, notamment pour les commandes internes.
- Ajoute les gardes de concurrence, d’immutabilité du type de commande et de suppression définitive, ainsi que les scripts SQL de préflight/vérification.
- Génère le contrat consommé par le frontend et documente la machine d’état.

## Cause racine

Le statut pouvait être modifié depuis plusieurs modules sans autorité unique ni graphe partagé. Les règles de rôle, les prérequis métier et les protections de concurrence divergeaient selon le point d’entrée.

## Impact

- Le setter direct de statut répond désormais `410`; les clients doivent utiliser les actions du workflow.
- `order_type` devient immuable après création.
- Les commandes internes restent non facturables et ne peuvent produire un BL qu’après validation qualité.
- Les opérations sensibles suivent un ordre de verrouillage commun et revalident l’état sous verrou.

## Validation

- `npm run test:run`
- `npm run build`
- `npm run test:collection` — 182 fichiers collectés
- `npm run contract:generate`
- `git diff --check`
- Revue ciblée indépendante — 13 fichiers critiques, 115 tests, aucun P0–P2 restant

Closes #314

## Summary by Sourcery

Canonicalize and centralize the order workflow state machine, enforcing role-based checkpoint actions, internal-order invariants, and idempotent status transitions, while generating a backend-authored workflow contract for frontend consumption.

New Features:
- Expose a canonical, versioned command workflow contract (statuses, transitions, checkpoints) consumable by the frontend.
- Introduce workflow checkpoint views with role-based action availability and per-user assignment, including administrator overrides.
- Add atomic AR generation/send gates tied to workflow checkpoints and order status, with idempotent send claims and provider error handling.
- Support internal order-specific workflow paths that skip AR/invoicing, gate BL creation on quality release, and prevent billing of internal commands.

Bug Fixes:
- Prevent direct command status mutations in favor of workflow checkpoint actions, eliminating divergent state changes across modules.
- Ensure downstream shipment and invoice synchronizations are idempotent and respect the canonical status graph, avoiding illegal jumps or double effects.
- Block invoice issuance and legacy invoice creation when any internal order source is involved, preventing accidental billing of internal commands.
- Tighten deletion semantics so only initial, artifact-free customer orders can be hard-deleted, enforcing archiving for all other cases.

Enhancements:
- Normalize legacy command statuses to their canonical equivalents at read-time, while rejecting non-canonical write targets and invalid history.
- Refine workflow checkpoint lifecycle with strict active/blocked transitions, metadata-based resume, and idempotent replay detection for patches and actions.
- Strengthen fulfillment guards around OF production, quality release, delivery, and invoicing, and reuse them consistently across workflow actions and sync paths.
- Align planning and AR flows with the central workflow graph, using shared checkpoint access control and milestone updates instead of ad-hoc status writes.
- Improve RBAC for workflow checkpoints, mapping business roles to responsibilities and honoring explicit user assignment and admin override semantics.

Build:
- Introduce a contract generation script to emit the compiled workflow JSON artifact as part of the build pipeline.

Deployment:
- Provide read-only SQL preflight and verification scripts to validate workflow history and checkpoint consistency before and after deployment.

Documentation:
- Document the canonical customer-order workflow machine, its deployment/rollback expectations, and database preflight/verification guards.
- Add tests validating the SQL preflight/verify scripts and the generated workflow contract against the backend authority.

Tests:
- Add extensive tests for the canonical workflow state machine, checkpoint RBAC, AR send claims, planning checkpoint access, internal-order delivery guards, immutable order_type, deletion retention, and invoice internal-order protections.
- Extend route and repository tests to cover disabled direct status endpoint, role-based workflow action availability, idempotent workflow actions and checkpoint patches, and updated planning/AR behaviors.