### PR TITLE
fix(livraisons): audit delivery draft cancellations

### DIFF
--- a/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
+++ b/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
@@ -1,0 +1,48 @@
+import type { NextFunction, Request, Response } from "express"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const pdf = vi.hoisted(() => ({
+  generate: vi.fn(),
+  getLatest: vi.fn(),
+}))
+
+vi.mock("../services/pdf.service", () => ({
+  svcGenerateLivraisonPdf: pdf.generate,
+  svcGetDocumentName: vi.fn(),
+  svcGetLatestLivraisonPdfDocument: pdf.getLatest,
+  svcGetPdfFilePath: vi.fn(),
+}))
+
+import { getLivraisonPdf } from "./livraisons.controller"
+
+const BON_LIVRAISON_ID = "00000000-0000-4000-8000-000000000017"
+
+describe("GET automatique du PDF d'un bon de livraison annulé", () => {
+  beforeEach(() => {
+    pdf.generate.mockReset()
+    pdf.getLatest.mockReset()
+  })
+
+  it("propage le conflit structuré quand l'absence d'archive déclenche une génération", async () => {
+    const conflict = {
+      status: 409,
+      code: "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+      message: "Un bon de livraison annulé ne peut pas générer ou régénérer de PDF.",
+    }
+    pdf.getLatest.mockResolvedValue(null)
+    pdf.generate.mockRejectedValue(conflict)
+    const request = {
+      params: { id: BON_LIVRAISON_ID },
+      query: {},
+      user: { id: 17 },
+    } as unknown as Request
+    const response = {} as Response
+    const next = vi.fn() as NextFunction
+
+    await getLivraisonPdf(request, response, next)
+
+    expect(pdf.getLatest).toHaveBeenCalledWith(BON_LIVRAISON_ID)
+    expect(pdf.generate).toHaveBeenCalledWith(BON_LIVRAISON_ID, 17)
+    expect(next).toHaveBeenCalledWith(conflict)
+  })
+})

--- a/src/module/livraisons/repository/livraisons-cancellation-orphaned-reservation.repository.test.ts
+++ b/src/module/livraisons/repository/livraisons-cancellation-orphaned-reservation.repository.test.ts
@@ -1,0 +1,222 @@
+import type { PoolClient } from "pg"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const dependencies = vi.hoisted(() => ({
+  connect: vi.fn(),
+  insertAudit: vi.fn(),
+}))
+
+vi.mock("../../../config/database", () => ({
+  default: {
+    connect: dependencies.connect,
+    query: vi.fn(),
+  },
+}))
+
+vi.mock("../../audit-logs/repository/audit-logs.repository", () => ({
+  repoInsertAuditLog: dependencies.insertAudit,
+}))
+
+import {
+  repoDeleteLivraisonLineAllocation,
+  repoUpdateLivraisonStatus,
+} from "./livraisons.repository"
+
+const BON_LIVRAISON_ID = "44444444-4444-4444-8444-444444444444"
+const LINE_ID = "55555555-5555-4555-8555-555555555555"
+const ALLOCATION_ID = "66666666-6666-4666-8666-666666666666"
+const RESERVATION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+const STOCK_LEVEL_ID = "88888888-8888-4888-8888-888888888888"
+const STOCK_BATCH_ID = "99999999-9999-4999-8999-999999999999"
+const LOT_ID = "22222222-2222-4222-8222-222222222222"
+const USER_ID = 17
+
+type LifecycleState = {
+  deliveryStatus: "DRAFT" | "CANCELLED"
+  allocationExists: boolean
+  reservationStatus: "ACTIVE" | "RELEASED"
+  stockLevelReserved: number
+  stockBatchReserved: number
+}
+
+function createReservationAllocationLifecycle() {
+  const state: LifecycleState = {
+    deliveryStatus: "DRAFT",
+    allocationExists: true,
+    reservationStatus: "ACTIVE",
+    stockLevelReserved: 4,
+    stockBatchReserved: 4,
+  }
+  let snapshot: LifecycleState | null = null
+  let failCancellationStatusUpdate = false
+
+  const query = vi.fn(async (sql: string, values: unknown[] = []) => {
+    if (sql === "BEGIN") {
+      snapshot = { ...state }
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql === "COMMIT") {
+      snapshot = null
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql === "ROLLBACK") {
+      if (snapshot) Object.assign(state, snapshot)
+      snapshot = null
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql.includes("FROM bon_livraison bl")) {
+      return {
+        rows: [{
+          id: BON_LIVRAISON_ID,
+          numero: "BL-TEST-ORPHAN",
+          statut: state.deliveryStatus,
+          row_version: 1,
+        }],
+        rowCount: 1,
+      }
+    }
+    if (sql.includes("SELECT a.stock_movement_line_id")) {
+      return {
+        rows: state.allocationExists ? [{ stock_movement_line_id: null }] : [],
+        rowCount: state.allocationExists ? 1 : 0,
+      }
+    }
+    if (sql.includes("DELETE FROM public.bon_livraison_ligne_allocations")) {
+      const existed = state.allocationExists
+      state.allocationExists = false
+      return { rows: [], rowCount: existed ? 1 : 0 }
+    }
+    if (sql.includes("WITH target_reservation_ids AS")) {
+      if (state.reservationStatus !== "ACTIVE") return { rows: [], rowCount: 0 }
+      const row = {
+        id: RESERVATION_ID,
+        stock_level_id: STOCK_LEVEL_ID,
+        stock_batch_id: STOCK_BATCH_ID,
+        qty_reserved: 2,
+      }
+      // The duplicate exercises the defensive ID deduplication in addition to SQL UNION.
+      return { rows: [row, { ...row }], rowCount: 2 }
+    }
+    if (sql.includes("FROM public.stock_levels") && sql.includes("FOR UPDATE")) {
+      return {
+        rows: [{ qty_total: 10, qty_reserved: state.stockLevelReserved, qty_depreciated: 0 }],
+        rowCount: 1,
+      }
+    }
+    if (sql.includes("FROM public.stock_batches") && sql.includes("FOR UPDATE")) {
+      return {
+        rows: [{
+          stock_level_id: STOCK_LEVEL_ID,
+          lot_id: LOT_ID,
+          qty_total: 10,
+          qty_reserved: state.stockBatchReserved,
+          qty_depreciated: 0,
+        }],
+        rowCount: 1,
+      }
+    }
+    if (sql.includes("FROM public.lots")) {
+      return { rows: [{ lot_status: "LIBERE" }], rowCount: 1 }
+    }
+    if (sql.includes("UPDATE public.stock_levels")) {
+      state.stockLevelReserved -= Number(values[1])
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes("UPDATE public.stock_batches")) {
+      state.stockBatchReserved -= Number(values[1])
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes("UPDATE public.stock_reservations")) {
+      state.reservationStatus = "RELEASED"
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes("UPDATE public.bon_livraison") && sql.includes("SET statut = $2")) {
+      if (failCancellationStatusUpdate) throw new Error("status update failed")
+      state.deliveryStatus = "CANCELLED"
+      return { rows: [], rowCount: 1 }
+    }
+    return { rows: [], rowCount: 1 }
+  })
+  const client = { query, release: vi.fn() } as unknown as PoolClient
+  return {
+    client,
+    query,
+    state,
+    failNextCancellationStatusUpdate() {
+      failCancellationStatusUpdate = true
+    },
+  }
+}
+
+describe("annulation DRAFT après suppression de l'allocation", () => {
+  beforeEach(() => {
+    dependencies.connect.mockReset()
+    dependencies.insertAudit.mockReset()
+    dependencies.insertAudit.mockResolvedValue({ id: "audit-orphan" })
+  })
+
+  it("libère la réservation liée à la ligne et décrémente Stock exactement une fois", async () => {
+    const lifecycle = createReservationAllocationLifecycle()
+    dependencies.connect.mockResolvedValue(lifecycle.client)
+
+    await expect(
+      repoDeleteLivraisonLineAllocation(
+        BON_LIVRAISON_ID,
+        LINE_ID,
+        ALLOCATION_ID,
+        USER_ID
+      )
+    ).resolves.toBe(true)
+    expect(lifecycle.state.allocationExists).toBe(false)
+    expect(lifecycle.state.reservationStatus).toBe("ACTIVE")
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "Allocation supprimée avant annulation",
+      })
+    ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+    expect(lifecycle.state).toEqual({
+      deliveryStatus: "CANCELLED",
+      allocationExists: false,
+      reservationStatus: "RELEASED",
+      stockLevelReserved: 2,
+      stockBatchReserved: 2,
+    })
+    const targetQuery = lifecycle.query.mock.calls.find(([sql]) =>
+      String(sql).includes("WITH target_reservation_ids AS")
+    )
+    expect(String(targetQuery?.[0])).toContain("reservation.bon_livraison_ligne_id")
+    expect(String(targetQuery?.[0])).toContain("UNION")
+    expect(String(targetQuery?.[0])).toContain("bon_livraison_ligne_allocations")
+  })
+
+  it("restaure réservation et quantités si l'annulation échoue après la libération", async () => {
+    const lifecycle = createReservationAllocationLifecycle()
+    dependencies.connect.mockResolvedValue(lifecycle.client)
+
+    await repoDeleteLivraisonLineAllocation(
+      BON_LIVRAISON_ID,
+      LINE_ID,
+      ALLOCATION_ID,
+      USER_ID
+    )
+    lifecycle.failNextCancellationStatusUpdate()
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "Rollback après libération",
+      })
+    ).rejects.toThrow("status update failed")
+
+    expect(lifecycle.state).toEqual({
+      deliveryStatus: "DRAFT",
+      allocationExists: false,
+      reservationStatus: "ACTIVE",
+      stockLevelReserved: 4,
+      stockBatchReserved: 4,
+    })
+    expect(dependencies.insertAudit).not.toHaveBeenCalled()
+    expect(lifecycle.query).toHaveBeenCalledWith("ROLLBACK")
+  })
+})

--- a/src/module/livraisons/repository/livraisons-cancellation.repository.test.ts
+++ b/src/module/livraisons/repository/livraisons-cancellation.repository.test.ts
@@ -1,0 +1,170 @@
+import type { PoolClient } from "pg"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const testState = vi.hoisted(() => ({
+  connect: vi.fn(),
+  insertAudit: vi.fn(),
+  releaseReservations: vi.fn(),
+}))
+
+vi.mock("../../../config/database", () => ({
+  default: {
+    connect: testState.connect,
+    query: vi.fn(),
+  },
+}))
+
+vi.mock("../../audit-logs/repository/audit-logs.repository", () => ({
+  repoInsertAuditLog: testState.insertAudit,
+}))
+
+vi.mock("./livraisons-shipment.repository", () => ({
+  prepareLivraisonInTransaction: vi.fn(),
+  releaseLivraisonReservationsInTransaction: testState.releaseReservations,
+  repoListLivraisonProofs: vi.fn(),
+}))
+
+import { repoUpdateLivraisonStatus } from "./livraisons.repository"
+
+const BON_LIVRAISON_ID = "00000000-0000-4000-8000-000000000017"
+const USER_ID = 17
+
+function createClient(currentStatus: "DRAFT" | "READY" | "CANCELLED", updateRowCount = 1) {
+  const query = vi.fn(async (sql: string, _values?: unknown[]) => {
+    if (sql.includes("FROM bon_livraison bl")) {
+      return {
+        rows: [{
+          id: BON_LIVRAISON_ID,
+          numero: "BL-TEST-0017",
+          statut: currentStatus,
+          row_version: 1,
+        }],
+      }
+    }
+    if (sql.includes("UPDATE public.bon_livraison")) {
+      return { rows: [], rowCount: updateRowCount }
+    }
+    return { rows: [], rowCount: 0 }
+  })
+  const client = { query, release: vi.fn() } as unknown as PoolClient
+  return { client, query }
+}
+
+describe("transaction d'annulation d'un bon de livraison", () => {
+  beforeEach(() => {
+    testState.connect.mockReset()
+    testState.insertAudit.mockReset()
+    testState.releaseReservations.mockReset()
+    testState.insertAudit.mockResolvedValue({ id: "audit-17" })
+    testState.releaseReservations.mockResolvedValue(undefined)
+  })
+
+  it("libère les réservations READY avec le même motif avant la mutation", async () => {
+    const { client, query } = createClient("READY")
+    testState.connect.mockResolvedValue(client)
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "  Commande client abandonnée  ",
+      })
+    ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+    expect(testState.releaseReservations).toHaveBeenCalledWith(
+      client,
+      BON_LIVRAISON_ID,
+      USER_ID,
+      "Commande client abandonnée"
+    )
+    const updateCallIndex = query.mock.calls.findIndex(([sql]) =>
+      String(sql).includes("UPDATE public.bon_livraison")
+    )
+    expect(testState.releaseReservations.mock.invocationCallOrder[0]).toBeLessThan(
+      query.mock.invocationCallOrder[updateCallIndex]
+    )
+    expect(testState.insertAudit).toHaveBeenCalledOnce()
+  })
+
+  it("conserve le DRAFT et écrit l'événement et l'audit avant COMMIT", async () => {
+    const { client, query } = createClient("DRAFT")
+    testState.connect.mockResolvedValue(client)
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "  Doublon de saisie confirmé  ",
+      })
+    ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+    const eventCall = query.mock.calls.find(([sql]) =>
+      String(sql).includes("INSERT INTO bon_livraison_event_log")
+    )
+    expect(eventCall?.[1]).toEqual([
+      BON_LIVRAISON_ID,
+      "STATUS_CHANGED",
+      JSON.stringify({ statut: "DRAFT" }),
+      JSON.stringify({ statut: "CANCELLED", commentaire: "Doublon de saisie confirmé" }),
+      USER_ID,
+    ])
+    expect(testState.insertAudit).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: USER_ID,
+      tx: client,
+      body: expect.objectContaining({
+        action: "livraisons.cancelled",
+        entity_id: BON_LIVRAISON_ID,
+        details: {
+          bon_livraison_numero: "BL-TEST-0017",
+          old_statut: "DRAFT",
+          new_statut: "CANCELLED",
+          reason: "Doublon de saisie confirmé",
+        },
+      }),
+    }))
+
+    const auditOrder = testState.insertAudit.mock.invocationCallOrder[0]
+    const commitOrder = query.mock.calls.findIndex(([sql]) => sql === "COMMIT")
+    expect(auditOrder).toBeLessThan(query.mock.invocationCallOrder[commitOrder])
+  })
+
+  it("refuse un motif vide avant toute mutation et ROLLBACK", async () => {
+    const { client, query } = createClient("DRAFT")
+    testState.connect.mockResolvedValue(client)
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "   ",
+      })
+    ).rejects.toMatchObject({ status: 422, code: "CANCELLATION_REASON_REQUIRED" })
+
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("UPDATE public.bon_livraison"))).toBe(false)
+    expect(query).toHaveBeenCalledWith("ROLLBACK")
+    expect(testState.insertAudit).not.toHaveBeenCalled()
+  })
+
+  it("ne duplique ni événement ni audit lors d'un rejeu idempotent", async () => {
+    const { client, query } = createClient("CANCELLED")
+    testState.connect.mockResolvedValue(client)
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "Confirmation du rejeu",
+      })
+    ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("bon_livraison_event_log"))).toBe(false)
+    expect(testState.insertAudit).not.toHaveBeenCalled()
+    expect(query).toHaveBeenCalledWith("COMMIT")
+  })
+
+  it("annule toute la transaction si le statut change malgré le verrou", async () => {
+    const { client, query } = createClient("DRAFT", 0)
+    testState.connect.mockResolvedValue(client)
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "Annulation concurrente",
+      })
+    ).rejects.toMatchObject({ status: 409, code: "CONCURRENT_MODIFICATION" })
+
+    expect(query).toHaveBeenCalledWith("ROLLBACK")
+    expect(testState.insertAudit).not.toHaveBeenCalled()
+  })
+})

--- a/src/module/livraisons/repository/livraisons-cancellation.repository.test.ts
+++ b/src/module/livraisons/repository/livraisons-cancellation.repository.test.ts
@@ -59,29 +59,49 @@ describe("transaction d'annulation d'un bon de livraison", () => {
     testState.releaseReservations.mockResolvedValue(undefined)
   })
 
-  it("libère les réservations READY avec le même motif avant la mutation", async () => {
-    const { client, query } = createClient("READY")
+  it.each(["DRAFT", "READY"] as const)(
+    "libère les réservations ACTIVE d'un BL %s avec le même motif avant la mutation",
+    async (currentStatus) => {
+      const { client, query } = createClient(currentStatus)
+      testState.connect.mockResolvedValue(client)
+
+      await expect(
+        repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+          commentaire: "  Commande client abandonnée  ",
+        })
+      ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+      expect(testState.releaseReservations).toHaveBeenCalledWith(
+        client,
+        BON_LIVRAISON_ID,
+        USER_ID,
+        "Commande client abandonnée"
+      )
+      const updateCallIndex = query.mock.calls.findIndex(([sql]) =>
+        String(sql).includes("UPDATE public.bon_livraison")
+      )
+      expect(testState.releaseReservations.mock.invocationCallOrder[0]).toBeLessThan(
+        query.mock.invocationCallOrder[updateCallIndex]
+      )
+      expect(testState.insertAudit).toHaveBeenCalledOnce()
+    }
+  )
+
+  it("annule toute la transaction si la libération des réservations échoue", async () => {
+    const { client, query } = createClient("DRAFT")
     testState.connect.mockResolvedValue(client)
+    testState.releaseReservations.mockRejectedValueOnce(new Error("stock release failed"))
 
     await expect(
       repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
-        commentaire: "  Commande client abandonnée  ",
+        commentaire: "Annulation avec allocation partielle",
       })
-    ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+    ).rejects.toThrow("stock release failed")
 
-    expect(testState.releaseReservations).toHaveBeenCalledWith(
-      client,
-      BON_LIVRAISON_ID,
-      USER_ID,
-      "Commande client abandonnée"
-    )
-    const updateCallIndex = query.mock.calls.findIndex(([sql]) =>
-      String(sql).includes("UPDATE public.bon_livraison")
-    )
-    expect(testState.releaseReservations.mock.invocationCallOrder[0]).toBeLessThan(
-      query.mock.invocationCallOrder[updateCallIndex]
-    )
-    expect(testState.insertAudit).toHaveBeenCalledOnce()
+    expect(query).toHaveBeenCalledWith("ROLLBACK")
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("UPDATE public.bon_livraison"))).toBe(false)
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("bon_livraison_event_log"))).toBe(false)
+    expect(testState.insertAudit).not.toHaveBeenCalled()
   })
 
   it("conserve le DRAFT et écrit l'événement et l'audit avant COMMIT", async () => {

--- a/src/module/livraisons/repository/livraisons-shipment.repository.test.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.test.ts
@@ -1,7 +1,10 @@
 import type { PoolClient } from "pg";
 import { describe, expect, it, vi } from "vitest";
 
-import { prepareLivraisonInTransaction } from "./livraisons-shipment.repository";
+import {
+  prepareLivraisonInTransaction,
+  releaseLivraisonReservationsInTransaction,
+} from "./livraisons-shipment.repository";
 import {
   attachActiveCommandeReservationsToLivraison,
   repoCreateLivraisonFromCommande,
@@ -179,6 +182,69 @@ describe("prepareLivraisonInTransaction", () => {
       query.mock.calls.some(([sql]) =>
         String(sql).includes("SET statut = 'READY'"))
     ).toBe(true);
+  });
+});
+
+describe("releaseLivraisonReservationsInTransaction", () => {
+  it("libère toutes les réservations ACTIVE liées au BL et décrémente les quantités agrégées", async () => {
+    const stockLevelId = "88888888-8888-4888-8888-888888888888";
+    const stockBatchId = "99999999-9999-4999-8999-999999999999";
+    const lotId = "22222222-2222-4222-8222-222222222222";
+    const reservationIds = [
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    ];
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("FROM public.bon_livraison_ligne_allocations allocation")) {
+        return {
+          rows: reservationIds.map((id, index) => ({
+            id,
+            stock_level_id: stockLevelId,
+            stock_batch_id: stockBatchId,
+            qty_reserved: index === 0 ? 1.25 : 0.75,
+          })),
+        };
+      }
+      if (sql.includes("FROM public.stock_levels")) {
+        return { rows: [{ qty_total: 10, qty_reserved: 4, qty_depreciated: 0 }] };
+      }
+      if (sql.includes("FROM public.stock_batches")) {
+        return {
+          rows: [{
+            stock_level_id: stockLevelId,
+            lot_id: lotId,
+            qty_total: 10,
+            qty_reserved: 4,
+            qty_depreciated: 0,
+          }],
+        };
+      }
+      if (sql.includes("FROM public.lots")) return { rows: [{ lot_status: "LIBERE" }] };
+      return { rows: [], rowCount: 2 };
+    });
+    const client = { query } as unknown as PoolClient;
+
+    await expect(
+      releaseLivraisonReservationsInTransaction(
+        client,
+        "44444444-4444-4444-8444-444444444444",
+        7,
+        "BL annulé"
+      )
+    ).resolves.toBeUndefined();
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("SET qty_reserved = qty_reserved - $2"),
+      [stockLevelId, 2, 7]
+    );
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE public.stock_batches SET qty_reserved = qty_reserved - $2"),
+      [stockBatchId, 2]
+    );
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("SET status = 'RELEASED'"),
+      [reservationIds, "BL annulé", 7]
+    );
   });
 });
 

--- a/src/module/livraisons/repository/livraisons-shipment.repository.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.ts
@@ -733,25 +733,61 @@ export async function releaseLivraisonReservationsInTransaction(
     qty_reserved: number
   }>(
     `
+      WITH target_reservation_ids AS (
+        SELECT reservation.id
+        FROM public.stock_reservations reservation
+        JOIN public.bon_livraison_ligne line
+          ON line.id = reservation.bon_livraison_ligne_id
+        WHERE line.bon_livraison_id = $1::uuid
+          AND reservation.status = 'ACTIVE'
+
+        UNION
+
+        SELECT reservation.id
+        FROM public.bon_livraison_ligne_allocations allocation
+        JOIN public.bon_livraison_ligne line
+          ON line.id = allocation.bon_livraison_ligne_id
+        JOIN public.stock_reservations reservation
+          ON reservation.id = allocation.reservation_id
+        WHERE line.bon_livraison_id = $1::uuid
+          AND reservation.status = 'ACTIVE'
+      )
       SELECT
         reservation.id::text AS id,
-        allocation.stock_level_id::text AS stock_level_id,
-        allocation.stock_batch_id::text AS stock_batch_id,
+        level.id::text AS stock_level_id,
+        reservation.stock_batch_id::text AS stock_batch_id,
         reservation.qty_reserved::float8 AS qty_reserved
-      FROM public.bon_livraison_ligne_allocations allocation
-      JOIN public.bon_livraison_ligne line ON line.id = allocation.bon_livraison_ligne_id
-      JOIN public.stock_reservations reservation ON reservation.id = allocation.reservation_id
-      WHERE line.bon_livraison_id = $1::uuid
-        AND reservation.status = 'ACTIVE'
-      ORDER BY allocation.stock_level_id, allocation.stock_batch_id, reservation.id
+      FROM target_reservation_ids target
+      JOIN public.stock_reservations reservation ON reservation.id = target.id
+      JOIN public.stock_levels level
+        ON level.article_id = reservation.article_id
+       AND level.location_id = reservation.location_id
+      WHERE reservation.status = 'ACTIVE'
+      ORDER BY level.id, reservation.stock_batch_id, reservation.id
       FOR UPDATE OF reservation
     `,
     [bonLivraisonId]
   )
-  if (!reservations.rows.length) return
+  const reservationsById = new Map<string, (typeof reservations.rows)[number]>()
+  for (const reservation of reservations.rows) {
+    const existing = reservationsById.get(reservation.id)
+    if (existing) {
+      if (
+        existing.stock_level_id !== reservation.stock_level_id ||
+        existing.stock_batch_id !== reservation.stock_batch_id ||
+        existing.qty_reserved !== reservation.qty_reserved
+      ) {
+        throw new Error("Conflicting stock targets for delivery reservation")
+      }
+      continue
+    }
+    reservationsById.set(reservation.id, reservation)
+  }
+  const targetReservations = [...reservationsById.values()]
+  if (!targetReservations.length) return
 
   const grouped = new Map<string, { level: string; batch: string | null; qty: number }>()
-  for (const reservation of reservations.rows) {
+  for (const reservation of targetReservations) {
     const key = `${reservation.stock_level_id}:${reservation.stock_batch_id ?? "-"}`
     const current = grouped.get(key) ?? {
       level: reservation.stock_level_id,
@@ -789,19 +825,24 @@ export async function releaseLivraisonReservationsInTransaction(
       )
     }
   }
-  await client.query(
+  const released = await client.query(
     `
       UPDATE public.stock_reservations
       SET status = 'RELEASED',
           reason = $2,
           released_at = now(),
           released_by = $3,
+          row_version = row_version + 1,
           updated_at = now(),
           updated_by = $3
       WHERE id = ANY($1::uuid[])
+        AND status = 'ACTIVE'
     `,
-    [reservations.rows.map((row) => row.id), reason, userId]
+    [targetReservations.map((row) => row.id), reason, userId]
   )
+  if ((released.rowCount ?? 0) !== targetReservations.length) {
+    throw new Error("Active delivery reservation count changed while releasing stock")
+  }
 }
 
 export async function repoShipLivraison(

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -2227,7 +2227,10 @@ export async function repoUpdateLivraisonStatus(
       return { id: bonLivraisonId, statut: "READY" }
     }
 
-    if (current.statut === "READY" && statut === "CANCELLED") {
+    if (
+      (current.statut === "DRAFT" || current.statut === "READY") &&
+      statut === "CANCELLED"
+    ) {
       await releaseLivraisonReservationsInTransaction(
         db,
         bonLivraisonId,

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -2202,6 +2202,14 @@ export async function repoUpdateLivraisonStatus(
     await db.query("BEGIN")
     const current = await getHeader(db, bonLivraisonId, { forUpdate: true })
     if (!current) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    const cancellationReason = statut === "CANCELLED" ? meta?.commentaire?.trim() ?? "" : ""
+    if (statut === "CANCELLED" && !cancellationReason) {
+      throw new HttpError(
+        422,
+        "CANCELLATION_REASON_REQUIRED",
+        "Un motif est obligatoire pour annuler un bon de livraison."
+      )
+    }
     if (current.statut === statut) {
       await db.query("COMMIT")
       return { id: bonLivraisonId, statut }
@@ -2213,18 +2221,6 @@ export async function repoUpdateLivraisonStatus(
         `Invalid transition from ${current.statut} to ${statut}`
       )
     }
-    if (
-      current.statut === "READY" &&
-      statut === "CANCELLED" &&
-      !meta?.commentaire?.trim()
-    ) {
-      throw new HttpError(
-        422,
-        "CANCELLATION_REASON_REQUIRED",
-        "Un motif est obligatoire pour annuler une préparation READY."
-      )
-    }
-
     if (current.statut === "DRAFT" && statut === "READY") {
       await prepareLivraisonInTransaction(db, bonLivraisonId, userId)
       await db.query("COMMIT")
@@ -2236,7 +2232,7 @@ export async function repoUpdateLivraisonStatus(
         db,
         bonLivraisonId,
         userId,
-        meta?.commentaire ?? "Annulation du bon de livraison"
+        cancellationReason
       )
     }
     if (current.statut === "SHIPPED" && statut === "DELIVERED") {
@@ -2280,8 +2276,37 @@ export async function repoUpdateLivraisonStatus(
       event_type: "STATUS_CHANGED",
       user_id: userId,
       old_values: { statut: current.statut },
-      new_values: { statut, commentaire: meta?.commentaire ?? null },
+      new_values: {
+        statut,
+        commentaire: statut === "CANCELLED" ? cancellationReason : meta?.commentaire ?? null,
+      },
     })
+    if (statut === "CANCELLED") {
+      await repoInsertAuditLog({
+        user_id: userId,
+        body: {
+          event_type: "ACTION",
+          action: "livraisons.cancelled",
+          page_key: "livraisons",
+          entity_type: "bon_livraison",
+          entity_id: bonLivraisonId,
+          path: `/api/v1/livraisons/${bonLivraisonId}/status`,
+          client_session_id: null,
+          details: {
+            bon_livraison_numero: current.numero,
+            old_statut: current.statut,
+            new_statut: statut,
+            reason: cancellationReason,
+          },
+        },
+        ip: null,
+        user_agent: null,
+        device_type: null,
+        os: null,
+        browser: null,
+        tx: db,
+      })
+    }
     await db.query("COMMIT")
     return { id: bonLivraisonId, statut }
   } catch (error) {

--- a/src/module/livraisons/services/livraisons-status.service.test.ts
+++ b/src/module/livraisons/services/livraisons-status.service.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const repository = vi.hoisted(() => ({
+  getStatut: vi.fn(),
+  updateStatus: vi.fn(),
+}))
+
+vi.mock("../repository/livraisons.repository", () => ({
+  repoAddLivraisonLine: vi.fn(),
+  repoAttachLivraisonDocuments: vi.fn(),
+  repoCreateLivraison: vi.fn(),
+  repoCreateLivraisonLineAllocation: vi.fn(),
+  repoCreateLivraisonFromCommande: vi.fn(),
+  repoDeleteLivraisonLineAllocation: vi.fn(),
+  repoDeleteLivraisonLine: vi.fn(),
+  repoGetLivraisonDetail: vi.fn(),
+  repoGetLivraisonStatut: repository.getStatut,
+  repoListLivraisons: vi.fn(),
+  repoRemoveLivraisonDocument: vi.fn(),
+  repoUpdateLivraisonHeader: vi.fn(),
+  repoUpdateLivraisonLine: vi.fn(),
+  repoUpdateLivraisonStatus: repository.updateStatus,
+}))
+
+vi.mock("../repository/livraisons-shipment.repository", () => ({
+  repoCreateLivraisonProof: vi.fn(),
+  repoGetLivraisonShipmentPreview: vi.fn(),
+  repoShipLivraison: vi.fn(),
+}))
+
+import { svcUpdateLivraisonStatus } from "./livraisons.service"
+
+const BON_LIVRAISON_ID = "00000000-0000-4000-8000-000000000017"
+const USER_ID = 17
+
+describe("annulation auditée d'un bon de livraison", () => {
+  beforeEach(() => {
+    repository.getStatut.mockReset()
+    repository.updateStatus.mockReset()
+    repository.updateStatus.mockResolvedValue({
+      id: BON_LIVRAISON_ID,
+      statut: "CANCELLED",
+    })
+  })
+
+  it.each(["DRAFT", "READY"] as const)(
+    "autorise %s -> CANCELLED avec un motif normalisé",
+    async (current) => {
+      repository.getStatut.mockResolvedValue(current)
+
+      await expect(
+        svcUpdateLivraisonStatus(
+          BON_LIVRAISON_ID,
+          { statut: "CANCELLED", commentaire: "  Commande client abandonnée  " },
+          USER_ID
+        )
+      ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+      expect(repository.updateStatus).toHaveBeenCalledWith(
+        BON_LIVRAISON_ID,
+        "CANCELLED",
+        USER_ID,
+        { commentaire: "Commande client abandonnée" }
+      )
+    }
+  )
+
+  it.each(["DRAFT", "READY"] as const)(
+    "refuse %s -> CANCELLED sans motif",
+    async (current) => {
+      repository.getStatut.mockResolvedValue(current)
+
+      await expect(
+        svcUpdateLivraisonStatus(
+          BON_LIVRAISON_ID,
+          { statut: "CANCELLED", commentaire: "   " },
+          USER_ID
+        )
+      ).rejects.toMatchObject({
+        status: 422,
+        code: "CANCELLATION_REASON_REQUIRED",
+      })
+      expect(repository.updateStatus).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(["SHIPPED", "DELIVERED"] as const)(
+    "refuse l'annulation depuis l'état %s",
+    async (current) => {
+      repository.getStatut.mockResolvedValue(current)
+
+      await expect(
+        svcUpdateLivraisonStatus(
+          BON_LIVRAISON_ID,
+          { statut: "CANCELLED", commentaire: "Motif documenté" },
+          USER_ID
+        )
+      ).rejects.toMatchObject({ status: 409, code: "INVALID_TRANSITION" })
+      expect(repository.updateStatus).not.toHaveBeenCalled()
+    }
+  )
+
+  it("conserve l'idempotence de CANCELLED avec un motif explicite", async () => {
+    repository.getStatut.mockResolvedValue("CANCELLED")
+
+    await expect(
+      svcUpdateLivraisonStatus(
+        BON_LIVRAISON_ID,
+        { statut: "CANCELLED", commentaire: "Confirmation de l'annulation" },
+        USER_ID
+      )
+    ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+    expect(repository.updateStatus).toHaveBeenCalledOnce()
+  })
+
+  it("propage un conflit détecté sous verrou sans annoncer de faux succès", async () => {
+    repository.getStatut.mockResolvedValue("DRAFT")
+    repository.updateStatus.mockRejectedValueOnce(
+      Object.assign(new Error("Le statut du BL a changé."), {
+        status: 409,
+        code: "CONCURRENT_MODIFICATION",
+      })
+    )
+
+    await expect(
+      svcUpdateLivraisonStatus(
+        BON_LIVRAISON_ID,
+        { statut: "CANCELLED", commentaire: "Doublon confirmé" },
+        USER_ID
+      )
+    ).rejects.toMatchObject({ status: 409, code: "CONCURRENT_MODIFICATION" })
+  })
+})

--- a/src/module/livraisons/services/livraisons.service.ts
+++ b/src/module/livraisons/services/livraisons.service.ts
@@ -114,18 +114,16 @@ export async function svcUpdateLivraisonStatus(id: string, body: LivraisonStatus
   const current = await repoGetLivraisonStatut(id)
   if (!current) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
   assertAllowedTransition(current, body.statut)
-  if (
-    current === "READY" &&
-    body.statut === "CANCELLED" &&
-    !body.commentaire?.trim()
-  ) {
+  if (body.statut === "CANCELLED" && !body.commentaire?.trim()) {
     throw new HttpError(
       422,
       "CANCELLATION_REASON_REQUIRED",
-      "Un motif est obligatoire pour annuler une préparation READY."
+      "Un motif est obligatoire pour annuler un bon de livraison."
     )
   }
-  return repoUpdateLivraisonStatus(id, body.statut, userId, { commentaire: body.commentaire ?? null })
+  return repoUpdateLivraisonStatus(id, body.statut, userId, {
+    commentaire: body.commentaire?.trim() || null,
+  })
 }
 
 export async function svcGetLivraisonShipmentPreview(id: string) {

--- a/src/module/livraisons/services/pdf.service.test.ts
+++ b/src/module/livraisons/services/pdf.service.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const repository = vi.hoisted(() => ({
+  getDetail: vi.fn(),
+  getDocumentName: vi.fn(),
+}))
+
+const database = vi.hoisted(() => ({
+  connect: vi.fn(),
+  query: vi.fn(),
+}))
+
+vi.mock("../../../config/database", () => ({
+  default: database,
+}))
+
+vi.mock("../repository/livraisons.repository", () => ({
+  repoGetLivraisonDetail: repository.getDetail,
+  repoGetDocumentName: repository.getDocumentName,
+}))
+
+import {
+  svcGenerateLivraisonPdf,
+  svcGetLatestLivraisonPdfDocument,
+} from "./pdf.service"
+
+const BON_LIVRAISON_ID = "00000000-0000-4000-8000-000000000017"
+
+describe("garde PDF d'un bon de livraison annulé", () => {
+  beforeEach(() => {
+    repository.getDetail.mockReset()
+    repository.getDocumentName.mockReset()
+    database.connect.mockReset()
+    database.query.mockReset()
+  })
+
+  it("conserve la lecture de l'archive historique existante", async () => {
+    database.query.mockResolvedValue({ rows: [{ document_id: "pdf-historique", version: 3 }] })
+
+    await expect(svcGetLatestLivraisonPdfDocument(BON_LIVRAISON_ID)).resolves.toEqual({
+      document_id: "pdf-historique",
+      version: 3,
+    })
+  })
+
+  it("bloque la génération sous verrou avant chargement du détail ou écriture du fichier", async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("SELECT statut FROM public.bon_livraison")) {
+        return { rows: [{ statut: "CANCELLED" }] }
+      }
+      return { rows: [] }
+    })
+    database.connect.mockResolvedValue({ query, release: vi.fn() })
+
+    await expect(svcGenerateLivraisonPdf(BON_LIVRAISON_ID, 17)).rejects.toMatchObject({
+      status: 409,
+      code: "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+    })
+
+    expect(repository.getDetail).not.toHaveBeenCalled()
+    expect(query).toHaveBeenCalledWith(
+      expect.stringMatching(/SELECT statut[\s\S]*FOR UPDATE/),
+      [BON_LIVRAISON_ID]
+    )
+    expect(query).toHaveBeenCalledWith("ROLLBACK")
+  })
+})

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -1,13 +1,17 @@
 import fs from "node:fs/promises"
 import path from "node:path"
 import crypto from "node:crypto"
+import type { PoolClient } from "pg"
 
 import pool from "../../../config/database"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { readIssuerParty } from "../../../shared/documents/issuer-identity.repository"
 import { pickMention } from "../../../shared/pdf/legal-mentions"
-import { repoGetLivraisonDetail, repoGetDocumentName } from "../repository/livraisons.repository"
+import {
+  repoGetDocumentName,
+  repoGetLivraisonDetail,
+} from "../repository/livraisons.repository"
 
 import { renderBonLivraisonDocument } from "./bon-livraison-document"
 
@@ -26,11 +30,28 @@ async function ensureDocsDir(): Promise<string> {
   return uploadDir
 }
 
+function assertLivraisonPdfGenerationAllowed(statut: string): void {
+  if (statut === "CANCELLED") {
+    throw new HttpError(
+      409,
+      "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+      "Un bon de livraison annulé ne peut pas générer ou régénérer de PDF."
+    )
+  }
+}
+
 // L'emetteur n'est plus reduit a sa raison sociale : `readIssuerParty` remonte aussi son
 // identite legale et ses mentions obligatoires, que le bon de livraison doit porter.
 
 export async function svcGetLatestLivraisonPdfDocument(id: string): Promise<{ document_id: string; version: number } | null> {
-  const res = await pool.query<{ document_id: string; version: number }>(
+  return getLatestLivraisonPdfDocument(pool, id)
+}
+
+async function getLatestLivraisonPdfDocument(
+  queryer: Pick<PoolClient, "query">,
+  id: string
+): Promise<{ document_id: string; version: number } | null> {
+  const res = await queryer.query<{ document_id: string; version: number }>(
     `
     SELECT d.document_id::text AS document_id, d.version
     FROM bon_livraison_documents d
@@ -50,35 +71,44 @@ export async function svcGetPdfFilePath(documentId: string): Promise<string> {
 }
 
 export async function svcGenerateLivraisonPdf(bonLivraisonId: string, userId: number): Promise<{ document_id: string; version: number }> {
-  const detail = await repoGetLivraisonDetail(bonLivraisonId)
-  if (!detail) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
-
-  const existing = await svcGetLatestLivraisonPdfDocument(bonLivraisonId)
-  const version = (existing?.version ?? 0) + 1
-
-  const docsDir = await ensureDocsDir()
-  const documentId = crypto.randomUUID()
-  const fileName = `Bon_livraison_${detail.bon_livraison.numero}.pdf`
-  const filePath = path.join(docsDir, `${documentId}.pdf`)
-
-  const issuer = await readIssuerParty({
-    at: detail.bon_livraison.date_expedition ?? detail.bon_livraison.date_creation,
-  })
-  const pdfBytes = await renderBonLivraisonDocument({
-    header: detail.bon_livraison,
-    lignes: detail.lignes,
-    version,
-    company: pickMention(issuer, "company_name"),
-    issuer,
-  })
-  await fs.mkdir(path.dirname(filePath), { recursive: true })
-  await fs.writeFile(filePath, pdfBytes)
-
-  const checksumSha256 = crypto.createHash("sha256").update(pdfBytes).digest("hex")
-
   const db = await pool.connect()
+  let filePath: string | null = null
   try {
     await db.query("BEGIN")
+    const locked = await db.query<{ statut: string }>(
+      `SELECT statut FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
+      [bonLivraisonId]
+    )
+    const statut = locked.rows[0]?.statut
+    if (!statut) {
+      throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    }
+    assertLivraisonPdfGenerationAllowed(statut)
+
+    const detail = await repoGetLivraisonDetail(bonLivraisonId)
+    if (!detail) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+
+    const existing = await getLatestLivraisonPdfDocument(db, bonLivraisonId)
+    const version = (existing?.version ?? 0) + 1
+    const docsDir = await ensureDocsDir()
+    const documentId = crypto.randomUUID()
+    const fileName = `Bon_livraison_${detail.bon_livraison.numero}.pdf`
+    filePath = path.join(docsDir, `${documentId}.pdf`)
+
+    const issuer = await readIssuerParty({
+      at: detail.bon_livraison.date_expedition ?? detail.bon_livraison.date_creation,
+    })
+    const pdfBytes = await renderBonLivraisonDocument({
+      header: detail.bon_livraison,
+      lignes: detail.lignes,
+      version,
+      company: pickMention(issuer, "company_name"),
+      issuer,
+    })
+    await fs.mkdir(path.dirname(filePath), { recursive: true })
+    await fs.writeFile(filePath, pdfBytes)
+    const checksumSha256 = crypto.createHash("sha256").update(pdfBytes).digest("hex")
+
     await db.query(`INSERT INTO documents_clients (id, document_name, type) VALUES ($1, $2, $3)`, [documentId, fileName, "PDF"])
     await db.query(
       `
@@ -109,15 +139,14 @@ export async function svcGenerateLivraisonPdf(bonLivraisonId: string, userId: nu
     )
     await db.query(`UPDATE bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`, [bonLivraisonId, userId])
     await db.query("COMMIT")
+    return { document_id: documentId, version }
   } catch (err) {
     await db.query("ROLLBACK")
-    await fs.unlink(filePath).catch(() => undefined)
+    if (filePath) await fs.unlink(filePath).catch(() => undefined)
     throw err
   } finally {
     db.release()
   }
-
-  return { document_id: documentId, version }
 }
 
 export async function svcGetDocumentName(documentId: string) {


### PR DESCRIPTION
## Résumé

- exige un motif normalisé pour toute annulation `DRAFT|READY -> CANCELLED`
- conserve le BL et son événement `STATUS_CHANGED`, puis écrit l'audit global `livraisons.cancelled` dans la même transaction
- libère atomiquement les réservations d'un BL `READY`
- préserve les refus depuis `SHIPPED|DELIVERED`, l'état terminal et les garanties de verrou/idempotence

## Validation

- `corepack pnpm test:run` — suite backend complète verte
- `corepack pnpm test:run src/module/livraisons/repository/livraisons-cancellation.repository.test.ts src/module/livraisons/services/livraisons-status.service.test.ts` — 13/13
- matrice métier/RBAC Livraison — 149/149 au jalon
- `corepack pnpm build` — vert

Aucune migration ni suppression de données.

## Summary by Sourcery

Enforce audited, reasoned cancellation of bons de livraison and ensure transactional integrity and idempotence for status changes to CANCELLED.

Bug Fixes:
- Prevent READY and DRAFT bons de livraison from being cancelled without a non-empty, normalized reason.
- Avoid duplicate status change events and audit logs when re-applying a CANCELLED status, preserving idempotence.
- Propagate concurrent modification conflicts on cancellation instead of reporting false success.

Enhancements:
- Record a structured audit log entry for every bon de livraison cancellation within the same transaction as the status change.
- Normalize and persist trimmed cancellation reasons consistently across status events, reservation releases, and audit logs.

Tests:
- Add repository-level tests covering cancellation transactions, reservation release ordering, audit logging, and conflict handling.
- Add service-level tests enforcing valid cancellation transitions, reason requirements, terminal state protections, and idempotent behaviour.