### PR TITLE
[BUG-CERP-0016] Verrouiller le contrat workflow facture v1

### DIFF
--- a/docs/http/facturation-227.md
+++ b/docs/http/facturation-227.md
@@ -11,12 +11,23 @@ un même document ni les écritures d'audit.
 
 ## Facture
 
+Le contrat conserve la version HTTP `/api/v1`. Il n'existe pas de route
+workflow v2 implicite : `preview_version: 1` versionne le calcul serveur, les
+mutations portent `expected_version` pour le verrou optimiste et les réponses
+de commande exposent `row_version`. Cette livraison ne modifie donc ni les
+URLs ni les payloads déjà consommés par le frontend.
+
 - `GET /factures/workflow/eligible-sources`
 - `POST /factures/workflow/preview`
 - `POST /factures/workflow/drafts`
 - `POST /factures/workflow/:id/request-validation`
 - `POST /factures/workflow/:id/validate`
 - `POST /factures/workflow/:id/issue`
+
+`eligible-sources` retourne uniquement des lignes de BL `SHIPPED` ou
+`DELIVERED`. Une commande `INTERNE` est exclue de la liste, de l'aperçu et de
+l'émission, y compris pour un ancien brouillon. Les lignes incomplètes restent
+visibles avec des `blockers` typés ; elles ne peuvent pas produire de brouillon.
 
 L'aperçu reçoit le client, la devise, les lignes source BL, les quantités et
 l'échéancier. Pour une échéance unique, le montant absent est rempli par le

--- a/src/__tests__/facturation-workflow.routes.test.ts
+++ b/src/__tests__/facturation-workflow.routes.test.ts
@@ -1,0 +1,185 @@
+import express, { type RequestHandler } from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listSources: vi.fn(),
+  preview: vi.fn(),
+  createDraft: vi.fn(),
+  requestValidation: vi.fn(),
+  validate: vi.fn(),
+  issue: vi.fn(),
+}));
+
+vi.mock("../module/facturation/services/facture-workflow.service", () => ({
+  svcListEligibleFactureSources: (...args: unknown[]) => mocks.listSources(...args),
+  svcPreviewFacture: (...args: unknown[]) => mocks.preview(...args),
+  svcCreateFactureDraft: (...args: unknown[]) => mocks.createDraft(...args),
+  svcRequestFactureValidation: (...args: unknown[]) => mocks.requestValidation(...args),
+  svcValidateFacture: (...args: unknown[]) => mocks.validate(...args),
+  svcIssueFacture: (...args: unknown[]) => mocks.issue(...args),
+}));
+
+import { validationErrorMiddleware } from "../module/auth/middlewares/validationError.middleware";
+import factureRoutes from "../module/facturation/routes/factures.routes";
+import { errorHandler } from "../middlewares/errorHandler";
+import { HttpError } from "../utils/httpError";
+
+const source = {
+  source_type: "DELIVERY_LINE",
+  source_id: "11111111-1111-4111-8111-111111111111",
+  source_line_id: "22222222-2222-4222-8222-222222222222",
+  delivery_number: "BL-000001",
+  delivery_status: "SHIPPED",
+  client_id: "CLI-1",
+  client_name: "Client test",
+  commande_id: 67,
+  affaire_id: null,
+  commande_line_id: 9,
+  designation: "Piece test",
+  code_piece: "P-1",
+  unit: "u",
+  quantity_source: "2.000",
+  quantity_already_invoiced: "0.000",
+  quantity_already_credited: "0.000",
+  quantity_remaining: "2.000",
+  unit_price_ex_tax: "10.0000",
+  discount_percent: "0.0000",
+  tax_rate_percent: "20.0000",
+  pricing_version: "COMMANDE_LINE:9:v1",
+  rule_code: "DELIVERY_SHIPPED:POLICY-1",
+  blockers: [],
+};
+
+const commandResult = {
+  id: 42,
+  uuid: "33333333-3333-4333-8333-333333333333",
+  draft_reference: "DFT-2026-000042",
+  legal_number: null,
+  status: "DRAFT",
+  row_version: 1,
+  correlation_id: "44444444-4444-4444-8444-444444444444",
+  idempotent_replay: false,
+};
+
+function testApp(options: { granted?: boolean; authenticated?: boolean } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use(((req, _res, next) => {
+    if (options.authenticated !== false) {
+      req.user = {
+        id: 7,
+        username: "finance-test",
+        email: "finance@test.invalid",
+        role: "Employee",
+      };
+    }
+    if (options.granted !== false) {
+      req.accountModuleAccess = { userId: 7, moduleKey: "facturation", granted: true };
+    }
+    req.requestId = "request-test-001";
+    next();
+  }) as RequestHandler);
+  app.use("/factures", factureRoutes);
+  app.use(validationErrorMiddleware);
+  app.use(errorHandler);
+  return app;
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockReset();
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+describe("BUG-CERP-0016 - contrat HTTP workflow facture v1", () => {
+  it("retourne les lignes BL eligibles et transmet les filtres types (200)", async () => {
+    mocks.listSources.mockResolvedValue({ items: [source], total: 1, policy_active: true });
+
+    const response = await request(testApp())
+      .get("/factures/workflow/eligible-sources?commande_id=67&page=2&pageSize=10");
+
+    expect(response.status, JSON.stringify(response.body)).toBe(200);
+    expect(response.body).toEqual({ items: [source], total: 1, policy_active: true });
+    expect(mocks.listSources).toHaveBeenCalledWith({ commande_id: 67, page: 2, pageSize: 10 });
+  });
+
+  it("refuse un filtre de commande invalide avant le service (400)", async () => {
+    const response = await request(testApp())
+      .get("/factures/workflow/eligible-sources?commande_id=0");
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ error: "VALIDATION_ERROR" });
+    expect(mocks.listSources).not.toHaveBeenCalled();
+  });
+
+  it("reste fail-closed sans contexte module ni capacite Finance (403)", async () => {
+    const response = await request(testApp({ granted: false }))
+      .get("/factures/workflow/eligible-sources");
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({
+      success: false,
+      code: "FINANCE_CAPABILITY_REQUIRED",
+    });
+    expect(mocks.listSources).not.toHaveBeenCalled();
+  });
+
+  it("retourne 201 au premier brouillon et 200 lors du rejeu idempotent", async () => {
+    mocks.createDraft
+      .mockResolvedValueOnce(commandResult)
+      .mockResolvedValueOnce({ ...commandResult, idempotent_replay: true });
+    const body = {
+      client_id: "CLI-1",
+      currency: "EUR",
+      sources: [{
+        source_type: "DELIVERY_LINE",
+        source_id: source.source_id,
+        source_line_id: source.source_line_id,
+        quantity: "2.000",
+      }],
+      global_discount_percent: "0",
+      due_dates: [{ due_date: "2026-08-31", label: "Echeance principale" }],
+      internal_comment: null,
+      customer_text: null,
+      preview_hash: "a".repeat(64),
+    };
+
+    const first = await request(testApp())
+      .post("/factures/workflow/drafts")
+      .set("Idempotency-Key", "facture-draft-attempt-001")
+      .send(body);
+    const replay = await request(testApp())
+      .post("/factures/workflow/drafts")
+      .set("Idempotency-Key", "facture-draft-attempt-001")
+      .send(body);
+
+    expect(first.status).toBe(201);
+    expect(replay.status).toBe(200);
+    expect(replay.body.idempotent_replay).toBe(true);
+    expect(mocks.createDraft).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      idempotencyKey: "facture-draft-attempt-001",
+      actor: expect.objectContaining({ userId: 7, requestId: "request-test-001" }),
+    }));
+  });
+
+  it("propage un conflit de version sans masquer le code de reprise (409)", async () => {
+    mocks.requestValidation.mockRejectedValue(
+      new HttpError(409, "CONCURRENT_MODIFICATION", "La facture a change."),
+    );
+
+    const response = await request(testApp())
+      .post("/factures/workflow/42/request-validation")
+      .set("Idempotency-Key", "request-validation-attempt-001")
+      .send({ expected_version: 1, preview_hash: "a".repeat(64), confirm: true });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      success: false,
+      code: "CONCURRENT_MODIFICATION",
+    });
+    expect(mocks.requestValidation).toHaveBeenCalledWith(expect.objectContaining({
+      factureId: 42,
+      idempotencyKey: "request-validation-attempt-001",
+    }));
+  });
+});

--- a/src/module/facturation/repository/workflow.repository.shared.test.ts
+++ b/src/module/facturation/repository/workflow.repository.shared.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import type { PoolClient } from "pg";
 
 import { HttpError } from "../../../utils/httpError";
 import {
+  acquireFinanceIdempotency,
   type DbQueryer,
   requireFinanceIssuerSnapshotAt,
 } from "./workflow.repository.shared";
@@ -67,5 +69,47 @@ describe("requireFinanceIssuerSnapshotAt", () => {
       code: "FINANCE_LEGAL_MENTIONS_NOT_CONFIGURED",
       details: { missing: ["recovery_indemnity"] },
     });
+  });
+});
+
+describe("finance workflow idempotency race guard", () => {
+  it("takes the transaction advisory lock before reading a competing receipt", async () => {
+    const query = vi.fn(async (sql: string, values?: unknown[]) => {
+      if (sql.includes("pg_advisory_xact_lock")) return { rows: [] };
+      if (sql.includes("FROM public.finance_command_receipts")) return { rows: [] };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+    const client = { query } as unknown as PoolClient;
+
+    const result = await acquireFinanceIdempotency({
+      client,
+      actor: { userId: 7, requestId: "request-1", path: "/factures/workflow/drafts" },
+      idempotencyKeyRaw: "facture-attempt-001",
+      commandType: "FACTURE_DRAFT_CREATE",
+      requestPayload: { preview_hash: "a".repeat(64) },
+    });
+
+    expect(result.replay).toBeNull();
+    expect(String(query.mock.calls[0]?.[0])).toContain("pg_advisory_xact_lock");
+    expect(query.mock.calls[0]?.[1]).toEqual(["finance:7:facture-attempt-001"]);
+    expect(String(query.mock.calls[1]?.[0])).toContain("finance_command_receipts");
+  });
+
+  it("rejects the same actor/key with a different command payload (409)", async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("pg_advisory_xact_lock")) return { rows: [] };
+      if (sql.includes("FROM public.finance_command_receipts")) {
+        return { rows: [{ request_hash: "different", result_payload: { id: 42 } }] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    await expect(acquireFinanceIdempotency({
+      client: { query } as unknown as PoolClient,
+      actor: { userId: 7, requestId: "request-2", path: "/factures/workflow/drafts" },
+      idempotencyKeyRaw: "facture-attempt-001",
+      commandType: "FACTURE_DRAFT_CREATE",
+      requestPayload: { preview_hash: "b".repeat(64) },
+    })).rejects.toMatchObject({ status: 409, code: "IDEMPOTENCY_KEY_REUSED" });
   });
 });


### PR DESCRIPTION
## What

- verrouille par tests HTTP le contrat v1 du workflow de facturation ;
- couvre les autorisations, la validation des entrées et les statuts d’idempotence 201/200/409 ;
- ajoute des tests de concurrence sur le verrou advisory et documente les sources BL éligibles.

## Why

L’audit BUG-CERP-0016 signalait des endpoints manquants. La branche dev les contient déjà ; le risque réel restant côté backend était une régression du contrat et de ses garanties d’idempotence/concurrence.

## Impact

Pas de migration ni de changement du contrat de production. Cette PR renforce les preuves automatisées et la documentation du workflow facture v1.

## Root cause

Les invariants critiques existaient dans l’implémentation, mais n’étaient pas tous verrouillés au niveau route HTTP et course idempotente.

## Checks

- pnpm run build
- pnpm run test:run
- pnpm run test:collection
- démarrage local de dist/index.js et réponse HTTP 200

Audit: BUG-CERP-0016

## Summary by Sourcery

Reinforce the HTTP contract and concurrency/idempotency guarantees of the v1 facture workflow without changing public APIs.

Bug Fixes:
- Guard against regressions in idempotency behavior by enforcing 201/200/409 semantics on facture workflow commands.
- Ensure finance workflow idempotency rejects conflicting reuses of the same key for different payloads.

Enhancements:
- Add HTTP route tests for the facture workflow to cover authorizations, input validation, and idempotent replay behavior.
- Introduce repository-level tests to verify advisory lock acquisition and race-guard behavior for finance workflow idempotency.
- Clarify documentation of the facture v1 HTTP contract, including versioning semantics and eligibility rules for BL sources.

Documentation:
- Document that facture workflow remains on /api/v1 and detail versioning fields and BL eligibility rules for workflow endpoints.

Tests:
- Add end-to-end-style tests for facture workflow HTTP routes, including permission checks and error propagation for concurrent modifications.
- Extend repository tests to cover advisory lock ordering and idempotency conflict handling in finance workflows.