### PR TITLE
fix(livraisons): make BL PDF availability side-effect free

### DIFF
--- a/docs/frontend_repo_map.md
+++ b/docs/frontend_repo_map.md
@@ -425,6 +425,7 @@ POST	/api/v1/livraisons/:id/pack/generate	authenticateToken	controller
 GET	/api/v1/livraisons/:id/pack/preview	authenticateToken	controller
 POST	/api/v1/livraisons/:id/pack/revoke/:versionId	authenticateToken	controller
 GET	/api/v1/livraisons/:id/pdf	authenticateToken	controller
+GET	/api/v1/livraisons/:id/pdf/availability	authenticateToken	controller
 POST	/api/v1/livraisons/:id/pdf	authenticateToken	controller
 POST	/api/v1/livraisons/:id/status	authenticateToken	controller
 POST	/api/v1/livraisons/from-commande/:commandeId	authenticateToken	controller

--- a/docs/livraison-document-cerp-213.md
+++ b/docs/livraison-document-cerp-213.md
@@ -89,7 +89,9 @@ ne peut être produit après le passage à `CANCELLED`.
 La disponibilité, la lecture d'une version exacte et le rejeu relisent les octets stockés et
 vérifient leur signature, leur taille et leur SHA-256 persistant. Une altération conservant la
 même taille et l'en-tête `%PDF-` est donc rejetée avec `LIVRAISON_PDF_INTEGRITY_ERROR`, au lieu
-d'être confondue avec une absence ordinaire.
+d'être confondue avec une absence ordinaire. Le GET exact envoie directement le buffer ainsi
+validé : il ne rouvre jamais le chemin du fichier après le contrôle, ce qui ferme la fenêtre de
+substitution entre validation et réponse HTTP.
 
 Les réponses PDF et de disponibilité portent `Cache-Control: private, no-store` afin qu'un
 navigateur ou un proxy ne réutilise pas un état d'autorisation ou une version obsolète.
@@ -139,7 +141,8 @@ d'affirmer qu'aucun UUID n'y figure.
 un BL complet, la régénération, le rejeu idempotent, l'archive manquante, la corruption SHA-256
 à taille identique, deux générations concurrentes et les deux ordres de verrou entre annulation
 et génération. Le contrôleur vérifie séparément que `GET` reste sans effet de bord et ne masque
-pas les erreurs d'autorisation ou de stockage.
+pas les erreurs d'autorisation ou de stockage, puis qu'un remplacement du fichier après sa
+validation ne peut pas substituer les octets servis.
 
 Suite complète : **2968 tests verts sur 2969**. L'échec restant
 (`src/__tests__/surface-finish-210.migration-guards.test.ts`) est **antérieur** à ce chantier —

--- a/docs/livraison-document-cerp-213.md
+++ b/docs/livraison-document-cerp-213.md
@@ -80,6 +80,17 @@ journal.
   version suivante. Ses archives `GENERATED_SIMPLE_BL_PDF` restent séparées des BL du pack
   figé (`GENERATED_BL_PDF`), dont le cycle de version est autonome.
 
+Le même verrou charge le statut courant avant tout rejeu ou rendu. Une annulation qui obtient le
+verrou en premier interdit génération et régénération avec
+`LIVRAISON_CANCELLED_PDF_FORBIDDEN` (`409`). Une génération déjà verrouillée peut terminer avant
+l'annulation ; son archive devient alors une pièce historique lisible, mais aucun nouveau rendu
+ne peut être produit après le passage à `CANCELLED`.
+
+La disponibilité, la lecture d'une version exacte et le rejeu relisent les octets stockés et
+vérifient leur signature, leur taille et leur SHA-256 persistant. Une altération conservant la
+même taille et l'en-tête `%PDF-` est donc rejetée avec `LIVRAISON_PDF_INTEGRITY_ERROR`, au lieu
+d'être confondue avec une absence ordinaire.
+
 Les réponses PDF et de disponibilité portent `Cache-Control: private, no-store` afin qu'un
 navigateur ou un proxy ne réutilise pas un état d'autorisation ou une version obsolète.
 
@@ -125,8 +136,9 @@ donc ce que le document affiche, pas ce que le code croit avoir écrit. C'est ce
 d'affirmer qu'aucun UUID n'y figure.
 
 `src/module/livraisons/services/pdf.service.test.ts` couvre en complément le brouillon vide,
-un BL complet, la régénération, le rejeu idempotent, l'archive manquante et deux générations
-concurrentes. Le contrôleur vérifie séparément que `GET` reste sans effet de bord et ne masque
+un BL complet, la régénération, le rejeu idempotent, l'archive manquante, la corruption SHA-256
+à taille identique, deux générations concurrentes et les deux ordres de verrou entre annulation
+et génération. Le contrôleur vérifie séparément que `GET` reste sans effet de bord et ne masque
 pas les erreurs d'autorisation ou de stockage.
 
 Suite complète : **2968 tests verts sur 2969**. L'échec restant

--- a/docs/livraison-document-cerp-213.md
+++ b/docs/livraison-document-cerp-213.md
@@ -67,6 +67,22 @@ les deux chemins produisent **le même binaire** — vérifié par un test, pas 
 `pdf.service.ts` ne s'occupe plus que du versionnement, du stockage, de l'empreinte et du
 journal.
 
+### Disponibilité et génération sont deux opérations distinctes
+
+- `GET /livraisons/:id/pdf/availability` indique si une archive lisible existe, sans créer de
+  fichier ni de version. Une absence ordinaire renvoie `NOT_GENERATED` ; une archive référencée
+  mais absente ou invalide reste une erreur d'intégrité explicite.
+- `GET /livraisons/:id/pdf?version=N` est strictement en lecture : il sert uniquement une version
+  déjà archivée et ne régénère jamais silencieusement un document manquant.
+- `POST /livraisons/:id/pdf` est la seule opération de génération. Elle exige la capacité
+  `documents_manage` et une clé `Idempotency-Key`. Un verrou sur le BL sérialise les demandes
+  concurrentes ; la même intention rejouée rend la même version, une nouvelle intention crée la
+  version suivante. Ses archives `GENERATED_SIMPLE_BL_PDF` restent séparées des BL du pack
+  figé (`GENERATED_BL_PDF`), dont le cycle de version est autonome.
+
+Les réponses PDF et de disponibilité portent `Cache-Control: private, no-store` afin qu'un
+navigateur ou un proxy ne réutilise pas un état d'autorisation ou une version obsolète.
+
 ## 4. Ce qui ne doit jamais figurer sur ces documents
 
 | Fuite trouvée | Corrigé en |
@@ -108,6 +124,11 @@ Le texte est relu **dans les flux de contenu du PDF**, décompressés et décod�
 donc ce que le document affiche, pas ce que le code croit avoir écrit. C'est ce qui permet
 d'affirmer qu'aucun UUID n'y figure.
 
+`src/module/livraisons/services/pdf.service.test.ts` couvre en complément le brouillon vide,
+un BL complet, la régénération, le rejeu idempotent, l'archive manquante et deux générations
+concurrentes. Le contrôleur vérifie séparément que `GET` reste sans effet de bord et ne masque
+pas les erreurs d'autorisation ou de stockage.
+
 Suite complète : **2968 tests verts sur 2969**. L'échec restant
 (`src/__tests__/surface-finish-210.migration-guards.test.ts`) est **antérieur** à ce chantier —
 vérifié en remisant les modifications et en relançant sur `origin/dev` seul.
@@ -116,5 +137,5 @@ vérifié en remisant les modifications et en relançant sur `origin/dev` seul.
 
 - Aucune recette navigateur.
 - Aucun déploiement, aucune modification de production.
-- **Aucune migration de base** : ces documents ne changent pas de schéma, le contrat d'API non
-  plus.
+- **Aucune migration de base** : le contrat HTTP évolue, mais les tables existantes suffisent au
+  versionnement, à l'empreinte et au journal d'idempotence.

--- a/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
+++ b/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
@@ -1,8 +1,13 @@
+import crypto from "node:crypto"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
 import type { NextFunction, Request, Response } from "express"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   availability: vi.fn(),
+  read: vi.fn(),
   generate: vi.fn(),
   getPath: vi.fn(),
   getName: vi.fn(),
@@ -11,6 +16,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../services/pdf.service", () => ({
   svcGetLivraisonPdfAvailability: (...args: unknown[]) => mocks.availability(...args),
+  svcReadLivraisonPdf: (...args: unknown[]) => mocks.read(...args),
   svcGenerateLivraisonPdf: (...args: unknown[]) => mocks.generate(...args),
   svcGetPdfFilePath: (...args: unknown[]) => mocks.getPath(...args),
   svcGetDocumentName: (...args: unknown[]) => mocks.getName(...args),
@@ -32,6 +38,7 @@ function responseDouble() {
     setHeader: vi.fn(),
     status: vi.fn(),
     json: vi.fn(),
+    send: vi.fn(),
     sendFile: vi.fn(),
   }
   response.status.mockReturnValue(response)
@@ -56,12 +63,13 @@ beforeEach(() => {
 
 describe("livraison PDF controller contract", () => {
   it("keeps GET read-only when no archive exists", async () => {
-    mocks.availability.mockResolvedValue({
+    mocks.read.mockResolvedValue({
       available: false,
       status: "NOT_GENERATED",
       document_id: null,
       version: null,
       generated_at: null,
+      bytes: null,
     })
     const response = responseDouble()
     const next = vi.fn() as NextFunction
@@ -75,9 +83,9 @@ describe("livraison PDF controller contract", () => {
     expect(response.sendFile).not.toHaveBeenCalled()
   })
 
-  it("does not mask authorization or storage failures from availability checks", async () => {
+  it("does not mask authorization or storage failures from archive reads", async () => {
     const forbidden = Object.assign(new Error("Forbidden"), { status: 403, code: "FORBIDDEN" })
-    mocks.availability.mockRejectedValue(forbidden)
+    mocks.read.mockRejectedValue(forbidden)
     const response = responseDouble()
     const next = vi.fn() as NextFunction
 
@@ -88,12 +96,14 @@ describe("livraison PDF controller contract", () => {
   })
 
   it("serves one requested archive version with private no-store caching", async () => {
-    mocks.availability.mockResolvedValue({
+    const validatedBytes = Buffer.from("%PDF-1.7\nvalidated")
+    mocks.read.mockResolvedValue({
       available: true,
       status: "AVAILABLE",
       document_id: "22222222-2222-4222-8222-222222222222",
       version: 3,
       generated_at: "2026-08-04T12:00:00.000Z",
+      bytes: validatedBytes,
     })
     const response = responseDouble()
     const next = vi.fn() as NextFunction
@@ -104,13 +114,67 @@ describe("livraison PDF controller contract", () => {
       next,
     )
 
-    expect(mocks.availability).toHaveBeenCalledWith(BL_ID, 3)
+    expect(mocks.read).toHaveBeenCalledWith(BL_ID, 3)
+    expect(response.setHeader).toHaveBeenCalledWith("Content-Type", "application/pdf")
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Content-Disposition",
+      'inline; filename="BL-0018.pdf"',
+    )
     expect(response.setHeader).toHaveBeenCalledWith(
       "Cache-Control",
       "private, no-store, max-age=0",
     )
-    expect(response.sendFile).toHaveBeenCalledWith("C:\\archives\\livraisons\\pdf.pdf")
+    expect(response.send).toHaveBeenCalledWith(validatedBytes)
+    expect(response.sendFile).not.toHaveBeenCalled()
+    expect(mocks.getPath).not.toHaveBeenCalled()
     expect(next).not.toHaveBeenCalled()
+  })
+
+  it("serves the validated buffer when the archived path is replaced before send", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-pdf-controller-"))
+    const archivePath = path.join(directory, "archive.pdf")
+    const validatedBytes = Buffer.from("%PDF-1.7\nvalidated-original")
+    const replacementBytes = Buffer.from("%PDF-1.7\nreplaced-after-validation")
+    const expectedChecksum = crypto.createHash("sha256").update(validatedBytes).digest("hex")
+    let serviceBytes: Buffer | null = null
+
+    try {
+      await fs.writeFile(archivePath, validatedBytes)
+      mocks.read.mockImplementation(async () => {
+        serviceBytes = await fs.readFile(archivePath)
+        expect(crypto.createHash("sha256").update(serviceBytes).digest("hex")).toBe(
+          expectedChecksum,
+        )
+        return {
+          available: true,
+          status: "AVAILABLE",
+          document_id: "22222222-2222-4222-8222-222222222222",
+          version: 3,
+          generated_at: "2026-08-04T12:00:00.000Z",
+          bytes: serviceBytes,
+        }
+      })
+      mocks.getName.mockImplementation(async () => {
+        await fs.writeFile(archivePath, replacementBytes)
+        return "BL-0018.pdf"
+      })
+      const response = responseDouble()
+      const next = vi.fn() as NextFunction
+
+      await getLivraisonPdf(
+        requestDouble({ query: { version: "3" } }),
+        response as unknown as Response,
+        next,
+      )
+
+      await expect(fs.readFile(archivePath)).resolves.toEqual(replacementBytes)
+      expect(response.send).toHaveBeenCalledWith(serviceBytes)
+      expect(response.send).not.toHaveBeenCalledWith(replacementBytes)
+      expect(response.sendFile).not.toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true })
+    }
   })
 
   it("requires idempotency before explicit generation", async () => {

--- a/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
+++ b/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
@@ -1,0 +1,147 @@
+import type { NextFunction, Request, Response } from "express"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  availability: vi.fn(),
+  generate: vi.fn(),
+  getPath: vi.fn(),
+  getName: vi.fn(),
+  emitEntityChanged: vi.fn(),
+}))
+
+vi.mock("../services/pdf.service", () => ({
+  svcGetLivraisonPdfAvailability: (...args: unknown[]) => mocks.availability(...args),
+  svcGenerateLivraisonPdf: (...args: unknown[]) => mocks.generate(...args),
+  svcGetPdfFilePath: (...args: unknown[]) => mocks.getPath(...args),
+  svcGetDocumentName: (...args: unknown[]) => mocks.getName(...args),
+}))
+
+vi.mock("../../../shared/realtime/realtime.service", () => ({
+  emitEntityChanged: (...args: unknown[]) => mocks.emitEntityChanged(...args),
+}))
+
+import {
+  generateLivraisonPdf,
+  getLivraisonPdf,
+} from "./livraisons.controller"
+
+const BL_ID = "11111111-1111-4111-8111-111111111111"
+
+function responseDouble() {
+  const response = {
+    setHeader: vi.fn(),
+    status: vi.fn(),
+    json: vi.fn(),
+    sendFile: vi.fn(),
+  }
+  response.status.mockReturnValue(response)
+  return response
+}
+
+function requestDouble(overrides: Partial<Request> = {}) {
+  return {
+    user: { id: 7 },
+    params: { id: BL_ID },
+    query: {},
+    headers: {},
+    ...overrides,
+  } as unknown as Request
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.getPath.mockReturnValue("C:\\archives\\livraisons\\pdf.pdf")
+  mocks.getName.mockResolvedValue("BL-0018.pdf")
+})
+
+describe("livraison PDF controller contract", () => {
+  it("keeps GET read-only when no archive exists", async () => {
+    mocks.availability.mockResolvedValue({
+      available: false,
+      status: "NOT_GENERATED",
+      document_id: null,
+      version: null,
+      generated_at: null,
+    })
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await getLivraisonPdf(requestDouble(), response as unknown as Response, next)
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 404, code: "LIVRAISON_PDF_NOT_GENERATED" }),
+    )
+    expect(mocks.generate).not.toHaveBeenCalled()
+    expect(response.sendFile).not.toHaveBeenCalled()
+  })
+
+  it("does not mask authorization or storage failures from availability checks", async () => {
+    const forbidden = Object.assign(new Error("Forbidden"), { status: 403, code: "FORBIDDEN" })
+    mocks.availability.mockRejectedValue(forbidden)
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await getLivraisonPdf(requestDouble(), response as unknown as Response, next)
+
+    expect(next).toHaveBeenCalledWith(forbidden)
+    expect(mocks.generate).not.toHaveBeenCalled()
+  })
+
+  it("serves one requested archive version with private no-store caching", async () => {
+    mocks.availability.mockResolvedValue({
+      available: true,
+      status: "AVAILABLE",
+      document_id: "22222222-2222-4222-8222-222222222222",
+      version: 3,
+      generated_at: "2026-08-04T12:00:00.000Z",
+    })
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await getLivraisonPdf(
+      requestDouble({ query: { version: "3" } }),
+      response as unknown as Response,
+      next,
+    )
+
+    expect(mocks.availability).toHaveBeenCalledWith(BL_ID, 3)
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Cache-Control",
+      "private, no-store, max-age=0",
+    )
+    expect(response.sendFile).toHaveBeenCalledWith("C:\\archives\\livraisons\\pdf.pdf")
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it("requires idempotency before explicit generation", async () => {
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await generateLivraisonPdf(requestDouble(), response as unknown as Response, next)
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 400, code: "IDEMPOTENCY_KEY_REQUIRED" }),
+    )
+    expect(mocks.generate).not.toHaveBeenCalled()
+  })
+
+  it("returns a created immutable version for a new idempotency key", async () => {
+    mocks.generate.mockResolvedValue({
+      document_id: "22222222-2222-4222-8222-222222222222",
+      version: 4,
+      idempotent_replay: false,
+    })
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await generateLivraisonPdf(
+      requestDouble({ headers: { "idempotency-key": "generation-key-18" } }),
+      response as unknown as Response,
+      next,
+    )
+
+    expect(mocks.generate).toHaveBeenCalledWith(BL_ID, 7, "generation-key-18")
+    expect(response.status).toHaveBeenCalledWith(201)
+    expect(next).not.toHaveBeenCalled()
+  })
+})

--- a/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
+++ b/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
@@ -144,4 +144,24 @@ describe("livraison PDF controller contract", () => {
     expect(response.status).toHaveBeenCalledWith(201)
     expect(next).not.toHaveBeenCalled()
   })
+
+  it("preserves the structured cancellation conflict from explicit generation", async () => {
+    const conflict = Object.assign(new Error("Cancelled"), {
+      status: 409,
+      code: "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+    })
+    mocks.generate.mockRejectedValue(conflict)
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await generateLivraisonPdf(
+      requestDouble({ headers: { "idempotency-key": "cancelled-generation" } }),
+      response as unknown as Response,
+      next,
+    )
+
+    expect(next).toHaveBeenCalledWith(conflict)
+    expect(response.status).not.toHaveBeenCalled()
+    expect(mocks.emitEntityChanged).not.toHaveBeenCalled()
+  })
 })

--- a/src/module/livraisons/controllers/livraisons.controller.ts
+++ b/src/module/livraisons/controllers/livraisons.controller.ts
@@ -415,8 +415,8 @@ export const getLivraisonPdf: RequestHandler = async (req, res, next) => {
     const { id } = livraisonIdParamsSchema.parse(req.params)
     const query = livraisonPdfQuerySchema.parse(req.query)
     const download = coerceBool(query.download)
-    const availability = await pdfService.svcGetLivraisonPdfAvailability(id, query.version)
-    if (!availability.available) {
+    const archive = await pdfService.svcReadLivraisonPdf(id, query.version)
+    if (!archive.available) {
       throw new HttpError(
         404,
         "LIVRAISON_PDF_NOT_GENERATED",
@@ -424,13 +424,12 @@ export const getLivraisonPdf: RequestHandler = async (req, res, next) => {
       )
     }
 
-    const filePath = pdfService.svcGetPdfFilePath(availability.document_id)
-    const docName = (await pdfService.svcGetDocumentName(availability.document_id)) ?? `bon-livraison-${id}.pdf`
+    const docName = (await pdfService.svcGetDocumentName(archive.document_id)) ?? `bon-livraison-${id}.pdf`
     const disposition = download ? "attachment" : "inline"
     res.setHeader("Content-Type", "application/pdf")
     res.setHeader("Content-Disposition", `${disposition}; filename=\"${docName.replace(/\"/g, "")}\"`)
     res.setHeader("Cache-Control", "private, no-store, max-age=0")
-    res.sendFile(filePath)
+    res.send(archive.bytes)
   } catch (e) {
     next(e)
   }

--- a/src/module/livraisons/controllers/livraisons.controller.ts
+++ b/src/module/livraisons/controllers/livraisons.controller.ts
@@ -1,6 +1,4 @@
 import type { Request, RequestHandler } from "express"
-import fs from "node:fs/promises"
-
 import { HttpError } from "../../../utils/httpError"
 import {
   createLivraisonBodySchema,
@@ -11,6 +9,7 @@ import {
   livraisonIdParamsSchema,
   livraisonLineIdParamsSchema,
   livraisonLineAllocationIdParamsSchema,
+  livraisonPdfQuerySchema,
   livraisonStatusBodySchema,
   livraisonProofBodySchema,
   shipLivraisonBodySchema,
@@ -385,10 +384,26 @@ export const generateLivraisonPdf: RequestHandler = async (req, res, next) => {
   try {
     const userId = getUserId(req)
     const { id } = livraisonIdParamsSchema.parse(req.params)
-    const out = await pdfService.svcGenerateLivraisonPdf(id, userId)
+    const out = await pdfService.svcGenerateLivraisonPdf(
+      id,
+      userId,
+      getRequiredIdempotencyKey(req)
+    )
 
     emitLivraisonChanged(req, { entityId: id, action: "updated" })
-    res.status(201).json(out)
+    res.status(out.idempotent_replay ? 200 : 201).json(out)
+  } catch (e) {
+    next(e)
+  }
+}
+
+export const getLivraisonPdfAvailability: RequestHandler = async (req, res, next) => {
+  try {
+    getUserId(req)
+    const { id } = livraisonIdParamsSchema.parse(req.params)
+    const out = await pdfService.svcGetLivraisonPdfAvailability(id)
+    res.setHeader("Cache-Control", "private, no-store, max-age=0")
+    res.status(200).json(out)
   } catch (e) {
     next(e)
   }
@@ -396,29 +411,25 @@ export const generateLivraisonPdf: RequestHandler = async (req, res, next) => {
 
 export const getLivraisonPdf: RequestHandler = async (req, res, next) => {
   try {
-    const userId = getUserId(req)
+    getUserId(req)
     const { id } = livraisonIdParamsSchema.parse(req.params)
-    const download = coerceBool((req.query as { download?: unknown } | undefined)?.download)
-
-    let latest = await pdfService.svcGetLatestLivraisonPdfDocument(id)
-    if (!latest) {
-      const created = await pdfService.svcGenerateLivraisonPdf(id, userId)
-      latest = { document_id: created.document_id, version: created.version }
+    const query = livraisonPdfQuerySchema.parse(req.query)
+    const download = coerceBool(query.download)
+    const availability = await pdfService.svcGetLivraisonPdfAvailability(id, query.version)
+    if (!availability.available) {
+      throw new HttpError(
+        404,
+        "LIVRAISON_PDF_NOT_GENERATED",
+        "Aucun PDF n'a encore ete genere pour ce bon de livraison."
+      )
     }
 
-    let filePath = await pdfService.svcGetPdfFilePath(latest.document_id)
-    try {
-      await fs.stat(filePath)
-    } catch {
-      const regenerated = await pdfService.svcGenerateLivraisonPdf(id, userId)
-      latest = { document_id: regenerated.document_id, version: regenerated.version }
-      filePath = await pdfService.svcGetPdfFilePath(latest.document_id)
-    }
-
-    const docName = (await pdfService.svcGetDocumentName(latest.document_id)) ?? `bon-livraison-${id}.pdf`
+    const filePath = pdfService.svcGetPdfFilePath(availability.document_id)
+    const docName = (await pdfService.svcGetDocumentName(availability.document_id)) ?? `bon-livraison-${id}.pdf`
     const disposition = download ? "attachment" : "inline"
     res.setHeader("Content-Type", "application/pdf")
     res.setHeader("Content-Disposition", `${disposition}; filename=\"${docName.replace(/\"/g, "")}\"`)
+    res.setHeader("Cache-Control", "private, no-store, max-age=0")
     res.sendFile(filePath)
   } catch (e) {
     next(e)

--- a/src/module/livraisons/domain/livraisons-rbac.test.ts
+++ b/src/module/livraisons/domain/livraisons-rbac.test.ts
@@ -9,6 +9,7 @@ describe("livraisons RBAC", () => {
     ["Responsable Logistique", "allocate"],
     ["Magasinier", "deliver"],
     ["Responsable Qualité", "read"],
+    ["Responsable Qualité", "documents_manage"],
     ["Secretaire", "proof_manage"],
   ] as const)("accorde %s -> %s", (role, capability) => {
     expect(roleHasLivraisonCapability(role, capability)).toBe(true)
@@ -18,6 +19,7 @@ describe("livraisons RBAC", () => {
     [null, "read"],
     ["", "read"],
     ["Employe", "ship"],
+    ["Employe", "documents_manage"],
     ["Responsable Qualité", "ship"],
     ["Comptable", "allocate"],
     ["Commercial", "cancel"],

--- a/src/module/livraisons/routes/livraisons.routes.ts
+++ b/src/module/livraisons/routes/livraisons.routes.ts
@@ -20,6 +20,7 @@ import {
   deleteLivraisonLineAllocation,
   generateLivraisonPdf,
   getLivraison,
+  getLivraisonPdfAvailability,
   getLivraisonShipmentPreview,
   getLivraisonDocumentFile,
   getLivraisonPdf,
@@ -139,6 +140,11 @@ router.get(
   getLivraisonDocumentFile
 )
 
+router.get(
+  "/:id/pdf/availability",
+  requireLivraisonCapability("read"),
+  getLivraisonPdfAvailability
+)
 router.get("/:id/pdf", requireLivraisonCapability("read"), getLivraisonPdf)
 router.post(
   "/:id/pdf",

--- a/src/module/livraisons/services/pdf.service.test.ts
+++ b/src/module/livraisons/services/pdf.service.test.ts
@@ -1,0 +1,295 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  readIssuerParty: vi.fn(),
+  repoGetLivraisonDetail: vi.fn(),
+  repoGetDocumentName: vi.fn(),
+  renderBonLivraisonDocument: vi.fn(),
+}))
+
+vi.mock("../../../config/database", () => ({
+  default: {
+    query: (...args: unknown[]) => mocks.poolQuery(...args),
+    connect: (...args: unknown[]) => mocks.poolConnect(...args),
+  },
+}))
+vi.mock("../../../shared/documents/issuer-identity.repository", () => ({
+  readIssuerParty: (...args: unknown[]) => mocks.readIssuerParty(...args),
+}))
+vi.mock("../repository/livraisons.repository", () => ({
+  repoGetLivraisonDetail: (...args: unknown[]) => mocks.repoGetLivraisonDetail(...args),
+  repoGetDocumentName: (...args: unknown[]) => mocks.repoGetDocumentName(...args),
+}))
+vi.mock("./bon-livraison-document", () => ({
+  renderBonLivraisonDocument: (...args: unknown[]) => mocks.renderBonLivraisonDocument(...args),
+}))
+
+import {
+  svcGenerateLivraisonPdf,
+  svcGetLivraisonPdfAvailability,
+} from "./pdf.service"
+
+const BL_ID = "11111111-1111-4111-8111-111111111111"
+const DOC_ID = "22222222-2222-4222-8222-222222222222"
+const PDF_BYTES = Buffer.from("%PDF-1.7\nsynthetic")
+
+type TestPoolClient = {
+  query: ReturnType<typeof vi.fn>
+  release: ReturnType<typeof vi.fn>
+}
+
+let documentsRoot = ""
+
+function detail(lines: unknown[] = []) {
+  return {
+    bon_livraison: {
+      id: BL_ID,
+      numero: "BL-2026-0018",
+      statut: "DRAFT",
+      date_creation: "2026-08-04",
+      date_expedition: null,
+    },
+    lignes: lines,
+    documents: [],
+    proofs: [],
+    events: [],
+  }
+}
+
+function generationDb(options: {
+  nextVersion?: number
+  replay?: {
+    document_id: string
+    version: number
+    generated_at: string
+    file_size_bytes: number
+  }
+} = {}): TestPoolClient {
+  const query = vi.fn(async (sqlValue: unknown) => {
+    const sql = String(sqlValue)
+    if (sql.includes("SELECT id::text AS id") && sql.includes("FOR UPDATE")) {
+      return { rows: [{ id: BL_ID }] }
+    }
+    if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) {
+      return {
+        rows: options.replay
+          ? [{ bon_livraison_id: BL_ID, ...options.replay }]
+          : [],
+      }
+    }
+    if (sql.includes("COALESCE(MAX(document.version)")) {
+      return { rows: [{ version: options.nextVersion ?? 1 }] }
+    }
+    return { rows: [] }
+  })
+  return { query, release: vi.fn() }
+}
+
+async function storePdf(documentId = DOC_ID, bytes = PDF_BYTES) {
+  const directory = path.join(documentsRoot, "livraisons")
+  await fs.mkdir(directory, { recursive: true })
+  await fs.writeFile(path.join(directory, `${documentId}.pdf`), bytes)
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  documentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-pdf-availability-"))
+  process.env.CERP_DOCUMENTS_ROOT = documentsRoot
+  mocks.readIssuerParty.mockResolvedValue({ company_name: "CERP" })
+  mocks.repoGetLivraisonDetail.mockResolvedValue(detail())
+  mocks.repoGetDocumentName.mockResolvedValue("Bon_livraison_BL-2026-0018.pdf")
+  mocks.renderBonLivraisonDocument.mockResolvedValue(PDF_BYTES)
+})
+
+afterEach(async () => {
+  delete process.env.CERP_DOCUMENTS_ROOT
+  await fs.rm(documentsRoot, { recursive: true, force: true })
+})
+
+describe("livraison PDF availability", () => {
+  it("reports an empty draft as not generated without creating a document", async () => {
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{
+        bon_livraison_id: BL_ID,
+        document_id: null,
+        version: null,
+        generated_at: null,
+        file_size_bytes: null,
+      }],
+    })
+
+    await expect(svcGetLivraisonPdfAvailability(BL_ID)).resolves.toEqual({
+      available: false,
+      status: "NOT_GENERATED",
+      document_id: null,
+      version: null,
+      generated_at: null,
+    })
+    expect(mocks.poolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("document.type = 'GENERATED_SIMPLE_BL_PDF'"),
+      [BL_ID, null],
+    )
+    expect(String(mocks.poolQuery.mock.calls[0]?.[0])).not.toContain(
+      "document.type = 'GENERATED_BL_PDF'",
+    )
+    await expect(fs.readdir(documentsRoot)).resolves.toEqual([])
+  })
+
+  it("only reports a generated archive as available when its PDF file is readable", async () => {
+    await storePdf()
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{
+        bon_livraison_id: BL_ID,
+        document_id: DOC_ID,
+        version: 3,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+      }],
+    })
+
+    await expect(svcGetLivraisonPdfAvailability(BL_ID)).resolves.toEqual({
+      available: true,
+      status: "AVAILABLE",
+      document_id: DOC_ID,
+      version: 3,
+      generated_at: "2026-08-04T12:00:00.000Z",
+    })
+  })
+
+  it("surfaces a missing archived file as an integrity error, not ordinary unavailability", async () => {
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{
+        bon_livraison_id: BL_ID,
+        document_id: DOC_ID,
+        version: 1,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+      }],
+    })
+
+    await expect(svcGetLivraisonPdfAvailability(BL_ID)).rejects.toMatchObject({
+      status: 410,
+      code: "LIVRAISON_PDF_FILE_MISSING",
+    })
+  })
+})
+
+describe("livraison PDF generation", () => {
+  it("generates a valid archived version for an empty draft", async () => {
+    const db = generationDb()
+    mocks.poolConnect.mockResolvedValue(db)
+
+    const result = await svcGenerateLivraisonPdf(BL_ID, 7, "generate-empty-draft")
+
+    expect(result).toMatchObject({ version: 1, idempotent_replay: false })
+    expect(mocks.renderBonLivraisonDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ lignes: [], version: 1 }),
+    )
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${result.document_id}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining("FOR UPDATE"),
+      [BL_ID],
+    )
+    expect(
+      db.query.mock.calls.some(([sql]) =>
+        String(sql).includes("'GENERATED_SIMPLE_BL_PDF'"),
+      ),
+    ).toBe(true)
+  })
+
+  it("regenerates a complete delivery as the next version", async () => {
+    const db = generationDb({ nextVersion: 4 })
+    mocks.poolConnect.mockResolvedValue(db)
+    mocks.repoGetLivraisonDetail.mockResolvedValue(
+      detail([{ id: "line-1", designation: "Pièce usinée", quantite: 2 }]),
+    )
+
+    const result = await svcGenerateLivraisonPdf(BL_ID, 7, "regenerate-complete")
+
+    expect(result).toMatchObject({ version: 4, idempotent_replay: false })
+    expect(mocks.renderBonLivraisonDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lignes: [expect.objectContaining({ designation: "Pièce usinée" })],
+        version: 4,
+      }),
+    )
+  })
+
+  it("replays the same actor and idempotency key without rendering another version", async () => {
+    await storePdf()
+    const db = generationDb({
+      replay: {
+        document_id: DOC_ID,
+        version: 2,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+      },
+    })
+    mocks.poolConnect.mockResolvedValue(db)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "same-generation-key"),
+    ).resolves.toEqual({
+      document_id: DOC_ID,
+      version: 2,
+      idempotent_replay: true,
+    })
+    expect(mocks.renderBonLivraisonDocument).not.toHaveBeenCalled()
+    expect(
+      db.query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO public.documents_clients")),
+    ).toBe(false)
+  })
+
+  it("serializes concurrent requests so distinct keys receive distinct versions", async () => {
+    let version = 0
+    let locked = false
+    const waiters: Array<() => void> = []
+
+    const releaseLock = () => {
+      const next = waiters.shift()
+      if (next) next()
+      else locked = false
+    }
+    const createConcurrentDb = () => {
+      let ownsLock = false
+      const query = vi.fn(async (sqlValue: unknown, values?: unknown[]) => {
+        const sql = String(sqlValue)
+        if (sql.includes("SELECT id::text AS id") && sql.includes("FOR UPDATE")) {
+          if (locked) await new Promise<void>((resolve) => waiters.push(resolve))
+          else locked = true
+          ownsLock = true
+          return { rows: [{ id: BL_ID }] }
+        }
+        if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) return { rows: [] }
+        if (sql.includes("COALESCE(MAX(document.version)")) {
+          return { rows: [{ version: version + 1 }] }
+        }
+        if (sql.includes("INSERT INTO public.bon_livraison_documents")) {
+          version = Number(values?.[2])
+        }
+        if ((sql === "COMMIT" || sql === "ROLLBACK") && ownsLock) {
+          ownsLock = false
+          releaseLock()
+        }
+        return { rows: [] }
+      })
+      return { query, release: vi.fn() }
+    }
+    mocks.poolConnect.mockImplementation(async () => createConcurrentDb())
+
+    const [first, second] = await Promise.all([
+      svcGenerateLivraisonPdf(BL_ID, 7, "concurrent-key-one"),
+      svcGenerateLivraisonPdf(BL_ID, 7, "concurrent-key-two"),
+    ])
+
+    expect([first.version, second.version].sort()).toEqual([1, 2])
+    expect(mocks.renderBonLivraisonDocument).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/module/livraisons/services/pdf.service.test.ts
+++ b/src/module/livraisons/services/pdf.service.test.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
@@ -37,10 +38,19 @@ import {
 const BL_ID = "11111111-1111-4111-8111-111111111111"
 const DOC_ID = "22222222-2222-4222-8222-222222222222"
 const PDF_BYTES = Buffer.from("%PDF-1.7\nsynthetic")
+const PDF_CHECKSUM = crypto.createHash("sha256").update(PDF_BYTES).digest("hex")
 
 type TestPoolClient = {
   query: ReturnType<typeof vi.fn>
   release: ReturnType<typeof vi.fn>
+}
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
 }
 
 let documentsRoot = ""
@@ -63,17 +73,19 @@ function detail(lines: unknown[] = []) {
 
 function generationDb(options: {
   nextVersion?: number
+  statut?: "DRAFT" | "CANCELLED"
   replay?: {
     document_id: string
     version: number
     generated_at: string
     file_size_bytes: number
+    checksum_sha256: string
   }
 } = {}): TestPoolClient {
   const query = vi.fn(async (sqlValue: unknown) => {
     const sql = String(sqlValue)
     if (sql.includes("SELECT id::text AS id") && sql.includes("FOR UPDATE")) {
-      return { rows: [{ id: BL_ID }] }
+      return { rows: [{ id: BL_ID, statut: options.statut ?? "DRAFT" }] }
     }
     if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) {
       return {
@@ -94,6 +106,81 @@ async function storePdf(documentId = DOC_ID, bytes = PDF_BYTES) {
   const directory = path.join(documentsRoot, "livraisons")
   await fs.mkdir(directory, { recursive: true })
   await fs.writeFile(path.join(directory, `${documentId}.pdf`), bytes)
+}
+
+function lifecycleDatabase() {
+  let statut: "DRAFT" | "CANCELLED" = "DRAFT"
+  let version = 0
+  let lockOwner: symbol | null = null
+  const waiters: Array<() => void> = []
+  const lockWaiterQueued = deferred()
+
+  const releaseLock = (owner: symbol) => {
+    if (lockOwner !== owner) return
+    const next = waiters.shift()
+    if (next) next()
+    else lockOwner = null
+  }
+
+  const connect = (): TestPoolClient => {
+    const owner = Symbol("delivery-transaction")
+    let ownsLock = false
+    const query = vi.fn(async (sqlValue: unknown, values?: unknown[]) => {
+      const sql = String(sqlValue)
+      if (sql.includes("SELECT id::text AS id") && sql.includes("FOR UPDATE")) {
+        if (lockOwner !== null) {
+          lockWaiterQueued.resolve()
+          await new Promise<void>((done) => waiters.push(done))
+        }
+        lockOwner = owner
+        ownsLock = true
+        return { rows: [{ id: BL_ID, statut }] }
+      }
+      if (sql.includes("TEST_CANCEL_DELIVERY")) {
+        statut = "CANCELLED"
+      }
+      if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) return { rows: [] }
+      if (sql.includes("COALESCE(MAX(document.version)")) {
+        return { rows: [{ version: version + 1 }] }
+      }
+      if (sql.includes("INSERT INTO public.bon_livraison_documents")) {
+        version = Number(values?.[2])
+      }
+      if ((sql === "COMMIT" || sql === "ROLLBACK") && ownsLock) {
+        ownsLock = false
+        releaseLock(owner)
+      }
+      return { rows: [] }
+    })
+    return { query, release: vi.fn() }
+  }
+
+  return {
+    connect,
+    getStatut: () => statut,
+    waitForBlockedTransaction: lockWaiterQueued.promise,
+  }
+}
+
+async function cancelDeliveryWithRowLock(
+  afterLock?: () => Promise<void> | void,
+): Promise<void> {
+  const db = await mocks.poolConnect()
+  try {
+    await db.query("BEGIN")
+    await db.query(
+      `SELECT id::text AS id, statut FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
+      [BL_ID],
+    )
+    await db.query(`UPDATE public.bon_livraison SET statut = 'CANCELLED' /* TEST_CANCEL_DELIVERY */`)
+    await afterLock?.()
+    await db.query("COMMIT")
+  } catch (error) {
+    await db.query("ROLLBACK")
+    throw error
+  } finally {
+    db.release()
+  }
 }
 
 beforeEach(async () => {
@@ -120,6 +207,7 @@ describe("livraison PDF availability", () => {
         version: null,
         generated_at: null,
         file_size_bytes: null,
+        checksum_sha256: null,
       }],
     })
 
@@ -149,6 +237,7 @@ describe("livraison PDF availability", () => {
         version: 3,
         generated_at: "2026-08-04T12:00:00.000Z",
         file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
       }],
     })
 
@@ -169,6 +258,7 @@ describe("livraison PDF availability", () => {
         version: 1,
         generated_at: "2026-08-04T12:00:00.000Z",
         file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
       }],
     })
 
@@ -176,6 +266,33 @@ describe("livraison PDF availability", () => {
       status: 410,
       code: "LIVRAISON_PDF_FILE_MISSING",
     })
+  })
+
+  it("rejects a version-specific archive whose bytes changed without changing size or signature", async () => {
+    const corruptedBytes = Buffer.from(PDF_BYTES)
+    corruptedBytes[corruptedBytes.byteLength - 1] ^= 1
+    expect(corruptedBytes.byteLength).toBe(PDF_BYTES.byteLength)
+    expect(corruptedBytes.subarray(0, 5).toString("ascii")).toBe("%PDF-")
+    await storePdf(DOC_ID, corruptedBytes)
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{
+        bon_livraison_id: BL_ID,
+        document_id: DOC_ID,
+        version: 3,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
+      }],
+    })
+
+    await expect(svcGetLivraisonPdfAvailability(BL_ID, 3)).rejects.toMatchObject({
+      status: 500,
+      code: "LIVRAISON_PDF_INTEGRITY_ERROR",
+    })
+    expect(mocks.poolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("latest.checksum_sha256"),
+      [BL_ID, 3],
+    )
   })
 })
 
@@ -194,7 +311,7 @@ describe("livraison PDF generation", () => {
       fs.readFile(path.join(documentsRoot, "livraisons", `${result.document_id}.pdf`)),
     ).resolves.toEqual(PDF_BYTES)
     expect(db.query).toHaveBeenCalledWith(
-      expect.stringContaining("FOR UPDATE"),
+      expect.stringContaining("id::text AS id, statut"),
       [BL_ID],
     )
     expect(
@@ -230,6 +347,7 @@ describe("livraison PDF generation", () => {
         version: 2,
         generated_at: "2026-08-04T12:00:00.000Z",
         file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
       },
     })
     mocks.poolConnect.mockResolvedValue(db)
@@ -245,6 +363,119 @@ describe("livraison PDF generation", () => {
     expect(
       db.query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO public.documents_clients")),
     ).toBe(false)
+  })
+
+  it("rejects a same-size checksum corruption during idempotent replay", async () => {
+    const corruptedBytes = Buffer.from(PDF_BYTES)
+    corruptedBytes[corruptedBytes.byteLength - 1] ^= 1
+    await storePdf(DOC_ID, corruptedBytes)
+    const db = generationDb({
+      replay: {
+        document_id: DOC_ID,
+        version: 2,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
+      },
+    })
+    mocks.poolConnect.mockResolvedValue(db)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "corrupted-replay-key"),
+    ).rejects.toMatchObject({
+      status: 500,
+      code: "LIVRAISON_PDF_INTEGRITY_ERROR",
+    })
+    expect(mocks.renderBonLivraisonDocument).not.toHaveBeenCalled()
+    expect(db.query).toHaveBeenCalledWith("ROLLBACK")
+    expect(
+      db.query.mock.calls.some(([sql]) =>
+        String(sql).includes("document.checksum_sha256"),
+      ),
+    ).toBe(true)
+  })
+
+  it("rejects generation and creator replay after cancellation before rendering", async () => {
+    await storePdf()
+    const db = generationDb({
+      statut: "CANCELLED",
+      replay: {
+        document_id: DOC_ID,
+        version: 2,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
+      },
+    })
+    mocks.poolConnect.mockResolvedValue(db)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "cancelled-replay-key"),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+    })
+    expect(mocks.renderBonLivraisonDocument).not.toHaveBeenCalled()
+    expect(
+      db.query.mock.calls.some(([sql]) => String(sql).includes("idempotency_key_hash")),
+    ).toBe(false)
+    expect(db.query).toHaveBeenCalledWith("ROLLBACK")
+  })
+
+  it("lets cancellation win the row lock and blocks the waiting generation before render", async () => {
+    const lifecycle = lifecycleDatabase()
+    mocks.poolConnect.mockImplementation(async () => lifecycle.connect())
+    const cancellationLocked = deferred()
+    const allowCancellationCommit = deferred()
+
+    const cancellation = cancelDeliveryWithRowLock(async () => {
+      cancellationLocked.resolve()
+      await allowCancellationCommit.promise
+    })
+    await cancellationLocked.promise
+    const generation = svcGenerateLivraisonPdf(BL_ID, 7, "cancel-wins-generation")
+
+    await lifecycle.waitForBlockedTransaction
+    expect(mocks.renderBonLivraisonDocument).not.toHaveBeenCalled()
+    allowCancellationCommit.resolve()
+    await cancellation
+    await expect(generation).rejects.toMatchObject({
+      status: 409,
+      code: "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+    })
+    expect(lifecycle.getStatut()).toBe("CANCELLED")
+    expect(mocks.renderBonLivraisonDocument).not.toHaveBeenCalled()
+  })
+
+  it("lets an already locked generation finish, then blocks every post-cancellation render", async () => {
+    const lifecycle = lifecycleDatabase()
+    mocks.poolConnect.mockImplementation(async () => lifecycle.connect())
+    const rendering = deferred()
+    const allowRender = deferred()
+    mocks.renderBonLivraisonDocument.mockImplementationOnce(async () => {
+      rendering.resolve()
+      await allowRender.promise
+      return PDF_BYTES
+    })
+
+    const generation = svcGenerateLivraisonPdf(BL_ID, 7, "generation-wins-cancel")
+    await rendering.promise
+    const cancellation = cancelDeliveryWithRowLock()
+    await lifecycle.waitForBlockedTransaction
+    expect(lifecycle.getStatut()).toBe("DRAFT")
+
+    allowRender.resolve()
+    await expect(generation).resolves.toMatchObject({ version: 1 })
+    await cancellation
+    expect(lifecycle.getStatut()).toBe("CANCELLED")
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "post-cancel-generation"),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+    })
+    expect(mocks.renderBonLivraisonDocument).toHaveBeenCalledTimes(1)
   })
 
   it("serializes concurrent requests so distinct keys receive distinct versions", async () => {
@@ -265,7 +496,7 @@ describe("livraison PDF generation", () => {
           if (locked) await new Promise<void>((resolve) => waiters.push(resolve))
           else locked = true
           ownsLock = true
-          return { rows: [{ id: BL_ID }] }
+          return { rows: [{ id: BL_ID, statut: "DRAFT" }] }
         }
         if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) return { rows: [] }
         if (sql.includes("COALESCE(MAX(document.version)")) {

--- a/src/module/livraisons/services/pdf.service.test.ts
+++ b/src/module/livraisons/services/pdf.service.test.ts
@@ -33,6 +33,7 @@ vi.mock("./bon-livraison-document", () => ({
 import {
   svcGenerateLivraisonPdf,
   svcGetLivraisonPdfAvailability,
+  svcReadLivraisonPdf,
 } from "./pdf.service"
 
 const BL_ID = "11111111-1111-4111-8111-111111111111"
@@ -248,6 +249,35 @@ describe("livraison PDF availability", () => {
       version: 3,
       generated_at: "2026-08-04T12:00:00.000Z",
     })
+  })
+
+  it("returns the exact validated bytes for a version-specific read", async () => {
+    await storePdf()
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{
+        bon_livraison_id: BL_ID,
+        document_id: DOC_ID,
+        version: 3,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
+      }],
+    })
+
+    const result = await svcReadLivraisonPdf(BL_ID, 3)
+
+    expect(result).toMatchObject({
+      available: true,
+      status: "AVAILABLE",
+      document_id: DOC_ID,
+      version: 3,
+      generated_at: "2026-08-04T12:00:00.000Z",
+    })
+    expect(result.bytes).toEqual(PDF_BYTES)
+    expect(mocks.poolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("latest.checksum_sha256"),
+      [BL_ID, 3],
+    )
   })
 
   it("surfaces a missing archived file as an integrity error, not ordinary unavailability", async () => {

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -1,88 +1,307 @@
+import crypto from "node:crypto"
 import fs from "node:fs/promises"
 import path from "node:path"
-import crypto from "node:crypto"
+import type { PoolClient } from "pg"
 
 import pool from "../../../config/database"
-import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
-import { HttpError } from "../../../utils/httpError"
 import { readIssuerParty } from "../../../shared/documents/issuer-identity.repository"
 import { pickMention } from "../../../shared/pdf/legal-mentions"
+import {
+  ensureDocumentStoragePath,
+  getDocumentStoragePath,
+} from "../../../utils/cerpStorage"
+import { HttpError } from "../../../utils/httpError"
 import { repoGetLivraisonDetail, repoGetDocumentName } from "../repository/livraisons.repository"
+import type {
+  LivraisonPdfAvailability,
+  LivraisonPdfGenerationResult,
+} from "../types/livraisons.types"
 
 import { renderBonLivraisonDocument } from "./bon-livraison-document"
 
-/**
- * Generation simple du bon de livraison (`POST /livraisons/:id/pdf`).
- *
- * Le rendu vit dans `bon-livraison-document.ts`, partage avec le pack fige : ce service ne
- * s'occupe plus que du versionnement, du stockage, de l'empreinte et du journal. Les deux
- * chemins dessinaient auparavant leur propre mise en page, et l'ancienne imprimait
- * l'identifiant technique du client sur un document envoye au client.
- */
+type Queryable = Pick<PoolClient, "query">
 
-async function ensureDocsDir(): Promise<string> {
-  const uploadDir = ensureDocumentStoragePath("livraisons")
-  await fs.mkdir(uploadDir, { recursive: true })
-  return uploadDir
+type PdfDocumentRow = {
+  bon_livraison_id: string
+  document_id: string | null
+  version: number | null
+  generated_at: string | null
+  file_size_bytes: number | null
 }
 
-// L'emetteur n'est plus reduit a sa raison sociale : `readIssuerParty` remonte aussi son
-// identite legale et ses mentions obligatoires, que le bon de livraison doit porter.
-
-export async function svcGetLatestLivraisonPdfDocument(id: string): Promise<{ document_id: string; version: number } | null> {
-  const res = await pool.query<{ document_id: string; version: number }>(
-    `
-    SELECT d.document_id::text AS document_id, d.version
-    FROM bon_livraison_documents d
-    WHERE d.bon_livraison_id = $1::uuid AND d.type = 'PDF'
-    ORDER BY d.version DESC, d.id DESC
-    LIMIT 1
-    `,
-    [id]
+const generatedPdfPredicate = `
+  (
+    document.type = 'GENERATED_SIMPLE_BL_PDF'
+    OR (
+      document.type = 'PDF'
+      AND EXISTS (
+        SELECT 1
+        FROM public.bon_livraison_event_log event
+        WHERE event.bon_livraison_id = document.bon_livraison_id
+          AND event.event_type = 'PDF_GENERATED'
+          AND event.new_values ->> 'document_id' = document.document_id::text
+      )
+    )
   )
-  const row = res.rows[0]
-  return row ? { document_id: row.document_id, version: row.version } : null
+`
+
+function normalizeIdempotencyKey(value: string): string {
+  const normalized = value.trim()
+  if (normalized.length < 8 || normalized.length > 200) {
+    throw new HttpError(
+      400,
+      "IDEMPOTENCY_KEY_REQUIRED",
+      "A valid Idempotency-Key header is required (8 to 200 characters)."
+    )
+  }
+  return normalized
 }
 
-export async function svcGetPdfFilePath(documentId: string): Promise<string> {
-  const docsDir = await ensureDocsDir()
-  return path.join(docsDir, `${documentId}.pdf`)
+function idempotencyKeyHash(value: string): string {
+  return crypto.createHash("sha256").update(value, "utf8").digest("hex")
 }
 
-export async function svcGenerateLivraisonPdf(bonLivraisonId: string, userId: number): Promise<{ document_id: string; version: number }> {
-  const detail = await repoGetLivraisonDetail(bonLivraisonId)
-  if (!detail) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+async function queryPdfDocument(
+  bonLivraisonId: string,
+  version?: number,
+  queryable: Queryable = pool
+): Promise<PdfDocumentRow | null> {
+  const result = await queryable.query<PdfDocumentRow>(
+    `
+      SELECT
+        delivery.id::text AS bon_livraison_id,
+        latest.document_id,
+        latest.version,
+        latest.generated_at,
+        latest.file_size_bytes
+      FROM public.bon_livraison delivery
+      LEFT JOIN LATERAL (
+        SELECT
+          document.document_id::text AS document_id,
+          document.version::int AS version,
+          document.created_at::text AS generated_at,
+          document.file_size_bytes::float8 AS file_size_bytes
+        FROM public.bon_livraison_documents document
+        WHERE document.bon_livraison_id = delivery.id
+          AND ${generatedPdfPredicate}
+          AND ($2::int IS NULL OR document.version = $2::int)
+        ORDER BY document.version DESC, document.created_at DESC, document.id DESC
+        LIMIT 1
+      ) latest ON TRUE
+      WHERE delivery.id = $1::uuid
+    `,
+    [bonLivraisonId, version ?? null]
+  )
+  return result.rows[0] ?? null
+}
 
-  const existing = await svcGetLatestLivraisonPdfDocument(bonLivraisonId)
-  const version = (existing?.version ?? 0) + 1
+async function assertStoredPdf(
+  documentId: string,
+  expectedSize: number | null
+): Promise<void> {
+  const filePath = svcGetPdfFilePath(documentId)
+  let handle: Awaited<ReturnType<typeof fs.open>> | null = null
+  try {
+    handle = await fs.open(filePath, "r")
+    const stat = await handle.stat()
+    const signature = Buffer.alloc(5)
+    const read = await handle.read(signature, 0, signature.length, 0)
+    if (
+      !stat.isFile() ||
+      stat.size < signature.length ||
+      read.bytesRead !== signature.length ||
+      signature.toString("ascii") !== "%PDF-"
+    ) {
+      throw new HttpError(
+        500,
+        "LIVRAISON_PDF_INVALID",
+        "Le PDF archive est invalide. Une regeneration explicite est requise."
+      )
+    }
+    if (expectedSize !== null && expectedSize > 0 && stat.size !== expectedSize) {
+      throw new HttpError(
+        500,
+        "LIVRAISON_PDF_INTEGRITY_ERROR",
+        "Le PDF archive ne correspond plus a son empreinte de stockage."
+      )
+    }
+  } catch (error) {
+    if (error instanceof HttpError) throw error
+    const code = typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code ?? "")
+      : ""
+    if (code === "ENOENT") {
+      throw new HttpError(
+        410,
+        "LIVRAISON_PDF_FILE_MISSING",
+        "Le PDF archive est reference mais son fichier est indisponible. Une regeneration explicite est requise."
+      )
+    }
+    throw error
+  } finally {
+    await handle?.close().catch(() => undefined)
+  }
+}
 
-  const docsDir = await ensureDocsDir()
-  const documentId = crypto.randomUUID()
-  const fileName = `Bon_livraison_${detail.bon_livraison.numero}.pdf`
-  const filePath = path.join(docsDir, `${documentId}.pdf`)
+export async function svcGetLivraisonPdfAvailability(
+  bonLivraisonId: string,
+  version?: number
+): Promise<LivraisonPdfAvailability> {
+  const row = await queryPdfDocument(bonLivraisonId, version)
+  if (!row) {
+    throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+  }
+  if (!row.document_id || !row.version || !row.generated_at) {
+    if (version !== undefined) {
+      throw new HttpError(
+        404,
+        "LIVRAISON_PDF_VERSION_NOT_FOUND",
+        `La version ${version} du PDF n'existe pas.`
+      )
+    }
+    return {
+      available: false,
+      status: "NOT_GENERATED",
+      document_id: null,
+      version: null,
+      generated_at: null,
+    }
+  }
 
-  const issuer = await readIssuerParty({
-    at: detail.bon_livraison.date_expedition ?? detail.bon_livraison.date_creation,
-  })
-  const pdfBytes = await renderBonLivraisonDocument({
-    header: detail.bon_livraison,
-    lignes: detail.lignes,
-    version,
-    company: pickMention(issuer, "company_name"),
-    issuer,
-  })
-  await fs.mkdir(path.dirname(filePath), { recursive: true })
-  await fs.writeFile(filePath, pdfBytes)
+  await assertStoredPdf(row.document_id, row.file_size_bytes)
+  return {
+    available: true,
+    status: "AVAILABLE",
+    document_id: row.document_id,
+    version: row.version,
+    generated_at: row.generated_at,
+  }
+}
 
-  const checksumSha256 = crypto.createHash("sha256").update(pdfBytes).digest("hex")
+export function svcGetPdfFilePath(documentId: string): string {
+  return path.join(getDocumentStoragePath("livraisons"), `${documentId}.pdf`)
+}
 
+async function findIdempotentReplay(
+  db: Queryable,
+  bonLivraisonId: string,
+  userId: number,
+  keyHash: string
+): Promise<PdfDocumentRow | null> {
+  const result = await db.query<PdfDocumentRow>(
+    `
+      SELECT
+        event.bon_livraison_id::text AS bon_livraison_id,
+        document.document_id::text AS document_id,
+        document.version::int AS version,
+        document.created_at::text AS generated_at,
+        document.file_size_bytes::float8 AS file_size_bytes
+      FROM public.bon_livraison_event_log event
+      JOIN public.bon_livraison_documents document
+        ON document.bon_livraison_id = event.bon_livraison_id
+       AND document.document_id::text = event.new_values ->> 'document_id'
+      WHERE event.bon_livraison_id = $1::uuid
+        AND event.user_id = $2
+        AND event.event_type = 'PDF_GENERATED'
+        AND event.new_values ->> 'idempotency_key_hash' = $3
+      ORDER BY event.id DESC
+      LIMIT 1
+    `,
+    [bonLivraisonId, userId, keyHash]
+  )
+  return result.rows[0] ?? null
+}
+
+async function nextPdfVersion(db: Queryable, bonLivraisonId: string): Promise<number> {
+  const result = await db.query<{ version: number }>(
+    `
+      SELECT COALESCE(MAX(document.version), 0)::int + 1 AS version
+      FROM public.bon_livraison_documents document
+      WHERE document.bon_livraison_id = $1::uuid
+        AND ${generatedPdfPredicate}
+    `,
+    [bonLivraisonId]
+  )
+  const version = result.rows[0]?.version
+  if (!Number.isInteger(version) || version < 1) {
+    throw new Error("Failed to compute livraison PDF version")
+  }
+  return version
+}
+
+/**
+ * Generate one archived BL version.
+ *
+ * The delivery row lock serializes concurrent generation requests. Replaying the same
+ * actor/key returns the original result, while a new key intentionally creates a new version.
+ */
+export async function svcGenerateLivraisonPdf(
+  bonLivraisonId: string,
+  userId: number,
+  idempotencyKeyRaw: string
+): Promise<LivraisonPdfGenerationResult> {
+  const idempotencyKey = normalizeIdempotencyKey(idempotencyKeyRaw)
+  const keyHash = idempotencyKeyHash(idempotencyKey)
   const db = await pool.connect()
+  let filePath: string | null = null
+  let temporaryPath: string | null = null
+  let committed = false
+
   try {
     await db.query("BEGIN")
-    await db.query(`INSERT INTO documents_clients (id, document_name, type) VALUES ($1, $2, $3)`, [documentId, fileName, "PDF"])
+    const delivery = await db.query<{ id: string }>(
+      `SELECT id::text AS id FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
+      [bonLivraisonId]
+    )
+    if (!delivery.rows[0]) {
+      throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    }
+
+    const replay = await findIdempotentReplay(db, bonLivraisonId, userId, keyHash)
+    if (replay?.document_id && replay.version) {
+      await assertStoredPdf(replay.document_id, replay.file_size_bytes)
+      await db.query("COMMIT")
+      committed = true
+      return {
+        document_id: replay.document_id,
+        version: replay.version,
+        idempotent_replay: true,
+      }
+    }
+
+    const detail = await repoGetLivraisonDetail(bonLivraisonId)
+    if (!detail) {
+      throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    }
+    const version = await nextPdfVersion(db, bonLivraisonId)
+    const issuer = await readIssuerParty({
+      at: detail.bon_livraison.date_expedition ?? detail.bon_livraison.date_creation,
+    })
+    const pdfBytes = await renderBonLivraisonDocument({
+      header: detail.bon_livraison,
+      lignes: detail.lignes,
+      version,
+      company: pickMention(issuer, "company_name"),
+      issuer,
+    })
+
+    const docsDir = ensureDocumentStoragePath("livraisons")
+    const documentId = crypto.randomUUID()
+    const fileName = `Bon_livraison_${detail.bon_livraison.numero}.pdf`
+    filePath = path.join(docsDir, `${documentId}.pdf`)
+    temporaryPath = path.join(docsDir, `.${documentId}.pdf.tmp`)
+    await fs.writeFile(temporaryPath, pdfBytes, { flag: "wx" })
+    await fs.rename(temporaryPath, filePath)
+    temporaryPath = null
+
+    const checksumSha256 = crypto.createHash("sha256").update(pdfBytes).digest("hex")
+    await db.query(
+      `INSERT INTO public.documents_clients (id, document_name, type) VALUES ($1, $2, 'PDF')`,
+      [documentId, fileName]
+    )
     await db.query(
       `
-        INSERT INTO bon_livraison_documents (
+        INSERT INTO public.bon_livraison_documents (
           bon_livraison_id,
           document_id,
           type,
@@ -92,32 +311,52 @@ export async function svcGenerateLivraisonPdf(bonLivraisonId: string, userId: nu
           file_size_bytes,
           mime_type
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, 'application/pdf')
+        VALUES ($1::uuid, $2::uuid, 'GENERATED_SIMPLE_BL_PDF', $3, $4, $5, $6, 'application/pdf')
       `,
-      [bonLivraisonId, documentId, "PDF", version, userId, checksumSha256, pdfBytes.byteLength]
+      [bonLivraisonId, documentId, version, userId, checksumSha256, pdfBytes.byteLength]
     )
     await db.query(
-      `INSERT INTO bon_livraison_event_log (bon_livraison_id, event_type, old_values, new_values, user_id)
-       VALUES ($1, $2, $3::jsonb, $4::jsonb, $5)`,
+      `
+        INSERT INTO public.bon_livraison_event_log (
+          bon_livraison_id,
+          event_type,
+          old_values,
+          new_values,
+          user_id
+        )
+        VALUES ($1::uuid, 'PDF_GENERATED', NULL, $2::jsonb, $3)
+      `,
       [
         bonLivraisonId,
-        "PDF_GENERATED",
-        null,
-        JSON.stringify({ document_id: documentId, version, checksum_sha256: checksumSha256 }),
+        JSON.stringify({
+          document_id: documentId,
+          version,
+          checksum_sha256: checksumSha256,
+          idempotency_key_hash: keyHash,
+        }),
         userId,
       ]
     )
-    await db.query(`UPDATE bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`, [bonLivraisonId, userId])
+    await db.query(
+      `UPDATE public.bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`,
+      [bonLivraisonId, userId]
+    )
     await db.query("COMMIT")
-  } catch (err) {
-    await db.query("ROLLBACK")
-    await fs.unlink(filePath).catch(() => undefined)
-    throw err
+    committed = true
+    return { document_id: documentId, version, idempotent_replay: false }
+  } catch (error) {
+    if (!committed) await db.query("ROLLBACK").catch(() => undefined)
+    throw error
   } finally {
     db.release()
+    if (!committed) {
+      await Promise.all(
+        [temporaryPath, filePath]
+          .filter((candidate): candidate is string => Boolean(candidate))
+          .map((candidate) => fs.unlink(candidate).catch(() => undefined))
+      )
+    }
   }
-
-  return { document_id: documentId, version }
 }
 
 export async function svcGetDocumentName(documentId: string) {

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -13,6 +13,7 @@ import {
 import { HttpError } from "../../../utils/httpError"
 import { repoGetLivraisonDetail, repoGetDocumentName } from "../repository/livraisons.repository"
 import type {
+  BonLivraisonStatut,
   LivraisonPdfAvailability,
   LivraisonPdfGenerationResult,
 } from "../types/livraisons.types"
@@ -27,6 +28,7 @@ type PdfDocumentRow = {
   version: number | null
   generated_at: string | null
   file_size_bytes: number | null
+  checksum_sha256: string | null
 }
 
 const generatedPdfPredicate = `
@@ -73,14 +75,16 @@ async function queryPdfDocument(
         latest.document_id,
         latest.version,
         latest.generated_at,
-        latest.file_size_bytes
+        latest.file_size_bytes,
+        latest.checksum_sha256
       FROM public.bon_livraison delivery
       LEFT JOIN LATERAL (
         SELECT
           document.document_id::text AS document_id,
           document.version::int AS version,
           document.created_at::text AS generated_at,
-          document.file_size_bytes::float8 AS file_size_bytes
+          document.file_size_bytes::float8 AS file_size_bytes,
+          document.checksum_sha256
         FROM public.bon_livraison_documents document
         WHERE document.bon_livraison_id = delivery.id
           AND ${generatedPdfPredicate}
@@ -97,20 +101,15 @@ async function queryPdfDocument(
 
 async function assertStoredPdf(
   documentId: string,
-  expectedSize: number | null
+  expectedSize: number | null,
+  expectedChecksum: string | null
 ): Promise<void> {
   const filePath = svcGetPdfFilePath(documentId)
-  let handle: Awaited<ReturnType<typeof fs.open>> | null = null
   try {
-    handle = await fs.open(filePath, "r")
-    const stat = await handle.stat()
-    const signature = Buffer.alloc(5)
-    const read = await handle.read(signature, 0, signature.length, 0)
+    const bytes = await fs.readFile(filePath)
     if (
-      !stat.isFile() ||
-      stat.size < signature.length ||
-      read.bytesRead !== signature.length ||
-      signature.toString("ascii") !== "%PDF-"
+      bytes.byteLength < 5 ||
+      bytes.subarray(0, 5).toString("ascii") !== "%PDF-"
     ) {
       throw new HttpError(
         500,
@@ -118,12 +117,23 @@ async function assertStoredPdf(
         "Le PDF archive est invalide. Une regeneration explicite est requise."
       )
     }
-    if (expectedSize !== null && expectedSize > 0 && stat.size !== expectedSize) {
+    if (expectedSize !== null && expectedSize > 0 && bytes.byteLength !== expectedSize) {
       throw new HttpError(
         500,
         "LIVRAISON_PDF_INTEGRITY_ERROR",
         "Le PDF archive ne correspond plus a son empreinte de stockage."
       )
+    }
+    if (expectedChecksum !== null) {
+      const normalizedChecksum = expectedChecksum.trim().toLowerCase()
+      const actualChecksum = crypto.createHash("sha256").update(bytes).digest("hex")
+      if (!/^[a-f0-9]{64}$/.test(normalizedChecksum) || actualChecksum !== normalizedChecksum) {
+        throw new HttpError(
+          500,
+          "LIVRAISON_PDF_INTEGRITY_ERROR",
+          "Le PDF archive ne correspond plus a son empreinte SHA-256."
+        )
+      }
     }
   } catch (error) {
     if (error instanceof HttpError) throw error
@@ -138,8 +148,6 @@ async function assertStoredPdf(
       )
     }
     throw error
-  } finally {
-    await handle?.close().catch(() => undefined)
   }
 }
 
@@ -168,7 +176,7 @@ export async function svcGetLivraisonPdfAvailability(
     }
   }
 
-  await assertStoredPdf(row.document_id, row.file_size_bytes)
+  await assertStoredPdf(row.document_id, row.file_size_bytes, row.checksum_sha256)
   return {
     available: true,
     status: "AVAILABLE",
@@ -195,7 +203,8 @@ async function findIdempotentReplay(
         document.document_id::text AS document_id,
         document.version::int AS version,
         document.created_at::text AS generated_at,
-        document.file_size_bytes::float8 AS file_size_bytes
+        document.file_size_bytes::float8 AS file_size_bytes,
+        document.checksum_sha256
       FROM public.bon_livraison_event_log event
       JOIN public.bon_livraison_documents document
         ON document.bon_livraison_id = event.bon_livraison_id
@@ -249,17 +258,29 @@ export async function svcGenerateLivraisonPdf(
 
   try {
     await db.query("BEGIN")
-    const delivery = await db.query<{ id: string }>(
-      `SELECT id::text AS id FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
+    const delivery = await db.query<{ id: string; statut: BonLivraisonStatut }>(
+      `SELECT id::text AS id, statut FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
       [bonLivraisonId]
     )
-    if (!delivery.rows[0]) {
+    const lockedDelivery = delivery.rows[0]
+    if (!lockedDelivery) {
       throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    }
+    if (lockedDelivery.statut === "CANCELLED") {
+      throw new HttpError(
+        409,
+        "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+        "Un bon de livraison annulé ne peut plus générer de nouveau PDF."
+      )
     }
 
     const replay = await findIdempotentReplay(db, bonLivraisonId, userId, keyHash)
     if (replay?.document_id && replay.version) {
-      await assertStoredPdf(replay.document_id, replay.file_size_bytes)
+      await assertStoredPdf(
+        replay.document_id,
+        replay.file_size_bytes,
+        replay.checksum_sha256
+      )
       await db.query("COMMIT")
       committed = true
       return {

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -31,6 +31,10 @@ type PdfDocumentRow = {
   checksum_sha256: string | null
 }
 
+type LivraisonPdfReadResult =
+  | (Extract<LivraisonPdfAvailability, { available: false }> & { bytes: null })
+  | (Extract<LivraisonPdfAvailability, { available: true }> & { bytes: Buffer })
+
 const generatedPdfPredicate = `
   (
     document.type = 'GENERATED_SIMPLE_BL_PDF'
@@ -103,7 +107,7 @@ async function assertStoredPdf(
   documentId: string,
   expectedSize: number | null,
   expectedChecksum: string | null
-): Promise<void> {
+): Promise<Buffer> {
   const filePath = svcGetPdfFilePath(documentId)
   try {
     const bytes = await fs.readFile(filePath)
@@ -135,6 +139,7 @@ async function assertStoredPdf(
         )
       }
     }
+    return bytes
   } catch (error) {
     if (error instanceof HttpError) throw error
     const code = typeof error === "object" && error !== null && "code" in error
@@ -151,10 +156,10 @@ async function assertStoredPdf(
   }
 }
 
-export async function svcGetLivraisonPdfAvailability(
+async function readLivraisonPdf(
   bonLivraisonId: string,
   version?: number
-): Promise<LivraisonPdfAvailability> {
+): Promise<LivraisonPdfReadResult> {
   const row = await queryPdfDocument(bonLivraisonId, version)
   if (!row) {
     throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
@@ -173,17 +178,53 @@ export async function svcGetLivraisonPdfAvailability(
       document_id: null,
       version: null,
       generated_at: null,
+      bytes: null,
     }
   }
 
-  await assertStoredPdf(row.document_id, row.file_size_bytes, row.checksum_sha256)
+  const bytes = await assertStoredPdf(
+    row.document_id,
+    row.file_size_bytes,
+    row.checksum_sha256
+  )
   return {
     available: true,
     status: "AVAILABLE",
     document_id: row.document_id,
     version: row.version,
     generated_at: row.generated_at,
+    bytes,
   }
+}
+
+export async function svcGetLivraisonPdfAvailability(
+  bonLivraisonId: string,
+  version?: number
+): Promise<LivraisonPdfAvailability> {
+  const result = await readLivraisonPdf(bonLivraisonId, version)
+  if (!result.available) {
+    return {
+      available: false,
+      status: result.status,
+      document_id: null,
+      version: null,
+      generated_at: null,
+    }
+  }
+  return {
+    available: true,
+    status: result.status,
+    document_id: result.document_id,
+    version: result.version,
+    generated_at: result.generated_at,
+  }
+}
+
+export async function svcReadLivraisonPdf(
+  bonLivraisonId: string,
+  version?: number
+): Promise<LivraisonPdfReadResult> {
+  return readLivraisonPdf(bonLivraisonId, version)
 }
 
 export function svcGetPdfFilePath(documentId: string): string {

--- a/src/module/livraisons/types/livraisons.types.ts
+++ b/src/module/livraisons/types/livraisons.types.ts
@@ -189,6 +189,28 @@ export type BonLivraisonDetail = {
   events: BonLivraisonEventLog[]
 }
 
+export type LivraisonPdfAvailability =
+  | {
+      available: false
+      status: "NOT_GENERATED"
+      document_id: null
+      version: null
+      generated_at: null
+    }
+  | {
+      available: true
+      status: "AVAILABLE"
+      document_id: string
+      version: number
+      generated_at: string
+    }
+
+export type LivraisonPdfGenerationResult = {
+  document_id: string
+  version: number
+  idempotent_replay: boolean
+}
+
 export type ShipmentPreviewBlocker = {
   code: string
   message: string

--- a/src/module/livraisons/validators/livraisons.validators.ts
+++ b/src/module/livraisons/validators/livraisons.validators.ts
@@ -28,6 +28,13 @@ export const livraisonDocParamsSchema = z.object({
   docId: uuid,
 }).strict()
 
+export const livraisonPdfQuerySchema = z
+  .object({
+    version: z.coerce.number().int().positive().optional(),
+    download: z.union([z.string(), z.number(), z.boolean()]).optional(),
+  })
+  .strict()
+
 export const fromCommandeParamsSchema = z.object({
   commandeId: z.coerce.number().int().positive(),
 }).strict()


### PR DESCRIPTION
## Summary

Fixes BUG-CERP-0018 at the API boundary by separating BL PDF availability, read, and generation.

## Changes

- adds a read-only PDF availability endpoint
- makes GET PDF fail closed without implicit generation or repair
- requires documents_manage and Idempotency-Key for explicit generation
- serializes concurrent generation and replays the same intention
- keeps standalone BL archives separate from frozen pack versions
- reports missing or invalid stored archives as integrity errors

## Validation

- backend build passed
- full backend suite: 3714/3714 tests passed
- focused livraison PDF suite: 26/26 tests passed
- Vitest collection gate: 188 files

## Related

- Frontend PR: https://github.com/BigFootLime/crp-systems-web/pull/493