### PR TITLE
fix(livraisons): reconcile uncertain PDF commits

### DIFF
--- a/docs/livraison-document-cerp-213.md
+++ b/docs/livraison-document-cerp-213.md
@@ -101,10 +101,13 @@ navigateur ou un proxy ne réutilise pas un état d'autorisation ou une version 
 Le fichier final est renommé avant le `COMMIT` qui archive ses métadonnées. Si PostgreSQL rend
 le commit durable mais que son accusé réseau est perdu, la connexion d'origine est considérée
 comme incertaine et n'est jamais « prouvée » par un `ROLLBACK`. Le service la détruit, prend une
-connexion fraîche, attend la résolution du verrou du BL, puis recherche l'événement et le
-document par livraison, auteur, empreinte d'`Idempotency-Key`, identifiant et version :
+connexion fraîche et ouvre une transaction dédiée. Cette transaction attend la résolution du
+verrou du BL, recherche l'événement et le document, puis vérifie avant son propre `COMMIT` que
+livraison, auteur, empreinte d'`Idempotency-Key`, identifiant, version et SHA-256 concordent. Le
+SHA-256 attendu reste celui calculé en mémoire avant le commit original :
 
-- identité exacte retrouvée et fichier intègre : le résultat est finalisé et le fichier reste ;
+- identité exacte `résultat attendu = événement = document` retrouvée, puis octets du fichier
+  conformes au SHA-256 attendu : le résultat est finalisé et le fichier reste ;
 - aucune métadonnée après la barrière de verrou : le commit n'a pas été durable et le fichier
   orphelin est supprimé ;
 - connexion, recherche ou identité incohérente : réponse

--- a/docs/livraison-document-cerp-213.md
+++ b/docs/livraison-document-cerp-213.md
@@ -96,6 +96,25 @@ substitution entre validation et réponse HTTP.
 Les réponses PDF et de disponibilité portent `Cache-Control: private, no-store` afin qu'un
 navigateur ou un proxy ne réutilise pas un état d'autorisation ou une version obsolète.
 
+### Commit PostgreSQL incertain
+
+Le fichier final est renommé avant le `COMMIT` qui archive ses métadonnées. Si PostgreSQL rend
+le commit durable mais que son accusé réseau est perdu, la connexion d'origine est considérée
+comme incertaine et n'est jamais « prouvée » par un `ROLLBACK`. Le service la détruit, prend une
+connexion fraîche, attend la résolution du verrou du BL, puis recherche l'événement et le
+document par livraison, auteur, empreinte d'`Idempotency-Key`, identifiant et version :
+
+- identité exacte retrouvée et fichier intègre : le résultat est finalisé et le fichier reste ;
+- aucune métadonnée après la barrière de verrou : le commit n'a pas été durable et le fichier
+  orphelin est supprimé ;
+- connexion, recherche ou identité incohérente : réponse
+  `LIVRAISON_PDF_COMMIT_UNCERTAIN` (`503`), fichier conservé par sécurité et alerte structurée.
+
+Runbook opérateur pour le dernier cas : rejouer d'abord la même `Idempotency-Key`, vérifier
+l'événement `PDF_GENERATED` et `bon_livraison_documents.document_id`, puis comparer taille et
+SHA-256 du fichier. Ne jamais supprimer le fichier tant qu'une référence durable n'a pas été
+exclue après verrouillage du BL.
+
 ## 4. Ce qui ne doit jamais figurer sur ces documents
 
 | Fuite trouvée | Corrigé en |

--- a/src/module/livraisons/services/pdf.service.test.ts
+++ b/src/module/livraisons/services/pdf.service.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   repoGetLivraisonDetail: vi.fn(),
   repoGetDocumentName: vi.fn(),
   renderBonLivraisonDocument: vi.fn(),
+  loggerError: vi.fn(),
 }))
 
 vi.mock("../../../config/database", () => ({
@@ -28,6 +29,11 @@ vi.mock("../repository/livraisons.repository", () => ({
 }))
 vi.mock("./bon-livraison-document", () => ({
   renderBonLivraisonDocument: (...args: unknown[]) => mocks.renderBonLivraisonDocument(...args),
+}))
+vi.mock("../../../utils/logger", () => ({
+  default: {
+    error: (...args: unknown[]) => mocks.loggerError(...args),
+  },
 }))
 
 import {
@@ -101,6 +107,75 @@ function generationDb(options: {
     return { rows: [] }
   })
   return { query, release: vi.fn() }
+}
+
+function uncertainCommitDatabase(options: {
+  durable: boolean
+  reconciliationError?: Error
+  reconciledDocumentId?: string
+  reconciledVersion?: number
+}) {
+  let documentId: string | null = null
+  let persisted: {
+    document_id: string
+    version: number
+    generated_at: string
+    file_size_bytes: number
+    checksum_sha256: string
+  } | null = null
+
+  const primaryQuery = vi.fn(async (sqlValue: unknown, values?: unknown[]) => {
+    const sql = String(sqlValue)
+    if (sql.includes("SELECT id::text AS id") && sql.includes("statut") && sql.includes("FOR UPDATE")) {
+      return { rows: [{ id: BL_ID, statut: "DRAFT" }] }
+    }
+    if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) return { rows: [] }
+    if (sql.includes("COALESCE(MAX(document.version)")) return { rows: [{ version: 1 }] }
+    if (sql.includes("INSERT INTO public.bon_livraison_documents")) {
+      documentId = String(values?.[1])
+      persisted = {
+        document_id: documentId,
+        version: Number(values?.[2]),
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: Number(values?.[5]),
+        checksum_sha256: String(values?.[4]),
+      }
+    }
+    if (sql === "COMMIT") {
+      if (!options.durable) persisted = null
+      throw Object.assign(new Error("commit acknowledgement lost"), { code: "ECONNRESET" })
+    }
+    return { rows: [] }
+  })
+  const reconciliationQuery = vi.fn(async (sqlValue: unknown) => {
+    const sql = String(sqlValue)
+    if (sql.includes("FROM public.bon_livraison") && sql.includes("FOR UPDATE")) {
+      return { rows: [{ id: BL_ID }] }
+    }
+    if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) {
+      if (options.reconciliationError) throw options.reconciliationError
+      return {
+        rows: persisted
+          ? [{
+              bon_livraison_id: BL_ID,
+              ...persisted,
+              document_id: options.reconciledDocumentId ?? persisted.document_id,
+              version: options.reconciledVersion ?? persisted.version,
+            }]
+          : [],
+      }
+    }
+    return { rows: [] }
+  })
+  const primary: TestPoolClient = { query: primaryQuery, release: vi.fn() }
+  const reconciliation: TestPoolClient = { query: reconciliationQuery, release: vi.fn() }
+
+  return {
+    primary,
+    reconciliation,
+    getDocumentId: () => documentId,
+    getPersisted: () => persisted,
+  }
 }
 
 async function storePdf(documentId = DOC_ID, bytes = PDF_BYTES) {
@@ -393,6 +468,148 @@ describe("livraison PDF generation", () => {
     expect(
       db.query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO public.documents_clients")),
     ).toBe(false)
+  })
+
+  it("keeps a durable PDF when COMMIT succeeds but its acknowledgement is lost", async () => {
+    const scenario = uncertainCommitDatabase({ durable: true })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    const result = await svcGenerateLivraisonPdf(BL_ID, 7, "durable-commit-reconcile")
+
+    expect(result).toMatchObject({ version: 1, idempotent_replay: false })
+    expect(result.document_id).toBe(scenario.getDocumentId())
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${result.document_id}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(scenario.primary.query).not.toHaveBeenCalledWith("ROLLBACK")
+    expect(scenario.primary.release).toHaveBeenCalledWith(expect.any(Error))
+    expect(scenario.reconciliation.query).toHaveBeenCalledWith(
+      expect.stringContaining("FOR UPDATE"),
+      [BL_ID],
+    )
+
+    const persisted = scenario.getPersisted()
+    expect(persisted).not.toBeNull()
+    const retryDb = generationDb({ replay: persisted ?? undefined })
+    mocks.poolConnect.mockResolvedValueOnce(retryDb)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "durable-commit-reconcile"),
+    ).resolves.toEqual({
+      document_id: result.document_id,
+      version: 1,
+      idempotent_replay: true,
+    })
+    expect(mocks.renderBonLivraisonDocument).toHaveBeenCalledTimes(1)
+  })
+
+  it("cleans the file when a failed COMMIT is proven non-durable", async () => {
+    const scenario = uncertainCommitDatabase({ durable: false })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "non-durable-commit"),
+    ).rejects.toMatchObject({ code: "ECONNRESET" })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.access(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).rejects.toMatchObject({ code: "ENOENT" })
+    expect(scenario.getPersisted()).toBeNull()
+    expect(scenario.primary.query).not.toHaveBeenCalledWith("ROLLBACK")
+    expect(mocks.loggerError).not.toHaveBeenCalled()
+  })
+
+  it("preserves a potentially referenced file when commit reconciliation fails", async () => {
+    const scenario = uncertainCommitDatabase({
+      durable: true,
+      reconciliationError: new Error("reconciliation database unavailable"),
+    })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "uncertain-commit-lookup"),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+    })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(scenario.getPersisted()).not.toBeNull()
+    expect(scenario.primary.query).not.toHaveBeenCalledWith("ROLLBACK")
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "livraison_pdf_commit_uncertain",
+      expect.objectContaining({ document_id: documentId, version: 1 }),
+    )
+  })
+
+  it("preserves the file and fails closed when reconciliation resolves another document identity", async () => {
+    const scenario = uncertainCommitDatabase({
+      durable: true,
+      reconciledDocumentId: "99999999-9999-4999-8999-999999999999",
+    })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "uncertain-commit-identity"),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+    })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(scenario.getPersisted()).not.toBeNull()
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "livraison_pdf_commit_uncertain",
+      expect.objectContaining({ document_id: documentId, version: 1 }),
+    )
+  })
+
+  it("preserves the file when no fresh connection can reconcile the commit", async () => {
+    const scenario = uncertainCommitDatabase({ durable: true })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockRejectedValueOnce(new Error("reconciliation pool unavailable"))
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "uncertain-commit-connect"),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+    })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(scenario.getPersisted()).not.toBeNull()
+    expect(scenario.primary.query).not.toHaveBeenCalledWith("ROLLBACK")
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "livraison_pdf_commit_uncertain",
+      expect.objectContaining({
+        document_id: documentId,
+        version: 1,
+        reconciliation_error: "reconciliation pool unavailable",
+      }),
+    )
   })
 
   it("rejects a same-size checksum corruption during idempotent replay", async () => {

--- a/src/module/livraisons/services/pdf.service.test.ts
+++ b/src/module/livraisons/services/pdf.service.test.ts
@@ -97,7 +97,13 @@ function generationDb(options: {
     if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) {
       return {
         rows: options.replay
-          ? [{ bon_livraison_id: BL_ID, ...options.replay }]
+          ? [{
+              bon_livraison_id: BL_ID,
+              event_document_id: options.replay.document_id,
+              event_version: options.replay.version,
+              event_checksum_sha256: options.replay.checksum_sha256,
+              ...options.replay,
+            }]
           : [],
       }
     }
@@ -114,6 +120,10 @@ function uncertainCommitDatabase(options: {
   reconciliationError?: Error
   reconciledDocumentId?: string
   reconciledVersion?: number
+  reconciledEventChecksum?: string
+  reconciledDocumentChecksum?: string
+  beforeReconciliationLookup?: () => Promise<void>
+  afterReconciliationCommit?: () => Promise<void>
 }) {
   let documentId: string | null = null
   let persisted: {
@@ -149,18 +159,29 @@ function uncertainCommitDatabase(options: {
   })
   const reconciliationQuery = vi.fn(async (sqlValue: unknown) => {
     const sql = String(sqlValue)
+    if (sql === "COMMIT") {
+      await options.afterReconciliationCommit?.()
+      return { rows: [] }
+    }
     if (sql.includes("FROM public.bon_livraison") && sql.includes("FOR UPDATE")) {
       return { rows: [{ id: BL_ID }] }
     }
     if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) {
+      await options.beforeReconciliationLookup?.()
       if (options.reconciliationError) throw options.reconciliationError
       return {
         rows: persisted
           ? [{
               bon_livraison_id: BL_ID,
+              event_document_id: persisted.document_id,
+              event_version: persisted.version,
+              event_checksum_sha256:
+                options.reconciledEventChecksum ?? persisted.checksum_sha256,
               ...persisted,
               document_id: options.reconciledDocumentId ?? persisted.document_id,
               version: options.reconciledVersion ?? persisted.version,
+              checksum_sha256:
+                options.reconciledDocumentChecksum ?? persisted.checksum_sha256,
             }]
           : [],
       }
@@ -489,6 +510,16 @@ describe("livraison PDF generation", () => {
       expect.stringContaining("FOR UPDATE"),
       [BL_ID],
     )
+    const reconciliationStatements = scenario.reconciliation.query.mock.calls.map(([sql]) =>
+      String(sql),
+    )
+    expect(reconciliationStatements[0]).toBe("BEGIN")
+    expect(reconciliationStatements.findIndex((sql) => sql.includes("FOR UPDATE"))).toBe(1)
+    expect(
+      reconciliationStatements.findIndex((sql) => sql.includes("idempotency_key_hash")),
+    ).toBe(2)
+    expect(reconciliationStatements[3]).toBe("COMMIT")
+    expect(scenario.reconciliation.release).toHaveBeenCalledWith()
 
     const persisted = scenario.getPersisted()
     expect(persisted).not.toBeNull()
@@ -503,6 +534,36 @@ describe("livraison PDF generation", () => {
       idempotent_replay: true,
     })
     expect(mocks.renderBonLivraisonDocument).toHaveBeenCalledTimes(1)
+  })
+
+  it("holds the reconciliation transaction across the lock barrier and proof lookup", async () => {
+    const lookupStarted = deferred()
+    const allowLookup = deferred()
+    const scenario = uncertainCommitDatabase({
+      durable: true,
+      beforeReconciliationLookup: async () => {
+        lookupStarted.resolve()
+        await allowLookup.promise
+      },
+    })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    const generation = svcGenerateLivraisonPdf(BL_ID, 7, "atomic-commit-reconcile")
+    await lookupStarted.promise
+
+    const pendingStatements = scenario.reconciliation.query.mock.calls.map(([sql]) => String(sql))
+    expect(pendingStatements[0]).toBe("BEGIN")
+    expect(pendingStatements[1]).toContain("FOR UPDATE")
+    expect(pendingStatements[2]).toContain("idempotency_key_hash")
+    expect(pendingStatements).not.toContain("COMMIT")
+    expect(scenario.reconciliation.release).not.toHaveBeenCalled()
+
+    allowLookup.resolve()
+    await expect(generation).resolves.toMatchObject({ version: 1, idempotent_replay: false })
+    expect(scenario.reconciliation.query).toHaveBeenLastCalledWith("COMMIT")
+    expect(scenario.reconciliation.release).toHaveBeenCalledWith()
   })
 
   it("cleans the file when a failed COMMIT is proven non-durable", async () => {
@@ -580,6 +641,106 @@ describe("livraison PDF generation", () => {
       "livraison_pdf_commit_uncertain",
       expect.objectContaining({ document_id: documentId, version: 1 }),
     )
+    expect(scenario.reconciliation.query).toHaveBeenCalledWith("ROLLBACK")
+    expect(scenario.reconciliation.release).toHaveBeenCalledWith(expect.any(Error))
+  })
+
+  it("preserves the file and fails closed when reconciliation resolves another version", async () => {
+    const scenario = uncertainCommitDatabase({ durable: true, reconciledVersion: 2 })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "uncertain-commit-version"),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+    })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(scenario.reconciliation.query).toHaveBeenCalledWith("ROLLBACK")
+    expect(scenario.reconciliation.release).toHaveBeenCalledWith(expect.any(Error))
+  })
+
+  it.each([
+    { label: "event checksum", overrides: { reconciledEventChecksum: "a".repeat(64) } },
+    { label: "document checksum", overrides: { reconciledDocumentChecksum: "b".repeat(64) } },
+    {
+      label: "pending checksum",
+      overrides: {
+        reconciledEventChecksum: "c".repeat(64),
+        reconciledDocumentChecksum: "c".repeat(64),
+      },
+    },
+  ])("preserves the file when the $label does not match the three-way proof", async ({ label, overrides }) => {
+    const scenario = uncertainCommitDatabase({ durable: true, ...overrides })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, `uncertain-${label.replace(" ", "-")}`),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+    })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(scenario.reconciliation.query).toHaveBeenCalledWith("ROLLBACK")
+    expect(scenario.reconciliation.release).toHaveBeenCalledWith(expect.any(Error))
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "livraison_pdf_commit_uncertain",
+      expect.objectContaining({
+        document_id: documentId,
+        version: 1,
+        expected_checksum_sha256: PDF_CHECKSUM,
+      }),
+    )
+  })
+
+  it("validates durable bytes against the pre-commit checksum and preserves corruption", async () => {
+    const corruptedBytes = Buffer.from(PDF_BYTES)
+    corruptedBytes[corruptedBytes.byteLength - 1] ^= 1
+    let scenario!: ReturnType<typeof uncertainCommitDatabase>
+    scenario = uncertainCommitDatabase({
+      durable: true,
+      afterReconciliationCommit: async () => {
+        const documentId = scenario.getDocumentId()
+        if (!documentId) throw new Error("test document id unavailable")
+        await fs.writeFile(
+          path.join(documentsRoot, "livraisons", `${documentId}.pdf`),
+          corruptedBytes,
+        )
+      },
+    })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "durable-file-corruption"),
+    ).rejects.toMatchObject({
+      status: 500,
+      code: "LIVRAISON_PDF_INTEGRITY_ERROR",
+    })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).resolves.toEqual(corruptedBytes)
+    expect(scenario.reconciliation.query).toHaveBeenLastCalledWith("COMMIT")
+    expect(scenario.reconciliation.query).not.toHaveBeenCalledWith("ROLLBACK")
+    expect(mocks.loggerError).not.toHaveBeenCalled()
   })
 
   it("preserves the file when no fresh connection can reconcile the commit", async () => {

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -11,6 +11,7 @@ import {
   getDocumentStoragePath,
 } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
+import logger from "../../../utils/logger"
 import { repoGetLivraisonDetail, repoGetDocumentName } from "../repository/livraisons.repository"
 import type {
   BonLivraisonStatut,
@@ -262,6 +263,63 @@ async function findIdempotentReplay(
   return result.rows[0] ?? null
 }
 
+async function reconcilePdfCommit(args: {
+  bonLivraisonId: string
+  userId: number
+  keyHash: string
+}): Promise<PdfDocumentRow | null> {
+  const reconciliationDb = await pool.connect()
+  let discardConnection = false
+  try {
+    const delivery = await reconciliationDb.query<{ id: string }>(
+      `SELECT id::text AS id FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
+      [args.bonLivraisonId]
+    )
+    if (!delivery.rows[0]) {
+      throw new Error("Delivery disappeared while reconciling an uncertain PDF commit")
+    }
+    return findIdempotentReplay(
+      reconciliationDb,
+      args.bonLivraisonId,
+      args.userId,
+      args.keyHash
+    )
+  } catch (error) {
+    discardConnection = true
+    throw error
+  } finally {
+    reconciliationDb.release(discardConnection)
+  }
+}
+
+function uncertainPdfCommitError(args: {
+  result: LivraisonPdfGenerationResult
+  commitError: unknown
+  reconciliationError?: unknown
+}): HttpError {
+  logger.error("livraison_pdf_commit_uncertain", {
+    document_id: args.result.document_id,
+    version: args.result.version,
+    commit_error: args.commitError instanceof Error ? args.commitError.message : String(args.commitError),
+    reconciliation_error:
+      args.reconciliationError instanceof Error
+        ? args.reconciliationError.message
+        : args.reconciliationError === undefined
+          ? null
+          : String(args.reconciliationError),
+  })
+  return new HttpError(
+    503,
+    "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+    "L'etat de la generation PDF doit etre reconcilie. Rejouez la meme Idempotency-Key et suivez le runbook sans supprimer le fichier archive.",
+    {
+      document_id: args.result.document_id,
+      version: args.result.version,
+      runbook: "docs/livraison-document-cerp-213.md#commit-postgresql-incertain",
+    }
+  )
+}
+
 async function nextPdfVersion(db: Queryable, bonLivraisonId: string): Promise<number> {
   const result = await db.query<{ version: number }>(
     `
@@ -296,6 +354,10 @@ export async function svcGenerateLivraisonPdf(
   let filePath: string | null = null
   let temporaryPath: string | null = null
   let committed = false
+  let commitAttempted = false
+  let primaryConnectionReleased = false
+  let cleanupAllowed = true
+  let pendingResult: LivraisonPdfGenerationResult | null = null
 
   try {
     await db.query("BEGIN")
@@ -322,13 +384,15 @@ export async function svcGenerateLivraisonPdf(
         replay.file_size_bytes,
         replay.checksum_sha256
       )
-      await db.query("COMMIT")
-      committed = true
-      return {
+      pendingResult = {
         document_id: replay.document_id,
         version: replay.version,
         idempotent_replay: true,
       }
+      commitAttempted = true
+      await db.query("COMMIT")
+      committed = true
+      return pendingResult
     }
 
     const detail = await repoGetLivraisonDetail(bonLivraisonId)
@@ -403,15 +467,65 @@ export async function svcGenerateLivraisonPdf(
       `UPDATE public.bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`,
       [bonLivraisonId, userId]
     )
+    pendingResult = { document_id: documentId, version, idempotent_replay: false }
+    commitAttempted = true
     await db.query("COMMIT")
     committed = true
-    return { document_id: documentId, version, idempotent_replay: false }
+    return pendingResult
   } catch (error) {
-    if (!committed) await db.query("ROLLBACK").catch(() => undefined)
-    throw error
+    if (!commitAttempted) {
+      await db.query("ROLLBACK").catch(() => undefined)
+      throw error
+    }
+
+    db.release(error instanceof Error ? error : true)
+    primaryConnectionReleased = true
+    if (!pendingResult) {
+      cleanupAllowed = false
+      throw new HttpError(
+        503,
+        "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+        "L'etat de la generation PDF est incertain et doit etre reconcilie manuellement."
+      )
+    }
+
+    let reconciled: PdfDocumentRow | null
+    try {
+      reconciled = await reconcilePdfCommit({ bonLivraisonId, userId, keyHash })
+    } catch (reconciliationError) {
+      cleanupAllowed = false
+      throw uncertainPdfCommitError({
+        result: pendingResult,
+        commitError: error,
+        reconciliationError,
+      })
+    }
+
+    if (!reconciled) {
+      throw error
+    }
+    if (
+      reconciled.document_id !== pendingResult.document_id ||
+      reconciled.version !== pendingResult.version
+    ) {
+      cleanupAllowed = false
+      throw uncertainPdfCommitError({
+        result: pendingResult,
+        commitError: error,
+        reconciliationError: new Error("The idempotency identity resolved to another PDF"),
+      })
+    }
+
+    committed = true
+    await assertStoredPdf(
+      reconciled.document_id,
+      reconciled.file_size_bytes,
+      reconciled.checksum_sha256
+    )
+    return pendingResult
   } finally {
-    db.release()
-    if (!committed) {
+    if (!primaryConnectionReleased) db.release()
+    if (!committed && cleanupAllowed) {
       await Promise.all(
         [temporaryPath, filePath]
           .filter((candidate): candidate is string => Boolean(candidate))

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -32,6 +32,18 @@ type PdfDocumentRow = {
   checksum_sha256: string | null
 }
 
+type PdfReplayRow = PdfDocumentRow & {
+  event_document_id: string | null
+  event_version: number | null
+  event_checksum_sha256: string | null
+}
+
+type PendingPdfResult = {
+  result: LivraisonPdfGenerationResult
+  expected_checksum_sha256: string
+  expected_file_size_bytes: number | null
+}
+
 type LivraisonPdfReadResult =
   | (Extract<LivraisonPdfAvailability, { available: false }> & { bytes: null })
   | (Extract<LivraisonPdfAvailability, { available: true }> & { bytes: Buffer })
@@ -237,11 +249,18 @@ async function findIdempotentReplay(
   bonLivraisonId: string,
   userId: number,
   keyHash: string
-): Promise<PdfDocumentRow | null> {
-  const result = await db.query<PdfDocumentRow>(
+): Promise<PdfReplayRow | null> {
+  const result = await db.query<PdfReplayRow>(
     `
       SELECT
         event.bon_livraison_id::text AS bon_livraison_id,
+        event.new_values ->> 'document_id' AS event_document_id,
+        CASE
+          WHEN COALESCE(event.new_values ->> 'version', '') ~ '^[1-9][0-9]*$'
+            THEN (event.new_values ->> 'version')::int
+          ELSE NULL
+        END AS event_version,
+        event.new_values ->> 'checksum_sha256' AS event_checksum_sha256,
         document.document_id::text AS document_id,
         document.version::int AS version,
         document.created_at::text AS generated_at,
@@ -263,14 +282,64 @@ async function findIdempotentReplay(
   return result.rows[0] ?? null
 }
 
+function normalizeChecksum(value: string | null): string | null {
+  const normalized = value?.trim().toLowerCase() ?? ""
+  return /^[a-f0-9]{64}$/.test(normalized) ? normalized : null
+}
+
+function assertReplayIdentity(row: PdfReplayRow): string {
+  const eventChecksum = normalizeChecksum(row.event_checksum_sha256)
+  const documentChecksum = normalizeChecksum(row.checksum_sha256)
+  if (
+    !row.document_id ||
+    !row.version ||
+    row.event_document_id !== row.document_id ||
+    row.event_version !== row.version ||
+    !eventChecksum ||
+    eventChecksum !== documentChecksum
+  ) {
+    throw new HttpError(
+      500,
+      "LIVRAISON_PDF_INTEGRITY_ERROR",
+      "Les metadonnees archivees du PDF sont incoherentes. Une reconciliation est requise."
+    )
+  }
+  return documentChecksum
+}
+
+function assertReconciledIdentity(expected: PendingPdfResult, row: PdfReplayRow): void {
+  const expectedChecksum = normalizeChecksum(expected.expected_checksum_sha256)
+  const eventChecksum = normalizeChecksum(row.event_checksum_sha256)
+  const documentChecksum = normalizeChecksum(row.checksum_sha256)
+  if (
+    !expectedChecksum ||
+    row.document_id !== expected.result.document_id ||
+    row.event_document_id !== expected.result.document_id ||
+    row.version !== expected.result.version ||
+    row.event_version !== expected.result.version ||
+    eventChecksum !== expectedChecksum ||
+    documentChecksum !== expectedChecksum ||
+    (expected.expected_file_size_bytes !== null &&
+      row.file_size_bytes !== expected.expected_file_size_bytes)
+  ) {
+    throw new Error(
+      "The reconciled event/document identity does not match the pending PDF document, version, checksum, or size"
+    )
+  }
+}
+
 async function reconcilePdfCommit(args: {
   bonLivraisonId: string
   userId: number
   keyHash: string
-}): Promise<PdfDocumentRow | null> {
+  pending: PendingPdfResult
+}): Promise<PdfReplayRow | null> {
   const reconciliationDb = await pool.connect()
-  let discardConnection = false
+  let transactionOpen = false
+  let released = false
   try {
+    await reconciliationDb.query("BEGIN")
+    transactionOpen = true
     const delivery = await reconciliationDb.query<{ id: string }>(
       `SELECT id::text AS id FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
       [args.bonLivraisonId]
@@ -278,28 +347,43 @@ async function reconcilePdfCommit(args: {
     if (!delivery.rows[0]) {
       throw new Error("Delivery disappeared while reconciling an uncertain PDF commit")
     }
-    return findIdempotentReplay(
+    const reconciled = await findIdempotentReplay(
       reconciliationDb,
       args.bonLivraisonId,
       args.userId,
       args.keyHash
     )
+    if (reconciled) assertReconciledIdentity(args.pending, reconciled)
+    await reconciliationDb.query("COMMIT")
+    transactionOpen = false
+    reconciliationDb.release()
+    released = true
+    return reconciled
   } catch (error) {
-    discardConnection = true
+    if (transactionOpen) await reconciliationDb.query("ROLLBACK").catch(() => undefined)
+    reconciliationDb.release(error instanceof Error ? error : true)
+    released = true
     throw error
   } finally {
-    reconciliationDb.release(discardConnection)
+    if (!released) reconciliationDb.release()
   }
 }
 
 function uncertainPdfCommitError(args: {
-  result: LivraisonPdfGenerationResult
+  pending: PendingPdfResult
+  bonLivraisonId: string
+  userId: number
+  keyHash: string
   commitError: unknown
   reconciliationError?: unknown
 }): HttpError {
   logger.error("livraison_pdf_commit_uncertain", {
-    document_id: args.result.document_id,
-    version: args.result.version,
+    bon_livraison_id: args.bonLivraisonId,
+    user_id: args.userId,
+    idempotency_key_hash: args.keyHash,
+    document_id: args.pending.result.document_id,
+    version: args.pending.result.version,
+    expected_checksum_sha256: args.pending.expected_checksum_sha256,
     commit_error: args.commitError instanceof Error ? args.commitError.message : String(args.commitError),
     reconciliation_error:
       args.reconciliationError instanceof Error
@@ -313,8 +397,8 @@ function uncertainPdfCommitError(args: {
     "LIVRAISON_PDF_COMMIT_UNCERTAIN",
     "L'etat de la generation PDF doit etre reconcilie. Rejouez la meme Idempotency-Key et suivez le runbook sans supprimer le fichier archive.",
     {
-      document_id: args.result.document_id,
-      version: args.result.version,
+      document_id: args.pending.result.document_id,
+      version: args.pending.result.version,
       runbook: "docs/livraison-document-cerp-213.md#commit-postgresql-incertain",
     }
   )
@@ -357,7 +441,7 @@ export async function svcGenerateLivraisonPdf(
   let commitAttempted = false
   let primaryConnectionReleased = false
   let cleanupAllowed = true
-  let pendingResult: LivraisonPdfGenerationResult | null = null
+  let pendingResult: PendingPdfResult | null = null
 
   try {
     await db.query("BEGIN")
@@ -379,20 +463,25 @@ export async function svcGenerateLivraisonPdf(
 
     const replay = await findIdempotentReplay(db, bonLivraisonId, userId, keyHash)
     if (replay?.document_id && replay.version) {
+      const expectedChecksum = assertReplayIdentity(replay)
       await assertStoredPdf(
         replay.document_id,
         replay.file_size_bytes,
-        replay.checksum_sha256
+        expectedChecksum
       )
       pendingResult = {
-        document_id: replay.document_id,
-        version: replay.version,
-        idempotent_replay: true,
+        result: {
+          document_id: replay.document_id,
+          version: replay.version,
+          idempotent_replay: true,
+        },
+        expected_checksum_sha256: expectedChecksum,
+        expected_file_size_bytes: replay.file_size_bytes,
       }
       commitAttempted = true
       await db.query("COMMIT")
       committed = true
-      return pendingResult
+      return pendingResult.result
     }
 
     const detail = await repoGetLivraisonDetail(bonLivraisonId)
@@ -467,11 +556,15 @@ export async function svcGenerateLivraisonPdf(
       `UPDATE public.bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`,
       [bonLivraisonId, userId]
     )
-    pendingResult = { document_id: documentId, version, idempotent_replay: false }
+    pendingResult = {
+      result: { document_id: documentId, version, idempotent_replay: false },
+      expected_checksum_sha256: checksumSha256,
+      expected_file_size_bytes: pdfBytes.byteLength,
+    }
     commitAttempted = true
     await db.query("COMMIT")
     committed = true
-    return pendingResult
+    return pendingResult.result
   } catch (error) {
     if (!commitAttempted) {
       await db.query("ROLLBACK").catch(() => undefined)
@@ -489,13 +582,21 @@ export async function svcGenerateLivraisonPdf(
       )
     }
 
-    let reconciled: PdfDocumentRow | null
+    let reconciled: PdfReplayRow | null
     try {
-      reconciled = await reconcilePdfCommit({ bonLivraisonId, userId, keyHash })
+      reconciled = await reconcilePdfCommit({
+        bonLivraisonId,
+        userId,
+        keyHash,
+        pending: pendingResult,
+      })
     } catch (reconciliationError) {
       cleanupAllowed = false
       throw uncertainPdfCommitError({
-        result: pendingResult,
+        pending: pendingResult,
+        bonLivraisonId,
+        userId,
+        keyHash,
         commitError: error,
         reconciliationError,
       })
@@ -504,25 +605,13 @@ export async function svcGenerateLivraisonPdf(
     if (!reconciled) {
       throw error
     }
-    if (
-      reconciled.document_id !== pendingResult.document_id ||
-      reconciled.version !== pendingResult.version
-    ) {
-      cleanupAllowed = false
-      throw uncertainPdfCommitError({
-        result: pendingResult,
-        commitError: error,
-        reconciliationError: new Error("The idempotency identity resolved to another PDF"),
-      })
-    }
-
     committed = true
     await assertStoredPdf(
-      reconciled.document_id,
-      reconciled.file_size_bytes,
-      reconciled.checksum_sha256
+      pendingResult.result.document_id,
+      pendingResult.expected_file_size_bytes,
+      pendingResult.expected_checksum_sha256
     )
-    return pendingResult
+    return pendingResult.result
   } finally {
     if (!primaryConnectionReleased) db.release()
     if (!committed && cleanupAllowed) {


### PR DESCRIPTION
## Why

A PostgreSQL `COMMIT` can become durable even when its acknowledgement is lost. The previous error path treated every thrown commit as a rollback and could delete a PDF already referenced by durable metadata.

## What changed

- distinguish pre-commit failures from uncertain commit outcomes;
- discard the uncertain primary connection and reconcile through a fresh transaction;
- keep `BEGIN`, the delivery `FOR UPDATE` barrier, event/document lookup, proof validation, and reconciliation `COMMIT` atomic;
- retain the pre-commit checksum and require exact pending/event/document identity for document ID, version, checksum, and stored size;
- validate final bytes against the pre-commit checksum rather than mutable reconciliation metadata;
- clean the file only when absence is proven, while preserving it and returning `LIVRAISON_PDF_COMMIT_UNCERTAIN` when reconciliation is unavailable or inconsistent;
- add structured logging, operator runbook guidance, and deterministic durable/non-durable/race/mismatch tests.

## Validation

- targeted PDF service suite — 24 tests passed
- Livraison/RBAC/cancellation/shipment/Facturation non-regression suite — 203 tests passed
- `npm run build`
- `npm run test:collection` — 192 files verified
- `git diff --check`
