### PR TITLE
release: intégrer la vague 5 de l’audit CERP

### DIFF
--- a/docs/frontend_repo_map.md
+++ b/docs/frontend_repo_map.md
@@ -425,6 +425,7 @@ POST	/api/v1/livraisons/:id/pack/generate	authenticateToken	controller
 GET	/api/v1/livraisons/:id/pack/preview	authenticateToken	controller
 POST	/api/v1/livraisons/:id/pack/revoke/:versionId	authenticateToken	controller
 GET	/api/v1/livraisons/:id/pdf	authenticateToken	controller
+GET	/api/v1/livraisons/:id/pdf/availability	authenticateToken	controller
 POST	/api/v1/livraisons/:id/pdf	authenticateToken	controller
 POST	/api/v1/livraisons/:id/status	authenticateToken	controller
 POST	/api/v1/livraisons/from-commande/:commandeId	authenticateToken	controller

--- a/docs/http/facturation-227.md
+++ b/docs/http/facturation-227.md
@@ -11,12 +11,23 @@ un même document ni les écritures d'audit.
 
 ## Facture
 
+Le contrat conserve la version HTTP `/api/v1`. Il n'existe pas de route
+workflow v2 implicite : `preview_version: 1` versionne le calcul serveur, les
+mutations portent `expected_version` pour le verrou optimiste et les réponses
+de commande exposent `row_version`. Cette livraison ne modifie donc ni les
+URLs ni les payloads déjà consommés par le frontend.
+
 - `GET /factures/workflow/eligible-sources`
 - `POST /factures/workflow/preview`
 - `POST /factures/workflow/drafts`
 - `POST /factures/workflow/:id/request-validation`
 - `POST /factures/workflow/:id/validate`
 - `POST /factures/workflow/:id/issue`
+
+`eligible-sources` retourne uniquement des lignes de BL `SHIPPED` ou
+`DELIVERED`. Une commande `INTERNE` est exclue de la liste, de l'aperçu et de
+l'émission, y compris pour un ancien brouillon. Les lignes incomplètes restent
+visibles avec des `blockers` typés ; elles ne peuvent pas produire de brouillon.
 
 L'aperçu reçoit le client, la devise, les lignes source BL, les quantités et
 l'échéancier. Pour une échéance unique, le montant absent est rempli par le

--- a/docs/livraison-document-cerp-213.md
+++ b/docs/livraison-document-cerp-213.md
@@ -101,10 +101,13 @@ navigateur ou un proxy ne réutilise pas un état d'autorisation ou une version 
 Le fichier final est renommé avant le `COMMIT` qui archive ses métadonnées. Si PostgreSQL rend
 le commit durable mais que son accusé réseau est perdu, la connexion d'origine est considérée
 comme incertaine et n'est jamais « prouvée » par un `ROLLBACK`. Le service la détruit, prend une
-connexion fraîche, attend la résolution du verrou du BL, puis recherche l'événement et le
-document par livraison, auteur, empreinte d'`Idempotency-Key`, identifiant et version :
+connexion fraîche et ouvre une transaction dédiée. Cette transaction attend la résolution du
+verrou du BL, recherche l'événement et le document, puis vérifie avant son propre `COMMIT` que
+livraison, auteur, empreinte d'`Idempotency-Key`, identifiant, version et SHA-256 concordent. Le
+SHA-256 attendu reste celui calculé en mémoire avant le commit original :
 
-- identité exacte retrouvée et fichier intègre : le résultat est finalisé et le fichier reste ;
+- identité exacte `résultat attendu = événement = document` retrouvée, puis octets du fichier
+  conformes au SHA-256 attendu : le résultat est finalisé et le fichier reste ;
 - aucune métadonnée après la barrière de verrou : le commit n'a pas été durable et le fichier
   orphelin est supprimé ;
 - connexion, recherche ou identité incohérente : réponse

--- a/docs/livraison-document-cerp-213.md
+++ b/docs/livraison-document-cerp-213.md
@@ -89,7 +89,9 @@ ne peut être produit après le passage à `CANCELLED`.
 La disponibilité, la lecture d'une version exacte et le rejeu relisent les octets stockés et
 vérifient leur signature, leur taille et leur SHA-256 persistant. Une altération conservant la
 même taille et l'en-tête `%PDF-` est donc rejetée avec `LIVRAISON_PDF_INTEGRITY_ERROR`, au lieu
-d'être confondue avec une absence ordinaire.
+d'être confondue avec une absence ordinaire. Le GET exact envoie directement le buffer ainsi
+validé : il ne rouvre jamais le chemin du fichier après le contrôle, ce qui ferme la fenêtre de
+substitution entre validation et réponse HTTP.
 
 Les réponses PDF et de disponibilité portent `Cache-Control: private, no-store` afin qu'un
 navigateur ou un proxy ne réutilise pas un état d'autorisation ou une version obsolète.
@@ -139,7 +141,8 @@ d'affirmer qu'aucun UUID n'y figure.
 un BL complet, la régénération, le rejeu idempotent, l'archive manquante, la corruption SHA-256
 à taille identique, deux générations concurrentes et les deux ordres de verrou entre annulation
 et génération. Le contrôleur vérifie séparément que `GET` reste sans effet de bord et ne masque
-pas les erreurs d'autorisation ou de stockage.
+pas les erreurs d'autorisation ou de stockage, puis qu'un remplacement du fichier après sa
+validation ne peut pas substituer les octets servis.
 
 Suite complète : **2968 tests verts sur 2969**. L'échec restant
 (`src/__tests__/surface-finish-210.migration-guards.test.ts`) est **antérieur** à ce chantier —

--- a/docs/livraison-document-cerp-213.md
+++ b/docs/livraison-document-cerp-213.md
@@ -80,6 +80,17 @@ journal.
   version suivante. Ses archives `GENERATED_SIMPLE_BL_PDF` restent séparées des BL du pack
   figé (`GENERATED_BL_PDF`), dont le cycle de version est autonome.
 
+Le même verrou charge le statut courant avant tout rejeu ou rendu. Une annulation qui obtient le
+verrou en premier interdit génération et régénération avec
+`LIVRAISON_CANCELLED_PDF_FORBIDDEN` (`409`). Une génération déjà verrouillée peut terminer avant
+l'annulation ; son archive devient alors une pièce historique lisible, mais aucun nouveau rendu
+ne peut être produit après le passage à `CANCELLED`.
+
+La disponibilité, la lecture d'une version exacte et le rejeu relisent les octets stockés et
+vérifient leur signature, leur taille et leur SHA-256 persistant. Une altération conservant la
+même taille et l'en-tête `%PDF-` est donc rejetée avec `LIVRAISON_PDF_INTEGRITY_ERROR`, au lieu
+d'être confondue avec une absence ordinaire.
+
 Les réponses PDF et de disponibilité portent `Cache-Control: private, no-store` afin qu'un
 navigateur ou un proxy ne réutilise pas un état d'autorisation ou une version obsolète.
 
@@ -125,8 +136,9 @@ donc ce que le document affiche, pas ce que le code croit avoir écrit. C'est ce
 d'affirmer qu'aucun UUID n'y figure.
 
 `src/module/livraisons/services/pdf.service.test.ts` couvre en complément le brouillon vide,
-un BL complet, la régénération, le rejeu idempotent, l'archive manquante et deux générations
-concurrentes. Le contrôleur vérifie séparément que `GET` reste sans effet de bord et ne masque
+un BL complet, la régénération, le rejeu idempotent, l'archive manquante, la corruption SHA-256
+à taille identique, deux générations concurrentes et les deux ordres de verrou entre annulation
+et génération. Le contrôleur vérifie séparément que `GET` reste sans effet de bord et ne masque
 pas les erreurs d'autorisation ou de stockage.
 
 Suite complète : **2968 tests verts sur 2969**. L'échec restant

--- a/docs/livraison-document-cerp-213.md
+++ b/docs/livraison-document-cerp-213.md
@@ -67,6 +67,22 @@ les deux chemins produisent **le même binaire** — vérifié par un test, pas 
 `pdf.service.ts` ne s'occupe plus que du versionnement, du stockage, de l'empreinte et du
 journal.
 
+### Disponibilité et génération sont deux opérations distinctes
+
+- `GET /livraisons/:id/pdf/availability` indique si une archive lisible existe, sans créer de
+  fichier ni de version. Une absence ordinaire renvoie `NOT_GENERATED` ; une archive référencée
+  mais absente ou invalide reste une erreur d'intégrité explicite.
+- `GET /livraisons/:id/pdf?version=N` est strictement en lecture : il sert uniquement une version
+  déjà archivée et ne régénère jamais silencieusement un document manquant.
+- `POST /livraisons/:id/pdf` est la seule opération de génération. Elle exige la capacité
+  `documents_manage` et une clé `Idempotency-Key`. Un verrou sur le BL sérialise les demandes
+  concurrentes ; la même intention rejouée rend la même version, une nouvelle intention crée la
+  version suivante. Ses archives `GENERATED_SIMPLE_BL_PDF` restent séparées des BL du pack
+  figé (`GENERATED_BL_PDF`), dont le cycle de version est autonome.
+
+Les réponses PDF et de disponibilité portent `Cache-Control: private, no-store` afin qu'un
+navigateur ou un proxy ne réutilise pas un état d'autorisation ou une version obsolète.
+
 ## 4. Ce qui ne doit jamais figurer sur ces documents
 
 | Fuite trouvée | Corrigé en |
@@ -108,6 +124,11 @@ Le texte est relu **dans les flux de contenu du PDF**, décompressés et décod�
 donc ce que le document affiche, pas ce que le code croit avoir écrit. C'est ce qui permet
 d'affirmer qu'aucun UUID n'y figure.
 
+`src/module/livraisons/services/pdf.service.test.ts` couvre en complément le brouillon vide,
+un BL complet, la régénération, le rejeu idempotent, l'archive manquante et deux générations
+concurrentes. Le contrôleur vérifie séparément que `GET` reste sans effet de bord et ne masque
+pas les erreurs d'autorisation ou de stockage.
+
 Suite complète : **2968 tests verts sur 2969**. L'échec restant
 (`src/__tests__/surface-finish-210.migration-guards.test.ts`) est **antérieur** à ce chantier —
 vérifié en remisant les modifications et en relançant sur `origin/dev` seul.
@@ -116,5 +137,5 @@ vérifié en remisant les modifications et en relançant sur `origin/dev` seul.
 
 - Aucune recette navigateur.
 - Aucun déploiement, aucune modification de production.
-- **Aucune migration de base** : ces documents ne changent pas de schéma, le contrat d'API non
-  plus.
+- **Aucune migration de base** : le contrat HTTP évolue, mais les tables existantes suffisent au
+  versionnement, à l'empreinte et au journal d'idempotence.

--- a/docs/livraison-document-cerp-213.md
+++ b/docs/livraison-document-cerp-213.md
@@ -96,6 +96,25 @@ substitution entre validation et réponse HTTP.
 Les réponses PDF et de disponibilité portent `Cache-Control: private, no-store` afin qu'un
 navigateur ou un proxy ne réutilise pas un état d'autorisation ou une version obsolète.
 
+### Commit PostgreSQL incertain
+
+Le fichier final est renommé avant le `COMMIT` qui archive ses métadonnées. Si PostgreSQL rend
+le commit durable mais que son accusé réseau est perdu, la connexion d'origine est considérée
+comme incertaine et n'est jamais « prouvée » par un `ROLLBACK`. Le service la détruit, prend une
+connexion fraîche, attend la résolution du verrou du BL, puis recherche l'événement et le
+document par livraison, auteur, empreinte d'`Idempotency-Key`, identifiant et version :
+
+- identité exacte retrouvée et fichier intègre : le résultat est finalisé et le fichier reste ;
+- aucune métadonnée après la barrière de verrou : le commit n'a pas été durable et le fichier
+  orphelin est supprimé ;
+- connexion, recherche ou identité incohérente : réponse
+  `LIVRAISON_PDF_COMMIT_UNCERTAIN` (`503`), fichier conservé par sécurité et alerte structurée.
+
+Runbook opérateur pour le dernier cas : rejouer d'abord la même `Idempotency-Key`, vérifier
+l'événement `PDF_GENERATED` et `bon_livraison_documents.document_id`, puis comparer taille et
+SHA-256 du fichier. Ne jamais supprimer le fichier tant qu'une référence durable n'a pas été
+exclue après verrouillage du BL.
+
 ## 4. Ce qui ne doit jamais figurer sur ces documents
 
 | Fuite trouvée | Corrigé en |

--- a/src/__tests__/facturation-workflow.routes.test.ts
+++ b/src/__tests__/facturation-workflow.routes.test.ts
@@ -1,0 +1,185 @@
+import express, { type RequestHandler } from "express";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  listSources: vi.fn(),
+  preview: vi.fn(),
+  createDraft: vi.fn(),
+  requestValidation: vi.fn(),
+  validate: vi.fn(),
+  issue: vi.fn(),
+}));
+
+vi.mock("../module/facturation/services/facture-workflow.service", () => ({
+  svcListEligibleFactureSources: (...args: unknown[]) => mocks.listSources(...args),
+  svcPreviewFacture: (...args: unknown[]) => mocks.preview(...args),
+  svcCreateFactureDraft: (...args: unknown[]) => mocks.createDraft(...args),
+  svcRequestFactureValidation: (...args: unknown[]) => mocks.requestValidation(...args),
+  svcValidateFacture: (...args: unknown[]) => mocks.validate(...args),
+  svcIssueFacture: (...args: unknown[]) => mocks.issue(...args),
+}));
+
+import { validationErrorMiddleware } from "../module/auth/middlewares/validationError.middleware";
+import factureRoutes from "../module/facturation/routes/factures.routes";
+import { errorHandler } from "../middlewares/errorHandler";
+import { HttpError } from "../utils/httpError";
+
+const source = {
+  source_type: "DELIVERY_LINE",
+  source_id: "11111111-1111-4111-8111-111111111111",
+  source_line_id: "22222222-2222-4222-8222-222222222222",
+  delivery_number: "BL-000001",
+  delivery_status: "SHIPPED",
+  client_id: "CLI-1",
+  client_name: "Client test",
+  commande_id: 67,
+  affaire_id: null,
+  commande_line_id: 9,
+  designation: "Piece test",
+  code_piece: "P-1",
+  unit: "u",
+  quantity_source: "2.000",
+  quantity_already_invoiced: "0.000",
+  quantity_already_credited: "0.000",
+  quantity_remaining: "2.000",
+  unit_price_ex_tax: "10.0000",
+  discount_percent: "0.0000",
+  tax_rate_percent: "20.0000",
+  pricing_version: "COMMANDE_LINE:9:v1",
+  rule_code: "DELIVERY_SHIPPED:POLICY-1",
+  blockers: [],
+};
+
+const commandResult = {
+  id: 42,
+  uuid: "33333333-3333-4333-8333-333333333333",
+  draft_reference: "DFT-2026-000042",
+  legal_number: null,
+  status: "DRAFT",
+  row_version: 1,
+  correlation_id: "44444444-4444-4444-8444-444444444444",
+  idempotent_replay: false,
+};
+
+function testApp(options: { granted?: boolean; authenticated?: boolean } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use(((req, _res, next) => {
+    if (options.authenticated !== false) {
+      req.user = {
+        id: 7,
+        username: "finance-test",
+        email: "finance@test.invalid",
+        role: "Employee",
+      };
+    }
+    if (options.granted !== false) {
+      req.accountModuleAccess = { userId: 7, moduleKey: "facturation", granted: true };
+    }
+    req.requestId = "request-test-001";
+    next();
+  }) as RequestHandler);
+  app.use("/factures", factureRoutes);
+  app.use(validationErrorMiddleware);
+  app.use(errorHandler);
+  return app;
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(mocks)) mock.mockReset();
+  vi.spyOn(console, "error").mockImplementation(() => undefined);
+});
+
+describe("BUG-CERP-0016 - contrat HTTP workflow facture v1", () => {
+  it("retourne les lignes BL eligibles et transmet les filtres types (200)", async () => {
+    mocks.listSources.mockResolvedValue({ items: [source], total: 1, policy_active: true });
+
+    const response = await request(testApp())
+      .get("/factures/workflow/eligible-sources?commande_id=67&page=2&pageSize=10");
+
+    expect(response.status, JSON.stringify(response.body)).toBe(200);
+    expect(response.body).toEqual({ items: [source], total: 1, policy_active: true });
+    expect(mocks.listSources).toHaveBeenCalledWith({ commande_id: 67, page: 2, pageSize: 10 });
+  });
+
+  it("refuse un filtre de commande invalide avant le service (400)", async () => {
+    const response = await request(testApp())
+      .get("/factures/workflow/eligible-sources?commande_id=0");
+
+    expect(response.status).toBe(400);
+    expect(response.body).toMatchObject({ error: "VALIDATION_ERROR" });
+    expect(mocks.listSources).not.toHaveBeenCalled();
+  });
+
+  it("reste fail-closed sans contexte module ni capacite Finance (403)", async () => {
+    const response = await request(testApp({ granted: false }))
+      .get("/factures/workflow/eligible-sources");
+
+    expect(response.status).toBe(403);
+    expect(response.body).toMatchObject({
+      success: false,
+      code: "FINANCE_CAPABILITY_REQUIRED",
+    });
+    expect(mocks.listSources).not.toHaveBeenCalled();
+  });
+
+  it("retourne 201 au premier brouillon et 200 lors du rejeu idempotent", async () => {
+    mocks.createDraft
+      .mockResolvedValueOnce(commandResult)
+      .mockResolvedValueOnce({ ...commandResult, idempotent_replay: true });
+    const body = {
+      client_id: "CLI-1",
+      currency: "EUR",
+      sources: [{
+        source_type: "DELIVERY_LINE",
+        source_id: source.source_id,
+        source_line_id: source.source_line_id,
+        quantity: "2.000",
+      }],
+      global_discount_percent: "0",
+      due_dates: [{ due_date: "2026-08-31", label: "Echeance principale" }],
+      internal_comment: null,
+      customer_text: null,
+      preview_hash: "a".repeat(64),
+    };
+
+    const first = await request(testApp())
+      .post("/factures/workflow/drafts")
+      .set("Idempotency-Key", "facture-draft-attempt-001")
+      .send(body);
+    const replay = await request(testApp())
+      .post("/factures/workflow/drafts")
+      .set("Idempotency-Key", "facture-draft-attempt-001")
+      .send(body);
+
+    expect(first.status).toBe(201);
+    expect(replay.status).toBe(200);
+    expect(replay.body.idempotent_replay).toBe(true);
+    expect(mocks.createDraft).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      idempotencyKey: "facture-draft-attempt-001",
+      actor: expect.objectContaining({ userId: 7, requestId: "request-test-001" }),
+    }));
+  });
+
+  it("propage un conflit de version sans masquer le code de reprise (409)", async () => {
+    mocks.requestValidation.mockRejectedValue(
+      new HttpError(409, "CONCURRENT_MODIFICATION", "La facture a change."),
+    );
+
+    const response = await request(testApp())
+      .post("/factures/workflow/42/request-validation")
+      .set("Idempotency-Key", "request-validation-attempt-001")
+      .send({ expected_version: 1, preview_hash: "a".repeat(64), confirm: true });
+
+    expect(response.status).toBe(409);
+    expect(response.body).toMatchObject({
+      success: false,
+      code: "CONCURRENT_MODIFICATION",
+    });
+    expect(mocks.requestValidation).toHaveBeenCalledWith(expect.objectContaining({
+      factureId: 42,
+      idempotencyKey: "request-validation-attempt-001",
+    }));
+  });
+});

--- a/src/module/facturation/repository/workflow.repository.shared.test.ts
+++ b/src/module/facturation/repository/workflow.repository.shared.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it, vi } from "vitest";
+import type { PoolClient } from "pg";
 
 import { HttpError } from "../../../utils/httpError";
 import {
+  acquireFinanceIdempotency,
   type DbQueryer,
   requireFinanceIssuerSnapshotAt,
 } from "./workflow.repository.shared";
@@ -67,5 +69,47 @@ describe("requireFinanceIssuerSnapshotAt", () => {
       code: "FINANCE_LEGAL_MENTIONS_NOT_CONFIGURED",
       details: { missing: ["recovery_indemnity"] },
     });
+  });
+});
+
+describe("finance workflow idempotency race guard", () => {
+  it("takes the transaction advisory lock before reading a competing receipt", async () => {
+    const query = vi.fn(async (sql: string, values?: unknown[]) => {
+      if (sql.includes("pg_advisory_xact_lock")) return { rows: [] };
+      if (sql.includes("FROM public.finance_command_receipts")) return { rows: [] };
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+    const client = { query } as unknown as PoolClient;
+
+    const result = await acquireFinanceIdempotency({
+      client,
+      actor: { userId: 7, requestId: "request-1", path: "/factures/workflow/drafts" },
+      idempotencyKeyRaw: "facture-attempt-001",
+      commandType: "FACTURE_DRAFT_CREATE",
+      requestPayload: { preview_hash: "a".repeat(64) },
+    });
+
+    expect(result.replay).toBeNull();
+    expect(String(query.mock.calls[0]?.[0])).toContain("pg_advisory_xact_lock");
+    expect(query.mock.calls[0]?.[1]).toEqual(["finance:7:facture-attempt-001"]);
+    expect(String(query.mock.calls[1]?.[0])).toContain("finance_command_receipts");
+  });
+
+  it("rejects the same actor/key with a different command payload (409)", async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("pg_advisory_xact_lock")) return { rows: [] };
+      if (sql.includes("FROM public.finance_command_receipts")) {
+        return { rows: [{ request_hash: "different", result_payload: { id: 42 } }] };
+      }
+      throw new Error(`Unexpected query: ${sql}`);
+    });
+
+    await expect(acquireFinanceIdempotency({
+      client: { query } as unknown as PoolClient,
+      actor: { userId: 7, requestId: "request-2", path: "/factures/workflow/drafts" },
+      idempotencyKeyRaw: "facture-attempt-001",
+      commandType: "FACTURE_DRAFT_CREATE",
+      requestPayload: { preview_hash: "b".repeat(64) },
+    })).rejects.toMatchObject({ status: 409, code: "IDEMPOTENCY_KEY_REUSED" });
   });
 });

--- a/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
+++ b/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
@@ -1,8 +1,13 @@
+import crypto from "node:crypto"
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
 import type { NextFunction, Request, Response } from "express"
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const mocks = vi.hoisted(() => ({
   availability: vi.fn(),
+  read: vi.fn(),
   generate: vi.fn(),
   getPath: vi.fn(),
   getName: vi.fn(),
@@ -11,6 +16,7 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock("../services/pdf.service", () => ({
   svcGetLivraisonPdfAvailability: (...args: unknown[]) => mocks.availability(...args),
+  svcReadLivraisonPdf: (...args: unknown[]) => mocks.read(...args),
   svcGenerateLivraisonPdf: (...args: unknown[]) => mocks.generate(...args),
   svcGetPdfFilePath: (...args: unknown[]) => mocks.getPath(...args),
   svcGetDocumentName: (...args: unknown[]) => mocks.getName(...args),
@@ -32,6 +38,7 @@ function responseDouble() {
     setHeader: vi.fn(),
     status: vi.fn(),
     json: vi.fn(),
+    send: vi.fn(),
     sendFile: vi.fn(),
   }
   response.status.mockReturnValue(response)
@@ -56,12 +63,13 @@ beforeEach(() => {
 
 describe("livraison PDF controller contract", () => {
   it("keeps GET read-only when no archive exists", async () => {
-    mocks.availability.mockResolvedValue({
+    mocks.read.mockResolvedValue({
       available: false,
       status: "NOT_GENERATED",
       document_id: null,
       version: null,
       generated_at: null,
+      bytes: null,
     })
     const response = responseDouble()
     const next = vi.fn() as NextFunction
@@ -75,9 +83,9 @@ describe("livraison PDF controller contract", () => {
     expect(response.sendFile).not.toHaveBeenCalled()
   })
 
-  it("does not mask authorization or storage failures from availability checks", async () => {
+  it("does not mask authorization or storage failures from archive reads", async () => {
     const forbidden = Object.assign(new Error("Forbidden"), { status: 403, code: "FORBIDDEN" })
-    mocks.availability.mockRejectedValue(forbidden)
+    mocks.read.mockRejectedValue(forbidden)
     const response = responseDouble()
     const next = vi.fn() as NextFunction
 
@@ -88,12 +96,14 @@ describe("livraison PDF controller contract", () => {
   })
 
   it("serves one requested archive version with private no-store caching", async () => {
-    mocks.availability.mockResolvedValue({
+    const validatedBytes = Buffer.from("%PDF-1.7\nvalidated")
+    mocks.read.mockResolvedValue({
       available: true,
       status: "AVAILABLE",
       document_id: "22222222-2222-4222-8222-222222222222",
       version: 3,
       generated_at: "2026-08-04T12:00:00.000Z",
+      bytes: validatedBytes,
     })
     const response = responseDouble()
     const next = vi.fn() as NextFunction
@@ -104,13 +114,67 @@ describe("livraison PDF controller contract", () => {
       next,
     )
 
-    expect(mocks.availability).toHaveBeenCalledWith(BL_ID, 3)
+    expect(mocks.read).toHaveBeenCalledWith(BL_ID, 3)
+    expect(response.setHeader).toHaveBeenCalledWith("Content-Type", "application/pdf")
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Content-Disposition",
+      'inline; filename="BL-0018.pdf"',
+    )
     expect(response.setHeader).toHaveBeenCalledWith(
       "Cache-Control",
       "private, no-store, max-age=0",
     )
-    expect(response.sendFile).toHaveBeenCalledWith("C:\\archives\\livraisons\\pdf.pdf")
+    expect(response.send).toHaveBeenCalledWith(validatedBytes)
+    expect(response.sendFile).not.toHaveBeenCalled()
+    expect(mocks.getPath).not.toHaveBeenCalled()
     expect(next).not.toHaveBeenCalled()
+  })
+
+  it("serves the validated buffer when the archived path is replaced before send", async () => {
+    const directory = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-pdf-controller-"))
+    const archivePath = path.join(directory, "archive.pdf")
+    const validatedBytes = Buffer.from("%PDF-1.7\nvalidated-original")
+    const replacementBytes = Buffer.from("%PDF-1.7\nreplaced-after-validation")
+    const expectedChecksum = crypto.createHash("sha256").update(validatedBytes).digest("hex")
+    let serviceBytes: Buffer | null = null
+
+    try {
+      await fs.writeFile(archivePath, validatedBytes)
+      mocks.read.mockImplementation(async () => {
+        serviceBytes = await fs.readFile(archivePath)
+        expect(crypto.createHash("sha256").update(serviceBytes).digest("hex")).toBe(
+          expectedChecksum,
+        )
+        return {
+          available: true,
+          status: "AVAILABLE",
+          document_id: "22222222-2222-4222-8222-222222222222",
+          version: 3,
+          generated_at: "2026-08-04T12:00:00.000Z",
+          bytes: serviceBytes,
+        }
+      })
+      mocks.getName.mockImplementation(async () => {
+        await fs.writeFile(archivePath, replacementBytes)
+        return "BL-0018.pdf"
+      })
+      const response = responseDouble()
+      const next = vi.fn() as NextFunction
+
+      await getLivraisonPdf(
+        requestDouble({ query: { version: "3" } }),
+        response as unknown as Response,
+        next,
+      )
+
+      await expect(fs.readFile(archivePath)).resolves.toEqual(replacementBytes)
+      expect(response.send).toHaveBeenCalledWith(serviceBytes)
+      expect(response.send).not.toHaveBeenCalledWith(replacementBytes)
+      expect(response.sendFile).not.toHaveBeenCalled()
+      expect(next).not.toHaveBeenCalled()
+    } finally {
+      await fs.rm(directory, { recursive: true, force: true })
+    }
   })
 
   it("requires idempotency before explicit generation", async () => {

--- a/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
+++ b/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
@@ -1,0 +1,48 @@
+import type { NextFunction, Request, Response } from "express"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const pdf = vi.hoisted(() => ({
+  generate: vi.fn(),
+  getLatest: vi.fn(),
+}))
+
+vi.mock("../services/pdf.service", () => ({
+  svcGenerateLivraisonPdf: pdf.generate,
+  svcGetDocumentName: vi.fn(),
+  svcGetLatestLivraisonPdfDocument: pdf.getLatest,
+  svcGetPdfFilePath: vi.fn(),
+}))
+
+import { getLivraisonPdf } from "./livraisons.controller"
+
+const BON_LIVRAISON_ID = "00000000-0000-4000-8000-000000000017"
+
+describe("GET automatique du PDF d'un bon de livraison annulé", () => {
+  beforeEach(() => {
+    pdf.generate.mockReset()
+    pdf.getLatest.mockReset()
+  })
+
+  it("propage le conflit structuré quand l'absence d'archive déclenche une génération", async () => {
+    const conflict = {
+      status: 409,
+      code: "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+      message: "Un bon de livraison annulé ne peut pas générer ou régénérer de PDF.",
+    }
+    pdf.getLatest.mockResolvedValue(null)
+    pdf.generate.mockRejectedValue(conflict)
+    const request = {
+      params: { id: BON_LIVRAISON_ID },
+      query: {},
+      user: { id: 17 },
+    } as unknown as Request
+    const response = {} as Response
+    const next = vi.fn() as NextFunction
+
+    await getLivraisonPdf(request, response, next)
+
+    expect(pdf.getLatest).toHaveBeenCalledWith(BON_LIVRAISON_ID)
+    expect(pdf.generate).toHaveBeenCalledWith(BON_LIVRAISON_ID, 17)
+    expect(next).toHaveBeenCalledWith(conflict)
+  })
+})

--- a/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
+++ b/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
@@ -1,0 +1,147 @@
+import type { NextFunction, Request, Response } from "express"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  availability: vi.fn(),
+  generate: vi.fn(),
+  getPath: vi.fn(),
+  getName: vi.fn(),
+  emitEntityChanged: vi.fn(),
+}))
+
+vi.mock("../services/pdf.service", () => ({
+  svcGetLivraisonPdfAvailability: (...args: unknown[]) => mocks.availability(...args),
+  svcGenerateLivraisonPdf: (...args: unknown[]) => mocks.generate(...args),
+  svcGetPdfFilePath: (...args: unknown[]) => mocks.getPath(...args),
+  svcGetDocumentName: (...args: unknown[]) => mocks.getName(...args),
+}))
+
+vi.mock("../../../shared/realtime/realtime.service", () => ({
+  emitEntityChanged: (...args: unknown[]) => mocks.emitEntityChanged(...args),
+}))
+
+import {
+  generateLivraisonPdf,
+  getLivraisonPdf,
+} from "./livraisons.controller"
+
+const BL_ID = "11111111-1111-4111-8111-111111111111"
+
+function responseDouble() {
+  const response = {
+    setHeader: vi.fn(),
+    status: vi.fn(),
+    json: vi.fn(),
+    sendFile: vi.fn(),
+  }
+  response.status.mockReturnValue(response)
+  return response
+}
+
+function requestDouble(overrides: Partial<Request> = {}) {
+  return {
+    user: { id: 7 },
+    params: { id: BL_ID },
+    query: {},
+    headers: {},
+    ...overrides,
+  } as unknown as Request
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  mocks.getPath.mockReturnValue("C:\\archives\\livraisons\\pdf.pdf")
+  mocks.getName.mockResolvedValue("BL-0018.pdf")
+})
+
+describe("livraison PDF controller contract", () => {
+  it("keeps GET read-only when no archive exists", async () => {
+    mocks.availability.mockResolvedValue({
+      available: false,
+      status: "NOT_GENERATED",
+      document_id: null,
+      version: null,
+      generated_at: null,
+    })
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await getLivraisonPdf(requestDouble(), response as unknown as Response, next)
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 404, code: "LIVRAISON_PDF_NOT_GENERATED" }),
+    )
+    expect(mocks.generate).not.toHaveBeenCalled()
+    expect(response.sendFile).not.toHaveBeenCalled()
+  })
+
+  it("does not mask authorization or storage failures from availability checks", async () => {
+    const forbidden = Object.assign(new Error("Forbidden"), { status: 403, code: "FORBIDDEN" })
+    mocks.availability.mockRejectedValue(forbidden)
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await getLivraisonPdf(requestDouble(), response as unknown as Response, next)
+
+    expect(next).toHaveBeenCalledWith(forbidden)
+    expect(mocks.generate).not.toHaveBeenCalled()
+  })
+
+  it("serves one requested archive version with private no-store caching", async () => {
+    mocks.availability.mockResolvedValue({
+      available: true,
+      status: "AVAILABLE",
+      document_id: "22222222-2222-4222-8222-222222222222",
+      version: 3,
+      generated_at: "2026-08-04T12:00:00.000Z",
+    })
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await getLivraisonPdf(
+      requestDouble({ query: { version: "3" } }),
+      response as unknown as Response,
+      next,
+    )
+
+    expect(mocks.availability).toHaveBeenCalledWith(BL_ID, 3)
+    expect(response.setHeader).toHaveBeenCalledWith(
+      "Cache-Control",
+      "private, no-store, max-age=0",
+    )
+    expect(response.sendFile).toHaveBeenCalledWith("C:\\archives\\livraisons\\pdf.pdf")
+    expect(next).not.toHaveBeenCalled()
+  })
+
+  it("requires idempotency before explicit generation", async () => {
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await generateLivraisonPdf(requestDouble(), response as unknown as Response, next)
+
+    expect(next).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 400, code: "IDEMPOTENCY_KEY_REQUIRED" }),
+    )
+    expect(mocks.generate).not.toHaveBeenCalled()
+  })
+
+  it("returns a created immutable version for a new idempotency key", async () => {
+    mocks.generate.mockResolvedValue({
+      document_id: "22222222-2222-4222-8222-222222222222",
+      version: 4,
+      idempotent_replay: false,
+    })
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await generateLivraisonPdf(
+      requestDouble({ headers: { "idempotency-key": "generation-key-18" } }),
+      response as unknown as Response,
+      next,
+    )
+
+    expect(mocks.generate).toHaveBeenCalledWith(BL_ID, 7, "generation-key-18")
+    expect(response.status).toHaveBeenCalledWith(201)
+    expect(next).not.toHaveBeenCalled()
+  })
+})

--- a/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
+++ b/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
@@ -144,4 +144,24 @@ describe("livraison PDF controller contract", () => {
     expect(response.status).toHaveBeenCalledWith(201)
     expect(next).not.toHaveBeenCalled()
   })
+
+  it("preserves the structured cancellation conflict from explicit generation", async () => {
+    const conflict = Object.assign(new Error("Cancelled"), {
+      status: 409,
+      code: "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+    })
+    mocks.generate.mockRejectedValue(conflict)
+    const response = responseDouble()
+    const next = vi.fn() as NextFunction
+
+    await generateLivraisonPdf(
+      requestDouble({ headers: { "idempotency-key": "cancelled-generation" } }),
+      response as unknown as Response,
+      next,
+    )
+
+    expect(next).toHaveBeenCalledWith(conflict)
+    expect(response.status).not.toHaveBeenCalled()
+    expect(mocks.emitEntityChanged).not.toHaveBeenCalled()
+  })
 })

--- a/src/module/livraisons/controllers/livraisons.controller.ts
+++ b/src/module/livraisons/controllers/livraisons.controller.ts
@@ -415,8 +415,8 @@ export const getLivraisonPdf: RequestHandler = async (req, res, next) => {
     const { id } = livraisonIdParamsSchema.parse(req.params)
     const query = livraisonPdfQuerySchema.parse(req.query)
     const download = coerceBool(query.download)
-    const availability = await pdfService.svcGetLivraisonPdfAvailability(id, query.version)
-    if (!availability.available) {
+    const archive = await pdfService.svcReadLivraisonPdf(id, query.version)
+    if (!archive.available) {
       throw new HttpError(
         404,
         "LIVRAISON_PDF_NOT_GENERATED",
@@ -424,13 +424,12 @@ export const getLivraisonPdf: RequestHandler = async (req, res, next) => {
       )
     }
 
-    const filePath = pdfService.svcGetPdfFilePath(availability.document_id)
-    const docName = (await pdfService.svcGetDocumentName(availability.document_id)) ?? `bon-livraison-${id}.pdf`
+    const docName = (await pdfService.svcGetDocumentName(archive.document_id)) ?? `bon-livraison-${id}.pdf`
     const disposition = download ? "attachment" : "inline"
     res.setHeader("Content-Type", "application/pdf")
     res.setHeader("Content-Disposition", `${disposition}; filename=\"${docName.replace(/\"/g, "")}\"`)
     res.setHeader("Cache-Control", "private, no-store, max-age=0")
-    res.sendFile(filePath)
+    res.send(archive.bytes)
   } catch (e) {
     next(e)
   }

--- a/src/module/livraisons/controllers/livraisons.controller.ts
+++ b/src/module/livraisons/controllers/livraisons.controller.ts
@@ -1,6 +1,4 @@
 import type { Request, RequestHandler } from "express"
-import fs from "node:fs/promises"
-
 import { HttpError } from "../../../utils/httpError"
 import {
   createLivraisonBodySchema,
@@ -11,6 +9,7 @@ import {
   livraisonIdParamsSchema,
   livraisonLineIdParamsSchema,
   livraisonLineAllocationIdParamsSchema,
+  livraisonPdfQuerySchema,
   livraisonStatusBodySchema,
   livraisonProofBodySchema,
   shipLivraisonBodySchema,
@@ -385,10 +384,26 @@ export const generateLivraisonPdf: RequestHandler = async (req, res, next) => {
   try {
     const userId = getUserId(req)
     const { id } = livraisonIdParamsSchema.parse(req.params)
-    const out = await pdfService.svcGenerateLivraisonPdf(id, userId)
+    const out = await pdfService.svcGenerateLivraisonPdf(
+      id,
+      userId,
+      getRequiredIdempotencyKey(req)
+    )
 
     emitLivraisonChanged(req, { entityId: id, action: "updated" })
-    res.status(201).json(out)
+    res.status(out.idempotent_replay ? 200 : 201).json(out)
+  } catch (e) {
+    next(e)
+  }
+}
+
+export const getLivraisonPdfAvailability: RequestHandler = async (req, res, next) => {
+  try {
+    getUserId(req)
+    const { id } = livraisonIdParamsSchema.parse(req.params)
+    const out = await pdfService.svcGetLivraisonPdfAvailability(id)
+    res.setHeader("Cache-Control", "private, no-store, max-age=0")
+    res.status(200).json(out)
   } catch (e) {
     next(e)
   }
@@ -396,29 +411,25 @@ export const generateLivraisonPdf: RequestHandler = async (req, res, next) => {
 
 export const getLivraisonPdf: RequestHandler = async (req, res, next) => {
   try {
-    const userId = getUserId(req)
+    getUserId(req)
     const { id } = livraisonIdParamsSchema.parse(req.params)
-    const download = coerceBool((req.query as { download?: unknown } | undefined)?.download)
-
-    let latest = await pdfService.svcGetLatestLivraisonPdfDocument(id)
-    if (!latest) {
-      const created = await pdfService.svcGenerateLivraisonPdf(id, userId)
-      latest = { document_id: created.document_id, version: created.version }
+    const query = livraisonPdfQuerySchema.parse(req.query)
+    const download = coerceBool(query.download)
+    const availability = await pdfService.svcGetLivraisonPdfAvailability(id, query.version)
+    if (!availability.available) {
+      throw new HttpError(
+        404,
+        "LIVRAISON_PDF_NOT_GENERATED",
+        "Aucun PDF n'a encore ete genere pour ce bon de livraison."
+      )
     }
 
-    let filePath = await pdfService.svcGetPdfFilePath(latest.document_id)
-    try {
-      await fs.stat(filePath)
-    } catch {
-      const regenerated = await pdfService.svcGenerateLivraisonPdf(id, userId)
-      latest = { document_id: regenerated.document_id, version: regenerated.version }
-      filePath = await pdfService.svcGetPdfFilePath(latest.document_id)
-    }
-
-    const docName = (await pdfService.svcGetDocumentName(latest.document_id)) ?? `bon-livraison-${id}.pdf`
+    const filePath = pdfService.svcGetPdfFilePath(availability.document_id)
+    const docName = (await pdfService.svcGetDocumentName(availability.document_id)) ?? `bon-livraison-${id}.pdf`
     const disposition = download ? "attachment" : "inline"
     res.setHeader("Content-Type", "application/pdf")
     res.setHeader("Content-Disposition", `${disposition}; filename=\"${docName.replace(/\"/g, "")}\"`)
+    res.setHeader("Cache-Control", "private, no-store, max-age=0")
     res.sendFile(filePath)
   } catch (e) {
     next(e)

--- a/src/module/livraisons/domain/livraisons-rbac.test.ts
+++ b/src/module/livraisons/domain/livraisons-rbac.test.ts
@@ -9,6 +9,7 @@ describe("livraisons RBAC", () => {
     ["Responsable Logistique", "allocate"],
     ["Magasinier", "deliver"],
     ["Responsable Qualité", "read"],
+    ["Responsable Qualité", "documents_manage"],
     ["Secretaire", "proof_manage"],
   ] as const)("accorde %s -> %s", (role, capability) => {
     expect(roleHasLivraisonCapability(role, capability)).toBe(true)
@@ -18,6 +19,7 @@ describe("livraisons RBAC", () => {
     [null, "read"],
     ["", "read"],
     ["Employe", "ship"],
+    ["Employe", "documents_manage"],
     ["Responsable Qualité", "ship"],
     ["Comptable", "allocate"],
     ["Commercial", "cancel"],

--- a/src/module/livraisons/repository/livraisons-cancellation-orphaned-reservation.repository.test.ts
+++ b/src/module/livraisons/repository/livraisons-cancellation-orphaned-reservation.repository.test.ts
@@ -1,0 +1,222 @@
+import type { PoolClient } from "pg"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const dependencies = vi.hoisted(() => ({
+  connect: vi.fn(),
+  insertAudit: vi.fn(),
+}))
+
+vi.mock("../../../config/database", () => ({
+  default: {
+    connect: dependencies.connect,
+    query: vi.fn(),
+  },
+}))
+
+vi.mock("../../audit-logs/repository/audit-logs.repository", () => ({
+  repoInsertAuditLog: dependencies.insertAudit,
+}))
+
+import {
+  repoDeleteLivraisonLineAllocation,
+  repoUpdateLivraisonStatus,
+} from "./livraisons.repository"
+
+const BON_LIVRAISON_ID = "44444444-4444-4444-8444-444444444444"
+const LINE_ID = "55555555-5555-4555-8555-555555555555"
+const ALLOCATION_ID = "66666666-6666-4666-8666-666666666666"
+const RESERVATION_ID = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"
+const STOCK_LEVEL_ID = "88888888-8888-4888-8888-888888888888"
+const STOCK_BATCH_ID = "99999999-9999-4999-8999-999999999999"
+const LOT_ID = "22222222-2222-4222-8222-222222222222"
+const USER_ID = 17
+
+type LifecycleState = {
+  deliveryStatus: "DRAFT" | "CANCELLED"
+  allocationExists: boolean
+  reservationStatus: "ACTIVE" | "RELEASED"
+  stockLevelReserved: number
+  stockBatchReserved: number
+}
+
+function createReservationAllocationLifecycle() {
+  const state: LifecycleState = {
+    deliveryStatus: "DRAFT",
+    allocationExists: true,
+    reservationStatus: "ACTIVE",
+    stockLevelReserved: 4,
+    stockBatchReserved: 4,
+  }
+  let snapshot: LifecycleState | null = null
+  let failCancellationStatusUpdate = false
+
+  const query = vi.fn(async (sql: string, values: unknown[] = []) => {
+    if (sql === "BEGIN") {
+      snapshot = { ...state }
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql === "COMMIT") {
+      snapshot = null
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql === "ROLLBACK") {
+      if (snapshot) Object.assign(state, snapshot)
+      snapshot = null
+      return { rows: [], rowCount: 0 }
+    }
+    if (sql.includes("FROM bon_livraison bl")) {
+      return {
+        rows: [{
+          id: BON_LIVRAISON_ID,
+          numero: "BL-TEST-ORPHAN",
+          statut: state.deliveryStatus,
+          row_version: 1,
+        }],
+        rowCount: 1,
+      }
+    }
+    if (sql.includes("SELECT a.stock_movement_line_id")) {
+      return {
+        rows: state.allocationExists ? [{ stock_movement_line_id: null }] : [],
+        rowCount: state.allocationExists ? 1 : 0,
+      }
+    }
+    if (sql.includes("DELETE FROM public.bon_livraison_ligne_allocations")) {
+      const existed = state.allocationExists
+      state.allocationExists = false
+      return { rows: [], rowCount: existed ? 1 : 0 }
+    }
+    if (sql.includes("WITH target_reservation_ids AS")) {
+      if (state.reservationStatus !== "ACTIVE") return { rows: [], rowCount: 0 }
+      const row = {
+        id: RESERVATION_ID,
+        stock_level_id: STOCK_LEVEL_ID,
+        stock_batch_id: STOCK_BATCH_ID,
+        qty_reserved: 2,
+      }
+      // The duplicate exercises the defensive ID deduplication in addition to SQL UNION.
+      return { rows: [row, { ...row }], rowCount: 2 }
+    }
+    if (sql.includes("FROM public.stock_levels") && sql.includes("FOR UPDATE")) {
+      return {
+        rows: [{ qty_total: 10, qty_reserved: state.stockLevelReserved, qty_depreciated: 0 }],
+        rowCount: 1,
+      }
+    }
+    if (sql.includes("FROM public.stock_batches") && sql.includes("FOR UPDATE")) {
+      return {
+        rows: [{
+          stock_level_id: STOCK_LEVEL_ID,
+          lot_id: LOT_ID,
+          qty_total: 10,
+          qty_reserved: state.stockBatchReserved,
+          qty_depreciated: 0,
+        }],
+        rowCount: 1,
+      }
+    }
+    if (sql.includes("FROM public.lots")) {
+      return { rows: [{ lot_status: "LIBERE" }], rowCount: 1 }
+    }
+    if (sql.includes("UPDATE public.stock_levels")) {
+      state.stockLevelReserved -= Number(values[1])
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes("UPDATE public.stock_batches")) {
+      state.stockBatchReserved -= Number(values[1])
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes("UPDATE public.stock_reservations")) {
+      state.reservationStatus = "RELEASED"
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes("UPDATE public.bon_livraison") && sql.includes("SET statut = $2")) {
+      if (failCancellationStatusUpdate) throw new Error("status update failed")
+      state.deliveryStatus = "CANCELLED"
+      return { rows: [], rowCount: 1 }
+    }
+    return { rows: [], rowCount: 1 }
+  })
+  const client = { query, release: vi.fn() } as unknown as PoolClient
+  return {
+    client,
+    query,
+    state,
+    failNextCancellationStatusUpdate() {
+      failCancellationStatusUpdate = true
+    },
+  }
+}
+
+describe("annulation DRAFT après suppression de l'allocation", () => {
+  beforeEach(() => {
+    dependencies.connect.mockReset()
+    dependencies.insertAudit.mockReset()
+    dependencies.insertAudit.mockResolvedValue({ id: "audit-orphan" })
+  })
+
+  it("libère la réservation liée à la ligne et décrémente Stock exactement une fois", async () => {
+    const lifecycle = createReservationAllocationLifecycle()
+    dependencies.connect.mockResolvedValue(lifecycle.client)
+
+    await expect(
+      repoDeleteLivraisonLineAllocation(
+        BON_LIVRAISON_ID,
+        LINE_ID,
+        ALLOCATION_ID,
+        USER_ID
+      )
+    ).resolves.toBe(true)
+    expect(lifecycle.state.allocationExists).toBe(false)
+    expect(lifecycle.state.reservationStatus).toBe("ACTIVE")
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "Allocation supprimée avant annulation",
+      })
+    ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+    expect(lifecycle.state).toEqual({
+      deliveryStatus: "CANCELLED",
+      allocationExists: false,
+      reservationStatus: "RELEASED",
+      stockLevelReserved: 2,
+      stockBatchReserved: 2,
+    })
+    const targetQuery = lifecycle.query.mock.calls.find(([sql]) =>
+      String(sql).includes("WITH target_reservation_ids AS")
+    )
+    expect(String(targetQuery?.[0])).toContain("reservation.bon_livraison_ligne_id")
+    expect(String(targetQuery?.[0])).toContain("UNION")
+    expect(String(targetQuery?.[0])).toContain("bon_livraison_ligne_allocations")
+  })
+
+  it("restaure réservation et quantités si l'annulation échoue après la libération", async () => {
+    const lifecycle = createReservationAllocationLifecycle()
+    dependencies.connect.mockResolvedValue(lifecycle.client)
+
+    await repoDeleteLivraisonLineAllocation(
+      BON_LIVRAISON_ID,
+      LINE_ID,
+      ALLOCATION_ID,
+      USER_ID
+    )
+    lifecycle.failNextCancellationStatusUpdate()
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "Rollback après libération",
+      })
+    ).rejects.toThrow("status update failed")
+
+    expect(lifecycle.state).toEqual({
+      deliveryStatus: "DRAFT",
+      allocationExists: false,
+      reservationStatus: "ACTIVE",
+      stockLevelReserved: 4,
+      stockBatchReserved: 4,
+    })
+    expect(dependencies.insertAudit).not.toHaveBeenCalled()
+    expect(lifecycle.query).toHaveBeenCalledWith("ROLLBACK")
+  })
+})

--- a/src/module/livraisons/repository/livraisons-cancellation.repository.test.ts
+++ b/src/module/livraisons/repository/livraisons-cancellation.repository.test.ts
@@ -1,0 +1,170 @@
+import type { PoolClient } from "pg"
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const testState = vi.hoisted(() => ({
+  connect: vi.fn(),
+  insertAudit: vi.fn(),
+  releaseReservations: vi.fn(),
+}))
+
+vi.mock("../../../config/database", () => ({
+  default: {
+    connect: testState.connect,
+    query: vi.fn(),
+  },
+}))
+
+vi.mock("../../audit-logs/repository/audit-logs.repository", () => ({
+  repoInsertAuditLog: testState.insertAudit,
+}))
+
+vi.mock("./livraisons-shipment.repository", () => ({
+  prepareLivraisonInTransaction: vi.fn(),
+  releaseLivraisonReservationsInTransaction: testState.releaseReservations,
+  repoListLivraisonProofs: vi.fn(),
+}))
+
+import { repoUpdateLivraisonStatus } from "./livraisons.repository"
+
+const BON_LIVRAISON_ID = "00000000-0000-4000-8000-000000000017"
+const USER_ID = 17
+
+function createClient(currentStatus: "DRAFT" | "READY" | "CANCELLED", updateRowCount = 1) {
+  const query = vi.fn(async (sql: string, _values?: unknown[]) => {
+    if (sql.includes("FROM bon_livraison bl")) {
+      return {
+        rows: [{
+          id: BON_LIVRAISON_ID,
+          numero: "BL-TEST-0017",
+          statut: currentStatus,
+          row_version: 1,
+        }],
+      }
+    }
+    if (sql.includes("UPDATE public.bon_livraison")) {
+      return { rows: [], rowCount: updateRowCount }
+    }
+    return { rows: [], rowCount: 0 }
+  })
+  const client = { query, release: vi.fn() } as unknown as PoolClient
+  return { client, query }
+}
+
+describe("transaction d'annulation d'un bon de livraison", () => {
+  beforeEach(() => {
+    testState.connect.mockReset()
+    testState.insertAudit.mockReset()
+    testState.releaseReservations.mockReset()
+    testState.insertAudit.mockResolvedValue({ id: "audit-17" })
+    testState.releaseReservations.mockResolvedValue(undefined)
+  })
+
+  it("libère les réservations READY avec le même motif avant la mutation", async () => {
+    const { client, query } = createClient("READY")
+    testState.connect.mockResolvedValue(client)
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "  Commande client abandonnée  ",
+      })
+    ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+    expect(testState.releaseReservations).toHaveBeenCalledWith(
+      client,
+      BON_LIVRAISON_ID,
+      USER_ID,
+      "Commande client abandonnée"
+    )
+    const updateCallIndex = query.mock.calls.findIndex(([sql]) =>
+      String(sql).includes("UPDATE public.bon_livraison")
+    )
+    expect(testState.releaseReservations.mock.invocationCallOrder[0]).toBeLessThan(
+      query.mock.invocationCallOrder[updateCallIndex]
+    )
+    expect(testState.insertAudit).toHaveBeenCalledOnce()
+  })
+
+  it("conserve le DRAFT et écrit l'événement et l'audit avant COMMIT", async () => {
+    const { client, query } = createClient("DRAFT")
+    testState.connect.mockResolvedValue(client)
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "  Doublon de saisie confirmé  ",
+      })
+    ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+    const eventCall = query.mock.calls.find(([sql]) =>
+      String(sql).includes("INSERT INTO bon_livraison_event_log")
+    )
+    expect(eventCall?.[1]).toEqual([
+      BON_LIVRAISON_ID,
+      "STATUS_CHANGED",
+      JSON.stringify({ statut: "DRAFT" }),
+      JSON.stringify({ statut: "CANCELLED", commentaire: "Doublon de saisie confirmé" }),
+      USER_ID,
+    ])
+    expect(testState.insertAudit).toHaveBeenCalledWith(expect.objectContaining({
+      user_id: USER_ID,
+      tx: client,
+      body: expect.objectContaining({
+        action: "livraisons.cancelled",
+        entity_id: BON_LIVRAISON_ID,
+        details: {
+          bon_livraison_numero: "BL-TEST-0017",
+          old_statut: "DRAFT",
+          new_statut: "CANCELLED",
+          reason: "Doublon de saisie confirmé",
+        },
+      }),
+    }))
+
+    const auditOrder = testState.insertAudit.mock.invocationCallOrder[0]
+    const commitOrder = query.mock.calls.findIndex(([sql]) => sql === "COMMIT")
+    expect(auditOrder).toBeLessThan(query.mock.invocationCallOrder[commitOrder])
+  })
+
+  it("refuse un motif vide avant toute mutation et ROLLBACK", async () => {
+    const { client, query } = createClient("DRAFT")
+    testState.connect.mockResolvedValue(client)
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "   ",
+      })
+    ).rejects.toMatchObject({ status: 422, code: "CANCELLATION_REASON_REQUIRED" })
+
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("UPDATE public.bon_livraison"))).toBe(false)
+    expect(query).toHaveBeenCalledWith("ROLLBACK")
+    expect(testState.insertAudit).not.toHaveBeenCalled()
+  })
+
+  it("ne duplique ni événement ni audit lors d'un rejeu idempotent", async () => {
+    const { client, query } = createClient("CANCELLED")
+    testState.connect.mockResolvedValue(client)
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "Confirmation du rejeu",
+      })
+    ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("bon_livraison_event_log"))).toBe(false)
+    expect(testState.insertAudit).not.toHaveBeenCalled()
+    expect(query).toHaveBeenCalledWith("COMMIT")
+  })
+
+  it("annule toute la transaction si le statut change malgré le verrou", async () => {
+    const { client, query } = createClient("DRAFT", 0)
+    testState.connect.mockResolvedValue(client)
+
+    await expect(
+      repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+        commentaire: "Annulation concurrente",
+      })
+    ).rejects.toMatchObject({ status: 409, code: "CONCURRENT_MODIFICATION" })
+
+    expect(query).toHaveBeenCalledWith("ROLLBACK")
+    expect(testState.insertAudit).not.toHaveBeenCalled()
+  })
+})

--- a/src/module/livraisons/repository/livraisons-cancellation.repository.test.ts
+++ b/src/module/livraisons/repository/livraisons-cancellation.repository.test.ts
@@ -59,29 +59,49 @@ describe("transaction d'annulation d'un bon de livraison", () => {
     testState.releaseReservations.mockResolvedValue(undefined)
   })
 
-  it("libère les réservations READY avec le même motif avant la mutation", async () => {
-    const { client, query } = createClient("READY")
+  it.each(["DRAFT", "READY"] as const)(
+    "libère les réservations ACTIVE d'un BL %s avec le même motif avant la mutation",
+    async (currentStatus) => {
+      const { client, query } = createClient(currentStatus)
+      testState.connect.mockResolvedValue(client)
+
+      await expect(
+        repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
+          commentaire: "  Commande client abandonnée  ",
+        })
+      ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+      expect(testState.releaseReservations).toHaveBeenCalledWith(
+        client,
+        BON_LIVRAISON_ID,
+        USER_ID,
+        "Commande client abandonnée"
+      )
+      const updateCallIndex = query.mock.calls.findIndex(([sql]) =>
+        String(sql).includes("UPDATE public.bon_livraison")
+      )
+      expect(testState.releaseReservations.mock.invocationCallOrder[0]).toBeLessThan(
+        query.mock.invocationCallOrder[updateCallIndex]
+      )
+      expect(testState.insertAudit).toHaveBeenCalledOnce()
+    }
+  )
+
+  it("annule toute la transaction si la libération des réservations échoue", async () => {
+    const { client, query } = createClient("DRAFT")
     testState.connect.mockResolvedValue(client)
+    testState.releaseReservations.mockRejectedValueOnce(new Error("stock release failed"))
 
     await expect(
       repoUpdateLivraisonStatus(BON_LIVRAISON_ID, "CANCELLED", USER_ID, {
-        commentaire: "  Commande client abandonnée  ",
+        commentaire: "Annulation avec allocation partielle",
       })
-    ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+    ).rejects.toThrow("stock release failed")
 
-    expect(testState.releaseReservations).toHaveBeenCalledWith(
-      client,
-      BON_LIVRAISON_ID,
-      USER_ID,
-      "Commande client abandonnée"
-    )
-    const updateCallIndex = query.mock.calls.findIndex(([sql]) =>
-      String(sql).includes("UPDATE public.bon_livraison")
-    )
-    expect(testState.releaseReservations.mock.invocationCallOrder[0]).toBeLessThan(
-      query.mock.invocationCallOrder[updateCallIndex]
-    )
-    expect(testState.insertAudit).toHaveBeenCalledOnce()
+    expect(query).toHaveBeenCalledWith("ROLLBACK")
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("UPDATE public.bon_livraison"))).toBe(false)
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("bon_livraison_event_log"))).toBe(false)
+    expect(testState.insertAudit).not.toHaveBeenCalled()
   })
 
   it("conserve le DRAFT et écrit l'événement et l'audit avant COMMIT", async () => {

--- a/src/module/livraisons/repository/livraisons-shipment.repository.test.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.test.ts
@@ -1,7 +1,10 @@
 import type { PoolClient } from "pg";
 import { describe, expect, it, vi } from "vitest";
 
-import { prepareLivraisonInTransaction } from "./livraisons-shipment.repository";
+import {
+  prepareLivraisonInTransaction,
+  releaseLivraisonReservationsInTransaction,
+} from "./livraisons-shipment.repository";
 import {
   attachActiveCommandeReservationsToLivraison,
   repoCreateLivraisonFromCommande,
@@ -179,6 +182,69 @@ describe("prepareLivraisonInTransaction", () => {
       query.mock.calls.some(([sql]) =>
         String(sql).includes("SET statut = 'READY'"))
     ).toBe(true);
+  });
+});
+
+describe("releaseLivraisonReservationsInTransaction", () => {
+  it("libère toutes les réservations ACTIVE liées au BL et décrémente les quantités agrégées", async () => {
+    const stockLevelId = "88888888-8888-4888-8888-888888888888";
+    const stockBatchId = "99999999-9999-4999-8999-999999999999";
+    const lotId = "22222222-2222-4222-8222-222222222222";
+    const reservationIds = [
+      "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+      "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    ];
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("FROM public.bon_livraison_ligne_allocations allocation")) {
+        return {
+          rows: reservationIds.map((id, index) => ({
+            id,
+            stock_level_id: stockLevelId,
+            stock_batch_id: stockBatchId,
+            qty_reserved: index === 0 ? 1.25 : 0.75,
+          })),
+        };
+      }
+      if (sql.includes("FROM public.stock_levels")) {
+        return { rows: [{ qty_total: 10, qty_reserved: 4, qty_depreciated: 0 }] };
+      }
+      if (sql.includes("FROM public.stock_batches")) {
+        return {
+          rows: [{
+            stock_level_id: stockLevelId,
+            lot_id: lotId,
+            qty_total: 10,
+            qty_reserved: 4,
+            qty_depreciated: 0,
+          }],
+        };
+      }
+      if (sql.includes("FROM public.lots")) return { rows: [{ lot_status: "LIBERE" }] };
+      return { rows: [], rowCount: 2 };
+    });
+    const client = { query } as unknown as PoolClient;
+
+    await expect(
+      releaseLivraisonReservationsInTransaction(
+        client,
+        "44444444-4444-4444-8444-444444444444",
+        7,
+        "BL annulé"
+      )
+    ).resolves.toBeUndefined();
+
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("SET qty_reserved = qty_reserved - $2"),
+      [stockLevelId, 2, 7]
+    );
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE public.stock_batches SET qty_reserved = qty_reserved - $2"),
+      [stockBatchId, 2]
+    );
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("SET status = 'RELEASED'"),
+      [reservationIds, "BL annulé", 7]
+    );
   });
 });
 

--- a/src/module/livraisons/repository/livraisons-shipment.repository.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.ts
@@ -733,25 +733,61 @@ export async function releaseLivraisonReservationsInTransaction(
     qty_reserved: number
   }>(
     `
+      WITH target_reservation_ids AS (
+        SELECT reservation.id
+        FROM public.stock_reservations reservation
+        JOIN public.bon_livraison_ligne line
+          ON line.id = reservation.bon_livraison_ligne_id
+        WHERE line.bon_livraison_id = $1::uuid
+          AND reservation.status = 'ACTIVE'
+
+        UNION
+
+        SELECT reservation.id
+        FROM public.bon_livraison_ligne_allocations allocation
+        JOIN public.bon_livraison_ligne line
+          ON line.id = allocation.bon_livraison_ligne_id
+        JOIN public.stock_reservations reservation
+          ON reservation.id = allocation.reservation_id
+        WHERE line.bon_livraison_id = $1::uuid
+          AND reservation.status = 'ACTIVE'
+      )
       SELECT
         reservation.id::text AS id,
-        allocation.stock_level_id::text AS stock_level_id,
-        allocation.stock_batch_id::text AS stock_batch_id,
+        level.id::text AS stock_level_id,
+        reservation.stock_batch_id::text AS stock_batch_id,
         reservation.qty_reserved::float8 AS qty_reserved
-      FROM public.bon_livraison_ligne_allocations allocation
-      JOIN public.bon_livraison_ligne line ON line.id = allocation.bon_livraison_ligne_id
-      JOIN public.stock_reservations reservation ON reservation.id = allocation.reservation_id
-      WHERE line.bon_livraison_id = $1::uuid
-        AND reservation.status = 'ACTIVE'
-      ORDER BY allocation.stock_level_id, allocation.stock_batch_id, reservation.id
+      FROM target_reservation_ids target
+      JOIN public.stock_reservations reservation ON reservation.id = target.id
+      JOIN public.stock_levels level
+        ON level.article_id = reservation.article_id
+       AND level.location_id = reservation.location_id
+      WHERE reservation.status = 'ACTIVE'
+      ORDER BY level.id, reservation.stock_batch_id, reservation.id
       FOR UPDATE OF reservation
     `,
     [bonLivraisonId]
   )
-  if (!reservations.rows.length) return
+  const reservationsById = new Map<string, (typeof reservations.rows)[number]>()
+  for (const reservation of reservations.rows) {
+    const existing = reservationsById.get(reservation.id)
+    if (existing) {
+      if (
+        existing.stock_level_id !== reservation.stock_level_id ||
+        existing.stock_batch_id !== reservation.stock_batch_id ||
+        existing.qty_reserved !== reservation.qty_reserved
+      ) {
+        throw new Error("Conflicting stock targets for delivery reservation")
+      }
+      continue
+    }
+    reservationsById.set(reservation.id, reservation)
+  }
+  const targetReservations = [...reservationsById.values()]
+  if (!targetReservations.length) return
 
   const grouped = new Map<string, { level: string; batch: string | null; qty: number }>()
-  for (const reservation of reservations.rows) {
+  for (const reservation of targetReservations) {
     const key = `${reservation.stock_level_id}:${reservation.stock_batch_id ?? "-"}`
     const current = grouped.get(key) ?? {
       level: reservation.stock_level_id,
@@ -789,19 +825,24 @@ export async function releaseLivraisonReservationsInTransaction(
       )
     }
   }
-  await client.query(
+  const released = await client.query(
     `
       UPDATE public.stock_reservations
       SET status = 'RELEASED',
           reason = $2,
           released_at = now(),
           released_by = $3,
+          row_version = row_version + 1,
           updated_at = now(),
           updated_by = $3
       WHERE id = ANY($1::uuid[])
+        AND status = 'ACTIVE'
     `,
-    [reservations.rows.map((row) => row.id), reason, userId]
+    [targetReservations.map((row) => row.id), reason, userId]
   )
+  if ((released.rowCount ?? 0) !== targetReservations.length) {
+    throw new Error("Active delivery reservation count changed while releasing stock")
+  }
 }
 
 export async function repoShipLivraison(

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -2227,7 +2227,10 @@ export async function repoUpdateLivraisonStatus(
       return { id: bonLivraisonId, statut: "READY" }
     }
 
-    if (current.statut === "READY" && statut === "CANCELLED") {
+    if (
+      (current.statut === "DRAFT" || current.statut === "READY") &&
+      statut === "CANCELLED"
+    ) {
       await releaseLivraisonReservationsInTransaction(
         db,
         bonLivraisonId,

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -2202,6 +2202,14 @@ export async function repoUpdateLivraisonStatus(
     await db.query("BEGIN")
     const current = await getHeader(db, bonLivraisonId, { forUpdate: true })
     if (!current) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    const cancellationReason = statut === "CANCELLED" ? meta?.commentaire?.trim() ?? "" : ""
+    if (statut === "CANCELLED" && !cancellationReason) {
+      throw new HttpError(
+        422,
+        "CANCELLATION_REASON_REQUIRED",
+        "Un motif est obligatoire pour annuler un bon de livraison."
+      )
+    }
     if (current.statut === statut) {
       await db.query("COMMIT")
       return { id: bonLivraisonId, statut }
@@ -2213,18 +2221,6 @@ export async function repoUpdateLivraisonStatus(
         `Invalid transition from ${current.statut} to ${statut}`
       )
     }
-    if (
-      current.statut === "READY" &&
-      statut === "CANCELLED" &&
-      !meta?.commentaire?.trim()
-    ) {
-      throw new HttpError(
-        422,
-        "CANCELLATION_REASON_REQUIRED",
-        "Un motif est obligatoire pour annuler une préparation READY."
-      )
-    }
-
     if (current.statut === "DRAFT" && statut === "READY") {
       await prepareLivraisonInTransaction(db, bonLivraisonId, userId)
       await db.query("COMMIT")
@@ -2236,7 +2232,7 @@ export async function repoUpdateLivraisonStatus(
         db,
         bonLivraisonId,
         userId,
-        meta?.commentaire ?? "Annulation du bon de livraison"
+        cancellationReason
       )
     }
     if (current.statut === "SHIPPED" && statut === "DELIVERED") {
@@ -2280,8 +2276,37 @@ export async function repoUpdateLivraisonStatus(
       event_type: "STATUS_CHANGED",
       user_id: userId,
       old_values: { statut: current.statut },
-      new_values: { statut, commentaire: meta?.commentaire ?? null },
+      new_values: {
+        statut,
+        commentaire: statut === "CANCELLED" ? cancellationReason : meta?.commentaire ?? null,
+      },
     })
+    if (statut === "CANCELLED") {
+      await repoInsertAuditLog({
+        user_id: userId,
+        body: {
+          event_type: "ACTION",
+          action: "livraisons.cancelled",
+          page_key: "livraisons",
+          entity_type: "bon_livraison",
+          entity_id: bonLivraisonId,
+          path: `/api/v1/livraisons/${bonLivraisonId}/status`,
+          client_session_id: null,
+          details: {
+            bon_livraison_numero: current.numero,
+            old_statut: current.statut,
+            new_statut: statut,
+            reason: cancellationReason,
+          },
+        },
+        ip: null,
+        user_agent: null,
+        device_type: null,
+        os: null,
+        browser: null,
+        tx: db,
+      })
+    }
     await db.query("COMMIT")
     return { id: bonLivraisonId, statut }
   } catch (error) {

--- a/src/module/livraisons/routes/livraisons.routes.ts
+++ b/src/module/livraisons/routes/livraisons.routes.ts
@@ -20,6 +20,7 @@ import {
   deleteLivraisonLineAllocation,
   generateLivraisonPdf,
   getLivraison,
+  getLivraisonPdfAvailability,
   getLivraisonShipmentPreview,
   getLivraisonDocumentFile,
   getLivraisonPdf,
@@ -139,6 +140,11 @@ router.get(
   getLivraisonDocumentFile
 )
 
+router.get(
+  "/:id/pdf/availability",
+  requireLivraisonCapability("read"),
+  getLivraisonPdfAvailability
+)
 router.get("/:id/pdf", requireLivraisonCapability("read"), getLivraisonPdf)
 router.post(
   "/:id/pdf",

--- a/src/module/livraisons/services/livraisons-status.service.test.ts
+++ b/src/module/livraisons/services/livraisons-status.service.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const repository = vi.hoisted(() => ({
+  getStatut: vi.fn(),
+  updateStatus: vi.fn(),
+}))
+
+vi.mock("../repository/livraisons.repository", () => ({
+  repoAddLivraisonLine: vi.fn(),
+  repoAttachLivraisonDocuments: vi.fn(),
+  repoCreateLivraison: vi.fn(),
+  repoCreateLivraisonLineAllocation: vi.fn(),
+  repoCreateLivraisonFromCommande: vi.fn(),
+  repoDeleteLivraisonLineAllocation: vi.fn(),
+  repoDeleteLivraisonLine: vi.fn(),
+  repoGetLivraisonDetail: vi.fn(),
+  repoGetLivraisonStatut: repository.getStatut,
+  repoListLivraisons: vi.fn(),
+  repoRemoveLivraisonDocument: vi.fn(),
+  repoUpdateLivraisonHeader: vi.fn(),
+  repoUpdateLivraisonLine: vi.fn(),
+  repoUpdateLivraisonStatus: repository.updateStatus,
+}))
+
+vi.mock("../repository/livraisons-shipment.repository", () => ({
+  repoCreateLivraisonProof: vi.fn(),
+  repoGetLivraisonShipmentPreview: vi.fn(),
+  repoShipLivraison: vi.fn(),
+}))
+
+import { svcUpdateLivraisonStatus } from "./livraisons.service"
+
+const BON_LIVRAISON_ID = "00000000-0000-4000-8000-000000000017"
+const USER_ID = 17
+
+describe("annulation auditée d'un bon de livraison", () => {
+  beforeEach(() => {
+    repository.getStatut.mockReset()
+    repository.updateStatus.mockReset()
+    repository.updateStatus.mockResolvedValue({
+      id: BON_LIVRAISON_ID,
+      statut: "CANCELLED",
+    })
+  })
+
+  it.each(["DRAFT", "READY"] as const)(
+    "autorise %s -> CANCELLED avec un motif normalisé",
+    async (current) => {
+      repository.getStatut.mockResolvedValue(current)
+
+      await expect(
+        svcUpdateLivraisonStatus(
+          BON_LIVRAISON_ID,
+          { statut: "CANCELLED", commentaire: "  Commande client abandonnée  " },
+          USER_ID
+        )
+      ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+      expect(repository.updateStatus).toHaveBeenCalledWith(
+        BON_LIVRAISON_ID,
+        "CANCELLED",
+        USER_ID,
+        { commentaire: "Commande client abandonnée" }
+      )
+    }
+  )
+
+  it.each(["DRAFT", "READY"] as const)(
+    "refuse %s -> CANCELLED sans motif",
+    async (current) => {
+      repository.getStatut.mockResolvedValue(current)
+
+      await expect(
+        svcUpdateLivraisonStatus(
+          BON_LIVRAISON_ID,
+          { statut: "CANCELLED", commentaire: "   " },
+          USER_ID
+        )
+      ).rejects.toMatchObject({
+        status: 422,
+        code: "CANCELLATION_REASON_REQUIRED",
+      })
+      expect(repository.updateStatus).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(["SHIPPED", "DELIVERED"] as const)(
+    "refuse l'annulation depuis l'état %s",
+    async (current) => {
+      repository.getStatut.mockResolvedValue(current)
+
+      await expect(
+        svcUpdateLivraisonStatus(
+          BON_LIVRAISON_ID,
+          { statut: "CANCELLED", commentaire: "Motif documenté" },
+          USER_ID
+        )
+      ).rejects.toMatchObject({ status: 409, code: "INVALID_TRANSITION" })
+      expect(repository.updateStatus).not.toHaveBeenCalled()
+    }
+  )
+
+  it("conserve l'idempotence de CANCELLED avec un motif explicite", async () => {
+    repository.getStatut.mockResolvedValue("CANCELLED")
+
+    await expect(
+      svcUpdateLivraisonStatus(
+        BON_LIVRAISON_ID,
+        { statut: "CANCELLED", commentaire: "Confirmation de l'annulation" },
+        USER_ID
+      )
+    ).resolves.toEqual({ id: BON_LIVRAISON_ID, statut: "CANCELLED" })
+
+    expect(repository.updateStatus).toHaveBeenCalledOnce()
+  })
+
+  it("propage un conflit détecté sous verrou sans annoncer de faux succès", async () => {
+    repository.getStatut.mockResolvedValue("DRAFT")
+    repository.updateStatus.mockRejectedValueOnce(
+      Object.assign(new Error("Le statut du BL a changé."), {
+        status: 409,
+        code: "CONCURRENT_MODIFICATION",
+      })
+    )
+
+    await expect(
+      svcUpdateLivraisonStatus(
+        BON_LIVRAISON_ID,
+        { statut: "CANCELLED", commentaire: "Doublon confirmé" },
+        USER_ID
+      )
+    ).rejects.toMatchObject({ status: 409, code: "CONCURRENT_MODIFICATION" })
+  })
+})

--- a/src/module/livraisons/services/livraisons.service.ts
+++ b/src/module/livraisons/services/livraisons.service.ts
@@ -114,18 +114,16 @@ export async function svcUpdateLivraisonStatus(id: string, body: LivraisonStatus
   const current = await repoGetLivraisonStatut(id)
   if (!current) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
   assertAllowedTransition(current, body.statut)
-  if (
-    current === "READY" &&
-    body.statut === "CANCELLED" &&
-    !body.commentaire?.trim()
-  ) {
+  if (body.statut === "CANCELLED" && !body.commentaire?.trim()) {
     throw new HttpError(
       422,
       "CANCELLATION_REASON_REQUIRED",
-      "Un motif est obligatoire pour annuler une préparation READY."
+      "Un motif est obligatoire pour annuler un bon de livraison."
     )
   }
-  return repoUpdateLivraisonStatus(id, body.statut, userId, { commentaire: body.commentaire ?? null })
+  return repoUpdateLivraisonStatus(id, body.statut, userId, {
+    commentaire: body.commentaire?.trim() || null,
+  })
 }
 
 export async function svcGetLivraisonShipmentPreview(id: string) {

--- a/src/module/livraisons/services/pdf.service.test.ts
+++ b/src/module/livraisons/services/pdf.service.test.ts
@@ -1,0 +1,295 @@
+import fs from "node:fs/promises"
+import os from "node:os"
+import path from "node:path"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  poolQuery: vi.fn(),
+  poolConnect: vi.fn(),
+  readIssuerParty: vi.fn(),
+  repoGetLivraisonDetail: vi.fn(),
+  repoGetDocumentName: vi.fn(),
+  renderBonLivraisonDocument: vi.fn(),
+}))
+
+vi.mock("../../../config/database", () => ({
+  default: {
+    query: (...args: unknown[]) => mocks.poolQuery(...args),
+    connect: (...args: unknown[]) => mocks.poolConnect(...args),
+  },
+}))
+vi.mock("../../../shared/documents/issuer-identity.repository", () => ({
+  readIssuerParty: (...args: unknown[]) => mocks.readIssuerParty(...args),
+}))
+vi.mock("../repository/livraisons.repository", () => ({
+  repoGetLivraisonDetail: (...args: unknown[]) => mocks.repoGetLivraisonDetail(...args),
+  repoGetDocumentName: (...args: unknown[]) => mocks.repoGetDocumentName(...args),
+}))
+vi.mock("./bon-livraison-document", () => ({
+  renderBonLivraisonDocument: (...args: unknown[]) => mocks.renderBonLivraisonDocument(...args),
+}))
+
+import {
+  svcGenerateLivraisonPdf,
+  svcGetLivraisonPdfAvailability,
+} from "./pdf.service"
+
+const BL_ID = "11111111-1111-4111-8111-111111111111"
+const DOC_ID = "22222222-2222-4222-8222-222222222222"
+const PDF_BYTES = Buffer.from("%PDF-1.7\nsynthetic")
+
+type TestPoolClient = {
+  query: ReturnType<typeof vi.fn>
+  release: ReturnType<typeof vi.fn>
+}
+
+let documentsRoot = ""
+
+function detail(lines: unknown[] = []) {
+  return {
+    bon_livraison: {
+      id: BL_ID,
+      numero: "BL-2026-0018",
+      statut: "DRAFT",
+      date_creation: "2026-08-04",
+      date_expedition: null,
+    },
+    lignes: lines,
+    documents: [],
+    proofs: [],
+    events: [],
+  }
+}
+
+function generationDb(options: {
+  nextVersion?: number
+  replay?: {
+    document_id: string
+    version: number
+    generated_at: string
+    file_size_bytes: number
+  }
+} = {}): TestPoolClient {
+  const query = vi.fn(async (sqlValue: unknown) => {
+    const sql = String(sqlValue)
+    if (sql.includes("SELECT id::text AS id") && sql.includes("FOR UPDATE")) {
+      return { rows: [{ id: BL_ID }] }
+    }
+    if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) {
+      return {
+        rows: options.replay
+          ? [{ bon_livraison_id: BL_ID, ...options.replay }]
+          : [],
+      }
+    }
+    if (sql.includes("COALESCE(MAX(document.version)")) {
+      return { rows: [{ version: options.nextVersion ?? 1 }] }
+    }
+    return { rows: [] }
+  })
+  return { query, release: vi.fn() }
+}
+
+async function storePdf(documentId = DOC_ID, bytes = PDF_BYTES) {
+  const directory = path.join(documentsRoot, "livraisons")
+  await fs.mkdir(directory, { recursive: true })
+  await fs.writeFile(path.join(directory, `${documentId}.pdf`), bytes)
+}
+
+beforeEach(async () => {
+  vi.clearAllMocks()
+  documentsRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-pdf-availability-"))
+  process.env.CERP_DOCUMENTS_ROOT = documentsRoot
+  mocks.readIssuerParty.mockResolvedValue({ company_name: "CERP" })
+  mocks.repoGetLivraisonDetail.mockResolvedValue(detail())
+  mocks.repoGetDocumentName.mockResolvedValue("Bon_livraison_BL-2026-0018.pdf")
+  mocks.renderBonLivraisonDocument.mockResolvedValue(PDF_BYTES)
+})
+
+afterEach(async () => {
+  delete process.env.CERP_DOCUMENTS_ROOT
+  await fs.rm(documentsRoot, { recursive: true, force: true })
+})
+
+describe("livraison PDF availability", () => {
+  it("reports an empty draft as not generated without creating a document", async () => {
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{
+        bon_livraison_id: BL_ID,
+        document_id: null,
+        version: null,
+        generated_at: null,
+        file_size_bytes: null,
+      }],
+    })
+
+    await expect(svcGetLivraisonPdfAvailability(BL_ID)).resolves.toEqual({
+      available: false,
+      status: "NOT_GENERATED",
+      document_id: null,
+      version: null,
+      generated_at: null,
+    })
+    expect(mocks.poolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("document.type = 'GENERATED_SIMPLE_BL_PDF'"),
+      [BL_ID, null],
+    )
+    expect(String(mocks.poolQuery.mock.calls[0]?.[0])).not.toContain(
+      "document.type = 'GENERATED_BL_PDF'",
+    )
+    await expect(fs.readdir(documentsRoot)).resolves.toEqual([])
+  })
+
+  it("only reports a generated archive as available when its PDF file is readable", async () => {
+    await storePdf()
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{
+        bon_livraison_id: BL_ID,
+        document_id: DOC_ID,
+        version: 3,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+      }],
+    })
+
+    await expect(svcGetLivraisonPdfAvailability(BL_ID)).resolves.toEqual({
+      available: true,
+      status: "AVAILABLE",
+      document_id: DOC_ID,
+      version: 3,
+      generated_at: "2026-08-04T12:00:00.000Z",
+    })
+  })
+
+  it("surfaces a missing archived file as an integrity error, not ordinary unavailability", async () => {
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{
+        bon_livraison_id: BL_ID,
+        document_id: DOC_ID,
+        version: 1,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+      }],
+    })
+
+    await expect(svcGetLivraisonPdfAvailability(BL_ID)).rejects.toMatchObject({
+      status: 410,
+      code: "LIVRAISON_PDF_FILE_MISSING",
+    })
+  })
+})
+
+describe("livraison PDF generation", () => {
+  it("generates a valid archived version for an empty draft", async () => {
+    const db = generationDb()
+    mocks.poolConnect.mockResolvedValue(db)
+
+    const result = await svcGenerateLivraisonPdf(BL_ID, 7, "generate-empty-draft")
+
+    expect(result).toMatchObject({ version: 1, idempotent_replay: false })
+    expect(mocks.renderBonLivraisonDocument).toHaveBeenCalledWith(
+      expect.objectContaining({ lignes: [], version: 1 }),
+    )
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${result.document_id}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining("FOR UPDATE"),
+      [BL_ID],
+    )
+    expect(
+      db.query.mock.calls.some(([sql]) =>
+        String(sql).includes("'GENERATED_SIMPLE_BL_PDF'"),
+      ),
+    ).toBe(true)
+  })
+
+  it("regenerates a complete delivery as the next version", async () => {
+    const db = generationDb({ nextVersion: 4 })
+    mocks.poolConnect.mockResolvedValue(db)
+    mocks.repoGetLivraisonDetail.mockResolvedValue(
+      detail([{ id: "line-1", designation: "Pièce usinée", quantite: 2 }]),
+    )
+
+    const result = await svcGenerateLivraisonPdf(BL_ID, 7, "regenerate-complete")
+
+    expect(result).toMatchObject({ version: 4, idempotent_replay: false })
+    expect(mocks.renderBonLivraisonDocument).toHaveBeenCalledWith(
+      expect.objectContaining({
+        lignes: [expect.objectContaining({ designation: "Pièce usinée" })],
+        version: 4,
+      }),
+    )
+  })
+
+  it("replays the same actor and idempotency key without rendering another version", async () => {
+    await storePdf()
+    const db = generationDb({
+      replay: {
+        document_id: DOC_ID,
+        version: 2,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+      },
+    })
+    mocks.poolConnect.mockResolvedValue(db)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "same-generation-key"),
+    ).resolves.toEqual({
+      document_id: DOC_ID,
+      version: 2,
+      idempotent_replay: true,
+    })
+    expect(mocks.renderBonLivraisonDocument).not.toHaveBeenCalled()
+    expect(
+      db.query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO public.documents_clients")),
+    ).toBe(false)
+  })
+
+  it("serializes concurrent requests so distinct keys receive distinct versions", async () => {
+    let version = 0
+    let locked = false
+    const waiters: Array<() => void> = []
+
+    const releaseLock = () => {
+      const next = waiters.shift()
+      if (next) next()
+      else locked = false
+    }
+    const createConcurrentDb = () => {
+      let ownsLock = false
+      const query = vi.fn(async (sqlValue: unknown, values?: unknown[]) => {
+        const sql = String(sqlValue)
+        if (sql.includes("SELECT id::text AS id") && sql.includes("FOR UPDATE")) {
+          if (locked) await new Promise<void>((resolve) => waiters.push(resolve))
+          else locked = true
+          ownsLock = true
+          return { rows: [{ id: BL_ID }] }
+        }
+        if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) return { rows: [] }
+        if (sql.includes("COALESCE(MAX(document.version)")) {
+          return { rows: [{ version: version + 1 }] }
+        }
+        if (sql.includes("INSERT INTO public.bon_livraison_documents")) {
+          version = Number(values?.[2])
+        }
+        if ((sql === "COMMIT" || sql === "ROLLBACK") && ownsLock) {
+          ownsLock = false
+          releaseLock()
+        }
+        return { rows: [] }
+      })
+      return { query, release: vi.fn() }
+    }
+    mocks.poolConnect.mockImplementation(async () => createConcurrentDb())
+
+    const [first, second] = await Promise.all([
+      svcGenerateLivraisonPdf(BL_ID, 7, "concurrent-key-one"),
+      svcGenerateLivraisonPdf(BL_ID, 7, "concurrent-key-two"),
+    ])
+
+    expect([first.version, second.version].sort()).toEqual([1, 2])
+    expect(mocks.renderBonLivraisonDocument).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/module/livraisons/services/pdf.service.test.ts
+++ b/src/module/livraisons/services/pdf.service.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const repository = vi.hoisted(() => ({
+  getDetail: vi.fn(),
+  getDocumentName: vi.fn(),
+}))
+
+const database = vi.hoisted(() => ({
+  connect: vi.fn(),
+  query: vi.fn(),
+}))
+
+vi.mock("../../../config/database", () => ({
+  default: database,
+}))
+
+vi.mock("../repository/livraisons.repository", () => ({
+  repoGetLivraisonDetail: repository.getDetail,
+  repoGetDocumentName: repository.getDocumentName,
+}))
+
+import {
+  svcGenerateLivraisonPdf,
+  svcGetLatestLivraisonPdfDocument,
+} from "./pdf.service"
+
+const BON_LIVRAISON_ID = "00000000-0000-4000-8000-000000000017"
+
+describe("garde PDF d'un bon de livraison annulé", () => {
+  beforeEach(() => {
+    repository.getDetail.mockReset()
+    repository.getDocumentName.mockReset()
+    database.connect.mockReset()
+    database.query.mockReset()
+  })
+
+  it("conserve la lecture de l'archive historique existante", async () => {
+    database.query.mockResolvedValue({ rows: [{ document_id: "pdf-historique", version: 3 }] })
+
+    await expect(svcGetLatestLivraisonPdfDocument(BON_LIVRAISON_ID)).resolves.toEqual({
+      document_id: "pdf-historique",
+      version: 3,
+    })
+  })
+
+  it("bloque la génération sous verrou avant chargement du détail ou écriture du fichier", async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes("SELECT statut FROM public.bon_livraison")) {
+        return { rows: [{ statut: "CANCELLED" }] }
+      }
+      return { rows: [] }
+    })
+    database.connect.mockResolvedValue({ query, release: vi.fn() })
+
+    await expect(svcGenerateLivraisonPdf(BON_LIVRAISON_ID, 17)).rejects.toMatchObject({
+      status: 409,
+      code: "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+    })
+
+    expect(repository.getDetail).not.toHaveBeenCalled()
+    expect(query).toHaveBeenCalledWith(
+      expect.stringMatching(/SELECT statut[\s\S]*FOR UPDATE/),
+      [BON_LIVRAISON_ID]
+    )
+    expect(query).toHaveBeenCalledWith("ROLLBACK")
+  })
+})

--- a/src/module/livraisons/services/pdf.service.test.ts
+++ b/src/module/livraisons/services/pdf.service.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   repoGetLivraisonDetail: vi.fn(),
   repoGetDocumentName: vi.fn(),
   renderBonLivraisonDocument: vi.fn(),
+  loggerError: vi.fn(),
 }))
 
 vi.mock("../../../config/database", () => ({
@@ -28,6 +29,11 @@ vi.mock("../repository/livraisons.repository", () => ({
 }))
 vi.mock("./bon-livraison-document", () => ({
   renderBonLivraisonDocument: (...args: unknown[]) => mocks.renderBonLivraisonDocument(...args),
+}))
+vi.mock("../../../utils/logger", () => ({
+  default: {
+    error: (...args: unknown[]) => mocks.loggerError(...args),
+  },
 }))
 
 import {
@@ -101,6 +107,75 @@ function generationDb(options: {
     return { rows: [] }
   })
   return { query, release: vi.fn() }
+}
+
+function uncertainCommitDatabase(options: {
+  durable: boolean
+  reconciliationError?: Error
+  reconciledDocumentId?: string
+  reconciledVersion?: number
+}) {
+  let documentId: string | null = null
+  let persisted: {
+    document_id: string
+    version: number
+    generated_at: string
+    file_size_bytes: number
+    checksum_sha256: string
+  } | null = null
+
+  const primaryQuery = vi.fn(async (sqlValue: unknown, values?: unknown[]) => {
+    const sql = String(sqlValue)
+    if (sql.includes("SELECT id::text AS id") && sql.includes("statut") && sql.includes("FOR UPDATE")) {
+      return { rows: [{ id: BL_ID, statut: "DRAFT" }] }
+    }
+    if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) return { rows: [] }
+    if (sql.includes("COALESCE(MAX(document.version)")) return { rows: [{ version: 1 }] }
+    if (sql.includes("INSERT INTO public.bon_livraison_documents")) {
+      documentId = String(values?.[1])
+      persisted = {
+        document_id: documentId,
+        version: Number(values?.[2]),
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: Number(values?.[5]),
+        checksum_sha256: String(values?.[4]),
+      }
+    }
+    if (sql === "COMMIT") {
+      if (!options.durable) persisted = null
+      throw Object.assign(new Error("commit acknowledgement lost"), { code: "ECONNRESET" })
+    }
+    return { rows: [] }
+  })
+  const reconciliationQuery = vi.fn(async (sqlValue: unknown) => {
+    const sql = String(sqlValue)
+    if (sql.includes("FROM public.bon_livraison") && sql.includes("FOR UPDATE")) {
+      return { rows: [{ id: BL_ID }] }
+    }
+    if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) {
+      if (options.reconciliationError) throw options.reconciliationError
+      return {
+        rows: persisted
+          ? [{
+              bon_livraison_id: BL_ID,
+              ...persisted,
+              document_id: options.reconciledDocumentId ?? persisted.document_id,
+              version: options.reconciledVersion ?? persisted.version,
+            }]
+          : [],
+      }
+    }
+    return { rows: [] }
+  })
+  const primary: TestPoolClient = { query: primaryQuery, release: vi.fn() }
+  const reconciliation: TestPoolClient = { query: reconciliationQuery, release: vi.fn() }
+
+  return {
+    primary,
+    reconciliation,
+    getDocumentId: () => documentId,
+    getPersisted: () => persisted,
+  }
 }
 
 async function storePdf(documentId = DOC_ID, bytes = PDF_BYTES) {
@@ -393,6 +468,148 @@ describe("livraison PDF generation", () => {
     expect(
       db.query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO public.documents_clients")),
     ).toBe(false)
+  })
+
+  it("keeps a durable PDF when COMMIT succeeds but its acknowledgement is lost", async () => {
+    const scenario = uncertainCommitDatabase({ durable: true })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    const result = await svcGenerateLivraisonPdf(BL_ID, 7, "durable-commit-reconcile")
+
+    expect(result).toMatchObject({ version: 1, idempotent_replay: false })
+    expect(result.document_id).toBe(scenario.getDocumentId())
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${result.document_id}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(scenario.primary.query).not.toHaveBeenCalledWith("ROLLBACK")
+    expect(scenario.primary.release).toHaveBeenCalledWith(expect.any(Error))
+    expect(scenario.reconciliation.query).toHaveBeenCalledWith(
+      expect.stringContaining("FOR UPDATE"),
+      [BL_ID],
+    )
+
+    const persisted = scenario.getPersisted()
+    expect(persisted).not.toBeNull()
+    const retryDb = generationDb({ replay: persisted ?? undefined })
+    mocks.poolConnect.mockResolvedValueOnce(retryDb)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "durable-commit-reconcile"),
+    ).resolves.toEqual({
+      document_id: result.document_id,
+      version: 1,
+      idempotent_replay: true,
+    })
+    expect(mocks.renderBonLivraisonDocument).toHaveBeenCalledTimes(1)
+  })
+
+  it("cleans the file when a failed COMMIT is proven non-durable", async () => {
+    const scenario = uncertainCommitDatabase({ durable: false })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "non-durable-commit"),
+    ).rejects.toMatchObject({ code: "ECONNRESET" })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.access(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).rejects.toMatchObject({ code: "ENOENT" })
+    expect(scenario.getPersisted()).toBeNull()
+    expect(scenario.primary.query).not.toHaveBeenCalledWith("ROLLBACK")
+    expect(mocks.loggerError).not.toHaveBeenCalled()
+  })
+
+  it("preserves a potentially referenced file when commit reconciliation fails", async () => {
+    const scenario = uncertainCommitDatabase({
+      durable: true,
+      reconciliationError: new Error("reconciliation database unavailable"),
+    })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "uncertain-commit-lookup"),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+    })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(scenario.getPersisted()).not.toBeNull()
+    expect(scenario.primary.query).not.toHaveBeenCalledWith("ROLLBACK")
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "livraison_pdf_commit_uncertain",
+      expect.objectContaining({ document_id: documentId, version: 1 }),
+    )
+  })
+
+  it("preserves the file and fails closed when reconciliation resolves another document identity", async () => {
+    const scenario = uncertainCommitDatabase({
+      durable: true,
+      reconciledDocumentId: "99999999-9999-4999-8999-999999999999",
+    })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "uncertain-commit-identity"),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+    })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(scenario.getPersisted()).not.toBeNull()
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "livraison_pdf_commit_uncertain",
+      expect.objectContaining({ document_id: documentId, version: 1 }),
+    )
+  })
+
+  it("preserves the file when no fresh connection can reconcile the commit", async () => {
+    const scenario = uncertainCommitDatabase({ durable: true })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockRejectedValueOnce(new Error("reconciliation pool unavailable"))
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "uncertain-commit-connect"),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+    })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(scenario.getPersisted()).not.toBeNull()
+    expect(scenario.primary.query).not.toHaveBeenCalledWith("ROLLBACK")
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "livraison_pdf_commit_uncertain",
+      expect.objectContaining({
+        document_id: documentId,
+        version: 1,
+        reconciliation_error: "reconciliation pool unavailable",
+      }),
+    )
   })
 
   it("rejects a same-size checksum corruption during idempotent replay", async () => {

--- a/src/module/livraisons/services/pdf.service.test.ts
+++ b/src/module/livraisons/services/pdf.service.test.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto"
 import fs from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
@@ -37,10 +38,19 @@ import {
 const BL_ID = "11111111-1111-4111-8111-111111111111"
 const DOC_ID = "22222222-2222-4222-8222-222222222222"
 const PDF_BYTES = Buffer.from("%PDF-1.7\nsynthetic")
+const PDF_CHECKSUM = crypto.createHash("sha256").update(PDF_BYTES).digest("hex")
 
 type TestPoolClient = {
   query: ReturnType<typeof vi.fn>
   release: ReturnType<typeof vi.fn>
+}
+
+function deferred() {
+  let resolve!: () => void
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
 }
 
 let documentsRoot = ""
@@ -63,17 +73,19 @@ function detail(lines: unknown[] = []) {
 
 function generationDb(options: {
   nextVersion?: number
+  statut?: "DRAFT" | "CANCELLED"
   replay?: {
     document_id: string
     version: number
     generated_at: string
     file_size_bytes: number
+    checksum_sha256: string
   }
 } = {}): TestPoolClient {
   const query = vi.fn(async (sqlValue: unknown) => {
     const sql = String(sqlValue)
     if (sql.includes("SELECT id::text AS id") && sql.includes("FOR UPDATE")) {
-      return { rows: [{ id: BL_ID }] }
+      return { rows: [{ id: BL_ID, statut: options.statut ?? "DRAFT" }] }
     }
     if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) {
       return {
@@ -94,6 +106,81 @@ async function storePdf(documentId = DOC_ID, bytes = PDF_BYTES) {
   const directory = path.join(documentsRoot, "livraisons")
   await fs.mkdir(directory, { recursive: true })
   await fs.writeFile(path.join(directory, `${documentId}.pdf`), bytes)
+}
+
+function lifecycleDatabase() {
+  let statut: "DRAFT" | "CANCELLED" = "DRAFT"
+  let version = 0
+  let lockOwner: symbol | null = null
+  const waiters: Array<() => void> = []
+  const lockWaiterQueued = deferred()
+
+  const releaseLock = (owner: symbol) => {
+    if (lockOwner !== owner) return
+    const next = waiters.shift()
+    if (next) next()
+    else lockOwner = null
+  }
+
+  const connect = (): TestPoolClient => {
+    const owner = Symbol("delivery-transaction")
+    let ownsLock = false
+    const query = vi.fn(async (sqlValue: unknown, values?: unknown[]) => {
+      const sql = String(sqlValue)
+      if (sql.includes("SELECT id::text AS id") && sql.includes("FOR UPDATE")) {
+        if (lockOwner !== null) {
+          lockWaiterQueued.resolve()
+          await new Promise<void>((done) => waiters.push(done))
+        }
+        lockOwner = owner
+        ownsLock = true
+        return { rows: [{ id: BL_ID, statut }] }
+      }
+      if (sql.includes("TEST_CANCEL_DELIVERY")) {
+        statut = "CANCELLED"
+      }
+      if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) return { rows: [] }
+      if (sql.includes("COALESCE(MAX(document.version)")) {
+        return { rows: [{ version: version + 1 }] }
+      }
+      if (sql.includes("INSERT INTO public.bon_livraison_documents")) {
+        version = Number(values?.[2])
+      }
+      if ((sql === "COMMIT" || sql === "ROLLBACK") && ownsLock) {
+        ownsLock = false
+        releaseLock(owner)
+      }
+      return { rows: [] }
+    })
+    return { query, release: vi.fn() }
+  }
+
+  return {
+    connect,
+    getStatut: () => statut,
+    waitForBlockedTransaction: lockWaiterQueued.promise,
+  }
+}
+
+async function cancelDeliveryWithRowLock(
+  afterLock?: () => Promise<void> | void,
+): Promise<void> {
+  const db = await mocks.poolConnect()
+  try {
+    await db.query("BEGIN")
+    await db.query(
+      `SELECT id::text AS id, statut FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
+      [BL_ID],
+    )
+    await db.query(`UPDATE public.bon_livraison SET statut = 'CANCELLED' /* TEST_CANCEL_DELIVERY */`)
+    await afterLock?.()
+    await db.query("COMMIT")
+  } catch (error) {
+    await db.query("ROLLBACK")
+    throw error
+  } finally {
+    db.release()
+  }
 }
 
 beforeEach(async () => {
@@ -120,6 +207,7 @@ describe("livraison PDF availability", () => {
         version: null,
         generated_at: null,
         file_size_bytes: null,
+        checksum_sha256: null,
       }],
     })
 
@@ -149,6 +237,7 @@ describe("livraison PDF availability", () => {
         version: 3,
         generated_at: "2026-08-04T12:00:00.000Z",
         file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
       }],
     })
 
@@ -169,6 +258,7 @@ describe("livraison PDF availability", () => {
         version: 1,
         generated_at: "2026-08-04T12:00:00.000Z",
         file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
       }],
     })
 
@@ -176,6 +266,33 @@ describe("livraison PDF availability", () => {
       status: 410,
       code: "LIVRAISON_PDF_FILE_MISSING",
     })
+  })
+
+  it("rejects a version-specific archive whose bytes changed without changing size or signature", async () => {
+    const corruptedBytes = Buffer.from(PDF_BYTES)
+    corruptedBytes[corruptedBytes.byteLength - 1] ^= 1
+    expect(corruptedBytes.byteLength).toBe(PDF_BYTES.byteLength)
+    expect(corruptedBytes.subarray(0, 5).toString("ascii")).toBe("%PDF-")
+    await storePdf(DOC_ID, corruptedBytes)
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{
+        bon_livraison_id: BL_ID,
+        document_id: DOC_ID,
+        version: 3,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
+      }],
+    })
+
+    await expect(svcGetLivraisonPdfAvailability(BL_ID, 3)).rejects.toMatchObject({
+      status: 500,
+      code: "LIVRAISON_PDF_INTEGRITY_ERROR",
+    })
+    expect(mocks.poolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("latest.checksum_sha256"),
+      [BL_ID, 3],
+    )
   })
 })
 
@@ -194,7 +311,7 @@ describe("livraison PDF generation", () => {
       fs.readFile(path.join(documentsRoot, "livraisons", `${result.document_id}.pdf`)),
     ).resolves.toEqual(PDF_BYTES)
     expect(db.query).toHaveBeenCalledWith(
-      expect.stringContaining("FOR UPDATE"),
+      expect.stringContaining("id::text AS id, statut"),
       [BL_ID],
     )
     expect(
@@ -230,6 +347,7 @@ describe("livraison PDF generation", () => {
         version: 2,
         generated_at: "2026-08-04T12:00:00.000Z",
         file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
       },
     })
     mocks.poolConnect.mockResolvedValue(db)
@@ -245,6 +363,119 @@ describe("livraison PDF generation", () => {
     expect(
       db.query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO public.documents_clients")),
     ).toBe(false)
+  })
+
+  it("rejects a same-size checksum corruption during idempotent replay", async () => {
+    const corruptedBytes = Buffer.from(PDF_BYTES)
+    corruptedBytes[corruptedBytes.byteLength - 1] ^= 1
+    await storePdf(DOC_ID, corruptedBytes)
+    const db = generationDb({
+      replay: {
+        document_id: DOC_ID,
+        version: 2,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
+      },
+    })
+    mocks.poolConnect.mockResolvedValue(db)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "corrupted-replay-key"),
+    ).rejects.toMatchObject({
+      status: 500,
+      code: "LIVRAISON_PDF_INTEGRITY_ERROR",
+    })
+    expect(mocks.renderBonLivraisonDocument).not.toHaveBeenCalled()
+    expect(db.query).toHaveBeenCalledWith("ROLLBACK")
+    expect(
+      db.query.mock.calls.some(([sql]) =>
+        String(sql).includes("document.checksum_sha256"),
+      ),
+    ).toBe(true)
+  })
+
+  it("rejects generation and creator replay after cancellation before rendering", async () => {
+    await storePdf()
+    const db = generationDb({
+      statut: "CANCELLED",
+      replay: {
+        document_id: DOC_ID,
+        version: 2,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
+      },
+    })
+    mocks.poolConnect.mockResolvedValue(db)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "cancelled-replay-key"),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+    })
+    expect(mocks.renderBonLivraisonDocument).not.toHaveBeenCalled()
+    expect(
+      db.query.mock.calls.some(([sql]) => String(sql).includes("idempotency_key_hash")),
+    ).toBe(false)
+    expect(db.query).toHaveBeenCalledWith("ROLLBACK")
+  })
+
+  it("lets cancellation win the row lock and blocks the waiting generation before render", async () => {
+    const lifecycle = lifecycleDatabase()
+    mocks.poolConnect.mockImplementation(async () => lifecycle.connect())
+    const cancellationLocked = deferred()
+    const allowCancellationCommit = deferred()
+
+    const cancellation = cancelDeliveryWithRowLock(async () => {
+      cancellationLocked.resolve()
+      await allowCancellationCommit.promise
+    })
+    await cancellationLocked.promise
+    const generation = svcGenerateLivraisonPdf(BL_ID, 7, "cancel-wins-generation")
+
+    await lifecycle.waitForBlockedTransaction
+    expect(mocks.renderBonLivraisonDocument).not.toHaveBeenCalled()
+    allowCancellationCommit.resolve()
+    await cancellation
+    await expect(generation).rejects.toMatchObject({
+      status: 409,
+      code: "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+    })
+    expect(lifecycle.getStatut()).toBe("CANCELLED")
+    expect(mocks.renderBonLivraisonDocument).not.toHaveBeenCalled()
+  })
+
+  it("lets an already locked generation finish, then blocks every post-cancellation render", async () => {
+    const lifecycle = lifecycleDatabase()
+    mocks.poolConnect.mockImplementation(async () => lifecycle.connect())
+    const rendering = deferred()
+    const allowRender = deferred()
+    mocks.renderBonLivraisonDocument.mockImplementationOnce(async () => {
+      rendering.resolve()
+      await allowRender.promise
+      return PDF_BYTES
+    })
+
+    const generation = svcGenerateLivraisonPdf(BL_ID, 7, "generation-wins-cancel")
+    await rendering.promise
+    const cancellation = cancelDeliveryWithRowLock()
+    await lifecycle.waitForBlockedTransaction
+    expect(lifecycle.getStatut()).toBe("DRAFT")
+
+    allowRender.resolve()
+    await expect(generation).resolves.toMatchObject({ version: 1 })
+    await cancellation
+    expect(lifecycle.getStatut()).toBe("CANCELLED")
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "post-cancel-generation"),
+    ).rejects.toMatchObject({
+      status: 409,
+      code: "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+    })
+    expect(mocks.renderBonLivraisonDocument).toHaveBeenCalledTimes(1)
   })
 
   it("serializes concurrent requests so distinct keys receive distinct versions", async () => {
@@ -265,7 +496,7 @@ describe("livraison PDF generation", () => {
           if (locked) await new Promise<void>((resolve) => waiters.push(resolve))
           else locked = true
           ownsLock = true
-          return { rows: [{ id: BL_ID }] }
+          return { rows: [{ id: BL_ID, statut: "DRAFT" }] }
         }
         if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) return { rows: [] }
         if (sql.includes("COALESCE(MAX(document.version)")) {

--- a/src/module/livraisons/services/pdf.service.test.ts
+++ b/src/module/livraisons/services/pdf.service.test.ts
@@ -33,6 +33,7 @@ vi.mock("./bon-livraison-document", () => ({
 import {
   svcGenerateLivraisonPdf,
   svcGetLivraisonPdfAvailability,
+  svcReadLivraisonPdf,
 } from "./pdf.service"
 
 const BL_ID = "11111111-1111-4111-8111-111111111111"
@@ -248,6 +249,35 @@ describe("livraison PDF availability", () => {
       version: 3,
       generated_at: "2026-08-04T12:00:00.000Z",
     })
+  })
+
+  it("returns the exact validated bytes for a version-specific read", async () => {
+    await storePdf()
+    mocks.poolQuery.mockResolvedValue({
+      rows: [{
+        bon_livraison_id: BL_ID,
+        document_id: DOC_ID,
+        version: 3,
+        generated_at: "2026-08-04T12:00:00.000Z",
+        file_size_bytes: PDF_BYTES.byteLength,
+        checksum_sha256: PDF_CHECKSUM,
+      }],
+    })
+
+    const result = await svcReadLivraisonPdf(BL_ID, 3)
+
+    expect(result).toMatchObject({
+      available: true,
+      status: "AVAILABLE",
+      document_id: DOC_ID,
+      version: 3,
+      generated_at: "2026-08-04T12:00:00.000Z",
+    })
+    expect(result.bytes).toEqual(PDF_BYTES)
+    expect(mocks.poolQuery).toHaveBeenCalledWith(
+      expect.stringContaining("latest.checksum_sha256"),
+      [BL_ID, 3],
+    )
   })
 
   it("surfaces a missing archived file as an integrity error, not ordinary unavailability", async () => {

--- a/src/module/livraisons/services/pdf.service.test.ts
+++ b/src/module/livraisons/services/pdf.service.test.ts
@@ -97,7 +97,13 @@ function generationDb(options: {
     if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) {
       return {
         rows: options.replay
-          ? [{ bon_livraison_id: BL_ID, ...options.replay }]
+          ? [{
+              bon_livraison_id: BL_ID,
+              event_document_id: options.replay.document_id,
+              event_version: options.replay.version,
+              event_checksum_sha256: options.replay.checksum_sha256,
+              ...options.replay,
+            }]
           : [],
       }
     }
@@ -114,6 +120,10 @@ function uncertainCommitDatabase(options: {
   reconciliationError?: Error
   reconciledDocumentId?: string
   reconciledVersion?: number
+  reconciledEventChecksum?: string
+  reconciledDocumentChecksum?: string
+  beforeReconciliationLookup?: () => Promise<void>
+  afterReconciliationCommit?: () => Promise<void>
 }) {
   let documentId: string | null = null
   let persisted: {
@@ -149,18 +159,29 @@ function uncertainCommitDatabase(options: {
   })
   const reconciliationQuery = vi.fn(async (sqlValue: unknown) => {
     const sql = String(sqlValue)
+    if (sql === "COMMIT") {
+      await options.afterReconciliationCommit?.()
+      return { rows: [] }
+    }
     if (sql.includes("FROM public.bon_livraison") && sql.includes("FOR UPDATE")) {
       return { rows: [{ id: BL_ID }] }
     }
     if (sql.includes("idempotency_key_hash") && sql.includes("SELECT")) {
+      await options.beforeReconciliationLookup?.()
       if (options.reconciliationError) throw options.reconciliationError
       return {
         rows: persisted
           ? [{
               bon_livraison_id: BL_ID,
+              event_document_id: persisted.document_id,
+              event_version: persisted.version,
+              event_checksum_sha256:
+                options.reconciledEventChecksum ?? persisted.checksum_sha256,
               ...persisted,
               document_id: options.reconciledDocumentId ?? persisted.document_id,
               version: options.reconciledVersion ?? persisted.version,
+              checksum_sha256:
+                options.reconciledDocumentChecksum ?? persisted.checksum_sha256,
             }]
           : [],
       }
@@ -489,6 +510,16 @@ describe("livraison PDF generation", () => {
       expect.stringContaining("FOR UPDATE"),
       [BL_ID],
     )
+    const reconciliationStatements = scenario.reconciliation.query.mock.calls.map(([sql]) =>
+      String(sql),
+    )
+    expect(reconciliationStatements[0]).toBe("BEGIN")
+    expect(reconciliationStatements.findIndex((sql) => sql.includes("FOR UPDATE"))).toBe(1)
+    expect(
+      reconciliationStatements.findIndex((sql) => sql.includes("idempotency_key_hash")),
+    ).toBe(2)
+    expect(reconciliationStatements[3]).toBe("COMMIT")
+    expect(scenario.reconciliation.release).toHaveBeenCalledWith()
 
     const persisted = scenario.getPersisted()
     expect(persisted).not.toBeNull()
@@ -503,6 +534,36 @@ describe("livraison PDF generation", () => {
       idempotent_replay: true,
     })
     expect(mocks.renderBonLivraisonDocument).toHaveBeenCalledTimes(1)
+  })
+
+  it("holds the reconciliation transaction across the lock barrier and proof lookup", async () => {
+    const lookupStarted = deferred()
+    const allowLookup = deferred()
+    const scenario = uncertainCommitDatabase({
+      durable: true,
+      beforeReconciliationLookup: async () => {
+        lookupStarted.resolve()
+        await allowLookup.promise
+      },
+    })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    const generation = svcGenerateLivraisonPdf(BL_ID, 7, "atomic-commit-reconcile")
+    await lookupStarted.promise
+
+    const pendingStatements = scenario.reconciliation.query.mock.calls.map(([sql]) => String(sql))
+    expect(pendingStatements[0]).toBe("BEGIN")
+    expect(pendingStatements[1]).toContain("FOR UPDATE")
+    expect(pendingStatements[2]).toContain("idempotency_key_hash")
+    expect(pendingStatements).not.toContain("COMMIT")
+    expect(scenario.reconciliation.release).not.toHaveBeenCalled()
+
+    allowLookup.resolve()
+    await expect(generation).resolves.toMatchObject({ version: 1, idempotent_replay: false })
+    expect(scenario.reconciliation.query).toHaveBeenLastCalledWith("COMMIT")
+    expect(scenario.reconciliation.release).toHaveBeenCalledWith()
   })
 
   it("cleans the file when a failed COMMIT is proven non-durable", async () => {
@@ -580,6 +641,106 @@ describe("livraison PDF generation", () => {
       "livraison_pdf_commit_uncertain",
       expect.objectContaining({ document_id: documentId, version: 1 }),
     )
+    expect(scenario.reconciliation.query).toHaveBeenCalledWith("ROLLBACK")
+    expect(scenario.reconciliation.release).toHaveBeenCalledWith(expect.any(Error))
+  })
+
+  it("preserves the file and fails closed when reconciliation resolves another version", async () => {
+    const scenario = uncertainCommitDatabase({ durable: true, reconciledVersion: 2 })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "uncertain-commit-version"),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+    })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(scenario.reconciliation.query).toHaveBeenCalledWith("ROLLBACK")
+    expect(scenario.reconciliation.release).toHaveBeenCalledWith(expect.any(Error))
+  })
+
+  it.each([
+    { label: "event checksum", overrides: { reconciledEventChecksum: "a".repeat(64) } },
+    { label: "document checksum", overrides: { reconciledDocumentChecksum: "b".repeat(64) } },
+    {
+      label: "pending checksum",
+      overrides: {
+        reconciledEventChecksum: "c".repeat(64),
+        reconciledDocumentChecksum: "c".repeat(64),
+      },
+    },
+  ])("preserves the file when the $label does not match the three-way proof", async ({ label, overrides }) => {
+    const scenario = uncertainCommitDatabase({ durable: true, ...overrides })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, `uncertain-${label.replace(" ", "-")}`),
+    ).rejects.toMatchObject({
+      status: 503,
+      code: "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+    })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).resolves.toEqual(PDF_BYTES)
+    expect(scenario.reconciliation.query).toHaveBeenCalledWith("ROLLBACK")
+    expect(scenario.reconciliation.release).toHaveBeenCalledWith(expect.any(Error))
+    expect(mocks.loggerError).toHaveBeenCalledWith(
+      "livraison_pdf_commit_uncertain",
+      expect.objectContaining({
+        document_id: documentId,
+        version: 1,
+        expected_checksum_sha256: PDF_CHECKSUM,
+      }),
+    )
+  })
+
+  it("validates durable bytes against the pre-commit checksum and preserves corruption", async () => {
+    const corruptedBytes = Buffer.from(PDF_BYTES)
+    corruptedBytes[corruptedBytes.byteLength - 1] ^= 1
+    let scenario!: ReturnType<typeof uncertainCommitDatabase>
+    scenario = uncertainCommitDatabase({
+      durable: true,
+      afterReconciliationCommit: async () => {
+        const documentId = scenario.getDocumentId()
+        if (!documentId) throw new Error("test document id unavailable")
+        await fs.writeFile(
+          path.join(documentsRoot, "livraisons", `${documentId}.pdf`),
+          corruptedBytes,
+        )
+      },
+    })
+    mocks.poolConnect
+      .mockResolvedValueOnce(scenario.primary)
+      .mockResolvedValueOnce(scenario.reconciliation)
+
+    await expect(
+      svcGenerateLivraisonPdf(BL_ID, 7, "durable-file-corruption"),
+    ).rejects.toMatchObject({
+      status: 500,
+      code: "LIVRAISON_PDF_INTEGRITY_ERROR",
+    })
+
+    const documentId = scenario.getDocumentId()
+    expect(documentId).not.toBeNull()
+    await expect(
+      fs.readFile(path.join(documentsRoot, "livraisons", `${documentId}.pdf`)),
+    ).resolves.toEqual(corruptedBytes)
+    expect(scenario.reconciliation.query).toHaveBeenLastCalledWith("COMMIT")
+    expect(scenario.reconciliation.query).not.toHaveBeenCalledWith("ROLLBACK")
+    expect(mocks.loggerError).not.toHaveBeenCalled()
   })
 
   it("preserves the file when no fresh connection can reconcile the commit", async () => {

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -1,13 +1,17 @@
 import fs from "node:fs/promises"
 import path from "node:path"
 import crypto from "node:crypto"
+import type { PoolClient } from "pg"
 
 import pool from "../../../config/database"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { readIssuerParty } from "../../../shared/documents/issuer-identity.repository"
 import { pickMention } from "../../../shared/pdf/legal-mentions"
-import { repoGetLivraisonDetail, repoGetDocumentName } from "../repository/livraisons.repository"
+import {
+  repoGetDocumentName,
+  repoGetLivraisonDetail,
+} from "../repository/livraisons.repository"
 
 import { renderBonLivraisonDocument } from "./bon-livraison-document"
 
@@ -26,11 +30,28 @@ async function ensureDocsDir(): Promise<string> {
   return uploadDir
 }
 
+function assertLivraisonPdfGenerationAllowed(statut: string): void {
+  if (statut === "CANCELLED") {
+    throw new HttpError(
+      409,
+      "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+      "Un bon de livraison annulé ne peut pas générer ou régénérer de PDF."
+    )
+  }
+}
+
 // L'emetteur n'est plus reduit a sa raison sociale : `readIssuerParty` remonte aussi son
 // identite legale et ses mentions obligatoires, que le bon de livraison doit porter.
 
 export async function svcGetLatestLivraisonPdfDocument(id: string): Promise<{ document_id: string; version: number } | null> {
-  const res = await pool.query<{ document_id: string; version: number }>(
+  return getLatestLivraisonPdfDocument(pool, id)
+}
+
+async function getLatestLivraisonPdfDocument(
+  queryer: Pick<PoolClient, "query">,
+  id: string
+): Promise<{ document_id: string; version: number } | null> {
+  const res = await queryer.query<{ document_id: string; version: number }>(
     `
     SELECT d.document_id::text AS document_id, d.version
     FROM bon_livraison_documents d
@@ -50,35 +71,44 @@ export async function svcGetPdfFilePath(documentId: string): Promise<string> {
 }
 
 export async function svcGenerateLivraisonPdf(bonLivraisonId: string, userId: number): Promise<{ document_id: string; version: number }> {
-  const detail = await repoGetLivraisonDetail(bonLivraisonId)
-  if (!detail) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
-
-  const existing = await svcGetLatestLivraisonPdfDocument(bonLivraisonId)
-  const version = (existing?.version ?? 0) + 1
-
-  const docsDir = await ensureDocsDir()
-  const documentId = crypto.randomUUID()
-  const fileName = `Bon_livraison_${detail.bon_livraison.numero}.pdf`
-  const filePath = path.join(docsDir, `${documentId}.pdf`)
-
-  const issuer = await readIssuerParty({
-    at: detail.bon_livraison.date_expedition ?? detail.bon_livraison.date_creation,
-  })
-  const pdfBytes = await renderBonLivraisonDocument({
-    header: detail.bon_livraison,
-    lignes: detail.lignes,
-    version,
-    company: pickMention(issuer, "company_name"),
-    issuer,
-  })
-  await fs.mkdir(path.dirname(filePath), { recursive: true })
-  await fs.writeFile(filePath, pdfBytes)
-
-  const checksumSha256 = crypto.createHash("sha256").update(pdfBytes).digest("hex")
-
   const db = await pool.connect()
+  let filePath: string | null = null
   try {
     await db.query("BEGIN")
+    const locked = await db.query<{ statut: string }>(
+      `SELECT statut FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
+      [bonLivraisonId]
+    )
+    const statut = locked.rows[0]?.statut
+    if (!statut) {
+      throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    }
+    assertLivraisonPdfGenerationAllowed(statut)
+
+    const detail = await repoGetLivraisonDetail(bonLivraisonId)
+    if (!detail) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+
+    const existing = await getLatestLivraisonPdfDocument(db, bonLivraisonId)
+    const version = (existing?.version ?? 0) + 1
+    const docsDir = await ensureDocsDir()
+    const documentId = crypto.randomUUID()
+    const fileName = `Bon_livraison_${detail.bon_livraison.numero}.pdf`
+    filePath = path.join(docsDir, `${documentId}.pdf`)
+
+    const issuer = await readIssuerParty({
+      at: detail.bon_livraison.date_expedition ?? detail.bon_livraison.date_creation,
+    })
+    const pdfBytes = await renderBonLivraisonDocument({
+      header: detail.bon_livraison,
+      lignes: detail.lignes,
+      version,
+      company: pickMention(issuer, "company_name"),
+      issuer,
+    })
+    await fs.mkdir(path.dirname(filePath), { recursive: true })
+    await fs.writeFile(filePath, pdfBytes)
+    const checksumSha256 = crypto.createHash("sha256").update(pdfBytes).digest("hex")
+
     await db.query(`INSERT INTO documents_clients (id, document_name, type) VALUES ($1, $2, $3)`, [documentId, fileName, "PDF"])
     await db.query(
       `
@@ -109,15 +139,14 @@ export async function svcGenerateLivraisonPdf(bonLivraisonId: string, userId: nu
     )
     await db.query(`UPDATE bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`, [bonLivraisonId, userId])
     await db.query("COMMIT")
+    return { document_id: documentId, version }
   } catch (err) {
     await db.query("ROLLBACK")
-    await fs.unlink(filePath).catch(() => undefined)
+    if (filePath) await fs.unlink(filePath).catch(() => undefined)
     throw err
   } finally {
     db.release()
   }
-
-  return { document_id: documentId, version }
 }
 
 export async function svcGetDocumentName(documentId: string) {

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -1,88 +1,307 @@
+import crypto from "node:crypto"
 import fs from "node:fs/promises"
 import path from "node:path"
-import crypto from "node:crypto"
+import type { PoolClient } from "pg"
 
 import pool from "../../../config/database"
-import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
-import { HttpError } from "../../../utils/httpError"
 import { readIssuerParty } from "../../../shared/documents/issuer-identity.repository"
 import { pickMention } from "../../../shared/pdf/legal-mentions"
+import {
+  ensureDocumentStoragePath,
+  getDocumentStoragePath,
+} from "../../../utils/cerpStorage"
+import { HttpError } from "../../../utils/httpError"
 import { repoGetLivraisonDetail, repoGetDocumentName } from "../repository/livraisons.repository"
+import type {
+  LivraisonPdfAvailability,
+  LivraisonPdfGenerationResult,
+} from "../types/livraisons.types"
 
 import { renderBonLivraisonDocument } from "./bon-livraison-document"
 
-/**
- * Generation simple du bon de livraison (`POST /livraisons/:id/pdf`).
- *
- * Le rendu vit dans `bon-livraison-document.ts`, partage avec le pack fige : ce service ne
- * s'occupe plus que du versionnement, du stockage, de l'empreinte et du journal. Les deux
- * chemins dessinaient auparavant leur propre mise en page, et l'ancienne imprimait
- * l'identifiant technique du client sur un document envoye au client.
- */
+type Queryable = Pick<PoolClient, "query">
 
-async function ensureDocsDir(): Promise<string> {
-  const uploadDir = ensureDocumentStoragePath("livraisons")
-  await fs.mkdir(uploadDir, { recursive: true })
-  return uploadDir
+type PdfDocumentRow = {
+  bon_livraison_id: string
+  document_id: string | null
+  version: number | null
+  generated_at: string | null
+  file_size_bytes: number | null
 }
 
-// L'emetteur n'est plus reduit a sa raison sociale : `readIssuerParty` remonte aussi son
-// identite legale et ses mentions obligatoires, que le bon de livraison doit porter.
-
-export async function svcGetLatestLivraisonPdfDocument(id: string): Promise<{ document_id: string; version: number } | null> {
-  const res = await pool.query<{ document_id: string; version: number }>(
-    `
-    SELECT d.document_id::text AS document_id, d.version
-    FROM bon_livraison_documents d
-    WHERE d.bon_livraison_id = $1::uuid AND d.type = 'PDF'
-    ORDER BY d.version DESC, d.id DESC
-    LIMIT 1
-    `,
-    [id]
+const generatedPdfPredicate = `
+  (
+    document.type = 'GENERATED_SIMPLE_BL_PDF'
+    OR (
+      document.type = 'PDF'
+      AND EXISTS (
+        SELECT 1
+        FROM public.bon_livraison_event_log event
+        WHERE event.bon_livraison_id = document.bon_livraison_id
+          AND event.event_type = 'PDF_GENERATED'
+          AND event.new_values ->> 'document_id' = document.document_id::text
+      )
+    )
   )
-  const row = res.rows[0]
-  return row ? { document_id: row.document_id, version: row.version } : null
+`
+
+function normalizeIdempotencyKey(value: string): string {
+  const normalized = value.trim()
+  if (normalized.length < 8 || normalized.length > 200) {
+    throw new HttpError(
+      400,
+      "IDEMPOTENCY_KEY_REQUIRED",
+      "A valid Idempotency-Key header is required (8 to 200 characters)."
+    )
+  }
+  return normalized
 }
 
-export async function svcGetPdfFilePath(documentId: string): Promise<string> {
-  const docsDir = await ensureDocsDir()
-  return path.join(docsDir, `${documentId}.pdf`)
+function idempotencyKeyHash(value: string): string {
+  return crypto.createHash("sha256").update(value, "utf8").digest("hex")
 }
 
-export async function svcGenerateLivraisonPdf(bonLivraisonId: string, userId: number): Promise<{ document_id: string; version: number }> {
-  const detail = await repoGetLivraisonDetail(bonLivraisonId)
-  if (!detail) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+async function queryPdfDocument(
+  bonLivraisonId: string,
+  version?: number,
+  queryable: Queryable = pool
+): Promise<PdfDocumentRow | null> {
+  const result = await queryable.query<PdfDocumentRow>(
+    `
+      SELECT
+        delivery.id::text AS bon_livraison_id,
+        latest.document_id,
+        latest.version,
+        latest.generated_at,
+        latest.file_size_bytes
+      FROM public.bon_livraison delivery
+      LEFT JOIN LATERAL (
+        SELECT
+          document.document_id::text AS document_id,
+          document.version::int AS version,
+          document.created_at::text AS generated_at,
+          document.file_size_bytes::float8 AS file_size_bytes
+        FROM public.bon_livraison_documents document
+        WHERE document.bon_livraison_id = delivery.id
+          AND ${generatedPdfPredicate}
+          AND ($2::int IS NULL OR document.version = $2::int)
+        ORDER BY document.version DESC, document.created_at DESC, document.id DESC
+        LIMIT 1
+      ) latest ON TRUE
+      WHERE delivery.id = $1::uuid
+    `,
+    [bonLivraisonId, version ?? null]
+  )
+  return result.rows[0] ?? null
+}
 
-  const existing = await svcGetLatestLivraisonPdfDocument(bonLivraisonId)
-  const version = (existing?.version ?? 0) + 1
+async function assertStoredPdf(
+  documentId: string,
+  expectedSize: number | null
+): Promise<void> {
+  const filePath = svcGetPdfFilePath(documentId)
+  let handle: Awaited<ReturnType<typeof fs.open>> | null = null
+  try {
+    handle = await fs.open(filePath, "r")
+    const stat = await handle.stat()
+    const signature = Buffer.alloc(5)
+    const read = await handle.read(signature, 0, signature.length, 0)
+    if (
+      !stat.isFile() ||
+      stat.size < signature.length ||
+      read.bytesRead !== signature.length ||
+      signature.toString("ascii") !== "%PDF-"
+    ) {
+      throw new HttpError(
+        500,
+        "LIVRAISON_PDF_INVALID",
+        "Le PDF archive est invalide. Une regeneration explicite est requise."
+      )
+    }
+    if (expectedSize !== null && expectedSize > 0 && stat.size !== expectedSize) {
+      throw new HttpError(
+        500,
+        "LIVRAISON_PDF_INTEGRITY_ERROR",
+        "Le PDF archive ne correspond plus a son empreinte de stockage."
+      )
+    }
+  } catch (error) {
+    if (error instanceof HttpError) throw error
+    const code = typeof error === "object" && error !== null && "code" in error
+      ? String((error as { code?: unknown }).code ?? "")
+      : ""
+    if (code === "ENOENT") {
+      throw new HttpError(
+        410,
+        "LIVRAISON_PDF_FILE_MISSING",
+        "Le PDF archive est reference mais son fichier est indisponible. Une regeneration explicite est requise."
+      )
+    }
+    throw error
+  } finally {
+    await handle?.close().catch(() => undefined)
+  }
+}
 
-  const docsDir = await ensureDocsDir()
-  const documentId = crypto.randomUUID()
-  const fileName = `Bon_livraison_${detail.bon_livraison.numero}.pdf`
-  const filePath = path.join(docsDir, `${documentId}.pdf`)
+export async function svcGetLivraisonPdfAvailability(
+  bonLivraisonId: string,
+  version?: number
+): Promise<LivraisonPdfAvailability> {
+  const row = await queryPdfDocument(bonLivraisonId, version)
+  if (!row) {
+    throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+  }
+  if (!row.document_id || !row.version || !row.generated_at) {
+    if (version !== undefined) {
+      throw new HttpError(
+        404,
+        "LIVRAISON_PDF_VERSION_NOT_FOUND",
+        `La version ${version} du PDF n'existe pas.`
+      )
+    }
+    return {
+      available: false,
+      status: "NOT_GENERATED",
+      document_id: null,
+      version: null,
+      generated_at: null,
+    }
+  }
 
-  const issuer = await readIssuerParty({
-    at: detail.bon_livraison.date_expedition ?? detail.bon_livraison.date_creation,
-  })
-  const pdfBytes = await renderBonLivraisonDocument({
-    header: detail.bon_livraison,
-    lignes: detail.lignes,
-    version,
-    company: pickMention(issuer, "company_name"),
-    issuer,
-  })
-  await fs.mkdir(path.dirname(filePath), { recursive: true })
-  await fs.writeFile(filePath, pdfBytes)
+  await assertStoredPdf(row.document_id, row.file_size_bytes)
+  return {
+    available: true,
+    status: "AVAILABLE",
+    document_id: row.document_id,
+    version: row.version,
+    generated_at: row.generated_at,
+  }
+}
 
-  const checksumSha256 = crypto.createHash("sha256").update(pdfBytes).digest("hex")
+export function svcGetPdfFilePath(documentId: string): string {
+  return path.join(getDocumentStoragePath("livraisons"), `${documentId}.pdf`)
+}
 
+async function findIdempotentReplay(
+  db: Queryable,
+  bonLivraisonId: string,
+  userId: number,
+  keyHash: string
+): Promise<PdfDocumentRow | null> {
+  const result = await db.query<PdfDocumentRow>(
+    `
+      SELECT
+        event.bon_livraison_id::text AS bon_livraison_id,
+        document.document_id::text AS document_id,
+        document.version::int AS version,
+        document.created_at::text AS generated_at,
+        document.file_size_bytes::float8 AS file_size_bytes
+      FROM public.bon_livraison_event_log event
+      JOIN public.bon_livraison_documents document
+        ON document.bon_livraison_id = event.bon_livraison_id
+       AND document.document_id::text = event.new_values ->> 'document_id'
+      WHERE event.bon_livraison_id = $1::uuid
+        AND event.user_id = $2
+        AND event.event_type = 'PDF_GENERATED'
+        AND event.new_values ->> 'idempotency_key_hash' = $3
+      ORDER BY event.id DESC
+      LIMIT 1
+    `,
+    [bonLivraisonId, userId, keyHash]
+  )
+  return result.rows[0] ?? null
+}
+
+async function nextPdfVersion(db: Queryable, bonLivraisonId: string): Promise<number> {
+  const result = await db.query<{ version: number }>(
+    `
+      SELECT COALESCE(MAX(document.version), 0)::int + 1 AS version
+      FROM public.bon_livraison_documents document
+      WHERE document.bon_livraison_id = $1::uuid
+        AND ${generatedPdfPredicate}
+    `,
+    [bonLivraisonId]
+  )
+  const version = result.rows[0]?.version
+  if (!Number.isInteger(version) || version < 1) {
+    throw new Error("Failed to compute livraison PDF version")
+  }
+  return version
+}
+
+/**
+ * Generate one archived BL version.
+ *
+ * The delivery row lock serializes concurrent generation requests. Replaying the same
+ * actor/key returns the original result, while a new key intentionally creates a new version.
+ */
+export async function svcGenerateLivraisonPdf(
+  bonLivraisonId: string,
+  userId: number,
+  idempotencyKeyRaw: string
+): Promise<LivraisonPdfGenerationResult> {
+  const idempotencyKey = normalizeIdempotencyKey(idempotencyKeyRaw)
+  const keyHash = idempotencyKeyHash(idempotencyKey)
   const db = await pool.connect()
+  let filePath: string | null = null
+  let temporaryPath: string | null = null
+  let committed = false
+
   try {
     await db.query("BEGIN")
-    await db.query(`INSERT INTO documents_clients (id, document_name, type) VALUES ($1, $2, $3)`, [documentId, fileName, "PDF"])
+    const delivery = await db.query<{ id: string }>(
+      `SELECT id::text AS id FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
+      [bonLivraisonId]
+    )
+    if (!delivery.rows[0]) {
+      throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    }
+
+    const replay = await findIdempotentReplay(db, bonLivraisonId, userId, keyHash)
+    if (replay?.document_id && replay.version) {
+      await assertStoredPdf(replay.document_id, replay.file_size_bytes)
+      await db.query("COMMIT")
+      committed = true
+      return {
+        document_id: replay.document_id,
+        version: replay.version,
+        idempotent_replay: true,
+      }
+    }
+
+    const detail = await repoGetLivraisonDetail(bonLivraisonId)
+    if (!detail) {
+      throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    }
+    const version = await nextPdfVersion(db, bonLivraisonId)
+    const issuer = await readIssuerParty({
+      at: detail.bon_livraison.date_expedition ?? detail.bon_livraison.date_creation,
+    })
+    const pdfBytes = await renderBonLivraisonDocument({
+      header: detail.bon_livraison,
+      lignes: detail.lignes,
+      version,
+      company: pickMention(issuer, "company_name"),
+      issuer,
+    })
+
+    const docsDir = ensureDocumentStoragePath("livraisons")
+    const documentId = crypto.randomUUID()
+    const fileName = `Bon_livraison_${detail.bon_livraison.numero}.pdf`
+    filePath = path.join(docsDir, `${documentId}.pdf`)
+    temporaryPath = path.join(docsDir, `.${documentId}.pdf.tmp`)
+    await fs.writeFile(temporaryPath, pdfBytes, { flag: "wx" })
+    await fs.rename(temporaryPath, filePath)
+    temporaryPath = null
+
+    const checksumSha256 = crypto.createHash("sha256").update(pdfBytes).digest("hex")
+    await db.query(
+      `INSERT INTO public.documents_clients (id, document_name, type) VALUES ($1, $2, 'PDF')`,
+      [documentId, fileName]
+    )
     await db.query(
       `
-        INSERT INTO bon_livraison_documents (
+        INSERT INTO public.bon_livraison_documents (
           bon_livraison_id,
           document_id,
           type,
@@ -92,32 +311,52 @@ export async function svcGenerateLivraisonPdf(bonLivraisonId: string, userId: nu
           file_size_bytes,
           mime_type
         )
-        VALUES ($1, $2, $3, $4, $5, $6, $7, 'application/pdf')
+        VALUES ($1::uuid, $2::uuid, 'GENERATED_SIMPLE_BL_PDF', $3, $4, $5, $6, 'application/pdf')
       `,
-      [bonLivraisonId, documentId, "PDF", version, userId, checksumSha256, pdfBytes.byteLength]
+      [bonLivraisonId, documentId, version, userId, checksumSha256, pdfBytes.byteLength]
     )
     await db.query(
-      `INSERT INTO bon_livraison_event_log (bon_livraison_id, event_type, old_values, new_values, user_id)
-       VALUES ($1, $2, $3::jsonb, $4::jsonb, $5)`,
+      `
+        INSERT INTO public.bon_livraison_event_log (
+          bon_livraison_id,
+          event_type,
+          old_values,
+          new_values,
+          user_id
+        )
+        VALUES ($1::uuid, 'PDF_GENERATED', NULL, $2::jsonb, $3)
+      `,
       [
         bonLivraisonId,
-        "PDF_GENERATED",
-        null,
-        JSON.stringify({ document_id: documentId, version, checksum_sha256: checksumSha256 }),
+        JSON.stringify({
+          document_id: documentId,
+          version,
+          checksum_sha256: checksumSha256,
+          idempotency_key_hash: keyHash,
+        }),
         userId,
       ]
     )
-    await db.query(`UPDATE bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`, [bonLivraisonId, userId])
+    await db.query(
+      `UPDATE public.bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`,
+      [bonLivraisonId, userId]
+    )
     await db.query("COMMIT")
-  } catch (err) {
-    await db.query("ROLLBACK")
-    await fs.unlink(filePath).catch(() => undefined)
-    throw err
+    committed = true
+    return { document_id: documentId, version, idempotent_replay: false }
+  } catch (error) {
+    if (!committed) await db.query("ROLLBACK").catch(() => undefined)
+    throw error
   } finally {
     db.release()
+    if (!committed) {
+      await Promise.all(
+        [temporaryPath, filePath]
+          .filter((candidate): candidate is string => Boolean(candidate))
+          .map((candidate) => fs.unlink(candidate).catch(() => undefined))
+      )
+    }
   }
-
-  return { document_id: documentId, version }
 }
 
 export async function svcGetDocumentName(documentId: string) {

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -13,6 +13,7 @@ import {
 import { HttpError } from "../../../utils/httpError"
 import { repoGetLivraisonDetail, repoGetDocumentName } from "../repository/livraisons.repository"
 import type {
+  BonLivraisonStatut,
   LivraisonPdfAvailability,
   LivraisonPdfGenerationResult,
 } from "../types/livraisons.types"
@@ -27,6 +28,7 @@ type PdfDocumentRow = {
   version: number | null
   generated_at: string | null
   file_size_bytes: number | null
+  checksum_sha256: string | null
 }
 
 const generatedPdfPredicate = `
@@ -73,14 +75,16 @@ async function queryPdfDocument(
         latest.document_id,
         latest.version,
         latest.generated_at,
-        latest.file_size_bytes
+        latest.file_size_bytes,
+        latest.checksum_sha256
       FROM public.bon_livraison delivery
       LEFT JOIN LATERAL (
         SELECT
           document.document_id::text AS document_id,
           document.version::int AS version,
           document.created_at::text AS generated_at,
-          document.file_size_bytes::float8 AS file_size_bytes
+          document.file_size_bytes::float8 AS file_size_bytes,
+          document.checksum_sha256
         FROM public.bon_livraison_documents document
         WHERE document.bon_livraison_id = delivery.id
           AND ${generatedPdfPredicate}
@@ -97,20 +101,15 @@ async function queryPdfDocument(
 
 async function assertStoredPdf(
   documentId: string,
-  expectedSize: number | null
+  expectedSize: number | null,
+  expectedChecksum: string | null
 ): Promise<void> {
   const filePath = svcGetPdfFilePath(documentId)
-  let handle: Awaited<ReturnType<typeof fs.open>> | null = null
   try {
-    handle = await fs.open(filePath, "r")
-    const stat = await handle.stat()
-    const signature = Buffer.alloc(5)
-    const read = await handle.read(signature, 0, signature.length, 0)
+    const bytes = await fs.readFile(filePath)
     if (
-      !stat.isFile() ||
-      stat.size < signature.length ||
-      read.bytesRead !== signature.length ||
-      signature.toString("ascii") !== "%PDF-"
+      bytes.byteLength < 5 ||
+      bytes.subarray(0, 5).toString("ascii") !== "%PDF-"
     ) {
       throw new HttpError(
         500,
@@ -118,12 +117,23 @@ async function assertStoredPdf(
         "Le PDF archive est invalide. Une regeneration explicite est requise."
       )
     }
-    if (expectedSize !== null && expectedSize > 0 && stat.size !== expectedSize) {
+    if (expectedSize !== null && expectedSize > 0 && bytes.byteLength !== expectedSize) {
       throw new HttpError(
         500,
         "LIVRAISON_PDF_INTEGRITY_ERROR",
         "Le PDF archive ne correspond plus a son empreinte de stockage."
       )
+    }
+    if (expectedChecksum !== null) {
+      const normalizedChecksum = expectedChecksum.trim().toLowerCase()
+      const actualChecksum = crypto.createHash("sha256").update(bytes).digest("hex")
+      if (!/^[a-f0-9]{64}$/.test(normalizedChecksum) || actualChecksum !== normalizedChecksum) {
+        throw new HttpError(
+          500,
+          "LIVRAISON_PDF_INTEGRITY_ERROR",
+          "Le PDF archive ne correspond plus a son empreinte SHA-256."
+        )
+      }
     }
   } catch (error) {
     if (error instanceof HttpError) throw error
@@ -138,8 +148,6 @@ async function assertStoredPdf(
       )
     }
     throw error
-  } finally {
-    await handle?.close().catch(() => undefined)
   }
 }
 
@@ -168,7 +176,7 @@ export async function svcGetLivraisonPdfAvailability(
     }
   }
 
-  await assertStoredPdf(row.document_id, row.file_size_bytes)
+  await assertStoredPdf(row.document_id, row.file_size_bytes, row.checksum_sha256)
   return {
     available: true,
     status: "AVAILABLE",
@@ -195,7 +203,8 @@ async function findIdempotentReplay(
         document.document_id::text AS document_id,
         document.version::int AS version,
         document.created_at::text AS generated_at,
-        document.file_size_bytes::float8 AS file_size_bytes
+        document.file_size_bytes::float8 AS file_size_bytes,
+        document.checksum_sha256
       FROM public.bon_livraison_event_log event
       JOIN public.bon_livraison_documents document
         ON document.bon_livraison_id = event.bon_livraison_id
@@ -249,17 +258,29 @@ export async function svcGenerateLivraisonPdf(
 
   try {
     await db.query("BEGIN")
-    const delivery = await db.query<{ id: string }>(
-      `SELECT id::text AS id FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
+    const delivery = await db.query<{ id: string; statut: BonLivraisonStatut }>(
+      `SELECT id::text AS id, statut FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
       [bonLivraisonId]
     )
-    if (!delivery.rows[0]) {
+    const lockedDelivery = delivery.rows[0]
+    if (!lockedDelivery) {
       throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    }
+    if (lockedDelivery.statut === "CANCELLED") {
+      throw new HttpError(
+        409,
+        "LIVRAISON_CANCELLED_PDF_FORBIDDEN",
+        "Un bon de livraison annulé ne peut plus générer de nouveau PDF."
+      )
     }
 
     const replay = await findIdempotentReplay(db, bonLivraisonId, userId, keyHash)
     if (replay?.document_id && replay.version) {
-      await assertStoredPdf(replay.document_id, replay.file_size_bytes)
+      await assertStoredPdf(
+        replay.document_id,
+        replay.file_size_bytes,
+        replay.checksum_sha256
+      )
       await db.query("COMMIT")
       committed = true
       return {

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -11,6 +11,7 @@ import {
   getDocumentStoragePath,
 } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
+import logger from "../../../utils/logger"
 import { repoGetLivraisonDetail, repoGetDocumentName } from "../repository/livraisons.repository"
 import type {
   BonLivraisonStatut,
@@ -262,6 +263,63 @@ async function findIdempotentReplay(
   return result.rows[0] ?? null
 }
 
+async function reconcilePdfCommit(args: {
+  bonLivraisonId: string
+  userId: number
+  keyHash: string
+}): Promise<PdfDocumentRow | null> {
+  const reconciliationDb = await pool.connect()
+  let discardConnection = false
+  try {
+    const delivery = await reconciliationDb.query<{ id: string }>(
+      `SELECT id::text AS id FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
+      [args.bonLivraisonId]
+    )
+    if (!delivery.rows[0]) {
+      throw new Error("Delivery disappeared while reconciling an uncertain PDF commit")
+    }
+    return findIdempotentReplay(
+      reconciliationDb,
+      args.bonLivraisonId,
+      args.userId,
+      args.keyHash
+    )
+  } catch (error) {
+    discardConnection = true
+    throw error
+  } finally {
+    reconciliationDb.release(discardConnection)
+  }
+}
+
+function uncertainPdfCommitError(args: {
+  result: LivraisonPdfGenerationResult
+  commitError: unknown
+  reconciliationError?: unknown
+}): HttpError {
+  logger.error("livraison_pdf_commit_uncertain", {
+    document_id: args.result.document_id,
+    version: args.result.version,
+    commit_error: args.commitError instanceof Error ? args.commitError.message : String(args.commitError),
+    reconciliation_error:
+      args.reconciliationError instanceof Error
+        ? args.reconciliationError.message
+        : args.reconciliationError === undefined
+          ? null
+          : String(args.reconciliationError),
+  })
+  return new HttpError(
+    503,
+    "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+    "L'etat de la generation PDF doit etre reconcilie. Rejouez la meme Idempotency-Key et suivez le runbook sans supprimer le fichier archive.",
+    {
+      document_id: args.result.document_id,
+      version: args.result.version,
+      runbook: "docs/livraison-document-cerp-213.md#commit-postgresql-incertain",
+    }
+  )
+}
+
 async function nextPdfVersion(db: Queryable, bonLivraisonId: string): Promise<number> {
   const result = await db.query<{ version: number }>(
     `
@@ -296,6 +354,10 @@ export async function svcGenerateLivraisonPdf(
   let filePath: string | null = null
   let temporaryPath: string | null = null
   let committed = false
+  let commitAttempted = false
+  let primaryConnectionReleased = false
+  let cleanupAllowed = true
+  let pendingResult: LivraisonPdfGenerationResult | null = null
 
   try {
     await db.query("BEGIN")
@@ -322,13 +384,15 @@ export async function svcGenerateLivraisonPdf(
         replay.file_size_bytes,
         replay.checksum_sha256
       )
-      await db.query("COMMIT")
-      committed = true
-      return {
+      pendingResult = {
         document_id: replay.document_id,
         version: replay.version,
         idempotent_replay: true,
       }
+      commitAttempted = true
+      await db.query("COMMIT")
+      committed = true
+      return pendingResult
     }
 
     const detail = await repoGetLivraisonDetail(bonLivraisonId)
@@ -403,15 +467,65 @@ export async function svcGenerateLivraisonPdf(
       `UPDATE public.bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`,
       [bonLivraisonId, userId]
     )
+    pendingResult = { document_id: documentId, version, idempotent_replay: false }
+    commitAttempted = true
     await db.query("COMMIT")
     committed = true
-    return { document_id: documentId, version, idempotent_replay: false }
+    return pendingResult
   } catch (error) {
-    if (!committed) await db.query("ROLLBACK").catch(() => undefined)
-    throw error
+    if (!commitAttempted) {
+      await db.query("ROLLBACK").catch(() => undefined)
+      throw error
+    }
+
+    db.release(error instanceof Error ? error : true)
+    primaryConnectionReleased = true
+    if (!pendingResult) {
+      cleanupAllowed = false
+      throw new HttpError(
+        503,
+        "LIVRAISON_PDF_COMMIT_UNCERTAIN",
+        "L'etat de la generation PDF est incertain et doit etre reconcilie manuellement."
+      )
+    }
+
+    let reconciled: PdfDocumentRow | null
+    try {
+      reconciled = await reconcilePdfCommit({ bonLivraisonId, userId, keyHash })
+    } catch (reconciliationError) {
+      cleanupAllowed = false
+      throw uncertainPdfCommitError({
+        result: pendingResult,
+        commitError: error,
+        reconciliationError,
+      })
+    }
+
+    if (!reconciled) {
+      throw error
+    }
+    if (
+      reconciled.document_id !== pendingResult.document_id ||
+      reconciled.version !== pendingResult.version
+    ) {
+      cleanupAllowed = false
+      throw uncertainPdfCommitError({
+        result: pendingResult,
+        commitError: error,
+        reconciliationError: new Error("The idempotency identity resolved to another PDF"),
+      })
+    }
+
+    committed = true
+    await assertStoredPdf(
+      reconciled.document_id,
+      reconciled.file_size_bytes,
+      reconciled.checksum_sha256
+    )
+    return pendingResult
   } finally {
-    db.release()
-    if (!committed) {
+    if (!primaryConnectionReleased) db.release()
+    if (!committed && cleanupAllowed) {
       await Promise.all(
         [temporaryPath, filePath]
           .filter((candidate): candidate is string => Boolean(candidate))

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -32,6 +32,18 @@ type PdfDocumentRow = {
   checksum_sha256: string | null
 }
 
+type PdfReplayRow = PdfDocumentRow & {
+  event_document_id: string | null
+  event_version: number | null
+  event_checksum_sha256: string | null
+}
+
+type PendingPdfResult = {
+  result: LivraisonPdfGenerationResult
+  expected_checksum_sha256: string
+  expected_file_size_bytes: number | null
+}
+
 type LivraisonPdfReadResult =
   | (Extract<LivraisonPdfAvailability, { available: false }> & { bytes: null })
   | (Extract<LivraisonPdfAvailability, { available: true }> & { bytes: Buffer })
@@ -237,11 +249,18 @@ async function findIdempotentReplay(
   bonLivraisonId: string,
   userId: number,
   keyHash: string
-): Promise<PdfDocumentRow | null> {
-  const result = await db.query<PdfDocumentRow>(
+): Promise<PdfReplayRow | null> {
+  const result = await db.query<PdfReplayRow>(
     `
       SELECT
         event.bon_livraison_id::text AS bon_livraison_id,
+        event.new_values ->> 'document_id' AS event_document_id,
+        CASE
+          WHEN COALESCE(event.new_values ->> 'version', '') ~ '^[1-9][0-9]*$'
+            THEN (event.new_values ->> 'version')::int
+          ELSE NULL
+        END AS event_version,
+        event.new_values ->> 'checksum_sha256' AS event_checksum_sha256,
         document.document_id::text AS document_id,
         document.version::int AS version,
         document.created_at::text AS generated_at,
@@ -263,14 +282,64 @@ async function findIdempotentReplay(
   return result.rows[0] ?? null
 }
 
+function normalizeChecksum(value: string | null): string | null {
+  const normalized = value?.trim().toLowerCase() ?? ""
+  return /^[a-f0-9]{64}$/.test(normalized) ? normalized : null
+}
+
+function assertReplayIdentity(row: PdfReplayRow): string {
+  const eventChecksum = normalizeChecksum(row.event_checksum_sha256)
+  const documentChecksum = normalizeChecksum(row.checksum_sha256)
+  if (
+    !row.document_id ||
+    !row.version ||
+    row.event_document_id !== row.document_id ||
+    row.event_version !== row.version ||
+    !eventChecksum ||
+    eventChecksum !== documentChecksum
+  ) {
+    throw new HttpError(
+      500,
+      "LIVRAISON_PDF_INTEGRITY_ERROR",
+      "Les metadonnees archivees du PDF sont incoherentes. Une reconciliation est requise."
+    )
+  }
+  return documentChecksum
+}
+
+function assertReconciledIdentity(expected: PendingPdfResult, row: PdfReplayRow): void {
+  const expectedChecksum = normalizeChecksum(expected.expected_checksum_sha256)
+  const eventChecksum = normalizeChecksum(row.event_checksum_sha256)
+  const documentChecksum = normalizeChecksum(row.checksum_sha256)
+  if (
+    !expectedChecksum ||
+    row.document_id !== expected.result.document_id ||
+    row.event_document_id !== expected.result.document_id ||
+    row.version !== expected.result.version ||
+    row.event_version !== expected.result.version ||
+    eventChecksum !== expectedChecksum ||
+    documentChecksum !== expectedChecksum ||
+    (expected.expected_file_size_bytes !== null &&
+      row.file_size_bytes !== expected.expected_file_size_bytes)
+  ) {
+    throw new Error(
+      "The reconciled event/document identity does not match the pending PDF document, version, checksum, or size"
+    )
+  }
+}
+
 async function reconcilePdfCommit(args: {
   bonLivraisonId: string
   userId: number
   keyHash: string
-}): Promise<PdfDocumentRow | null> {
+  pending: PendingPdfResult
+}): Promise<PdfReplayRow | null> {
   const reconciliationDb = await pool.connect()
-  let discardConnection = false
+  let transactionOpen = false
+  let released = false
   try {
+    await reconciliationDb.query("BEGIN")
+    transactionOpen = true
     const delivery = await reconciliationDb.query<{ id: string }>(
       `SELECT id::text AS id FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
       [args.bonLivraisonId]
@@ -278,28 +347,43 @@ async function reconcilePdfCommit(args: {
     if (!delivery.rows[0]) {
       throw new Error("Delivery disappeared while reconciling an uncertain PDF commit")
     }
-    return findIdempotentReplay(
+    const reconciled = await findIdempotentReplay(
       reconciliationDb,
       args.bonLivraisonId,
       args.userId,
       args.keyHash
     )
+    if (reconciled) assertReconciledIdentity(args.pending, reconciled)
+    await reconciliationDb.query("COMMIT")
+    transactionOpen = false
+    reconciliationDb.release()
+    released = true
+    return reconciled
   } catch (error) {
-    discardConnection = true
+    if (transactionOpen) await reconciliationDb.query("ROLLBACK").catch(() => undefined)
+    reconciliationDb.release(error instanceof Error ? error : true)
+    released = true
     throw error
   } finally {
-    reconciliationDb.release(discardConnection)
+    if (!released) reconciliationDb.release()
   }
 }
 
 function uncertainPdfCommitError(args: {
-  result: LivraisonPdfGenerationResult
+  pending: PendingPdfResult
+  bonLivraisonId: string
+  userId: number
+  keyHash: string
   commitError: unknown
   reconciliationError?: unknown
 }): HttpError {
   logger.error("livraison_pdf_commit_uncertain", {
-    document_id: args.result.document_id,
-    version: args.result.version,
+    bon_livraison_id: args.bonLivraisonId,
+    user_id: args.userId,
+    idempotency_key_hash: args.keyHash,
+    document_id: args.pending.result.document_id,
+    version: args.pending.result.version,
+    expected_checksum_sha256: args.pending.expected_checksum_sha256,
     commit_error: args.commitError instanceof Error ? args.commitError.message : String(args.commitError),
     reconciliation_error:
       args.reconciliationError instanceof Error
@@ -313,8 +397,8 @@ function uncertainPdfCommitError(args: {
     "LIVRAISON_PDF_COMMIT_UNCERTAIN",
     "L'etat de la generation PDF doit etre reconcilie. Rejouez la meme Idempotency-Key et suivez le runbook sans supprimer le fichier archive.",
     {
-      document_id: args.result.document_id,
-      version: args.result.version,
+      document_id: args.pending.result.document_id,
+      version: args.pending.result.version,
       runbook: "docs/livraison-document-cerp-213.md#commit-postgresql-incertain",
     }
   )
@@ -357,7 +441,7 @@ export async function svcGenerateLivraisonPdf(
   let commitAttempted = false
   let primaryConnectionReleased = false
   let cleanupAllowed = true
-  let pendingResult: LivraisonPdfGenerationResult | null = null
+  let pendingResult: PendingPdfResult | null = null
 
   try {
     await db.query("BEGIN")
@@ -379,20 +463,25 @@ export async function svcGenerateLivraisonPdf(
 
     const replay = await findIdempotentReplay(db, bonLivraisonId, userId, keyHash)
     if (replay?.document_id && replay.version) {
+      const expectedChecksum = assertReplayIdentity(replay)
       await assertStoredPdf(
         replay.document_id,
         replay.file_size_bytes,
-        replay.checksum_sha256
+        expectedChecksum
       )
       pendingResult = {
-        document_id: replay.document_id,
-        version: replay.version,
-        idempotent_replay: true,
+        result: {
+          document_id: replay.document_id,
+          version: replay.version,
+          idempotent_replay: true,
+        },
+        expected_checksum_sha256: expectedChecksum,
+        expected_file_size_bytes: replay.file_size_bytes,
       }
       commitAttempted = true
       await db.query("COMMIT")
       committed = true
-      return pendingResult
+      return pendingResult.result
     }
 
     const detail = await repoGetLivraisonDetail(bonLivraisonId)
@@ -467,11 +556,15 @@ export async function svcGenerateLivraisonPdf(
       `UPDATE public.bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`,
       [bonLivraisonId, userId]
     )
-    pendingResult = { document_id: documentId, version, idempotent_replay: false }
+    pendingResult = {
+      result: { document_id: documentId, version, idempotent_replay: false },
+      expected_checksum_sha256: checksumSha256,
+      expected_file_size_bytes: pdfBytes.byteLength,
+    }
     commitAttempted = true
     await db.query("COMMIT")
     committed = true
-    return pendingResult
+    return pendingResult.result
   } catch (error) {
     if (!commitAttempted) {
       await db.query("ROLLBACK").catch(() => undefined)
@@ -489,13 +582,21 @@ export async function svcGenerateLivraisonPdf(
       )
     }
 
-    let reconciled: PdfDocumentRow | null
+    let reconciled: PdfReplayRow | null
     try {
-      reconciled = await reconcilePdfCommit({ bonLivraisonId, userId, keyHash })
+      reconciled = await reconcilePdfCommit({
+        bonLivraisonId,
+        userId,
+        keyHash,
+        pending: pendingResult,
+      })
     } catch (reconciliationError) {
       cleanupAllowed = false
       throw uncertainPdfCommitError({
-        result: pendingResult,
+        pending: pendingResult,
+        bonLivraisonId,
+        userId,
+        keyHash,
         commitError: error,
         reconciliationError,
       })
@@ -504,25 +605,13 @@ export async function svcGenerateLivraisonPdf(
     if (!reconciled) {
       throw error
     }
-    if (
-      reconciled.document_id !== pendingResult.document_id ||
-      reconciled.version !== pendingResult.version
-    ) {
-      cleanupAllowed = false
-      throw uncertainPdfCommitError({
-        result: pendingResult,
-        commitError: error,
-        reconciliationError: new Error("The idempotency identity resolved to another PDF"),
-      })
-    }
-
     committed = true
     await assertStoredPdf(
-      reconciled.document_id,
-      reconciled.file_size_bytes,
-      reconciled.checksum_sha256
+      pendingResult.result.document_id,
+      pendingResult.expected_file_size_bytes,
+      pendingResult.expected_checksum_sha256
     )
-    return pendingResult
+    return pendingResult.result
   } finally {
     if (!primaryConnectionReleased) db.release()
     if (!committed && cleanupAllowed) {

--- a/src/module/livraisons/services/pdf.service.ts
+++ b/src/module/livraisons/services/pdf.service.ts
@@ -31,6 +31,10 @@ type PdfDocumentRow = {
   checksum_sha256: string | null
 }
 
+type LivraisonPdfReadResult =
+  | (Extract<LivraisonPdfAvailability, { available: false }> & { bytes: null })
+  | (Extract<LivraisonPdfAvailability, { available: true }> & { bytes: Buffer })
+
 const generatedPdfPredicate = `
   (
     document.type = 'GENERATED_SIMPLE_BL_PDF'
@@ -103,7 +107,7 @@ async function assertStoredPdf(
   documentId: string,
   expectedSize: number | null,
   expectedChecksum: string | null
-): Promise<void> {
+): Promise<Buffer> {
   const filePath = svcGetPdfFilePath(documentId)
   try {
     const bytes = await fs.readFile(filePath)
@@ -135,6 +139,7 @@ async function assertStoredPdf(
         )
       }
     }
+    return bytes
   } catch (error) {
     if (error instanceof HttpError) throw error
     const code = typeof error === "object" && error !== null && "code" in error
@@ -151,10 +156,10 @@ async function assertStoredPdf(
   }
 }
 
-export async function svcGetLivraisonPdfAvailability(
+async function readLivraisonPdf(
   bonLivraisonId: string,
   version?: number
-): Promise<LivraisonPdfAvailability> {
+): Promise<LivraisonPdfReadResult> {
   const row = await queryPdfDocument(bonLivraisonId, version)
   if (!row) {
     throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
@@ -173,17 +178,53 @@ export async function svcGetLivraisonPdfAvailability(
       document_id: null,
       version: null,
       generated_at: null,
+      bytes: null,
     }
   }
 
-  await assertStoredPdf(row.document_id, row.file_size_bytes, row.checksum_sha256)
+  const bytes = await assertStoredPdf(
+    row.document_id,
+    row.file_size_bytes,
+    row.checksum_sha256
+  )
   return {
     available: true,
     status: "AVAILABLE",
     document_id: row.document_id,
     version: row.version,
     generated_at: row.generated_at,
+    bytes,
   }
+}
+
+export async function svcGetLivraisonPdfAvailability(
+  bonLivraisonId: string,
+  version?: number
+): Promise<LivraisonPdfAvailability> {
+  const result = await readLivraisonPdf(bonLivraisonId, version)
+  if (!result.available) {
+    return {
+      available: false,
+      status: result.status,
+      document_id: null,
+      version: null,
+      generated_at: null,
+    }
+  }
+  return {
+    available: true,
+    status: result.status,
+    document_id: result.document_id,
+    version: result.version,
+    generated_at: result.generated_at,
+  }
+}
+
+export async function svcReadLivraisonPdf(
+  bonLivraisonId: string,
+  version?: number
+): Promise<LivraisonPdfReadResult> {
+  return readLivraisonPdf(bonLivraisonId, version)
 }
 
 export function svcGetPdfFilePath(documentId: string): string {

--- a/src/module/livraisons/types/livraisons.types.ts
+++ b/src/module/livraisons/types/livraisons.types.ts
@@ -189,6 +189,28 @@ export type BonLivraisonDetail = {
   events: BonLivraisonEventLog[]
 }
 
+export type LivraisonPdfAvailability =
+  | {
+      available: false
+      status: "NOT_GENERATED"
+      document_id: null
+      version: null
+      generated_at: null
+    }
+  | {
+      available: true
+      status: "AVAILABLE"
+      document_id: string
+      version: number
+      generated_at: string
+    }
+
+export type LivraisonPdfGenerationResult = {
+  document_id: string
+  version: number
+  idempotent_replay: boolean
+}
+
 export type ShipmentPreviewBlocker = {
   code: string
   message: string

--- a/src/module/livraisons/validators/livraisons.validators.ts
+++ b/src/module/livraisons/validators/livraisons.validators.ts
@@ -28,6 +28,13 @@ export const livraisonDocParamsSchema = z.object({
   docId: uuid,
 }).strict()
 
+export const livraisonPdfQuerySchema = z
+  .object({
+    version: z.coerce.number().int().positive().optional(),
+    download: z.union([z.string(), z.number(), z.boolean()]).optional(),
+  })
+  .strict()
+
 export const fromCommandeParamsSchema = z.object({
   commandeId: z.coerce.number().int().positive(),
 }).strict()


### PR DESCRIPTION
Publication contrôlée de la vague 5 GPT-5.6 : annulation auditée des BL, disponibilité/intégrité PDF et contrat du workflow de facturation, incluant les correctifs de réconciliation post-COMMIT.

Validation exacte de `dev` (`d6d65aa129ebdadca09cf988865764e6a589ab61`) : 192 fichiers / 3 758 tests, build, contrat, diff et scan de secrets verts. Aucun P0–P2 restant; `main` est ancêtre de `dev`.

## Summary by Sourcery

Introduce idempotent, integrity-checked delivery PDF generation and availability reporting, harden delivery cancellation and stock reservation release semantics, and extend finance workflow idempotency and HTTP contracts with thorough documentation and test coverage.

New Features:
- Expose a dedicated endpoint and service to report delivery PDF availability separately from generation and reading.
- Introduce idempotent PDF generation for delivery notes with archived versions, SHA-256 integrity checks, and cancellation-aware locking.
- Add idempotent finance workflow commands for facture drafts and validation using advisory locks and command receipts.

Bug Fixes:
- Ensure cancelling a delivery releases all active stock reservations consistently, including those whose allocations were deleted before cancellation, and rolls back cleanly on failure.
- Prevent duplicate or inconsistent stock reservation updates by de-duplicating reservation IDs and guarding against concurrent status changes.
- Enforce mandatory, normalized cancellation reasons for deliveries across service and repository layers and audit them consistently.

Enhancements:
- Strengthen delivery PDF storage by validating archived files against stored size and SHA-256, surfacing integrity errors instead of regenerating silently.
- Refine delivery status transitions to cancel from both DRAFT and READY while auditing cancellations and emitting structured audit logs.
- Tighten RBAC by granting delivery PDF management capability to appropriate roles and documenting the HTTP contract and frontend mappings for new routes.
- Improve PDF controller behavior by making GET strictly read-only, cache-safe, and resilient to file replacement races.

Documentation:
- Document the delivery PDF lifecycle, integrity guarantees, and PostgreSQL commit reconciliation runbook for operators.
- Clarify the HTTP contract for facture workflow v1, including eligible source rules and versioning semantics for previews and mutations.
- Extend frontend HTTP route mapping docs with the new livraison PDF availability endpoint and updated behavior.

Tests:
- Add comprehensive unit and integration tests for delivery PDF services, controllers, cancellation flows, and stock reservation release behavior.
- Add tests for finance workflow idempotency guards and facture workflow HTTP routes, ensuring correct status codes, replay handling, and error propagation.
- Backfill tests for delivery status service to cover audited cancellations, invalid transitions, and concurrent modification handling.