### PR TITLE
security: distribute authentication rate limits

### DIFF
--- a/INSTRUCTIONS_BACKEND.md
+++ b/INSTRUCTIONS_BACKEND.md
@@ -95,6 +95,15 @@ Env var names observed in code (names only):
 - `JWT_SECRET` (JWT signing/verifying secret) in:
   - `src/module/auth/middlewares/auth.middleware.ts`
   - `src/module/auth/services/auth.service.ts`
+- Distributed authentication throttling in `src/config/auth-rate-limit.ts`:
+  - `AUTH_RATE_LIMIT_ENABLED`
+  - `AUTH_RATE_LIMIT_STORE`
+  - `AUTH_RATE_LIMIT_HASH_KEY`
+  - `AUTH_RATE_LIMIT_*_WINDOW_MS` and `AUTH_RATE_LIMIT_*_LIMIT`
+  - `AUTH_RATE_LIMIT_STORE_RETRY_AFTER_SECONDS`
+  - `AUTH_RATE_LIMIT_CLEANUP_INTERVAL_MS`
+  - `AUTH_RATE_LIMIT_RETENTION_AFTER_EXPIRY_MS`
+- `TRUST_PROXY_HOPS` (bounded reverse-proxy hop count) in `src/config/trust-proxy.ts`
 - `BACKEND_URL` (base URL used to build public image URLs) in `src/module/outils/repository/outil.repository.ts`
 
 GitHub Actions and automated Dependabot updates are disabled at repository

--- a/db/patches/20260804_auth_rate_limit_buckets.sql
+++ b/db/patches/20260804_auth_rate_limit_buckets.sql
@@ -1,0 +1,40 @@
+BEGIN;
+
+-- SEC-CERP-0005: shared fixed-window counters for every backend replica.
+-- `subject_hash` is an HMAC-SHA256 digest. Raw IPs, emails, usernames and reset
+-- tokens must never be written to this table.
+CREATE TABLE IF NOT EXISTS public.auth_rate_limit_buckets (
+  scope text NOT NULL,
+  subject_hash character(64) NOT NULL,
+  request_count integer NOT NULL,
+  window_started_at timestamptz NOT NULL,
+  expires_at timestamptz NOT NULL,
+  updated_at timestamptz NOT NULL DEFAULT statement_timestamp(),
+  CONSTRAINT auth_rate_limit_buckets_pk PRIMARY KEY (scope, subject_hash),
+  CONSTRAINT auth_rate_limit_buckets_scope_ck
+    CHECK (scope ~ '^[a-z][a-z0-9:_-]{2,63}$'),
+  CONSTRAINT auth_rate_limit_buckets_subject_hash_ck
+    CHECK (subject_hash ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT auth_rate_limit_buckets_count_ck
+    CHECK (request_count > 0),
+  CONSTRAINT auth_rate_limit_buckets_window_ck
+    CHECK (expires_at > window_started_at)
+);
+
+COMMENT ON TABLE public.auth_rate_limit_buckets IS
+  'SEC-CERP-0005 shared auth throttling counters; HMAC pseudonyms only, no raw PII';
+COMMENT ON COLUMN public.auth_rate_limit_buckets.subject_hash IS
+  'HMAC-SHA256(scope and normalized subject); never a raw IP, email, username or token';
+
+CREATE INDEX IF NOT EXISTS auth_rate_limit_buckets_expires_at_idx
+  ON public.auth_rate_limit_buckets (expires_at);
+
+DO $grant$
+BEGIN
+  IF to_regrole('cerp_app') IS NOT NULL THEN
+    GRANT SELECT, INSERT, UPDATE, DELETE ON public.auth_rate_limit_buckets TO cerp_app;
+  END IF;
+END
+$grant$;
+
+COMMIT;

--- a/db/patches/support/20260804_auth_rate_limit_buckets.preflight.sql
+++ b/db/patches/support/20260804_auth_rate_limit_buckets.preflight.sql
@@ -1,0 +1,47 @@
+\set ON_ERROR_STOP on
+
+-- Read-only preflight. Run against cerp_test first, then cerp_prod only after
+-- the documented human approval and backup gate.
+DO $preflight$
+DECLARE
+  missing_columns text[];
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 preflight: unexpected database %', current_database();
+  END IF;
+
+  IF to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 preflight: role cerp_app is missing';
+  END IF;
+
+  IF to_regclass('public.auth_rate_limit_buckets') IS NOT NULL THEN
+    SELECT array_agg(required.column_name ORDER BY required.column_name)
+      INTO missing_columns
+    FROM (
+      VALUES
+        ('scope'),
+        ('subject_hash'),
+        ('request_count'),
+        ('window_started_at'),
+        ('expires_at'),
+        ('updated_at')
+    ) AS required(column_name)
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM information_schema.columns existing
+      WHERE existing.table_schema = 'public'
+        AND existing.table_name = 'auth_rate_limit_buckets'
+        AND existing.column_name = required.column_name
+    );
+
+    IF missing_columns IS NOT NULL THEN
+      RAISE EXCEPTION 'SEC-CERP-0005 preflight: incompatible existing table, missing %', missing_columns;
+    END IF;
+  END IF;
+END
+$preflight$;
+
+SELECT
+  current_database() AS database_name,
+  to_regclass('public.auth_rate_limit_buckets') AS existing_table,
+  'SEC-CERP-0005 preflight passed (read-only)' AS result;

--- a/db/patches/support/20260804_auth_rate_limit_buckets.rollback.sql
+++ b/db/patches/support/20260804_auth_rate_limit_buckets.rollback.sql
@@ -1,0 +1,15 @@
+\set ON_ERROR_STOP on
+
+-- Destructive rollback is deliberately restricted to cerp_test. Production
+-- rollback reverts the application release and leaves the inert table in place.
+DO $guard$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback is restricted to cerp_test';
+  END IF;
+END
+$guard$;
+
+BEGIN;
+DROP TABLE IF EXISTS public.auth_rate_limit_buckets;
+COMMIT;

--- a/db/patches/support/20260804_auth_rate_limit_buckets.verify.sql
+++ b/db/patches/support/20260804_auth_rate_limit_buckets.verify.sql
@@ -1,0 +1,75 @@
+\set ON_ERROR_STOP on
+
+-- Read-only structural verification. Counter behavior is covered by the
+-- deterministic application tests; this script never inserts identifying data.
+DO $verify$
+DECLARE
+  pk_definition text;
+  required_constraint_count integer;
+  hash_length integer;
+BEGIN
+  IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: unexpected database %', current_database();
+  END IF;
+
+  IF to_regclass('public.auth_rate_limit_buckets') IS NULL THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: table is missing';
+  END IF;
+
+  SELECT pg_get_constraintdef(oid)
+    INTO pk_definition
+  FROM pg_constraint
+  WHERE conrelid = 'public.auth_rate_limit_buckets'::regclass
+    AND contype = 'p';
+
+  IF pk_definition IS NULL OR pk_definition NOT LIKE '%(scope, subject_hash)%' THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: expected composite primary key is missing';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO required_constraint_count
+  FROM pg_constraint
+  WHERE conrelid = 'public.auth_rate_limit_buckets'::regclass
+    AND convalidated
+    AND conname = ANY (ARRAY[
+      'auth_rate_limit_buckets_scope_ck',
+      'auth_rate_limit_buckets_subject_hash_ck',
+      'auth_rate_limit_buckets_count_ck',
+      'auth_rate_limit_buckets_window_ck'
+    ]);
+
+  IF required_constraint_count <> 4 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: required validated checks are incomplete';
+  END IF;
+
+  SELECT character_maximum_length
+    INTO hash_length
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'auth_rate_limit_buckets'
+    AND column_name = 'subject_hash';
+
+  IF hash_length IS DISTINCT FROM 64 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: subject_hash must be character(64)';
+  END IF;
+
+  IF to_regclass('public.auth_rate_limit_buckets_expires_at_idx') IS NULL THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: expiry index is missing';
+  END IF;
+
+  IF has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'SELECT') IS NOT TRUE
+     OR has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'INSERT') IS NOT TRUE
+     OR has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'UPDATE') IS NOT TRUE
+     OR has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'DELETE') IS NOT TRUE THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: cerp_app privileges are incomplete';
+  END IF;
+END
+$verify$;
+
+SELECT
+  current_database() AS database_name,
+  COUNT(*) AS current_pseudonymous_buckets,
+  MIN(expires_at) AS oldest_expiry,
+  MAX(expires_at) AS newest_expiry,
+  'SEC-CERP-0005 verification passed (read-only)' AS result
+FROM public.auth_rate_limit_buckets;

--- a/docs/adr/ADR-SEC-CERP-0005-distributed-auth-rate-limits.md
+++ b/docs/adr/ADR-SEC-CERP-0005-distributed-auth-rate-limits.md
@@ -30,10 +30,10 @@ The subjects are:
 
 | Endpoint | Subjects | Default window and thresholds |
 |---|---|---|
-| login | client network, normalized username | IP 50 / 15 min; username 10 / 15 min |
-| register | client network, normalized username, normalized email | IP 10 / 60 min; each identifier 3 / 60 min |
-| forgot-password | client network, normalized username/email | IP 20 / 60 min; identifier 5 / 60 min |
-| reset-password | client network, reset token | IP 30 / 15 min; token 10 / 15 min |
+| login | client network, NFKC/uppercase username | IP 50 / 15 min; username 10 / 15 min |
+| register | client network, NFKC/uppercase username, NFKC/lowercase email | IP 10 / 60 min; username and email each 3 / 60 min |
+| forgot-password | client network plus both username and email canonical candidates | IP 20 / 60 min; username and email candidates each 5 / 60 min |
+| reset-password | client network, exact opaque reset token | IP 30 / 15 min; token 10 / 15 min |
 
 Before storage, each subject is transformed as
 `HMAC-SHA256(secret, "v1\0<scope>\0<normalized-subject>")`. The table receives
@@ -41,6 +41,12 @@ only the scope and 64-character digest. It never receives a raw IP, username,
 email or reset token. Rate-limit logs contain only endpoint, outcome, policy,
 request ID, retry duration and a sanitized error class; they do not contain a
 subject or digest.
+
+Username canonicalization is shared with validation and account lookup:
+`NFKC`, trim, then Unicode uppercase. Email uses `NFKC`, trim, then lowercase,
+matching writes and `LOWER(email)` lookup. Forgot-password always consumes both
+canonical candidates without classifying or looking up the input first. Reset
+tokens are opaque and are never trimmed, normalized or case-folded.
 
 IPv4 addresses use their canonical address. IPv4-mapped IPv6 collapses to the
 same IPv4 subject. Native IPv6 uses a canonical `/64` network subject so textual

--- a/docs/adr/ADR-SEC-CERP-0005-distributed-auth-rate-limits.md
+++ b/docs/adr/ADR-SEC-CERP-0005-distributed-auth-rate-limits.md
@@ -1,0 +1,95 @@
+# ADR SEC-CERP-0005 — Distributed authentication rate limits
+
+- Status: accepted
+- Date: 2026-08-04
+- Scope: `login`, `register`, `forgot-password`, `reset-password`
+
+## Context
+
+The CERP API runs as two independent processes: one on the atelier host and one
+in the VPS Coolify deployment. Both use the same PostgreSQL source of truth over
+the documented local/WireGuard paths. The previous login and password-reset
+limits were four process-local `Map` objects. Their counters disappeared on
+restart and were not shared between the two deployments. Registration and reset
+token submission had no equivalent guard.
+
+No shared Redis service is part of the verified deployment. Introducing one
+only for authentication throttling would add an unowned availability and secret
+management boundary. PostgreSQL is already shared, backed up and reachable by
+both API instances.
+
+## Decision
+
+Use a PostgreSQL fixed-window counter store behind the `AuthRateLimitStore`
+interface. Every request consumes all applicable subjects in one atomic
+`INSERT ... ON CONFLICT ... DO UPDATE` statement. PostgreSQL's
+`statement_timestamp()` defines window expiry and `Retry-After`, avoiding
+application-clock skew between replicas.
+
+The subjects are:
+
+| Endpoint | Subjects | Default window and thresholds |
+|---|---|---|
+| login | client network, normalized username | IP 50 / 15 min; username 10 / 15 min |
+| register | client network, normalized username, normalized email | IP 10 / 60 min; each identifier 3 / 60 min |
+| forgot-password | client network, normalized username/email | IP 20 / 60 min; identifier 5 / 60 min |
+| reset-password | client network, reset token | IP 30 / 15 min; token 10 / 15 min |
+
+Before storage, each subject is transformed as
+`HMAC-SHA256(secret, "v1\0<scope>\0<normalized-subject>")`. The table receives
+only the scope and 64-character digest. It never receives a raw IP, username,
+email or reset token. Rate-limit logs contain only endpoint, outcome, policy,
+request ID, retry duration and a sanitized error class; they do not contain a
+subject or digest.
+
+IPv4 addresses use their canonical address. IPv4-mapped IPv6 collapses to the
+same IPv4 subject. Native IPv6 uses a canonical `/64` network subject so textual
+variants and privacy addresses within the same client network cannot bypass the
+limit. Express trusts one proxy hop by default, matching both Apache and
+Traefik paths. `TRUST_PROXY_HOPS` is bounded and must match the deployed path;
+the right-most trusted address is used, not an attacker-controlled left-most
+`X-Forwarded-For` value.
+
+## Failure policy
+
+| Endpoint | Store unavailable | Quota exceeded |
+|---|---|---|
+| login | fail closed, generic `503`, `Retry-After` | generic `429`, `Retry-After` |
+| register | fail closed, generic `503`, `Retry-After` | generic `429`, `Retry-After` |
+| reset-password | fail closed, generic `503`, `Retry-After` | generic `429`, `Retry-After` |
+| forgot-password | suppress reset work, preserve generic `200` and minimum response time | same generic `200`; suppress reset work |
+
+The forgot-password behavior prevents account enumeration and avoids sending
+mail when abuse controls cannot make a reliable decision. The other endpoints
+fail closed because bypassing their guard during a shared-store incident would
+re-open brute force or automated account creation.
+
+## Retention and observability
+
+Expired rows are deleted by an unreferenced periodic maintenance timer after a
+short configurable grace period. Only HMAC pseudonyms are retained. Store
+failure, cleanup failure and blocked-request events are structured and contain
+no subject values. Normal allowed requests add no rate-limit log noise.
+
+## Alternatives considered
+
+- Process-local memory: rejected because it fails restart and multi-replica
+  requirements.
+- Redis: rejected for now because it is not part of the verified infrastructure.
+- Reusing `auth_login_logs`: rejected because it covers neither registration nor
+  reset requests, retains personal audit data, and cannot provide one atomic
+  counter contract across all endpoints.
+- Fail-open fallback: rejected for normal operation. The explicit emergency
+  disable switch exists only as a short rollback aid under human supervision.
+
+## Consequences
+
+The table patch must be applied before the new release is enabled. A PostgreSQL
+incident now makes login, registration and reset submission temporarily
+unavailable by design; forgot-password remains indistinguishable to callers but
+does no work. Both API deployments must use the same HMAC key. Coordinated key
+rotation resets the effective buckets and therefore must occur only at a
+documented window boundary.
+
+No frontend contract change is required: existing successful responses remain
+unchanged and the frontend already handles HTTP errors generically.

--- a/docs/runbooks/auth-rate-limit-deployment.md
+++ b/docs/runbooks/auth-rate-limit-deployment.md
@@ -1,0 +1,92 @@
+# Runbook — distributed authentication rate limits
+
+This runbook covers `SEC-CERP-0005`. It does not authorize a production change.
+Production backup, patching, deployment and secret configuration require the
+existing human approval gates.
+
+## Artifacts
+
+- patch: `db/patches/20260804_auth_rate_limit_buckets.sql`;
+- read-only preflight: `db/patches/support/20260804_auth_rate_limit_buckets.preflight.sql`;
+- read-only verification: `db/patches/support/20260804_auth_rate_limit_buckets.verify.sql`;
+- test-only destructive rollback: `db/patches/support/20260804_auth_rate_limit_buckets.rollback.sql`.
+
+No SQL from these files was executed while preparing this change. The automated
+evidence is static guard testing plus deterministic fake-store integration tests.
+
+## Required configuration
+
+Set the same values on the atelier systemd service and the VPS Coolify service.
+Secret values belong in their server-side secret stores and must never be pasted
+into Git, issues, logs or evidence.
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `AUTH_RATE_LIMIT_ENABLED` | `true` | Emergency feature switch; normal production value is `true` |
+| `AUTH_RATE_LIMIT_STORE` | `postgres` | Only supported shared store |
+| `AUTH_RATE_LIMIT_HASH_KEY` | none in production | At least 32 characters; identical on both backends |
+| `TRUST_PROXY_HOPS` | `1` | Apache/Traefik hop count; `0` only for a direct local process |
+| `AUTH_RATE_LIMIT_STORE_RETRY_AFTER_SECONDS` | `30` | Retry hint during store failure |
+| `AUTH_RATE_LIMIT_CLEANUP_INTERVAL_MS` | `900000` | Expired-row cleanup cadence |
+| `AUTH_RATE_LIMIT_RETENTION_AFTER_EXPIRY_MS` | `3600000` | Pseudonym grace period after expiry |
+| `AUTH_RATE_LIMIT_LOGIN_WINDOW_MS` | `900000` | Login fixed window |
+| `AUTH_RATE_LIMIT_LOGIN_IP_LIMIT` | `50` | Login client-network threshold |
+| `AUTH_RATE_LIMIT_LOGIN_IDENTIFIER_LIMIT` | `10` | Login username threshold |
+| `AUTH_RATE_LIMIT_REGISTER_WINDOW_MS` | `3600000` | Registration fixed window |
+| `AUTH_RATE_LIMIT_REGISTER_IP_LIMIT` | `10` | Registration client-network threshold |
+| `AUTH_RATE_LIMIT_REGISTER_IDENTIFIER_LIMIT` | `3` | Registration username/email threshold |
+| `AUTH_RATE_LIMIT_FORGOT_WINDOW_MS` | `3600000` | Forgot-password fixed window |
+| `AUTH_RATE_LIMIT_FORGOT_IP_LIMIT` | `20` | Forgot-password client-network threshold |
+| `AUTH_RATE_LIMIT_FORGOT_IDENTIFIER_LIMIT` | `5` | Forgot-password identifier threshold |
+| `AUTH_RATE_LIMIT_RESET_WINDOW_MS` | `900000` | Reset-token fixed window |
+| `AUTH_RATE_LIMIT_RESET_IP_LIMIT` | `30` | Reset client-network threshold |
+| `AUTH_RATE_LIMIT_RESET_TOKEN_LIMIT` | `10` | Reset-token threshold |
+
+Invalid values fail application startup. Every enabled runtime outside the test
+harness also fails startup when the HMAC key is absent or shorter than 32
+characters; an absent or unexpected `NODE_ENV` never enables a public fallback.
+
+## Test-first rollout
+
+1. Confirm a current backup and recovery point for `cerp_test`.
+2. Run the preflight against `cerp_test`; it performs no writes.
+3. Apply the patch to `cerp_test` through the established patch process.
+4. Run the read-only verify script against `cerp_test`.
+5. Configure a non-production HMAC key on both test API instances.
+6. Deploy the same release to both test API instances.
+7. Exercise only synthetic identifiers reserved for testing. Confirm that a
+   bucket consumed through instance A blocks through instance B, remains after
+   restarting A, returns a numeric `Retry-After`, and expires after its window.
+8. Use the deterministic injected failing store from the automated tests; do
+   not stop or disconnect the shared database. Confirm `503` for
+   login/register/reset and generic `200` without mail for forgot-password.
+9. Confirm logs contain endpoint/outcome only and no synthetic identifier/IP.
+
+Promotion to production repeats backup, preflight, patch and verify only after
+explicit human approval. Apply the table before deploying code. Configure the
+same HMAC key on both deployments, deploy the two backends in a short controlled
+window, then confirm health and store-unavailable logs.
+
+## Rollback
+
+Preferred production rollback:
+
+1. restore the previous application release on both backends;
+2. leave `public.auth_rate_limit_buckets` in place (it is inert for old code);
+3. remove new environment variables only after both old instances are healthy.
+
+Do not run the destructive rollback script on production; it refuses any
+database other than `cerp_test`. On `cerp_test`, the script may be used only
+after confirming that no active test depends on the counters.
+
+If the table patch is healthy but the new code must be disabled briefly during
+an approved rollback, set `AUTH_RATE_LIMIT_ENABLED=false` on both instances,
+restart them, and complete the application rollback immediately. This is a
+temporary fail-open state and must not be treated as a steady configuration.
+
+## HMAC key rotation
+
+Rotate only through the normal secret-change procedure. Because a new key makes
+new pseudonyms, drain both instances and change them together at or after the
+longest configured window. Expect previous buckets to age out; never log or
+export their digests.

--- a/docs/runbooks/auth-rate-limit-deployment.md
+++ b/docs/runbooks/auth-rate-limit-deployment.md
@@ -34,10 +34,10 @@ into Git, issues, logs or evidence.
 | `AUTH_RATE_LIMIT_LOGIN_IDENTIFIER_LIMIT` | `10` | Login username threshold |
 | `AUTH_RATE_LIMIT_REGISTER_WINDOW_MS` | `3600000` | Registration fixed window |
 | `AUTH_RATE_LIMIT_REGISTER_IP_LIMIT` | `10` | Registration client-network threshold |
-| `AUTH_RATE_LIMIT_REGISTER_IDENTIFIER_LIMIT` | `3` | Registration username/email threshold |
+| `AUTH_RATE_LIMIT_REGISTER_IDENTIFIER_LIMIT` | `3` | Per-dimension registration username/email threshold |
 | `AUTH_RATE_LIMIT_FORGOT_WINDOW_MS` | `3600000` | Forgot-password fixed window |
 | `AUTH_RATE_LIMIT_FORGOT_IP_LIMIT` | `20` | Forgot-password client-network threshold |
-| `AUTH_RATE_LIMIT_FORGOT_IDENTIFIER_LIMIT` | `5` | Forgot-password identifier threshold |
+| `AUTH_RATE_LIMIT_FORGOT_IDENTIFIER_LIMIT` | `5` | Per-candidate forgot-password username/email threshold |
 | `AUTH_RATE_LIMIT_RESET_WINDOW_MS` | `900000` | Reset-token fixed window |
 | `AUTH_RATE_LIMIT_RESET_IP_LIMIT` | `30` | Reset client-network threshold |
 | `AUTH_RATE_LIMIT_RESET_TOKEN_LIMIT` | `10` | Reset-token threshold |

--- a/docs/security/auth-rate-limit-policy.md
+++ b/docs/security/auth-rate-limit-policy.md
@@ -1,0 +1,59 @@
+# Authentication rate-limit policy
+
+This policy implements `SEC-CERP-0005`. The architectural rationale is in
+[`../adr/ADR-SEC-CERP-0005-distributed-auth-rate-limits.md`](../adr/ADR-SEC-CERP-0005-distributed-auth-rate-limits.md).
+
+## Control map
+
+The previous process-local counters were:
+
+- login by IP: 10 requests per 15 minutes;
+- login by username: 10 requests per 15 minutes;
+- forgot-password by IP: 5 requests per 60 minutes;
+- forgot-password by username/email: 5 requests per 60 minutes.
+
+They were removed. The distributed policy preserves the username protection,
+raises the shared-IP login ceiling to avoid locking a legitimate NAT population,
+and adds registration and reset-token controls. Exact defaults and environment
+overrides are defined in `src/config/auth-rate-limit.ts`.
+
+## Privacy properties
+
+- The application HMACs every subject before calling the repository.
+- PostgreSQL stores no raw IP, email, username or reset token in the rate table.
+- Rate-limit operational logs contain no subject and no HMAC digest.
+- Native IPv6 is minimized to a `/64` network before HMAC.
+- Expired pseudonyms are removed by periodic maintenance; the default grace
+  period is one hour after expiry.
+- The HMAC key is a server-side secret and must be identical on both backends.
+
+The existing security audit records are a separate, access-controlled purpose
+and are not reused as a throttling store.
+
+## Anti-enumeration contract
+
+`forgot-password` always returns status `200` with:
+
+```json
+{"message":"Si ce compte existe, un lien de réinitialisation a été envoyé."}
+```
+
+The minimum response time remains 600 ms whether validation fails, a bucket is
+blocked, the shared store is unavailable, or the account does not exist. A
+blocked/degraded request does not query the account or send an email.
+
+The other endpoints use generic `429` or `503` messages. A response never states
+which subject reached a threshold and never confirms whether an identifier or
+token exists.
+
+## Operator signals
+
+Structured event types:
+
+- `auth_rate_limit` with outcome `blocked`;
+- `auth_rate_limit` with outcome `store_unavailable` and the configured policy;
+- `auth_rate_limit_cleanup_failed`.
+
+Alert on sustained `store_unavailable`, on cleanup failures across two
+intervals, or on a sharp rise of blocked requests. Do not add subject values,
+headers or database error messages to these logs.

--- a/docs/security/auth-rate-limit-policy.md
+++ b/docs/security/auth-rate-limit-policy.md
@@ -23,6 +23,10 @@ overrides are defined in `src/config/auth-rate-limit.ts`.
 - PostgreSQL stores no raw IP, email, username or reset token in the rate table.
 - Rate-limit operational logs contain no subject and no HMAC digest.
 - Native IPv6 is minimized to a `/64` network before HMAC.
+- Usernames use the account contract (`NFKC`, trim, Unicode uppercase) and
+  emails use `NFKC`, trim and lowercase before HMAC.
+- Reset tokens remain exact opaque byte-for-byte strings; they are never
+  trimmed, normalized or case-folded.
 - Expired pseudonyms are removed by periodic maintenance; the default grace
   period is one hour after expiry.
 - The HMAC key is a server-side secret and must be identical on both backends.
@@ -41,6 +45,12 @@ and are not reused as a throttling store.
 The minimum response time remains 600 ms whether validation fails, a bucket is
 blocked, the shared store is unavailable, or the account does not exist. A
 blocked/degraded request does not query the account or send an email.
+
+Every syntactically supplied forgot-password identifier consumes both a
+username-canonical bucket and an email-canonical bucket, plus the client
+network bucket. This happens before validation and without a database lookup or
+input-shape branch, so the bucket set and response do not reveal whether the
+value resembles or matches an account of either type.
 
 The other endpoints use generic `429` or `503` messages. A response never states
 which subject reached a threshold and never confirms whether an identifier or

--- a/src/__tests__/auth-rate-limit.config-and-ip.test.ts
+++ b/src/__tests__/auth-rate-limit.config-and-ip.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { loadAuthRateLimitConfig } from "../config/auth-rate-limit";
+import { resolveTrustProxySetting } from "../config/trust-proxy";
+import { canonicalizeRateLimitClientAddress } from "../utils/requestMeta";
+
+describe("auth rate limit configuration and client addressing", () => {
+  it("requires a dedicated pseudonymization key in production", () => {
+    expect(() => loadAuthRateLimitConfig({ NODE_ENV: "production" })).toThrow(
+      "AUTH_RATE_LIMIT_HASH_KEY"
+    );
+    expect(
+      loadAuthRateLimitConfig({
+        NODE_ENV: "production",
+        AUTH_RATE_LIMIT_HASH_KEY: "production-placeholder-with-at-least-32-chars",
+      }).store
+    ).toBe("postgres");
+  });
+
+  it("fails safe when NODE_ENV is absent outside the explicit test harness", () => {
+    expect(() => loadAuthRateLimitConfig({})).toThrow("AUTH_RATE_LIMIT_HASH_KEY");
+    expect(loadAuthRateLimitConfig({ NODE_ENV: "test" }).hashKey).toHaveLength(37);
+  });
+
+  it("rejects unsupported stores and invalid proxy hop counts", () => {
+    expect(() => loadAuthRateLimitConfig({ AUTH_RATE_LIMIT_STORE: "redis" })).toThrow(
+      "AUTH_RATE_LIMIT_STORE must be postgres"
+    );
+    expect(() => resolveTrustProxySetting({ TRUST_PROXY_HOPS: "all" })).toThrow();
+    expect(resolveTrustProxySetting({ TRUST_PROXY_HOPS: "0" })).toBe(false);
+    expect(resolveTrustProxySetting({ TRUST_PROXY_HOPS: "1" })).toBe(1);
+  });
+
+  it.each([
+    ["192.0.2.8", "ipv4:192.0.2.8"],
+    ["::ffff:192.0.2.8", "ipv4:192.0.2.8"],
+    ["2001:0DB8:abcd:12:0:0:0:1", "ipv6:2001:db8:abcd:12::/64"],
+    ["2001:db8:abcd:12::99", "ipv6:2001:db8:abcd:12::/64"],
+    ["fe80::1%12", "ipv6:fe80:0:0:0::/64"],
+  ])("canonicalizes %s as %s", (input, expected) => {
+    expect(canonicalizeRateLimitClientAddress(input)).toBe(expected);
+  });
+
+  it("keeps different IPv6 /64 networks separate and rejects invalid input", () => {
+    expect(canonicalizeRateLimitClientAddress("2001:db8:1:1::1")).not.toBe(
+      canonicalizeRateLimitClientAddress("2001:db8:1:2::1")
+    );
+    expect(canonicalizeRateLimitClientAddress("not-an-ip")).toBeNull();
+  });
+});

--- a/src/__tests__/auth-rate-limit.middleware.test.ts
+++ b/src/__tests__/auth-rate-limit.middleware.test.ts
@@ -1,0 +1,132 @@
+import express from "express";
+import request from "supertest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { AuthRateLimitDecision } from "../module/auth/domain/auth-rate-limit";
+import { createAuthRateLimitMiddleware } from "../module/auth/middlewares/auth-rate-limit.middleware";
+
+function appWithDecision(endpoint: Parameters<typeof createAuthRateLimitMiddleware>[0], decision: AuthRateLimitDecision) {
+  const checkedSubjects: unknown[][] = [];
+  const limiter = {
+    check: vi.fn(async (_endpoint, subjects) => {
+      checkedSubjects.push([...subjects]);
+      return decision;
+    }),
+  };
+  const app = express();
+  app.set("trust proxy", 1);
+  app.use(express.json());
+  app.post(
+    "/auth",
+    createAuthRateLimitMiddleware(endpoint, limiter as never),
+    (req, res) => res.status(200).json({
+      message: "Si ce compte existe, un lien de réinitialisation a été envoyé.",
+      suppressed: req.authRateLimit?.suppressAction ?? false,
+    })
+  );
+  return { app, limiter, checkedSubjects };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("auth rate limit middleware", () => {
+  it("returns a generic 429 with Retry-After for an explicit login block", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { app } = appWithDecision("login", {
+      status: "blocked",
+      endpoint: "login",
+      retryAfterSeconds: 37,
+    });
+
+    const response = await request(app).post("/auth").send({ username: "operator", password: "wrong" });
+
+    expect(response.status).toBe(429);
+    expect(response.headers["retry-after"]).toBe("37");
+    expect(response.body).toEqual({
+      error: "TOO_MANY_ATTEMPTS",
+      message: "Trop de tentatives. Réessayez plus tard.",
+    });
+  });
+
+  it("suppresses forgot-password work while preserving the generic 200 response", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { app } = appWithDecision("forgotPassword", {
+      status: "blocked",
+      endpoint: "forgotPassword",
+      retryAfterSeconds: 55,
+    });
+
+    const response = await request(app)
+      .post("/auth")
+      .send({ usernameOrEmail: "person@example.test" });
+
+    expect(response.status).toBe(200);
+    expect(response.headers["retry-after"]).toBeUndefined();
+    expect(response.body).toEqual({
+      message: "Si ce compte existe, un lien de réinitialisation a été envoyé.",
+      suppressed: true,
+    });
+  });
+
+  it("fails closed with a generic 503 when the shared store is unavailable", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { app } = appWithDecision("register", {
+      status: "unavailable",
+      endpoint: "register",
+      failurePolicy: "closed-error",
+      retryAfterSeconds: 19,
+      errorName: "Error",
+    });
+
+    const response = await request(app).post("/auth").send({ username: "new-user" });
+
+    expect(response.status).toBe(503);
+    expect(response.headers["retry-after"]).toBe("19");
+    expect(response.body).toEqual({
+      error: "AUTH_TEMPORARILY_UNAVAILABLE",
+      message: "Service d'authentification temporairement indisponible.",
+    });
+  });
+
+  it("uses the nearest proxy hop and canonicalizes IPv4-mapped addresses", async () => {
+    const { app, limiter, checkedSubjects } = appWithDecision("login", {
+      status: "allowed",
+      endpoint: "login",
+      disabled: false,
+    });
+
+    await request(app)
+      .post("/auth")
+      .set("X-Forwarded-For", "198.51.100.9, ::ffff:203.0.113.7")
+      .send({ username: "operator" })
+      .expect(200);
+
+    expect(limiter.check).toHaveBeenCalledTimes(1);
+    expect(checkedSubjects[0]).toEqual([
+      { dimension: "ip", value: "ipv4:203.0.113.7" },
+      { dimension: "identifier", value: "operator" },
+    ]);
+  });
+
+  it("never emits request subjects in rate-limit observability logs", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const { app } = appWithDecision("forgotPassword", {
+      status: "unavailable",
+      endpoint: "forgotPassword",
+      failurePolicy: "closed-generic",
+      retryAfterSeconds: 19,
+      errorName: "Error",
+    });
+
+    await request(app)
+      .post("/auth")
+      .set("X-Forwarded-For", "198.51.100.44")
+      .send({ usernameOrEmail: "person@example.test" })
+      .expect(200);
+
+    const logged = warn.mock.calls.flat().join(" ");
+    expect(logged).not.toContain("198.51.100.44");
+    expect(logged).not.toContain("person@example.test");
+    expect(logged).toContain("store_unavailable");
+  });
+});

--- a/src/__tests__/auth-rate-limit.middleware.test.ts
+++ b/src/__tests__/auth-rate-limit.middleware.test.ts
@@ -104,7 +104,65 @@ describe("auth rate limit middleware", () => {
     expect(limiter.check).toHaveBeenCalledTimes(1);
     expect(checkedSubjects[0]).toEqual([
       { dimension: "ip", value: "ipv4:203.0.113.7" },
-      { dimension: "identifier", value: "operator" },
+      { dimension: "username", value: "OPERATOR" },
+    ]);
+  });
+
+  it("always consumes both canonical forgot-password identity candidates", async () => {
+    const { app, checkedSubjects } = appWithDecision("forgotPassword", {
+      status: "allowed",
+      endpoint: "forgotPassword",
+      disabled: false,
+    });
+
+    const responses = [];
+    for (const identifier of ["stra\u00dfe", "Person@Example.Test", "unknown-account"]) {
+      responses.push(
+        await request(app)
+          .post("/auth")
+          .send({ usernameOrEmail: identifier })
+      );
+    }
+
+    expect(responses.map((response) => [response.status, response.body])).toEqual([
+      [200, expect.objectContaining({ suppressed: false })],
+      [200, expect.objectContaining({ suppressed: false })],
+      [200, expect.objectContaining({ suppressed: false })],
+    ]);
+    expect(checkedSubjects).toEqual([
+      [
+        { dimension: "ip", value: "ipv4:127.0.0.1" },
+        { dimension: "username", value: "STRASSE" },
+        { dimension: "email", value: "stra\u00dfe" },
+      ],
+      [
+        { dimension: "ip", value: "ipv4:127.0.0.1" },
+        { dimension: "username", value: "PERSON@EXAMPLE.TEST" },
+        { dimension: "email", value: "person@example.test" },
+      ],
+      [
+        { dimension: "ip", value: "ipv4:127.0.0.1" },
+        { dimension: "username", value: "UNKNOWN-ACCOUNT" },
+        { dimension: "email", value: "unknown-account" },
+      ],
+    ]);
+  });
+
+  it("passes an opaque reset token without trimming or case folding", async () => {
+    const { app, checkedSubjects } = appWithDecision("resetPassword", {
+      status: "allowed",
+      endpoint: "resetPassword",
+      disabled: false,
+    });
+
+    await request(app)
+      .post("/auth")
+      .send({ token: " AbC-opaque-token " })
+      .expect(200);
+
+    expect(checkedSubjects[0]).toEqual([
+      { dimension: "ip", value: "ipv4:127.0.0.1" },
+      { dimension: "token", value: " AbC-opaque-token " },
     ]);
   });
 

--- a/src/__tests__/auth-rate-limit.migration-guards.test.ts
+++ b/src/__tests__/auth-rate-limit.migration-guards.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import { repoRoot } from "./helpers/repo-paths";
+
+const patch = readFileSync(resolve(repoRoot, "db/patches/20260804_auth_rate_limit_buckets.sql"), "utf8");
+const preflight = readFileSync(
+  resolve(repoRoot, "db/patches/support/20260804_auth_rate_limit_buckets.preflight.sql"),
+  "utf8"
+);
+const verify = readFileSync(
+  resolve(repoRoot, "db/patches/support/20260804_auth_rate_limit_buckets.verify.sql"),
+  "utf8"
+);
+const rollback = readFileSync(
+  resolve(repoRoot, "db/patches/support/20260804_auth_rate_limit_buckets.rollback.sql"),
+  "utf8"
+);
+const repository = readFileSync(
+  resolve(repoRoot, "src/module/auth/repository/auth-rate-limit.repository.ts"),
+  "utf8"
+);
+
+describe("SEC-CERP-0005 migration guards", () => {
+  it("stores only bounded HMAC pseudonyms with expiry", () => {
+    expect(patch).toContain("subject_hash character(64)");
+    expect(patch).toContain("subject_hash ~ '^[0-9a-f]{64}$'");
+    expect(patch).toContain("PRIMARY KEY (scope, subject_hash)");
+    expect(patch).toContain("auth_rate_limit_buckets_expires_at_idx");
+    expect(patch).not.toMatch(/\b(email|username|ip_address|raw_ip|token)\s+(?:text|varchar|inet)/i);
+  });
+
+  it("uses an atomic upsert and the PostgreSQL clock", () => {
+    expect(repository).toContain("ON CONFLICT (scope, subject_hash) DO UPDATE");
+    expect(repository).toContain("auth_rate_limit_buckets.request_count + 1");
+    expect(repository).toContain("statement_timestamp()");
+    expect(repository).toContain("retry_after_seconds");
+  });
+
+  it("keeps verification read-only and destructive rollback test-only", () => {
+    const mutatingSql = /\b(?:INSERT\s+INTO|UPDATE\s+public\.|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE)\b/i;
+    expect(preflight).not.toMatch(mutatingSql);
+    expect(verify).not.toMatch(mutatingSql);
+    expect(rollback).toContain("current_database() <> 'cerp_test'");
+    expect(rollback).toContain("DROP TABLE IF EXISTS public.auth_rate_limit_buckets");
+  });
+});

--- a/src/__tests__/auth-rate-limit.repository.test.ts
+++ b/src/__tests__/auth-rate-limit.repository.test.ts
@@ -13,7 +13,7 @@ describe("PostgresAuthRateLimitStore", () => {
           retry_after_seconds: 41,
         },
         {
-          scope: "auth:login:identifier",
+          scope: "auth:login:username",
           subject_hash: "b".repeat(64),
           request_count: "11",
           retry_after_seconds: "42",
@@ -26,12 +26,12 @@ describe("PostgresAuthRateLimitStore", () => {
     await expect(
       store.consume([
         { scope: "auth:login:ip", subjectHash: "a".repeat(64), windowMs: 900_000 },
-        { scope: "auth:login:identifier", subjectHash: "b".repeat(64), windowMs: 900_000 },
+        { scope: "auth:login:username", subjectHash: "b".repeat(64), windowMs: 900_000 },
       ])
     ).resolves.toEqual([
       { scope: "auth:login:ip", subjectHash: "a".repeat(64), count: 3, retryAfterSeconds: 41 },
       {
-        scope: "auth:login:identifier",
+        scope: "auth:login:username",
         subjectHash: "b".repeat(64),
         count: 11,
         retryAfterSeconds: 42,
@@ -48,7 +48,7 @@ describe("PostgresAuthRateLimitStore", () => {
       "auth:login:ip",
       "a".repeat(64),
       900_000,
-      "auth:login:identifier",
+      "auth:login:username",
       "b".repeat(64),
       900_000,
     ]);

--- a/src/__tests__/auth-rate-limit.repository.test.ts
+++ b/src/__tests__/auth-rate-limit.repository.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { PostgresAuthRateLimitStore } from "../module/auth/repository/auth-rate-limit.repository";
+
+describe("PostgresAuthRateLimitStore", () => {
+  it("increments every request subject in one atomic PostgreSQL statement", async () => {
+    const query = vi.fn().mockResolvedValue({
+      rows: [
+        {
+          scope: "auth:login:ip",
+          subject_hash: "a".repeat(64),
+          request_count: 3,
+          retry_after_seconds: 41,
+        },
+        {
+          scope: "auth:login:identifier",
+          subject_hash: "b".repeat(64),
+          request_count: "11",
+          retry_after_seconds: "42",
+        },
+      ],
+      rowCount: 2,
+    });
+    const store = new PostgresAuthRateLimitStore({ query } as never);
+
+    await expect(
+      store.consume([
+        { scope: "auth:login:ip", subjectHash: "a".repeat(64), windowMs: 900_000 },
+        { scope: "auth:login:identifier", subjectHash: "b".repeat(64), windowMs: 900_000 },
+      ])
+    ).resolves.toEqual([
+      { scope: "auth:login:ip", subjectHash: "a".repeat(64), count: 3, retryAfterSeconds: 41 },
+      {
+        scope: "auth:login:identifier",
+        subjectHash: "b".repeat(64),
+        count: 11,
+        retryAfterSeconds: 42,
+      },
+    ]);
+
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, values] = query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("ON CONFLICT (scope, subject_hash) DO UPDATE");
+    expect(sql).toContain("public.auth_rate_limit_buckets.request_count + 1");
+    expect(sql).toContain("statement_timestamp()");
+    expect(sql).toContain("retry_after_seconds");
+    expect(values).toEqual([
+      "auth:login:ip",
+      "a".repeat(64),
+      900_000,
+      "auth:login:identifier",
+      "b".repeat(64),
+      900_000,
+    ]);
+  });
+
+  it("removes expired pseudonymous buckets using an explicit cutoff", async () => {
+    const query = vi.fn().mockResolvedValue({ rows: [], rowCount: 7 });
+    const store = new PostgresAuthRateLimitStore({ query } as never);
+
+    await expect(store.deleteExpired(3_600_000)).resolves.toBe(7);
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining("DELETE FROM public.auth_rate_limit_buckets"),
+      [3_600_000]
+    );
+    expect(query.mock.calls[0]?.[0]).toContain("statement_timestamp()");
+  });
+});

--- a/src/__tests__/auth-rate-limit.service.test.ts
+++ b/src/__tests__/auth-rate-limit.service.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it } from "vitest";
+
+import type { AuthRateLimitConfig } from "../config/auth-rate-limit";
+import type {
+  AuthRateLimitStore,
+  AuthRateLimitStoreCounter,
+  AuthRateLimitStoreInput,
+} from "../module/auth/domain/auth-rate-limit";
+import { AuthRateLimiter } from "../module/auth/services/auth-rate-limit.service";
+
+type SharedCounter = { count: number; expiresAt: number };
+
+class SharedDeterministicStore implements AuthRateLimitStore {
+  readonly state: Map<string, SharedCounter>;
+  lastInputs: readonly AuthRateLimitStoreInput[] = [];
+  fail = false;
+
+  constructor(
+    private readonly now: () => number,
+    state: Map<string, SharedCounter> = new Map()
+  ) {
+    this.state = state;
+  }
+
+  async consume(inputs: readonly AuthRateLimitStoreInput[]): Promise<AuthRateLimitStoreCounter[]> {
+    if (this.fail) throw new Error("simulated-store-outage");
+    this.lastInputs = inputs;
+
+    return inputs.map((input) => {
+      const key = `${input.scope}:${input.subjectHash}`;
+      const existing = this.state.get(key);
+      const current = !existing || existing.expiresAt <= this.now()
+        ? { count: 1, expiresAt: this.now() + input.windowMs }
+        : { count: existing.count + 1, expiresAt: existing.expiresAt };
+      this.state.set(key, current);
+      return {
+        scope: input.scope,
+        subjectHash: input.subjectHash,
+        count: current.count,
+        retryAfterSeconds: Math.max(1, Math.ceil((current.expiresAt - this.now()) / 1000)),
+      };
+    });
+  }
+
+  async deleteExpired(retentionAfterExpiryMs: number): Promise<number> {
+    const before = this.now() - retentionAfterExpiryMs;
+    let deleted = 0;
+    for (const [key, value] of this.state) {
+      if (value.expiresAt < before) {
+        this.state.delete(key);
+        deleted += 1;
+      }
+    }
+    return deleted;
+  }
+}
+
+function testConfig(overrides: Partial<AuthRateLimitConfig> = {}): AuthRateLimitConfig {
+  const windowMs = 60_000;
+  return {
+    enabled: true,
+    store: "postgres",
+    hashKey: "deterministic-test-key-with-at-least-32-characters",
+    storeUnavailableRetryAfterSeconds: 17,
+    cleanupIntervalMs: 60_000,
+    retentionAfterExpiryMs: 0,
+    endpoints: {
+      login: {
+        failurePolicy: "closed-error",
+        dimensions: { identifier: { limit: 2, windowMs }, ip: { limit: 50, windowMs } },
+      },
+      register: {
+        failurePolicy: "closed-error",
+        dimensions: { identifier: { limit: 2, windowMs }, ip: { limit: 2, windowMs } },
+      },
+      forgotPassword: {
+        failurePolicy: "closed-generic",
+        dimensions: { identifier: { limit: 2, windowMs }, ip: { limit: 2, windowMs } },
+      },
+      resetPassword: {
+        failurePolicy: "closed-error",
+        dimensions: { token: { limit: 2, windowMs }, ip: { limit: 2, windowMs } },
+      },
+    },
+    ...overrides,
+  };
+}
+
+describe("distributed auth rate limiter", () => {
+  it("shares counters across instances and survives an application restart", async () => {
+    let now = Date.parse("2026-08-04T10:00:00.000Z");
+    const sharedState = new Map<string, SharedCounter>();
+    const instanceAStore = new SharedDeterministicStore(() => now, sharedState);
+    const instanceBStore = new SharedDeterministicStore(() => now, sharedState);
+    const instanceA = new AuthRateLimiter(instanceAStore, testConfig());
+    const instanceB = new AuthRateLimiter(instanceBStore, testConfig());
+    const subject = [{ dimension: "identifier" as const, value: "operator@example.test" }];
+
+    await expect(instanceA.check("login", subject)).resolves.toMatchObject({ status: "allowed" });
+    await expect(instanceB.check("login", subject)).resolves.toMatchObject({ status: "allowed" });
+    await expect(instanceA.check("login", subject)).resolves.toMatchObject({
+      status: "blocked",
+      retryAfterSeconds: 60,
+    });
+
+    const restartedInstance = new AuthRateLimiter(
+      new SharedDeterministicStore(() => now, sharedState),
+      testConfig()
+    );
+    await expect(restartedInstance.check("login", subject)).resolves.toMatchObject({ status: "blocked" });
+
+    now += 60_001;
+    await expect(restartedInstance.check("login", subject)).resolves.toMatchObject({ status: "allowed" });
+  });
+
+  it("sends only HMAC pseudonyms to the shared store", async () => {
+    const store = new SharedDeterministicStore(() => 1_000);
+    const limiter = new AuthRateLimiter(store, testConfig());
+
+    await limiter.check("forgotPassword", [
+      { dimension: "ip", value: "ipv4:198.51.100.42" },
+      { dimension: "identifier", value: "Person@Example.Test" },
+    ]);
+
+    expect(store.lastInputs).toHaveLength(2);
+    for (const input of store.lastInputs) {
+      expect(input.scope).toMatch(/^[a-z][a-z0-9:_-]{2,63}$/);
+      expect(input.subjectHash).toMatch(/^[0-9a-f]{64}$/);
+      expect(input.subjectHash).not.toContain("198.51.100.42");
+      expect(input.subjectHash).not.toContain("person@example.test");
+    }
+  });
+
+  it("returns the endpoint-specific fail-closed policy on store outage", async () => {
+    const store = new SharedDeterministicStore(() => 1_000);
+    store.fail = true;
+    const limiter = new AuthRateLimiter(store, testConfig());
+
+    await expect(
+      limiter.check("login", [{ dimension: "identifier", value: "operator" }])
+    ).resolves.toMatchObject({
+      status: "unavailable",
+      failurePolicy: "closed-error",
+      retryAfterSeconds: 17,
+    });
+    await expect(
+      limiter.check("forgotPassword", [{ dimension: "identifier", value: "operator" }])
+    ).resolves.toMatchObject({
+      status: "unavailable",
+      failurePolicy: "closed-generic",
+      retryAfterSeconds: 17,
+    });
+  });
+
+  it("supports the documented emergency disable switch without touching the store", async () => {
+    const store = new SharedDeterministicStore(() => 1_000);
+    store.fail = true;
+    const limiter = new AuthRateLimiter(store, testConfig({ enabled: false, hashKey: "disabled" }));
+
+    await expect(
+      limiter.check("login", [{ dimension: "identifier", value: "operator" }])
+    ).resolves.toEqual({ status: "allowed", endpoint: "login", disabled: true });
+  });
+});

--- a/src/__tests__/auth-rate-limit.service.test.ts
+++ b/src/__tests__/auth-rate-limit.service.test.ts
@@ -67,15 +67,23 @@ function testConfig(overrides: Partial<AuthRateLimitConfig> = {}): AuthRateLimit
     endpoints: {
       login: {
         failurePolicy: "closed-error",
-        dimensions: { identifier: { limit: 2, windowMs }, ip: { limit: 50, windowMs } },
+        dimensions: { username: { limit: 2, windowMs }, ip: { limit: 50, windowMs } },
       },
       register: {
         failurePolicy: "closed-error",
-        dimensions: { identifier: { limit: 2, windowMs }, ip: { limit: 2, windowMs } },
+        dimensions: {
+          username: { limit: 2, windowMs },
+          email: { limit: 2, windowMs },
+          ip: { limit: 2, windowMs },
+        },
       },
       forgotPassword: {
         failurePolicy: "closed-generic",
-        dimensions: { identifier: { limit: 2, windowMs }, ip: { limit: 2, windowMs } },
+        dimensions: {
+          username: { limit: 2, windowMs },
+          email: { limit: 2, windowMs },
+          ip: { limit: 2, windowMs },
+        },
       },
       resetPassword: {
         failurePolicy: "closed-error",
@@ -94,7 +102,7 @@ describe("distributed auth rate limiter", () => {
     const instanceBStore = new SharedDeterministicStore(() => now, sharedState);
     const instanceA = new AuthRateLimiter(instanceAStore, testConfig());
     const instanceB = new AuthRateLimiter(instanceBStore, testConfig());
-    const subject = [{ dimension: "identifier" as const, value: "operator@example.test" }];
+    const subject = [{ dimension: "username" as const, value: "operator" }];
 
     await expect(instanceA.check("login", subject)).resolves.toMatchObject({ status: "allowed" });
     await expect(instanceB.check("login", subject)).resolves.toMatchObject({ status: "allowed" });
@@ -119,7 +127,7 @@ describe("distributed auth rate limiter", () => {
 
     await limiter.check("forgotPassword", [
       { dimension: "ip", value: "ipv4:198.51.100.42" },
-      { dimension: "identifier", value: "Person@Example.Test" },
+      { dimension: "email", value: "Person@Example.Test" },
     ]);
 
     expect(store.lastInputs).toHaveLength(2);
@@ -137,14 +145,14 @@ describe("distributed auth rate limiter", () => {
     const limiter = new AuthRateLimiter(store, testConfig());
 
     await expect(
-      limiter.check("login", [{ dimension: "identifier", value: "operator" }])
+      limiter.check("login", [{ dimension: "username", value: "operator" }])
     ).resolves.toMatchObject({
       status: "unavailable",
       failurePolicy: "closed-error",
       retryAfterSeconds: 17,
     });
     await expect(
-      limiter.check("forgotPassword", [{ dimension: "identifier", value: "operator" }])
+      limiter.check("forgotPassword", [{ dimension: "username", value: "operator" }])
     ).resolves.toMatchObject({
       status: "unavailable",
       failurePolicy: "closed-generic",
@@ -158,7 +166,50 @@ describe("distributed auth rate limiter", () => {
     const limiter = new AuthRateLimiter(store, testConfig({ enabled: false, hashKey: "disabled" }));
 
     await expect(
-      limiter.check("login", [{ dimension: "identifier", value: "operator" }])
+      limiter.check("login", [{ dimension: "username", value: "operator" }])
     ).resolves.toEqual({ status: "allowed", endpoint: "login", disabled: true });
+  });
+
+  it.each([
+    ["stra\u00dfe", "STRASSE"],
+    ["u\u017fer", "USER"],
+    ["adm\u0131n", "ADMIN"],
+    ["o\ufb03ce", "OFFICE"],
+  ])("shares the username bucket for Unicode variant %s and %s", async (variant, canonical) => {
+    const store = new SharedDeterministicStore(() => 1_000);
+    const limiter = new AuthRateLimiter(store, testConfig());
+
+    await limiter.check("login", [{ dimension: "username", value: variant }]);
+    const variantHash = store.lastInputs[0]?.subjectHash;
+    await limiter.check("login", [{ dimension: "username", value: canonical }]);
+    const canonicalHash = store.lastInputs[0]?.subjectHash;
+
+    expect(variantHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(variantHash).toBe(canonicalHash);
+  });
+
+  it("shares the email bucket after NFKC, trim and lowercase", async () => {
+    const store = new SharedDeterministicStore(() => 1_000);
+    const limiter = new AuthRateLimiter(store, testConfig());
+
+    await limiter.check("register", [{ dimension: "email", value: " O\ufb03CE@Example.Test " }]);
+    const variantHash = store.lastInputs[0]?.subjectHash;
+    await limiter.check("register", [{ dimension: "email", value: "office@example.test" }]);
+
+    expect(store.lastInputs[0]?.subjectHash).toBe(variantHash);
+  });
+
+  it("keeps opaque reset-token case and whitespace in distinct buckets", async () => {
+    const store = new SharedDeterministicStore(() => 1_000);
+    const limiter = new AuthRateLimiter(store, testConfig());
+
+    const hashFor = async (token: string) => {
+      await limiter.check("resetPassword", [{ dimension: "token", value: token }]);
+      return store.lastInputs[0]?.subjectHash;
+    };
+
+    const exact = await hashFor("AbC-opaque-token");
+    expect(await hashFor("abc-opaque-token")).not.toBe(exact);
+    expect(await hashFor(" AbC-opaque-token ")).not.toBe(exact);
   });
 });

--- a/src/__tests__/auth.controller.test.ts
+++ b/src/__tests__/auth.controller.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, vi, beforeEach } from 'vitest'
 import { Request, Response } from 'express'
-import { register, login } from '../module/auth/controllers/auth.controller'
+import { forgotPassword, register, login } from '../module/auth/controllers/auth.controller'
 import { ZodError, ZodIssueCode } from "zod"
 
 // 🔧 Mocks
@@ -33,8 +33,10 @@ import * as mockedAuthService from '../module/auth/services/auth.service'
 
 const mockedRegisterParse = mockedRegisterValidator.registerSchema.parse as unknown as ReturnType<typeof vi.fn>
 const mockedLoginParse = mockedLoginValidator.loginSchema.parse as unknown as ReturnType<typeof vi.fn>
+const mockedForgotSafeParse = mockedLoginValidator.forgotPasswordSchema.safeParse as unknown as ReturnType<typeof vi.fn>
 const mockedRegisterUser = mockedAuthService.registerUser as unknown as ReturnType<typeof vi.fn>
 const mockedLoginUser = mockedAuthService.loginUser as unknown as ReturnType<typeof vi.fn>
+const mockedRequestPasswordReset = mockedAuthService.requestPasswordReset as unknown as ReturnType<typeof vi.fn>
 
 describe('🧪 auth.controller.ts', () => {
   let req: Partial<Request>
@@ -111,5 +113,30 @@ describe('🧪 auth.controller.ts', () => {
       token: 'fake-jwt',
       user: { id: 1, username: 'admin' }
     })
+  })
+
+  test('🔒 forgot-password conserve le message générique sans effet quand le middleware supprime l’action', async () => {
+    vi.useFakeTimers()
+    mockedForgotSafeParse.mockReturnValue({
+      success: true,
+      data: { usernameOrEmail: 'person@example.test' }
+    })
+    req = {
+      body: { usernameOrEmail: 'person@example.test' },
+      headers: {},
+      authRateLimit: { suppressAction: true, reason: 'blocked' },
+      originalUrl: '/api/v1/auth/forgot-password'
+    }
+
+    const pending = forgotPassword(req as Request, res as Response, vi.fn())
+    await vi.advanceTimersByTimeAsync(600)
+    await pending
+
+    expect(mockedRequestPasswordReset).not.toHaveBeenCalled()
+    expect(statusMock).toHaveBeenCalledWith(200)
+    expect(jsonMock).toHaveBeenCalledWith({
+      message: 'Si ce compte existe, un lien de réinitialisation a été envoyé.'
+    })
+    vi.useRealTimers()
   })
 })

--- a/src/__tests__/auth.routes.test.ts
+++ b/src/__tests__/auth.routes.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeAll, vi } from 'vitest'
 import request from 'supertest'
 
+const rateLimitMocks = vi.hoisted(() => ({
+  check: vi.fn(async (endpoint: string, _subjects?: unknown) => ({ status: 'allowed', endpoint, disabled: false })),
+}))
+
 // 🛑 Place les mocks AVANT d'importer app
 vi.mock('../module/auth/controllers/auth.controller', () => ({
   register: vi.fn((req, res) => res.status(201).json({ message: 'Utilisateur enregistré' })),
@@ -13,7 +17,7 @@ vi.mock('../module/auth/controllers/auth.controller', () => ({
 
 vi.mock('../module/auth/services/auth-rate-limit.service', () => ({
   authRateLimiter: {
-    check: vi.fn(async (endpoint: string) => ({ status: 'allowed', endpoint, disabled: false })),
+    check: rateLimitMocks.check,
   },
 }))
 
@@ -61,6 +65,20 @@ describe('🧪 Routes Authentification (/auth)', () => {
     expect(res.body).toHaveProperty('token')
   })
 
+  it('canonicalise les variantes Unicode du username avant le bucket login', async () => {
+    rateLimitMocks.check.mockClear()
+
+    await request(app)
+      .post('/api/v1/auth/login')
+      .send({ username: 'stra\u00dfe', password: 'password123' })
+      .expect(200)
+
+    expect(rateLimitMocks.check).toHaveBeenCalledWith(
+      'login',
+      expect.arrayContaining([{ dimension: 'username', value: 'STRASSE' }]),
+    )
+  })
+
   it('🔒 GET /api/v1/auth/me retourne les infos profil avec JWT + rôle', async () => {
     const res = await request(app)
       .get('/api/v1/auth/me')
@@ -82,6 +100,29 @@ describe('🧪 Routes Authentification (/auth)', () => {
     expect(res.body).toHaveProperty('message')
   })
 
+  it('forgot-password consomme username et email sans classifier le compte', async () => {
+    rateLimitMocks.check.mockClear()
+
+    const usernameResponse = await request(app)
+      .post('/api/v1/auth/forgot-password')
+      .send({ usernameOrEmail: 'adm\u0131n' })
+    const emailResponse = await request(app)
+      .post('/api/v1/auth/forgot-password')
+      .send({ usernameOrEmail: 'Person@Example.Test' })
+
+    expect([usernameResponse.status, usernameResponse.body]).toEqual([emailResponse.status, emailResponse.body])
+    const forgotCalls = rateLimitMocks.check.mock.calls.filter(([endpoint]) => endpoint === 'forgotPassword')
+    expect(forgotCalls).toHaveLength(2)
+    expect(forgotCalls[0]?.[1]).toEqual(expect.arrayContaining([
+      { dimension: 'username', value: 'ADMIN' },
+      { dimension: 'email', value: 'adm\u0131n' },
+    ]))
+    expect(forgotCalls[1]?.[1]).toEqual(expect.arrayContaining([
+      { dimension: 'username', value: 'PERSON@EXAMPLE.TEST' },
+      { dimension: 'email', value: 'person@example.test' },
+    ]))
+  })
+
   it('✅ POST /api/v1/auth/reset-password retourne 200', async () => {
     const res = await request(app)
       .post('/api/v1/auth/reset-password')
@@ -89,6 +130,21 @@ describe('🧪 Routes Authentification (/auth)', () => {
 
     expect(res.status).toBe(200)
     expect(res.body).toHaveProperty('message')
+  })
+
+  it('conserve le reset token opaque dans le bucket route', async () => {
+    rateLimitMocks.check.mockClear()
+    const token = ' AbC-opaque-token '
+
+    await request(app)
+      .post('/api/v1/auth/reset-password')
+      .send({ token, newPassword: 'P@ssw0rd-OK' })
+      .expect(200)
+
+    expect(rateLimitMocks.check).toHaveBeenCalledWith(
+      'resetPassword',
+      expect.arrayContaining([{ dimension: 'token', value: token }]),
+    )
   })
 
 //   it('🚫 GET /api/v1/auth/me refuse l’accès si rôle non autorisé', async () => {

--- a/src/__tests__/auth.routes.test.ts
+++ b/src/__tests__/auth.routes.test.ts
@@ -11,6 +11,12 @@ vi.mock('../module/auth/controllers/auth.controller', () => ({
   resetPassword: vi.fn((req, res) => res.status(200).json({ message: 'Mot de passe réinitialisé' })),
 }))
 
+vi.mock('../module/auth/services/auth-rate-limit.service', () => ({
+  authRateLimiter: {
+    check: vi.fn(async (endpoint: string) => ({ status: 'allowed', endpoint, disabled: false })),
+  },
+}))
+
 vi.mock('../module/auth/controllers/user.controller', () => ({
   getProfile: vi.fn((req, res) => res.status(200).json({ username: 'admin', role: 'Administrateur' })),
 }))

--- a/src/__tests__/auth.validator.test.ts
+++ b/src/__tests__/auth.validator.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { loginSchema } from "../module/auth/validators/auth.validator";
+import { loginSchema, resetPasswordSchema } from "../module/auth/validators/auth.validator";
+import { strictEmail } from "../module/auth/validators/_helpers";
 
 describe("auth login validator", () => {
   it("accepts the frontend database selector", () => {
@@ -47,5 +48,23 @@ describe("auth login validator", () => {
         unsafe: true,
       })
     ).toThrow();
+  });
+
+  it.each([
+    ["stra\u00dfe", "STRASSE"],
+    ["u\u017fer", "USER"],
+    ["adm\u0131n", "ADMIN"],
+    ["o\ufb03ce", "OFFICE"],
+  ])("uses the stored-account username canonical form for %s", (username, expected) => {
+    expect(loginSchema.parse({ username, password: "secret" }).username).toBe(expected);
+  });
+
+  it("normalizes email with NFKC and lowercase", () => {
+    expect(strictEmail.parse(" O\ufb03CE@Example.Test ")).toBe("office@example.test");
+  });
+
+  it("does not trim or case-fold an opaque reset token", () => {
+    const token = " AbC-opaque-token ";
+    expect(resetPasswordSchema.parse({ token, newPassword: "P@ssw0rd-OK" }).token).toBe(token);
   });
 });

--- a/src/__tests__/login-ratelimit.routes.test.ts
+++ b/src/__tests__/login-ratelimit.routes.test.ts
@@ -1,12 +1,34 @@
 import request from "supertest";
 import { describe, it, expect, vi } from "vitest";
 
+const rateLimitState = vi.hoisted(() => ({ loginChecks: 0 }));
+
 // Fichier isolé : les maps de rate-limit (module-level) sont fraîches dans ce worker vitest.
 vi.mock("pg", () => {
   const pool = { on: vi.fn(), query: vi.fn().mockResolvedValue({ rows: [] }), connect: vi.fn() };
   return { Pool: vi.fn(() => pool) };
 });
 vi.mock("../utils/checkNetworkDrive", () => ({ checkNetworkDrive: vi.fn(() => Promise.resolve()) }));
+vi.mock("../module/auth/services/auth.service", () => ({
+  loginUser: vi.fn(async (username: string) => ({
+    token: "test-token",
+    user: { id: 1, username },
+  })),
+  registerUser: vi.fn(),
+  requestPasswordReset: vi.fn(),
+  resetPasswordWithToken: vi.fn(),
+}));
+vi.mock("../module/auth/services/auth-rate-limit.service", () => ({
+  authRateLimiter: {
+    check: vi.fn(async (endpoint: string) => {
+      if (endpoint !== "login") return { status: "allowed", endpoint, disabled: false };
+      rateLimitState.loginChecks += 1;
+      return rateLimitState.loginChecks > 10
+        ? { status: "blocked", endpoint, retryAfterSeconds: 60 }
+        : { status: "allowed", endpoint, disabled: false };
+    }),
+  },
+}));
 
 import app from "../config/app";
 

--- a/src/config/app.ts
+++ b/src/config/app.ts
@@ -15,11 +15,12 @@ import { requestLogger } from "../middlewares/requestLogger";
 import { getImagesRootPath } from "../utils/imageStorage";
 import { stripQueryFromUrl } from "../utils/logPath";
 import pool from "./database";
+import { resolveTrustProxySetting } from "./trust-proxy";
 
 const app = express();
 
 // Reverse proxy (Nginx/Traefik) support: trust X-Forwarded-* headers.
-app.set("trust proxy", 1);
+app.set("trust proxy", resolveTrustProxySetting());
 
 /* ------------------ 1) Sécurité & CORS ------------------ */
 

--- a/src/config/auth-rate-limit.ts
+++ b/src/config/auth-rate-limit.ts
@@ -1,0 +1,188 @@
+export type AuthRateLimitEndpoint =
+  | "login"
+  | "register"
+  | "forgotPassword"
+  | "resetPassword";
+
+export type AuthRateLimitDimension = "ip" | "identifier" | "token";
+export type AuthRateLimitFailurePolicy = "closed-error" | "closed-generic";
+
+export type AuthRateLimitDimensionConfig = {
+  limit: number;
+  windowMs: number;
+};
+
+export type AuthRateLimitEndpointConfig = {
+  failurePolicy: AuthRateLimitFailurePolicy;
+  dimensions: Partial<Record<AuthRateLimitDimension, AuthRateLimitDimensionConfig>>;
+};
+
+export type AuthRateLimitConfig = {
+  enabled: boolean;
+  store: "postgres";
+  hashKey: string;
+  storeUnavailableRetryAfterSeconds: number;
+  cleanupIntervalMs: number;
+  retentionAfterExpiryMs: number;
+  endpoints: Record<AuthRateLimitEndpoint, AuthRateLimitEndpointConfig>;
+};
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const NON_PRODUCTION_HASH_KEY = "cerp-non-production-rate-limit-key-v1";
+
+function readBoolean(env: NodeJS.ProcessEnv, name: string, fallback: boolean): boolean {
+  const raw = env[name]?.trim().toLowerCase();
+  if (!raw) return fallback;
+  if (["1", "true", "yes", "on"].includes(raw)) return true;
+  if (["0", "false", "no", "off"].includes(raw)) return false;
+  throw new Error(`${name} must be a boolean`);
+}
+
+function readBoundedInteger(
+  env: NodeJS.ProcessEnv,
+  name: string,
+  fallback: number,
+  min: number,
+  max: number
+): number {
+  const raw = env[name]?.trim();
+  if (!raw) return fallback;
+  if (!/^\d+$/.test(raw)) throw new Error(`${name} must be an integer`);
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < min || parsed > max) {
+    throw new Error(`${name} must be between ${min} and ${max}`);
+  }
+  return parsed;
+}
+
+function readHashKey(env: NodeJS.ProcessEnv, enabled: boolean): string {
+  if (!enabled) return "disabled";
+
+  const configured = env.AUTH_RATE_LIMIT_HASH_KEY?.trim();
+  if (configured && configured.length >= 32) return configured;
+
+  if (env.NODE_ENV === "test") {
+    return NON_PRODUCTION_HASH_KEY;
+  }
+
+  throw new Error(
+    "AUTH_RATE_LIMIT_HASH_KEY must contain at least 32 characters when rate limiting is enabled outside tests"
+  );
+}
+
+function endpointConfig(
+  failurePolicy: AuthRateLimitFailurePolicy,
+  dimensions: AuthRateLimitEndpointConfig["dimensions"]
+): AuthRateLimitEndpointConfig {
+  return { failurePolicy, dimensions };
+}
+
+export function loadAuthRateLimitConfig(env: NodeJS.ProcessEnv = process.env): AuthRateLimitConfig {
+  const enabled = readBoolean(env, "AUTH_RATE_LIMIT_ENABLED", true);
+  const store = (env.AUTH_RATE_LIMIT_STORE ?? "postgres").trim().toLowerCase();
+  if (store !== "postgres") {
+    throw new Error("AUTH_RATE_LIMIT_STORE must be postgres");
+  }
+
+  const loginWindowMs = readBoundedInteger(
+    env,
+    "AUTH_RATE_LIMIT_LOGIN_WINDOW_MS",
+    15 * MINUTE_MS,
+    MINUTE_MS,
+    24 * HOUR_MS
+  );
+  const registerWindowMs = readBoundedInteger(
+    env,
+    "AUTH_RATE_LIMIT_REGISTER_WINDOW_MS",
+    HOUR_MS,
+    MINUTE_MS,
+    24 * HOUR_MS
+  );
+  const forgotWindowMs = readBoundedInteger(
+    env,
+    "AUTH_RATE_LIMIT_FORGOT_WINDOW_MS",
+    HOUR_MS,
+    MINUTE_MS,
+    24 * HOUR_MS
+  );
+  const resetWindowMs = readBoundedInteger(
+    env,
+    "AUTH_RATE_LIMIT_RESET_WINDOW_MS",
+    15 * MINUTE_MS,
+    MINUTE_MS,
+    24 * HOUR_MS
+  );
+
+  return {
+    enabled,
+    store: "postgres",
+    hashKey: readHashKey(env, enabled),
+    storeUnavailableRetryAfterSeconds: readBoundedInteger(
+      env,
+      "AUTH_RATE_LIMIT_STORE_RETRY_AFTER_SECONDS",
+      30,
+      1,
+      300
+    ),
+    cleanupIntervalMs: readBoundedInteger(
+      env,
+      "AUTH_RATE_LIMIT_CLEANUP_INTERVAL_MS",
+      15 * MINUTE_MS,
+      MINUTE_MS,
+      24 * HOUR_MS
+    ),
+    retentionAfterExpiryMs: readBoundedInteger(
+      env,
+      "AUTH_RATE_LIMIT_RETENTION_AFTER_EXPIRY_MS",
+      HOUR_MS,
+      0,
+      7 * 24 * HOUR_MS
+    ),
+    endpoints: {
+      login: endpointConfig("closed-error", {
+        ip: {
+          limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_LOGIN_IP_LIMIT", 50, 1, 10_000),
+          windowMs: loginWindowMs,
+        },
+        identifier: {
+          limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_LOGIN_IDENTIFIER_LIMIT", 10, 1, 10_000),
+          windowMs: loginWindowMs,
+        },
+      }),
+      register: endpointConfig("closed-error", {
+        ip: {
+          limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_REGISTER_IP_LIMIT", 10, 1, 10_000),
+          windowMs: registerWindowMs,
+        },
+        identifier: {
+          limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_REGISTER_IDENTIFIER_LIMIT", 3, 1, 10_000),
+          windowMs: registerWindowMs,
+        },
+      }),
+      forgotPassword: endpointConfig("closed-generic", {
+        ip: {
+          limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_FORGOT_IP_LIMIT", 20, 1, 10_000),
+          windowMs: forgotWindowMs,
+        },
+        identifier: {
+          limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_FORGOT_IDENTIFIER_LIMIT", 5, 1, 10_000),
+          windowMs: forgotWindowMs,
+        },
+      }),
+      resetPassword: endpointConfig("closed-error", {
+        ip: {
+          limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_RESET_IP_LIMIT", 30, 1, 10_000),
+          windowMs: resetWindowMs,
+        },
+        token: {
+          limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_RESET_TOKEN_LIMIT", 10, 1, 10_000),
+          windowMs: resetWindowMs,
+        },
+      }),
+    },
+  };
+}
+
+export const authRateLimitConfig = loadAuthRateLimitConfig();

--- a/src/config/auth-rate-limit.ts
+++ b/src/config/auth-rate-limit.ts
@@ -4,7 +4,7 @@ export type AuthRateLimitEndpoint =
   | "forgotPassword"
   | "resetPassword";
 
-export type AuthRateLimitDimension = "ip" | "identifier" | "token";
+export type AuthRateLimitDimension = "ip" | "username" | "email" | "token";
 export type AuthRateLimitFailurePolicy = "closed-error" | "closed-generic";
 
 export type AuthRateLimitDimensionConfig = {
@@ -146,7 +146,7 @@ export function loadAuthRateLimitConfig(env: NodeJS.ProcessEnv = process.env): A
           limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_LOGIN_IP_LIMIT", 50, 1, 10_000),
           windowMs: loginWindowMs,
         },
-        identifier: {
+        username: {
           limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_LOGIN_IDENTIFIER_LIMIT", 10, 1, 10_000),
           windowMs: loginWindowMs,
         },
@@ -156,7 +156,11 @@ export function loadAuthRateLimitConfig(env: NodeJS.ProcessEnv = process.env): A
           limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_REGISTER_IP_LIMIT", 10, 1, 10_000),
           windowMs: registerWindowMs,
         },
-        identifier: {
+        username: {
+          limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_REGISTER_IDENTIFIER_LIMIT", 3, 1, 10_000),
+          windowMs: registerWindowMs,
+        },
+        email: {
           limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_REGISTER_IDENTIFIER_LIMIT", 3, 1, 10_000),
           windowMs: registerWindowMs,
         },
@@ -166,7 +170,11 @@ export function loadAuthRateLimitConfig(env: NodeJS.ProcessEnv = process.env): A
           limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_FORGOT_IP_LIMIT", 20, 1, 10_000),
           windowMs: forgotWindowMs,
         },
-        identifier: {
+        username: {
+          limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_FORGOT_IDENTIFIER_LIMIT", 5, 1, 10_000),
+          windowMs: forgotWindowMs,
+        },
+        email: {
           limit: readBoundedInteger(env, "AUTH_RATE_LIMIT_FORGOT_IDENTIFIER_LIMIT", 5, 1, 10_000),
           windowMs: forgotWindowMs,
         },

--- a/src/config/trust-proxy.ts
+++ b/src/config/trust-proxy.ts
@@ -1,0 +1,11 @@
+export function resolveTrustProxySetting(env: NodeJS.ProcessEnv = process.env): false | number {
+  const raw = env.TRUST_PROXY_HOPS?.trim();
+  if (!raw) return 1;
+  if (!/^\d+$/.test(raw)) throw new Error("TRUST_PROXY_HOPS must be an integer between 0 and 5");
+
+  const hops = Number.parseInt(raw, 10);
+  if (!Number.isSafeInteger(hops) || hops < 0 || hops > 5) {
+    throw new Error("TRUST_PROXY_HOPS must be an integer between 0 and 5");
+  }
+  return hops === 0 ? false : hops;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import app from './config/app';
 import { createServer } from 'http';
 import { initSocketServer } from './sockets/sockeServer'
 import { startAuditNotifyListener } from "./shared/realtime/audit-notify.listener";
+import { startAuthRateLimitMaintenance } from "./module/auth/services/auth-rate-limit.service";
 
 
 dotenv.config();
@@ -11,6 +12,8 @@ const PORT = parseInt(process.env.PORT || '5000', 10);
 
 // 🛠 Serveur HTTP de base
 const httpServer = createServer(app);
+const stopAuthRateLimitMaintenance = startAuthRateLimitMaintenance();
+httpServer.on("close", stopAuthRateLimitMaintenance);
 
 // 🔌 Initialisation du serveur WebSocket
 initSocketServer(httpServer);

--- a/src/module/admin/repository/admin.repository.ts
+++ b/src/module/admin/repository/admin.repository.ts
@@ -5,6 +5,10 @@ import type { PoolClient } from "pg";
 
 import { HttpError } from "../../../utils/httpError";
 import { normalizeAssignedRoles } from "../../auth/domain/roles";
+import {
+  canonicalizeAuthEmail,
+  canonicalizeAuthUsername,
+} from "../../auth/domain/auth-identity";
 
 export type AdminUserListRow = {
   id: number;
@@ -310,11 +314,11 @@ export async function repoCreateUser(input: {
         RETURNING id::int AS id
       `,
       [
-        input.username,
+        canonicalizeAuthUsername(input.username),
         input.passwordHash,
         input.name,
         input.surname,
-        input.email,
+        canonicalizeAuthEmail(input.email),
         input.tel_no,
         input.role,
         input.gender,
@@ -412,10 +416,10 @@ export async function repoUpdateUser(
     return `$${values.length}`;
   };
 
-  if (patch.username !== undefined) sets.push(`username = ${push(patch.username)}`);
+  if (patch.username !== undefined) sets.push(`username = ${push(canonicalizeAuthUsername(patch.username))}`);
   if (patch.name !== undefined) sets.push(`name = ${push(patch.name)}`);
   if (patch.surname !== undefined) sets.push(`surname = ${push(patch.surname)}`);
-  if (patch.email !== undefined) sets.push(`email = ${push(patch.email)}`);
+  if (patch.email !== undefined) sets.push(`email = ${push(canonicalizeAuthEmail(patch.email))}`);
   if (patch.tel_no !== undefined) sets.push(`tel_no = ${push(patch.tel_no)}`);
   if (patch.role !== undefined) sets.push(`role = ${push(patch.role)}`);
   if (patch.gender !== undefined) sets.push(`gender = ${push(patch.gender)}`);

--- a/src/module/admin/validators/admin.validators.ts
+++ b/src/module/admin/validators/admin.validators.ts
@@ -5,6 +5,7 @@ import {
   ASSIGNABLE_USER_ROLES,
   PRIMARY_USER_ROLES,
 } from "../../auth/domain/roles";
+import { canonicalizeAuthUsername } from "../../auth/domain/auth-identity";
 
 const userIdParam = z
   .string({ required_error: "ID utilisateur requis", invalid_type_error: "ID utilisateur invalide" })
@@ -12,7 +13,7 @@ const userIdParam = z
   .regex(/^\d+$/, "ID utilisateur invalide");
 
 const usernameSchema = trimString(3, "Nom d'utilisateur requis (min 3 caractères)")
-  .transform((v) => v.toUpperCase())
+  .transform(canonicalizeAuthUsername)
   .refine((v) => /^[A-Z0-9._-]+$/.test(v), "Username: caractères autorisés A-Z 0-9 . _ -");
 
 const phoneFR = z

--- a/src/module/auth/controllers/auth.controller.ts
+++ b/src/module/auth/controllers/auth.controller.ts
@@ -28,17 +28,6 @@ export const login = asyncHandler(async (req: Request, res: Response) => {
   const device = parseDevice(user_agent);
 
   // Rate-limit anti-bruteforce (A.8.5) : par IP + identifiant, avant toute vérification.
-  const rateKey = normalizeIdentifier(username);
-  const rateLimited =
-    trackAndCheckRateLimit(loginRateByIp, ip, LOGIN_RATE_LIMIT, LOGIN_RATE_WINDOW_MS) ||
-    trackAndCheckRateLimit(loginRateByUsername, rateKey, LOGIN_RATE_LIMIT, LOGIN_RATE_WINDOW_MS);
-  if (rateLimited) {
-    return res.status(429).json({
-      error: "TOO_MANY_ATTEMPTS",
-      message: "Trop de tentatives de connexion. Réessayez dans quelques minutes.",
-    });
-  }
-
   const data = await loginUser(username, password, {
     ip,
     user_agent,
@@ -60,36 +49,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-type RateEntry = { count: number; resetAt: number };
-const resetRateByIp = new Map<string, RateEntry>();
-const resetRateByIdentifier = new Map<string, RateEntry>();
-const RESET_RATE_LIMIT = 5;
-const RESET_RATE_WINDOW_MS = 60 * 60 * 1000;
-
-// Anti-bruteforce login (ISO/IEC 27001 A.8.5) : limite les tentatives par IP et par identifiant.
-const loginRateByIp = new Map<string, RateEntry>();
-const loginRateByUsername = new Map<string, RateEntry>();
-const LOGIN_RATE_LIMIT = 10;
-const LOGIN_RATE_WINDOW_MS = 15 * 60 * 1000;
-
-function trackAndCheckRateLimit(map: Map<string, RateEntry>, key: string | null, limit: number, windowMs: number): boolean {
-  if (!key) return false;
-  const now = Date.now();
-  const existing = map.get(key);
-  if (!existing || now >= existing.resetAt) {
-    map.set(key, { count: 1, resetAt: now + windowMs });
-    return false;
-  }
-
-  const nextCount = existing.count + 1;
-  map.set(key, { count: nextCount, resetAt: existing.resetAt });
-  return nextCount > limit;
-}
-
-function normalizeIdentifier(value: string): string {
-  return value.trim().toLowerCase();
-}
-
 export const forgotPassword = asyncHandler(async (req: Request, res: Response) => {
   const startedAt = Date.now();
 
@@ -98,13 +57,9 @@ export const forgotPassword = asyncHandler(async (req: Request, res: Response) =
   const device = parseDevice(user_agent);
 
   const parsed = forgotPasswordSchema.safeParse(req.body);
-  const identifier = parsed.success ? normalizeIdentifier(parsed.data.usernameOrEmail) : null;
+  const suppressAction = req.authRateLimit?.suppressAction === true;
 
-  const limited =
-    trackAndCheckRateLimit(resetRateByIp, ip, RESET_RATE_LIMIT, RESET_RATE_WINDOW_MS) ||
-    trackAndCheckRateLimit(resetRateByIdentifier, identifier, RESET_RATE_LIMIT, RESET_RATE_WINDOW_MS);
-
-  if (!limited && parsed.success) {
+  if (!suppressAction && parsed.success) {
     // Fire-and-forget: we don't want email delivery or DB latency to become an enumeration side-channel.
     void requestPasswordReset(parsed.data.usernameOrEmail, {
       request_id: req.requestId ?? null,
@@ -120,7 +75,6 @@ export const forgotPassword = asyncHandler(async (req: Request, res: Response) =
           type: "password_reset_request_failed",
           requestId: req.requestId ?? null,
           path: req.originalUrl,
-          ip,
           error: e instanceof Error ? e.name : "unknown",
         })
       );

--- a/src/module/auth/domain/auth-identity.ts
+++ b/src/module/auth/domain/auth-identity.ts
@@ -1,0 +1,33 @@
+export type AuthIdentityType = "username" | "email";
+
+/**
+ * Usernames are stored and queried as uppercase ASCII after validation. NFKC
+ * must run first so compatibility characters (for example ligatures) and
+ * Unicode case variants resolve to the same stored account identity.
+ */
+export function canonicalizeAuthUsername(value: string): string {
+  return value.normalize("NFKC").trim().toUpperCase();
+}
+
+/** Email writes and lookups use the same NFKC, trim and lowercase contract. */
+export function canonicalizeAuthEmail(value: string): string {
+  return value.normalize("NFKC").trim().toLowerCase();
+}
+
+/**
+ * Reset tokens are opaque secrets. Do not trim, case-fold, normalize or
+ * otherwise rewrite them before hashing, lookup or abuse-control bucketing.
+ */
+export function preserveOpaqueAuthToken(value: string): string {
+  return value;
+}
+
+export function canonicalAuthIdentifierCandidates(value: string): ReadonlyArray<{
+  type: AuthIdentityType;
+  value: string;
+}> {
+  return [
+    { type: "username", value: canonicalizeAuthUsername(value) },
+    { type: "email", value: canonicalizeAuthEmail(value) },
+  ];
+}

--- a/src/module/auth/domain/auth-rate-limit.ts
+++ b/src/module/auth/domain/auth-rate-limit.ts
@@ -1,0 +1,39 @@
+import type {
+  AuthRateLimitDimension,
+  AuthRateLimitEndpoint,
+  AuthRateLimitFailurePolicy,
+} from "../../../config/auth-rate-limit";
+
+export type AuthRateLimitSubject = {
+  dimension: AuthRateLimitDimension;
+  value: string | null;
+};
+
+export type AuthRateLimitStoreInput = {
+  scope: string;
+  subjectHash: string;
+  windowMs: number;
+};
+
+export type AuthRateLimitStoreCounter = {
+  scope: string;
+  subjectHash: string;
+  count: number;
+  retryAfterSeconds: number;
+};
+
+export interface AuthRateLimitStore {
+  consume(inputs: readonly AuthRateLimitStoreInput[]): Promise<AuthRateLimitStoreCounter[]>;
+  deleteExpired(retentionAfterExpiryMs: number): Promise<number>;
+}
+
+export type AuthRateLimitDecision =
+  | { status: "allowed"; endpoint: AuthRateLimitEndpoint; disabled: boolean }
+  | { status: "blocked"; endpoint: AuthRateLimitEndpoint; retryAfterSeconds: number }
+  | {
+      status: "unavailable";
+      endpoint: AuthRateLimitEndpoint;
+      failurePolicy: AuthRateLimitFailurePolicy;
+      retryAfterSeconds: number;
+      errorName: string;
+    };

--- a/src/module/auth/middlewares/auth-rate-limit.middleware.ts
+++ b/src/module/auth/middlewares/auth-rate-limit.middleware.ts
@@ -1,0 +1,119 @@
+import type { Request, RequestHandler } from "express";
+
+import type { AuthRateLimitEndpoint } from "../../../config/auth-rate-limit";
+import type { AuthRateLimitSubject } from "../domain/auth-rate-limit";
+import { authRateLimiter, type AuthRateLimiter } from "../services/auth-rate-limit.service";
+import { getRateLimitClientAddress } from "../../../utils/requestMeta";
+
+declare global {
+  namespace Express {
+    interface Request {
+      authRateLimit?: {
+        suppressAction: boolean;
+        reason: "blocked" | "store-unavailable";
+      };
+    }
+  }
+}
+
+type SubjectFactory = (req: Request) => readonly AuthRateLimitSubject[];
+
+const GENERIC_RATE_LIMIT_MESSAGE = "Trop de tentatives. Réessayez plus tard.";
+const GENERIC_UNAVAILABLE_MESSAGE = "Service d'authentification temporairement indisponible.";
+
+function bodyString(req: Request, field: string): string | null {
+  const body = req.body as Record<string, unknown> | null | undefined;
+  const value = body?.[field];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed ? trimmed.slice(0, 512) : null;
+}
+
+function safeRequestId(req: Request): string | null {
+  const value = req.requestId;
+  return value && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value)
+    ? value
+    : null;
+}
+
+function subjectsFor(endpoint: AuthRateLimitEndpoint, req: Request): AuthRateLimitSubject[] {
+  const ip: AuthRateLimitSubject = { dimension: "ip", value: getRateLimitClientAddress(req) };
+  switch (endpoint) {
+    case "login":
+      return [ip, { dimension: "identifier", value: bodyString(req, "username") }];
+    case "register":
+      return [
+        ip,
+        { dimension: "identifier", value: bodyString(req, "username") },
+        { dimension: "identifier", value: bodyString(req, "email") },
+      ];
+    case "forgotPassword":
+      return [ip, { dimension: "identifier", value: bodyString(req, "usernameOrEmail") }];
+    case "resetPassword":
+      return [ip, { dimension: "token", value: bodyString(req, "token") }];
+  }
+}
+
+function logDecision(req: Request, endpoint: AuthRateLimitEndpoint, event: Record<string, unknown>) {
+  console.warn(
+    JSON.stringify({
+      type: "auth_rate_limit",
+      endpoint,
+      requestId: safeRequestId(req),
+      store: "postgres",
+      ...event,
+    })
+  );
+}
+
+export function createAuthRateLimitMiddleware(
+  endpoint: AuthRateLimitEndpoint,
+  limiter: Pick<AuthRateLimiter, "check"> = authRateLimiter,
+  subjectFactory: SubjectFactory = (req) => subjectsFor(endpoint, req)
+): RequestHandler {
+  return async (req, res, next) => {
+    const decision = await limiter.check(endpoint, subjectFactory(req));
+    if (decision.status === "allowed") return next();
+
+    if (decision.status === "blocked") {
+      logDecision(req, endpoint, {
+        outcome: "blocked",
+        retryAfterSeconds: decision.retryAfterSeconds,
+      });
+
+      if (endpoint === "forgotPassword") {
+        req.authRateLimit = { suppressAction: true, reason: "blocked" };
+        return next();
+      }
+
+      res.setHeader("Retry-After", String(decision.retryAfterSeconds));
+      return res.status(429).json({
+        error: "TOO_MANY_ATTEMPTS",
+        message: GENERIC_RATE_LIMIT_MESSAGE,
+      });
+    }
+
+    logDecision(req, endpoint, {
+      outcome: "store_unavailable",
+      policy: decision.failurePolicy,
+      retryAfterSeconds: decision.retryAfterSeconds,
+      error: decision.errorName,
+    });
+
+    if (decision.failurePolicy === "closed-generic") {
+      req.authRateLimit = { suppressAction: true, reason: "store-unavailable" };
+      return next();
+    }
+
+    res.setHeader("Retry-After", String(decision.retryAfterSeconds));
+    return res.status(503).json({
+      error: "AUTH_TEMPORARILY_UNAVAILABLE",
+      message: GENERIC_UNAVAILABLE_MESSAGE,
+    });
+  };
+}
+
+export const registerRateLimit = createAuthRateLimitMiddleware("register");
+export const loginRateLimit = createAuthRateLimitMiddleware("login");
+export const forgotPasswordRateLimit = createAuthRateLimitMiddleware("forgotPassword");
+export const resetPasswordRateLimit = createAuthRateLimitMiddleware("resetPassword");

--- a/src/module/auth/middlewares/auth-rate-limit.middleware.ts
+++ b/src/module/auth/middlewares/auth-rate-limit.middleware.ts
@@ -4,6 +4,12 @@ import type { AuthRateLimitEndpoint } from "../../../config/auth-rate-limit";
 import type { AuthRateLimitSubject } from "../domain/auth-rate-limit";
 import { authRateLimiter, type AuthRateLimiter } from "../services/auth-rate-limit.service";
 import { getRateLimitClientAddress } from "../../../utils/requestMeta";
+import {
+  canonicalAuthIdentifierCandidates,
+  canonicalizeAuthEmail,
+  canonicalizeAuthUsername,
+  preserveOpaqueAuthToken,
+} from "../domain/auth-identity";
 
 declare global {
   namespace Express {
@@ -24,9 +30,7 @@ const GENERIC_UNAVAILABLE_MESSAGE = "Service d'authentification temporairement i
 function bodyString(req: Request, field: string): string | null {
   const body = req.body as Record<string, unknown> | null | undefined;
   const value = body?.[field];
-  if (typeof value !== "string") return null;
-  const trimmed = value.trim();
-  return trimmed ? trimmed.slice(0, 512) : null;
+  return typeof value === "string" ? value : null;
 }
 
 function safeRequestId(req: Request): string | null {
@@ -39,18 +43,45 @@ function safeRequestId(req: Request): string | null {
 function subjectsFor(endpoint: AuthRateLimitEndpoint, req: Request): AuthRateLimitSubject[] {
   const ip: AuthRateLimitSubject = { dimension: "ip", value: getRateLimitClientAddress(req) };
   switch (endpoint) {
-    case "login":
-      return [ip, { dimension: "identifier", value: bodyString(req, "username") }];
-    case "register":
+    case "login": {
+      const username = bodyString(req, "username");
       return [
         ip,
-        { dimension: "identifier", value: bodyString(req, "username") },
-        { dimension: "identifier", value: bodyString(req, "email") },
+        { dimension: "username", value: username === null ? null : canonicalizeAuthUsername(username) },
       ];
-    case "forgotPassword":
-      return [ip, { dimension: "identifier", value: bodyString(req, "usernameOrEmail") }];
-    case "resetPassword":
-      return [ip, { dimension: "token", value: bodyString(req, "token") }];
+    }
+    case "register": {
+      const username = bodyString(req, "username");
+      const email = bodyString(req, "email");
+      return [
+        ip,
+        { dimension: "username", value: username === null ? null : canonicalizeAuthUsername(username) },
+        { dimension: "email", value: email === null ? null : canonicalizeAuthEmail(email) },
+      ];
+    }
+    case "forgotPassword": {
+      const identifier = bodyString(req, "usernameOrEmail");
+      const candidates = identifier === null
+        ? [
+            { type: "username" as const, value: null },
+            { type: "email" as const, value: null },
+          ]
+        : canonicalAuthIdentifierCandidates(identifier);
+      return [
+        ip,
+        ...candidates.map((candidate) => ({
+          dimension: candidate.type,
+          value: candidate.value,
+        })),
+      ];
+    }
+    case "resetPassword": {
+      const token = bodyString(req, "token");
+      return [
+        ip,
+        { dimension: "token", value: token === null ? null : preserveOpaqueAuthToken(token) },
+      ];
+    }
   }
 }
 

--- a/src/module/auth/repository/auth-rate-limit.repository.ts
+++ b/src/module/auth/repository/auth-rate-limit.repository.ts
@@ -1,0 +1,114 @@
+import type { QueryResult } from "pg";
+
+import pool from "../../../config/database";
+import type {
+  AuthRateLimitStore,
+  AuthRateLimitStoreCounter,
+  AuthRateLimitStoreInput,
+} from "../domain/auth-rate-limit";
+
+type Queryable = {
+  query<T extends Record<string, unknown>>(
+    sql: string,
+    values?: readonly unknown[]
+  ): Promise<QueryResult<T>>;
+};
+
+type CounterRow = {
+  scope: string;
+  subject_hash: string;
+  request_count: number | string;
+  retry_after_seconds: number | string;
+};
+
+export class PostgresAuthRateLimitStore implements AuthRateLimitStore {
+  constructor(private readonly queryable: Queryable = pool) {}
+
+  async consume(inputs: readonly AuthRateLimitStoreInput[]): Promise<AuthRateLimitStoreCounter[]> {
+    if (inputs.length === 0) return [];
+
+    const values: unknown[] = [];
+    const tuples = inputs.map((input) => {
+      values.push(input.scope, input.subjectHash, input.windowMs);
+      const offset = values.length - 2;
+      return `($${offset}::text, $${offset + 1}::text, $${offset + 2}::bigint)`;
+    });
+
+    const result = await this.queryable.query<CounterRow>(
+      `
+        WITH input(scope, subject_hash, window_ms) AS (
+          VALUES ${tuples.join(", ")}
+        ), upserted AS (
+          INSERT INTO public.auth_rate_limit_buckets (
+            scope,
+            subject_hash,
+            request_count,
+            window_started_at,
+            expires_at,
+            updated_at
+          )
+          SELECT
+            input.scope,
+            input.subject_hash,
+            1,
+            statement_timestamp(),
+            statement_timestamp() + (input.window_ms * INTERVAL '1 millisecond'),
+            statement_timestamp()
+          FROM input
+          ON CONFLICT (scope, subject_hash) DO UPDATE
+          SET
+            request_count = CASE
+              WHEN public.auth_rate_limit_buckets.expires_at <= statement_timestamp() THEN 1
+              ELSE public.auth_rate_limit_buckets.request_count + 1
+            END,
+            window_started_at = CASE
+              WHEN public.auth_rate_limit_buckets.expires_at <= statement_timestamp()
+                THEN EXCLUDED.window_started_at
+              ELSE public.auth_rate_limit_buckets.window_started_at
+            END,
+            expires_at = CASE
+              WHEN public.auth_rate_limit_buckets.expires_at <= statement_timestamp()
+                THEN EXCLUDED.expires_at
+              ELSE public.auth_rate_limit_buckets.expires_at
+            END,
+            updated_at = statement_timestamp()
+          RETURNING scope, subject_hash, request_count, expires_at
+        )
+        SELECT
+          scope,
+          subject_hash,
+          request_count,
+          GREATEST(
+            1,
+            CEIL(EXTRACT(EPOCH FROM (expires_at - statement_timestamp())))::int
+          ) AS retry_after_seconds
+        FROM upserted
+      `,
+      values
+    );
+
+    if (result.rows.length !== inputs.length) {
+      throw new Error("AUTH_RATE_LIMIT_STORE_INCOMPLETE_RESULT");
+    }
+
+    return result.rows.map((row) => ({
+      scope: row.scope,
+      subjectHash: row.subject_hash,
+      count: Number(row.request_count),
+      retryAfterSeconds: Number(row.retry_after_seconds),
+    }));
+  }
+
+  async deleteExpired(retentionAfterExpiryMs: number): Promise<number> {
+    const result = await this.queryable.query(
+      `
+        DELETE FROM public.auth_rate_limit_buckets
+        WHERE expires_at < statement_timestamp() - ($1::bigint * INTERVAL '1 millisecond')
+      `,
+      [retentionAfterExpiryMs]
+    );
+    return result.rowCount ?? 0;
+  }
+}
+
+export const authRateLimitStore = new PostgresAuthRateLimitStore();

--- a/src/module/auth/repository/auth.repository.ts
+++ b/src/module/auth/repository/auth.repository.ts
@@ -1,5 +1,9 @@
 import pool from '../../../config/database';
 import { CreateUserDTO } from '../types/user.type';
+import {
+  canonicalizeAuthEmail,
+  canonicalizeAuthUsername,
+} from '../domain/auth-identity';
 
 export const createUser = async (user: CreateUserDTO, hashedPassword: string) => {
   const client = await pool.connect();
@@ -9,6 +13,8 @@ export const createUser = async (user: CreateUserDTO, hashedPassword: string) =>
       house_no, postcode, country = 'France', salary = 0,
       date_of_birth, role = 'Utilisateur', social_security_number
     } = user;
+    const canonicalUsername = canonicalizeAuthUsername(username);
+    const canonicalEmail = canonicalizeAuthEmail(email);
 
     const result = await client.query(
       `INSERT INTO users (
@@ -19,7 +25,7 @@ export const createUser = async (user: CreateUserDTO, hashedPassword: string) =>
         $9, $10, $11, $12, $13, $14, $15, $16
       ) RETURNING id, username, email, role;`,
       [
-        username, hashedPassword, name, surname, email, tel_no, gender, address,
+        canonicalUsername, hashedPassword, name, surname, canonicalEmail, tel_no, gender, address,
         lane, house_no, postcode, country, salary, date_of_birth, role, social_security_number
       ]
     );
@@ -32,6 +38,7 @@ export const createUser = async (user: CreateUserDTO, hashedPassword: string) =>
 
 // 🔍 Cherche un utilisateur par email
 export const findUserByUsername = async (username: string) => {
+  const canonicalUsername = canonicalizeAuthUsername(username);
   const client = await pool.connect();
   try {
     const result = await client.query(
@@ -49,7 +56,7 @@ export const findUserByUsername = async (username: string) => {
         GROUP BY u.id
         LIMIT 1
       `,
-      [username]
+      [canonicalUsername]
     );
     return result.rows[0]; // undefined si pas trouvé
   } finally {
@@ -65,11 +72,12 @@ export type AuthUserLookupRow = {
 };
 
 export const findUserByUsernameOrEmail = async (usernameOrEmail: string): Promise<AuthUserLookupRow | null> => {
-  const raw = typeof usernameOrEmail === "string" ? usernameOrEmail.trim() : "";
+  const raw = typeof usernameOrEmail === "string" ? usernameOrEmail : "";
   if (!raw) return null;
 
-  const normalizedUsername = raw.toUpperCase();
-  const normalizedEmail = raw.toLowerCase();
+  const normalizedUsername = canonicalizeAuthUsername(raw);
+  const normalizedEmail = canonicalizeAuthEmail(raw);
+  if (!normalizedUsername && !normalizedEmail) return null;
 
   const client = await pool.connect();
   try {

--- a/src/module/auth/routes/auth.routes.ts
+++ b/src/module/auth/routes/auth.routes.ts
@@ -7,13 +7,19 @@ import {
 import {asyncHandler} from '../../../utils/asyncHandler';
 import { getProfile } from '../controllers/user.controller';
 import { getAccessProfile } from '../../access-control/controllers/access-control.controller';
+import {
+  forgotPasswordRateLimit,
+  loginRateLimit,
+  registerRateLimit,
+  resetPasswordRateLimit,
+} from '../middlewares/auth-rate-limit.middleware';
 
 const router: Router = Router();
 
-router.post('/register', register);
-router.post('/login', login);
-router.post('/forgot-password', forgotPassword);
-router.post('/reset-password', resetPassword);
+router.post('/register', registerRateLimit, register);
+router.post('/login', loginRateLimit, login);
+router.post('/forgot-password', forgotPasswordRateLimit, forgotPassword);
+router.post('/reset-password', resetPasswordRateLimit, resetPassword);
 router.get(
   '/me',
   authenticateToken,

--- a/src/module/auth/services/auth-rate-limit.service.ts
+++ b/src/module/auth/services/auth-rate-limit.service.ts
@@ -1,0 +1,127 @@
+import crypto from "node:crypto";
+
+import {
+  authRateLimitConfig,
+  type AuthRateLimitConfig,
+  type AuthRateLimitEndpoint,
+} from "../../../config/auth-rate-limit";
+import type {
+  AuthRateLimitDecision,
+  AuthRateLimitStore,
+  AuthRateLimitStoreInput,
+  AuthRateLimitSubject,
+} from "../domain/auth-rate-limit";
+import { authRateLimitStore } from "../repository/auth-rate-limit.repository";
+
+function normalizeSubject(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function safeErrorName(error: unknown): string {
+  if (!(error instanceof Error)) return "UnknownError";
+  return /^[A-Za-z0-9_.-]{1,80}$/.test(error.name) ? error.name : "Error";
+}
+
+function scopeEndpoint(endpoint: AuthRateLimitEndpoint): string {
+  return endpoint.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`);
+}
+
+export class AuthRateLimiter {
+  constructor(
+    private readonly store: AuthRateLimitStore,
+    private readonly config: AuthRateLimitConfig
+  ) {}
+
+  async check(
+    endpoint: AuthRateLimitEndpoint,
+    subjects: readonly AuthRateLimitSubject[]
+  ): Promise<AuthRateLimitDecision> {
+    if (!this.config.enabled) return { status: "allowed", endpoint, disabled: true };
+
+    const endpointConfig = this.config.endpoints[endpoint];
+    const inputs: AuthRateLimitStoreInput[] = [];
+    const limits: number[] = [];
+
+    for (const subject of subjects) {
+      const value = subject.value ? normalizeSubject(subject.value) : "";
+      const dimensionConfig = endpointConfig.dimensions[subject.dimension];
+      if (!value || !dimensionConfig) continue;
+
+      const scope = `auth:${scopeEndpoint(endpoint)}:${subject.dimension}`;
+      const subjectHash = crypto
+        .createHmac("sha256", this.config.hashKey)
+        .update(`v1\0${scope}\0${value}`, "utf8")
+        .digest("hex");
+
+      if (!inputs.some((input) => input.scope === scope && input.subjectHash === subjectHash)) {
+        inputs.push({ scope, subjectHash, windowMs: dimensionConfig.windowMs });
+        limits.push(dimensionConfig.limit);
+      }
+    }
+
+    if (inputs.length === 0) return { status: "allowed", endpoint, disabled: false };
+
+    try {
+      const counters = await this.store.consume(inputs);
+      const completeResult = inputs.every((input) =>
+        counters.some(
+          (counter) => counter.scope === input.scope && counter.subjectHash === input.subjectHash
+        )
+      );
+      if (!completeResult) throw new Error("AUTH_RATE_LIMIT_STORE_INCOMPLETE_RESULT");
+
+      let retryAfterSeconds = 0;
+      let blocked = false;
+
+      for (const counter of counters) {
+        const inputIndex = inputs.findIndex(
+          (input) => input.scope === counter.scope && input.subjectHash === counter.subjectHash
+        );
+        const limit = inputIndex >= 0 ? limits[inputIndex] : undefined;
+        if (counter && typeof limit === "number" && counter.count > limit) {
+          blocked = true;
+          retryAfterSeconds = Math.max(retryAfterSeconds, counter.retryAfterSeconds);
+        }
+      }
+
+      return blocked
+        ? { status: "blocked", endpoint, retryAfterSeconds: Math.max(1, retryAfterSeconds) }
+        : { status: "allowed", endpoint, disabled: false };
+    } catch (error) {
+      return {
+        status: "unavailable",
+        endpoint,
+        failurePolicy: endpointConfig.failurePolicy,
+        retryAfterSeconds: this.config.storeUnavailableRetryAfterSeconds,
+        errorName: safeErrorName(error),
+      };
+    }
+  }
+}
+
+export const authRateLimiter = new AuthRateLimiter(authRateLimitStore, authRateLimitConfig);
+
+export function startAuthRateLimitMaintenance(
+  store: AuthRateLimitStore = authRateLimitStore,
+  config: AuthRateLimitConfig = authRateLimitConfig
+): () => void {
+  if (!config.enabled) return () => undefined;
+
+  const run = async () => {
+    try {
+      await store.deleteExpired(config.retentionAfterExpiryMs);
+    } catch (error) {
+      console.warn(
+        JSON.stringify({
+          type: "auth_rate_limit_cleanup_failed",
+          store: config.store,
+          error: safeErrorName(error),
+        })
+      );
+    }
+  };
+
+  const timer = setInterval(() => void run(), config.cleanupIntervalMs);
+  timer.unref();
+  return () => clearInterval(timer);
+}

--- a/src/module/auth/services/auth-rate-limit.service.ts
+++ b/src/module/auth/services/auth-rate-limit.service.ts
@@ -12,9 +12,24 @@ import type {
   AuthRateLimitSubject,
 } from "../domain/auth-rate-limit";
 import { authRateLimitStore } from "../repository/auth-rate-limit.repository";
+import {
+  canonicalizeAuthEmail,
+  canonicalizeAuthUsername,
+  preserveOpaqueAuthToken,
+} from "../domain/auth-identity";
 
-function normalizeSubject(value: string): string {
-  return value.trim().toLowerCase();
+function canonicalizeSubject(subject: AuthRateLimitSubject): string {
+  if (subject.value === null) return "";
+  switch (subject.dimension) {
+    case "username":
+      return canonicalizeAuthUsername(subject.value);
+    case "email":
+      return canonicalizeAuthEmail(subject.value);
+    case "token":
+      return preserveOpaqueAuthToken(subject.value);
+    case "ip":
+      return subject.value;
+  }
 }
 
 function safeErrorName(error: unknown): string {
@@ -43,7 +58,7 @@ export class AuthRateLimiter {
     const limits: number[] = [];
 
     for (const subject of subjects) {
-      const value = subject.value ? normalizeSubject(subject.value) : "";
+      const value = canonicalizeSubject(subject);
       const dimensionConfig = endpointConfig.dimensions[subject.dimension];
       if (!value || !dimensionConfig) continue;
 

--- a/src/module/auth/services/auth.service.ts
+++ b/src/module/auth/services/auth.service.ts
@@ -21,6 +21,10 @@ import {
 import { sendPasswordResetEmail } from "./password-reset-email.service";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import { authorizationRole, normalizeAssignedRoles } from "../domain/roles";
+import {
+  canonicalizeAuthUsername,
+  preserveOpaqueAuthToken,
+} from "../domain/auth-identity";
 
 export const registerUser = async (data: CreateUserDTO) => {
   // 🔐 Hash du mot de passe
@@ -43,7 +47,7 @@ export const loginUser = async (
     browser: string | null;
   }
 ) => {
-  const normalizedUsername = username.trim().toUpperCase();
+  const normalizedUsername = canonicalizeAuthUsername(username);
 
   const user = await findUserByUsername(normalizedUsername);
 
@@ -251,7 +255,7 @@ export async function resetPasswordWithToken(
     browser: string | null;
   }
 ) {
-  const token_hash = sha256Hex(token);
+  const token_hash = sha256Hex(preserveOpaqueAuthToken(token));
   const client = await pool.connect();
 
   try {

--- a/src/module/auth/validators/_helpers.ts
+++ b/src/module/auth/validators/_helpers.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { canonicalizeAuthEmail } from "../domain/auth-identity";
 
 export const trimString = (min: number, message: string) =>
   z.string({ required_error: message, invalid_type_error: message })
@@ -7,9 +8,8 @@ export const trimString = (min: number, message: string) =>
 
 export const strictEmail = z
   .string({ required_error: "Email requis", invalid_type_error: "Email invalide" })
-  .trim()
-  .toLowerCase()
-  .email("Email invalide");
+  .transform(canonicalizeAuthEmail)
+  .pipe(z.string().email("Email invalide"));
 
 export const strongPassword = z
   .string({ required_error: "Mot de passe requis", invalid_type_error: "Mot de passe invalide" })

--- a/src/module/auth/validators/auth.validator.ts
+++ b/src/module/auth/validators/auth.validator.ts
@@ -1,10 +1,14 @@
 import { z } from "zod";
 import { trimString } from "./_helpers";
 import { strongPasswordReset } from "./_helpers";
+import {
+  canonicalizeAuthUsername,
+  preserveOpaqueAuthToken,
+} from "../domain/auth-identity";
 
 export const loginSchema = z.object({
   username: trimString(3, "Nom d'utilisateur requis (min 3 caractères)")
-    .transform(v => v.toUpperCase()), // si tu veux forcer "UTILISATEUR" style ERP
+    .transform(canonicalizeAuthUsername),
   password: z
     .string({ required_error: "Mot de passe requis" })
     .min(1, "Mot de passe requis"),
@@ -25,9 +29,9 @@ export const resetPasswordSchema = z
   .object({
     token: z
       .string({ required_error: "Token requis" })
-      .trim()
       .min(1, "Token requis")
-      .max(256, "Token invalide"),
+      .max(256, "Token invalide")
+      .transform(preserveOpaqueAuthToken),
     newPassword: strongPasswordReset,
   })
   .strict();

--- a/src/module/auth/validators/user.validator.ts
+++ b/src/module/auth/validators/user.validator.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { isoDate, strictEmail, strongPassword, trimString } from "./_helpers";
 import { PRIMARY_USER_ROLES } from "../domain/roles";
+import { canonicalizeAuthUsername } from "../domain/auth-identity";
 
 export const roles = PRIMARY_USER_ROLES;
 
@@ -20,7 +21,7 @@ const phoneFR = z
 
 export const registerSchema = z.object({
   username: trimString(3, "Nom d'utilisateur requis (min 3 caractères)")
-    .transform(v => v.toUpperCase())
+    .transform(canonicalizeAuthUsername)
     .refine(v => /^[A-Z0-9._-]+$/.test(v), "Username: caractères autorisés A-Z 0-9 . _ -"),
 
   password: strongPassword,

--- a/src/utils/requestMeta.ts
+++ b/src/utils/requestMeta.ts
@@ -1,8 +1,69 @@
 import type { Request } from "express";
+import net from "node:net";
 
 export function getClientIp(req: Request): string | null {
   // Avec trust proxy, req.ip est ok
   return req.ip || (req.socket?.remoteAddress ?? null);
+}
+
+function canonicalIpv6Groups(value: string): number[] | null {
+  try {
+    const hostname = new URL(`http://[${value}]/`).hostname;
+    const canonical = hostname.slice(1, -1);
+    const parts = canonical.split("::");
+    if (parts.length > 2) return null;
+
+    const left = parts[0] ? parts[0].split(":") : [];
+    const right = parts[1] ? parts[1].split(":") : [];
+    const missing = 8 - left.length - right.length;
+    if (missing < 0 || (parts.length === 1 && missing !== 0)) return null;
+
+    const groups = [
+      ...left,
+      ...Array.from({ length: missing }, () => "0"),
+      ...right,
+    ].map((part) => Number.parseInt(part || "0", 16));
+
+    return groups.length === 8 && groups.every((group) => Number.isInteger(group) && group >= 0 && group <= 0xffff)
+      ? groups
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Produces a stable abuse-prevention subject, not a value suitable for logs.
+ * IPv4-mapped IPv6 addresses collapse to IPv4 and native IPv6 addresses are
+ * grouped by /64 so alternate textual forms and privacy addresses share a key.
+ */
+export function canonicalizeRateLimitClientAddress(value: string | null): string | null {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+
+  const withoutZone = trimmed.split("%", 1)[0] ?? "";
+  if (net.isIPv4(withoutZone)) {
+    return `ipv4:${withoutZone.split(".").map((part) => Number.parseInt(part, 10)).join(".")}`;
+  }
+  if (!net.isIPv6(withoutZone)) return null;
+
+  const groups = canonicalIpv6Groups(withoutZone);
+  if (!groups) return null;
+
+  const isIpv4Mapped = groups.slice(0, 5).every((group) => group === 0) && groups[5] === 0xffff;
+  if (isIpv4Mapped) {
+    const high = groups[6] ?? 0;
+    const low = groups[7] ?? 0;
+    const ipv4 = [high >> 8, high & 0xff, low >> 8, low & 0xff].join(".");
+    return `ipv4:${ipv4}`;
+  }
+
+  const prefix = groups.slice(0, 4).map((group) => group.toString(16)).join(":");
+  return `ipv6:${prefix}::/64`;
+}
+
+export function getRateLimitClientAddress(req: Request): string | null {
+  return canonicalizeRateLimitClientAddress(getClientIp(req));
 }
 
 export function parseDevice(userAgent?: string | null) {


### PR DESCRIPTION
## What

- replace process-local authentication throttles with atomic PostgreSQL-backed counters shared by every backend instance
- cover login, registration, forgotten-password, and password-reset flows with identifier and network dimensions
- pseudonymize all limiter subjects with HMAC-SHA-256, canonicalize IPv4/IPv6 addresses (IPv6 `/64`), and make proxy trust explicit
- add guarded preflight/apply/verify/rollback SQL, an ADR, the security policy, and an operational runbook

## Why

The previous login and forgotten-password limits lived in module-level `Map` objects. They reset on process restart and were not shared across replicas. Registration and password reset also had no equivalent distributed protection.

Task: `SEC-CERP-0005`

## Behavior and failure policy

- login and registration: deny with generic `429` when limited; fail closed with generic `503` if the store is unavailable
- forgotten-password: keep the enumeration-safe generic `200` response while suppressing the side effect when limited or when the store is unavailable
- password reset: deny with generic `429` when limited; fail closed with generic `503` if the store is unavailable
- an emergency `AUTH_RATE_LIMIT_ENABLED=false` switch is documented; production configuration otherwise requires a shared HMAC key of at least 32 characters

## Deployment impact

Apply and verify `20260804_auth_rate_limit_buckets.sql`, configure the same `AUTH_RATE_LIMIT_HMAC_KEY` on all backend instances, and then deploy the application. The table is intentionally retained during application rollback and may be removed later with the guarded rollback script.

No production database or external service was accessed while preparing this change. The frontend contract already handles the generic `429`/`503` responses, so no frontend change is required.

## Validation

- `npm run build`
- `npm run test:collection`: 197 test files; manifest SHA-256 `1474ab8d04ae76b116632aecd0beea7863c49409ebd5038ef50934a3cba6df3c`
- full Vitest gate: 735 suites, 3,782 tests, 0 failures
- targeted rate-limit/config/repository/middleware/auth route tests: green
- `git diff --check`

## Summary by Sourcery

Introduce distributed, PostgreSQL-backed authentication rate limiting with shared HMAC-pseudonymized counters and middleware across all auth endpoints, plus supporting configuration, migration guards, and documentation.

New Features:
- Add a configurable distributed auth rate limiter covering login, registration, forgot-password, and reset-password flows with IP/identifier/token dimensions.
- Introduce Express middleware and per-endpoint policies to enforce auth rate limits and propagate suppress-action hints to controllers.
- Canonicalize and pseudonymize client network addresses for abuse-prevention subjects, including IPv4-mapped IPv6 and /64 IPv6 grouping.

Enhancements:
- Make reverse-proxy trust configurable and bounded via a TRUST_PROXY_HOPS setting and integrate it into Express app configuration.
- Add a background maintenance loop for cleaning up expired rate-limit buckets with structured logging on failures.

Build:
- Add guarded PostgreSQL migration, preflight, verification, and test-only rollback scripts for the auth_rate_limit_buckets table.

Documentation:
- Document the distributed auth rate-limit design in an ADR, a security policy, and an operational deployment/runbook guide.

Tests:
- Add comprehensive tests for auth rate-limit configuration, IP canonicalization, middleware behavior, store implementation, SQL migration guards, and service behavior.
- Extend auth routes and controller tests to cover forgot-password behavior under rate limiting and to mock the new limiter service.