### PR TITLE
fix(security): harden CERP uploads and downloads

### DIFF
--- a/.env_exemple
+++ b/.env_exemple
@@ -32,3 +32,8 @@ RESEND_API_BASE_URL=https://api.resend.com
 
 # Optional: explicit email logo URL (fallback uses BACKEND_URL + /images/...)
 EMAIL_LOGO_URL=
+# Analyse antivirus des fichiers entrants. Une exÃ©cution hors tests sans ces
+# valeurs dÃ©marre en mode fail-closed et refuse les uploads.
+CERP_UPLOAD_SCAN_MODE=enforce
+CERP_UPLOAD_SCAN_PROVIDER=clamdscan
+CERP_UPLOAD_SCANNER_COMMAND=clamdscan

--- a/docs/upload-hardening.md
+++ b/docs/upload-hardening.md
@@ -1,0 +1,71 @@
+# Politique de sécurité des uploads CERP
+
+Statut : mise en œuvre de `SEC-CERP-0003` / `GPT56-CERP-0011`.
+
+## Contrat commun
+
+Tout nouvel upload HTTP passe par `src/shared/uploads/secure-upload.ts` et une politique déclarée dans `upload-policy.ts`. Le middleware :
+
+- impose un plafond de taille, de nombre de fichiers et de champs avant le traitement métier ;
+- refuse les noms vides, ambigus, trop longs, les contrôles Unicode et toute composante de chemin ;
+- vérifie l'extension, le MIME déclaré et les octets significatifs ;
+- refuse les fichiers vides, les exécutables renommés et les doublons de contenu dans un même envoi ;
+- calcule une empreinte SHA-256 et publie le résultat du scan dans `file.uploadSecurity` ;
+- conserve les fichiers disque dans `CERP_TMP_ROOT/upload-quarantine/<usage>` jusqu'à validation ;
+- supprime le staging après la réponse et compense les destinations enregistrées si la requête échoue ou est interrompue ;
+- journalise usage, acteur, requête, volume, résultat et statut du scan, sans nom, chemin ni contenu du fichier.
+
+Les documents déjà stockés ne sont pas revalidés par cette politique. Le téléchargement vérifie uniquement que le fichier réel existe, est régulier et reste dans une racine autorisée après résolution des liens symboliques. Les réponses ajoutent `nosniff`, `Cache-Control: private, no-store`, une politique cross-origin de même origine et un `Content-Disposition` neutralisé.
+
+## Matrice par usage
+
+| Usage central | Modules | Limite par fichier | Nombre | Formats |
+|---|---|---:|---:|---|
+| `business-document` | commande client, devis, fournisseurs, livraisons, planning, stock | 25 Mo | 10 | PDF, images, texte/CSV, Word, Excel, ODF |
+| `technical-document` | pièces techniques, dossiers d'opération | 25 Mo | 10 | formats métier + TIFF, archives, STEP/STL/DXF/DWG/IGES/3MF et formats CAO/CN historiques |
+| `machine-document` | parc machine | 50 Mo | 1 | formats techniques |
+| `quality-document` | qualité, réceptions, métrologie v1/v2 | 25 Mo | 10 | formats métier + TIFF |
+| `image` | images d'entités et de production | 10 Mo | 3 | PNG, JPEG, WebP, GIF |
+| `tool-media` | outillage | 25 Mo | 3 | images ou PDF |
+| `import-tabular` | assistant d'import | 25 Mo | 1 | CSV ou XLSX |
+| `ged-deferred` | GED | transport 512 Mo | 1 | classe GED validée ensuite ; contrôles communs et anti-exécutable immédiats |
+| `project-evidence-deferred` | preuve Project Office | 25 Mo | 1 | type de preuve validé ensuite ; contrôles communs immédiats |
+| `project-asset-image` | capture Project Office | 5 Mo | 1 | PNG ou JPEG |
+
+Les plafonds GED et Project Office sont des plafonds de transport. Les règles de classe ou de preuve existantes restent plus restrictives et continuent de s'appliquer avant persistance.
+
+## Scan et quarantaine
+
+Variables de configuration :
+
+- `CERP_UPLOAD_SCAN_MODE=off|monitor|enforce` ;
+- `CERP_UPLOAD_SCAN_PROVIDER=clamdscan` pour activer l'adaptateur ClamAV ;
+- `CERP_UPLOAD_SCANNER_COMMAND` pour remplacer le nom de l'exécutable, sans arguments shell.
+
+Sans mode explicite, le développement utilise `monitor` et la production utilise `enforce`. Une valeur de mode invalide devient également `enforce`. En mode `enforce`, un scanner absent ou indisponible renvoie `503 UPLOAD_SCAN_UNAVAILABLE` et aucun fichier n'est persisté. `monitor` conserve le statut `unavailable` dans l'audit mais n'affirme jamais qu'un antivirus a validé le contenu. `off` est réservé aux tests et au rollback d'urgence approuvé.
+
+Déploiement recommandé :
+
+1. installer et superviser `clamdscan` sur les instances, sans envoyer de fichier réel de production pendant la validation ;
+2. déployer avec `monitor`, vérifier les audits `security.upload` et la latence sur des fixtures inoffensives ;
+3. tester tous les usages de la matrice, y compris scanner arrêté ;
+4. passer à `enforce` lorsque le fournisseur est sain sur toutes les instances ;
+5. surveiller les `UPLOAD_SCAN_UNAVAILABLE`, `UPLOAD_SIGNATURE_MISMATCH`, volumes et temps de réponse.
+
+## Rollback et nettoyage
+
+Le rollback ne nécessite aucune migration de base. Revenir au commit précédent restaure le code ; si seul le scanner bloque l'exploitation, revenir temporairement à `monitor` après décision sécurité documentée. `off` est un dernier recours limité dans le temps. Les documents historiques restent lisibles dans tous les cas.
+
+Après un arrêt brutal, traiter uniquement le staging :
+
+1. arrêter les instances qui utilisent la racine concernée et relever l'heure du dernier arrêt ;
+2. inventorier sans suppression les fichiers de `CERP_TMP_ROOT/upload-quarantine` plus anciens que 24 heures et antérieurs au dernier arrêt ;
+3. vérifier qu'aucun processus ne les maintient ouverts et archiver la liste avec tailles et dates ;
+4. déplacer la liste explicitement approuvée vers une quarantaine opérateur récupérable ;
+5. supprimer cette quarantaine seulement après la durée de rétention opérationnelle convenue.
+
+Ne jamais appliquer cette règle d'âge à `CERP_DOCUMENTS_ROOT`, au coffre GED ou aux preuves Project Office. Pour un orphelin supposé dans un stockage final, produire d'abord un rapprochement lecture seule entre les références de métadonnées et les chemins réels, exclure les documents historiques et les versions retenues, puis déplacer les candidats vers une quarantaine récupérable. Aucune suppression finale ne doit être automatisée à partir du seul nom de fichier.
+
+## Vérification minimale
+
+Les fixtures doivent être inoffensives. Vérifier : PDF valide, extension trompeuse, MIME incohérent, zéro octet, dépassement de limite, doublon dans un lot, nom avec traversal, rollback après déplacement final, scanner indisponible en `enforce`, téléchargement historique sans extension et tentative de téléchargement hors racine.

--- a/docs/upload-hardening.md
+++ b/docs/upload-hardening.md
@@ -12,10 +12,19 @@ Tout nouvel upload HTTP passe par `src/shared/uploads/secure-upload.ts` et une p
 - refuse les fichiers vides, les exécutables renommés et les doublons de contenu dans un même envoi ;
 - calcule une empreinte SHA-256 et publie le résultat du scan dans `file.uploadSecurity` ;
 - conserve les fichiers disque dans `CERP_TMP_ROOT/upload-quarantine/<usage>` jusqu'à validation ;
-- supprime le staging après la réponse et compense les destinations enregistrées si la requête échoue ou est interrompue ;
+- supprime après la réponse uniquement le staging encore sous sa responsabilité ;
+- ne supprime une destination finale qu'après un `ROLLBACK` pré-`COMMIT`
+  confirmé, ou après un rapprochement sur une nouvelle connexion prouvant que
+  le `COMMIT` tenté n'a pas été appliqué ;
 - journalise usage, acteur, requête, volume, résultat et statut du scan, sans nom, chemin ni contenu du fichier.
 
-Les documents déjà stockés ne sont pas revalidés par cette politique. Le téléchargement vérifie uniquement que le fichier réel existe, est régulier et reste dans une racine autorisée après résolution des liens symboliques. Les réponses ajoutent `nosniff`, `Cache-Control: private, no-store`, une politique cross-origin de même origine et un `Content-Disposition` neutralisé.
+Les documents déjà stockés ne sont pas revalidés par cette politique. Le
+téléchargement valide le chemin puis ouvre le fichier sans suivre le dernier
+lien symbolique, compare `dev`/`ino`/taille avec la validation et sert exactement
+ce descripteur. Les réponses ajoutent `nosniff`, `Cache-Control: private,
+no-store`, une politique cross-origin de même origine et un
+`Content-Disposition` neutralisé. La GED stage sur disque et traite par flux son
+plafond de 512 Mo ; aucun Buffer de cette taille n'est créé.
 
 ## Matrice par usage
 
@@ -38,11 +47,18 @@ Les plafonds GED et Project Office sont des plafonds de transport. Les règles d
 
 Variables de configuration :
 
-- `CERP_UPLOAD_SCAN_MODE=off|monitor|enforce` ;
+- `CERP_UPLOAD_SCAN_MODE=off|monitor|enforce` ; hors tests, une valeur absente
+  vaut `enforce` (y compris avec `NODE_ENV=development`) ;
 - `CERP_UPLOAD_SCAN_PROVIDER=clamdscan` pour activer l'adaptateur ClamAV ;
 - `CERP_UPLOAD_SCANNER_COMMAND` pour remplacer le nom de l'exécutable, sans arguments shell.
 
-Sans mode explicite, le développement utilise `monitor` et la production utilise `enforce`. Une valeur de mode invalide devient également `enforce`. En mode `enforce`, un scanner absent ou indisponible renvoie `503 UPLOAD_SCAN_UNAVAILABLE` et aucun fichier n'est persisté. `monitor` conserve le statut `unavailable` dans l'audit mais n'affirme jamais qu'un antivirus a validé le contenu. `off` est réservé aux tests et au rollback d'urgence approuvé.
+Le runtime de tests utilise seul `monitor` par défaut. Hors tests, une valeur de
+mode invalide bloque le preflight de démarrage. En mode `enforce`,
+`CERP_UPLOAD_SCAN_PROVIDER=clamdscan` est obligatoire au démarrage ; un scanner
+ensuite absent ou indisponible renvoie `503 UPLOAD_SCAN_UNAVAILABLE` et aucun
+fichier n'est persisté. `monitor` conserve le statut `unavailable` dans l'audit
+mais n'affirme jamais qu'un antivirus a validé le contenu. `off` est réservé aux
+tests et au rollback d'urgence approuvé.
 
 Déploiement recommandé :
 
@@ -65,6 +81,13 @@ Après un arrêt brutal, traiter uniquement le staging :
 5. supprimer cette quarantaine seulement après la durée de rétention opérationnelle convenue.
 
 Ne jamais appliquer cette règle d'âge à `CERP_DOCUMENTS_ROOT`, au coffre GED ou aux preuves Project Office. Pour un orphelin supposé dans un stockage final, produire d'abord un rapprochement lecture seule entre les références de métadonnées et les chemins réels, exclure les documents historiques et les versions retenues, puis déplacer les candidats vers une quarantaine récupérable. Aucune suppression finale ne doit être automatisée à partir du seul nom de fichier.
+
+Une fermeture HTTP n'est jamais une preuve de rollback : elle peut survenir
+après un `COMMIT` réussi. Si l'accusé de réception du `COMMIT` est perdu, les
+modules Commande, GED et Project Office interrogent une nouvelle connexion.
+Un état partiel ou une panne de rapprochement préserve le fichier, renvoie une
+erreur d'incertitude et laisse l'opérateur appliquer le rapprochement lecture
+seule ci-dessus.
 
 ## Vérification minimale
 

--- a/src/__tests__/gammes-versions.routes.test.ts
+++ b/src/__tests__/gammes-versions.routes.test.ts
@@ -64,7 +64,8 @@ vi.mock("../module/methodes/middlewares/methodes-authorization.middleware", () =
   requireMethodesCapability: () => (_req: unknown, _res: unknown, next: () => void) => next(),
 }))
 
-vi.mock("../utils/cerpStorage", () => ({
+vi.mock("../utils/cerpStorage", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../utils/cerpStorage")>()),
   ensureDocumentStoragePath: () => process.cwd(),
 }))
 

--- a/src/__tests__/ged-core.routes.test.ts
+++ b/src/__tests__/ged-core.routes.test.ts
@@ -152,24 +152,6 @@ describe("GED — coffre indisponible", () => {
 
 describe("GED — contrôle de contenu au niveau route", () => {
   it("refuse un exécutable renommé en .pdf avant toute écriture", async () => {
-    mocks.poolQuery.mockResolvedValueOnce({
-      rows: [
-        {
-          class_key: "PLAN_CLIENT",
-          domain: "TECHNIQUE",
-          label: "Plan client",
-          nature: "SOURCE",
-          allowed_mime_types: ["application/pdf"],
-          allowed_extensions: [".pdf"],
-          max_size_bytes: "104857600",
-          approvals_required: 1,
-          retention_months: 120,
-          hold_on_publish: false,
-          is_active: true,
-        },
-      ],
-    });
-
     const res = await request(app)
       .post("/api/v1/ged/documents")
       .set("x-test-role", "administrateur")
@@ -181,7 +163,8 @@ describe("GED — contrôle de contenu au niveau route", () => {
       });
 
     expect(res.status).toBe(415);
-    expect(JSON.stringify(res.body)).toContain("GED_FILE_SIGNATURE");
+    expect(JSON.stringify(res.body)).toContain("UPLOAD_EXECUTABLE_FORBIDDEN");
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/ged-streaming-vault.test.ts
+++ b/src/__tests__/ged-streaming-vault.test.ts
@@ -1,0 +1,96 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { cleanupUploadsAfterConfirmedRollback } from "../shared/uploads/secure-upload";
+import { assertAcceptedFileOnDisk } from "../module/ged/domain/ged-content";
+import {
+  computeFileSha256,
+  writeBlobFromPath,
+} from "../module/ged/services/ged-vault.service";
+
+const PDF_RULES = {
+  class_key: "PLAN_CLIENT",
+  allowed_mime_types: ["application/pdf"],
+  allowed_extensions: [".pdf"],
+  max_size_bytes: 512 * 1024 * 1024,
+} as const;
+
+describe("GED — pipeline disque borné", () => {
+  let temporaryRoot: string;
+  let vaultRoot: string;
+
+  beforeEach(async () => {
+    temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-ged-stream-"));
+    vaultRoot = path.join(temporaryRoot, "ged-volume");
+    process.env.CERP_GED_VAULT_ROOT = vaultRoot;
+    process.env.CERP_GED_REQUIRE_SENTINEL = "false";
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    delete process.env.CERP_GED_VAULT_ROOT;
+    delete process.env.CERP_GED_REQUIRE_SENTINEL;
+    await fs.rm(temporaryRoot, { recursive: true, force: true });
+  });
+
+  async function largeSparsePdf(name: string): Promise<string> {
+    const source = path.join(temporaryRoot, name);
+    const handle = await fs.open(source, "wx", 0o600);
+    try {
+      await handle.write(Buffer.from("%PDF-1.7\n", "ascii"), 0, 9, 0);
+      // Large enough to detect accidental whole-file buffering while keeping
+      // the suite fast; the transport policy itself remains 512 MiB.
+      await handle.truncate(32 * 1024 * 1024);
+    } finally {
+      await handle.close();
+    }
+    return source;
+  }
+
+  it("valide, hache et promeut un gros fichier sans fs.readFile", async () => {
+    const source = await largeSparsePdf("large.pdf.part");
+    const readFile = vi.spyOn(fs, "readFile");
+
+    const accepted = await assertAcceptedFileOnDisk({
+      path: source,
+      originalname: "large.pdf",
+      mimetype: "application/pdf",
+      size: 32 * 1024 * 1024,
+    }, PDF_RULES);
+    const expectedHash = await computeFileSha256(source);
+    const written = await writeBlobFromPath(accepted.path);
+
+    expect(written).toMatchObject({
+      sha256: expectedHash,
+      size_bytes: 32 * 1024 * 1024,
+      deduplicated: false,
+    });
+    expect(readFile).not.toHaveBeenCalled();
+    await expect(fs.stat(source)).rejects.toMatchObject({ code: "ENOENT" });
+
+    const destination = path.join(vaultRoot, ...written.storage_key.split("/"));
+    expect((await fs.stat(destination)).size).toBe(32 * 1024 * 1024);
+
+    // A proven pre-COMMIT rollback owns and removes the promoted blob.
+    await cleanupUploadsAfterConfirmedRollback([{ path: source }]);
+    await expect(fs.stat(destination)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("déduplique par flux et nettoie aussi le second staging", async () => {
+    const first = await largeSparsePdf("first.pdf.part");
+    const firstWritten = await writeBlobFromPath(first);
+    const second = await largeSparsePdf("second.pdf.part");
+    const readFile = vi.spyOn(fs, "readFile");
+
+    const secondWritten = await writeBlobFromPath(second);
+    expect(secondWritten.sha256).toBe(firstWritten.sha256);
+    expect(secondWritten.deduplicated).toBe(true);
+    expect(readFile).not.toHaveBeenCalled();
+    await expect(fs.stat(second)).rejects.toMatchObject({ code: "ENOENT" });
+
+    await cleanupUploadsAfterConfirmedRollback([{ path: first }]);
+  });
+});

--- a/src/__tests__/machine-image-upload-ownership.contract.test.ts
+++ b/src/__tests__/machine-image-upload-ownership.contract.test.ts
@@ -1,0 +1,61 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const sourceRoot = path.resolve(__dirname, "..");
+
+function source(relativePath: string): string {
+  return fs.readFileSync(path.join(sourceRoot, relativePath), "utf8");
+}
+
+function exportedFunctionBody(contents: string, functionName: string): string {
+  const functionStart = contents.indexOf(`export async function ${functionName}`);
+  const constStart = contents.indexOf(`export const ${functionName} =`);
+  const start = functionStart >= 0 ? functionStart : constStart;
+  if (start < 0) throw new Error(`Missing ${functionName}`);
+  const nextFunction = contents.indexOf("\nexport async function ", start + 1);
+  const nextConst = contents.indexOf("\nexport const ", start + 1);
+  const candidates = [nextFunction, nextConst].filter((index) => index >= 0);
+  const next = candidates.length ? Math.min(...candidates) : contents.length;
+  return contents.slice(start, next);
+}
+
+describe("machine image upload ownership contract", () => {
+  const routes = source("module/production/routes/production.routes.ts");
+  const controller = source("module/production/controllers/production.controller.ts");
+  const repository = source("module/production/repository/production.repository.ts");
+
+  const endpoints = [
+    { method: "post", route: "/machines/onboarding", handler: "createMachineOnboarding", repository: "repoCreateMachineOnboarding" },
+    { method: "post", route: "/machines", handler: "createMachine", repository: "repoCreateMachine" },
+    { method: "patch", route: "/machines/:id/onboarding", handler: "updateMachineOnboarding", repository: "repoUpdateMachineOnboarding" },
+    { method: "patch", route: "/machines/:id", handler: "updateMachine", repository: "repoUpdateMachine" },
+  ] as const;
+
+  for (const endpoint of endpoints) {
+    it(`${endpoint.method.toUpperCase()} ${endpoint.route} stages first and transfers ownership transactionally`, () => {
+      expect(routes).toContain(
+        `router.${endpoint.method}("${endpoint.route}", requireMachineCapability(`
+      );
+      const routeLine = routes.split("\n").find((line) =>
+        line.includes(`router.${endpoint.method}("${endpoint.route}"`)
+      );
+      expect(routeLine).toContain('machineImageUpload.single("image")');
+      expect(routeLine).not.toContain('upload.single("image")');
+
+      const controllerBody = exportedFunctionBody(controller, endpoint.handler);
+      expect(controllerBody).toContain("image_file: imageFile");
+
+      const repositoryBody = exportedFunctionBody(repository, endpoint.repository);
+      expect(repositoryBody).toContain("withUploadTransaction({");
+      expect(repositoryBody).toContain("promoteSecureUpload(");
+      expect(repositoryBody).toContain("reconcileMachineMutation(expected)");
+    });
+  }
+
+  it("uses staging middleware rather than direct final-directory image storage", () => {
+    expect(routes).toContain('const machineImageUpload = createSecureUpload("image", { maxFiles: 1 });');
+    expect(routes).not.toContain('import { upload } from "../../../middlewares/upload"');
+  });
+});

--- a/src/__tests__/secure-upload.test.ts
+++ b/src/__tests__/secure-upload.test.ts
@@ -42,6 +42,7 @@ function errorHandler(): ErrorRequestHandler {
 
 function uploadApp(options?: {
   failAfterUpload?: boolean;
+  failureStatus?: 409 | 422 | 500;
   moveBeforeFailureTo?: string;
   usage?: "business-document" | "image";
   ownership?: "rolled-back" | "commit-attempted" | "committed";
@@ -74,7 +75,10 @@ function uploadApp(options?: {
         }
       }
       if (options?.failAfterUpload) {
-        next(new HttpError(409, "BUSINESS_ROLLBACK", "Transaction métier annulée."));
+        const status = options.failureStatus ?? 409;
+        next(status === 500
+          ? new Error("downstream failure")
+          : new HttpError(status, "BUSINESS_ROLLBACK", "Transaction métier annulée."));
         return;
       }
       res.status(201).json({ files: files.map((file) => file.uploadSecurity) });
@@ -194,6 +198,21 @@ describe("politique centrale des uploads", () => {
       .attach("documents[]", VALID_PDF, { filename: "rollback.pdf", contentType: "application/pdf" });
 
     expect(response.status).toBe(409);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(await allFiles(temporaryRoot)).toEqual([]);
+  });
+
+  it.each([422, 500] as const)("nettoie le staging image après un rejet aval %i", async (failureStatus) => {
+    const response = await request(uploadApp({ usage: "image", failAfterUpload: true, failureStatus }))
+      .post("/upload")
+      .attach("documents[]", Buffer.from([
+        0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+        0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+        0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+        0x08, 0x02, 0x00, 0x00, 0x00,
+      ]), { filename: "machine.png", contentType: "image/png" });
+
+    expect(response.status).toBe(failureStatus);
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(await allFiles(temporaryRoot)).toEqual([]);
   });

--- a/src/__tests__/secure-upload.test.ts
+++ b/src/__tests__/secure-upload.test.ts
@@ -1,0 +1,228 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import express, { type ErrorRequestHandler } from "express";
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HttpError } from "../utils/httpError";
+import {
+  assertSafeUploadName,
+  contentMatchesExtension,
+  createSecureUpload,
+  registerUploadDestination,
+} from "../shared/uploads/secure-upload";
+import {
+  assertSecureDownloadPath,
+  buildContentDisposition,
+} from "../shared/uploads/secure-download";
+import { setUploadScannerForTests } from "../shared/uploads/upload-scanner";
+
+const VALID_PDF = Buffer.from("%PDF-1.4\n1 0 obj\n<<>>\nendobj\n%%EOF", "ascii");
+
+function errorHandler(): ErrorRequestHandler {
+  return (error, _req, res, _next) => {
+    const status = error instanceof HttpError ? error.status : 500;
+    res.status(status).json({
+      code: error instanceof HttpError ? error.code : "INTERNAL_ERROR",
+      message: error instanceof Error ? error.message : "Erreur interne",
+    });
+  };
+}
+
+function uploadApp(options?: {
+  failAfterUpload?: boolean;
+  moveBeforeFailureTo?: string;
+  usage?: "business-document" | "image";
+}) {
+  const app = express();
+  const usage = options?.usage ?? "business-document";
+  const upload = createSecureUpload(usage);
+  app.post("/upload", upload.array("documents[]", 10), async (req, res, next) => {
+    try {
+      const files = Array.isArray(req.files) ? req.files : [];
+      if (options?.moveBeforeFailureTo && files[0]) {
+        await fs.mkdir(options.moveBeforeFailureTo, { recursive: true });
+        const destination = path.join(options.moveBeforeFailureTo, "stored.pdf");
+        const sourcePath = files[0].path;
+        await fs.rename(sourcePath, destination);
+        registerUploadDestination({ path: sourcePath }, destination);
+      }
+      if (options?.failAfterUpload) {
+        next(new HttpError(409, "BUSINESS_ROLLBACK", "Transaction métier annulée."));
+        return;
+      }
+      res.status(201).json({ files: files.map((file) => file.uploadSecurity) });
+    } catch (error) {
+      next(error);
+    }
+  });
+  app.use(errorHandler());
+  return app;
+}
+
+async function allFiles(directory: string): Promise<string[]> {
+  const entries = await fs.readdir(directory, { recursive: true, withFileTypes: true }).catch(() => []);
+  return entries.filter((entry) => entry.isFile()).map((entry) => entry.name);
+}
+
+describe("politique centrale des uploads", () => {
+  let temporaryRoot: string;
+
+  beforeEach(async () => {
+    temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-secure-upload-"));
+    process.env.CERP_TMP_ROOT = temporaryRoot;
+    process.env.CERP_UPLOAD_SCAN_MODE = "off";
+    delete process.env.CERP_UPLOAD_SCAN_PROVIDER;
+    setUploadScannerForTests(null);
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    setUploadScannerForTests(null);
+    delete process.env.CERP_TMP_ROOT;
+    delete process.env.CERP_UPLOAD_SCAN_MODE;
+    delete process.env.CERP_UPLOAD_SCAN_PROVIDER;
+    await fs.rm(temporaryRoot, { recursive: true, force: true });
+  });
+
+  it("accepte un PDF inoffensif et calcule son empreinte", async () => {
+    const response = await request(uploadApp())
+      .post("/upload")
+      .attach("documents[]", VALID_PDF, { filename: "controle.pdf", contentType: "application/pdf" });
+
+    expect(response.status).toBe(201);
+    expect(response.body.files[0]).toMatchObject({
+      usage: "business-document",
+      scanStatus: "unavailable",
+      scanProvider: "disabled",
+    });
+    expect(response.body.files[0].sha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it("refuse une extension trompeuse même si le MIME annoncé paraît cohérent", async () => {
+    const executable = Buffer.concat([Buffer.from("MZ", "ascii"), Buffer.alloc(32)]);
+    const response = await request(uploadApp())
+      .post("/upload")
+      .attach("documents[]", executable, { filename: "preuve.pdf", contentType: "application/pdf" });
+
+    expect(response.status).toBe(415);
+    expect(response.body.code).toBe("UPLOAD_EXECUTABLE_FORBIDDEN");
+  });
+
+  it("refuse un MIME incohérent avant l’écriture du contenu", async () => {
+    const response = await request(uploadApp())
+      .post("/upload")
+      .attach("documents[]", VALID_PDF, { filename: "preuve.pdf", contentType: "image/png" });
+
+    expect(response.status).toBe(415);
+    expect(response.body.code).toBe("UPLOAD_MIME_MISMATCH");
+    expect(await allFiles(temporaryRoot)).toEqual([]);
+  });
+
+  it("refuse un fichier zéro octet", async () => {
+    const response = await request(uploadApp())
+      .post("/upload")
+      .attach("documents[]", Buffer.alloc(0), { filename: "vide.pdf", contentType: "application/pdf" });
+
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe("UPLOAD_EMPTY_FILE");
+  });
+
+  it("applique la limite de taille centralisée", async () => {
+    const oversizedImage = Buffer.alloc(10 * 1024 * 1024 + 1);
+    oversizedImage.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a], 0);
+    const response = await request(uploadApp({ usage: "image" }))
+      .post("/upload")
+      .attach("documents[]", oversizedImage, { filename: "atelier.png", contentType: "image/png" });
+
+    expect(response.status).toBe(413);
+    expect(response.body.code).toBe("UPLOAD_FILE_TOO_LARGE");
+  });
+
+  it("refuse le traversal et les noms ambigus", () => {
+    for (const name of ["../../preuve.pdf", "..\\..\\preuve.pdf", "preuve.pdf\r\nX-Test: oui", "preuve\u202Efdp.exe"]) {
+      expect(() => assertSafeUploadName(name)).toThrowError(expect.objectContaining({ code: "UPLOAD_NAME_INVALID" }));
+    }
+  });
+
+  it("refuse un doublon de contenu dans le même lot", async () => {
+    const response = await request(uploadApp())
+      .post("/upload")
+      .attach("documents[]", VALID_PDF, { filename: "a.pdf", contentType: "application/pdf" })
+      .attach("documents[]", VALID_PDF, { filename: "b.pdf", contentType: "application/pdf" });
+
+    expect(response.status).toBe(409);
+    expect(response.body.code).toBe("UPLOAD_DUPLICATE_FILE");
+    expect(await allFiles(temporaryRoot)).toEqual([]);
+  });
+
+  it("compense le staging et le stockage final lorsque la transaction métier est annulée", async () => {
+    const finalDirectory = path.join(temporaryRoot, "documents");
+    const response = await request(uploadApp({ failAfterUpload: true, moveBeforeFailureTo: finalDirectory }))
+      .post("/upload")
+      .attach("documents[]", VALID_PDF, { filename: "rollback.pdf", contentType: "application/pdf" });
+
+    expect(response.status).toBe(409);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(await allFiles(temporaryRoot)).toEqual([]);
+  });
+
+  it("échoue fermé en mode enforce lorsqu’aucun scanner réel n’est configuré", async () => {
+    process.env.CERP_UPLOAD_SCAN_MODE = "enforce";
+    const response = await request(uploadApp())
+      .post("/upload")
+      .attach("documents[]", VALID_PDF, { filename: "preuve.pdf", contentType: "application/pdf" });
+
+    expect(response.status).toBe(503);
+    expect(response.body.code).toBe("UPLOAD_SCAN_UNAVAILABLE");
+    expect(await allFiles(temporaryRoot)).toEqual([]);
+  });
+
+  it("valide les signatures sans se fier au seul nom", () => {
+    const pdfSample = { head: VALID_PDF, tail: VALID_PDF };
+    const fakePng = { head: VALID_PDF, tail: VALID_PDF };
+    expect(contentMatchesExtension(".pdf", pdfSample, VALID_PDF.length)).toBe(true);
+    expect(contentMatchesExtension(".png", fakePng, VALID_PDF.length)).toBe(false);
+  });
+});
+
+describe("téléchargement sécurisé et compatibilité historique", () => {
+  let root: string;
+  let outside: string;
+
+  beforeEach(async () => {
+    root = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-download-root-"));
+    outside = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-download-outside-"));
+  });
+
+  afterEach(async () => {
+    await Promise.all([
+      fs.rm(root, { recursive: true, force: true }),
+      fs.rm(outside, { recursive: true, force: true }),
+    ]);
+  });
+
+  it("sert un fichier historique contenu dans sa racine sans revalider son format", async () => {
+    const legacy = path.join(root, "legacy-sans-extension");
+    await fs.writeFile(legacy, "historique");
+    await expect(assertSecureDownloadPath(legacy, [root])).resolves.toBe(await fs.realpath(legacy));
+  });
+
+  it("refuse un fichier extérieur à la racine autorisée", async () => {
+    const escaped = path.join(outside, "secret.txt");
+    await fs.writeFile(escaped, "hors périmètre");
+    await expect(assertSecureDownloadPath(escaped, [root])).rejects.toMatchObject({ code: "INVALID_STORAGE_PATH" });
+  });
+
+  it("neutralise traversal, CRLF et Unicode dans Content-Disposition", () => {
+    const header = buildContentDisposition("../../contrôle.pdf\r\nX-Evil: yes", true);
+    expect(header).toContain("attachment;");
+    expect(header).toContain("filename*=UTF-8''");
+    expect(header).not.toContain("\r");
+    expect(header).not.toContain("\n");
+    expect(header).not.toContain("../");
+  });
+});

--- a/src/__tests__/secure-upload.test.ts
+++ b/src/__tests__/secure-upload.test.ts
@@ -10,14 +10,23 @@ import { HttpError } from "../utils/httpError";
 import {
   assertSafeUploadName,
   contentMatchesExtension,
+  cleanupUploadsAfterConfirmedRollback,
   createSecureUpload,
+  markUploadCommitAttempted,
+  markUploadsCommitted,
   registerUploadDestination,
 } from "../shared/uploads/secure-upload";
 import {
   assertSecureDownloadPath,
   buildContentDisposition,
+  sendSecureStoredFile,
+  setSecureDownloadHookForTests,
 } from "../shared/uploads/secure-download";
-import { setUploadScannerForTests } from "../shared/uploads/upload-scanner";
+import {
+  assertUploadScannerConfiguration,
+  getUploadScanMode,
+  setUploadScannerForTests,
+} from "../shared/uploads/upload-scanner";
 
 const VALID_PDF = Buffer.from("%PDF-1.4\n1 0 obj\n<<>>\nendobj\n%%EOF", "ascii");
 
@@ -35,6 +44,8 @@ function uploadApp(options?: {
   failAfterUpload?: boolean;
   moveBeforeFailureTo?: string;
   usage?: "business-document" | "image";
+  ownership?: "rolled-back" | "commit-attempted" | "committed";
+  disconnectAfterCommit?: boolean;
 }) {
   const app = express();
   const usage = options?.usage ?? "business-document";
@@ -47,7 +58,20 @@ function uploadApp(options?: {
         const destination = path.join(options.moveBeforeFailureTo, "stored.pdf");
         const sourcePath = files[0].path;
         await fs.rename(sourcePath, destination);
-        registerUploadDestination({ path: sourcePath }, destination);
+        const references = [{ path: sourcePath }];
+        registerUploadDestination(references[0], destination);
+        if (options.ownership === "rolled-back") {
+          await cleanupUploadsAfterConfirmedRollback(references);
+        } else if (options.ownership === "commit-attempted") {
+          markUploadCommitAttempted(references);
+        } else if (options.ownership === "committed") {
+          markUploadCommitAttempted(references);
+          markUploadsCommitted(references);
+        }
+        if (options.disconnectAfterCommit) {
+          res.socket?.destroy();
+          return;
+        }
       }
       if (options?.failAfterUpload) {
         next(new HttpError(409, "BUSINESS_ROLLBACK", "Transaction métier annulée."));
@@ -161,13 +185,47 @@ describe("politique centrale des uploads", () => {
 
   it("compense le staging et le stockage final lorsque la transaction métier est annulée", async () => {
     const finalDirectory = path.join(temporaryRoot, "documents");
-    const response = await request(uploadApp({ failAfterUpload: true, moveBeforeFailureTo: finalDirectory }))
+    const response = await request(uploadApp({
+      failAfterUpload: true,
+      moveBeforeFailureTo: finalDirectory,
+      ownership: "rolled-back",
+    }))
       .post("/upload")
       .attach("documents[]", VALID_PDF, { filename: "rollback.pdf", contentType: "application/pdf" });
 
     expect(response.status).toBe(409);
     await new Promise((resolve) => setTimeout(resolve, 20));
     expect(await allFiles(temporaryRoot)).toEqual([]);
+  });
+
+  it("préserve la destination si COMMIT a été tenté puis son ACK perdu", async () => {
+    const finalDirectory = path.join(temporaryRoot, "documents");
+    const response = await request(uploadApp({
+      failAfterUpload: true,
+      moveBeforeFailureTo: finalDirectory,
+      ownership: "commit-attempted",
+    }))
+      .post("/upload")
+      .attach("documents[]", VALID_PDF, { filename: "ack-perdu.pdf", contentType: "application/pdf" });
+
+    expect(response.status).toBe(409);
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(await fs.readFile(path.join(finalDirectory, "stored.pdf"))).toEqual(VALID_PDF);
+  });
+
+  it("ne supprime pas un fichier durable si le client se déconnecte après COMMIT", async () => {
+    const finalDirectory = path.join(temporaryRoot, "documents");
+    await request(uploadApp({
+      moveBeforeFailureTo: finalDirectory,
+      ownership: "committed",
+      disconnectAfterCommit: true,
+    }))
+      .post("/upload")
+      .attach("documents[]", VALID_PDF, { filename: "committed.pdf", contentType: "application/pdf" })
+      .catch(() => undefined);
+
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(await fs.readFile(path.join(finalDirectory, "stored.pdf"))).toEqual(VALID_PDF);
   });
 
   it("échoue fermé en mode enforce lorsqu’aucun scanner réel n’est configuré", async () => {
@@ -189,6 +247,53 @@ describe("politique centrale des uploads", () => {
   });
 });
 
+describe("configuration fail-closed du scanner", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = originalNodeEnv;
+    delete process.env.CERP_UPLOAD_SCAN_MODE;
+    delete process.env.CERP_UPLOAD_SCAN_PROVIDER;
+    delete process.env.CERP_UPLOAD_SCANNER_COMMAND;
+  });
+
+  it.each(["production", "development", undefined])(
+    "utilise enforce hors tests lorsque NODE_ENV=%s",
+    (nodeEnv) => {
+      if (nodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = nodeEnv;
+      expect(getUploadScanMode()).toBe("enforce");
+    }
+  );
+
+  it("conserve monitor uniquement pour le runtime de tests", () => {
+    process.env.NODE_ENV = "test";
+    expect(getUploadScanMode()).toBe("monitor");
+  });
+
+  it("refuse au preflight un mode invalide et un scanner absent en enforce", () => {
+    process.env.NODE_ENV = "development";
+    process.env.CERP_UPLOAD_SCAN_MODE = "permissive";
+    expect(() => assertUploadScannerConfiguration()).toThrow(/SCAN_MODE invalide/);
+
+    process.env.CERP_UPLOAD_SCAN_MODE = "enforce";
+    expect(() => assertUploadScannerConfiguration()).toThrow(/PROVIDER=clamdscan/);
+  });
+
+  it("accepte la configuration enforce explicite et cohérente", () => {
+    process.env.NODE_ENV = "development";
+    process.env.CERP_UPLOAD_SCAN_MODE = "enforce";
+    process.env.CERP_UPLOAD_SCAN_PROVIDER = "clamdscan";
+    process.env.CERP_UPLOAD_SCANNER_COMMAND = "clamdscan-custom";
+    expect(assertUploadScannerConfiguration()).toEqual({
+      mode: "enforce",
+      provider: "clamdscan",
+      command: "clamdscan-custom",
+    });
+  });
+});
+
 describe("téléchargement sécurisé et compatibilité historique", () => {
   let root: string;
   let outside: string;
@@ -199,11 +304,31 @@ describe("téléchargement sécurisé et compatibilité historique", () => {
   });
 
   afterEach(async () => {
+    setSecureDownloadHookForTests(null);
     await Promise.all([
       fs.rm(root, { recursive: true, force: true }),
       fs.rm(outside, { recursive: true, force: true }),
     ]);
   });
+
+  function downloadApp(filePath: string) {
+    const app = express();
+    app.get("/download", async (_req, res, next) => {
+      try {
+        await sendSecureStoredFile(res, {
+          filePath,
+          allowedRoots: [root],
+          filename: "document.txt",
+          mimeType: "text/plain",
+          download: true,
+        });
+      } catch (error) {
+        next(error);
+      }
+    });
+    app.use(errorHandler());
+    return app;
+  }
 
   it("sert un fichier historique contenu dans sa racine sans revalider son format", async () => {
     const legacy = path.join(root, "legacy-sans-extension");
@@ -215,6 +340,58 @@ describe("téléchargement sécurisé et compatibilité historique", () => {
     const escaped = path.join(outside, "secret.txt");
     await fs.writeFile(escaped, "hors périmètre");
     await expect(assertSecureDownloadPath(escaped, [root])).rejects.toMatchObject({ code: "INVALID_STORAGE_PATH" });
+  });
+
+  it("refuse une substitution entre la validation et l’ouverture", async () => {
+    const candidate = path.join(root, "document.txt");
+    const replacement = path.join(root, "replacement.txt");
+    await fs.writeFile(candidate, "contenu-original");
+    await fs.writeFile(replacement, "contenu-remplace");
+    setSecureDownloadHookForTests(async (phase) => {
+      if (phase !== "after-validation") return;
+      await fs.rename(candidate, path.join(root, "original-retire.txt"));
+      await fs.rename(replacement, candidate);
+    });
+
+    const response = await request(downloadApp(candidate)).get("/download");
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe("INVALID_STORAGE_PATH");
+  });
+
+  it("refuse aussi une substitution du répertoire parent", async () => {
+    const parent = path.join(root, "parent");
+    const retiredParent = path.join(root, "parent-retired");
+    const outsideParent = path.join(outside, "replacement-parent");
+    await fs.mkdir(parent);
+    await fs.mkdir(outsideParent);
+    const candidate = path.join(parent, "document.txt");
+    await fs.writeFile(candidate, "contenu-original");
+    await fs.writeFile(path.join(outsideParent, "document.txt"), "secret-exterieur");
+    setSecureDownloadHookForTests(async (phase) => {
+      if (phase !== "after-validation") return;
+      await fs.rename(parent, retiredParent);
+      await fs.symlink(outsideParent, parent, "junction");
+    });
+
+    const response = await request(downloadApp(candidate)).get("/download");
+    expect(response.status).toBe(400);
+    expect(response.body.code).toBe("INVALID_STORAGE_PATH");
+  });
+
+  it("sert exactement le descripteur ouvert même si le nom est remplacé ensuite", async () => {
+    const candidate = path.join(root, "document.txt");
+    const replacement = path.join(root, "replacement.txt");
+    await fs.writeFile(candidate, "contenu-original");
+    await fs.writeFile(replacement, "contenu-remplace");
+    setSecureDownloadHookForTests(async (phase) => {
+      if (phase !== "after-open") return;
+      await fs.rename(candidate, path.join(root, "original-ouvert.txt"));
+      await fs.rename(replacement, candidate);
+    });
+
+    const response = await request(downloadApp(candidate)).get("/download");
+    expect(response.status).toBe(200);
+    expect(response.text).toBe("contenu-original");
   });
 
   it("neutralise traversal, CRLF et Unicode dans Content-Disposition", () => {

--- a/src/__tests__/traceability-asbuilt.routes.test.ts
+++ b/src/__tests__/traceability-asbuilt.routes.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeAll, afterAll } from "vitest"
 import request from "supertest"
 import fs from "node:fs/promises"
 import path from "node:path"
-import { ensureTmpStoragePath } from "../utils/cerpStorage"
+import { ensureDocumentsPath } from "../utils/cerpStorage"
 
 const lotId = "11111111-1111-1111-1111-111111111111"
 const docId = "22222222-2222-2222-2222-222222222222"
@@ -139,7 +139,7 @@ import app from "../config/app"
 
 describe("🧪 Routes Traceabilite + As-built (/traceability, /asbuilt)", () => {
   beforeAll(async () => {
-    const dir = await fs.mkdtemp(path.join(ensureTmpStoragePath("fixtures"), "asbuilt-"))
+    const dir = await fs.mkdtemp(path.join(ensureDocumentsPath("asbuilt"), "test-"))
     tmpPdfPath = path.join(dir, "fake.pdf")
     await fs.writeFile(tmpPdfPath, Buffer.from("%PDF-1.4\n%fake\n"))
   })

--- a/src/__tests__/upload-ownership-contract.test.ts
+++ b/src/__tests__/upload-ownership-contract.test.ts
@@ -1,0 +1,56 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const sourceRoot = path.resolve(__dirname, "..");
+
+const helperOwnedRepositories = [
+  "module/commande-client/repository/commande-client.repository.ts",
+  "module/devis/repository/devis.repository.ts",
+  "module/fournisseurs/repository/fournisseurs.repository.ts",
+  "module/livraisons/repository/livraisons.repository.ts",
+  "module/metrologie/repository/metrologie.repository.ts",
+  "module/metrologie/repository/metrology-execution.repository.ts",
+  "module/operation-dossiers/repository/operation-dossiers.repository.ts",
+  "module/pieces-techniques/repository/pieces-techniques.repository.ts",
+  "module/planning/repository/planning.repository.ts",
+  "module/production/repository/machine-park.repository.ts",
+  "module/qualite/repository/qualite.repository.ts",
+  "module/receptions/repository/receptions.repository.ts",
+  "module/stock/repository/stock.repository.ts",
+] as const;
+
+describe("durable upload ownership coverage", () => {
+  for (const relativePath of helperOwnedRepositories) {
+    it(`${relativePath} delegates every registered destination to the shared transaction owner`, () => {
+      const contents = fs.readFileSync(path.join(sourceRoot, relativePath), "utf8");
+      expect(contents).toContain("registerUploadDestination");
+      expect(contents).toContain("withUploadTransaction");
+      expect(contents).toContain("reconcile:");
+    });
+  }
+
+  it("keeps GED on its audited fresh-read reconciliation adapter", () => {
+    const service = fs.readFileSync(path.join(sourceRoot, "module/ged/services/ged.service.ts"), "utf8");
+    expect(service).toContain("beforeCommit: () => markUploadCommitAttempted(files)");
+    expect(service).toContain("afterCommit: () => markUploadsCommitted(files)");
+    expect(service).toContain("repoIsVersionBlobCommitted(error.transactionResult.versionId, sha256)");
+    expect(service).toContain('outcome === "committed"');
+    expect(service).toContain('outcome === "not-committed"');
+    expect(service).toContain("durableFilePresent");
+    expect(service).toContain("cleanupUploadsAfterReconciledNoCommit(files)");
+  });
+
+  it("keeps Project Office evidence on exact fresh-read reconciliation", () => {
+    const service = fs.readFileSync(
+      path.join(sourceRoot, "module/project-office/services/project-office-registers.service.ts"),
+      "utf8"
+    );
+    expect(service).toContain("err instanceof PoCommitUncertainError");
+    expect(service).toContain("repoGetEvidenceFileById(result.file.id)");
+    expect(service).toContain("persisted.sha256 === sha256 && persisted.storage_key === storageKey");
+    expect(service).toContain("durableFilePresent");
+    expect(service).toContain("written && !(err instanceof PoRollbackUncertainError)");
+  });
+});

--- a/src/__tests__/upload-transaction-outcomes.test.ts
+++ b/src/__tests__/upload-transaction-outcomes.test.ts
@@ -16,10 +16,13 @@ vi.mock("../config/database", () => ({
 
 import {
   GedCommitUncertainError,
+  GedRollbackUncertainError,
+  repoIsVersionBlobCommitted,
   withGedTransaction,
 } from "../module/ged/repository/ged.repository";
 import {
   PoCommitUncertainError,
+  PoRollbackUncertainError,
   withTransaction as withProjectOfficeTransaction,
 } from "../module/project-office/repository/project-office.repository";
 
@@ -51,6 +54,7 @@ describe("transactions avec fichiers durables", () => {
     expect(beforeCommit).toHaveBeenCalledOnce();
     expect(afterRollback).not.toHaveBeenCalled();
     expect(database.clientQuery.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "COMMIT"]);
+    expect(database.release).toHaveBeenCalledWith(true);
   });
 
   it("GED exécute le nettoyage seulement après un vrai ROLLBACK confirmé", async () => {
@@ -66,6 +70,32 @@ describe("transactions avec fichiers durables", () => {
     expect(database.clientQuery.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "ROLLBACK"]);
   });
 
+  it("GED preserves the connection and durable ownership when ROLLBACK acknowledgement is lost", async () => {
+    database.clientQuery.mockImplementation(async (sql: string) => {
+      if (sql === "ROLLBACK") throw new Error("rollback acknowledgement lost");
+      return { rows: [] };
+    });
+    const afterRollback = vi.fn();
+
+    await expect(withGedTransaction(
+      async () => { throw new Error("business failure"); },
+      { afterConfirmedRollback: afterRollback }
+    )).rejects.toBeInstanceOf(GedRollbackUncertainError);
+
+    expect(afterRollback).not.toHaveBeenCalled();
+    expect(database.release).toHaveBeenCalledWith(true);
+  });
+
+  it.each([
+    [{ version_sha256: "sha", blob_present: true }, "committed"],
+    [{ version_sha256: "different", blob_present: true }, "uncertain"],
+    [{ version_sha256: null, blob_present: true }, "uncertain"],
+    [{ version_sha256: null, blob_present: false }, "not-committed"],
+  ] as const)("GED classifies fresh version/blob state without false cleanup: %s", async (row, expected) => {
+    database.query.mockResolvedValueOnce({ rows: [row] });
+    await expect(repoIsVersionBlobCommitted("version-id", "sha")).resolves.toBe(expected);
+  });
+
   it("Project Office préserve le résultat métier quand seul l’ACK de COMMIT manque", async () => {
     database.clientQuery.mockImplementation(async (sql: string) => {
       if (sql === "COMMIT") throw new Error("ack lost");
@@ -78,6 +108,7 @@ describe("transactions avec fichiers durables", () => {
     expect(error).toBeInstanceOf(PoCommitUncertainError);
     expect(error.transactionResult).toEqual({ file: { id: "file-1" } });
     expect(database.clientQuery.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "COMMIT"]);
+    expect(database.release).toHaveBeenCalledWith(true);
   });
 
   it("Project Office nettoie via ROLLBACK sur une erreur pré-COMMIT", async () => {
@@ -87,5 +118,18 @@ describe("transactions avec fichiers durables", () => {
     })).rejects.toBe(businessError);
 
     expect(database.clientQuery.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "ROLLBACK"]);
+  });
+
+  it("Project Office destroys a client whose ROLLBACK acknowledgement is uncertain", async () => {
+    database.clientQuery.mockImplementation(async (sql: string) => {
+      if (sql === "ROLLBACK") throw new Error("rollback acknowledgement lost");
+      return { rows: [] };
+    });
+
+    await expect(withProjectOfficeTransaction(async () => {
+      throw new Error("insert failed");
+    })).rejects.toBeInstanceOf(PoRollbackUncertainError);
+
+    expect(database.release).toHaveBeenCalledWith(true);
   });
 });

--- a/src/__tests__/upload-transaction-outcomes.test.ts
+++ b/src/__tests__/upload-transaction-outcomes.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const database = vi.hoisted(() => ({
+  connect: vi.fn(),
+  query: vi.fn(),
+  clientQuery: vi.fn(),
+  release: vi.fn(),
+}));
+
+vi.mock("../config/database", () => ({
+  default: {
+    connect: database.connect,
+    query: database.query,
+  },
+}));
+
+import {
+  GedCommitUncertainError,
+  withGedTransaction,
+} from "../module/ged/repository/ged.repository";
+import {
+  PoCommitUncertainError,
+  withTransaction as withProjectOfficeTransaction,
+} from "../module/project-office/repository/project-office.repository";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  database.connect.mockResolvedValue({
+    query: database.clientQuery,
+    release: database.release,
+  });
+  database.clientQuery.mockResolvedValue({ rows: [] });
+});
+
+describe("transactions avec fichiers durables", () => {
+  it("GED ne lance jamais ROLLBACK après un COMMIT envoyé dont l’ACK est perdu", async () => {
+    database.clientQuery.mockImplementation(async (sql: string) => {
+      if (sql === "COMMIT") throw new Error("connection lost after commit");
+      return { rows: [] };
+    });
+    const beforeCommit = vi.fn();
+    const afterRollback = vi.fn();
+
+    const error = await withGedTransaction(
+      async () => ({ documentId: "d", versionId: "v" }),
+      { beforeCommit, afterConfirmedRollback: afterRollback }
+    ).catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(GedCommitUncertainError);
+    expect(error.transactionResult).toEqual({ documentId: "d", versionId: "v" });
+    expect(beforeCommit).toHaveBeenCalledOnce();
+    expect(afterRollback).not.toHaveBeenCalled();
+    expect(database.clientQuery.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "COMMIT"]);
+  });
+
+  it("GED exécute le nettoyage seulement après un vrai ROLLBACK confirmé", async () => {
+    const afterRollback = vi.fn();
+    const businessError = new Error("validation failed");
+
+    await expect(withGedTransaction(
+      async () => { throw businessError; },
+      { afterConfirmedRollback: afterRollback }
+    )).rejects.toBe(businessError);
+
+    expect(afterRollback).toHaveBeenCalledOnce();
+    expect(database.clientQuery.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "ROLLBACK"]);
+  });
+
+  it("Project Office préserve le résultat métier quand seul l’ACK de COMMIT manque", async () => {
+    database.clientQuery.mockImplementation(async (sql: string) => {
+      if (sql === "COMMIT") throw new Error("ack lost");
+      return { rows: [] };
+    });
+
+    const error = await withProjectOfficeTransaction(async () => ({ file: { id: "file-1" } }))
+      .catch((caught) => caught);
+
+    expect(error).toBeInstanceOf(PoCommitUncertainError);
+    expect(error.transactionResult).toEqual({ file: { id: "file-1" } });
+    expect(database.clientQuery.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "COMMIT"]);
+  });
+
+  it("Project Office nettoie via ROLLBACK sur une erreur pré-COMMIT", async () => {
+    const businessError = new Error("insert failed");
+    await expect(withProjectOfficeTransaction(async () => {
+      throw businessError;
+    })).rejects.toBe(businessError);
+
+    expect(database.clientQuery.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "ROLLBACK"]);
+  });
+});

--- a/src/__tests__/upload-transaction.test.ts
+++ b/src/__tests__/upload-transaction.test.ts
@@ -1,0 +1,223 @@
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { promoteSecureUpload, registerUploadDestination } from "../shared/uploads/secure-upload";
+import {
+  UploadCommitUncertainError,
+  UploadRollbackUncertainError,
+  classifyUploadReconciliation,
+  withUploadTransaction,
+} from "../shared/uploads/upload-transaction";
+
+type FakeClient = {
+  query: ReturnType<typeof vi.fn>;
+  release: ReturnType<typeof vi.fn>;
+};
+
+const roots: string[] = [];
+
+async function ownedFile(): Promise<{ source: string; destination: string }> {
+  const root = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-upload-tx-"));
+  roots.push(root);
+  const source = path.join(root, "upload.part");
+  const destination = path.join(root, "durable.pdf");
+  await fs.writeFile(destination, "%PDF-1.7\n");
+  registerUploadDestination({ path: source }, destination);
+  return { source, destination };
+}
+
+function clientWith(handler?: (sql: string) => Promise<unknown>): FakeClient {
+  return {
+    query: vi.fn(async (sql: string) => handler ? handler(sql) : { rows: [] }),
+    release: vi.fn(),
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => fs.rm(root, { recursive: true, force: true })));
+});
+
+describe("shared upload transaction lifecycle", () => {
+  it("tracks a staging file after promotion mutates its path", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-upload-promote-"));
+    roots.push(root);
+    const stagingPath = path.join(root, "machine.part");
+    const durableDirectory = path.join(root, "images");
+    await fs.writeFile(stagingPath, "safe image");
+    const file = {
+      path: stagingPath,
+      originalname: "machine.png",
+      fieldname: "image",
+      encoding: "7bit",
+      mimetype: "image/png",
+      size: 10,
+      destination: path.dirname(stagingPath),
+      filename: path.basename(stagingPath),
+      stream: null,
+      buffer: Buffer.alloc(0),
+    } as unknown as Express.Multer.File;
+    const client = clientWith();
+
+    await expect(withUploadTransaction({
+      client: client as never,
+      files: [file],
+      context: "test.promoted-path",
+      work: async () => promoteSecureUpload(file, durableDirectory, "machine.png"),
+      reconcile: async () => "uncertain",
+    })).resolves.toBe(path.resolve(durableDirectory, "machine.png"));
+
+    expect(file.path).toBe(path.resolve(durableDirectory, "machine.png"));
+    await expect(fs.stat(file.path)).resolves.toBeDefined();
+  });
+
+  it("removes an in-transaction promotion after a confirmed downstream rejection", async () => {
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), "cerp-upload-promote-reject-"));
+    roots.push(root);
+    const stagingPath = path.join(root, "machine.part");
+    const durableDirectory = path.join(root, "images");
+    await fs.writeFile(stagingPath, "safe image");
+    const file = {
+      path: stagingPath,
+      originalname: "machine.png",
+      fieldname: "image",
+      encoding: "7bit",
+      mimetype: "image/png",
+      size: 10,
+      destination: path.dirname(stagingPath),
+      filename: path.basename(stagingPath),
+      stream: null,
+      buffer: Buffer.alloc(0),
+    } as unknown as Express.Multer.File;
+    const client = clientWith();
+
+    await expect(withUploadTransaction({
+      client: client as never,
+      files: [file],
+      context: "test.promoted-path-rejected",
+      work: async () => {
+        await promoteSecureUpload(file, durableDirectory, "machine.png");
+        throw new Error("downstream 422");
+      },
+      reconcile: async () => "uncertain",
+    })).rejects.toThrow("downstream 422");
+
+    await expect(fs.stat(path.join(durableDirectory, "machine.png"))).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("marks a normal commit terminal and preserves its durable destination", async () => {
+    const file = await ownedFile();
+    const client = clientWith();
+
+    await expect(withUploadTransaction({
+      client: client as never,
+      files: [{ path: file.source }],
+      context: "test.normal",
+      work: async () => ({ id: "doc-1" }),
+      reconcile: async () => "uncertain",
+    })).resolves.toEqual({ id: "doc-1" });
+
+    expect(client.query.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "COMMIT"]);
+    expect(client.release).toHaveBeenCalledWith(false);
+    await expect(fs.readFile(file.destination, "utf8")).resolves.toContain("%PDF");
+  });
+
+  it("removes durable files only after a confirmed pre-COMMIT rollback", async () => {
+    const file = await ownedFile();
+    const client = clientWith();
+
+    await expect(withUploadTransaction({
+      client: client as never,
+      files: [{ path: file.source }],
+      context: "test.rollback",
+      work: async () => { throw new Error("downstream rejected"); },
+      reconcile: async () => "uncertain",
+    })).rejects.toThrow("downstream rejected");
+
+    expect(client.query.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "ROLLBACK"]);
+    await expect(fs.stat(file.destination)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("treats COMMIT ACK loss with a matching fresh row as success and never rolls back", async () => {
+    const file = await ownedFile();
+    const client = clientWith(async (sql) => {
+      if (sql === "COMMIT") throw new Error("connection reset after commit");
+      return { rows: [] };
+    });
+
+    await expect(withUploadTransaction({
+      client: client as never,
+      files: [{ path: file.source }],
+      context: "test.ack-loss-present",
+      work: async () => ({ id: "doc-2" }),
+      reconcile: async () => "committed",
+    })).resolves.toEqual({ id: "doc-2" });
+
+    expect(client.query.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "COMMIT"]);
+    expect(client.release).toHaveBeenCalledWith(true);
+    await expect(fs.stat(file.destination)).resolves.toBeDefined();
+  });
+
+  it("cleans after a fresh read proves a lost COMMIT was not applied", async () => {
+    const file = await ownedFile();
+    const client = clientWith(async (sql) => {
+      if (sql === "COMMIT") throw new Error("commit rejected");
+      return { rows: [] };
+    });
+
+    await expect(withUploadTransaction({
+      client: client as never,
+      files: [{ path: file.source }],
+      context: "test.ack-loss-absent",
+      work: async () => ({ id: "doc-3" }),
+      reconcile: async () => "not-committed",
+    })).rejects.toThrow("commit rejected");
+
+    expect(client.query.mock.calls.map(([sql]) => sql)).toEqual(["BEGIN", "COMMIT"]);
+    await expect(fs.stat(file.destination)).rejects.toMatchObject({ code: "ENOENT" });
+  });
+
+  it("preserves ownership when COMMIT reconciliation is unavailable or partial", async () => {
+    const file = await ownedFile();
+    const client = clientWith(async (sql) => {
+      if (sql === "COMMIT") throw new Error("ack lost");
+      return { rows: [] };
+    });
+
+    await expect(withUploadTransaction({
+      client: client as never,
+      files: [{ path: file.source }],
+      context: "test.ack-loss-unknown",
+      work: async () => ({ id: "doc-4" }),
+      reconcile: async () => "uncertain",
+    })).rejects.toBeInstanceOf(UploadCommitUncertainError);
+    await expect(fs.stat(file.destination)).resolves.toBeDefined();
+  });
+
+  it("preserves ownership when rollback itself cannot be confirmed", async () => {
+    const file = await ownedFile();
+    const client = clientWith(async (sql) => {
+      if (sql === "ROLLBACK") throw new Error("rollback connection lost");
+      return { rows: [] };
+    });
+
+    await expect(withUploadTransaction({
+      client: client as never,
+      files: [{ path: file.source }],
+      context: "test.rollback-unknown",
+      work: async () => { throw new Error("business failure"); },
+      reconcile: async () => "uncertain",
+    })).rejects.toBeInstanceOf(UploadRollbackUncertainError);
+    expect(client.release).toHaveBeenCalledWith(true);
+    await expect(fs.stat(file.destination)).resolves.toBeDefined();
+  });
+
+  it("classifies exact, absent, and partial fresh identities deterministically", () => {
+    expect(classifyUploadReconciliation(["a", "b"], ["b", "a"])).toBe("committed");
+    expect(classifyUploadReconciliation(["a", "b"], [])).toBe("not-committed");
+    expect(classifyUploadReconciliation(["a", "b"], ["a"])).toBe("uncertain");
+    expect(classifyUploadReconciliation(["a"], ["different"])).toBe("uncertain");
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,11 +1,12 @@
-import dotenv from 'dotenv';
+import 'dotenv/config';
 import app from './config/app';
 import { createServer } from 'http';
 import { initSocketServer } from './sockets/sockeServer'
 import { startAuditNotifyListener } from "./shared/realtime/audit-notify.listener";
+import { assertUploadScannerConfiguration } from "./shared/uploads/upload-scanner";
 
 
-dotenv.config();
+const uploadScanner = assertUploadScannerConfiguration();
 
 const PORT = parseInt(process.env.PORT || '5000', 10);
 
@@ -22,6 +23,7 @@ startAuditNotifyListener().catch((err) => {
 
 // 🚀 Lancement du serveur
 httpServer.listen(PORT, '0.0.0.0', () => {
+  console.log(`[upload_scan] mode=${uploadScanner.mode} provider=${uploadScanner.provider}`);
   console.log(`🚀 Serveur CERP lancé sur http://0.0.0.0:${PORT}`);
   console.log(`🌐 Accès local prévu : http://10.90.0.2:${PORT}`);
 });

--- a/src/middlewares/upload.ts
+++ b/src/middlewares/upload.ts
@@ -1,15 +1,6 @@
-import multer from "multer";
-import path from "path";
 import { ensureImagesSubdir } from "../utils/imageStorage";
-
-function sanitizeStem(value: string) {
-  return value
-    .normalize("NFKD")
-    .replace(/[^a-zA-Z0-9._-]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-|-$/g, "")
-    .toLowerCase();
-}
+import { createSecureUpload } from "../shared/uploads/secure-upload";
+import type { UploadUsage } from "../shared/uploads/upload-policy";
 
 function splitSubdirectory(subdirectory?: string) {
   return (subdirectory ?? "")
@@ -18,20 +9,9 @@ function splitSubdirectory(subdirectory?: string) {
     .filter(Boolean);
 }
 
-export function createImageUpload(subdirectory?: string) {
-  const storage = multer.diskStorage({
-    destination: (_req, _file, cb) => {
-      cb(null, ensureImagesSubdir(...splitSubdirectory(subdirectory)));
-    },
-    filename: (_req, file, cb) => {
-      const uniqueSuffix = Date.now() + "-" + Math.round(Math.random() * 1e9);
-      const ext = path.extname(file.originalname).toLowerCase();
-      const stem = sanitizeStem(path.basename(file.originalname, ext)) || sanitizeStem(file.fieldname) || "image";
-      cb(null, `${stem}-${uniqueSuffix}${ext}`);
-    },
-  });
-
-  return multer({ storage });
+export function createImageUpload(subdirectory?: string, usage: Extract<UploadUsage, "image" | "tool-media"> = "image") {
+  const finalDirectory = ensureImagesSubdir(...splitSubdirectory(subdirectory));
+  return createSecureUpload(usage, { storage: { finalDirectory } });
 }
 
 export const upload = createImageUpload();

--- a/src/module/asbuilt/controllers/asbuilt.controller.ts
+++ b/src/module/asbuilt/controllers/asbuilt.controller.ts
@@ -1,6 +1,8 @@
 import type { RequestHandler } from "express"
 
 import { HttpError } from "../../../utils/httpError"
+import { getDocumentStoragePath } from "../../../utils/cerpStorage"
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download"
 
 import { svcGenerateAsbuiltPack, svcGetAsbuiltPreview, svcResolveAsbuiltDocument } from "../services/asbuilt.service"
 import { asbuiltDownloadParamsSchema, asbuiltGenerateBodySchema, asbuiltLotParamsSchema } from "../validators/asbuilt.validators"
@@ -56,10 +58,13 @@ export const downloadAsbuiltDocument: RequestHandler = async (req, res, next) =>
 
     const { filePath, name } = await svcResolveAsbuiltDocument({ lotId, documentId })
 
-    const disposition = download ? "attachment" : "inline"
-    res.setHeader("Content-Type", "application/pdf")
-    res.setHeader("Content-Disposition", `${disposition}; filename=\"${name.replace(/\"/g, "")}\"`)
-    res.sendFile(filePath)
+    await sendSecureStoredFile(res, {
+      filePath,
+      allowedRoots: [getDocumentStoragePath("asbuilt")],
+      filename: name,
+      mimeType: "application/pdf",
+      download,
+    })
   } catch (e) {
     next(e)
   }

--- a/src/module/commande-client/controllers/commande-client.controller.ts
+++ b/src/module/commande-client/controllers/commande-client.controller.ts
@@ -1,9 +1,9 @@
 import type { Request, RequestHandler } from "express";
-import fs from "node:fs/promises";
 import path from "node:path";
 import { z } from "zod";
 import { HttpError } from "../../../utils/httpError";
-import { getDocumentStoragePath, isPathInsideDirectory } from "../../../utils/cerpStorage";
+import { getDocumentStoragePath } from "../../../utils/cerpStorage";
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
 import {
   createCommandeSVC,
   createCadreReleaseSVC,
@@ -603,20 +603,15 @@ export const getCommandeDocumentFile: RequestHandler = async (req, res, next) =>
 
     const baseDir = getDocumentStoragePath();
     const absPath = path.resolve(baseDir, `${doc.id}${safeExtFromName(doc.document_name)}`);
-    if (!isPathInsideDirectory(baseDir, absPath)) {
-      throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path");
-    }
-
-    await fs.access(absPath);
-
-    res.setHeader("Content-Type", resolveMimeType(doc.type));
     const rawDownload = (req.query as { download?: unknown } | undefined)?.download;
     const download = rawDownload === true || rawDownload === "true" || rawDownload === "1" || rawDownload === 1;
-    res.setHeader(
-      "Content-Disposition",
-      `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(doc.document_name)}"`
-    );
-    res.sendFile(absPath);
+    await sendSecureStoredFile(res, {
+      filePath: absPath,
+      allowedRoots: [baseDir],
+      filename: doc.document_name,
+      mimeType: resolveMimeType(doc.type),
+      download,
+    });
   } catch (err) {
     if (err && typeof err === "object" && "code" in err && (err as { code?: unknown }).code === "ENOENT") {
       next(new HttpError(404, "FILE_NOT_FOUND", "File not found"));

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -7,6 +7,7 @@ import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { generateAffaireCode, generateCommandeCode, generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
 import { emitAppNotificationCreated, emitEntityChanged } from "../../../shared/realtime/realtime.service";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
@@ -2979,6 +2980,7 @@ async function insertCommandeDocuments(client: PoolClient, commandeId: string, d
       await fs.copyFile(doc.path, finalPath);
       await fs.unlink(doc.path);
     }
+    registerUploadDestination(doc, finalPath);
 
     await client.query(
       `

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -5,16 +5,10 @@ import { isDeepStrictEqual } from "node:util";
 import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
-import logger from "../../../utils/logger";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { generateAffaireCode, generateCommandeCode, generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
-import {
-  cleanupUploadsAfterConfirmedRollback,
-  cleanupUploadsAfterReconciledNoCommit,
-  markUploadCommitAttempted,
-  markUploadsCommitted,
-  registerUploadDestination,
-} from "../../../shared/uploads/secure-upload";
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
+import { withUploadTransaction } from "../../../shared/uploads/upload-transaction";
 import { emitAppNotificationCreated, emitEntityChanged } from "../../../shared/realtime/realtime.service";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
@@ -3037,15 +3031,19 @@ async function reconcileCommandeUploadCommit(
     }
 
     const ids = movedDocuments.map((move) => move.documentId);
-    const result = await pool.query<{ document_id: string }>(
-      `SELECT cd.document_id::text AS document_id
-         FROM public.commande_documents cd
-        WHERE cd.commande_id = $1::bigint
-          AND cd.document_id = ANY($2::uuid[])`,
+    const result = await pool.query<{ document_id: string; commande_id: string | null }>(
+      `SELECT dc.id::text AS document_id, cd.commande_id::text AS commande_id
+         FROM public.documents_clients dc
+         LEFT JOIN public.commande_documents cd
+           ON cd.document_id = dc.id AND cd.commande_id = $1::bigint
+        WHERE dc.id = ANY($2::uuid[])`,
       [commandeId, ids]
     );
-    const persisted = new Set(result.rows.map((row) => String(row.document_id)));
-    if (persisted.size === 0) return "not-committed";
+    const persisted = new Set(result.rows
+      .filter((row) => row.commande_id === commandeId)
+      .map((row) => String(row.document_id)));
+    if (result.rows.length === 0) return "not-committed";
+    if (persisted.size === 0) return "uncertain";
     if (persisted.size !== ids.length || ids.some((id) => !persisted.has(id))) return "uncertain";
 
     const filesPresent = await Promise.all(movedDocuments.map(async (move) => {
@@ -3118,11 +3116,15 @@ async function transitionLinkedDevisArticlesToValide(
 export async function repoCreateCommande(input: CreateCommandeInput, documents: UploadedDocument[]) {
   const client = await pool.connect();
   let notifications: AppNotification[] = [];
-  let commitAttempted = false;
   let commandeIdForReconciliation: string | null = null;
   const movedDocuments: CommandeDocumentMove[] = [];
+  let result: { id: number };
   try {
-    await client.query("BEGIN");
+    result = await withUploadTransaction({
+      client,
+      files: documents,
+      context: "commande-client.create",
+      work: async () => {
 
     await assertDevisDraftIsFresh(client, input.devis_id ?? null, input.source_devis_updated_at ?? null);
 
@@ -3261,54 +3263,13 @@ export async function repoCreateCommande(input: CreateCommandeInput, documents: 
       dedupe_key: `commande:${commandeIdInt}:checkpoint:technical_analysis:created`,
     });
 
-    markUploadCommitAttempted(documents);
-    commitAttempted = true;
-    await client.query("COMMIT");
-    markUploadsCommitted(documents);
-    for (const notification of notifications) {
-      emitAppNotificationCreated(notification.user_id, notification);
-    }
     return { id: toInt(commandeId, "commande.id") };
+      },
+      reconcile: async () => commandeIdForReconciliation
+        ? reconcileCommandeUploadCommit(commandeIdForReconciliation, movedDocuments, "create")
+        : "uncertain",
+    });
   } catch (e) {
-    if (commitAttempted && commandeIdForReconciliation) {
-      const outcome = await reconcileCommandeUploadCommit(
-        commandeIdForReconciliation,
-        movedDocuments,
-        "create"
-      );
-      if (outcome === "committed") {
-        markUploadsCommitted(documents);
-        for (const notification of notifications) {
-          emitAppNotificationCreated(notification.user_id, notification);
-        }
-        return { id: toInt(commandeIdForReconciliation, "commande.id") };
-      }
-      if (outcome === "not-committed") {
-        await cleanupUploadsAfterReconciledNoCommit(documents);
-      } else {
-        logger.error("[COMMANDE_UPLOAD_COMMIT_UNCERTAIN] durable files preserved", JSON.stringify({
-          operation: "create",
-          document_count: movedDocuments.length,
-        }));
-        throw new HttpError(
-          503,
-          "COMMANDE_COMMIT_UNCERTAIN",
-          "Le résultat de l’enregistrement doit être rapproché avant de renvoyer les documents."
-        );
-      }
-    } else {
-      let rollbackConfirmed = false;
-      try {
-        await client.query("ROLLBACK");
-        rollbackConfirmed = true;
-      } catch {
-        logger.error("[COMMANDE_UPLOAD_ROLLBACK_UNCERTAIN] durable files preserved", JSON.stringify({
-          operation: "create",
-          document_count: movedDocuments.length,
-        }));
-      }
-      if (rollbackConfirmed) await cleanupUploadsAfterConfirmedRollback(documents);
-    }
     if (isObject(e)) {
       const code = typeof e.code === "string" ? e.code : null;
       const constraint = typeof e.constraint === "string" ? e.constraint : null;
@@ -3317,17 +3278,22 @@ export async function repoCreateCommande(input: CreateCommandeInput, documents: 
       }
     }
     throw e;
-  } finally {
-    client.release();
   }
+  for (const notification of notifications) {
+    emitAppNotificationCreated(notification.user_id, notification);
+  }
+  return result;
 }
 
 export async function repoUpdateCommande(id: string, input: CreateCommandeInput, documents: UploadedDocument[]) {
   const client = await pool.connect();
-  let commitAttempted = false;
   const movedDocuments: CommandeDocumentMove[] = [];
   try {
-    await client.query("BEGIN");
+    return await withUploadTransaction({
+      client,
+      files: documents,
+      context: "commande-client.update",
+      work: async () => {
 
     const existingRes = await client.query<{
       numero: string;
@@ -3361,7 +3327,6 @@ export async function repoUpdateCommande(id: string, input: CreateCommandeInput,
     );
     const existing = existingRes.rows[0] ?? null;
     if (!existing) {
-      await client.query("ROLLBACK");
       return null;
     }
 
@@ -3475,7 +3440,6 @@ export async function repoUpdateCommande(id: string, input: CreateCommandeInput,
     const updated = await client.query<{ id: string }>(updateSql, updateParams);
     const commandeId = updated.rows[0]?.id;
     if (!commandeId) {
-      await client.query("ROLLBACK");
       return null;
     }
 
@@ -3490,44 +3454,11 @@ export async function repoUpdateCommande(id: string, input: CreateCommandeInput,
     await insertCommandeDocuments(client, id, documents, movedDocuments);
     await transitionLinkedDevisArticlesToValide(client, toInt(id, "commande_id"), devisIdForUpdate);
 
-    markUploadCommitAttempted(documents);
-    commitAttempted = true;
-    await client.query("COMMIT");
-    markUploadsCommitted(documents);
     return { id: toInt(commandeId, "commande.id") };
+      },
+      reconcile: async () => reconcileCommandeUploadCommit(id, movedDocuments, "update"),
+    });
   } catch (e) {
-    if (commitAttempted) {
-      const outcome = await reconcileCommandeUploadCommit(id, movedDocuments, "update");
-      if (outcome === "committed") {
-        markUploadsCommitted(documents);
-        return { id: toInt(id, "commande.id") };
-      }
-      if (outcome === "not-committed") {
-        await cleanupUploadsAfterReconciledNoCommit(documents);
-      } else {
-        logger.error("[COMMANDE_UPLOAD_COMMIT_UNCERTAIN] durable files preserved", JSON.stringify({
-          operation: "update",
-          document_count: movedDocuments.length,
-        }));
-        throw new HttpError(
-          503,
-          "COMMANDE_COMMIT_UNCERTAIN",
-          "Le résultat de la mise à jour doit être rapproché avant de renvoyer les documents."
-        );
-      }
-    } else {
-      let rollbackConfirmed = false;
-      try {
-        await client.query("ROLLBACK");
-        rollbackConfirmed = true;
-      } catch {
-        logger.error("[COMMANDE_UPLOAD_ROLLBACK_UNCERTAIN] durable files preserved", JSON.stringify({
-          operation: "update",
-          document_count: movedDocuments.length,
-        }));
-      }
-      if (rollbackConfirmed) await cleanupUploadsAfterConfirmedRollback(documents);
-    }
     if (isObject(e)) {
       const code = typeof e.code === "string" ? e.code : null;
       const constraint = typeof e.constraint === "string" ? e.constraint : null;
@@ -3536,8 +3467,6 @@ export async function repoUpdateCommande(id: string, input: CreateCommandeInput,
       }
     }
     throw e;
-  } finally {
-    client.release();
   }
 }
 

--- a/src/module/commande-client/repository/commande-client.repository.ts
+++ b/src/module/commande-client/repository/commande-client.repository.ts
@@ -5,9 +5,16 @@ import { isDeepStrictEqual } from "node:util";
 import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
+import logger from "../../../utils/logger";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { generateAffaireCode, generateCommandeCode, generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
-import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
+import {
+  cleanupUploadsAfterConfirmedRollback,
+  cleanupUploadsAfterReconciledNoCommit,
+  markUploadCommitAttempted,
+  markUploadsCommitted,
+  registerUploadDestination,
+} from "../../../shared/uploads/secure-upload";
 import { emitAppNotificationCreated, emitEntityChanged } from "../../../shared/realtime/realtime.service";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
@@ -2959,7 +2966,18 @@ async function insertCommandeEcheances(
   );
 }
 
-async function insertCommandeDocuments(client: PoolClient, commandeId: string, documents: UploadedDocument[]) {
+type CommandeDocumentMove = Readonly<{
+  file: UploadedDocument;
+  documentId: string;
+  finalPath: string;
+}>;
+
+async function insertCommandeDocuments(
+  client: PoolClient,
+  commandeId: string,
+  documents: UploadedDocument[],
+  movedDocuments: CommandeDocumentMove[]
+) {
   if (!documents.length) return;
 
   for (const doc of documents) {
@@ -2981,6 +2999,7 @@ async function insertCommandeDocuments(client: PoolClient, commandeId: string, d
       await fs.unlink(doc.path);
     }
     registerUploadDestination(doc, finalPath);
+    movedDocuments.push({ file: doc, documentId, finalPath });
 
     await client.query(
       `
@@ -2997,6 +3016,45 @@ async function insertCommandeDocuments(client: PoolClient, commandeId: string, d
       `,
       [commandeId, documentId, isPdf ? "PDF" : null]
     );
+  }
+}
+
+type CommandeUploadCommitOutcome = "committed" | "not-committed" | "uncertain";
+
+async function reconcileCommandeUploadCommit(
+  commandeId: string,
+  movedDocuments: readonly CommandeDocumentMove[],
+  operation: "create" | "update"
+): Promise<CommandeUploadCommitOutcome> {
+  try {
+    if (movedDocuments.length === 0) {
+      if (operation === "update") return "uncertain";
+      const command = await pool.query(
+        `SELECT EXISTS (SELECT 1 FROM public.commande_client WHERE id = $1::bigint) AS committed`,
+        [commandeId]
+      );
+      return command.rows[0]?.committed === true ? "committed" : "not-committed";
+    }
+
+    const ids = movedDocuments.map((move) => move.documentId);
+    const result = await pool.query<{ document_id: string }>(
+      `SELECT cd.document_id::text AS document_id
+         FROM public.commande_documents cd
+        WHERE cd.commande_id = $1::bigint
+          AND cd.document_id = ANY($2::uuid[])`,
+      [commandeId, ids]
+    );
+    const persisted = new Set(result.rows.map((row) => String(row.document_id)));
+    if (persisted.size === 0) return "not-committed";
+    if (persisted.size !== ids.length || ids.some((id) => !persisted.has(id))) return "uncertain";
+
+    const filesPresent = await Promise.all(movedDocuments.map(async (move) => {
+      const stat = await fs.stat(move.finalPath).catch(() => null);
+      return stat?.isFile() === true;
+    }));
+    return filesPresent.every(Boolean) ? "committed" : "uncertain";
+  } catch {
+    return "uncertain";
   }
 }
 
@@ -3060,6 +3118,9 @@ async function transitionLinkedDevisArticlesToValide(
 export async function repoCreateCommande(input: CreateCommandeInput, documents: UploadedDocument[]) {
   const client = await pool.connect();
   let notifications: AppNotification[] = [];
+  let commitAttempted = false;
+  let commandeIdForReconciliation: string | null = null;
+  const movedDocuments: CommandeDocumentMove[] = [];
   try {
     await client.query("BEGIN");
 
@@ -3152,13 +3213,14 @@ export async function repoCreateCommande(input: CreateCommandeInput, documents: 
     const ins = await client.query<{ id: string }>(insertSql, insertParams);
     const commandeId = ins.rows[0]?.id;
     if (!commandeId) throw new Error("Failed to create commande");
+    commandeIdForReconciliation = commandeId;
 
     await insertCommandeLignes(client, commandeId, input.lignes, {
       officialize_preparatory_data: input.officialize_preparatory_data ?? false,
       commande_id_int: commandeIdInt,
     });
     await insertCommandeEcheances(client, commandeId, input.echeances ?? []);
-    await insertCommandeDocuments(client, commandeId, documents);
+    await insertCommandeDocuments(client, commandeId, documents, movedDocuments);
     await transitionLinkedDevisArticlesToValide(client, commandeIdInt, input.devis_id ?? null);
     await repoEnsureCommandeWorkflowCheckpoints(client, commandeIdInt, initialWorkflowStatus);
 
@@ -3199,13 +3261,54 @@ export async function repoCreateCommande(input: CreateCommandeInput, documents: 
       dedupe_key: `commande:${commandeIdInt}:checkpoint:technical_analysis:created`,
     });
 
+    markUploadCommitAttempted(documents);
+    commitAttempted = true;
     await client.query("COMMIT");
+    markUploadsCommitted(documents);
     for (const notification of notifications) {
       emitAppNotificationCreated(notification.user_id, notification);
     }
     return { id: toInt(commandeId, "commande.id") };
   } catch (e) {
-    await client.query("ROLLBACK");
+    if (commitAttempted && commandeIdForReconciliation) {
+      const outcome = await reconcileCommandeUploadCommit(
+        commandeIdForReconciliation,
+        movedDocuments,
+        "create"
+      );
+      if (outcome === "committed") {
+        markUploadsCommitted(documents);
+        for (const notification of notifications) {
+          emitAppNotificationCreated(notification.user_id, notification);
+        }
+        return { id: toInt(commandeIdForReconciliation, "commande.id") };
+      }
+      if (outcome === "not-committed") {
+        await cleanupUploadsAfterReconciledNoCommit(documents);
+      } else {
+        logger.error("[COMMANDE_UPLOAD_COMMIT_UNCERTAIN] durable files preserved", JSON.stringify({
+          operation: "create",
+          document_count: movedDocuments.length,
+        }));
+        throw new HttpError(
+          503,
+          "COMMANDE_COMMIT_UNCERTAIN",
+          "Le résultat de l’enregistrement doit être rapproché avant de renvoyer les documents."
+        );
+      }
+    } else {
+      let rollbackConfirmed = false;
+      try {
+        await client.query("ROLLBACK");
+        rollbackConfirmed = true;
+      } catch {
+        logger.error("[COMMANDE_UPLOAD_ROLLBACK_UNCERTAIN] durable files preserved", JSON.stringify({
+          operation: "create",
+          document_count: movedDocuments.length,
+        }));
+      }
+      if (rollbackConfirmed) await cleanupUploadsAfterConfirmedRollback(documents);
+    }
     if (isObject(e)) {
       const code = typeof e.code === "string" ? e.code : null;
       const constraint = typeof e.constraint === "string" ? e.constraint : null;
@@ -3221,6 +3324,8 @@ export async function repoCreateCommande(input: CreateCommandeInput, documents: 
 
 export async function repoUpdateCommande(id: string, input: CreateCommandeInput, documents: UploadedDocument[]) {
   const client = await pool.connect();
+  let commitAttempted = false;
+  const movedDocuments: CommandeDocumentMove[] = [];
   try {
     await client.query("BEGIN");
 
@@ -3382,13 +3487,47 @@ export async function repoUpdateCommande(id: string, input: CreateCommandeInput,
       commande_id_int: toInt(id, "commande_id"),
     });
     await insertCommandeEcheances(client, id, input.echeances ?? []);
-    await insertCommandeDocuments(client, id, documents);
+    await insertCommandeDocuments(client, id, documents, movedDocuments);
     await transitionLinkedDevisArticlesToValide(client, toInt(id, "commande_id"), devisIdForUpdate);
 
+    markUploadCommitAttempted(documents);
+    commitAttempted = true;
     await client.query("COMMIT");
+    markUploadsCommitted(documents);
     return { id: toInt(commandeId, "commande.id") };
   } catch (e) {
-    await client.query("ROLLBACK");
+    if (commitAttempted) {
+      const outcome = await reconcileCommandeUploadCommit(id, movedDocuments, "update");
+      if (outcome === "committed") {
+        markUploadsCommitted(documents);
+        return { id: toInt(id, "commande.id") };
+      }
+      if (outcome === "not-committed") {
+        await cleanupUploadsAfterReconciledNoCommit(documents);
+      } else {
+        logger.error("[COMMANDE_UPLOAD_COMMIT_UNCERTAIN] durable files preserved", JSON.stringify({
+          operation: "update",
+          document_count: movedDocuments.length,
+        }));
+        throw new HttpError(
+          503,
+          "COMMANDE_COMMIT_UNCERTAIN",
+          "Le résultat de la mise à jour doit être rapproché avant de renvoyer les documents."
+        );
+      }
+    } else {
+      let rollbackConfirmed = false;
+      try {
+        await client.query("ROLLBACK");
+        rollbackConfirmed = true;
+      } catch {
+        logger.error("[COMMANDE_UPLOAD_ROLLBACK_UNCERTAIN] durable files preserved", JSON.stringify({
+          operation: "update",
+          document_count: movedDocuments.length,
+        }));
+      }
+      if (rollbackConfirmed) await cleanupUploadsAfterConfirmedRollback(documents);
+    }
     if (isObject(e)) {
       const code = typeof e.code === "string" ? e.code : null;
       const constraint = typeof e.constraint === "string" ? e.constraint : null;

--- a/src/module/commande-client/routes/commande-client.routes.ts
+++ b/src/module/commande-client/routes/commande-client.routes.ts
@@ -1,10 +1,9 @@
 import type { RequestHandler } from "express"
 import { Router } from "express"
-import multer from "multer"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
 import { HttpError } from "../../../utils/httpError"
-import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
+import { createSecureUpload } from "../../../shared/uploads/secure-upload"
 import {
   addCadreReleaseLine,
   analyzeCommandeStock,
@@ -45,8 +44,7 @@ import {
   validate,
 } from "../validators/commande-client.validators"
 
-const uploadDir = ensureDocumentStoragePath()
-const upload = multer({ dest: uploadDir })
+const upload = createSecureUpload("business-document")
 
 // middleware pour parser `data` JSON depuis multipart
 declare global {

--- a/src/module/devis/controllers/devis.controller.ts
+++ b/src/module/devis/controllers/devis.controller.ts
@@ -1,8 +1,8 @@
 import type { Request, RequestHandler } from "express";
-import fs from "node:fs/promises";
 import path from "node:path";
-import { getDocumentStoragePath, isPathInsideDirectory } from "../../../utils/cerpStorage";
+import { getDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
 import {
   convertDevisBodySchema,
   devisArticleParamsSchema,
@@ -283,20 +283,15 @@ export const getDevisDocumentFile: RequestHandler = async (req, res, next) => {
 
     const baseDir = getDocumentStoragePath();
     const absPath = path.resolve(baseDir, `${doc.id}${safeExtFromName(doc.document_name)}`);
-    if (!isPathInsideDirectory(baseDir, absPath)) {
-      throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path");
-    }
-
-    await fs.access(absPath);
-
-    res.setHeader("Content-Type", resolveMimeType(doc.type));
     const rawDownload = (req.query as { download?: unknown } | undefined)?.download;
     const download = rawDownload === true || rawDownload === "true" || rawDownload === "1" || rawDownload === 1;
-    res.setHeader(
-      "Content-Disposition",
-      `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(doc.document_name)}"`
-    );
-    res.sendFile(absPath);
+    await sendSecureStoredFile(res, {
+      filePath: absPath,
+      allowedRoots: [baseDir],
+      filename: doc.document_name,
+      mimeType: resolveMimeType(doc.type),
+      download,
+    });
   } catch (err) {
     if (err && typeof err === "object" && "code" in err && (err as { code?: unknown }).code === "ENOENT") {
       next(new HttpError(404, "FILE_NOT_FOUND", "File not found"));

--- a/src/module/devis/repository/devis.repository.ts
+++ b/src/module/devis/repository/devis.repository.ts
@@ -7,6 +7,7 @@ import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { generateCommandeCode, generateDevisCode } from "../../../shared/codes/code-generator.service";
 import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
+import { classifyUploadReconciliation, withUploadTransaction } from "../../../shared/uploads/upload-transaction";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import { computeDevisTotals, computeLineTotals } from "../lib/totals";
@@ -1045,8 +1046,30 @@ async function insertDevisLines(client: PoolClient, devisId: number, lignes: Cre
   return inserted;
 }
 
-async function insertDevisDocuments(client: PoolClient, devisId: number, documents: UploadedDocument[]) {
-  if (!documents.length) return;
+type DevisUploadExpectation = {
+  documentId: string;
+  devisId: number;
+  key: string;
+  absolutePath: string;
+};
+
+type DevisMutationExpectation = {
+  mode: "create" | "revise" | "update" | "replay";
+  devisId: number;
+  rootDevisId?: number;
+  parentDevisId?: number | null;
+  versionNumber?: number;
+  updatedAt?: string | null;
+  previousUpdatedAt?: string | null;
+};
+
+async function insertDevisDocuments(
+  client: PoolClient,
+  devisId: number,
+  documents: UploadedDocument[]
+): Promise<DevisUploadExpectation[]> {
+  const expected: DevisUploadExpectation[] = [];
+  if (!documents.length) return expected;
 
   for (const doc of documents) {
     const documentId = crypto.randomUUID();
@@ -1081,7 +1104,85 @@ async function insertDevisDocuments(client: PoolClient, devisId: number, documen
       `,
       [devisId, documentId, isPdf ? "PDF" : null]
     );
+    expected.push({
+      documentId,
+      devisId,
+      key: `${devisId}|${documentId}|${doc.originalname}|${docType}`,
+      absolutePath: finalPath,
+    });
   }
+  return expected;
+}
+
+async function reconcileDevisDocumentUploads(
+  expected: readonly DevisUploadExpectation[]
+): Promise<"committed" | "not-committed" | "uncertain"> {
+  if (expected.length === 0) return "committed";
+  const { rows } = await pool.query<{
+    devis_id: string | null;
+    document_id: string;
+    document_name: string;
+    type: string | null;
+  }>(
+    `SELECT dd.devis_id::text AS devis_id,
+            dc.id::text AS document_id,
+            dc.document_name,
+            dc.type
+       FROM public.documents_clients dc
+       LEFT JOIN public.devis_documents dd ON dd.document_id = dc.id
+      WHERE dc.id = ANY($1::uuid[])`,
+    [expected.map((entry) => entry.documentId)]
+  );
+  const status = classifyUploadReconciliation(
+    expected.map((entry) => entry.key),
+    rows.map((row) => `${row.devis_id ?? ""}|${row.document_id}|${row.document_name}|${row.type ?? ""}`)
+  );
+  if (status !== "committed") return status;
+  const present = await Promise.all(
+    expected.map((entry) => fs.stat(entry.absolutePath).then((stat) => stat.isFile()).catch(() => false))
+  );
+  return present.every(Boolean) ? "committed" : "uncertain";
+}
+
+async function reconcileDevisMutation(
+  mutation: DevisMutationExpectation | null,
+  uploads: readonly DevisUploadExpectation[]
+): Promise<"committed" | "not-committed" | "uncertain"> {
+  if (!mutation) return "uncertain";
+  const { rows } = await pool.query<{
+    id: string;
+    root_devis_id: string | null;
+    parent_devis_id: string | null;
+    version_number: number;
+    updated_at: string | null;
+  }>(
+    `SELECT id::text AS id,
+            root_devis_id::text AS root_devis_id,
+            parent_devis_id::text AS parent_devis_id,
+            version_number::int AS version_number,
+            updated_at::text AS updated_at
+       FROM public.devis
+      WHERE id = $1::bigint`,
+    [mutation.devisId]
+  );
+  const row = rows[0];
+  if (!row) return mutation.mode === "create" || mutation.mode === "revise" ? "not-committed" : "uncertain";
+  if (mutation.mode === "replay") return "committed";
+  if (mutation.mode === "update") {
+    if (row.updated_at === mutation.updatedAt) {
+      const documents = await reconcileDevisDocumentUploads(uploads);
+      return documents === "not-committed" ? "uncertain" : documents;
+    }
+    if (row.updated_at === mutation.previousUpdatedAt) return "not-committed";
+    return "uncertain";
+  }
+  const aggregateMatches =
+    row.root_devis_id === String(mutation.rootDevisId) &&
+    row.parent_devis_id === (mutation.parentDevisId === null ? null : String(mutation.parentDevisId)) &&
+    row.version_number === mutation.versionNumber;
+  if (!aggregateMatches) return "uncertain";
+  const documents = await reconcileDevisDocumentUploads(uploads);
+  return documents === "not-committed" ? "uncertain" : documents;
 }
 
 export async function repoGetDevis(id: number, includeValue: string) {
@@ -1591,13 +1692,19 @@ export async function repoCreateDevis(
   const idempotencyPayloadHash = ctx.idempotency_key
     ? devisIdempotencyPayloadHash({ input, documents: documents.map((d) => d.originalname) })
     : null;
+  let expectedUploads: DevisUploadExpectation[] = [];
+  let expectedMutation: DevisMutationExpectation | null = null;
   try {
-    await client.query("BEGIN");
+    return await withUploadTransaction({
+      client,
+      files: documents,
+      context: "devis.create",
+      work: async () => {
 
     if (ctx.idempotency_key && idempotencyPayloadHash && (await hasDevisIdempotenceTable(client))) {
       const replay = await readDevisIdempotentReplay(client, ctx.idempotency_key, "CREATE", idempotencyPayloadHash);
       if (replay) {
-        await client.query("COMMIT");
+        expectedMutation = { mode: "replay", devisId: Number(replay.id) };
         return replay as { id: number; idempotent_replay: true };
       }
     }
@@ -1684,7 +1791,7 @@ export async function repoCreateDevis(
     );
 
     await insertDevisLines(client, devisId, input.lignes);
-    await insertDevisDocuments(client, devisId, documents);
+    expectedUploads = await insertDevisDocuments(client, devisId, documents);
 
     await insertDevisAuditLog(client, ctx.audit, {
       action: "devis.create",
@@ -1701,14 +1808,22 @@ export async function repoCreateDevis(
 
     const inserted = ins.rows[0]?.id;
     const resultat = { id: inserted ? toInt(inserted, "devis.id") : devisId };
+    expectedMutation = {
+      mode: "create",
+      devisId: resultat.id,
+      rootDevisId: devisId,
+      parentDevisId: null,
+      versionNumber: 1,
+    };
     if (ctx.idempotency_key && idempotencyPayloadHash && (await hasDevisIdempotenceTable(client))) {
       await recordDevisIdempotence(client, ctx.idempotency_key, "CREATE", resultat.id, idempotencyPayloadHash, resultat);
     }
 
-    await client.query("COMMIT");
     return { ...resultat, idempotent_replay: false };
+      },
+      reconcile: async () => reconcileDevisMutation(expectedMutation, expectedUploads),
+    });
   } catch (err) {
-    await client.query("ROLLBACK");
     const { code, constraint } = getPgErrorInfo(err);
     if (code === "23505" && constraint === "devis_numero_key") {
       throw new HttpError(409, "DEVIS_NUMERO_EXISTS", "Numero already exists");
@@ -1719,8 +1834,6 @@ export async function repoCreateDevis(
       if (replay) return replay as { id: number; idempotent_replay: true };
     }
     throw err;
-  } finally {
-    client.release();
   }
 }
 
@@ -1748,8 +1861,14 @@ export async function repoUpdateDevis(
   ctx: DevisWriteContext = {}
 ) {
   const client = await pool.connect();
+  let expectedUploads: DevisUploadExpectation[] = [];
+  let expectedMutation: DevisMutationExpectation | null = null;
   try {
-    await client.query("BEGIN");
+    return await withUploadTransaction({
+      client,
+      files: documents,
+      context: "devis.update",
+      work: async () => {
 
     // #167 : l'écriture démarre TOUJOURS par un verrou de la ligne + lecture de l'état
     // (statut courant, jeton de fraîcheur, descendance) — l'automate et l'immutabilité
@@ -1778,7 +1897,6 @@ export async function repoUpdateDevis(
     );
     const current = currentRes.rows[0] ?? null;
     if (!current) {
-      await client.query("ROLLBACK");
       return null;
     }
 
@@ -1890,38 +2008,45 @@ export async function repoUpdateDevis(
     }
 
     if (sets.length === 0 && input.lignes === undefined && documents.length === 0) {
-      await client.query("ROLLBACK");
       throw new HttpError(400, "NO_UPDATE", "No fields to update");
     }
 
     let updatedId: number | null = null;
+    let updatedAt: string | null = null;
     if (sets.length) {
       sets.push("updated_at = now()");
       const updateSql = `
         UPDATE devis
         SET ${sets.join(", ")}
         WHERE id = $1
-        RETURNING id::text AS id
+        RETURNING id::text AS id, updated_at::text AS updated_at
       `;
-      const updateRes = await client.query<{ id: string }>(updateSql, values);
+      const updateRes = await client.query<{ id: string; updated_at: string | null }>(updateSql, values);
       const row = updateRes.rows[0] ?? null;
       if (!row) {
-        await client.query("ROLLBACK");
         return null;
       }
       updatedId = toInt(row.id, "devis.id");
+      updatedAt = row.updated_at;
     } else {
-      const touch = await client.query<{ id: string }>(
-        `UPDATE devis SET updated_at = now() WHERE id = $1 RETURNING id::text AS id`,
+      const touch = await client.query<{ id: string; updated_at: string | null }>(
+        `UPDATE devis SET updated_at = now() WHERE id = $1 RETURNING id::text AS id, updated_at::text AS updated_at`,
         [id]
       );
       const row = touch.rows[0] ?? null;
       if (!row) {
-        await client.query("ROLLBACK");
         return null;
       }
       updatedId = toInt(row.id, "devis.id");
+      updatedAt = row.updated_at;
     }
+
+    expectedMutation = {
+      mode: "update",
+      devisId: id,
+      updatedAt,
+      previousUpdatedAt: current.updated_at,
+    };
 
     if (input.lignes) {
       await deleteDevisPreparatoryEntities(client, id);
@@ -1929,7 +2054,7 @@ export async function repoUpdateDevis(
       await insertDevisLines(client, id, input.lignes);
     }
 
-    await insertDevisDocuments(client, id, documents);
+    expectedUploads = await insertDevisDocuments(client, id, documents);
 
     if (statutChanges) {
       await insertDevisAuditLog(client, ctx.audit, {
@@ -1951,17 +2076,16 @@ export async function repoUpdateDevis(
       });
     }
 
-    await client.query("COMMIT");
     return { id: updatedId };
+      },
+      reconcile: async () => reconcileDevisMutation(expectedMutation, expectedUploads),
+    });
   } catch (err) {
-    await client.query("ROLLBACK");
     const { code, constraint } = getPgErrorInfo(err);
     if (code === "23505" && constraint === "devis_numero_key") {
       throw new HttpError(409, "DEVIS_NUMERO_EXISTS", "Numero already exists");
     }
     throw err;
-  } finally {
-    client.release();
   }
 }
 
@@ -1976,13 +2100,19 @@ export async function repoReviseDevis(
   const idempotencyPayloadHash = ctx.idempotency_key
     ? devisIdempotencyPayloadHash({ source_devis_id: id, input, documents: documents.map((d) => d.originalname) })
     : null;
+  let expectedUploads: DevisUploadExpectation[] = [];
+  let expectedMutation: DevisMutationExpectation | null = null;
   try {
-    await client.query("BEGIN");
+    return await withUploadTransaction({
+      client,
+      files: documents,
+      context: "devis.revise",
+      work: async () => {
 
     if (ctx.idempotency_key && idempotencyPayloadHash && (await hasDevisIdempotenceTable(client))) {
       const replay = await readDevisIdempotentReplay(client, ctx.idempotency_key, "REVISE", idempotencyPayloadHash);
       if (replay) {
-        await client.query("COMMIT");
+        expectedMutation = { mode: "replay", devisId: Number(replay.id) };
         return replay as {
           id: number;
           root_devis_id: number;
@@ -2042,7 +2172,6 @@ export async function repoReviseDevis(
 
     const source = sourceRes.rows[0] ?? null;
     if (!source) {
-      await client.query("ROLLBACK");
       return null;
     }
 
@@ -2210,7 +2339,7 @@ export async function repoReviseDevis(
       [newDevisId, id]
     );
 
-    await insertDevisDocuments(client, newDevisId, documents);
+    expectedUploads = await insertDevisDocuments(client, newDevisId, documents);
 
     const newId = inserted.rows[0]?.id;
     const resultat = {
@@ -2218,6 +2347,13 @@ export async function repoReviseDevis(
       root_devis_id: rootDevisId,
       parent_devis_id: id,
       version_number: nextVersion,
+    };
+    expectedMutation = {
+      mode: "revise",
+      devisId: resultat.id,
+      rootDevisId,
+      parentDevisId: id,
+      versionNumber: nextVersion,
     };
 
     await insertDevisAuditLog(client, ctx.audit, {
@@ -2239,10 +2375,11 @@ export async function repoReviseDevis(
       await recordDevisIdempotence(client, ctx.idempotency_key, "REVISE", resultat.id, idempotencyPayloadHash, resultat);
     }
 
-    await client.query("COMMIT");
     return { ...resultat, idempotent_replay: false };
+      },
+      reconcile: async () => reconcileDevisMutation(expectedMutation, expectedUploads),
+    });
   } catch (err) {
-    await client.query("ROLLBACK");
     const { code, constraint } = getPgErrorInfo(err);
     if (code === "23505" && constraint === "devis_numero_key") {
       throw new HttpError(409, "DEVIS_NUMERO_EXISTS", "Numero already exists");
@@ -2260,8 +2397,6 @@ export async function repoReviseDevis(
       }
     }
     throw err;
-  } finally {
-    client.release();
   }
 }
 

--- a/src/module/devis/repository/devis.repository.ts
+++ b/src/module/devis/repository/devis.repository.ts
@@ -6,6 +6,7 @@ import pool from "../../../config/database";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { generateCommandeCode, generateDevisCode } from "../../../shared/codes/code-generator.service";
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import { computeDevisTotals, computeLineTotals } from "../lib/totals";
@@ -1063,6 +1064,7 @@ async function insertDevisDocuments(client: PoolClient, devisId: number, documen
       await fs.copyFile(doc.path, finalPath);
       await fs.unlink(doc.path);
     }
+    registerUploadDestination(doc, finalPath);
 
     await client.query(
       `

--- a/src/module/devis/routes/devis.routes.ts
+++ b/src/module/devis/routes/devis.routes.ts
@@ -1,10 +1,9 @@
 import type { RequestHandler } from "express";
 import { Router } from "express";
 import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
-import multer from "multer";
 import { z } from "zod";
 import { HttpError } from "../../../utils/httpError";
-import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
+import { createSecureUpload } from "../../../shared/uploads/secure-upload";
 import {
   DEVIS_TRANSITION_CAPABILITIES,
   roleHasDevisCapability,
@@ -34,8 +33,7 @@ declare global {
   }
 }
 
-const uploadDir = ensureDocumentStoragePath();
-const upload = multer({ dest: uploadDir });
+const upload = createSecureUpload("business-document");
 
 const parseMultipartData = (schema: z.ZodTypeAny): RequestHandler => {
   return (req, _res, next) => {

--- a/src/module/facturation/controllers/avoirs.controller.ts
+++ b/src/module/facturation/controllers/avoirs.controller.ts
@@ -1,5 +1,7 @@
 import type { RequestHandler } from "express";
 import fs from "node:fs/promises";
+import { getDocumentStoragePath } from "../../../utils/cerpStorage";
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
 import {
   avoirIdParamsSchema,
   createAvoirBodySchema,
@@ -124,10 +126,13 @@ export const getAvoirPdf: RequestHandler = async (req, res, next) => {
     }
 
     const docName = (await svcGetDocumentName(documentId)) ?? `avoir-${id}.pdf`;
-    const disposition = download ? "attachment" : "inline";
-    res.setHeader("Content-Type", "application/pdf");
-    res.setHeader("Content-Disposition", `${disposition}; filename="${docName.replace(/\"/g, "")}"`);
-    res.sendFile(filePath);
+    await sendSecureStoredFile(res, {
+      filePath,
+      allowedRoots: [getDocumentStoragePath()],
+      filename: docName,
+      mimeType: "application/pdf",
+      download,
+    });
   } catch (err) {
     next(err);
   }

--- a/src/module/facturation/controllers/factures.controller.ts
+++ b/src/module/facturation/controllers/factures.controller.ts
@@ -1,5 +1,7 @@
 import type { RequestHandler } from "express";
 import fs from "node:fs/promises";
+import { getDocumentStoragePath } from "../../../utils/cerpStorage";
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
 import {
   createFactureBodySchema,
   factureIdParamsSchema,
@@ -130,10 +132,13 @@ export const getFacturePdf: RequestHandler = async (req, res, next) => {
     }
 
     const docName = (await svcGetDocumentName(documentId)) ?? `facture-${id}.pdf`;
-    const disposition = download ? "attachment" : "inline";
-    res.setHeader("Content-Type", "application/pdf");
-    res.setHeader("Content-Disposition", `${disposition}; filename="${docName.replace(/\"/g, "")}"`);
-    res.sendFile(filePath);
+    await sendSecureStoredFile(res, {
+      filePath,
+      allowedRoots: [getDocumentStoragePath()],
+      filename: docName,
+      mimeType: "application/pdf",
+      download,
+    });
   } catch (err) {
     next(err);
   }

--- a/src/module/facturation/controllers/reporting-v2.controller.ts
+++ b/src/module/facturation/controllers/reporting-v2.controller.ts
@@ -6,6 +6,7 @@
 import type { RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { buildContentDisposition } from "../../../shared/uploads/secure-download";
 import {
   buildExport,
   getClientsSection,
@@ -93,7 +94,7 @@ export const reportingExport: RequestHandler = async (req, res, next) => {
 
     sealResponse(res);
     res.setHeader("Content-Type", "text/csv; charset=utf-8");
-    res.setHeader("Content-Disposition", `attachment; filename="${payload.filename}"`);
+    res.setHeader("Content-Disposition", buildContentDisposition(payload.filename, true));
     res.setHeader("X-CERP-Export-Checksum", payload.checksum_sha256);
     res.setHeader("X-CERP-Export-Rows", String(payload.rows));
     // BOM : Excel FR ouvre le CSV en UTF-8 sans casser les accents.

--- a/src/module/fournisseurs/controllers/fournisseurs.controller.ts
+++ b/src/module/fournisseurs/controllers/fournisseurs.controller.ts
@@ -1,8 +1,8 @@
 import type { Request, RequestHandler, Response } from "express"
-import fs from "node:fs/promises"
 
-import { getDocumentStoragePath, isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage"
+import { getDocumentStoragePath, resolveCerpStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download"
 import type { AuditContext } from "../repository/fournisseurs.repository"
 import {
   adresseIdParamSchema,
@@ -107,18 +107,15 @@ async function sendDocumentFile(
 ) {
   const baseDir = getDocumentStoragePath("fournisseurs")
   const absPath = resolveCerpStoragePath(doc.storage_path, baseDir)
-  if (!isPathInsideDirectory(baseDir, absPath)) {
-    throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path")
-  }
-  await fs.access(absPath)
-  res.setHeader("Content-Type", doc.mime_type)
   const rawDownload = (req.query as { download?: unknown } | undefined)?.download
   const download = rawDownload === true || rawDownload === "true" || rawDownload === "1" || rawDownload === 1
-  res.setHeader(
-    "Content-Disposition",
-    `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(doc.original_name)}"`
-  )
-  res.sendFile(absPath)
+  await sendSecureStoredFile(res, {
+    filePath: absPath,
+    allowedRoots: [baseDir],
+    filename: doc.original_name,
+    mimeType: doc.mime_type,
+    download,
+  })
 }
 
 export const listFournisseurs: RequestHandler = async (req, res, next) => {

--- a/src/module/fournisseurs/repository/fournisseurs.repository.ts
+++ b/src/module/fournisseurs/repository/fournisseurs.repository.ts
@@ -9,6 +9,7 @@ import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { generateFournisseurCode } from "../../../shared/codes/code-generator.service"
 import { registerUploadDestination } from "../../../shared/uploads/secure-upload"
+import { classifyUploadReconciliation, withUploadTransaction } from "../../../shared/uploads/upload-transaction"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators"
 import type {
@@ -1471,15 +1472,17 @@ export async function repoAttachFournisseurDocuments(
   const validated: Array<{ doc: UploadedDocument; ext: string }> = []
   for (const doc of documents) validated.push({ doc, ext: await assertUploadAllowed(doc) })
 
-  const client = await db.connect()
   const docsDirRel = ensureDocumentStoragePath("fournisseurs")
   const docsDirAbs = path.resolve(docsDirRel)
-  const movedFiles: string[] = []
-  let commitAttempted = false
-  try {
-    await client.query("BEGIN")
-    if (!(await ensureFournisseurExists(client, fournisseurId))) { await client.query("ROLLBACK"); return null }
-    if (!validated.length) { await client.query("COMMIT"); return [] }
+  const client = await db.connect()
+  const expected = new Map<string, { key: string; absolutePath: string }>()
+  return withUploadTransaction({
+    client,
+    files: documents,
+    context: "fournisseurs.documents.attach",
+    work: async () => {
+    if (!(await ensureFournisseurExists(client, fournisseurId))) return null
+    if (!validated.length) return []
     await fs.mkdir(docsDirAbs, { recursive: true })
     const inserted: FournisseurDocument[] = []
     for (const { doc, ext } of validated) {
@@ -1490,7 +1493,6 @@ export async function repoAttachFournisseurDocuments(
       const tempPath = path.resolve(doc.path)
       try { await fs.rename(tempPath, absPath) } catch { await fs.copyFile(tempPath, absPath); await fs.unlink(tempPath) }
       registerUploadDestination(doc, absPath)
-      movedFiles.push(absPath)
       const hash = await sha256File(absPath)
       const ins = await client.query<DocumentRow>(
         `INSERT INTO public.fournisseur_documents
@@ -1501,6 +1503,7 @@ export async function repoAttachFournisseurDocuments(
       )
       const row = ins.rows[0]
       if (!row) throw new Error("Failed to insert fournisseur document")
+      expected.set(row.id, { key: `${row.id}|${row.sha256 ?? ""}|${relPath}`, absolutePath: absPath })
       inserted.push(mapDocumentRow(row))
     }
     await insertAuditLog(client, audit, {
@@ -1508,21 +1511,27 @@ export async function repoAttachFournisseurDocuments(
       details: { document_type: body.document_type, count: inserted.length,
         documents: inserted.map((d) => ({ id: d.id, original_name: d.original_name, mime_type: d.mime_type, size_bytes: d.size_bytes })) },
     })
-    commitAttempted = true
-    await client.query("COMMIT")
     return inserted
-  } catch (err) {
-    if (!commitAttempted) {
-      let rollbackConfirmed = false
-      try { await client.query("ROLLBACK"); rollbackConfirmed = true } catch { /* preserve for reconciliation */ }
-      if (rollbackConfirmed) for (const f of movedFiles) await fs.unlink(f).catch(() => undefined)
-    } else {
-      console.error("[FOURNISSEUR_UPLOAD_COMMIT_UNCERTAIN] durable files preserved", { count: movedFiles.length })
-    }
-    throw err
-  } finally {
-    client.release()
-  }
+    },
+    reconcile: async () => {
+      const ids = [...expected.keys()]
+      if (!ids.length) return "committed"
+      const { rows } = await db.query<{ id: string; sha256: string | null; storage_path: string }>(
+        `SELECT id::text AS id, sha256, storage_path
+          FROM public.fournisseur_documents
+          WHERE fournisseur_id = $1::uuid
+            AND id = ANY($2::uuid[])`,
+        [fournisseurId, ids]
+      )
+      const status = classifyUploadReconciliation(
+        [...expected.values()].map((entry) => entry.key),
+        rows.map((row) => `${row.id}|${row.sha256 ?? ""}|${row.storage_path}`)
+      )
+      if (status !== "committed") return status
+      const present = await Promise.all([...expected.values()].map((entry) => fs.stat(entry.absolutePath).then((stat) => stat.isFile()).catch(() => false)))
+      return present.every(Boolean) ? "committed" : "uncertain"
+    },
+  })
 }
 
 export async function repoRemoveFournisseurDocument(

--- a/src/module/fournisseurs/repository/fournisseurs.repository.ts
+++ b/src/module/fournisseurs/repository/fournisseurs.repository.ts
@@ -8,6 +8,7 @@ import db from "../../../config/database"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { generateFournisseurCode } from "../../../shared/codes/code-generator.service"
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators"
 import type {
@@ -1487,6 +1488,7 @@ export async function repoAttachFournisseurDocuments(
       const absPath = path.join(docsDirAbs, storedName)
       const tempPath = path.resolve(doc.path)
       try { await fs.rename(tempPath, absPath) } catch { await fs.copyFile(tempPath, absPath); await fs.unlink(tempPath) }
+      registerUploadDestination(doc, absPath)
       movedFiles.push(absPath)
       const hash = await sha256File(absPath)
       const ins = await client.query<DocumentRow>(

--- a/src/module/fournisseurs/repository/fournisseurs.repository.ts
+++ b/src/module/fournisseurs/repository/fournisseurs.repository.ts
@@ -1475,6 +1475,7 @@ export async function repoAttachFournisseurDocuments(
   const docsDirRel = ensureDocumentStoragePath("fournisseurs")
   const docsDirAbs = path.resolve(docsDirRel)
   const movedFiles: string[] = []
+  let commitAttempted = false
   try {
     await client.query("BEGIN")
     if (!(await ensureFournisseurExists(client, fournisseurId))) { await client.query("ROLLBACK"); return null }
@@ -1507,11 +1508,17 @@ export async function repoAttachFournisseurDocuments(
       details: { document_type: body.document_type, count: inserted.length,
         documents: inserted.map((d) => ({ id: d.id, original_name: d.original_name, mime_type: d.mime_type, size_bytes: d.size_bytes })) },
     })
+    commitAttempted = true
     await client.query("COMMIT")
     return inserted
   } catch (err) {
-    await client.query("ROLLBACK")
-    for (const f of movedFiles) await fs.unlink(f).catch(() => undefined)
+    if (!commitAttempted) {
+      let rollbackConfirmed = false
+      try { await client.query("ROLLBACK"); rollbackConfirmed = true } catch { /* preserve for reconciliation */ }
+      if (rollbackConfirmed) for (const f of movedFiles) await fs.unlink(f).catch(() => undefined)
+    } else {
+      console.error("[FOURNISSEUR_UPLOAD_COMMIT_UNCERTAIN] durable files preserved", { count: movedFiles.length })
+    }
     throw err
   } finally {
     client.release()

--- a/src/module/fournisseurs/routes/fournisseurs.routes.ts
+++ b/src/module/fournisseurs/routes/fournisseurs.routes.ts
@@ -1,8 +1,7 @@
 import { Router } from "express"
-import multer from "multer"
 
 import { authenticateToken, authorizeRole } from "../../auth/middlewares/auth.middleware"
-import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
+import { createSecureUpload } from "../../../shared/uploads/secure-upload"
 import {
   archiveFournisseur,
   attachFournisseurDocuments,
@@ -41,11 +40,7 @@ const WRITE: string[] = ["Directeur", "Administrateur Systeme et Reseau", "Secre
 const QUALIF: string[] = ["Directeur", "Administrateur Systeme et Reseau", "Responsable Qualité"]
 const ARCHIVE: string[] = ["Directeur", "Administrateur Systeme et Reseau"]
 
-const docsBaseDir = ensureDocumentStoragePath("fournisseurs")
-const upload = multer({
-  dest: docsBaseDir,
-  limits: { fileSize: 25 * 1024 * 1024, files: 10 },
-})
+const upload = createSecureUpload("business-document")
 
 const router = Router()
 router.use(authenticateToken)

--- a/src/module/ged/controllers/ged.controller.ts
+++ b/src/module/ged/controllers/ged.controller.ts
@@ -3,7 +3,7 @@
 import type { NextFunction, Request, Response } from "express";
 
 import { HttpError } from "../../../utils/httpError";
-import { setSecureDownloadHeaders } from "../../../shared/uploads/secure-download";
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
 import * as service from "../services/ged.service";
 import {
   listQuerySchema,
@@ -179,15 +179,34 @@ export async function publishVersion(req: Request, res: Response, next: NextFunc
 export async function downloadVersion(req: Request, res: Response, next: NextFunction) {
   try {
     const versionId = parseUuid(req.params.versionId, "Identifiant de version");
-    const result = await service.downloadVersion(actorFrom(req), versionId);
+    const actor = actorFrom(req);
+    const result = await service.downloadVersion(actor, versionId);
 
     // `attachment` + `nosniff` : un document n'est jamais interprété par le
     // navigateur, quel que soit son type déclaré.
-    res.setHeader("Content-Length", String(result.buffer.byteLength));
     res.setHeader("X-CERP-Document-SHA256", result.sha256);
-    setSecureDownloadHeaders(res, { filename: result.original_name, mimeType: result.mime_type, download: true });
     res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'");
-    res.send(result.buffer);
+    try {
+      await sendSecureStoredFile(res, {
+        filePath: result.file_path,
+        allowedRoots: [result.allowed_root],
+        filename: result.original_name,
+        mimeType: result.mime_type,
+        download: true,
+        expectedSha256: result.sha256,
+        integrityError: {
+          status: 409,
+          code: "GED_INTEGRITY",
+          message: "L'intégrité du document ne peut pas être vérifiée. Le contenu ne sera pas servi.",
+        },
+      });
+    } catch (error) {
+      if (error instanceof HttpError && error.code === "GED_INTEGRITY") {
+        await service.recordVersionDownload(actor, result, "INTEGRITY_FAILURE");
+      }
+      throw error;
+    }
+    await service.recordVersionDownload(actor, result, "DOWNLOAD");
   } catch (err) {
     next(err);
   }

--- a/src/module/ged/controllers/ged.controller.ts
+++ b/src/module/ged/controllers/ged.controller.ts
@@ -3,6 +3,7 @@
 import type { NextFunction, Request, Response } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { setSecureDownloadHeaders } from "../../../shared/uploads/secure-download";
 import * as service from "../services/ged.service";
 import {
   listQuerySchema,
@@ -182,15 +183,10 @@ export async function downloadVersion(req: Request, res: Response, next: NextFun
 
     // `attachment` + `nosniff` : un document n'est jamais interprété par le
     // navigateur, quel que soit son type déclaré.
-    res.setHeader("Content-Type", result.mime_type);
     res.setHeader("Content-Length", String(result.buffer.byteLength));
-    res.setHeader("X-Content-Type-Options", "nosniff");
-    res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'");
     res.setHeader("X-CERP-Document-SHA256", result.sha256);
-    res.setHeader(
-      "Content-Disposition",
-      `attachment; filename="${result.original_name.replace(/"/g, "")}"`
-    );
+    setSecureDownloadHeaders(res, { filename: result.original_name, mimeType: result.mime_type, download: true });
+    res.setHeader("Content-Security-Policy", "sandbox; default-src 'none'");
     res.send(result.buffer);
   } catch (err) {
     next(err);

--- a/src/module/ged/domain/ged-content.ts
+++ b/src/module/ged/domain/ged-content.ts
@@ -5,8 +5,10 @@
 // binaire concordent. Un exécutable renommé en `.pdf` est refusé ici, pas
 // découvert plus tard sur le poste de quelqu'un.
 //
-// Aucune I/O : ces fonctions travaillent sur un buffer déjà en mémoire.
+// La voie historique sur Buffer reste disponible pour les tests et petits
+// producteurs internes. Les uploads HTTP utilisent la voie disque bornée.
 
+import fs from "node:fs/promises";
 import { HttpError } from "../../../utils/httpError";
 import { fileExtension, sanitizeOriginalName } from "./ged-policy";
 
@@ -161,8 +163,7 @@ export function hasValidSignature(buffer: Buffer, kind: GedFileKind): boolean {
 /* Contrôle complet                                                           */
 /* -------------------------------------------------------------------------- */
 
-export type AcceptedGedFile = {
-  buffer: Buffer;
+export type AcceptedGedFileMetadata = {
   sanitized_name: string;
   extension: string;
   mime_type: string;
@@ -170,19 +171,18 @@ export type AcceptedGedFile = {
   kind: GedFileKind;
 };
 
-/**
- * Contrôle complet d'un fichier déposé, dans l'ordre du moins cher au plus cher :
- * présence, taille, extension interdite, allowlist de classe, puis signature.
- */
-export function assertAcceptedFile(
-  file: { buffer?: Buffer; originalname?: string; mimetype?: string; size?: number } | undefined,
+export type AcceptedGedFile = AcceptedGedFileMetadata & { buffer: Buffer };
+export type AcceptedGedFileOnDisk = AcceptedGedFileMetadata & { path: string };
+
+function assertAcceptedMetadata(
+  file: { originalname?: string; mimetype?: string; size?: number } | undefined,
   rules: GedClassContentRules
-): AcceptedGedFile {
-  if (!file || !Buffer.isBuffer(file.buffer)) {
+): AcceptedGedFileMetadata {
+  if (!file || !Number.isSafeInteger(file.size)) {
     throw new HttpError(400, "GED_FILE_REQUIRED", "Un fichier est requis.");
   }
 
-  const size = file.size ?? file.buffer.byteLength;
+  const size = file.size!;
   if (size <= 0) {
     throw new HttpError(400, "GED_FILE_REQUIRED", "Le fichier est vide.");
   }
@@ -229,7 +229,31 @@ export function assertAcceptedFile(
   if (!kind) {
     throw new HttpError(415, "GED_FILE_TYPE", "Type de fichier non reconnu par la GED.");
   }
-  if (!hasValidSignature(file.buffer, kind)) {
+  return {
+    sanitized_name: sanitizedName,
+    extension,
+    mime_type: mimeType,
+    size_bytes: size,
+    kind,
+  };
+}
+
+/**
+ * Contrôle complet d'un fichier déposé, dans l'ordre du moins cher au plus cher :
+ * présence, taille, extension interdite, allowlist de classe, puis signature.
+ */
+export function assertAcceptedFile(
+  file: { buffer?: Buffer; originalname?: string; mimetype?: string; size?: number } | undefined,
+  rules: GedClassContentRules
+): AcceptedGedFile {
+  if (!file || !Buffer.isBuffer(file.buffer)) {
+    throw new HttpError(400, "GED_FILE_REQUIRED", "Un fichier est requis.");
+  }
+  const metadata = assertAcceptedMetadata(
+    { ...file, size: file.size ?? file.buffer.byteLength },
+    rules
+  );
+  if (!hasValidSignature(file.buffer, metadata.kind)) {
     throw new HttpError(
       415,
       "GED_FILE_SIGNATURE",
@@ -239,10 +263,46 @@ export function assertAcceptedFile(
 
   return {
     buffer: file.buffer,
-    sanitized_name: sanitizedName,
-    extension,
-    mime_type: mimeType,
-    size_bytes: size,
-    kind,
+    ...metadata,
   };
+}
+
+const SIGNATURE_SAMPLE_BYTES = 64 * 1024;
+
+/** Validate a staged upload without ever allocating the complete file. */
+export async function assertAcceptedFileOnDisk(
+  file: { path?: string; originalname?: string; mimetype?: string; size?: number } | undefined,
+  rules: GedClassContentRules
+): Promise<AcceptedGedFileOnDisk> {
+  if (!file?.path) throw new HttpError(400, "GED_FILE_REQUIRED", "Un fichier est requis.");
+  const metadata = assertAcceptedMetadata(file, rules);
+  const handle = await fs.open(file.path, "r").catch(() => {
+    throw new HttpError(400, "GED_FILE_REQUIRED", "Le fichier déposé est introuvable.");
+  });
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile() || stat.size !== metadata.size_bytes) {
+      throw new HttpError(409, "GED_FILE_CHANGED", "Le fichier déposé a changé pendant sa validation.");
+    }
+    const headLength = Math.min(SIGNATURE_SAMPLE_BYTES, stat.size);
+    const tailLength = Math.min(SIGNATURE_SAMPLE_BYTES, Math.max(0, stat.size - headLength));
+    const head = Buffer.allocUnsafe(headLength);
+    await handle.read(head, 0, headLength, 0);
+    let sample = head;
+    if (tailLength > 0) {
+      const tail = Buffer.allocUnsafe(tailLength);
+      await handle.read(tail, 0, tailLength, stat.size - tailLength);
+      sample = Buffer.concat([head, tail]);
+    }
+    if (!hasValidSignature(sample, metadata.kind)) {
+      throw new HttpError(
+        415,
+        "GED_FILE_SIGNATURE",
+        "La signature binaire du fichier ne correspond pas au type annoncé."
+      );
+    }
+  } finally {
+    await handle.close();
+  }
+  return { path: file.path, ...metadata };
 }

--- a/src/module/ged/repository/ged.repository.ts
+++ b/src/module/ged/repository/ged.repository.ts
@@ -46,16 +46,77 @@ function rethrowGed(err: unknown): never {
   throw err;
 }
 
-export async function withGedTransaction<T>(fn: (tx: PoolClient) => Promise<T>): Promise<T> {
-  const client = await pool.connect();
+export class GedCommitUncertainError<T> extends HttpError {
+  readonly transactionResult: T;
+  readonly originalError: unknown;
+
+  constructor(transactionResult: T, originalError: unknown) {
+    super(
+      503,
+      "GED_COMMIT_UNCERTAIN",
+      "Le résultat du COMMIT GED doit être rapproché avant toute compensation de fichier."
+    );
+    this.transactionResult = transactionResult;
+    this.originalError = originalError;
+  }
+}
+
+export class GedRollbackUncertainError extends HttpError {
+  readonly originalError: unknown;
+
+  constructor(originalError: unknown) {
+    super(
+      503,
+      "GED_ROLLBACK_UNCERTAIN",
+      "Le rollback GED n’a pas pu être confirmé ; le fichier est préservé pour rapprochement."
+    );
+    this.originalError = originalError;
+  }
+}
+
+export type GedTransactionHooks = Readonly<{
+  beforeCommit?: () => void | Promise<void>;
+  afterCommit?: () => void | Promise<void>;
+  afterConfirmedRollback?: () => void | Promise<void>;
+}>;
+
+export async function withGedTransaction<T>(
+  fn: (tx: PoolClient) => Promise<T>,
+  hooks: GedTransactionHooks = {}
+): Promise<T> {
+  let client!: PoolClient;
   try {
+    client = await pool.connect();
     await client.query("BEGIN");
-    const out = await fn(client);
-    await client.query("COMMIT");
-    return out;
   } catch (err) {
-    await client.query("ROLLBACK").catch(() => undefined);
+    client?.release();
+    await hooks.afterConfirmedRollback?.();
     return rethrowGed(err);
+  }
+  try {
+    let out: T;
+    try {
+      out = await fn(client);
+      await hooks.beforeCommit?.();
+    } catch (err) {
+      try {
+        await client.query("ROLLBACK");
+      } catch {
+        throw new GedRollbackUncertainError(err);
+      }
+      await hooks.afterConfirmedRollback?.();
+      return rethrowGed(err);
+    }
+
+    try {
+      await client.query("COMMIT");
+    } catch (err) {
+      // Never issue ROLLBACK after COMMIT was sent: PostgreSQL may have applied
+      // it and only the acknowledgement may have been lost.
+      throw new GedCommitUncertainError(out, err);
+    }
+    await hooks.afterCommit?.();
+    return out;
   } finally {
     client.release();
   }
@@ -646,12 +707,13 @@ export async function repoInternalGetVersionContentRef(versionId: string): Promi
   original_name: string;
   mime_type: string;
   sha256: string;
+  size_bytes: number;
   storage_key: string;
 } | null> {
   try {
     const res = await pool.query(
       `SELECT v.id::text AS version_id, v.document_id::text AS document_id, v.status::text AS status,
-              v.original_name, b.mime_type, b.sha256, b.storage_key
+              v.original_name, b.mime_type, b.sha256, b.size_bytes, b.storage_key
          FROM public.ged_document_versions v
          JOIN public.ged_blobs b ON b.id = v.blob_id
         WHERE v.id = $1::uuid`,
@@ -666,8 +728,27 @@ export async function repoInternalGetVersionContentRef(versionId: string): Promi
       original_name: String(r.original_name),
       mime_type: String(r.mime_type),
       sha256: String(r.sha256),
+      size_bytes: Number(r.size_bytes),
       storage_key: String(r.storage_key),
     };
+  } catch (err) {
+    return rethrowGed(err);
+  }
+}
+
+/** Fresh-connection reconciliation used only after a COMMIT acknowledgement loss. */
+export async function repoIsVersionBlobCommitted(versionId: string, sha256: string): Promise<boolean> {
+  try {
+    const res = await pool.query(
+      `SELECT EXISTS (
+         SELECT 1
+           FROM public.ged_document_versions v
+           JOIN public.ged_blobs b ON b.id = v.blob_id
+          WHERE v.id = $1::uuid AND b.sha256 = $2
+       ) AS committed`,
+      [versionId, sha256]
+    );
+    return res.rows[0]?.committed === true;
   } catch (err) {
     return rethrowGed(err);
   }

--- a/src/module/ged/repository/ged.repository.ts
+++ b/src/module/ged/repository/ged.repository.ts
@@ -14,6 +14,7 @@
 import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
+import type { UploadCommitReconciliation } from "../../../shared/uploads/upload-transaction";
 import { HttpError } from "../../../utils/httpError";
 import { formatDocumentCode, type GedVersionStatus } from "../domain/ged-policy";
 import type {
@@ -85,11 +86,17 @@ export async function withGedTransaction<T>(
   hooks: GedTransactionHooks = {}
 ): Promise<T> {
   let client!: PoolClient;
+  let released = false;
+  const release = (destroy = false) => {
+    if (!client || released) return;
+    released = true;
+    client.release(destroy);
+  };
   try {
     client = await pool.connect();
     await client.query("BEGIN");
   } catch (err) {
-    client?.release();
+    release(true);
     await hooks.afterConfirmedRollback?.();
     return rethrowGed(err);
   }
@@ -102,6 +109,7 @@ export async function withGedTransaction<T>(
       try {
         await client.query("ROLLBACK");
       } catch {
+        release(true);
         throw new GedRollbackUncertainError(err);
       }
       await hooks.afterConfirmedRollback?.();
@@ -113,12 +121,13 @@ export async function withGedTransaction<T>(
     } catch (err) {
       // Never issue ROLLBACK after COMMIT was sent: PostgreSQL may have applied
       // it and only the acknowledgement may have been lost.
+      release(true);
       throw new GedCommitUncertainError(out, err);
     }
     await hooks.afterCommit?.();
     return out;
   } finally {
-    client.release();
+    release();
   }
 }
 
@@ -737,18 +746,26 @@ export async function repoInternalGetVersionContentRef(versionId: string): Promi
 }
 
 /** Fresh-connection reconciliation used only after a COMMIT acknowledgement loss. */
-export async function repoIsVersionBlobCommitted(versionId: string, sha256: string): Promise<boolean> {
+export async function repoIsVersionBlobCommitted(
+  versionId: string,
+  sha256: string
+): Promise<UploadCommitReconciliation> {
   try {
-    const res = await pool.query(
-      `SELECT EXISTS (
-         SELECT 1
-           FROM public.ged_document_versions v
-           JOIN public.ged_blobs b ON b.id = v.blob_id
-          WHERE v.id = $1::uuid AND b.sha256 = $2
-       ) AS committed`,
+    const res = await pool.query<{ version_sha256: string | null; blob_present: boolean }>(
+      `SELECT
+         (SELECT b.sha256
+            FROM public.ged_document_versions v
+            JOIN public.ged_blobs b ON b.id = v.blob_id
+           WHERE v.id = $1::uuid) AS version_sha256,
+         EXISTS (
+           SELECT 1 FROM public.ged_blobs b WHERE b.sha256 = $2
+         ) AS blob_present`,
       [versionId, sha256]
     );
-    return res.rows[0]?.committed === true;
+    const row = res.rows[0];
+    if (row?.version_sha256 === sha256) return "committed";
+    if (row?.version_sha256 || row?.blob_present) return "uncertain";
+    return "not-committed";
   } catch (err) {
     return rethrowGed(err);
   }

--- a/src/module/ged/routes/ged.routes.ts
+++ b/src/module/ged/routes/ged.routes.ts
@@ -6,21 +6,16 @@
 // vérifient ensuite — quand ils vérifient.
 
 import { Router } from "express";
-import multer from "multer";
 
 import * as controller from "../controllers/ged.controller";
 import { requireGedCapability } from "../middlewares/require-ged-capability";
+import { createSecureUpload } from "../../../shared/uploads/secure-upload";
 
 const router = Router();
 
 // Plafond global du transport. Le plafond RÉEL est celui de la classe
 // documentaire, appliqué ensuite par `assertAcceptedFile`.
-const MAX_TRANSPORT_BYTES = 512 * 1024 * 1024;
-
-const upload = multer({
-  storage: multer.memoryStorage(),
-  limits: { fileSize: MAX_TRANSPORT_BYTES, files: 1, fields: 12, fieldSize: 64 * 1024 },
-});
+const upload = createSecureUpload("ged-deferred", { storage: "memory" });
 
 /* Référentiel et navigation */
 router.get("/classes", requireGedCapability("read"), controller.getClasses);

--- a/src/module/ged/routes/ged.routes.ts
+++ b/src/module/ged/routes/ged.routes.ts
@@ -1,9 +1,8 @@
 // GED centrale CERP (ADR-0037) — routeur.
 //
-// `memoryStorage` et non `dest:` : le fichier est contrôlé (taille, MIME,
-// extension, signature) AVANT toute écriture. Aucun octet non validé n'atteint
-// le coffre, contrairement aux modules historiques qui écrivent d'abord et
-// vérifient ensuite — quand ils vérifient.
+// Le transport GED est toujours stagé sur disque : un document de 512 Mio ne
+// doit jamais devenir un Buffer Node. Validation, scan, empreinte et promotion
+// dans le coffre travaillent ensuite par flux bornés.
 
 import { Router } from "express";
 
@@ -15,7 +14,7 @@ const router = Router();
 
 // Plafond global du transport. Le plafond RÉEL est celui de la classe
 // documentaire, appliqué ensuite par `assertAcceptedFile`.
-const upload = createSecureUpload("ged-deferred", { storage: "memory" });
+const upload = createSecureUpload("ged-deferred", { storage: "staging" });
 
 /* Référentiel et navigation */
 router.get("/classes", requireGedCapability("read"), controller.getClasses);

--- a/src/module/ged/services/ged-vault.service.ts
+++ b/src/module/ged/services/ged-vault.service.ts
@@ -14,11 +14,14 @@
 // répertoire local de repli que personne ne sauvegarderait.
 
 import crypto from "node:crypto";
+import { createReadStream, createWriteStream } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { pipeline } from "node:stream/promises";
 
 import { HttpError } from "../../../utils/httpError";
 import { isPathInsideDirectory } from "../../../utils/cerpStorage";
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
 
 const VAULT_SUBDIR = "vault";
 const STAGING_SUBDIR = "staging";
@@ -117,6 +120,13 @@ export function computeSha256(buffer: Buffer): string {
   return crypto.createHash("sha256").update(buffer).digest("hex");
 }
 
+export async function computeFileSha256(filePath: string): Promise<string> {
+  const hash = crypto.createHash("sha256");
+  const stream = createReadStream(filePath);
+  for await (const chunk of stream) hash.update(chunk as Buffer);
+  return hash.digest("hex");
+}
+
 /** Clé interne opaque, relative à la racine. N'est jamais retournée par l'API. */
 export function storageKeyForSha256(sha256: string): string {
   if (!/^[a-f0-9]{64}$/.test(sha256)) {
@@ -187,6 +197,84 @@ export async function writeBlob(buffer: Buffer): Promise<WrittenBlob> {
 }
 
 /**
+ * Move a staged HTTP upload into the content-addressed vault with bounded
+ * memory. A hard link is used on the same filesystem; EXDEV falls back to a
+ * streamed exclusive copy. The durable path is never overwritten.
+ */
+export async function writeBlobFromPath(sourcePath: string): Promise<WrittenBlob> {
+  const root = await ensureVaultReady();
+  const sourceStat = await fs.stat(sourcePath).catch(() => null);
+  if (!sourceStat?.isFile()) {
+    throw new HttpError(400, "GED_FILE_REQUIRED", "Le fichier déposé est introuvable.");
+  }
+
+  const sha256 = await computeFileSha256(sourcePath);
+  const storageKey = storageKeyForSha256(sha256);
+  const destination = resolveInsideVault(root, storageKey);
+  await fs.mkdir(path.dirname(destination), { recursive: true });
+
+  let created = false;
+  try {
+    try {
+      await fs.link(sourcePath, destination);
+      created = true;
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code === "EEXIST") {
+        created = false;
+      } else if (code === "EXDEV" || code === "EPERM" || code === "ENOTSUP") {
+        try {
+          await pipeline(
+            createReadStream(sourcePath),
+            createWriteStream(destination, { flags: "wx", mode: 0o600 })
+          );
+          created = true;
+        } catch (copyError) {
+          if ((copyError as NodeJS.ErrnoException).code !== "EEXIST") {
+            await fs.unlink(destination).catch(() => undefined);
+            throw copyError;
+          }
+          created = false;
+        }
+      } else {
+        throw error;
+      }
+    }
+
+    const storedHash = await computeFileSha256(destination);
+    if (storedHash !== sha256) {
+      if (created) await fs.unlink(destination).catch(() => undefined);
+      throw new HttpError(409, "GED_INTEGRITY", "Le blob du coffre ne correspond pas à son empreinte.");
+    }
+
+    if (created) {
+      await fs.chmod(destination, 0o600).catch(() => undefined);
+      registerUploadDestination({ path: sourcePath }, destination);
+    }
+    await fs.unlink(sourcePath).catch(() => undefined);
+    return {
+      sha256,
+      storage_key: storageKey,
+      size_bytes: sourceStat.size,
+      deduplicated: !created,
+    };
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code === "ENOSPC") {
+      throw new HttpError(507, "GED_VAULT_FULL", "Le coffre documentaire est plein.");
+    }
+    if ((err as NodeJS.ErrnoException)?.code === "EROFS") {
+      throw new HttpError(503, "GED_VAULT_UNAVAILABLE", "Le coffre documentaire est en lecture seule.");
+    }
+    throw err;
+  }
+}
+
+export async function resolveBlobForDownload(storageKey: string): Promise<{ file_path: string; allowed_root: string }> {
+  const root = await ensureVaultReady();
+  return { file_path: resolveInsideVault(root, storageKey), allowed_root: root };
+}
+
+/**
  * Lit un blob et REVÉRIFIE son empreinte. Un fichier altéré sur disque est
  * refusé, jamais servi : c'est ce qui distingue un coffre d'un répertoire.
  */
@@ -209,21 +297,6 @@ export async function readBlob(storageKey: string, expectedSha256: string): Prom
     );
   }
   return buffer;
-}
-
-/**
- * Supprime un blob. Réservé à la compensation d'une transaction échouée juste
- * après l'écriture : un blob déjà référencé n'est jamais supprimé.
- */
-export async function removeBlobIfOrphan(storageKey: string): Promise<void> {
-  try {
-    const root = getVaultRoot();
-    const target = resolveInsideVault(root, storageKey);
-    await fs.unlink(target);
-  } catch {
-    // La compensation est un filet, pas une garantie : un échec ici ne doit pas
-    // masquer l'erreur d'origine. Le rapport d'intégrité détectera l'orphelin.
-  }
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/module/ged/services/ged.service.ts
+++ b/src/module/ged/services/ged.service.ts
@@ -9,7 +9,14 @@ import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
-import { assertAcceptedFile } from "../domain/ged-content";
+import logger from "../../../utils/logger";
+import {
+  cleanupUploadsAfterConfirmedRollback,
+  cleanupUploadsAfterReconciledNoCommit,
+  markUploadCommitAttempted,
+  markUploadsCommitted,
+} from "../../../shared/uploads/secure-upload";
+import { assertAcceptedFileOnDisk } from "../domain/ged-content";
 import {
   assertDistinctApprover,
   assertGedCapability,
@@ -27,6 +34,7 @@ import {
   repoGetVersionForUpdate,
   repoInsertApproval,
   repoInternalGetVersionContentRef,
+  repoIsVersionBlobCommitted,
   repoListAccessEvents,
   repoListClasses,
   repoListDocuments,
@@ -36,6 +44,7 @@ import {
   repoSetVersionStatus,
   repoUpsertBlob,
   withGedTransaction,
+  GedCommitUncertainError,
 } from "../repository/ged.repository";
 import type {
   GedAccessEvent,
@@ -45,11 +54,46 @@ import type {
   GedListResult,
   GedTreeNode,
 } from "../types/ged.types";
-import { checkVaultHealth, readBlob, removeBlobIfOrphan, writeBlob } from "./ged-vault.service";
+import {
+  checkVaultHealth,
+  resolveBlobForDownload,
+  writeBlobFromPath,
+} from "./ged-vault.service";
 
 export type GedActor = { id: number; role: string | null };
 
-type UploadedFile = { buffer?: Buffer; originalname?: string; mimetype?: string; size?: number };
+type UploadedFile = { path?: string; originalname?: string; mimetype?: string; size?: number };
+type GedUploadTransactionResult = { documentId: string; versionId: string };
+
+function uploadTransactionHooks(files: readonly { path: string }[]) {
+  return {
+    beforeCommit: () => markUploadCommitAttempted(files),
+    afterCommit: () => markUploadsCommitted(files),
+    afterConfirmedRollback: () => cleanupUploadsAfterConfirmedRollback(files),
+  };
+}
+
+async function reconcileGedCommit(
+  error: GedCommitUncertainError<GedUploadTransactionResult>,
+  sha256: string,
+  files: readonly { path: string }[]
+): Promise<GedUploadTransactionResult> {
+  try {
+    const committed = await repoIsVersionBlobCommitted(error.transactionResult.versionId, sha256);
+    if (committed) {
+      markUploadsCommitted(files);
+      return error.transactionResult;
+    }
+    await cleanupUploadsAfterReconciledNoCommit(files);
+    throw error.originalError;
+  } catch (reconcileError) {
+    if (reconcileError === error.originalError) throw reconcileError;
+    logger.error("[GED_UPLOAD_COMMIT_UNCERTAIN] fresh-connection reconciliation failed", JSON.stringify({
+      version_id: error.transactionResult.versionId,
+    }));
+    throw error;
+  }
+}
 
 /**
  * Relit un document APRÈS le commit.
@@ -148,7 +192,7 @@ export async function uploadDocument(
     throw new HttpError(400, "GED_CLASS_UNKNOWN", `Classe documentaire inconnue : ${input.class_key}.`);
   }
 
-  const accepted = assertAcceptedFile(file, {
+  const accepted = await assertAcceptedFileOnDisk(file, {
     class_key: documentClass.class_key,
     allowed_mime_types: documentClass.allowed_mime_types,
     allowed_extensions: documentClass.allowed_extensions,
@@ -157,11 +201,12 @@ export async function uploadDocument(
 
   // 1) Écriture du contenu AVANT la transaction : un blob orphelin se détecte
   //    et se nettoie ; une métadonnée sans fichier est un mensonge durable.
-  const written = await writeBlob(accepted.buffer);
+  const written = await writeBlobFromPath(accepted.path);
+  const uploadedFiles = [{ path: accepted.path }];
 
-  let documentId: string;
+  let transactionResult: GedUploadTransactionResult;
   try {
-    documentId = await withGedTransaction(async (tx: PoolClient) => {
+    transactionResult = await withGedTransaction(async (tx: PoolClient) => {
       const duplicate = await repoFindDocumentByBlobHash(tx, written.sha256);
       if (duplicate) {
         throw new HttpError(
@@ -214,17 +259,25 @@ export async function uploadDocument(
         },
       });
 
-      return created.document_id;
-    });
+      return { documentId: created.document_id, versionId: created.version_id };
+    }, uploadTransactionHooks(uploadedFiles));
   } catch (err) {
-    // Compensation : uniquement si le blob venait d'être créé par ce dépôt.
-    if (!written.deduplicated) await removeBlobIfOrphan(written.storage_key);
-    throw err;
+    if (err instanceof GedCommitUncertainError) {
+      transactionResult = await reconcileGedCommit(
+        err as GedCommitUncertainError<GedUploadTransactionResult>,
+        written.sha256,
+        uploadedFiles
+      );
+    } else {
+      // A rollback-uncertain error deliberately preserves the blob. All other
+      // transaction failures already ran the confirmed-rollback hook.
+      throw err;
+    }
   }
 
   // Relecture APRÈS le commit : `repoGetDocumentDetail` ouvre sa propre
   // connexion et ne verrait rien d'une transaction encore ouverte.
-  return readDetailOrFail(documentId);
+  return readDetailOrFail(transactionResult.documentId);
 }
 
 export async function uploadNewVersion(
@@ -253,17 +306,19 @@ export async function uploadNewVersion(
     throw new HttpError(400, "GED_CLASS_UNKNOWN", "Classe documentaire inconnue.");
   }
 
-  const accepted = assertAcceptedFile(file, {
+  const accepted = await assertAcceptedFileOnDisk(file, {
     class_key: documentClass.class_key,
     allowed_mime_types: documentClass.allowed_mime_types,
     allowed_extensions: documentClass.allowed_extensions,
     max_size_bytes: documentClass.max_size_bytes,
   });
 
-  const written = await writeBlob(accepted.buffer);
+  const written = await writeBlobFromPath(accepted.path);
+  const uploadedFiles = [{ path: accepted.path }];
 
+  let transactionResult: GedUploadTransactionResult;
   try {
-    await withGedTransaction(async (tx: PoolClient) => {
+    transactionResult = await withGedTransaction(async (tx: PoolClient) => {
       const blob = await repoUpsertBlob(tx, {
         sha256: written.sha256,
         size_bytes: written.size_bytes,
@@ -288,14 +343,22 @@ export async function uploadNewVersion(
         details: { version_number: version.version_number, sha256: written.sha256, size_bytes: written.size_bytes },
       });
 
-    });
+      return { documentId, versionId: version.version_id };
+    }, uploadTransactionHooks(uploadedFiles));
   } catch (err) {
-    if (!written.deduplicated) await removeBlobIfOrphan(written.storage_key);
-    throw err;
+    if (err instanceof GedCommitUncertainError) {
+      transactionResult = await reconcileGedCommit(
+        err as GedCommitUncertainError<GedUploadTransactionResult>,
+        written.sha256,
+        uploadedFiles
+      );
+    } else {
+      throw err;
+    }
   }
 
   // Relecture APRÈS le commit, pour la même raison que dans `uploadDocument`.
-  return readDetailOrFail(documentId);
+  return readDetailOrFail(transactionResult.documentId);
 }
 
 /* -------------------------------------------------------------------------- */
@@ -384,10 +447,14 @@ export async function obsoleteVersion(actor: GedActor, versionId: string, reason
 /* -------------------------------------------------------------------------- */
 
 export type DownloadResult = {
-  buffer: Buffer;
+  file_path: string;
+  allowed_root: string;
+  size_bytes: number;
   original_name: string;
   mime_type: string;
   sha256: string;
+  document_id: string;
+  version_id: string;
 };
 
 export async function downloadVersion(actor: GedActor, versionId: string): Promise<DownloadResult> {
@@ -402,38 +469,32 @@ export async function downloadVersion(actor: GedActor, versionId: string): Promi
     assertGedCapability(actor.role, "upload");
   }
 
-  let buffer: Buffer;
-  try {
-    // L'empreinte est RECALCULÉE ici : un fichier altéré sur disque est refusé.
-    buffer = await readBlob(ref.storage_key, ref.sha256);
-  } catch (err) {
-    if (err instanceof HttpError && err.code === "GED_INTEGRITY") {
-      // Une atteinte à l'intégrité est un événement de sécurité : elle est
-      // journalisée même si la lecture échoue.
-      await repoLogAccess(pool, {
-        document_id: ref.document_id,
-        version_id: ref.version_id,
-        event_type: "INTEGRITY_FAILURE",
-        actor_id: actor.id,
-        details: { expected_sha256: ref.sha256 },
-      }).catch(() => undefined);
-    }
-    throw err;
-  }
-
-  // Le journal ne doit jamais faire échouer un téléchargement légitime.
-  await repoLogAccess(pool, {
-    document_id: ref.document_id,
-    version_id: ref.version_id,
-    event_type: "DOWNLOAD",
-    actor_id: actor.id,
-    details: { size_bytes: buffer.byteLength },
-  }).catch(() => undefined);
+  const blob = await resolveBlobForDownload(ref.storage_key);
 
   return {
-    buffer,
+    file_path: blob.file_path,
+    allowed_root: blob.allowed_root,
+    size_bytes: ref.size_bytes,
     original_name: ref.original_name,
     mime_type: ref.mime_type,
     sha256: ref.sha256,
+    document_id: ref.document_id,
+    version_id: ref.version_id,
   };
+}
+
+export async function recordVersionDownload(
+  actor: GedActor,
+  result: DownloadResult,
+  outcome: "DOWNLOAD" | "INTEGRITY_FAILURE"
+): Promise<void> {
+  await repoLogAccess(pool, {
+    document_id: result.document_id,
+    version_id: result.version_id,
+    event_type: outcome,
+    actor_id: actor.id,
+    details: outcome === "DOWNLOAD"
+      ? { size_bytes: result.size_bytes }
+      : { expected_sha256: result.sha256 },
+  }).catch(() => undefined);
 }

--- a/src/module/ged/services/ged.service.ts
+++ b/src/module/ged/services/ged.service.ts
@@ -5,6 +5,8 @@
 // compensé. L'inverse (base d'abord) laisserait des métadonnées sans fichier,
 // c'est-à-dire des documents fantômes.
 
+import fs from "node:fs/promises";
+
 import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
@@ -76,23 +78,41 @@ function uploadTransactionHooks(files: readonly { path: string }[]) {
 async function reconcileGedCommit(
   error: GedCommitUncertainError<GedUploadTransactionResult>,
   sha256: string,
+  storageKey: string,
   files: readonly { path: string }[]
 ): Promise<GedUploadTransactionResult> {
+  let outcome: Awaited<ReturnType<typeof repoIsVersionBlobCommitted>>;
+  let durableFilePresent = false;
   try {
-    const committed = await repoIsVersionBlobCommitted(error.transactionResult.versionId, sha256);
-    if (committed) {
-      markUploadsCommitted(files);
-      return error.transactionResult;
+    outcome = await repoIsVersionBlobCommitted(error.transactionResult.versionId, sha256);
+    if (outcome === "committed") {
+      const blob = await resolveBlobForDownload(storageKey);
+      durableFilePresent = await fs.stat(blob.file_path).then((stat) => stat.isFile()).catch(() => false);
     }
-    await cleanupUploadsAfterReconciledNoCommit(files);
-    throw error.originalError;
   } catch (reconcileError) {
-    if (reconcileError === error.originalError) throw reconcileError;
     logger.error("[GED_UPLOAD_COMMIT_UNCERTAIN] fresh-connection reconciliation failed", JSON.stringify({
       version_id: error.transactionResult.versionId,
     }));
     throw error;
   }
+  if (outcome === "committed") {
+    if (!durableFilePresent) {
+      logger.error("[GED_UPLOAD_COMMIT_UNCERTAIN] metadata committed but durable blob missing", JSON.stringify({
+        version_id: error.transactionResult.versionId,
+      }));
+      throw error;
+    }
+    markUploadsCommitted(files);
+    return error.transactionResult;
+  }
+  if (outcome === "not-committed") {
+    await cleanupUploadsAfterReconciledNoCommit(files);
+    throw error.originalError;
+  }
+  logger.error("[GED_UPLOAD_COMMIT_UNCERTAIN] metadata mismatch; durable blob preserved", JSON.stringify({
+    version_id: error.transactionResult.versionId,
+  }));
+  throw error;
 }
 
 /**
@@ -266,6 +286,7 @@ export async function uploadDocument(
       transactionResult = await reconcileGedCommit(
         err as GedCommitUncertainError<GedUploadTransactionResult>,
         written.sha256,
+        written.storage_key,
         uploadedFiles
       );
     } else {
@@ -350,6 +371,7 @@ export async function uploadNewVersion(
       transactionResult = await reconcileGedCommit(
         err as GedCommitUncertainError<GedUploadTransactionResult>,
         written.sha256,
+        written.storage_key,
         uploadedFiles
       );
     } else {

--- a/src/module/import-assistant/controllers/import-assistant.controller.ts
+++ b/src/module/import-assistant/controllers/import-assistant.controller.ts
@@ -1,5 +1,6 @@
 import type { Request, RequestHandler } from "express";
 
+import { buildContentDisposition } from "../../../shared/uploads/secure-download";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 import { stripQueryFromUrl } from "../../../utils/logPath";
 import { HttpError } from "../../../utils/httpError";
@@ -125,7 +126,7 @@ export const getBatchReport: RequestHandler = async (req, res, next) => {
     const { id } = importBatchIdSchema.parse(req.params);
     const report = await service.buildImportReportCsv(id);
     res.setHeader("Content-Type", "text/csv; charset=utf-8");
-    res.setHeader("Content-Disposition", `attachment; filename="${report.filename}"`);
+    res.setHeader("Content-Disposition", buildContentDisposition(report.filename, true));
     res.send(report.csv);
   } catch (error) {
     next(error);

--- a/src/module/import-assistant/routes/import-assistant.routes.ts
+++ b/src/module/import-assistant/routes/import-assistant.routes.ts
@@ -1,11 +1,8 @@
-import path from "node:path";
-
 import { Router, type RequestHandler } from "express";
-import multer from "multer";
 
 import pool from "../../../config/database";
 import { authorizeRole } from "../../auth/middlewares/auth.middleware";
-import { HttpError } from "../../../utils/httpError";
+import { createSecureUpload } from "../../../shared/uploads/secure-upload";
 import * as controller from "../controllers/import-assistant.controller";
 import { assertImportAssistantDatabase } from "../domain/import-database-guard";
 
@@ -22,18 +19,7 @@ const requireImportTestDatabase: RequestHandler = async (_req, _res, next) => {
     next(error);
   }
 };
-const upload = multer({
-  storage: multer.memoryStorage(),
-  limits: { files: 1, fileSize: 25 * 1024 * 1024 },
-  fileFilter: (_req, file, callback) => {
-    const extension = path.extname(file.originalname).toLowerCase();
-    if (![".xlsx", ".csv"].includes(extension)) {
-      callback(new HttpError(400, "UNSUPPORTED_IMPORT_FORMAT", "Format refusé. Utilisez un fichier .xlsx ou .csv."));
-      return;
-    }
-    callback(null, true);
-  },
-});
+const upload = createSecureUpload("import-tabular", { storage: "memory" });
 
 router.use(requireImportAdmin, requireImportTestDatabase);
 

--- a/src/module/import-assistant/services/import-targets.service.ts
+++ b/src/module/import-assistant/services/import-targets.service.ts
@@ -223,7 +223,7 @@ export async function createImportTarget(params: {
     case "MACHINE": {
       const result = await svcCreateMachine({
         body: params.normalized_data as CreateMachineBodyDTO,
-        image_path: null,
+        image_file: null,
         idempotency_key: params.idempotency_key,
         audit,
       });

--- a/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
+++ b/src/module/livraisons/controllers/livraisons-pdf.controller.test.ts
@@ -118,12 +118,14 @@ describe("livraison PDF controller contract", () => {
     expect(response.setHeader).toHaveBeenCalledWith("Content-Type", "application/pdf")
     expect(response.setHeader).toHaveBeenCalledWith(
       "Content-Disposition",
-      'inline; filename="BL-0018.pdf"',
+      'inline; filename="BL-0018.pdf"; filename*=UTF-8\'\'BL-0018.pdf',
     )
     expect(response.setHeader).toHaveBeenCalledWith(
       "Cache-Control",
       "private, no-store, max-age=0",
     )
+    expect(response.setHeader).toHaveBeenCalledWith("X-Content-Type-Options", "nosniff")
+    expect(response.setHeader).toHaveBeenCalledWith("Cross-Origin-Resource-Policy", "same-origin")
     expect(response.send).toHaveBeenCalledWith(validatedBytes)
     expect(response.sendFile).not.toHaveBeenCalled()
     expect(mocks.getPath).not.toHaveBeenCalled()

--- a/src/module/livraisons/controllers/livraisons.controller.ts
+++ b/src/module/livraisons/controllers/livraisons.controller.ts
@@ -24,6 +24,8 @@ import {
 } from "../services/livraisons-document-validation"
 import { repoFindDocumentFilePath, repoGetDocumentName, repoIsLivraisonDocumentLinked } from "../repository/livraisons.repository"
 import { emitEntityChanged } from "../../../shared/realtime/realtime.service"
+import { getDocumentStoragePath } from "../../../utils/cerpStorage"
+import { sendSecureStoredFile, setSecureDownloadHeaders } from "../../../shared/uploads/secure-download"
 
 function coerceBool(value: unknown): boolean {
   if (typeof value === "boolean") return value
@@ -373,8 +375,12 @@ export const getLivraisonDocumentFile: RequestHandler = async (req, res, next) =
       return
     }
     const name = (await repoGetDocumentName(docId)) ?? `document-${id}`
-    res.setHeader("Content-Disposition", `inline; filename=\"${name.replace(/\"/g, "")}\"`)
-    res.sendFile(filePath)
+    await sendSecureStoredFile(res, {
+      filePath,
+      allowedRoots: [getDocumentStoragePath("livraisons")],
+      filename: name,
+      download: false,
+    })
   } catch (e) {
     next(e)
   }
@@ -425,10 +431,7 @@ export const getLivraisonPdf: RequestHandler = async (req, res, next) => {
     }
 
     const docName = (await pdfService.svcGetDocumentName(archive.document_id)) ?? `bon-livraison-${id}.pdf`
-    const disposition = download ? "attachment" : "inline"
-    res.setHeader("Content-Type", "application/pdf")
-    res.setHeader("Content-Disposition", `${disposition}; filename=\"${docName.replace(/\"/g, "")}\"`)
-    res.setHeader("Cache-Control", "private, no-store, max-age=0")
+    setSecureDownloadHeaders(res, { filename: docName, mimeType: "application/pdf", download })
     res.send(archive.bytes)
   } catch (e) {
     next(e)

--- a/src/module/livraisons/controllers/pack.controller.ts
+++ b/src/module/livraisons/controllers/pack.controller.ts
@@ -1,6 +1,8 @@
 import type { Request, RequestHandler } from "express"
 
 import { HttpError } from "../../../utils/httpError"
+import { getDocumentStoragePath } from "../../../utils/cerpStorage"
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download"
 import { packGenerateBodySchema, packPreviewParamsSchema, packRevokeParamsSchema } from "../validators/pack.validators"
 import { repoFindDocumentFilePath, repoGetDocumentName, repoIsLivraisonDocumentLinked } from "../repository/livraisons.repository"
 import { svcGenerateLivraisonPack, svcGetLivraisonPackPreview, svcRevokeLivraisonPackVersion } from "../services/pack.service"
@@ -73,10 +75,13 @@ export const downloadLivraisonPackDocument: RequestHandler = async (req, res, ne
       return
     }
     const name = (await repoGetDocumentName(documentId)) ?? `document-${id}.pdf`
-    const disposition = download ? "attachment" : "inline"
-    res.setHeader("Content-Type", "application/pdf")
-    res.setHeader("Content-Disposition", `${disposition}; filename=\"${name.replace(/\"/g, "")}\"`)
-    res.sendFile(filePath)
+    await sendSecureStoredFile(res, {
+      filePath,
+      allowedRoots: [getDocumentStoragePath("livraisons")],
+      filename: name,
+      mimeType: "application/pdf",
+      download,
+    })
   } catch (e) {
     next(e)
   }

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -2792,6 +2792,7 @@ export async function repoAttachLivraisonDocuments(params: {
   const db = await pool.connect()
   const docsDir = await ensureDocsDir()
   const storedPaths: string[] = []
+  let commitAttempted = false
   try {
     await db.query("BEGIN")
     const header = await getHeader(db, params.bonLivraisonId, { forUpdate: true })
@@ -2921,11 +2922,19 @@ export async function repoAttachLivraisonDocuments(params: {
       }))
     }
 
+    commitAttempted = true
     await db.query("COMMIT")
     return docsOut
   } catch (err) {
-    await db.query("ROLLBACK")
-    await Promise.all(storedPaths.map((filePath) => fs.unlink(filePath).catch(() => undefined)))
+    if (!commitAttempted) {
+      let rollbackConfirmed = false
+      try { await db.query("ROLLBACK"); rollbackConfirmed = true } catch { /* preserve for reconciliation */ }
+      if (rollbackConfirmed) {
+        await Promise.all(storedPaths.map((filePath) => fs.unlink(filePath).catch(() => undefined)))
+      }
+    } else {
+      console.error("[LIVRAISON_UPLOAD_COMMIT_UNCERTAIN] durable files preserved", { count: storedPaths.length })
+    }
     throw err
   } finally {
     db.release()

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -6,6 +6,7 @@ import type { PoolClient } from "pg"
 import pool from "../../../config/database"
 import { canonicalizeStockUnitCode } from "../../../shared/stock-unit"
 import { registerUploadDestination } from "../../../shared/uploads/secure-upload"
+import { classifyUploadReconciliation, withUploadTransaction } from "../../../shared/uploads/upload-transaction"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { normalizeCommandeWorkflowStatus } from "../../commande-client/workflow/commande-client-workflow.definition"
@@ -2789,12 +2790,14 @@ export async function repoAttachLivraisonDocuments(params: {
   type?: string | null
   userId: number
 }): Promise<BonLivraisonDocument[]> {
-  const db = await pool.connect()
   const docsDir = await ensureDocsDir()
-  const storedPaths: string[] = []
-  let commitAttempted = false
-  try {
-    await db.query("BEGIN")
+  const db = await pool.connect()
+  const expected = new Map<string, { key: string; absolutePath: string }>()
+  return withUploadTransaction({
+    client: db,
+    files: params.documents,
+    context: "livraisons.documents.attach",
+    work: async () => {
     const header = await getHeader(db, params.bonLivraisonId, { forUpdate: true })
     if (!header) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
     if (header.statut === "DELIVERED" || header.statut === "CANCELLED") {
@@ -2827,7 +2830,6 @@ export async function repoAttachLivraisonDocuments(params: {
         await fs.unlink(doc.path)
       }
       registerUploadDestination(doc, finalPath)
-      storedPaths.push(finalPath)
 
       await db.query(`INSERT INTO documents_clients (id, document_name, type) VALUES ($1, $2, $3)`, [
         documentId,
@@ -2860,6 +2862,10 @@ export async function repoAttachLivraisonDocuments(params: {
       )
 
       insertedDocIds.push(documentId)
+      expected.set(documentId, {
+        key: `${params.bonLivraisonId}|${documentId}|${checksumSha256}|${doc.originalname}|${docType}`,
+        absolutePath: finalPath,
+      })
     }
 
     await db.query(`UPDATE bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`, [params.bonLivraisonId, params.userId])
@@ -2922,23 +2928,38 @@ export async function repoAttachLivraisonDocuments(params: {
       }))
     }
 
-    commitAttempted = true
-    await db.query("COMMIT")
     return docsOut
-  } catch (err) {
-    if (!commitAttempted) {
-      let rollbackConfirmed = false
-      try { await db.query("ROLLBACK"); rollbackConfirmed = true } catch { /* preserve for reconciliation */ }
-      if (rollbackConfirmed) {
-        await Promise.all(storedPaths.map((filePath) => fs.unlink(filePath).catch(() => undefined)))
-      }
-    } else {
-      console.error("[LIVRAISON_UPLOAD_COMMIT_UNCERTAIN] durable files preserved", { count: storedPaths.length })
-    }
-    throw err
-  } finally {
-    db.release()
-  }
+    },
+    reconcile: async () => {
+      const ids = [...expected.keys()]
+      if (!ids.length) return "committed"
+      const { rows } = await pool.query<{
+        bon_livraison_id: string | null
+        document_id: string
+        checksum_sha256: string | null
+        document_name: string | null
+        document_type: string | null
+      }>(
+        `SELECT bld.bon_livraison_id::text AS bon_livraison_id,
+                dc.id::text AS document_id,
+                bld.checksum_sha256,
+                dc.document_name,
+                dc.type AS document_type
+           FROM public.documents_clients dc
+           LEFT JOIN public.bon_livraison_documents bld
+             ON bld.document_id = dc.id AND bld.bon_livraison_id = $1::uuid
+          WHERE dc.id = ANY($2::uuid[])`,
+        [params.bonLivraisonId, ids]
+      )
+      const status = classifyUploadReconciliation(
+        [...expected.values()].map((entry) => entry.key),
+        rows.map((row) => `${row.bon_livraison_id ?? ""}|${row.document_id}|${row.checksum_sha256 ?? ""}|${row.document_name ?? ""}|${row.document_type ?? ""}`)
+      )
+      if (status !== "committed") return status
+      const present = await Promise.all([...expected.values()].map((entry) => fs.stat(entry.absolutePath).then((stat) => stat.isFile()).catch(() => false)))
+      return present.every(Boolean) ? "committed" : "uncertain"
+    },
+  })
 }
 
 export async function repoRemoveLivraisonDocument(params: {

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -5,6 +5,7 @@ import type { PoolClient } from "pg"
 
 import pool from "../../../config/database"
 import { canonicalizeStockUnitCode } from "../../../shared/stock-unit"
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { normalizeCommandeWorkflowStatus } from "../../commande-client/workflow/commande-client-workflow.definition"
@@ -2824,6 +2825,7 @@ export async function repoAttachLivraisonDocuments(params: {
         await fs.copyFile(doc.path, finalPath)
         await fs.unlink(doc.path)
       }
+      registerUploadDestination(doc, finalPath)
       storedPaths.push(finalPath)
 
       await db.query(`INSERT INTO documents_clients (id, document_name, type) VALUES ($1, $2, $3)`, [

--- a/src/module/livraisons/routes/livraisons.routes.ts
+++ b/src/module/livraisons/routes/livraisons.routes.ts
@@ -1,9 +1,8 @@
 import { Router, type RequestHandler } from "express"
 import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
-import multer from "multer"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
-import { ensureTmpStoragePath } from "../../../utils/cerpStorage"
+import { createSecureUpload } from "../../../shared/uploads/secure-upload"
 import { HttpError } from "../../../utils/httpError"
 import {
   roleHasLivraisonCapability,
@@ -40,15 +39,7 @@ import {
   revokeLivraisonPackVersion,
 } from "../controllers/pack.controller"
 
-const uploadTmpDir = ensureTmpStoragePath("livraisons")
-const upload = multer({
-  dest: uploadTmpDir,
-  limits: {
-    files: 10,
-    fileSize: 20 * 1024 * 1024,
-    fields: 10,
-  },
-})
+const upload = createSecureUpload("business-document")
 
 const router = Router()
 

--- a/src/module/metrologie/controllers/metrologie.controller.ts
+++ b/src/module/metrologie/controllers/metrologie.controller.ts
@@ -1,11 +1,11 @@
 import type { Request, RequestHandler } from "express";
-import fs from "node:fs/promises";
 
 import { asyncHandler } from "../../../utils/asyncHandler";
-import { isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage";
+import { resolveCerpStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 import { emitEntityChanged } from "../../../shared/realtime/realtime.service";
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
 
 import type { AuditContext } from "../repository/metrologie.repository";
 import {
@@ -231,19 +231,14 @@ export const downloadCertificatFile: RequestHandler = asyncHandler(async (req, r
 
   const baseDir = svcMetrologieDocsBaseDir();
   const absPath = resolveCerpStoragePath(doc.storage_path, baseDir);
-  if (!isPathInsideDirectory(baseDir, absPath)) {
-    throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path");
-  }
-
-  await fs.access(absPath);
-  res.setHeader("Content-Type", doc.mime_type ?? "application/octet-stream");
-
   const rawDownload = (req.query as { download?: unknown } | undefined)?.download;
   const download = rawDownload === true || rawDownload === "true" || rawDownload === "1" || rawDownload === 1;
   const name = doc.file_original_name ?? `certificat-${certificatId}`;
-  res.setHeader(
-    "Content-Disposition",
-    `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(name)}"`
-  );
-  res.sendFile(absPath);
+  await sendSecureStoredFile(res, {
+    filePath: absPath,
+    allowedRoots: [baseDir],
+    filename: name,
+    mimeType: doc.mime_type,
+    download,
+  });
 });

--- a/src/module/metrologie/controllers/metrology-360.controller.ts
+++ b/src/module/metrologie/controllers/metrology-360.controller.ts
@@ -5,14 +5,14 @@
 // aucune décision prise côté client.
 
 import type { Request, RequestHandler } from "express";
-import fs from "node:fs/promises";
 import { ZodError, type ZodTypeAny, type z } from "zod";
 
 import { asyncHandler } from "../../../utils/asyncHandler";
-import { isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage";
+import { resolveCerpStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 import { emitEntityChanged } from "../../../shared/realtime/realtime.service";
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
 
 import type { MetrologyActor } from "../repository/metrology-shared.repository";
 import {
@@ -482,21 +482,15 @@ export const downloadCertificate: RequestHandler = asyncHandler(async (req, res)
   const absPath = resolveCerpStoragePath(doc.storage_path, baseDir);
   // Défense en profondeur : même si un chemin corrompu franchissait la base, il
   // ne peut pas sortir du répertoire privé des documents.
-  if (!isPathInsideDirectory(baseDir, absPath)) {
-    throw new HttpError(400, "INVALID_STORAGE_PATH", "Chemin de document invalide.");
-  }
-  await fs.access(absPath);
-
-  res.setHeader("Content-Type", doc.mime_type ?? "application/octet-stream");
-  res.setHeader("X-Content-Type-Options", "nosniff");
-  res.setHeader("Cache-Control", "private, no-store");
   const download = req.query.download === "true" || req.query.download === "1";
   const name = doc.file_original_name ?? `certificat-${params.childId}`;
-  res.setHeader(
-    "Content-Disposition",
-    `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(name)}"`
-  );
-  res.sendFile(absPath);
+  await sendSecureStoredFile(res, {
+    filePath: absPath,
+    allowedRoots: [baseDir],
+    filename: name,
+    mimeType: doc.mime_type,
+    download,
+  });
 });
 
 /* -------------------------------------------------------------------------- */

--- a/src/module/metrologie/repository/metrologie.repository.ts
+++ b/src/module/metrologie/repository/metrologie.repository.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 
 import pool from "../../../config/database";
 import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
+import { classifyUploadReconciliation, withUploadTransaction } from "../../../shared/uploads/upload-transaction";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -1234,24 +1235,25 @@ export async function repoAttachCertificats(params: {
   audit: AuditContext;
 }): Promise<MetrologieCertificat[] | null> {
   const { equipement_id, body, documents, audit } = params;
-  const client = await pool.connect();
   const docsDirRel = ensureDocumentStoragePath("metrologie");
   const docsDirAbs = path.resolve(docsDirRel);
+  const client = await pool.connect();
+  const expected = new Map<string, { key: string; absolutePath: string }>();
 
-  try {
-    await client.query("BEGIN");
-
+  return withUploadTransaction({
+    client,
+    files: documents,
+    context: "metrologie.certificats.attach",
+    work: async () => {
     const equipOk = await client.query<{ ok: number }>(
       `SELECT 1::int AS ok FROM public.metrologie_equipements WHERE id = $1::uuid AND deleted_at IS NULL LIMIT 1`,
       [equipement_id]
     );
     if (!equipOk.rows[0]?.ok) {
-      await client.query("ROLLBACK");
       return null;
     }
 
     if (!documents.length) {
-      await client.query("COMMIT");
       return [];
     }
 
@@ -1352,6 +1354,10 @@ export async function repoAttachCertificats(params: {
       );
       const row = ins.rows[0] ?? null;
       if (!row) throw new Error("Failed to insert certificat");
+      expected.set(row.id, {
+        key: `${row.id}|${row.sha256 ?? ""}|${row.storage_path ?? ""}`,
+        absolutePath: absPath,
+      });
       inserted.push(mapCertRow(row));
     }
 
@@ -1422,14 +1428,28 @@ export async function repoAttachCertificats(params: {
       details: { equipement_id, count: inserted.length, date_etalonnage: body.date_etalonnage, resultat: body.resultat },
     });
 
-    await client.query("COMMIT");
     return inserted;
-  } catch (err) {
-    await client.query("ROLLBACK");
-    throw err;
-  } finally {
-    client.release();
-  }
+    },
+    reconcile: async () => {
+      const ids = [...expected.keys()];
+      if (ids.length === 0) return "committed";
+      const { rows } = await pool.query<{ id: string; sha256: string | null; storage_path: string | null }>(
+        `SELECT id::text AS id, sha256, storage_path
+         FROM public.metrologie_certificats
+          WHERE id = ANY($1::uuid[])`,
+        [ids]
+      );
+      const status = classifyUploadReconciliation(
+        [...expected.values()].map((entry) => entry.key),
+        rows.map((row) => `${row.id}|${row.sha256 ?? ""}|${row.storage_path ?? ""}`)
+      );
+      if (status !== "committed") return status;
+      const present = await Promise.all(
+        [...expected.values()].map((entry) => fs.stat(entry.absolutePath).then((stat) => stat.isFile()).catch(() => false))
+      );
+      return present.every(Boolean) ? "committed" : "uncertain";
+    },
+  });
 }
 
 export async function repoRemoveCertificat(params: {

--- a/src/module/metrologie/repository/metrologie.repository.ts
+++ b/src/module/metrologie/repository/metrologie.repository.ts
@@ -5,6 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 
 import pool from "../../../config/database";
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -1271,6 +1272,7 @@ export async function repoAttachCertificats(params: {
         await fs.copyFile(tempPath, absPath);
         await fs.unlink(tempPath);
       }
+      registerUploadDestination(doc, absPath);
 
       const hash = await sha256File(absPath);
 

--- a/src/module/metrologie/repository/metrology-execution.repository.ts
+++ b/src/module/metrologie/repository/metrology-execution.repository.ts
@@ -13,6 +13,7 @@ import type { PoolClient } from "pg";
 
 import { generateMetrologieExecutionCode } from "../../../shared/codes/code-generator.service";
 import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
+import { withUploadTransaction } from "../../../shared/uploads/upload-transaction";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 
@@ -59,8 +60,6 @@ import {
   insertAuditLog,
   insertMetrologyEvent,
   isRecord,
-  MetrologyCommitUncertainError,
-  MetrologyRollbackUncertainError,
   rethrowMapped,
   saveReceipt,
   sortDirection,
@@ -1365,7 +1364,6 @@ export async function repoUploadCertificate(params: {
 
   const docsDirRel = ensureDocumentStoragePath("metrologie");
   const docsDirAbs = path.resolve(docsDirRel);
-  await fs.mkdir(docsDirAbs, { recursive: true });
 
   const certId = crypto.randomUUID();
   const extension = path.extname(file.originalname).toLowerCase();
@@ -1373,17 +1371,15 @@ export async function repoUploadCertificate(params: {
   const relPath = path.join(docsDirRel, storedName).split(path.sep).join(path.posix.sep);
   const absPath = path.join(docsDirAbs, storedName);
 
-  try {
-    await fs.rename(path.resolve(file.path), absPath);
-  } catch {
-    await fs.copyFile(path.resolve(file.path), absPath);
-    await fs.unlink(path.resolve(file.path));
-  }
-  registerUploadDestination(file, absPath);
-  const hash = await sha256File(absPath);
-
-  try {
-    await withTransaction(async (client) => {
+  const hash = await sha256File(path.resolve(file.path));
+  const client = await db().connect();
+  let inserted = false;
+  let resultId: string = certId;
+  await withUploadTransaction({
+    client,
+    files: [file],
+    context: "metrologie.certificate.upload",
+    work: async () => {
       const claim = await acquireIdempotency({
         client,
         actor,
@@ -1391,7 +1387,14 @@ export async function repoUploadCertificate(params: {
         commandType: "metrology.certificate.upload",
         requestPayload: { equipementId, ...body, sha256: hash },
       });
-      if (claim.replay) return;
+      if (claim.replay) {
+        const replayId = claim.replay.id;
+        if (typeof replayId !== "string") {
+          throw new HttpError(500, "METROLOGY_RECEIPT_INVALID", "Le reÃ§u idempotent du certificat est invalide.");
+        }
+        resultId = replayId;
+        return { id: replayId, inserted: false };
+      }
 
       const equip = await client.query<{ id: string }>(
         `SELECT id::text AS id FROM public.metrologie_equipements
@@ -1410,6 +1413,16 @@ export async function repoUploadCertificate(params: {
           throw new HttpError(422, "METROLOGY_EXECUTION_MISMATCH", "Cette exécution n'appartient pas à l'équipement.");
         }
       }
+
+      await fs.mkdir(docsDirAbs, { recursive: true });
+      try {
+        await fs.rename(path.resolve(file.path), absPath);
+      } catch {
+        await fs.copyFile(path.resolve(file.path), absPath);
+        await fs.unlink(path.resolve(file.path));
+      }
+      registerUploadDestination(file, absPath);
+      inserted = true;
 
       try {
         await client.query(
@@ -1489,16 +1502,27 @@ export async function repoUploadCertificate(params: {
         resultPayload: { id: certId, sha256: hash },
         correlationId,
       });
-    });
-  } catch (err) {
-    // Delete only after the transaction wrapper confirmed a pre-COMMIT
-    // rollback. COMMIT/rollback uncertainty preserves the proof for a fresh
-    // connection reconciliation instead of risking durable metadata without it.
-    if (!(err instanceof MetrologyCommitUncertainError) && !(err instanceof MetrologyRollbackUncertainError)) {
-      await fs.unlink(absPath).catch(() => undefined);
-    }
-    throw err;
-  }
+      return { id: certId, inserted: true };
+    },
+    reconcile: async () => {
+      if (!inserted) return "committed";
+      const { rows } = await db().query<{
+        equipement_id: string;
+        sha256: string | null;
+        storage_path: string | null;
+      }>(
+        `SELECT equipement_id::text AS equipement_id, sha256, storage_path
+           FROM public.metrologie_certificats
+          WHERE id = $1::uuid`,
+        [certId]
+      );
+      const row = rows[0];
+      if (!row) return "not-committed";
+      if (row.equipement_id !== equipementId || row.sha256 !== hash || row.storage_path !== relPath) return "uncertain";
+      const filePresent = await fs.stat(absPath).then((stat) => stat.isFile()).catch(() => false);
+      return filePresent ? "committed" : "uncertain";
+    },
+  });
 
   const res = await db().query(
     `
@@ -1516,7 +1540,7 @@ export async function repoUploadCertificate(params: {
       LEFT JOIN public.users cb ON cb.id = c.created_by
       WHERE c.id = $1::uuid
     `,
-    [certId]
+    [resultId]
   );
   const row = res.rows[0];
   if (!row) throw new HttpError(500, "METROLOGY_CERTIFICATE_RELOAD_FAILED", "Certificat introuvable après dépôt.");

--- a/src/module/metrologie/repository/metrology-execution.repository.ts
+++ b/src/module/metrologie/repository/metrology-execution.repository.ts
@@ -12,6 +12,7 @@ import path from "node:path";
 import type { PoolClient } from "pg";
 
 import { generateMetrologieExecutionCode } from "../../../shared/codes/code-generator.service";
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 
@@ -1376,6 +1377,7 @@ export async function repoUploadCertificate(params: {
     await fs.copyFile(path.resolve(file.path), absPath);
     await fs.unlink(path.resolve(file.path));
   }
+  registerUploadDestination(file, absPath);
   const hash = await sha256File(absPath);
 
   try {

--- a/src/module/metrologie/repository/metrology-execution.repository.ts
+++ b/src/module/metrologie/repository/metrology-execution.repository.ts
@@ -59,6 +59,8 @@ import {
   insertAuditLog,
   insertMetrologyEvent,
   isRecord,
+  MetrologyCommitUncertainError,
+  MetrologyRollbackUncertainError,
   rethrowMapped,
   saveReceipt,
   sortDirection,
@@ -1489,9 +1491,12 @@ export async function repoUploadCertificate(params: {
       });
     });
   } catch (err) {
-    // Le fichier ne doit pas survivre à une transaction annulée : sinon on
-    // accumule des preuves orphelines dans le stockage privé.
-    await fs.unlink(absPath).catch(() => undefined);
+    // Delete only after the transaction wrapper confirmed a pre-COMMIT
+    // rollback. COMMIT/rollback uncertainty preserves the proof for a fresh
+    // connection reconciliation instead of risking durable metadata without it.
+    if (!(err instanceof MetrologyCommitUncertainError) && !(err instanceof MetrologyRollbackUncertainError)) {
+      await fs.unlink(absPath).catch(() => undefined);
+    }
     throw err;
   }
 

--- a/src/module/metrologie/repository/metrology-shared.repository.ts
+++ b/src/module/metrologie/repository/metrology-shared.repository.ts
@@ -49,16 +49,41 @@ export const METROLOGY_SETTING_KEY = "metrologie.block_on_overdue_critical";
 /* Transaction, journal, audit                                                */
 /* ========================================================================== */
 
+export class MetrologyCommitUncertainError<T> extends HttpError {
+  readonly transactionResult: T;
+  constructor(transactionResult: T) {
+    super(503, "METROLOGY_COMMIT_UNCERTAIN", "Le résultat du COMMIT doit être rapproché avant toute compensation.");
+    this.transactionResult = transactionResult;
+  }
+}
+
+export class MetrologyRollbackUncertainError extends HttpError {
+  constructor() {
+    super(503, "METROLOGY_ROLLBACK_UNCERTAIN", "Le rollback n’a pas pu être confirmé ; les preuves sont préservées.");
+  }
+}
+
 export async function withTransaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
-    const out = await fn(client);
-    await client.query("COMMIT");
+    let out: T;
+    try {
+      out = await fn(client);
+    } catch (err) {
+      try {
+        await client.query("ROLLBACK");
+      } catch {
+        throw new MetrologyRollbackUncertainError();
+      }
+      throw err;
+    }
+    try {
+      await client.query("COMMIT");
+    } catch {
+      throw new MetrologyCommitUncertainError(out);
+    }
     return out;
-  } catch (err) {
-    await client.query("ROLLBACK");
-    throw err;
   } finally {
     client.release();
   }

--- a/src/module/metrologie/routes/metrologie.routes.ts
+++ b/src/module/metrologie/routes/metrologie.routes.ts
@@ -1,8 +1,7 @@
 import { Router } from "express";
-import multer from "multer";
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
-import { ensureTmpStoragePath } from "../../../utils/cerpStorage";
+import { createSecureUpload } from "../../../shared/uploads/secure-upload";
 import { requireMetrologyCapability } from "../middlewares/metrology-authorization.middleware";
 import {
   attachCertificats,
@@ -20,14 +19,7 @@ import {
   upsertPlan,
 } from "../controllers/metrologie.controller";
 
-const tmpBaseDir = ensureTmpStoragePath("metrologie");
-
-const upload = multer({
-  dest: tmpBaseDir,
-  limits: {
-    fileSize: 25 * 1024 * 1024,
-  },
-});
+const upload = createSecureUpload("quality-document");
 
 /**
  * Routeur historique du module Métrologie.

--- a/src/module/metrologie/routes/metrology-360.routes.ts
+++ b/src/module/metrologie/routes/metrology-360.routes.ts
@@ -1,8 +1,7 @@
 import { Router } from "express";
-import multer from "multer";
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
-import { ensureTmpStoragePath } from "../../../utils/cerpStorage";
+import { createSecureUpload } from "../../../shared/uploads/secure-upload";
 import { requireMetrologyCapability } from "../middlewares/metrology-authorization.middleware";
 import {
   cancelCertificate,
@@ -51,10 +50,7 @@ router.use(authenticateToken);
 
 // Les fichiers transitent par un répertoire temporaire privé, jamais par le
 // répertoire des documents avant d'avoir été contrôlés.
-const upload = multer({
-  dest: ensureTmpStoragePath("metrologie"),
-  limits: { fileSize: 25 * 1024 * 1024, files: 1 },
-});
+const upload = createSecureUpload("quality-document", { maxFiles: 1 });
 
 /* Référentiels ------------------------------------------------------------ */
 router.get("/categories", requireMetrologyCapability("read"), listCategories);

--- a/src/module/operation-dossiers/controllers/operation-dossiers.controller.ts
+++ b/src/module/operation-dossiers/controllers/operation-dossiers.controller.ts
@@ -1,9 +1,10 @@
 import type { Request } from "express"
 import type { RequestHandler } from "express"
 import fs from "node:fs/promises"
-import path from "node:path"
 
 import { HttpError } from "../../../utils/httpError"
+import { getDocumentStoragePath } from "../../../utils/cerpStorage"
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download"
 import {
   createOperationDossierVersionBodySchema,
   dossierIdParamsSchema,
@@ -11,7 +12,6 @@ import {
   getOperationDossierQuerySchema,
 } from "../validators/operation-dossiers.validators"
 import {
-  computeContentDisposition,
   getDownloadFlag,
   pickMimeType,
   repoFindOperationDossierDocumentFilePath,
@@ -106,11 +106,14 @@ export const downloadOperationDossierDocument: RequestHandler = async (req, res,
       return
     }
 
-    await fs.access(filePath)
     const download = getDownloadFlag((req.query as { download?: unknown } | undefined)?.download)
-    res.setHeader("Content-Type", pickMimeType(meta?.mime_type ?? null))
-    res.setHeader("Content-Disposition", computeContentDisposition({ download, filename: name }))
-    res.sendFile(path.resolve(filePath))
+    await sendSecureStoredFile(res, {
+      filePath,
+      allowedRoots: [getDocumentStoragePath("operation-dossiers")],
+      filename: name,
+      mimeType: pickMimeType(meta?.mime_type ?? null),
+      download,
+    })
   } catch (err) {
     if (err && typeof err === "object" && "code" in err && (err as { code?: unknown }).code === "ENOENT") {
       next(new HttpError(404, "FILE_NOT_FOUND", "File not found"))

--- a/src/module/operation-dossiers/repository/operation-dossiers.repository.ts
+++ b/src/module/operation-dossiers/repository/operation-dossiers.repository.ts
@@ -4,6 +4,7 @@ import path from "node:path"
 import type { PoolClient } from "pg"
 
 import pool from "../../../config/database"
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
@@ -539,6 +540,7 @@ export async function repoCreateOperationDossierVersion(params: {
           await fs.copyFile(file.path, finalPath)
           await fs.unlink(file.path)
         }
+        registerUploadDestination(file, finalPath)
         movedFiles.push(finalPath)
 
         await tx.query(`INSERT INTO public.documents_clients (id, document_name, type) VALUES ($1, $2, $3)`, [

--- a/src/module/operation-dossiers/repository/operation-dossiers.repository.ts
+++ b/src/module/operation-dossiers/repository/operation-dossiers.repository.ts
@@ -481,6 +481,7 @@ export async function repoCreateOperationDossierVersion(params: {
   const docsDir = await ensureDocsDir()
   const tx = await pool.connect()
   const movedFiles: string[] = []
+  let commitAttempted = false
 
   try {
     await tx.query("BEGIN")
@@ -602,11 +603,17 @@ export async function repoCreateOperationDossierVersion(params: {
       },
     })
 
+    commitAttempted = true
     await tx.query("COMMIT")
     return { id: versionRow.id, dossier_id: versionRow.dossier_id, version: versionRow.version }
   } catch (err) {
-    await tx.query("ROLLBACK")
-    for (const f of movedFiles) await fs.unlink(f).catch(() => undefined)
+    if (!commitAttempted) {
+      let rollbackConfirmed = false
+      try { await tx.query("ROLLBACK"); rollbackConfirmed = true } catch { /* preserve for reconciliation */ }
+      if (rollbackConfirmed) for (const f of movedFiles) await fs.unlink(f).catch(() => undefined)
+    } else {
+      console.error("[OPERATION_DOSSIER_UPLOAD_COMMIT_UNCERTAIN] durable files preserved", { count: movedFiles.length })
+    }
     throw err
   } finally {
     tx.release()

--- a/src/module/operation-dossiers/repository/operation-dossiers.repository.ts
+++ b/src/module/operation-dossiers/repository/operation-dossiers.repository.ts
@@ -5,6 +5,7 @@ import type { PoolClient } from "pg"
 
 import pool from "../../../config/database"
 import { registerUploadDestination } from "../../../shared/uploads/secure-upload"
+import { classifyUploadReconciliation, withUploadTransaction } from "../../../shared/uploads/upload-transaction"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
@@ -480,12 +481,14 @@ export async function repoCreateOperationDossierVersion(params: {
 }): Promise<CreateOperationDossierVersionResult> {
   const docsDir = await ensureDocsDir()
   const tx = await pool.connect()
-  const movedFiles: string[] = []
-  let commitAttempted = false
+  let expectedVersion: { id: string; dossierId: string; version: number } | null = null
+  const expectedDocuments = new Map<string, { key: string; absolutePath: string }>()
 
-  try {
-    await tx.query("BEGIN")
-
+  return withUploadTransaction({
+    client: tx,
+    files: [...params.uploadsBySlot.values()],
+    context: "operation-dossiers.version.create",
+    work: async () => {
     const dossier = await repoGetDossierForUpdate(tx, params.dossier_id)
     const baseline = await repoGetLatestVersionBaseline(tx, params.dossier_id)
 
@@ -501,6 +504,7 @@ export async function repoCreateOperationDossierVersion(params: {
 
     const versionRow = versionIns.rows[0] ?? null
     if (!versionRow) throw new Error("Failed to create operation dossier version")
+    expectedVersion = { id: versionRow.id, dossierId: versionRow.dossier_id, version: versionRow.version }
 
     const allowedSlots = slotKeysForType(dossier.dossier_type)
     const docsBySlot = baseline?.docsBySlot ?? new Map<string, SlotDocumentBaseline>()
@@ -542,7 +546,6 @@ export async function repoCreateOperationDossierVersion(params: {
           await fs.unlink(file.path)
         }
         registerUploadDestination(file, finalPath)
-        movedFiles.push(finalPath)
 
         await tx.query(`INSERT INTO public.documents_clients (id, document_name, type) VALUES ($1, $2, $3)`, [
           documentId,
@@ -554,6 +557,10 @@ export async function repoCreateOperationDossierVersion(params: {
         nextMimeType = file.mimetype
         nextFileName = file.originalname
         nextSizeBytes = typeof file.size === "number" && Number.isFinite(file.size) ? file.size : null
+        expectedDocuments.set(documentId, {
+          key: `${versionRow.id}|${slotKey}|${documentId}|${file.originalname}|${file.mimetype}`,
+          absolutePath: finalPath,
+        })
       }
 
       await tx.query(
@@ -603,21 +610,49 @@ export async function repoCreateOperationDossierVersion(params: {
       },
     })
 
-    commitAttempted = true
-    await tx.query("COMMIT")
     return { id: versionRow.id, dossier_id: versionRow.dossier_id, version: versionRow.version }
-  } catch (err) {
-    if (!commitAttempted) {
-      let rollbackConfirmed = false
-      try { await tx.query("ROLLBACK"); rollbackConfirmed = true } catch { /* preserve for reconciliation */ }
-      if (rollbackConfirmed) for (const f of movedFiles) await fs.unlink(f).catch(() => undefined)
-    } else {
-      console.error("[OPERATION_DOSSIER_UPLOAD_COMMIT_UNCERTAIN] durable files preserved", { count: movedFiles.length })
-    }
-    throw err
-  } finally {
-    tx.release()
-  }
+    },
+    reconcile: async () => {
+      const version = expectedVersion
+      if (!version) return "uncertain"
+      const versionRes = await pool.query<{ id: string; dossier_id: string; version: number }>(
+        `SELECT id::text AS id, dossier_id::text AS dossier_id, version
+           FROM public.operation_dossier_versions
+          WHERE id = $1::uuid`,
+        [version.id]
+      )
+      const observedVersion = versionRes.rows[0]
+      if (!observedVersion) return "not-committed"
+      if (observedVersion.dossier_id !== version.dossierId || observedVersion.version !== version.version) return "uncertain"
+
+      const ids = [...expectedDocuments.keys()]
+      if (!ids.length) return "committed"
+      const { rows } = await pool.query<{
+        dossier_version_id: string
+        slot_key: string
+        document_id: string
+        file_name: string | null
+        mime_type: string | null
+      }>(
+        `SELECT dossier_version_id::text AS dossier_version_id,
+                slot_key,
+                document_id::text AS document_id,
+                file_name,
+                mime_type
+           FROM public.operation_dossier_version_documents
+          WHERE dossier_version_id = $1::uuid
+            AND document_id = ANY($2::uuid[])`,
+        [version.id, ids]
+      )
+      const status = classifyUploadReconciliation(
+        [...expectedDocuments.values()].map((entry) => entry.key),
+        rows.map((row) => `${row.dossier_version_id}|${row.slot_key}|${row.document_id}|${row.file_name ?? ""}|${row.mime_type ?? ""}`)
+      )
+      if (status !== "committed") return "uncertain"
+      const present = await Promise.all([...expectedDocuments.values()].map((entry) => fs.stat(entry.absolutePath).then((stat) => stat.isFile()).catch(() => false)))
+      return present.every(Boolean) ? "committed" : "uncertain"
+    },
+  })
 }
 
 export async function repoIsOperationDossierDocumentLinked(documentId: string): Promise<boolean> {

--- a/src/module/operation-dossiers/routes/operation-dossiers.routes.ts
+++ b/src/module/operation-dossiers/routes/operation-dossiers.routes.ts
@@ -1,16 +1,14 @@
 import { Router } from "express"
-import multer from "multer"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
-import { ensureTmpStoragePath } from "../../../utils/cerpStorage"
+import { createSecureUpload } from "../../../shared/uploads/secure-upload"
 import {
   createOperationDossierVersion,
   downloadOperationDossierDocument,
   getOperationDossierByOperation,
 } from "../controllers/operation-dossiers.controller"
 
-const uploadTmpDir = ensureTmpStoragePath("operation-dossiers")
-const upload = multer({ dest: uploadTmpDir, limits: { files: 10 } })
+const upload = createSecureUpload("technical-document")
 
 const router = Router()
 router.use(authenticateToken)

--- a/src/module/outils/utils/outillage-upload.ts
+++ b/src/module/outils/utils/outillage-upload.ts
@@ -3,7 +3,7 @@ import { toStoredImagePath } from "../../../utils/imageStorage"
 
 const OUTILLAGE_ROOT = "outillage"
 
-export const outillageToolUpload = createImageUpload(`${OUTILLAGE_ROOT}/outils`)
+export const outillageToolUpload = createImageUpload(`${OUTILLAGE_ROOT}/outils`, "tool-media")
 export const outillageFabricantUpload = createImageUpload(`${OUTILLAGE_ROOT}/fabricants`)
 export const outillageFamilleUpload = createImageUpload(`${OUTILLAGE_ROOT}/familles`)
 export const outillageGeometrieUpload = createImageUpload(`${OUTILLAGE_ROOT}/geometries`)

--- a/src/module/pieces-techniques/controllers/document-policy.controller.ts
+++ b/src/module/pieces-techniques/controllers/document-policy.controller.ts
@@ -3,6 +3,7 @@
 import type { Request, RequestHandler } from "express";
 
 import { HttpError } from "../../../utils/httpError";
+import { buildContentDisposition } from "../../../shared/uploads/secure-download";
 import { CLIENT_DOCUMENT_POLICIES, CLIENT_DOCUMENT_POLICY_LABELS } from "../domain/document-policy";
 import { describePieceTechniquePermissions } from "../pieces-techniques.permissions";
 import {
@@ -191,7 +192,7 @@ export const downloadPieceDocumentDossierPdf: RequestHandler = async (req, res, 
     // `inline` : l'impression se fait depuis le visualiseur, sans détour par le disque.
     res.setHeader(
       "Content-Disposition",
-      `${req.query.download === "true" ? "attachment" : "inline"}; filename="${filename}"`
+      buildContentDisposition(filename, req.query.download === "true")
     );
     res.end(pdf);
   } catch (err) {

--- a/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
+++ b/src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
@@ -1,11 +1,11 @@
 // src/module/pieces-techniques/controllers/pieces-techniques.controller.ts
 import type { Request, RequestHandler } from "express"
-import fs from "node:fs/promises"
 import db from "../../../config/database"
 import { repoFindIdempotentPieceCreate } from "../repository/create-drafts.repository"
 import { generatePieceTechniqueBusinessCode } from "../../../shared/codes/code-generator.service"
-import { getDocumentStoragePath, isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage"
+import { getDocumentStoragePath, resolveCerpStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download"
 import {
   achatIdParamSchema,
   addAchatSchema,
@@ -390,19 +390,15 @@ export const downloadPieceTechniqueDocument: RequestHandler = async (req, res, n
 
     const baseDir = getDocumentStoragePath("pieces-techniques")
     const absPath = resolveCerpStoragePath(doc.storage_path, baseDir)
-    if (!isPathInsideDirectory(baseDir, absPath)) {
-      throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path")
-    }
-    await fs.access(absPath)
-
-    res.setHeader("Content-Type", doc.mime_type)
     const rawDownload = (req.query as { download?: unknown } | undefined)?.download
     const download = rawDownload === true || rawDownload === "true" || rawDownload === "1" || rawDownload === 1
-    res.setHeader(
-      "Content-Disposition",
-      `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(doc.original_name)}"`
-    )
-    res.sendFile(absPath)
+    await sendSecureStoredFile(res, {
+      filePath: absPath,
+      allowedRoots: [baseDir],
+      filename: doc.original_name,
+      mimeType: doc.mime_type,
+      download,
+    })
   } catch (err) {
     if (err && typeof err === "object" && "code" in err && (err as { code?: unknown }).code === "ENOENT") {
       next(new HttpError(404, "FILE_NOT_FOUND", "File not found"))

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -8,6 +8,7 @@ import db from "../../../config/database";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { generatePieceTechniqueBusinessCode } from "../../../shared/codes/code-generator.service";
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import type {
@@ -1024,6 +1025,7 @@ export async function repoAttachPieceTechniqueDocuments(
         await fs.copyFile(tempPath, absPath);
         await fs.unlink(tempPath);
       }
+      registerUploadDestination(doc, absPath);
 
       const hash = await sha256File(absPath);
       const ins = await client.query<PieceTechniqueDocumentRow>(

--- a/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
+++ b/src/module/pieces-techniques/repository/pieces-techniques.repository.ts
@@ -9,6 +9,7 @@ import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { generatePieceTechniqueBusinessCode } from "../../../shared/codes/code-generator.service";
 import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
+import { classifyUploadReconciliation, withUploadTransaction } from "../../../shared/uploads/upload-transaction";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import type {
@@ -969,21 +970,22 @@ export async function repoAttachPieceTechniqueDocuments(
    */
   options: { documentTypeCode?: string | null } = {}
 ): Promise<PieceTechniqueDocument[] | null> {
-  const client = await db.connect();
   const docsDirRel = ensureDocumentStoragePath("pieces-techniques");
   const docsDirAbs = path.resolve(docsDirRel);
+  const client = await db.connect();
+  const expected = new Map<string, { key: string; absolutePath: string }>();
 
-  try {
-    await client.query("BEGIN");
-
+  return withUploadTransaction({
+    client,
+    files: documents,
+    context: "pieces-techniques.attach-documents",
+    work: async () => {
     const exists = await ensurePieceTechniqueExists(client, pieceTechniqueId);
     if (!exists) {
-      await client.query("ROLLBACK");
       return null;
     }
 
     if (!documents.length) {
-      await client.query("COMMIT");
       return [];
     }
 
@@ -1077,6 +1079,10 @@ export async function repoAttachPieceTechniqueDocuments(
 
       const row = ins.rows[0];
       if (!row) throw new Error("Failed to insert piece technique document");
+      expected.set(row.id, {
+        key: `${row.id}|${row.sha256 ?? ""}|${row.storage_path}`,
+        absolutePath: absPath,
+      });
       inserted.push(mapDocRow(row));
     }
 
@@ -1096,14 +1102,28 @@ export async function repoAttachPieceTechniqueDocuments(
       },
     });
 
-    await client.query("COMMIT");
     return inserted;
-  } catch (err) {
-    await client.query("ROLLBACK");
-    throw err;
-  } finally {
-    client.release();
-  }
+    },
+    reconcile: async () => {
+      const ids = [...expected.keys()];
+      if (ids.length === 0) return "committed";
+      const { rows } = await db.query<{ id: string; sha256: string | null; storage_path: string }>(
+        `SELECT id::text AS id, sha256, storage_path
+           FROM public.pieces_techniques_documents
+          WHERE id = ANY($1::uuid[])`,
+        [ids]
+      );
+      const status = classifyUploadReconciliation(
+        [...expected.values()].map((entry) => entry.key),
+        rows.map((row) => `${row.id}|${row.sha256 ?? ""}|${row.storage_path}`)
+      );
+      if (status !== "committed") return status;
+      const filesPresent = await Promise.all(
+        [...expected.values()].map((entry) => fs.stat(entry.absolutePath).then((stat) => stat.isFile()).catch(() => false))
+      );
+      return filesPresent.every(Boolean) ? "committed" : "uncertain";
+    },
+  });
 }
 
 export async function repoRemovePieceTechniqueDocument(

--- a/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
+++ b/src/module/pieces-techniques/routes/pieces-techniques.routes.ts
@@ -1,10 +1,9 @@
 // src/module/pieces-techniques/routes/pieces-techniques.routes.ts
 import { Router, type RequestHandler } from "express"
 import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
-import multer from "multer"
 
 import { authenticateToken, authorizeRole } from "../../auth/middlewares/auth.middleware"
-import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
+import { createSecureUpload } from "../../../shared/uploads/secure-upload"
 import { HttpError } from "../../../utils/httpError"
 import {
   canValidatePieceTechnique,
@@ -138,14 +137,7 @@ const requireVersionApproval: RequestHandler = (req, _res, next) => {
   next()
 }
 
-const docsBaseDir = ensureDocumentStoragePath("pieces-techniques")
-
-const upload = multer({
-  dest: docsBaseDir,
-  limits: {
-    fileSize: 25 * 1024 * 1024,
-  },
-})
+const upload = createSecureUpload("technical-document")
 
 router.use(authenticateToken)
 

--- a/src/module/planning/controllers/planning.controller.ts
+++ b/src/module/planning/controllers/planning.controller.ts
@@ -1,11 +1,11 @@
 import type { Request } from "express";
 import type { RequestHandler } from "express";
-import fs from "node:fs/promises";
 import path from "node:path";
 
 import { asyncHandler } from "../../../utils/asyncHandler";
-import { getDocumentStoragePath, isPathInsideDirectory } from "../../../utils/cerpStorage";
+import { getDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
 import type { AuditContext } from "../repository/planning.repository";
 import {
   autoPlanPlanningSchema,
@@ -260,20 +260,15 @@ export const getPlanningEventDocumentFile: RequestHandler = async (req, res, nex
 
     const baseDir = getDocumentStoragePath();
     const absPath = path.resolve(baseDir, `${doc.id}${safeExtFromName(doc.document_name)}`);
-    if (!isPathInsideDirectory(baseDir, absPath)) {
-      throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path");
-    }
-
-    await fs.access(absPath);
-
-    res.setHeader("Content-Type", resolveMimeType(doc.type));
     const rawDownload = (req.query as { download?: unknown } | undefined)?.download;
     const download = rawDownload === true || rawDownload === "true" || rawDownload === "1" || rawDownload === 1;
-    res.setHeader(
-      "Content-Disposition",
-      `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(doc.document_name)}"`
-    );
-    res.sendFile(absPath);
+    await sendSecureStoredFile(res, {
+      filePath: absPath,
+      allowedRoots: [baseDir],
+      filename: doc.document_name,
+      mimeType: resolveMimeType(doc.type),
+      download,
+    });
   } catch (err) {
     if (err && typeof err === "object" && "code" in err && (err as { code?: unknown }).code === "ENOENT") {
       next(new HttpError(404, "FILE_NOT_FOUND", "File not found"));

--- a/src/module/planning/repository/planning.repository.ts
+++ b/src/module/planning/repository/planning.repository.ts
@@ -6,6 +6,7 @@ import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { emitAppNotificationCreated, emitEntityChanged } from "../../../shared/realtime/realtime.service";
 import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
+import { classifyUploadReconciliation, withUploadTransaction } from "../../../shared/uploads/upload-transaction";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -2422,8 +2423,9 @@ async function insertPlanningEventDocuments(tx: PoolClient, params: {
   event_id: string;
   documents: UploadedDocument[];
   user_id: number;
-}) {
-  if (!params.documents.length) return;
+}): Promise<Array<{ id: string; key: string; absolutePath: string }>> {
+  const expected: Array<{ id: string; key: string; absolutePath: string }> = [];
+  if (!params.documents.length) return expected;
 
   for (const doc of params.documents) {
     const documentId = crypto.randomUUID();
@@ -2456,7 +2458,13 @@ async function insertPlanningEventDocuments(tx: PoolClient, params: {
       `,
       [params.event_id, documentId, isPdf ? "PDF" : null, params.user_id]
     );
+    expected.push({
+      id: documentId,
+      key: `${params.event_id}|${documentId}|${doc.originalname}|${docType}`,
+      absolutePath: finalPath,
+    });
   }
+  return expected;
 }
 
 export async function repoUploadPlanningEventDocuments(params: {
@@ -2465,8 +2473,12 @@ export async function repoUploadPlanningEventDocuments(params: {
   audit: AuditContext;
 }): Promise<PlanningEventDocument[]> {
   const client = await pool.connect();
-  try {
-    await client.query("BEGIN");
+  let expected: Array<{ id: string; key: string; absolutePath: string }> = [];
+  return withUploadTransaction({
+    client,
+    files: params.documents,
+    context: "planning.events.documents.upload",
+    work: async () => {
 
     const exists = await client.query<{ id: string }>(
       `SELECT id::text AS id FROM public.planning_events WHERE id = $1::uuid AND archived_at IS NULL LIMIT 1`,
@@ -2476,7 +2488,7 @@ export async function repoUploadPlanningEventDocuments(params: {
       throw new HttpError(404, "PLANNING_EVENT_NOT_FOUND", "Event not found");
     }
 
-    await insertPlanningEventDocuments(client, {
+    expected = await insertPlanningEventDocuments(client, {
       event_id: params.event_id,
       documents: params.documents,
       user_id: params.audit.user_id,
@@ -2489,9 +2501,7 @@ export async function repoUploadPlanningEventDocuments(params: {
       details: { count: params.documents.length },
     });
 
-    await client.query("COMMIT");
-
-    const docsRes = await pool.query<{ document_id: string; document_name: string; type: string | null }>(
+    const docsRes = await client.query<{ document_id: string; document_name: string; type: string | null }>(
       `
         SELECT
           ped.document_id::text AS document_id,
@@ -2510,12 +2520,28 @@ export async function repoUploadPlanningEventDocuments(params: {
       document_name: r.document_name,
       type: r.type,
     }));
-  } catch (err) {
-    await client.query("ROLLBACK");
-    throw err;
-  } finally {
-    client.release();
-  }
+    },
+    reconcile: async () => {
+      if (expected.length === 0) return "committed";
+      const { rows } = await pool.query<{ event_id: string | null; document_id: string; document_name: string; type: string | null }>(
+        `SELECT ped.event_id::text AS event_id, dc.id::text AS document_id, dc.document_name, dc.type
+           FROM public.documents_clients dc
+           LEFT JOIN public.planning_event_documents ped
+             ON ped.document_id = dc.id AND ped.event_id = $1::uuid
+          WHERE dc.id = ANY($2::uuid[])`,
+        [params.event_id, expected.map((entry) => entry.id)]
+      );
+      const status = classifyUploadReconciliation(
+        expected.map((entry) => entry.key),
+        rows.map((row) => `${row.event_id ?? ""}|${row.document_id}|${row.document_name}|${row.type ?? ""}`)
+      );
+      if (status !== "committed") return status;
+      const filesPresent = await Promise.all(
+        expected.map((entry) => fs.stat(entry.absolutePath).then((stat) => stat.isFile()).catch(() => false))
+      );
+      return filesPresent.every(Boolean) ? "committed" : "uncertain";
+    },
+  });
 }
 
 export async function repoGetPlanningEventDocumentFileMeta(params: {

--- a/src/module/planning/repository/planning.repository.ts
+++ b/src/module/planning/repository/planning.repository.ts
@@ -5,6 +5,7 @@ import type { PoolClient } from "pg";
 
 import pool from "../../../config/database";
 import { emitAppNotificationCreated, emitEntityChanged } from "../../../shared/realtime/realtime.service";
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -2441,6 +2442,7 @@ async function insertPlanningEventDocuments(tx: PoolClient, params: {
       await fs.copyFile(doc.path, finalPath);
       await fs.unlink(doc.path);
     }
+    registerUploadDestination(doc, finalPath);
 
     await tx.query(
       `INSERT INTO public.documents_clients (id, document_name, type) VALUES ($1, $2, $3)`,

--- a/src/module/planning/routes/planning.routes.ts
+++ b/src/module/planning/routes/planning.routes.ts
@@ -1,8 +1,7 @@
 import { Router, type RequestHandler } from "express";
 import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
-import multer from "multer";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
-import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
+import { createSecureUpload } from "../../../shared/uploads/secure-upload";
 import { HttpError } from "../../../utils/httpError";
 import { roleHasPlanningAccess } from "../domain/planning-rbac";
 import {
@@ -33,7 +32,7 @@ const requireProductionOrAdmin: RequestHandler = (req, _res, next) => {
   next();
 };
 
-const uploadDocs = multer({ dest: ensureDocumentStoragePath() });
+const uploadDocs = createSecureUpload("business-document");
 
 const router = Router();
 

--- a/src/module/production/controllers/machine-park.controller.ts
+++ b/src/module/production/controllers/machine-park.controller.ts
@@ -1,8 +1,9 @@
 import fs from "node:fs/promises";
 
 import { asyncHandler } from "../../../utils/asyncHandler";
-import { getDocumentStoragePath, isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage";
+import { getDocumentStoragePath, resolveCerpStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
 import { buildAuditContext } from "./production.controller";
 import {
   createMachineMaintenanceEventSchema,
@@ -134,21 +135,14 @@ export const downloadMachineDocument = asyncHandler(async (req, res) => {
   if (!document) throw new HttpError(404, "MACHINE_DOCUMENT_NOT_FOUND", "Machine document not found.");
   const baseDirectory = getDocumentStoragePath("machines");
   const absolutePath = resolveCerpStoragePath(document.storage_path, baseDirectory);
-  if (!isPathInsideDirectory(baseDirectory, absolutePath)) {
-    throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path.");
-  }
-  try {
-    await fs.access(absolutePath);
-  } catch {
-    throw new HttpError(404, "MACHINE_DOCUMENT_FILE_NOT_FOUND", "Machine document file not found.");
-  }
-  res.setHeader("Content-Type", document.mime_type);
   const download = req.query.download === "true" || req.query.download === "1";
-  res.setHeader(
-    "Content-Disposition",
-    `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(document.original_name)}"`
-  );
-  res.sendFile(absolutePath);
+  await sendSecureStoredFile(res, {
+    filePath: absolutePath,
+    allowedRoots: [baseDirectory],
+    filename: document.original_name,
+    mimeType: document.mime_type,
+    download,
+  });
 });
 
 export const removeMachineDocument = asyncHandler(async (req, res) => {

--- a/src/module/production/controllers/of-versioning.controller.ts
+++ b/src/module/production/controllers/of-versioning.controller.ts
@@ -9,6 +9,7 @@ import type { Request, Response } from "express";
 
 import { asyncHandler } from "../../../utils/asyncHandler";
 import { HttpError } from "../../../utils/httpError";
+import { buildContentDisposition } from "../../../shared/uploads/secure-download";
 import { buildAuditContext } from "../../project-office/controllers/project-office.controller";
 import { readMachineFamilies } from "../repository/of-versioning.repository";
 import { roleHasOfCapability, type OfCapability } from "../domain/of-rbac";
@@ -308,7 +309,7 @@ export const previewPdf = asyncHandler(async (req: Request, res: Response) => {
   res.setHeader("X-Snapshot-Sha256", result.payload.snapshotSha256);
   res.setHeader(
     "Content-Disposition",
-    `inline; filename="apercu-OF-${result.payload.ofNumero}-${result.payload.revisionCode}.pdf"`
+    buildContentDisposition(`apercu-OF-${result.payload.ofNumero}-${result.payload.revisionCode}.pdf`, false)
   );
   res.end(result.buffer);
 });
@@ -347,6 +348,6 @@ export const reprintDocument = asyncHandler(async (req: Request, res: Response) 
   res.setHeader("Content-Length", String(result.pdf.byteLength));
   res.setHeader("X-Document-Sha256", String(result.document.pdf_sha256));
   res.setHeader("X-Reprint-Source", result.source);
-  res.setHeader("Content-Disposition", `inline; filename="OF-${documentId}.pdf"`);
+  res.setHeader("Content-Disposition", buildContentDisposition(`OF-${documentId}.pdf`, false));
   res.end(result.pdf);
 });

--- a/src/module/production/controllers/production.controller.ts
+++ b/src/module/production/controllers/production.controller.ts
@@ -208,10 +208,10 @@ export const createMachine = asyncHandler(async (req, res) => {
     throw new HttpError(403, "MACHINE_COST_FORBIDDEN", "Machine cost capability required.");
   }
   const file = (req as Request & { file?: unknown }).file;
-  const imagePath = isMulterFile(file) ? file.path : null;
+  const imageFile = isMulterFile(file) ? file : null;
   const idempotencyKey = typeof req.headers["idempotency-key"] === "string" ? req.headers["idempotency-key"].trim() : null;
   if (idempotencyKey && (idempotencyKey.length < 8 || idempotencyKey.length > 200)) throw new HttpError(400, "INVALID_IDEMPOTENCY_KEY", "Idempotency-Key must contain 8 to 200 characters.");
-  const out = await svcCreateMachine({ body, image_path: imagePath, idempotency_key: idempotencyKey, audit });
+  const out = await svcCreateMachine({ body, image_file: imageFile, idempotency_key: idempotencyKey, audit });
   res.status(201).json(requestHasMachineCapability(req, "costs") ? out : redactMachineCosts(out));
 });
 
@@ -224,10 +224,10 @@ export const createMachineOnboarding = asyncHandler(async (req, res) => {
     throw new HttpError(403, "MACHINE_COST_FORBIDDEN", "Machine cost capability required.");
   }
   const file = (req as Request & { file?: unknown }).file;
-  const imagePath = isMulterFile(file) ? file.path : null;
+  const imageFile = isMulterFile(file) ? file : null;
   const idempotencyKey = typeof req.headers["idempotency-key"] === "string" ? req.headers["idempotency-key"].trim() : null;
   if (!idempotencyKey || idempotencyKey.length < 8 || idempotencyKey.length > 200) throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "A stable Idempotency-Key containing 8 to 200 characters is required.");
-  const out = await svcCreateMachineOnboarding({ body, image_path: imagePath, idempotency_key: idempotencyKey, audit });
+  const out = await svcCreateMachineOnboarding({ body, image_file: imageFile, idempotency_key: idempotencyKey, audit });
   res.status(201).json(requestHasMachineCapability(req, "costs") ? out : redactMachineCosts(out));
 });
 
@@ -241,8 +241,8 @@ export const updateMachine = asyncHandler(async (req, res) => {
     throw new HttpError(403, "MACHINE_COST_FORBIDDEN", "Machine cost capability required.");
   }
   const file = (req as Request & { file?: unknown }).file;
-  const imagePath = isMulterFile(file) ? file.path : undefined;
-  const out = await svcUpdateMachine({ id, patch, image_path: imagePath, audit });
+  const imageFile = isMulterFile(file) ? file : undefined;
+  const out = await svcUpdateMachine({ id, patch, image_file: imageFile, audit });
   if (!out) {
     res.status(404).json({ error: "Not found" });
     return;
@@ -263,8 +263,8 @@ export const updateMachineOnboarding = asyncHandler(async (req, res) => {
     throw new HttpError(403, "MACHINE_MODEL_UPDATE_FORBIDDEN", "Shared machine model update capability required.");
   }
   const file = (req as Request & { file?: unknown }).file;
-  const imagePath = isMulterFile(file) ? file.path : undefined;
-  const out = await svcUpdateMachineOnboarding({ id, body, image_path: imagePath, audit });
+  const imageFile = isMulterFile(file) ? file : undefined;
+  const out = await svcUpdateMachineOnboarding({ id, body, image_file: imageFile, audit });
   if (!out) {
     res.status(404).json({ error: "Not found" });
     return;

--- a/src/module/production/repository/machine-park.repository.ts
+++ b/src/module/production/repository/machine-park.repository.ts
@@ -492,6 +492,7 @@ export async function repoUploadMachineDocument(params: {
   const id = crypto.randomUUID();
   const finalPath = path.join(documentsDirectory, `${id}${extension}`);
   let moved = false;
+  let commitAttempted = false;
   try {
     await client.query("BEGIN");
     await requireActiveMachine(client, params.machineId);
@@ -546,12 +547,20 @@ export async function repoUploadMachineDocument(params: {
         sha256,
       },
     });
+    commitAttempted = true;
     await client.query("COMMIT");
     return created;
   } catch (error) {
-    await client.query("ROLLBACK");
-    if (moved) await fs.unlink(finalPath).catch(() => undefined);
-    else await fs.unlink(params.file.path).catch(() => undefined);
+    if (!commitAttempted) {
+      let rollbackConfirmed = false;
+      try { await client.query("ROLLBACK"); rollbackConfirmed = true; } catch { /* preserve for reconciliation */ }
+      if (rollbackConfirmed) {
+        if (moved) await fs.unlink(finalPath).catch(() => undefined);
+        else await fs.unlink(params.file.path).catch(() => undefined);
+      }
+    } else {
+      console.error("[MACHINE_UPLOAD_COMMIT_UNCERTAIN] durable file preserved");
+    }
     throw error;
   } finally {
     client.release();

--- a/src/module/production/repository/machine-park.repository.ts
+++ b/src/module/production/repository/machine-park.repository.ts
@@ -11,6 +11,7 @@ import {
   sha256DocumentFile,
   toPosixStoragePath,
 } from "../../../shared/documents/document-upload";
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import type { AuditContext } from "./production.repository";
@@ -500,6 +501,7 @@ export async function repoUploadMachineDocument(params: {
       await fs.copyFile(path.resolve(params.file.path), finalPath);
       await fs.unlink(path.resolve(params.file.path));
     }
+    registerUploadDestination(params.file, finalPath);
     moved = true;
     const sha256 = await sha256DocumentFile(finalPath);
     const b = params.body;

--- a/src/module/production/repository/machine-park.repository.ts
+++ b/src/module/production/repository/machine-park.repository.ts
@@ -12,6 +12,7 @@ import {
   toPosixStoragePath,
 } from "../../../shared/documents/document-upload";
 import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
+import { withUploadTransaction } from "../../../shared/uploads/upload-transaction";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
 import type { AuditContext } from "./production.repository";
@@ -487,14 +488,17 @@ export async function repoUploadMachineDocument(params: {
     throw error;
   }
 
-  const client = await pool.connect();
   const documentsDirectory = ensureDocumentStoragePath("machines");
+  const client = await pool.connect();
   const id = crypto.randomUUID();
   const finalPath = path.join(documentsDirectory, `${id}${extension}`);
-  let moved = false;
-  let commitAttempted = false;
-  try {
-    await client.query("BEGIN");
+  let expectedSha256: string | null = null;
+  const storagePath = toPosixStoragePath(finalPath);
+  return withUploadTransaction({
+    client,
+    files: [params.file],
+    context: "production.machines.document.upload",
+    work: async () => {
     await requireActiveMachine(client, params.machineId);
     try {
       await fs.rename(path.resolve(params.file.path), finalPath);
@@ -503,8 +507,8 @@ export async function repoUploadMachineDocument(params: {
       await fs.unlink(path.resolve(params.file.path));
     }
     registerUploadDestination(params.file, finalPath);
-    moved = true;
     const sha256 = await sha256DocumentFile(finalPath);
+    expectedSha256 = sha256;
     const b = params.body;
     const result = await client.query<MachineDocument>(
       `INSERT INTO public.production_machine_documents (
@@ -520,7 +524,7 @@ export async function repoUploadMachineDocument(params: {
         params.machineId,
         b.title,
         b.document_type,
-        toPosixStoragePath(finalPath),
+        storagePath,
         b.revision ?? null,
         sha256,
         params.file.mimetype,
@@ -547,24 +551,23 @@ export async function repoUploadMachineDocument(params: {
         sha256,
       },
     });
-    commitAttempted = true;
-    await client.query("COMMIT");
     return created;
-  } catch (error) {
-    if (!commitAttempted) {
-      let rollbackConfirmed = false;
-      try { await client.query("ROLLBACK"); rollbackConfirmed = true; } catch { /* preserve for reconciliation */ }
-      if (rollbackConfirmed) {
-        if (moved) await fs.unlink(finalPath).catch(() => undefined);
-        else await fs.unlink(params.file.path).catch(() => undefined);
-      }
-    } else {
-      console.error("[MACHINE_UPLOAD_COMMIT_UNCERTAIN] durable file preserved");
-    }
-    throw error;
-  } finally {
-    client.release();
-  }
+    },
+    reconcile: async () => {
+      if (!expectedSha256) return "uncertain";
+      const { rows } = await pool.query<{ machine_id: string; sha256: string | null; storage_path: string | null }>(
+        `SELECT machine_id::text AS machine_id, sha256, storage_path
+           FROM public.production_machine_documents
+          WHERE id = $1::uuid`,
+        [id]
+      );
+      const row = rows[0];
+      if (!row) return "not-committed";
+      if (row.machine_id !== params.machineId || row.sha256 !== expectedSha256 || row.storage_path !== storagePath) return "uncertain";
+      const filePresent = await fs.stat(finalPath).then((stat) => stat.isFile()).catch(() => false);
+      return filePresent ? "committed" : "uncertain";
+    },
+  });
 }
 
 export async function repoGetMachineDocumentForDownload(params: {

--- a/src/module/production/repository/production.repository.ts
+++ b/src/module/production/repository/production.repository.ts
@@ -1,9 +1,13 @@
 import type { PoolClient } from "pg";
 import crypto from "node:crypto";
+import fs from "node:fs/promises";
 import path from "node:path";
 
 import pool from "../../../config/database";
 import { generateMachineCode, generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
+import { promoteSecureUpload } from "../../../shared/uploads/secure-upload";
+import { withUploadTransaction, type UploadCommitReconciliation } from "../../../shared/uploads/upload-transaction";
+import { ensureImagesSubdir } from "../../../utils/imageStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
@@ -72,6 +76,43 @@ const BASE_IMAGE_URL = process.env.BACKEND_URL || "http://erp-backend.croix-rous
 function imageUrl(imagePath: string | null): string | null {
   if (!imagePath) return null;
   return `${BASE_IMAGE_URL}/images/${path.basename(imagePath)}`;
+}
+
+type MachineMutationExpectation = {
+  mode: "create" | "update" | "replay";
+  machineId: string;
+  imagePath: string | null;
+  updatedAt?: string;
+  previousImagePath?: string | null;
+  previousUpdatedAt?: string;
+};
+
+async function reconcileMachineMutation(
+  expected: MachineMutationExpectation | null
+): Promise<UploadCommitReconciliation> {
+  if (!expected) return "uncertain";
+  const { rows } = await pool.query<{ id: string; image_path: string | null; updated_at: string }>(
+    `SELECT id::text AS id, image_path, updated_at::text AS updated_at
+       FROM public.machines
+      WHERE id = $1::uuid`,
+    [expected.machineId]
+  );
+  const row = rows[0];
+  if (!row) return expected.mode === "create" ? "not-committed" : "uncertain";
+  if (expected.mode === "replay") return "committed";
+  if (row.image_path === expected.imagePath && (!expected.updatedAt || row.updated_at === expected.updatedAt)) {
+    if (!expected.imagePath) return "committed";
+    const present = await fs.stat(expected.imagePath).then((stat) => stat.isFile()).catch(() => false);
+    return present ? "committed" : "uncertain";
+  }
+  if (
+    expected.mode === "update" &&
+    row.updated_at === expected.previousUpdatedAt &&
+    row.image_path === expected.previousImagePath
+  ) {
+    return "not-committed";
+  }
+  return "uncertain";
 }
 
 async function insertAuditLog(tx: DbQueryer, audit: AuditContext, entry: {
@@ -658,13 +699,18 @@ export async function repoGetMachine(id: string): Promise<MachineDetail | null> 
 
 export async function repoCreateMachine(params: {
   body: CreateMachineBodyDTO;
-  image_path: string | null;
+  image_file: Express.Multer.File | null;
   idempotency_key?: string | null;
   audit: AuditContext;
 }): Promise<MachineDetail> {
   const client = await pool.connect();
+  let expected: MachineMutationExpectation | null = null;
   try {
-    await client.query("BEGIN");
+    return await withUploadTransaction({
+      client,
+      files: params.image_file ? [params.image_file] : [],
+      context: "production.machines.create",
+      work: async () => {
 
     type Row = {
       id: string;
@@ -713,13 +759,16 @@ export async function repoCreateMachine(params: {
       );
       if (replay.rows[0]) {
         if (replay.rows[0].request_hash !== requestHash) throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Idempotency key was reused with a different payload.");
-        await client.query("COMMIT");
+        expected = { mode: "replay", machineId: replay.rows[0].machine_id, imagePath: null };
         const existing = await repoGetMachine(replay.rows[0].machine_id);
         if (!existing) throw new Error("Idempotent machine no longer exists");
         return existing;
       }
     }
     const code = await generateMachineCode(client);
+    const imagePath = params.image_file
+      ? await promoteSecureUpload(params.image_file, ensureImagesSubdir())
+      : null;
 
     const ins = await client.query<Row>(
       `
@@ -802,7 +851,7 @@ export async function repoCreateMachine(params: {
         b.model ?? null,
         b.serial_number ?? null,
         b.commissioned_year ?? null,
-        params.image_path,
+        imagePath,
         b.hourly_rate,
         b.hourly_rate_source ?? null,
         b.hourly_rate_effective_at ?? null,
@@ -826,6 +875,12 @@ export async function repoCreateMachine(params: {
 
     const row = ins.rows[0];
     if (!row) throw new Error("Failed to create machine");
+    expected = {
+      mode: "create",
+      machineId: row.id,
+      imagePath: row.image_path,
+      updatedAt: row.updated_at,
+    };
 
     if (params.idempotency_key) {
       await client.query(
@@ -845,8 +900,6 @@ export async function repoCreateMachine(params: {
         status: row.status,
       },
     });
-
-    await client.query("COMMIT");
 
     return {
       id: row.id,
@@ -887,26 +940,31 @@ export async function repoCreateMachine(params: {
       updated_by: row.updated_by,
       archived_by: row.archived_by,
     };
+      },
+      reconcile: async () => reconcileMachineMutation(expected),
+    });
   } catch (err) {
-    await client.query("ROLLBACK");
     if (isPgUniqueViolation(err)) {
       throw new HttpError(409, "MACHINE_CODE_EXISTS", "A machine with this code already exists");
     }
     throw err;
-  } finally {
-    client.release();
   }
 }
 
 export async function repoCreateMachineOnboarding(params: {
   body: CreateMachineOnboardingBodyDTO;
-  image_path: string | null;
+  image_file: Express.Multer.File | null;
   idempotency_key?: string | null;
   audit: AuditContext;
 }): Promise<MachineDetail> {
   const client = await pool.connect();
+  let expected: MachineMutationExpectation | null = null;
   try {
-    await client.query("BEGIN");
+    return await withUploadTransaction({
+      client,
+      files: params.image_file ? [params.image_file] : [],
+      context: "production.machines.onboarding.create",
+      work: async () => {
 
     const b = params.body;
     const requestHash = crypto.createHash("sha256").update(JSON.stringify(b)).digest("hex");
@@ -917,7 +975,7 @@ export async function repoCreateMachineOnboarding(params: {
       );
       if (replay.rows[0]) {
         if (replay.rows[0].request_hash !== requestHash) throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Idempotency key was reused with a different payload.");
-        await client.query("COMMIT");
+        expected = { mode: "replay", machineId: replay.rows[0].machine_id, imagePath: null };
         const replayMachine = await repoGetMachine(replay.rows[0].machine_id);
         if (!replayMachine) throw new Error("Idempotent machine no longer exists");
         return replayMachine;
@@ -1063,6 +1121,9 @@ export async function repoCreateMachineOnboarding(params: {
 
     const machine = b.machine;
     const code = await generateMachineCode(client);
+    const imagePath = params.image_file
+      ? await promoteSecureUpload(params.image_file, ensureImagesSubdir())
+      : null;
     const ins = await client.query<Row>(
       `
         INSERT INTO machines (
@@ -1144,7 +1205,7 @@ export async function repoCreateMachineOnboarding(params: {
         machine.model ?? resolvedModel?.model ?? null,
         machine.serial_number ?? null,
         machine.commissioned_year ?? null,
-        params.image_path,
+        imagePath,
         machine.hourly_rate,
         machine.hourly_rate_source ?? null,
         machine.hourly_rate_effective_at ?? null,
@@ -1168,6 +1229,12 @@ export async function repoCreateMachineOnboarding(params: {
 
     const row = ins.rows[0];
     if (!row) throw new Error("Failed to create machine from onboarding");
+    expected = {
+      mode: "create",
+      machineId: row.id,
+      imagePath: row.image_path,
+      updatedAt: row.updated_at,
+    };
 
     if (params.idempotency_key) {
       await client.query(
@@ -1191,8 +1258,6 @@ export async function repoCreateMachineOnboarding(params: {
         tooling_count: b.tooling?.length ?? 0,
       },
     });
-
-    await client.query("COMMIT");
 
     return {
       id: row.id,
@@ -1233,8 +1298,10 @@ export async function repoCreateMachineOnboarding(params: {
       updated_by: row.updated_by,
       archived_by: row.archived_by,
     };
+      },
+      reconcile: async () => reconcileMachineMutation(expected),
+    });
   } catch (err) {
-    await client.query("ROLLBACK");
     if (isPgUniqueViolation(err)) {
       const constraint = pgConstraint(err);
       if (constraint === "machines_code_key") {
@@ -1249,20 +1316,23 @@ export async function repoCreateMachineOnboarding(params: {
       throw new HttpError(422, "MACHINE_ONBOARDING_REFERENCE_INVALID", "Machine onboarding references invalid data");
     }
     throw err;
-  } finally {
-    client.release();
   }
 }
 
 export async function repoUpdateMachineOnboarding(params: {
   id: string;
   body: UpdateMachineOnboardingBodyDTO;
-  image_path?: string | null;
+  image_file?: Express.Multer.File | null;
   audit: AuditContext;
 }): Promise<MachineDetail | null> {
   const client = await pool.connect();
+  let expected: MachineMutationExpectation | null = null;
   try {
-    await client.query("BEGIN");
+    const machineId = await withUploadTransaction({
+      client,
+      files: params.image_file ? [params.image_file] : [],
+      context: "production.machines.onboarding.update",
+      work: async () => {
 
     const existingMachine = await client.query<{
       id: string;
@@ -1275,6 +1345,7 @@ export async function repoUpdateMachineOnboarding(params: {
       commissioned_year: number | null;
       location: string | null;
       workshop_zone: string | null;
+      image_path: string | null;
       archived_at: string | null;
       updated_at: string;
     }>(
@@ -1290,6 +1361,7 @@ export async function repoUpdateMachineOnboarding(params: {
           commissioned_year,
           location,
           workshop_zone,
+          image_path,
           archived_at::text AS archived_at,
           updated_at::text AS updated_at
         FROM machines
@@ -1300,7 +1372,6 @@ export async function repoUpdateMachineOnboarding(params: {
     );
     const existing = existingMachine.rows[0] ?? null;
     if (!existing) {
-      await client.query("ROLLBACK");
       return null;
     }
     if (existing.archived_at) {
@@ -1477,6 +1548,10 @@ export async function repoUpdateMachineOnboarding(params: {
       await upsertMachineTooling(client, resolvedModelId, b.tooling ?? []);
     }
 
+    const imagePath = params.image_file
+      ? await promoteSecureUpload(params.image_file, ensureImagesSubdir())
+      : undefined;
+
     const sets: string[] = [];
     const values: unknown[] = [];
     const push = (v: unknown) => {
@@ -1508,8 +1583,8 @@ export async function repoUpdateMachineOnboarding(params: {
     sets.push(`location = ${push(machine.location ?? null)}`);
     sets.push(`workshop_zone = ${push(machine.workshop_zone ?? null)}`);
     sets.push(`notes = ${push(machine.notes ?? null)}`);
-    if (params.image_path !== undefined) {
-      sets.push(`image_path = ${push(params.image_path)}`);
+    if (imagePath !== undefined) {
+      sets.push(`image_path = ${push(imagePath)}`);
     }
     sets.push(`updated_by = ${push(params.audit.user_id)}`);
     sets.push(`updated_at = now()`);
@@ -1525,6 +1600,8 @@ export async function repoUpdateMachineOnboarding(params: {
       commissioned_year: number | null;
       location: string | null;
       workshop_zone: string | null;
+      image_path: string | null;
+      updated_at: string;
     }>(
       `
         UPDATE machines
@@ -1541,13 +1618,23 @@ export async function repoUpdateMachineOnboarding(params: {
           serial_number,
           commissioned_year,
           location,
-          workshop_zone
+          workshop_zone,
+          image_path,
+          updated_at::text AS updated_at
       `,
       values
     );
 
     const row = upd.rows[0] ?? null;
     if (!row) throw new HttpError(409, "CONCURRENT_MODIFICATION", "Machine has been modified by another user.");
+    expected = {
+      mode: "update",
+      machineId: row.id,
+      imagePath: row.image_path,
+      updatedAt: row.updated_at,
+      previousImagePath: existing.image_path,
+      previousUpdatedAt: existing.updated_at,
+    };
 
     await insertAuditLog(client, params.audit, {
       action: "production.machines.onboarding.update",
@@ -1586,13 +1673,15 @@ export async function repoUpdateMachineOnboarding(params: {
       },
     });
 
-    await client.query("COMMIT");
-
-    const out = await repoGetMachine(row.id);
+    return row.id;
+      },
+      reconcile: async () => reconcileMachineMutation(expected),
+    });
+    if (machineId === null) return null;
+    const out = await repoGetMachine(machineId);
     if (!out) throw new Error("Failed to load updated machine");
     return out;
   } catch (err) {
-    await client.query("ROLLBACK");
     if (isPgUniqueViolation(err)) {
       const constraint = pgConstraint(err);
       if (constraint === "machines_code_key") {
@@ -1610,28 +1699,30 @@ export async function repoUpdateMachineOnboarding(params: {
       throw new HttpError(422, "MACHINE_ONBOARDING_REFERENCE_INVALID", "Machine onboarding references invalid data");
     }
     throw err;
-  } finally {
-    client.release();
   }
 }
 
 export async function repoUpdateMachine(params: {
   id: string;
   patch: UpdateMachineBodyDTO;
-  image_path?: string | null;
+  image_file?: Express.Multer.File | null;
   audit: AuditContext;
 }): Promise<MachineDetail | null> {
   const client = await pool.connect();
+  let expected: MachineMutationExpectation | null = null;
   try {
-    await client.query("BEGIN");
+    return await withUploadTransaction({
+      client,
+      files: params.image_file ? [params.image_file] : [],
+      context: "production.machines.update",
+      work: async () => {
 
-    const before = await client.query<{ id: string; archived_at: string | null; updated_at: string }>(
-      `SELECT id::text AS id, archived_at::text AS archived_at, updated_at::text AS updated_at FROM machines WHERE id = $1::uuid FOR UPDATE`,
+    const before = await client.query<{ id: string; image_path: string | null; archived_at: string | null; updated_at: string }>(
+      `SELECT id::text AS id, image_path, archived_at::text AS archived_at, updated_at::text AS updated_at FROM machines WHERE id = $1::uuid FOR UPDATE`,
       [params.id]
     );
     const existing = before.rows[0];
     if (!existing) {
-      await client.query("ROLLBACK");
       return null;
     }
     if (existing.archived_at) {
@@ -1640,6 +1731,10 @@ export async function repoUpdateMachine(params: {
     if (existing.updated_at !== params.patch.expected_updated_at) {
       throw new HttpError(409, "CONCURRENT_MODIFICATION", "Machine has been modified by another user.");
     }
+
+    const imagePath = params.image_file
+      ? await promoteSecureUpload(params.image_file, ensureImagesSubdir())
+      : undefined;
 
     const sets: string[] = [];
     const values: unknown[] = [];
@@ -1676,8 +1771,8 @@ export async function repoUpdateMachine(params: {
     if (p.workshop_zone !== undefined) sets.push(`workshop_zone = ${push(p.workshop_zone ?? null)}`);
     if (p.notes !== undefined) sets.push(`notes = ${push(p.notes ?? null)}`);
 
-    if (params.image_path !== undefined) {
-      sets.push(`image_path = ${push(params.image_path)}`);
+    if (imagePath !== undefined) {
+      sets.push(`image_path = ${push(imagePath)}`);
     }
 
     sets.push(`updated_by = ${push(params.audit.user_id)}`);
@@ -1765,9 +1860,16 @@ export async function repoUpdateMachine(params: {
 
     const row = upd.rows[0];
     if (!row) {
-      await client.query("ROLLBACK");
       return null;
     }
+    expected = {
+      mode: "update",
+      machineId: row.id,
+      imagePath: row.image_path,
+      updatedAt: row.updated_at,
+      previousImagePath: existing.image_path,
+      previousUpdatedAt: existing.updated_at,
+    };
 
     await insertAuditLog(client, params.audit, {
       action: "production.machines.update",
@@ -1778,8 +1880,6 @@ export async function repoUpdateMachine(params: {
         name: row.name,
       },
     });
-
-    await client.query("COMMIT");
 
     return {
       id: row.id,
@@ -1820,14 +1920,14 @@ export async function repoUpdateMachine(params: {
       updated_by: row.updated_by,
       archived_by: row.archived_by,
     };
+      },
+      reconcile: async () => reconcileMachineMutation(expected),
+    });
   } catch (err) {
-    await client.query("ROLLBACK");
     if (isPgUniqueViolation(err)) {
       throw new HttpError(409, "MACHINE_CODE_EXISTS", "A machine with this code already exists");
     }
     throw err;
-  } finally {
-    client.release();
   }
 }
 

--- a/src/module/production/routes/production.routes.ts
+++ b/src/module/production/routes/production.routes.ts
@@ -4,7 +4,6 @@ import {
   hasGrantedAccountModuleAccess,
   requestHasGrantedAccountModuleAccess,
 } from "../../access-control/context/account-module-access.context";
-import { upload } from "../../../middlewares/upload";
 import { createSecureUpload } from "../../../shared/uploads/secure-upload";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { HttpError } from "../../../utils/httpError";
@@ -165,6 +164,7 @@ const requireAnyOfCapability = (capabilities: readonly OfCapability[]): RequestH
 
 const router = Router();
 const machineDocumentUpload = createSecureUpload("machine-document", { maxFiles: 1 });
+const machineImageUpload = createSecureUpload("image", { maxFiles: 1 });
 
 router.use(authenticateToken);
 
@@ -192,10 +192,10 @@ router.post("/machines/:id/documents", requireMachineCapability("documents"), cr
 router.get("/machines/:id/documents/:documentId/download", requireMachineCapability("read"), downloadMachineDocument);
 router.delete("/machines/:id/documents/:documentId", requireMachineCapability("documents"), removeMachineDocument);
 router.get("/machines/:id", requireMachineCapability("read"), getMachine);
-router.post("/machines/onboarding", requireMachineCapability("create"), upload.single("image"), createMachineOnboarding);
-router.post("/machines", requireMachineCapability("create"), upload.single("image"), createMachine);
-router.patch("/machines/:id/onboarding", requireMachineCapability("update"), upload.single("image"), updateMachineOnboarding);
-router.patch("/machines/:id", requireMachineCapability("update"), upload.single("image"), updateMachine);
+router.post("/machines/onboarding", requireMachineCapability("create"), machineImageUpload.single("image"), createMachineOnboarding);
+router.post("/machines", requireMachineCapability("create"), machineImageUpload.single("image"), createMachine);
+router.patch("/machines/:id/onboarding", requireMachineCapability("update"), machineImageUpload.single("image"), updateMachineOnboarding);
+router.patch("/machines/:id", requireMachineCapability("update"), machineImageUpload.single("image"), updateMachine);
 router.delete("/machines/:id", requireMachineCapability("archive"), archiveMachine);
 
 // Postes

--- a/src/module/production/routes/production.routes.ts
+++ b/src/module/production/routes/production.routes.ts
@@ -1,12 +1,11 @@
 import { Router, type RequestHandler } from "express";
-import multer from "multer";
 
 import {
   hasGrantedAccountModuleAccess,
   requestHasGrantedAccountModuleAccess,
 } from "../../access-control/context/account-module-access.context";
 import { upload } from "../../../middlewares/upload";
-import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
+import { createSecureUpload } from "../../../shared/uploads/secure-upload";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { HttpError } from "../../../utils/httpError";
 import { roleHasMachineCapability, type MachineCapability } from "../domain/machine-rbac";
@@ -165,10 +164,7 @@ const requireAnyOfCapability = (capabilities: readonly OfCapability[]): RequestH
 };
 
 const router = Router();
-const machineDocumentUpload = multer({
-  dest: ensureDocumentStoragePath("machines"),
-  limits: { fileSize: 50 * 1024 * 1024, files: 1 },
-});
+const machineDocumentUpload = createSecureUpload("machine-document", { maxFiles: 1 });
 
 router.use(authenticateToken);
 

--- a/src/module/production/services/production.service.ts
+++ b/src/module/production/services/production.service.ts
@@ -28,14 +28,14 @@ export const svcGetMachine = (id: string) => repo.repoGetMachine(id);
 
 export const svcCreateMachine = (params: {
   body: CreateMachineBodyDTO;
-  image_path: string | null;
+  image_file: Express.Multer.File | null;
   idempotency_key?: string | null;
   audit: repo.AuditContext;
 }) => repo.repoCreateMachine(params);
 
 export const svcCreateMachineOnboarding = (params: {
   body: CreateMachineOnboardingBodyDTO;
-  image_path: string | null;
+  image_file: Express.Multer.File | null;
   idempotency_key?: string | null;
   audit: repo.AuditContext;
 }) => repo.repoCreateMachineOnboarding(params);
@@ -43,14 +43,14 @@ export const svcCreateMachineOnboarding = (params: {
 export const svcUpdateMachine = (params: {
   id: string;
   patch: UpdateMachineBodyDTO;
-  image_path?: string | null;
+  image_file?: Express.Multer.File | null;
   audit: repo.AuditContext;
 }) => repo.repoUpdateMachine(params);
 
 export const svcUpdateMachineOnboarding = (params: {
   id: string;
   body: UpdateMachineOnboardingBodyDTO;
-  image_path?: string | null;
+  image_file?: Express.Multer.File | null;
   audit: repo.AuditContext;
 }) => repo.repoUpdateMachineOnboarding(params);
 

--- a/src/module/project-office/controllers/project-office-registers.controller.ts
+++ b/src/module/project-office/controllers/project-office-registers.controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import { asyncHandler } from "../../../utils/asyncHandler";
+import { buildContentDisposition, setSecureDownloadHeaders } from "../../../shared/uploads/secure-download";
 import * as reg from "../services/project-office-registers.service";
 import * as status from "../services/project-office-status.service";
 import {
@@ -139,20 +140,16 @@ export const getProjectEvidenceFileContent = asyncHandler(async (req: Request, r
   const { projectId, id } = projectEvidenceFileContentParamsSchema.parse(req.params);
   const { disposition } = evidenceFileContentQuerySchema.parse(req.query);
   const file = await reg.downloadProjectEvidenceFile(requireUser(req), projectId, id);
-  const safeName = file.original_name.replace(/["\\\r\n]/g, "_");
-  res.setHeader("Content-Type", file.mime_type);
   res.setHeader("Content-Length", String(file.buffer.byteLength));
-  res.setHeader("Content-Disposition", `${disposition}; filename="${safeName}"`);
+  setSecureDownloadHeaders(res, { filename: file.original_name, mimeType: file.mime_type, download: disposition === "attachment" });
   res.send(file.buffer);
 });
 
 export const getEvidenceFileDownload = asyncHandler(async (req: Request, res: Response) => {
   const { id } = uuidParamsSchema.parse(req.params);
   const file = await reg.downloadEvidenceFile(requireUser(req), id);
-  const safeName = file.original_name.replace(/["\\\r\n]/g, "_");
-  res.setHeader("Content-Type", file.mime_type);
   res.setHeader("Content-Length", String(file.size_bytes));
-  res.setHeader("Content-Disposition", `attachment; filename="${safeName}"`);
+  setSecureDownloadHeaders(res, { filename: file.original_name, mimeType: file.mime_type, download: true });
   res.send(file.buffer);
 });
 
@@ -177,7 +174,7 @@ export const getStatusReportMarkdown = asyncHandler(async (req: Request, res: Re
   const report = await status.buildStatusReport(requireUser(req), id);
   const md = status.statusReportToMarkdown(report);
   res.setHeader("Content-Type", "text/markdown; charset=utf-8");
-  res.setHeader("Content-Disposition", `attachment; filename="statut-${report.project.code.toLowerCase()}.md"`);
+  res.setHeader("Content-Disposition", buildContentDisposition(`statut-${report.project.code.toLowerCase()}.md`, true));
   res.send(md);
 });
 
@@ -186,6 +183,6 @@ export const getStatusReportPdf = asyncHandler(async (req: Request, res: Respons
   const report = await status.buildStatusReport(requireUser(req), id);
   const pdf = await status.statusReportToPdf(report);
   res.setHeader("Content-Type", "application/pdf");
-  res.setHeader("Content-Disposition", `attachment; filename="statut-${report.project.code.toLowerCase()}.pdf"`);
+  res.setHeader("Content-Disposition", buildContentDisposition(`statut-${report.project.code.toLowerCase()}.pdf`, true));
   res.send(pdf);
 });

--- a/src/module/project-office/controllers/project-office-report.controller.ts
+++ b/src/module/project-office/controllers/project-office-report.controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import { asyncHandler } from "../../../utils/asyncHandler";
+import { buildContentDisposition } from "../../../shared/uploads/secure-download";
 import * as svc from "../services/project-office-report.service";
 import {
   createAssetSchema,
@@ -79,7 +80,7 @@ export const getReportDocx = asyncHandler(async (req: Request, res: Response) =>
   const { id } = uuidParamsSchema.parse(req.params);
   const { filename, buffer } = await svc.exportReportDocx(requireUser(req), id, {}, buildAuditContext(req));
   res.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
-  res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+  res.setHeader("Content-Disposition", buildContentDisposition(filename, true));
   res.send(buffer);
 });
 
@@ -87,7 +88,7 @@ export const getSectionDocx = asyncHandler(async (req: Request, res: Response) =
   const { id, sectionId } = entryParamsSchema.parse(req.params);
   const { filename, buffer } = await svc.exportReportDocx(requireUser(req), id, { sectionId }, buildAuditContext(req));
   res.setHeader("Content-Type", "application/vnd.openxmlformats-officedocument.wordprocessingml.document");
-  res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+  res.setHeader("Content-Disposition", buildContentDisposition(filename, true));
   res.send(buffer);
 });
 
@@ -95,7 +96,7 @@ export const getReportMarkdown = asyncHandler(async (req: Request, res: Response
   const { id } = uuidParamsSchema.parse(req.params);
   const { filename, markdown } = await svc.exportReportMarkdown(requireUser(req), id, buildAuditContext(req));
   res.setHeader("Content-Type", "text/markdown; charset=utf-8");
-  res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+  res.setHeader("Content-Disposition", buildContentDisposition(filename, true));
   res.send(markdown);
 });
 
@@ -107,7 +108,7 @@ export const getExportFile = asyncHandler(async (req: Request, res: Response) =>
     : export_type === "PDF" ? "application/pdf"
     : "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
   res.setHeader("Content-Type", mime);
-  res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+  res.setHeader("Content-Disposition", buildContentDisposition(filename, true));
   res.send(buffer);
 });
 

--- a/src/module/project-office/repository/project-office.repository.ts
+++ b/src/module/project-office/repository/project-office.repository.ts
@@ -55,11 +55,17 @@ export class PoRollbackUncertainError extends HttpError {
 
 export async function withTransaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
   let client!: PoolClient;
+  let released = false;
+  const release = (destroy = false) => {
+    if (!client || released) return;
+    released = true;
+    client.release(destroy);
+  };
   try {
     client = await pool.connect();
     await client.query("BEGIN");
   } catch (err) {
-    client?.release();
+    release(true);
     throw err;
   }
   try {
@@ -70,6 +76,7 @@ export async function withTransaction<T>(fn: (client: PoolClient) => Promise<T>)
       try {
         await client.query("ROLLBACK");
       } catch {
+        release(true);
         throw new PoRollbackUncertainError(err);
       }
       throw err;
@@ -78,11 +85,12 @@ export async function withTransaction<T>(fn: (client: PoolClient) => Promise<T>)
     try {
       await client.query("COMMIT");
     } catch (err) {
+      release(true);
       throw new PoCommitUncertainError(result, err);
     }
     return result;
   } finally {
-    client.release();
+    release();
   }
 }
 

--- a/src/module/project-office/repository/project-office.repository.ts
+++ b/src/module/project-office/repository/project-office.repository.ts
@@ -3,6 +3,7 @@ import pool from "../../../config/database";
 import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
+import { HttpError } from "../../../utils/httpError";
 import type {
   ActivityRow,
   MemberRow,
@@ -32,20 +33,54 @@ export function isPgUniqueViolation(err: unknown): boolean {
   return (err as { code?: unknown } | null)?.code === "23505";
 }
 
+export class PoCommitUncertainError<T> extends HttpError {
+  readonly transactionResult: T;
+  readonly originalError: unknown;
+
+  constructor(transactionResult: T, originalError: unknown) {
+    super(503, "PO_COMMIT_UNCERTAIN", "Le résultat du COMMIT doit être rapproché avant toute compensation de fichier.");
+    this.transactionResult = transactionResult;
+    this.originalError = originalError;
+  }
+}
+
+export class PoRollbackUncertainError extends HttpError {
+  readonly originalError: unknown;
+
+  constructor(originalError: unknown) {
+    super(503, "PO_ROLLBACK_UNCERTAIN", "Le rollback n’a pas pu être confirmé ; le fichier est préservé pour rapprochement.");
+    this.originalError = originalError;
+  }
+}
+
 export async function withTransaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
-  const client = await pool.connect();
+  let client!: PoolClient;
   try {
+    client = await pool.connect();
     await client.query("BEGIN");
-    const result = await fn(client);
-    await client.query("COMMIT");
-    return result;
   } catch (err) {
-    try {
-      await client.query("ROLLBACK");
-    } catch {
-      // ignore
-    }
+    client?.release();
     throw err;
+  }
+  try {
+    let result: T;
+    try {
+      result = await fn(client);
+    } catch (err) {
+      try {
+        await client.query("ROLLBACK");
+      } catch {
+        throw new PoRollbackUncertainError(err);
+      }
+      throw err;
+    }
+
+    try {
+      await client.query("COMMIT");
+    } catch (err) {
+      throw new PoCommitUncertainError(result, err);
+    }
+    return result;
   } finally {
     client.release();
   }

--- a/src/module/project-office/routes/project-office.routes.ts
+++ b/src/module/project-office/routes/project-office.routes.ts
@@ -1,5 +1,5 @@
 import { Router } from "express";
-import multer from "multer";
+import { createSecureUpload } from "../../../shared/uploads/secure-upload";
 import { requireProjectOfficeAccess } from "../middlewares/require-project-office-access";
 import * as base from "../controllers/project-office.controller";
 import * as projects from "../controllers/project-office-projects.controller";
@@ -61,10 +61,7 @@ router.post("/projects/:id/actions", registers.postAction);
 router.patch("/actions/:id", registers.patchAction);
 router.get("/projects/:id/evidence", registers.getEvidence);
 router.post("/projects/:id/evidence", registers.postEvidence);
-const evidenceFileUpload = multer({
-  storage: multer.memoryStorage(),
-  limits: { fileSize: 25 * 1024 * 1024, files: 1, fields: 12, fieldSize: 64 * 1024 },
-});
+const evidenceFileUpload = createSecureUpload("project-evidence-deferred", { storage: "memory" });
 router.post("/projects/:id/evidence/files", evidenceFileUpload.single("file"), registers.postEvidenceFile);
 router.get("/projects/:id/evidence/files", registers.getEvidenceFiles);
 router.get("/projects/:projectId/evidence-files/:id/content", registers.getProjectEvidenceFileContent);
@@ -78,10 +75,7 @@ router.get("/projects/:id/export.md", registers.getStatusReportMarkdown);
 router.get("/projects/:id/export.pdf", registers.getStatusReportPdf);
 
 // Rapport de projet Bac+5
-const assetUpload = multer({
-  storage: multer.memoryStorage(),
-  limits: { fileSize: 5 * 1024 * 1024, files: 1, fields: 5, fieldSize: 64 * 1024 },
-});
+const assetUpload = createSecureUpload("project-asset-image", { storage: "memory" });
 router.get("/report-templates", report.getTemplates);
 router.get("/projects/:id/reports", report.getReports);
 router.post("/projects/:id/reports", report.postReport);

--- a/src/module/project-office/services/project-office-registers.service.ts
+++ b/src/module/project-office/services/project-office-registers.service.ts
@@ -9,10 +9,13 @@ import {
   requirePersistentDocumentsRoot,
 } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
+import logger from "../../../utils/logger";
 import {
   insertAuditLog,
   insertProjectActivity,
   isPgUniqueViolation,
+  PoCommitUncertainError,
+  PoRollbackUncertainError,
   withTransaction,
   type AuditContext,
 } from "../repository/project-office.repository";
@@ -565,7 +568,36 @@ export async function uploadEvidenceFile(
       return { evidence, file: evidenceFile };
     });
   } catch (err) {
-    if (written) await fs.unlink(destination).catch(() => undefined);
+    if (err instanceof PoCommitUncertainError) {
+      const result = err.transactionResult as {
+        evidence: Awaited<ReturnType<typeof repoCreateEvidence>>;
+        file: EvidenceFileRow;
+      };
+      try {
+        const persisted = await repoGetEvidenceFileById(result.file.id);
+        if (persisted && persisted.sha256 === sha256 && persisted.storage_key === storageKey) {
+          return result;
+        }
+        if (!persisted) {
+          if (written) await fs.unlink(destination).catch(() => undefined);
+          throw err.originalError;
+        }
+        logger.error("[PO_UPLOAD_COMMIT_UNCERTAIN] metadata mismatch; durable file preserved", JSON.stringify({
+          file_id: result.file.id,
+        }));
+        throw err;
+      } catch (reconcileError) {
+        if (reconcileError === err.originalError || reconcileError === err) throw reconcileError;
+        logger.error("[PO_UPLOAD_COMMIT_UNCERTAIN] reconciliation failed; durable file preserved", JSON.stringify({
+          file_id: result.file.id,
+        }));
+        throw err;
+      }
+    }
+    if (written && !(err instanceof PoRollbackUncertainError)) {
+      // withTransaction only yields the original error after a confirmed ROLLBACK.
+      await fs.unlink(destination).catch(() => undefined);
+    }
     if (isPgUniqueViolation(err)) {
       throw new HttpError(409, "PO_EVIDENCE_FILE_DUPLICATE", "Ce fichier est déjà enregistré dans ce projet.");
     }

--- a/src/module/project-office/services/project-office-registers.service.ts
+++ b/src/module/project-office/services/project-office-registers.service.ts
@@ -576,7 +576,12 @@ export async function uploadEvidenceFile(
       try {
         const persisted = await repoGetEvidenceFileById(result.file.id);
         if (persisted && persisted.sha256 === sha256 && persisted.storage_key === storageKey) {
-          return result;
+          const durableFilePresent = await fs.stat(destination).then((stat) => stat.isFile()).catch(() => false);
+          if (durableFilePresent) return result;
+          logger.error("[PO_UPLOAD_COMMIT_UNCERTAIN] metadata committed but durable file missing", JSON.stringify({
+            file_id: result.file.id,
+          }));
+          throw err;
         }
         if (!persisted) {
           if (written) await fs.unlink(destination).catch(() => undefined);

--- a/src/module/qualite/controllers/qualite.controller.ts
+++ b/src/module/qualite/controllers/qualite.controller.ts
@@ -1,11 +1,11 @@
 import type { Request, RequestHandler } from "express";
-import fs from "node:fs/promises";
 
 import { asyncHandler } from "../../../utils/asyncHandler";
-import { isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage";
+import { resolveCerpStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 import { emitEntityChanged } from "../../../shared/realtime/realtime.service";
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
 
 import type { AuditContext } from "../repository/qualite.repository";
 import {
@@ -322,19 +322,15 @@ async function downloadDocHandler(req: Request, res: Parameters<RequestHandler>[
 
   const baseDir = svcQualityDocumentBaseDir();
   const absPath = resolveCerpStoragePath(doc.storage_path, baseDir);
-  if (!isPathInsideDirectory(baseDir, absPath)) {
-    throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path");
-  }
-  await fs.access(absPath);
-
-  res.setHeader("Content-Type", doc.mime_type);
   const rawDownload = (req.query as { download?: unknown } | undefined)?.download;
   const download = rawDownload === true || rawDownload === "true" || rawDownload === "1" || rawDownload === 1;
-  res.setHeader(
-    "Content-Disposition",
-    `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(doc.original_name)}"`
-  );
-  res.sendFile(absPath);
+  await sendSecureStoredFile(res, {
+    filePath: absPath,
+    allowedRoots: [baseDir],
+    filename: doc.original_name,
+    mimeType: doc.mime_type,
+    download,
+  });
 }
 
 export const listControlDocuments = asyncHandler(async (req, res) => {

--- a/src/module/qualite/repository/qualite.repository.ts
+++ b/src/module/qualite/repository/qualite.repository.ts
@@ -8,6 +8,7 @@ import pool from "../../../config/database";
 import { generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
 import { canonicalizeStockUnitCode } from "../../../shared/stock-unit";
 import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
+import { classifyUploadReconciliation, withUploadTransaction } from "../../../shared/uploads/upload-transaction";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -1426,15 +1427,17 @@ export async function repoAttachDocuments(params: {
 }): Promise<QualityDocument[]> {
   const { entity_type, entity_id, document_type, documents, audit } = params;
 
-  const client = await pool.connect();
   const docsDirRel = ensureDocumentStoragePath("qualite");
   const docsDirAbs = path.resolve(docsDirRel);
+  const client = await pool.connect();
+  const expected = new Map<string, { key: string; absolutePath: string }>();
 
-  try {
-    await client.query("BEGIN");
-
+  return withUploadTransaction({
+    client,
+    files: documents,
+    context: "qualite.attach-documents",
+    work: async () => {
     if (!documents.length) {
-      await client.query("COMMIT");
       return [];
     }
 
@@ -1530,6 +1533,10 @@ export async function repoAttachDocuments(params: {
 
       const row = ins.rows[0];
       if (!row) throw new Error("Failed to insert quality document");
+      expected.set(row.id, {
+        key: `${row.id}|${row.sha256 ?? ""}|${row.storage_path}`,
+        absolutePath: absPath,
+      });
       inserted.push({
         id: row.id,
         entity_type: row.entity_type,
@@ -1569,14 +1576,28 @@ export async function repoAttachDocuments(params: {
       details: { entity_type, entity_id, document_type, count: inserted.length },
     });
 
-    await client.query("COMMIT");
     return inserted;
-  } catch (err) {
-    await client.query("ROLLBACK");
-    throw err;
-  } finally {
-    client.release();
-  }
+    },
+    reconcile: async () => {
+      const ids = [...expected.keys()];
+      if (ids.length === 0) return "committed";
+      const { rows } = await pool.query<{ id: string; sha256: string | null; storage_path: string }>(
+        `SELECT id::text AS id, sha256, storage_path
+         FROM public.quality_documents
+         WHERE id = ANY($1::uuid[])`,
+        [ids]
+      );
+      const status = classifyUploadReconciliation(
+        [...expected.values()].map((entry) => entry.key),
+        rows.map((row) => `${row.id}|${row.sha256 ?? ""}|${row.storage_path}`)
+      );
+      if (status !== "committed") return status;
+      const filesPresent = await Promise.all(
+        [...expected.values()].map((entry) => fs.stat(entry.absolutePath).then((stat) => stat.isFile()).catch(() => false))
+      );
+      return filesPresent.every(Boolean) ? "committed" : "uncertain";
+    },
+  });
 }
 
 export async function repoRemoveDocument(params: {

--- a/src/module/qualite/repository/qualite.repository.ts
+++ b/src/module/qualite/repository/qualite.repository.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import pool from "../../../config/database";
 import { generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service";
 import { canonicalizeStockUnitCode } from "../../../shared/stock-unit";
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -1466,6 +1467,7 @@ export async function repoAttachDocuments(params: {
         await fs.copyFile(tempPath, absPath);
         await fs.unlink(tempPath);
       }
+      registerUploadDestination(doc, absPath);
 
       const hash = await sha256File(absPath);
 

--- a/src/module/qualite/routes/qualite.routes.ts
+++ b/src/module/qualite/routes/qualite.routes.ts
@@ -1,12 +1,11 @@
 import { Router, type RequestHandler } from "express";
-import multer from "multer";
 
 import {
   hasGrantedAccountModuleAccess,
   requestHasGrantedAccountModuleAccess,
 } from "../../access-control/context/account-module-access.context";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
-import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
+import { createSecureUpload } from "../../../shared/uploads/secure-upload";
 import { HttpError } from "../../../utils/httpError";
 
 import {
@@ -103,14 +102,7 @@ router.post("/actions", createAction);
 router.patch("/actions/:id", patchAction);
 
 // Documents (multer)
-const docsBaseDir = ensureDocumentStoragePath("qualite");
-
-const upload = multer({
-  dest: docsBaseDir,
-  limits: {
-    fileSize: 25 * 1024 * 1024,
-  },
-});
+const upload = createSecureUpload("quality-document");
 
 router.get("/controls/:id/documents", listControlDocuments);
 router.post("/controls/:id/documents", upload.array("documents[]"), attachControlDocuments);

--- a/src/module/receptions/controllers/receptions.controller.ts
+++ b/src/module/receptions/controllers/receptions.controller.ts
@@ -1,9 +1,9 @@
 import type { Request, RequestHandler, Response } from "express"
-import fs from "node:fs/promises"
 
-import { getDocumentStoragePath, isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage"
+import { getDocumentStoragePath, resolveCerpStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { emitEntityChanged } from "../../../shared/realtime/realtime.service"
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download"
 import type { AuditContext } from "../repository/receptions.repository"
 import {
   addMeasurementSchema,
@@ -118,20 +118,15 @@ async function sendDocumentFile(
 ) {
   const baseDir = getDocumentStoragePath("receptions")
   const absPath = resolveCerpStoragePath(doc.storage_path, baseDir)
-  if (!isPathInsideDirectory(baseDir, absPath)) {
-    throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path")
-  }
-
-  await fs.access(absPath)
-  res.setHeader("Content-Type", doc.mime_type)
-
   const rawDownload = (req.query as { download?: unknown } | undefined)?.download
   const download = rawDownload === true || rawDownload === "true" || rawDownload === "1" || rawDownload === 1
-  res.setHeader(
-    "Content-Disposition",
-    `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(doc.original_name)}"`
-  )
-  res.sendFile(absPath)
+  await sendSecureStoredFile(res, {
+    filePath: absPath,
+    allowedRoots: [baseDir],
+    filename: doc.original_name,
+    mimeType: doc.mime_type,
+    download,
+  })
 }
 
 export const listReceptions: RequestHandler = async (req, res, next) => {

--- a/src/module/receptions/repository/receptions.repository.ts
+++ b/src/module/receptions/repository/receptions.repository.ts
@@ -6,6 +6,7 @@ import path from "node:path"
 
 import db from "../../../config/database"
 import { generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service"
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
@@ -1106,6 +1107,7 @@ export async function repoAttachDocuments(
         await fs.copyFile(tempPath, absPath)
         await fs.unlink(tempPath)
       }
+      registerUploadDestination(doc, absPath)
 
       movedFiles.push(absPath)
       const hash = await sha256File(absPath)

--- a/src/module/receptions/repository/receptions.repository.ts
+++ b/src/module/receptions/repository/receptions.repository.ts
@@ -7,6 +7,7 @@ import path from "node:path"
 import db from "../../../config/database"
 import { generateTransactionalBusinessCode } from "../../../shared/codes/code-generator.service"
 import { registerUploadDestination } from "../../../shared/uploads/secure-upload"
+import { classifyUploadReconciliation, withUploadTransaction } from "../../../shared/uploads/upload-transaction"
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage"
 import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
@@ -1060,16 +1061,17 @@ export async function repoAttachDocuments(
   documents: UploadedDocument[],
   audit: AuditContext
 ): Promise<ReceptionFournisseurDocument[] | null> {
-  const client = await db.connect()
   const docsDirRel = ensureDocumentStoragePath("receptions")
   const docsDirAbs = path.resolve(docsDirRel)
-  const movedFiles: string[] = []
-  let commitAttempted = false
-  try {
-    await client.query("BEGIN")
+  const client = await db.connect()
+  const expected = new Map<string, { key: string; absolutePath: string }>()
+  return withUploadTransaction({
+    client,
+    files: documents,
+    context: "receptions.documents.attach",
+    work: async () => {
     const exists = await ensureReceptionExists(client, receptionId)
     if (!exists) {
-      await client.query("ROLLBACK")
       return null
     }
 
@@ -1087,7 +1089,6 @@ export async function repoAttachDocuments(
     }
 
     if (!documents.length) {
-      await client.query("COMMIT")
       return []
     }
 
@@ -1110,7 +1111,6 @@ export async function repoAttachDocuments(
       }
       registerUploadDestination(doc, absPath)
 
-      movedFiles.push(absPath)
       const hash = await sha256File(absPath)
 
       const ins = await client.query<DocumentRow>(
@@ -1170,6 +1170,10 @@ export async function repoAttachDocuments(
       )
       const row = ins.rows[0] ?? null
       if (!row) throw new Error("Failed to insert reception document")
+      expected.set(row.id, {
+        key: `${row.id}|${row.sha256 ?? ""}|${row.storage_path}`,
+        absolutePath: absPath,
+      })
       inserted.push(mapDocumentRow(row))
     }
 
@@ -1185,21 +1189,27 @@ export async function repoAttachDocuments(
       },
     })
 
-    commitAttempted = true
-    await client.query("COMMIT")
     return inserted
-  } catch (err) {
-    if (!commitAttempted) {
-      let rollbackConfirmed = false
-      try { await client.query("ROLLBACK"); rollbackConfirmed = true } catch { /* preserve for reconciliation */ }
-      if (rollbackConfirmed) for (const f of movedFiles) await fs.unlink(f).catch(() => undefined)
-    } else {
-      console.error("[RECEPTION_UPLOAD_COMMIT_UNCERTAIN] durable files preserved", { count: movedFiles.length })
-    }
-    throw err
-  } finally {
-    client.release()
-  }
+    },
+    reconcile: async () => {
+      const ids = [...expected.keys()]
+      if (!ids.length) return "committed"
+      const { rows } = await db.query<{ id: string; sha256: string | null; storage_path: string }>(
+        `SELECT id::text AS id, sha256, storage_path
+          FROM public.reception_fournisseur_documents
+          WHERE reception_id = $1::uuid
+            AND id = ANY($2::uuid[])`,
+        [receptionId, ids]
+      )
+      const status = classifyUploadReconciliation(
+        [...expected.values()].map((entry) => entry.key),
+        rows.map((row) => `${row.id}|${row.sha256 ?? ""}|${row.storage_path}`)
+      )
+      if (status !== "committed") return status
+      const present = await Promise.all([...expected.values()].map((entry) => fs.stat(entry.absolutePath).then((stat) => stat.isFile()).catch(() => false)))
+      return present.every(Boolean) ? "committed" : "uncertain"
+    },
+  })
 }
 
 export async function repoRemoveDocument(receptionId: string, documentId: string, audit: AuditContext): Promise<boolean | null> {

--- a/src/module/receptions/repository/receptions.repository.ts
+++ b/src/module/receptions/repository/receptions.repository.ts
@@ -1064,6 +1064,7 @@ export async function repoAttachDocuments(
   const docsDirRel = ensureDocumentStoragePath("receptions")
   const docsDirAbs = path.resolve(docsDirRel)
   const movedFiles: string[] = []
+  let commitAttempted = false
   try {
     await client.query("BEGIN")
     const exists = await ensureReceptionExists(client, receptionId)
@@ -1184,11 +1185,17 @@ export async function repoAttachDocuments(
       },
     })
 
+    commitAttempted = true
     await client.query("COMMIT")
     return inserted
   } catch (err) {
-    await client.query("ROLLBACK")
-    for (const f of movedFiles) await fs.unlink(f).catch(() => undefined)
+    if (!commitAttempted) {
+      let rollbackConfirmed = false
+      try { await client.query("ROLLBACK"); rollbackConfirmed = true } catch { /* preserve for reconciliation */ }
+      if (rollbackConfirmed) for (const f of movedFiles) await fs.unlink(f).catch(() => undefined)
+    } else {
+      console.error("[RECEPTION_UPLOAD_COMMIT_UNCERTAIN] durable files preserved", { count: movedFiles.length })
+    }
     throw err
   } finally {
     client.release()

--- a/src/module/receptions/routes/receptions.routes.ts
+++ b/src/module/receptions/routes/receptions.routes.ts
@@ -1,8 +1,7 @@
 import { Router } from "express"
-import multer from "multer"
 
 import { authenticateToken } from "../../auth/middlewares/auth.middleware"
-import { ensureTmpStoragePath } from "../../../utils/cerpStorage"
+import { createSecureUpload } from "../../../shared/uploads/secure-upload"
 import {
   addIncomingMeasurement,
   attachReceptionDocuments,
@@ -20,12 +19,7 @@ import {
   startIncomingInspection,
 } from "../controllers/receptions.controller"
 
-const tmpBaseDir = ensureTmpStoragePath("receptions")
-
-const upload = multer({
-  dest: tmpBaseDir,
-  limits: { fileSize: 25 * 1024 * 1024, files: 10 },
-})
+const upload = createSecureUpload("quality-document")
 
 const router = Router()
 router.use(authenticateToken)

--- a/src/module/stock/controllers/stock.controller.ts
+++ b/src/module/stock/controllers/stock.controller.ts
@@ -1,10 +1,10 @@
 import type { Request, RequestHandler, Response } from "express";
 import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
-import fs from "node:fs/promises";
 
 import { previewArticleCode } from "../../../shared/codes/code-generator.service";
-import { getDocumentStoragePath, isPathInsideDirectory, resolveCerpStoragePath } from "../../../utils/cerpStorage";
+import { getDocumentStoragePath, resolveCerpStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
+import { sendSecureStoredFile } from "../../../shared/uploads/secure-download";
 import {
   createInventorySessionSchema,
   createArticleSchema,
@@ -337,20 +337,15 @@ async function sendDocumentFile(
 ) {
   const baseDir = getDocumentStoragePath("stock");
   const absPath = resolveCerpStoragePath(doc.storage_path, baseDir);
-  if (!isPathInsideDirectory(baseDir, absPath)) {
-    throw new HttpError(400, "INVALID_STORAGE_PATH", "Invalid document storage path");
-  }
-
-  await fs.access(absPath);
-  res.setHeader("Content-Type", doc.mime_type);
-
   const rawDownload = (req.query as { download?: unknown } | undefined)?.download;
   const download = rawDownload === true || rawDownload === "true" || rawDownload === "1" || rawDownload === 1;
-  res.setHeader(
-    "Content-Disposition",
-    `${download ? "attachment" : "inline"}; filename="${encodeURIComponent(doc.original_name)}"`
-  );
-  res.sendFile(absPath);
+  await sendSecureStoredFile(res, {
+    filePath: absPath,
+    allowedRoots: [baseDir],
+    filename: doc.original_name,
+    mimeType: doc.mime_type,
+    download,
+  });
 }
 
 export const listStockArticles: RequestHandler = async (req, res, next) => {

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -23,6 +23,7 @@ import {
 } from "../../../shared/codes/material-article-code";
 import { canonicalizeStockUnitCode } from "../../../shared/stock-unit";
 import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
+import { classifyUploadReconciliation, withUploadTransaction } from "../../../shared/uploads/upload-transaction";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -7670,21 +7671,29 @@ export async function repoAttachArticleDocuments(
   metadata: ArticleDocumentMetadataDTO,
   audit: AuditContext
 ): Promise<StockDocument[] | null> {
-  const client = await db.connect();
   const docsDirRel = ensureDocumentStoragePath("stock", "articles");
-  try {
-    await client.query("BEGIN");
+  const client = await db.connect();
+  let expected: Array<{ id: string; key: string; absolutePath: string }> = [];
+  const result = await withUploadTransaction({
+    client,
+    files: documents,
+    context: "stock.articles.documents.attach",
+    work: async () => {
 
     const exists = await client.query<{ ok: number }>(
       `SELECT 1::int AS ok FROM public.articles WHERE id = $1::uuid FOR UPDATE`,
       [articleId]
     );
     if (!exists.rows[0]?.ok) {
-      await client.query("ROLLBACK");
       return null;
     }
 
     const inserted = await insertStockDocuments(client, documents, audit, docsDirRel);
+    expected = inserted.map((document) => ({
+      id: document.id,
+      key: `${articleId}|${document.id}|${document.sha256 ?? ""}|${document.storage_path}`,
+      absolutePath: path.resolve(document.storage_path),
+    }));
     for (const d of inserted) {
       await client.query(
         `
@@ -7715,14 +7724,29 @@ export async function repoAttachArticleDocuments(
       },
     });
 
-    await client.query("COMMIT");
-    return repoListArticleDocuments(articleId);
-  } catch (err) {
-    await client.query("ROLLBACK");
-    throw err;
-  } finally {
-    client.release();
-  }
+    return inserted;
+    },
+    reconcile: async () => {
+      if (expected.length === 0) return "committed";
+      const { rows } = await db.query<{ article_id: string | null; id: string; sha256: string | null; storage_path: string }>(
+        `SELECT ad.article_id::text AS article_id, sd.id::text AS id, sd.sha256, sd.storage_path
+           FROM public.stock_documents sd
+           LEFT JOIN public.article_documents ad
+             ON ad.document_id = sd.id AND ad.article_id = $1::uuid
+          WHERE sd.id = ANY($2::uuid[])`,
+        [articleId, expected.map((entry) => entry.id)]
+      );
+      const status = classifyUploadReconciliation(
+        expected.map((entry) => entry.key),
+        rows.map((row) => `${row.article_id ?? ""}|${row.id}|${row.sha256 ?? ""}|${row.storage_path}`)
+      );
+      if (status !== "committed") return status;
+      const present = await Promise.all(expected.map((entry) => fs.stat(entry.absolutePath).then((stat) => stat.isFile()).catch(() => false)));
+      return present.every(Boolean) ? "committed" : "uncertain";
+    },
+  });
+  if (result === null) return null;
+  return repoListArticleDocuments(articleId);
 }
 
 export async function repoRemoveArticleDocument(
@@ -7841,21 +7865,29 @@ export async function repoAttachMovementDocuments(
   documents: UploadedDocument[],
   audit: AuditContext
 ): Promise<StockDocument[] | null> {
-  const client = await db.connect();
   const docsDirRel = ensureDocumentStoragePath("stock", "movements");
-  try {
-    await client.query("BEGIN");
+  const client = await db.connect();
+  let expected: Array<{ id: string; key: string; absolutePath: string }> = [];
+  const result = await withUploadTransaction({
+    client,
+    files: documents,
+    context: "stock.movements.documents.attach",
+    work: async () => {
 
     const exists = await client.query<{ ok: number }>(
       `SELECT 1::int AS ok FROM public.stock_movements WHERE id = $1::uuid FOR UPDATE`,
       [movementId]
     );
     if (!exists.rows[0]?.ok) {
-      await client.query("ROLLBACK");
       return null;
     }
 
     const inserted = await insertStockDocuments(client, documents, audit, docsDirRel);
+    expected = inserted.map((document) => ({
+      id: document.id,
+      key: `${movementId}|${document.id}|${document.sha256 ?? ""}|${document.storage_path}`,
+      absolutePath: path.resolve(document.storage_path),
+    }));
     for (const d of inserted) {
       await client.query(
         `
@@ -7882,14 +7914,29 @@ export async function repoAttachMovementDocuments(
       },
     });
 
-    await client.query("COMMIT");
-    return repoListMovementDocuments(movementId);
-  } catch (err) {
-    await client.query("ROLLBACK");
-    throw err;
-  } finally {
-    client.release();
-  }
+    return inserted;
+    },
+    reconcile: async () => {
+      if (expected.length === 0) return "committed";
+      const { rows } = await db.query<{ stock_movement_id: string | null; id: string; sha256: string | null; storage_path: string }>(
+        `SELECT md.stock_movement_id::text AS stock_movement_id, sd.id::text AS id, sd.sha256, sd.storage_path
+           FROM public.stock_documents sd
+           LEFT JOIN public.stock_movement_documents md
+             ON md.document_id = sd.id AND md.stock_movement_id = $1::uuid
+          WHERE sd.id = ANY($2::uuid[])`,
+        [movementId, expected.map((entry) => entry.id)]
+      );
+      const status = classifyUploadReconciliation(
+        expected.map((entry) => entry.key),
+        rows.map((row) => `${row.stock_movement_id ?? ""}|${row.id}|${row.sha256 ?? ""}|${row.storage_path}`)
+      );
+      if (status !== "committed") return status;
+      const present = await Promise.all(expected.map((entry) => fs.stat(entry.absolutePath).then((stat) => stat.isFile()).catch(() => false)));
+      return present.every(Boolean) ? "committed" : "uncertain";
+    },
+  });
+  if (result === null) return null;
+  return repoListMovementDocuments(movementId);
 }
 
 export async function repoRemoveMovementDocument(

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -22,6 +22,7 @@ import {
   type MaterialProfileCode,
 } from "../../../shared/codes/material-article-code";
 import { canonicalizeStockUnitCode } from "../../../shared/stock-unit";
+import { registerUploadDestination } from "../../../shared/uploads/secure-upload";
 import { ensureDocumentStoragePath } from "../../../utils/cerpStorage";
 import { HttpError } from "../../../utils/httpError";
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
@@ -7584,6 +7585,7 @@ async function insertStockDocuments(
       await fs.copyFile(tempPath, absPath);
       await fs.unlink(tempPath);
     }
+    registerUploadDestination(doc, absPath);
 
     const hash = await sha256File(absPath);
 

--- a/src/module/stock/routes/stock.routes.ts
+++ b/src/module/stock/routes/stock.routes.ts
@@ -1,9 +1,8 @@
 import { Router, type RequestHandler } from "express";
 import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
-import multer from "multer";
 
 import { authenticateToken, authorizeRole } from "../../auth/middlewares/auth.middleware";
-import { ensureTmpStoragePath } from "../../../utils/cerpStorage";
+import { createSecureUpload } from "../../../shared/uploads/secure-upload";
 import { HttpError } from "../../../utils/httpError";
 import {
   attachStockArticleDocuments,
@@ -99,14 +98,7 @@ import { roleHasStockCapability, type StockCapability } from "../domain/stock-rb
 
 const router = Router();
 
-const tmpBaseDir = ensureTmpStoragePath("stock");
-
-const upload = multer({
-  dest: tmpBaseDir,
-  limits: {
-    fileSize: 25 * 1024 * 1024,
-  },
-});
+const upload = createSecureUpload("business-document");
 
 router.use(authenticateToken);
 

--- a/src/module/temps-deplacements/controllers/temps-deplacements-exports.controller.ts
+++ b/src/module/temps-deplacements/controllers/temps-deplacements-exports.controller.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import { asyncHandler } from "../../../utils/asyncHandler";
+import { buildContentDisposition } from "../../../shared/uploads/secure-download";
 import * as svc from "../services/temps-deplacements-exports.service";
 import { exportBodySchema, uuidParamsSchema } from "../validators/temps-deplacements.validators";
 import { buildAuditContext, requireUser } from "./temps-deplacements.controller";
@@ -19,7 +20,7 @@ export const downloadExport = asyncHandler(async (req: Request, res: Response) =
   const { id } = uuidParamsSchema.parse(req.params);
   const file = await svc.getExportFile(requireUser(req), id);
   res.setHeader("Content-Type", file.contentType);
-  res.setHeader("Content-Disposition", `attachment; filename="${file.filename}"`);
+  res.setHeader("Content-Disposition", buildContentDisposition(file.filename, true));
   res.setHeader("X-Checksum-SHA256", file.checksum);
   res.send(file.buffer);
 });

--- a/src/shared/uploads/secure-download.ts
+++ b/src/shared/uploads/secure-download.ts
@@ -1,0 +1,93 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import type { Response } from "express";
+
+import { isPathInsideDirectory } from "../../utils/cerpStorage";
+import { HttpError } from "../../utils/httpError";
+
+function asciiFilename(value: string): string {
+  const normalized = value
+    .replace(/\\/g, "/")
+    .split("/")
+    .pop()
+    ?.normalize("NFKD")
+    .replace(/[\u0000-\u001f\u007f\u202a-\u202e\u2066-\u2069]/g, "")
+    .replace(/[^a-zA-Z0-9._ -]+/g, "_")
+    .replace(/["\\]/g, "_")
+    .trim();
+  return normalized && normalized !== "." && normalized !== ".." ? normalized.slice(0, 180) : "document";
+}
+
+export function buildContentDisposition(filename: string, download: boolean): string {
+  const fallback = asciiFilename(filename);
+  const unicodeName = filename
+    .replace(/\\/g, "/")
+    .split("/")
+    .pop()
+    ?.replace(/[\u0000-\u001f\u007f\u202a-\u202e\u2066-\u2069]/g, "")
+    .trim() || fallback;
+  const encoded = encodeURIComponent(unicodeName).replace(/[!'()*]/g, (char) => `%${char.charCodeAt(0).toString(16).toUpperCase()}`);
+  return `${download ? "attachment" : "inline"}; filename="${fallback}"; filename*=UTF-8''${encoded}`;
+}
+
+export function setSecureDownloadHeaders(
+  res: Response,
+  options: { filename: string; mimeType?: string | null; download?: boolean }
+): void {
+  res.setHeader("Content-Type", options.mimeType?.trim() || "application/octet-stream");
+  res.setHeader("Content-Disposition", buildContentDisposition(options.filename, options.download === true));
+  res.setHeader("Cache-Control", "private, no-store, max-age=0");
+  res.setHeader("X-Content-Type-Options", "nosniff");
+  res.setHeader("Cross-Origin-Resource-Policy", "same-origin");
+  if (options.download !== true) res.setHeader("Content-Security-Policy", "sandbox");
+}
+
+async function realExistingDirectory(directory: string): Promise<string> {
+  try {
+    return await fs.realpath(path.resolve(directory));
+  } catch {
+    return path.resolve(directory);
+  }
+}
+
+export async function assertSecureDownloadPath(filePath: string, allowedRoots: readonly string[]): Promise<string> {
+  if (!allowedRoots.length) {
+    throw new HttpError(500, "DOWNLOAD_ROOT_MISSING", "Le stockage documentaire n’est pas configuré.");
+  }
+  let realFile: string;
+  try {
+    realFile = await fs.realpath(path.resolve(filePath));
+  } catch {
+    throw new HttpError(404, "DOCUMENT_FILE_NOT_FOUND", "Le fichier demandé est introuvable.");
+  }
+  const roots = await Promise.all(allowedRoots.map(realExistingDirectory));
+  if (!roots.some((root) => isPathInsideDirectory(root, realFile))) {
+    throw new HttpError(400, "INVALID_STORAGE_PATH", "Le chemin de stockage du document est invalide.");
+  }
+  const stat = await fs.stat(realFile);
+  if (!stat.isFile()) {
+    throw new HttpError(404, "DOCUMENT_FILE_NOT_FOUND", "Le fichier demandé est introuvable.");
+  }
+  return realFile;
+}
+
+export async function sendSecureStoredFile(
+  res: Response,
+  options: {
+    filePath: string;
+    allowedRoots: readonly string[];
+    filename: string;
+    mimeType?: string | null;
+    download?: boolean;
+  }
+): Promise<void> {
+  const realFile = await assertSecureDownloadPath(options.filePath, options.allowedRoots);
+  setSecureDownloadHeaders(res, options);
+  await new Promise<void>((resolve, reject) => {
+    res.sendFile(realFile, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}

--- a/src/shared/uploads/secure-download.ts
+++ b/src/shared/uploads/secure-download.ts
@@ -1,4 +1,6 @@
-import fs from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { constants, createReadStream } from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
 import path from "node:path";
 
 import type { Response } from "express";
@@ -51,25 +53,113 @@ async function realExistingDirectory(directory: string): Promise<string> {
   }
 }
 
-export async function assertSecureDownloadPath(filePath: string, allowedRoots: readonly string[]): Promise<string> {
+type SecureDownloadHookPhase = "after-validation" | "after-open";
+type SecureDownloadHook = (
+  phase: SecureDownloadHookPhase,
+  context: Readonly<{ candidatePath: string; realPath: string }>
+) => void | Promise<void>;
+
+let secureDownloadHook: SecureDownloadHook | null = null;
+
+/** Deterministic race injection for tests; never configured by application code. */
+export function setSecureDownloadHookForTests(hook: SecureDownloadHook | null): void {
+  secureDownloadHook = hook;
+}
+
+function notFound(): HttpError {
+  return new HttpError(404, "DOCUMENT_FILE_NOT_FOUND", "Le fichier demandé est introuvable.");
+}
+
+function invalidPath(): HttpError {
+  return new HttpError(400, "INVALID_STORAGE_PATH", "Le chemin de stockage du document est invalide.");
+}
+
+function sameIdentity(
+  expected: Readonly<{ dev: number | bigint; ino: number | bigint; size: number | bigint }>,
+  actual: Readonly<{ dev: number | bigint; ino: number | bigint; size: number | bigint }>
+): boolean {
+  return String(expected.dev) === String(actual.dev)
+    && String(expected.ino) === String(actual.ino)
+    && String(expected.size) === String(actual.size);
+}
+
+type SecureOpenedFile = Readonly<{
+  handle: FileHandle;
+  realPath: string;
+  size: number;
+}>;
+
+async function openSecureDownloadPath(filePath: string, allowedRoots: readonly string[]): Promise<SecureOpenedFile> {
   if (!allowedRoots.length) {
     throw new HttpError(500, "DOWNLOAD_ROOT_MISSING", "Le stockage documentaire n’est pas configuré.");
   }
-  let realFile: string;
+
+  const candidatePath = path.resolve(filePath);
+  let realPath: string;
   try {
-    realFile = await fs.realpath(path.resolve(filePath));
-  } catch {
-    throw new HttpError(404, "DOCUMENT_FILE_NOT_FOUND", "Le fichier demandé est introuvable.");
+    const candidateStat = await fs.lstat(candidatePath);
+    if (candidateStat.isSymbolicLink()) throw invalidPath();
+    if (!candidateStat.isFile()) throw notFound();
+    realPath = await fs.realpath(candidatePath);
+  } catch (error) {
+    if (error instanceof HttpError) throw error;
+    throw notFound();
   }
+
   const roots = await Promise.all(allowedRoots.map(realExistingDirectory));
-  if (!roots.some((root) => isPathInsideDirectory(root, realFile))) {
-    throw new HttpError(400, "INVALID_STORAGE_PATH", "Le chemin de stockage du document est invalide.");
+  if (!roots.some((root) => isPathInsideDirectory(root, realPath))) throw invalidPath();
+
+  let validatedStat;
+  try {
+    validatedStat = await fs.lstat(realPath);
+  } catch {
+    throw notFound();
   }
-  const stat = await fs.stat(realFile);
-  if (!stat.isFile()) {
-    throw new HttpError(404, "DOCUMENT_FILE_NOT_FOUND", "Le fichier demandé est introuvable.");
+  if (validatedStat.isSymbolicLink()) throw invalidPath();
+  if (!validatedStat.isFile()) throw notFound();
+
+  await secureDownloadHook?.("after-validation", { candidatePath, realPath });
+
+  let handle: FileHandle;
+  try {
+    const noFollow = typeof constants.O_NOFOLLOW === "number" ? constants.O_NOFOLLOW : 0;
+    handle = await fs.open(realPath, constants.O_RDONLY | noFollow);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ELOOP") throw invalidPath();
+    throw notFound();
   }
-  return realFile;
+
+  try {
+    const openedStat = await handle.stat();
+    if (!openedStat.isFile() || !sameIdentity(validatedStat, openedStat)) throw invalidPath();
+
+    // Re-resolve the caller's path after opening. Together with the inode check
+    // this detects both leaf replacement and parent-directory substitution.
+    let resolvedAfterOpen: string;
+    try {
+      resolvedAfterOpen = await fs.realpath(candidatePath);
+    } catch {
+      throw invalidPath();
+    }
+    if (resolvedAfterOpen !== realPath) throw invalidPath();
+    if (!roots.some((root) => isPathInsideDirectory(root, resolvedAfterOpen))) throw invalidPath();
+
+    await secureDownloadHook?.("after-open", { candidatePath, realPath });
+
+    const finalStat = await handle.stat();
+    if (!sameIdentity(openedStat, finalStat)) throw invalidPath();
+    return { handle, realPath, size: Number(finalStat.size) };
+  } catch (error) {
+    await handle.close().catch(() => undefined);
+    throw error;
+  }
+}
+
+export async function assertSecureDownloadPath(filePath: string, allowedRoots: readonly string[]): Promise<string> {
+  const opened = await openSecureDownloadPath(filePath, allowedRoots);
+  await opened.handle.close();
+  return opened.realPath;
 }
 
 export async function sendSecureStoredFile(
@@ -80,14 +170,74 @@ export async function sendSecureStoredFile(
     filename: string;
     mimeType?: string | null;
     download?: boolean;
+    expectedSha256?: string;
+    integrityError?: Readonly<{ status: number; code: string; message: string }>;
   }
 ): Promise<void> {
-  const realFile = await assertSecureDownloadPath(options.filePath, options.allowedRoots);
-  setSecureDownloadHeaders(res, options);
-  await new Promise<void>((resolve, reject) => {
-    res.sendFile(realFile, (error) => {
-      if (error) reject(error);
-      else resolve();
+  const opened = await openSecureDownloadPath(options.filePath, options.allowedRoots);
+  let stream: ReturnType<typeof createReadStream> | null = null;
+  try {
+    if (options.expectedSha256) {
+      const hash = createHash("sha256");
+      if (opened.size > 0) {
+        const verifier = createReadStream(opened.realPath, {
+          fd: opened.handle.fd,
+          autoClose: false,
+          start: 0,
+          end: opened.size - 1,
+        });
+        for await (const chunk of verifier) hash.update(chunk as Buffer);
+      }
+      if (hash.digest("hex") !== options.expectedSha256.toLowerCase()) {
+        const failure = options.integrityError ?? {
+          status: 503,
+          code: "DOCUMENT_INTEGRITY_ERROR",
+          message: "L’intégrité du document ne peut pas être confirmée.",
+        };
+        throw new HttpError(failure.status, failure.code, failure.message);
+      }
+    }
+
+    setSecureDownloadHeaders(res, options);
+    res.setHeader("Content-Length", String(opened.size));
+    if (opened.size === 0) {
+      res.end();
+      return;
+    }
+
+    stream = createReadStream(opened.realPath, {
+      fd: opened.handle.fd,
+      autoClose: false,
+      start: 0,
+      end: opened.size - 1,
     });
-  });
+
+    await new Promise<void>((resolve, reject) => {
+      const cleanup = () => {
+        res.off("finish", finish);
+        res.off("close", close);
+        stream?.off("error", fail);
+      };
+      const finish = () => {
+        cleanup();
+        resolve();
+      };
+      const close = () => {
+        stream?.destroy();
+        cleanup();
+        resolve();
+      };
+      const fail = (error: Error) => {
+        cleanup();
+        reject(error);
+      };
+      res.once("finish", finish);
+      res.once("close", close);
+      stream?.once("error", fail);
+      stream?.pipe(res);
+    });
+  } finally {
+    stream?.destroy();
+    await opened.handle.close().catch(() => undefined);
+  }
 }

--- a/src/shared/uploads/secure-upload.ts
+++ b/src/shared/uploads/secure-upload.ts
@@ -52,27 +52,87 @@ export type SecureUpload = Readonly<{
 const SAMPLE_BYTES = 64 * 1024;
 const WINDOWS_UNSAFE = /[:*?"<>|]/;
 const CONTROL_OR_BIDI = /[\u0000-\u001f\u007f\u202a-\u202e\u2066-\u2069]/;
-const uploadDestinations = new Map<string, Set<string>>();
+type UploadDestinationState = "transferred" | "commit-attempted" | "committed" | "rolled-back";
+type UploadDestination = { destination: string; state: UploadDestinationState };
+type UploadFileReference = Readonly<{ path: string }>;
+const uploadDestinations = new Map<string, Map<string, UploadDestination>>();
 
 /**
  * Registers an application-managed destination created from an uploaded file.
- * The secure upload lifecycle removes it when the request aborts or returns an
- * error, which compensates file moves performed before a database transaction
- * commits. Successful responses keep the destination.
+ * Registration transfers ownership out of central staging. A response close
+ * can happen after COMMIT (or after COMMIT was applied but its ACK was lost),
+ * so the response lifecycle never deletes a registered destination.
  */
 export function registerUploadDestination(file: Readonly<{ path: string }>, destination: string): void {
   const source = path.resolve(file.path);
   const resolved = path.resolve(destination);
-  const destinations = uploadDestinations.get(source) ?? new Set<string>();
-  destinations.add(resolved);
+  const destinations = uploadDestinations.get(source) ?? new Map<string, UploadDestination>();
+  destinations.set(resolved, { destination: resolved, state: "transferred" });
   uploadDestinations.set(source, destinations);
 }
 
-function takeRegisteredUploadDestinations(files: readonly Express.Multer.File[]): string[] {
+function updateUploadDestinationState(
+  files: readonly UploadFileReference[],
+  state: UploadDestinationState
+): void {
+  for (const file of files) {
+    const destinations = uploadDestinations.get(path.resolve(file.path));
+    if (!destinations) continue;
+    for (const record of destinations.values()) record.state = state;
+  }
+}
+
+/** Call immediately before issuing COMMIT. From this point deletion is unsafe. */
+export function markUploadCommitAttempted(files: readonly UploadFileReference[]): void {
+  updateUploadDestinationState(files, "commit-attempted");
+}
+
+/** Call after a successful COMMIT or positive reconciliation on a fresh connection. */
+export function markUploadsCommitted(files: readonly UploadFileReference[]): void {
+  updateUploadDestinationState(files, "committed");
+}
+
+/**
+ * Delete transferred destinations only after the caller has proven that the
+ * database transaction rolled back before COMMIT was attempted.
+ */
+async function cleanupOwnedDestinations(
+  files: readonly UploadFileReference[],
+  allowedStates: ReadonlySet<UploadDestinationState>
+): Promise<void> {
+  const removable: string[] = [];
+  for (const file of files) {
+    const destinations = uploadDestinations.get(path.resolve(file.path));
+    if (!destinations) continue;
+    for (const record of destinations.values()) {
+      if (!allowedStates.has(record.state)) {
+        logger.error("[UPLOAD_OWNERSHIP] refused unsafe cleanup", JSON.stringify({ state: record.state }));
+        continue;
+      }
+      record.state = "rolled-back";
+      removable.push(record.destination);
+    }
+  }
+  await cleanupPaths(removable);
+}
+
+export async function cleanupUploadsAfterConfirmedRollback(files: readonly UploadFileReference[]): Promise<void> {
+  await cleanupOwnedDestinations(files, new Set<UploadDestinationState>(["transferred"]));
+}
+
+/** Cleanup after a fresh connection proved that a previously attempted COMMIT was not applied. */
+export async function cleanupUploadsAfterReconciledNoCommit(files: readonly UploadFileReference[]): Promise<void> {
+  await cleanupOwnedDestinations(
+    files,
+    new Set<UploadDestinationState>(["transferred", "commit-attempted"])
+  );
+}
+
+function releaseRegisteredUploadDestinations(files: readonly Express.Multer.File[]): UploadDestination[] {
   return files.flatMap((file) => {
     if (!file.path) return [];
     const source = path.resolve(file.path);
-    const destinations = Array.from(uploadDestinations.get(source) ?? []);
+    const destinations = Array.from(uploadDestinations.get(source)?.values() ?? []);
     uploadDestinations.delete(source);
     return destinations;
   });
@@ -427,15 +487,26 @@ export function createSecureUpload(usage: UploadUsage, options: SecureUploadOpti
       const cleanupAfterResponse = () => {
         if (cleanupStarted) return;
         cleanupStarted = true;
-        const shouldRemovePromoted = res.statusCode >= 400 || !res.writableEnded;
-        const downstreamDestinations = takeRegisteredUploadDestinations(files);
-        void cleanupPaths(
-          shouldRemovePromoted ? [...stagedPaths, ...promotedPaths, ...downstreamDestinations] : stagedPaths
-        ).then(() => {
-          if (shouldRemovePromoted || stagedPaths.length > 0) {
+        const ownership = releaseRegisteredUploadDestinations(files);
+        const uncertain = ownership.filter((record) => record.state === "transferred" || record.state === "commit-attempted");
+        if (uncertain.length > 0 || (promotedPaths.length > 0 && (res.statusCode >= 400 || !res.writableEnded))) {
+          logger.error("[UPLOAD_OWNERSHIP] durable destination preserved for reconciliation", JSON.stringify({
+            state_counts: ownership.reduce<Record<string, number>>((counts, record) => {
+              counts[record.state] = (counts[record.state] ?? 0) + 1;
+              return counts;
+            }, {}),
+            central_promotions: promotedPaths.length,
+            response_status: res.statusCode,
+            response_ended: res.writableEnded,
+          }));
+        }
+        // Response close/abort is never proof of a database rollback. Only
+        // untransferred staging belongs to this lifecycle callback.
+        void cleanupPaths(stagedPaths).then(() => {
+          if (stagedPaths.length > 0) {
             auditUpload(req, usage, "cleaned", {
               staged_count: stagedPaths.length,
-              promoted_count: shouldRemovePromoted ? promotedPaths.length + downstreamDestinations.length : 0,
+              promoted_count: 0,
             });
           }
         });

--- a/src/shared/uploads/secure-upload.ts
+++ b/src/shared/uploads/secure-upload.ts
@@ -52,9 +52,14 @@ export type SecureUpload = Readonly<{
 const SAMPLE_BYTES = 64 * 1024;
 const WINDOWS_UNSAFE = /[:*?"<>|]/;
 const CONTROL_OR_BIDI = /[\u0000-\u001f\u007f\u202a-\u202e\u2066-\u2069]/;
-type UploadDestinationState = "transferred" | "commit-attempted" | "committed" | "rolled-back";
+export type UploadDestinationState =
+  | "transferred"
+  | "commit-attempted"
+  | "committed"
+  | "rolled-back"
+  | "rollback-uncertain";
 type UploadDestination = { destination: string; state: UploadDestinationState };
-type UploadFileReference = Readonly<{ path: string }>;
+export type UploadFileReference = Readonly<{ path: string }>;
 const uploadDestinations = new Map<string, Map<string, UploadDestination>>();
 
 /**
@@ -90,6 +95,11 @@ export function markUploadCommitAttempted(files: readonly UploadFileReference[])
 /** Call after a successful COMMIT or positive reconciliation on a fresh connection. */
 export function markUploadsCommitted(files: readonly UploadFileReference[]): void {
   updateUploadDestinationState(files, "committed");
+}
+
+/** Mark ownership as indeterminate when a pre-COMMIT rollback could not be confirmed. */
+export function markUploadRollbackUncertain(files: readonly UploadFileReference[]): void {
+  updateUploadDestinationState(files, "rollback-uncertain");
 }
 
 /**
@@ -362,6 +372,29 @@ async function moveFile(source: string, destination: string): Promise<void> {
   }
 }
 
+/**
+ * Promote one validated staging file into durable storage and transfer its
+ * ownership to the transaction lifecycle. The file object is updated so both
+ * transaction helpers and the response cleanup callback address the same key.
+ */
+export async function promoteSecureUpload(
+  file: Express.Multer.File,
+  finalDirectory: string,
+  filename?: string
+): Promise<string> {
+  ensureDirectory(finalDirectory);
+  const extension = path.extname(file.originalname).toLowerCase();
+  const storedName = filename ?? `${randomUUID()}${extension}`;
+  const destination = path.resolve(finalDirectory, storedName);
+  await moveFile(path.resolve(file.path), destination);
+  await fs.chmod(destination, 0o600).catch(() => undefined);
+  file.destination = path.resolve(finalDirectory);
+  file.filename = storedName;
+  file.path = destination;
+  registerUploadDestination(file, destination);
+  return destination;
+}
+
 async function promoteFiles(files: Express.Multer.File[], finalDirectory: string): Promise<string[]> {
   ensureDirectory(finalDirectory);
   const promoted: string[] = [];
@@ -488,7 +521,11 @@ export function createSecureUpload(usage: UploadUsage, options: SecureUploadOpti
         if (cleanupStarted) return;
         cleanupStarted = true;
         const ownership = releaseRegisteredUploadDestinations(files);
-        const uncertain = ownership.filter((record) => record.state === "transferred" || record.state === "commit-attempted");
+        const uncertain = ownership.filter((record) =>
+          record.state === "transferred" ||
+          record.state === "commit-attempted" ||
+          record.state === "rollback-uncertain"
+        );
         if (uncertain.length > 0 || (promotedPaths.length > 0 && (res.statusCode >= 400 || !res.writableEnded))) {
           logger.error("[UPLOAD_OWNERSHIP] durable destination preserved for reconciliation", JSON.stringify({
             state_counts: ownership.reduce<Record<string, number>>((counts, record) => {

--- a/src/shared/uploads/secure-upload.ts
+++ b/src/shared/uploads/secure-upload.ts
@@ -1,0 +1,488 @@
+import { createHash, randomUUID } from "node:crypto";
+import { createReadStream } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+import type { Request, RequestHandler } from "express";
+import multer from "multer";
+
+import { ensureDirectory, ensureTmpStoragePath } from "../../utils/cerpStorage";
+import { HttpError } from "../../utils/httpError";
+import logger from "../../utils/logger";
+import {
+  MIME_TYPES_BY_EXTENSION,
+  formatUploadLimit,
+  getUploadPolicy,
+  type UploadPolicy,
+  type UploadUsage,
+} from "./upload-policy";
+import { scanUpload, type UploadScanStatus } from "./upload-scanner";
+
+export type UploadSecurityMetadata = Readonly<{
+  usage: UploadUsage;
+  sha256: string;
+  scanStatus: UploadScanStatus;
+  scanProvider: string;
+}>;
+
+declare global {
+  namespace Express {
+    namespace Multer {
+      interface File {
+        uploadSecurity?: UploadSecurityMetadata;
+      }
+    }
+  }
+}
+
+type SecureUploadStorage = "memory" | "staging" | Readonly<{ finalDirectory: string }>;
+
+export type SecureUploadOptions = Readonly<{
+  storage?: SecureUploadStorage;
+  maxFiles?: number;
+}>;
+
+export type SecureUpload = Readonly<{
+  single(fieldName: string): RequestHandler;
+  array(fieldName: string, maxCount?: number): RequestHandler;
+  fields(fields: readonly { name: string; maxCount?: number }[]): RequestHandler;
+  any(): RequestHandler;
+}>;
+
+const SAMPLE_BYTES = 64 * 1024;
+const WINDOWS_UNSAFE = /[:*?"<>|]/;
+const CONTROL_OR_BIDI = /[\u0000-\u001f\u007f\u202a-\u202e\u2066-\u2069]/;
+const uploadDestinations = new Map<string, Set<string>>();
+
+/**
+ * Registers an application-managed destination created from an uploaded file.
+ * The secure upload lifecycle removes it when the request aborts or returns an
+ * error, which compensates file moves performed before a database transaction
+ * commits. Successful responses keep the destination.
+ */
+export function registerUploadDestination(file: Readonly<{ path: string }>, destination: string): void {
+  const source = path.resolve(file.path);
+  const resolved = path.resolve(destination);
+  const destinations = uploadDestinations.get(source) ?? new Set<string>();
+  destinations.add(resolved);
+  uploadDestinations.set(source, destinations);
+}
+
+function takeRegisteredUploadDestinations(files: readonly Express.Multer.File[]): string[] {
+  return files.flatMap((file) => {
+    if (!file.path) return [];
+    const source = path.resolve(file.path);
+    const destinations = Array.from(uploadDestinations.get(source) ?? []);
+    uploadDestinations.delete(source);
+    return destinations;
+  });
+}
+
+function auditUpload(
+  req: Request,
+  usage: UploadUsage,
+  outcome: "accepted" | "rejected" | "cleaned",
+  details: Record<string, unknown>
+): void {
+  logger.info(
+    "[UPLOAD_AUDIT]",
+    JSON.stringify({
+      event: "security.upload",
+      request_id: req.requestId ?? null,
+      actor_id: req.user?.id ?? null,
+      method: req.method,
+      route: req.baseUrl + req.path,
+      usage,
+      outcome,
+      ...details,
+    })
+  );
+}
+
+export function assertSafeUploadName(originalName: string): string {
+  if (!originalName || originalName !== originalName.trim()) {
+    throw new HttpError(400, "UPLOAD_NAME_INVALID", "Le nom du fichier est vide ou contient des espaces ambigus.");
+  }
+  if (Buffer.byteLength(originalName, "utf8") > 240) {
+    throw new HttpError(400, "UPLOAD_NAME_TOO_LONG", "Le nom du fichier dépasse 240 octets. Renommez-le puis réessayez.");
+  }
+  if (
+    CONTROL_OR_BIDI.test(originalName) ||
+    WINDOWS_UNSAFE.test(originalName) ||
+    originalName.includes("/") ||
+    originalName.includes("\\") ||
+    originalName === "." ||
+    originalName === ".." ||
+    path.basename(originalName) !== originalName
+  ) {
+    throw new HttpError(400, "UPLOAD_NAME_INVALID", "Le nom du fichier contient un chemin ou des caractères interdits. Renommez-le puis réessayez.");
+  }
+  return originalName.normalize("NFC");
+}
+
+function extensionOf(originalName: string): string {
+  const extension = path.extname(originalName).toLowerCase();
+  if (!/^\.[a-z0-9_]+$/.test(extension) || extension.length > 12) {
+    throw new HttpError(415, "UPLOAD_EXTENSION_INVALID", "L’extension du fichier est absente ou invalide.");
+  }
+  return extension;
+}
+
+function normalizeMime(value: string): string {
+  return value.split(";", 1)[0]?.trim().toLowerCase() || "application/octet-stream";
+}
+
+function assertPreflight(file: Pick<Express.Multer.File, "originalname" | "mimetype">, policy: UploadPolicy): string | null {
+  const name = assertSafeUploadName(file.originalname);
+  if (policy.deferContentValidation) return null;
+  const extension = extensionOf(name);
+  if (!policy.allowedExtensions?.has(extension)) {
+    throw new HttpError(415, "UPLOAD_EXTENSION_FORBIDDEN", `Ce format n’est pas autorisé pour un ${policy.label}.`);
+  }
+  const allowedMimes = MIME_TYPES_BY_EXTENSION[extension];
+  if (!allowedMimes?.has(normalizeMime(file.mimetype))) {
+    throw new HttpError(415, "UPLOAD_MIME_MISMATCH", "Le type déclaré du fichier ne correspond pas à son extension.");
+  }
+  return extension;
+}
+
+type FileSample = Readonly<{ head: Buffer; tail: Buffer }>;
+
+async function sampleFile(file: Express.Multer.File): Promise<FileSample> {
+  if (file.buffer) {
+    return {
+      head: file.buffer.subarray(0, SAMPLE_BYTES),
+      tail: file.buffer.subarray(Math.max(0, file.buffer.length - SAMPLE_BYTES)),
+    };
+  }
+  const handle = await fs.open(file.path, "r");
+  try {
+    const head = Buffer.alloc(Math.min(SAMPLE_BYTES, file.size));
+    const tail = Buffer.alloc(Math.min(SAMPLE_BYTES, file.size));
+    if (head.length) await handle.read(head, 0, head.length, 0);
+    if (tail.length) await handle.read(tail, 0, tail.length, Math.max(0, file.size - tail.length));
+    return { head, tail };
+  } finally {
+    await handle.close();
+  }
+}
+
+function startsWith(buffer: Buffer, signature: readonly number[], offset = 0): boolean {
+  return signature.every((byte, index) => buffer[offset + index] === byte);
+}
+
+function containsAscii(sample: FileSample, text: string): boolean {
+  return sample.head.includes(Buffer.from(text, "ascii")) || sample.tail.includes(Buffer.from(text, "ascii"));
+}
+
+function isProbablyText(buffer: Buffer): boolean {
+  if (buffer.includes(0)) return false;
+  if (buffer.length === 0) return false;
+  let controls = 0;
+  for (const byte of buffer) {
+    if (byte < 0x20 && ![0x09, 0x0a, 0x0d, 0x0c].includes(byte)) controls += 1;
+  }
+  return controls / buffer.length < 0.01;
+}
+
+function isForbiddenExecutable(head: Buffer): boolean {
+  return (
+    startsWith(head, [0x4d, 0x5a]) ||
+    startsWith(head, [0x7f, 0x45, 0x4c, 0x46]) ||
+    startsWith(head, [0xcf, 0xfa, 0xed, 0xfe]) ||
+    startsWith(head, [0xfe, 0xed, 0xfa, 0xcf])
+  );
+}
+
+export function contentMatchesExtension(extension: string, sample: FileSample, size: number): boolean {
+  const { head, tail } = sample;
+  if (isForbiddenExecutable(head)) return false;
+
+  switch (extension) {
+    case ".pdf":
+      return head.subarray(0, 5).toString("latin1") === "%PDF-" && tail.includes(Buffer.from("%%EOF", "ascii"));
+    case ".png":
+      return startsWith(head, [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+    case ".jpg":
+    case ".jpeg":
+      return startsWith(head, [0xff, 0xd8, 0xff]) && tail.subarray(Math.max(0, tail.length - 2)).equals(Buffer.from([0xff, 0xd9]));
+    case ".gif":
+      return head.subarray(0, 6).toString("ascii") === "GIF87a" || head.subarray(0, 6).toString("ascii") === "GIF89a";
+    case ".webp":
+      return head.subarray(0, 4).toString("ascii") === "RIFF" && head.subarray(8, 12).toString("ascii") === "WEBP";
+    case ".tif":
+    case ".tiff":
+      return startsWith(head, [0x49, 0x49, 0x2a, 0x00]) || startsWith(head, [0x4d, 0x4d, 0x00, 0x2a]);
+    case ".doc":
+    case ".xls":
+      return startsWith(head, [0xd0, 0xcf, 0x11, 0xe0, 0xa1, 0xb1, 0x1a, 0xe1]);
+    case ".docx":
+      return startsWith(head, [0x50, 0x4b]) && containsAscii(sample, "word/");
+    case ".xlsx":
+      return startsWith(head, [0x50, 0x4b]) && containsAscii(sample, "xl/");
+    case ".pptx":
+      return startsWith(head, [0x50, 0x4b]) && containsAscii(sample, "ppt/");
+    case ".odt":
+    case ".ods":
+      return startsWith(head, [0x50, 0x4b]) && containsAscii(sample, "content.xml");
+    case ".zip":
+    case ".3mf":
+      return startsWith(head, [0x50, 0x4b]);
+    case ".7z":
+      return startsWith(head, [0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c]);
+    case ".stp":
+    case ".step":
+      return isProbablyText(head) && containsAscii(sample, "ISO-10303-21");
+    case ".stl":
+      return (isProbablyText(head) && head.subarray(0, 80).toString("ascii").trimStart().startsWith("solid")) || size >= 84;
+    case ".dxf":
+      return (isProbablyText(head) && containsAscii(sample, "SECTION")) || head.toString("ascii", 0, 22) === "AutoCAD Binary DXF\r\n\x1a\0";
+    case ".dwg":
+      return /^AC10\d{2}/.test(head.subarray(0, 6).toString("ascii"));
+    case ".igs":
+    case ".iges":
+    case ".x_t":
+    case ".ncp":
+    case ".nc":
+    case ".cnc":
+    case ".tap":
+    case ".h":
+    case ".mpf":
+    case ".gcode":
+    case ".txt":
+    case ".csv":
+    case ".xml":
+    case ".json":
+      return isProbablyText(head);
+    // Proprietary CAD containers have no stable public magic value. They are
+    // accepted only with an octet-stream MIME and after executable rejection.
+    case ".sldprt":
+    case ".sldasm":
+    case ".x_b":
+    case ".ipt":
+    case ".iam":
+    case ".catpart":
+    case ".catproduct":
+      return true;
+    default:
+      return false;
+  }
+}
+
+async function sha256(file: Express.Multer.File): Promise<string> {
+  const hash = createHash("sha256");
+  if (file.buffer) {
+    hash.update(file.buffer);
+    return hash.digest("hex");
+  }
+  const stream = createReadStream(file.path);
+  for await (const chunk of stream) hash.update(chunk);
+  return hash.digest("hex");
+}
+
+async function cleanupPaths(paths: Iterable<string>): Promise<void> {
+  await Promise.all(Array.from(new Set(paths)).map((filePath) => fs.unlink(filePath).catch(() => undefined)));
+}
+
+function multerFiles(req: Request): Express.Multer.File[] {
+  if (req.file) return [req.file];
+  if (Array.isArray(req.files)) return req.files;
+  if (req.files && typeof req.files === "object") return Object.values(req.files).flat();
+  return [];
+}
+
+async function moveFile(source: string, destination: string): Promise<void> {
+  try {
+    await fs.rename(source, destination);
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "EXDEV") throw error;
+    await fs.copyFile(source, destination, fs.constants.COPYFILE_EXCL);
+    await fs.unlink(source);
+  }
+}
+
+async function promoteFiles(files: Express.Multer.File[], finalDirectory: string): Promise<string[]> {
+  ensureDirectory(finalDirectory);
+  const promoted: string[] = [];
+  try {
+    for (const file of files) {
+      const extension = path.extname(file.originalname).toLowerCase();
+      const filename = `${randomUUID()}${extension}`;
+      const destination = path.resolve(finalDirectory, filename);
+      await moveFile(file.path, destination);
+      await fs.chmod(destination, 0o600).catch(() => undefined);
+      file.destination = path.resolve(finalDirectory);
+      file.filename = filename;
+      file.path = destination;
+      promoted.push(destination);
+    }
+    return promoted;
+  } catch (error) {
+    await cleanupPaths(promoted);
+    throw error;
+  }
+}
+
+async function validateFiles(files: Express.Multer.File[], policy: UploadPolicy): Promise<void> {
+  if (files.length > policy.maxFiles) {
+    throw new HttpError(400, "UPLOAD_TOO_MANY_FILES", `Vous pouvez envoyer au maximum ${policy.maxFiles} fichier(s) à la fois.`);
+  }
+  const hashes = new Set<string>();
+  for (const file of files) {
+    if (!Number.isSafeInteger(file.size) || file.size <= 0) {
+      throw new HttpError(400, "UPLOAD_EMPTY_FILE", "Le fichier est vide. Sélectionnez un fichier contenant des données.");
+    }
+    if (file.size > policy.maxFileBytes) {
+      throw new HttpError(413, "UPLOAD_FILE_TOO_LARGE", `Le fichier dépasse la limite de ${formatUploadLimit(policy.maxFileBytes)}.`);
+    }
+    const extension = assertPreflight(file, policy);
+    const sample = await sampleFile(file);
+    if (isForbiddenExecutable(sample.head)) {
+      throw new HttpError(415, "UPLOAD_EXECUTABLE_FORBIDDEN", "Les fichiers exécutables sont interdits.");
+    }
+    if (extension && !contentMatchesExtension(extension, sample, file.size)) {
+      throw new HttpError(415, "UPLOAD_SIGNATURE_MISMATCH", "Le contenu du fichier ne correspond pas à son extension.");
+    }
+    const digest = await sha256(file);
+    if (hashes.has(digest)) {
+      throw new HttpError(409, "UPLOAD_DUPLICATE_FILE", "Le même fichier apparaît plusieurs fois dans cet envoi.");
+    }
+    hashes.add(digest);
+
+    const scan = await scanUpload(file.buffer ? { buffer: file.buffer } : { path: file.path });
+    if (scan.status === "infected") {
+      throw new HttpError(422, "UPLOAD_SCAN_REJECTED", "Le fichier a été placé en quarantaine et refusé par le scanner de sécurité.");
+    }
+    if (scan.status === "unavailable" && scan.mode === "enforce") {
+      throw new HttpError(503, "UPLOAD_SCAN_UNAVAILABLE", "Le contrôle antivirus est indisponible. Réessayez plus tard ou contactez l’administrateur.");
+    }
+    file.uploadSecurity = {
+      usage: policy.usage,
+      sha256: digest,
+      scanStatus: scan.status,
+      scanProvider: scan.provider,
+    };
+  }
+}
+
+function translateMulterError(error: unknown, policy: UploadPolicy): Error {
+  if (!(error instanceof multer.MulterError)) return error instanceof Error ? error : new Error("Upload failure");
+  switch (error.code) {
+    case "LIMIT_FILE_SIZE":
+      return new HttpError(413, "UPLOAD_FILE_TOO_LARGE", `Le fichier dépasse la limite de ${formatUploadLimit(policy.maxFileBytes)}.`);
+    case "LIMIT_FILE_COUNT":
+    case "LIMIT_UNEXPECTED_FILE":
+      return new HttpError(400, "UPLOAD_TOO_MANY_FILES", `Le nombre de fichiers dépasse la limite autorisée (${policy.maxFiles}).`);
+    case "LIMIT_FIELD_COUNT":
+    case "LIMIT_FIELD_KEY":
+    case "LIMIT_FIELD_VALUE":
+      return new HttpError(400, "UPLOAD_FORM_INVALID", "Le formulaire d’envoi est trop volumineux ou contient trop de champs.");
+    default:
+      return new HttpError(400, "UPLOAD_INVALID", "Le fichier n’a pas pu être reçu. Vérifiez-le puis réessayez.");
+  }
+}
+
+export function createSecureUpload(usage: UploadUsage, options: SecureUploadOptions = {}): SecureUpload {
+  const basePolicy = getUploadPolicy(usage);
+  const policy: UploadPolicy = options.maxFiles
+    ? Object.freeze({ ...basePolicy, maxFiles: Math.min(options.maxFiles, basePolicy.maxFiles) })
+    : basePolicy;
+  const storage = options.storage ?? "staging";
+  const isMemory = storage === "memory";
+  const quarantineDirectory = isMemory ? null : ensureTmpStoragePath("upload-quarantine", usage);
+
+  const makeMulter = (maxFiles: number) =>
+    multer({
+      storage: isMemory
+        ? multer.memoryStorage()
+        : multer.diskStorage({
+            destination: quarantineDirectory!,
+            filename: (_req, _file, callback) => callback(null, `${randomUUID()}.part`),
+          }),
+      preservePath: true,
+      limits: {
+        fileSize: policy.maxFileBytes,
+        files: maxFiles,
+        fields: policy.maxFields,
+        fieldSize: policy.maxFieldBytes,
+      },
+      fileFilter: (_req, file, callback) => {
+        try {
+          assertPreflight(file, policy);
+          callback(null, true);
+        } catch (error) {
+          callback(error as Error);
+        }
+      },
+    });
+
+  const wrap = (multerHandler: RequestHandler): RequestHandler => (req, res, next) => {
+    multerHandler(req, res, async (uploadError?: unknown) => {
+      const files = multerFiles(req);
+      const stagedPaths = files.filter((file) => !!file.path).map((file) => file.path);
+      let promotedPaths: string[] = [];
+      let cleanupStarted = false;
+
+      const cleanupAfterResponse = () => {
+        if (cleanupStarted) return;
+        cleanupStarted = true;
+        const shouldRemovePromoted = res.statusCode >= 400 || !res.writableEnded;
+        const downstreamDestinations = takeRegisteredUploadDestinations(files);
+        void cleanupPaths(
+          shouldRemovePromoted ? [...stagedPaths, ...promotedPaths, ...downstreamDestinations] : stagedPaths
+        ).then(() => {
+          if (shouldRemovePromoted || stagedPaths.length > 0) {
+            auditUpload(req, usage, "cleaned", {
+              staged_count: stagedPaths.length,
+              promoted_count: shouldRemovePromoted ? promotedPaths.length + downstreamDestinations.length : 0,
+            });
+          }
+        });
+      };
+
+      try {
+        if (uploadError) throw translateMulterError(uploadError, policy);
+        await validateFiles(files, policy);
+        if (typeof storage === "object") {
+          promotedPaths = await promoteFiles(files, storage.finalDirectory);
+        } else if (!isMemory) {
+          await Promise.all(files.map((file) => fs.chmod(file.path, 0o600).catch(() => undefined)));
+        }
+        if (files.length > 0) {
+          res.once("finish", cleanupAfterResponse);
+          res.once("close", cleanupAfterResponse);
+        }
+        auditUpload(req, usage, "accepted", {
+          file_count: files.length,
+          total_bytes: files.reduce((sum, file) => sum + file.size, 0),
+          scan_statuses: Array.from(new Set(files.map((file) => file.uploadSecurity?.scanStatus ?? "unknown"))),
+        });
+        next();
+      } catch (error) {
+        await cleanupPaths([...stagedPaths, ...promotedPaths]);
+        auditUpload(req, usage, "rejected", {
+          code: error instanceof HttpError ? error.code : "UPLOAD_INTERNAL_ERROR",
+          file_count: files.length,
+        });
+        next(error);
+      }
+    });
+  };
+
+  return {
+    single: (fieldName) => wrap(makeMulter(1).single(fieldName)),
+    array: (fieldName, maxCount = policy.maxFiles) => {
+      const effective = Math.min(maxCount, policy.maxFiles);
+      return wrap(makeMulter(effective).array(fieldName, effective));
+    },
+    fields: (fields) => {
+      const maxFiles = Math.min(
+        fields.reduce((sum, field) => sum + (field.maxCount ?? 1), 0),
+        policy.maxFiles
+      );
+      return wrap(makeMulter(maxFiles).fields(fields.map((field) => ({ ...field }))));
+    },
+    any: () => wrap(makeMulter(policy.maxFiles).any()),
+  };
+}

--- a/src/shared/uploads/upload-policy.ts
+++ b/src/shared/uploads/upload-policy.ts
@@ -1,0 +1,230 @@
+const MIB = 1024 * 1024;
+
+export type UploadUsage =
+  | "business-document"
+  | "technical-document"
+  | "machine-document"
+  | "quality-document"
+  | "image"
+  | "tool-media"
+  | "import-tabular"
+  | "ged-deferred"
+  | "project-evidence-deferred"
+  | "project-asset-image";
+
+export type UploadPolicy = Readonly<{
+  usage: UploadUsage;
+  label: string;
+  maxFileBytes: number;
+  maxFiles: number;
+  maxFields: number;
+  maxFieldBytes: number;
+  allowedExtensions: ReadonlySet<string> | null;
+  deferContentValidation: boolean;
+}>;
+
+const BUSINESS_DOCUMENT_EXTENSIONS = new Set([
+  ".pdf",
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".webp",
+  ".gif",
+  ".txt",
+  ".csv",
+  ".doc",
+  ".docx",
+  ".xls",
+  ".xlsx",
+  ".odt",
+  ".ods",
+]);
+
+const TECHNICAL_DOCUMENT_EXTENSIONS = new Set([
+  ...BUSINESS_DOCUMENT_EXTENSIONS,
+  ".tif",
+  ".tiff",
+  ".pptx",
+  ".xml",
+  ".json",
+  ".zip",
+  ".7z",
+  ".stp",
+  ".step",
+  ".stl",
+  ".dxf",
+  ".dwg",
+  ".igs",
+  ".iges",
+  ".3mf",
+  ".sldprt",
+  ".sldasm",
+  ".x_t",
+  ".x_b",
+  ".ipt",
+  ".iam",
+  ".catpart",
+  ".catproduct",
+  ".ncp",
+  ".nc",
+  ".cnc",
+  ".tap",
+  ".h",
+  ".mpf",
+  ".gcode",
+]);
+
+const QUALITY_DOCUMENT_EXTENSIONS = new Set([
+  ...BUSINESS_DOCUMENT_EXTENSIONS,
+  ".tif",
+  ".tiff",
+]);
+
+const IMAGE_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif"]);
+const TOOL_MEDIA_EXTENSIONS = new Set([...IMAGE_EXTENSIONS, ".pdf"]);
+const IMPORT_EXTENSIONS = new Set([".csv", ".xlsx"]);
+
+function policy(
+  usage: UploadUsage,
+  label: string,
+  maxFileBytes: number,
+  maxFiles: number,
+  allowedExtensions: ReadonlySet<string> | null,
+  deferContentValidation = false
+): UploadPolicy {
+  return Object.freeze({
+    usage,
+    label,
+    maxFileBytes,
+    maxFiles,
+    maxFields: 20,
+    maxFieldBytes: 1024 * 1024,
+    allowedExtensions,
+    deferContentValidation,
+  });
+}
+
+/**
+ * One transport policy per real CERP usage. Historical files are never
+ * revalidated with this table at download time: it governs new bytes only.
+ */
+export const UPLOAD_POLICIES: Readonly<Record<UploadUsage, UploadPolicy>> = Object.freeze({
+  "business-document": policy(
+    "business-document",
+    "document métier",
+    25 * MIB,
+    10,
+    BUSINESS_DOCUMENT_EXTENSIONS
+  ),
+  "technical-document": policy(
+    "technical-document",
+    "document technique",
+    25 * MIB,
+    10,
+    TECHNICAL_DOCUMENT_EXTENSIONS
+  ),
+  "machine-document": policy(
+    "machine-document",
+    "document machine",
+    50 * MIB,
+    1,
+    TECHNICAL_DOCUMENT_EXTENSIONS
+  ),
+  "quality-document": policy(
+    "quality-document",
+    "document qualité",
+    25 * MIB,
+    10,
+    QUALITY_DOCUMENT_EXTENSIONS
+  ),
+  image: policy("image", "image", 10 * MIB, 3, IMAGE_EXTENSIONS),
+  "tool-media": policy("tool-media", "média outillage", 25 * MIB, 3, TOOL_MEDIA_EXTENSIONS),
+  "import-tabular": policy("import-tabular", "fichier d’import", 25 * MIB, 1, IMPORT_EXTENSIONS),
+  // GED and Project Office already apply a stricter class-specific validator.
+  // The central layer still enforces name, non-empty body, transport bounds,
+  // duplicate detection, quarantine lifecycle and scanner mode.
+  "ged-deferred": policy("ged-deferred", "document GED", 512 * MIB, 1, null, true),
+  "project-evidence-deferred": policy(
+    "project-evidence-deferred",
+    "preuve Project Office",
+    25 * MIB,
+    1,
+    null,
+    true
+  ),
+  "project-asset-image": policy(
+    "project-asset-image",
+    "capture Project Office",
+    5 * MIB,
+    1,
+    new Set([".png", ".jpg", ".jpeg"])
+  ),
+});
+
+export const MIME_TYPES_BY_EXTENSION: Readonly<Record<string, ReadonlySet<string>>> = Object.freeze({
+  ".pdf": new Set(["application/pdf"]),
+  ".png": new Set(["image/png"]),
+  ".jpg": new Set(["image/jpeg", "image/jpg"]),
+  ".jpeg": new Set(["image/jpeg", "image/jpg"]),
+  ".webp": new Set(["image/webp"]),
+  ".gif": new Set(["image/gif"]),
+  ".tif": new Set(["image/tiff"]),
+  ".tiff": new Set(["image/tiff"]),
+  ".txt": new Set(["text/plain"]),
+  ".csv": new Set(["text/csv", "text/plain", "application/vnd.ms-excel"]),
+  ".doc": new Set(["application/msword", "application/octet-stream"]),
+  ".docx": new Set([
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/zip",
+    "application/octet-stream",
+  ]),
+  ".xls": new Set(["application/vnd.ms-excel", "application/octet-stream"]),
+  ".xlsx": new Set([
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.ms-excel",
+    "application/zip",
+    "application/octet-stream",
+  ]),
+  ".pptx": new Set([
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/zip",
+    "application/octet-stream",
+  ]),
+  ".odt": new Set(["application/vnd.oasis.opendocument.text", "application/zip", "application/octet-stream"]),
+  ".ods": new Set(["application/vnd.oasis.opendocument.spreadsheet", "application/zip", "application/octet-stream"]),
+  ".xml": new Set(["application/xml", "text/xml", "text/plain"]),
+  ".json": new Set(["application/json", "text/plain"]),
+  ".zip": new Set(["application/zip", "application/x-zip-compressed"]),
+  ".7z": new Set(["application/x-7z-compressed", "application/octet-stream"]),
+  ".stp": new Set(["model/step", "application/step", "text/plain", "application/octet-stream"]),
+  ".step": new Set(["model/step", "application/step", "text/plain", "application/octet-stream"]),
+  ".stl": new Set(["model/stl", "application/sla", "text/plain", "application/octet-stream"]),
+  ".dxf": new Set(["application/dxf", "image/vnd.dxf", "text/plain", "application/octet-stream"]),
+  ".dwg": new Set(["image/vnd.dwg", "application/acad", "application/octet-stream"]),
+  ".igs": new Set(["model/iges", "application/iges", "text/plain", "application/octet-stream"]),
+  ".iges": new Set(["model/iges", "application/iges", "text/plain", "application/octet-stream"]),
+  ".3mf": new Set(["model/3mf", "application/zip", "application/octet-stream"]),
+  ".sldprt": new Set(["application/octet-stream"]),
+  ".sldasm": new Set(["application/octet-stream"]),
+  ".x_t": new Set(["application/octet-stream", "text/plain"]),
+  ".x_b": new Set(["application/octet-stream"]),
+  ".ipt": new Set(["application/octet-stream"]),
+  ".iam": new Set(["application/octet-stream"]),
+  ".catpart": new Set(["application/octet-stream"]),
+  ".catproduct": new Set(["application/octet-stream"]),
+  ".ncp": new Set(["text/plain", "application/octet-stream"]),
+  ".nc": new Set(["text/plain", "application/octet-stream"]),
+  ".cnc": new Set(["text/plain", "application/octet-stream"]),
+  ".tap": new Set(["text/plain", "application/octet-stream"]),
+  ".h": new Set(["text/plain", "application/octet-stream"]),
+  ".mpf": new Set(["text/plain", "application/octet-stream"]),
+  ".gcode": new Set(["text/plain", "application/octet-stream"]),
+});
+
+export function getUploadPolicy(usage: UploadUsage): UploadPolicy {
+  return UPLOAD_POLICIES[usage];
+}
+
+export function formatUploadLimit(bytes: number): string {
+  return `${Math.round(bytes / MIB)} Mo`;
+}

--- a/src/shared/uploads/upload-scanner.ts
+++ b/src/shared/uploads/upload-scanner.ts
@@ -1,0 +1,114 @@
+import { spawn } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+
+import { ensureTmpStoragePath } from "../../utils/cerpStorage";
+
+export type UploadScanStatus = "clean" | "infected" | "unavailable";
+export type UploadScanMode = "off" | "monitor" | "enforce";
+
+export type UploadScanInput = Readonly<{
+  path?: string;
+  buffer?: Buffer;
+}>;
+
+export type UploadScanResult = Readonly<{
+  status: UploadScanStatus;
+  provider: string;
+  reason?: string;
+}>;
+
+export interface UploadScanner {
+  readonly name: string;
+  scan(input: UploadScanInput): Promise<UploadScanResult>;
+}
+
+class UnavailableScanner implements UploadScanner {
+  readonly name = "none";
+
+  async scan(): Promise<UploadScanResult> {
+    return { status: "unavailable", provider: this.name, reason: "scanner_non_configure" };
+  }
+}
+
+/**
+ * Optional ClamAV adapter. It is used only when explicitly configured. The
+ * process is spawned without a shell and receives an application-generated
+ * path, never a user-provided command fragment.
+ */
+class ClamDscanScanner implements UploadScanner {
+  readonly name = "clamdscan";
+  private readonly executable: string;
+
+  constructor() {
+    this.executable = process.env.CERP_UPLOAD_SCANNER_COMMAND?.trim() || "clamdscan";
+  }
+
+  async scan(input: UploadScanInput): Promise<UploadScanResult> {
+    const temporaryPath = input.path ? null : path.join(ensureTmpStoragePath("upload-scanner"), `${randomUUID()}.scan`);
+    const scanPath = input.path ?? temporaryPath;
+    if (!scanPath || (!input.path && !input.buffer)) {
+      return { status: "unavailable", provider: this.name, reason: "contenu_absent" };
+    }
+
+    if (temporaryPath && input.buffer) await fs.writeFile(temporaryPath, input.buffer, { flag: "wx", mode: 0o600 });
+
+    try {
+      return await new Promise<UploadScanResult>((resolve) => {
+        const child = spawn(this.executable, ["--no-summary", "--", scanPath], {
+          shell: false,
+          windowsHide: true,
+          stdio: "ignore",
+        });
+        let settled = false;
+        const finish = (result: UploadScanResult) => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          resolve(result);
+        };
+        const timer = setTimeout(() => {
+          child.kill();
+          finish({ status: "unavailable", provider: this.name, reason: "delai_depasse" });
+        }, 30_000);
+        child.once("error", () => finish({ status: "unavailable", provider: this.name, reason: "scanner_injoignable" }));
+        child.once("exit", (code) => {
+          if (code === 0) finish({ status: "clean", provider: this.name });
+          else if (code === 1) finish({ status: "infected", provider: this.name, reason: "contenu_suspect" });
+          else finish({ status: "unavailable", provider: this.name, reason: "scanner_en_erreur" });
+        });
+      });
+    } finally {
+      if (temporaryPath) await fs.unlink(temporaryPath).catch(() => undefined);
+    }
+  }
+}
+
+let scannerOverride: UploadScanner | null = null;
+
+export function setUploadScannerForTests(scanner: UploadScanner | null): void {
+  scannerOverride = scanner;
+}
+
+export function getUploadScanMode(): UploadScanMode {
+  const configured = process.env.CERP_UPLOAD_SCAN_MODE?.trim().toLowerCase();
+  if (!configured) return process.env.NODE_ENV === "production" ? "enforce" : "monitor";
+  if (configured === "off" || configured === "monitor" || configured === "enforce") return configured;
+  // An invalid security configuration must not silently disable scanning.
+  return "enforce";
+}
+
+function configuredScanner(): UploadScanner {
+  if (scannerOverride) return scannerOverride;
+  const provider = process.env.CERP_UPLOAD_SCAN_PROVIDER?.trim().toLowerCase();
+  if (provider === "clamdscan") return new ClamDscanScanner();
+  return new UnavailableScanner();
+}
+
+export async function scanUpload(input: UploadScanInput): Promise<UploadScanResult & { mode: UploadScanMode }> {
+  const mode = getUploadScanMode();
+  if (mode === "off") return { status: "unavailable", provider: "disabled", reason: "scan_desactive", mode };
+  const result = await configuredScanner().scan(input);
+  return { ...result, mode };
+}

--- a/src/shared/uploads/upload-scanner.ts
+++ b/src/shared/uploads/upload-scanner.ts
@@ -93,10 +93,48 @@ export function setUploadScannerForTests(scanner: UploadScanner | null): void {
 
 export function getUploadScanMode(): UploadScanMode {
   const configured = process.env.CERP_UPLOAD_SCAN_MODE?.trim().toLowerCase();
-  if (!configured) return process.env.NODE_ENV === "production" ? "enforce" : "monitor";
+  // Vitest can keep the historical monitor default so unrelated unit tests do
+  // not need a ClamAV daemon. Every real runtime, including the Docker image
+  // which currently uses NODE_ENV=development, fails closed.
+  if (!configured) return process.env.NODE_ENV === "test" ? "monitor" : "enforce";
   if (configured === "off" || configured === "monitor" || configured === "enforce") return configured;
   // An invalid security configuration must not silently disable scanning.
   return "enforce";
+}
+
+export type UploadScannerConfiguration = Readonly<{
+  mode: UploadScanMode;
+  provider: "clamdscan" | "none";
+  command: string | null;
+}>;
+
+/**
+ * Startup preflight. Runtime upload handling is fail-closed as a second line
+ * of defence, but an enforce deployment should fail during boot instead of
+ * discovering a missing scanner on its first customer upload.
+ */
+export function assertUploadScannerConfiguration(): UploadScannerConfiguration {
+  const rawMode = process.env.CERP_UPLOAD_SCAN_MODE?.trim().toLowerCase();
+  if (rawMode && rawMode !== "off" && rawMode !== "monitor" && rawMode !== "enforce") {
+    throw new Error(`CERP_UPLOAD_SCAN_MODE invalide: ${rawMode}`);
+  }
+
+  const mode = getUploadScanMode();
+  const rawProvider = process.env.CERP_UPLOAD_SCAN_PROVIDER?.trim().toLowerCase();
+  if (rawProvider && rawProvider !== "clamdscan") {
+    throw new Error(`CERP_UPLOAD_SCAN_PROVIDER invalide: ${rawProvider}`);
+  }
+  if (mode === "enforce" && rawProvider !== "clamdscan") {
+    throw new Error("CERP_UPLOAD_SCAN_PROVIDER=clamdscan est obligatoire en mode enforce.");
+  }
+
+  return {
+    mode,
+    provider: rawProvider === "clamdscan" ? "clamdscan" : "none",
+    command: rawProvider === "clamdscan"
+      ? process.env.CERP_UPLOAD_SCANNER_COMMAND?.trim() || "clamdscan"
+      : null,
+  };
 }
 
 function configuredScanner(): UploadScanner {

--- a/src/shared/uploads/upload-transaction.ts
+++ b/src/shared/uploads/upload-transaction.ts
@@ -1,0 +1,146 @@
+import type { PoolClient } from "pg";
+
+import { HttpError } from "../../utils/httpError";
+import logger from "../../utils/logger";
+import {
+  cleanupUploadsAfterConfirmedRollback,
+  cleanupUploadsAfterReconciledNoCommit,
+  markUploadCommitAttempted,
+  markUploadRollbackUncertain,
+  markUploadsCommitted,
+  type UploadFileReference,
+} from "./secure-upload";
+
+export type UploadCommitReconciliation = "committed" | "not-committed" | "uncertain";
+
+type UploadTransactionClient = Pick<PoolClient, "query" | "release">;
+
+export type UploadTransactionOptions<T> = Readonly<{
+  client: UploadTransactionClient;
+  files: readonly UploadFileReference[];
+  context: string;
+  work: (client: UploadTransactionClient) => Promise<T>;
+  /** Must query through a fresh pool connection, never `client`. */
+  reconcile: (result: T) => Promise<UploadCommitReconciliation>;
+}>;
+
+export class UploadCommitUncertainError extends HttpError {
+  constructor() {
+    super(
+      503,
+      "UPLOAD_COMMIT_UNCERTAIN",
+      "Le résultat de l’enregistrement du fichier est incertain. Réessayez après vérification."
+    );
+    this.name = "UploadCommitUncertainError";
+  }
+}
+
+export class UploadRollbackUncertainError extends HttpError {
+  constructor() {
+    super(
+      503,
+      "UPLOAD_ROLLBACK_UNCERTAIN",
+      "L’annulation de l’enregistrement du fichier n’a pas pu être confirmée."
+    );
+    this.name = "UploadRollbackUncertainError";
+  }
+}
+
+function privacySafeErrorName(error: unknown): string {
+  return error instanceof Error ? error.name : "unknown";
+}
+
+/**
+ * Owns one database transaction and the durable files promoted inside `work`.
+ * It never issues ROLLBACK after COMMIT was attempted. An ACK-loss is resolved
+ * only by the caller's fresh read; ambiguous ownership is preserved.
+ */
+export async function withUploadTransaction<T>(options: UploadTransactionOptions<T>): Promise<T> {
+  const { client, files, context, work, reconcile } = options;
+  let released = false;
+  const release = (destroy = false) => {
+    if (released) return;
+    released = true;
+    client.release(destroy);
+  };
+
+  try {
+    await client.query("BEGIN");
+  } catch (error) {
+    release(true);
+    throw error;
+  }
+
+  let result: T;
+  try {
+    result = await work(client);
+  } catch (error) {
+    try {
+      await client.query("ROLLBACK");
+      await cleanupUploadsAfterConfirmedRollback(files);
+    } catch (rollbackError) {
+      markUploadRollbackUncertain(files);
+      release(true);
+      logger.error("[UPLOAD_TRANSACTION] rollback uncertain", JSON.stringify({
+        context,
+        error: privacySafeErrorName(rollbackError),
+      }));
+      throw new UploadRollbackUncertainError();
+    }
+    release();
+    throw error;
+  }
+
+  markUploadCommitAttempted(files);
+  try {
+    await client.query("COMMIT");
+    markUploadsCommitted(files);
+    release();
+    return result;
+  } catch (commitError) {
+    // The connection that lost the COMMIT acknowledgement must never be used
+    // for reconciliation or returned to the pool.
+    release(true);
+
+    let reconciliation: UploadCommitReconciliation = "uncertain";
+    try {
+      reconciliation = await reconcile(result);
+    } catch (reconciliationError) {
+      logger.error("[UPLOAD_TRANSACTION] reconciliation failed", JSON.stringify({
+        context,
+        error: privacySafeErrorName(reconciliationError),
+      }));
+    }
+
+    if (reconciliation === "committed") {
+      markUploadsCommitted(files);
+      return result;
+    }
+    if (reconciliation === "not-committed") {
+      await cleanupUploadsAfterReconciledNoCommit(files);
+      throw commitError;
+    }
+
+    logger.error("[UPLOAD_TRANSACTION] commit uncertain; durable files preserved", JSON.stringify({
+      context,
+      error: privacySafeErrorName(commitError),
+    }));
+    throw new UploadCommitUncertainError();
+  }
+}
+
+/** Classifies exact immutable identities returned by a fresh reconciliation query. */
+export function classifyUploadReconciliation(
+  expectedKeys: readonly string[],
+  observedKeys: readonly string[]
+): UploadCommitReconciliation {
+  const expected = new Set(expectedKeys);
+  const observed = new Set(observedKeys);
+  if (expected.size === 0) return "committed";
+  if (observed.size === 0) return "not-committed";
+  if (observed.size !== expected.size) return "uncertain";
+  for (const key of expected) {
+    if (!observed.has(key)) return "uncertain";
+  }
+  return "committed";
+}


### PR DESCRIPTION
SEC-CERP-0003 / GPT56-CERP-0011. Centralizes upload policies by usage, validates names, MIME, extensions and content signatures, stages and compensates file persistence, adds fail-closed scanner modes, hardens downloads, and documents rollout/rollback/cleanup. Verification: TypeScript build; 195 test files and 3788 tests passed; targeted upload/module suites passed. No migration and no production operation performed.

## Summary by Sourcery

Harden CERP file upload and download flows with centralized security policies, scanning, and safe delivery headers.

New Features:
- Introduce a shared secure upload middleware with per-usage policies, content validation, and scanner integration.
- Add shared secure download utilities to enforce path safety, HTTP security headers, and robust Content-Disposition handling.

Bug Fixes:
- Prevent executable and mismatched-content uploads from being accepted even when renamed with safe extensions.
- Ensure downloads cannot escape their intended storage roots, returning appropriate errors when paths are invalid or files missing.

Enhancements:
- Refactor module-specific upload routes to use centralized secure upload policies and staging instead of ad hoc multer configurations.
- Refactor multiple document and PDF download endpoints to use common secure file sending helpers and consistent response headers.
- Improve tests to cover secure upload rejection scenarios, download header contracts, and traceability/asbuilt storage expectations.

Documentation:
- Add upload hardening documentation describing central policies, scanner modes, rollout, rollback, and cleanup procedures.

Tests:
- Add dedicated secure upload and secure download test suites validating validation rules, scanner behavior, and cleanup semantics.
- Update existing route/controller tests to assert new error codes, headers, and storage path behavior for hardened flows.