### PR TITLE
fix(db): sécuriser le ledger du limiteur distribué

### DIFF
--- a/db/patches/20260804_auth_rate_limit_buckets.sql
+++ b/db/patches/20260804_auth_rate_limit_buckets.sql
@@ -3,7 +3,23 @@ BEGIN;
 -- SEC-CERP-0005: shared fixed-window counters for every backend replica.
 -- `subject_hash` is an HMAC-SHA256 digest. Raw IPs, emails, usernames and reset
 -- tokens must never be written to this table.
-CREATE TABLE IF NOT EXISTS public.auth_rate_limit_buckets (
+-- The runner executes this patch only while its ledger record is pending. Never
+-- bless a table or index left by an interrupted/manual execution as complete.
+DO $preexisting_guard$
+BEGIN
+  IF to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 patch: required owner/runtime role cerp_app is missing';
+  END IF;
+
+  IF to_regclass('public.auth_rate_limit_buckets') IS NOT NULL
+     OR to_regclass('public.auth_rate_limit_buckets_expires_at_idx') IS NOT NULL THEN
+    RAISE EXCEPTION
+      'SEC-CERP-0005 patch: pre-existing rate-limit artifact found while migration is pending; reconcile it manually';
+  END IF;
+END
+$preexisting_guard$;
+
+CREATE TABLE public.auth_rate_limit_buckets (
   scope text NOT NULL,
   subject_hash character(64) NOT NULL,
   request_count integer NOT NULL,
@@ -26,15 +42,81 @@ COMMENT ON TABLE public.auth_rate_limit_buckets IS
 COMMENT ON COLUMN public.auth_rate_limit_buckets.subject_hash IS
   'HMAC-SHA256(scope and normalized subject); never a raw IP, email, username or token';
 
-CREATE INDEX IF NOT EXISTS auth_rate_limit_buckets_expires_at_idx
+CREATE INDEX auth_rate_limit_buckets_expires_at_idx
   ON public.auth_rate_limit_buckets (expires_at);
 
-DO $grant$
+-- The real cerp_test/cerp_prod contract owns public application tables with
+-- cerp_app. Reset the ACL after ownership transfer so creator default ACLs
+-- cannot leak privileges to PUBLIC or another role.
+ALTER TABLE public.auth_rate_limit_buckets OWNER TO cerp_app;
+REVOKE ALL ON public.auth_rate_limit_buckets FROM PUBLIC;
+
+DO $acl_contract$
+DECLARE
+  unexpected_grantee name;
+  total_acl_entries integer;
+  expected_acl_entries integer;
+  effective_privileges_are_expected boolean;
 BEGIN
-  IF to_regrole('cerp_app') IS NOT NULL THEN
-    GRANT SELECT, INSERT, UPDATE, DELETE ON public.auth_rate_limit_buckets TO cerp_app;
+  FOR unexpected_grantee IN
+    SELECT DISTINCT grantee_role.rolname
+    FROM pg_class relation_metadata
+    CROSS JOIN LATERAL aclexplode(
+      COALESCE(
+        relation_metadata.relacl,
+        acldefault('r', relation_metadata.relowner)
+      )
+    ) acl_entry
+    JOIN pg_roles grantee_role ON grantee_role.oid = acl_entry.grantee
+    WHERE relation_metadata.oid = 'public.auth_rate_limit_buckets'::regclass
+      AND acl_entry.grantee <> relation_metadata.relowner
+  LOOP
+    EXECUTE format(
+      'REVOKE ALL ON public.auth_rate_limit_buckets FROM %I CASCADE',
+      unexpected_grantee
+    );
+  END LOOP;
+
+  -- Ownership has unavoidable object-control and regrant authority. Ordinary
+  -- table privileges are nevertheless reduced to the four runtime DML rights,
+  -- without grant option, and contain no other grantee.
+  REVOKE ALL ON public.auth_rate_limit_buckets FROM cerp_app;
+  GRANT SELECT, INSERT, UPDATE, DELETE ON public.auth_rate_limit_buckets TO cerp_app;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE
+           acl_entry.grantor = to_regrole('cerp_app')
+           AND acl_entry.grantee = to_regrole('cerp_app')
+           AND acl_entry.privilege_type = ANY (
+             ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE']
+           )
+           AND NOT acl_entry.is_grantable
+         )::integer
+    INTO total_acl_entries, expected_acl_entries
+  FROM pg_class relation_metadata
+  CROSS JOIN LATERAL aclexplode(
+    COALESCE(
+      relation_metadata.relacl,
+      acldefault('r', relation_metadata.relowner)
+    )
+  ) acl_entry
+  WHERE relation_metadata.oid = 'public.auth_rate_limit_buckets'::regclass;
+
+  SELECT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'SELECT')
+         AND has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'INSERT')
+         AND has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'UPDATE')
+         AND has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'DELETE')
+         AND NOT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'TRUNCATE')
+         AND NOT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'REFERENCES')
+         AND NOT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'TRIGGER')
+    INTO effective_privileges_are_expected;
+
+  IF total_acl_entries <> 4
+     OR expected_acl_entries <> 4
+     OR effective_privileges_are_expected IS NOT TRUE THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 patch: exact cerp_app ACL contract was not established';
   END IF;
 END
-$grant$;
+$acl_contract$;
 
 COMMIT;

--- a/db/patches/support/20260804_auth_rate_limit_buckets.preflight.sql
+++ b/db/patches/support/20260804_auth_rate_limit_buckets.preflight.sql
@@ -1,10 +1,15 @@
 \set ON_ERROR_STOP on
 
 -- Read-only preflight. Run against cerp_test first, then cerp_prod only after
--- the documented human approval and backup gate.
+-- the automated backup and release gates have passed.
 DO $preflight$
 DECLARE
   missing_columns text[];
+  registered_sha256 text;
+  registry_entry_exists boolean := FALSE;
+  target_table_exists boolean;
+  target_index_exists boolean;
+  expected_sha256 constant text := 'f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2';
 BEGIN
   IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
     RAISE EXCEPTION 'SEC-CERP-0005 preflight: unexpected database %', current_database();
@@ -14,7 +19,34 @@ BEGIN
     RAISE EXCEPTION 'SEC-CERP-0005 preflight: role cerp_app is missing';
   END IF;
 
-  IF to_regclass('public.auth_rate_limit_buckets') IS NOT NULL THEN
+  target_table_exists := to_regclass('public.auth_rate_limit_buckets') IS NOT NULL;
+  target_index_exists := to_regclass('public.auth_rate_limit_buckets_expires_at_idx') IS NOT NULL;
+
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    SELECT sha256
+      INTO registered_sha256
+    FROM public.cerp_schema_migrations
+    WHERE filename = '20260804_auth_rate_limit_buckets.sql';
+    registry_entry_exists := FOUND;
+  END IF;
+
+  IF (target_table_exists OR target_index_exists) AND NOT registry_entry_exists THEN
+    RAISE EXCEPTION
+      'SEC-CERP-0005 preflight: target table or index exists without its migration registry entry';
+  END IF;
+
+  IF registry_entry_exists AND registered_sha256 IS DISTINCT FROM expected_sha256 THEN
+    RAISE EXCEPTION
+      'SEC-CERP-0005 preflight: registered checksum mismatch (expected %, found %)',
+      expected_sha256,
+      registered_sha256;
+  END IF;
+
+  IF registry_entry_exists AND (NOT target_table_exists OR NOT target_index_exists) THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 preflight: patch is registered but its table or index is missing';
+  END IF;
+
+  IF target_table_exists THEN
     SELECT array_agg(required.column_name ORDER BY required.column_name)
       INTO missing_columns
     FROM (
@@ -44,4 +76,6 @@ $preflight$;
 SELECT
   current_database() AS database_name,
   to_regclass('public.auth_rate_limit_buckets') AS existing_table,
+  to_regclass('public.auth_rate_limit_buckets_expires_at_idx') AS existing_index,
+  to_regclass('public.cerp_schema_migrations') AS migration_registry,
   'SEC-CERP-0005 preflight passed (read-only)' AS result;

--- a/db/patches/support/20260804_auth_rate_limit_buckets.rollback.sql
+++ b/db/patches/support/20260804_auth_rate_limit_buckets.rollback.sql
@@ -1,15 +1,372 @@
 \set ON_ERROR_STOP on
 
--- Destructive rollback is deliberately restricted to cerp_test. Production
+-- Destructive rollback is deliberately restricted to cerp_dev/cerp_test. Production
 -- rollback reverts the application release and leaves the inert table in place.
-DO $guard$
+BEGIN;
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+DO $environment_guard$
 BEGIN
-  IF current_database() <> 'cerp_test' THEN
-    RAISE EXCEPTION 'SEC-CERP-0005 rollback is restricted to cerp_test';
+  IF current_database() NOT IN ('cerp_dev', 'cerp_test') THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback is restricted to cerp_dev/cerp_test';
   END IF;
 END
-$guard$;
+$environment_guard$;
 
-BEGIN;
-DROP TABLE IF EXISTS public.auth_rate_limit_buckets;
+-- Match the runner's transaction-scoped serialization key before observing
+-- any target state.
+SELECT pg_advisory_xact_lock(hashtext('cerp_schema_migrations'));
+
+-- Preserve the first observation across top-level statements. PostgreSQL READ
+-- COMMITTED gives the later validation block a fresh snapshot.
+SELECT
+  set_config(
+    'cerp.rollback_initial_table_exists',
+    (observed.target_oid IS NOT NULL)::text,
+    true
+  ),
+  set_config(
+    'cerp.rollback_initial_table_oid',
+    COALESCE(observed.target_oid::text, ''),
+    true
+  )
+FROM (
+  SELECT to_regclass('public.auth_rate_limit_buckets')::oid AS target_oid
+) observed;
+
+-- If the table existed at the first observation, take and retain the strongest
+-- relation lock before the fresh-snapshot structural inspection below.
+DO $table_lock$
+BEGIN
+  IF current_setting('cerp.rollback_initial_table_exists')::boolean THEN
+    LOCK TABLE public.auth_rate_limit_buckets IN ACCESS EXCLUSIVE MODE;
+  END IF;
+END
+$table_lock$;
+
+-- A privileged concurrent DROP/recreate can retain the relation name while
+-- changing its identity. Only the exact OID observed before the lock is ever
+-- eligible for rollback, and the lock must be held on that OID.
+DO $table_identity_guard$
+DECLARE
+  initial_table_exists boolean := current_setting(
+    'cerp.rollback_initial_table_exists'
+  )::boolean;
+  initial_table_oid oid := NULLIF(
+    current_setting('cerp.rollback_initial_table_oid'),
+    ''
+  )::oid;
+  current_table_oid oid := to_regclass('public.auth_rate_limit_buckets')::oid;
+BEGIN
+  IF initial_table_exists AND (
+    current_table_oid IS DISTINCT FROM initial_table_oid
+    OR NOT EXISTS (
+      SELECT 1
+      FROM pg_locks
+      WHERE locktype = 'relation'
+        AND pid = pg_backend_pid()
+        AND relation = initial_table_oid
+        AND mode = 'AccessExclusiveLock'
+        AND granted
+    )
+  ) THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: initial table identity changed before the exclusive lock; refusing rollback';
+  END IF;
+END
+$table_identity_guard$;
+
+-- Lock an existing provenance row in its own command. Besides preserving the
+-- table-before-ledger lock order, this makes the following validation command
+-- start with a fresh snapshot after any wait.
+DO $registry_lock$
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    PERFORM 1
+    FROM public.cerp_schema_migrations
+    WHERE filename = '20260804_auth_rate_limit_buckets.sql'
+    FOR UPDATE;
+  END IF;
+END
+$registry_lock$;
+
+DO $rollback$
+DECLARE
+  expected_sha256 constant text := 'f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2';
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  initial_table_exists boolean := current_setting(
+    'cerp.rollback_initial_table_exists'
+  )::boolean;
+  table_exists boolean;
+  expiry_index_exists boolean;
+  registry_exists boolean;
+  registry_entry_exists boolean := FALSE;
+  table_metadata_is_expected boolean;
+  table_owner_oid oid;
+  pk_definition text;
+  total_constraint_count integer;
+  required_constraint_count integer;
+  total_column_count integer;
+  expected_column_count integer;
+  total_index_count integer;
+  expiry_index_is_expected boolean;
+  user_trigger_count integer;
+  policy_count integer;
+  inheritance_parent_count integer;
+  total_acl_entries integer;
+  expected_acl_entries integer;
+  column_acl_count integer;
+  owner_effective_privileges_are_expected boolean;
+  deleted_registry_rows integer;
+BEGIN
+  -- This is a new command snapshot after the optional table/registry locks.
+  -- A table that was absent initially is never eligible for this rollback.
+  table_exists := to_regclass('public.auth_rate_limit_buckets') IS NOT NULL;
+  expiry_index_exists := to_regclass('public.auth_rate_limit_buckets_expires_at_idx') IS NOT NULL;
+  registry_exists := to_regclass('public.cerp_schema_migrations') IS NOT NULL;
+
+  IF registry_exists THEN
+    SELECT sha256, applied_at
+      INTO registered_sha256, registered_applied_at
+    FROM public.cerp_schema_migrations
+    WHERE filename = '20260804_auth_rate_limit_buckets.sql'
+    FOR UPDATE;
+    registry_entry_exists := FOUND;
+  END IF;
+
+  -- A table absent at the first observation can never enter the destructive
+  -- branch. A no-op is valid only when all target artifacts are still absent.
+  IF NOT initial_table_exists THEN
+    IF table_exists THEN
+      RAISE EXCEPTION 'SEC-CERP-0005 rollback: target table appeared concurrently before it could be locked; refusing rollback';
+    END IF;
+    IF registry_entry_exists OR expiry_index_exists THEN
+      RAISE EXCEPTION 'SEC-CERP-0005 rollback: table is missing but its registry entry or named index remains';
+    END IF;
+    RETURN;
+  END IF;
+
+  IF NOT table_exists THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: initially observed table disappeared after the exclusive lock';
+  END IF;
+
+  IF NOT registry_exists THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: migration registry is missing';
+  END IF;
+
+  IF NOT registry_entry_exists THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: exact migration registry entry is missing';
+  END IF;
+
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 THEN
+    RAISE EXCEPTION
+      'SEC-CERP-0005 rollback: registered checksum mismatch (expected %, found %)',
+      expected_sha256,
+      registered_sha256;
+  END IF;
+
+  IF registered_applied_at IS NULL THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: migration applied_at is missing';
+  END IF;
+
+  SELECT relkind = 'r'
+         AND NOT relispartition
+         AND NOT relrowsecurity
+         AND NOT relforcerowsecurity,
+         relowner
+    INTO table_metadata_is_expected, table_owner_oid
+  FROM pg_class
+  WHERE oid = 'public.auth_rate_limit_buckets'::regclass;
+
+  IF table_metadata_is_expected IS NOT TRUE THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: table kind, partitioning or row security is altered';
+  END IF;
+
+  IF table_owner_oid IS DISTINCT FROM to_regrole('cerp_app') THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: table owner is unexpected (expected cerp_app)';
+  END IF;
+
+  SELECT pg_get_constraintdef(oid)
+    INTO pk_definition
+  FROM pg_constraint
+  WHERE conrelid = 'public.auth_rate_limit_buckets'::regclass
+    AND contype = 'p';
+
+  IF pk_definition IS DISTINCT FROM 'PRIMARY KEY (scope, subject_hash)' THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: expected composite primary key is missing';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO total_constraint_count
+  FROM pg_constraint
+  WHERE conrelid = 'public.auth_rate_limit_buckets'::regclass;
+
+  SELECT COUNT(*)::integer
+    INTO required_constraint_count
+  FROM pg_constraint
+  WHERE conrelid = 'public.auth_rate_limit_buckets'::regclass
+    AND contype = 'c'
+    AND convalidated
+    AND conname = ANY (ARRAY[
+      'auth_rate_limit_buckets_scope_ck',
+      'auth_rate_limit_buckets_subject_hash_ck',
+      'auth_rate_limit_buckets_count_ck',
+      'auth_rate_limit_buckets_window_ck'
+    ])
+    AND pg_get_constraintdef(oid) = CASE conname
+      WHEN 'auth_rate_limit_buckets_scope_ck'
+        THEN 'CHECK ((scope ~ ''^[a-z][a-z0-9:_-]{2,63}$''::text))'
+      WHEN 'auth_rate_limit_buckets_subject_hash_ck'
+        THEN 'CHECK ((subject_hash ~ ''^[0-9a-f]{64}$''::text))'
+      WHEN 'auth_rate_limit_buckets_count_ck'
+        THEN 'CHECK ((request_count > 0))'
+      WHEN 'auth_rate_limit_buckets_window_ck'
+        THEN 'CHECK ((expires_at > window_started_at))'
+    END;
+
+  IF total_constraint_count <> 5 OR required_constraint_count <> 4 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: constraints are incomplete, altered or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE
+           (column_name = 'scope'
+             AND data_type = 'text'
+             AND is_nullable = 'NO'
+             AND column_default IS NULL)
+           OR (column_name = 'subject_hash'
+             AND data_type = 'character'
+             AND character_maximum_length = 64
+             AND is_nullable = 'NO'
+             AND column_default IS NULL)
+           OR (column_name = 'request_count'
+             AND data_type = 'integer'
+             AND is_nullable = 'NO'
+             AND column_default IS NULL)
+           OR (column_name IN ('window_started_at', 'expires_at')
+             AND data_type = 'timestamp with time zone'
+             AND is_nullable = 'NO'
+             AND column_default IS NULL)
+           OR (column_name = 'updated_at'
+             AND data_type = 'timestamp with time zone'
+             AND is_nullable = 'NO'
+             AND column_default = 'statement_timestamp()')
+         )::integer
+    INTO total_column_count, expected_column_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = 'auth_rate_limit_buckets';
+
+  IF total_column_count <> 6 OR expected_column_count <> 6 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: expected columns are incomplete or altered';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO total_index_count
+  FROM pg_index
+  WHERE indrelid = 'public.auth_rate_limit_buckets'::regclass;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM pg_index index_metadata
+    JOIN pg_class index_class ON index_class.oid = index_metadata.indexrelid
+    JOIN pg_am access_method ON access_method.oid = index_class.relam
+    WHERE index_metadata.indrelid = 'public.auth_rate_limit_buckets'::regclass
+      AND index_metadata.indexrelid = to_regclass('public.auth_rate_limit_buckets_expires_at_idx')
+      AND index_metadata.indisvalid
+      AND index_metadata.indisready
+      AND NOT index_metadata.indisunique
+      AND index_metadata.indpred IS NULL
+      AND index_metadata.indexprs IS NULL
+      AND index_metadata.indnkeyatts = 1
+      AND index_metadata.indnatts = 1
+      AND access_method.amname = 'btree'
+      AND pg_get_indexdef(index_metadata.indexrelid, 1, TRUE) = 'expires_at'
+  ) INTO expiry_index_is_expected;
+
+  IF total_index_count <> 2 OR NOT expiry_index_is_expected THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: indexes are incomplete, altered or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO user_trigger_count
+  FROM pg_trigger
+  WHERE tgrelid = 'public.auth_rate_limit_buckets'::regclass
+    AND NOT tgisinternal;
+
+  SELECT COUNT(*)::integer
+    INTO policy_count
+  FROM pg_policy
+  WHERE polrelid = 'public.auth_rate_limit_buckets'::regclass;
+
+  SELECT COUNT(*)::integer
+    INTO inheritance_parent_count
+  FROM pg_inherits
+  WHERE inhrelid = 'public.auth_rate_limit_buckets'::regclass;
+
+  IF user_trigger_count <> 0 OR policy_count <> 0 OR inheritance_parent_count <> 0 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: triggers, row policies or inheritance are additional';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE
+           acl_entry.grantor = to_regrole('cerp_app')
+           AND acl_entry.grantee = to_regrole('cerp_app')
+           AND acl_entry.privilege_type = ANY (
+             ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE']
+           )
+           AND NOT acl_entry.is_grantable
+         )::integer
+    INTO total_acl_entries, expected_acl_entries
+  FROM pg_class relation_metadata
+  CROSS JOIN LATERAL aclexplode(
+    COALESCE(
+      relation_metadata.relacl,
+      acldefault('r', relation_metadata.relowner)
+    )
+  ) acl_entry
+  WHERE relation_metadata.oid = 'public.auth_rate_limit_buckets'::regclass;
+
+  IF total_acl_entries <> 4 OR expected_acl_entries <> 4 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: table ACL has PUBLIC, an unexpected grantee, extra privileges, grant options or missing cerp_app DML';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO column_acl_count
+  FROM pg_attribute
+  WHERE attrelid = 'public.auth_rate_limit_buckets'::regclass
+    AND attnum > 0
+    AND NOT attisdropped
+    AND attacl IS NOT NULL;
+
+  IF column_acl_count <> 0 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: column ACLs are unexpected';
+  END IF;
+
+  SELECT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'SELECT')
+         AND has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'INSERT')
+         AND has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'UPDATE')
+         AND has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'DELETE')
+         AND NOT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'TRUNCATE')
+         AND NOT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'REFERENCES')
+         AND NOT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'TRIGGER')
+    INTO owner_effective_privileges_are_expected;
+
+  IF owner_effective_privileges_are_expected IS NOT TRUE THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: cerp_app effective table privileges are not exact DML';
+  END IF;
+
+  DROP TABLE public.auth_rate_limit_buckets;
+
+  DELETE FROM public.cerp_schema_migrations
+  WHERE filename = '20260804_auth_rate_limit_buckets.sql'
+    AND sha256 = expected_sha256;
+
+  GET DIAGNOSTICS deleted_registry_rows = ROW_COUNT;
+  IF deleted_registry_rows <> 1 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 rollback: exact migration registry entry was not removed';
+  END IF;
+END
+$rollback$;
+
 COMMIT;

--- a/db/patches/support/20260804_auth_rate_limit_buckets.verify.sql
+++ b/db/patches/support/20260804_auth_rate_limit_buckets.verify.sql
@@ -4,9 +4,25 @@
 -- deterministic application tests; this script never inserts identifying data.
 DO $verify$
 DECLARE
+  table_metadata_is_expected boolean;
+  table_owner_oid oid;
   pk_definition text;
+  total_constraint_count integer;
   required_constraint_count integer;
-  hash_length integer;
+  total_column_count integer;
+  expected_column_count integer;
+  total_index_count integer;
+  expiry_index_is_expected boolean;
+  user_trigger_count integer;
+  policy_count integer;
+  inheritance_parent_count integer;
+  total_acl_entries integer;
+  expected_acl_entries integer;
+  column_acl_count integer;
+  owner_effective_privileges_are_expected boolean;
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  expected_sha256 constant text := 'f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2';
 BEGIN
   IF current_database() NOT IN ('cerp_test', 'cerp_prod') THEN
     RAISE EXCEPTION 'SEC-CERP-0005 verify: unexpected database %', current_database();
@@ -16,58 +32,235 @@ BEGIN
     RAISE EXCEPTION 'SEC-CERP-0005 verify: table is missing';
   END IF;
 
+  IF to_regclass('public.cerp_schema_migrations') IS NULL THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: migration registry is missing';
+  END IF;
+
+  IF to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: role cerp_app is missing';
+  END IF;
+
+  SELECT sha256, applied_at
+    INTO registered_sha256, registered_applied_at
+  FROM public.cerp_schema_migrations
+  WHERE filename = '20260804_auth_rate_limit_buckets.sql';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: migration registry entry is missing';
+  END IF;
+
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 THEN
+    RAISE EXCEPTION
+      'SEC-CERP-0005 verify: registered checksum mismatch (expected %, found %)',
+      expected_sha256,
+      registered_sha256;
+  END IF;
+
+  IF registered_applied_at IS NULL THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: migration applied_at is missing';
+  END IF;
+
+  SELECT relkind = 'r'
+         AND NOT relispartition
+         AND NOT relrowsecurity
+         AND NOT relforcerowsecurity,
+         relowner
+    INTO table_metadata_is_expected, table_owner_oid
+  FROM pg_class
+  WHERE oid = 'public.auth_rate_limit_buckets'::regclass;
+
+  IF table_metadata_is_expected IS NOT TRUE THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: table kind, partitioning or row security is altered';
+  END IF;
+
+  IF table_owner_oid IS DISTINCT FROM to_regrole('cerp_app') THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: table owner is unexpected (expected cerp_app)';
+  END IF;
+
   SELECT pg_get_constraintdef(oid)
     INTO pk_definition
   FROM pg_constraint
   WHERE conrelid = 'public.auth_rate_limit_buckets'::regclass
     AND contype = 'p';
 
-  IF pk_definition IS NULL OR pk_definition NOT LIKE '%(scope, subject_hash)%' THEN
+  IF pk_definition IS DISTINCT FROM 'PRIMARY KEY (scope, subject_hash)' THEN
     RAISE EXCEPTION 'SEC-CERP-0005 verify: expected composite primary key is missing';
   END IF;
+
+  SELECT COUNT(*)::integer
+    INTO total_constraint_count
+  FROM pg_constraint
+  WHERE conrelid = 'public.auth_rate_limit_buckets'::regclass;
 
   SELECT COUNT(*)::integer
     INTO required_constraint_count
   FROM pg_constraint
   WHERE conrelid = 'public.auth_rate_limit_buckets'::regclass
+    AND contype = 'c'
     AND convalidated
     AND conname = ANY (ARRAY[
       'auth_rate_limit_buckets_scope_ck',
       'auth_rate_limit_buckets_subject_hash_ck',
       'auth_rate_limit_buckets_count_ck',
       'auth_rate_limit_buckets_window_ck'
-    ]);
+    ])
+    AND pg_get_constraintdef(oid) = CASE conname
+      WHEN 'auth_rate_limit_buckets_scope_ck'
+        THEN 'CHECK ((scope ~ ''^[a-z][a-z0-9:_-]{2,63}$''::text))'
+      WHEN 'auth_rate_limit_buckets_subject_hash_ck'
+        THEN 'CHECK ((subject_hash ~ ''^[0-9a-f]{64}$''::text))'
+      WHEN 'auth_rate_limit_buckets_count_ck'
+        THEN 'CHECK ((request_count > 0))'
+      WHEN 'auth_rate_limit_buckets_window_ck'
+        THEN 'CHECK ((expires_at > window_started_at))'
+    END;
 
-  IF required_constraint_count <> 4 THEN
-    RAISE EXCEPTION 'SEC-CERP-0005 verify: required validated checks are incomplete';
+  IF total_constraint_count <> 5 OR required_constraint_count <> 4 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: constraints are incomplete, altered or additional';
   END IF;
 
-  SELECT character_maximum_length
-    INTO hash_length
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE
+           (column_name = 'scope'
+             AND data_type = 'text'
+             AND is_nullable = 'NO'
+             AND column_default IS NULL)
+           OR (column_name = 'subject_hash'
+             AND data_type = 'character'
+             AND character_maximum_length = 64
+             AND is_nullable = 'NO'
+             AND column_default IS NULL)
+           OR (column_name = 'request_count'
+             AND data_type = 'integer'
+             AND is_nullable = 'NO'
+             AND column_default IS NULL)
+           OR (column_name IN ('window_started_at', 'expires_at')
+             AND data_type = 'timestamp with time zone'
+             AND is_nullable = 'NO'
+             AND column_default IS NULL)
+           OR (column_name = 'updated_at'
+             AND data_type = 'timestamp with time zone'
+             AND is_nullable = 'NO'
+             AND column_default = 'statement_timestamp()')
+         )::integer
+    INTO total_column_count, expected_column_count
   FROM information_schema.columns
   WHERE table_schema = 'public'
-    AND table_name = 'auth_rate_limit_buckets'
-    AND column_name = 'subject_hash';
+    AND table_name = 'auth_rate_limit_buckets';
 
-  IF hash_length IS DISTINCT FROM 64 THEN
-    RAISE EXCEPTION 'SEC-CERP-0005 verify: subject_hash must be character(64)';
+  IF total_column_count <> 6 OR expected_column_count <> 6 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: columns, types, nullability or defaults are altered';
   END IF;
 
-  IF to_regclass('public.auth_rate_limit_buckets_expires_at_idx') IS NULL THEN
-    RAISE EXCEPTION 'SEC-CERP-0005 verify: expiry index is missing';
+  SELECT COUNT(*)::integer
+    INTO total_index_count
+  FROM pg_index
+  WHERE indrelid = 'public.auth_rate_limit_buckets'::regclass;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM pg_index index_metadata
+    JOIN pg_class index_class ON index_class.oid = index_metadata.indexrelid
+    JOIN pg_am access_method ON access_method.oid = index_class.relam
+    WHERE index_metadata.indrelid = 'public.auth_rate_limit_buckets'::regclass
+      AND index_metadata.indexrelid = to_regclass('public.auth_rate_limit_buckets_expires_at_idx')
+      AND index_metadata.indisvalid
+      AND index_metadata.indisready
+      AND NOT index_metadata.indisunique
+      AND index_metadata.indpred IS NULL
+      AND index_metadata.indexprs IS NULL
+      AND index_metadata.indnkeyatts = 1
+      AND index_metadata.indnatts = 1
+      AND access_method.amname = 'btree'
+      AND pg_get_indexdef(index_metadata.indexrelid, 1, TRUE) = 'expires_at'
+  ) INTO expiry_index_is_expected;
+
+  IF total_index_count <> 2 OR NOT expiry_index_is_expected THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: indexes are incomplete, altered or additional';
   END IF;
 
-  IF has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'SELECT') IS NOT TRUE
-     OR has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'INSERT') IS NOT TRUE
-     OR has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'UPDATE') IS NOT TRUE
-     OR has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'DELETE') IS NOT TRUE THEN
-    RAISE EXCEPTION 'SEC-CERP-0005 verify: cerp_app privileges are incomplete';
+  SELECT COUNT(*)::integer
+    INTO user_trigger_count
+  FROM pg_trigger
+  WHERE tgrelid = 'public.auth_rate_limit_buckets'::regclass
+    AND NOT tgisinternal;
+
+  SELECT COUNT(*)::integer
+    INTO policy_count
+  FROM pg_policy
+  WHERE polrelid = 'public.auth_rate_limit_buckets'::regclass;
+
+  SELECT COUNT(*)::integer
+    INTO inheritance_parent_count
+  FROM pg_inherits
+  WHERE inhrelid = 'public.auth_rate_limit_buckets'::regclass;
+
+  IF user_trigger_count <> 0 OR policy_count <> 0 OR inheritance_parent_count <> 0 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: triggers, row policies or inheritance are additional';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE
+           acl_entry.grantor = to_regrole('cerp_app')
+           AND acl_entry.grantee = to_regrole('cerp_app')
+           AND acl_entry.privilege_type = ANY (
+             ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE']
+           )
+           AND NOT acl_entry.is_grantable
+         )::integer
+    INTO total_acl_entries, expected_acl_entries
+  FROM pg_class relation_metadata
+  CROSS JOIN LATERAL aclexplode(
+    COALESCE(
+      relation_metadata.relacl,
+      acldefault('r', relation_metadata.relowner)
+    )
+  ) acl_entry
+  WHERE relation_metadata.oid = 'public.auth_rate_limit_buckets'::regclass;
+
+  IF total_acl_entries <> 4 OR expected_acl_entries <> 4 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: table ACL has PUBLIC, an unexpected grantee, extra privileges, grant options or missing cerp_app DML';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO column_acl_count
+  FROM pg_attribute
+  WHERE attrelid = 'public.auth_rate_limit_buckets'::regclass
+    AND attnum > 0
+    AND NOT attisdropped
+    AND attacl IS NOT NULL;
+
+  IF column_acl_count <> 0 THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: column ACLs are unexpected';
+  END IF;
+
+  SELECT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'SELECT')
+         AND has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'INSERT')
+         AND has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'UPDATE')
+         AND has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'DELETE')
+         AND NOT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'TRUNCATE')
+         AND NOT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'REFERENCES')
+         AND NOT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'TRIGGER')
+    INTO owner_effective_privileges_are_expected;
+
+  IF owner_effective_privileges_are_expected IS NOT TRUE THEN
+    RAISE EXCEPTION 'SEC-CERP-0005 verify: cerp_app effective table privileges are not exact DML';
   END IF;
 END
 $verify$;
 
 SELECT
   current_database() AS database_name,
+  (
+    SELECT sha256
+    FROM public.cerp_schema_migrations
+    WHERE filename = '20260804_auth_rate_limit_buckets.sql'
+  ) AS migration_sha256,
+  (
+    SELECT applied_at
+    FROM public.cerp_schema_migrations
+    WHERE filename = '20260804_auth_rate_limit_buckets.sql'
+  ) AS migration_applied_at,
   COUNT(*) AS current_pseudonymous_buckets,
   MIN(expires_at) AS oldest_expiry,
   MAX(expires_at) AS newest_expiry,

--- a/docs/auth-rate-limit-migration-evidence.md
+++ b/docs/auth-rate-limit-migration-evidence.md
@@ -1,0 +1,100 @@
+# SEC-CERP-0005 migration validation record
+
+- Date: 2026-08-04
+- Candidate branch: `fix/gpt56-0013-rate-limit-migration-ledger`
+- Base commit: `58ffacb5c9a216a60655a88042b51da33fb42bbf`
+- Patch: `20260804_auth_rate_limit_buckets.sql`
+- Canonical LF SHA-256: `f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2`
+
+## Scope and interpretation
+
+This record covers the uncommitted candidate diff exercised in disposable local
+databases named `cerp_test` and `cerp_dev`. It does **not** claim that a shared or
+deployed `cerp_test` or production database was changed. The authorized release
+record must append the non-destructive shared-`cerp_test` checks below before
+promotion. No connection string, password, HMAC key or other secret was captured.
+
+## Disposable database results
+
+The candidate was exercised on PostgreSQL 16.14 and PostgreSQL 17.10. The real
+repository inventory contained 127 primary SQL patches.
+
+On a pristine `cerp_test` database for each PostgreSQL version:
+
+- read-only preflight passed;
+- `up --dry-run --only 20260804_auth_rate_limit_buckets.sql` reported 0 applied,
+  127 pending, 0 checksum mismatches, and exactly one selected patch to apply;
+- `up --only 20260804_auth_rate_limit_buckets.sql` applied only the selected patch;
+- `status --check --only 20260804_auth_rate_limit_buckets.sql` reported 1 applied,
+  126 unrelated patches still pending, 0 checksum mismatches, and selected status
+  `applied`;
+- the ledger contained exactly one row: the selected patch with the canonical
+  checksum and non-null `applied_at`; no unrelated patch was registered;
+- read-only exact verification passed;
+- a second identical `up --only` invocation applied 0 patches and left the
+  one-row ledger unchanged;
+- exact rollback removed the table and selected ledger row together, and a
+  second rollback against the fully absent state was a no-op (also replayed on
+  PostgreSQL 17.10).
+
+PostgreSQL 16 refusal checks passed as listed below. The four ACL/owner cases
+were also replayed on PostgreSQL 17.10, including refusal by both read-only
+verification and destructive rollback:
+
+| Case | Expected and observed result |
+|---|---|
+| Target table exists without the target ledger row | Preflight refused |
+| Named expiry index exists without the target ledger row | Preflight refused |
+| `request_count` changed from integer to text | Exact verification refused |
+| Count constraint replaced by same-named `CHECK (TRUE)` | Exact verification refused |
+| Expiry index recreated on `scope` under the expected name | Exact verification refused |
+| Another applied inventory file has a different checksum | Immutable `--only` refused before patch execution |
+| Alternate `--patch-dir` supplied with immutable `--only` | Argument validation refused before inventory loading |
+| Creator default privileges grant table rights to `PUBLIC` and `rogue_reader` | Patch produced owner `cerp_app`, removed both grants, stored exactly `cerp_app=arwd/cerp_app`, and exact verification passed |
+| Owner changed from `cerp_app` to `rogue_owner` | Exact verification and rollback refused |
+| `ALL` granted to `PUBLIC` after application | Exact verification and rollback refused |
+| `SELECT` granted to `rogue_reader` after application | Exact verification and rollback refused |
+
+For the accepted ACL, effective `cerp_app` ordinary table rights were confirmed
+true for `SELECT`/`INSERT`/`UPDATE`/`DELETE` and false for
+`TRUNCATE`/`REFERENCES`/`TRIGGER`. Ownership still gives `cerp_app` inherent
+alter/drop/regrant authority; no claim is made that ACL revokes remove ownership
+itself. Exact rollback succeeded on the restored contract in both PostgreSQL
+versions and removed the table and target ledger row together.
+
+Rollback concurrency was exercised only in disposable PostgreSQL 16 `cerp_dev`:
+
+- a transaction holding the runner's `cerp_schema_migrations` advisory key kept
+  rollback blocked throughout a 300 ms observation interval; after release,
+  exact rollback removed both table and ledger row atomically;
+- an `ACCESS SHARE` holder kept rollback's `ACCESS EXCLUSIVE` table lock blocked
+  throughout a 300 ms observation interval; after release, exact rollback
+  removed both table and ledger row;
+- with the table initially absent, rollback was paused on the provenance row and
+  another session created the target table before the fresh-snapshot recheck.
+  Rollback raised the dedicated concurrent-appearance refusal and preserved both
+  the newly created table (including its race-marker column) and the ledger row;
+- with the rollback session default deliberately set to `REPEATABLE READ`, the
+  script forced `READ COMMITTED`, observed OID 16694, waited on the original
+  relation lock, and then refused a same-name replacement with OID 16707. The
+  replacement table, its marker column and the ledger row were all preserved.
+
+The PostgreSQL containers and disposable databases used for this record are
+temporary validation fixtures and are removed at the end of the final gate run.
+
+## Shared `cerp_test` evidence to append to the release record
+
+After the authorized runner application, execute only these non-destructive
+checks. Keep `DATABASE_URL` in the environment and do not echo it:
+
+```text
+npm run db:patches:status -- --check --only 20260804_auth_rate_limit_buckets.sql
+psql "$DATABASE_URL" -X -v ON_ERROR_STOP=1 -f db/patches/support/20260804_auth_rate_limit_buckets.preflight.sql
+psql "$DATABASE_URL" -X -v ON_ERROR_STOP=1 -f db/patches/support/20260804_auth_rate_limit_buckets.verify.sql
+```
+
+Append the command timestamp, PostgreSQL version, selected status, global
+inventory summary, preflight result and verification result to the authorized
+release record. The acceptance state is selected status `applied`, zero checksum
+mismatches, exact verification success, and unrelated pending patches still
+unregistered. These commands do not alter schema or data.

--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -36,6 +36,33 @@ npm run db:patches:baseline
 Use `baseline` only after confirming the restored database already contains the
 schema represented by the current patch files.
 
+The runner owns `public.cerp_schema_migrations`; patch files must not insert a
+second, competing registry row. For `up`, it normalizes SQL line endings to LF
+for a platform-independent SHA-256, removes a supported outer `BEGIN`/`COMMIT`
+wrapper for execution, pins `standard_conforming_strings=on` transaction-locally
+so its lexer matches PostgreSQL, and commits the patch plus `filename`, `sha256`
+and `applied_at` together. A registry-write failure therefore rolls the patch back.
+`baseline` remains a separate metadata-only operation: it never executes patch
+SQL and is allowed only after the represented schema has been verified manually.
+
+For the rate-limit rollout, `--only 20260804_auth_rate_limit_buckets.sql` is an
+immutable selector: the runner accepts the exact basename only, verifies its
+canonical LF SHA-256, still evaluates the complete patch inventory for checksum
+mismatches, and applies zero or one selected patch according to its
+`pending`/`applied` status. The selector always reads the repository's canonical
+`db/patches` directory; it refuses `--patch-dir`, substituted directories and
+symbolic-link SQL files so a reduced inventory cannot conceal another applied
+checksum mismatch. `--only` is deliberately unavailable to `baseline`.
+
+The rate-limit table is owned by `cerp_app`. Its explicit table ACL is exactly
+`SELECT`/`INSERT`/`UPDATE`/`DELETE` for that role, with no grant option, no
+`PUBLIC` entry, no other grantee and no column ACL. The patch removes creator
+default-ACL leakage before recording the migration. Effective ordinary table
+rights are the same four DML privileges: `TRUNCATE`, `REFERENCES` and `TRIGGER`
+are revoked. PostgreSQL ownership still carries inherent alter/drop/regrant
+authority; verification and rollback account for that separately and reject
+every owner other than `cerp_app`.
+
 ## Rules
 
 - Before any database change, download or retrieve the latest SQL backup from
@@ -45,6 +72,8 @@ schema represented by the current patch files.
 - Prefer additive SQL changes.
 - Do not edit a patch file after it has been applied; add a new patch instead.
 - Review `checksum-mismatch` results before continuing.
+- Apply primary patch files through `db:patches:up`, not directly with `psql`,
+  so schema state and the migration registry cannot diverge.
 - Keep passwords and `DATABASE_URL` out of Git, logs, and tickets.
 
 ## Issue #446 - Stock functional scopes OLD/NEW

--- a/docs/runbooks/auth-rate-limit-deployment.md
+++ b/docs/runbooks/auth-rate-limit-deployment.md
@@ -1,18 +1,44 @@
 # Runbook — distributed authentication rate limits
 
-This runbook covers `SEC-CERP-0005`. It does not authorize a production change.
-Production backup, patching, deployment and secret configuration require the
-existing human approval gates.
+This runbook covers the controlled deployment and rollback gates for
+`SEC-CERP-0005`. Record environment-specific execution evidence in the release
+log; this document does not assert the current state of any deployed environment.
 
 ## Artifacts
 
 - patch: `db/patches/20260804_auth_rate_limit_buckets.sql`;
 - read-only preflight: `db/patches/support/20260804_auth_rate_limit_buckets.preflight.sql`;
 - read-only verification: `db/patches/support/20260804_auth_rate_limit_buckets.verify.sql`;
-- test-only destructive rollback: `db/patches/support/20260804_auth_rate_limit_buckets.rollback.sql`.
+- non-production destructive rollback: `db/patches/support/20260804_auth_rate_limit_buckets.rollback.sql`;
+- durable validation record: `docs/auth-rate-limit-migration-evidence.md`.
 
-No SQL from these files was executed while preparing this change. The automated
-evidence is static guard testing plus deterministic fake-store integration tests.
+The primary patch does not self-register. Apply it only through
+`npm run db:patches:up -- --only 20260804_auth_rate_limit_buckets.sql`: the runner records
+`20260804_auth_rate_limit_buckets.sql`, its canonical LF SHA-256
+`f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2`,
+and `applied_at` in the same transaction as the table change. The verify script
+checks all three fields against that runner-owned record. A pending patch refuses
+any pre-existing target table or index instead of registering a potentially
+partial artifact as complete.
+
+The table owner is deterministically `cerp_app`, matching the public-table
+ownership contract on `cerp_test` and `cerp_prod`. The patch revokes `PUBLIC`,
+removes any other table grants inherited from the creator's default privileges,
+and records an explicit ACL containing only `SELECT`, `INSERT`, `UPDATE` and
+`DELETE` for `cerp_app`, without grant option; effective `TRUNCATE`, `REFERENCES`
+and `TRIGGER` are revoked. PostgreSQL table owners still retain inherent object
+control, including the ability to alter/drop the table and regrant privileges;
+that ownership authority is accepted only because the exact owner is
+`cerp_app`. No other table or column ACL is allowed.
+
+Runner atomicity, migration guards, registry compensation and refusal paths are
+validated against disposable PostgreSQL 16 and, when available, PostgreSQL 17
+databases as part of release evidence; those databases are removed afterwards.
+
+Production execution requires an authorization recorded in the release log.
+This is an explicit governance gate, not an interactive runner prompt: once the
+controlled release is authorized, the commands below execute non-interactively
+and do not request the same decision again.
 
 ## Required configuration
 
@@ -50,22 +76,50 @@ characters; an absent or unexpected `NODE_ENV` never enables a public fallback.
 
 1. Confirm a current backup and recovery point for `cerp_test`.
 2. Run the preflight against `cerp_test`; it performs no writes.
-3. Apply the patch to `cerp_test` through the established patch process.
-4. Run the read-only verify script against `cerp_test`.
-5. Configure a non-production HMAC key on both test API instances.
-6. Deploy the same release to both test API instances.
-7. Exercise only synthetic identifiers reserved for testing. Confirm that a
+3. Run `npm run db:patches:up -- --dry-run --only 20260804_auth_rate_limit_buckets.sql`.
+   Review the complete inventory/checksum output and the selected pending/applied
+   status.
+4. Apply only with
+   `npm run db:patches:up -- --only 20260804_auth_rate_limit_buckets.sql`.
+   Do not execute the primary patch directly with `psql`, because that bypasses
+   the registry and immutable selector.
+5. Run the read-only verify script against `cerp_test`.
+6. Configure a non-production HMAC key on both test API instances.
+7. Deploy the same release to both test API instances.
+8. Exercise only synthetic identifiers reserved for testing. Confirm that a
    bucket consumed through instance A blocks through instance B, remains after
    restarting A, returns a numeric `Retry-After`, and expires after its window.
-8. Use the deterministic injected failing store from the automated tests; do
+9. Use the deterministic injected failing store from the automated tests; do
    not stop or disconnect the shared database. Confirm `503` for
    login/register/reset and generic `200` without mail for forgot-password.
-9. Confirm logs contain endpoint/outcome only and no synthetic identifier/IP.
+10. Confirm logs contain endpoint/outcome only and no synthetic identifier/IP.
 
-Promotion to production repeats backup, preflight, patch and verify only after
-explicit human approval. Apply the table before deploying code. Configure the
-same HMAC key on both deployments, deploy the two backends in a short controlled
-window, then confirm health and store-unavailable logs.
+Promotion to production repeats backup, preflight, patch and verify through the
+controlled release workflow. Apply the table before deploying code. Configure
+the same HMAC key on both deployments, deploy the two backends in a short
+controlled window, then confirm health and store-unavailable logs. Patch
+application uses the same immutable `--only 20260804_auth_rate_limit_buckets.sql`
+selector as `cerp_test`; an unscoped apply command is not part of this runbook.
+
+## Durable, non-destructive `cerp_test` evidence
+
+After application, capture these read-only checks in the authorized release
+record without printing `DATABASE_URL` or secret values:
+
+```text
+npm run db:patches:status -- --check --only 20260804_auth_rate_limit_buckets.sql
+psql "$DATABASE_URL" -X -v ON_ERROR_STOP=1 -f db/patches/support/20260804_auth_rate_limit_buckets.preflight.sql
+psql "$DATABASE_URL" -X -v ON_ERROR_STOP=1 -f db/patches/support/20260804_auth_rate_limit_buckets.verify.sql
+```
+
+The selected status must be `applied`, while unrelated pending patches remain
+pending and unregistered. Preflight and verify perform no schema/data writes;
+verify checks exact columns, types, nullability, defaults, normalized CHECK
+expressions, indexes, triggers, RLS/policies, owner, explicit table/column ACL,
+ledger SHA-256 and `applied_at`.
+The repository validation record linked above captures the reproducible
+disposable-database proof; the release log is the durable evidence for the
+specific deployed `cerp_test` execution.
 
 ## Rollback
 
@@ -76,8 +130,17 @@ Preferred production rollback:
 3. remove new environment variables only after both old instances are healthy.
 
 Do not run the destructive rollback script on production; it refuses any
-database other than `cerp_test`. On `cerp_test`, the script may be used only
-after confirming that no active test depends on the counters.
+database other than `cerp_dev` or `cerp_test`. On those databases, the script
+may be used only after confirming that no active test depends on the counters.
+When it actually drops the patch table, it removes the matching runner-owned
+registry entry in the same transaction. If the table is already absent, the
+rollback is a no-op only when its ledger entry and named index are also absent.
+Any one-sided artifact/ledger state, mismatched ledger entry, or
+altered/additional table structure aborts before `DROP TABLE` and preserves the
+existing state. Rollback forces `READ COMMITTED`, takes the runner's advisory
+transaction lock, pins the initially observed table OID, and requires an
+`ACCESS EXCLUSIVE` lock on that exact relation before structural inspection; a
+concurrent create or same-name replacement is refused and preserved.
 
 If the table patch is healthy but the new code must be disabled briefly during
 an approved rollback, set `AUTH_RATE_LIMIT_ENABLED=false` on both instances,

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -10,17 +10,23 @@ const ROOT_DIR = path.resolve(__dirname, "..");
 const DEFAULT_PATCH_DIR = path.join(ROOT_DIR, "db", "patches");
 const MIGRATION_TABLE = "public.cerp_schema_migrations";
 const LOCK_NAME = "cerp_schema_migrations";
+const IMMUTABLE_ONLY_PATCHES = Object.freeze({
+  "20260804_auth_rate_limit_buckets.sql":
+    "f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2",
+});
 
 dotenv.config({ path: path.join(ROOT_DIR, ".env") });
 
 function parseArgs(argv) {
   const args = [...argv];
   const command = args[0] && !args[0].startsWith("--") ? args.shift() : "status";
+  let patchDirWasSpecified = false;
   const options = {
     command,
     dryRun: false,
     check: false,
     patchDir: DEFAULT_PATCH_DIR,
+    only: null,
   };
 
   for (let i = 0; i < args.length; i += 1) {
@@ -30,9 +36,17 @@ function parseArgs(argv) {
     } else if (arg === "--check") {
       options.check = true;
     } else if (arg === "--patch-dir") {
+      patchDirWasSpecified = true;
       options.patchDir = path.resolve(args[++i]);
     } else if (arg.startsWith("--patch-dir=")) {
+      patchDirWasSpecified = true;
       options.patchDir = path.resolve(arg.slice("--patch-dir=".length));
+    } else if (arg === "--only") {
+      if (options.only !== null) throw new Error("--only may be specified only once");
+      options.only = args[++i];
+    } else if (arg.startsWith("--only=")) {
+      if (options.only !== null) throw new Error("--only may be specified only once");
+      options.only = arg.slice("--only=".length);
     } else if (arg === "--help" || arg === "-h") {
       printHelp();
       process.exit(0);
@@ -41,13 +55,30 @@ function parseArgs(argv) {
     }
   }
 
+  if (options.only !== null) {
+    if (!options.only || options.only.includes("/") || options.only.includes("\\")) {
+      throw new Error("--only requires one exact patch basename");
+    }
+    if (!Object.prototype.hasOwnProperty.call(IMMUTABLE_ONLY_PATCHES, options.only)) {
+      throw new Error(`--only is not registered as an immutable patch selection: ${options.only}`);
+    }
+    if (command === "baseline") {
+      throw new Error("--only is not supported for metadata-only baseline operations");
+    }
+    if (patchDirWasSpecified) {
+      throw new Error(
+        "--only always validates the canonical db/patches inventory and cannot be combined with --patch-dir"
+      );
+    }
+  }
+
   return options;
 }
 
 function printHelp() {
   console.log(`Usage:
-  node scripts/db-patches.js status [--check] [--patch-dir DIR]
-  node scripts/db-patches.js up [--dry-run] [--patch-dir DIR]
+  node scripts/db-patches.js status [--check] [--only FILE] [--patch-dir DIR]
+  node scripts/db-patches.js up [--dry-run] [--only FILE] [--patch-dir DIR]
   node scripts/db-patches.js baseline [--dry-run] [--patch-dir DIR]
 
 Commands:
@@ -58,8 +89,39 @@ Commands:
 Notes:
   - Requires DATABASE_URL.
   - Stores patch metadata in ${MIGRATION_TABLE}.
+  - --only accepts a registered immutable basename and validates the complete inventory first.
   - Does not print connection strings or secrets.
 `);
+}
+
+function canonicalizeSqlForHash(sql) {
+  return sql.replace(/\r\n?/g, "\n");
+}
+
+function sha256Sql(sql) {
+  return crypto
+    .createHash("sha256")
+    .update(canonicalizeSqlForHash(sql), "utf8")
+    .digest("hex");
+}
+
+function sanitizeLeadingBom(sql) {
+  let sanitized = sql;
+  let previous;
+  do {
+    previous = sanitized;
+    sanitized = sanitized.replace(/^([^\S\uFEFF]*)\uFEFF/, "$1 ");
+  } while (sanitized !== previous);
+  return sanitized;
+}
+
+function isIdentifierContinuation(char) {
+  return Boolean(char) && (/[A-Za-z0-9_$]/.test(char) || char.codePointAt(0) >= 0x80);
+}
+
+function hasEscapeStringPrefix(sql, quoteIndex) {
+  if (quoteIndex < 1 || !/[eE]/.test(sql[quoteIndex - 1])) return false;
+  return quoteIndex === 1 || !isIdentifierContinuation(sql[quoteIndex - 2]);
 }
 
 function listPatches(patchDir) {
@@ -73,9 +135,218 @@ function listPatches(patchDir) {
     .map((filename) => {
       const fullPath = path.join(patchDir, filename);
       const sql = fs.readFileSync(fullPath, "utf8");
-      const sha256 = crypto.createHash("sha256").update(sql).digest("hex");
+      const sha256 = sha256Sql(sql);
       return { filename, fullPath, sql, sha256 };
     });
+}
+
+function canonicalPathKey(value) {
+  const normalized = path.normalize(path.resolve(value));
+  return process.platform === "win32" ? normalized.toLowerCase() : normalized;
+}
+
+function validateImmutableInventoryPath(patchDir, onlyFilename) {
+  if (onlyFilename === null || onlyFilename === undefined) return;
+
+  if (canonicalPathKey(patchDir) !== canonicalPathKey(DEFAULT_PATCH_DIR)) {
+    throw new Error("Immutable --only requires the canonical db/patches inventory");
+  }
+
+  const directoryMetadata = fs.lstatSync(DEFAULT_PATCH_DIR);
+  const realDirectory = fs.realpathSync.native(DEFAULT_PATCH_DIR);
+  if (
+    !directoryMetadata.isDirectory()
+    || directoryMetadata.isSymbolicLink()
+    || canonicalPathKey(realDirectory) !== canonicalPathKey(DEFAULT_PATCH_DIR)
+  ) {
+    throw new Error("Immutable --only refuses a substituted or symbolic-link patch directory");
+  }
+
+  for (const entry of fs.readdirSync(DEFAULT_PATCH_DIR, { withFileTypes: true })) {
+    if (!entry.name.endsWith(".sql")) continue;
+    const expectedPath = path.join(DEFAULT_PATCH_DIR, entry.name);
+    const fileMetadata = fs.lstatSync(expectedPath);
+    const realFile = fs.realpathSync.native(expectedPath);
+    if (
+      !entry.isFile()
+      || entry.isSymbolicLink()
+      || !fileMetadata.isFile()
+      || fileMetadata.isSymbolicLink()
+      || canonicalPathKey(realFile) !== canonicalPathKey(expectedPath)
+    ) {
+      throw new Error(`Immutable --only refuses a substituted or symbolic-link patch file: ${entry.name}`);
+    }
+  }
+}
+
+function immutableOnlyPatch(patches, onlyFilename) {
+  if (onlyFilename === null || onlyFilename === undefined) return null;
+
+  const matches = patches.filter((patch) => patch.filename === onlyFilename);
+  if (matches.length !== 1) {
+    throw new Error(
+      `Immutable --only patch must exist exactly once in the global inventory: ${onlyFilename}`
+    );
+  }
+
+  const patch = matches[0];
+  const expectedSha256 = IMMUTABLE_ONLY_PATCHES[onlyFilename];
+  if (patch.sha256 !== expectedSha256) {
+    throw new Error(
+      `Immutable --only checksum mismatch for ${onlyFilename}: expected canonical LF SHA-256 ${expectedSha256}, found ${patch.sha256}`
+    );
+  }
+  return patch;
+}
+
+function topLevelSqlStatements(sql) {
+  const statements = [];
+  let statementStart = -1;
+  let statementText = "";
+
+  function appendPlaceholder(value) {
+    if (statementStart === -1) {
+      statementStart = value.start;
+    }
+    statementText += value.text;
+  }
+
+  for (let index = 0; index < sql.length;) {
+    const char = sql[index];
+    const next = sql[index + 1];
+
+    if (char === "-" && next === "-") {
+      if (statementStart !== -1) statementText += " ";
+      index += 2;
+      while (index < sql.length && sql[index] !== "\n" && sql[index] !== "\r") index += 1;
+      continue;
+    }
+
+    if (char === "/" && next === "*") {
+      if (statementStart !== -1) statementText += " ";
+      let depth = 1;
+      index += 2;
+      while (index < sql.length && depth > 0) {
+        if (sql[index] === "/" && sql[index + 1] === "*") {
+          depth += 1;
+          index += 2;
+        } else if (sql[index] === "*" && sql[index + 1] === "/") {
+          depth -= 1;
+          index += 2;
+        } else {
+          index += 1;
+        }
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      const quote = char;
+      const backslashEscapes = quote === "'" && hasEscapeStringPrefix(sql, index);
+      appendPlaceholder({ start: index, text: quote === "'" ? " 'literal' " : ' "identifier" ' });
+      index += 1;
+      while (index < sql.length) {
+        if (backslashEscapes && sql[index] === "\\") {
+          index += Math.min(2, sql.length - index);
+        } else if (sql[index] === quote && sql[index + 1] === quote) {
+          index += 2;
+        } else if (sql[index] === quote) {
+          index += 1;
+          break;
+        } else {
+          index += 1;
+        }
+      }
+      continue;
+    }
+
+    if (char === "$") {
+      const tagMatch = sql.slice(index).match(/^\$(?:[A-Za-z_][A-Za-z0-9_]*)?\$/);
+      if (tagMatch && !isIdentifierContinuation(sql[index - 1])) {
+        const tag = tagMatch[0];
+        appendPlaceholder({ start: index, text: " $quoted$ " });
+        const closingIndex = sql.indexOf(tag, index + tag.length);
+        index = closingIndex === -1 ? sql.length : closingIndex + tag.length;
+        continue;
+      }
+    }
+
+    if (char === ";") {
+      if (statementStart !== -1 && statementText.trim() !== "") {
+        statements.push({ start: statementStart, end: index + 1, text: statementText.trim() });
+      }
+      statementStart = -1;
+      statementText = "";
+      index += 1;
+      continue;
+    }
+
+    if (statementStart === -1 && (/\s/.test(char) || char === "\uFEFF")) {
+      index += 1;
+      continue;
+    }
+
+    if (statementStart === -1) statementStart = index;
+    statementText += char;
+    index += 1;
+  }
+
+  if (statementStart !== -1 && statementText.trim() !== "") {
+    statements.push({ start: statementStart, end: sql.length, text: statementText.trim() });
+  }
+
+  return statements;
+}
+
+function transactionControlKind(statementText) {
+  const normalized = statementText.replace(/\s+/g, " ").trim().toUpperCase();
+  if (/^(?:BEGIN(?: (?:WORK|TRANSACTION))?|START TRANSACTION)$/.test(normalized)) {
+    return "begin";
+  }
+  if (/^COMMIT(?: (?:WORK|TRANSACTION))?$/.test(normalized)) {
+    return "commit";
+  }
+  if (
+    /^(?:BEGIN|START\s+TRANSACTION|COMMIT|END|ROLLBACK|ABORT|SAVEPOINT|RELEASE(?:\s+SAVEPOINT)?|PREPARE\s+TRANSACTION|COMMIT\s+PREPARED|ROLLBACK\s+PREPARED|SET\s+(?:LOCAL\s+)?TRANSACTION|SET\s+SESSION\s+CHARACTERISTICS\s+AS\s+TRANSACTION)(?:\s|$)/.test(
+      normalized
+    )
+  ) {
+    return "unsupported";
+  }
+  return null;
+}
+
+function blankStatement(sql, statement) {
+  return sql.slice(0, statement.start)
+    + sql.slice(statement.start, statement.end).replace(/[^\r\n]/g, " ")
+    + sql.slice(statement.end);
+}
+
+function sqlWithoutOuterTransaction(sql, filename = "SQL patch") {
+  const statements = topLevelSqlStatements(sql);
+  const controls = statements
+    .map((statement) => ({ ...statement, kind: transactionControlKind(statement.text) }))
+    .filter((statement) => statement.kind !== null);
+
+  if (
+    controls.length === 2
+    && controls[0].kind === "begin"
+    && controls[1].kind === "commit"
+    && controls[0].start === statements[0]?.start
+    && controls[1].start === statements[statements.length - 1]?.start
+  ) {
+    let executableSql = blankStatement(sql, controls[1]);
+    executableSql = blankStatement(executableSql, controls[0]);
+    return sanitizeLeadingBom(executableSql);
+  }
+
+  if (controls.length > 0) {
+    throw new Error(
+      `${filename} contains unsupported transaction control; use one outer BEGIN/COMMIT pair or none.`
+    );
+  }
+
+  return sanitizeLeadingBom(sql);
 }
 
 async function tableExists(client) {
@@ -165,25 +436,75 @@ async function withMigrationLock(client, fn) {
   }
 }
 
-async function runStatus(client, patches, { check }) {
+async function runStatus(client, patches, { check, only }) {
+  immutableOnlyPatch(patches, only);
   const applied = await getApplied(client);
   const statuses = buildStatuses(patches, applied);
   printStatuses(statuses);
 
   const mismatches = statuses.filter((item) => item.status === "checksum-mismatch");
-  const pending = statuses.filter((item) => item.status === "pending");
+  const selected = only
+    ? statuses.find((item) => item.filename === only)
+    : null;
+  const pending = selected
+    ? (selected.status === "pending" ? [selected] : [])
+    : statuses.filter((item) => item.status === "pending");
+  if (selected) {
+    console.log("");
+    console.log(`Immutable selection: ${selected.filename} is ${selected.status}.`);
+  }
   if (mismatches.length > 0 || (check && pending.length > 0)) {
     process.exitCode = 1;
   }
 }
 
-async function runUp(client, patches, { dryRun }) {
+async function recordMigration(client, patch) {
+  await client.query(`
+    INSERT INTO ${MIGRATION_TABLE} (filename, sha256, applied_at)
+    VALUES ($1, $2, statement_timestamp())
+  `, [patch.filename, patch.sha256]);
+}
+
+async function applyPatch(client, patch) {
+  const executableSql = sqlWithoutOuterTransaction(patch.sql, patch.filename);
+
+  await client.query("BEGIN");
+  try {
+    await client.query("SELECT pg_advisory_xact_lock(hashtext($1))", [LOCK_NAME]);
+    // Keep the server lexer aligned with sqlWithoutOuterTransaction even when
+    // a database or role default was configured with the legacy `off` value.
+    await client.query("SET LOCAL standard_conforming_strings = on");
+    await client.query(executableSql);
+    await recordMigration(client, patch);
+    await client.query("COMMIT");
+  } catch (error) {
+    try {
+      await client.query("ROLLBACK");
+    } catch (_) {
+      // Preserve the original patch or registry error.
+    }
+    throw error;
+  }
+}
+
+async function runUp(client, patches, { dryRun, only }) {
+  immutableOnlyPatch(patches, only);
   if (dryRun) {
     const applied = await getApplied(client);
     const statuses = buildStatuses(patches, applied);
-    const pending = statuses.filter((item) => item.status === "pending");
+    const mismatches = statuses.filter((item) => item.status === "checksum-mismatch");
+    const selected = only ? statuses.find((item) => item.filename === only) : null;
+    const pending = selected
+      ? (selected.status === "pending" ? [selected] : [])
+      : statuses.filter((item) => item.status === "pending");
     printStatuses(statuses);
+    if (mismatches.length > 0) {
+      throw new Error(
+        "Refusing dry-run selection because one or more applied files changed checksum."
+      );
+    }
     console.log("");
+    if (selected) console.log(`Immutable selection: ${selected.filename} is ${selected.status}.`);
     console.log(`Dry-run: ${pending.length} patch(es) would be applied.`);
     return;
   }
@@ -198,23 +519,14 @@ async function runUp(client, patches, { dryRun }) {
       throw new Error("Refusing to apply patches because one or more applied files changed checksum.");
     }
 
-    const pending = statuses.filter((item) => item.status === "pending");
+    const selected = only ? statuses.find((item) => item.filename === only) : null;
+    const pending = selected
+      ? (selected.status === "pending" ? [selected] : [])
+      : statuses.filter((item) => item.status === "pending");
+    if (selected) console.log(`Immutable selection: ${selected.filename} is ${selected.status}.`);
     for (const patch of pending) {
       console.log(`Applying ${patch.filename}`);
-      try {
-        await client.query(patch.sql);
-        await client.query(`
-          INSERT INTO ${MIGRATION_TABLE} (filename, sha256)
-          VALUES ($1, $2)
-        `, [patch.filename, patch.sha256]);
-      } catch (error) {
-        try {
-          await client.query("ROLLBACK");
-        } catch (_) {
-          // Ignore rollback errors; the patch may not have opened a transaction.
-        }
-        throw error;
-      }
+      await applyPatch(client, patch);
     }
     console.log(`Applied ${pending.length} patch(es).`);
   });
@@ -242,10 +554,7 @@ async function runBaseline(client, patches, { dryRun }) {
 
     const pending = statuses.filter((item) => item.status === "pending");
     for (const patch of pending) {
-      await client.query(`
-        INSERT INTO ${MIGRATION_TABLE} (filename, sha256)
-        VALUES ($1, $2)
-      `, [patch.filename, patch.sha256]);
+      await recordMigration(client, patch);
     }
     console.log(`Baselined ${pending.length} patch(es) without executing SQL.`);
   });
@@ -253,7 +562,9 @@ async function runBaseline(client, patches, { dryRun }) {
 
 async function main() {
   const options = parseArgs(process.argv.slice(2));
+  validateImmutableInventoryPath(options.patchDir, options.only);
   const patches = listPatches(options.patchDir);
+  immutableOnlyPatch(patches, options.only);
 
   await withClient(async (client) => {
     if (options.command === "status") {
@@ -268,7 +579,25 @@ async function main() {
   });
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  process.exit(1);
-});
+module.exports = {
+  MIGRATION_TABLE,
+  IMMUTABLE_ONLY_PATCHES,
+  applyPatch,
+  buildStatuses,
+  canonicalizeSqlForHash,
+  immutableOnlyPatch,
+  listPatches,
+  parseArgs,
+  recordMigration,
+  runUp,
+  sha256Sql,
+  sqlWithoutOuterTransaction,
+  validateImmutableInventoryPath,
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/src/__tests__/auth-rate-limit.migration-guards.test.ts
+++ b/src/__tests__/auth-rate-limit.migration-guards.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -21,6 +22,10 @@ const repository = readFileSync(
   resolve(repoRoot, "src/module/auth/repository/auth-rate-limit.repository.ts"),
   "utf8"
 );
+const runner = readFileSync(resolve(repoRoot, "scripts/db-patches.js"), "utf8");
+const expectedPatchSha256 = createHash("sha256")
+  .update(patch.replace(/\r\n?/g, "\n"), "utf8")
+  .digest("hex");
 
 describe("SEC-CERP-0005 migration guards", () => {
   it("stores only bounded HMAC pseudonyms with expiry", () => {
@@ -38,11 +43,212 @@ describe("SEC-CERP-0005 migration guards", () => {
     expect(repository).toContain("retry_after_seconds");
   });
 
-  it("keeps verification read-only and destructive rollback test-only", () => {
+  it("keeps verification read-only and destructive rollback non-production-only", () => {
     const mutatingSql = /\b(?:INSERT\s+INTO|UPDATE\s+public\.|DELETE\s+FROM|DROP\s+TABLE|ALTER\s+TABLE|CREATE\s+TABLE)\b/i;
     expect(preflight).not.toMatch(mutatingSql);
     expect(verify).not.toMatch(mutatingSql);
-    expect(rollback).toContain("current_database() <> 'cerp_test'");
-    expect(rollback).toContain("DROP TABLE IF EXISTS public.auth_rate_limit_buckets");
+    expect(rollback).toContain("current_database() NOT IN ('cerp_dev', 'cerp_test')");
+    expect(rollback).toContain("DROP TABLE public.auth_rate_limit_buckets");
+    expect(rollback).not.toContain("cerp_prod");
+  });
+
+  it("fails preflight for either target relation when the ledger entry is absent", () => {
+    expect(preflight).toContain(
+      "IF (target_table_exists OR target_index_exists) AND NOT registry_entry_exists THEN"
+    );
+    expect(preflight).toContain(
+      "target table or index exists without its migration registry entry"
+    );
+  });
+
+  it("verifies exact runtime column, check and expiry-index contracts", () => {
+    expect(verify).toMatch(
+      /column_name = 'request_count'[\s\S]*data_type = 'integer'[\s\S]*is_nullable = 'NO'[\s\S]*column_default IS NULL/
+    );
+    expect(verify).toContain("THEN 'CHECK ((request_count > 0))'");
+    expect(verify).toContain("total_constraint_count <> 5");
+    expect(verify).toContain("total_index_count <> 2");
+    expect(verify).toContain("pg_get_indexdef(index_metadata.indexrelid, 1, TRUE) = 'expires_at'");
+    expect(verify).toContain("index_metadata.indpred IS NULL");
+    expect(verify).toContain("access_method.amname = 'btree'");
+  });
+
+  it("neutralizes creator default ACLs and establishes the cerp_app owner contract", () => {
+    const ownerTransfer = patch.indexOf(
+      "ALTER TABLE public.auth_rate_limit_buckets OWNER TO cerp_app"
+    );
+    const publicRevoke = patch.indexOf(
+      "REVOKE ALL ON public.auth_rate_limit_buckets FROM PUBLIC",
+      ownerTransfer
+    );
+    const unexpectedGranteeCleanup = patch.indexOf("FOR unexpected_grantee IN", publicRevoke);
+    const ownerRevoke = patch.indexOf(
+      "REVOKE ALL ON public.auth_rate_limit_buckets FROM cerp_app",
+      unexpectedGranteeCleanup
+    );
+    const exactGrant = patch.indexOf(
+      "GRANT SELECT, INSERT, UPDATE, DELETE ON public.auth_rate_limit_buckets TO cerp_app",
+      ownerRevoke
+    );
+
+    expect(patch).toContain("required owner/runtime role cerp_app is missing");
+    expect(ownerTransfer).toBeGreaterThan(-1);
+    expect(publicRevoke).toBeGreaterThan(ownerTransfer);
+    expect(unexpectedGranteeCleanup).toBeGreaterThan(publicRevoke);
+    expect(patch).toContain("aclexplode(");
+    expect(patch).toContain("FROM %I CASCADE");
+    expect(ownerRevoke).toBeGreaterThan(unexpectedGranteeCleanup);
+    expect(exactGrant).toBeGreaterThan(ownerRevoke);
+  });
+
+  it("refuses rogue ownership, PUBLIC, extra grantees and any non-contract ACL", () => {
+    for (const contractSql of [verify, rollback]) {
+      expect(contractSql).toContain(
+        "table_owner_oid IS DISTINCT FROM to_regrole('cerp_app')"
+      );
+      expect(contractSql).toContain("total_acl_entries <> 4 OR expected_acl_entries <> 4");
+      expect(contractSql).toContain("acl_entry.grantor = to_regrole('cerp_app')");
+      expect(contractSql).toContain("acl_entry.grantee = to_regrole('cerp_app')");
+      expect(contractSql).toContain("ARRAY['SELECT', 'INSERT', 'UPDATE', 'DELETE']");
+      expect(contractSql).toContain("AND NOT acl_entry.is_grantable");
+      expect(contractSql).toContain("attacl IS NOT NULL");
+      expect(contractSql).toContain("effective table privileges are not exact DML");
+      expect(contractSql).toContain(
+        "NOT has_table_privilege('cerp_app', 'public.auth_rate_limit_buckets', 'TRUNCATE')"
+      );
+    }
+  });
+
+  it("uses the runner-owned deterministic migration registry contract", () => {
+    expect(expectedPatchSha256).toBe(
+      "f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2"
+    );
+    expect(patch).not.toContain("cerp_schema_migrations");
+    expect(runner).toContain("canonicalizeSqlForHash");
+    expect(runner).toContain("SET LOCAL standard_conforming_strings = on");
+    expect(runner).toContain("INSERT INTO ${MIGRATION_TABLE} (filename, sha256, applied_at)");
+    expect(preflight).toContain(expectedPatchSha256);
+    expect(verify).toContain(expectedPatchSha256);
+    expect(verify).toContain("SELECT sha256, applied_at");
+    expect(verify).toContain("migration registry entry is missing");
+  });
+
+  it("refuses to bless pre-existing artifacts while the patch is pending", () => {
+    const guard = patch.indexOf("DO $preexisting_guard$");
+    const tablePresenceCheck = patch.indexOf(
+      "to_regclass('public.auth_rate_limit_buckets') IS NOT NULL",
+      guard
+    );
+    const indexPresenceCheck = patch.indexOf(
+      "to_regclass('public.auth_rate_limit_buckets_expires_at_idx') IS NOT NULL",
+      guard
+    );
+    const createTable = patch.indexOf("CREATE TABLE public.auth_rate_limit_buckets", guard);
+
+    expect(guard).toBeGreaterThan(-1);
+    expect(tablePresenceCheck).toBeGreaterThan(guard);
+    expect(indexPresenceCheck).toBeGreaterThan(tablePresenceCheck);
+    expect(createTable).toBeGreaterThan(indexPresenceCheck);
+    expect(patch).not.toMatch(/CREATE\s+(?:TABLE|INDEX)\s+IF\s+NOT\s+EXISTS/i);
+  });
+
+  it("validates exact provenance and structure before compensating the registry", () => {
+    const presenceGuard = rollback.indexOf(
+      "table_exists := to_regclass('public.auth_rate_limit_buckets') IS NOT NULL"
+    );
+    const registryLock = rollback.indexOf("FOR UPDATE", presenceGuard);
+    const checksumGuard = rollback.indexOf(
+      "registered_sha256 IS DISTINCT FROM expected_sha256",
+      registryLock
+    );
+    const exactConstraintCount = rollback.indexOf("total_constraint_count <> 5", checksumGuard);
+    const structureGuard = rollback.indexOf("expected_column_count <> 6", checksumGuard);
+    const exactIndexCount = rollback.indexOf("total_index_count <> 2", structureGuard);
+    const triggerPolicyGuard = rollback.indexOf(
+      "user_trigger_count <> 0 OR policy_count <> 0",
+      exactIndexCount
+    );
+    const drop = rollback.indexOf("DROP TABLE public.auth_rate_limit_buckets", presenceGuard);
+    const registryDelete = rollback.indexOf("DELETE FROM public.cerp_schema_migrations", drop);
+
+    expect(presenceGuard).toBeGreaterThan(-1);
+    expect(registryLock).toBeGreaterThan(presenceGuard);
+    expect(checksumGuard).toBeGreaterThan(registryLock);
+    expect(exactConstraintCount).toBeGreaterThan(checksumGuard);
+    expect(structureGuard).toBeGreaterThan(checksumGuard);
+    expect(exactIndexCount).toBeGreaterThan(structureGuard);
+    expect(triggerPolicyGuard).toBeGreaterThan(exactIndexCount);
+    expect(drop).toBeGreaterThan(triggerPolicyGuard);
+    expect(registryDelete).toBeGreaterThan(drop);
+    expect(rollback).toContain("WHERE filename = '20260804_auth_rate_limit_buckets.sql'");
+    expect(rollback).toContain("AND sha256 = expected_sha256");
+    expect(rollback).toContain(expectedPatchSha256);
+  });
+
+  it("serializes rollback with the runner and rechecks state under an exclusive table lock", () => {
+    const transactionStart = rollback.indexOf("BEGIN;");
+    const readCommitted = rollback.indexOf(
+      "SET TRANSACTION ISOLATION LEVEL READ COMMITTED",
+      transactionStart
+    );
+    const environmentGuard = rollback.indexOf("DO $environment_guard$", readCommitted);
+    const advisoryLock = rollback.indexOf(
+      "SELECT pg_advisory_xact_lock(hashtext('cerp_schema_migrations'))"
+    );
+    const firstLookup = rollback.indexOf(
+      "to_regclass('public.auth_rate_limit_buckets')::oid AS target_oid",
+      advisoryLock
+    );
+    const tableLock = rollback.indexOf(
+      "LOCK TABLE public.auth_rate_limit_buckets IN ACCESS EXCLUSIVE MODE",
+      firstLookup
+    );
+    const identityGuard = rollback.indexOf("DO $table_identity_guard$", tableLock);
+    const registryRowLock = rollback.indexOf("DO $registry_lock$", tableLock);
+    const lockedLookup = rollback.indexOf(
+      "table_exists := to_regclass('public.auth_rate_limit_buckets') IS NOT NULL",
+      registryRowLock
+    );
+    const ledgerInspection = rollback.indexOf("SELECT sha256, applied_at", lockedLookup);
+    const structureInspection = rollback.indexOf("SELECT relkind = 'r'", lockedLookup);
+
+    expect(runner).toContain("SELECT pg_advisory_xact_lock(hashtext($1))");
+    expect(transactionStart).toBeGreaterThan(-1);
+    expect(readCommitted).toBeGreaterThan(transactionStart);
+    expect(environmentGuard).toBeGreaterThan(readCommitted);
+    expect(advisoryLock).toBeGreaterThan(-1);
+    expect(firstLookup).toBeGreaterThan(advisoryLock);
+    expect(tableLock).toBeGreaterThan(firstLookup);
+    expect(identityGuard).toBeGreaterThan(tableLock);
+    expect(registryRowLock).toBeGreaterThan(identityGuard);
+    expect(registryRowLock).toBeGreaterThan(tableLock);
+    expect(lockedLookup).toBeGreaterThan(tableLock);
+    expect(ledgerInspection).toBeGreaterThan(lockedLookup);
+    expect(structureInspection).toBeGreaterThan(lockedLookup);
+    expect(rollback).toContain("IF NOT initial_table_exists THEN");
+    expect(rollback).toContain("current_table_oid IS DISTINCT FROM initial_table_oid");
+    expect(rollback).toContain("relation = initial_table_oid");
+    expect(rollback).toContain("initial table identity changed before the exclusive lock");
+    expect(rollback).toContain("target table appeared concurrently before it could be locked");
+  });
+
+  it("allows a rollback no-op only when both the table and target ledger entry are absent", () => {
+    const ledgerLookup = rollback.indexOf("SELECT sha256, applied_at");
+    const absentTableGuard = rollback.indexOf("IF NOT initial_table_exists THEN", ledgerLookup);
+    const inconsistentStateGuard = rollback.indexOf(
+      "IF registry_entry_exists OR expiry_index_exists THEN",
+      absentTableGuard
+    );
+    const inconsistencyError = rollback.indexOf(
+      "table is missing but its registry entry or named index remains",
+      inconsistentStateGuard
+    );
+    const noOpReturn = rollback.indexOf("RETURN;", inconsistencyError);
+
+    expect(ledgerLookup).toBeGreaterThan(-1);
+    expect(absentTableGuard).toBeGreaterThan(ledgerLookup);
+    expect(inconsistentStateGuard).toBeGreaterThan(absentTableGuard);
+    expect(inconsistencyError).toBeGreaterThan(inconsistentStateGuard);
+    expect(noOpReturn).toBeGreaterThan(inconsistencyError);
   });
 });

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -1,0 +1,396 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { resolve } from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+import { repoRoot } from "./helpers/repo-paths";
+
+type Patch = {
+  filename: string;
+  sql: string;
+  sha256: string;
+};
+
+type RunnerModule = {
+  applyPatch: (client: { query: (...args: unknown[]) => Promise<unknown> }, patch: Patch) => Promise<void>;
+  buildStatuses: (
+    patches: Patch[],
+    applied: Map<string, { sha256: string; applied_at: Date }>
+  ) => Array<Patch & { status: string }>;
+  listPatches: (patchDir: string) => Array<Patch & { fullPath: string }>;
+  immutableOnlyPatch: (patches: Patch[], onlyFilename: string | null) => Patch | null;
+  parseArgs: (args: string[]) => {
+    command: string;
+    dryRun: boolean;
+    check: boolean;
+    patchDir: string;
+    only: string | null;
+  };
+  runUp: (
+    client: { query: (...args: unknown[]) => Promise<unknown> },
+    patches: Patch[],
+    options: { dryRun: boolean; only: string | null }
+  ) => Promise<void>;
+  sha256Sql: (sql: string) => string;
+  sqlWithoutOuterTransaction: (sql: string, filename?: string) => string;
+  validateImmutableInventoryPath: (patchDir: string, onlyFilename: string | null) => void;
+};
+
+const require = createRequire(import.meta.url);
+const runner = require(resolve(repoRoot, "scripts/db-patches.js")) as RunnerModule;
+const patchFilename = "20260804_auth_rate_limit_buckets.sql";
+
+function queryText(value: unknown): string {
+  return String(value).replace(/\s+/g, " ").trim();
+}
+
+function transactionalClient(failure?: "patch" | "registry") {
+  const committed = { patchObject: false, registryEntry: false };
+  let pending = { ...committed };
+  let inTransaction = false;
+
+  const query = vi.fn(async (sql: unknown) => {
+    const statement = queryText(sql);
+    if (statement === "BEGIN") {
+      inTransaction = true;
+      pending = { ...committed };
+    } else if (statement.includes("CREATE TABLE example")) {
+      if (failure === "patch") throw new Error("patch failed");
+      pending.patchObject = true;
+    } else if (statement.includes("INSERT INTO public.cerp_schema_migrations")) {
+      if (failure === "registry") throw new Error("registry failed");
+      pending.registryEntry = true;
+    } else if (statement === "COMMIT") {
+      Object.assign(committed, pending);
+      inTransaction = false;
+    } else if (statement === "ROLLBACK") {
+      pending = { ...committed };
+      inTransaction = false;
+    }
+    return { rows: [] };
+  });
+
+  return { committed, isInTransaction: () => inTransaction, query };
+}
+
+function inventoryClient(appliedRows: Array<{ filename: string; sha256: string; applied_at: Date }> = []) {
+  const query = vi.fn(async (sql: unknown) => {
+    const statement = queryText(sql);
+    if (statement.includes("SELECT to_regclass($1) IS NOT NULL AS exists")) {
+      return { rows: [{ exists: true }] };
+    }
+    if (statement.includes("SELECT filename, sha256, applied_at")) {
+      return { rows: appliedRows };
+    }
+    return { rows: [] };
+  });
+  return { query };
+}
+
+describe("database patch runner", () => {
+  it("uses the same deterministic LF checksum on Windows and Linux checkouts", () => {
+    const lf = "BEGIN;\nSELECT 'rate-limit';\nCOMMIT;\n";
+    const crlf = lf.replace(/\n/g, "\r\n");
+    expect(runner.sha256Sql(crlf)).toBe(runner.sha256Sql(lf));
+
+    const patch = readFileSync(resolve(repoRoot, "db/patches", patchFilename), "utf8");
+    expect(runner.sha256Sql(patch)).toBe(
+      "f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2"
+    );
+
+    const previouslyRecordedPatch = readFileSync(
+      resolve(repoRoot, "db/patches/20260731_stock_old_new_446.sql"),
+      "utf8"
+    );
+    expect(runner.sha256Sql(previouslyRecordedPatch)).toBe(
+      "624bb347dfd0458b913cad1fe25affc71ef0bdf3a2a1e2c9250f6f10589af794"
+    );
+  });
+
+  it("binds --only to one exact basename and canonical LF checksum", () => {
+    const patches = runner.listPatches(resolve(repoRoot, "db/patches"));
+    const selected = runner.immutableOnlyPatch(patches, patchFilename);
+
+    expect(selected).toMatchObject({
+      filename: patchFilename,
+      sha256: "f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2",
+    });
+    expect(runner.parseArgs(["up", "--only", patchFilename]).only).toBe(patchFilename);
+    expect(() => runner.parseArgs(["up", "--only", `db/patches/${patchFilename}`])).toThrow(
+      /exact patch basename/
+    );
+    expect(() => runner.parseArgs(["up", "--only", patchFilename.toUpperCase()])).toThrow(
+      /not registered as an immutable patch selection/
+    );
+    expect(() => runner.parseArgs(["up", "--only"])).toThrow(/exact patch basename/);
+    expect(() => runner.parseArgs(["baseline", "--only", patchFilename])).toThrow(
+      /not supported for metadata-only baseline/
+    );
+    expect(() =>
+      runner.immutableOnlyPatch(
+        [{ filename: patchFilename, sql: "SELECT 1;", sha256: runner.sha256Sql("SELECT 1;") }],
+        patchFilename
+      )
+    ).toThrow(/expected canonical LF SHA-256/);
+  });
+
+  it("refuses an alternate --patch-dir that could hide the global inventory", () => {
+    const targetOnlyDirectory = resolve(repoRoot, "tmp/target-only");
+
+    expect(() =>
+      runner.parseArgs([
+        "up",
+        "--only",
+        patchFilename,
+        "--patch-dir",
+        targetOnlyDirectory,
+      ])
+    ).toThrow(/cannot be combined with --patch-dir/);
+    expect(() =>
+      runner.parseArgs([
+        "up",
+        `--only=${patchFilename}`,
+        `--patch-dir=${resolve(repoRoot, "db/patches")}`,
+      ])
+    ).toThrow(/cannot be combined with --patch-dir/);
+    expect(() =>
+      runner.validateImmutableInventoryPath(targetOnlyDirectory, patchFilename)
+    ).toThrow(/canonical db\/patches inventory/);
+    expect(() =>
+      runner.validateImmutableInventoryPath(resolve(repoRoot, "db/patches"), patchFilename)
+    ).not.toThrow();
+  });
+
+  it("applies only the immutable target while leaving another global patch pending", async () => {
+    const target = runner.immutableOnlyPatch(
+      runner.listPatches(resolve(repoRoot, "db/patches")),
+      patchFilename
+    )!;
+    const otherSql = "BEGIN;\nSELECT 'OTHER_PENDING_PATCH';\nCOMMIT;\n";
+    const other = {
+      filename: "20260803_other_pending.sql",
+      sql: otherSql,
+      sha256: runner.sha256Sql(otherSql),
+    };
+    const client = inventoryClient();
+
+    await runner.runUp(
+      { query: client.query },
+      [other, target],
+      { dryRun: false, only: patchFilename }
+    );
+
+    const statements = client.query.mock.calls.map(([statement]) => String(statement));
+    expect(statements.some((statement) => statement.includes("CREATE TABLE public.auth_rate_limit_buckets"))).toBe(true);
+    expect(statements.some((statement) => statement.includes("OTHER_PENDING_PATCH"))).toBe(false);
+    const registryCall = client.query.mock.calls.find(([statement]) =>
+      String(statement).includes("INSERT INTO public.cerp_schema_migrations")
+    );
+    expect(registryCall?.[1]).toEqual([patchFilename, target.sha256]);
+  });
+
+  it("treats an applied --only target as a no-op while another patch remains pending", async () => {
+    const target = runner.immutableOnlyPatch(
+      runner.listPatches(resolve(repoRoot, "db/patches")),
+      patchFilename
+    )!;
+    const otherSql = "SELECT 'STILL_PENDING';\n";
+    const other = {
+      filename: "20260803_other_pending.sql",
+      sql: otherSql,
+      sha256: runner.sha256Sql(otherSql),
+    };
+    const client = inventoryClient([
+      { filename: target.filename, sha256: target.sha256, applied_at: new Date(0) },
+    ]);
+
+    await runner.runUp(
+      { query: client.query },
+      [other, target],
+      { dryRun: false, only: patchFilename }
+    );
+
+    const statements = client.query.mock.calls.map(([statement]) => String(statement));
+    expect(statements.some((statement) => statement.includes("auth_rate_limit_buckets"))).toBe(false);
+    expect(statements.some((statement) => statement.includes("STILL_PENDING"))).toBe(false);
+    expect(statements.some((statement) => statement.includes("INSERT INTO"))).toBe(false);
+  });
+
+  it("refuses --only when any other applied inventory checksum mismatches", async () => {
+    const target = runner.immutableOnlyPatch(
+      runner.listPatches(resolve(repoRoot, "db/patches")),
+      patchFilename
+    )!;
+    const otherSql = "SELECT 'GLOBAL_CHECKSUM';\n";
+    const other = {
+      filename: "20260803_other_applied.sql",
+      sql: otherSql,
+      sha256: runner.sha256Sql(otherSql),
+    };
+    const client = inventoryClient([
+      { filename: other.filename, sha256: "0".repeat(64), applied_at: new Date(0) },
+    ]);
+
+    await expect(
+      runner.runUp(
+        { query: client.query },
+        [other, target],
+        { dryRun: false, only: patchFilename }
+      )
+    ).rejects.toThrow(/one or more applied files changed checksum/);
+
+    const statements = client.query.mock.calls.map(([statement]) => String(statement));
+    expect(statements.some((statement) => statement.includes("CREATE TABLE public.auth_rate_limit_buckets"))).toBe(false);
+  });
+
+  it("accepts every tracked primary patch transaction shape", () => {
+    const patches = runner.listPatches(resolve(repoRoot, "db/patches"));
+    expect(patches.length).toBeGreaterThan(0);
+    for (const patch of patches) {
+      expect(() => runner.sqlWithoutOuterTransaction(patch.sql, patch.filename)).not.toThrow();
+      expect(patch.sql).not.toMatch(
+        /\b(?:CREATE\s+(?:UNIQUE\s+)?INDEX\s+CONCURRENTLY|VACUUM|REINDEX\s+(?:DATABASE|SYSTEM)|CREATE\s+DATABASE|DROP\s+DATABASE|ALTER\s+SYSTEM)\b/i
+      );
+    }
+  });
+
+  it("supports BOM and commented wrappers without mistaking comments or a DO block for controls", () => {
+    const wrapped = [
+      " \t\n\uFEFF/* header /* nested block comment */ still header */",
+      "START TRANSACTION /* runner wrapper */; -- removed before execution",
+      "SELECT 1;",
+      "COMMIT WORK /* runner commits after the registry insert */;",
+      "",
+    ].join("\n");
+    const executable = runner.sqlWithoutOuterTransaction(wrapped, "commented.sql");
+    expect(executable).toContain("SELECT 1;");
+    expect(executable).not.toMatch(/\b(?:START\s+TRANSACTION|COMMIT\s+WORK)\b/i);
+    expect(executable).not.toContain("\uFEFF");
+
+    const unwrappedDoBlock = [
+      "/* COMMIT; is only a comment. */",
+      "DO $body$",
+      "BEGIN",
+      "  PERFORM 'ROLLBACK;';",
+      "END",
+      "$body$;",
+      "",
+    ].join("\n");
+    expect(runner.sqlWithoutOuterTransaction(unwrappedDoBlock, "do-block.sql")).toBe(
+      unwrappedDoBlock
+    );
+  });
+
+  it("cannot hide top-level controls behind PostgreSQL standard strings or quoted identifiers", () => {
+    expect(() =>
+      runner.sqlWithoutOuterTransaction(
+        String.raw`SELECT '\'; COMMIT; SELECT 1;`,
+        "standard-string-bypass.sql"
+      )
+    ).toThrow(/unsupported transaction control/);
+
+    expect(() =>
+      runner.sqlWithoutOuterTransaction(
+        String.raw`SELECT "\"; ROLLBACK; SELECT 1;`,
+        "quoted-identifier-bypass.sql"
+      )
+    ).toThrow(/unsupported transaction control/);
+  });
+
+  it("does not mistake dollar signs inside PostgreSQL identifiers for dollar quotes", () => {
+    expect(() =>
+      runner.sqlWithoutOuterTransaction(
+        "SELECT 1 AS first$tag$; COMMIT; SELECT 1 AS second$tag$;",
+        "dollar-identifier-bypass.sql"
+      )
+    ).toThrow(/unsupported transaction control/);
+  });
+
+  it("keeps backslash quote escapes inside explicit PostgreSQL E strings", () => {
+    const sql = String.raw`SELECT E'not top-level: \'; COMMIT;'; SELECT 1;`;
+    expect(runner.sqlWithoutOuterTransaction(sql, "escape-string.sql")).toBe(sql);
+  });
+
+  it.each([
+    "BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;\nSELECT 1;\nCOMMIT;\n",
+    "START TRANSACTION READ ONLY;\nSELECT 1;\nCOMMIT;\n",
+    "SELECT 1;\nCOMMIT AND CHAIN;\n",
+    "SAVEPOINT future_control;\nSELECT 1;\n",
+    "ROLLBACK TO SAVEPOINT future_control;\n",
+    "PREPARE TRANSACTION 'future-control';\n",
+  ])("refuses unsupported top-level transaction control: %s", (sql) => {
+    expect(() => runner.sqlWithoutOuterTransaction(sql, "unsupported.sql")).toThrow(
+      /unsupported transaction control/
+    );
+  });
+
+  it("commits the patch and its complete registry record in one runner-owned transaction", async () => {
+    const client = transactionalClient();
+    const sql = "-- wrapped patch\r\nBEGIN;\r\nCREATE TABLE example(id integer);\r\nCOMMIT;\r\n";
+    const patch = { filename: patchFilename, sql, sha256: runner.sha256Sql(sql) };
+
+    await runner.applyPatch({ query: client.query }, patch);
+
+    expect(client.query).toHaveBeenCalledTimes(6);
+    expect(client.query.mock.calls[0][0]).toBe("BEGIN");
+    expect(queryText(client.query.mock.calls[1][0])).toContain(
+      "SELECT pg_advisory_xact_lock(hashtext($1))"
+    );
+    expect(client.query.mock.calls[1][1]).toEqual(["cerp_schema_migrations"]);
+    expect(client.query.mock.calls[2][0]).toBe(
+      "SET LOCAL standard_conforming_strings = on"
+    );
+    expect(queryText(client.query.mock.calls[3][0])).toContain("CREATE TABLE example(id integer);");
+    expect(queryText(client.query.mock.calls[3][0])).not.toMatch(/\b(?:BEGIN|COMMIT)\s*;/i);
+    expect(queryText(client.query.mock.calls[4][0])).toContain(
+      "INSERT INTO public.cerp_schema_migrations (filename, sha256, applied_at)"
+    );
+    expect(queryText(client.query.mock.calls[4][0])).toContain("statement_timestamp()");
+    expect(client.query.mock.calls[4][1]).toEqual([patch.filename, patch.sha256]);
+    expect(client.query.mock.calls[5][0]).toBe("COMMIT");
+    expect(client.committed).toEqual({ patchObject: true, registryEntry: true });
+    expect(client.isInTransaction()).toBe(false);
+  });
+
+  it.each(["patch", "registry"] as const)(
+    "rolls back without a patch object or registry entry when the %s write fails",
+    async (failure) => {
+      const client = transactionalClient(failure);
+      const sql = "BEGIN;\nCREATE TABLE example(id integer);\nCOMMIT;\n";
+
+      await expect(
+        runner.applyPatch(
+          { query: client.query },
+          { filename: patchFilename, sql, sha256: runner.sha256Sql(sql) }
+        )
+      ).rejects.toThrow(`${failure} failed`);
+
+      const statements = client.query.mock.calls.map(([statement]) => queryText(statement));
+      expect(statements.at(-1)).toBe("ROLLBACK");
+      expect(statements).not.toContain("COMMIT");
+      if (failure === "patch") {
+        expect(statements.some((statement) => statement.includes("INSERT INTO"))).toBe(false);
+      }
+      expect(client.committed).toEqual({ patchObject: false, registryEntry: false });
+      expect(client.isInTransaction()).toBe(false);
+    }
+  );
+
+  it("skips a matching registered patch and rejects unsafe transaction control", () => {
+    const patch = {
+      filename: patchFilename,
+      sql: "SELECT 1;\n",
+      sha256: runner.sha256Sql("SELECT 1;\n"),
+    };
+    const statuses = runner.buildStatuses(
+      [patch],
+      new Map([[patch.filename, { sha256: patch.sha256, applied_at: new Date(0) }]])
+    );
+
+    expect(statuses).toMatchObject([{ filename: patch.filename, status: "applied" }]);
+    expect(() =>
+      runner.sqlWithoutOuterTransaction("BEGIN;\nSELECT 1;\n", "unsafe.sql")
+    ).toThrow(/unsupported transaction control/);
+  });
+});


### PR DESCRIPTION
## Résumé
- borne l'exécution au patch immuable du limiteur distribué
- rend patch et ledger atomiques avec preuve PostgreSQL 16/17
- verrouille owner/ACL, vérification et rollback contre les dérives et courses

## Validation
- build backend
- 3 829 tests backend
- matrices PostgreSQL 16.14 et 17.10
- contre-revue indépendante finale PASS

## Summary by Sourcery

Secure the distributed rate limiter database patch and migration ledger with an immutable runner-owned contract and stronger rollback/verification guarantees.

New Features:
- Introduce an immutable patch selector (--only) bound to a specific rate-limit patch and checksum for controlled application.
- Add a durable SEC-CERP-0005 migration validation record documenting disposable database evidence and required shared cerp_test checks.

Enhancements:
- Tighten the db patch runner so patch execution and migration ledger writes are atomic, deterministic across platforms, and reject unsafe transaction control patterns.
- Strengthen rate-limit migration preflight, verify, and rollback scripts to enforce exact table structure, owner/ACL contracts, and ledger provenance, while serializing changes with advisory locks.
- Clarify database patching and auth rate-limit deployment runbooks to mandate runner-driven patch application, immutable selectors, and explicit governance gates.

Documentation:
- Update database patching and auth rate-limit deployment documentation with immutable patch selection, runner-owned registry semantics, ACL/owner expectations, and non-destructive evidence capture procedures.
- Add a dedicated SEC-CERP-0005 migration evidence document summarizing disposable database validation results and required shared cerp_test checks.

Tests:
- Add unit tests for the db patch runner covering LF-normalized checksums, immutable patch selection, transaction handling, and unsupported transaction control detection.
- Extend SEC-CERP-0005 guard tests to assert ACL/owner contracts, rollback serialization, registry usage, and refusal paths for inconsistent artifacts.