### PR TITLE
feat: gouverner la convergence des dashboards

### DIFF
--- a/db/patches/20260805_dashboard_convergence_governance.sql
+++ b/db/patches/20260805_dashboard_convergence_governance.sql
@@ -1,8 +1,25 @@
--- Dashboard ARIANE/V2/Legacy convergence: privacy-preserving daily counters.
--- Additive only. No preference or dashboard surface is removed by this patch.
+-- Dashboard ARIANE/V2/Legacy convergence governance.
+-- Additive only: both kill-switches are created OFF (fail-closed), and no
+-- dashboard surface or browser preference is removed by this patch.
 
-CREATE TABLE IF NOT EXISTS public.dashboard_usage_daily (
-  id uuid NOT NULL DEFAULT gen_random_uuid(),
+DO $preexisting_guard$
+BEGIN
+  IF to_regclass('public.dashboard_usage_daily') IS NOT NULL
+     OR to_regprocedure('public.prune_dashboard_usage_daily(integer)') IS NOT NULL THEN
+    RAISE EXCEPTION 'dashboard convergence artifact already exists without this migration ledger entry';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.app_feature_flags
+    WHERE key IN ('DASHBOARD_ARIANE_DEFAULT', 'DASHBOARD_USAGE_METRICS')
+  ) THEN
+    RAISE EXCEPTION 'dashboard convergence feature flag already exists without this migration ledger entry';
+  END IF;
+END
+$preexisting_guard$;
+
+CREATE TABLE public.dashboard_usage_daily (
   usage_date date NOT NULL DEFAULT CURRENT_DATE,
   experience text NOT NULL,
   event_type text NOT NULL,
@@ -12,24 +29,66 @@ CREATE TABLE IF NOT EXISTS public.dashboard_usage_daily (
   event_count bigint NOT NULL DEFAULT 0,
   first_seen_at timestamptz NOT NULL DEFAULT now(),
   last_seen_at timestamptz NOT NULL DEFAULT now(),
-  CONSTRAINT dashboard_usage_daily_pkey PRIMARY KEY (id),
+  CONSTRAINT dashboard_usage_daily_pkey PRIMARY KEY (
+    usage_date, experience, event_type, selection_source, previous_experience, role_bucket
+  ),
   CONSTRAINT dashboard_usage_daily_experience_ck CHECK (experience IN ('ariane','v2','legacy')),
   CONSTRAINT dashboard_usage_daily_event_ck CHECK (event_type IN ('view','switch','deep_link','preference_migrated','fallback')),
   CONSTRAINT dashboard_usage_daily_source_ck CHECK (selection_source IN ('default','preference','query','switch','rollback','migration')),
   CONSTRAINT dashboard_usage_daily_previous_ck CHECK (previous_experience IN ('none','ariane','v2','legacy')),
   CONSTRAINT dashboard_usage_daily_role_ck CHECK (role_bucket IN ('direction','production','achats','qualite','operateur')),
-  CONSTRAINT dashboard_usage_daily_count_ck CHECK (event_count >= 0),
-  CONSTRAINT dashboard_usage_daily_bucket_key UNIQUE (
-    usage_date, experience, event_type, selection_source, previous_experience, role_bucket
-  )
+  CONSTRAINT dashboard_usage_daily_count_ck CHECK (event_count >= 0)
 );
 
-CREATE INDEX IF NOT EXISTS dashboard_usage_daily_date_idx
-  ON public.dashboard_usage_daily (usage_date DESC);
-
 COMMENT ON TABLE public.dashboard_usage_daily IS
-  'Aggregats journaliers de convergence dashboard; aucun user_id, IP, URL, user-agent ou texte libre.';
+  'Agrégats journaliers indicatifs de convergence; aucun user_id, IP, URL, user-agent, identifiant de session ou texte libre.';
+
+CREATE FUNCTION public.prune_dashboard_usage_daily(p_retention_days integer DEFAULT 90)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $retention$
+DECLARE
+  deleted_rows bigint;
+BEGIN
+  IF p_retention_days IS DISTINCT FROM 90 THEN
+    RAISE EXCEPTION 'dashboard usage retention is fixed at 90 days';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('dashboard_usage_daily_retention'));
+  DELETE FROM public.dashboard_usage_daily
+  WHERE usage_date < (CURRENT_DATE - p_retention_days);
+  GET DIAGNOSTICS deleted_rows = ROW_COUNT;
+  RETURN deleted_rows;
+END
+$retention$;
+
+COMMENT ON FUNCTION public.prune_dashboard_usage_daily(integer) IS
+  'Maintenance indépendante du trafic: purge les agrégats dashboard âgés de plus de 90 jours.';
+
+INSERT INTO public.app_feature_flags (key, name, description, enabled, environment)
+VALUES
+  (
+    'DASHBOARD_ARIANE_DEFAULT',
+    'ARIANE par défaut',
+    'Kill-switch global prioritaire. OFF force V2, y compris face aux overrides utilisateur et aux deep links ARIANE.',
+    false,
+    'all'
+  ),
+  (
+    'DASHBOARD_USAGE_METRICS',
+    'Mesure indicative de convergence dashboard',
+    'OFF jusqu’aux validations DPO/Product/QA et à la preuve de maintenance quotidienne des agrégats à 90 jours.',
+    false,
+    'all'
+  );
 
 ALTER TABLE public.dashboard_usage_daily OWNER TO cerp_app;
 REVOKE ALL ON TABLE public.dashboard_usage_daily FROM PUBLIC;
+REVOKE ALL ON TABLE public.dashboard_usage_daily FROM cerp_app;
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.dashboard_usage_daily TO cerp_app;
+
+ALTER FUNCTION public.prune_dashboard_usage_daily(integer) OWNER TO cerp_app;
+REVOKE ALL ON FUNCTION public.prune_dashboard_usage_daily(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.prune_dashboard_usage_daily(integer) TO cerp_app;

--- a/db/patches/20260805_dashboard_convergence_governance.sql
+++ b/db/patches/20260805_dashboard_convergence_governance.sql
@@ -1,0 +1,35 @@
+-- Dashboard ARIANE/V2/Legacy convergence: privacy-preserving daily counters.
+-- Additive only. No preference or dashboard surface is removed by this patch.
+
+CREATE TABLE IF NOT EXISTS public.dashboard_usage_daily (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  usage_date date NOT NULL DEFAULT CURRENT_DATE,
+  experience text NOT NULL,
+  event_type text NOT NULL,
+  selection_source text NOT NULL,
+  previous_experience text NOT NULL DEFAULT 'none',
+  role_bucket text NOT NULL,
+  event_count bigint NOT NULL DEFAULT 0,
+  first_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT dashboard_usage_daily_pkey PRIMARY KEY (id),
+  CONSTRAINT dashboard_usage_daily_experience_ck CHECK (experience IN ('ariane','v2','legacy')),
+  CONSTRAINT dashboard_usage_daily_event_ck CHECK (event_type IN ('view','switch','deep_link','preference_migrated','fallback')),
+  CONSTRAINT dashboard_usage_daily_source_ck CHECK (selection_source IN ('default','preference','query','switch','rollback','migration')),
+  CONSTRAINT dashboard_usage_daily_previous_ck CHECK (previous_experience IN ('none','ariane','v2','legacy')),
+  CONSTRAINT dashboard_usage_daily_role_ck CHECK (role_bucket IN ('direction','production','achats','qualite','operateur')),
+  CONSTRAINT dashboard_usage_daily_count_ck CHECK (event_count >= 0),
+  CONSTRAINT dashboard_usage_daily_bucket_key UNIQUE (
+    usage_date, experience, event_type, selection_source, previous_experience, role_bucket
+  )
+);
+
+CREATE INDEX IF NOT EXISTS dashboard_usage_daily_date_idx
+  ON public.dashboard_usage_daily (usage_date DESC);
+
+COMMENT ON TABLE public.dashboard_usage_daily IS
+  'Aggregats journaliers de convergence dashboard; aucun user_id, IP, URL, user-agent ou texte libre.';
+
+ALTER TABLE public.dashboard_usage_daily OWNER TO cerp_app;
+REVOKE ALL ON TABLE public.dashboard_usage_daily FROM PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.dashboard_usage_daily TO cerp_app;

--- a/db/patches/support/20260805_dashboard_convergence_governance.preflight.sql
+++ b/db/patches/support/20260805_dashboard_convergence_governance.preflight.sql
@@ -1,4 +1,60 @@
 \set ON_ERROR_STOP on
-SELECT current_database() AS database, current_user AS actor;
-SELECT to_regclass('public.app_feature_flags') AS feature_flags,
-       to_regclass('public.users') AS users;
+
+-- Read-only preflight. It refuses to let the runner bless pre-existing target
+-- artifacts or flags that have no matching immutable ledger entry.
+BEGIN TRANSACTION READ ONLY;
+
+DO $preflight$
+DECLARE
+  expected_sha256 constant text := '76828b33484f604efe1236e7d95fb32101aafaa42aba8b4ec4cc4fbe5db9a717';
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  registry_entry_exists boolean := false;
+  target_table_exists boolean := to_regclass('public.dashboard_usage_daily') IS NOT NULL;
+  target_function_exists boolean := to_regprocedure('public.prune_dashboard_usage_daily(integer)') IS NOT NULL;
+  target_flag_count integer;
+BEGIN
+  IF to_regclass('public.app_feature_flags') IS NULL
+     OR to_regclass('public.app_feature_flag_users') IS NULL THEN
+    RAISE EXCEPTION 'dashboard convergence preflight: feature-flag foundation is missing';
+  END IF;
+
+  IF to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'dashboard convergence preflight: required role cerp_app is missing';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO target_flag_count
+  FROM public.app_feature_flags
+  WHERE key IN ('DASHBOARD_ARIANE_DEFAULT', 'DASHBOARD_USAGE_METRICS');
+
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    SELECT sha256, applied_at
+      INTO registered_sha256, registered_applied_at
+    FROM public.cerp_schema_migrations
+    WHERE filename = '20260805_dashboard_convergence_governance.sql';
+    registry_entry_exists := FOUND;
+  END IF;
+
+  IF registry_entry_exists THEN
+    IF registered_sha256 IS DISTINCT FROM expected_sha256 OR registered_applied_at IS NULL THEN
+      RAISE EXCEPTION 'dashboard convergence preflight: migration ledger provenance is invalid';
+    END IF;
+    IF NOT target_table_exists OR NOT target_function_exists OR target_flag_count <> 2 THEN
+      RAISE EXCEPTION 'dashboard convergence preflight: ledger exists but target artifacts are incomplete';
+    END IF;
+    RAISE NOTICE 'dashboard convergence preflight: exact patch is already registered';
+    RETURN;
+  END IF;
+
+  IF target_table_exists OR target_function_exists OR target_flag_count <> 0 THEN
+    RAISE EXCEPTION 'dashboard convergence preflight: target artifact or flag exists without its migration ledger entry';
+  END IF;
+END
+$preflight$;
+
+SELECT current_database() AS database_name,
+       current_user AS actor,
+       'dashboard convergence preflight passed (read-only)' AS result;
+
+ROLLBACK;

--- a/db/patches/support/20260805_dashboard_convergence_governance.preflight.sql
+++ b/db/patches/support/20260805_dashboard_convergence_governance.preflight.sql
@@ -1,0 +1,4 @@
+\set ON_ERROR_STOP on
+SELECT current_database() AS database, current_user AS actor;
+SELECT to_regclass('public.app_feature_flags') AS feature_flags,
+       to_regclass('public.users') AS users;

--- a/db/patches/support/20260805_dashboard_convergence_governance.rollback.sql
+++ b/db/patches/support/20260805_dashboard_convergence_governance.rollback.sql
@@ -1,0 +1,5 @@
+\set ON_ERROR_STOP on
+-- Destructive and manual only: export metrics before executing.
+DELETE FROM public.app_feature_flags
+WHERE key IN ('DASHBOARD_ARIANE_DEFAULT','DASHBOARD_USAGE_METRICS');
+DROP TABLE IF EXISTS public.dashboard_usage_daily;

--- a/db/patches/support/20260805_dashboard_convergence_governance.rollback.sql
+++ b/db/patches/support/20260805_dashboard_convergence_governance.rollback.sql
@@ -1,5 +1,156 @@
 \set ON_ERROR_STOP on
--- Destructive and manual only: export metrics before executing.
-DELETE FROM public.app_feature_flags
-WHERE key IN ('DASHBOARD_ARIANE_DEFAULT','DASHBOARD_USAGE_METRICS');
-DROP TABLE IF EXISTS public.dashboard_usage_daily;
+
+-- Destructive schema rollback is test/dev-only. Production rollback uses the
+-- global ARIANE flag and keeps privacy evidence inert until an approved export
+-- and retention outcome exist.
+BEGIN;
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+DO $environment_guard$
+BEGIN
+  IF current_database() NOT IN ('cerp_dev', 'cerp_test') THEN
+    RAISE EXCEPTION 'dashboard convergence rollback is restricted to cerp_dev/cerp_test';
+  END IF;
+END
+$environment_guard$;
+
+SELECT pg_advisory_xact_lock(hashtext('cerp_schema_migrations'));
+
+DO $rollback$
+DECLARE
+  expected_sha256 constant text := '76828b33484f604efe1236e7d95fb32101aafaa42aba8b4ec4cc4fbe5db9a717';
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  registry_entry_exists boolean := false;
+  table_exists boolean := to_regclass('public.dashboard_usage_daily') IS NOT NULL;
+  function_exists boolean := to_regprocedure('public.prune_dashboard_usage_daily(integer)') IS NOT NULL;
+  target_flag_count integer := 0;
+  disabled_flag_count integer := 0;
+  override_count integer := 0;
+  usage_row_count bigint := 0;
+  total_constraint_count integer;
+  expected_constraint_count integer;
+  table_owner oid;
+  function_owner oid;
+  deleted_rows integer;
+BEGIN
+  IF to_regclass('public.app_feature_flags') IS NULL
+     OR to_regclass('public.app_feature_flag_users') IS NULL THEN
+    RAISE EXCEPTION 'dashboard convergence rollback: feature-flag foundation is missing';
+  END IF;
+
+  PERFORM 1
+  FROM public.app_feature_flags
+  WHERE key IN ('DASHBOARD_ARIANE_DEFAULT', 'DASHBOARD_USAGE_METRICS')
+  FOR UPDATE;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE enabled IS FALSE AND environment = 'all')::integer
+    INTO target_flag_count, disabled_flag_count
+  FROM public.app_feature_flags
+  WHERE key IN ('DASHBOARD_ARIANE_DEFAULT', 'DASHBOARD_USAGE_METRICS');
+
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    SELECT sha256, applied_at
+      INTO registered_sha256, registered_applied_at
+    FROM public.cerp_schema_migrations
+    WHERE filename = '20260805_dashboard_convergence_governance.sql'
+    FOR UPDATE;
+    registry_entry_exists := FOUND;
+  END IF;
+
+  IF NOT table_exists AND NOT function_exists
+     AND target_flag_count = 0 AND NOT registry_entry_exists THEN
+    RAISE NOTICE 'dashboard convergence rollback: exact artifacts already absent';
+    RETURN;
+  END IF;
+
+  IF NOT table_exists OR NOT function_exists OR target_flag_count <> 2
+     OR NOT registry_entry_exists THEN
+    RAISE EXCEPTION 'dashboard convergence rollback: target artifacts or ledger are in a partial state';
+  END IF;
+
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 OR registered_applied_at IS NULL THEN
+    RAISE EXCEPTION 'dashboard convergence rollback: migration ledger provenance is invalid';
+  END IF;
+
+  LOCK TABLE public.dashboard_usage_daily IN ACCESS EXCLUSIVE MODE;
+
+  SELECT relowner
+    INTO table_owner
+  FROM pg_class
+  WHERE oid = 'public.dashboard_usage_daily'::regclass;
+
+  SELECT proowner
+    INTO function_owner
+  FROM pg_proc
+  WHERE oid = 'public.prune_dashboard_usage_daily(integer)'::regprocedure;
+
+  IF table_owner IS DISTINCT FROM to_regrole('cerp_app')
+     OR function_owner IS DISTINCT FROM to_regrole('cerp_app') THEN
+    RAISE EXCEPTION 'dashboard convergence rollback: target ownership is unexpected';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE conname = ANY (ARRAY[
+           'dashboard_usage_daily_pkey',
+           'dashboard_usage_daily_experience_ck',
+           'dashboard_usage_daily_event_ck',
+           'dashboard_usage_daily_source_ck',
+           'dashboard_usage_daily_previous_ck',
+           'dashboard_usage_daily_role_ck',
+           'dashboard_usage_daily_count_ck'
+         ]) AND convalidated)::integer
+    INTO total_constraint_count, expected_constraint_count
+  FROM pg_constraint
+  WHERE conrelid = 'public.dashboard_usage_daily'::regclass;
+
+  IF total_constraint_count <> 7 OR expected_constraint_count <> 7 THEN
+    RAISE EXCEPTION 'dashboard convergence rollback: table constraints are incomplete, altered or additional';
+  END IF;
+
+  IF disabled_flag_count <> 2 THEN
+    RAISE EXCEPTION 'dashboard convergence rollback: a target flag is active or altered';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO override_count
+  FROM public.app_feature_flag_users ffu
+  JOIN public.app_feature_flags ff ON ff.id = ffu.feature_flag_id
+  WHERE ff.key IN ('DASHBOARD_ARIANE_DEFAULT', 'DASHBOARD_USAGE_METRICS');
+
+  IF override_count <> 0 THEN
+    RAISE EXCEPTION 'dashboard convergence rollback: user overrides exist';
+  END IF;
+
+  SELECT COUNT(*)::bigint INTO usage_row_count FROM public.dashboard_usage_daily;
+  IF usage_row_count <> 0 THEN
+    RAISE EXCEPTION 'dashboard convergence rollback: usage evidence exists; export/retention decision required';
+  END IF;
+
+  EXECUTE 'DROP FUNCTION public.prune_dashboard_usage_daily(integer)';
+  EXECUTE 'DROP TABLE public.dashboard_usage_daily';
+
+  DELETE FROM public.app_feature_flags
+  WHERE key IN ('DASHBOARD_ARIANE_DEFAULT', 'DASHBOARD_USAGE_METRICS');
+  GET DIAGNOSTICS deleted_rows = ROW_COUNT;
+  IF deleted_rows <> 2 THEN
+    RAISE EXCEPTION 'dashboard convergence rollback: exact feature flags were not removed';
+  END IF;
+
+  DELETE FROM public.cerp_schema_migrations
+  WHERE filename = '20260805_dashboard_convergence_governance.sql'
+    AND sha256 = expected_sha256;
+  GET DIAGNOSTICS deleted_rows = ROW_COUNT;
+  IF deleted_rows <> 1 THEN
+    RAISE EXCEPTION 'dashboard convergence rollback: exact migration ledger row was not removed';
+  END IF;
+
+  IF to_regclass('public.dashboard_usage_daily') IS NOT NULL
+     OR to_regprocedure('public.prune_dashboard_usage_daily(integer)') IS NOT NULL THEN
+    RAISE EXCEPTION 'dashboard convergence rollback: target artifact remains after rollback';
+  END IF;
+END
+$rollback$;
+
+COMMIT;

--- a/db/patches/support/20260805_dashboard_convergence_governance.verify.sql
+++ b/db/patches/support/20260805_dashboard_convergence_governance.verify.sql
@@ -1,0 +1,10 @@
+\set ON_ERROR_STOP on
+SELECT to_regclass('public.dashboard_usage_daily') AS usage_table;
+SELECT column_name, data_type, is_nullable
+FROM information_schema.columns
+WHERE table_schema='public' AND table_name='dashboard_usage_daily'
+ORDER BY ordinal_position;
+SELECT key, enabled, environment
+FROM public.app_feature_flags
+WHERE key IN ('DASHBOARD_ARIANE_DEFAULT','DASHBOARD_USAGE_METRICS')
+ORDER BY key;

--- a/db/patches/support/20260805_dashboard_convergence_governance.verify.sql
+++ b/db/patches/support/20260805_dashboard_convergence_governance.verify.sql
@@ -1,10 +1,128 @@
 \set ON_ERROR_STOP on
-SELECT to_regclass('public.dashboard_usage_daily') AS usage_table;
-SELECT column_name, data_type, is_nullable
-FROM information_schema.columns
-WHERE table_schema='public' AND table_name='dashboard_usage_daily'
-ORDER BY ordinal_position;
-SELECT key, enabled, environment
-FROM public.app_feature_flags
-WHERE key IN ('DASHBOARD_ARIANE_DEFAULT','DASHBOARD_USAGE_METRICS')
-ORDER BY key;
+
+-- Baseline verification is deliberately blocking: it passes only while both
+-- global flags are OFF and no per-user override exists. Run before any signed
+-- operational activation; later activation is a separate audited decision.
+BEGIN TRANSACTION READ ONLY;
+
+DO $verify$
+DECLARE
+  expected_sha256 constant text := '76828b33484f604efe1236e7d95fb32101aafaa42aba8b4ec4cc4fbe5db9a717';
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  table_owner oid;
+  function_owner oid;
+  target_flag_count integer;
+  disabled_flag_count integer;
+  override_count integer;
+  total_column_count integer;
+  expected_column_count integer;
+  total_constraint_count integer;
+  expected_constraint_count integer;
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NULL THEN
+    RAISE EXCEPTION 'dashboard convergence verify: migration registry is missing';
+  END IF;
+
+  SELECT sha256, applied_at
+    INTO registered_sha256, registered_applied_at
+  FROM public.cerp_schema_migrations
+  WHERE filename = '20260805_dashboard_convergence_governance.sql';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'dashboard convergence verify: migration registry entry is missing';
+  END IF;
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 OR registered_applied_at IS NULL THEN
+    RAISE EXCEPTION 'dashboard convergence verify: migration ledger provenance is invalid';
+  END IF;
+
+  IF to_regclass('public.dashboard_usage_daily') IS NULL
+     OR to_regprocedure('public.prune_dashboard_usage_daily(integer)') IS NULL THEN
+    RAISE EXCEPTION 'dashboard convergence verify: table or retention function is missing';
+  END IF;
+
+  SELECT relowner
+    INTO table_owner
+  FROM pg_class
+  WHERE oid = 'public.dashboard_usage_daily'::regclass;
+
+  SELECT proowner
+    INTO function_owner
+  FROM pg_proc
+  WHERE oid = 'public.prune_dashboard_usage_daily(integer)'::regprocedure;
+
+  IF table_owner IS DISTINCT FROM to_regrole('cerp_app')
+     OR function_owner IS DISTINCT FROM to_regrole('cerp_app') THEN
+    RAISE EXCEPTION 'dashboard convergence verify: runtime ownership is not cerp_app';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE enabled IS FALSE AND environment = 'all')::integer
+    INTO target_flag_count, disabled_flag_count
+  FROM public.app_feature_flags
+  WHERE key IN ('DASHBOARD_ARIANE_DEFAULT', 'DASHBOARD_USAGE_METRICS');
+
+  IF target_flag_count <> 2 OR disabled_flag_count <> 2 THEN
+    RAISE EXCEPTION 'dashboard convergence verify: both baseline flags must exist globally and remain OFF';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO override_count
+  FROM public.app_feature_flag_users ffu
+  JOIN public.app_feature_flags ff ON ff.id = ffu.feature_flag_id
+  WHERE ff.key IN ('DASHBOARD_ARIANE_DEFAULT', 'DASHBOARD_USAGE_METRICS');
+
+  IF override_count <> 0 THEN
+    RAISE EXCEPTION 'dashboard convergence verify: user overrides are forbidden before signed activation';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE column_name = ANY (ARRAY[
+           'usage_date', 'experience', 'event_type', 'selection_source',
+           'previous_experience', 'role_bucket', 'event_count',
+           'first_seen_at', 'last_seen_at'
+         ]))::integer
+    INTO total_column_count, expected_column_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public' AND table_name = 'dashboard_usage_daily';
+
+  IF total_column_count <> 9 OR expected_column_count <> 9 THEN
+    RAISE EXCEPTION 'dashboard convergence verify: table columns are incomplete or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE conname = ANY (ARRAY[
+           'dashboard_usage_daily_pkey',
+           'dashboard_usage_daily_experience_ck',
+           'dashboard_usage_daily_event_ck',
+           'dashboard_usage_daily_source_ck',
+           'dashboard_usage_daily_previous_ck',
+           'dashboard_usage_daily_role_ck',
+           'dashboard_usage_daily_count_ck'
+         ]) AND convalidated)::integer
+    INTO total_constraint_count, expected_constraint_count
+  FROM pg_constraint
+  WHERE conrelid = 'public.dashboard_usage_daily'::regclass;
+
+  IF total_constraint_count <> 7 OR expected_constraint_count <> 7 THEN
+    RAISE EXCEPTION 'dashboard convergence verify: table constraints are incomplete, altered or additional';
+  END IF;
+
+  IF NOT has_table_privilege('cerp_app', 'public.dashboard_usage_daily', 'SELECT,INSERT,UPDATE,DELETE')
+     OR NOT has_function_privilege('cerp_app', 'public.prune_dashboard_usage_daily(integer)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'dashboard convergence verify: runtime DML or maintenance privilege is missing';
+  END IF;
+END
+$verify$;
+
+SELECT
+  current_database() AS database_name,
+  (SELECT sha256 FROM public.cerp_schema_migrations
+   WHERE filename = '20260805_dashboard_convergence_governance.sql') AS migration_sha256,
+  (SELECT enabled FROM public.app_feature_flags
+   WHERE key = 'DASHBOARD_ARIANE_DEFAULT') AS ariane_enabled,
+  (SELECT enabled FROM public.app_feature_flags
+   WHERE key = 'DASHBOARD_USAGE_METRICS') AS telemetry_enabled,
+  'dashboard convergence baseline verification passed (read-only)' AS result;
+
+ROLLBACK;

--- a/db/seeds/dashboard-convergence-flags.sql
+++ b/db/seeds/dashboard-convergence-flags.sql
@@ -1,6 +1,0 @@
--- Baseline idempotente. ON CONFLICT DO NOTHING preserves every later ops decision.
-INSERT INTO public.app_feature_flags (key, name, description, enabled, environment)
-VALUES
-  ('DASHBOARD_ARIANE_DEFAULT', 'ARIANE par défaut', 'OFF rebascule les préférences ARIANE vers V2 tout en préservant les deep links.', true, 'all'),
-  ('DASHBOARD_USAGE_METRICS', 'Mesure de convergence dashboard', 'Compteurs journaliers agrégés sans identifiant, rétention 90 jours.', true, 'all')
-ON CONFLICT (key) DO NOTHING;

--- a/db/seeds/dashboard-convergence-flags.sql
+++ b/db/seeds/dashboard-convergence-flags.sql
@@ -1,0 +1,6 @@
+-- Baseline idempotente. ON CONFLICT DO NOTHING preserves every later ops decision.
+INSERT INTO public.app_feature_flags (key, name, description, enabled, environment)
+VALUES
+  ('DASHBOARD_ARIANE_DEFAULT', 'ARIANE par défaut', 'OFF rebascule les préférences ARIANE vers V2 tout en préservant les deep links.', true, 'all'),
+  ('DASHBOARD_USAGE_METRICS', 'Mesure de convergence dashboard', 'Compteurs journaliers agrégés sans identifiant, rétention 90 jours.', true, 'all')
+ON CONFLICT (key) DO NOTHING;

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "db:patches:status": "node scripts/db-patches.js status",
     "db:patches:up": "node scripts/db-patches.js up",
     "db:patches:baseline": "node scripts/db-patches.js baseline",
+    "maintenance:dashboard-usage": "node scripts/prune-dashboard-usage.js",
     "test": "vitest --config vitest.config.ts",
     "test:run": "vitest run --config vitest.config.ts",
     "test:list": "vitest list --filesOnly --config vitest.config.ts",

--- a/scripts/prune-dashboard-usage.js
+++ b/scripts/prune-dashboard-usage.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+const path = require("node:path");
+const dotenv = require("dotenv");
+const { Client } = require("pg");
+
+const ROOT_DIR = path.resolve(__dirname, "..");
+const RETENTION_DAYS = 90;
+
+dotenv.config({ path: path.join(ROOT_DIR, ".env") });
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) throw new Error("DATABASE_URL is required");
+
+  const client = new Client({ connectionString });
+  await client.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("SET LOCAL lock_timeout = '5s'");
+    await client.query("SET LOCAL statement_timeout = '60s'");
+    const result = await client.query(
+      "SELECT public.prune_dashboard_usage_daily($1::integer)::text AS deleted_rows",
+      [RETENTION_DAYS]
+    );
+    await client.query("COMMIT");
+    process.stdout.write(`dashboard usage retention complete: ${result.rows[0]?.deleted_rows ?? "0"} row(s) deleted\n`);
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`dashboard usage retention failed: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/__tests__/dashboard-governance.test.ts
+++ b/src/__tests__/dashboard-governance.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -58,14 +59,61 @@ describe("dashboard governance", () => {
     })).toThrow();
   });
 
-  it("keeps the migration additive and ships operational scripts", () => {
+  it("accepts only coherent bounded telemetry transitions", () => {
+    expect(dashboardUsageBodySchema.parse({
+      experience: "v2",
+      event_type: "switch",
+      selection_source: "switch",
+      previous_experience: "legacy",
+    })).toMatchObject({ experience: "v2", previous_experience: "legacy" });
+
+    for (const invalid of [
+      { experience: "v2", event_type: "switch", selection_source: "switch" },
+      { experience: "v2", event_type: "switch", selection_source: "switch", previous_experience: "v2" },
+      { experience: "legacy", event_type: "deep_link", selection_source: "default" },
+      { experience: "v2", event_type: "fallback", selection_source: "query" },
+      { experience: "v2", event_type: "view", selection_source: "default", previous_experience: "legacy" },
+    ]) {
+      expect(() => dashboardUsageBodySchema.parse(invalid)).toThrow();
+    }
+  });
+
+  it("ships a fail-closed canonical patch and independent retention maintenance", () => {
     const root = path.resolve(__dirname, "../..");
     const patch = fs.readFileSync(path.join(root, "db/patches/20260805_dashboard_convergence_governance.sql"), "utf8");
-    expect(patch).toMatch(/CREATE TABLE IF NOT EXISTS public\.dashboard_usage_daily/);
-    expect(patch).not.toMatch(/DROP\s+TABLE|TRUNCATE|DELETE\s+FROM/i);
+    const repository = fs.readFileSync(path.join(root, "src/module/dashboard-governance/repository/dashboard-governance.repository.ts"), "utf8");
+    const maintenance = fs.readFileSync(path.join(root, "scripts/prune-dashboard-usage.js"), "utf8");
+    const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")) as { scripts: Record<string, string> };
+
+    expect(patch).toMatch(/CREATE TABLE public\.dashboard_usage_daily/);
+    expect(patch).toContain("CREATE FUNCTION public.prune_dashboard_usage_daily");
+    expect(patch).toMatch(/'DASHBOARD_ARIANE_DEFAULT'[\s\S]*false[\s\S]*'DASHBOARD_USAGE_METRICS'[\s\S]*false/);
+    expect(fs.existsSync(path.join(root, "db/seeds/dashboard-convergence-flags.sql"))).toBe(false);
     expect(patch).not.toMatch(/^\s*(user_id|ip_address|user_agent)\s+/im);
+    expect(repository).toContain("ff.enabled IS TRUE AND COALESCE(ffu.enabled, TRUE) IS TRUE");
+    expect(repository).not.toMatch(/DELETE FROM public\.dashboard_usage_daily/);
+    expect(maintenance).toContain("public.prune_dashboard_usage_daily");
+    expect(packageJson.scripts["maintenance:dashboard-usage"]).toBe("node scripts/prune-dashboard-usage.js");
+
     for (const suffix of ["preflight", "verify", "rollback"]) {
       expect(fs.existsSync(path.join(root, `db/patches/support/20260805_dashboard_convergence_governance.${suffix}.sql`))).toBe(true);
     }
+  });
+
+  it("guards read-only verification and destructive rollback with exact provenance", () => {
+    const root = path.resolve(__dirname, "../..");
+    const patch = fs.readFileSync(path.join(root, "db/patches/20260805_dashboard_convergence_governance.sql"), "utf8");
+    const verify = fs.readFileSync(path.join(root, "db/patches/support/20260805_dashboard_convergence_governance.verify.sql"), "utf8");
+    const rollback = fs.readFileSync(path.join(root, "db/patches/support/20260805_dashboard_convergence_governance.rollback.sql"), "utf8");
+    const expectedSha = createHash("sha256").update(patch.replace(/\r\n?/g, "\n"), "utf8").digest("hex");
+
+    expect(verify).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(verify).toContain(expectedSha);
+    expect(verify).toContain("both baseline flags must exist globally and remain OFF");
+    expect(rollback).toContain("current_database() NOT IN ('cerp_dev', 'cerp_test')");
+    expect(rollback).toContain("SELECT pg_advisory_xact_lock(hashtext('cerp_schema_migrations'))");
+    expect(rollback).toContain(expectedSha);
+    expect(rollback).toContain("usage evidence exists; export/retention decision required");
+    expect(rollback).toContain("DELETE FROM public.cerp_schema_migrations");
   });
 });

--- a/src/__tests__/dashboard-governance.test.ts
+++ b/src/__tests__/dashboard-governance.test.ts
@@ -1,0 +1,71 @@
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const repo = vi.hoisted(() => ({
+  flags: vi.fn(),
+  increment: vi.fn(),
+  metrics: vi.fn(),
+}));
+
+vi.mock("../module/dashboard-governance/repository/dashboard-governance.repository", () => ({
+  repoResolveDashboardFlags: repo.flags,
+  repoIncrementDashboardUsage: repo.increment,
+  repoListDashboardUsageMetrics: repo.metrics,
+}));
+
+import {
+  resolveDashboardRoleBucket,
+  svcGetDashboardGovernance,
+  svcRecordDashboardUsage,
+} from "../module/dashboard-governance/services/dashboard-governance.service";
+import { dashboardUsageBodySchema } from "../module/dashboard-governance/validators/dashboard-governance.validators";
+
+describe("dashboard governance", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("maps effective roles to coarse non-identifying buckets", () => {
+    expect(resolveDashboardRoleBucket("Employee | Opérateur")).toBe("operateur");
+    expect(resolveDashboardRoleBucket("Qualité | Production")).toBe("qualite");
+    expect(resolveDashboardRoleBucket("Approvisionnement")).toBe("achats");
+    expect(resolveDashboardRoleBucket("Administrateur")).toBe("direction");
+  });
+
+  it("rolls the default back to V2 without disabling deep links", async () => {
+    repo.flags.mockResolvedValue({ ariane_default_enabled: false, telemetry_enabled: true });
+    const config = await svcGetDashboardGovernance(7);
+    expect(config.default_experience).toBe("v2");
+    expect(config.deep_links_preserved).toBe(true);
+    expect(config.telemetry.identifiers_collected).toBe(false);
+  });
+
+  it("does not write when the telemetry kill-switch is off", async () => {
+    repo.flags.mockResolvedValue({ ariane_default_enabled: true, telemetry_enabled: false });
+    await expect(svcRecordDashboardUsage({
+      user_id: 7,
+      effective_role: "Production",
+      input: { experience: "ariane", event_type: "view", selection_source: "default" },
+    })).resolves.toEqual({ recorded: false });
+    expect(repo.increment).not.toHaveBeenCalled();
+  });
+
+  it("rejects identifiers and free-form telemetry fields", () => {
+    expect(() => dashboardUsageBodySchema.parse({
+      experience: "ariane",
+      event_type: "view",
+      selection_source: "default",
+      user_id: 42,
+    })).toThrow();
+  });
+
+  it("keeps the migration additive and ships operational scripts", () => {
+    const root = path.resolve(__dirname, "../..");
+    const patch = fs.readFileSync(path.join(root, "db/patches/20260805_dashboard_convergence_governance.sql"), "utf8");
+    expect(patch).toMatch(/CREATE TABLE IF NOT EXISTS public\.dashboard_usage_daily/);
+    expect(patch).not.toMatch(/DROP\s+TABLE|TRUNCATE|DELETE\s+FROM/i);
+    expect(patch).not.toMatch(/^\s*(user_id|ip_address|user_agent)\s+/im);
+    for (const suffix of ["preflight", "verify", "rollback"]) {
+      expect(fs.existsSync(path.join(root, `db/patches/support/20260805_dashboard_convergence_governance.${suffix}.sql`))).toBe(true);
+    }
+  });
+});

--- a/src/module/dashboard-governance/controllers/dashboard-governance.controller.ts
+++ b/src/module/dashboard-governance/controllers/dashboard-governance.controller.ts
@@ -21,6 +21,7 @@ function getUser(req: Request) {
 
 export const getDashboardGovernance: RequestHandler = asyncHandler(async (req, res) => {
   const user = getUser(req);
+  res.set("Cache-Control", "no-store");
   res.json(await svcGetDashboardGovernance(user.id));
 });
 

--- a/src/module/dashboard-governance/controllers/dashboard-governance.controller.ts
+++ b/src/module/dashboard-governance/controllers/dashboard-governance.controller.ts
@@ -1,0 +1,42 @@
+import type { Request, RequestHandler } from "express";
+
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { HttpError } from "../../../utils/httpError";
+import {
+  svcGetDashboardGovernance,
+  svcGetDashboardUsageMetrics,
+  svcRecordDashboardUsage,
+} from "../services/dashboard-governance.service";
+import {
+  dashboardMetricsQuerySchema,
+  dashboardUsageBodySchema,
+} from "../validators/dashboard-governance.validators";
+
+function getUser(req: Request) {
+  if (!req.user || typeof req.user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  return req.user;
+}
+
+export const getDashboardGovernance: RequestHandler = asyncHandler(async (req, res) => {
+  const user = getUser(req);
+  res.json(await svcGetDashboardGovernance(user.id));
+});
+
+export const postDashboardUsage: RequestHandler = asyncHandler(async (req, res) => {
+  const user = getUser(req);
+  const input = dashboardUsageBodySchema.parse(req.body);
+  const result = await svcRecordDashboardUsage({
+    user_id: user.id,
+    effective_role: user.role,
+    input,
+  });
+  res.status(202).json(result);
+});
+
+export const getDashboardUsageMetrics: RequestHandler = asyncHandler(async (req, res) => {
+  getUser(req);
+  const query = dashboardMetricsQuerySchema.parse(req.query);
+  res.json(await svcGetDashboardUsageMetrics(query));
+});

--- a/src/module/dashboard-governance/repository/dashboard-governance.repository.ts
+++ b/src/module/dashboard-governance/repository/dashboard-governance.repository.ts
@@ -4,7 +4,6 @@ import pool from "../../../config/database";
 import {
   DASHBOARD_ARIANE_DEFAULT_FLAG,
   DASHBOARD_USAGE_METRICS_FLAG,
-  DASHBOARD_USAGE_RETENTION_DAYS,
   type DashboardRoleBucket,
   type DashboardUsageInput,
   type DashboardUsageMetricRow,
@@ -19,9 +18,8 @@ function isUndefinedTable(error: unknown): boolean {
 }
 
 /**
- * Résout les deux kill-switches de convergence. Les valeurs de compatibilité
- * préservent le comportement livré avant ce module : ARIANE reste la cible et
- * la collecte reste OFF tant que le seed et la table ne sont pas présents.
+ * Résout les deux kill-switches de convergence. L'absence de table, de flag ou
+ * de valeur globale positive reste fail-closed : V2 et collecte OFF.
  */
 export async function repoResolveDashboardFlags(
   userId: number,
@@ -33,7 +31,9 @@ export async function repoResolveDashboardFlags(
         WITH requested(key) AS (
           SELECT unnest($1::text[])
         )
-        SELECT requested.key, COALESCE(ffu.enabled, ff.enabled) AS enabled
+        SELECT
+          requested.key,
+          (ff.enabled IS TRUE AND COALESCE(ffu.enabled, TRUE) IS TRUE) AS enabled
         FROM requested
         LEFT JOIN public.app_feature_flags ff ON ff.key = requested.key
         LEFT JOIN public.app_feature_flag_users ffu
@@ -47,14 +47,14 @@ export async function repoResolveDashboardFlags(
     );
 
     return {
-      ariane_default_enabled: byKey.get(DASHBOARD_ARIANE_DEFAULT_FLAG) !== false,
+      ariane_default_enabled: byKey.get(DASHBOARD_ARIANE_DEFAULT_FLAG) === true,
       telemetry_enabled:
         byKey.get(DASHBOARD_USAGE_METRICS_FLAG) === true &&
         infrastructure.rows[0]?.usage_table_ready === true,
     };
   } catch (error) {
     if (isUndefinedTable(error)) {
-      return { ariane_default_enabled: true, telemetry_enabled: false };
+      return { ariane_default_enabled: false, telemetry_enabled: false };
     }
     throw error;
   }
@@ -70,10 +70,6 @@ export async function repoIncrementDashboardUsage(
 ): Promise<void> {
   await q.query(
     `
-      WITH pruned AS (
-        DELETE FROM public.dashboard_usage_daily
-        WHERE usage_date < (CURRENT_DATE - $6::int)
-      )
       INSERT INTO public.dashboard_usage_daily (
         usage_date,
         experience,
@@ -114,7 +110,6 @@ export async function repoIncrementDashboardUsage(
       params.input.selection_source,
       params.input.previous_experience ?? "none",
       params.role_bucket,
-      DASHBOARD_USAGE_RETENTION_DAYS,
     ]
   );
 }

--- a/src/module/dashboard-governance/repository/dashboard-governance.repository.ts
+++ b/src/module/dashboard-governance/repository/dashboard-governance.repository.ts
@@ -1,0 +1,155 @@
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import {
+  DASHBOARD_ARIANE_DEFAULT_FLAG,
+  DASHBOARD_USAGE_METRICS_FLAG,
+  DASHBOARD_USAGE_RETENTION_DAYS,
+  type DashboardRoleBucket,
+  type DashboardUsageInput,
+  type DashboardUsageMetricRow,
+} from "../types/dashboard-governance.types";
+
+type DbQueryer = Pick<PoolClient, "query">;
+
+type FlagRow = { key: string; enabled: boolean | null };
+
+function isUndefinedTable(error: unknown): boolean {
+  return (error as { code?: unknown } | null)?.code === "42P01";
+}
+
+/**
+ * Résout les deux kill-switches de convergence. Les valeurs de compatibilité
+ * préservent le comportement livré avant ce module : ARIANE reste la cible et
+ * la collecte reste OFF tant que le seed et la table ne sont pas présents.
+ */
+export async function repoResolveDashboardFlags(
+  userId: number,
+  q: DbQueryer = pool
+): Promise<{ ariane_default_enabled: boolean; telemetry_enabled: boolean }> {
+  try {
+    const flags = await q.query<FlagRow>(
+      `
+        WITH requested(key) AS (
+          SELECT unnest($1::text[])
+        )
+        SELECT requested.key, COALESCE(ffu.enabled, ff.enabled) AS enabled
+        FROM requested
+        LEFT JOIN public.app_feature_flags ff ON ff.key = requested.key
+        LEFT JOIN public.app_feature_flag_users ffu
+          ON ffu.feature_flag_id = ff.id AND ffu.user_id = $2::int
+      `,
+      [[DASHBOARD_ARIANE_DEFAULT_FLAG, DASHBOARD_USAGE_METRICS_FLAG], userId]
+    );
+    const byKey = new Map(flags.rows.map((row) => [row.key, row.enabled]));
+    const infrastructure = await q.query<{ usage_table_ready: boolean }>(
+      "SELECT to_regclass('public.dashboard_usage_daily') IS NOT NULL AS usage_table_ready"
+    );
+
+    return {
+      ariane_default_enabled: byKey.get(DASHBOARD_ARIANE_DEFAULT_FLAG) !== false,
+      telemetry_enabled:
+        byKey.get(DASHBOARD_USAGE_METRICS_FLAG) === true &&
+        infrastructure.rows[0]?.usage_table_ready === true,
+    };
+  } catch (error) {
+    if (isUndefinedTable(error)) {
+      return { ariane_default_enabled: true, telemetry_enabled: false };
+    }
+    throw error;
+  }
+}
+
+/**
+ * Compteur quotidien uniquement : aucun user_id, IP, URL, user-agent ou texte
+ * libre n'est écrit. Le rôle est réduit à une famille métier avant ce niveau.
+ */
+export async function repoIncrementDashboardUsage(
+  params: { input: DashboardUsageInput; role_bucket: DashboardRoleBucket },
+  q: DbQueryer = pool
+): Promise<void> {
+  await q.query(
+    `
+      WITH pruned AS (
+        DELETE FROM public.dashboard_usage_daily
+        WHERE usage_date < (CURRENT_DATE - $6::int)
+      )
+      INSERT INTO public.dashboard_usage_daily (
+        usage_date,
+        experience,
+        event_type,
+        selection_source,
+        previous_experience,
+        role_bucket,
+        event_count,
+        first_seen_at,
+        last_seen_at
+      )
+      VALUES (
+        CURRENT_DATE,
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        1,
+        now(),
+        now()
+      )
+      ON CONFLICT (
+        usage_date,
+        experience,
+        event_type,
+        selection_source,
+        previous_experience,
+        role_bucket
+      )
+      DO UPDATE SET
+        event_count = public.dashboard_usage_daily.event_count + 1,
+        last_seen_at = now()
+    `,
+    [
+      params.input.experience,
+      params.input.event_type,
+      params.input.selection_source,
+      params.input.previous_experience ?? "none",
+      params.role_bucket,
+      DASHBOARD_USAGE_RETENTION_DAYS,
+    ]
+  );
+}
+
+type UsageMetricDbRow = Omit<DashboardUsageMetricRow, "previous_experience" | "event_count"> & {
+  previous_experience: string;
+  event_count: string | number;
+};
+
+export async function repoListDashboardUsageMetrics(
+  params: { from: string; to: string },
+  q: DbQueryer = pool
+): Promise<DashboardUsageMetricRow[]> {
+  const result = await q.query<UsageMetricDbRow>(
+    `
+      SELECT
+        usage_date::text,
+        experience,
+        event_type,
+        selection_source,
+        previous_experience,
+        role_bucket,
+        event_count::text
+      FROM public.dashboard_usage_daily
+      WHERE usage_date BETWEEN $1::date AND $2::date
+      ORDER BY usage_date, role_bucket, experience, event_type, selection_source
+    `,
+    [params.from, params.to]
+  );
+
+  return result.rows.map((row) => ({
+    ...row,
+    previous_experience: row.previous_experience === "none"
+      ? null
+      : row.previous_experience as DashboardUsageMetricRow["previous_experience"],
+    event_count: Number(row.event_count),
+  }));
+}

--- a/src/module/dashboard-governance/routes/dashboard-governance.routes.ts
+++ b/src/module/dashboard-governance/routes/dashboard-governance.routes.ts
@@ -1,0 +1,19 @@
+import { Router } from "express";
+
+import { requireSuperadmin } from "../../access-control/middlewares/require-superadmin";
+import {
+  getDashboardGovernance,
+  getDashboardUsageMetrics,
+  postDashboardUsage,
+} from "../controllers/dashboard-governance.controller";
+
+// Monté après authenticateToken dans v1.routes.ts. La configuration et le
+// compteur sont accessibles à tout compte authentifié ; les agrégats restent
+// réservés au superadmin et ne contiennent aucun identifiant individuel.
+const router = Router();
+
+router.get("/", getDashboardGovernance);
+router.post("/usage", postDashboardUsage);
+router.get("/metrics", requireSuperadmin, getDashboardUsageMetrics);
+
+export default router;

--- a/src/module/dashboard-governance/services/dashboard-governance.service.ts
+++ b/src/module/dashboard-governance/services/dashboard-governance.service.ts
@@ -1,0 +1,88 @@
+import {
+  DASHBOARD_USAGE_RETENTION_DAYS,
+  type DashboardGovernanceConfig,
+  type DashboardRoleBucket,
+  type DashboardUsageInput,
+} from "../types/dashboard-governance.types";
+import {
+  repoIncrementDashboardUsage,
+  repoListDashboardUsageMetrics,
+  repoResolveDashboardFlags,
+} from "../repository/dashboard-governance.repository";
+
+function normalize(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "");
+}
+
+/** Famille d'analyse seulement, jamais une décision d'autorisation. */
+export function resolveDashboardRoleBucket(role: string | null | undefined): DashboardRoleBucket {
+  const parts = String(role ?? "").split("|").map(normalize).filter(Boolean);
+  const has = (needle: string) => parts.some((part) => part.includes(needle));
+
+  if (has("operateur") || has("usinage") || has("pointage") || has("mon poste")) return "operateur";
+  if (has("qualit") || has("metrolog")) return "qualite";
+  if (has("achat") || has("approvision") || has("fournisseur")) return "achats";
+  if (has("production") || has("planification") || has("methode") || has("atelier") || has("ordonnancement")) {
+    return "production";
+  }
+  return "direction";
+}
+
+export async function svcGetDashboardGovernance(userId: number): Promise<DashboardGovernanceConfig> {
+  const flags = await repoResolveDashboardFlags(userId);
+  return {
+    schema_version: 1,
+    default_experience: flags.ariane_default_enabled ? "ariane" : "v2",
+    rollback_experience: "v2",
+    ariane_default_enabled: flags.ariane_default_enabled,
+    deep_links_preserved: true,
+    telemetry: {
+      enabled: flags.telemetry_enabled,
+      collection: "daily_aggregate",
+      retention_days: DASHBOARD_USAGE_RETENTION_DAYS,
+      identifiers_collected: false,
+    },
+  };
+}
+
+export async function svcRecordDashboardUsage(params: {
+  user_id: number;
+  effective_role: string | null | undefined;
+  input: DashboardUsageInput;
+}): Promise<{ recorded: boolean }> {
+  const flags = await repoResolveDashboardFlags(params.user_id);
+  if (!flags.telemetry_enabled) return { recorded: false };
+
+  await repoIncrementDashboardUsage({
+    input: params.input,
+    role_bucket: resolveDashboardRoleBucket(params.effective_role),
+  });
+  return { recorded: true };
+}
+
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export async function svcGetDashboardUsageMetrics(params: { from?: string; to?: string }) {
+  const to = params.to ?? isoDate(new Date());
+  const fromDate = new Date(`${to}T00:00:00.000Z`);
+  fromDate.setUTCDate(fromDate.getUTCDate() - 27);
+  const from = params.from ?? isoDate(fromDate);
+  const rows = await repoListDashboardUsageMetrics({ from, to });
+
+  return {
+    from,
+    to,
+    rows,
+    privacy: {
+      collection: "daily_aggregate" as const,
+      identifiers_collected: false as const,
+      retention_days: DASHBOARD_USAGE_RETENTION_DAYS,
+    },
+  };
+}

--- a/src/module/dashboard-governance/types/dashboard-governance.types.ts
+++ b/src/module/dashboard-governance/types/dashboard-governance.types.ts
@@ -1,0 +1,46 @@
+export const DASHBOARD_EXPERIENCES = ["ariane", "v2", "legacy"] as const;
+export type DashboardExperience = (typeof DASHBOARD_EXPERIENCES)[number];
+
+export const DASHBOARD_USAGE_EVENTS = ["view", "switch", "deep_link", "preference_migrated", "fallback"] as const;
+export type DashboardUsageEvent = (typeof DASHBOARD_USAGE_EVENTS)[number];
+
+export const DASHBOARD_SELECTION_SOURCES = ["default", "preference", "query", "switch", "rollback", "migration"] as const;
+export type DashboardSelectionSource = (typeof DASHBOARD_SELECTION_SOURCES)[number];
+
+export const DASHBOARD_ROLE_BUCKETS = ["direction", "production", "achats", "qualite", "operateur"] as const;
+export type DashboardRoleBucket = (typeof DASHBOARD_ROLE_BUCKETS)[number];
+
+export const DASHBOARD_USAGE_RETENTION_DAYS = 90;
+export const DASHBOARD_ARIANE_DEFAULT_FLAG = "DASHBOARD_ARIANE_DEFAULT";
+export const DASHBOARD_USAGE_METRICS_FLAG = "DASHBOARD_USAGE_METRICS";
+
+export type DashboardGovernanceConfig = {
+  schema_version: 1;
+  default_experience: "ariane" | "v2";
+  rollback_experience: "v2";
+  ariane_default_enabled: boolean;
+  deep_links_preserved: true;
+  telemetry: {
+    enabled: boolean;
+    collection: "daily_aggregate";
+    retention_days: typeof DASHBOARD_USAGE_RETENTION_DAYS;
+    identifiers_collected: false;
+  };
+};
+
+export type DashboardUsageInput = {
+  experience: DashboardExperience;
+  event_type: DashboardUsageEvent;
+  selection_source: DashboardSelectionSource;
+  previous_experience?: DashboardExperience;
+};
+
+export type DashboardUsageMetricRow = {
+  usage_date: string;
+  experience: DashboardExperience;
+  event_type: DashboardUsageEvent;
+  selection_source: DashboardSelectionSource;
+  previous_experience: DashboardExperience | null;
+  role_bucket: DashboardRoleBucket;
+  event_count: number;
+};

--- a/src/module/dashboard-governance/validators/dashboard-governance.validators.ts
+++ b/src/module/dashboard-governance/validators/dashboard-governance.validators.ts
@@ -11,7 +11,41 @@ export const dashboardUsageBodySchema = z.object({
   event_type: z.enum(DASHBOARD_USAGE_EVENTS),
   selection_source: z.enum(DASHBOARD_SELECTION_SOURCES),
   previous_experience: z.enum(DASHBOARD_EXPERIENCES).optional(),
-}).strict();
+}).strict().superRefine((value, ctx) => {
+  const issue = (path: "selection_source" | "previous_experience", message: string) => {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: [path], message });
+  };
+
+  if (value.event_type === "switch") {
+    if (value.selection_source !== "switch") {
+      issue("selection_source", "switch exige selection_source=switch");
+    }
+    if (!value.previous_experience || value.previous_experience === value.experience) {
+      issue("previous_experience", "switch exige une expérience précédente différente");
+    }
+    return;
+  }
+
+  if (value.previous_experience !== undefined) {
+    issue("previous_experience", "previous_experience est réservé à switch");
+  }
+
+  const requiredSource = {
+    deep_link: "query",
+    preference_migrated: "migration",
+    fallback: "rollback",
+  } as const;
+  if (value.event_type in requiredSource) {
+    const expected = requiredSource[value.event_type as keyof typeof requiredSource];
+    if (value.selection_source !== expected) {
+      issue("selection_source", `${value.event_type} exige selection_source=${expected}`);
+    }
+  } else if (!(["default", "preference", "switch"] as const).includes(
+    value.selection_source as "default" | "preference" | "switch"
+  )) {
+    issue("selection_source", "view accepte uniquement default, preference ou switch");
+  }
+});
 
 export const dashboardMetricsQuerySchema = z.object({
   from: z.string().date().optional(),

--- a/src/module/dashboard-governance/validators/dashboard-governance.validators.ts
+++ b/src/module/dashboard-governance/validators/dashboard-governance.validators.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+import {
+  DASHBOARD_EXPERIENCES,
+  DASHBOARD_SELECTION_SOURCES,
+  DASHBOARD_USAGE_EVENTS,
+} from "../types/dashboard-governance.types";
+
+export const dashboardUsageBodySchema = z.object({
+  experience: z.enum(DASHBOARD_EXPERIENCES),
+  event_type: z.enum(DASHBOARD_USAGE_EVENTS),
+  selection_source: z.enum(DASHBOARD_SELECTION_SOURCES),
+  previous_experience: z.enum(DASHBOARD_EXPERIENCES).optional(),
+}).strict();
+
+export const dashboardMetricsQuerySchema = z.object({
+  from: z.string().date().optional(),
+  to: z.string().date().optional(),
+}).superRefine((value, ctx) => {
+  if (value.from && value.to && value.from > value.to) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["from"], message: "from doit précéder to" });
+  }
+});
+
+export type DashboardUsageBodyDTO = z.infer<typeof dashboardUsageBodySchema>;
+export type DashboardMetricsQueryDTO = z.infer<typeof dashboardMetricsQuerySchema>;

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -55,6 +55,7 @@ import pieceTechniqueVersionsRoutes from "../module/gammes/routes/piece-techniqu
 import methodesRoutes from "../module/methodes/routes/methodes.routes"
 import importAssistantRoutes from "../module/import-assistant/routes/import-assistant.routes"
 import accessControlRoutes from "../module/access-control/routes/access-control.routes"
+import dashboardGovernanceRoutes from "../module/dashboard-governance/routes/dashboard-governance.routes"
 import { moduleAccessGate } from "../module/access-control/middlewares/module-access-gate"
 import { runWithAccountModuleAccessScope } from "../module/access-control/context/account-module-access.context"
 const router = Router()
@@ -73,6 +74,10 @@ router.use(authenticateToken)
 // module métier pour qu'aucune surface future n'y échappe par oubli. Une fois le
 // module autorisé, les anciens gardes de rôle deviennent de simples compatibilités.
 router.use(moduleAccessGate)
+
+// Gouvernance transverse de l'accueil : rollback ARIANE/V2 et métriques
+// d'adoption agrégées. Ce n'est pas un module métier restrictible.
+router.use("/dashboard-governance", dashboardGovernanceRoutes)
 
 router.use("/outils", outilRoutes)
 router.use("/banking-info", bankingInfoRoutes)  


### PR DESCRIPTION
Implémente le prompt GPT56-REMOVE-CERP-0003 sans retirer de surface tant que la parité et les signatures ne sont pas acquises. Ajoute une gouvernance fail-closed, une télémétrie indicative minimisée, une rétention indépendante et un cycle SQL vérifiable. Validations ciblées et PostgreSQL jetable réussies.

## Summary by Sourcery

Introduce a governed dashboard convergence layer with fail-closed feature flags, privacy-preserving telemetry, and verifiable SQL migration lifecycle.

New Features:
- Expose a non-restrictible /dashboard-governance API to provide dashboard convergence configuration and record usage events.
- Add coarse-grained role bucketing and daily aggregate dashboard usage metrics with a superadmin-only metrics endpoint.

Enhancements:
- Enforce strict validation of dashboard telemetry payloads and bounded state transitions to preserve coherence and privacy.

Build:
- Add a maintenance script and npm task to run periodic pruning of dashboard usage aggregates.

Tests:
- Add tests covering dashboard governance behavior, telemetry safeguards, migration integrity, and support SQL scripts for preflight, verify, and rollback of the dashboard governance schema.