### PR TITLE
feat: moteur de marge prévu/réel auditable

### DIFF
--- a/db/patches/20260805_margin_engine_0001.sql
+++ b/db/patches/20260805_margin_engine_0001.sql
@@ -1,47 +1,101 @@
 -- CERP FEAT-0001 - Moteur de marge auditable.
--- Append-only: les hypotheses historiques ne sont jamais reecrites.
+-- Creation exacte et fail-safe: aucun artefact preexistant n'est adopte.
 
-BEGIN;
+DO $preexisting_guard$
+BEGIN
+  IF to_regclass('public.users') IS NULL THEN
+    RAISE EXCEPTION 'margin engine patch: required users table is missing';
+  END IF;
+  IF to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'margin engine patch: required role cerp_app is missing';
+  END IF;
 
-CREATE TABLE IF NOT EXISTS public.margin_rate_versions (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  IF to_regclass('public.margin_rate_versions') IS NOT NULL
+     OR to_regclass('public.margin_rates') IS NOT NULL
+     OR to_regclass('public.margin_input_versions') IS NOT NULL
+     OR to_regclass('public.margin_recalculations') IS NOT NULL
+     OR to_regprocedure('public.fn_margin_append_only()') IS NOT NULL
+     OR EXISTS (
+       SELECT 1
+       FROM pg_class c
+       JOIN pg_namespace n ON n.oid = c.relnamespace
+       WHERE n.nspname = 'public'
+         AND c.relname = ANY (ARRAY[
+           'margin_rate_versions_pkey',
+           'margin_rate_versions_code_version_uk',
+           'margin_rate_versions_supersedes_uk',
+           'margin_rate_versions_effective_idx',
+           'margin_rates_pkey',
+           'margin_rates_version_code_scope_uk',
+           'margin_rates_resolution_idx',
+           'margin_rates_version_code_scope_coalesced_uk',
+           'margin_input_versions_pkey',
+           'margin_input_versions_supersedes_uk',
+           'margin_input_versions_lookup_idx',
+           'margin_recalculations_pkey',
+           'margin_recalculations_lookup_idx'
+         ])
+     ) THEN
+    RAISE EXCEPTION 'margin engine patch: target artifact already exists without this migration ledger entry';
+  END IF;
+END
+$preexisting_guard$;
+
+CREATE TABLE public.margin_rate_versions (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
   code text NOT NULL,
-  version integer NOT NULL CHECK (version > 0),
-  currency char(3) NOT NULL DEFAULT 'EUR' CHECK (currency = 'EUR'),
+  version integer NOT NULL,
+  currency char(3) NOT NULL DEFAULT 'EUR',
   effective_from date NOT NULL,
   effective_to date NULL,
-  source text NOT NULL CHECK (btrim(source) <> ''),
+  source text NOT NULL,
   assumption_date date NOT NULL,
   notes text NULL,
-  supersedes_id uuid NULL REFERENCES public.margin_rate_versions(id) ON DELETE RESTRICT,
-  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  supersedes_id uuid NULL,
+  created_by integer NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT margin_rate_versions_pkey PRIMARY KEY (id),
+  CONSTRAINT margin_rate_versions_version_ck CHECK (version > 0),
+  CONSTRAINT margin_rate_versions_currency_ck CHECK (currency = 'EUR'),
+  CONSTRAINT margin_rate_versions_source_ck CHECK (btrim(source) <> ''),
   CONSTRAINT margin_rate_versions_dates_ck CHECK (effective_to IS NULL OR effective_to >= effective_from),
   CONSTRAINT margin_rate_versions_code_version_uk UNIQUE (code, version),
-  CONSTRAINT margin_rate_versions_no_self_ck CHECK (supersedes_id IS NULL OR supersedes_id <> id)
+  CONSTRAINT margin_rate_versions_no_self_ck CHECK (supersedes_id IS NULL OR supersedes_id <> id),
+  CONSTRAINT margin_rate_versions_supersedes_fk FOREIGN KEY (supersedes_id)
+    REFERENCES public.margin_rate_versions(id) ON DELETE RESTRICT,
+  CONSTRAINT margin_rate_versions_created_by_fk FOREIGN KEY (created_by)
+    REFERENCES public.users(id) ON DELETE RESTRICT
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS margin_rate_versions_supersedes_uk
+CREATE UNIQUE INDEX margin_rate_versions_supersedes_uk
   ON public.margin_rate_versions(supersedes_id) WHERE supersedes_id IS NOT NULL;
-CREATE INDEX IF NOT EXISTS margin_rate_versions_effective_idx
+CREATE INDEX margin_rate_versions_effective_idx
   ON public.margin_rate_versions(code, effective_from DESC, effective_to);
 
-CREATE TABLE IF NOT EXISTS public.margin_rates (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  rate_version_id uuid NOT NULL REFERENCES public.margin_rate_versions(id) ON DELETE RESTRICT,
-  rate_code text NOT NULL CHECK (btrim(rate_code) <> ''),
-  category text NOT NULL CHECK (category IN (
+CREATE TABLE public.margin_rates (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  rate_version_id uuid NOT NULL,
+  rate_code text NOT NULL,
+  category text NOT NULL,
+  scope_type text NOT NULL DEFAULT 'GLOBAL',
+  scope_ref text NULL,
+  amount numeric(18,6) NOT NULL,
+  unit text NOT NULL,
+  source_ref text NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT margin_rates_pkey PRIMARY KEY (id),
+  CONSTRAINT margin_rates_rate_version_fk FOREIGN KEY (rate_version_id)
+    REFERENCES public.margin_rate_versions(id) ON DELETE RESTRICT,
+  CONSTRAINT margin_rates_rate_code_ck CHECK (btrim(rate_code) <> ''),
+  CONSTRAINT margin_rates_category_ck CHECK (category IN (
     'MATERIAL','PURCHASE','SUBCONTRACTING','MACHINE','OPERATOR','CONTROL',
     'TOOLING','PACKAGING','TRANSPORT','SCRAP','OVERHEAD'
   )),
-  scope_type text NOT NULL DEFAULT 'GLOBAL' CHECK (scope_type IN (
+  CONSTRAINT margin_rates_scope_type_ck CHECK (scope_type IN (
     'GLOBAL','USER','MACHINE','COST_CENTER','PIECE_TECHNIQUE'
   )),
-  scope_ref text NULL,
-  amount numeric(18,6) NOT NULL CHECK (amount >= 0),
-  unit text NOT NULL CHECK (unit IN ('EUR_PER_HOUR','EUR_PER_UNIT','PERCENT_OF_DIRECT_COST')),
-  source_ref text NULL,
-  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT margin_rates_amount_ck CHECK (amount >= 0),
+  CONSTRAINT margin_rates_unit_ck CHECK (unit IN ('EUR_PER_HOUR','EUR_PER_UNIT','PERCENT_OF_DIRECT_COST')),
   CONSTRAINT margin_rates_scope_ck CHECK (
     (scope_type = 'GLOBAL' AND scope_ref IS NULL) OR
     (scope_type <> 'GLOBAL' AND scope_ref IS NOT NULL AND btrim(scope_ref) <> '')
@@ -49,37 +103,55 @@ CREATE TABLE IF NOT EXISTS public.margin_rates (
   CONSTRAINT margin_rates_version_code_scope_uk UNIQUE (rate_version_id, rate_code, scope_type, scope_ref)
 );
 
-CREATE INDEX IF NOT EXISTS margin_rates_resolution_idx
+CREATE INDEX margin_rates_resolution_idx
   ON public.margin_rates(category, scope_type, scope_ref, rate_version_id);
-CREATE UNIQUE INDEX IF NOT EXISTS margin_rates_version_code_scope_coalesced_uk
+CREATE UNIQUE INDEX margin_rates_version_code_scope_coalesced_uk
   ON public.margin_rates(rate_version_id, rate_code, scope_type, COALESCE(scope_ref, ''));
 
-CREATE TABLE IF NOT EXISTS public.margin_input_versions (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  scope_type text NOT NULL CHECK (scope_type IN ('DEVIS_LINE','DEVIS','AFFAIRE','OF')),
-  scope_ref text NOT NULL CHECK (btrim(scope_ref) <> ''),
-  basis text NOT NULL CHECK (basis IN ('PLANNED','ACTUAL')),
-  input_key text NOT NULL CHECK (btrim(input_key) <> ''),
-  input_kind text NOT NULL CHECK (input_kind IN ('REVENUE','COST')),
-  category text NULL CHECK (category IS NULL OR category IN (
-    'MATERIAL','PURCHASE','SUBCONTRACTING','MACHINE','OPERATOR','CONTROL',
-    'TOOLING','PACKAGING','TRANSPORT','SCRAP','OVERHEAD'
-  )),
-  availability text NOT NULL CHECK (availability IN ('PROVIDED','NOT_APPLICABLE')),
-  amount_ht numeric(18,6) NULL CHECK (amount_ht IS NULL OR amount_ht >= 0),
-  quantity numeric(18,6) NULL CHECK (quantity IS NULL OR quantity >= 0),
-  rate_id uuid NULL REFERENCES public.margin_rates(id) ON DELETE RESTRICT,
+CREATE TABLE public.margin_input_versions (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  scope_type text NOT NULL,
+  scope_ref text NOT NULL,
+  basis text NOT NULL,
+  input_key text NOT NULL,
+  input_kind text NOT NULL,
+  category text NULL,
+  availability text NOT NULL,
+  amount_ht numeric(18,6) NULL,
+  quantity numeric(18,6) NULL,
+  rate_id uuid NULL,
   rate_effective_at date NULL,
   rate_validation_snapshot jsonb NULL,
-  currency char(3) NOT NULL DEFAULT 'EUR' CHECK (currency = 'EUR'),
-  source_type text NOT NULL CHECK (btrim(source_type) <> ''),
+  currency char(3) NOT NULL DEFAULT 'EUR',
+  source_type text NOT NULL,
   source_ref text NULL,
   observed_at timestamptz NULL,
   assumption text NULL,
   assumption_date date NULL,
-  supersedes_id uuid NULL REFERENCES public.margin_input_versions(id) ON DELETE RESTRICT,
-  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  supersedes_id uuid NULL,
+  created_by integer NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT margin_input_versions_pkey PRIMARY KEY (id),
+  CONSTRAINT margin_input_versions_scope_type_ck CHECK (scope_type IN ('DEVIS_LINE','DEVIS','AFFAIRE','OF')),
+  CONSTRAINT margin_input_versions_scope_ref_ck CHECK (btrim(scope_ref) <> ''),
+  CONSTRAINT margin_input_versions_basis_ck CHECK (basis IN ('PLANNED','ACTUAL')),
+  CONSTRAINT margin_input_versions_input_key_ck CHECK (btrim(input_key) <> ''),
+  CONSTRAINT margin_input_versions_input_kind_ck CHECK (input_kind IN ('REVENUE','COST')),
+  CONSTRAINT margin_input_versions_category_ck CHECK (category IS NULL OR category IN (
+    'MATERIAL','PURCHASE','SUBCONTRACTING','MACHINE','OPERATOR','CONTROL',
+    'TOOLING','PACKAGING','TRANSPORT','SCRAP','OVERHEAD'
+  )),
+  CONSTRAINT margin_input_versions_availability_ck CHECK (availability IN ('PROVIDED','NOT_APPLICABLE')),
+  CONSTRAINT margin_input_versions_amount_ht_ck CHECK (amount_ht IS NULL OR amount_ht >= 0),
+  CONSTRAINT margin_input_versions_quantity_ck CHECK (quantity IS NULL OR quantity >= 0),
+  CONSTRAINT margin_input_versions_rate_fk FOREIGN KEY (rate_id)
+    REFERENCES public.margin_rates(id) ON DELETE RESTRICT,
+  CONSTRAINT margin_input_versions_currency_ck CHECK (currency = 'EUR'),
+  CONSTRAINT margin_input_versions_source_type_ck CHECK (btrim(source_type) <> ''),
+  CONSTRAINT margin_input_versions_supersedes_fk FOREIGN KEY (supersedes_id)
+    REFERENCES public.margin_input_versions(id) ON DELETE RESTRICT,
+  CONSTRAINT margin_input_versions_created_by_fk FOREIGN KEY (created_by)
+    REFERENCES public.users(id) ON DELETE RESTRICT,
   CONSTRAINT margin_input_versions_kind_ck CHECK (
     (input_kind = 'REVENUE' AND category IS NULL) OR
     (input_kind = 'COST' AND category IS NOT NULL)
@@ -104,54 +176,59 @@ CREATE TABLE IF NOT EXISTS public.margin_input_versions (
   CONSTRAINT margin_input_versions_no_self_ck CHECK (supersedes_id IS NULL OR supersedes_id <> id)
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS margin_input_versions_supersedes_uk
+CREATE UNIQUE INDEX margin_input_versions_supersedes_uk
   ON public.margin_input_versions(supersedes_id) WHERE supersedes_id IS NOT NULL;
-CREATE INDEX IF NOT EXISTS margin_input_versions_lookup_idx
+CREATE INDEX margin_input_versions_lookup_idx
   ON public.margin_input_versions(scope_type, scope_ref, basis, input_key, created_at DESC);
 
-CREATE TABLE IF NOT EXISTS public.margin_recalculations (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  scope_type text NOT NULL CHECK (scope_type IN ('DEVIS_LINE','DEVIS','AFFAIRE','OF')),
-  scope_ref text NOT NULL CHECK (btrim(scope_ref) <> ''),
-  basis text NOT NULL CHECK (basis IN ('PLANNED','ACTUAL')),
+CREATE TABLE public.margin_recalculations (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  scope_type text NOT NULL,
+  scope_ref text NOT NULL,
+  basis text NOT NULL,
   as_of date NOT NULL,
   formula_version text NOT NULL,
-  calculation_hash char(64) NOT NULL CHECK (calculation_hash ~ '^[0-9a-f]{64}$'),
+  calculation_hash char(64) NOT NULL,
   input_snapshot jsonb NOT NULL,
   result_snapshot jsonb NOT NULL,
-  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
-  created_at timestamptz NOT NULL DEFAULT now()
+  created_by integer NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT margin_recalculations_pkey PRIMARY KEY (id),
+  CONSTRAINT margin_recalculations_scope_type_ck CHECK (scope_type IN ('DEVIS_LINE','DEVIS','AFFAIRE','OF')),
+  CONSTRAINT margin_recalculations_scope_ref_ck CHECK (btrim(scope_ref) <> ''),
+  CONSTRAINT margin_recalculations_basis_ck CHECK (basis IN ('PLANNED','ACTUAL')),
+  CONSTRAINT margin_recalculations_hash_ck CHECK (calculation_hash ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT margin_recalculations_created_by_fk FOREIGN KEY (created_by)
+    REFERENCES public.users(id) ON DELETE RESTRICT
 );
 
-CREATE INDEX IF NOT EXISTS margin_recalculations_lookup_idx
+CREATE INDEX margin_recalculations_lookup_idx
   ON public.margin_recalculations(scope_type, scope_ref, basis, created_at DESC);
 
-CREATE OR REPLACE FUNCTION public.fn_margin_append_only()
+CREATE FUNCTION public.fn_margin_append_only()
 RETURNS trigger
 LANGUAGE plpgsql
-AS $$
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $append_only$
 BEGIN
   RAISE EXCEPTION '% is append-only; create a superseding version instead', TG_TABLE_NAME
     USING ERRCODE = '55000';
-END;
-$$;
+END
+$append_only$;
 
-DROP TRIGGER IF EXISTS trg_margin_rate_versions_append_only ON public.margin_rate_versions;
 CREATE TRIGGER trg_margin_rate_versions_append_only
   BEFORE UPDATE OR DELETE ON public.margin_rate_versions
   FOR EACH ROW EXECUTE FUNCTION public.fn_margin_append_only();
 
-DROP TRIGGER IF EXISTS trg_margin_rates_append_only ON public.margin_rates;
 CREATE TRIGGER trg_margin_rates_append_only
   BEFORE UPDATE OR DELETE ON public.margin_rates
   FOR EACH ROW EXECUTE FUNCTION public.fn_margin_append_only();
 
-DROP TRIGGER IF EXISTS trg_margin_input_versions_append_only ON public.margin_input_versions;
 CREATE TRIGGER trg_margin_input_versions_append_only
   BEFORE UPDATE OR DELETE ON public.margin_input_versions
   FOR EACH ROW EXECUTE FUNCTION public.fn_margin_append_only();
 
-DROP TRIGGER IF EXISTS trg_margin_recalculations_append_only ON public.margin_recalculations;
 CREATE TRIGGER trg_margin_recalculations_append_only
   BEFORE UPDATE OR DELETE ON public.margin_recalculations
   FOR EACH ROW EXECUTE FUNCTION public.fn_margin_append_only();
@@ -160,5 +237,23 @@ COMMENT ON TABLE public.margin_input_versions IS
   'Entrees de marge datees et append-only. Une absence reste absente; NOT_APPLICABLE est explicite.';
 COMMENT ON TABLE public.margin_recalculations IS
   'Preuves de recalcul immuables: formule, entrees, resultat et empreinte SHA-256.';
+COMMENT ON FUNCTION public.fn_margin_append_only() IS
+  'Refuse UPDATE et DELETE sur les quatre relations de preuve du moteur de marge.';
 
-COMMIT;
+ALTER TABLE public.margin_rate_versions OWNER TO cerp_app;
+ALTER TABLE public.margin_rates OWNER TO cerp_app;
+ALTER TABLE public.margin_input_versions OWNER TO cerp_app;
+ALTER TABLE public.margin_recalculations OWNER TO cerp_app;
+ALTER FUNCTION public.fn_margin_append_only() OWNER TO cerp_app;
+
+REVOKE ALL ON TABLE public.margin_rate_versions FROM PUBLIC;
+REVOKE ALL ON TABLE public.margin_rates FROM PUBLIC;
+REVOKE ALL ON TABLE public.margin_input_versions FROM PUBLIC;
+REVOKE ALL ON TABLE public.margin_recalculations FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.fn_margin_append_only() FROM PUBLIC;
+
+GRANT SELECT, INSERT ON TABLE public.margin_rate_versions TO cerp_app;
+GRANT SELECT, INSERT ON TABLE public.margin_rates TO cerp_app;
+GRANT SELECT, INSERT ON TABLE public.margin_input_versions TO cerp_app;
+GRANT SELECT, INSERT ON TABLE public.margin_recalculations TO cerp_app;
+GRANT EXECUTE ON FUNCTION public.fn_margin_append_only() TO cerp_app;

--- a/db/patches/20260805_margin_engine_0001.sql
+++ b/db/patches/20260805_margin_engine_0001.sql
@@ -69,6 +69,8 @@ CREATE TABLE IF NOT EXISTS public.margin_input_versions (
   amount_ht numeric(18,6) NULL CHECK (amount_ht IS NULL OR amount_ht >= 0),
   quantity numeric(18,6) NULL CHECK (quantity IS NULL OR quantity >= 0),
   rate_id uuid NULL REFERENCES public.margin_rates(id) ON DELETE RESTRICT,
+  rate_effective_at date NULL,
+  rate_validation_snapshot jsonb NULL,
   currency char(3) NOT NULL DEFAULT 'EUR' CHECK (currency = 'EUR'),
   source_type text NOT NULL CHECK (btrim(source_type) <> ''),
   source_ref text NULL,
@@ -83,8 +85,18 @@ CREATE TABLE IF NOT EXISTS public.margin_input_versions (
     (input_kind = 'COST' AND category IS NOT NULL)
   ),
   CONSTRAINT margin_input_versions_value_ck CHECK (
-    (availability = 'NOT_APPLICABLE' AND amount_ht IS NULL AND quantity IS NULL AND rate_id IS NULL) OR
-    (availability = 'PROVIDED' AND (amount_ht IS NOT NULL OR rate_id IS NOT NULL))
+    (availability = 'NOT_APPLICABLE'
+      AND amount_ht IS NULL AND quantity IS NULL AND rate_id IS NULL
+      AND rate_effective_at IS NULL AND rate_validation_snapshot IS NULL) OR
+    (availability = 'PROVIDED' AND (
+      (amount_ht IS NOT NULL AND rate_id IS NULL AND quantity IS NULL
+        AND rate_effective_at IS NULL AND rate_validation_snapshot IS NULL) OR
+      (amount_ht IS NULL AND rate_id IS NOT NULL
+        AND rate_effective_at IS NOT NULL AND rate_validation_snapshot IS NOT NULL)
+    ))
+  ),
+  CONSTRAINT margin_input_versions_rate_snapshot_ck CHECK (
+    rate_validation_snapshot IS NULL OR jsonb_typeof(rate_validation_snapshot) = 'object'
   ),
   CONSTRAINT margin_input_versions_assumption_ck CHECK (
     assumption IS NULL OR (btrim(assumption) <> '' AND assumption_date IS NOT NULL)

--- a/db/patches/20260805_margin_engine_0001.sql
+++ b/db/patches/20260805_margin_engine_0001.sql
@@ -1,0 +1,152 @@
+-- CERP FEAT-0001 - Moteur de marge auditable.
+-- Append-only: les hypotheses historiques ne sont jamais reecrites.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.margin_rate_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  code text NOT NULL,
+  version integer NOT NULL CHECK (version > 0),
+  currency char(3) NOT NULL DEFAULT 'EUR' CHECK (currency = 'EUR'),
+  effective_from date NOT NULL,
+  effective_to date NULL,
+  source text NOT NULL CHECK (btrim(source) <> ''),
+  assumption_date date NOT NULL,
+  notes text NULL,
+  supersedes_id uuid NULL REFERENCES public.margin_rate_versions(id) ON DELETE RESTRICT,
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT margin_rate_versions_dates_ck CHECK (effective_to IS NULL OR effective_to >= effective_from),
+  CONSTRAINT margin_rate_versions_code_version_uk UNIQUE (code, version),
+  CONSTRAINT margin_rate_versions_no_self_ck CHECK (supersedes_id IS NULL OR supersedes_id <> id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS margin_rate_versions_supersedes_uk
+  ON public.margin_rate_versions(supersedes_id) WHERE supersedes_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS margin_rate_versions_effective_idx
+  ON public.margin_rate_versions(code, effective_from DESC, effective_to);
+
+CREATE TABLE IF NOT EXISTS public.margin_rates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  rate_version_id uuid NOT NULL REFERENCES public.margin_rate_versions(id) ON DELETE RESTRICT,
+  rate_code text NOT NULL CHECK (btrim(rate_code) <> ''),
+  category text NOT NULL CHECK (category IN (
+    'MATERIAL','PURCHASE','SUBCONTRACTING','MACHINE','OPERATOR','CONTROL',
+    'TOOLING','PACKAGING','TRANSPORT','SCRAP','OVERHEAD'
+  )),
+  scope_type text NOT NULL DEFAULT 'GLOBAL' CHECK (scope_type IN (
+    'GLOBAL','USER','MACHINE','COST_CENTER','PIECE_TECHNIQUE'
+  )),
+  scope_ref text NULL,
+  amount numeric(18,6) NOT NULL CHECK (amount >= 0),
+  unit text NOT NULL CHECK (unit IN ('EUR_PER_HOUR','EUR_PER_UNIT','PERCENT_OF_DIRECT_COST')),
+  source_ref text NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT margin_rates_scope_ck CHECK (
+    (scope_type = 'GLOBAL' AND scope_ref IS NULL) OR
+    (scope_type <> 'GLOBAL' AND scope_ref IS NOT NULL AND btrim(scope_ref) <> '')
+  ),
+  CONSTRAINT margin_rates_version_code_scope_uk UNIQUE (rate_version_id, rate_code, scope_type, scope_ref)
+);
+
+CREATE INDEX IF NOT EXISTS margin_rates_resolution_idx
+  ON public.margin_rates(category, scope_type, scope_ref, rate_version_id);
+CREATE UNIQUE INDEX IF NOT EXISTS margin_rates_version_code_scope_coalesced_uk
+  ON public.margin_rates(rate_version_id, rate_code, scope_type, COALESCE(scope_ref, ''));
+
+CREATE TABLE IF NOT EXISTS public.margin_input_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope_type text NOT NULL CHECK (scope_type IN ('DEVIS_LINE','DEVIS','AFFAIRE','OF')),
+  scope_ref text NOT NULL CHECK (btrim(scope_ref) <> ''),
+  basis text NOT NULL CHECK (basis IN ('PLANNED','ACTUAL')),
+  input_key text NOT NULL CHECK (btrim(input_key) <> ''),
+  input_kind text NOT NULL CHECK (input_kind IN ('REVENUE','COST')),
+  category text NULL CHECK (category IS NULL OR category IN (
+    'MATERIAL','PURCHASE','SUBCONTRACTING','MACHINE','OPERATOR','CONTROL',
+    'TOOLING','PACKAGING','TRANSPORT','SCRAP','OVERHEAD'
+  )),
+  availability text NOT NULL CHECK (availability IN ('PROVIDED','NOT_APPLICABLE')),
+  amount_ht numeric(18,6) NULL CHECK (amount_ht IS NULL OR amount_ht >= 0),
+  quantity numeric(18,6) NULL CHECK (quantity IS NULL OR quantity >= 0),
+  rate_id uuid NULL REFERENCES public.margin_rates(id) ON DELETE RESTRICT,
+  currency char(3) NOT NULL DEFAULT 'EUR' CHECK (currency = 'EUR'),
+  source_type text NOT NULL CHECK (btrim(source_type) <> ''),
+  source_ref text NULL,
+  observed_at timestamptz NULL,
+  assumption text NULL,
+  assumption_date date NULL,
+  supersedes_id uuid NULL REFERENCES public.margin_input_versions(id) ON DELETE RESTRICT,
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT margin_input_versions_kind_ck CHECK (
+    (input_kind = 'REVENUE' AND category IS NULL) OR
+    (input_kind = 'COST' AND category IS NOT NULL)
+  ),
+  CONSTRAINT margin_input_versions_value_ck CHECK (
+    (availability = 'NOT_APPLICABLE' AND amount_ht IS NULL AND quantity IS NULL AND rate_id IS NULL) OR
+    (availability = 'PROVIDED' AND (amount_ht IS NOT NULL OR rate_id IS NOT NULL))
+  ),
+  CONSTRAINT margin_input_versions_assumption_ck CHECK (
+    assumption IS NULL OR (btrim(assumption) <> '' AND assumption_date IS NOT NULL)
+  ),
+  CONSTRAINT margin_input_versions_no_self_ck CHECK (supersedes_id IS NULL OR supersedes_id <> id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS margin_input_versions_supersedes_uk
+  ON public.margin_input_versions(supersedes_id) WHERE supersedes_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS margin_input_versions_lookup_idx
+  ON public.margin_input_versions(scope_type, scope_ref, basis, input_key, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.margin_recalculations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope_type text NOT NULL CHECK (scope_type IN ('DEVIS_LINE','DEVIS','AFFAIRE','OF')),
+  scope_ref text NOT NULL CHECK (btrim(scope_ref) <> ''),
+  basis text NOT NULL CHECK (basis IN ('PLANNED','ACTUAL')),
+  as_of date NOT NULL,
+  formula_version text NOT NULL,
+  calculation_hash char(64) NOT NULL CHECK (calculation_hash ~ '^[0-9a-f]{64}$'),
+  input_snapshot jsonb NOT NULL,
+  result_snapshot jsonb NOT NULL,
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS margin_recalculations_lookup_idx
+  ON public.margin_recalculations(scope_type, scope_ref, basis, created_at DESC);
+
+CREATE OR REPLACE FUNCTION public.fn_margin_append_only()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION '% is append-only; create a superseding version instead', TG_TABLE_NAME
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_margin_rate_versions_append_only ON public.margin_rate_versions;
+CREATE TRIGGER trg_margin_rate_versions_append_only
+  BEFORE UPDATE OR DELETE ON public.margin_rate_versions
+  FOR EACH ROW EXECUTE FUNCTION public.fn_margin_append_only();
+
+DROP TRIGGER IF EXISTS trg_margin_rates_append_only ON public.margin_rates;
+CREATE TRIGGER trg_margin_rates_append_only
+  BEFORE UPDATE OR DELETE ON public.margin_rates
+  FOR EACH ROW EXECUTE FUNCTION public.fn_margin_append_only();
+
+DROP TRIGGER IF EXISTS trg_margin_input_versions_append_only ON public.margin_input_versions;
+CREATE TRIGGER trg_margin_input_versions_append_only
+  BEFORE UPDATE OR DELETE ON public.margin_input_versions
+  FOR EACH ROW EXECUTE FUNCTION public.fn_margin_append_only();
+
+DROP TRIGGER IF EXISTS trg_margin_recalculations_append_only ON public.margin_recalculations;
+CREATE TRIGGER trg_margin_recalculations_append_only
+  BEFORE UPDATE OR DELETE ON public.margin_recalculations
+  FOR EACH ROW EXECUTE FUNCTION public.fn_margin_append_only();
+
+COMMENT ON TABLE public.margin_input_versions IS
+  'Entrees de marge datees et append-only. Une absence reste absente; NOT_APPLICABLE est explicite.';
+COMMENT ON TABLE public.margin_recalculations IS
+  'Preuves de recalcul immuables: formule, entrees, resultat et empreinte SHA-256.';
+
+COMMIT;

--- a/db/patches/support/20260805_margin_engine_0001.cerp_test_demo.sql
+++ b/db/patches/support/20260805_margin_engine_0001.cerp_test_demo.sql
@@ -1,0 +1,35 @@
+-- DEMO SEULEMENT. Ne jamais executer sur cerp_prod.
+-- Prerequis navigateur: creer un devis TEST_TD_MARGIN_*, une commande puis un OF,
+-- et saisir un pointage + une declaration de rebut depuis l'UI.
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Demo margin engine refusee: base attendue cerp_test, base courante %', current_database();
+  END IF;
+END $$;
+
+-- Les donnees metier TEST_TD_* se creent exclusivement via l'UI.
+-- Les hypotheses suivantes se creent via POST /api/v1/margins/rate-versions
+-- et POST /api/v1/margins/inputs afin de conserver auteur et journal d'audit.
+SELECT
+  d.id,
+  d.numero,
+  d.total_ht,
+  count(dl.id) AS line_count
+FROM public.devis d
+LEFT JOIN public.devis_ligne dl ON dl.devis_id = d.id
+WHERE d.numero LIKE 'TEST_TD_MARGIN_%'
+GROUP BY d.id, d.numero, d.total_ht
+ORDER BY d.id DESC;
+
+SELECT
+  o.id,
+  o.numero,
+  sum(op.temps_total_planned) AS planned_hours,
+  sum(op.temps_total_real) AS actual_hours,
+  sum(op.hourly_rate_applied * op.temps_total_real) AS traceable_actual_operator_cost
+FROM public.ordres_fabrication o
+LEFT JOIN public.of_operations op ON op.of_id = o.id
+WHERE o.numero LIKE 'TEST_TD_MARGIN_%'
+GROUP BY o.id, o.numero
+ORDER BY o.id DESC;

--- a/db/patches/support/20260805_margin_engine_0001.preflight.sql
+++ b/db/patches/support/20260805_margin_engine_0001.preflight.sql
@@ -1,15 +1,104 @@
--- Lecture seule. A executer avant le patch dans la base cible.
-SELECT current_database() AS database_name, current_user AS database_user;
+\set ON_ERROR_STOP on
 
-SELECT
-  to_regclass('public.users') AS users_table,
-  to_regclass('public.devis') AS devis_table,
-  to_regclass('public.devis_ligne') AS devis_line_table,
-  to_regclass('public.ordres_fabrication') AS of_table,
-  to_regclass('public.of_operations') AS of_operations_table;
+-- Preflight strictement read-only. Il refuse toute adoption d'artefact sans
+-- provenance exacte dans le registre immuable du runner.
+BEGIN TRANSACTION READ ONLY;
 
-SELECT table_name
-FROM information_schema.tables
-WHERE table_schema = 'public'
-  AND table_name IN ('margin_rate_versions','margin_rates','margin_input_versions','margin_recalculations')
-ORDER BY table_name;
+DO $preflight$
+DECLARE
+  expected_sha256 constant text := 'bc0706c2af406d9a8e9f8221beb05492f9f0f7eba879de26cb77c8542863f514';
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  registry_entry_exists boolean := false;
+  target_table_count integer;
+  target_index_count integer;
+  target_trigger_count integer;
+  target_function_exists boolean := to_regprocedure('public.fn_margin_append_only()') IS NOT NULL;
+BEGIN
+  IF to_regclass('public.users') IS NULL THEN
+    RAISE EXCEPTION 'margin engine preflight: required users table is missing';
+  END IF;
+  IF to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'margin engine preflight: required role cerp_app is missing';
+  END IF;
+  IF to_regprocedure('pg_catalog.gen_random_uuid()') IS NULL THEN
+    RAISE EXCEPTION 'margin engine preflight: gen_random_uuid() is unavailable';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO target_table_count
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relkind IN ('r', 'p')
+    AND c.relname = ANY (ARRAY[
+      'margin_rate_versions', 'margin_rates',
+      'margin_input_versions', 'margin_recalculations'
+    ]);
+
+  SELECT COUNT(*)::integer
+    INTO target_index_count
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relkind = 'i'
+    AND c.relname = ANY (ARRAY[
+      'margin_rate_versions_pkey',
+      'margin_rate_versions_code_version_uk',
+      'margin_rate_versions_supersedes_uk',
+      'margin_rate_versions_effective_idx',
+      'margin_rates_pkey',
+      'margin_rates_version_code_scope_uk',
+      'margin_rates_resolution_idx',
+      'margin_rates_version_code_scope_coalesced_uk',
+      'margin_input_versions_pkey',
+      'margin_input_versions_supersedes_uk',
+      'margin_input_versions_lookup_idx',
+      'margin_recalculations_pkey',
+      'margin_recalculations_lookup_idx'
+    ]);
+
+  SELECT COUNT(*)::integer
+    INTO target_trigger_count
+  FROM pg_trigger t
+  JOIN pg_class c ON c.oid = t.tgrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = ANY (ARRAY[
+      'margin_rate_versions', 'margin_rates',
+      'margin_input_versions', 'margin_recalculations'
+    ])
+    AND NOT t.tgisinternal;
+
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    SELECT sha256, applied_at
+      INTO registered_sha256, registered_applied_at
+    FROM public.cerp_schema_migrations
+    WHERE filename = '20260805_margin_engine_0001.sql';
+    registry_entry_exists := FOUND;
+  END IF;
+
+  IF registry_entry_exists THEN
+    IF registered_sha256 IS DISTINCT FROM expected_sha256 OR registered_applied_at IS NULL THEN
+      RAISE EXCEPTION 'margin engine preflight: migration ledger provenance is invalid';
+    END IF;
+    IF target_table_count <> 4 OR target_index_count <> 13
+       OR target_trigger_count <> 4 OR NOT target_function_exists THEN
+      RAISE EXCEPTION 'margin engine preflight: ledger exists but target artifacts are incomplete';
+    END IF;
+    RAISE NOTICE 'margin engine preflight: exact patch is already registered';
+    RETURN;
+  END IF;
+
+  IF target_table_count <> 0 OR target_index_count <> 0
+     OR target_trigger_count <> 0 OR target_function_exists THEN
+    RAISE EXCEPTION 'margin engine preflight: target artifact exists without its migration ledger entry';
+  END IF;
+END
+$preflight$;
+
+SELECT current_database() AS database_name,
+       current_user AS actor,
+       'margin engine preflight passed (read-only)' AS result;
+
+ROLLBACK;

--- a/db/patches/support/20260805_margin_engine_0001.preflight.sql
+++ b/db/patches/support/20260805_margin_engine_0001.preflight.sql
@@ -1,0 +1,15 @@
+-- Lecture seule. A executer avant le patch dans la base cible.
+SELECT current_database() AS database_name, current_user AS database_user;
+
+SELECT
+  to_regclass('public.users') AS users_table,
+  to_regclass('public.devis') AS devis_table,
+  to_regclass('public.devis_ligne') AS devis_line_table,
+  to_regclass('public.ordres_fabrication') AS of_table,
+  to_regclass('public.of_operations') AS of_operations_table;
+
+SELECT table_name
+FROM information_schema.tables
+WHERE table_schema = 'public'
+  AND table_name IN ('margin_rate_versions','margin_rates','margin_input_versions','margin_recalculations')
+ORDER BY table_name;

--- a/db/patches/support/20260805_margin_engine_0001.rollback.sql
+++ b/db/patches/support/20260805_margin_engine_0001.rollback.sql
@@ -1,0 +1,15 @@
+-- Repli destructif uniquement pour les donnees de CE patch. Sauvegarder avant execution.
+BEGIN;
+
+DROP TRIGGER IF EXISTS trg_margin_recalculations_append_only ON public.margin_recalculations;
+DROP TRIGGER IF EXISTS trg_margin_input_versions_append_only ON public.margin_input_versions;
+DROP TRIGGER IF EXISTS trg_margin_rates_append_only ON public.margin_rates;
+DROP TRIGGER IF EXISTS trg_margin_rate_versions_append_only ON public.margin_rate_versions;
+
+DROP TABLE IF EXISTS public.margin_recalculations;
+DROP TABLE IF EXISTS public.margin_input_versions;
+DROP TABLE IF EXISTS public.margin_rates;
+DROP TABLE IF EXISTS public.margin_rate_versions;
+DROP FUNCTION IF EXISTS public.fn_margin_append_only();
+
+COMMIT;

--- a/db/patches/support/20260805_margin_engine_0001.rollback.sql
+++ b/db/patches/support/20260805_margin_engine_0001.rollback.sql
@@ -1,15 +1,294 @@
--- Repli destructif uniquement pour les donnees de CE patch. Sauvegarder avant execution.
+\set ON_ERROR_STOP on
+
+-- Rollback destructif strictement reserve aux bases jetables de dev/test.
+-- Il refuse les donnees, les artefacts partiels, les owners inattendus et toute
+-- provenance differente du checksum canonique du patch.
 BEGIN;
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
 
-DROP TRIGGER IF EXISTS trg_margin_recalculations_append_only ON public.margin_recalculations;
-DROP TRIGGER IF EXISTS trg_margin_input_versions_append_only ON public.margin_input_versions;
-DROP TRIGGER IF EXISTS trg_margin_rates_append_only ON public.margin_rates;
-DROP TRIGGER IF EXISTS trg_margin_rate_versions_append_only ON public.margin_rate_versions;
+DO $environment_guard$
+BEGIN
+  IF current_database() NOT IN ('cerp_dev', 'cerp_test') THEN
+    RAISE EXCEPTION 'margin engine rollback is restricted to cerp_dev/cerp_test';
+  END IF;
+END
+$environment_guard$;
 
-DROP TABLE IF EXISTS public.margin_recalculations;
-DROP TABLE IF EXISTS public.margin_input_versions;
-DROP TABLE IF EXISTS public.margin_rates;
-DROP TABLE IF EXISTS public.margin_rate_versions;
-DROP FUNCTION IF EXISTS public.fn_margin_append_only();
+SELECT pg_advisory_xact_lock(hashtext('cerp_schema_migrations'));
+
+DO $rollback$
+DECLARE
+  expected_sha256 constant text := 'bc0706c2af406d9a8e9f8221beb05492f9f0f7eba879de26cb77c8542863f514';
+  expected_constraints constant text[] := ARRAY[
+    'margin_rate_versions_pkey',
+    'margin_rate_versions_version_ck',
+    'margin_rate_versions_currency_ck',
+    'margin_rate_versions_source_ck',
+    'margin_rate_versions_dates_ck',
+    'margin_rate_versions_code_version_uk',
+    'margin_rate_versions_no_self_ck',
+    'margin_rate_versions_supersedes_fk',
+    'margin_rate_versions_created_by_fk',
+    'margin_rates_pkey',
+    'margin_rates_rate_version_fk',
+    'margin_rates_rate_code_ck',
+    'margin_rates_category_ck',
+    'margin_rates_scope_type_ck',
+    'margin_rates_amount_ck',
+    'margin_rates_unit_ck',
+    'margin_rates_scope_ck',
+    'margin_rates_version_code_scope_uk',
+    'margin_input_versions_pkey',
+    'margin_input_versions_scope_type_ck',
+    'margin_input_versions_scope_ref_ck',
+    'margin_input_versions_basis_ck',
+    'margin_input_versions_input_key_ck',
+    'margin_input_versions_input_kind_ck',
+    'margin_input_versions_category_ck',
+    'margin_input_versions_availability_ck',
+    'margin_input_versions_amount_ht_ck',
+    'margin_input_versions_quantity_ck',
+    'margin_input_versions_rate_fk',
+    'margin_input_versions_currency_ck',
+    'margin_input_versions_source_type_ck',
+    'margin_input_versions_supersedes_fk',
+    'margin_input_versions_created_by_fk',
+    'margin_input_versions_kind_ck',
+    'margin_input_versions_value_ck',
+    'margin_input_versions_rate_snapshot_ck',
+    'margin_input_versions_assumption_ck',
+    'margin_input_versions_no_self_ck',
+    'margin_recalculations_pkey',
+    'margin_recalculations_scope_type_ck',
+    'margin_recalculations_scope_ref_ck',
+    'margin_recalculations_basis_ck',
+    'margin_recalculations_hash_ck',
+    'margin_recalculations_created_by_fk'
+  ];
+  expected_indexes constant text[] := ARRAY[
+    'margin_rate_versions_pkey',
+    'margin_rate_versions_code_version_uk',
+    'margin_rate_versions_supersedes_uk',
+    'margin_rate_versions_effective_idx',
+    'margin_rates_pkey',
+    'margin_rates_version_code_scope_uk',
+    'margin_rates_resolution_idx',
+    'margin_rates_version_code_scope_coalesced_uk',
+    'margin_input_versions_pkey',
+    'margin_input_versions_supersedes_uk',
+    'margin_input_versions_lookup_idx',
+    'margin_recalculations_pkey',
+    'margin_recalculations_lookup_idx'
+  ];
+  expected_triggers constant text[] := ARRAY[
+    'trg_margin_rate_versions_append_only',
+    'trg_margin_rates_append_only',
+    'trg_margin_input_versions_append_only',
+    'trg_margin_recalculations_append_only'
+  ];
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  registry_entry_exists boolean := false;
+  cerp_app_oid oid;
+  table_count integer;
+  index_count integer;
+  trigger_count integer;
+  function_exists boolean;
+  owned_table_count integer;
+  function_owner oid;
+  total_column_count integer;
+  total_constraint_count integer;
+  expected_constraint_count integer;
+  expected_index_count integer;
+  expected_trigger_count integer;
+  evidence_row_count bigint;
+  deleted_rows integer;
+BEGIN
+  SELECT COUNT(*)::integer
+    INTO table_count
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relkind IN ('r', 'p')
+    AND c.relname = ANY (ARRAY[
+      'margin_rate_versions', 'margin_rates',
+      'margin_input_versions', 'margin_recalculations'
+    ]);
+
+  SELECT COUNT(*)::integer
+    INTO index_count
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relkind = 'i'
+    AND c.relname = ANY (expected_indexes);
+
+  SELECT COUNT(*)::integer
+    INTO trigger_count
+  FROM pg_trigger t
+  JOIN pg_class c ON c.oid = t.tgrelid
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = ANY (ARRAY[
+      'margin_rate_versions', 'margin_rates',
+      'margin_input_versions', 'margin_recalculations'
+    ])
+    AND NOT t.tgisinternal;
+
+  function_exists := to_regprocedure('public.fn_margin_append_only()') IS NOT NULL;
+
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    SELECT sha256, applied_at
+      INTO registered_sha256, registered_applied_at
+    FROM public.cerp_schema_migrations
+    WHERE filename = '20260805_margin_engine_0001.sql'
+    FOR UPDATE;
+    registry_entry_exists := FOUND;
+  END IF;
+
+  IF table_count = 0 AND index_count = 0 AND trigger_count = 0
+     AND NOT function_exists AND NOT registry_entry_exists THEN
+    RAISE NOTICE 'margin engine rollback: exact artifacts already absent';
+    RETURN;
+  END IF;
+
+  IF table_count <> 4 OR index_count <> 13 OR trigger_count <> 4
+     OR NOT function_exists OR NOT registry_entry_exists THEN
+    RAISE EXCEPTION 'margin engine rollback: target artifacts or ledger are in a partial/preexisting state';
+  END IF;
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 OR registered_applied_at IS NULL THEN
+    RAISE EXCEPTION 'margin engine rollback: migration ledger provenance is invalid';
+  END IF;
+  IF to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'margin engine rollback: required owner cerp_app is missing';
+  END IF;
+  cerp_app_oid := to_regrole('cerp_app');
+
+  LOCK TABLE public.margin_recalculations,
+             public.margin_input_versions,
+             public.margin_rates,
+             public.margin_rate_versions
+    IN ACCESS EXCLUSIVE MODE;
+
+  SELECT COUNT(*) FILTER (WHERE c.relowner = cerp_app_oid)::integer
+    INTO owned_table_count
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relkind IN ('r', 'p')
+    AND c.relname = ANY (ARRAY[
+      'margin_rate_versions', 'margin_rates',
+      'margin_input_versions', 'margin_recalculations'
+    ]);
+
+  SELECT p.proowner
+    INTO function_owner
+  FROM pg_proc p
+  WHERE p.oid = 'public.fn_margin_append_only()'::regprocedure;
+
+  IF owned_table_count <> 4 OR function_owner IS DISTINCT FROM cerp_app_oid THEN
+    RAISE EXCEPTION 'margin engine rollback: target ownership is unexpected';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO total_column_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = ANY (ARRAY[
+      'margin_rate_versions', 'margin_rates',
+      'margin_input_versions', 'margin_recalculations'
+    ]);
+  IF total_column_count <> 55 THEN
+    RAISE EXCEPTION 'margin engine rollback: target columns are incomplete, altered or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE convalidated AND conname = ANY (expected_constraints))::integer
+    INTO total_constraint_count, expected_constraint_count
+  FROM pg_constraint
+  WHERE conrelid = ANY (ARRAY[
+    'public.margin_rate_versions'::regclass,
+    'public.margin_rates'::regclass,
+    'public.margin_input_versions'::regclass,
+    'public.margin_recalculations'::regclass
+  ]::oid[]);
+  IF total_constraint_count <> 44 OR expected_constraint_count <> 44 THEN
+    RAISE EXCEPTION 'margin engine rollback: target constraints are incomplete, altered or additional';
+  END IF;
+
+  SELECT COUNT(*) FILTER (
+           WHERE i.indisvalid AND i.indisready
+             AND c.relowner = cerp_app_oid
+             AND c.relname = ANY (expected_indexes)
+         )::integer
+    INTO expected_index_count
+  FROM pg_index i
+  JOIN pg_class c ON c.oid = i.indexrelid
+  WHERE i.indrelid = ANY (ARRAY[
+    'public.margin_rate_versions'::regclass,
+    'public.margin_rates'::regclass,
+    'public.margin_input_versions'::regclass,
+    'public.margin_recalculations'::regclass
+  ]::oid[]);
+  IF expected_index_count <> 13 THEN
+    RAISE EXCEPTION 'margin engine rollback: target indexes are invalid or unexpectedly owned';
+  END IF;
+
+  SELECT COUNT(*) FILTER (
+           WHERE t.tgname = ANY (expected_triggers)
+             AND t.tgfoid = 'public.fn_margin_append_only()'::regprocedure
+             AND t.tgenabled = 'O'
+             AND t.tgtype = 27
+         )::integer
+    INTO expected_trigger_count
+  FROM pg_trigger t
+  WHERE NOT t.tgisinternal
+    AND t.tgrelid = ANY (ARRAY[
+      'public.margin_rate_versions'::regclass,
+      'public.margin_rates'::regclass,
+      'public.margin_input_versions'::regclass,
+      'public.margin_recalculations'::regclass
+    ]::oid[]);
+  IF expected_trigger_count <> 4 THEN
+    RAISE EXCEPTION 'margin engine rollback: append-only triggers are invalid';
+  END IF;
+
+  SELECT (SELECT COUNT(*) FROM public.margin_rate_versions)
+       + (SELECT COUNT(*) FROM public.margin_rates)
+       + (SELECT COUNT(*) FROM public.margin_input_versions)
+       + (SELECT COUNT(*) FROM public.margin_recalculations)
+    INTO evidence_row_count;
+  IF evidence_row_count <> 0 THEN
+    RAISE EXCEPTION 'margin engine rollback: governed margin evidence exists; export/retention decision required';
+  END IF;
+
+  DROP TRIGGER trg_margin_recalculations_append_only ON public.margin_recalculations;
+  DROP TRIGGER trg_margin_input_versions_append_only ON public.margin_input_versions;
+  DROP TRIGGER trg_margin_rates_append_only ON public.margin_rates;
+  DROP TRIGGER trg_margin_rate_versions_append_only ON public.margin_rate_versions;
+
+  DROP TABLE public.margin_recalculations;
+  DROP TABLE public.margin_input_versions;
+  DROP TABLE public.margin_rates;
+  DROP TABLE public.margin_rate_versions;
+  DROP FUNCTION public.fn_margin_append_only();
+
+  DELETE FROM public.cerp_schema_migrations
+  WHERE filename = '20260805_margin_engine_0001.sql'
+    AND sha256 = expected_sha256;
+  GET DIAGNOSTICS deleted_rows = ROW_COUNT;
+  IF deleted_rows <> 1 THEN
+    RAISE EXCEPTION 'margin engine rollback: exact migration ledger row was not removed';
+  END IF;
+
+  IF to_regclass('public.margin_rate_versions') IS NOT NULL
+     OR to_regclass('public.margin_rates') IS NOT NULL
+     OR to_regclass('public.margin_input_versions') IS NOT NULL
+     OR to_regclass('public.margin_recalculations') IS NOT NULL
+     OR to_regprocedure('public.fn_margin_append_only()') IS NOT NULL THEN
+    RAISE EXCEPTION 'margin engine rollback: target artifact remains after rollback';
+  END IF;
+END
+$rollback$;
 
 COMMIT;

--- a/db/patches/support/20260805_margin_engine_0001.verify.sql
+++ b/db/patches/support/20260805_margin_engine_0001.verify.sql
@@ -6,6 +6,10 @@ SELECT
   to_regclass('public.margin_recalculations') IS NOT NULL AS recalculations_ready;
 
 SELECT
+  EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='margin_input_versions' AND column_name='rate_effective_at') AS rate_effective_at_ready,
+  EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='margin_input_versions' AND column_name='rate_validation_snapshot') AS rate_validation_snapshot_ready;
+
+SELECT
   EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_margin_rate_versions_append_only' AND NOT tgisinternal) AS rate_versions_append_only,
   EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_margin_rates_append_only' AND NOT tgisinternal) AS rates_append_only,
   EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_margin_input_versions_append_only' AND NOT tgisinternal) AS inputs_append_only,

--- a/db/patches/support/20260805_margin_engine_0001.verify.sql
+++ b/db/patches/support/20260805_margin_engine_0001.verify.sql
@@ -1,0 +1,17 @@
+-- Lecture seule. Toutes les colonnes *_append_only doivent etre vraies.
+SELECT
+  to_regclass('public.margin_rate_versions') IS NOT NULL AS rate_versions_ready,
+  to_regclass('public.margin_rates') IS NOT NULL AS rates_ready,
+  to_regclass('public.margin_input_versions') IS NOT NULL AS inputs_ready,
+  to_regclass('public.margin_recalculations') IS NOT NULL AS recalculations_ready;
+
+SELECT
+  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_margin_rate_versions_append_only' AND NOT tgisinternal) AS rate_versions_append_only,
+  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_margin_rates_append_only' AND NOT tgisinternal) AS rates_append_only,
+  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_margin_input_versions_append_only' AND NOT tgisinternal) AS inputs_append_only,
+  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_margin_recalculations_append_only' AND NOT tgisinternal) AS recalculations_append_only;
+
+SELECT scope_type, basis, count(*) AS version_count
+FROM public.margin_input_versions
+GROUP BY scope_type, basis
+ORDER BY scope_type, basis;

--- a/db/patches/support/20260805_margin_engine_0001.verify.sql
+++ b/db/patches/support/20260805_margin_engine_0001.verify.sql
@@ -1,21 +1,288 @@
--- Lecture seule. Toutes les colonnes *_append_only doivent etre vraies.
-SELECT
-  to_regclass('public.margin_rate_versions') IS NOT NULL AS rate_versions_ready,
-  to_regclass('public.margin_rates') IS NOT NULL AS rates_ready,
-  to_regclass('public.margin_input_versions') IS NOT NULL AS inputs_ready,
-  to_regclass('public.margin_recalculations') IS NOT NULL AS recalculations_ready;
+\set ON_ERROR_STOP on
 
-SELECT
-  EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='margin_input_versions' AND column_name='rate_effective_at') AS rate_effective_at_ready,
-  EXISTS (SELECT 1 FROM information_schema.columns WHERE table_schema='public' AND table_name='margin_input_versions' AND column_name='rate_validation_snapshot') AS rate_validation_snapshot_ready;
+-- Verification bloquante et read-only de la provenance et de la forme exacte.
+BEGIN TRANSACTION READ ONLY;
 
-SELECT
-  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_margin_rate_versions_append_only' AND NOT tgisinternal) AS rate_versions_append_only,
-  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_margin_rates_append_only' AND NOT tgisinternal) AS rates_append_only,
-  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_margin_input_versions_append_only' AND NOT tgisinternal) AS inputs_append_only,
-  EXISTS (SELECT 1 FROM pg_trigger WHERE tgname = 'trg_margin_recalculations_append_only' AND NOT tgisinternal) AS recalculations_append_only;
+DO $verify$
+DECLARE
+  expected_sha256 constant text := 'bc0706c2af406d9a8e9f8221beb05492f9f0f7eba879de26cb77c8542863f514';
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  cerp_app_oid oid;
+  owned_table_count integer;
+  function_owner oid;
+  function_security_definer boolean;
+  function_config text[];
+  total_constraint_count integer;
+  expected_constraint_count integer;
+  total_index_count integer;
+  expected_index_count integer;
+  total_trigger_count integer;
+  expected_trigger_count integer;
+  public_table_acl_count integer;
+  public_function_acl_count integer;
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NULL THEN
+    RAISE EXCEPTION 'margin engine verify: migration registry is missing';
+  END IF;
 
-SELECT scope_type, basis, count(*) AS version_count
-FROM public.margin_input_versions
-GROUP BY scope_type, basis
-ORDER BY scope_type, basis;
+  SELECT sha256, applied_at
+    INTO registered_sha256, registered_applied_at
+  FROM public.cerp_schema_migrations
+  WHERE filename = '20260805_margin_engine_0001.sql';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'margin engine verify: migration registry entry is missing';
+  END IF;
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 OR registered_applied_at IS NULL THEN
+    RAISE EXCEPTION 'margin engine verify: migration ledger provenance is invalid';
+  END IF;
+
+  IF to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'margin engine verify: required role cerp_app is missing';
+  END IF;
+  cerp_app_oid := to_regrole('cerp_app');
+
+  IF to_regclass('public.margin_rate_versions') IS NULL
+     OR to_regclass('public.margin_rates') IS NULL
+     OR to_regclass('public.margin_input_versions') IS NULL
+     OR to_regclass('public.margin_recalculations') IS NULL
+     OR to_regprocedure('public.fn_margin_append_only()') IS NULL THEN
+    RAISE EXCEPTION 'margin engine verify: required table or append-only function is missing';
+  END IF;
+
+  SELECT COUNT(*) FILTER (WHERE c.relowner = cerp_app_oid)::integer
+    INTO owned_table_count
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relkind IN ('r', 'p')
+    AND c.relname = ANY (ARRAY[
+      'margin_rate_versions', 'margin_rates',
+      'margin_input_versions', 'margin_recalculations'
+    ]);
+
+  IF owned_table_count <> 4 THEN
+    RAISE EXCEPTION 'margin engine verify: all target tables must be owned by cerp_app';
+  END IF;
+
+  SELECT p.proowner, p.prosecdef, p.proconfig
+    INTO function_owner, function_security_definer, function_config
+  FROM pg_proc p
+  WHERE p.oid = 'public.fn_margin_append_only()'::regprocedure;
+
+  IF function_owner IS DISTINCT FROM cerp_app_oid
+     OR function_security_definer IS DISTINCT FROM false
+     OR NOT (COALESCE(function_config, ARRAY[]::text[]) @> ARRAY['search_path=pg_catalog, public']) THEN
+    RAISE EXCEPTION 'margin engine verify: append-only function owner or execution context is invalid';
+  END IF;
+  IF position(
+       'is append-only; create a superseding version instead'
+       IN pg_get_functiondef('public.fn_margin_append_only()'::regprocedure)
+     ) = 0 THEN
+    RAISE EXCEPTION 'margin engine verify: append-only function body is unexpected';
+  END IF;
+
+  IF (SELECT array_agg(column_name::text ORDER BY ordinal_position)
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'margin_rate_versions')
+     IS DISTINCT FROM ARRAY[
+       'id','code','version','currency','effective_from','effective_to','source',
+       'assumption_date','notes','supersedes_id','created_by','created_at'
+     ]::text[] THEN
+    RAISE EXCEPTION 'margin engine verify: margin_rate_versions columns are altered';
+  END IF;
+
+  IF (SELECT array_agg(column_name::text ORDER BY ordinal_position)
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'margin_rates')
+     IS DISTINCT FROM ARRAY[
+       'id','rate_version_id','rate_code','category','scope_type','scope_ref',
+       'amount','unit','source_ref','created_at'
+     ]::text[] THEN
+    RAISE EXCEPTION 'margin engine verify: margin_rates columns are altered';
+  END IF;
+
+  IF (SELECT array_agg(column_name::text ORDER BY ordinal_position)
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'margin_input_versions')
+     IS DISTINCT FROM ARRAY[
+       'id','scope_type','scope_ref','basis','input_key','input_kind','category',
+       'availability','amount_ht','quantity','rate_id','rate_effective_at',
+       'rate_validation_snapshot','currency','source_type','source_ref','observed_at',
+       'assumption','assumption_date','supersedes_id','created_by','created_at'
+     ]::text[] THEN
+    RAISE EXCEPTION 'margin engine verify: margin_input_versions columns are altered';
+  END IF;
+
+  IF (SELECT array_agg(column_name::text ORDER BY ordinal_position)
+      FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'margin_recalculations')
+     IS DISTINCT FROM ARRAY[
+       'id','scope_type','scope_ref','basis','as_of','formula_version',
+       'calculation_hash','input_snapshot','result_snapshot','created_by','created_at'
+     ]::text[] THEN
+    RAISE EXCEPTION 'margin engine verify: margin_recalculations columns are altered';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE convalidated AND conname = ANY (ARRAY[
+           'margin_rate_versions_pkey',
+           'margin_rate_versions_version_ck',
+           'margin_rate_versions_currency_ck',
+           'margin_rate_versions_source_ck',
+           'margin_rate_versions_dates_ck',
+           'margin_rate_versions_code_version_uk',
+           'margin_rate_versions_no_self_ck',
+           'margin_rate_versions_supersedes_fk',
+           'margin_rate_versions_created_by_fk',
+           'margin_rates_pkey',
+           'margin_rates_rate_version_fk',
+           'margin_rates_rate_code_ck',
+           'margin_rates_category_ck',
+           'margin_rates_scope_type_ck',
+           'margin_rates_amount_ck',
+           'margin_rates_unit_ck',
+           'margin_rates_scope_ck',
+           'margin_rates_version_code_scope_uk',
+           'margin_input_versions_pkey',
+           'margin_input_versions_scope_type_ck',
+           'margin_input_versions_scope_ref_ck',
+           'margin_input_versions_basis_ck',
+           'margin_input_versions_input_key_ck',
+           'margin_input_versions_input_kind_ck',
+           'margin_input_versions_category_ck',
+           'margin_input_versions_availability_ck',
+           'margin_input_versions_amount_ht_ck',
+           'margin_input_versions_quantity_ck',
+           'margin_input_versions_rate_fk',
+           'margin_input_versions_currency_ck',
+           'margin_input_versions_source_type_ck',
+           'margin_input_versions_supersedes_fk',
+           'margin_input_versions_created_by_fk',
+           'margin_input_versions_kind_ck',
+           'margin_input_versions_value_ck',
+           'margin_input_versions_rate_snapshot_ck',
+           'margin_input_versions_assumption_ck',
+           'margin_input_versions_no_self_ck',
+           'margin_recalculations_pkey',
+           'margin_recalculations_scope_type_ck',
+           'margin_recalculations_scope_ref_ck',
+           'margin_recalculations_basis_ck',
+           'margin_recalculations_hash_ck',
+           'margin_recalculations_created_by_fk'
+         ]))::integer
+    INTO total_constraint_count, expected_constraint_count
+  FROM pg_constraint
+  WHERE conrelid = ANY (ARRAY[
+    'public.margin_rate_versions'::regclass,
+    'public.margin_rates'::regclass,
+    'public.margin_input_versions'::regclass,
+    'public.margin_recalculations'::regclass
+  ]::oid[]);
+
+  IF total_constraint_count <> 44 OR expected_constraint_count <> 44 THEN
+    RAISE EXCEPTION 'margin engine verify: constraints are incomplete, altered or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (
+           WHERE i.indisvalid AND i.indisready AND c.relowner = cerp_app_oid
+             AND c.relname = ANY (ARRAY[
+               'margin_rate_versions_pkey',
+               'margin_rate_versions_code_version_uk',
+               'margin_rate_versions_supersedes_uk',
+               'margin_rate_versions_effective_idx',
+               'margin_rates_pkey',
+               'margin_rates_version_code_scope_uk',
+               'margin_rates_resolution_idx',
+               'margin_rates_version_code_scope_coalesced_uk',
+               'margin_input_versions_pkey',
+               'margin_input_versions_supersedes_uk',
+               'margin_input_versions_lookup_idx',
+               'margin_recalculations_pkey',
+               'margin_recalculations_lookup_idx'
+             ])
+         )::integer
+    INTO total_index_count, expected_index_count
+  FROM pg_index i
+  JOIN pg_class c ON c.oid = i.indexrelid
+  WHERE i.indrelid = ANY (ARRAY[
+    'public.margin_rate_versions'::regclass,
+    'public.margin_rates'::regclass,
+    'public.margin_input_versions'::regclass,
+    'public.margin_recalculations'::regclass
+  ]::oid[]);
+
+  IF total_index_count <> 13 OR expected_index_count <> 13 THEN
+    RAISE EXCEPTION 'margin engine verify: indexes are incomplete, altered or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (
+           WHERE t.tgname = ANY (ARRAY[
+             'trg_margin_rate_versions_append_only',
+             'trg_margin_rates_append_only',
+             'trg_margin_input_versions_append_only',
+             'trg_margin_recalculations_append_only'
+           ])
+             AND t.tgfoid = 'public.fn_margin_append_only()'::regprocedure
+             AND t.tgenabled = 'O'
+             AND t.tgtype = 27
+         )::integer
+    INTO total_trigger_count, expected_trigger_count
+  FROM pg_trigger t
+  WHERE NOT t.tgisinternal
+    AND t.tgrelid = ANY (ARRAY[
+      'public.margin_rate_versions'::regclass,
+      'public.margin_rates'::regclass,
+      'public.margin_input_versions'::regclass,
+      'public.margin_recalculations'::regclass
+    ]::oid[]);
+
+  IF total_trigger_count <> 4 OR expected_trigger_count <> 4 THEN
+    RAISE EXCEPTION 'margin engine verify: append-only triggers are incomplete, altered or additional';
+  END IF;
+
+  IF NOT has_table_privilege('cerp_app', 'public.margin_rate_versions', 'SELECT,INSERT')
+     OR NOT has_table_privilege('cerp_app', 'public.margin_rates', 'SELECT,INSERT')
+     OR NOT has_table_privilege('cerp_app', 'public.margin_input_versions', 'SELECT,INSERT')
+     OR NOT has_table_privilege('cerp_app', 'public.margin_recalculations', 'SELECT,INSERT')
+     OR NOT has_function_privilege('cerp_app', 'public.fn_margin_append_only()', 'EXECUTE') THEN
+    RAISE EXCEPTION 'margin engine verify: runtime read/append privileges are missing';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO public_table_acl_count
+  FROM pg_class c
+  CROSS JOIN LATERAL aclexplode(COALESCE(c.relacl, acldefault('r', c.relowner))) acl
+  WHERE c.oid = ANY (ARRAY[
+      'public.margin_rate_versions'::regclass,
+      'public.margin_rates'::regclass,
+      'public.margin_input_versions'::regclass,
+      'public.margin_recalculations'::regclass
+    ]::oid[])
+    AND acl.grantee = 0;
+
+  SELECT COUNT(*)::integer
+    INTO public_function_acl_count
+  FROM pg_proc p
+  CROSS JOIN LATERAL aclexplode(COALESCE(p.proacl, acldefault('f', p.proowner))) acl
+  WHERE p.oid = 'public.fn_margin_append_only()'::regprocedure
+    AND acl.grantee = 0;
+
+  IF public_table_acl_count <> 0 OR public_function_acl_count <> 0 THEN
+    RAISE EXCEPTION 'margin engine verify: PUBLIC retains a target privilege';
+  END IF;
+END
+$verify$;
+
+SELECT current_database() AS database_name,
+       (SELECT sha256 FROM public.cerp_schema_migrations
+        WHERE filename = '20260805_margin_engine_0001.sql') AS migration_sha256,
+       4 AS verified_tables,
+       44 AS verified_constraints,
+       4 AS verified_append_only_triggers,
+       'margin engine verification passed (read-only)' AS result;
+
+ROLLBACK;

--- a/src/__tests__/margin-engine.domain.test.ts
+++ b/src/__tests__/margin-engine.domain.test.ts
@@ -15,6 +15,10 @@ const EVIDENCE: MarginEvidence = {
   assumption: null,
   assumption_date: null,
   rate_version_id: null,
+  rate_id: null,
+  rate_effective_at: null,
+  rate_scope_type: null,
+  rate_scope_ref: null,
 };
 
 function na(category: MarginCostInput["category"]): MarginCostInput {
@@ -96,6 +100,33 @@ describe("margin engine formulas", () => {
     expect(result.cost_total_ht).toBeNull();
     expect(result.gross_margin_ht).toBeNull();
     expect(result.missing_inputs.map((row) => row.category)).toContain("MACHINE");
+  });
+
+  it("keeps a category incomplete when any rate-driven entry is unresolved", () => {
+    const costs = MARGIN_COST_CATEGORIES.map(na);
+    costs.push(provided("OPERATOR", "25"));
+    costs.push({
+      ...provided("OPERATOR", "0"),
+      key: "operator:unresolved-rate",
+      amount_ht: null,
+      quantity: null,
+      rate: "50",
+      rate_unit: "EUR_PER_HOUR",
+    });
+    const result = calculateMargin(input(costs));
+    expect(result.components.find((row) => row.category === "OPERATOR")?.status).toBe("MISSING");
+    expect(result.cost_total_ht).toBeNull();
+    expect(result.missing_inputs.map((row) => row.code)).toContain("OPERATOR_MISSING");
+  });
+
+  it("uses the frozen operation cost once after preparation, quantity and coefficient", () => {
+    // 0.5 h préparation + (0.1 h × 10 pièces × coef 1.5) = 2 h; 2 h × 50 €/h = 100 €.
+    // `cout_mo=100` est déjà ce total autoritaire : la quantité du devis ne doit pas le remultiplier.
+    const costs = MARGIN_COST_CATEGORIES.map(na);
+    costs.push(provided("OPERATOR", "100"));
+    const result = calculateMargin(input(costs));
+    expect(result.components.find((row) => row.category === "OPERATOR")?.amount_ht).toBe("100.00");
+    expect(result.cost_total_ht).toBe("100.00");
   });
 
   it("computes planned/actual variance only when both calculations are complete", () => {

--- a/src/__tests__/margin-engine.domain.test.ts
+++ b/src/__tests__/margin-engine.domain.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import {
+  MARGIN_COST_CATEGORIES,
+  calculateMargin,
+  compareMargins,
+  type MarginCalculationInput,
+  type MarginCostInput,
+  type MarginEvidence,
+} from "../module/margin-engine/domain/margin-engine";
+
+const EVIDENCE: MarginEvidence = {
+  source_type: "TEST",
+  source_ref: "TEST_TD_MARGIN_001",
+  observed_at: "2026-08-05T08:00:00.000Z",
+  assumption: null,
+  assumption_date: null,
+  rate_version_id: null,
+};
+
+function na(category: MarginCostInput["category"]): MarginCostInput {
+  return {
+    key: `na:${category}`,
+    category,
+    availability: "NOT_APPLICABLE",
+    amount_ht: null,
+    quantity: null,
+    rate: null,
+    rate_unit: null,
+    currency: "EUR",
+    evidence: EVIDENCE,
+  };
+}
+
+function provided(category: MarginCostInput["category"], amount: string): MarginCostInput {
+  return { ...na(category), key: `value:${category}`, availability: "PROVIDED", amount_ht: amount };
+}
+
+function input(costs: MarginCostInput[], basis: "PLANNED" | "ACTUAL" = "PLANNED"): MarginCalculationInput {
+  return {
+    scope_type: "DEVIS",
+    scope_ref: "1",
+    label: "TEST_TD_MARGIN_001",
+    basis,
+    as_of: "2026-08-05",
+    revenue: { availability: "PROVIDED", amount_ht: "100", currency: "EUR", evidence: EVIDENCE },
+    costs,
+  };
+}
+
+describe("margin engine formulas", () => {
+  it("distinguishes gross margin, taux de marge and taux de marque", () => {
+    const costs = MARGIN_COST_CATEGORIES.map(na);
+    costs.push(provided("MATERIAL", "60"));
+    const result = calculateMargin(input(costs));
+
+    expect(result.availability).toBe("COMPLETE");
+    expect(result.cost_total_ht).toBe("60.00");
+    expect(result.gross_margin_ht).toBe("40.00");
+    expect(result.margin_rate_pct).toBe("66.67"); // marge / coût de revient
+    expect(result.mark_rate_pct).toBe("40.00"); // marge / prix de vente HT
+  });
+
+  it("rounds money half away from zero only at the output boundary", () => {
+    const costs = MARGIN_COST_CATEGORIES.map(na);
+    costs.push({
+      ...provided("MATERIAL", "0"),
+      amount_ht: null,
+      quantity: "3",
+      rate: "0.335",
+      rate_unit: "EUR_PER_UNIT",
+    });
+    const result = calculateMargin(input(costs));
+    expect(result.components.find((row) => row.category === "MATERIAL")?.amount_ht).toBe("1.01");
+    expect(result.cost_total_ht).toBe("1.01");
+  });
+
+  it("applies overhead percentage to known direct costs", () => {
+    const costs = MARGIN_COST_CATEGORIES.map(na);
+    costs.push(provided("MATERIAL", "50"), provided("OPERATOR", "50"));
+    costs.push({
+      ...provided("OVERHEAD", "0"),
+      amount_ht: null,
+      quantity: null,
+      rate: "10",
+      rate_unit: "PERCENT_OF_DIRECT_COST",
+    });
+    const result = calculateMargin(input(costs));
+    expect(result.components.find((row) => row.category === "OVERHEAD")?.amount_ht).toBe("10.00");
+    expect(result.cost_total_ht).toBe("110.00");
+  });
+
+  it("never converts missing cost inputs into zero or a real margin", () => {
+    const result = calculateMargin(input([provided("MATERIAL", "10")]));
+    expect(result.availability).toBe("PARTIAL");
+    expect(result.partial_cost_total_ht).toBe("10.00");
+    expect(result.cost_total_ht).toBeNull();
+    expect(result.gross_margin_ht).toBeNull();
+    expect(result.missing_inputs.map((row) => row.category)).toContain("MACHINE");
+  });
+
+  it("computes planned/actual variance only when both calculations are complete", () => {
+    const complete = MARGIN_COST_CATEGORIES.map(na);
+    const planned = calculateMargin(input([...complete, provided("MATERIAL", "60")], "PLANNED"));
+    const actual = calculateMargin(input([...complete, provided("MATERIAL", "65")], "ACTUAL"));
+    expect(compareMargins(planned, actual).variance).toMatchObject({
+      available: true,
+      cost_ht: "5.00",
+      gross_margin_ht: "-5.00",
+    });
+
+    const partialActual = calculateMargin(input([provided("MATERIAL", "65")], "ACTUAL"));
+    expect(compareMargins(planned, partialActual).variance.available).toBe(false);
+  });
+});

--- a/src/__tests__/margin-engine.integration-contracts.test.ts
+++ b/src/__tests__/margin-engine.integration-contracts.test.ts
@@ -1,0 +1,167 @@
+import fs from "node:fs";
+import path from "node:path";
+import type { PoolClient } from "pg";
+import { describe, expect, it, vi } from "vitest";
+import { HttpError } from "../utils/httpError";
+import { calculateMargin, compareMargins, type MarginEvidence } from "../module/margin-engine/domain/margin-engine";
+import {
+  isMarginRateResolutionValid,
+  rateUnitMatchesCategory,
+  validateRateForInput,
+  type ManualInputRow,
+} from "../module/margin-engine/repository/margin-engine.repository";
+import { assertCurrentMarginDate, renderMarginCsv } from "../module/margin-engine/services/margin-engine.service";
+import { createMarginInputSchema } from "../module/margin-engine/validators/margin-engine.validators";
+import { repoRoot } from "./helpers/repo-paths";
+
+const rateRow: ManualInputRow = {
+  input_key: "operator-rate",
+  input_kind: "COST",
+  category: "OPERATOR",
+  availability: "PROVIDED",
+  amount_ht: null,
+  quantity: "2",
+  currency: "EUR",
+  source_type: "RATE_INPUT",
+  source_ref: "OF-42",
+  observed_at: "2026-08-05T08:00:00.000Z",
+  assumption: null,
+  assumption_date: null,
+  rate_id: "11111111-1111-4111-8111-111111111111",
+  rate_effective_at: "2026-08-05",
+  rate_validation_snapshot: {
+    rate_id: "11111111-1111-4111-8111-111111111111",
+    rate_version_id: "22222222-2222-4222-8222-222222222222",
+    category: "OPERATOR",
+    unit: "EUR_PER_HOUR",
+    scope_type: "GLOBAL",
+    scope_ref: null,
+    rate_effective_at: "2026-08-05",
+    validated_scope_type: "OF",
+    validated_scope_ref: "42",
+  },
+  rate_amount: "50.000000",
+  rate_unit: "EUR_PER_HOUR",
+  rate_version_id: "22222222-2222-4222-8222-222222222222",
+  rate_category: "OPERATOR",
+  rate_scope_type: "GLOBAL",
+  rate_scope_ref: null,
+  rate_effective_from: "2026-01-01",
+  rate_effective_to: "2026-12-31",
+  created_by: 7,
+};
+
+describe("margin rate resolution", () => {
+  it("validates category, unit, quantity, scope proof and effective period at read time", () => {
+    expect(isMarginRateResolutionValid(rateRow, "OF", "42")).toBe(true);
+    expect(isMarginRateResolutionValid({ ...rateRow, quantity: null }, "OF", "42")).toBe(false);
+    expect(isMarginRateResolutionValid({ ...rateRow, rate_category: "MACHINE" }, "OF", "42")).toBe(false);
+    expect(isMarginRateResolutionValid({ ...rateRow, rate_effective_at: "2027-01-01" }, "OF", "42")).toBe(false);
+    expect(isMarginRateResolutionValid(rateRow, "OF", "43")).toBe(false);
+    expect(isMarginRateResolutionValid({ ...rateRow, rate_validation_snapshot: null }, "OF", "42")).toBe(false);
+  });
+
+  it("rejects incoherent category/unit pairs", () => {
+    expect(rateUnitMatchesCategory("EUR_PER_HOUR", "OPERATOR")).toBe(true);
+    expect(rateUnitMatchesCategory("EUR_PER_HOUR", "MATERIAL")).toBe(false);
+    expect(rateUnitMatchesCategory("PERCENT_OF_DIRECT_COST", "OVERHEAD")).toBe(true);
+    expect(rateUnitMatchesCategory("PERCENT_OF_DIRECT_COST", "TRANSPORT")).toBe(false);
+  });
+
+  it("validates category, unit, period and business scope atomically at creation", async () => {
+    const input = createMarginInputSchema.parse({
+      scope_type: "OF", scope_ref: "42", basis: "ACTUAL", input_key: "operator-rate",
+      input_kind: "COST", category: "OPERATOR", availability: "PROVIDED",
+      quantity: 2, rate_id: rateRow.rate_id, rate_effective_at: "2026-08-05", source_type: "RATE_INPUT",
+    });
+    const globalRate = {
+      id: rateRow.rate_id!, category: "OPERATOR" as const, unit: "EUR_PER_HOUR" as const,
+      scope_type: "GLOBAL", scope_ref: null, rate_version_id: rateRow.rate_version_id!,
+      effective_from: "2026-01-01", effective_to: "2026-12-31",
+    };
+    const tx = { query: vi.fn().mockResolvedValue({ rows: [globalRate] }) } as unknown as PoolClient;
+    await expect(validateRateForInput(tx, input, 7)).resolves.toMatchObject({
+      category: "OPERATOR", unit: "EUR_PER_HOUR", validated_scope_type: "OF", validated_scope_ref: "42",
+    });
+
+    const wrongCategoryTx = { query: vi.fn().mockResolvedValue({ rows: [{ ...globalRate, category: "MACHINE" }] }) } as unknown as PoolClient;
+    await expect(validateRateForInput(wrongCategoryTx, input, 7)).rejects.toMatchObject({ code: "MARGIN_RATE_CATEGORY_UNIT_MISMATCH" });
+
+    const expiredTx = { query: vi.fn().mockResolvedValue({ rows: [{ ...globalRate, effective_to: "2026-07-31" }] }) } as unknown as PoolClient;
+    await expect(validateRateForInput(expiredTx, input, 7)).rejects.toMatchObject({ code: "MARGIN_RATE_OUTSIDE_EFFECTIVE_PERIOD" });
+
+    const scopedTx = {
+      query: vi.fn()
+        .mockResolvedValueOnce({ rows: [{ ...globalRate, scope_type: "PIECE_TECHNIQUE", scope_ref: "33333333-3333-4333-8333-333333333333" }] })
+        .mockResolvedValueOnce({ rows: [{ matches: false }] }),
+    } as unknown as PoolClient;
+    await expect(validateRateForInput(scopedTx, input, 7)).rejects.toMatchObject({ code: "MARGIN_RATE_SCOPE_MISMATCH" });
+  });
+});
+
+describe("margin historical contract", () => {
+  it("refuses to recalculate a past state from mutable current sources", () => {
+    try {
+      assertCurrentMarginDate("2000-01-01");
+    } catch (error) {
+      expect(error).toBeInstanceOf(HttpError);
+      expect((error as HttpError).code).toBe("MARGIN_HISTORICAL_RECALCULATION_FORBIDDEN");
+      return;
+    }
+    throw new Error("Historical recalculation should have been rejected");
+  });
+});
+
+describe("margin governed CSV", () => {
+  it("exports evidence, dated assumptions, rate proof, missing inputs, measurements and as_of", () => {
+    const revenueEvidence: MarginEvidence = {
+      source_type: "DEVIS_TOTAL_HT", source_ref: "7", observed_at: "2026-08-05T08:00:00Z",
+      assumption: null, assumption_date: null, rate_version_id: null, rate_id: null,
+      rate_effective_at: null, rate_scope_type: null, rate_scope_ref: null,
+    };
+    const costEvidence: MarginEvidence = {
+      source_type: "RATE_INPUT", source_ref: "OF-42", observed_at: "2026-08-05T09:00:00Z",
+      assumption: "Budget validé", assumption_date: "2026-08-01",
+      rate_id: rateRow.rate_id, rate_version_id: rateRow.rate_version_id,
+      rate_effective_at: rateRow.rate_effective_at, rate_scope_type: "GLOBAL", rate_scope_ref: null,
+    };
+    const base = {
+      scope_type: "OF" as const, scope_ref: "42", label: "TEST_TD_MARGIN_42",
+      as_of: "2026-08-05", revenue: { availability: "PROVIDED" as const, amount_ht: "100", currency: "EUR", evidence: revenueEvidence },
+      costs: [{
+        key: "operator-rate", category: "OPERATOR" as const, availability: "PROVIDED" as const,
+        amount_ht: "25", quantity: null, rate: null, rate_unit: null, currency: "EUR", evidence: costEvidence,
+      }],
+      measurements: { actual_hours: "2.0" },
+    };
+    const planned = calculateMargin({ ...base, basis: "PLANNED" });
+    const actual = calculateMargin({ ...base, basis: "ACTUAL" });
+    const csv = renderMarginCsv({ ...compareMargins(planned, actual), generated_at: "2026-08-05T10:00:00Z" });
+
+    for (const expected of [
+      "source_type", "observed_at", "assumption_date", "rate_version_id", "rate_effective_at",
+      "missing_code", "measurement_key", "as_of", "DEVIS_TOTAL_HT", "Budget validé",
+      "MACHINE_MISSING", "actual_hours", "2026-08-05",
+    ]) expect(csv).toContain(expected);
+
+    const lines = csv.trim().replace(/^\ufeff/, "").split("\r\n");
+    const width = lines[0]!.split(";").length;
+    expect(lines.slice(1).every((line) => line.split(";").length === width)).toBe(true);
+  });
+});
+
+describe("margin mutation audit contract", () => {
+  it("writes audit through the same transaction before every business commit", () => {
+    const source = fs.readFileSync(path.join(repoRoot, "src", "module", "margin-engine", "repository", "margin-engine.repository.ts"), "utf8");
+    expect(source).toMatch(/repoInsertAuditLog\(\{[\s\S]*?tx,/);
+    expect(source).toMatch(/MARGIN_INPUT_VERSION_CREATED[\s\S]*?client\.query\("COMMIT"\)/);
+    expect(source).toMatch(/MARGIN_RATE_VERSION_CREATED[\s\S]*?client\.query\("COMMIT"\)/);
+    expect(source).toMatch(/MARGIN_RECALCULATION_SNAPSHOTTED[\s\S]*?client\.query\("COMMIT"\)/);
+  });
+
+  it("revalidates a versioned rate scope against the live target when reading inputs", () => {
+    const source = fs.readFileSync(path.join(repoRoot, "src", "module", "margin-engine", "repository", "margin-engine.repository.ts"), "utf8");
+    expect(source).toMatch(/rateResolved\s*=\s*await scopedRateMatchesTarget\(\s*pool,/s);
+    expect(source).toContain("row.created_by");
+  });
+});

--- a/src/__tests__/margin-engine.migration-guards.test.ts
+++ b/src/__tests__/margin-engine.migration-guards.test.ts
@@ -1,0 +1,31 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { repoRoot } from "./helpers/repo-paths";
+
+const patch = fs.readFileSync(path.join(repoRoot, "db", "patches", "20260805_margin_engine_0001.sql"), "utf8");
+const support = path.join(repoRoot, "db", "patches", "support");
+
+describe("margin engine migration guards", () => {
+  it("is additive and does not rewrite existing business history", () => {
+    expect(patch).not.toMatch(/\bTRUNCATE\b/i);
+    expect(patch).not.toMatch(/\bDELETE\s+FROM\b/i);
+    expect(patch).not.toMatch(/\bUPDATE\s+(public\.)?(devis|affaire|ordres_fabrication|of_operations)\b/i);
+    expect(patch).not.toMatch(/DROP\s+TABLE/i);
+  });
+
+  it("protects rates, inputs and recalculation proofs as append-only", () => {
+    expect(patch).toContain("trg_margin_rate_versions_append_only");
+    expect(patch).toContain("trg_margin_rates_append_only");
+    expect(patch).toContain("trg_margin_input_versions_append_only");
+    expect(patch).toContain("trg_margin_recalculations_append_only");
+  });
+
+  it("ships preflight, verification, cerp_test demo and rollback scripts", () => {
+    for (const suffix of ["preflight.sql", "verify.sql", "cerp_test_demo.sql", "rollback.sql"]) {
+      expect(fs.existsSync(path.join(support, `20260805_margin_engine_0001.${suffix}`))).toBe(true);
+    }
+    const demo = fs.readFileSync(path.join(support, "20260805_margin_engine_0001.cerp_test_demo.sql"), "utf8");
+    expect(demo).toContain("current_database() <> 'cerp_test'");
+  });
+});

--- a/src/__tests__/margin-engine.migration-guards.test.ts
+++ b/src/__tests__/margin-engine.migration-guards.test.ts
@@ -5,6 +5,7 @@ import { repoRoot } from "./helpers/repo-paths";
 
 const patch = fs.readFileSync(path.join(repoRoot, "db", "patches", "20260805_margin_engine_0001.sql"), "utf8");
 const support = path.join(repoRoot, "db", "patches", "support");
+const repository = fs.readFileSync(path.join(repoRoot, "src", "module", "margin-engine", "repository", "margin-engine.repository.ts"), "utf8");
 
 describe("margin engine migration guards", () => {
   it("is additive and does not rewrite existing business history", () => {
@@ -19,6 +20,8 @@ describe("margin engine migration guards", () => {
     expect(patch).toContain("trg_margin_rates_append_only");
     expect(patch).toContain("trg_margin_input_versions_append_only");
     expect(patch).toContain("trg_margin_recalculations_append_only");
+    expect(patch).toContain("rate_effective_at date");
+    expect(patch).toContain("rate_validation_snapshot jsonb");
   });
 
   it("ships preflight, verification, cerp_test demo and rollback scripts", () => {
@@ -27,5 +30,10 @@ describe("margin engine migration guards", () => {
     }
     const demo = fs.readFileSync(path.join(support, "20260805_margin_engine_0001.cerp_test_demo.sql"), "utf8");
     expect(demo).toContain("current_database() <> 'cerp_test'");
+  });
+
+  it("does not multiply an already calculated technical operation cost by quote quantity", () => {
+    expect(repository).not.toMatch(/op\.cout_mo\s*\*\s*dl\.quantite/i);
+    expect(repository).toContain("round(op.cout_mo, 6)::text AS amount_ht");
   });
 });

--- a/src/__tests__/margin-engine.migration-guards.test.ts
+++ b/src/__tests__/margin-engine.migration-guards.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
@@ -6,6 +7,10 @@ import { repoRoot } from "./helpers/repo-paths";
 const patch = fs.readFileSync(path.join(repoRoot, "db", "patches", "20260805_margin_engine_0001.sql"), "utf8");
 const support = path.join(repoRoot, "db", "patches", "support");
 const repository = fs.readFileSync(path.join(repoRoot, "src", "module", "margin-engine", "repository", "margin-engine.repository.ts"), "utf8");
+const preflight = fs.readFileSync(path.join(support, "20260805_margin_engine_0001.preflight.sql"), "utf8");
+const verify = fs.readFileSync(path.join(support, "20260805_margin_engine_0001.verify.sql"), "utf8");
+const rollback = fs.readFileSync(path.join(support, "20260805_margin_engine_0001.rollback.sql"), "utf8");
+const expectedSha = createHash("sha256").update(patch.replace(/\r\n?/g, "\n"), "utf8").digest("hex");
 
 describe("margin engine migration guards", () => {
   it("is additive and does not rewrite existing business history", () => {
@@ -13,6 +18,9 @@ describe("margin engine migration guards", () => {
     expect(patch).not.toMatch(/\bDELETE\s+FROM\b/i);
     expect(patch).not.toMatch(/\bUPDATE\s+(public\.)?(devis|affaire|ordres_fabrication|of_operations)\b/i);
     expect(patch).not.toMatch(/DROP\s+TABLE/i);
+    expect(patch).not.toMatch(/\bIF\s+NOT\s+EXISTS\b/i);
+    expect(patch).not.toMatch(/\bCREATE\s+OR\s+REPLACE\b/i);
+    expect(patch).toContain("target artifact already exists without this migration ledger entry");
   });
 
   it("protects rates, inputs and recalculation proofs as append-only", () => {
@@ -30,6 +38,30 @@ describe("margin engine migration guards", () => {
     }
     const demo = fs.readFileSync(path.join(support, "20260805_margin_engine_0001.cerp_test_demo.sql"), "utf8");
     expect(demo).toContain("current_database() <> 'cerp_test'");
+  });
+
+  it("blocks preflight and verification unless ledger provenance and exact artifacts match", () => {
+    for (const sql of [preflight, verify]) {
+      expect(sql).toContain("\\set ON_ERROR_STOP on");
+      expect(sql).toContain("BEGIN TRANSACTION READ ONLY");
+      expect(sql).toContain(expectedSha);
+      expect(sql).toContain("public.cerp_schema_migrations");
+      expect(sql).toContain("RAISE EXCEPTION");
+    }
+    expect(verify).toContain("all target tables must be owned by cerp_app");
+    expect(verify).toContain("total_constraint_count <> 44");
+    expect(verify).toContain("total_index_count <> 13");
+    expect(verify).toContain("total_trigger_count <> 4");
+  });
+
+  it("guards exact rollback to empty dev/test artifacts and removes the ledger row", () => {
+    expect(rollback).toContain("current_database() NOT IN ('cerp_dev', 'cerp_test')");
+    expect(rollback).toContain("SELECT pg_advisory_xact_lock(hashtext('cerp_schema_migrations'))");
+    expect(rollback).toContain(expectedSha);
+    expect(rollback).toContain("governed margin evidence exists; export/retention decision required");
+    expect(rollback).toContain("DELETE FROM public.cerp_schema_migrations");
+    expect(rollback).not.toMatch(/\bDROP\s+(?:TABLE|FUNCTION|TRIGGER)\s+IF\s+EXISTS\b/i);
+    expect(rollback).not.toMatch(/\bCASCADE\b/i);
   });
 
   it("does not multiply an already calculated technical operation cost by quote quantity", () => {

--- a/src/__tests__/margin-engine.policy-and-validation.test.ts
+++ b/src/__tests__/margin-engine.policy-and-validation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { roleHasMarginCapability } from "../module/margin-engine/domain/margin-engine-policy";
+import { createMarginInputSchema, createRateVersionSchema } from "../module/margin-engine/validators/margin-engine.validators";
+
+describe("margin engine RBAC", () => {
+  it("denies unknown roles by default and separates read from administration", () => {
+    expect(roleHasMarginCapability(null, "read_costs")).toBe(false);
+    expect(roleHasMarginCapability("Opérateur atelier", "read_costs")).toBe(false);
+    expect(roleHasMarginCapability("Méthodes", "read_costs")).toBe(true);
+    expect(roleHasMarginCapability("Méthodes", "manage_rates")).toBe(false);
+    expect(roleHasMarginCapability("Contrôle de gestion", "manage_rates")).toBe(true);
+  });
+});
+
+describe("margin engine write contracts", () => {
+  it("requires an explicitly dated assumption", () => {
+    const result = createMarginInputSchema.safeParse({
+      scope_type: "OF", scope_ref: "42", basis: "ACTUAL", input_key: "transport",
+      input_kind: "COST", category: "TRANSPORT", availability: "PROVIDED", amount_ht: 12,
+      source_type: "MANUAL", assumption: "Forfait transporteur",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts explicit not-applicable and rejects a hidden value on it", () => {
+    const base = {
+      scope_type: "DEVIS" as const, scope_ref: "1", basis: "PLANNED" as const,
+      input_key: "tooling", input_kind: "COST" as const, category: "TOOLING" as const,
+      source_type: "USER_DECISION", availability: "NOT_APPLICABLE" as const,
+    };
+    expect(createMarginInputSchema.safeParse(base).success).toBe(true);
+    expect(createMarginInputSchema.safeParse({ ...base, amount_ht: 0 }).success).toBe(false);
+  });
+
+  it("requires a source and effective date on every rate version", () => {
+    const result = createRateVersionSchema.safeParse({
+      code: "OPERATOR_2026", version: 1, effective_from: "2026-08-01",
+      assumption_date: "2026-07-31", source: "Budget validé DG",
+      rates: [{ rate_code: "OP", category: "OPERATOR", scope_type: "GLOBAL", amount: 55, unit: "EUR_PER_HOUR" }],
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/__tests__/margin-engine.policy-and-validation.test.ts
+++ b/src/__tests__/margin-engine.policy-and-validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { roleHasMarginCapability } from "../module/margin-engine/domain/margin-engine-policy";
+import { canUseMarginCapability, roleHasMarginCapability } from "../module/margin-engine/domain/margin-engine-policy";
 import { createMarginInputSchema, createRateVersionSchema } from "../module/margin-engine/validators/margin-engine.validators";
 
 describe("margin engine RBAC", () => {
@@ -9,6 +9,15 @@ describe("margin engine RBAC", () => {
     expect(roleHasMarginCapability("Méthodes", "read_costs")).toBe(true);
     expect(roleHasMarginCapability("Méthodes", "manage_rates")).toBe(false);
     expect(roleHasMarginCapability("Contrôle de gestion", "manage_rates")).toBe(true);
+  });
+
+  it("does not turn reporting module access into financial administration", () => {
+    expect(canUseMarginCapability("Opérateur atelier", "read_costs", true)).toBe(true);
+    for (const capability of ["manage_rates", "manage_inputs", "snapshot", "export"] as const) {
+      expect(canUseMarginCapability("Opérateur atelier", capability, true)).toBe(false);
+    }
+    expect(canUseMarginCapability("Contrôle de gestion", "export", false)).toBe(true);
+    expect(canUseMarginCapability("Directeur", "snapshot", false)).toBe(true);
   });
 });
 
@@ -39,5 +48,17 @@ describe("margin engine write contracts", () => {
       rates: [{ rate_code: "OP", category: "OPERATOR", scope_type: "GLOBAL", amount: 55, unit: "EUR_PER_HOUR" }],
     });
     expect(result.success).toBe(true);
+  });
+
+  it("requires a rate application date and exactly one amount source", () => {
+    const base = {
+      scope_type: "OF" as const, scope_ref: "42", basis: "ACTUAL" as const,
+      input_key: "operator", input_kind: "COST" as const, category: "OPERATOR" as const,
+      availability: "PROVIDED" as const, source_type: "RATE_INPUT",
+      rate_id: "11111111-1111-4111-8111-111111111111", quantity: 2,
+    };
+    expect(createMarginInputSchema.safeParse(base).success).toBe(false);
+    expect(createMarginInputSchema.safeParse({ ...base, rate_effective_at: "2026-08-05" }).success).toBe(true);
+    expect(createMarginInputSchema.safeParse({ ...base, rate_effective_at: "2026-08-05", amount_ht: 100 }).success).toBe(false);
   });
 });

--- a/src/module/access-control/domain/module-catalog.ts
+++ b/src/module/access-control/domain/module-catalog.ts
@@ -80,7 +80,7 @@ export const MODULE_CATALOG: readonly ModuleCatalogEntry[] = [
     label: "Reporting commercial",
     description: "Indicateurs commerciaux et exports gouvernés.",
     category: "Commerce",
-    api_prefixes: ["/reporting"],
+    api_prefixes: ["/reporting", "/margins"],
     nav_page_keys: ["reporting-commercial"],
     is_protected: false,
     sort_order: 70,

--- a/src/module/margin-engine/controllers/margin-engine.controller.ts
+++ b/src/module/margin-engine/controllers/margin-engine.controller.ts
@@ -1,14 +1,15 @@
 import type { Request, RequestHandler } from "express";
 import { HttpError } from "../../../utils/httpError";
 import { getClientIp, parseDevice } from "../../../utils/requestMeta";
-import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type { MarginScopeType } from "../domain/margin-engine";
+import type { MarginAuditContext } from "../repository/margin-engine.repository";
 import {
   createMarginInputSchema,
   createRateVersionSchema,
   marginReadQuerySchema,
   marginScopeParamsSchema,
   marginSnapshotBodySchema,
+  marginSnapshotListQuerySchema,
 } from "../validators/margin-engine.validators";
 import {
   svcCreateMarginInput,
@@ -17,6 +18,7 @@ import {
   svcExportMargin,
   svcGetMargin,
   svcListRateVersions,
+  svcListMarginSnapshots,
 } from "../services/margin-engine.service";
 
 const SCOPE_MAP: Record<"devis-line" | "devis" | "affaire" | "of", MarginScopeType> = {
@@ -31,27 +33,24 @@ function actorId(req: Request): number {
   return req.user.id;
 }
 
-async function auditMutation(req: Request, action: string, entityType: string, entityId: string, details: Record<string, unknown>) {
+function buildAuditContext(req: Request): MarginAuditContext {
   const userAgent = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null;
   const device = parseDevice(userAgent);
-  await repoInsertAuditLog({
+  const rawSessionId = typeof req.headers["x-client-session-id"] === "string" ? req.headers["x-client-session-id"] : null;
+  const clientSessionId = rawSessionId && /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(rawSessionId)
+    ? rawSessionId
+    : null;
+  return {
     user_id: actorId(req),
     ip: getClientIp(req),
     user_agent: userAgent,
     device_type: device.device_type,
     os: device.os,
     browser: device.browser,
-    body: {
-      event_type: "ACTION",
-      action,
-      page_key: "margin-engine",
-      entity_type: entityType,
-      entity_id: entityId,
-      path: req.originalUrl,
-      client_session_id: typeof req.headers["x-client-session-id"] === "string" ? req.headers["x-client-session-id"] : null,
-      details,
-    },
-  });
+    path: req.originalUrl ?? null,
+    page_key: "margin-engine",
+    client_session_id: clientSessionId,
+  };
 }
 
 export const getMargin: RequestHandler = async (req, res, next) => {
@@ -76,11 +75,7 @@ export const exportMargin: RequestHandler = async (req, res, next) => {
 export const createMarginInput: RequestHandler = async (req, res, next) => {
   try {
     const input = createMarginInputSchema.parse(req.body);
-    const created = await svcCreateMarginInput(input, actorId(req));
-    await auditMutation(req, "MARGIN_INPUT_VERSION_CREATED", "margin_input_version", created.id, {
-      scope_type: input.scope_type, scope_ref: input.scope_ref, basis: input.basis,
-      input_key: input.input_key, supersedes_id: input.supersedes_id ?? null,
-    });
+    const created = await svcCreateMarginInput(input, buildAuditContext(req));
     res.status(201).json(created);
   } catch (error) { next(error); }
 };
@@ -88,11 +83,7 @@ export const createMarginInput: RequestHandler = async (req, res, next) => {
 export const createRateVersion: RequestHandler = async (req, res, next) => {
   try {
     const input = createRateVersionSchema.parse(req.body);
-    const created = await svcCreateRateVersion(input, actorId(req));
-    await auditMutation(req, "MARGIN_RATE_VERSION_CREATED", "margin_rate_version", created.id, {
-      code: input.code, version: input.version, effective_from: input.effective_from,
-      supersedes_id: input.supersedes_id ?? null, rate_count: input.rates.length,
-    });
+    const created = await svcCreateRateVersion(input, buildAuditContext(req));
     res.status(201).json(created);
   } catch (error) { next(error); }
 };
@@ -109,11 +100,18 @@ export const createMarginSnapshot: RequestHandler = async (req, res, next) => {
     const params = marginScopeParamsSchema.parse(req.params);
     const body = marginSnapshotBodySchema.parse(req.body);
     const query = marginReadQuerySchema.parse(req.query);
-    const asOf = query.as_of ?? new Date().toISOString().slice(0, 10);
-    const created = await svcCreateMarginSnapshot(SCOPE_MAP[params.scopeType], params.scopeRef, body.basis, asOf, actorId(req));
-    await auditMutation(req, "MARGIN_RECALCULATION_SNAPSHOTTED", "margin_recalculation", created.id, {
-      scope_type: SCOPE_MAP[params.scopeType], scope_ref: params.scopeRef, basis: body.basis, as_of: asOf,
-    });
+    const created = await svcCreateMarginSnapshot(
+      SCOPE_MAP[params.scopeType], params.scopeRef, body.basis, query.as_of, buildAuditContext(req),
+    );
     res.status(201).json(created);
+  } catch (error) { next(error); }
+};
+
+export const listMarginSnapshots: RequestHandler = async (req, res, next) => {
+  try {
+    const params = marginScopeParamsSchema.parse(req.params);
+    const query = marginSnapshotListQuerySchema.parse(req.query);
+    const items = await svcListMarginSnapshots(SCOPE_MAP[params.scopeType], params.scopeRef, query);
+    res.json({ items });
   } catch (error) { next(error); }
 };

--- a/src/module/margin-engine/controllers/margin-engine.controller.ts
+++ b/src/module/margin-engine/controllers/margin-engine.controller.ts
@@ -1,0 +1,119 @@
+import type { Request, RequestHandler } from "express";
+import { HttpError } from "../../../utils/httpError";
+import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import type { MarginScopeType } from "../domain/margin-engine";
+import {
+  createMarginInputSchema,
+  createRateVersionSchema,
+  marginReadQuerySchema,
+  marginScopeParamsSchema,
+  marginSnapshotBodySchema,
+} from "../validators/margin-engine.validators";
+import {
+  svcCreateMarginInput,
+  svcCreateMarginSnapshot,
+  svcCreateRateVersion,
+  svcExportMargin,
+  svcGetMargin,
+  svcListRateVersions,
+} from "../services/margin-engine.service";
+
+const SCOPE_MAP: Record<"devis-line" | "devis" | "affaire" | "of", MarginScopeType> = {
+  "devis-line": "DEVIS_LINE",
+  devis: "DEVIS",
+  affaire: "AFFAIRE",
+  of: "OF",
+};
+
+function actorId(req: Request): number {
+  if (typeof req.user?.id !== "number") throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  return req.user.id;
+}
+
+async function auditMutation(req: Request, action: string, entityType: string, entityId: string, details: Record<string, unknown>) {
+  const userAgent = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null;
+  const device = parseDevice(userAgent);
+  await repoInsertAuditLog({
+    user_id: actorId(req),
+    ip: getClientIp(req),
+    user_agent: userAgent,
+    device_type: device.device_type,
+    os: device.os,
+    browser: device.browser,
+    body: {
+      event_type: "ACTION",
+      action,
+      page_key: "margin-engine",
+      entity_type: entityType,
+      entity_id: entityId,
+      path: req.originalUrl,
+      client_session_id: typeof req.headers["x-client-session-id"] === "string" ? req.headers["x-client-session-id"] : null,
+      details,
+    },
+  });
+}
+
+export const getMargin: RequestHandler = async (req, res, next) => {
+  try {
+    const params = marginScopeParamsSchema.parse(req.params);
+    const query = marginReadQuerySchema.parse(req.query);
+    res.json(await svcGetMargin(SCOPE_MAP[params.scopeType], params.scopeRef, query.as_of));
+  } catch (error) { next(error); }
+};
+
+export const exportMargin: RequestHandler = async (req, res, next) => {
+  try {
+    const params = marginScopeParamsSchema.parse(req.params);
+    const query = marginReadQuerySchema.parse(req.query);
+    const csv = await svcExportMargin(SCOPE_MAP[params.scopeType], params.scopeRef, query.as_of);
+    res.setHeader("Content-Type", "text/csv; charset=utf-8");
+    res.setHeader("Content-Disposition", `attachment; filename="margin-${params.scopeType}-${params.scopeRef}.csv"`);
+    res.send(csv);
+  } catch (error) { next(error); }
+};
+
+export const createMarginInput: RequestHandler = async (req, res, next) => {
+  try {
+    const input = createMarginInputSchema.parse(req.body);
+    const created = await svcCreateMarginInput(input, actorId(req));
+    await auditMutation(req, "MARGIN_INPUT_VERSION_CREATED", "margin_input_version", created.id, {
+      scope_type: input.scope_type, scope_ref: input.scope_ref, basis: input.basis,
+      input_key: input.input_key, supersedes_id: input.supersedes_id ?? null,
+    });
+    res.status(201).json(created);
+  } catch (error) { next(error); }
+};
+
+export const createRateVersion: RequestHandler = async (req, res, next) => {
+  try {
+    const input = createRateVersionSchema.parse(req.body);
+    const created = await svcCreateRateVersion(input, actorId(req));
+    await auditMutation(req, "MARGIN_RATE_VERSION_CREATED", "margin_rate_version", created.id, {
+      code: input.code, version: input.version, effective_from: input.effective_from,
+      supersedes_id: input.supersedes_id ?? null, rate_count: input.rates.length,
+    });
+    res.status(201).json(created);
+  } catch (error) { next(error); }
+};
+
+export const listRateVersions: RequestHandler = async (req, res, next) => {
+  try {
+    const query = marginReadQuerySchema.parse(req.query);
+    res.json({ items: await svcListRateVersions(query.as_of) });
+  } catch (error) { next(error); }
+};
+
+export const createMarginSnapshot: RequestHandler = async (req, res, next) => {
+  try {
+    const params = marginScopeParamsSchema.parse(req.params);
+    const body = marginSnapshotBodySchema.parse(req.body);
+    const query = marginReadQuerySchema.parse(req.query);
+    const asOf = query.as_of ?? new Date().toISOString().slice(0, 10);
+    const created = await svcCreateMarginSnapshot(SCOPE_MAP[params.scopeType], params.scopeRef, body.basis, asOf, actorId(req));
+    await auditMutation(req, "MARGIN_RECALCULATION_SNAPSHOTTED", "margin_recalculation", created.id, {
+      scope_type: SCOPE_MAP[params.scopeType], scope_ref: params.scopeRef, basis: body.basis, as_of: asOf,
+    });
+    res.status(201).json(created);
+  } catch (error) { next(error); }
+};

--- a/src/module/margin-engine/domain/margin-engine-policy.ts
+++ b/src/module/margin-engine/domain/margin-engine-policy.ts
@@ -1,0 +1,15 @@
+export type MarginCapability = "read_costs" | "manage_rates" | "manage_inputs" | "snapshot" | "export";
+
+const CAPABILITY_ROLE_NEEDLES: Record<MarginCapability, readonly string[]> = {
+  read_costs: ["admin", "administrateur", "direction", "directeur", "compt", "controle", "contrôle", "method", "méthod"],
+  manage_rates: ["admin", "administrateur", "direction", "directeur", "compt", "controle", "contrôle"],
+  manage_inputs: ["admin", "administrateur", "direction", "directeur", "compt", "controle", "contrôle", "method", "méthod"],
+  snapshot: ["admin", "administrateur", "direction", "directeur", "compt", "controle", "contrôle"],
+  export: ["admin", "administrateur", "direction", "directeur", "compt", "controle", "contrôle"],
+};
+
+/** Deny-by-default server policy. Account-module grants are handled by the route middleware. */
+export function roleHasMarginCapability(role: string | null | undefined, capability: MarginCapability): boolean {
+  const normalized = role?.trim().toLocaleLowerCase("fr") ?? "";
+  return normalized.length > 0 && CAPABILITY_ROLE_NEEDLES[capability].some((needle) => normalized.includes(needle));
+}

--- a/src/module/margin-engine/domain/margin-engine-policy.ts
+++ b/src/module/margin-engine/domain/margin-engine-policy.ts
@@ -13,3 +13,16 @@ export function roleHasMarginCapability(role: string | null | undefined, capabil
   const normalized = role?.trim().toLocaleLowerCase("fr") ?? "";
   return normalized.length > 0 && CAPABILITY_ROLE_NEEDLES[capability].some((needle) => normalized.includes(needle));
 }
+
+/**
+ * L'accès au module reporting est seulement un filtre de navigation/lecture.
+ * Il ne confère jamais une capacité financière d'écriture, de preuve ou d'export.
+ */
+export function canUseMarginCapability(
+  role: string | null | undefined,
+  capability: MarginCapability,
+  hasReportingModuleAccess: boolean,
+): boolean {
+  if (roleHasMarginCapability(role, capability)) return true;
+  return capability === "read_costs" && hasReportingModuleAccess;
+}

--- a/src/module/margin-engine/domain/margin-engine.ts
+++ b/src/module/margin-engine/domain/margin-engine.ts
@@ -1,0 +1,272 @@
+import crypto from "node:crypto";
+
+export const MARGIN_FORMULA_VERSION = "CERP-MARGIN-1.0.0" as const;
+export const MARGIN_CURRENCY = "EUR" as const;
+
+export const MARGIN_COST_CATEGORIES = [
+  "MATERIAL",
+  "PURCHASE",
+  "SUBCONTRACTING",
+  "MACHINE",
+  "OPERATOR",
+  "CONTROL",
+  "TOOLING",
+  "PACKAGING",
+  "TRANSPORT",
+  "SCRAP",
+  "OVERHEAD",
+] as const;
+export type MarginCostCategory = (typeof MARGIN_COST_CATEGORIES)[number];
+export type MarginBasis = "PLANNED" | "ACTUAL";
+export type MarginScopeType = "DEVIS_LINE" | "DEVIS" | "AFFAIRE" | "OF";
+export type MarginInputAvailability = "PROVIDED" | "NOT_APPLICABLE";
+export type MarginRateUnit = "EUR_PER_HOUR" | "EUR_PER_UNIT" | "PERCENT_OF_DIRECT_COST";
+
+const SCALE_DIGITS = 6;
+const SCALE = 1_000_000n;
+
+function pow10(digits: number): bigint {
+  return 10n ** BigInt(digits);
+}
+
+/** Decimal parser with half-away-from-zero rounding to six internal decimals. */
+export function decimal(value: string | number | bigint): bigint {
+  if (typeof value === "bigint") return value * SCALE;
+  const text = String(value).trim();
+  const match = /^([+-]?)(\d+)(?:\.(\d+))?$/.exec(text);
+  if (!match) throw new Error(`Invalid decimal: ${text}`);
+  const sign = match[1] === "-" ? -1n : 1n;
+  const whole = BigInt(match[2]);
+  const fraction = match[3] ?? "";
+  const kept = (fraction.slice(0, SCALE_DIGITS) + "0".repeat(SCALE_DIGITS)).slice(0, SCALE_DIGITS);
+  let scaled = whole * SCALE + BigInt(kept);
+  const next = fraction[SCALE_DIGITS];
+  if (next && next >= "5") scaled += 1n;
+  return sign * scaled;
+}
+
+function roundDiv(numerator: bigint, denominator: bigint): bigint {
+  if (denominator === 0n) throw new Error("Division by zero");
+  const negative = (numerator < 0n) !== (denominator < 0n);
+  const a = numerator < 0n ? -numerator : numerator;
+  const b = denominator < 0n ? -denominator : denominator;
+  const quotient = a / b;
+  const remainder = a % b;
+  const rounded = remainder * 2n >= b ? quotient + 1n : quotient;
+  return negative ? -rounded : rounded;
+}
+
+function multiply(left: bigint, right: bigint): bigint {
+  return roundDiv(left * right, SCALE);
+}
+
+function format(value: bigint, digits: number): string {
+  const factor = pow10(SCALE_DIGITS - digits);
+  const rounded = roundDiv(value, factor);
+  const negative = rounded < 0n;
+  const absolute = negative ? -rounded : rounded;
+  const unit = pow10(digits);
+  const whole = absolute / unit;
+  const fraction = (absolute % unit).toString().padStart(digits, "0");
+  return `${negative ? "-" : ""}${whole}${digits > 0 ? `.${fraction}` : ""}`;
+}
+
+export function money(value: bigint): string {
+  return format(value, 2);
+}
+
+function percentage(numerator: bigint, denominator: bigint): string | null {
+  if (denominator === 0n) return null;
+  const scaledPercent = roundDiv(numerator * 100n * SCALE, denominator);
+  return format(scaledPercent, 2);
+}
+
+export type MarginEvidence = {
+  source_type: string;
+  source_ref: string | null;
+  observed_at: string | null;
+  assumption: string | null;
+  assumption_date: string | null;
+  rate_version_id: string | null;
+};
+
+export type MarginCostInput = {
+  key: string;
+  category: MarginCostCategory;
+  availability: MarginInputAvailability;
+  amount_ht: string | null;
+  quantity: string | null;
+  rate: string | null;
+  rate_unit: MarginRateUnit | null;
+  currency: string;
+  evidence: MarginEvidence;
+};
+
+export type MarginRevenueInput = {
+  availability: MarginInputAvailability;
+  amount_ht: string | null;
+  currency: string;
+  evidence: MarginEvidence;
+};
+
+export type MarginCalculationInput = {
+  scope_type: MarginScopeType;
+  scope_ref: string;
+  label: string;
+  basis: MarginBasis;
+  as_of: string;
+  revenue: MarginRevenueInput | null;
+  costs: MarginCostInput[];
+  required_categories?: readonly MarginCostCategory[];
+  measurements?: Record<string, string | number | null>;
+};
+
+type ResolvedInput = MarginCostInput & { resolved_amount_ht: string | null };
+
+function resolveInput(input: MarginCostInput, directSubtotal: bigint): { amount: bigint | null; row: ResolvedInput } {
+  if (input.availability === "NOT_APPLICABLE") {
+    return { amount: null, row: { ...input, resolved_amount_ht: null } };
+  }
+  let amount: bigint | null = null;
+  try {
+    if (input.amount_ht !== null) amount = decimal(input.amount_ht);
+    else if (input.rate !== null && input.rate_unit !== null) {
+      if (input.rate_unit === "PERCENT_OF_DIRECT_COST") {
+        amount = roundDiv(directSubtotal * decimal(input.rate), 100n * SCALE);
+      } else if (input.quantity !== null) {
+        amount = multiply(decimal(input.quantity), decimal(input.rate));
+      }
+    }
+  } catch {
+    amount = null;
+  }
+  return { amount, row: { ...input, resolved_amount_ht: amount === null ? null : money(amount) } };
+}
+
+export type MarginCalculation = {
+  formula_version: typeof MARGIN_FORMULA_VERSION;
+  scope: { type: MarginScopeType; ref: string; label: string };
+  basis: MarginBasis;
+  as_of: string;
+  currency: string;
+  availability: "COMPLETE" | "PARTIAL" | "UNAVAILABLE";
+  revenue_ht: string | null;
+  cost_total_ht: string | null;
+  partial_cost_total_ht: string;
+  gross_margin_ht: string | null;
+  margin_rate_pct: string | null;
+  mark_rate_pct: string | null;
+  components: Array<{
+    category: MarginCostCategory;
+    status: "PROVIDED" | "NOT_APPLICABLE" | "MISSING";
+    amount_ht: string | null;
+    inputs: ResolvedInput[];
+  }>;
+  missing_inputs: Array<{ code: string; category: MarginCostCategory | "REVENUE"; message: string }>;
+  measurements: Record<string, string | number | null>;
+  calculation_hash: string;
+};
+
+export function calculateMargin(input: MarginCalculationInput): MarginCalculation {
+  const required = input.required_categories ?? MARGIN_COST_CATEGORIES;
+  const missing: MarginCalculation["missing_inputs"] = [];
+  let revenue: bigint | null = null;
+  if (input.revenue?.availability === "PROVIDED" && input.revenue.amount_ht !== null) {
+    try { revenue = decimal(input.revenue.amount_ht); } catch { revenue = null; }
+  }
+  if (revenue === null) {
+    missing.push({ code: "REVENUE_HT_MISSING", category: "REVENUE", message: "Prix de vente HT/remises non attribués à ce périmètre." });
+  }
+
+  const nonOverhead = input.costs.filter((item) => item.category !== "OVERHEAD");
+  const overhead = input.costs.filter((item) => item.category === "OVERHEAD");
+  const firstPass = nonOverhead.map((item) => resolveInput(item, 0n));
+  const directSubtotal = firstPass.reduce((sum, item) => sum + (item.amount ?? 0n), 0n);
+  const resolved = [...firstPass, ...overhead.map((item) => resolveInput(item, directSubtotal))];
+
+  const components = MARGIN_COST_CATEGORIES.map((category) => {
+    const categoryRows = resolved.filter((entry) => entry.row.category === category);
+    const provided = categoryRows.filter((entry) => entry.row.availability === "PROVIDED" && entry.amount !== null);
+    const explicitNa = categoryRows.some((entry) => entry.row.availability === "NOT_APPLICABLE");
+    const invalid = categoryRows.some((entry) => entry.row.availability === "PROVIDED" && entry.amount === null);
+    const status = provided.length > 0 ? "PROVIDED" : explicitNa && !invalid ? "NOT_APPLICABLE" : "MISSING";
+    const amount = provided.reduce((sum, entry) => sum + (entry.amount ?? 0n), 0n);
+    if (required.includes(category) && status === "MISSING") {
+      missing.push({
+        code: `${category}_MISSING`,
+        category,
+        message: invalid ? `Entrée ${category} incomplète : montant ou taux manquant.` : `Entrée ${category} absente (elle n'est pas assimilée à zéro).`,
+      });
+    }
+    return {
+      category,
+      status,
+      amount_ht: status === "PROVIDED" ? money(amount) : null,
+      inputs: categoryRows.map((entry) => entry.row),
+    } as MarginCalculation["components"][number];
+  });
+
+  const partialCost = resolved.reduce((sum, entry) => sum + (entry.amount ?? 0n), 0n);
+  const costMissing = missing.some((entry) => entry.category !== "REVENUE");
+  const complete = revenue !== null && !costMissing;
+  const costTotal = costMissing ? null : partialCost;
+  const grossMargin = complete && costTotal !== null ? revenue! - costTotal : null;
+  const availability: MarginCalculation["availability"] = complete
+    ? "COMPLETE"
+    : revenue === null && partialCost === 0n
+      ? "UNAVAILABLE"
+      : "PARTIAL";
+
+  const unsigned = {
+    formula_version: MARGIN_FORMULA_VERSION,
+    scope: { type: input.scope_type, ref: input.scope_ref, label: input.label },
+    basis: input.basis,
+    as_of: input.as_of,
+    currency: input.revenue?.currency ?? MARGIN_CURRENCY,
+    availability,
+    revenue_ht: revenue === null ? null : money(revenue),
+    cost_total_ht: costTotal === null ? null : money(costTotal),
+    partial_cost_total_ht: money(partialCost),
+    gross_margin_ht: grossMargin === null ? null : money(grossMargin),
+    // Taux de marge = marge / coût de revient. Taux de marque = marge / prix de vente HT.
+    margin_rate_pct: grossMargin === null || costTotal === null ? null : percentage(grossMargin, costTotal),
+    mark_rate_pct: grossMargin === null || revenue === null ? null : percentage(grossMargin, revenue!),
+    components,
+    missing_inputs: missing,
+    measurements: input.measurements ?? {},
+  };
+  const calculation_hash = crypto.createHash("sha256").update(JSON.stringify(unsigned)).digest("hex");
+  return { ...unsigned, calculation_hash };
+}
+
+export type MarginComparison = {
+  planned: MarginCalculation;
+  actual: MarginCalculation;
+  variance: {
+    available: boolean;
+    cost_ht: string | null;
+    gross_margin_ht: string | null;
+    reason: string | null;
+  };
+};
+
+export function compareMargins(planned: MarginCalculation, actual: MarginCalculation): MarginComparison {
+  const canCompare = planned.cost_total_ht !== null && actual.cost_total_ht !== null && planned.gross_margin_ht !== null && actual.gross_margin_ht !== null;
+  return {
+    planned,
+    actual,
+    variance: canCompare
+      ? {
+          available: true,
+          cost_ht: money(decimal(actual.cost_total_ht!) - decimal(planned.cost_total_ht!)),
+          gross_margin_ht: money(decimal(actual.gross_margin_ht!) - decimal(planned.gross_margin_ht!)),
+          reason: null,
+        }
+      : {
+          available: false,
+          cost_ht: null,
+          gross_margin_ht: null,
+          reason: "Écart indisponible tant que les entrées prévues et réelles ne sont pas complètes.",
+        },
+  };
+}

--- a/src/module/margin-engine/domain/margin-engine.ts
+++ b/src/module/margin-engine/domain/margin-engine.ts
@@ -88,6 +88,10 @@ export type MarginEvidence = {
   assumption: string | null;
   assumption_date: string | null;
   rate_version_id: string | null;
+  rate_id: string | null;
+  rate_effective_at: string | null;
+  rate_scope_type: string | null;
+  rate_scope_ref: string | null;
 };
 
 export type MarginCostInput = {
@@ -151,6 +155,7 @@ export type MarginCalculation = {
   currency: string;
   availability: "COMPLETE" | "PARTIAL" | "UNAVAILABLE";
   revenue_ht: string | null;
+  revenue_evidence: MarginEvidence | null;
   cost_total_ht: string | null;
   partial_cost_total_ht: string;
   gross_margin_ht: string | null;
@@ -189,7 +194,7 @@ export function calculateMargin(input: MarginCalculationInput): MarginCalculatio
     const provided = categoryRows.filter((entry) => entry.row.availability === "PROVIDED" && entry.amount !== null);
     const explicitNa = categoryRows.some((entry) => entry.row.availability === "NOT_APPLICABLE");
     const invalid = categoryRows.some((entry) => entry.row.availability === "PROVIDED" && entry.amount === null);
-    const status = provided.length > 0 ? "PROVIDED" : explicitNa && !invalid ? "NOT_APPLICABLE" : "MISSING";
+    const status = invalid ? "MISSING" : provided.length > 0 ? "PROVIDED" : explicitNa ? "NOT_APPLICABLE" : "MISSING";
     const amount = provided.reduce((sum, entry) => sum + (entry.amount ?? 0n), 0n);
     if (required.includes(category) && status === "MISSING") {
       missing.push({
@@ -225,6 +230,7 @@ export function calculateMargin(input: MarginCalculationInput): MarginCalculatio
     currency: input.revenue?.currency ?? MARGIN_CURRENCY,
     availability,
     revenue_ht: revenue === null ? null : money(revenue),
+    revenue_evidence: input.revenue?.evidence ?? null,
     cost_total_ht: costTotal === null ? null : money(costTotal),
     partial_cost_total_ht: money(partialCost),
     gross_margin_ht: grossMargin === null ? null : money(grossMargin),

--- a/src/module/margin-engine/repository/margin-engine.repository.ts
+++ b/src/module/margin-engine/repository/margin-engine.repository.ts
@@ -1,5 +1,7 @@
+import type { PoolClient } from "pg";
 import pool from "../../../config/database";
 import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
 import type {
   MarginBasis,
   MarginCalculation,
@@ -18,6 +20,47 @@ type ScopeIdentity = {
   revenue_ht: string | null;
 };
 
+export type MarginAuditContext = {
+  user_id: number;
+  ip: string | null;
+  user_agent: string | null;
+  device_type: string | null;
+  os: string | null;
+  browser: string | null;
+  path: string | null;
+  page_key: string;
+  client_session_id: string | null;
+};
+
+async function auditMutation(
+  tx: PoolClient,
+  audit: MarginAuditContext,
+  action: string,
+  entityType: string,
+  entityId: string,
+  details: Record<string, unknown>,
+): Promise<void> {
+  await repoInsertAuditLog({
+    user_id: audit.user_id,
+    ip: audit.ip,
+    user_agent: audit.user_agent,
+    device_type: audit.device_type,
+    os: audit.os,
+    browser: audit.browser,
+    tx,
+    body: {
+      event_type: "ACTION",
+      action,
+      page_key: audit.page_key,
+      entity_type: entityType,
+      entity_id: entityId,
+      path: audit.path,
+      client_session_id: audit.client_session_id,
+      details,
+    },
+  });
+}
+
 const evidence = (sourceType: string, sourceRef: string | null, observedAt: string | null = null): MarginEvidence => ({
   source_type: sourceType,
   source_ref: sourceRef,
@@ -25,6 +68,10 @@ const evidence = (sourceType: string, sourceRef: string | null, observedAt: stri
   assumption: null,
   assumption_date: null,
   rate_version_id: null,
+  rate_id: null,
+  rate_effective_at: null,
+  rate_scope_type: null,
+  rate_scope_ref: null,
 });
 
 function automaticCost(row: {
@@ -117,7 +164,7 @@ async function loadDevisCosts(scopeType: "DEVIS_LINE" | "DEVIS", scopeRef: strin
              WHEN op.type_operation = 'SOUS_TRAITANCE' THEN 'SUBCONTRACTING'
              ELSE 'OPERATOR'
            END::text AS category,
-           round(op.cout_mo * dl.quantite, 6)::text AS amount_ht,
+           round(op.cout_mo, 6)::text AS amount_ht,
            'PIECE_TECHNIQUE_OPERATION'::text AS source_type,
            op.id::text AS source_ref,
            op.updated_at::text AS observed_at
@@ -166,7 +213,7 @@ async function loadOfCosts(scopeRef: string, basis: MarginBasis): Promise<{ cost
   };
 }
 
-type ManualInputRow = {
+export type ManualInputRow = {
   input_key: string;
   input_kind: "REVENUE" | "COST";
   category: MarginCostInput["category"] | null;
@@ -180,10 +227,50 @@ type ManualInputRow = {
   assumption: string | null;
   assumption_date: string | null;
   rate_id: string | null;
+  rate_effective_at: string | null;
+  rate_validation_snapshot: unknown;
   rate_amount: string | null;
   rate_unit: MarginCostInput["rate_unit"];
   rate_version_id: string | null;
+  rate_category: MarginCostInput["category"] | null;
+  rate_scope_type: string | null;
+  rate_scope_ref: string | null;
+  rate_effective_from: string | null;
+  rate_effective_to: string | null;
+  created_by: number;
 };
+
+function record(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value) ? value as Record<string, unknown> : null;
+}
+
+export function rateUnitMatchesCategory(unit: MarginCostInput["rate_unit"], category: MarginCostInput["category"] | null): boolean {
+  if (!unit || !category) return false;
+  if (unit === "PERCENT_OF_DIRECT_COST") return category === "OVERHEAD";
+  if (unit === "EUR_PER_HOUR") return ["MACHINE", "OPERATOR", "CONTROL"].includes(category);
+  return !["OVERHEAD", "OPERATOR", "CONTROL"].includes(category);
+}
+
+export function isMarginRateResolutionValid(row: ManualInputRow, scopeType: MarginScopeType, scopeRef: string): boolean {
+  if (row.rate_id === null) return true;
+  const snapshot = record(row.rate_validation_snapshot);
+  if (
+    !snapshot || row.rate_amount === null || row.rate_unit === null || row.rate_version_id === null ||
+    row.rate_category !== row.category || row.rate_effective_at === null || row.rate_effective_from === null ||
+    !rateUnitMatchesCategory(row.rate_unit, row.category)
+  ) return false;
+  if (row.rate_effective_at < row.rate_effective_from || (row.rate_effective_to !== null && row.rate_effective_at > row.rate_effective_to)) return false;
+  if (row.rate_unit === "PERCENT_OF_DIRECT_COST" ? row.quantity !== null : row.quantity === null) return false;
+  return snapshot.rate_id === row.rate_id &&
+    snapshot.rate_version_id === row.rate_version_id &&
+    snapshot.category === row.rate_category &&
+    snapshot.unit === row.rate_unit &&
+    snapshot.scope_type === row.rate_scope_type &&
+    (snapshot.scope_ref ?? null) === row.rate_scope_ref &&
+    snapshot.rate_effective_at === row.rate_effective_at &&
+    snapshot.validated_scope_type === scopeType &&
+    snapshot.validated_scope_ref === scopeRef;
+}
 
 async function loadManualInputs(scopeType: MarginScopeType, scopeRef: string, basis: MarginBasis, asOf: string): Promise<{
   revenue: MarginRevenueInput | null;
@@ -195,13 +282,18 @@ async function loadManualInputs(scopeType: MarginScopeType, scopeRef: string, ba
       i.amount_ht::text, i.quantity::text, i.currency,
       i.source_type, i.source_ref, i.observed_at::text,
       i.assumption, i.assumption_date::text,
-      i.rate_id::text, r.amount::text AS rate_amount, r.unit AS rate_unit,
-      r.rate_version_id::text AS rate_version_id
+      i.created_by,
+      i.rate_id::text, i.rate_effective_at::text, i.rate_validation_snapshot,
+      r.amount::text AS rate_amount, r.unit AS rate_unit,
+      r.rate_version_id::text AS rate_version_id, r.category AS rate_category,
+      r.scope_type AS rate_scope_type, r.scope_ref AS rate_scope_ref,
+      v.effective_from::text AS rate_effective_from, v.effective_to::text AS rate_effective_to
     FROM public.margin_input_versions i
     LEFT JOIN public.margin_input_versions successor
       ON successor.supersedes_id = i.id
      AND successor.created_at < ($4::date + interval '1 day')
     LEFT JOIN public.margin_rates r ON r.id = i.rate_id
+    LEFT JOIN public.margin_rate_versions v ON v.id = r.rate_version_id
     WHERE i.scope_type = $1 AND i.scope_ref = $2 AND i.basis = $3
       AND i.created_at < ($4::date + interval '1 day')
       AND successor.id IS NULL
@@ -210,6 +302,15 @@ async function loadManualInputs(scopeType: MarginScopeType, scopeRef: string, ba
   let revenue: MarginRevenueInput | null = null;
   const costs: MarginCostInput[] = [];
   for (const row of result.rows) {
+    let rateResolved = isMarginRateResolutionValid(row, scopeType, scopeRef);
+    if (rateResolved && row.rate_id !== null) {
+      rateResolved = await scopedRateMatchesTarget(
+        pool,
+        { scope_type: scopeType, scope_ref: scopeRef },
+        { scope_type: row.rate_scope_type!, scope_ref: row.rate_scope_ref },
+        row.created_by,
+      );
+    }
     const sourceEvidence: MarginEvidence = {
       source_type: row.source_type,
       source_ref: row.source_ref,
@@ -217,6 +318,10 @@ async function loadManualInputs(scopeType: MarginScopeType, scopeRef: string, ba
       assumption: row.assumption,
       assumption_date: row.assumption_date,
       rate_version_id: row.rate_version_id,
+      rate_id: row.rate_id,
+      rate_effective_at: row.rate_effective_at,
+      rate_scope_type: row.rate_scope_type,
+      rate_scope_ref: row.rate_scope_ref,
     };
     if (row.input_kind === "REVENUE") {
       revenue = { availability: row.availability, amount_ht: row.amount_ht, currency: row.currency, evidence: sourceEvidence };
@@ -225,9 +330,9 @@ async function loadManualInputs(scopeType: MarginScopeType, scopeRef: string, ba
         key: row.input_key,
         category: row.category,
         availability: row.availability,
-        amount_ht: row.amount_ht,
+        amount_ht: rateResolved ? row.amount_ht : null,
         quantity: row.quantity,
-        rate: row.rate_amount,
+        rate: rateResolved ? row.rate_amount : null,
         rate_unit: row.rate_unit,
         currency: row.currency,
         evidence: sourceEvidence,
@@ -266,35 +371,168 @@ export async function repoBuildCalculationInput(identity: ScopeIdentity, basis: 
   };
 }
 
-export async function repoCreateMarginInput(input: CreateMarginInput, userId: number): Promise<{ id: string; created_at: string }> {
-  if (input.supersedes_id) {
-    const predecessor = await pool.query<{ scope_type: string; scope_ref: string; basis: string; input_key: string }>(`
-      SELECT scope_type, scope_ref, basis, input_key
-      FROM public.margin_input_versions
-      WHERE id = $1::uuid
-    `, [input.supersedes_id]);
-    const row = predecessor.rows[0];
-    if (!row || row.scope_type !== input.scope_type || row.scope_ref !== input.scope_ref || row.basis !== input.basis || row.input_key !== input.input_key) {
-      throw new HttpError(409, "MARGIN_SUPERSEDES_MISMATCH", "La version remplacée doit porter la même entrée et le même périmètre.");
-    }
-  }
-  const result = await pool.query<{ id: string; created_at: string }>(`
-    INSERT INTO public.margin_input_versions (
-      scope_type, scope_ref, basis, input_key, input_kind, category, availability,
-      amount_ht, quantity, rate_id, source_type, source_ref, observed_at,
-      assumption, assumption_date, supersedes_id, created_by
-    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::numeric,$9::numeric,$10::uuid,$11,$12,$13::timestamptz,$14,$15::date,$16::uuid,$17)
-    RETURNING id::text, created_at::text
-  `, [
-    input.scope_type, input.scope_ref, input.basis, input.input_key, input.input_kind,
-    input.category ?? null, input.availability, input.amount_ht ?? null, input.quantity ?? null,
-    input.rate_id ?? null, input.source_type, input.source_ref ?? null, input.observed_at ?? null,
-    input.assumption ?? null, input.assumption_date ?? null, input.supersedes_id ?? null, userId,
-  ]);
-  return result.rows[0]!;
+type RateValidationRow = {
+  id: string;
+  category: MarginCostInput["category"];
+  unit: NonNullable<MarginCostInput["rate_unit"]>;
+  scope_type: string;
+  scope_ref: string | null;
+  rate_version_id: string;
+  effective_from: string;
+  effective_to: string | null;
+};
+
+async function scopedRateMatchesTarget(
+  tx: Pick<PoolClient, "query">,
+  input: Pick<CreateMarginInput, "scope_type" | "scope_ref">,
+  rate: Pick<RateValidationRow, "scope_type" | "scope_ref">,
+  userId: number,
+): Promise<boolean> {
+  if (rate.scope_type === "GLOBAL") return rate.scope_ref === null;
+  if (rate.scope_type === "USER") return rate.scope_ref === String(userId);
+  if (!rate.scope_ref) return false;
+  const result = await tx.query<{ matches: boolean }>(`
+    WITH target_devis AS (
+      SELECT d.id
+      FROM public.devis d
+      WHERE ($1 = 'DEVIS' AND d.id = $2::bigint)
+      UNION
+      SELECT dl.devis_id
+      FROM public.devis_ligne dl
+      WHERE $1 = 'DEVIS_LINE' AND dl.id = $2::bigint
+      UNION
+      SELECT a.devis_id
+      FROM public.affaire a
+      WHERE $1 = 'AFFAIRE' AND a.id = $2::bigint AND a.devis_id IS NOT NULL
+    ), target_ofs AS (
+      SELECT o.id, o.piece_technique_id
+      FROM public.ordres_fabrication o
+      WHERE ($1 = 'OF' AND o.id = $2::bigint)
+         OR ($1 = 'AFFAIRE' AND o.affaire_id = $2::bigint)
+         OR EXISTS (
+           SELECT 1 FROM public.affaire a
+           JOIN target_devis d ON d.id = a.devis_id
+           WHERE a.id = o.affaire_id
+         )
+    ), target_pieces AS (
+      SELECT piece_technique_id AS id FROM target_ofs
+      UNION
+      SELECT COALESCE(dl.piece_technique_id, ar.piece_technique_id)
+      FROM public.devis_ligne dl
+      LEFT JOIN public.articles ar ON ar.id = dl.article_id
+      WHERE (($1 = 'DEVIS_LINE' AND dl.id = $2::bigint)
+          OR ($1 <> 'DEVIS_LINE' AND dl.devis_id IN (SELECT id FROM target_devis)))
+        AND COALESCE(dl.piece_technique_id, ar.piece_technique_id) IS NOT NULL
+    )
+    SELECT CASE $3
+      WHEN 'PIECE_TECHNIQUE' THEN EXISTS (SELECT 1 FROM target_pieces p WHERE p.id::text = $4)
+      WHEN 'MACHINE' THEN
+        EXISTS (SELECT 1 FROM public.pieces_techniques_operations op JOIN target_pieces p ON p.id = op.piece_technique_id WHERE op.machine_id::text = $4)
+        OR EXISTS (SELECT 1 FROM public.of_operations op JOIN target_ofs o ON o.id = op.of_id AND o.piece_technique_id IN (SELECT id FROM target_pieces) WHERE op.machine_id::text = $4)
+      WHEN 'COST_CENTER' THEN
+        EXISTS (SELECT 1 FROM public.pieces_techniques_operations op JOIN target_pieces p ON p.id = op.piece_technique_id WHERE op.cf_id::text = $4)
+        OR EXISTS (SELECT 1 FROM public.of_operations op JOIN target_ofs o ON o.id = op.of_id AND o.piece_technique_id IN (SELECT id FROM target_pieces) WHERE op.cf_id::text = $4)
+      ELSE false
+    END AS matches
+  `, [input.scope_type, input.scope_ref, rate.scope_type, rate.scope_ref]);
+  return result.rows[0]?.matches === true;
 }
 
-export async function repoCreateRateVersion(input: CreateRateVersion, userId: number): Promise<{ id: string; created_at: string }> {
+export async function validateRateForInput(
+  tx: PoolClient,
+  input: CreateMarginInput,
+  userId: number,
+): Promise<Record<string, unknown> | null> {
+  if (!input.rate_id) return null;
+  if (input.input_kind !== "COST" || !input.category || input.amount_ht != null || !input.rate_effective_at) {
+    throw new HttpError(422, "MARGIN_RATE_INPUT_INVALID", "Un taux s'applique uniquement à un coût sans montant direct et avec une date d'application.");
+  }
+  const result = await tx.query<RateValidationRow>(`
+    SELECT r.id::text, r.category, r.unit, r.scope_type, r.scope_ref,
+           r.rate_version_id::text, v.effective_from::text, v.effective_to::text
+    FROM public.margin_rates r
+    JOIN public.margin_rate_versions v ON v.id = r.rate_version_id
+    WHERE r.id = $1::uuid
+    FOR SHARE
+  `, [input.rate_id]);
+  const rate = result.rows[0];
+  if (!rate) throw new HttpError(422, "MARGIN_RATE_NOT_FOUND", "Taux de marge introuvable.");
+  if (rate.category !== input.category || !rateUnitMatchesCategory(rate.unit, input.category)) {
+    throw new HttpError(422, "MARGIN_RATE_CATEGORY_UNIT_MISMATCH", "La catégorie ou l'unité du taux ne correspond pas au coût.");
+  }
+  if (rate.unit === "PERCENT_OF_DIRECT_COST" ? input.quantity != null : input.quantity == null) {
+    throw new HttpError(422, "MARGIN_RATE_QUANTITY_INVALID", rate.unit === "PERCENT_OF_DIRECT_COST"
+      ? "Un taux de frais généraux ne porte pas de quantité."
+      : "Une quantité est requise pour ce taux.");
+  }
+  if (input.rate_effective_at < rate.effective_from || (rate.effective_to !== null && input.rate_effective_at > rate.effective_to)) {
+    throw new HttpError(422, "MARGIN_RATE_OUTSIDE_EFFECTIVE_PERIOD", "Le taux n'est pas applicable à la date demandée.");
+  }
+  if (!(await scopedRateMatchesTarget(tx, input, rate, userId))) {
+    throw new HttpError(422, "MARGIN_RATE_SCOPE_MISMATCH", "La portée du taux ne correspond pas au périmètre métier.");
+  }
+  return {
+    rate_id: rate.id,
+    rate_version_id: rate.rate_version_id,
+    category: rate.category,
+    unit: rate.unit,
+    scope_type: rate.scope_type,
+    scope_ref: rate.scope_ref,
+    effective_from: rate.effective_from,
+    effective_to: rate.effective_to,
+    rate_effective_at: input.rate_effective_at,
+    validated_scope_type: input.scope_type,
+    validated_scope_ref: input.scope_ref,
+  };
+}
+
+export async function repoCreateMarginInput(input: CreateMarginInput, audit: MarginAuditContext): Promise<{ id: string; created_at: string }> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    if (input.supersedes_id) {
+      const predecessor = await client.query<{ scope_type: string; scope_ref: string; basis: string; input_key: string }>(`
+        SELECT scope_type, scope_ref, basis, input_key
+        FROM public.margin_input_versions
+        WHERE id = $1::uuid FOR SHARE
+      `, [input.supersedes_id]);
+      const row = predecessor.rows[0];
+      if (!row || row.scope_type !== input.scope_type || row.scope_ref !== input.scope_ref || row.basis !== input.basis || row.input_key !== input.input_key) {
+        throw new HttpError(409, "MARGIN_SUPERSEDES_MISMATCH", "La version remplacée doit porter la même entrée et le même périmètre.");
+      }
+    }
+    const rateSnapshot = await validateRateForInput(client, input, audit.user_id);
+    const result = await client.query<{ id: string; created_at: string }>(`
+      INSERT INTO public.margin_input_versions (
+        scope_type, scope_ref, basis, input_key, input_kind, category, availability,
+        amount_ht, quantity, rate_id, rate_effective_at, rate_validation_snapshot,
+        source_type, source_ref, observed_at, assumption, assumption_date, supersedes_id, created_by
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::numeric,$9::numeric,$10::uuid,$11::date,$12::jsonb,$13,$14,$15::timestamptz,$16,$17::date,$18::uuid,$19)
+      RETURNING id::text, created_at::text
+    `, [
+      input.scope_type, input.scope_ref, input.basis, input.input_key, input.input_kind,
+      input.category ?? null, input.availability, input.amount_ht ?? null, input.quantity ?? null,
+      input.rate_id ?? null, input.rate_effective_at ?? null, rateSnapshot ? JSON.stringify(rateSnapshot) : null,
+      input.source_type, input.source_ref ?? null, input.observed_at ?? null,
+      input.assumption ?? null, input.assumption_date ?? null, input.supersedes_id ?? null, audit.user_id,
+    ]);
+    const created = result.rows[0]!;
+    await auditMutation(client, audit, "MARGIN_INPUT_VERSION_CREATED", "margin_input_version", created.id, {
+      scope_type: input.scope_type, scope_ref: input.scope_ref, basis: input.basis,
+      input_key: input.input_key, supersedes_id: input.supersedes_id ?? null,
+      rate_id: input.rate_id ?? null, rate_effective_at: input.rate_effective_at ?? null,
+    });
+    await client.query("COMMIT");
+    return created;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoCreateRateVersion(input: CreateRateVersion, audit: MarginAuditContext): Promise<{ id: string; created_at: string }> {
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
@@ -312,7 +550,7 @@ export async function repoCreateRateVersion(input: CreateRateVersion, userId: nu
         (code, version, effective_from, effective_to, source, assumption_date, notes, supersedes_id, created_by)
       VALUES ($1,$2,$3::date,$4::date,$5,$6::date,$7,$8::uuid,$9)
       RETURNING id::text, created_at::text
-    `, [input.code, input.version, input.effective_from, input.effective_to ?? null, input.source, input.assumption_date, input.notes ?? null, input.supersedes_id ?? null, userId]);
+    `, [input.code, input.version, input.effective_from, input.effective_to ?? null, input.source, input.assumption_date, input.notes ?? null, input.supersedes_id ?? null, audit.user_id]);
     const versionId = version.rows[0]!.id;
     for (const rate of input.rates) {
       await client.query(`
@@ -321,6 +559,11 @@ export async function repoCreateRateVersion(input: CreateRateVersion, userId: nu
         VALUES ($1::uuid,$2,$3,$4,$5,$6::numeric,$7,$8)
       `, [versionId, rate.rate_code, rate.category, rate.scope_type, rate.scope_ref ?? null, rate.amount, rate.unit, rate.source_ref ?? null]);
     }
+    await auditMutation(client, audit, "MARGIN_RATE_VERSION_CREATED", "margin_rate_version", versionId, {
+      code: input.code, version: input.version, effective_from: input.effective_from,
+      effective_to: input.effective_to ?? null, supersedes_id: input.supersedes_id ?? null,
+      rate_count: input.rates.length,
+    });
     await client.query("COMMIT");
     return version.rows[0]!;
   } catch (error) {
@@ -349,13 +592,47 @@ export async function repoListRateVersions(asOf: string): Promise<unknown[]> {
   return result.rows;
 }
 
-export async function repoCreateSnapshot(calculation: MarginCalculation, input: MarginCalculationInput, userId: number): Promise<{ id: string; created_at: string }> {
-  const result = await pool.query<{ id: string; created_at: string }>(`
-    INSERT INTO public.margin_recalculations
-      (scope_type, scope_ref, basis, as_of, formula_version, calculation_hash, input_snapshot, result_snapshot, created_by)
-    VALUES ($1,$2,$3,$4::date,$5,$6,$7::jsonb,$8::jsonb,$9)
-    RETURNING id::text, created_at::text
-  `, [calculation.scope.type, calculation.scope.ref, calculation.basis, calculation.as_of, calculation.formula_version,
-      calculation.calculation_hash, JSON.stringify(input), JSON.stringify(calculation), userId]);
-  return result.rows[0]!;
+export async function repoCreateSnapshot(calculation: MarginCalculation, input: MarginCalculationInput, audit: MarginAuditContext): Promise<{ id: string; created_at: string }> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await client.query<{ id: string; created_at: string }>(`
+      INSERT INTO public.margin_recalculations
+        (scope_type, scope_ref, basis, as_of, formula_version, calculation_hash, input_snapshot, result_snapshot, created_by)
+      VALUES ($1,$2,$3,$4::date,$5,$6,$7::jsonb,$8::jsonb,$9)
+      RETURNING id::text, created_at::text
+    `, [calculation.scope.type, calculation.scope.ref, calculation.basis, calculation.as_of, calculation.formula_version,
+        calculation.calculation_hash, JSON.stringify(input), JSON.stringify(calculation), audit.user_id]);
+    const created = result.rows[0]!;
+    await auditMutation(client, audit, "MARGIN_RECALCULATION_SNAPSHOTTED", "margin_recalculation", created.id, {
+      scope_type: calculation.scope.type, scope_ref: calculation.scope.ref,
+      basis: calculation.basis, as_of: calculation.as_of,
+      formula_version: calculation.formula_version, calculation_hash: calculation.calculation_hash,
+    });
+    await client.query("COMMIT");
+    return created;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoListSnapshots(
+  scopeType: MarginScopeType,
+  scopeRef: string,
+  filters: { basis?: MarginBasis; as_of?: string },
+): Promise<unknown[]> {
+  const result = await pool.query(`
+    SELECT id::text, scope_type, scope_ref, basis, as_of::text, formula_version,
+           calculation_hash, input_snapshot, result_snapshot, created_by, created_at::text
+    FROM public.margin_recalculations
+    WHERE scope_type = $1 AND scope_ref = $2
+      AND ($3::text IS NULL OR basis = $3)
+      AND ($4::date IS NULL OR as_of = $4::date)
+    ORDER BY created_at DESC, id DESC
+    LIMIT 100
+  `, [scopeType, scopeRef, filters.basis ?? null, filters.as_of ?? null]);
+  return result.rows;
 }

--- a/src/module/margin-engine/repository/margin-engine.repository.ts
+++ b/src/module/margin-engine/repository/margin-engine.repository.ts
@@ -1,0 +1,361 @@
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import type {
+  MarginBasis,
+  MarginCalculation,
+  MarginCalculationInput,
+  MarginCostInput,
+  MarginEvidence,
+  MarginRevenueInput,
+  MarginScopeType,
+} from "../domain/margin-engine";
+import type { CreateMarginInput, CreateRateVersion } from "../validators/margin-engine.validators";
+
+type ScopeIdentity = {
+  scope_type: MarginScopeType;
+  scope_ref: string;
+  label: string;
+  revenue_ht: string | null;
+};
+
+const evidence = (sourceType: string, sourceRef: string | null, observedAt: string | null = null): MarginEvidence => ({
+  source_type: sourceType,
+  source_ref: sourceRef,
+  observed_at: observedAt,
+  assumption: null,
+  assumption_date: null,
+  rate_version_id: null,
+});
+
+function automaticCost(row: {
+  key: string;
+  category: MarginCostInput["category"];
+  amount_ht: string;
+  source_type: string;
+  source_ref: string | null;
+  observed_at: string | null;
+  rate_version_id?: string | null;
+}): MarginCostInput {
+  return {
+    key: row.key,
+    category: row.category,
+    availability: "PROVIDED",
+    amount_ht: row.amount_ht,
+    quantity: null,
+    rate: null,
+    rate_unit: null,
+    currency: "EUR",
+    evidence: { ...evidence(row.source_type, row.source_ref, row.observed_at), rate_version_id: row.rate_version_id ?? null },
+  };
+}
+
+export async function repoLoadScopeIdentity(scopeType: MarginScopeType, scopeRef: string): Promise<ScopeIdentity | null> {
+  if (scopeType === "DEVIS_LINE") {
+    const result = await pool.query<ScopeIdentity>(`
+      SELECT 'DEVIS_LINE'::text AS scope_type, dl.id::text AS scope_ref,
+             concat(d.numero, ' · ', COALESCE(NULLIF(dl.description, ''), 'ligne ' || dl.id::text)) AS label,
+             round(dl.total_ht * (1 - COALESCE(d.remise_globale, 0) / 100.0), 6)::text AS revenue_ht
+      FROM public.devis_ligne dl
+      JOIN public.devis d ON d.id = dl.devis_id
+      WHERE dl.id = $1::bigint
+    `, [scopeRef]);
+    return result.rows[0] ?? null;
+  }
+  if (scopeType === "DEVIS") {
+    const result = await pool.query<ScopeIdentity>(`
+      SELECT 'DEVIS'::text AS scope_type, id::text AS scope_ref, numero::text AS label,
+             total_ht::text AS revenue_ht FROM public.devis WHERE id = $1::bigint
+    `, [scopeRef]);
+    return result.rows[0] ?? null;
+  }
+  if (scopeType === "AFFAIRE") {
+    const result = await pool.query<ScopeIdentity>(`
+      SELECT 'AFFAIRE'::text AS scope_type, id::text AS scope_ref, reference::text AS label,
+             NULL::text AS revenue_ht FROM public.affaire WHERE id = $1::bigint
+    `, [scopeRef]);
+    return result.rows[0] ?? null;
+  }
+  const result = await pool.query<ScopeIdentity>(`
+    SELECT 'OF'::text AS scope_type, id::text AS scope_ref, numero::text AS label,
+           NULL::text AS revenue_ht FROM public.ordres_fabrication WHERE id = $1::bigint
+  `, [scopeRef]);
+  return result.rows[0] ?? null;
+}
+
+type CostRow = {
+  key: string;
+  category: MarginCostInput["category"];
+  amount_ht: string;
+  source_type: string;
+  source_ref: string | null;
+  observed_at: string | null;
+};
+
+async function loadDevisCosts(scopeType: "DEVIS_LINE" | "DEVIS", scopeRef: string): Promise<MarginCostInput[]> {
+  const linePredicate = scopeType === "DEVIS_LINE" ? "dl.id = $1::bigint" : "dl.devis_id = $1::bigint";
+  const rows = await pool.query<CostRow>(`
+    SELECT concat('purchase:', a.id::text) AS key,
+           CASE
+             WHEN a.type_achat = 'MATIERE' THEN 'MATERIAL'
+             WHEN a.type_achat IN ('SOUS_TRAITANCE', 'TRAITEMENT') THEN 'SUBCONTRACTING'
+             ELSE 'PURCHASE'
+           END::text AS category,
+           round(a.total_achat_ht * dl.quantite, 6)::text AS amount_ht,
+           'PIECE_TECHNIQUE_ACHAT'::text AS source_type,
+           a.id::text AS source_ref,
+           a.updated_at::text AS observed_at
+    FROM public.devis_ligne dl
+    LEFT JOIN public.articles ar ON ar.id = dl.article_id
+    JOIN public.pieces_techniques_achats a
+      ON a.piece_technique_id = COALESCE(dl.piece_technique_id, ar.piece_technique_id)
+    WHERE ${linePredicate} AND a.total_achat_ht IS NOT NULL
+    UNION ALL
+    SELECT concat('operation:', op.id::text) AS key,
+           CASE
+             WHEN op.type_operation = 'CONTROLE' THEN 'CONTROL'
+             WHEN op.type_operation = 'EMBALLAGE' THEN 'PACKAGING'
+             WHEN op.type_operation = 'SOUS_TRAITANCE' THEN 'SUBCONTRACTING'
+             ELSE 'OPERATOR'
+           END::text AS category,
+           round(op.cout_mo * dl.quantite, 6)::text AS amount_ht,
+           'PIECE_TECHNIQUE_OPERATION'::text AS source_type,
+           op.id::text AS source_ref,
+           op.updated_at::text AS observed_at
+    FROM public.devis_ligne dl
+    LEFT JOIN public.articles ar ON ar.id = dl.article_id
+    JOIN public.pieces_techniques_operations op
+      ON op.piece_technique_id = COALESCE(dl.piece_technique_id, ar.piece_technique_id)
+    WHERE ${linePredicate} AND op.cout_mo IS NOT NULL AND op.taux_horaire > 0
+    ORDER BY key
+  `, [scopeRef]);
+  return rows.rows.map(automaticCost);
+}
+
+async function loadOfCosts(scopeRef: string, basis: MarginBasis): Promise<{ costs: MarginCostInput[]; measurements: Record<string, string | number | null> }> {
+  const hoursColumn = basis === "PLANNED" ? "op.temps_total_planned" : "op.temps_total_real";
+  const result = await pool.query<CostRow>(`
+    SELECT concat('of-operation:', op.id::text) AS key,
+           CASE WHEN op.designation ILIKE '%contrôle%' OR op.designation ILIKE '%controle%' THEN 'CONTROL' ELSE 'OPERATOR' END::text AS category,
+           round(op.hourly_rate_applied * ${hoursColumn}, 6)::text AS amount_ht,
+           ${basis === "PLANNED" ? "'OF_OPERATION_PLAN'" : "'PRODUCTION_POINTAGES_RECALC'"}::text AS source_type,
+           op.id::text AS source_ref,
+           op.updated_at::text AS observed_at
+    FROM public.of_operations op
+    WHERE op.of_id = $1::bigint
+      AND op.hourly_rate_applied > 0
+      AND ${hoursColumn} >= 0
+    ORDER BY op.phase, op.id
+  `, [scopeRef]);
+  const measureResult = await pool.query<{
+    planned_hours: string;
+    actual_hours: string;
+    good_quantity: string;
+    scrap_quantity: string;
+    rework_quantity: string;
+  }>(`
+    SELECT
+      COALESCE((SELECT sum(temps_total_planned) FROM public.of_operations WHERE of_id = $1::bigint), 0)::text AS planned_hours,
+      COALESCE((SELECT sum(temps_total_real) FROM public.of_operations WHERE of_id = $1::bigint), 0)::text AS actual_hours,
+      COALESCE((SELECT sum(qty_good) FROM public.production_quantity_declarations WHERE of_id = $1::bigint), 0)::text AS good_quantity,
+      COALESCE((SELECT sum(qty_scrap) FROM public.production_quantity_declarations WHERE of_id = $1::bigint), 0)::text AS scrap_quantity,
+      COALESCE((SELECT sum(qty_rework) FROM public.production_quantity_declarations WHERE of_id = $1::bigint), 0)::text AS rework_quantity
+  `, [scopeRef]);
+  return {
+    costs: result.rows.map(automaticCost),
+    measurements: measureResult.rows[0] ?? {},
+  };
+}
+
+type ManualInputRow = {
+  input_key: string;
+  input_kind: "REVENUE" | "COST";
+  category: MarginCostInput["category"] | null;
+  availability: "PROVIDED" | "NOT_APPLICABLE";
+  amount_ht: string | null;
+  quantity: string | null;
+  currency: string;
+  source_type: string;
+  source_ref: string | null;
+  observed_at: string | null;
+  assumption: string | null;
+  assumption_date: string | null;
+  rate_id: string | null;
+  rate_amount: string | null;
+  rate_unit: MarginCostInput["rate_unit"];
+  rate_version_id: string | null;
+};
+
+async function loadManualInputs(scopeType: MarginScopeType, scopeRef: string, basis: MarginBasis, asOf: string): Promise<{
+  revenue: MarginRevenueInput | null;
+  costs: MarginCostInput[];
+}> {
+  const result = await pool.query<ManualInputRow>(`
+    SELECT DISTINCT ON (i.input_key)
+      i.input_key, i.input_kind, i.category, i.availability,
+      i.amount_ht::text, i.quantity::text, i.currency,
+      i.source_type, i.source_ref, i.observed_at::text,
+      i.assumption, i.assumption_date::text,
+      i.rate_id::text, r.amount::text AS rate_amount, r.unit AS rate_unit,
+      r.rate_version_id::text AS rate_version_id
+    FROM public.margin_input_versions i
+    LEFT JOIN public.margin_input_versions successor
+      ON successor.supersedes_id = i.id
+     AND successor.created_at < ($4::date + interval '1 day')
+    LEFT JOIN public.margin_rates r ON r.id = i.rate_id
+    WHERE i.scope_type = $1 AND i.scope_ref = $2 AND i.basis = $3
+      AND i.created_at < ($4::date + interval '1 day')
+      AND successor.id IS NULL
+    ORDER BY i.input_key, i.created_at DESC, i.id DESC
+  `, [scopeType, scopeRef, basis, asOf]);
+  let revenue: MarginRevenueInput | null = null;
+  const costs: MarginCostInput[] = [];
+  for (const row of result.rows) {
+    const sourceEvidence: MarginEvidence = {
+      source_type: row.source_type,
+      source_ref: row.source_ref,
+      observed_at: row.observed_at,
+      assumption: row.assumption,
+      assumption_date: row.assumption_date,
+      rate_version_id: row.rate_version_id,
+    };
+    if (row.input_kind === "REVENUE") {
+      revenue = { availability: row.availability, amount_ht: row.amount_ht, currency: row.currency, evidence: sourceEvidence };
+    } else if (row.category) {
+      costs.push({
+        key: row.input_key,
+        category: row.category,
+        availability: row.availability,
+        amount_ht: row.amount_ht,
+        quantity: row.quantity,
+        rate: row.rate_amount,
+        rate_unit: row.rate_unit,
+        currency: row.currency,
+        evidence: sourceEvidence,
+      });
+    }
+  }
+  return { revenue, costs };
+}
+
+export async function repoBuildCalculationInput(identity: ScopeIdentity, basis: MarginBasis, asOf: string): Promise<MarginCalculationInput> {
+  const manual = await loadManualInputs(identity.scope_type, identity.scope_ref, basis, asOf);
+  let automaticCosts: MarginCostInput[] = [];
+  let measurements: Record<string, string | number | null> = {};
+  if (basis === "PLANNED" && (identity.scope_type === "DEVIS" || identity.scope_type === "DEVIS_LINE")) {
+    automaticCosts = await loadDevisCosts(identity.scope_type, identity.scope_ref);
+  } else if (identity.scope_type === "OF") {
+    const ofData = await loadOfCosts(identity.scope_ref, basis);
+    automaticCosts = ofData.costs;
+    measurements = ofData.measurements;
+  }
+  const canonicalRevenue: MarginRevenueInput | null = identity.revenue_ht === null ? null : {
+    availability: "PROVIDED",
+    amount_ht: identity.revenue_ht,
+    currency: "EUR",
+    evidence: evidence(identity.scope_type === "DEVIS" ? "DEVIS_TOTAL_HT" : "DEVIS_LINE_TOTAL_HT", identity.scope_ref),
+  };
+  return {
+    scope_type: identity.scope_type,
+    scope_ref: identity.scope_ref,
+    label: identity.label,
+    basis,
+    as_of: asOf,
+    revenue: canonicalRevenue ?? manual.revenue,
+    costs: [...automaticCosts, ...manual.costs],
+    measurements,
+  };
+}
+
+export async function repoCreateMarginInput(input: CreateMarginInput, userId: number): Promise<{ id: string; created_at: string }> {
+  if (input.supersedes_id) {
+    const predecessor = await pool.query<{ scope_type: string; scope_ref: string; basis: string; input_key: string }>(`
+      SELECT scope_type, scope_ref, basis, input_key
+      FROM public.margin_input_versions
+      WHERE id = $1::uuid
+    `, [input.supersedes_id]);
+    const row = predecessor.rows[0];
+    if (!row || row.scope_type !== input.scope_type || row.scope_ref !== input.scope_ref || row.basis !== input.basis || row.input_key !== input.input_key) {
+      throw new HttpError(409, "MARGIN_SUPERSEDES_MISMATCH", "La version remplacée doit porter la même entrée et le même périmètre.");
+    }
+  }
+  const result = await pool.query<{ id: string; created_at: string }>(`
+    INSERT INTO public.margin_input_versions (
+      scope_type, scope_ref, basis, input_key, input_kind, category, availability,
+      amount_ht, quantity, rate_id, source_type, source_ref, observed_at,
+      assumption, assumption_date, supersedes_id, created_by
+    ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::numeric,$9::numeric,$10::uuid,$11,$12,$13::timestamptz,$14,$15::date,$16::uuid,$17)
+    RETURNING id::text, created_at::text
+  `, [
+    input.scope_type, input.scope_ref, input.basis, input.input_key, input.input_kind,
+    input.category ?? null, input.availability, input.amount_ht ?? null, input.quantity ?? null,
+    input.rate_id ?? null, input.source_type, input.source_ref ?? null, input.observed_at ?? null,
+    input.assumption ?? null, input.assumption_date ?? null, input.supersedes_id ?? null, userId,
+  ]);
+  return result.rows[0]!;
+}
+
+export async function repoCreateRateVersion(input: CreateRateVersion, userId: number): Promise<{ id: string; created_at: string }> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    if (input.supersedes_id) {
+      const predecessor = await client.query<{ code: string; version: number }>(`
+        SELECT code, version FROM public.margin_rate_versions WHERE id = $1::uuid FOR SHARE
+      `, [input.supersedes_id]);
+      const row = predecessor.rows[0];
+      if (!row || row.code !== input.code || input.version <= row.version) {
+        throw new HttpError(409, "MARGIN_RATE_SUPERSEDES_MISMATCH", "La nouvelle version doit remplacer une version antérieure du même référentiel.");
+      }
+    }
+    const version = await client.query<{ id: string; created_at: string }>(`
+      INSERT INTO public.margin_rate_versions
+        (code, version, effective_from, effective_to, source, assumption_date, notes, supersedes_id, created_by)
+      VALUES ($1,$2,$3::date,$4::date,$5,$6::date,$7,$8::uuid,$9)
+      RETURNING id::text, created_at::text
+    `, [input.code, input.version, input.effective_from, input.effective_to ?? null, input.source, input.assumption_date, input.notes ?? null, input.supersedes_id ?? null, userId]);
+    const versionId = version.rows[0]!.id;
+    for (const rate of input.rates) {
+      await client.query(`
+        INSERT INTO public.margin_rates
+          (rate_version_id, rate_code, category, scope_type, scope_ref, amount, unit, source_ref)
+        VALUES ($1::uuid,$2,$3,$4,$5,$6::numeric,$7,$8)
+      `, [versionId, rate.rate_code, rate.category, rate.scope_type, rate.scope_ref ?? null, rate.amount, rate.unit, rate.source_ref ?? null]);
+    }
+    await client.query("COMMIT");
+    return version.rows[0]!;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoListRateVersions(asOf: string): Promise<unknown[]> {
+  const result = await pool.query(`
+    SELECT v.id::text, v.code, v.version, v.currency, v.effective_from::text, v.effective_to::text,
+           v.source, v.assumption_date::text, v.notes, v.supersedes_id::text, v.created_by, v.created_at::text,
+           COALESCE(jsonb_agg(jsonb_build_object(
+             'id', r.id::text, 'rate_code', r.rate_code, 'category', r.category,
+             'scope_type', r.scope_type, 'scope_ref', r.scope_ref, 'amount', r.amount::text,
+             'unit', r.unit, 'source_ref', r.source_ref
+           ) ORDER BY r.rate_code) FILTER (WHERE r.id IS NOT NULL), '[]'::jsonb) AS rates
+    FROM public.margin_rate_versions v
+    LEFT JOIN public.margin_rates r ON r.rate_version_id = v.id
+    WHERE v.effective_from <= $1::date AND (v.effective_to IS NULL OR v.effective_to >= $1::date)
+    GROUP BY v.id
+    ORDER BY v.code, v.version DESC
+  `, [asOf]);
+  return result.rows;
+}
+
+export async function repoCreateSnapshot(calculation: MarginCalculation, input: MarginCalculationInput, userId: number): Promise<{ id: string; created_at: string }> {
+  const result = await pool.query<{ id: string; created_at: string }>(`
+    INSERT INTO public.margin_recalculations
+      (scope_type, scope_ref, basis, as_of, formula_version, calculation_hash, input_snapshot, result_snapshot, created_by)
+    VALUES ($1,$2,$3,$4::date,$5,$6,$7::jsonb,$8::jsonb,$9)
+    RETURNING id::text, created_at::text
+  `, [calculation.scope.type, calculation.scope.ref, calculation.basis, calculation.as_of, calculation.formula_version,
+      calculation.calculation_hash, JSON.stringify(input), JSON.stringify(calculation), userId]);
+  return result.rows[0]!;
+}

--- a/src/module/margin-engine/routes/margin-engine.routes.ts
+++ b/src/module/margin-engine/routes/margin-engine.routes.ts
@@ -1,7 +1,7 @@
 import { Router, type RequestHandler } from "express";
 import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 import { HttpError } from "../../../utils/httpError";
-import { roleHasMarginCapability, type MarginCapability } from "../domain/margin-engine-policy";
+import { canUseMarginCapability, type MarginCapability } from "../domain/margin-engine-policy";
 import {
   createMarginInput,
   createMarginSnapshot,
@@ -9,13 +9,14 @@ import {
   exportMargin,
   getMargin,
   listRateVersions,
+  listMarginSnapshots,
 } from "../controllers/margin-engine.controller";
 
 const router = Router();
 
 function requireMarginCapability(capability: MarginCapability): RequestHandler {
   return (req, _res, next) => {
-    if (requestHasGrantedAccountModuleAccess(req) || roleHasMarginCapability(req.user?.role, capability)) {
+    if (canUseMarginCapability(req.user?.role, capability, requestHasGrantedAccountModuleAccess(req))) {
       next();
       return;
     }
@@ -27,6 +28,7 @@ router.get("/rate-versions", requireMarginCapability("read_costs"), listRateVers
 router.post("/rate-versions", requireMarginCapability("manage_rates"), createRateVersion);
 router.post("/inputs", requireMarginCapability("manage_inputs"), createMarginInput);
 router.get("/:scopeType/:scopeRef/export.csv", requireMarginCapability("export"), exportMargin);
+router.get("/:scopeType/:scopeRef/snapshots", requireMarginCapability("read_costs"), listMarginSnapshots);
 router.post("/:scopeType/:scopeRef/snapshots", requireMarginCapability("snapshot"), createMarginSnapshot);
 router.get("/:scopeType/:scopeRef", requireMarginCapability("read_costs"), getMargin);
 

--- a/src/module/margin-engine/routes/margin-engine.routes.ts
+++ b/src/module/margin-engine/routes/margin-engine.routes.ts
@@ -1,0 +1,33 @@
+import { Router, type RequestHandler } from "express";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import { HttpError } from "../../../utils/httpError";
+import { roleHasMarginCapability, type MarginCapability } from "../domain/margin-engine-policy";
+import {
+  createMarginInput,
+  createMarginSnapshot,
+  createRateVersion,
+  exportMargin,
+  getMargin,
+  listRateVersions,
+} from "../controllers/margin-engine.controller";
+
+const router = Router();
+
+function requireMarginCapability(capability: MarginCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (requestHasGrantedAccountModuleAccess(req) || roleHasMarginCapability(req.user?.role, capability)) {
+      next();
+      return;
+    }
+    next(new HttpError(403, "FORBIDDEN", `Capacité de marge « ${capability} » requise.`));
+  };
+}
+
+router.get("/rate-versions", requireMarginCapability("read_costs"), listRateVersions);
+router.post("/rate-versions", requireMarginCapability("manage_rates"), createRateVersion);
+router.post("/inputs", requireMarginCapability("manage_inputs"), createMarginInput);
+router.get("/:scopeType/:scopeRef/export.csv", requireMarginCapability("export"), exportMargin);
+router.post("/:scopeType/:scopeRef/snapshots", requireMarginCapability("snapshot"), createMarginSnapshot);
+router.get("/:scopeType/:scopeRef", requireMarginCapability("read_costs"), getMargin);
+
+export default router;

--- a/src/module/margin-engine/services/margin-engine.service.ts
+++ b/src/module/margin-engine/services/margin-engine.service.ts
@@ -1,20 +1,33 @@
 import { HttpError } from "../../../utils/httpError";
-import { calculateMargin, compareMargins, type MarginBasis, type MarginScopeType } from "../domain/margin-engine";
+import { calculateMargin, compareMargins, type MarginBasis, type MarginComparison, type MarginScopeType } from "../domain/margin-engine";
 import {
   repoBuildCalculationInput,
   repoCreateMarginInput,
   repoCreateRateVersion,
   repoCreateSnapshot,
   repoListRateVersions,
+  repoListSnapshots,
   repoLoadScopeIdentity,
+  type MarginAuditContext,
 } from "../repository/margin-engine.repository";
 import type { CreateMarginInput, CreateRateVersion } from "../validators/margin-engine.validators";
 
 function currentDate(): string {
-  return new Date().toISOString().slice(0, 10);
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Europe/Paris" }).format(new Date());
+}
+
+export function assertCurrentMarginDate(asOf: string): void {
+  if (asOf !== currentDate()) {
+    throw new HttpError(
+      409,
+      "MARGIN_HISTORICAL_RECALCULATION_FORBIDDEN",
+      "Un état passé ne peut pas être recalculé depuis les données courantes. Consultez une preuve de recalcul immuable.",
+    );
+  }
 }
 
 export async function svcGetMargin(scopeType: MarginScopeType, scopeRef: string, asOf = currentDate()) {
+  assertCurrentMarginDate(asOf);
   const identity = await repoLoadScopeIdentity(scopeType, scopeRef);
   if (!identity) throw new HttpError(404, "MARGIN_SCOPE_NOT_FOUND", "Périmètre de marge introuvable.");
   const [plannedInput, actualInput] = await Promise.all([
@@ -30,32 +43,85 @@ function csvCell(value: unknown): string {
   return `"${text.replace(/"/g, '""')}"`;
 }
 
-export async function svcExportMargin(scopeType: MarginScopeType, scopeRef: string, asOf?: string): Promise<string> {
-  const result = await svcGetMargin(scopeType, scopeRef, asOf);
+type GeneratedMarginComparison = MarginComparison & { generated_at: string };
+
+export function renderMarginCsv(result: GeneratedMarginComparison): string {
   const rows: unknown[][] = [[
-    "scope_type", "scope_ref", "basis", "availability", "category", "status", "amount_ht",
-    "revenue_ht", "cost_total_ht", "gross_margin_ht", "taux_de_marge_pct", "taux_de_marque_pct",
-    "formula_version", "calculation_hash",
+    "record_type", "scope_type", "scope_ref", "scope_label", "basis", "as_of", "generated_at", "availability",
+    "category", "component_status", "component_amount_ht", "input_key", "resolved_input_amount_ht",
+    "input_quantity", "rate_amount", "rate_unit", "input_currency",
+    "source_type", "source_ref", "observed_at", "assumption", "assumption_date",
+    "rate_id", "rate_version_id", "rate_effective_at", "rate_scope_type", "rate_scope_ref",
+    "missing_code", "missing_message", "measurement_key", "measurement_value",
+    "revenue_ht", "cost_total_ht", "partial_cost_total_ht", "gross_margin_ht",
+    "taux_de_marge_pct", "taux_de_marque_pct", "formula_version", "calculation_hash",
   ]];
   for (const calculation of [result.planned, result.actual]) {
+    const base = [
+      calculation.scope.type, calculation.scope.ref, calculation.scope.label, calculation.basis,
+      calculation.as_of, result.generated_at, calculation.availability,
+    ];
+    const totals = [
+      calculation.revenue_ht, calculation.cost_total_ht, calculation.partial_cost_total_ht,
+      calculation.gross_margin_ht, calculation.margin_rate_pct, calculation.mark_rate_pct,
+      calculation.formula_version, calculation.calculation_hash,
+    ];
+    const revenueEvidence = calculation.revenue_evidence;
+    rows.push([
+      "REVENUE", ...base, "REVENUE", calculation.revenue_ht === null ? "MISSING" : "PROVIDED",
+      calculation.revenue_ht, "revenue", calculation.revenue_ht,
+      null, null, null, calculation.currency,
+      revenueEvidence?.source_type, revenueEvidence?.source_ref, revenueEvidence?.observed_at,
+      revenueEvidence?.assumption, revenueEvidence?.assumption_date,
+      revenueEvidence?.rate_id, revenueEvidence?.rate_version_id, revenueEvidence?.rate_effective_at,
+      revenueEvidence?.rate_scope_type, revenueEvidence?.rate_scope_ref,
+      null, null, null, null, ...totals,
+    ]);
     for (const component of calculation.components) {
+      const inputs = component.inputs.length > 0 ? component.inputs : [null];
+      for (const input of inputs) {
+        rows.push([
+          "COMPONENT", ...base, component.category, component.status, component.amount_ht,
+          input?.key, input?.resolved_amount_ht,
+          input?.quantity, input?.rate, input?.rate_unit, input?.currency,
+          input?.evidence.source_type, input?.evidence.source_ref, input?.evidence.observed_at,
+          input?.evidence.assumption, input?.evidence.assumption_date,
+          input?.evidence.rate_id, input?.evidence.rate_version_id, input?.evidence.rate_effective_at,
+          input?.evidence.rate_scope_type, input?.evidence.rate_scope_ref,
+          null, null, null, null, ...totals,
+        ]);
+      }
+    }
+    for (const missing of calculation.missing_inputs) {
       rows.push([
-        calculation.scope.type, calculation.scope.ref, calculation.basis, calculation.availability,
-        component.category, component.status, component.amount_ht, calculation.revenue_ht,
-        calculation.cost_total_ht, calculation.gross_margin_ht, calculation.margin_rate_pct,
-        calculation.mark_rate_pct, calculation.formula_version, calculation.calculation_hash,
+        "MISSING", ...base, missing.category, "MISSING", null, null, null,
+        null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null,
+        missing.code, missing.message, null, null, ...totals,
+      ]);
+    }
+    for (const [key, value] of Object.entries(calculation.measurements)) {
+      rows.push([
+        "MEASUREMENT", ...base, null, null, null, null, null,
+        null, null, null, null,
+        null, null, null, null, null, null, null, null, null, null,
+        null, null, key, value, ...totals,
       ]);
     }
   }
   return `\ufeff${rows.map((row) => row.map(csvCell).join(";")).join("\r\n")}\r\n`;
 }
 
-export async function svcCreateMarginInput(input: CreateMarginInput, userId: number) {
-  return repoCreateMarginInput(input, userId);
+export async function svcExportMargin(scopeType: MarginScopeType, scopeRef: string, asOf?: string): Promise<string> {
+  return renderMarginCsv(await svcGetMargin(scopeType, scopeRef, asOf));
 }
 
-export async function svcCreateRateVersion(input: CreateRateVersion, userId: number) {
-  return repoCreateRateVersion(input, userId);
+export async function svcCreateMarginInput(input: CreateMarginInput, audit: MarginAuditContext) {
+  return repoCreateMarginInput(input, audit);
+}
+
+export async function svcCreateRateVersion(input: CreateRateVersion, audit: MarginAuditContext) {
+  return repoCreateRateVersion(input, audit);
 }
 
 export async function svcListRateVersions(asOf = currentDate()) {
@@ -66,12 +132,22 @@ export async function svcCreateMarginSnapshot(
   scopeType: MarginScopeType,
   scopeRef: string,
   basis: MarginBasis,
-  asOf: string,
-  userId: number,
+  asOf: string | undefined,
+  audit: MarginAuditContext,
 ) {
+  const effectiveAsOf = asOf ?? currentDate();
+  assertCurrentMarginDate(effectiveAsOf);
   const identity = await repoLoadScopeIdentity(scopeType, scopeRef);
   if (!identity) throw new HttpError(404, "MARGIN_SCOPE_NOT_FOUND", "Périmètre de marge introuvable.");
-  const input = await repoBuildCalculationInput(identity, basis, asOf);
+  const input = await repoBuildCalculationInput(identity, basis, effectiveAsOf);
   const calculation = calculateMargin(input);
-  return repoCreateSnapshot(calculation, input, userId);
+  return repoCreateSnapshot(calculation, input, audit);
+}
+
+export async function svcListMarginSnapshots(
+  scopeType: MarginScopeType,
+  scopeRef: string,
+  filters: { basis?: MarginBasis; as_of?: string },
+) {
+  return repoListSnapshots(scopeType, scopeRef, filters);
 }

--- a/src/module/margin-engine/services/margin-engine.service.ts
+++ b/src/module/margin-engine/services/margin-engine.service.ts
@@ -1,0 +1,77 @@
+import { HttpError } from "../../../utils/httpError";
+import { calculateMargin, compareMargins, type MarginBasis, type MarginScopeType } from "../domain/margin-engine";
+import {
+  repoBuildCalculationInput,
+  repoCreateMarginInput,
+  repoCreateRateVersion,
+  repoCreateSnapshot,
+  repoListRateVersions,
+  repoLoadScopeIdentity,
+} from "../repository/margin-engine.repository";
+import type { CreateMarginInput, CreateRateVersion } from "../validators/margin-engine.validators";
+
+function currentDate(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+export async function svcGetMargin(scopeType: MarginScopeType, scopeRef: string, asOf = currentDate()) {
+  const identity = await repoLoadScopeIdentity(scopeType, scopeRef);
+  if (!identity) throw new HttpError(404, "MARGIN_SCOPE_NOT_FOUND", "Périmètre de marge introuvable.");
+  const [plannedInput, actualInput] = await Promise.all([
+    repoBuildCalculationInput(identity, "PLANNED", asOf),
+    repoBuildCalculationInput(identity, "ACTUAL", asOf),
+  ]);
+  const comparison = compareMargins(calculateMargin(plannedInput), calculateMargin(actualInput));
+  return { ...comparison, generated_at: new Date().toISOString() };
+}
+
+function csvCell(value: unknown): string {
+  const text = value == null ? "" : String(value);
+  return `"${text.replace(/"/g, '""')}"`;
+}
+
+export async function svcExportMargin(scopeType: MarginScopeType, scopeRef: string, asOf?: string): Promise<string> {
+  const result = await svcGetMargin(scopeType, scopeRef, asOf);
+  const rows: unknown[][] = [[
+    "scope_type", "scope_ref", "basis", "availability", "category", "status", "amount_ht",
+    "revenue_ht", "cost_total_ht", "gross_margin_ht", "taux_de_marge_pct", "taux_de_marque_pct",
+    "formula_version", "calculation_hash",
+  ]];
+  for (const calculation of [result.planned, result.actual]) {
+    for (const component of calculation.components) {
+      rows.push([
+        calculation.scope.type, calculation.scope.ref, calculation.basis, calculation.availability,
+        component.category, component.status, component.amount_ht, calculation.revenue_ht,
+        calculation.cost_total_ht, calculation.gross_margin_ht, calculation.margin_rate_pct,
+        calculation.mark_rate_pct, calculation.formula_version, calculation.calculation_hash,
+      ]);
+    }
+  }
+  return `\ufeff${rows.map((row) => row.map(csvCell).join(";")).join("\r\n")}\r\n`;
+}
+
+export async function svcCreateMarginInput(input: CreateMarginInput, userId: number) {
+  return repoCreateMarginInput(input, userId);
+}
+
+export async function svcCreateRateVersion(input: CreateRateVersion, userId: number) {
+  return repoCreateRateVersion(input, userId);
+}
+
+export async function svcListRateVersions(asOf = currentDate()) {
+  return repoListRateVersions(asOf);
+}
+
+export async function svcCreateMarginSnapshot(
+  scopeType: MarginScopeType,
+  scopeRef: string,
+  basis: MarginBasis,
+  asOf: string,
+  userId: number,
+) {
+  const identity = await repoLoadScopeIdentity(scopeType, scopeRef);
+  if (!identity) throw new HttpError(404, "MARGIN_SCOPE_NOT_FOUND", "Périmètre de marge introuvable.");
+  const input = await repoBuildCalculationInput(identity, basis, asOf);
+  const calculation = calculateMargin(input);
+  return repoCreateSnapshot(calculation, input, userId);
+}

--- a/src/module/margin-engine/validators/margin-engine.validators.ts
+++ b/src/module/margin-engine/validators/margin-engine.validators.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+import { MARGIN_COST_CATEGORIES } from "../domain/margin-engine";
+
+export const marginScopeTypeSchema = z.enum(["DEVIS_LINE", "DEVIS", "AFFAIRE", "OF"]);
+export const marginBasisSchema = z.enum(["PLANNED", "ACTUAL"]);
+export const marginScopeParamsSchema = z.object({
+  scopeType: z.enum(["devis-line", "devis", "affaire", "of"]),
+  scopeRef: z.string().regex(/^\d+$/, "Identifiant numérique attendu."),
+});
+export const marginReadQuerySchema = z.object({
+  as_of: z.string().date().optional(),
+});
+export const marginSnapshotBodySchema = z.object({ basis: marginBasisSchema });
+
+const availabilitySchema = z.enum(["PROVIDED", "NOT_APPLICABLE"]);
+const amountSchema = z.coerce.number().finite().nonnegative().transform(String);
+
+export const createMarginInputSchema = z.object({
+  scope_type: marginScopeTypeSchema,
+  scope_ref: z.string().regex(/^\d+$/),
+  basis: marginBasisSchema,
+  input_key: z.string().trim().min(1).max(120),
+  input_kind: z.enum(["REVENUE", "COST"]),
+  category: z.enum(MARGIN_COST_CATEGORIES).nullable().optional(),
+  availability: availabilitySchema,
+  amount_ht: amountSchema.nullable().optional(),
+  quantity: amountSchema.nullable().optional(),
+  rate_id: z.string().uuid().nullable().optional(),
+  source_type: z.string().trim().min(1).max(80),
+  source_ref: z.string().trim().max(200).nullable().optional(),
+  observed_at: z.string().datetime({ offset: true }).nullable().optional(),
+  assumption: z.string().trim().min(1).max(1000).nullable().optional(),
+  assumption_date: z.string().date().nullable().optional(),
+  supersedes_id: z.string().uuid().nullable().optional(),
+}).superRefine((value, ctx) => {
+  if ((value.input_kind === "REVENUE") !== (value.category == null)) {
+    ctx.addIssue({ code: "custom", path: ["category"], message: "La catégorie est requise uniquement pour un coût." });
+  }
+  if (value.availability === "NOT_APPLICABLE" && (value.amount_ht != null || value.quantity != null || value.rate_id != null)) {
+    ctx.addIssue({ code: "custom", path: ["availability"], message: "NOT_APPLICABLE ne porte aucune valeur." });
+  }
+  if (value.availability === "PROVIDED" && value.amount_ht == null && value.rate_id == null) {
+    ctx.addIssue({ code: "custom", path: ["amount_ht"], message: "Un montant ou un taux versionné est requis." });
+  }
+  if ((value.assumption == null) !== (value.assumption_date == null)) {
+    ctx.addIssue({ code: "custom", path: ["assumption_date"], message: "Toute hypothèse doit être datée." });
+  }
+});
+
+export const createRateVersionSchema = z.object({
+  code: z.string().trim().min(1).max(80),
+  version: z.number().int().positive(),
+  effective_from: z.string().date(),
+  effective_to: z.string().date().nullable().optional(),
+  source: z.string().trim().min(1).max(500),
+  assumption_date: z.string().date(),
+  notes: z.string().trim().max(2000).nullable().optional(),
+  supersedes_id: z.string().uuid().nullable().optional(),
+  rates: z.array(z.object({
+    rate_code: z.string().trim().min(1).max(80),
+    category: z.enum(MARGIN_COST_CATEGORIES),
+    scope_type: z.enum(["GLOBAL", "USER", "MACHINE", "COST_CENTER", "PIECE_TECHNIQUE"]),
+    scope_ref: z.string().trim().min(1).max(200).nullable().optional(),
+    amount: amountSchema,
+    unit: z.enum(["EUR_PER_HOUR", "EUR_PER_UNIT", "PERCENT_OF_DIRECT_COST"]),
+    source_ref: z.string().trim().max(500).nullable().optional(),
+  })).min(1).max(100),
+}).superRefine((value, ctx) => {
+  value.rates.forEach((rate, index) => {
+    if ((rate.scope_type === "GLOBAL") !== (rate.scope_ref == null)) {
+      ctx.addIssue({ code: "custom", path: ["rates", index, "scope_ref"], message: "GLOBAL n'a pas de référence; les autres portées en exigent une." });
+    }
+  });
+});
+
+export type CreateMarginInput = z.infer<typeof createMarginInputSchema>;
+export type CreateRateVersion = z.infer<typeof createRateVersionSchema>;

--- a/src/module/margin-engine/validators/margin-engine.validators.ts
+++ b/src/module/margin-engine/validators/margin-engine.validators.ts
@@ -11,6 +11,10 @@ export const marginReadQuerySchema = z.object({
   as_of: z.string().date().optional(),
 });
 export const marginSnapshotBodySchema = z.object({ basis: marginBasisSchema });
+export const marginSnapshotListQuerySchema = z.object({
+  basis: marginBasisSchema.optional(),
+  as_of: z.string().date().optional(),
+});
 
 const availabilitySchema = z.enum(["PROVIDED", "NOT_APPLICABLE"]);
 const amountSchema = z.coerce.number().finite().nonnegative().transform(String);
@@ -26,6 +30,7 @@ export const createMarginInputSchema = z.object({
   amount_ht: amountSchema.nullable().optional(),
   quantity: amountSchema.nullable().optional(),
   rate_id: z.string().uuid().nullable().optional(),
+  rate_effective_at: z.string().date().nullable().optional(),
   source_type: z.string().trim().min(1).max(80),
   source_ref: z.string().trim().max(200).nullable().optional(),
   observed_at: z.string().datetime({ offset: true }).nullable().optional(),
@@ -36,11 +41,17 @@ export const createMarginInputSchema = z.object({
   if ((value.input_kind === "REVENUE") !== (value.category == null)) {
     ctx.addIssue({ code: "custom", path: ["category"], message: "La catégorie est requise uniquement pour un coût." });
   }
-  if (value.availability === "NOT_APPLICABLE" && (value.amount_ht != null || value.quantity != null || value.rate_id != null)) {
+  if (value.availability === "NOT_APPLICABLE" && (value.amount_ht != null || value.quantity != null || value.rate_id != null || value.rate_effective_at != null)) {
     ctx.addIssue({ code: "custom", path: ["availability"], message: "NOT_APPLICABLE ne porte aucune valeur." });
   }
-  if (value.availability === "PROVIDED" && value.amount_ht == null && value.rate_id == null) {
-    ctx.addIssue({ code: "custom", path: ["amount_ht"], message: "Un montant ou un taux versionné est requis." });
+  if (value.availability === "PROVIDED" && ((value.amount_ht == null) === (value.rate_id == null))) {
+    ctx.addIssue({ code: "custom", path: ["amount_ht"], message: "Fournir exactement un montant ou un taux versionné." });
+  }
+  if ((value.rate_id == null) !== (value.rate_effective_at == null)) {
+    ctx.addIssue({ code: "custom", path: ["rate_effective_at"], message: "Tout taux doit porter sa date d'application." });
+  }
+  if (value.amount_ht != null && value.quantity != null) {
+    ctx.addIssue({ code: "custom", path: ["quantity"], message: "Une quantité ne s'applique qu'à un taux versionné." });
   }
   if ((value.assumption == null) !== (value.assumption_date == null)) {
     ctx.addIssue({ code: "custom", path: ["assumption_date"], message: "Toute hypothèse doit être datée." });
@@ -66,9 +77,20 @@ export const createRateVersionSchema = z.object({
     source_ref: z.string().trim().max(500).nullable().optional(),
   })).min(1).max(100),
 }).superRefine((value, ctx) => {
+  if (value.effective_to && value.effective_to < value.effective_from) {
+    ctx.addIssue({ code: "custom", path: ["effective_to"], message: "La date de fin doit suivre la date d'effet." });
+  }
   value.rates.forEach((rate, index) => {
     if ((rate.scope_type === "GLOBAL") !== (rate.scope_ref == null)) {
       ctx.addIssue({ code: "custom", path: ["rates", index, "scope_ref"], message: "GLOBAL n'a pas de référence; les autres portées en exigent une." });
+    }
+    const unitMatches = rate.unit === "PERCENT_OF_DIRECT_COST"
+      ? rate.category === "OVERHEAD"
+      : rate.unit === "EUR_PER_HOUR"
+        ? ["MACHINE", "OPERATOR", "CONTROL"].includes(rate.category)
+        : !["OVERHEAD", "OPERATOR", "CONTROL"].includes(rate.category);
+    if (!unitMatches) {
+      ctx.addIssue({ code: "custom", path: ["rates", index, "unit"], message: "L'unité n'est pas compatible avec la catégorie de coût." });
     }
   });
 });

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -40,6 +40,7 @@ import codesRoutes from "../module/codes/routes/codes.routes";
 import notificationsRoutes from "../module/notifications/routes/notifications.routes";
 import chatRoutes from "../module/chat/routes/chat.routes";
 import usersRoutes from "../module/users/routes/users.routes";
+import marginEngineRoutes from "../module/margin-engine/routes/margin-engine.routes";
 
 import traceabilityRoutes from "../module/traceability/routes/traceability.routes"
 import traceability360Routes from "../module/traceability/routes/traceability-360.routes"
@@ -111,6 +112,7 @@ router.use("/avoirs", avoirsRoutes);
 router.use("/paiements", paiementsRoutes);
 router.use("/tarification", tarificationRoutes);
 router.use("/reporting", reportingRoutes);
+router.use("/margins", marginEngineRoutes);
 // Suivi et pointage de production 360 (#274) monté AVANT le routeur historique :
 // ses routes déclarent des capacités fines (refus par défaut) et exigent une
 // clé d'idempotence. Le routeur hérité reste inchangé pour les écrans existants.


### PR DESCRIPTION
Implémente GPT56-FEAT-CERP-0001: moteur décimal backend autoritaire, données manquantes explicites, prévu/réel, taux versionnés, RBAC fin, audit transactionnel, snapshots immuables et export probant. Cycle SQL contrôlé et testé sur PostgreSQL 16 jetable. Backend build et 27 tests ciblés réussis.

## Summary by Sourcery

Add a governed, auditable margin calculation engine with planned/actual costing, versioned rates and inputs, immutable recalculation snapshots, RBAC-protected APIs, and supporting PostgreSQL migrations and tests, surfaced via new /margins endpoints in the reporting module.

New Features:
- Introduce an auditable margin engine backend with planned/actual calculations, variance comparison, and governed CSV export for commercial scopes (devis, affaires, OF).

Enhancements:
- Add strict RBAC policies and route protections for margin engine capabilities, separating read access from rate/input administration, snapshotting, and export.
- Implement append-only, versioned SQL schema for margin rates, manual inputs, and recalculation snapshots with preflight, verification, demo, and rollback guards tied to migration provenance.
- Integrate margin engine routes into the v1 API and reporting module catalog, exposing /margins endpoints under the commercial reporting module.

Build:
- Add PostgreSQL migration scripts and support tooling to create, verify, and safely rollback the margin engine schema on dev/test databases.

Tests:
- Add domain, integration, policy, and migration guard tests to assert margin engine formulas, contracts, RBAC rules, audit wiring, and database guardrails.