### PR TITLE
release: réapprovisionnement explicable

### DIFF
--- a/db/patches/20260805_replenishment_proposals.sql
+++ b/db/patches/20260805_replenishment_proposals.sql
@@ -1,61 +1,138 @@
 -- FEAT-CERP-0003 -- Explainable, human-validated replenishment proposals.
--- Additive and idempotent. This patch never creates, approves or sends a purchase order.
+-- Exact, runner-owned migration: pre-existing target artifacts are rejected so
+-- every object removed by the guarded dev/test rollback has unambiguous provenance.
 
 BEGIN;
 
-DO $$
+DO $preexisting_guard$
+DECLARE
+  target_column_count integer;
+  target_constraint_count integer;
+  target_index_count integer;
 BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003: migration registry is missing';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.cerp_schema_migrations
+    WHERE filename = '20260805_replenishment_proposals.sql'
+  ) THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003: migration ledger already exists; use the patch runner';
+  END IF;
+
   IF to_regclass('public.stock_levels') IS NULL
      OR to_regclass('public.articles') IS NULL
+     OR to_regclass('public.units') IS NULL
+     OR to_regclass('public.magasins') IS NULL
+     OR to_regclass('public.fournisseurs') IS NULL
      OR to_regclass('public.fournisseur_catalogue') IS NULL
      OR to_regclass('public.commande_fournisseur') IS NULL
-     OR to_regclass('public.commande_fournisseur_ligne') IS NULL THEN
-    RAISE EXCEPTION 'FEAT-CERP-0003 prerequisites are missing';
+     OR to_regclass('public.commande_fournisseur_ligne') IS NULL
+     OR to_regclass('public.commande_fournisseur_ligne_besoin') IS NULL
+     OR to_regclass('public.reception_fournisseur_lignes') IS NULL
+     OR to_regclass('public.app_modules') IS NULL
+     OR to_regprocedure('public.tg_set_updated_at()') IS NULL
+     OR to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003: prerequisite table, function, or role is missing';
   END IF;
-END $$;
 
-DO $$
-BEGIN
-  IF to_regclass('public.app_modules') IS NOT NULL THEN
-    UPDATE public.app_modules
-       SET api_prefixes = array_append(api_prefixes, '/replenishment-proposals'),
-           updated_at = now()
-     WHERE module_key = 'commandes-fournisseurs'
-       AND NOT ('/replenishment-proposals' = ANY(api_prefixes));
+  IF to_regclass('public.replenishment_budgets') IS NOT NULL
+     OR to_regclass('public.replenishment_proposals') IS NOT NULL
+     OR to_regclass('public.replenishment_proposal_events') IS NOT NULL
+     OR to_regclass('public.replenishment_proposal_idempotence') IS NOT NULL
+     OR to_regprocedure('public.fn_replenishment_event_immutable()') IS NOT NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003: target table or function already exists without ledger provenance';
   END IF;
-END $$;
+
+  SELECT COUNT(*)::integer INTO target_column_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND (
+      (table_name = 'stock_levels' AND column_name IN ('safety_stock_qty','target_stock_qty','order_lot_size'))
+      OR (table_name = 'fournisseur_catalogue' AND column_name IN ('unite_stock','coef_conversion','lot_achat'))
+      OR (table_name = 'commande_fournisseur' AND column_name = 'replenishment_proposal_id')
+    );
+  IF target_column_count <> 0 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003: target column already exists without ledger provenance';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO target_constraint_count
+  FROM pg_constraint
+  WHERE conname = ANY (ARRAY[
+    'stock_levels_replenishment_qty_chk',
+    'fournisseur_catalogue_conversion_chk',
+    'commande_fournisseur_replenishment_fkey',
+    'replenishment_budgets_pkey','replenishment_budgets_magasin_id_fkey',
+    'replenishment_budgets_values_chk','replenishment_budgets_scope_uniq',
+    'replenishment_proposals_pkey','replenishment_proposals_article_id_fkey',
+    'replenishment_proposals_magasin_id_fkey','replenishment_proposals_selected_catalogue_id_fkey',
+    'replenishment_proposals_selected_supplier_id_fkey',
+    'replenishment_proposals_commande_fournisseur_id_fkey',
+    'replenishment_proposals_commande_fournisseur_ligne_id_fkey',
+    'replenishment_proposals_status_chk','replenishment_proposals_budget_chk',
+    'replenishment_proposals_values_chk','replenishment_proposal_events_pkey',
+    'replenishment_proposal_events_proposal_id_fkey','replenishment_proposal_idempotence_pkey',
+    'replenishment_proposal_idempotence_proposal_id_fkey','replenishment_proposal_idem_uniq',
+    'replenishment_proposal_idem_key_chk','replenishment_proposal_idem_hash_chk'
+  ]);
+  IF target_constraint_count <> 0 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003: target constraint name already exists without ledger provenance';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO target_index_count
+  FROM pg_class
+  WHERE relkind = 'i'
+    AND relname = ANY (ARRAY[
+      'commande_fournisseur_replenishment_idx',
+      'replenishment_budgets_pkey','replenishment_budgets_scope_uniq',
+      'replenishment_proposals_pkey',
+      'replenishment_proposals_status_idx',
+      'replenishment_proposals_article_site_uniq',
+      'replenishment_proposals_article_unmapped_uniq',
+      'replenishment_proposal_events_pkey','replenishment_proposal_events_proposal_idx',
+      'replenishment_proposal_idempotence_pkey','replenishment_proposal_idem_uniq'
+    ]);
+  IF target_index_count <> 0 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003: target index name already exists without ledger provenance';
+  END IF;
+
+  IF (SELECT COUNT(*) FROM public.app_modules WHERE module_key = 'commandes-fournisseurs') <> 1 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003: commandes-fournisseurs module catalogue entry is missing';
+  END IF;
+  IF EXISTS (
+    SELECT 1
+    FROM public.app_modules m, unnest(m.api_prefixes) AS prefix
+    WHERE m.module_key = 'commandes-fournisseurs'
+      AND prefix = '/replenishment-proposals'
+  ) THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003: module prefix already exists without ledger provenance';
+  END IF;
+END
+$preexisting_guard$;
 
 ALTER TABLE public.stock_levels
-  ADD COLUMN IF NOT EXISTS safety_stock_qty numeric(18,3),
-  ADD COLUMN IF NOT EXISTS target_stock_qty numeric(18,3),
-  ADD COLUMN IF NOT EXISTS order_lot_size numeric(18,3);
+  ADD COLUMN safety_stock_qty numeric(18,3),
+  ADD COLUMN target_stock_qty numeric(18,3),
+  ADD COLUMN order_lot_size numeric(18,3),
+  ADD CONSTRAINT stock_levels_replenishment_qty_chk CHECK (
+    (safety_stock_qty IS NULL OR safety_stock_qty >= 0)
+    AND (target_stock_qty IS NULL OR target_stock_qty >= 0)
+    AND (order_lot_size IS NULL OR order_lot_size > 0)
+  );
 
 ALTER TABLE public.fournisseur_catalogue
-  ADD COLUMN IF NOT EXISTS unite_stock text,
-  ADD COLUMN IF NOT EXISTS coef_conversion numeric(18,6),
-  ADD COLUMN IF NOT EXISTS lot_achat numeric(18,3);
+  ADD COLUMN unite_stock text,
+  ADD COLUMN coef_conversion numeric(18,6),
+  ADD COLUMN lot_achat numeric(18,3),
+  ADD CONSTRAINT fournisseur_catalogue_conversion_chk CHECK (
+    (coef_conversion IS NULL OR coef_conversion > 0)
+    AND (lot_achat IS NULL OR lot_achat > 0)
+    AND ((unite_stock IS NULL AND coef_conversion IS NULL) OR (unite_stock IS NOT NULL AND coef_conversion IS NOT NULL))
+  );
 
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'stock_levels_replenishment_qty_chk') THEN
-    ALTER TABLE public.stock_levels ADD CONSTRAINT stock_levels_replenishment_qty_chk CHECK (
-      (safety_stock_qty IS NULL OR safety_stock_qty >= 0)
-      AND (target_stock_qty IS NULL OR target_stock_qty >= 0)
-      AND (order_lot_size IS NULL OR order_lot_size > 0)
-    );
-  END IF;
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fournisseur_catalogue_conversion_chk') THEN
-    ALTER TABLE public.fournisseur_catalogue ADD CONSTRAINT fournisseur_catalogue_conversion_chk CHECK (
-      (coef_conversion IS NULL OR coef_conversion > 0)
-      AND (lot_achat IS NULL OR lot_achat > 0)
-      AND ((unite_stock IS NULL AND coef_conversion IS NULL) OR (unite_stock IS NOT NULL AND coef_conversion IS NOT NULL))
-    );
-  END IF;
-END $$;
-
-CREATE TABLE IF NOT EXISTS public.replenishment_budgets (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  magasin_id uuid NOT NULL REFERENCES public.magasins(id) ON DELETE RESTRICT,
+CREATE TABLE public.replenishment_budgets (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  magasin_id uuid NOT NULL,
   currency text NOT NULL DEFAULT 'EUR',
   period_start date NOT NULL,
   period_end date NOT NULL,
@@ -65,17 +142,20 @@ CREATE TABLE IF NOT EXISTS public.replenishment_budgets (
   updated_at timestamptz NOT NULL DEFAULT now(),
   created_by integer,
   updated_by integer,
+  CONSTRAINT replenishment_budgets_pkey PRIMARY KEY (id),
+  CONSTRAINT replenishment_budgets_magasin_id_fkey FOREIGN KEY (magasin_id)
+    REFERENCES public.magasins(id) ON DELETE RESTRICT,
   CONSTRAINT replenishment_budgets_values_chk CHECK (
     period_end >= period_start AND amount_limit >= 0 AND char_length(currency) = 3
   ),
   CONSTRAINT replenishment_budgets_scope_uniq UNIQUE (magasin_id, currency, period_start, period_end)
 );
 
-CREATE TABLE IF NOT EXISTS public.replenishment_proposals (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+CREATE TABLE public.replenishment_proposals (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
   stock_level_ids uuid[] NOT NULL,
-  article_id uuid NOT NULL REFERENCES public.articles(id) ON DELETE RESTRICT,
-  magasin_id uuid REFERENCES public.magasins(id) ON DELETE RESTRICT,
+  article_id uuid NOT NULL,
+  magasin_id uuid,
   status text NOT NULL DEFAULT 'PROPOSEE',
   version integer NOT NULL DEFAULT 1,
   reason_code text NOT NULL,
@@ -88,8 +168,8 @@ CREATE TABLE IF NOT EXISTS public.replenishment_proposals (
   safety_stock_qty numeric(18,3),
   target_stock_qty numeric(18,3),
   net_requirement_qty numeric(18,3) NOT NULL DEFAULT 0,
-  selected_catalogue_id uuid REFERENCES public.fournisseur_catalogue(id) ON DELETE SET NULL,
-  selected_supplier_id uuid REFERENCES public.fournisseurs(id) ON DELETE SET NULL,
+  selected_catalogue_id uuid,
+  selected_supplier_id uuid,
   purchase_unit text,
   stock_units_per_purchase_unit numeric(18,6),
   proposed_purchase_qty numeric(18,3),
@@ -102,8 +182,8 @@ CREATE TABLE IF NOT EXISTS public.replenishment_proposals (
   missing_data text[] NOT NULL DEFAULT '{}',
   warnings text[] NOT NULL DEFAULT '{}',
   calculation jsonb NOT NULL DEFAULT '{}'::jsonb,
-  commande_fournisseur_id uuid REFERENCES public.commande_fournisseur(id) ON DELETE SET NULL,
-  commande_fournisseur_ligne_id uuid REFERENCES public.commande_fournisseur_ligne(id) ON DELETE SET NULL,
+  commande_fournisseur_id uuid,
+  commande_fournisseur_ligne_id uuid,
   generated_at timestamptz NOT NULL DEFAULT now(),
   last_recalculated_at timestamptz NOT NULL DEFAULT now(),
   validated_at timestamptz,
@@ -111,6 +191,19 @@ CREATE TABLE IF NOT EXISTS public.replenishment_proposals (
   resolution_reason text,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT replenishment_proposals_pkey PRIMARY KEY (id),
+  CONSTRAINT replenishment_proposals_article_id_fkey FOREIGN KEY (article_id)
+    REFERENCES public.articles(id) ON DELETE RESTRICT,
+  CONSTRAINT replenishment_proposals_magasin_id_fkey FOREIGN KEY (magasin_id)
+    REFERENCES public.magasins(id) ON DELETE RESTRICT,
+  CONSTRAINT replenishment_proposals_selected_catalogue_id_fkey FOREIGN KEY (selected_catalogue_id)
+    REFERENCES public.fournisseur_catalogue(id) ON DELETE SET NULL,
+  CONSTRAINT replenishment_proposals_selected_supplier_id_fkey FOREIGN KEY (selected_supplier_id)
+    REFERENCES public.fournisseurs(id) ON DELETE SET NULL,
+  CONSTRAINT replenishment_proposals_commande_fournisseur_id_fkey FOREIGN KEY (commande_fournisseur_id)
+    REFERENCES public.commande_fournisseur(id) ON DELETE SET NULL,
+  CONSTRAINT replenishment_proposals_commande_fournisseur_ligne_id_fkey FOREIGN KEY (commande_fournisseur_ligne_id)
+    REFERENCES public.commande_fournisseur_ligne(id) ON DELETE SET NULL,
   CONSTRAINT replenishment_proposals_status_chk CHECK (status IN ('PROPOSEE','A_COMPLETER','CONVERTIE','RESOLUE')),
   CONSTRAINT replenishment_proposals_budget_chk CHECK (budget_status IN ('OK','EXCEEDED','MISSING','NOT_APPLICABLE')),
   CONSTRAINT replenishment_proposals_values_chk CHECK (
@@ -124,75 +217,156 @@ CREATE TABLE IF NOT EXISTS public.replenishment_proposals (
   )
 );
 
-CREATE TABLE IF NOT EXISTS public.replenishment_proposal_events (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  proposal_id uuid NOT NULL REFERENCES public.replenishment_proposals(id) ON DELETE RESTRICT,
+CREATE TABLE public.replenishment_proposal_events (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  proposal_id uuid NOT NULL,
   event_type text NOT NULL,
   from_status text,
   to_status text NOT NULL,
   calculation jsonb NOT NULL DEFAULT '{}'::jsonb,
   details jsonb NOT NULL DEFAULT '{}'::jsonb,
   actor_id integer,
-  created_at timestamptz NOT NULL DEFAULT now()
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT replenishment_proposal_events_pkey PRIMARY KEY (id),
+  CONSTRAINT replenishment_proposal_events_proposal_id_fkey FOREIGN KEY (proposal_id)
+    REFERENCES public.replenishment_proposals(id) ON DELETE RESTRICT
 );
 
-CREATE TABLE IF NOT EXISTS public.replenishment_proposal_idempotence (
-  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+CREATE TABLE public.replenishment_proposal_idempotence (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
   actor_id integer NOT NULL,
   idempotency_key text NOT NULL,
   request_hash text NOT NULL,
-  proposal_id uuid NOT NULL REFERENCES public.replenishment_proposals(id) ON DELETE RESTRICT,
+  proposal_id uuid NOT NULL,
   result jsonb NOT NULL,
   created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT replenishment_proposal_idempotence_pkey PRIMARY KEY (id),
+  CONSTRAINT replenishment_proposal_idempotence_proposal_id_fkey FOREIGN KEY (proposal_id)
+    REFERENCES public.replenishment_proposals(id) ON DELETE RESTRICT,
   CONSTRAINT replenishment_proposal_idem_uniq UNIQUE (actor_id, idempotency_key),
   CONSTRAINT replenishment_proposal_idem_key_chk CHECK (char_length(idempotency_key) BETWEEN 8 AND 200),
   CONSTRAINT replenishment_proposal_idem_hash_chk CHECK (request_hash ~ '^[0-9a-f]{64}$')
 );
 
 ALTER TABLE public.commande_fournisseur
-  ADD COLUMN IF NOT EXISTS replenishment_proposal_id uuid;
+  ADD COLUMN replenishment_proposal_id uuid,
+  ADD CONSTRAINT commande_fournisseur_replenishment_fkey
+    FOREIGN KEY (replenishment_proposal_id)
+    REFERENCES public.replenishment_proposals(id) ON DELETE RESTRICT;
 
-DO $$
-BEGIN
-  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_replenishment_fkey') THEN
-    ALTER TABLE public.commande_fournisseur ADD CONSTRAINT commande_fournisseur_replenishment_fkey
-      FOREIGN KEY (replenishment_proposal_id) REFERENCES public.replenishment_proposals(id) ON DELETE RESTRICT;
-  END IF;
-END $$;
-
-DROP INDEX IF EXISTS public.commande_fournisseur_replenishment_uniq;
-CREATE INDEX IF NOT EXISTS commande_fournisseur_replenishment_idx
+CREATE INDEX commande_fournisseur_replenishment_idx
   ON public.commande_fournisseur(replenishment_proposal_id)
   WHERE replenishment_proposal_id IS NOT NULL;
-CREATE INDEX IF NOT EXISTS replenishment_proposals_status_idx ON public.replenishment_proposals(status, updated_at DESC);
-CREATE UNIQUE INDEX IF NOT EXISTS replenishment_proposals_article_site_uniq
+CREATE INDEX replenishment_proposals_status_idx
+  ON public.replenishment_proposals(status, updated_at DESC);
+CREATE UNIQUE INDEX replenishment_proposals_article_site_uniq
   ON public.replenishment_proposals(article_id, magasin_id)
   WHERE magasin_id IS NOT NULL;
-CREATE UNIQUE INDEX IF NOT EXISTS replenishment_proposals_article_unmapped_uniq
+CREATE UNIQUE INDEX replenishment_proposals_article_unmapped_uniq
   ON public.replenishment_proposals(article_id)
   WHERE magasin_id IS NULL;
-CREATE INDEX IF NOT EXISTS replenishment_proposal_events_proposal_idx ON public.replenishment_proposal_events(proposal_id, created_at DESC);
+CREATE INDEX replenishment_proposal_events_proposal_idx
+  ON public.replenishment_proposal_events(proposal_id, created_at DESC);
 
-CREATE OR REPLACE FUNCTION public.fn_replenishment_event_immutable()
-RETURNS trigger LANGUAGE plpgsql AS $$
+CREATE FUNCTION public.fn_replenishment_event_immutable()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $immutable$
 BEGIN
   RAISE EXCEPTION 'Replenishment proposal events are append-only' USING ERRCODE = '55000';
-END $$;
+END
+$immutable$;
 
-DROP TRIGGER IF EXISTS replenishment_proposal_events_immutable ON public.replenishment_proposal_events;
 CREATE TRIGGER replenishment_proposal_events_immutable
 BEFORE UPDATE OR DELETE ON public.replenishment_proposal_events
 FOR EACH ROW EXECUTE FUNCTION public.fn_replenishment_event_immutable();
 
-DO $$
+CREATE TRIGGER replenishment_proposals_set_updated_at
+BEFORE UPDATE ON public.replenishment_proposals
+FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at();
+
+CREATE TRIGGER replenishment_budgets_set_updated_at
+BEFORE UPDATE ON public.replenishment_budgets
+FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at();
+
+DO $module_catalog$
+DECLARE
+  changed_rows integer;
 BEGIN
-  IF to_regproc('public.tg_set_updated_at()') IS NOT NULL THEN
-    EXECUTE 'DROP TRIGGER IF EXISTS replenishment_proposals_set_updated_at ON public.replenishment_proposals';
-    EXECUTE 'CREATE TRIGGER replenishment_proposals_set_updated_at BEFORE UPDATE ON public.replenishment_proposals FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
-    EXECUTE 'DROP TRIGGER IF EXISTS replenishment_budgets_set_updated_at ON public.replenishment_budgets';
-    EXECUTE 'CREATE TRIGGER replenishment_budgets_set_updated_at BEFORE UPDATE ON public.replenishment_budgets FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
+  UPDATE public.app_modules
+     SET api_prefixes = array_append(api_prefixes, '/replenishment-proposals'),
+         updated_at = now()
+   WHERE module_key = 'commandes-fournisseurs'
+     AND NOT ('/replenishment-proposals' = ANY(api_prefixes));
+  GET DIAGNOSTICS changed_rows = ROW_COUNT;
+  IF changed_rows <> 1 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003: module prefix update did not affect exactly one row';
   END IF;
-END $$;
+END
+$module_catalog$;
+
+ALTER TABLE public.replenishment_budgets OWNER TO cerp_app;
+ALTER TABLE public.replenishment_proposals OWNER TO cerp_app;
+ALTER TABLE public.replenishment_proposal_events OWNER TO cerp_app;
+ALTER TABLE public.replenishment_proposal_idempotence OWNER TO cerp_app;
+ALTER FUNCTION public.fn_replenishment_event_immutable() OWNER TO cerp_app;
+
+DO $remove_default_acl_leaks$
+DECLARE
+  target_relation regclass;
+  unexpected_grantee name;
+BEGIN
+  FOREACH target_relation IN ARRAY ARRAY[
+    'public.replenishment_budgets'::regclass,
+    'public.replenishment_proposals'::regclass,
+    'public.replenishment_proposal_events'::regclass,
+    'public.replenishment_proposal_idempotence'::regclass
+  ]
+  LOOP
+    FOR unexpected_grantee IN
+      SELECT DISTINCT grantee_role.rolname
+      FROM pg_class relation_metadata
+      CROSS JOIN LATERAL aclexplode(COALESCE(
+        relation_metadata.relacl,
+        acldefault('r', relation_metadata.relowner)
+      )) acl_entry
+      JOIN pg_roles grantee_role ON grantee_role.oid = acl_entry.grantee
+      WHERE relation_metadata.oid = target_relation
+        AND acl_entry.grantee <> relation_metadata.relowner
+    LOOP
+      EXECUTE format('REVOKE ALL ON TABLE %s FROM %I CASCADE', target_relation, unexpected_grantee);
+    END LOOP;
+  END LOOP;
+
+  FOR unexpected_grantee IN
+    SELECT DISTINCT grantee_role.rolname
+    FROM pg_proc function_metadata
+    CROSS JOIN LATERAL aclexplode(COALESCE(
+      function_metadata.proacl,
+      acldefault('f', function_metadata.proowner)
+    )) acl_entry
+    JOIN pg_roles grantee_role ON grantee_role.oid = acl_entry.grantee
+    WHERE function_metadata.oid = 'public.fn_replenishment_event_immutable()'::regprocedure
+      AND acl_entry.grantee <> function_metadata.proowner
+  LOOP
+    EXECUTE format(
+      'REVOKE ALL ON FUNCTION public.fn_replenishment_event_immutable() FROM %I CASCADE',
+      unexpected_grantee
+    );
+  END LOOP;
+END
+$remove_default_acl_leaks$;
+
+REVOKE ALL ON TABLE public.replenishment_budgets FROM PUBLIC, cerp_app;
+REVOKE ALL ON TABLE public.replenishment_proposals FROM PUBLIC, cerp_app;
+REVOKE ALL ON TABLE public.replenishment_proposal_events FROM PUBLIC, cerp_app;
+REVOKE ALL ON TABLE public.replenishment_proposal_idempotence FROM PUBLIC, cerp_app;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.replenishment_budgets TO cerp_app;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.replenishment_proposals TO cerp_app;
+GRANT SELECT, INSERT ON TABLE public.replenishment_proposal_events TO cerp_app;
+GRANT SELECT, INSERT ON TABLE public.replenishment_proposal_idempotence TO cerp_app;
+REVOKE ALL ON FUNCTION public.fn_replenishment_event_immutable() FROM PUBLIC, cerp_app;
+GRANT EXECUTE ON FUNCTION public.fn_replenishment_event_immutable() TO cerp_app;
 
 COMMENT ON TABLE public.replenishment_proposals IS
   'FEAT-CERP-0003 current explainable proposal, unique per aggregated article/site scope. Validation always recalculates before creating a BCF draft.';
@@ -200,15 +374,5 @@ COMMENT ON COLUMN public.replenishment_proposals.stock_level_ids IS
   'Auditable source stock levels aggregated into the unique article/site proposal; order-independent UUID array.';
 COMMENT ON COLUMN public.fournisseur_catalogue.coef_conversion IS
   'Number of stock units represented by one supplier purchase unit. Required with unite_stock when units differ.';
-
-DO $$
-BEGIN
-  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
-    GRANT SELECT, INSERT, UPDATE ON public.replenishment_budgets TO cerp_app;
-    GRANT SELECT, INSERT, UPDATE ON public.replenishment_proposals TO cerp_app;
-    GRANT SELECT, INSERT ON public.replenishment_proposal_events TO cerp_app;
-    GRANT SELECT, INSERT ON public.replenishment_proposal_idempotence TO cerp_app;
-  END IF;
-END $$;
 
 COMMIT;

--- a/db/patches/20260805_replenishment_proposals.sql
+++ b/db/patches/20260805_replenishment_proposals.sql
@@ -1,0 +1,197 @@
+-- FEAT-CERP-0003 -- Explainable, human-validated replenishment proposals.
+-- Additive and idempotent. This patch never creates, approves or sends a purchase order.
+
+BEGIN;
+
+DO $$
+BEGIN
+  IF to_regclass('public.stock_levels') IS NULL
+     OR to_regclass('public.articles') IS NULL
+     OR to_regclass('public.fournisseur_catalogue') IS NULL
+     OR to_regclass('public.commande_fournisseur') IS NULL
+     OR to_regclass('public.commande_fournisseur_ligne') IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 prerequisites are missing';
+  END IF;
+END $$;
+
+ALTER TABLE public.stock_levels
+  ADD COLUMN IF NOT EXISTS safety_stock_qty numeric(18,3),
+  ADD COLUMN IF NOT EXISTS target_stock_qty numeric(18,3),
+  ADD COLUMN IF NOT EXISTS order_lot_size numeric(18,3);
+
+ALTER TABLE public.fournisseur_catalogue
+  ADD COLUMN IF NOT EXISTS unite_stock text,
+  ADD COLUMN IF NOT EXISTS coef_conversion numeric(18,6),
+  ADD COLUMN IF NOT EXISTS lot_achat numeric(18,3);
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'stock_levels_replenishment_qty_chk') THEN
+    ALTER TABLE public.stock_levels ADD CONSTRAINT stock_levels_replenishment_qty_chk CHECK (
+      (safety_stock_qty IS NULL OR safety_stock_qty >= 0)
+      AND (target_stock_qty IS NULL OR target_stock_qty >= 0)
+      AND (order_lot_size IS NULL OR order_lot_size > 0)
+    );
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'fournisseur_catalogue_conversion_chk') THEN
+    ALTER TABLE public.fournisseur_catalogue ADD CONSTRAINT fournisseur_catalogue_conversion_chk CHECK (
+      (coef_conversion IS NULL OR coef_conversion > 0)
+      AND (lot_achat IS NULL OR lot_achat > 0)
+      AND ((unite_stock IS NULL AND coef_conversion IS NULL) OR (unite_stock IS NOT NULL AND coef_conversion IS NOT NULL))
+    );
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.replenishment_budgets (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  magasin_id uuid NOT NULL REFERENCES public.magasins(id) ON DELETE RESTRICT,
+  currency text NOT NULL DEFAULT 'EUR',
+  period_start date NOT NULL,
+  period_end date NOT NULL,
+  amount_limit numeric(14,2) NOT NULL,
+  active boolean NOT NULL DEFAULT true,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer,
+  updated_by integer,
+  CONSTRAINT replenishment_budgets_values_chk CHECK (
+    period_end >= period_start AND amount_limit >= 0 AND char_length(currency) = 3
+  ),
+  CONSTRAINT replenishment_budgets_scope_uniq UNIQUE (magasin_id, currency, period_start, period_end)
+);
+
+CREATE TABLE IF NOT EXISTS public.replenishment_proposals (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  stock_level_id uuid NOT NULL REFERENCES public.stock_levels(id) ON DELETE RESTRICT,
+  article_id uuid NOT NULL REFERENCES public.articles(id) ON DELETE RESTRICT,
+  location_id uuid,
+  magasin_id uuid REFERENCES public.magasins(id) ON DELETE RESTRICT,
+  status text NOT NULL DEFAULT 'PROPOSEE',
+  version integer NOT NULL DEFAULT 1,
+  reason_code text NOT NULL,
+  stock_unit text,
+  qty_on_hand numeric(18,3) NOT NULL DEFAULT 0,
+  qty_reserved numeric(18,3) NOT NULL DEFAULT 0,
+  qty_available numeric(18,3) NOT NULL DEFAULT 0,
+  qty_open_orders numeric(18,3) NOT NULL DEFAULT 0,
+  minimum_stock_qty numeric(18,3),
+  safety_stock_qty numeric(18,3),
+  target_stock_qty numeric(18,3),
+  net_requirement_qty numeric(18,3) NOT NULL DEFAULT 0,
+  selected_catalogue_id uuid REFERENCES public.fournisseur_catalogue(id) ON DELETE SET NULL,
+  selected_supplier_id uuid REFERENCES public.fournisseurs(id) ON DELETE SET NULL,
+  purchase_unit text,
+  stock_units_per_purchase_unit numeric(18,6),
+  proposed_purchase_qty numeric(18,3),
+  proposed_stock_qty numeric(18,3),
+  unit_price numeric(14,4),
+  currency text,
+  estimated_total numeric(14,2),
+  budget_status text NOT NULL DEFAULT 'MISSING',
+  budget_remaining numeric(14,2),
+  missing_data text[] NOT NULL DEFAULT '{}',
+  warnings text[] NOT NULL DEFAULT '{}',
+  calculation jsonb NOT NULL DEFAULT '{}'::jsonb,
+  commande_fournisseur_id uuid REFERENCES public.commande_fournisseur(id) ON DELETE SET NULL,
+  commande_fournisseur_ligne_id uuid REFERENCES public.commande_fournisseur_ligne(id) ON DELETE SET NULL,
+  generated_at timestamptz NOT NULL DEFAULT now(),
+  last_recalculated_at timestamptz NOT NULL DEFAULT now(),
+  validated_at timestamptz,
+  validated_by integer,
+  resolution_reason text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT replenishment_proposals_stock_level_uniq UNIQUE (stock_level_id),
+  CONSTRAINT replenishment_proposals_status_chk CHECK (status IN ('PROPOSEE','A_COMPLETER','CONVERTIE','RESOLUE')),
+  CONSTRAINT replenishment_proposals_budget_chk CHECK (budget_status IN ('OK','EXCEEDED','MISSING','NOT_APPLICABLE')),
+  CONSTRAINT replenishment_proposals_values_chk CHECK (
+    version > 0 AND qty_on_hand >= 0 AND qty_reserved >= 0 AND qty_available >= 0
+    AND qty_open_orders >= 0 AND net_requirement_qty >= 0
+    AND (stock_units_per_purchase_unit IS NULL OR stock_units_per_purchase_unit > 0)
+    AND (proposed_purchase_qty IS NULL OR proposed_purchase_qty > 0)
+    AND (proposed_stock_qty IS NULL OR proposed_stock_qty > 0)
+    AND (unit_price IS NULL OR unit_price >= 0)
+  )
+);
+
+CREATE TABLE IF NOT EXISTS public.replenishment_proposal_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  proposal_id uuid NOT NULL REFERENCES public.replenishment_proposals(id) ON DELETE RESTRICT,
+  event_type text NOT NULL,
+  from_status text,
+  to_status text NOT NULL,
+  calculation jsonb NOT NULL DEFAULT '{}'::jsonb,
+  details jsonb NOT NULL DEFAULT '{}'::jsonb,
+  actor_id integer,
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS public.replenishment_proposal_idempotence (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  actor_id integer NOT NULL,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  proposal_id uuid NOT NULL REFERENCES public.replenishment_proposals(id) ON DELETE RESTRICT,
+  result jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT replenishment_proposal_idem_uniq UNIQUE (actor_id, idempotency_key),
+  CONSTRAINT replenishment_proposal_idem_key_chk CHECK (char_length(idempotency_key) BETWEEN 8 AND 200),
+  CONSTRAINT replenishment_proposal_idem_hash_chk CHECK (request_hash ~ '^[0-9a-f]{64}$')
+);
+
+ALTER TABLE public.commande_fournisseur
+  ADD COLUMN IF NOT EXISTS replenishment_proposal_id uuid;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_constraint WHERE conname = 'commande_fournisseur_replenishment_fkey') THEN
+    ALTER TABLE public.commande_fournisseur ADD CONSTRAINT commande_fournisseur_replenishment_fkey
+      FOREIGN KEY (replenishment_proposal_id) REFERENCES public.replenishment_proposals(id) ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+DROP INDEX IF EXISTS public.commande_fournisseur_replenishment_uniq;
+CREATE INDEX IF NOT EXISTS commande_fournisseur_replenishment_idx
+  ON public.commande_fournisseur(replenishment_proposal_id)
+  WHERE replenishment_proposal_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS replenishment_proposals_status_idx ON public.replenishment_proposals(status, updated_at DESC);
+CREATE INDEX IF NOT EXISTS replenishment_proposals_article_site_idx ON public.replenishment_proposals(article_id, magasin_id);
+CREATE INDEX IF NOT EXISTS replenishment_proposal_events_proposal_idx ON public.replenishment_proposal_events(proposal_id, created_at DESC);
+
+CREATE OR REPLACE FUNCTION public.fn_replenishment_event_immutable()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  RAISE EXCEPTION 'Replenishment proposal events are append-only' USING ERRCODE = '55000';
+END $$;
+
+DROP TRIGGER IF EXISTS replenishment_proposal_events_immutable ON public.replenishment_proposal_events;
+CREATE TRIGGER replenishment_proposal_events_immutable
+BEFORE UPDATE OR DELETE ON public.replenishment_proposal_events
+FOR EACH ROW EXECUTE FUNCTION public.fn_replenishment_event_immutable();
+
+DO $$
+BEGIN
+  IF to_regproc('public.tg_set_updated_at()') IS NOT NULL THEN
+    EXECUTE 'DROP TRIGGER IF EXISTS replenishment_proposals_set_updated_at ON public.replenishment_proposals';
+    EXECUTE 'CREATE TRIGGER replenishment_proposals_set_updated_at BEFORE UPDATE ON public.replenishment_proposals FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
+    EXECUTE 'DROP TRIGGER IF EXISTS replenishment_budgets_set_updated_at ON public.replenishment_budgets';
+    EXECUTE 'CREATE TRIGGER replenishment_budgets_set_updated_at BEFORE UPDATE ON public.replenishment_budgets FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at()';
+  END IF;
+END $$;
+
+COMMENT ON TABLE public.replenishment_proposals IS
+  'FEAT-CERP-0003 current explainable proposal, unique per stock level (article/site). Validation always recalculates before creating a BCF draft.';
+COMMENT ON COLUMN public.fournisseur_catalogue.coef_conversion IS
+  'Number of stock units represented by one supplier purchase unit. Required with unite_stock when units differ.';
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT, INSERT, UPDATE ON public.replenishment_budgets TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE ON public.replenishment_proposals TO cerp_app;
+    GRANT SELECT, INSERT ON public.replenishment_proposal_events TO cerp_app;
+    GRANT SELECT, INSERT ON public.replenishment_proposal_idempotence TO cerp_app;
+  END IF;
+END $$;
+
+COMMIT;

--- a/db/patches/20260805_replenishment_proposals.sql
+++ b/db/patches/20260805_replenishment_proposals.sql
@@ -14,6 +14,17 @@ BEGIN
   END IF;
 END $$;
 
+DO $$
+BEGIN
+  IF to_regclass('public.app_modules') IS NOT NULL THEN
+    UPDATE public.app_modules
+       SET api_prefixes = array_append(api_prefixes, '/replenishment-proposals'),
+           updated_at = now()
+     WHERE module_key = 'commandes-fournisseurs'
+       AND NOT ('/replenishment-proposals' = ANY(api_prefixes));
+  END IF;
+END $$;
+
 ALTER TABLE public.stock_levels
   ADD COLUMN IF NOT EXISTS safety_stock_qty numeric(18,3),
   ADD COLUMN IF NOT EXISTS target_stock_qty numeric(18,3),
@@ -62,9 +73,8 @@ CREATE TABLE IF NOT EXISTS public.replenishment_budgets (
 
 CREATE TABLE IF NOT EXISTS public.replenishment_proposals (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
-  stock_level_id uuid NOT NULL REFERENCES public.stock_levels(id) ON DELETE RESTRICT,
+  stock_level_ids uuid[] NOT NULL,
   article_id uuid NOT NULL REFERENCES public.articles(id) ON DELETE RESTRICT,
-  location_id uuid,
   magasin_id uuid REFERENCES public.magasins(id) ON DELETE RESTRICT,
   status text NOT NULL DEFAULT 'PROPOSEE',
   version integer NOT NULL DEFAULT 1,
@@ -101,11 +111,11 @@ CREATE TABLE IF NOT EXISTS public.replenishment_proposals (
   resolution_reason text,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now(),
-  CONSTRAINT replenishment_proposals_stock_level_uniq UNIQUE (stock_level_id),
   CONSTRAINT replenishment_proposals_status_chk CHECK (status IN ('PROPOSEE','A_COMPLETER','CONVERTIE','RESOLUE')),
   CONSTRAINT replenishment_proposals_budget_chk CHECK (budget_status IN ('OK','EXCEEDED','MISSING','NOT_APPLICABLE')),
   CONSTRAINT replenishment_proposals_values_chk CHECK (
-    version > 0 AND qty_on_hand >= 0 AND qty_reserved >= 0 AND qty_available >= 0
+    version > 0 AND cardinality(stock_level_ids) > 0
+    AND qty_on_hand >= 0 AND qty_reserved >= 0 AND qty_available >= 0
     AND qty_open_orders >= 0 AND net_requirement_qty >= 0
     AND (stock_units_per_purchase_unit IS NULL OR stock_units_per_purchase_unit > 0)
     AND (proposed_purchase_qty IS NULL OR proposed_purchase_qty > 0)
@@ -155,7 +165,12 @@ CREATE INDEX IF NOT EXISTS commande_fournisseur_replenishment_idx
   ON public.commande_fournisseur(replenishment_proposal_id)
   WHERE replenishment_proposal_id IS NOT NULL;
 CREATE INDEX IF NOT EXISTS replenishment_proposals_status_idx ON public.replenishment_proposals(status, updated_at DESC);
-CREATE INDEX IF NOT EXISTS replenishment_proposals_article_site_idx ON public.replenishment_proposals(article_id, magasin_id);
+CREATE UNIQUE INDEX IF NOT EXISTS replenishment_proposals_article_site_uniq
+  ON public.replenishment_proposals(article_id, magasin_id)
+  WHERE magasin_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS replenishment_proposals_article_unmapped_uniq
+  ON public.replenishment_proposals(article_id)
+  WHERE magasin_id IS NULL;
 CREATE INDEX IF NOT EXISTS replenishment_proposal_events_proposal_idx ON public.replenishment_proposal_events(proposal_id, created_at DESC);
 
 CREATE OR REPLACE FUNCTION public.fn_replenishment_event_immutable()
@@ -180,7 +195,9 @@ BEGIN
 END $$;
 
 COMMENT ON TABLE public.replenishment_proposals IS
-  'FEAT-CERP-0003 current explainable proposal, unique per stock level (article/site). Validation always recalculates before creating a BCF draft.';
+  'FEAT-CERP-0003 current explainable proposal, unique per aggregated article/site scope. Validation always recalculates before creating a BCF draft.';
+COMMENT ON COLUMN public.replenishment_proposals.stock_level_ids IS
+  'Auditable source stock levels aggregated into the unique article/site proposal; order-independent UUID array.';
 COMMENT ON COLUMN public.fournisseur_catalogue.coef_conversion IS
   'Number of stock units represented by one supplier purchase unit. Required with unite_stock when units differ.';
 

--- a/db/patches/support/20260805_replenishment_proposals.preflight.sql
+++ b/db/patches/support/20260805_replenishment_proposals.preflight.sql
@@ -1,10 +1,352 @@
-\if :{?cerp_test}
-\else
-  \echo 'Run with -v cerp_test=1 against cerp_test only.'
-  \quit
-\endif
+\set ON_ERROR_STOP on
+
+-- Read-only and blocking. A pending patch is accepted only when every artifact
+-- it owns is absent; an applied patch is accepted only with its exact ledger SHA
+-- and complete governed shape.
+BEGIN TRANSACTION READ ONLY;
+
+DO $preflight$
+DECLARE
+  expected_sha256 constant text := 'ff54b540e49cb855b74bdc150304e8ebfaf0322c3c4b0e6dbfcf9c71cd2f983a';
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  registry_entry_exists boolean := false;
+  target_table_count integer;
+  target_function_count integer;
+  target_column_count integer;
+  expected_column_count integer;
+  target_constraint_count integer;
+  expected_constraint_count integer;
+  target_index_count integer;
+  expected_index_count integer;
+  target_trigger_count integer;
+  expected_trigger_count integer;
+  module_prefix_count integer;
+  owner_count integer;
+  table_acl_count integer;
+  function_acl_count integer;
+  actual_count integer;
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 preflight: migration registry is missing';
+  END IF;
+  IF to_regclass('public.stock_levels') IS NULL
+     OR to_regclass('public.articles') IS NULL
+     OR to_regclass('public.units') IS NULL
+     OR to_regclass('public.magasins') IS NULL
+     OR to_regclass('public.fournisseurs') IS NULL
+     OR to_regclass('public.fournisseur_catalogue') IS NULL
+     OR to_regclass('public.commande_fournisseur') IS NULL
+     OR to_regclass('public.commande_fournisseur_ligne') IS NULL
+     OR to_regclass('public.commande_fournisseur_ligne_besoin') IS NULL
+     OR to_regclass('public.reception_fournisseur_lignes') IS NULL
+     OR to_regclass('public.app_modules') IS NULL
+     OR to_regprocedure('public.tg_set_updated_at()') IS NULL
+     OR to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 preflight: prerequisite table, function, or role is missing';
+  END IF;
+  IF (SELECT COUNT(*) FROM public.app_modules WHERE module_key = 'commandes-fournisseurs') <> 1 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 preflight: commandes-fournisseurs module entry is missing';
+  END IF;
+
+  SELECT sha256, applied_at
+    INTO registered_sha256, registered_applied_at
+  FROM public.cerp_schema_migrations
+  WHERE filename = '20260805_replenishment_proposals.sql';
+  registry_entry_exists := FOUND;
+
+  SELECT COUNT(*)::integer INTO target_table_count
+  FROM pg_class c
+  JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relkind = 'r'
+    AND c.relname = ANY (ARRAY[
+      'replenishment_budgets','replenishment_proposals',
+      'replenishment_proposal_events','replenishment_proposal_idempotence'
+    ]);
+
+  SELECT COUNT(*)::integer INTO target_function_count
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'fn_replenishment_event_immutable'
+    AND p.pronargs = 0;
+
+  SELECT COUNT(*)::integer INTO target_column_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND (
+      (table_name = 'stock_levels' AND column_name IN ('safety_stock_qty','target_stock_qty','order_lot_size'))
+      OR (table_name = 'fournisseur_catalogue' AND column_name IN ('unite_stock','coef_conversion','lot_achat'))
+      OR (table_name = 'commande_fournisseur' AND column_name = 'replenishment_proposal_id')
+    );
+
+  SELECT COUNT(*)::integer INTO target_constraint_count
+  FROM pg_constraint
+  WHERE conname = ANY (ARRAY[
+    'stock_levels_replenishment_qty_chk','fournisseur_catalogue_conversion_chk',
+    'commande_fournisseur_replenishment_fkey',
+    'replenishment_budgets_pkey','replenishment_budgets_magasin_id_fkey',
+    'replenishment_budgets_values_chk','replenishment_budgets_scope_uniq',
+    'replenishment_proposals_pkey','replenishment_proposals_article_id_fkey',
+    'replenishment_proposals_magasin_id_fkey','replenishment_proposals_selected_catalogue_id_fkey',
+    'replenishment_proposals_selected_supplier_id_fkey',
+    'replenishment_proposals_commande_fournisseur_id_fkey',
+    'replenishment_proposals_commande_fournisseur_ligne_id_fkey',
+    'replenishment_proposals_status_chk','replenishment_proposals_budget_chk',
+    'replenishment_proposals_values_chk','replenishment_proposal_events_pkey',
+    'replenishment_proposal_events_proposal_id_fkey','replenishment_proposal_idempotence_pkey',
+    'replenishment_proposal_idempotence_proposal_id_fkey','replenishment_proposal_idem_uniq',
+    'replenishment_proposal_idem_key_chk','replenishment_proposal_idem_hash_chk'
+  ]);
+
+  SELECT COUNT(*)::integer INTO target_index_count
+  FROM pg_class
+  WHERE relkind = 'i' AND relname = ANY (ARRAY[
+    'commande_fournisseur_replenishment_idx','replenishment_budgets_pkey',
+    'replenishment_budgets_scope_uniq','replenishment_proposals_pkey','replenishment_proposals_status_idx',
+    'replenishment_proposals_article_site_uniq','replenishment_proposals_article_unmapped_uniq',
+    'replenishment_proposal_events_pkey','replenishment_proposal_events_proposal_idx',
+    'replenishment_proposal_idempotence_pkey','replenishment_proposal_idem_uniq'
+  ]);
+
+  SELECT COUNT(*)::integer INTO module_prefix_count
+  FROM public.app_modules m, unnest(m.api_prefixes) AS prefix
+  WHERE m.module_key = 'commandes-fournisseurs'
+    AND prefix = '/replenishment-proposals';
+
+  IF NOT registry_entry_exists THEN
+    IF target_table_count <> 0 OR target_function_count <> 0 OR target_column_count <> 0
+       OR target_constraint_count <> 0 OR target_index_count <> 0 OR module_prefix_count <> 0 THEN
+      RAISE EXCEPTION 'FEAT-CERP-0003 preflight: target artifact exists without migration ledger provenance';
+    END IF;
+    RETURN;
+  END IF;
+
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 OR registered_applied_at IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 preflight: migration ledger provenance is invalid';
+  END IF;
+  IF target_table_count <> 4 OR target_function_count <> 1 OR target_column_count <> 7
+     OR target_constraint_count <> 24 OR target_index_count <> 11 OR module_prefix_count <> 1 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 preflight: ledger exists but owned artifacts are incomplete';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE (table_name || '.' || column_name) = ANY (ARRAY[
+           'replenishment_budgets.id','replenishment_budgets.magasin_id','replenishment_budgets.currency',
+           'replenishment_budgets.period_start','replenishment_budgets.period_end','replenishment_budgets.amount_limit',
+           'replenishment_budgets.active','replenishment_budgets.created_at','replenishment_budgets.updated_at',
+           'replenishment_budgets.created_by','replenishment_budgets.updated_by',
+           'replenishment_proposals.id','replenishment_proposals.stock_level_ids','replenishment_proposals.article_id',
+           'replenishment_proposals.magasin_id','replenishment_proposals.status','replenishment_proposals.version',
+           'replenishment_proposals.reason_code','replenishment_proposals.stock_unit','replenishment_proposals.qty_on_hand',
+           'replenishment_proposals.qty_reserved','replenishment_proposals.qty_available','replenishment_proposals.qty_open_orders',
+           'replenishment_proposals.minimum_stock_qty','replenishment_proposals.safety_stock_qty',
+           'replenishment_proposals.target_stock_qty','replenishment_proposals.net_requirement_qty',
+           'replenishment_proposals.selected_catalogue_id','replenishment_proposals.selected_supplier_id',
+           'replenishment_proposals.purchase_unit','replenishment_proposals.stock_units_per_purchase_unit',
+           'replenishment_proposals.proposed_purchase_qty','replenishment_proposals.proposed_stock_qty',
+           'replenishment_proposals.unit_price','replenishment_proposals.currency','replenishment_proposals.estimated_total',
+           'replenishment_proposals.budget_status','replenishment_proposals.budget_remaining',
+           'replenishment_proposals.missing_data','replenishment_proposals.warnings','replenishment_proposals.calculation',
+           'replenishment_proposals.commande_fournisseur_id','replenishment_proposals.commande_fournisseur_ligne_id',
+           'replenishment_proposals.generated_at','replenishment_proposals.last_recalculated_at',
+           'replenishment_proposals.validated_at','replenishment_proposals.validated_by',
+           'replenishment_proposals.resolution_reason','replenishment_proposals.created_at','replenishment_proposals.updated_at',
+           'replenishment_proposal_events.id','replenishment_proposal_events.proposal_id',
+           'replenishment_proposal_events.event_type','replenishment_proposal_events.from_status',
+           'replenishment_proposal_events.to_status','replenishment_proposal_events.calculation',
+           'replenishment_proposal_events.details','replenishment_proposal_events.actor_id',
+           'replenishment_proposal_events.created_at','replenishment_proposal_idempotence.id',
+           'replenishment_proposal_idempotence.actor_id','replenishment_proposal_idempotence.idempotency_key',
+           'replenishment_proposal_idempotence.request_hash','replenishment_proposal_idempotence.proposal_id',
+           'replenishment_proposal_idempotence.result','replenishment_proposal_idempotence.created_at'
+         ]))::integer
+    INTO target_column_count, expected_column_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = ANY (ARRAY[
+      'replenishment_budgets','replenishment_proposals',
+      'replenishment_proposal_events','replenishment_proposal_idempotence'
+    ]);
+  IF target_column_count <> 66 OR expected_column_count <> 66 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 preflight: target columns are incomplete or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE conname = ANY (ARRAY[
+           'replenishment_budgets_pkey','replenishment_budgets_magasin_id_fkey',
+           'replenishment_budgets_values_chk','replenishment_budgets_scope_uniq',
+           'replenishment_proposals_pkey','replenishment_proposals_article_id_fkey',
+           'replenishment_proposals_magasin_id_fkey','replenishment_proposals_selected_catalogue_id_fkey',
+           'replenishment_proposals_selected_supplier_id_fkey',
+           'replenishment_proposals_commande_fournisseur_id_fkey',
+           'replenishment_proposals_commande_fournisseur_ligne_id_fkey',
+           'replenishment_proposals_status_chk','replenishment_proposals_budget_chk',
+           'replenishment_proposals_values_chk','replenishment_proposal_events_pkey',
+           'replenishment_proposal_events_proposal_id_fkey','replenishment_proposal_idempotence_pkey',
+           'replenishment_proposal_idempotence_proposal_id_fkey','replenishment_proposal_idem_uniq',
+           'replenishment_proposal_idem_key_chk','replenishment_proposal_idem_hash_chk'
+         ]) AND convalidated)::integer
+    INTO target_constraint_count, expected_constraint_count
+  FROM pg_constraint
+  WHERE conrelid = ANY (ARRAY[
+    'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+    'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+  ]);
+  IF target_constraint_count <> 21 OR expected_constraint_count <> 21 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 preflight: target constraints are incomplete, invalid, or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE c.relname = ANY (ARRAY[
+           'replenishment_budgets_pkey','replenishment_budgets_scope_uniq',
+           'replenishment_proposals_pkey','replenishment_proposals_status_idx',
+           'replenishment_proposals_article_site_uniq','replenishment_proposals_article_unmapped_uniq',
+           'replenishment_proposal_events_pkey','replenishment_proposal_events_proposal_idx',
+           'replenishment_proposal_idempotence_pkey','replenishment_proposal_idem_uniq'
+         ]))::integer
+    INTO target_index_count, expected_index_count
+  FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+  WHERE i.indrelid = ANY (ARRAY[
+    'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+    'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+  ]);
+  IF target_index_count <> 10 OR expected_index_count <> 10 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 preflight: target indexes are incomplete or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE tgname = ANY (ARRAY[
+           'replenishment_proposal_events_immutable','replenishment_proposals_set_updated_at',
+           'replenishment_budgets_set_updated_at'
+         ]) AND tgenabled = 'O')::integer
+    INTO target_trigger_count, expected_trigger_count
+  FROM pg_trigger
+  WHERE NOT tgisinternal AND tgrelid = ANY (ARRAY[
+    'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+    'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+  ]);
+  IF target_trigger_count <> 3 OR expected_trigger_count <> 3 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 preflight: target triggers are incomplete, disabled, or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO owner_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = ANY (ARRAY[
+      'replenishment_budgets','replenishment_proposals',
+      'replenishment_proposal_events','replenishment_proposal_idempotence'
+    ]) AND c.relowner = to_regrole('cerp_app');
+  IF owner_count <> 4 OR (
+    SELECT proowner FROM pg_proc
+    WHERE oid = 'public.fn_replenishment_event_immutable()'::regprocedure
+  ) IS DISTINCT FROM to_regrole('cerp_app') THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 preflight: runtime ownership is not cerp_app';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO table_acl_count
+  FROM pg_class c
+  CROSS JOIN LATERAL aclexplode(COALESCE(c.relacl, acldefault('r', c.relowner))) acl
+  WHERE c.oid = ANY (ARRAY[
+    'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+    'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+  ])
+    AND acl.grantor = to_regrole('cerp_app') AND acl.grantee = to_regrole('cerp_app')
+    AND NOT acl.is_grantable
+    AND (
+      (c.relname IN ('replenishment_budgets','replenishment_proposals')
+        AND acl.privilege_type IN ('SELECT','INSERT','UPDATE'))
+      OR (c.relname IN ('replenishment_proposal_events','replenishment_proposal_idempotence')
+        AND acl.privilege_type IN ('SELECT','INSERT'))
+    );
+  IF table_acl_count <> 10 OR EXISTS (
+    SELECT 1 FROM pg_class c
+    CROSS JOIN LATERAL aclexplode(COALESCE(c.relacl, acldefault('r', c.relowner))) acl
+    WHERE c.oid = ANY (ARRAY[
+      'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+      'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+    ]) AND (
+      acl.grantee <> to_regrole('cerp_app') OR acl.is_grantable
+      OR (c.relname IN ('replenishment_budgets','replenishment_proposals') AND acl.privilege_type NOT IN ('SELECT','INSERT','UPDATE'))
+      OR (c.relname IN ('replenishment_proposal_events','replenishment_proposal_idempotence') AND acl.privilege_type NOT IN ('SELECT','INSERT'))
+    )
+  ) THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 preflight: table ACL is not exact';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO function_acl_count
+  FROM pg_proc p CROSS JOIN LATERAL aclexplode(COALESCE(p.proacl, acldefault('f', p.proowner))) acl
+  WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure
+    AND acl.grantor = to_regrole('cerp_app') AND acl.grantee = to_regrole('cerp_app')
+    AND acl.privilege_type = 'EXECUTE' AND NOT acl.is_grantable;
+  IF function_acl_count <> 1 OR EXISTS (
+    SELECT 1 FROM pg_proc p CROSS JOIN LATERAL aclexplode(COALESCE(p.proacl, acldefault('f', p.proowner))) acl
+    WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure
+      AND (acl.grantee <> to_regrole('cerp_app') OR acl.privilege_type <> 'EXECUTE' OR acl.is_grantable)
+  ) THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 preflight: function ACL is not exact';
+  END IF;
+
+  -- Fingerprints include every owned column's ordinal/type/nullability/default/
+  -- identity state, and every owned constraint/index/trigger/function definition.
+  -- They deliberately reject a same-named replacement before a lifecycle action.
+  WITH expected(relname, signature) AS (VALUES
+    ('replenishment_budgets','528a64d4e7fa553f0f5d71f47ce80c00'),
+    ('replenishment_proposals','89d363177e4f65d5a58c7deb09b3ecf5'),
+    ('replenishment_proposal_events','bf8191942108d66226df3a844dbac83e'),
+    ('replenishment_proposal_idempotence','73073d375a6c673616a608d479a0085d')
+  ), actual AS (
+    SELECT c.relname, md5(string_agg(format('%s|%s|%s|%s|%s|%s', a.attnum, a.attname,
+      format_type(a.atttypid, a.atttypmod), a.attnotnull,
+      coalesce(pg_get_expr(d.adbin, d.adrelid), ''), a.attidentity), E'\n' ORDER BY a.attnum)) AS signature
+    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_attribute a ON a.attrelid = c.oid
+    LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+    WHERE n.nspname = 'public' AND c.relname IN (SELECT relname FROM expected)
+      AND a.attnum > 0 AND NOT a.attisdropped
+    GROUP BY c.relname
+  ) SELECT COUNT(*) INTO actual_count FROM expected e JOIN actual a USING (relname)
+      WHERE e.signature = a.signature;
+  IF actual_count <> 4 THEN RAISE EXCEPTION 'FEAT-CERP-0003 preflight: full target column shape is altered'; END IF;
+
+  WITH expected(relname, signature) AS (VALUES
+    ('commande_fournisseur','ff186f775244f355e43241b53f7b1e11'),('fournisseur_catalogue','2cae272d52d3b409aea319cbeb8cb79d'),
+    ('replenishment_budgets','f9d2132bf7f6961c4218e49666b1ec7c'),('replenishment_proposal_events','d000474beb2f6b3fcaf815188e8ae575'),
+    ('replenishment_proposal_idempotence','3e1781cf5bf3d6c81c23576dfb83d0cf'),('replenishment_proposals','b51eb5fbdf7c26cf7b0e5c8b5a846042'),
+    ('stock_levels','471249431c3f1c61764259ab31e524a6')
+  ), actual AS (
+    SELECT conrelid::regclass::text AS relname, md5(string_agg(format('%s|%s|%s', conname, contype,
+      regexp_replace(pg_get_constraintdef(oid), '\s+', ' ', 'g')), E'\n' ORDER BY conname)) AS signature
+    FROM pg_constraint WHERE conname = ANY (ARRAY[
+      'stock_levels_replenishment_qty_chk','fournisseur_catalogue_conversion_chk','commande_fournisseur_replenishment_fkey',
+      'replenishment_budgets_pkey','replenishment_budgets_magasin_id_fkey','replenishment_budgets_values_chk','replenishment_budgets_scope_uniq',
+      'replenishment_proposals_pkey','replenishment_proposals_article_id_fkey','replenishment_proposals_magasin_id_fkey','replenishment_proposals_selected_catalogue_id_fkey','replenishment_proposals_selected_supplier_id_fkey','replenishment_proposals_commande_fournisseur_id_fkey','replenishment_proposals_commande_fournisseur_ligne_id_fkey','replenishment_proposals_status_chk','replenishment_proposals_budget_chk','replenishment_proposals_values_chk','replenishment_proposal_events_pkey','replenishment_proposal_events_proposal_id_fkey','replenishment_proposal_idempotence_pkey','replenishment_proposal_idempotence_proposal_id_fkey','replenishment_proposal_idem_uniq','replenishment_proposal_idem_key_chk','replenishment_proposal_idem_hash_chk'
+    ]) GROUP BY conrelid
+  ) SELECT COUNT(*) INTO actual_count FROM expected e JOIN actual a USING (relname) WHERE e.signature = a.signature;
+  IF actual_count <> 7 THEN RAISE EXCEPTION 'FEAT-CERP-0003 preflight: owned constraint definition is altered'; END IF;
+
+  WITH expected(relname, signature) AS (VALUES
+    ('commande_fournisseur','b158333753277d57e9ecf7dd9df2c3fb'),('replenishment_budgets','e54643077ceba4240c065f3afdc69953'),
+    ('replenishment_proposal_events','a55096cdc9603c72780a71651fabc465'),('replenishment_proposal_idempotence','df3cda198e42959304c28f97261291c4'),
+    ('replenishment_proposals','793e25cd95c988147fe30ec37f0ab2ea')
+  ), actual AS (
+    SELECT i.indrelid::regclass::text AS relname, md5(string_agg(format('%s|%s|%s|%s|%s', c.relname, i.indisunique, i.indisprimary, i.indnkeyatts,
+      regexp_replace(pg_get_indexdef(i.indexrelid), '\s+', ' ', 'g')), E'\n' ORDER BY c.relname)) AS signature
+    FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+    WHERE c.relname = ANY (ARRAY['commande_fournisseur_replenishment_idx','replenishment_budgets_pkey','replenishment_budgets_scope_uniq','replenishment_proposals_pkey','replenishment_proposals_status_idx','replenishment_proposals_article_site_uniq','replenishment_proposals_article_unmapped_uniq','replenishment_proposal_events_pkey','replenishment_proposal_events_proposal_idx','replenishment_proposal_idempotence_pkey','replenishment_proposal_idem_uniq'])
+    GROUP BY i.indrelid
+  ) SELECT COUNT(*) INTO actual_count FROM expected e JOIN actual a USING (relname) WHERE e.signature = a.signature;
+  IF actual_count <> 5 THEN RAISE EXCEPTION 'FEAT-CERP-0003 preflight: owned index definition is altered'; END IF;
+
+  SELECT md5(string_agg(format('%s|%s|%s|%s|%s', tgname, tgtype, tgenabled, tgfoid::regprocedure, encode(tgargs, 'escape')), E'\n' ORDER BY tgname))
+    INTO registered_sha256 FROM pg_trigger WHERE NOT tgisinternal AND tgrelid = ANY (ARRAY['public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass]);
+  IF registered_sha256 IS DISTINCT FROM '7e574b34d6c795630b9c08be2d6aded2' THEN RAISE EXCEPTION 'FEAT-CERP-0003 preflight: owned trigger mapping/event is altered'; END IF;
+  SELECT md5(format('%s|%s|%s|%s|%s|%s', pg_get_functiondef(p.oid), p.provolatile, p.proisstrict, p.prosecdef, p.proleakproof, coalesce(array_to_string(p.proconfig, E'\n'), '')))
+    INTO registered_sha256 FROM pg_proc p WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure;
+  IF registered_sha256 IS DISTINCT FROM '0e1298dced0e423190dfa3dc059ab371' THEN RAISE EXCEPTION 'FEAT-CERP-0003 preflight: immutable function definition/settings are altered'; END IF;
+END
+$preflight$;
 
 SELECT current_database() AS database_name,
-       to_regclass('public.stock_levels') IS NOT NULL AS has_stock_levels,
-       to_regclass('public.commande_fournisseur') IS NOT NULL AS has_supplier_orders,
-       to_regclass('public.fournisseur_catalogue') IS NOT NULL AS has_supplier_catalogue;
+       current_user AS actor,
+       'FEAT-CERP-0003 preflight passed (read-only)' AS result;
+
+ROLLBACK;

--- a/db/patches/support/20260805_replenishment_proposals.preflight.sql
+++ b/db/patches/support/20260805_replenishment_proposals.preflight.sql
@@ -1,0 +1,10 @@
+\if :{?cerp_test}
+\else
+  \echo 'Run with -v cerp_test=1 against cerp_test only.'
+  \quit
+\endif
+
+SELECT current_database() AS database_name,
+       to_regclass('public.stock_levels') IS NOT NULL AS has_stock_levels,
+       to_regclass('public.commande_fournisseur') IS NOT NULL AS has_supplier_orders,
+       to_regclass('public.fournisseur_catalogue') IS NOT NULL AS has_supplier_catalogue;

--- a/db/patches/support/20260805_replenishment_proposals.rollback.sql
+++ b/db/patches/support/20260805_replenishment_proposals.rollback.sql
@@ -1,42 +1,377 @@
-DO $$
-BEGIN
-  IF current_database() <> 'cerp_test' THEN
-    RAISE EXCEPTION 'FEAT-CERP-0003 rollback is restricted to cerp_test';
-  END IF;
-  IF EXISTS (SELECT 1 FROM public.replenishment_proposal_events)
-     OR EXISTS (SELECT 1 FROM public.replenishment_proposals)
-     OR EXISTS (SELECT 1 FROM public.replenishment_budgets)
-     OR EXISTS (SELECT 1 FROM public.commande_fournisseur WHERE replenishment_proposal_id IS NOT NULL) THEN
-    RAISE EXCEPTION 'Rollback refused: replenishment evidence exists';
-  END IF;
-END $$;
+\set ON_ERROR_STOP on
 
+-- Destructive schema rollback is dev/test-only. It removes only the exact
+-- artifacts proven to belong to this migration and deletes the matching ledger
+-- row in the same transaction so the canonical runner can reapply the patch.
 BEGIN;
-DO $$
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+DO $environment_guard$
 BEGIN
-  IF to_regclass('public.app_modules') IS NOT NULL THEN
-    UPDATE public.app_modules
-       SET api_prefixes = array_remove(api_prefixes, '/replenishment-proposals'),
-           updated_at = now()
-     WHERE module_key = 'commandes-fournisseurs';
+  IF current_database() NOT IN ('cerp_dev', 'cerp_test') THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback is restricted to cerp_dev/cerp_test';
   END IF;
-END $$;
-ALTER TABLE public.commande_fournisseur DROP CONSTRAINT IF EXISTS commande_fournisseur_replenishment_fkey;
-DROP INDEX IF EXISTS public.commande_fournisseur_replenishment_idx;
-ALTER TABLE public.commande_fournisseur DROP COLUMN IF EXISTS replenishment_proposal_id;
-DROP TABLE IF EXISTS public.replenishment_proposal_idempotence;
-DROP TABLE IF EXISTS public.replenishment_proposal_events;
-DROP INDEX IF EXISTS public.replenishment_proposals_article_site_uniq;
-DROP INDEX IF EXISTS public.replenishment_proposals_article_unmapped_uniq;
-DROP TABLE IF EXISTS public.replenishment_proposals;
-DROP TABLE IF EXISTS public.replenishment_budgets;
-DROP FUNCTION IF EXISTS public.fn_replenishment_event_immutable();
-ALTER TABLE public.fournisseur_catalogue DROP CONSTRAINT IF EXISTS fournisseur_catalogue_conversion_chk;
-ALTER TABLE public.fournisseur_catalogue DROP COLUMN IF EXISTS lot_achat;
-ALTER TABLE public.fournisseur_catalogue DROP COLUMN IF EXISTS coef_conversion;
-ALTER TABLE public.fournisseur_catalogue DROP COLUMN IF EXISTS unite_stock;
-ALTER TABLE public.stock_levels DROP CONSTRAINT IF EXISTS stock_levels_replenishment_qty_chk;
-ALTER TABLE public.stock_levels DROP COLUMN IF EXISTS order_lot_size;
-ALTER TABLE public.stock_levels DROP COLUMN IF EXISTS target_stock_qty;
-ALTER TABLE public.stock_levels DROP COLUMN IF EXISTS safety_stock_qty;
+END
+$environment_guard$;
+
+SELECT pg_advisory_xact_lock(hashtext('cerp_schema_migrations'));
+
+DO $rollback$
+DECLARE
+  expected_sha256 constant text := 'ff54b540e49cb855b74bdc150304e8ebfaf0322c3c4b0e6dbfcf9c71cd2f983a';
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  registry_entry_exists boolean := false;
+  target_table_count integer;
+  target_function_count integer;
+  target_column_count integer;
+  target_constraint_count integer;
+  target_index_count integer;
+  target_trigger_count integer;
+  module_prefix_count integer;
+  owner_count integer;
+  acl_count integer;
+  actual_count integer;
+  evidence_count bigint;
+  changed_rows integer;
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: migration registry is missing';
+  END IF;
+  IF to_regclass('public.app_modules') IS NULL OR to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: module catalogue or runtime role is missing';
+  END IF;
+
+  SELECT sha256, applied_at INTO registered_sha256, registered_applied_at
+  FROM public.cerp_schema_migrations
+  WHERE filename = '20260805_replenishment_proposals.sql'
+  FOR UPDATE;
+  registry_entry_exists := FOUND;
+
+  SELECT COUNT(*)::integer INTO target_table_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public' AND c.relkind = 'r'
+    AND c.relname = ANY (ARRAY[
+      'replenishment_budgets','replenishment_proposals',
+      'replenishment_proposal_events','replenishment_proposal_idempotence'
+    ]);
+  SELECT COUNT(*)::integer INTO target_function_count
+  FROM pg_proc p JOIN pg_namespace n ON n.oid = p.pronamespace
+  WHERE n.nspname = 'public' AND p.proname = 'fn_replenishment_event_immutable'
+    AND p.pronargs = 0;
+  SELECT COUNT(*)::integer INTO target_column_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public' AND (
+    (table_name = 'stock_levels' AND column_name IN ('safety_stock_qty','target_stock_qty','order_lot_size'))
+    OR (table_name = 'fournisseur_catalogue' AND column_name IN ('unite_stock','coef_conversion','lot_achat'))
+    OR (table_name = 'commande_fournisseur' AND column_name = 'replenishment_proposal_id')
+  );
+  SELECT COUNT(*)::integer INTO target_constraint_count
+  FROM pg_constraint WHERE conname = ANY (ARRAY[
+    'stock_levels_replenishment_qty_chk','fournisseur_catalogue_conversion_chk',
+    'commande_fournisseur_replenishment_fkey',
+    'replenishment_budgets_pkey','replenishment_budgets_magasin_id_fkey',
+    'replenishment_budgets_values_chk','replenishment_budgets_scope_uniq',
+    'replenishment_proposals_pkey','replenishment_proposals_article_id_fkey',
+    'replenishment_proposals_magasin_id_fkey','replenishment_proposals_selected_catalogue_id_fkey',
+    'replenishment_proposals_selected_supplier_id_fkey',
+    'replenishment_proposals_commande_fournisseur_id_fkey',
+    'replenishment_proposals_commande_fournisseur_ligne_id_fkey',
+    'replenishment_proposals_status_chk','replenishment_proposals_budget_chk',
+    'replenishment_proposals_values_chk','replenishment_proposal_events_pkey',
+    'replenishment_proposal_events_proposal_id_fkey','replenishment_proposal_idempotence_pkey',
+    'replenishment_proposal_idempotence_proposal_id_fkey','replenishment_proposal_idem_uniq',
+    'replenishment_proposal_idem_key_chk','replenishment_proposal_idem_hash_chk'
+  ]);
+  SELECT COUNT(*)::integer INTO target_index_count
+  FROM pg_class WHERE relkind = 'i' AND relname = ANY (ARRAY[
+    'commande_fournisseur_replenishment_idx','replenishment_budgets_pkey',
+    'replenishment_budgets_scope_uniq','replenishment_proposals_pkey','replenishment_proposals_status_idx',
+    'replenishment_proposals_article_site_uniq','replenishment_proposals_article_unmapped_uniq',
+    'replenishment_proposal_events_pkey','replenishment_proposal_events_proposal_idx',
+    'replenishment_proposal_idempotence_pkey','replenishment_proposal_idem_uniq'
+  ]);
+  SELECT COUNT(*)::integer INTO module_prefix_count
+  FROM public.app_modules m, unnest(m.api_prefixes) AS prefix
+  WHERE m.module_key = 'commandes-fournisseurs' AND prefix = '/replenishment-proposals';
+
+  IF NOT registry_entry_exists THEN
+    IF target_table_count = 0 AND target_function_count = 0 AND target_column_count = 0
+       AND target_constraint_count = 0 AND target_index_count = 0 AND module_prefix_count = 0 THEN
+      RAISE NOTICE 'FEAT-CERP-0003 rollback: exact artifacts already absent';
+      RETURN;
+    END IF;
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: artifacts exist without migration ledger provenance';
+  END IF;
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 OR registered_applied_at IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: migration ledger provenance is invalid';
+  END IF;
+  IF target_table_count <> 4 OR target_function_count <> 1 OR target_column_count <> 7
+     OR target_constraint_count <> 24 OR target_index_count <> 11 OR module_prefix_count <> 1 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: target artifacts or ledger are in a partial state';
+  END IF;
+
+  LOCK TABLE public.app_modules,
+    public.stock_levels,
+    public.fournisseur_catalogue,
+    public.commande_fournisseur,
+    public.replenishment_budgets,
+    public.replenishment_proposals,
+    public.replenishment_proposal_events,
+    public.replenishment_proposal_idempotence
+  IN ACCESS EXCLUSIVE MODE;
+
+  SELECT COUNT(*)::integer INTO target_column_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = ANY (ARRAY[
+      'replenishment_budgets','replenishment_proposals',
+      'replenishment_proposal_events','replenishment_proposal_idempotence'
+    ]);
+  IF target_column_count <> 66 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: target table columns are incomplete or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO target_constraint_count
+  FROM pg_constraint
+  WHERE conrelid = ANY (ARRAY[
+    'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+    'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+  ]) AND convalidated AND conname = ANY (ARRAY[
+    'replenishment_budgets_pkey','replenishment_budgets_magasin_id_fkey',
+    'replenishment_budgets_values_chk','replenishment_budgets_scope_uniq',
+    'replenishment_proposals_pkey','replenishment_proposals_article_id_fkey',
+    'replenishment_proposals_magasin_id_fkey','replenishment_proposals_selected_catalogue_id_fkey',
+    'replenishment_proposals_selected_supplier_id_fkey',
+    'replenishment_proposals_commande_fournisseur_id_fkey',
+    'replenishment_proposals_commande_fournisseur_ligne_id_fkey',
+    'replenishment_proposals_status_chk','replenishment_proposals_budget_chk',
+    'replenishment_proposals_values_chk','replenishment_proposal_events_pkey',
+    'replenishment_proposal_events_proposal_id_fkey','replenishment_proposal_idempotence_pkey',
+    'replenishment_proposal_idempotence_proposal_id_fkey','replenishment_proposal_idem_uniq',
+    'replenishment_proposal_idem_key_chk','replenishment_proposal_idem_hash_chk'
+  ]);
+  IF target_constraint_count <> 21 OR (
+    SELECT COUNT(*) FROM pg_constraint WHERE conrelid = ANY (ARRAY[
+      'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+      'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+    ])
+  ) <> 21 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: target constraints are altered or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO target_index_count
+  FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+  WHERE i.indrelid = ANY (ARRAY[
+    'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+    'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+  ]) AND c.relname = ANY (ARRAY[
+    'replenishment_budgets_pkey','replenishment_budgets_scope_uniq',
+    'replenishment_proposals_pkey','replenishment_proposals_status_idx',
+    'replenishment_proposals_article_site_uniq','replenishment_proposals_article_unmapped_uniq',
+    'replenishment_proposal_events_pkey','replenishment_proposal_events_proposal_idx',
+    'replenishment_proposal_idempotence_pkey','replenishment_proposal_idem_uniq'
+  ]);
+  IF target_index_count <> 10 OR (
+    SELECT COUNT(*) FROM pg_index WHERE indrelid = ANY (ARRAY[
+      'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+      'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+    ])
+  ) <> 10 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: target indexes are altered or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO target_trigger_count
+  FROM pg_trigger
+  WHERE NOT tgisinternal AND tgenabled = 'O'
+    AND tgrelid = ANY (ARRAY[
+      'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+      'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+    ]) AND tgname = ANY (ARRAY[
+      'replenishment_proposal_events_immutable','replenishment_proposals_set_updated_at',
+      'replenishment_budgets_set_updated_at'
+    ]);
+  IF target_trigger_count <> 3 OR (
+    SELECT COUNT(*) FROM pg_trigger
+    WHERE NOT tgisinternal AND tgrelid = ANY (ARRAY[
+      'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+      'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+    ])
+  ) <> 3 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: target triggers are altered, disabled, or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO owner_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = ANY (ARRAY[
+      'replenishment_budgets','replenishment_proposals',
+      'replenishment_proposal_events','replenishment_proposal_idempotence'
+    ]) AND c.relowner = to_regrole('cerp_app');
+  IF owner_count <> 4 OR (
+    SELECT proowner FROM pg_proc
+    WHERE oid = 'public.fn_replenishment_event_immutable()'::regprocedure
+  ) IS DISTINCT FROM to_regrole('cerp_app') THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: target ownership is unexpected';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO acl_count
+  FROM pg_class c CROSS JOIN LATERAL aclexplode(COALESCE(c.relacl, acldefault('r', c.relowner))) acl
+  WHERE c.oid = ANY (ARRAY[
+    'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+    'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+  ]) AND acl.grantor = to_regrole('cerp_app') AND acl.grantee = to_regrole('cerp_app') AND NOT acl.is_grantable
+    AND ((c.relname IN ('replenishment_budgets','replenishment_proposals') AND acl.privilege_type IN ('SELECT','INSERT','UPDATE'))
+      OR (c.relname IN ('replenishment_proposal_events','replenishment_proposal_idempotence') AND acl.privilege_type IN ('SELECT','INSERT')));
+  IF acl_count <> 10 OR EXISTS (
+    SELECT 1 FROM pg_class c CROSS JOIN LATERAL aclexplode(COALESCE(c.relacl, acldefault('r', c.relowner))) acl
+    WHERE c.oid = ANY (ARRAY[
+      'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+      'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+    ]) AND (acl.grantee <> to_regrole('cerp_app') OR acl.is_grantable
+      OR (c.relname IN ('replenishment_budgets','replenishment_proposals') AND acl.privilege_type NOT IN ('SELECT','INSERT','UPDATE'))
+      OR (c.relname IN ('replenishment_proposal_events','replenishment_proposal_idempotence') AND acl.privilege_type NOT IN ('SELECT','INSERT')))
+  ) THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: target table ACL is unexpected';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO acl_count
+  FROM pg_proc p CROSS JOIN LATERAL aclexplode(COALESCE(p.proacl, acldefault('f', p.proowner))) acl
+  WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure
+    AND acl.grantor = to_regrole('cerp_app') AND acl.grantee = to_regrole('cerp_app')
+    AND acl.privilege_type = 'EXECUTE' AND NOT acl.is_grantable;
+  IF acl_count <> 1 OR EXISTS (
+    SELECT 1 FROM pg_proc p
+    CROSS JOIN LATERAL aclexplode(COALESCE(p.proacl, acldefault('f', p.proowner))) acl
+    WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure
+      AND (acl.grantee <> to_regrole('cerp_app') OR acl.privilege_type <> 'EXECUTE' OR acl.is_grantable)
+  ) THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: target function ACL is unexpected';
+  END IF;
+
+  -- Destructive DDL is allowed only while catalog definitions still match the
+  -- exact objects created by this patch; same-named replacements are refused.
+  WITH expected(relname, signature) AS (VALUES
+    ('replenishment_budgets','528a64d4e7fa553f0f5d71f47ce80c00'),
+    ('replenishment_proposals','89d363177e4f65d5a58c7deb09b3ecf5'),
+    ('replenishment_proposal_events','bf8191942108d66226df3a844dbac83e'),
+    ('replenishment_proposal_idempotence','73073d375a6c673616a608d479a0085d')
+  ), actual AS (
+    SELECT c.relname, md5(string_agg(format('%s|%s|%s|%s|%s|%s', a.attnum, a.attname,
+      format_type(a.atttypid, a.atttypmod), a.attnotnull,
+      coalesce(pg_get_expr(d.adbin, d.adrelid), ''), a.attidentity), E'\n' ORDER BY a.attnum)) AS signature
+    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_attribute a ON a.attrelid = c.oid
+    LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+    WHERE n.nspname = 'public' AND c.relname IN (SELECT relname FROM expected)
+      AND a.attnum > 0 AND NOT a.attisdropped
+    GROUP BY c.relname
+  ) SELECT COUNT(*) INTO actual_count FROM expected e JOIN actual a USING (relname)
+      WHERE e.signature = a.signature;
+  IF actual_count <> 4 THEN RAISE EXCEPTION 'FEAT-CERP-0003 rollback: full target column shape is altered'; END IF;
+
+  WITH expected(relname, signature) AS (VALUES
+    ('commande_fournisseur','ff186f775244f355e43241b53f7b1e11'),('fournisseur_catalogue','2cae272d52d3b409aea319cbeb8cb79d'),
+    ('replenishment_budgets','f9d2132bf7f6961c4218e49666b1ec7c'),('replenishment_proposal_events','d000474beb2f6b3fcaf815188e8ae575'),
+    ('replenishment_proposal_idempotence','3e1781cf5bf3d6c81c23576dfb83d0cf'),('replenishment_proposals','b51eb5fbdf7c26cf7b0e5c8b5a846042'),
+    ('stock_levels','471249431c3f1c61764259ab31e524a6')
+  ), actual AS (
+    SELECT conrelid::regclass::text AS relname, md5(string_agg(format('%s|%s|%s', conname, contype,
+      regexp_replace(pg_get_constraintdef(oid), '\s+', ' ', 'g')), E'\n' ORDER BY conname)) AS signature
+    FROM pg_constraint WHERE conname = ANY (ARRAY[
+      'stock_levels_replenishment_qty_chk','fournisseur_catalogue_conversion_chk','commande_fournisseur_replenishment_fkey',
+      'replenishment_budgets_pkey','replenishment_budgets_magasin_id_fkey','replenishment_budgets_values_chk','replenishment_budgets_scope_uniq',
+      'replenishment_proposals_pkey','replenishment_proposals_article_id_fkey','replenishment_proposals_magasin_id_fkey','replenishment_proposals_selected_catalogue_id_fkey','replenishment_proposals_selected_supplier_id_fkey','replenishment_proposals_commande_fournisseur_id_fkey','replenishment_proposals_commande_fournisseur_ligne_id_fkey','replenishment_proposals_status_chk','replenishment_proposals_budget_chk','replenishment_proposals_values_chk','replenishment_proposal_events_pkey','replenishment_proposal_events_proposal_id_fkey','replenishment_proposal_idempotence_pkey','replenishment_proposal_idempotence_proposal_id_fkey','replenishment_proposal_idem_uniq','replenishment_proposal_idem_key_chk','replenishment_proposal_idem_hash_chk'
+    ]) GROUP BY conrelid
+  ) SELECT COUNT(*) INTO actual_count FROM expected e JOIN actual a USING (relname) WHERE e.signature = a.signature;
+  IF actual_count <> 7 THEN RAISE EXCEPTION 'FEAT-CERP-0003 rollback: owned constraint definition is altered'; END IF;
+
+  WITH expected(relname, signature) AS (VALUES
+    ('commande_fournisseur','b158333753277d57e9ecf7dd9df2c3fb'),('replenishment_budgets','e54643077ceba4240c065f3afdc69953'),
+    ('replenishment_proposal_events','a55096cdc9603c72780a71651fabc465'),('replenishment_proposal_idempotence','df3cda198e42959304c28f97261291c4'),
+    ('replenishment_proposals','793e25cd95c988147fe30ec37f0ab2ea')
+  ), actual AS (
+    SELECT i.indrelid::regclass::text AS relname, md5(string_agg(format('%s|%s|%s|%s|%s', c.relname, i.indisunique, i.indisprimary, i.indnkeyatts,
+      regexp_replace(pg_get_indexdef(i.indexrelid), '\s+', ' ', 'g')), E'\n' ORDER BY c.relname)) AS signature
+    FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+    WHERE c.relname = ANY (ARRAY['commande_fournisseur_replenishment_idx','replenishment_budgets_pkey','replenishment_budgets_scope_uniq','replenishment_proposals_pkey','replenishment_proposals_status_idx','replenishment_proposals_article_site_uniq','replenishment_proposals_article_unmapped_uniq','replenishment_proposal_events_pkey','replenishment_proposal_events_proposal_idx','replenishment_proposal_idempotence_pkey','replenishment_proposal_idem_uniq'])
+    GROUP BY i.indrelid
+  ) SELECT COUNT(*) INTO actual_count FROM expected e JOIN actual a USING (relname) WHERE e.signature = a.signature;
+  IF actual_count <> 5 THEN RAISE EXCEPTION 'FEAT-CERP-0003 rollback: owned index definition is altered'; END IF;
+
+  SELECT md5(string_agg(format('%s|%s|%s|%s|%s', tgname, tgtype, tgenabled, tgfoid::regprocedure, encode(tgargs, 'escape')), E'\n' ORDER BY tgname))
+    INTO registered_sha256 FROM pg_trigger WHERE NOT tgisinternal AND tgrelid = ANY (ARRAY['public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass]);
+  IF registered_sha256 IS DISTINCT FROM '7e574b34d6c795630b9c08be2d6aded2' THEN RAISE EXCEPTION 'FEAT-CERP-0003 rollback: owned trigger mapping/event is altered'; END IF;
+  SELECT md5(format('%s|%s|%s|%s|%s|%s', pg_get_functiondef(p.oid), p.provolatile, p.proisstrict, p.prosecdef, p.proleakproof, coalesce(array_to_string(p.proconfig, E'\n'), '')))
+    INTO registered_sha256 FROM pg_proc p WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure;
+  IF registered_sha256 IS DISTINCT FROM '0e1298dced0e423190dfa3dc059ab371' THEN RAISE EXCEPTION 'FEAT-CERP-0003 rollback: immutable function definition/settings are altered'; END IF;
+
+  SELECT (
+    (SELECT COUNT(*) FROM public.replenishment_budgets)
+    + (SELECT COUNT(*) FROM public.replenishment_proposals)
+    + (SELECT COUNT(*) FROM public.replenishment_proposal_events)
+    + (SELECT COUNT(*) FROM public.replenishment_proposal_idempotence)
+    + (SELECT COUNT(*) FROM public.commande_fournisseur WHERE replenishment_proposal_id IS NOT NULL)
+    + (SELECT COUNT(*) FROM public.stock_levels
+       WHERE safety_stock_qty IS NOT NULL OR target_stock_qty IS NOT NULL OR order_lot_size IS NOT NULL)
+    + (SELECT COUNT(*) FROM public.fournisseur_catalogue
+       WHERE unite_stock IS NOT NULL OR coef_conversion IS NOT NULL OR lot_achat IS NOT NULL)
+  )::bigint INTO evidence_count;
+  IF evidence_count <> 0 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: replenishment evidence or governed values exist';
+  END IF;
+
+  EXECUTE 'DROP TRIGGER replenishment_proposal_events_immutable ON public.replenishment_proposal_events';
+  EXECUTE 'DROP TRIGGER replenishment_proposals_set_updated_at ON public.replenishment_proposals';
+  EXECUTE 'DROP TRIGGER replenishment_budgets_set_updated_at ON public.replenishment_budgets';
+  EXECUTE 'DROP FUNCTION public.fn_replenishment_event_immutable()';
+
+  EXECUTE 'ALTER TABLE public.commande_fournisseur DROP CONSTRAINT commande_fournisseur_replenishment_fkey';
+  EXECUTE 'DROP INDEX public.commande_fournisseur_replenishment_idx';
+  EXECUTE 'ALTER TABLE public.commande_fournisseur DROP COLUMN replenishment_proposal_id';
+  EXECUTE 'DROP TABLE public.replenishment_proposal_idempotence';
+  EXECUTE 'DROP TABLE public.replenishment_proposal_events';
+  EXECUTE 'DROP TABLE public.replenishment_proposals';
+  EXECUTE 'DROP TABLE public.replenishment_budgets';
+
+  EXECUTE 'ALTER TABLE public.fournisseur_catalogue DROP CONSTRAINT fournisseur_catalogue_conversion_chk';
+  EXECUTE 'ALTER TABLE public.fournisseur_catalogue DROP COLUMN lot_achat, DROP COLUMN coef_conversion, DROP COLUMN unite_stock';
+  EXECUTE 'ALTER TABLE public.stock_levels DROP CONSTRAINT stock_levels_replenishment_qty_chk';
+  EXECUTE 'ALTER TABLE public.stock_levels DROP COLUMN order_lot_size, DROP COLUMN target_stock_qty, DROP COLUMN safety_stock_qty';
+
+  UPDATE public.app_modules
+     SET api_prefixes = array_remove(api_prefixes, '/replenishment-proposals'),
+         updated_at = now()
+   WHERE module_key = 'commandes-fournisseurs'
+     AND '/replenishment-proposals' = ANY(api_prefixes);
+  GET DIAGNOSTICS changed_rows = ROW_COUNT;
+  IF changed_rows <> 1 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: exact module prefix was not removed';
+  END IF;
+
+  DELETE FROM public.cerp_schema_migrations
+  WHERE filename = '20260805_replenishment_proposals.sql'
+    AND sha256 = expected_sha256;
+  GET DIAGNOSTICS changed_rows = ROW_COUNT;
+  IF changed_rows <> 1 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: exact migration ledger row was not removed';
+  END IF;
+
+  IF to_regclass('public.replenishment_budgets') IS NOT NULL
+     OR to_regclass('public.replenishment_proposals') IS NOT NULL
+     OR to_regclass('public.replenishment_proposal_events') IS NOT NULL
+     OR to_regclass('public.replenishment_proposal_idempotence') IS NOT NULL
+     OR to_regprocedure('public.fn_replenishment_event_immutable()') IS NOT NULL
+     OR EXISTS (
+       SELECT 1 FROM public.cerp_schema_migrations
+       WHERE filename = '20260805_replenishment_proposals.sql'
+     ) OR EXISTS (
+       SELECT 1 FROM public.app_modules m, unnest(m.api_prefixes) AS prefix
+       WHERE m.module_key = 'commandes-fournisseurs' AND prefix = '/replenishment-proposals'
+     ) THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback: an owned artifact remains after rollback';
+  END IF;
+END
+$rollback$;
+
 COMMIT;

--- a/db/patches/support/20260805_replenishment_proposals.rollback.sql
+++ b/db/patches/support/20260805_replenishment_proposals.rollback.sql
@@ -12,11 +12,22 @@ BEGIN
 END $$;
 
 BEGIN;
+DO $$
+BEGIN
+  IF to_regclass('public.app_modules') IS NOT NULL THEN
+    UPDATE public.app_modules
+       SET api_prefixes = array_remove(api_prefixes, '/replenishment-proposals'),
+           updated_at = now()
+     WHERE module_key = 'commandes-fournisseurs';
+  END IF;
+END $$;
 ALTER TABLE public.commande_fournisseur DROP CONSTRAINT IF EXISTS commande_fournisseur_replenishment_fkey;
 DROP INDEX IF EXISTS public.commande_fournisseur_replenishment_idx;
 ALTER TABLE public.commande_fournisseur DROP COLUMN IF EXISTS replenishment_proposal_id;
 DROP TABLE IF EXISTS public.replenishment_proposal_idempotence;
 DROP TABLE IF EXISTS public.replenishment_proposal_events;
+DROP INDEX IF EXISTS public.replenishment_proposals_article_site_uniq;
+DROP INDEX IF EXISTS public.replenishment_proposals_article_unmapped_uniq;
 DROP TABLE IF EXISTS public.replenishment_proposals;
 DROP TABLE IF EXISTS public.replenishment_budgets;
 DROP FUNCTION IF EXISTS public.fn_replenishment_event_immutable();

--- a/db/patches/support/20260805_replenishment_proposals.rollback.sql
+++ b/db/patches/support/20260805_replenishment_proposals.rollback.sql
@@ -1,0 +1,31 @@
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 rollback is restricted to cerp_test';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.replenishment_proposal_events)
+     OR EXISTS (SELECT 1 FROM public.replenishment_proposals)
+     OR EXISTS (SELECT 1 FROM public.replenishment_budgets)
+     OR EXISTS (SELECT 1 FROM public.commande_fournisseur WHERE replenishment_proposal_id IS NOT NULL) THEN
+    RAISE EXCEPTION 'Rollback refused: replenishment evidence exists';
+  END IF;
+END $$;
+
+BEGIN;
+ALTER TABLE public.commande_fournisseur DROP CONSTRAINT IF EXISTS commande_fournisseur_replenishment_fkey;
+DROP INDEX IF EXISTS public.commande_fournisseur_replenishment_idx;
+ALTER TABLE public.commande_fournisseur DROP COLUMN IF EXISTS replenishment_proposal_id;
+DROP TABLE IF EXISTS public.replenishment_proposal_idempotence;
+DROP TABLE IF EXISTS public.replenishment_proposal_events;
+DROP TABLE IF EXISTS public.replenishment_proposals;
+DROP TABLE IF EXISTS public.replenishment_budgets;
+DROP FUNCTION IF EXISTS public.fn_replenishment_event_immutable();
+ALTER TABLE public.fournisseur_catalogue DROP CONSTRAINT IF EXISTS fournisseur_catalogue_conversion_chk;
+ALTER TABLE public.fournisseur_catalogue DROP COLUMN IF EXISTS lot_achat;
+ALTER TABLE public.fournisseur_catalogue DROP COLUMN IF EXISTS coef_conversion;
+ALTER TABLE public.fournisseur_catalogue DROP COLUMN IF EXISTS unite_stock;
+ALTER TABLE public.stock_levels DROP CONSTRAINT IF EXISTS stock_levels_replenishment_qty_chk;
+ALTER TABLE public.stock_levels DROP COLUMN IF EXISTS order_lot_size;
+ALTER TABLE public.stock_levels DROP COLUMN IF EXISTS target_stock_qty;
+ALTER TABLE public.stock_levels DROP COLUMN IF EXISTS safety_stock_qty;
+COMMIT;

--- a/db/patches/support/20260805_replenishment_proposals.verify.sql
+++ b/db/patches/support/20260805_replenishment_proposals.verify.sql
@@ -1,34 +1,311 @@
-SELECT
-  to_regclass('public.replenishment_proposals') IS NOT NULL AS has_proposals,
-  to_regclass('public.replenishment_proposal_events') IS NOT NULL AS has_events,
-  to_regclass('public.replenishment_proposal_idempotence') IS NOT NULL AS has_idempotence,
-  to_regclass('public.replenishment_budgets') IS NOT NULL AS has_budgets;
+\set ON_ERROR_STOP on
 
-SELECT module_key, '/replenishment-proposals' = ANY(api_prefixes) AS has_replenishment_prefix
-FROM public.app_modules
-WHERE module_key = 'commandes-fournisseurs';
+-- Blocking post-apply verification. It validates registry provenance, exact
+-- shape, active triggers, module routing, ownership, and explicit ACLs.
+BEGIN TRANSACTION READ ONLY;
 
-SELECT conname, convalidated
-FROM pg_constraint
-WHERE conname IN (
-  'replenishment_proposals_status_chk',
-  'replenishment_proposals_values_chk',
-  'commande_fournisseur_replenishment_fkey'
-)
-ORDER BY conname;
+DO $verify$
+DECLARE
+  expected_sha256 constant text := 'ff54b540e49cb855b74bdc150304e8ebfaf0322c3c4b0e6dbfcf9c71cd2f983a';
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  actual_count integer;
+  expected_count integer;
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: migration registry is missing';
+  END IF;
+  SELECT sha256, applied_at INTO registered_sha256, registered_applied_at
+  FROM public.cerp_schema_migrations
+  WHERE filename = '20260805_replenishment_proposals.sql';
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: migration registry entry is missing';
+  END IF;
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 OR registered_applied_at IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: migration ledger provenance is invalid';
+  END IF;
+  IF to_regrole('cerp_app') IS NULL OR to_regclass('public.app_modules') IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: runtime role or module catalogue is missing';
+  END IF;
+  IF to_regclass('public.replenishment_budgets') IS NULL
+     OR to_regclass('public.replenishment_proposals') IS NULL
+     OR to_regclass('public.replenishment_proposal_events') IS NULL
+     OR to_regclass('public.replenishment_proposal_idempotence') IS NULL
+     OR to_regprocedure('public.fn_replenishment_event_immutable()') IS NULL THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: target table or function is missing';
+  END IF;
 
-SELECT indexname
-FROM pg_indexes
-WHERE schemaname = 'public'
-  AND indexname IN (
-    'commande_fournisseur_replenishment_idx',
-    'replenishment_proposals_status_idx',
-    'replenishment_proposals_article_site_uniq',
-    'replenishment_proposals_article_unmapped_uniq'
-  )
-ORDER BY indexname;
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE (table_name || '.' || column_name) = ANY (ARRAY[
+           'replenishment_budgets.id','replenishment_budgets.magasin_id','replenishment_budgets.currency',
+           'replenishment_budgets.period_start','replenishment_budgets.period_end','replenishment_budgets.amount_limit',
+           'replenishment_budgets.active','replenishment_budgets.created_at','replenishment_budgets.updated_at',
+           'replenishment_budgets.created_by','replenishment_budgets.updated_by',
+           'replenishment_proposals.id','replenishment_proposals.stock_level_ids','replenishment_proposals.article_id',
+           'replenishment_proposals.magasin_id','replenishment_proposals.status','replenishment_proposals.version',
+           'replenishment_proposals.reason_code','replenishment_proposals.stock_unit','replenishment_proposals.qty_on_hand',
+           'replenishment_proposals.qty_reserved','replenishment_proposals.qty_available','replenishment_proposals.qty_open_orders',
+           'replenishment_proposals.minimum_stock_qty','replenishment_proposals.safety_stock_qty',
+           'replenishment_proposals.target_stock_qty','replenishment_proposals.net_requirement_qty',
+           'replenishment_proposals.selected_catalogue_id','replenishment_proposals.selected_supplier_id',
+           'replenishment_proposals.purchase_unit','replenishment_proposals.stock_units_per_purchase_unit',
+           'replenishment_proposals.proposed_purchase_qty','replenishment_proposals.proposed_stock_qty',
+           'replenishment_proposals.unit_price','replenishment_proposals.currency','replenishment_proposals.estimated_total',
+           'replenishment_proposals.budget_status','replenishment_proposals.budget_remaining',
+           'replenishment_proposals.missing_data','replenishment_proposals.warnings','replenishment_proposals.calculation',
+           'replenishment_proposals.commande_fournisseur_id','replenishment_proposals.commande_fournisseur_ligne_id',
+           'replenishment_proposals.generated_at','replenishment_proposals.last_recalculated_at',
+           'replenishment_proposals.validated_at','replenishment_proposals.validated_by',
+           'replenishment_proposals.resolution_reason','replenishment_proposals.created_at','replenishment_proposals.updated_at',
+           'replenishment_proposal_events.id','replenishment_proposal_events.proposal_id',
+           'replenishment_proposal_events.event_type','replenishment_proposal_events.from_status',
+           'replenishment_proposal_events.to_status','replenishment_proposal_events.calculation',
+           'replenishment_proposal_events.details','replenishment_proposal_events.actor_id',
+           'replenishment_proposal_events.created_at','replenishment_proposal_idempotence.id',
+           'replenishment_proposal_idempotence.actor_id','replenishment_proposal_idempotence.idempotency_key',
+           'replenishment_proposal_idempotence.request_hash','replenishment_proposal_idempotence.proposal_id',
+           'replenishment_proposal_idempotence.result','replenishment_proposal_idempotence.created_at'
+         ]))::integer
+    INTO actual_count, expected_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND table_name = ANY (ARRAY[
+      'replenishment_budgets','replenishment_proposals',
+      'replenishment_proposal_events','replenishment_proposal_idempotence'
+    ]);
+  IF actual_count <> 66 OR expected_count <> 66 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: target columns are incomplete or additional';
+  END IF;
 
-SELECT article_id, magasin_id, count(*) AS duplicate_count
-FROM public.replenishment_proposals
-GROUP BY article_id, magasin_id
-HAVING count(*) > 1;
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE
+           (table_name = 'stock_levels' AND column_name IN ('safety_stock_qty','target_stock_qty','order_lot_size')
+             AND data_type = 'numeric' AND numeric_precision = 18 AND numeric_scale = 3 AND is_nullable = 'YES')
+           OR (table_name = 'fournisseur_catalogue' AND column_name = 'unite_stock'
+             AND data_type = 'text' AND is_nullable = 'YES')
+           OR (table_name = 'fournisseur_catalogue' AND column_name = 'coef_conversion'
+             AND data_type = 'numeric' AND numeric_precision = 18 AND numeric_scale = 6 AND is_nullable = 'YES')
+           OR (table_name = 'fournisseur_catalogue' AND column_name = 'lot_achat'
+             AND data_type = 'numeric' AND numeric_precision = 18 AND numeric_scale = 3 AND is_nullable = 'YES')
+           OR (table_name = 'commande_fournisseur' AND column_name = 'replenishment_proposal_id'
+             AND data_type = 'uuid' AND is_nullable = 'YES'))::integer
+    INTO actual_count, expected_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public'
+    AND (
+      (table_name = 'stock_levels' AND column_name IN ('safety_stock_qty','target_stock_qty','order_lot_size'))
+      OR (table_name = 'fournisseur_catalogue' AND column_name IN ('unite_stock','coef_conversion','lot_achat'))
+      OR (table_name = 'commande_fournisseur' AND column_name = 'replenishment_proposal_id')
+    );
+  IF actual_count <> 7 OR expected_count <> 7 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: added columns have unexpected types or nullability';
+  END IF;
+  IF (SELECT udt_name FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'replenishment_proposals'
+        AND column_name = 'stock_level_ids') IS DISTINCT FROM '_uuid' THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: stock_level_ids is not uuid[]';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE conname = ANY (ARRAY[
+           'replenishment_budgets_pkey','replenishment_budgets_magasin_id_fkey',
+           'replenishment_budgets_values_chk','replenishment_budgets_scope_uniq',
+           'replenishment_proposals_pkey','replenishment_proposals_article_id_fkey',
+           'replenishment_proposals_magasin_id_fkey','replenishment_proposals_selected_catalogue_id_fkey',
+           'replenishment_proposals_selected_supplier_id_fkey',
+           'replenishment_proposals_commande_fournisseur_id_fkey',
+           'replenishment_proposals_commande_fournisseur_ligne_id_fkey',
+           'replenishment_proposals_status_chk','replenishment_proposals_budget_chk',
+           'replenishment_proposals_values_chk','replenishment_proposal_events_pkey',
+           'replenishment_proposal_events_proposal_id_fkey','replenishment_proposal_idempotence_pkey',
+           'replenishment_proposal_idempotence_proposal_id_fkey','replenishment_proposal_idem_uniq',
+           'replenishment_proposal_idem_key_chk','replenishment_proposal_idem_hash_chk'
+         ]) AND convalidated)::integer
+    INTO actual_count, expected_count
+  FROM pg_constraint
+  WHERE conrelid = ANY (ARRAY[
+    'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+    'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+  ]);
+  IF actual_count <> 21 OR expected_count <> 21 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: target constraints are incomplete, invalid, or additional';
+  END IF;
+  SELECT COUNT(*)::integer INTO actual_count FROM pg_constraint
+  WHERE conname = ANY (ARRAY[
+    'stock_levels_replenishment_qty_chk','fournisseur_catalogue_conversion_chk',
+    'commande_fournisseur_replenishment_fkey'
+  ]) AND convalidated;
+  IF actual_count <> 3 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: base-table constraints are missing or invalid';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE c.relname = ANY (ARRAY[
+           'replenishment_budgets_pkey','replenishment_budgets_scope_uniq',
+           'replenishment_proposals_pkey','replenishment_proposals_status_idx',
+           'replenishment_proposals_article_site_uniq','replenishment_proposals_article_unmapped_uniq',
+           'replenishment_proposal_events_pkey','replenishment_proposal_events_proposal_idx',
+           'replenishment_proposal_idempotence_pkey','replenishment_proposal_idem_uniq'
+         ]))::integer
+    INTO actual_count, expected_count
+  FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+  WHERE i.indrelid = ANY (ARRAY[
+    'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+    'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+  ]);
+  IF actual_count <> 10 OR expected_count <> 10 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: target indexes are incomplete or additional';
+  END IF;
+  SELECT COUNT(*)::integer INTO actual_count
+  FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+  WHERE i.indrelid = 'public.commande_fournisseur'::regclass
+    AND c.relname = 'commande_fournisseur_replenishment_idx'
+    AND NOT i.indisunique AND i.indpred IS NOT NULL;
+  IF actual_count <> 1 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: commande replenishment index is missing or altered';
+  END IF;
+  SELECT COUNT(*)::integer INTO actual_count
+  FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+  WHERE i.indrelid = 'public.replenishment_proposals'::regclass
+    AND c.relname IN ('replenishment_proposals_article_site_uniq','replenishment_proposals_article_unmapped_uniq')
+    AND i.indisunique AND i.indpred IS NOT NULL;
+  IF actual_count <> 2 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: article/site partial uniqueness is missing or altered';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE
+           (tgname = 'replenishment_proposal_events_immutable'
+             AND tgfoid = 'public.fn_replenishment_event_immutable()'::regprocedure)
+           OR (tgname IN ('replenishment_proposals_set_updated_at','replenishment_budgets_set_updated_at')
+             AND tgfoid = 'public.tg_set_updated_at()'::regprocedure))::integer
+    INTO actual_count, expected_count
+  FROM pg_trigger
+  WHERE NOT tgisinternal AND tgenabled = 'O'
+    AND tgrelid = ANY (ARRAY[
+      'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+      'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+    ]);
+  IF actual_count <> 3 OR expected_count <> 3 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: target triggers are incomplete, disabled, altered, or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO actual_count
+  FROM public.app_modules m, unnest(m.api_prefixes) AS prefix
+  WHERE m.module_key = 'commandes-fournisseurs' AND prefix = '/replenishment-proposals';
+  IF actual_count <> 1 THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: module prefix is missing or duplicated';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO actual_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname = 'public'
+    AND c.relname = ANY (ARRAY[
+      'replenishment_budgets','replenishment_proposals',
+      'replenishment_proposal_events','replenishment_proposal_idempotence'
+    ]) AND c.relowner = to_regrole('cerp_app');
+  IF actual_count <> 4 OR (
+    SELECT proowner FROM pg_proc
+    WHERE oid = 'public.fn_replenishment_event_immutable()'::regprocedure
+  ) IS DISTINCT FROM to_regrole('cerp_app') THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: runtime ownership is not cerp_app';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO actual_count
+  FROM pg_class c CROSS JOIN LATERAL aclexplode(COALESCE(c.relacl, acldefault('r', c.relowner))) acl
+  WHERE c.oid = ANY (ARRAY[
+    'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+    'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+  ]) AND acl.grantor = to_regrole('cerp_app') AND acl.grantee = to_regrole('cerp_app') AND NOT acl.is_grantable
+    AND ((c.relname IN ('replenishment_budgets','replenishment_proposals') AND acl.privilege_type IN ('SELECT','INSERT','UPDATE'))
+      OR (c.relname IN ('replenishment_proposal_events','replenishment_proposal_idempotence') AND acl.privilege_type IN ('SELECT','INSERT')));
+  IF actual_count <> 10 OR EXISTS (
+    SELECT 1 FROM pg_class c CROSS JOIN LATERAL aclexplode(COALESCE(c.relacl, acldefault('r', c.relowner))) acl
+    WHERE c.oid = ANY (ARRAY[
+      'public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,
+      'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass
+    ]) AND (acl.grantee <> to_regrole('cerp_app') OR acl.is_grantable
+      OR (c.relname IN ('replenishment_budgets','replenishment_proposals') AND acl.privilege_type NOT IN ('SELECT','INSERT','UPDATE'))
+      OR (c.relname IN ('replenishment_proposal_events','replenishment_proposal_idempotence') AND acl.privilege_type NOT IN ('SELECT','INSERT')))
+  ) THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: table ACL is not exact';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO actual_count
+  FROM pg_proc p CROSS JOIN LATERAL aclexplode(COALESCE(p.proacl, acldefault('f', p.proowner))) acl
+  WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure
+    AND acl.grantor = to_regrole('cerp_app') AND acl.grantee = to_regrole('cerp_app') AND acl.privilege_type = 'EXECUTE'
+    AND NOT acl.is_grantable;
+  IF actual_count <> 1 OR EXISTS (
+    SELECT 1 FROM pg_proc p CROSS JOIN LATERAL aclexplode(COALESCE(p.proacl, acldefault('f', p.proowner))) acl
+    WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure
+      AND (acl.grantee <> to_regrole('cerp_app') OR acl.privilege_type <> 'EXECUTE' OR acl.is_grantable)
+  ) THEN
+    RAISE EXCEPTION 'FEAT-CERP-0003 verify: function ACL is not exact';
+  END IF;
+
+  -- Refuse same-named replacements by comparing catalog-derived signatures for
+  -- every owned column, constraint, index, trigger, and function definition.
+  WITH expected(relname, signature) AS (VALUES
+    ('replenishment_budgets','528a64d4e7fa553f0f5d71f47ce80c00'),
+    ('replenishment_proposals','89d363177e4f65d5a58c7deb09b3ecf5'),
+    ('replenishment_proposal_events','bf8191942108d66226df3a844dbac83e'),
+    ('replenishment_proposal_idempotence','73073d375a6c673616a608d479a0085d')
+  ), actual AS (
+    SELECT c.relname, md5(string_agg(format('%s|%s|%s|%s|%s|%s', a.attnum, a.attname,
+      format_type(a.atttypid, a.atttypmod), a.attnotnull,
+      coalesce(pg_get_expr(d.adbin, d.adrelid), ''), a.attidentity), E'\n' ORDER BY a.attnum)) AS signature
+    FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+    JOIN pg_attribute a ON a.attrelid = c.oid
+    LEFT JOIN pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
+    WHERE n.nspname = 'public' AND c.relname IN (SELECT relname FROM expected)
+      AND a.attnum > 0 AND NOT a.attisdropped
+    GROUP BY c.relname
+  ) SELECT COUNT(*) INTO actual_count FROM expected e JOIN actual a USING (relname)
+      WHERE e.signature = a.signature;
+  IF actual_count <> 4 THEN RAISE EXCEPTION 'FEAT-CERP-0003 verify: full target column shape is altered'; END IF;
+
+  WITH expected(relname, signature) AS (VALUES
+    ('commande_fournisseur','ff186f775244f355e43241b53f7b1e11'),('fournisseur_catalogue','2cae272d52d3b409aea319cbeb8cb79d'),
+    ('replenishment_budgets','f9d2132bf7f6961c4218e49666b1ec7c'),('replenishment_proposal_events','d000474beb2f6b3fcaf815188e8ae575'),
+    ('replenishment_proposal_idempotence','3e1781cf5bf3d6c81c23576dfb83d0cf'),('replenishment_proposals','b51eb5fbdf7c26cf7b0e5c8b5a846042'),
+    ('stock_levels','471249431c3f1c61764259ab31e524a6')
+  ), actual AS (
+    SELECT conrelid::regclass::text AS relname, md5(string_agg(format('%s|%s|%s', conname, contype,
+      regexp_replace(pg_get_constraintdef(oid), '\s+', ' ', 'g')), E'\n' ORDER BY conname)) AS signature
+    FROM pg_constraint WHERE conname = ANY (ARRAY[
+      'stock_levels_replenishment_qty_chk','fournisseur_catalogue_conversion_chk','commande_fournisseur_replenishment_fkey',
+      'replenishment_budgets_pkey','replenishment_budgets_magasin_id_fkey','replenishment_budgets_values_chk','replenishment_budgets_scope_uniq',
+      'replenishment_proposals_pkey','replenishment_proposals_article_id_fkey','replenishment_proposals_magasin_id_fkey','replenishment_proposals_selected_catalogue_id_fkey','replenishment_proposals_selected_supplier_id_fkey','replenishment_proposals_commande_fournisseur_id_fkey','replenishment_proposals_commande_fournisseur_ligne_id_fkey','replenishment_proposals_status_chk','replenishment_proposals_budget_chk','replenishment_proposals_values_chk','replenishment_proposal_events_pkey','replenishment_proposal_events_proposal_id_fkey','replenishment_proposal_idempotence_pkey','replenishment_proposal_idempotence_proposal_id_fkey','replenishment_proposal_idem_uniq','replenishment_proposal_idem_key_chk','replenishment_proposal_idem_hash_chk'
+    ]) GROUP BY conrelid
+  ) SELECT COUNT(*) INTO actual_count FROM expected e JOIN actual a USING (relname) WHERE e.signature = a.signature;
+  IF actual_count <> 7 THEN RAISE EXCEPTION 'FEAT-CERP-0003 verify: owned constraint definition is altered'; END IF;
+
+  WITH expected(relname, signature) AS (VALUES
+    ('commande_fournisseur','b158333753277d57e9ecf7dd9df2c3fb'),('replenishment_budgets','e54643077ceba4240c065f3afdc69953'),
+    ('replenishment_proposal_events','a55096cdc9603c72780a71651fabc465'),('replenishment_proposal_idempotence','df3cda198e42959304c28f97261291c4'),
+    ('replenishment_proposals','793e25cd95c988147fe30ec37f0ab2ea')
+  ), actual AS (
+    SELECT i.indrelid::regclass::text AS relname, md5(string_agg(format('%s|%s|%s|%s|%s', c.relname, i.indisunique, i.indisprimary, i.indnkeyatts,
+      regexp_replace(pg_get_indexdef(i.indexrelid), '\s+', ' ', 'g')), E'\n' ORDER BY c.relname)) AS signature
+    FROM pg_index i JOIN pg_class c ON c.oid = i.indexrelid
+    WHERE c.relname = ANY (ARRAY['commande_fournisseur_replenishment_idx','replenishment_budgets_pkey','replenishment_budgets_scope_uniq','replenishment_proposals_pkey','replenishment_proposals_status_idx','replenishment_proposals_article_site_uniq','replenishment_proposals_article_unmapped_uniq','replenishment_proposal_events_pkey','replenishment_proposal_events_proposal_idx','replenishment_proposal_idempotence_pkey','replenishment_proposal_idem_uniq'])
+    GROUP BY i.indrelid
+  ) SELECT COUNT(*) INTO actual_count FROM expected e JOIN actual a USING (relname) WHERE e.signature = a.signature;
+  IF actual_count <> 5 THEN RAISE EXCEPTION 'FEAT-CERP-0003 verify: owned index definition is altered'; END IF;
+
+  SELECT md5(string_agg(format('%s|%s|%s|%s|%s', tgname, tgtype, tgenabled, tgfoid::regprocedure, encode(tgargs, 'escape')), E'\n' ORDER BY tgname))
+    INTO registered_sha256 FROM pg_trigger WHERE NOT tgisinternal AND tgrelid = ANY (ARRAY['public.replenishment_budgets'::regclass,'public.replenishment_proposals'::regclass,'public.replenishment_proposal_events'::regclass,'public.replenishment_proposal_idempotence'::regclass]);
+  IF registered_sha256 IS DISTINCT FROM '7e574b34d6c795630b9c08be2d6aded2' THEN RAISE EXCEPTION 'FEAT-CERP-0003 verify: owned trigger mapping/event is altered'; END IF;
+  SELECT md5(format('%s|%s|%s|%s|%s|%s', pg_get_functiondef(p.oid), p.provolatile, p.proisstrict, p.prosecdef, p.proleakproof, coalesce(array_to_string(p.proconfig, E'\n'), '')))
+    INTO registered_sha256 FROM pg_proc p WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure;
+  IF registered_sha256 IS DISTINCT FROM '0e1298dced0e423190dfa3dc059ab371' THEN RAISE EXCEPTION 'FEAT-CERP-0003 verify: immutable function definition/settings are altered'; END IF;
+END
+$verify$;
+
+SELECT current_database() AS database_name,
+       (SELECT sha256 FROM public.cerp_schema_migrations
+        WHERE filename = '20260805_replenishment_proposals.sql') AS migration_sha256,
+       'FEAT-CERP-0003 verification passed (read-only)' AS result;
+
+ROLLBACK;

--- a/db/patches/support/20260805_replenishment_proposals.verify.sql
+++ b/db/patches/support/20260805_replenishment_proposals.verify.sql
@@ -4,11 +4,15 @@ SELECT
   to_regclass('public.replenishment_proposal_idempotence') IS NOT NULL AS has_idempotence,
   to_regclass('public.replenishment_budgets') IS NOT NULL AS has_budgets;
 
+SELECT module_key, '/replenishment-proposals' = ANY(api_prefixes) AS has_replenishment_prefix
+FROM public.app_modules
+WHERE module_key = 'commandes-fournisseurs';
+
 SELECT conname, convalidated
 FROM pg_constraint
 WHERE conname IN (
-  'replenishment_proposals_stock_level_uniq',
   'replenishment_proposals_status_chk',
+  'replenishment_proposals_values_chk',
   'commande_fournisseur_replenishment_fkey'
 )
 ORDER BY conname;
@@ -19,6 +23,12 @@ WHERE schemaname = 'public'
   AND indexname IN (
     'commande_fournisseur_replenishment_idx',
     'replenishment_proposals_status_idx',
-    'replenishment_proposals_article_site_idx'
+    'replenishment_proposals_article_site_uniq',
+    'replenishment_proposals_article_unmapped_uniq'
   )
 ORDER BY indexname;
+
+SELECT article_id, magasin_id, count(*) AS duplicate_count
+FROM public.replenishment_proposals
+GROUP BY article_id, magasin_id
+HAVING count(*) > 1;

--- a/db/patches/support/20260805_replenishment_proposals.verify.sql
+++ b/db/patches/support/20260805_replenishment_proposals.verify.sql
@@ -1,0 +1,24 @@
+SELECT
+  to_regclass('public.replenishment_proposals') IS NOT NULL AS has_proposals,
+  to_regclass('public.replenishment_proposal_events') IS NOT NULL AS has_events,
+  to_regclass('public.replenishment_proposal_idempotence') IS NOT NULL AS has_idempotence,
+  to_regclass('public.replenishment_budgets') IS NOT NULL AS has_budgets;
+
+SELECT conname, convalidated
+FROM pg_constraint
+WHERE conname IN (
+  'replenishment_proposals_stock_level_uniq',
+  'replenishment_proposals_status_chk',
+  'commande_fournisseur_replenishment_fkey'
+)
+ORDER BY conname;
+
+SELECT indexname
+FROM pg_indexes
+WHERE schemaname = 'public'
+  AND indexname IN (
+    'commande_fournisseur_replenishment_idx',
+    'replenishment_proposals_status_idx',
+    'replenishment_proposals_article_site_idx'
+  )
+ORDER BY indexname;

--- a/src/__tests__/access-control.gate.test.ts
+++ b/src/__tests__/access-control.gate.test.ts
@@ -397,3 +397,25 @@ describe("Gate d'accès module — application réelle", () => {
     expect(repo.repoResolveAccessProfile).not.toHaveBeenCalled();
   });
 });
+
+describe("Gate d'accès module — propositions de réapprovisionnement", () => {
+  it("rattache le préfixe au module commandes-fournisseurs et applique son refus", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "commandes-fournisseurs", access: "DENIED" }),
+    ]);
+    const { res, next } = await run("/replenishment-proposals/refresh");
+    expect(repo.repoResolveAccessProfile).toHaveBeenCalledOnce();
+    expect(res.statusCode).toBe(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("installe le contexte du module commandes-fournisseurs quand le compte est autorisé", async () => {
+    repo.repoResolveAccessProfile.mockResolvedValue([
+      profileRow({ module_key: "commandes-fournisseurs", access: "GRANTED" }),
+    ]);
+    const { res, next, accountPolicyInstalled } = await run("/replenishment-proposals");
+    expect(res.statusCode).toBe(0);
+    expect(next).toHaveBeenCalledOnce();
+    expect(accountPolicyInstalled).toBe(true);
+  });
+});

--- a/src/__tests__/access-control.test.ts
+++ b/src/__tests__/access-control.test.ts
@@ -185,6 +185,7 @@ describe("Catalogue de modules #326", () => {
     // « /commandes » ne doit jamais capter « /commandes-fournisseurs ».
     expect(resolveModuleKeyForPath("/commandes/17")).toBe("commandes-clients");
     expect(resolveModuleKeyForPath("/commandes-fournisseurs/17")).toBe("commandes-fournisseurs");
+    expect(resolveModuleKeyForPath("/replenishment-proposals/17/validate")).toBe("commandes-fournisseurs");
     expect(resolveModuleKeyForPath("/piece-technique-versions/9")).toBe("pieces-techniques");
     expect(resolveModuleKeyForPath("/pieces-techniques/9")).toBe("pieces-techniques");
     expect(resolveModuleKeyForPath("/finitions/9")).toBe("finitions");

--- a/src/__tests__/commande-fournisseur.routes.test.ts
+++ b/src/__tests__/commande-fournisseur.routes.test.ts
@@ -89,6 +89,7 @@ function dispatch(sqlRaw: unknown): { rows: unknown[]; rowCount?: number } {
   if (/FROM public\.fournisseurs WHERE id/.test(sql)) return { rows: [state.fournisseur] };
   if (/FROM public\.fournisseur_adresses/.test(sql)) return { rows: [] };
   if (/UPDATE public\.commande_fournisseur_document/.test(sql)) return { rows: [], rowCount: 0 };
+  if (/UPDATE public\.commande_fournisseur_ligne_besoin besoin/.test(sql)) return { rows: [], rowCount: 1 };
   if (/UPDATE public\.commande_fournisseur/.test(sql)) return { rows: [], rowCount: 1 };
   if (/erp_audit_logs/i.test(sql)) return { rows: [{ id: 99 }] };
   if (/pg_notify/i.test(sql)) return { rows: [] };
@@ -291,6 +292,10 @@ describe("/api/v1/commandes-fournisseurs — machine d'état", () => {
       .send({ to: "ANNULEE", motif: "Erreur de saisie fournisseur" });
     expect(avec.status).toBe(200);
     expect(avec.body.statut).toBe("ANNULEE");
+    expect(mocks.clientQuery).toHaveBeenCalledWith(
+      expect.stringMatching(/UPDATE public\.commande_fournisseur_ligne_besoin besoin[\s\S]*SET annule = true/),
+      [UUID]
+    );
   });
 
   it("annulation impossible si des quantités sont déjà reçues → 422", async () => {
@@ -360,5 +365,45 @@ describe("/api/v1/commandes-fournisseurs — totaux serveur", () => {
       });
     expect(res.status).toBe(200);
     expect(res.body).toMatchObject({ total_ht: 205, total_remise: 20, total_tva: 41, total_ttc: 246 });
+  });
+});
+
+describe("/api/v1/replenishment-proposals — RBAC achat et prix", () => {
+  it("refuse la lecture à un rôle lecteur achat sans droit prix", async () => {
+    const res = await request(app)
+      .get("/api/v1/replenishment-proposals")
+      .set("x-test-role", "Responsable Qualité");
+    expect(res.status).toBe(403);
+  });
+
+  it("autorise lecture et recalcul au Responsable Programmation", async () => {
+    const read = await request(app)
+      .get("/api/v1/replenishment-proposals")
+      .set("x-test-role", "Responsable Programmation");
+    expect(read.status).toBe(200);
+    expect(read.body).toEqual([]);
+
+    const refresh = await request(app)
+      .post("/api/v1/replenishment-proposals/refresh")
+      .set("x-test-role", "Responsable Programmation")
+      .send({ limit: 10 });
+    expect(refresh.status).toBe(200);
+    expect(refresh.body).toMatchObject({ items: [], refreshed: 0, resolved: 0 });
+  });
+
+  it("refuse la validation sans droit de création et atteint le métier quand elle est autorisée", async () => {
+    const body = { catalogue_id: UUID, expected_version: 1, idempotency_key: "replenishment-rbac-01" };
+    const denied = await request(app)
+      .post(`/api/v1/replenishment-proposals/${UUID}/validate`)
+      .set("x-test-role", "Comptable")
+      .send(body);
+    expect(denied.status).toBe(403);
+
+    const allowed = await request(app)
+      .post(`/api/v1/replenishment-proposals/${UUID}/validate`)
+      .set("x-test-role", "Responsable Programmation")
+      .send(body);
+    expect(allowed.status).toBe(404);
+    expect(allowed.body.code).toBe("REPLENISHMENT_PROPOSAL_NOT_FOUND");
   });
 });

--- a/src/__tests__/replenishment-proposals.domain.test.ts
+++ b/src/__tests__/replenishment-proposals.domain.test.ts
@@ -1,8 +1,10 @@
+import { createHash } from "node:crypto"
 import fs from "node:fs"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 
 import {
+  allocateCoverage,
   calculateReplenishment,
   convertOpenOrderRemainderToStock,
 } from "../module/commande-fournisseur/domain/replenishment-calculation"
@@ -92,6 +94,28 @@ describe("FEAT-CERP-0003 replenishment calculation", () => {
     expect(calculateReplenishment({ ...base, qty_open_orders: 0, open_order_conversion_missing: true }).missing_data)
       .toContain("OPEN_ORDER_UNIT_CONVERSION")
   })
+
+  it("allocates coverage in exact positive milliunits without manufacturing quantity", () => {
+    const levels = ["level-a", "level-b", "level-c"]
+
+    expect(allocateCoverage(0.001, levels)).toEqual([
+      { stock_level_id: "level-a", quantity: 0.001 },
+    ])
+    expect(allocateCoverage(0.002, levels)).toEqual([
+      { stock_level_id: "level-a", quantity: 0.001 },
+      { stock_level_id: "level-b", quantity: 0.001 },
+    ])
+
+    const split = allocateCoverage(0.005, levels.slice(0, 2))
+    expect(split).toEqual([
+      { stock_level_id: "level-a", quantity: 0.003 },
+      { stock_level_id: "level-b", quantity: 0.002 },
+    ])
+    expect(Math.round(split.reduce((sum, item) => sum + item.quantity, 0) * 1000)).toBe(5)
+    expect(split.every((item) => item.quantity > 0)).toBe(true)
+    expect(allocateCoverage(0.0004, levels)).toEqual([])
+    expect(allocateCoverage(10, [])).toEqual([])
+  })
 })
 
 describe("FEAT-CERP-0003 boundaries", () => {
@@ -105,13 +129,36 @@ describe("FEAT-CERP-0003 boundaries", () => {
 
   it("migration carries deduplication, append-only audit, order linkage and guarded rollback", () => {
     const migration = fs.readFileSync(path.resolve("db/patches/20260805_replenishment_proposals.sql"), "utf8")
+    const preflight = fs.readFileSync(path.resolve("db/patches/support/20260805_replenishment_proposals.preflight.sql"), "utf8")
+    const verify = fs.readFileSync(path.resolve("db/patches/support/20260805_replenishment_proposals.verify.sql"), "utf8")
     const rollback = fs.readFileSync(path.resolve("db/patches/support/20260805_replenishment_proposals.rollback.sql"), "utf8")
+    const canonicalSha256 = createHash("sha256")
+      .update(migration.replace(/\r\n?/g, "\n"), "utf8")
+      .digest("hex")
+
     expect(migration).toMatch(/replenishment_proposals_article_site_uniq/)
     expect(migration).toMatch(/replenishment_proposals_article_unmapped_uniq/)
     expect(migration).toMatch(/stock_level_ids uuid\[\] NOT NULL/)
     expect(migration).toMatch(/replenishment_proposal_events_immutable/)
     expect(migration).toMatch(/commande_fournisseur_replenishment_idx/)
     expect(migration).toMatch(/UNIQUE \(actor_id, idempotency_key\)/)
+    expect(migration).not.toMatch(/\b(?:CREATE TABLE|CREATE INDEX|ADD COLUMN)\s+IF NOT EXISTS/i)
+    expect(migration).not.toMatch(/CREATE\s+OR\s+REPLACE/i)
+    for (const lifecycleScript of [preflight, verify, rollback]) {
+      expect(lifecycleScript).toContain(canonicalSha256)
+      expect(lifecycleScript).toMatch(/cerp_schema_migrations/)
+      expect(lifecycleScript).toMatch(/full target column shape is altered/)
+      expect(lifecycleScript).toMatch(/owned constraint definition is altered/)
+      expect(lifecycleScript).toMatch(/owned index definition is altered/)
+      expect(lifecycleScript).toMatch(/owned trigger mapping\/event is altered/)
+      expect(lifecycleScript).toMatch(/immutable function definition\/settings are altered/)
+    }
+    expect(preflight).toMatch(/BEGIN TRANSACTION READ ONLY/)
+    expect(preflight).toMatch(/target artifact exists without migration ledger provenance/)
+    expect(preflight).toMatch(/aclexplode/)
+    expect(verify).toMatch(/BEGIN TRANSACTION READ ONLY/)
+    expect(verify).toMatch(/module prefix is missing or duplicated/)
+    expect(verify).toMatch(/aclexplode/)
     const repository = fs.readFileSync(path.resolve("src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts"), "utf8")
     expect(repository).toMatch(/BEGIN ISOLATION LEVEL SERIALIZABLE/)
     expect(repository).toMatch(/FOR UPDATE OF p/)
@@ -120,8 +167,11 @@ describe("FEAT-CERP-0003 boundaries", () => {
     expect(repository).toMatch(/array_agg\(id::text ORDER BY id::text\) AS stock_level_ids/)
     expect(repository).toMatch(/GROUP BY article_id, magasin_id/)
     expect(repository).toMatch(/ON CONFLICT \$\{conflictTarget\}/)
-    expect(rollback).toMatch(/restricted to cerp_test/)
-    expect(rollback).toMatch(/Rollback refused/)
+    expect(rollback).toMatch(/restricted to cerp_dev\/cerp_test/)
+    expect(rollback).toMatch(/pg_advisory_xact_lock/)
+    expect(rollback).toMatch(/replenishment evidence or governed values exist/)
+    expect(rollback).toMatch(/exact migration ledger row was not removed/)
+    expect(rollback).not.toMatch(/DROP\s+(?:TABLE|INDEX|COLUMN|FUNCTION|TRIGGER)[\s\S]{0,80}\bIF EXISTS\b/i)
   })
 
   it("releases STOCK_LEVEL coverage transactionally for replacement while keeping active 23505 protection", () => {

--- a/src/__tests__/replenishment-proposals.domain.test.ts
+++ b/src/__tests__/replenishment-proposals.domain.test.ts
@@ -1,0 +1,82 @@
+import fs from "node:fs"
+import path from "node:path"
+import { describe, expect, it } from "vitest"
+
+import { calculateReplenishment } from "../module/commande-fournisseur/domain/replenishment-calculation"
+import { validateReplenishmentProposalSchema } from "../module/commande-fournisseur/validators/replenishment-proposal.validators"
+
+const UUID = "3b9f2a44-6d3e-4f7a-9c2d-1e5b8a7c6d90"
+const base = {
+  qty_on_hand: 4,
+  qty_reserved: 1,
+  qty_available: 3,
+  qty_open_orders: 2,
+  minimum_stock_qty: 8,
+  safety_stock_qty: 2,
+  target_stock_qty: null,
+  reorder_qty: null,
+  stock_unit: "kg",
+  purchase_unit: "barre",
+  stock_units_per_purchase_unit: 2.5,
+  supplier_moq: 3,
+  purchase_lot_size: 2,
+  unit_price: 10,
+}
+
+describe("FEAT-CERP-0003 replenishment calculation", () => {
+  it("subtracts available stock and open orders, then applies MOQ, conversion and lot rounding", () => {
+    const result = calculateReplenishment(base)
+    expect(result.target_stock_qty).toBe(10)
+    expect(result.gross_requirement_qty).toBe(7)
+    expect(result.net_requirement_qty).toBe(5)
+    expect(result.proposed_purchase_qty).toBe(4)
+    expect(result.proposed_stock_qty).toBe(10)
+    expect(result.estimated_total).toBe(40)
+    expect(result.warnings).toContain("MOQ_APPLIED")
+    expect(result.warnings).toContain("PURCHASE_LOT_ROUNDED")
+  })
+
+  it("a receipt replacing incoming quantity with available stock does not recreate a need", () => {
+    const before = calculateReplenishment(base)
+    const after = calculateReplenishment({ ...base, qty_on_hand: 6, qty_available: 5, qty_open_orders: 0 })
+    expect(before.net_requirement_qty).toBe(after.net_requirement_qty)
+  })
+
+  it("an open order can resolve the proposal and missing thresholds remain explicit", () => {
+    expect(calculateReplenishment({ ...base, qty_open_orders: 20 }).reason_code).toBe("COUVERT")
+    const incomplete = calculateReplenishment({ ...base, minimum_stock_qty: null, safety_stock_qty: null })
+    expect(incomplete.reason_code).toBe("SEUIL_MANQUANT")
+    expect(incomplete.missing_data).toContain("MINIMUM_STOCK")
+    expect(incomplete.warnings).toContain("SAFETY_STOCK_MISSING")
+  })
+
+  it("blocks an ungoverned unit conversion", () => {
+    const result = calculateReplenishment({ ...base, stock_units_per_purchase_unit: null })
+    expect(result.proposed_purchase_qty).toBeNull()
+    expect(result.missing_data).toContain("UNIT_CONVERSION")
+  })
+})
+
+describe("FEAT-CERP-0003 boundaries", () => {
+  it("requires optimistic version, supplier catalogue and idempotency key", () => {
+    expect(validateReplenishmentProposalSchema.safeParse({
+      params: { id: UUID },
+      body: { catalogue_id: UUID, expected_version: 1, idempotency_key: "validate-0001" },
+    }).success).toBe(true)
+    expect(validateReplenishmentProposalSchema.safeParse({ params: { id: UUID }, body: { catalogue_id: UUID } }).success).toBe(false)
+  })
+
+  it("migration carries deduplication, append-only audit, order linkage and guarded rollback", () => {
+    const migration = fs.readFileSync(path.resolve("db/patches/20260805_replenishment_proposals.sql"), "utf8")
+    const rollback = fs.readFileSync(path.resolve("db/patches/support/20260805_replenishment_proposals.rollback.sql"), "utf8")
+    expect(migration).toMatch(/UNIQUE \(stock_level_id\)/)
+    expect(migration).toMatch(/replenishment_proposal_events_immutable/)
+    expect(migration).toMatch(/commande_fournisseur_replenishment_idx/)
+    expect(migration).toMatch(/UNIQUE \(actor_id, idempotency_key\)/)
+    const repository = fs.readFileSync(path.resolve("src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts"), "utf8")
+    expect(repository).toMatch(/BEGIN ISOLATION LEVEL SERIALIZABLE/)
+    expect(repository).toMatch(/FOR UPDATE OF p/)
+    expect(rollback).toMatch(/restricted to cerp_test/)
+    expect(rollback).toMatch(/Rollback refused/)
+  })
+})

--- a/src/__tests__/replenishment-proposals.domain.test.ts
+++ b/src/__tests__/replenishment-proposals.domain.test.ts
@@ -2,7 +2,10 @@ import fs from "node:fs"
 import path from "node:path"
 import { describe, expect, it } from "vitest"
 
-import { calculateReplenishment } from "../module/commande-fournisseur/domain/replenishment-calculation"
+import {
+  calculateReplenishment,
+  convertOpenOrderRemainderToStock,
+} from "../module/commande-fournisseur/domain/replenishment-calculation"
 import { validateReplenishmentProposalSchema } from "../module/commande-fournisseur/validators/replenishment-proposal.validators"
 
 const UUID = "3b9f2a44-6d3e-4f7a-9c2d-1e5b8a7c6d90"
@@ -55,6 +58,40 @@ describe("FEAT-CERP-0003 replenishment calculation", () => {
     expect(result.proposed_purchase_qty).toBeNull()
     expect(result.missing_data).toContain("UNIT_CONVERSION")
   })
+
+  it("converts every open-order remainder from purchase units to stock units", () => {
+    expect(convertOpenOrderRemainderToStock({
+      ordered_purchase_qty: 2,
+      cancelled_purchase_qty: 0,
+      received_purchase_qty: 0,
+      purchase_unit: "barre",
+      stock_unit: "kg",
+      stock_units_per_purchase_unit: 2.5,
+    })).toMatchObject({ remaining_purchase_qty: 2, remaining_stock_qty: 5, coefficient: 2.5, conversion_missing: false })
+
+    expect(convertOpenOrderRemainderToStock({
+      ordered_purchase_qty: 2,
+      cancelled_purchase_qty: 0.25,
+      received_purchase_qty: 0.5,
+      purchase_unit: "barre",
+      stock_unit: "kg",
+      stock_units_per_purchase_unit: 2.5,
+    }).remaining_stock_qty).toBe(3.125)
+  })
+
+  it("blocks an historical open remainder whose purchase-to-stock conversion is absent", () => {
+    const remainder = convertOpenOrderRemainderToStock({
+      ordered_purchase_qty: 2,
+      cancelled_purchase_qty: 0,
+      received_purchase_qty: 0,
+      purchase_unit: "barre",
+      stock_unit: "kg",
+      stock_units_per_purchase_unit: null,
+    })
+    expect(remainder).toMatchObject({ remaining_stock_qty: 0, conversion_missing: true })
+    expect(calculateReplenishment({ ...base, qty_open_orders: 0, open_order_conversion_missing: true }).missing_data)
+      .toContain("OPEN_ORDER_UNIT_CONVERSION")
+  })
 })
 
 describe("FEAT-CERP-0003 boundaries", () => {
@@ -69,14 +106,30 @@ describe("FEAT-CERP-0003 boundaries", () => {
   it("migration carries deduplication, append-only audit, order linkage and guarded rollback", () => {
     const migration = fs.readFileSync(path.resolve("db/patches/20260805_replenishment_proposals.sql"), "utf8")
     const rollback = fs.readFileSync(path.resolve("db/patches/support/20260805_replenishment_proposals.rollback.sql"), "utf8")
-    expect(migration).toMatch(/UNIQUE \(stock_level_id\)/)
+    expect(migration).toMatch(/replenishment_proposals_article_site_uniq/)
+    expect(migration).toMatch(/replenishment_proposals_article_unmapped_uniq/)
+    expect(migration).toMatch(/stock_level_ids uuid\[\] NOT NULL/)
     expect(migration).toMatch(/replenishment_proposal_events_immutable/)
     expect(migration).toMatch(/commande_fournisseur_replenishment_idx/)
     expect(migration).toMatch(/UNIQUE \(actor_id, idempotency_key\)/)
     const repository = fs.readFileSync(path.resolve("src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts"), "utf8")
     expect(repository).toMatch(/BEGIN ISOLATION LEVEL SERIALIZABLE/)
     expect(repository).toMatch(/FOR UPDATE OF p/)
+    expect(repository).toMatch(/remaining_purchase_qty \* open_line\.stock_units_per_purchase_unit/)
+    expect(repository).toMatch(/open_order_conversion_missing/)
+    expect(repository).toMatch(/array_agg\(id::text ORDER BY id::text\) AS stock_level_ids/)
+    expect(repository).toMatch(/GROUP BY article_id, magasin_id/)
+    expect(repository).toMatch(/ON CONFLICT \$\{conflictTarget\}/)
     expect(rollback).toMatch(/restricted to cerp_test/)
     expect(rollback).toMatch(/Rollback refused/)
+  })
+
+  it("releases STOCK_LEVEL coverage transactionally for replacement while keeping active 23505 protection", () => {
+    const orderRepository = fs.readFileSync(path.resolve("src/module/commande-fournisseur/repository/commande-fournisseur.repository.ts"), "utf8")
+    const replenishmentRepository = fs.readFileSync(path.resolve("src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts"), "utf8")
+    expect(orderRepository).toMatch(/kind === "cancel"[\s\S]*UPDATE public\.commande_fournisseur_ligne_besoin besoin[\s\S]*SET annule = true/)
+    expect(orderRepository.indexOf("SET annule = true")).toBeLessThan(orderRepository.indexOf('client.query("COMMIT")', orderRepository.indexOf("SET annule = true")))
+    expect(replenishmentRepository).toMatch(/INSERT INTO public\.commande_fournisseur_ligne_besoin/)
+    expect(replenishmentRepository).toMatch(/code === "23505"[\s\S]*REPLENISHMENT_ALREADY_CONVERTED/)
   })
 })

--- a/src/__tests__/replenishment-proposals.repository.test.ts
+++ b/src/__tests__/replenishment-proposals.repository.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const mocks = vi.hoisted(() => ({
+  poolConnect: vi.fn(),
+  clientQuery: vi.fn(),
+  clientRelease: vi.fn(),
+  generateCode: vi.fn(),
+  insertAudit: vi.fn(),
+}))
+
+vi.mock("../config/database", () => ({
+  default: { connect: mocks.poolConnect, query: vi.fn() },
+}))
+
+vi.mock("../shared/codes/code-generator.service", () => ({
+  generateCommandeFournisseurCode: mocks.generateCode,
+}))
+
+vi.mock("../module/audit-logs/repository/audit-logs.repository", () => ({
+  repoInsertAuditLog: mocks.insertAudit,
+}))
+
+import { repoValidateReplenishmentProposal } from "../module/commande-fournisseur/repository/replenishment-proposal.repository"
+
+const PROPOSAL_ID = "11111111-1111-4111-8111-111111111111"
+const ARTICLE_ID = "22222222-2222-4222-8222-222222222222"
+const STOCK_LEVEL_ID = "33333333-3333-4333-8333-333333333333"
+const MAGASIN_ID = "44444444-4444-4444-8444-444444444444"
+const CATALOGUE_ID = "55555555-5555-4555-8555-555555555555"
+const SUPPLIER_ID = "66666666-6666-4666-8666-666666666666"
+const CANCELLED_ORDER_ID = "77777777-7777-4777-8777-777777777777"
+const NEW_ORDER_ID = "88888888-8888-4888-8888-888888888888"
+const NEW_LINE_ID = "99999999-9999-4999-8999-999999999999"
+
+const audit = {
+  user_id: 42,
+  ip: "127.0.0.1",
+  user_agent: "vitest",
+  device_type: null,
+  os: null,
+  browser: null,
+  path: `/api/v1/replenishment-proposals/${PROPOSAL_ID}/validate`,
+  page_key: "commandes-fournisseurs",
+  client_session_id: "replenishment-test",
+}
+
+let activeCoverageConflict = false
+
+function dispatch(sqlRaw: unknown, values?: unknown[]) {
+  const sql = String(sqlRaw)
+  if (sql.includes("FROM public.replenishment_proposal_idempotence")) return { rows: [], rowCount: 0 }
+  if (sql.includes("FROM public.replenishment_proposals p") && sql.includes("FOR UPDATE OF p")) {
+    return {
+      rows: [{
+        id: PROPOSAL_ID,
+        version: 1,
+        status: "CONVERTIE",
+        article_id: ARTICLE_ID,
+        magasin_id: MAGASIN_ID,
+        stock_level_ids: [STOCK_LEVEL_ID],
+        commande_fournisseur_id: CANCELLED_ORDER_ID,
+        commande_code: "BCF-2026-0001",
+        commande_statut: "ANNULEE",
+      }],
+      rowCount: 1,
+    }
+  }
+  if (sql.includes("SELECT id FROM public.stock_levels") && sql.includes("FOR UPDATE")) {
+    return { rows: [{ id: STOCK_LEVEL_ID }], rowCount: 1 }
+  }
+  if (sql.includes("WITH stock_rows AS")) {
+    return {
+      rows: [{
+        stock_level_ids: [STOCK_LEVEL_ID],
+        stock_level_count: 1,
+        article_id: ARTICLE_ID,
+        article_code: "ART-TEST-000001",
+        article_designation: "Article agrégé",
+        stock_unit: "u",
+        magasin_id: MAGASIN_ID,
+        magasin_name: "Site test",
+        qty_on_hand: 0,
+        qty_reserved: 0,
+        qty_available: 0,
+        qty_open_orders: 0,
+        open_order_conversion_missing: false,
+        stock_unit_conflict: false,
+        min_qty: 10,
+        safety_stock_qty: 0,
+        target_stock_qty: 10,
+        reorder_qty: null,
+        order_lot_size: 1,
+        preferred_catalogue_id: CATALOGUE_ID,
+        preferred_supplier_id: SUPPLIER_ID,
+      }],
+      rowCount: 1,
+    }
+  }
+  if (sql.includes("FROM public.fournisseur_catalogue")) {
+    return {
+      rows: [{
+        catalogue_id: CATALOGUE_ID,
+        supplier_id: SUPPLIER_ID,
+        supplier_code: "FOU-001",
+        supplier_name: "Fournisseur test",
+        purchase_unit: "u",
+        stock_unit: "u",
+        stock_units_per_purchase_unit: null,
+        moq: 1,
+        purchase_lot_size: 1,
+        lead_time_days: 2,
+        catalogue_price: 2,
+        currency: "EUR",
+        last_order_unit_price: null,
+        last_order_date: null,
+        preferred: true,
+      }],
+      rowCount: 1,
+    }
+  }
+  if (sql.includes("FROM public.replenishment_budgets")) {
+    return { rows: [{ amount_limit: 100, committed: 0 }], rowCount: 1 }
+  }
+  if (sql.includes("INSERT INTO public.commande_fournisseur_ligne_besoin")) {
+    if (activeCoverageConflict) throw Object.assign(new Error("active coverage already exists"), { code: "23505" })
+    return { rows: [], rowCount: 1 }
+  }
+  if (sql.includes("INSERT INTO public.commande_fournisseur_ligne") && !sql.includes("ligne_besoin")) {
+    return { rows: [{ id: NEW_LINE_ID }], rowCount: 1 }
+  }
+  if (sql.includes("INSERT INTO public.commande_fournisseur") && !sql.includes("_ligne")) {
+    return { rows: [{ id: NEW_ORDER_ID }], rowCount: 1 }
+  }
+  if (sql.includes("INSERT INTO public.replenishment_proposal_idempotence")) {
+    expect(values?.[3]).toBe(PROPOSAL_ID)
+  }
+  return { rows: [], rowCount: 0 }
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  activeCoverageConflict = false
+  mocks.poolConnect.mockResolvedValue({ query: mocks.clientQuery, release: mocks.clientRelease })
+  mocks.generateCode.mockResolvedValue("BCF-2026-0002")
+  mocks.insertAudit.mockResolvedValue(undefined)
+  mocks.clientQuery.mockImplementation(dispatch)
+})
+
+describe("repoValidateReplenishmentProposal — remplacement après annulation", () => {
+  const body = {
+    catalogue_id: CATALOGUE_ID,
+    expected_version: 1,
+    idempotency_key: "replenishment-replacement-1",
+  }
+
+  it("traduit le conflit 23505 d'une couverture encore active en conflit métier", async () => {
+    activeCoverageConflict = true
+
+    await expect(repoValidateReplenishmentProposal(PROPOSAL_ID, body, audit)).rejects.toMatchObject({
+      status: 409,
+      code: "REPLENISHMENT_ALREADY_CONVERTED",
+    })
+
+    expect(mocks.clientQuery).toHaveBeenCalledWith("ROLLBACK")
+    expect(mocks.clientQuery).not.toHaveBeenCalledWith("COMMIT")
+  })
+
+  it("crée un nouveau brouillon lorsque la couverture de la commande annulée a été libérée", async () => {
+    await expect(repoValidateReplenishmentProposal(PROPOSAL_ID, body, audit)).resolves.toMatchObject({
+      converted: true,
+      commande_fournisseur_id: NEW_ORDER_ID,
+      code: "BCF-2026-0002",
+      status: "BROUILLON",
+      idempotent_replay: false,
+    })
+
+    expect(mocks.clientQuery).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO public.commande_fournisseur_ligne_besoin"),
+      [NEW_LINE_ID, STOCK_LEVEL_ID, 10],
+    )
+    expect(mocks.clientQuery).toHaveBeenCalledWith("COMMIT")
+    expect(mocks.clientQuery).not.toHaveBeenCalledWith("ROLLBACK")
+  })
+})

--- a/src/module/access-control/domain/module-catalog.ts
+++ b/src/module/access-control/domain/module-catalog.ts
@@ -100,7 +100,7 @@ export const MODULE_CATALOG: readonly ModuleCatalogEntry[] = [
     label: "Commandes fournisseurs",
     description: "Bons de commande fournisseurs et suivi des accusés.",
     category: "Achats",
-    api_prefixes: ["/commandes-fournisseurs"],
+    api_prefixes: ["/commandes-fournisseurs", "/replenishment-proposals"],
     nav_page_keys: ["commandes-fournisseurs"],
     is_protected: false,
     sort_order: 90,

--- a/src/module/commande-fournisseur/controllers/replenishment-proposal.controller.ts
+++ b/src/module/commande-fournisseur/controllers/replenishment-proposal.controller.ts
@@ -1,0 +1,52 @@
+import type { Request, RequestHandler } from "express"
+
+import { HttpError } from "../../../utils/httpError"
+import type { AuditContext } from "../repository/commande-fournisseur.repository"
+import {
+  listReplenishmentProposalsSVC,
+  refreshReplenishmentProposalsSVC,
+  validateReplenishmentProposalSVC,
+} from "../services/replenishment-proposal.service"
+import {
+  listReplenishmentProposalsSchema,
+  refreshReplenishmentProposalsSchema,
+  validateReplenishmentProposalSchema,
+} from "../validators/replenishment-proposal.validators"
+
+function auditContext(req: Request): AuditContext {
+  if (!req.user) throw new HttpError(401, "UNAUTHORIZED", "Authentication required")
+  const forwarded = req.headers["x-forwarded-for"]
+  return {
+    user_id: req.user.id,
+    role: req.user.role ?? null,
+    ip: typeof forwarded === "string" ? forwarded.split(",")[0]?.trim() ?? null : req.ip ?? null,
+    user_agent: typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null,
+    device_type: null,
+    os: null,
+    browser: null,
+    path: req.originalUrl ?? null,
+    page_key: typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null,
+    client_session_id: typeof req.headers["x-client-session-id"] === "string" ? req.headers["x-client-session-id"] : null,
+  }
+}
+
+export const listReplenishmentProposals: RequestHandler = async (req, res, next) => {
+  try {
+    const { query } = listReplenishmentProposalsSchema.parse({ query: req.query })
+    res.json(await listReplenishmentProposalsSVC(query))
+  } catch (error) { next(error) }
+}
+
+export const refreshReplenishmentProposals: RequestHandler = async (req, res, next) => {
+  try {
+    const { body } = refreshReplenishmentProposalsSchema.parse({ body: req.body ?? {} })
+    res.json(await refreshReplenishmentProposalsSVC(body, auditContext(req)))
+  } catch (error) { next(error) }
+}
+
+export const validateReplenishmentProposal: RequestHandler = async (req, res, next) => {
+  try {
+    const { params, body } = validateReplenishmentProposalSchema.parse({ params: req.params, body: req.body })
+    res.json(await validateReplenishmentProposalSVC(params.id, body, auditContext(req)))
+  } catch (error) { next(error) }
+}

--- a/src/module/commande-fournisseur/domain/replenishment-calculation.ts
+++ b/src/module/commande-fournisseur/domain/replenishment-calculation.ts
@@ -60,6 +60,27 @@ export function roundMoney(value: number): number {
   return Math.round((value + Number.EPSILON) * 100) / 100
 }
 
+export function allocateCoverage(
+  totalStockQty: number,
+  stockLevelIds: string[]
+): Array<{ stock_level_id: string; quantity: number }> {
+  const totalMilliunits = Math.max(0, Math.round(totalStockQty * 1000))
+  if (totalMilliunits === 0 || stockLevelIds.length === 0) return []
+
+  // quantite_couverte is NUMERIC(...,3) and must stay strictly positive. When
+  // there are fewer milliunits than stock levels, only the deterministic first
+  // levels receive a link; manufacturing extra 0.001 links would overstate the
+  // order coverage.
+  const linkCount = Math.min(totalMilliunits, stockLevelIds.length)
+  const baseMilliunits = Math.floor(totalMilliunits / linkCount)
+  const extraMilliunits = totalMilliunits % linkCount
+
+  return stockLevelIds.slice(0, linkCount).map((stockLevelId, index) => ({
+    stock_level_id: stockLevelId,
+    quantity: (baseMilliunits + (index < extraMilliunits ? 1 : 0)) / 1000,
+  }))
+}
+
 export function convertOpenOrderRemainderToStock(input: OpenOrderRemainderInput): {
   remaining_purchase_qty: number
   remaining_stock_qty: number

--- a/src/module/commande-fournisseur/domain/replenishment-calculation.ts
+++ b/src/module/commande-fournisseur/domain/replenishment-calculation.ts
@@ -1,0 +1,125 @@
+export type ReplenishmentCalculationInput = {
+  qty_on_hand: number
+  qty_reserved: number
+  qty_available: number
+  qty_open_orders: number
+  minimum_stock_qty: number | null
+  safety_stock_qty: number | null
+  target_stock_qty: number | null
+  reorder_qty: number | null
+  stock_unit: string | null
+  purchase_unit: string | null
+  stock_units_per_purchase_unit: number | null
+  supplier_moq: number | null
+  purchase_lot_size: number | null
+  unit_price: number | null
+}
+
+export type ReplenishmentCalculation = {
+  reason_code: "RUPTURE" | "SOUS_MINIMUM" | "COUVERT" | "SEUIL_MANQUANT"
+  target_stock_qty: number
+  gross_requirement_qty: number
+  net_requirement_qty: number
+  proposed_purchase_qty: number | null
+  proposed_stock_qty: number | null
+  stock_units_per_purchase_unit: number | null
+  estimated_total: number | null
+  missing_data: string[]
+  warnings: string[]
+  formula: string
+}
+
+const EPS = 1e-9
+
+export function normalizeUnit(value: string | null | undefined): string | null {
+  const unit = value?.trim().toLowerCase()
+  if (!unit) return null
+  if (["pce", "pcs", "pc", "piece", "pièce"].includes(unit)) return "u"
+  return unit
+}
+
+function nonNegative(value: number | null | undefined): number {
+  return Number.isFinite(value) ? Math.max(0, Number(value)) : 0
+}
+
+export function roundQty(value: number): number {
+  return Math.round((value + Number.EPSILON) * 1000) / 1000
+}
+
+export function roundMoney(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100
+}
+
+function ceilToLot(value: number, lot: number | null): number {
+  if (!lot || lot <= 0) return roundQty(value)
+  return roundQty(Math.ceil((value - EPS) / lot) * lot)
+}
+
+export function calculateReplenishment(input: ReplenishmentCalculationInput): ReplenishmentCalculation {
+  const missing = new Set<string>()
+  const warnings = new Set<string>()
+  const available = nonNegative(input.qty_available)
+  const openOrders = nonNegative(input.qty_open_orders)
+  const minimum = input.minimum_stock_qty == null ? null : nonNegative(input.minimum_stock_qty)
+  const safety = input.safety_stock_qty == null ? 0 : nonNegative(input.safety_stock_qty)
+
+  if (minimum == null || minimum <= 0) missing.add("MINIMUM_STOCK")
+  if (input.safety_stock_qty == null) warnings.add("SAFETY_STOCK_MISSING")
+  if (!normalizeUnit(input.stock_unit)) missing.add("STOCK_UNIT")
+
+  const target = input.target_stock_qty != null
+    ? nonNegative(input.target_stock_qty)
+    : nonNegative(minimum) + safety
+  const gross = roundQty(Math.max(0, target - available))
+  const net = roundQty(Math.max(0, target - available - openOrders))
+  const reason = minimum == null || minimum <= 0
+    ? "SEUIL_MANQUANT"
+    : net <= EPS
+      ? "COUVERT"
+      : available <= EPS
+        ? "RUPTURE"
+        : "SOUS_MINIMUM"
+
+  const stockUnit = normalizeUnit(input.stock_unit)
+  const purchaseUnit = normalizeUnit(input.purchase_unit)
+  let coefficient: number | null = null
+  if (!purchaseUnit) {
+    missing.add("PURCHASE_UNIT")
+  } else if (stockUnit === purchaseUnit) {
+    coefficient = 1
+  } else if (input.stock_units_per_purchase_unit && input.stock_units_per_purchase_unit > 0) {
+    coefficient = input.stock_units_per_purchase_unit
+  } else {
+    missing.add("UNIT_CONVERSION")
+  }
+
+  let purchaseQty: number | null = null
+  let stockQty: number | null = null
+  if (net > EPS && coefficient) {
+    const baseStockNeed = Math.max(net, nonNegative(input.reorder_qty))
+    const rawPurchase = baseStockNeed / coefficient
+    const moqApplied = Math.max(rawPurchase, nonNegative(input.supplier_moq))
+    purchaseQty = ceilToLot(moqApplied, input.purchase_lot_size)
+    stockQty = roundQty(purchaseQty * coefficient)
+    if (input.supplier_moq && purchaseQty > rawPurchase + EPS) warnings.add("MOQ_APPLIED")
+    if (input.purchase_lot_size && purchaseQty > moqApplied + EPS) warnings.add("PURCHASE_LOT_ROUNDED")
+    if (stockQty > net + EPS) warnings.add("OVERAGE_AFTER_ROUNDING")
+  }
+  if (input.unit_price == null) warnings.add("PRICE_MISSING")
+
+  return {
+    reason_code: reason,
+    target_stock_qty: roundQty(target),
+    gross_requirement_qty: gross,
+    net_requirement_qty: net,
+    proposed_purchase_qty: purchaseQty,
+    proposed_stock_qty: stockQty,
+    stock_units_per_purchase_unit: coefficient,
+    estimated_total: purchaseQty != null && input.unit_price != null
+      ? roundMoney(purchaseQty * nonNegative(input.unit_price))
+      : null,
+    missing_data: [...missing].sort(),
+    warnings: [...warnings].sort(),
+    formula: "max(0, cible - disponible - commandes_ouvertes); puis MOQ et arrondi au lot d'achat",
+  }
+}

--- a/src/module/commande-fournisseur/domain/replenishment-calculation.ts
+++ b/src/module/commande-fournisseur/domain/replenishment-calculation.ts
@@ -3,6 +3,7 @@ export type ReplenishmentCalculationInput = {
   qty_reserved: number
   qty_available: number
   qty_open_orders: number
+  open_order_conversion_missing?: boolean
   minimum_stock_qty: number | null
   safety_stock_qty: number | null
   target_stock_qty: number | null
@@ -31,6 +32,15 @@ export type ReplenishmentCalculation = {
 
 const EPS = 1e-9
 
+export type OpenOrderRemainderInput = {
+  ordered_purchase_qty: number
+  cancelled_purchase_qty: number
+  received_purchase_qty: number
+  purchase_unit: string | null
+  stock_unit: string | null
+  stock_units_per_purchase_unit: number | null
+}
+
 export function normalizeUnit(value: string | null | undefined): string | null {
   const unit = value?.trim().toLowerCase()
   if (!unit) return null
@@ -50,6 +60,36 @@ export function roundMoney(value: number): number {
   return Math.round((value + Number.EPSILON) * 100) / 100
 }
 
+export function convertOpenOrderRemainderToStock(input: OpenOrderRemainderInput): {
+  remaining_purchase_qty: number
+  remaining_stock_qty: number
+  coefficient: number | null
+  conversion_missing: boolean
+} {
+  const remainingPurchase = roundQty(Math.max(
+    0,
+    nonNegative(input.ordered_purchase_qty)
+      - nonNegative(input.cancelled_purchase_qty)
+      - nonNegative(input.received_purchase_qty)
+  ))
+  if (remainingPurchase <= EPS) {
+    return { remaining_purchase_qty: 0, remaining_stock_qty: 0, coefficient: null, conversion_missing: false }
+  }
+  const purchaseUnit = normalizeUnit(input.purchase_unit)
+  const stockUnit = normalizeUnit(input.stock_unit)
+  const coefficient = purchaseUnit && stockUnit && purchaseUnit === stockUnit
+    ? 1
+    : input.stock_units_per_purchase_unit && input.stock_units_per_purchase_unit > 0
+      ? input.stock_units_per_purchase_unit
+      : null
+  return {
+    remaining_purchase_qty: remainingPurchase,
+    remaining_stock_qty: coefficient ? roundQty(remainingPurchase * coefficient) : 0,
+    coefficient,
+    conversion_missing: coefficient == null,
+  }
+}
+
 function ceilToLot(value: number, lot: number | null): number {
   if (!lot || lot <= 0) return roundQty(value)
   return roundQty(Math.ceil((value - EPS) / lot) * lot)
@@ -64,6 +104,7 @@ export function calculateReplenishment(input: ReplenishmentCalculationInput): Re
   const safety = input.safety_stock_qty == null ? 0 : nonNegative(input.safety_stock_qty)
 
   if (minimum == null || minimum <= 0) missing.add("MINIMUM_STOCK")
+  if (input.open_order_conversion_missing) missing.add("OPEN_ORDER_UNIT_CONVERSION")
   if (input.safety_stock_qty == null) warnings.add("SAFETY_STOCK_MISSING")
   if (!normalizeUnit(input.stock_unit)) missing.add("STOCK_UNIT")
 

--- a/src/module/commande-fournisseur/repository/commande-fournisseur.repository.ts
+++ b/src/module/commande-fournisseur/repository/commande-fournisseur.repository.ts
@@ -1254,6 +1254,7 @@ export async function repoTransitionCommandeFournisseur(
     }
 
     // Effets par transition.
+    let releasedNeedLinks = 0;
     const sets: string[] = [`statut = $2`, `updated_by = $3`];
     const values: unknown[] = [id, to, audit.user_id];
     const pushSet = (fragment: string, value?: unknown) => {
@@ -1305,12 +1306,27 @@ export async function repoTransitionCommandeFournisseur(
     }
 
     await client.query(`UPDATE public.commande_fournisseur SET ${sets.join(", ")} WHERE id = $1::uuid`, values);
+    if (kind === "cancel") {
+      // La couverture est une protection anti double-commande, pas une preuve que le
+      // besoin reste couvert après annulation. La libération est atomique avec la
+      // transition; la ligne et le lien restent conservés pour l'audit.
+      const released = await client.query(
+        `UPDATE public.commande_fournisseur_ligne_besoin besoin
+            SET annule = true
+           FROM public.commande_fournisseur_ligne ligne
+          WHERE besoin.ligne_id = ligne.id
+            AND ligne.commande_id = $1::uuid
+            AND besoin.annule IS FALSE`,
+        [id]
+      );
+      releasedNeedLinks = released.rowCount ?? 0;
+    }
     await insertTransitionRow(client, id, from, to, motif, options?.system ? null : audit.user_id);
     await insertAuditLog(client, audit, {
       action: `commandes_fournisseurs.transition.${kind}`,
       entity_type: "commande_fournisseur",
       entity_id: id,
-      details: { from, to, motif, system: Boolean(options?.system) },
+      details: { from, to, motif, system: Boolean(options?.system), released_need_links: releasedNeedLinks },
     });
 
     const resultat = { statut: to };

--- a/src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts
+++ b/src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts
@@ -1,0 +1,559 @@
+import crypto from "node:crypto"
+import type { PoolClient } from "pg"
+
+import db from "../../../config/database"
+import { generateCommandeFournisseurCode } from "../../../shared/codes/code-generator.service"
+import { HttpError } from "../../../utils/httpError"
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
+import { computeCommandeTotaux } from "../domain/commande-fournisseur-totaux"
+import { calculateReplenishment, normalizeUnit } from "../domain/replenishment-calculation"
+import type { AuditContext } from "./commande-fournisseur.repository"
+import type {
+  ReplenishmentProposal,
+  ReplenishmentRefreshResult,
+  ReplenishmentSupplierCandidate,
+} from "../types/replenishment-proposal.types"
+import type {
+  ListReplenishmentProposalsDTO,
+  RefreshReplenishmentProposalsDTO,
+  ValidateReplenishmentProposalDTO,
+} from "../validators/replenishment-proposal.validators"
+
+type Queryer = Pick<PoolClient, "query">
+
+type StockContext = {
+  stock_level_id: string
+  article_id: string
+  article_code: string
+  article_designation: string
+  stock_unit: string | null
+  location_id: string | null
+  magasin_id: string | null
+  magasin_name: string | null
+  emplacement_name: string | null
+  qty_on_hand: number
+  qty_reserved: number
+  qty_available: number
+  qty_open_orders: number
+  min_qty: number | null
+  safety_stock_qty: number | null
+  target_stock_qty: number | null
+  reorder_qty: number | null
+  order_lot_size: number | null
+  preferred_catalogue_id: string | null
+  preferred_supplier_id: string | null
+}
+
+const n = (value: unknown): number => Number(value ?? 0)
+const nullableNumber = (value: unknown): number | null => value == null ? null : Number(value)
+
+function stable(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value)
+  if (Array.isArray(value)) return `[${value.map(stable).join(",")}]`
+  return `{${Object.entries(value as Record<string, unknown>)
+    .filter(([, item]) => item !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, item]) => `${JSON.stringify(key)}:${stable(item)}`)
+    .join(",")}}`
+}
+
+const hashRequest = (value: unknown) => crypto.createHash("sha256").update(stable(value)).digest("hex")
+
+async function audit(tx: Queryer, context: AuditContext, action: string, entityId: string, details: Record<string, unknown>) {
+  await repoInsertAuditLog({
+    user_id: context.user_id,
+    body: {
+      event_type: "ACTION",
+      action,
+      page_key: context.page_key,
+      entity_type: "replenishment_proposal",
+      entity_id: entityId,
+      path: context.path,
+      client_session_id: context.client_session_id,
+      details,
+    },
+    ip: context.ip,
+    user_agent: context.user_agent,
+    device_type: context.device_type,
+    os: context.os,
+    browser: context.browser,
+    tx,
+  })
+}
+
+async function readStockContexts(
+  queryer: Queryer,
+  filters: RefreshReplenishmentProposalsDTO & { stock_level_id?: string }
+): Promise<StockContext[]> {
+  const values: unknown[] = []
+  const where = ["sl.managed_in_stock IS TRUE"]
+  const push = (value: unknown) => { values.push(value); return `$${values.length}` }
+  if (filters.magasin_id) where.push(`m.id = ${push(filters.magasin_id)}::uuid`)
+  if (filters.article_id) where.push(`sl.article_id = ${push(filters.article_id)}::uuid`)
+  if (filters.stock_level_id) where.push(`sl.id = ${push(filters.stock_level_id)}::uuid`)
+  values.push(filters.limit)
+
+  const result = await queryer.query(
+    `SELECT
+       sl.id::text AS stock_level_id, sl.article_id::text AS article_id,
+       a.code AS article_code, a.designation AS article_designation,
+       COALESCE(u.code::text, a.unite)::text AS stock_unit,
+       sl.location_id::text AS location_id, m.id::text AS magasin_id,
+       COALESCE(m.name, m.libelle, m.code_magasin)::text AS magasin_name,
+       COALESCE(e.name, e.libelle, e.code)::text AS emplacement_name,
+       COALESCE(av.qty_on_hand, sl.qty_total, 0)::float8 AS qty_on_hand,
+       COALESCE(av.qty_reserved, sl.qty_reserved, 0)::float8 AS qty_reserved,
+       COALESCE(av.qty_available, GREATEST(sl.qty_total - sl.qty_reserved, 0), 0)::float8 AS qty_available,
+       COALESCE(po.qty_open_orders, 0)::float8 AS qty_open_orders,
+       COALESCE(sl.min_qty, app.min_stock)::float8 AS min_qty,
+       sl.safety_stock_qty::float8 AS safety_stock_qty,
+       COALESCE(sl.target_stock_qty, app.max_stock)::float8 AS target_stock_qty,
+       sl.reorder_qty::float8 AS reorder_qty,
+       sl.order_lot_size::float8 AS order_lot_size,
+       app.preferred_catalogue_id::text AS preferred_catalogue_id,
+       sl.supplier_id::text AS preferred_supplier_id
+     FROM public.stock_levels sl
+     JOIN public.articles a ON a.id = sl.article_id
+     LEFT JOIN public.units u ON u.id = sl.unit_id
+     LEFT JOIN public.emplacements e ON e.location_id = sl.location_id
+     LEFT JOIN public.magasins m ON m.id = e.magasin_id
+     LEFT JOIN public.article_procurement_profile app ON app.article_id = sl.article_id
+     LEFT JOIN LATERAL (
+       SELECT SUM(GREATEST(line.quantite - line.qty_annulee - COALESCE(received.qty, 0), 0)) AS qty_open_orders
+       FROM public.commande_fournisseur_ligne line
+       JOIN public.commande_fournisseur po_header ON po_header.id = line.commande_id
+       LEFT JOIN LATERAL (
+         SELECT SUM(reception_line.qty_received) AS qty
+         FROM public.reception_fournisseur_lignes reception_line
+         WHERE reception_line.commande_fournisseur_ligne_id = line.id
+       ) received ON TRUE
+       WHERE line.article_id = sl.article_id
+         AND line.statut_ligne = 'ACTIVE'
+         AND po_header.statut IN ('BROUILLON','A_VALIDER','APPROUVEE','ENVOYEE','ACCUSE_RECU','PARTIELLEMENT_RECUE')
+         AND m.id IS NOT NULL
+         AND COALESCE(line.magasin_id, po_header.magasin_livraison_id) = m.id
+     ) po ON TRUE
+     LEFT JOIN LATERAL (
+       SELECT SUM(v.qty_on_hand)::float8 AS qty_on_hand,
+              SUM(v.qty_reserved)::float8 AS qty_reserved,
+              SUM(v.qty_available)::float8 AS qty_available
+       FROM public.v_stock_availability_225 v
+       WHERE v.stock_level_id = sl.id
+     ) av ON TRUE
+     WHERE ${where.join(" AND ")}
+     ORDER BY a.code, m.name NULLS LAST, e.code NULLS LAST
+     LIMIT $${values.length}`,
+    values
+  )
+  return result.rows.map((row) => ({
+    ...row,
+    qty_on_hand: n(row.qty_on_hand), qty_reserved: n(row.qty_reserved), qty_available: n(row.qty_available),
+    qty_open_orders: n(row.qty_open_orders), min_qty: nullableNumber(row.min_qty),
+    safety_stock_qty: nullableNumber(row.safety_stock_qty), target_stock_qty: nullableNumber(row.target_stock_qty),
+    reorder_qty: nullableNumber(row.reorder_qty), order_lot_size: nullableNumber(row.order_lot_size),
+  })) as StockContext[]
+}
+
+async function loadCandidates(queryer: Queryer, context: StockContext): Promise<ReplenishmentSupplierCandidate[]> {
+  const result = await queryer.query(
+    `SELECT fc.id::text AS catalogue_id, f.id::text AS supplier_id,
+            COALESCE(f.code, f.code_fournisseur)::text AS supplier_code,
+            COALESCE(f.nom, f.raison_sociale)::text AS supplier_name,
+            fc.unite AS purchase_unit, COALESCE(fc.unite_stock, $2)::text AS stock_unit,
+            fc.coef_conversion::float8 AS stock_units_per_purchase_unit,
+            fc.moq::float8 AS moq, COALESCE(fc.lot_achat, $3::numeric)::float8 AS purchase_lot_size,
+            fc.delai_jours::int AS lead_time_days, fc.prix_unitaire::float8 AS catalogue_price,
+            COALESCE(fc.devise, 'EUR')::text AS currency,
+            history.unit_price::float8 AS last_order_unit_price, history.order_date::text AS last_order_date,
+            (fc.id = $4::uuid OR f.id = $5::uuid) AS preferred,
+            f.actif, f.status
+       FROM public.fournisseur_catalogue fc
+       JOIN public.fournisseurs f ON f.id = fc.fournisseur_id
+       LEFT JOIN LATERAL (
+         SELECT line.prix_unitaire_ht AS unit_price, header.created_at::date AS order_date
+         FROM public.commande_fournisseur_ligne line
+         JOIN public.commande_fournisseur header ON header.id = line.commande_id
+         WHERE line.article_id = fc.article_id AND header.fournisseur_id = fc.fournisseur_id
+           AND line.statut_ligne = 'ACTIVE' AND header.statut <> 'ANNULEE'
+         ORDER BY header.created_at DESC LIMIT 1
+       ) history ON TRUE
+      WHERE fc.article_id = $1::uuid AND fc.actif IS TRUE
+        AND COALESCE(f.actif, true) IS TRUE AND COALESCE(f.status, 'actif') NOT IN ('inactif','archive')
+      ORDER BY preferred DESC, fc.prix_unitaire ASC NULLS LAST, supplier_name`,
+    [context.article_id, context.stock_unit, context.order_lot_size, context.preferred_catalogue_id, context.preferred_supplier_id]
+  )
+  return result.rows.map((row) => {
+    const stockUnit = normalizeUnit(row.stock_unit)
+    const purchaseUnit = normalizeUnit(row.purchase_unit)
+    const coefficient = stockUnit && purchaseUnit && stockUnit === purchaseUnit
+      ? 1
+      : nullableNumber(row.stock_units_per_purchase_unit)
+    const blockers: string[] = []
+    if (!purchaseUnit) blockers.push("PURCHASE_UNIT")
+    if (!stockUnit) blockers.push("STOCK_UNIT")
+    if (stockUnit && purchaseUnit && stockUnit !== purchaseUnit && !coefficient) blockers.push("UNIT_CONVERSION")
+    const cataloguePrice = nullableNumber(row.catalogue_price)
+    const historicalPrice = nullableNumber(row.last_order_unit_price)
+    return {
+      catalogue_id: row.catalogue_id,
+      supplier_id: row.supplier_id,
+      supplier_code: row.supplier_code ?? null,
+      supplier_name: row.supplier_name,
+      purchase_unit: row.purchase_unit ?? null,
+      stock_unit: row.stock_unit ?? null,
+      stock_units_per_purchase_unit: coefficient,
+      moq: nullableNumber(row.moq),
+      purchase_lot_size: nullableNumber(row.purchase_lot_size),
+      lead_time_days: row.lead_time_days == null ? null : Number(row.lead_time_days),
+      unit_price: cataloguePrice ?? historicalPrice,
+      currency: row.currency ?? "EUR",
+      price_source: cataloguePrice != null ? "CATALOGUE" : historicalPrice != null ? "HISTORICAL" : "MISSING",
+      last_order_unit_price: historicalPrice,
+      last_order_date: row.last_order_date ?? null,
+      preferred: Boolean(row.preferred),
+      blockers,
+    }
+  })
+}
+
+async function budgetFor(queryer: Queryer, context: StockContext, candidate: ReplenishmentSupplierCandidate | null, estimate: number | null) {
+  if (!context.magasin_id || !candidate || estimate == null) return { status: "MISSING" as const, remaining: null }
+  const result = await queryer.query(
+    `SELECT budget.amount_limit::float8 AS amount_limit,
+            COALESCE(committed.amount, 0)::float8 AS committed
+       FROM public.replenishment_budgets budget
+       LEFT JOIN LATERAL (
+         SELECT SUM(line.quantite * line.prix_unitaire_ht) AS amount
+         FROM public.commande_fournisseur_ligne line
+         JOIN public.commande_fournisseur header ON header.id = line.commande_id
+         WHERE COALESCE(line.magasin_id, header.magasin_livraison_id) = budget.magasin_id
+           AND header.devise = budget.currency AND header.created_at::date BETWEEN budget.period_start AND budget.period_end
+           AND header.statut <> 'ANNULEE' AND line.statut_ligne = 'ACTIVE'
+       ) committed ON TRUE
+      WHERE budget.magasin_id = $1::uuid AND budget.currency = $2 AND budget.active
+        AND CURRENT_DATE BETWEEN budget.period_start AND budget.period_end
+      ORDER BY budget.period_start DESC LIMIT 1`,
+    [context.magasin_id, candidate.currency]
+  )
+  const row = result.rows[0]
+  if (!row) return { status: "MISSING" as const, remaining: null }
+  const remaining = Math.round((n(row.amount_limit) - n(row.committed)) * 100) / 100
+  return { status: estimate > remaining ? "EXCEEDED" as const : "OK" as const, remaining }
+}
+
+async function upsertProposal(queryer: Queryer, context: StockContext, actorId: number | null) {
+  const candidates = await loadCandidates(queryer, context)
+  const selected = candidates.find((candidate) => candidate.preferred && candidate.blockers.length === 0)
+    ?? candidates.find((candidate) => candidate.blockers.length === 0)
+    ?? null
+  const calculation = calculateReplenishment({
+    qty_on_hand: context.qty_on_hand, qty_reserved: context.qty_reserved, qty_available: context.qty_available,
+    qty_open_orders: context.qty_open_orders, minimum_stock_qty: context.min_qty,
+    safety_stock_qty: context.safety_stock_qty, target_stock_qty: context.target_stock_qty,
+    reorder_qty: context.reorder_qty, stock_unit: context.stock_unit,
+    purchase_unit: selected?.purchase_unit ?? null,
+    stock_units_per_purchase_unit: selected?.stock_units_per_purchase_unit ?? null,
+    supplier_moq: selected?.moq ?? null, purchase_lot_size: selected?.purchase_lot_size ?? null,
+    unit_price: selected?.unit_price ?? null,
+  })
+  if (!context.magasin_id) calculation.missing_data.push("SITE")
+  if (!selected) calculation.missing_data.push("SUPPLIER")
+  calculation.missing_data = [...new Set(calculation.missing_data)].sort()
+  const budget = await budgetFor(queryer, context, selected, calculation.estimated_total)
+  if (budget.status === "MISSING") calculation.warnings.push("BUDGET_MISSING")
+  if (selected?.price_source === "HISTORICAL") calculation.warnings.push("HISTORICAL_PRICE")
+  const status = calculation.net_requirement_qty <= 0
+    ? "RESOLUE"
+    : calculation.missing_data.length > 0
+      ? "A_COMPLETER"
+      : "PROPOSEE"
+  const calcJson = { ...calculation, inputs: context }
+  const existing = await queryer.query(`SELECT id::text, status FROM public.replenishment_proposals WHERE stock_level_id = $1::uuid`, [context.stock_level_id])
+  const result = await queryer.query<{ id: string }>(
+    `INSERT INTO public.replenishment_proposals (
+       stock_level_id, article_id, location_id, magasin_id, status, reason_code, stock_unit,
+       qty_on_hand, qty_reserved, qty_available, qty_open_orders, minimum_stock_qty, safety_stock_qty,
+       target_stock_qty, net_requirement_qty, selected_catalogue_id, selected_supplier_id,
+       purchase_unit, stock_units_per_purchase_unit, proposed_purchase_qty, proposed_stock_qty,
+       unit_price, currency, estimated_total, budget_status, budget_remaining, missing_data, warnings, calculation,
+       resolution_reason)
+     VALUES ($1::uuid,$2::uuid,$3::uuid,$4::uuid,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,
+       $16::uuid,$17::uuid,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27::text[],$28::text[],$29::jsonb,$30)
+     ON CONFLICT (stock_level_id) DO UPDATE SET
+       article_id=EXCLUDED.article_id, location_id=EXCLUDED.location_id, magasin_id=EXCLUDED.magasin_id,
+       status=EXCLUDED.status, version=replenishment_proposals.version+1, reason_code=EXCLUDED.reason_code,
+       stock_unit=EXCLUDED.stock_unit, qty_on_hand=EXCLUDED.qty_on_hand, qty_reserved=EXCLUDED.qty_reserved,
+       qty_available=EXCLUDED.qty_available, qty_open_orders=EXCLUDED.qty_open_orders,
+       minimum_stock_qty=EXCLUDED.minimum_stock_qty, safety_stock_qty=EXCLUDED.safety_stock_qty,
+       target_stock_qty=EXCLUDED.target_stock_qty, net_requirement_qty=EXCLUDED.net_requirement_qty,
+       selected_catalogue_id=EXCLUDED.selected_catalogue_id, selected_supplier_id=EXCLUDED.selected_supplier_id,
+       purchase_unit=EXCLUDED.purchase_unit, stock_units_per_purchase_unit=EXCLUDED.stock_units_per_purchase_unit,
+       proposed_purchase_qty=EXCLUDED.proposed_purchase_qty, proposed_stock_qty=EXCLUDED.proposed_stock_qty,
+       unit_price=EXCLUDED.unit_price, currency=EXCLUDED.currency, estimated_total=EXCLUDED.estimated_total,
+       budget_status=EXCLUDED.budget_status, budget_remaining=EXCLUDED.budget_remaining,
+       missing_data=EXCLUDED.missing_data, warnings=EXCLUDED.warnings, calculation=EXCLUDED.calculation,
+       resolution_reason=EXCLUDED.resolution_reason, last_recalculated_at=now(), updated_at=now()
+     RETURNING id::text`,
+    [context.stock_level_id, context.article_id, context.location_id, context.magasin_id, status,
+      calculation.reason_code, context.stock_unit, context.qty_on_hand, context.qty_reserved, context.qty_available,
+      context.qty_open_orders, context.min_qty, context.safety_stock_qty, calculation.target_stock_qty,
+      calculation.net_requirement_qty, selected?.catalogue_id ?? null, selected?.supplier_id ?? null,
+      selected?.purchase_unit ?? null, calculation.stock_units_per_purchase_unit,
+      calculation.proposed_purchase_qty, calculation.proposed_stock_qty, selected?.unit_price ?? null,
+      selected?.currency ?? null, calculation.estimated_total, budget.status, budget.remaining,
+      calculation.missing_data, [...new Set(calculation.warnings)].sort(), JSON.stringify(calcJson),
+      status === "RESOLUE" ? "Stock disponible et commandes ouvertes couvrent la cible" : null]
+  )
+  const id = result.rows[0].id
+  if (!existing.rows[0] || existing.rows[0].status !== status) {
+    await queryer.query(
+      `INSERT INTO public.replenishment_proposal_events
+         (proposal_id,event_type,from_status,to_status,calculation,details,actor_id)
+       VALUES ($1::uuid,$2,$3,$4,$5::jsonb,$6::jsonb,$7)`,
+      [id, existing.rows[0] ? "RECALCULATED" : "GENERATED", existing.rows[0]?.status ?? null, status,
+        JSON.stringify(calcJson), JSON.stringify({ selected_catalogue_id: selected?.catalogue_id ?? null }), actorId]
+    )
+  }
+  return { id, status }
+}
+
+async function hydrateProposals(queryer: Queryer, filters: ListReplenishmentProposalsDTO): Promise<ReplenishmentProposal[]> {
+  const values: unknown[] = []
+  const where: string[] = []
+  const push = (value: unknown) => { values.push(value); return `$${values.length}` }
+  if (filters.status) where.push(`p.status = ${push(filters.status)}`)
+  else where.push(`p.status IN ('PROPOSEE','A_COMPLETER','CONVERTIE')`)
+  if (filters.magasin_id) where.push(`p.magasin_id = ${push(filters.magasin_id)}::uuid`)
+  if (filters.article_id) where.push(`p.article_id = ${push(filters.article_id)}::uuid`)
+  values.push(filters.limit)
+  const result = await queryer.query(
+    `SELECT p.*, a.code AS article_code, a.designation AS article_designation,
+            COALESCE(m.name,m.libelle,m.code_magasin)::text AS magasin_name,
+            COALESCE(e.name,e.libelle,e.code)::text AS emplacement_name,
+            cf.code AS commande_fournisseur_code
+       FROM public.replenishment_proposals p
+       JOIN public.articles a ON a.id = p.article_id
+       LEFT JOIN public.magasins m ON m.id = p.magasin_id
+       LEFT JOIN public.emplacements e ON e.location_id = p.location_id
+       LEFT JOIN public.commande_fournisseur cf ON cf.id = p.commande_fournisseur_id
+      WHERE ${where.join(" AND ")}
+      ORDER BY CASE p.status WHEN 'A_COMPLETER' THEN 0 WHEN 'PROPOSEE' THEN 1 ELSE 2 END,
+               p.net_requirement_qty DESC, a.code
+      LIMIT $${values.length}`,
+    values
+  )
+  const items: ReplenishmentProposal[] = []
+  for (const row of result.rows) {
+    const contexts = await readStockContexts(queryer, { stock_level_id: row.stock_level_id, limit: 1 })
+    const candidates = contexts[0] ? await loadCandidates(queryer, contexts[0]) : []
+    items.push({
+      id: row.id, status: row.status, version: Number(row.version), reason_code: row.reason_code,
+      article_id: row.article_id, article_code: row.article_code, article_designation: row.article_designation,
+      stock_level_id: row.stock_level_id, magasin_id: row.magasin_id ?? null, magasin_name: row.magasin_name ?? null,
+      emplacement_name: row.emplacement_name ?? null, stock_unit: row.stock_unit ?? null,
+      qty_on_hand: n(row.qty_on_hand), qty_reserved: n(row.qty_reserved), qty_available: n(row.qty_available),
+      qty_open_orders: n(row.qty_open_orders), minimum_stock_qty: nullableNumber(row.minimum_stock_qty),
+      safety_stock_qty: nullableNumber(row.safety_stock_qty), target_stock_qty: nullableNumber(row.target_stock_qty),
+      net_requirement_qty: n(row.net_requirement_qty), selected_catalogue_id: row.selected_catalogue_id ?? null,
+      proposed_purchase_qty: nullableNumber(row.proposed_purchase_qty), proposed_stock_qty: nullableNumber(row.proposed_stock_qty),
+      unit_price: nullableNumber(row.unit_price), currency: row.currency ?? null, estimated_total: nullableNumber(row.estimated_total),
+      budget_status: row.budget_status, budget_remaining: nullableNumber(row.budget_remaining),
+      missing_data: row.missing_data ?? [], warnings: row.warnings ?? [], calculation: row.calculation ?? {}, candidates,
+      commande_fournisseur_id: row.commande_fournisseur_id ?? null,
+      commande_fournisseur_code: row.commande_fournisseur_code ?? null,
+      last_recalculated_at: row.last_recalculated_at, updated_at: row.updated_at,
+    })
+  }
+  return items
+}
+
+export function repoListReplenishmentProposals(filters: ListReplenishmentProposalsDTO) {
+  return hydrateProposals(db, filters)
+}
+
+export async function repoRefreshReplenishmentProposals(
+  filters: RefreshReplenishmentProposalsDTO,
+  context: AuditContext
+): Promise<ReplenishmentRefreshResult> {
+  const client = await db.connect()
+  try {
+    await client.query("BEGIN")
+    const stocks = await readStockContexts(client, filters)
+    let resolved = 0
+    for (const stock of stocks) {
+      const out = await upsertProposal(client, stock, context.user_id)
+      if (out.status === "RESOLUE") resolved += 1
+    }
+    await client.query("COMMIT")
+    const items = await hydrateProposals(db, { ...filters, limit: filters.limit })
+    return { items, refreshed: stocks.length, resolved, as_of: new Date().toISOString() }
+  } catch (error) {
+    await client.query("ROLLBACK")
+    throw error
+  } finally {
+    client.release()
+  }
+}
+
+export async function repoValidateReplenishmentProposal(
+  id: string,
+  body: ValidateReplenishmentProposalDTO,
+  context: AuditContext
+): Promise<Record<string, unknown>> {
+  const client = await db.connect()
+  const requestHash = hashRequest({ id, ...body })
+  try {
+    await client.query("BEGIN ISOLATION LEVEL SERIALIZABLE")
+    const replay = await client.query(
+      `SELECT request_hash, result FROM public.replenishment_proposal_idempotence
+       WHERE actor_id=$1 AND idempotency_key=$2`, [context.user_id, body.idempotency_key]
+    )
+    if (replay.rows[0]) {
+      if (replay.rows[0].request_hash !== requestHash) throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Clé d'idempotence déjà utilisée avec une autre demande.")
+      await client.query("COMMIT")
+      return { ...replay.rows[0].result, idempotent_replay: true }
+    }
+
+    const locked = await client.query(
+      `SELECT p.*, cf.code AS commande_code, cf.statut AS commande_statut FROM public.replenishment_proposals p
+       LEFT JOIN public.commande_fournisseur cf ON cf.id=p.commande_fournisseur_id
+       WHERE p.id=$1::uuid FOR UPDATE OF p`, [id]
+    )
+    const proposal = locked.rows[0]
+    if (!proposal) throw new HttpError(404, "REPLENISHMENT_PROPOSAL_NOT_FOUND", "Proposition introuvable.")
+    if (Number(proposal.version) !== body.expected_version) throw new HttpError(409, "CONCURRENT_MODIFICATION", "La proposition a changé; rechargez le calcul.")
+    if (proposal.commande_fournisseur_id && proposal.commande_code && proposal.commande_statut !== "ANNULEE") {
+      const result = {
+        converted: true,
+        proposal_id: id,
+        commande_fournisseur_id: proposal.commande_fournisseur_id,
+        code: proposal.commande_code,
+        status: proposal.commande_statut ?? "BROUILLON",
+      }
+      await client.query(
+        `INSERT INTO public.replenishment_proposal_idempotence(actor_id,idempotency_key,request_hash,proposal_id,result)
+         VALUES($1,$2,$3,$4::uuid,$5::jsonb)`, [context.user_id, body.idempotency_key, requestHash, id, JSON.stringify(result)]
+      )
+      await client.query("COMMIT")
+      return { ...result, idempotent_replay: true }
+    }
+
+    await client.query(`SELECT id FROM public.stock_levels WHERE id=$1::uuid FOR UPDATE`, [proposal.stock_level_id])
+    const stock = (await readStockContexts(client, { stock_level_id: proposal.stock_level_id, limit: 1 }))[0]
+    if (!stock) throw new HttpError(409, "REPLENISHMENT_SOURCE_CHANGED", "Le niveau de stock n'est plus géré.")
+    const candidates = await loadCandidates(client, stock)
+    const candidate = candidates.find((item) => item.catalogue_id === body.catalogue_id)
+    if (!candidate) throw new HttpError(422, "SUPPLIER_CANDIDATE_INVALID", "Le fournisseur ou son catalogue n'est plus disponible.")
+    if (candidate.blockers.length) throw new HttpError(422, "UNIT_CONVERSION_REQUIRED", "La conversion d'unité du catalogue est incomplète.", { blockers: candidate.blockers })
+    const calculation = calculateReplenishment({
+      qty_on_hand: stock.qty_on_hand, qty_reserved: stock.qty_reserved, qty_available: stock.qty_available,
+      qty_open_orders: stock.qty_open_orders, minimum_stock_qty: stock.min_qty,
+      safety_stock_qty: stock.safety_stock_qty, target_stock_qty: stock.target_stock_qty,
+      reorder_qty: stock.reorder_qty, stock_unit: stock.stock_unit, purchase_unit: candidate.purchase_unit,
+      stock_units_per_purchase_unit: candidate.stock_units_per_purchase_unit, supplier_moq: candidate.moq,
+      purchase_lot_size: candidate.purchase_lot_size, unit_price: candidate.unit_price,
+    })
+    if (calculation.net_requirement_qty <= 0) {
+      await client.query(
+        `UPDATE public.replenishment_proposals SET status='RESOLUE',version=version+1,
+          net_requirement_qty=0,resolution_reason='Besoin couvert lors de la validation',calculation=$2::jsonb,
+          last_recalculated_at=now(),updated_at=now() WHERE id=$1::uuid`, [id, JSON.stringify(calculation)]
+      )
+      await client.query(
+        `INSERT INTO public.replenishment_proposal_events(proposal_id,event_type,from_status,to_status,calculation,actor_id)
+         VALUES($1::uuid,'RESOLVED_AT_VALIDATION',$2,'RESOLUE',$3::jsonb,$4)`, [id, proposal.status, JSON.stringify(calculation), context.user_id]
+      )
+      const result = { converted: false, proposal_id: id, status: "RESOLUE", recalculated: calculation }
+      await client.query(
+        `INSERT INTO public.replenishment_proposal_idempotence(actor_id,idempotency_key,request_hash,proposal_id,result)
+         VALUES($1,$2,$3,$4::uuid,$5::jsonb)`, [context.user_id, body.idempotency_key, requestHash, id, JSON.stringify(result)]
+      )
+      await audit(client, context, "replenishment_proposals.validation.resolved", id, { calculation })
+      await client.query("COMMIT")
+      return { ...result, idempotent_replay: false }
+    }
+    if (calculation.missing_data.length || calculation.proposed_purchase_qty == null || calculation.proposed_stock_qty == null) {
+      throw new HttpError(422, "REPLENISHMENT_DATA_INCOMPLETE", "La proposition ne peut pas être convertie tant que ses données obligatoires manquent.", { missing_data: calculation.missing_data })
+    }
+    const budget = await budgetFor(client, stock, candidate, calculation.estimated_total)
+    if (budget.status === "EXCEEDED") throw new HttpError(422, "REPLENISHMENT_BUDGET_EXCEEDED", "Le budget configuré est insuffisant pour ce brouillon.", { remaining: budget.remaining, estimate: calculation.estimated_total })
+
+    const code = await generateCommandeFournisseurCode(client)
+    const totals = computeCommandeTotaux([{
+      quantite: calculation.proposed_purchase_qty,
+      prix_unitaire_ht: candidate.unit_price ?? 0,
+      remise_pct: 0, tva_pct: 20, frais_ht: 0,
+    }], { frais_port_ht: 0, tva_frais_pct: 20 })
+    const header = await client.query<{ id: string }>(
+      `INSERT INTO public.commande_fournisseur
+        (code,statut,origine,fournisseur_id,magasin_livraison_id,devise,note_interne,total_ht,total_remise,total_tva,total_ttc,
+         replenishment_proposal_id,created_by,updated_by)
+       VALUES($1,'BROUILLON','SEUIL_STOCK',$2::uuid,$3::uuid,$4,$5,$6,$7,$8,$9,$10::uuid,$11,$11)
+       RETURNING id::text`,
+      [code, candidate.supplier_id, stock.magasin_id, candidate.currency,
+        `Créée après validation humaine de la proposition ${id}. Budget: ${budget.status}.`,
+        totals.total_ht, totals.total_remise, totals.total_tva, totals.total_ttc, id, context.user_id]
+    )
+    const orderId = header.rows[0].id
+    const line = await client.query<{ id: string }>(
+      `INSERT INTO public.commande_fournisseur_ligne
+        (commande_id,position,type,article_id,catalogue_id,designation,unite,unite_stock,coef_conversion,
+         quantite,prix_unitaire_ht,remise_pct,tva_pct,frais_ht,delai_jours,magasin_id,created_by,updated_by)
+       VALUES($1::uuid,1,'ARTICLE',$2::uuid,$3::uuid,$4,$5,$6,$7,$8,$9,0,20,0,$10,$11::uuid,$12,$12)
+       RETURNING id::text`,
+      [orderId, stock.article_id, candidate.catalogue_id, stock.article_designation, candidate.purchase_unit,
+        stock.stock_unit, calculation.stock_units_per_purchase_unit, calculation.proposed_purchase_qty,
+        candidate.unit_price ?? 0, candidate.lead_time_days, stock.magasin_id, context.user_id]
+    )
+    await client.query(
+      `INSERT INTO public.commande_fournisseur_ligne_besoin
+        (ligne_id,besoin_type,besoin_ref,besoin_of_id,quantite_couverte)
+       VALUES($1::uuid,'STOCK_LEVEL',$2,0,$3)`,
+      [line.rows[0].id, stock.stock_level_id, calculation.proposed_stock_qty]
+    )
+    await client.query(
+      `INSERT INTO public.commande_fournisseur_transition(commande_id,from_statut,to_statut,motif,acteur_id)
+       VALUES($1::uuid,NULL,'BROUILLON','Validation humaine d''une proposition de réapprovisionnement',$2)`, [orderId, context.user_id]
+    )
+    await client.query(
+      `UPDATE public.replenishment_proposals SET status='CONVERTIE',version=version+1,
+        selected_catalogue_id=$2::uuid,selected_supplier_id=$3::uuid,purchase_unit=$4,
+        stock_units_per_purchase_unit=$5,proposed_purchase_qty=$6,proposed_stock_qty=$7,
+        unit_price=$8,currency=$9,estimated_total=$10,budget_status=$11,budget_remaining=$12,
+        calculation=$13::jsonb,commande_fournisseur_id=$14::uuid,commande_fournisseur_ligne_id=$15::uuid,
+        validated_at=now(),validated_by=$16,last_recalculated_at=now(),updated_at=now()
+       WHERE id=$1::uuid`,
+      [id, candidate.catalogue_id, candidate.supplier_id, candidate.purchase_unit,
+        calculation.stock_units_per_purchase_unit, calculation.proposed_purchase_qty, calculation.proposed_stock_qty,
+        candidate.unit_price, candidate.currency, calculation.estimated_total, budget.status, budget.remaining,
+        JSON.stringify(calculation), orderId, line.rows[0].id, context.user_id]
+    )
+    await client.query(
+      `INSERT INTO public.replenishment_proposal_events(proposal_id,event_type,from_status,to_status,calculation,details,actor_id)
+       VALUES($1::uuid,'VALIDATED',$2,'CONVERTIE',$3::jsonb,$4::jsonb,$5)`,
+      [id, proposal.status, JSON.stringify(calculation), JSON.stringify({ commande_fournisseur_id: orderId, code, catalogue_id: candidate.catalogue_id }), context.user_id]
+    )
+    const result = { converted: true, proposal_id: id, commande_fournisseur_id: orderId, code, status: "BROUILLON", recalculated: calculation }
+    await client.query(
+      `INSERT INTO public.replenishment_proposal_idempotence(actor_id,idempotency_key,request_hash,proposal_id,result)
+       VALUES($1,$2,$3,$4::uuid,$5::jsonb)`, [context.user_id, body.idempotency_key, requestHash, id, JSON.stringify(result)]
+    )
+    await audit(client, context, "replenishment_proposals.validation.converted", id, {
+      commande_fournisseur_id: orderId, code, supplier_id: candidate.supplier_id,
+      calculation, budget_status: budget.status,
+    })
+    await client.query("COMMIT")
+    return { ...result, idempotent_replay: false }
+  } catch (error) {
+    await client.query("ROLLBACK")
+    if ((error as { code?: string })?.code === "40001") {
+      throw new HttpError(409, "REPLENISHMENT_RETRY", "Le stock ou une commande a changé pendant la validation; rechargez la proposition.")
+    }
+    if ((error as { code?: string; constraint?: string })?.code === "23505") {
+      throw new HttpError(409, "REPLENISHMENT_ALREADY_CONVERTED", "Une commande couvre déjà cette proposition.")
+    }
+    throw error
+  } finally {
+    client.release()
+  }
+}

--- a/src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts
+++ b/src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts
@@ -6,7 +6,7 @@ import { generateCommandeFournisseurCode } from "../../../shared/codes/code-gene
 import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
 import { computeCommandeTotaux } from "../domain/commande-fournisseur-totaux"
-import { calculateReplenishment, normalizeUnit } from "../domain/replenishment-calculation"
+import { allocateCoverage, calculateReplenishment, normalizeUnit } from "../domain/replenishment-calculation"
 import type { AuditContext } from "./commande-fournisseur.repository"
 import type {
   ReplenishmentProposal,
@@ -323,19 +323,6 @@ function hasBlockingScopeData(calculation: ReturnType<typeof calculateReplenishm
     "OPEN_ORDER_UNIT_CONVERSION",
     "SITE",
   ].includes(item))
-}
-
-function allocateCoverage(total: number, stockLevelIds: string[]): Array<{ stock_level_id: string; quantity: number }> {
-  if (!stockLevelIds.length || total <= 0) return []
-  const base = Math.max(0.001, Math.floor((total * 1000) / stockLevelIds.length) / 1000)
-  let allocated = 0
-  return stockLevelIds.map((stockLevelId, index) => {
-    const quantity = index === stockLevelIds.length - 1
-      ? Math.max(0.001, Math.round((total - allocated) * 1000) / 1000)
-      : base
-    allocated += quantity
-    return { stock_level_id: stockLevelId, quantity }
-  })
 }
 
 async function upsertProposal(queryer: Queryer, context: StockContext, actorId: number | null) {

--- a/src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts
+++ b/src/module/commande-fournisseur/repository/replenishment-proposal.repository.ts
@@ -22,19 +22,20 @@ import type {
 type Queryer = Pick<PoolClient, "query">
 
 type StockContext = {
-  stock_level_id: string
+  stock_level_ids: string[]
+  stock_level_count: number
   article_id: string
   article_code: string
   article_designation: string
   stock_unit: string | null
-  location_id: string | null
   magasin_id: string | null
   magasin_name: string | null
-  emplacement_name: string | null
   qty_on_hand: number
   qty_reserved: number
   qty_available: number
   qty_open_orders: number
+  open_order_conversion_missing: boolean
+  stock_unit_conflict: boolean
   min_qty: number | null
   safety_stock_qty: number | null
   target_stock_qty: number | null
@@ -83,74 +84,135 @@ async function audit(tx: Queryer, context: AuditContext, action: string, entityI
 
 async function readStockContexts(
   queryer: Queryer,
-  filters: RefreshReplenishmentProposalsDTO & { stock_level_id?: string }
+  filters: RefreshReplenishmentProposalsDTO & {
+    scope?: { article_id: string; magasin_id: string | null }
+  }
 ): Promise<StockContext[]> {
   const values: unknown[] = []
   const where = ["sl.managed_in_stock IS TRUE"]
   const push = (value: unknown) => { values.push(value); return `$${values.length}` }
-  if (filters.magasin_id) where.push(`m.id = ${push(filters.magasin_id)}::uuid`)
-  if (filters.article_id) where.push(`sl.article_id = ${push(filters.article_id)}::uuid`)
-  if (filters.stock_level_id) where.push(`sl.id = ${push(filters.stock_level_id)}::uuid`)
+  if (filters.scope) {
+    where.push(`sl.article_id = ${push(filters.scope.article_id)}::uuid`)
+    where.push(filters.scope.magasin_id
+      ? `m.id = ${push(filters.scope.magasin_id)}::uuid`
+      : "m.id IS NULL")
+  } else {
+    if (filters.magasin_id) where.push(`m.id = ${push(filters.magasin_id)}::uuid`)
+    if (filters.article_id) where.push(`sl.article_id = ${push(filters.article_id)}::uuid`)
+  }
   values.push(filters.limit)
 
   const result = await queryer.query(
-    `SELECT
-       sl.id::text AS stock_level_id, sl.article_id::text AS article_id,
-       a.code AS article_code, a.designation AS article_designation,
-       COALESCE(u.code::text, a.unite)::text AS stock_unit,
-       sl.location_id::text AS location_id, m.id::text AS magasin_id,
-       COALESCE(m.name, m.libelle, m.code_magasin)::text AS magasin_name,
-       COALESCE(e.name, e.libelle, e.code)::text AS emplacement_name,
-       COALESCE(av.qty_on_hand, sl.qty_total, 0)::float8 AS qty_on_hand,
-       COALESCE(av.qty_reserved, sl.qty_reserved, 0)::float8 AS qty_reserved,
-       COALESCE(av.qty_available, GREATEST(sl.qty_total - sl.qty_reserved, 0), 0)::float8 AS qty_available,
-       COALESCE(po.qty_open_orders, 0)::float8 AS qty_open_orders,
-       COALESCE(sl.min_qty, app.min_stock)::float8 AS min_qty,
-       sl.safety_stock_qty::float8 AS safety_stock_qty,
-       COALESCE(sl.target_stock_qty, app.max_stock)::float8 AS target_stock_qty,
-       sl.reorder_qty::float8 AS reorder_qty,
-       sl.order_lot_size::float8 AS order_lot_size,
-       app.preferred_catalogue_id::text AS preferred_catalogue_id,
-       sl.supplier_id::text AS preferred_supplier_id
-     FROM public.stock_levels sl
-     JOIN public.articles a ON a.id = sl.article_id
-     LEFT JOIN public.units u ON u.id = sl.unit_id
-     LEFT JOIN public.emplacements e ON e.location_id = sl.location_id
-     LEFT JOIN public.magasins m ON m.id = e.magasin_id
-     LEFT JOIN public.article_procurement_profile app ON app.article_id = sl.article_id
-     LEFT JOIN LATERAL (
-       SELECT SUM(GREATEST(line.quantite - line.qty_annulee - COALESCE(received.qty, 0), 0)) AS qty_open_orders
-       FROM public.commande_fournisseur_ligne line
-       JOIN public.commande_fournisseur po_header ON po_header.id = line.commande_id
+    `WITH stock_rows AS (
+       SELECT
+         sl.id, sl.article_id, a.code AS article_code, a.designation AS article_designation,
+         COALESCE(u.code::text, a.unite)::text AS stock_unit,
+         m.id AS magasin_id, COALESCE(m.name, m.libelle, m.code_magasin)::text AS magasin_name,
+         COALESCE(av.qty_on_hand, sl.qty_total, 0)::numeric AS qty_on_hand,
+         COALESCE(av.qty_reserved, sl.qty_reserved, 0)::numeric AS qty_reserved,
+         COALESCE(av.qty_available, GREATEST(sl.qty_total - sl.qty_reserved, 0), 0)::numeric AS qty_available,
+         sl.min_qty, app.min_stock AS profile_min_qty, sl.safety_stock_qty,
+         sl.target_stock_qty, app.max_stock AS profile_target_qty,
+         sl.reorder_qty, sl.order_lot_size, app.preferred_catalogue_id, sl.supplier_id
+       FROM public.stock_levels sl
+       JOIN public.articles a ON a.id = sl.article_id
+       LEFT JOIN public.units u ON u.id = sl.unit_id
+       LEFT JOIN public.emplacements e ON e.location_id = sl.location_id
+       LEFT JOIN public.magasins m ON m.id = e.magasin_id
+       LEFT JOIN public.article_procurement_profile app ON app.article_id = sl.article_id
        LEFT JOIN LATERAL (
-         SELECT SUM(reception_line.qty_received) AS qty
-         FROM public.reception_fournisseur_lignes reception_line
-         WHERE reception_line.commande_fournisseur_ligne_id = line.id
-       ) received ON TRUE
-       WHERE line.article_id = sl.article_id
-         AND line.statut_ligne = 'ACTIVE'
-         AND po_header.statut IN ('BROUILLON','A_VALIDER','APPROUVEE','ENVOYEE','ACCUSE_RECU','PARTIELLEMENT_RECUE')
-         AND m.id IS NOT NULL
-         AND COALESCE(line.magasin_id, po_header.magasin_livraison_id) = m.id
-     ) po ON TRUE
+         SELECT SUM(v.qty_on_hand) AS qty_on_hand,
+                SUM(v.qty_reserved) AS qty_reserved,
+                SUM(v.qty_available) AS qty_available
+         FROM public.v_stock_availability_225 v
+         WHERE v.stock_level_id = sl.id
+       ) av ON TRUE
+       WHERE ${where.join(" AND ")}
+     ), stock_scopes AS (
+       SELECT
+         article_id, magasin_id,
+         MAX(article_code)::text AS article_code,
+         MAX(article_designation)::text AS article_designation,
+         array_agg(id::text ORDER BY id::text) AS stock_level_ids,
+         COUNT(*)::int AS stock_level_count,
+         CASE
+           WHEN COUNT(stock_unit) = COUNT(*) AND COUNT(DISTINCT
+             CASE WHEN lower(btrim(stock_unit)) IN ('pce','pcs','pc','piece','pièce') THEN 'u' ELSE lower(btrim(stock_unit)) END
+           ) = 1
+             THEN MIN(stock_unit)
+           ELSE NULL
+         END::text AS stock_unit,
+         (COUNT(stock_unit) <> COUNT(*) OR COUNT(DISTINCT
+           CASE WHEN lower(btrim(stock_unit)) IN ('pce','pcs','pc','piece','pièce') THEN 'u' ELSE lower(btrim(stock_unit)) END
+         ) > 1) AS stock_unit_conflict,
+         MAX(magasin_name)::text AS magasin_name,
+         SUM(qty_on_hand)::float8 AS qty_on_hand,
+         SUM(qty_reserved)::float8 AS qty_reserved,
+         SUM(qty_available)::float8 AS qty_available,
+         CASE WHEN COUNT(min_qty) > 0 THEN SUM(COALESCE(min_qty, 0)) ELSE MAX(profile_min_qty) END::float8 AS min_qty,
+         CASE WHEN COUNT(safety_stock_qty) > 0 THEN SUM(COALESCE(safety_stock_qty, 0)) ELSE NULL END::float8 AS safety_stock_qty,
+         CASE WHEN COUNT(target_stock_qty) > 0 THEN SUM(COALESCE(target_stock_qty, 0)) ELSE MAX(profile_target_qty) END::float8 AS target_stock_qty,
+         CASE WHEN COUNT(reorder_qty) > 0 THEN SUM(COALESCE(reorder_qty, 0)) ELSE NULL END::float8 AS reorder_qty,
+         MAX(order_lot_size)::float8 AS order_lot_size,
+         MAX(preferred_catalogue_id::text) AS preferred_catalogue_id,
+         CASE WHEN COUNT(DISTINCT supplier_id) = 1 THEN MIN(supplier_id::text) ELSE NULL END AS preferred_supplier_id
+       FROM stock_rows
+       GROUP BY article_id, magasin_id
+     )
+     SELECT scope.*,
+            COALESCE(incoming.qty_open_orders_stock, 0)::float8 AS qty_open_orders,
+            COALESCE(incoming.conversion_missing, false) AS open_order_conversion_missing
+     FROM stock_scopes scope
      LEFT JOIN LATERAL (
-       SELECT SUM(v.qty_on_hand)::float8 AS qty_on_hand,
-              SUM(v.qty_reserved)::float8 AS qty_reserved,
-              SUM(v.qty_available)::float8 AS qty_available
-       FROM public.v_stock_availability_225 v
-       WHERE v.stock_level_id = sl.id
-     ) av ON TRUE
-     WHERE ${where.join(" AND ")}
-     ORDER BY a.code, m.name NULLS LAST, e.code NULLS LAST
+       SELECT
+         SUM(open_line.remaining_purchase_qty * open_line.stock_units_per_purchase_unit)
+           FILTER (WHERE open_line.stock_units_per_purchase_unit IS NOT NULL)::float8 AS qty_open_orders_stock,
+         BOOL_OR(open_line.remaining_purchase_qty > 0 AND open_line.stock_units_per_purchase_unit IS NULL) AS conversion_missing
+       FROM (
+         SELECT
+           GREATEST(line.quantite - line.qty_annulee - COALESCE(received.qty, 0), 0) AS remaining_purchase_qty,
+           CASE
+             WHEN
+               (CASE WHEN lower(btrim(COALESCE(line.unite, ''))) IN ('pce','pcs','pc','piece','pièce') THEN 'u' ELSE lower(btrim(COALESCE(line.unite, ''))) END)
+               =
+               (CASE WHEN lower(btrim(COALESCE(scope.stock_unit, ''))) IN ('pce','pcs','pc','piece','pièce') THEN 'u' ELSE lower(btrim(COALESCE(scope.stock_unit, ''))) END)
+               AND btrim(COALESCE(scope.stock_unit, '')) <> ''
+               THEN 1::numeric
+             WHEN line.coef_conversion > 0
+               AND line.unite_stock IS NOT NULL
+               AND (CASE WHEN lower(btrim(line.unite_stock)) IN ('pce','pcs','pc','piece','pièce') THEN 'u' ELSE lower(btrim(line.unite_stock)) END)
+                 =
+                 (CASE WHEN lower(btrim(COALESCE(scope.stock_unit, ''))) IN ('pce','pcs','pc','piece','pièce') THEN 'u' ELSE lower(btrim(COALESCE(scope.stock_unit, ''))) END)
+               THEN line.coef_conversion
+             ELSE NULL
+           END AS stock_units_per_purchase_unit
+         FROM public.commande_fournisseur_ligne line
+         JOIN public.commande_fournisseur po_header ON po_header.id = line.commande_id
+         LEFT JOIN LATERAL (
+           SELECT SUM(reception_line.qty_received) AS qty
+           FROM public.reception_fournisseur_lignes reception_line
+           WHERE reception_line.commande_fournisseur_ligne_id = line.id
+         ) received ON TRUE
+         WHERE line.article_id = scope.article_id
+           AND line.statut_ligne = 'ACTIVE'
+           AND po_header.statut IN ('BROUILLON','A_VALIDER','APPROUVEE','ENVOYEE','ACCUSE_RECU','PARTIELLEMENT_RECUE')
+           AND COALESCE(line.magasin_id, po_header.magasin_livraison_id) IS NOT DISTINCT FROM scope.magasin_id
+       ) open_line
+     ) incoming ON TRUE
+     ORDER BY scope.article_code, scope.magasin_name NULLS LAST
      LIMIT $${values.length}`,
     values
   )
   return result.rows.map((row) => ({
     ...row,
+    stock_level_ids: Array.isArray(row.stock_level_ids) ? row.stock_level_ids : [],
+    stock_level_count: n(row.stock_level_count),
     qty_on_hand: n(row.qty_on_hand), qty_reserved: n(row.qty_reserved), qty_available: n(row.qty_available),
     qty_open_orders: n(row.qty_open_orders), min_qty: nullableNumber(row.min_qty),
     safety_stock_qty: nullableNumber(row.safety_stock_qty), target_stock_qty: nullableNumber(row.target_stock_qty),
     reorder_qty: nullableNumber(row.reorder_qty), order_lot_size: nullableNumber(row.order_lot_size),
+    open_order_conversion_missing: Boolean(row.open_order_conversion_missing),
+    stock_unit_conflict: Boolean(row.stock_unit_conflict),
   })) as StockContext[]
 }
 
@@ -241,6 +303,41 @@ async function budgetFor(queryer: Queryer, context: StockContext, candidate: Rep
   return { status: estimate > remaining ? "EXCEEDED" as const : "OK" as const, remaining }
 }
 
+function addScopeMissingData(
+  calculation: ReturnType<typeof calculateReplenishment>,
+  context: StockContext,
+  hasSupplier: boolean
+) {
+  if (!context.magasin_id) calculation.missing_data.push("SITE")
+  if (context.stock_unit_conflict) calculation.missing_data.push("STOCK_UNIT_CONFLICT")
+  if (!hasSupplier) calculation.missing_data.push("SUPPLIER")
+  calculation.missing_data = [...new Set(calculation.missing_data)].sort()
+  calculation.warnings = [...new Set(calculation.warnings)].sort()
+}
+
+function hasBlockingScopeData(calculation: ReturnType<typeof calculateReplenishment>): boolean {
+  return calculation.missing_data.some((item) => [
+    "MINIMUM_STOCK",
+    "STOCK_UNIT",
+    "STOCK_UNIT_CONFLICT",
+    "OPEN_ORDER_UNIT_CONVERSION",
+    "SITE",
+  ].includes(item))
+}
+
+function allocateCoverage(total: number, stockLevelIds: string[]): Array<{ stock_level_id: string; quantity: number }> {
+  if (!stockLevelIds.length || total <= 0) return []
+  const base = Math.max(0.001, Math.floor((total * 1000) / stockLevelIds.length) / 1000)
+  let allocated = 0
+  return stockLevelIds.map((stockLevelId, index) => {
+    const quantity = index === stockLevelIds.length - 1
+      ? Math.max(0.001, Math.round((total - allocated) * 1000) / 1000)
+      : base
+    allocated += quantity
+    return { stock_level_id: stockLevelId, quantity }
+  })
+}
+
 async function upsertProposal(queryer: Queryer, context: StockContext, actorId: number | null) {
   const candidates = await loadCandidates(queryer, context)
   const selected = candidates.find((candidate) => candidate.preferred && candidate.blockers.length === 0)
@@ -248,7 +345,8 @@ async function upsertProposal(queryer: Queryer, context: StockContext, actorId: 
     ?? null
   const calculation = calculateReplenishment({
     qty_on_hand: context.qty_on_hand, qty_reserved: context.qty_reserved, qty_available: context.qty_available,
-    qty_open_orders: context.qty_open_orders, minimum_stock_qty: context.min_qty,
+    qty_open_orders: context.qty_open_orders, open_order_conversion_missing: context.open_order_conversion_missing,
+    minimum_stock_qty: context.min_qty,
     safety_stock_qty: context.safety_stock_qty, target_stock_qty: context.target_stock_qty,
     reorder_qty: context.reorder_qty, stock_unit: context.stock_unit,
     purchase_unit: selected?.purchase_unit ?? null,
@@ -256,31 +354,37 @@ async function upsertProposal(queryer: Queryer, context: StockContext, actorId: 
     supplier_moq: selected?.moq ?? null, purchase_lot_size: selected?.purchase_lot_size ?? null,
     unit_price: selected?.unit_price ?? null,
   })
-  if (!context.magasin_id) calculation.missing_data.push("SITE")
-  if (!selected) calculation.missing_data.push("SUPPLIER")
-  calculation.missing_data = [...new Set(calculation.missing_data)].sort()
+  addScopeMissingData(calculation, context, Boolean(selected))
   const budget = await budgetFor(queryer, context, selected, calculation.estimated_total)
   if (budget.status === "MISSING") calculation.warnings.push("BUDGET_MISSING")
   if (selected?.price_source === "HISTORICAL") calculation.warnings.push("HISTORICAL_PRICE")
-  const status = calculation.net_requirement_qty <= 0
-    ? "RESOLUE"
-    : calculation.missing_data.length > 0
-      ? "A_COMPLETER"
+  calculation.warnings = [...new Set(calculation.warnings)].sort()
+  const status = hasBlockingScopeData(calculation) || (calculation.net_requirement_qty > 0 && calculation.missing_data.length > 0)
+    ? "A_COMPLETER"
+    : calculation.net_requirement_qty <= 0
+      ? "RESOLUE"
       : "PROPOSEE"
   const calcJson = { ...calculation, inputs: context }
-  const existing = await queryer.query(`SELECT id::text, status FROM public.replenishment_proposals WHERE stock_level_id = $1::uuid`, [context.stock_level_id])
+  const existing = await queryer.query(
+    `SELECT id::text, status FROM public.replenishment_proposals
+      WHERE article_id = $1::uuid AND magasin_id IS NOT DISTINCT FROM $2::uuid`,
+    [context.article_id, context.magasin_id]
+  )
+  const conflictTarget = context.magasin_id
+    ? "(article_id, magasin_id) WHERE magasin_id IS NOT NULL"
+    : "(article_id) WHERE magasin_id IS NULL"
   const result = await queryer.query<{ id: string }>(
     `INSERT INTO public.replenishment_proposals (
-       stock_level_id, article_id, location_id, magasin_id, status, reason_code, stock_unit,
+       stock_level_ids, article_id, magasin_id, status, reason_code, stock_unit,
        qty_on_hand, qty_reserved, qty_available, qty_open_orders, minimum_stock_qty, safety_stock_qty,
        target_stock_qty, net_requirement_qty, selected_catalogue_id, selected_supplier_id,
        purchase_unit, stock_units_per_purchase_unit, proposed_purchase_qty, proposed_stock_qty,
        unit_price, currency, estimated_total, budget_status, budget_remaining, missing_data, warnings, calculation,
        resolution_reason)
-     VALUES ($1::uuid,$2::uuid,$3::uuid,$4::uuid,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,
-       $16::uuid,$17::uuid,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27::text[],$28::text[],$29::jsonb,$30)
-     ON CONFLICT (stock_level_id) DO UPDATE SET
-       article_id=EXCLUDED.article_id, location_id=EXCLUDED.location_id, magasin_id=EXCLUDED.magasin_id,
+     VALUES ($1::uuid[],$2::uuid,$3::uuid,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,
+       $15::uuid,$16::uuid,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26::text[],$27::text[],$28::jsonb,$29)
+     ON CONFLICT ${conflictTarget} DO UPDATE SET
+       stock_level_ids=EXCLUDED.stock_level_ids,
        status=EXCLUDED.status, version=replenishment_proposals.version+1, reason_code=EXCLUDED.reason_code,
        stock_unit=EXCLUDED.stock_unit, qty_on_hand=EXCLUDED.qty_on_hand, qty_reserved=EXCLUDED.qty_reserved,
        qty_available=EXCLUDED.qty_available, qty_open_orders=EXCLUDED.qty_open_orders,
@@ -294,14 +398,14 @@ async function upsertProposal(queryer: Queryer, context: StockContext, actorId: 
        missing_data=EXCLUDED.missing_data, warnings=EXCLUDED.warnings, calculation=EXCLUDED.calculation,
        resolution_reason=EXCLUDED.resolution_reason, last_recalculated_at=now(), updated_at=now()
      RETURNING id::text`,
-    [context.stock_level_id, context.article_id, context.location_id, context.magasin_id, status,
+    [context.stock_level_ids, context.article_id, context.magasin_id, status,
       calculation.reason_code, context.stock_unit, context.qty_on_hand, context.qty_reserved, context.qty_available,
       context.qty_open_orders, context.min_qty, context.safety_stock_qty, calculation.target_stock_qty,
       calculation.net_requirement_qty, selected?.catalogue_id ?? null, selected?.supplier_id ?? null,
       selected?.purchase_unit ?? null, calculation.stock_units_per_purchase_unit,
       calculation.proposed_purchase_qty, calculation.proposed_stock_qty, selected?.unit_price ?? null,
       selected?.currency ?? null, calculation.estimated_total, budget.status, budget.remaining,
-      calculation.missing_data, [...new Set(calculation.warnings)].sort(), JSON.stringify(calcJson),
+      calculation.missing_data, calculation.warnings, JSON.stringify(calcJson),
       status === "RESOLUE" ? "Stock disponible et commandes ouvertes couvrent la cible" : null]
   )
   const id = result.rows[0].id
@@ -311,7 +415,12 @@ async function upsertProposal(queryer: Queryer, context: StockContext, actorId: 
          (proposal_id,event_type,from_status,to_status,calculation,details,actor_id)
        VALUES ($1::uuid,$2,$3,$4,$5::jsonb,$6::jsonb,$7)`,
       [id, existing.rows[0] ? "RECALCULATED" : "GENERATED", existing.rows[0]?.status ?? null, status,
-        JSON.stringify(calcJson), JSON.stringify({ selected_catalogue_id: selected?.catalogue_id ?? null }), actorId]
+        JSON.stringify(calcJson), JSON.stringify({
+          article_id: context.article_id,
+          magasin_id: context.magasin_id,
+          stock_level_ids: context.stock_level_ids,
+          selected_catalogue_id: selected?.catalogue_id ?? null,
+        }), actorId]
     )
   }
   return { id, status }
@@ -329,12 +438,10 @@ async function hydrateProposals(queryer: Queryer, filters: ListReplenishmentProp
   const result = await queryer.query(
     `SELECT p.*, a.code AS article_code, a.designation AS article_designation,
             COALESCE(m.name,m.libelle,m.code_magasin)::text AS magasin_name,
-            COALESCE(e.name,e.libelle,e.code)::text AS emplacement_name,
             cf.code AS commande_fournisseur_code
        FROM public.replenishment_proposals p
        JOIN public.articles a ON a.id = p.article_id
        LEFT JOIN public.magasins m ON m.id = p.magasin_id
-       LEFT JOIN public.emplacements e ON e.location_id = p.location_id
        LEFT JOIN public.commande_fournisseur cf ON cf.id = p.commande_fournisseur_id
       WHERE ${where.join(" AND ")}
       ORDER BY CASE p.status WHEN 'A_COMPLETER' THEN 0 WHEN 'PROPOSEE' THEN 1 ELSE 2 END,
@@ -344,13 +451,18 @@ async function hydrateProposals(queryer: Queryer, filters: ListReplenishmentProp
   )
   const items: ReplenishmentProposal[] = []
   for (const row of result.rows) {
-    const contexts = await readStockContexts(queryer, { stock_level_id: row.stock_level_id, limit: 1 })
+    const contexts = await readStockContexts(queryer, {
+      scope: { article_id: row.article_id, magasin_id: row.magasin_id ?? null },
+      limit: 1,
+    })
     const candidates = contexts[0] ? await loadCandidates(queryer, contexts[0]) : []
     items.push({
       id: row.id, status: row.status, version: Number(row.version), reason_code: row.reason_code,
       article_id: row.article_id, article_code: row.article_code, article_designation: row.article_designation,
-      stock_level_id: row.stock_level_id, magasin_id: row.magasin_id ?? null, magasin_name: row.magasin_name ?? null,
-      emplacement_name: row.emplacement_name ?? null, stock_unit: row.stock_unit ?? null,
+      stock_level_ids: row.stock_level_ids ?? [], stock_level_count: (row.stock_level_ids ?? []).length,
+      magasin_id: row.magasin_id ?? null, magasin_name: row.magasin_name ?? null,
+      emplacement_name: (row.stock_level_ids ?? []).length > 1 ? `${row.stock_level_ids.length} emplacements` : null,
+      stock_unit: row.stock_unit ?? null,
       qty_on_hand: n(row.qty_on_hand), qty_reserved: n(row.qty_reserved), qty_available: n(row.qty_available),
       qty_open_orders: n(row.qty_open_orders), minimum_stock_qty: nullableNumber(row.minimum_stock_qty),
       safety_stock_qty: nullableNumber(row.safety_stock_qty), target_stock_qty: nullableNumber(row.target_stock_qty),
@@ -438,21 +550,44 @@ export async function repoValidateReplenishmentProposal(
       return { ...result, idempotent_replay: true }
     }
 
-    await client.query(`SELECT id FROM public.stock_levels WHERE id=$1::uuid FOR UPDATE`, [proposal.stock_level_id])
-    const stock = (await readStockContexts(client, { stock_level_id: proposal.stock_level_id, limit: 1 }))[0]
-    if (!stock) throw new HttpError(409, "REPLENISHMENT_SOURCE_CHANGED", "Le niveau de stock n'est plus géré.")
+    const stockLevelIds = Array.isArray(proposal.stock_level_ids) ? proposal.stock_level_ids as string[] : []
+    if (!stockLevelIds.length) {
+      throw new HttpError(409, "REPLENISHMENT_SOURCE_CHANGED", "Le périmètre article/site n'a plus de niveaux de stock.")
+    }
+    const lockedLevels = await client.query(
+      `SELECT id FROM public.stock_levels WHERE id = ANY($1::uuid[]) ORDER BY id FOR UPDATE`,
+      [stockLevelIds]
+    )
+    if (lockedLevels.rowCount !== stockLevelIds.length) {
+      throw new HttpError(409, "REPLENISHMENT_SOURCE_CHANGED", "Le périmètre article/site a changé; relancez le calcul.")
+    }
+    const stock = (await readStockContexts(client, {
+      scope: { article_id: proposal.article_id, magasin_id: proposal.magasin_id ?? null },
+      limit: 1,
+    }))[0]
+    if (!stock) throw new HttpError(409, "REPLENISHMENT_SOURCE_CHANGED", "Le périmètre article/site n'est plus géré.")
+    if (stock.stock_level_ids.join(",") !== [...stockLevelIds].sort().join(",")) {
+      throw new HttpError(409, "REPLENISHMENT_SOURCE_CHANGED", "Les niveaux du périmètre article/site ont changé; relancez le calcul.")
+    }
     const candidates = await loadCandidates(client, stock)
     const candidate = candidates.find((item) => item.catalogue_id === body.catalogue_id)
     if (!candidate) throw new HttpError(422, "SUPPLIER_CANDIDATE_INVALID", "Le fournisseur ou son catalogue n'est plus disponible.")
     if (candidate.blockers.length) throw new HttpError(422, "UNIT_CONVERSION_REQUIRED", "La conversion d'unité du catalogue est incomplète.", { blockers: candidate.blockers })
     const calculation = calculateReplenishment({
       qty_on_hand: stock.qty_on_hand, qty_reserved: stock.qty_reserved, qty_available: stock.qty_available,
-      qty_open_orders: stock.qty_open_orders, minimum_stock_qty: stock.min_qty,
+      qty_open_orders: stock.qty_open_orders, open_order_conversion_missing: stock.open_order_conversion_missing,
+      minimum_stock_qty: stock.min_qty,
       safety_stock_qty: stock.safety_stock_qty, target_stock_qty: stock.target_stock_qty,
       reorder_qty: stock.reorder_qty, stock_unit: stock.stock_unit, purchase_unit: candidate.purchase_unit,
       stock_units_per_purchase_unit: candidate.stock_units_per_purchase_unit, supplier_moq: candidate.moq,
       purchase_lot_size: candidate.purchase_lot_size, unit_price: candidate.unit_price,
     })
+    addScopeMissingData(calculation, stock, true)
+    if (hasBlockingScopeData(calculation)) {
+      throw new HttpError(422, "REPLENISHMENT_DATA_INCOMPLETE", "Le périmètre article/site ou un reliquat historique exige une correction avant validation.", {
+        missing_data: calculation.missing_data,
+      })
+    }
     if (calculation.net_requirement_qty <= 0) {
       await client.query(
         `UPDATE public.replenishment_proposals SET status='RESOLUE',version=version+1,
@@ -505,12 +640,14 @@ export async function repoValidateReplenishmentProposal(
         stock.stock_unit, calculation.stock_units_per_purchase_unit, calculation.proposed_purchase_qty,
         candidate.unit_price ?? 0, candidate.lead_time_days, stock.magasin_id, context.user_id]
     )
-    await client.query(
-      `INSERT INTO public.commande_fournisseur_ligne_besoin
-        (ligne_id,besoin_type,besoin_ref,besoin_of_id,quantite_couverte)
-       VALUES($1::uuid,'STOCK_LEVEL',$2,0,$3)`,
-      [line.rows[0].id, stock.stock_level_id, calculation.proposed_stock_qty]
-    )
+    for (const coverage of allocateCoverage(calculation.proposed_stock_qty, stock.stock_level_ids)) {
+      await client.query(
+        `INSERT INTO public.commande_fournisseur_ligne_besoin
+          (ligne_id,besoin_type,besoin_ref,besoin_of_id,quantite_couverte)
+         VALUES($1::uuid,'STOCK_LEVEL',$2,0,$3)`,
+        [line.rows[0].id, coverage.stock_level_id, coverage.quantity]
+      )
+    }
     await client.query(
       `INSERT INTO public.commande_fournisseur_transition(commande_id,from_statut,to_statut,motif,acteur_id)
        VALUES($1::uuid,NULL,'BROUILLON','Validation humaine d''une proposition de réapprovisionnement',$2)`, [orderId, context.user_id]

--- a/src/module/commande-fournisseur/routes/replenishment-proposal.routes.ts
+++ b/src/module/commande-fournisseur/routes/replenishment-proposal.routes.ts
@@ -1,0 +1,27 @@
+import { Router, type RequestHandler } from "express"
+
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context"
+import { HttpError } from "../../../utils/httpError"
+import { roleHasCommandeFournisseurCapability, type CommandeFournisseurCapability } from "../domain/commande-fournisseur-rbac"
+import {
+  listReplenishmentProposals,
+  refreshReplenishmentProposals,
+  validateReplenishmentProposal,
+} from "../controllers/replenishment-proposal.controller"
+
+function requireCapability(capability: CommandeFournisseurCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (!requestHasGrantedAccountModuleAccess(req) && !roleHasCommandeFournisseurCapability(req.user?.role, capability)) {
+      next(new HttpError(403, "FORBIDDEN", "Votre rôle ne permet pas cette action de réapprovisionnement."))
+      return
+    }
+    next()
+  }
+}
+
+const router = Router()
+router.get("/", requireCapability("read"), requireCapability("prices"), listReplenishmentProposals)
+router.post("/refresh", requireCapability("create"), requireCapability("prices"), refreshReplenishmentProposals)
+router.post("/:id/validate", requireCapability("create"), requireCapability("prices"), validateReplenishmentProposal)
+
+export default router

--- a/src/module/commande-fournisseur/services/replenishment-proposal.service.ts
+++ b/src/module/commande-fournisseur/services/replenishment-proposal.service.ts
@@ -1,0 +1,23 @@
+import {
+  repoListReplenishmentProposals,
+  repoRefreshReplenishmentProposals,
+  repoValidateReplenishmentProposal,
+} from "../repository/replenishment-proposal.repository"
+import type { AuditContext } from "../repository/commande-fournisseur.repository"
+import type {
+  ListReplenishmentProposalsDTO,
+  RefreshReplenishmentProposalsDTO,
+  ValidateReplenishmentProposalDTO,
+} from "../validators/replenishment-proposal.validators"
+
+export const listReplenishmentProposalsSVC = (query: ListReplenishmentProposalsDTO) =>
+  repoListReplenishmentProposals(query)
+
+export const refreshReplenishmentProposalsSVC = (body: RefreshReplenishmentProposalsDTO, audit: AuditContext) =>
+  repoRefreshReplenishmentProposals(body, audit)
+
+export const validateReplenishmentProposalSVC = (
+  id: string,
+  body: ValidateReplenishmentProposalDTO,
+  audit: AuditContext
+) => repoValidateReplenishmentProposal(id, body, audit)

--- a/src/module/commande-fournisseur/types/replenishment-proposal.types.ts
+++ b/src/module/commande-fournisseur/types/replenishment-proposal.types.ts
@@ -1,0 +1,65 @@
+export type ReplenishmentSupplierCandidate = {
+  catalogue_id: string
+  supplier_id: string
+  supplier_code: string | null
+  supplier_name: string
+  purchase_unit: string | null
+  stock_unit: string | null
+  stock_units_per_purchase_unit: number | null
+  moq: number | null
+  purchase_lot_size: number | null
+  lead_time_days: number | null
+  unit_price: number | null
+  currency: string
+  price_source: "CATALOGUE" | "HISTORICAL" | "MISSING"
+  last_order_unit_price: number | null
+  last_order_date: string | null
+  preferred: boolean
+  blockers: string[]
+}
+
+export type ReplenishmentProposal = {
+  id: string
+  status: "PROPOSEE" | "A_COMPLETER" | "CONVERTIE" | "RESOLUE"
+  version: number
+  reason_code: string
+  article_id: string
+  article_code: string
+  article_designation: string
+  stock_level_id: string
+  magasin_id: string | null
+  magasin_name: string | null
+  emplacement_name: string | null
+  stock_unit: string | null
+  qty_on_hand: number
+  qty_reserved: number
+  qty_available: number
+  qty_open_orders: number
+  minimum_stock_qty: number | null
+  safety_stock_qty: number | null
+  target_stock_qty: number | null
+  net_requirement_qty: number
+  selected_catalogue_id: string | null
+  proposed_purchase_qty: number | null
+  proposed_stock_qty: number | null
+  unit_price: number | null
+  currency: string | null
+  estimated_total: number | null
+  budget_status: "OK" | "EXCEEDED" | "MISSING" | "NOT_APPLICABLE"
+  budget_remaining: number | null
+  missing_data: string[]
+  warnings: string[]
+  calculation: Record<string, unknown>
+  candidates: ReplenishmentSupplierCandidate[]
+  commande_fournisseur_id: string | null
+  commande_fournisseur_code: string | null
+  last_recalculated_at: string
+  updated_at: string
+}
+
+export type ReplenishmentRefreshResult = {
+  items: ReplenishmentProposal[]
+  refreshed: number
+  resolved: number
+  as_of: string
+}

--- a/src/module/commande-fournisseur/types/replenishment-proposal.types.ts
+++ b/src/module/commande-fournisseur/types/replenishment-proposal.types.ts
@@ -26,7 +26,8 @@ export type ReplenishmentProposal = {
   article_id: string
   article_code: string
   article_designation: string
-  stock_level_id: string
+  stock_level_ids: string[]
+  stock_level_count: number
   magasin_id: string | null
   magasin_name: string | null
   emplacement_name: string | null

--- a/src/module/commande-fournisseur/validators/replenishment-proposal.validators.ts
+++ b/src/module/commande-fournisseur/validators/replenishment-proposal.validators.ts
@@ -1,0 +1,33 @@
+import { z } from "zod"
+
+const uuid = z.string().uuid()
+
+export const listReplenishmentProposalsSchema = z.object({
+  query: z.object({
+    status: z.enum(["PROPOSEE", "A_COMPLETER", "CONVERTIE", "RESOLUE"]).optional(),
+    magasin_id: uuid.optional(),
+    article_id: uuid.optional(),
+    limit: z.coerce.number().int().min(1).max(500).default(200),
+  }).strict(),
+})
+
+export const refreshReplenishmentProposalsSchema = z.object({
+  body: z.object({
+    magasin_id: uuid.optional(),
+    article_id: uuid.optional(),
+    limit: z.number().int().min(1).max(500).default(200),
+  }).strict().default({ limit: 200 }),
+})
+
+export const validateReplenishmentProposalSchema = z.object({
+  params: z.object({ id: uuid }).strict(),
+  body: z.object({
+    catalogue_id: uuid,
+    expected_version: z.number().int().positive(),
+    idempotency_key: z.string().trim().min(8).max(200),
+  }).strict(),
+})
+
+export type ListReplenishmentProposalsDTO = z.infer<typeof listReplenishmentProposalsSchema>["query"]
+export type RefreshReplenishmentProposalsDTO = z.infer<typeof refreshReplenishmentProposalsSchema>["body"]
+export type ValidateReplenishmentProposalDTO = z.infer<typeof validateReplenishmentProposalSchema>["body"]

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -33,6 +33,7 @@ import programmationRoutes from "../module/programmation/routes/programmation.ro
 import operationDossiersRoutes from "../module/operation-dossiers/routes/operation-dossiers.routes";
 import fournisseursRoutes from "../module/fournisseurs/routes/fournisseurs.routes";
 import commandeFournisseurRoutes from "../module/commande-fournisseur/routes/commande-fournisseur.routes";
+import replenishmentProposalRoutes from "../module/commande-fournisseur/routes/replenishment-proposal.routes";
 import receptionsRoutes from "../module/receptions/routes/receptions.routes";
 import metrologieRoutes from "../module/metrologie/routes/metrologie.routes";
 import metrology360Routes from "../module/metrologie/routes/metrology-360.routes";
@@ -138,6 +139,7 @@ router.use("/stock", stockRoutes);
 router.use("/dossiers", operationDossiersRoutes);
 router.use("/fournisseurs", fournisseursRoutes);
 router.use("/commandes-fournisseurs", commandeFournisseurRoutes); // Module « Commandes fournisseurs » (#172) — BCF
+router.use("/replenishment-proposals", replenishmentProposalRoutes); // FEAT-CERP-0003 — suggestions sans achat automatique
 router.use("/receptions", receptionsRoutes);
 // Métrologie 360 (#229) monté AVANT le routeur historique : ses routes
 // déclarent des capacités fines (refus par défaut) et ne partagent pas les


### PR DESCRIPTION
Promeut depuis dev la livraison validée des propositions de réapprovisionnement et son cycle SQL contrôlé.

## Summary by Sourcery

Introduce explainable, human-validated replenishment proposals integrated with supplier orders and access control.

New Features:
- Add end-to-end infrastructure for replenishment proposals, including domain model, repository, service, controller, validators, and Express routes under /api/v1/replenishment-proposals.
- Implement SQL schema, preflight, verify, and rollback migrations to support replenishment budgets, proposals, immutable events, idempotence, and stock-level metadata.
- Expose RBAC-protected APIs to list, refresh, and validate replenishment proposals, wired into the commandes-fournisseurs module catalog and routing.

Bug Fixes:
- Ensure cancelling a supplier order marks linked stock-level coverage as annulled and records released_need_links in audit logs, preventing double-order protection issues.

Enhancements:
- Extend module catalog and access-control gates so replenishment proposal routes inherit the commandes-fournisseurs module access context.
- Add deterministic stock coverage allocation, replenishment calculation logic, and domain tests for unit conversion, budgeting, and migration integrity.
- Add idempotent validation workflow that recalculates proposals, enforces optimistic locking and budget checks, and converts approved proposals into draft supplier orders with stock coverage links.

Tests:
- Add comprehensive domain and repository tests for replenishment calculations, migrations, idempotency, and replacement of cancelled orders, plus RBAC and routing tests for new APIs and module gates.