### PR TITLE
fix(db): support replenishment verification on PostgreSQL 17

### DIFF
--- a/db/patches/support/20260805_replenishment_proposals.preflight.sql
+++ b/db/patches/support/20260805_replenishment_proposals.preflight.sql
@@ -341,7 +341,12 @@ BEGIN
   IF registered_sha256 IS DISTINCT FROM '7e574b34d6c795630b9c08be2d6aded2' THEN RAISE EXCEPTION 'FEAT-CERP-0003 preflight: owned trigger mapping/event is altered'; END IF;
   SELECT md5(format('%s|%s|%s|%s|%s|%s', pg_get_functiondef(p.oid), p.provolatile, p.proisstrict, p.prosecdef, p.proleakproof, coalesce(array_to_string(p.proconfig, E'\n'), '')))
     INTO registered_sha256 FROM pg_proc p WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure;
-  IF registered_sha256 IS DISTINCT FROM '0e1298dced0e423190dfa3dc059ab371' THEN RAISE EXCEPTION 'FEAT-CERP-0003 preflight: immutable function definition/settings are altered'; END IF;
+  -- pg_get_functiondef() has different canonical formatting on PostgreSQL 16 and 17.
+  IF registered_sha256 IS DISTINCT FROM (CASE current_setting('server_version_num')::integer / 10000
+      WHEN 16 THEN '0e1298dced0e423190dfa3dc059ab371'
+      WHEN 17 THEN 'ccbe4b8458960dcbbd17d206a759d990'
+      ELSE NULL
+    END) THEN RAISE EXCEPTION 'FEAT-CERP-0003 preflight: immutable function definition/settings are altered'; END IF;
 END
 $preflight$;
 

--- a/db/patches/support/20260805_replenishment_proposals.rollback.sql
+++ b/db/patches/support/20260805_replenishment_proposals.rollback.sql
@@ -304,7 +304,12 @@ BEGIN
   IF registered_sha256 IS DISTINCT FROM '7e574b34d6c795630b9c08be2d6aded2' THEN RAISE EXCEPTION 'FEAT-CERP-0003 rollback: owned trigger mapping/event is altered'; END IF;
   SELECT md5(format('%s|%s|%s|%s|%s|%s', pg_get_functiondef(p.oid), p.provolatile, p.proisstrict, p.prosecdef, p.proleakproof, coalesce(array_to_string(p.proconfig, E'\n'), '')))
     INTO registered_sha256 FROM pg_proc p WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure;
-  IF registered_sha256 IS DISTINCT FROM '0e1298dced0e423190dfa3dc059ab371' THEN RAISE EXCEPTION 'FEAT-CERP-0003 rollback: immutable function definition/settings are altered'; END IF;
+  -- pg_get_functiondef() has different canonical formatting on PostgreSQL 16 and 17.
+  IF registered_sha256 IS DISTINCT FROM (CASE current_setting('server_version_num')::integer / 10000
+      WHEN 16 THEN '0e1298dced0e423190dfa3dc059ab371'
+      WHEN 17 THEN 'ccbe4b8458960dcbbd17d206a759d990'
+      ELSE NULL
+    END) THEN RAISE EXCEPTION 'FEAT-CERP-0003 rollback: immutable function definition/settings are altered'; END IF;
 
   SELECT (
     (SELECT COUNT(*) FROM public.replenishment_budgets)

--- a/db/patches/support/20260805_replenishment_proposals.verify.sql
+++ b/db/patches/support/20260805_replenishment_proposals.verify.sql
@@ -299,7 +299,12 @@ BEGIN
   IF registered_sha256 IS DISTINCT FROM '7e574b34d6c795630b9c08be2d6aded2' THEN RAISE EXCEPTION 'FEAT-CERP-0003 verify: owned trigger mapping/event is altered'; END IF;
   SELECT md5(format('%s|%s|%s|%s|%s|%s', pg_get_functiondef(p.oid), p.provolatile, p.proisstrict, p.prosecdef, p.proleakproof, coalesce(array_to_string(p.proconfig, E'\n'), '')))
     INTO registered_sha256 FROM pg_proc p WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure;
-  IF registered_sha256 IS DISTINCT FROM '0e1298dced0e423190dfa3dc059ab371' THEN RAISE EXCEPTION 'FEAT-CERP-0003 verify: immutable function definition/settings are altered'; END IF;
+  -- pg_get_functiondef() has different canonical formatting on PostgreSQL 16 and 17.
+  IF registered_sha256 IS DISTINCT FROM (CASE current_setting('server_version_num')::integer / 10000
+      WHEN 16 THEN '0e1298dced0e423190dfa3dc059ab371'
+      WHEN 17 THEN 'ccbe4b8458960dcbbd17d206a759d990'
+      ELSE NULL
+    END) THEN RAISE EXCEPTION 'FEAT-CERP-0003 verify: immutable function definition/settings are altered'; END IF;
 END
 $verify$;
 

--- a/src/__tests__/replenishment-proposals.domain.test.ts
+++ b/src/__tests__/replenishment-proposals.domain.test.ts
@@ -152,6 +152,10 @@ describe("FEAT-CERP-0003 boundaries", () => {
       expect(lifecycleScript).toMatch(/owned index definition is altered/)
       expect(lifecycleScript).toMatch(/owned trigger mapping\/event is altered/)
       expect(lifecycleScript).toMatch(/immutable function definition\/settings are altered/)
+      expect(lifecycleScript).toMatch(/current_setting\('server_version_num'\)/)
+      expect(lifecycleScript).toContain("0e1298dced0e423190dfa3dc059ab371")
+      expect(lifecycleScript).toContain("ccbe4b8458960dcbbd17d206a759d990")
+      expect(lifecycleScript).toMatch(/WHEN 16[\s\S]*WHEN 17[\s\S]*ELSE NULL/)
     }
     expect(preflight).toMatch(/BEGIN TRANSACTION READ ONLY/)
     expect(preflight).toMatch(/target artifact exists without migration ledger provenance/)


### PR DESCRIPTION
Production PostgreSQL 17 formats pg_get_functiondef differently from PostgreSQL 16. Pin the exact supported signature per server major in preflight, verify, and rollback. Validated against PostgreSQL 17 cerp_test, targeted tests, full suite, and build.

## Summary by Sourcery

Adjust replenishment proposal lifecycle scripts to tolerate PostgreSQL version-specific canonical function formatting while preserving integrity checks.

Bug Fixes:
- Relax immutable function definition hash checks to accept distinct pg_get_functiondef output on PostgreSQL 16 and 17 in preflight, verify, and rollback scripts without weakening integrity guarantees.

Tests:
- Extend replenishment proposals domain test to assert the presence of version-conditional hashing logic and both PostgreSQL 16 and 17 hash values in lifecycle scripts.