### PR TITLE
release: PostgreSQL 17 replenishment verification

### DIFF
--- a/db/patches/support/20260805_replenishment_proposals.preflight.sql
+++ b/db/patches/support/20260805_replenishment_proposals.preflight.sql
@@ -341,7 +341,12 @@ BEGIN
   IF registered_sha256 IS DISTINCT FROM '7e574b34d6c795630b9c08be2d6aded2' THEN RAISE EXCEPTION 'FEAT-CERP-0003 preflight: owned trigger mapping/event is altered'; END IF;
   SELECT md5(format('%s|%s|%s|%s|%s|%s', pg_get_functiondef(p.oid), p.provolatile, p.proisstrict, p.prosecdef, p.proleakproof, coalesce(array_to_string(p.proconfig, E'\n'), '')))
     INTO registered_sha256 FROM pg_proc p WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure;
-  IF registered_sha256 IS DISTINCT FROM '0e1298dced0e423190dfa3dc059ab371' THEN RAISE EXCEPTION 'FEAT-CERP-0003 preflight: immutable function definition/settings are altered'; END IF;
+  -- pg_get_functiondef() has different canonical formatting on PostgreSQL 16 and 17.
+  IF registered_sha256 IS DISTINCT FROM (CASE current_setting('server_version_num')::integer / 10000
+      WHEN 16 THEN '0e1298dced0e423190dfa3dc059ab371'
+      WHEN 17 THEN 'ccbe4b8458960dcbbd17d206a759d990'
+      ELSE NULL
+    END) THEN RAISE EXCEPTION 'FEAT-CERP-0003 preflight: immutable function definition/settings are altered'; END IF;
 END
 $preflight$;
 

--- a/db/patches/support/20260805_replenishment_proposals.rollback.sql
+++ b/db/patches/support/20260805_replenishment_proposals.rollback.sql
@@ -304,7 +304,12 @@ BEGIN
   IF registered_sha256 IS DISTINCT FROM '7e574b34d6c795630b9c08be2d6aded2' THEN RAISE EXCEPTION 'FEAT-CERP-0003 rollback: owned trigger mapping/event is altered'; END IF;
   SELECT md5(format('%s|%s|%s|%s|%s|%s', pg_get_functiondef(p.oid), p.provolatile, p.proisstrict, p.prosecdef, p.proleakproof, coalesce(array_to_string(p.proconfig, E'\n'), '')))
     INTO registered_sha256 FROM pg_proc p WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure;
-  IF registered_sha256 IS DISTINCT FROM '0e1298dced0e423190dfa3dc059ab371' THEN RAISE EXCEPTION 'FEAT-CERP-0003 rollback: immutable function definition/settings are altered'; END IF;
+  -- pg_get_functiondef() has different canonical formatting on PostgreSQL 16 and 17.
+  IF registered_sha256 IS DISTINCT FROM (CASE current_setting('server_version_num')::integer / 10000
+      WHEN 16 THEN '0e1298dced0e423190dfa3dc059ab371'
+      WHEN 17 THEN 'ccbe4b8458960dcbbd17d206a759d990'
+      ELSE NULL
+    END) THEN RAISE EXCEPTION 'FEAT-CERP-0003 rollback: immutable function definition/settings are altered'; END IF;
 
   SELECT (
     (SELECT COUNT(*) FROM public.replenishment_budgets)

--- a/db/patches/support/20260805_replenishment_proposals.verify.sql
+++ b/db/patches/support/20260805_replenishment_proposals.verify.sql
@@ -299,7 +299,12 @@ BEGIN
   IF registered_sha256 IS DISTINCT FROM '7e574b34d6c795630b9c08be2d6aded2' THEN RAISE EXCEPTION 'FEAT-CERP-0003 verify: owned trigger mapping/event is altered'; END IF;
   SELECT md5(format('%s|%s|%s|%s|%s|%s', pg_get_functiondef(p.oid), p.provolatile, p.proisstrict, p.prosecdef, p.proleakproof, coalesce(array_to_string(p.proconfig, E'\n'), '')))
     INTO registered_sha256 FROM pg_proc p WHERE p.oid = 'public.fn_replenishment_event_immutable()'::regprocedure;
-  IF registered_sha256 IS DISTINCT FROM '0e1298dced0e423190dfa3dc059ab371' THEN RAISE EXCEPTION 'FEAT-CERP-0003 verify: immutable function definition/settings are altered'; END IF;
+  -- pg_get_functiondef() has different canonical formatting on PostgreSQL 16 and 17.
+  IF registered_sha256 IS DISTINCT FROM (CASE current_setting('server_version_num')::integer / 10000
+      WHEN 16 THEN '0e1298dced0e423190dfa3dc059ab371'
+      WHEN 17 THEN 'ccbe4b8458960dcbbd17d206a759d990'
+      ELSE NULL
+    END) THEN RAISE EXCEPTION 'FEAT-CERP-0003 verify: immutable function definition/settings are altered'; END IF;
 END
 $verify$;
 

--- a/src/__tests__/replenishment-proposals.domain.test.ts
+++ b/src/__tests__/replenishment-proposals.domain.test.ts
@@ -152,6 +152,10 @@ describe("FEAT-CERP-0003 boundaries", () => {
       expect(lifecycleScript).toMatch(/owned index definition is altered/)
       expect(lifecycleScript).toMatch(/owned trigger mapping\/event is altered/)
       expect(lifecycleScript).toMatch(/immutable function definition\/settings are altered/)
+      expect(lifecycleScript).toMatch(/current_setting\('server_version_num'\)/)
+      expect(lifecycleScript).toContain("0e1298dced0e423190dfa3dc059ab371")
+      expect(lifecycleScript).toContain("ccbe4b8458960dcbbd17d206a759d990")
+      expect(lifecycleScript).toMatch(/WHEN 16[\s\S]*WHEN 17[\s\S]*ELSE NULL/)
     }
     expect(preflight).toMatch(/BEGIN TRANSACTION READ ONLY/)
     expect(preflight).toMatch(/target artifact exists without migration ledger provenance/)


### PR DESCRIPTION
Promote the PostgreSQL 17-safe replenishment lifecycle verification from dev to main after successful production-like validation.

## Summary by Sourcery

Allow replenishment lifecycle verification scripts to run safely on both PostgreSQL 16 and 17 by accommodating version-specific canonical function definitions.

New Features:
- Add PostgreSQL-version-aware checksum validation for the immutable replenishment event function in preflight, rollback, and verify scripts.

Tests:
- Extend replenishment lifecycle boundary tests to assert the presence of PostgreSQL 16/17 specific checksum and version checks in the generated lifecycle scripts.