### PR TITLE
release(backend): promote planning convergence governance

### DIFF
--- a/db/patches/20260805_planning_convergence_governance.sql
+++ b/db/patches/20260805_planning_convergence_governance.sql
@@ -1,0 +1,100 @@
+-- Premium / legacy planning convergence governance.
+-- Additive only: the legacy dashboard board and all planning data remain in
+-- place. Both flags start OFF, so the baseline is behaviorally inert.
+
+DO $preexisting_guard$
+BEGIN
+  IF to_regclass('public.planning_surface_usage_daily') IS NOT NULL
+     OR to_regprocedure('public.prune_planning_surface_usage_daily(integer)') IS NOT NULL THEN
+    RAISE EXCEPTION 'planning convergence artifact already exists without this migration ledger entry';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.app_feature_flags
+    WHERE key IN ('PLANNING_LEGACY_DASHBOARD_RETIREMENT', 'PLANNING_USAGE_METRICS')
+  ) THEN
+    RAISE EXCEPTION 'planning convergence feature flag already exists without this migration ledger entry';
+  END IF;
+END
+$preexisting_guard$;
+
+CREATE TABLE public.planning_surface_usage_daily (
+  usage_date date NOT NULL DEFAULT CURRENT_DATE,
+  surface text NOT NULL,
+  event_type text NOT NULL,
+  browser_family text NOT NULL,
+  role_bucket text NOT NULL,
+  event_count bigint NOT NULL DEFAULT 0,
+  first_seen_at timestamptz NOT NULL DEFAULT now(),
+  last_seen_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT planning_surface_usage_daily_pkey PRIMARY KEY (
+    usage_date, surface, event_type, browser_family, role_bucket
+  ),
+  CONSTRAINT planning_surface_usage_daily_surface_ck CHECK (
+    surface IN ('premium_route','legacy_dashboard')
+  ),
+  CONSTRAINT planning_surface_usage_daily_event_ck CHECK (
+    event_type IN ('view','open_premium')
+  ),
+  CONSTRAINT planning_surface_usage_daily_browser_ck CHECK (
+    browser_family IN ('chromium','firefox','webkit','other')
+  ),
+  CONSTRAINT planning_surface_usage_daily_role_ck CHECK (
+    role_bucket IN ('direction','planification','production','atelier','secretariat','other')
+  ),
+  CONSTRAINT planning_surface_usage_daily_count_ck CHECK (event_count >= 0)
+);
+
+COMMENT ON TABLE public.planning_surface_usage_daily IS
+  'Daily indicative planning-surface counters; no user_id, IP, URL, raw user-agent, session identifier or free text.';
+
+CREATE FUNCTION public.prune_planning_surface_usage_daily(p_retention_days integer DEFAULT 90)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $retention$
+DECLARE
+  deleted_rows bigint;
+BEGIN
+  IF p_retention_days IS DISTINCT FROM 90 THEN
+    RAISE EXCEPTION 'planning usage retention is fixed at 90 days';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('planning_surface_usage_daily_retention'));
+  DELETE FROM public.planning_surface_usage_daily
+  WHERE usage_date < (CURRENT_DATE - p_retention_days);
+  GET DIAGNOSTICS deleted_rows = ROW_COUNT;
+  RETURN deleted_rows;
+END
+$retention$;
+
+COMMENT ON FUNCTION public.prune_planning_surface_usage_daily(integer) IS
+  'Independent maintenance job for planning aggregates older than 90 days.';
+
+INSERT INTO public.app_feature_flags (key, name, description, enabled, environment)
+VALUES
+  (
+    'PLANNING_LEGACY_DASHBOARD_RETIREMENT',
+    'Retrait du planning dashboard historique',
+    'Rollback switch. Must remain OFF while REMOVE-CERP-0004 is NO-GO; code approval and signed parity evidence are also required.',
+    false,
+    'all'
+  ),
+  (
+    'PLANNING_USAGE_METRICS',
+    'Mesure indicative des surfaces planning',
+    'OFF until DPO, Product and QA approve aggregate collection and prove the independent 90-day retention job.',
+    false,
+    'all'
+  );
+
+ALTER TABLE public.planning_surface_usage_daily OWNER TO cerp_app;
+REVOKE ALL ON TABLE public.planning_surface_usage_daily FROM PUBLIC;
+REVOKE ALL ON TABLE public.planning_surface_usage_daily FROM cerp_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.planning_surface_usage_daily TO cerp_app;
+
+ALTER FUNCTION public.prune_planning_surface_usage_daily(integer) OWNER TO cerp_app;
+REVOKE ALL ON FUNCTION public.prune_planning_surface_usage_daily(integer) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.prune_planning_surface_usage_daily(integer) TO cerp_app;

--- a/db/patches/support/20260805_planning_convergence_governance.preflight.sql
+++ b/db/patches/support/20260805_planning_convergence_governance.preflight.sql
@@ -1,0 +1,58 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $preflight$
+DECLARE
+  expected_sha256 constant text := '4ac0aa05dc489ae5f882491e7b41cc6e96ac3bcaabd554ecddfb82d6580734dc';
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  registry_entry_exists boolean := false;
+  target_table_exists boolean := to_regclass('public.planning_surface_usage_daily') IS NOT NULL;
+  target_function_exists boolean := to_regprocedure('public.prune_planning_surface_usage_daily(integer)') IS NOT NULL;
+  target_flag_count integer;
+BEGIN
+  IF to_regclass('public.app_feature_flags') IS NULL
+     OR to_regclass('public.app_feature_flag_users') IS NULL THEN
+    RAISE EXCEPTION 'planning convergence preflight: feature-flag foundation is missing';
+  END IF;
+
+  IF to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'planning convergence preflight: required role cerp_app is missing';
+  END IF;
+
+  SELECT COUNT(*)::integer
+    INTO target_flag_count
+  FROM public.app_feature_flags
+  WHERE key IN ('PLANNING_LEGACY_DASHBOARD_RETIREMENT', 'PLANNING_USAGE_METRICS');
+
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    SELECT sha256, applied_at
+      INTO registered_sha256, registered_applied_at
+    FROM public.cerp_schema_migrations
+    WHERE filename = '20260805_planning_convergence_governance.sql';
+    registry_entry_exists := FOUND;
+  END IF;
+
+  IF registry_entry_exists THEN
+    IF registered_sha256 IS DISTINCT FROM expected_sha256 OR registered_applied_at IS NULL THEN
+      RAISE EXCEPTION 'planning convergence preflight: migration ledger provenance is invalid';
+    END IF;
+    IF NOT target_table_exists OR NOT target_function_exists OR target_flag_count <> 2 THEN
+      RAISE EXCEPTION 'planning convergence preflight: ledger exists but target artifacts are incomplete';
+    END IF;
+    RAISE NOTICE 'planning convergence preflight: exact patch is already registered';
+    RETURN;
+  END IF;
+
+  IF target_table_exists OR target_function_exists OR target_flag_count <> 0 THEN
+    RAISE EXCEPTION 'planning convergence preflight: target artifact or flag exists without its migration ledger entry';
+  END IF;
+END
+$preflight$;
+
+SELECT current_database() AS database_name,
+       current_user AS actor,
+       'planning convergence preflight passed (read-only)' AS result;
+
+ROLLBACK;

--- a/db/patches/support/20260805_planning_convergence_governance.rollback.sql
+++ b/db/patches/support/20260805_planning_convergence_governance.rollback.sql
@@ -1,0 +1,151 @@
+\set ON_ERROR_STOP on
+
+-- Schema rollback is dev/test-only. Runtime rollback is the global retirement
+-- flag: OFF keeps the legacy board available without destructive SQL.
+BEGIN;
+SET TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+DO $environment_guard$
+BEGIN
+  IF current_database() NOT IN ('cerp_dev', 'cerp_test') THEN
+    RAISE EXCEPTION 'planning convergence rollback is restricted to cerp_dev/cerp_test';
+  END IF;
+END
+$environment_guard$;
+
+SELECT pg_advisory_xact_lock(hashtext('cerp_schema_migrations'));
+
+DO $rollback$
+DECLARE
+  expected_sha256 constant text := '4ac0aa05dc489ae5f882491e7b41cc6e96ac3bcaabd554ecddfb82d6580734dc';
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  registry_entry_exists boolean := false;
+  table_exists boolean := to_regclass('public.planning_surface_usage_daily') IS NOT NULL;
+  function_exists boolean := to_regprocedure('public.prune_planning_surface_usage_daily(integer)') IS NOT NULL;
+  target_flag_count integer := 0;
+  disabled_flag_count integer := 0;
+  override_count integer := 0;
+  usage_row_count bigint := 0;
+  total_constraint_count integer;
+  expected_constraint_count integer;
+  table_owner oid;
+  function_owner oid;
+  deleted_rows integer;
+BEGIN
+  IF to_regclass('public.app_feature_flags') IS NULL
+     OR to_regclass('public.app_feature_flag_users') IS NULL THEN
+    RAISE EXCEPTION 'planning convergence rollback: feature-flag foundation is missing';
+  END IF;
+
+  PERFORM 1
+  FROM public.app_feature_flags
+  WHERE key IN ('PLANNING_LEGACY_DASHBOARD_RETIREMENT', 'PLANNING_USAGE_METRICS')
+  FOR UPDATE;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE enabled IS FALSE AND environment = 'all')::integer
+    INTO target_flag_count, disabled_flag_count
+  FROM public.app_feature_flags
+  WHERE key IN ('PLANNING_LEGACY_DASHBOARD_RETIREMENT', 'PLANNING_USAGE_METRICS');
+
+  IF to_regclass('public.cerp_schema_migrations') IS NOT NULL THEN
+    SELECT sha256, applied_at
+      INTO registered_sha256, registered_applied_at
+    FROM public.cerp_schema_migrations
+    WHERE filename = '20260805_planning_convergence_governance.sql'
+    FOR UPDATE;
+    registry_entry_exists := FOUND;
+  END IF;
+
+  IF NOT table_exists AND NOT function_exists
+     AND target_flag_count = 0 AND NOT registry_entry_exists THEN
+    RAISE NOTICE 'planning convergence rollback: exact artifacts already absent';
+    RETURN;
+  END IF;
+
+  IF NOT table_exists OR NOT function_exists OR target_flag_count <> 2
+     OR NOT registry_entry_exists THEN
+    RAISE EXCEPTION 'planning convergence rollback: target artifacts or ledger are in a partial state';
+  END IF;
+
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 OR registered_applied_at IS NULL THEN
+    RAISE EXCEPTION 'planning convergence rollback: migration ledger provenance is invalid';
+  END IF;
+
+  LOCK TABLE public.planning_surface_usage_daily IN ACCESS EXCLUSIVE MODE;
+
+  SELECT relowner INTO table_owner
+  FROM pg_class
+  WHERE oid = 'public.planning_surface_usage_daily'::regclass;
+
+  SELECT proowner INTO function_owner
+  FROM pg_proc
+  WHERE oid = 'public.prune_planning_surface_usage_daily(integer)'::regprocedure;
+
+  IF table_owner IS DISTINCT FROM to_regrole('cerp_app')
+     OR function_owner IS DISTINCT FROM to_regrole('cerp_app') THEN
+    RAISE EXCEPTION 'planning convergence rollback: target ownership is unexpected';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE conname = ANY (ARRAY[
+           'planning_surface_usage_daily_pkey',
+           'planning_surface_usage_daily_surface_ck',
+           'planning_surface_usage_daily_event_ck',
+           'planning_surface_usage_daily_browser_ck',
+           'planning_surface_usage_daily_role_ck',
+           'planning_surface_usage_daily_count_ck'
+         ]) AND convalidated)::integer
+    INTO total_constraint_count, expected_constraint_count
+  FROM pg_constraint
+  WHERE conrelid = 'public.planning_surface_usage_daily'::regclass;
+
+  IF total_constraint_count <> 6 OR expected_constraint_count <> 6 THEN
+    RAISE EXCEPTION 'planning convergence rollback: table constraints are incomplete, altered or additional';
+  END IF;
+
+  IF disabled_flag_count <> 2 THEN
+    RAISE EXCEPTION 'planning convergence rollback: a target flag is active or altered';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO override_count
+  FROM public.app_feature_flag_users ffu
+  JOIN public.app_feature_flags ff ON ff.id = ffu.feature_flag_id
+  WHERE ff.key IN ('PLANNING_LEGACY_DASHBOARD_RETIREMENT', 'PLANNING_USAGE_METRICS');
+
+  IF override_count <> 0 THEN
+    RAISE EXCEPTION 'planning convergence rollback: user overrides exist';
+  END IF;
+
+  SELECT COUNT(*)::bigint INTO usage_row_count FROM public.planning_surface_usage_daily;
+  IF usage_row_count <> 0 THEN
+    RAISE EXCEPTION 'planning convergence rollback: usage evidence exists; export/retention decision required';
+  END IF;
+
+  EXECUTE 'DROP FUNCTION public.prune_planning_surface_usage_daily(integer)';
+  EXECUTE 'DROP TABLE public.planning_surface_usage_daily';
+
+  DELETE FROM public.app_feature_flags
+  WHERE key IN ('PLANNING_LEGACY_DASHBOARD_RETIREMENT', 'PLANNING_USAGE_METRICS');
+  GET DIAGNOSTICS deleted_rows = ROW_COUNT;
+  IF deleted_rows <> 2 THEN
+    RAISE EXCEPTION 'planning convergence rollback: exact feature flags were not removed';
+  END IF;
+
+  DELETE FROM public.cerp_schema_migrations
+  WHERE filename = '20260805_planning_convergence_governance.sql'
+    AND sha256 = expected_sha256;
+  GET DIAGNOSTICS deleted_rows = ROW_COUNT;
+  IF deleted_rows <> 1 THEN
+    RAISE EXCEPTION 'planning convergence rollback: exact migration ledger row was not removed';
+  END IF;
+
+  IF to_regclass('public.planning_surface_usage_daily') IS NOT NULL
+     OR to_regprocedure('public.prune_planning_surface_usage_daily(integer)') IS NOT NULL THEN
+    RAISE EXCEPTION 'planning convergence rollback: target artifact remains after rollback';
+  END IF;
+END
+$rollback$;
+
+COMMIT;

--- a/db/patches/support/20260805_planning_convergence_governance.verify.sql
+++ b/db/patches/support/20260805_planning_convergence_governance.verify.sql
@@ -1,0 +1,122 @@
+\set ON_ERROR_STOP on
+
+-- Baseline verification passes only while both flags are globally OFF and no
+-- user override exists. Activation is a later, signed operational decision.
+BEGIN TRANSACTION READ ONLY;
+
+DO $verify$
+DECLARE
+  expected_sha256 constant text := '4ac0aa05dc489ae5f882491e7b41cc6e96ac3bcaabd554ecddfb82d6580734dc';
+  registered_sha256 text;
+  registered_applied_at timestamptz;
+  table_owner oid;
+  function_owner oid;
+  target_flag_count integer;
+  disabled_flag_count integer;
+  override_count integer;
+  total_column_count integer;
+  expected_column_count integer;
+  total_constraint_count integer;
+  expected_constraint_count integer;
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NULL THEN
+    RAISE EXCEPTION 'planning convergence verify: migration registry is missing';
+  END IF;
+
+  SELECT sha256, applied_at
+    INTO registered_sha256, registered_applied_at
+  FROM public.cerp_schema_migrations
+  WHERE filename = '20260805_planning_convergence_governance.sql';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'planning convergence verify: migration registry entry is missing';
+  END IF;
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 OR registered_applied_at IS NULL THEN
+    RAISE EXCEPTION 'planning convergence verify: migration ledger provenance is invalid';
+  END IF;
+
+  IF to_regclass('public.planning_surface_usage_daily') IS NULL
+     OR to_regprocedure('public.prune_planning_surface_usage_daily(integer)') IS NULL THEN
+    RAISE EXCEPTION 'planning convergence verify: table or retention function is missing';
+  END IF;
+
+  SELECT relowner INTO table_owner
+  FROM pg_class
+  WHERE oid = 'public.planning_surface_usage_daily'::regclass;
+
+  SELECT proowner INTO function_owner
+  FROM pg_proc
+  WHERE oid = 'public.prune_planning_surface_usage_daily(integer)'::regprocedure;
+
+  IF table_owner IS DISTINCT FROM to_regrole('cerp_app')
+     OR function_owner IS DISTINCT FROM to_regrole('cerp_app') THEN
+    RAISE EXCEPTION 'planning convergence verify: runtime ownership is not cerp_app';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE enabled IS FALSE AND environment = 'all')::integer
+    INTO target_flag_count, disabled_flag_count
+  FROM public.app_feature_flags
+  WHERE key IN ('PLANNING_LEGACY_DASHBOARD_RETIREMENT', 'PLANNING_USAGE_METRICS');
+
+  IF target_flag_count <> 2 OR disabled_flag_count <> 2 THEN
+    RAISE EXCEPTION 'planning convergence verify: both baseline flags must exist globally and remain OFF';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO override_count
+  FROM public.app_feature_flag_users ffu
+  JOIN public.app_feature_flags ff ON ff.id = ffu.feature_flag_id
+  WHERE ff.key IN ('PLANNING_LEGACY_DASHBOARD_RETIREMENT', 'PLANNING_USAGE_METRICS');
+
+  IF override_count <> 0 THEN
+    RAISE EXCEPTION 'planning convergence verify: user overrides are forbidden before signed activation';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE column_name = ANY (ARRAY[
+           'usage_date', 'surface', 'event_type', 'browser_family',
+           'role_bucket', 'event_count', 'first_seen_at', 'last_seen_at'
+         ]))::integer
+    INTO total_column_count, expected_column_count
+  FROM information_schema.columns
+  WHERE table_schema = 'public' AND table_name = 'planning_surface_usage_daily';
+
+  IF total_column_count <> 8 OR expected_column_count <> 8 THEN
+    RAISE EXCEPTION 'planning convergence verify: table columns are incomplete or additional';
+  END IF;
+
+  SELECT COUNT(*)::integer,
+         COUNT(*) FILTER (WHERE conname = ANY (ARRAY[
+           'planning_surface_usage_daily_pkey',
+           'planning_surface_usage_daily_surface_ck',
+           'planning_surface_usage_daily_event_ck',
+           'planning_surface_usage_daily_browser_ck',
+           'planning_surface_usage_daily_role_ck',
+           'planning_surface_usage_daily_count_ck'
+         ]) AND convalidated)::integer
+    INTO total_constraint_count, expected_constraint_count
+  FROM pg_constraint
+  WHERE conrelid = 'public.planning_surface_usage_daily'::regclass;
+
+  IF total_constraint_count <> 6 OR expected_constraint_count <> 6 THEN
+    RAISE EXCEPTION 'planning convergence verify: table constraints are incomplete, altered or additional';
+  END IF;
+
+  IF NOT has_table_privilege('cerp_app', 'public.planning_surface_usage_daily', 'SELECT,INSERT,UPDATE,DELETE')
+     OR NOT has_function_privilege('cerp_app', 'public.prune_planning_surface_usage_daily(integer)', 'EXECUTE') THEN
+    RAISE EXCEPTION 'planning convergence verify: runtime DML or maintenance privilege is missing';
+  END IF;
+END
+$verify$;
+
+SELECT
+  current_database() AS database_name,
+  (SELECT sha256 FROM public.cerp_schema_migrations
+   WHERE filename = '20260805_planning_convergence_governance.sql') AS migration_sha256,
+  (SELECT enabled FROM public.app_feature_flags
+   WHERE key = 'PLANNING_LEGACY_DASHBOARD_RETIREMENT') AS retirement_enabled,
+  (SELECT enabled FROM public.app_feature_flags
+   WHERE key = 'PLANNING_USAGE_METRICS') AS telemetry_enabled,
+  'planning convergence baseline verification passed (read-only)' AS result;
+
+ROLLBACK;

--- a/docs/http/planning.md
+++ b/docs/http/planning.md
@@ -1,10 +1,12 @@
 # API Planning de production — issue #171
 
-Base : `/api/v1/planning`. Toutes les routes exigent une session authentifiée et un rôle Planning
-exactement reconnu (direction, production/programmation, atelier, secrétariat ou administration
-système). Une chaîne contenant seulement le mot `admin`, telle que `administratif`, n'accorde aucun
-droit. Le chevauchement forcé reste limité à la direction, l'administration et la responsabilité
-production/atelier.
+Base : `/api/v1/planning`. Toutes les routes exigent une session authentifiée. L'accès compte ×
+module Production décidé par la Tour de contrôle est autoritaire conformément à l'ADR-0049 : une
+fois le module ouvert, le rôle affiché ne retire aucune action Planning. En l'absence de contexte
+module accordé, le fallback historique reconnaît seulement des rôles exacts
+(direction, production/programmation, atelier, secrétariat ou administration système) ; une chaîne
+contenant seulement le mot `admin`, telle que `administratif`, n'accorde aucun droit. Le
+chevauchement forcé suit lui aussi le module ouvert ; son fallback historique reste exact.
 
 ## Convention temporelle
 
@@ -17,6 +19,9 @@ deux événements adjacents sont autorisés, un chevauchement positif est un con
 
 | Méthode | Route | Objet |
 | --- | --- | --- |
+| GET | `/governance` | Décision de retrait fail-closed, route canonique et politique de mesure |
+| POST | `/governance/usage` | Incrément journalier borné (`surface`, `event_type`, `browser_family`) si le flag est actif |
+| GET | `/governance/metrics` | Agrégats 28 jours par défaut, réservés au superadmin |
 | GET | `/resources` | Machines et postes planifiables |
 | GET | `/events` | Fenêtre bornée ; `limit` 2 000 par défaut, 5 000 maximum, `offset`; `total` reste exhaustif |
 | GET | `/events/:id` | Détail, commentaires et documents |
@@ -29,6 +34,26 @@ deux événements adjacents sont autorisés, un chevauchement positif est un con
 | GET | `/events/:id/documents/:docId/file` | Lecture authentifiée du contenu d'un document |
 | POST | `/autoplan` | Application séquentielle avec créations, éléments ignorés et résumé partiel explicite |
 | POST | `/validate-for-ar` | Fait progresser vers `AR_PRET`; n'envoie jamais l'AR |
+
+## Convergence Premium / historique
+
+La décision `REMOVE-CERP-0004` est `no_go`. Le flag
+`PLANNING_LEGACY_DASHBOARD_RETIREMENT` est créé OFF et ne devient effectif qu'après une nouvelle
+décision de code `go`; un flag activé seul ne masque donc pas le board historique. La route de
+configuration répond avec `Cache-Control: no-store`. Le client conserve le rollback en cas de
+réponse absente ou incohérente.
+
+`PLANNING_USAGE_METRICS` est également créé OFF. Quand il est explicitement approuvé, le serveur
+ne stocke que des compteurs quotidiens par surface, événement, famille navigateur bornée et famille
+de rôle dérivée. Aucun champ `user_id`, IP, URL, user-agent brut, session ou texte libre n'est
+accepté dans le payload de mesure ni persisté par cette capacité.
+La rétention indépendante appelle `pnpm maintenance:planning-usage` et reste fixée à 90 jours.
+Les compteurs sont indicatifs et ne peuvent jamais décider d'un retrait.
+
+Le patch canonique est `20260805_planning_convergence_governance.sql`; preflight et verify sont en
+lecture seule. Le rollback de schéma refuse toute base autre que `cerp_dev`/`cerp_test`, toute
+provenance différente, tout flag/override actif et toute preuve d'usage non exportée. Le rollback
+normal consiste uniquement à remettre le flag de retrait OFF.
 
 ## Concurrence, archive et autoplan
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "db:patches:up": "node scripts/db-patches.js up",
     "db:patches:baseline": "node scripts/db-patches.js baseline",
     "maintenance:dashboard-usage": "node scripts/prune-dashboard-usage.js",
+    "maintenance:planning-usage": "node scripts/prune-planning-usage.js",
     "test": "vitest --config vitest.config.ts",
     "test:run": "vitest run --config vitest.config.ts",
     "test:list": "vitest list --filesOnly --config vitest.config.ts",

--- a/scripts/prune-planning-usage.js
+++ b/scripts/prune-planning-usage.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+
+const path = require("node:path");
+const dotenv = require("dotenv");
+const { Client } = require("pg");
+
+const ROOT_DIR = path.resolve(__dirname, "..");
+const RETENTION_DAYS = 90;
+
+dotenv.config({ path: path.join(ROOT_DIR, ".env") });
+
+async function main() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) throw new Error("DATABASE_URL is required");
+
+  const client = new Client({ connectionString });
+  await client.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("SET LOCAL lock_timeout = '5s'");
+    await client.query("SET LOCAL statement_timeout = '60s'");
+    const result = await client.query(
+      "SELECT public.prune_planning_surface_usage_daily($1::integer)::text AS deleted_rows",
+      [RETENTION_DAYS]
+    );
+    await client.query("COMMIT");
+    process.stdout.write(`planning usage retention complete: ${result.rows[0]?.deleted_rows ?? "0"} row(s) deleted\n`);
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((error) => {
+  process.stderr.write(`planning usage retention failed: ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 1;
+});

--- a/src/__tests__/planning-convergence.test.ts
+++ b/src/__tests__/planning-convergence.test.ts
@@ -1,0 +1,131 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const repo = vi.hoisted(() => ({
+  flags: vi.fn(),
+  increment: vi.fn(),
+  metrics: vi.fn(),
+}));
+
+vi.mock("../module/planning/repository/planning-convergence.repository", () => ({
+  repoResolvePlanningConvergenceFlags: repo.flags,
+  repoIncrementPlanningUsage: repo.increment,
+  repoListPlanningUsageMetrics: repo.metrics,
+}));
+
+import {
+  resolvePlanningRoleBucket,
+  svcGetPlanningConvergence,
+  svcRecordPlanningUsage,
+} from "../module/planning/services/planning-convergence.service";
+import { planningUsageBodySchema } from "../module/planning/validators/planning-convergence.validators";
+
+describe("planning convergence governance", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("maps exact effective roles to coarse non-identifying buckets", () => {
+    expect(resolvePlanningRoleBucket("Employee | Operateur atelier")).toBe("atelier");
+    expect(resolvePlanningRoleBucket("Planification | Production")).toBe("planification");
+    expect(resolvePlanningRoleBucket("Production")).toBe("production");
+    expect(resolvePlanningRoleBucket("Secretaire")).toBe("secretariat");
+    expect(resolvePlanningRoleBucket("Administrateur Systeme et Reseau")).toBe("direction");
+    expect(resolvePlanningRoleBucket("Responsable Qualite")).toBe("other");
+  });
+
+  it("keeps legacy effective while the code decision is NO-GO, even if the flag is on", async () => {
+    repo.flags.mockResolvedValue({ legacy_retirement_enabled: true, telemetry_enabled: true });
+
+    const config = await svcGetPlanningConvergence(7);
+
+    expect(config.retirement_decision).toBe("no_go");
+    expect(config.legacy_dashboard_retirement_enabled).toBe(true);
+    expect(config.legacy_dashboard_retired).toBe(false);
+    expect(config.rollback_surface).toBe("legacy_dashboard");
+    expect(config.telemetry.identifiers_collected).toBe(false);
+  });
+
+  it("does not write when the telemetry kill-switch is off", async () => {
+    repo.flags.mockResolvedValue({ legacy_retirement_enabled: false, telemetry_enabled: false });
+    await expect(svcRecordPlanningUsage({
+      user_id: 7,
+      effective_role: "Planification",
+      input: { surface: "premium_route", event_type: "view", browser_family: "chromium" },
+    })).resolves.toEqual({ recorded: false });
+    expect(repo.increment).not.toHaveBeenCalled();
+  });
+
+  it("rejects identifiers, raw user agents, free text and incoherent transitions", () => {
+    expect(() => planningUsageBodySchema.parse({
+      surface: "premium_route",
+      event_type: "view",
+      browser_family: "chromium",
+      user_id: 42,
+    })).toThrow();
+    expect(() => planningUsageBodySchema.parse({
+      surface: "premium_route",
+      event_type: "view",
+      browser_family: "chromium",
+      user_agent: "raw",
+    })).toThrow();
+    expect(() => planningUsageBodySchema.parse({
+      surface: "premium_route",
+      event_type: "open_premium",
+      browser_family: "firefox",
+    })).toThrow();
+    expect(planningUsageBodySchema.parse({
+      surface: "legacy_dashboard",
+      event_type: "open_premium",
+      browser_family: "webkit",
+    })).toMatchObject({ surface: "legacy_dashboard", event_type: "open_premium" });
+  });
+
+  it("ships an inert canonical patch and independent retention maintenance", () => {
+    const root = path.resolve(__dirname, "../..");
+    const patch = fs.readFileSync(path.join(root, "db/patches/20260805_planning_convergence_governance.sql"), "utf8");
+    const repository = fs.readFileSync(path.join(root, "src/module/planning/repository/planning-convergence.repository.ts"), "utf8");
+    const maintenance = fs.readFileSync(path.join(root, "scripts/prune-planning-usage.js"), "utf8");
+    const packageJson = JSON.parse(fs.readFileSync(path.join(root, "package.json"), "utf8")) as { scripts: Record<string, string> };
+
+    expect(patch).toMatch(/CREATE TABLE public\.planning_surface_usage_daily/);
+    expect(patch).toContain("CREATE FUNCTION public.prune_planning_surface_usage_daily");
+    expect(patch).toMatch(/'PLANNING_LEGACY_DASHBOARD_RETIREMENT'[\s\S]*false[\s\S]*'PLANNING_USAGE_METRICS'[\s\S]*false/);
+    expect(patch).not.toMatch(/^\s*(user_id|ip_address|user_agent|session_id)\s+/im);
+    expect(repository).toContain("ff.enabled IS TRUE AND COALESCE(ffu.enabled, TRUE) IS TRUE");
+    expect(repository).not.toMatch(/DELETE FROM public\.planning_surface_usage_daily/);
+    expect(maintenance).toContain("public.prune_planning_surface_usage_daily");
+    expect(packageJson.scripts["maintenance:planning-usage"]).toBe("node scripts/prune-planning-usage.js");
+
+    for (const suffix of ["preflight", "verify", "rollback"]) {
+      expect(fs.existsSync(path.join(root, `db/patches/support/20260805_planning_convergence_governance.${suffix}.sql`))).toBe(true);
+    }
+  });
+
+  it("guards baseline verification and destructive rollback with exact provenance", () => {
+    const root = path.resolve(__dirname, "../..");
+    const patch = fs.readFileSync(path.join(root, "db/patches/20260805_planning_convergence_governance.sql"), "utf8");
+    const verify = fs.readFileSync(path.join(root, "db/patches/support/20260805_planning_convergence_governance.verify.sql"), "utf8");
+    const rollback = fs.readFileSync(path.join(root, "db/patches/support/20260805_planning_convergence_governance.rollback.sql"), "utf8");
+    const expectedSha = createHash("sha256").update(patch.replace(/\r\n?/g, "\n"), "utf8").digest("hex");
+
+    expect(verify).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(verify).toContain(expectedSha);
+    expect(verify).toContain("both baseline flags must exist globally and remain OFF");
+    expect(rollback).toContain("current_database() NOT IN ('cerp_dev', 'cerp_test')");
+    expect(rollback).toContain("SELECT pg_advisory_xact_lock(hashtext('cerp_schema_migrations'))");
+    expect(rollback).toContain(expectedSha);
+    expect(rollback).toContain("usage evidence exists; export/retention decision required");
+    expect(rollback).toContain("DELETE FROM public.cerp_schema_migrations");
+  });
+
+  it("uses the same exact-role planning policy for the programmation route", () => {
+    const root = path.resolve(__dirname, "../..");
+    const route = fs.readFileSync(path.join(root, "src/module/programmation/routes/programmation.routes.ts"), "utf8");
+
+    expect(route).toContain("roleHasPlanningAccess");
+    expect(route).not.toContain(".includes(");
+    expect(route).not.toContain("isAdminRole");
+    expect(route).not.toContain("isProductionRole");
+  });
+});

--- a/src/__tests__/planning.rbac.test.ts
+++ b/src/__tests__/planning.rbac.test.ts
@@ -4,6 +4,7 @@ import {
   roleCanForcePlanningOverlap,
   roleHasPlanningAccess,
 } from "../module/planning/domain/planning-rbac";
+import { runWithAccountModuleAccess } from "../module/access-control/context/account-module-access.context";
 
 describe("planning RBAC uses exact normalized roles", () => {
   it.each([
@@ -12,6 +13,8 @@ describe("planning RBAC uses exact normalized roles", () => {
     "Directeur",
     "Responsable Production",
     "Responsable Programmation",
+    "Planning",
+    "Planification",
     "Responsable Atelier",
     "Chef Atelier",
     "Operateur Atelier",
@@ -46,4 +49,15 @@ describe("planning RBAC uses exact normalized roles", () => {
       expect(roleCanForcePlanningOverlap(role)).toBe(false);
     }
   );
+
+  it("lets an account-level Production grant supersede legacy role fallbacks", () => {
+    runWithAccountModuleAccess(
+      { userId: 42, moduleKey: "Production" },
+      () => {
+        expect(roleHasPlanningAccess("Employee")).toBe(true);
+        expect(roleCanForcePlanningOverlap("Employee")).toBe(true);
+      }
+    );
+  });
+
 });

--- a/src/__tests__/planning.routes.test.ts
+++ b/src/__tests__/planning.routes.test.ts
@@ -78,6 +78,55 @@ describe("/api/v1/planning", () => {
     expect(res.body).toEqual({ ok: true });
   });
 
+  it("GET /api/v1/planning/governance fails closed when flags and usage storage are absent", async () => {
+    mocks.poolQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ usage_table_ready: false }] });
+
+    const res = await request(app)
+      .get("/api/v1/planning/governance")
+      .set("Authorization", "Bearer fake");
+
+    expect(res.status).toBe(200);
+    expect(res.headers["cache-control"]).toBe("no-store");
+    expect(res.body).toMatchObject({
+      retirement_decision: "no_go",
+      legacy_dashboard_retirement_enabled: false,
+      legacy_dashboard_retired: false,
+      telemetry: { enabled: false, identifiers_collected: false },
+    });
+  });
+
+  it("POST /api/v1/planning/governance/usage acknowledges without writing while telemetry is OFF", async () => {
+    mocks.poolQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ usage_table_ready: true }] });
+
+    const res = await request(app)
+      .post("/api/v1/planning/governance/usage")
+      .set("Authorization", "Bearer fake")
+      .send({ surface: "legacy_dashboard", event_type: "view", browser_family: "firefox" });
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ recorded: false });
+    expect(mocks.poolQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("POST /api/v1/planning/governance/usage rejects identifying fields", async () => {
+    const res = await request(app)
+      .post("/api/v1/planning/governance/usage")
+      .set("Authorization", "Bearer fake")
+      .send({
+        surface: "legacy_dashboard",
+        event_type: "view",
+        browser_family: "firefox",
+        user_id: 1,
+      });
+
+    expect(res.status).toBe(400);
+    expect(mocks.poolQuery).not.toHaveBeenCalled();
+  });
+
   it("GET /api/v1/planning/resources returns machines + postes", async () => {
     mocks.poolQuery
       .mockResolvedValueOnce({

--- a/src/module/planning/controllers/planning-convergence.controller.ts
+++ b/src/module/planning/controllers/planning-convergence.controller.ts
@@ -1,0 +1,43 @@
+import type { Request, RequestHandler } from "express";
+
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { HttpError } from "../../../utils/httpError";
+import {
+  svcGetPlanningConvergence,
+  svcGetPlanningUsageMetrics,
+  svcRecordPlanningUsage,
+} from "../services/planning-convergence.service";
+import {
+  planningUsageBodySchema,
+  planningUsageMetricsQuerySchema,
+} from "../validators/planning-convergence.validators";
+
+function getUser(req: Request) {
+  if (!req.user || typeof req.user.id !== "number") {
+    throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  }
+  return req.user;
+}
+
+export const getPlanningConvergence: RequestHandler = asyncHandler(async (req, res) => {
+  const user = getUser(req);
+  res.set("Cache-Control", "no-store");
+  res.json(await svcGetPlanningConvergence(user.id));
+});
+
+export const postPlanningUsage: RequestHandler = asyncHandler(async (req, res) => {
+  const user = getUser(req);
+  const input = planningUsageBodySchema.parse(req.body);
+  const result = await svcRecordPlanningUsage({
+    user_id: user.id,
+    effective_role: user.role,
+    input,
+  });
+  res.status(202).json(result);
+});
+
+export const getPlanningUsageMetrics: RequestHandler = asyncHandler(async (req, res) => {
+  getUser(req);
+  const query = planningUsageMetricsQuerySchema.parse(req.query);
+  res.json(await svcGetPlanningUsageMetrics(query));
+});

--- a/src/module/planning/domain/planning-rbac.ts
+++ b/src/module/planning/domain/planning-rbac.ts
@@ -1,4 +1,5 @@
 import { effectiveRoleParts } from "../../auth/domain/roles";
+import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
 
 function normalizeRole(role: string | null | undefined): string {
   return String(role ?? "")
@@ -17,6 +18,8 @@ const PLANNING_ACCESS_ROLES = new Set([
   "production",
   "responsableproduction",
   "responsableprogrammation",
+  "planning",
+  "planification",
   "atelier",
   "operateuratelier",
   "responsableatelier",
@@ -41,7 +44,7 @@ export function roleHasPlanningAccess(role: string | null | undefined): boolean 
 }
 
 export function roleCanForcePlanningOverlap(role: string | null | undefined): boolean {
+  // ADR-0049: an account-level module grant supersedes this legacy role fallback.
   if (hasGrantedAccountModuleAccess()) return true;
   return effectiveRoleParts(role).some((part) => FORCE_OVERLAP_ROLES.has(normalizeRole(part)));
 }
-import { hasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";

--- a/src/module/planning/repository/planning-convergence.repository.ts
+++ b/src/module/planning/repository/planning-convergence.repository.ts
@@ -1,0 +1,116 @@
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import {
+  PLANNING_LEGACY_DASHBOARD_RETIREMENT_FLAG,
+  PLANNING_USAGE_METRICS_FLAG,
+  type PlanningRoleBucket,
+  type PlanningUsageInput,
+  type PlanningUsageMetricRow,
+} from "../types/planning-convergence.types";
+
+type DbQueryer = Pick<PoolClient, "query">;
+type FlagRow = { key: string; enabled: boolean | null };
+
+function isUndefinedTable(error: unknown): boolean {
+  return (error as { code?: unknown } | null)?.code === "42P01";
+}
+
+/** Missing tables, flags and non-positive values all keep retirement and telemetry OFF. */
+export async function repoResolvePlanningConvergenceFlags(
+  userId: number,
+  q: DbQueryer = pool
+): Promise<{ legacy_retirement_enabled: boolean; telemetry_enabled: boolean }> {
+  try {
+    const flags = await q.query<FlagRow>(
+      `
+        WITH requested(key) AS (
+          SELECT unnest($1::text[])
+        )
+        SELECT
+          requested.key,
+          (ff.enabled IS TRUE AND COALESCE(ffu.enabled, TRUE) IS TRUE) AS enabled
+        FROM requested
+        LEFT JOIN public.app_feature_flags ff ON ff.key = requested.key
+        LEFT JOIN public.app_feature_flag_users ffu
+          ON ffu.feature_flag_id = ff.id AND ffu.user_id = $2::int
+      `,
+      [[PLANNING_LEGACY_DASHBOARD_RETIREMENT_FLAG, PLANNING_USAGE_METRICS_FLAG], userId]
+    );
+    const byKey = new Map(flags.rows.map((row) => [row.key, row.enabled]));
+    const infrastructure = await q.query<{ usage_table_ready: boolean }>(
+      "SELECT to_regclass('public.planning_surface_usage_daily') IS NOT NULL AS usage_table_ready"
+    );
+
+    return {
+      legacy_retirement_enabled: byKey.get(PLANNING_LEGACY_DASHBOARD_RETIREMENT_FLAG) === true,
+      telemetry_enabled:
+        byKey.get(PLANNING_USAGE_METRICS_FLAG) === true &&
+        infrastructure.rows[0]?.usage_table_ready === true,
+    };
+  } catch (error) {
+    if (isUndefinedTable(error)) {
+      return { legacy_retirement_enabled: false, telemetry_enabled: false };
+    }
+    throw error;
+  }
+}
+
+/** Daily counter only; no user/session/network identifier or free text reaches storage. */
+export async function repoIncrementPlanningUsage(
+  params: { input: PlanningUsageInput; role_bucket: PlanningRoleBucket },
+  q: DbQueryer = pool
+): Promise<void> {
+  await q.query(
+    `
+      INSERT INTO public.planning_surface_usage_daily (
+        usage_date,
+        surface,
+        event_type,
+        browser_family,
+        role_bucket,
+        event_count,
+        first_seen_at,
+        last_seen_at
+      )
+      VALUES (CURRENT_DATE, $1, $2, $3, $4, 1, now(), now())
+      ON CONFLICT (usage_date, surface, event_type, browser_family, role_bucket)
+      DO UPDATE SET
+        event_count = public.planning_surface_usage_daily.event_count + 1,
+        last_seen_at = now()
+    `,
+    [
+      params.input.surface,
+      params.input.event_type,
+      params.input.browser_family,
+      params.role_bucket,
+    ]
+  );
+}
+
+type PlanningUsageMetricDbRow = Omit<PlanningUsageMetricRow, "event_count"> & {
+  event_count: string | number;
+};
+
+export async function repoListPlanningUsageMetrics(
+  params: { from: string; to: string },
+  q: DbQueryer = pool
+): Promise<PlanningUsageMetricRow[]> {
+  const result = await q.query<PlanningUsageMetricDbRow>(
+    `
+      SELECT
+        usage_date::text,
+        surface,
+        event_type,
+        browser_family,
+        role_bucket,
+        event_count::text
+      FROM public.planning_surface_usage_daily
+      WHERE usage_date BETWEEN $1::date AND $2::date
+      ORDER BY usage_date, role_bucket, browser_family, surface, event_type
+    `,
+    [params.from, params.to]
+  );
+
+  return result.rows.map((row) => ({ ...row, event_count: Number(row.event_count) }));
+}

--- a/src/module/planning/routes/planning.routes.ts
+++ b/src/module/planning/routes/planning.routes.ts
@@ -4,6 +4,7 @@ import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { createSecureUpload } from "../../../shared/uploads/secure-upload";
 import { HttpError } from "../../../utils/httpError";
 import { roleHasPlanningAccess } from "../domain/planning-rbac";
+import { requireSuperadmin } from "../../access-control/middlewares/require-superadmin";
 import {
   archivePlanningEvent,
   autoPlanPlanning,
@@ -19,6 +20,11 @@ import {
   uploadPlanningEventDocuments,
   validatePlanningForAr,
 } from "../controllers/planning.controller";
+import {
+  getPlanningConvergence,
+  getPlanningUsageMetrics,
+  postPlanningUsage,
+} from "../controllers/planning-convergence.controller";
 
 const requireProductionOrAdmin: RequestHandler = (req, _res, next) => {
   const role = req.user?.role;
@@ -40,6 +46,12 @@ router.use(authenticateToken);
 router.use(requireProductionOrAdmin);
 
 router.get("/health", healthPlanning);
+
+// Convergence du board Premium / dashboard historique. La decision NO-GO et
+// le flag OFF conservent le board historique; les metriques sont agregees.
+router.get("/governance", getPlanningConvergence);
+router.post("/governance/usage", postPlanningUsage);
+router.get("/governance/metrics", requireSuperadmin, getPlanningUsageMetrics);
 
 router.get("/resources", listPlanningResources);
 router.get("/events", listPlanningEvents);

--- a/src/module/planning/services/planning-convergence.service.ts
+++ b/src/module/planning/services/planning-convergence.service.ts
@@ -1,0 +1,103 @@
+import { effectiveRoleParts } from "../../auth/domain/roles";
+import {
+  PLANNING_RETIREMENT_DECISION,
+  PLANNING_USAGE_RETENTION_DAYS,
+  type PlanningConvergenceConfig,
+  type PlanningRoleBucket,
+  type PlanningUsageInput,
+} from "../types/planning-convergence.types";
+import {
+  repoIncrementPlanningUsage,
+  repoListPlanningUsageMetrics,
+  repoResolvePlanningConvergenceFlags,
+} from "../repository/planning-convergence.repository";
+
+function normalizeRole(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[\s_-]+/g, "");
+}
+
+/** Analytics grouping only. Authorization remains in planning-rbac.ts. */
+export function resolvePlanningRoleBucket(role: string | null | undefined): PlanningRoleBucket {
+  const parts = new Set(effectiveRoleParts(role).map(normalizeRole));
+  const hasAny = (...roles: string[]) => roles.some((candidate) => parts.has(candidate));
+
+  if (hasAny("operateuratelier", "responsableatelier", "chefatelier", "atelier")) return "atelier";
+  if (hasAny("responsableprogrammation", "planification", "planning")) return "planification";
+  if (hasAny("responsableproduction", "production")) return "production";
+  if (hasAny("secretariat", "secretaire")) return "secretariat";
+  if (hasAny("admin", "administrateur", "administrateursystemeetreseau", "directeur")) return "direction";
+  return "other";
+}
+
+function isPlanningLegacyDashboardRetired(params: {
+  decision: "go" | "no_go";
+  flag_enabled: boolean;
+}): boolean {
+  return params.decision === "go" && params.flag_enabled;
+}
+
+export async function svcGetPlanningConvergence(userId: number): Promise<PlanningConvergenceConfig> {
+  const flags = await repoResolvePlanningConvergenceFlags(userId);
+  const legacyDashboardRetired = isPlanningLegacyDashboardRetired({
+    decision: PLANNING_RETIREMENT_DECISION,
+    flag_enabled: flags.legacy_retirement_enabled,
+  });
+
+  return {
+    schema_version: 1,
+    canonical_route: "/production/planning",
+    rollback_surface: "legacy_dashboard",
+    retirement_decision: PLANNING_RETIREMENT_DECISION,
+    legacy_dashboard_retirement_enabled: flags.legacy_retirement_enabled,
+    legacy_dashboard_retired: legacyDashboardRetired,
+    telemetry: {
+      enabled: flags.telemetry_enabled,
+      collection: "daily_aggregate",
+      retention_days: PLANNING_USAGE_RETENTION_DAYS,
+      identifiers_collected: false,
+    },
+  };
+}
+
+export async function svcRecordPlanningUsage(params: {
+  user_id: number;
+  effective_role: string | null | undefined;
+  input: PlanningUsageInput;
+}): Promise<{ recorded: boolean }> {
+  const flags = await repoResolvePlanningConvergenceFlags(params.user_id);
+  if (!flags.telemetry_enabled) return { recorded: false };
+
+  await repoIncrementPlanningUsage({
+    input: params.input,
+    role_bucket: resolvePlanningRoleBucket(params.effective_role),
+  });
+  return { recorded: true };
+}
+
+function isoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+export async function svcGetPlanningUsageMetrics(params: { from?: string; to?: string }) {
+  const to = params.to ?? isoDate(new Date());
+  const fromDate = new Date(`${to}T00:00:00.000Z`);
+  fromDate.setUTCDate(fromDate.getUTCDate() - 27);
+  const from = params.from ?? isoDate(fromDate);
+  const rows = await repoListPlanningUsageMetrics({ from, to });
+
+  return {
+    from,
+    to,
+    rows,
+    privacy: {
+      collection: "daily_aggregate" as const,
+      identifiers_collected: false as const,
+      retention_days: PLANNING_USAGE_RETENTION_DAYS,
+    },
+  };
+}

--- a/src/module/planning/types/planning-convergence.types.ts
+++ b/src/module/planning/types/planning-convergence.types.ts
@@ -1,0 +1,60 @@
+export const PLANNING_SURFACES = ["premium_route", "legacy_dashboard"] as const;
+export type PlanningSurface = (typeof PLANNING_SURFACES)[number];
+
+export const PLANNING_USAGE_EVENTS = ["view", "open_premium"] as const;
+export type PlanningUsageEvent = (typeof PLANNING_USAGE_EVENTS)[number];
+
+export const PLANNING_BROWSER_FAMILIES = ["chromium", "firefox", "webkit", "other"] as const;
+export type PlanningBrowserFamily = (typeof PLANNING_BROWSER_FAMILIES)[number];
+
+export const PLANNING_ROLE_BUCKETS = [
+  "direction",
+  "planification",
+  "production",
+  "atelier",
+  "secretariat",
+  "other",
+] as const;
+export type PlanningRoleBucket = (typeof PLANNING_ROLE_BUCKETS)[number];
+
+export const PLANNING_USAGE_RETENTION_DAYS = 90;
+export const PLANNING_LEGACY_DASHBOARD_RETIREMENT_FLAG = "PLANNING_LEGACY_DASHBOARD_RETIREMENT";
+export const PLANNING_USAGE_METRICS_FLAG = "PLANNING_USAGE_METRICS";
+
+/**
+ * REMOVE-CERP-0004 is deliberately NO-GO. A later parity PR must change this
+ * decision in code as well as activating the database flag: either key alone
+ * is insufficient to hide the rollback surface.
+ */
+export const PLANNING_RETIREMENT_DECISION = "no_go" as const;
+export type PlanningRetirementDecision = "go" | "no_go";
+
+export type PlanningConvergenceConfig = {
+  schema_version: 1;
+  canonical_route: "/production/planning";
+  rollback_surface: "legacy_dashboard";
+  retirement_decision: PlanningRetirementDecision;
+  legacy_dashboard_retirement_enabled: boolean;
+  legacy_dashboard_retired: boolean;
+  telemetry: {
+    enabled: boolean;
+    collection: "daily_aggregate";
+    retention_days: typeof PLANNING_USAGE_RETENTION_DAYS;
+    identifiers_collected: false;
+  };
+};
+
+export type PlanningUsageInput = {
+  surface: PlanningSurface;
+  event_type: PlanningUsageEvent;
+  browser_family: PlanningBrowserFamily;
+};
+
+export type PlanningUsageMetricRow = {
+  usage_date: string;
+  surface: PlanningSurface;
+  event_type: PlanningUsageEvent;
+  browser_family: PlanningBrowserFamily;
+  role_bucket: PlanningRoleBucket;
+  event_count: number;
+};

--- a/src/module/planning/validators/planning-convergence.validators.ts
+++ b/src/module/planning/validators/planning-convergence.validators.ts
@@ -1,0 +1,33 @@
+import { z } from "zod";
+
+import {
+  PLANNING_BROWSER_FAMILIES,
+  PLANNING_SURFACES,
+  PLANNING_USAGE_EVENTS,
+} from "../types/planning-convergence.types";
+
+export const planningUsageBodySchema = z.object({
+  surface: z.enum(PLANNING_SURFACES),
+  event_type: z.enum(PLANNING_USAGE_EVENTS),
+  browser_family: z.enum(PLANNING_BROWSER_FAMILIES),
+}).strict().superRefine((value, ctx) => {
+  if (value.event_type === "open_premium" && value.surface !== "legacy_dashboard") {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["surface"],
+      message: "open_premium exige surface=legacy_dashboard",
+    });
+  }
+});
+
+export const planningUsageMetricsQuerySchema = z.object({
+  from: z.string().date().optional(),
+  to: z.string().date().optional(),
+}).superRefine((value, ctx) => {
+  if (value.from && value.to && value.from > value.to) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["from"], message: "from doit preceder to" });
+  }
+});
+
+export type PlanningUsageBodyDTO = z.infer<typeof planningUsageBodySchema>;
+export type PlanningUsageMetricsQueryDTO = z.infer<typeof planningUsageMetricsQuerySchema>;

--- a/src/module/programmation/routes/programmation.routes.ts
+++ b/src/module/programmation/routes/programmation.routes.ts
@@ -1,38 +1,21 @@
 import { Router, type RequestHandler } from "express";
 import {
-  hasGrantedAccountModuleAccess,
   requestHasGrantedAccountModuleAccess,
 } from "../../access-control/context/account-module-access.context";
 import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { HttpError } from "../../../utils/httpError";
+import { roleHasPlanningAccess } from "../../planning/domain/planning-rbac";
 import { healthProgrammations, listProgrammations } from "../controllers/programmation.controller";
-
-function isAdminRole(role: string | undefined): boolean {
-  if (!role) return false;
-  const r = role.trim().toLowerCase();
-  return r.includes("admin") || r.includes("administrateur");
-}
-
-function isProductionRole(role: string | undefined): boolean {
-  if (!role) return false;
-  const r = role.trim().toLowerCase();
-  return r.includes("production") || r.includes("atelier") || r.includes("secretaire") || r.includes("secretariat");
-}
 
 const requireProductionOrAdmin: RequestHandler = (req, _res, next) => {
   if (
     requestHasGrantedAccountModuleAccess(req) ||
-    hasGrantedAccountModuleAccess()
+    roleHasPlanningAccess(req.user?.role)
   ) {
     next();
     return;
   }
-  const role = req.user?.role;
-  if (!isAdminRole(role) && !isProductionRole(role)) {
-    next(new HttpError(403, "FORBIDDEN", "Production, atelier, secretariat or admin role required"));
-    return;
-  }
-  next();
+  next(new HttpError(403, "FORBIDDEN", "Production, planning, atelier, secretariat or admin role required"));
 };
 
 const router = Router();


### PR DESCRIPTION
Promotes validated GPT56-REMOVE-CERP-0004 planning convergence governance from dev to main.

## Summary by Sourcery

Introduce planning convergence governance endpoints, telemetry, and database support while keeping the legacy planning dashboard available by default.

New Features:
- Add planning governance API endpoints for convergence configuration, usage recording, and metrics retrieval.
- Introduce planning telemetry domain types, services, and repository for privacy-preserving daily aggregate usage metrics.
- Add dedicated maintenance script and SQL patch suite (preflight, verify, rollback) for planning usage metrics and feature flags.

Enhancements:
- Unify planning/programmation access control around the exact-role planning RBAC policy and account-level module grants.
- Update planning HTTP documentation to describe new governance routes and clarify module-based access semantics.

Build:
- Wire the planning usage maintenance script into npm scripts for scheduled retention.

Tests:
- Add unit and integration tests covering planning governance behavior, telemetry validation, DB patch provenance, and programmation route RBAC alignment.