### PR TITLE
release(backend): promote planning migration selector

### DIFF
--- a/docs/http/planning.md
+++ b/docs/http/planning.md
@@ -54,6 +54,14 @@ Le patch canonique est `20260805_planning_convergence_governance.sql`; preflight
 lecture seule. Le rollback de schéma refuse toute base autre que `cerp_dev`/`cerp_test`, toute
 provenance différente, tout flag/override actif et toute preuve d'usage non exportée. Le rollback
 normal consiste uniquement à remettre le flag de retrait OFF.
+Le déploiement contrôlé utilise le sélecteur immuable du runner afin de ne pas appliquer d'autres
+patches en attente :
+
+```bash
+npm run db:patches:up -- --dry-run --only 20260805_planning_convergence_governance.sql
+npm run db:patches:up -- --only 20260805_planning_convergence_governance.sql
+npm run db:patches:status -- --check --only 20260805_planning_convergence_governance.sql
+```
 
 ## Concurrence, archive et autoplan
 

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -13,6 +13,8 @@ const LOCK_NAME = "cerp_schema_migrations";
 const IMMUTABLE_ONLY_PATCHES = Object.freeze({
   "20260804_auth_rate_limit_buckets.sql":
     "f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2",
+  "20260805_planning_convergence_governance.sql":
+    "4ac0aa05dc489ae5f882491e7b41cc6e96ac3bcaabd554ecddfb82d6580734dc",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -40,6 +40,7 @@ type RunnerModule = {
 const require = createRequire(import.meta.url);
 const runner = require(resolve(repoRoot, "scripts/db-patches.js")) as RunnerModule;
 const patchFilename = "20260804_auth_rate_limit_buckets.sql";
+const planningPatchFilename = "20260805_planning_convergence_governance.sql";
 
 function queryText(value: unknown): string {
   return String(value).replace(/\s+/g, " ").trim();
@@ -99,6 +100,11 @@ describe("database patch runner", () => {
       "f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2"
     );
 
+    const planningPatch = readFileSync(resolve(repoRoot, "db/patches", planningPatchFilename), "utf8");
+    expect(runner.sha256Sql(planningPatch)).toBe(
+      "4ac0aa05dc489ae5f882491e7b41cc6e96ac3bcaabd554ecddfb82d6580734dc"
+    );
+
     const previouslyRecordedPatch = readFileSync(
       resolve(repoRoot, "db/patches/20260731_stock_old_new_446.sql"),
       "utf8"
@@ -116,6 +122,13 @@ describe("database patch runner", () => {
       filename: patchFilename,
       sha256: "f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2",
     });
+    expect(runner.immutableOnlyPatch(patches, planningPatchFilename)).toMatchObject({
+      filename: planningPatchFilename,
+      sha256: "4ac0aa05dc489ae5f882491e7b41cc6e96ac3bcaabd554ecddfb82d6580734dc",
+    });
+    expect(runner.parseArgs(["up", "--only", planningPatchFilename]).only).toBe(
+      planningPatchFilename
+    );
     expect(runner.parseArgs(["up", "--only", patchFilename]).only).toBe(patchFilename);
     expect(() => runner.parseArgs(["up", "--only", `db/patches/${patchFilename}`])).toThrow(
       /exact patch basename/


### PR DESCRIPTION
Promotes the isolated, checksum-pinned planning migration selector to main.

## Summary by Sourcery

Promote the planning convergence governance database patch to an immutable, checksum-verified migration selectable via the db patch runner.

Enhancements:
- Add the planning convergence governance patch to the immutable-only patch selector with a pinned SHA-256 checksum.
- Extend the db patch runner tests to cover the planning patch’s checksum, selection, and argument parsing.
- Document controlled deployment commands for running the planning patch in isolation using the immutable selector.

Documentation:
- Update planning HTTP documentation to describe isolated deployment of the planning convergence governance patch via db patch runner commands.

Tests:
- Add tests ensuring the planning convergence governance patch checksum and immutable-only selection behavior are enforced by the db patch runner.