### PR TITLE
release: promote planning prerequisite selector

### DIFF
--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -11,6 +11,8 @@ const DEFAULT_PATCH_DIR = path.join(ROOT_DIR, "db", "patches");
 const MIGRATION_TABLE = "public.cerp_schema_migrations";
 const LOCK_NAME = "cerp_schema_migrations";
 const IMMUTABLE_ONLY_PATCHES = Object.freeze({
+  "20260216_planning_visuals_programmation.sql":
+    "e220d040caae9b18bb42d3c970104b2d2612bce53dac6b43c4aac60268491a1b",
   "20260804_auth_rate_limit_buckets.sql":
     "f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2",
   "20260805_adv_reminders.sql":

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -43,6 +43,10 @@ const patchFilename = "20260804_auth_rate_limit_buckets.sql";
 const planningPatchFilename = "20260805_planning_convergence_governance.sql";
 const wave9PatchChecksums = new Map([
   [
+    "20260216_planning_visuals_programmation.sql",
+    "e220d040caae9b18bb42d3c970104b2d2612bce53dac6b43c4aac60268491a1b",
+  ],
+  [
     "20260805_programmation_safe_reschedule_0004.sql",
     "341f7911a7bcb479fce6602d0567c51d47f083a08b37409e55d05cf3110f01b5",
   ],


### PR DESCRIPTION
Promotes the validated selector needed before Wave 9 planning migration.

## Summary by Sourcery

Promote the planning visuals programmation schema patch to an immutable, checksum-validated migration required for Wave 9 planning.

Enhancements:
- Add the planning visuals programmation SQL migration to the Wave 9 patch checksum list used by the db-patches runner.
- Register the planning visuals programmation SQL migration as an immutable patch with its expected checksum in the db-patches script.