### PR TITLE
release: promote ADV client contract fix

### DIFF
--- a/db/patches/20260805_adv_reminders.sql
+++ b/db/patches/20260805_adv_reminders.sql
@@ -108,7 +108,7 @@ CREATE UNIQUE INDEX adv_reminder_one_validated_policy_uniq
   ON public.adv_reminder_policies ((status)) WHERE status='VALIDATED';
 
 CREATE TABLE public.adv_reminder_client_preferences (
-  client_id uuid NOT NULL,
+  client_id varchar(3) NOT NULL,
   channel text NOT NULL DEFAULT 'EMAIL',
   recipient_contact_id uuid,
   opted_out boolean NOT NULL DEFAULT false,
@@ -141,7 +141,7 @@ CREATE TABLE public.adv_reminder_client_preferences (
 CREATE TABLE public.adv_reminder_suggestions (
   id uuid NOT NULL DEFAULT gen_random_uuid(),
   facture_id bigint NOT NULL,
-  client_id uuid NOT NULL,
+  client_id varchar(3) NOT NULL,
   policy_id uuid NOT NULL,
   policy_version integer NOT NULL,
   cadence_step_days smallint NOT NULL,

--- a/db/patches/support/20260805_adv_reminders.preflight.sql
+++ b/db/patches/support/20260805_adv_reminders.preflight.sql
@@ -4,7 +4,7 @@ BEGIN TRANSACTION READ ONLY;
 
 DO $preflight$
 DECLARE
-  expected_sha256 constant text := '060e1e8a3dcaaa673bb24beebb4701af0e82ca165ceaf3fe9466138f19cfcc2d';
+  expected_sha256 constant text := 'df06021c03898c4e719634ab753c986122ad4645ffb7c146c6be0e4954c40616';
   registered_sha256 text;
   target_tables integer;
   target_functions integer;

--- a/db/patches/support/20260805_adv_reminders.rollback.sql
+++ b/db/patches/support/20260805_adv_reminders.rollback.sql
@@ -9,7 +9,7 @@ BEGIN;
 
 DO $guard$
 DECLARE
-  expected_sha256 constant text := '060e1e8a3dcaaa673bb24beebb4701af0e82ca165ceaf3fe9466138f19cfcc2d';
+  expected_sha256 constant text := 'df06021c03898c4e719634ab753c986122ad4645ffb7c146c6be0e4954c40616';
   registered_sha256 text;
 BEGIN
   IF current_database() !~* '(test|dev|local|sandbox)' THEN

--- a/db/patches/support/20260805_adv_reminders.verify.sql
+++ b/db/patches/support/20260805_adv_reminders.verify.sql
@@ -4,7 +4,7 @@ BEGIN TRANSACTION READ ONLY;
 
 DO $verify$
 DECLARE
-  expected_sha256 constant text := '060e1e8a3dcaaa673bb24beebb4701af0e82ca165ceaf3fe9466138f19cfcc2d';
+  expected_sha256 constant text := 'df06021c03898c4e719634ab753c986122ad4645ffb7c146c6be0e4954c40616';
   registered_sha256 text;
   owner_count integer;
   trigger_count integer;

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -16,7 +16,7 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
   "20260804_auth_rate_limit_buckets.sql":
     "f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2",
   "20260805_adv_reminders.sql":
-    "060e1e8a3dcaaa673bb24beebb4701af0e82ca165ceaf3fe9466138f19cfcc2d",
+    "df06021c03898c4e719634ab753c986122ad4645ffb7c146c6be0e4954c40616",
   "20260805_planning_convergence_governance.sql":
     "4ac0aa05dc489ae5f882491e7b41cc6e96ac3bcaabd554ecddfb82d6580734dc",
   "20260805_programmation_safe_reschedule_0004.sql":

--- a/src/__tests__/adv-reminders.migration-guards.test.ts
+++ b/src/__tests__/adv-reminders.migration-guards.test.ts
@@ -28,6 +28,10 @@ const provider = readFileSync(
   resolve(repoRoot, "src/module/facturation/providers/reminder.provider.ts"),
   "utf8"
 );
+const validators = readFileSync(
+  resolve(repoRoot, "src/module/facturation/validators/reminders.validators.ts"),
+  "utf8"
+);
 
 const sha256 = createHash("sha256").update(patch.replace(/\r\n?/g, "\n")).digest("hex");
 
@@ -46,6 +50,13 @@ describe("FEAT-CERP-0002 migration and runtime guards", () => {
     expect(repository).toContain("FOR UPDATE OF s SKIP LOCKED");
     expect(repository).toContain("claim_token=$2::uuid");
     expect(verify).toContain("invoice/cadence idempotence is violated");
+  });
+
+  it("uses the canonical three-character CERP client identifier", () => {
+    expect(patch.match(/client_id varchar\(3\) NOT NULL/g)).toHaveLength(2);
+    expect(patch).not.toMatch(/client_id uuid/i);
+    expect(repository).not.toMatch(/client_id\s*=\s*\$\d+::uuid/);
+    expect(validators).toContain("z.string().trim().min(1).max(3)");
   });
 
   it("cancels pending or claimed work in the payment and credit transaction", () => {

--- a/src/module/facturation/repository/reminders.repository.ts
+++ b/src/module/facturation/repository/reminders.repository.ts
@@ -523,7 +523,7 @@ export async function repoListReminderSuggestions(
   };
   if (filters.status) where.push(`s.status=${push(filters.status)}`);
   if (filters.facture_id) where.push(`s.facture_id=${push(filters.facture_id)}`);
-  if (filters.client_id) where.push(`s.client_id=${push(filters.client_id)}::uuid`);
+  if (filters.client_id) where.push(`s.client_id=${push(filters.client_id)}`);
   if (filters.from_due_date) where.push(`s.due_date>=${push(filters.from_due_date)}::date`);
   if (filters.to_due_date) where.push(`s.due_date<=${push(filters.to_due_date)}::date`);
   const whereSql = where.length ? `WHERE ${where.join(" AND ")}` : "";
@@ -1295,7 +1295,7 @@ export async function repoListReminderHistory(params: {
   clientId?: string;
   limit: number;
 }): Promise<ReminderHistoryEvent[]> {
-  const where = params.factureId ? "s.facture_id=$1" : "s.client_id=$1::uuid";
+  const where = params.factureId ? "s.facture_id=$1" : "s.client_id=$1";
   const value = params.factureId ?? params.clientId;
   const result = await pool.query(
     `
@@ -1342,11 +1342,11 @@ export async function repoUpsertReminderClientPreference(params: {
       await client.query("COMMIT");
       return { ...command.replay, idempotent_replay: true };
     }
-    const clientExists = await client.query(`SELECT 1 FROM public.clients WHERE client_id=$1::uuid`, [params.clientId]);
+    const clientExists = await client.query(`SELECT 1 FROM public.clients WHERE client_id=$1`, [params.clientId]);
     if (!clientExists.rows[0]) throw new HttpError(404, "CLIENT_NOT_FOUND", "Client introuvable.");
     if (params.input.recipient_contact_id) {
       const contact = await client.query(
-        `SELECT 1 FROM public.contacts WHERE contact_id=$1::uuid AND client_id=$2::uuid AND archived_at IS NULL`,
+        `SELECT 1 FROM public.contacts WHERE contact_id=$1::uuid AND client_id=$2 AND archived_at IS NULL`,
         [params.input.recipient_contact_id, params.clientId]
       );
       if (!contact.rows[0]) {
@@ -1354,7 +1354,7 @@ export async function repoUpsertReminderClientPreference(params: {
       }
     }
     const existing = await client.query<{ row_version: number }>(
-      `SELECT row_version FROM public.adv_reminder_client_preferences WHERE client_id=$1::uuid FOR UPDATE`,
+      `SELECT row_version FROM public.adv_reminder_client_preferences WHERE client_id=$1 FOR UPDATE`,
       [params.clientId]
     );
     const actualVersion = existing.rows[0]?.row_version ?? 0;
@@ -1366,7 +1366,7 @@ export async function repoUpsertReminderClientPreference(params: {
         INSERT INTO public.adv_reminder_client_preferences (
           client_id,channel,recipient_contact_id,opted_out,restricted_processing,lawful_basis,
           consent_granted,consent_version,consent_source,consent_recorded_at,created_by,updated_by,row_version
-        ) VALUES ($1::uuid,$2,$3::uuid,$4,$5,$6,$7,$8,$9,
+        ) VALUES ($1,$2,$3::uuid,$4,$5,$6,$7,$8,$9,
           CASE WHEN $7 IS NULL THEN NULL ELSE now() END,$10,$10,1)
         ON CONFLICT (client_id) DO UPDATE SET
           channel=EXCLUDED.channel,recipient_contact_id=EXCLUDED.recipient_contact_id,
@@ -1396,7 +1396,7 @@ export async function repoUpsertReminderClientPreference(params: {
         `
           WITH candidates AS (
             SELECT id,status AS previous_status FROM public.adv_reminder_suggestions
-            WHERE client_id=$1::uuid AND status IN ('SUGGESTED','BLOCKED','APPROVED','FAILED_RETRYABLE','FAILED_FINAL')
+            WHERE client_id=$1 AND status IN ('SUGGESTED','BLOCKED','APPROVED','FAILED_RETRYABLE','FAILED_FINAL')
             FOR UPDATE
           ), updated AS (
             UPDATE public.adv_reminder_suggestions s
@@ -1464,12 +1464,12 @@ export async function repoGetReminderClientPreference(clientId: string): Promise
       SELECT client_id::text,channel,recipient_contact_id::text,opted_out,restricted_processing,
         lawful_basis,consent_granted,consent_version,consent_source,consent_recorded_at::text,row_version
       FROM public.adv_reminder_client_preferences
-      WHERE client_id=$1::uuid
+      WHERE client_id=$1
     `,
     [clientId]
   );
   if (result.rows[0]) return result.rows[0];
-  const exists = await pool.query(`SELECT 1 FROM public.clients WHERE client_id=$1::uuid`, [clientId]);
+  const exists = await pool.query(`SELECT 1 FROM public.clients WHERE client_id=$1`, [clientId]);
   if (!exists.rows[0]) throw new HttpError(404, "CLIENT_NOT_FOUND", "Client introuvable.");
   return {
     client_id: clientId,

--- a/src/module/facturation/validators/reminders.validators.ts
+++ b/src/module/facturation/validators/reminders.validators.ts
@@ -1,12 +1,13 @@
 import { z } from "zod";
 
 const uuid = z.string().uuid();
+const clientId = z.string().trim().min(1).max(3);
 const strictDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/);
 const idempotencyKey = z.string().trim().min(8).max(200);
 
 export const reminderIdParamsSchema = z.object({ id: uuid }).strict();
 export const reminderFactureParamsSchema = z.object({ id: z.coerce.number().int().positive() }).strict();
-export const reminderClientParamsSchema = z.object({ id: uuid }).strict();
+export const reminderClientParamsSchema = z.object({ id: clientId }).strict();
 export const reminderHistoryQuerySchema = z.object({
   limit: z.coerce.number().int().min(1).max(200).default(100),
 }).strict();
@@ -43,7 +44,7 @@ export const listReminderSuggestionsSchema = z.object({
     "FAILED_RETRYABLE", "FAILED_FINAL", "CANCELLED",
   ]).optional(),
   facture_id: z.coerce.number().int().positive().optional(),
-  client_id: uuid.optional(),
+  client_id: clientId.optional(),
   from_due_date: strictDate.optional(),
   to_due_date: strictDate.optional(),
   limit: z.coerce.number().int().min(1).max(200).default(50),


### PR DESCRIPTION
Promotes the validated CERP client identifier correction required by Wave 9 deployment.

## Summary by Sourcery

Align ADV reminder client handling with canonical three-character CERP client identifiers across database schema, validation, and repository queries.

Bug Fixes:
- Correct reminder repository queries and preference handling to use the canonical CERP client identifier type instead of UUIDs.

Enhancements:
- Update reminder validation schemas to enforce three-character CERP client identifiers for client-related operations.
- Strengthen migration guard tests to verify use of the canonical CERP client identifier and ensure repository and validator consistency.

Build:
- Refresh immutable patch checksum registration for the ADV reminders database patch to reflect the updated schema.

Tests:
- Extend migration guard tests to assert the CERP client identifier format and repository usage for ADV reminders.