### PR TITLE
fix(adv): register finance-state prerequisite

### DIFF
--- a/db/patches/support/20260805_adv_reminders.preflight.sql
+++ b/db/patches/support/20260805_adv_reminders.preflight.sql
@@ -34,6 +34,16 @@ BEGIN
   IF (SELECT COUNT(*) FROM public.app_modules WHERE module_key='facturation') <> 1 THEN
     RAISE EXCEPTION 'FEAT-CERP-0002 preflight: facturation module entry is missing';
   END IF;
+  IF NOT EXISTS (
+       SELECT 1 FROM information_schema.columns
+       WHERE table_schema='public' AND table_name='facture' AND column_name='document_status'
+     )
+     OR NOT EXISTS (
+       SELECT 1 FROM information_schema.columns
+       WHERE table_schema='public' AND table_name='facture' AND column_name='settlement_status'
+     ) THEN
+    RAISE EXCEPTION 'FEAT-CERP-0002 preflight: finance settlement-state prerequisite is missing';
+  END IF;
 
   SELECT sha256 INTO registered_sha256
   FROM public.cerp_schema_migrations

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -15,6 +15,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "e220d040caae9b18bb42d3c970104b2d2612bce53dac6b43c4aac60268491a1b",
   "20260804_auth_rate_limit_buckets.sql":
     "f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2",
+  "20260804_finance_settlement_state_469.sql":
+    "f045e770642e53eaac8eac02ee6f1c8ced5885a9f53d4831462d05356544c10a",
   "20260805_adv_reminders.sql":
     "df06021c03898c4e719634ab753c986122ad4645ffb7c146c6be0e4954c40616",
   "20260805_planning_convergence_governance.sql":

--- a/src/__tests__/adv-reminders.migration-guards.test.ts
+++ b/src/__tests__/adv-reminders.migration-guards.test.ts
@@ -39,6 +39,7 @@ describe("FEAT-CERP-0002 migration and runtime guards", () => {
   it("pins lifecycle scripts to the exact immutable migration", () => {
     for (const support of [preflight, verify, rollback]) expect(support).toContain(sha256);
     expect(preflight).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(preflight).toContain("finance settlement-state prerequisite is missing");
     expect(verify).toContain("BEGIN TRANSACTION READ ONLY");
     expect(rollback).toContain("cerp.allow_adv_reminder_rollback");
     expect(rollback).toContain("usage evidence exists; rollback refused");

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -47,6 +47,10 @@ const wave9PatchChecksums = new Map([
     "e220d040caae9b18bb42d3c970104b2d2612bce53dac6b43c4aac60268491a1b",
   ],
   [
+    "20260804_finance_settlement_state_469.sql",
+    "f045e770642e53eaac8eac02ee6f1c8ced5885a9f53d4831462d05356544c10a",
+  ],
+  [
     "20260805_programmation_safe_reschedule_0004.sql",
     "341f7911a7bcb479fce6602d0567c51d47f083a08b37409e55d05cf3110f01b5",
   ],


### PR DESCRIPTION
Adds exact controlled selector for the already-delivered finance settlement migration and makes ADV preflight reject the missing columns. Build and 27 tests pass.

## Summary by Sourcery

Enforce the finance settlement-state migration as a prerequisite for the ADV reminders patch and register its checksum in the immutable patch set.

Bug Fixes:
- Add a preflight guard that fails if required finance settlement-state columns are missing for ADV reminders.
- Register the finance settlement-state migration checksum to ensure the exact immutable patch is applied before ADV reminders.

Tests:
- Extend ADV migration guard tests to cover the new finance settlement-state preflight requirement.
- Update DB patch runner tests to include the finance settlement-state migration checksum.