### PR TITLE
release: promote executable settlement migration

### DIFF
--- a/db/patches/20260804_finance_settlement_state_469.sql
+++ b/db/patches/20260804_finance_settlement_state_469.sql
@@ -212,10 +212,10 @@ BEGIN
        'ISSUED', 'PARTIALLY_PAID', 'PAID',
        'emise', 'envoyee', 'partielle', 'payee', 'emis'
      )
-     AND NEW.statut = CASE
-       WHEN NEW.settlement_status = 'UNPAID' THEN 'ISSUED'
-       ELSE NEW.settlement_status
-     END
+     AND (
+       (NEW.settlement_status = 'UNPAID' AND NEW.statut = 'ISSUED')
+       OR (NEW.settlement_status <> 'UNPAID' AND NEW.statut = NEW.settlement_status)
+     )
      AND NEW.row_version = OLD.row_version + 1
      AND current_setting('cerp.finance_settlement_correlation_id', true) IS NOT NULL
      AND current_setting('cerp.finance_settlement_correlation_id', true)
@@ -282,11 +282,15 @@ BEGIN
         ))
        AND NEW.amount_allocated >= OLD.amount_allocated
        AND NEW.amount_allocated <= NEW.amount_due
-       AND NEW.status = CASE
-         WHEN NEW.amount_allocated >= NEW.amount_due THEN 'PAID'
-         WHEN NEW.amount_allocated > 0 THEN 'PARTIALLY_PAID'
-         ELSE OLD.status
-       END
+       AND (
+         (NEW.amount_allocated >= NEW.amount_due AND NEW.status = 'PAID')
+         OR (
+           NEW.amount_allocated > 0
+           AND NEW.amount_allocated < NEW.amount_due
+           AND NEW.status = 'PARTIALLY_PAID'
+         )
+         OR (NEW.amount_allocated <= 0 AND NEW.status = OLD.status)
+       )
        AND (to_jsonb(NEW) - 'amount_allocated' - 'status')
            IS NOT DISTINCT FROM
            (to_jsonb(OLD) - 'amount_allocated' - 'status') THEN

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -16,7 +16,7 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
   "20260804_auth_rate_limit_buckets.sql":
     "f61120b4068a36138b1d85c0269f764061a525aab6141f99df9c93ad6c5d27a2",
   "20260804_finance_settlement_state_469.sql":
-    "f045e770642e53eaac8eac02ee6f1c8ced5885a9f53d4831462d05356544c10a",
+    "55e8cb8304d71e790056111e6452b8825fc5349b88976bd0eea281359da543d5",
   "20260805_adv_reminders.sql":
     "df06021c03898c4e719634ab753c986122ad4645ffb7c146c6be0e4954c40616",
   "20260805_planning_convergence_governance.sql":

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -48,7 +48,7 @@ const wave9PatchChecksums = new Map([
   ],
   [
     "20260804_finance_settlement_state_469.sql",
-    "f045e770642e53eaac8eac02ee6f1c8ced5885a9f53d4831462d05356544c10a",
+    "55e8cb8304d71e790056111e6452b8825fc5349b88976bd0eea281359da543d5",
   ],
   [
     "20260805_programmation_safe_reschedule_0004.sql",

--- a/src/__tests__/facturation-469.migration-guards.test.ts
+++ b/src/__tests__/facturation-469.migration-guards.test.ts
@@ -182,6 +182,8 @@ describe("#469 settlement-state guards", () => {
       /current_setting\('cerp\.finance_settlement_correlation_id', true\)\s*= NEW\.correlation_id::text/
     );
     expect(patch).toContain("NEW.row_version = OLD.row_version + 1");
+    expect(patch).toContain("NEW.settlement_status = 'UNPAID' AND NEW.statut = 'ISSUED'");
+    expect(patch).not.toContain("NEW.statut = CASE");
     expect(patch).toContain("'emise', 'envoyee', 'partielle', 'payee', 'emis'");
   });
 
@@ -259,6 +261,8 @@ describe("#469 settlement-state guards", () => {
     expect(patch).toContain("parent_document_status = 'ISSUED'");
     expect(patch).toContain("NEW.amount_allocated >= OLD.amount_allocated");
     expect(patch).toContain("NEW.amount_allocated <= NEW.amount_due");
+    expect(patch).toContain("NEW.amount_allocated < NEW.amount_due");
+    expect(patch).not.toContain("NEW.status = CASE");
     expect(patch).toContain("to_jsonb(NEW) - 'amount_allocated' - 'status'");
   });
 


### PR DESCRIPTION
Promotes the PostgreSQL 17-proven finance prerequisite correction.

## Summary by Sourcery

Align settlement-state migration guards with explicit status transitions and promote the updated patch into the immutable release set.

Bug Fixes:
- Ensure settlement status and display statut are only accepted for valid UNPAID and non-UNPAID combinations in the settlement-state trigger.
- Ensure amount allocation updates only allow coherent status transitions between PAID, PARTIALLY_PAID, and unchanged status in the settlement-state trigger.

Build:
- Refresh the immutable-only patch checksum for the finance settlement-state migration to reflect the promoted version.

Tests:
- Extend migration guard tests to cover the new explicit settlement status and amount allocation conditions.
- Update db-patch checksum tests to track the promoted immutable settlement-state patch revision.