### PR TITLE
feat: safe offline station queue

### DIFF
--- a/db/patches/20260805_station_offline_queue_0006.sql
+++ b/db/patches/20260805_station_offline_queue_0006.sql
@@ -54,24 +54,30 @@ CREATE TABLE public.production_station_offline_events (
   operator_user_id integer NOT NULL,
   station_session_id uuid NOT NULL,
   machine_id uuid,
+  authenticated_device_id uuid NOT NULL,
+  authenticated_operator_user_id integer NOT NULL,
+  authenticated_station_session_id uuid NOT NULL,
+  authenticated_machine_id uuid,
   payload jsonb NOT NULL,
-  clock_drift_seconds integer NOT NULL,
+  clock_drift_seconds bigint NOT NULL,
   status text NOT NULL DEFAULT 'PROCESSING',
   attempt_count integer NOT NULL DEFAULT 1,
   last_attempt_at timestamptz NOT NULL DEFAULT now(),
+  processing_token uuid NOT NULL,
+  lease_expires_at timestamptz NOT NULL,
   server_entity_id uuid,
   result_payload jsonb,
   error_code text,
   error_message text,
   CONSTRAINT production_station_offline_events_pkey PRIMARY KEY (event_id),
   CONSTRAINT production_station_offline_events_idem_uq UNIQUE (idempotency_key),
-  CONSTRAINT production_station_offline_events_device_fk FOREIGN KEY (device_id)
+  CONSTRAINT production_station_offline_events_authenticated_device_fk FOREIGN KEY (authenticated_device_id)
     REFERENCES public.production_devices(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
-  CONSTRAINT production_station_offline_events_user_fk FOREIGN KEY (operator_user_id)
+  CONSTRAINT production_station_offline_events_authenticated_user_fk FOREIGN KEY (authenticated_operator_user_id)
     REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
-  CONSTRAINT production_station_offline_events_session_fk FOREIGN KEY (station_session_id)
+  CONSTRAINT production_station_offline_events_authenticated_session_fk FOREIGN KEY (authenticated_station_session_id)
     REFERENCES public.operator_device_sessions(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
-  CONSTRAINT production_station_offline_events_machine_fk FOREIGN KEY (machine_id)
+  CONSTRAINT production_station_offline_events_authenticated_machine_fk FOREIGN KEY (authenticated_machine_id)
     REFERENCES public.machines(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
   CONSTRAINT production_station_offline_events_idem_ck CHECK (char_length(idempotency_key) BETWEEN 8 AND 200),
   CONSTRAINT production_station_offline_events_hash_ck CHECK (request_hash ~ '^[0-9a-f]{64}$'),
@@ -83,6 +89,7 @@ CREATE TABLE public.production_station_offline_events (
   ),
   CONSTRAINT production_station_offline_events_payload_ck CHECK (jsonb_typeof(payload) = 'object'),
   CONSTRAINT production_station_offline_events_attempt_ck CHECK (attempt_count > 0),
+  CONSTRAINT production_station_offline_events_lease_ck CHECK (lease_expires_at > received_at),
   CONSTRAINT production_station_offline_events_outcome_ck CHECK (
     (status = 'PROCESSING' AND processed_at IS NULL AND error_code IS NULL)
     OR (status = 'SYNCED' AND processed_at IS NOT NULL AND server_entity_id IS NOT NULL AND error_code IS NULL)
@@ -93,7 +100,7 @@ CREATE TABLE public.production_station_offline_events (
 CREATE INDEX production_station_offline_events_device_idx
   ON public.production_station_offline_events(device_id, received_at DESC);
 CREATE INDEX production_station_offline_events_status_idx
-  ON public.production_station_offline_events(status, last_attempt_at);
+  ON public.production_station_offline_events(status, lease_expires_at);
 CREATE INDEX production_station_offline_events_expiry_idx
   ON public.production_station_offline_events(expires_at)
   WHERE status IN ('SYNCED','REJECTED');
@@ -116,6 +123,10 @@ BEGIN
      OR NEW.operator_user_id IS DISTINCT FROM OLD.operator_user_id
      OR NEW.station_session_id IS DISTINCT FROM OLD.station_session_id
      OR NEW.machine_id IS DISTINCT FROM OLD.machine_id
+     OR NEW.authenticated_device_id IS DISTINCT FROM OLD.authenticated_device_id
+     OR NEW.authenticated_operator_user_id IS DISTINCT FROM OLD.authenticated_operator_user_id
+     OR NEW.authenticated_station_session_id IS DISTINCT FROM OLD.authenticated_station_session_id
+     OR NEW.authenticated_machine_id IS DISTINCT FROM OLD.authenticated_machine_id
      OR NEW.payload IS DISTINCT FROM OLD.payload THEN
     RAISE EXCEPTION 'Offline receipt identity and payload are immutable' USING ERRCODE = '55000';
   END IF;

--- a/db/patches/20260805_station_offline_queue_0006.sql
+++ b/db/patches/20260805_station_offline_queue_0006.sql
@@ -54,6 +54,7 @@ CREATE TABLE public.production_station_offline_events (
   operator_user_id integer NOT NULL,
   station_session_id uuid NOT NULL,
   machine_id uuid,
+  execution_session_id uuid,
   authenticated_device_id uuid NOT NULL,
   authenticated_operator_user_id integer NOT NULL,
   authenticated_station_session_id uuid NOT NULL,
@@ -89,6 +90,9 @@ CREATE TABLE public.production_station_offline_events (
   ),
   CONSTRAINT production_station_offline_events_payload_ck CHECK (jsonb_typeof(payload) = 'object'),
   CONSTRAINT production_station_offline_events_attempt_ck CHECK (attempt_count > 0),
+  CONSTRAINT production_station_offline_events_execution_session_ck CHECK (
+    event_type <> 'POINTAGE_START' OR execution_session_id IS NOT NULL
+  ),
   CONSTRAINT production_station_offline_events_lease_ck CHECK (lease_expires_at > received_at),
   CONSTRAINT production_station_offline_events_outcome_ck CHECK (
     (status = 'PROCESSING' AND processed_at IS NULL AND error_code IS NULL)
@@ -123,6 +127,7 @@ BEGIN
      OR NEW.operator_user_id IS DISTINCT FROM OLD.operator_user_id
      OR NEW.station_session_id IS DISTINCT FROM OLD.station_session_id
      OR NEW.machine_id IS DISTINCT FROM OLD.machine_id
+     OR NEW.execution_session_id IS DISTINCT FROM OLD.execution_session_id
      OR NEW.authenticated_device_id IS DISTINCT FROM OLD.authenticated_device_id
      OR NEW.authenticated_operator_user_id IS DISTINCT FROM OLD.authenticated_operator_user_id
      OR NEW.authenticated_station_session_id IS DISTINCT FROM OLD.authenticated_station_session_id

--- a/db/patches/20260805_station_offline_queue_0006.sql
+++ b/db/patches/20260805_station_offline_queue_0006.sql
@@ -1,0 +1,168 @@
+-- GPT56-FEAT-CERP-0006 -- bounded, resumable shop-floor offline receipts.
+BEGIN;
+
+DO $preflight$
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NULL
+     OR to_regclass('public.production_devices') IS NULL
+     OR to_regclass('public.operator_device_sessions') IS NULL
+     OR to_regclass('public.production_execution_idempotency') IS NULL
+     OR to_regclass('public.production_pointages') IS NULL
+     OR to_regclass('public.production_quantity_declarations') IS NULL
+     OR to_regclass('public.users') IS NULL
+     OR to_regclass('public.machines') IS NULL
+     OR to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'GPT56-FEAT-CERP-0006 prerequisite is missing';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.cerp_schema_migrations
+    WHERE filename = '20260805_station_offline_queue_0006.sql'
+  ) THEN
+    RAISE EXCEPTION 'GPT56-FEAT-CERP-0006 ledger entry already exists; use the patch runner';
+  END IF;
+  IF to_regclass('public.production_station_offline_config') IS NOT NULL
+     OR to_regclass('public.production_station_offline_events') IS NOT NULL
+     OR to_regprocedure('public.fn_purge_production_station_offline_events(integer)') IS NOT NULL
+     OR to_regprocedure('public.fn_guard_production_station_offline_event()') IS NOT NULL THEN
+    RAISE EXCEPTION 'GPT56-FEAT-CERP-0006 target object exists without ledger provenance';
+  END IF;
+END
+$preflight$;
+
+CREATE TABLE public.production_station_offline_config (
+  singleton boolean NOT NULL DEFAULT true,
+  enabled boolean NOT NULL DEFAULT true,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  updated_by integer REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  CONSTRAINT production_station_offline_config_pkey PRIMARY KEY (singleton),
+  CONSTRAINT production_station_offline_config_singleton_ck CHECK (singleton)
+);
+
+INSERT INTO public.production_station_offline_config(singleton, enabled) VALUES (true, true);
+
+CREATE TABLE public.production_station_offline_events (
+  event_id uuid NOT NULL,
+  idempotency_key text NOT NULL,
+  request_hash text NOT NULL,
+  client_batch_id uuid NOT NULL,
+  event_type text NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  received_at timestamptz NOT NULL DEFAULT now(),
+  processed_at timestamptz,
+  expires_at timestamptz NOT NULL DEFAULT (now() + interval '30 days'),
+  device_id uuid NOT NULL,
+  operator_user_id integer NOT NULL,
+  station_session_id uuid NOT NULL,
+  machine_id uuid,
+  payload jsonb NOT NULL,
+  clock_drift_seconds integer NOT NULL,
+  status text NOT NULL DEFAULT 'PROCESSING',
+  attempt_count integer NOT NULL DEFAULT 1,
+  last_attempt_at timestamptz NOT NULL DEFAULT now(),
+  server_entity_id uuid,
+  result_payload jsonb,
+  error_code text,
+  error_message text,
+  CONSTRAINT production_station_offline_events_pkey PRIMARY KEY (event_id),
+  CONSTRAINT production_station_offline_events_idem_uq UNIQUE (idempotency_key),
+  CONSTRAINT production_station_offline_events_device_fk FOREIGN KEY (device_id)
+    REFERENCES public.production_devices(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  CONSTRAINT production_station_offline_events_user_fk FOREIGN KEY (operator_user_id)
+    REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  CONSTRAINT production_station_offline_events_session_fk FOREIGN KEY (station_session_id)
+    REFERENCES public.operator_device_sessions(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  CONSTRAINT production_station_offline_events_machine_fk FOREIGN KEY (machine_id)
+    REFERENCES public.machines(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  CONSTRAINT production_station_offline_events_idem_ck CHECK (char_length(idempotency_key) BETWEEN 8 AND 200),
+  CONSTRAINT production_station_offline_events_hash_ck CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+  CONSTRAINT production_station_offline_events_type_ck CHECK (
+    event_type IN ('POINTAGE_START','POINTAGE_STOP','QUANTITY_DECLARE')
+  ),
+  CONSTRAINT production_station_offline_events_status_ck CHECK (
+    status IN ('PROCESSING','SYNCED','REJECTED')
+  ),
+  CONSTRAINT production_station_offline_events_payload_ck CHECK (jsonb_typeof(payload) = 'object'),
+  CONSTRAINT production_station_offline_events_attempt_ck CHECK (attempt_count > 0),
+  CONSTRAINT production_station_offline_events_outcome_ck CHECK (
+    (status = 'PROCESSING' AND processed_at IS NULL AND error_code IS NULL)
+    OR (status = 'SYNCED' AND processed_at IS NOT NULL AND server_entity_id IS NOT NULL AND error_code IS NULL)
+    OR (status = 'REJECTED' AND processed_at IS NOT NULL AND server_entity_id IS NULL AND error_code IS NOT NULL)
+  )
+);
+
+CREATE INDEX production_station_offline_events_device_idx
+  ON public.production_station_offline_events(device_id, received_at DESC);
+CREATE INDEX production_station_offline_events_status_idx
+  ON public.production_station_offline_events(status, last_attempt_at);
+CREATE INDEX production_station_offline_events_expiry_idx
+  ON public.production_station_offline_events(expires_at)
+  WHERE status IN ('SYNCED','REJECTED');
+
+CREATE FUNCTION public.fn_guard_production_station_offline_event()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $guard$
+BEGIN
+  IF OLD.status IN ('SYNCED','REJECTED') THEN
+    RAISE EXCEPTION 'Final offline receipts are immutable' USING ERRCODE = '55000';
+  END IF;
+  IF NEW.event_id IS DISTINCT FROM OLD.event_id
+     OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+     OR NEW.request_hash IS DISTINCT FROM OLD.request_hash
+     OR NEW.client_batch_id IS DISTINCT FROM OLD.client_batch_id
+     OR NEW.event_type IS DISTINCT FROM OLD.event_type
+     OR NEW.occurred_at IS DISTINCT FROM OLD.occurred_at
+     OR NEW.device_id IS DISTINCT FROM OLD.device_id
+     OR NEW.operator_user_id IS DISTINCT FROM OLD.operator_user_id
+     OR NEW.station_session_id IS DISTINCT FROM OLD.station_session_id
+     OR NEW.machine_id IS DISTINCT FROM OLD.machine_id
+     OR NEW.payload IS DISTINCT FROM OLD.payload THEN
+    RAISE EXCEPTION 'Offline receipt identity and payload are immutable' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END
+$guard$;
+
+CREATE TRIGGER trg_guard_production_station_offline_event_0006
+BEFORE UPDATE ON public.production_station_offline_events
+FOR EACH ROW EXECUTE FUNCTION public.fn_guard_production_station_offline_event();
+
+CREATE FUNCTION public.fn_purge_production_station_offline_events(retention_days integer)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $purge$
+DECLARE purged bigint;
+BEGIN
+  IF retention_days < 7 OR retention_days > 365 THEN
+    RAISE EXCEPTION 'retention_days must be between 7 and 365';
+  END IF;
+  DELETE FROM public.production_station_offline_events
+   WHERE status IN ('SYNCED','REJECTED')
+     AND received_at < now() - make_interval(days => retention_days);
+  GET DIAGNOSTICS purged = ROW_COUNT;
+  RETURN purged;
+END
+$purge$;
+
+ALTER TABLE public.production_station_offline_config OWNER TO postgres;
+ALTER TABLE public.production_station_offline_events OWNER TO postgres;
+ALTER FUNCTION public.fn_guard_production_station_offline_event() OWNER TO postgres;
+ALTER FUNCTION public.fn_purge_production_station_offline_events(integer) OWNER TO postgres;
+
+REVOKE ALL ON TABLE public.production_station_offline_config FROM PUBLIC, cerp_app;
+GRANT SELECT ON TABLE public.production_station_offline_config TO cerp_app;
+REVOKE ALL ON TABLE public.production_station_offline_events FROM PUBLIC, cerp_app;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.production_station_offline_events TO cerp_app;
+REVOKE ALL ON FUNCTION public.fn_guard_production_station_offline_event() FROM PUBLIC, cerp_app;
+GRANT EXECUTE ON FUNCTION public.fn_guard_production_station_offline_event() TO cerp_app;
+REVOKE ALL ON FUNCTION public.fn_purge_production_station_offline_events(integer) FROM PUBLIC, cerp_app;
+GRANT EXECUTE ON FUNCTION public.fn_purge_production_station_offline_events(integer) TO cerp_app;
+
+COMMENT ON TABLE public.production_station_offline_events IS
+  'GPT56-FEAT-CERP-0006 resumable receipt journal; contains no authentication material and writes no stock or quality decision.';
+COMMENT ON TABLE public.production_station_offline_config IS
+  'Operational database kill switch; false disables station offline synchronization without redeploying.';
+
+COMMIT;

--- a/db/patches/support/20260805_station_offline_queue_0006.preflight.sql
+++ b/db/patches/support/20260805_station_offline_queue_0006.preflight.sql
@@ -1,0 +1,20 @@
+\set ON_ERROR_STOP on
+
+DO $$
+DECLARE missing text[] := ARRAY[]::text[];
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NULL THEN missing := array_append(missing, 'cerp_schema_migrations'); END IF;
+  IF to_regclass('public.production_devices') IS NULL THEN missing := array_append(missing, 'production_devices'); END IF;
+  IF to_regclass('public.operator_device_sessions') IS NULL THEN missing := array_append(missing, 'operator_device_sessions'); END IF;
+  IF to_regclass('public.production_execution_idempotency') IS NULL THEN missing := array_append(missing, 'production_execution_idempotency'); END IF;
+  IF to_regclass('public.production_pointages') IS NULL THEN missing := array_append(missing, 'production_pointages'); END IF;
+  IF to_regclass('public.production_quantity_declarations') IS NULL THEN missing := array_append(missing, 'production_quantity_declarations'); END IF;
+  IF cardinality(missing) > 0 THEN
+    RAISE EXCEPTION 'GPT56-FEAT-CERP-0006 prerequisites missing: %', array_to_string(missing, ', ');
+  END IF;
+  IF to_regclass('public.production_station_offline_events') IS NOT NULL
+     OR to_regclass('public.production_station_offline_config') IS NOT NULL THEN
+    RAISE EXCEPTION 'GPT56-FEAT-CERP-0006 target objects already exist';
+  END IF;
+END;
+$$;

--- a/db/patches/support/20260805_station_offline_queue_0006.rollback.sql
+++ b/db/patches/support/20260805_station_offline_queue_0006.rollback.sql
@@ -1,0 +1,21 @@
+\set ON_ERROR_STOP on
+
+DO $$
+BEGIN
+  IF current_database() <> 'cerp_test' THEN
+    RAISE EXCEPTION 'Rollback GPT56-FEAT-CERP-0006 is restricted to disposable cerp_test';
+  END IF;
+  IF to_regclass('public.production_station_offline_events') IS NOT NULL
+     AND EXISTS (SELECT 1 FROM public.production_station_offline_events) THEN
+    RAISE EXCEPTION 'Rollback refused: offline receipt data exists';
+  END IF;
+END;
+$$;
+
+BEGIN;
+DROP FUNCTION IF EXISTS public.fn_purge_production_station_offline_events(integer);
+DROP TRIGGER IF EXISTS trg_guard_production_station_offline_event_0006 ON public.production_station_offline_events;
+DROP FUNCTION IF EXISTS public.fn_guard_production_station_offline_event();
+DROP TABLE IF EXISTS public.production_station_offline_events;
+DROP TABLE IF EXISTS public.production_station_offline_config;
+COMMIT;

--- a/db/patches/support/20260805_station_offline_queue_0006.verify.sql
+++ b/db/patches/support/20260805_station_offline_queue_0006.verify.sql
@@ -1,0 +1,26 @@
+\set ON_ERROR_STOP on
+
+BEGIN;
+DO $$
+BEGIN
+  IF to_regclass('public.production_station_offline_events') IS NULL
+     OR to_regclass('public.production_station_offline_config') IS NULL
+     OR to_regprocedure('public.fn_purge_production_station_offline_events(integer)') IS NULL
+     OR to_regprocedure('public.fn_guard_production_station_offline_event()') IS NULL THEN
+    RAISE EXCEPTION 'GPT56-FEAT-CERP-0006 object missing';
+  END IF;
+  IF (SELECT count(*) FROM public.production_station_offline_config WHERE singleton AND enabled) <> 1 THEN
+    RAISE EXCEPTION 'GPT56-FEAT-CERP-0006 kill-switch configuration invalid';
+  END IF;
+  IF (SELECT count(*) FROM pg_constraint WHERE conrelid = 'public.production_station_offline_events'::regclass
+      AND conname IN ('production_station_offline_events_pkey','production_station_offline_events_idem_uq',
+                      'production_station_offline_events_type_ck','production_station_offline_events_status_ck',
+                      'production_station_offline_events_outcome_ck')) <> 5 THEN
+    RAISE EXCEPTION 'GPT56-FEAT-CERP-0006 constraint set incomplete';
+  END IF;
+  IF has_table_privilege('cerp_app', 'public.production_station_offline_config', 'UPDATE') THEN
+    RAISE EXCEPTION 'cerp_app must not control the database kill switch';
+  END IF;
+END;
+$$;
+ROLLBACK;

--- a/db/patches/support/20260805_station_offline_queue_0006.verify.sql
+++ b/db/patches/support/20260805_station_offline_queue_0006.verify.sql
@@ -16,17 +16,18 @@ BEGIN
       AND conname IN ('production_station_offline_events_pkey','production_station_offline_events_idem_uq',
                       'production_station_offline_events_type_ck','production_station_offline_events_status_ck',
                       'production_station_offline_events_outcome_ck','production_station_offline_events_lease_ck',
+                      'production_station_offline_events_execution_session_ck',
                       'production_station_offline_events_authenticated_device_fk',
                       'production_station_offline_events_authenticated_user_fk',
                       'production_station_offline_events_authenticated_session_fk',
-                      'production_station_offline_events_authenticated_machine_fk')) <> 10 THEN
+                      'production_station_offline_events_authenticated_machine_fk')) <> 11 THEN
     RAISE EXCEPTION 'GPT56-FEAT-CERP-0006 constraint set incomplete';
   END IF;
   IF (SELECT count(*) FROM information_schema.columns
        WHERE table_schema = 'public' AND table_name = 'production_station_offline_events'
          AND column_name IN ('authenticated_device_id','authenticated_operator_user_id',
                              'authenticated_station_session_id','authenticated_machine_id',
-                             'processing_token','lease_expires_at')) <> 6 THEN
+                             'processing_token','lease_expires_at','execution_session_id')) <> 7 THEN
     RAISE EXCEPTION 'GPT56-FEAT-CERP-0006 fencing/authentication columns incomplete';
   END IF;
   IF has_table_privilege('cerp_app', 'public.production_station_offline_config', 'UPDATE') THEN

--- a/db/patches/support/20260805_station_offline_queue_0006.verify.sql
+++ b/db/patches/support/20260805_station_offline_queue_0006.verify.sql
@@ -15,8 +15,19 @@ BEGIN
   IF (SELECT count(*) FROM pg_constraint WHERE conrelid = 'public.production_station_offline_events'::regclass
       AND conname IN ('production_station_offline_events_pkey','production_station_offline_events_idem_uq',
                       'production_station_offline_events_type_ck','production_station_offline_events_status_ck',
-                      'production_station_offline_events_outcome_ck')) <> 5 THEN
+                      'production_station_offline_events_outcome_ck','production_station_offline_events_lease_ck',
+                      'production_station_offline_events_authenticated_device_fk',
+                      'production_station_offline_events_authenticated_user_fk',
+                      'production_station_offline_events_authenticated_session_fk',
+                      'production_station_offline_events_authenticated_machine_fk')) <> 10 THEN
     RAISE EXCEPTION 'GPT56-FEAT-CERP-0006 constraint set incomplete';
+  END IF;
+  IF (SELECT count(*) FROM information_schema.columns
+       WHERE table_schema = 'public' AND table_name = 'production_station_offline_events'
+         AND column_name IN ('authenticated_device_id','authenticated_operator_user_id',
+                             'authenticated_station_session_id','authenticated_machine_id',
+                             'processing_token','lease_expires_at')) <> 6 THEN
+    RAISE EXCEPTION 'GPT56-FEAT-CERP-0006 fencing/authentication columns incomplete';
   END IF;
   IF has_table_privilege('cerp_app', 'public.production_station_offline_config', 'UPDATE') THEN
     RAISE EXCEPTION 'cerp_app must not control the database kill switch';

--- a/docs/adr/ADR-FEAT-CERP-0006-offline-station-queue.md
+++ b/docs/adr/ADR-FEAT-CERP-0006-offline-station-queue.md
@@ -6,9 +6,9 @@ Statut : accepté pour le MVP. Le mode hors ligne n'est pas un second moteur mé
 
 La station peut conserver localement, chiffrés par AES-GCM avec une clé non exportable, au plus quelques événements `POINTAGE_START`, `POINTAGE_STOP` et `QUANTITY_DECLARE`. Après retour réseau, l'opérateur se réauthentifie et envoie un lot de 1 à 25 événements à `POST /api/v1/production/station/offline/sync`.
 
-Le serveur vérifie à chaque reprise la session vivante, l'appareil, l'opérateur et la machine. Chaque événement est borné à 24 h par défaut, tolère au plus 60 s d'avance d'horloge, possède un `event_id` et une clé d'idempotence. Le moteur canonique de production applique chaque événement dans sa transaction existante. Le reçu de reprise peut rester `PROCESSING` après une panne entre l'effet et l'accusé : le retry rejoue alors la même clé canonique sans second effet.
+Le serveur exige une session vivante au moment de la reprise. La session d'origine peut être close après réauthentification, mais elle doit prouver le même appareil, le même opérateur, la machine déclarée et une date d'événement comprise dans son cycle de vie. Chaque événement est borné à 24 h par défaut, tolère au plus 60 s d'avance d'horloge, possède un `event_id` et une clé d'idempotence. Le moteur canonique de production applique chaque événement dans sa transaction existante. Le reçu de reprise peut rester `PROCESSING` après une panne entre l'effet et l'accusé : le retry rejoue alors la même clé canonique sans second effet.
 
-Une réservation `PROCESSING` récente agit comme bail de deux minutes : un second appel reçoit `OFFLINE_EVENT_IN_PROGRESS` au lieu de concurrencer le premier. Après expiration, la reprise est autorisée et reste protégée par l'idempotence canonique.
+Une réservation `PROCESSING` porte un bail de deux minutes et un jeton de fencing unique : un second appel reçoit `OFFLINE_EVENT_IN_PROGRESS` au lieu de concurrencer le premier. Après expiration, la reprise obtient un nouveau jeton; l'ancien propriétaire ne peut plus finaliser le reçu et l'idempotence canonique empêche un second effet.
 
 Un lot est volontairement partiel : chaque résultat est `SYNCED` ou `REJECTED`. Une dépendance, un changement d'identité ou une collision produit un conflit explicite; rien n'est écrasé. Aucun événement offline ne valide de qualité, ne réceptionne une production et ne crée de mouvement, lot, réservation ou décision de stock.
 
@@ -18,7 +18,7 @@ Un lot est volontairement partiel : chaque résultat est `SYNCED` ou `REJECTED`.
 |---|---|
 | appareil perdu ou volé | aucune session/secret persistant dans la file; révocation du device et session vivante contrôlées à chaque sync |
 | double clic, retry, double onglet | clé canonique et reçu serveur uniques; empreinte de requête immuable |
-| substitution d'opérateur/station | identité exacte comparée à la session réauthentifiée |
+| substitution d'opérateur/station | identité appareil/opérateur exacte; session source et période d'origine vérifiées après réauthentification |
 | horloge fausse | fenêtre passée/future bornée, dérive enregistrée, heure serveur retournée |
 | réseau intermittent ou crash | reçu `PROCESSING`, action canonique transactionnelle, reprise idempotente |
 | données altérées | conflit d'empreinte explicite; aucune mise à jour silencieuse |

--- a/docs/adr/ADR-FEAT-CERP-0006-offline-station-queue.md
+++ b/docs/adr/ADR-FEAT-CERP-0006-offline-station-queue.md
@@ -1,0 +1,36 @@
+# ADR FEAT-CERP-0006 — File différée bornée du poste atelier
+
+Statut : accepté pour le MVP. Le mode hors ligne n'est pas un second moteur métier.
+
+## Décision
+
+La station peut conserver localement, chiffrés par AES-GCM avec une clé non exportable, au plus quelques événements `POINTAGE_START`, `POINTAGE_STOP` et `QUANTITY_DECLARE`. Après retour réseau, l'opérateur se réauthentifie et envoie un lot de 1 à 25 événements à `POST /api/v1/production/station/offline/sync`.
+
+Le serveur vérifie à chaque reprise la session vivante, l'appareil, l'opérateur et la machine. Chaque événement est borné à 24 h par défaut, tolère au plus 60 s d'avance d'horloge, possède un `event_id` et une clé d'idempotence. Le moteur canonique de production applique chaque événement dans sa transaction existante. Le reçu de reprise peut rester `PROCESSING` après une panne entre l'effet et l'accusé : le retry rejoue alors la même clé canonique sans second effet.
+
+Une réservation `PROCESSING` récente agit comme bail de deux minutes : un second appel reçoit `OFFLINE_EVENT_IN_PROGRESS` au lieu de concurrencer le premier. Après expiration, la reprise est autorisée et reste protégée par l'idempotence canonique.
+
+Un lot est volontairement partiel : chaque résultat est `SYNCED` ou `REJECTED`. Une dépendance, un changement d'identité ou une collision produit un conflit explicite; rien n'est écrasé. Aucun événement offline ne valide de qualité, ne réceptionne une production et ne crée de mouvement, lot, réservation ou décision de stock.
+
+## Menaces et contrôles
+
+| Menace | Contrôle |
+|---|---|
+| appareil perdu ou volé | aucune session/secret persistant dans la file; révocation du device et session vivante contrôlées à chaque sync |
+| double clic, retry, double onglet | clé canonique et reçu serveur uniques; empreinte de requête immuable |
+| substitution d'opérateur/station | identité exacte comparée à la session réauthentifiée |
+| horloge fausse | fenêtre passée/future bornée, dérive enregistrée, heure serveur retournée |
+| réseau intermittent ou crash | reçu `PROCESSING`, action canonique transactionnelle, reprise idempotente |
+| données altérées | conflit d'empreinte explicite; aucune mise à jour silencieuse |
+| accumulation de données | purge des reçus terminés après 30 jours par défaut (7–365) |
+| risque industriel | liste blanche de trois événements; aucune action stock/qualité irréversible |
+
+## Exploitation et rollback
+
+`STATION_OFFLINE_SYNC_ENABLED=false` coupe immédiatement le traitement au niveau processus. La ligne singleton `production_station_offline_config.enabled=false` fournit le kill switch base sans redéploiement; `cerp_app` ne peut pas la modifier. Un appel coupé retourne HTTP 503, `kill_switch_enabled: true` et aucun événement traité.
+
+Les durées sont configurables par `STATION_OFFLINE_MAX_EVENT_AGE_SECONDS`, `STATION_OFFLINE_MAX_FUTURE_SKEW_SECONDS` et `STATION_OFFLINE_RECEIPT_RETENTION_DAYS`, toujours re-bornées par le serveur. Le rollback fourni est limité à `cerp_test` et refuse toute suppression si un reçu existe.
+
+## Conséquences
+
+Le client garde les statuts locaux `LOCAL`, `SYNCING`, `SYNCED`, `REJECTED`; seuls les deux derniers viennent du serveur. Le cache reste en lecture seule et explicitement daté. Le prototype est couvert par les tests de conflit, double synchronisation, crash avant accusé, dépendance et kill switch; son périmètre devient le contrat MVP, sans service worker ni background sync autonome.

--- a/docs/adr/ADR-FEAT-CERP-0006-offline-station-queue.md
+++ b/docs/adr/ADR-FEAT-CERP-0006-offline-station-queue.md
@@ -6,11 +6,11 @@ Statut : accepté pour le MVP. Le mode hors ligne n'est pas un second moteur mé
 
 La station peut conserver localement, chiffrés par AES-GCM avec une clé non exportable, au plus quelques événements `POINTAGE_START`, `POINTAGE_STOP` et `QUANTITY_DECLARE`. Après retour réseau, l'opérateur se réauthentifie et envoie un lot de 1 à 25 événements à `POST /api/v1/production/station/offline/sync`.
 
-Le serveur exige une session vivante au moment de la reprise. La session d'origine peut être close après réauthentification, mais elle doit prouver le même appareil, le même opérateur, la machine déclarée et une date d'événement comprise dans son cycle de vie. Chaque événement est borné à 24 h par défaut, tolère au plus 60 s d'avance d'horloge, possède un `event_id` et une clé d'idempotence. Le moteur canonique de production applique chaque événement dans sa transaction existante. Le reçu de reprise peut rester `PROCESSING` après une panne entre l'effet et l'accusé : le retry rejoue alors la même clé canonique sans second effet.
+Le serveur exige une session vivante au premier traitement. La session d'origine peut être close après réauthentification, mais elle doit prouver le même appareil, le même opérateur, la machine déclarée et une date d'événement comprise dans son cycle de vie. Chaque événement est borné à 24 h par défaut, tolère au plus 60 s d'avance d'horloge, possède un `event_id` et une clé d'idempotence. Un reçu déjà terminal est rejoué à l'identique sans réévaluer ces conditions volatiles. Une session d'exécution UUID stable, dérivée du `POINTAGE_START` et distincte de la session d'authentification station, relie le démarrage et ses dépendants.
 
-Une réservation `PROCESSING` porte un bail de deux minutes et un jeton de fencing unique : un second appel reçoit `OFFLINE_EVENT_IN_PROGRESS` au lieu de concurrencer le premier. Après expiration, la reprise obtient un nouveau jeton; l'ancien propriétaire ne peut plus finaliser le reçu et l'idempotence canonique empêche un second effet.
+Une réservation `PROCESSING` porte un bail de deux minutes et un jeton de fencing unique : un second appel reçoit `OFFLINE_EVENT_IN_PROGRESS` au lieu de concurrencer le premier. La transaction canonique verrouille et vérifie ce jeton avant tout effet, puis écrit l'effet, la réponse idempotente et le reçu `SYNCED` dans le même commit. Après expiration, la reprise obtient un nouveau jeton; l'ancien propriétaire ne peut donc produire aucun effet visible.
 
-Un lot est volontairement partiel : chaque résultat est `SYNCED` ou `REJECTED`. Une dépendance, un changement d'identité ou une collision produit un conflit explicite; rien n'est écrasé. Aucun événement offline ne valide de qualité, ne réceptionne une production et ne crée de mouvement, lot, réservation ou décision de stock.
+Un lot est volontairement partiel : chaque résultat terminal est `SYNCED` ou `REJECTED`. Un START absent ou encore `PROCESSING` libère immédiatement le bail du dépendant et produit un HTTP 503 rejouable; le reste du lot est néanmoins tenté, ce qui autorise un ordre d'arrivée intermittent. Une dépendance rejetée ou incohérente, un changement d'identité initial ou une collision produit un conflit terminal explicite; rien n'est écrasé. Aucun événement offline ne valide de qualité, ne réceptionne une production et ne crée de mouvement, lot, réservation ou décision de stock.
 
 ## Menaces et contrôles
 
@@ -20,7 +20,7 @@ Un lot est volontairement partiel : chaque résultat est `SYNCED` ou `REJECTED`.
 | double clic, retry, double onglet | clé canonique et reçu serveur uniques; empreinte de requête immuable |
 | substitution d'opérateur/station | identité appareil/opérateur exacte; session source et période d'origine vérifiées après réauthentification |
 | horloge fausse | fenêtre passée/future bornée, dérive enregistrée, heure serveur retournée |
-| réseau intermittent ou crash | reçu `PROCESSING`, action canonique transactionnelle, reprise idempotente |
+| réseau intermittent ou crash | dépendance absente rejouable; effet canonique et reçu dans une transaction unique |
 | données altérées | conflit d'empreinte explicite; aucune mise à jour silencieuse |
 | accumulation de données | purge des reçus terminés après 30 jours par défaut (7–365) |
 | risque industriel | liste blanche de trois événements; aucune action stock/qualité irréversible |

--- a/docs/http/station-offline-sync.md
+++ b/docs/http/station-offline-sync.md
@@ -1,0 +1,41 @@
+# Contrat UI — reprise offline station
+
+Route : `POST /api/v1/production/station/offline/sync`. Cookie ou en-tête de session station vivant obligatoire; l'opérateur doit s'être réauthentifié.
+
+```json
+{
+  "client_batch_id": "uuid",
+  "events": [{
+    "event_id": "uuid",
+    "idempotency_key": "station:uuid",
+    "type": "POINTAGE_START | POINTAGE_STOP | QUANTITY_DECLARE",
+    "occurred_at": "2026-08-05T08:30:00.000Z",
+    "device_id": "uuid",
+    "user_id": 7,
+    "station_session_id": "uuid",
+    "machine_id": "uuid-ou-null",
+    "payload": {}
+  }]
+}
+```
+
+`POINTAGE_START.payload` contient `of_id`, `activity_code`, et facultativement `operation_id`, `poste_id`, `time_type`, `comment`. `POINTAGE_STOP.payload` contient exactement `pointage_id` ou `start_event_id`. `QUANTITY_DECLARE.payload` contient `of_id`, les deltas `qty_good`, `qty_scrap`, `qty_rework`, `qty_pending_control`, et facultativement `operation_id`, `pointage_id` ou `pointage_start_event_id`, unités/motifs/note.
+
+Réponse HTTP 200 :
+
+```json
+{
+  "server_time": "2026-08-05T08:31:00.000Z",
+  "kill_switch_enabled": false,
+  "results": [{
+    "event_id": "uuid",
+    "status": "SYNCED | REJECTED",
+    "code": "présent si rejet",
+    "message": "présent si rejet",
+    "server_entity_id": "présent si synchronisé",
+    "replayed": false
+  }]
+}
+```
+
+HTTP 503 avec `kill_switch_enabled: true` et `results: []` signifie « conserver les événements locaux et réessayer plus tard ». Tout `REJECTED` est terminal et doit être affiché; un conflit ne doit jamais être remplacé automatiquement. Le client ne doit envoyer ni jeton, ni badge, ni secret dans IndexedDB ou dans `payload`.

--- a/docs/http/station-offline-sync.md
+++ b/docs/http/station-offline-sync.md
@@ -19,7 +19,9 @@ Route : `POST /api/v1/production/station/offline/sync`. Cookie ou en-tête de se
 }
 ```
 
-`POINTAGE_START.payload` contient `of_id`, `activity_code`, et facultativement `operation_id`, `poste_id`, `time_type`, `comment`. `POINTAGE_STOP.payload` contient exactement `pointage_id` ou `start_event_id`. `QUANTITY_DECLARE.payload` contient `of_id`, les deltas `qty_good`, `qty_scrap`, `qty_rework`, `qty_pending_control`, et facultativement `operation_id`, `pointage_id` ou `pointage_start_event_id`, unités/motifs/note.
+`POINTAGE_START.payload` contient `of_id`, `activity_code`, et facultativement `operation_id`, `poste_id`, `time_type`, `comment`. `POINTAGE_STOP.payload` contient exactement `pointage_id` ou `start_event_id`. `QUANTITY_DECLARE.payload` contient `of_id`, les deltas `qty_good`, `qty_scrap`, `qty_rework`, `qty_pending_control`, et facultativement `operation_id`, `pointage_id` ou `start_event_id`, unités/motifs/note. Pour une quantité, les deux références peuvent être absentes mais jamais présentes ensemble.
+
+Un `start_event_id` n'est résolu que vers un `POINTAGE_START` déjà synchronisé du même lot, appareil, opérateur, session source et machine. Une nouvelle session vivante peut authentifier la reprise si cette session source historique et sa période sont encore vérifiables côté serveur.
 
 Réponse HTTP 200 :
 

--- a/docs/http/station-offline-sync.md
+++ b/docs/http/station-offline-sync.md
@@ -21,7 +21,7 @@ Route : `POST /api/v1/production/station/offline/sync`. Cookie ou en-tête de se
 
 `POINTAGE_START.payload` contient `of_id`, `activity_code`, et facultativement `operation_id`, `poste_id`, `time_type`, `comment`. `POINTAGE_STOP.payload` contient exactement `pointage_id` ou `start_event_id`. `QUANTITY_DECLARE.payload` contient `of_id`, les deltas `qty_good`, `qty_scrap`, `qty_rework`, `qty_pending_control`, et facultativement `operation_id`, `pointage_id` ou `start_event_id`, unités/motifs/note. Pour une quantité, les deux références peuvent être absentes mais jamais présentes ensemble.
 
-Un `start_event_id` n'est résolu que vers un `POINTAGE_START` déjà synchronisé du même lot, appareil, opérateur, session source et machine. Une nouvelle session vivante peut authentifier la reprise si cette session source historique et sa période sont encore vérifiables côté serveur.
+Un `start_event_id` n'est résolu que vers un `POINTAGE_START` déjà synchronisé du même lot, appareil, opérateur, session source, machine et session d'exécution. Une nouvelle session vivante peut authentifier le premier traitement si cette session source historique et sa période sont encore vérifiables côté serveur. Un reçu terminal est ensuite rejoué sans revalidation volatile.
 
 Réponse HTTP 200 :
 
@@ -41,3 +41,5 @@ Réponse HTTP 200 :
 ```
 
 HTTP 503 avec `kill_switch_enabled: true` et `results: []` signifie « conserver les événements locaux et réessayer plus tard ». Tout `REJECTED` est terminal et doit être affiché; un conflit ne doit jamais être remplacé automatiquement. Le client ne doit envoyer ni jeton, ni badge, ni secret dans IndexedDB ou dans `payload`.
+
+HTTP 503 avec `OFFLINE_DEPENDENCY_MISSING`, `OFFLINE_DEPENDENCY_PENDING`, `OFFLINE_EVENT_IN_PROGRESS` ou `OFFLINE_EVENT_CLAIM_LOST` est transitoire : conserver exactement `event_id`, `idempotency_key`, `client_batch_id` et la charge, puis rejouer. Aucun reçu `REJECTED` n'est créé pour une dépendance simplement absente ou encore en cours.

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -25,6 +25,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "341f7911a7bcb479fce6602d0567c51d47f083a08b37409e55d05cf3110f01b5",
   "20260805_quality_delivery_release_gate_0005.sql":
     "ceff91b88820e9943d199f71a73e32fd4f994d383f76aabb620ea648c9d1ae53",
+  "20260805_station_offline_queue_0006.sql":
+    "a6517726c4a852bea43f1ea51aa1ca6cffbc6e97a8f29dd8eec49c4a9941eb80",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -26,7 +26,7 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
   "20260805_quality_delivery_release_gate_0005.sql":
     "ceff91b88820e9943d199f71a73e32fd4f994d383f76aabb620ea648c9d1ae53",
   "20260805_station_offline_queue_0006.sql":
-    "41158624061dd93aa0fb4173ea7e3bc8a3c33e521705548969fb59dfe93ad4b4",
+    "3e223c43698bdf3399ab2d37e6493d0d014952eb0fe877cdeb1c4b4f7f7db3da",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -26,7 +26,7 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
   "20260805_quality_delivery_release_gate_0005.sql":
     "ceff91b88820e9943d199f71a73e32fd4f994d383f76aabb620ea648c9d1ae53",
   "20260805_station_offline_queue_0006.sql":
-    "a6517726c4a852bea43f1ea51aa1ca6cffbc6e97a8f29dd8eec49c4a9941eb80",
+    "41158624061dd93aa0fb4173ea7e3bc8a3c33e521705548969fb59dfe93ad4b4",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -60,7 +60,7 @@ const wave9PatchChecksums = new Map([
   ],
   [
     "20260805_station_offline_queue_0006.sql",
-    "41158624061dd93aa0fb4173ea7e3bc8a3c33e521705548969fb59dfe93ad4b4",
+    "3e223c43698bdf3399ab2d37e6493d0d014952eb0fe877cdeb1c4b4f7f7db3da",
   ],
 ]);
 

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -60,7 +60,7 @@ const wave9PatchChecksums = new Map([
   ],
   [
     "20260805_station_offline_queue_0006.sql",
-    "a6517726c4a852bea43f1ea51aa1ca6cffbc6e97a8f29dd8eec49c4a9941eb80",
+    "41158624061dd93aa0fb4173ea7e3bc8a3c33e521705548969fb59dfe93ad4b4",
   ],
 ]);
 

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -58,6 +58,10 @@ const wave9PatchChecksums = new Map([
     "20260805_quality_delivery_release_gate_0005.sql",
     "ceff91b88820e9943d199f71a73e32fd4f994d383f76aabb620ea648c9d1ae53",
   ],
+  [
+    "20260805_station_offline_queue_0006.sql",
+    "a6517726c4a852bea43f1ea51aa1ca6cffbc6e97a8f29dd8eec49c4a9941eb80",
+  ],
 ]);
 
 function queryText(value: unknown): string {

--- a/src/__tests__/offline-station-queue.test.ts
+++ b/src/__tests__/offline-station-queue.test.ts
@@ -10,6 +10,8 @@ const mocks = vi.hoisted(() => ({
   enabled: vi.fn(),
   reserve: vi.fn(),
   complete: vi.fn(),
+  assertClaim: vi.fn(),
+  releaseClaim: vi.fn(),
   dependency: vi.fn(),
   sourceSession: vi.fn(),
   canonicalExists: vi.fn(),
@@ -24,6 +26,8 @@ vi.mock("../module/production/repository/offline-station.repository", () => ({
   repoOfflineSyncEnabled: mocks.enabled,
   repoReserveOfflineEvent: mocks.reserve,
   repoCompleteOfflineEvent: mocks.complete,
+  repoAssertOfflineEventClaim: mocks.assertClaim,
+  repoReleaseOfflineEventClaim: mocks.releaseClaim,
   repoOfflineDependency: mocks.dependency,
   repoOfflineSourceSession: mocks.sourceSession,
   repoCanonicalIdempotencyExists: mocks.canonicalExists,
@@ -148,6 +152,7 @@ function syncedStartDependency(overrides: Record<string, unknown> = {}) {
     error_code: null,
     error_message: null,
     server_entity_id: ENTITY,
+    execution_session_id: null,
     client_batch_id: BATCH,
     event_type: "POINTAGE_START" as const,
     device_id: DEVICE,
@@ -158,17 +163,39 @@ function syncedStartDependency(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function currentSyncedStartDependency(overrides: Record<string, unknown> = {}) {
+  return syncedStartDependency({
+    execution_session_id: mocks.reserve.mock.calls.at(-1)?.[0].executionSessionId ?? null,
+    ...overrides,
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   delete process.env.STATION_OFFLINE_SYNC_ENABLED;
   mocks.enabled.mockResolvedValue(true);
   mocks.reserve.mockResolvedValue(processing());
   mocks.complete.mockResolvedValue(undefined);
+  mocks.assertClaim.mockResolvedValue(undefined);
+  mocks.releaseClaim.mockResolvedValue(undefined);
   mocks.canonicalExists.mockResolvedValue(false);
   mocks.sourceSession.mockResolvedValue(null);
   mocks.purge.mockResolvedValue(0);
   mocks.audit.mockResolvedValue(undefined);
-  mocks.start.mockResolvedValue({ id: ENTITY });
+  const runCanonical = async (params: {
+    transactionHooks?: {
+      beforeEffect: (tx: { query: ReturnType<typeof vi.fn> }) => Promise<void>;
+      beforeCommit: (tx: { query: ReturnType<typeof vi.fn> }, result: { id: string }) => Promise<void>;
+    };
+  }) => {
+    const tx = { query: vi.fn() };
+    await params.transactionHooks?.beforeEffect(tx);
+    await params.transactionHooks?.beforeCommit(tx, { id: ENTITY });
+    return { id: ENTITY };
+  };
+  mocks.start.mockImplementation(runCanonical);
+  mocks.stop.mockImplementation(runCanonical);
+  mocks.quantity.mockImplementation(runCanonical);
 });
 
 describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
@@ -223,6 +250,31 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
     expect(mocks.start).toHaveBeenCalledTimes(1);
   });
 
+  it("rejoue un reçu SYNCED terminal avant tout contrôle volatil d'horloge ou de session source", async () => {
+    mocks.reserve.mockResolvedValue({
+      kind: "RESERVED",
+      existing: true,
+      outcome: {
+        ...processing().outcome,
+        status: "SYNCED",
+        server_entity_id: ENTITY,
+      },
+    });
+    const result = await svcSyncOfflineStation({
+      body: startBatch({
+        occurred_at: new Date(Date.now() - 48 * 3_600_000).toISOString(),
+        station_session_id: OLD_SESSION,
+        machine_id: OLD_MACHINE,
+      }),
+      station,
+      audit,
+    });
+    expect(result.results[0]).toMatchObject({ status: "SYNCED", server_entity_id: ENTITY, replayed: true });
+    expect(mocks.sourceSession).not.toHaveBeenCalled();
+    expect(mocks.start).not.toHaveBeenCalled();
+    expect(mocks.complete).not.toHaveBeenCalled();
+  });
+
   it("résout un STOP vers le START local synchronisé juste avant dans le même lot", async () => {
     const start = startBatch().events[0]!;
     const body = offlineStationSyncSchema.parse({
@@ -246,11 +298,15 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
       ...processing(),
       outcome: { ...processing().outcome, event_id: event.event_id },
     }));
-    mocks.dependency.mockResolvedValue(syncedStartDependency());
+    mocks.dependency.mockImplementation(() => Promise.resolve(currentSyncedStartDependency()));
     mocks.stop.mockResolvedValue({ id: ENTITY });
     const result = await svcSyncOfflineStation({ body, station, audit });
     expect(result.results.map((item) => item.status)).toEqual(["SYNCED", "SYNCED"]);
     expect(mocks.stop).toHaveBeenCalledWith(expect.objectContaining({ id: ENTITY }));
+    expect(mocks.reserve.mock.calls[0]?.[0].executionSessionId).toEqual(expect.any(String));
+    expect(mocks.reserve.mock.calls[1]?.[0].executionSessionId).toBe(
+      mocks.reserve.mock.calls[0]?.[0].executionSessionId
+    );
   });
 
   it.each([
@@ -261,7 +317,7 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
     ["session", { station_session_id: OLD_SESSION }, "OFFLINE_DEPENDENCY_CONTEXT_CONFLICT"],
     ["machine", { machine_id: OLD_MACHINE }, "OFFLINE_DEPENDENCY_CONTEXT_CONFLICT"],
   ])("refuse un start_event_id dont le %s diffère", async (_label, dependencyOverride, code) => {
-    mocks.dependency.mockResolvedValue(syncedStartDependency(dependencyOverride));
+    mocks.dependency.mockImplementation(() => Promise.resolve(currentSyncedStartDependency(dependencyOverride)));
     const result = await svcSyncOfflineStation({ body: stopBatch(), station, audit });
     expect(result.results[0]).toMatchObject({ status: "REJECTED", code });
     expect(mocks.complete).toHaveBeenCalledWith(expect.objectContaining({ status: "REJECTED" }));
@@ -269,7 +325,7 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
   });
 
   it("résout aussi start_event_id pour une déclaration de quantité", async () => {
-    mocks.dependency.mockResolvedValue(syncedStartDependency());
+    mocks.dependency.mockImplementation(() => Promise.resolve(currentSyncedStartDependency()));
     mocks.quantity.mockResolvedValue({ id: ENTITY });
     const result = await svcSyncOfflineStation({
       body: quantityBatch({ pointage_id: null, start_event_id: EVENT }),
@@ -288,11 +344,94 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
     expect(() => quantityBatch({ pointage_id: ENTITY, start_event_id: EVENT })).toThrow();
   });
 
-  it("reprend après un crash entre effet canonique et reçu sans nouvel effet logique", async () => {
+  it.each([
+    ["absente", null, "OFFLINE_DEPENDENCY_MISSING"],
+    ["encore en cours", "PROCESSING", "OFFLINE_DEPENDENCY_PENDING"],
+  ])("laisse une dépendance START %s rejouable sans reçu REJECTED", async (_label, dependencyStatus, code) => {
+    if (dependencyStatus) {
+      mocks.dependency.mockImplementation(() => Promise.resolve(currentSyncedStartDependency({
+        status: dependencyStatus,
+        server_entity_id: null,
+      })));
+    } else {
+      mocks.dependency.mockResolvedValue(null);
+    }
+    await expect(svcSyncOfflineStation({ body: stopBatch(), station, audit })).rejects.toMatchObject({
+      status: 503,
+      code,
+    });
+    expect(mocks.releaseClaim).toHaveBeenCalledWith(expect.objectContaining({
+      eventId: STOP_EVENT,
+      claimToken: expect.any(String),
+    }));
+    expect(mocks.complete).not.toHaveBeenCalled();
+    expect(mocks.stop).not.toHaveBeenCalled();
+  });
+
+  it("synchronise le STOP au retry dès que son START intermittent est disponible", async () => {
     mocks.reserve.mockResolvedValueOnce(processing()).mockResolvedValueOnce(processing(true));
-    mocks.complete.mockRejectedValueOnce(new Error("network lost after commit")).mockResolvedValueOnce(undefined);
-    mocks.canonicalExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
-    await expect(svcSyncOfflineStation({ body: startBatch(), station, audit })).rejects.toThrow("network lost");
+    mocks.dependency
+      .mockResolvedValueOnce(null)
+      .mockImplementation(() => Promise.resolve(currentSyncedStartDependency()));
+    await expect(svcSyncOfflineStation({ body: stopBatch(), station, audit })).rejects.toMatchObject({
+      status: 503,
+      code: "OFFLINE_DEPENDENCY_MISSING",
+    });
+    const result = await svcSyncOfflineStation({ body: stopBatch(), station, audit });
+    expect(result.results[0]).toMatchObject({ status: "SYNCED", server_entity_id: ENTITY, replayed: true });
+    expect(mocks.releaseClaim).toHaveBeenCalledTimes(1);
+    expect(mocks.stop).toHaveBeenCalledTimes(1);
+  });
+
+  it("continue le lot après une dépendance transitoire pour laisser arriver son START", async () => {
+    const stop = stopBatch().events[0]!;
+    const start = startBatch().events[0]!;
+    const body = offlineStationSyncSchema.parse({ client_batch_id: BATCH, events: [stop, start] });
+    mocks.reserve.mockImplementation(({ event }: { event: { event_id: string } }) => Promise.resolve({
+      ...processing(),
+      outcome: { ...processing().outcome, event_id: event.event_id },
+    }));
+    mocks.dependency.mockResolvedValue(null);
+    await expect(svcSyncOfflineStation({ body, station, audit })).rejects.toMatchObject({
+      status: 503,
+      code: "OFFLINE_DEPENDENCY_MISSING",
+    });
+    expect(mocks.releaseClaim).toHaveBeenCalledTimes(1);
+    expect(mocks.stop).not.toHaveBeenCalled();
+    expect(mocks.start).toHaveBeenCalledTimes(1);
+    expect(mocks.complete).toHaveBeenCalledWith(
+      expect.objectContaining({ eventId: EVENT, status: "SYNCED" }),
+      expect.anything()
+    );
+  });
+
+  it("verrouille le fencing avant l'effet puis finalise le reçu dans la même transaction", async () => {
+    const order: string[] = [];
+    const tx = { query: vi.fn() };
+    mocks.assertClaim.mockImplementation(async () => { order.push("claim"); });
+    mocks.complete.mockImplementation(async () => { order.push("receipt"); });
+    mocks.start.mockImplementation(async (params: {
+      transactionHooks: {
+        beforeEffect: (client: typeof tx) => Promise<void>;
+        beforeCommit: (client: typeof tx, result: { id: string }) => Promise<void>;
+      };
+    }) => {
+      await params.transactionHooks.beforeEffect(tx);
+      order.push("effect");
+      await params.transactionHooks.beforeCommit(tx, { id: ENTITY });
+      return { id: ENTITY };
+    });
+    await svcSyncOfflineStation({ body: startBatch(), station, audit });
+    expect(order).toEqual(["claim", "effect", "receipt"]);
+    expect(mocks.assertClaim.mock.calls[0]?.[0]).toBe(tx);
+    expect(mocks.complete.mock.calls[0]?.[1]).toBe(tx);
+  });
+
+  it("annule effet et reçu ensemble si la finalisation atomique échoue, puis reprend avec un nouveau token", async () => {
+    mocks.reserve.mockResolvedValueOnce(processing()).mockResolvedValueOnce(processing(true));
+    mocks.complete.mockRejectedValueOnce(new Error("atomic finalization failed")).mockResolvedValueOnce(undefined);
+    mocks.canonicalExists.mockResolvedValue(false);
+    await expect(svcSyncOfflineStation({ body: startBatch(), station, audit })).rejects.toThrow("atomic finalization failed");
     const resumed = await svcSyncOfflineStation({ body: startBatch(), station, audit });
     expect(resumed.results[0]).toMatchObject({ status: "SYNCED", replayed: true });
     expect(mocks.start).toHaveBeenNthCalledWith(2, expect.objectContaining({ idempotencyKey: "offline-start-000001" }));
@@ -301,6 +440,12 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
     expect(firstClaim).toEqual(expect.any(String));
     expect(resumedClaim).toEqual(expect.any(String));
     expect(resumedClaim).not.toBe(firstClaim);
+    expect(mocks.reserve.mock.calls[1]?.[0].executionSessionId).toBe(
+      mocks.reserve.mock.calls[0]?.[0].executionSessionId
+    );
+    expect(mocks.start.mock.calls[1]?.[0].executionSessionId).toBe(
+      mocks.start.mock.calls[0]?.[0].executionSessionId
+    );
     expect(mocks.complete.mock.calls[0]?.[0].claimToken).toBe(firstClaim);
     expect(mocks.complete.mock.calls[1]?.[0].claimToken).toBe(resumedClaim);
   });
@@ -372,9 +517,13 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
     expect(result.results[0]).toMatchObject({ status: "SYNCED", server_entity_id: ENTITY });
     expect(mocks.sourceSession).toHaveBeenCalledWith(OLD_SESSION);
     expect(mocks.start).toHaveBeenCalledWith(expect.objectContaining({
-      stationSessionId: SESSION,
+      executionSessionId: expect.any(String),
       body: expect.objectContaining({ machine_id: OLD_MACHINE }),
     }));
+    const executionId = mocks.start.mock.calls[0]?.[0].executionSessionId;
+    expect(executionId).toBe(mocks.reserve.mock.calls[0]?.[0].executionSessionId);
+    expect(executionId).not.toBe(SESSION);
+    expect(executionId).not.toBe(OLD_SESSION);
   });
 
   it("fige le rejet si la session source ne correspond pas au contexte déclaré", async () => {
@@ -483,6 +632,10 @@ describe("GPT56-FEAT-CERP-0006 — migration et frontières", () => {
     path.join(repoRoot, "src", "module", "production", "repository", "offline-station.repository.ts"),
     "utf8"
   );
+  const canonicalRepository = fs.readFileSync(
+    path.join(repoRoot, "src", "module", "production", "repository", "production-execution.repository.ts"),
+    "utf8"
+  );
 
   it("fournit migration, preflight, vérification et rollback test-only", () => {
     for (const suffix of ["preflight", "verify", "rollback"]) {
@@ -525,5 +678,25 @@ describe("GPT56-FEAT-CERP-0006 — migration et frontières", () => {
     expect(repository).toContain("lease_expires_at > clock_timestamp()");
     expect(repository).toContain("processing_token = $8::uuid");
     expect(repository).toContain("result.rowCount !== 1");
+  });
+
+  it("verrouille le reçu avant chaque transaction canonique et le finalise avant COMMIT", () => {
+    expect(repository).toMatch(/repoAssertOfflineEventClaim[\s\S]*FOR UPDATE/);
+    expect(repository).toContain("lease_expires_at > clock_timestamp()");
+    for (const functionName of ["repoStartExecution", "repoStopExecution", "repoDeclareQuantity"]) {
+      const start = canonicalRepository.indexOf(`export async function ${functionName}`);
+      const end = canonicalRepository.indexOf("\nexport async function ", start + 1);
+      const body = canonicalRepository.slice(start, end === -1 ? undefined : end);
+      expect(body.indexOf("beforeEffect(client)")).toBeGreaterThan(-1);
+      expect(body.indexOf("beforeEffect(client)")).toBeLessThan(body.indexOf("reserveIdempotencyKey"));
+      expect(body.lastIndexOf("beforeCommit(client")).toBeGreaterThan(body.indexOf("storeIdempotentResponse"));
+      expect(body.lastIndexOf("beforeCommit(client")).toBeLessThan(body.lastIndexOf('client.query("COMMIT")'));
+    }
+  });
+
+  it("porte une session d'exécution stable distincte de la session d'authentification", () => {
+    expect(migration).toContain("execution_session_id uuid");
+    expect(migration).toContain("event_type <> 'POINTAGE_START' OR execution_session_id IS NOT NULL");
+    expect(migration).toContain("NEW.execution_session_id IS DISTINCT FROM OLD.execution_session_id");
   });
 });

--- a/src/__tests__/offline-station-queue.test.ts
+++ b/src/__tests__/offline-station-queue.test.ts
@@ -179,7 +179,16 @@ beforeEach(() => {
   mocks.assertClaim.mockResolvedValue(undefined);
   mocks.releaseClaim.mockResolvedValue(undefined);
   mocks.canonicalExists.mockResolvedValue(false);
-  mocks.sourceSession.mockResolvedValue(null);
+  mocks.sourceSession.mockResolvedValue({
+    id: SESSION,
+    device_id: DEVICE,
+    user_id: 7,
+    machine_id: MACHINE,
+    state: "ACTIVE",
+    started_at: new Date(Date.now() - 7 * 86_400_000).toISOString(),
+    closed_at: null,
+    expires_at: new Date(Date.now() + 7 * 86_400_000).toISOString(),
+  });
   mocks.purge.mockResolvedValue(0);
   mocks.audit.mockResolvedValue(undefined);
   const runCanonical = async (params: {
@@ -225,6 +234,38 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
         payload: { of_id: 42, qty_good: 0 },
       }],
     })).toThrow();
+  });
+
+  it("canonicalise tous les UUID avant réservation et recherche de dépendance", async () => {
+    const event = stopBatch().events[0]!;
+    const uppercaseEventId = "ABCDEFAB-CDEF-4ABC-8DEF-ABCDEFABCDEF";
+    const canonicalEventId = uppercaseEventId.toLowerCase();
+    const body = offlineStationSyncSchema.parse({
+      client_batch_id: BATCH.toUpperCase(),
+      events: [{
+        ...event,
+        event_id: uppercaseEventId,
+        device_id: DEVICE.toUpperCase(),
+        station_session_id: SESSION.toUpperCase(),
+        machine_id: MACHINE.toUpperCase(),
+        payload: { pointage_id: null, start_event_id: EVENT.toUpperCase() },
+      }],
+    });
+    mocks.dependency.mockImplementation(() => Promise.resolve(currentSyncedStartDependency()));
+
+    const result = await svcSyncOfflineStation({ body, station, audit });
+
+    expect(body.client_batch_id).toBe(BATCH);
+    expect(body.events[0]).toMatchObject({
+      event_id: canonicalEventId,
+      device_id: DEVICE,
+      station_session_id: SESSION,
+      machine_id: MACHINE,
+      payload: { start_event_id: EVENT },
+    });
+    expect(mocks.reserve.mock.calls[0]?.[0].event.event_id).toBe(canonicalEventId);
+    expect(mocks.dependency).toHaveBeenCalledWith(EVENT);
+    expect(result.results[0]).toMatchObject({ status: "SYNCED" });
   });
 
   it("double sync: applique une fois puis renvoie le reçu synchronisé", async () => {
@@ -524,6 +565,30 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
     expect(executionId).toBe(mocks.reserve.mock.calls[0]?.[0].executionSessionId);
     expect(executionId).not.toBe(SESSION);
     expect(executionId).not.toBe(OLD_SESSION);
+  });
+
+  it("refuse aussi l'antidatage antérieur à l'ouverture de la session courante", async () => {
+    const startedAt = new Date();
+    mocks.sourceSession.mockResolvedValue({
+      id: SESSION,
+      device_id: DEVICE,
+      user_id: 7,
+      machine_id: MACHINE,
+      state: "ACTIVE",
+      started_at: startedAt.toISOString(),
+      closed_at: null,
+      expires_at: new Date(startedAt.getTime() + 8 * 3_600_000).toISOString(),
+    });
+    const result = await svcSyncOfflineStation({
+      body: startBatch({ occurred_at: new Date(startedAt.getTime() - 61_000).toISOString() }),
+      station,
+      audit,
+    });
+    expect(result.results[0]).toMatchObject({
+      status: "REJECTED",
+      code: "OFFLINE_SOURCE_SESSION_TIME_CONFLICT",
+    });
+    expect(mocks.start).not.toHaveBeenCalled();
   });
 
   it("fige le rejet si la session source ne correspond pas au contexte déclaré", async () => {

--- a/src/__tests__/offline-station-queue.test.ts
+++ b/src/__tests__/offline-station-queue.test.ts
@@ -1,0 +1,297 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HttpError } from "../utils/httpError";
+import { repoRoot } from "./helpers/repo-paths";
+
+const mocks = vi.hoisted(() => ({
+  enabled: vi.fn(),
+  reserve: vi.fn(),
+  complete: vi.fn(),
+  dependency: vi.fn(),
+  canonicalExists: vi.fn(),
+  purge: vi.fn(),
+  audit: vi.fn(),
+  start: vi.fn(),
+  stop: vi.fn(),
+  quantity: vi.fn(),
+}));
+
+vi.mock("../module/production/repository/offline-station.repository", () => ({
+  repoOfflineSyncEnabled: mocks.enabled,
+  repoReserveOfflineEvent: mocks.reserve,
+  repoCompleteOfflineEvent: mocks.complete,
+  repoOfflineDependency: mocks.dependency,
+  repoCanonicalIdempotencyExists: mocks.canonicalExists,
+  repoPurgeOfflineEvents: mocks.purge,
+}));
+vi.mock("../module/production/repository/station.repository", () => ({ repoStationAudit: mocks.audit }));
+vi.mock("../module/production/services/production-execution.service", () => ({
+  svcStartExecution: mocks.start,
+  svcStopExecution: mocks.stop,
+  svcDeclareQuantity: mocks.quantity,
+}));
+
+import { svcSyncOfflineStation } from "../module/production/services/offline-station.service";
+import { offlineStationSyncSchema } from "../module/production/validators/offline-station.validators";
+
+const DEVICE = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
+const SESSION = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const MACHINE = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const EVENT = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
+const STOP_EVENT = "12121212-1212-4121-8121-121212121212";
+const ENTITY = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
+const BATCH = "ffffffff-ffff-4fff-8fff-ffffffffffff";
+
+const station = {
+  session_id: SESSION,
+  device_id: DEVICE,
+  device_code: "TAB-0001",
+  device_zone: "USINAGE",
+  device_assignment_mode: "FIXED" as const,
+  machine_id: MACHINE,
+  user: { id: 7, username: "operator", name: null, surname: null, role: "Operateur CN" },
+  auto_lock_seconds: 180,
+};
+const audit = {
+  user_id: 7,
+  user_role: "Operateur CN",
+  ip: null,
+  user_agent: null,
+  device_type: "tablet",
+  os: null,
+  browser: null,
+  path: "/api/v1/production/station/offline/sync",
+  page_key: "atelier-offline-sync",
+  client_session_id: SESSION,
+};
+
+function startBatch(overrides: Record<string, unknown> = {}) {
+  return offlineStationSyncSchema.parse({
+    client_batch_id: BATCH,
+    events: [{
+      event_id: EVENT,
+      idempotency_key: "offline-start-000001",
+      type: "POINTAGE_START",
+      occurred_at: new Date().toISOString(),
+      device_id: DEVICE,
+      user_id: 7,
+      station_session_id: SESSION,
+      machine_id: MACHINE,
+      payload: { of_id: 42, activity_code: "PRODUCTION" },
+      ...overrides,
+    }],
+  });
+}
+
+function processing(existing = false) {
+  return {
+    kind: "RESERVED" as const,
+    existing,
+    outcome: {
+      event_id: EVENT,
+      status: "PROCESSING" as const,
+      result_payload: null,
+      error_code: null,
+      error_message: null,
+      server_entity_id: null,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env.STATION_OFFLINE_SYNC_ENABLED;
+  mocks.enabled.mockResolvedValue(true);
+  mocks.reserve.mockResolvedValue(processing());
+  mocks.complete.mockResolvedValue(undefined);
+  mocks.canonicalExists.mockResolvedValue(false);
+  mocks.purge.mockResolvedValue(0);
+  mocks.audit.mockResolvedValue(undefined);
+  mocks.start.mockResolvedValue({ id: ENTITY });
+});
+
+describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
+  it("n'accepte que les trois événements et 25 éléments au maximum", () => {
+    expect(startBatch().events[0]?.type).toBe("POINTAGE_START");
+    expect(() => startBatch({ type: "QUALITY_RELEASE" })).toThrow();
+    expect(() => startBatch({ occurred_at: "2026-08-05" })).toThrow();
+    const one = startBatch().events[0];
+    expect(() => offlineStationSyncSchema.parse({
+      client_batch_id: BATCH,
+      events: Array.from({ length: 26 }, (_, index) => ({
+        ...one,
+        event_id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+        idempotency_key: `offline-${index}-unique`,
+      })),
+    })).toThrow();
+  });
+
+  it("refuse les doublons internes et une quantité nulle", () => {
+    const event = startBatch().events[0];
+    expect(() => offlineStationSyncSchema.parse({ client_batch_id: BATCH, events: [event, event] })).toThrow();
+    expect(() => offlineStationSyncSchema.parse({
+      client_batch_id: BATCH,
+      events: [{
+        ...event,
+        type: "QUANTITY_DECLARE",
+        payload: { of_id: 42, qty_good: 0 },
+      }],
+    })).toThrow();
+  });
+
+  it("double sync: applique une fois puis renvoie le reçu synchronisé", async () => {
+    mocks.reserve
+      .mockResolvedValueOnce(processing())
+      .mockResolvedValueOnce({
+        kind: "RESERVED",
+        existing: true,
+        outcome: {
+          event_id: EVENT,
+          status: "SYNCED",
+          result_payload: { server_entity_id: ENTITY },
+          error_code: null,
+          error_message: null,
+          server_entity_id: ENTITY,
+        },
+      });
+    const body = startBatch();
+    const first = await svcSyncOfflineStation({ body, station, audit });
+    const second = await svcSyncOfflineStation({ body, station, audit });
+    expect(first.results[0]).toMatchObject({ status: "SYNCED", replayed: false, server_entity_id: ENTITY });
+    expect(second.results[0]).toMatchObject({ status: "SYNCED", replayed: true, server_entity_id: ENTITY });
+    expect(mocks.start).toHaveBeenCalledTimes(1);
+  });
+
+  it("résout un STOP vers le START local synchronisé juste avant dans le même lot", async () => {
+    const start = startBatch().events[0]!;
+    const body = offlineStationSyncSchema.parse({
+      client_batch_id: BATCH,
+      events: [
+        start,
+        {
+          event_id: STOP_EVENT,
+          idempotency_key: "offline-stop-000001",
+          type: "POINTAGE_STOP",
+          occurred_at: new Date().toISOString(),
+          device_id: DEVICE,
+          user_id: 7,
+          station_session_id: SESSION,
+          machine_id: MACHINE,
+          payload: { pointage_id: null, start_event_id: EVENT },
+        },
+      ],
+    });
+    mocks.reserve.mockImplementation(({ event }: { event: { event_id: string } }) => Promise.resolve({
+      ...processing(),
+      outcome: { ...processing().outcome, event_id: event.event_id },
+    }));
+    mocks.dependency.mockResolvedValue({
+      event_id: EVENT,
+      status: "SYNCED",
+      result_payload: { server_entity_id: ENTITY },
+      error_code: null,
+      error_message: null,
+      server_entity_id: ENTITY,
+    });
+    mocks.stop.mockResolvedValue({ id: ENTITY });
+    const result = await svcSyncOfflineStation({ body, station, audit });
+    expect(result.results.map((item) => item.status)).toEqual(["SYNCED", "SYNCED"]);
+    expect(mocks.stop).toHaveBeenCalledWith(expect.objectContaining({ id: ENTITY }));
+  });
+
+  it("reprend après un crash entre effet canonique et reçu sans nouvel effet logique", async () => {
+    mocks.reserve.mockResolvedValueOnce(processing()).mockResolvedValueOnce(processing(true));
+    mocks.complete.mockRejectedValueOnce(new Error("network lost after commit")).mockResolvedValueOnce(undefined);
+    mocks.canonicalExists.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
+    await expect(svcSyncOfflineStation({ body: startBatch(), station, audit })).rejects.toThrow("network lost");
+    const resumed = await svcSyncOfflineStation({ body: startBatch(), station, audit });
+    expect(resumed.results[0]).toMatchObject({ status: "SYNCED", replayed: true });
+    expect(mocks.start).toHaveBeenNthCalledWith(2, expect.objectContaining({ idempotencyKey: "offline-start-000001" }));
+  });
+
+  it("rend les conflits explicites et persistants", async () => {
+    mocks.start.mockRejectedValue(new HttpError(409, "PRODUCTION_EXECUTION_OVERLAP", "Chevauchement détecté."));
+    const result = await svcSyncOfflineStation({ body: startBatch(), station, audit });
+    expect(result.results[0]).toMatchObject({
+      status: "REJECTED",
+      code: "PRODUCTION_EXECUTION_OVERLAP",
+      message: "Chevauchement détecté.",
+    });
+    expect(mocks.complete).toHaveBeenCalledWith(expect.objectContaining({ status: "REJECTED" }));
+  });
+
+  it("n'écrase jamais une collision d'identifiant ou de clé", async () => {
+    mocks.reserve.mockResolvedValue({ kind: "CONFLICT" });
+    const result = await svcSyncOfflineStation({ body: startBatch(), station, audit });
+    expect(result.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_IDEMPOTENCY_CONFLICT" });
+    expect(mocks.start).not.toHaveBeenCalled();
+    expect(mocks.complete).not.toHaveBeenCalled();
+  });
+
+  it("exige l'identité exacte après réauthentification", async () => {
+    const result = await svcSyncOfflineStation({ body: startBatch({ user_id: 8 }), station, audit });
+    expect(result.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_OPERATOR_CONFLICT" });
+    expect(mocks.reserve).not.toHaveBeenCalled();
+    expect(mocks.start).not.toHaveBeenCalled();
+  });
+
+  it("rejette explicitement une horloge trop en avance ou un événement expiré", async () => {
+    const future = new Date(Date.now() + 120_000).toISOString();
+    const old = new Date(Date.now() - 25 * 3_600_000).toISOString();
+    const ahead = await svcSyncOfflineStation({ body: startBatch({ occurred_at: future }), station, audit });
+    const expired = await svcSyncOfflineStation({ body: startBatch({ occurred_at: old }), station, audit });
+    expect(ahead.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_CLOCK_AHEAD" });
+    expect(expired.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_EVENT_EXPIRED" });
+    expect(mocks.reserve).not.toHaveBeenCalled();
+  });
+
+  it("le kill switch ne consomme aucun événement", async () => {
+    mocks.enabled.mockResolvedValue(false);
+    const result = await svcSyncOfflineStation({ body: startBatch(), station, audit });
+    expect(result).toMatchObject({ kill_switch_enabled: true, results: [] });
+    expect(mocks.reserve).not.toHaveBeenCalled();
+  });
+
+  it("refuse temporairement une synchronisation concurrente sans marquer l'événement rejeté", async () => {
+    mocks.reserve.mockResolvedValue({ kind: "BUSY" });
+    await expect(svcSyncOfflineStation({ body: startBatch(), station, audit })).rejects.toMatchObject({
+      status: 503,
+      code: "OFFLINE_EVENT_IN_PROGRESS",
+    });
+    expect(mocks.complete).not.toHaveBeenCalled();
+    expect(mocks.start).not.toHaveBeenCalled();
+  });
+});
+
+describe("GPT56-FEAT-CERP-0006 — migration et frontières", () => {
+  const patchDir = path.join(repoRoot, "db", "patches");
+  const migration = fs.readFileSync(path.join(patchDir, "20260805_station_offline_queue_0006.sql"), "utf8");
+
+  it("fournit migration, preflight, vérification et rollback test-only", () => {
+    for (const suffix of ["preflight", "verify", "rollback"]) {
+      expect(fs.existsSync(path.join(patchDir, "support", `20260805_station_offline_queue_0006.${suffix}.sql`))).toBe(true);
+    }
+    expect(migration.trimStart()).toMatch(/^--[\s\S]*?BEGIN;/);
+    expect(migration.trimEnd()).toMatch(/COMMIT;$/);
+    const rollback = fs.readFileSync(path.join(patchDir, "support", "20260805_station_offline_queue_0006.rollback.sql"), "utf8");
+    expect(rollback).toContain("current_database() <> 'cerp_test'");
+    expect(rollback).toContain("offline receipt data exists");
+  });
+
+  it("ne crée ni effet stock/qualité ni secret persistant", () => {
+    expect(migration).not.toMatch(/INSERT INTO public\.(stock_|lots|quality_|production_receipts)/i);
+    expect(migration).not.toMatch(/\b(session_token|badge_uid|password|enrollment_secret)\s+(text|bytea)\b/i);
+    expect(migration).toContain("POINTAGE_START");
+    expect(migration).toContain("QUANTITY_DECLARE");
+  });
+
+  it("rend les reçus finaux immuables et fournit purge et kill switch", () => {
+    expect(migration).toContain("Final offline receipts are immutable");
+    expect(migration).toContain("fn_purge_production_station_offline_events");
+    expect(migration).toContain("production_station_offline_config");
+    expect(migration).toMatch(/GRANT SELECT ON TABLE public\.production_station_offline_config TO cerp_app/);
+  });
+});

--- a/src/__tests__/offline-station-queue.test.ts
+++ b/src/__tests__/offline-station-queue.test.ts
@@ -11,6 +11,7 @@ const mocks = vi.hoisted(() => ({
   reserve: vi.fn(),
   complete: vi.fn(),
   dependency: vi.fn(),
+  sourceSession: vi.fn(),
   canonicalExists: vi.fn(),
   purge: vi.fn(),
   audit: vi.fn(),
@@ -24,6 +25,7 @@ vi.mock("../module/production/repository/offline-station.repository", () => ({
   repoReserveOfflineEvent: mocks.reserve,
   repoCompleteOfflineEvent: mocks.complete,
   repoOfflineDependency: mocks.dependency,
+  repoOfflineSourceSession: mocks.sourceSession,
   repoCanonicalIdempotencyExists: mocks.canonicalExists,
   repoPurgeOfflineEvents: mocks.purge,
 }));
@@ -39,7 +41,9 @@ import { offlineStationSyncSchema } from "../module/production/validators/offlin
 
 const DEVICE = "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa";
 const SESSION = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb";
+const OLD_SESSION = "abababab-abab-4bab-8bab-abababababab";
 const MACHINE = "cccccccc-cccc-4ccc-8ccc-cccccccccccc";
+const OLD_MACHINE = "cdcdcdcd-cdcd-4dcd-8dcd-cdcdcdcdcdcd";
 const EVENT = "dddddddd-dddd-4ddd-8ddd-dddddddddddd";
 const STOP_EVENT = "12121212-1212-4121-8121-121212121212";
 const ENTITY = "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee";
@@ -86,6 +90,41 @@ function startBatch(overrides: Record<string, unknown> = {}) {
   });
 }
 
+function stopBatch(overrides: Record<string, unknown> = {}) {
+  return offlineStationSyncSchema.parse({
+    client_batch_id: BATCH,
+    events: [{
+      event_id: STOP_EVENT,
+      idempotency_key: "offline-stop-000001",
+      type: "POINTAGE_STOP",
+      occurred_at: new Date().toISOString(),
+      device_id: DEVICE,
+      user_id: 7,
+      station_session_id: SESSION,
+      machine_id: MACHINE,
+      payload: { pointage_id: null, start_event_id: EVENT },
+      ...overrides,
+    }],
+  });
+}
+
+function quantityBatch(payloadOverrides: Record<string, unknown> = {}) {
+  return offlineStationSyncSchema.parse({
+    client_batch_id: BATCH,
+    events: [{
+      event_id: STOP_EVENT,
+      idempotency_key: "offline-quantity-0001",
+      type: "QUANTITY_DECLARE",
+      occurred_at: new Date().toISOString(),
+      device_id: DEVICE,
+      user_id: 7,
+      station_session_id: SESSION,
+      machine_id: MACHINE,
+      payload: { of_id: 42, qty_good: 1, ...payloadOverrides },
+    }],
+  });
+}
+
 function processing(existing = false) {
   return {
     kind: "RESERVED" as const,
@@ -101,6 +140,24 @@ function processing(existing = false) {
   };
 }
 
+function syncedStartDependency(overrides: Record<string, unknown> = {}) {
+  return {
+    event_id: EVENT,
+    status: "SYNCED" as const,
+    result_payload: { server_entity_id: ENTITY },
+    error_code: null,
+    error_message: null,
+    server_entity_id: ENTITY,
+    client_batch_id: BATCH,
+    event_type: "POINTAGE_START" as const,
+    device_id: DEVICE,
+    operator_user_id: 7,
+    station_session_id: SESSION,
+    machine_id: MACHINE,
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   delete process.env.STATION_OFFLINE_SYNC_ENABLED;
@@ -108,6 +165,7 @@ beforeEach(() => {
   mocks.reserve.mockResolvedValue(processing());
   mocks.complete.mockResolvedValue(undefined);
   mocks.canonicalExists.mockResolvedValue(false);
+  mocks.sourceSession.mockResolvedValue(null);
   mocks.purge.mockResolvedValue(0);
   mocks.audit.mockResolvedValue(undefined);
   mocks.start.mockResolvedValue({ id: ENTITY });
@@ -188,18 +246,46 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
       ...processing(),
       outcome: { ...processing().outcome, event_id: event.event_id },
     }));
-    mocks.dependency.mockResolvedValue({
-      event_id: EVENT,
-      status: "SYNCED",
-      result_payload: { server_entity_id: ENTITY },
-      error_code: null,
-      error_message: null,
-      server_entity_id: ENTITY,
-    });
+    mocks.dependency.mockResolvedValue(syncedStartDependency());
     mocks.stop.mockResolvedValue({ id: ENTITY });
     const result = await svcSyncOfflineStation({ body, station, audit });
     expect(result.results.map((item) => item.status)).toEqual(["SYNCED", "SYNCED"]);
     expect(mocks.stop).toHaveBeenCalledWith(expect.objectContaining({ id: ENTITY }));
+  });
+
+  it.each([
+    ["type", { event_type: "QUANTITY_DECLARE" }, "OFFLINE_DEPENDENCY_TYPE_INVALID"],
+    ["lot", { client_batch_id: "10101010-1010-4010-8010-101010101010" }, "OFFLINE_DEPENDENCY_CONTEXT_CONFLICT"],
+    ["appareil", { device_id: "20202020-2020-4020-8020-202020202020" }, "OFFLINE_DEPENDENCY_CONTEXT_CONFLICT"],
+    ["opérateur", { operator_user_id: 8 }, "OFFLINE_DEPENDENCY_CONTEXT_CONFLICT"],
+    ["session", { station_session_id: OLD_SESSION }, "OFFLINE_DEPENDENCY_CONTEXT_CONFLICT"],
+    ["machine", { machine_id: OLD_MACHINE }, "OFFLINE_DEPENDENCY_CONTEXT_CONFLICT"],
+  ])("refuse un start_event_id dont le %s diffère", async (_label, dependencyOverride, code) => {
+    mocks.dependency.mockResolvedValue(syncedStartDependency(dependencyOverride));
+    const result = await svcSyncOfflineStation({ body: stopBatch(), station, audit });
+    expect(result.results[0]).toMatchObject({ status: "REJECTED", code });
+    expect(mocks.complete).toHaveBeenCalledWith(expect.objectContaining({ status: "REJECTED" }));
+    expect(mocks.stop).not.toHaveBeenCalled();
+  });
+
+  it("résout aussi start_event_id pour une déclaration de quantité", async () => {
+    mocks.dependency.mockResolvedValue(syncedStartDependency());
+    mocks.quantity.mockResolvedValue({ id: ENTITY });
+    const result = await svcSyncOfflineStation({
+      body: quantityBatch({ pointage_id: null, start_event_id: EVENT }),
+      station,
+      audit,
+    });
+    expect(result.results[0]).toMatchObject({ status: "SYNCED", server_entity_id: ENTITY });
+    expect(mocks.quantity).toHaveBeenCalledWith(expect.objectContaining({
+      body: expect.objectContaining({ pointage_id: ENTITY }),
+    }));
+    expect(mocks.quantity.mock.calls[0]?.[0].body).not.toHaveProperty("start_event_id");
+  });
+
+  it("autorise une quantité sans pointage mais jamais deux références", () => {
+    expect(quantityBatch({ pointage_id: null, start_event_id: null }).events[0]?.type).toBe("QUANTITY_DECLARE");
+    expect(() => quantityBatch({ pointage_id: ENTITY, start_event_id: EVENT })).toThrow();
   });
 
   it("reprend après un crash entre effet canonique et reçu sans nouvel effet logique", async () => {
@@ -210,6 +296,13 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
     const resumed = await svcSyncOfflineStation({ body: startBatch(), station, audit });
     expect(resumed.results[0]).toMatchObject({ status: "SYNCED", replayed: true });
     expect(mocks.start).toHaveBeenNthCalledWith(2, expect.objectContaining({ idempotencyKey: "offline-start-000001" }));
+    const firstClaim = mocks.reserve.mock.calls[0]?.[0].claimToken;
+    const resumedClaim = mocks.reserve.mock.calls[1]?.[0].claimToken;
+    expect(firstClaim).toEqual(expect.any(String));
+    expect(resumedClaim).toEqual(expect.any(String));
+    expect(resumedClaim).not.toBe(firstClaim);
+    expect(mocks.complete.mock.calls[0]?.[0].claimToken).toBe(firstClaim);
+    expect(mocks.complete.mock.calls[1]?.[0].claimToken).toBe(resumedClaim);
   });
 
   it("rend les conflits explicites et persistants", async () => {
@@ -231,21 +324,138 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
     expect(mocks.complete).not.toHaveBeenCalled();
   });
 
-  it("exige l'identité exacte après réauthentification", async () => {
-    const result = await svcSyncOfflineStation({ body: startBatch({ user_id: 8 }), station, audit });
-    expect(result.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_OPERATOR_CONFLICT" });
-    expect(mocks.reserve).not.toHaveBeenCalled();
+  it("réserve et fige un rejet d'identité avant tout effet canonique", async () => {
+    mocks.reserve
+      .mockResolvedValueOnce(processing())
+      .mockResolvedValueOnce({
+        kind: "RESERVED",
+        existing: true,
+        outcome: {
+          ...processing().outcome,
+          status: "REJECTED",
+          error_code: "OFFLINE_OPERATOR_CONFLICT",
+          error_message: "Identité refusée.",
+        },
+      });
+    const body = startBatch({ user_id: 8 });
+    const first = await svcSyncOfflineStation({ body, station, audit });
+    const retry = await svcSyncOfflineStation({ body, station, audit });
+    expect(first.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_OPERATOR_CONFLICT", replayed: false });
+    expect(retry.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_OPERATOR_CONFLICT", replayed: true });
+    expect(mocks.reserve).toHaveBeenCalledTimes(2);
+    expect(mocks.complete).toHaveBeenCalledTimes(1);
+    expect(mocks.complete).toHaveBeenCalledWith(expect.objectContaining({ status: "REJECTED", claimToken: expect.any(String) }));
     expect(mocks.start).not.toHaveBeenCalled();
+  });
+
+  it("reprend après réauthentification si la session source prouve le même opérateur et appareil", async () => {
+    const occurredAt = new Date();
+    mocks.sourceSession.mockResolvedValue({
+      id: OLD_SESSION,
+      device_id: DEVICE,
+      user_id: 7,
+      machine_id: OLD_MACHINE,
+      state: "CLOSED",
+      started_at: new Date(occurredAt.getTime() - 3_600_000).toISOString(),
+      closed_at: new Date(occurredAt.getTime() + 1_000).toISOString(),
+      expires_at: new Date(occurredAt.getTime() + 7_200_000).toISOString(),
+    });
+    const result = await svcSyncOfflineStation({
+      body: startBatch({
+        station_session_id: OLD_SESSION,
+        machine_id: OLD_MACHINE,
+        occurred_at: occurredAt.toISOString(),
+      }),
+      station,
+      audit,
+    });
+    expect(result.results[0]).toMatchObject({ status: "SYNCED", server_entity_id: ENTITY });
+    expect(mocks.sourceSession).toHaveBeenCalledWith(OLD_SESSION);
+    expect(mocks.start).toHaveBeenCalledWith(expect.objectContaining({
+      stationSessionId: SESSION,
+      body: expect.objectContaining({ machine_id: OLD_MACHINE }),
+    }));
+  });
+
+  it("fige le rejet si la session source ne correspond pas au contexte déclaré", async () => {
+    mocks.sourceSession.mockResolvedValue({
+      id: OLD_SESSION,
+      device_id: DEVICE,
+      user_id: 99,
+      machine_id: OLD_MACHINE,
+      state: "CLOSED",
+      started_at: new Date(Date.now() - 3_600_000).toISOString(),
+      closed_at: new Date().toISOString(),
+      expires_at: new Date(Date.now() + 3_600_000).toISOString(),
+    });
+    const result = await svcSyncOfflineStation({
+      body: startBatch({ station_session_id: OLD_SESSION, machine_id: OLD_MACHINE }),
+      station,
+      audit,
+    });
+    expect(result.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_SOURCE_SESSION_CONFLICT" });
+    expect(mocks.complete).toHaveBeenCalledWith(expect.objectContaining({ status: "REJECTED" }));
+    expect(mocks.start).not.toHaveBeenCalled();
+  });
+
+  it("refuse un événement hors de la fenêtre de sa session source", async () => {
+    const occurredAt = new Date();
+    mocks.sourceSession.mockResolvedValue({
+      id: OLD_SESSION,
+      device_id: DEVICE,
+      user_id: 7,
+      machine_id: OLD_MACHINE,
+      state: "CLOSED",
+      started_at: new Date(occurredAt.getTime() - 7_200_000).toISOString(),
+      closed_at: new Date(occurredAt.getTime() - 120_000).toISOString(),
+      expires_at: new Date(occurredAt.getTime() + 3_600_000).toISOString(),
+    });
+    const result = await svcSyncOfflineStation({
+      body: startBatch({
+        station_session_id: OLD_SESSION,
+        machine_id: OLD_MACHINE,
+        occurred_at: occurredAt.toISOString(),
+      }),
+      station,
+      audit,
+    });
+    expect(result.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_SOURCE_SESSION_TIME_CONFLICT" });
+    expect(mocks.complete).toHaveBeenCalledWith(expect.objectContaining({ status: "REJECTED" }));
   });
 
   it("rejette explicitement une horloge trop en avance ou un événement expiré", async () => {
     const future = new Date(Date.now() + 120_000).toISOString();
     const old = new Date(Date.now() - 25 * 3_600_000).toISOString();
-    const ahead = await svcSyncOfflineStation({ body: startBatch({ occurred_at: future }), station, audit });
-    const expired = await svcSyncOfflineStation({ body: startBatch({ occurred_at: old }), station, audit });
+    mocks.reserve
+      .mockResolvedValueOnce(processing())
+      .mockResolvedValueOnce({
+        kind: "RESERVED",
+        existing: true,
+        outcome: {
+          ...processing().outcome,
+          status: "REJECTED",
+          error_code: "OFFLINE_CLOCK_AHEAD",
+          error_message: "Horloge refusée.",
+        },
+      })
+      .mockResolvedValueOnce({
+        ...processing(),
+        outcome: { ...processing().outcome, event_id: STOP_EVENT },
+      });
+    const futureBody = startBatch({ occurred_at: future });
+    const ahead = await svcSyncOfflineStation({ body: futureBody, station, audit });
+    const aheadRetry = await svcSyncOfflineStation({ body: futureBody, station, audit });
+    const expired = await svcSyncOfflineStation({
+      body: startBatch({ occurred_at: old, event_id: STOP_EVENT, idempotency_key: "offline-start-expired-1" }),
+      station,
+      audit,
+    });
     expect(ahead.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_CLOCK_AHEAD" });
+    expect(aheadRetry.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_CLOCK_AHEAD", replayed: true });
     expect(expired.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_EVENT_EXPIRED" });
-    expect(mocks.reserve).not.toHaveBeenCalled();
+    expect(mocks.reserve).toHaveBeenCalledTimes(3);
+    expect(mocks.complete).toHaveBeenCalledTimes(2);
+    expect(mocks.start).not.toHaveBeenCalled();
   });
 
   it("le kill switch ne consomme aucun événement", async () => {
@@ -269,6 +479,10 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
 describe("GPT56-FEAT-CERP-0006 — migration et frontières", () => {
   const patchDir = path.join(repoRoot, "db", "patches");
   const migration = fs.readFileSync(path.join(patchDir, "20260805_station_offline_queue_0006.sql"), "utf8");
+  const repository = fs.readFileSync(
+    path.join(repoRoot, "src", "module", "production", "repository", "offline-station.repository.ts"),
+    "utf8"
+  );
 
   it("fournit migration, preflight, vérification et rollback test-only", () => {
     for (const suffix of ["preflight", "verify", "rollback"]) {
@@ -293,5 +507,23 @@ describe("GPT56-FEAT-CERP-0006 — migration et frontières", () => {
     expect(migration).toContain("fn_purge_production_station_offline_events");
     expect(migration).toContain("production_station_offline_config");
     expect(migration).toMatch(/GRANT SELECT ON TABLE public\.production_station_offline_config TO cerp_app/);
+  });
+
+  it("sépare les déclarations clientes de l'identité authentifiée persistée", () => {
+    expect(migration).toContain("authenticated_station_session_id uuid NOT NULL");
+    expect(migration).toContain("FOREIGN KEY (authenticated_device_id)");
+    expect(migration).toContain("FOREIGN KEY (authenticated_operator_user_id)");
+    expect(migration).not.toMatch(/FOREIGN KEY \(device_id\)/);
+    expect(migration).not.toMatch(/FOREIGN KEY \(operator_user_id\)/);
+    expect(migration).toContain("NEW.authenticated_station_session_id IS DISTINCT FROM OLD.authenticated_station_session_id");
+  });
+
+  it("fence chaque reprise et interdit à un ancien propriétaire de finaliser", () => {
+    expect(migration).toContain("processing_token uuid NOT NULL");
+    expect(migration).toContain("lease_expires_at timestamptz NOT NULL");
+    expect(repository).toContain("processing_token = $2::uuid");
+    expect(repository).toContain("lease_expires_at > clock_timestamp()");
+    expect(repository).toContain("processing_token = $8::uuid");
+    expect(repository).toContain("result.rowCount !== 1");
   });
 });

--- a/src/__tests__/offline-station-queue.test.ts
+++ b/src/__tests__/offline-station-queue.test.ts
@@ -376,13 +376,22 @@ describe("GPT56-FEAT-CERP-0006 — contrat borné", () => {
     expect(result.results[0]).toMatchObject({ status: "SYNCED", server_entity_id: ENTITY });
     expect(mocks.quantity).toHaveBeenCalledWith(expect.objectContaining({
       body: expect.objectContaining({ pointage_id: ENTITY }),
+      sourceContext: {
+        operatorUserId: 7,
+        machineId: MACHINE,
+        executionSessionId: expect.any(String),
+      },
     }));
     expect(mocks.quantity.mock.calls[0]?.[0].body).not.toHaveProperty("start_event_id");
   });
 
-  it("autorise une quantité sans pointage mais jamais deux références", () => {
-    expect(quantityBatch({ pointage_id: null, start_event_id: null }).events[0]?.type).toBe("QUANTITY_DECLARE");
+  it("refuse à l'exécution une quantité offline sans pointage et jamais deux références", async () => {
+    const withoutPointage = quantityBatch({ pointage_id: null, start_event_id: null });
+    expect(withoutPointage.events[0]?.type).toBe("QUANTITY_DECLARE");
     expect(() => quantityBatch({ pointage_id: ENTITY, start_event_id: EVENT })).toThrow();
+    const result = await svcSyncOfflineStation({ body: withoutPointage, station, audit });
+    expect(result.results[0]).toMatchObject({ status: "REJECTED", code: "OFFLINE_POINTAGE_REQUIRED" });
+    expect(mocks.quantity).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/__tests__/production-execution-274.routes.test.ts
+++ b/src/__tests__/production-execution-274.routes.test.ts
@@ -368,6 +368,146 @@ describe("#274 idempotence", () => {
 });
 
 /* -------------------------------------------------------------------------- */
+/* Intégrité transactionnelle des quantités                                  */
+/* -------------------------------------------------------------------------- */
+
+describe("#274 intégrité des quantités", () => {
+  const quantityRequest = (body: Record<string, unknown>, key = `${KEY}-quantity`) => request(app)
+    .post(`${BASE}/quantities`)
+    .set("x-test-role", OPERATOR)
+    .set("x-test-user-id", "7")
+    .set("Idempotency-Key", key)
+    .send(body);
+
+  function mockQuantityQueries(params: {
+    ofStatus?: string;
+    operationStatus?: string;
+    alreadyGood?: number;
+    pointageOwner?: number;
+  } = {}) {
+    let inserts = 0;
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_execution_idempotency")) return { rows: [] };
+      if (sql.includes("FROM public.ordres_fabrication") && sql.includes("FOR UPDATE")) {
+        return {
+          rows: [{
+            id: "10",
+            statut: params.ofStatus ?? "EN_COURS",
+            quantite_lancee: 10,
+          }],
+        };
+      }
+      if (sql.includes("FROM public.of_operations") && sql.includes("FOR UPDATE")) {
+        return {
+          rows: [{
+            id: OP_ID,
+            status: params.operationStatus ?? "RUNNING",
+            phase: 10,
+            of_id: "10",
+          }],
+        };
+      }
+      if (sql.includes("FROM public.production_pointages") && sql.includes("WHERE id = $1::uuid")) {
+        return { rows: [executionRow({ operator_user_id: params.pointageOwner ?? 7 })] };
+      }
+      if (sql.includes("FROM public.production_quantity_declarations")) {
+        return { rows: [{ qty_good: params.alreadyGood ?? 0, qty_scrap: 0 }] };
+      }
+      if (sql.includes("INSERT INTO public.production_quantity_declarations")) {
+        inserts += 1;
+        return { rows: [{ id: `44444444-4444-4444-8444-${String(inserts).padStart(12, "0")}` }] };
+      }
+      return { rows: [] };
+    });
+    return () => inserts;
+  }
+
+  it("refuse une quantité sur un OF clos", async () => {
+    const inserts = mockQuantityQueries({ ofStatus: "TERMINE" });
+    const res = await quantityRequest({ of_id: 10, qty_good: 1 });
+    expect(res.status).toBe(422);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_OF_NOT_EXECUTABLE");
+    expect(inserts()).toBe(0);
+  });
+
+  it("refuse une quantité sur une opération terminée", async () => {
+    const inserts = mockQuantityQueries({ operationStatus: "DONE" });
+    const res = await quantityRequest({ of_id: 10, operation_id: OP_ID, qty_good: 1 });
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe("OF_OPERATION_ALREADY_DONE");
+    expect(inserts()).toBe(0);
+  });
+
+  it("refuse la surproduction après relecture du cumul sous verrou", async () => {
+    const inserts = mockQuantityQueries({ alreadyGood: 9 });
+    const res = await quantityRequest({ of_id: 10, qty_good: 2 });
+    expect(res.status).toBe(422);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_QUANTITY_EXCEEDS_REMAINING");
+    expect(inserts()).toBe(0);
+  });
+
+  it("refuse un pointage appartenant à un autre opérateur", async () => {
+    const inserts = mockQuantityQueries({ pointageOwner: 99 });
+    const res = await quantityRequest({
+      of_id: 10,
+      operation_id: OP_ID,
+      pointage_id: POINTAGE_ID,
+      qty_good: 1,
+    });
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_QUANTITY_POINTAGE_OPERATOR_CONFLICT");
+    expect(inserts()).toBe(0);
+  });
+
+  it("sérialise deux déclarations concurrentes et refuse celle qui dépasse le restant", async () => {
+    let connectionCount = 0;
+    let committedGood = 0;
+    let insertCount = 0;
+    let releaseFirstLock!: () => void;
+    let firstLocked!: () => void;
+    const firstHasLock = new Promise<void>((resolve) => { firstLocked = resolve; });
+    const firstCommitted = new Promise<void>((resolve) => { releaseFirstLock = resolve; });
+
+    mocks.poolConnect.mockImplementation(() => {
+      const connectionId = ++connectionCount;
+      let pendingGood = 0;
+      const query = vi.fn(async (sql: string, values?: unknown[]) => {
+        if (sql.includes("FROM public.production_execution_idempotency")) return { rows: [] };
+        if (sql.includes("FROM public.ordres_fabrication") && sql.includes("FOR UPDATE")) {
+          if (connectionId === 1) firstLocked();
+          if (connectionId === 2) await firstCommitted;
+          return { rows: [{ id: "10", statut: "EN_COURS", quantite_lancee: 10 }] };
+        }
+        if (sql.includes("FROM public.production_quantity_declarations")) {
+          return { rows: [{ qty_good: committedGood, qty_scrap: 0 }] };
+        }
+        if (sql.includes("INSERT INTO public.production_quantity_declarations")) {
+          insertCount += 1;
+          pendingGood = Number(values?.[3] ?? 0);
+          return { rows: [{ id: "55555555-5555-4555-8555-555555555555" }] };
+        }
+        if (sql === "COMMIT" && connectionId === 1) {
+          committedGood += pendingGood;
+          releaseFirstLock();
+        }
+        return { rows: [] };
+      });
+      return Promise.resolve({ query, release: vi.fn() });
+    });
+
+    const first = quantityRequest({ of_id: 10, qty_good: 6 }, `${KEY}-concurrent-a`).then((res) => res);
+    await firstHasLock;
+    const second = quantityRequest({ of_id: 10, qty_good: 6 }, `${KEY}-concurrent-b`).then((res) => res);
+    const [firstRes, secondRes] = await Promise.all([first, second]);
+
+    expect(firstRes.status).toBe(201);
+    expect(secondRes.status).toBe(422);
+    expect(secondRes.body.code ?? secondRes.body.error?.code).toBe("PRODUCTION_QUANTITY_EXCEEDS_REMAINING");
+    expect(insertCount).toBe(1);
+  });
+});
+
+/* -------------------------------------------------------------------------- */
 /* Validation Zod et erreurs structurées                                      */
 /* -------------------------------------------------------------------------- */
 

--- a/src/__tests__/production-execution-274.routes.test.ts
+++ b/src/__tests__/production-execution-274.routes.test.ts
@@ -289,6 +289,7 @@ describe("#274 idempotence", () => {
                 )
                 .digest("hex"),
               response_body: { id: POINTAGE_ID },
+              user_id: 7,
             },
           ],
         };
@@ -320,7 +321,7 @@ describe("#274 idempotence", () => {
     mocks.clientQuery.mockImplementation((sql: string) => {
       if (sql.includes("FROM public.production_execution_idempotency")) {
         return {
-          rows: [{ request_fingerprint: "a".repeat(64), response_body: { id: POINTAGE_ID } }],
+          rows: [{ request_fingerprint: "a".repeat(64), response_body: { id: POINTAGE_ID }, user_id: 1 }],
         };
       }
       return { rows: [] };
@@ -334,6 +335,35 @@ describe("#274 idempotence", () => {
 
     expect(res.status).toBe(409);
     expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_IDEMPOTENCY_CONFLICT");
+  });
+
+  it.each([
+    ["STOP", `${BASE}/${POINTAGE_ID}/stop`, {}],
+    ["QUANTITY", `${BASE}/quantities`, { of_id: 10, qty_good: 1 }],
+  ])("ne rejoue jamais la réponse %s d'un autre opérateur", async (_kind, endpoint, body) => {
+    mocks.clientQuery.mockImplementation((sql: string) => {
+      if (sql.includes("FROM public.production_execution_idempotency")) {
+        return {
+          rows: [{
+            request_fingerprint: "a".repeat(64),
+            response_body: { id: POINTAGE_ID },
+            user_id: 99,
+          }],
+        };
+      }
+      return { rows: [] };
+    });
+
+    const res = await request(app)
+      .post(endpoint)
+      .set("x-test-role", OPERATOR)
+      .set("x-test-user-id", "7")
+      .set("Idempotency-Key", KEY)
+      .send(body);
+
+    expect(res.status).toBe(409);
+    expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_EXECUTION_IDEMPOTENCY_ACTOR_CONFLICT");
+    expect(mocks.clientQuery).not.toHaveBeenCalledWith("COMMIT");
   });
 });
 

--- a/src/__tests__/production-execution-274.routes.test.ts
+++ b/src/__tests__/production-execution-274.routes.test.ts
@@ -66,6 +66,7 @@ vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
 }));
 
 import app from "../config/app";
+import { repoDeclareQuantity } from "../module/production/repository/production-execution.repository";
 
 const BASE = "/api/v1/production/execution";
 const OP_ID = "11111111-1111-1111-1111-111111111111";
@@ -456,6 +457,62 @@ describe("#274 intégrité des quantités", () => {
     });
     expect(res.status).toBe(409);
     expect(res.body.code ?? res.body.error?.code).toBe("PRODUCTION_QUANTITY_POINTAGE_OPERATOR_CONFLICT");
+    expect(inserts()).toBe(0);
+  });
+
+  it("accepte un pointage serveur actif direct sans imposer une session offline absente", async () => {
+    const inserts = mockQuantityQueries();
+    const result = await repoDeclareQuantity({
+      body: { of_id: 10, operation_id: OP_ID, pointage_id: POINTAGE_ID, qty_good: 1 },
+      idempotencyKey: `${KEY}-direct-active`,
+      audit: {
+        user_id: 7,
+        user_role: OPERATOR,
+        ip: null,
+        user_agent: null,
+        device_type: "tablet",
+        os: null,
+        browser: null,
+        path: `${BASE}/quantities`,
+        page_key: "atelier-offline-sync",
+        client_session_id: null,
+      },
+      sourceContext: {
+        operatorUserId: 7,
+        machineId: MACHINE_ID,
+        executionSessionId: null,
+      },
+    });
+    expect(result.id).toEqual(expect.any(String));
+    expect(inserts()).toBe(1);
+  });
+
+  it("refuse toujours une session de START résolue qui ne correspond pas au pointage", async () => {
+    const inserts = mockQuantityQueries();
+    await expect(repoDeclareQuantity({
+      body: { of_id: 10, operation_id: OP_ID, pointage_id: POINTAGE_ID, qty_good: 1 },
+      idempotencyKey: `${KEY}-resolved-start-mismatch`,
+      audit: {
+        user_id: 7,
+        user_role: OPERATOR,
+        ip: null,
+        user_agent: null,
+        device_type: "tablet",
+        os: null,
+        browser: null,
+        path: `${BASE}/quantities`,
+        page_key: "atelier-offline-sync",
+        client_session_id: null,
+      },
+      sourceContext: {
+        operatorUserId: 7,
+        machineId: MACHINE_ID,
+        executionSessionId: "66666666-6666-4666-8666-666666666666",
+      },
+    })).rejects.toMatchObject({
+      status: 409,
+      code: "OFFLINE_QUANTITY_POINTAGE_SESSION_CONFLICT",
+    });
     expect(inserts()).toBe(0);
   });
 

--- a/src/module/production/controllers/offline-station.controller.ts
+++ b/src/module/production/controllers/offline-station.controller.ts
@@ -1,0 +1,31 @@
+import type { Request, Response } from "express";
+
+import { asyncHandler } from "../../../utils/asyncHandler";
+import { HttpError } from "../../../utils/httpError";
+import { getClientIp, parseDevice } from "../../../utils/requestMeta";
+import type { AuditContext } from "../repository/production.repository";
+import { svcSyncOfflineStation } from "../services/offline-station.service";
+import { offlineStationSyncSchema } from "../validators/offline-station.validators";
+
+export const syncOfflineStation = asyncHandler(async (req: Request, res: Response) => {
+  if (!req.station) {
+    throw new HttpError(401, "STATION_SESSION_REQUIRED", "Réauthentification de la station requise.");
+  }
+  const body = offlineStationSyncSchema.parse(req.body);
+  const userAgent = typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null;
+  const device = parseDevice(userAgent);
+  const audit: AuditContext = {
+    user_id: req.station.user.id,
+    user_role: req.station.user.role,
+    ip: getClientIp(req),
+    user_agent: userAgent,
+    device_type: device.device_type,
+    os: device.os,
+    browser: device.browser,
+    path: req.originalUrl ?? null,
+    page_key: "atelier-offline-sync",
+    client_session_id: req.station.session_id,
+  };
+  const result = await svcSyncOfflineStation({ body, station: req.station, audit });
+  res.status(result.kill_switch_enabled ? 503 : 200).json(result);
+});

--- a/src/module/production/domain/station.ts
+++ b/src/module/production/domain/station.ts
@@ -1011,6 +1011,8 @@ export const STATION_AUDIT_EVENTS = [
   "DOSSIER_OPENED",
   "PLAN_OPENED",
   "HEARTBEAT",
+  "OFFLINE_EVENT_SYNCED",
+  "OFFLINE_EVENT_REJECTED",
 ] as const;
 
 export type StationAuditEventType = (typeof STATION_AUDIT_EVENTS)[number];

--- a/src/module/production/repository/offline-station.repository.ts
+++ b/src/module/production/repository/offline-station.repository.ts
@@ -1,4 +1,7 @@
+import type { PoolClient } from "pg";
+
 import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
 
 import type { OfflineStationEventDTO } from "../validators/offline-station.validators";
 
@@ -9,7 +12,10 @@ export type OfflineStoredOutcome = {
   error_code: string | null;
   error_message: string | null;
   server_entity_id: string | null;
+  execution_session_id: string | null;
 };
+
+type DbQueryer = Pick<PoolClient, "query">;
 
 export type OfflineDependency = OfflineStoredOutcome & {
   client_batch_id: string;
@@ -44,14 +50,15 @@ export async function repoOfflineSyncEnabled(): Promise<boolean> {
 }
 
 /**
- * Reserve before applying the canonical command. A crash after reservation is
- * recoverable: the canonical execution idempotency key is replayed on retry.
+ * Reserve the transport claim. The canonical transaction locks this receipt
+ * again before any effect and finalizes it in the same commit.
  */
 export async function repoReserveOfflineEvent(params: {
   batchId: string;
   event: OfflineStationEventDTO;
   requestHash: string;
   clockDriftSeconds: number;
+  executionSessionId: string | null;
   claimToken: string;
   authenticatedDeviceId: string;
   authenticatedOperatorUserId: number;
@@ -62,16 +69,17 @@ export async function repoReserveOfflineEvent(params: {
   try {
     await client.query("BEGIN");
     const inserted = await client.query(
-       `INSERT INTO public.production_station_offline_events (
+      `INSERT INTO public.production_station_offline_events (
          event_id, idempotency_key, request_hash, client_batch_id, event_type,
          occurred_at, device_id, operator_user_id, station_session_id, machine_id,
+         execution_session_id,
          authenticated_device_id, authenticated_operator_user_id,
          authenticated_station_session_id, authenticated_machine_id,
          payload, clock_drift_seconds, status, attempt_count, last_attempt_at,
          processing_token, lease_expires_at
        ) VALUES (
-         $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,
-         $15::jsonb,$16,'PROCESSING',1,clock_timestamp(),$17,clock_timestamp() + interval '2 minutes'
+         $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,
+         $16::jsonb,$17,'PROCESSING',1,clock_timestamp(),$18,clock_timestamp() + interval '2 minutes'
        )
        ON CONFLICT DO NOTHING
        RETURNING event_id`,
@@ -86,6 +94,7 @@ export async function repoReserveOfflineEvent(params: {
         params.event.user_id,
         params.event.station_session_id,
         params.event.machine_id,
+        params.executionSessionId,
         params.authenticatedDeviceId,
         params.authenticatedOperatorUserId,
         params.authenticatedStationSessionId,
@@ -100,10 +109,14 @@ export async function repoReserveOfflineEvent(params: {
       idempotency_key: string;
       request_hash: string;
       client_batch_id: string;
+      authenticated_device_id: string;
+      authenticated_operator_user_id: number;
       lease_active: boolean;
     }>(
       `SELECT event_id::text, idempotency_key, request_hash, client_batch_id::text, status,
               result_payload, error_code, error_message, server_entity_id::text,
+              execution_session_id::text, authenticated_device_id::text,
+              authenticated_operator_user_id,
               (status = 'PROCESSING' AND lease_expires_at > clock_timestamp()) AS lease_active
          FROM public.production_station_offline_events
         WHERE event_id = $1::uuid OR idempotency_key = $2
@@ -115,6 +128,9 @@ export async function repoReserveOfflineEvent(params: {
       && found.rows[0]?.event_id === params.event.event_id
       && found.rows[0]?.idempotency_key === params.event.idempotency_key
       && found.rows[0]?.client_batch_id === params.batchId
+      && found.rows[0]?.execution_session_id === params.executionSessionId
+      && found.rows[0]?.authenticated_device_id === params.authenticatedDeviceId
+      && found.rows[0]?.authenticated_operator_user_id === params.authenticatedOperatorUserId
       && found.rows[0]?.request_hash === params.requestHash;
     if (!exact) {
       await client.query("COMMIT");
@@ -156,8 +172,8 @@ export async function repoCompleteOfflineEvent(params: {
   resultPayload?: Record<string, unknown> | null;
   errorCode?: string | null;
   errorMessage?: string | null;
-}): Promise<void> {
-  const result = await pool.query(
+}, tx?: DbQueryer): Promise<void> {
+  const result = await (tx ?? pool).query(
     `UPDATE public.production_station_offline_events
         SET status = $3,
             server_entity_id = $4::uuid,
@@ -186,10 +202,59 @@ export async function repoCompleteOfflineEvent(params: {
   }
 }
 
+export async function repoAssertOfflineEventClaim(
+  tx: DbQueryer,
+  params: { eventId: string; requestHash: string; claimToken: string }
+): Promise<void> {
+  const result = await tx.query(
+    `SELECT event_id
+       FROM public.production_station_offline_events
+      WHERE event_id = $1::uuid
+        AND request_hash = $2
+        AND processing_token = $3::uuid
+        AND status = 'PROCESSING'
+        AND lease_expires_at > clock_timestamp()
+      FOR UPDATE`,
+    [params.eventId, params.requestHash, params.claimToken]
+  );
+  if (result.rowCount !== 1) {
+    throw new HttpError(
+      503,
+      "OFFLINE_EVENT_CLAIM_LOST",
+      "Le bail de synchronisation a expiré; réessayez le même événement sans le modifier."
+    );
+  }
+}
+
+export async function repoReleaseOfflineEventClaim(params: {
+  eventId: string;
+  requestHash: string;
+  claimToken: string;
+}): Promise<void> {
+  const result = await pool.query(
+    `UPDATE public.production_station_offline_events
+        SET lease_expires_at = GREATEST(received_at + interval '1 microsecond', clock_timestamp()),
+            last_attempt_at = clock_timestamp()
+      WHERE event_id = $1::uuid
+        AND request_hash = $2
+        AND processing_token = $3::uuid
+        AND status = 'PROCESSING'`,
+    [params.eventId, params.requestHash, params.claimToken]
+  );
+  if (result.rowCount !== 1) {
+    throw new HttpError(
+      503,
+      "OFFLINE_EVENT_CLAIM_LOST",
+      "Le bail de synchronisation a été repris; réessayez le même événement sans le modifier."
+    );
+  }
+}
+
 export async function repoOfflineDependency(eventId: string): Promise<OfflineDependency | null> {
   const { rows } = await pool.query<OfflineDependency>(
     `SELECT event_id::text, status, result_payload, error_code, error_message,
-            server_entity_id::text, client_batch_id::text, event_type,
+            server_entity_id::text, execution_session_id::text,
+            client_batch_id::text, event_type,
             device_id::text, operator_user_id, station_session_id::text,
             machine_id::text
        FROM public.production_station_offline_events

--- a/src/module/production/repository/offline-station.repository.ts
+++ b/src/module/production/repository/offline-station.repository.ts
@@ -11,6 +11,26 @@ export type OfflineStoredOutcome = {
   server_entity_id: string | null;
 };
 
+export type OfflineDependency = OfflineStoredOutcome & {
+  client_batch_id: string;
+  event_type: OfflineStationEventDTO["type"];
+  device_id: string;
+  operator_user_id: number;
+  station_session_id: string;
+  machine_id: string | null;
+};
+
+export type OfflineSourceSession = {
+  id: string;
+  device_id: string;
+  user_id: number;
+  machine_id: string | null;
+  state: "ACTIVE" | "LOCKED" | "CLOSED" | "EXPIRED" | "REVOKED";
+  started_at: string;
+  closed_at: string | null;
+  expires_at: string;
+};
+
 export type OfflineReservation =
   | { kind: "CONFLICT" }
   | { kind: "BUSY" }
@@ -32,16 +52,27 @@ export async function repoReserveOfflineEvent(params: {
   event: OfflineStationEventDTO;
   requestHash: string;
   clockDriftSeconds: number;
+  claimToken: string;
+  authenticatedDeviceId: string;
+  authenticatedOperatorUserId: number;
+  authenticatedStationSessionId: string;
+  authenticatedMachineId: string | null;
 }): Promise<OfflineReservation> {
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
     const inserted = await client.query(
-      `INSERT INTO public.production_station_offline_events (
+       `INSERT INTO public.production_station_offline_events (
          event_id, idempotency_key, request_hash, client_batch_id, event_type,
          occurred_at, device_id, operator_user_id, station_session_id, machine_id,
-         payload, clock_drift_seconds, status, attempt_count, last_attempt_at
-       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb,$12,'PROCESSING',1,now())
+         authenticated_device_id, authenticated_operator_user_id,
+         authenticated_station_session_id, authenticated_machine_id,
+         payload, clock_drift_seconds, status, attempt_count, last_attempt_at,
+         processing_token, lease_expires_at
+       ) VALUES (
+         $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,
+         $15::jsonb,$16,'PROCESSING',1,clock_timestamp(),$17,clock_timestamp() + interval '2 minutes'
+       )
        ON CONFLICT DO NOTHING
        RETURNING event_id`,
       [
@@ -55,19 +86,25 @@ export async function repoReserveOfflineEvent(params: {
         params.event.user_id,
         params.event.station_session_id,
         params.event.machine_id,
+        params.authenticatedDeviceId,
+        params.authenticatedOperatorUserId,
+        params.authenticatedStationSessionId,
+        params.authenticatedMachineId,
         JSON.stringify(params.event.payload),
         params.clockDriftSeconds,
+        params.claimToken,
       ]
     );
 
     const found = await client.query<OfflineStoredOutcome & {
       idempotency_key: string;
       request_hash: string;
+      client_batch_id: string;
       lease_active: boolean;
     }>(
-      `SELECT event_id::text, idempotency_key, request_hash, status,
+      `SELECT event_id::text, idempotency_key, request_hash, client_batch_id::text, status,
               result_payload, error_code, error_message, server_entity_id::text,
-              (status = 'PROCESSING' AND last_attempt_at > now() - interval '2 minutes') AS lease_active
+              (status = 'PROCESSING' AND lease_expires_at > clock_timestamp()) AS lease_active
          FROM public.production_station_offline_events
         WHERE event_id = $1::uuid OR idempotency_key = $2
         FOR UPDATE`,
@@ -77,6 +114,7 @@ export async function repoReserveOfflineEvent(params: {
     const exact = found.rows.length === 1
       && found.rows[0]?.event_id === params.event.event_id
       && found.rows[0]?.idempotency_key === params.event.idempotency_key
+      && found.rows[0]?.client_batch_id === params.batchId
       && found.rows[0]?.request_hash === params.requestHash;
     if (!exact) {
       await client.query("COMMIT");
@@ -91,9 +129,12 @@ export async function repoReserveOfflineEvent(params: {
       }
       await client.query(
         `UPDATE public.production_station_offline_events
-            SET attempt_count = attempt_count + 1, last_attempt_at = now()
-          WHERE event_id = $1::uuid`,
-        [params.event.event_id]
+            SET attempt_count = attempt_count + 1,
+                last_attempt_at = clock_timestamp(),
+                processing_token = $2::uuid,
+                lease_expires_at = clock_timestamp() + interval '2 minutes'
+          WHERE event_id = $1::uuid AND status = 'PROCESSING'`,
+        [params.event.event_id, params.claimToken]
       );
     }
     await client.query("COMMIT");
@@ -109,6 +150,7 @@ export async function repoReserveOfflineEvent(params: {
 export async function repoCompleteOfflineEvent(params: {
   eventId: string;
   requestHash: string;
+  claimToken: string;
   status: "SYNCED" | "REJECTED";
   serverEntityId?: string | null;
   resultPayload?: Record<string, unknown> | null;
@@ -124,7 +166,10 @@ export async function repoCompleteOfflineEvent(params: {
             error_message = $7,
             processed_at = now(),
             last_attempt_at = now()
-      WHERE event_id = $1::uuid AND request_hash = $2 AND status = 'PROCESSING'`,
+      WHERE event_id = $1::uuid
+        AND request_hash = $2
+        AND processing_token = $8::uuid
+        AND status = 'PROCESSING'`,
     [
       params.eventId,
       params.requestHash,
@@ -133,6 +178,7 @@ export async function repoCompleteOfflineEvent(params: {
       JSON.stringify(params.resultPayload ?? null),
       params.errorCode ?? null,
       params.errorMessage ?? null,
+      params.claimToken,
     ]
   );
   if (result.rowCount !== 1) {
@@ -140,13 +186,26 @@ export async function repoCompleteOfflineEvent(params: {
   }
 }
 
-export async function repoOfflineDependency(eventId: string): Promise<OfflineStoredOutcome | null> {
-  const { rows } = await pool.query<OfflineStoredOutcome>(
+export async function repoOfflineDependency(eventId: string): Promise<OfflineDependency | null> {
+  const { rows } = await pool.query<OfflineDependency>(
     `SELECT event_id::text, status, result_payload, error_code, error_message,
-            server_entity_id::text
+            server_entity_id::text, client_batch_id::text, event_type,
+            device_id::text, operator_user_id, station_session_id::text,
+            machine_id::text
        FROM public.production_station_offline_events
       WHERE event_id = $1::uuid`,
     [eventId]
+  );
+  return rows[0] ?? null;
+}
+
+export async function repoOfflineSourceSession(sessionId: string): Promise<OfflineSourceSession | null> {
+  const { rows } = await pool.query<OfflineSourceSession>(
+    `SELECT id::text, device_id::text, user_id, machine_id::text, state,
+            started_at::text, closed_at::text, expires_at::text
+       FROM public.operator_device_sessions
+      WHERE id = $1::uuid`,
+    [sessionId]
   );
   return rows[0] ?? null;
 }

--- a/src/module/production/repository/offline-station.repository.ts
+++ b/src/module/production/repository/offline-station.repository.ts
@@ -1,0 +1,170 @@
+import pool from "../../../config/database";
+
+import type { OfflineStationEventDTO } from "../validators/offline-station.validators";
+
+export type OfflineStoredOutcome = {
+  event_id: string;
+  status: "PROCESSING" | "SYNCED" | "REJECTED";
+  result_payload: Record<string, unknown> | null;
+  error_code: string | null;
+  error_message: string | null;
+  server_entity_id: string | null;
+};
+
+export type OfflineReservation =
+  | { kind: "CONFLICT" }
+  | { kind: "BUSY" }
+  | { kind: "RESERVED"; existing: boolean; outcome: OfflineStoredOutcome };
+
+export async function repoOfflineSyncEnabled(): Promise<boolean> {
+  const { rows } = await pool.query<{ enabled: boolean }>(
+    `SELECT enabled FROM public.production_station_offline_config WHERE singleton = true`
+  );
+  return rows[0]?.enabled === true;
+}
+
+/**
+ * Reserve before applying the canonical command. A crash after reservation is
+ * recoverable: the canonical execution idempotency key is replayed on retry.
+ */
+export async function repoReserveOfflineEvent(params: {
+  batchId: string;
+  event: OfflineStationEventDTO;
+  requestHash: string;
+  clockDriftSeconds: number;
+}): Promise<OfflineReservation> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const inserted = await client.query(
+      `INSERT INTO public.production_station_offline_events (
+         event_id, idempotency_key, request_hash, client_batch_id, event_type,
+         occurred_at, device_id, operator_user_id, station_session_id, machine_id,
+         payload, clock_drift_seconds, status, attempt_count, last_attempt_at
+       ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb,$12,'PROCESSING',1,now())
+       ON CONFLICT DO NOTHING
+       RETURNING event_id`,
+      [
+        params.event.event_id,
+        params.event.idempotency_key,
+        params.requestHash,
+        params.batchId,
+        params.event.type,
+        params.event.occurred_at,
+        params.event.device_id,
+        params.event.user_id,
+        params.event.station_session_id,
+        params.event.machine_id,
+        JSON.stringify(params.event.payload),
+        params.clockDriftSeconds,
+      ]
+    );
+
+    const found = await client.query<OfflineStoredOutcome & {
+      idempotency_key: string;
+      request_hash: string;
+      lease_active: boolean;
+    }>(
+      `SELECT event_id::text, idempotency_key, request_hash, status,
+              result_payload, error_code, error_message, server_entity_id::text,
+              (status = 'PROCESSING' AND last_attempt_at > now() - interval '2 minutes') AS lease_active
+         FROM public.production_station_offline_events
+        WHERE event_id = $1::uuid OR idempotency_key = $2
+        FOR UPDATE`,
+      [params.event.event_id, params.event.idempotency_key]
+    );
+
+    const exact = found.rows.length === 1
+      && found.rows[0]?.event_id === params.event.event_id
+      && found.rows[0]?.idempotency_key === params.event.idempotency_key
+      && found.rows[0]?.request_hash === params.requestHash;
+    if (!exact) {
+      await client.query("COMMIT");
+      return { kind: "CONFLICT" };
+    }
+
+    const outcome = found.rows[0]!;
+    if (inserted.rowCount === 0 && outcome.status === "PROCESSING") {
+      if (outcome.lease_active) {
+        await client.query("COMMIT");
+        return { kind: "BUSY" };
+      }
+      await client.query(
+        `UPDATE public.production_station_offline_events
+            SET attempt_count = attempt_count + 1, last_attempt_at = now()
+          WHERE event_id = $1::uuid`,
+        [params.event.event_id]
+      );
+    }
+    await client.query("COMMIT");
+    return { kind: "RESERVED", existing: inserted.rowCount === 0, outcome };
+  } catch (error) {
+    await client.query("ROLLBACK").catch(() => undefined);
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoCompleteOfflineEvent(params: {
+  eventId: string;
+  requestHash: string;
+  status: "SYNCED" | "REJECTED";
+  serverEntityId?: string | null;
+  resultPayload?: Record<string, unknown> | null;
+  errorCode?: string | null;
+  errorMessage?: string | null;
+}): Promise<void> {
+  const result = await pool.query(
+    `UPDATE public.production_station_offline_events
+        SET status = $3,
+            server_entity_id = $4::uuid,
+            result_payload = $5::jsonb,
+            error_code = $6,
+            error_message = $7,
+            processed_at = now(),
+            last_attempt_at = now()
+      WHERE event_id = $1::uuid AND request_hash = $2 AND status = 'PROCESSING'`,
+    [
+      params.eventId,
+      params.requestHash,
+      params.status,
+      params.serverEntityId ?? null,
+      JSON.stringify(params.resultPayload ?? null),
+      params.errorCode ?? null,
+      params.errorMessage ?? null,
+    ]
+  );
+  if (result.rowCount !== 1) {
+    throw new Error(`Offline receipt ${params.eventId} could not be finalized`);
+  }
+}
+
+export async function repoOfflineDependency(eventId: string): Promise<OfflineStoredOutcome | null> {
+  const { rows } = await pool.query<OfflineStoredOutcome>(
+    `SELECT event_id::text, status, result_payload, error_code, error_message,
+            server_entity_id::text
+       FROM public.production_station_offline_events
+      WHERE event_id = $1::uuid`,
+    [eventId]
+  );
+  return rows[0] ?? null;
+}
+
+export async function repoCanonicalIdempotencyExists(idempotencyKey: string): Promise<boolean> {
+  const { rows } = await pool.query<{ present: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM public.production_execution_idempotency WHERE idempotency_key = $1
+     ) AS present`,
+    [idempotencyKey]
+  );
+  return rows[0]?.present === true;
+}
+
+export async function repoPurgeOfflineEvents(retentionDays: number): Promise<number> {
+  const { rows } = await pool.query<{ purged: string | number }>(
+    `SELECT public.fn_purge_production_station_offline_events($1::integer) AS purged`,
+    [retentionDays]
+  );
+  return Number(rows[0]?.purged ?? 0);
+}

--- a/src/module/production/repository/production-execution.repository.ts
+++ b/src/module/production/repository/production-execution.repository.ts
@@ -54,6 +54,11 @@ import type {
 
 type DbQueryer = Pick<PoolClient, "query">;
 
+export type ProductionExecutionTransactionHooks<T extends { id: string }> = {
+  beforeEffect: (tx: PoolClient) => Promise<void>;
+  beforeCommit: (tx: PoolClient, result: T) => Promise<void>;
+};
+
 /* -------------------------------------------------------------------------- */
 /* Utilitaires                                                                */
 /* -------------------------------------------------------------------------- */
@@ -985,10 +990,12 @@ export async function repoStartExecution(params: {
   previousSegmentId?: string | null;
   segmentIndex?: number;
   source?: string;
+  transactionHooks?: ProductionExecutionTransactionHooks<{ id: string }>;
 }): Promise<ExecutionListItem> {
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
+    await params.transactionHooks?.beforeEffect(client);
 
     const replay = await reserveIdempotencyKey<{ id: string }>(client, {
       key: params.idempotencyKey,
@@ -997,6 +1004,7 @@ export async function repoStartExecution(params: {
       user_id: params.audit.user_id,
     });
     if (replay.replayed) {
+      await params.transactionHooks?.beforeCommit(client, replay.body);
       await client.query("COMMIT");
       const existing = await repoGetExecution({ id: replay.body.id });
       if (!existing) throw new HttpError(409, "PRODUCTION_EXECUTION_REPLAY_LOST", "Rejeu impossible.");
@@ -1161,6 +1169,7 @@ export async function repoStartExecution(params: {
     });
 
     await storeIdempotentResponse(client, params.idempotencyKey, { id });
+    await params.transactionHooks?.beforeCommit(client, { id });
     await client.query("COMMIT");
 
     const created = await repoGetExecution({ id });
@@ -1190,10 +1199,12 @@ export async function repoStopExecution(params: {
   actorRole: string | null | undefined;
   audit: AuditContext;
   eventType?: ExecutionEventType;
+  transactionHooks?: ProductionExecutionTransactionHooks<{ id: string }>;
 }): Promise<ExecutionListItem> {
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
+    await params.transactionHooks?.beforeEffect(client);
 
     const replay = await reserveIdempotencyKey<{ id: string }>(client, {
       key: params.idempotencyKey,
@@ -1202,6 +1213,7 @@ export async function repoStopExecution(params: {
       user_id: params.audit.user_id,
     });
     if (replay.replayed) {
+      await params.transactionHooks?.beforeCommit(client, replay.body);
       await client.query("COMMIT");
       const existing = await repoGetExecution({ id: params.id });
       if (!existing) throw new HttpError(409, "PRODUCTION_EXECUTION_REPLAY_LOST", "Rejeu impossible.");
@@ -1289,6 +1301,7 @@ export async function repoStopExecution(params: {
     });
 
     await storeIdempotentResponse(client, params.idempotencyKey, { id: params.id });
+    await params.transactionHooks?.beforeCommit(client, { id: params.id });
     await client.query("COMMIT");
 
     const updated = await repoGetExecution({ id: params.id });
@@ -1962,10 +1975,12 @@ export async function repoDeclareQuantity(params: {
   body: DeclareQuantityBodyDTO;
   idempotencyKey: string;
   audit: AuditContext;
+  transactionHooks?: ProductionExecutionTransactionHooks<{ id: string }>;
 }): Promise<{ id: string }> {
   const client = await pool.connect();
   try {
     await client.query("BEGIN");
+    await params.transactionHooks?.beforeEffect(client);
 
     const replay = await reserveIdempotencyKey<{ id: string }>(client, {
       key: params.idempotencyKey,
@@ -1974,6 +1989,7 @@ export async function repoDeclareQuantity(params: {
       user_id: params.audit.user_id,
     });
     if (replay.replayed) {
+      await params.transactionHooks?.beforeCommit(client, replay.body);
       await client.query("COMMIT");
       return replay.body;
     }
@@ -2056,6 +2072,7 @@ export async function repoDeclareQuantity(params: {
     });
 
     await storeIdempotentResponse(client, params.idempotencyKey, { id });
+    await params.transactionHooks?.beforeCommit(client, { id });
     await client.query("COMMIT");
     return { id };
   } catch (err) {

--- a/src/module/production/repository/production-execution.repository.ts
+++ b/src/module/production/repository/production-execution.repository.ts
@@ -2094,7 +2094,14 @@ export async function repoDeclareQuantity(params: {
             "Le pointage ne correspond pas à la machine de la capture hors ligne."
           );
         }
-        if ((pointage.session_id ?? null) !== params.sourceContext.executionSessionId) {
+        // Un pointage direct déjà actif n'a pas de start_event_id dans la file :
+        // `executionSessionId` vaut alors null et ne doit pas imposer que la
+        // session serveur le soit aussi. Lorsqu'un START offline a été résolu,
+        // son identifiant déterministe reste en revanche obligatoire.
+        if (
+          params.sourceContext.executionSessionId !== null
+          && (pointage.session_id ?? null) !== params.sourceContext.executionSessionId
+        ) {
           throw new HttpError(
             409,
             "OFFLINE_QUANTITY_POINTAGE_SESSION_CONFLICT",

--- a/src/module/production/repository/production-execution.repository.ts
+++ b/src/module/production/repository/production-execution.repository.ts
@@ -59,6 +59,13 @@ export type ProductionExecutionTransactionHooks<T extends { id: string }> = {
   beforeCommit: (tx: PoolClient, result: T) => Promise<void>;
 };
 
+/** Contexte fiable ajouté par la reprise offline, jamais lu dans le payload client. */
+export type ProductionQuantitySourceContext = {
+  operatorUserId: number;
+  machineId: string | null;
+  executionSessionId: string | null;
+};
+
 /* -------------------------------------------------------------------------- */
 /* Utilitaires                                                                */
 /* -------------------------------------------------------------------------- */
@@ -880,8 +887,9 @@ async function lockExecutionContext(
   tx: DbQueryer,
   params: { of_id: number; operation_id?: string | null; operator_user_id: number; machine_id?: string | null }
 ) {
-  const ofRes = await tx.query<{ id: string; statut: string }>(
-    `SELECT id::text AS id, statut::text AS statut FROM public.ordres_fabrication WHERE id = $1::bigint FOR UPDATE`,
+  const ofRes = await tx.query<{ id: string; statut: string; quantite_lancee: number }>(
+    `SELECT id::text AS id, statut::text AS statut, quantite_lancee::float8 AS quantite_lancee
+       FROM public.ordres_fabrication WHERE id = $1::bigint FOR UPDATE`,
     [params.of_id]
   );
   const of = ofRes.rows[0];
@@ -1983,6 +1991,7 @@ export async function repoDeclareQuantity(params: {
   body: DeclareQuantityBodyDTO;
   idempotencyKey: string;
   audit: AuditContext;
+  sourceContext?: ProductionQuantitySourceContext;
   transactionHooks?: ProductionExecutionTransactionHooks<{ id: string }>;
 }): Promise<{ id: string }> {
   const client = await pool.connect();
@@ -1993,7 +2002,9 @@ export async function repoDeclareQuantity(params: {
     const replay = await reserveIdempotencyKey<{ id: string }>(client, {
       key: params.idempotencyKey,
       scope: "production.execution.declare-quantity",
-      payload: params.body,
+      payload: params.sourceContext
+        ? { ...params.body, source_context: params.sourceContext }
+        : params.body,
       user_id: params.audit.user_id,
     });
     if (replay.replayed) {
@@ -2002,11 +2013,96 @@ export async function repoDeclareQuantity(params: {
       return replay.body;
     }
 
-    await lockExecutionContext(client, {
+    if (params.sourceContext && !params.body.pointage_id) {
+      throw new HttpError(
+        409,
+        "OFFLINE_POINTAGE_REQUIRED",
+        "Une quantité hors ligne doit référencer son pointage de production."
+      );
+    }
+
+    // Si l'opération n'est pas répétée dans le payload, le pointage fournit un
+    // indice non verrouillé. La valeur définitive est relue sous verrou après
+    // l'ordre global OF → opération → pointage, afin d'éviter les deadlocks.
+    let operationId = params.body.operation_id ?? null;
+    if (params.body.pointage_id && !operationId) {
+      const hint = await client.query<{ operation_id: string | null }>(
+        `SELECT operation_id::text AS operation_id
+           FROM public.production_pointages
+          WHERE id = $1::uuid`,
+        [params.body.pointage_id]
+      );
+      if (!hint.rows[0]) {
+        throw new HttpError(404, "PRODUCTION_EXECUTION_NOT_FOUND", "Pointage introuvable.", {
+          id: params.body.pointage_id,
+        });
+      }
+      operationId = hint.rows[0].operation_id;
+    }
+
+    const { of, operation } = await lockExecutionContext(client, {
       of_id: params.body.of_id,
-      operation_id: params.body.operation_id ?? null,
+      operation_id: operationId,
       operator_user_id: params.audit.user_id,
     });
+    assertOfExecutable(of.statut);
+    assertOperationExecutable(operation);
+
+    let pointage: LockedPointage | null = null;
+    if (params.body.pointage_id) {
+      pointage = await lockPointage(client, params.body.pointage_id);
+      if (pointage.operator_user_id !== params.audit.user_id) {
+        throw new HttpError(
+          409,
+          "PRODUCTION_QUANTITY_POINTAGE_OPERATOR_CONFLICT",
+          "Ce pointage appartient à un autre opérateur."
+        );
+      }
+      if (Number(pointage.of_id) !== Number(params.body.of_id)) {
+        throw new HttpError(
+          422,
+          "PRODUCTION_QUANTITY_POINTAGE_OF_CONFLICT",
+          "Le pointage ne concerne pas l'ordre de fabrication indiqué."
+        );
+      }
+      if ((pointage.operation_id ?? null) !== operationId) {
+        throw new HttpError(
+          422,
+          "PRODUCTION_QUANTITY_POINTAGE_OPERATION_CONFLICT",
+          "Le pointage ne concerne pas l'opération indiquée."
+        );
+      }
+      if (pointage.status === "CANCELLED" || pointage.status === "CORRECTED") {
+        throw new HttpError(
+          409,
+          "PRODUCTION_QUANTITY_POINTAGE_NOT_ELIGIBLE",
+          "Un pointage annulé ou corrigé ne peut pas recevoir de quantité."
+        );
+      }
+      if (params.sourceContext) {
+        if (pointage.operator_user_id !== params.sourceContext.operatorUserId) {
+          throw new HttpError(
+            409,
+            "OFFLINE_QUANTITY_POINTAGE_OPERATOR_CONFLICT",
+            "Le pointage ne correspond pas à l'opérateur de la capture hors ligne."
+          );
+        }
+        if ((pointage.machine_id ?? null) !== params.sourceContext.machineId) {
+          throw new HttpError(
+            409,
+            "OFFLINE_QUANTITY_POINTAGE_MACHINE_CONFLICT",
+            "Le pointage ne correspond pas à la machine de la capture hors ligne."
+          );
+        }
+        if ((pointage.session_id ?? null) !== params.sourceContext.executionSessionId) {
+          throw new HttpError(
+            409,
+            "OFFLINE_QUANTITY_POINTAGE_SESSION_CONFLICT",
+            "Le pointage ne correspond pas au démarrage de la capture hors ligne."
+          );
+        }
+      }
+    }
 
     const delta = {
       qty_good: params.body.qty_good ?? 0,
@@ -2023,6 +2119,28 @@ export async function repoDeclareQuantity(params: {
       throw new HttpError(422, "PRODUCTION_QUANTITY_REWORK_REASON_REQUIRED", "Une cause de reprise est obligatoire.");
     }
 
+    // L'OF est encore verrouillé : deux déclarations concurrentes relisent le
+    // cumul l'une après l'autre et ne peuvent pas dépasser ensemble le restant.
+    const declaredRes = await client.query<{ qty_good: number; qty_scrap: number }>(
+      `
+        SELECT COALESCE(SUM(qty_good), 0)::float8 AS qty_good,
+               COALESCE(SUM(qty_scrap), 0)::float8 AS qty_scrap
+          FROM public.production_quantity_declarations
+         WHERE of_id = $1::bigint
+           AND operation_id IS NOT DISTINCT FROM $2::uuid
+      `,
+      [params.body.of_id, operationId]
+    );
+    const alreadyDeclared = Number(declaredRes.rows[0]?.qty_good ?? 0)
+      + Number(declaredRes.rows[0]?.qty_scrap ?? 0);
+    assertWithinRemaining({
+      declared: delta.qty_good + delta.qty_scrap,
+      alreadyDeclared,
+      quantityTarget: Number(of.quantite_lancee),
+      overproductionTolerance: 0,
+      reason: params.body.overproduction_reason ?? null,
+    });
+
     const ins = await client.query<{ id: string }>(
       `
         INSERT INTO public.production_quantity_declarations (
@@ -2037,7 +2155,7 @@ export async function repoDeclareQuantity(params: {
       [
         params.body.pointage_id ?? null,
         params.body.of_id,
-        params.body.operation_id ?? null,
+        operationId,
         delta.qty_good,
         delta.qty_scrap,
         delta.qty_rework,
@@ -2076,7 +2194,7 @@ export async function repoDeclareQuantity(params: {
       action: "production.execution.declare-quantity",
       entity_type: "production_quantity_declarations",
       entity_id: id,
-      details: { of_id: params.body.of_id, operation_id: params.body.operation_id ?? null, ...delta, no_stock_movement: true },
+      details: { of_id: params.body.of_id, operation_id: operationId, ...delta, no_stock_movement: true },
     });
 
     await storeIdempotentResponse(client, params.idempotencyKey, { id });

--- a/src/module/production/repository/production-execution.repository.ts
+++ b/src/module/production/repository/production-execution.repository.ts
@@ -190,9 +190,10 @@ async function reserveIdempotencyKey<T>(
   const existing = await tx.query<{
     request_fingerprint: string;
     response_body: T | null;
+    user_id: number;
   }>(
     `
-      SELECT request_fingerprint, response_body
+      SELECT request_fingerprint, response_body, user_id
       FROM public.production_execution_idempotency
       WHERE idempotency_key = $1
       FOR UPDATE
@@ -202,6 +203,13 @@ async function reserveIdempotencyKey<T>(
 
   const row = existing.rows[0];
   if (row) {
+    if (row.user_id !== params.user_id) {
+      throw new HttpError(
+        409,
+        "PRODUCTION_EXECUTION_IDEMPOTENCY_ACTOR_CONFLICT",
+        "Cette clé d'idempotence appartient à un autre utilisateur."
+      );
+    }
     assertIdempotencyMatch({
       key: params.key,
       storedFingerprint: row.request_fingerprint,

--- a/src/module/production/routes/station.routes.ts
+++ b/src/module/production/routes/station.routes.ts
@@ -31,6 +31,7 @@ import {
   updateDevice,
   worklist,
 } from "../controllers/station.controller";
+import { syncOfflineStation } from "../controllers/offline-station.controller";
 
 /**
  * Surface « CERP Atelier — Mon poste » (#159), montée sous `/production/station`.
@@ -88,6 +89,15 @@ router.get(
   worklist
 );
 router.post("/scan", requireStationSession, requireStationCapability("read_own_station"), scan);
+
+// Reprise bornée : la session de poste vivante constitue la réauthentification.
+// Chaque événement garde ensuite sa propre clé d'idempotence dans le corps.
+router.post(
+  "/offline/sync",
+  requireStationSession,
+  requireStationCapability("read_own_station"),
+  syncOfflineStation
+);
 
 router.get(
   "/dossier/:ofId/:operationId",

--- a/src/module/production/services/offline-station.service.ts
+++ b/src/module/production/services/offline-station.service.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "node:crypto";
+
 import { HttpError } from "../../../utils/httpError";
 import { fingerprintPayload } from "../domain/production-execution";
 import type { StationContext } from "../middlewares/station-authorization.middleware";
@@ -7,6 +9,7 @@ import {
   repoCanonicalIdempotencyExists,
   repoCompleteOfflineEvent,
   repoOfflineDependency,
+  repoOfflineSourceSession,
   repoOfflineSyncEnabled,
   repoPurgeOfflineEvents,
   repoReserveOfflineEvent,
@@ -45,18 +48,42 @@ function rejection(eventId: string, code: string, message: string, replayed = fa
   return { event_id: eventId, status: "REJECTED", code, message, replayed };
 }
 
-function assertIdentity(station: StationContext, event: OfflineStationEventDTO): void {
+async function assertIdentity(station: StationContext, event: OfflineStationEventDTO): Promise<void> {
   if (event.device_id !== station.device_id) {
     throw new HttpError(409, "OFFLINE_DEVICE_CONFLICT", "L'appareil de l'événement ne correspond plus à la session active.");
   }
   if (event.user_id !== station.user.id) {
     throw new HttpError(409, "OFFLINE_OPERATOR_CONFLICT", "L'opérateur doit se réauthentifier avant la synchronisation.");
   }
-  if (event.station_session_id !== station.session_id) {
-    throw new HttpError(409, "OFFLINE_SESSION_CONFLICT", "La session d'origine n'est plus la session active.");
+  if (event.station_session_id === station.session_id) {
+    if (event.machine_id !== station.machine_id) {
+      throw new HttpError(409, "OFFLINE_MACHINE_CONFLICT", "La machine confirmée a changé depuis la capture hors ligne.");
+    }
+    return;
   }
-  if (event.machine_id !== station.machine_id) {
-    throw new HttpError(409, "OFFLINE_MACHINE_CONFLICT", "La machine confirmée a changé depuis la capture hors ligne.");
+
+  const source = await repoOfflineSourceSession(event.station_session_id);
+  if (!source
+      || source.device_id !== event.device_id
+      || source.user_id !== event.user_id
+      || source.machine_id !== event.machine_id) {
+    throw new HttpError(
+      409,
+      "OFFLINE_SOURCE_SESSION_CONFLICT",
+      "La session d'origine ne correspond pas à l'opérateur, l'appareil et la machine authentifiés."
+    );
+  }
+
+  const occurredAt = Date.parse(event.occurred_at);
+  const startedAt = Date.parse(source.started_at);
+  const endedAt = Date.parse(source.closed_at ?? source.expires_at);
+  const lifecycleToleranceMs = 60_000;
+  if (occurredAt < startedAt - lifecycleToleranceMs || occurredAt > endedAt + lifecycleToleranceMs) {
+    throw new HttpError(
+      409,
+      "OFFLINE_SOURCE_SESSION_TIME_CONFLICT",
+      "L'événement est hors de la période prouvée par sa session d'origine."
+    );
   }
 }
 
@@ -79,13 +106,29 @@ function assertClock(event: OfflineStationEventDTO, nowMs: number): number {
 
 async function referencedPointage(
   directId: string | null | undefined,
-  startEventId: string | null | undefined
+  startEventId: string | null | undefined,
+  batchId: string,
+  event: OfflineStationEventDTO
 ): Promise<string | null> {
   if (directId) return directId;
   if (!startEventId) return null;
   const dependency = await repoOfflineDependency(startEventId);
   if (!dependency) {
     throw new HttpError(409, "OFFLINE_DEPENDENCY_MISSING", "Le démarrage référencé n'a pas été synchronisé.");
+  }
+  if (dependency.event_type !== "POINTAGE_START") {
+    throw new HttpError(409, "OFFLINE_DEPENDENCY_TYPE_INVALID", "La dépendance référencée n'est pas un démarrage.");
+  }
+  if (dependency.client_batch_id !== batchId
+      || dependency.device_id !== event.device_id
+      || dependency.operator_user_id !== event.user_id
+      || dependency.station_session_id !== event.station_session_id
+      || dependency.machine_id !== event.machine_id) {
+    throw new HttpError(
+      409,
+      "OFFLINE_DEPENDENCY_CONTEXT_CONFLICT",
+      "Le démarrage référencé n'appartient pas au même lot et au même contexte opérateur."
+    );
   }
   if (dependency.status !== "SYNCED" || !dependency.server_entity_id) {
     throw new HttpError(
@@ -101,6 +144,7 @@ async function applyCanonicalEvent(params: {
   event: OfflineStationEventDTO;
   station: StationContext;
   audit: AuditContext;
+  batchId: string;
 }): Promise<string> {
   const actor = { id: params.station.user.id, role: params.station.user.role };
   const { event } = params;
@@ -121,7 +165,12 @@ async function applyCanonicalEvent(params: {
     return result.id;
   }
   if (event.type === "POINTAGE_STOP") {
-    const pointageId = await referencedPointage(event.payload.pointage_id, event.payload.start_event_id);
+    const pointageId = await referencedPointage(
+      event.payload.pointage_id,
+      event.payload.start_event_id,
+      params.batchId,
+      event
+    );
     if (!pointageId) throw new HttpError(409, "OFFLINE_POINTAGE_REQUIRED", "Pointage à arrêter introuvable.");
     const result = await svcStopExecution({
       actor,
@@ -137,8 +186,13 @@ async function applyCanonicalEvent(params: {
     return result.id;
   }
 
-  const pointageId = await referencedPointage(event.payload.pointage_id, event.payload.pointage_start_event_id);
-  const { pointage_start_event_id: _dependencyId, ...quantityBody } = event.payload;
+  const pointageId = await referencedPointage(
+    event.payload.pointage_id,
+    event.payload.start_event_id,
+    params.batchId,
+    event
+  );
+  const { start_event_id: _dependencyId, ...quantityBody } = event.payload;
   const result = await svcDeclareQuantity({
     actor,
     idempotencyKey: event.idempotency_key,
@@ -155,30 +209,22 @@ async function processEvent(params: {
   audit: AuditContext;
   nowMs: number;
 }): Promise<OfflineSyncResult> {
-  const requestHash = fingerprintPayload("production.station.offline.v1", params.event);
-  let drift: number;
-  try {
-    assertIdentity(params.station, params.event);
-    drift = assertClock(params.event, params.nowMs);
-  } catch (error) {
-    if (!(error instanceof HttpError) || error.status >= 500) throw error;
-    await repoStationAudit({
-      event_type: "OFFLINE_EVENT_REJECTED",
-      outcome: "DENIED",
-      reason_code: error.code,
-      device_id: params.station.device_id,
-      session_id: params.station.session_id,
-      user_id: params.station.user.id,
-      machine_id: params.station.machine_id,
-      detail: { event_id: params.event.event_id, event_type: params.event.type },
-    });
-    return rejection(params.event.event_id, error.code, error.message.slice(0, 500));
-  }
+  const requestHash = fingerprintPayload("production.station.offline.v1", {
+    client_batch_id: params.batchId,
+    event: params.event,
+  });
+  const drift = clockDriftSeconds(params.event, params.nowMs);
+  const claimToken = randomUUID();
   const reservation = await repoReserveOfflineEvent({
     batchId: params.batchId,
     event: params.event,
     requestHash,
     clockDriftSeconds: drift,
+    claimToken,
+    authenticatedDeviceId: params.station.device_id,
+    authenticatedOperatorUserId: params.station.user.id,
+    authenticatedStationSessionId: params.station.session_id,
+    authenticatedMachineId: params.station.machine_id,
   });
   if (reservation.kind === "CONFLICT") {
     await repoStationAudit({
@@ -196,14 +242,6 @@ async function processEvent(params: {
   if (reservation.kind === "BUSY") {
     throw new HttpError(503, "OFFLINE_EVENT_IN_PROGRESS", "Une synchronisation identique est déjà en cours; réessayez sans modifier l'événement.");
   }
-  if (reservation.outcome.status === "SYNCED") {
-    return {
-      event_id: params.event.event_id,
-      status: "SYNCED",
-      server_entity_id: reservation.outcome.server_entity_id ?? undefined,
-      replayed: true,
-    };
-  }
   if (reservation.outcome.status === "REJECTED") {
     return rejection(
       params.event.event_id,
@@ -214,11 +252,50 @@ async function processEvent(params: {
   }
 
   try {
+    await assertIdentity(params.station, params.event);
+    assertClock(params.event, params.nowMs);
+  } catch (error) {
+    if (!(error instanceof HttpError) || error.status >= 500) throw error;
+    const message = error.message.slice(0, 500);
+    if (reservation.outcome.status === "PROCESSING") {
+      await repoCompleteOfflineEvent({
+        eventId: params.event.event_id,
+        requestHash,
+        claimToken,
+        status: "REJECTED",
+        errorCode: error.code,
+        errorMessage: message,
+      });
+    }
+    await repoStationAudit({
+      event_type: "OFFLINE_EVENT_REJECTED",
+      outcome: "DENIED",
+      reason_code: error.code,
+      device_id: params.station.device_id,
+      session_id: params.station.session_id,
+      user_id: params.station.user.id,
+      machine_id: params.station.machine_id,
+      detail: { event_id: params.event.event_id, event_type: params.event.type },
+    });
+    return rejection(params.event.event_id, error.code, message, reservation.outcome.status === "SYNCED");
+  }
+
+  if (reservation.outcome.status === "SYNCED") {
+    return {
+      event_id: params.event.event_id,
+      status: "SYNCED",
+      server_entity_id: reservation.outcome.server_entity_id ?? undefined,
+      replayed: true,
+    };
+  }
+
+  try {
     const canonicalReplay = await repoCanonicalIdempotencyExists(params.event.idempotency_key);
     const entityId = await applyCanonicalEvent(params);
     await repoCompleteOfflineEvent({
       eventId: params.event.event_id,
       requestHash,
+      claimToken,
       status: "SYNCED",
       serverEntityId: entityId,
       resultPayload: { server_entity_id: entityId },
@@ -243,6 +320,7 @@ async function processEvent(params: {
     await repoCompleteOfflineEvent({
       eventId: params.event.event_id,
       requestHash,
+      claimToken,
       status: "REJECTED",
       errorCode: error.code,
       errorMessage: message,

--- a/src/module/production/services/offline-station.service.ts
+++ b/src/module/production/services/offline-station.service.ts
@@ -29,6 +29,7 @@ import type {
 
 const OFFLINE_REASON = "Synchronisation différée depuis une station hors ligne.";
 const OFFLINE_EXECUTION_NAMESPACE = Buffer.from("6ba7b8109dad11d180b400c04fd430c8", "hex");
+const SOURCE_SESSION_CLOCK_TOLERANCE_MS = 60_000;
 const RETRYABLE_DEPENDENCY_CODES = new Set(["OFFLINE_DEPENDENCY_MISSING", "OFFLINE_DEPENDENCY_PENDING"]);
 
 export type OfflineSyncResult = {
@@ -79,11 +80,8 @@ async function assertIdentity(station: StationContext, event: OfflineStationEven
   if (event.user_id !== station.user.id) {
     throw new HttpError(409, "OFFLINE_OPERATOR_CONFLICT", "L'opérateur doit se réauthentifier avant la synchronisation.");
   }
-  if (event.station_session_id === station.session_id) {
-    if (event.machine_id !== station.machine_id) {
-      throw new HttpError(409, "OFFLINE_MACHINE_CONFLICT", "La machine confirmée a changé depuis la capture hors ligne.");
-    }
-    return;
+  if (event.station_session_id === station.session_id && event.machine_id !== station.machine_id) {
+    throw new HttpError(409, "OFFLINE_MACHINE_CONFLICT", "La machine confirmée a changé depuis la capture hors ligne.");
   }
 
   const source = await repoOfflineSourceSession(event.station_session_id);
@@ -101,8 +99,10 @@ async function assertIdentity(station: StationContext, event: OfflineStationEven
   const occurredAt = Date.parse(event.occurred_at);
   const startedAt = Date.parse(source.started_at);
   const endedAt = Date.parse(source.closed_at ?? source.expires_at);
-  const lifecycleToleranceMs = 60_000;
-  if (occurredAt < startedAt - lifecycleToleranceMs || occurredAt > endedAt + lifecycleToleranceMs) {
+  if (
+    occurredAt < startedAt - SOURCE_SESSION_CLOCK_TOLERANCE_MS
+    || occurredAt > endedAt + SOURCE_SESSION_CLOCK_TOLERANCE_MS
+  ) {
     throw new HttpError(
       409,
       "OFFLINE_SOURCE_SESSION_TIME_CONFLICT",

--- a/src/module/production/services/offline-station.service.ts
+++ b/src/module/production/services/offline-station.service.ts
@@ -1,17 +1,20 @@
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 
 import { HttpError } from "../../../utils/httpError";
 import { fingerprintPayload } from "../domain/production-execution";
 import type { StationContext } from "../middlewares/station-authorization.middleware";
 import type { AuditContext } from "../repository/production.repository";
+import type { ProductionExecutionTransactionHooks } from "../repository/production-execution.repository";
 import { repoStationAudit } from "../repository/station.repository";
 import {
   repoCanonicalIdempotencyExists,
+  repoAssertOfflineEventClaim,
   repoCompleteOfflineEvent,
   repoOfflineDependency,
   repoOfflineSourceSession,
   repoOfflineSyncEnabled,
   repoPurgeOfflineEvents,
+  repoReleaseOfflineEventClaim,
   repoReserveOfflineEvent,
 } from "../repository/offline-station.repository";
 import {
@@ -25,6 +28,8 @@ import type {
 } from "../validators/offline-station.validators";
 
 const OFFLINE_REASON = "Synchronisation différée depuis une station hors ligne.";
+const OFFLINE_EXECUTION_NAMESPACE = Buffer.from("6ba7b8109dad11d180b400c04fd430c8", "hex");
+const RETRYABLE_DEPENDENCY_CODES = new Set(["OFFLINE_DEPENDENCY_MISSING", "OFFLINE_DEPENDENCY_PENDING"]);
 
 export type OfflineSyncResult = {
   event_id: string;
@@ -46,6 +51,25 @@ function envKillSwitchEnabled(): boolean {
 
 function rejection(eventId: string, code: string, message: string, replayed = false): OfflineSyncResult {
   return { event_id: eventId, status: "REJECTED", code, message, replayed };
+}
+
+function executionSessionIdForStartEvent(startEventId: string): string {
+  const bytes = createHash("sha1")
+    .update(OFFLINE_EXECUTION_NAMESPACE)
+    .update(`cerp:offline-execution:${startEventId}`, "utf8")
+    .digest()
+    .subarray(0, 16);
+  bytes[6] = (bytes[6]! & 0x0f) | 0x50;
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80;
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20)}`;
+}
+
+function executionSessionId(event: OfflineStationEventDTO): string | null {
+  if (event.type === "POINTAGE_START") return executionSessionIdForStartEvent(event.event_id);
+  return event.payload.start_event_id
+    ? executionSessionIdForStartEvent(event.payload.start_event_id)
+    : null;
 }
 
 async function assertIdentity(station: StationContext, event: OfflineStationEventDTO): Promise<void> {
@@ -108,7 +132,8 @@ async function referencedPointage(
   directId: string | null | undefined,
   startEventId: string | null | undefined,
   batchId: string,
-  event: OfflineStationEventDTO
+  event: OfflineStationEventDTO,
+  expectedExecutionSessionId: string | null
 ): Promise<string | null> {
   if (directId) return directId;
   if (!startEventId) return null;
@@ -123,7 +148,9 @@ async function referencedPointage(
       || dependency.device_id !== event.device_id
       || dependency.operator_user_id !== event.user_id
       || dependency.station_session_id !== event.station_session_id
-      || dependency.machine_id !== event.machine_id) {
+      || dependency.machine_id !== event.machine_id
+      || !expectedExecutionSessionId
+      || dependency.execution_session_id !== expectedExecutionSessionId) {
     throw new HttpError(
       409,
       "OFFLINE_DEPENDENCY_CONTEXT_CONFLICT",
@@ -145,16 +172,20 @@ async function applyCanonicalEvent(params: {
   station: StationContext;
   audit: AuditContext;
   batchId: string;
+  executionSessionId: string | null;
+  transactionHooks: ProductionExecutionTransactionHooks<{ id: string }>;
 }): Promise<string> {
   const actor = { id: params.station.user.id, role: params.station.user.role };
   const { event } = params;
   if (event.type === "POINTAGE_START") {
+    if (!params.executionSessionId) throw new Error("Offline START execution session is missing");
     const result = await svcStartExecution({
       actor,
       idempotencyKey: event.idempotency_key,
       audit: params.audit,
-      stationSessionId: params.station.session_id,
+      executionSessionId: params.executionSessionId,
       source: "OFFLINE_STATION",
+      transactionHooks: params.transactionHooks,
       body: {
         ...event.payload,
         machine_id: event.machine_id,
@@ -169,7 +200,8 @@ async function applyCanonicalEvent(params: {
       event.payload.pointage_id,
       event.payload.start_event_id,
       params.batchId,
-      event
+      event,
+      params.executionSessionId
     );
     if (!pointageId) throw new HttpError(409, "OFFLINE_POINTAGE_REQUIRED", "Pointage à arrêter introuvable.");
     const result = await svcStopExecution({
@@ -177,6 +209,7 @@ async function applyCanonicalEvent(params: {
       id: pointageId,
       idempotencyKey: event.idempotency_key,
       audit: params.audit,
+      transactionHooks: params.transactionHooks,
       body: {
         comment: event.payload.comment,
         end_ts: event.occurred_at,
@@ -190,13 +223,15 @@ async function applyCanonicalEvent(params: {
     event.payload.pointage_id,
     event.payload.start_event_id,
     params.batchId,
-    event
+    event,
+    params.executionSessionId
   );
   const { start_event_id: _dependencyId, ...quantityBody } = event.payload;
   const result = await svcDeclareQuantity({
     actor,
     idempotencyKey: event.idempotency_key,
     audit: params.audit,
+    transactionHooks: params.transactionHooks,
     body: { ...quantityBody, pointage_id: pointageId },
   });
   return result.id;
@@ -214,12 +249,14 @@ async function processEvent(params: {
     event: params.event,
   });
   const drift = clockDriftSeconds(params.event, params.nowMs);
+  const stableExecutionSessionId = executionSessionId(params.event);
   const claimToken = randomUUID();
   const reservation = await repoReserveOfflineEvent({
     batchId: params.batchId,
     event: params.event,
     requestHash,
     clockDriftSeconds: drift,
+    executionSessionId: stableExecutionSessionId,
     claimToken,
     authenticatedDeviceId: params.station.device_id,
     authenticatedOperatorUserId: params.station.user.id,
@@ -250,36 +287,6 @@ async function processEvent(params: {
       true
     );
   }
-
-  try {
-    await assertIdentity(params.station, params.event);
-    assertClock(params.event, params.nowMs);
-  } catch (error) {
-    if (!(error instanceof HttpError) || error.status >= 500) throw error;
-    const message = error.message.slice(0, 500);
-    if (reservation.outcome.status === "PROCESSING") {
-      await repoCompleteOfflineEvent({
-        eventId: params.event.event_id,
-        requestHash,
-        claimToken,
-        status: "REJECTED",
-        errorCode: error.code,
-        errorMessage: message,
-      });
-    }
-    await repoStationAudit({
-      event_type: "OFFLINE_EVENT_REJECTED",
-      outcome: "DENIED",
-      reason_code: error.code,
-      device_id: params.station.device_id,
-      session_id: params.station.session_id,
-      user_id: params.station.user.id,
-      machine_id: params.station.machine_id,
-      detail: { event_id: params.event.event_id, event_type: params.event.type },
-    });
-    return rejection(params.event.event_id, error.code, message, reservation.outcome.status === "SYNCED");
-  }
-
   if (reservation.outcome.status === "SYNCED") {
     return {
       event_id: params.event.event_id,
@@ -290,15 +297,57 @@ async function processEvent(params: {
   }
 
   try {
-    const canonicalReplay = await repoCanonicalIdempotencyExists(params.event.idempotency_key);
-    const entityId = await applyCanonicalEvent(params);
+    await assertIdentity(params.station, params.event);
+    assertClock(params.event, params.nowMs);
+  } catch (error) {
+    if (!(error instanceof HttpError) || error.status >= 500) throw error;
+    const message = error.message.slice(0, 500);
     await repoCompleteOfflineEvent({
       eventId: params.event.event_id,
       requestHash,
       claimToken,
+      status: "REJECTED",
+      errorCode: error.code,
+      errorMessage: message,
+    });
+    await repoStationAudit({
+      event_type: "OFFLINE_EVENT_REJECTED",
+      outcome: "DENIED",
+      reason_code: error.code,
+      device_id: params.station.device_id,
+      session_id: params.station.session_id,
+      user_id: params.station.user.id,
+      machine_id: params.station.machine_id,
+      detail: { event_id: params.event.event_id, event_type: params.event.type },
+    });
+    return rejection(params.event.event_id, error.code, message);
+  }
+
+  const transactionHooks: ProductionExecutionTransactionHooks<{ id: string }> = {
+    beforeEffect: (tx) => repoAssertOfflineEventClaim(tx, {
+      eventId: params.event.event_id,
+      requestHash,
+      claimToken,
+    }),
+    beforeCommit: (tx, result) => repoCompleteOfflineEvent({
+      eventId: params.event.event_id,
+      requestHash,
+      claimToken,
       status: "SYNCED",
-      serverEntityId: entityId,
-      resultPayload: { server_entity_id: entityId },
+      serverEntityId: result.id,
+      resultPayload: {
+        server_entity_id: result.id,
+        execution_session_id: stableExecutionSessionId,
+      },
+    }, tx),
+  };
+
+  try {
+    const canonicalReplay = await repoCanonicalIdempotencyExists(params.event.idempotency_key);
+    const entityId = await applyCanonicalEvent({
+      ...params,
+      executionSessionId: stableExecutionSessionId,
+      transactionHooks,
     });
     await repoStationAudit({
       event_type: "OFFLINE_EVENT_SYNCED",
@@ -317,6 +366,14 @@ async function processEvent(params: {
   } catch (error) {
     if (!(error instanceof HttpError) || error.status >= 500) throw error;
     const message = error.message.slice(0, 500);
+    if (RETRYABLE_DEPENDENCY_CODES.has(error.code)) {
+      await repoReleaseOfflineEventClaim({
+        eventId: params.event.event_id,
+        requestHash,
+        claimToken,
+      });
+      throw new HttpError(503, error.code, message);
+    }
     await repoCompleteOfflineEvent({
       eventId: params.event.event_id,
       requestHash,
@@ -351,15 +408,25 @@ export async function svcSyncOfflineStation(params: {
   }
 
   const results: OfflineSyncResult[] = [];
+  let retryableError: HttpError | null = null;
   for (const event of params.body.events) {
-    results.push(await processEvent({
-      batchId: params.body.client_batch_id,
-      event,
-      station: params.station,
-      audit: params.audit,
-      nowMs: serverTime.getTime(),
-    }));
+    try {
+      results.push(await processEvent({
+        batchId: params.body.client_batch_id,
+        event,
+        station: params.station,
+        audit: params.audit,
+        nowMs: serverTime.getTime(),
+      }));
+    } catch (error) {
+      if (error instanceof HttpError && error.status === 503) {
+        retryableError ??= error;
+        continue;
+      }
+      throw error;
+    }
   }
+  if (retryableError) throw retryableError;
 
   const retentionDays = boundedEnv("STATION_OFFLINE_RECEIPT_RETENTION_DAYS", 30, 7, 365);
   void repoPurgeOfflineEvents(retentionDays).catch(() => undefined);

--- a/src/module/production/services/offline-station.service.ts
+++ b/src/module/production/services/offline-station.service.ts
@@ -226,11 +226,23 @@ async function applyCanonicalEvent(params: {
     event,
     params.executionSessionId
   );
+  if (!pointageId) {
+    throw new HttpError(
+      409,
+      "OFFLINE_POINTAGE_REQUIRED",
+      "Une quantité hors ligne doit référencer son pointage de production."
+    );
+  }
   const { start_event_id: _dependencyId, ...quantityBody } = event.payload;
   const result = await svcDeclareQuantity({
     actor,
     idempotencyKey: event.idempotency_key,
     audit: params.audit,
+    sourceContext: {
+      operatorUserId: event.user_id,
+      machineId: event.machine_id,
+      executionSessionId: params.executionSessionId,
+    },
     transactionHooks: params.transactionHooks,
     body: { ...quantityBody, pointage_id: pointageId },
   });

--- a/src/module/production/services/offline-station.service.ts
+++ b/src/module/production/services/offline-station.service.ts
@@ -1,0 +1,289 @@
+import { HttpError } from "../../../utils/httpError";
+import { fingerprintPayload } from "../domain/production-execution";
+import type { StationContext } from "../middlewares/station-authorization.middleware";
+import type { AuditContext } from "../repository/production.repository";
+import { repoStationAudit } from "../repository/station.repository";
+import {
+  repoCanonicalIdempotencyExists,
+  repoCompleteOfflineEvent,
+  repoOfflineDependency,
+  repoOfflineSyncEnabled,
+  repoPurgeOfflineEvents,
+  repoReserveOfflineEvent,
+} from "../repository/offline-station.repository";
+import {
+  svcDeclareQuantity,
+  svcStartExecution,
+  svcStopExecution,
+} from "./production-execution.service";
+import type {
+  OfflineStationEventDTO,
+  OfflineStationSyncDTO,
+} from "../validators/offline-station.validators";
+
+const OFFLINE_REASON = "Synchronisation différée depuis une station hors ligne.";
+
+export type OfflineSyncResult = {
+  event_id: string;
+  status: "SYNCED" | "REJECTED";
+  code?: string;
+  message?: string;
+  server_entity_id?: string;
+  replayed: boolean;
+};
+
+function boundedEnv(name: string, fallback: number, min: number, max: number): number {
+  const parsed = Number.parseInt(process.env[name] ?? "", 10);
+  return Number.isInteger(parsed) ? Math.min(max, Math.max(min, parsed)) : fallback;
+}
+
+function envKillSwitchEnabled(): boolean {
+  return /^(?:0|false|off|disabled)$/i.test(process.env.STATION_OFFLINE_SYNC_ENABLED?.trim() ?? "");
+}
+
+function rejection(eventId: string, code: string, message: string, replayed = false): OfflineSyncResult {
+  return { event_id: eventId, status: "REJECTED", code, message, replayed };
+}
+
+function assertIdentity(station: StationContext, event: OfflineStationEventDTO): void {
+  if (event.device_id !== station.device_id) {
+    throw new HttpError(409, "OFFLINE_DEVICE_CONFLICT", "L'appareil de l'événement ne correspond plus à la session active.");
+  }
+  if (event.user_id !== station.user.id) {
+    throw new HttpError(409, "OFFLINE_OPERATOR_CONFLICT", "L'opérateur doit se réauthentifier avant la synchronisation.");
+  }
+  if (event.station_session_id !== station.session_id) {
+    throw new HttpError(409, "OFFLINE_SESSION_CONFLICT", "La session d'origine n'est plus la session active.");
+  }
+  if (event.machine_id !== station.machine_id) {
+    throw new HttpError(409, "OFFLINE_MACHINE_CONFLICT", "La machine confirmée a changé depuis la capture hors ligne.");
+  }
+}
+
+function clockDriftSeconds(event: OfflineStationEventDTO, nowMs: number): number {
+  return Math.trunc((Date.parse(event.occurred_at) - nowMs) / 1000);
+}
+
+function assertClock(event: OfflineStationEventDTO, nowMs: number): number {
+  const drift = clockDriftSeconds(event, nowMs);
+  const maxAge = boundedEnv("STATION_OFFLINE_MAX_EVENT_AGE_SECONDS", 86_400, 300, 604_800);
+  const maxFuture = boundedEnv("STATION_OFFLINE_MAX_FUTURE_SKEW_SECONDS", 60, 0, 60);
+  if (drift > maxFuture) {
+    throw new HttpError(409, "OFFLINE_CLOCK_AHEAD", "L'horloge de la station est trop en avance; l'événement doit être vérifié.");
+  }
+  if (drift < -maxAge) {
+    throw new HttpError(409, "OFFLINE_EVENT_EXPIRED", "L'événement hors ligne dépasse la fenêtre de reprise autorisée.");
+  }
+  return drift;
+}
+
+async function referencedPointage(
+  directId: string | null | undefined,
+  startEventId: string | null | undefined
+): Promise<string | null> {
+  if (directId) return directId;
+  if (!startEventId) return null;
+  const dependency = await repoOfflineDependency(startEventId);
+  if (!dependency) {
+    throw new HttpError(409, "OFFLINE_DEPENDENCY_MISSING", "Le démarrage référencé n'a pas été synchronisé.");
+  }
+  if (dependency.status !== "SYNCED" || !dependency.server_entity_id) {
+    throw new HttpError(
+      409,
+      dependency.status === "REJECTED" ? "OFFLINE_DEPENDENCY_REJECTED" : "OFFLINE_DEPENDENCY_PENDING",
+      "Le démarrage référencé n'est pas utilisable; aucun conflit n'a été écrasé."
+    );
+  }
+  return dependency.server_entity_id;
+}
+
+async function applyCanonicalEvent(params: {
+  event: OfflineStationEventDTO;
+  station: StationContext;
+  audit: AuditContext;
+}): Promise<string> {
+  const actor = { id: params.station.user.id, role: params.station.user.role };
+  const { event } = params;
+  if (event.type === "POINTAGE_START") {
+    const result = await svcStartExecution({
+      actor,
+      idempotencyKey: event.idempotency_key,
+      audit: params.audit,
+      stationSessionId: params.station.session_id,
+      source: "OFFLINE_STATION",
+      body: {
+        ...event.payload,
+        machine_id: event.machine_id,
+        start_ts: event.occurred_at,
+        retroactive_reason: OFFLINE_REASON,
+      },
+    });
+    return result.id;
+  }
+  if (event.type === "POINTAGE_STOP") {
+    const pointageId = await referencedPointage(event.payload.pointage_id, event.payload.start_event_id);
+    if (!pointageId) throw new HttpError(409, "OFFLINE_POINTAGE_REQUIRED", "Pointage à arrêter introuvable.");
+    const result = await svcStopExecution({
+      actor,
+      id: pointageId,
+      idempotencyKey: event.idempotency_key,
+      audit: params.audit,
+      body: {
+        comment: event.payload.comment,
+        end_ts: event.occurred_at,
+        retroactive_reason: OFFLINE_REASON,
+      },
+    });
+    return result.id;
+  }
+
+  const pointageId = await referencedPointage(event.payload.pointage_id, event.payload.pointage_start_event_id);
+  const { pointage_start_event_id: _dependencyId, ...quantityBody } = event.payload;
+  const result = await svcDeclareQuantity({
+    actor,
+    idempotencyKey: event.idempotency_key,
+    audit: params.audit,
+    body: { ...quantityBody, pointage_id: pointageId },
+  });
+  return result.id;
+}
+
+async function processEvent(params: {
+  batchId: string;
+  event: OfflineStationEventDTO;
+  station: StationContext;
+  audit: AuditContext;
+  nowMs: number;
+}): Promise<OfflineSyncResult> {
+  const requestHash = fingerprintPayload("production.station.offline.v1", params.event);
+  let drift: number;
+  try {
+    assertIdentity(params.station, params.event);
+    drift = assertClock(params.event, params.nowMs);
+  } catch (error) {
+    if (!(error instanceof HttpError) || error.status >= 500) throw error;
+    await repoStationAudit({
+      event_type: "OFFLINE_EVENT_REJECTED",
+      outcome: "DENIED",
+      reason_code: error.code,
+      device_id: params.station.device_id,
+      session_id: params.station.session_id,
+      user_id: params.station.user.id,
+      machine_id: params.station.machine_id,
+      detail: { event_id: params.event.event_id, event_type: params.event.type },
+    });
+    return rejection(params.event.event_id, error.code, error.message.slice(0, 500));
+  }
+  const reservation = await repoReserveOfflineEvent({
+    batchId: params.batchId,
+    event: params.event,
+    requestHash,
+    clockDriftSeconds: drift,
+  });
+  if (reservation.kind === "CONFLICT") {
+    await repoStationAudit({
+      event_type: "OFFLINE_EVENT_REJECTED",
+      outcome: "DENIED",
+      reason_code: "OFFLINE_IDEMPOTENCY_CONFLICT",
+      device_id: params.station.device_id,
+      session_id: params.station.session_id,
+      user_id: params.station.user.id,
+      machine_id: params.station.machine_id,
+      detail: { event_id: params.event.event_id, event_type: params.event.type },
+    });
+    return rejection(params.event.event_id, "OFFLINE_IDEMPOTENCY_CONFLICT", "L'identifiant a déjà servi à un événement différent.");
+  }
+  if (reservation.kind === "BUSY") {
+    throw new HttpError(503, "OFFLINE_EVENT_IN_PROGRESS", "Une synchronisation identique est déjà en cours; réessayez sans modifier l'événement.");
+  }
+  if (reservation.outcome.status === "SYNCED") {
+    return {
+      event_id: params.event.event_id,
+      status: "SYNCED",
+      server_entity_id: reservation.outcome.server_entity_id ?? undefined,
+      replayed: true,
+    };
+  }
+  if (reservation.outcome.status === "REJECTED") {
+    return rejection(
+      params.event.event_id,
+      reservation.outcome.error_code ?? "OFFLINE_REJECTED",
+      reservation.outcome.error_message ?? "Événement refusé.",
+      true
+    );
+  }
+
+  try {
+    const canonicalReplay = await repoCanonicalIdempotencyExists(params.event.idempotency_key);
+    const entityId = await applyCanonicalEvent(params);
+    await repoCompleteOfflineEvent({
+      eventId: params.event.event_id,
+      requestHash,
+      status: "SYNCED",
+      serverEntityId: entityId,
+      resultPayload: { server_entity_id: entityId },
+    });
+    await repoStationAudit({
+      event_type: "OFFLINE_EVENT_SYNCED",
+      device_id: params.station.device_id,
+      session_id: params.station.session_id,
+      user_id: params.station.user.id,
+      machine_id: params.station.machine_id,
+      detail: { event_id: params.event.event_id, event_type: params.event.type, clock_drift_seconds: drift },
+    });
+    return {
+      event_id: params.event.event_id,
+      status: "SYNCED",
+      server_entity_id: entityId,
+      replayed: reservation.existing || canonicalReplay,
+    };
+  } catch (error) {
+    if (!(error instanceof HttpError) || error.status >= 500) throw error;
+    const message = error.message.slice(0, 500);
+    await repoCompleteOfflineEvent({
+      eventId: params.event.event_id,
+      requestHash,
+      status: "REJECTED",
+      errorCode: error.code,
+      errorMessage: message,
+    });
+    await repoStationAudit({
+      event_type: "OFFLINE_EVENT_REJECTED",
+      outcome: "DENIED",
+      reason_code: error.code,
+      device_id: params.station.device_id,
+      session_id: params.station.session_id,
+      user_id: params.station.user.id,
+      machine_id: params.station.machine_id,
+      detail: { event_id: params.event.event_id, event_type: params.event.type },
+    });
+    return rejection(params.event.event_id, error.code, message);
+  }
+}
+
+export async function svcSyncOfflineStation(params: {
+  body: OfflineStationSyncDTO;
+  station: StationContext;
+  audit: AuditContext;
+}) {
+  const serverTime = new Date();
+  const enabled = !envKillSwitchEnabled() && await repoOfflineSyncEnabled();
+  if (!enabled) {
+    return { server_time: serverTime.toISOString(), kill_switch_enabled: true, results: [] as OfflineSyncResult[] };
+  }
+
+  const results: OfflineSyncResult[] = [];
+  for (const event of params.body.events) {
+    results.push(await processEvent({
+      batchId: params.body.client_batch_id,
+      event,
+      station: params.station,
+      audit: params.audit,
+      nowMs: serverTime.getTime(),
+    }));
+  }
+
+  const retentionDays = boundedEnv("STATION_OFFLINE_RECEIPT_RETENTION_DAYS", 30, 7, 365);
+  void repoPurgeOfflineEvents(retentionDays).catch(() => undefined);
+  return { server_time: serverTime.toISOString(), kill_switch_enabled: false, results };
+}

--- a/src/module/production/services/production-execution.service.ts
+++ b/src/module/production/services/production-execution.service.ts
@@ -31,6 +31,7 @@ import {
   repoSubmitExecution,
   repoTransitionSegment,
   repoValidateExecution,
+  type ProductionExecutionTransactionHooks,
 } from "../repository/production-execution.repository";
 import type {
   CancelExecutionBodyDTO,
@@ -170,8 +171,9 @@ export async function svcStartExecution(params: {
   body: StartExecutionBodyDTO;
   idempotencyKey: string;
   audit: AuditContext;
-  stationSessionId?: string | null;
+  executionSessionId?: string | null;
   source?: string;
+  transactionHooks?: ProductionExecutionTransactionHooks<{ id: string }>;
 }) {
   assertProductionExecutionCapability(params.actor.role, "start_self");
   const operatorUserId = resolveOperator(params.actor, params.body);
@@ -180,8 +182,9 @@ export async function svcStartExecution(params: {
     operatorUserId,
     idempotencyKey: params.idempotencyKey,
     audit: params.audit,
-    sessionId: params.stationSessionId,
+    sessionId: params.executionSessionId,
     source: params.source,
+    transactionHooks: params.transactionHooks,
   });
 }
 
@@ -191,6 +194,7 @@ export async function svcStopExecution(params: {
   body: StopExecutionBodyDTO;
   idempotencyKey: string;
   audit: AuditContext;
+  transactionHooks?: ProductionExecutionTransactionHooks<{ id: string }>;
 }) {
   assertProductionExecutionCapability(params.actor.role, "stop_self");
   return repoStopExecution({
@@ -199,6 +203,7 @@ export async function svcStopExecution(params: {
     idempotencyKey: params.idempotencyKey,
     actorRole: params.actor.role,
     audit: params.audit,
+    transactionHooks: params.transactionHooks,
   });
 }
 
@@ -290,12 +295,14 @@ export async function svcDeclareQuantity(params: {
   body: DeclareQuantityBodyDTO;
   idempotencyKey: string;
   audit: AuditContext;
+  transactionHooks?: ProductionExecutionTransactionHooks<{ id: string }>;
 }) {
   assertProductionExecutionCapability(params.actor.role, "declare_quantity");
   return repoDeclareQuantity({
     body: params.body,
     idempotencyKey: params.idempotencyKey,
     audit: params.audit,
+    transactionHooks: params.transactionHooks,
   });
 }
 

--- a/src/module/production/services/production-execution.service.ts
+++ b/src/module/production/services/production-execution.service.ts
@@ -170,6 +170,8 @@ export async function svcStartExecution(params: {
   body: StartExecutionBodyDTO;
   idempotencyKey: string;
   audit: AuditContext;
+  stationSessionId?: string | null;
+  source?: string;
 }) {
   assertProductionExecutionCapability(params.actor.role, "start_self");
   const operatorUserId = resolveOperator(params.actor, params.body);
@@ -178,6 +180,8 @@ export async function svcStartExecution(params: {
     operatorUserId,
     idempotencyKey: params.idempotencyKey,
     audit: params.audit,
+    sessionId: params.stationSessionId,
+    source: params.source,
   });
 }
 

--- a/src/module/production/services/production-execution.service.ts
+++ b/src/module/production/services/production-execution.service.ts
@@ -31,6 +31,7 @@ import {
   repoSubmitExecution,
   repoTransitionSegment,
   repoValidateExecution,
+  type ProductionQuantitySourceContext,
   type ProductionExecutionTransactionHooks,
 } from "../repository/production-execution.repository";
 import type {
@@ -295,6 +296,7 @@ export async function svcDeclareQuantity(params: {
   body: DeclareQuantityBodyDTO;
   idempotencyKey: string;
   audit: AuditContext;
+  sourceContext?: ProductionQuantitySourceContext;
   transactionHooks?: ProductionExecutionTransactionHooks<{ id: string }>;
 }) {
   assertProductionExecutionCapability(params.actor.role, "declare_quantity");
@@ -302,6 +304,7 @@ export async function svcDeclareQuantity(params: {
     body: params.body,
     idempotencyKey: params.idempotencyKey,
     audit: params.audit,
+    sourceContext: params.sourceContext,
     transactionHooks: params.transactionHooks,
   });
 }

--- a/src/module/production/validators/offline-station.validators.ts
+++ b/src/module/production/validators/offline-station.validators.ts
@@ -1,6 +1,9 @@
 import { z } from "zod";
 
-const uuid = z.string().uuid();
+// PostgreSQL restitue les UUID en minuscules. Canonicaliser dès la frontière
+// HTTP garantit que hash, réservation et recherche de dépendance utilisent la
+// même identité textuelle, quelle que soit la casse envoyée par la station.
+const uuid = z.string().uuid().transform((value) => value.toLowerCase());
 const nullableUuid = uuid.nullable();
 const idempotencyKey = z.string().trim().min(8).max(200);
 const occurredAt = z.string().trim()

--- a/src/module/production/validators/offline-station.validators.ts
+++ b/src/module/production/validators/offline-station.validators.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+
+const uuid = z.string().uuid();
+const nullableUuid = uuid.nullable();
+const idempotencyKey = z.string().trim().min(8).max(200);
+const occurredAt = z.string().trim()
+  .regex(
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/,
+    "Horodatage ISO 8601 avec fuseau requis"
+  )
+  .refine((value) => Number.isFinite(Date.parse(value)), { message: "Horodatage invalide" });
+const activityCode = z.string().trim().regex(/^[A-Z][A-Z0-9_]{1,39}$/);
+const optionalComment = z.string().trim().max(2000).nullable().optional();
+
+const commonEvent = z.object({
+  event_id: uuid,
+  idempotency_key: idempotencyKey,
+  occurred_at: occurredAt,
+  device_id: uuid,
+  user_id: z.coerce.number().int().positive(),
+  station_session_id: uuid,
+  machine_id: nullableUuid,
+});
+
+const pointageStart = commonEvent.extend({
+  type: z.literal("POINTAGE_START"),
+  payload: z.object({
+    of_id: z.coerce.number().int().positive(),
+    operation_id: nullableUuid.optional(),
+    poste_id: nullableUuid.optional(),
+    activity_code: activityCode,
+    time_type: z.enum(["OPERATEUR", "MACHINE", "PROGRAMMATION"]).optional(),
+    comment: optionalComment,
+  }).strict(),
+}).strict();
+
+const pointageStop = commonEvent.extend({
+  type: z.literal("POINTAGE_STOP"),
+  payload: z.object({
+    pointage_id: uuid.nullable().optional(),
+    start_event_id: uuid.nullable().optional(),
+    comment: optionalComment,
+  }).strict().refine((value) => Number(Boolean(value.pointage_id)) + Number(Boolean(value.start_event_id)) === 1, {
+    message: "Indiquez exactement pointage_id ou start_event_id",
+  }),
+}).strict();
+
+const quantityDeclare = commonEvent.extend({
+  type: z.literal("QUANTITY_DECLARE"),
+  payload: z.object({
+    of_id: z.coerce.number().int().positive(),
+    operation_id: nullableUuid.optional(),
+    pointage_id: uuid.optional(),
+    pointage_start_event_id: uuid.optional(),
+    qty_good: z.coerce.number().finite().min(0).max(1_000_000).optional().default(0),
+    qty_scrap: z.coerce.number().finite().min(0).max(1_000_000).optional().default(0),
+    qty_rework: z.coerce.number().finite().min(0).max(1_000_000).optional().default(0),
+    qty_pending_control: z.coerce.number().finite().min(0).max(1_000_000).optional().default(0),
+    unite: z.string().trim().max(32).nullable().optional(),
+    scrap_reason_code: z.string().trim().max(64).nullable().optional(),
+    rework_reason_code: z.string().trim().max(64).nullable().optional(),
+    note: optionalComment,
+    overproduction_reason: z.string().trim().min(3).max(2000).optional(),
+  }).strict()
+    .refine(
+      (value) =>
+        value.qty_good + value.qty_scrap + value.qty_rework + value.qty_pending_control > 0,
+      { message: "La quantité totale doit être strictement positive" }
+    )
+    .refine(
+      (value) => !(value.pointage_id && value.pointage_start_event_id),
+      { message: "pointage_id et pointage_start_event_id sont mutuellement exclusifs" }
+    ),
+}).strict();
+
+export const offlineStationEventSchema = z.discriminatedUnion("type", [
+  pointageStart,
+  pointageStop,
+  quantityDeclare,
+]);
+
+export const offlineStationSyncSchema = z.object({
+  client_batch_id: uuid,
+  events: z.array(offlineStationEventSchema).min(1).max(25),
+}).strict().superRefine((value, ctx) => {
+  const eventIds = new Set<string>();
+  const keys = new Set<string>();
+  value.events.forEach((event, index) => {
+    if (eventIds.has(event.event_id)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["events", index, "event_id"], message: "event_id dupliqué" });
+    }
+    if (keys.has(event.idempotency_key)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["events", index, "idempotency_key"], message: "idempotency_key dupliquée" });
+    }
+    eventIds.add(event.event_id);
+    keys.add(event.idempotency_key);
+  });
+});
+
+export type OfflineStationEventDTO = z.infer<typeof offlineStationEventSchema>;
+export type OfflineStationSyncDTO = z.infer<typeof offlineStationSyncSchema>;

--- a/src/module/production/validators/offline-station.validators.ts
+++ b/src/module/production/validators/offline-station.validators.ts
@@ -50,8 +50,8 @@ const quantityDeclare = commonEvent.extend({
   payload: z.object({
     of_id: z.coerce.number().int().positive(),
     operation_id: nullableUuid.optional(),
-    pointage_id: uuid.optional(),
-    pointage_start_event_id: uuid.optional(),
+    pointage_id: uuid.nullable().optional(),
+    start_event_id: uuid.nullable().optional(),
     qty_good: z.coerce.number().finite().min(0).max(1_000_000).optional().default(0),
     qty_scrap: z.coerce.number().finite().min(0).max(1_000_000).optional().default(0),
     qty_rework: z.coerce.number().finite().min(0).max(1_000_000).optional().default(0),
@@ -68,8 +68,8 @@ const quantityDeclare = commonEvent.extend({
       { message: "La quantité totale doit être strictement positive" }
     )
     .refine(
-      (value) => !(value.pointage_id && value.pointage_start_event_id),
-      { message: "pointage_id et pointage_start_event_id sont mutuellement exclusifs" }
+      (value) => !(value.pointage_id && value.start_event_id),
+      { message: "pointage_id et start_event_id sont mutuellement exclusifs" }
     ),
 }).strict();
 


### PR DESCRIPTION
Implements GPT56-FEAT-CERP-0006 with bounded encrypted offline queue, idempotent transactional replay, explicit conflicts, retention and kill switch.

## Summary by Sourcery

Introduce a bounded, resumable offline station sync pipeline with strong idempotency, transactional fencing, and explicit conflict handling for production events.

New Features:
- Add HTTP endpoint, service layer, repository, validators and database schema to accept and process offline station START/STOP/QUANTITY events in bounded batches with replayable receipts.
- Expose offline station sync contract and behavior through new user-facing documentation and ADR.

Bug Fixes:
- Ensure production execution idempotency keys are bound to a specific user to prevent cross-operator reply of cached responses.
- Enforce transactional integrity and concurrency control for quantity declarations, including OF/operation status, ownership, and remaining-quantity checks.

Enhancements:
- Extend production execution repositories and services with transaction hooks and source-context metadata to integrate offline replay while preserving atomic commits.
- Tighten quantity declaration validation around pointage ownership, offline session matching and overproduction detection, with comprehensive tests.
- Add station audit event types for offline sync outcomes and wire them into the offline processing pipeline.

Build:
- Register the new offline station queue database patch and checksum in the patch runner scripts.

Documentation:
- Document the offline station sync HTTP contract and capture architectural decisions around the bounded offline queue design and constraints.

Tests:
- Add extensive tests covering offline station queue behavior, dependency resolution, fencing, kill switch, conflict handling, migration guards and transactional quantity integrity.