### PR TITLE
chore(release): promote isolated stock navigation patch

### DIFF
--- a/docs/database-patches.md
+++ b/docs/database-patches.md
@@ -55,8 +55,8 @@ and `applied_at` together. A registry-write failure therefore rolls the patch ba
 `baseline` remains a separate metadata-only operation: it never executes patch
 SQL and is allowed only after the represented schema has been verified manually.
 
-For the rate-limit rollout, `--only 20260804_auth_rate_limit_buckets.sql` is an
-immutable selector: the runner accepts the exact basename only, verifies its
+For targeted rollouts, registered `--only` patch basenames are immutable
+selectors. The runner accepts the exact basename only, verifies its
 canonical LF SHA-256, still evaluates the complete patch inventory for checksum
 mismatches, and applies zero or one selected patch according to its
 `pending`/`applied` status. The selector always reads the repository's canonical
@@ -101,7 +101,8 @@ Correctif applicatif du 2026-08-10 :
   Stock, sans remplacer les clés déjà présentes. Son preflight et sa vérification
   sont en lecture seule ; son rollback est limité à `cerp_test`.
 
-Ce nouveau patch de navigation est livré non appliqué. Son exécution sur
+Ce nouveau patch de navigation peut être appliqué seul avec
+`--only 20260810_stock_old_new_navigation_446.sql`. Son exécution sur
 `cerp_test` puis `cerp_prod` reste soumise aux sauvegardes, contrôles et décisions
 humaines décrits plus haut.
 

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -27,6 +27,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "ceff91b88820e9943d199f71a73e32fd4f994d383f76aabb620ea648c9d1ae53",
   "20260805_station_offline_queue_0006.sql":
     "3e223c43698bdf3399ab2d37e6493d0d014952eb0fe877cdeb1c4b4f7f7db3da",
+  "20260810_stock_old_new_navigation_446.sql":
+    "4900f01411ab89349874fcd6d28993aa34a1ec560320d4d32b05489800bf3b9b",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -41,6 +41,9 @@ const require = createRequire(import.meta.url);
 const runner = require(resolve(repoRoot, "scripts/db-patches.js")) as RunnerModule;
 const patchFilename = "20260804_auth_rate_limit_buckets.sql";
 const planningPatchFilename = "20260805_planning_convergence_governance.sql";
+const stockNavigationPatchFilename = "20260810_stock_old_new_navigation_446.sql";
+const stockNavigationPatchChecksum =
+  "4900f01411ab89349874fcd6d28993aa34a1ec560320d4d32b05489800bf3b9b";
 const wave9PatchChecksums = new Map([
   [
     "20260216_planning_visuals_programmation.sql",
@@ -127,6 +130,12 @@ describe("database patch runner", () => {
       "4ac0aa05dc489ae5f882491e7b41cc6e96ac3bcaabd554ecddfb82d6580734dc"
     );
 
+    const stockNavigationPatch = readFileSync(
+      resolve(repoRoot, "db/patches", stockNavigationPatchFilename),
+      "utf8"
+    );
+    expect(runner.sha256Sql(stockNavigationPatch)).toBe(stockNavigationPatchChecksum);
+
     for (const [filename, checksum] of wave9PatchChecksums) {
       const sql = readFileSync(resolve(repoRoot, "db/patches", filename), "utf8");
       expect(runner.sha256Sql(sql)).toBe(checksum);
@@ -155,6 +164,13 @@ describe("database patch runner", () => {
     });
     expect(runner.parseArgs(["up", "--only", planningPatchFilename]).only).toBe(
       planningPatchFilename
+    );
+    expect(runner.immutableOnlyPatch(patches, stockNavigationPatchFilename)).toMatchObject({
+      filename: stockNavigationPatchFilename,
+      sha256: stockNavigationPatchChecksum,
+    });
+    expect(runner.parseArgs(["up", "--only", stockNavigationPatchFilename]).only).toBe(
+      stockNavigationPatchFilename
     );
     for (const [filename, checksum] of wave9PatchChecksums) {
       expect(runner.immutableOnlyPatch(patches, filename)).toMatchObject({


### PR DESCRIPTION
Promotion de `dev` vers `main` du garde-fou permettant l’application isolée et vérifiée de `20260810_stock_old_new_navigation_446.sql`.

Validation locale : 21 tests du lanceur SQL et build backend réussis.

## Summary by Sourcery

Promote the new stock navigation database patch into the immutable, targeted rollout mechanism and document its isolated application.

New Features:
- Allow the 20260810_stock_old_new_navigation_446.sql patch to be applied in isolation via the db patch runner.

Enhancements:
- Extend the immutable-only patch registry and related tests to cover the stock navigation patch.
- Update database patch documentation to describe generic targeted rollouts and the isolated execution of the new stock navigation patch.

Tests:
- Add checksum and selection tests for the stock navigation patch in the database patch runner suite.