### PR TITLE
release: Base OLD stock repair (#446)

### DIFF
--- a/src/__tests__/old-material-definition-446.test.ts
+++ b/src/__tests__/old-material-definition-446.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildOldMaterialDefinition,
+  type OldMaterialDefinitionSource,
+} from "../module/stock/domain/old-material-definition";
+
+const base: OldMaterialDefinitionSource = {
+  article_category: "matiere",
+  designation: "",
+  profile_code: "PL",
+  nuance_code: null,
+  etat_code: null,
+  sous_etat_code: null,
+  longueur_mm: null,
+  largeur_mm: null,
+  hauteur_mm: null,
+  epaisseur_mm: null,
+  diametre_mm: null,
+};
+
+describe("#446 Base OLD material definition", () => {
+  it("derives the requested Clipper plate definition without changing its ART code", () => {
+    expect(
+      buildOldMaterialDefinition({
+        ...base,
+        designation: "ALUMINIUM 7075/T651 1 X 90 EP 30",
+      })
+    ).toBe("PL-7075-T651-1-90-30");
+  });
+
+  it("supports structured material data and keeps the historical segment order", () => {
+    expect(
+      buildOldMaterialDefinition({
+        ...base,
+        designation: "Plate structured",
+        nuance_code: "7075",
+        etat_code: "T651",
+        sous_etat_code: "DETENSIONNE",
+        longueur_mm: 1,
+        largeur_mm: 115,
+        epaisseur_mm: 25,
+      })
+    ).toBe("PL-7075-T651-DETENSIONNE-1-115-25");
+  });
+
+  it("uses length before diameter for a legacy round", () => {
+    expect(
+      buildOldMaterialDefinition({
+        ...base,
+        profile_code: "ROND",
+        designation: "ALUMINIUM 7075/T6 Ø 20 L 1",
+      })
+    ).toBe("RO-7075-T6-1-20");
+  });
+
+  it("falls back to the technical code when the legacy definition is ambiguous", () => {
+    expect(
+      buildOldMaterialDefinition({
+        ...base,
+        designation: "INOX 303 1 X 50 EP 40",
+      })
+    ).toBeNull();
+    expect(buildOldMaterialDefinition({ ...base, article_category: "fabrique" })).toBeNull();
+  });
+});

--- a/src/__tests__/stock-old-new-446.migration-guards.test.ts
+++ b/src/__tests__/stock-old-new-446.migration-guards.test.ts
@@ -145,6 +145,15 @@ describe("#446 Base OLD corrective guards", () => {
     expect(historicalImportSource).not.toMatch(/\b(?:affaire_id|of_id|commande_id)\b/);
   });
 
+  it("resolves an existing MP nuance through the canonical stock referential", () => {
+    const historicalImportStart = stockRepository.indexOf("export async function repoCreateHistoricalImport");
+    const historicalImportEnd = stockRepository.indexOf("export async function repoListBalances");
+    const historicalImportSource = stockRepository.slice(historicalImportStart, historicalImportEnd);
+
+    expect(historicalImportSource).toContain("public.stock_nuances");
+    expect(historicalImportSource).not.toContain("public.matiere_nuances");
+  });
+
   it("adds the OLD and NEW navigation shortcuts without replacing existing keys", () => {
     expect(navigationPatch).toContain("BEGIN;");
     expect(navigationPatch).toContain("COMMIT;");

--- a/src/module/stock/domain/old-material-definition.ts
+++ b/src/module/stock/domain/old-material-definition.ts
@@ -1,0 +1,143 @@
+import {
+  isSpecialMaterialProfile,
+  normalizeMaterialProfile,
+  type MaterialProfileCode,
+} from "../../../shared/codes/material-article-code";
+
+/**
+ * Read-only representation used by Base OLD.
+ *
+ * Legacy Clipper articles keep their immutable ART-* code. This helper only
+ * derives the workshop definition displayed for historical stock.
+ */
+export type OldMaterialDefinitionSource = {
+  article_category: string | null;
+  designation: string;
+  profile_code: string | null;
+  nuance_code: string | null;
+  etat_code: string | null;
+  sous_etat_code: string | null;
+  longueur_mm: number | null;
+  largeur_mm: number | null;
+  hauteur_mm: number | null;
+  epaisseur_mm: number | null;
+  diametre_mm: number | null;
+};
+
+type ParsedLegacyDefinition = {
+  nuance: string | null;
+  etat: string | null;
+  dimensions: string[];
+};
+
+function normalizeSegment(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const normalized = value
+    .normalize("NFD")
+    .replace(/\p{Diacritic}/gu, "")
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+  return normalized || null;
+}
+
+function dimensionToken(value: unknown): string | null {
+  if (value === null || value === undefined || value === "") return null;
+  const numeric = Number(String(value).replace(",", "."));
+  return Number.isFinite(numeric) && numeric > 0 ? String(numeric) : null;
+}
+
+function parseIdentity(prefix: string): Pick<ParsedLegacyDefinition, "nuance" | "etat"> {
+  const slashIndex = prefix.lastIndexOf("/");
+  if (slashIndex < 0) return { nuance: null, etat: null };
+
+  const beforeSlash = prefix.slice(0, slashIndex).trim();
+  const afterSlash = prefix.slice(slashIndex + 1).trim();
+  const nuanceMatch = beforeSlash.match(/([A-Z0-9]+(?:[.-][A-Z0-9]+)*)\s*$/i);
+
+  return {
+    nuance: normalizeSegment(nuanceMatch?.[1] ?? null),
+    etat: normalizeSegment(afterSlash.replace(/^[-\s]+/, "")),
+  };
+}
+
+function parseLegacyDesignation(
+  profile: MaterialProfileCode,
+  designation: string
+): ParsedLegacyDefinition | null {
+  const normalized = designation.replace(/\u00a0/g, " ").trim();
+  let match: RegExpMatchArray | null = null;
+  let dimensions: string[] = [];
+
+  if (profile === "PL") {
+    match = normalized.match(
+      /(\d+(?:[.,]\d+)?)\s*(?:X|×)\s*(\d+(?:[.,]\d+)?)\s*(?:EP|EPAISSEUR)\s*=?\s*(\d+(?:[.,]\d+)?)/i
+    );
+    if (match) dimensions = [match[1], match[2], match[3]];
+  } else if (profile === "TUBE") {
+    match = normalized.match(
+      /(?:Ø|⌀|DIAM(?:ETRE)?\.?)\s*(\d+(?:[.,]\d+)?)\s*(?:EP|EPAISSEUR)\s*=?\s*(\d+(?:[.,]\d+)?)\s*(?:L|LG|X)\s*(\d+(?:[.,]\d+)?)/i
+    );
+    if (match) dimensions = [match[3], match[1], match[2]];
+  } else if (profile === "RO") {
+    match = normalized.match(
+      /(?:Ø|⌀|DIAM(?:ETRE)?\.?)\s*(\d+(?:[.,]\d+)?)\s*(?:L|LG|X)\s*(\d+(?:[.,]\d+)?)/i
+    );
+    if (match) dimensions = [match[2], match[1]];
+  } else if (profile === "U") {
+    match = normalized.match(
+      /LARG(?:EUR)?\s*(\d+(?:[.,]\d+)?)\s*(?:HT|HAUT(?:EUR)?)\s*(\d+(?:[.,]\d+)?)\s*(?:EP|EPAISSEUR)\s*(\d+(?:[.,]\d+)?)(?:\s*(?:L|LG)\s*(\d+(?:[.,]\d+)?))?/i
+    );
+    if (match) dimensions = [match[4], match[1], match[2], match[3]];
+  }
+
+  if (!match || match.index === undefined) return null;
+  const identity = parseIdentity(normalized.slice(0, match.index));
+  const normalizedDimensions = dimensions
+    .map(dimensionToken)
+    .filter((value): value is string => Boolean(value));
+
+  return { ...identity, dimensions: normalizedDimensions };
+}
+
+function structuredDimensions(source: OldMaterialDefinitionSource, profile: MaterialProfileCode): string[] {
+  const length = dimensionToken(source.longueur_mm);
+  const width = dimensionToken(source.largeur_mm);
+  const height = dimensionToken(source.hauteur_mm);
+  const thickness = dimensionToken(source.epaisseur_mm);
+  const diameter = dimensionToken(source.diametre_mm);
+
+  if (profile === "PL") return [length, width, thickness].filter((value): value is string => Boolean(value));
+  if (profile === "RO") return [length, diameter].filter((value): value is string => Boolean(value));
+  if (profile === "TUBE") return [length, diameter, thickness].filter((value): value is string => Boolean(value));
+  if (profile === "U") return [length, width, height, thickness].filter((value): value is string => Boolean(value));
+  return [];
+}
+
+export function buildOldMaterialDefinition(source: OldMaterialDefinitionSource): string | null {
+  if (source.article_category !== "matiere") return null;
+
+  let profile: MaterialProfileCode;
+  try {
+    profile = normalizeMaterialProfile(source.profile_code);
+  } catch {
+    return null;
+  }
+  if (isSpecialMaterialProfile(profile)) return null;
+
+  const legacy = parseLegacyDesignation(profile, source.designation);
+  const nuance = normalizeSegment(source.nuance_code) ?? legacy?.nuance ?? null;
+  const etat = normalizeSegment(source.etat_code) ?? legacy?.etat ?? null;
+  const sousEtat = normalizeSegment(source.sous_etat_code);
+  const structured = structuredDimensions(source, profile);
+  const dimensions = structured.length > 0 ? structured : legacy?.dimensions ?? [];
+
+  // A partial reconstruction would look authoritative while shifting segments.
+  // Keep the immutable ART-* code whenever the historical label is ambiguous.
+  if (!nuance || !etat || dimensions.length === 0) return null;
+
+  return [profile, nuance, etat, sousEtat, ...dimensions]
+    .filter((value): value is string => Boolean(value))
+    .join("-");
+}

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -40,6 +40,10 @@ import {
   commandeArticleEligibleSql,
   commandeArticleIneligibilityCodeSql,
 } from "../domain/commande-article-eligibility";
+import {
+  buildOldMaterialDefinition,
+  type OldMaterialDefinitionSource,
+} from "../domain/old-material-definition";
 import type {
   ArticleCategory,
   ArticleBusinessCategory,
@@ -122,6 +126,37 @@ import type {
   HistoricalImportBodyDTO,
   ListConsolidatedInventoryQueryDTO,
 } from "../validators/stock.validators";
+
+type OldMaterialDefinitionProjection = {
+  material_article_category: string | null;
+  material_designation: string;
+  material_profile_code: string | null;
+  material_nuance_code: string | null;
+  material_etat_code: string | null;
+  material_sous_etat_code: string | null;
+  material_longueur_mm: number | null;
+  material_largeur_mm: number | null;
+  material_hauteur_mm: number | null;
+  material_epaisseur_mm: number | null;
+  material_diametre_mm: number | null;
+};
+
+function oldMaterialDefinitionFromProjection(row: OldMaterialDefinitionProjection): string | null {
+  const source: OldMaterialDefinitionSource = {
+    article_category: row.material_article_category,
+    designation: row.material_designation,
+    profile_code: row.material_profile_code,
+    nuance_code: row.material_nuance_code,
+    etat_code: row.material_etat_code,
+    sous_etat_code: row.material_sous_etat_code,
+    longueur_mm: row.material_longueur_mm,
+    largeur_mm: row.material_largeur_mm,
+    hauteur_mm: row.material_hauteur_mm,
+    epaisseur_mm: row.material_epaisseur_mm,
+    diametre_mm: row.material_diametre_mm,
+  };
+  return buildOldMaterialDefinition(source);
+}
 
 export type AuditContext = {
   user_id: number;
@@ -2745,6 +2780,22 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
       a.projet_id::int AS projet_id,
       a.code,
       a.designation,
+      a.article_category::text AS material_article_category,
+      a.designation AS material_designation,
+      COALESCE(article_material.family_code, a.family_code)::text AS material_profile_code,
+      material_nuance.code::text AS material_nuance_code,
+      material_etat.code::text AS material_etat_code,
+      material_sous_etat.code::text AS material_sous_etat_code,
+      COALESCE(
+        article_material.longueur_brut_mm,
+        article_material.longueur_coupe_mm,
+        article_material.longueur_mm,
+        article_material.longueur_unitaire_mm
+      )::float8 AS material_longueur_mm,
+      article_material.largeur_mm::float8 AS material_largeur_mm,
+      article_material.hauteur_mm::float8 AS material_hauteur_mm,
+      article_material.epaisseur_mm::float8 AS material_epaisseur_mm,
+      article_material.diametre_mm::float8 AS material_diametre_mm,
       a.designation_secondary,
       CASE WHEN ${normalizedArticleCategorySql("a.article_category")} = 'fabrique' THEN 'PIECE_TECHNIQUE' ELSE 'PURCHASED' END AS article_type,
       ${normalizedArticleCategorySql("a.article_category")} AS article_category,
@@ -2779,6 +2830,14 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
     FROM public.articles a
     LEFT JOIN public.pieces_techniques pt
       ON pt.id = a.piece_technique_id
+    LEFT JOIN public.articles_matiere article_material
+      ON article_material.article_id = a.id
+    LEFT JOIN public.stock_nuances material_nuance
+      ON material_nuance.id = article_material.nuance_id
+    LEFT JOIN public.stock_etats material_etat
+      ON material_etat.id = article_material.etat_id
+    LEFT JOIN public.stock_sous_etats material_sous_etat
+      ON material_sous_etat.id = article_material.sous_etat_id
     LEFT JOIN LATERAL (
       SELECT v.id, v.indice, v.statut, v.plan_reference, v.date_application::text AS date_application
       FROM public.piece_technique_versions v
@@ -2808,8 +2867,39 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
     OFFSET $${values.length + 2}
   `;
 
-  const rows = await db.query<StockArticleListItem>(dataSql, [...values, pageSize, offset]);
-  return { items: rows.rows, total };
+  type ArticleRow = Omit<StockArticleListItem, "old_material_definition"> & OldMaterialDefinitionProjection;
+  const rows = await db.query<ArticleRow>(dataSql, [...values, pageSize, offset]);
+  const items = rows.rows.map((row): StockArticleListItem => {
+    const {
+      material_article_category,
+      material_designation,
+      material_profile_code,
+      material_nuance_code,
+      material_etat_code,
+      material_sous_etat_code,
+      material_longueur_mm,
+      material_largeur_mm,
+      material_hauteur_mm,
+      material_epaisseur_mm,
+      material_diametre_mm,
+      ...article
+    } = row;
+    const projection: OldMaterialDefinitionProjection = {
+      material_article_category,
+      material_designation,
+      material_profile_code,
+      material_nuance_code,
+      material_etat_code,
+      material_sous_etat_code,
+      material_longueur_mm,
+      material_largeur_mm,
+      material_hauteur_mm,
+      material_epaisseur_mm,
+      material_diametre_mm,
+    };
+    return { ...article, old_material_definition: oldMaterialDefinitionFromProjection(projection) };
+  });
+  return { items, total };
 }
 
 export async function repoGetArticle(id: string, includeCosts = false): Promise<StockArticleDetail | null> {
@@ -5323,11 +5413,32 @@ export async function repoListConsolidatedInventory(
     LEFT JOIN public.emplacements e ON e.location_id = b.location_id
     LEFT JOIN public.magasins m ON m.id = e.magasin_id
     LEFT JOIN public.lots l ON l.id = b.lot_id
+    LEFT JOIN public.articles_matiere article_material ON article_material.article_id = a.id
+    LEFT JOIN public.stock_nuances material_nuance ON material_nuance.id = article_material.nuance_id
+    LEFT JOIN public.stock_etats material_etat ON material_etat.id = article_material.etat_id
+    LEFT JOIN public.stock_sous_etats material_sous_etat ON material_sous_etat.id = article_material.sous_etat_id
   `;
   const count = await db.query<{ total: number }>(`SELECT COUNT(*)::int AS total ${fromSql} ${whereSql}`, values);
-  const rows = await db.query<ConsolidatedInventoryRow>(
+  type InventoryRow = Omit<ConsolidatedInventoryRow, "old_material_definition"> & OldMaterialDefinitionProjection;
+  const rows = await db.query<InventoryRow>(
     `SELECT
        b.article_id::text AS article_id, a.code AS article_code, a.designation AS article_designation,
+       a.article_category::text AS material_article_category,
+       a.designation AS material_designation,
+       COALESCE(article_material.family_code, a.family_code)::text AS material_profile_code,
+       material_nuance.code::text AS material_nuance_code,
+       material_etat.code::text AS material_etat_code,
+       material_sous_etat.code::text AS material_sous_etat_code,
+       COALESCE(
+         article_material.longueur_brut_mm,
+         article_material.longueur_coupe_mm,
+         article_material.longueur_mm,
+         article_material.longueur_unitaire_mm
+       )::float8 AS material_longueur_mm,
+       article_material.largeur_mm::float8 AS material_largeur_mm,
+       article_material.hauteur_mm::float8 AS material_hauteur_mm,
+       article_material.epaisseur_mm::float8 AS material_epaisseur_mm,
+       article_material.diametre_mm::float8 AS material_diametre_mm,
        COALESCE(m.stock_scope, w.stock_scope, 'NEW')::text AS scope,
        COALESCE(m.id, '00000000-0000-0000-0000-000000000000')::text AS magasin_id,
        COALESCE(m.code, m.code_magasin, w.code)::text AS magasin_code,
@@ -5340,7 +5451,41 @@ export async function repoListConsolidatedInventory(
      LIMIT $${values.length + 1} OFFSET $${values.length + 2}`,
     [...values, pageSize, offset]
   );
-  return { items: rows.rows, total: count.rows[0]?.total ?? 0 };
+  const items = rows.rows.map((row): ConsolidatedInventoryRow => {
+    const {
+      material_article_category,
+      material_designation,
+      material_profile_code,
+      material_nuance_code,
+      material_etat_code,
+      material_sous_etat_code,
+      material_longueur_mm,
+      material_largeur_mm,
+      material_hauteur_mm,
+      material_epaisseur_mm,
+      material_diametre_mm,
+      ...inventoryRow
+    } = row;
+    const projection: OldMaterialDefinitionProjection = {
+      material_article_category,
+      material_designation,
+      material_profile_code,
+      material_nuance_code,
+      material_etat_code,
+      material_sous_etat_code,
+      material_longueur_mm,
+      material_largeur_mm,
+      material_hauteur_mm,
+      material_epaisseur_mm,
+      material_diametre_mm,
+    };
+    return {
+      ...inventoryRow,
+      old_material_definition:
+        inventoryRow.scope === "OLD" ? oldMaterialDefinitionFromProjection(projection) : null,
+    };
+  });
+  return { items, total: count.rows[0]?.total ?? 0 };
 }
 
 async function ensureHistoricalPositionTx(client: PoolClient, kind: "PF" | "MP", shelf: string, audit: AuditContext) {
@@ -5415,7 +5560,7 @@ export async function repoCreateHistoricalImport(body: HistoricalImportBodyDTO, 
       if (body.article_id) articleId = body.article_id;
       else if (body.article) articleId = (await repoCreateArticleTx(client, body.article, audit)).id;
       else throw new HttpError(400, "ARTICLE_REQUIRED", "Article matière requis.");
-      const a = await client.query<{ category: string; nuance: string | null }>(`SELECT a.article_category::text AS category, n.code AS nuance FROM public.articles a LEFT JOIN public.articles_matiere am ON am.article_id=a.id LEFT JOIN public.matiere_nuances n ON n.id=am.nuance_id WHERE a.id=$1::uuid FOR UPDATE`, [articleId]);
+      const a = await client.query<{ category: string; nuance: string | null }>(`SELECT a.article_category::text AS category, n.code AS nuance FROM public.articles a LEFT JOIN public.articles_matiere am ON am.article_id=a.id LEFT JOIN public.stock_nuances n ON n.id=am.nuance_id WHERE a.id=$1::uuid FOR UPDATE`, [articleId]);
       if (a.rows[0]?.category !== "matiere") throw new HttpError(422, "MP_ARTICLE_REQUIRED", "L'import MP requiert un article matière première.");
       shelf = a.rows[0]?.nuance?.trim() || "SANS-NUANCE";
     } else {

--- a/src/module/stock/types/stock.types.ts
+++ b/src/module/stock/types/stock.types.ts
@@ -8,7 +8,7 @@ export type Paginated<T> = {
 
 export type HistoricalStockImport = { article_id: string; lot_id: string; movement_id: string; stock_trace_code: string; qr_payload: string; replayed: boolean };
 export type ConsolidatedInventoryRow = {
-  article_id: string; article_code: string; article_designation: string; scope: "OLD" | "NEW";
+  article_id: string; article_code: string; article_designation: string; old_material_definition: string | null; scope: "OLD" | "NEW";
   magasin_id: string; magasin_code: string; rayon_code: string; lot_id: string | null; lot_code: string | null;
   stock_trace_code: string | null; qr_payload: string | null; qty_total: number; qty_reserved: number; qty_available: number;
   updated_at: string;
@@ -162,6 +162,7 @@ export type StockArticleListItem = {
   projet_id: number | null;
   code: string;
   designation: string;
+  old_material_definition?: string | null;
   designation_secondary: string | null;
   article_type: ArticleType;
   article_category: ArticleCategory;


### PR DESCRIPTION
## Livraison
- corrige les imports historiques PF/MP en Base OLD
- utilise la table canonique stock_nuances
- dérive le libellé matière OLD attendu sans modifier les codes articles

## Validation
- suite complète, typecheck et build backend verts
- aucun patch SQL supplémentaire
- rollback : redéployer le SHA précédent

Closes #446

## Summary by Sourcery

Repair Base OLD stock material labeling by deriving workshop material definitions from canonical referential data and wiring them into article and inventory listings while aligning MP imports with the stock_nuances referential.

New Features:
- Expose an OLD material definition label for articles and consolidated inventory rows based on material referential data.

Bug Fixes:
- Resolve MP historical imports using the canonical stock_nuances table instead of the legacy matiere_nuances referential.

Enhancements:
- Introduce a helper to reconstruct legacy material definitions from structured material attributes and article designations, skipping ambiguous cases.
- Populate article and inventory queries with structured material attributes required to compute OLD material definitions, without altering existing article codes.

Tests:
- Add unit tests covering OLD material definition reconstruction for various material profiles and ambiguity cases.
- Extend migration guard tests to assert that historical imports now use the stock_nuances referential.