### PR TITLE
release: PF Base OLD schema compatibility (#446)

### DIFF
--- a/src/__tests__/stock-old-new-446.migration-guards.test.ts
+++ b/src/__tests__/stock-old-new-446.migration-guards.test.ts
@@ -154,6 +154,15 @@ describe("#446 Base OLD corrective guards", () => {
     expect(historicalImportSource).not.toContain("public.matiere_nuances");
   });
 
+  it("creates a historical PF without depending on the obsolete central family catalog", () => {
+    const historicalImportStart = stockRepository.indexOf("export async function repoCreateHistoricalImport");
+    const historicalImportEnd = stockRepository.indexOf("export async function repoListBalances");
+    const historicalImportSource = stockRepository.slice(historicalImportStart, historicalImportEnd);
+
+    expect(historicalImportSource).toContain('defaultFamilyCodeForCategory("fabrique")');
+    expect(historicalImportSource).not.toContain("public.article_families");
+  });
+
   it("adds the OLD and NEW navigation shortcuts without replacing existing keys", () => {
     expect(navigationPatch).toContain("BEGIN;");
     expect(navigationPatch).toContain("COMMIT;");

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -5568,8 +5568,7 @@ export async function repoCreateHistoricalImport(body: HistoricalImportBodyDTO, 
       const existing = await client.query<{ id: string }>(`SELECT id::text AS id FROM public.articles WHERE piece_technique_id=$1::uuid LIMIT 1 FOR UPDATE`, [ptId]);
       if (existing.rows[0]?.id) articleId = existing.rows[0].id;
       else {
-        const family = body.family_code ?? (await client.query<{ code: string }>(`SELECT code FROM public.article_families WHERE category='fabrique' AND is_active=true ORDER BY code LIMIT 1`)).rows[0]?.code;
-        if (!family) throw new HttpError(422, "PF_FAMILY_REQUIRED", "Aucune famille active de produits fabriqués n'est disponible.");
+        const family = body.family_code ?? defaultFamilyCodeForCategory("fabrique");
         articleId = (await repoCreateArticleTx(client, { designation: body.designation, article_type: "PIECE_TECHNIQUE", article_category: "fabrique", article_categories: ["piece_finie_fabriquee"], family_code: family, piece_technique_id: ptId, stock_managed: true, lot_tracking: true, is_sold: true, is_active: true, status: "VALIDE" }, audit)).id;
       }
       shelf = body.client_number.trim();


### PR DESCRIPTION
Correctif issu de la recette réelle cerp_test : suppression de la lecture de colonnes inexistantes dans article_families, avec fallback PF canonique PT. Tests ciblés, TypeScript et build verts. Aucun SQL. Rollback par redéploiement du SHA précédent.

## Summary by Sourcery

Ensure historical PF imports remain compatible with the OLD schema by removing reliance on obsolete article family tables and using canonical defaults instead.

Bug Fixes:
- Avoid failures when importing historical PF data on bases where the central article_families catalog is missing by falling back to a default family code.

Tests:
- Extend migration guard tests to verify historical PF creation no longer depends on the obsolete central family catalog.