### PR TITLE
fix(stock): verrouiller uniquement l’article MP OLD (#446)

### DIFF
--- a/src/__tests__/stock-old-new-446.migration-guards.test.ts
+++ b/src/__tests__/stock-old-new-446.migration-guards.test.ts
@@ -152,6 +152,8 @@ describe("#446 Base OLD corrective guards", () => {
 
     expect(historicalImportSource).toContain("public.stock_nuances");
     expect(historicalImportSource).not.toContain("public.matiere_nuances");
+    expect(historicalImportSource).toContain("FOR UPDATE OF a");
+    expect(historicalImportSource).not.toMatch(/WHERE a\.id=\$1::uuid FOR UPDATE`/);
   });
 
   it("creates a historical PF without depending on the obsolete central family catalog", () => {

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -5560,7 +5560,7 @@ export async function repoCreateHistoricalImport(body: HistoricalImportBodyDTO, 
       if (body.article_id) articleId = body.article_id;
       else if (body.article) articleId = (await repoCreateArticleTx(client, body.article, audit)).id;
       else throw new HttpError(400, "ARTICLE_REQUIRED", "Article matière requis.");
-      const a = await client.query<{ category: string; nuance: string | null }>(`SELECT a.article_category::text AS category, n.code AS nuance FROM public.articles a LEFT JOIN public.articles_matiere am ON am.article_id=a.id LEFT JOIN public.stock_nuances n ON n.id=am.nuance_id WHERE a.id=$1::uuid FOR UPDATE`, [articleId]);
+      const a = await client.query<{ category: string; nuance: string | null }>(`SELECT a.article_category::text AS category, n.code AS nuance FROM public.articles a LEFT JOIN public.articles_matiere am ON am.article_id=a.id LEFT JOIN public.stock_nuances n ON n.id=am.nuance_id WHERE a.id=$1::uuid FOR UPDATE OF a`, [articleId]);
       if (a.rows[0]?.category !== "matiere") throw new HttpError(422, "MP_ARTICLE_REQUIRED", "L'import MP requiert un article matière première.");
       shelf = a.rows[0]?.nuance?.trim() || "SANS-NUANCE";
     } else {


### PR DESCRIPTION
La recette MP réelle a révélé PostgreSQL 0A000 : FOR UPDATE était appliqué au côté nullable de LEFT JOIN. Le verrou est maintenant limité à la ligne articles avec FOR UPDATE OF a. Garde de non-régression, 20 tests ciblés, TypeScript et build verts. Aucun SQL.

## Summary by Sourcery

Restrict row-level locking in historical import creation to the articles table to avoid PostgreSQL errors while preserving behavior for MP OLD imports.

Bug Fixes:
- Fix historical MP import query by applying FOR UPDATE only to the articles table instead of the nullable side of a LEFT JOIN to prevent PostgreSQL 0A000 errors.

Tests:
- Extend migration guard tests for MP OLD stock imports to assert the corrected FOR UPDATE OF a locking behavior and guard against regressions.