### PR TITLE
release: MP Base OLD row-lock compatibility (#446)

### DIFF
--- a/src/__tests__/stock-old-new-446.migration-guards.test.ts
+++ b/src/__tests__/stock-old-new-446.migration-guards.test.ts
@@ -152,6 +152,8 @@ describe("#446 Base OLD corrective guards", () => {
 
     expect(historicalImportSource).toContain("public.stock_nuances");
     expect(historicalImportSource).not.toContain("public.matiere_nuances");
+    expect(historicalImportSource).toContain("FOR UPDATE OF a");
+    expect(historicalImportSource).not.toMatch(/WHERE a\.id=\$1::uuid FOR UPDATE`/);
   });
 
   it("creates a historical PF without depending on the obsolete central family catalog", () => {

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -5560,7 +5560,7 @@ export async function repoCreateHistoricalImport(body: HistoricalImportBodyDTO, 
       if (body.article_id) articleId = body.article_id;
       else if (body.article) articleId = (await repoCreateArticleTx(client, body.article, audit)).id;
       else throw new HttpError(400, "ARTICLE_REQUIRED", "Article matière requis.");
-      const a = await client.query<{ category: string; nuance: string | null }>(`SELECT a.article_category::text AS category, n.code AS nuance FROM public.articles a LEFT JOIN public.articles_matiere am ON am.article_id=a.id LEFT JOIN public.stock_nuances n ON n.id=am.nuance_id WHERE a.id=$1::uuid FOR UPDATE`, [articleId]);
+      const a = await client.query<{ category: string; nuance: string | null }>(`SELECT a.article_category::text AS category, n.code AS nuance FROM public.articles a LEFT JOIN public.articles_matiere am ON am.article_id=a.id LEFT JOIN public.stock_nuances n ON n.id=am.nuance_id WHERE a.id=$1::uuid FOR UPDATE OF a`, [articleId]);
       if (a.rows[0]?.category !== "matiere") throw new HttpError(422, "MP_ARTICLE_REQUIRED", "L'import MP requiert un article matière première.");
       shelf = a.rows[0]?.nuance?.trim() || "SANS-NUANCE";
     } else {


### PR DESCRIPTION
Correctif de recette cerp_test : PostgreSQL refuse FOR UPDATE sur le côté nullable d’un LEFT JOIN. Le verrou cible désormais seulement articles. Tests ciblés, TypeScript et build verts. Aucun SQL; rollback par SHA précédent.

## Summary by Sourcery

Adjust historical import locking to maintain compatibility with PostgreSQL row-locking rules for LEFT JOINs.

Bug Fixes:
- Restrict the FOR UPDATE lock in historical import queries to the articles table to avoid PostgreSQL errors on nullable LEFT JOIN sides.

Tests:
- Extend migration guard tests to assert the corrected FOR UPDATE clause and absence of the previous invalid locking pattern.