### PR TITLE
fix(db): register SOL-11 immutable patch

### DIFF
--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -29,6 +29,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "3e223c43698bdf3399ab2d37e6493d0d014952eb0fe877cdeb1c4b4f7f7db3da",
   "20260810_stock_old_new_navigation_446.sql":
     "4900f01411ab89349874fcd6d28993aa34a1ec560320d4d32b05489800bf3b9b",
+  "20260811_ged_antivirus_quarantine.sql":
+    "7e1e026c8a16be2609f072434d1930afbd248a543d96e3b013e89426fdaa1336",
 });
 const REALTIME_V1_FILENAME = "20260804_realtime_shared_control_plane.sql";
 const REALTIME_V1_SHA256 = "a532c87aa9962b6171b65db421ee82069ed177bf6f5becb52295df4dacbc76f6";

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -44,6 +44,9 @@ const planningPatchFilename = "20260805_planning_convergence_governance.sql";
 const stockNavigationPatchFilename = "20260810_stock_old_new_navigation_446.sql";
 const stockNavigationPatchChecksum =
   "4900f01411ab89349874fcd6d28993aa34a1ec560320d4d32b05489800bf3b9b";
+const gedAntivirusPatchFilename = "20260811_ged_antivirus_quarantine.sql";
+const gedAntivirusPatchChecksum =
+  "7e1e026c8a16be2609f072434d1930afbd248a543d96e3b013e89426fdaa1336";
 const wave9PatchChecksums = new Map([
   [
     "20260216_planning_visuals_programmation.sql",
@@ -136,6 +139,12 @@ describe("database patch runner", () => {
     );
     expect(runner.sha256Sql(stockNavigationPatch)).toBe(stockNavigationPatchChecksum);
 
+    const gedAntivirusPatch = readFileSync(
+      resolve(repoRoot, "db/patches", gedAntivirusPatchFilename),
+      "utf8"
+    );
+    expect(runner.sha256Sql(gedAntivirusPatch)).toBe(gedAntivirusPatchChecksum);
+
     for (const [filename, checksum] of wave9PatchChecksums) {
       const sql = readFileSync(resolve(repoRoot, "db/patches", filename), "utf8");
       expect(runner.sha256Sql(sql)).toBe(checksum);
@@ -171,6 +180,13 @@ describe("database patch runner", () => {
     });
     expect(runner.parseArgs(["up", "--only", stockNavigationPatchFilename]).only).toBe(
       stockNavigationPatchFilename
+    );
+    expect(runner.immutableOnlyPatch(patches, gedAntivirusPatchFilename)).toMatchObject({
+      filename: gedAntivirusPatchFilename,
+      sha256: gedAntivirusPatchChecksum,
+    });
+    expect(runner.parseArgs(["up", "--only", gedAntivirusPatchFilename]).only).toBe(
+      gedAntivirusPatchFilename
     );
     for (const [filename, checksum] of wave9PatchChecksums) {
       expect(runner.immutableOnlyPatch(patches, filename)).toMatchObject({


### PR DESCRIPTION
Follow-up SOL-11: register the quarantine migration checksum so operators can run the reviewed patch alone with the guarded --only workflow. Targeted runner and migration-guard tests: 25 passed.

## Summary by Sourcery

Register the new GED antivirus quarantine database patch as an immutable, checksum-verified patch that can be targeted via the guarded --only workflow.

Enhancements:
- Extend the database patch runner and immutable patch registry to include the SOL-11 GED antivirus quarantine migration with its fixed checksum.

Tests:
- Add runner tests to validate checksum computation and --only handling for the GED antivirus quarantine immutable patch.