### PR TITLE
fix(db): register recent SOL migrations

### DIFF
--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -29,6 +29,14 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "3e223c43698bdf3399ab2d37e6493d0d014952eb0fe877cdeb1c4b4f7f7db3da",
   "20260810_stock_old_new_navigation_446.sql":
     "4900f01411ab89349874fcd6d28993aa34a1ec560320d4d32b05489800bf3b9b",
+  "20260803_admin_user_provisioning_boundary.sql":
+    "c1b706a1d9ba046e63e7e0b05dfc132272bb27fccda7bd0efe8cf481ffbd5ca5",
+  "20260809_account_invitation_activation.sql":
+    "07fb4d08c4cd0bcf07abd1eb295a30db61b5d64f66d00406f4a24a4291fa4911",
+  "20260810_stock_movement_event_correlation.sql":
+    "736887f658a39504d7cd499cd6b630e05eba0e7fcaa8ecda9f3d92083a1278be",
+  "20260810_system_reference_data_readiness.sql":
+    "9be8c63bf5c0a1a12ac43c2e684ef7d6ffe454171fd58461ee8c8c25c03004f9",
   "20260811_ged_antivirus_quarantine.sql":
     "7e1e026c8a16be2609f072434d1930afbd248a543d96e3b013e89426fdaa1336",
 });

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -47,6 +47,24 @@ const stockNavigationPatchChecksum =
 const gedAntivirusPatchFilename = "20260811_ged_antivirus_quarantine.sql";
 const gedAntivirusPatchChecksum =
   "7e1e026c8a16be2609f072434d1930afbd248a543d96e3b013e89426fdaa1336";
+const recentSolPatchChecksums = new Map([
+  [
+    "20260803_admin_user_provisioning_boundary.sql",
+    "c1b706a1d9ba046e63e7e0b05dfc132272bb27fccda7bd0efe8cf481ffbd5ca5",
+  ],
+  [
+    "20260809_account_invitation_activation.sql",
+    "07fb4d08c4cd0bcf07abd1eb295a30db61b5d64f66d00406f4a24a4291fa4911",
+  ],
+  [
+    "20260810_stock_movement_event_correlation.sql",
+    "736887f658a39504d7cd499cd6b630e05eba0e7fcaa8ecda9f3d92083a1278be",
+  ],
+  [
+    "20260810_system_reference_data_readiness.sql",
+    "9be8c63bf5c0a1a12ac43c2e684ef7d6ffe454171fd58461ee8c8c25c03004f9",
+  ],
+]);
 const wave9PatchChecksums = new Map([
   [
     "20260216_planning_visuals_programmation.sql",
@@ -145,6 +163,11 @@ describe("database patch runner", () => {
     );
     expect(runner.sha256Sql(gedAntivirusPatch)).toBe(gedAntivirusPatchChecksum);
 
+    for (const [filename, checksum] of recentSolPatchChecksums) {
+      const sql = readFileSync(resolve(repoRoot, "db/patches", filename), "utf8");
+      expect(runner.sha256Sql(sql)).toBe(checksum);
+    }
+
     for (const [filename, checksum] of wave9PatchChecksums) {
       const sql = readFileSync(resolve(repoRoot, "db/patches", filename), "utf8");
       expect(runner.sha256Sql(sql)).toBe(checksum);
@@ -188,6 +211,13 @@ describe("database patch runner", () => {
     expect(runner.parseArgs(["up", "--only", gedAntivirusPatchFilename]).only).toBe(
       gedAntivirusPatchFilename
     );
+    for (const [filename, checksum] of recentSolPatchChecksums) {
+      expect(runner.immutableOnlyPatch(patches, filename)).toMatchObject({
+        filename,
+        sha256: checksum,
+      });
+      expect(runner.parseArgs(["up", "--only", filename]).only).toBe(filename);
+    }
     for (const [filename, checksum] of wave9PatchChecksums) {
       expect(runner.immutableOnlyPatch(patches, filename)).toMatchObject({
         filename,


### PR DESCRIPTION
Register exact canonical SHA-256 values for the remaining SOL-02, SOL-05 and SOL-06 patches so each can be applied independently with the guarded --only runner. Targeted migration/runner tests: 33 passed.

## Summary by Sourcery

Register recent SOL database patches as immutable-only migrations and extend tests to cover their SHA-256 checksums and guarded --only execution.

Bug Fixes:
- Allow targeted execution of recent SOL-02, SOL-05, and SOL-06 migrations using the guarded --only patch runner by registering their canonical checksums.

Enhancements:
- Add checksum coverage for recent SOL database patches in the patch runner tests.