### PR TITLE
fix(auth): repair account provisioning schema drift

### DIFF
--- a/db/patches/20260811_account_provisioning_schema_repair.sql
+++ b/db/patches/20260811_account_provisioning_schema_repair.sql
@@ -1,0 +1,95 @@
+-- SOL-02 production drift repair.
+-- Recreates the final account-provisioning tables when an older ledger claims
+-- password-reset support was applied but the runtime table is absent.
+
+BEGIN;
+
+DO $preflight$
+BEGIN
+  IF to_regclass('public.users') IS NULL
+     OR to_regclass('public.erp_audit_logs') IS NULL
+     OR to_regclass('public.realtime_session_epochs') IS NULL
+     OR to_regclass('public.realtime_authorization_epoch') IS NULL THEN
+    RAISE EXCEPTION 'SOL-02 repair: required account and realtime tables are missing';
+  END IF;
+
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'SOL-02 repair: required cerp_app role is missing';
+  END IF;
+END
+$preflight$;
+
+CREATE TABLE IF NOT EXISTS public.password_reset_tokens (
+  id UUID PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES public.users(id) ON DELETE CASCADE,
+  token_hash TEXT NOT NULL,
+  expires_at TIMESTAMP WITHOUT TIME ZONE NOT NULL,
+  used_at TIMESTAMP WITHOUT TIME ZONE NULL,
+  created_at TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now(),
+  created_by INTEGER NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  idempotency_key UUID NULL,
+  request_hash CHAR(64) NULL
+    CHECK (request_hash IS NULL OR request_hash ~ '^[0-9a-f]{64}$')
+);
+
+ALTER TABLE public.password_reset_tokens
+  ADD COLUMN IF NOT EXISTS created_by INTEGER NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  ADD COLUMN IF NOT EXISTS idempotency_key UUID NULL,
+  ADD COLUMN IF NOT EXISTS request_hash CHAR(64) NULL
+    CHECK (request_hash IS NULL OR request_hash ~ '^[0-9a-f]{64}$');
+
+CREATE INDEX IF NOT EXISTS password_reset_tokens_user_id_idx
+  ON public.password_reset_tokens (user_id);
+CREATE INDEX IF NOT EXISTS password_reset_tokens_expires_at_idx
+  ON public.password_reset_tokens (expires_at);
+CREATE UNIQUE INDEX IF NOT EXISTS password_reset_tokens_user_hash_uq
+  ON public.password_reset_tokens (user_id, token_hash);
+CREATE UNIQUE INDEX IF NOT EXISTS password_reset_tokens_actor_idempotency_uq
+  ON public.password_reset_tokens (created_by, idempotency_key)
+  WHERE created_by IS NOT NULL AND idempotency_key IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS public.admin_account_invitations (
+  id UUID PRIMARY KEY,
+  user_id INTEGER NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_by INTEGER NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  idempotency_key UUID NOT NULL,
+  request_hash CHAR(64) NOT NULL CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+  token_hash CHAR(64) NOT NULL CHECK (token_hash ~ '^[0-9a-f]{64}$'),
+  created_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  accepted_at TIMESTAMPTZ NULL,
+  revoked_at TIMESTAMPTZ NULL,
+  CONSTRAINT admin_account_invitations_actor_idempotency_uq
+    UNIQUE (created_by, idempotency_key),
+  CONSTRAINT admin_account_invitations_timeline_ck CHECK (
+    expires_at > created_at
+    AND (accepted_at IS NULL OR accepted_at >= created_at)
+    AND (revoked_at IS NULL OR revoked_at >= created_at)
+    AND NOT (accepted_at IS NOT NULL AND revoked_at IS NOT NULL)
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS admin_account_invitations_token_hash_uq
+  ON public.admin_account_invitations (token_hash);
+CREATE INDEX IF NOT EXISTS admin_account_invitations_user_created_idx
+  ON public.admin_account_invitations (user_id, created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS admin_account_invitations_one_open_per_user_uq
+  ON public.admin_account_invitations (user_id)
+  WHERE accepted_at IS NULL AND revoked_at IS NULL;
+
+ALTER TABLE public.password_reset_tokens OWNER TO cerp_app;
+ALTER TABLE public.admin_account_invitations OWNER TO cerp_app;
+
+REVOKE ALL ON TABLE public.password_reset_tokens FROM PUBLIC;
+REVOKE ALL ON TABLE public.admin_account_invitations FROM PUBLIC;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.password_reset_tokens TO cerp_app;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.admin_account_invitations TO cerp_app;
+
+COMMENT ON TABLE public.password_reset_tokens IS
+  'Single-use password reset tokens. Token material is stored only as a hash.';
+COMMENT ON TABLE public.admin_account_invitations IS
+  'Idempotent administrative invitations. Only a signed, unexpired token can activate its inactive account.';
+COMMENT ON COLUMN public.password_reset_tokens.idempotency_key IS
+  'Administrative reset creation retry key; NULL for legacy or public-reset tokens.';
+
+COMMIT;

--- a/db/patches/support/20260811_account_provisioning_schema_repair.preflight.sql
+++ b/db/patches/support/20260811_account_provisioning_schema_repair.preflight.sql
@@ -1,0 +1,11 @@
+-- Read-only preflight for the SOL-02 schema-drift repair.
+
+SELECT
+  current_database() IN ('cerp_test', 'cerp_prod') AS approved_database,
+  to_regclass('public.users') IS NOT NULL AS users_present,
+  to_regclass('public.erp_audit_logs') IS NOT NULL AS audit_present,
+  to_regclass('public.realtime_session_epochs') IS NOT NULL AS session_epochs_present,
+  to_regclass('public.realtime_authorization_epoch') IS NOT NULL AS authorization_epoch_present,
+  EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') AS cerp_app_role_present,
+  to_regclass('public.password_reset_tokens') IS NOT NULL AS password_reset_tokens_present,
+  to_regclass('public.admin_account_invitations') IS NOT NULL AS invitations_present;

--- a/db/patches/support/20260811_account_provisioning_schema_repair.rollback.sql
+++ b/db/patches/support/20260811_account_provisioning_schema_repair.rollback.sql
@@ -1,0 +1,10 @@
+-- Production rollback is restoration into a fresh database from the validated
+-- pre-migration dump. Destructive in-place rollback is intentionally refused
+-- because reset/invitation rows are security audit evidence.
+
+DO $rollback$
+BEGIN
+  RAISE EXCEPTION
+    'SOL-02 repair rollback requires restoration of the validated pre-migration backup into a fresh database';
+END
+$rollback$;

--- a/db/patches/support/20260811_account_provisioning_schema_repair.verify.sql
+++ b/db/patches/support/20260811_account_provisioning_schema_repair.verify.sql
@@ -1,0 +1,45 @@
+-- Read-only verification for the SOL-02 schema-drift repair. Every boolean must be true.
+
+SELECT
+  to_regclass('public.password_reset_tokens') IS NOT NULL AS password_reset_tokens_present,
+  to_regclass('public.admin_account_invitations') IS NOT NULL AS invitations_present,
+  (SELECT tableowner = 'cerp_app' FROM pg_tables
+    WHERE schemaname = 'public' AND tablename = 'password_reset_tokens') AS reset_owner_is_cerp_app,
+  (SELECT tableowner = 'cerp_app' FROM pg_tables
+    WHERE schemaname = 'public' AND tablename = 'admin_account_invitations') AS invitation_owner_is_cerp_app,
+  has_table_privilege('cerp_app', 'public.password_reset_tokens', 'SELECT,INSERT,UPDATE,DELETE')
+    AS reset_runtime_privileges,
+  has_table_privilege('cerp_app', 'public.admin_account_invitations', 'SELECT,INSERT,UPDATE,DELETE')
+    AS invitation_runtime_privileges,
+  NOT EXISTS (
+    SELECT 1
+    FROM pg_class relation
+    CROSS JOIN LATERAL aclexplode(
+      COALESCE(relation.relacl, acldefault('r', relation.relowner))
+    ) privilege
+    WHERE relation.oid = 'public.password_reset_tokens'::regclass
+      AND privilege.grantee = 0
+      AND privilege.privilege_type IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE')
+  ) AS reset_not_public,
+  NOT EXISTS (
+    SELECT 1
+    FROM pg_class relation
+    CROSS JOIN LATERAL aclexplode(
+      COALESCE(relation.relacl, acldefault('r', relation.relowner))
+    ) privilege
+    WHERE relation.oid = 'public.admin_account_invitations'::regclass
+      AND privilege.grantee = 0
+      AND privilege.privilege_type IN ('SELECT', 'INSERT', 'UPDATE', 'DELETE')
+  ) AS invitation_not_public,
+  EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = 'password_reset_tokens'
+      AND indexname = 'password_reset_tokens_actor_idempotency_uq'
+  ) AS reset_idempotency_guard,
+  EXISTS (
+    SELECT 1 FROM pg_indexes
+    WHERE schemaname = 'public'
+      AND tablename = 'admin_account_invitations'
+      AND indexname = 'admin_account_invitations_one_open_per_user_uq'
+  ) AS invitation_single_open_guard;

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -37,6 +37,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "736887f658a39504d7cd499cd6b630e05eba0e7fcaa8ecda9f3d92083a1278be",
   "20260810_system_reference_data_readiness.sql":
     "9be8c63bf5c0a1a12ac43c2e684ef7d6ffe454171fd58461ee8c8c25c03004f9",
+  "20260811_account_provisioning_schema_repair.sql":
+    "e4a994888e3ff0dc38923a128216647f76919d4001efc70e26219742befca116",
   "20260811_ged_antivirus_quarantine.sql":
     "7e1e026c8a16be2609f072434d1930afbd248a543d96e3b013e89426fdaa1336",
 });

--- a/src/__tests__/account-provisioning-schema-repair.migration-guards.test.ts
+++ b/src/__tests__/account-provisioning-schema-repair.migration-guards.test.ts
@@ -1,0 +1,26 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("SOL-02 account provisioning schema repair", () => {
+  const read = (name: string) => fs.readFileSync(path.join(process.cwd(), "db", "patches", name), "utf8");
+
+  it("recreates the final tables with runtime ownership and no public access", () => {
+    const patch = read("20260811_account_provisioning_schema_repair.sql");
+    const preflight = read("support/20260811_account_provisioning_schema_repair.preflight.sql");
+    const verify = read("support/20260811_account_provisioning_schema_repair.verify.sql");
+    const rollback = read("support/20260811_account_provisioning_schema_repair.rollback.sql");
+
+    expect(patch).toMatch(/^BEGIN;/m);
+    expect(patch).toMatch(/CREATE TABLE IF NOT EXISTS public\.password_reset_tokens/);
+    expect(patch).toMatch(/CREATE TABLE IF NOT EXISTS public\.admin_account_invitations/);
+    expect(patch).toMatch(/OWNER TO cerp_app/g);
+    expect(patch).toMatch(/REVOKE ALL ON TABLE public\.password_reset_tokens FROM PUBLIC/);
+    expect(patch).toMatch(/password_reset_tokens_actor_idempotency_uq/);
+    expect(patch).toMatch(/admin_account_invitations_one_open_per_user_uq/);
+    expect(preflight).toMatch(/current_database\(\) IN \('cerp_test', 'cerp_prod'\)/);
+    expect(verify).toMatch(/reset_owner_is_cerp_app/);
+    expect(verify).toMatch(/invitation_not_public/);
+    expect(rollback).toMatch(/requires restoration of the validated pre-migration backup/);
+  });
+});

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -64,6 +64,10 @@ const recentSolPatchChecksums = new Map([
     "20260810_system_reference_data_readiness.sql",
     "9be8c63bf5c0a1a12ac43c2e684ef7d6ffe454171fd58461ee8c8c25c03004f9",
   ],
+  [
+    "20260811_account_provisioning_schema_repair.sql",
+    "e4a994888e3ff0dc38923a128216647f76919d4001efc70e26219742befca116",
+  ],
 ]);
 const wave9PatchChecksums = new Map([
   [


### PR DESCRIPTION
Both cerp_test and cerp_prod have the legacy password-reset migration recorded but the runtime table is absent. This additive repair recreates the final reset/invitation schema, enforces cerp_app ownership and runtime grants, removes PUBLIC access, ships read-only preflight/verify plus restore-only rollback guidance, and registers the immutable checksum. Targeted tests: 23 passed.

## Summary by Sourcery

Repair drift in the account provisioning schema by recreating password reset and admin invitation tables with correct ownership and access controls and registering the patch as immutable.

Enhancements:
- Add a SOL-02 account provisioning schema repair migration that recreates missing password reset and admin invitation tables with idempotency and timeline constraints.
- Ensure cerp_app owns the account provisioning tables and has explicit runtime privileges while removing PUBLIC access.
- Provide read-only preflight and verification SQL helpers plus a rollback guard that mandates restoring from a validated pre-migration backup.

Build:
- Register the new account provisioning schema repair patch as an immutable database patch with its checksum in the patch runner and scripts.

Tests:
- Add migration guard tests to assert the repair patch, its support scripts, and security constraints are present and correctly wired into the patch system.