### PR TITLE
fix(db): register canonical unit migration

### DIFF
--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -31,6 +31,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "4900f01411ab89349874fcd6d28993aa34a1ec560320d4d32b05489800bf3b9b",
   "20260803_admin_user_provisioning_boundary.sql":
     "c1b706a1d9ba046e63e7e0b05dfc132272bb27fccda7bd0efe8cf481ffbd5ca5",
+  "20260804_article_unit_stock_contract.sql":
+    "cd7b4bba961e2b9783cb3046e3f3dba794b8ce68c8252377f3ecbe105007d607",
   "20260809_account_invitation_activation.sql":
     "07fb4d08c4cd0bcf07abd1eb295a30db61b5d64f66d00406f4a24a4291fa4911",
   "20260810_stock_movement_event_correlation.sql":

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -53,6 +53,10 @@ const recentSolPatchChecksums = new Map([
     "c1b706a1d9ba046e63e7e0b05dfc132272bb27fccda7bd0efe8cf481ffbd5ca5",
   ],
   [
+    "20260804_article_unit_stock_contract.sql",
+    "cd7b4bba961e2b9783cb3046e3f3dba794b8ce68c8252377f3ecbe105007d607",
+  ],
+  [
     "20260809_account_invitation_activation.sql",
     "07fb4d08c4cd0bcf07abd1eb295a30db61b5d64f66d00406f4a24a4291fa4911",
   ],


### PR DESCRIPTION
SOL-06 preflight on restored cerp_test/prod backups found that mm, m and kg are absent. Register the existing reviewed 20260804 unit contract by exact checksum so it can be applied alone before SOL-06. Targeted runner, migration and runtime tests: 38 passed.

## Summary by Sourcery

Register the canonical article unit stock contract migration as an immutable DB patch and include it in recent patch checksum coverage.

Enhancements:
- Add the 20260804_article_unit_stock_contract.sql migration to the immutable-only DB patches list with its exact checksum.

Tests:
- Extend db-patches runner tests to cover the 20260804_article_unit_stock_contract.sql checksum.