### PR TITLE
fix(db): repair missing canonical base unit

### DIFF
--- a/db/patches/20260811_base_unit_drift_repair.sql
+++ b/db/patches/20260811_base_unit_drift_repair.sql
@@ -1,0 +1,54 @@
+-- SOL-06 drift repair: restore the canonical base unit when the historical
+-- 20260223 seed is present in the ledger but its reference row is absent.
+
+BEGIN;
+
+DO $preflight$
+BEGIN
+  IF to_regclass('public.units') IS NULL THEN
+    RAISE EXCEPTION 'SOL-06 unit repair: public.units is missing';
+  END IF;
+  IF (SELECT count(*) FROM public.units WHERE lower(code::text) = 'u') > 1 THEN
+    RAISE EXCEPTION 'SOL-06 unit repair: duplicate case-insensitive u codes must be reconciled';
+  END IF;
+END
+$preflight$;
+
+CREATE TABLE IF NOT EXISTS public.cerp_patch_20260811_base_unit_repair (
+  code TEXT PRIMARY KEY,
+  unit_id TEXT NOT NULL,
+  inserted_by_patch BOOLEAN NOT NULL,
+  recorded_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+DO $repair$
+DECLARE
+  v_unit_id TEXT;
+  v_inserted BOOLEAN := false;
+BEGIN
+  SELECT id::text INTO v_unit_id
+  FROM public.units
+  WHERE lower(code::text) = 'u'
+  LIMIT 1;
+
+  IF v_unit_id IS NULL THEN
+    INSERT INTO public.units (code, label)
+    VALUES ('u', 'Unite')
+    RETURNING id::text INTO v_unit_id;
+    v_inserted := true;
+  END IF;
+
+  INSERT INTO public.cerp_patch_20260811_base_unit_repair (
+    code,
+    unit_id,
+    inserted_by_patch
+  )
+  VALUES ('u', v_unit_id, v_inserted)
+  ON CONFLICT (code) DO UPDATE SET
+    unit_id = EXCLUDED.unit_id,
+    inserted_by_patch = public.cerp_patch_20260811_base_unit_repair.inserted_by_patch
+      OR EXCLUDED.inserted_by_patch;
+END
+$repair$;
+
+COMMIT;

--- a/db/patches/support/20260811_base_unit_drift_repair.preflight.sql
+++ b/db/patches/support/20260811_base_unit_drift_repair.preflight.sql
@@ -1,0 +1,11 @@
+-- Read-only preflight for the canonical base-unit repair.
+
+SELECT
+  to_regclass('public.units') IS NOT NULL AS units_present,
+  (SELECT count(*) FROM public.units WHERE lower(code::text) = 'u') <= 1
+    AS no_case_insensitive_duplicate,
+  EXISTS (SELECT 1 FROM public.cerp_schema_migrations
+    WHERE filename = '20260223_seed_currencies_units.sql')
+    AS historical_seed_recorded,
+  EXISTS (SELECT 1 FROM public.units WHERE lower(code::text) = 'u')
+    AS base_unit_currently_present;

--- a/db/patches/support/20260811_base_unit_drift_repair.rollback.sql
+++ b/db/patches/support/20260811_base_unit_drift_repair.rollback.sql
@@ -1,0 +1,10 @@
+-- Production rollback is restoration from the validated pre-migration dump.
+-- In-place deletion is refused because the base unit may be referenced as soon
+-- as stock flows resume.
+
+DO $rollback$
+BEGIN
+  RAISE EXCEPTION
+    'SOL-06 unit repair rollback requires restoration of the validated pre-migration backup into a fresh database';
+END
+$rollback$;

--- a/db/patches/support/20260811_base_unit_drift_repair.verify.sql
+++ b/db/patches/support/20260811_base_unit_drift_repair.verify.sql
@@ -1,0 +1,13 @@
+-- Read-only verification for the canonical base-unit repair. Every boolean must be true.
+
+SELECT
+  (SELECT count(*) FROM public.units WHERE lower(code::text) = 'u') = 1
+    AS one_canonical_base_unit,
+  EXISTS (
+    SELECT 1
+    FROM public.cerp_patch_20260811_base_unit_repair marker
+    JOIN public.units unit
+      ON unit.id::text = marker.unit_id
+     AND lower(unit.code::text) = marker.code
+    WHERE marker.code = 'u'
+  ) AS provenance_matches_unit;

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -41,6 +41,8 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
     "9be8c63bf5c0a1a12ac43c2e684ef7d6ffe454171fd58461ee8c8c25c03004f9",
   "20260811_account_provisioning_schema_repair.sql":
     "e4a994888e3ff0dc38923a128216647f76919d4001efc70e26219742befca116",
+  "20260811_base_unit_drift_repair.sql":
+    "53e6d11928dcd329b80fd493932aa29d2f0f65874b20a2cd1daa4e9a8847eb66",
   "20260811_ged_antivirus_quarantine.sql":
     "7e1e026c8a16be2609f072434d1930afbd248a543d96e3b013e89426fdaa1336",
 });

--- a/src/__tests__/base-unit-drift-repair.migration-guards.test.ts
+++ b/src/__tests__/base-unit-drift-repair.migration-guards.test.ts
@@ -1,0 +1,22 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("SOL-06 canonical base-unit drift repair", () => {
+  const read = (name: string) => fs.readFileSync(path.join(process.cwd(), "db", "patches", name), "utf8");
+
+  it("restores only u, records provenance and requires backup restoration for rollback", () => {
+    const patch = read("20260811_base_unit_drift_repair.sql");
+    const preflight = read("support/20260811_base_unit_drift_repair.preflight.sql");
+    const verify = read("support/20260811_base_unit_drift_repair.verify.sql");
+    const rollback = read("support/20260811_base_unit_drift_repair.rollback.sql");
+
+    expect(patch).toMatch(/VALUES \('u', 'Unite'\)/);
+    expect(patch).toMatch(/cerp_patch_20260811_base_unit_repair/);
+    expect(patch).toMatch(/duplicate case-insensitive u codes/);
+    expect(preflight).toMatch(/20260223_seed_currencies_units\.sql/);
+    expect(verify).toMatch(/one_canonical_base_unit/);
+    expect(verify).toMatch(/provenance_matches_unit/);
+    expect(rollback).toMatch(/requires restoration of the validated pre-migration backup/);
+  });
+});

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -72,6 +72,10 @@ const recentSolPatchChecksums = new Map([
     "20260811_account_provisioning_schema_repair.sql",
     "e4a994888e3ff0dc38923a128216647f76919d4001efc70e26219742befca116",
   ],
+  [
+    "20260811_base_unit_drift_repair.sql",
+    "53e6d11928dcd329b80fd493932aa29d2f0f65874b20a2cd1daa4e9a8847eb66",
+  ],
 ]);
 const wave9PatchChecksums = new Map([
   [


### PR DESCRIPTION
The production backup restore has 20260223_seed_currencies_units.sql recorded but no rows in public.units. Add a guarded, idempotent u-unit repair with provenance, verify/rollback guidance and immutable selection. Targeted tests: 34 passed.

## Summary by Sourcery

Add a guarded migration patch to repair drift in the canonical base unit and integrate it into the immutable patch system.

Bug Fixes:
- Restore the missing canonical base unit record when the historical seed migration was applied but the corresponding unit row is absent, while reconciling potential duplicates.

Enhancements:
- Record provenance for the repaired base unit in a dedicated marker table and provide read-only preflight and verification scripts to validate schema and repair state.
- Enforce rollback guidance by refusing in-place deletion and requiring restoration from a validated pre-migration backup for production rollbacks.
- Extend the immutable patch checksum registry to include the new base-unit drift repair patch.

Tests:
- Add migration guard tests to ensure the base-unit repair patch, preflight, verification, and rollback scripts enforce the expected invariants and guidance.