### PR TITLE
release: publish SOL-11 production evidence

### DIFF
--- a/docs/execution-reports/SOL-06.md
+++ b/docs/execution-reports/SOL-06.md
@@ -4,7 +4,7 @@ Date d'exécution : 2026-08-10
 
 Branche de travail : `fix/sol-06-migration-reliability`
 
-Statut : **candidate fusionnable ; aucune écriture production effectuée**
+Statut : **code fusionné ; décision CUMP enregistrée sur les deux bases ; gate SOL-06 non activé tant que calendriers et taux réels manquent**
 
 ## Diagnostic et cause racine
 
@@ -97,5 +97,38 @@ La procédure exacte est dans `docs/runbooks/database-upgrade-sol06.md`. Le fich
 
 - Avant toute production : répéter sur une copie de staging anonymisée représentative de la volumétrie et fixer la fenêtre de verrou.
 - Traiter les 25 contrats historiques manquants et les 10 `CHECK NOT VALID` selon les propriétaires/échéances de `MIGRATION_EXCEPTIONS_SOL_06.md`.
-- Faire approuver et renseigner la méthode de valorisation réelle avec sa définition, sa source, sa période, sa fraîcheur et sa fiabilité.
-- Aucun autre changement SOL-06 n'est connu comme non intégré.
+- Créer puis faire valider les calendriers de production et les taux horaires réels des centres de coûts ; ces données ne doivent pas être inventées par une migration.
+- Activer ensuite le patch SOL-06 et ses triggers sur les deux bases avec un nouveau preflight.
+
+## Validation métier et application contrôlée du 11/08/2026
+
+Keenan Martin a validé la méthode CUMP. La valeur canonique enregistrée est
+`WEIGHTED_AVERAGE`, définie comme le coût moyen pondéré recalculé à chaque
+réception valorisée ; les sorties de stock et consommations d'OF utilisent le
+coût moyen courant. Provenance : « Décision dirigeant Keenan Martin — validation
+de release SOL-06 du 2026-08-11 », période à compter du 11/08/2026, fraîcheur
+11/08/2026, fiabilité `DECLARED`.
+
+La décision a été écrite de façon idempotente dans `cerp_test` et `cerp_prod`
+après sauvegarde complète et répétition sur deux restaurations jetables. Le patch
+`20260810_system_reference_data_readiness.sql` n'a volontairement pas été
+appliqué aux bases actives : le preflight réaliste prouve l'absence de
+calendriers de production actifs et de centres de coûts/taux horaires actifs ;
+le schéma réel des magasins/emplacements ne porte pas encore le contrat
+`is_active` attendu. Activer les triggers dans cet état bloquerait des flux
+métier légitimes. Cette retenue est un gate de sécurité, pas un échec de
+migration.
+
+Sauvegardes opérateur avant écriture :
+
+- `cerp_test_pre_sol11_20260811-120450.dump`, 72 779 738 octets, SHA-256
+  `05844614cac0e3ac7e81bc11735aa9e70f80ab3cbc46a8655660fe6751ef1373` ;
+- `cerp_prod_pre_sol11_20260811-120450.dump`, 49 314 521 octets, SHA-256
+  `9c35b2a3eb80390a74a19c06e80d7967333066d4a024215fb8024feef28220a7`.
+
+Les deux dumps ont passé `pg_restore --list`, ont été restaurés dans des bases
+neuves, migrés, vérifiés, puis la restauration production a été refaite depuis
+le dump original avant le second passage. Les unités canoniques `u`, `mm`, `m`
+et `kg` sont présentes sur les deux bases actives ; la réparation du drift de
+l'unité `u` et la réparation du schéma de provisioning sont enregistrées dans le
+ledger avec empreintes immuables.

--- a/docs/execution-reports/SOL-11.md
+++ b/docs/execution-reports/SOL-11.md
@@ -139,12 +139,46 @@ avant preuve de restauration.
 
 ## Reste réellement à faire
 
-- appliquer la migration en environnement de validation puis en production
-  uniquement dans une fenêtre SOL-06 avec sauvegarde et contrôles opérateur ;
-- configurer les destinataires d'alertes et vérifier les ressources ClamAV sur
-  HYPERBOX2 et Coolify ;
+- configurer les destinataires externes d'alertes et effectuer un test de
+  notification contrôlé ;
 - effectuer un exercice pilote de réanalyse/libération/suppression avec un
   administrateur désigné ;
 - planifier le backscan des versions historiques et le reconciler des nettoyages
   post-commit ;
 - construire, si souhaité, le panneau admin de quarantaine en réutilisant ces API.
+
+## Promotion, bases et déploiements réels du 11/08/2026
+
+Les correctifs SOL-11 et les réparations de registre associées ont été fusionnés
+dans `dev`, puis dans `main` par les PR backend `#381` à `#387`. La base de
+release vérifiée est `main` `ebb8d7509a53f7eeca270c1e7bf8101681911c0f` ; son
+arbre est identique à celui de `dev` au moment de la promotion.
+
+Après les sauvegardes et restaurations décrites dans le rapport SOL-06, les
+patches suivants ont été exécutés par le rôle applicatif et vérifiés sur
+`cerp_test` puis `cerp_prod` : réparation de l'unité canonique, réparation du
+schéma de provisioning, frontière admin, invitations, contrat unités/articles,
+corrélation stock et quarantaine antivirus GED. État final du registre :
+`cerp_test` 128 appliqués / 16 en attente / 0 mismatch ; `cerp_prod` 123
+appliqués / 21 en attente / 0 mismatch. Les patches historiques restants n'ont
+pas été appliqués aveuglément. Le smoke GED transactionnel a réussi sur les deux
+bases et s'est terminé par `ROLLBACK`.
+
+HYPERBOX2 exécute l'artefact backend immuable
+`/srv/cerp/releases/20260811-ebb8d750` ; `cerp-api` et `cerp-api-test` sont actifs,
+les endpoints live/ready répondent 200, PostgreSQL, GED, ClamAV et realtime sont
+`up`. Le build de cet artefact a vérifié 625 fichiers source et 625 fichiers
+émis.
+
+Sur le VPS Coolify, l'image `rcccokw0wgcw0ck44g0wk0ck:ebb8d750...` a été
+construite avec succès. Le volume `/app/data` porte désormais un répertoire GED
+persistant et un témoin de montage ; Coolify enregistre
+`CERP_GED_VAULT_ROOT`, `CERP_GED_SENTINEL`,
+`CERP_GED_REQUIRE_SENTINEL=true` et configure
+`CERP_READINESS_REQUIRED_DEPENDENCIES=database,ged_storage,antivirus,realtime`.
+Le déploiement Coolify `e4xx2p0g8x9ohjr6uh59k6i9` a réussi en 3 min 12 s. Le
+conteneur final `edbe168429b1` est seul actif et sain ; `/health/live` est
+`alive`, `/health/ready` est `ready` et les quatre composants database,
+`ged_storage`, antivirus et realtime sont tous `up` et `required=true`. Le
+preflight CORS de `POST /api/auth/login` répond 204 pour l'origine frontend et
+propage les identifiants de corrélation.


### PR DESCRIPTION
## Résumé
Promotion documentaire de `dev` vers `main` après application contrôlée des patches, sauvegardes/restaurations, déploiements HYPERBOX2/Coolify et validation CUMP.

## Validation
- PR #388 fusionnée dans `dev`
- diff documentaire uniquement
- readiness VPS : database, ged_storage, antivirus et realtime tous `up` et `required=true`
- CORS login : HTTP 204 pour l'origine frontend

## Summary by Sourcery

Document SOL-11 and SOL-06 execution outcomes and production readiness for the SOL-11 release, including applied patches, business validation, and deployment status across environments.

Enhancements:
- Clarify remaining operational tasks by refining alert configuration requirements and specifying controlled notification testing.
- Record precise backup artifacts, restoration procedures, and ledger entries for unit and provisioning repairs as part of the SOL-06/SOL-11 release evidence.

Documentation:
- Update SOL-11 execution report with details of applied patches, registry state, smoke tests, and backend deployments on HYPERBOX2 and Coolify, including readiness and CORS preflight results.
- Update SOL-06 execution report to reflect merged code status, recorded CUMP decision on both databases, and the security gate pending real production calendars and rates, with full backup and restoration evidence.