### PR TITLE
release: promote SOL-06 live-schema compatibility

### DIFF
--- a/db/e2e/legacy-bootstrap.sql
+++ b/db/e2e/legacy-bootstrap.sql
@@ -294,7 +294,6 @@ CREATE TABLE public.warehouses (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   code text NOT NULL UNIQUE,
   name text NOT NULL,
-  is_active boolean NOT NULL DEFAULT true,
   created_at timestamptz NOT NULL DEFAULT now(),
   updated_at timestamptz NOT NULL DEFAULT now()
 );
@@ -303,8 +302,9 @@ CREATE TABLE public.locations (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   warehouse_id uuid REFERENCES public.warehouses(id),
   code text NOT NULL,
-  name text,
-  is_active boolean NOT NULL DEFAULT true,
+  description text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
   UNIQUE (warehouse_id, code)
 );
 

--- a/db/patches/20260810_system_reference_data_readiness.sql
+++ b/db/patches/20260810_system_reference_data_readiness.sql
@@ -180,27 +180,26 @@ WITH requested AS (
     EXISTS (
       SELECT 1 FROM public.locations l
       JOIN public.warehouses w ON w.id = l.warehouse_id
-      WHERE l.is_active AND w.is_active
     )
     AND EXISTS (
       SELECT 1 FROM public.emplacements e
       JOIN public.magasins m ON m.id = e.magasin_id
       JOIN public.locations l ON l.id = e.location_id
       JOIN public.warehouses w ON w.id = l.warehouse_id AND w.id = m.warehouse_id
-      WHERE e.is_active AND m.is_active AND l.is_active AND w.is_active
+      WHERE e.is_active AND m.is_active
     ),
     'Au moins un magasin et un emplacement actifs sont reliés au référentiel warehouse/location.',
     'emplacements', CURRENT_DATE, NULL,
     'public.warehouses + locations + magasins + emplacements', now(), 'VERIFIED',
     jsonb_build_object(
-      'active_warehouses', (SELECT count(*) FROM public.warehouses WHERE is_active),
-      'active_locations', (SELECT count(*) FROM public.locations WHERE is_active),
+      'configured_warehouses', (SELECT count(*) FROM public.warehouses),
+      'configured_locations', (SELECT count(*) FROM public.locations),
       'mapped_active_emplacements', (
         SELECT count(*) FROM public.emplacements e
         JOIN public.magasins m ON m.id = e.magasin_id
         JOIN public.locations l ON l.id = e.location_id
         JOIN public.warehouses w ON w.id = l.warehouse_id AND w.id = m.warehouse_id
-        WHERE e.is_active AND m.is_active AND l.is_active AND w.is_active
+        WHERE e.is_active AND m.is_active
       )
     ),
     'au moins 1 chaîne active warehouse > magasin > emplacement > location',

--- a/db/patches/support/20260810_system_reference_data_readiness.preflight.sql
+++ b/db/patches/support/20260810_system_reference_data_readiness.preflight.sql
@@ -52,16 +52,6 @@ BEGIN
     RAISE EXCEPTION 'SOL-06 preflight: canonical units u/mm/m/kg are incomplete';
   END IF;
 
-  IF NOT EXISTS (
-    SELECT 1 FROM public.emplacements e
-    JOIN public.magasins m ON m.id = e.magasin_id
-    JOIN public.locations l ON l.id = e.location_id
-    JOIN public.warehouses w ON w.id = l.warehouse_id AND w.id = m.warehouse_id
-    WHERE e.is_active AND m.is_active AND l.is_active AND w.is_active
-  ) THEN
-    RAISE EXCEPTION 'SOL-06 preflight: no active warehouse/magasin/emplacement/location chain';
-  END IF;
-
   -- Les valeurs métier absentes ne doivent pas empêcher l'installation du
   -- garde-fou : la fonction et ses triggers sont précisément chargés de
   -- bloquer les flux concernés jusqu'à leur saisie guidée. Les compteurs du
@@ -88,8 +78,8 @@ SELECT
   pg_database_size(current_database()) AS database_bytes,
   (SELECT count(*) FROM public.cerp_schema_migrations) AS applied_patches,
   (SELECT count(*) FROM public.units) AS units,
-  (SELECT count(*) FROM public.warehouses WHERE is_active) AS active_warehouses,
-  (SELECT count(*) FROM public.locations WHERE is_active) AS active_locations,
+  (SELECT count(*) FROM public.warehouses) AS configured_warehouses,
+  (SELECT count(*) FROM public.locations) AS configured_locations,
   (SELECT count(*) FROM public.programmation_calendars WHERE active) AS active_calendars,
   (SELECT count(*) FROM public.centres_frais WHERE statut = 'ACTIF' AND archived_at IS NULL) AS active_cost_centers,
   (SELECT count(*) FROM public.app_roles WHERE is_active) AS active_roles,

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-11T12:05:11.341Z",
+  "started_at": "2026-08-11T12:43:48.592Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,23 +9,23 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 19566,
-    "source_seed": 186,
-    "backup": 739,
-    "preflight": 133,
-    "integrity_before": 596,
-    "migration": 175,
-    "verify": 117,
-    "replay": 126,
-    "integrity_after": 1351,
-    "negative_gate": 42,
-    "rollback": 24,
-    "restore": 4094
+    "source_migration": 19393,
+    "source_seed": 206,
+    "backup": 827,
+    "preflight": 190,
+    "integrity_before": 674,
+    "migration": 239,
+    "verify": 132,
+    "replay": 191,
+    "integrity_after": 1401,
+    "negative_gate": 43,
+    "rollback": 22,
+    "restore": 4083
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-11T12:05:33.827Z",
-    "duration_ms": 84,
+    "checked_at": "2026-08-11T12:44:11.086Z",
+    "duration_ms": 138,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36199447"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-Zf3bMy\\cerp-test-before-sol06.dump",
-      "bytes": 1954228,
-      "sha256": "d758b5290e1c831f98bf1274f64d53fc8d351e7de7aee7bf9f4a52aa253ed5b8",
-      "free_bytes": 438071201792
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-2rVOBD\\cerp-test-before-sol06.dump",
+      "bytes": 1954334,
+      "sha256": "fa9157465fb67e3a9c44b4d4dfd23682af809f440f1650760b44def70e45f283",
+      "free_bytes": 437795725312
     },
     "ledger": {
       "applied": 140,
@@ -439,8 +439,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-11T12:05:36.197Z",
-    "duration_ms": 1336,
+    "checked_at": "2026-08-11T12:44:13.730Z",
+    "duration_ms": 1386,
     "table_counts": {
       "admin_account_invitations": "0",
       "admin_user_provisioning_migration_state": "12",
@@ -892,7 +892,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-11T12:05:34.862Z",
+        "freshness_at": "2026-08-11T12:44:12.345Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -909,7 +909,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-11T12:05:34.862Z",
+        "freshness_at": "2026-08-11T12:44:12.345Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -927,7 +927,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-11T12:05:34.862Z",
+        "freshness_at": "2026-08-11T12:44:12.345Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -953,7 +953,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-11T12:05:34.862Z",
+        "freshness_at": "2026-08-11T12:44:12.345Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -970,7 +970,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-11T12:05:34.862Z",
+        "freshness_at": "2026-08-11T12:44:12.345Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -988,7 +988,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-11T12:05:34.862Z",
+        "freshness_at": "2026-08-11T12:44:12.345Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1008,7 +1008,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-11T12:05:34.862Z",
+        "freshness_at": "2026-08-11T12:44:12.345Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1026,7 +1026,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-11T12:05:34.862Z",
+        "freshness_at": "2026-08-11T12:44:12.345Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1052,7 +1052,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-11T12:05:34.862Z",
+        "freshness_at": "2026-08-11T12:44:12.345Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1070,11 +1070,11 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-11T12:05:34.862Z",
+        "freshness_at": "2026-08-11T12:44:12.345Z",
         "reliability": "VERIFIED",
         "actual_value": {
-          "active_locations": 1,
-          "active_warehouses": 4,
+          "configured_locations": 1,
+          "configured_warehouses": 4,
           "mapped_active_emplacements": 1
         },
         "expected_value": "au moins 1 chaîne active warehouse > magasin > emplacement > location",
@@ -1089,7 +1089,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-11T12:05:34.862Z",
+        "freshness_at": "2026-08-11T12:44:12.345Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1127,7 +1127,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-11T12:05:34.862Z",
+        "freshness_at": "2026-08-11T12:44:12.345Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1199,5 +1199,5 @@
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-11T12:05:40.539Z"
+  "completed_at": "2026-08-11T12:44:18.150Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,10 +1,10 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-11T12:05:40.539Z
+- Exécutée : 2026-08-11T12:44:18.150Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36199447 octets
-- Sauvegarde : 1954228 octets, SHA-256 `d758b5290e1c831f98bf1274f64d53fc8d351e7de7aee7bf9f4a52aa253ed5b8`
+- Sauvegarde : 1954334 octets, SHA-256 `fa9157465fb67e3a9c44b4d4dfd23682af809f440f1650760b44def70e45f283`
 - Patches avant/après : 140 / 145
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
@@ -17,17 +17,17 @@
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 19566 |
-| source_seed | 186 |
-| backup | 739 |
-| preflight | 133 |
-| integrity_before | 596 |
-| migration | 175 |
-| verify | 117 |
-| replay | 126 |
-| integrity_after | 1351 |
-| negative_gate | 42 |
-| rollback | 24 |
-| restore | 4094 |
+| source_migration | 19393 |
+| source_seed | 206 |
+| backup | 827 |
+| preflight | 190 |
+| integrity_before | 674 |
+| migration | 239 |
+| verify | 132 |
+| replay | 191 |
+| integrity_after | 1401 |
+| negative_gate | 43 |
+| rollback | 22 |
+| restore | 4083 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/scripts/db-patches.js
+++ b/scripts/db-patches.js
@@ -38,7 +38,7 @@ const IMMUTABLE_ONLY_PATCHES = Object.freeze({
   "20260810_stock_movement_event_correlation.sql":
     "736887f658a39504d7cd499cd6b630e05eba0e7fcaa8ecda9f3d92083a1278be",
   "20260810_system_reference_data_readiness.sql":
-    "9be8c63bf5c0a1a12ac43c2e684ef7d6ffe454171fd58461ee8c8c25c03004f9",
+    "8a6bfa740ddc6e80f7b19ace948a92df379cc0df097879e9f5d125758a9f8eec",
   "20260811_account_provisioning_schema_repair.sql":
     "e4a994888e3ff0dc38923a128216647f76919d4001efc70e26219742befca116",
   "20260811_base_unit_drift_repair.sql":

--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -203,10 +203,10 @@ async function main() {
        ON CONFLICT (id) DO UPDATE SET code=EXCLUDED.code,nom=EXCLUDED.nom,actif=true,status='actif'`
     );
     await client.query(
-      `INSERT INTO public.locations (id,warehouse_id,code,name,is_active)
-       SELECT '10000000-0000-4000-8000-000000000001',id,'E2E-RECEPTION','Emplacement reception SOL-05',true
+      `INSERT INTO public.locations (id,warehouse_id,code,description)
+       SELECT '10000000-0000-4000-8000-000000000001',id,'E2E-RECEPTION','Emplacement reception SOL-05'
        FROM public.warehouses WHERE code='NEW-MP'
-       ON CONFLICT (id) DO UPDATE SET code=EXCLUDED.code,name=EXCLUDED.name,is_active=true`
+       ON CONFLICT (id) DO UPDATE SET code=EXCLUDED.code,description=EXCLUDED.description`
     );
     await client.query(
       `INSERT INTO public.magasins (

--- a/src/__tests__/db-patches.runner.test.ts
+++ b/src/__tests__/db-patches.runner.test.ts
@@ -66,7 +66,7 @@ const recentSolPatchChecksums = new Map([
   ],
   [
     "20260810_system_reference_data_readiness.sql",
-    "9be8c63bf5c0a1a12ac43c2e684ef7d6ffe454171fd58461ee8c8c25c03004f9",
+    "8a6bfa740ddc6e80f7b19ace948a92df379cc0df097879e9f5d125758a9f8eec",
   ],
   [
     "20260811_account_provisioning_schema_repair.sql",

--- a/src/__tests__/migration-release-gate-sol06.test.ts
+++ b/src/__tests__/migration-release-gate-sol06.test.ts
@@ -62,6 +62,21 @@ describe("SOL-06 migration release gate", () => {
     expect(sql).not.toMatch(/INSERT INTO public\.erp_settings[\s\S]*stock\.valuation_method/i);
   });
 
+  it("reste compatible avec le schéma terrain warehouse/location sans statut actif", () => {
+    const sql = fs.readFileSync(PATCH, "utf8");
+    const preflight = fs.readFileSync(`${SUPPORT}.preflight.sql`, "utf8");
+    const bootstrap = fs.readFileSync(path.join(ROOT, "db", "e2e", "legacy-bootstrap.sql"), "utf8");
+
+    expect(sql).not.toMatch(/(?:l|w)\.is_active/);
+    expect(preflight).not.toMatch(/(?:l|w)\.is_active/);
+    expect(preflight).not.toContain("no active warehouse/magasin/emplacement/location chain");
+    const warehouseTable = bootstrap.match(/CREATE TABLE public\.warehouses \([\s\S]*?\n\);/)?.[0];
+    const locationTable = bootstrap.match(/CREATE TABLE public\.locations \([\s\S]*?\n\);/)?.[0];
+    expect(warehouseTable).not.toContain("is_active");
+    expect(locationTable).not.toContain("is_active");
+    expect(locationTable).toContain("description text");
+  });
+
   it("rend le preflight lecture seule et le rollback explicitement test-only", () => {
     const preflight = fs.readFileSync(`${SUPPORT}.preflight.sql`, "utf8");
     const verify = fs.readFileSync(`${SUPPORT}.verify.sql`, "utf8");


### PR DESCRIPTION
Promotes the reviewed SOL-06 live-schema compatibility fix from dev to main.\n\nEvidence is recorded in #393. No production database write is part of this PR.

## Summary by Sourcery

Align SOL-06 migration, tests, and E2E fixtures with environments lacking warehouse/location is_active columns while updating rehearsal evidence.

Enhancements:
- Relax SOL-06 preflight and readiness checks to no longer require is_active flags on warehouse/location tables and report configured counts instead of active ones.
- Adjust legacy bootstrap and isolated seeding to reflect warehouse/location schemas without is_active, including using description and timestamps for locations.
- Update SOL-06 migration rehearsal metadata and checksums to reflect the new patch version and keep the immutable-patch runner in sync.

Tests:
- Add a regression test ensuring SOL-06 remains compatible with a warehouse/location schema that omits is_active columns and uses description for locations.