### PR TITLE
fix(migrations): separate gate install from business readiness (#392)

### DIFF
--- a/db/patches/support/20260810_system_reference_data_readiness.verify.sql
+++ b/db/patches/support/20260810_system_reference_data_readiness.verify.sql
@@ -15,14 +15,17 @@ BEGIN
     RAISE EXCEPTION 'SOL-06 verify: one or more business-flow readiness triggers are missing or disabled';
   END IF;
 
-  IF EXISTS (
-    SELECT 1 FROM public.fn_business_prerequisite_status('STOCK') WHERE NOT ready
-    UNION ALL
-    SELECT 1 FROM public.fn_business_prerequisite_status('PLANNING') WHERE NOT ready
-    UNION ALL
-    SELECT 1 FROM public.fn_business_prerequisite_status('PRODUCTION') WHERE NOT ready
+  IF NOT EXISTS (
+    SELECT 1 FROM public.fn_business_prerequisite_status('STOCK')
+    WHERE prerequisite_code = 'ACTIVE_STOCK_LOCATIONS'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.fn_business_prerequisite_status('PLANNING')
+    WHERE prerequisite_code = 'ACTIVE_PRODUCTION_CALENDAR'
+  ) OR NOT EXISTS (
+    SELECT 1 FROM public.fn_business_prerequisite_status('PRODUCTION')
+    WHERE prerequisite_code = 'CURRENT_COST_CENTER_RATES'
   ) THEN
-    RAISE EXCEPTION 'SOL-06 verify: reference-data readiness contains blocking findings';
+    RAISE EXCEPTION 'SOL-06 verify: expected guided readiness checks are missing';
   END IF;
 
   IF EXISTS (

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-11T12:43:48.592Z",
+  "started_at": "2026-08-11T12:50:06.203Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,23 +9,23 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 19393,
-    "source_seed": 206,
-    "backup": 827,
-    "preflight": 190,
-    "integrity_before": 674,
-    "migration": 239,
-    "verify": 132,
-    "replay": 191,
-    "integrity_after": 1401,
-    "negative_gate": 43,
-    "rollback": 22,
-    "restore": 4083
+    "source_migration": 19039,
+    "source_seed": 197,
+    "backup": 744,
+    "preflight": 174,
+    "integrity_before": 609,
+    "migration": 219,
+    "verify": 123,
+    "replay": 164,
+    "integrity_after": 1364,
+    "negative_gate": 41,
+    "rollback": 23,
+    "restore": 4160
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-11T12:44:11.086Z",
-    "duration_ms": 138,
+    "checked_at": "2026-08-11T12:50:28.169Z",
+    "duration_ms": 126,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36199447"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-2rVOBD\\cerp-test-before-sol06.dump",
-      "bytes": 1954334,
-      "sha256": "fa9157465fb67e3a9c44b4d4dfd23682af809f440f1650760b44def70e45f283",
-      "free_bytes": 437795725312
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-7Y3yyZ\\cerp-test-before-sol06.dump",
+      "bytes": 1954302,
+      "sha256": "cfb03d3edfacf61fc8bbf63c218aee069a443c38a094e1c766b8ba9cd1d73d58",
+      "free_bytes": 437792104448
     },
     "ledger": {
       "applied": 140,
@@ -439,8 +439,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-11T12:44:13.730Z",
-    "duration_ms": 1386,
+    "checked_at": "2026-08-11T12:50:30.653Z",
+    "duration_ms": 1349,
     "table_counts": {
       "admin_account_invitations": "0",
       "admin_user_provisioning_migration_state": "12",
@@ -892,7 +892,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-11T12:44:12.345Z",
+        "freshness_at": "2026-08-11T12:50:29.303Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -909,7 +909,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-11T12:44:12.345Z",
+        "freshness_at": "2026-08-11T12:50:29.303Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -927,7 +927,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-11T12:44:12.345Z",
+        "freshness_at": "2026-08-11T12:50:29.303Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -953,7 +953,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-11T12:44:12.345Z",
+        "freshness_at": "2026-08-11T12:50:29.303Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -970,7 +970,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-11T12:44:12.345Z",
+        "freshness_at": "2026-08-11T12:50:29.303Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -988,7 +988,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-11T12:44:12.345Z",
+        "freshness_at": "2026-08-11T12:50:29.303Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1008,7 +1008,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-11T12:44:12.345Z",
+        "freshness_at": "2026-08-11T12:50:29.303Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1026,7 +1026,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-11T12:44:12.345Z",
+        "freshness_at": "2026-08-11T12:50:29.303Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1052,7 +1052,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-11T12:44:12.345Z",
+        "freshness_at": "2026-08-11T12:50:29.303Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1070,7 +1070,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-11T12:44:12.345Z",
+        "freshness_at": "2026-08-11T12:50:29.303Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1089,7 +1089,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-11T12:44:12.345Z",
+        "freshness_at": "2026-08-11T12:50:29.303Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1127,7 +1127,7 @@
         "period_start": "2026-08-10T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-11T12:44:12.345Z",
+        "freshness_at": "2026-08-11T12:50:29.303Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1199,5 +1199,5 @@
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-11T12:44:18.150Z"
+  "completed_at": "2026-08-11T12:50:35.056Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,10 +1,10 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-11T12:44:18.150Z
+- Exécutée : 2026-08-11T12:50:35.056Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36199447 octets
-- Sauvegarde : 1954334 octets, SHA-256 `fa9157465fb67e3a9c44b4d4dfd23682af809f440f1650760b44def70e45f283`
+- Sauvegarde : 1954302 octets, SHA-256 `cfb03d3edfacf61fc8bbf63c218aee069a443c38a094e1c766b8ba9cd1d73d58`
 - Patches avant/après : 140 / 145
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
@@ -17,17 +17,17 @@
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 19393 |
-| source_seed | 206 |
-| backup | 827 |
-| preflight | 190 |
-| integrity_before | 674 |
-| migration | 239 |
-| verify | 132 |
-| replay | 191 |
-| integrity_after | 1401 |
-| negative_gate | 43 |
-| rollback | 22 |
-| restore | 4083 |
+| source_migration | 19039 |
+| source_seed | 197 |
+| backup | 744 |
+| preflight | 174 |
+| integrity_before | 609 |
+| migration | 219 |
+| verify | 123 |
+| replay | 164 |
+| integrity_after | 1364 |
+| negative_gate | 41 |
+| rollback | 23 |
+| restore | 4160 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/src/__tests__/migration-release-gate-sol06.test.ts
+++ b/src/__tests__/migration-release-gate-sol06.test.ts
@@ -84,7 +84,11 @@ describe("SOL-06 migration release gate", () => {
 
     expect(preflight).toContain("BEGIN TRANSACTION READ ONLY");
     expect(preflight).toContain("stock.valuation_method");
-    expect(verify).toContain("WHERE NOT ready");
+    expect(verify).toContain("expected guided readiness checks are missing");
+    expect(verify).toContain("ACTIVE_STOCK_LOCATIONS");
+    expect(verify).toContain("ACTIVE_PRODUCTION_CALENDAR");
+    expect(verify).toContain("CURRENT_COST_CENTER_RATES");
+    expect(verify).not.toContain("reference-data readiness contains blocking findings");
     expect(verify).toContain("contype = 'f' AND NOT convalidated");
     expect(rollback).toContain("current_database() <> 'cerp_test'");
     expect(rollback).toContain("cerp.migration_rehearsal");


### PR DESCRIPTION
The post-migration verifier now proves that guided checks exist without requiring the business to have already entered calendars, mapped stock locations, cost centres and rates. Missing values remain visible and block only the affected business flow.\n\nProof: 37 targeted tests, full backend suite, build, and isolated backup/migrate/replay/P2606/rollback/restore rehearsal all pass. No production database write.

## Summary by Sourcery

Relax migration gate to only require presence of guided readiness checks while keeping missing reference data as flow-specific blockers.

Bug Fixes:
- Adjust SOL-06 verification to fail only when expected guided readiness checks are missing instead of when any readiness finding is unready.

Enhancements:
- Align SOL-06 verifier message and tests with guided readiness semantics, decoupling gate install from business reference-data completion.
- Refresh SOL-06 migration rehearsal documentation with latest rehearsal run metadata.