### PR TITLE
feat(release): contrôles backend SOL-12

### DIFF
--- a/docs/execution-reports/SOL-06-PRODUCTION-MIGRATION-20260811.md
+++ b/docs/execution-reports/SOL-06-PRODUCTION-MIGRATION-20260811.md
@@ -1,0 +1,40 @@
+# SOL-06 — Migration `cerp_prod` autorisée du 2026-08-11
+
+Ce rapport remplace explicitement l'état « non appliqué » de la première édition de `SOL-06-PRODUCTION-READINESS-DEPLOYMENT.md`. Keenan Martin a autorisé la fenêtre d'écriture production le 2026-08-11.
+
+## Résultat
+
+Les patches `20260810_system_reference_data_readiness.sql` et `20260811_production_readiness_center.sql` sont appliqués sur `cerp_prod`. Les fonctions v1/v2 et le trigger de production sont présents, le registre contient exactement les deux lignes attendues et aucune clé étrangère invalide n'a été trouvée.
+
+Le contrôle retourne cinq prérequis : rôles, unités et statuts prêts ; calendrier de production et taux de centre de frais non prêts. Ces deux absences sont volontairement actionnables et continuent de bloquer le démarrage d'une production. Aucune donnée métier fictive n'a été insérée.
+
+## Preflight et sauvegarde
+
+- release immuable exécutée : `a7ace695265dda02b7c1bd295c59df724e588c6f` ;
+- PostgreSQL : `17.10` ;
+- taille initiale : `105 658 035` octets ; espace disponible : `388 044 980 224` octets ;
+- registre initial : `123` patches ;
+- sauvegarde : `/var/backups/cerp/cerp_prod_pre_sol06_readiness_20260811-132522.dump` ;
+- taille sauvegarde : `49 338 351` octets ; catalogue : `4 165` entrées ;
+- SHA-256 : `fd4a9d4df55ca6f61a1d54fcafc34bfd75a26153bd9baa930d0bece7a42cd450` ;
+- fichier protégé par propriétaire `postgres` et mode `0600`.
+
+Chaque patch a suivi `status --only`, `up --dry-run --only`, `up --only`, puis son script de vérification. Le deuxième preflight a été rejoué après le premier patch, car il dépend normalement des objets créés par celui-ci.
+
+## Preuve de restauration
+
+La sauvegarde a été restaurée dans `cerp_restore_verify_prod_sol06_20260811`, une base isolée et temporaire. La base restaurée contient les `123` entrées historiques, aucune fonction SOL-06, aucune ligne SOL-06 et zéro clé étrangère invalide. La base temporaire a ensuite été supprimée. Verdict : `RESTORE_PROOF=passed`.
+
+## Vérifications service
+
+- endpoint public `/health/live` : HTTP 200, version `a7ace` ;
+- endpoint public `/health/ready` : HTTP 200 ; DB, GED, antivirus et realtime `up` ;
+- services HYPERBOX2 production et test : readiness `up`, version `a7ace`.
+
+## Rollback
+
+Arrêter les écritures, conserver l'état incident, restaurer le dump vérifié dans une base neuve, contrôler le registre, les comptages et la cohérence GED, puis basculer sous approbation humaine. Le rollback SQL test-only ne doit pas être utilisé sur `cerp_prod`.
+
+## Reste métier
+
+Les utilisateurs autorisés doivent saisir dans le centre de préparation les vrais calendriers, centres de frais et taux horaires. La production demeure protégée tant que ces données ne sont pas complètes.

--- a/docs/execution-reports/SOL-12.md
+++ b/docs/execution-reports/SOL-12.md
@@ -1,0 +1,11 @@
+# SOL-12 — Intégration backend au contrôle de release
+
+Date : 2026-08-11
+
+Le runner canonique vit dans `crp-systems-web` et orchestre ce dépôt backend autoritaire. Ce dépôt fournit désormais un `pnpm typecheck` explicite et permet à `db:migrations:rehearse --report-dir <répertoire>` d'écrire ses preuves hors du worktree.
+
+Cette option évite que la répétition SQL obligatoire modifie les rapports versionnés pendant un gate. La répétition continue de créer PostgreSQL en `tmpfs`, sauvegarder, appliquer, vérifier, rejouer à zéro, exercer le rollback test-only et restaurer dans une base neuve.
+
+Tests ciblés avant intégration : `src/__tests__/migration-release-gate-sol06.test.ts`, 7/7 réussis ; `pnpm typecheck`, réussi. Les résultats complets seront consignés dans le rapport SOL-12 frontend produit par la commande unifiée.
+
+Rollback : revenir sur ce commit remet l'écriture des rapports dans `docs/release`; aucun schéma ni donnée n'est modifié par ce changement.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "build": "node scripts/security/check-production-data-boundary.mjs && tsc -p tsconfig.json && node scripts/security/check-production-data-boundary.mjs --dist",
     "security:production-data": "node scripts/security/check-production-data-boundary.mjs",
     "contract:generate": "npm run build && node scripts/generate-commande-workflow-contract.mjs",

--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -595,9 +595,10 @@ async function rehearse(options = {}) {
 
     report.status = "passed";
     report.completed_at = new Date().toISOString();
-    fs.mkdirSync(DEFAULT_REPORT_DIR, { recursive: true });
-    fs.writeFileSync(path.join(DEFAULT_REPORT_DIR, "MIGRATION_REHEARSAL_SOL_06.json"), `${JSON.stringify(report, null, 2)}\n`);
-    fs.writeFileSync(path.join(DEFAULT_REPORT_DIR, "MIGRATION_REHEARSAL_SOL_06.md"), rehearsalMarkdown(report));
+    const reportDir = options["report-dir"] ? path.resolve(options["report-dir"]) : DEFAULT_REPORT_DIR;
+    fs.mkdirSync(reportDir, { recursive: true });
+    fs.writeFileSync(path.join(reportDir, "MIGRATION_REHEARSAL_SOL_06.json"), `${JSON.stringify(report, null, 2)}\n`);
+    fs.writeFileSync(path.join(reportDir, "MIGRATION_REHEARSAL_SOL_06.md"), rehearsalMarkdown(report));
     return report;
   } finally {
     if (containerStarted) spawnSync("docker", ["rm", "-f", container], { env: systemEnv(), stdio: "ignore", windowsHide: true });

--- a/src/__tests__/migration-release-gate-sol06.test.ts
+++ b/src/__tests__/migration-release-gate-sol06.test.ts
@@ -102,6 +102,14 @@ describe("SOL-06 migration release gate", () => {
     expect(migrator).toContain("stop-before is reserved for the SOL-06 isolated rehearsal");
   });
 
+  it("ecrit le rapport de repetition hors du worktree quand le gate le demande", () => {
+    const source = fs.readFileSync(path.join(ROOT, "scripts", "migrations", "release-gate.js"), "utf8");
+
+    expect(source).toContain('options["report-dir"]');
+    expect(source).toContain('path.join(reportDir, "MIGRATION_REHEARSAL_SOL_06.json")');
+    expect(source).toContain('path.join(reportDir, "MIGRATION_REHEARSAL_SOL_06.md")');
+  });
+
   it("refuse une sauvegarde vide ou dont le SHA-256 ne correspond pas", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "cerp-sol06-test-"));
     temporaryDirectories.push(directory);


### PR DESCRIPTION
## Résultat
- script typecheck backend explicite
- rapports de répétition migration hors worktree
- preuve de migration cerp_prod autorisée et restauration isolée

## Preuves ciblées
- migration release gate: 7/7
- typecheck backend: OK
- build backend: OK

## Summary by Sourcery

Integrate backend type checking and configurable migration rehearsal reporting into the release gate workflow.

New Features:
- Add an explicit backend typecheck npm script for use in release controls.
- Allow the SOL-06 migration rehearsal command to write its execution reports to a configurable directory outside the repository worktree.
- Document the SOL-06 production migration authorization and the SOL-12 backend release-control integration in new execution report markdown files.

Enhancements:
- Extend SOL-06 migration release gate tests to cover writing rehearsal reports to a custom report directory instead of the default location.

Documentation:
- Add a detailed execution report for the authorized SOL-06 `cerp_prod` production migration on 2026-08-11.
- Add documentation of the SOL-12 backend integration into the release control pipeline, including typecheck and migration rehearsal behavior.

Tests:
- Expand migration release gate tests to assert that rehearsal reporting honors the configurable report directory option.