### PR TITLE
fix(deps): corriger nanoid transitif backend

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nanoid@<3.3.17: ^3.3.17
+
 importers:
 
   .:
@@ -1293,8 +1296,8 @@ packages:
     resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3001,7 +3004,7 @@ snapshots:
       concat-stream: 2.0.0
       type-is: 1.6.18
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -3113,7 +3116,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ allowBuilds:
   '@scarf/scarf': false
   bcrypt: true
   esbuild: true
+overrides:
+  'nanoid@<3.3.17': '^3.3.17'


### PR DESCRIPTION
Le gate SOL-12 a bloqué GHSA-2v37-7h3g-55p8 via Vitest/Vite/PostCSS. Override pnpm 11 minimal vers nanoid 3.3.18. Preuves : audit 0 vulnérabilité, 7/7 tests migration, typecheck et build OK.

## Summary by Sourcery

Build:
- Add a pnpm override to force nanoid versions earlier than 3.3.17 to resolve to ^3.3.17 across the workspace.