### PR TITLE
fix(migrations): attendre le serveur PostgreSQL final

### DIFF
--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -370,14 +370,22 @@ function command(name, args, options = {}) {
 
 async function waitForPostgres(container) {
   const deadline = Date.now() + 60_000;
+  let consecutiveReady = 0;
   while (Date.now() < deadline) {
+    const logs = spawnSync("docker", ["logs", container], {
+      env: systemEnv(), encoding: "utf8", windowsHide: true,
+    });
+    const initializationComplete = /PostgreSQL init process complete; ready for start up/i.test(
+      `${logs.stdout ?? ""}\n${logs.stderr ?? ""}`
+    );
     const result = spawnSync("docker", ["exec", container, "pg_isready", "-U", "cerp_e2e", "-d", "cerp_test"], {
       env: systemEnv(), stdio: "ignore", windowsHide: true,
     });
-    if (result.status === 0) return;
+    consecutiveReady = initializationComplete && result.status === 0 ? consecutiveReady + 1 : 0;
+    if (consecutiveReady >= 2) return;
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
-  fail("PostgreSQL did not become ready within 60 seconds");
+  fail("PostgreSQL final server did not become stably ready within 60 seconds");
 }
 
 function rehearsalMarkdown(report) {

--- a/src/__tests__/migration-release-gate-sol06.test.ts
+++ b/src/__tests__/migration-release-gate-sol06.test.ts
@@ -110,6 +110,14 @@ describe("SOL-06 migration release gate", () => {
     expect(source).toContain('path.join(reportDir, "MIGRATION_REHEARSAL_SOL_06.md")');
   });
 
+  it("attend le serveur PostgreSQL final au lieu du serveur temporaire d'initialisation", () => {
+    const source = fs.readFileSync(path.join(ROOT, "scripts", "migrations", "release-gate.js"), "utf8");
+
+    expect(source).toContain("PostgreSQL init process complete; ready for start up")
+    expect(source).toContain("consecutiveReady >= 2")
+    expect(source).toContain("final server did not become stably ready")
+  });
+
   it("refuse une sauvegarde vide ou dont le SHA-256 ne correspond pas", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "cerp-sol06-test-"));
     temporaryDirectories.push(directory);


### PR DESCRIPTION
Cause réelle du run bloqué : pg_isready captait le serveur temporaire de l'entrypoint avant son arrêt. La readiness exige maintenant le marqueur de fin d'init et deux sondes consécutives, timeout inchangé. Preuves : 8/8 tests, répétition complète restore=passed/replay=true, typecheck OK.

## Summary by Sourcery

Harden PostgreSQL readiness checks in the migration release gate script to wait for the final, fully initialized server and add a regression test covering this behavior.

Enhancements:
- Update the PostgreSQL wait logic to require the init-complete log marker and multiple consecutive readiness probes before proceeding, clarifying the failure message for unstable readiness.

Tests:
- Add a test ensuring the migration release gate script targets the final PostgreSQL server rather than the temporary initialization server.