### PR TITLE
fix(e2e): make commerce proof standalone

### DIFF
--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -282,7 +282,9 @@ async function main() {
     );
     await client.query(
       `INSERT INTO public.articles_fabrique_families (code,designation,is_active)
-       VALUES ('piece_finie','Piece finie E2E',true)
+       VALUES
+         ('piece_finie','Piece finie E2E',true),
+         ('PT','Piece technique E2E',true)
        ON CONFLICT (code) DO UPDATE SET designation=EXCLUDED.designation,is_active=true`
     );
     await client.query(

--- a/src/__tests__/errorHandler.test.ts
+++ b/src/__tests__/errorHandler.test.ts
@@ -61,6 +61,21 @@ describe("CA-SEC-04 — errorHandler ne fuite pas d'internes sur 5xx", () => {
     expect(logLines.join("\n")).not.toContain("due_date");
   });
 
+  it("journalise seulement le nom sûr de la contrainte SQL", () => {
+    const { req, res } = mockReqRes();
+
+    errorHandler({
+      name: "error",
+      code: "23503",
+      constraint: "commande_ligne_article_id_fkey",
+      detail: "Key (article_id)=(sensitive) is not present",
+    }, req, res, () => {});
+
+    const log = logLines.join("\n");
+    expect(log).toContain('"failure_constraint":"commande_ligne_article_id_fkey"');
+    expect(log).not.toContain("sensitive");
+  });
+
   it("HttpError < 500 conserve son message volontaire (ex. 404)", () => {
     const { req, res, status, json } = mockReqRes();
 

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -2,7 +2,7 @@ import type { Request, Response, NextFunction } from "express";
 import { HttpError } from "../utils/httpError";
 import { ApiError } from "../utils/apiError";
 import { stripQueryFromUrl } from "../utils/logPath";
-import { errorFingerprint, logger, safeErrorCode } from "../shared/observability/logger";
+import { errorFingerprint, logger, safeErrorCode, safeErrorConstraint } from "../shared/observability/logger";
 import { observabilityRoute } from "./requestLogger";
 
 // Message générique renvoyé au client pour toute erreur serveur (5xx) ou inconnue.
@@ -165,6 +165,7 @@ export function errorHandler(err: unknown, req: Request, res: Response, _next: N
     http_status: status,
     error_code: code,
     failure_code: safeErrorCode(err),
+    failure_constraint: safeErrorConstraint(err),
     failure_type: err instanceof Error ? err.name : "UnknownError",
     error_fingerprint: errorFingerprint(err),
     http_method: req.method,

--- a/src/shared/observability/logger.ts
+++ b/src/shared/observability/logger.ts
@@ -89,6 +89,12 @@ export function safeErrorCode(error: unknown): string | null {
   return SAFE_IDENTIFIER.test(code) ? code : null;
 }
 
+export function safeErrorConstraint(error: unknown): string | null {
+  if (!error || typeof error !== "object" || !("constraint" in error)) return null;
+  const constraint = String((error as { constraint?: unknown }).constraint ?? "").trim();
+  return SAFE_IDENTIFIER.test(constraint) ? constraint : null;
+}
+
 export function errorFingerprint(error: unknown): string {
   const errorObject = error && typeof error === "object" ? error as { name?: unknown; message?: unknown; code?: unknown } : null;
   const input = [errorObject?.name, errorObject?.code, errorObject?.message]


### PR DESCRIPTION
## Résultat
- charge la famille canonique PT dans la fixture isolée
- expose le nom validé de la contrainte SQL dans les logs sans détail ni valeur sensible

## Preuves
- flux commerce autonome passé depuis une base vide
- contrainte diagnostiquée: articles_fabrique_family_fk
- errorHandler 32/32, typecheck, build et frontières production réussis

## Summary by Sourcery

Harden server error logging to expose only safe SQL constraint identifiers and update isolated e2e seeding so the commerce flow can run independently on an empty database.

New Features:
- Log validated SQL constraint names in error logs for safer diagnostics

Bug Fixes:
- Ensure the error handler does not leak sensitive SQL error details while still exposing the constraint name
- Make the isolated e2e commerce seed include the canonical PT family so flows can run from an empty database

Enhancements:
- Add a reusable helper to extract and validate safe SQL constraint identifiers for observability

Tests:
- Extend error handler tests to cover safe logging of SQL constraint names without including sensitive details