### PR TITLE
release: promote validated SOL-12 backend

### DIFF
--- a/docs/execution-reports/SOL-06-PRODUCTION-MIGRATION-20260811.md
+++ b/docs/execution-reports/SOL-06-PRODUCTION-MIGRATION-20260811.md
@@ -1,0 +1,40 @@
+# SOL-06 — Migration `cerp_prod` autorisée du 2026-08-11
+
+Ce rapport remplace explicitement l'état « non appliqué » de la première édition de `SOL-06-PRODUCTION-READINESS-DEPLOYMENT.md`. Keenan Martin a autorisé la fenêtre d'écriture production le 2026-08-11.
+
+## Résultat
+
+Les patches `20260810_system_reference_data_readiness.sql` et `20260811_production_readiness_center.sql` sont appliqués sur `cerp_prod`. Les fonctions v1/v2 et le trigger de production sont présents, le registre contient exactement les deux lignes attendues et aucune clé étrangère invalide n'a été trouvée.
+
+Le contrôle retourne cinq prérequis : rôles, unités et statuts prêts ; calendrier de production et taux de centre de frais non prêts. Ces deux absences sont volontairement actionnables et continuent de bloquer le démarrage d'une production. Aucune donnée métier fictive n'a été insérée.
+
+## Preflight et sauvegarde
+
+- release immuable exécutée : `a7ace695265dda02b7c1bd295c59df724e588c6f` ;
+- PostgreSQL : `17.10` ;
+- taille initiale : `105 658 035` octets ; espace disponible : `388 044 980 224` octets ;
+- registre initial : `123` patches ;
+- sauvegarde : `/var/backups/cerp/cerp_prod_pre_sol06_readiness_20260811-132522.dump` ;
+- taille sauvegarde : `49 338 351` octets ; catalogue : `4 165` entrées ;
+- SHA-256 : `fd4a9d4df55ca6f61a1d54fcafc34bfd75a26153bd9baa930d0bece7a42cd450` ;
+- fichier protégé par propriétaire `postgres` et mode `0600`.
+
+Chaque patch a suivi `status --only`, `up --dry-run --only`, `up --only`, puis son script de vérification. Le deuxième preflight a été rejoué après le premier patch, car il dépend normalement des objets créés par celui-ci.
+
+## Preuve de restauration
+
+La sauvegarde a été restaurée dans `cerp_restore_verify_prod_sol06_20260811`, une base isolée et temporaire. La base restaurée contient les `123` entrées historiques, aucune fonction SOL-06, aucune ligne SOL-06 et zéro clé étrangère invalide. La base temporaire a ensuite été supprimée. Verdict : `RESTORE_PROOF=passed`.
+
+## Vérifications service
+
+- endpoint public `/health/live` : HTTP 200, version `a7ace` ;
+- endpoint public `/health/ready` : HTTP 200 ; DB, GED, antivirus et realtime `up` ;
+- services HYPERBOX2 production et test : readiness `up`, version `a7ace`.
+
+## Rollback
+
+Arrêter les écritures, conserver l'état incident, restaurer le dump vérifié dans une base neuve, contrôler le registre, les comptages et la cohérence GED, puis basculer sous approbation humaine. Le rollback SQL test-only ne doit pas être utilisé sur `cerp_prod`.
+
+## Reste métier
+
+Les utilisateurs autorisés doivent saisir dans le centre de préparation les vrais calendriers, centres de frais et taux horaires. La production demeure protégée tant que ces données ne sont pas complètes.

--- a/docs/execution-reports/SOL-12.md
+++ b/docs/execution-reports/SOL-12.md
@@ -6,6 +6,27 @@ Le runner canonique vit dans `crp-systems-web` et orchestre ce dépôt backend a
 
 Cette option évite que la répétition SQL obligatoire modifie les rapports versionnés pendant un gate. La répétition continue de créer PostgreSQL en `tmpfs`, sauvegarder, appliquer, vérifier, rejouer à zéro, exercer le rollback test-only et restaurer dans une base neuve.
 
-Tests ciblés avant intégration : `src/__tests__/migration-release-gate-sol06.test.ts`, 7/7 réussis ; `pnpm typecheck`, réussi. Les résultats complets seront consignés dans le rapport SOL-12 frontend produit par la commande unifiée.
+La répétition attend désormais le marqueur officiel de fin d'initialisation PostgreSQL puis deux réponses `pg_isready` consécutives. Cela élimine la course avec le serveur temporaire lancé par l'image pendant `initdb`, sans augmenter le timeout de 60 secondes. La fixture E2E charge aussi la famille canonique `PT` réellement utilisée par le frontend. Enfin, les erreurs PostgreSQL peuvent journaliser le nom de contrainte après validation stricte comme identifiant SQL ; aucune valeur, requête ou donnée personnelle n'est ajoutée aux logs.
 
-Rollback : revenir sur ce commit remet l'écriture des rapports dans `docs/release`; aucun schéma ni donnée n'est modifié par ce changement.
+Le lockfile force `nanoid@3.3.18` pour corriger l'avis transitif sans montée majeure. L'audit backend final retourne zéro vulnérabilité connue.
+
+## Preuve finale intégrée
+
+Le gate `test` a attesté `dev` backend `d8077b5f01fac99aadc2b7a6da371a9c1238868e` avec le frontend `53d0638ce80a3dd0b71d111c362745bf409acc2f`.
+
+- typecheck et build backend : réussis ;
+- 267 fichiers de tests réussis, 1 ignoré ; 4 446 tests réussis, 4 ignorés ;
+- audit : zéro vulnérabilité connue ;
+- répétition migrations : 5 patches appliqués, restauration réussie, rejeu idempotent ;
+- E2E isolé : 63/63 scénarios réussis, dont les deux parcours métier SOL-05 ;
+- manifeste global : 1 146 fichiers, SHA-256 `5488551b1ecb3c06c21ae9f47bd8a07eb711a8cb711486406cf36de56353519f`, vérifié.
+
+Rapport canonique : `crp-systems-web/docs/execution-reports/SOL-12.md`. Preuve d'exécution locale : `test-results/release-gate/20260811T153143Z-test-53d0638c-d8077b5f/` dans le checkout de validation frontend.
+
+## Données, risques et rollback
+
+SOL-12 n'ajoute aucune migration et n'écrit dans aucune base persistante. La famille `PT` est une fixture strictement limitée à la base jetable E2E. Le seul risque opérationnel nouveau est qu'une release auparavant tolérée soit désormais bloquée ; c'est le comportement voulu.
+
+Rollback code : redéployer les artefacts précédents par SHA. Rollback de données : restaurer la sauvegarde vérifiée dans une base neuve sous approbation humaine. Revenir sur les commits SOL-12 supprimerait le contrôle mais ne modifierait aucun schéma ni donnée.
+
+Reste identifié : le dépôt backend n'a pas encore de lint autoritaire ; l'exception est explicite et typecheck, tests et build restent bloquants.

--- a/docs/execution-reports/SOL-12.md
+++ b/docs/execution-reports/SOL-12.md
@@ -1,0 +1,11 @@
+# SOL-12 — Intégration backend au contrôle de release
+
+Date : 2026-08-11
+
+Le runner canonique vit dans `crp-systems-web` et orchestre ce dépôt backend autoritaire. Ce dépôt fournit désormais un `pnpm typecheck` explicite et permet à `db:migrations:rehearse --report-dir <répertoire>` d'écrire ses preuves hors du worktree.
+
+Cette option évite que la répétition SQL obligatoire modifie les rapports versionnés pendant un gate. La répétition continue de créer PostgreSQL en `tmpfs`, sauvegarder, appliquer, vérifier, rejouer à zéro, exercer le rollback test-only et restaurer dans une base neuve.
+
+Tests ciblés avant intégration : `src/__tests__/migration-release-gate-sol06.test.ts`, 7/7 réussis ; `pnpm typecheck`, réussi. Les résultats complets seront consignés dans le rapport SOL-12 frontend produit par la commande unifiée.
+
+Rollback : revenir sur ce commit remet l'écriture des rapports dans `docs/release`; aucun schéma ni donnée n'est modifié par ce changement.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.json",
     "build": "node scripts/security/check-production-data-boundary.mjs && tsc -p tsconfig.json && node scripts/security/check-production-data-boundary.mjs --dist",
     "security:production-data": "node scripts/security/check-production-data-boundary.mjs",
     "contract:generate": "npm run build && node scripts/generate-commande-workflow-contract.mjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  nanoid@<3.3.17: ^3.3.17
+
 importers:
 
   .:
@@ -1293,8 +1296,8 @@ packages:
     resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -3001,7 +3004,7 @@ snapshots:
       concat-stream: 2.0.0
       type-is: 1.6.18
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   nanoid@5.1.16: {}
 
@@ -3113,7 +3116,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ allowBuilds:
   '@scarf/scarf': false
   bcrypt: true
   esbuild: true
+overrides:
+  'nanoid@<3.3.17': '^3.3.17'

--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -282,7 +282,9 @@ async function main() {
     );
     await client.query(
       `INSERT INTO public.articles_fabrique_families (code,designation,is_active)
-       VALUES ('piece_finie','Piece finie E2E',true)
+       VALUES
+         ('piece_finie','Piece finie E2E',true),
+         ('PT','Piece technique E2E',true)
        ON CONFLICT (code) DO UPDATE SET designation=EXCLUDED.designation,is_active=true`
     );
     await client.query(

--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -595,9 +595,10 @@ async function rehearse(options = {}) {
 
     report.status = "passed";
     report.completed_at = new Date().toISOString();
-    fs.mkdirSync(DEFAULT_REPORT_DIR, { recursive: true });
-    fs.writeFileSync(path.join(DEFAULT_REPORT_DIR, "MIGRATION_REHEARSAL_SOL_06.json"), `${JSON.stringify(report, null, 2)}\n`);
-    fs.writeFileSync(path.join(DEFAULT_REPORT_DIR, "MIGRATION_REHEARSAL_SOL_06.md"), rehearsalMarkdown(report));
+    const reportDir = options["report-dir"] ? path.resolve(options["report-dir"]) : DEFAULT_REPORT_DIR;
+    fs.mkdirSync(reportDir, { recursive: true });
+    fs.writeFileSync(path.join(reportDir, "MIGRATION_REHEARSAL_SOL_06.json"), `${JSON.stringify(report, null, 2)}\n`);
+    fs.writeFileSync(path.join(reportDir, "MIGRATION_REHEARSAL_SOL_06.md"), rehearsalMarkdown(report));
     return report;
   } finally {
     if (containerStarted) spawnSync("docker", ["rm", "-f", container], { env: systemEnv(), stdio: "ignore", windowsHide: true });

--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -370,14 +370,22 @@ function command(name, args, options = {}) {
 
 async function waitForPostgres(container) {
   const deadline = Date.now() + 60_000;
+  let consecutiveReady = 0;
   while (Date.now() < deadline) {
+    const logs = spawnSync("docker", ["logs", container], {
+      env: systemEnv(), encoding: "utf8", windowsHide: true,
+    });
+    const initializationComplete = /PostgreSQL init process complete; ready for start up/i.test(
+      `${logs.stdout ?? ""}\n${logs.stderr ?? ""}`
+    );
     const result = spawnSync("docker", ["exec", container, "pg_isready", "-U", "cerp_e2e", "-d", "cerp_test"], {
       env: systemEnv(), stdio: "ignore", windowsHide: true,
     });
-    if (result.status === 0) return;
+    consecutiveReady = initializationComplete && result.status === 0 ? consecutiveReady + 1 : 0;
+    if (consecutiveReady >= 2) return;
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
-  fail("PostgreSQL did not become ready within 60 seconds");
+  fail("PostgreSQL final server did not become stably ready within 60 seconds");
 }
 
 function rehearsalMarkdown(report) {

--- a/src/__tests__/errorHandler.test.ts
+++ b/src/__tests__/errorHandler.test.ts
@@ -61,6 +61,21 @@ describe("CA-SEC-04 — errorHandler ne fuite pas d'internes sur 5xx", () => {
     expect(logLines.join("\n")).not.toContain("due_date");
   });
 
+  it("journalise seulement le nom sûr de la contrainte SQL", () => {
+    const { req, res } = mockReqRes();
+
+    errorHandler({
+      name: "error",
+      code: "23503",
+      constraint: "commande_ligne_article_id_fkey",
+      detail: "Key (article_id)=(sensitive) is not present",
+    }, req, res, () => {});
+
+    const log = logLines.join("\n");
+    expect(log).toContain('"failure_constraint":"commande_ligne_article_id_fkey"');
+    expect(log).not.toContain("sensitive");
+  });
+
   it("HttpError < 500 conserve son message volontaire (ex. 404)", () => {
     const { req, res, status, json } = mockReqRes();
 

--- a/src/__tests__/migration-release-gate-sol06.test.ts
+++ b/src/__tests__/migration-release-gate-sol06.test.ts
@@ -110,6 +110,14 @@ describe("SOL-06 migration release gate", () => {
     expect(source).toContain('path.join(reportDir, "MIGRATION_REHEARSAL_SOL_06.md")');
   });
 
+  it("attend le serveur PostgreSQL final au lieu du serveur temporaire d'initialisation", () => {
+    const source = fs.readFileSync(path.join(ROOT, "scripts", "migrations", "release-gate.js"), "utf8");
+
+    expect(source).toContain("PostgreSQL init process complete; ready for start up")
+    expect(source).toContain("consecutiveReady >= 2")
+    expect(source).toContain("final server did not become stably ready")
+  });
+
   it("refuse une sauvegarde vide ou dont le SHA-256 ne correspond pas", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "cerp-sol06-test-"));
     temporaryDirectories.push(directory);

--- a/src/__tests__/migration-release-gate-sol06.test.ts
+++ b/src/__tests__/migration-release-gate-sol06.test.ts
@@ -102,6 +102,14 @@ describe("SOL-06 migration release gate", () => {
     expect(migrator).toContain("stop-before is reserved for the SOL-06 isolated rehearsal");
   });
 
+  it("ecrit le rapport de repetition hors du worktree quand le gate le demande", () => {
+    const source = fs.readFileSync(path.join(ROOT, "scripts", "migrations", "release-gate.js"), "utf8");
+
+    expect(source).toContain('options["report-dir"]');
+    expect(source).toContain('path.join(reportDir, "MIGRATION_REHEARSAL_SOL_06.json")');
+    expect(source).toContain('path.join(reportDir, "MIGRATION_REHEARSAL_SOL_06.md")');
+  });
+
   it("refuse une sauvegarde vide ou dont le SHA-256 ne correspond pas", () => {
     const directory = fs.mkdtempSync(path.join(os.tmpdir(), "cerp-sol06-test-"));
     temporaryDirectories.push(directory);

--- a/src/middlewares/errorHandler.ts
+++ b/src/middlewares/errorHandler.ts
@@ -2,7 +2,7 @@ import type { Request, Response, NextFunction } from "express";
 import { HttpError } from "../utils/httpError";
 import { ApiError } from "../utils/apiError";
 import { stripQueryFromUrl } from "../utils/logPath";
-import { errorFingerprint, logger, safeErrorCode } from "../shared/observability/logger";
+import { errorFingerprint, logger, safeErrorCode, safeErrorConstraint } from "../shared/observability/logger";
 import { observabilityRoute } from "./requestLogger";
 
 // Message générique renvoyé au client pour toute erreur serveur (5xx) ou inconnue.
@@ -165,6 +165,7 @@ export function errorHandler(err: unknown, req: Request, res: Response, _next: N
     http_status: status,
     error_code: code,
     failure_code: safeErrorCode(err),
+    failure_constraint: safeErrorConstraint(err),
     failure_type: err instanceof Error ? err.name : "UnknownError",
     error_fingerprint: errorFingerprint(err),
     http_method: req.method,

--- a/src/shared/observability/logger.ts
+++ b/src/shared/observability/logger.ts
@@ -89,6 +89,12 @@ export function safeErrorCode(error: unknown): string | null {
   return SAFE_IDENTIFIER.test(code) ? code : null;
 }
 
+export function safeErrorConstraint(error: unknown): string | null {
+  if (!error || typeof error !== "object" || !("constraint" in error)) return null;
+  const constraint = String((error as { constraint?: unknown }).constraint ?? "").trim();
+  return SAFE_IDENTIFIER.test(constraint) ? constraint : null;
+}
+
 export function errorFingerprint(error: unknown): string {
   const errorObject = error && typeof error === "object" ? error as { name?: unknown; message?: unknown; code?: unknown } : null;
   const input = [errorObject?.name, errorObject?.code, errorObject?.message]


### PR DESCRIPTION
Promotes the exact backend dev tree validated by release gate 20260811T153143Z-test-53d0638c-d8077b5f, plus documentation-only evidence. Gate: 4446 backend tests, zero known dependency vulnerabilities, migration restore/replay passed, 63/63 integrated E2E. Includes the separately authorized SOL-06 production migration report; no new persistent data write.

## Summary by Sourcery

Integrate the backend into the SOL-12 release gate with stronger PostgreSQL readiness checks, externalized migration rehearsal reporting, and hardened error observability, plus accompanying execution reports and dependency override.

New Features:
- Allow SOL-06 migration rehearsal to write its JSON and Markdown reports to a caller-specified directory outside the repository worktree.
- Expose a dedicated pnpm typecheck script for the backend to participate explicitly in the release gate.
- Log validated SQL constraint names for database errors while still avoiding leakage of sensitive values.

Bug Fixes:
- Ensure the migration gate waits for the fully initialized PostgreSQL final server by checking init-complete logs and requiring consecutive readiness responses, avoiding races with the temporary init server.

Enhancements:
- Extend E2E seed data to include the canonical PT article family used by the frontend.
- Add a safeErrorConstraint helper wired into error logging to align log fields with security requirements.
- Tighten tests around migration rehearsal reporting and PostgreSQL readiness behavior to guard the new gate semantics.

Build:
- Override nanoid versions below 3.3.17 to 3.3.17+ at the workspace level to address a transitive advisory without major upgrades.

Documentation:
- Add a detailed SOL-06 production migration execution report documenting the authorized write window, validation steps, and rollback plan.
- Add a SOL-12 execution report describing the backend release gate integration, test evidence, data impacts, risks, and rollback strategy.

Tests:
- Introduce tests that assert the SOL-06 rehearsal script honors the report-dir option and the PostgreSQL readiness logic targets the final server.
- Add tests verifying that error logging only records safe SQL constraint identifiers and excludes sensitive details.