### PR TITLE
feat(margin): rendre les coûts industriels traçables

### DIFF
--- a/db/patches/20260811_margin_traceability_0002.sql
+++ b/db/patches/20260811_margin_traceability_0002.sql
@@ -1,0 +1,89 @@
+-- SOL-13 - Perspectives de marge et contrat de preuve v2.
+-- Métadonnées uniquement : aucune valeur de coût existante n'est modifiée.
+
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+
+DO $preflight$
+BEGIN
+  IF to_regclass('public.margin_input_versions') IS NULL
+     OR to_regclass('public.margin_rates') IS NULL
+     OR to_regclass('public.margin_recalculations') IS NULL THEN
+    RAISE EXCEPTION 'SOL-13: base margin migration 20260805_margin_engine_0001 is missing';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'margin_input_versions'
+      AND column_name = 'evidence_contract_version'
+  ) THEN
+    RAISE EXCEPTION 'SOL-13: target evidence columns already exist without this ledger entry';
+  END IF;
+END
+$preflight$;
+
+ALTER TABLE public.margin_rates
+  DROP CONSTRAINT margin_rates_category_ck,
+  ADD CONSTRAINT margin_rates_category_ck CHECK (category IN (
+    'MATERIAL','PURCHASE','SUBCONTRACTING','MACHINE','OPERATOR','CONTROL',
+    'TOOLING','PACKAGING','TRANSPORT','SCRAP','REWORK','OVERHEAD'
+  ));
+
+ALTER TABLE public.margin_rate_versions
+  ADD COLUMN evidence_contract_version smallint NOT NULL DEFAULT 1,
+  ADD COLUMN source_reliability text NOT NULL DEFAULT 'DECLARED',
+  ADD CONSTRAINT margin_rate_versions_evidence_version_ck CHECK (evidence_contract_version IN (1, 2)),
+  ADD CONSTRAINT margin_rate_versions_source_reliability_ck CHECK (
+    source_reliability IN ('ESTIMATED','DECLARED','VERIFIED')
+  );
+
+ALTER TABLE public.margin_rate_versions ALTER COLUMN evidence_contract_version SET DEFAULT 2;
+
+ALTER TABLE public.margin_input_versions
+  DROP CONSTRAINT margin_input_versions_basis_ck,
+  DROP CONSTRAINT margin_input_versions_category_ck,
+  ADD COLUMN evidence_contract_version smallint NOT NULL DEFAULT 1,
+  ADD COLUMN definition text NULL,
+  ADD COLUMN unit text NULL,
+  ADD COLUMN period_start date NULL,
+  ADD COLUMN period_end date NULL,
+  ADD COLUMN source_reliability text NULL,
+  ADD COLUMN source_document_type text NULL,
+  ADD COLUMN source_document_ref text NULL,
+  ADD CONSTRAINT margin_input_versions_basis_ck CHECK (basis IN (
+    'PLANNED','QUOTED','STANDARD','UPDATED','ACTUAL'
+  )),
+  ADD CONSTRAINT margin_input_versions_category_ck CHECK (category IS NULL OR category IN (
+    'MATERIAL','PURCHASE','SUBCONTRACTING','MACHINE','OPERATOR','CONTROL',
+    'TOOLING','PACKAGING','TRANSPORT','SCRAP','REWORK','OVERHEAD'
+  )),
+  ADD CONSTRAINT margin_input_versions_evidence_version_ck CHECK (evidence_contract_version IN (1, 2)),
+  ADD CONSTRAINT margin_input_versions_evidence_v2_ck CHECK (
+    evidence_contract_version = 1 OR (
+      definition IS NOT NULL AND btrim(definition) <> ''
+      AND unit IS NOT NULL AND btrim(unit) <> ''
+      AND period_start IS NOT NULL AND period_end IS NOT NULL AND period_end >= period_start
+      AND source_reliability IN ('ESTIMATED','DECLARED','VERIFIED')
+      AND (source_reliability <> 'VERIFIED' OR (
+        observed_at IS NOT NULL
+        AND source_document_type IS NOT NULL AND btrim(source_document_type) <> ''
+        AND source_document_ref IS NOT NULL AND btrim(source_document_ref) <> ''
+      ))
+    )
+  );
+
+ALTER TABLE public.margin_input_versions ALTER COLUMN evidence_contract_version SET DEFAULT 2;
+
+ALTER TABLE public.margin_recalculations
+  DROP CONSTRAINT margin_recalculations_basis_ck,
+  ADD CONSTRAINT margin_recalculations_basis_ck CHECK (basis IN (
+    'PLANNED','QUOTED','STANDARD','UPDATED','ACTUAL'
+  ));
+
+COMMENT ON COLUMN public.margin_input_versions.evidence_contract_version IS
+  'v1 = preuve historique antérieure à SOL-13; v2 = définition, unité, période et fiabilité obligatoires.';
+COMMENT ON COLUMN public.margin_input_versions.source_reliability IS
+  'ESTIMATED, DECLARED ou VERIFIED. UNKNOWN est rendu uniquement pour les preuves historiques v1.';
+COMMENT ON COLUMN public.margin_rate_versions.source_reliability IS
+  'Niveau de preuve du référentiel de taux, explicite et conservé avec sa période d effet.';
+
+COMMIT;

--- a/db/patches/support/20260811_margin_traceability_0002.preflight.sql
+++ b/db/patches/support/20260811_margin_traceability_0002.preflight.sql
@@ -1,0 +1,45 @@
+\set ON_ERROR_STOP on
+BEGIN TRANSACTION READ ONLY;
+
+DO $preflight$
+BEGIN
+  IF current_database() NOT IN ('cerp_dev', 'cerp_test', 'cerp_prod') THEN
+    RAISE EXCEPTION 'SOL-13 preflight: database % is not approved', current_database();
+  END IF;
+  IF to_regclass('public.margin_input_versions') IS NULL
+     OR to_regclass('public.margin_rates') IS NULL
+     OR to_regclass('public.margin_recalculations') IS NULL THEN
+    RAISE EXCEPTION 'SOL-13 preflight: base margin engine is missing';
+  END IF;
+  IF to_regclass('public.cerp_schema_migrations') IS NULL OR NOT EXISTS (
+    SELECT 1 FROM public.cerp_schema_migrations
+    WHERE filename = '20260805_margin_engine_0001.sql'
+      AND sha256 = 'bc0706c2af406d9a8e9f8221beb05492f9f0f7eba879de26cb77c8542863f514'
+  ) THEN
+    RAISE EXCEPTION 'SOL-13 preflight: canonical base margin migration is not proven by the ledger';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.cerp_schema_migrations
+    WHERE filename = '20260811_margin_traceability_0002.sql'
+      AND sha256 <> '8639afd24dfbf6ecd49131d2247c506ec1ca7acc17346bfdbacb61aaf6582d61'
+  ) THEN
+    RAISE EXCEPTION 'SOL-13 preflight: target migration ledger checksum differs from the canonical patch';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'SOL-13 preflight: role cerp_app is missing';
+  END IF;
+  IF EXISTS (SELECT 1 FROM pg_stat_activity WHERE datname = current_database() AND pid <> pg_backend_pid() AND state <> 'idle') THEN
+    RAISE EXCEPTION 'SOL-13 preflight: active sessions would make the constraint lock unsafe';
+  END IF;
+END
+$preflight$;
+
+SELECT current_database() AS database_name,
+       current_setting('server_version_num')::integer AS server_version_num,
+       pg_size_pretty(pg_database_size(current_database())) AS database_size,
+       (SELECT count(*) FROM public.margin_input_versions) AS input_version_count,
+       (SELECT count(*) FROM public.margin_recalculations) AS snapshot_count,
+       (SELECT sha256 FROM public.cerp_schema_migrations
+        WHERE filename = '20260805_margin_engine_0001.sql') AS base_margin_sha256;
+
+ROLLBACK;

--- a/db/patches/support/20260811_margin_traceability_0002.rollback.sql
+++ b/db/patches/support/20260811_margin_traceability_0002.rollback.sql
@@ -1,0 +1,68 @@
+\set ON_ERROR_STOP on
+BEGIN;
+SET LOCAL lock_timeout = '5s';
+SELECT pg_advisory_xact_lock(hashtext('cerp_schema_migrations'));
+
+DO $rollback_guard$
+BEGIN
+  IF current_database() NOT IN ('cerp_dev', 'cerp_test') THEN
+    RAISE EXCEPTION 'SOL-13 rollback is restricted to cerp_dev/cerp_test; restore the pre-migration backup in production';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM public.cerp_schema_migrations
+    WHERE filename = '20260811_margin_traceability_0002.sql'
+      AND sha256 = '8639afd24dfbf6ecd49131d2247c506ec1ca7acc17346bfdbacb61aaf6582d61'
+  ) THEN
+    RAISE EXCEPTION 'SOL-13 rollback refused: canonical migration ledger entry is missing or differs';
+  END IF;
+  IF EXISTS (SELECT 1 FROM public.margin_input_versions WHERE evidence_contract_version = 2)
+     OR EXISTS (SELECT 1 FROM public.margin_rate_versions WHERE evidence_contract_version = 2)
+     OR EXISTS (SELECT 1 FROM public.margin_input_versions WHERE basis IN ('QUOTED','STANDARD','UPDATED'))
+     OR EXISTS (SELECT 1 FROM public.margin_recalculations WHERE basis IN ('QUOTED','STANDARD','UPDATED'))
+     OR EXISTS (SELECT 1 FROM public.margin_rates WHERE category = 'REWORK') THEN
+    RAISE EXCEPTION 'SOL-13 rollback refused: v2 governed evidence exists; restore the pre-migration backup instead';
+  END IF;
+END
+$rollback_guard$;
+
+ALTER TABLE public.margin_rates
+  DROP CONSTRAINT margin_rates_category_ck,
+  ADD CONSTRAINT margin_rates_category_ck CHECK (category IN (
+    'MATERIAL','PURCHASE','SUBCONTRACTING','MACHINE','OPERATOR','CONTROL',
+    'TOOLING','PACKAGING','TRANSPORT','SCRAP','OVERHEAD'
+  ));
+
+ALTER TABLE public.margin_rate_versions
+  DROP CONSTRAINT margin_rate_versions_evidence_version_ck,
+  DROP CONSTRAINT margin_rate_versions_source_reliability_ck,
+  DROP COLUMN source_reliability,
+  DROP COLUMN evidence_contract_version;
+
+ALTER TABLE public.margin_input_versions
+  DROP CONSTRAINT margin_input_versions_basis_ck,
+  DROP CONSTRAINT margin_input_versions_category_ck,
+  DROP CONSTRAINT margin_input_versions_evidence_version_ck,
+  DROP CONSTRAINT margin_input_versions_evidence_v2_ck,
+  ADD CONSTRAINT margin_input_versions_basis_ck CHECK (basis IN ('PLANNED','ACTUAL')),
+  ADD CONSTRAINT margin_input_versions_category_ck CHECK (category IS NULL OR category IN (
+    'MATERIAL','PURCHASE','SUBCONTRACTING','MACHINE','OPERATOR','CONTROL',
+    'TOOLING','PACKAGING','TRANSPORT','SCRAP','OVERHEAD'
+  )),
+  DROP COLUMN source_document_ref,
+  DROP COLUMN source_document_type,
+  DROP COLUMN source_reliability,
+  DROP COLUMN period_end,
+  DROP COLUMN period_start,
+  DROP COLUMN unit,
+  DROP COLUMN definition,
+  DROP COLUMN evidence_contract_version;
+
+ALTER TABLE public.margin_recalculations
+  DROP CONSTRAINT margin_recalculations_basis_ck,
+  ADD CONSTRAINT margin_recalculations_basis_ck CHECK (basis IN ('PLANNED','ACTUAL'));
+
+DELETE FROM public.cerp_schema_migrations
+WHERE filename = '20260811_margin_traceability_0002.sql'
+  AND sha256 = '8639afd24dfbf6ecd49131d2247c506ec1ca7acc17346bfdbacb61aaf6582d61';
+
+COMMIT;

--- a/db/patches/support/20260811_margin_traceability_0002.verify.sql
+++ b/db/patches/support/20260811_margin_traceability_0002.verify.sql
@@ -1,0 +1,66 @@
+\set ON_ERROR_STOP on
+BEGIN TRANSACTION READ ONLY;
+
+DO $verify$
+DECLARE
+  missing_columns integer;
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM public.cerp_schema_migrations
+    WHERE filename = '20260811_margin_traceability_0002.sql'
+      AND sha256 = '8639afd24dfbf6ecd49131d2247c506ec1ca7acc17346bfdbacb61aaf6582d61'
+  ) THEN
+    RAISE EXCEPTION 'SOL-13 verify: canonical migration ledger entry is missing or has a different checksum';
+  END IF;
+  SELECT count(*) INTO missing_columns
+  FROM unnest(ARRAY[
+    'evidence_contract_version','definition','unit','period_start','period_end',
+    'source_reliability','source_document_type','source_document_ref'
+  ]) expected(column_name)
+  WHERE NOT EXISTS (
+    SELECT 1 FROM information_schema.columns actual
+    WHERE actual.table_schema = 'public'
+      AND actual.table_name = 'margin_input_versions'
+      AND actual.column_name = expected.column_name
+  );
+  IF missing_columns <> 0 THEN
+    RAISE EXCEPTION 'SOL-13 verify: % evidence columns are missing', missing_columns;
+  END IF;
+  IF 2 <> (
+    SELECT count(*) FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'margin_rate_versions'
+      AND column_name IN ('evidence_contract_version','source_reliability')
+  ) THEN
+    RAISE EXCEPTION 'SOL-13 verify: rate evidence columns are missing';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.margin_input_versions
+    WHERE evidence_contract_version = 2
+      AND (definition IS NULL OR unit IS NULL OR period_start IS NULL OR period_end IS NULL
+        OR source_reliability NOT IN ('ESTIMATED','DECLARED','VERIFIED')
+        OR (source_reliability = 'VERIFIED' AND (
+          observed_at IS NULL OR source_document_type IS NULL OR btrim(source_document_type) = ''
+          OR source_document_ref IS NULL OR btrim(source_document_ref) = ''
+        )))
+  ) THEN
+    RAISE EXCEPTION 'SOL-13 verify: incomplete evidence v2 rows found';
+  END IF;
+END
+$verify$;
+
+SELECT conname, pg_get_constraintdef(oid) AS definition
+FROM pg_constraint
+WHERE conrelid IN (
+  'public.margin_rates'::regclass,
+  'public.margin_input_versions'::regclass,
+  'public.margin_recalculations'::regclass
+)
+  AND conname IN (
+    'margin_rates_category_ck','margin_rate_versions_evidence_version_ck',
+    'margin_rate_versions_source_reliability_ck','margin_input_versions_basis_ck',
+    'margin_input_versions_category_ck','margin_input_versions_evidence_version_ck',
+    'margin_input_versions_evidence_v2_ck','margin_recalculations_basis_ck'
+  )
+ORDER BY conname;
+
+ROLLBACK;

--- a/docs/adr/ADR-0061-industrial-margin-perspectives.md
+++ b/docs/adr/ADR-0061-industrial-margin-perspectives.md
@@ -1,0 +1,48 @@
+# ADR-0061 — Marges industrielles honnêtes et traçables
+
+- Statut : accepté
+- Date : 2026-08-11
+- Décideur métier : Keenan Martin
+- Valorisation matière : CUMP, décision déclarée du 11/08/2026
+
+## Contexte
+
+Le moteur initial opposait `PLANNED` et `ACTUAL`. Cette lecture ne distinguait pas le coût proposé au client, le coût standard daté et la meilleure estimation à terminaison. Une fiche technique reconstruisait en outre une « marge théorique » côté navigateur en remplaçant des valeurs absentes par zéro.
+
+## Décision
+
+`CERP-MARGIN-2.0.0` publie quatre perspectives :
+
+| Base | Définition | Fiabilité maximale |
+|---|---|---|
+| `QUOTED` | Prix et coûts figés dans le devis | `ESTIMATED` |
+| `STANDARD` | Quantités prévues et paramètres applicables à la date | `ESTIMATED` |
+| `UPDATED` | Coûts engagés disponibles et temps à terminaison valorisé sur `max(prévu, réel)` | `ESTIMATED` |
+| `ACTUAL` | Sources réellement enregistrées et valorisées | `ACTUAL` |
+
+`PARTIAL` est obligatoire dès qu'une entrée requise manque. `ACTUAL` exige un calcul complet et uniquement des sources `VERIFIED`; une donnée déclarée ou estimée ramène le statut à `ESTIMATED`.
+
+Chaque preuve comporte définition, unité, période, fraîcheur, fiabilité, type/référence de source et document métier. Les écritures v2 incomplètes sont rejetées par validation API et contrainte SQL. Les lignes historiques v1 restent lisibles avec `UNKNOWN`; elles ne sont pas réécrites.
+
+## Sources canoniques
+
+- matière constatée : sorties de stock `POSTED` consommées par une réservation d'OF, quantité × `unit_cost` CUMP;
+- temps : opérations d'OF et taux figé à leur préparation;
+- sous-traitance : quantités réellement réceptionnées × prix/remise/frais de la ligne fournisseur;
+- rebuts et retouches : déclarations append-only; une quantité positive sans valorisation reste manquante;
+- paramètres : référentiels de taux versionnés et datés;
+- frais non connectés : entrée versionnée ou `NOT_APPLICABLE` explicite.
+
+Pour un OF sans rattachement probant au devis, `QUOTED` reste incomplet : le moteur n'utilise jamais les heures réelles comme substitut. L'estimation `UPDATED` est explicitement un proxy à terminaison pour le temps; elle ne prétend pas connaître un avancement physique absent.
+
+Le waterfall serveur est `prix → matière/achats → temps → sous-traitance → rebuts/retouches → autres → marge`. Une étape inconnue reste `null` et ne devient jamais zéro.
+
+## Compatibilité
+
+Les snapshots `PLANNED` historiques restent lisibles. À la lecture, une entrée `PLANNED` sert de repli `STANDARD` seulement en l'absence d'une version `STANDARD` plus récente. Les nouveaux endpoints d'écriture n'acceptent plus `PLANNED`.
+
+Le reporting client agrégé demeure explicitement indisponible : le moteur objet est réel, mais l'allocation multi-objets, les retours, avoirs et frais indirects ne sont pas encore exhaustivement réconciliés.
+
+## Retour arrière
+
+En test/dev, le script SOL-13 retire les colonnes et contraintes uniquement si aucune preuve v2, aucune nouvelle perspective et aucun taux `REWORK` n'existent. En production, le retour arrière impose la restauration du dump pré-migration afin de préserver la cohérence des preuves append-only.

--- a/docs/execution-reports/SOL-13.md
+++ b/docs/execution-reports/SOL-13.md
@@ -1,0 +1,58 @@
+# SOL-13 — Coûts industriels et marges traçables (backend)
+
+Date : 2026-08-11
+Branche : `fix/405-sol-13-margin-traceability`
+
+## Diagnostic et cause racine
+
+Le moteur opposait seulement `PLANNED` et `ACTUAL`, sans distinguer devis, standard daté et actualisé. Les preuves ne portaient pas systématiquement définition, unité, période, fraîcheur et fiabilité. Certaines quantités absentes pouvaient être transformées en zéro par des agrégats SQL, et les rebuts/retouches ou réceptions fournisseur n'étaient pas reliés à une preuve suffisamment explicite.
+
+## Choix d'architecture
+
+`CERP-MARGIN-2.0.0` est l'unique calcul autoritaire. Il publie `QUOTED`, `STANDARD`, `UPDATED`, `ACTUAL`, les statuts `ESTIMATED|PARTIAL|ACTUAL`, deux écarts serveur et un waterfall serveur. `ACTUAL` exige un calcul complet composé uniquement de preuves `VERIFIED`. Une entrée manquante maintient coût, marge et ratios à `null`.
+
+Les paramètres et entrées restent append-only et datés. Le contrat de preuve v2 exige définition, unité, période, fiabilité et document source pour une preuve vérifiée. Les anciennes preuves v1 restent lisibles sans être réécrites.
+
+## Fichiers modifiés
+
+- domaine, repository, service et validateurs de `src/module/margin-engine/`;
+- politiques de marge différée du reporting facturation;
+- tests numériques, RBAC, contrat, CSV et garde-fous de migration;
+- patch `db/patches/20260811_margin_traceability_0002.sql` et son trio preflight/verify/rollback;
+- `scripts/migrations/release-gate.js` pour exercer réellement le rollback SOL-13;
+- ADR-0061, runbook opérateur et audit exhaustif des usages.
+
+## Migration et données
+
+Le patch ajoute uniquement métadonnées et contraintes aux tables de marge; aucune valeur métier existante n'est réécrite. Il conserve `PLANNED` pour l'historique et autorise les quatre bases nouvelles ainsi que `REWORK`.
+
+La répétition PostgreSQL jetable finale a appliqué 6 patches, dont SOL-13 (SHA-256 `8639afd24dfbf6ecd49131d2247c506ec1ca7acc17346bfdbacb61aaf6582d61`), avec : sauvegarde 1 954 315 octets (SHA-256 `e1bdb51992d8b683124b1d45aababa1c51233726d4a624f4edeb890ea678091d`), preflight, intégrité, verify, rejeu à zéro, rollback SOL-13 en 56 ms et restauration en 4 038 ms. Le contrôle `margin_traceability_removed=true` prouve le retrait des objets SOL-13 avant restauration; les comptages restaurés sont identiques.
+
+La valorisation matière retenue est le CUMP, source : décision du dirigeant Keenan Martin du 11/08/2026, fiabilité `DECLARED`.
+
+## Tests et navigateur
+
+- cœur ciblé backend : 4 fichiers, 27 tests réussis;
+- suite backend complète finale : 269 fichiers, 4 453 tests réussis, 4 ignorés, aucun échec;
+- le premier passage global a détecté 3 assertions reporting devenues obsolètes; leur contrat a été aligné sur `CROSS_OBJECT_MARGIN_AGGREGATION_NOT_VALIDATED`, puis la suite complète a été rejouée avec succès;
+- `npm run typecheck` et `npm run build` réussis; frontière de données validée sur 633 fichiers source et 633 fichiers émis;
+- audit production backend : 0 vulnérabilité connue;
+- migration isolée : `passed`, 140 → 146 patches, aucun checksum divergent, restauration et rejeu idempotent réussis;
+- build réel de la pile E2E : backend et frontend démarrés sur loopback avec `cerp_test` jetable;
+- navigateur : connexion KEENAN, devis de preuve, onglet Rentabilité et drill-down vérifiés contre l'API réelle. Les quatre perspectives sont `PARTIAL`, les 48 entrées manquantes sont explicites, la formule et la période sont visibles, coûts et marges complets restent `—`.
+
+## Risques et compatibilité
+
+- Les consommateurs historiques peuvent encore lire les snapshots `PLANNED`; les nouveaux endpoints d'écriture les refusent.
+- La marge client agrégée reste volontairement indisponible tant que les allocations, retours, avoirs et frais indirects ne sont pas réconciliés.
+- Les rebuts/retouches positifs bloquent une marge complète tant qu'ils ne sont pas valorisés : c'est un garde-fou, pas une panne.
+- La migration prend brièvement des verrous exclusifs et abandonne après 5 secondes.
+
+## Rollback
+
+En `cerp_dev`/`cerp_test`, le rollback vérifie le SHA du ledger, prend le verrou de migration, refuse toute preuve v2 ou nouvelle perspective, retire les objets puis supprime exactement l'entrée ledger SOL-13. En production, arrêter les écritures et restaurer le dump pré-migration vérifié; ne pas exécuter un SQL inverse après création de preuves v2.
+
+## Reste réellement à faire
+
+- faire exécuter le gate SOL-12 de promotion sur les commits propres après fusion;
+- appliquer la migration sur une base persistante uniquement pendant une fenêtre autorisée avec sauvegarde vérifiée.

--- a/docs/release/MARGIN_USAGE_AUDIT_SOL_13.md
+++ b/docs/release/MARGIN_USAGE_AUDIT_SOL_13.md
@@ -1,0 +1,41 @@
+# Audit des usages « marge » — SOL-13
+
+Date : 2026-08-11
+Périmètre : `erp-crp-backend` et `crp-systems-web`
+
+## Verdict
+
+Le seul calcul financier publiable est `CERP-MARGIN-2.0.0`, servi par `/api/v1/margins`. Il distingue `QUOTED`, `STANDARD`, `UPDATED` et `ACTUAL`; chaque résultat porte définition, unité, période, fraîcheur, fiabilité, formule et preuves. Une entrée absente laisse coût et marge à `null`.
+
+## Usages décisionnels
+
+| Consommateur | Décision SOL-13 | Statut |
+|---|---|---|
+| `src/module/margin-engine/**` | Moteur autoritaire, quatre perspectives, waterfall et drill-down serveur | Branché |
+| `src/modules/devis/components/DevisRentabiliteTab.tsx` | Consomme exclusivement le moteur; aucun calcul React | Branché |
+| `src/modules/margin/components/margin-ledger.tsx` | Affiche fiabilité, période, fraîcheur, formule, sources et absences | Branché |
+| `src/modules/margin/components/margin-lines-table.tsx` | Interroge chaque ligne et affiche les écarts fournis par le serveur | Branché |
+| `src/modules/pieces-technique/pages/PieceTechniqueViewPage.tsx` | Ancienne « marge théorique » locale supprimée; redirection vers un devis/OF | Indisponible explicite |
+| `src/module/facturation/services/reporting-v2.service.ts` | `MARGIN_UNAVAILABLE`; aucune agrégation client approximative | Indisponible explicite |
+| `src/module/facturation/domain/reporting-policy.ts` | Explique que l'allocation multi-objets, avoirs, retours et frais indirects n'est pas réconciliée | Différé honnêtement |
+
+## Faux positifs exclus
+
+Les occurrences `margin` des générateurs PDF, e-mails HTML et géométrie de document désignent des marges de mise en page. Le mot-clé `marge` du poste opérateur relève de la recherche textuelle. Ils ne calculent ni ne publient une marge financière.
+
+## Sources de coût
+
+| Poste | Source actuelle | Règle d'absence |
+|---|---|---|
+| Prix/devis | devis et lignes, HT après remises | `null` si le périmètre n'existe pas |
+| Matière réelle | sorties stock `POSTED` liées à une réservation d'OF `CONSUMED`, valorisées au CUMP | coût unitaire absent = entrée manquante |
+| Temps prévu/réel | opérations d'OF et taux versionnés applicables à la date | heures ou taux absents = entrée manquante |
+| Sous-traitance | réception fournisseur × prix remisé + frais proratisés | réception ou prix absent = entrée manquante |
+| Rebuts/retouches | déclarations de production append-only | quantité positive non valorisée = entrée manquante |
+| Outillage, emballage, transport, frais indirects | entrée versionnée ou taux versionné | jamais de zéro implicite; `NOT_APPLICABLE` doit être explicite |
+
+## Limites assumées
+
+- La marge client consolidée reste indisponible jusqu'à la réconciliation exhaustive facture ↔ objet de marge.
+- Une quantité positive de rebut/retouche n'est pas monétisée arbitrairement : elle bloque la marge complète jusqu'à sa valorisation.
+- Les preuves `PLANNED` historiques restent lisibles comme repli standard hérité, mais aucune nouvelle écriture ne peut utiliser cette base ambiguë.

--- a/docs/runbooks/margin-traceability-sol13-migration.md
+++ b/docs/runbooks/margin-traceability-sol13-migration.md
@@ -1,0 +1,24 @@
+# Runbook opérateur — migration SOL-13 des marges
+
+## Fenêtre et sauvegarde
+
+La modification de contraintes prend brièvement un verrou exclusif sur quatre tables de marge. Prévoir une fenêtre sans écriture de taux, d'entrées ni de snapshots. Le patch abandonne après 5 secondes d'attente au lieu de bloquer l'ERP.
+
+1. Identifier le SHA applicatif et la base cible.
+2. Exécuter `db/patches/support/20260811_margin_traceability_0002.preflight.sql` en lecture seule.
+3. Produire un dump PostgreSQL chiffré selon le runbook SOL-10, puis vérifier taille et SHA-256.
+4. Appliquer `db/patches/20260811_margin_traceability_0002.sql` via le runner de migrations.
+5. Exécuter `db/patches/support/20260811_margin_traceability_0002.verify.sql`.
+6. Vérifier un devis et un OF : quatre perspectives, entrées manquantes explicites, export CSV avec preuve v2.
+
+## Contrôles post-migration
+
+- aucune ligne v2 sans définition, unité, période ou fiabilité;
+- contraintes de bases contenant `PLANNED`, `QUOTED`, `STANDARD`, `UPDATED`, `ACTUAL`;
+- `REWORK` accepté comme catégorie;
+- anciennes preuves `PLANNED` toujours listables;
+- application et worker au même SHA.
+
+## Retour arrière
+
+Avant toute preuve v2, le rollback fourni est autorisé uniquement sur `cerp_dev`/`cerp_test`. Après une écriture v2 ou en production : arrêter les écritures, conserver/exporter les preuves créées si nécessaire, puis restaurer le dump pré-migration. Ne jamais supprimer manuellement une preuve append-only.

--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -11,6 +11,7 @@ const PATCH_DIR = path.join(ROOT, "db", "patches");
 const SUPPORT_DIR = path.join(PATCH_DIR, "support");
 const SOL06_PATCH = "20260810_system_reference_data_readiness.sql";
 const PRODUCTION_READINESS_PATCH = "20260811_production_readiness_center.sql";
+const MARGIN_TRACEABILITY_PATCH = "20260811_margin_traceability_0002.sql";
 const SOL06_SUPPORT = path.join(SUPPORT_DIR, "20260810_system_reference_data_readiness");
 const POSTGRES_IMAGE = "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229";
 const DEFAULT_REPORT_DIR = path.join(ROOT, "docs", "release");
@@ -441,6 +442,17 @@ async function proveRollback(databaseUrl) {
   await client.connect();
   try {
     await client.query("SET cerp.migration_rehearsal = 'on'");
+    const marginTraceabilityRollback = patchSupportSql(MARGIN_TRACEABILITY_PATCH, "rollback");
+    const marginEvidenceColumn = await client.query(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_schema='public' AND table_name='margin_input_versions'
+           AND column_name='evidence_contract_version'
+       ) AS present`
+    );
+    if (marginTraceabilityRollback && marginEvidenceColumn.rows[0].present) {
+      await runSqlFile(client, marginTraceabilityRollback);
+    }
     const readinessRollback = patchSupportSql(PRODUCTION_READINESS_PATCH, "rollback");
     const readinessObject = await client.query(
       "SELECT to_regprocedure('public.fn_business_prerequisite_status_v2(text)') IS NOT NULL AS present"
@@ -452,9 +464,15 @@ async function proveRollback(databaseUrl) {
     const objects = await client.query(
       `SELECT to_regprocedure('public.fn_business_prerequisite_status(text)') IS NULL AS function_removed,
               to_regprocedure('public.fn_business_prerequisite_status_v2(text)') IS NULL AS function_v2_removed,
+              NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_schema='public' AND table_name='margin_input_versions'
+                  AND column_name='evidence_contract_version'
+              ) AS margin_traceability_removed,
               NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname='trg_stock_reference_readiness_2606') AS trigger_removed`
     );
-    if (!objects.rows[0].function_removed || !objects.rows[0].function_v2_removed || !objects.rows[0].trigger_removed) {
+    if (!objects.rows[0].function_removed || !objects.rows[0].function_v2_removed
+        || !objects.rows[0].margin_traceability_removed || !objects.rows[0].trigger_removed) {
       fail("rollback left SOL-06 objects behind");
     }
     return { status: "passed", ...objects.rows[0] };
@@ -656,6 +674,7 @@ if (require.main === module) {
 
 module.exports = {
   SOL06_PATCH,
+  MARGIN_TRACEABILITY_PATCH,
   expectedRehearsalPatches,
   inventory,
   inventoryMarkdown,

--- a/src/__tests__/margin-engine.domain.test.ts
+++ b/src/__tests__/margin-engine.domain.test.ts
@@ -9,6 +9,12 @@ import {
 } from "../module/margin-engine/domain/margin-engine";
 
 const EVIDENCE: MarginEvidence = {
+  definition: "Valeur de test",
+  unit: "EUR_HT",
+  period_start: "2026-08-05",
+  period_end: "2026-08-05",
+  freshness_at: "2026-08-05T08:00:00.000Z",
+  source_reliability: "VERIFIED",
   source_type: "TEST",
   source_ref: "TEST_TD_MARGIN_001",
   observed_at: "2026-08-05T08:00:00.000Z",
@@ -19,6 +25,8 @@ const EVIDENCE: MarginEvidence = {
   rate_effective_at: null,
   rate_scope_type: null,
   rate_scope_ref: null,
+  source_document_type: "TEST_CASE",
+  source_document_ref: "TEST_TD_MARGIN_001",
 };
 
 function na(category: MarginCostInput["category"]): MarginCostInput {
@@ -39,7 +47,7 @@ function provided(category: MarginCostInput["category"], amount: string): Margin
   return { ...na(category), key: `value:${category}`, availability: "PROVIDED", amount_ht: amount };
 }
 
-function input(costs: MarginCostInput[], basis: "PLANNED" | "ACTUAL" = "PLANNED"): MarginCalculationInput {
+function input(costs: MarginCostInput[], basis: "QUOTED" | "STANDARD" | "UPDATED" | "ACTUAL" = "STANDARD"): MarginCalculationInput {
   return {
     scope_type: "DEVIS",
     scope_ref: "1",
@@ -129,17 +137,51 @@ describe("margin engine formulas", () => {
     expect(result.cost_total_ht).toBe("100.00");
   });
 
-  it("computes planned/actual variance only when both calculations are complete", () => {
+  it("computes actual/standard variance only when both calculations are complete", () => {
     const complete = MARGIN_COST_CATEGORIES.map(na);
-    const planned = calculateMargin(input([...complete, provided("MATERIAL", "60")], "PLANNED"));
+    const quoted = calculateMargin(input([...complete, provided("MATERIAL", "60")], "QUOTED"));
+    const standard = calculateMargin(input([...complete, provided("MATERIAL", "60")], "STANDARD"));
+    const updated = calculateMargin(input([...complete, provided("MATERIAL", "62")], "UPDATED"));
     const actual = calculateMargin(input([...complete, provided("MATERIAL", "65")], "ACTUAL"));
-    expect(compareMargins(planned, actual).variance).toMatchObject({
+    expect(compareMargins(quoted, standard, updated, actual).variances.actual_vs_standard).toMatchObject({
       available: true,
       cost_ht: "5.00",
       gross_margin_ht: "-5.00",
     });
 
     const partialActual = calculateMargin(input([provided("MATERIAL", "65")], "ACTUAL"));
-    expect(compareMargins(planned, partialActual).variance.available).toBe(false);
+    expect(compareMargins(quoted, standard, updated, partialActual).variances.actual_vs_standard.available).toBe(false);
+  });
+
+  it("publishes reliability and a server-side waterfall without inventing missing steps", () => {
+    const complete = MARGIN_COST_CATEGORIES.map(na);
+    const actual = calculateMargin(input([
+      ...complete,
+      provided("MATERIAL", "20"),
+      provided("OPERATOR", "30"),
+      provided("SUBCONTRACTING", "10"),
+    ], "ACTUAL"));
+    expect(actual.reliability).toBe("ACTUAL");
+    expect(actual.waterfall.map((row) => [row.code, row.amount_ht, row.running_total_ht])).toEqual([
+      ["PRICE", "100.00", "100.00"],
+      ["MATERIAL", "-20.00", "80.00"],
+      ["TIME", "-30.00", "50.00"],
+      ["SUBCONTRACTING", "-10.00", "40.00"],
+      ["SCRAP_REWORK", "0.00", "40.00"],
+      ["OTHER", "0.00", "40.00"],
+      ["MARGIN", "40.00", "40.00"],
+    ]);
+    const partial = calculateMargin(input([provided("MATERIAL", "20")], "ACTUAL"));
+    expect(partial.reliability).toBe("PARTIAL");
+    expect(partial.waterfall.find((row) => row.code === "TIME")?.amount_ht).toBeNull();
+  });
+
+  it("publishes the oldest source freshness as the calculation freshness", () => {
+    const oldCost = {
+      ...provided("MATERIAL", "20"),
+      evidence: { ...EVIDENCE, freshness_at: "2026-08-01T08:00:00.000Z" },
+    };
+    const result = calculateMargin(input([...MARGIN_COST_CATEGORIES.map(na), oldCost]));
+    expect(result.freshness_at).toBe("2026-08-01T08:00:00.000Z");
   });
 });

--- a/src/__tests__/margin-engine.integration-contracts.test.ts
+++ b/src/__tests__/margin-engine.integration-contracts.test.ts
@@ -49,6 +49,13 @@ const rateRow: ManualInputRow = {
   rate_effective_from: "2026-01-01",
   rate_effective_to: "2026-12-31",
   created_by: 7,
+  definition: "Temps opérateur constaté",
+  unit: "HOUR",
+  period_start: "2026-08-05",
+  period_end: "2026-08-05",
+  source_reliability: "VERIFIED",
+  source_document_type: "OF_OPERATION",
+  source_document_ref: "42",
 };
 
 describe("margin rate resolution", () => {
@@ -73,6 +80,8 @@ describe("margin rate resolution", () => {
       scope_type: "OF", scope_ref: "42", basis: "ACTUAL", input_key: "operator-rate",
       input_kind: "COST", category: "OPERATOR", availability: "PROVIDED",
       quantity: 2, rate_id: rateRow.rate_id, rate_effective_at: "2026-08-05", source_type: "RATE_INPUT",
+      definition: "Temps opérateur valorisé", unit: "HOUR",
+      period_start: "2026-08-05", period_end: "2026-08-05", source_reliability: "DECLARED",
     });
     const globalRate = {
       id: rateRow.rate_id!, category: "OPERATOR" as const, unit: "EUR_PER_HOUR" as const,
@@ -115,15 +124,21 @@ describe("margin historical contract", () => {
 describe("margin governed CSV", () => {
   it("exports evidence, dated assumptions, rate proof, missing inputs, measurements and as_of", () => {
     const revenueEvidence: MarginEvidence = {
+      definition: "Prix de vente HT", unit: "EUR_HT", period_start: "2026-08-05", period_end: "2026-08-05",
+      freshness_at: "2026-08-05T08:00:00Z", source_reliability: "VERIFIED",
       source_type: "DEVIS_TOTAL_HT", source_ref: "7", observed_at: "2026-08-05T08:00:00Z",
       assumption: null, assumption_date: null, rate_version_id: null, rate_id: null,
       rate_effective_at: null, rate_scope_type: null, rate_scope_ref: null,
+      source_document_type: "DEVIS", source_document_ref: "7",
     };
     const costEvidence: MarginEvidence = {
+      definition: "Temps opérateur valorisé", unit: "EUR_HT", period_start: "2026-08-05", period_end: "2026-08-05",
+      freshness_at: "2026-08-05T09:00:00Z", source_reliability: "DECLARED",
       source_type: "RATE_INPUT", source_ref: "OF-42", observed_at: "2026-08-05T09:00:00Z",
       assumption: "Budget validé", assumption_date: "2026-08-01",
       rate_id: rateRow.rate_id, rate_version_id: rateRow.rate_version_id,
       rate_effective_at: rateRow.rate_effective_at, rate_scope_type: "GLOBAL", rate_scope_ref: null,
+      source_document_type: "OF", source_document_ref: "42",
     };
     const base = {
       scope_type: "OF" as const, scope_ref: "42", label: "TEST_TD_MARGIN_42",
@@ -134,11 +149,14 @@ describe("margin governed CSV", () => {
       }],
       measurements: { actual_hours: "2.0" },
     };
-    const planned = calculateMargin({ ...base, basis: "PLANNED" });
+    const quoted = calculateMargin({ ...base, basis: "QUOTED" });
+    const standard = calculateMargin({ ...base, basis: "STANDARD" });
+    const updated = calculateMargin({ ...base, basis: "UPDATED" });
     const actual = calculateMargin({ ...base, basis: "ACTUAL" });
-    const csv = renderMarginCsv({ ...compareMargins(planned, actual), generated_at: "2026-08-05T10:00:00Z" });
+    const csv = renderMarginCsv({ ...compareMargins(quoted, standard, updated, actual), generated_at: "2026-08-05T10:00:00Z" });
 
     for (const expected of [
+      "definition", "unit", "period_start", "period_end", "source_reliability",
       "source_type", "observed_at", "assumption_date", "rate_version_id", "rate_effective_at",
       "missing_code", "measurement_key", "as_of", "DEVIS_TOTAL_HT", "Budget validé",
       "MACHINE_MISSING", "actual_hours", "2026-08-05",

--- a/src/__tests__/margin-engine.policy-and-validation.test.ts
+++ b/src/__tests__/margin-engine.policy-and-validation.test.ts
@@ -2,6 +2,14 @@ import { describe, expect, it } from "vitest";
 import { canUseMarginCapability, roleHasMarginCapability } from "../module/margin-engine/domain/margin-engine-policy";
 import { createMarginInputSchema, createRateVersionSchema } from "../module/margin-engine/validators/margin-engine.validators";
 
+const evidenceContract = {
+  definition: "Décision de coût documentée",
+  unit: "EUR_HT",
+  period_start: "2026-08-01",
+  period_end: "2026-08-31",
+  source_reliability: "DECLARED" as const,
+};
+
 describe("margin engine RBAC", () => {
   it("denies unknown roles by default and separates read from administration", () => {
     expect(roleHasMarginCapability(null, "read_costs")).toBe(false);
@@ -33,9 +41,10 @@ describe("margin engine write contracts", () => {
 
   it("accepts explicit not-applicable and rejects a hidden value on it", () => {
     const base = {
-      scope_type: "DEVIS" as const, scope_ref: "1", basis: "PLANNED" as const,
+      scope_type: "DEVIS" as const, scope_ref: "1", basis: "QUOTED" as const,
       input_key: "tooling", input_kind: "COST" as const, category: "TOOLING" as const,
       source_type: "USER_DECISION", availability: "NOT_APPLICABLE" as const,
+      ...evidenceContract,
     };
     expect(createMarginInputSchema.safeParse(base).success).toBe(true);
     expect(createMarginInputSchema.safeParse({ ...base, amount_ht: 0 }).success).toBe(false);
@@ -44,7 +53,7 @@ describe("margin engine write contracts", () => {
   it("requires a source and effective date on every rate version", () => {
     const result = createRateVersionSchema.safeParse({
       code: "OPERATOR_2026", version: 1, effective_from: "2026-08-01",
-      assumption_date: "2026-07-31", source: "Budget validé DG",
+      assumption_date: "2026-07-31", source: "Budget validé DG", source_reliability: "DECLARED",
       rates: [{ rate_code: "OP", category: "OPERATOR", scope_type: "GLOBAL", amount: 55, unit: "EUR_PER_HOUR" }],
     });
     expect(result.success).toBe(true);
@@ -56,6 +65,7 @@ describe("margin engine write contracts", () => {
       input_key: "operator", input_kind: "COST" as const, category: "OPERATOR" as const,
       availability: "PROVIDED" as const, source_type: "RATE_INPUT",
       rate_id: "11111111-1111-4111-8111-111111111111", quantity: 2,
+      ...evidenceContract,
     };
     expect(createMarginInputSchema.safeParse(base).success).toBe(false);
     expect(createMarginInputSchema.safeParse({ ...base, rate_effective_at: "2026-08-05" }).success).toBe(true);

--- a/src/__tests__/margin-traceability-sol13.migration-guards.test.ts
+++ b/src/__tests__/margin-traceability-sol13.migration-guards.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { repoRoot } from "./helpers/repo-paths";
+
+const patchName = "20260811_margin_traceability_0002";
+const patch = fs.readFileSync(path.join(repoRoot, "db", "patches", `${patchName}.sql`), "utf8");
+const repository = fs.readFileSync(path.join(repoRoot, "src", "module", "margin-engine", "repository", "margin-engine.repository.ts"), "utf8");
+const support = path.join(repoRoot, "db", "patches", "support");
+const releaseGate = fs.readFileSync(path.join(repoRoot, "scripts", "migrations", "release-gate.js"), "utf8");
+
+describe("SOL-13 margin traceability migration guards", () => {
+  it("only changes governed margin metadata and constraints", () => {
+    expect(patch).toContain("SET LOCAL lock_timeout = '5s'");
+    expect(patch).not.toMatch(/\bTRUNCATE\b/i);
+    expect(patch).not.toMatch(/\bDELETE\s+FROM\b/i);
+    expect(patch).not.toMatch(/\bUPDATE\s+(?:public\.)?(?:devis|affaire|ordres_fabrication|stock_movements)\b/i);
+    expect(patch).not.toMatch(/DROP\s+TABLE/i);
+  });
+
+  it("keeps legacy PLANNED evidence readable while governing four explicit perspectives", () => {
+    for (const basis of ["QUOTED", "STANDARD", "UPDATED", "ACTUAL"]) expect(patch).toContain(`'${basis}'`);
+    expect(patch).toContain("'PLANNED'");
+    expect(patch).toContain("evidence_contract_version");
+    expect(patch).toContain("source_reliability");
+    expect(patch).toMatch(/source_reliability <> 'VERIFIED'[\s\S]*source_document_type[\s\S]*source_document_ref/);
+    expect(patch).toContain("'REWORK'");
+  });
+
+  it("ships preflight, post-validation and a guarded non-production rollback", () => {
+    for (const suffix of ["preflight.sql", "verify.sql", "rollback.sql"]) {
+      expect(fs.existsSync(path.join(support, `${patchName}.${suffix}`))).toBe(true);
+    }
+    const preflight = fs.readFileSync(path.join(support, `${patchName}.preflight.sql`), "utf8");
+    const verify = fs.readFileSync(path.join(support, `${patchName}.verify.sql`), "utf8");
+    const rollback = fs.readFileSync(path.join(support, `${patchName}.rollback.sql`), "utf8");
+    expect(preflight).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(verify).toContain("BEGIN TRANSACTION READ ONLY");
+    expect(rollback).toContain("restricted to cerp_dev/cerp_test");
+    expect(rollback).toContain("restore the pre-migration backup in production");
+    expect(preflight).toContain("bc0706c2af406d9a8e9f8221beb05492f9f0f7eba879de26cb77c8542863f514");
+    expect(verify).toContain("8639afd24dfbf6ecd49131d2247c506ec1ca7acc17346bfdbacb61aaf6582d61");
+    expect(rollback).toContain("pg_advisory_xact_lock(hashtext('cerp_schema_migrations'))");
+    expect(rollback).toContain("DELETE FROM public.cerp_schema_migrations");
+    expect(releaseGate).toContain('const MARGIN_TRACEABILITY_PATCH = "20260811_margin_traceability_0002.sql"');
+    expect(releaseGate).toContain("margin_traceability_removed");
+    expect(rollback).not.toMatch(/\bCASCADE\b/i);
+  });
+
+  it("uses canonical actual stock, supplier receipt and declaration evidence", () => {
+    expect(repository).toContain("STOCK_CUMP_CONSUMPTION");
+    expect(repository).toContain("reservation.status::text = 'CONSUMED'");
+    expect(repository).toContain("SUPPLIER_RECEPTION_ACTUAL");
+    expect(repository).toContain("PRODUCTION_QUANTITY_DECLARATIONS");
+    expect(repository).not.toMatch(/COALESCE\(\(SELECT sum\(qty_(?:good|scrap|rework)/i);
+  });
+
+  it("never substitutes actual OF hours for a missing quoted cost", () => {
+    expect(repository).toContain('identity.scope_type === "OF" && basis !== "QUOTED"');
+    expect(repository).not.toMatch(/identity\.scope_type === "OF"\)\s*\{\s*const ofData = await loadOfCosts/);
+  });
+});

--- a/src/__tests__/reporting-360-275.domain.test.ts
+++ b/src/__tests__/reporting-360-275.domain.test.ts
@@ -450,11 +450,17 @@ describe("#275 catalogue de métriques", () => {
 describe("#275 marge", () => {
   it("est déclarée indisponible, jamais nulle", () => {
     expect(MARGIN_UNAVAILABLE.available).toBe(false);
-    expect(MARGIN_UNAVAILABLE.message).toContain("Marge réelle indisponible");
+    expect(MARGIN_UNAVAILABLE.reason_code).toBe("CROSS_OBJECT_MARGIN_AGGREGATION_NOT_VALIDATED");
+    expect(MARGIN_UNAVAILABLE.message).toContain("Marge client indisponible");
   });
 
-  it("énumère les entrées manquantes du modèle de coût", () => {
-    for (const input of ["temps_reel_par_of", "taux_horaires_dates", "frais_indirects"]) {
+  it("énumère les réconciliations manquantes du reporting client", () => {
+    for (const input of [
+      "allocation_objet_vers_client",
+      "allocation_frais_indirects",
+      "traitement_retours_et_avoirs",
+      "reconciliation_facture_objet_marge",
+    ]) {
       expect(MARGIN_UNAVAILABLE.missing_inputs).toContain(input);
     }
   });

--- a/src/__tests__/reporting-360-275.routes.test.ts
+++ b/src/__tests__/reporting-360-275.routes.test.ts
@@ -163,7 +163,8 @@ describe("#275 synthèse — cloisonnement des blocs", () => {
   it("ne renvoie jamais une marge chiffrée", async () => {
     const res = await request(app).get(`${BASE}/overview`);
     expect(res.body.data.margin.available).toBe(false);
-    expect(res.body.data.margin.message).toContain("Marge réelle indisponible");
+    expect(res.body.data.margin.reason_code).toBe("CROSS_OBJECT_MARGIN_AGGREGATION_NOT_VALIDATED");
+    expect(res.body.data.margin.message).toContain("Marge client indisponible");
     expect(typeof res.body.data.margin.value).toBe("undefined");
   });
 });

--- a/src/module/facturation/domain/reporting-metrics.ts
+++ b/src/module/facturation/domain/reporting-metrics.ts
@@ -929,7 +929,7 @@ const CATALOG: MetricDefinition[] = [
     owner: "Contrôle de gestion",
     availability: "deferred",
     limitations: [
-      "Bloquant : aucun coût réel transverse et exhaustif n'est modélisé (voir MARGIN_UNAVAILABLE).",
+      "Bloquant : l'allocation et la réconciliation multi-objets par client ne sont pas exhaustives (voir MARGIN_UNAVAILABLE).",
       "Interdit d'afficher une marge estimée sous le libellé « marge réelle », « rentabilité » ou « contribution ».",
     ],
   },

--- a/src/module/facturation/domain/reporting-policy.ts
+++ b/src/module/facturation/domain/reporting-policy.ts
@@ -407,25 +407,20 @@ export type ReportingCapability = (typeof REPORTING_CAPABILITIES)[number];
 // ---------------------------------------------------------------------------
 
 /**
- * Aucun coût réel transverse (matière consommée, temps réel, taux horaires,
- * sous-traitance, rebuts, valorisation stock, frais indirects) n'est modélisé de
- * façon exhaustive et datée. Toute marge affichée serait une fiction.
- * L'API renvoie donc l'indisponibilité explicitement — jamais zéro.
+ * Le moteur de marge objet publie des perspectives traçables, mais le reporting
+ * client ne dispose pas encore d'une allocation exhaustive et réconciliée des
+ * avoirs, retours, frais indirects et objets multi-clients. Agréger partiellement
+ * ces objets fabriquerait un total trompeur ; l'API reste donc indisponible.
  */
 export const MARGIN_UNAVAILABLE = {
   available: false,
-  reason_code: "REAL_COST_MODEL_NOT_VALIDATED",
+  reason_code: "CROSS_OBJECT_MARGIN_AGGREGATION_NOT_VALIDATED",
   message:
-    "Marge réelle indisponible — modèle de coût réel non validé (matière consommée, temps réel, taux horaires, sous-traitance, rebuts, valorisation stock, frais indirects).",
+    "Marge client indisponible — l'allocation exhaustive des objets de marge, retours, avoirs et frais indirects n'est pas encore réconciliée.",
   missing_inputs: [
-    "matiere_reellement_consommee",
-    "temps_reel_par_of",
-    "taux_horaires_dates",
-    "sous_traitance",
-    "rebuts_et_reprises",
-    "valorisation_stock",
-    "frais_indirects",
-    "cout_applicable_a_la_date",
+    "allocation_objet_vers_client",
+    "allocation_frais_indirects",
     "traitement_retours_et_avoirs",
+    "reconciliation_facture_objet_marge",
   ],
 } as const;

--- a/src/module/margin-engine/domain/margin-engine.ts
+++ b/src/module/margin-engine/domain/margin-engine.ts
@@ -1,6 +1,6 @@
 import crypto from "node:crypto";
 
-export const MARGIN_FORMULA_VERSION = "CERP-MARGIN-1.0.0" as const;
+export const MARGIN_FORMULA_VERSION = "CERP-MARGIN-2.0.0" as const;
 export const MARGIN_CURRENCY = "EUR" as const;
 
 export const MARGIN_COST_CATEGORIES = [
@@ -14,10 +14,14 @@ export const MARGIN_COST_CATEGORIES = [
   "PACKAGING",
   "TRANSPORT",
   "SCRAP",
+  "REWORK",
   "OVERHEAD",
 ] as const;
 export type MarginCostCategory = (typeof MARGIN_COST_CATEGORIES)[number];
-export type MarginBasis = "PLANNED" | "ACTUAL";
+export const MARGIN_BASES = ["QUOTED", "STANDARD", "UPDATED", "ACTUAL"] as const;
+export type MarginBasis = (typeof MARGIN_BASES)[number];
+export type MarginReliability = "ESTIMATED" | "PARTIAL" | "ACTUAL";
+export type MarginSourceReliability = "ESTIMATED" | "DECLARED" | "VERIFIED" | "UNKNOWN";
 export type MarginScopeType = "DEVIS_LINE" | "DEVIS" | "AFFAIRE" | "OF";
 export type MarginInputAvailability = "PROVIDED" | "NOT_APPLICABLE";
 export type MarginRateUnit = "EUR_PER_HOUR" | "EUR_PER_UNIT" | "PERCENT_OF_DIRECT_COST";
@@ -82,6 +86,12 @@ function percentage(numerator: bigint, denominator: bigint): string | null {
 }
 
 export type MarginEvidence = {
+  definition: string;
+  unit: string;
+  period_start: string;
+  period_end: string;
+  freshness_at: string | null;
+  source_reliability: MarginSourceReliability;
   source_type: string;
   source_ref: string | null;
   observed_at: string | null;
@@ -92,6 +102,8 @@ export type MarginEvidence = {
   rate_effective_at: string | null;
   rate_scope_type: string | null;
   rate_scope_ref: string | null;
+  source_document_type: string | null;
+  source_document_ref: string | null;
 };
 
 export type MarginCostInput = {
@@ -154,6 +166,16 @@ export type MarginCalculation = {
   as_of: string;
   currency: string;
   availability: "COMPLETE" | "PARTIAL" | "UNAVAILABLE";
+  reliability: MarginReliability;
+  reliability_reasons: string[];
+  definition: string;
+  period: { start: string; end: string };
+  freshness_at: string | null;
+  formula: {
+    gross_margin: "revenue_ht - cost_total_ht";
+    margin_rate: "gross_margin_ht / cost_total_ht * 100";
+    mark_rate: "gross_margin_ht / revenue_ht * 100";
+  };
   revenue_ht: string | null;
   revenue_evidence: MarginEvidence | null;
   cost_total_ht: string | null;
@@ -169,8 +191,74 @@ export type MarginCalculation = {
   }>;
   missing_inputs: Array<{ code: string; category: MarginCostCategory | "REVENUE"; message: string }>;
   measurements: Record<string, string | number | null>;
+  waterfall: Array<{
+    code: "PRICE" | "MATERIAL" | "TIME" | "SUBCONTRACTING" | "SCRAP_REWORK" | "OTHER" | "MARGIN";
+    label: string;
+    amount_ht: string | null;
+    running_total_ht: string | null;
+    available: boolean;
+    source_categories: MarginCostCategory[];
+  }>;
   calculation_hash: string;
 };
+
+function limitingFreshness(evidenceRows: Array<MarginEvidence | null>): string | null {
+  const values = evidenceRows.flatMap((row) => row?.freshness_at ? [row.freshness_at] : []);
+  return values.length > 0 ? values.sort().at(0)! : null;
+}
+
+function sumCategories(
+  components: MarginCalculation["components"],
+  categories: MarginCostCategory[],
+): { amount: bigint | null; available: boolean } {
+  const selected = components.filter((component) => categories.includes(component.category));
+  if (selected.some((component) => component.status === "MISSING")) return { amount: null, available: false };
+  return {
+    amount: selected.reduce((sum, component) => sum + (component.amount_ht === null ? 0n : decimal(component.amount_ht)), 0n),
+    available: true,
+  };
+}
+
+function buildWaterfall(
+  revenue: bigint | null,
+  components: MarginCalculation["components"],
+  grossMargin: bigint | null,
+): MarginCalculation["waterfall"] {
+  const groups: Array<{
+    code: MarginCalculation["waterfall"][number]["code"];
+    label: string;
+    categories: MarginCostCategory[];
+  }> = [
+    { code: "MATERIAL", label: "Matière et achats", categories: ["MATERIAL", "PURCHASE"] },
+    { code: "TIME", label: "Temps machine et main-d'œuvre", categories: ["MACHINE", "OPERATOR", "CONTROL"] },
+    { code: "SUBCONTRACTING", label: "Sous-traitance", categories: ["SUBCONTRACTING"] },
+    { code: "SCRAP_REWORK", label: "Rebuts et retouches", categories: ["SCRAP", "REWORK"] },
+    { code: "OTHER", label: "Autres coûts", categories: ["TOOLING", "PACKAGING", "TRANSPORT", "OVERHEAD"] },
+  ];
+  let running = revenue;
+  const rows: MarginCalculation["waterfall"] = [{
+    code: "PRICE", label: "Prix de vente HT", amount_ht: revenue === null ? null : money(revenue),
+    running_total_ht: revenue === null ? null : money(revenue), available: revenue !== null, source_categories: [],
+  }];
+  for (const group of groups) {
+    const value = sumCategories(components, group.categories);
+    if (running !== null && value.amount !== null) running -= value.amount;
+    else running = null;
+    rows.push({
+      code: group.code,
+      label: group.label,
+      amount_ht: value.amount === null ? null : money(-value.amount),
+      running_total_ht: running === null ? null : money(running),
+      available: value.available,
+      source_categories: group.categories,
+    });
+  }
+  rows.push({
+    code: "MARGIN", label: "Marge brute HT", amount_ht: grossMargin === null ? null : money(grossMargin),
+    running_total_ht: grossMargin === null ? null : money(grossMargin), available: grossMargin !== null, source_categories: [],
+  });
+  return rows;
+}
 
 export function calculateMargin(input: MarginCalculationInput): MarginCalculation {
   const required = input.required_categories ?? MARGIN_COST_CATEGORIES;
@@ -222,6 +310,26 @@ export function calculateMargin(input: MarginCalculationInput): MarginCalculatio
       ? "UNAVAILABLE"
       : "PARTIAL";
 
+  const providedEvidence = resolved
+    .filter((entry) => entry.row.availability === "PROVIDED")
+    .map((entry) => entry.row.evidence);
+  if (input.revenue?.availability === "PROVIDED") providedEvidence.push(input.revenue.evidence);
+  const reliabilityReasons: string[] = [];
+  let reliability: MarginReliability;
+  if (!complete) {
+    reliability = "PARTIAL";
+    reliabilityReasons.push("Au moins une donnée requise est absente ou non valorisable.");
+  } else if (input.basis === "ACTUAL" && providedEvidence.every((row) => row.source_reliability === "VERIFIED")) {
+    reliability = "ACTUAL";
+    reliabilityReasons.push("Toutes les valeurs publiées proviennent de sources constatées et vérifiées.");
+  } else {
+    reliability = "ESTIMATED";
+    reliabilityReasons.push(input.basis === "ACTUAL"
+      ? "Le périmètre réel contient au moins une donnée déclarée ou estimée."
+      : "Cette perspective utilise par définition des hypothèses ou paramètres prévisionnels.");
+  }
+  const freshnessAt = limitingFreshness(providedEvidence);
+
   const unsigned = {
     formula_version: MARGIN_FORMULA_VERSION,
     scope: { type: input.scope_type, ref: input.scope_ref, label: input.label },
@@ -229,6 +337,22 @@ export function calculateMargin(input: MarginCalculationInput): MarginCalculatio
     as_of: input.as_of,
     currency: input.revenue?.currency ?? MARGIN_CURRENCY,
     availability,
+    reliability,
+    reliability_reasons: reliabilityReasons,
+    definition: input.basis === "QUOTED"
+      ? "Marge issue des coûts et du prix figés dans le devis."
+      : input.basis === "STANDARD"
+        ? "Marge calculée avec les quantités prévues et les paramètres de coût applicables à la date."
+        : input.basis === "UPDATED"
+          ? "Marge actualisée à date : coûts engagés disponibles et temps à terminaison valorisé sur max(prévu, réel), sans remplacer les inconnues par zéro."
+          : "Marge constatée à partir des consommations, temps, achats, rebuts et retouches enregistrés.",
+    period: { start: input.as_of, end: input.as_of },
+    freshness_at: freshnessAt,
+    formula: {
+      gross_margin: "revenue_ht - cost_total_ht" as const,
+      margin_rate: "gross_margin_ht / cost_total_ht * 100" as const,
+      mark_rate: "gross_margin_ht / revenue_ht * 100" as const,
+    },
     revenue_ht: revenue === null ? null : money(revenue),
     revenue_evidence: input.revenue?.evidence ?? null,
     cost_total_ht: costTotal === null ? null : money(costTotal),
@@ -240,39 +364,64 @@ export function calculateMargin(input: MarginCalculationInput): MarginCalculatio
     components,
     missing_inputs: missing,
     measurements: input.measurements ?? {},
+    waterfall: buildWaterfall(revenue, components, grossMargin),
   };
   const calculation_hash = crypto.createHash("sha256").update(JSON.stringify(unsigned)).digest("hex");
   return { ...unsigned, calculation_hash };
 }
 
 export type MarginComparison = {
-  planned: MarginCalculation;
+  quoted: MarginCalculation;
+  standard: MarginCalculation;
+  updated: MarginCalculation;
   actual: MarginCalculation;
-  variance: {
-    available: boolean;
-    cost_ht: string | null;
-    gross_margin_ht: string | null;
-    reason: string | null;
+  variances: {
+    actual_vs_standard: {
+      available: boolean;
+      cost_ht: string | null;
+      gross_margin_ht: string | null;
+      reason: string | null;
+    };
+    updated_vs_quoted: {
+      available: boolean;
+      cost_ht: string | null;
+      gross_margin_ht: string | null;
+      reason: string | null;
+    };
   };
 };
 
-export function compareMargins(planned: MarginCalculation, actual: MarginCalculation): MarginComparison {
-  const canCompare = planned.cost_total_ht !== null && actual.cost_total_ht !== null && planned.gross_margin_ht !== null && actual.gross_margin_ht !== null;
+function variance(left: MarginCalculation, right: MarginCalculation) {
+  const canCompare = left.cost_total_ht !== null && right.cost_total_ht !== null && left.gross_margin_ht !== null && right.gross_margin_ht !== null;
+  return canCompare
+    ? {
+        available: true,
+        cost_ht: money(decimal(right.cost_total_ht!) - decimal(left.cost_total_ht!)),
+        gross_margin_ht: money(decimal(right.gross_margin_ht!) - decimal(left.gross_margin_ht!)),
+        reason: null,
+      }
+    : {
+        available: false,
+        cost_ht: null,
+        gross_margin_ht: null,
+        reason: "Écart indisponible tant que les deux perspectives ne sont pas complètes.",
+      };
+}
+
+export function compareMargins(
+  quoted: MarginCalculation,
+  standard: MarginCalculation,
+  updated: MarginCalculation,
+  actual: MarginCalculation,
+): MarginComparison {
   return {
-    planned,
+    quoted,
+    standard,
+    updated,
     actual,
-    variance: canCompare
-      ? {
-          available: true,
-          cost_ht: money(decimal(actual.cost_total_ht!) - decimal(planned.cost_total_ht!)),
-          gross_margin_ht: money(decimal(actual.gross_margin_ht!) - decimal(planned.gross_margin_ht!)),
-          reason: null,
-        }
-      : {
-          available: false,
-          cost_ht: null,
-          gross_margin_ht: null,
-          reason: "Écart indisponible tant que les entrées prévues et réelles ne sont pas complètes.",
-        },
+    variances: {
+      actual_vs_standard: variance(standard, actual),
+      updated_vs_quoted: variance(quoted, updated),
+    },
   };
 }

--- a/src/module/margin-engine/repository/margin-engine.repository.ts
+++ b/src/module/margin-engine/repository/margin-engine.repository.ts
@@ -18,6 +18,7 @@ type ScopeIdentity = {
   scope_ref: string;
   label: string;
   revenue_ht: string | null;
+  source_observed_at: string | null;
 };
 
 export type MarginAuditContext = {
@@ -61,7 +62,21 @@ async function auditMutation(
   });
 }
 
-const evidence = (sourceType: string, sourceRef: string | null, observedAt: string | null = null): MarginEvidence => ({
+const evidence = (
+  sourceType: string,
+  sourceRef: string | null,
+  observedAt: string | null = null,
+  metadata: Partial<Pick<MarginEvidence,
+    "definition" | "unit" | "period_start" | "period_end" | "freshness_at" |
+    "source_reliability" | "source_document_type" | "source_document_ref"
+  >> = {},
+): MarginEvidence => ({
+  definition: metadata.definition ?? `Valeur issue de ${sourceType}.`,
+  unit: metadata.unit ?? "EUR_HT",
+  period_start: metadata.period_start ?? observedAt?.slice(0, 10) ?? "non-renseignée",
+  period_end: metadata.period_end ?? observedAt?.slice(0, 10) ?? "non-renseignée",
+  freshness_at: metadata.freshness_at ?? observedAt,
+  source_reliability: metadata.source_reliability ?? "UNKNOWN",
   source_type: sourceType,
   source_ref: sourceRef,
   observed_at: observedAt,
@@ -72,12 +87,14 @@ const evidence = (sourceType: string, sourceRef: string | null, observedAt: stri
   rate_effective_at: null,
   rate_scope_type: null,
   rate_scope_ref: null,
+  source_document_type: metadata.source_document_type ?? sourceType,
+  source_document_ref: metadata.source_document_ref ?? sourceRef,
 });
 
 function automaticCost(row: {
   key: string;
   category: MarginCostInput["category"];
-  amount_ht: string;
+  amount_ht: string | null;
   source_type: string;
   source_ref: string | null;
   observed_at: string | null;
@@ -92,7 +109,15 @@ function automaticCost(row: {
     rate: null,
     rate_unit: null,
     currency: "EUR",
-    evidence: { ...evidence(row.source_type, row.source_ref, row.observed_at), rate_version_id: row.rate_version_id ?? null },
+    evidence: {
+      ...evidence(row.source_type, row.source_ref, row.observed_at, {
+        definition: `Coût HT calculé depuis ${row.source_type}.`,
+        source_reliability: row.source_type.includes("RECALC") || row.source_type.includes("STOCK") || row.source_type.includes("RECEPTION")
+          ? "VERIFIED"
+          : "ESTIMATED",
+      }),
+      rate_version_id: row.rate_version_id ?? null,
+    },
   };
 }
 
@@ -101,7 +126,8 @@ export async function repoLoadScopeIdentity(scopeType: MarginScopeType, scopeRef
     const result = await pool.query<ScopeIdentity>(`
       SELECT 'DEVIS_LINE'::text AS scope_type, dl.id::text AS scope_ref,
              concat(d.numero, ' · ', COALESCE(NULLIF(dl.description, ''), 'ligne ' || dl.id::text)) AS label,
-             round(dl.total_ht * (1 - COALESCE(d.remise_globale, 0) / 100.0), 6)::text AS revenue_ht
+             round(dl.total_ht * (1 - COALESCE(d.remise_globale, 0) / 100.0), 6)::text AS revenue_ht,
+             d.updated_at::text AS source_observed_at
       FROM public.devis_ligne dl
       JOIN public.devis d ON d.id = dl.devis_id
       WHERE dl.id = $1::bigint
@@ -111,20 +137,23 @@ export async function repoLoadScopeIdentity(scopeType: MarginScopeType, scopeRef
   if (scopeType === "DEVIS") {
     const result = await pool.query<ScopeIdentity>(`
       SELECT 'DEVIS'::text AS scope_type, id::text AS scope_ref, numero::text AS label,
-             total_ht::text AS revenue_ht FROM public.devis WHERE id = $1::bigint
+             total_ht::text AS revenue_ht, updated_at::text AS source_observed_at
+      FROM public.devis WHERE id = $1::bigint
     `, [scopeRef]);
     return result.rows[0] ?? null;
   }
   if (scopeType === "AFFAIRE") {
     const result = await pool.query<ScopeIdentity>(`
       SELECT 'AFFAIRE'::text AS scope_type, id::text AS scope_ref, reference::text AS label,
-             NULL::text AS revenue_ht FROM public.affaire WHERE id = $1::bigint
+             NULL::text AS revenue_ht, NULL::text AS source_observed_at
+      FROM public.affaire WHERE id = $1::bigint
     `, [scopeRef]);
     return result.rows[0] ?? null;
   }
   const result = await pool.query<ScopeIdentity>(`
     SELECT 'OF'::text AS scope_type, id::text AS scope_ref, numero::text AS label,
-           NULL::text AS revenue_ht FROM public.ordres_fabrication WHERE id = $1::bigint
+           NULL::text AS revenue_ht, NULL::text AS source_observed_at
+    FROM public.ordres_fabrication WHERE id = $1::bigint
   `, [scopeRef]);
   return result.rows[0] ?? null;
 }
@@ -132,7 +161,7 @@ export async function repoLoadScopeIdentity(scopeType: MarginScopeType, scopeRef
 type CostRow = {
   key: string;
   category: MarginCostInput["category"];
-  amount_ht: string;
+  amount_ht: string | null;
   source_type: string;
   source_ref: string | null;
   observed_at: string | null;
@@ -179,12 +208,20 @@ async function loadDevisCosts(scopeType: "DEVIS_LINE" | "DEVIS", scopeRef: strin
 }
 
 async function loadOfCosts(scopeRef: string, basis: MarginBasis): Promise<{ costs: MarginCostInput[]; measurements: Record<string, string | number | null> }> {
-  const hoursColumn = basis === "PLANNED" ? "op.temps_total_planned" : "op.temps_total_real";
+  const hoursColumn = basis === "STANDARD"
+    ? "op.temps_total_planned"
+    : basis === "UPDATED"
+      ? "GREATEST(op.temps_total_planned, op.temps_total_real)"
+      : "op.temps_total_real";
   const result = await pool.query<CostRow>(`
     SELECT concat('of-operation:', op.id::text) AS key,
            CASE WHEN op.designation ILIKE '%contrôle%' OR op.designation ILIKE '%controle%' THEN 'CONTROL' ELSE 'OPERATOR' END::text AS category,
            round(op.hourly_rate_applied * ${hoursColumn}, 6)::text AS amount_ht,
-           ${basis === "PLANNED" ? "'OF_OPERATION_PLAN'" : "'PRODUCTION_POINTAGES_RECALC'"}::text AS source_type,
+           ${basis === "STANDARD"
+             ? "'OF_OPERATION_STANDARD'"
+             : basis === "UPDATED"
+               ? "'OF_OPERATION_ESTIMATE_AT_COMPLETION'"
+               : "'PRODUCTION_POINTAGES_RECALC'"}::text AS source_type,
            op.id::text AS source_ref,
            op.updated_at::text AS observed_at
     FROM public.of_operations op
@@ -194,23 +231,108 @@ async function loadOfCosts(scopeRef: string, basis: MarginBasis): Promise<{ cost
     ORDER BY op.phase, op.id
   `, [scopeRef]);
   const measureResult = await pool.query<{
-    planned_hours: string;
-    actual_hours: string;
-    good_quantity: string;
-    scrap_quantity: string;
-    rework_quantity: string;
+    planned_hours: string | null;
+    actual_hours: string | null;
+    good_quantity: string | null;
+    scrap_quantity: string | null;
+    rework_quantity: string | null;
+    declaration_count: number;
+    declaration_freshness: string | null;
   }>(`
     SELECT
-      COALESCE((SELECT sum(temps_total_planned) FROM public.of_operations WHERE of_id = $1::bigint), 0)::text AS planned_hours,
-      COALESCE((SELECT sum(temps_total_real) FROM public.of_operations WHERE of_id = $1::bigint), 0)::text AS actual_hours,
-      COALESCE((SELECT sum(qty_good) FROM public.production_quantity_declarations WHERE of_id = $1::bigint), 0)::text AS good_quantity,
-      COALESCE((SELECT sum(qty_scrap) FROM public.production_quantity_declarations WHERE of_id = $1::bigint), 0)::text AS scrap_quantity,
-      COALESCE((SELECT sum(qty_rework) FROM public.production_quantity_declarations WHERE of_id = $1::bigint), 0)::text AS rework_quantity
+      (SELECT sum(temps_total_planned) FROM public.of_operations WHERE of_id = $1::bigint)::text AS planned_hours,
+      (SELECT sum(temps_total_real) FROM public.of_operations WHERE of_id = $1::bigint)::text AS actual_hours,
+      (SELECT sum(qty_good) FROM public.production_quantity_declarations WHERE of_id = $1::bigint)::text AS good_quantity,
+      (SELECT sum(qty_scrap) FROM public.production_quantity_declarations WHERE of_id = $1::bigint)::text AS scrap_quantity,
+      (SELECT sum(qty_rework) FROM public.production_quantity_declarations WHERE of_id = $1::bigint)::text AS rework_quantity,
+      (SELECT count(*)::integer FROM public.production_quantity_declarations WHERE of_id = $1::bigint) AS declaration_count,
+      (SELECT max(declared_at)::text FROM public.production_quantity_declarations WHERE of_id = $1::bigint) AS declaration_freshness
   `, [scopeRef]);
-  return {
-    costs: result.rows.map(automaticCost),
-    measurements: measureResult.rows[0] ?? {},
+  const measures = measureResult.rows[0] ?? {
+    planned_hours: null, actual_hours: null, good_quantity: null,
+    scrap_quantity: null, rework_quantity: null, declaration_count: 0, declaration_freshness: null,
   };
+  const quantityCosts: MarginCostInput[] = [];
+  if ((basis === "ACTUAL" || basis === "UPDATED") && measures.declaration_count > 0) {
+    for (const [category, quantity] of [["SCRAP", measures.scrap_quantity], ["REWORK", measures.rework_quantity]] as const) {
+      quantityCosts.push({
+        key: `production-quantity:${category.toLowerCase()}`,
+        category,
+        availability: quantity !== null && Number(quantity) === 0 ? "NOT_APPLICABLE" : "PROVIDED",
+        amount_ht: null,
+        quantity,
+        rate: null,
+        rate_unit: null,
+        currency: "EUR",
+        evidence: evidence("PRODUCTION_QUANTITY_DECLARATIONS", scopeRef, measures.declaration_freshness, {
+          definition: `${category === "SCRAP" ? "Rebuts" : "Retouches"} déclarés sur l'OF ; une quantité positive exige une valorisation versionnée.`,
+          unit: "UNIT",
+          source_reliability: "VERIFIED",
+          source_document_type: "OF",
+          source_document_ref: scopeRef,
+        }),
+      });
+    }
+  }
+  const actualCosts = basis === "ACTUAL" || basis === "UPDATED"
+    ? [...await loadActualMaterialCosts(scopeRef), ...await loadActualSubcontractingCosts(scopeRef)]
+    : [];
+  return {
+    costs: [...result.rows.map(automaticCost), ...actualCosts, ...quantityCosts],
+    measurements: measures,
+  };
+}
+
+async function loadActualMaterialCosts(scopeRef: string): Promise<MarginCostInput[]> {
+  const rows = await pool.query<CostRow>(`
+    SELECT concat('stock-consumption:', line.id::text) AS key,
+           'MATERIAL'::text AS category,
+           CASE WHEN line.unit_cost IS NULL THEN NULL
+                ELSE round(abs(line.qty) * line.unit_cost, 6)::text END AS amount_ht,
+           'STOCK_CUMP_CONSUMPTION'::text AS source_type,
+           movement.id::text AS source_ref,
+           movement.posted_at::text AS observed_at
+    FROM public.stock_movement_lines line
+    JOIN public.stock_movements movement ON movement.id = line.movement_id
+    WHERE movement.status::text = 'POSTED'
+      AND movement.movement_type::text = 'OUT'
+      AND EXISTS (
+        SELECT 1 FROM public.stock_reservations reservation
+        WHERE reservation.of_id = $1::bigint
+          AND reservation.status::text = 'CONSUMED'
+          AND reservation.consumed_stock_movement_id = movement.id
+      )
+    ORDER BY line.id
+  `, [scopeRef]);
+  return rows.rows.map(automaticCost);
+}
+
+async function loadActualSubcontractingCosts(scopeRef: string): Promise<MarginCostInput[]> {
+  const rows = await pool.query<CostRow>(`
+    SELECT concat('supplier-receipt:', receipt_line.id::text) AS key,
+           'SUBCONTRACTING'::text AS category,
+           CASE WHEN order_line.prix_unitaire_ht <= 0 THEN NULL
+                ELSE round(
+                  receipt_line.qty_received * order_line.prix_unitaire_ht * (1 - order_line.remise_pct / 100.0)
+                  + CASE WHEN order_line.quantite > 0
+                      THEN order_line.frais_ht * receipt_line.qty_received / order_line.quantite ELSE 0 END,
+                  6
+                )::text END AS amount_ht,
+           'SUPPLIER_RECEPTION_ACTUAL'::text AS source_type,
+           receipt.id::text AS source_ref,
+           receipt_line.updated_at::text AS observed_at
+    FROM public.reception_fournisseur_lignes receipt_line
+    JOIN public.receptions_fournisseurs receipt ON receipt.id = receipt_line.reception_id
+    JOIN public.commande_fournisseur_ligne order_line
+      ON order_line.id = receipt_line.commande_fournisseur_ligne_id
+    WHERE order_line.of_id = $1::bigint
+      AND order_line.type IN ('SOUS_TRAITANCE','PRESTATION')
+      AND order_line.statut_ligne <> 'ANNULEE'
+      AND receipt.status::text <> 'CANCELLED'
+      AND receipt_line.qty_received > 0
+    ORDER BY receipt_line.id
+  `, [scopeRef]);
+  return rows.rows.map(automaticCost);
 }
 
 export type ManualInputRow = {
@@ -238,6 +360,13 @@ export type ManualInputRow = {
   rate_effective_from: string | null;
   rate_effective_to: string | null;
   created_by: number;
+  definition: string | null;
+  unit: string | null;
+  period_start: string | null;
+  period_end: string | null;
+  source_reliability: MarginEvidence["source_reliability"] | null;
+  source_document_type: string | null;
+  source_document_ref: string | null;
 };
 
 function record(value: unknown): Record<string, unknown> | null {
@@ -282,6 +411,8 @@ async function loadManualInputs(scopeType: MarginScopeType, scopeRef: string, ba
       i.amount_ht::text, i.quantity::text, i.currency,
       i.source_type, i.source_ref, i.observed_at::text,
       i.assumption, i.assumption_date::text,
+      i.definition, i.unit, i.period_start::text, i.period_end::text,
+      i.source_reliability, i.source_document_type, i.source_document_ref,
       i.created_by,
       i.rate_id::text, i.rate_effective_at::text, i.rate_validation_snapshot,
       r.amount::text AS rate_amount, r.unit AS rate_unit,
@@ -294,10 +425,11 @@ async function loadManualInputs(scopeType: MarginScopeType, scopeRef: string, ba
      AND successor.created_at < ($4::date + interval '1 day')
     LEFT JOIN public.margin_rates r ON r.id = i.rate_id
     LEFT JOIN public.margin_rate_versions v ON v.id = r.rate_version_id
-    WHERE i.scope_type = $1 AND i.scope_ref = $2 AND i.basis = $3
+    WHERE i.scope_type = $1 AND i.scope_ref = $2
+      AND (i.basis = $3 OR ($3 = 'STANDARD' AND i.basis = 'PLANNED'))
       AND i.created_at < ($4::date + interval '1 day')
       AND successor.id IS NULL
-    ORDER BY i.input_key, i.created_at DESC, i.id DESC
+    ORDER BY i.input_key, (i.basis = $3) DESC, i.created_at DESC, i.id DESC
   `, [scopeType, scopeRef, basis, asOf]);
   let revenue: MarginRevenueInput | null = null;
   const costs: MarginCostInput[] = [];
@@ -312,6 +444,12 @@ async function loadManualInputs(scopeType: MarginScopeType, scopeRef: string, ba
       );
     }
     const sourceEvidence: MarginEvidence = {
+      definition: row.definition ?? `Entrée versionnée ${row.input_key}.`,
+      unit: row.unit ?? (row.input_kind === "REVENUE" || row.amount_ht !== null ? "EUR_HT" : row.rate_unit ?? "non-renseignée"),
+      period_start: row.period_start ?? row.assumption_date ?? row.observed_at?.slice(0, 10) ?? "non-renseignée",
+      period_end: row.period_end ?? row.assumption_date ?? row.observed_at?.slice(0, 10) ?? "non-renseignée",
+      freshness_at: row.observed_at,
+      source_reliability: row.source_reliability ?? "UNKNOWN",
       source_type: row.source_type,
       source_ref: row.source_ref,
       observed_at: row.observed_at,
@@ -322,6 +460,8 @@ async function loadManualInputs(scopeType: MarginScopeType, scopeRef: string, ba
       rate_effective_at: row.rate_effective_at,
       rate_scope_type: row.rate_scope_type,
       rate_scope_ref: row.rate_scope_ref,
+      source_document_type: row.source_document_type,
+      source_document_ref: row.source_document_ref,
     };
     if (row.input_kind === "REVENUE") {
       revenue = { availability: row.availability, amount_ht: row.amount_ht, currency: row.currency, evidence: sourceEvidence };
@@ -346,9 +486,9 @@ export async function repoBuildCalculationInput(identity: ScopeIdentity, basis: 
   const manual = await loadManualInputs(identity.scope_type, identity.scope_ref, basis, asOf);
   let automaticCosts: MarginCostInput[] = [];
   let measurements: Record<string, string | number | null> = {};
-  if (basis === "PLANNED" && (identity.scope_type === "DEVIS" || identity.scope_type === "DEVIS_LINE")) {
+  if ((basis === "QUOTED" || basis === "STANDARD") && (identity.scope_type === "DEVIS" || identity.scope_type === "DEVIS_LINE")) {
     automaticCosts = await loadDevisCosts(identity.scope_type, identity.scope_ref);
-  } else if (identity.scope_type === "OF") {
+  } else if (identity.scope_type === "OF" && basis !== "QUOTED") {
     const ofData = await loadOfCosts(identity.scope_ref, basis);
     automaticCosts = ofData.costs;
     measurements = ofData.measurements;
@@ -357,7 +497,14 @@ export async function repoBuildCalculationInput(identity: ScopeIdentity, basis: 
     availability: "PROVIDED",
     amount_ht: identity.revenue_ht,
     currency: "EUR",
-    evidence: evidence(identity.scope_type === "DEVIS" ? "DEVIS_TOTAL_HT" : "DEVIS_LINE_TOTAL_HT", identity.scope_ref),
+    evidence: evidence(identity.scope_type === "DEVIS" ? "DEVIS_TOTAL_HT" : "DEVIS_LINE_TOTAL_HT", identity.scope_ref, identity.source_observed_at, {
+      definition: "Prix de vente HT après remises porté par le devis.",
+      period_start: asOf,
+      period_end: asOf,
+      source_reliability: "VERIFIED",
+      source_document_type: identity.scope_type,
+      source_document_ref: identity.scope_ref,
+    }),
   };
   return {
     scope_type: identity.scope_type,
@@ -506,15 +653,20 @@ export async function repoCreateMarginInput(input: CreateMarginInput, audit: Mar
       INSERT INTO public.margin_input_versions (
         scope_type, scope_ref, basis, input_key, input_kind, category, availability,
         amount_ht, quantity, rate_id, rate_effective_at, rate_validation_snapshot,
-        source_type, source_ref, observed_at, assumption, assumption_date, supersedes_id, created_by
-      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::numeric,$9::numeric,$10::uuid,$11::date,$12::jsonb,$13,$14,$15::timestamptz,$16,$17::date,$18::uuid,$19)
+        source_type, source_ref, observed_at, assumption, assumption_date,
+        definition, unit, period_start, period_end, source_reliability,
+        source_document_type, source_document_ref, supersedes_id, created_by
+      ) VALUES ($1,$2,$3,$4,$5,$6,$7,$8::numeric,$9::numeric,$10::uuid,$11::date,$12::jsonb,$13,$14,$15::timestamptz,$16,$17::date,$18,$19,$20::date,$21::date,$22,$23,$24,$25::uuid,$26)
       RETURNING id::text, created_at::text
     `, [
       input.scope_type, input.scope_ref, input.basis, input.input_key, input.input_kind,
       input.category ?? null, input.availability, input.amount_ht ?? null, input.quantity ?? null,
       input.rate_id ?? null, input.rate_effective_at ?? null, rateSnapshot ? JSON.stringify(rateSnapshot) : null,
       input.source_type, input.source_ref ?? null, input.observed_at ?? null,
-      input.assumption ?? null, input.assumption_date ?? null, input.supersedes_id ?? null, audit.user_id,
+      input.assumption ?? null, input.assumption_date ?? null,
+      input.definition, input.unit, input.period_start, input.period_end, input.source_reliability,
+      input.source_document_type ?? null, input.source_document_ref ?? null,
+      input.supersedes_id ?? null, audit.user_id,
     ]);
     const created = result.rows[0]!;
     await auditMutation(client, audit, "MARGIN_INPUT_VERSION_CREATED", "margin_input_version", created.id, {
@@ -547,10 +699,11 @@ export async function repoCreateRateVersion(input: CreateRateVersion, audit: Mar
     }
     const version = await client.query<{ id: string; created_at: string }>(`
       INSERT INTO public.margin_rate_versions
-        (code, version, effective_from, effective_to, source, assumption_date, notes, supersedes_id, created_by)
-      VALUES ($1,$2,$3::date,$4::date,$5,$6::date,$7,$8::uuid,$9)
+        (code, version, effective_from, effective_to, source, source_reliability, assumption_date, notes, supersedes_id, created_by)
+      VALUES ($1,$2,$3::date,$4::date,$5,$6,$7::date,$8,$9::uuid,$10)
       RETURNING id::text, created_at::text
-    `, [input.code, input.version, input.effective_from, input.effective_to ?? null, input.source, input.assumption_date, input.notes ?? null, input.supersedes_id ?? null, audit.user_id]);
+    `, [input.code, input.version, input.effective_from, input.effective_to ?? null, input.source, input.source_reliability,
+      input.assumption_date, input.notes ?? null, input.supersedes_id ?? null, audit.user_id]);
     const versionId = version.rows[0]!.id;
     for (const rate of input.rates) {
       await client.query(`
@@ -577,7 +730,7 @@ export async function repoCreateRateVersion(input: CreateRateVersion, audit: Mar
 export async function repoListRateVersions(asOf: string): Promise<unknown[]> {
   const result = await pool.query(`
     SELECT v.id::text, v.code, v.version, v.currency, v.effective_from::text, v.effective_to::text,
-           v.source, v.assumption_date::text, v.notes, v.supersedes_id::text, v.created_by, v.created_at::text,
+           v.source, v.source_reliability, v.assumption_date::text, v.notes, v.supersedes_id::text, v.created_by, v.created_at::text,
            COALESCE(jsonb_agg(jsonb_build_object(
              'id', r.id::text, 'rate_code', r.rate_code, 'category', r.category,
              'scope_type', r.scope_type, 'scope_ref', r.scope_ref, 'amount', r.amount::text,

--- a/src/module/margin-engine/services/margin-engine.service.ts
+++ b/src/module/margin-engine/services/margin-engine.service.ts
@@ -30,11 +30,18 @@ export async function svcGetMargin(scopeType: MarginScopeType, scopeRef: string,
   assertCurrentMarginDate(asOf);
   const identity = await repoLoadScopeIdentity(scopeType, scopeRef);
   if (!identity) throw new HttpError(404, "MARGIN_SCOPE_NOT_FOUND", "Périmètre de marge introuvable.");
-  const [plannedInput, actualInput] = await Promise.all([
-    repoBuildCalculationInput(identity, "PLANNED", asOf),
+  const [quotedInput, standardInput, updatedInput, actualInput] = await Promise.all([
+    repoBuildCalculationInput(identity, "QUOTED", asOf),
+    repoBuildCalculationInput(identity, "STANDARD", asOf),
+    repoBuildCalculationInput(identity, "UPDATED", asOf),
     repoBuildCalculationInput(identity, "ACTUAL", asOf),
   ]);
-  const comparison = compareMargins(calculateMargin(plannedInput), calculateMargin(actualInput));
+  const comparison = compareMargins(
+    calculateMargin(quotedInput),
+    calculateMargin(standardInput),
+    calculateMargin(updatedInput),
+    calculateMargin(actualInput),
+  );
   return { ...comparison, generated_at: new Date().toISOString() };
 }
 
@@ -46,70 +53,69 @@ function csvCell(value: unknown): string {
 type GeneratedMarginComparison = MarginComparison & { generated_at: string };
 
 export function renderMarginCsv(result: GeneratedMarginComparison): string {
-  const rows: unknown[][] = [[
+  const headers = [
     "record_type", "scope_type", "scope_ref", "scope_label", "basis", "as_of", "generated_at", "availability",
+    "reliability", "reliability_reasons", "calculation_definition", "period_start", "period_end", "calculation_freshness_at",
     "category", "component_status", "component_amount_ht", "input_key", "resolved_input_amount_ht",
     "input_quantity", "rate_amount", "rate_unit", "input_currency",
-    "source_type", "source_ref", "observed_at", "assumption", "assumption_date",
+    "evidence_definition", "evidence_unit", "evidence_period_start", "evidence_period_end", "evidence_freshness_at", "source_reliability",
+    "source_type", "source_ref", "source_document_type", "source_document_ref", "observed_at", "assumption", "assumption_date",
     "rate_id", "rate_version_id", "rate_effective_at", "rate_scope_type", "rate_scope_ref",
     "missing_code", "missing_message", "measurement_key", "measurement_value",
     "revenue_ht", "cost_total_ht", "partial_cost_total_ht", "gross_margin_ht",
     "taux_de_marge_pct", "taux_de_marque_pct", "formula_version", "calculation_hash",
-  ]];
-  for (const calculation of [result.planned, result.actual]) {
-    const base = [
-      calculation.scope.type, calculation.scope.ref, calculation.scope.label, calculation.basis,
-      calculation.as_of, result.generated_at, calculation.availability,
-    ];
-    const totals = [
-      calculation.revenue_ht, calculation.cost_total_ht, calculation.partial_cost_total_ht,
-      calculation.gross_margin_ht, calculation.margin_rate_pct, calculation.mark_rate_pct,
-      calculation.formula_version, calculation.calculation_hash,
-    ];
+  ] as const;
+  const records: Array<Record<string, unknown>> = [];
+  for (const calculation of [result.quoted, result.standard, result.updated, result.actual]) {
+    const base: Record<string, unknown> = {
+      scope_type: calculation.scope.type, scope_ref: calculation.scope.ref, scope_label: calculation.scope.label,
+      basis: calculation.basis, as_of: calculation.as_of, generated_at: result.generated_at,
+      availability: calculation.availability, reliability: calculation.reliability,
+      reliability_reasons: calculation.reliability_reasons.join(" | "),
+      calculation_definition: calculation.definition,
+      period_start: calculation.period.start, period_end: calculation.period.end,
+      calculation_freshness_at: calculation.freshness_at,
+      revenue_ht: calculation.revenue_ht, cost_total_ht: calculation.cost_total_ht,
+      partial_cost_total_ht: calculation.partial_cost_total_ht, gross_margin_ht: calculation.gross_margin_ht,
+      taux_de_marge_pct: calculation.margin_rate_pct, taux_de_marque_pct: calculation.mark_rate_pct,
+      formula_version: calculation.formula_version, calculation_hash: calculation.calculation_hash,
+    };
+    const evidenceFields = (proof: typeof calculation.revenue_evidence): Record<string, unknown> => proof ? ({
+      evidence_definition: proof.definition, evidence_unit: proof.unit,
+      evidence_period_start: proof.period_start, evidence_period_end: proof.period_end,
+      evidence_freshness_at: proof.freshness_at, source_reliability: proof.source_reliability,
+      source_type: proof.source_type, source_ref: proof.source_ref,
+      source_document_type: proof.source_document_type, source_document_ref: proof.source_document_ref,
+      observed_at: proof.observed_at, assumption: proof.assumption, assumption_date: proof.assumption_date,
+      rate_id: proof.rate_id, rate_version_id: proof.rate_version_id, rate_effective_at: proof.rate_effective_at,
+      rate_scope_type: proof.rate_scope_type, rate_scope_ref: proof.rate_scope_ref,
+    }) : {};
     const revenueEvidence = calculation.revenue_evidence;
-    rows.push([
-      "REVENUE", ...base, "REVENUE", calculation.revenue_ht === null ? "MISSING" : "PROVIDED",
-      calculation.revenue_ht, "revenue", calculation.revenue_ht,
-      null, null, null, calculation.currency,
-      revenueEvidence?.source_type, revenueEvidence?.source_ref, revenueEvidence?.observed_at,
-      revenueEvidence?.assumption, revenueEvidence?.assumption_date,
-      revenueEvidence?.rate_id, revenueEvidence?.rate_version_id, revenueEvidence?.rate_effective_at,
-      revenueEvidence?.rate_scope_type, revenueEvidence?.rate_scope_ref,
-      null, null, null, null, ...totals,
-    ]);
+    records.push({ ...base, record_type: "REVENUE", category: "REVENUE",
+      component_status: calculation.revenue_ht === null ? "MISSING" : "PROVIDED",
+      component_amount_ht: calculation.revenue_ht, input_key: "revenue",
+      resolved_input_amount_ht: calculation.revenue_ht, input_currency: calculation.currency,
+      ...evidenceFields(revenueEvidence) });
     for (const component of calculation.components) {
       const inputs = component.inputs.length > 0 ? component.inputs : [null];
       for (const input of inputs) {
-        rows.push([
-          "COMPONENT", ...base, component.category, component.status, component.amount_ht,
-          input?.key, input?.resolved_amount_ht,
-          input?.quantity, input?.rate, input?.rate_unit, input?.currency,
-          input?.evidence.source_type, input?.evidence.source_ref, input?.evidence.observed_at,
-          input?.evidence.assumption, input?.evidence.assumption_date,
-          input?.evidence.rate_id, input?.evidence.rate_version_id, input?.evidence.rate_effective_at,
-          input?.evidence.rate_scope_type, input?.evidence.rate_scope_ref,
-          null, null, null, null, ...totals,
-        ]);
+        records.push({ ...base, record_type: "COMPONENT", category: component.category,
+          component_status: component.status, component_amount_ht: component.amount_ht,
+          input_key: input?.key, resolved_input_amount_ht: input?.resolved_amount_ht,
+          input_quantity: input?.quantity, rate_amount: input?.rate, rate_unit: input?.rate_unit,
+          input_currency: input?.currency, ...evidenceFields(input?.evidence ?? null) });
       }
     }
     for (const missing of calculation.missing_inputs) {
-      rows.push([
-        "MISSING", ...base, missing.category, "MISSING", null, null, null,
-        null, null, null, null,
-        null, null, null, null, null, null, null, null, null, null,
-        missing.code, missing.message, null, null, ...totals,
-      ]);
+      records.push({ ...base, record_type: "MISSING", category: missing.category,
+        component_status: "MISSING", missing_code: missing.code, missing_message: missing.message });
     }
     for (const [key, value] of Object.entries(calculation.measurements)) {
-      rows.push([
-        "MEASUREMENT", ...base, null, null, null, null, null,
-        null, null, null, null,
-        null, null, null, null, null, null, null, null, null, null,
-        null, null, key, value, ...totals,
-      ]);
+      records.push({ ...base, record_type: "MEASUREMENT", measurement_key: key, measurement_value: value });
     }
   }
-  return `\ufeff${rows.map((row) => row.map(csvCell).join(";")).join("\r\n")}\r\n`;
+  const rows = [headers.map(csvCell), ...records.map((record) => headers.map((header) => csvCell(record[header] ?? null)))];
+  return `\ufeff${rows.map((row) => row.join(";")).join("\r\n")}\r\n`;
 }
 
 export async function svcExportMargin(scopeType: MarginScopeType, scopeRef: string, asOf?: string): Promise<string> {

--- a/src/module/margin-engine/validators/margin-engine.validators.ts
+++ b/src/module/margin-engine/validators/margin-engine.validators.ts
@@ -1,8 +1,8 @@
 import { z } from "zod";
-import { MARGIN_COST_CATEGORIES } from "../domain/margin-engine";
+import { MARGIN_BASES, MARGIN_COST_CATEGORIES } from "../domain/margin-engine";
 
 export const marginScopeTypeSchema = z.enum(["DEVIS_LINE", "DEVIS", "AFFAIRE", "OF"]);
-export const marginBasisSchema = z.enum(["PLANNED", "ACTUAL"]);
+export const marginBasisSchema = z.enum(MARGIN_BASES);
 export const marginScopeParamsSchema = z.object({
   scopeType: z.enum(["devis-line", "devis", "affaire", "of"]),
   scopeRef: z.string().regex(/^\d+$/, "Identifiant numérique attendu."),
@@ -34,10 +34,26 @@ export const createMarginInputSchema = z.object({
   source_type: z.string().trim().min(1).max(80),
   source_ref: z.string().trim().max(200).nullable().optional(),
   observed_at: z.string().datetime({ offset: true }).nullable().optional(),
+  definition: z.string().trim().min(1).max(500),
+  unit: z.string().trim().min(1).max(80),
+  period_start: z.string().date(),
+  period_end: z.string().date(),
+  source_reliability: z.enum(["ESTIMATED", "DECLARED", "VERIFIED"]),
+  source_document_type: z.string().trim().min(1).max(80).nullable().optional(),
+  source_document_ref: z.string().trim().min(1).max(200).nullable().optional(),
   assumption: z.string().trim().min(1).max(1000).nullable().optional(),
   assumption_date: z.string().date().nullable().optional(),
   supersedes_id: z.string().uuid().nullable().optional(),
 }).superRefine((value, ctx) => {
+  if (value.period_end < value.period_start) {
+    ctx.addIssue({ code: "custom", path: ["period_end"], message: "La fin de période doit suivre son début." });
+  }
+  if (value.source_reliability === "VERIFIED" && value.observed_at == null) {
+    ctx.addIssue({ code: "custom", path: ["observed_at"], message: "Une source vérifiée doit être datée." });
+  }
+  if (value.source_reliability === "VERIFIED" && (value.source_document_type == null || value.source_document_ref == null)) {
+    ctx.addIssue({ code: "custom", path: ["source_document_ref"], message: "Une source vérifiée doit référencer son document métier." });
+  }
   if ((value.input_kind === "REVENUE") !== (value.category == null)) {
     ctx.addIssue({ code: "custom", path: ["category"], message: "La catégorie est requise uniquement pour un coût." });
   }
@@ -64,6 +80,7 @@ export const createRateVersionSchema = z.object({
   effective_from: z.string().date(),
   effective_to: z.string().date().nullable().optional(),
   source: z.string().trim().min(1).max(500),
+  source_reliability: z.enum(["ESTIMATED", "DECLARED", "VERIFIED"]),
   assumption_date: z.string().date(),
   notes: z.string().trim().max(2000).nullable().optional(),
   supersedes_id: z.string().uuid().nullable().optional(),


### PR DESCRIPTION
## Objet

Rend les coûts industriels et les marges honnêtes, traçables et reproductibles avec quatre perspectives : devisée, standard, actualisée et constatée.

## Cause racine

Le moteur ne distinguait que prévu/réel, les preuves n'avaient pas toutes une définition, une unité, une période, une fraîcheur et une fiabilité, et certaines absences pouvaient être assimilées à zéro.

## Changements

- moteur autoritaire `CERP-MARGIN-2.0.0`, statuts `ESTIMATED|PARTIAL|ACTUAL` et waterfall serveur ;
- sources réelles pour CUMP consommé, temps d'OF, réceptions de sous-traitance, rebuts et retouches ;
- preuve v2 versionnée et auditée, sans substitution du réel à une perspective devisée absente ;
- reporting client maintenu explicitement indisponible tant que la réconciliation multi-objets est incomplète ;
- migration avec preflight, vérification et rollback non-production protégé.

## Validation

- 269 fichiers backend, 4 453 tests réussis, 4 ignorés ;
- typecheck et build réussis ;
- audit production : 0 vulnérabilité connue ;
- répétition PostgreSQL jetable : 140 → 146 patches, rejeu 0, rollback et restauration réussis ;
- navigateur réel contre `cerp_test` : quatre perspectives, sources et absences explicites vérifiées.

Closes #405

## Summary by Sourcery

Introduce authoritative margin engine version CERP-MARGIN-2.0.0 with four bases (quoted, standard, updated, actual) and audited evidence metadata to make industrial costs and margins traceable, while keeping client margin reporting explicitly unavailable until cross-object reconciliation is complete.

New Features:
- Expose four distinct margin perspectives (QUOTED, STANDARD, UPDATED, ACTUAL) with reliability status and a server-side waterfall view for price, cost components and margin.
- Add canonical evidence v2 metadata (definition, unit, period, freshness, source reliability, source document) to margin inputs, rates and CSV exports so every cost and revenue is auditable.
- Support new margin cost category REWORK and actual-cost ingestion from stock CUMP consumption, supplier receipts and production quantity declarations.

Bug Fixes:
- Stop treating absent production quantities and costs as implicit zeros in SQL aggregates, ensuring partial margins remain explicitly incomplete.
- Clarify reporting policy so client-level margin aggregation stays unavailable until multi-object allocations, returns, credit notes and indirect costs are reconciled, avoiding misleading totals.

Enhancements:
- Refine margin comparison to publish variances between actual vs standard and updated vs quoted instead of a single planned vs actual delta.
- Derive calculation reliability and freshness from underlying evidence instead of inferring from availability only, and prevent missing data from being silently treated as zero.
- Extend validators and RBAC tests to enforce governed write contracts on margin inputs and rate versions, including period consistency and verified-source requirements.

Build:
- Add SOL-13 margin traceability migration patch with preflight, verify and guarded rollback scripts, and wire it into the release gate rehearsal flow.

Documentation:
- Document SOL-13 margin traceability design, migration runbook, usage audit and ADR for industrial margin perspectives and evidence governance.

Tests:
- Add unit, integration and migration-guard tests covering new bases, reliability, waterfall, CSV contracts, reporting policy changes and SOL-13 patch safety checks.
- Update existing reporting and margin tests to assert the new unavailability reason code and evidence metadata expectations.