### PR TITLE
fix(build): nettoyer les sorties backend obsolètes

### DIFF
--- a/docs/execution-reports/SOL-13.md
+++ b/docs/execution-reports/SOL-13.md
@@ -48,6 +48,8 @@ La valorisation matière retenue est le CUMP, source : décision du dirigeant Ke
 - Les rebuts/retouches positifs bloquent une marge complète tant qu'ils ne sont pas valorisés : c'est un garde-fou, pas une panne.
 - La migration prend brièvement des verrous exclusifs et abandonne après 5 secondes.
 
+Le premier gate SOL-12 exécuté après fusion sur `dev` a été bloqué avant E2E par un artefact TypeScript ancien resté dans `dist` après le déplacement d'une fixture. Le build nettoie désormais exclusivement le répertoire généré `dist` avant `tsc`; un test garantit que les fichiers voisins ne sont jamais supprimés.
+
 ## Rollback
 
 En `cerp_dev`/`cerp_test`, le rollback vérifie le SHA du ledger, prend le verrou de migration, refuse toute preuve v2 ou nouvelle perspective, retire les objets puis supprime exactement l'entrée ledger SOL-13. En production, arrêter les écritures et restaurer le dump pré-migration vérifié; ne pas exécuter un SQL inverse après création de preuves v2.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "typecheck": "tsc --noEmit -p tsconfig.json",
-    "build": "node scripts/security/check-production-data-boundary.mjs && tsc -p tsconfig.json && node scripts/security/check-production-data-boundary.mjs --dist",
+    "build": "node scripts/security/check-production-data-boundary.mjs && node scripts/build/clean-dist.js && tsc -p tsconfig.json && node scripts/security/check-production-data-boundary.mjs --dist",
     "security:production-data": "node scripts/security/check-production-data-boundary.mjs",
     "contract:generate": "npm run build && node scripts/generate-commande-workflow-contract.mjs",
     "start": "node dist/index.js",

--- a/scripts/build/clean-dist.js
+++ b/scripts/build/clean-dist.js
@@ -1,0 +1,24 @@
+const fs = require("node:fs");
+const path = require("node:path");
+
+/**
+ * Remove only the repository's generated dist directory.
+ * @param {string} repositoryRoot
+ */
+function cleanBuildOutput(repositoryRoot) {
+  const resolvedRoot = path.resolve(repositoryRoot);
+  const buildOutput = path.resolve(resolvedRoot, "dist");
+  if (path.dirname(buildOutput) !== resolvedRoot || path.basename(buildOutput) !== "dist") {
+    throw new Error(`Refusing to clean unexpected build output: ${buildOutput}`);
+  }
+  fs.rmSync(buildOutput, { recursive: true, force: true });
+  return buildOutput;
+}
+
+if (require.main === module) {
+  const repositoryRoot = path.resolve(__dirname, "..", "..");
+  const removed = cleanBuildOutput(repositoryRoot);
+  process.stdout.write(`Build output cleaned: ${removed}\n`);
+}
+
+module.exports = { cleanBuildOutput };

--- a/src/__tests__/build-clean-dist.test.ts
+++ b/src/__tests__/build-clean-dist.test.ts
@@ -1,0 +1,38 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { createRequire } from "node:module";
+import { describe, expect, it } from "vitest";
+import { repoRoot } from "./helpers/repo-paths";
+
+type CleanBuildOutput = (repositoryRoot: string) => string;
+const require = createRequire(import.meta.url);
+const { cleanBuildOutput } = require("../../scripts/build/clean-dist.js") as {
+  cleanBuildOutput: CleanBuildOutput;
+};
+
+describe("backend build output cleanup", () => {
+  it("removes stale emitted files while preserving siblings", () => {
+    const temporaryRoot = fs.mkdtempSync(path.join(os.tmpdir(), "cerp-build-clean-"));
+    const dist = path.join(temporaryRoot, "dist");
+    const sibling = path.join(temporaryRoot, "keep.txt");
+    try {
+      fs.mkdirSync(path.join(dist, "module", "__fixtures__"), { recursive: true });
+      fs.writeFileSync(path.join(dist, "module", "__fixtures__", "stale.js"), "fixture");
+      fs.writeFileSync(sibling, "keep");
+
+      expect(cleanBuildOutput(temporaryRoot)).toBe(dist);
+      expect(fs.existsSync(dist)).toBe(false);
+      expect(fs.readFileSync(sibling, "utf8")).toBe("keep");
+    } finally {
+      fs.rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("runs the cleanup before TypeScript compilation", () => {
+    const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8")) as {
+      scripts: { build: string };
+    };
+    expect(packageJson.scripts.build).toMatch(/clean-dist\.js && tsc -p tsconfig\.json/);
+  });
+});


### PR DESCRIPTION
## Objet

Empêche un build backend de conserver des fichiers JavaScript obsolètes dans `dist` après le déplacement ou la suppression d'une source TypeScript.

## Cause racine

`tsc` réécrit les sorties présentes mais ne supprime pas les anciens chemins. Le gate SOL-12 a donc détecté une ancienne fixture compilée alors que la source avait été déplacée hors du runtime.

## Correction

- nettoyage strictement limité au répertoire généré `dist` avant `tsc` ;
- garde de chemin empêchant toute cible plus large ;
- test réel prouvant la suppression d'un artefact imbriqué et la conservation d'un fichier voisin ;
- reproduction réussie avec une fixture obsolète injectée dans `dist`.

## Validation

- 2 tests ciblés réussis ;
- typecheck réussi ;
- build réussi, 633 fichiers source et 633 fichiers émis validés ;
- l'artefact obsolète injecté n'existe plus après build.

## Summary by Sourcery

Ensure backend builds remove obsolete compiled artifacts by cleaning the generated dist directory before TypeScript compilation while preserving non-build files.

Bug Fixes:
- Prevent stale JavaScript files from remaining in dist after TypeScript sources are moved or deleted by adding a guarded cleanup step to the build pipeline.

Enhancements:
- Document the SOL-12 gate regression and its resolution in the SOL-13 execution report.
- Add a build utility script dedicated to safely deleting only the repository's generated dist directory.

Build:
- Update the build script to invoke the dist cleanup utility before running tsc.

Tests:
- Add tests verifying that the dist cleanup removes nested stale artifacts, preserves neighboring files, and is wired into the build script.