### PR TITLE
fix(docker): include build scripts in release image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY src ./src
 # `npm run build` executes the production-data boundary before and after tsc.
 # Keep that guard inside the container build used by Coolify and HyperBox2.
 COPY scripts/security ./scripts/security
+COPY scripts/build ./scripts/build
 RUN npm run build
 
 # --------- Runtime ------------

--- a/docs/execution-reports/SOL-14.md
+++ b/docs/execution-reports/SOL-14.md
@@ -1,0 +1,11 @@
+# SOL-14 — preuve backend des runbooks d'exploitation
+
+- Date : 2026-08-11
+- Propriétaire : Keenan Martin — administrateur CERP+
+- Tâche : #412
+
+Le build réel de l'image d'exploitation a révélé `MODULE_NOT_FOUND: /app/scripts/build/clean-dist.js`. `npm run build` appelle ce nettoyage depuis SOL-13, mais le stage builder ne copiait que `scripts/security`. Le `Dockerfile` copie désormais aussi `scripts/build`, et le contrat Docker empêche sa régression.
+
+Aucune migration ni donnée n'est modifiée. Résultats : suite backend complète PASS (code 0, 24,2 s), typecheck PASS (9,9 s), build local PASS (633 fichiers, 12 s), build Docker PASS (`sha256:74ad29d3...`), smoke ClamAV PASS avec fichier sain, EICAR et limite de récursion en mode `enforce`.
+
+Rollback : retirer ce `COPY` seulement si le script de build est aussi retiré du manifeste ; sinon Coolify et HYPERBOX2 redeviendraient non livrables. Le corpus canonique et le détail des simulations sont dans `crp-systems-web/docs/execution-reports/SOL-14.md`.

--- a/src/__tests__/upload-scanner-docker.contract.test.ts
+++ b/src/__tests__/upload-scanner-docker.contract.test.ts
@@ -46,6 +46,7 @@ describe("autonomous ClamAV Docker contract", () => {
     expect(dockerfile).not.toMatch(/RUN\s+freshclam/);
     expect(dockerfile).toContain("addgroup node clamav");
     expect(dockerfile).toContain('ENV CERP_UPLOAD_SCAN_MODE=enforce');
+    expect(dockerfile).toContain("COPY scripts/build ./scripts/build");
     expect(dockerfile).toContain("/health/ready");
     expect(dockerfile).toContain('ENTRYPOINT ["/sbin/tini"');
     expect(dockerfile).toContain('"/var/lib/clamav"');


### PR DESCRIPTION
## Résumé
Le stage builder copie désormais `scripts/build`, requis par `npm run build`, et le contrat Docker verrouille cette frontière.

## Cause racine
Le build Coolify/HYPERBOX2 échouait avec `MODULE_NOT_FOUND /app/scripts/build/clean-dist.js` avant le démarrage de ClamAV.

## Validation
- suite backend complète : PASS
- typecheck et build : PASS
- build Docker : PASS
- smoke ClamAV réel : fichier sain, EICAR et limite de récursion PASS en mode enforce

Rapport : `docs/execution-reports/SOL-14.md`.

Closes #412

## Summary by Sourcery

Include build scripts in the Docker release image and lock this behavior with a contract test.

Bug Fixes:
- Ensure Docker builder stage copies the build scripts required by npm run build to prevent MODULE_NOT_FOUND errors in Coolify/HyperBox2 builds.

Enhancements:
- Extend the Docker contract test to assert that build scripts are copied into the image.

Documentation:
- Add an execution report documenting SOL-14 backend validation of the operational image build and ClamAV smoke tests.