### PR TITLE
release: promote SOL-14 backend Docker fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY src ./src
 # `npm run build` executes the production-data boundary before and after tsc.
 # Keep that guard inside the container build used by Coolify and HyperBox2.
 COPY scripts/security ./scripts/security
+COPY scripts/build ./scripts/build
 RUN npm run build
 
 # --------- Runtime ------------

--- a/docs/execution-reports/SOL-14.md
+++ b/docs/execution-reports/SOL-14.md
@@ -1,0 +1,11 @@
+# SOL-14 — preuve backend des runbooks d'exploitation
+
+- Date : 2026-08-11
+- Propriétaire : Keenan Martin — administrateur CERP+
+- Tâche : #412
+
+Le build réel de l'image d'exploitation a révélé `MODULE_NOT_FOUND: /app/scripts/build/clean-dist.js`. `npm run build` appelle ce nettoyage depuis SOL-13, mais le stage builder ne copiait que `scripts/security`. Le `Dockerfile` copie désormais aussi `scripts/build`, et le contrat Docker empêche sa régression.
+
+Aucune migration ni donnée n'est modifiée. Résultats : suite backend complète PASS (code 0, 24,2 s), typecheck PASS (9,9 s), build local PASS (633 fichiers, 12 s), build Docker PASS (`sha256:74ad29d3...`), smoke ClamAV PASS avec fichier sain, EICAR et limite de récursion en mode `enforce`.
+
+Rollback : retirer ce `COPY` seulement si le script de build est aussi retiré du manifeste ; sinon Coolify et HYPERBOX2 redeviendraient non livrables. Le corpus canonique et le détail des simulations sont dans `crp-systems-web/docs/execution-reports/SOL-14.md`.

--- a/src/__tests__/upload-scanner-docker.contract.test.ts
+++ b/src/__tests__/upload-scanner-docker.contract.test.ts
@@ -46,6 +46,7 @@ describe("autonomous ClamAV Docker contract", () => {
     expect(dockerfile).not.toMatch(/RUN\s+freshclam/);
     expect(dockerfile).toContain("addgroup node clamav");
     expect(dockerfile).toContain('ENV CERP_UPLOAD_SCAN_MODE=enforce');
+    expect(dockerfile).toContain("COPY scripts/build ./scripts/build");
     expect(dockerfile).toContain("/health/ready");
     expect(dockerfile).toContain('ENTRYPOINT ["/sbin/tini"');
     expect(dockerfile).toContain('"/var/lib/clamav"');


### PR DESCRIPTION
## Promotion
Promote le correctif Docker SOL-14 validé de `dev` vers `main`.

## Preuve bloquante
- frontend `a314e7e8aa7c41b43d126c2cc82948ce19693484`
- backend `f947df6cacddcce66c95fbd5c8a6eae901529578`
- gate `20260811T192133Z-test-a314e7e8-f947df6c` : PASSED en 654,8 s
- build Docker et smoke ClamAV/EICAR réels : PASS
- 63 scénarios Playwright ; migrations isolées : PASS

Aucune migration ni donnée production dans SOL-14.

## Summary by Sourcery

Ensure backend Docker image build stage includes required build scripts and document SOL-14 execution evidence.

Bug Fixes:
- Fix backend Docker build failure by copying the scripts/build directory into the build stage image.

Enhancements:
- Extend Docker contract test to assert presence of build scripts in the image specification.

Documentation:
- Add SOL-14 execution report documenting the Docker build issue, its resolution, and validation results.