### PR TITLE
release: correctifs Stock OLD commande et PF

### DIFF
--- a/src/__tests__/commandes.routes.test.ts
+++ b/src/__tests__/commandes.routes.test.ts
@@ -1528,7 +1528,8 @@ describe("/api/v1/commandes", () => {
         return { rows: [{ id: "44444444-4444-4444-8444-444444444444" }] };
       }
       if (q.includes("v_bon_livraison_reliquats_226") && q.includes("remainder.quantite_restante::float8 AS quantite") && !q.includes("AS quantite_restante")) {
-        return { rows: [{ id: 1, designation: "Line", code_piece: "P1", quantite: 1, unite: "u", delai_client: null }] };
+        // BIGINT identifiers are strings at the node-postgres boundary.
+        return { rows: [{ id: "1", designation: "Line", code_piece: "P1", quantite: 1, unite: "u", delai_client: null }] };
       }
       if (q.includes("INSERT INTO bon_livraison_ligne (")) return { rows: [] };
       if (q.includes("SELECT id::text AS id, commande_ligne_id::bigint::int AS commande_ligne_id")) {

--- a/src/__tests__/stock-commande-article-filter-315.test.ts
+++ b/src/__tests__/stock-commande-article-filter-315.test.ts
@@ -41,4 +41,14 @@ describe("BUG-CERP-0015 - filtre GET /stock/articles", () => {
     expect(countSql).toContain("IS NOT TRUE");
     expect(countSql).toContain("a.article_category IN ('fabrique', 'PIECE_TECHNIQUE')");
   });
+
+  it("filtre les articles PF par code client métier", async () => {
+    await repoListArticles({ client_code: "CLI-0042" });
+
+    expect(normalized(queryMock.mock.calls[0]?.[0])).toContain(
+      "LOWER(TRIM(COALESCE(pt.code_client, ''))) = LOWER(TRIM($1))"
+    );
+    expect(queryMock.mock.calls[0]?.[1]).toEqual(["CLI-0042"]);
+    expect(normalized(queryMock.mock.calls[1]?.[0])).toContain("latest_version.plan_reference AS piece_plan_reference");
+  });
 });

--- a/src/module/livraisons/repository/livraisons.repository.ts
+++ b/src/module/livraisons/repository/livraisons.repository.ts
@@ -2618,7 +2618,7 @@ export async function repoCreateLivraisonFromCommande(
     }
 
     const lignesRes = await db.query<{
-      id: number
+      id: string
       designation: string
       code_piece: string | null
       quantite: number
@@ -2627,7 +2627,7 @@ export async function repoCreateLivraisonFromCommande(
     }>(
       `
       SELECT
-        line.id,
+        line.id::text AS id,
         line.designation,
         line.code_piece,
         remainder.quantite_restante::float8 AS quantite,
@@ -2643,21 +2643,27 @@ export async function repoCreateLivraisonFromCommande(
       [commandeId]
     )
     const lignes = lignesRes.rows.flatMap((line) => {
+      // PostgreSQL BIGINT values are returned as strings by node-postgres. Normalize the
+      // identifier before consulting the numeric map produced by the stock analysis.
+      const commandeLineId = Number(line.id)
+      if (!Number.isSafeInteger(commandeLineId) || commandeLineId <= 0) {
+        throw new Error(`Invalid commande line identifier: ${line.id}`)
+      }
       const requestedQuantity = quantitiesByCommandeLine
-        ? Number(quantitiesByCommandeLine.get(line.id) ?? 0)
+        ? Number(quantitiesByCommandeLine.get(commandeLineId) ?? 0)
         : Number(line.quantite)
       if (!Number.isFinite(requestedQuantity) || requestedQuantity < 0) {
-        throw new HttpError(400, "INVALID_DELIVERY_QUANTITY", `Quantité de BL invalide pour la ligne ${line.id}.`)
+        throw new HttpError(400, "INVALID_DELIVERY_QUANTITY", `Quantité de BL invalide pour la ligne ${commandeLineId}.`)
       }
       if (requestedQuantity <= 1e-9) return []
       if (requestedQuantity > Number(line.quantite) + 1e-9) {
         throw new HttpError(
           409,
           "DELIVERY_QUANTITY_EXCEEDS_REMAINDER",
-          `La quantité de BL dépasse le reliquat de la ligne ${line.id}.`
+          `La quantité de BL dépasse le reliquat de la ligne ${commandeLineId}.`
         )
       }
-      return [{ ...line, quantite: requestedQuantity }]
+      return [{ ...line, id: commandeLineId, quantite: requestedQuantity }]
     })
     if (!lignes.length) {
       throw new HttpError(

--- a/src/module/stock/repository/stock.repository.ts
+++ b/src/module/stock/repository/stock.repository.ts
@@ -2722,6 +2722,9 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
       )
     )`);
   }
+  if (filters.client_code) {
+    where.push(`LOWER(TRIM(COALESCE(pt.code_client, ''))) = LOWER(TRIM(${push(filters.client_code)}))`);
+  }
   if (filters.article_type) {
     where.push(
       filters.article_type === "PIECE_TECHNIQUE"
@@ -2805,6 +2808,9 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
       a.piece_technique_id::text AS piece_technique_id,
       pt.code_piece AS piece_code,
       pt.designation AS piece_designation,
+      pt.code_client AS piece_client_code,
+      latest_version.plan_reference AS piece_plan_reference,
+      latest_version.indice AS piece_indice,
       a.unite,
       a.lot_tracking,
       a.is_sold,
@@ -2846,6 +2852,13 @@ export async function repoListArticles(filters: ListArticlesQueryDTO): Promise<P
       ORDER BY v.date_application DESC NULLS LAST, v.created_at DESC
       LIMIT 1
     ) av ON TRUE
+    LEFT JOIN LATERAL (
+      SELECT v.indice, v.plan_reference
+      FROM public.piece_technique_versions v
+      WHERE v.piece_technique_id = a.piece_technique_id
+      ORDER BY v.is_current DESC, v.version_interne DESC, v.created_at DESC
+      LIMIT 1
+    ) latest_version ON TRUE
     LEFT JOIN (
       SELECT
         article_id::text AS article_id,
@@ -5564,12 +5577,35 @@ export async function repoCreateHistoricalImport(body: HistoricalImportBodyDTO, 
       if (a.rows[0]?.category !== "matiere") throw new HttpError(422, "MP_ARTICLE_REQUIRED", "L'import MP requiert un article matière première.");
       shelf = a.rows[0]?.nuance?.trim() || "SANS-NUANCE";
     } else {
-      const ptId = await ensureHistoricalPieceTechniqueTx(client, { clientNumber: body.client_number, reference: body.reference, indice: body.indice ?? null, designation: body.designation }, audit);
-      const existing = await client.query<{ id: string }>(`SELECT id::text AS id FROM public.articles WHERE piece_technique_id=$1::uuid LIMIT 1 FOR UPDATE`, [ptId]);
-      if (existing.rows[0]?.id) articleId = existing.rows[0].id;
-      else {
-        const family = body.family_code ?? defaultFamilyCodeForCategory("fabrique");
-        articleId = (await repoCreateArticleTx(client, { designation: body.designation, article_type: "PIECE_TECHNIQUE", article_category: "fabrique", article_categories: ["piece_finie_fabriquee"], family_code: family, piece_technique_id: ptId, stock_managed: true, lot_tracking: true, is_sold: true, is_active: true, status: "VALIDE" }, audit)).id;
+      if (body.article_id) {
+        const selected = await client.query<{ id: string; category: string; is_active: boolean; piece_technique_id: string | null; client_code: string | null }>(
+          `SELECT a.id::text AS id, ${normalizedArticleCategorySql("a.article_category")} AS category,
+                  a.is_active, a.piece_technique_id::text AS piece_technique_id, pt.code_client AS client_code
+           FROM public.articles a
+           LEFT JOIN public.pieces_techniques pt ON pt.id = a.piece_technique_id
+           WHERE a.id = $1::uuid
+           FOR UPDATE OF a`,
+          [body.article_id]
+        );
+        const article = selected.rows[0];
+        if (!article) throw new HttpError(422, "PF_ARTICLE_NOT_FOUND", "L'article PF sélectionné est introuvable.");
+        if (article.category !== "fabrique" || !article.piece_technique_id) {
+          throw new HttpError(422, "PF_ARTICLE_REQUIRED", "La reprise PF requiert un article fabriqué relié à une pièce technique.");
+        }
+        if (!article.is_active) throw new HttpError(422, "PF_ARTICLE_INACTIVE", "L'article PF sélectionné est inactif.");
+        if ((article.client_code ?? "").trim().toLowerCase() !== body.client_number.trim().toLowerCase()) {
+          throw new HttpError(422, "PF_ARTICLE_CLIENT_MISMATCH", "L'article PF sélectionné n'appartient pas au client indiqué.");
+        }
+        articleId = article.id;
+      } else {
+        if (!body.reference || !body.designation) throw new HttpError(400, "PF_ARTICLE_DETAILS_REQUIRED", "Référence et désignation PF requises.");
+        const ptId = await ensureHistoricalPieceTechniqueTx(client, { clientNumber: body.client_number, reference: body.reference, indice: body.indice ?? null, designation: body.designation }, audit);
+        const existing = await client.query<{ id: string }>(`SELECT id::text AS id FROM public.articles WHERE piece_technique_id=$1::uuid LIMIT 1 FOR UPDATE`, [ptId]);
+        if (existing.rows[0]?.id) articleId = existing.rows[0].id;
+        else {
+          const family = body.family_code ?? defaultFamilyCodeForCategory("fabrique");
+          articleId = (await repoCreateArticleTx(client, { designation: body.designation, article_type: "PIECE_TECHNIQUE", article_category: "fabrique", article_categories: ["piece_finie_fabriquee"], family_code: family, piece_technique_id: ptId, stock_managed: true, lot_tracking: true, is_sold: true, is_active: true, status: "VALIDE" }, audit)).id;
+        }
       }
       shelf = body.client_number.trim();
     }

--- a/src/module/stock/types/stock.types.ts
+++ b/src/module/stock/types/stock.types.ts
@@ -172,6 +172,9 @@ export type StockArticleListItem = {
   piece_technique_id: string | null;
   piece_code: string | null;
   piece_designation: string | null;
+  piece_client_code: string | null;
+  piece_plan_reference: string | null;
+  piece_indice: string | null;
   unite: string | null;
   lot_tracking: boolean;
   is_sold: boolean;

--- a/src/module/stock/validators/stock-225.validators.test.ts
+++ b/src/module/stock/validators/stock-225.validators.test.ts
@@ -50,6 +50,18 @@ describe("#225 stock validators", () => {
       kind: "PF", client_number: "CLI-01", reference: "PLAN-42", designation: "Pièce reprise", quantity: 2,
       of_affaire_refs: ["OF-1"], mp_lot_refs: [], traitement_lot_refs: [],
     } }).success).toBe(true);
+    expect(historicalImportSchema.safeParse({ body: {
+      kind: "PF", client_number: "CLI-01", article_id: UUID_A, quantity: 2,
+      of_affaire_refs: [], mp_lot_refs: [], traitement_lot_refs: [],
+    } }).success).toBe(true);
+    expect(historicalImportSchema.safeParse({ body: {
+      kind: "PF", client_number: "CLI-01", quantity: 2,
+      of_affaire_refs: [], mp_lot_refs: [], traitement_lot_refs: [],
+    } }).success).toBe(false);
+    expect(historicalImportSchema.safeParse({ body: {
+      kind: "PF", client_number: "CLI-01", article_id: UUID_A, reference: "PLAN-42", designation: "Doublon", quantity: 2,
+      of_affaire_refs: [], mp_lot_refs: [], traitement_lot_refs: [],
+    } }).success).toBe(false);
     expect(historicalImportSchema.safeParse({ body: { kind: "MP", quantity: 1, lot_number: "F-1" } }).success).toBe(false);
     expect(historicalImportSchema.safeParse({ body: {
       kind: "MP", article_id: UUID_A, quantity: 1, lot_number: "F-1", unexpected: true,

--- a/src/module/stock/validators/stock.validators.ts
+++ b/src/module/stock/validators/stock.validators.ts
@@ -81,6 +81,7 @@ export const docIdParamSchema = z.object({
 
 export const listArticlesQuerySchema = z.object({
   q: z.string().trim().optional(),
+  client_code: z.string().trim().min(1).max(40).optional(),
   article_type: articleTypeSchema.optional(),
   article_category: articleCategorySchema.optional(),
   status: articleWorkflowStatusSchema.optional(),
@@ -757,10 +758,11 @@ export type StockScopeDTO = z.infer<typeof stockScopeSchema>;
 const historicalPfImportSchema = z.object({
     kind: z.literal("PF"),
     client_number: z.string().trim().min(1).max(40),
-    reference: z.string().trim().min(1).max(120),
+    article_id: uuid.optional(),
+    reference: z.string().trim().min(1).max(120).optional(),
     indice: z.string().trim().min(1).max(40).optional().nullable(),
     family_code: z.string().trim().min(1).max(40).optional(),
-    designation: z.string().trim().min(1).max(400),
+    designation: z.string().trim().min(1).max(400).optional(),
     quantity: z.coerce.number().positive(),
     of_affaire_refs: z.array(z.string().trim().min(1).max(120)).max(4).optional().default([]),
     mp_lot_refs: z.array(z.string().trim().min(1).max(120)).max(4).optional().default([]),
@@ -777,7 +779,14 @@ const historicalMpImportSchema = z.object({
     notes: z.string().trim().min(1).max(2000).optional().nullable(),
   }).strict();
 export const historicalImportSchema = z.object({ body: z.discriminatedUnion("kind", [historicalPfImportSchema, historicalMpImportSchema]) }).superRefine((value, ctx) => {
-  if (value.body.kind !== "MP") return;
+  if (value.body.kind === "PF") {
+    if (!value.body.article_id && !value.body.reference) ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["body", "reference"], message: "reference is required when article_id is absent" });
+    if (!value.body.article_id && !value.body.designation) ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["body", "designation"], message: "designation is required when article_id is absent" });
+    if (value.body.article_id && (value.body.reference || value.body.indice || value.body.family_code || value.body.designation)) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["body", "article_id"], message: "article_id and article creation fields are mutually exclusive" });
+    }
+    return;
+  }
   if (!value.body.article_id && !value.body.article) ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["body", "article_id"], message: "article_id or article is required" });
   if (value.body.article_id && value.body.article) ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["body", "article"], message: "article_id and article are mutually exclusive" });
 });


### PR DESCRIPTION
Promotion de `dev` vers `main` après fusion de #422.

- corrige le faux reliquat non livrable lors d'une réservation OLD/NEW
- ajoute la sélection sécurisée d'un article PF existant pour la reprise OLD
- validations locales documentées dans #422

Closes #421

## Summary by Sourcery

Update stock and delivery flows to support safer PF article selection, client-based filtering, and correct handling of commande line identifiers.

New Features:
- Allow listing stock articles filtered by client code and expose related client, plan reference, and indice metadata in article list items.
- Support historical PF imports using either an existing PF article selection or on-the-fly article creation, with mutually exclusive payload shapes.

Bug Fixes:
- Fix livraison creation from commande by normalizing BIGINT line identifiers returned by PostgreSQL, preventing invalid remainder and quantity validation behavior in OLD/NEW reservation flows.

Enhancements:
- Strengthen PF import validation rules to enforce required fields when no existing article is provided and to prevent conflicting data when an article_id is supplied.
- Extend article listing SQL to join the latest piece technique version for consistent plan reference and indice exposure.

Tests:
- Add tests covering PF import validation variants and client-code-based PF article filtering, including latest version plan reference exposure.
- Adjust commandes route tests to reflect BIGINT identifiers being returned as strings by node-postgres.