### PR TITLE
release: promouvoir SOL-17 commercial sur main

### DIFF
--- a/contracts/commande-client-workflow.v1.json
+++ b/contracts/commande-client-workflow.v1.json
@@ -18,7 +18,8 @@
     "LIVRE",
     "FACTURE",
     "ARCHIVE",
-    "BLOQUE"
+    "BLOQUE",
+    "ANNULE"
   ],
   "status_labels": {
     "BROUILLON": "Brouillon",
@@ -37,7 +38,8 @@
     "LIVRE": "Livré",
     "FACTURE": "Facturé",
     "ARCHIVE": "Archivé",
-    "BLOQUE": "Bloqué"
+    "BLOQUE": "Bloqué",
+    "ANNULE": "Annulé"
   },
   "status_order": {
     "BROUILLON": 0,
@@ -56,7 +58,8 @@
     "LIVRE": 13,
     "FACTURE": 14,
     "ARCHIVE": 15,
-    "BLOQUE": 99
+    "BLOQUE": 99,
+    "ANNULE": 100
   },
   "checkpoint_statuses": [
     "pending",
@@ -114,7 +117,8 @@
       "ARCHIVE"
     ],
     "ARCHIVE": [],
-    "BLOQUE": []
+    "BLOQUE": [],
+    "ANNULE": []
   },
   "transition_rules": [
     {
@@ -181,6 +185,76 @@
       "from": "FACTURE",
       "to": "ARCHIVE",
       "cause": "checkpoint"
+    },
+    {
+      "from": "BROUILLON",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "EN_ANALYSE",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "ATTENTE_TECHNIQUE",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "ATTENTE_STOCK",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "ATTENTE_OF",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "ATTENTE_PLANNING",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "PLANNING_VALIDE",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "AR_PRET",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "AR_ENVOYE",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "EN_PRODUCTION",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "PRODUCTION_TERMINEE",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "CONTROLE_QUALITE",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "PRET_LIVRAISON",
+      "to": "ANNULE",
+      "cause": "cancel"
+    },
+    {
+      "from": "BLOQUE",
+      "to": "ANNULE",
+      "cause": "cancel"
     },
     {
       "from": "ATTENTE_OF",

--- a/db/patches/20260812_commercial_reliability_sol17.sql
+++ b/db/patches/20260812_commercial_reliability_sol17.sql
@@ -1,0 +1,184 @@
+-- SOL-17 — Commercial reliability: quote decisions, reminders, discount approvals
+-- and explicit customer-order cancellation evidence.
+--
+-- This migration is additive. It does not infer or backfill historical events:
+-- an unknown send/decision date must remain unknown instead of being fabricated.
+
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NULL
+     OR to_regclass('public.devis') IS NULL
+     OR to_regclass('public.commande_client') IS NULL
+     OR to_regclass('public.commande_historique') IS NULL
+     OR to_regclass('public.commande_client_event_log') IS NULL
+     OR to_regclass('public.users') IS NULL
+     OR to_regclass('public.erp_audit_logs') IS NULL
+     OR to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'SOL-17: prerequisite table or runtime role is missing';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.cerp_schema_migrations
+    WHERE filename = '20260812_commercial_reliability_sol17.sql'
+  ) THEN
+    RAISE EXCEPTION 'SOL-17: migration ledger already exists; use the patch runner';
+  END IF;
+
+  IF to_regclass('public.commercial_quote_events') IS NOT NULL
+     OR to_regclass('public.commercial_order_cancellations') IS NOT NULL
+     OR to_regclass('public.commercial_command_receipts') IS NOT NULL
+     OR to_regprocedure('public.fn_commercial_evidence_append_only()') IS NOT NULL THEN
+    RAISE EXCEPTION 'SOL-17: target artifact exists without ledger provenance';
+  END IF;
+END
+$guard$;
+
+CREATE TABLE public.commercial_quote_events (
+  id uuid NOT NULL DEFAULT gen_random_uuid(),
+  devis_id bigint NOT NULL,
+  event_type text NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  actor_user_id integer,
+  owner_user_id integer,
+  reason_code text,
+  channel text,
+  note text,
+  quote_content_hash char(64),
+  discount_pct numeric(7,4),
+  approval_request_id uuid,
+  source text NOT NULL DEFAULT 'APPLICATION',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT commercial_quote_events_pkey PRIMARY KEY (id),
+  CONSTRAINT commercial_quote_events_devis_fkey FOREIGN KEY (devis_id)
+    REFERENCES public.devis(id) ON DELETE RESTRICT,
+  CONSTRAINT commercial_quote_events_actor_fkey FOREIGN KEY (actor_user_id)
+    REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT commercial_quote_events_owner_fkey FOREIGN KEY (owner_user_id)
+    REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT commercial_quote_events_type_ck CHECK (event_type IN (
+    'SENT','REMINDER_RECORDED','ACCEPTED','LOST','EXPIRED',
+    'DISCOUNT_REQUESTED','DISCOUNT_APPROVED','DISCOUNT_REJECTED'
+  )),
+  CONSTRAINT commercial_quote_events_reason_ck CHECK (
+    reason_code IS NULL OR reason_code IN (
+      'PRICE','LEAD_TIME','TECHNICAL_FIT','COMPETITOR','BUDGET',
+      'NO_DECISION','DUPLICATE','CUSTOMER_CANCELLED','OTHER'
+    )
+  ),
+  CONSTRAINT commercial_quote_events_channel_ck CHECK (
+    channel IS NULL OR channel IN ('EMAIL','PHONE','MEETING','OTHER')
+  ),
+  CONSTRAINT commercial_quote_events_note_ck CHECK (note IS NULL OR char_length(note) <= 1000),
+  CONSTRAINT commercial_quote_events_hash_ck CHECK (
+    quote_content_hash IS NULL OR quote_content_hash ~ '^[0-9a-f]{64}$'
+  ),
+  CONSTRAINT commercial_quote_events_discount_ck CHECK (
+    discount_pct IS NULL OR (discount_pct >= 0 AND discount_pct <= 100)
+  ),
+  CONSTRAINT commercial_quote_events_required_ck CHECK (
+    (event_type <> 'REMINDER_RECORDED' OR channel IS NOT NULL)
+    AND (event_type <> 'LOST' OR reason_code IS NOT NULL)
+    AND (event_type NOT IN ('DISCOUNT_REQUESTED','DISCOUNT_APPROVED','DISCOUNT_REJECTED')
+      OR (quote_content_hash IS NOT NULL AND discount_pct IS NOT NULL AND approval_request_id IS NOT NULL))
+  ),
+  CONSTRAINT commercial_quote_events_source_ck CHECK (source IN ('APPLICATION','MIGRATION_BACKFILL'))
+);
+
+CREATE INDEX commercial_quote_events_devis_time_idx
+  ON public.commercial_quote_events (devis_id, occurred_at DESC, id DESC);
+CREATE INDEX commercial_quote_events_type_time_idx
+  ON public.commercial_quote_events (event_type, occurred_at DESC);
+CREATE UNIQUE INDEX commercial_quote_reminder_daily_channel_uniq
+  ON public.commercial_quote_events (devis_id, channel, ((occurred_at AT TIME ZONE 'Europe/Paris')::date))
+  WHERE event_type = 'REMINDER_RECORDED';
+CREATE UNIQUE INDEX commercial_quote_discount_request_uniq
+  ON public.commercial_quote_events (devis_id, approval_request_id)
+  WHERE event_type = 'DISCOUNT_REQUESTED';
+CREATE UNIQUE INDEX commercial_quote_discount_content_request_uniq
+  ON public.commercial_quote_events (devis_id, quote_content_hash)
+  WHERE event_type = 'DISCOUNT_REQUESTED';
+CREATE UNIQUE INDEX commercial_quote_discount_decision_uniq
+  ON public.commercial_quote_events (approval_request_id)
+  WHERE event_type IN ('DISCOUNT_APPROVED','DISCOUNT_REJECTED');
+
+CREATE TABLE public.commercial_order_cancellations (
+  commande_id bigint NOT NULL,
+  reason_code text NOT NULL,
+  note text,
+  cancelled_by integer NOT NULL,
+  cancelled_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT commercial_order_cancellations_pkey PRIMARY KEY (commande_id),
+  CONSTRAINT commercial_order_cancellations_commande_fkey FOREIGN KEY (commande_id)
+    REFERENCES public.commande_client(id) ON DELETE RESTRICT,
+  CONSTRAINT commercial_order_cancellations_user_fkey FOREIGN KEY (cancelled_by)
+    REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT commercial_order_cancellations_reason_ck CHECK (reason_code IN (
+    'CUSTOMER_CANCELLED','DUPLICATE','COMMERCIAL_ERROR','TECHNICAL_IMPOSSIBILITY','OTHER'
+  )),
+  CONSTRAINT commercial_order_cancellations_note_ck CHECK (note IS NULL OR char_length(note) <= 1000)
+);
+
+CREATE TABLE public.commercial_command_receipts (
+  action text NOT NULL,
+  idempotency_key text NOT NULL,
+  request_hash char(64) NOT NULL,
+  actor_user_id integer NOT NULL,
+  response_snapshot jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT commercial_command_receipts_pkey PRIMARY KEY (action, idempotency_key),
+  CONSTRAINT commercial_command_receipts_actor_fkey FOREIGN KEY (actor_user_id)
+    REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT commercial_command_receipts_action_ck CHECK (action IN (
+    'QUOTE_REMINDER','QUOTE_LOSS','DISCOUNT_REQUEST','DISCOUNT_DECISION',
+    'EXPIRE_DUE_QUOTES','ORDER_CANCEL'
+  )),
+  CONSTRAINT commercial_command_receipts_key_ck CHECK (char_length(idempotency_key) BETWEEN 8 AND 120),
+  CONSTRAINT commercial_command_receipts_hash_ck CHECK (request_hash ~ '^[0-9a-f]{64}$')
+);
+
+CREATE FUNCTION public.fn_commercial_evidence_append_only()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $append_only$
+BEGIN
+  RAISE EXCEPTION '% is append-only; add a new commercial event instead', TG_TABLE_NAME
+    USING ERRCODE = '55000';
+END
+$append_only$;
+
+CREATE TRIGGER commercial_quote_events_append_only
+  BEFORE UPDATE OR DELETE ON public.commercial_quote_events
+  FOR EACH ROW EXECUTE FUNCTION public.fn_commercial_evidence_append_only();
+CREATE TRIGGER commercial_order_cancellations_append_only
+  BEFORE UPDATE OR DELETE ON public.commercial_order_cancellations
+  FOR EACH ROW EXECUTE FUNCTION public.fn_commercial_evidence_append_only();
+CREATE TRIGGER commercial_command_receipts_append_only
+  BEFORE UPDATE OR DELETE ON public.commercial_command_receipts
+  FOR EACH ROW EXECUTE FUNCTION public.fn_commercial_evidence_append_only();
+
+ALTER TABLE public.commercial_quote_events OWNER TO cerp_app;
+ALTER TABLE public.commercial_order_cancellations OWNER TO cerp_app;
+ALTER TABLE public.commercial_command_receipts OWNER TO cerp_app;
+ALTER FUNCTION public.fn_commercial_evidence_append_only() OWNER TO cerp_app;
+
+REVOKE ALL ON TABLE public.commercial_quote_events FROM PUBLIC, cerp_app;
+REVOKE ALL ON TABLE public.commercial_order_cancellations FROM PUBLIC, cerp_app;
+REVOKE ALL ON TABLE public.commercial_command_receipts FROM PUBLIC, cerp_app;
+GRANT SELECT, INSERT ON TABLE public.commercial_quote_events TO cerp_app;
+GRANT SELECT, INSERT ON TABLE public.commercial_order_cancellations TO cerp_app;
+GRANT SELECT, INSERT ON TABLE public.commercial_command_receipts TO cerp_app;
+REVOKE ALL ON FUNCTION public.fn_commercial_evidence_append_only() FROM PUBLIC, cerp_app;
+GRANT EXECUTE ON FUNCTION public.fn_commercial_evidence_append_only() TO cerp_app;
+
+COMMENT ON TABLE public.commercial_quote_events IS
+  'SOL-17 append-only quote history. No inferred dates: source and actor make reliability explicit.';
+COMMENT ON TABLE public.commercial_order_cancellations IS
+  'SOL-17 terminal, audited order cancellations. One immutable cancellation per customer order.';
+COMMENT ON TABLE public.commercial_command_receipts IS
+  'SOL-17 idempotency receipts. Same action/key/payload replays; a changed payload is rejected.';
+
+COMMIT;

--- a/db/patches/support/20260812_commercial_reliability_sol17.preflight.sql
+++ b/db/patches/support/20260812_commercial_reliability_sol17.preflight.sql
@@ -1,0 +1,61 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $preflight$
+DECLARE
+  expected_sha256 constant text := '9da8fc1d7a71a5cf1133995de85d2c2680eeec5f7d7ffbcaa826351d8f35e97e';
+  registered_sha256 text;
+  target_tables integer;
+  target_triggers integer;
+BEGIN
+  IF to_regclass('public.cerp_schema_migrations') IS NULL
+     OR to_regclass('public.devis') IS NULL
+     OR to_regclass('public.devis_ligne') IS NULL
+     OR to_regclass('public.commande_client') IS NULL
+     OR to_regclass('public.commande_historique') IS NULL
+     OR to_regclass('public.commande_client_event_log') IS NULL
+     OR to_regclass('public.users') IS NULL
+     OR to_regclass('public.erp_audit_logs') IS NULL
+     OR to_regrole('cerp_app') IS NULL THEN
+    RAISE EXCEPTION 'SOL-17 preflight: prerequisite table or runtime role is missing';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM public.devis
+    WHERE statut NOT IN ('BROUILLON','ENVOYE','ACCEPTE','REFUSE','EXPIRE','ANNULE')
+  ) THEN
+    RAISE EXCEPTION 'SOL-17 preflight: devis contains an unknown status';
+  END IF;
+
+  SELECT sha256 INTO registered_sha256
+  FROM public.cerp_schema_migrations
+  WHERE filename='20260812_commercial_reliability_sol17.sql';
+
+  SELECT COUNT(*)::integer INTO target_tables
+  FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+  WHERE n.nspname='public' AND c.relkind='r' AND c.relname=ANY(ARRAY[
+    'commercial_quote_events','commercial_order_cancellations','commercial_command_receipts'
+  ]);
+  SELECT COUNT(*)::integer INTO target_triggers
+  FROM pg_trigger WHERE NOT tgisinternal AND tgname=ANY(ARRAY[
+    'commercial_quote_events_append_only','commercial_order_cancellations_append_only',
+    'commercial_command_receipts_append_only'
+  ]);
+
+  IF registered_sha256 IS NULL THEN
+    IF target_tables<>0 OR target_triggers<>0 OR to_regprocedure('public.fn_commercial_evidence_append_only()') IS NOT NULL THEN
+      RAISE EXCEPTION 'SOL-17 preflight: target artifact exists without ledger provenance';
+    END IF;
+    RETURN;
+  END IF;
+  IF registered_sha256<>expected_sha256 THEN
+    RAISE EXCEPTION 'SOL-17 preflight: migration ledger checksum is unexpected';
+  END IF;
+  IF target_tables<>3 OR target_triggers<>3 OR to_regprocedure('public.fn_commercial_evidence_append_only()') IS NULL THEN
+    RAISE EXCEPTION 'SOL-17 preflight: applied migration shape is incomplete';
+  END IF;
+END
+$preflight$;
+
+ROLLBACK;

--- a/db/patches/support/20260812_commercial_reliability_sol17.rollback.sql
+++ b/db/patches/support/20260812_commercial_reliability_sol17.rollback.sql
@@ -1,0 +1,45 @@
+\set ON_ERROR_STOP on
+
+-- Disposable environments only. Operational evidence is never deleted.
+-- Invoke in one psql session with:
+--   -c "SET cerp.allow_sol17_rollback='SOL-17'" -f <this-file>
+BEGIN;
+
+DO $guard$
+DECLARE
+  expected_sha256 constant text := '9da8fc1d7a71a5cf1133995de85d2c2680eeec5f7d7ffbcaa826351d8f35e97e';
+  registered_sha256 text;
+BEGIN
+  IF current_database() !~* '(test|dev|local|sandbox)' THEN
+    RAISE EXCEPTION 'SOL-17 rollback: only a disposable dev/test database is allowed';
+  END IF;
+  IF current_setting('cerp.allow_sol17_rollback',true) IS DISTINCT FROM 'SOL-17' THEN
+    RAISE EXCEPTION 'SOL-17 rollback: explicit session token is missing';
+  END IF;
+  SELECT sha256 INTO registered_sha256
+  FROM public.cerp_schema_migrations
+  WHERE filename='20260812_commercial_reliability_sol17.sql'
+  FOR UPDATE;
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 THEN
+    RAISE EXCEPTION 'SOL-17 rollback: migration ledger checksum is missing or unexpected';
+  END IF;
+  IF (SELECT COUNT(*) FROM public.commercial_quote_events)>0
+     OR (SELECT COUNT(*) FROM public.commercial_order_cancellations)>0
+     OR (SELECT COUNT(*) FROM public.commercial_command_receipts)>0 THEN
+    RAISE EXCEPTION 'SOL-17 rollback: commercial evidence exists; rollback refused';
+  END IF;
+END
+$guard$;
+
+DROP TRIGGER commercial_quote_events_append_only ON public.commercial_quote_events;
+DROP TRIGGER commercial_order_cancellations_append_only ON public.commercial_order_cancellations;
+DROP TRIGGER commercial_command_receipts_append_only ON public.commercial_command_receipts;
+DROP TABLE public.commercial_command_receipts;
+DROP TABLE public.commercial_order_cancellations;
+DROP TABLE public.commercial_quote_events;
+DROP FUNCTION public.fn_commercial_evidence_append_only();
+
+DELETE FROM public.cerp_schema_migrations
+WHERE filename='20260812_commercial_reliability_sol17.sql';
+
+COMMIT;

--- a/db/patches/support/20260812_commercial_reliability_sol17.verify.sql
+++ b/db/patches/support/20260812_commercial_reliability_sol17.verify.sql
@@ -1,0 +1,80 @@
+\set ON_ERROR_STOP on
+
+BEGIN TRANSACTION READ ONLY;
+
+DO $verify$
+DECLARE
+  expected_sha256 constant text := '9da8fc1d7a71a5cf1133995de85d2c2680eeec5f7d7ffbcaa826351d8f35e97e';
+  registered_sha256 text;
+  owner_count integer;
+  trigger_count integer;
+BEGIN
+  SELECT sha256 INTO registered_sha256
+  FROM public.cerp_schema_migrations
+  WHERE filename='20260812_commercial_reliability_sol17.sql';
+  IF registered_sha256 IS DISTINCT FROM expected_sha256 THEN
+    RAISE EXCEPTION 'SOL-17 verify: exact migration checksum is not registered';
+  END IF;
+  IF to_regclass('public.commercial_quote_events') IS NULL
+     OR to_regclass('public.commercial_order_cancellations') IS NULL
+     OR to_regclass('public.commercial_command_receipts') IS NULL THEN
+    RAISE EXCEPTION 'SOL-17 verify: one or more target tables are missing';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO owner_count
+  FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace
+  WHERE n.nspname='public' AND c.relname=ANY(ARRAY[
+    'commercial_quote_events','commercial_order_cancellations','commercial_command_receipts'
+  ]) AND c.relowner=to_regrole('cerp_app');
+  IF owner_count<>3 THEN
+    RAISE EXCEPTION 'SOL-17 verify: runtime ownership is not exact';
+  END IF;
+
+  SELECT COUNT(*)::integer INTO trigger_count
+  FROM pg_trigger WHERE NOT tgisinternal AND tgenabled='O' AND tgname=ANY(ARRAY[
+    'commercial_quote_events_append_only','commercial_order_cancellations_append_only',
+    'commercial_command_receipts_append_only'
+  ]);
+  IF trigger_count<>3 THEN
+    RAISE EXCEPTION 'SOL-17 verify: append-only triggers are missing or disabled';
+  END IF;
+
+  IF EXISTS (
+    SELECT action,idempotency_key FROM public.commercial_command_receipts
+    GROUP BY action,idempotency_key HAVING COUNT(*)>1
+  ) THEN
+    RAISE EXCEPTION 'SOL-17 verify: idempotency receipt uniqueness is violated';
+  END IF;
+  IF EXISTS (
+    SELECT devis_id,channel,(occurred_at AT TIME ZONE 'Europe/Paris')::date
+    FROM public.commercial_quote_events WHERE event_type='REMINDER_RECORDED'
+    GROUP BY devis_id,channel,(occurred_at AT TIME ZONE 'Europe/Paris')::date HAVING COUNT(*)>1
+  ) THEN
+    RAISE EXCEPTION 'SOL-17 verify: duplicate daily quote reminders exist';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.commercial_quote_events
+    WHERE event_type='LOST' AND reason_code IS NULL
+  ) THEN
+    RAISE EXCEPTION 'SOL-17 verify: a quote loss lacks a structured reason';
+  END IF;
+  IF EXISTS (
+    SELECT devis_id,quote_content_hash FROM public.commercial_quote_events
+    WHERE event_type='DISCOUNT_REQUESTED'
+    GROUP BY devis_id,quote_content_hash HAVING COUNT(*)>1
+  ) THEN
+    RAISE EXCEPTION 'SOL-17 verify: duplicate discount requests exist for one quote version';
+  END IF;
+  IF EXISTS (
+    SELECT 1 FROM public.commercial_order_cancellations c
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.commande_historique h
+      WHERE h.commande_id=c.commande_id AND h.nouveau_statut='ANNULE'
+    )
+  ) THEN
+    RAISE EXCEPTION 'SOL-17 verify: an order cancellation lacks status history';
+  END IF;
+END
+$verify$;
+
+ROLLBACK;

--- a/docs/adr/ADR-0063-commercial-reliability-boundary.md
+++ b/docs/adr/ADR-0063-commercial-reliability-boundary.md
@@ -1,0 +1,78 @@
+# ADR-0063 — Frontière de fiabilité commerciale
+
+- Statut : accepté
+- Date : 2026-08-12
+- Décision : SOL-17
+- Propriétaire métier : Keenan Martin, Direction CERP+
+
+## Contexte
+
+Le domaine commercial disposait des clients, devis versionnés, commandes, livraisons,
+factures et règlements, mais pas d'une preuve commune pour les relances, pertes,
+validations de remise et annulations. La conversion pouvait être confondue avec le
+statut `ACCEPTE`, les révisions V1/V2 pouvaient compter plusieurs fois une même
+opportunité et une marge incomplète pouvait sembler exploitable.
+
+## Décision
+
+Le backend est l'autorité du contrat `CERP-COMMERCIAL-1.0.0`. Il publie les
+agrégats, leurs sources et leur fiabilité ; le frontend valide et affiche ce contrat
+sans recalcul métier.
+
+### Définitions décisionnelles
+
+| Indicateur | Définition | Unité / période | Source et fiabilité |
+|---|---|---|---|
+| Facturé client | Factures finalisées de la période, nettes des avoirs finalisés. Il s'agit d'un facturé opérationnel, pas d'un état comptable certifié. | devise HT/TTC, dates de document inclusives | `facture`, `avoir`; `ACTUAL` dans une devise unique |
+| Marge proposée qualifiée | Somme des marges `QUOTED` de la dernière version de chaque devis. Le montant est `null` si un seul snapshot est absent ou incomplet. | devise HT, cohorte de création | `margin_recalculations`; au mieux `ESTIMATED`, sinon `PARTIAL` |
+| Conversion devis → commande | Nombre de dernières versions de racines de devis reliées par `devis_id` ou `source_devis_version_id` à une commande non annulée, divisé par le nombre de racines émises. | %, cohorte mensuelle | `devis`, `commande_client`, `commande_historique`; `ACTUAL` si le dénominateur existe |
+| Délai de réponse | Temps entre le premier événement `SENT` et le premier événement `ACCEPTED` ou `LOST`. | jours, cohorte | `commercial_quote_events`; `PARTIAL` tant que l'historique antérieur n'a pas ces événements |
+| Impayé | Solde TTC positif après paiements et avoirs alloués, échu strictement à la date d'arrêté. | devise TTC, `as_of` | `facture`, `paiement_allocations`, `avoir_source_allocations` |
+| Backlog | Quantité commandée non expédiée × prix unitaire HT après remise ligne ; les commandes annulées sont exclues. | devise HT, état à `as_of` | `commande_ligne`, `bon_livraison_ligne`, `commande_historique` |
+| Risque client | Catégorie explicable, sans probabilité fabriquée : blocage client, impayé échu, commande bloquée, backlog en retard ou devis expiré. | `LOW|MEDIUM|HIGH|CRITICAL` | faits sources listés dans la réponse ; `ACTUAL` ou `PARTIAL` |
+
+Les devis sont dédupliqués par `root_devis_id` et seule la version la plus récente
+est retenue. Sans devise explicite, un périmètre multi-devises est refusé avec 409.
+Une absence de donnée produit `null` ou une limitation, jamais un zéro de remplissage.
+Le fuseau des relances quotidiennes et des bornes métier est `Europe/Paris`.
+
+### Actions et preuves
+
+- les événements de devis et annulations sont append-only ; aucune date historique
+  n'est inventée ni rétro-remplie ;
+- une remise doit être approuvée pour l'empreinte SHA-256 exacte du contenu avant
+  l'envoi du devis ; toute modification invalide donc l'approbation précédente ;
+- perte et annulation utilisent des motifs structurés ; une relance identique sur le
+  même canal et le même jour est unique ;
+- chaque commande sensible porte une clé d'idempotence, une empreinte de requête et
+  un reçu rejouable ; réutiliser la clé avec un autre payload retourne 409 ;
+- une annulation est refusée après preuve de livraison, facturation ou état terminal ;
+- chaque action écrit l'acteur, le propriétaire, la date et un audit dans la même
+  transaction ;
+- les lectures financières exigent `reporting_financial`. Les décisions de remise,
+  expirations et annulations sont réservées à la Direction ou à l'administration ;
+  les rôles commerciaux peuvent relancer, enregistrer une perte et demander une
+  validation.
+
+La chronologie commande rassemble les sources réelles `commande_client`,
+`commande_historique`, `ordres_fabrication`, pointages/déclarations/réceptions de
+production, bons de livraison et factures.
+
+## Isolation et limites
+
+L'isolation disponible est celle de la base CERP choisie et validée par le middleware
+existant. Les tables commerciales actuelles ne portent pas de société/site
+autoritaire commun ; aucun filtre de site fictif n'est donc ajouté. Les événements
+antérieurs à SOL-17 restent partiels. Les coûts indirects ou constatés ne sont pas
+substitués à la marge proposée : les perspectives industrielles restent gouvernées
+par `CERP-MARGIN-2.0.0`.
+
+## Migration et retour arrière
+
+Le patch ajoute trois tables et une fonction de garde, sans réécrire les devis ni les
+commandes. Le rollback SQL n'est autorisé que sur une base jetable `test|dev|local`
+avec le jeton de session SOL-17 et seulement si aucune preuve commerciale n'existe.
+En production, après la première preuve, le retour arrière consiste à redéployer
+l'artefact précédent compatible et conserver les tables ; si un retour de schéma est
+indispensable, restaurer la sauvegarde complète prise avant la fenêtre.
+

--- a/docs/adr/ADR-0063-commercial-reliability-boundary.md
+++ b/docs/adr/ADR-0063-commercial-reliability-boundary.md
@@ -75,4 +75,3 @@ avec le jeton de session SOL-17 et seulement si aucune preuve commerciale n'exis
 En production, après la première preuve, le retour arrière consiste à redéployer
 l'artefact précédent compatible et conserver les tables ; si un retour de schéma est
 indispensable, restaurer la sauvegarde complète prise avant la fenêtre.
-

--- a/docs/execution-reports/SOL-17.md
+++ b/docs/execution-reports/SOL-17.md
@@ -111,4 +111,3 @@ son jeton de session, puis vérifier l'absence des quatre objets. Après créati
 preuve en production, ne pas supprimer les tables : redéployer les artefacts
 précédents compatibles. Pour un retour de schéma imposé, arrêter les écritures et
 restaurer le recovery set pré-migration dont le checksum a été vérifié.
-

--- a/docs/execution-reports/SOL-17.md
+++ b/docs/execution-reports/SOL-17.md
@@ -1,0 +1,114 @@
+# SOL-17 — Clients, devis et commandes clients (backend)
+
+- Date : 2026-08-12
+- Issue : [#420](https://github.com/BigFootLime/erp-crp-backend/issues/420)
+- Branche : `feature/420-sol17-commercial-reliability`
+- Commits fonctionnels avant documentation : `2112e95`, `c5f332f`
+
+## Diagnostic et cause racine
+
+Les sources commerciales existaient mais n'avaient ni journal commun des décisions
+de devis, ni validation de remise liée au contenu, ni reçu d'idempotence commun. La
+conversion pouvait être assimilée au statut accepté et les révisions pouvaient
+doubler les cohortes. Le reporting ne reliait pas dans un contrat unique facturé,
+impayés, backlog, marge qualifiée, risque et chronologie de production.
+
+Le premier passage de la suite complète a aussi révélé une assertion héritée de
+SOL-16 : elle exigeait « Indisponible » pour toute métrique différée alors que l'OTIF
+possède désormais une formule autoritaire sur une autre route. Le test distingue
+maintenant cette délégation documentée sans rendre l'OTIF historique plus fiable.
+
+## Choix d'architecture
+
+- contrat serveur `CERP-COMMERCIAL-1.0.0`, valeurs `null` en cas d'absence et refus
+  409 des agrégats multi-devises ;
+- dernière version par racine de devis, conversion prouvée par une commande liée et
+  non annulée ;
+- marge `QUOTED` masquée si la couverture n'est pas complète ;
+- risques catégoriels fondés sur des faits, exceptions avec responsable et prochaine
+  action ;
+- événements et annulations append-only, audit transactionnel, RBAC serveur et reçus
+  d'idempotence ;
+- chronologie source de bout en bout, sans événement synthétique.
+
+La définition détaillée est dans `docs/adr/ADR-0063-commercial-reliability-boundary.md`.
+
+## Fichiers modifiés
+
+- nouveau module `src/module/commercial-reliability/` (domaine, validation,
+  repository, contrôleur, routes et tests) ;
+- workflow commande, repository devis, reporting v2 et route facturation ;
+- contrat généré `contracts/commande-client-workflow.v1.json` ;
+- patch SQL SOL-17 et scripts `preflight`, `verify`, `rollback` ;
+- tests de workflow devis/commande, RBAC, idempotence, migration et contrat OTIF ;
+- ADR, répétition de migration et présent rapport.
+
+## Migration et données
+
+`20260812_commercial_reliability_sol17.sql` ajoute
+`commercial_quote_events`, `commercial_order_cancellations`,
+`commercial_command_receipts` et la garde append-only. Il ne modifie et ne
+rétro-remplit aucune donnée historique. SHA-256 normalisé enregistré par le runner :
+`9da8fc1d7a71a5cf1133995de85d2c2680eeec5f7d7ffbcaa826351d8f35e97e`.
+
+Répétition PostgreSQL 16 jetable finale :
+
+- sauvegarde 1 954 319 octets, SHA-256
+  `97efcd6ac410312fe0ea5d5c61c6cdc4a2a4477e8d3f951e46cb3ae454518eca` ;
+- preflight : 140 patches appliqués, 7 attendus, 0 checksum divergent ;
+- migration : 223 ms, 147 appliqués, vérification 132 ms, rejeu 0 patch ;
+- intégrité post-migration : `passed` ;
+- rollback SOL-17 : tables et fonction retirées, preuve globale `passed` en 72 ms ;
+- restauration : 3 861 ms, comptages identiques et empreinte source/restaurée
+  `d33b4e782dab383bc42a7a6d32f5b842080fb9e800d2bc27c415598bdfe1f00f` ;
+- conteneur tmpfs et sauvegarde temporaire détruits après le test.
+
+Aucune base persistante ou de production n'a été lue ou écrite.
+
+## Tests exécutés
+
+| Contrôle | Résultat réel |
+|---|---|
+| domaine/repository/routes/devis SOL-17 ciblés | PASS — 5 fichiers, 52 tests |
+| workflow commande | PASS — 17 tests |
+| reporting SQL + domaine/repository SOL-17 | PASS — 83 tests |
+| garde migration finale | PASS — 4/4 |
+| contrat reporting hérité corrigé | PASS — 92/92 |
+| suite backend complète | PASS — code 0, 64,5 s |
+| `pnpm typecheck` | PASS |
+| `pnpm build` | PASS — frontière production 643 sources / 643 fichiers émis |
+| répétition migration complète | PASS — sauvegarde, 7 patches, verify, rejeu, rollback, restauration |
+| E2E isolé inter-dépôts | PASS — 3/3, 147 migrations, 1,1 min Playwright |
+
+Les E2E couvrent conversion V1→V2 sans double comptage, annulation et retry,
+refus après livraison partielle ou facture, chronologie
+commande→analyse→OF→production→livraison→facture et le parcours achat complet.
+
+## Vérification navigateur
+
+Sur la pile isolée, connexion à `cerp_test`, ouverture du Reporting commercial puis
+de l'onglet « Risques & actions ». Les métadonnées, le statut partiel, la conversion
+absente affichée `—`, la marge indisponible sans zéro et les états vides actionnables
+ont été vérifiés. Deux erreurs console `legacy_browser_console` correspondent au live
+dégradé déjà visible hors SOL-17 ; aucune erreur de l'API commerciale n'a été relevée.
+
+## Risques, compatibilité et reste à faire
+
+- les devis antérieurs n'ont pas d'événements `SENT/LOST` : délai et motifs restent
+  honnêtement partiels ;
+- l'isolation société/site ne peut pas être filtrée plus finement que la base CERP
+  tant qu'un lien autoritaire n'existe pas dans les tables commerciales ;
+- les gros chunks Vite existants restent un avertissement de performance, sans échec
+  de build ;
+- diagnostiquer séparément le live dégradé/`legacy_browser_console` ;
+- appliquer le patch sur une base persistante uniquement par le gate de release,
+  pendant une fenêtre autorisée, avec sauvegarde validée.
+
+## Rollback
+
+Avant toute preuve SOL-17 sur une base jetable, utiliser le script de rollback avec
+son jeton de session, puis vérifier l'absence des quatre objets. Après création d'une
+preuve en production, ne pas supprimer les tables : redéployer les artefacts
+précédents compatibles. Pour un retour de schéma imposé, arrêter les écritures et
+restaurer le recovery set pré-migration dont le checksum a été vérifié.
+

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-11T12:50:06.203Z",
+  "started_at": "2026-08-12T15:46:29.303Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,23 +9,23 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 19039,
-    "source_seed": 197,
-    "backup": 744,
-    "preflight": 174,
-    "integrity_before": 609,
-    "migration": 219,
-    "verify": 123,
-    "replay": 164,
-    "integrity_after": 1364,
-    "negative_gate": 41,
-    "rollback": 23,
-    "restore": 4160
+    "source_migration": 18274,
+    "source_seed": 189,
+    "backup": 728,
+    "preflight": 162,
+    "integrity_before": 642,
+    "migration": 223,
+    "verify": 132,
+    "replay": 122,
+    "integrity_after": 1342,
+    "negative_gate": 40,
+    "rollback": 72,
+    "restore": 3861
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-11T12:50:28.169Z",
-    "duration_ms": 126,
+    "checked_at": "2026-08-12T15:46:51.043Z",
+    "duration_ms": 93,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36199447"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-7Y3yyZ\\cerp-test-before-sol06.dump",
-      "bytes": 1954302,
-      "sha256": "cfb03d3edfacf61fc8bbf63c218aee069a443c38a094e1c766b8ba9cd1d73d58",
-      "free_bytes": 437792104448
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-WZ1gmU\\cerp-test-before-sol06.dump",
+      "bytes": 1954319,
+      "sha256": "97efcd6ac410312fe0ea5d5c61c6cdc4a2a4477e8d3f951e46cb3ae454518eca",
+      "free_bytes": 427947581440
     },
     "ledger": {
       "applied": 140,
@@ -45,7 +45,9 @@
         "20260811_account_provisioning_schema_repair.sql",
         "20260811_base_unit_drift_repair.sql",
         "20260811_ged_antivirus_quarantine.sql",
-        "20260811_production_readiness_center.sql"
+        "20260811_margin_traceability_0002.sql",
+        "20260811_production_readiness_center.sql",
+        "20260812_commercial_reliability_sol17.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
@@ -86,7 +88,7 @@
       "articles_achat": "0",
       "articles_achat_families": "0",
       "articles_fabrique": "1",
-      "articles_fabrique_families": "1",
+      "articles_fabrique_families": "2",
       "articles_matiere": "0",
       "articles_matiere_families": "7",
       "articles_traitement": "0",
@@ -426,12 +428,14 @@
         "20260811_account_provisioning_schema_repair.sql",
         "20260811_base_unit_drift_repair.sql",
         "20260811_ged_antivirus_quarantine.sql",
-        "20260811_production_readiness_center.sql"
+        "20260811_margin_traceability_0002.sql",
+        "20260811_production_readiness_center.sql",
+        "20260812_commercial_reliability_sol17.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
     },
-    "fingerprint": "ed3d10df6ba7c504198adf1892a5380425537598d84751db416355285314c9b3"
+    "fingerprint": "d33b4e782dab383bc42a7a6d32f5b842080fb9e800d2bc27c415598bdfe1f00f"
   },
   "replay": {
     "applied_zero": true,
@@ -439,8 +443,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-11T12:50:30.653Z",
-    "duration_ms": 1349,
+    "checked_at": "2026-08-12T15:46:53.509Z",
+    "duration_ms": 1328,
     "table_counts": {
       "admin_account_invitations": "0",
       "admin_user_provisioning_migration_state": "12",
@@ -474,7 +478,7 @@
       "articles_achat": "0",
       "articles_achat_families": "0",
       "articles_fabrique": "1",
-      "articles_fabrique_families": "1",
+      "articles_fabrique_families": "2",
       "articles_matiere": "0",
       "articles_matiere_families": "7",
       "articles_traitement": "0",
@@ -497,7 +501,7 @@
       "centres_frais": "1",
       "cerp_patch_20260804_stock_units": "3",
       "cerp_patch_20260811_base_unit_repair": "1",
-      "cerp_schema_migrations": "145",
+      "cerp_schema_migrations": "147",
       "chat_conversation_participants": "0",
       "chat_conversations": "0",
       "chat_messages": "0",
@@ -528,6 +532,9 @@
       "commande_ligne": "0",
       "commande_ligne_affaire_allocation": "0",
       "commande_to_affaire": "0",
+      "commercial_command_receipts": "0",
+      "commercial_order_cancellations": "0",
+      "commercial_quote_events": "0",
       "contacts": "1",
       "currencies": "4",
       "dashboard_usage_daily": "0",
@@ -808,7 +815,7 @@
       "users": "7",
       "warehouses": "4"
     },
-    "table_count": 365,
+    "table_count": 368,
     "unvalidated_constraints": [
       {
         "table_name": "avoir",
@@ -880,7 +887,7 @@
         "groups": 0
       }
     ],
-    "foreign_key_count": 1058,
+    "foreign_key_count": 1064,
     "orphans": [],
     "readiness": [
       {
@@ -889,10 +896,10 @@
         "ready": true,
         "definition": "Calendrier de capacité actif avec jours et horaires explicites.",
         "unit": "calendriers",
-        "period_start": "2026-08-10T22:00:00.000Z",
+        "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-11T12:50:29.303Z",
+        "freshness_at": "2026-08-12T15:46:52.182Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -906,10 +913,10 @@
         "ready": true,
         "definition": "Chaque compte actif possède un rôle principal issu du catalogue actif.",
         "unit": "comptes",
-        "period_start": "2026-08-10T22:00:00.000Z",
+        "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-11T12:50:29.303Z",
+        "freshness_at": "2026-08-12T15:46:52.182Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -924,10 +931,10 @@
         "ready": true,
         "definition": "Les statuts canoniques OF et stock sont présents et leur contrainte est validée.",
         "unit": "contrats",
-        "period_start": "2026-08-10T22:00:00.000Z",
+        "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-11T12:50:29.303Z",
+        "freshness_at": "2026-08-12T15:46:52.182Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -950,10 +957,10 @@
         "ready": true,
         "definition": "Calendrier de capacité actif avec jours et horaires explicites.",
         "unit": "calendriers",
-        "period_start": "2026-08-10T22:00:00.000Z",
+        "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-11T12:50:29.303Z",
+        "freshness_at": "2026-08-12T15:46:52.182Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -967,10 +974,10 @@
         "ready": true,
         "definition": "Chaque compte actif possède un rôle principal issu du catalogue actif.",
         "unit": "comptes",
-        "period_start": "2026-08-10T22:00:00.000Z",
+        "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-11T12:50:29.303Z",
+        "freshness_at": "2026-08-12T15:46:52.182Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -985,10 +992,10 @@
         "ready": true,
         "definition": "Unités canoniques utilisables sans conversion implicite.",
         "unit": "unités",
-        "period_start": "2026-08-10T22:00:00.000Z",
+        "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-11T12:50:29.303Z",
+        "freshness_at": "2026-08-12T15:46:52.182Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1005,10 +1012,10 @@
         "ready": true,
         "definition": "Chaque centre de frais actif possède un taux horaire versionné applicable et sourcé.",
         "unit": "EUR/heure",
-        "period_start": "2026-08-10T22:00:00.000Z",
+        "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-11T12:50:29.303Z",
+        "freshness_at": "2026-08-12T15:46:52.182Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1023,10 +1030,10 @@
         "ready": true,
         "definition": "Les statuts canoniques OF et stock sont présents et leur contrainte est validée.",
         "unit": "contrats",
-        "period_start": "2026-08-10T22:00:00.000Z",
+        "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-11T12:50:29.303Z",
+        "freshness_at": "2026-08-12T15:46:52.182Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1049,10 +1056,10 @@
         "ready": true,
         "definition": "Chaque compte actif possède un rôle principal issu du catalogue actif.",
         "unit": "comptes",
-        "period_start": "2026-08-10T22:00:00.000Z",
+        "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-11T12:50:29.303Z",
+        "freshness_at": "2026-08-12T15:46:52.182Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1067,10 +1074,10 @@
         "ready": true,
         "definition": "Au moins un magasin et un emplacement actifs sont reliés au référentiel warehouse/location.",
         "unit": "emplacements",
-        "period_start": "2026-08-10T22:00:00.000Z",
+        "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-11T12:50:29.303Z",
+        "freshness_at": "2026-08-12T15:46:52.182Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1086,10 +1093,10 @@
         "ready": true,
         "definition": "Unités canoniques utilisables sans conversion implicite.",
         "unit": "unités",
-        "period_start": "2026-08-10T22:00:00.000Z",
+        "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-11T12:50:29.303Z",
+        "freshness_at": "2026-08-12T15:46:52.182Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1124,10 +1131,10 @@
         "ready": true,
         "definition": "Les statuts canoniques OF et stock sont présents et leur contrainte est validée.",
         "unit": "contrats",
-        "period_start": "2026-08-10T22:00:00.000Z",
+        "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-11T12:50:29.303Z",
+        "freshness_at": "2026-08-12T15:46:52.182Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1146,12 +1153,12 @@
       }
     ],
     "ledger": {
-      "applied": 145,
+      "applied": 147,
       "pending": [],
       "checksum_mismatches": [],
       "unknown_applied": []
     },
-    "fingerprint": "7668d0ea59b45b4d6e086a7c9a0b97e4ffb15c2c7596e1e53c9b896609ea9740"
+    "fingerprint": "dea7aa51eb37205fc5be7dc0008dd578d6fa9f9f9b1854500524eb378534e746"
   },
   "negative_gate": {
     "status": "passed",
@@ -1180,11 +1187,13 @@
     "status": "passed",
     "function_removed": true,
     "function_v2_removed": true,
+    "margin_traceability_removed": true,
+    "commercial_reliability_removed": true,
     "trigger_removed": true
   },
   "restore": {
     "status": "passed",
-    "fingerprint": "ed3d10df6ba7c504198adf1892a5380425537598d84751db416355285314c9b3",
+    "fingerprint": "d33b4e782dab383bc42a7a6d32f5b842080fb9e800d2bc27c415598bdfe1f00f",
     "table_counts_equal": true,
     "ledger": {
       "applied": 140,
@@ -1193,11 +1202,13 @@
         "20260811_account_provisioning_schema_repair.sql",
         "20260811_base_unit_drift_repair.sql",
         "20260811_ged_antivirus_quarantine.sql",
-        "20260811_production_readiness_center.sql"
+        "20260811_margin_traceability_0002.sql",
+        "20260811_production_readiness_center.sql",
+        "20260812_commercial_reliability_sol17.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-11T12:50:35.056Z"
+  "completed_at": "2026-08-12T15:46:57.637Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,33 +1,33 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-11T12:50:35.056Z
+- Exécutée : 2026-08-12T15:46:57.637Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36199447 octets
-- Sauvegarde : 1954302 octets, SHA-256 `cfb03d3edfacf61fc8bbf63c218aee069a443c38a094e1c766b8ba9cd1d73d58`
-- Patches avant/après : 140 / 145
+- Sauvegarde : 1954319 octets, SHA-256 `97efcd6ac410312fe0ea5d5c61c6cdc4a2a4477e8d3f951e46cb3ae454518eca`
+- Patches avant/après : 140 / 147
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
 - Refus métier négatif : SQLSTATE P2606
 - Rollback test-only : passed
 - Restauration vers base neuve : passed
-- Empreinte source/restaurée : `ed3d10df6ba7c504198adf1892a5380425537598d84751db416355285314c9b3` / `ed3d10df6ba7c504198adf1892a5380425537598d84751db416355285314c9b3`
+- Empreinte source/restaurée : `d33b4e782dab383bc42a7a6d32f5b842080fb9e800d2bc27c415598bdfe1f00f` / `d33b4e782dab383bc42a7a6d32f5b842080fb9e800d2bc27c415598bdfe1f00f`
 
 ## Durées réelles
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 19039 |
-| source_seed | 197 |
-| backup | 744 |
-| preflight | 174 |
-| integrity_before | 609 |
-| migration | 219 |
-| verify | 123 |
-| replay | 164 |
-| integrity_after | 1364 |
-| negative_gate | 41 |
-| rollback | 23 |
-| restore | 4160 |
+| source_migration | 18274 |
+| source_seed | 189 |
+| backup | 728 |
+| preflight | 162 |
+| integrity_before | 642 |
+| migration | 223 |
+| verify | 132 |
+| replay | 122 |
+| integrity_after | 1342 |
+| negative_gate | 40 |
+| rollback | 72 |
+| restore | 3861 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -12,6 +12,7 @@ const SUPPORT_DIR = path.join(PATCH_DIR, "support");
 const SOL06_PATCH = "20260810_system_reference_data_readiness.sql";
 const PRODUCTION_READINESS_PATCH = "20260811_production_readiness_center.sql";
 const MARGIN_TRACEABILITY_PATCH = "20260811_margin_traceability_0002.sql";
+const COMMERCIAL_RELIABILITY_PATCH = "20260812_commercial_reliability_sol17.sql";
 const SOL06_SUPPORT = path.join(SUPPORT_DIR, "20260810_system_reference_data_readiness");
 const POSTGRES_IMAGE = "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229";
 const DEFAULT_REPORT_DIR = path.join(ROOT, "docs", "release");
@@ -442,6 +443,14 @@ async function proveRollback(databaseUrl) {
   await client.connect();
   try {
     await client.query("SET cerp.migration_rehearsal = 'on'");
+    const commercialReliabilityRollback = patchSupportSql(COMMERCIAL_RELIABILITY_PATCH, "rollback");
+    const commercialReliabilityObject = await client.query(
+      "SELECT to_regclass('public.commercial_quote_events') IS NOT NULL AS present"
+    );
+    if (commercialReliabilityRollback && commercialReliabilityObject.rows[0].present) {
+      await client.query("SET cerp.allow_sol17_rollback = 'SOL-17'");
+      await runSqlFile(client, commercialReliabilityRollback);
+    }
     const marginTraceabilityRollback = patchSupportSql(MARGIN_TRACEABILITY_PATCH, "rollback");
     const marginEvidenceColumn = await client.query(
       `SELECT EXISTS (
@@ -469,10 +478,16 @@ async function proveRollback(databaseUrl) {
                 WHERE table_schema='public' AND table_name='margin_input_versions'
                   AND column_name='evidence_contract_version'
               ) AS margin_traceability_removed,
+              to_regclass('public.commercial_quote_events') IS NULL
+                AND to_regclass('public.commercial_order_cancellations') IS NULL
+                AND to_regclass('public.commercial_command_receipts') IS NULL
+                AND to_regprocedure('public.fn_commercial_evidence_append_only()') IS NULL
+                AS commercial_reliability_removed,
               NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname='trg_stock_reference_readiness_2606') AS trigger_removed`
     );
     if (!objects.rows[0].function_removed || !objects.rows[0].function_v2_removed
-        || !objects.rows[0].margin_traceability_removed || !objects.rows[0].trigger_removed) {
+        || !objects.rows[0].margin_traceability_removed || !objects.rows[0].commercial_reliability_removed
+        || !objects.rows[0].trigger_removed) {
       fail("rollback left SOL-06 objects behind");
     }
     return { status: "passed", ...objects.rows[0] };
@@ -675,6 +690,7 @@ if (require.main === module) {
 module.exports = {
   SOL06_PATCH,
   MARGIN_TRACEABILITY_PATCH,
+  COMMERCIAL_RELIABILITY_PATCH,
   expectedRehearsalPatches,
   inventory,
   inventoryMarkdown,

--- a/src/__tests__/commercial-reliability-sol17.migration-guards.test.ts
+++ b/src/__tests__/commercial-reliability-sol17.migration-guards.test.ts
@@ -1,0 +1,32 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const patch = fs.readFileSync(
+  path.resolve(process.cwd(), "db/patches/20260812_commercial_reliability_sol17.sql"),
+  "utf8",
+);
+
+describe("SOL-17 commercial migration guards", () => {
+  it("creates append-only evidence and idempotency receipts", () => {
+    expect(patch).toContain("CREATE TABLE public.commercial_quote_events");
+    expect(patch).toContain("CREATE TABLE public.commercial_order_cancellations");
+    expect(patch).toContain("CREATE TABLE public.commercial_command_receipts");
+    expect(patch).toContain("commercial_quote_events_append_only");
+    expect(patch).toContain("commercial_command_receipts_pkey PRIMARY KEY (action, idempotency_key)");
+  });
+
+  it("does not fabricate historical commercial events", () => {
+    expect(patch).not.toMatch(/INSERT\s+INTO\s+public\.commercial_quote_events\s+SELECT/i);
+    expect(patch).not.toMatch(/UPDATE\s+public\.devis/i);
+    expect(patch).not.toMatch(/UPDATE\s+public\.commande_client/i);
+  });
+
+  it("keeps structured loss and cancellation vocabularies constrained", () => {
+    expect(patch).toContain("commercial_quote_events_reason_ck");
+    expect(patch).toContain("commercial_order_cancellations_reason_ck");
+    expect(patch).toContain("commercial_quote_reminder_daily_channel_uniq");
+    expect(patch).toContain("commercial_quote_discount_content_request_uniq");
+    expect(patch).toContain("commercial_quote_discount_decision_uniq");
+  });
+});

--- a/src/__tests__/commercial-reliability-sol17.migration-guards.test.ts
+++ b/src/__tests__/commercial-reliability-sol17.migration-guards.test.ts
@@ -6,6 +6,10 @@ const patch = fs.readFileSync(
   path.resolve(process.cwd(), "db/patches/20260812_commercial_reliability_sol17.sql"),
   "utf8",
 );
+const releaseGate = fs.readFileSync(
+  path.resolve(process.cwd(), "scripts/migrations/release-gate.js"),
+  "utf8",
+);
 
 describe("SOL-17 commercial migration guards", () => {
   it("creates append-only evidence and idempotency receipts", () => {
@@ -28,5 +32,13 @@ describe("SOL-17 commercial migration guards", () => {
     expect(patch).toContain("commercial_quote_reminder_daily_channel_uniq");
     expect(patch).toContain("commercial_quote_discount_content_request_uniq");
     expect(patch).toContain("commercial_quote_discount_decision_uniq");
+  });
+
+  it("exercises the guarded rollback in the isolated migration rehearsal", () => {
+    expect(releaseGate).toContain(
+      'const COMMERCIAL_RELIABILITY_PATCH = "20260812_commercial_reliability_sol17.sql"',
+    );
+    expect(releaseGate).toContain('SET cerp.allow_sol17_rollback = \'SOL-17\'');
+    expect(releaseGate).toContain("commercial_reliability_removed");
   });
 });

--- a/src/__tests__/commercial-reliability-sol17.routes.test.ts
+++ b/src/__tests__/commercial-reliability-sol17.routes.test.ts
@@ -1,0 +1,134 @@
+import { EventEmitter } from "events";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  currentRole: { value: "Directeur" as string | null },
+  overview: vi.fn(),
+  timeline: vi.fn(),
+  reminder: vi.fn(),
+  loss: vi.fn(),
+  discountRequest: vi.fn(),
+  discountDecision: vi.fn(),
+  expire: vi.fn(),
+  cancel: vi.fn(),
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = { on: emitter.on.bind(emitter), query: vi.fn(), connect: vi.fn() };
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({ checkNetworkDrive: vi.fn(() => Promise.resolve()) }));
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; username: string; email: string; role: string; primary_role: string; roles: string[] } },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void,
+  ) => {
+    if (mocks.currentRole.value === null) {
+      res.status(401).json({ error: "UNAUTHORIZED" });
+      return;
+    }
+    req.user = {
+      id: 7,
+      username: "sol17-test",
+      email: "sol17@test.invalid",
+      role: mocks.currentRole.value,
+      primary_role: mocks.currentRole.value,
+      roles: [mocks.currentRole.value],
+    };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+vi.mock("../module/commercial-reliability/repository/commercial-reliability.repository", () => ({
+  assertQuoteDiscountApprovedForSubmission: vi.fn(),
+  repoCommercialOverview: mocks.overview,
+  repoOrderTimeline: mocks.timeline,
+  repoRecordQuoteReminder: mocks.reminder,
+  repoRecordQuoteLoss: mocks.loss,
+  repoRequestDiscountApproval: mocks.discountRequest,
+  repoDecideDiscountApproval: mocks.discountDecision,
+  repoExpireDueQuotes: mocks.expire,
+  repoCancelOrder: mocks.cancel,
+}));
+
+import app from "../config/app";
+
+const BASE = "/api/v1/reporting/commercial/reliability";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.currentRole.value = "Directeur";
+  mocks.overview.mockResolvedValue({ envelope: { contract_version: "CERP-COMMERCIAL-1.0.0" }, exceptions: [] });
+  mocks.timeline.mockResolvedValue({ commande_id: 9, events: [] });
+  mocks.reminder.mockResolvedValue({ event_id: "evt", devis_id: 4, idempotent_replay: false });
+  mocks.loss.mockResolvedValue({ devis_id: 4, status: "REFUSE" });
+  mocks.discountRequest.mockResolvedValue({ devis_id: 4, status: "PENDING" });
+  mocks.discountDecision.mockResolvedValue({ devis_id: 4, status: "APPROVED" });
+  mocks.expire.mockResolvedValue({ expired_count: 2 });
+  mocks.cancel.mockResolvedValue({ commande_id: 9, status: "ANNULE" });
+});
+
+describe("SOL-17 commercial reliability RBAC and contracts", () => {
+  it("refuses anonymous and non-financial overview access", async () => {
+    mocks.currentRole.value = null;
+    expect((await request(app).get(`${BASE}/overview`).query({ from: "2026-01-01", to: "2026-08-12" })).status).toBe(401);
+    mocks.currentRole.value = "Operateur";
+    expect((await request(app).get(`${BASE}/overview`).query({ from: "2026-01-01", to: "2026-08-12" })).status).toBe(403);
+  });
+
+  it("returns the governed overview to Direction", async () => {
+    const response = await request(app).get(`${BASE}/overview`).query({ from: "2026-01-01", to: "2026-08-12", currency: "usd" });
+    expect(response.status).toBe(200);
+    expect(response.headers["cache-control"]).toContain("no-store");
+    expect(response.body.envelope.contract_version).toBe("CERP-COMMERCIAL-1.0.0");
+    expect(mocks.overview).toHaveBeenCalledWith(expect.objectContaining({ currency: "USD" }));
+  });
+
+  it("requires an idempotency key for reminders", async () => {
+    mocks.currentRole.value = "Commercial";
+    const missing = await request(app).post(`${BASE}/quotes/4/reminders`).send({ channel: "EMAIL" });
+    expect(missing.status).toBe(400);
+    expect(mocks.reminder).not.toHaveBeenCalled();
+
+    const accepted = await request(app)
+      .post(`${BASE}/quotes/4/reminders`)
+      .set("Idempotency-Key", "sol17-reminder-0001")
+      .send({ channel: "EMAIL" });
+    expect(accepted.status).toBe(201);
+    expect(mocks.reminder).toHaveBeenCalledWith(expect.objectContaining({ idempotencyKey: "sol17-reminder-0001" }));
+  });
+
+  it("prevents a standard user from recording a loss", async () => {
+    mocks.currentRole.value = "Operateur";
+    const response = await request(app)
+      .post(`${BASE}/quotes/4/loss`)
+      .set("Idempotency-Key", "sol17-loss-0001")
+      .send({ reason_code: "PRICE" });
+    expect(response.status).toBe(403);
+    expect(mocks.loss).not.toHaveBeenCalled();
+  });
+
+  it("reserves discount decisions and order cancellation to Direction/Admin", async () => {
+    mocks.currentRole.value = "Commercial";
+    const forbidden = await request(app)
+      .post(`${BASE}/quotes/4/discount-decisions`)
+      .set("Idempotency-Key", "sol17-decision-0001")
+      .send({ approval_request_id: "11111111-1111-4111-8111-111111111111", decision: "APPROVE", note: "Validé" });
+    expect(forbidden.status).toBe(403);
+
+    mocks.currentRole.value = "Directeur";
+    const cancel = await request(app)
+      .post(`${BASE}/orders/9/cancel`)
+      .set("Idempotency-Key", "sol17-cancel-0001")
+      .send({ reason_code: "CUSTOMER_CANCELLED" });
+    expect(cancel.status).toBe(200);
+    expect(cancel.body.status).toBe("ANNULE");
+  });
+});

--- a/src/__tests__/devis-workflow-167.routes.test.ts
+++ b/src/__tests__/devis-workflow-167.routes.test.ts
@@ -36,6 +36,14 @@ vi.mock("../module/commande-client/repository/commande-client.repository", async
   return { ...actual, repoCreateCommande: commandeEngine.repoCreateCommande };
 });
 
+const commercialReliability = vi.hoisted(() => ({
+  assertDiscountApproved: vi.fn(),
+}));
+vi.mock("../module/commercial-reliability/repository/commercial-reliability.repository", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../module/commercial-reliability/repository/commercial-reliability.repository")>();
+  return { ...actual, assertQuoteDiscountApprovedForSubmission: commercialReliability.assertDiscountApproved };
+});
+
 // RBAC réel testé : le rôle vient de l'en-tête `x-test-role` (défaut : administrateur).
 vi.mock("../module/auth/middlewares/auth.middleware", () => ({
   authenticateToken: (
@@ -157,6 +165,8 @@ beforeEach(() => {
   mocks.clientQuery.mockImplementation(async (sql: unknown, params?: unknown[]) => dispatch(sql, params));
   commandeEngine.repoCreateCommande.mockReset();
   commandeEngine.repoCreateCommande.mockResolvedValue({ id: 55 });
+  commercialReliability.assertDiscountApproved.mockReset();
+  commercialReliability.assertDiscountApproved.mockResolvedValue(undefined);
 });
 
 const plainDraftLine = (over: Record<string, unknown> = {}) => ({
@@ -180,6 +190,7 @@ const draftCurrent = (over: Record<string, unknown> = {}) => ({
   numero: "DEV-2026-0007",
   statut: "BROUILLON",
   remise_globale: 0,
+  has_discount: false,
   updated_at: "2026-07-22T08:00:00+00:00",
   has_children: false,
   ...over,
@@ -270,6 +281,29 @@ describe("#167 — automate de statuts appliqué au write-path", () => {
     const auditCall = mocks.clientQuery.mock.calls.find((c) => /erp_audit_logs/i.test(String(c[0])));
     expect(auditCall).toBeTruthy();
     expect(String((auditCall?.[1] as unknown[])?.[2])).toBe("devis.statut_transition");
+  });
+
+  it("refuse ENVOYE → REFUSE sans motif de perte structuré", async () => {
+    state.updateCurrent = draftCurrent({ statut: "ENVOYE" });
+    const res = await patchDevis({ statut: "REFUSE" });
+    expect(res.status).toBe(409);
+    expect(res.body.code).toBe("STRUCTURED_LOSS_REASON_REQUIRED");
+    expect(mocks.clientQuery.mock.calls.some(([sql]) => /UPDATE devis\s+SET/i.test(String(sql)))).toBe(false);
+  });
+
+  it("soumet un devis remisé uniquement après validation de sa version exacte", async () => {
+    state.updateCurrent = draftCurrent({ has_discount: true, remise_globale: 5 });
+    const accepted = await patchDevis({ statut: "ENVOYE" });
+    expect(accepted.status).toBe(200);
+    expect(commercialReliability.assertDiscountApproved).toHaveBeenCalledWith(expect.anything(), 7);
+
+    commercialReliability.assertDiscountApproved.mockRejectedValueOnce(
+      new HttpError(409, "QUOTE_DISCOUNT_APPROVAL_REQUIRED", "Validation requise"),
+    );
+    state.updateCurrent = draftCurrent({ has_discount: true, remise_globale: 5 });
+    const rejected = await patchDevis({ statut: "ENVOYE" });
+    expect(rejected.status).toBe(409);
+    expect(rejected.body.code).toBe("QUOTE_DISCOUNT_APPROVAL_REQUIRED");
   });
 
   it("ENVOYE → ACCEPTE (statut seul) passe même sur devis engagé", async () => {

--- a/src/__tests__/reporting-360-275.domain.test.ts
+++ b/src/__tests__/reporting-360-275.domain.test.ts
@@ -381,6 +381,12 @@ describe("#275 catalogue de métriques", () => {
     const deferred = listDeferredMetrics();
     expect(deferred.length).toBeGreaterThan(0);
     for (const metric of deferred) {
+      if (metric.id === "deliveries.otif_rate") {
+        expect(metric.formula).toContain("COUNT(commandes");
+        expect(metric.limitations.join(" ")).toContain("différée uniquement");
+        expect(metric.limitations.join(" ")).toContain("/reporting/direction/overview");
+        continue;
+      }
       expect(metric.formula).toBe("Indisponible.");
       expect(metric.limitations.join(" ")).toMatch(/[Bb]loquant/);
     }

--- a/src/module/commande-client/workflow/commande-client-workflow.definition.ts
+++ b/src/module/commande-client/workflow/commande-client-workflow.definition.ts
@@ -16,6 +16,7 @@ export const COMMANDE_WORKFLOW_STATUSES = [
   "FACTURE",
   "ARCHIVE",
   "BLOQUE",
+  "ANNULE",
 ] as const;
 
 export type CommandeWorkflowStatus = (typeof COMMANDE_WORKFLOW_STATUSES)[number];
@@ -38,6 +39,7 @@ export const COMMANDE_WORKFLOW_STATUS_LABELS: Record<CommandeWorkflowStatus, str
   FACTURE: "Facturé",
   ARCHIVE: "Archivé",
   BLOQUE: "Bloqué",
+  ANNULE: "Annulé",
 };
 
 export const COMMANDE_WORKFLOW_STATUS_ORDER: Record<CommandeWorkflowStatus, number> = {
@@ -58,6 +60,7 @@ export const COMMANDE_WORKFLOW_STATUS_ORDER: Record<CommandeWorkflowStatus, numb
   FACTURE: 14,
   ARCHIVE: 15,
   BLOQUE: 99,
+  ANNULE: 100,
 };
 
 export const COMMANDE_WORKFLOW_LEGACY_STATUS_ALIASES: Record<string, CommandeWorkflowStatus> = {
@@ -80,6 +83,7 @@ export const COMMANDE_WORKFLOW_TRANSITION_CAUSES = [
   "invoice_sync",
   "block",
   "resume",
+  "cancel",
 ] as const;
 
 export type CommandeWorkflowTransitionCause = (typeof COMMANDE_WORKFLOW_TRANSITION_CAUSES)[number];
@@ -109,12 +113,18 @@ const CHECKPOINT_TRANSITIONS: CommandeWorkflowTransitionRule[] = [
   { from: "FACTURE", to: "ARCHIVE", cause: "checkpoint" },
 ];
 
+const CANCELLATION_TRANSITIONS: CommandeWorkflowTransitionRule[] = COMMANDE_WORKFLOW_STATUSES
+  .filter((status) => !["LIVRE", "FACTURE", "ARCHIVE", "ANNULE"].includes(status))
+  .map((from) => ({ from, to: "ANNULE", cause: "cancel" }));
+
 export const COMMANDE_WORKFLOW_BLOCKABLE_STATUSES = COMMANDE_WORKFLOW_STATUSES.filter(
-  (status): status is Exclude<CommandeWorkflowStatus, "ARCHIVE" | "BLOQUE"> => status !== "ARCHIVE" && status !== "BLOQUE"
+  (status): status is Exclude<CommandeWorkflowStatus, "ARCHIVE" | "BLOQUE" | "ANNULE"> =>
+    status !== "ARCHIVE" && status !== "BLOQUE" && status !== "ANNULE"
 );
 
 export const COMMANDE_WORKFLOW_TRANSITIONS: readonly CommandeWorkflowTransitionRule[] = [
   ...CHECKPOINT_TRANSITIONS,
+  ...CANCELLATION_TRANSITIONS,
   { from: "ATTENTE_OF", to: "ATTENTE_PLANNING", cause: "customer_order_launch" },
   { from: "ATTENTE_OF", to: "PRET_LIVRAISON", cause: "customer_order_launch" },
   // A legacy invalid planning state can be recovered by reopening the launch
@@ -155,6 +165,9 @@ export function canCommandeWorkflowTransition(
   }
   if (cause === "resume") {
     return from === "BLOQUE" && context.resume_status === to;
+  }
+  if (cause === "cancel") {
+    return to === "ANNULE" && !["LIVRE", "FACTURE", "ARCHIVE", "ANNULE"].includes(from);
   }
   return COMMANDE_WORKFLOW_TRANSITIONS.some(
     (transition) => transition.from === from && transition.to === to && transition.cause === cause

--- a/src/module/commercial-reliability/controllers/commercial-reliability.controller.ts
+++ b/src/module/commercial-reliability/controllers/commercial-reliability.controller.ts
@@ -1,0 +1,181 @@
+import type { Request, RequestHandler } from "express";
+import type { z } from "zod";
+
+import { HttpError } from "../../../utils/httpError";
+import { resolveRequest } from "../../facturation/services/reporting-v2.service";
+import { reportingFiltersSchema } from "../../facturation/validators/reporting-v2.validators";
+import { requireIdempotencyKey } from "../domain/commercial-reliability";
+import {
+  repoCancelOrder,
+  repoCommercialOverview,
+  repoDecideDiscountApproval,
+  repoExpireDueQuotes,
+  repoOrderTimeline,
+  repoRecordQuoteLoss,
+  repoRecordQuoteReminder,
+  repoRequestDiscountApproval,
+  type CommercialActor,
+} from "../repository/commercial-reliability.repository";
+import {
+  cancelOrderBodySchema,
+  commercialEntityIdParamsSchema,
+  commercialOverviewQuerySchema,
+  discountDecisionBodySchema,
+  discountRequestBodySchema,
+  expireDueQuotesBodySchema,
+  quoteLossBodySchema,
+  quoteReminderBodySchema,
+} from "../validators/commercial-reliability.validators";
+
+function actorFrom(req: Request): CommercialActor {
+  if (!req.user) throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  const forwarded = req.headers["x-forwarded-for"];
+  const forwardedIp = typeof forwarded === "string" ? forwarded.split(",")[0]?.trim() : null;
+  return {
+    user_id: req.user.id,
+    role: req.user.role ?? null,
+    ip: forwardedIp ?? req.ip ?? null,
+    user_agent: typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null,
+    path: req.originalUrl ?? null,
+    page_key: typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null,
+    client_session_id: typeof req.headers["x-client-session-id"] === "string"
+      ? req.headers["x-client-session-id"]
+      : null,
+  };
+}
+
+function parse<T extends z.ZodTypeAny>(schema: T, value: unknown): z.infer<T> {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    throw new HttpError(422, "VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Demande invalide.", parsed.error.flatten());
+  }
+  return parsed.data;
+}
+
+function idempotencyKeyFrom(req: Request): string {
+  try {
+    return requireIdempotencyKey(req.headers["idempotency-key"]);
+  } catch {
+    throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "L'en-tête Idempotency-Key (8 à 120 caractères) est obligatoire.");
+  }
+}
+
+export const commercialOverview: RequestHandler = async (req, res, next) => {
+  try {
+    actorFrom(req);
+    const reportingQuery = parse(reportingFiltersSchema, req.query);
+    const resolved = resolveRequest(reportingQuery);
+    res.setHeader("Cache-Control", "no-store, private");
+    res.json(await repoCommercialOverview(parse(commercialOverviewQuerySchema, {
+      from: resolved.ctx.period.from,
+      to: resolved.ctx.period.to,
+      as_of: resolved.ctx.asOf,
+      client_id: resolved.ctx.clientId,
+      currency: resolved.ctx.currency,
+      commercial_id: resolved.ctx.commercialId,
+      limit: resolved.ctx.limit,
+    })));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const commercialOrderTimeline: RequestHandler = async (req, res, next) => {
+  try {
+    actorFrom(req);
+    const { id } = parse(commercialEntityIdParamsSchema, req.params);
+    const result = await repoOrderTimeline(id);
+    if (!result) throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable.");
+    res.setHeader("Cache-Control", "no-store, private");
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const recordQuoteReminder: RequestHandler = async (req, res, next) => {
+  try {
+    const actor = actorFrom(req);
+    const { id } = parse(commercialEntityIdParamsSchema, req.params);
+    res.status(201).json(await repoRecordQuoteReminder({
+      devisId: id,
+      input: parse(quoteReminderBodySchema, req.body),
+      actor,
+      idempotencyKey: idempotencyKeyFrom(req),
+    }));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const recordQuoteLoss: RequestHandler = async (req, res, next) => {
+  try {
+    const actor = actorFrom(req);
+    const { id } = parse(commercialEntityIdParamsSchema, req.params);
+    res.json(await repoRecordQuoteLoss({
+      devisId: id,
+      input: parse(quoteLossBodySchema, req.body),
+      actor,
+      idempotencyKey: idempotencyKeyFrom(req),
+    }));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const requestDiscountApproval: RequestHandler = async (req, res, next) => {
+  try {
+    const actor = actorFrom(req);
+    const { id } = parse(commercialEntityIdParamsSchema, req.params);
+    res.status(201).json(await repoRequestDiscountApproval({
+      devisId: id,
+      input: parse(discountRequestBodySchema, req.body),
+      actor,
+      idempotencyKey: idempotencyKeyFrom(req),
+    }));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const decideDiscountApproval: RequestHandler = async (req, res, next) => {
+  try {
+    const actor = actorFrom(req);
+    const { id } = parse(commercialEntityIdParamsSchema, req.params);
+    res.json(await repoDecideDiscountApproval({
+      devisId: id,
+      input: parse(discountDecisionBodySchema, req.body),
+      actor,
+      idempotencyKey: idempotencyKeyFrom(req),
+    }));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const expireDueQuotes: RequestHandler = async (req, res, next) => {
+  try {
+    res.json(await repoExpireDueQuotes({
+      input: parse(expireDueQuotesBodySchema, req.body),
+      actor: actorFrom(req),
+      idempotencyKey: idempotencyKeyFrom(req),
+    }));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const cancelOrder: RequestHandler = async (req, res, next) => {
+  try {
+    const actor = actorFrom(req);
+    const { id } = parse(commercialEntityIdParamsSchema, req.params);
+    res.json(await repoCancelOrder({
+      commandeId: id,
+      input: parse(cancelOrderBodySchema, req.body),
+      actor,
+      idempotencyKey: idempotencyKeyFrom(req),
+    }));
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/module/commercial-reliability/domain/commercial-reliability.test.ts
+++ b/src/module/commercial-reliability/domain/commercial-reliability.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  commercialPayloadHash,
+  conversionRate,
+  effectiveDiscountPct,
+  orderAgingBucket,
+  qualifyCommercialRisk,
+} from "./commercial-reliability";
+
+describe("SOL-17 commercial reliability rules", () => {
+  it("qualifies risk from source facts without an invented score", () => {
+    expect(qualifyCommercialRisk({
+      clientBlocked: true,
+      overdueReceivablesTtc: 0,
+      overdueBacklogHt: 0,
+      blockedOrders: 0,
+      expiredOpenQuotes: 0,
+    })).toMatchObject({ level: "CRITICAL", reliability: "ACTUAL", factors: ["CLIENT_BLOCKED"] });
+
+    expect(qualifyCommercialRisk({
+      clientBlocked: false,
+      overdueReceivablesTtc: 0,
+      overdueBacklogHt: 120,
+      blockedOrders: 0,
+      expiredOpenQuotes: 0,
+      missingFinancialPermission: true,
+    })).toMatchObject({ level: "MEDIUM", reliability: "PARTIAL" });
+  });
+
+  it("keeps undated promises separate from zero lateness", () => {
+    expect(orderAgingBucket(null, "2026-08-12")).toBe("UNDATED");
+    expect(orderAgingBucket("2026-08-12", "2026-08-12")).toBe("NOT_DUE");
+    expect(orderAgingBucket("2026-07-13", "2026-08-12")).toBe("1_30");
+    expect(orderAgingBucket("2026-05-01", "2026-08-12")).toBe("90_PLUS");
+  });
+
+  it("uses stable request hashes and honest null denominators", () => {
+    expect(commercialPayloadHash({ b: 2, a: 1 })).toBe(commercialPayloadHash({ a: 1, b: 2 }));
+    expect(conversionRate(0, 0)).toBeNull();
+    expect(conversionRate(1, 4)).toBe(25);
+    expect(effectiveDiscountPct({ grossAmountHt: 100, netAmountHt: 90 })).toBe(10);
+    expect(effectiveDiscountPct({ grossAmountHt: 0, netAmountHt: 10 })).toBeNull();
+  });
+});

--- a/src/module/commercial-reliability/domain/commercial-reliability.ts
+++ b/src/module/commercial-reliability/domain/commercial-reliability.ts
@@ -1,0 +1,121 @@
+import crypto from "node:crypto";
+
+export const COMMERCIAL_CONTRACT_VERSION = "CERP-COMMERCIAL-1.0.0";
+export const COMMERCIAL_TIMEZONE = "Europe/Paris";
+
+export const LOSS_REASON_CODES = [
+  "PRICE",
+  "LEAD_TIME",
+  "TECHNICAL_FIT",
+  "COMPETITOR",
+  "BUDGET",
+  "NO_DECISION",
+  "DUPLICATE",
+  "CUSTOMER_CANCELLED",
+  "OTHER",
+] as const;
+
+export const ORDER_CANCELLATION_REASON_CODES = [
+  "CUSTOMER_CANCELLED",
+  "DUPLICATE",
+  "COMMERCIAL_ERROR",
+  "TECHNICAL_IMPOSSIBILITY",
+  "OTHER",
+] as const;
+
+export const REMINDER_CHANNELS = ["EMAIL", "PHONE", "MEETING", "OTHER"] as const;
+
+export type CommercialReliability = "ESTIMATED" | "PARTIAL" | "ACTUAL";
+export type CommercialRiskLevel = "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
+
+export type CommercialRiskInput = {
+  clientBlocked: boolean;
+  overdueReceivablesTtc: number;
+  overdueBacklogHt: number;
+  blockedOrders: number;
+  expiredOpenQuotes: number;
+  missingFinancialPermission?: boolean;
+};
+
+export type CommercialRisk = {
+  level: CommercialRiskLevel;
+  factors: string[];
+  reliability: CommercialReliability;
+};
+
+/**
+ * Risk is deliberately categorical: no unsupported probability is fabricated.
+ * Each escalation is backed by an observable source fact.
+ */
+export function qualifyCommercialRisk(input: CommercialRiskInput): CommercialRisk {
+  const factors: string[] = [];
+  if (input.clientBlocked) factors.push("CLIENT_BLOCKED");
+  if (input.overdueReceivablesTtc > 0) factors.push("OVERDUE_RECEIVABLES");
+  if (input.blockedOrders > 0) factors.push("BLOCKED_ORDERS");
+  if (input.overdueBacklogHt > 0) factors.push("OVERDUE_BACKLOG");
+  if (input.expiredOpenQuotes > 0) factors.push("EXPIRED_OPEN_QUOTES");
+  if (input.missingFinancialPermission) factors.push("FINANCIAL_SCOPE_HIDDEN");
+
+  let level: CommercialRiskLevel = "LOW";
+  if (input.clientBlocked) level = "CRITICAL";
+  else if (input.overdueReceivablesTtc > 0 || input.blockedOrders > 0) level = "HIGH";
+  else if (input.overdueBacklogHt > 0 || input.expiredOpenQuotes > 0) level = "MEDIUM";
+
+  return {
+    level,
+    factors,
+    reliability: input.missingFinancialPermission ? "PARTIAL" : "ACTUAL",
+  };
+}
+
+export type AgingBucket = "NOT_DUE" | "1_30" | "31_60" | "61_90" | "90_PLUS" | "UNDATED";
+
+export function orderAgingBucket(dueDate: string | null, asOf: string): AgingBucket {
+  if (dueDate === null) return "UNDATED";
+  const due = Date.parse(`${dueDate}T00:00:00Z`);
+  const cut = Date.parse(`${asOf}T00:00:00Z`);
+  if (!Number.isFinite(due) || !Number.isFinite(cut)) return "UNDATED";
+  const days = Math.floor((cut - due) / 86_400_000);
+  if (days <= 0) return "NOT_DUE";
+  if (days <= 30) return "1_30";
+  if (days <= 60) return "31_60";
+  if (days <= 90) return "61_90";
+  return "90_PLUS";
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  return `{${Object.entries(value as Record<string, unknown>)
+    .filter(([, child]) => child !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, child]) => `${JSON.stringify(key)}:${stableStringify(child)}`)
+    .join(",")}}`;
+}
+
+export function commercialPayloadHash(value: unknown): string {
+  return crypto.createHash("sha256").update(stableStringify(value), "utf8").digest("hex");
+}
+
+export function requireIdempotencyKey(value: unknown): string {
+  if (typeof value !== "string" || value.trim().length < 8) {
+    throw new Error("IDEMPOTENCY_KEY_REQUIRED");
+  }
+  return value.trim().slice(0, 120);
+}
+
+export function effectiveDiscountPct(input: {
+  grossAmountHt: number;
+  netAmountHt: number;
+}): number | null {
+  if (!Number.isFinite(input.grossAmountHt) || !Number.isFinite(input.netAmountHt) || input.grossAmountHt < 0) {
+    return null;
+  }
+  if (input.grossAmountHt === 0) return input.netAmountHt === 0 ? 0 : null;
+  return Math.round(((input.grossAmountHt - input.netAmountHt) / input.grossAmountHt) * 1_000_000) / 10_000;
+}
+
+export function conversionRate(won: number, decided: number): number | null {
+  if (!Number.isFinite(won) || !Number.isFinite(decided) || won < 0 || decided <= 0) return null;
+  return Math.round((won / decided) * 1_000_000) / 10_000;
+}

--- a/src/module/commercial-reliability/repository/commercial-reliability.repository.test.ts
+++ b/src/module/commercial-reliability/repository/commercial-reliability.repository.test.ts
@@ -1,0 +1,136 @@
+import type { PoolClient } from "pg";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  connect: vi.fn(),
+  audit: vi.fn(),
+}));
+
+vi.mock("../../../config/database", () => ({
+  default: { connect: mocks.connect, query: vi.fn() },
+}));
+
+vi.mock("../../audit-logs/repository/audit-logs.repository", () => ({
+  repoInsertAuditLog: mocks.audit,
+}));
+
+import { repoCancelOrder } from "./commercial-reliability.repository";
+import { commercialPayloadHash } from "../domain/commercial-reliability";
+
+const actor = {
+  user_id: 17,
+  role: "Directeur",
+  ip: "127.0.0.1",
+  user_agent: "vitest",
+  path: "/reporting/commercial/reliability/orders/9/cancel",
+  page_key: "commercial-reliability",
+  client_session_id: "sol17-session",
+};
+
+function createClient(options: {
+  currentStatus?: string;
+  downstreamBlocked?: boolean;
+  receipt?: { request_hash: string; response_snapshot: Record<string, unknown> } | null;
+} = {}) {
+  const state = {
+    currentStatus: options.currentStatus ?? "EN_ANALYSE",
+    downstreamBlocked: options.downstreamBlocked ?? false,
+    receipt: options.receipt ?? null,
+  };
+  const query = vi.fn(async (sql: unknown) => {
+    const statement = String(sql);
+    if (statement.includes("FROM public.commercial_command_receipts")) {
+      return { rows: state.receipt ? [state.receipt] : [] };
+    }
+    if (statement.includes("FROM public.commande_client WHERE")) {
+      return { rows: [{ id: "9", numero: "CMD-0009" }] };
+    }
+    if (statement.includes("FROM public.commande_historique")) {
+      return { rows: [{ nouveau_statut: state.currentStatus }] };
+    }
+    if (statement.includes("FROM public.bon_livraison") && statement.includes("AS blocked")) {
+      return { rows: [{ blocked: state.downstreamBlocked }] };
+    }
+    return { rows: [], rowCount: 1 };
+  });
+  const client = { query, release: vi.fn() } as unknown as PoolClient;
+  return { client, query, state };
+}
+
+function cancel(idempotencyKey = "sol17-order-cancel-0001") {
+  return repoCancelOrder({
+    commandeId: 9,
+    input: { reason_code: "CUSTOMER_CANCELLED", note: "Confirmation client" },
+    actor,
+    idempotencyKey,
+  });
+}
+
+describe("SOL-17 order cancellation transaction", () => {
+  beforeEach(() => {
+    mocks.connect.mockReset();
+    mocks.audit.mockReset();
+    mocks.audit.mockResolvedValue({ id: "audit-sol17" });
+  });
+
+  it("records one cancellation, workflow event, audit and receipt in the same transaction", async () => {
+    const { client, query } = createClient();
+    mocks.connect.mockResolvedValue(client);
+
+    await expect(cancel()).resolves.toEqual({ commande_id: 9, status: "ANNULE", idempotent_replay: false });
+
+    expect(query.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.commercial_order_cancellations"))).toHaveLength(1);
+    expect(query.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.commande_historique"))).toHaveLength(1);
+    expect(query.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.commande_client_event_log"))).toHaveLength(1);
+    expect(query.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.commercial_command_receipts"))).toHaveLength(1);
+    expect(mocks.audit).toHaveBeenCalledOnce();
+    expect(query).toHaveBeenCalledWith("COMMIT");
+  });
+
+  it("replays the saved response without duplicating cancellation, event or audit", async () => {
+    const { client, query, state } = createClient();
+    mocks.connect.mockResolvedValue(client);
+
+    const first = await cancel("sol17-order-cancel-replay");
+    state.receipt = {
+      request_hash: commercialPayloadHash({
+        commande_id: 9,
+        reason_code: "CUSTOMER_CANCELLED",
+        note: "Confirmation client",
+      }),
+      response_snapshot: first,
+    };
+
+    await expect(cancel("sol17-order-cancel-replay")).resolves.toMatchObject({
+      commande_id: 9,
+      status: "ANNULE",
+      idempotent_replay: true,
+    });
+    expect(query.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.commercial_order_cancellations"))).toHaveLength(1);
+    expect(mocks.audit).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ["une commande partiellement livrée", "SHIPPED"],
+    ["une commande déjà facturée", "INVOICED"],
+  ])("refuses %s when downstream evidence exists (%s)", async () => {
+    const { client, query } = createClient({ downstreamBlocked: true });
+    mocks.connect.mockResolvedValue(client);
+
+    await expect(cancel()).rejects.toMatchObject({
+      status: 409,
+      code: "ORDER_CANCELLATION_HAS_DOWNSTREAM_EVIDENCE",
+    });
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("commercial_order_cancellations"))).toBe(false);
+    expect(mocks.audit).not.toHaveBeenCalled();
+    expect(query).toHaveBeenCalledWith("ROLLBACK");
+  });
+
+  it.each(["LIVRE", "FACTURE", "ARCHIVE", "ANNULE"])("refuses terminal status %s", async (currentStatus) => {
+    const { client, query } = createClient({ currentStatus });
+    mocks.connect.mockResolvedValue(client);
+
+    await expect(cancel()).rejects.toMatchObject({ status: 409, code: "ORDER_CANCELLATION_TOO_LATE" });
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("commercial_order_cancellations"))).toBe(false);
+  });
+});

--- a/src/module/commercial-reliability/repository/commercial-reliability.repository.ts
+++ b/src/module/commercial-reliability/repository/commercial-reliability.repository.ts
@@ -1,0 +1,1152 @@
+import crypto from "node:crypto";
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
+import {
+  repoClients,
+  repoOrders,
+  repoQuotes,
+  repoReceivables,
+  type ReportingContext,
+} from "../../facturation/repository/reporting-v2.repository";
+import { normalizeCommandeWorkflowStatus } from "../../commande-client/workflow/commande-client-workflow.definition";
+import {
+  COMMERCIAL_CONTRACT_VERSION,
+  COMMERCIAL_TIMEZONE,
+  commercialPayloadHash,
+  conversionRate,
+  effectiveDiscountPct,
+  qualifyCommercialRisk,
+} from "../domain/commercial-reliability";
+import type {
+  CancelOrderBodyDTO,
+  CommercialOverviewQueryDTO,
+  DiscountDecisionBodyDTO,
+  DiscountRequestBodyDTO,
+  ExpireDueQuotesBodyDTO,
+  QuoteLossBodyDTO,
+  QuoteReminderBodyDTO,
+} from "../validators/commercial-reliability.validators";
+
+type Queryer = Pick<PoolClient, "query">;
+
+export type CommercialActor = {
+  user_id: number;
+  role: string | null;
+  ip: string | null;
+  user_agent: string | null;
+  path: string | null;
+  page_key: string | null;
+  client_session_id: string | null;
+};
+
+type CommandAction =
+  | "QUOTE_REMINDER"
+  | "QUOTE_LOSS"
+  | "DISCOUNT_REQUEST"
+  | "DISCOUNT_DECISION"
+  | "EXPIRE_DUE_QUOTES"
+  | "ORDER_CANCEL";
+
+function toNumber(value: unknown): number {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+async function insertAudit(
+  tx: Queryer,
+  actor: CommercialActor,
+  entry: { action: string; entity_type: string; entity_id: string; details: Record<string, unknown> },
+) {
+  const body: CreateAuditLogBodyDTO = {
+    event_type: "ACTION",
+    action: entry.action,
+    page_key: actor.page_key,
+    entity_type: entry.entity_type,
+    entity_id: entry.entity_id,
+    path: actor.path,
+    client_session_id: actor.client_session_id,
+    details: entry.details,
+  };
+  await repoInsertAuditLog({
+    user_id: actor.user_id,
+    body,
+    ip: actor.ip,
+    user_agent: actor.user_agent,
+    device_type: null,
+    os: null,
+    browser: null,
+    tx,
+  });
+}
+
+async function readReceipt<T>(
+  tx: Queryer,
+  action: CommandAction,
+  idempotencyKey: string,
+  requestHash: string,
+): Promise<T | null> {
+  const result = await tx.query<{ request_hash: string; response_snapshot: T }>(
+    `SELECT request_hash, response_snapshot
+     FROM public.commercial_command_receipts
+     WHERE action=$1 AND idempotency_key=$2
+     FOR SHARE`,
+    [action, idempotencyKey],
+  );
+  const row = result.rows[0];
+  if (!row) return null;
+  if (row.request_hash !== requestHash) {
+    throw new HttpError(
+      409,
+      "IDEMPOTENCY_PAYLOAD_MISMATCH",
+      "Cette clé d'idempotence a déjà été utilisée avec une demande différente.",
+    );
+  }
+  return { ...row.response_snapshot, idempotent_replay: true } as T;
+}
+
+async function saveReceipt(
+  tx: Queryer,
+  action: CommandAction,
+  idempotencyKey: string,
+  requestHash: string,
+  actorUserId: number,
+  response: Record<string, unknown>,
+) {
+  await tx.query(
+    `INSERT INTO public.commercial_command_receipts
+       (action,idempotency_key,request_hash,actor_user_id,response_snapshot)
+     VALUES ($1,$2,$3,$4,$5::jsonb)`,
+    [action, idempotencyKey, requestHash, actorUserId, JSON.stringify(response)],
+  );
+}
+
+type QuoteSnapshot = {
+  id: number;
+  numero: string;
+  statut: string;
+  owner_user_id: number | null;
+  date_validite: string | null;
+  total_ht: number;
+  gross_ht: number;
+  content_hash: string;
+  discount_pct: number | null;
+};
+
+async function loadQuoteSnapshot(tx: Queryer, devisId: number, lock = false): Promise<QuoteSnapshot | null> {
+  const header = await tx.query<{
+    id: string;
+    numero: string;
+    statut: string;
+    owner_user_id: number | null;
+    date_validite: string | null;
+    total_ht: number;
+    remise_globale: number;
+  }>(
+    `SELECT d.id::text AS id,d.numero,d.statut,d.user_id AS owner_user_id,
+            d.date_validite::text,d.total_ht::float8 AS total_ht,d.remise_globale::float8 AS remise_globale
+     FROM public.devis d WHERE d.id=$1 ${lock ? "FOR UPDATE" : ""}`,
+    [devisId],
+  );
+  const row = header.rows[0];
+  if (!row) return null;
+  const lines = await tx.query<{
+    id: string;
+    quantite: number;
+    prix_unitaire_ht: number;
+    remise_ligne: number | null;
+    taux_tva: number | null;
+  }>(
+    `SELECT id::text,quantite::float8,prix_unitaire_ht::float8,
+            remise_ligne::float8,taux_tva::float8
+     FROM public.devis_ligne WHERE devis_id=$1 ORDER BY id`,
+    [devisId],
+  );
+  const grossHt = lines.rows.reduce((sum, line) => sum + line.quantite * line.prix_unitaire_ht, 0);
+  const contentHash = commercialPayloadHash({
+    devis_id: devisId,
+    remise_globale: row.remise_globale,
+    lignes: lines.rows,
+  });
+  return {
+    id: Number(row.id),
+    numero: row.numero,
+    statut: row.statut,
+    owner_user_id: row.owner_user_id,
+    date_validite: row.date_validite,
+    total_ht: row.total_ht,
+    gross_ht: grossHt,
+    content_hash: contentHash,
+    discount_pct: effectiveDiscountPct({ grossAmountHt: grossHt, netAmountHt: row.total_ht }),
+  };
+}
+
+/** Called by the canonical devis transition before BROUILLON -> ENVOYE. */
+export async function assertQuoteDiscountApprovedForSubmission(tx: Queryer, devisId: number): Promise<void> {
+  const quote = await loadQuoteSnapshot(tx, devisId, false);
+  if (!quote) throw new HttpError(404, "DEVIS_NOT_FOUND", "Devis introuvable.");
+  if (quote.discount_pct === null) {
+    throw new HttpError(409, "QUOTE_DISCOUNT_UNQUALIFIED", "La remise effective ne peut pas être calculée.");
+  }
+  if (quote.discount_pct <= 0) return;
+  const approval = await tx.query<{ approved: boolean }>(
+    `SELECT EXISTS (
+       SELECT 1 FROM public.commercial_quote_events e
+       WHERE e.devis_id=$1 AND e.event_type='DISCOUNT_APPROVED'
+         AND e.quote_content_hash=$2
+     ) AS approved`,
+    [devisId, quote.content_hash],
+  );
+  if (approval.rows[0]?.approved !== true) {
+    throw new HttpError(
+      409,
+      "QUOTE_DISCOUNT_APPROVAL_REQUIRED",
+      "Ce devis contient une remise. Faites valider cette version avant l'envoi.",
+      { devis_id: devisId, discount_pct: quote.discount_pct, quote_content_hash: quote.content_hash },
+    );
+  }
+}
+
+function reportingContext(query: CommercialOverviewQueryDTO): ReportingContext {
+  return {
+    period: { from: query.from, to: query.to },
+    asOf: query.as_of ?? query.to,
+    basis: "document_date",
+    granularity: "month",
+    clientId: query.client_id,
+    currency: query.currency,
+    commercialId: query.commercial_id,
+    limit: query.limit,
+  };
+}
+
+async function repoCommercialDetails(query: CommercialOverviewQueryDTO) {
+  const values: unknown[] = [query.from, query.to, query.as_of ?? query.to];
+  const clientFilter = query.client_id ? `AND d.client_id=$${values.push(query.client_id)}` : "";
+  const currencyFilter = query.currency
+    ? `AND EXISTS (
+         SELECT 1 FROM public.clients currency_client
+         WHERE currency_client.client_id=d.client_id
+           AND UPPER(COALESCE(NULLIF(BTRIM(currency_client.devise),''),'EUR'))=$${values.push(query.currency)}
+       )`
+    : "";
+  const commercialFilter = query.commercial_id ? `AND d.user_id=$${values.push(query.commercial_id)}` : "";
+  const result = await pool.query<{
+    cohorts: unknown;
+    loss_reasons: unknown;
+    response_days_avg: number | null;
+    event_coverage_count: number;
+    eligible_count: number;
+    margin_complete_count: number;
+    margin_partial_count: number;
+    margin_gross_ht: string | null;
+    converted_count: number;
+  }>(
+    `WITH latest_order_status AS (
+       SELECT DISTINCT ON (ch.commande_id) ch.commande_id,ch.nouveau_statut
+       FROM public.commande_historique ch
+       ORDER BY ch.commande_id,ch.date_action DESC,ch.id DESC
+     ), scoped AS (
+       SELECT d.*,
+         (SELECT MIN(e.occurred_at) FROM public.commercial_quote_events e
+          WHERE e.devis_id=d.id AND e.event_type='SENT') AS sent_at,
+         (SELECT MIN(e.occurred_at) FROM public.commercial_quote_events e
+          WHERE e.devis_id=d.id AND e.event_type IN ('ACCEPTED','LOST')) AS decided_at,
+         EXISTS (
+           SELECT 1
+           FROM public.commande_client cc
+           LEFT JOIN latest_order_status los ON los.commande_id=cc.id
+           WHERE (cc.devis_id=d.id OR cc.source_devis_version_id=d.id)
+             AND COALESCE(los.nouveau_statut,'BROUILLON') <> 'ANNULE'
+         ) AS converted
+       FROM public.devis d
+       WHERE d.date_creation BETWEEN $1::date AND $2::date
+         AND d.statut NOT IN ('BROUILLON','ANNULE') ${clientFilter} ${currencyFilter} ${commercialFilter}
+         AND NOT EXISTS (
+           SELECT 1 FROM public.devis newer_quote
+           WHERE COALESCE(newer_quote.root_devis_id,newer_quote.id)=COALESCE(d.root_devis_id,d.id)
+             AND (newer_quote.version_number>d.version_number
+               OR (newer_quote.version_number=d.version_number AND newer_quote.id>d.id))
+         )
+     ), latest_margin AS (
+       SELECT DISTINCT ON (m.scope_ref) m.scope_ref,m.result_snapshot
+       FROM public.margin_recalculations m
+       JOIN scoped s ON s.id::text=m.scope_ref
+       WHERE m.scope_type='DEVIS' AND m.basis='QUOTED' AND m.as_of <= $3::date
+       ORDER BY m.scope_ref,m.created_at DESC,m.id DESC
+     ), cohorts AS (
+       SELECT date_trunc('month',COALESCE(sent_at,date_creation::timestamptz))::date::text AS cohort,
+               COUNT(*)::int AS issued,
+               COUNT(*) FILTER (WHERE statut IN ('ACCEPTE','REFUSE'))::int AS decided,
+               COUNT(*) FILTER (WHERE statut='ACCEPTE')::int AS won,
+               COUNT(*) FILTER (WHERE converted)::int AS converted
+       FROM scoped GROUP BY 1 ORDER BY 1
+     ), losses AS (
+       SELECT e.reason_code,COUNT(*)::int AS count
+       FROM public.commercial_quote_events e JOIN scoped s ON s.id=e.devis_id
+       WHERE e.event_type='LOST' GROUP BY e.reason_code ORDER BY count DESC,e.reason_code
+     )
+     SELECT
+       COALESCE((SELECT json_agg(json_build_object(
+         'cohort',cohort,'issued',issued,'decided',decided,'won',won,'converted',converted,
+         'conversion_rate_pct',CASE WHEN issued=0 THEN NULL ELSE round(converted::numeric/issued*100,4) END
+       )) FROM cohorts),'[]'::json) AS cohorts,
+       COALESCE((SELECT json_agg(losses) FROM losses),'[]'::json) AS loss_reasons,
+       (SELECT AVG(EXTRACT(EPOCH FROM (decided_at-sent_at))/86400)::float8
+        FROM scoped WHERE sent_at IS NOT NULL AND decided_at IS NOT NULL AND decided_at>=sent_at) AS response_days_avg,
+       (SELECT COUNT(*) FROM scoped WHERE sent_at IS NOT NULL)::int AS event_coverage_count,
+        (SELECT COUNT(*) FROM scoped)::int AS eligible_count,
+        (SELECT COUNT(*) FROM scoped WHERE converted)::int AS converted_count,
+       (SELECT COUNT(*) FROM latest_margin WHERE result_snapshot->>'availability'='COMPLETE')::int AS margin_complete_count,
+       ((SELECT COUNT(*) FROM scoped)-
+        (SELECT COUNT(*) FROM latest_margin
+         WHERE result_snapshot->>'availability'='COMPLETE'
+           AND result_snapshot->>'gross_margin_ht' IS NOT NULL))::int AS margin_partial_count,
+       (SELECT CASE
+          WHEN (SELECT COUNT(*) FROM scoped)=0 THEN NULL
+          WHEN (SELECT COUNT(*) FROM latest_margin WHERE result_snapshot->>'availability'='COMPLETE')=(SELECT COUNT(*) FROM scoped)
+          THEN SUM((result_snapshot->>'gross_margin_ht')::numeric)::numeric(18,2)::text
+          ELSE NULL END FROM latest_margin) AS margin_gross_ht`,
+    values,
+  );
+  return result.rows[0];
+}
+
+async function repoCommercialCurrencies(query: CommercialOverviewQueryDTO): Promise<string[]> {
+  if (query.currency) return [query.currency];
+  const result = await pool.query<{ currency: string }>(
+    `WITH currencies AS (
+       SELECT UPPER(COALESCE(NULLIF(BTRIM(c.devise),''),'EUR')) AS currency
+       FROM public.devis d JOIN public.clients c ON c.client_id=d.client_id
+       WHERE d.date_creation BETWEEN $1::date AND $2::date
+          AND d.statut NOT IN ('BROUILLON','ANNULE')
+          AND NOT EXISTS (
+            SELECT 1 FROM public.devis newer_quote
+            WHERE COALESCE(newer_quote.root_devis_id,newer_quote.id)=COALESCE(d.root_devis_id,d.id)
+              AND (newer_quote.version_number>d.version_number
+                OR (newer_quote.version_number=d.version_number AND newer_quote.id>d.id))
+          )
+         AND ($3::text IS NULL OR d.client_id=$3)
+         AND ($4::integer IS NULL OR d.user_id=$4)
+       UNION
+       SELECT UPPER(COALESCE(NULLIF(BTRIM(c.devise),''),'EUR'))
+       FROM public.commande_client cc JOIN public.clients c ON c.client_id=cc.client_id
+       WHERE cc.date_commande BETWEEN $1::date AND $2::date
+         AND ($3::text IS NULL OR cc.client_id=$3)
+       UNION
+       SELECT UPPER(COALESCE(NULLIF(BTRIM(f.currency),''),'EUR'))
+       FROM public.facture f
+       WHERE f.date_emission BETWEEN $1::date AND $2::date
+         AND f.statut NOT IN ('DRAFT','CANCELLED','brouillon','annule','annulee')
+         AND ($3::text IS NULL OR f.client_id=$3)
+       UNION
+       SELECT UPPER(COALESCE(NULLIF(BTRIM(a.currency),''),'EUR'))
+       FROM public.avoir a
+       WHERE a.date_emission BETWEEN $1::date AND $2::date
+         AND a.statut NOT IN ('DRAFT','CANCELLED','brouillon','annule','annulee')
+         AND ($3::text IS NULL OR a.client_id=$3)
+     )
+     SELECT currency FROM currencies WHERE currency IS NOT NULL ORDER BY currency`,
+    [query.from, query.to, query.client_id ?? null, query.commercial_id ?? null],
+  );
+  return result.rows.map((row) => row.currency);
+}
+
+async function repoCommercialActivityClients(query: CommercialOverviewQueryDTO) {
+  const limit = query.limit + 1;
+  const result = await pool.query<{ client_id: string; company_name: string | null }>(
+    `WITH latest_order_status AS (
+       SELECT DISTINCT ON (ch.commande_id) ch.commande_id,ch.nouveau_statut
+       FROM public.commande_historique ch
+       ORDER BY ch.commande_id,ch.date_action DESC,ch.id DESC
+     ), activity AS (
+       SELECT d.client_id
+       FROM public.devis d
+       WHERE d.date_creation BETWEEN $1::date AND $2::date
+         AND d.statut NOT IN ('BROUILLON','ANNULE')
+         AND NOT EXISTS (
+           SELECT 1 FROM public.devis newer_quote
+           WHERE COALESCE(newer_quote.root_devis_id,newer_quote.id)=COALESCE(d.root_devis_id,d.id)
+             AND (newer_quote.version_number>d.version_number
+               OR (newer_quote.version_number=d.version_number AND newer_quote.id>d.id))
+         )
+         AND ($3::integer IS NULL OR d.user_id=$3)
+       UNION
+       SELECT cc.client_id
+       FROM public.commande_client cc
+       LEFT JOIN latest_order_status los ON los.commande_id=cc.id
+       WHERE cc.date_commande BETWEEN $1::date AND $2::date
+         AND COALESCE(cc.order_type,'FERME') <> 'INTERNE'
+         AND COALESCE(los.nouveau_statut,'BROUILLON') <> 'ANNULE'
+         AND ($3::integer IS NULL OR cc.created_by=$3)
+       UNION
+       SELECT $4::text WHERE $4::text IS NOT NULL AND $3::integer IS NULL
+     )
+     SELECT c.client_id,c.company_name
+     FROM activity a
+     JOIN public.clients c ON c.client_id=a.client_id
+     WHERE ($4::text IS NULL OR c.client_id=$4)
+       AND ($5::text IS NULL OR UPPER(COALESCE(NULLIF(BTRIM(c.devise),''),'EUR'))=$5)
+     ORDER BY c.company_name NULLS LAST,c.client_id
+     LIMIT $6`,
+    [query.from, query.to, query.commercial_id ?? null, query.client_id ?? null, query.currency ?? null, limit],
+  );
+  return {
+    items: result.rows.slice(0, query.limit),
+    truncated: result.rows.length > query.limit,
+  };
+}
+
+type ClientQualification = {
+  client_id: string;
+  client_blocked: boolean;
+  quote_count: number;
+  decided_count: number;
+  won_count: number;
+  converted_count: number;
+  expired_open_quotes: number;
+  margin_complete_count: number;
+  qualified_margin_ht: string | null;
+  blocked_orders: number;
+  overdue_backlog_ht: string;
+};
+
+async function repoClientQualifications(query: CommercialOverviewQueryDTO, clientIds: string[]) {
+  if (clientIds.length === 0) return new Map<string, ClientQualification>();
+  const result = await pool.query<ClientQualification>(
+    `WITH latest_status AS (
+       SELECT DISTINCT ON (ch.commande_id) ch.commande_id,ch.nouveau_statut
+       FROM public.commande_historique ch
+       ORDER BY ch.commande_id,ch.date_action DESC,ch.id DESC
+     ), shipped AS (
+       SELECT bll.commande_ligne_id,SUM(bll.quantite)::numeric AS qty
+       FROM public.bon_livraison_ligne bll
+       JOIN public.bon_livraison bl ON bl.id=bll.bon_livraison_id
+       WHERE bl.statut IN ('SHIPPED','DELIVERED')
+         AND COALESCE(bl.date_expedition,bl.date_livraison,bl.date_creation) <= $4::date
+       GROUP BY bll.commande_ligne_id
+     ), open_lines AS (
+       SELECT cc.client_id,cc.id AS commande_id,COALESCE(ls.nouveau_statut,'BROUILLON') AS workflow_status,
+              cl.delai_client,
+              GREATEST(cl.quantite-COALESCE(shipped.qty,0),0)::numeric AS remaining_qty,
+              (GREATEST(cl.quantite-COALESCE(shipped.qty,0),0)*cl.prix_unitaire_ht*(1-COALESCE(cl.remise_ligne,0)/100))::numeric(18,2) AS remaining_ht
+       FROM public.commande_ligne cl
+       JOIN public.commande_client cc ON cc.id=cl.commande_id
+       JOIN public.clients c ON c.client_id=cc.client_id
+       LEFT JOIN shipped ON shipped.commande_ligne_id=cl.id
+       LEFT JOIN latest_status ls ON ls.commande_id=cc.id
+       WHERE cc.client_id=ANY($1::text[])
+         AND COALESCE(cc.order_type,'FERME') <> 'INTERNE'
+         AND COALESCE(ls.nouveau_statut,'BROUILLON') <> 'ANNULE'
+         AND ($5::text IS NULL OR UPPER(COALESCE(NULLIF(BTRIM(c.devise),''),'EUR'))=$5)
+     ), order_facts AS (
+       SELECT client_id,
+              COUNT(DISTINCT commande_id) FILTER (WHERE workflow_status='BLOQUE')::int AS blocked_orders,
+              COALESCE(SUM(remaining_ht) FILTER (
+                WHERE remaining_qty>0 AND delai_client IS NOT NULL AND delai_client<$4::date
+              ),0)::numeric(18,2)::text AS overdue_backlog_ht
+       FROM open_lines GROUP BY client_id
+     ), scoped_quotes AS (
+        SELECT d.id,d.client_id,d.statut,d.date_validite,
+               EXISTS (
+                 SELECT 1
+                 FROM public.commande_client cc
+                 LEFT JOIN latest_status conversion_status ON conversion_status.commande_id=cc.id
+                 WHERE (cc.devis_id=d.id OR cc.source_devis_version_id=d.id)
+                   AND COALESCE(conversion_status.nouveau_statut,'BROUILLON') <> 'ANNULE'
+               ) AS converted
+       FROM public.devis d
+       JOIN public.clients c ON c.client_id=d.client_id
+       WHERE d.client_id=ANY($1::text[])
+         AND d.date_creation BETWEEN $2::date AND $3::date
+         AND d.statut NOT IN ('BROUILLON','ANNULE')
+         AND NOT EXISTS (
+           SELECT 1 FROM public.devis newer_quote
+           WHERE COALESCE(newer_quote.root_devis_id,newer_quote.id)=COALESCE(d.root_devis_id,d.id)
+             AND (newer_quote.version_number>d.version_number
+               OR (newer_quote.version_number=d.version_number AND newer_quote.id>d.id))
+         )
+         AND ($5::text IS NULL OR UPPER(COALESCE(NULLIF(BTRIM(c.devise),''),'EUR'))=$5)
+         AND ($6::integer IS NULL OR d.user_id=$6)
+     ), latest_margin AS (
+       SELECT DISTINCT ON (m.scope_ref) m.scope_ref,m.result_snapshot
+       FROM public.margin_recalculations m
+       JOIN scoped_quotes q ON q.id::text=m.scope_ref
+       WHERE m.scope_type='DEVIS' AND m.basis='QUOTED' AND m.as_of <= $4::date
+       ORDER BY m.scope_ref,m.created_at DESC,m.id DESC
+     ), quote_facts AS (
+       SELECT q.client_id,
+              COUNT(*)::int AS quote_count,
+               COUNT(*) FILTER (WHERE q.statut IN ('ACCEPTE','REFUSE'))::int AS decided_count,
+               COUNT(*) FILTER (WHERE q.statut='ACCEPTE')::int AS won_count,
+               COUNT(*) FILTER (WHERE q.converted)::int AS converted_count,
+              COUNT(*) FILTER (WHERE q.statut='ENVOYE' AND q.date_validite<$4::date)::int AS expired_open_quotes,
+              COUNT(*) FILTER (
+                WHERE lm.result_snapshot->>'availability'='COMPLETE'
+                  AND lm.result_snapshot->>'gross_margin_ht' IS NOT NULL
+              )::int AS margin_complete_count,
+              CASE WHEN COUNT(*)>0 AND COUNT(*) FILTER (
+                       WHERE lm.result_snapshot->>'availability'='COMPLETE'
+                         AND lm.result_snapshot->>'gross_margin_ht' IS NOT NULL
+                     )=COUNT(*)
+                   THEN SUM((lm.result_snapshot->>'gross_margin_ht')::numeric)::numeric(18,2)::text
+                   ELSE NULL END AS qualified_margin_ht
+       FROM scoped_quotes q LEFT JOIN latest_margin lm ON lm.scope_ref=q.id::text
+       GROUP BY q.client_id
+     )
+     SELECT c.client_id,c.blocked AS client_blocked,
+            COALESCE(q.quote_count,0)::int AS quote_count,
+             COALESCE(q.decided_count,0)::int AS decided_count,
+             COALESCE(q.won_count,0)::int AS won_count,
+             COALESCE(q.converted_count,0)::int AS converted_count,
+            COALESCE(q.expired_open_quotes,0)::int AS expired_open_quotes,
+            COALESCE(q.margin_complete_count,0)::int AS margin_complete_count,
+            q.qualified_margin_ht,
+            COALESCE(o.blocked_orders,0)::int AS blocked_orders,
+            COALESCE(o.overdue_backlog_ht,'0.00')::text AS overdue_backlog_ht
+     FROM public.clients c
+     LEFT JOIN quote_facts q ON q.client_id=c.client_id
+     LEFT JOIN order_facts o ON o.client_id=c.client_id
+     WHERE c.client_id=ANY($1::text[])`,
+    [clientIds, query.from, query.to, query.as_of ?? query.to, query.currency ?? null, query.commercial_id ?? null],
+  );
+  return new Map(result.rows.map((row) => [row.client_id, row]));
+}
+
+async function repoCommercialExceptions(query: CommercialOverviewQueryDTO) {
+  const asOf = query.as_of ?? query.to;
+  const result = await pool.query(
+    `WITH latest_status AS (
+       SELECT DISTINCT ON (ch.commande_id) ch.commande_id,ch.nouveau_statut
+       FROM public.commande_historique ch
+       ORDER BY ch.commande_id,ch.date_action DESC,ch.id DESC
+     ), shipped AS (
+       SELECT bll.commande_ligne_id,SUM(bll.quantite)::numeric AS qty
+       FROM public.bon_livraison_ligne bll
+       JOIN public.bon_livraison bl ON bl.id=bll.bon_livraison_id
+       WHERE bl.statut IN ('SHIPPED','DELIVERED')
+         AND COALESCE(bl.date_expedition,bl.date_livraison,bl.date_creation) <= $1::date
+       GROUP BY bll.commande_ligne_id
+     ), open_lines AS (
+       SELECT cc.id AS commande_id,cc.numero,cc.client_id,cc.created_by AS owner_user_id,cl.delai_client,
+              GREATEST(cl.quantite-COALESCE(shipped.qty,0),0)::numeric AS remaining_qty,
+              (GREATEST(cl.quantite-COALESCE(shipped.qty,0),0)*cl.prix_unitaire_ht*(1-COALESCE(cl.remise_ligne,0)/100))::numeric(18,2) AS remaining_ht,
+              COALESCE(ls.nouveau_statut,'BROUILLON') AS workflow_status
+       FROM public.commande_ligne cl
+       JOIN public.commande_client cc ON cc.id=cl.commande_id
+       JOIN public.clients c ON c.client_id=cc.client_id
+       LEFT JOIN shipped ON shipped.commande_ligne_id=cl.id
+       LEFT JOIN latest_status ls ON ls.commande_id=cc.id
+       WHERE COALESCE(ls.nouveau_statut,'BROUILLON') <> 'ANNULE'
+         AND ($2::text IS NULL OR cc.client_id=$2)
+         AND ($4::text IS NULL OR UPPER(COALESCE(NULLIF(BTRIM(c.devise),''),'EUR'))=$4)
+         AND ($5::integer IS NULL OR cc.created_by=$5)
+     ), raw AS (
+       SELECT 'QUOTE_EXPIRED'::text AS code,'HIGH'::text AS priority,'DEVIS'::text AS entity_type,
+              d.id::text AS entity_id,d.numero AS label,d.user_id AS owner_user_id,
+              'Requalifier le devis ou enregistrer le motif de perte.'::text AS next_action,
+              jsonb_build_object('date_validite',d.date_validite,'source','devis.date_validite') AS evidence
+       FROM public.devis d
+       JOIN public.clients c ON c.client_id=d.client_id
+        WHERE d.statut='ENVOYE' AND d.date_validite<$1::date
+          AND NOT EXISTS (
+            SELECT 1 FROM public.devis newer_quote
+            WHERE COALESCE(newer_quote.root_devis_id,newer_quote.id)=COALESCE(d.root_devis_id,d.id)
+              AND (newer_quote.version_number>d.version_number
+                OR (newer_quote.version_number=d.version_number AND newer_quote.id>d.id))
+          )
+         AND ($2::text IS NULL OR d.client_id=$2)
+         AND ($4::text IS NULL OR UPPER(COALESCE(NULLIF(BTRIM(c.devise),''),'EUR'))=$4)
+         AND ($5::integer IS NULL OR d.user_id=$5)
+       UNION ALL
+       SELECT 'ORDER_BLOCKED','HIGH','COMMANDE',ol.commande_id::text,ol.numero,ol.owner_user_id,
+              'Traiter le motif du checkpoint bloqué.',
+              jsonb_build_object('status','BLOQUE','source','commande_historique')
+       FROM open_lines ol WHERE ol.workflow_status='BLOQUE' GROUP BY ol.commande_id,ol.numero,ol.owner_user_id
+       UNION ALL
+       SELECT 'ORDER_PROMISE_MISSING','MEDIUM','COMMANDE',ol.commande_id::text,ol.numero,ol.owner_user_id,
+              'Renseigner la date promise sur les lignes ouvertes.',
+              jsonb_build_object('undated_lines',COUNT(*),'source','commande_ligne.delai_client')
+       FROM open_lines ol WHERE ol.remaining_qty>0 AND ol.delai_client IS NULL GROUP BY ol.commande_id,ol.numero,ol.owner_user_id
+       UNION ALL
+       SELECT 'ORDER_OVERDUE','HIGH','COMMANDE',ol.commande_id::text,ol.numero,ol.owner_user_id,
+              'Replanifier ou confirmer une nouvelle promesse au client.',
+              jsonb_build_object('overdue_ht',SUM(ol.remaining_ht),'earliest_due',MIN(ol.delai_client),'source','commande_ligne + bon_livraison_ligne')
+       FROM open_lines ol WHERE ol.remaining_qty>0 AND ol.delai_client<$1::date GROUP BY ol.commande_id,ol.numero,ol.owner_user_id
+     )
+     SELECT * FROM raw ORDER BY CASE priority WHEN 'HIGH' THEN 1 ELSE 2 END,code,entity_id LIMIT $3`,
+    [asOf, query.client_id ?? null, query.limit, query.currency ?? null, query.commercial_id ?? null],
+  );
+  return result.rows;
+}
+
+async function repoOrderAging(query: CommercialOverviewQueryDTO) {
+  const asOf = query.as_of ?? query.to;
+  const result = await pool.query<{ bucket: string; count: number; amount_ht: string }>(
+    `WITH latest_status AS (
+       SELECT DISTINCT ON (ch.commande_id) ch.commande_id,ch.nouveau_statut
+       FROM public.commande_historique ch
+       ORDER BY ch.commande_id,ch.date_action DESC,ch.id DESC
+     ), shipped AS (
+       SELECT bll.commande_ligne_id,SUM(bll.quantite)::numeric AS qty
+       FROM public.bon_livraison_ligne bll
+       JOIN public.bon_livraison bl ON bl.id=bll.bon_livraison_id
+       WHERE bl.statut IN ('SHIPPED','DELIVERED')
+         AND COALESCE(bl.date_expedition,bl.date_livraison,bl.date_creation) <= $1::date
+       GROUP BY bll.commande_ligne_id
+     ), open_lines AS (
+       SELECT cc.id AS commande_id,cl.delai_client,
+              GREATEST(cl.quantite-COALESCE(shipped.qty,0),0)::numeric AS remaining_qty,
+              (GREATEST(cl.quantite-COALESCE(shipped.qty,0),0)*cl.prix_unitaire_ht*(1-COALESCE(cl.remise_ligne,0)/100))::numeric(18,2) AS remaining_ht
+       FROM public.commande_ligne cl
+       JOIN public.commande_client cc ON cc.id=cl.commande_id
+       JOIN public.clients c ON c.client_id=cc.client_id
+       LEFT JOIN shipped ON shipped.commande_ligne_id=cl.id
+       LEFT JOIN latest_status ls ON ls.commande_id=cc.id
+       WHERE COALESCE(cc.order_type,'FERME') <> 'INTERNE'
+         AND COALESCE(ls.nouveau_statut,'BROUILLON') <> 'ANNULE'
+         AND ($2::text IS NULL OR cc.client_id=$2)
+         AND ($3::text IS NULL OR UPPER(COALESCE(NULLIF(BTRIM(c.devise),''),'EUR'))=$3)
+         AND ($4::integer IS NULL OR cc.created_by=$4)
+     ), per_order AS (
+       SELECT commande_id,MIN(delai_client) AS earliest_due,SUM(remaining_ht)::numeric(18,2) AS amount_ht
+       FROM open_lines WHERE remaining_qty>0 GROUP BY commande_id
+     ), bucketed AS (
+       SELECT CASE
+         WHEN earliest_due IS NULL THEN 'UNDATED'
+         WHEN earliest_due >= $1::date THEN 'NOT_DUE'
+         WHEN $1::date-earliest_due <= 30 THEN '1_30'
+         WHEN $1::date-earliest_due <= 60 THEN '31_60'
+         WHEN $1::date-earliest_due <= 90 THEN '61_90'
+         ELSE '90_PLUS' END AS bucket,amount_ht
+       FROM per_order
+     )
+     SELECT bucket,COUNT(*)::int AS count,SUM(amount_ht)::numeric(18,2)::text AS amount_ht
+     FROM bucketed GROUP BY bucket`,
+    [asOf, query.client_id ?? null, query.currency ?? null, query.commercial_id ?? null],
+  );
+  const buckets = new Map(result.rows.map((row) => [row.bucket, row]));
+  return ["NOT_DUE", "1_30", "31_60", "61_90", "90_PLUS", "UNDATED"].map((key) => ({
+    key,
+    count: toNumber(buckets.get(key)?.count),
+    amount_ht: toNumber(buckets.get(key)?.amount_ht),
+    truncated_source: false,
+  }));
+}
+
+export async function repoCommercialOverview(query: CommercialOverviewQueryDTO) {
+  const detectedCurrencies = await repoCommercialCurrencies(query);
+  if (!query.currency && detectedCurrencies.length > 1) {
+    throw new HttpError(
+      409,
+      "COMMERCIAL_CURRENCY_REQUIRED",
+      "Plusieurs devises sont présentes. Sélectionnez une devise pour obtenir des montants comparables.",
+      { currencies: detectedCurrencies },
+    );
+  }
+  const effectiveQuery = query.currency || detectedCurrencies.length === 0
+    ? query
+    : { ...query, currency: detectedCurrencies[0] };
+  const ctx = reportingContext(effectiveQuery);
+  const [clients, quotes, orders, receivables, details, exceptions, aging, activityClients] = await Promise.all([
+    repoClients(ctx),
+    repoQuotes(ctx),
+    repoOrders(ctx),
+    repoReceivables(ctx),
+    repoCommercialDetails(effectiveQuery),
+    repoCommercialExceptions(effectiveQuery),
+    repoOrderAging(effectiveQuery),
+    repoCommercialActivityClients(effectiveQuery),
+  ]);
+
+  const cohorts = (Array.isArray(details?.cohorts) ? details.cohorts : []) as Array<Record<string, unknown>>;
+  const baseClientIds = new Set(clients.items.map((client) => client.client_id));
+  const activityOnlyClients = activityClients.items
+    .filter((client) => !baseClientIds.has(client.client_id))
+    .map((client) => ({
+      ...client,
+      net_ht: 0,
+      net_ttc: 0,
+      invoice_count: 0,
+      credit_count: 0,
+      share: clients.net_ht_total > 0 ? 0 : null,
+      open_ttc: 0,
+      overdue_ttc: 0,
+    }));
+  const combinedCandidateCount = clients.items.length + activityOnlyClients.length;
+  const combinedClientItems = clients.truncated
+    ? clients.items
+    : [...clients.items, ...activityOnlyClients].slice(0, effectiveQuery.limit);
+  const qualifications = await repoClientQualifications(effectiveQuery, combinedClientItems.map((client) => client.client_id));
+  const clientItems = combinedClientItems.map((client) => {
+    const qualification = qualifications.get(client.client_id);
+    const quoteCount = toNumber(qualification?.quote_count);
+    const completeMargins = toNumber(qualification?.margin_complete_count);
+    const marginComplete = quoteCount > 0 && completeMargins === quoteCount;
+    return {
+      ...client,
+      qualified_margin: {
+        amount_ht: marginComplete ? toNumber(qualification?.qualified_margin_ht) : null,
+        reliability: (marginComplete ? "ESTIMATED" : "PARTIAL") as "ESTIMATED" | "PARTIAL",
+        coverage: { complete_quotes: completeMargins, eligible_quotes: quoteCount },
+        reason: marginComplete
+          ? "Tous les devis du périmètre disposent d'un snapshot QUOTED complet."
+          : "Marge masquée : au moins un devis ne dispose pas d'un snapshot QUOTED complet.",
+      },
+      quote_to_order_conversion: {
+        value_pct: conversionRate(toNumber(qualification?.converted_count), quoteCount),
+        reliability: (quoteCount > 0 ? "ACTUAL" : "PARTIAL") as "ACTUAL" | "PARTIAL",
+        numerator: toNumber(qualification?.converted_count),
+        denominator: quoteCount,
+        reason: quoteCount > 0 ? null : "Aucun devis émis dans la cohorte.",
+      },
+      risk: qualifyCommercialRisk({
+        clientBlocked: qualification?.client_blocked === true,
+        overdueReceivablesTtc: client.overdue_ttc,
+        overdueBacklogHt: toNumber(qualification?.overdue_backlog_ht),
+        blockedOrders: toNumber(qualification?.blocked_orders),
+        expiredOpenQuotes: toNumber(qualification?.expired_open_quotes),
+      }),
+    };
+  });
+
+  return {
+    envelope: {
+      contract_version: COMMERCIAL_CONTRACT_VERSION,
+      period: { from: effectiveQuery.from, to: effectiveQuery.to },
+      as_of: ctx.asOf,
+      timezone: COMMERCIAL_TIMEZONE,
+      currency: effectiveQuery.currency ?? null,
+      generated_at: new Date().toISOString(),
+      source: "live" as const,
+      freshness: { measured_at: new Date().toISOString(), max_age_seconds: 0 },
+      reliability: (toNumber(details?.event_coverage_count) === toNumber(details?.eligible_count) ? "ACTUAL" : "PARTIAL") as "ACTUAL" | "PARTIAL",
+      limitations: [
+        "Le chiffre d'affaires affiché est le facturé net HT opérationnel, pas un état comptable certifié.",
+        "Les délais de réponse historiques restent indisponibles pour les devis sans événement SENT/decision horodaté.",
+        "Les montants sont limités à une seule devise ; une requête multi-devises est refusée.",
+      ],
+    },
+    clients: {
+      definition: "Facturé net HT, encours TTC et risque catégoriel à la date d'arrêté.",
+      unit: "currency / percent / category",
+      source: ["facture", "avoir", "paiement", "devis", "commande_historique"],
+      data: {
+        ...clients,
+        client_count: clients.truncated ? clients.client_count : clientItems.length,
+        items: clientItems,
+        truncated: clients.truncated || activityClients.truncated || combinedCandidateCount > effectiveQuery.limit,
+      },
+    },
+    quotes: {
+      definition: "Cohorte du premier envoi connu; conversion = devis reliés à une commande non annulée / devis émis.",
+      unit: "count / currency / days / percent",
+      source: ["devis", "commercial_quote_events", "commande_client", "commande_historique", "margin_recalculations"],
+      data: {
+        ...quotes,
+        cohorts,
+        response_days_average: details?.response_days_avg ?? null,
+        response_time_reliability: toNumber(details?.event_coverage_count) === toNumber(details?.eligible_count) ? "ACTUAL" : "PARTIAL",
+        event_coverage: { recorded: toNumber(details?.event_coverage_count), eligible: toNumber(details?.eligible_count) },
+        loss_reasons: Array.isArray(details?.loss_reasons) ? details.loss_reasons : [],
+        proposed_margin: {
+          gross_margin_ht: details?.margin_gross_ht ?? null,
+          reliability: toNumber(details?.margin_complete_count) === toNumber(details?.eligible_count) && toNumber(details?.eligible_count) > 0
+            ? "ESTIMATED" : "PARTIAL",
+          complete_quotes: toNumber(details?.margin_complete_count),
+          partial_quotes: toNumber(details?.margin_partial_count),
+          formula: "sum(quoted revenue_ht - quoted cost_total_ht), only with complete coverage",
+        },
+        conversion_total_pct: conversionRate(toNumber(details?.converted_count), toNumber(details?.eligible_count)),
+      },
+    },
+    orders: {
+      definition: "Backlog restant après quantités expédiées; retard relatif à la promesse ligne.",
+      unit: "currency / count / days",
+      source: ["commande_client", "commande_ligne", "commande_historique", "bon_livraison_ligne"],
+      data: { ...orders, aging },
+    },
+    receivables: {
+      definition: "Solde TTC échu après paiements et avoirs alloués à la date d'arrêté.",
+      unit: "currency / days",
+      source: ["facture", "paiement_allocations", "avoir_source_allocations"],
+      data: receivables,
+    },
+    exceptions,
+  };
+}
+
+export async function repoOrderTimeline(commandeId: number) {
+  const exists = await pool.query(`SELECT 1 FROM public.commande_client WHERE id=$1`, [commandeId]);
+  if (!exists.rows[0]) return null;
+  const result = await pool.query(
+    `WITH events AS (
+       SELECT COALESCE((to_jsonb(cc)->>'created_at')::timestamptz,cc.date_commande::timestamptz) AS occurred_at,
+              'ORDER'::text AS stage,'COMMANDE'::text AS entity_type,cc.id::text AS entity_id,
+              'Commande créée'::text AS label,'commande_client'::text AS source,'ACTUAL'::text AS reliability,
+              jsonb_build_object('numero',cc.numero) AS details
+       FROM public.commande_client cc WHERE cc.id=$1
+       UNION ALL
+       SELECT ch.date_action,'ANALYSIS', 'COMMANDE',ch.commande_id::text,
+              'Statut '||ch.nouveau_statut,'commande_historique','ACTUAL',
+              jsonb_build_object('from',ch.ancien_statut,'to',ch.nouveau_statut,'comment',ch.commentaire)
+       FROM public.commande_historique ch WHERE ch.commande_id=$1
+       UNION ALL
+       SELECT COALESCE((to_jsonb(o)->>'created_at')::timestamptz,(to_jsonb(o)->>'updated_at')::timestamptz),
+              'OF','OF',o.id::text,'OF '||COALESCE(o.numero,o.id::text),
+              'ordres_fabrication','ACTUAL',jsonb_build_object('status',o.statut)
+       FROM public.ordres_fabrication o WHERE o.commande_id=$1
+       UNION ALL
+       SELECT p.start_ts,'PRODUCTION','POINTAGE',p.id::text,
+              'Pointage production '||p.time_type::text,
+              'production_pointages','ACTUAL',
+              jsonb_build_object('of_id',p.of_id,'status',p.status,'duration_minutes',p.duration_minutes)
+       FROM public.production_pointages p
+       JOIN public.ordres_fabrication o ON o.id=p.of_id
+       WHERE o.commande_id=$1 AND p.status<>'CANCELLED'
+       UNION ALL
+       SELECT q.declared_at,'PRODUCTION','DECLARATION_QUANTITE',q.id::text,
+              'Déclaration de quantité production',
+              'production_quantity_declarations','ACTUAL',
+              jsonb_build_object('of_id',q.of_id,'qty_good',q.qty_good,'qty_scrap',q.qty_scrap,'qty_rework',q.qty_rework)
+       FROM public.production_quantity_declarations q
+       JOIN public.ordres_fabrication o ON o.id=q.of_id
+       WHERE o.commande_id=$1
+       UNION ALL
+       SELECT r.created_at,'PRODUCTION','RECEPTION_OF',r.id::text,
+              'Réception de production',
+              'of_receipts','ACTUAL',
+              jsonb_build_object('of_id',r.of_id,'qty_ok',r.qty_ok,'qty_scrap',r.qty_scrap,'qty_rework',r.qty_rework,'quality_status',r.quality_status)
+       FROM public.of_receipts r
+       JOIN public.ordres_fabrication o ON o.id=r.of_id
+       WHERE o.commande_id=$1
+       UNION ALL
+       SELECT COALESCE((to_jsonb(bl)->>'date_expedition')::date::timestamptz,bl.created_at),
+              'DELIVERY','BON_LIVRAISON',bl.id::text,'Livraison '||bl.numero,
+              'bon_livraison','ACTUAL',jsonb_build_object('status',bl.statut,'date_expedition',bl.date_expedition)
+       FROM public.bon_livraison bl WHERE bl.commande_id=$1
+       UNION ALL
+       SELECT COALESCE(f.date_emission::timestamptz,f.created_at),
+              'INVOICE','FACTURE',f.id::text,'Facture '||f.numero,
+              'facture','ACTUAL',jsonb_build_object('status',f.statut,'total_ht',f.total_ht)
+       FROM public.facture f WHERE f.commande_id=$1
+     )
+     SELECT * FROM events WHERE occurred_at IS NOT NULL ORDER BY occurred_at,stage,entity_id`,
+    [commandeId],
+  );
+  const covered = new Set(result.rows.map((row) => String(row.stage)));
+  return {
+    commande_id: commandeId,
+    generated_at: new Date().toISOString(),
+    source: "live",
+    reliability: "ACTUAL",
+    stages: ["ORDER", "ANALYSIS", "OF", "PRODUCTION", "DELIVERY", "INVOICE"].map((stage) => ({
+      stage,
+      available: covered.has(stage),
+    })),
+    events: result.rows,
+  };
+}
+
+async function inTransaction<T>(run: (tx: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await run(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoRecordQuoteReminder(params: {
+  devisId: number;
+  input: QuoteReminderBodyDTO;
+  actor: CommercialActor;
+  idempotencyKey: string;
+}) {
+  return inTransaction(async (tx) => {
+    const requestHash = commercialPayloadHash({ devis_id: params.devisId, ...params.input });
+    const replay = await readReceipt<Record<string, unknown>>(tx, "QUOTE_REMINDER", params.idempotencyKey, requestHash);
+    if (replay) return replay;
+    const quote = await loadQuoteSnapshot(tx, params.devisId, true);
+    if (!quote) throw new HttpError(404, "DEVIS_NOT_FOUND", "Devis introuvable.");
+    if (quote.statut !== "ENVOYE") throw new HttpError(409, "QUOTE_NOT_SENT", "Seul un devis envoyé peut être relancé.");
+    const occurredAt = params.input.occurred_at ?? new Date().toISOString();
+    if (quote.date_validite && occurredAt.slice(0, 10) > quote.date_validite) {
+      throw new HttpError(409, "QUOTE_EXPIRED", "Ce devis est expiré : requalifiez-le avant toute relance.");
+    }
+    let inserted;
+    try {
+      inserted = await tx.query<{ id: string; created_at: string }>(
+        `INSERT INTO public.commercial_quote_events
+           (devis_id,event_type,occurred_at,actor_user_id,owner_user_id,channel,note)
+         VALUES ($1,'REMINDER_RECORDED',$2,$3,$4,$5,$6)
+         RETURNING id::text,created_at::text`,
+        [params.devisId, occurredAt, params.actor.user_id, params.input.owner_user_id ?? quote.owner_user_id,
+          params.input.channel, params.input.note ?? null],
+      );
+    } catch (error) {
+      const constraint = (error as { constraint?: string }).constraint;
+      if (constraint === "commercial_quote_reminder_daily_channel_uniq") {
+        throw new HttpError(409, "DUPLICATE_QUOTE_REMINDER", "Une relance de ce canal est déjà enregistrée aujourd'hui.");
+      }
+      throw error;
+    }
+    const response = { event_id: inserted.rows[0]?.id, devis_id: params.devisId, idempotent_replay: false };
+    await insertAudit(tx, params.actor, {
+      action: "commercial.quote.reminder_recorded", entity_type: "devis", entity_id: String(params.devisId),
+      details: { channel: params.input.channel, owner_user_id: params.input.owner_user_id ?? quote.owner_user_id },
+    });
+    await saveReceipt(tx, "QUOTE_REMINDER", params.idempotencyKey, requestHash, params.actor.user_id, response);
+    return response;
+  });
+}
+
+export async function repoRecordQuoteLoss(params: {
+  devisId: number;
+  input: QuoteLossBodyDTO;
+  actor: CommercialActor;
+  idempotencyKey: string;
+}) {
+  return inTransaction(async (tx) => {
+    const requestHash = commercialPayloadHash({ devis_id: params.devisId, ...params.input });
+    const replay = await readReceipt<Record<string, unknown>>(tx, "QUOTE_LOSS", params.idempotencyKey, requestHash);
+    if (replay) return replay;
+    const quote = await loadQuoteSnapshot(tx, params.devisId, true);
+    if (!quote) throw new HttpError(404, "DEVIS_NOT_FOUND", "Devis introuvable.");
+    if (quote.statut !== "ENVOYE") throw new HttpError(409, "QUOTE_NOT_DECIDABLE", "Seul un devis envoyé peut être déclaré perdu.");
+    const occurredAt = params.input.occurred_at ?? new Date().toISOString();
+    await tx.query(`UPDATE public.devis SET statut='REFUSE',updated_at=now() WHERE id=$1`, [params.devisId]);
+    const event = await tx.query<{ id: string }>(
+      `INSERT INTO public.commercial_quote_events
+         (devis_id,event_type,occurred_at,actor_user_id,owner_user_id,reason_code,note)
+       VALUES ($1,'LOST',$2,$3,$4,$5,$6) RETURNING id::text`,
+      [params.devisId, occurredAt, params.actor.user_id, params.input.owner_user_id ?? quote.owner_user_id,
+        params.input.reason_code, params.input.note ?? null],
+    );
+    const response = { event_id: event.rows[0]?.id, devis_id: params.devisId, status: "REFUSE", idempotent_replay: false };
+    await insertAudit(tx, params.actor, {
+      action: "commercial.quote.lost", entity_type: "devis", entity_id: String(params.devisId),
+      details: { from: quote.statut, to: "REFUSE", reason_code: params.input.reason_code },
+    });
+    await saveReceipt(tx, "QUOTE_LOSS", params.idempotencyKey, requestHash, params.actor.user_id, response);
+    return response;
+  });
+}
+
+export async function repoRequestDiscountApproval(params: {
+  devisId: number;
+  input: DiscountRequestBodyDTO;
+  actor: CommercialActor;
+  idempotencyKey: string;
+}) {
+  return inTransaction(async (tx) => {
+    const requestHash = commercialPayloadHash({ devis_id: params.devisId, ...params.input });
+    const replay = await readReceipt<Record<string, unknown>>(tx, "DISCOUNT_REQUEST", params.idempotencyKey, requestHash);
+    if (replay) return replay;
+    const quote = await loadQuoteSnapshot(tx, params.devisId, true);
+    if (!quote) throw new HttpError(404, "DEVIS_NOT_FOUND", "Devis introuvable.");
+    if (quote.statut !== "BROUILLON") throw new HttpError(409, "QUOTE_NOT_DRAFT", "La validation porte uniquement sur un brouillon.");
+    if (quote.discount_pct === null) throw new HttpError(409, "QUOTE_DISCOUNT_UNQUALIFIED", "La remise effective ne peut pas être calculée.");
+    if (quote.discount_pct <= 0) throw new HttpError(409, "QUOTE_DISCOUNT_NOT_REQUIRED", "Ce devis ne contient aucune remise à valider.");
+    const requestId = crypto.randomUUID();
+    let event;
+    try {
+      event = await tx.query<{ id: string }>(
+        `INSERT INTO public.commercial_quote_events
+           (devis_id,event_type,occurred_at,actor_user_id,owner_user_id,note,
+            quote_content_hash,discount_pct,approval_request_id)
+         VALUES ($1,'DISCOUNT_REQUESTED',now(),$2,$3,$4,$5,$6,$7) RETURNING id::text`,
+        [params.devisId, params.actor.user_id, quote.owner_user_id, params.input.note ?? null,
+          quote.content_hash, quote.discount_pct, requestId],
+      );
+    } catch (error) {
+      if ((error as { constraint?: string }).constraint === "commercial_quote_discount_content_request_uniq") {
+        throw new HttpError(409, "DUPLICATE_DISCOUNT_REQUEST", "Cette version du devis possède déjà une demande de validation.");
+      }
+      throw error;
+    }
+    const response = {
+      event_id: event.rows[0]?.id, approval_request_id: requestId, devis_id: params.devisId,
+      quote_content_hash: quote.content_hash, discount_pct: quote.discount_pct, status: "PENDING", idempotent_replay: false,
+    };
+    await insertAudit(tx, params.actor, {
+      action: "commercial.quote.discount_requested", entity_type: "devis", entity_id: String(params.devisId),
+      details: { approval_request_id: requestId, quote_content_hash: quote.content_hash, discount_pct: quote.discount_pct },
+    });
+    await saveReceipt(tx, "DISCOUNT_REQUEST", params.idempotencyKey, requestHash, params.actor.user_id, response);
+    return response;
+  });
+}
+
+export async function repoDecideDiscountApproval(params: {
+  devisId: number;
+  input: DiscountDecisionBodyDTO;
+  actor: CommercialActor;
+  idempotencyKey: string;
+}) {
+  return inTransaction(async (tx) => {
+    const requestHash = commercialPayloadHash({ devis_id: params.devisId, ...params.input });
+    const replay = await readReceipt<Record<string, unknown>>(tx, "DISCOUNT_DECISION", params.idempotencyKey, requestHash);
+    if (replay) return replay;
+    const quote = await loadQuoteSnapshot(tx, params.devisId, true);
+    if (!quote) throw new HttpError(404, "DEVIS_NOT_FOUND", "Devis introuvable.");
+    const request = await tx.query<{
+      actor_user_id: number;
+      quote_content_hash: string;
+      discount_pct: number;
+    }>(
+      `SELECT actor_user_id,quote_content_hash,discount_pct::float8
+       FROM public.commercial_quote_events
+       WHERE devis_id=$1 AND approval_request_id=$2 AND event_type='DISCOUNT_REQUESTED'
+       FOR SHARE`,
+      [params.devisId, params.input.approval_request_id],
+    );
+    const requested = request.rows[0];
+    if (!requested) throw new HttpError(404, "DISCOUNT_REQUEST_NOT_FOUND", "Demande de validation introuvable.");
+    if (requested.actor_user_id === params.actor.user_id) {
+      throw new HttpError(403, "DISCOUNT_SELF_APPROVAL_FORBIDDEN", "Le demandeur ne peut pas valider sa propre remise.");
+    }
+    if (requested.quote_content_hash !== quote.content_hash) {
+      throw new HttpError(409, "QUOTE_CHANGED_AFTER_APPROVAL_REQUEST", "Le devis a changé : créez une nouvelle demande de validation.");
+    }
+    const eventType = params.input.decision === "APPROVE" ? "DISCOUNT_APPROVED" : "DISCOUNT_REJECTED";
+    let event;
+    try {
+      event = await tx.query<{ id: string }>(
+        `INSERT INTO public.commercial_quote_events
+           (devis_id,event_type,occurred_at,actor_user_id,owner_user_id,note,
+            quote_content_hash,discount_pct,approval_request_id)
+         VALUES ($1,$2,now(),$3,$4,$5,$6,$7,$8) RETURNING id::text`,
+        [params.devisId, eventType, params.actor.user_id, quote.owner_user_id, params.input.note,
+          quote.content_hash, requested.discount_pct, params.input.approval_request_id],
+      );
+    } catch (error) {
+      if ((error as { constraint?: string }).constraint === "commercial_quote_discount_decision_uniq") {
+        throw new HttpError(409, "DISCOUNT_ALREADY_DECIDED", "Cette demande de validation a déjà reçu une décision.");
+      }
+      throw error;
+    }
+    const response = {
+      event_id: event.rows[0]?.id, approval_request_id: params.input.approval_request_id,
+      devis_id: params.devisId, status: params.input.decision === "APPROVE" ? "APPROVED" : "REJECTED",
+      idempotent_replay: false,
+    };
+    await insertAudit(tx, params.actor, {
+      action: `commercial.quote.discount_${params.input.decision.toLowerCase()}`,
+      entity_type: "devis", entity_id: String(params.devisId),
+      details: { approval_request_id: params.input.approval_request_id, quote_content_hash: quote.content_hash },
+    });
+    await saveReceipt(tx, "DISCOUNT_DECISION", params.idempotencyKey, requestHash, params.actor.user_id, response);
+    return response;
+  });
+}
+
+export async function repoExpireDueQuotes(params: {
+  input: ExpireDueQuotesBodyDTO;
+  actor: CommercialActor;
+  idempotencyKey: string;
+}) {
+  return inTransaction(async (tx) => {
+    const requestHash = commercialPayloadHash(params.input);
+    const replay = await readReceipt<Record<string, unknown>>(tx, "EXPIRE_DUE_QUOTES", params.idempotencyKey, requestHash);
+    if (replay) return replay;
+    const due = await tx.query<{ id: string; numero: string; owner_user_id: number | null }>(
+      `SELECT id::text,numero,user_id AS owner_user_id FROM public.devis
+       WHERE statut='ENVOYE' AND date_validite<$1::date
+       ORDER BY date_validite,id LIMIT $2 FOR UPDATE SKIP LOCKED`,
+      [params.input.as_of, params.input.limit],
+    );
+    const ids = due.rows.map((row) => Number(row.id));
+    if (ids.length > 0) {
+      await tx.query(`UPDATE public.devis SET statut='EXPIRE',updated_at=now() WHERE id=ANY($1::bigint[])`, [ids]);
+      for (const quote of due.rows) {
+        await tx.query(
+          `INSERT INTO public.commercial_quote_events
+             (devis_id,event_type,occurred_at,actor_user_id,owner_user_id)
+           VALUES ($1,'EXPIRED',$2::date::timestamptz,$3,$4)`,
+          [quote.id, params.input.as_of, params.actor.user_id, quote.owner_user_id],
+        );
+      }
+    }
+    const response = { as_of: params.input.as_of, expired_count: ids.length, devis_ids: ids, idempotent_replay: false };
+    await insertAudit(tx, params.actor, {
+      action: "commercial.quote.expire_due", entity_type: "devis_batch", entity_id: params.input.as_of,
+      details: { expired_count: ids.length, devis_ids: ids },
+    });
+    await saveReceipt(tx, "EXPIRE_DUE_QUOTES", params.idempotencyKey, requestHash, params.actor.user_id, response);
+    return response;
+  });
+}
+
+export async function repoCancelOrder(params: {
+  commandeId: number;
+  input: CancelOrderBodyDTO;
+  actor: CommercialActor;
+  idempotencyKey: string;
+}) {
+  return inTransaction(async (tx) => {
+    const requestHash = commercialPayloadHash({ commande_id: params.commandeId, ...params.input });
+    const replay = await readReceipt<Record<string, unknown>>(tx, "ORDER_CANCEL", params.idempotencyKey, requestHash);
+    if (replay) return replay;
+    const order = await tx.query<{ id: string; numero: string }>(
+      `SELECT id::text,numero FROM public.commande_client WHERE id=$1 FOR UPDATE`,
+      [params.commandeId],
+    );
+    if (!order.rows[0]) throw new HttpError(404, "COMMANDE_NOT_FOUND", "Commande introuvable.");
+    const last = await tx.query<{ nouveau_statut: string }>(
+      `SELECT nouveau_statut FROM public.commande_historique WHERE commande_id=$1
+       ORDER BY date_action DESC,id DESC LIMIT 1 FOR UPDATE`,
+      [params.commandeId],
+    );
+    const current = normalizeCommandeWorkflowStatus(last.rows[0]?.nouveau_statut ?? "BROUILLON");
+    if (!current) throw new HttpError(409, "COMMAND_STATUS_HISTORY_INVALID", "Le statut courant est inconnu.");
+    if (["LIVRE", "FACTURE", "ARCHIVE", "ANNULE"].includes(current)) {
+      throw new HttpError(409, "ORDER_CANCELLATION_TOO_LATE", "Une commande livrée, facturée, archivée ou déjà annulée ne peut pas être annulée ici.");
+    }
+    const downstream = await tx.query<{ blocked: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM public.bon_livraison WHERE commande_id=$1 AND statut IN ('SHIPPED','DELIVERED')
+       ) OR EXISTS (
+         SELECT 1 FROM public.facture WHERE commande_id=$1 AND statut NOT IN ('DRAFT','CANCELLED','brouillon','annule','annulee')
+       ) AS blocked`,
+      [params.commandeId],
+    );
+    if (downstream.rows[0]?.blocked) {
+      throw new HttpError(409, "ORDER_CANCELLATION_HAS_DOWNSTREAM_EVIDENCE", "Annulation refusée : livraison ou facture active déjà enregistrée.");
+    }
+    await tx.query(
+      `INSERT INTO public.commercial_order_cancellations
+         (commande_id,reason_code,note,cancelled_by)
+       VALUES ($1,$2,$3,$4)`,
+      [params.commandeId, params.input.reason_code, params.input.note ?? null, params.actor.user_id],
+    );
+    await tx.query(
+      `INSERT INTO public.commande_historique
+         (commande_id,user_id,ancien_statut,nouveau_statut,commentaire)
+       VALUES ($1,$2,$3,'ANNULE',$4)`,
+      [params.commandeId, params.actor.user_id, current, `SOL-17:${params.input.reason_code}`],
+    );
+    await tx.query(
+      `INSERT INTO public.commande_client_event_log
+         (commande_id,event_type,old_values,new_values,user_id)
+       VALUES ($1,'ORDER_CANCELLED',$2::jsonb,$3::jsonb,$4)`,
+      [params.commandeId, JSON.stringify({ statut: current }), JSON.stringify({ statut: "ANNULE", reason_code: params.input.reason_code }), params.actor.user_id],
+    );
+    const response = { commande_id: params.commandeId, status: "ANNULE", idempotent_replay: false };
+    await insertAudit(tx, params.actor, {
+      action: "commercial.order.cancel", entity_type: "commande_client", entity_id: String(params.commandeId),
+      details: { from: current, to: "ANNULE", reason_code: params.input.reason_code },
+    });
+    await saveReceipt(tx, "ORDER_CANCEL", params.idempotencyKey, requestHash, params.actor.user_id, response);
+    return response;
+  });
+}

--- a/src/module/commercial-reliability/routes/commercial-reliability.routes.ts
+++ b/src/module/commercial-reliability/routes/commercial-reliability.routes.ts
@@ -1,0 +1,53 @@
+import type { RequestHandler } from "express";
+import { Router } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import { effectiveRoleHasAny, hasAnyAssignedRole, normalizeAssignedRoles } from "../../auth/domain/roles";
+import { requireFinanceCapability } from "../../facturation/middlewares/finance-authorization.middleware";
+import {
+  cancelOrder,
+  commercialOrderTimeline,
+  commercialOverview,
+  decideDiscountApproval,
+  expireDueQuotes,
+  recordQuoteLoss,
+  recordQuoteReminder,
+  requestDiscountApproval,
+} from "../controllers/commercial-reliability.controller";
+
+const COMMERCIAL_ACTORS = [
+  "Commercial",
+  "Secretaire",
+  "Directeur",
+  "Administrateur Systeme et Reseau",
+] as const;
+const COMMERCIAL_DECIDERS = ["Directeur", "Administrateur Systeme et Reseau"] as const;
+
+function requireAssignedRole(allowed: readonly string[]): RequestHandler {
+  return (req, _res, next) => {
+    if (!req.user) {
+      next(new HttpError(401, "UNAUTHORIZED", "Authentification requise."));
+      return;
+    }
+    const primaryRole = req.user.primary_role ?? req.user.role;
+    const assignedRoles = normalizeAssignedRoles(primaryRole, req.user.roles);
+    if (!effectiveRoleHasAny(req.user.role, allowed) && !hasAnyAssignedRole(primaryRole, assignedRoles, allowed)) {
+      next(new HttpError(403, "COMMERCIAL_CAPABILITY_REQUIRED", "Votre rôle ne permet pas cette action commerciale."));
+      return;
+    }
+    next();
+  };
+}
+
+const router = Router();
+
+router.get("/overview", requireFinanceCapability("reporting_financial"), commercialOverview);
+router.get("/orders/:id/timeline", requireFinanceCapability("reporting_read"), commercialOrderTimeline);
+router.post("/quotes/:id/reminders", requireAssignedRole(COMMERCIAL_ACTORS), recordQuoteReminder);
+router.post("/quotes/:id/loss", requireAssignedRole(COMMERCIAL_ACTORS), recordQuoteLoss);
+router.post("/quotes/:id/discount-approvals", requireAssignedRole(COMMERCIAL_ACTORS), requestDiscountApproval);
+router.post("/quotes/:id/discount-decisions", requireAssignedRole(COMMERCIAL_DECIDERS), decideDiscountApproval);
+router.post("/quotes/expire-due", requireAssignedRole(COMMERCIAL_DECIDERS), expireDueQuotes);
+router.post("/orders/:id/cancel", requireAssignedRole(COMMERCIAL_DECIDERS), cancelOrder);
+
+export default router;

--- a/src/module/commercial-reliability/validators/commercial-reliability.validators.ts
+++ b/src/module/commercial-reliability/validators/commercial-reliability.validators.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import {
+  LOSS_REASON_CODES,
+  ORDER_CANCELLATION_REASON_CODES,
+  REMINDER_CHANNELS,
+} from "../domain/commercial-reliability";
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date attendue au format YYYY-MM-DD");
+const isoDateTime = z.string().datetime({ offset: true });
+const boundedNote = z.string().trim().min(1).max(1000);
+
+export const commercialOverviewQuerySchema = z.object({
+  from: isoDate,
+  to: isoDate,
+  as_of: isoDate.optional(),
+  client_id: z.string().trim().min(1).max(40).optional(),
+  currency: z.string().trim().regex(/^[A-Za-z]{3}$/, "Devise ISO 4217 attendue").transform((value) => value.toUpperCase()).optional(),
+  commercial_id: z.coerce.number().int().positive().optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(25),
+}).superRefine((value, ctx) => {
+  if (value.from > value.to) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["to"], message: "La fin doit suivre le début." });
+  }
+  if (value.as_of && value.as_of < value.from) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["as_of"], message: "L'arrêté doit suivre le début." });
+  }
+});
+
+export const commercialEntityIdParamsSchema = z.object({
+  id: z.coerce.number().int().positive(),
+});
+
+export const quoteReminderBodySchema = z.object({
+  channel: z.enum(REMINDER_CHANNELS),
+  occurred_at: isoDateTime.optional(),
+  owner_user_id: z.number().int().positive().nullable().optional(),
+  note: boundedNote.optional(),
+});
+
+export const quoteLossBodySchema = z.object({
+  reason_code: z.enum(LOSS_REASON_CODES),
+  occurred_at: isoDateTime.optional(),
+  owner_user_id: z.number().int().positive().nullable().optional(),
+  note: boundedNote.optional(),
+});
+
+export const discountRequestBodySchema = z.object({
+  note: boundedNote.optional(),
+});
+
+export const discountDecisionBodySchema = z.object({
+  approval_request_id: z.string().uuid(),
+  decision: z.enum(["APPROVE", "REJECT"]),
+  note: boundedNote,
+});
+
+export const expireDueQuotesBodySchema = z.object({
+  as_of: isoDate,
+  limit: z.number().int().min(1).max(500).default(100),
+});
+
+export const cancelOrderBodySchema = z.object({
+  reason_code: z.enum(ORDER_CANCELLATION_REASON_CODES),
+  note: boundedNote.optional(),
+});
+
+export type CommercialOverviewQueryDTO = z.infer<typeof commercialOverviewQuerySchema>;
+export type QuoteReminderBodyDTO = z.infer<typeof quoteReminderBodySchema>;
+export type QuoteLossBodyDTO = z.infer<typeof quoteLossBodySchema>;
+export type DiscountRequestBodyDTO = z.infer<typeof discountRequestBodySchema>;
+export type DiscountDecisionBodyDTO = z.infer<typeof discountDecisionBodySchema>;
+export type ExpireDueQuotesBodyDTO = z.infer<typeof expireDueQuotesBodySchema>;
+export type CancelOrderBodyDTO = z.infer<typeof cancelOrderBodySchema>;

--- a/src/module/devis/repository/devis.repository.ts
+++ b/src/module/devis/repository/devis.repository.ts
@@ -35,6 +35,7 @@ import type {
 } from "../types/devis.types";
 import type { CreateCommandeInput } from "../../commande-client/types/commande-client.types";
 import { repoCreateCommande } from "../../commande-client/repository/commande-client.repository";
+import { assertQuoteDiscountApprovedForSubmission } from "../../commercial-reliability/repository/commercial-reliability.repository";
 
 type DevisCommandeHeaderRow = {
   id: string;
@@ -1888,6 +1889,7 @@ export async function repoUpdateDevis(
       numero: string;
       statut: string;
       remise_globale: number;
+      has_discount: boolean;
       updated_at: string | null;
       has_children: boolean;
     }>(
@@ -1897,6 +1899,13 @@ export async function repoUpdateDevis(
           d.numero,
           d.statut,
           d.remise_globale::float8 AS remise_globale,
+          (
+            d.remise_globale > 0
+            OR EXISTS (
+              SELECT 1 FROM devis_ligne discounted_line
+              WHERE discounted_line.devis_id=d.id AND COALESCE(discounted_line.remise_ligne,0)>0
+            )
+          ) AS has_discount,
           to_jsonb(d)->>'updated_at' AS updated_at,
           EXISTS (SELECT 1 FROM devis child WHERE child.parent_devis_id = d.id) AS has_children
         FROM devis d
@@ -1953,6 +1962,19 @@ export async function repoUpdateDevis(
         `Transition ${currentStatut} → ${requestedStatut} refusée par l'automate devis.`,
         { from: currentStatut, to: requestedStatut, allowed: DEVIS_STATUT_TRANSITIONS[currentStatut] }
       );
+    }
+
+    // SOL-17: a loss requires a structured reason, and a discounted quote needs
+    // approval tied to the exact content sent to the customer.
+    if (statutChanges && requestedStatut === "REFUSE") {
+      throw new HttpError(
+        409,
+        "STRUCTURED_LOSS_REASON_REQUIRED",
+        "Enregistrez la perte avec un motif structuré via l'action commerciale dédiée.",
+      );
+    }
+    if (statutChanges && requestedStatut === "ENVOYE" && current.has_discount === true) {
+      await assertQuoteDiscountApprovedForSubmission(client, id);
     }
 
     // RBAC fin dépendant de l'état (pattern #172) : re-vérifié ici, l'état source étant connu.
@@ -2067,6 +2089,21 @@ export async function repoUpdateDevis(
     expectedUploads = await insertDevisDocuments(client, id, documents);
 
     if (statutChanges) {
+      const commercialEventType = requestedStatut === "ENVOYE"
+        ? "SENT"
+        : requestedStatut === "ACCEPTE"
+          ? "ACCEPTED"
+          : requestedStatut === "EXPIRE"
+            ? "EXPIRED"
+            : null;
+      if (commercialEventType) {
+        await client.query(
+          `INSERT INTO public.commercial_quote_events
+             (devis_id,event_type,occurred_at,actor_user_id,owner_user_id)
+           VALUES ($1,$2,now(),$3,$4)`,
+          [id, commercialEventType, ctx.audit?.user_id ?? null, input.user_id ?? userId ?? null],
+        );
+      }
       await insertDevisAuditLog(client, ctx.audit, {
         action: "devis.statut_transition",
         entity_id: String(id),

--- a/src/module/facturation/repository/reporting-v2.repository.ts
+++ b/src/module/facturation/repository/reporting-v2.repository.ts
@@ -102,12 +102,28 @@ export type QuotesSummary = {
 };
 
 function quoteScope(p: Params, ctx: ReportingContext, bounded: boolean): string[] {
-  const where: string[] = [`d.statut <> ALL(${p.push(["BROUILLON", "ANNULE"])}::text[])`];
+  const where: string[] = [
+    `d.statut <> ALL(${p.push(["BROUILLON", "ANNULE"])}::text[])`,
+    `NOT EXISTS (
+      SELECT 1
+      FROM devis newer_quote
+      WHERE COALESCE(newer_quote.root_devis_id,newer_quote.id)=COALESCE(d.root_devis_id,d.id)
+        AND (newer_quote.version_number>d.version_number
+          OR (newer_quote.version_number=d.version_number AND newer_quote.id>d.id))
+    )`,
+  ];
   if (bounded) {
     where.push(`d.date_creation::date >= ${p.push(ctx.period.from)}::date`);
     where.push(`d.date_creation::date <= ${p.push(ctx.period.to)}::date`);
   }
   if (ctx.clientId) where.push(`d.client_id = ${p.push(ctx.clientId)}`);
+  if (ctx.currency) {
+    where.push(`EXISTS (
+      SELECT 1 FROM clients quote_client
+      WHERE quote_client.client_id=d.client_id
+        AND UPPER(COALESCE(NULLIF(BTRIM(quote_client.devise), ''), 'EUR')) = ${p.push(ctx.currency)}
+    )`);
+  }
   if (ctx.commercialId) where.push(`d.user_id = ${p.push(ctx.commercialId)}`);
   return where;
 }
@@ -264,12 +280,25 @@ export type OrdersSummary = {
 };
 
 function orderScope(p: Params, ctx: ReportingContext, bounded: boolean, alias = "cc"): string[] {
-  const where: string[] = [];
+  const where: string[] = [
+    `COALESCE((
+      SELECT ch.nouveau_statut FROM commande_historique ch
+      WHERE ch.commande_id=${alias}.id
+      ORDER BY ch.date_action DESC,ch.id DESC LIMIT 1
+    ),'BROUILLON') <> 'ANNULE'`,
+  ];
   if (bounded) {
     where.push(`${alias}.date_commande >= ${p.push(ctx.period.from)}::date`);
     where.push(`${alias}.date_commande <= ${p.push(ctx.period.to)}::date`);
   }
   if (ctx.clientId) where.push(`${alias}.client_id = ${p.push(ctx.clientId)}`);
+  if (ctx.currency) {
+    where.push(`EXISTS (
+      SELECT 1 FROM clients order_client
+      WHERE order_client.client_id=${alias}.client_id
+        AND UPPER(COALESCE(NULLIF(BTRIM(order_client.devise), ''), 'EUR')) = ${p.push(ctx.currency)}
+    )`);
+  }
   if (ctx.orderType) where.push(`COALESCE(${alias}.order_type, 'FERME') = ${p.push(ctx.orderType)}`);
   return where;
 }
@@ -1021,7 +1050,7 @@ export async function repoClients(ctx: ReportingContext): Promise<ClientsSummary
       LEFT JOIN settled  s ON s.facture_id = lo.id
       LEFT JOIN credited c ON c.facture_id = lo.id
     ),
-    per_client AS (
+    document_totals AS (
       SELECT client_id,
              SUM(net_ht)::numeric(18,2) AS net_ht,
              SUM(net_ttc)::numeric(18,2) AS net_ttc,
@@ -1033,6 +1062,20 @@ export async function repoClients(ctx: ReportingContext): Promise<ClientsSummary
         SELECT client_id, -total_ht, -total_ttc, 0, 1 FROM ledger_avoir
       ) u
       GROUP BY client_id
+    ),
+    financial_clients AS (
+      SELECT client_id FROM document_totals
+      UNION
+      SELECT client_id FROM open_balances WHERE balance_ttc > 0
+    ),
+    per_client AS (
+      SELECT fc.client_id,
+             COALESCE(dt.net_ht,0)::numeric(18,2) AS net_ht,
+             COALESCE(dt.net_ttc,0)::numeric(18,2) AS net_ttc,
+             COALESCE(dt.invoice_count,0)::int AS invoice_count,
+             COALESCE(dt.credit_count,0)::int AS credit_count
+      FROM financial_clients fc
+      LEFT JOIN document_totals dt ON dt.client_id=fc.client_id
     ),
     ranked AS (
       SELECT pc.*, ROW_NUMBER() OVER (ORDER BY pc.net_ht DESC, pc.client_id ASC) AS rn

--- a/src/module/facturation/routes/reporting.routes.ts
+++ b/src/module/facturation/routes/reporting.routes.ts
@@ -14,8 +14,14 @@ import {
   reportingReceivables,
 } from "../controllers/reporting-v2.controller";
 import { requireFinanceCapability } from "../middlewares/finance-authorization.middleware";
+import commercialReliabilityRoutes from "../../commercial-reliability/routes/commercial-reliability.routes";
 
 const router = Router();
+
+// SOL-17 — projection commerciale transverse et commandes sensibles auditables.
+// Montée sous /reporting pour réutiliser la frontière module existante, avec RBAC
+// d'action supplémentaire sur chaque mutation.
+router.use("/commercial/reliability", commercialReliabilityRoutes);
 
 // --- Surface historique (#227), conservée pour ses consommateurs ---------------
 // Contrat inchangé ; les agrégats sous-jacents ont été corrigés par #275.


### PR DESCRIPTION
## Promotion SOL-17 vers production

Promeut la base `dev` contenant uniquement SOL-17 au-dessus de `main`.

- contrat commercial fiable et audité
- migration additive avec preflight/verify/rollback
- répétition isolée : sauvegarde, 140→147 patches, rejeu 0, rollback et restauration PASS
- suite backend, typecheck et build PASS
- E2E inter-dépôts 3/3 PASS

PR source : #424. Aucune écriture de base de production n'est effectuée par cette PR.

## Summary by Sourcery

Introduce a governed commercial reliability boundary covering quotes, orders and clients, with append-only evidence, idempotent commands and reporting integration.

New Features:
- Expose a new /reporting/commercial/reliability API surface providing a transverse commercial overview, exceptions, order timelines and controlled actions on quotes and orders.
- Add a commercial quote events journal, explicit order cancellation evidence and idempotent command receipts backed by a dedicated SOL-17 migration patch.
- Enforce discount approval tied to the exact quote content before sending discounted quotes and record key commercial quote events (sent/accepted/lost/expired/discount lifecycle).
- Allow audited, reasoned cancellation of customer orders via workflow support for an ANNULE status and associated transition rules.
- Provide commercial risk qualification, margin and conversion summaries, and aging/backlog metrics built on existing billing, orders, margin and receivables data.

Bug Fixes:
- Correct quote and order reporting scopes to exclude drafts, cancelled documents and superseded quote versions, and to properly filter by client currency.
- Ensure client financial reporting includes customers with open receivables even when they have no recent documents, fixing missing rows in client aggregates.
- Relax a SOL-16 test expectation so that the OTIF metric can use its dedicated authoritative route while keeping other deferred metrics marked as unavailable.

Enhancements:
- Extend commande-client workflow contracts to include an explicit ANNULE status, labels, ordering and cancellation transitions, tightening downstream status checks.
- Strengthen reporting metrics and tests around deliveries and commercial KPIs, including explicit formulas and limitations for deferred metrics.
- Add strict RBAC and validation for commercial reliability actions, tying permissions and roles to financial reporting and decision capabilities.

Build:
- Wire the new SOL-17 migration patch and its preflight/verify/rollback support scripts into the release gate to exercise guarded application and rollback.

Documentation:
- Document the SOL-17 commercial reliability boundary, its data definitions, risks and migration/rollback strategy via an ADR and execution report.
- Update migration rehearsal documentation and JSON report for SOL-06 to reflect the additional SOL-17 patch and revised timings and checks.

Tests:
- Add targeted unit and integration tests for commercial reliability domain logic, repositories, HTTP routes, RBAC, idempotency receipts and migration guards.
- Extend existing workflow and reporting tests to cover new quote status rules, discount approval enforcement, order cancellation behaviour and metric contracts.