### PR TITLE
fix(livraisons): corriger le paramètre SQL du lancement en stock

### DIFF
--- a/src/module/livraisons/repository/livraisons-shipment.repository.test.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.test.ts
@@ -33,6 +33,17 @@ describe("shipment stock movement audit contract", () => {
       /INSERT INTO public\.stock_movement_event_log \(\s*movement_id,/
     );
   });
+
+  it("keeps the delivery-line parameter UUID-typed when creating a reservation (#428)", () => {
+    // PostgreSQL assigns one type to each bind parameter. Reusing $6 as both the
+    // TEXT source_id and the UUID line filter fails at parse time with 42P08.
+    expect(shipmentRepositorySource).toMatch(
+      /'BON_LIVRAISON_LIGNE',\s*line\.id::text,\s*line\.commande_ligne_id/
+    );
+    expect(shipmentRepositorySource).not.toMatch(
+      /'BON_LIVRAISON_LIGNE',\s*\$6,\s*line\.commande_ligne_id/
+    );
+  });
 });
 
 describe("internal order delivery gate", () => {

--- a/src/module/livraisons/repository/livraisons-shipment.repository.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.ts
@@ -688,7 +688,7 @@ export async function prepareLivraisonInTransaction(
             $4::uuid,
             $5,
             'BON_LIVRAISON_LIGNE',
-            $6,
+            line.id::text,
             line.commande_ligne_id,
             line.id,
             delivery.affaire_id,


### PR DESCRIPTION
Closes #428

## Cause

La création d'une réservation réutilisait le paramètre $6 comme UUID dans le filtre de ligne et comme TEXT dans source_id. PostgreSQL rejetait la requête avec 42P08 avant toute insertion.

## Correction

source_id est maintenant dérivé de line.id::text; $6 reste exclusivement UUID.

## Validation

- 42 tests ciblés réussis
- typecheck réussi
- ancienne requête reproduite en 42P08 sur cerp_test
- requête corrigée validée par PREPARE sur PostgreSQL cerp_test, transaction read-only rollbackée

## Summary by Sourcery

Ensure stock reservation creation uses correctly typed SQL parameters for delivery line handling in the livraisons module.

Bug Fixes:
- Prevent PostgreSQL parse-time failures by avoiding reuse of a single bind parameter as both UUID and TEXT in shipment reservation queries.

Tests:
- Add a repository test asserting the SQL source uses line.id::text for source_id and keeps the delivery-line parameter UUID-typed, preventing regression of issue #428.