### PR TITLE
release: corriger le lancement tout en stock (#428)

### DIFF
--- a/src/module/livraisons/repository/livraisons-shipment.repository.test.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.test.ts
@@ -33,6 +33,17 @@ describe("shipment stock movement audit contract", () => {
       /INSERT INTO public\.stock_movement_event_log \(\s*movement_id,/
     );
   });
+
+  it("keeps the delivery-line parameter UUID-typed when creating a reservation (#428)", () => {
+    // PostgreSQL assigns one type to each bind parameter. Reusing $6 as both the
+    // TEXT source_id and the UUID line filter fails at parse time with 42P08.
+    expect(shipmentRepositorySource).toMatch(
+      /'BON_LIVRAISON_LIGNE',\s*line\.id::text,\s*line\.commande_ligne_id/
+    );
+    expect(shipmentRepositorySource).not.toMatch(
+      /'BON_LIVRAISON_LIGNE',\s*\$6,\s*line\.commande_ligne_id/
+    );
+  });
 });
 
 describe("internal order delivery gate", () => {

--- a/src/module/livraisons/repository/livraisons-shipment.repository.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.ts
@@ -688,7 +688,7 @@ export async function prepareLivraisonInTransaction(
             $4::uuid,
             $5,
             'BON_LIVRAISON_LIGNE',
-            $6,
+            line.id::text,
             line.commande_ligne_id,
             line.id,
             delivery.affaire_id,


### PR DESCRIPTION
Promotion du correctif #428 validé sur cerp_test : PostgreSQL accepte désormais la requête de réservation et le conflit de type 42P08 est supprimé.

Validation : 42 tests ciblés, typecheck et PREPARE réel en lecture seule sur cerp_test.

## Summary by Sourcery

Ensure shipment reservation queries use correctly typed parameters to avoid PostgreSQL parse-time type conflicts.

Enhancements:
- Adjust stock movement reservation query to keep the delivery-line identifier typed as UUID/text consistently rather than reusing a bind parameter that causes PostgreSQL error 42P08.

Tests:
- Add a repository test asserting that the delivery-line parameter remains UUID-typed and not reused as a generic bind parameter in the reservation query.