### PR TITLE
release: promouvoir SOL-18 achats fiables vers main

### DIFF
--- a/db/patches/20260812_procurement_reliability_sol18.sql
+++ b/db/patches/20260812_procurement_reliability_sol18.sql
@@ -1,0 +1,140 @@
+-- SOL-18 supplier performance evidence, promise history and actionable anomalies.
+-- Additive and repeat-safe through the canonical schema_migrations runner.
+BEGIN;
+
+DO $guard$
+BEGIN
+  IF to_regclass('public.commande_fournisseur') IS NULL
+     OR to_regclass('public.commande_fournisseur_ligne') IS NULL
+     OR to_regclass('public.receptions_fournisseurs') IS NULL
+     OR to_regclass('public.reception_fournisseur_lignes') IS NULL
+     OR to_regclass('public.reception_incoming_inspections') IS NULL
+     OR to_regclass('public.lots') IS NULL THEN
+    RAISE EXCEPTION 'SOL-18 prerequisites are missing; apply supplier-order, reception, stock and quality patches first';
+  END IF;
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    RAISE EXCEPTION 'SOL-18 runtime role cerp_app is missing';
+  END IF;
+END
+$guard$;
+
+CREATE TABLE public.procurement_promised_date_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  commande_id uuid NOT NULL REFERENCES public.commande_fournisseur(id) ON DELETE RESTRICT,
+  ligne_id uuid NULL REFERENCES public.commande_fournisseur_ligne(id) ON DELETE RESTRICT,
+  previous_date date NULL,
+  promised_date date NOT NULL,
+  reason_code text NOT NULL CHECK (reason_code IN (
+    'SUPPLIER_ACKNOWLEDGEMENT','SUPPLIER_DELAY','SUPPLIER_ADVANCE',
+    'PARTIAL_SHIPMENT','ORDER_CORRECTION','OTHER'
+  )),
+  note text NULL CHECK (note IS NULL OR char_length(note) <= 1000),
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT procurement_promise_change_ck CHECK (
+    reason_code = 'SUPPLIER_ACKNOWLEDGEMENT' OR previous_date IS DISTINCT FROM promised_date
+  ),
+  CONSTRAINT procurement_promise_other_note_ck CHECK (reason_code <> 'OTHER' OR note IS NOT NULL)
+);
+CREATE INDEX procurement_promises_order_idx
+  ON public.procurement_promised_date_events (commande_id, created_at DESC);
+CREATE INDEX procurement_promises_line_idx
+  ON public.procurement_promised_date_events (ligne_id, created_at DESC) WHERE ligne_id IS NOT NULL;
+
+CREATE TABLE public.procurement_anomaly_actions (
+  anomaly_key text PRIMARY KEY CHECK (anomaly_key ~ '^[A-Z_]+:[0-9a-f]{24}$'),
+  owner_user_id integer NULL REFERENCES public.users(id) ON DELETE SET NULL,
+  next_action text NOT NULL CHECK (char_length(next_action) BETWEEN 3 AND 500),
+  due_date date NOT NULL,
+  status text NOT NULL CHECK (status IN ('OPEN','IN_PROGRESS','RESOLVED','DISMISSED')),
+  resolution_note text NULL CHECK (resolution_note IS NULL OR char_length(resolution_note) <= 1000),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  updated_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT procurement_anomaly_close_note_ck CHECK (
+    status NOT IN ('RESOLVED','DISMISSED') OR resolution_note IS NOT NULL
+  )
+);
+CREATE INDEX procurement_anomaly_queue_idx
+  ON public.procurement_anomaly_actions (status, due_date, owner_user_id);
+
+CREATE TABLE public.procurement_policy_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  scope_type text NOT NULL CHECK (scope_type IN ('COMPANY','SUPPLIER','ARTICLE','FAMILY')),
+  scope_id text NULL,
+  valid_from date NOT NULL,
+  price_tolerance_pct numeric(7,4) NULL CHECK (price_tolerance_pct BETWEEN 0 AND 100),
+  over_receipt_tolerance_pct numeric(7,4) NOT NULL DEFAULT 0 CHECK (over_receipt_tolerance_pct BETWEEN 0 AND 100),
+  lead_grace_days integer NOT NULL DEFAULT 0 CHECK (lead_grace_days BETWEEN 0 AND 365),
+  reason text NOT NULL CHECK (char_length(reason) BETWEEN 3 AND 1000),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  CONSTRAINT procurement_policy_scope_ck CHECK (
+    (scope_type = 'COMPANY' AND scope_id IS NULL)
+    OR (scope_type <> 'COMPANY' AND scope_id IS NOT NULL)
+  ),
+  CONSTRAINT procurement_policy_scope_date_uniq UNIQUE NULLS NOT DISTINCT (scope_type, scope_id, valid_from)
+);
+CREATE INDEX procurement_policy_effective_idx
+  ON public.procurement_policy_versions (scope_type, scope_id, valid_from DESC);
+
+CREATE TABLE public.procurement_command_receipts (
+  action text NOT NULL CHECK (action IN ('ANOMALY_ACTION','PROMISED_DATE','POLICY_VERSION')),
+  idempotency_key text NOT NULL CHECK (char_length(idempotency_key) BETWEEN 8 AND 120),
+  request_hash char(64) NOT NULL CHECK (request_hash ~ '^[0-9a-f]{64}$'),
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  response_snapshot jsonb NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (action, idempotency_key)
+);
+
+CREATE FUNCTION public.fn_procurement_evidence_append_only()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $append_only$
+BEGIN
+  RAISE EXCEPTION '% is append-only; add a new procurement event or policy version instead', TG_TABLE_NAME
+    USING ERRCODE = '55000';
+END
+$append_only$;
+
+CREATE TRIGGER procurement_promises_append_only
+  BEFORE UPDATE OR DELETE ON public.procurement_promised_date_events
+  FOR EACH ROW EXECUTE FUNCTION public.fn_procurement_evidence_append_only();
+CREATE TRIGGER procurement_policies_append_only
+  BEFORE UPDATE OR DELETE ON public.procurement_policy_versions
+  FOR EACH ROW EXECUTE FUNCTION public.fn_procurement_evidence_append_only();
+CREATE TRIGGER procurement_receipts_append_only
+  BEFORE UPDATE OR DELETE ON public.procurement_command_receipts
+  FOR EACH ROW EXECUTE FUNCTION public.fn_procurement_evidence_append_only();
+
+ALTER TABLE public.procurement_promised_date_events OWNER TO cerp_app;
+ALTER TABLE public.procurement_anomaly_actions OWNER TO cerp_app;
+ALTER TABLE public.procurement_policy_versions OWNER TO cerp_app;
+ALTER TABLE public.procurement_command_receipts OWNER TO cerp_app;
+ALTER FUNCTION public.fn_procurement_evidence_append_only() OWNER TO cerp_app;
+
+REVOKE ALL ON TABLE public.procurement_promised_date_events FROM PUBLIC, cerp_app;
+REVOKE ALL ON TABLE public.procurement_anomaly_actions FROM PUBLIC, cerp_app;
+REVOKE ALL ON TABLE public.procurement_policy_versions FROM PUBLIC, cerp_app;
+REVOKE ALL ON TABLE public.procurement_command_receipts FROM PUBLIC, cerp_app;
+GRANT SELECT, INSERT ON TABLE public.procurement_promised_date_events TO cerp_app;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.procurement_anomaly_actions TO cerp_app;
+GRANT SELECT, INSERT ON TABLE public.procurement_policy_versions TO cerp_app;
+GRANT SELECT, INSERT ON TABLE public.procurement_command_receipts TO cerp_app;
+REVOKE ALL ON FUNCTION public.fn_procurement_evidence_append_only() FROM PUBLIC, cerp_app;
+GRANT EXECUTE ON FUNCTION public.fn_procurement_evidence_append_only() TO cerp_app;
+
+COMMENT ON TABLE public.procurement_promised_date_events IS
+  'SOL-18 append-only supplier promise history. Existing pre-SOL-18 promise values remain explicitly unversioned.';
+COMMENT ON TABLE public.procurement_anomaly_actions IS
+  'SOL-18 mutable triage overlay for deterministic procurement anomalies; every mutation is also written to the central audit log.';
+COMMENT ON TABLE public.procurement_policy_versions IS
+  'SOL-18 dated tolerance policies. No implicit price tolerance is assumed when no version exists.';
+COMMENT ON TABLE public.procurement_command_receipts IS
+  'SOL-18 idempotency receipts for anomaly triage, promise revisions and tolerance versions.';
+
+COMMIT;

--- a/db/patches/support/20260812_procurement_reliability_sol18.preflight.sql
+++ b/db/patches/support/20260812_procurement_reliability_sol18.preflight.sql
@@ -1,0 +1,21 @@
+-- Read-only preflight. Every boolean must be true before applying SOL-18.
+SELECT
+  current_setting('server_version_num')::integer >= 150000 AS postgres_15_or_newer,
+  pg_has_role(current_user, 'cerp_migrator', 'MEMBER') AS migrator_role,
+  EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') AS runtime_role,
+  to_regclass('public.commande_fournisseur') IS NOT NULL AS orders_present,
+  to_regclass('public.commande_fournisseur_ligne') IS NOT NULL AS order_lines_present,
+  to_regclass('public.receptions_fournisseurs') IS NOT NULL AS receipts_present,
+  to_regclass('public.reception_fournisseur_lignes') IS NOT NULL AS receipt_lines_present,
+  to_regclass('public.reception_incoming_inspections') IS NOT NULL AS incoming_quality_present,
+  to_regclass('public.lots') IS NOT NULL AS lots_present,
+  to_regclass('public.procurement_promised_date_events') IS NULL AS promises_target_absent,
+  to_regclass('public.procurement_anomaly_actions') IS NULL AS anomaly_target_absent,
+  to_regclass('public.procurement_policy_versions') IS NULL AS policy_target_absent,
+  to_regclass('public.procurement_command_receipts') IS NULL AS receipts_target_absent;
+
+SELECT pg_size_pretty(pg_database_size(current_database())) AS database_size,
+       pg_size_pretty(pg_tablespace_size('pg_default')) AS tablespace_size;
+
+-- Operator prerequisite: a verified pg_dump backup and checksum must exist outside
+-- this database before execution. This query deliberately cannot fake that proof.

--- a/db/patches/support/20260812_procurement_reliability_sol18.rollback.sql
+++ b/db/patches/support/20260812_procurement_reliability_sol18.rollback.sql
@@ -1,0 +1,22 @@
+-- Guarded rollback for an empty, unapplied SOL-18 feature only.
+-- If any evidence exists, restore the validated pre-migration backup into a new
+-- database and promote it; never erase industrial evidence in place.
+BEGIN;
+DO $guard$
+BEGIN
+  IF EXISTS (SELECT 1 FROM public.procurement_promised_date_events)
+     OR EXISTS (SELECT 1 FROM public.procurement_anomaly_actions)
+     OR EXISTS (SELECT 1 FROM public.procurement_policy_versions)
+     OR EXISTS (SELECT 1 FROM public.procurement_command_receipts) THEN
+    RAISE EXCEPTION 'SOL-18 rollback refused: procurement evidence exists; restore the pre-migration backup into a fresh database';
+  END IF;
+END
+$guard$;
+
+DROP TABLE public.procurement_command_receipts;
+DROP TABLE public.procurement_policy_versions;
+DROP TABLE public.procurement_anomaly_actions;
+DROP TABLE public.procurement_promised_date_events;
+DROP FUNCTION public.fn_procurement_evidence_append_only();
+DELETE FROM public.cerp_schema_migrations WHERE filename = '20260812_procurement_reliability_sol18.sql';
+COMMIT;

--- a/db/patches/support/20260812_procurement_reliability_sol18.verify.sql
+++ b/db/patches/support/20260812_procurement_reliability_sol18.verify.sql
@@ -1,0 +1,32 @@
+-- Read-only post-migration verification. Every boolean must be true.
+SELECT
+  to_regclass('public.procurement_promised_date_events') IS NOT NULL AS promises_present,
+  to_regclass('public.procurement_anomaly_actions') IS NOT NULL AS anomaly_actions_present,
+  to_regclass('public.procurement_policy_versions') IS NOT NULL AS policies_present,
+  to_regclass('public.procurement_command_receipts') IS NOT NULL AS command_receipts_present,
+  to_regprocedure('public.fn_procurement_evidence_append_only()') IS NOT NULL AS append_only_guard_present;
+
+SELECT
+  NOT EXISTS (
+    SELECT 1 FROM public.procurement_promised_date_events
+    WHERE (reason_code <> 'SUPPLIER_ACKNOWLEDGEMENT' AND previous_date IS NOT DISTINCT FROM promised_date)
+       OR (reason_code = 'OTHER' AND note IS NULL)
+  ) AS promise_history_valid,
+  NOT EXISTS (
+    SELECT 1 FROM public.procurement_anomaly_actions
+    WHERE status IN ('RESOLVED','DISMISSED') AND resolution_note IS NULL
+  ) AS anomaly_closure_valid,
+  NOT EXISTS (
+    SELECT 1 FROM public.procurement_policy_versions
+    GROUP BY scope_type, scope_id, valid_from HAVING count(*) > 1
+  ) AS policy_versions_unique,
+  NOT EXISTS (
+    SELECT 1 FROM public.procurement_command_receipts
+    WHERE request_hash !~ '^[0-9a-f]{64}$'
+  ) AS receipt_hashes_valid;
+
+SELECT table_name, privilege_type
+FROM information_schema.role_table_grants
+WHERE grantee = 'cerp_app'
+  AND table_name LIKE 'procurement_%'
+ORDER BY table_name, privilege_type;

--- a/docs/adr/ADR-0064-procurement-reliability-boundary.md
+++ b/docs/adr/ADR-0064-procurement-reliability-boundary.md
@@ -1,0 +1,82 @@
+# ADR-0064 — Frontière de fiabilité des achats
+
+- Statut : accepté
+- Date : 2026-08-12
+- Décision : SOL-18
+- Propriétaire métier : Keenan Martin, Direction CERP+
+
+## Contexte
+
+Les commandes fournisseurs, réceptions, contrôles entrants et lots existaient,
+mais aucune vue autoritaire ne reliait leurs preuves. La date promise pouvait être
+écrasée sans historique, les unités de réception pouvaient être additionnées sans
+garantie de conversion et aucune file commune ne portait le responsable d'une
+anomalie. Les factures, avoirs et retours fournisseurs ne sont pas modélisés dans
+le schéma actuel.
+
+## Décision
+
+Le backend publie le contrat CERP-PROCUREMENT-1.0.0. Le frontend valide ce
+contrat et l'affiche sans recalculer les indicateurs.
+
+| Indicateur | Définition | Unité et période | Sources |
+|---|---|---|---|
+| OTD fournisseur | Engagements arrivés à échéance et reçus intégralement au plus tard à la date promise / engagements arrivés à échéance. | %, cohorte de dates promises incluses entre from et min(to, as_of) | commandes/lignes, historique des promesses, lignes de réception |
+| Variabilité du délai | Écart-type population des jours calendaires entre envoi de la commande et réception intégrale. Au moins deux observations sont requises. | jours calendaires, même cohorte | date d'envoi, dates de réception |
+| Écart de prix | (Facturé rapproché − commandé) / commandé, pondéré par montant. | % | UNAVAILABLE tant qu'aucune facture/ligne d'avoir fournisseur n'existe |
+| Taux de rejet | Quantité normalisée des contrôles décidés BLOQUE / quantité normalisée de tous les contrôles décidés. | % de quantité en unité d'achat | contrôles entrants, réceptions, lots |
+
+Chaque métrique expose définition, unité, période, source, fraîcheur, numérateur,
+dénominateur, éléments manquants et fiabilité ESTIMATED, PARTIAL, ACTUAL
+ou UNAVAILABLE. Une cohorte vide et une source absente donnent null, jamais
+zéro.
+
+## Dates promises, unités et tolérances
+
+- l'accusé fournisseur crée toujours un événement initial
+  SUPPLIER_ACKNOWLEDGEMENT, même si la date confirmée est identique à la date
+  précédemment prévue ;
+- chaque révision ultérieure exige un motif structuré, l'acteur et un verrou
+  optimiste sur l'en-tête ou la ligne réellement modifiée ;
+- l'historique est append-only. Les promesses antérieures à SOL-18 ne sont pas
+  rétro-inventées et abaissent la fiabilité à PARTIAL ;
+- une quantité reçue n'est rapprochée que dans la même unité ou avec le
+  coefficient explicite stock-par-unité-d'achat. Une quantité source absente ou
+  négative provoque une erreur de données, pas un zéro ;
+- les tolérances de sur-réception, délai et prix sont datées et append-only par
+  société, fournisseur, article ou famille. En l'absence de politique, la
+  sur-réception et le délai utilisent une tolérance stricte de zéro ; aucune
+  tolérance de prix n'est inventée.
+
+## Rapprochement et anomalies
+
+La réponse relie commande et ligne, réceptions partielles, unité normalisée,
+contrôle entrant, lot et documents. Elle détecte quantité manquante ou excédentaire,
+réception tardive, unité non convertible, lot bloqué, document absent et contrôle
+obligatoire manquant. Chaque anomalie a une clé déterministe, une gravité, les
+preuves sources, une action recommandée et une échéance ; l'overlay de traitement
+ajoute responsable, prochaine action, statut et motif de clôture.
+
+Les factures, avoirs et retours fournisseurs sont exposés avec
+SUPPLIER_*_SOURCE_NOT_MODELLED. Ils ne sont ni simulés ni remplacés par des
+valeurs de commande.
+
+## Autorisation, audit et idempotence
+
+Toutes les routes restent derrière l'authentification et le gate de base CERP.
+Lecture et prix suivent les capacités achats existantes ; dates promises exigent
+acknowledge, traitement d'anomalie close, politique de tolérance approve.
+Chaque mutation exige Idempotency-Key, compare l'empreinte du payload, conserve
+un reçu rejouable et écrit l'audit central dans la transaction.
+
+## Migration et rollback
+
+Le patch est additif et doit être appliqué avant le nouvel artefact backend, car
+l'accusé fournisseur écrit désormais l'événement initial. L'ancienne application
+reste compatible avec le schéma enrichi.
+
+Le rollback SQL n'est permis que tant qu'aucune preuve SOL-18 n'existe. Après la
+première promesse, politique, action ou commande idempotente, conserver les tables
+et redéployer l'artefact précédent. Si un retour de schéma est imposé, arrêter les
+écritures et restaurer la sauvegarde complète vérifiée dans une nouvelle base,
+puis promouvoir cette base.

--- a/docs/execution-reports/SOL-18.md
+++ b/docs/execution-reports/SOL-18.md
@@ -1,0 +1,135 @@
+# SOL-18 — Fournisseurs, achats et réceptions (backend)
+
+- Date : 2026-08-12
+- Issue : https://github.com/BigFootLime/erp-crp-backend/issues/431
+- Branche de travail : feature/431-sol18-procurement-scorecard
+- Base : origin/dev 6891114fdd6232972c3eaad83a50b4b26d4460b0
+- ADR : docs/adr/ADR-0064-procurement-reliability-boundary.md
+
+## Diagnostic et cause racine
+
+Les commandes, réceptions, contrôles entrants, lots et documents existaient mais
+étaient consultés séparément. Les dates promises étaient écrasables sans journal,
+les unités reçues n'avaient pas de règle commune de normalisation, les tolérances
+n'étaient pas datées et aucune file d'anomalies ne portait propriétaire, prochaine
+action ou échéance. Un écart de prix semblait calculable depuis le prix commandé
+alors que le dépôt ne contient aucune facture fournisseur autoritaire.
+
+La répétition a également découvert un défaut dormant du rollback : le nouveau
+script visait schema_migrations au lieu du registre canonique
+cerp_schema_migrations. Le runner l'a détecté après application des huit patchs ;
+le nom a été corrigé et toute la répétition a ensuite réussi.
+
+## Choix d'architecture
+
+- contrat serveur CERP-PROCUREMENT-1.0.0 avec définition, unité, période, source,
+  fraîcheur, fiabilité, manquants, numérateur et dénominateur ;
+- OTD sur cohorte de dates promises échues, variabilité en écart-type population
+  de jours calendaires et taux de rejet pondéré par quantités normalisées ;
+- historique append-only des promesses, politiques de tolérance datées et reçus
+  d'idempotence append-only ;
+- conversion d'unité uniquement si l'unité est identique ou si le coefficient
+  explicite stock-par-unité-d'achat existe ;
+- rapprochement commande → réception → contrôle → lot → documents ;
+- anomalies déterministes : manquant, excédent, retard, unité incompatible, lot
+  bloqué, document absent et contrôle obligatoire absent ;
+- RBAC serveur, verrou optimiste, audit transactionnel et Idempotency-Key sur
+  toutes les corrections ;
+- factures, avoirs, retours et écart de prix fournisseur déclarés UNAVAILABLE
+  plutôt que simulés.
+
+## Fichiers modifiés
+
+- nouveau module src/module/procurement-reliability avec domaine, validation,
+  repository, contrôleur, routes et tests ;
+- montage de route dans src/routes/v1.routes.ts ;
+- intégration de l'événement de promesse initiale dans le workflow d'accusé
+  fournisseur ;
+- patch db/patches/20260812_procurement_reliability_sol18.sql et scripts support
+  preflight, verify et rollback ;
+- ajout de SOL-18 au runner scripts/migrations/release-gate.js ;
+- tests de domaine, transactions, RBAC/routes et gardes migration ;
+- ADR, rapport de répétition migration et présent rapport.
+
+## Migration et changements de données
+
+Le patch ajoute :
+
+- procurement_promised_date_events ;
+- procurement_anomaly_actions ;
+- procurement_policy_versions ;
+- procurement_command_receipts ;
+- fn_procurement_evidence_append_only et trois triggers append-only.
+
+Il ne réécrit aucune commande ni promesse historique. Les anciennes promesses
+restent explicitement partielles. L'application du schéma doit précéder le nouvel
+artefact backend.
+
+Répétition PostgreSQL 16 jetable finale :
+
+- source : 140 patchs appliqués, 8 attendus, 0 divergence de checksum ;
+- sauvegarde : 1 954 339 octets, SHA-256
+  ac0e6f9884f6296c408af4cc0146f322f99501afb80a1e823c637f9dfc4cfd82 ;
+- migration : 277 ms, vérification 146 ms, rejeu 0 patch en 140 ms ;
+- rollback test-only : passed en 110 ms ;
+- restauration : passed en 4 233 ms ;
+- empreintes source/restaurée identiques :
+  95604517cb6cd91ff263ce0dce1ffeabd091c7fa45e9151c6f7c09761a635f09.
+
+La base était liée à 127.0.0.1:55493, stockée en tmpfs et détruite après le test.
+Aucune base persistante ou de production n'a été lue ou écrite.
+
+## Tests exécutés
+
+| Contrôle | Résultat réel |
+|---|---|
+| tests SOL-18 domaine/repository/routes/migration | PASS |
+| suite backend complète | PASS — 923 fichiers, 4 506 tests réussis, 4 ignorés, 0 échec |
+| pnpm typecheck | PASS |
+| pnpm build | PASS — frontière données de production validée sur 648 sources et 648 fichiers émis |
+| pnpm audit --audit-level high | PASS — aucune vulnérabilité connue |
+| répétition migration complète | PASS — backup, preflight, 8 patchs, verify, replay, rollback, restore |
+| E2E intégré inter-dépôts | PASS — 3/3, 148 migrations, retries à zéro |
+
+L'E2E intégré crée réellement une commande fournisseur, la fait valider et envoyer,
+enregistre l'accusé et sa promesse, puis couvre :
+
+1. réception complète → contrôle → lot → stock → OTD constaté et historique ;
+2. réception partielle → anomalie de quantité → affectation → retry idempotent.
+
+## Vérification navigateur
+
+Playwright Chromium a exécuté les trois parcours sur un frontend compilé, une API
+compilée et PostgreSQL jetable. Le spec fonctionnel UI Commandes fournisseurs a
+également passé 7/7 scénarios avec retries désactivés, dont accès refusé, erreur et
+reprise, achat partiel, achat complet, scorecard, état indisponible et prise en
+charge. Le premier essai avait révélé un readiness insuffisant du serveur Vite ;
+Playwright construit puis sert désormais le bundle avec une frontière API locale
+explicite avant de commencer.
+
+## Risques, compatibilité et éléments restant à faire
+
+- P1 : aucune facture fournisseur, ligne d'avoir ni workflow de retour fournisseur
+  n'existe dans le schéma. L'écart de prix, les avoirs et retours restent
+  indisponibles avec motif machine-readable. Prochaine action : décider puis
+  concevoir ces trois sous-domaines et leur rapprochement comptable ;
+- les dates promises antérieures à SOL-18 n'ont pas d'acteur ni de motif et
+  abaissent la fiabilité à PARTIAL ;
+- l'isolation disponible reste celle de la base CERP sélectionnée ; les tables
+  achats ne portent pas encore de société/site autoritaire commun ;
+- les gros chunks Vite existants restent un avertissement de performance sans
+  échec de build ;
+- le helper Project Office n'a pas pu publier l'avancement, faute de
+  PROJECT_OFFICE_API_URL et de jeton dans cet environnement. L'issue Git #431
+  reste la trace exploitable ;
+- le patch n'a volontairement pas été appliqué sur HYPERBOX2 ou Coolify. Il doit
+  passer par le gate de release, sauvegarde vérifiée et fenêtre autorisée.
+
+## Rollback
+
+Avant toute preuve SOL-18, le script support peut retirer les quatre tables, les
+triggers, la fonction et l'entrée du registre. Après la première preuve, le script
+refuse la suppression : redéployer l'artefact backend précédent, qui ignore les
+tables additives. Si un retour de schéma est indispensable, geler les écritures et
+restaurer le dump pré-migration dans une nouvelle base, vérifier son empreinte et
+promouvoir la base restaurée.

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,31 +1,31 @@
 {
   "status": "passed",
-  "started_at": "2026-08-12T15:46:29.303Z",
+  "started_at": "2026-08-12T20:33:01.696Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
-    "port": 55436,
+    "port": 55493,
     "database": "cerp_test",
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 18274,
-    "source_seed": 189,
-    "backup": 728,
-    "preflight": 162,
-    "integrity_before": 642,
-    "migration": 223,
-    "verify": 132,
-    "replay": 122,
-    "integrity_after": 1342,
-    "negative_gate": 40,
-    "rollback": 72,
-    "restore": 3861
+    "source_migration": 19319,
+    "source_seed": 221,
+    "backup": 762,
+    "preflight": 147,
+    "integrity_before": 649,
+    "migration": 277,
+    "verify": 146,
+    "replay": 140,
+    "integrity_after": 1491,
+    "negative_gate": 41,
+    "rollback": 110,
+    "restore": 4233
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-12T15:46:51.043Z",
-    "duration_ms": 93,
+    "checked_at": "2026-08-12T20:33:24.721Z",
+    "duration_ms": 91,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
@@ -33,10 +33,10 @@
       "database_bytes": "36199447"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-WZ1gmU\\cerp-test-before-sol06.dump",
-      "bytes": 1954319,
-      "sha256": "97efcd6ac410312fe0ea5d5c61c6cdc4a2a4477e8d3f951e46cb3ae454518eca",
-      "free_bytes": 427947581440
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-9UCmRa\\cerp-test-before-sol06.dump",
+      "bytes": 1954339,
+      "sha256": "ac0e6f9884f6296c408af4cc0146f322f99501afb80a1e823c637f9dfc4cfd82",
+      "free_bytes": 433570611200
     },
     "ledger": {
       "applied": 140,
@@ -47,7 +47,8 @@
         "20260811_ged_antivirus_quarantine.sql",
         "20260811_margin_traceability_0002.sql",
         "20260811_production_readiness_center.sql",
-        "20260812_commercial_reliability_sol17.sql"
+        "20260812_commercial_reliability_sol17.sql",
+        "20260812_procurement_reliability_sol18.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
@@ -430,12 +431,13 @@
         "20260811_ged_antivirus_quarantine.sql",
         "20260811_margin_traceability_0002.sql",
         "20260811_production_readiness_center.sql",
-        "20260812_commercial_reliability_sol17.sql"
+        "20260812_commercial_reliability_sol17.sql",
+        "20260812_procurement_reliability_sol18.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
     },
-    "fingerprint": "d33b4e782dab383bc42a7a6d32f5b842080fb9e800d2bc27c415598bdfe1f00f"
+    "fingerprint": "95604517cb6cd91ff263ce0dce1ffeabd091c7fa45e9151c6f7c09761a635f09"
   },
   "replay": {
     "applied_zero": true,
@@ -443,8 +445,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-12T15:46:53.509Z",
-    "duration_ms": 1328,
+    "checked_at": "2026-08-12T20:33:27.430Z",
+    "duration_ms": 1476,
     "table_counts": {
       "admin_account_invitations": "0",
       "admin_user_provisioning_migration_state": "12",
@@ -501,7 +503,7 @@
       "centres_frais": "1",
       "cerp_patch_20260804_stock_units": "3",
       "cerp_patch_20260811_base_unit_repair": "1",
-      "cerp_schema_migrations": "147",
+      "cerp_schema_migrations": "148",
       "chat_conversation_participants": "0",
       "chat_conversations": "0",
       "chat_messages": "0",
@@ -688,6 +690,10 @@
       "planning_events": "0",
       "planning_surface_usage_daily": "0",
       "postes": "1",
+      "procurement_anomaly_actions": "0",
+      "procurement_command_receipts": "0",
+      "procurement_policy_versions": "0",
+      "procurement_promised_date_events": "0",
       "production_activity_categories": "15",
       "production_cost_center_rates": "1",
       "production_devices": "0",
@@ -815,7 +821,7 @@
       "users": "7",
       "warehouses": "4"
     },
-    "table_count": 368,
+    "table_count": 372,
     "unvalidated_constraints": [
       {
         "table_name": "avoir",
@@ -887,7 +893,7 @@
         "groups": 0
       }
     ],
-    "foreign_key_count": 1064,
+    "foreign_key_count": 1072,
     "orphans": [],
     "readiness": [
       {
@@ -899,7 +905,7 @@
         "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-12T15:46:52.182Z",
+        "freshness_at": "2026-08-12T20:33:25.955Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -916,7 +922,7 @@
         "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-12T15:46:52.182Z",
+        "freshness_at": "2026-08-12T20:33:25.955Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -934,7 +940,7 @@
         "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-12T15:46:52.182Z",
+        "freshness_at": "2026-08-12T20:33:25.955Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -960,7 +966,7 @@
         "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-12T15:46:52.182Z",
+        "freshness_at": "2026-08-12T20:33:25.955Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -977,7 +983,7 @@
         "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-12T15:46:52.182Z",
+        "freshness_at": "2026-08-12T20:33:25.955Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -995,7 +1001,7 @@
         "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-12T15:46:52.182Z",
+        "freshness_at": "2026-08-12T20:33:25.955Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1015,7 +1021,7 @@
         "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-12T15:46:52.182Z",
+        "freshness_at": "2026-08-12T20:33:25.955Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1033,7 +1039,7 @@
         "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-12T15:46:52.182Z",
+        "freshness_at": "2026-08-12T20:33:25.955Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1059,7 +1065,7 @@
         "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-12T15:46:52.182Z",
+        "freshness_at": "2026-08-12T20:33:25.955Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1077,7 +1083,7 @@
         "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-12T15:46:52.182Z",
+        "freshness_at": "2026-08-12T20:33:25.955Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1096,7 +1102,7 @@
         "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-12T15:46:52.182Z",
+        "freshness_at": "2026-08-12T20:33:25.955Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1134,7 +1140,7 @@
         "period_start": "2026-08-11T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-12T15:46:52.182Z",
+        "freshness_at": "2026-08-12T20:33:25.955Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1153,12 +1159,12 @@
       }
     ],
     "ledger": {
-      "applied": 147,
+      "applied": 148,
       "pending": [],
       "checksum_mismatches": [],
       "unknown_applied": []
     },
-    "fingerprint": "dea7aa51eb37205fc5be7dc0008dd578d6fa9f9f9b1854500524eb378534e746"
+    "fingerprint": "1ab4a4968aa33529f650a49dc2ce225be064cce0262108aeb4dd1534ba9c07a1"
   },
   "negative_gate": {
     "status": "passed",
@@ -1189,11 +1195,12 @@
     "function_v2_removed": true,
     "margin_traceability_removed": true,
     "commercial_reliability_removed": true,
+    "procurement_reliability_removed": true,
     "trigger_removed": true
   },
   "restore": {
     "status": "passed",
-    "fingerprint": "d33b4e782dab383bc42a7a6d32f5b842080fb9e800d2bc27c415598bdfe1f00f",
+    "fingerprint": "95604517cb6cd91ff263ce0dce1ffeabd091c7fa45e9151c6f7c09761a635f09",
     "table_counts_equal": true,
     "ledger": {
       "applied": 140,
@@ -1204,11 +1211,12 @@
         "20260811_ged_antivirus_quarantine.sql",
         "20260811_margin_traceability_0002.sql",
         "20260811_production_readiness_center.sql",
-        "20260812_commercial_reliability_sol17.sql"
+        "20260812_commercial_reliability_sol17.sql",
+        "20260812_procurement_reliability_sol18.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-12T15:46:57.637Z"
+  "completed_at": "2026-08-12T20:33:32.002Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,33 +1,33 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-12T15:46:57.637Z
+- Exécutée : 2026-08-12T20:33:32.002Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 - Base source : cerp_test, 36199447 octets
-- Sauvegarde : 1954319 octets, SHA-256 `97efcd6ac410312fe0ea5d5c61c6cdc4a2a4477e8d3f951e46cb3ae454518eca`
-- Patches avant/après : 140 / 147
+- Sauvegarde : 1954339 octets, SHA-256 `ac0e6f9884f6296c408af4cc0146f322f99501afb80a1e823c637f9dfc4cfd82`
+- Patches avant/après : 140 / 148
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
 - Refus métier négatif : SQLSTATE P2606
 - Rollback test-only : passed
 - Restauration vers base neuve : passed
-- Empreinte source/restaurée : `d33b4e782dab383bc42a7a6d32f5b842080fb9e800d2bc27c415598bdfe1f00f` / `d33b4e782dab383bc42a7a6d32f5b842080fb9e800d2bc27c415598bdfe1f00f`
+- Empreinte source/restaurée : `95604517cb6cd91ff263ce0dce1ffeabd091c7fa45e9151c6f7c09761a635f09` / `95604517cb6cd91ff263ce0dce1ffeabd091c7fa45e9151c6f7c09761a635f09`
 
 ## Durées réelles
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 18274 |
-| source_seed | 189 |
-| backup | 728 |
-| preflight | 162 |
-| integrity_before | 642 |
-| migration | 223 |
-| verify | 132 |
-| replay | 122 |
-| integrity_after | 1342 |
-| negative_gate | 40 |
-| rollback | 72 |
-| restore | 3861 |
+| source_migration | 19319 |
+| source_seed | 221 |
+| backup | 762 |
+| preflight | 147 |
+| integrity_before | 649 |
+| migration | 277 |
+| verify | 146 |
+| replay | 140 |
+| integrity_after | 1491 |
+| negative_gate | 41 |
+| rollback | 110 |
+| restore | 4233 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -13,6 +13,7 @@ const SOL06_PATCH = "20260810_system_reference_data_readiness.sql";
 const PRODUCTION_READINESS_PATCH = "20260811_production_readiness_center.sql";
 const MARGIN_TRACEABILITY_PATCH = "20260811_margin_traceability_0002.sql";
 const COMMERCIAL_RELIABILITY_PATCH = "20260812_commercial_reliability_sol17.sql";
+const PROCUREMENT_RELIABILITY_PATCH = "20260812_procurement_reliability_sol18.sql";
 const SOL06_SUPPORT = path.join(SUPPORT_DIR, "20260810_system_reference_data_readiness");
 const POSTGRES_IMAGE = "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229";
 const DEFAULT_REPORT_DIR = path.join(ROOT, "docs", "release");
@@ -443,6 +444,13 @@ async function proveRollback(databaseUrl) {
   await client.connect();
   try {
     await client.query("SET cerp.migration_rehearsal = 'on'");
+    const procurementReliabilityRollback = patchSupportSql(PROCUREMENT_RELIABILITY_PATCH, "rollback");
+    const procurementReliabilityObject = await client.query(
+      "SELECT to_regclass('public.procurement_promised_date_events') IS NOT NULL AS present"
+    );
+    if (procurementReliabilityRollback && procurementReliabilityObject.rows[0].present) {
+      await runSqlFile(client, procurementReliabilityRollback);
+    }
     const commercialReliabilityRollback = patchSupportSql(COMMERCIAL_RELIABILITY_PATCH, "rollback");
     const commercialReliabilityObject = await client.query(
       "SELECT to_regclass('public.commercial_quote_events') IS NOT NULL AS present"
@@ -483,10 +491,17 @@ async function proveRollback(databaseUrl) {
                 AND to_regclass('public.commercial_command_receipts') IS NULL
                 AND to_regprocedure('public.fn_commercial_evidence_append_only()') IS NULL
                 AS commercial_reliability_removed,
+              to_regclass('public.procurement_promised_date_events') IS NULL
+                AND to_regclass('public.procurement_anomaly_actions') IS NULL
+                AND to_regclass('public.procurement_policy_versions') IS NULL
+                AND to_regclass('public.procurement_command_receipts') IS NULL
+                AND to_regprocedure('public.fn_procurement_evidence_append_only()') IS NULL
+                AS procurement_reliability_removed,
               NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname='trg_stock_reference_readiness_2606') AS trigger_removed`
     );
     if (!objects.rows[0].function_removed || !objects.rows[0].function_v2_removed
         || !objects.rows[0].margin_traceability_removed || !objects.rows[0].commercial_reliability_removed
+        || !objects.rows[0].procurement_reliability_removed
         || !objects.rows[0].trigger_removed) {
       fail("rollback left SOL-06 objects behind");
     }
@@ -691,6 +706,7 @@ module.exports = {
   SOL06_PATCH,
   MARGIN_TRACEABILITY_PATCH,
   COMMERCIAL_RELIABILITY_PATCH,
+  PROCUREMENT_RELIABILITY_PATCH,
   expectedRehearsalPatches,
   inventory,
   inventoryMarkdown,

--- a/src/__tests__/procurement-reliability-sol18.migration-guards.test.ts
+++ b/src/__tests__/procurement-reliability-sol18.migration-guards.test.ts
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const patch = fs.readFileSync(path.resolve(process.cwd(), "db/patches/20260812_procurement_reliability_sol18.sql"), "utf8");
+const preflight = fs.readFileSync(path.resolve(process.cwd(), "db/patches/support/20260812_procurement_reliability_sol18.preflight.sql"), "utf8");
+const verify = fs.readFileSync(path.resolve(process.cwd(), "db/patches/support/20260812_procurement_reliability_sol18.verify.sql"), "utf8");
+const rollback = fs.readFileSync(path.resolve(process.cwd(), "db/patches/support/20260812_procurement_reliability_sol18.rollback.sql"), "utf8");
+const releaseGate = fs.readFileSync(path.resolve(process.cwd(), "scripts/migrations/release-gate.js"), "utf8");
+
+describe("SOL-18 procurement migration guards", () => {
+  it("creates append-only promise, policy and idempotency evidence", () => {
+    expect(patch).toContain("CREATE TABLE public.procurement_promised_date_events");
+    expect(patch).toContain("CREATE TABLE public.procurement_policy_versions");
+    expect(patch).toContain("CREATE TABLE public.procurement_command_receipts");
+    expect(patch).toContain("procurement_promises_append_only");
+    expect(patch).toContain("procurement_policies_append_only");
+    expect(patch).toContain("reason_code = 'SUPPLIER_ACKNOWLEDGEMENT' OR previous_date IS DISTINCT FROM promised_date");
+  });
+
+  it("does not fabricate historical promises, invoices, returns or credits", () => {
+    expect(patch).not.toMatch(/INSERT\s+INTO\s+public\.procurement_promised_date_events\s+SELECT/i);
+    expect(patch).not.toMatch(/supplier_invoice|facture_fournisseur|supplier_return/i);
+  });
+
+  it("ships explicit preflight, verification and guarded rollback", () => {
+    expect(preflight).toContain("orders_present");
+    expect(preflight).toContain("verified pg_dump backup");
+    expect(verify).toContain("promise_history_valid");
+    expect(verify).toContain("policy_versions_unique");
+    expect(rollback).toContain("rollback refused");
+    expect(rollback).toContain("restore the pre-migration backup into a fresh database");
+    expect(releaseGate).toContain('const PROCUREMENT_RELIABILITY_PATCH = "20260812_procurement_reliability_sol18.sql"');
+    expect(releaseGate).toContain("procurement_reliability_removed");
+  });
+});

--- a/src/__tests__/procurement-reliability-sol18.routes.test.ts
+++ b/src/__tests__/procurement-reliability-sol18.routes.test.ts
@@ -1,0 +1,137 @@
+import { EventEmitter } from "events";
+import request from "supertest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  currentRole: { value: "Directeur" as string | null },
+  overview: vi.fn(),
+  anomaly: vi.fn(),
+  promise: vi.fn(),
+  policy: vi.fn(),
+  grantModuleAccess: { value: false },
+}));
+
+vi.mock("pg", () => {
+  const emitter = new EventEmitter();
+  const pool = { on: emitter.on.bind(emitter), query: vi.fn(), connect: vi.fn() };
+  return { Pool: vi.fn(() => pool), __emitter__: emitter };
+});
+
+vi.mock("../utils/checkNetworkDrive", () => ({ checkNetworkDrive: vi.fn(() => Promise.resolve()) }));
+vi.mock("../module/access-control/middlewares/module-access-gate", () => ({
+  moduleAccessGate: (req: { accountModuleAccess?: { userId: number; moduleKey: string; granted: boolean } }, _res: unknown, next: () => void) => {
+    if (mocks.grantModuleAccess.value) {
+      req.accountModuleAccess = { userId: 11, moduleKey: "procurement", granted: true };
+    }
+    next();
+  },
+}));
+vi.mock("../module/auth/middlewares/auth.middleware", () => ({
+  authenticateToken: (
+    req: { user?: { id: number; username: string; email: string; role: string; primary_role: string; roles: string[] } },
+    res: { status: (code: number) => { json: (body: unknown) => void } },
+    next: () => void,
+  ) => {
+    if (mocks.currentRole.value === null) {
+      res.status(401).json({ error: "UNAUTHORIZED" });
+      return;
+    }
+    req.user = {
+      id: 11,
+      username: "sol18-test",
+      email: "sol18@test.invalid",
+      role: mocks.currentRole.value,
+      primary_role: mocks.currentRole.value,
+      roles: [mocks.currentRole.value],
+    };
+    next();
+  },
+  authorizeRole: () => (_req: unknown, _res: unknown, next: () => void) => next(),
+}));
+vi.mock("../module/procurement-reliability/repository/procurement-reliability.repository", () => ({
+  repoProcurementOverview: mocks.overview,
+  repoUpsertAnomalyAction: mocks.anomaly,
+  repoRecordPromisedDate: mocks.promise,
+  repoCreateProcurementPolicy: mocks.policy,
+  repoRecordInitialPromiseEvent: vi.fn(),
+}));
+
+import app from "../config/app";
+
+const BASE = "/api/v1/procurement-reliability";
+const ORDER_ID = "11111111-1111-4111-8111-111111111111";
+const ANOMALY_KEY = "MISSING_QUANTITY:0123456789abcdef01234567";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.currentRole.value = "Directeur";
+  mocks.grantModuleAccess.value = false;
+  mocks.overview.mockResolvedValue({ contract_version: "CERP-PROCUREMENT-1.0.0", anomalies: [] });
+  mocks.anomaly.mockResolvedValue({ action: { anomaly_key: ANOMALY_KEY }, idempotent_replay: false });
+  mocks.promise.mockResolvedValue({ event_id: ORDER_ID, promised_date: "2026-08-25", idempotent_replay: false });
+  mocks.policy.mockResolvedValue({ policy_id: ORDER_ID, valid_from: "2026-09-01", idempotent_replay: false });
+});
+
+describe("SOL-18 procurement reliability RBAC and contracts", () => {
+  it("denies anonymous and unrelated roles", async () => {
+    mocks.currentRole.value = null;
+    expect((await request(app).get(`${BASE}/overview`).query({ from: "2026-01-01", to: "2026-08-12" })).status).toBe(401);
+    mocks.currentRole.value = "Operateur";
+    expect((await request(app).get(`${BASE}/overview`).query({ from: "2026-01-01", to: "2026-08-12" })).status).toBe(403);
+  });
+
+  it("returns a no-store scorecard to an authorised buyer", async () => {
+    mocks.currentRole.value = "Responsable Achats";
+    const response = await request(app).get(`${BASE}/overview`).query({
+      from: "2026-01-01",
+      to: "2026-08-12",
+      dimension: "ARTICLE",
+    });
+    expect(response.status).toBe(200);
+    expect(response.headers["cache-control"]).toContain("no-store");
+    expect(mocks.overview).toHaveBeenCalledWith(expect.objectContaining({ dimension: "ARTICLE" }), true);
+  });
+
+  it("requires idempotency for anomaly triage and promise revisions", async () => {
+    mocks.currentRole.value = "Responsable Achats";
+    const actionBody = {
+      owner_user_id: 11,
+      next_action: "Relancer le fournisseur",
+      due_date: "2026-08-13",
+      status: "IN_PROGRESS",
+    };
+    expect((await request(app).put(`${BASE}/anomalies/${ANOMALY_KEY}/action`).send(actionBody)).status).toBe(400);
+    expect((await request(app)
+      .put(`${BASE}/anomalies/${ANOMALY_KEY}/action`)
+      .set("Idempotency-Key", "sol18-action-0001")
+      .send(actionBody)).status).toBe(200);
+
+    expect((await request(app)
+      .post(`${BASE}/orders/${ORDER_ID}/promised-dates`)
+      .set("Idempotency-Key", "sol18-promise-0001")
+      .send({
+        promised_date: "2026-08-25",
+        reason_code: "SUPPLIER_DELAY",
+        note: "Retard matière confirmé",
+        expected_updated_at: "2026-08-12T10:00:00.000Z",
+      })).status).toBe(200);
+  });
+
+  it("reserves tolerance policy versions to Direction or Admin", async () => {
+    mocks.currentRole.value = "Responsable Achats";
+    const body = {
+      scope_type: "COMPANY",
+      scope_id: null,
+      valid_from: "2026-09-01",
+      price_tolerance_pct: 2,
+      over_receipt_tolerance_pct: 0,
+      lead_grace_days: 0,
+      reason: "Décision Direction",
+    };
+    expect((await request(app).post(`${BASE}/policies`).set("Idempotency-Key", "sol18-policy-0001").send(body)).status).toBe(403);
+    mocks.grantModuleAccess.value = true;
+    expect((await request(app).post(`${BASE}/policies`).set("Idempotency-Key", "sol18-policy-0002").send(body)).status).toBe(403);
+    mocks.currentRole.value = "Directeur";
+    expect((await request(app).post(`${BASE}/policies`).set("Idempotency-Key", "sol18-policy-0001").send(body)).status).toBe(201);
+  });
+});

--- a/src/module/commande-fournisseur/repository/commande-fournisseur.repository.ts
+++ b/src/module/commande-fournisseur/repository/commande-fournisseur.repository.ts
@@ -19,6 +19,7 @@ import {
   roleHasCommandeFournisseurCapability,
 } from "../domain/commande-fournisseur-rbac";
 import { computeCommandeTotaux, computeLigneTotaux, roundMoney } from "../domain/commande-fournisseur-totaux";
+import { repoRecordInitialPromiseEvent } from "../../procurement-reliability/repository/procurement-reliability.repository";
 import type {
   AccuseBodyDTO,
   AddLigneBodyDTO,
@@ -163,11 +164,12 @@ type HeaderLockRow = {
   frais_port_ht: string;
   tva_frais_pct: string;
   updated_at_token: string;
+  date_promesse: string | null;
 };
 
 async function lockHeader(tx: DbQueryer, id: string): Promise<HeaderLockRow> {
   const res = await tx.query<HeaderLockRow>(
-    `SELECT id, code, statut, fournisseur_id, devise, version_document,
+    `SELECT id, code, statut, fournisseur_id, devise, version_document, date_promesse::text,
             frais_port_ht::text, tva_frais_pct::text, updated_at::text AS updated_at_token
        FROM public.commande_fournisseur
       WHERE id = $1::uuid
@@ -1375,12 +1377,24 @@ export async function repoAccuseReception(
         WHERE id = $1::uuid`,
       [id, body.reference_fournisseur, body.date_accuse ?? null, body.date_promesse ?? null, audit.user_id]
     );
+    if (body.date_promesse) {
+      await repoRecordInitialPromiseEvent(client, {
+        orderId: id,
+        previousDate: header.date_promesse,
+        promisedDate: body.date_promesse,
+        actorUserId: audit.user_id,
+      });
+    }
     await insertTransitionRow(client, id, "ENVOYEE", "ACCUSE_RECU", null, audit.user_id);
     await insertAuditLog(client, audit, {
       action: "commandes_fournisseurs.transition.acknowledge",
       entity_type: "commande_fournisseur",
       entity_id: id,
-      details: { reference_fournisseur: body.reference_fournisseur },
+      details: {
+        reference_fournisseur: body.reference_fournisseur,
+        promised_date: body.date_promesse ?? header.date_promesse,
+        promise_versioned: Boolean(body.date_promesse),
+      },
     });
     await client.query("COMMIT");
     return { statut: "ACCUSE_RECU" };

--- a/src/module/procurement-reliability/controllers/procurement-reliability.controller.ts
+++ b/src/module/procurement-reliability/controllers/procurement-reliability.controller.ts
@@ -1,0 +1,104 @@
+import type { Request, RequestHandler } from "express";
+import type { z } from "zod";
+
+import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import { roleHasCommandeFournisseurCapability } from "../../commande-fournisseur/domain/commande-fournisseur-rbac";
+import {
+  repoCreateProcurementPolicy,
+  repoProcurementOverview,
+  repoRecordPromisedDate,
+  repoUpsertAnomalyAction,
+  type ProcurementActor,
+} from "../repository/procurement-reliability.repository";
+import {
+  anomalyActionBodySchema,
+  anomalyParamsSchema,
+  procurementOverviewQuerySchema,
+  procurementPolicyBodySchema,
+  promisedDateBodySchema,
+  purchaseOrderParamsSchema,
+} from "../validators/procurement-reliability.validators";
+
+function parse<T extends z.ZodTypeAny>(schema: T, value: unknown): z.infer<T> {
+  const parsed = schema.safeParse(value);
+  if (!parsed.success) {
+    throw new HttpError(422, "VALIDATION_ERROR", parsed.error.issues[0]?.message ?? "Demande invalide.", parsed.error.flatten());
+  }
+  return parsed.data;
+}
+
+function actorFrom(req: Request): ProcurementActor {
+  if (!req.user) throw new HttpError(401, "UNAUTHORIZED", "Authentification requise.");
+  const forwarded = req.headers["x-forwarded-for"];
+  return {
+    user_id: req.user.id,
+    role: req.user.role ?? null,
+    ip: typeof forwarded === "string" ? forwarded.split(",")[0]?.trim() ?? null : req.ip ?? null,
+    user_agent: typeof req.headers["user-agent"] === "string" ? req.headers["user-agent"] : null,
+    path: req.originalUrl ?? null,
+    page_key: typeof req.headers["x-page-key"] === "string" ? req.headers["x-page-key"] : null,
+    client_session_id: typeof req.headers["x-client-session-id"] === "string" ? req.headers["x-client-session-id"] : null,
+  };
+}
+
+function idempotencyKeyFrom(req: Request): string {
+  const key = req.headers["idempotency-key"];
+  if (typeof key !== "string" || key.trim().length < 8 || key.trim().length > 120) {
+    throw new HttpError(400, "IDEMPOTENCY_KEY_REQUIRED", "L'en-tête Idempotency-Key (8 à 120 caractères) est obligatoire.");
+  }
+  return key.trim();
+}
+
+export const procurementOverview: RequestHandler = async (req, res, next) => {
+  try {
+    actorFrom(req);
+    const query = parse(procurementOverviewQuerySchema, req.query);
+    const includePrices = requestHasGrantedAccountModuleAccess(req)
+      || roleHasCommandeFournisseurCapability(req.user?.role, "prices");
+    res.setHeader("Cache-Control", "no-store, private");
+    res.json(await repoProcurementOverview(query, includePrices));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateProcurementAnomalyAction: RequestHandler = async (req, res, next) => {
+  try {
+    const { anomalyKey } = parse(anomalyParamsSchema, req.params);
+    res.json(await repoUpsertAnomalyAction({
+      anomalyKey,
+      input: parse(anomalyActionBodySchema, req.body),
+      actor: actorFrom(req),
+      idempotencyKey: idempotencyKeyFrom(req),
+    }));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const reviseProcurementPromise: RequestHandler = async (req, res, next) => {
+  try {
+    const { id } = parse(purchaseOrderParamsSchema, req.params);
+    res.json(await repoRecordPromisedDate({
+      orderId: id,
+      input: parse(promisedDateBodySchema, req.body),
+      actor: actorFrom(req),
+      idempotencyKey: idempotencyKeyFrom(req),
+    }));
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const createProcurementPolicy: RequestHandler = async (req, res, next) => {
+  try {
+    res.status(201).json(await repoCreateProcurementPolicy({
+      input: parse(procurementPolicyBodySchema, req.body),
+      actor: actorFrom(req),
+      idempotencyKey: idempotencyKeyFrom(req),
+    }));
+  } catch (error) {
+    next(error);
+  }
+};

--- a/src/module/procurement-reliability/domain/procurement-reliability.test.ts
+++ b/src/module/procurement-reliability/domain/procurement-reliability.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  leadTimeVariabilityDays,
+  normalizeReceiptQuantity,
+  rejectionRatePct,
+  supplierOtdPct,
+  weightedPriceVariancePct,
+} from "./procurement-reliability";
+
+describe("SOL-18 procurement KPI formulas", () => {
+  it("calculates OTD on the due-commitment cohort without fabricating an empty rate", () => {
+    expect(supplierOtdPct(8, 10)).toBe(80);
+    expect(supplierOtdPct(0, 0)).toBeNull();
+    expect(supplierOtdPct(11, 10)).toBeNull();
+  });
+
+  it("calculates population lead-time variability and requires two observations", () => {
+    expect(leadTimeVariabilityDays([8, 10, 12])).toBe(1.63);
+    expect(leadTimeVariabilityDays([8])).toBeNull();
+  });
+
+  it("calculates weighted price variance and rejection rate from explicit denominators", () => {
+    expect(weightedPriceVariancePct({ orderedAmount: 1_000, invoicedAmount: 1_050 })).toBe(5);
+    expect(weightedPriceVariancePct({ orderedAmount: 0, invoicedAmount: 0 })).toBeNull();
+    expect(rejectionRatePct(2, 40)).toBe(5);
+    expect(rejectionRatePct(0, 0)).toBeNull();
+  });
+
+  it("normalizes multiple units only with an explicit conversion factor", () => {
+    expect(normalizeReceiptQuantity({
+      receiptQty: 12,
+      receiptUnit: "m",
+      purchaseUnit: "m",
+      stockUnit: "mm",
+      stockUnitsPerPurchaseUnit: 1_000,
+    })).toEqual({ status: "EXACT", purchaseQty: 12 });
+    expect(normalizeReceiptQuantity({
+      receiptQty: 12_000,
+      receiptUnit: "mm",
+      purchaseUnit: "m",
+      stockUnit: "mm",
+      stockUnitsPerPurchaseUnit: 1_000,
+    })).toEqual({ status: "CONVERTED", purchaseQty: 12 });
+    expect(normalizeReceiptQuantity({
+      receiptQty: 12,
+      receiptUnit: "kg",
+      purchaseUnit: "m",
+      stockUnit: "mm",
+      stockUnitsPerPurchaseUnit: 1_000,
+    })).toEqual({ status: "UNCONVERTIBLE", purchaseQty: null });
+  });
+});

--- a/src/module/procurement-reliability/domain/procurement-reliability.ts
+++ b/src/module/procurement-reliability/domain/procurement-reliability.ts
@@ -1,0 +1,117 @@
+import crypto from "node:crypto";
+
+export const PROCUREMENT_CONTRACT_VERSION = "CERP-PROCUREMENT-1.0.0";
+export const PROCUREMENT_TIMEZONE = "Europe/Paris";
+
+export const PROCUREMENT_PROMISE_REASON_CODES = [
+  "SUPPLIER_ACKNOWLEDGEMENT",
+  "SUPPLIER_DELAY",
+  "SUPPLIER_ADVANCE",
+  "PARTIAL_SHIPMENT",
+  "ORDER_CORRECTION",
+  "OTHER",
+] as const;
+
+export const PROCUREMENT_ANOMALY_STATUSES = ["OPEN", "IN_PROGRESS", "RESOLVED", "DISMISSED"] as const;
+export const PROCUREMENT_POLICY_SCOPE_TYPES = ["COMPANY", "SUPPLIER", "ARTICLE", "FAMILY"] as const;
+
+export type ProcurementReliability = "ESTIMATED" | "PARTIAL" | "ACTUAL" | "UNAVAILABLE";
+
+export function roundMetric(value: number, decimals = 2): number {
+  const factor = 10 ** decimals;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+}
+
+export function supplierOtdPct(onTimeCommitments: number, dueCommitments: number): number | null {
+  if (!Number.isFinite(onTimeCommitments) || !Number.isFinite(dueCommitments)) return null;
+  if (onTimeCommitments < 0 || dueCommitments <= 0 || onTimeCommitments > dueCommitments) return null;
+  return roundMetric((onTimeCommitments / dueCommitments) * 100, 2);
+}
+
+/** Population standard deviation, expressed in calendar days. */
+export function leadTimeVariabilityDays(values: readonly number[]): number | null {
+  const finite = values.filter((value) => Number.isFinite(value) && value >= 0);
+  if (finite.length < 2) return null;
+  const mean = finite.reduce((sum, value) => sum + value, 0) / finite.length;
+  const variance = finite.reduce((sum, value) => sum + (value - mean) ** 2, 0) / finite.length;
+  return roundMetric(Math.sqrt(variance), 2);
+}
+
+export function weightedPriceVariancePct(input: {
+  orderedAmount: number;
+  invoicedAmount: number;
+}): number | null {
+  if (!Number.isFinite(input.orderedAmount) || !Number.isFinite(input.invoicedAmount)) return null;
+  if (input.orderedAmount <= 0 || input.invoicedAmount < 0) return null;
+  return roundMetric(((input.invoicedAmount - input.orderedAmount) / input.orderedAmount) * 100, 2);
+}
+
+export function rejectionRatePct(rejectedQty: number, inspectedQty: number): number | null {
+  if (!Number.isFinite(rejectedQty) || !Number.isFinite(inspectedQty)) return null;
+  if (rejectedQty < 0 || inspectedQty <= 0 || rejectedQty > inspectedQty) return null;
+  return roundMetric((rejectedQty / inspectedQty) * 100, 2);
+}
+
+export function calendarDaysBetween(from: string, to: string): number | null {
+  const start = Date.parse(`${from.slice(0, 10)}T00:00:00Z`);
+  const end = Date.parse(`${to.slice(0, 10)}T00:00:00Z`);
+  if (!Number.isFinite(start) || !Number.isFinite(end) || end < start) return null;
+  return Math.floor((end - start) / 86_400_000);
+}
+
+export type UnitNormalization =
+  | { status: "EXACT" | "CONVERTED"; purchaseQty: number }
+  | { status: "UNCONVERTIBLE"; purchaseQty: null };
+
+/**
+ * A receipt can contribute only when its unit is the purchase unit, or when the
+ * order stores an explicit stock-units-per-purchase-unit coefficient.
+ */
+export function normalizeReceiptQuantity(input: {
+  receiptQty: number;
+  receiptUnit: string | null;
+  purchaseUnit: string | null;
+  stockUnit: string | null;
+  stockUnitsPerPurchaseUnit: number | null;
+}): UnitNormalization {
+  if (!Number.isFinite(input.receiptQty) || input.receiptQty < 0) {
+    return { status: "UNCONVERTIBLE", purchaseQty: null };
+  }
+  const receiptUnit = input.receiptUnit?.trim().toLowerCase() ?? null;
+  const purchaseUnit = input.purchaseUnit?.trim().toLowerCase() ?? null;
+  const stockUnit = input.stockUnit?.trim().toLowerCase() ?? null;
+  if (receiptUnit === purchaseUnit || (receiptUnit === null && purchaseUnit === null)) {
+    return { status: "EXACT", purchaseQty: input.receiptQty };
+  }
+  if (
+    receiptUnit !== null &&
+    receiptUnit === stockUnit &&
+    input.stockUnitsPerPurchaseUnit !== null &&
+    Number.isFinite(input.stockUnitsPerPurchaseUnit) &&
+    input.stockUnitsPerPurchaseUnit > 0
+  ) {
+    return {
+      status: "CONVERTED",
+      purchaseQty: roundMetric(input.receiptQty / input.stockUnitsPerPurchaseUnit, 6),
+    };
+  }
+  return { status: "UNCONVERTIBLE", purchaseQty: null };
+}
+
+function stableStringify(value: unknown): string {
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableStringify).join(",")}]`;
+  return `{${Object.entries(value as Record<string, unknown>)
+    .filter(([, child]) => child !== undefined)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, child]) => `${JSON.stringify(key)}:${stableStringify(child)}`)
+    .join(",")}}`;
+}
+
+export function procurementPayloadHash(value: unknown): string {
+  return crypto.createHash("sha256").update(stableStringify(value), "utf8").digest("hex");
+}
+
+export function anomalyKey(kind: string, entityId: string): string {
+  return `${kind}:${crypto.createHash("sha256").update(entityId, "utf8").digest("hex").slice(0, 24)}`;
+}

--- a/src/module/procurement-reliability/repository/procurement-reliability.repository.test.ts
+++ b/src/module/procurement-reliability/repository/procurement-reliability.repository.test.ts
@@ -1,0 +1,164 @@
+import type { PoolClient } from "pg";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({ connect: vi.fn(), audit: vi.fn() }));
+
+vi.mock("../../../config/database", () => ({
+  default: { connect: mocks.connect, query: vi.fn() },
+}));
+vi.mock("../../audit-logs/repository/audit-logs.repository", () => ({ repoInsertAuditLog: mocks.audit }));
+
+import { procurementPayloadHash } from "../domain/procurement-reliability";
+import {
+  repoRecordInitialPromiseEvent,
+  repoRecordPromisedDate,
+  repoUpsertAnomalyAction,
+} from "./procurement-reliability.repository";
+
+const actor = {
+  user_id: 17,
+  role: "Responsable Achats",
+  ip: "127.0.0.1",
+  user_agent: "vitest",
+  path: "/procurement-reliability",
+  page_key: "procurement-reliability",
+  client_session_id: "sol18",
+};
+
+function promiseInput() {
+  return {
+    promised_date: "2026-08-25",
+    reason_code: "SUPPLIER_DELAY" as const,
+    note: "Retard matière confirmé",
+    expected_updated_at: "2026-08-12T10:00:00.000Z",
+  };
+}
+
+function createPromiseClient(receipt: { request_hash: string; response_snapshot: Record<string, unknown> } | null = null) {
+  const query = vi.fn(async (sql: unknown) => {
+    const statement = String(sql);
+    if (statement.includes("AS installed")) return { rows: [{ installed: true }] };
+    if (statement.includes("FROM public.procurement_command_receipts")) return { rows: receipt ? [receipt] : [] };
+    if (statement.includes("FROM public.commande_fournisseur WHERE")) {
+      return { rows: [{ statut: "ACCUSE_RECU", updated_at: "2026-08-12T10:00:00.000Z", date_promesse: "2026-08-20" }] };
+    }
+    if (statement.includes("INSERT INTO public.procurement_promised_date_events")) {
+      return { rows: [{ id: "11111111-1111-4111-8111-111111111111", created_at: "2026-08-12T10:01:00.000Z" }] };
+    }
+    return { rows: [], rowCount: 1 };
+  });
+  return { query, release: vi.fn() } as unknown as PoolClient;
+}
+
+describe("SOL-18 procurement write transactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.audit.mockResolvedValue({ id: "audit-sol18" });
+  });
+
+  it("versions a changed supplier promise, audits it and saves an idempotency receipt", async () => {
+    const client = createPromiseClient();
+    mocks.connect.mockResolvedValue(client);
+    await expect(repoRecordPromisedDate({
+      orderId: "22222222-2222-4222-8222-222222222222",
+      input: promiseInput(),
+      actor,
+      idempotencyKey: "sol18-promise-0001",
+    })).resolves.toMatchObject({ promised_date: "2026-08-25", idempotent_replay: false });
+    const query = client.query as ReturnType<typeof vi.fn>;
+    expect(query.mock.calls.filter(([sql]) => String(sql).includes("UPDATE public.commande_fournisseur SET date_promesse"))).toHaveLength(1);
+    expect(query.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.procurement_promised_date_events"))).toHaveLength(1);
+    expect(query.mock.calls.filter(([sql]) => String(sql).includes("INSERT INTO public.procurement_command_receipts"))).toHaveLength(1);
+    expect(mocks.audit).toHaveBeenCalledOnce();
+    expect(query).toHaveBeenCalledWith("COMMIT");
+  });
+
+  it("records the initial supplier promise inside the acknowledgement transaction", async () => {
+    const query = vi.fn().mockResolvedValue({ rowCount: 1, rows: [] });
+    const client = { query } as unknown as PoolClient;
+
+    await repoRecordInitialPromiseEvent(client, {
+      orderId: "22222222-2222-4222-8222-222222222222",
+      previousDate: null,
+      promisedDate: "2026-08-20",
+      actorUserId: 17,
+    });
+
+    expect(query).toHaveBeenCalledOnce();
+    expect(String(query.mock.calls[0][0])).toContain("SUPPLIER_ACKNOWLEDGEMENT");
+    expect(query.mock.calls[0][1]).toEqual([
+      "22222222-2222-4222-8222-222222222222",
+      null,
+      "2026-08-20",
+      17,
+    ]);
+  });
+
+  it("replays a promise command without a second update or event", async () => {
+    const input = promiseInput();
+    const orderId = "22222222-2222-4222-8222-222222222222";
+    const client = createPromiseClient({
+      request_hash: procurementPayloadHash({ order_id: orderId, ...input }),
+      response_snapshot: { event_id: "evt", promised_date: input.promised_date, idempotent_replay: false },
+    });
+    mocks.connect.mockResolvedValue(client);
+    await expect(repoRecordPromisedDate({ orderId, input, actor, idempotencyKey: "sol18-promise-replay" }))
+      .resolves.toMatchObject({ idempotent_replay: true });
+    const query = client.query as ReturnType<typeof vi.fn>;
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("UPDATE public.commande_fournisseur"))).toBe(false);
+    expect(mocks.audit).not.toHaveBeenCalled();
+  });
+
+  it("rejects a concurrent anomaly edit before overwriting another buyer", async () => {
+    const query = vi.fn(async (sql: unknown) => {
+      const statement = String(sql);
+      if (statement.includes("AS installed")) return { rows: [{ installed: true }] };
+      if (statement.includes("FROM public.procurement_command_receipts")) return { rows: [] };
+      if (statement.includes("FROM public.procurement_anomaly_actions")) {
+        return { rows: [{ updated_at: "2026-08-12T11:00:00.000Z" }] };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+    const client = { query, release: vi.fn() } as unknown as PoolClient;
+    mocks.connect.mockResolvedValue(client);
+    await expect(repoUpsertAnomalyAction({
+      anomalyKey: "MISSING_QUANTITY:0123456789abcdef01234567",
+      input: {
+        owner_user_id: 17,
+        next_action: "Relancer le fournisseur",
+        due_date: "2026-08-13",
+        status: "IN_PROGRESS",
+        expected_updated_at: "2026-08-12T10:00:00.000Z",
+      },
+      actor,
+      idempotencyKey: "sol18-action-concurrent",
+    })).rejects.toMatchObject({ status: 409, code: "CONCURRENT_MODIFICATION" });
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("INSERT INTO public.procurement_anomaly_actions"))).toBe(false);
+    expect(query).toHaveBeenCalledWith("ROLLBACK");
+  });
+
+  it("uses the line token when revising a line promise", async () => {
+    const query = vi.fn(async (sql: unknown) => {
+      const statement = String(sql);
+      if (statement.includes("AS installed")) return { rows: [{ installed: true }] };
+      if (statement.includes("FROM public.procurement_command_receipts")) return { rows: [] };
+      if (statement.includes("FROM public.commande_fournisseur WHERE")) {
+        return { rows: [{ statut: "ACCUSE_RECU", updated_at: "2026-08-12T10:00:00.000Z", date_promesse: "2026-08-20" }] };
+      }
+      if (statement.includes("FROM public.commande_fournisseur_ligne")) {
+        return { rows: [{ date_promesse: "2026-08-21", updated_at: "2026-08-12T10:05:00.000Z" }] };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+    mocks.connect.mockResolvedValue({ query, release: vi.fn() } as unknown as PoolClient);
+
+    await expect(repoRecordPromisedDate({
+      orderId: "22222222-2222-4222-8222-222222222222",
+      input: { ...promiseInput(), line_id: "33333333-3333-4333-8333-333333333333" },
+      actor,
+      idempotencyKey: "sol18-line-promise-concurrent",
+    })).rejects.toMatchObject({ status: 409, code: "CONCURRENT_MODIFICATION" });
+    expect(query.mock.calls.some(([sql]) => String(sql).includes("UPDATE public.commande_fournisseur_ligne"))).toBe(false);
+    expect(query).toHaveBeenCalledWith("ROLLBACK");
+  });
+});

--- a/src/module/procurement-reliability/repository/procurement-reliability.repository.ts
+++ b/src/module/procurement-reliability/repository/procurement-reliability.repository.ts
@@ -1,0 +1,963 @@
+import type { PoolClient } from "pg";
+
+import db from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
+import {
+  PROCUREMENT_CONTRACT_VERSION,
+  PROCUREMENT_TIMEZONE,
+  anomalyKey,
+  calendarDaysBetween,
+  leadTimeVariabilityDays,
+  normalizeReceiptQuantity,
+  procurementPayloadHash,
+  rejectionRatePct,
+  roundMetric,
+  supplierOtdPct,
+  type ProcurementReliability,
+} from "../domain/procurement-reliability";
+import type {
+  AnomalyActionBodyDTO,
+  ProcurementOverviewQueryDTO,
+  ProcurementPolicyBodyDTO,
+  PromisedDateBodyDTO,
+} from "../validators/procurement-reliability.validators";
+
+type Queryer = Pick<PoolClient, "query">;
+
+export type ProcurementActor = {
+  user_id: number;
+  role: string | null;
+  ip: string | null;
+  user_agent: string | null;
+  path: string | null;
+  page_key: string | null;
+  client_session_id: string | null;
+};
+
+type ProcurementCommandAction = "ANOMALY_ACTION" | "PROMISED_DATE" | "POLICY_VERSION";
+
+type LineRow = {
+  line_id: string;
+  order_id: string;
+  order_code: string;
+  order_status: string;
+  supplier_id: string;
+  supplier_code: string | null;
+  supplier_name: string | null;
+  article_id: string | null;
+  article_code: string | null;
+  article_name: string | null;
+  family_code: string | null;
+  designation: string;
+  purchase_unit: string | null;
+  stock_unit: string | null;
+  conversion_factor: number | null;
+  ordered_qty: number;
+  cancelled_qty: number;
+  promised_date: string;
+  promised_date_source: "LINE" | "HEADER";
+  sent_date: string | null;
+  expected_documents: string[];
+  quality_requirements: Array<{ type?: unknown; obligatoire?: unknown }>;
+  updated_at: string;
+  price_tolerance_pct: number | null;
+  over_receipt_tolerance_pct: number;
+  lead_grace_days: number;
+  policy_source: string | null;
+};
+
+type ReceiptRow = {
+  receipt_line_id: string;
+  line_id: string;
+  receipt_id: string;
+  receipt_no: string;
+  receipt_status: string;
+  receipt_date: string;
+  qty_received: number;
+  receipt_unit: string | null;
+  lot_id: string | null;
+  lot_code: string | null;
+  lot_status: string | null;
+  inspection_id: string | null;
+  inspection_status: string | null;
+  inspection_decision: string | null;
+  inspection_decided_at: string | null;
+  document_types: string[];
+  updated_at: string;
+};
+
+type PromiseEventRow = {
+  id: string;
+  line_id: string | null;
+  previous_date: string | null;
+  promised_date: string;
+  reason_code: string;
+  note: string | null;
+  actor_user_id: number;
+  actor_name: string | null;
+  created_at: string;
+};
+
+type ActionRow = {
+  anomaly_key: string;
+  owner_user_id: number | null;
+  owner_name: string | null;
+  next_action: string;
+  due_date: string;
+  status: "OPEN" | "IN_PROGRESS" | "RESOLVED" | "DISMISSED";
+  resolution_note: string | null;
+  updated_at: string;
+};
+
+type NormalizedReceipt = ReceiptRow & {
+  purchase_qty: number | null;
+  normalization: "EXACT" | "CONVERTED" | "UNCONVERTIBLE";
+};
+
+type LineFact = {
+  line: LineRow;
+  receipts: NormalizedReceipt[];
+  expected_qty: number;
+  received_qty: number;
+  completion_date: string | null;
+  on_time: boolean;
+  due: boolean;
+  has_unconvertible_receipt: boolean;
+  inspected_qty: number;
+  rejected_qty: number;
+  promise_versioned: boolean;
+  promise_history: PromiseEventRow[];
+};
+
+type Metric = {
+  value: number | null;
+  definition: string;
+  unit: string;
+  period: { from: string; to: string; as_of: string };
+  source: string[];
+  freshness_at: string | null;
+  reliability: ProcurementReliability;
+  missing: string[];
+  numerator?: number;
+  denominator?: number;
+};
+
+type ProcurementAnomaly = {
+  key: string;
+  kind: string;
+  severity: "P1" | "P2" | "P3";
+  supplier_id: string;
+  order_id: string;
+  order_code: string;
+  line_id: string;
+  label: string;
+  evidence: Record<string, unknown>;
+  recommended_action: string;
+  suggested_due_date: string;
+  action: ActionRow | null;
+};
+
+function numberOrNull(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function requiredNonNegativeNumber(value: unknown, field: string): number {
+  const parsed = numberOrNull(value);
+  if (parsed === null || parsed < 0) {
+    throw new HttpError(500, "PROCUREMENT_SOURCE_DATA_INVALID", `La donnée source ${field} est absente ou invalide.`);
+  }
+  return parsed;
+}
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function qualityRequirements(value: unknown): Array<{ type?: unknown; obligatoire?: unknown }> {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is { type?: unknown; obligatoire?: unknown } => item !== null && typeof item === "object");
+}
+
+function maxTimestamp(values: Array<string | null | undefined>): string | null {
+  const valid = values.filter((value): value is string => typeof value === "string" && Number.isFinite(Date.parse(value)));
+  return valid.sort((left, right) => Date.parse(right) - Date.parse(left))[0] ?? null;
+}
+
+async function ensureInstalled(queryer: Queryer = db): Promise<void> {
+  const result = await queryer.query<{ installed: boolean }>(
+    `SELECT to_regclass('public.procurement_promised_date_events') IS NOT NULL
+         AND to_regclass('public.procurement_anomaly_actions') IS NOT NULL
+         AND to_regclass('public.procurement_policy_versions') IS NOT NULL
+         AND to_regclass('public.procurement_command_receipts') IS NOT NULL AS installed`,
+  );
+  if (!result.rows[0]?.installed) {
+    throw new HttpError(503, "PROCUREMENT_RELIABILITY_NOT_INSTALLED", "Le patch SOL-18 doit être appliqué avant d'utiliser le pilotage achats.");
+  }
+}
+
+async function insertAudit(
+  tx: Queryer,
+  actor: ProcurementActor,
+  entry: { action: string; entity_type: string; entity_id: string; details: Record<string, unknown> },
+) {
+  const body: CreateAuditLogBodyDTO = {
+    event_type: "ACTION",
+    action: entry.action,
+    page_key: actor.page_key,
+    entity_type: entry.entity_type,
+    entity_id: entry.entity_id,
+    path: actor.path,
+    client_session_id: actor.client_session_id,
+    details: entry.details,
+  };
+  await repoInsertAuditLog({
+    user_id: actor.user_id,
+    body,
+    ip: actor.ip,
+    user_agent: actor.user_agent,
+    device_type: null,
+    os: null,
+    browser: null,
+    tx,
+  });
+}
+
+async function inTransaction<T>(work: (tx: PoolClient) => Promise<T>): Promise<T> {
+  const client = await db.connect();
+  try {
+    await client.query("BEGIN");
+    const value = await work(client);
+    await client.query("COMMIT");
+    return value;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function readCommandReceipt<T>(
+  tx: Queryer,
+  action: ProcurementCommandAction,
+  idempotencyKey: string,
+  requestHash: string,
+): Promise<T | null> {
+  const result = await tx.query<{ request_hash: string; response_snapshot: T }>(
+    `SELECT request_hash,response_snapshot FROM public.procurement_command_receipts
+     WHERE action=$1 AND idempotency_key=$2 FOR SHARE`,
+    [action, idempotencyKey],
+  );
+  const row = result.rows[0];
+  if (!row) return null;
+  if (row.request_hash !== requestHash) {
+    throw new HttpError(409, "IDEMPOTENCY_PAYLOAD_MISMATCH", "Cette clé d'idempotence a déjà été utilisée avec une demande différente.");
+  }
+  return { ...row.response_snapshot, idempotent_replay: true } as T;
+}
+
+async function saveCommandReceipt(
+  tx: Queryer,
+  action: ProcurementCommandAction,
+  idempotencyKey: string,
+  requestHash: string,
+  actorUserId: number,
+  response: Record<string, unknown>,
+) {
+  await tx.query(
+    `INSERT INTO public.procurement_command_receipts
+       (action,idempotency_key,request_hash,actor_user_id,response_snapshot)
+     VALUES ($1,$2,$3,$4,$5::jsonb)`,
+    [action, idempotencyKey, requestHash, actorUserId, JSON.stringify(response)],
+  );
+}
+
+async function loadLineRows(query: ProcurementOverviewQueryDTO, asOf: string): Promise<LineRow[]> {
+  const values: unknown[] = [query.from, query.to, asOf];
+  const where: string[] = [
+    `COALESCE(l.date_promesse,cf.date_promesse) BETWEEN $1::date AND LEAST($2::date,$3::date)`,
+    `l.statut_ligne='ACTIVE'`,
+    `cf.statut NOT IN ('BROUILLON','A_VALIDER','APPROUVEE','ANNULEE')`,
+  ];
+  if (query.supplier_id) {
+    values.push(query.supplier_id);
+    where.push(`cf.fournisseur_id=$${values.length}::uuid`);
+  }
+  if (query.article_id) {
+    values.push(query.article_id);
+    where.push(`l.article_id=$${values.length}::uuid`);
+  }
+  if (query.family_code) {
+    values.push(query.family_code);
+    where.push(`a.family_code=$${values.length}`);
+  }
+
+  const result = await db.query<Record<string, unknown>>(
+    `SELECT
+       l.id::text AS line_id,cf.id::text AS order_id,cf.code AS order_code,cf.statut AS order_status,
+       cf.fournisseur_id::text AS supplier_id,COALESCE(f.code,f.code_fournisseur) AS supplier_code,
+       COALESCE(f.nom,f.raison_sociale) AS supplier_name,l.article_id::text AS article_id,
+       a.code AS article_code,a.designation AS article_name,a.family_code,l.designation,
+       l.unite AS purchase_unit,l.unite_stock AS stock_unit,l.coef_conversion::float8 AS conversion_factor,
+       l.quantite::float8 AS ordered_qty,l.qty_annulee::float8 AS cancelled_qty,
+       COALESCE(l.date_promesse,cf.date_promesse)::text AS promised_date,
+       CASE WHEN l.date_promesse IS NOT NULL THEN 'LINE' ELSE 'HEADER' END AS promised_date_source,
+       cf.date_envoi::date::text AS sent_date,l.documents_attendus,l.exigences_qualite,
+       GREATEST(cf.updated_at,l.updated_at)::text AS updated_at,
+       policy.price_tolerance_pct::float8,COALESCE(policy.over_receipt_tolerance_pct,0)::float8 AS over_receipt_tolerance_pct,
+       COALESCE(policy.lead_grace_days,0)::int AS lead_grace_days,
+       CASE WHEN policy.id IS NULL THEN NULL ELSE policy.scope_type || ':' || COALESCE(policy.scope_id,'COMPANY') || ':' || policy.valid_from::text END AS policy_source
+     FROM public.commande_fournisseur_ligne l
+     JOIN public.commande_fournisseur cf ON cf.id=l.commande_id
+     JOIN public.fournisseurs f ON f.id=cf.fournisseur_id
+     LEFT JOIN public.articles a ON a.id=l.article_id
+     LEFT JOIN LATERAL (
+       SELECT p.* FROM public.procurement_policy_versions p
+       WHERE p.valid_from <= $3::date AND (
+         (p.scope_type='ARTICLE' AND p.scope_id=l.article_id::text)
+         OR (p.scope_type='SUPPLIER' AND p.scope_id=cf.fournisseur_id::text)
+         OR (p.scope_type='FAMILY' AND p.scope_id=a.family_code)
+         OR (p.scope_type='COMPANY' AND p.scope_id IS NULL)
+       )
+       ORDER BY CASE p.scope_type WHEN 'ARTICLE' THEN 1 WHEN 'SUPPLIER' THEN 2 WHEN 'FAMILY' THEN 3 ELSE 4 END,
+                p.valid_from DESC
+       LIMIT 1
+     ) policy ON TRUE
+     WHERE ${where.join(" AND ")}
+     ORDER BY COALESCE(l.date_promesse,cf.date_promesse),cf.code,l.position`,
+    values,
+  );
+
+  return result.rows.map((row) => ({
+    line_id: String(row.line_id),
+    order_id: String(row.order_id),
+    order_code: String(row.order_code),
+    order_status: String(row.order_status),
+    supplier_id: String(row.supplier_id),
+    supplier_code: typeof row.supplier_code === "string" ? row.supplier_code : null,
+    supplier_name: typeof row.supplier_name === "string" ? row.supplier_name : null,
+    article_id: typeof row.article_id === "string" ? row.article_id : null,
+    article_code: typeof row.article_code === "string" ? row.article_code : null,
+    article_name: typeof row.article_name === "string" ? row.article_name : null,
+    family_code: typeof row.family_code === "string" ? row.family_code : null,
+    designation: String(row.designation),
+    purchase_unit: typeof row.purchase_unit === "string" ? row.purchase_unit : null,
+    stock_unit: typeof row.stock_unit === "string" ? row.stock_unit : null,
+    conversion_factor: numberOrNull(row.conversion_factor),
+    ordered_qty: requiredNonNegativeNumber(row.ordered_qty, "commande_fournisseur_ligne.quantite"),
+    cancelled_qty: requiredNonNegativeNumber(row.cancelled_qty, "commande_fournisseur_ligne.qty_annulee"),
+    promised_date: String(row.promised_date),
+    promised_date_source: row.promised_date_source === "LINE" ? "LINE" : "HEADER",
+    sent_date: typeof row.sent_date === "string" ? row.sent_date : null,
+    expected_documents: stringArray(row.documents_attendus),
+    quality_requirements: qualityRequirements(row.exigences_qualite),
+    updated_at: String(row.updated_at),
+    price_tolerance_pct: numberOrNull(row.price_tolerance_pct),
+    over_receipt_tolerance_pct: requiredNonNegativeNumber(row.over_receipt_tolerance_pct, "procurement_policy_versions.over_receipt_tolerance_pct"),
+    lead_grace_days: requiredNonNegativeNumber(row.lead_grace_days, "procurement_policy_versions.lead_grace_days"),
+    policy_source: typeof row.policy_source === "string" ? row.policy_source : null,
+  }));
+}
+
+async function loadReceiptRows(lineIds: string[], asOf: string): Promise<ReceiptRow[]> {
+  if (lineIds.length === 0) return [];
+  const result = await db.query<Record<string, unknown>>(
+    `SELECT rl.id::text AS receipt_line_id,rl.commande_fournisseur_ligne_id::text AS line_id,
+            r.id::text AS receipt_id,r.reception_no,r.status AS receipt_status,r.reception_date::text,
+            rl.qty_received::float8,rl.unite AS receipt_unit,rl.lot_id::text AS lot_id,
+            lot.lot_code,lot.lot_status,ins.id::text AS inspection_id,ins.status AS inspection_status,
+            ins.decision AS inspection_decision,ins.decided_at::text AS inspection_decided_at,
+            COALESCE(array_agg(DISTINCT doc.document_type) FILTER (WHERE doc.id IS NOT NULL),ARRAY[]::text[]) AS document_types,
+            GREATEST(r.updated_at,rl.updated_at,COALESCE(ins.updated_at,'epoch'::timestamptz))::text AS updated_at
+       FROM public.reception_fournisseur_lignes rl
+       JOIN public.receptions_fournisseurs r ON r.id=rl.reception_id
+       LEFT JOIN public.lots lot ON lot.id=rl.lot_id
+       LEFT JOIN public.reception_incoming_inspections ins ON ins.reception_line_id=rl.id
+       LEFT JOIN public.reception_fournisseur_documents doc
+         ON doc.reception_id=r.id AND doc.removed_at IS NULL
+        AND (doc.reception_line_id=rl.id OR doc.reception_line_id IS NULL)
+      WHERE rl.commande_fournisseur_ligne_id=ANY($1::uuid[])
+        AND r.reception_date <= $2::date
+      GROUP BY rl.id,r.id,r.reception_no,r.status,r.reception_date,lot.lot_code,lot.lot_status,
+               ins.id,ins.status,ins.decision,ins.decided_at,ins.updated_at
+      ORDER BY r.reception_date,rl.id`,
+    [lineIds, asOf],
+  );
+  return result.rows.map((row) => ({
+    receipt_line_id: String(row.receipt_line_id),
+    line_id: String(row.line_id),
+    receipt_id: String(row.receipt_id),
+    receipt_no: String(row.reception_no),
+    receipt_status: String(row.receipt_status),
+    receipt_date: String(row.reception_date),
+    qty_received: requiredNonNegativeNumber(row.qty_received, "reception_fournisseur_lignes.qty_received"),
+    receipt_unit: typeof row.receipt_unit === "string" ? row.receipt_unit : null,
+    lot_id: typeof row.lot_id === "string" ? row.lot_id : null,
+    lot_code: typeof row.lot_code === "string" ? row.lot_code : null,
+    lot_status: typeof row.lot_status === "string" ? row.lot_status : null,
+    inspection_id: typeof row.inspection_id === "string" ? row.inspection_id : null,
+    inspection_status: typeof row.inspection_status === "string" ? row.inspection_status : null,
+    inspection_decision: typeof row.inspection_decision === "string" ? row.inspection_decision : null,
+    inspection_decided_at: typeof row.inspection_decided_at === "string" ? row.inspection_decided_at : null,
+    document_types: stringArray(row.document_types),
+    updated_at: String(row.updated_at),
+  }));
+}
+
+async function loadPromiseHistory(lines: LineRow[]): Promise<Map<string, PromiseEventRow[]>> {
+  if (lines.length === 0) return new Map();
+  const result = await db.query<PromiseEventRow & { effective_line_id: string }>(
+    `SELECT l.id::text AS effective_line_id,e.id::text,e.ligne_id::text,e.previous_date::text,
+            e.promised_date::text,e.reason_code,e.note,e.actor_user_id,
+            COALESCE(NULLIF(trim(concat_ws(' ',u.name,u.surname)),''),u.username) AS actor_name,
+            e.created_at::text
+       FROM public.commande_fournisseur_ligne l
+       JOIN public.procurement_promised_date_events e
+         ON e.commande_id=l.commande_id AND (e.ligne_id=l.id OR e.ligne_id IS NULL)
+       LEFT JOIN public.users u ON u.id=e.actor_user_id
+      WHERE l.id=ANY($1::uuid[])`,
+    [lines.map((line) => line.line_id)],
+  );
+  const histories = new Map<string, PromiseEventRow[]>();
+  for (const row of result.rows) {
+    const history = histories.get(row.effective_line_id) ?? [];
+    history.push({
+      id: row.id,
+      line_id: row.line_id,
+      previous_date: row.previous_date,
+      promised_date: row.promised_date,
+      reason_code: row.reason_code,
+      note: row.note,
+      actor_user_id: row.actor_user_id,
+      actor_name: row.actor_name,
+      created_at: row.created_at,
+    });
+    histories.set(row.effective_line_id, history);
+  }
+  for (const history of histories.values()) history.sort((left, right) => left.created_at.localeCompare(right.created_at));
+  return histories;
+}
+
+function buildFacts(lines: LineRow[], receipts: ReceiptRow[], promiseHistory: Map<string, PromiseEventRow[]>, asOf: string): LineFact[] {
+  const linesById = new Map(lines.map((line) => [line.line_id, line]));
+  const receiptsByLine = new Map<string, NormalizedReceipt[]>();
+  for (const receipt of receipts) {
+    if (receipt.receipt_status === "CANCELLED") continue;
+    const sourceLine = linesById.get(receipt.line_id);
+    const normalized = normalizeReceiptQuantity({
+      receiptQty: receipt.qty_received,
+      receiptUnit: receipt.receipt_unit,
+      purchaseUnit: sourceLine?.purchase_unit ?? null,
+      stockUnit: sourceLine?.stock_unit ?? null,
+      stockUnitsPerPurchaseUnit: sourceLine?.conversion_factor ?? null,
+    });
+    const list = receiptsByLine.get(receipt.line_id) ?? [];
+    list.push({ ...receipt, purchase_qty: normalized.purchaseQty, normalization: normalized.status });
+    receiptsByLine.set(receipt.line_id, list);
+  }
+
+  return lines.map((line) => {
+    const lineReceipts = (receiptsByLine.get(line.line_id) ?? []).sort((a, b) => a.receipt_date.localeCompare(b.receipt_date));
+    const expectedQty = Math.max(0, line.ordered_qty - line.cancelled_qty);
+    let cumulative = 0;
+    let completionDate: string | null = null;
+    for (const receipt of lineReceipts) {
+      if (receipt.purchase_qty === null) continue;
+      cumulative += receipt.purchase_qty;
+      if (completionDate === null && cumulative + 1e-9 >= expectedQty) completionDate = receipt.receipt_date;
+    }
+    const decided = lineReceipts.filter((receipt) => receipt.inspection_status === "DECIDED" && receipt.purchase_qty !== null);
+    const inspectedQty = decided.reduce((sum, receipt) => sum + (receipt.purchase_qty ?? 0), 0);
+    const rejectedQty = decided
+      .filter((receipt) => receipt.inspection_decision === "BLOQUE")
+      .reduce((sum, receipt) => sum + (receipt.purchase_qty ?? 0), 0);
+    return {
+      line,
+      receipts: lineReceipts,
+      expected_qty: expectedQty,
+      received_qty: roundMetric(cumulative, 6),
+      completion_date: completionDate,
+      on_time: completionDate !== null && completionDate <= line.promised_date,
+      due: line.promised_date <= asOf,
+      has_unconvertible_receipt: lineReceipts.some((receipt) => receipt.normalization === "UNCONVERTIBLE"),
+      inspected_qty: roundMetric(inspectedQty, 6),
+      rejected_qty: roundMetric(rejectedQty, 6),
+      promise_versioned: (promiseHistory.get(line.line_id)?.length ?? 0) > 0,
+      promise_history: promiseHistory.get(line.line_id) ?? [],
+    };
+  });
+}
+
+function metricSet(facts: LineFact[], period: Metric["period"], includePrices: boolean): Record<string, Metric> {
+  const due = facts.filter((fact) => fact.due && !fact.has_unconvertible_receipt);
+  const onTime = due.filter((fact) => fact.on_time).length;
+  const leadTimes = facts.flatMap((fact) => {
+    if (!fact.completion_date || !fact.line.sent_date || fact.has_unconvertible_receipt) return [];
+    const days = calendarDaysBetween(fact.line.sent_date, fact.completion_date);
+    return days === null ? [] : [days];
+  });
+  const inspectedQty = facts.reduce((sum, fact) => sum + fact.inspected_qty, 0);
+  const rejectedQty = facts.reduce((sum, fact) => sum + fact.rejected_qty, 0);
+  const freshness = maxTimestamp(facts.flatMap((fact) => [fact.line.updated_at, ...fact.receipts.map((receipt) => receipt.updated_at)]));
+  const unversioned = facts.filter((fact) => !fact.promise_versioned).length;
+  const unitGaps = facts.filter((fact) => fact.has_unconvertible_receipt).length;
+  const commonMissing = [
+    ...(unversioned > 0 ? [`${unversioned} promesse(s) héritée(s) sans événement SOL-18`] : []),
+    ...(unitGaps > 0 ? [`${unitGaps} ligne(s) avec unité non convertible`] : []),
+  ];
+  const actualReliability: ProcurementReliability = commonMissing.length === 0 ? "ACTUAL" : "PARTIAL";
+  return {
+    otd: {
+      value: supplierOtdPct(onTime, due.length),
+      definition: "Engagements fournisseurs arrivés à échéance et reçus intégralement au plus tard à la date promise / engagements arrivés à échéance.",
+      unit: "%",
+      period,
+      source: ["commande_fournisseur_ligne", "procurement_promised_date_events", "reception_fournisseur_lignes"],
+      freshness_at: freshness,
+      reliability: due.length === 0 ? "UNAVAILABLE" : actualReliability,
+      missing: due.length === 0 ? ["Aucun engagement arrivé à échéance sur la période"] : commonMissing,
+      numerator: onTime,
+      denominator: due.length,
+    },
+    lead_time_variability: {
+      value: leadTimeVariabilityDays(leadTimes),
+      definition: "Écart-type population du délai calendaire entre envoi de la commande et réception intégrale.",
+      unit: "jours calendaires",
+      period,
+      source: ["commande_fournisseur.date_envoi", "receptions_fournisseurs.reception_date"],
+      freshness_at: freshness,
+      reliability: leadTimes.length < 2 ? "UNAVAILABLE" : actualReliability,
+      missing: leadTimes.length < 2 ? ["Deux lignes réceptionnées avec date d'envoi sont requises"] : commonMissing,
+      denominator: leadTimes.length,
+    },
+    price_variance: {
+      value: null,
+      definition: "(Montant facturé fournisseur rapproché - montant commandé) / montant commandé, pondéré par les montants rapprochés.",
+      unit: "%",
+      period,
+      source: includePrices ? [] : ["HIDDEN_BY_RBAC"],
+      freshness_at: null,
+      reliability: "UNAVAILABLE",
+      missing: [includePrices ? "Aucune facture fournisseur ni ligne d'avoir fournisseur n'est modélisée" : "Permission prix achats requise"],
+    },
+    rejection_rate: {
+      value: rejectionRatePct(rejectedQty, inspectedQty),
+      definition: "Quantité des lignes de réception inspectées avec décision BLOQUE / quantité totale des lignes inspectées et décidées.",
+      unit: "% quantité en unité d'achat normalisée",
+      period,
+      source: ["reception_incoming_inspections", "reception_fournisseur_lignes", "lots"],
+      freshness_at: freshness,
+      reliability: inspectedQty <= 0 ? "UNAVAILABLE" : unitGaps > 0 ? "PARTIAL" : "ACTUAL",
+      missing: inspectedQty <= 0 ? ["Aucune inspection décidée sur la période"] : unitGaps > 0 ? [`${unitGaps} ligne(s) avec unité non convertible`] : [],
+      numerator: rejectedQty,
+      denominator: inspectedQty,
+    },
+  };
+}
+
+function dimensionFor(fact: LineFact, dimension: ProcurementOverviewQueryDTO["dimension"]): { key: string; label: string } {
+  if (dimension === "ARTICLE") {
+    return {
+      key: fact.line.article_id ?? `UNLINKED:${fact.line.line_id}`,
+      label: fact.line.article_code ?? fact.line.article_name ?? fact.line.designation,
+    };
+  }
+  if (dimension === "FAMILY") {
+    return { key: fact.line.family_code ?? "UNCLASSIFIED", label: fact.line.family_code ?? "Famille non renseignée" };
+  }
+  return {
+    key: fact.line.supplier_id,
+    label: fact.line.supplier_name ?? fact.line.supplier_code ?? fact.line.supplier_id,
+  };
+}
+
+function makeAnomaly(
+  fact: LineFact,
+  kind: string,
+  severity: ProcurementAnomaly["severity"],
+  label: string,
+  evidence: Record<string, unknown>,
+  recommendedAction: string,
+  suggestedDueDate: string,
+): ProcurementAnomaly {
+  return {
+    key: anomalyKey(kind, `${fact.line.line_id}:${kind}`),
+    kind,
+    severity,
+    supplier_id: fact.line.supplier_id,
+    order_id: fact.line.order_id,
+    order_code: fact.line.order_code,
+    line_id: fact.line.line_id,
+    label,
+    evidence,
+    recommended_action: recommendedAction,
+    suggested_due_date: suggestedDueDate,
+    action: null,
+  };
+}
+
+function buildAnomalies(facts: LineFact[], asOf: string): ProcurementAnomaly[] {
+  const anomalies: ProcurementAnomaly[] = [];
+  for (const fact of facts) {
+    const line = fact.line;
+    const allowedMax = fact.expected_qty * (1 + line.over_receipt_tolerance_pct / 100);
+    const remaining = roundMetric(Math.max(0, fact.expected_qty - fact.received_qty), 6);
+    if (fact.due && remaining > 0 && !fact.has_unconvertible_receipt) {
+      anomalies.push(makeAnomaly(
+        fact,
+        "MISSING_QUANTITY",
+        line.promised_date < asOf ? "P1" : "P2",
+        `${line.order_code} — quantité ${fact.received_qty > 0 ? "partiellement reçue" : "non reçue"}`,
+        { expected_qty: fact.expected_qty, received_qty: fact.received_qty, remaining_qty: remaining, unit: line.purchase_unit, promised_date: line.promised_date },
+        "Confirmer la date et la quantité du prochain envoi fournisseur.",
+        line.promised_date,
+      ));
+    }
+    if (fact.received_qty > allowedMax + 1e-9) {
+      anomalies.push(makeAnomaly(
+        fact,
+        "EXCESS_QUANTITY",
+        "P1",
+        `${line.order_code} — quantité reçue au-dessus de la tolérance`,
+        { expected_qty: fact.expected_qty, received_qty: fact.received_qty, tolerance_pct: line.over_receipt_tolerance_pct, allowed_max_qty: roundMetric(allowedMax, 6), policy_source: line.policy_source ?? "STRICT_ZERO_TOLERANCE" },
+        "Décider du retour fournisseur ou faire approuver l'écart avant mise en stock.",
+        asOf,
+      ));
+    }
+    const lateDays = fact.completion_date ? calendarDaysBetween(line.promised_date, fact.completion_date) : null;
+    if (fact.completion_date && lateDays !== null && lateDays > line.lead_grace_days) {
+      anomalies.push(makeAnomaly(
+        fact,
+        "LATE_RECEIPT",
+        "P2",
+        `${line.order_code} — réception intégrale tardive`,
+        { promised_date: line.promised_date, completion_date: fact.completion_date, late_days: lateDays, grace_days: line.lead_grace_days, policy_source: line.policy_source ?? "STRICT_ZERO_GRACE" },
+        "Qualifier la cause du retard avec le fournisseur.",
+        fact.completion_date,
+      ));
+    }
+    if (fact.has_unconvertible_receipt) {
+      anomalies.push(makeAnomaly(
+        fact,
+        "UNIT_MISMATCH",
+        "P1",
+        `${line.order_code} — unité de réception non rapprochable`,
+        { purchase_unit: line.purchase_unit, stock_unit: line.stock_unit, conversion_factor: line.conversion_factor, receipt_units: [...new Set(fact.receipts.map((receipt) => receipt.receipt_unit))] },
+        "Renseigner une conversion explicite ou corriger l'unité de réception sans modifier l'historique.",
+        asOf,
+      ));
+    }
+    for (const receipt of fact.receipts.filter((candidate) => candidate.lot_status === "BLOQUE" || candidate.lot_status === "QUARANTAINE")) {
+      anomalies.push(makeAnomaly(
+        fact,
+        "BLOCKED_LOT",
+        "P1",
+        `${line.order_code} — lot ${receipt.lot_code ?? receipt.lot_id ?? "sans code"} bloqué`,
+        { receipt_id: receipt.receipt_id, receipt_no: receipt.receipt_no, lot_id: receipt.lot_id, lot_status: receipt.lot_status, inspection_decision: receipt.inspection_decision },
+        "Ouvrir le contrôle réception et statuer sur le lot.",
+        asOf,
+      ));
+    }
+    if (fact.receipts.length > 0 && line.expected_documents.length > 0) {
+      const present = new Set(fact.receipts.flatMap((receipt) => receipt.document_types.map((value) => value.toUpperCase())));
+      const missing = line.expected_documents.filter((expected) => !present.has(expected.toUpperCase()));
+      if (missing.length > 0) {
+        anomalies.push(makeAnomaly(
+          fact,
+          "MISSING_DOCUMENT",
+          "P2",
+          `${line.order_code} — documents de réception absents`,
+          { expected_documents: line.expected_documents, missing_documents: missing, present_documents: [...present] },
+          "Demander et joindre les documents manquants à la réception.",
+          asOf,
+        ));
+      }
+    }
+    const qualityRequired = line.quality_requirements.some((requirement) => requirement.obligatoire !== false && requirement.type === "CONTROLE_RECEPTION");
+    if (qualityRequired && fact.receipts.some((receipt) => receipt.inspection_id === null)) {
+      anomalies.push(makeAnomaly(
+        fact,
+        "QUALITY_INSPECTION_MISSING",
+        "P1",
+        `${line.order_code} — contrôle réception obligatoire non démarré`,
+        { reception_lines_without_inspection: fact.receipts.filter((receipt) => receipt.inspection_id === null).map((receipt) => receipt.receipt_line_id) },
+        "Démarrer le contrôle réception avant libération du lot.",
+        asOf,
+      ));
+    }
+  }
+  return anomalies;
+}
+
+async function attachActions(anomalies: ProcurementAnomaly[]): Promise<void> {
+  if (anomalies.length === 0) return;
+  const result = await db.query<ActionRow>(
+    `SELECT a.anomaly_key,a.owner_user_id,
+            COALESCE(NULLIF(trim(concat_ws(' ',u.name,u.surname)),''),u.username) AS owner_name,
+            a.next_action,a.due_date::text,a.status,a.resolution_note,a.updated_at::text
+       FROM public.procurement_anomaly_actions a
+       LEFT JOIN public.users u ON u.id=a.owner_user_id
+      WHERE a.anomaly_key=ANY($1::text[])`,
+    [anomalies.map((anomaly) => anomaly.key)],
+  );
+  const byKey = new Map(result.rows.map((row) => [row.anomaly_key, row]));
+  for (const anomaly of anomalies) anomaly.action = byKey.get(anomaly.key) ?? null;
+}
+
+export async function repoProcurementOverview(query: ProcurementOverviewQueryDTO, includePrices: boolean) {
+  await ensureInstalled();
+  const asOf = query.as_of ?? new Date().toISOString().slice(0, 10);
+  const period = { from: query.from, to: query.to, as_of: asOf };
+  const lines = await loadLineRows(query, asOf);
+  const [receipts, promiseHistory] = await Promise.all([
+    loadReceiptRows(lines.map((line) => line.line_id), asOf),
+    loadPromiseHistory(lines),
+  ]);
+  const facts = buildFacts(lines, receipts, promiseHistory, asOf);
+  const anomalies = buildAnomalies(facts, asOf);
+  await attachActions(anomalies);
+  const grouped = new Map<string, { label: string; facts: LineFact[] }>();
+  for (const fact of facts) {
+    const dimension = dimensionFor(fact, query.dimension);
+    const group = grouped.get(dimension.key) ?? { label: dimension.label, facts: [] };
+    group.facts.push(fact);
+    grouped.set(dimension.key, group);
+  }
+  const scorecards = [...grouped.entries()]
+    .map(([key, value]) => ({ key, label: value.label, line_count: value.facts.length, metrics: metricSet(value.facts, period, includePrices) }))
+    .sort((left, right) => (right.metrics.otd.denominator ?? 0) - (left.metrics.otd.denominator ?? 0) || left.label.localeCompare(right.label))
+    .slice(0, query.limit);
+  const promiseCoverage = facts.length === 0 ? null : roundMetric((facts.filter((fact) => fact.promise_versioned).length / facts.length) * 100, 2);
+  return {
+    contract_version: PROCUREMENT_CONTRACT_VERSION,
+    generated_at: new Date().toISOString(),
+    timezone: PROCUREMENT_TIMEZONE,
+    period,
+    cohort: "PROMISED_DATE_DUE",
+    dimension: query.dimension,
+    metrics: metricSet(facts, period, includePrices),
+    scorecards,
+    anomalies: anomalies
+      .sort((left, right) => left.severity.localeCompare(right.severity) || left.suggested_due_date.localeCompare(right.suggested_due_date))
+      .slice(0, query.limit),
+    reconciliation: facts.slice(0, query.limit).map((fact) => ({
+      order: {
+        id: fact.line.order_id,
+        code: fact.line.order_code,
+        line_id: fact.line.line_id,
+        supplier_id: fact.line.supplier_id,
+        article_id: fact.line.article_id,
+        family_code: fact.line.family_code,
+        expected_qty: fact.expected_qty,
+        unit: fact.line.purchase_unit,
+        promised_date: fact.line.promised_date,
+        promised_date_source: fact.line.promised_date_source,
+        promise_history: fact.promise_history,
+      },
+      receipts: fact.receipts.map((receipt) => ({
+        id: receipt.receipt_id,
+        no: receipt.receipt_no,
+        line_id: receipt.receipt_line_id,
+        date: receipt.receipt_date,
+        qty: receipt.qty_received,
+        unit: receipt.receipt_unit,
+        normalized_purchase_qty: receipt.purchase_qty,
+        normalization: receipt.normalization,
+        quality_control: receipt.inspection_id === null ? null : {
+          id: receipt.inspection_id,
+          status: receipt.inspection_status,
+          decision: receipt.inspection_decision,
+          decided_at: receipt.inspection_decided_at,
+        },
+        lot: receipt.lot_id === null ? null : { id: receipt.lot_id, code: receipt.lot_code, status: receipt.lot_status },
+        documents: receipt.document_types,
+      })),
+      supplier_invoice: { status: "UNAVAILABLE", reason: "SUPPLIER_INVOICE_SOURCE_NOT_MODELLED" },
+      supplier_credit: { status: "UNAVAILABLE", reason: "SUPPLIER_CREDIT_SOURCE_NOT_MODELLED" },
+      returns: { status: "UNAVAILABLE", reason: "SUPPLIER_RETURN_WORKFLOW_NOT_MODELLED" },
+    })),
+    capabilities: {
+      purchase_order: { available: true, source: "commande_fournisseur" },
+      receipt: { available: true, source: "receptions_fournisseurs" },
+      incoming_quality: { available: true, source: "reception_incoming_inspections" },
+      lot: { available: true, source: "lots" },
+      supplier_invoice: { available: false, reason: "SUPPLIER_INVOICE_SOURCE_NOT_MODELLED" },
+      supplier_credit: { available: false, reason: "SUPPLIER_CREDIT_SOURCE_NOT_MODELLED" },
+      returns: { available: false, reason: "SUPPLIER_RETURN_WORKFLOW_NOT_MODELLED" },
+    },
+    data_quality: {
+      line_count: facts.length,
+      receipt_line_count: receipts.length,
+      promise_history_coverage_pct: promiseCoverage,
+      unconvertible_receipt_lines: facts.filter((fact) => fact.has_unconvertible_receipt).length,
+      missing_price_policy_lines: facts.filter((fact) => fact.line.price_tolerance_pct === null).length,
+      source_freshness_at: maxTimestamp(facts.flatMap((fact) => [fact.line.updated_at, ...fact.receipts.map((receipt) => receipt.updated_at)])),
+    },
+  };
+}
+
+export async function repoUpsertAnomalyAction(params: {
+  anomalyKey: string;
+  input: AnomalyActionBodyDTO;
+  actor: ProcurementActor;
+  idempotencyKey: string;
+}) {
+  return inTransaction(async (tx) => {
+    await ensureInstalled(tx);
+    const requestHash = procurementPayloadHash({ anomaly_key: params.anomalyKey, ...params.input });
+    const replay = await readCommandReceipt<Record<string, unknown>>(tx, "ANOMALY_ACTION", params.idempotencyKey, requestHash);
+    if (replay) return replay;
+    const current = await tx.query<{ updated_at: string }>(
+      `SELECT updated_at::text FROM public.procurement_anomaly_actions WHERE anomaly_key=$1 FOR UPDATE`,
+      [params.anomalyKey],
+    );
+    if (params.input.expected_updated_at && current.rows[0]?.updated_at !== params.input.expected_updated_at) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "L'anomalie a été modifiée. Rechargez la file avant de réessayer.");
+    }
+    const result = await tx.query<ActionRow>(
+      `INSERT INTO public.procurement_anomaly_actions
+         (anomaly_key,owner_user_id,next_action,due_date,status,resolution_note,created_by,updated_by)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$7)
+       ON CONFLICT (anomaly_key) DO UPDATE SET
+         owner_user_id=EXCLUDED.owner_user_id,next_action=EXCLUDED.next_action,due_date=EXCLUDED.due_date,
+         status=EXCLUDED.status,resolution_note=EXCLUDED.resolution_note,updated_at=now(),updated_by=EXCLUDED.updated_by
+       RETURNING anomaly_key,owner_user_id,NULL::text AS owner_name,next_action,due_date::text,status,resolution_note,updated_at::text`,
+      [params.anomalyKey, params.input.owner_user_id, params.input.next_action, params.input.due_date, params.input.status,
+        params.input.resolution_note ?? null, params.actor.user_id],
+    );
+    const response = { action: result.rows[0], idempotent_replay: false };
+    await insertAudit(tx, params.actor, {
+      action: "procurement.anomaly.action_updated",
+      entity_type: "procurement_anomaly",
+      entity_id: params.anomalyKey,
+      details: { owner_user_id: params.input.owner_user_id, due_date: params.input.due_date, status: params.input.status },
+    });
+    await saveCommandReceipt(tx, "ANOMALY_ACTION", params.idempotencyKey, requestHash, params.actor.user_id, response);
+    return response;
+  });
+}
+
+export async function repoRecordPromisedDate(params: {
+  orderId: string;
+  input: PromisedDateBodyDTO;
+  actor: ProcurementActor;
+  idempotencyKey: string;
+}) {
+  return inTransaction(async (tx) => {
+    await ensureInstalled(tx);
+    const requestHash = procurementPayloadHash({ order_id: params.orderId, ...params.input });
+    const replay = await readCommandReceipt<Record<string, unknown>>(tx, "PROMISED_DATE", params.idempotencyKey, requestHash);
+    if (replay) return replay;
+    const header = await tx.query<{ statut: string; updated_at: string; date_promesse: string | null }>(
+      `SELECT statut,updated_at::text,date_promesse::text FROM public.commande_fournisseur WHERE id=$1::uuid FOR UPDATE`,
+      [params.orderId],
+    );
+    const order = header.rows[0];
+    if (!order) throw new HttpError(404, "COMMANDE_FOURNISSEUR_NOT_FOUND", "Commande fournisseur introuvable.");
+    if (!['ENVOYEE','ACCUSE_RECU','PARTIELLEMENT_RECUE'].includes(order.statut)) {
+      throw new HttpError(409, "PROMISE_REVISION_STATUS_INVALID", "Une promesse fournisseur ne peut être révisée que sur une commande envoyée et non clôturée.");
+    }
+    let previousDate: string | null = order.date_promesse;
+    let optimisticToken = order.updated_at;
+    if (params.input.line_id) {
+      const line = await tx.query<{ date_promesse: string | null; updated_at: string }>(
+        `SELECT date_promesse::text,updated_at::text FROM public.commande_fournisseur_ligne
+         WHERE id=$1::uuid AND commande_id=$2::uuid AND statut_ligne='ACTIVE' FOR UPDATE`,
+        [params.input.line_id, params.orderId],
+      );
+      if (!line.rows[0]) throw new HttpError(404, "COMMANDE_FOURNISSEUR_LINE_NOT_FOUND", "Ligne de commande introuvable.");
+      previousDate = line.rows[0].date_promesse ?? order.date_promesse;
+      optimisticToken = line.rows[0].updated_at;
+    }
+    if (optimisticToken !== params.input.expected_updated_at) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "La promesse a été modifiée. Rechargez la commande avant de réessayer.");
+    }
+    if (previousDate === params.input.promised_date) {
+      throw new HttpError(409, "PROMISE_DATE_UNCHANGED", "La nouvelle date promise est identique à la date actuelle.");
+    }
+    if (params.input.line_id) {
+      await tx.query(
+        `UPDATE public.commande_fournisseur_ligne SET date_promesse=$3::date,updated_at=now(),updated_by=$4
+         WHERE id=$1::uuid AND commande_id=$2::uuid`,
+        [params.input.line_id, params.orderId, params.input.promised_date, params.actor.user_id],
+      );
+    } else {
+      await tx.query(
+        `UPDATE public.commande_fournisseur SET date_promesse=$2::date,updated_at=now(),updated_by=$3 WHERE id=$1::uuid`,
+        [params.orderId, params.input.promised_date, params.actor.user_id],
+      );
+    }
+    const event = await tx.query<{ id: string; created_at: string }>(
+      `INSERT INTO public.procurement_promised_date_events
+         (commande_id,ligne_id,previous_date,promised_date,reason_code,note,actor_user_id)
+       VALUES ($1::uuid,$2::uuid,$3::date,$4::date,$5,$6,$7)
+       RETURNING id::text,created_at::text`,
+      [params.orderId, params.input.line_id ?? null, previousDate, params.input.promised_date,
+        params.input.reason_code, params.input.note ?? null, params.actor.user_id],
+    );
+    const response = { event_id: event.rows[0]?.id, promised_date: params.input.promised_date, idempotent_replay: false };
+    await insertAudit(tx, params.actor, {
+      action: "procurement.promise.revised",
+      entity_type: params.input.line_id ? "commande_fournisseur_ligne" : "commande_fournisseur",
+      entity_id: params.input.line_id ?? params.orderId,
+      details: { order_id: params.orderId, previous_date: previousDate, promised_date: params.input.promised_date, reason_code: params.input.reason_code },
+    });
+    await saveCommandReceipt(tx, "PROMISED_DATE", params.idempotencyKey, requestHash, params.actor.user_id, response);
+    return response;
+  });
+}
+
+export async function repoCreateProcurementPolicy(params: {
+  input: ProcurementPolicyBodyDTO;
+  actor: ProcurementActor;
+  idempotencyKey: string;
+}) {
+  return inTransaction(async (tx) => {
+    await ensureInstalled(tx);
+    const requestHash = procurementPayloadHash(params.input);
+    const replay = await readCommandReceipt<Record<string, unknown>>(tx, "POLICY_VERSION", params.idempotencyKey, requestHash);
+    if (replay) return replay;
+    let inserted;
+    try {
+      inserted = await tx.query<{ id: string; created_at: string }>(
+        `INSERT INTO public.procurement_policy_versions
+           (scope_type,scope_id,valid_from,price_tolerance_pct,over_receipt_tolerance_pct,lead_grace_days,reason,created_by)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+         RETURNING id::text,created_at::text`,
+        [params.input.scope_type, params.input.scope_id, params.input.valid_from, params.input.price_tolerance_pct,
+          params.input.over_receipt_tolerance_pct, params.input.lead_grace_days, params.input.reason, params.actor.user_id],
+      );
+    } catch (error) {
+      if ((error as { code?: string }).code === "23505") {
+        throw new HttpError(409, "POLICY_VERSION_ALREADY_EXISTS", "Une politique existe déjà pour ce périmètre et cette date d'effet.");
+      }
+      throw error;
+    }
+    const response = { policy_id: inserted.rows[0]?.id, valid_from: params.input.valid_from, idempotent_replay: false };
+    await insertAudit(tx, params.actor, {
+      action: "procurement.policy.version_created",
+      entity_type: "procurement_policy",
+      entity_id: inserted.rows[0]?.id ?? "unknown",
+      details: { scope_type: params.input.scope_type, scope_id: params.input.scope_id, valid_from: params.input.valid_from },
+    });
+    await saveCommandReceipt(tx, "POLICY_VERSION", params.idempotencyKey, requestHash, params.actor.user_id, response);
+    return response;
+  });
+}
+
+/** Called inside the existing acknowledgement transaction. */
+export async function repoRecordInitialPromiseEvent(
+  tx: Queryer,
+  params: { orderId: string; previousDate: string | null; promisedDate: string; actorUserId: number },
+): Promise<void> {
+  await tx.query(
+    `INSERT INTO public.procurement_promised_date_events
+       (commande_id,ligne_id,previous_date,promised_date,reason_code,actor_user_id)
+     VALUES ($1::uuid,NULL,$2::date,$3::date,'SUPPLIER_ACKNOWLEDGEMENT',$4)`,
+    [params.orderId, params.previousDate, params.promisedDate, params.actorUserId],
+  );
+}

--- a/src/module/procurement-reliability/routes/procurement-reliability.routes.ts
+++ b/src/module/procurement-reliability/routes/procurement-reliability.routes.ts
@@ -1,0 +1,43 @@
+import { Router, type RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import { requestHasGrantedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import {
+  roleHasCommandeFournisseurCapability,
+  type CommandeFournisseurCapability,
+} from "../../commande-fournisseur/domain/commande-fournisseur-rbac";
+import {
+  createProcurementPolicy,
+  procurementOverview,
+  reviseProcurementPromise,
+  updateProcurementAnomalyAction,
+} from "../controllers/procurement-reliability.controller";
+
+function requireCapability(capability: CommandeFournisseurCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (!requestHasGrantedAccountModuleAccess(req) && !roleHasCommandeFournisseurCapability(req.user?.role, capability)) {
+      next(new HttpError(403, "PROCUREMENT_CAPABILITY_REQUIRED", "Votre rôle ne permet pas cette action de pilotage achats."));
+      return;
+    }
+    next();
+  };
+}
+
+function requireRoleCapability(capability: CommandeFournisseurCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (!roleHasCommandeFournisseurCapability(req.user?.role, capability)) {
+      next(new HttpError(403, "PROCUREMENT_ROLE_CAPABILITY_REQUIRED", "Cette décision de politique achats est réservée à la Direction ou à l'administration."));
+      return;
+    }
+    next();
+  };
+}
+
+const router = Router();
+
+router.get("/overview", requireCapability("read"), procurementOverview);
+router.put("/anomalies/:anomalyKey/action", requireCapability("close"), updateProcurementAnomalyAction);
+router.post("/orders/:id/promised-dates", requireCapability("acknowledge"), reviseProcurementPromise);
+router.post("/policies", requireRoleCapability("approve"), createProcurementPolicy);
+
+export default router;

--- a/src/module/procurement-reliability/validators/procurement-reliability.validators.ts
+++ b/src/module/procurement-reliability/validators/procurement-reliability.validators.ts
@@ -1,0 +1,80 @@
+import { z } from "zod";
+
+import {
+  PROCUREMENT_ANOMALY_STATUSES,
+  PROCUREMENT_POLICY_SCOPE_TYPES,
+  PROCUREMENT_PROMISE_REASON_CODES,
+} from "../domain/procurement-reliability";
+
+const isoDate = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Date attendue au format YYYY-MM-DD");
+const isoDateTime = z.string().datetime({ offset: true });
+const uuid = z.string().uuid();
+
+export const procurementOverviewQuerySchema = z.object({
+  from: isoDate,
+  to: isoDate,
+  as_of: isoDate.optional(),
+  dimension: z.enum(["SUPPLIER", "ARTICLE", "FAMILY"]).default("SUPPLIER"),
+  supplier_id: uuid.optional(),
+  article_id: uuid.optional(),
+  family_code: z.string().trim().min(1).max(40).optional(),
+  limit: z.coerce.number().int().min(1).max(200).default(50),
+}).superRefine((value, ctx) => {
+  if (value.from > value.to) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["to"], message: "La fin doit suivre le début." });
+  }
+  const days = Math.floor((Date.parse(`${value.to}T00:00:00Z`) - Date.parse(`${value.from}T00:00:00Z`)) / 86_400_000);
+  if (days > 731) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["to"], message: "La période est limitée à 24 mois." });
+  }
+});
+
+export const anomalyParamsSchema = z.object({ anomalyKey: z.string().regex(/^[A-Z_]+:[0-9a-f]{24}$/) });
+export const purchaseOrderParamsSchema = z.object({ id: uuid });
+
+export const anomalyActionBodySchema = z.object({
+  owner_user_id: z.number().int().positive().nullable(),
+  next_action: z.string().trim().min(3).max(500),
+  due_date: isoDate,
+  status: z.enum(PROCUREMENT_ANOMALY_STATUSES),
+  resolution_note: z.string().trim().min(3).max(1000).nullable().optional(),
+  expected_updated_at: isoDateTime.nullable().optional(),
+}).superRefine((value, ctx) => {
+  if (["RESOLVED", "DISMISSED"].includes(value.status) && !value.resolution_note) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["resolution_note"], message: "Un motif est requis pour clore l'anomalie." });
+  }
+});
+
+export const promisedDateBodySchema = z.object({
+  line_id: uuid.nullable().optional(),
+  promised_date: isoDate,
+  reason_code: z.enum(PROCUREMENT_PROMISE_REASON_CODES).exclude(["SUPPLIER_ACKNOWLEDGEMENT"]),
+  note: z.string().trim().min(3).max(1000).nullable().optional(),
+  expected_updated_at: isoDateTime,
+}).superRefine((value, ctx) => {
+  if (value.reason_code === "OTHER" && !value.note) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["note"], message: "Une explication est requise pour le motif AUTRE." });
+  }
+});
+
+export const procurementPolicyBodySchema = z.object({
+  scope_type: z.enum(PROCUREMENT_POLICY_SCOPE_TYPES),
+  scope_id: z.string().trim().min(1).max(80).nullable(),
+  valid_from: isoDate,
+  price_tolerance_pct: z.number().finite().min(0).max(100).nullable(),
+  over_receipt_tolerance_pct: z.number().finite().min(0).max(100).default(0),
+  lead_grace_days: z.number().int().min(0).max(365).default(0),
+  reason: z.string().trim().min(3).max(1000),
+}).superRefine((value, ctx) => {
+  if (value.scope_type === "COMPANY" && value.scope_id !== null) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["scope_id"], message: "Le périmètre société ne porte pas d'identifiant." });
+  }
+  if (value.scope_type !== "COMPANY" && value.scope_id === null) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["scope_id"], message: "Un identifiant de périmètre est requis." });
+  }
+});
+
+export type ProcurementOverviewQueryDTO = z.infer<typeof procurementOverviewQuerySchema>;
+export type AnomalyActionBodyDTO = z.infer<typeof anomalyActionBodySchema>;
+export type PromisedDateBodyDTO = z.infer<typeof promisedDateBodySchema>;
+export type ProcurementPolicyBodyDTO = z.infer<typeof procurementPolicyBodySchema>;

--- a/src/routes/v1.routes.ts
+++ b/src/routes/v1.routes.ts
@@ -35,6 +35,7 @@ import programmationRoutes from "../module/programmation/routes/programmation.ro
 import operationDossiersRoutes from "../module/operation-dossiers/routes/operation-dossiers.routes";
 import fournisseursRoutes from "../module/fournisseurs/routes/fournisseurs.routes";
 import commandeFournisseurRoutes from "../module/commande-fournisseur/routes/commande-fournisseur.routes";
+import procurementReliabilityRoutes from "../module/procurement-reliability/routes/procurement-reliability.routes";
 import replenishmentProposalRoutes from "../module/commande-fournisseur/routes/replenishment-proposal.routes";
 import receptionsRoutes from "../module/receptions/routes/receptions.routes";
 import metrologieRoutes from "../module/metrologie/routes/metrologie.routes";
@@ -145,6 +146,7 @@ router.use("/stock", stockRoutes);
 router.use("/dossiers", operationDossiersRoutes);
 router.use("/fournisseurs", fournisseursRoutes);
 router.use("/commandes-fournisseurs", commandeFournisseurRoutes); // Module « Commandes fournisseurs » (#172) — BCF
+router.use("/procurement-reliability", procurementReliabilityRoutes); // SOL-18 — scorecards et rapprochement achats
 router.use("/replenishment-proposals", replenishmentProposalRoutes); // FEAT-CERP-0003 — suggestions sans achat automatique
 router.use("/receptions", receptionsRoutes);
 // Métrologie 360 (#229) monté AVANT le routeur historique : ses routes


### PR DESCRIPTION
Promotion de la branche dev après fusion de #432.

Preuves : 4 506 tests backend, typecheck/build/audit, migration + replay + rollback + restauration, E2E achats complet et partiel. Le patch reste à appliquer uniquement par une fenêtre de migration autorisée.

## Summary by Sourcery

Introduce SOL-18 procurement reliability capabilities, wiring them into supplier order acknowledgement, release migration tooling, and the public API.

New Features:
- Expose a new /procurement-reliability API module providing procurement overview scorecards, promise revisions, anomaly triage, and tolerance policy management.
- Add a procurement reliability domain model computing supplier OTD, lead-time variability, rejection rate, anomaly detection, and reconciliation views over orders, receipts, quality, lots, and documents.

Enhancements:
- Record initial supplier promise events when acknowledging purchase orders, enriching promise history for reliability metrics without altering existing data.
- Enforce RBAC, optimistic locking, idempotency, and central auditing on procurement reliability write operations via dedicated controllers and routes.
- Extend release gate and migration rehearsal artefacts to cover the SOL-18 procurement reliability patch with guarded rollback, preflight, and verification scripts.

Build:
- Add the 20260812_procurement_reliability_sol18.sql schema patch defining append-only procurement evidence tables, anomaly actions, policy versions, and command receipts with permissions and triggers.
- Ship supporting migration SQL for SOL-18 preflight, verification, and rollback, and register the patch in the release-gate script for automated rehearsal and rollback proofs.

Documentation:
- Document the SOL-18 procurement reliability boundary, execution report, and updated migration rehearsal details, including metrics definitions, data constraints, and operational risks.

Tests:
- Add unit and integration tests for procurement reliability domain formulas, repository transactions, routes/RBAC, migration guards, and the initial promise event behaviour, and update migration rehearsal reports and JSON metadata accordingly.