### PR TITLE
fix(livraisons): sécuriser la préparation physique du BL

### DIFF
--- a/src/module/livraisons/controllers/livraisons.controller.ts
+++ b/src/module/livraisons/controllers/livraisons.controller.ts
@@ -9,10 +9,13 @@ import {
   livraisonIdParamsSchema,
   livraisonLineIdParamsSchema,
   livraisonLineAllocationIdParamsSchema,
+  livraisonPreparationAllocationParamsSchema,
   livraisonPdfQuerySchema,
   livraisonStatusBodySchema,
   livraisonProofBodySchema,
   shipLivraisonBodySchema,
+  confirmLivraisonPreparationBodySchema,
+  resetLivraisonPreparationBodySchema,
   updateLivraisonBodySchema,
   updateLivraisonLineBodySchema,
 } from "../validators/livraisons.validators"
@@ -228,6 +231,54 @@ export const getLivraisonShipmentPreview: RequestHandler = async (req, res, next
     getUserId(req)
     const { id } = livraisonIdParamsSchema.parse(req.params)
     const out = await service.svcGetLivraisonShipmentPreview(id)
+    res.status(200).json(out)
+  } catch (e) {
+    next(e)
+  }
+}
+
+export const getLivraisonPreparation: RequestHandler = async (req, res, next) => {
+  try {
+    getUserId(req)
+    const { id } = livraisonIdParamsSchema.parse(req.params)
+    const out = await service.svcGetLivraisonPreparation(id)
+    res.setHeader("Cache-Control", "private, no-store, max-age=0")
+    res.status(200).json(out)
+  } catch (e) {
+    next(e)
+  }
+}
+
+export const confirmLivraisonPreparation: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = getUserId(req)
+    const { id, allocationId } = livraisonPreparationAllocationParamsSchema.parse(req.params)
+    const body = confirmLivraisonPreparationBodySchema.parse(req.body)
+    const out = await service.svcConfirmLivraisonPreparation(
+      id,
+      allocationId,
+      body,
+      userId,
+      getRequiredIdempotencyKey(req)
+    )
+    res.status(200).json(out)
+  } catch (e) {
+    next(e)
+  }
+}
+
+export const resetLivraisonPreparation: RequestHandler = async (req, res, next) => {
+  try {
+    const userId = getUserId(req)
+    const { id, allocationId } = livraisonPreparationAllocationParamsSchema.parse(req.params)
+    const body = resetLivraisonPreparationBodySchema.parse(req.body)
+    const out = await service.svcResetLivraisonPreparation(
+      id,
+      allocationId,
+      body,
+      userId,
+      getRequiredIdempotencyKey(req)
+    )
     res.status(200).json(out)
   } catch (e) {
     next(e)

--- a/src/module/livraisons/domain/livraisons-preparation.test.ts
+++ b/src/module/livraisons/domain/livraisons-preparation.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+
+import {
+  deriveLivraisonPreparationState,
+  matchesLivraisonPickScanCode,
+} from "./livraisons-preparation"
+
+describe("livraisons preparation", () => {
+  it("accepts the lot, short trace and canonical QR codes", () => {
+    const expected = {
+      lot_code: "LOT-042",
+      stock_trace_code: "123456",
+      qr_payload: "CERP-STOCK:123456",
+    }
+    expect(matchesLivraisonPickScanCode(" lot-042 ", expected)).toBe(true)
+    expect(matchesLivraisonPickScanCode("123456", expected)).toBe(true)
+    expect(matchesLivraisonPickScanCode("CERP-STOCK:123456", expected)).toBe(true)
+    expect(matchesLivraisonPickScanCode("LOT-999", expected)).toBe(false)
+  })
+
+  it("derives an explicit operator state", () => {
+    expect(deriveLivraisonPreparationState({ status: "DRAFT", total: 2, confirmed: 0 })).toBe("NOT_READY")
+    expect(deriveLivraisonPreparationState({ status: "READY", total: 2, confirmed: 0 })).toBe("TO_PREPARE")
+    expect(deriveLivraisonPreparationState({ status: "READY", total: 2, confirmed: 1 })).toBe("IN_PROGRESS")
+    expect(deriveLivraisonPreparationState({ status: "READY", total: 2, confirmed: 2 })).toBe("COMPLETE")
+    expect(deriveLivraisonPreparationState({ status: "READY", total: 0, confirmed: 0 })).toBe("BLOCKED")
+  })
+})

--- a/src/module/livraisons/domain/livraisons-preparation.ts
+++ b/src/module/livraisons/domain/livraisons-preparation.ts
@@ -1,0 +1,32 @@
+import type { BonLivraisonStatut } from "../types/livraisons.types"
+
+export function matchesLivraisonPickScanCode(
+  scanCode: string,
+  expected: {
+    lot_code: string | null
+    stock_trace_code: string | null
+    qr_payload: string | null
+  }
+): boolean {
+  const normalized = scanCode.trim().toUpperCase()
+  if (!normalized) return false
+  const candidates = [
+    expected.lot_code,
+    expected.stock_trace_code,
+    expected.qr_payload,
+    expected.stock_trace_code ? `CERP-STOCK:${expected.stock_trace_code}` : null,
+  ]
+  return candidates.some((candidate) => candidate?.trim().toUpperCase() === normalized)
+}
+
+export function deriveLivraisonPreparationState(args: {
+  status: BonLivraisonStatut
+  total: number
+  confirmed: number
+}): "NOT_READY" | "TO_PREPARE" | "IN_PROGRESS" | "COMPLETE" | "BLOCKED" {
+  if (args.status === "DRAFT") return "NOT_READY"
+  if (args.total === 0) return "BLOCKED"
+  if (args.confirmed >= args.total) return "COMPLETE"
+  if (args.confirmed > 0) return "IN_PROGRESS"
+  return "TO_PREPARE"
+}

--- a/src/module/livraisons/repository/livraisons-preparation.contract.test.ts
+++ b/src/module/livraisons/repository/livraisons-preparation.contract.test.ts
@@ -1,0 +1,31 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { describe, expect, it } from "vitest"
+
+import { repoRoot } from "../../../__tests__/helpers/repo-paths"
+
+const preparationSource = readFileSync(
+  resolve(repoRoot, "src/module/livraisons/repository/livraisons-preparation.repository.ts"),
+  "utf8"
+)
+const shipmentSource = readFileSync(
+  resolve(repoRoot, "src/module/livraisons/repository/livraisons-shipment.repository.ts"),
+  "utf8"
+)
+
+describe("delivery physical preparation contract", () => {
+  it("persists append-only confirmations with idempotency, audit and realtime invalidation", () => {
+    expect(preparationSource).toContain("PICK_CONFIRMED")
+    expect(preparationSource).toContain("PICK_RESET")
+    expect(preparationSource).toContain("pg_advisory_xact_lock")
+    expect(preparationSource).toContain("livraisons.pick.confirmed")
+    expect(preparationSource).toContain("enqueueEntityChanged")
+  })
+
+  it("makes an unconfirmed pick a server-side shipment blocker and hashes the pick state", () => {
+    expect(shipmentSource).toContain("PREPARATION_CONFIRMATION_REQUIRED")
+    expect(shipmentSource).toMatch(/enforcePicking\s*&&\s*!allocation\.pick_confirmed/)
+    expect(shipmentSource).toContain("pick_confirmed:")
+    expect(shipmentSource).toContain("buildPreview(snapshot, qualityRelease, true, true)")
+  })
+})

--- a/src/module/livraisons/repository/livraisons-preparation.repository.ts
+++ b/src/module/livraisons/repository/livraisons-preparation.repository.ts
@@ -1,0 +1,515 @@
+import crypto from "node:crypto"
+import type { PoolClient } from "pg"
+
+import pool from "../../../config/database"
+import { withRealtimeOutboxTransaction } from "../../../shared/realtime/realtime-outbox-transaction"
+import { enqueueEntityChanged } from "../../../shared/realtime/realtime-outbox.service"
+import { HttpError } from "../../../utils/httpError"
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
+import { hashStockCommand, normalizeIdempotencyKey } from "../../stock/domain/stock-command"
+import {
+  deriveLivraisonPreparationState,
+  matchesLivraisonPickScanCode,
+} from "../domain/livraisons-preparation"
+import type {
+  BonLivraisonPreparation,
+  BonLivraisonStatut,
+  LivraisonPreparationTask,
+  UserLite,
+} from "../types/livraisons.types"
+import type {
+  ConfirmLivraisonPreparationBodyDTO,
+  ResetLivraisonPreparationBodyDTO,
+} from "../validators/livraisons.validators"
+
+type Queryable = Pick<PoolClient, "query">
+
+type PreparationHeaderRow = {
+  id: string
+  numero: string
+  statut: BonLivraisonStatut
+  row_version: number
+}
+
+type PreparationTaskRow = {
+  allocation_id: string
+  line_id: string
+  line_order: number
+  designation: string
+  code_piece: string | null
+  article_id: string
+  article_code: string | null
+  article_designation: string | null
+  lot_id: string | null
+  lot_code: string | null
+  lot_status: string | null
+  stock_trace_code: string | null
+  qr_payload: string | null
+  magasin_code: string | null
+  emplacement_code: string | null
+  location_id: string | null
+  stock_level_id: string | null
+  reservation_status: string | null
+  stock_movement_line_id: string | null
+  quantity: number
+  unit: string | null
+  affaire_refs: string[] | null
+  mp_lot_refs: string[] | null
+  traitement_lot_refs: string[] | null
+  latest_event_id: string | null
+  latest_event_type: string | null
+  latest_event_values: Record<string, unknown> | null
+  latest_event_created_at: string | null
+  confirmed_by_id: number | null
+  confirmed_by_username: string | null
+  confirmed_by_name: string | null
+  confirmed_by_surname: string | null
+}
+
+function toUser(row: PreparationTaskRow): UserLite | null {
+  if (row.confirmed_by_id === null || !row.confirmed_by_username) return null
+  const label = [row.confirmed_by_name, row.confirmed_by_surname]
+    .map((value) => value?.trim())
+    .filter(Boolean)
+    .join(" ") || row.confirmed_by_username
+  return {
+    id: row.confirmed_by_id,
+    username: row.confirmed_by_username,
+    name: row.confirmed_by_name,
+    surname: row.confirmed_by_surname,
+    label,
+  }
+}
+
+function isTaskOperational(row: PreparationTaskRow): boolean {
+  return Boolean(
+    row.location_id &&
+      row.stock_level_id &&
+      row.reservation_status === "ACTIVE" &&
+      !row.stock_movement_line_id &&
+      (!row.lot_id || row.lot_status === "LIBERE")
+  )
+}
+
+export async function repoGetLivraisonPreparation(
+  bonLivraisonId: string,
+  queryable: Queryable = pool
+): Promise<BonLivraisonPreparation | null> {
+  const headerResult = await queryable.query<PreparationHeaderRow>(
+    `
+      SELECT
+        id::text AS id,
+        numero,
+        statut,
+        row_version::int AS row_version
+      FROM public.bon_livraison
+      WHERE id = $1::uuid
+    `,
+    [bonLivraisonId]
+  )
+  const header = headerResult.rows[0] ?? null
+  if (!header) return null
+
+  const taskResult = await queryable.query<PreparationTaskRow>(
+    `
+      SELECT
+        allocation.id::text AS allocation_id,
+        line.id::text AS line_id,
+        line.ordre::int AS line_order,
+        line.designation,
+        line.code_piece,
+        allocation.article_id::text AS article_id,
+        article.code AS article_code,
+        article.designation AS article_designation,
+        allocation.lot_id::text AS lot_id,
+        lot.lot_code,
+        lot.lot_status,
+        lot.stock_trace_code::text AS stock_trace_code,
+        lot.qr_payload,
+        COALESCE(magasin.code, magasin.code_magasin)::text AS magasin_code,
+        emplacement.code AS emplacement_code,
+        allocation.location_id::text AS location_id,
+        allocation.stock_level_id::text AS stock_level_id,
+        reservation.status AS reservation_status,
+        allocation.stock_movement_line_id::text AS stock_movement_line_id,
+        allocation.quantite::float8 AS quantity,
+        allocation.unite AS unit,
+        ARRAY(
+          SELECT DISTINCT ref_value
+          FROM (
+            SELECT affaire.reference::text AS ref_value
+            WHERE affaire.reference IS NOT NULL
+            UNION ALL
+            SELECT trace.reference_value
+            FROM public.stock_lot_trace_references trace
+            WHERE trace.lot_id = allocation.lot_id
+              AND trace.reference_type IN ('AFFAIRE', 'OF')
+          ) refs
+          WHERE ref_value IS NOT NULL AND btrim(ref_value) <> ''
+          ORDER BY ref_value
+        ) AS affaire_refs,
+        ARRAY(
+          SELECT DISTINCT trace.reference_value
+          FROM public.stock_lot_trace_references trace
+          WHERE trace.lot_id = allocation.lot_id
+            AND trace.reference_type = 'MP_LOT'
+          ORDER BY trace.reference_value
+        ) AS mp_lot_refs,
+        ARRAY(
+          SELECT DISTINCT trace.reference_value
+          FROM public.stock_lot_trace_references trace
+          WHERE trace.lot_id = allocation.lot_id
+            AND trace.reference_type = 'TRAITEMENT_LOT'
+          ORDER BY trace.reference_value
+        ) AS traitement_lot_refs,
+        latest_event.id::text AS latest_event_id,
+        latest_event.event_type AS latest_event_type,
+        latest_event.new_values AS latest_event_values,
+        latest_event.created_at::text AS latest_event_created_at,
+        actor.id AS confirmed_by_id,
+        actor.username AS confirmed_by_username,
+        actor.name AS confirmed_by_name,
+        actor.surname AS confirmed_by_surname
+      FROM public.bon_livraison_ligne_allocations allocation
+      JOIN public.bon_livraison_ligne line
+        ON line.id = allocation.bon_livraison_ligne_id
+      JOIN public.bon_livraison delivery
+        ON delivery.id = line.bon_livraison_id
+      LEFT JOIN public.articles article ON article.id = allocation.article_id
+      LEFT JOIN public.lots lot ON lot.id = allocation.lot_id
+      LEFT JOIN public.magasins magasin ON magasin.id = allocation.magasin_id
+      LEFT JOIN public.emplacements emplacement ON emplacement.id = allocation.emplacement_id
+      LEFT JOIN public.stock_reservations reservation ON reservation.id = allocation.reservation_id
+      LEFT JOIN public.affaire affaire ON affaire.id = delivery.affaire_id
+      LEFT JOIN LATERAL (
+        SELECT event.id, event.event_type, event.new_values, event.created_at, event.user_id
+        FROM public.bon_livraison_event_log event
+        WHERE event.bon_livraison_id = delivery.id
+          AND event.event_type IN ('PICK_CONFIRMED', 'PICK_RESET')
+          AND event.new_values->>'allocation_id' = allocation.id::text
+        ORDER BY event.created_at DESC, event.id DESC
+        LIMIT 1
+      ) latest_event ON TRUE
+      LEFT JOIN public.users actor ON actor.id = latest_event.user_id
+      WHERE delivery.id = $1::uuid
+      ORDER BY line.ordre, allocation.created_at, allocation.id
+    `,
+    [bonLivraisonId]
+  )
+
+  const tasks: LivraisonPreparationTask[] = taskResult.rows.map((row) => {
+    const confirmed = row.latest_event_type === "PICK_CONFIRMED"
+    const inputMethod = row.latest_event_values?.input_method === "SCANNER" ? "SCANNER" : "MANUAL"
+    return {
+      allocation_id: row.allocation_id,
+      line_id: row.line_id,
+      line_order: row.line_order,
+      designation: row.designation,
+      code_piece: row.code_piece,
+      article_id: row.article_id,
+      article_code: row.article_code,
+      article_designation: row.article_designation,
+      lot_id: row.lot_id,
+      lot_code: row.lot_code,
+      lot_status: row.lot_status,
+      stock_trace_code: row.stock_trace_code,
+      magasin_code: row.magasin_code,
+      emplacement_code: row.emplacement_code,
+      quantity: Number(row.quantity),
+      unit: row.unit,
+      reservation_status: row.reservation_status,
+      affaire_refs: row.affaire_refs ?? [],
+      mp_lot_refs: row.mp_lot_refs ?? [],
+      traitement_lot_refs: row.traitement_lot_refs ?? [],
+      confirmation: confirmed && row.latest_event_id && row.latest_event_created_at
+        ? {
+            event_id: row.latest_event_id,
+            input_method: inputMethod,
+            confirmed_at: row.latest_event_created_at,
+            confirmed_by: toUser(row),
+          }
+        : null,
+      can_confirm: header.statut === "READY" && !confirmed && isTaskOperational(row),
+    }
+  })
+  const confirmed = tasks.filter((task) => task.confirmation !== null).length
+  const hasBlockedTask = tasks.some((task) => !task.confirmation && !task.can_confirm)
+  const derivedState = deriveLivraisonPreparationState({
+    status: header.statut,
+    total: tasks.length,
+    confirmed,
+  })
+  const state = hasBlockedTask && header.statut === "READY" ? "BLOCKED" : derivedState
+
+  return {
+    bon_livraison_id: header.id,
+    numero: header.numero,
+    status: header.statut,
+    row_version: header.row_version,
+    state,
+    can_ship: header.statut === "READY" && tasks.length > 0 && confirmed === tasks.length,
+    progress: {
+      total: tasks.length,
+      confirmed,
+      remaining: Math.max(tasks.length - confirmed, 0),
+      percent: tasks.length ? Math.round((confirmed / tasks.length) * 100) : 0,
+    },
+    tasks,
+  }
+}
+
+async function findIdempotentEvent(
+  client: Queryable,
+  userId: number,
+  idempotencyKey: string
+): Promise<{ request_hash: string } | null> {
+  const result = await client.query<{ request_hash: string }>(
+    `
+      SELECT new_values->>'request_hash' AS request_hash
+      FROM public.bon_livraison_event_log
+      WHERE user_id = $1
+        AND event_type IN ('PICK_CONFIRMED', 'PICK_RESET')
+        AND new_values->>'idempotency_key' = $2
+      ORDER BY created_at DESC, id DESC
+      LIMIT 1
+    `,
+    [userId, idempotencyKey]
+  )
+  return result.rows[0] ?? null
+}
+
+async function insertPreparationEvent(
+  client: Queryable,
+  args: {
+    bonLivraisonId: string
+    allocationId: string
+    eventType: "PICK_CONFIRMED" | "PICK_RESET"
+    userId: number
+    values: Record<string, unknown>
+  }
+) {
+  const event = await client.query<{ id: string; created_at: string }>(
+    `
+      INSERT INTO public.bon_livraison_event_log (
+        bon_livraison_id, event_type, old_values, new_values, user_id
+      )
+      VALUES ($1::uuid,$2,NULL,$3::jsonb,$4)
+      RETURNING id::text AS id, created_at::text AS created_at
+    `,
+    [args.bonLivraisonId, args.eventType, JSON.stringify(args.values), args.userId]
+  )
+  const inserted = event.rows[0]
+  if (!inserted) throw new Error("Failed to persist preparation event")
+  await enqueueEntityChanged(client, {
+    entityType: "BON_LIVRAISON",
+    entityId: args.bonLivraisonId,
+    action: "updated",
+    module: "livraisons",
+    at: inserted.created_at,
+    invalidateKeys: ["livraisons:list", `livraisons:detail:${args.bonLivraisonId}`],
+  }, { deduplicationKey: `livraison-event:${inserted.id}` })
+}
+
+async function mutatePreparation(args: {
+  bonLivraisonId: string
+  allocationId: string
+  body: ConfirmLivraisonPreparationBodyDTO | ResetLivraisonPreparationBodyDTO
+  userId: number
+  idempotencyKeyRaw: string
+  mode: "CONFIRM" | "RESET"
+}): Promise<BonLivraisonPreparation> {
+  const client = await pool.connect()
+  await withRealtimeOutboxTransaction(client, async (tx) => {
+    await tx.query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
+    const idempotencyKey = normalizeIdempotencyKey(args.idempotencyKeyRaw)
+    const requestPayload = {
+      bon_livraison_id: args.bonLivraisonId,
+      allocation_id: args.allocationId,
+      mode: args.mode,
+      ...args.body,
+    }
+    const requestHash = hashStockCommand("DELIVERY_PICK", requestPayload)
+    await tx.query(
+      "SELECT pg_advisory_xact_lock(hashtextextended($1, 0))",
+      [`delivery-pick:${args.userId}:${idempotencyKey}`]
+    )
+    const receipt = await findIdempotentEvent(tx, args.userId, idempotencyKey)
+    if (receipt && receipt.request_hash !== requestHash) {
+      throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Cette Idempotency-Key a déjà été utilisée pour un autre prélèvement.")
+    }
+    if (receipt) return
+
+    const headerResult = await tx.query<PreparationHeaderRow>(
+      `
+        SELECT id::text AS id, numero, statut, row_version::int AS row_version
+        FROM public.bon_livraison
+        WHERE id = $1::uuid
+        FOR UPDATE
+      `,
+      [args.bonLivraisonId]
+    )
+    const header = headerResult.rows[0] ?? null
+    if (!header) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+    if (header.statut !== "READY") {
+      throw new HttpError(409, "PREPARATION_NOT_READY", "Le prélèvement physique est autorisé uniquement au statut READY.")
+    }
+    if (header.row_version !== args.body.expected_version) {
+      throw new HttpError(409, "CONCURRENT_MODIFICATION", "Le bon de livraison a changé. Rafraîchissez la préparation.")
+    }
+
+    const allocationResult = await tx.query<{
+      lot_code: string | null
+      stock_trace_code: string | null
+      qr_payload: string | null
+      lot_id: string | null
+      lot_status: string | null
+      location_id: string | null
+      stock_level_id: string | null
+      reservation_status: string | null
+      stock_movement_line_id: string | null
+      latest_event_type: string | null
+    }>(
+      `
+        SELECT
+          lot.lot_code,
+          lot.stock_trace_code::text AS stock_trace_code,
+          lot.qr_payload,
+          allocation.lot_id::text AS lot_id,
+          lot.lot_status,
+          allocation.location_id::text AS location_id,
+          allocation.stock_level_id::text AS stock_level_id,
+          reservation.status AS reservation_status,
+          allocation.stock_movement_line_id::text AS stock_movement_line_id,
+          latest_event.event_type AS latest_event_type
+        FROM public.bon_livraison_ligne_allocations allocation
+        JOIN public.bon_livraison_ligne line ON line.id = allocation.bon_livraison_ligne_id
+        LEFT JOIN public.lots lot ON lot.id = allocation.lot_id
+        LEFT JOIN public.stock_reservations reservation ON reservation.id = allocation.reservation_id
+        LEFT JOIN LATERAL (
+          SELECT event.event_type
+          FROM public.bon_livraison_event_log event
+          WHERE event.bon_livraison_id = line.bon_livraison_id
+            AND event.event_type IN ('PICK_CONFIRMED', 'PICK_RESET')
+            AND event.new_values->>'allocation_id' = allocation.id::text
+          ORDER BY event.created_at DESC, event.id DESC
+          LIMIT 1
+        ) latest_event ON TRUE
+        WHERE line.bon_livraison_id = $1::uuid
+          AND allocation.id = $2::uuid
+        FOR UPDATE OF allocation
+      `,
+      [args.bonLivraisonId, args.allocationId]
+    )
+    const allocation = allocationResult.rows[0] ?? null
+    if (!allocation) throw new HttpError(404, "ALLOCATION_NOT_FOUND", "Allocation de livraison introuvable.")
+    const alreadyConfirmed = allocation.latest_event_type === "PICK_CONFIRMED"
+    if ((args.mode === "CONFIRM" && alreadyConfirmed) || (args.mode === "RESET" && !alreadyConfirmed)) return
+
+    if (args.mode === "CONFIRM") {
+      if (
+        !allocation.location_id ||
+        !allocation.stock_level_id ||
+        allocation.reservation_status !== "ACTIVE" ||
+        allocation.stock_movement_line_id ||
+        (allocation.lot_id && allocation.lot_status !== "LIBERE")
+      ) {
+        throw new HttpError(409, "PICK_BLOCKED", "La source de stock n’est pas complète, réservée et libérée.")
+      }
+      const body = args.body as ConfirmLivraisonPreparationBodyDTO
+      if (
+        body.input_method === "SCANNER" &&
+        !matchesLivraisonPickScanCode(body.scan_code ?? "", allocation)
+      ) {
+        throw new HttpError(409, "PICK_SCAN_MISMATCH", "Le code scanné ne correspond pas au lot demandé.")
+      }
+    }
+
+    const correlationId = crypto.randomUUID()
+    const inputMethod = args.mode === "CONFIRM"
+      ? (args.body as ConfirmLivraisonPreparationBodyDTO).input_method
+      : null
+    const scanCode = args.mode === "CONFIRM"
+      ? (args.body as ConfirmLivraisonPreparationBodyDTO).scan_code
+      : null
+    await insertPreparationEvent(tx, {
+      bonLivraisonId: args.bonLivraisonId,
+      allocationId: args.allocationId,
+      eventType: args.mode === "CONFIRM" ? "PICK_CONFIRMED" : "PICK_RESET",
+      userId: args.userId,
+      values: {
+        allocation_id: args.allocationId,
+        input_method: inputMethod,
+        scan_code_sha256: scanCode
+          ? crypto.createHash("sha256").update(scanCode.trim()).digest("hex")
+          : null,
+        correlation_id: correlationId,
+        idempotency_key: idempotencyKey,
+        request_hash: requestHash,
+      },
+    })
+    await tx.query(
+      `UPDATE public.bon_livraison SET updated_at = now(), updated_by = $2 WHERE id = $1::uuid`,
+      [args.bonLivraisonId, args.userId]
+    )
+    await repoInsertAuditLog({
+      user_id: args.userId,
+      body: {
+        event_type: "ACTION",
+        action: args.mode === "CONFIRM" ? "livraisons.pick.confirmed" : "livraisons.pick.reset",
+        page_key: "livraisons",
+        entity_type: "bon_livraison",
+        entity_id: args.bonLivraisonId,
+        path: `/api/v1/livraisons/${args.bonLivraisonId}/preparation/allocations/${args.allocationId}/${args.mode === "CONFIRM" ? "confirm" : "reset"}`,
+        client_session_id: null,
+        details: {
+          allocation_id: args.allocationId,
+          input_method: inputMethod,
+          correlation_id: correlationId,
+        },
+      },
+      ip: null,
+      user_agent: null,
+      device_type: null,
+      os: null,
+      browser: null,
+      tx,
+    })
+  })
+  const preparation = await repoGetLivraisonPreparation(args.bonLivraisonId)
+  if (!preparation) throw new Error("Failed to reload livraison preparation")
+  return preparation
+}
+
+export function repoConfirmLivraisonPreparation(
+  bonLivraisonId: string,
+  allocationId: string,
+  body: ConfirmLivraisonPreparationBodyDTO,
+  userId: number,
+  idempotencyKey: string
+) {
+  return mutatePreparation({
+    bonLivraisonId,
+    allocationId,
+    body,
+    userId,
+    idempotencyKeyRaw: idempotencyKey,
+    mode: "CONFIRM",
+  })
+}
+
+export function repoResetLivraisonPreparation(
+  bonLivraisonId: string,
+  allocationId: string,
+  body: ResetLivraisonPreparationBodyDTO,
+  userId: number,
+  idempotencyKey: string
+) {
+  return mutatePreparation({
+    bonLivraisonId,
+    allocationId,
+    body,
+    userId,
+    idempotencyKeyRaw: idempotencyKey,
+    mode: "RESET",
+  })
+}

--- a/src/module/livraisons/repository/livraisons-shipment.repository.ts
+++ b/src/module/livraisons/repository/livraisons-shipment.repository.ts
@@ -82,6 +82,7 @@ type AllocationRow = {
   qty_on_hand: number | null
   qty_reserved: number | null
   qty_depreciated: number | null
+  pick_confirmed: boolean
 }
 
 type ShipmentSnapshot = {
@@ -174,13 +175,23 @@ async function loadShipmentSnapshot(
         allocation.unite,
         level.qty_total::float8 AS qty_on_hand,
         level.qty_reserved::float8 AS qty_reserved,
-        level.qty_depreciated::float8 AS qty_depreciated
+        level.qty_depreciated::float8 AS qty_depreciated,
+        COALESCE(latest_pick.event_type = 'PICK_CONFIRMED', false) AS pick_confirmed
       FROM public.bon_livraison_ligne_allocations allocation
       JOIN public.bon_livraison_ligne line
         ON line.id = allocation.bon_livraison_ligne_id
       LEFT JOIN public.lots lot ON lot.id = allocation.lot_id
       LEFT JOIN public.stock_levels level ON level.id = allocation.stock_level_id
       LEFT JOIN public.stock_reservations reservation ON reservation.id = allocation.reservation_id
+      LEFT JOIN LATERAL (
+        SELECT event.event_type
+        FROM public.bon_livraison_event_log event
+        WHERE event.bon_livraison_id = line.bon_livraison_id
+          AND event.event_type IN ('PICK_CONFIRMED', 'PICK_RESET')
+          AND event.new_values->>'allocation_id' = allocation.id::text
+        ORDER BY event.created_at DESC, event.id DESC
+        LIMIT 1
+      ) latest_pick ON TRUE
       WHERE line.bon_livraison_id = $1::uuid
       ORDER BY line.ordre, allocation.id
       ${forUpdate ? "FOR UPDATE OF allocation" : ""}
@@ -252,7 +263,8 @@ function buildGroups(rows: AllocationRow[]): AllocationGroup[] {
 function buildPreview(
   snapshot: ShipmentSnapshot,
   qualityRelease: DeliveryQualityRelease | null = null,
-  enforceQuality = false
+  enforceQuality = false,
+  enforcePicking = false
 ): BonLivraisonShipmentPreview {
   const blockers: ShipmentPreviewBlocker[] = []
   const byLine = new Map<string, AllocationRow[]>()
@@ -387,6 +399,14 @@ function buildPreview(
         allocation_id: allocation.id,
       })
     }
+    if (enforcePicking && !allocation.pick_confirmed) {
+      blockers.push({
+        code: "PREPARATION_CONFIRMATION_REQUIRED",
+        message: "Le prélèvement physique de cette allocation doit être validé avant expédition.",
+        allocation_id: allocation.id,
+        line_id: allocation.bon_livraison_ligne_id,
+      })
+    }
 
     const available = deliveryQuantityAvailable({
       qty_on_hand: Number(allocation.qty_on_hand ?? 0),
@@ -436,6 +456,9 @@ function buildPreview(
       reservation_id: allocation.reservation_id,
       quantity: allocation.quantity,
       quantity_available: allocation.quantity_available,
+      pick_confirmed: snapshot.allocations.find(
+        (row) => row.id === allocation.allocation_id
+      )?.pick_confirmed ?? false,
     })),
     blockers: blockers.map((blocker) => blocker.code).sort(),
     document_pack: snapshot.document_pack,
@@ -583,7 +606,7 @@ export async function repoGetLivraisonShipmentPreview(
   const snapshot = await loadShipmentSnapshot(pool, bonLivraisonId)
   if (!snapshot) return null
   const qualityRelease = await repoGetDeliveryQualityRelease(bonLivraisonId)
-  return buildPreview(snapshot, qualityRelease, true)
+  return buildPreview(snapshot, qualityRelease, true, true)
 }
 
 export async function prepareLivraisonInTransaction(
@@ -948,7 +971,7 @@ export async function repoShipLivraison(
     const snapshot = await loadShipmentSnapshot(client, bonLivraisonId, true)
     if (!snapshot) throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
     const qualityRelease = await repoGetDeliveryQualityRelease(bonLivraisonId, client)
-    const preview = buildPreview(snapshot, qualityRelease, true)
+    const preview = buildPreview(snapshot, qualityRelease, true, true)
     if (
       !shipmentConfirmationMatches({
         expectedVersion: body.expected_version,

--- a/src/module/livraisons/routes/livraisons.routes.ts
+++ b/src/module/livraisons/routes/livraisons.routes.ts
@@ -21,10 +21,13 @@ import {
   getLivraison,
   getLivraisonPdfAvailability,
   getLivraisonShipmentPreview,
+  getLivraisonPreparation,
   getLivraisonDocumentFile,
   getLivraisonPdf,
   listLivraisons,
   shipLivraison,
+  confirmLivraisonPreparation,
+  resetLivraisonPreparation,
   updateLivraison,
   updateLivraisonLine,
   updateLivraisonStatus,
@@ -103,6 +106,22 @@ router.delete(
   "/:id/lignes/:lineId/allocations/:allocationId",
   requireLivraisonCapability("allocate"),
   deleteLivraisonLineAllocation
+)
+
+router.get(
+  "/:id/preparation",
+  requireLivraisonCapability("read"),
+  getLivraisonPreparation
+)
+router.post(
+  "/:id/preparation/allocations/:allocationId/confirm",
+  requireLivraisonCapability("prepare"),
+  confirmLivraisonPreparation
+)
+router.post(
+  "/:id/preparation/allocations/:allocationId/reset",
+  requireLivraisonCapability("prepare"),
+  resetLivraisonPreparation
 )
 
 router.get(

--- a/src/module/livraisons/services/livraisons.service.ts
+++ b/src/module/livraisons/services/livraisons.service.ts
@@ -9,6 +9,8 @@ import type {
   ListLivraisonsQueryDTO,
   LivraisonStatusBodyDTO,
   LivraisonProofBodyDTO,
+  ConfirmLivraisonPreparationBodyDTO,
+  ResetLivraisonPreparationBodyDTO,
   ShipLivraisonBodyDTO,
   UpdateLivraisonBodyDTO,
   UpdateLivraisonLineBodyDTO,
@@ -35,6 +37,11 @@ import {
   repoGetLivraisonShipmentPreview,
   repoShipLivraison,
 } from "../repository/livraisons-shipment.repository"
+import {
+  repoConfirmLivraisonPreparation,
+  repoGetLivraisonPreparation,
+  repoResetLivraisonPreparation,
+} from "../repository/livraisons-preparation.repository"
 
 function assertEditable(statut: BonLivraisonStatut, action: string) {
   if (statut === "DRAFT" || statut === "READY") return
@@ -132,6 +139,34 @@ export async function svcGetLivraisonShipmentPreview(id: string) {
     throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
   }
   return preview
+}
+
+export async function svcGetLivraisonPreparation(id: string) {
+  const preparation = await repoGetLivraisonPreparation(id)
+  if (!preparation) {
+    throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
+  }
+  return preparation
+}
+
+export function svcConfirmLivraisonPreparation(
+  id: string,
+  allocationId: string,
+  body: ConfirmLivraisonPreparationBodyDTO,
+  userId: number,
+  idempotencyKey: string
+) {
+  return repoConfirmLivraisonPreparation(id, allocationId, body, userId, idempotencyKey)
+}
+
+export function svcResetLivraisonPreparation(
+  id: string,
+  allocationId: string,
+  body: ResetLivraisonPreparationBodyDTO,
+  userId: number,
+  idempotencyKey: string
+) {
+  return repoResetLivraisonPreparation(id, allocationId, body, userId, idempotencyKey)
 }
 
 export function svcShipLivraison(

--- a/src/module/livraisons/types/livraisons.types.ts
+++ b/src/module/livraisons/types/livraisons.types.ts
@@ -296,3 +296,53 @@ export type BonLivraisonShipResult = {
   billing_event: "DELIVERY.SHIPPED"
   invoice_created: false
 }
+
+export type LivraisonPreparationInputMethod = "MANUAL" | "SCANNER"
+
+export type LivraisonPreparationConfirmation = {
+  event_id: string
+  input_method: LivraisonPreparationInputMethod
+  confirmed_at: string
+  confirmed_by: UserLite | null
+}
+
+export type LivraisonPreparationTask = {
+  allocation_id: string
+  line_id: string
+  line_order: number
+  designation: string
+  code_piece: string | null
+  article_id: string
+  article_code: string | null
+  article_designation: string | null
+  lot_id: string | null
+  lot_code: string | null
+  lot_status: string | null
+  stock_trace_code: string | null
+  magasin_code: string | null
+  emplacement_code: string | null
+  quantity: number
+  unit: string | null
+  reservation_status: string | null
+  affaire_refs: string[]
+  mp_lot_refs: string[]
+  traitement_lot_refs: string[]
+  confirmation: LivraisonPreparationConfirmation | null
+  can_confirm: boolean
+}
+
+export type BonLivraisonPreparation = {
+  bon_livraison_id: string
+  numero: string
+  status: BonLivraisonStatut
+  row_version: number
+  state: "NOT_READY" | "TO_PREPARE" | "IN_PROGRESS" | "COMPLETE" | "BLOCKED"
+  can_ship: boolean
+  progress: {
+    total: number
+    confirmed: number
+    remaining: number
+    percent: number
+  }
+  tasks: LivraisonPreparationTask[]
+}

--- a/src/module/livraisons/validators/livraisons.validators.ts
+++ b/src/module/livraisons/validators/livraisons.validators.ts
@@ -23,6 +23,11 @@ export const livraisonLineAllocationIdParamsSchema = z.object({
   allocationId: uuid,
 }).strict()
 
+export const livraisonPreparationAllocationParamsSchema = z.object({
+  id: uuid,
+  allocationId: uuid,
+}).strict()
+
 export const livraisonDocParamsSchema = z.object({
   id: uuid,
   docId: uuid,
@@ -166,6 +171,40 @@ export const shipLivraisonBodySchema = z
   .strict()
 
 export type ShipLivraisonBodyDTO = z.infer<typeof shipLivraisonBodySchema>
+
+export const confirmLivraisonPreparationBodySchema = z
+  .object({
+    expected_version: z.coerce.number().int().positive(),
+    input_method: z.enum(["MANUAL", "SCANNER"]),
+    scan_code: z.string().trim().min(1).max(200).optional(),
+  })
+  .strict()
+  .superRefine((body, ctx) => {
+    if (body.input_method === "SCANNER" && !body.scan_code) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["scan_code"],
+        message: "Le code scanné est obligatoire en mode SCANNER.",
+      })
+    }
+    if (body.input_method === "MANUAL" && body.scan_code) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["scan_code"],
+        message: "Le mode MANUAL n’accepte pas de code scanné.",
+      })
+    }
+  })
+
+export type ConfirmLivraisonPreparationBodyDTO = z.infer<typeof confirmLivraisonPreparationBodySchema>
+
+export const resetLivraisonPreparationBodySchema = z
+  .object({
+    expected_version: z.coerce.number().int().positive(),
+  })
+  .strict()
+
+export type ResetLivraisonPreparationBodyDTO = z.infer<typeof resetLivraisonPreparationBodySchema>
 
 export const livraisonProofBodySchema = z
   .object({


### PR DESCRIPTION
## Ce qui change
- expose la préparation physique d'un BL et ses tâches de prélèvement ;
- journalise les confirmations/réinitialisations de manière append-only, idempotente et auditée ;
- valide le lot scanné sans conserver le code brut ;
- bloque côté serveur le passage à SHIPPED tant que tous les prélèvements ne sont pas confirmés ;
- réutilise le schéma existant : aucune migration SQL.

## Pourquoi
La confirmation d'expédition devait être reliée à une preuve de prélèvement physique des réservations de stock.

## Validation
- TypeScript backend
- 145 tests ciblés Livraison
- contrat de schéma vérifié sur cerp_test et cerp_prod

Related: BigFootLime/crp-systems-web#226

## Summary by Sourcery

Introduce backend support for physical preparation of delivery notes, including exposure of pick tasks and enforcing confirmation before shipment.

New Features:
- Add API endpoints and service/repository layer to fetch a delivery’s physical preparation tasks and state, and to confirm or reset individual picks.
- Model preparation tasks and progress (including operator-facing state and confirmation metadata) for each delivery allocation.

Bug Fixes:
- Prevent server-side shipment of a delivery while any required pick tasks remain unconfirmed.

Enhancements:
- Validate scanner/manual input for pick confirmations and accept multiple canonical codes without storing raw scan data, using hashed values instead.
- Implement append-only, idempotent, audited logging of pick confirmation/reset events with realtime invalidation of delivery views.
- Extend shipment preview to surface pick confirmation status and treat missing confirmations as shipment blockers.
- Add contract and domain tests to verify preparation state derivation, scan code matching, and the integrity of the preparation/shipment coupling.