### PR TITLE
feat(quality): sécuriser la libération Qualité des BL

### DIFF
--- a/db/patches/20260813_quality_delivery_workflow_0437.sql
+++ b/db/patches/20260813_quality_delivery_workflow_0437.sql
@@ -1,0 +1,346 @@
+-- MEGA-QUALITE-BL-01 / #437 -- liberation qualite complete des BL.
+-- Ce patch ne cree aucune politique, aucun verdict et aucune signature.
+
+BEGIN;
+
+/* Politique globale, versionnee et auditee. */
+ALTER TABLE public.quality_delivery_release_policy
+  ADD COLUMN IF NOT EXISTS label text NULL,
+  ADD COLUMN IF NOT EXISTS justification text NULL,
+  ADD COLUMN IF NOT EXISTS document_reference text NULL,
+  ADD COLUMN IF NOT EXISTS submitted_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD COLUMN IF NOT EXISTS submitted_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS activated_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD COLUMN IF NOT EXISTS activated_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS superseded_by_policy_id uuid NULL
+    REFERENCES public.quality_delivery_release_policy(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD COLUMN IF NOT EXISTS superseded_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS revoked_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  ADD COLUMN IF NOT EXISTS revoked_at timestamptz NULL,
+  ADD COLUMN IF NOT EXISTS revocation_reason text NULL;
+
+UPDATE public.quality_delivery_release_policy
+SET status = CASE status WHEN 'RETIRED' THEN 'SUPERSEDED' ELSE status END,
+    label = COALESCE(label, code)
+WHERE status = 'RETIRED' OR label IS NULL;
+
+ALTER TABLE public.quality_delivery_release_policy
+  ALTER COLUMN label SET NOT NULL;
+
+DROP INDEX IF EXISTS public.quality_delivery_release_policy_one_signed_0005_uq;
+ALTER TABLE public.quality_delivery_release_policy
+  DROP CONSTRAINT IF EXISTS quality_delivery_release_policy_status_0005_ck,
+  DROP CONSTRAINT IF EXISTS quality_delivery_release_policy_signature_0005_ck;
+
+ALTER TABLE public.quality_delivery_release_policy
+  ADD CONSTRAINT quality_delivery_release_policy_status_0437_ck
+    CHECK (status IN ('DRAFT', 'IN_REVIEW', 'SIGNED', 'ACTIVE', 'SUPERSEDED', 'REVOKED')),
+  ADD CONSTRAINT quality_delivery_release_policy_signature_0437_ck
+    CHECK (
+      status IN ('DRAFT', 'IN_REVIEW')
+      OR (
+        signed_by IS NOT NULL
+        AND signed_at IS NOT NULL
+        AND signature_reference IS NOT NULL
+        AND char_length(btrim(signature_reference)) >= 3
+        AND document_reference IS NOT NULL
+        AND char_length(btrim(document_reference)) >= 3
+      )
+    ),
+  ADD CONSTRAINT quality_delivery_release_policy_revocation_0437_ck
+    CHECK (
+      status <> 'REVOKED'
+      OR (
+        revoked_by IS NOT NULL
+        AND revoked_at IS NOT NULL
+        AND revocation_reason IS NOT NULL
+        AND char_length(btrim(revocation_reason)) >= 10
+      )
+    );
+
+CREATE UNIQUE INDEX quality_delivery_release_policy_one_active_0437_uq
+  ON public.quality_delivery_release_policy ((status))
+  WHERE status = 'ACTIVE';
+
+CREATE TABLE IF NOT EXISTS public.quality_delivery_release_policy_event (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  policy_id uuid NOT NULL REFERENCES public.quality_delivery_release_policy(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  event_type text NOT NULL,
+  from_status text NULL,
+  to_status text NULL,
+  reason text NULL,
+  snapshot jsonb NOT NULL,
+  snapshot_sha256 text NOT NULL,
+  actor_user_id integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  idempotency_key text NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT quality_delivery_release_policy_event_type_0437_ck
+    CHECK (event_type IN ('CREATED', 'UPDATED', 'SUBMITTED', 'SIGNED', 'ACTIVATED', 'SUPERSEDED', 'REVOKED')),
+  CONSTRAINT quality_delivery_release_policy_event_hash_0437_ck
+    CHECK (snapshot_sha256 ~ '^[a-f0-9]{64}$'),
+  CONSTRAINT quality_delivery_release_policy_event_snapshot_0437_ck
+    CHECK (jsonb_typeof(snapshot) = 'object')
+);
+
+CREATE INDEX IF NOT EXISTS quality_delivery_release_policy_event_policy_0437_idx
+  ON public.quality_delivery_release_policy_event (policy_id, created_at, id);
+
+CREATE OR REPLACE FUNCTION public.quality_delivery_release_policy_guard_0005()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' AND OLD.status <> 'DRAFT' THEN
+    RAISE EXCEPTION 'Reviewed quality delivery policy is immutable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.status IN ('SIGNED', 'ACTIVE', 'SUPERSEDED', 'REVOKED') THEN
+    IF NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.code IS DISTINCT FROM OLD.code
+       OR NEW.version IS DISTINCT FROM OLD.version
+       OR NEW.label IS DISTINCT FROM OLD.label
+       OR NEW.rules IS DISTINCT FROM OLD.rules
+       OR NEW.rules_sha256 IS DISTINCT FROM OLD.rules_sha256
+       OR NEW.signature_reference IS DISTINCT FROM OLD.signature_reference
+       OR NEW.signed_by IS DISTINCT FROM OLD.signed_by
+       OR NEW.signed_at IS DISTINCT FROM OLD.signed_at
+       OR NEW.document_reference IS DISTINCT FROM OLD.document_reference
+       OR NEW.valid_from IS DISTINCT FROM OLD.valid_from
+       OR NEW.valid_to IS DISTINCT FROM OLD.valid_to
+       OR NEW.created_at IS DISTINCT FROM OLD.created_at
+       OR NEW.created_by IS DISTINCT FROM OLD.created_by
+    THEN
+      RAISE EXCEPTION 'Signed quality delivery policy content is immutable'
+        USING ERRCODE = '55000';
+    END IF;
+
+    IF NOT (
+      (OLD.status = 'SIGNED' AND NEW.status IN ('SIGNED', 'ACTIVE', 'REVOKED'))
+      OR (OLD.status = 'ACTIVE' AND NEW.status IN ('ACTIVE', 'SUPERSEDED', 'REVOKED'))
+      OR (OLD.status = 'SUPERSEDED' AND NEW.status = 'SUPERSEDED')
+      OR (OLD.status = 'REVOKED' AND NEW.status = 'REVOKED')
+    ) THEN
+      RAISE EXCEPTION 'Invalid signed quality delivery policy transition'
+        USING ERRCODE = '55000';
+    END IF;
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.quality_delivery_release_policy_event_append_only_0437()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  RAISE EXCEPTION 'Quality delivery policy audit is append-only'
+    USING ERRCODE = '55000';
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_quality_delivery_release_policy_event_append_only_0437
+  ON public.quality_delivery_release_policy_event;
+CREATE TRIGGER trg_quality_delivery_release_policy_event_append_only_0437
+  BEFORE UPDATE OR DELETE ON public.quality_delivery_release_policy_event
+  FOR EACH ROW EXECUTE FUNCTION public.quality_delivery_release_policy_event_append_only_0437();
+
+/* Un controle LOT_RELEASE designe l'allocation exacte et son BL. */
+ALTER TABLE public.quality_control
+  ADD COLUMN IF NOT EXISTS delivery_allocation_id uuid NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_delivery_allocation_0437_fk'
+      AND conrelid = 'public.quality_control'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control
+      ADD CONSTRAINT quality_control_delivery_allocation_0437_fk
+      FOREIGN KEY (delivery_allocation_id)
+      REFERENCES public.bon_livraison_ligne_allocations(id)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'quality_control_delivery_release_scope_0437_ck'
+      AND conrelid = 'public.quality_control'::regclass
+  ) THEN
+    ALTER TABLE public.quality_control
+      ADD CONSTRAINT quality_control_delivery_release_scope_0437_ck
+      CHECK (
+        trigger_type <> 'LOT_RELEASE'
+        OR (
+          source_type = 'LOT'
+          AND lot_id IS NOT NULL
+          AND bon_livraison_id IS NOT NULL
+          AND delivery_allocation_id IS NOT NULL
+        )
+      ) NOT VALID;
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS quality_control_delivery_allocation_0437_idx
+  ON public.quality_control (delivery_allocation_id, control_date DESC, id DESC)
+  WHERE delivery_allocation_id IS NOT NULL;
+
+/* Dossier canonique fige avant toute emission de pack. */
+CREATE TABLE IF NOT EXISTS public.quality_delivery_dossier_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  bon_livraison_id uuid NOT NULL REFERENCES public.bon_livraison(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  version integer NOT NULL,
+  status text NOT NULL DEFAULT 'FROZEN',
+  policy_id uuid NOT NULL REFERENCES public.quality_delivery_release_policy(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  policy_sha256 text NOT NULL,
+  release_preview_sha256 text NOT NULL,
+  dossier_sha256 text NOT NULL,
+  release_snapshot jsonb NOT NULL,
+  evidence_manifest jsonb NOT NULL,
+  freeze_reason text NOT NULL,
+  frozen_by integer NOT NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  frozen_at timestamptz NOT NULL DEFAULT now(),
+  revoked_by integer NULL REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE RESTRICT,
+  revoked_at timestamptz NULL,
+  revocation_reason text NULL,
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  idempotency_key text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT quality_delivery_dossier_versions_delivery_version_0437_uq UNIQUE (bon_livraison_id, version),
+  CONSTRAINT quality_delivery_dossier_versions_actor_key_0437_uq UNIQUE (frozen_by, idempotency_key),
+  CONSTRAINT quality_delivery_dossier_versions_status_0437_ck CHECK (status IN ('FROZEN', 'REVOKED')),
+  CONSTRAINT quality_delivery_dossier_versions_hashes_0437_ck CHECK (
+    policy_sha256 ~ '^[a-f0-9]{64}$'
+    AND release_preview_sha256 ~ '^[a-f0-9]{64}$'
+    AND dossier_sha256 ~ '^[a-f0-9]{64}$'
+  ),
+  CONSTRAINT quality_delivery_dossier_versions_json_0437_ck CHECK (
+    jsonb_typeof(release_snapshot) = 'object'
+    AND jsonb_typeof(evidence_manifest) = 'array'
+  ),
+  CONSTRAINT quality_delivery_dossier_versions_reason_0437_ck CHECK (char_length(btrim(freeze_reason)) >= 10),
+  CONSTRAINT quality_delivery_dossier_versions_revocation_0437_ck CHECK (
+    status <> 'REVOKED'
+    OR (
+      revoked_by IS NOT NULL
+      AND revoked_at IS NOT NULL
+      AND revocation_reason IS NOT NULL
+      AND char_length(btrim(revocation_reason)) >= 10
+    )
+  )
+);
+
+CREATE INDEX IF NOT EXISTS quality_delivery_dossier_versions_current_0437_idx
+  ON public.quality_delivery_dossier_versions (bon_livraison_id, version DESC)
+  WHERE status = 'FROZEN';
+
+CREATE OR REPLACE FUNCTION public.quality_delivery_dossier_guard_0437()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'Quality delivery dossier is append-only' USING ERRCODE = '55000';
+  END IF;
+  IF OLD.status = 'REVOKED' OR NEW.status <> 'REVOKED'
+     OR NEW.bon_livraison_id IS DISTINCT FROM OLD.bon_livraison_id
+     OR NEW.version IS DISTINCT FROM OLD.version
+     OR NEW.policy_id IS DISTINCT FROM OLD.policy_id
+     OR NEW.policy_sha256 IS DISTINCT FROM OLD.policy_sha256
+     OR NEW.release_preview_sha256 IS DISTINCT FROM OLD.release_preview_sha256
+     OR NEW.dossier_sha256 IS DISTINCT FROM OLD.dossier_sha256
+     OR NEW.release_snapshot IS DISTINCT FROM OLD.release_snapshot
+     OR NEW.evidence_manifest IS DISTINCT FROM OLD.evidence_manifest
+     OR NEW.freeze_reason IS DISTINCT FROM OLD.freeze_reason
+     OR NEW.frozen_by IS DISTINCT FROM OLD.frozen_by
+     OR NEW.frozen_at IS DISTINCT FROM OLD.frozen_at
+     OR NEW.correlation_id IS DISTINCT FROM OLD.correlation_id
+     OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key
+     OR NEW.created_at IS DISTINCT FROM OLD.created_at
+  THEN
+    RAISE EXCEPTION 'Frozen quality delivery dossier is immutable' USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_quality_delivery_dossier_guard_0437
+  ON public.quality_delivery_dossier_versions;
+CREATE TRIGGER trg_quality_delivery_dossier_guard_0437
+  BEFORE UPDATE OR DELETE ON public.quality_delivery_dossier_versions
+  FOR EACH ROW EXECUTE FUNCTION public.quality_delivery_dossier_guard_0437();
+
+ALTER TABLE public.bon_livraison_pack_versions
+  ADD COLUMN IF NOT EXISTS quality_dossier_version_id uuid NULL;
+
+CREATE OR REPLACE FUNCTION public.bon_livraison_pack_quality_dossier_guard_0437()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' AND NEW.status = 'GENERATED' AND NEW.quality_dossier_version_id IS NULL THEN
+    RAISE EXCEPTION 'A generated delivery pack requires a frozen quality dossier'
+      USING ERRCODE = '23514';
+  END IF;
+  IF TG_OP = 'UPDATE'
+     AND NEW.quality_dossier_version_id IS DISTINCT FROM OLD.quality_dossier_version_id
+  THEN
+    RAISE EXCEPTION 'Delivery pack quality dossier link is immutable'
+      USING ERRCODE = '55000';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_bon_livraison_pack_quality_dossier_guard_0437
+  ON public.bon_livraison_pack_versions;
+CREATE TRIGGER trg_bon_livraison_pack_quality_dossier_guard_0437
+  BEFORE INSERT OR UPDATE ON public.bon_livraison_pack_versions
+  FOR EACH ROW EXECUTE FUNCTION public.bon_livraison_pack_quality_dossier_guard_0437();
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'bon_livraison_pack_quality_dossier_0437_fk'
+      AND conrelid = 'public.bon_livraison_pack_versions'::regclass
+  ) THEN
+    ALTER TABLE public.bon_livraison_pack_versions
+      ADD CONSTRAINT bon_livraison_pack_quality_dossier_0437_fk
+      FOREIGN KEY (quality_dossier_version_id)
+      REFERENCES public.quality_delivery_dossier_versions(id)
+      ON UPDATE RESTRICT ON DELETE RESTRICT;
+  END IF;
+END $$;
+
+ALTER TABLE public.quality_command_receipts
+  DROP CONSTRAINT IF EXISTS quality_command_receipts_aggregate_228_ck;
+ALTER TABLE public.quality_command_receipts
+  ADD CONSTRAINT quality_command_receipts_aggregate_0437_ck
+  CHECK (aggregate_type IN (
+    'PLAN', 'CONTROL', 'NON_CONFORMITY', 'ACTION', 'DEROGATION',
+    'RELEASE', 'DISPOSITION', 'POLICY', 'DOSSIER'
+  ));
+
+REVOKE ALL ON public.quality_delivery_release_policy_event FROM PUBLIC;
+REVOKE ALL ON public.quality_delivery_dossier_versions FROM PUBLIC;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT, INSERT, UPDATE ON public.quality_delivery_release_policy TO cerp_app;
+    GRANT SELECT, INSERT ON public.quality_delivery_release_policy_event TO cerp_app;
+    GRANT SELECT, INSERT, UPDATE ON public.quality_delivery_dossier_versions TO cerp_app;
+  END IF;
+END $$;
+
+COMMENT ON TABLE public.quality_delivery_release_policy_event IS
+  'Journal append-only de la politique globale de liberation qualite des BL.';
+COMMENT ON COLUMN public.quality_control.delivery_allocation_id IS
+  'Allocation exacte du BL couverte par un controle LOT_RELEASE.';
+COMMENT ON TABLE public.quality_delivery_dossier_versions IS
+  'Versions canoniques et immuables du dossier qualite d un BL, figees avant emission.';
+
+COMMIT;

--- a/db/patches/support/20260813_quality_delivery_workflow_0437.preflight.sql
+++ b/db/patches/support/20260813_quality_delivery_workflow_0437.preflight.sql
@@ -1,0 +1,5 @@
+SELECT current_database() AS database_name,
+       to_regclass('public.quality_delivery_release_policy') IS NOT NULL AS has_policy,
+       to_regclass('public.quality_control') IS NOT NULL AS has_quality_control,
+       to_regclass('public.bon_livraison_pack_versions') IS NOT NULL AS has_pack_versions,
+       to_regclass('public.bon_livraison_ligne_allocations') IS NOT NULL AS has_allocations;

--- a/db/patches/support/20260813_quality_delivery_workflow_0437.rollback.sql
+++ b/db/patches/support/20260813_quality_delivery_workflow_0437.rollback.sql
@@ -1,0 +1,12 @@
+-- Rollback structurel uniquement pour environnement isole, apres suppression
+-- explicite des donnees creees par le patch.
+BEGIN;
+ALTER TABLE public.bon_livraison_pack_versions DROP CONSTRAINT IF EXISTS bon_livraison_pack_quality_dossier_0437_fk;
+ALTER TABLE public.bon_livraison_pack_versions DROP COLUMN IF EXISTS quality_dossier_version_id;
+DROP TABLE IF EXISTS public.quality_delivery_dossier_versions;
+ALTER TABLE public.quality_control DROP CONSTRAINT IF EXISTS quality_control_delivery_release_scope_0437_ck;
+ALTER TABLE public.quality_control DROP CONSTRAINT IF EXISTS quality_control_delivery_allocation_0437_fk;
+ALTER TABLE public.quality_control DROP COLUMN IF EXISTS delivery_allocation_id;
+DROP TABLE IF EXISTS public.quality_delivery_release_policy_event;
+DROP INDEX IF EXISTS public.quality_delivery_release_policy_one_active_0437_uq;
+COMMIT;

--- a/db/patches/support/20260813_quality_delivery_workflow_0437.verify.sql
+++ b/db/patches/support/20260813_quality_delivery_workflow_0437.verify.sql
@@ -1,0 +1,13 @@
+SELECT current_database() AS database_name,
+       to_regclass('public.quality_delivery_release_policy_event') IS NOT NULL AS has_policy_audit,
+       to_regclass('public.quality_delivery_dossier_versions') IS NOT NULL AS has_dossiers,
+       EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public' AND table_name = 'quality_control'
+           AND column_name = 'delivery_allocation_id'
+       ) AS has_allocation_scope,
+       EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_schema = 'public' AND table_name = 'bon_livraison_pack_versions'
+           AND column_name = 'quality_dossier_version_id'
+       ) AS pack_links_dossier;

--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -392,19 +392,25 @@ async function main() {
     );
     await client.query(
       `INSERT INTO public.quality_delivery_release_policy (
-         id,code,version,status,rules,rules_sha256,signature_reference,
-         signed_by,signed_at,valid_from,valid_to,created_by,updated_by
+         id,code,version,label,status,justification,rules,rules_sha256,signature_reference,
+         document_reference,signed_by,signed_at,activated_by,activated_at,
+         valid_from,valid_to,created_by,updated_by
        ) VALUES (
-         '2a000000-0000-4000-8000-000000000001','SOL05-DELIVERY-RELEASE',1,'SIGNED',
-         $1::jsonb,$2,'SOL05-E2E-SIGNATURE',
+         '2a000000-0000-4000-8000-000000000001','SOL05-DELIVERY-RELEASE',1,
+         'Politique livraison fixture SOL-05','ACTIVE','Fixture preexistante strictement isolee',
+         $1::jsonb,$2,'SOL05-E2E-SIGNATURE','SOL05-E2E-DOCUMENT',
+         (SELECT id FROM public.users WHERE username='KEENAN'),'2026-01-01T00:00:00Z',
          (SELECT id FROM public.users WHERE username='KEENAN'),'2026-01-01T00:00:00Z',
          '2026-01-01T00:00:00Z',NULL,
          (SELECT id FROM public.users WHERE username='KEENAN'),
          (SELECT id FROM public.users WHERE username='KEENAN')
        ) ON CONFLICT (code,version) DO UPDATE SET
-         status='SIGNED',rules=EXCLUDED.rules,rules_sha256=EXCLUDED.rules_sha256,
+         status='ACTIVE',label=EXCLUDED.label,justification=EXCLUDED.justification,
+         rules=EXCLUDED.rules,rules_sha256=EXCLUDED.rules_sha256,
          signature_reference=EXCLUDED.signature_reference,signed_by=EXCLUDED.signed_by,
-         signed_at=EXCLUDED.signed_at,valid_from=EXCLUDED.valid_from,valid_to=NULL,
+         document_reference=EXCLUDED.document_reference,signed_at=EXCLUDED.signed_at,
+         activated_by=EXCLUDED.activated_by,activated_at=EXCLUDED.activated_at,
+         valid_from=EXCLUDED.valid_from,valid_to=NULL,
          updated_by=EXCLUDED.updated_by`,
       [JSON.stringify(DELIVERY_QUALITY_RULES), DELIVERY_QUALITY_RULES_SHA256]
     );

--- a/src/__tests__/quality-delivery-policy-437.domain.test.ts
+++ b/src/__tests__/quality-delivery-policy-437.domain.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  assertDeliveryPolicyContentMutable,
+  assertDeliveryPolicyTransition,
+} from "../module/qualite/domain/quality-policy";
+
+describe("#437 politique globale de liberation BL", () => {
+  it.each([
+    ["DRAFT", "IN_REVIEW"],
+    ["IN_REVIEW", "SIGNED"],
+    ["SIGNED", "ACTIVE"],
+    ["ACTIVE", "SUPERSEDED"],
+    ["ACTIVE", "REVOKED"],
+  ] as const)("autorise %s vers %s", (from, to) => {
+    expect(() => assertDeliveryPolicyTransition(from, to)).not.toThrow();
+  });
+
+  it("refuse l'activation directe et toute edition apres signature", () => {
+    expect(() => assertDeliveryPolicyTransition("DRAFT", "ACTIVE")).toThrowError(/interdite/);
+    expect(() => assertDeliveryPolicyContentMutable("ACTIVE")).toThrowError(/revision/);
+  });
+});

--- a/src/module/commande-client/repository/commande-fulfillment-guards.repository.ts
+++ b/src/module/commande-client/repository/commande-fulfillment-guards.repository.ts
@@ -134,15 +134,35 @@ export async function assertCommandeQualityReleased(tx: Queryable, commandeId: n
         SELECT id, GREATEST(COALESCE(quantite_bonne, 0), 0)::numeric AS qty_required
         FROM public.ordres_fabrication
         WHERE commande_id = $1 AND statut::text <> 'ANNULE'
+      ), release_evidence AS (
+        SELECT decision.object_id AS of_id,
+               decision.qty,
+               decision.decision,
+               decision.verdict
+        FROM public.quality_release_decision decision
+        WHERE decision.object_type = 'OF'
+          AND decision.object_id IN (SELECT id::text FROM active_of)
+
+        UNION ALL
+
+        SELECT control.of_id::text AS of_id,
+               decision.qty,
+               decision.decision,
+               decision.verdict
+        FROM public.quality_release_decision decision
+        JOIN public.quality_control control ON control.id = decision.quality_control_id
+        WHERE control.of_id IN (SELECT id FROM active_of)
+          AND control.trigger_type = 'LOT_RELEASE'
+          AND control.delivery_allocation_id IS NOT NULL
+          AND decision.object_type = control.source_type
+          AND decision.object_id = control.source_id
       ), released AS (
-        SELECT object_id,
+        SELECT of_id AS object_id,
           COALESCE(SUM(qty) FILTER (
             WHERE decision IN ('FULL','PARTIAL') AND verdict IN ('CONFORME','PARTIEL')
           ), 0)::numeric AS qty_released
-        FROM public.quality_release_decision
-        WHERE object_type = 'OF'
-          AND object_id IN (SELECT id::text FROM active_of)
-        GROUP BY object_id
+        FROM release_evidence
+        GROUP BY of_id
       )
       SELECT
         (SELECT COUNT(*)::int FROM active_of) AS total,

--- a/src/module/livraisons/controllers/pack.controller.ts
+++ b/src/module/livraisons/controllers/pack.controller.ts
@@ -3,8 +3,20 @@ import type { Request, RequestHandler } from "express"
 import { HttpError } from "../../../utils/httpError"
 import { getDocumentStoragePath } from "../../../utils/cerpStorage"
 import { sendSecureStoredFile } from "../../../shared/uploads/secure-download"
-import { packGenerateBodySchema, packPreviewParamsSchema, packRevokeParamsSchema } from "../validators/pack.validators"
+import { normalizeQualityIdempotencyKey } from "../../qualite/domain/quality-policy"
+import {
+  packGenerateBodySchema,
+  packPreviewParamsSchema,
+  packRevokeParamsSchema,
+  qualityDossierFreezeBodySchema,
+  qualityDossierRevokeBodySchema,
+} from "../validators/pack.validators"
 import { repoFindDocumentFilePath, repoGetDocumentName, repoIsLivraisonDocumentLinked } from "../repository/livraisons.repository"
+import {
+  repoFreezeDeliveryQualityDossier,
+  repoGetDeliveryQualityDossier,
+  repoRevokeDeliveryQualityDossier,
+} from "../repository/quality-dossier.repository"
 import { svcGenerateLivraisonPack, svcGetLivraisonPackPreview, svcRevokeLivraisonPackVersion } from "../services/pack.service"
 
 function coerceBool(value: unknown): boolean {
@@ -37,6 +49,53 @@ export const getLivraisonPackPreview: RequestHandler = async (req, res, next) =>
     res.json(out)
   } catch (e) {
     next(e)
+  }
+}
+
+export const getLivraisonQualityDossier: RequestHandler = async (req, res, next) => {
+  try {
+    getUserId(req)
+    const { id } = packPreviewParamsSchema.parse(req.params)
+    res.json(await repoGetDeliveryQualityDossier(id))
+  } catch (error) {
+    next(error)
+  }
+}
+
+export const freezeLivraisonQualityDossier: RequestHandler = async (req, res, next) => {
+  try {
+    const actorUserId = getUserId(req)
+    const { id } = packPreviewParamsSchema.parse(req.params)
+    const body = qualityDossierFreezeBodySchema.parse(req.body)
+    const key = normalizeQualityIdempotencyKey(
+      typeof req.headers["idempotency-key"] === "string" ? req.headers["idempotency-key"] : null
+    )
+    const out = await repoFreezeDeliveryQualityDossier({
+      bonLivraisonId: id,
+      expectedPreviewSha256: body.quality_preview_sha256,
+      reason: body.reason,
+      actorUserId,
+      idempotencyKey: key,
+    })
+    res.status(201).json(out)
+  } catch (error) {
+    next(error)
+  }
+}
+
+export const revokeLivraisonQualityDossier: RequestHandler = async (req, res, next) => {
+  try {
+    const actorUserId = getUserId(req)
+    const { id, versionId } = packRevokeParamsSchema.parse(req.params)
+    const body = qualityDossierRevokeBodySchema.parse(req.body)
+    res.json(await repoRevokeDeliveryQualityDossier({
+      bonLivraisonId: id,
+      versionId,
+      reason: body.reason,
+      actorUserId,
+    }))
+  } catch (error) {
+    next(error)
   }
 }
 

--- a/src/module/livraisons/domain/quality-release-gate.test.ts
+++ b/src/module/livraisons/domain/quality-release-gate.test.ts
@@ -16,6 +16,8 @@ const CONTROL_ID = "10000000-0000-4000-8000-000000000003"
 const RELEASE_ID = "10000000-0000-4000-8000-000000000004"
 const DEROGATION_ID = "10000000-0000-4000-8000-000000000005"
 const CONSUMPTION_ID = "10000000-0000-4000-8000-000000000006"
+const ALLOCATION_ID = "10000000-0000-4000-8000-000000000007"
+const LINE_ID = "10000000-0000-4000-8000-000000000008"
 
 function rules(requiredDocuments: Array<Record<string, unknown>> = []) {
   return {
@@ -41,7 +43,23 @@ function policy(policyRules: unknown = rules()): DeliveryQualityPolicy {
 
 function target(overrides: Partial<DeliveryQualityTargetObservation["target"]> = {}): DeliveryQualityTargetObservation {
   return {
-    key: `LOT:${LOT_ID}`,
+    key: `ALLOCATION:${ALLOCATION_ID}`,
+    allocation_id: ALLOCATION_ID,
+    delivery_line_id: LINE_ID,
+    article_id: null,
+    article_code: null,
+    article_designation: null,
+    lot_id: LOT_ID,
+    lot_code: "LOT-42",
+    unite: "pce",
+    plan: null,
+    control_count: 1,
+    latest_decision: {
+      id: RELEASE_ID,
+      decision: "FULL",
+      qty: 5,
+      decided_at: "2026-08-05T08:00:00.000Z",
+    },
     target: {
       object_type: "LOT",
       object_id: LOT_ID,
@@ -72,7 +90,7 @@ function evidence(): DeliveryQualityEvidence {
     mime_type: "application/pdf",
     size_bytes: 2048,
     sha256: "c".repeat(64),
-    target_keys: [`LOT:${LOT_ID}`],
+    target_keys: [`ALLOCATION:${ALLOCATION_ID}`],
   }
 }
 
@@ -96,6 +114,8 @@ describe("delivery quality release gate", () => {
 
     expect(first.state).toBe("UNKNOWN")
     expect(first.reasons[0]?.code).toBe("QUALITY_POLICY_MISSING")
+    expect(first.targets).toHaveLength(1)
+    expect(first.targets[0]?.allocation_id).toBe(ALLOCATION_ID)
     expect(first.preview_sha256).toBe(later.preview_sha256)
   })
 

--- a/src/module/livraisons/domain/quality-release-gate.ts
+++ b/src/module/livraisons/domain/quality-release-gate.ts
@@ -44,10 +44,12 @@ export type DeliveryQualityPolicy = {
 }
 
 export type DeliveryQualityPolicyRules = {
-  schema: "cerp.quality.delivery-release-policy.v1"
+  schema: "cerp.quality.delivery-release-policy.v1" | "cerp.quality.delivery-release-policy.v2"
   engine: "CERP_QUALITY_ELIGIBILITY_V1"
   aggregate_scope: "ALL_DELIVERY_ALLOCATIONS"
   derogation_mode: "FORBIDDEN" | "APPROVED_LINKED_RELEASE_ONLY"
+  required_control_triggers: Array<"LOT_RELEASE">
+  require_independent_decider: boolean
   required_documents: Array<{
     document_type: string
     scope: "PER_DELIVERY" | "PER_TARGET"
@@ -74,6 +76,22 @@ export type DeliveryQualityDerogation = {
 export type DeliveryQualityTargetObservation = {
   key: string
   target: EligibilityTarget
+  allocation_id: string
+  delivery_line_id: string
+  article_id: string | null
+  article_code: string | null
+  article_designation: string | null
+  lot_id: string | null
+  lot_code: string | null
+  unite: string | null
+  plan: { id: string; code: string; version: number } | null
+  control_count: number
+  latest_decision: {
+    id: string
+    decision: "FULL" | "PARTIAL" | "HOLD" | "REJECT"
+    qty: number
+    decided_at: string
+  } | null
   derogation: DeliveryQualityDerogation | null
 }
 
@@ -100,11 +118,22 @@ export type DeliveryQualityRelease = {
   reasons: DeliveryQualityReleaseReason[]
   targets: Array<{
     key: string
+    allocation_id: string
+    delivery_line_id: string
+    article_id: string | null
+    article_code: string | null
+    article_designation: string | null
+    lot_id: string | null
+    lot_code: string | null
+    unite: string | null
     object_type: string
     object_id: string
     label: string | null
     qty_requested: number
     qty_allowed: number
+    plan: { id: string; code: string; version: number } | null
+    control_count: number
+    latest_decision: DeliveryQualityTargetObservation["latest_decision"]
     derogation_id: string | null
     release_decision_id: string | null
   }>
@@ -124,12 +153,33 @@ function hasExactKeys(value: Record<string, unknown>, keys: string[]): boolean {
 
 export function parseDeliveryQualityPolicyRules(value: unknown): DeliveryQualityPolicyRules | null {
   if (!isRecord(value)) return null
-  if (!hasExactKeys(value, ["schema", "engine", "aggregate_scope", "derogation_mode", "required_documents"])) return null
-  if (value.schema !== "cerp.quality.delivery-release-policy.v1") return null
+  const isV1 = value.schema === "cerp.quality.delivery-release-policy.v1"
+  const isV2 = value.schema === "cerp.quality.delivery-release-policy.v2"
+  if (!isV1 && !isV2) return null
+  const expectedKeys = isV1
+    ? ["schema", "engine", "aggregate_scope", "derogation_mode", "required_documents"]
+    : [
+        "schema",
+        "engine",
+        "aggregate_scope",
+        "derogation_mode",
+        "required_control_triggers",
+        "require_independent_decider",
+        "required_documents",
+      ]
+  if (!hasExactKeys(value, expectedKeys)) return null
   if (value.engine !== "CERP_QUALITY_ELIGIBILITY_V1") return null
   if (value.aggregate_scope !== "ALL_DELIVERY_ALLOCATIONS") return null
   if (value.derogation_mode !== "FORBIDDEN" && value.derogation_mode !== "APPROVED_LINKED_RELEASE_ONLY") return null
   if (!Array.isArray(value.required_documents)) return null
+  if (isV2) {
+    if (!Array.isArray(value.required_control_triggers)) return null
+    if (
+      value.required_control_triggers.length !== 1 ||
+      value.required_control_triggers[0] !== "LOT_RELEASE" ||
+      typeof value.require_independent_decider !== "boolean"
+    ) return null
+  }
 
   const requiredDocuments: DeliveryQualityPolicyRules["required_documents"] = []
   for (const raw of value.required_documents) {
@@ -145,12 +195,51 @@ export function parseDeliveryQualityPolicyRules(value: unknown): DeliveryQuality
   }
 
   return {
-    schema: value.schema,
+    schema: isV2
+      ? "cerp.quality.delivery-release-policy.v2"
+      : "cerp.quality.delivery-release-policy.v1",
     engine: value.engine,
     aggregate_scope: value.aggregate_scope,
     derogation_mode: value.derogation_mode,
+    required_control_triggers: isV2 ? ["LOT_RELEASE"] : [],
+    require_independent_decider: isV2 ? Boolean(value.require_independent_decider) : true,
     required_documents: requiredDocuments,
   }
+}
+
+function targetSnapshot(
+  observation: DeliveryQualityTargetObservation,
+  qtyAllowed = 0,
+  derogationId: string | null = null,
+  releaseDecisionId: string | null = null
+): DeliveryQualityRelease["targets"][number] {
+  return {
+    key: observation.key,
+    allocation_id: observation.allocation_id,
+    delivery_line_id: observation.delivery_line_id,
+    article_id: observation.article_id,
+    article_code: observation.article_code,
+    article_designation: observation.article_designation,
+    lot_id: observation.lot_id,
+    lot_code: observation.lot_code,
+    unite: observation.unite,
+    object_type: observation.target.object_type,
+    object_id: observation.target.object_id,
+    label: observation.target.label,
+    qty_requested: observation.target.qty_requested,
+    qty_allowed: qtyAllowed,
+    plan: observation.plan,
+    control_count: observation.control_count,
+    latest_decision: observation.latest_decision,
+    derogation_id: derogationId,
+    release_decision_id: releaseDecisionId,
+  }
+}
+
+function visibleTargets(input: DeliveryQualityReleaseInput): DeliveryQualityRelease["targets"] {
+  return [...input.targets]
+    .sort((left, right) => left.key.localeCompare(right.key))
+    .map((observation) => targetSnapshot(observation))
 }
 
 function blockingReason(params: Omit<DeliveryQualityReleaseReason, "severity">): DeliveryQualityReleaseReason {
@@ -219,7 +308,7 @@ export function evaluateDeliveryQualityRelease(input: DeliveryQualityReleaseInpu
           object_id: input.bon_livraison_id,
         }),
       ],
-      [],
+      visibleTargets(input),
       [],
       []
     )
@@ -243,7 +332,7 @@ export function evaluateDeliveryQualityRelease(input: DeliveryQualityReleaseInpu
           object_id: input.bon_livraison_id,
         }),
       ],
-      [],
+      visibleTargets(input),
       [],
       []
     )
@@ -266,7 +355,7 @@ export function evaluateDeliveryQualityRelease(input: DeliveryQualityReleaseInpu
           object_id: policy.id,
         }),
       ],
-      [],
+      visibleTargets(input),
       [],
       []
     )
@@ -286,7 +375,7 @@ export function evaluateDeliveryQualityRelease(input: DeliveryQualityReleaseInpu
           object_id: input.bon_livraison_id,
         }),
       ],
-      [],
+      visibleTargets(input),
       [],
       []
     )
@@ -307,7 +396,7 @@ export function evaluateDeliveryQualityRelease(input: DeliveryQualityReleaseInpu
           object_id: input.bon_livraison_id,
         }),
       ],
-      [],
+      visibleTargets(input),
       [],
       []
     )
@@ -318,6 +407,39 @@ export function evaluateDeliveryQualityRelease(input: DeliveryQualityReleaseInpu
   const derogationIds = new Set<string>()
 
   for (const observation of [...input.targets].sort((a, b) => a.key.localeCompare(b.key))) {
+    if (rules.required_control_triggers.includes("LOT_RELEASE")) {
+      if (!observation.plan) {
+        reasons.push(
+          blockingReason({
+            code: "QUALITY_PLAN_REQUIRED",
+            message: `Aucun plan LOT_RELEASE publie ne couvre ${observation.target.label ?? observation.target.object_id}.`,
+            expected_action: "Publier un plan LOT_RELEASE applicable a l'article puis demarrer le controle.",
+            object_type: observation.target.object_type,
+            object_id: observation.target.object_id,
+          })
+        )
+      } else if (observation.control_count === 0) {
+        reasons.push(
+          blockingReason({
+            code: "QUALITY_CONTROL_REQUIRED",
+            message: `Le controle LOT_RELEASE de ${observation.target.label ?? observation.target.object_id} n'a pas ete demarre.`,
+            expected_action: "Demarrer et renseigner le controle sur cette allocation exacte.",
+            object_type: observation.target.object_type,
+            object_id: observation.target.object_id,
+          })
+        )
+      } else if (!observation.latest_decision) {
+        reasons.push(
+          blockingReason({
+            code: "QUALITY_DECISION_REQUIRED",
+            message: `Aucune decision de liberation n'est prononcee pour ${observation.target.label ?? observation.target.object_id}.`,
+            expected_action: "Faire decider le controle par un utilisateur distinct de l'operateur.",
+            object_type: observation.target.object_type,
+            object_id: observation.target.object_id,
+          })
+        )
+      }
+    }
     const verdict = evaluateQualityEligibility(observation.target, "SHIP", at)
     for (const block of verdict.blocks) {
       reasons.push(
@@ -395,16 +517,14 @@ export function evaluateDeliveryQualityRelease(input: DeliveryQualityReleaseInpu
       }
     }
 
-    targets.push({
-      key: observation.key,
-      object_type: observation.target.object_type,
-      object_id: observation.target.object_id,
-      label: observation.target.label,
-      qty_requested: observation.target.qty_requested,
-      qty_allowed: verdict.qty_allowed,
-      derogation_id: acceptedDerogation?.state.id ?? null,
-      release_decision_id: acceptedDerogation?.release_decision_id ?? null,
-    })
+    targets.push(
+      targetSnapshot(
+        observation,
+        verdict.qty_allowed,
+        acceptedDerogation?.state.id ?? null,
+        observation.latest_decision?.id ?? acceptedDerogation?.release_decision_id ?? null
+      )
+    )
   }
 
   const requiredEvidence = new Map<string, DeliveryQualityEvidence>()

--- a/src/module/livraisons/repository/pack.repository.ts
+++ b/src/module/livraisons/repository/pack.repository.ts
@@ -4,7 +4,7 @@ import { HttpError } from "../../../utils/httpError"
 import type { LivraisonPackPreview, LivraisonPackStockMovement, LivraisonPackVersion, LivraisonPackAllocation } from "../types/pack.types"
 import type { BonLivraisonDocument, BonLivraisonLigne } from "../types/livraisons.types"
 import { repoGetLivraisonDetail } from "./livraisons.repository"
-import { repoGetDeliveryQualityRelease } from "./quality-release.repository"
+import { repoGetDeliveryQualityDossier } from "./quality-dossier.repository"
 import type { DeliveryQualityRelease } from "../domain/quality-release-gate"
 
 function almostEqual(a: number, b: number, tolerance = 0.0001): boolean {
@@ -139,6 +139,7 @@ export async function repoGetLivraisonPackPreview(bonLivraisonId: string): Promi
     quality_policy_id: string | null
     quality_policy_sha256: string | null
     quality_release_snapshot: DeliveryQualityRelease | null
+    quality_dossier_version_id: string | null
   }
 
   const packVersionsRes = await pool.query<PackVersionRow>(
@@ -165,6 +166,7 @@ export async function repoGetLivraisonPackPreview(bonLivraisonId: string): Promi
         pv.quality_policy_id::text AS quality_policy_id,
         pv.quality_policy_sha256,
         pv.quality_release_snapshot
+        , pv.quality_dossier_version_id::text AS quality_dossier_version_id
       FROM public.bon_livraison_pack_versions pv
       LEFT JOIN public.users u ON u.id = pv.generated_by
       LEFT JOIN public.bon_livraison_documents blDoc ON blDoc.id = pv.bl_pdf_document_id
@@ -219,6 +221,7 @@ export async function repoGetLivraisonPackPreview(bonLivraisonId: string): Promi
       quality_policy_id: r.quality_policy_id,
       quality_policy_sha256: r.quality_policy_sha256,
       quality_release_snapshot: r.quality_release_snapshot,
+      quality_dossier_version_id: r.quality_dossier_version_id,
     }
   })
 
@@ -245,9 +248,11 @@ export async function repoGetLivraisonPackPreview(bonLivraisonId: string): Promi
   missing.push(...allocCheck.missing)
   if (!stock_link_ok) missing.push("STOCK_LINK_MISSING")
 
-  const quality_release = await repoGetDeliveryQualityRelease(bonLivraisonId)
+  const dossier = await repoGetDeliveryQualityDossier(bonLivraisonId)
+  const quality_release = dossier.release
   const quality_release_ok = quality_release.state === "READY" || quality_release.state === "DEROGATED"
   if (!quality_release_ok) missing.push(`QUALITY_RELEASE_${quality_release.state}`)
+  if (!dossier.is_current) missing.push("QUALITY_DOSSIER_NOT_FROZEN")
 
   return {
     bon_livraison: detail.bon_livraison,
@@ -257,6 +262,11 @@ export async function repoGetLivraisonPackPreview(bonLivraisonId: string): Promi
     documents_generated,
     pack_versions,
     quality_release,
+    quality_dossier: {
+      latest: dossier.latest,
+      versions: dossier.versions,
+      is_current: dossier.is_current,
+    },
     checks: {
       allocations_ok: allocCheck.allocations_ok,
       shipped_or_ready,

--- a/src/module/livraisons/repository/quality-dossier.repository.ts
+++ b/src/module/livraisons/repository/quality-dossier.repository.ts
@@ -1,0 +1,164 @@
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { qualitySha256 } from "../../qualite/domain/quality-policy";
+import { HttpError } from "../../../utils/httpError";
+import type { DeliveryQualityRelease } from "../domain/quality-release-gate";
+import { repoGetDeliveryQualityRelease } from "./quality-release.repository";
+
+export type DeliveryQualityDossierVersion = {
+  id: string;
+  bon_livraison_id: string;
+  version: number;
+  status: "FROZEN" | "REVOKED";
+  policy_id: string;
+  policy_sha256: string;
+  release_preview_sha256: string;
+  dossier_sha256: string;
+  release_snapshot: DeliveryQualityRelease;
+  evidence_manifest: DeliveryQualityRelease["required_evidence"];
+  freeze_reason: string;
+  frozen_by: number;
+  frozen_at: string;
+  revoked_by: number | null;
+  revoked_at: string | null;
+  revocation_reason: string | null;
+  created_at: string;
+};
+
+const DOSSIER_COLUMNS = `
+  id::text AS id, bon_livraison_id::text AS bon_livraison_id, version, status,
+  policy_id::text AS policy_id, policy_sha256, release_preview_sha256, dossier_sha256,
+  release_snapshot, evidence_manifest, freeze_reason, frozen_by,
+  frozen_at::text AS frozen_at, revoked_by, revoked_at::text AS revoked_at,
+  revocation_reason, created_at::text AS created_at
+`;
+
+async function selectVersions(
+  q: Pick<PoolClient, "query">,
+  bonLivraisonId: string
+): Promise<DeliveryQualityDossierVersion[]> {
+  const result = await q.query<DeliveryQualityDossierVersion>(
+    `SELECT ${DOSSIER_COLUMNS}
+     FROM public.quality_delivery_dossier_versions
+     WHERE bon_livraison_id = $1::uuid
+     ORDER BY version DESC, id DESC`,
+    [bonLivraisonId]
+  );
+  return result.rows;
+}
+
+export async function repoGetDeliveryQualityDossier(
+  bonLivraisonId: string,
+  q: Pick<PoolClient, "query"> = pool
+): Promise<{
+  release: DeliveryQualityRelease;
+  latest: DeliveryQualityDossierVersion | null;
+  versions: DeliveryQualityDossierVersion[];
+  is_current: boolean;
+}> {
+  const [release, versions] = await Promise.all([
+    repoGetDeliveryQualityRelease(bonLivraisonId, q),
+    selectVersions(q, bonLivraisonId),
+  ]);
+  const latest = versions.find((version) => version.status === "FROZEN") ?? null;
+  return {
+    release,
+    latest,
+    versions,
+    is_current:
+      latest !== null &&
+      latest.release_preview_sha256 === release.preview_sha256 &&
+      latest.policy_sha256 === release.policy?.rules_sha256,
+  };
+}
+
+export async function repoFreezeDeliveryQualityDossier(params: {
+  bonLivraisonId: string;
+  expectedPreviewSha256: string;
+  reason: string;
+  actorUserId: number;
+  idempotencyKey: string;
+}): Promise<DeliveryQualityDossierVersion> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query(`SELECT pg_advisory_xact_lock(hashtextextended($1, $2::bigint))`, [params.idempotencyKey, params.actorUserId]);
+    const replay = await client.query<DeliveryQualityDossierVersion>(
+      `SELECT ${DOSSIER_COLUMNS}
+       FROM public.quality_delivery_dossier_versions
+       WHERE frozen_by = $1 AND idempotency_key = $2`,
+      [params.actorUserId, params.idempotencyKey]
+    );
+    if (replay.rows[0]) {
+      if (replay.rows[0].bon_livraison_id !== params.bonLivraisonId) {
+        throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Cette Idempotency-Key designe un autre dossier.");
+      }
+      await client.query("COMMIT");
+      return replay.rows[0];
+    }
+
+    const delivery = await client.query<{ id: string }>(
+      `SELECT id::text AS id FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`,
+      [params.bonLivraisonId]
+    );
+    if (!delivery.rows[0]) throw new HttpError(404, "NOT_FOUND", "Bon de livraison introuvable.");
+
+    const release = await repoGetDeliveryQualityRelease(params.bonLivraisonId, client);
+    if (release.preview_sha256 !== params.expectedPreviewSha256) {
+      throw new HttpError(409, "QUALITY_PREVIEW_STALE", "La decision qualite a change : rechargez le dossier.");
+    }
+    if ((release.state !== "READY" && release.state !== "DEROGATED") || !release.policy) {
+      throw new HttpError(409, "QUALITY_DOSSIER_NOT_RELEASABLE", "Le dossier ne peut etre fige tant que la liberation est bloquee.", { release });
+    }
+    const versionResult = await client.query<{ version: number }>(
+      `SELECT COALESCE(MAX(version), 0)::int + 1 AS version
+       FROM public.quality_delivery_dossier_versions
+       WHERE bon_livraison_id = $1::uuid`,
+      [params.bonLivraisonId]
+    );
+    const version = versionResult.rows[0]!.version;
+    const canonical = {
+      schema: "cerp.quality.delivery-dossier.v1",
+      bon_livraison_id: params.bonLivraisonId,
+      version,
+      policy: release.policy,
+      release,
+      evidence_manifest: release.required_evidence,
+      freeze_reason: params.reason,
+    };
+    const inserted = await client.query<DeliveryQualityDossierVersion>(
+      `INSERT INTO public.quality_delivery_dossier_versions (
+         bon_livraison_id, version, policy_id, policy_sha256,
+         release_preview_sha256, dossier_sha256, release_snapshot,
+         evidence_manifest, freeze_reason, frozen_by, idempotency_key
+       ) VALUES ($1::uuid, $2, $3::uuid, $4, $5, $6, $7::jsonb, $8::jsonb, $9, $10, $11)
+       RETURNING ${DOSSIER_COLUMNS}`,
+      [params.bonLivraisonId, version, release.policy.id, release.policy.rules_sha256, release.preview_sha256, qualitySha256(canonical), JSON.stringify(release), JSON.stringify(release.required_evidence), params.reason, params.actorUserId, params.idempotencyKey]
+    );
+    await client.query("COMMIT");
+    return inserted.rows[0]!;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+export async function repoRevokeDeliveryQualityDossier(params: {
+  bonLivraisonId: string;
+  versionId: string;
+  reason: string;
+  actorUserId: number;
+}): Promise<DeliveryQualityDossierVersion> {
+  const result = await pool.query<DeliveryQualityDossierVersion>(
+    `UPDATE public.quality_delivery_dossier_versions
+     SET status = 'REVOKED', revoked_by = $3, revoked_at = now(), revocation_reason = $4
+     WHERE id = $1::uuid AND bon_livraison_id = $2::uuid AND status = 'FROZEN'
+     RETURNING ${DOSSIER_COLUMNS}`,
+    [params.versionId, params.bonLivraisonId, params.actorUserId, params.reason]
+  );
+  if (!result.rows[0]) throw new HttpError(404, "NOT_FOUND", "Version de dossier qualite active introuvable.");
+  return result.rows[0];
+}

--- a/src/module/livraisons/repository/quality-release.repository.ts
+++ b/src/module/livraisons/repository/quality-release.repository.ts
@@ -14,6 +14,8 @@ type Queryable = Pick<PoolClient, "query">
 
 type TargetRow = {
   target_key: string
+  allocation_id: string
+  delivery_line_id: string
   object_type: "LOT" | "DELIVERY_LINE"
   object_id: string
   label: string | null
@@ -21,12 +23,19 @@ type TargetRow = {
   unite: string | null
   lot_status: "LIBERE" | "EN_ATTENTE" | "QUARANTAINE" | "BLOQUE" | null
   article_id: string | null
+  article_code: string | null
+  article_designation: string | null
   lot_id: string | null
+  lot_code: string | null
   commande_id: string | null
+  plan_id: string | null
+  plan_code: string | null
+  plan_version: number | null
 }
 
 type ControlRow = {
   id: string
+  delivery_allocation_id: string | null
   source_type: string
   source_id: string
   qty_released: string
@@ -45,6 +54,9 @@ type NcRow = {
 
 type ReleaseRow = {
   id: string
+  quality_control_id: string
+  decision: "FULL" | "PARTIAL" | "HOLD" | "REJECT"
+  qty: string
   object_type: string
   object_id: string
   derogation_id: string | null
@@ -111,10 +123,6 @@ function unknownRelease(bonLivraisonId: string, reason: string): DeliveryQuality
   })
 }
 
-function targetKey(objectType: string, objectId: string): string {
-  return `${objectType}:${objectId}`
-}
-
 /**
  * Builds the canonical quality release aggregate for one delivery. All reads
  * can use the caller's transaction so generation and shipment re-check the
@@ -141,7 +149,7 @@ export async function repoGetDeliveryQualityRelease(
         SELECT id::text AS id, code, version, rules, rules_sha256,
                signature_reference, signed_at::text AS signed_at
         FROM public.quality_delivery_release_policy
-        WHERE status = 'SIGNED'
+        WHERE status = 'ACTIVE'
           AND signed_at IS NOT NULL
           AND valid_from <= clock_timestamp()
           AND (valid_to IS NULL OR valid_to >= clock_timestamp())
@@ -162,63 +170,88 @@ export async function repoGetDeliveryQualityRelease(
     const targetsRes = await db.query<TargetRow>(
       `
         SELECT
-          CASE WHEN a.lot_id IS NOT NULL
-            THEN 'LOT:' || a.lot_id::text
-            ELSE 'DELIVERY_LINE:' || bl.id::text
-          END AS target_key,
+          'ALLOCATION:' || a.id::text AS target_key,
+          a.id::text AS allocation_id,
+          bl.id::text AS delivery_line_id,
           CASE WHEN a.lot_id IS NOT NULL THEN 'LOT' ELSE 'DELIVERY_LINE' END AS object_type,
           COALESCE(a.lot_id::text, bl.id::text) AS object_id,
           CASE WHEN a.lot_id IS NOT NULL THEN l.lot_code ELSE 'Ligne ' || bl.ordre::text END AS label,
-          SUM(a.quantite)::text AS qty_requested,
-          CASE WHEN COUNT(DISTINCT COALESCE(a.unite, '')) = 1 THEN MIN(a.unite) ELSE NULL END AS unite,
+          a.quantite::text AS qty_requested,
+          a.unite,
           CASE WHEN a.lot_id IS NOT NULL THEN l.lot_status::text ELSE NULL END AS lot_status,
-          CASE WHEN COUNT(DISTINCT a.article_id) = 1
-            THEN (array_agg(DISTINCT a.article_id ORDER BY a.article_id))[1]::text
-            ELSE NULL
-          END AS article_id,
+          a.article_id::text AS article_id,
+          article.code AS article_code,
+          article.designation AS article_designation,
           a.lot_id::text AS lot_id,
-          b.commande_id::text AS commande_id
+          l.lot_code AS lot_code,
+          b.commande_id::text AS commande_id,
+          applicable_plan.id::text AS plan_id,
+          applicable_plan.code AS plan_code,
+          applicable_plan.version AS plan_version
         FROM public.bon_livraison b
         JOIN public.bon_livraison_ligne bl ON bl.bon_livraison_id = b.id
         JOIN public.bon_livraison_ligne_allocations a ON a.bon_livraison_ligne_id = bl.id
         LEFT JOIN public.lots l ON l.id = a.lot_id
+        LEFT JOIN public.articles article ON article.id = a.article_id
+        LEFT JOIN public.pieces_techniques piece ON piece.id = article.piece_technique_id
+        LEFT JOIN LATERAL (
+          SELECT p.id, p.code, p.version
+          FROM public.quality_control_plan p
+          WHERE p.status = 'PUBLISHED'
+            AND p.trigger_type = 'LOT_RELEASE'
+            AND (p.article_id IS NULL OR p.article_id = a.article_id)
+            AND (p.piece_technique_id IS NULL OR p.piece_technique_id = article.piece_technique_id)
+            AND (p.famille_id IS NULL OR p.famille_id = piece.famille_id)
+            AND p.piece_version_id IS NULL
+            AND p.operation_code IS NULL
+            AND p.fournisseur_id IS NULL
+            AND (p.effective_from IS NULL OR p.effective_from <= clock_timestamp())
+            AND (p.effective_to IS NULL OR p.effective_to >= clock_timestamp())
+          ORDER BY
+            ((p.article_id IS NOT NULL)::int * 8 +
+             (p.piece_technique_id IS NOT NULL)::int * 4 +
+             (p.famille_id IS NOT NULL)::int * 2) DESC,
+            p.version DESC,
+            p.id
+          LIMIT 1
+        ) applicable_plan ON true
         WHERE b.id = $1::uuid
-        GROUP BY b.commande_id, bl.id, bl.ordre, a.lot_id, l.lot_code, l.lot_status
-        ORDER BY target_key
+        ORDER BY bl.ordre, a.id
       `,
       [bonLivraisonId]
     )
 
     const targetRows = targetsRes.rows
-    const objectTypes = targetRows.map((row) => row.object_type)
-    const objectIds = targetRows.map((row) => row.object_id)
+    const allocationIds = targetRows.map((row) => row.allocation_id)
 
     const controlsRes =
       targetRows.length === 0
         ? { rows: [] as ControlRow[] }
         : await db.query<ControlRow>(
             `
-              SELECT qc.id::text AS id, qc.source_type, qc.source_id,
+              SELECT qc.id::text AS id, qc.delivery_allocation_id::text AS delivery_allocation_id,
+                     qc.source_type, qc.source_id,
                      qc.qty_released::text, qc.qty_held::text, qc.qty_consumed::text,
                      (qc.validation_date IS NULL OR COALESCE(qc.verdict, 'EN_ATTENTE') = 'EN_ATTENTE') AS pending
               FROM public.quality_control qc
-              WHERE (qc.source_type, qc.source_id) IN (
-                SELECT x.object_type, x.object_id
-                FROM unnest($1::text[], $2::text[]) AS x(object_type, object_id)
-              )
-              ORDER BY qc.source_type, qc.source_id, qc.control_date, qc.id
+              WHERE qc.delivery_allocation_id = ANY($1::uuid[])
+                AND qc.trigger_type = 'LOT_RELEASE'
+              ORDER BY qc.delivery_allocation_id, qc.control_date DESC, qc.id DESC
             `,
-            [objectTypes, objectIds]
+            [allocationIds]
           )
 
     const controlsByTarget = new Map<string, ControlRow[]>()
+    const targetKeyByControl = new Map<string, string>()
     const targetKeysByControl = new Map<string, string[]>()
     for (const row of controlsRes.rows) {
-      const key = targetKey(row.source_type, row.source_id)
+      if (!row.delivery_allocation_id) continue
+      const key = `ALLOCATION:${row.delivery_allocation_id}`
       const values = controlsByTarget.get(key) ?? []
       values.push(row)
       controlsByTarget.set(key, values)
       targetKeysByControl.set(row.id, [key])
+      targetKeyByControl.set(row.id, key)
     }
 
     const ncRes = await db.query<NcRow>(
@@ -248,9 +281,12 @@ export async function repoGetDeliveryQualityRelease(
     const releaseRes =
       targetRows.length === 0
         ? { rows: [] as ReleaseRow[] }
-        : await db.query<ReleaseRow>(
+        : controlsRes.rows.length === 0
+          ? { rows: [] as ReleaseRow[] }
+          : await db.query<ReleaseRow>(
             `
-              SELECT rd.id::text AS id, rd.object_type, rd.object_id,
+              SELECT rd.id::text AS id, rd.quality_control_id::text AS quality_control_id,
+                     rd.decision, rd.qty::text AS qty, rd.object_type, rd.object_id,
                      rd.derogation_id::text AS derogation_id, rd.justification,
                      rd.decided_at::text AS decided_at,
                      d.code AS d_code, d.status AS d_status,
@@ -274,33 +310,34 @@ export async function repoGetDeliveryQualityRelease(
               LEFT JOIN public.quality_derogation_consumption dc
                 ON dc.derogation_id = d.id
                AND dc.release_decision_id = rd.id
-               AND dc.bon_livraison_id = $3::uuid
-              WHERE (rd.object_type, rd.object_id) IN (
-                SELECT x.object_type, x.object_id
-                FROM unnest($1::text[], $2::text[]) AS x(object_type, object_id)
-              )
-                AND rd.decision IN ('FULL', 'PARTIAL')
-              ORDER BY rd.object_type, rd.object_id, rd.decided_at DESC, rd.id DESC
+               AND dc.bon_livraison_id = $2::uuid
+              WHERE rd.quality_control_id = ANY($1::uuid[])
+              ORDER BY rd.quality_control_id, rd.decided_at DESC, rd.id DESC
             `,
-            [objectTypes, objectIds, bonLivraisonId]
+            [controlsRes.rows.map((row) => row.id), bonLivraisonId]
           )
 
     const latestReleaseByTarget = new Map<string, ReleaseRow>()
     const targetKeysByRelease = new Map<string, string[]>()
     const targetKeysByDerogation = new Map<string, string[]>()
     for (const row of releaseRes.rows) {
-      const key = targetKey(row.object_type, row.object_id)
+      const key = targetKeyByControl.get(row.quality_control_id)
+      if (!key) continue
       targetKeysByRelease.set(row.id, [key])
       if (row.derogation_id) {
         const keys = targetKeysByDerogation.get(row.derogation_id) ?? []
         if (!keys.includes(key)) keys.push(key)
         targetKeysByDerogation.set(row.derogation_id, keys)
       }
-      if (!latestReleaseByTarget.has(key)) latestReleaseByTarget.set(key, row)
+      if (
+        !latestReleaseByTarget.has(key) &&
+        controlsByTarget.get(key)?.[0]?.id === row.quality_control_id
+      ) latestReleaseByTarget.set(key, row)
     }
 
     const observations: DeliveryQualityTargetObservation[] = targetRows.map((row) => {
       const controls = controlsByTarget.get(row.target_key) ?? []
+      const effectiveControl = controls[0] ?? null
       const openNc = ncRes.rows.filter((nc) => {
         if (!nc.open_without_disposition) return false
         if (nc.bon_livraison_id === bonLivraisonId && !nc.lot_id && !nc.control_id) return true
@@ -355,17 +392,37 @@ export async function repoGetDeliveryQualityRelease(
 
       return {
         key: row.target_key,
+        allocation_id: row.allocation_id,
+        delivery_line_id: row.delivery_line_id,
+        article_id: row.article_id,
+        article_code: row.article_code,
+        article_designation: row.article_designation,
+        lot_id: row.lot_id,
+        lot_code: row.lot_code,
+        unite: row.unite,
+        plan: row.plan_id && row.plan_code && row.plan_version
+          ? { id: row.plan_id, code: row.plan_code, version: row.plan_version }
+          : null,
+        control_count: controls.length,
+        latest_decision: release
+          ? {
+              id: release.id,
+              decision: release.decision,
+              qty: toNumber(release.qty),
+              decided_at: release.decided_at,
+            }
+          : null,
         target: {
           object_type: row.object_type,
           object_id: row.object_id,
           label: row.label,
           qty_requested: toNumber(row.qty_requested),
           lot_status: row.lot_status,
-          qty_released: controls.reduce((sum, control) => sum + toNumber(control.qty_released), 0),
-          qty_held: controls.reduce((sum, control) => sum + toNumber(control.qty_held), 0),
-          qty_consumed: controls.reduce((sum, control) => sum + toNumber(control.qty_consumed), 0),
+          qty_released: effectiveControl ? toNumber(effectiveControl.qty_released) : 0,
+          qty_held: effectiveControl ? toNumber(effectiveControl.qty_held) : 0,
+          qty_consumed: effectiveControl ? toNumber(effectiveControl.qty_consumed) : 0,
           open_nc_without_disposition: openNc,
-          pending_mandatory_controls: controls.filter((control) => control.pending).length,
+          pending_mandatory_controls: effectiveControl?.pending ? 1 : 0,
           derogation: derogation ? { status: derogation.state.status, valid_to: derogation.state.valid_to } : null,
         },
         derogation,

--- a/src/module/livraisons/routes/livraisons.routes.ts
+++ b/src/module/livraisons/routes/livraisons.routes.ts
@@ -37,9 +37,12 @@ import {
 
 import {
   downloadLivraisonPackDocument,
+  freezeLivraisonQualityDossier,
   generateLivraisonPack,
   getLivraisonPackPreview,
+  getLivraisonQualityDossier,
   revokeLivraisonPackVersion,
+  revokeLivraisonQualityDossier,
 } from "../controllers/pack.controller"
 
 const upload = createSecureUpload("business-document")
@@ -160,6 +163,22 @@ router.post(
   "/:id/pdf",
   requireLivraisonCapability("documents_manage"),
   generateLivraisonPdf
+)
+
+router.get(
+  "/:id/quality-dossier",
+  requireLivraisonCapability("read"),
+  getLivraisonQualityDossier
+)
+router.post(
+  "/:id/quality-dossier/freeze",
+  requireLivraisonCapability("documents_manage"),
+  freezeLivraisonQualityDossier
+)
+router.post(
+  "/:id/quality-dossier/revoke/:versionId",
+  requireLivraisonCapability("documents_manage"),
+  revokeLivraisonQualityDossier
 )
 
 router.get(

--- a/src/module/livraisons/services/livraisons.service.ts
+++ b/src/module/livraisons/services/livraisons.service.ts
@@ -42,6 +42,7 @@ import {
   repoGetLivraisonPreparation,
   repoResetLivraisonPreparation,
 } from "../repository/livraisons-preparation.repository"
+import { repoGetDeliveryQualityRelease } from "../repository/quality-release.repository"
 
 function assertEditable(statut: BonLivraisonStatut, action: string) {
   if (statut === "DRAFT" || statut === "READY") return
@@ -142,6 +143,7 @@ export async function svcGetLivraisonShipmentPreview(id: string) {
 }
 
 export async function svcGetLivraisonPreparation(id: string) {
+  await assertDeliveryQualityAllowsPreparation(id)
   const preparation = await repoGetLivraisonPreparation(id)
   if (!preparation) {
     throw new HttpError(404, "BON_LIVRAISON_NOT_FOUND", "Bon de livraison not found")
@@ -149,23 +151,37 @@ export async function svcGetLivraisonPreparation(id: string) {
   return preparation
 }
 
-export function svcConfirmLivraisonPreparation(
+async function assertDeliveryQualityAllowsPreparation(id: string): Promise<void> {
+  const release = await repoGetDeliveryQualityRelease(id)
+  if (release.state !== "READY" && release.state !== "DEROGATED") {
+    throw new HttpError(
+      409,
+      "QUALITY_PREPARATION_BLOCKED",
+      "La preparation est verrouillee tant que le dossier qualite n'est pas liberable.",
+      { quality_release: release }
+    )
+  }
+}
+
+export async function svcConfirmLivraisonPreparation(
   id: string,
   allocationId: string,
   body: ConfirmLivraisonPreparationBodyDTO,
   userId: number,
   idempotencyKey: string
 ) {
+  await assertDeliveryQualityAllowsPreparation(id)
   return repoConfirmLivraisonPreparation(id, allocationId, body, userId, idempotencyKey)
 }
 
-export function svcResetLivraisonPreparation(
+export async function svcResetLivraisonPreparation(
   id: string,
   allocationId: string,
   body: ResetLivraisonPreparationBodyDTO,
   userId: number,
   idempotencyKey: string
 ) {
+  await assertDeliveryQualityAllowsPreparation(id)
   return repoResetLivraisonPreparation(id, allocationId, body, userId, idempotencyKey)
 }
 

--- a/src/module/livraisons/services/pack-pdf.service.test.ts
+++ b/src/module/livraisons/services/pack-pdf.service.test.ts
@@ -259,6 +259,7 @@ function preview(overrides: Partial<LivraisonPackPreview> = {}): LivraisonPackPr
       required_evidence: [],
       derogation_ids: [],
     },
+    quality_dossier: { latest: null, versions: [], is_current: false },
     checks: { allocations_ok: true, shipped_or_ready: true, stock_link_ok: true, quality_release_ok: true, missing: [] },
   }
 

--- a/src/module/livraisons/services/pack.service.ts
+++ b/src/module/livraisons/services/pack.service.ts
@@ -9,7 +9,7 @@ import { HttpError } from "../../../utils/httpError"
 import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository"
 
 import { repoGetLivraisonPackPreview } from "../repository/pack.repository"
-import { repoGetDeliveryQualityRelease } from "../repository/quality-release.repository"
+import { repoGetDeliveryQualityDossier } from "../repository/quality-dossier.repository"
 import type { PackGenerateBodyDTO } from "../validators/pack.validators"
 import type { LivraisonPackGenerateResult, LivraisonPackPreview } from "../types/pack.types"
 import { svcRenderPackBonLivraisonPdf, svcRenderPackCofcPdf } from "./pack-pdf.service"
@@ -174,6 +174,13 @@ export async function svcGenerateLivraisonPack(params: {
       quality_release: preview.quality_release,
     })
   }
+  if (!preview.quality_dossier.is_current || !preview.quality_dossier.latest) {
+    throw new HttpError(
+      409,
+      "QUALITY_DOSSIER_NOT_FROZEN",
+      "Figez la version courante du dossier qualite avant de generer le pack."
+    )
+  }
   if (preview.quality_release.preview_sha256 !== params.body.quality_preview_sha256) {
     throw new HttpError(409, "QUALITY_RELEASE_PREVIEW_STALE", "La décision Qualité a changé; actualisez l'aperçu.", {
       expected: params.body.quality_preview_sha256,
@@ -230,7 +237,9 @@ export async function svcGenerateLivraisonPack(params: {
       await db.query("SET TRANSACTION ISOLATION LEVEL SERIALIZABLE")
       await db.query(`SELECT id FROM public.bon_livraison WHERE id = $1::uuid FOR UPDATE`, [params.bonLivraisonId])
 
-      const qualityRelease = await repoGetDeliveryQualityRelease(params.bonLivraisonId, db)
+      const qualityDossier = await repoGetDeliveryQualityDossier(params.bonLivraisonId, db)
+      const qualityRelease = qualityDossier.release
+      const frozenDossier = qualityDossier.latest
       if (qualityRelease.state !== "READY" && qualityRelease.state !== "DEROGATED") {
         throw new HttpError(409, "QUALITY_RELEASE_BLOCKED", "La Qualité bloque la génération du pack.", {
           quality_release: qualityRelease,
@@ -247,6 +256,13 @@ export async function svcGenerateLivraisonPack(params: {
       }
       if (!qualityRelease.policy) {
         throw new HttpError(409, "QUALITY_POLICY_MISSING", "Aucune politique Qualité signée ne permet cette émission.")
+      }
+      if (!qualityDossier.is_current || !frozenDossier) {
+        throw new HttpError(
+          409,
+          "QUALITY_DOSSIER_STALE",
+          "Le dossier qualite fige n'est plus la version courante."
+        )
       }
 
       await db.query(`INSERT INTO public.documents_clients (id, document_name, type) VALUES ($1, $2, $3)`, [
@@ -344,12 +360,13 @@ export async function svcGenerateLivraisonPack(params: {
             quality_policy_id,
             quality_policy_sha256,
             quality_release_snapshot,
+            quality_dossier_version_id,
             created_by,
             updated_by
           )
           VALUES (
             $1::uuid, $2, 'GENERATED', $3, $4::uuid, $5::uuid, $6::jsonb, $7,
-            $8, $9, $10::uuid, $11, $12::jsonb, $13, $13
+            $8, $9, $10::uuid, $11, $12::jsonb, $13::uuid, $14, $14
           )
           RETURNING id::text AS id
         `,
@@ -365,14 +382,15 @@ export async function svcGenerateLivraisonPack(params: {
           qualityRelease.preview_sha256,
           qualityRelease.policy.id,
           qualityRelease.policy.rules_sha256,
-          JSON.stringify(qualityRelease),
+          JSON.stringify(frozenDossier.release_snapshot),
+          frozenDossier.id,
           params.actorUserId,
         ]
       )
       const packVersionId = packIns.rows[0]?.id
       if (!packVersionId) throw new Error("Failed to create bon_livraison_pack_versions row")
 
-      for (const evidence of qualityRelease.required_evidence) {
+      for (const evidence of frozenDossier.evidence_manifest) {
         await db.query(
           `
             INSERT INTO public.bon_livraison_pack_quality_documents (
@@ -414,6 +432,8 @@ export async function svcGenerateLivraisonPack(params: {
           quality_release_preview_sha256: qualityRelease.preview_sha256,
           quality_policy_id: qualityRelease.policy.id,
           quality_policy_sha256: qualityRelease.policy.rules_sha256,
+          quality_dossier_version_id: frozenDossier.id,
+          quality_dossier_sha256: frozenDossier.dossier_sha256,
           quality_derogation_ids: qualityRelease.derogation_ids,
           quality_evidence_ids: qualityRelease.required_evidence.map((evidence) => evidence.id),
         },
@@ -445,6 +465,8 @@ export async function svcGenerateLivraisonPack(params: {
             quality_release_preview_sha256: qualityRelease.preview_sha256,
             quality_policy_id: qualityRelease.policy.id,
             quality_policy_sha256: qualityRelease.policy.rules_sha256,
+            quality_dossier_version_id: frozenDossier.id,
+            quality_dossier_sha256: frozenDossier.dossier_sha256,
             quality_derogation_ids: qualityRelease.derogation_ids,
             quality_evidence_ids: qualityRelease.required_evidence.map((evidence) => evidence.id),
           },

--- a/src/module/livraisons/types/pack.types.ts
+++ b/src/module/livraisons/types/pack.types.ts
@@ -1,5 +1,6 @@
 import type { BonLivraisonDocument, BonLivraisonHeader, BonLivraisonLigneAllocation, BonLivraisonLigne, UserLite } from "./livraisons.types"
 import type { DeliveryQualityRelease } from "../domain/quality-release-gate"
+import type { DeliveryQualityDossierVersion } from "../repository/quality-dossier.repository"
 
 export type LivraisonPackCheck = {
   allocations_ok: boolean
@@ -57,6 +58,7 @@ export type LivraisonPackVersion = {
   quality_policy_id: string | null
   quality_policy_sha256: string | null
   quality_release_snapshot: DeliveryQualityRelease | null
+  quality_dossier_version_id: string | null
 }
 
 export type LivraisonPackPreview = {
@@ -67,6 +69,11 @@ export type LivraisonPackPreview = {
   documents_generated: BonLivraisonDocument[]
   pack_versions: LivraisonPackVersion[]
   quality_release: DeliveryQualityRelease
+  quality_dossier: {
+    latest: DeliveryQualityDossierVersion | null
+    versions: DeliveryQualityDossierVersion[]
+    is_current: boolean
+  }
   checks: LivraisonPackCheck
 }
 

--- a/src/module/livraisons/validators/pack.validators.ts
+++ b/src/module/livraisons/validators/pack.validators.ts
@@ -37,3 +37,12 @@ export const packRevokeParamsSchema = z.object({
   id: z.string().uuid(),
   versionId: z.string().uuid(),
 })
+
+export const qualityDossierFreezeBodySchema = z.object({
+  quality_preview_sha256: z.string().trim().regex(/^[a-f0-9]{64}$/),
+  reason: z.string().trim().min(10).max(2000),
+}).strict()
+
+export const qualityDossierRevokeBodySchema = z.object({
+  reason: z.string().trim().min(10).max(2000),
+}).strict()

--- a/src/module/qualite/controllers/quality-360.controller.ts
+++ b/src/module/qualite/controllers/quality-360.controller.ts
@@ -14,10 +14,12 @@ import { getClientIp, parseDevice } from "../../../utils/requestMeta";
 import type { QualityActor } from "../repository/quality-360.repository";
 import {
   consumeDerogationSchema,
+  createDeliveryPolicySchema,
   createDerogationSchema,
   createExecutionSchema,
   createPlanSchema,
   decideExecutionSchema,
+  deliveryPolicyTransitionSchema,
   derogationTransitionSchema,
   eligibilityQuerySchema,
   executionPreviewSchema,
@@ -30,22 +32,27 @@ import {
   planTransitionSchema,
   qualityCenterQuerySchema,
   recordMeasurementsSchema,
+  reviseDeliveryPolicySchema,
   revisePlanSchema,
   updatePlanSchema,
+  updateDeliveryPolicySchema,
   upsertAnalysisSchema,
 } from "../validators/quality-360.validators";
 import {
   svcConsumeDerogation,
+  svcCreateDeliveryPolicy,
   svcCreateDerogation,
   svcCreateExecution,
   svcCreatePlan,
   svcDecideExecution,
   svcEvaluateEligibility,
+  svcGetDeliveryPolicy,
   svcGetDerogation,
   svcGetExecution,
   svcGetNcAnalysis,
   svcGetPlan,
   svcListDerogations,
+  svcListDeliveryPolicies,
   svcListExecutions,
   svcListPlans,
   svcPlanApplicability,
@@ -53,13 +60,69 @@ import {
   svcPreviewVerdict,
   svcQualityCenter,
   svcRecordMeasurements,
+  svcReviseDeliveryPolicy,
   svcRevisePlan,
   svcTransitionDerogation,
+  svcTransitionDeliveryPolicy,
   svcTransitionNc,
   svcTransitionPlan,
   svcUpdatePlan,
+  svcUpdateDeliveryPolicy,
   svcUpsertNcAnalysis,
 } from "../services/quality-360.service";
+
+/* -------------------------------------------------------------------------- */
+/* Politique globale de liberation des BL                                     */
+/* -------------------------------------------------------------------------- */
+
+export const listDeliveryPolicies: RequestHandler = asyncHandler(async (_req, res) => {
+  const items = await svcListDeliveryPolicies();
+  res.json({ items, total: items.length });
+});
+
+export const getDeliveryPolicy: RequestHandler = asyncHandler(async (req, res) => {
+  const { params } = parseOrThrow(idParamSchema, { params: req.params });
+  const out = await svcGetDeliveryPolicy(params.id);
+  if (!out) notFound("Politique de liberation");
+  res.json(out);
+});
+
+export const createDeliveryPolicy: RequestHandler = asyncHandler(async (req, res) => {
+  const { body } = parseOrThrow(createDeliveryPolicySchema, { body: req.body });
+  const out = await svcCreateDeliveryPolicy({ body, actor: buildActor(req), idempotencyKey: idempotencyKey(req) });
+  res.status(201).json(out);
+});
+
+export const updateDeliveryPolicy: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(updateDeliveryPolicySchema, { params: req.params, body: req.body });
+  const out = await svcUpdateDeliveryPolicy({ id: parsed.params.id, body: parsed.body, actor: buildActor(req) });
+  if (!out) notFound("Politique de liberation");
+  res.json(out);
+});
+
+export const transitionDeliveryPolicy: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(deliveryPolicyTransitionSchema, { params: req.params, body: req.body });
+  const out = await svcTransitionDeliveryPolicy({
+    id: parsed.params.id,
+    body: parsed.body,
+    actor: buildActor(req),
+    idempotencyKey: idempotencyKey(req),
+  });
+  if (!out) notFound("Politique de liberation");
+  res.json(out);
+});
+
+export const reviseDeliveryPolicy: RequestHandler = asyncHandler(async (req, res) => {
+  const parsed = parseOrThrow(reviseDeliveryPolicySchema, { params: req.params, body: req.body });
+  const out = await svcReviseDeliveryPolicy({
+    id: parsed.params.id,
+    revisionReason: parsed.body.revision_reason,
+    actor: buildActor(req),
+    idempotencyKey: idempotencyKey(req),
+  });
+  if (!out) notFound("Politique de liberation");
+  res.status(201).json(out);
+});
 
 /**
  * Parse strict avec mapping par champ : le frontend peut recoller chaque

--- a/src/module/qualite/domain/quality-policy.ts
+++ b/src/module/qualite/domain/quality-policy.ts
@@ -141,6 +141,56 @@ export function assertPlanSelectableForExecution(status: QualityPlanStatus): voi
 }
 
 /* -------------------------------------------------------------------------- */
+/* 2b) Politique globale de liberation des BL                                 */
+/* -------------------------------------------------------------------------- */
+
+export const QUALITY_DELIVERY_POLICY_STATUSES = [
+  "DRAFT",
+  "IN_REVIEW",
+  "SIGNED",
+  "ACTIVE",
+  "SUPERSEDED",
+  "REVOKED",
+] as const;
+
+export type QualityDeliveryPolicyStatus =
+  (typeof QUALITY_DELIVERY_POLICY_STATUSES)[number];
+
+const DELIVERY_POLICY_TRANSITIONS: Readonly<
+  Record<QualityDeliveryPolicyStatus, readonly QualityDeliveryPolicyStatus[]>
+> = {
+  DRAFT: ["IN_REVIEW"],
+  IN_REVIEW: ["DRAFT", "SIGNED"],
+  SIGNED: ["ACTIVE", "REVOKED"],
+  ACTIVE: ["SUPERSEDED", "REVOKED"],
+  SUPERSEDED: [],
+  REVOKED: [],
+};
+
+export function assertDeliveryPolicyTransition(
+  from: QualityDeliveryPolicyStatus,
+  to: QualityDeliveryPolicyStatus
+): void {
+  if (!DELIVERY_POLICY_TRANSITIONS[from]?.includes(to)) {
+    throw new HttpError(
+      409,
+      "QUALITY_DELIVERY_POLICY_TRANSITION_FORBIDDEN",
+      `Transition de politique de liberation interdite : ${from} vers ${to}.`
+    );
+  }
+}
+
+export function assertDeliveryPolicyContentMutable(status: QualityDeliveryPolicyStatus): void {
+  if (status !== "DRAFT" && status !== "IN_REVIEW") {
+    throw new HttpError(
+      409,
+      "QUALITY_DELIVERY_POLICY_IMMUTABLE",
+      "Une politique signee ne se modifie plus : creez une nouvelle revision."
+    );
+  }
+}
+
+/* -------------------------------------------------------------------------- */
 /* 3) Exécutions de contrôle — statuts et verdicts                            */
 /* -------------------------------------------------------------------------- */
 

--- a/src/module/qualite/repository/quality-360.repository.ts
+++ b/src/module/qualite/repository/quality-360.repository.ts
@@ -1051,9 +1051,88 @@ export type ExecutionPreview = {
   characteristics: Array<QualityCharacteristicSpec & { required_samples: number }>;
 };
 
+async function resolveLotReleaseAllocation(
+  q: DbQueryer,
+  body: ExecutionPreviewBodyDTO
+): Promise<ExecutionPreviewBodyDTO> {
+  if (body.trigger !== "LOT_RELEASE") return body;
+  if (
+    body.source_type !== "LOT" ||
+    !body.lot_id ||
+    !body.article_id ||
+    !body.bon_livraison_id ||
+    !body.delivery_allocation_id ||
+    body.source_id !== body.lot_id
+  ) {
+    throw new HttpError(
+      422,
+      "QUALITY_DELIVERY_RELEASE_SCOPE_REQUIRED",
+      "LOT_RELEASE exige le BL, l'allocation, l'article et le lot exacts."
+    );
+  }
+  const result = await q.query<{
+    bon_livraison_id: string;
+    lot_id: string | null;
+    article_id: string | null;
+    quantite: string;
+    unite: string | null;
+    piece_technique_id: string | null;
+    famille_id: string | null;
+  }>(
+    `SELECT line.bon_livraison_id::text AS bon_livraison_id,
+            allocation.lot_id::text AS lot_id,
+            allocation.article_id::text AS article_id,
+            allocation.quantite::text AS quantite,
+            allocation.unite,
+            article.piece_technique_id::text AS piece_technique_id,
+            piece.famille_id::text AS famille_id
+     FROM public.bon_livraison_ligne_allocations allocation
+     JOIN public.bon_livraison_ligne line ON line.id = allocation.bon_livraison_ligne_id
+     JOIN public.articles article ON article.id = allocation.article_id
+     LEFT JOIN public.pieces_techniques piece ON piece.id = article.piece_technique_id
+     WHERE allocation.id = $1::uuid`,
+    [body.delivery_allocation_id]
+  );
+  const allocation = result.rows[0];
+  if (!allocation) {
+    throw new HttpError(404, "QUALITY_DELIVERY_ALLOCATION_NOT_FOUND", "Allocation de BL introuvable.");
+  }
+  if (
+    allocation.bon_livraison_id !== body.bon_livraison_id ||
+    allocation.lot_id !== body.lot_id ||
+    allocation.article_id !== body.article_id
+  ) {
+    throw new HttpError(
+      409,
+      "QUALITY_DELIVERY_ALLOCATION_SCOPE_MISMATCH",
+      "Le BL, l'allocation, l'article et le lot ne designent pas le meme perimetre."
+    );
+  }
+  if (body.population > toNumber(allocation.quantite)) {
+    throw new HttpError(
+      422,
+      "QUALITY_POPULATION_EXCEEDS_ALLOCATION",
+      "La population controlee depasse la quantite de l'allocation."
+    );
+  }
+  if (allocation.unite && allocation.unite !== body.unite) {
+    throw new HttpError(
+      422,
+      "QUALITY_ALLOCATION_UNIT_MISMATCH",
+      "L'unite du controle differe de celle de l'allocation."
+    );
+  }
+  return {
+    ...body,
+    piece_technique_id: body.piece_technique_id ?? allocation.piece_technique_id,
+    famille_id: body.famille_id ?? allocation.famille_id,
+  };
+}
+
 export async function repoPreviewExecution(body: ExecutionPreviewBodyDTO): Promise<ExecutionPreview> {
   assertSourceRef({ source_type: body.source_type, source_id: body.source_id });
-  const built = await buildExecutionSnapshot(pool, body);
+  const scopedBody = await resolveLotReleaseAllocation(pool, body);
+  const built = await buildExecutionSnapshot(pool, scopedBody);
   return {
     plan: { id: built.plan.id, code: built.plan.code, version: built.plan.version },
     snapshot_sha256: built.snapshot.sha256,
@@ -1087,6 +1166,8 @@ export type ExecutionDetail = {
   created_at: string;
   updated_at: string;
   controlled_by: number;
+  bon_livraison_id: string | null;
+  delivery_allocation_id: string | null;
   measurements: Array<{
     id: string;
     characteristic_key: string | null;
@@ -1135,6 +1216,8 @@ type ExecutionRow = {
   created_at: string;
   updated_at: string;
   controlled_by: number;
+  bon_livraison_id: string | null;
+  delivery_allocation_id: string | null;
   correlation_id: string;
 };
 
@@ -1144,7 +1227,8 @@ const EXECUTION_COLUMNS = `
   qc.source_type, qc.source_id, qc.plan_id, qc.plan_version, qc.plan_snapshot, qc.plan_snapshot_sha256,
   qc.unite, qc.qty_population, qc.qty_controlled, qc.qty_conforming, qc.qty_released, qc.qty_held,
   qc.qty_scrapped, qc.qty_reworked, qc.qty_sorted, qc.qty_returned, qc.qty_consumed,
-  qc.control_date, qc.validation_date, qc.created_at, qc.updated_at, qc.controlled_by, qc.correlation_id,
+  qc.control_date, qc.validation_date, qc.created_at, qc.updated_at, qc.controlled_by,
+  qc.bon_livraison_id, qc.delivery_allocation_id, qc.correlation_id,
   p.code AS plan_code
 `;
 
@@ -1239,6 +1323,8 @@ function buildExecutionDetail(row: ExecutionRow, measurements: ExecutionDetail["
     created_at: row.created_at,
     updated_at: row.updated_at,
     controlled_by: row.controlled_by,
+    bon_livraison_id: row.bon_livraison_id,
+    delivery_allocation_id: row.delivery_allocation_id,
     measurements,
   };
 }
@@ -1321,7 +1407,8 @@ export async function repoCreateExecution(params: {
       if (replayed) return buildExecutionDetail(replayed, await selectMeasurements(client, replayed.id));
     }
 
-    const built = await buildExecutionSnapshot(client, params.body);
+    const scopedBody = await resolveLotReleaseAllocation(client, params.body);
+    const built = await buildExecutionSnapshot(client, scopedBody);
     // L'aperçu doit encore correspondre au plan applicable : sinon le référentiel
     // a bougé entre l'aperçu et la confirmation.
     assertPreviewFresh({
@@ -1340,6 +1427,7 @@ export async function repoCreateExecution(params: {
           plan_id, plan_version, plan_snapshot, plan_snapshot_sha256,
           source_type, source_id, trigger_type,
           lot_id, article_id, fournisseur_id, reception_ligne_id,
+          bon_livraison_id, delivery_allocation_id,
           unite, qty_population, verdict, verdict_computed, comments,
           created_by, updated_by
         )
@@ -1349,8 +1437,9 @@ export async function repoCreateExecution(params: {
           $6::uuid, $7, $8::jsonb, $9,
           $10, $11, $12,
           $13::uuid, $14::uuid, $15::uuid, $16::uuid,
-          $17, $18, 'EN_ATTENTE', 'EN_ATTENTE', $19,
-          $20, $20
+          $17::uuid, $18::uuid,
+          $19, $20, 'EN_ATTENTE', 'EN_ATTENTE', $21,
+          $22, $22
         )
         RETURNING id, correlation_id
       `,
@@ -1371,6 +1460,8 @@ export async function repoCreateExecution(params: {
         params.body.article_id ?? null,
         params.body.fournisseur_id ?? null,
         params.body.reception_ligne_id ?? null,
+        params.body.bon_livraison_id ?? null,
+        params.body.delivery_allocation_id ?? null,
         params.body.unite,
         params.body.population,
         params.body.comments ?? null,
@@ -1940,11 +2031,16 @@ export async function repoDecideExecution(params: {
     assertSnapshotIntegrity(before.plan_snapshot, before.plan_snapshot_sha256);
 
     // L'auteur de l'exécution ne prononce pas lui-même la libération.
-    if (params.body.decision === "FULL" || params.body.decision === "PARTIAL") {
-      assertReleaseSeparation({
-        executorUserId: before.controlled_by,
-        deciderUserId: params.actor.user_id,
-      });
+    assertReleaseSeparation({
+      executorUserId: before.controlled_by,
+      deciderUserId: params.actor.user_id,
+    });
+    if (params.body.object_type !== before.source_type || params.body.object_id !== before.source_id) {
+      throw new HttpError(
+        409,
+        "QUALITY_RELEASE_SCOPE_MISMATCH",
+        "La decision doit porter sur la source exacte figee dans l'execution."
+      );
     }
 
     const specs = characteristicsFromSnapshot(before.plan_snapshot);

--- a/src/module/qualite/repository/quality-delivery-policy.repository.ts
+++ b/src/module/qualite/repository/quality-delivery-policy.repository.ts
@@ -1,0 +1,345 @@
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import {
+  assertDeliveryPolicyContentMutable,
+  assertDeliveryPolicyTransition,
+  assertOptimisticVersion,
+  normalizeQualityIdempotencyKey,
+  qualityRequestHash,
+  qualitySha256,
+  type QualityDeliveryPolicyStatus,
+} from "../domain/quality-policy";
+import type { QualityActor } from "./quality-360.repository";
+import type {
+  CreateDeliveryPolicyBodyDTO,
+  DeliveryPolicyTransitionBodyDTO,
+  UpdateDeliveryPolicyBodyDTO,
+} from "../validators/quality-360.validators";
+
+export type DeliveryPolicyRow = {
+  id: string;
+  code: string;
+  version: number;
+  label: string;
+  status: QualityDeliveryPolicyStatus;
+  justification: string | null;
+  rules: unknown;
+  rules_sha256: string;
+  signature_reference: string | null;
+  document_reference: string | null;
+  signed_by: number | null;
+  signed_at: string | null;
+  valid_from: string;
+  valid_to: string | null;
+  submitted_by: number | null;
+  submitted_at: string | null;
+  activated_by: number | null;
+  activated_at: string | null;
+  superseded_by_policy_id: string | null;
+  superseded_at: string | null;
+  revoked_by: number | null;
+  revoked_at: string | null;
+  revocation_reason: string | null;
+  created_at: string;
+  updated_at: string;
+  created_by: number;
+  updated_by: number;
+};
+
+const POLICY_COLUMNS = `
+  id::text AS id, code, version, label, status, justification, rules, rules_sha256,
+  signature_reference, document_reference, signed_by, signed_at::text AS signed_at,
+  valid_from::text AS valid_from, valid_to::text AS valid_to,
+  submitted_by, submitted_at::text AS submitted_at,
+  activated_by, activated_at::text AS activated_at,
+  superseded_by_policy_id::text AS superseded_by_policy_id,
+  superseded_at::text AS superseded_at, revoked_by, revoked_at::text AS revoked_at,
+  revocation_reason, created_at::text AS created_at, updated_at::text AS updated_at,
+  created_by, updated_by
+`;
+
+async function transaction<T>(fn: (client: PoolClient) => Promise<T>): Promise<T> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const result = await fn(client);
+    await client.query("COMMIT");
+    return result;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function selectPolicy(
+  client: Pick<PoolClient, "query">,
+  id: string,
+  forUpdate = false
+): Promise<DeliveryPolicyRow | null> {
+  const result = await client.query<DeliveryPolicyRow>(
+    `SELECT ${POLICY_COLUMNS}
+     FROM public.quality_delivery_release_policy
+     WHERE id = $1::uuid
+     ${forUpdate ? "FOR UPDATE" : ""}`,
+    [id]
+  );
+  return result.rows[0] ?? null;
+}
+
+async function acquireCommand(params: {
+  client: PoolClient;
+  actor: QualityActor;
+  idempotencyKeyRaw: string | null | undefined;
+  commandType: string;
+  payload: unknown;
+}): Promise<{ key: string; hash: string; replayId: string | null }> {
+  const key = normalizeQualityIdempotencyKey(params.idempotencyKeyRaw);
+  const hash = qualityRequestHash(params.commandType, params.payload);
+  await params.client.query(
+    `SELECT pg_advisory_xact_lock(hashtextextended($1, $2::bigint))`,
+    [key, params.actor.user_id]
+  );
+  const found = await params.client.query<{ request_hash: string; aggregate_id: string }>(
+    `SELECT request_hash, aggregate_id
+     FROM public.quality_command_receipts
+     WHERE actor_user_id = $1 AND idempotency_key = $2`,
+    [params.actor.user_id, key]
+  );
+  const existing = found.rows[0];
+  if (existing && existing.request_hash !== hash) {
+    throw new HttpError(409, "IDEMPOTENCY_KEY_REUSED", "Cette Idempotency-Key a deja ete utilisee avec un autre contenu.");
+  }
+  return { key, hash, replayId: existing?.aggregate_id ?? null };
+}
+
+async function appendEvent(params: {
+  client: PoolClient;
+  policy: DeliveryPolicyRow;
+  eventType: string;
+  fromStatus: string | null;
+  reason: string | null;
+  actor: QualityActor;
+  idempotencyKey: string | null;
+}): Promise<void> {
+  const snapshot = { ...params.policy };
+  await params.client.query(
+    `INSERT INTO public.quality_delivery_release_policy_event (
+       policy_id, event_type, from_status, to_status, reason, snapshot,
+       snapshot_sha256, actor_user_id, idempotency_key
+     ) VALUES ($1::uuid, $2, $3, $4, $5, $6::jsonb, $7, $8, $9)`,
+    [
+      params.policy.id,
+      params.eventType,
+      params.fromStatus,
+      params.policy.status,
+      params.reason,
+      JSON.stringify(snapshot),
+      qualitySha256(snapshot),
+      params.actor.user_id,
+      params.idempotencyKey,
+    ]
+  );
+}
+
+async function saveReceipt(params: {
+  client: PoolClient;
+  actor: QualityActor;
+  key: string;
+  hash: string;
+  commandType: string;
+  payload: unknown;
+  policy: DeliveryPolicyRow;
+}): Promise<void> {
+  await params.client.query(
+    `INSERT INTO public.quality_command_receipts (
+       actor_user_id, idempotency_key, request_hash, command_type,
+       aggregate_type, aggregate_id, request_payload, result_payload, correlation_id
+     ) VALUES ($1, $2, $3, $4, 'POLICY', $5, $6::jsonb, $7::jsonb, gen_random_uuid())`,
+    [
+      params.actor.user_id,
+      params.key,
+      params.hash,
+      params.commandType,
+      params.policy.id,
+      JSON.stringify(params.payload),
+      JSON.stringify({ policy_id: params.policy.id, version: params.policy.version }),
+    ]
+  );
+}
+
+export async function repoListDeliveryPolicies(): Promise<DeliveryPolicyRow[]> {
+  const result = await pool.query<DeliveryPolicyRow>(
+    `SELECT ${POLICY_COLUMNS}
+     FROM public.quality_delivery_release_policy
+     ORDER BY version DESC, created_at DESC, id`
+  );
+  return result.rows;
+}
+
+export async function repoGetDeliveryPolicy(id: string): Promise<DeliveryPolicyRow | null> {
+  return selectPolicy(pool, id);
+}
+
+export async function repoCreateDeliveryPolicy(params: {
+  body: CreateDeliveryPolicyBodyDTO;
+  actor: QualityActor;
+  idempotencyKey: string | null | undefined;
+}): Promise<DeliveryPolicyRow> {
+  return transaction(async (client) => {
+    const command = await acquireCommand({
+      client,
+      actor: params.actor,
+      idempotencyKeyRaw: params.idempotencyKey,
+      commandType: "quality.delivery-policy.create",
+      payload: params.body,
+    });
+    if (command.replayId) {
+      const replay = await selectPolicy(client, command.replayId);
+      if (replay) return replay;
+    }
+    await client.query(`LOCK TABLE public.quality_delivery_release_policy IN SHARE ROW EXCLUSIVE MODE`);
+    const versionResult = await client.query<{ version: number }>(
+      `SELECT COALESCE(MAX(version), 0)::int + 1 AS version
+       FROM public.quality_delivery_release_policy
+       WHERE code = 'DELIVERY-RELEASE'`
+    );
+    const rulesHash = qualitySha256(params.body.rules);
+    const inserted = await client.query<{ id: string }>(
+      `INSERT INTO public.quality_delivery_release_policy (
+         code, version, label, status, justification, rules, rules_sha256,
+         valid_from, valid_to, created_by, updated_by
+       ) VALUES ('DELIVERY-RELEASE', $1, $2, 'DRAFT', $3, $4::jsonb, $5,
+                 $6::timestamptz, $7::timestamptz, $8, $8)
+       RETURNING id::text AS id`,
+      [
+        versionResult.rows[0]!.version,
+        params.body.label,
+        params.body.justification,
+        JSON.stringify(params.body.rules),
+        rulesHash,
+        params.body.valid_from,
+        params.body.valid_to ?? null,
+        params.actor.user_id,
+      ]
+    );
+    const policy = (await selectPolicy(client, inserted.rows[0]!.id))!;
+    await appendEvent({ client, policy, eventType: "CREATED", fromStatus: null, reason: params.body.justification, actor: params.actor, idempotencyKey: command.key });
+    await saveReceipt({ client, actor: params.actor, key: command.key, hash: command.hash, commandType: "quality.delivery-policy.create", payload: params.body, policy });
+    return policy;
+  });
+}
+
+export async function repoUpdateDeliveryPolicy(params: {
+  id: string;
+  body: UpdateDeliveryPolicyBodyDTO;
+  actor: QualityActor;
+}): Promise<DeliveryPolicyRow | null> {
+  return transaction(async (client) => {
+    const before = await selectPolicy(client, params.id, true);
+    if (!before) return null;
+    assertDeliveryPolicyContentMutable(before.status);
+    assertOptimisticVersion({ expectedUpdatedAt: params.body.expected_updated_at, currentUpdatedAt: before.updated_at });
+    await client.query(
+      `UPDATE public.quality_delivery_release_policy
+       SET label = $2, justification = $3, rules = $4::jsonb, rules_sha256 = $5,
+           valid_from = $6::timestamptz, valid_to = $7::timestamptz,
+           updated_by = $8, updated_at = now()
+       WHERE id = $1::uuid`,
+      [params.id, params.body.label, params.body.justification, JSON.stringify(params.body.rules), qualitySha256(params.body.rules), params.body.valid_from, params.body.valid_to ?? null, params.actor.user_id]
+    );
+    const policy = (await selectPolicy(client, params.id))!;
+    await appendEvent({ client, policy, eventType: "UPDATED", fromStatus: before.status, reason: params.body.justification, actor: params.actor, idempotencyKey: null });
+    return policy;
+  });
+}
+
+export async function repoReviseDeliveryPolicy(params: {
+  id: string;
+  revisionReason: string;
+  actor: QualityActor;
+  idempotencyKey: string | null | undefined;
+}): Promise<DeliveryPolicyRow | null> {
+  const source = await repoGetDeliveryPolicy(params.id);
+  if (!source) return null;
+  return repoCreateDeliveryPolicy({
+    body: {
+      label: source.label,
+      justification: params.revisionReason,
+      valid_from: source.valid_from,
+      valid_to: source.valid_to,
+      rules: source.rules as CreateDeliveryPolicyBodyDTO["rules"],
+    },
+    actor: params.actor,
+    idempotencyKey: params.idempotencyKey,
+  });
+}
+
+export async function repoTransitionDeliveryPolicy(params: {
+  id: string;
+  body: DeliveryPolicyTransitionBodyDTO;
+  actor: QualityActor;
+  idempotencyKey: string | null | undefined;
+}): Promise<DeliveryPolicyRow | null> {
+  return transaction(async (client) => {
+    const before = await selectPolicy(client, params.id, true);
+    if (!before) return null;
+    assertOptimisticVersion({ expectedUpdatedAt: params.body.expected_updated_at, currentUpdatedAt: before.updated_at });
+    assertDeliveryPolicyTransition(before.status, params.body.target_status);
+    const command = await acquireCommand({ client, actor: params.actor, idempotencyKeyRaw: params.idempotencyKey, commandType: "quality.delivery-policy.transition", payload: { id: params.id, ...params.body } });
+    if (command.replayId) return (await selectPolicy(client, command.replayId)) ?? before;
+
+    if (params.body.target_status === "SIGNED" && (!params.body.signature_reference || !params.body.document_reference)) {
+      throw new HttpError(422, "QUALITY_POLICY_SIGNATURE_REQUIRED", "La reference de signature et le document signe sont obligatoires.");
+    }
+    if (params.body.target_status === "REVOKED" && params.body.reason.trim().length < 10) {
+      throw new HttpError(422, "QUALITY_POLICY_REVOCATION_REASON_REQUIRED", "La revocation exige un motif d'au moins 10 caracteres.");
+    }
+
+    if (params.body.target_status === "ACTIVE") {
+      const active = await client.query<{ id: string }>(
+        `SELECT id::text AS id FROM public.quality_delivery_release_policy
+         WHERE status = 'ACTIVE' AND id <> $1::uuid FOR UPDATE`,
+        [params.id]
+      );
+      for (const row of active.rows) {
+        await client.query(
+          `UPDATE public.quality_delivery_release_policy
+           SET status = 'SUPERSEDED', superseded_by_policy_id = $2::uuid,
+               superseded_at = now(), updated_by = $3, updated_at = now()
+           WHERE id = $1::uuid`,
+          [row.id, params.id, params.actor.user_id]
+        );
+        const superseded = (await selectPolicy(client, row.id))!;
+        await appendEvent({ client, policy: superseded, eventType: "SUPERSEDED", fromStatus: "ACTIVE", reason: params.body.reason, actor: params.actor, idempotencyKey: command.key });
+      }
+    }
+
+    const eventType = params.body.target_status === "IN_REVIEW" ? "SUBMITTED" : params.body.target_status;
+    await client.query(
+      `UPDATE public.quality_delivery_release_policy
+       SET status = $2,
+           submitted_by = CASE WHEN $2 = 'IN_REVIEW' THEN $3 ELSE submitted_by END,
+           submitted_at = CASE WHEN $2 = 'IN_REVIEW' THEN now() ELSE submitted_at END,
+           signed_by = CASE WHEN $2 = 'SIGNED' THEN $3 ELSE signed_by END,
+           signed_at = CASE WHEN $2 = 'SIGNED' THEN now() ELSE signed_at END,
+           signature_reference = CASE WHEN $2 = 'SIGNED' THEN $4 ELSE signature_reference END,
+           document_reference = CASE WHEN $2 = 'SIGNED' THEN $5 ELSE document_reference END,
+           activated_by = CASE WHEN $2 = 'ACTIVE' THEN $3 ELSE activated_by END,
+           activated_at = CASE WHEN $2 = 'ACTIVE' THEN now() ELSE activated_at END,
+           revoked_by = CASE WHEN $2 = 'REVOKED' THEN $3 ELSE revoked_by END,
+           revoked_at = CASE WHEN $2 = 'REVOKED' THEN now() ELSE revoked_at END,
+           revocation_reason = CASE WHEN $2 = 'REVOKED' THEN $6 ELSE revocation_reason END,
+           updated_by = $3, updated_at = now()
+       WHERE id = $1::uuid`,
+      [params.id, params.body.target_status, params.actor.user_id, params.body.signature_reference ?? null, params.body.document_reference ?? null, params.body.reason]
+    );
+    const policy = (await selectPolicy(client, params.id))!;
+    await appendEvent({ client, policy, eventType, fromStatus: before.status, reason: params.body.reason, actor: params.actor, idempotencyKey: command.key });
+    await saveReceipt({ client, actor: params.actor, key: command.key, hash: command.hash, commandType: "quality.delivery-policy.transition", payload: { id: params.id, ...params.body }, policy });
+    return policy;
+  });
+}

--- a/src/module/qualite/routes/quality-360.routes.ts
+++ b/src/module/qualite/routes/quality-360.routes.ts
@@ -4,16 +4,19 @@ import { authenticateToken } from "../../auth/middlewares/auth.middleware";
 import { requireQualityCapability } from "../middlewares/quality-authorization.middleware";
 import {
   consumeDerogation,
+  createDeliveryPolicy,
   createDerogation,
   createExecution,
   createPlan,
   decideExecution,
   evaluateEligibility,
   getDerogation,
+  getDeliveryPolicy,
   getExecution,
   getNcAnalysis,
   getPlan,
   listDerogations,
+  listDeliveryPolicies,
   listExecutions,
   listPlans,
   planApplicability,
@@ -21,11 +24,14 @@ import {
   previewVerdict,
   qualityCenter,
   recordMeasurements,
+  reviseDeliveryPolicy,
   revisePlan,
   transitionDerogation,
+  transitionDeliveryPolicy,
   transitionNc,
   transitionPlan,
   updatePlan,
+  updateDeliveryPolicy,
   upsertNcAnalysis,
 } from "../controllers/quality-360.controller";
 
@@ -54,6 +60,14 @@ const requireDerogationTransitionCapability: RequestHandler = (req, res, next) =
 // Centre Qualité et éligibilité (lecture).
 router.get("/center", requireQualityCapability("read"), qualityCenter);
 router.get("/eligibility", requireQualityCapability("read"), evaluateEligibility);
+
+// Politique globale de liberation des BL : aucune valeur par defaut n'est creee.
+router.get("/delivery-release-policies", requireQualityCapability("read"), listDeliveryPolicies);
+router.get("/delivery-release-policies/:id", requireQualityCapability("read"), getDeliveryPolicy);
+router.post("/delivery-release-policies", requireQualityCapability("settings_manage"), createDeliveryPolicy);
+router.patch("/delivery-release-policies/:id", requireQualityCapability("settings_manage"), updateDeliveryPolicy);
+router.post("/delivery-release-policies/:id/revisions", requireQualityCapability("settings_manage"), reviseDeliveryPolicy);
+router.post("/delivery-release-policies/:id/transitions", requireQualityCapability("settings_manage"), transitionDeliveryPolicy);
 
 // Plans de contrôle.
 router.get("/plans", requireQualityCapability("read"), listPlans);

--- a/src/module/qualite/services/quality-360.service.ts
+++ b/src/module/qualite/services/quality-360.service.ts
@@ -27,6 +27,21 @@ import {
   repoUpdatePlan,
   repoUpsertNcAnalysis,
 } from "../repository/quality-360.repository";
+import {
+  repoCreateDeliveryPolicy,
+  repoGetDeliveryPolicy,
+  repoListDeliveryPolicies,
+  repoReviseDeliveryPolicy,
+  repoTransitionDeliveryPolicy,
+  repoUpdateDeliveryPolicy,
+} from "../repository/quality-delivery-policy.repository";
+
+export const svcListDeliveryPolicies = repoListDeliveryPolicies;
+export const svcGetDeliveryPolicy = repoGetDeliveryPolicy;
+export const svcCreateDeliveryPolicy = repoCreateDeliveryPolicy;
+export const svcUpdateDeliveryPolicy = repoUpdateDeliveryPolicy;
+export const svcTransitionDeliveryPolicy = repoTransitionDeliveryPolicy;
+export const svcReviseDeliveryPolicy = repoReviseDeliveryPolicy;
 
 export const svcListPlans = repoListPlans;
 export const svcGetPlan = repoGetPlan;

--- a/src/module/qualite/validators/quality-360.validators.ts
+++ b/src/module/qualite/validators/quality-360.validators.ts
@@ -13,6 +13,7 @@ import {
 } from "../domain/quality-plan";
 import {
   QUALITY_DEROGATION_STATUSES,
+  QUALITY_DELIVERY_POLICY_STATUSES,
   QUALITY_DISPOSITION_TYPES,
   QUALITY_NC_STATUSES,
   QUALITY_PLAN_STATUSES,
@@ -197,6 +198,79 @@ export const planApplicabilityQuerySchema = z
 export type PlanApplicabilityQueryDTO = z.infer<typeof planApplicabilityQuerySchema>;
 
 /* -------------------------------------------------------------------------- */
+/* Politique globale de liberation des BL                                     */
+/* -------------------------------------------------------------------------- */
+
+export const deliveryReleasePolicyRulesSchema = z
+  .object({
+    schema: z.literal("cerp.quality.delivery-release-policy.v2"),
+    engine: z.literal("CERP_QUALITY_ELIGIBILITY_V1"),
+    aggregate_scope: z.literal("ALL_DELIVERY_ALLOCATIONS"),
+    derogation_mode: z.enum(["FORBIDDEN", "APPROVED_LINKED_RELEASE_ONLY"]),
+    required_control_triggers: z.tuple([z.literal("LOT_RELEASE")]),
+    require_independent_decider: z.literal(true),
+    required_documents: z
+      .array(
+        z
+          .object({
+            document_type: shortText(80),
+            scope: z.enum(["PER_DELIVERY", "PER_TARGET"]),
+            min_count: z.number().int().min(1).max(100),
+          })
+          .strict()
+      )
+      .max(50),
+  })
+  .strict();
+
+export const createDeliveryPolicySchema = z.object({
+  body: z
+    .object({
+      label: shortText(200),
+      justification: shortText(1000),
+      valid_from: isoDateTime,
+      valid_to: isoDateTime.nullable().optional(),
+      rules: deliveryReleasePolicyRulesSchema,
+    })
+    .strict(),
+});
+export type CreateDeliveryPolicyBodyDTO = z.infer<typeof createDeliveryPolicySchema>["body"];
+
+export const updateDeliveryPolicySchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      expected_updated_at: isoDateTime,
+      label: shortText(200),
+      justification: shortText(1000),
+      valid_from: isoDateTime,
+      valid_to: isoDateTime.nullable().optional(),
+      rules: deliveryReleasePolicyRulesSchema,
+    })
+    .strict(),
+});
+export type UpdateDeliveryPolicyBodyDTO = z.infer<typeof updateDeliveryPolicySchema>["body"];
+
+export const deliveryPolicyTransitionSchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z
+    .object({
+      target_status: z.enum(QUALITY_DELIVERY_POLICY_STATUSES),
+      expected_updated_at: isoDateTime,
+      reason: shortText(1000),
+      signature_reference: z.string().trim().min(3).max(200).nullable().optional(),
+      document_reference: z.string().trim().min(3).max(500).nullable().optional(),
+    })
+    .strict(),
+});
+export type DeliveryPolicyTransitionBodyDTO = z.infer<typeof deliveryPolicyTransitionSchema>["body"];
+
+export const reviseDeliveryPolicySchema = z.object({
+  params: z.object({ id: uuid }),
+  body: z.object({ revision_reason: shortText(1000) }).strict(),
+});
+
+/* -------------------------------------------------------------------------- */
 /* Exécutions de contrôle                                                     */
 /* -------------------------------------------------------------------------- */
 
@@ -215,6 +289,8 @@ export const executionPreviewSchema = z.object({
       operation_code: z.string().trim().min(1).max(40).nullable().optional(),
       fournisseur_id: optionalUuid,
       lot_id: optionalUuid,
+      bon_livraison_id: optionalUuid,
+      delivery_allocation_id: optionalUuid,
       of_id: z.number().int().positive().nullable().optional(),
       reception_ligne_id: optionalUuid,
     })


### PR DESCRIPTION
Closes #437

Ajoute la politique versionnée, le lien allocation exact, la séparation opérateur/décideur, le dossier canonique, les gates pack/préparation et la migration 20260813.

Validation : migration isolée vérifiée, typecheck, build, frontière production et suite backend verte hors le test GED préexistant documenté.

## Summary by Sourcery

Introduce a versioned, audited global delivery-quality policy and per-delivery canonical quality dossier, enforce exact allocation-scoped LOT_RELEASE controls with independent deciders before BL preparation and pack generation, and wire the new workflow through quality and livraison APIs, repositories, types, tests, and an isolated migration.

New Features:
- Add support for v2 delivery quality policy rules including LOT_RELEASE control triggers and independent decider requirement.
- Introduce a canonical, frozen quality dossier per delivery that must be created and referenced before generating livraison packs.
- Expose REST endpoints and service/repository layer to manage versioned delivery-release policies (create, update, transition, revise) and to freeze/revoke delivery quality dossiers.
- Extend quality control executions and previews to scope LOT_RELEASE controls to exact delivery allocations and BLs, with stricter validation of control scope and release decisions.

Enhancements:
- Refine delivery quality release evaluation to surface detailed target metadata and latest control decisions, and to enforce presence of applicable LOT_RELEASE plans, started controls, and pronounced decisions.
- Change usage of delivery-release policies from SIGNED to ACTIVE status and add audited lifecycle with allowed transitions and content immutability after signature.
- Ensure BL preparation and pack generation are blocked until the quality release is releasable and a current frozen quality dossier exists, and have packs persist links to the dossier version and evidence manifest.
- Adjust commande fulfillment quality guard to account for LOT_RELEASE decisions tied to delivery allocations when computing released quantities.

Build:
- Add a new isolated migration (20260813_quality_delivery_workflow_0437) with preflight, verification, and rollback support to evolve delivery-quality policy, control, dossier, and pack schema and constraints.

Tests:
- Add domain tests for delivery-release policy transition rules and mutability constraints, and update livraison quality release gate and pack PDF tests to cover allocation-scoped targets and presence of quality dossiers.