### PR TITLE
fix(deploy): restore Alpine ClamAV image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,10 +26,10 @@ RUN printf '%s\n' \
     "curl=8.21.0-r0" \
     "tini=0.19.0-r3" \
     "su-exec=0.3-r0" \
-    "clamav=1.4.5-r0" \
-    "clamav-daemon=1.4.5-r0" \
-    "clamav-clamdscan=1.4.5-r0" \
-    "freshclam=1.4.5-r0" \
+    "clamav=1.4.6-r0" \
+    "clamav-daemon=1.4.6-r0" \
+    "clamav-clamdscan=1.4.6-r0" \
+    "freshclam=1.4.6-r0" \
   && addgroup node clamav
 
 COPY docker/clamd.conf /etc/clamav/clamd.conf


### PR DESCRIPTION
Corrects the Coolify build failure seen on commit 6824f95: Alpine 3.24 now serves ClamAV 1.4.6-r0 while the Dockerfile pinned 1.4.5-r0. Updates the four exact package pins. Verification: full production Docker image built locally successfully; runtime reports ClamAV 1.4.6. No database or production mutation performed. Closes #437.