### PR TITLE
fix(e2e): restore historical tooling contract

### DIFF
--- a/db/e2e/historical-runtime-contract.sql
+++ b/db/e2e/historical-runtime-contract.sql
@@ -154,11 +154,17 @@ ALTER TABLE public.affaire
   ADD COLUMN IF NOT EXISTS commentaire text;
 
 ALTER TABLE public.centres_frais
-  ADD COLUMN IF NOT EXISTS designation text;
+  ADD COLUMN IF NOT EXISTS designation text,
+  ADD COLUMN IF NOT EXISTS type_cf text,
+  ADD COLUMN IF NOT EXISTS section text;
 
 UPDATE public.centres_frais
 SET designation = COALESCE(designation, name)
 WHERE designation IS NULL;
+
+ALTER TABLE public.pieces_families
+  ADD COLUMN IF NOT EXISTS type_famille text,
+  ADD COLUMN IF NOT EXISTS section text;
 
 ALTER TABLE public.commande_historique
   ADD COLUMN IF NOT EXISTS ancien_statut text,
@@ -198,6 +204,59 @@ CREATE TABLE IF NOT EXISTS public.gestion_outils_fournisseur_fabricant (
   id_fournisseur integer NOT NULL REFERENCES public.gestion_outils_fournisseur(id_fournisseur) ON DELETE CASCADE,
   PRIMARY KEY (id_fabricant, id_fournisseur)
 );
+
+-- These legacy catalogue tables predate the additive patch ledger too. The
+-- runtime detail and pricing endpoints nevertheless depend on their deployed
+-- names, so the disposable baseline must reproduce that historical contract.
+CREATE TABLE IF NOT EXISTS public.gestion_outils_revetement (
+  id_revetement serial PRIMARY KEY,
+  nom text NOT NULL,
+  id_fabricant integer NULL REFERENCES public.gestion_outils_fabricant(id_fabricant) ON DELETE SET NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.gestion_outils_outil_revetement (
+  id_outil integer NOT NULL REFERENCES public.gestion_outils_outil(id_outil) ON DELETE CASCADE,
+  id_revetement integer NOT NULL REFERENCES public.gestion_outils_revetement(id_revetement) ON DELETE CASCADE,
+  PRIMARY KEY (id_outil, id_revetement)
+);
+
+CREATE TABLE IF NOT EXISTS public.gestion_outils_arete_coupe (
+  id_arete_coupe serial PRIMARY KEY,
+  nom_arete_coupe text NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS public.gestion_outils_geometrie_aretecoupe (
+  id_geometrie integer NOT NULL REFERENCES public.gestion_outils_geometrie(id_geometrie) ON DELETE CASCADE,
+  id_arete_coupe integer NOT NULL REFERENCES public.gestion_outils_arete_coupe(id_arete_coupe) ON DELETE CASCADE,
+  PRIMARY KEY (id_geometrie, id_arete_coupe)
+);
+
+CREATE TABLE IF NOT EXISTS public.gestion_outils_valeur_arete_coupe (
+  id_valeur_arete serial PRIMARY KEY,
+  id_outil integer NOT NULL REFERENCES public.gestion_outils_outil(id_outil) ON DELETE CASCADE,
+  id_arete_coupe integer NULL REFERENCES public.gestion_outils_arete_coupe(id_arete_coupe) ON DELETE SET NULL,
+  valeur numeric(18,6) NULL
+);
+
+-- The historical bootstrap intentionally starts from the oldest known name
+-- (`id`). Production repositories have long consumed `id_historique`.
+DO $outillage_history_key$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'gestion_outils_historique_prix'
+      AND column_name = 'id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'gestion_outils_historique_prix'
+      AND column_name = 'id_historique'
+  ) THEN
+    ALTER TABLE public.gestion_outils_historique_prix RENAME COLUMN id TO id_historique;
+  END IF;
+END
+$outillage_history_key$;
 
 CREATE TABLE IF NOT EXISTS public.gestion_outils_stock (
   id_outil integer PRIMARY KEY REFERENCES public.gestion_outils_outil(id_outil) ON DELETE CASCADE,
@@ -240,6 +299,22 @@ BEGIN
       AND column_name IN ('profile_picture', 'last_login', 'created_at')
   ) <> 3 THEN
     RAISE EXCEPTION 'SOL-05 historical contract verification failed: account administration columns missing';
+  END IF;
+
+  IF (
+    SELECT count(*)
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'pieces_families'
+      AND column_name IN ('type_famille', 'section')
+  ) <> 2 OR (
+    SELECT count(*)
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'centres_frais'
+      AND column_name IN ('designation', 'type_cf', 'section')
+  ) <> 3 THEN
+    RAISE EXCEPTION 'SOL-05 historical contract verification failed: technical referential columns missing';
   END IF;
 
   IF NOT EXISTS (
@@ -291,8 +366,10 @@ BEGIN
   END IF;
 
   IF to_regclass('public.gestion_outils_outil_fournisseur') IS NULL
-     OR to_regclass('public.gestion_outils_fournisseur_fabricant') IS NULL THEN
-    RAISE EXCEPTION 'SOL-05 historical contract verification failed: outillage supplier links missing';
+     OR to_regclass('public.gestion_outils_fournisseur_fabricant') IS NULL
+     OR to_regclass('public.gestion_outils_outil_revetement') IS NULL
+     OR to_regclass('public.gestion_outils_valeur_arete_coupe') IS NULL THEN
+    RAISE EXCEPTION 'SOL-05 historical contract verification failed: outillage catalogue links missing';
   END IF;
 
   IF NOT EXISTS (
@@ -302,6 +379,15 @@ BEGIN
       AND column_name = 'id_mouvement'
   ) THEN
     RAISE EXCEPTION 'SOL-05 historical contract verification failed: outillage movement key missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'gestion_outils_historique_prix'
+      AND column_name = 'id_historique'
+  ) THEN
+    RAISE EXCEPTION 'SOL-05 historical contract verification failed: outillage price-history key missing';
   END IF;
 END
 $verify$;

--- a/docs/execution-reports/CLAUDE-05.md
+++ b/docs/execution-reports/CLAUDE-05.md
@@ -1,0 +1,77 @@
+# CLAUDE-05 — Contrat historique E2E Outillage / Pièces techniques / GED
+
+- Date d'exécution : 13 août 2026
+- Responsable : Codex, pour Keenan Martin
+- Dépôt : `BigFootLime/erp-crp-backend`
+- Branche : `fix/633-sol20-isolated-outillage-contract`
+- Checkpoint : `1e3e1e3`
+- Portée : environnement E2E jetable uniquement
+
+## Diagnostic et cause racine
+
+Le runner SOL-05 reconstruisait une base historique minimale puis appliquait les
+151 migrations. Ce baseline ne contenait pas toutes les tables legacy du
+catalogue Outillage ni les colonnes historiques de référentiels encore lues par
+les routes SOL-20. Les tests navigateur rencontraient donc :
+
+- `42P01` sur les tables revêtements/arêtes de coupe ;
+- `42703` sur `gestion_outils_historique_prix.id_historique` ;
+- des colonnes absentes sur `pieces_families` et `centres_frais`.
+
+Les routes existent et compilent, mais une base reconstruite depuis le contrat
+historique ne reproduisait pas le comportement déployé. La cause était donc la
+fixture de schéma E2E, pas une migration ou une logique métier SOL-20.
+
+## Choix d'architecture
+
+`db/e2e/historical-runtime-contract.sql` complète le baseline jetable avec les
+objets historiques réellement requis : revêtements, liens outil/revêtement,
+arêtes, liens géométrie/arête, valeurs d'arête, colonnes de famille/centre de
+frais et clé d'historique de prix.
+
+Le renommage `id` → `id_historique` est protégé par une vérification des deux
+noms, donc sûr à rejouer. Le bloc de validation final échoue explicitement si le
+contrat attendu n'est pas présent. Aucun endpoint, modèle, permission, migration
+de production ou donnée métier n'est modifié.
+
+## Fichiers modifiés
+
+- `db/e2e/historical-runtime-contract.sql`
+- `docs/execution-reports/CLAUDE-05.md`
+
+## Tests exécutés
+
+- `corepack pnpm typecheck` : réussi ;
+- `corepack pnpm test:run` : réussi ;
+- `corepack pnpm build` : réussi ;
+- runner frontend `node scripts/e2e/run-isolated.mjs --workers=1 --retries=0
+  e2e/claude05-tooling-ged-ui.spec.ts e2e/tooling-technical-ged.spec.ts` :
+  8/8 scénarios réussis en 35,0 s ;
+- migration isolée : 151 appliquées, 0 en attente, 0 checksum divergent ;
+- contrôles post-application du contrat historique : réussis.
+
+## Migrations et données
+
+Aucune migration de production et aucun patch à appliquer sur les bases
+HYPERBOX2/Coolify. Les objets ajoutés appartiennent exclusivement à la
+reconstruction locale jetable SOL-05. La base et les fichiers temporaires ont
+été détruits après la preuve.
+
+## Risques et compatibilité
+
+- le SQL est additif et idempotent dans le baseline E2E ;
+- les clés étrangères reproduisent les liens réellement consommés ;
+- une divergence future du schéma historique fera échouer le bloc de validation
+  au lieu de produire des 500 tardifs ;
+- ce fichier ne doit jamais être utilisé comme patch de production.
+
+## Rollback
+
+Annuler le commit backend CLAUDE-05. Aucune restauration de données n'est
+nécessaire. Recréer ensuite une pile SOL-05 neuve : l'ancien défaut E2E doit
+réapparaître, ce qui constitue aussi la preuve de portée du rollback.
+
+## Reste réellement à faire
+
+Aucun changement backend produit. Le seul élément connexe restant est l'alerte
+de dépendance frontend `nanoid` documentée dans le rapport CLAUDE-05 frontend.


### PR DESCRIPTION
- restaure le contrat historique Outillage/Pièces du runner SOL-05
- baseline E2E uniquement, additif et idempotent
- backend typecheck/test/build réussis
- E2E frontend+backend isolé: 8/8, 151 migrations
- aucune migration ou écriture de production

## Summary by Sourcery

Restore the SOL-05 E2E historical tooling contract by completing the E2E baseline schema with the legacy catalogue tables and referential columns still consumed at runtime, and by documenting the CLAUDE-05 execution and its safeguards.

Bug Fixes:
- Restore the SOL-05 E2E historical tooling/runtime contract so browser tests can run against a schema matching deployed legacy expectations.

Enhancements:
- Extend the disposable E2E baseline schema with required legacy tooling catalogue tables, referential columns, and explicit contract verification for price history keys and technical referentials.

Documentation:
- Add the CLAUDE-05 execution report documenting the E2E diagnosis, scope, verification steps, and rollback for the restored historical tooling contract.