### PR TITLE
release: promote SOL-21 production planning

### DIFF
--- a/db/patches/20260814_planning_execution_intelligence_0021.sql
+++ b/db/patches/20260814_planning_execution_intelligence_0021.sql
@@ -1,0 +1,113 @@
+-- SOL-21 — server-side planning preferences for reliable production planning.
+-- Additive, transactional and safe to replay. No business value is fabricated.
+
+BEGIN;
+
+DO $preconditions$
+BEGIN
+  IF current_setting('server_version_num')::integer < 140000 THEN
+    RAISE EXCEPTION 'SOL-21 requires PostgreSQL 14 or newer';
+  END IF;
+  IF to_regclass('public.users') IS NULL
+     OR to_regclass('public.planning_events') IS NULL
+     OR to_regclass('public.of_operations') IS NULL
+     OR to_regclass('public.ordres_fabrication') IS NULL
+     OR to_regclass('public.machines') IS NULL
+     OR to_regclass('public.postes') IS NULL
+     OR to_regclass('public.production_pointages') IS NULL
+     OR to_regclass('public.production_activity_categories') IS NULL
+     OR to_regclass('public.production_quantity_declarations') IS NULL
+     OR to_regclass('public.production_machine_unavailability') IS NULL
+     OR to_regclass('public.programmation_calendars') IS NULL
+     OR to_regclass('public.programmation_calendar_closures') IS NULL THEN
+    RAISE EXCEPTION 'SOL-21 prerequisite relation is missing';
+  END IF;
+END
+$preconditions$;
+
+-- The offline station already records its provenance as OFFLINE_STATION.  The
+-- canonical pointage constraint predates that execution path and otherwise
+-- rejects the first synchronized START with SQLSTATE 23514.
+ALTER TABLE public.production_pointages
+  DROP CONSTRAINT IF EXISTS production_pointages_source_sol21_chk;
+ALTER TABLE public.production_pointages
+  ADD CONSTRAINT production_pointages_source_sol21_chk
+  CHECK (source IN ('CANONICAL', 'LEGACY_TIME_LOG', 'RETROACTIVE', 'ADAPTER', 'OFFLINE_STATION'))
+  NOT VALID;
+ALTER TABLE public.production_pointages
+  VALIDATE CONSTRAINT production_pointages_source_sol21_chk;
+ALTER TABLE public.production_pointages
+  DROP CONSTRAINT IF EXISTS production_pointages_source_chk;
+ALTER TABLE public.production_pointages
+  RENAME CONSTRAINT production_pointages_source_sol21_chk TO production_pointages_source_chk;
+
+CREATE OR REPLACE FUNCTION public.fn_planning_color_map_is_valid(value jsonb)
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+STRICT
+AS $function$
+BEGIN
+  IF jsonb_typeof(value) <> 'object' THEN
+    RETURN false;
+  END IF;
+  RETURN (SELECT count(*) FROM jsonb_object_keys(value)) <= 200
+     AND NOT EXISTS (
+       SELECT 1
+         FROM jsonb_each_text(value) entry
+        WHERE char_length(btrim(entry.key)) NOT BETWEEN 1 AND 160
+           OR entry.value !~ '^#[0-9A-F]{6}$'
+     );
+END;
+$function$;
+
+CREATE TABLE IF NOT EXISTS public.planning_user_preferences (
+  user_id integer PRIMARY KEY REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE CASCADE,
+  timezone text NOT NULL DEFAULT 'Europe/Paris',
+  horizon_weeks smallint NOT NULL DEFAULT 6,
+  view_mode text NOT NULL DEFAULT 'WEEK',
+  show_weekends boolean NOT NULL DEFAULT false,
+  machine_ids uuid[] NOT NULL DEFAULT '{}'::uuid[],
+  status_colors jsonb NOT NULL DEFAULT '{}'::jsonb,
+  client_color_overrides jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  created_by integer REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  updated_by integer REFERENCES public.users(id) ON UPDATE RESTRICT ON DELETE SET NULL,
+  CONSTRAINT planning_user_preferences_timezone_ck CHECK (char_length(btrim(timezone)) BETWEEN 1 AND 80),
+  CONSTRAINT planning_user_preferences_horizon_ck CHECK (horizon_weeks BETWEEN 1 AND 13),
+  CONSTRAINT planning_user_preferences_view_ck CHECK (view_mode IN ('DAY', 'WEEK', 'MONTH', 'YEAR')),
+  CONSTRAINT planning_user_preferences_status_colors_ck CHECK (public.fn_planning_color_map_is_valid(status_colors)),
+  CONSTRAINT planning_user_preferences_client_colors_ck CHECK (public.fn_planning_color_map_is_valid(client_color_overrides))
+);
+
+DO $trigger$
+BEGIN
+  IF to_regprocedure('public.tg_set_updated_at()') IS NULL THEN
+    RAISE EXCEPTION 'SOL-21 requires public.tg_set_updated_at()';
+  END IF;
+  DROP TRIGGER IF EXISTS planning_user_preferences_set_updated_at ON public.planning_user_preferences;
+  CREATE TRIGGER planning_user_preferences_set_updated_at
+    BEFORE UPDATE ON public.planning_user_preferences
+    FOR EACH ROW EXECUTE FUNCTION public.tg_set_updated_at();
+END
+$trigger$;
+
+DO $grants$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    GRANT SELECT, INSERT, UPDATE ON public.planning_user_preferences TO cerp_app;
+    GRANT EXECUTE ON FUNCTION public.fn_planning_color_map_is_valid(jsonb) TO cerp_app;
+    -- The station occupancy view is owned by cerp_app and reads machines.
+    -- Granting the view alone leaves session opening blocked with SQLSTATE 42501.
+    GRANT SELECT ON public.machines TO cerp_app;
+  END IF;
+END
+$grants$;
+
+COMMENT ON TABLE public.planning_user_preferences IS
+  'SOL-21 — audited per-user planning preferences. Browser storage is only a cache; this table is authoritative.';
+COMMENT ON COLUMN public.planning_user_preferences.client_color_overrides IS
+  'Per-user planning color overrides, validated server-side. Never used as a business KPI or machine state.';
+
+COMMIT;

--- a/db/patches/support/20260814_planning_execution_intelligence_0021.preflight.sql
+++ b/db/patches/support/20260814_planning_execution_intelligence_0021.preflight.sql
@@ -1,0 +1,49 @@
+-- Read-only preflight. Run after a verified encrypted backup and before SOL-21.
+DO $preflight$
+DECLARE
+  invalid_timezone_count bigint;
+BEGIN
+  IF current_setting('server_version_num')::integer < 140000 THEN
+    RAISE EXCEPTION 'SOL-21 preflight: PostgreSQL 14 or newer is required';
+  END IF;
+  IF to_regclass('public.users') IS NULL
+     OR to_regclass('public.planning_events') IS NULL
+     OR to_regclass('public.of_operations') IS NULL
+     OR to_regclass('public.ordres_fabrication') IS NULL
+     OR to_regclass('public.machines') IS NULL
+     OR to_regclass('public.postes') IS NULL
+     OR to_regclass('public.production_pointages') IS NULL
+     OR to_regclass('public.production_activity_categories') IS NULL
+     OR to_regclass('public.production_quantity_declarations') IS NULL
+     OR to_regclass('public.production_machine_unavailability') IS NULL
+     OR to_regclass('public.programmation_calendars') IS NULL
+     OR to_regclass('public.programmation_calendar_closures') IS NULL THEN
+    RAISE EXCEPTION 'SOL-21 preflight: a source relation is missing';
+  END IF;
+  IF to_regprocedure('public.tg_set_updated_at()') IS NULL THEN
+    RAISE EXCEPTION 'SOL-21 preflight: updated_at trigger function is missing';
+  END IF;
+  SELECT count(*) INTO invalid_timezone_count
+    FROM public.programmation_calendars calendar
+   WHERE NOT EXISTS (SELECT 1 FROM pg_timezone_names zone WHERE zone.name = calendar.timezone);
+  IF invalid_timezone_count > 0 THEN
+    RAISE EXCEPTION 'SOL-21 preflight: % production calendar(s) use an unknown timezone', invalid_timezone_count;
+  END IF;
+END
+$preflight$;
+
+DO $station_view_preflight$
+BEGIN
+  IF to_regclass('public.v_station_machine_occupancy') IS NULL THEN
+    RAISE EXCEPTION 'SOL-21 preflight: station occupancy view is missing';
+  END IF;
+END
+$station_view_preflight$;
+
+SELECT current_database() AS database_name,
+       current_setting('server_version') AS postgres_version,
+       pg_database_size(current_database()) AS database_size_bytes,
+       (SELECT count(*) FROM public.planning_events) AS planning_events,
+       (SELECT count(*) FROM public.production_pointages) AS production_pointages,
+       (SELECT count(*) FROM public.programmation_calendars WHERE active) AS active_calendars,
+       now() AS checked_at;

--- a/db/patches/support/20260814_planning_execution_intelligence_0021.rollback.sql
+++ b/db/patches/support/20260814_planning_execution_intelligence_0021.rollback.sql
@@ -1,0 +1,14 @@
+-- Destructive only for SOL-21 preferences. Export the table or restore the
+-- validated backup in production before acknowledging this rollback.
+DO $rollback_guard$
+BEGIN
+  IF current_setting('cerp.sol21_preferences_exported', true) IS DISTINCT FROM 'yes' THEN
+    RAISE EXCEPTION 'SOL-21 rollback refused: SET cerp.sol21_preferences_exported = yes after exporting preferences';
+  END IF;
+END
+$rollback_guard$;
+
+BEGIN;
+DROP TABLE IF EXISTS public.planning_user_preferences;
+DROP FUNCTION IF EXISTS public.fn_planning_color_map_is_valid(jsonb);
+COMMIT;

--- a/db/patches/support/20260814_planning_execution_intelligence_0021.verify.sql
+++ b/db/patches/support/20260814_planning_execution_intelligence_0021.verify.sql
@@ -1,0 +1,49 @@
+DO $verify$
+BEGIN
+  IF to_regclass('public.planning_user_preferences') IS NULL THEN
+    RAISE EXCEPTION 'SOL-21 verify: planning_user_preferences is missing';
+  END IF;
+  IF to_regprocedure('public.fn_planning_color_map_is_valid(jsonb)') IS NULL THEN
+    RAISE EXCEPTION 'SOL-21 verify: color validation function is missing';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+     WHERE tgrelid = 'public.planning_user_preferences'::regclass
+       AND tgname = 'planning_user_preferences_set_updated_at'
+       AND tgenabled <> 'D'
+  ) THEN
+    RAISE EXCEPTION 'SOL-21 verify: updated_at trigger is missing or disabled';
+  END IF;
+  IF public.fn_planning_color_map_is_valid('{"id:C01":"#AABBCC"}'::jsonb) IS NOT TRUE
+     OR public.fn_planning_color_map_is_valid('{"id:C01":"red"}'::jsonb) IS NOT FALSE THEN
+    RAISE EXCEPTION 'SOL-21 verify: color validation does not fail closed';
+  END IF;
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_constraint
+     WHERE conrelid = 'public.production_pointages'::regclass
+       AND conname = 'production_pointages_source_chk'
+       AND convalidated
+       AND pg_get_constraintdef(oid) LIKE '%OFFLINE_STATION%'
+  ) THEN
+    RAISE EXCEPTION 'SOL-21 verify: offline pointage provenance is not accepted';
+  END IF;
+END
+$verify$;
+
+DO $runtime_privilege_verify$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cerp_app') THEN
+    IF NOT has_table_privilege('cerp_app', 'public.machines', 'SELECT') THEN
+      RAISE EXCEPTION 'SOL-21 verify: cerp_app cannot read machines';
+    END IF;
+    SET LOCAL ROLE cerp_app;
+    PERFORM count(*) FROM public.v_station_machine_occupancy;
+    RESET ROLE;
+  END IF;
+END
+$runtime_privilege_verify$;
+
+SELECT count(*) AS preferences_count,
+       max(updated_at) AS preferences_freshness_at
+  FROM public.planning_user_preferences;

--- a/docs/adr/ADR-0067-production-planning-execution-intelligence.md
+++ b/docs/adr/ADR-0067-production-planning-execution-intelligence.md
@@ -1,0 +1,73 @@
+# ADR-0067 — Frontière planning, capacité et exécution atelier
+
+- Statut : accepté
+- Date : 2026-08-14
+- Décideur technique : CERP+
+- Contrat : `CERP-PRODUCTION-PLANNING-1.0.0`
+- Issue : https://github.com/BigFootLime/crp-systems-web/issues/638
+
+## Contexte
+
+Le planning possédait les créneaux prévus et l'atelier les pointages constatés,
+mais aucun contrat commun ne qualifiait le respect du planning, le WIP, le rebut,
+les arrêts ou la capacité. Les couleurs client restaient locales au navigateur et
+la file atelier ne distinguait pas suffisamment le travail déjà engagé du prochain
+ordre réellement prêt. Une absence de calendrier, de temps ou d'unité pouvait
+donc être interprétée à tort comme une valeur nulle.
+
+## Décision
+
+- `planning_events` et `of_operations` portent le prévu ;
+  `production_pointages` et `production_quantity_declarations` portent le réel.
+  `of_time_logs` reste un adaptateur de compatibilité, jamais une seconde vérité.
+- Chaque KPI publie définition, unité, période, sources, fraîcheur, fiabilité et
+  éléments manquants. Une donnée absente produit `null`, `PARTIAL` ou
+  `UNAVAILABLE`, jamais un zéro de remplissage.
+- Le respect du planning rapporte les opérations distinctes terminées avant la fin
+  de leur créneau aux opérations distinctes arrivées à échéance. Le débit compte
+  les opérations terminées. Le WIP compte les OF non terminés ayant une opération
+  ou un pointage en cours. Le WIP âgé utilise le premier démarrage traçable.
+- Le rebut est calculé uniquement sur une unité homogène : rebut / (bon + rebut),
+  après compensations. Une unité absente ou plusieurs unités empêchent le taux
+  global.
+- La capacité hebdomadaire vient du calendrier actif, diminué des fermetures et
+  indisponibilités machine. Zéro ou plusieurs calendriers actifs rendent la cellule
+  indisponible. La charge est explicable par un drill-down jusqu'aux OF.
+- Les seuils de lecture sont : chargé à partir de 80 %, surcharge au-dessus de
+  100 %, goulot au-dessus de 120 % ou charge positive sans capacité disponible.
+- Les conflits sont calculés côté serveur : ressource indisponible, chevauchement
+  explicitement forcé, ressource réelle différente, pointage ouvert plus de 12 h
+  et temps prévu manquant. Chaque conflit fournit cause, gravité et prochaine action.
+- Les préférences et couleurs sont persistées par utilisateur, validées côté
+  serveur, auditées et protégées contre les mises à jour concurrentes. Le stockage
+  navigateur n'est qu'un cache.
+- La file atelier place d'abord l'exécution en cours, puis les opérations prêtes,
+  les saisies en attente et les blocages. Le même identifiant canonique sert au
+  texte, au QR code et au code-barres CODE128.
+- La file hors ligne existante reste l'unique moteur : stockage IndexedDB chiffré,
+  clé d'idempotence stable, horodatage client, reprise ordonnée, revalidation de
+  session, conflit explicite et état de synchronisation visible.
+- Les rôles opérateur, superviseur et planificateur sont contrôlés dans l'API en
+  plus du droit de module. Un simple accès générique au module n'élève pas un
+  opérateur vers la lecture de capacité.
+
+## Conséquences
+
+Le cockpit fonctionnel peut expliquer toute valeur et remonter jusqu'aux OF sans
+devenir une seconde interface de saisie. Le poste atelier sait distinguer encours,
+prochain travail, blocage et saisie à synchroniser. Les calendriers réels restent
+un prérequis métier : le système signale leur absence au lieu d'inventer une
+capacité.
+
+## Migration et retour arrière
+
+La migration est additive : table `planning_user_preferences`, fonction de
+validation des couleurs, contrainte de provenance étendue à `OFFLINE_STATION` et
+privilège de lecture minimal sur `machines` pour la vue d'occupation du rôle
+applicatif. Elle n'insère aucune valeur métier.
+
+L'ancien backend ignore la table additive. Le rollback destructif exige d'abord
+l'export explicite des préférences ; il ne réécrit ni pointage ni planning. Après
+usage réel, le retour sûr consiste à redéployer les artefacts précédents en
+conservant le schéma. Toute suppression de données exige un gel des écritures et
+la restauration vérifiée du dump pré-migration dans une nouvelle base.

--- a/docs/execution-reports/SOL-21.md
+++ b/docs/execution-reports/SOL-21.md
@@ -1,0 +1,116 @@
+# SOL-21 — Production, atelier et planning (backend)
+
+- Date : 2026-08-14
+- Issue : https://github.com/BigFootLime/crp-systems-web/issues/638
+- Branche : `feature/638-sol21-production-planning`
+- Base initiale : `origin/dev` (`76eb183`), arbre identique à `origin/main` (`039c72e5`)
+- ADR : `docs/adr/ADR-0067-production-planning-execution-intelligence.md`
+
+## Diagnostic et cause racine
+
+Le prévu, le réel, les calendriers et les quantités existaient dans des domaines
+séparés sans définition décisionnelle commune. La capacité et les conflits
+n'étaient pas expliqués par une API unique, les couleurs restaient locales et
+l'accès générique au module pouvait être confondu avec une élévation de rôle.
+L'intégration réelle a aussi révélé quatre défauts dormants : le rôle applicatif
+ne pouvait pas lire `machines` via la vue station, la requête worklist conservait
+un paramètre SQL inutilisé (`42P18`), la contrainte de provenance refusait
+`OFFLINE_STATION`, et la fin d'une opération après quantité déjà synchronisée
+refusait à tort une confirmation sans quantité supplémentaire.
+
+## Choix d'architecture et résultat
+
+- `planning_events`/`of_operations` restent la source du prévu et
+  `production_pointages`/`production_quantity_declarations` celle du réel ;
+- KPI versionnés `SOL-21.v1` avec formule, unité, période, source, fraîcheur,
+  fiabilité et manquants ; aucune donnée absente remplacée par zéro ;
+- capacité hebdomadaire dérivée des calendriers, fermetures et indisponibilités,
+  avec états chargé/surchargé/goulot et drill-down OF ;
+- conflits côté serveur avec cause et action : ressource indisponible,
+  chevauchement forcé, ressource réelle différente, pointage >12 h et temps
+  prévu manquant ;
+- préférences/couleurs par utilisateur, validation, concurrence, audit et
+  idempotence transactionnelle ;
+- file atelier triée par exécution en cours, prochain ordre prêt, saisie en
+  attente et blocage, avec identifiant canonique prêt QR/CODE128 ;
+- moteur hors ligne existant conservé : file chiffrée, ordre, horodatage, clé
+  stable, reprise, conflit et visibilité de synchronisation ;
+- RBAC serveur séparant opérateur, superviseur et planificateur ; un accès module
+  ordinaire n'accorde plus implicitement `read_capacity`.
+
+## Fichiers modifiés
+
+- `src/module/planning/` : types, domaine, repository, service, validation,
+  middleware RBAC, contrôleur et routes ;
+- `src/module/production/` : exécution, worklist station, tri, scan et tests ;
+- `src/module/access-control/` : distinction accès module ordinaire/élevé ;
+- `db/patches/20260814_planning_execution_intelligence_0021.sql` et supports
+  preflight/verify/rollback ;
+- `scripts/e2e/seed-isolated.js` et `scripts/migrations/release-gate.js` ;
+- tests planning, production, station, RBAC et migration ;
+- ADR-0067, documentation HTTP, runbook et présent rapport.
+
+## Migration et changements de données
+
+Migration additive : une table de préférences utilisateur, une fonction de
+validation des couleurs, extension validée de la provenance des pointages à
+`OFFLINE_STATION`, et privilège SELECT minimal pour la vue station sous
+`cerp_app`. Aucune préférence, capacité, couleur ou donnée de production n'est
+créée.
+
+Répétition PostgreSQL 16.14 jetable finale : sauvegarde 1 968 435 octets,
+SHA-256 `342f22beca3c93bdb5dc8bf191693a704d70cf0e15f13f0f71a8b8e529e880d1` ;
+migration 395 ms, verify 180 ms, rejeu à zéro 123 ms, rollback 192 ms,
+restauration 4 334 ms ; 152 patchs appliqués, 0 attendu, puis comptages restaurés
+identiques. Aucune base HYPERBOX2, Coolify ou production n'a été lue ou écrite.
+
+## Tests exécutés et résultats
+
+| Contrôle | Résultat réel |
+|---|---|
+| suite backend Vitest complète | PASS — 952 suites, 4 567 réussis, 4 ignorés, 0 échec |
+| tests planning/production ciblés | PASS — domaines, routes, validation, RBAC, worklist et fin d'opération |
+| `pnpm typecheck` | PASS |
+| `pnpm build` | PASS — frontière de données production validée |
+| `pnpm db:migrations:rehearse` | PASS — backup, preflight, migration, verify, replay, rollback et restore |
+| Playwright inter-dépôts complet | PASS — 97/97, Chromium, 474,5 s, 0 retry |
+| répétition clavier/souris/tactile | PASS — 30/30, dix répétitions, 0 retry |
+
+Le backend ne déclare pas de script lint. Typecheck, build, tests et contrôle de
+migration sont les contrôles disponibles dans son manifeste.
+
+## Vérification navigateur/E2E
+
+Le runner a construit les deux applications, créé PostgreSQL et les stockages
+jetables, appliqué les 152 patchs et chargé huit utilisateurs. Le scénario réel
+prouve vente → commande → analyse → OF → planning → lancement → pointage → quantité
+hors ligne → retry sans doublon → fin → livraison → facture, avec lecture capacité,
+préférence idempotente et refus de capacité à l'opérateur. Les 97 scénarios
+historiques passent également sans retry.
+
+La première campagne complète a trouvé six échecs `ECONNREFUSED` : la recette UI
+historique du poste atelier ciblait son stub sans que le runner le démarre. Le
+runner lance maintenant explicitement ce service sur ports loopback contrôlés.
+Cette recette vérifie l'UI ; le scénario SOL-21 distinct continue d'utiliser le
+vrai backend PostgreSQL.
+
+## Risques, compatibilité et travail restant
+
+- le modèle actuel ne relie pas un calendrier à une machine : exactement un
+  calendrier actif est accepté ; zéro ou plusieurs rendent la capacité
+  indisponible. Une affectation machine/calendrier nécessitera une décision métier
+  et une migration additive ;
+- les anciennes quantités sans unité et les opérations sans temps prévu restent
+  partielles, conformément à la règle de non-fabrication ;
+- le seuil d'encours âgé et les seuils de charge sont contractuels `SOL-21.v1` ;
+  tout changement doit versionner la définition ;
+- la migration production reste à appliquer dans une fenêtre autorisée selon le
+  runbook, après sauvegarde vérifiée. Elle n'a pas été appliquée pendant ce travail.
+
+## Rollback
+
+Un défaut applicatif se traite en redéployant le SHA précédent tout en conservant
+les objets additifs. Avant toute préférence réelle, exporter la table puis utiliser
+le rollback support dans une session explicitement autorisée. Après usage, geler
+les écritures et restaurer le dump pré-migration dans une nouvelle base ; ne jamais
+supprimer silencieusement préférences, pointages ou preuves d'exécution.

--- a/docs/http/planning.md
+++ b/docs/http/planning.md
@@ -22,6 +22,9 @@ deux événements adjacents sont autorisés, un chevauchement positif est un con
 | GET | `/governance` | Décision de retrait fail-closed, route canonique et politique de mesure |
 | POST | `/governance/usage` | Incrément journalier borné (`surface`, `event_type`, `browser_family`) si le flag est actif |
 | GET | `/governance/metrics` | Agrégats 28 jours par défaut, réservés au superadmin |
+| GET | `/execution-intelligence` | KPI qualifiés, capacité hebdomadaire, conflits et file d'actions |
+| GET | `/preferences` | Préférences planning autoritaires de l'utilisateur |
+| PUT | `/preferences` | Mise à jour validée, auditée et protégée contre la concurrence |
 | GET | `/resources` | Machines et postes planifiables |
 | GET | `/events` | Fenêtre bornée ; `limit` 2 000 par défaut, 5 000 maximum, `offset`; `total` reste exhaustif |
 | GET | `/events/:id` | Détail, commentaires et documents |
@@ -34,6 +37,20 @@ deux événements adjacents sont autorisés, un chevauchement positif est un con
 | GET | `/events/:id/documents/:docId/file` | Lecture authentifiée du contenu d'un document |
 | POST | `/autoplan` | Application séquentielle avec créations, éléments ignorés et résumé partiel explicite |
 | POST | `/validate-for-ar` | Fait progresser vers `AR_PRET`; n'envoie jamais l'AR |
+
+## Intelligence d'exécution SOL-21
+
+`GET /execution-intelligence` exige la capacité `read_capacity` et une période
+ISO-8601 bornée. La réponse versionnée `SOL-21.v1` expose définition, unité,
+numérateur, dénominateur, source, fraîcheur, fiabilité et manquants pour chaque
+KPI. Les cellules de capacité contiennent la charge prévue/réelle et le drill-down
+jusqu'aux événements et OF. Une absence ou ambiguïté de calendrier rend la
+capacité `null`; une unité de rebut absente ou hétérogène empêche le taux global.
+
+Les préférences sont propres à l'utilisateur authentifié. Les couleurs acceptent
+uniquement `#RRGGBB`, avec au plus 200 entrées et des clés bornées. Les machines
+référencées doivent exister. Une version `updated_at` périmée renvoie un conflit
+au lieu d'écraser le réglage d'une autre session.
 
 ## Convergence Premium / historique
 

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.json
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.json
@@ -1,6 +1,6 @@
 {
   "status": "passed",
-  "started_at": "2026-08-13T11:29:45.935Z",
+  "started_at": "2026-08-13T23:31:29.113Z",
   "postgres_image": "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229",
   "isolated_target": {
     "host": "127.0.0.1",
@@ -9,34 +9,34 @@
     "storage": "tmpfs"
   },
   "durations": {
-    "source_migration": 18275,
-    "source_seed": 195,
-    "backup": 698,
-    "preflight": 144,
-    "integrity_before": 570,
-    "migration": 349,
-    "verify": 157,
-    "replay": 117,
-    "integrity_after": 1467,
-    "negative_gate": 42,
-    "rollback": 165,
-    "restore": 3905
+    "source_migration": 19605,
+    "source_seed": 230,
+    "backup": 740,
+    "preflight": 130,
+    "integrity_before": 630,
+    "migration": 395,
+    "verify": 180,
+    "replay": 123,
+    "integrity_after": 1453,
+    "negative_gate": 48,
+    "rollback": 192,
+    "restore": 4334
   },
   "source": {
     "status": "passed",
-    "checked_at": "2026-08-13T11:30:07.881Z",
-    "duration_ms": 87,
+    "checked_at": "2026-08-13T23:31:52.288Z",
+    "duration_ms": 80,
     "identity": {
       "database": "cerp_test",
       "database_user": "cerp_e2e",
       "server_version": "16.14",
-      "database_bytes": "36166679"
+      "database_bytes": "36355095"
     },
     "backup": {
-      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-PD9vR0\\cerp-test-before-sol06.dump",
-      "bytes": 1954052,
-      "sha256": "7dd8de175577c5d04a1f62cdea190ec53a4b4b5f4b9405ec35ee2a2e1a6c86a4",
-      "free_bytes": 430891192320
+      "file": "C:\\Users\\KEENAN~1\\AppData\\Local\\Temp\\cerp-sol06-FVm76h\\cerp-test-before-sol06.dump",
+      "bytes": 1968435,
+      "sha256": "342f22beca3c93bdb5dc8bf191693a704d70cf0e15f13f0f71a8b8e529e880d1",
+      "free_bytes": 415471935488
     },
     "ledger": {
       "applied": 140,
@@ -51,7 +51,8 @@
         "20260812_procurement_reliability_sol18.sql",
         "20260813_quality_delivery_workflow_0437.sql",
         "20260813_sol20_tooling_technical_ged.sql",
-        "20260813_stock_intelligence_sol19.sql"
+        "20260813_stock_intelligence_sol19.sql",
+        "20260814_planning_execution_intelligence_0021.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
@@ -76,7 +77,7 @@
       "app_feature_flag_users": "0",
       "app_feature_flags": "4",
       "app_module_access_events": "0",
-      "app_module_user_access": "6",
+      "app_module_user_access": "7",
       "app_modules": "24",
       "app_notifications": "0",
       "app_roles": "33",
@@ -189,7 +190,7 @@
       "fournisseur_outillage_mapping": "0",
       "fournisseurs": "1",
       "gamme_operation_finitions": "0",
-      "gammes": "0",
+      "gammes": "1",
       "ged_access_events": "0",
       "ged_approvals": "0",
       "ged_blobs": "0",
@@ -203,18 +204,23 @@
       "ged_snapshot_manifest_entries": "0",
       "ged_snapshot_manifests": "0",
       "ged_upload_sessions": "0",
+      "gestion_outils_arete_coupe": "0",
       "gestion_outils_fabricant": "0",
       "gestion_outils_famille": "0",
       "gestion_outils_fournisseur": "0",
       "gestion_outils_fournisseur_fabricant": "0",
       "gestion_outils_geometrie": "0",
+      "gestion_outils_geometrie_aretecoupe": "0",
       "gestion_outils_historique_prix": "0",
       "gestion_outils_import_batch": "0",
       "gestion_outils_import_row": "0",
       "gestion_outils_mouvement_stock": "0",
       "gestion_outils_outil": "0",
       "gestion_outils_outil_fournisseur": "0",
+      "gestion_outils_outil_revetement": "0",
+      "gestion_outils_revetement": "0",
       "gestion_outils_stock": "0",
+      "gestion_outils_valeur_arete_coupe": "0",
       "hr_badge_credentials": "0",
       "hr_employees": "0",
       "hr_employment_contracts": "0",
@@ -233,7 +239,7 @@
       "informations_bancaires": "0",
       "locations": "1",
       "lots": "0",
-      "machines": "10",
+      "machines": "11",
       "magasins": "5",
       "margin_input_versions": "0",
       "margin_rate_versions": "0",
@@ -421,8 +427,8 @@
       "traceability_links": "0",
       "units": "4",
       "user_role_assignment_events": "1",
-      "user_role_assignments": "12",
-      "users": "7",
+      "user_role_assignments": "14",
+      "users": "8",
       "warehouses": "4"
     },
     "ledger": {
@@ -438,12 +444,13 @@
         "20260812_procurement_reliability_sol18.sql",
         "20260813_quality_delivery_workflow_0437.sql",
         "20260813_sol20_tooling_technical_ged.sql",
-        "20260813_stock_intelligence_sol19.sql"
+        "20260813_stock_intelligence_sol19.sql",
+        "20260814_planning_execution_intelligence_0021.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
     },
-    "fingerprint": "ffba5ceb693763c901308b56f252bd5e498d8c53e2886ce4b9d76ba39e9bf49c"
+    "fingerprint": "687a3a0e5c56d2413ba0e726fec13ab6d32b3113e7a640df01c9673c8990961d"
   },
   "replay": {
     "applied_zero": true,
@@ -451,8 +458,8 @@
   },
   "after": {
     "status": "passed",
-    "checked_at": "2026-08-13T11:30:10.545Z",
-    "duration_ms": 1453,
+    "checked_at": "2026-08-13T23:31:55.072Z",
+    "duration_ms": 1437,
     "table_counts": {
       "admin_account_invitations": "0",
       "admin_user_provisioning_migration_state": "12",
@@ -470,7 +477,7 @@
       "app_feature_flag_users": "0",
       "app_feature_flags": "4",
       "app_module_access_events": "0",
-      "app_module_user_access": "6",
+      "app_module_user_access": "7",
       "app_modules": "24",
       "app_notifications": "0",
       "app_roles": "33",
@@ -509,7 +516,7 @@
       "centres_frais": "1",
       "cerp_patch_20260804_stock_units": "3",
       "cerp_patch_20260811_base_unit_repair": "1",
-      "cerp_schema_migrations": "151",
+      "cerp_schema_migrations": "152",
       "chat_conversation_participants": "0",
       "chat_conversations": "0",
       "chat_messages": "0",
@@ -587,7 +594,7 @@
       "fournisseur_outillage_mapping": "0",
       "fournisseurs": "1",
       "gamme_operation_finitions": "0",
-      "gammes": "0",
+      "gammes": "1",
       "ged_access_events": "0",
       "ged_approvals": "0",
       "ged_blobs": "0",
@@ -601,18 +608,23 @@
       "ged_snapshot_manifest_entries": "0",
       "ged_snapshot_manifests": "0",
       "ged_upload_sessions": "0",
+      "gestion_outils_arete_coupe": "0",
       "gestion_outils_fabricant": "0",
       "gestion_outils_famille": "0",
       "gestion_outils_fournisseur": "0",
       "gestion_outils_fournisseur_fabricant": "0",
       "gestion_outils_geometrie": "0",
+      "gestion_outils_geometrie_aretecoupe": "0",
       "gestion_outils_historique_prix": "0",
       "gestion_outils_import_batch": "0",
       "gestion_outils_import_row": "0",
       "gestion_outils_mouvement_stock": "0",
       "gestion_outils_outil": "0",
       "gestion_outils_outil_fournisseur": "0",
+      "gestion_outils_outil_revetement": "0",
+      "gestion_outils_revetement": "0",
       "gestion_outils_stock": "0",
+      "gestion_outils_valeur_arete_coupe": "0",
       "hr_badge_credentials": "0",
       "hr_employees": "0",
       "hr_employment_contracts": "0",
@@ -631,7 +643,7 @@
       "informations_bancaires": "0",
       "locations": "1",
       "lots": "0",
-      "machines": "10",
+      "machines": "11",
       "magasins": "5",
       "margin_input_versions": "0",
       "margin_rate_versions": "0",
@@ -699,6 +711,7 @@
       "planning_event_documents": "0",
       "planning_events": "0",
       "planning_surface_usage_daily": "0",
+      "planning_user_preferences": "0",
       "postes": "1",
       "procurement_anomaly_actions": "0",
       "procurement_command_receipts": "0",
@@ -831,11 +844,11 @@
       "traceability_links": "0",
       "units": "4",
       "user_role_assignment_events": "1",
-      "user_role_assignments": "12",
-      "users": "7",
+      "user_role_assignments": "14",
+      "users": "8",
       "warehouses": "4"
     },
-    "table_count": 380,
+    "table_count": 386,
     "unvalidated_constraints": [
       {
         "table_name": "avoir",
@@ -912,7 +925,7 @@
         "groups": 0
       }
     ],
-    "foreign_key_count": 1101,
+    "foreign_key_count": 1111,
     "orphans": [],
     "readiness": [
       {
@@ -924,7 +937,7 @@
         "period_start": "2026-08-12T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-13T11:30:09.093Z",
+        "freshness_at": "2026-08-13T23:31:53.636Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -941,7 +954,7 @@
         "period_start": "2026-08-12T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-13T11:30:09.093Z",
+        "freshness_at": "2026-08-13T23:31:53.636Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -959,7 +972,7 @@
         "period_start": "2026-08-12T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-13T11:30:09.093Z",
+        "freshness_at": "2026-08-13T23:31:53.636Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -985,7 +998,7 @@
         "period_start": "2026-08-12T22:00:00.000Z",
         "period_end": null,
         "source": "public.programmation_calendars",
-        "freshness_at": "2026-08-13T11:30:09.093Z",
+        "freshness_at": "2026-08-13T23:31:53.636Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_calendars": 1
@@ -1002,7 +1015,7 @@
         "period_start": "2026-08-12T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-13T11:30:09.093Z",
+        "freshness_at": "2026-08-13T23:31:53.636Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1020,7 +1033,7 @@
         "period_start": "2026-08-12T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-13T11:30:09.093Z",
+        "freshness_at": "2026-08-13T23:31:53.636Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1040,7 +1053,7 @@
         "period_start": "2026-08-12T22:00:00.000Z",
         "period_end": null,
         "source": "public.centres_frais + public.production_cost_center_rates",
-        "freshness_at": "2026-08-13T11:30:09.093Z",
+        "freshness_at": "2026-08-13T23:31:53.636Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_cost_centers": 1,
@@ -1058,7 +1071,7 @@
         "period_start": "2026-08-12T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-13T11:30:09.093Z",
+        "freshness_at": "2026-08-13T23:31:53.636Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1084,7 +1097,7 @@
         "period_start": "2026-08-12T22:00:00.000Z",
         "period_end": null,
         "source": "public.app_roles + public.user_role_assignments",
-        "freshness_at": "2026-08-13T11:30:09.093Z",
+        "freshness_at": "2026-08-13T23:31:53.636Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "active_roles": 33,
@@ -1102,7 +1115,7 @@
         "period_start": "2026-08-12T22:00:00.000Z",
         "period_end": null,
         "source": "public.warehouses + locations + magasins + emplacements",
-        "freshness_at": "2026-08-13T11:30:09.093Z",
+        "freshness_at": "2026-08-13T23:31:53.636Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "configured_locations": 1,
@@ -1121,7 +1134,7 @@
         "period_start": "2026-08-12T22:00:00.000Z",
         "period_end": null,
         "source": "public.units",
-        "freshness_at": "2026-08-13T11:30:09.093Z",
+        "freshness_at": "2026-08-13T23:31:53.636Z",
         "reliability": "VERIFIED",
         "actual_value": [
           "kg",
@@ -1159,7 +1172,7 @@
         "period_start": "2026-08-12T22:00:00.000Z",
         "period_end": null,
         "source": "pg_catalog.pg_enum + pg_catalog.pg_constraint",
-        "freshness_at": "2026-08-13T11:30:09.093Z",
+        "freshness_at": "2026-08-13T23:31:53.636Z",
         "reliability": "VERIFIED",
         "actual_value": {
           "of_statuses": [
@@ -1178,12 +1191,12 @@
       }
     ],
     "ledger": {
-      "applied": 151,
+      "applied": 152,
       "pending": [],
       "checksum_mismatches": [],
       "unknown_applied": []
     },
-    "fingerprint": "3cdfc7d2ab8e1fa186abd6fa6464a927311f59039d66b85eede0121dd58fae45"
+    "fingerprint": "16d821450436ef45e62b9634e1e249178e734b8a18b3d12b792c273a8f11f058"
   },
   "negative_gate": {
     "status": "passed",
@@ -1217,11 +1230,12 @@
     "procurement_reliability_removed": true,
     "stock_intelligence_removed": true,
     "tooling_technical_ged_removed": true,
+    "planning_execution_removed": true,
     "trigger_removed": true
   },
   "restore": {
     "status": "passed",
-    "fingerprint": "ffba5ceb693763c901308b56f252bd5e498d8c53e2886ce4b9d76ba39e9bf49c",
+    "fingerprint": "687a3a0e5c56d2413ba0e726fec13ab6d32b3113e7a640df01c9673c8990961d",
     "table_counts_equal": true,
     "ledger": {
       "applied": 140,
@@ -1236,11 +1250,12 @@
         "20260812_procurement_reliability_sol18.sql",
         "20260813_quality_delivery_workflow_0437.sql",
         "20260813_sol20_tooling_technical_ged.sql",
-        "20260813_stock_intelligence_sol19.sql"
+        "20260813_stock_intelligence_sol19.sql",
+        "20260814_planning_execution_intelligence_0021.sql"
       ],
       "checksum_mismatches": [],
       "unknown_applied": []
     }
   },
-  "completed_at": "2026-08-13T11:30:14.810Z"
+  "completed_at": "2026-08-13T23:31:59.852Z"
 }

--- a/docs/release/MIGRATION_REHEARSAL_SOL_06.md
+++ b/docs/release/MIGRATION_REHEARSAL_SOL_06.md
@@ -1,33 +1,33 @@
 # Répétition de migration isolée — SOL-06
 
 - Statut : **passed**
-- Exécutée : 2026-08-13T11:30:14.810Z
+- Exécutée : 2026-08-13T23:31:59.852Z
 - PostgreSQL : postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
-- Base source : cerp_test, 36166679 octets
-- Sauvegarde : 1954052 octets, SHA-256 `7dd8de175577c5d04a1f62cdea190ec53a4b4b5f4b9405ec35ee2a2e1a6c86a4`
-- Patches avant/après : 140 / 151
+- Base source : cerp_test, 36355095 octets
+- Sauvegarde : 1968435 octets, SHA-256 `342f22beca3c93bdb5dc8bf191693a704d70cf0e15f13f0f71a8b8e529e880d1`
+- Patches avant/après : 140 / 152
 - Intégrité avant/après : passed / passed
 - Rejeu du runner : 0 patch (conforme)
 - Refus métier négatif : SQLSTATE P2606
 - Rollback test-only : passed
 - Restauration vers base neuve : passed
-- Empreinte source/restaurée : `ffba5ceb693763c901308b56f252bd5e498d8c53e2886ce4b9d76ba39e9bf49c` / `ffba5ceb693763c901308b56f252bd5e498d8c53e2886ce4b9d76ba39e9bf49c`
+- Empreinte source/restaurée : `687a3a0e5c56d2413ba0e726fec13ab6d32b3113e7a640df01c9673c8990961d` / `687a3a0e5c56d2413ba0e726fec13ab6d32b3113e7a640df01c9673c8990961d`
 
 ## Durées réelles
 
 | Étape | Durée (ms) |
 |---|---:|
-| source_migration | 18275 |
-| source_seed | 195 |
-| backup | 698 |
-| preflight | 144 |
-| integrity_before | 570 |
-| migration | 349 |
-| verify | 157 |
-| replay | 117 |
-| integrity_after | 1467 |
-| negative_gate | 42 |
-| rollback | 165 |
-| restore | 3905 |
+| source_migration | 19605 |
+| source_seed | 230 |
+| backup | 740 |
+| preflight | 130 |
+| integrity_before | 630 |
+| migration | 395 |
+| verify | 180 |
+| replay | 123 |
+| integrity_after | 1453 |
+| negative_gate | 48 |
+| rollback | 192 |
+| restore | 4334 |
 
 La pile PostgreSQL était liée à `127.0.0.1`, stockée en tmpfs et détruite en fin d'exécution. Aucune URL ni donnée de production n'a été utilisée.

--- a/docs/runbooks/production-planning-sol21-migration.md
+++ b/docs/runbooks/production-planning-sol21-migration.md
@@ -1,0 +1,84 @@
+# Runbook opérateur — migration SOL-21 planning et exécution
+
+- Propriétaire : exploitation CERP+
+- Version : 1.0
+- Dernière vérification : 2026-08-14
+- Patch : `20260814_planning_execution_intelligence_0021.sql`
+
+## Symptômes et impact
+
+Ce runbook couvre le déploiement, le refus ou le retour arrière du schéma SOL-21.
+Une migration absente empêche la persistance serveur des préférences et peut
+refuser les pointages issus de la file hors ligne. Une capacité indisponible par
+absence de calendrier est un prérequis métier, pas un incident de migration.
+
+## Préparation sûre
+
+1. Confirmer que frontend et API ciblent le même SHA et la base attendue.
+2. Geler les changements de planning et les ouvertures de session atelier.
+3. Vérifier en lecture seule :
+
+   ```powershell
+   psql $env:DATABASE_URL -v ON_ERROR_STOP=1 -f db/patches/support/20260814_planning_execution_intelligence_0021.preflight.sql
+   pnpm db:patches:status
+   ```
+
+4. Produire la sauvegarde chiffrée DB selon SOL-10. Enregistrer taille, SHA-256,
+   âge et preuve de restauration. Ne pas continuer sans cette preuve.
+5. Vérifier PostgreSQL >= 14, les relations sources, les fuseaux des calendriers,
+   la vue d'occupation et la fonction `tg_set_updated_at()`.
+
+## Application et validation
+
+```powershell
+pnpm db:patches:up -- --dry-run --only 20260814_planning_execution_intelligence_0021.sql
+pnpm db:patches:up -- --only 20260814_planning_execution_intelligence_0021.sql
+psql $env:DATABASE_URL -v ON_ERROR_STOP=1 -f db/patches/support/20260814_planning_execution_intelligence_0021.verify.sql
+pnpm db:patches:status -- --check --only 20260814_planning_execution_intelligence_0021.sql
+```
+
+Valider ensuite avec trois comptes distincts :
+
+1. l'opérateur ouvre sa station, voit l'encours puis les opérations prêtes, mais
+   reçoit `403` sur `/planning/execution-intelligence` ;
+2. le superviseur consulte les blocages et corrige un pointage selon le workflow
+   existant ;
+3. le planificateur lit la capacité, ouvre le drill-down OF et enregistre ses
+   préférences ; le retry avec la même version ne crée aucun doublon ;
+4. une quantité hors ligne est synchronisée une seule fois avec la provenance
+   `OFFLINE_STATION`, puis l'opération peut être terminée ;
+5. les KPI sans calendrier, unité ou temps prévu restent explicitement
+   `UNAVAILABLE`/`PARTIAL`.
+
+Le service est rétabli uniquement si le verify passe, si la vue d'occupation est
+lisible sous le rôle applicatif et si ces contrôles n'exposent ni élévation de droit
+ni doublon.
+
+## Arbre de décision et rollback
+
+- Échec avant commit : conserver les logs, corriger le prérequis et rejouer. Ne
+  jamais modifier manuellement `cerp_schema_migrations`.
+- Échec applicatif sans corruption : redéployer l'ancien backend ; les objets
+  additifs restent compatibles.
+- Retour avant toute préférence : exporter la table, marquer explicitement
+  l'export dans la session SQL, puis exécuter le support de rollback.
+- Préférences déjà utilisées : ne pas les supprimer. Geler les écritures,
+  restaurer le dump pré-migration dans une nouvelle base, comparer comptages et
+  checksum, puis promouvoir explicitement cette base.
+
+```powershell
+pg_dump $env:DATABASE_URL --table=public.planning_user_preferences --format=custom --file=planning-user-preferences.dump
+psql $env:DATABASE_URL -v ON_ERROR_STOP=1 -c "SET cerp.sol21_preferences_exported = 'yes';" -f db/patches/support/20260814_planning_execution_intelligence_0021.rollback.sql
+```
+
+La seconde commande doit être exécutée dans une session unique adaptée par
+l'opérateur ; un `SET` dans une connexion séparée n'autorise pas le rollback.
+
+## Actions interdites et communication
+
+Ne jamais convertir une capacité absente en zéro, supprimer un pointage, changer
+la source d'un événement, contourner le RBAC, éditer le ledger de migration ou
+appliquer le patch sur une base non désignée. Informer les utilisateurs du gel,
+des entités touchées, de la décision de reprise et de la validation métier. Tout
+incident conserve SHA, fenêtre, comptes de test, OF concernés, cause racine et
+mesure préventive dans le post-mortem.

--- a/scripts/e2e/seed-isolated.js
+++ b/scripts/e2e/seed-isolated.js
@@ -35,6 +35,7 @@ const USERS = [
   ["E2E_STANDARD", "Standard", "E2E", "standard.e2e@invalid.example", "Employee", false, "Employee"],
   ["E2E_SALES", "Commerce", "E2E", "sales.e2e@invalid.example", "Secretaire", false, "Commerce"],
   ["E2E_PLANNER", "Planning", "E2E", "planner.e2e@invalid.example", "Responsable Programmation", false, "Planification"],
+  ["E2E_OPERATOR", "Operateur", "E2E", "operator.e2e@invalid.example", "Employee", false, "Opérateur atelier"],
   ["E2E_QUALITY", "Qualite", "E2E", "quality.e2e@invalid.example", "Responsable Qualité", false, "Qualité"],
   ["E2E_PURCHASING", "Achats", "E2E", "purchasing.e2e@invalid.example", "Directeur", false, "Achats"],
   ["E2E_ACCOUNTANT", "Comptabilite", "E2E", "accounting.e2e@invalid.example", "Directeur", false, "RH-Financier"],
@@ -369,6 +370,19 @@ async function main() {
          plan_reference=EXCLUDED.plan_reference,statut='APPLICABLE',is_current=true,date_validation=EXCLUDED.date_validation,
          date_application=EXCLUDED.date_application`
     );
+    // This applicable routing is a baseline production prerequisite, not a
+    // SOL-20-only document fixture.  Keeping it outside the optional SOL-20
+    // block lets the migration rehearsal seed a realistic pre-SOL-06 copy.
+    await client.query(
+      `INSERT INTO public.gammes (
+         id,piece_technique_version_id,code,designation,statut,is_current,created_by,updated_by
+       ) VALUES (
+         '92000000-0000-4000-8000-000000000003','23000000-0000-4000-8000-000000000001',
+         'E2E-GAMME-SOL20','Gamme applicable preuve SOL-20','APPLICABLE',true,
+         (SELECT id FROM public.users WHERE username='KEENAN'),
+         (SELECT id FROM public.users WHERE username='KEENAN')
+       ) ON CONFLICT (id) DO NOTHING`
+    );
 
     const sol20Available = await client.query(
       `SELECT to_regclass('public.outillage_allocations') IS NOT NULL AS available`
@@ -438,16 +452,6 @@ async function main() {
            920001,1,'Indice obsolète de preuve',(SELECT id FROM public.users WHERE username='KEENAN'),
            (SELECT id FROM public.users WHERE username='KEENAN')
          ) ON CONFLICT (piece_technique_version_id,id_outil) DO NOTHING`
-      );
-      await client.query(
-        `INSERT INTO public.gammes (
-           id,piece_technique_version_id,code,designation,statut,is_current,created_by,updated_by
-         ) VALUES (
-           '92000000-0000-4000-8000-000000000003','23000000-0000-4000-8000-000000000001',
-           'E2E-GAMME-SOL20','Gamme applicable preuve SOL-20','APPLICABLE',true,
-           (SELECT id FROM public.users WHERE username='KEENAN'),
-           (SELECT id FROM public.users WHERE username='KEENAN')
-         ) ON CONFLICT (id) DO NOTHING`
       );
       await client.query(
         `INSERT INTO public.ordres_fabrication (
@@ -530,21 +534,39 @@ async function main() {
       );
     }
     await client.query(
-      `INSERT INTO public.postes (id,code,label,currency,is_active)
-       VALUES ('24000000-0000-4000-8000-000000000001','E2E-POSTE-001','Poste planning preuve SOL-05','EUR',true)
-       ON CONFLICT (id) DO UPDATE SET code=EXCLUDED.code,label=EXCLUDED.label,is_active=true,archived_at=NULL`
+      `INSERT INTO public.machines (
+         id,code,name,type,status,is_available,workshop_zone,created_by,updated_by
+       ) VALUES (
+         '27000000-0000-4000-8000-000000000001','E2E-MACH-001','Machine atelier preuve SOL-21',
+         'MILLING','ACTIVE',true,'USINAGE',
+         (SELECT id FROM public.users WHERE username='KEENAN'),
+         (SELECT id FROM public.users WHERE username='KEENAN')
+       ) ON CONFLICT (id) DO UPDATE SET
+         code=EXCLUDED.code,name=EXCLUDED.name,status='ACTIVE',is_available=true,
+         workshop_zone='USINAGE',archived_at=NULL,updated_by=EXCLUDED.updated_by`
+    );
+    await client.query(
+      `INSERT INTO public.postes (id,code,label,machine_id,currency,is_active)
+       VALUES (
+         '24000000-0000-4000-8000-000000000001','E2E-POSTE-001','Poste planning preuve SOL-05',
+         '27000000-0000-4000-8000-000000000001','EUR',true
+       )
+       ON CONFLICT (id) DO UPDATE SET
+         code=EXCLUDED.code,label=EXCLUDED.label,machine_id=EXCLUDED.machine_id,
+         is_active=true,archived_at=NULL`
     );
     await client.query(
       `INSERT INTO public.pieces_techniques_operations (
-         id,piece_technique_id,phase,ordre,designation,type_operation,poste_id,
+         id,piece_technique_id,gamme_id,phase,ordre,designation,type_operation,poste_id,machine_id,
          coef,tp,tf_unit,qte,taux_horaire,temps_fabrication,temps_total,cout_mo
        ) VALUES (
          '26000000-0000-4000-8000-000000000001','21000000-0000-4000-8000-000000000001',
-         10,10,'Usinage preuve SOL-05','FRAISAGE','24000000-0000-4000-8000-000000000001',
+         '92000000-0000-4000-8000-000000000003',10,10,'Usinage preuve SOL-05','FRAISAGE',
+         '24000000-0000-4000-8000-000000000001','27000000-0000-4000-8000-000000000001',
          1,0.1,0.25,1,50,0.25,0.35,17.5
        ) ON CONFLICT (id) DO UPDATE SET
-         piece_technique_id=EXCLUDED.piece_technique_id,phase=EXCLUDED.phase,
-         ordre=EXCLUDED.ordre,designation=EXCLUDED.designation,poste_id=EXCLUDED.poste_id,
+         piece_technique_id=EXCLUDED.piece_technique_id,gamme_id=EXCLUDED.gamme_id,phase=EXCLUDED.phase,
+         ordre=EXCLUDED.ordre,designation=EXCLUDED.designation,poste_id=EXCLUDED.poste_id,machine_id=EXCLUDED.machine_id,
          temps_fabrication=EXCLUDED.temps_fabrication,temps_total=EXCLUDED.temps_total,
          cout_mo=EXCLUDED.cout_mo`
     );

--- a/scripts/migrations/release-gate.js
+++ b/scripts/migrations/release-gate.js
@@ -16,6 +16,7 @@ const COMMERCIAL_RELIABILITY_PATCH = "20260812_commercial_reliability_sol17.sql"
 const PROCUREMENT_RELIABILITY_PATCH = "20260812_procurement_reliability_sol18.sql";
 const STOCK_INTELLIGENCE_PATCH = "20260813_stock_intelligence_sol19.sql";
 const TOOLING_TECHNICAL_GED_PATCH = "20260813_sol20_tooling_technical_ged.sql";
+const PLANNING_EXECUTION_PATCH = "20260814_planning_execution_intelligence_0021.sql";
 const SOL06_SUPPORT = path.join(SUPPORT_DIR, "20260810_system_reference_data_readiness");
 const POSTGRES_IMAGE = "postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229";
 const DEFAULT_REPORT_DIR = path.join(ROOT, "docs", "release");
@@ -446,6 +447,14 @@ async function proveRollback(databaseUrl) {
   await client.connect();
   try {
     await client.query("SET cerp.migration_rehearsal = 'on'");
+    const planningExecutionRollback = patchSupportSql(PLANNING_EXECUTION_PATCH, "rollback");
+    const planningExecutionObject = await client.query(
+      "SELECT to_regclass('public.planning_user_preferences') IS NOT NULL AS present"
+    );
+    if (planningExecutionRollback && planningExecutionObject.rows[0].present) {
+      await client.query("SET cerp.sol21_preferences_exported = 'yes'");
+      await runSqlFile(client, planningExecutionRollback);
+    }
     const toolingTechnicalGedRollback = patchSupportSql(TOOLING_TECHNICAL_GED_PATCH, "rollback");
     const toolingTechnicalGedObject = await client.query(
       "SELECT to_regclass('public.outillage_allocations') IS NOT NULL AS present"
@@ -525,6 +534,9 @@ async function proveRollback(databaseUrl) {
                 AND to_regprocedure('public.fn_outillage_parameter_period_no_overlap_20()') IS NULL
                 AND to_regprocedure('public.fn_ged_validate_canonical_entity_link_20()') IS NULL
                 AS tooling_technical_ged_removed,
+              to_regclass('public.planning_user_preferences') IS NULL
+                AND to_regprocedure('public.fn_planning_color_map_is_valid(jsonb)') IS NULL
+                AS planning_execution_removed,
               NOT EXISTS (SELECT 1 FROM pg_trigger WHERE tgname='trg_stock_reference_readiness_2606') AS trigger_removed`
     );
     if (!objects.rows[0].function_removed || !objects.rows[0].function_v2_removed
@@ -532,6 +544,7 @@ async function proveRollback(databaseUrl) {
         || !objects.rows[0].procurement_reliability_removed
         || !objects.rows[0].stock_intelligence_removed
         || !objects.rows[0].tooling_technical_ged_removed
+        || !objects.rows[0].planning_execution_removed
         || !objects.rows[0].trigger_removed) {
       fail("rollback left SOL-06 objects behind");
     }
@@ -738,6 +751,7 @@ module.exports = {
   COMMERCIAL_RELIABILITY_PATCH,
   PROCUREMENT_RELIABILITY_PATCH,
   STOCK_INTELLIGENCE_PATCH,
+  PLANNING_EXECUTION_PATCH,
   expectedRehearsalPatches,
   inventory,
   inventoryMarkdown,

--- a/src/__tests__/planning-execution-intelligence.migration-guards.test.ts
+++ b/src/__tests__/planning-execution-intelligence.migration-guards.test.ts
@@ -1,0 +1,41 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+
+const read = (name: string) => fs.readFileSync(path.resolve(process.cwd(), name), "utf8");
+const patch = read("db/patches/20260814_planning_execution_intelligence_0021.sql");
+const preflight = read("db/patches/support/20260814_planning_execution_intelligence_0021.preflight.sql");
+const verify = read("db/patches/support/20260814_planning_execution_intelligence_0021.verify.sql");
+const rollback = read("db/patches/support/20260814_planning_execution_intelligence_0021.rollback.sql");
+const releaseGate = read("scripts/migrations/release-gate.js");
+
+describe("SOL-21 planning execution migration guards", () => {
+  it("adds only audited user preferences and validates color values server-side", () => {
+    expect(patch).toContain("CREATE TABLE IF NOT EXISTS public.planning_user_preferences");
+    expect(patch).toContain("fn_planning_color_map_is_valid");
+    expect(patch).toContain("horizon_weeks BETWEEN 1 AND 13");
+    expect(patch).toContain("REFERENCES public.users(id)");
+    expect(patch).toContain("'OFFLINE_STATION'");
+    expect(patch).toContain("VALIDATE CONSTRAINT production_pointages_source_sol21_chk");
+    expect(patch).toMatch(/GRANT SELECT ON public\.machines TO cerp_app/);
+    expect(patch).not.toMatch(/INSERT\s+INTO\s+public\.planning_user_preferences/i);
+  });
+
+  it("fails preflight on missing sources or invalid timezones and verifies the trigger", () => {
+    expect(preflight).toContain("production_quantity_declarations");
+    expect(preflight).toContain("pg_timezone_names");
+    expect(preflight).toContain("production calendar(s) use an unknown timezone");
+    expect(verify).toContain("planning_user_preferences_set_updated_at");
+    expect(verify).toContain("does not fail closed");
+    expect(verify).toContain("v_station_machine_occupancy");
+    expect(verify).toContain("SET LOCAL ROLE cerp_app");
+    expect(verify).toContain("offline pointage provenance is not accepted");
+  });
+
+  it("guards destructive rollback and is exercised by the isolated release gate", () => {
+    expect(rollback).toContain("cerp.sol21_preferences_exported");
+    expect(rollback).toContain("rollback refused");
+    expect(releaseGate).toContain('const PLANNING_EXECUTION_PATCH = "20260814_planning_execution_intelligence_0021.sql"');
+    expect(releaseGate).toContain("planning_execution_removed");
+  });
+});

--- a/src/__tests__/planning-intelligence.domain.test.ts
+++ b/src/__tests__/planning-intelligence.domain.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPlanningExecutionIntelligence,
+  defaultPlanningPreferences,
+  type PlanningCapacityRawRow,
+  type PlanningIntelligenceEventRow,
+  type PlanningIntelligencePointageRow,
+  type PlanningIntelligenceSnapshot,
+} from "../module/planning/domain/planning-intelligence";
+
+const NOW = new Date("2026-08-14T12:00:00.000Z");
+const MACHINE_1 = "11111111-1111-4111-8111-111111111111";
+const MACHINE_2 = "22222222-2222-4222-8222-222222222222";
+
+function event(overrides: Partial<PlanningIntelligenceEventRow> = {}): PlanningIntelligenceEventRow {
+  return {
+    event_id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+    of_id: 21,
+    of_numero: "OF-SOL21-001",
+    operation_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    phase: 10,
+    designation: "Usinage",
+    event_status: "PLANNED",
+    operation_status: "DONE",
+    start_ts: "2026-08-14T08:00:00.000Z",
+    end_ts: "2026-08-14T10:00:00.000Z",
+    updated_at: "2026-08-14T10:01:00.000Z",
+    operation_ended_at: "2026-08-14T09:55:00.000Z",
+    planned_hours: 2,
+    machine_id: MACHINE_1,
+    machine_code: "M-01",
+    machine_name: "Tour 1",
+    machine_available: true,
+    allow_overlap: false,
+    ...overrides,
+  };
+}
+
+function pointage(overrides: Partial<PlanningIntelligencePointageRow> = {}): PlanningIntelligencePointageRow {
+  return {
+    pointage_id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    of_id: 21,
+    operation_id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb",
+    machine_id: MACHINE_1,
+    machine_code: "M-01",
+    activity_code: "PRODUCTION",
+    activity_label: "Production",
+    activity_is_productive: true,
+    is_running: false,
+    start_ts: "2026-08-14T08:30:00.000Z",
+    end_ts: "2026-08-14T09:30:00.000Z",
+    duration_minutes: 60,
+    comment: null,
+    updated_at: "2026-08-14T09:30:00.000Z",
+    ...overrides,
+  };
+}
+
+function capacity(overrides: Partial<PlanningCapacityRawRow> = {}): PlanningCapacityRawRow {
+  return {
+    machine_id: MACHINE_1,
+    machine_code: "M-01",
+    machine_name: "Tour 1",
+    week_start: "2026-08-10",
+    available_minutes: 1_000,
+    calendar_count: 1,
+    calendar_freshness_at: "2026-08-14T07:00:00.000Z",
+    planned_event: null,
+    planned_minutes: 0,
+    actual_minutes: 0,
+    ...overrides,
+  };
+}
+
+function build(snapshot: PlanningIntelligenceSnapshot) {
+  return buildPlanningExecutionIntelligence({
+    snapshot,
+    from: "2026-08-10T00:00:00.000Z",
+    to: "2026-08-17T00:00:00.000Z",
+    timezone: "Europe/Paris",
+    agedWipDays: 7,
+    capabilities: {
+      read_capacity: true,
+      manage_schedule: true,
+      manage_preferences: true,
+      supervise_execution: true,
+    },
+    now: NOW,
+  });
+}
+
+describe("SOL-21 planning and execution intelligence", () => {
+  it("calculates traceable KPIs, bottlenecks, stop causes and actionable conflicts", () => {
+    const first = event();
+    const second = event({
+      event_id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+      of_id: 22,
+      of_numero: "OF-SOL21-002",
+      operation_id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+      phase: 20,
+      start_ts: "2026-08-14T09:30:00.000Z",
+      end_ts: "2026-08-14T11:00:00.000Z",
+      operation_status: "RUNNING",
+      operation_ended_at: null,
+      planned_hours: null,
+      machine_available: false,
+      allow_overlap: true,
+    });
+    const snapshot: PlanningIntelligenceSnapshot = {
+      events: [first, second],
+      pointages: [
+        pointage(),
+        pointage({
+          pointage_id: "ffffffff-ffff-4fff-8fff-ffffffffffff",
+          operation_id: second.operation_id,
+          machine_id: MACHINE_2,
+          machine_code: "M-02",
+          activity_code: "BREAKDOWN",
+          activity_label: "Panne",
+          activity_is_productive: false,
+          duration_minutes: 30,
+        }),
+        pointage({
+          pointage_id: "99999999-9999-4999-8999-999999999999",
+          operation_id: second.operation_id,
+          is_running: true,
+          start_ts: "2026-08-13T23:00:00.000Z",
+          end_ts: NOW.toISOString(),
+          duration_minutes: 780,
+        }),
+      ],
+      quantities: [{
+        unit: "u",
+        qty_good: 90,
+        qty_scrap: 10,
+        qty_rework: 2,
+        freshness_at: "2026-08-14T11:00:00.000Z",
+      }],
+      wip: [{
+        of_id: 22,
+        of_numero: "OF-SOL21-002",
+        operation_id: second.operation_id,
+        machine_id: MACHINE_1,
+        started_at: "2026-08-01T08:00:00.000Z",
+        due_date: "2026-08-13",
+      }],
+      capacity: [
+        capacity(),
+        capacity({ planned_event: first, planned_minutes: 900 }),
+        capacity({ planned_event: second, planned_minutes: 400 }),
+        capacity({ actual_minutes: 870 }),
+      ],
+    };
+
+    const result = build(snapshot);
+
+    expect(result.kpis.schedule_adherence).toMatchObject({ value: 50, numerator: 1, denominator: 2, reliability: "VERIFIED" });
+    expect(result.kpis.throughput.value).toBe(1);
+    expect(result.kpis.wip.value).toBe(1);
+    expect(result.kpis.aged_wip.value).toBe(1);
+    expect(result.kpis.scrap_rate).toMatchObject({ value: 10, numerator: 10, denominator: 100, reliability: "VERIFIED" });
+    expect(result.kpis.planned_time).toMatchObject({ value: 2, denominator: 2, reliability: "PARTIAL" });
+    expect(result.kpis.actual_time).toMatchObject({ value: 14.5, numerator: 870, reliability: "VERIFIED" });
+    expect(result.capacity[0]).toMatchObject({ planned_minutes: 1300, actual_minutes: 870, utilization_pct: 130, state: "BOTTLENECK" });
+    expect(result.capacity[0]?.drilldown).toHaveLength(2);
+    expect(result.stop_causes).toEqual([{ code: "BREAKDOWN", label: "Panne", duration_minutes: 30, occurrences: 1, reason_missing_count: 0, source: "production_pointages" }]);
+    expect(new Set(result.conflicts.map((item) => item.code))).toEqual(new Set([
+      "SCHEDULE_OVERLAP",
+      "RESOURCE_UNAVAILABLE",
+      "ACTUAL_RESOURCE_MISMATCH",
+      "LONG_RUNNING_EXECUTION",
+      "MISSING_PLANNED_TIME",
+    ]));
+    expect(result.action_queue[0]?.priority).toBe("P0");
+    expect(result.metadata.sources).toContain("public.production_pointages");
+    expect(result.metadata.freshness_at).toBe("2026-08-14T11:00:00.000Z");
+  });
+
+  it("never turns a missing unit or missing calendar into a trustworthy zero", () => {
+    const result = build({
+      events: [],
+      pointages: [],
+      quantities: [{ unit: "UNSPECIFIED", qty_good: 10, qty_scrap: 1, qty_rework: 0, freshness_at: null }],
+      wip: [{ of_id: 1, of_numero: "OF-1", operation_id: null, machine_id: MACHINE_1, started_at: null, due_date: null }],
+      capacity: [capacity({ available_minutes: null, calendar_count: 0 })],
+    });
+
+    expect(result.kpis.scrap_rate).toMatchObject({ value: null, reliability: "PARTIAL" });
+    expect(result.kpis.scrap_rate.missing.join(" ")).toMatch(/unité/i);
+    expect(result.capacity[0]).toMatchObject({ available_minutes: null, utilization_pct: null, state: "UNAVAILABLE", reliability: "UNAVAILABLE" });
+    expect(result.kpis.aged_wip).toMatchObject({ value: 0, reliability: "PARTIAL" });
+  });
+
+  it("flags planned work on a zero-capacity week as a bottleneck", () => {
+    const planned = event();
+    const result = build({
+      events: [planned],
+      pointages: [],
+      quantities: [],
+      wip: [],
+      capacity: [capacity({ available_minutes: 0 }), capacity({ available_minutes: 0, planned_event: planned, planned_minutes: 60 })],
+    });
+    expect(result.capacity[0]).toMatchObject({ available_minutes: 0, planned_minutes: 60, utilization_pct: null, state: "BOTTLENECK" });
+  });
+
+  it("provides deterministic, non-business defaults for personal preferences", () => {
+    expect(defaultPlanningPreferences()).toEqual({
+      timezone: "Europe/Paris",
+      horizon_weeks: 6,
+      view_mode: "WEEK",
+      show_weekends: false,
+      machine_ids: [],
+      status_colors: {},
+      client_color_overrides: {},
+      updated_at: null,
+    });
+  });
+});

--- a/src/__tests__/planning.rbac.test.ts
+++ b/src/__tests__/planning.rbac.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   roleCanForcePlanningOverlap,
   roleHasPlanningAccess,
+  roleHasPlanningCapability,
 } from "../module/planning/domain/planning-rbac";
 import { runWithAccountModuleAccess } from "../module/access-control/context/account-module-access.context";
 
@@ -56,8 +57,25 @@ describe("planning RBAC uses exact normalized roles", () => {
       () => {
         expect(roleHasPlanningAccess("Employee")).toBe(true);
         expect(roleCanForcePlanningOverlap("Employee")).toBe(true);
+        // Fine-grained SOL-21 capabilities remain role-backed. The request
+        // middleware separately recognizes an explicit elevated account grant.
+        expect(roleHasPlanningCapability("Employee", "manage_schedule")).toBe(false);
       }
     );
+  });
+
+  it("separates operator, supervisor and planner capabilities", () => {
+    expect(roleHasPlanningCapability("Operateur Atelier", "read")).toBe(true);
+    expect(roleHasPlanningCapability("Operateur Atelier", "manage_preferences")).toBe(true);
+    expect(roleHasPlanningCapability("Operateur Atelier", "read_capacity")).toBe(false);
+    expect(roleHasPlanningCapability("Operateur Atelier", "manage_schedule")).toBe(false);
+
+    expect(roleHasPlanningCapability("Chef Atelier", "read_capacity")).toBe(true);
+    expect(roleHasPlanningCapability("Chef Atelier", "supervise_execution")).toBe(true);
+    expect(roleHasPlanningCapability("Chef Atelier", "manage_schedule")).toBe(true);
+
+    expect(roleHasPlanningCapability("Responsable Programmation", "manage_schedule")).toBe(true);
+    expect(roleHasPlanningCapability("Responsable Programmation", "supervise_execution")).toBe(false);
   });
 
 });

--- a/src/__tests__/planning.routes.test.ts
+++ b/src/__tests__/planning.routes.test.ts
@@ -169,6 +169,59 @@ describe("/api/v1/planning", () => {
     expect(String(calls[1]?.[0])).toContain("FROM public.postes");
   });
 
+  it("GET /api/v1/planning/execution-intelligence exposes a source-backed empty state", async () => {
+    for (let index = 0; index < 7; index += 1) {
+      mocks.poolQuery.mockResolvedValueOnce({ rows: [] });
+    }
+    const res = await request(app)
+      .get("/api/v1/planning/execution-intelligence")
+      .set("Authorization", "Bearer fake")
+      .query({
+        from: "2026-08-10T00:00:00.000Z",
+        to: "2026-08-17T00:00:00.000Z",
+        timezone: "Europe/Paris",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["cache-control"]).toBe("no-store");
+    expect(res.body).toMatchObject({
+      metadata: {
+        definition_version: "SOL-21.v1",
+        period: { timezone: "Europe/Paris" },
+      },
+      capabilities: {
+        read_capacity: true,
+        manage_schedule: true,
+      },
+      kpis: {
+        wip: { value: 0, reliability: "VERIFIED" },
+        actual_time: { value: null, reliability: "UNAVAILABLE" },
+      },
+      capacity: [],
+      conflicts: [],
+    });
+    expect(res.body.metadata.sources).toContain("public.production_pointages");
+    expect(mocks.poolQuery).toHaveBeenCalledTimes(7);
+  });
+
+  it("GET /api/v1/planning/preferences returns non-business defaults when no row exists", async () => {
+    mocks.poolQuery.mockResolvedValueOnce({ rows: [] });
+    const res = await request(app)
+      .get("/api/v1/planning/preferences")
+      .set("Authorization", "Bearer fake");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      timezone: "Europe/Paris",
+      horizon_weeks: 6,
+      view_mode: "WEEK",
+      show_weekends: false,
+      machine_ids: [],
+      status_colors: {},
+      client_color_overrides: {},
+      updated_at: null,
+    });
+  });
+
   it("GET /api/v1/planning/events returns {items,total}", async () => {
     mocks.poolQuery
       .mockResolvedValueOnce({ rows: [{ total: 1 }] })

--- a/src/__tests__/planning.validators.test.ts
+++ b/src/__tests__/planning.validators.test.ts
@@ -6,6 +6,10 @@ import {
   isValidPlanningDateTime,
   listPlanningEventsQuerySchema,
 } from "../module/planning/validators/planning.validators";
+import {
+  planningIntelligenceQuerySchema,
+  planningPreferencesBodySchema,
+} from "../module/planning/validators/planning-intelligence.validators";
 
 describe("planning datetime validation", () => {
   it("accepts more than 100 offset-qualified ISO-8601 combinations", () => {
@@ -76,5 +80,48 @@ describe("planning request schemas", () => {
         limit: 5001,
       })
     ).toThrow();
+  });
+});
+
+describe("SOL-21 intelligence and preference schemas", () => {
+  it("accepts a timezone-qualified period up to 13 weeks", () => {
+    const parsed = planningIntelligenceQuerySchema.parse({
+      from: "2026-08-01T00:00:00+02:00",
+      to: "2026-10-30T00:00:00+01:00",
+      timezone: "Europe/Paris",
+      aged_wip_days: "14",
+    });
+    expect(parsed.aged_wip_days).toBe(14);
+  });
+
+  it("rejects reversed, oversized and unknown-timezone periods", () => {
+    expect(() => planningIntelligenceQuerySchema.parse({
+      from: "2026-08-02T00:00:00Z",
+      to: "2026-08-01T00:00:00Z",
+    })).toThrow();
+    expect(() => planningIntelligenceQuerySchema.parse({
+      from: "2026-01-01T00:00:00Z",
+      to: "2026-12-31T00:00:00Z",
+    })).toThrow();
+    expect(() => planningIntelligenceQuerySchema.parse({
+      from: "2026-08-01T00:00:00Z",
+      to: "2026-08-02T00:00:00Z",
+      timezone: "Mars/Olympus",
+    })).toThrow();
+  });
+
+  it("normalizes colors and rejects invalid preferences or unknown fields", () => {
+    const body = {
+      timezone: "Europe/Paris",
+      horizon_weeks: 6,
+      view_mode: "WEEK" as const,
+      show_weekends: false,
+      machine_ids: [],
+      status_colors: { RUNNING: "#aabbcc" },
+      client_color_overrides: {},
+    };
+    expect(planningPreferencesBodySchema.parse({ body }).body.status_colors.RUNNING).toBe("#AABBCC");
+    expect(() => planningPreferencesBodySchema.parse({ body: { ...body, timezone: "Not/AZone" } })).toThrow();
+    expect(() => planningPreferencesBodySchema.parse({ body: { ...body, injected_role: "admin" } })).toThrow();
   });
 });

--- a/src/__tests__/production-execution-274.routes.test.ts
+++ b/src/__tests__/production-execution-274.routes.test.ts
@@ -901,7 +901,7 @@ describe("#274 concurrence", () => {
       if (sql.includes("FROM public.ordres_fabrication") && sql.includes("FOR UPDATE")) {
         return { rows: [{ id: "10", statut: "EN_COURS" }] };
       }
-      if (sql.includes("FROM public.machines WHERE id")) return { rows: [{ statut: "DISPONIBLE" }] };
+      if (sql.includes("FROM public.machines WHERE id")) return { rows: [{ status: "ACTIVE" }] };
       if (sql.includes("production_activity_categories")) return { rows: [CATEGORY_ROW] };
       if (sql.includes("INSERT INTO public.production_pointages")) {
         const err = new Error("duplicate key") as Error & { code: string; constraint: string };
@@ -960,7 +960,7 @@ describe("#274 concurrence", () => {
       if (sql.includes("FROM public.ordres_fabrication") && sql.includes("FOR UPDATE")) {
         return { rows: [{ id: "10", statut: "EN_COURS" }] };
       }
-      if (sql.includes("FROM public.machines WHERE id")) return { rows: [{ statut: "MAINTENANCE" }] };
+      if (sql.includes("FROM public.machines WHERE id")) return { rows: [{ status: "IN_MAINTENANCE" }] };
       return { rows: [] };
     });
 

--- a/src/__tests__/shopfloor-station-159.domain.test.ts
+++ b/src/__tests__/shopfloor-station-159.domain.test.ts
@@ -19,6 +19,7 @@ import {
   assessOperationReadiness,
   canSubscribeStationRoom,
   compareWorklistEntries,
+  buildStationOperationScanIdentifier,
   evaluateMachineSelectability,
   evaluateSession,
   fingerprintCredential,
@@ -479,6 +480,24 @@ describe("#159 — préparation d'une opération", () => {
       { readiness: "READY" as const, due_date: "2027-01-01", phase: 20 },
     ].sort(compareWorklistEntries);
     expect(sorted[0].due_date).toBe("2027-01-01");
+  });
+
+  it("priorise l'encours de l'opérateur puis le prochain prêt et les saisies en attente", () => {
+    const sorted = [
+      { readiness: "BLOCKED" as const, due_date: "2026-08-10", phase: 40, pending_entry: false },
+      { readiness: "INCOMPLETE" as const, due_date: "2026-08-11", phase: 30, pending_entry: true },
+      { readiness: "READY" as const, due_date: "2026-08-12", phase: 20 },
+      { readiness: "BLOCKED" as const, due_date: "2026-08-13", phase: 10, mine: true },
+    ].sort(compareWorklistEntries);
+    expect(sorted.map((item) => item.phase)).toEqual([10, 20, 30, 40]);
+  });
+
+  it("uses one canonical identifier for QR and barcode scanning", () => {
+    expect(buildStationOperationScanIdentifier("OF-2026-0042", 30)).toEqual({
+      value: "OF-2026-0042/30",
+      symbologies: ["CODE128", "QR"],
+      resolver: "/production/station/scan",
+    });
   });
 });
 

--- a/src/module/access-control/context/account-module-access.context.ts
+++ b/src/module/access-control/context/account-module-access.context.ts
@@ -5,6 +5,8 @@ export type AccountModuleAccessContext = {
   userId: number | null;
   moduleKey: string | null;
   granted: boolean;
+  /** Explicit override/superadmin/kill-switch, as opposed to ordinary default access. */
+  elevated: boolean;
 };
 
 const accountModuleAccessStorage = new AsyncLocalStorage<AccountModuleAccessContext>();
@@ -24,7 +26,7 @@ declare global {
  */
 export function runWithAccountModuleAccessScope(callback: () => void): void {
   accountModuleAccessStorage.run(
-    { userId: null, moduleKey: null, granted: false },
+    { userId: null, moduleKey: null, granted: false, elevated: false },
     callback
   );
 }
@@ -38,31 +40,39 @@ export function runWithAccountModuleAccessScope(callback: () => void): void {
  * without mutating the authenticated identity or weakening the superadmin guard.
  */
 export function runWithAccountModuleAccess(
-  context: Pick<AccountModuleAccessContext, "userId" | "moduleKey">,
+  context: Pick<AccountModuleAccessContext, "userId" | "moduleKey"> &
+    Partial<Pick<AccountModuleAccessContext, "elevated">>,
   callback: () => void
 ): void {
+  const elevated = context.elevated ?? true;
   const existing = accountModuleAccessStorage.getStore();
   if (existing) {
     existing.userId = context.userId;
     existing.moduleKey = context.moduleKey;
     existing.granted = true;
+    existing.elevated = elevated;
     callback();
     return;
   }
-  accountModuleAccessStorage.run({ ...context, granted: true }, callback);
+  accountModuleAccessStorage.run({ ...context, granted: true, elevated }, callback);
 }
 
 export function grantAccountModuleAccessToRequest(
   req: Request,
-  context: Pick<AccountModuleAccessContext, "userId" | "moduleKey">,
+  context: Pick<AccountModuleAccessContext, "userId" | "moduleKey"> &
+    Partial<Pick<AccountModuleAccessContext, "elevated">>,
   callback: () => void
 ): void {
-  req.accountModuleAccess = { ...context, granted: true };
+  req.accountModuleAccess = { ...context, granted: true, elevated: context.elevated ?? true };
   runWithAccountModuleAccess(context, callback);
 }
 
 export function requestHasGrantedAccountModuleAccess(req: Request): boolean {
   return req.accountModuleAccess?.granted === true;
+}
+
+export function requestHasElevatedAccountModuleAccess(req: Request): boolean {
+  return req.accountModuleAccess?.granted === true && req.accountModuleAccess.elevated === true;
 }
 
 export function hasGrantedAccountModuleAccess(): boolean {

--- a/src/module/access-control/middlewares/module-access-gate.ts
+++ b/src/module/access-control/middlewares/module-access-gate.ts
@@ -78,7 +78,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
   if (!moduleKey) {
     // Les surfaces partagées authentifiées (utilisateurs, codes,
     // notifications, capabilities…) ne sont pas restrictibles par module.
-    grantAccountModuleAccessToRequest(req, { userId, moduleKey: "shared" }, next);
+    grantAccountModuleAccessToRequest(req, { userId, moduleKey: "shared", elevated: true }, next);
     return;
   }
 
@@ -86,7 +86,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
     warnKillSwitchOnce();
     // Le kill-switch désactive seulement les refus nominatifs. Il ne doit
     // jamais réactiver les anciens refus par rôle dans la suite de la requête.
-    grantAccountModuleAccessToRequest(req, { userId, moduleKey }, next);
+    grantAccountModuleAccessToRequest(req, { userId, moduleKey, elevated: true }, next);
     return;
   }
 
@@ -98,7 +98,7 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
         return;
       }
       if (profile.is_superadmin) {
-        grantAccountModuleAccessToRequest(req, { userId, moduleKey }, next);
+        grantAccountModuleAccessToRequest(req, { userId, moduleKey, elevated: true }, next);
         return;
       }
 
@@ -111,7 +111,11 @@ export function moduleAccessGate(req: Request, res: Response, next: NextFunction
         return;
       }
       if (decision.allowed) {
-        grantAccountModuleAccessToRequest(req, { userId, moduleKey }, next);
+        grantAccountModuleAccessToRequest(req, {
+          userId,
+          moduleKey,
+          elevated: decision.source === "OVERRIDE" || decision.source === "SUPERADMIN",
+        }, next);
         return;
       }
 

--- a/src/module/planning/controllers/planning.controller.ts
+++ b/src/module/planning/controllers/planning.controller.ts
@@ -19,6 +19,10 @@ import {
   validatePlanningForArSchema,
 } from "../validators/planning.validators";
 import {
+  planningIntelligenceQuerySchema,
+  planningPreferencesBodySchema,
+} from "../validators/planning-intelligence.validators";
+import {
   svcAutoPlanPlanning,
   svcArchivePlanningEvent,
   svcCreatePlanningEvent,
@@ -32,8 +36,13 @@ import {
   svcUploadPlanningEventDocuments,
   svcValidatePlanningForAr,
 } from "../services/planning.service";
+import {
+  svcGetPlanningExecutionIntelligence,
+  svcGetPlanningPreferences,
+  svcPutPlanningPreferences,
+} from "../services/planning-intelligence.service";
 
-function buildAuditContext(req: Request): AuditContext {
+export function buildAuditContext(req: Request): AuditContext {
   const user = req.user;
   if (!user) throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
 
@@ -61,6 +70,28 @@ function buildAuditContext(req: Request): AuditContext {
     client_session_id: clientSessionId,
   };
 }
+
+export const getPlanningExecutionIntelligence: RequestHandler = asyncHandler(async (req, res) => {
+  const query = planningIntelligenceQuerySchema.parse(req.query);
+  const out = await svcGetPlanningExecutionIntelligence({ query, role: req.user?.role });
+  res.setHeader("Cache-Control", "no-store");
+  res.json(out);
+});
+
+export const getPlanningPreferences: RequestHandler = asyncHandler(async (req, res) => {
+  if (!req.user) throw new HttpError(401, "UNAUTHORIZED", "Authentication required");
+  const out = await svcGetPlanningPreferences(req.user.id);
+  res.setHeader("Cache-Control", "no-store");
+  res.json(out);
+});
+
+export const putPlanningPreferences: RequestHandler = asyncHandler(async (req, res) => {
+  const audit = buildAuditContext(req);
+  const body = planningPreferencesBodySchema.parse({ body: req.body }).body;
+  const out = await svcPutPlanningPreferences({ body, audit });
+  res.setHeader("Cache-Control", "no-store");
+  res.json(out);
+});
 
 function resolveMimeType(value: string | null | undefined): string {
   const t = String(value ?? "").trim().toLowerCase();

--- a/src/module/planning/domain/planning-intelligence.ts
+++ b/src/module/planning/domain/planning-intelligence.ts
@@ -1,0 +1,557 @@
+import type {
+  PlanningAction,
+  PlanningCapacityCell,
+  PlanningConflict,
+  PlanningExecutionIntelligence,
+  PlanningMetric,
+  PlanningPreferences,
+  PlanningReliability,
+  PlanningStopCause,
+} from "../types/planning-intelligence.types";
+
+export type PlanningIntelligenceEventRow = {
+  event_id: string;
+  of_id: number | null;
+  of_numero: string | null;
+  operation_id: string | null;
+  phase: number | null;
+  designation: string | null;
+  event_status: string;
+  operation_status: string | null;
+  start_ts: string;
+  end_ts: string;
+  updated_at: string;
+  operation_ended_at: string | null;
+  planned_hours: number | null;
+  machine_id: string | null;
+  machine_code: string | null;
+  machine_name: string | null;
+  machine_available: boolean | null;
+  allow_overlap: boolean;
+};
+
+export type PlanningIntelligencePointageRow = {
+  pointage_id: string;
+  of_id: number;
+  operation_id: string | null;
+  machine_id: string | null;
+  machine_code: string | null;
+  activity_code: string | null;
+  activity_label: string | null;
+  activity_is_productive: boolean | null;
+  is_running: boolean;
+  start_ts: string;
+  end_ts: string;
+  duration_minutes: number;
+  comment: string | null;
+  updated_at: string;
+};
+
+export type PlanningQuantityRow = {
+  unit: string;
+  qty_good: number;
+  qty_scrap: number;
+  qty_rework: number;
+  freshness_at: string | null;
+};
+
+export type PlanningWipRow = {
+  of_id: number;
+  of_numero: string;
+  operation_id: string | null;
+  machine_id: string | null;
+  started_at: string | null;
+  due_date: string | null;
+};
+
+export type PlanningCapacityRawRow = {
+  machine_id: string;
+  machine_code: string;
+  machine_name: string;
+  week_start: string;
+  available_minutes: number | null;
+  unavailable_minutes: number;
+  calendar_count: number;
+  calendar_freshness_at: string | null;
+  planned_event: PlanningIntelligenceEventRow | null;
+  planned_minutes: number;
+  actual_minutes: number;
+};
+
+export type PlanningIntelligenceSnapshot = {
+  events: PlanningIntelligenceEventRow[];
+  pointages: PlanningIntelligencePointageRow[];
+  quantities: PlanningQuantityRow[];
+  wip: PlanningWipRow[];
+  capacity: PlanningCapacityRawRow[];
+};
+
+export type PlanningIntelligenceCapabilities = PlanningExecutionIntelligence["capabilities"];
+
+const round = (value: number, digits = 2): number => {
+  const factor = 10 ** digits;
+  return Math.round((value + Number.EPSILON) * factor) / factor;
+};
+
+function latest(values: Array<string | null | undefined>): string | null {
+  let latestValue: string | null = null;
+  let latestMs = Number.NEGATIVE_INFINITY;
+  for (const value of values) {
+    if (!value) continue;
+    const ms = Date.parse(value);
+    if (Number.isFinite(ms) && ms > latestMs) {
+      latestMs = ms;
+      latestValue = new Date(ms).toISOString();
+    }
+  }
+  return latestValue;
+}
+
+function metric(params: Omit<PlanningMetric, "missing"> & { missing?: string[] }): PlanningMetric {
+  return { ...params, missing: params.missing ?? [] };
+}
+
+function uniqueBy<T>(items: T[], key: (item: T) => string): T[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const value = key(item);
+    if (seen.has(value)) return false;
+    seen.add(value);
+    return true;
+  });
+}
+
+function buildMetrics(params: {
+  snapshot: PlanningIntelligenceSnapshot;
+  now: Date;
+  agedWipDays: number;
+}): PlanningExecutionIntelligence["kpis"] {
+  const { snapshot, now, agedWipDays } = params;
+  const dueEvents = uniqueBy(
+    snapshot.events.filter((event) => {
+      const due = Date.parse(event.end_ts);
+      return Number.isFinite(due) && due <= now.getTime() && event.event_status !== "CANCELLED";
+    }),
+    (event) => event.operation_id ?? event.event_id
+  );
+  const onTime = dueEvents.filter((event) => {
+    if (!event.operation_ended_at) return false;
+    return Date.parse(event.operation_ended_at) <= Date.parse(event.end_ts);
+  }).length;
+
+  const completedOperations = uniqueBy(
+    snapshot.events.filter((event) => Boolean(event.operation_id && event.operation_ended_at)),
+    (event) => event.operation_id as string
+  );
+  const operations = uniqueBy(
+    snapshot.events.filter((event) => Boolean(event.operation_id)),
+    (event) => event.operation_id as string
+  );
+  const knownPlanned = operations.filter((event) => typeof event.planned_hours === "number" && event.planned_hours > 0);
+  const plannedHours = knownPlanned.reduce((sum, event) => sum + (event.planned_hours ?? 0), 0);
+  const actualMinutes = snapshot.pointages.reduce((sum, pointage) => sum + pointage.duration_minutes, 0);
+  const wip = uniqueBy(snapshot.wip, (row) => String(row.of_id));
+  const agedCutoff = now.getTime() - agedWipDays * 86_400_000;
+  const agedWip = wip.filter((row) => row.started_at && Date.parse(row.started_at) < agedCutoff);
+
+  const quantitiesHaveOneUnit = snapshot.quantities.length === 1
+    && snapshot.quantities[0]?.unit !== "UNSPECIFIED";
+  const quantity = quantitiesHaveOneUnit ? snapshot.quantities[0] : null;
+  const scrapDenominator = quantity ? quantity.qty_good + quantity.qty_scrap : 0;
+  const scrapValue = quantity && scrapDenominator > 0 ? round((quantity.qty_scrap / scrapDenominator) * 100) : null;
+  const freshness = latest([
+    ...snapshot.events.map((row) => row.updated_at),
+    ...snapshot.pointages.map((row) => row.updated_at),
+    ...snapshot.quantities.map((row) => row.freshness_at),
+  ]);
+
+  return {
+    schedule_adherence: metric({
+      value: dueEvents.length ? round((onTime / dueEvents.length) * 100) : null,
+      unit: "% des opérations planifiées dues",
+      numerator: dueEvents.length ? onTime : null,
+      denominator: dueEvents.length || null,
+      definition: "Opérations terminées au plus tard à la fin du créneau / opérations planifiées dont le créneau est échu.",
+      source: ["public.planning_events", "public.of_operations.ended_at"],
+      freshness_at: freshness,
+      reliability: dueEvents.length ? "VERIFIED" : "UNAVAILABLE",
+      missing: dueEvents.length ? [] : ["Aucune opération planifiée arrivée à échéance sur la période."],
+    }),
+    throughput: metric({
+      value: completedOperations.length,
+      unit: "opérations terminées",
+      numerator: completedOperations.length,
+      denominator: null,
+      definition: "Nombre d'opérations distinctes dont la fin réelle appartient à la période.",
+      source: ["public.of_operations.ended_at"],
+      freshness_at: freshness,
+      reliability: "VERIFIED",
+    }),
+    wip: metric({
+      value: wip.length,
+      unit: "OF en cours",
+      numerator: wip.length,
+      denominator: null,
+      definition: "OF non terminés ayant une opération ou un pointage en cours.",
+      source: ["public.ordres_fabrication", "public.of_operations", "public.production_pointages"],
+      freshness_at: freshness,
+      reliability: "VERIFIED",
+    }),
+    aged_wip: metric({
+      value: agedWip.length,
+      unit: `OF en cours depuis plus de ${agedWipDays} jours`,
+      numerator: agedWip.length,
+      denominator: wip.length || null,
+      definition: `OF en cours dont le premier démarrage traçable date de plus de ${agedWipDays} jours.`,
+      source: ["public.ordres_fabrication.date_lancement_reelle", "public.production_pointages.start_ts"],
+      freshness_at: freshness,
+      reliability: wip.some((row) => !row.started_at) ? "PARTIAL" : "VERIFIED",
+      missing: wip.some((row) => !row.started_at) ? ["Certains OF en cours n'ont pas de date de démarrage traçable."] : [],
+    }),
+    scrap_rate: metric({
+      value: scrapValue,
+      unit: "% des quantités bonnes + rebut",
+      numerator: quantity ? quantity.qty_scrap : null,
+      denominator: quantity && scrapDenominator > 0 ? scrapDenominator : null,
+      definition: "Quantité rebut déclarée / (quantité bonne + quantité rebut), après compensations, pour une unité homogène.",
+      source: ["public.production_quantity_declarations"],
+      freshness_at: latest(snapshot.quantities.map((row) => row.freshness_at)),
+      reliability: quantitiesHaveOneUnit && scrapDenominator > 0 ? "VERIFIED" : snapshot.quantities.length ? "PARTIAL" : "UNAVAILABLE",
+      missing: !snapshot.quantities.length
+        ? ["Aucune déclaration de quantité sur la période."]
+        : !quantitiesHaveOneUnit
+          ? [snapshot.quantities.some((row) => row.unit === "UNSPECIFIED")
+              ? "Une unité de quantité manque : aucun taux global trompeur n'est calculé."
+              : "Plusieurs unités sont présentes : aucun taux global trompeur n'est calculé."]
+          : scrapDenominator <= 0
+            ? ["Le dénominateur bonne + rebut est nul."]
+            : [],
+    }),
+    planned_time: metric({
+      value: knownPlanned.length ? round(plannedHours) : null,
+      unit: "heures prévues",
+      numerator: knownPlanned.length ? round(plannedHours) : null,
+      denominator: operations.length || null,
+      definition: "Somme des temps prévus strictement positifs des opérations distinctes planifiées sur la période.",
+      source: ["public.of_operations.temps_total_planned"],
+      freshness_at: freshness,
+      reliability: !operations.length ? "UNAVAILABLE" : knownPlanned.length === operations.length ? "VERIFIED" : "PARTIAL",
+      missing: operations.length > knownPlanned.length ? [`${operations.length - knownPlanned.length} opération(s) sans temps prévu explicite.`] : [],
+    }),
+    actual_time: metric({
+      value: snapshot.pointages.length ? round(actualMinutes / 60) : null,
+      unit: "heures constatées",
+      numerator: snapshot.pointages.length ? actualMinutes : null,
+      denominator: null,
+      definition: "Somme des segments de pointage constatés, bornés à la période, convention [début, fin).",
+      source: ["public.production_pointages"],
+      freshness_at: latest(snapshot.pointages.map((row) => row.updated_at)),
+      reliability: snapshot.pointages.length ? "VERIFIED" : "UNAVAILABLE",
+      missing: snapshot.pointages.length ? [] : ["Aucun pointage constaté sur la période."],
+    }),
+  };
+}
+
+function buildCapacity(rows: PlanningCapacityRawRow[]): PlanningCapacityCell[] {
+  const groups = new Map<string, PlanningCapacityCell>();
+  for (const row of rows) {
+    const key = `${row.machine_id}:${row.week_start}`;
+    let cell = groups.get(key);
+    if (!cell) {
+      const missing = row.calendar_count === 0
+        ? ["Aucun calendrier de production actif."]
+        : row.calendar_count > 1
+          ? ["Plusieurs calendriers actifs sans affectation machine : capacité indisponible."]
+          : [];
+      cell = {
+        machine_id: row.machine_id,
+        machine_code: row.machine_code,
+        machine_name: row.machine_name,
+        week_start: row.week_start,
+        available_minutes: row.available_minutes,
+        unavailable_minutes: row.unavailable_minutes,
+        planned_minutes: 0,
+        actual_minutes: 0,
+        utilization_pct: null,
+        state: row.available_minutes === null ? "UNAVAILABLE" : "AVAILABLE",
+        reliability: row.available_minutes === null ? "UNAVAILABLE" : "VERIFIED",
+        missing,
+        drilldown: [],
+      };
+      groups.set(key, cell);
+    }
+    cell.planned_minutes += row.planned_minutes;
+    cell.actual_minutes += row.actual_minutes;
+    if (row.planned_event) {
+      cell.drilldown.push({
+        event_id: row.planned_event.event_id,
+        of_id: row.planned_event.of_id,
+        of_numero: row.planned_event.of_numero,
+        operation_id: row.planned_event.operation_id,
+        phase: row.planned_event.phase,
+        designation: row.planned_event.designation,
+        planned_minutes: row.planned_minutes,
+        start_ts: row.planned_event.start_ts,
+        end_ts: row.planned_event.end_ts,
+        status: row.planned_event.event_status,
+      });
+    }
+  }
+  for (const cell of groups.values()) {
+    cell.planned_minutes = round(cell.planned_minutes, 0);
+    cell.actual_minutes = round(cell.actual_minutes, 0);
+    cell.drilldown = uniqueBy(cell.drilldown, (item) => item.event_id);
+    if (cell.available_minutes === null) continue;
+    if (cell.available_minutes <= 0) {
+      if (cell.planned_minutes > 0) cell.state = "BOTTLENECK";
+      continue;
+    }
+    cell.utilization_pct = round((cell.planned_minutes / cell.available_minutes) * 100, 1);
+    if (cell.utilization_pct > 120) cell.state = "BOTTLENECK";
+    else if (cell.utilization_pct > 100) cell.state = "OVERLOADED";
+    else if (cell.utilization_pct >= 80) cell.state = "LOADED";
+  }
+  return [...groups.values()].sort((a, b) => a.week_start.localeCompare(b.week_start) || a.machine_code.localeCompare(b.machine_code));
+}
+
+function buildStops(pointages: PlanningIntelligencePointageRow[]): PlanningStopCause[] {
+  const grouped = new Map<string, PlanningStopCause>();
+  for (const row of pointages) {
+    if (row.activity_is_productive !== false) continue;
+    const code = row.activity_code ?? "UNCLASSIFIED_STOP";
+    const current = grouped.get(code) ?? {
+      code,
+      label: row.activity_label ?? "Arrêt non classé",
+      duration_minutes: 0,
+      occurrences: 0,
+      reason_missing_count: 0,
+      source: "production_pointages" as const,
+    };
+    current.duration_minutes += row.duration_minutes;
+    current.occurrences += 1;
+    if (!row.activity_code) current.reason_missing_count += 1;
+    grouped.set(code, current);
+  }
+  return [...grouped.values()]
+    .map((row) => ({ ...row, duration_minutes: round(row.duration_minutes, 0) }))
+    .sort((a, b) => b.duration_minutes - a.duration_minutes || a.code.localeCompare(b.code));
+}
+
+function buildConflicts(snapshot: PlanningIntelligenceSnapshot, now: Date): PlanningConflict[] {
+  const conflicts: PlanningConflict[] = [];
+  const byMachine = new Map<string, PlanningIntelligenceEventRow[]>();
+  for (const event of snapshot.events) {
+    if (!event.machine_id) continue;
+    const bucket = byMachine.get(event.machine_id) ?? [];
+    bucket.push(event);
+    byMachine.set(event.machine_id, bucket);
+    if (event.machine_available === false) {
+      conflicts.push({
+        id: `resource:${event.event_id}`,
+        code: "RESOURCE_UNAVAILABLE",
+        severity: "CRITICAL",
+        explanation: `${event.machine_code ?? "Machine"} est indisponible mais porte le créneau ${event.of_numero ?? event.event_id}.`,
+        next_action: "Réaffecter le créneau ou rendre la machine disponible après validation atelier.",
+        machine_id: event.machine_id,
+        machine_code: event.machine_code,
+        event_ids: [event.event_id],
+        of_ids: event.of_id ? [event.of_id] : [],
+      });
+    }
+    if (event.operation_id && (!event.planned_hours || event.planned_hours <= 0)) {
+      conflicts.push({
+        id: `planned-time:${event.event_id}`,
+        code: "MISSING_PLANNED_TIME",
+        severity: "WARNING",
+        explanation: `${event.of_numero ?? "OF"} phase ${event.phase ?? "?"} n'a pas de temps prévu explicite.`,
+        next_action: "Compléter la gamme ou l'opération avant d'utiliser la charge comme engagement.",
+        machine_id: event.machine_id,
+        machine_code: event.machine_code,
+        event_ids: [event.event_id],
+        of_ids: event.of_id ? [event.of_id] : [],
+      });
+    }
+  }
+  for (const [machineId, events] of byMachine) {
+    events.sort((a, b) => Date.parse(a.start_ts) - Date.parse(b.start_ts));
+    for (let index = 1; index < events.length; index += 1) {
+      const previous = events[index - 1];
+      const current = events[index];
+      if (Date.parse(current.start_ts) >= Date.parse(previous.end_ts)) continue;
+      if (!current.allow_overlap && !previous.allow_overlap) continue;
+      conflicts.push({
+        id: `overlap:${previous.event_id}:${current.event_id}`,
+        code: "SCHEDULE_OVERLAP",
+        severity: "WARNING",
+        explanation: `Chevauchement explicitement forcé sur ${current.machine_code ?? previous.machine_code ?? "la machine"}.`,
+        next_action: "Vérifier la décision de chevauchement et documenter la capacité réellement disponible.",
+        machine_id: machineId,
+        machine_code: current.machine_code ?? previous.machine_code,
+        event_ids: [previous.event_id, current.event_id],
+        of_ids: [previous.of_id, current.of_id].filter((value): value is number => typeof value === "number"),
+      });
+    }
+  }
+  const plannedByOperation = new Map(snapshot.events.filter((row) => row.operation_id).map((row) => [row.operation_id as string, row]));
+  for (const pointage of snapshot.pointages) {
+    const planned = pointage.operation_id ? plannedByOperation.get(pointage.operation_id) : null;
+    if (planned?.machine_id && pointage.machine_id && planned.machine_id !== pointage.machine_id) {
+      conflicts.push({
+        id: `machine-mismatch:${pointage.pointage_id}`,
+        code: "ACTUAL_RESOURCE_MISMATCH",
+        severity: "WARNING",
+        explanation: `${planned.of_numero ?? "OF"} s'exécute sur ${pointage.machine_code ?? "une autre machine"} au lieu de ${planned.machine_code ?? "la machine planifiée"}.`,
+        next_action: "Confirmer la réaffectation réelle ou corriger le planning avant la prochaine séquence.",
+        machine_id: pointage.machine_id,
+        machine_code: pointage.machine_code,
+        event_ids: [planned.event_id],
+        of_ids: [pointage.of_id],
+      });
+    }
+    if (pointage.is_running && pointage.duration_minutes > 12 * 60) {
+      conflicts.push({
+        id: `long-running:${pointage.pointage_id}`,
+        code: "LONG_RUNNING_EXECUTION",
+        severity: "CRITICAL",
+        explanation: `Un pointage est ouvert depuis ${round(pointage.duration_minutes / 60, 1)} h.`,
+        next_action: "Le superviseur doit vérifier le poste et arrêter ou corriger le pointage, sans réécrire l'historique.",
+        machine_id: pointage.machine_id,
+        machine_code: pointage.machine_code,
+        event_ids: planned ? [planned.event_id] : [],
+        of_ids: [pointage.of_id],
+      });
+    }
+  }
+  return uniqueBy(conflicts, (item) => item.id);
+}
+
+function buildActions(params: {
+  capacity: PlanningCapacityCell[];
+  conflicts: PlanningConflict[];
+  wip: PlanningWipRow[];
+  now: Date;
+  agedWipDays: number;
+}): PlanningAction[] {
+  const actions: PlanningAction[] = [];
+  for (const conflict of params.conflicts) {
+    actions.push({
+      id: `conflict:${conflict.id}`,
+      priority: conflict.severity === "CRITICAL" ? "P0" : "P1",
+      title: conflict.explanation,
+      explanation: conflict.next_action,
+      owner_role: conflict.code === "LONG_RUNNING_EXECUTION" ? "SUPERVISOR" : "PLANNER",
+      due_at: conflict.severity === "CRITICAL" ? params.now.toISOString() : null,
+      action_path: conflict.of_ids[0] ? `/production/ordres-fabrication/${conflict.of_ids[0]}` : "/planning",
+      machine_id: conflict.machine_id,
+      of_id: conflict.of_ids[0] ?? null,
+      operation_id: null,
+    });
+  }
+  for (const cell of params.capacity.filter((row) => row.state === "OVERLOADED" || row.state === "BOTTLENECK")) {
+    actions.push({
+      id: `capacity:${cell.machine_id}:${cell.week_start}`,
+      priority: cell.state === "BOTTLENECK" ? "P0" : "P1",
+      title: `${cell.machine_code} à ${cell.utilization_pct ?? "?"} % la semaine du ${cell.week_start}`,
+      explanation: "Ouvrir le drill-down, arbitrer les OF et replanifier avec une capacité réelle validée.",
+      owner_role: "PLANNER",
+      due_at: `${cell.week_start}T00:00:00.000Z`,
+      action_path: `/planning?machine_id=${encodeURIComponent(cell.machine_id)}&week=${encodeURIComponent(cell.week_start)}`,
+      machine_id: cell.machine_id,
+      of_id: cell.drilldown[0]?.of_id ?? null,
+      operation_id: cell.drilldown[0]?.operation_id ?? null,
+    });
+  }
+  const cutoff = params.now.getTime() - params.agedWipDays * 86_400_000;
+  for (const row of uniqueBy(params.wip, (item) => String(item.of_id)).filter((item) => item.started_at && Date.parse(item.started_at) < cutoff)) {
+    actions.push({
+      id: `aged-wip:${row.of_id}`,
+      priority: "P1",
+      title: `${row.of_numero} est un encours âgé`,
+      explanation: "Identifier le blocage, affecter un responsable et dater la prochaine action.",
+      owner_role: "SUPERVISOR",
+      due_at: row.due_date,
+      action_path: `/production/ordres-fabrication/${row.of_id}`,
+      machine_id: row.machine_id,
+      of_id: row.of_id,
+      operation_id: row.operation_id,
+    });
+  }
+  const rank = { P0: 0, P1: 1, P2: 2 } as const;
+  return uniqueBy(actions, (item) => item.id).sort((a, b) => rank[a.priority] - rank[b.priority] || (a.due_at ?? "9999").localeCompare(b.due_at ?? "9999"));
+}
+
+export function defaultPlanningPreferences(): PlanningPreferences {
+  return {
+    timezone: "Europe/Paris",
+    horizon_weeks: 6,
+    view_mode: "WEEK",
+    show_weekends: false,
+    machine_ids: [],
+    status_colors: {},
+    client_color_overrides: {},
+    updated_at: null,
+  };
+}
+
+export function buildPlanningExecutionIntelligence(params: {
+  snapshot: PlanningIntelligenceSnapshot;
+  from: string;
+  to: string;
+  timezone: string;
+  agedWipDays: number;
+  capabilities: PlanningIntelligenceCapabilities;
+  now?: Date;
+}): PlanningExecutionIntelligence {
+  const now = params.now ?? new Date();
+  const capacity = buildCapacity(params.snapshot.capacity);
+  const conflicts = buildConflicts(params.snapshot, now);
+  const stopCauses = buildStops(params.snapshot.pointages);
+  const kpis = buildMetrics({ snapshot: params.snapshot, now, agedWipDays: params.agedWipDays });
+  const warnings = uniqueBy(
+    [
+      ...capacity.flatMap((cell) => cell.missing),
+      ...Object.values(kpis).flatMap((value) => value.missing),
+    ],
+    (value) => value
+  );
+  const reliabilityValues: PlanningReliability[] = [
+    ...Object.values(kpis).map((value) => value.reliability),
+    ...capacity.map((value) => value.reliability),
+  ];
+  const reliability: PlanningReliability = reliabilityValues.every((value) => value === "UNAVAILABLE")
+    ? "UNAVAILABLE"
+    : reliabilityValues.some((value) => value !== "VERIFIED")
+      ? "PARTIAL"
+      : "VERIFIED";
+  const freshness = latest([
+    ...params.snapshot.events.map((row) => row.updated_at),
+    ...params.snapshot.pointages.map((row) => row.updated_at),
+    ...params.snapshot.quantities.map((row) => row.freshness_at),
+    ...params.snapshot.capacity.map((row) => row.calendar_freshness_at),
+  ]);
+
+  return {
+    metadata: {
+      generated_at: now.toISOString(),
+      period: { from: params.from, to: params.to, timezone: params.timezone },
+      definition_version: "SOL-21.v1",
+      sources: [
+        "public.planning_events",
+        "public.of_operations",
+        "public.ordres_fabrication",
+        "public.production_pointages",
+        "public.production_quantity_declarations",
+        "public.programmation_calendars",
+      ],
+      freshness_at: freshness,
+      reliability,
+      warnings,
+    },
+    capabilities: params.capabilities,
+    kpis,
+    capacity,
+    stop_causes: stopCauses,
+    conflicts,
+    action_queue: buildActions({ capacity, conflicts, wip: params.snapshot.wip, now, agedWipDays: params.agedWipDays }),
+  };
+}

--- a/src/module/planning/domain/planning-rbac.ts
+++ b/src/module/planning/domain/planning-rbac.ts
@@ -38,6 +38,43 @@ const FORCE_OVERLAP_ROLES = new Set([
   "chefatelier",
 ]);
 
+export type PlanningCapability =
+  | "read"
+  | "manage_schedule"
+  | "read_capacity"
+  | "manage_preferences"
+  | "supervise_execution";
+
+const PLANNING_MANAGE_ROLES = new Set([
+  "admin",
+  "administrateur",
+  "administrateursystemeetreseau",
+  "directeur",
+  "production",
+  "responsableproduction",
+  "responsableprogrammation",
+  "planning",
+  "planification",
+  "responsableatelier",
+  "chefatelier",
+]);
+
+const PLANNING_CAPACITY_ROLES = new Set([
+  ...PLANNING_MANAGE_ROLES,
+  "responsableatelier",
+  "chefatelier",
+]);
+
+const PLANNING_SUPERVISION_ROLES = new Set([
+  "admin",
+  "administrateur",
+  "administrateursystemeetreseau",
+  "directeur",
+  "responsableproduction",
+  "responsableatelier",
+  "chefatelier",
+]);
+
 export function roleHasPlanningAccess(role: string | null | undefined): boolean {
   if (hasGrantedAccountModuleAccess()) return true;
   return effectiveRoleParts(role).some((part) => PLANNING_ACCESS_ROLES.has(normalizeRole(part)));
@@ -47,4 +84,21 @@ export function roleCanForcePlanningOverlap(role: string | null | undefined): bo
   // ADR-0049: an account-level module grant supersedes this legacy role fallback.
   if (hasGrantedAccountModuleAccess()) return true;
   return effectiveRoleParts(role).some((part) => FORCE_OVERLAP_ROLES.has(normalizeRole(part)));
+}
+
+export function roleHasPlanningCapability(
+  role: string | null | undefined,
+  capability: PlanningCapability
+): boolean {
+  const parts = effectiveRoleParts(role).map(normalizeRole);
+  if (capability === "read" || capability === "manage_preferences") {
+    return parts.some((part) => PLANNING_ACCESS_ROLES.has(part));
+  }
+  if (capability === "manage_schedule") {
+    return parts.some((part) => PLANNING_MANAGE_ROLES.has(part));
+  }
+  if (capability === "read_capacity") {
+    return parts.some((part) => PLANNING_CAPACITY_ROLES.has(part));
+  }
+  return parts.some((part) => PLANNING_SUPERVISION_ROLES.has(part));
 }

--- a/src/module/planning/middlewares/planning-authorization.middleware.test.ts
+++ b/src/module/planning/middlewares/planning-authorization.middleware.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Request, Response } from "express";
+
+import { requirePlanningCapability } from "./planning-authorization.middleware";
+import { HttpError } from "../../../utils/httpError";
+
+function request(role: string, elevated: boolean): Request {
+  return {
+    user: { id: 42, role },
+    accountModuleAccess: {
+      userId: 42,
+      moduleKey: "production",
+      granted: true,
+      elevated,
+    },
+  } as Request;
+}
+
+describe("requirePlanningCapability", () => {
+  it("does not turn default module access into a capacity privilege", () => {
+    const next = vi.fn();
+    requirePlanningCapability("read_capacity")(
+      request("Employee | Opérateur atelier", false),
+      {} as Response,
+      next,
+    );
+
+    const error = next.mock.calls[0]?.[0];
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error).toMatchObject({ status: 403, code: "PLANNING_CAPABILITY_REQUIRED" });
+  });
+
+  it("allows a planner through ordinary module access", () => {
+    const next = vi.fn();
+    requirePlanningCapability("manage_schedule")(
+      request("Employee | Responsable Programmation", false),
+      {} as Response,
+      next,
+    );
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("honours an explicit account override as an elevated grant", () => {
+    const next = vi.fn();
+    requirePlanningCapability("read_capacity")(
+      request("Employee", true),
+      {} as Response,
+      next,
+    );
+
+    expect(next).toHaveBeenCalledWith();
+  });
+});

--- a/src/module/planning/middlewares/planning-authorization.middleware.ts
+++ b/src/module/planning/middlewares/planning-authorization.middleware.ts
@@ -1,0 +1,19 @@
+import type { RequestHandler } from "express";
+
+import { HttpError } from "../../../utils/httpError";
+import { requestHasElevatedAccountModuleAccess } from "../../access-control/context/account-module-access.context";
+import { roleHasPlanningCapability, type PlanningCapability } from "../domain/planning-rbac";
+
+export function requirePlanningCapability(capability: PlanningCapability): RequestHandler {
+  return (req, _res, next) => {
+    if (!req.user || typeof req.user.id !== "number") {
+      next(new HttpError(401, "UNAUTHORIZED", "Authentication required"));
+      return;
+    }
+    if (!requestHasElevatedAccountModuleAccess(req) && !roleHasPlanningCapability(req.user.role, capability)) {
+      next(new HttpError(403, "PLANNING_CAPABILITY_REQUIRED", `Planning capability '${capability}' is required`));
+      return;
+    }
+    next();
+  };
+}

--- a/src/module/planning/repository/planning-intelligence.repository.ts
+++ b/src/module/planning/repository/planning-intelligence.repository.ts
@@ -1,0 +1,686 @@
+import type { PoolClient } from "pg";
+
+import pool from "../../../config/database";
+import { HttpError } from "../../../utils/httpError";
+import { repoInsertAuditLog } from "../../audit-logs/repository/audit-logs.repository";
+import type { CreateAuditLogBodyDTO } from "../../audit-logs/validators/audit-logs.validators";
+import { defaultPlanningPreferences } from "../domain/planning-intelligence";
+import type {
+  PlanningCapacityRawRow,
+  PlanningIntelligenceEventRow,
+  PlanningIntelligencePointageRow,
+  PlanningIntelligenceSnapshot,
+  PlanningQuantityRow,
+  PlanningWipRow,
+} from "../domain/planning-intelligence";
+import type { PlanningPreferences } from "../types/planning-intelligence.types";
+import type { AuditContext } from "./planning.repository";
+import type {
+  PlanningIntelligenceQueryDTO,
+  PlanningPreferencesBodyDTO,
+} from "../validators/planning-intelligence.validators";
+
+type Queryer = Pick<PoolClient, "query">;
+
+function num(value: unknown): number {
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new Error("PLANNING_INTELLIGENCE_INVALID_NUMERIC_SOURCE");
+  }
+  return parsed;
+}
+
+function nullableNum(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function text(value: unknown): string | null {
+  return typeof value === "string" && value.length ? value : null;
+}
+
+function recordOfStrings(value: unknown): Record<string, string> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const entries = Object.entries(value).filter((entry): entry is [string, string] => typeof entry[1] === "string");
+  return Object.fromEntries(entries);
+}
+
+function mapEvent(row: Record<string, unknown>): PlanningIntelligenceEventRow {
+  return {
+    event_id: String(row.event_id),
+    of_id: nullableNum(row.of_id),
+    of_numero: text(row.of_numero),
+    operation_id: text(row.operation_id),
+    phase: nullableNum(row.phase),
+    designation: text(row.designation),
+    event_status: String(row.event_status ?? ""),
+    operation_status: text(row.operation_status),
+    start_ts: String(row.start_ts),
+    end_ts: String(row.end_ts),
+    updated_at: String(row.updated_at),
+    operation_ended_at: text(row.operation_ended_at),
+    planned_hours: nullableNum(row.planned_hours),
+    machine_id: text(row.machine_id),
+    machine_code: text(row.machine_code),
+    machine_name: text(row.machine_name),
+    machine_available: row.machine_available === null || row.machine_available === undefined ? null : Boolean(row.machine_available),
+    allow_overlap: Boolean(row.allow_overlap),
+  };
+}
+
+async function listEvents(query: PlanningIntelligenceQueryDTO): Promise<PlanningIntelligenceEventRow[]> {
+  const { rows } = await pool.query(
+    `
+      SELECT e.id::text AS event_id,
+             COALESCE(e.of_id, op.of_id)::text AS of_id,
+             ofa.numero AS of_numero,
+             e.of_operation_id::text AS operation_id,
+             op.phase::int AS phase,
+             op.designation,
+             e.status::text AS event_status,
+             op.status::text AS operation_status,
+             e.start_ts::text AS start_ts,
+             e.end_ts::text AS end_ts,
+             e.updated_at::text AS updated_at,
+             op.ended_at::text AS operation_ended_at,
+             CASE WHEN op.temps_total_planned > 0 THEN op.temps_total_planned::float8 ELSE NULL END AS planned_hours,
+             COALESCE(e.machine_id, poste.machine_id, op.machine_id)::text AS machine_id,
+             machine.code AS machine_code,
+             machine.name AS machine_name,
+             machine.is_available AS machine_available,
+             e.allow_overlap
+        FROM public.planning_events e
+        LEFT JOIN public.of_operations op ON op.id = e.of_operation_id
+        LEFT JOIN public.ordres_fabrication ofa ON ofa.id = COALESCE(e.of_id, op.of_id)
+        LEFT JOIN public.postes poste ON poste.id = e.poste_id
+        LEFT JOIN public.machines machine ON machine.id = COALESCE(e.machine_id, poste.machine_id, op.machine_id)
+       WHERE e.archived_at IS NULL
+         AND e.kind::text = 'OF_OPERATION'
+         AND (
+           tstzrange(e.start_ts, e.end_ts, '[)') && tstzrange($1::timestamptz, $2::timestamptz, '[)')
+           OR (op.ended_at >= $1::timestamptz AND op.ended_at < $2::timestamptz)
+         )
+         AND ($3::uuid IS NULL OR COALESCE(e.machine_id, poste.machine_id, op.machine_id) = $3::uuid)
+         AND ($4::text IS NULL OR machine.workshop_zone = $4::text)
+       ORDER BY e.start_ts, e.id
+    `,
+    [query.from, query.to, query.machine_id ?? null, query.workshop_zone ?? null]
+  );
+  return rows.map((row) => mapEvent(row as Record<string, unknown>));
+}
+
+async function listPointages(query: PlanningIntelligenceQueryDTO): Promise<PlanningIntelligencePointageRow[]> {
+  const { rows } = await pool.query(
+    `
+      SELECT p.id::text AS pointage_id,
+             p.of_id::text AS of_id,
+             p.operation_id::text AS operation_id,
+             p.machine_id::text AS machine_id,
+             machine.code AS machine_code,
+             p.activity_code,
+             category.label AS activity_label,
+             category.is_productive AS activity_is_productive,
+             (p.status::text = 'RUNNING') AS is_running,
+             p.start_ts::text AS start_ts,
+             COALESCE(p.end_ts, now())::text AS end_ts,
+             GREATEST(0, EXTRACT(EPOCH FROM (
+               LEAST(COALESCE(p.end_ts, now()), $2::timestamptz)
+               - GREATEST(p.start_ts, $1::timestamptz)
+             )) / 60.0)::float8 AS duration_minutes,
+             p.comment,
+             p.updated_at::text AS updated_at
+        FROM public.production_pointages p
+        LEFT JOIN public.production_activity_categories category ON category.code = p.activity_code
+        LEFT JOIN public.machines machine ON machine.id = p.machine_id
+       WHERE p.status::text IN ('RUNNING', 'DONE')
+         AND tstzrange(p.start_ts, COALESCE(p.end_ts, now()), '[)')
+             && tstzrange($1::timestamptz, $2::timestamptz, '[)')
+         AND ($3::uuid IS NULL OR p.machine_id = $3::uuid)
+         AND ($4::text IS NULL OR machine.workshop_zone = $4::text)
+       ORDER BY p.start_ts, p.id
+    `,
+    [query.from, query.to, query.machine_id ?? null, query.workshop_zone ?? null]
+  );
+  return rows.map((raw) => {
+    const row = raw as Record<string, unknown>;
+    return {
+      pointage_id: String(row.pointage_id),
+      of_id: num(row.of_id),
+      operation_id: text(row.operation_id),
+      machine_id: text(row.machine_id),
+      machine_code: text(row.machine_code),
+      activity_code: text(row.activity_code),
+      activity_label: text(row.activity_label),
+      activity_is_productive: row.activity_is_productive === null || row.activity_is_productive === undefined ? null : Boolean(row.activity_is_productive),
+      is_running: Boolean(row.is_running),
+      start_ts: String(row.start_ts),
+      end_ts: String(row.end_ts),
+      duration_minutes: num(row.duration_minutes),
+      comment: text(row.comment),
+      updated_at: String(row.updated_at),
+    };
+  });
+}
+
+async function listQuantities(query: PlanningIntelligenceQueryDTO): Promise<PlanningQuantityRow[]> {
+  const { rows } = await pool.query(
+    `
+      SELECT COALESCE(NULLIF(btrim(declaration.unite), ''), 'UNSPECIFIED') AS unit,
+             SUM(declaration.qty_good)::float8 AS qty_good,
+             SUM(declaration.qty_scrap)::float8 AS qty_scrap,
+             SUM(declaration.qty_rework)::float8 AS qty_rework,
+             MAX(declaration.declared_at)::text AS freshness_at
+        FROM public.production_quantity_declarations declaration
+        LEFT JOIN public.of_operations operation ON operation.id = declaration.operation_id
+        LEFT JOIN public.machines machine ON machine.id = operation.machine_id
+       WHERE declaration.declared_at >= $1::timestamptz
+         AND declaration.declared_at < $2::timestamptz
+         AND ($3::uuid IS NULL OR operation.machine_id = $3::uuid)
+         AND ($4::text IS NULL OR machine.workshop_zone = $4::text)
+       GROUP BY COALESCE(NULLIF(btrim(declaration.unite), ''), 'UNSPECIFIED')
+       ORDER BY unit
+    `,
+    [query.from, query.to, query.machine_id ?? null, query.workshop_zone ?? null]
+  );
+  return rows.map((raw) => {
+    const row = raw as Record<string, unknown>;
+    return {
+      unit: String(row.unit),
+      qty_good: num(row.qty_good),
+      qty_scrap: num(row.qty_scrap),
+      qty_rework: num(row.qty_rework),
+      freshness_at: text(row.freshness_at),
+    };
+  });
+}
+
+async function listWip(query: PlanningIntelligenceQueryDTO): Promise<PlanningWipRow[]> {
+  const { rows } = await pool.query(
+    `
+      SELECT ofa.id::text AS of_id,
+             ofa.numero AS of_numero,
+             operation.id::text AS operation_id,
+             operation.machine_id::text AS machine_id,
+             COALESCE(ofa.date_lancement_reelle::timestamptz, first_pointage.started_at, operation.started_at)::text AS started_at,
+             ofa.date_fin_prevue::text AS due_date
+        FROM public.ordres_fabrication ofa
+        JOIN LATERAL (
+          SELECT op.*
+            FROM public.of_operations op
+           WHERE op.of_id = ofa.id
+             AND op.status::text NOT IN ('DONE', 'CANCELLED')
+           ORDER BY CASE WHEN op.status::text = 'RUNNING' THEN 0 ELSE 1 END, op.phase
+           LIMIT 1
+        ) operation ON true
+        LEFT JOIN public.machines machine ON machine.id = operation.machine_id
+        LEFT JOIN LATERAL (
+          SELECT MIN(pointage.start_ts) AS started_at
+            FROM public.production_pointages pointage
+           WHERE pointage.of_id = ofa.id
+             AND pointage.status::text IN ('RUNNING', 'DONE')
+        ) first_pointage ON true
+       WHERE ofa.statut::text NOT IN ('BROUILLON', 'ANNULE', 'TERMINE', 'CLOTURE')
+         AND (
+           ofa.statut::text IN ('EN_COURS', 'EN_PAUSE')
+           OR operation.status::text = 'RUNNING'
+           OR EXISTS (SELECT 1 FROM public.production_pointages active WHERE active.of_id = ofa.id AND active.status::text = 'RUNNING')
+         )
+         AND ($1::uuid IS NULL OR operation.machine_id = $1::uuid)
+         AND ($2::text IS NULL OR machine.workshop_zone = $2::text)
+       ORDER BY ofa.date_fin_prevue NULLS LAST, ofa.id
+    `,
+    [query.machine_id ?? null, query.workshop_zone ?? null]
+  );
+  return rows.map((raw) => {
+    const row = raw as Record<string, unknown>;
+    return {
+      of_id: num(row.of_id),
+      of_numero: String(row.of_numero),
+      operation_id: text(row.operation_id),
+      machine_id: text(row.machine_id),
+      started_at: text(row.started_at),
+      due_date: text(row.due_date),
+    };
+  });
+}
+
+type CapacityBase = {
+  machine_id: string;
+  machine_code: string;
+  machine_name: string;
+  week_start: string;
+  available_minutes: number | null;
+  unavailable_minutes: number;
+  calendar_count: number;
+  calendar_freshness_at: string | null;
+};
+
+async function listCapacityBase(query: PlanningIntelligenceQueryDTO): Promise<CapacityBase[]> {
+  const { rows } = await pool.query(
+    `
+      WITH calendar_state AS (
+        SELECT count(*)::int AS calendar_count,
+               max(updated_at)::text AS calendar_freshness_at,
+               (SELECT selected.timezone FROM public.programmation_calendars selected WHERE selected.active ORDER BY selected.updated_at DESC, selected.id LIMIT 1) AS timezone,
+               (SELECT selected.working_days FROM public.programmation_calendars selected WHERE selected.active ORDER BY selected.updated_at DESC, selected.id LIMIT 1) AS working_days,
+               (SELECT selected.day_start FROM public.programmation_calendars selected WHERE selected.active ORDER BY selected.updated_at DESC, selected.id LIMIT 1) AS day_start,
+               (SELECT selected.day_end FROM public.programmation_calendars selected WHERE selected.active ORDER BY selected.updated_at DESC, selected.id LIMIT 1) AS day_end,
+               (SELECT selected.id FROM public.programmation_calendars selected WHERE selected.active ORDER BY selected.updated_at DESC, selected.id LIMIT 1) AS calendar_id
+          FROM public.programmation_calendars
+         WHERE active
+      ), settings AS (
+        SELECT calendar_state.*,
+               CASE WHEN calendar_count = 1 THEN timezone ELSE $3::text END AS effective_timezone
+          FROM calendar_state
+      ), weeks AS (
+        SELECT generate_series(
+                 date_trunc('week', $1::timestamptz AT TIME ZONE settings.effective_timezone)::date,
+                 date_trunc('week', ($2::timestamptz - interval '1 microsecond') AT TIME ZONE settings.effective_timezone)::date,
+                 interval '1 week'
+               )::date AS week_start,
+               settings.*
+          FROM settings
+      ), work_slots AS (
+        SELECT week.week_start,
+               ((day.value::date + week.day_start) AT TIME ZONE week.effective_timezone) AS slot_start,
+               ((day.value::date + week.day_end) AT TIME ZONE week.effective_timezone) AS slot_end
+          FROM weeks week
+          CROSS JOIN LATERAL generate_series(week.week_start, week.week_start + 6, interval '1 day') AS day(value)
+         WHERE week.calendar_count = 1
+           AND EXTRACT(ISODOW FROM day.value)::int = ANY(week.working_days)
+           AND NOT EXISTS (
+             SELECT 1 FROM public.programmation_calendar_closures closure
+              WHERE closure.calendar_id = week.calendar_id
+                AND day.value::date BETWEEN closure.start_date AND closure.end_date
+           )
+      ), machines_scope AS (
+        SELECT machine.id, machine.code, machine.name
+          FROM public.machines machine
+         WHERE machine.archived_at IS NULL
+           AND ($4::uuid IS NULL OR machine.id = $4::uuid)
+           AND ($5::text IS NULL OR machine.workshop_zone = $5::text)
+      ), capacity_by_machine_week AS (
+        SELECT machine.id AS machine_id,
+               machine.code AS machine_code,
+               machine.name AS machine_name,
+               week.week_start,
+               week.calendar_count,
+               week.calendar_freshness_at,
+               CASE WHEN week.calendar_count = 1 THEN
+                 COALESCE(SUM(EXTRACT(EPOCH FROM (slot.slot_end - slot.slot_start)) / 60.0), 0)::float8
+               ELSE NULL END AS nominal_minutes,
+               CASE WHEN week.calendar_count = 1 THEN
+                 COALESCE(SUM((
+                   SELECT COALESCE(SUM(EXTRACT(EPOCH FROM (
+                     LEAST(event.end_ts, slot.slot_end) - GREATEST(event.start_ts, slot.slot_start)
+                   )) / 60.0), 0)
+                     FROM public.production_machine_unavailability unavailable
+                     JOIN public.planning_events event ON event.id = unavailable.planning_event_id
+                    WHERE unavailable.machine_id = machine.id
+                      AND unavailable.archived_at IS NULL
+                      AND event.archived_at IS NULL
+                      AND event.status::text <> 'CANCELLED'
+                      AND tstzrange(event.start_ts, event.end_ts, '[)')
+                          && tstzrange(slot.slot_start, slot.slot_end, '[)')
+                 )), 0)::float8
+               ELSE 0 END AS unavailable_minutes,
+               GREATEST(
+                 week.calendar_freshness_at::timestamptz,
+                 (
+                   SELECT MAX(GREATEST(unavailable.updated_at, event.updated_at))
+                     FROM public.production_machine_unavailability unavailable
+                     JOIN public.planning_events event ON event.id = unavailable.planning_event_id
+                    WHERE unavailable.machine_id = machine.id
+                      AND unavailable.archived_at IS NULL
+                      AND event.archived_at IS NULL
+                      AND event.status::text <> 'CANCELLED'
+                      AND tstzrange(event.start_ts, event.end_ts, '[)') && tstzrange(
+                            week.week_start::timestamp AT TIME ZONE week.effective_timezone,
+                            (week.week_start + 7)::timestamp AT TIME ZONE week.effective_timezone,
+                            '[)'
+                          )
+                 )
+               )::text AS capacity_freshness_at
+          FROM weeks week
+          CROSS JOIN machines_scope machine
+          LEFT JOIN work_slots slot ON slot.week_start = week.week_start
+         GROUP BY machine.id, machine.code, machine.name, week.week_start,
+                  week.calendar_count, week.calendar_freshness_at, week.effective_timezone
+      )
+      SELECT machine.id::text AS machine_id,
+             machine.code AS machine_code,
+             machine.name AS machine_name,
+             week.week_start::text AS week_start,
+             CASE WHEN week.nominal_minutes IS NOT NULL
+                  THEN GREATEST(0, week.nominal_minutes - week.unavailable_minutes)
+                  ELSE NULL END AS available_minutes,
+             week.unavailable_minutes,
+             week.calendar_count,
+             week.capacity_freshness_at AS calendar_freshness_at
+        FROM capacity_by_machine_week week
+        JOIN machines_scope machine ON machine.id = week.machine_id
+       ORDER BY week.week_start, machine.code
+    `,
+    [query.from, query.to, query.timezone, query.machine_id ?? null, query.workshop_zone ?? null]
+  );
+  return rows.map((raw) => {
+    const row = raw as Record<string, unknown>;
+    return {
+      machine_id: String(row.machine_id),
+      machine_code: String(row.machine_code),
+      machine_name: String(row.machine_name),
+      week_start: String(row.week_start).slice(0, 10),
+      available_minutes: nullableNum(row.available_minutes),
+      unavailable_minutes: num(row.unavailable_minutes),
+      calendar_count: num(row.calendar_count),
+      calendar_freshness_at: text(row.calendar_freshness_at),
+    };
+  });
+}
+
+async function listCapacityPlanned(query: PlanningIntelligenceQueryDTO): Promise<Array<{
+  machine_id: string;
+  week_start: string;
+  event: PlanningIntelligenceEventRow;
+  planned_minutes: number;
+}>> {
+  const { rows } = await pool.query(
+    `
+      WITH calendar_state AS (
+        SELECT count(*)::int AS calendar_count,
+               (SELECT selected.timezone FROM public.programmation_calendars selected WHERE selected.active ORDER BY selected.updated_at DESC, selected.id LIMIT 1) AS timezone
+          FROM public.programmation_calendars WHERE active
+      ), settings AS (
+        SELECT CASE WHEN calendar_count = 1 THEN timezone ELSE $3::text END AS timezone FROM calendar_state
+      ), weeks AS (
+        SELECT generate_series(
+                 date_trunc('week', $1::timestamptz AT TIME ZONE settings.timezone)::date,
+                 date_trunc('week', ($2::timestamptz - interval '1 microsecond') AT TIME ZONE settings.timezone)::date,
+                 interval '1 week'
+               )::date AS week_start,
+               settings.timezone
+          FROM settings
+      )
+      SELECT e.id::text AS event_id,
+             COALESCE(e.of_id, operation.of_id)::text AS of_id,
+             ofa.numero AS of_numero,
+             e.of_operation_id::text AS operation_id,
+             operation.phase::int AS phase,
+             operation.designation,
+             e.status::text AS event_status,
+             operation.status::text AS operation_status,
+             e.start_ts::text AS start_ts,
+             e.end_ts::text AS end_ts,
+             e.updated_at::text AS updated_at,
+             operation.ended_at::text AS operation_ended_at,
+             CASE WHEN operation.temps_total_planned > 0 THEN operation.temps_total_planned::float8 ELSE NULL END AS planned_hours,
+             machine.id::text AS machine_id,
+             machine.code AS machine_code,
+             machine.name AS machine_name,
+             machine.is_available AS machine_available,
+             e.allow_overlap,
+             week.week_start::text AS week_start,
+             GREATEST(0, EXTRACT(EPOCH FROM (
+               LEAST(e.end_ts, (week.week_start + 7)::timestamp AT TIME ZONE week.timezone)
+               - GREATEST(e.start_ts, week.week_start::timestamp AT TIME ZONE week.timezone)
+             )) / 60.0)::float8 AS planned_minutes
+        FROM weeks week
+        JOIN public.planning_events e
+          ON tstzrange(e.start_ts, e.end_ts, '[)') && tstzrange(
+               week.week_start::timestamp AT TIME ZONE week.timezone,
+               (week.week_start + 7)::timestamp AT TIME ZONE week.timezone,
+               '[)'
+             )
+        LEFT JOIN public.of_operations operation ON operation.id = e.of_operation_id
+        LEFT JOIN public.ordres_fabrication ofa ON ofa.id = COALESCE(e.of_id, operation.of_id)
+        LEFT JOIN public.postes poste ON poste.id = e.poste_id
+        JOIN public.machines machine ON machine.id = COALESCE(e.machine_id, poste.machine_id, operation.machine_id)
+       WHERE e.archived_at IS NULL
+         AND e.kind::text = 'OF_OPERATION'
+         AND e.status::text <> 'CANCELLED'
+         AND ($4::uuid IS NULL OR machine.id = $4::uuid)
+         AND ($5::text IS NULL OR machine.workshop_zone = $5::text)
+       ORDER BY week.week_start, machine.code, e.start_ts
+    `,
+    [query.from, query.to, query.timezone, query.machine_id ?? null, query.workshop_zone ?? null]
+  );
+  return rows.map((raw) => {
+    const row = raw as Record<string, unknown>;
+    return {
+      machine_id: String(row.machine_id),
+      week_start: String(row.week_start).slice(0, 10),
+      event: mapEvent(row),
+      planned_minutes: num(row.planned_minutes),
+    };
+  });
+}
+
+async function listCapacityActual(query: PlanningIntelligenceQueryDTO): Promise<Array<{ machine_id: string; week_start: string; actual_minutes: number }>> {
+  const { rows } = await pool.query(
+    `
+      WITH calendar_state AS (
+        SELECT count(*)::int AS calendar_count,
+               (SELECT selected.timezone FROM public.programmation_calendars selected WHERE selected.active ORDER BY selected.updated_at DESC, selected.id LIMIT 1) AS timezone
+          FROM public.programmation_calendars WHERE active
+      ), settings AS (
+        SELECT CASE WHEN calendar_count = 1 THEN timezone ELSE $3::text END AS timezone FROM calendar_state
+      ), weeks AS (
+        SELECT generate_series(
+                 date_trunc('week', $1::timestamptz AT TIME ZONE settings.timezone)::date,
+                 date_trunc('week', ($2::timestamptz - interval '1 microsecond') AT TIME ZONE settings.timezone)::date,
+                 interval '1 week'
+               )::date AS week_start,
+               settings.timezone
+          FROM settings
+      )
+      SELECT pointage.machine_id::text AS machine_id,
+             week.week_start::text AS week_start,
+             SUM(GREATEST(0, EXTRACT(EPOCH FROM (
+               LEAST(COALESCE(pointage.end_ts, now()), (week.week_start + 7)::timestamp AT TIME ZONE week.timezone)
+               - GREATEST(pointage.start_ts, week.week_start::timestamp AT TIME ZONE week.timezone)
+             )) / 60.0))::float8 AS actual_minutes
+        FROM weeks week
+        JOIN public.production_pointages pointage
+          ON pointage.machine_id IS NOT NULL
+         AND pointage.status::text IN ('RUNNING', 'DONE')
+         AND tstzrange(pointage.start_ts, COALESCE(pointage.end_ts, now()), '[)') && tstzrange(
+               week.week_start::timestamp AT TIME ZONE week.timezone,
+               (week.week_start + 7)::timestamp AT TIME ZONE week.timezone,
+               '[)'
+             )
+        JOIN public.machines machine ON machine.id = pointage.machine_id
+       WHERE ($4::uuid IS NULL OR machine.id = $4::uuid)
+         AND ($5::text IS NULL OR machine.workshop_zone = $5::text)
+       GROUP BY pointage.machine_id, week.week_start
+       ORDER BY week.week_start, pointage.machine_id
+    `,
+    [query.from, query.to, query.timezone, query.machine_id ?? null, query.workshop_zone ?? null]
+  );
+  return rows.map((raw) => {
+    const row = raw as Record<string, unknown>;
+    return {
+      machine_id: String(row.machine_id),
+      week_start: String(row.week_start).slice(0, 10),
+      actual_minutes: num(row.actual_minutes),
+    };
+  });
+}
+
+export async function repoGetPlanningIntelligenceSnapshot(query: PlanningIntelligenceQueryDTO): Promise<PlanningIntelligenceSnapshot> {
+  const [events, pointages, quantities, wip, base, planned, actual] = await Promise.all([
+    listEvents(query),
+    listPointages(query),
+    listQuantities(query),
+    listWip(query),
+    listCapacityBase(query),
+    listCapacityPlanned(query),
+    listCapacityActual(query),
+  ]);
+  const byKey = new Map(base.map((row) => [`${row.machine_id}:${row.week_start}`, row]));
+  const capacity: PlanningCapacityRawRow[] = base.map((row) => ({
+    ...row,
+    planned_event: null,
+    planned_minutes: 0,
+    actual_minutes: 0,
+  }));
+  for (const item of planned) {
+    const baseRow = byKey.get(`${item.machine_id}:${item.week_start}`);
+    if (!baseRow) continue;
+    capacity.push({ ...baseRow, planned_event: item.event, planned_minutes: item.planned_minutes, actual_minutes: 0 });
+  }
+  for (const item of actual) {
+    const baseRow = byKey.get(`${item.machine_id}:${item.week_start}`);
+    if (!baseRow) continue;
+    capacity.push({ ...baseRow, planned_event: null, planned_minutes: 0, actual_minutes: item.actual_minutes });
+  }
+  return { events, pointages, quantities, wip, capacity };
+}
+
+function mapPreferences(row: Record<string, unknown> | undefined): PlanningPreferences {
+  if (!row) return defaultPlanningPreferences();
+  return {
+    timezone: String(row.timezone),
+    horizon_weeks: num(row.horizon_weeks),
+    view_mode: String(row.view_mode) as PlanningPreferences["view_mode"],
+    show_weekends: Boolean(row.show_weekends),
+    machine_ids: Array.isArray(row.machine_ids) ? row.machine_ids.map(String) : [],
+    status_colors: recordOfStrings(row.status_colors),
+    client_color_overrides: recordOfStrings(row.client_color_overrides),
+    updated_at: text(row.updated_at),
+  };
+}
+
+export async function repoGetPlanningPreferences(userId: number): Promise<PlanningPreferences> {
+  const result = await pool.query(
+    `SELECT timezone, horizon_weeks, view_mode, show_weekends, machine_ids,
+            status_colors, client_color_overrides, updated_at::text AS updated_at
+       FROM public.planning_user_preferences
+      WHERE user_id = $1`,
+    [userId]
+  );
+  return mapPreferences(result.rows[0] as Record<string, unknown> | undefined);
+}
+
+async function insertPreferenceAudit(tx: Queryer, audit: AuditContext, before: PlanningPreferences | null, after: PlanningPreferences): Promise<void> {
+  const body: CreateAuditLogBodyDTO = {
+    event_type: "ACTION",
+    action: "planning.preferences.upsert",
+    page_key: audit.page_key,
+    entity_type: "planning_user_preferences",
+    entity_id: String(audit.user_id),
+    path: audit.path,
+    client_session_id: audit.client_session_id,
+    details: { before, after },
+  };
+  const inserted = await repoInsertAuditLog({
+    user_id: audit.user_id,
+    body,
+    ip: audit.ip,
+    user_agent: audit.user_agent,
+    device_type: audit.device_type,
+    os: audit.os,
+    browser: audit.browser,
+    tx,
+  });
+  if (!inserted?.id) throw new Error("PLANNING_PREFERENCES_AUDIT_FAILED");
+}
+
+function samePreferences(before: PlanningPreferences, body: PlanningPreferencesBodyDTO): boolean {
+  return JSON.stringify({
+    timezone: before.timezone,
+    horizon_weeks: before.horizon_weeks,
+    view_mode: before.view_mode,
+    show_weekends: before.show_weekends,
+    machine_ids: before.machine_ids,
+    status_colors: before.status_colors,
+    client_color_overrides: before.client_color_overrides,
+  }) === JSON.stringify({
+    timezone: body.timezone,
+    horizon_weeks: body.horizon_weeks,
+    view_mode: body.view_mode,
+    show_weekends: body.show_weekends,
+    machine_ids: body.machine_ids,
+    status_colors: body.status_colors,
+    client_color_overrides: body.client_color_overrides,
+  });
+}
+
+export async function repoPutPlanningPreferences(params: {
+  body: PlanningPreferencesBodyDTO;
+  audit: AuditContext;
+}): Promise<PlanningPreferences> {
+  const client = await pool.connect();
+  try {
+    await client.query("BEGIN");
+    const locked = await client.query(
+      `SELECT timezone, horizon_weeks, view_mode, show_weekends, machine_ids,
+              status_colors, client_color_overrides, updated_at::text AS updated_at
+         FROM public.planning_user_preferences
+        WHERE user_id = $1
+        FOR UPDATE`,
+      [params.audit.user_id]
+    );
+    const existingRow = locked.rows[0] as Record<string, unknown> | undefined;
+    const before = existingRow ? mapPreferences(existingRow) : null;
+    if (before && params.body.expected_updated_at && before.updated_at !== params.body.expected_updated_at) {
+      throw new HttpError(409, "PLANNING_PREFERENCES_STALE", "Planning preferences were updated by another session", {
+        expected_updated_at: params.body.expected_updated_at,
+        actual_updated_at: before.updated_at,
+      });
+    }
+    if (before && samePreferences(before, params.body)) {
+      await client.query("COMMIT");
+      return before;
+    }
+    if (params.body.machine_ids.length) {
+      const knownMachines = await client.query<{ count: number }>(
+        `SELECT count(*)::int AS count
+           FROM public.machines
+          WHERE id = ANY($1::uuid[])
+            AND archived_at IS NULL`,
+        [params.body.machine_ids]
+      );
+      if (knownMachines.rows[0]?.count !== params.body.machine_ids.length) {
+        throw new HttpError(422, "PLANNING_PREFERENCE_MACHINE_UNKNOWN", "At least one planning machine is unknown or archived");
+      }
+    }
+    const result = await client.query(
+      `INSERT INTO public.planning_user_preferences
+         (user_id, timezone, horizon_weeks, view_mode, show_weekends, machine_ids,
+          status_colors, client_color_overrides, created_by, updated_by)
+       VALUES ($1,$2,$3,$4,$5,$6::uuid[],$7::jsonb,$8::jsonb,$1,$1)
+       ON CONFLICT (user_id) DO UPDATE
+         SET timezone = EXCLUDED.timezone,
+             horizon_weeks = EXCLUDED.horizon_weeks,
+             view_mode = EXCLUDED.view_mode,
+             show_weekends = EXCLUDED.show_weekends,
+             machine_ids = EXCLUDED.machine_ids,
+             status_colors = EXCLUDED.status_colors,
+             client_color_overrides = EXCLUDED.client_color_overrides,
+             updated_by = EXCLUDED.updated_by,
+             updated_at = now()
+       RETURNING timezone, horizon_weeks, view_mode, show_weekends, machine_ids,
+                 status_colors, client_color_overrides, updated_at::text AS updated_at`,
+      [
+        params.audit.user_id,
+        params.body.timezone,
+        params.body.horizon_weeks,
+        params.body.view_mode,
+        params.body.show_weekends,
+        params.body.machine_ids,
+        JSON.stringify(params.body.status_colors),
+        JSON.stringify(params.body.client_color_overrides),
+      ]
+    );
+    const after = mapPreferences(result.rows[0] as Record<string, unknown>);
+    await insertPreferenceAudit(client, params.audit, before, after);
+    await client.query("COMMIT");
+    return after;
+  } catch (error) {
+    await client.query("ROLLBACK");
+    throw error;
+  } finally {
+    client.release();
+  }
+}

--- a/src/module/planning/routes/planning.routes.ts
+++ b/src/module/planning/routes/planning.routes.ts
@@ -19,7 +19,11 @@ import {
   restorePlanningEvent,
   uploadPlanningEventDocuments,
   validatePlanningForAr,
+  getPlanningExecutionIntelligence,
+  getPlanningPreferences,
+  putPlanningPreferences,
 } from "../controllers/planning.controller";
+import { requirePlanningCapability } from "../middlewares/planning-authorization.middleware";
 import {
   getPlanningConvergence,
   getPlanningUsageMetrics,
@@ -53,18 +57,22 @@ router.get("/governance", getPlanningConvergence);
 router.post("/governance/usage", postPlanningUsage);
 router.get("/governance/metrics", requireSuperadmin, getPlanningUsageMetrics);
 
-router.get("/resources", listPlanningResources);
-router.get("/events", listPlanningEvents);
-router.post("/autoplan", autoPlanPlanning);
-router.post("/validate-for-ar", validatePlanningForAr);
-router.post("/events", createPlanningEvent);
-router.get("/events/:id", getPlanningEvent);
-router.patch("/events/:id", patchPlanningEvent);
-router.delete("/events/:id", archivePlanningEvent);
-router.post("/events/:id/restore", restorePlanningEvent);
-router.post("/events/:id/comments", createPlanningEventComment);
+router.get("/execution-intelligence", requirePlanningCapability("read_capacity"), getPlanningExecutionIntelligence);
+router.get("/preferences", requirePlanningCapability("manage_preferences"), getPlanningPreferences);
+router.put("/preferences", requirePlanningCapability("manage_preferences"), putPlanningPreferences);
 
-router.post("/events/:id/documents", uploadDocs.array("documents[]"), uploadPlanningEventDocuments);
-router.get("/events/:id/documents/:docId/file", getPlanningEventDocumentFile);
+router.get("/resources", requirePlanningCapability("read"), listPlanningResources);
+router.get("/events", requirePlanningCapability("read"), listPlanningEvents);
+router.post("/autoplan", requirePlanningCapability("manage_schedule"), autoPlanPlanning);
+router.post("/validate-for-ar", requirePlanningCapability("manage_schedule"), validatePlanningForAr);
+router.post("/events", requirePlanningCapability("manage_schedule"), createPlanningEvent);
+router.get("/events/:id", requirePlanningCapability("read"), getPlanningEvent);
+router.patch("/events/:id", requirePlanningCapability("manage_schedule"), patchPlanningEvent);
+router.delete("/events/:id", requirePlanningCapability("manage_schedule"), archivePlanningEvent);
+router.post("/events/:id/restore", requirePlanningCapability("manage_schedule"), restorePlanningEvent);
+router.post("/events/:id/comments", requirePlanningCapability("manage_schedule"), createPlanningEventComment);
+
+router.post("/events/:id/documents", requirePlanningCapability("manage_schedule"), uploadDocs.array("documents[]"), uploadPlanningEventDocuments);
+router.get("/events/:id/documents/:docId/file", requirePlanningCapability("read"), getPlanningEventDocumentFile);
 
 export default router;

--- a/src/module/planning/services/planning-intelligence.service.ts
+++ b/src/module/planning/services/planning-intelligence.service.ts
@@ -1,0 +1,37 @@
+import { buildPlanningExecutionIntelligence } from "../domain/planning-intelligence";
+import { roleHasPlanningCapability } from "../domain/planning-rbac";
+import {
+  repoGetPlanningIntelligenceSnapshot,
+  repoGetPlanningPreferences,
+  repoPutPlanningPreferences,
+} from "../repository/planning-intelligence.repository";
+import type { AuditContext } from "../repository/planning.repository";
+import type { PlanningPreferencesBodyDTO, PlanningIntelligenceQueryDTO } from "../validators/planning-intelligence.validators";
+
+export async function svcGetPlanningExecutionIntelligence(params: {
+  query: PlanningIntelligenceQueryDTO;
+  role: string | null | undefined;
+}) {
+  const snapshot = await repoGetPlanningIntelligenceSnapshot(params.query);
+  return buildPlanningExecutionIntelligence({
+    snapshot,
+    from: params.query.from,
+    to: params.query.to,
+    timezone: params.query.timezone,
+    agedWipDays: params.query.aged_wip_days,
+    capabilities: {
+      read_capacity: roleHasPlanningCapability(params.role, "read_capacity"),
+      manage_schedule: roleHasPlanningCapability(params.role, "manage_schedule"),
+      manage_preferences: roleHasPlanningCapability(params.role, "manage_preferences"),
+      supervise_execution: roleHasPlanningCapability(params.role, "supervise_execution"),
+    },
+  });
+}
+
+export function svcGetPlanningPreferences(userId: number) {
+  return repoGetPlanningPreferences(userId);
+}
+
+export function svcPutPlanningPreferences(params: { body: PlanningPreferencesBodyDTO; audit: AuditContext }) {
+  return repoPutPlanningPreferences(params);
+}

--- a/src/module/planning/types/planning-intelligence.types.ts
+++ b/src/module/planning/types/planning-intelligence.types.ts
@@ -1,0 +1,123 @@
+export type PlanningReliability = "VERIFIED" | "PARTIAL" | "UNAVAILABLE";
+
+export type PlanningMetric = {
+  value: number | null;
+  unit: string;
+  numerator: number | null;
+  denominator: number | null;
+  definition: string;
+  source: string[];
+  freshness_at: string | null;
+  reliability: PlanningReliability;
+  missing: string[];
+};
+
+export type PlanningStopCause = {
+  code: string;
+  label: string;
+  duration_minutes: number;
+  occurrences: number;
+  reason_missing_count: number;
+  source: "production_pointages";
+};
+
+export type PlanningCapacityOf = {
+  event_id: string;
+  of_id: number | null;
+  of_numero: string | null;
+  operation_id: string | null;
+  phase: number | null;
+  designation: string | null;
+  planned_minutes: number;
+  start_ts: string;
+  end_ts: string;
+  status: string;
+};
+
+export type PlanningCapacityCell = {
+  machine_id: string;
+  machine_code: string;
+  machine_name: string;
+  week_start: string;
+  available_minutes: number | null;
+  unavailable_minutes: number;
+  planned_minutes: number;
+  actual_minutes: number;
+  utilization_pct: number | null;
+  state: "AVAILABLE" | "LOADED" | "OVERLOADED" | "BOTTLENECK" | "UNAVAILABLE";
+  reliability: PlanningReliability;
+  missing: string[];
+  drilldown: PlanningCapacityOf[];
+};
+
+export type PlanningConflict = {
+  id: string;
+  code:
+    | "SCHEDULE_OVERLAP"
+    | "RESOURCE_UNAVAILABLE"
+    | "ACTUAL_RESOURCE_MISMATCH"
+    | "LONG_RUNNING_EXECUTION"
+    | "MISSING_PLANNED_TIME";
+  severity: "INFO" | "WARNING" | "CRITICAL";
+  explanation: string;
+  next_action: string;
+  machine_id: string | null;
+  machine_code: string | null;
+  event_ids: string[];
+  of_ids: number[];
+};
+
+export type PlanningAction = {
+  id: string;
+  priority: "P0" | "P1" | "P2";
+  title: string;
+  explanation: string;
+  owner_role: "PLANNER" | "SUPERVISOR" | "OPERATOR";
+  due_at: string | null;
+  action_path: string;
+  machine_id: string | null;
+  of_id: number | null;
+  operation_id: string | null;
+};
+
+export type PlanningPreferences = {
+  timezone: string;
+  horizon_weeks: number;
+  view_mode: "DAY" | "WEEK" | "MONTH" | "YEAR";
+  show_weekends: boolean;
+  machine_ids: string[];
+  status_colors: Record<string, string>;
+  client_color_overrides: Record<string, string>;
+  updated_at: string | null;
+};
+
+export type PlanningExecutionIntelligence = {
+  metadata: {
+    generated_at: string;
+    period: { from: string; to: string; timezone: string };
+    definition_version: "SOL-21.v1";
+    sources: string[];
+    freshness_at: string | null;
+    reliability: PlanningReliability;
+    warnings: string[];
+  };
+  capabilities: {
+    read_capacity: boolean;
+    manage_schedule: boolean;
+    manage_preferences: boolean;
+    supervise_execution: boolean;
+  };
+  kpis: {
+    schedule_adherence: PlanningMetric;
+    throughput: PlanningMetric;
+    wip: PlanningMetric;
+    aged_wip: PlanningMetric;
+    scrap_rate: PlanningMetric;
+    planned_time: PlanningMetric;
+    actual_time: PlanningMetric;
+  };
+  capacity: PlanningCapacityCell[];
+  stop_causes: PlanningStopCause[];
+  conflicts: PlanningConflict[];
+  action_queue: PlanningAction[];
+};

--- a/src/module/planning/validators/planning-intelligence.validators.ts
+++ b/src/module/planning/validators/planning-intelligence.validators.ts
@@ -1,0 +1,64 @@
+import { z } from "zod";
+
+import { isValidPlanningDateTime } from "./planning.validators";
+
+const dateTime = z.string().trim().refine(isValidPlanningDateTime, "Expected an ISO-8601 datetime with timezone");
+const uuid = z.string().uuid();
+const hexColor = z.string().regex(/^#[0-9A-Fa-f]{6}$/).transform((value) => value.toUpperCase());
+const ianaTimezone = z.string().trim().min(1).max(80).refine((value) => {
+  try {
+    new Intl.DateTimeFormat("fr-FR", { timeZone: value }).format(new Date(0));
+    return true;
+  } catch {
+    return false;
+  }
+}, "Unknown IANA timezone");
+
+export const planningIntelligenceQuerySchema = z
+  .object({
+    from: dateTime,
+    to: dateTime,
+    timezone: ianaTimezone.optional().default("Europe/Paris"),
+    workshop_zone: z.string().trim().min(1).max(100).optional(),
+    machine_id: uuid.optional(),
+    aged_wip_days: z.coerce.number().int().min(1).max(365).optional().default(7),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const from = Date.parse(value.from);
+    const to = Date.parse(value.to);
+    if (from >= to) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["to"], message: "'from' must be before 'to'" });
+      return;
+    }
+    if (to - from > 13 * 7 * 24 * 60 * 60 * 1000) {
+      ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["to"], message: "Period is limited to 13 weeks" });
+    }
+  });
+
+export type PlanningIntelligenceQueryDTO = z.infer<typeof planningIntelligenceQuerySchema>;
+
+const colorMap = z.record(z.string().trim().min(1).max(160), hexColor).superRefine((value, ctx) => {
+  if (Object.keys(value).length > 200) {
+    ctx.addIssue({ code: z.ZodIssueCode.custom, message: "At most 200 color overrides are allowed" });
+  }
+});
+
+export const planningPreferencesBodySchema = z
+  .object({
+    body: z
+      .object({
+        timezone: ianaTimezone,
+        horizon_weeks: z.number().int().min(1).max(13),
+        view_mode: z.enum(["DAY", "WEEK", "MONTH", "YEAR"]),
+        show_weekends: z.boolean(),
+        machine_ids: z.array(uuid).max(100),
+        status_colors: colorMap,
+        client_color_overrides: colorMap,
+        expected_updated_at: dateTime.optional().nullable(),
+      })
+      .strict(),
+  })
+  .strict();
+
+export type PlanningPreferencesBodyDTO = z.infer<typeof planningPreferencesBodySchema>["body"];

--- a/src/module/production/domain/production-execution-finish.test.ts
+++ b/src/module/production/domain/production-execution-finish.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+
+import { assertFiniteQuantities } from "./production-execution";
+
+describe("production operation finish quantity validation", () => {
+  it("allows an empty delta when the operation already has its declaration", () => {
+    expect(() =>
+      assertFiniteQuantities(
+        { qty_good: 0, qty_scrap: 0, qty_rework: 0, qty_pending_control: 0 },
+        { allowEmpty: true },
+      )
+    ).not.toThrow();
+  });
+
+  it("still rejects an empty standalone quantity declaration", () => {
+    expect(() =>
+      assertFiniteQuantities({ qty_good: 0, qty_scrap: 0, qty_rework: 0, qty_pending_control: 0 })
+    ).toThrowError(/vide/i);
+  });
+});

--- a/src/module/production/domain/production-execution.ts
+++ b/src/module/production/domain/production-execution.ts
@@ -391,7 +391,10 @@ export type QuantityDelta = {
   qty_pending_control: number;
 };
 
-export function assertFiniteQuantities(delta: QuantityDelta): void {
+export function assertFiniteQuantities(
+  delta: QuantityDelta,
+  options: { allowEmpty?: boolean } = {},
+): void {
   for (const [key, value] of Object.entries(delta)) {
     if (!Number.isFinite(value)) {
       throw new HttpError(422, "PRODUCTION_QUANTITY_NOT_FINITE", `Quantité invalide : ${key}.`);
@@ -405,7 +408,7 @@ export function assertFiniteQuantities(delta: QuantityDelta): void {
     }
   }
   const total = delta.qty_good + delta.qty_scrap + delta.qty_rework + delta.qty_pending_control;
-  if (total <= 0) {
+  if (total <= 0 && !options.allowEmpty) {
     throw new HttpError(
       422,
       "PRODUCTION_QUANTITY_EMPTY",

--- a/src/module/production/domain/station.ts
+++ b/src/module/production/domain/station.ts
@@ -699,12 +699,13 @@ export function assessOperationReadiness(signals: WorklistSignals): ReadinessAss
 }
 
 /**
- * Ordre d'affichage de la file. Trois critères vérifiables, dans cet ordre :
- * préparation, date cible, phase. Aucun poids arbitraire, aucun apprentissage,
+ * Ordre d'affichage de la file. Critères vérifiables, dans cet ordre : travail
+ * en cours, prochaine opération prête, saisie en attente, date cible, phase.
+ * Aucun poids arbitraire, aucun apprentissage,
  * aucun « score de pertinence » que personne ne pourrait auditer.
  */
 export const WORKLIST_ORDERING_EXPLANATION =
-  "Trié par : opérations prêtes d'abord, puis date de fin prévue la plus proche, puis numéro de phase.";
+  "Trié par : travail en cours de l'opérateur, prochain ordre prêt, saisies en attente, puis blocages ; à égalité, date cible puis phase.";
 
 const READINESS_RANK: Record<ReadinessLevel, number> = {
   READY: 0,
@@ -714,9 +715,17 @@ const READINESS_RANK: Record<ReadinessLevel, number> = {
 };
 
 export function compareWorklistEntries(
-  a: { readiness: ReadinessLevel; due_date: string | null; phase: number },
-  b: { readiness: ReadinessLevel; due_date: string | null; phase: number }
+  a: { readiness: ReadinessLevel; due_date: string | null; phase: number; mine?: boolean; pending_entry?: boolean },
+  b: { readiness: ReadinessLevel; due_date: string | null; phase: number; mine?: boolean; pending_entry?: boolean }
 ): number {
+  const queueRank = (item: typeof a): number => {
+    if (item.mine) return 0;
+    if (item.readiness === "READY") return 1;
+    if (item.pending_entry) return 2;
+    return 3;
+  };
+  const byQueue = queueRank(a) - queueRank(b);
+  if (byQueue !== 0) return byQueue;
   const byReadiness = READINESS_RANK[a.readiness] - READINESS_RANK[b.readiness];
   if (byReadiness !== 0) return byReadiness;
 
@@ -727,6 +736,19 @@ export function compareWorklistEntries(
   if (aDue !== bDue) return aDue - bDue;
 
   return a.phase - b.phase;
+}
+
+/** Une seule valeur alimente le code-barres et le QR code. */
+export function buildStationOperationScanIdentifier(ofNumero: string, phase: number): {
+  value: string;
+  symbologies: ["CODE128", "QR"];
+  resolver: "/production/station/scan";
+} {
+  return {
+    value: `${ofNumero}/${phase}`,
+    symbologies: ["CODE128", "QR"],
+    resolver: "/production/station/scan",
+  };
 }
 
 /* -------------------------------------------------------------------------- */

--- a/src/module/production/repository/production-execution.repository.ts
+++ b/src/module/production/repository/production-execution.repository.ts
@@ -974,21 +974,28 @@ function assertOperationExecutable(operation: { status: string } | null) {
 /** Une maintenance bloquante interdit le démarrage : elle n'est pas contournable. */
 async function assertMachineAvailable(tx: DbQueryer, machineId: string | null | undefined) {
   if (!machineId) return;
-  const res = await tx.query<{ statut: string | null }>(
-    `SELECT statut::text AS statut FROM public.machines WHERE id = $1::uuid`,
+  const res = await tx.query<{ status: string | null }>(
+    `SELECT status::text AS status FROM public.machines WHERE id = $1::uuid`,
     [machineId]
   );
   const row = res.rows[0];
   if (!row) {
     throw new HttpError(404, "MACHINE_NOT_FOUND", "Machine introuvable.", { machine_id: machineId });
   }
-  const blocking = ["HORS_SERVICE", "MAINTENANCE", "EN_MAINTENANCE", "INDISPONIBLE"];
-  if (row.statut && blocking.includes(row.statut)) {
+  const blocking = [
+    "HORS_SERVICE",
+    "OUT_OF_SERVICE",
+    "MAINTENANCE",
+    "EN_MAINTENANCE",
+    "IN_MAINTENANCE",
+    "INDISPONIBLE",
+  ];
+  if (row.status && blocking.includes(row.status)) {
     throw new HttpError(
       409,
       "PRODUCTION_EXECUTION_MACHINE_UNAVAILABLE",
-      `Cette machine est en statut ${row.statut} : le pointage est refusé.`,
-      { machine_id: machineId, statut: row.statut }
+      `Cette machine est en statut ${row.status} : le pointage est refusé.`,
+      { machine_id: machineId, statut: row.status }
     );
   }
 }
@@ -1798,7 +1805,10 @@ export async function repoFinishOperation(params: {
     }
 
     const delta = preview.declared;
-    assertFiniteQuantities(delta);
+    // Completing an operation after an offline quantity declaration is a real
+    // state transition even when this confirmation adds no further quantity.
+    // Standalone quantity declarations still reject an empty delta.
+    assertFiniteQuantities(delta, { allowEmpty: true });
 
     if (delta.qty_scrap > 0 && !params.body.scrap_reason_code) {
       throw new HttpError(

--- a/src/module/production/repository/station-worklist.repository.test.ts
+++ b/src/module/production/repository/station-worklist.repository.test.ts
@@ -1,0 +1,37 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  query: vi.fn(),
+}));
+
+vi.mock("../../../config/database", () => ({
+  default: { query: mocks.query },
+}));
+
+import { repoWorklist } from "./station.repository";
+
+describe("repoWorklist", () => {
+  beforeEach(() => {
+    mocks.query.mockReset().mockResolvedValue({ rows: [] });
+  });
+
+  it("binds every PostgreSQL parameter with a deterministic type", async () => {
+    await repoWorklist({
+      machineId: null,
+      workshopZone: null,
+      q: null,
+      machineOnly: false,
+      includeBlocked: true,
+      limit: 50,
+    });
+
+    const [sql, values] = mocks.query.mock.calls[0] as [string, unknown[]];
+    expect(values).toEqual([null, null, null, false, 50]);
+    expect(sql).toContain("$1::uuid");
+    expect(sql).toContain("$2::text");
+    expect(sql).toContain("$3::text");
+    expect(sql).toContain("$4::boolean");
+    expect(sql).toContain("LIMIT $5");
+    expect(sql).not.toMatch(/\$6\b/);
+  });
+});

--- a/src/module/production/repository/station.repository.ts
+++ b/src/module/production/repository/station.repository.ts
@@ -1059,7 +1059,6 @@ export type WorklistRow = {
  * complète qu'il devrait filtrer lui-même.
  */
 export async function repoWorklist(params: {
-  userId: number;
   machineId: string | null;
   workshopZone: string | null;
   q: string | null;
@@ -1081,15 +1080,15 @@ export async function repoWorklist(params: {
         JOIN public.ordres_fabrication o ON o.id = op.of_id
        WHERE o.statut::text NOT IN ('BROUILLON', 'ANNULE', 'TERMINE')
          AND op.status::text NOT IN ('DONE', 'CANCELLED')
-         AND ($2::uuid IS NULL OR NOT $5::boolean OR op.machine_id = $2 OR op.machine_id IS NULL)
+         AND ($1::uuid IS NULL OR NOT $4::boolean OR op.machine_id = $1 OR op.machine_id IS NULL)
          AND (
-           $3::text IS NULL
-           OR o.numero ILIKE '%' || $3 || '%'
-           OR op.designation ILIKE '%' || $3 || '%'
+           $2::text IS NULL
+           OR o.numero ILIKE '%' || $2 || '%'
+           OR op.designation ILIKE '%' || $2 || '%'
            OR EXISTS (
              SELECT 1 FROM public.pieces_techniques pt
               WHERE pt.id = o.piece_technique_id
-                AND (pt.code_piece ILIKE '%' || $3 || '%' OR pt.designation ILIKE '%' || $3 || '%')
+                AND (pt.code_piece ILIKE '%' || $2 || '%' OR pt.designation ILIKE '%' || $2 || '%')
            )
          )
        LIMIT 500
@@ -1155,12 +1154,11 @@ export async function repoWorklist(params: {
           FROM public.production_quantity_declarations d
          WHERE d.operation_id = c.operation_id
       ) qc ON true
-     WHERE ($4::text IS NULL OR m.workshop_zone IS NULL OR m.workshop_zone = $4)
+     WHERE ($3::text IS NULL OR m.workshop_zone IS NULL OR m.workshop_zone = $3)
      ORDER BY c.date_fin_prevue NULLS LAST, c.phase
-     LIMIT $6
+     LIMIT $5
     `,
     [
-      params.userId,
       params.machineId,
       params.q,
       params.workshopZone,

--- a/src/module/production/services/station.service.ts
+++ b/src/module/production/services/station.service.ts
@@ -24,6 +24,7 @@ import {
   assessOperationReadiness,
   BADGE_LOCK_SECONDS,
   BADGE_MAX_FAILED_ATTEMPTS,
+  buildStationOperationScanIdentifier,
   compareWorklistEntries,
   evaluateMachineSelectability,
   listStationCapabilities,
@@ -606,7 +607,6 @@ export async function svcWorklist(params: {
   query: StationWorklistQueryDTO;
 }): Promise<Record<string, unknown>> {
   const rows = await repoWorklist({
-    userId: params.station.user.id,
     machineId: params.station.machine_id,
     workshopZone: params.station.device_zone,
     q: params.query.q ?? null,
@@ -664,6 +664,21 @@ export async function svcWorklist(params: {
         readiness_headline: readiness.headline,
         readiness_reasons: readiness.reasons,
         qty_pending_control: row.qty_pending_control,
+        work_state: row.active_by_user_id === params.station.user.id
+          ? "IN_PROGRESS"
+          : row.qty_pending_control > 0
+            ? "PENDING_ENTRY"
+            : readiness.level === "READY"
+              ? "NEXT_READY"
+              : "BLOCKED",
+        next_action: row.active_by_user_id === params.station.user.id
+          ? "Reprendre l'exécution en cours et terminer les saisies attendues."
+          : row.qty_pending_control > 0
+            ? "Faire statuer la Qualité sur les quantités en attente."
+            : readiness.level === "READY"
+              ? "Ouvrir le dossier puis démarrer avec une clé d'idempotence."
+              : readiness.headline,
+        scan_identifier: buildStationOperationScanIdentifier(row.of_numero, row.phase),
         hierarchy: {
           parent_of_id: row.parent_of_id,
           child_count: row.child_of_count,
@@ -683,12 +698,12 @@ export async function svcWorklist(params: {
 
   filtered.sort((a, b) =>
     compareWorklistEntries(
-      { readiness: a.readiness, due_date: a.of.date_fin_prevue, phase: a.phase },
-      { readiness: b.readiness, due_date: b.of.date_fin_prevue, phase: b.phase }
+      { readiness: a.readiness, due_date: a.of.date_fin_prevue, phase: a.phase, mine: a.mine, pending_entry: a.qty_pending_control > 0 },
+      { readiness: b.readiness, due_date: b.of.date_fin_prevue, phase: b.phase, mine: b.mine, pending_entry: b.qty_pending_control > 0 }
     )
   );
 
-  const recommended = filtered.find((item) => item.readiness === "READY") ?? filtered[0] ?? null;
+  const recommended = filtered.find((item) => item.mine) ?? filtered.find((item) => item.readiness === "READY") ?? filtered[0] ?? null;
 
   return {
     server_time: new Date().toISOString(),
@@ -697,6 +712,7 @@ export async function svcWorklist(params: {
     ordering_explanation: WORKLIST_ORDERING_EXPLANATION,
     recommended_operation_id: recommended?.operation_id ?? null,
     recommendation_reason: recommended?.readiness_headline ?? null,
+    pending_entry_count: filtered.filter((item) => item.qty_pending_control > 0).length,
     total: filtered.length,
     items: filtered,
   };


### PR DESCRIPTION
## Promotion SOL-21
Promote la base `dev` validée vers `main` sans autre différence fonctionnelle.

## Preuves
- diff `main..dev` limité aux 38 fichiers SOL-21 backend
- 4 567 tests backend réussis, 4 ignorés, 0 échec
- typecheck et build: PASS
- migration PostgreSQL: backup, preflight, verify, replay, rollback, restore PASS
- Playwright inter-dépôts: 97/97, 0 retry

Le patch SQL reste à appliquer en fenêtre opérateur autorisée ; cette PR ne touche aucune base.

## Summary by Sourcery

Introduce SOL-21 planning execution intelligence, operator worklist improvements, and audited planning preferences, with supporting migration guards and documentation.

New Features:
- Expose a planning execution intelligence API with KPIs, capacity drill-down, conflicts and action queue backed by production and planning data.
- Add per-user planning preferences for timezone, horizon, view mode, machines and colors, enforced server-side with optimistic concurrency and audit logging.
- Extend station worklists with operator-centric ordering, next-action guidance, and canonical scan identifiers usable for QR/barcode workflows.

Bug Fixes:
- Allow finishing a production operation after an offline quantity declaration even when the final confirmation carries no additional quantities.
- Ensure the station worklist query uses a consistent parameter binding set and fix machine availability checks to rely on the unified status column and codes.
- Prevent generic module access from implicitly granting planning capacity privileges by distinguishing elevated account grants from ordinary access.

Enhancements:
- Refine planning RBAC with fine-grained capabilities separating operator, supervisor and planner roles for schedule, capacity and preferences.
- Improve production station worklist ordering to prioritize in-progress work, next-ready operations and pending entries before blocked items, and report pending entry counts.
- Wire new planning intelligence routes into the planning controller and routes with capability-based middleware and cache-control semantics.
- Add domain logic to derive reliable SOL-21 KPIs, capacity states and stop causes without fabricating data when calendars, units or planned times are missing.

Deployment:
- Add SOL-21 PostgreSQL migration patch, preflight, verify and rollback SQL scripts and integrate the new patch into the release gate with rollback proofing.

Documentation:
- Add SOL-21 execution report, ADR, HTTP documentation and operator runbook describing planning intelligence, capacity, preferences and migration procedures.
- Update SOL-06 migration rehearsal report to reflect the latest rehearsal metrics and patch count.

Tests:
- Add comprehensive tests for planning intelligence KPIs, capacity, conflicts and migration guards, planning RBAC and authorization middleware, station worklist behavior, scan identifiers, and production execution quantity validation.
- Extend planning route and validator tests to cover execution intelligence empty-state responses and default planning preferences.
- Update production execution and station-related tests to reflect machine status changes and offline provenance support.